### PR TITLE
feat(optim): Add Conjugate Gradient optimizer with three beta formulas

### DIFF
--- a/src/optim/mod.rs
+++ b/src/optim/mod.rs
@@ -764,6 +764,364 @@ impl Optimizer for LBFGS {
     }
 }
 
+/// Beta computation formula for Conjugate Gradient.
+///
+/// Different formulas provide different convergence properties and
+/// numerical stability characteristics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CGBetaFormula {
+    /// Fletcher-Reeves: β = (g_{k+1}^T g_{k+1}) / (g_k^T g_k)
+    ///
+    /// Most stable but can be slow on non-quadratic problems.
+    FletcherReeves,
+    /// Polak-Ribière: β = g_{k+1}^T (g_{k+1} - g_k) / (g_k^T g_k)
+    ///
+    /// Better performance than FR, includes automatic restart (β < 0).
+    PolakRibiere,
+    /// Hestenes-Stiefel: β = g_{k+1}^T (g_{k+1} - g_k) / (d_k^T (g_{k+1} - g_k))
+    ///
+    /// Similar to PR but with different denominator, can be more robust.
+    HestenesStiefel,
+}
+
+/// Nonlinear Conjugate Gradient (CG) optimizer.
+///
+/// CG is an iterative method for solving optimization problems that uses
+/// conjugate directions rather than steepest descent. It's particularly
+/// effective for quadratic problems but extends to general nonlinear optimization.
+///
+/// # Algorithm
+///
+/// 1. Initialize with steepest descent: d_0 = -∇f(x_0)
+/// 2. Line search: find α_k minimizing f(x_k + α_k d_k)
+/// 3. Update: x_{k+1} = x_k + α_k d_k
+/// 4. Compute β_{k+1} using chosen formula (FR, PR, or HS)
+/// 5. Update direction: d_{k+1} = -∇f(x_{k+1}) + β_{k+1} d_k
+/// 6. Restart if β < 0 or every n iterations
+///
+/// # Parameters
+///
+/// - **max_iter**: Maximum number of iterations
+/// - **tol**: Convergence tolerance (gradient norm)
+/// - **beta_formula**: Method for computing β (FR, PR, or HS)
+/// - **restart_interval**: Restart with steepest descent every n iterations (0 = no periodic restart)
+///
+/// # Example
+///
+/// ```
+/// use aprender::optim::{ConjugateGradient, CGBetaFormula};
+/// use aprender::primitives::Vector;
+///
+/// let mut optimizer = ConjugateGradient::new(100, 1e-5, CGBetaFormula::PolakRibiere);
+///
+/// // Minimize Rosenbrock function
+/// let f = |x: &Vector<f32>| {
+///     let a = x[0];
+///     let b = x[1];
+///     (1.0 - a).powi(2) + 100.0 * (b - a * a).powi(2)
+/// };
+///
+/// let grad = |x: &Vector<f32>| {
+///     let a = x[0];
+///     let b = x[1];
+///     Vector::from_slice(&[
+///         -2.0 * (1.0 - a) - 400.0 * a * (b - a * a),
+///         200.0 * (b - a * a),
+///     ])
+/// };
+///
+/// let x0 = Vector::from_slice(&[0.0, 0.0]);
+/// let result = optimizer.minimize(f, grad, x0);
+/// ```
+#[derive(Debug, Clone)]
+pub struct ConjugateGradient {
+    /// Maximum number of iterations
+    max_iter: usize,
+    /// Convergence tolerance (gradient norm)
+    tol: f32,
+    /// Beta computation formula
+    beta_formula: CGBetaFormula,
+    /// Restart interval (0 = no periodic restart, only on β < 0)
+    restart_interval: usize,
+    /// Line search strategy
+    line_search: WolfeLineSearch,
+    /// Previous search direction (for conjugacy)
+    prev_direction: Option<Vector<f32>>,
+    /// Previous gradient (for beta computation)
+    prev_gradient: Option<Vector<f32>>,
+    /// Iteration counter (for restart)
+    iter_count: usize,
+}
+
+impl ConjugateGradient {
+    /// Creates a new Conjugate Gradient optimizer.
+    ///
+    /// # Arguments
+    ///
+    /// * `max_iter` - Maximum number of iterations (typical: 100-1000)
+    /// * `tol` - Convergence tolerance for gradient norm (typical: 1e-5)
+    /// * `beta_formula` - Method for computing β (FletcherReeves, PolakRibiere, or HestenesStiefel)
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use aprender::optim::{ConjugateGradient, CGBetaFormula};
+    ///
+    /// let optimizer = ConjugateGradient::new(100, 1e-5, CGBetaFormula::PolakRibiere);
+    /// ```
+    #[must_use]
+    pub fn new(max_iter: usize, tol: f32, beta_formula: CGBetaFormula) -> Self {
+        Self {
+            max_iter,
+            tol,
+            beta_formula,
+            restart_interval: 0, // No periodic restart by default
+            line_search: WolfeLineSearch::new(1e-4, 0.1, 50), // c2=0.1 for CG (more exact line search)
+            prev_direction: None,
+            prev_gradient: None,
+            iter_count: 0,
+        }
+    }
+
+    /// Sets the restart interval.
+    ///
+    /// CG will restart with steepest descent every n iterations.
+    /// Setting to 0 disables periodic restart (only restarts on β < 0).
+    ///
+    /// # Arguments
+    ///
+    /// * `interval` - Number of iterations between restarts (typical: n, where n is problem dimension)
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use aprender::optim::{ConjugateGradient, CGBetaFormula};
+    ///
+    /// let optimizer = ConjugateGradient::new(100, 1e-5, CGBetaFormula::PolakRibiere)
+    ///     .with_restart_interval(50);
+    /// ```
+    #[must_use]
+    pub fn with_restart_interval(mut self, interval: usize) -> Self {
+        self.restart_interval = interval;
+        self
+    }
+
+    /// Computes beta coefficient based on the chosen formula.
+    fn compute_beta(&self, grad_new: &Vector<f32>, grad_old: &Vector<f32>, d_old: &Vector<f32>) -> f32 {
+        let n = grad_new.len();
+
+        match self.beta_formula {
+            CGBetaFormula::FletcherReeves => {
+                // β = (g_{k+1}^T g_{k+1}) / (g_k^T g_k)
+                let mut numerator = 0.0;
+                let mut denominator = 0.0;
+                for i in 0..n {
+                    numerator += grad_new[i] * grad_new[i];
+                    denominator += grad_old[i] * grad_old[i];
+                }
+                numerator / denominator.max(1e-12)
+            }
+            CGBetaFormula::PolakRibiere => {
+                // β = g_{k+1}^T (g_{k+1} - g_k) / (g_k^T g_k)
+                let mut numerator = 0.0;
+                let mut denominator = 0.0;
+                for i in 0..n {
+                    numerator += grad_new[i] * (grad_new[i] - grad_old[i]);
+                    denominator += grad_old[i] * grad_old[i];
+                }
+                let beta = numerator / denominator.max(1e-12);
+                // PR has automatic restart: if β < 0, restart with steepest descent
+                beta.max(0.0)
+            }
+            CGBetaFormula::HestenesStiefel => {
+                // β = g_{k+1}^T (g_{k+1} - g_k) / (d_k^T (g_{k+1} - g_k))
+                let mut numerator = 0.0;
+                let mut denominator = 0.0;
+                for i in 0..n {
+                    let y_i = grad_new[i] - grad_old[i];
+                    numerator += grad_new[i] * y_i;
+                    denominator += d_old[i] * y_i;
+                }
+                let beta = numerator / denominator.max(1e-12);
+                beta.max(0.0)
+            }
+        }
+    }
+
+    /// Computes the L2 norm of a vector.
+    fn norm(v: &Vector<f32>) -> f32 {
+        let mut sum = 0.0;
+        for i in 0..v.len() {
+            sum += v[i] * v[i];
+        }
+        sum.sqrt()
+    }
+}
+
+impl Optimizer for ConjugateGradient {
+    fn step(&mut self, _params: &mut Vector<f32>, _gradients: &Vector<f32>) {
+        unimplemented!(
+            "Conjugate Gradient does not support stochastic updates (step). Use minimize() for batch optimization."
+        )
+    }
+
+    fn minimize<F, G>(
+        &mut self,
+        objective: F,
+        gradient: G,
+        x0: Vector<f32>,
+    ) -> OptimizationResult
+    where
+        F: Fn(&Vector<f32>) -> f32,
+        G: Fn(&Vector<f32>) -> Vector<f32>,
+    {
+        let start_time = std::time::Instant::now();
+        let n = x0.len();
+
+        // Reset state
+        self.prev_direction = None;
+        self.prev_gradient = None;
+        self.iter_count = 0;
+
+        let mut x = x0;
+        let mut fx = objective(&x);
+        let mut grad = gradient(&x);
+        let mut grad_norm = Self::norm(&grad);
+
+        for iter in 0..self.max_iter {
+            // Check convergence
+            if grad_norm < self.tol {
+                return OptimizationResult {
+                    solution: x,
+                    objective_value: fx,
+                    iterations: iter,
+                    status: ConvergenceStatus::Converged,
+                    gradient_norm: grad_norm,
+                    constraint_violation: 0.0,
+                    elapsed_time: start_time.elapsed(),
+                };
+            }
+
+            // Compute search direction
+            let d = if let (Some(d_old), Some(g_old)) = (&self.prev_direction, &self.prev_gradient) {
+                // Check if we need to restart
+                let need_restart = if self.restart_interval > 0 {
+                    self.iter_count % self.restart_interval == 0
+                } else {
+                    false
+                };
+
+                if need_restart {
+                    // Restart with steepest descent
+                    let mut d_new = Vector::zeros(n);
+                    for i in 0..n {
+                        d_new[i] = -grad[i];
+                    }
+                    d_new
+                } else {
+                    // Compute beta and conjugate direction
+                    let beta = self.compute_beta(&grad, g_old, d_old);
+
+                    // d = -grad + beta * d_old
+                    let mut d_new = Vector::zeros(n);
+                    for i in 0..n {
+                        d_new[i] = -grad[i] + beta * d_old[i];
+                    }
+
+                    // Check if direction is descent (grad^T d < 0)
+                    let mut grad_dot_d = 0.0;
+                    for i in 0..n {
+                        grad_dot_d += grad[i] * d_new[i];
+                    }
+
+                    if grad_dot_d >= 0.0 {
+                        // Not a descent direction - restart with steepest descent
+                        for i in 0..n {
+                            d_new[i] = -grad[i];
+                        }
+                    }
+
+                    d_new
+                }
+            } else {
+                // First iteration: use steepest descent
+                let mut d_new = Vector::zeros(n);
+                for i in 0..n {
+                    d_new[i] = -grad[i];
+                }
+                d_new
+            };
+
+            // Line search
+            let alpha = self.line_search.search(&objective, &gradient, &x, &d);
+
+            // Check for stalled progress
+            if alpha < 1e-12 {
+                return OptimizationResult {
+                    solution: x,
+                    objective_value: fx,
+                    iterations: iter,
+                    status: ConvergenceStatus::Stalled,
+                    gradient_norm: grad_norm,
+                    constraint_violation: 0.0,
+                    elapsed_time: start_time.elapsed(),
+                };
+            }
+
+            // Update position: x_new = x + alpha * d
+            let mut x_new = Vector::zeros(n);
+            for i in 0..n {
+                x_new[i] = x[i] + alpha * d[i];
+            }
+
+            // Compute new objective and gradient
+            let fx_new = objective(&x_new);
+            let grad_new = gradient(&x_new);
+
+            // Check for numerical errors
+            if fx_new.is_nan() || fx_new.is_infinite() {
+                return OptimizationResult {
+                    solution: x,
+                    objective_value: fx,
+                    iterations: iter,
+                    status: ConvergenceStatus::NumericalError,
+                    gradient_norm: grad_norm,
+                    constraint_violation: 0.0,
+                    elapsed_time: start_time.elapsed(),
+                };
+            }
+
+            // Store current direction and gradient for next iteration
+            self.prev_direction = Some(d);
+            self.prev_gradient = Some(grad);
+
+            // Update for next iteration
+            x = x_new;
+            fx = fx_new;
+            grad = grad_new;
+            grad_norm = Self::norm(&grad);
+            self.iter_count += 1;
+        }
+
+        // Max iterations reached
+        OptimizationResult {
+            solution: x,
+            objective_value: fx,
+            iterations: self.max_iter,
+            status: ConvergenceStatus::MaxIterations,
+            gradient_norm: grad_norm,
+            constraint_violation: 0.0,
+            elapsed_time: start_time.elapsed(),
+        }
+    }
+
+    fn reset(&mut self) {
+        self.prev_direction = None;
+        self.prev_gradient = None;
+        self.iter_count = 0;
+    }
+}
+
 /// Stochastic Gradient Descent optimizer.
 ///
 /// SGD updates parameters using the gradient of the loss function:
@@ -2278,6 +2636,326 @@ mod tests {
         // Gradient norm at convergence should be small
         if result.status == ConvergenceStatus::Converged {
             assert!(result.gradient_norm < 1e-5);
+        }
+    }
+
+    // ==================== Conjugate Gradient Tests ====================
+
+    #[test]
+    fn test_cg_new_fletcher_reeves() {
+        let optimizer = ConjugateGradient::new(100, 1e-5, CGBetaFormula::FletcherReeves);
+        assert_eq!(optimizer.max_iter, 100);
+        assert!((optimizer.tol - 1e-5).abs() < 1e-10);
+        assert_eq!(optimizer.beta_formula, CGBetaFormula::FletcherReeves);
+        assert_eq!(optimizer.restart_interval, 0);
+    }
+
+    #[test]
+    fn test_cg_new_polak_ribiere() {
+        let optimizer = ConjugateGradient::new(100, 1e-5, CGBetaFormula::PolakRibiere);
+        assert_eq!(optimizer.beta_formula, CGBetaFormula::PolakRibiere);
+    }
+
+    #[test]
+    fn test_cg_new_hestenes_stiefel() {
+        let optimizer = ConjugateGradient::new(100, 1e-5, CGBetaFormula::HestenesStiefel);
+        assert_eq!(optimizer.beta_formula, CGBetaFormula::HestenesStiefel);
+    }
+
+    #[test]
+    fn test_cg_with_restart_interval() {
+        let optimizer = ConjugateGradient::new(100, 1e-5, CGBetaFormula::PolakRibiere)
+            .with_restart_interval(50);
+        assert_eq!(optimizer.restart_interval, 50);
+    }
+
+    #[test]
+    fn test_cg_simple_quadratic_fr() {
+        // Minimize f(x) = x^2, optimal at x = 0
+        let f = |x: &Vector<f32>| x[0] * x[0];
+        let grad = |x: &Vector<f32>| Vector::from_slice(&[2.0 * x[0]]);
+
+        let mut optimizer = ConjugateGradient::new(100, 1e-5, CGBetaFormula::FletcherReeves);
+        let x0 = Vector::from_slice(&[5.0]);
+        let result = optimizer.minimize(f, grad, x0);
+
+        assert_eq!(result.status, ConvergenceStatus::Converged);
+        assert!(result.solution[0].abs() < 1e-3);
+    }
+
+    #[test]
+    fn test_cg_simple_quadratic_pr() {
+        let f = |x: &Vector<f32>| x[0] * x[0];
+        let grad = |x: &Vector<f32>| Vector::from_slice(&[2.0 * x[0]]);
+
+        let mut optimizer = ConjugateGradient::new(100, 1e-5, CGBetaFormula::PolakRibiere);
+        let x0 = Vector::from_slice(&[5.0]);
+        let result = optimizer.minimize(f, grad, x0);
+
+        assert_eq!(result.status, ConvergenceStatus::Converged);
+        assert!(result.solution[0].abs() < 1e-3);
+    }
+
+    #[test]
+    fn test_cg_simple_quadratic_hs() {
+        let f = |x: &Vector<f32>| x[0] * x[0];
+        let grad = |x: &Vector<f32>| Vector::from_slice(&[2.0 * x[0]]);
+
+        let mut optimizer = ConjugateGradient::new(100, 1e-5, CGBetaFormula::HestenesStiefel);
+        let x0 = Vector::from_slice(&[5.0]);
+        let result = optimizer.minimize(f, grad, x0);
+
+        assert_eq!(result.status, ConvergenceStatus::Converged);
+        assert!(result.solution[0].abs() < 1e-3);
+    }
+
+    #[test]
+    fn test_cg_multidimensional_quadratic() {
+        // Minimize f(x) = ||x - c||^2 where c = [1, 2, 3]
+        let c = vec![1.0, 2.0, 3.0];
+        let f = |x: &Vector<f32>| {
+            let mut sum = 0.0;
+            for i in 0..x.len() {
+                sum += (x[i] - c[i]).powi(2);
+            }
+            sum
+        };
+
+        let grad = |x: &Vector<f32>| {
+            let mut g = Vector::zeros(x.len());
+            for i in 0..x.len() {
+                g[i] = 2.0 * (x[i] - c[i]);
+            }
+            g
+        };
+
+        let mut optimizer = ConjugateGradient::new(100, 1e-5, CGBetaFormula::PolakRibiere);
+        let x0 = Vector::from_slice(&[0.0, 0.0, 0.0]);
+        let result = optimizer.minimize(f, grad, x0);
+
+        assert_eq!(result.status, ConvergenceStatus::Converged);
+        for i in 0..3 {
+            assert!((result.solution[i] - c[i]).abs() < 1e-3);
+        }
+    }
+
+    #[test]
+    fn test_cg_rosenbrock() {
+        // Rosenbrock function: f(x,y) = (1-x)^2 + 100(y-x^2)^2
+        let f = |v: &Vector<f32>| {
+            let x = v[0];
+            let y = v[1];
+            (1.0 - x).powi(2) + 100.0 * (y - x * x).powi(2)
+        };
+
+        let grad = |v: &Vector<f32>| {
+            let x = v[0];
+            let y = v[1];
+            let dx = -2.0 * (1.0 - x) - 400.0 * x * (y - x * x);
+            let dy = 200.0 * (y - x * x);
+            Vector::from_slice(&[dx, dy])
+        };
+
+        let mut optimizer = ConjugateGradient::new(500, 1e-4, CGBetaFormula::PolakRibiere);
+        let x0 = Vector::from_slice(&[0.0, 0.0]);
+        let result = optimizer.minimize(f, grad, x0);
+
+        // Should converge close to (1, 1)
+        assert!(
+            result.status == ConvergenceStatus::Converged
+                || result.status == ConvergenceStatus::MaxIterations
+        );
+        assert!((result.solution[0] - 1.0).abs() < 0.1);
+        assert!((result.solution[1] - 1.0).abs() < 0.1);
+    }
+
+    #[test]
+    fn test_cg_sphere() {
+        // Sphere function: f(x) = sum(x_i^2)
+        let f = |x: &Vector<f32>| {
+            let mut sum = 0.0;
+            for i in 0..x.len() {
+                sum += x[i] * x[i];
+            }
+            sum
+        };
+
+        let grad = |x: &Vector<f32>| {
+            let mut g = Vector::zeros(x.len());
+            for i in 0..x.len() {
+                g[i] = 2.0 * x[i];
+            }
+            g
+        };
+
+        let mut optimizer = ConjugateGradient::new(100, 1e-5, CGBetaFormula::PolakRibiere);
+        let x0 = Vector::from_slice(&[5.0, -3.0, 2.0, -1.0]);
+        let result = optimizer.minimize(f, grad, x0);
+
+        assert_eq!(result.status, ConvergenceStatus::Converged);
+        for i in 0..4 {
+            assert!(result.solution[i].abs() < 1e-3);
+        }
+    }
+
+    #[test]
+    fn test_cg_compare_beta_formulas() {
+        // Compare different beta formulas on same problem
+        let f = |x: &Vector<f32>| x[0] * x[0] + x[1] * x[1];
+        let grad = |x: &Vector<f32>| Vector::from_slice(&[2.0 * x[0], 2.0 * x[1]]);
+        let x0 = Vector::from_slice(&[3.0, 4.0]);
+
+        let mut opt_fr = ConjugateGradient::new(100, 1e-5, CGBetaFormula::FletcherReeves);
+        let result_fr = opt_fr.minimize(&f, &grad, x0.clone());
+
+        let mut opt_pr = ConjugateGradient::new(100, 1e-5, CGBetaFormula::PolakRibiere);
+        let result_pr = opt_pr.minimize(&f, &grad, x0.clone());
+
+        let mut opt_hs = ConjugateGradient::new(100, 1e-5, CGBetaFormula::HestenesStiefel);
+        let result_hs = opt_hs.minimize(&f, &grad, x0);
+
+        // All should converge to same solution
+        assert_eq!(result_fr.status, ConvergenceStatus::Converged);
+        assert_eq!(result_pr.status, ConvergenceStatus::Converged);
+        assert_eq!(result_hs.status, ConvergenceStatus::Converged);
+
+        assert!(result_fr.solution[0].abs() < 1e-3);
+        assert!(result_pr.solution[0].abs() < 1e-3);
+        assert!(result_hs.solution[0].abs() < 1e-3);
+    }
+
+    #[test]
+    fn test_cg_with_periodic_restart() {
+        let f = |x: &Vector<f32>| x[0] * x[0] + x[1] * x[1];
+        let grad = |x: &Vector<f32>| Vector::from_slice(&[2.0 * x[0], 2.0 * x[1]]);
+
+        let mut optimizer = ConjugateGradient::new(100, 1e-5, CGBetaFormula::PolakRibiere)
+            .with_restart_interval(5);
+        let x0 = Vector::from_slice(&[5.0, 5.0]);
+        let result = optimizer.minimize(f, grad, x0);
+
+        assert_eq!(result.status, ConvergenceStatus::Converged);
+        assert!(result.solution[0].abs() < 1e-3);
+        assert!(result.solution[1].abs() < 1e-3);
+    }
+
+    #[test]
+    fn test_cg_reset() {
+        let f = |x: &Vector<f32>| x[0] * x[0];
+        let grad = |x: &Vector<f32>| Vector::from_slice(&[2.0 * x[0]]);
+
+        let mut optimizer = ConjugateGradient::new(100, 1e-5, CGBetaFormula::PolakRibiere);
+        let x0 = Vector::from_slice(&[5.0]);
+
+        // First run
+        optimizer.minimize(&f, &grad, x0.clone());
+        assert!(optimizer.prev_direction.is_some());
+
+        // Reset
+        optimizer.reset();
+        assert!(optimizer.prev_direction.is_none());
+        assert!(optimizer.prev_gradient.is_none());
+        assert_eq!(optimizer.iter_count, 0);
+
+        // Second run should work
+        let result = optimizer.minimize(&f, &grad, x0);
+        assert_eq!(result.status, ConvergenceStatus::Converged);
+    }
+
+    #[test]
+    fn test_cg_max_iterations() {
+        // Use Rosenbrock with very few iterations
+        let f = |v: &Vector<f32>| {
+            let x = v[0];
+            let y = v[1];
+            (1.0 - x).powi(2) + 100.0 * (y - x * x).powi(2)
+        };
+
+        let grad = |v: &Vector<f32>| {
+            let x = v[0];
+            let y = v[1];
+            let dx = -2.0 * (1.0 - x) - 400.0 * x * (y - x * x);
+            let dy = 200.0 * (y - x * x);
+            Vector::from_slice(&[dx, dy])
+        };
+
+        let mut optimizer = ConjugateGradient::new(3, 1e-10, CGBetaFormula::PolakRibiere);
+        let x0 = Vector::from_slice(&[0.0, 0.0]);
+        let result = optimizer.minimize(f, grad, x0);
+
+        assert_eq!(result.status, ConvergenceStatus::MaxIterations);
+        assert_eq!(result.iterations, 3);
+    }
+
+    #[test]
+    #[should_panic(expected = "does not support stochastic")]
+    fn test_cg_step_panics() {
+        let mut optimizer = ConjugateGradient::new(100, 1e-5, CGBetaFormula::PolakRibiere);
+        let mut params = Vector::from_slice(&[1.0]);
+        let grad = Vector::from_slice(&[0.1]);
+
+        // Should panic - CG doesn't support step()
+        optimizer.step(&mut params, &grad);
+    }
+
+    #[test]
+    fn test_cg_numerical_error_detection() {
+        // Function that produces NaN
+        let f = |x: &Vector<f32>| {
+            if x[0] < -100.0 {
+                f32::NAN
+            } else {
+                x[0] * x[0]
+            }
+        };
+        let grad = |x: &Vector<f32>| Vector::from_slice(&[2.0 * x[0]]);
+
+        let mut optimizer = ConjugateGradient::new(100, 1e-5, CGBetaFormula::PolakRibiere);
+        let x0 = Vector::from_slice(&[0.0]);
+        let result = optimizer.minimize(f, grad, x0);
+
+        // Should detect numerical error or converge normally
+        assert!(
+            result.status == ConvergenceStatus::Converged
+                || result.status == ConvergenceStatus::NumericalError
+                || result.status == ConvergenceStatus::MaxIterations
+        );
+    }
+
+    #[test]
+    fn test_cg_gradient_norm_tracking() {
+        let f = |x: &Vector<f32>| x[0] * x[0] + x[1] * x[1];
+        let grad = |x: &Vector<f32>| Vector::from_slice(&[2.0 * x[0], 2.0 * x[1]]);
+
+        let mut optimizer = ConjugateGradient::new(100, 1e-5, CGBetaFormula::PolakRibiere);
+        let x0 = Vector::from_slice(&[3.0, 4.0]);
+        let result = optimizer.minimize(f, grad, x0);
+
+        // Gradient norm at convergence should be small
+        if result.status == ConvergenceStatus::Converged {
+            assert!(result.gradient_norm < 1e-5);
+        }
+    }
+
+    #[test]
+    fn test_cg_vs_lbfgs_quadratic() {
+        // Compare CG and L-BFGS on a quadratic problem
+        let f = |x: &Vector<f32>| x[0] * x[0] + 2.0 * x[1] * x[1] + 3.0 * x[2] * x[2];
+        let grad = |x: &Vector<f32>| Vector::from_slice(&[2.0 * x[0], 4.0 * x[1], 6.0 * x[2]]);
+        let x0 = Vector::from_slice(&[5.0, 3.0, 2.0]);
+
+        let mut cg = ConjugateGradient::new(100, 1e-5, CGBetaFormula::PolakRibiere);
+        let result_cg = cg.minimize(&f, &grad, x0.clone());
+
+        let mut lbfgs = LBFGS::new(100, 1e-5, 10);
+        let result_lbfgs = lbfgs.minimize(&f, &grad, x0);
+
+        // Both should converge to same solution
+        assert_eq!(result_cg.status, ConvergenceStatus::Converged);
+        assert_eq!(result_lbfgs.status, ConvergenceStatus::Converged);
+
+        for i in 0..3 {
+            assert!((result_cg.solution[i] - result_lbfgs.solution[i]).abs() < 1e-3);
         }
     }
 }


### PR DESCRIPTION
Implement nonlinear Conjugate Gradient with Fletcher-Reeves, Polak-Ribiere, and Hestenes-Stiefel beta formulas. Includes automatic and periodic restart mechanisms, descent direction checking, and Wolfe line search.

- CGBetaFormula enum with 3 variants (FR, PR, HS)
- ConjugateGradient optimizer with conjugate direction computation
- Automatic restart on non-descent directions
- Optional periodic restart (configurable interval)
- 18 comprehensive tests covering all beta formulas
- Memory efficient: O(n) storage vs O(mn) for L-BFGS

All 1083 tests pass (+18 new). Total optimizer tests: 76.