### PR TITLE
fix: aarch64 cross-compilation for apr-cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,20 +96,20 @@ dependencies = [
 
 [[package]]
 name = "alimentar"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f995d174944bd6dac254db94d6dc76e27697c1e03177ead9b45ee5e8979ad3"
+checksum = "9598cc0cd588783c002cb637e10d29a201065b4459aae67f6ae35a405bb04e38"
 dependencies = [
- "arrow 57.2.0",
- "arrow-csv 57.2.0",
- "arrow-json 57.2.0",
+ "arrow 57.3.0",
+ "arrow-csv",
+ "arrow-json",
  "bytes",
  "clap",
  "crossterm",
  "lz4_flex",
  "memmap2",
  "nu-ansi-term",
- "parquet 57.2.0",
+ "parquet 57.3.0",
  "rand 0.8.5",
  "reedline",
  "rmp-serde",
@@ -151,7 +151,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed7572b7ba83a31e20d1b48970ee402d2e3e0537dcfe0a3ff4d6eb7508617d43"
 dependencies = [
  "alsa-sys",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "cfg-if",
  "libc",
 ]
@@ -233,9 +233,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "apr-cli"
@@ -279,7 +279,7 @@ dependencies = [
  "tower 0.5.3",
  "trueno 0.16.2",
  "trueno-explain",
- "trueno-viz 0.2.1",
+ "trueno-viz 0.2.2",
  "trueno-zram-core",
  "ureq",
  "which",
@@ -287,21 +287,24 @@ dependencies = [
 
 [[package]]
 name = "aprender"
-version = "0.25.9"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7053416de79df742f9da17a53dea7087830b83761a80f69bc2a91b708aab781c"
+checksum = "2c3d93f3daa67ae709f70bd4befb9676b4412fe1962cd475a30b5ae433a0c1f0"
 dependencies = [
+ "batuta-common",
  "bincode",
  "getrandom 0.2.17",
  "memmap2",
  "minijinja",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
+ "provable-contracts-macros",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
  "rayon",
  "rmp-serde",
  "serde",
  "serde_json",
- "trueno 0.14.6",
+ "serde_yaml_ng",
+ "trueno 0.15.0",
  "trueno-quant",
 ]
 
@@ -458,9 +461,9 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.8.0"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d03449bb8ca2cc2ef70869af31463d1ae5ccc8fa3e334b307203fbf815207e"
+checksum = "f9f3647c145568cec02c42054e07bdf9a5a698e15b466fb2341bfc393cd24aa5"
 dependencies = [
  "rustversion",
 ]
@@ -473,7 +476,7 @@ checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -502,42 +505,39 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "arrow"
-version = "54.2.1"
+version = "54.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc208515aa0151028e464cc94a692156e945ce5126abd3537bb7fd6ba2143ed1"
+checksum = "b5ec52ba94edeed950e4a41f75d35376df196e8cb04437f7280a5aa49f20f796"
 dependencies = [
  "arrow-arith 54.3.1",
  "arrow-array 54.3.1",
  "arrow-buffer 54.3.1",
  "arrow-cast 54.3.1",
- "arrow-csv 54.3.1",
  "arrow-data 54.3.1",
- "arrow-ipc 54.2.1",
- "arrow-json 54.3.1",
- "arrow-ord 54.2.1",
- "arrow-row 54.2.1",
+ "arrow-ord 54.3.1",
+ "arrow-row 54.3.1",
  "arrow-schema 54.3.1",
  "arrow-select 54.3.1",
- "arrow-string 54.2.1",
+ "arrow-string 54.3.1",
 ]
 
 [[package]]
 name = "arrow"
-version = "57.2.0"
+version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2b10dcb159faf30d3f81f6d56c1211a5bea2ca424eabe477648a44b993320e"
+checksum = "e4754a624e5ae42081f464514be454b39711daae0458906dacde5f4c632f33a8"
 dependencies = [
- "arrow-arith 57.2.0",
- "arrow-array 57.2.0",
- "arrow-buffer 57.2.0",
- "arrow-cast 57.2.0",
- "arrow-data 57.2.0",
- "arrow-ipc 57.2.0",
- "arrow-ord 57.2.0",
- "arrow-row 57.2.0",
- "arrow-schema 57.2.0",
- "arrow-select 57.2.0",
- "arrow-string 57.2.0",
+ "arrow-arith 57.3.0",
+ "arrow-array 57.3.0",
+ "arrow-buffer 57.3.0",
+ "arrow-cast 57.3.0",
+ "arrow-data 57.3.0",
+ "arrow-ipc 57.3.0",
+ "arrow-ord 57.3.0",
+ "arrow-row 57.3.0",
+ "arrow-schema 57.3.0",
+ "arrow-select 57.3.0",
+ "arrow-string 57.3.0",
 ]
 
 [[package]]
@@ -556,14 +556,14 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "57.2.0"
+version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "288015089e7931843c80ed4032c5274f02b37bcb720c4a42096d50b390e70372"
+checksum = "f7b3141e0ec5145a22d8694ea8b6d6f69305971c4fa1c1a13ef0195aef2d678b"
 dependencies = [
- "arrow-array 57.2.0",
- "arrow-buffer 57.2.0",
- "arrow-data 57.2.0",
- "arrow-schema 57.2.0",
+ "arrow-array 57.3.0",
+ "arrow-buffer 57.3.0",
+ "arrow-data 57.3.0",
+ "arrow-schema 57.3.0",
  "chrono",
  "num-traits",
 ]
@@ -586,14 +586,14 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "57.2.0"
+version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65ca404ea6191e06bf30956394173337fa9c35f445bd447fe6c21ab944e1a23c"
+checksum = "4c8955af33b25f3b175ee10af580577280b4bd01f7e823d94c7cdef7cf8c9aef"
 dependencies = [
  "ahash",
- "arrow-buffer 57.2.0",
- "arrow-data 57.2.0",
- "arrow-schema 57.2.0",
+ "arrow-buffer 57.3.0",
+ "arrow-data 57.3.0",
+ "arrow-schema 57.3.0",
  "chrono",
  "half",
  "hashbrown 0.16.1",
@@ -615,9 +615,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "57.2.0"
+version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36356383099be0151dacc4245309895f16ba7917d79bdb71a7148659c9206c56"
+checksum = "c697ddca96183182f35b3a18e50b9110b11e916d7b7799cbfd4d34662f2c56c2"
 dependencies = [
  "bytes",
  "half",
@@ -647,16 +647,16 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "57.2.0"
+version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8e372ed52bd4ee88cc1e6c3859aa7ecea204158ac640b10e187936e7e87074"
+checksum = "646bbb821e86fd57189c10b4fcdaa941deaf4181924917b0daa92735baa6ada5"
 dependencies = [
- "arrow-array 57.2.0",
- "arrow-buffer 57.2.0",
- "arrow-data 57.2.0",
- "arrow-ord 57.2.0",
- "arrow-schema 57.2.0",
- "arrow-select 57.2.0",
+ "arrow-array 57.3.0",
+ "arrow-buffer 57.3.0",
+ "arrow-data 57.3.0",
+ "arrow-ord 57.3.0",
+ "arrow-schema 57.3.0",
+ "arrow-select 57.3.0",
  "atoi",
  "base64 0.22.1",
  "chrono",
@@ -669,29 +669,13 @@ dependencies = [
 
 [[package]]
 name = "arrow-csv"
-version = "54.3.1"
+version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1644877d8bc9a0ef022d9153dc29375c2bda244c39aec05a91d0e87ccf77995f"
+checksum = "8da746f4180004e3ce7b83c977daf6394d768332349d3d913998b10a120b790a"
 dependencies = [
- "arrow-array 54.3.1",
- "arrow-cast 54.3.1",
- "arrow-schema 54.3.1",
- "chrono",
- "csv",
- "csv-core",
- "lazy_static",
- "regex",
-]
-
-[[package]]
-name = "arrow-csv"
-version = "57.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e4100b729fe656f2e4fb32bc5884f14acf9118d4ad532b7b33c1132e4dce896"
-dependencies = [
- "arrow-array 57.2.0",
- "arrow-cast 57.2.0",
- "arrow-schema 57.2.0",
+ "arrow-array 57.3.0",
+ "arrow-cast 57.3.0",
+ "arrow-schema 57.3.0",
  "chrono",
  "csv",
  "csv-core",
@@ -712,12 +696,12 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "57.2.0"
+version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf87f4ff5fc13290aa47e499a8b669a82c5977c6a1fedce22c7f542c1fd5a597"
+checksum = "1fdd994a9d28e6365aa78e15da3f3950c0fdcea6b963a12fa1c391afb637b304"
 dependencies = [
- "arrow-buffer 57.2.0",
- "arrow-schema 57.2.0",
+ "arrow-buffer 57.3.0",
+ "arrow-schema 57.3.0",
  "half",
  "num-integer",
  "num-traits",
@@ -725,9 +709,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "54.2.1"
+version = "54.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddecdeab02491b1ce88885986e25002a3da34dd349f682c7cfe67bab7cc17b86"
+checksum = "62ff528658b521e33905334723b795ee56b393dbe9cf76c8b1f64b648c65a60c"
 dependencies = [
  "arrow-array 54.3.1",
  "arrow-buffer 54.3.1",
@@ -738,51 +722,29 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "57.2.0"
+version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3ca63edd2073fcb42ba112f8ae165df1de935627ead6e203d07c99445f2081"
+checksum = "abf7df950701ab528bf7c0cf7eeadc0445d03ef5d6ffc151eaae6b38a58feff1"
 dependencies = [
- "arrow-array 57.2.0",
- "arrow-buffer 57.2.0",
- "arrow-data 57.2.0",
- "arrow-schema 57.2.0",
- "arrow-select 57.2.0",
+ "arrow-array 57.3.0",
+ "arrow-buffer 57.3.0",
+ "arrow-data 57.3.0",
+ "arrow-schema 57.3.0",
+ "arrow-select 57.3.0",
  "flatbuffers 25.12.19",
 ]
 
 [[package]]
 name = "arrow-json"
-version = "54.3.1"
+version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee5b4ca98a7fb2efb9ab3309a5d1c88b5116997ff93f3147efdc1062a6158e9"
+checksum = "0ff8357658bedc49792b13e2e862b80df908171275f8e6e075c460da5ee4bf86"
 dependencies = [
- "arrow-array 54.3.1",
- "arrow-buffer 54.3.1",
- "arrow-cast 54.3.1",
- "arrow-data 54.3.1",
- "arrow-schema 54.3.1",
- "chrono",
- "half",
- "indexmap",
- "lexical-core",
- "memchr",
- "num",
- "serde",
- "serde_json",
- "simdutf8",
-]
-
-[[package]]
-name = "arrow-json"
-version = "57.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a36b2332559d3310ebe3e173f75b29989b4412df4029a26a30cc3f7da0869297"
-dependencies = [
- "arrow-array 57.2.0",
- "arrow-buffer 57.2.0",
- "arrow-cast 57.2.0",
- "arrow-data 57.2.0",
- "arrow-schema 57.2.0",
+ "arrow-array 57.3.0",
+ "arrow-buffer 57.3.0",
+ "arrow-cast 57.3.0",
+ "arrow-data 57.3.0",
+ "arrow-schema 57.3.0",
  "chrono",
  "half",
  "indexmap",
@@ -798,9 +760,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "54.2.1"
+version = "54.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f841bfcc1997ef6ac48ee0305c4dfceb1f7c786fe31e67c1186edf775e1f1160"
+checksum = "f0a3334a743bd2a1479dbc635540617a3923b4b2f6870f37357339e6b5363c21"
 dependencies = [
  "arrow-array 54.3.1",
  "arrow-buffer 54.3.1",
@@ -811,22 +773,22 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "57.2.0"
+version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c4e0530272ca755d6814218dffd04425c5b7854b87fa741d5ff848bf50aa39"
+checksum = "f7d8f1870e03d4cbed632959498bcc84083b5a24bded52905ae1695bd29da45b"
 dependencies = [
- "arrow-array 57.2.0",
- "arrow-buffer 57.2.0",
- "arrow-data 57.2.0",
- "arrow-schema 57.2.0",
- "arrow-select 57.2.0",
+ "arrow-array 57.3.0",
+ "arrow-buffer 57.3.0",
+ "arrow-data 57.3.0",
+ "arrow-schema 57.3.0",
+ "arrow-select 57.3.0",
 ]
 
 [[package]]
 name = "arrow-row"
-version = "54.2.1"
+version = "54.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1eeb55b0a0a83851aa01f2ca5ee5648f607e8506ba6802577afdda9d75cdedcd"
+checksum = "8d1d7a7291d2c5107e92140f75257a99343956871f3d3ab33a7b41532f79cb68"
 dependencies = [
  "arrow-array 54.3.1",
  "arrow-buffer 54.3.1",
@@ -837,14 +799,14 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "57.2.0"
+version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b07f52788744cc71c4628567ad834cadbaeb9f09026ff1d7a4120f69edf7abd3"
+checksum = "18228633bad92bff92a95746bbeb16e5fc318e8382b75619dec26db79e4de4c0"
 dependencies = [
- "arrow-array 57.2.0",
- "arrow-buffer 57.2.0",
- "arrow-data 57.2.0",
- "arrow-schema 57.2.0",
+ "arrow-array 57.3.0",
+ "arrow-buffer 57.3.0",
+ "arrow-data 57.3.0",
+ "arrow-schema 57.3.0",
  "half",
 ]
 
@@ -856,9 +818,9 @@ checksum = "39cfaf5e440be44db5413b75b72c2a87c1f8f0627117d110264048f2969b99e9"
 
 [[package]]
 name = "arrow-schema"
-version = "57.2.0"
+version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bb63203e8e0e54b288d0d8043ca8fa1013820822a27692ef1b78a977d879f2c"
+checksum = "8c872d36b7bf2a6a6a2b40de9156265f0242910791db366a2c17476ba8330d68"
 
 [[package]]
 name = "arrow-select"
@@ -876,23 +838,23 @@ dependencies = [
 
 [[package]]
 name = "arrow-select"
-version = "57.2.0"
+version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c96d8a1c180b44ecf2e66c9a2f2bbcb8b1b6f14e165ce46ac8bde211a363411b"
+checksum = "68bf3e3efbd1278f770d67e5dc410257300b161b93baedb3aae836144edcaf4b"
 dependencies = [
  "ahash",
- "arrow-array 57.2.0",
- "arrow-buffer 57.2.0",
- "arrow-data 57.2.0",
- "arrow-schema 57.2.0",
+ "arrow-array 57.3.0",
+ "arrow-buffer 57.3.0",
+ "arrow-data 57.3.0",
+ "arrow-schema 57.3.0",
  "num-traits",
 ]
 
 [[package]]
 name = "arrow-string"
-version = "54.2.1"
+version = "54.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "912e38bd6a7a7714c1d9b61df80315685553b7455e8a6045c27531d8ecd5b458"
+checksum = "a21546b337ab304a32cfc0770f671db7411787586b45b78b4593ae78e64e2b03"
 dependencies = [
  "arrow-array 54.3.1",
  "arrow-buffer 54.3.1",
@@ -907,15 +869,15 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "57.2.0"
+version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8ad6a81add9d3ea30bf8374ee8329992c7fd246ffd8b7e2f48a3cea5aa0cc9a"
+checksum = "85e968097061b3c0e9fe3079cf2e703e487890700546b5b0647f60fca1b5a8d8"
 dependencies = [
- "arrow-array 57.2.0",
- "arrow-buffer 57.2.0",
- "arrow-data 57.2.0",
- "arrow-schema 57.2.0",
- "arrow-select 57.2.0",
+ "arrow-array 57.3.0",
+ "arrow-buffer 57.3.0",
+ "arrow-data 57.3.0",
+ "arrow-schema 57.3.0",
+ "arrow-select 57.3.0",
  "memchr",
  "num-traits",
  "regex",
@@ -984,7 +946,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -995,7 +957,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1061,9 +1023,9 @@ dependencies = [
 
 [[package]]
 name = "avif-serialize"
-version = "0.8.6"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c8fbc0f831f4519fe8b810b6a7a91410ec83031b8233f730a0480029f6a23f"
+checksum = "375082f007bd67184fb9c0374614b29f9aaa604ec301635f72338bb65386a53d"
 dependencies = [
  "arrayvec",
 ]
@@ -1234,9 +1196,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 dependencies = [
  "serde_core",
 ]
@@ -1310,6 +1272,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
 name = "brotli"
 version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1349,9 +1317,9 @@ checksum = "f4ad8f11f288f48ca24471bbd51ac257aaeaaa07adae295591266b792902ae64"
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytecount"
@@ -1361,9 +1329,9 @@ checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytemuck"
-version = "1.24.0"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 dependencies = [
  "bytemuck_derive",
 ]
@@ -1376,7 +1344,7 @@ checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1445,10 +1413,11 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.10"
+version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
+checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
+ "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
@@ -1468,9 +1437,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.43"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -1519,9 +1488,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.54"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1529,9 +1498,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.54"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1542,30 +1511,30 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.65"
+version = "4.5.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "430b4dc2b5e3861848de79627b2bedc9f3342c7da5173a14eaa5d0f8dc18ae5d"
+checksum = "c757a3b7e39161a4e56f9365141ada2a6c915a8622c408ab6bb4b5d047371031"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.5.49"
+version = "4.5.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "codespan-reporting"
@@ -1745,7 +1714,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "core-foundation",
  "libc",
 ]
@@ -1890,7 +1859,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "crossterm_winapi",
  "mio",
  "parking_lot",
@@ -1959,12 +1928,12 @@ dependencies = [
 
 [[package]]
 name = "ctrlc"
-version = "3.5.1"
+version = "3.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73736a89c4aff73035ba2ed2e565061954da00d4970fc9ac25dcc85a2a20d790"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
 dependencies = [
  "dispatch2",
- "nix",
+ "nix 0.31.2",
  "windows-sys 0.61.2",
 ]
 
@@ -1992,7 +1961,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2026,7 +1995,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2039,7 +2008,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2050,7 +2019,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2061,7 +2030,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2089,9 +2058,9 @@ dependencies = [
 
 [[package]]
 name = "deflate64"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26bf8fc351c5ed29b5c2f0cbbac1b209b74f60ecd62e675a998df72c49af5204"
+checksum = "807800ff3288b621186fe0a8f3392c4652068257302709c24efd918c3dffcdc2"
 
 [[package]]
 name = "der"
@@ -2105,9 +2074,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.5"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
 ]
@@ -2120,7 +2089,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2141,7 +2110,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2151,7 +2120,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2221,11 +2190,11 @@ dependencies = [
 
 [[package]]
 name = "dispatch2"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "block2",
  "libc",
  "objc2",
@@ -2239,7 +2208,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2250,6 +2219,12 @@ checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ed25519"
@@ -2283,6 +2258,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2291,25 +2275,31 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 [[package]]
 name = "entrenar"
 version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e777e2fd8a20a96a60c82e9449e340c9f9490146ffdc2ab4fdcffeaf683d69e"
 dependencies = [
  "alimentar",
  "aprender 0.27.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "arrow 57.2.0",
+ "arrow 57.3.0",
  "bytemuck",
  "chrono",
  "clap",
  "clap_complete",
+ "ctrlc",
  "dirs 5.0.1",
  "ed25519-dalek",
+ "fs4",
  "half",
  "hex",
+ "hostname",
+ "jsonschema",
  "ndarray",
+ "presentar-core",
+ "presentar-terminal",
  "rand 0.9.2",
  "realizar",
  "regex",
+ "rusqlite",
  "safetensors 0.7.0",
+ "schemars",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -2319,15 +2309,14 @@ dependencies = [
  "toml",
  "trueno 0.16.2",
  "trueno-gpu",
- "trueno-viz 0.2.1",
+ "trueno-viz 0.2.2",
+ "validator",
  "zip",
 ]
 
 [[package]]
 name = "entrenar-common"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8558b7437f5b1eb77bdc2d43c6a3ace5cc418effac4cbf1e395bf4f0f670e61a"
 dependencies = [
  "clap",
  "serde",
@@ -2339,8 +2328,6 @@ dependencies = [
 [[package]]
 name = "entrenar-lora"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d768472539adac6d7ec1954eb9cefc77d5f61df93a11c5d2697cf9775cb0de"
 dependencies = [
  "clap",
  "entrenar",
@@ -2373,7 +2360,7 @@ checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2459,7 +2446,7 @@ checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2469,7 +2456,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "windows-sys 0.59.0",
 ]
 
@@ -2511,6 +2498,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "flatbuffers"
 version = "24.12.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2526,15 +2519,15 @@ version = "25.12.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "rustc_version",
 ]
 
 [[package]]
 name = "flate2"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b375d6465b98090a5f25b1c7703f3859783755aa9a80433b36e0379a3ec2f369"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -2547,6 +2540,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "fluent-uri"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1918b65d96df47d3591bed19c5cca17e3fa5d0707318e4b5ef2eae01764df7e5"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
 ]
 
 [[package]]
@@ -2585,7 +2589,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2601,6 +2605,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f158e3ff0a1b334408dc9fb811cd99b446986f4d8b741bb08f9df1604085ae7"
+dependencies = [
+ "lazy_static",
+ "num",
+]
+
+[[package]]
+name = "fs4"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
+dependencies = [
+ "rustix 1.1.4",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2620,9 +2644,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2635,9 +2659,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2645,15 +2669,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2673,38 +2697,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2714,7 +2738,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -2760,9 +2783,22 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -2849,7 +2885,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbcd2dba93594b227a1f57ee09b8b9da8892c34d55aa332e034a228d0fe6a171"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "gpu-alloc-types",
 ]
 
@@ -2859,7 +2895,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -2880,7 +2916,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "gpu-descriptor-types",
  "hashbrown 0.15.5",
 ]
@@ -2891,7 +2927,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -3147,7 +3183,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.5",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -3165,14 +3201,13 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
  "http 1.4.0",
  "http-body",
@@ -3189,9 +3224,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.64"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -3199,7 +3234,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -3293,6 +3328,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3333,14 +3374,14 @@ dependencies = [
  "image-webp",
  "moxcms",
  "num-traits",
- "png 0.18.0",
+ "png 0.18.1",
  "qoi",
  "ravif",
  "rayon",
  "rgb",
  "tiff",
  "zune-core 0.5.1",
- "zune-jpeg 0.5.11",
+ "zune-jpeg 0.5.12",
 ]
 
 [[package]]
@@ -3367,6 +3408,8 @@ checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -3443,7 +3486,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3469,14 +3512,14 @@ checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
@@ -3565,12 +3608,37 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonschema"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b8f66fe41fa46a5c83ed1c717b7e0b4635988f427083108c8cf0a882cc13441"
+dependencies = [
+ "ahash",
+ "base64 0.22.1",
+ "bytecount",
+ "email_address",
+ "fancy-regex",
+ "fraction",
+ "idna",
+ "itoa",
+ "num-cmp",
+ "once_cell",
+ "percent-encoding",
+ "referencing",
+ "regex-syntax",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "uuid-simd",
 ]
 
 [[package]]
@@ -3625,7 +3693,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2",
- "syn 2.0.114",
+ "syn 2.0.117",
  "thiserror 2.0.18",
  "tracing",
  "tracing-subscriber",
@@ -3676,6 +3744,12 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lebe"
@@ -3742,15 +3816,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
 name = "libfuzzer-sys"
-version = "0.4.10"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5037190e1f70cbeef565bd267599242926f724d3b8a9f510fd7e0b540cfa4404"
+checksum = "f12a681b7dd8ce12bff52488013ba614b869148d54dd79836ab85aafdd53f08d"
 dependencies = [
  "arbitrary",
  "cc",
@@ -3768,19 +3842,20 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "libc",
- "redox_syscall 0.7.0",
+ "plain",
+ "redox_syscall 0.7.3",
 ]
 
 [[package]]
@@ -3802,9 +3877,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -3949,15 +4024,15 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744133e4a0e0a658e1374cf3bf8e415c4052a15a111acd372764c55b4177d490"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
 ]
@@ -3974,7 +4049,7 @@ version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00c15a6f673ff72ddcc22394663290f870fb224c1bfce55734a75c414150e605"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "block",
  "core-graphics-types",
  "foreign-types",
@@ -4001,9 +4076,9 @@ dependencies = [
 
 [[package]]
 name = "minijinja"
-version = "2.14.0"
+version = "2.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12ea9ac0a51fb5112607099560fdf0f90366ab088a2a9e6e8ae176794e9806aa"
+checksum = "5ea5ea1e90055f200af6b8e52a4a34e05e77e7fee953a9fb40c631efdc43cab1"
 dependencies = [
  "memo-map",
  "self_cell",
@@ -4057,7 +4132,7 @@ checksum = "e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4092,7 +4167,7 @@ checksum = "066cf25f0e8b11ee0df221219010f213ad429855f57c494f995590c861a9a7d8"
 dependencies = [
  "arrayvec",
  "bit-set",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "cfg-if",
  "cfg_aliases",
  "codespan-reporting",
@@ -4146,7 +4221,19 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+dependencies = [
+ "bitflags 2.11.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -4189,7 +4276,7 @@ version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c533b4c39709f9ba5005d8002048266593c1cfaf3c5f0739d5b8ab0c6c504009"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "filetime",
  "fsevent-sys",
  "inotify",
@@ -4245,6 +4332,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4267,7 +4360,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4339,9 +4432,9 @@ dependencies = [
 
 [[package]]
 name = "objc2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
 dependencies = [
  "objc2-encode",
 ]
@@ -4495,10 +4588,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
 name = "pacha"
 version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "873be034730a0b6ae567897812926b649f13f12d59d0f1805a7eb5f3622702a8"
 dependencies = [
  "anyhow",
  "blake3",
@@ -4550,16 +4647,16 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "54.2.0"
+version = "54.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "761c44d824fe83106e0600d2510c07bf4159a4985bf0569b513ea4288dc1b4fb"
+checksum = "bfb15796ac6f56b429fd99e33ba133783ad75b27c36b4b5ce06f1f82cc97754e"
 dependencies = [
  "ahash",
  "arrow-array 54.3.1",
  "arrow-buffer 54.3.1",
  "arrow-cast 54.3.1",
  "arrow-data 54.3.1",
- "arrow-ipc 54.2.1",
+ "arrow-ipc 54.3.1",
  "arrow-schema 54.3.1",
  "arrow-select 54.3.1",
  "base64 0.22.1",
@@ -4579,23 +4676,22 @@ dependencies = [
  "thrift",
  "twox-hash 1.6.3",
  "zstd",
- "zstd-sys",
 ]
 
 [[package]]
 name = "parquet"
-version = "57.2.0"
+version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6a2926a30477c0b95fea6c28c3072712b139337a242c2cc64817bdc20a8854"
+checksum = "6ee96b29972a257b855ff2341b37e61af5f12d6af1158b6dcdb5b31ea07bb3cb"
 dependencies = [
  "ahash",
- "arrow-array 57.2.0",
- "arrow-buffer 57.2.0",
- "arrow-cast 57.2.0",
- "arrow-data 57.2.0",
- "arrow-ipc 57.2.0",
- "arrow-schema 57.2.0",
- "arrow-select 57.2.0",
+ "arrow-array 57.3.0",
+ "arrow-buffer 57.3.0",
+ "arrow-cast 57.3.0",
+ "arrow-data 57.3.0",
+ "arrow-ipc 57.3.0",
+ "arrow-schema 57.3.0",
+ "arrow-select 57.3.0",
  "base64 0.22.1",
  "bytes",
  "chrono",
@@ -4653,29 +4749,29 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pin-utils"
@@ -4698,6 +4794,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plotters"
@@ -4742,11 +4844,11 @@ dependencies = [
 
 [[package]]
 name = "png"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97baced388464909d42d89643fe4361939af9b7ce7a31ee32a168f832a70f2a0"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -4773,15 +4875,15 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
 dependencies = [
  "portable-atomic",
 ]
@@ -4812,9 +4914,9 @@ dependencies = [
 
 [[package]]
 name = "predicates"
-version = "3.1.3"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
 dependencies = [
  "anstyle",
  "difflib",
@@ -4826,15 +4928,15 @@ dependencies = [
 
 [[package]]
 name = "predicates-core"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
 
 [[package]]
 name = "predicates-tree"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
 dependencies = [
  "predicates-core",
  "termtree",
@@ -4883,6 +4985,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "primal-check"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4916,6 +5028,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4940,18 +5074,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
 dependencies = [
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "proptest"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee689443a2bd0a16ab0348b52ee43e3b2d1b1f931c8aa5c9f8de4c86fbe8c40"
+checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "num-traits",
  "rand 0.9.2",
  "rand_chacha 0.9.0",
@@ -4982,14 +5116,12 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "provable-contracts"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25d845cee13c0160ff2d644c8bd4b65a8487f894a827d9d0fe23d47980a9fa5"
 dependencies = [
  "serde",
  "serde_json",
@@ -5000,22 +5132,17 @@ dependencies = [
 [[package]]
 name = "provable-contracts-macros"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c383d865124fe9fda96af4a04d0c2641bcb93e16eb5e13f7c665f98c15333447"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "pxfm"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7186d3822593aa4393561d186d1393b3923e9d6163d3fbfd6e825e3e6cf3e6a8"
-dependencies = [
- "num-traits",
-]
+checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
 
 [[package]]
 name = "qoi"
@@ -5095,9 +5222,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -5107,6 +5234,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "radium"
@@ -5184,9 +5317,9 @@ dependencies = [
 
 [[package]]
 name = "range-alloc"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d6831663a5098ea164f89cff59c6284e95f4e3c76ce9848d4529f5ccca9bde"
+checksum = "ca45419789ae5a7899559e9512e58ca889e41f04f1f2445e9f4b290ceccd1d08"
 
 [[package]]
 name = "ratatui"
@@ -5194,7 +5327,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "cassowary",
  "compact_str 0.8.1",
  "crossterm",
@@ -5305,11 +5438,9 @@ dependencies = [
 [[package]]
 name = "realizar"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76ac94cb7508ac0e151b85c597aec509e51d59dbf13c804dfc5ed26fd26e74df"
 dependencies = [
  "anyhow",
- "aprender 0.27.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aprender 0.27.4",
  "arc-swap",
  "async-stream",
  "axum",
@@ -5346,16 +5477,16 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.0"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
+checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -5401,10 +5532,43 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.12.2"
+name = "ref-cast"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "referencing"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0dcb5ab28989ad7c91eb1b9531a37a1a137cc69a0499aee4117cae4a107c464"
+dependencies = [
+ "ahash",
+ "fluent-uri",
+ "once_cell",
+ "percent-encoding",
+ "serde_json",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -5414,9 +5578,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -5425,15 +5589,13 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "renacer"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b29e60ecc0f423b24f6e68df5927e2632afe79c45725e541df38dbfeb8b9ea9a"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -5448,7 +5610,7 @@ dependencies = [
  "hex",
  "libc",
  "memmap2",
- "nix",
+ "nix 0.30.1",
  "object 0.38.1",
  "opentelemetry",
  "opentelemetry-otlp",
@@ -5469,7 +5631,7 @@ dependencies = [
  "trueno 0.16.2",
  "trueno-db",
  "trueno-graph",
- "trueno-viz 0.2.1",
+ "trueno-viz 0.2.2",
 ]
 
 [[package]]
@@ -5515,7 +5677,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 1.0.5",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -5529,9 +5691,9 @@ dependencies = [
 
 [[package]]
 name = "rgb"
-version = "0.8.52"
+version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6a884d2998352bb4daf0183589aec883f16a6da1f4dde84d8e2e9a5409a1ce"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
 
 [[package]]
 name = "ring"
@@ -5593,7 +5755,7 @@ version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -5664,7 +5826,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -5673,22 +5835,22 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys 0.11.0",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.36"
+version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "log",
  "once_cell",
@@ -5740,9 +5902,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "safetensors"
@@ -5772,6 +5934,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schemars"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5836,7 +6022,18 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6010,9 +6207,9 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slotmap"
@@ -6037,9 +6234,9 @@ checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
 name = "socket2"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",
@@ -6062,7 +6259,7 @@ version = "0.3.0+sdk-1.3.268.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -6148,7 +6345,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6170,9 +6367,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6196,7 +6393,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6230,14 +6427,14 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.24.0"
+version = "3.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
+checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -6256,7 +6453,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
 dependencies = [
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "windows-sys 0.60.2",
 ]
 
@@ -6292,7 +6489,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6303,7 +6500,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6451,9 +6648,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
@@ -6468,13 +6665,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6554,9 +6751,9 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tonic"
-version = "0.14.2"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb7613188ce9f7df5bfe185db26c5814347d110db17920415cf2fbcad85e7203"
+checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6580,9 +6777,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost"
-version = "0.14.2"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66bd50ad6ce1252d87ef024b3d64fe4c3cf54a86fb9ef4c631fdd0ded7aeaa67"
+checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
 dependencies = [
  "bytes",
  "prost",
@@ -6629,7 +6826,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "bytes",
  "futures-util",
  "http 1.4.0",
@@ -6673,7 +6870,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6774,8 +6971,6 @@ dependencies = [
 [[package]]
 name = "trueno"
 version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2676205d0af0b161e0fb1805ed6b5cbfe32d10d3630d3572609c7fa07d53816e"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -6784,6 +6979,7 @@ dependencies = [
  "hostname",
  "num_cpus",
  "pollster",
+ "rayon",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -6795,28 +6991,32 @@ dependencies = [
 
 [[package]]
 name = "trueno-db"
-version = "0.3.13"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2f3f3ebbdb21c6a035665ba76726c37edc1b107a56fde6579c8d937a2f82b56"
+checksum = "0056d735250bd4dc5eb7eda62b300aecd642a0a96dde42a0fb39674376d0b0bb"
 dependencies = [
  "anyhow",
- "arrow 54.2.1",
+ "arrow 54.3.1",
+ "axum",
+ "batuta-common",
  "chrono",
+ "clap",
  "console_error_panic_hook",
  "dashmap",
  "js-sys",
- "parquet 54.2.0",
+ "parquet 54.3.1",
  "rayon",
  "rustc-hash 2.1.1",
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
+ "serde_yaml_ng",
  "sqlparser",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
  "tracing-subscriber",
- "trueno 0.14.6",
+ "trueno 0.15.0",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -6841,9 +7041,7 @@ dependencies = [
 
 [[package]]
 name = "trueno-gpu"
-version = "0.4.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c63667e382b86b69adc03293c4aee4480b9cad483cbfaa12b5c49d321f58c2ec"
+version = "0.4.19"
 dependencies = [
  "batuta-common",
  "libloading",
@@ -6852,42 +7050,41 @@ dependencies = [
 
 [[package]]
 name = "trueno-graph"
-version = "0.1.15"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43e881cfbf40c8a3655acabf40576b91596a0b500181584f5763461722835ec6"
+checksum = "516bd31de3fc84dee42266f2360f15baf307c32f8573d27a22944a6bd192fad5"
 dependencies = [
  "anyhow",
- "aprender 0.25.9",
- "arrow 54.2.1",
- "parquet 54.2.0",
+ "aprender 0.26.3",
+ "arrow 54.3.1",
+ "parquet 54.3.1",
  "thiserror 2.0.18",
  "tokio",
- "trueno 0.14.6",
+ "trueno 0.15.0",
  "trueno-db",
 ]
 
 [[package]]
 name = "trueno-quant"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5da5ac788b596e45d1d3fa0991c04b0e1bac63ffe4ae2faf6ae7c0d9fdfc00eb"
 dependencies = [
  "half",
 ]
 
 [[package]]
 name = "trueno-rag"
-version = "0.2.1"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e440734dc7a36c64ff58c0193ffd01ebefde75d1a8968138a1ece9aa6913a792"
+checksum = "1ad9b10493d9af8befce7cf7c3db9f7bb92c9d04957cca8a543d01601345203a"
 dependencies = [
  "async-trait",
+ "batuta-common",
  "rusqlite",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "trueno 0.14.6",
+ "trueno 0.15.0",
  "trueno-db",
  "uuid",
 ]
@@ -6908,9 +7105,9 @@ dependencies = [
 
 [[package]]
 name = "trueno-viz"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e91f4e6187571b112986d271adee25bf9e87af3e8bc142282d793023da9be12"
+checksum = "6a8517b57060a70bcda986e3560fb9369af165fccf0c05dd593bd2db231d7e8f"
 dependencies = [
  "base64 0.22.1",
  "batuta-common",
@@ -6976,9 +7173,9 @@ checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-normalization-alignments"
@@ -7017,6 +7214,12 @@ name = "unicode-width"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unicode_categories"
@@ -7097,14 +7300,25 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.19.0"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
+checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "uuid",
+ "vsimd",
 ]
 
 [[package]]
@@ -7116,6 +7330,36 @@ dependencies = [
  "aligned-vec",
  "num-traits",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "validator"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43fb22e1a008ece370ce08a3e9e4447a910e92621bb49b85d6e48a45397e7cfa"
+dependencies = [
+ "idna",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "url",
+ "validator_derive",
+]
+
+[[package]]
+name = "validator_derive"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7df16e474ef958526d1205f6dda359fdfab79d9aa6d54bafcb92dcd07673dca"
+dependencies = [
+ "darling 0.20.11",
+ "once_cell",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7135,6 +7379,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vte"
@@ -7189,10 +7439,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.108"
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -7203,9 +7462,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.58"
+version = "0.4.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -7217,9 +7476,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -7227,31 +7486,65 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.85"
+name = "wasm-encoder"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7273,14 +7566,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.5",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12bed680863276c63889429bfd6cab3b99943659923822de1c8a39c49e4d722c"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -7298,7 +7591,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfe68bac7cde125de7a731c3400723cadaaf1703795ad3f4805f187459cd7a77"
 dependencies = [
  "arrayvec",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "cfg-if",
  "cfg_aliases",
  "document-features",
@@ -7329,7 +7622,7 @@ dependencies = [
  "arrayvec",
  "bit-set",
  "bit-vec",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "bytemuck",
  "cfg_aliases",
  "document-features",
@@ -7389,7 +7682,7 @@ dependencies = [
  "arrayvec",
  "ash",
  "bit-set",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "block",
  "bytemuck",
  "cfg-if",
@@ -7425,7 +7718,7 @@ dependencies = [
  "web-sys",
  "wgpu-types",
  "windows",
- "windows-core",
+ "windows-core 0.58.0",
 ]
 
 [[package]]
@@ -7434,7 +7727,7 @@ version = "27.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afdcf84c395990db737f2dd91628706cb31e86d72e53482320d368e52b5da5eb"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "bytemuck",
  "js-sys",
  "log",
@@ -7450,7 +7743,7 @@ checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
 dependencies = [
  "either",
  "env_home",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "winsafe",
 ]
 
@@ -7491,7 +7784,7 @@ version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
 dependencies = [
- "windows-core",
+ "windows-core 0.58.0",
  "windows-targets 0.52.6",
 ]
 
@@ -7501,11 +7794,24 @@ version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
 dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-result",
- "windows-strings",
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
+ "windows-link",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -7516,7 +7822,18 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7527,7 +7844,18 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7546,13 +7874,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
- "windows-result",
+ "windows-result 0.2.0",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -7806,6 +8152,88 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "indexmap",
+ "prettyplease",
+ "syn 2.0.117",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.0",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"
@@ -7878,28 +8306,28 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.33"
+version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668f5168d10b9ee831de31933dc111a459c97ec93225beb307aed970d1372dfd"
+checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.33"
+version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c7962b26b0a8685668b671ee4b54d007a67d4eaf05fda79ac0ecf41e32270f1"
+checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7919,7 +8347,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -7940,7 +8368,7 @@ checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7973,7 +8401,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8008,9 +8436,9 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.16"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfcd145825aace48cff44a8844de64bf75feec3080e0aa5cdbde72961ae51a65"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zopfli"
@@ -8035,18 +8463,18 @@ dependencies = [
 
 [[package]]
 name = "zstd-safe"
-version = "7.2.1"
+version = "7.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
 dependencies = [
  "zstd-sys",
 ]
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.13+zstd.1.5.6"
+version = "2.0.16+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
  "cc",
  "pkg-config",
@@ -8084,9 +8512,9 @@ dependencies = [
 
 [[package]]
 name = "zune-jpeg"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2959ca473aae96a14ecedf501d20b3608d2825ba280d5adb57d651721885b0c2"
+checksum = "410e9ecef634c709e3831c2cfdb8d9c32164fae1c67496d5b68fff728eec37fe"
 dependencies = [
  "zune-core 0.5.1",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7106,8 +7106,6 @@ dependencies = [
 [[package]]
 name = "trueno-viz"
 version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8517b57060a70bcda986e3560fb9369af165fccf0c05dd593bd2db231d7e8f"
 dependencies = [
  "base64 0.22.1",
  "batuta-common",

--- a/contracts/apr-cpu-q4k-routing-v1.yaml
+++ b/contracts/apr-cpu-q4k-routing-v1.yaml
@@ -1,0 +1,183 @@
+# APR CPU Q4K Kernel Routing Contract v1.0.0
+# THE SOURCE OF TRUTH for APR model CPU inference path selection
+#
+# STATUS: Authoritative — start_apr_server() MUST follow this contract
+# CONSUMERS:
+#   - crates/apr-cli/src/commands/serve/handlers.rs (start_apr_server)
+#   - crates/apr-cli/src/commands/serve/handlers_include_01.rs (start_apr_server_gpu)
+#   - crates/apr-cli/src/commands/serve/server.rs (run_cpu_server)
+#
+# ENFORCEMENT: Code review + benchmark regression test
+#
+# Problem Statement:
+#   APR CPU inference uses AprTransformer (F32 matmul), achieving only 9.5 tok/s.
+#   GGUF and SafeTensors CPU paths use OwnedQuantizedModel (fused Q4K kernels),
+#   achieving 23-28 tok/s. APR files already contain Q4K tensors — the slow path
+#   is unnecessary for transformer models.
+#
+# Citation: Internal benchmark (probador llm bench, 2026-03-03)
+#   - APR AprTransformer CPU: 9.5 tok/s
+#   - APR OwnedQuantizedModel CPU: ~28 tok/s (projected, matches SafeTensors)
+#   - GGUF OwnedQuantizedModel CPU: 23.0 tok/s
+#   - SafeTensors OwnedQuantizedModel CPU: 28.3 tok/s
+
+metadata:
+  version: "1.0.0"
+  created: "2026-03-03"
+  author: "PAIML Engineering"
+  description: "Route APR CPU inference through fused Q4K kernels (OwnedQuantizedModel)"
+  references:
+    - "GH-87: APR GPU fused Q4K (existing pattern)"
+    - "GH-99: SafeTensors CPU Q4K (template for this fix)"
+  issues:
+    - "APR CPU 7-23x slower than llama.cpp"
+
+# =============================================================================
+# ROUTING EQUATION
+# =============================================================================
+
+equations:
+  inference_dispatch:
+    formula: |
+      start_apr_server(path, config):
+        1. IF cuda available AND config.gpu: try start_apr_server_gpu(path, config)
+        2. TRY try_apr_quantized_cpu(path, config)
+           a. MappedAprModel::from_path(path)
+           b. OwnedQuantizedModel::from_apr(mapped)
+           c. run_cpu_server(quantized, vocab, config)
+        3. FALLBACK: load_apr_model_state → AprTransformer (for non-Q4K models)
+    domain: "path is valid APR v2 file"
+    properties:
+      - q4k_priority: "Fused Q4K path is tried BEFORE AprTransformer"
+      - graceful_fallback: "AprTransformer fallback for models without Q4K tensors"
+      - no_conversion: "APR files already contain Q4K data — zero conversion overhead"
+
+# =============================================================================
+# PRECONDITIONS
+# =============================================================================
+
+preconditions:
+  valid_apr_file:
+    description: "Model path must be a valid APR v2 file (detected by magic bytes)"
+    assertion: "detect_format(magic) == ModelFormat::Apr"
+
+  q4k_tensors_present:
+    description: "Most APR files from GGUF/SafeTensors import contain Q4K tensors"
+    assertion: "MappedAprModel::from_path(path).is_ok() implies Q4K data available"
+    note: "Fallback handles the case where Q4K is NOT available"
+
+# =============================================================================
+# POSTCONDITIONS
+# =============================================================================
+
+postconditions:
+  uses_fused_kernels:
+    description: "When Q4K path succeeds, inference uses fused Q4K/Q6K GEMV kernels"
+    assertion: "Server state contains OwnedQuantizedModel, NOT AprTransformer"
+    performance: ">=20 tok/s on CPU (vs 9.5 with AprTransformer)"
+
+  full_endpoint_parity:
+    description: "Q4K CPU path uses realizar's create_router (Ollama-parity endpoints)"
+    assertion: "Endpoints: /health, /generate, /v1/completions, /v1/chat/completions"
+
+  tokenizer_preserved:
+    description: "Embedded BPE tokenizer from APR metadata is used for encoding/decoding"
+    assertion: "vocab = mapped.metadata.get_embedded_vocabulary()"
+
+  fallback_correctness:
+    description: "When Q4K path fails, AprTransformer is used (existing behavior)"
+    assertion: "AprTransformer path produces identical output to pre-fix behavior"
+
+# =============================================================================
+# INVARIANTS
+# =============================================================================
+
+invariants:
+  gpu_path_unchanged:
+    description: "CUDA GPU path is not modified — only CPU fallback changes"
+    assertion: "start_apr_server_gpu() call site unchanged"
+
+  no_temp_files:
+    description: "Unlike SafeTensors path, APR Q4K does NOT create temp files"
+    assertion: "No std::env::temp_dir() usage in try_apr_quantized_cpu"
+    rationale: "APR files already contain Q4K tensors natively"
+
+  merge_rules_honored:
+    description: "BPE merge rules from APR metadata are used when available"
+    assertion: "mapped.metadata.get_embedded_merges() feeds into tokenizer"
+
+# =============================================================================
+# IMPLEMENTATION MANDATES
+# =============================================================================
+
+implementation:
+  loading_path:
+    description: "MappedAprModel::from_path → OwnedQuantizedModel::from_apr → run_cpu_server"
+    rationale: "Identical to start_apr_server_gpu minus CUDA, identical to start_safetensors_server_cpu_quantized minus conversion"
+
+  vocabulary_extraction:
+    description: "Use mapped.metadata.get_embedded_vocabulary() with placeholder fallback"
+    assertion: "Pattern matches start_apr_server_gpu lines 45-53"
+
+  error_reporting:
+    description: "On Q4K path failure, print warning and fall through to AprTransformer"
+    assertion: "println!(Q4K path unavailable ({}), using AprTransformer, e)"
+
+# =============================================================================
+# PERFORMANCE BOUNDS
+# =============================================================================
+
+performance:
+  benchmark_tool: "probador llm bench"
+  model: "qwen2.5-coder-1.5b-instruct-q4k.apr"
+
+  bounds:
+    apr_cpu_q4k:
+      description: "APR CPU with fused Q4K kernels"
+      min_tok_per_sec: 20
+      target_tok_per_sec: 28
+      baseline_tok_per_sec: 9.5
+      baseline_engine: "AprTransformer"
+      expected_speedup: "2.5-3x"
+
+# =============================================================================
+# FALSIFICATION TESTS
+# =============================================================================
+
+falsification:
+  FALSIFY-APR-CPU-001:
+    name: "Q4K path loads successfully for GGUF-imported APR"
+    assertion: "try_apr_quantized_cpu succeeds for qwen2.5-coder-1.5b-instruct-q4k.apr"
+    status: "PRE-REGISTERED"
+
+  FALSIFY-APR-CPU-002:
+    name: "Fallback activates for non-Q4K APR files"
+    assertion: "F32-only APR file triggers AprTransformer fallback"
+    status: "PRE-REGISTERED"
+
+  FALSIFY-APR-CPU-003:
+    name: "Endpoint parity with GGUF CPU path"
+    assertion: "/v1/chat/completions produces coherent output (not garbage)"
+    status: "PRE-REGISTERED"
+
+  FALSIFY-APR-CPU-004:
+    name: "Performance meets minimum bound"
+    assertion: ">=20 tok/s on CPU benchmark"
+    status: "PRE-REGISTERED"
+
+# =============================================================================
+# QA GATE
+# =============================================================================
+
+qa_gate:
+  id: "F-APR-CPU-Q4K-001"
+  name: "APR CPU Q4K Routing Contract"
+  checks:
+    - "Q4K path tried before AprTransformer"
+    - "run_cpu_server used (Ollama-parity endpoints)"
+    - "Embedded vocabulary extracted from APR metadata"
+    - "Fallback to AprTransformer on Q4K failure"
+    - "No temp file creation"
+    - ">=20 tok/s on benchmark"
+    - "All FALSIFY tests pass"
+  pass_criteria: "All checks pass"

--- a/crates/apr-cli/Cargo.toml
+++ b/crates/apr-cli/Cargo.toml
@@ -68,7 +68,7 @@ hf-hub = ["aprender/hf-hub-integration"]
 safetensors-compare = ["aprender/safetensors-compare"]
 inference = ["realizar", "trueno", "tokio", "axum", "futures-util"]
 cuda = ["inference", "realizar/cuda"]
-visualization = ["renacer", "trueno-viz"]
+visualization = ["trueno-viz"]
 zram = ["trueno-zram-core"]
 
 [dependencies]
@@ -136,7 +136,7 @@ ratatui = { version = "0.29", default-features = true }
 crossterm = "0.28"
 
 # Visualization (syscall tracing and charts)
-renacer = { version = "0.10", optional = true, default-features = false }
+renacer = { version = "0.10", default-features = false }
 trueno-viz = { version = "0.2", optional = true, default-features = false, features = ["svg"] }
 
 # ZRAM compression (SIMD-accelerated LZ4/ZSTD)

--- a/crates/apr-cli/Cargo.toml
+++ b/crates/apr-cli/Cargo.toml
@@ -157,7 +157,7 @@ entrenar = { version = "0.7.3", features = ["cuda", "gpu", "parquet"] }
 alimentar = { version = "0.2.6", default-features = false, features = ["shuffle"] }
 half = "2.4.1"
 # YAML config parsing (distillation configs, ALB-011)
-serde_yaml_ng = "0.10"
+serde_yaml = { package = "serde_yaml_ng", version = "0.10" }
 
 [[example]]
 name = "probar_tui_testing"

--- a/crates/apr-cli/src/commands/distill.rs
+++ b/crates/apr-cli/src/commands/distill.rs
@@ -211,7 +211,7 @@ impl DistillYamlConfig {
     fn load(path: &Path) -> Result<Self> {
         let content = std::fs::read_to_string(path)
             .map_err(|e| CliError::ValidationFailed(format!("Failed to read config: {e}")))?;
-        serde_yaml_ng::from_str(&content)
+        serde_yaml::from_str(&content)
             .map_err(|e| CliError::ValidationFailed(format!("Failed to parse YAML: {e}")))
     }
 

--- a/crates/apr-cli/src/commands/finetune.rs
+++ b/crates/apr-cli/src/commands/finetune.rs
@@ -77,6 +77,31 @@ fn setup_mps(gpu_share: u32, json_output: bool) -> Result<()> {
     Ok(())
 }
 
+/// Merge --adapters-config TOML entries with --adapter CLI flags (GPU-SHARE §2.4).
+fn merge_adapters_config(
+    cli_adapters: &[String],
+    config_path: Option<&Path>,
+    json_output: bool,
+) -> Result<Vec<String>> {
+    let mut all = cli_adapters.to_vec();
+    if let Some(path) = config_path {
+        let config =
+            entrenar::finetune::multi_adapter_pipeline::AdaptersConfigFile::from_file(path)
+                .map_err(CliError::ValidationFailed)?;
+        for entry in &config.adapters {
+            all.push(format!("{}:{}", entry.data.display(), entry.checkpoint.display()));
+        }
+        if !json_output {
+            eprintln!(
+                "[adapters-config] Loaded {} adapter(s) from {}",
+                config.adapters.len(),
+                path.display()
+            );
+        }
+    }
+    Ok(all)
+}
+
 /// Resolve model parameters from either --model-size flag or file inspection.
 fn resolve_model_params(model_size: Option<&str>, model_path: Option<&Path>) -> Result<u64> {
     if let Some(size) = model_size {
@@ -398,6 +423,7 @@ pub(crate) fn run(
     expect_workers: Option<usize>,
     wait_gpu: u64,
     adapters: &[String],
+    adapters_config: Option<&Path>,
     json_output: bool,
     experimental_mps: bool,
     gpu_share: u32,
@@ -406,6 +432,10 @@ pub(crate) fn run(
     if experimental_mps {
         setup_mps(gpu_share, json_output)?;
     }
+
+    // Merge --adapters-config TOML entries into the adapters list (GPU-SHARE §2.4)
+    let all_adapters = merge_adapters_config(adapters, adapters_config, json_output)?;
+    let adapters = &all_adapters;
 
     // Wait for VRAM if requested (GPU-SHARE-003)
     if wait_gpu > 0 {

--- a/crates/apr-cli/src/commands/finetune.rs
+++ b/crates/apr-cli/src/commands/finetune.rs
@@ -373,8 +373,37 @@ pub(crate) fn run(
     bind: Option<&str>,
     coordinator: Option<&str>,
     expect_workers: Option<usize>,
+    wait_gpu: u64,
     json_output: bool,
 ) -> Result<()> {
+    // Wait for VRAM if requested (GPU-SHARE-003)
+    if wait_gpu > 0 {
+        let vram_mb = (vram_gb * 1024.0) as usize;
+        let task_name = task.unwrap_or("finetune");
+        eprintln!(
+            "[GPU] Waiting up to {wait_gpu}s for {vram_mb} MB VRAM ({task_name})..."
+        );
+        let mut ledger = entrenar::gpu::ledger::auto_ledger();
+        let config =
+            entrenar::gpu::wait::WaitConfig::with_timeout_secs(wait_gpu);
+        let mut profiler = entrenar::gpu::profiler::GpuProfiler::disabled();
+        match entrenar::gpu::wait::wait_for_vram(
+            &mut ledger,
+            vram_mb,
+            task_name,
+            &config,
+            &mut profiler,
+        ) {
+            Ok(id) => eprintln!("[GPU] VRAM reserved: {vram_mb} MB (id: {id})"),
+            Err(e) => {
+                return Err(CliError::Aprender(format!(
+                    "VRAM wait failed: {e}"
+                )));
+            }
+        }
+        // Note: ledger reservation will be released on drop (end of training)
+    }
+
     if merge_mode {
         return run_merge(model_path, adapter_path, output_path, json_output);
     }

--- a/crates/apr-cli/src/commands/finetune.rs
+++ b/crates/apr-cli/src/commands/finetune.rs
@@ -1270,13 +1270,18 @@ fn run_multi_adapter_training(
             }
         }
 
-        if !json_output {
-            for (i, losses) in epoch_losses.iter().enumerate() {
-                let avg = if losses.is_empty() { 0.0 } else { losses.iter().sum::<f32>() / losses.len() as f32 };
+        // Per-adapter epoch logging and checkpointing
+        for (i, losses) in epoch_losses.iter().enumerate() {
+            let avg = if losses.is_empty() { 0.0 } else { losses.iter().sum::<f32>() / losses.len() as f32 };
+            if !json_output {
                 output::kv(
                     &format!("Epoch {} Adapter {i}", epoch + 1),
                     format!("avg_loss={avg:.4} ({} steps)", losses.len()),
                 );
+            }
+            // Save per-adapter checkpoint
+            if let Err(e) = multi.save_adapter_checkpoint(i, epoch as usize, avg) {
+                eprintln!("Warning: adapter {i} checkpoint failed: {e}");
             }
         }
     }

--- a/crates/apr-cli/src/commands/finetune.rs
+++ b/crates/apr-cli/src/commands/finetune.rs
@@ -54,6 +54,29 @@ impl From<FinetuneMethod> for Method {
     }
 }
 
+/// Setup CUDA MPS environment (GPU-SHARE §1.5).
+fn setup_mps(gpu_share: u32, json_output: bool) -> Result<()> {
+    let mps_config = entrenar::gpu::mps::MpsConfig::with_share(gpu_share);
+    let validation = entrenar::gpu::mps::validate_mps_config(&mps_config);
+    if validation.has_errors() {
+        return Err(CliError::ValidationFailed(format!(
+            "MPS config errors: {}",
+            validation.errors.join("; ")
+        )));
+    }
+    for w in &validation.warnings {
+        eprintln!("[MPS] Warning: {w}");
+    }
+    let vars = entrenar::gpu::mps::setup_mps_env(&mps_config);
+    entrenar::gpu::mps::print_mps_warning(&mps_config);
+    if !json_output {
+        for (k, v) in &vars {
+            eprintln!("[MPS] Set {k}={v}");
+        }
+    }
+    Ok(())
+}
+
 /// Resolve model parameters from either --model-size flag or file inspection.
 fn resolve_model_params(model_size: Option<&str>, model_path: Option<&Path>) -> Result<u64> {
     if let Some(size) = model_size {
@@ -376,7 +399,14 @@ pub(crate) fn run(
     wait_gpu: u64,
     adapters: &[String],
     json_output: bool,
+    experimental_mps: bool,
+    gpu_share: u32,
 ) -> Result<()> {
+    // MPS setup (GPU-SHARE §1.5) — must happen before any CUDA context creation
+    if experimental_mps {
+        setup_mps(gpu_share, json_output)?;
+    }
+
     // Wait for VRAM if requested (GPU-SHARE-003)
     if wait_gpu > 0 {
         let vram_mb = (vram_gb * 1024.0) as usize;

--- a/crates/apr-cli/src/commands/finetune.rs
+++ b/crates/apr-cli/src/commands/finetune.rs
@@ -374,6 +374,7 @@ pub(crate) fn run(
     coordinator: Option<&str>,
     expect_workers: Option<usize>,
     wait_gpu: u64,
+    adapters: &[String],
     json_output: bool,
 ) -> Result<()> {
     // Wait for VRAM if requested (GPU-SHARE-003)
@@ -430,6 +431,22 @@ pub(crate) fn run(
             bind,
             coordinator,
             expect_workers,
+            json_output,
+        );
+    }
+
+    // GPU-SHARE Phase 2: Multi-adapter training (GH-206)
+    if !adapters.is_empty() {
+        return run_multi_adapter(
+            model_path,
+            model_size,
+            adapters,
+            rank.unwrap_or(16),
+            epochs,
+            learning_rate,
+            plan_only,
+            quantize_nf4,
+            max_seq_len,
             json_output,
         );
     }
@@ -1158,6 +1175,223 @@ fn run_instruct(
         display_instruct_result(&result, &output_dir);
     }
 
+    Ok(())
+}
+
+/// Parse `--adapters DATA:CHECKPOINT` specs into (data_path, checkpoint_dir) pairs.
+fn parse_adapter_specs(adapters: &[String]) -> Result<Vec<(std::path::PathBuf, std::path::PathBuf)>> {
+    let mut specs = Vec::new();
+    for spec in adapters {
+        let parts: Vec<&str> = spec.splitn(2, ':').collect();
+        if parts.len() != 2 {
+            return Err(CliError::ValidationFailed(format!(
+                "Invalid --adapters format: {spec:?}. Expected DATA:CHECKPOINT (e.g., data/corpus.jsonl:checkpoints/adapter-a)"
+            )));
+        }
+        let data_path = std::path::PathBuf::from(parts[0]);
+        let checkpoint_dir = std::path::PathBuf::from(parts[1]);
+        if !data_path.exists() {
+            return Err(CliError::FileNotFound(data_path));
+        }
+        specs.push((data_path, checkpoint_dir));
+    }
+    Ok(specs)
+}
+
+/// Load adapter corpora and register slots on the multi-adapter pipeline.
+fn load_adapter_slots(
+    multi: &mut entrenar::finetune::multi_adapter_pipeline::MultiAdapterPipeline,
+    adapter_specs: &[(std::path::PathBuf, std::path::PathBuf)],
+    instruct_config: &entrenar::finetune::instruct_pipeline::InstructConfig,
+    json_output: bool,
+) -> Result<()> {
+    use entrenar::finetune::instruct_corpus::load_instruct_corpus;
+    use entrenar::finetune::multi_adapter_pipeline::AdapterConfig;
+
+    for (i, (data_path, checkpoint_dir)) in adapter_specs.iter().enumerate() {
+        let samples = load_instruct_corpus(data_path)
+            .map_err(|e| CliError::ValidationFailed(format!("Adapter {i}: failed to load corpus: {e}")))?;
+
+        let total = samples.len();
+        let val_split = (total / 10).max(1);
+        let (val_samples, train_samples) = if total > val_split {
+            let mut all = samples;
+            let val = all.split_off(all.len() - val_split);
+            (val, all)
+        } else {
+            (Vec::new(), samples)
+        };
+
+        if !json_output {
+            output::kv(
+                &format!("Adapter {i}"),
+                format!("{} train, {} val samples", train_samples.len(), val_samples.len()),
+            );
+        }
+
+        std::fs::create_dir_all(checkpoint_dir).map_err(|e| {
+            CliError::ValidationFailed(format!(
+                "Cannot create checkpoint dir {}: {e}",
+                checkpoint_dir.display()
+            ))
+        })?;
+
+        let adapter_config = AdapterConfig {
+            data_path: data_path.clone(),
+            checkpoint_dir: checkpoint_dir.clone(),
+            instruct_config: instruct_config.clone(),
+        };
+
+        multi.add_adapter(adapter_config, train_samples, val_samples);
+    }
+    Ok(())
+}
+
+/// Run the multi-adapter training loop and display results.
+fn run_multi_adapter_training(
+    multi: &mut entrenar::finetune::multi_adapter_pipeline::MultiAdapterPipeline,
+    epochs: u32,
+    json_output: bool,
+) {
+    use entrenar::finetune::instruct_pipeline::InstructStepResult;
+
+    let start = std::time::Instant::now();
+    for epoch in 0..epochs {
+        multi.reset_epoch(epoch as u64);
+        let mut epoch_losses: Vec<Vec<f32>> = vec![Vec::new(); multi.num_adapters()];
+
+        while !multi.all_exhausted() {
+            if let Some(idx) = multi.select_next_adapter() {
+                if let Some(InstructStepResult { loss, .. }) = multi.train_step_adapter(idx) {
+                    epoch_losses[idx].push(loss);
+                }
+            } else {
+                break;
+            }
+        }
+
+        if !json_output {
+            for (i, losses) in epoch_losses.iter().enumerate() {
+                let avg = if losses.is_empty() { 0.0 } else { losses.iter().sum::<f32>() / losses.len() as f32 };
+                output::kv(
+                    &format!("Epoch {} Adapter {i}", epoch + 1),
+                    format!("avg_loss={avg:.4} ({} steps)", losses.len()),
+                );
+            }
+        }
+    }
+
+    let elapsed = start.elapsed();
+    if json_output {
+        let json = serde_json::json!({
+            "status": "training_complete",
+            "mode": "multi_adapter",
+            "num_adapters": multi.num_adapters(),
+            "epochs": epochs,
+            "total_time_ms": elapsed.as_millis() as u64,
+            "global_steps": multi.global_step,
+        });
+        println!("{}", serde_json::to_string_pretty(&json).unwrap_or_default());
+    } else {
+        output::pipeline_stage("Multi-Adapter Training", output::StageStatus::Done);
+        println!();
+        output::kv("Total steps", multi.global_step.to_string());
+        output::kv("Total time", format!("{:.1}s", elapsed.as_secs_f64()));
+        for (i, slot) in multi.adapters.iter().enumerate() {
+            output::kv(&format!("Adapter {i} checkpoint"), slot.checkpoint_dir.display().to_string());
+        }
+    }
+}
+
+/// Multi-adapter training (GPU-SHARE Phase 2, GH-206).
+///
+/// Trains N independent LoRA adapter sets on a single frozen base model.
+/// Each `--adapters DATA:CHECKPOINT` pair is parsed into an adapter slot.
+#[allow(clippy::too_many_arguments)]
+fn run_multi_adapter(
+    model_path: Option<&Path>,
+    model_size: Option<&str>,
+    adapters: &[String],
+    rank: u32,
+    epochs: u32,
+    learning_rate: f64,
+    plan_only: bool,
+    quantize_nf4: bool,
+    max_seq_len: Option<usize>,
+    json_output: bool,
+) -> Result<()> {
+    use entrenar::finetune::instruct_pipeline::InstructConfig;
+    use entrenar::finetune::multi_adapter_pipeline::{AdapterSchedule, MultiAdapterPipeline};
+
+    if !json_output {
+        output::section("apr finetune --adapters (GPU-SHARE Phase 2: Multi-Adapter Training)");
+        println!();
+    }
+
+    let adapter_specs = parse_adapter_specs(adapters)?;
+    let model_config = super::model_config::resolve_transformer_config(model_path, model_size)?;
+
+    if !json_output {
+        output::kv("Model", format!("{}h x {}L (vocab {})", model_config.hidden_size, model_config.num_hidden_layers, model_config.vocab_size));
+        output::kv("Adapters", adapter_specs.len().to_string());
+        output::kv("Method", if quantize_nf4 { "QLoRA (NF4)" } else { "LoRA" });
+        output::kv("LoRA rank", rank.to_string());
+        output::kv("Epochs", epochs.to_string());
+        output::kv("Learning rate", format!("{learning_rate:.1e}"));
+        println!();
+        for (i, (data, ckpt)) in adapter_specs.iter().enumerate() {
+            output::kv(&format!("Adapter {i}"), format!("data={} ckpt={}", data.display(), ckpt.display()));
+        }
+        println!();
+    }
+
+    let instruct_config = InstructConfig {
+        lora_rank: rank as usize,
+        lora_alpha: rank as f32 * 2.0,
+        learning_rate: learning_rate as f32,
+        epochs: epochs as usize,
+        max_seq_len: max_seq_len.unwrap_or(InstructConfig::default().max_seq_len),
+        quantize_nf4,
+        ..InstructConfig::default()
+    };
+
+    let base_pipeline = load_instruct_pipeline(model_path, &model_config, instruct_config.clone())?;
+
+    if !json_output {
+        if let Some(ref name) = base_pipeline.gpu_name() {
+            output::kv("Device", format!("CUDA ({name})"));
+        } else {
+            output::kv("Device", "CPU");
+        }
+        println!();
+    }
+
+    let mut multi = MultiAdapterPipeline::new(base_pipeline, AdapterSchedule::RoundRobin);
+    load_adapter_slots(&mut multi, &adapter_specs, &instruct_config, json_output)?;
+
+    if plan_only {
+        if json_output {
+            let json = serde_json::json!({
+                "mode": "multi_adapter",
+                "num_adapters": multi.num_adapters(),
+                "schedule": "round_robin",
+                "lora_rank": rank,
+                "quantize_nf4": quantize_nf4,
+                "epochs": epochs,
+            });
+            println!("{}", serde_json::to_string_pretty(&json).unwrap_or_default());
+        } else {
+            output::kv("Status", "plan-only — no training will run");
+        }
+        return Ok(());
+    }
+
+    if !json_output {
+        output::pipeline_stage("Multi-Adapter Training", output::StageStatus::Running);
+        println!();
+    }
+
+    run_multi_adapter_training(&mut multi, epochs, json_output);
     Ok(())
 }
 

--- a/crates/apr-cli/src/commands/gpu.rs
+++ b/crates/apr-cli/src/commands/gpu.rs
@@ -1,0 +1,61 @@
+//! GPU status and VRAM reservation management (GPU-SHARE-001, GH-152).
+//!
+//! Displays GPU detection info, VRAM capacity, active reservations,
+//! and available budget from the entrenar VRAM ledger.
+
+use crate::CliError;
+use crate::error::Result;
+
+pub fn run(json: bool) -> Result<()> {
+    let uuid = entrenar::gpu::ledger::detect_gpu_uuid();
+    let total_mb = entrenar::gpu::ledger::detect_total_memory_mb();
+    let mem_type = entrenar::gpu::ledger::detect_memory_type();
+
+    let ledger =
+        entrenar::gpu::ledger::VramLedger::new(uuid.clone(), total_mb, mem_type.reserve_factor());
+
+    if json {
+        let reservations = ledger
+            .read_reservations()
+            .map_err(|e| CliError::Aprender(format!("ledger read: {e}")))?;
+        let reserved: usize = reservations
+            .iter()
+            .map(|r| r.actual_mb.unwrap_or(r.budget_mb))
+            .sum();
+
+        let json_val = serde_json::json!({
+            "gpu_uuid": uuid,
+            "total_mb": total_mb,
+            "memory_type": format!("{mem_type:?}"),
+            "reserve_factor": mem_type.reserve_factor(),
+            "capacity_mb": ledger.capacity_mb(),
+            "reserved_mb": reserved,
+            "available_mb": ledger.capacity_mb().saturating_sub(reserved),
+            "reservations": reservations.iter().map(|r| serde_json::json!({
+                "id": r.id,
+                "pid": r.pid,
+                "budget_mb": r.budget_mb,
+                "actual_mb": r.actual_mb,
+                "task": r.task,
+                "started": r.started.to_rfc3339(),
+                "lease_expires": r.lease_expires.to_rfc3339(),
+            })).collect::<Vec<_>>(),
+        });
+        println!("{}", serde_json::to_string_pretty(&json_val).unwrap_or_default());
+    } else {
+        println!("GPU: {uuid}");
+        println!("Total: {total_mb} MB");
+        println!(
+            "Type: {mem_type:?} (reserve factor: {:.0}%)",
+            mem_type.reserve_factor() * 100.0
+        );
+        println!();
+
+        match entrenar::gpu::ledger::gpu_status_display(&ledger) {
+            Ok(status) => print!("{status}"),
+            Err(e) => eprintln!("Ledger error: {e}"),
+        }
+    }
+
+    Ok(())
+}

--- a/crates/apr-cli/src/commands/mod.rs
+++ b/crates/apr-cli/src/commands/mod.rs
@@ -26,6 +26,7 @@ pub(crate) mod explain;
 pub(crate) mod export;
 pub(crate) mod finetune;
 pub(crate) mod flow;
+pub(crate) mod gpu;
 pub(crate) mod hex;
 pub(crate) mod import;
 pub(crate) mod inspect;

--- a/crates/apr-cli/src/commands/serve/handler_gpu_completion.rs
+++ b/crates/apr-cli/src/commands/serve/handler_gpu_completion.rs
@@ -434,7 +434,7 @@ fn start_gguf_server_cuda(
     mapped_model: &realizar::gguf::MappedGGUFModel,
     config: &ServerConfig,
 ) -> Result<()> {
-    use realizar::api::{create_router, AppState};
+    use realizar::api::{create_router, AppState, CudaBatchConfig};
     use realizar::gguf::{OwnedQuantizedModel, OwnedQuantizedModelCuda};
 
     println!(
@@ -449,6 +449,7 @@ fn start_gguf_server_cuda(
 
             let state = AppState::with_cuda_model_and_vocab(cuda_model, vocab)
                 .map_err(|e| CliError::InferenceFailed(format!("Failed to create state: {e}")))?
+                .with_cuda_dispatch(CudaBatchConfig::default())
                 .with_verbose(config.verbose)
                 .with_inference_trace(config.trace);
 

--- a/crates/apr-cli/src/commands/serve/handler_gpu_completion.rs
+++ b/crates/apr-cli/src/commands/serve/handler_gpu_completion.rs
@@ -449,7 +449,8 @@ fn start_gguf_server_cuda(
 
             let state = AppState::with_cuda_model_and_vocab(cuda_model, vocab)
                 .map_err(|e| CliError::InferenceFailed(format!("Failed to create state: {e}")))?
-                .with_verbose(config.verbose);
+                .with_verbose(config.verbose)
+                .with_inference_trace(config.trace);
 
             let app = create_router(state);
             run_server_async(app, &config.bind_addr(), "CUDA-optimized")

--- a/crates/apr-cli/src/commands/serve/handlers.rs
+++ b/crates/apr-cli/src/commands/serve/handlers.rs
@@ -84,6 +84,19 @@ pub(crate) fn start_realizar_server(model_path: &Path, config: &ServerConfig) ->
                     }
                 }
             }
+            // GH-99: Try Q4K CPU path (same fused kernels as GGUF, eliminates F32 fallback)
+            #[cfg(feature = "inference")]
+            {
+                match start_safetensors_server_cpu_quantized(model_path, config) {
+                    Ok(()) => return Ok(()),
+                    Err(e) => {
+                        println!(
+                            "{}",
+                            format!("Q4K conversion failed, falling back to F32: {e}").yellow()
+                        );
+                    }
+                }
+            }
             println!("{}", "Starting SafeTensors inspection server...".cyan());
             super::safetensors::start_safetensors_server(model_path, config)
         }
@@ -360,6 +373,23 @@ fn start_apr_server(model_path: &Path, config: &ServerConfig) -> Result<()> {
         }
     }
 
+    // Contract: apr-cpu-q4k-routing-v1.yaml
+    // Try fused Q4K CPU path first (same engine as GGUF/SafeTensors, 3x faster than AprTransformer).
+    // APR files from GGUF/SafeTensors import already contain Q4K tensors — no conversion needed.
+    #[cfg(feature = "inference")]
+    {
+        match try_apr_quantized_cpu(model_path, config) {
+            Ok(()) => return Ok(()),
+            Err(e) => {
+                println!(
+                    "{}",
+                    format!("Q4K path unavailable ({e}), using AprTransformer fallback").yellow()
+                );
+            }
+        }
+    }
+
+    // Fallback: AprTransformer for non-transformer or non-Q4K APR models
     let state = load_apr_model_state(model_path, config)?;
     let is_transformer = state.is_transformer;
 
@@ -386,6 +416,62 @@ fn start_apr_server(model_path: &Path, config: &ServerConfig) -> Result<()> {
         println!("{}", "Server stopped".yellow());
         Ok(())
     })
+}
+
+/// Route APR CPU inference through fused Q4K kernels (OwnedQuantizedModel).
+///
+/// Contract: apr-cpu-q4k-routing-v1.yaml
+/// Loading path: MappedAprModel::from_path → OwnedQuantizedModel::from_apr → run_cpu_server.
+/// APR files from GGUF/SafeTensors import already contain Q4K tensors, so this avoids
+/// the slow AprTransformer F32 matmul path (9.5 → ~28 tok/s).
+#[cfg(feature = "inference")]
+fn try_apr_quantized_cpu(model_path: &Path, config: &ServerConfig) -> Result<()> {
+    use realizar::apr::MappedAprModel;
+    use realizar::gguf::OwnedQuantizedModel;
+
+    println!("{}", "Loading APR model (fused Q4K kernels)...".dimmed());
+
+    let mapped = MappedAprModel::from_path(model_path)
+        .map_err(|e| CliError::InferenceFailed(format!("Failed to map APR: {e}")))?;
+
+    println!(
+        "{}",
+        format!(
+            "APR loaded: {} tensors, {} metadata entries",
+            mapped.tensors.len(),
+            mapped.metadata.extra.len()
+        )
+        .dimmed()
+    );
+
+    let quantized = OwnedQuantizedModel::from_apr(&mapped)
+        .map_err(|e| CliError::InferenceFailed(format!("Failed to create quantized model: {e}")))?;
+
+    println!(
+        "{}",
+        format!(
+            "Model ready: {} layers, vocab_size={}, hidden_dim={}",
+            quantized.layers().len(),
+            quantized.config().vocab_size,
+            quantized.config().hidden_dim
+        )
+        .green()
+    );
+
+    // Extract vocabulary from embedded APR metadata (GGUF-imported models embed tokenizer)
+    let vocab = mapped.metadata.get_embedded_vocabulary().unwrap_or_else(|| {
+        let vocab_size = mapped.metadata.vocab_size.unwrap_or(32000);
+        eprintln!("Warning: No embedded vocabulary in APR, using placeholder tokens");
+        let mut v: Vec<String> = (0..vocab_size).map(|i| format!("token{i}")).collect();
+        if !v.is_empty() {
+            v[0] = "<unk>".to_string();
+        }
+        v
+    });
+
+    println!("{}", "Q4K CPU inference ready".green());
+
+    run_cpu_server(quantized, vocab, config)
 }
 
 /// Build the axum Router for APR CPU inference.

--- a/crates/apr-cli/src/commands/serve/handlers_include_01.rs
+++ b/crates/apr-cli/src/commands/serve/handlers_include_01.rs
@@ -9,7 +9,7 @@ fn start_apr_server_gpu(
     config: &ServerConfig,
 ) -> Result<()> {
     use realizar::apr::MappedAprModel;
-    use realizar::api::{create_router, AppState};
+    use realizar::api::{create_router, AppState, CudaBatchConfig};
     use realizar::gguf::{OwnedQuantizedModel, OwnedQuantizedModelCuda};
 
     println!("{}", "Loading APR model (fused Q4K kernels)...".dimmed());
@@ -71,6 +71,7 @@ fn start_apr_server_gpu(
         AppState::with_cuda_model_and_vocab(cuda_model, vocab)
     }
     .map_err(|e| CliError::InferenceFailed(format!("Failed to create state: {e}")))?
+    .with_cuda_dispatch(CudaBatchConfig::default())
     .with_verbose(config.verbose)
     .with_inference_trace(config.trace);
 
@@ -91,7 +92,7 @@ fn start_safetensors_server_gpu(
 ) -> Result<()> {
     use aprender::format::{ImportOptions, QuantizationType};
     use realizar::apr::MappedAprModel;
-    use realizar::api::{create_router, AppState};
+    use realizar::api::{create_router, AppState, CudaBatchConfig};
     use realizar::gguf::{OwnedQuantizedModel, OwnedQuantizedModelCuda};
 
     println!("{}", "Converting SafeTensors → Q4K (one-time)...".dimmed());
@@ -156,6 +157,7 @@ fn start_safetensors_server_gpu(
         AppState::with_cuda_model_and_vocab(cuda_model, vocab)
     }
     .map_err(|e| CliError::InferenceFailed(format!("Failed to create state: {e}")))?
+    .with_cuda_dispatch(CudaBatchConfig::default())
     .with_verbose(config.verbose)
     .with_inference_trace(config.trace);
 

--- a/crates/apr-cli/src/commands/serve/handlers_include_01.rs
+++ b/crates/apr-cli/src/commands/serve/handlers_include_01.rs
@@ -71,7 +71,8 @@ fn start_apr_server_gpu(
         AppState::with_cuda_model_and_vocab(cuda_model, vocab)
     }
     .map_err(|e| CliError::InferenceFailed(format!("Failed to create state: {e}")))?
-    .with_verbose(config.verbose);
+    .with_verbose(config.verbose)
+    .with_inference_trace(config.trace);
 
     let app = create_router(state);
     run_server_async(app, &config.bind_addr(), "APR GPU (fused Q4K kernels)")
@@ -155,7 +156,8 @@ fn start_safetensors_server_gpu(
         AppState::with_cuda_model_and_vocab(cuda_model, vocab)
     }
     .map_err(|e| CliError::InferenceFailed(format!("Failed to create state: {e}")))?
-    .with_verbose(config.verbose);
+    .with_verbose(config.verbose)
+    .with_inference_trace(config.trace);
 
     let app = create_router(state);
     run_server_async(app, &config.bind_addr(), "SafeTensors GPU (fused Q4K kernels)")

--- a/crates/apr-cli/src/commands/serve/server.rs
+++ b/crates/apr-cli/src/commands/serve/server.rs
@@ -10,7 +10,8 @@ fn run_cpu_server(
 
     let state = AppState::with_quantized_model_and_vocab(quantized_model, vocab)
         .map_err(|e| CliError::InferenceFailed(format!("Failed to create app state: {e}")))?
-        .with_verbose(config.verbose); // GH-152: Pass verbose flag to handlers
+        .with_verbose(config.verbose) // GH-152: Pass verbose flag to handlers
+        .with_inference_trace(config.trace); // GH-103: Pass trace flag to inference engine
 
     // Create realizar's full inference router (Ollama-parity endpoints)
     let app = create_router(state);

--- a/crates/apr-cli/src/commands/serve_plan.rs
+++ b/crates/apr-cli/src/commands/serve_plan.rs
@@ -324,7 +324,7 @@ fn assemble_and_output(
             println!("{json}");
         }
         "yaml" => {
-            let yaml = serde_yaml_ng::to_string(&plan)
+            let yaml = serde_yaml::to_string(&plan)
                 .map_err(|e| CliError::Aprender(format!("YAML serialization failed: {e}")))?;
             print!("{yaml}");
         }

--- a/crates/apr-cli/src/commands/train.rs
+++ b/crates/apr-cli/src/commands/train.rs
@@ -1295,6 +1295,162 @@ pub(crate) fn run_archive(
     Ok(())
 }
 
+/// Run `apr train submit` — place adapter jobs across a cluster and show launch commands.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn run_submit(
+    cluster_path: &std::path::Path,
+    model_path: &std::path::Path,
+    adapters: &[String],
+    rank: u32,
+    epochs: u32,
+    budget_mb: u64,
+    dry_run: bool,
+    json: bool,
+) -> Result<()> {
+    use entrenar::gpu::cluster::ClusterConfig;
+    use entrenar::gpu::coordinator::build_launch_command;
+    use entrenar::gpu::placement::{place_adapters, AdapterJob};
+
+    let cluster = ClusterConfig::from_file(cluster_path)
+        .map_err(|e| CliError::InvalidInput(format!("failed to load cluster config: {e}")))?;
+
+    if adapters.is_empty() {
+        return Err(CliError::InvalidInput(
+            "at least one --adapter DATA:CHECKPOINT pair is required".to_string(),
+        ));
+    }
+
+    let jobs: Vec<AdapterJob> = adapters
+        .iter()
+        .enumerate()
+        .map(|(i, spec)| AdapterJob {
+            adapter_idx: i,
+            budget_mb,
+            label: spec.clone(),
+        })
+        .collect();
+
+    let placements = place_adapters(&cluster, &jobs, &[]);
+
+    if json {
+        let entries: Vec<serde_json::Value> = placements
+            .iter()
+            .map(|p| {
+                let parts: Vec<&str> = adapters[p.adapter_idx].splitn(2, ':').collect();
+                serde_json::json!({
+                    "adapter_idx": p.adapter_idx,
+                    "node": p.node_name,
+                    "score": p.score,
+                    "data": parts.first().unwrap_or(&""),
+                    "checkpoint": parts.get(1).unwrap_or(&""),
+                })
+            })
+            .collect();
+        println!("{}", serde_json::to_string_pretty(&serde_json::json!({
+            "cluster": cluster_path,
+            "model": model_path,
+            "placements": entries,
+            "total_adapters": adapters.len(),
+            "placed": placements.len(),
+            "dry_run": dry_run,
+        })).unwrap_or_default());
+        return Ok(());
+    }
+
+    println!("{}", cluster);
+    println!("--- Placement ---");
+    for p in &placements {
+        println!(
+            "  Adapter {} ({}): -> {} (score: {:.3})",
+            p.adapter_idx, adapters[p.adapter_idx], p.node_name, p.score
+        );
+    }
+
+    let unplaced: Vec<_> = jobs
+        .iter()
+        .filter(|j| !placements.iter().any(|p| p.adapter_idx == j.adapter_idx))
+        .collect();
+    for j in &unplaced {
+        println!("  Adapter {} ({}): {} (no eligible node)",
+            j.adapter_idx, j.label, "UNPLACED".red());
+    }
+
+    println!();
+    println!("--- Launch Commands ---");
+    for p in &placements {
+        if let Some(node) = cluster.find_node(&p.node_name) {
+            let parts: Vec<&str> = adapters[p.adapter_idx].splitn(2, ':').collect();
+            let data = parts.first().unwrap_or(&"data.jsonl");
+            let ckpt = parts.get(1).unwrap_or(&"/tmp/adapter");
+            let cmd = build_launch_command(
+                node,
+                model_path,
+                std::path::Path::new(data),
+                std::path::Path::new(ckpt),
+                rank,
+                epochs,
+            );
+            println!("  [{}] {cmd}", p.node_name);
+        }
+    }
+
+    if dry_run {
+        println!();
+        println!("  {} (dry run — no jobs launched)", "DRY RUN".yellow().bold());
+    }
+
+    Ok(())
+}
+
+/// Run `apr train cluster-status` — display cluster node info and capacity.
+pub(crate) fn run_cluster_status(
+    cluster_path: &std::path::Path,
+    json: bool,
+) -> Result<()> {
+    use entrenar::gpu::cluster::ClusterConfig;
+
+    let cluster = ClusterConfig::from_file(cluster_path)
+        .map_err(|e| CliError::InvalidInput(format!("failed to load cluster config: {e}")))?;
+
+    if json {
+        let nodes: Vec<serde_json::Value> = cluster
+            .nodes
+            .iter()
+            .map(|n| {
+                serde_json::json!({
+                    "name": n.name,
+                    "host": n.host,
+                    "transport": format!("{}", n.transport),
+                    "gpus": n.gpus.iter().map(|g| serde_json::json!({
+                        "uuid": g.uuid,
+                        "type": g.gpu_type,
+                        "vram_mb": g.vram_mb,
+                        "usable_vram_mb": g.usable_vram_mb(),
+                        "memory_type": format!("{:?}", g.memory_type),
+                    })).collect::<Vec<_>>(),
+                    "max_adapters": n.max_adapters,
+                    "total_vram_mb": n.total_vram_mb(),
+                    "usable_vram_mb": n.usable_vram_mb(),
+                    "is_local": n.is_local(),
+                    "is_cpu_only": n.is_cpu_only(),
+                })
+            })
+            .collect();
+        println!("{}", serde_json::to_string_pretty(&serde_json::json!({
+            "cluster_config": cluster_path,
+            "total_nodes": cluster.nodes.len(),
+            "total_adapter_capacity": cluster.total_adapter_capacity(),
+            "nodes": nodes,
+        })).unwrap_or_default());
+        return Ok(());
+    }
+
+    println!("{cluster}");
+    println!("Total adapter capacity: {}", cluster.total_adapter_capacity());
+
+    Ok(())
+}
+
 fn format_archive_size(bytes: u64) -> String {
     if bytes >= 1_073_741_824 {
         format!("{:.1} GB", bytes as f64 / 1_073_741_824.0)

--- a/crates/apr-cli/src/commands/train.rs
+++ b/crates/apr-cli/src/commands/train.rs
@@ -1312,10 +1312,10 @@ pub(crate) fn run_submit(
     use entrenar::gpu::placement::{place_adapters, AdapterJob};
 
     let cluster = ClusterConfig::from_file(cluster_path)
-        .map_err(|e| CliError::InvalidInput(format!("failed to load cluster config: {e}")))?;
+        .map_err(|e| CliError::ValidationFailed(format!("failed to load cluster config: {e}")))?;
 
     if adapters.is_empty() {
-        return Err(CliError::InvalidInput(
+        return Err(CliError::ValidationFailed(
             "at least one --adapter DATA:CHECKPOINT pair is required".to_string(),
         ));
     }
@@ -1410,7 +1410,7 @@ pub(crate) fn run_cluster_status(
     use entrenar::gpu::cluster::ClusterConfig;
 
     let cluster = ClusterConfig::from_file(cluster_path)
-        .map_err(|e| CliError::InvalidInput(format!("failed to load cluster config: {e}")))?;
+        .map_err(|e| CliError::ValidationFailed(format!("failed to load cluster config: {e}")))?;
 
     if json {
         let nodes: Vec<serde_json::Value> = cluster

--- a/crates/apr-cli/src/commands/train.rs
+++ b/crates/apr-cli/src/commands/train.rs
@@ -575,29 +575,29 @@ fn build_distributed_yaml(
     world_size: Option<usize>,
     rank: Option<usize>,
     coordinator_addr: Option<&str>,
-) -> serde_yaml_ng::Value {
-    let mut m = serde_yaml_ng::Mapping::new();
+) -> serde_yaml::Value {
+    let mut m = serde_yaml::Mapping::new();
     let ws = world_size.unwrap_or(2);
     m.insert(
-        serde_yaml_ng::Value::String("world_size".into()),
-        serde_yaml_ng::Value::Number(serde_yaml_ng::Number::from(ws as u64)),
+        serde_yaml::Value::String("world_size".into()),
+        serde_yaml::Value::Number(serde_yaml::Number::from(ws as u64)),
     );
     let r = rank.unwrap_or(0);
     m.insert(
-        serde_yaml_ng::Value::String("rank".into()),
-        serde_yaml_ng::Value::Number(serde_yaml_ng::Number::from(r as u64)),
+        serde_yaml::Value::String("rank".into()),
+        serde_yaml::Value::Number(serde_yaml::Number::from(r as u64)),
     );
     let addr = coordinator_addr.unwrap_or("0.0.0.0:9000");
     m.insert(
-        serde_yaml_ng::Value::String("coordinator_addr".into()),
-        serde_yaml_ng::Value::String(addr.into()),
+        serde_yaml::Value::String("coordinator_addr".into()),
+        serde_yaml::Value::String(addr.into()),
     );
     let role = if r == 0 { "coordinator" } else { "worker" };
     m.insert(
-        serde_yaml_ng::Value::String("role".into()),
-        serde_yaml_ng::Value::String(role.into()),
+        serde_yaml::Value::String("role".into()),
+        serde_yaml::Value::String(role.into()),
     );
-    serde_yaml_ng::Value::Mapping(m)
+    serde_yaml::Value::Mapping(m)
 }
 
 /// Patch a YAML training config with CLI overrides (distributed, deterministic, seed).
@@ -612,34 +612,34 @@ fn patch_yaml_config(
 ) -> Result<std::path::PathBuf> {
     let yaml_content = std::fs::read_to_string(config_path)
         .map_err(|e| CliError::ValidationFailed(format!("Failed to read config: {e}")))?;
-    let mut yaml_val: serde_yaml_ng::Value = serde_yaml_ng::from_str(&yaml_content)
+    let mut yaml_val: serde_yaml::Value = serde_yaml::from_str(&yaml_content)
         .map_err(|e| CliError::ValidationFailed(format!("Invalid YAML: {e}")))?;
 
     let training = yaml_val
         .get_mut("training")
         .ok_or_else(|| CliError::ValidationFailed("Missing 'training' section".into()))?;
 
-    if let serde_yaml_ng::Value::Mapping(training_map) = training {
+    if let serde_yaml::Value::Mapping(training_map) = training {
         if distributed {
             let dist = build_distributed_yaml(world_size, rank, coordinator_addr);
-            training_map.insert(serde_yaml_ng::Value::String("distributed".into()), dist);
+            training_map.insert(serde_yaml::Value::String("distributed".into()), dist);
         }
         if deterministic {
             training_map.insert(
-                serde_yaml_ng::Value::String("deterministic".into()),
-                serde_yaml_ng::Value::Bool(true),
+                serde_yaml::Value::String("deterministic".into()),
+                serde_yaml::Value::Bool(true),
             );
         }
         if let Some(s) = seed {
             training_map.insert(
-                serde_yaml_ng::Value::String("seed".into()),
-                serde_yaml_ng::Value::Number(serde_yaml_ng::Number::from(s)),
+                serde_yaml::Value::String("seed".into()),
+                serde_yaml::Value::Number(serde_yaml::Number::from(s)),
             );
         }
     }
 
     let temp_path = std::env::temp_dir().join("apr-patched-config.yaml");
-    let patched_yaml = serde_yaml_ng::to_string(&yaml_val)
+    let patched_yaml = serde_yaml::to_string(&yaml_val)
         .map_err(|e| CliError::ValidationFailed(format!("YAML serialize error: {e}")))?;
     std::fs::write(&temp_path, &patched_yaml)
         .map_err(|e| CliError::ValidationFailed(format!("Failed to write temp config: {e}")))?;
@@ -1030,7 +1030,7 @@ pub(crate) fn run_sweep(
 
     let base_content = std::fs::read_to_string(config_path)
         .map_err(|e| CliError::ValidationFailed(format!("Cannot read config: {e}")))?;
-    let base: serde_yaml_ng::Value = serde_yaml_ng::from_str(&base_content)
+    let base: serde_yaml::Value = serde_yaml::from_str(&base_content)
         .map_err(|e| CliError::ValidationFailed(format!("Invalid YAML: {e}")))?;
 
     std::fs::create_dir_all(output_dir)
@@ -1054,7 +1054,7 @@ pub(crate) fn run_sweep(
     let mut results = Vec::new();
     for (i, config) in configs.iter().enumerate() {
         let filename = output_dir.join(format!("sweep-{i:03}.yaml"));
-        let yaml_str = serde_yaml_ng::to_string(config)
+        let yaml_str = serde_yaml::to_string(config)
             .map_err(|e| CliError::ValidationFailed(format!("YAML serialize error: {e}")))?;
         std::fs::write(&filename, &yaml_str)
             .map_err(|e| CliError::ValidationFailed(format!("Cannot write {}: {e}", filename.display())))?;
@@ -1097,9 +1097,9 @@ pub(crate) fn run_sweep(
 
 /// Generate grid search configs over LR × batch_size × weight_decay.
 fn generate_grid_configs(
-    base: &serde_yaml_ng::Value,
+    base: &serde_yaml::Value,
     max_configs: usize,
-) -> Vec<serde_yaml_ng::Value> {
+) -> Vec<serde_yaml::Value> {
     let lr_values = [1e-5, 3e-5, 1e-4, 3e-4, 1e-3];
     let bs_values: &[u64] = &[2, 4, 8];
     let wd_values = [0.0, 0.01, 0.1];
@@ -1124,10 +1124,10 @@ fn generate_grid_configs(
 
 /// Generate random search configs using LCG PRNG.
 fn generate_random_configs(
-    base: &serde_yaml_ng::Value,
+    base: &serde_yaml::Value,
     num_configs: usize,
     seed: u64,
-) -> Vec<serde_yaml_ng::Value> {
+) -> Vec<serde_yaml::Value> {
     let mut rng_state = seed;
     let mut configs = Vec::new();
 
@@ -1166,14 +1166,14 @@ fn lcg_f64(state: &mut u64) -> f64 {
 }
 
 /// Set a nested YAML value (f64).
-fn set_yaml_f64(root: &mut serde_yaml_ng::Value, path: &[&str], val: f64) {
+fn set_yaml_f64(root: &mut serde_yaml::Value, path: &[&str], val: f64) {
     let mut node = root;
     for (i, key) in path.iter().enumerate() {
         if i == path.len() - 1 {
-            node[*key] = serde_yaml_ng::Value::Number(serde_yaml_ng::Number::from(val));
+            node[*key] = serde_yaml::Value::Number(serde_yaml::Number::from(val));
         } else {
             if node.get(*key).is_none() {
-                node[*key] = serde_yaml_ng::Value::Mapping(serde_yaml_ng::Mapping::new());
+                node[*key] = serde_yaml::Value::Mapping(serde_yaml::Mapping::new());
             }
             node = &mut node[*key];
         }
@@ -1181,14 +1181,14 @@ fn set_yaml_f64(root: &mut serde_yaml_ng::Value, path: &[&str], val: f64) {
 }
 
 /// Set a nested YAML value (u64).
-fn set_yaml_u64(root: &mut serde_yaml_ng::Value, path: &[&str], val: u64) {
+fn set_yaml_u64(root: &mut serde_yaml::Value, path: &[&str], val: u64) {
     let mut node = root;
     for (i, key) in path.iter().enumerate() {
         if i == path.len() - 1 {
-            node[*key] = serde_yaml_ng::Value::Number(serde_yaml_ng::Number::from(val));
+            node[*key] = serde_yaml::Value::Number(serde_yaml::Number::from(val));
         } else {
             if node.get(*key).is_none() {
-                node[*key] = serde_yaml_ng::Value::Mapping(serde_yaml_ng::Mapping::new());
+                node[*key] = serde_yaml::Value::Mapping(serde_yaml::Mapping::new());
             }
             node = &mut node[*key];
         }

--- a/crates/apr-cli/src/commands_enum.rs
+++ b/crates/apr-cli/src/commands_enum.rs
@@ -425,6 +425,12 @@ pub enum Commands {
         #[arg(long)]
         json: bool,
     },
+    /// GPU status and VRAM reservation management (GPU-SHARE-001)
+    Gpu {
+        /// Show reservations as JSON
+        #[arg(long)]
+        json: bool,
+    },
     /// Extended analysis, profiling, QA, and visualization commands
     #[command(flatten)]
     Extended(ExtendedCommands),

--- a/crates/apr-cli/src/dispatch.rs
+++ b/crates/apr-cli/src/dispatch.rs
@@ -329,6 +329,7 @@ fn dispatch_model_commands(cli: &Cli) -> Option<Result<(), CliError>> {
             coordinator,
             expect_workers,
             wait_gpu,
+            adapters,
         }) => finetune::run(
             file.as_deref(),
             method,
@@ -355,6 +356,7 @@ fn dispatch_model_commands(cli: &Cli) -> Option<Result<(), CliError>> {
             coordinator.as_deref(),
             *expect_workers,
             *wait_gpu,
+            adapters,
             cli.json,
         ),
         Commands::ModelOps(ModelOpsCommands::Prune {

--- a/crates/apr-cli/src/dispatch.rs
+++ b/crates/apr-cli/src/dispatch.rs
@@ -330,6 +330,8 @@ fn dispatch_model_commands(cli: &Cli) -> Option<Result<(), CliError>> {
             expect_workers,
             wait_gpu,
             adapters,
+            experimental_mps,
+            gpu_share,
         }) => finetune::run(
             file.as_deref(),
             method,
@@ -358,6 +360,8 @@ fn dispatch_model_commands(cli: &Cli) -> Option<Result<(), CliError>> {
             *wait_gpu,
             adapters,
             cli.json,
+            *experimental_mps,
+            *gpu_share,
         ),
         Commands::ModelOps(ModelOpsCommands::Prune {
             file,

--- a/crates/apr-cli/src/dispatch.rs
+++ b/crates/apr-cli/src/dispatch.rs
@@ -330,6 +330,7 @@ fn dispatch_model_commands(cli: &Cli) -> Option<Result<(), CliError>> {
             expect_workers,
             wait_gpu,
             adapters,
+            adapters_config,
             experimental_mps,
             gpu_share,
         }) => finetune::run(
@@ -359,6 +360,7 @@ fn dispatch_model_commands(cli: &Cli) -> Option<Result<(), CliError>> {
             *expect_workers,
             *wait_gpu,
             adapters,
+            adapters_config.as_deref(),
             cli.json,
             *experimental_mps,
             *gpu_share,

--- a/crates/apr-cli/src/dispatch.rs
+++ b/crates/apr-cli/src/dispatch.rs
@@ -302,6 +302,7 @@ fn dispatch_model_commands(cli: &Cli) -> Option<Result<(), CliError>> {
             seed,
             plan,
         } => merge::run(files, strategy, output, weights.clone(), base_model.clone(), *drop_rate, *density, *seed, cli.json, *plan),
+        Commands::Gpu { json } => gpu::run(*json),
         Commands::ModelOps(ModelOpsCommands::Finetune {
             file,
             method,
@@ -327,6 +328,7 @@ fn dispatch_model_commands(cli: &Cli) -> Option<Result<(), CliError>> {
             bind,
             coordinator,
             expect_workers,
+            wait_gpu,
         }) => finetune::run(
             file.as_deref(),
             method,
@@ -352,6 +354,7 @@ fn dispatch_model_commands(cli: &Cli) -> Option<Result<(), CliError>> {
             bind.as_deref(),
             coordinator.as_deref(),
             *expect_workers,
+            *wait_gpu,
             cli.json,
         ),
         Commands::ModelOps(ModelOpsCommands::Prune {

--- a/crates/apr-cli/src/dispatch_analysis.rs
+++ b/crates/apr-cli/src/dispatch_analysis.rs
@@ -407,6 +407,27 @@ fn dispatch_train_command(command: &TrainCommands, cli: &Cli) -> std::result::Re
             notes.as_deref(),
             cli.json,
         ),
+        TrainCommands::Submit {
+            cluster,
+            model,
+            adapters,
+            rank,
+            epochs,
+            budget_mb,
+            dry_run,
+        } => train::run_submit(
+            cluster,
+            model,
+            adapters,
+            *rank,
+            *epochs,
+            *budget_mb,
+            *dry_run,
+            cli.json,
+        ),
+        TrainCommands::ClusterStatus { cluster } => {
+            train::run_cluster_status(cluster, cli.json)
+        }
     }
 }
 

--- a/crates/apr-cli/src/lib.rs
+++ b/crates/apr-cli/src/lib.rs
@@ -29,7 +29,7 @@ pub mod federation;
 // Commands are crate-private, used internally by execute_command
 use commands::{
     bench, canary, canary::CanaryCommands, cbtop, chat, compare_hf, compile, convert, data, debug,
-    diagnose, diff, distill, eval, explain, export, finetune, flow, hex, import, inspect, lint,
+    diagnose, diff, distill, eval, explain, export, finetune, flow, gpu, hex, import, inspect, lint,
     merge, oracle, pipeline, probar, profile, prune, ptx_explain, publish, pull, qa, qualify, quantize,
     rosetta, rosetta::RosettaCommands, run, serve, showcase, tensors, tokenize, trace, train,
     tree, tui, tune, validate,

--- a/crates/apr-cli/src/model_ops_commands.rs
+++ b/crates/apr-cli/src/model_ops_commands.rs
@@ -84,6 +84,10 @@ pub enum ModelOpsCommands {
         #[arg(long, value_name = "DATA:CHECKPOINT")]
         adapters: Vec<String>,
 
+        /// Multi-adapter config file: TOML with [[adapter]] entries (GPU-SHARE §2.4)
+        #[arg(long, value_name = "FILE")]
+        adapters_config: Option<PathBuf>,
+
         /// Enable experimental CUDA MPS for concurrent GPU sharing (GPU-SHARE §1.5).
         /// WARNING: A GPU fault in any MPS client will crash ALL clients on that GPU.
         #[arg(long)]

--- a/crates/apr-cli/src/model_ops_commands.rs
+++ b/crates/apr-cli/src/model_ops_commands.rs
@@ -83,6 +83,16 @@ pub enum ModelOpsCommands {
         /// Can be specified multiple times for concurrent adapter training.
         #[arg(long, value_name = "DATA:CHECKPOINT")]
         adapters: Vec<String>,
+
+        /// Enable experimental CUDA MPS for concurrent GPU sharing (GPU-SHARE §1.5).
+        /// WARNING: A GPU fault in any MPS client will crash ALL clients on that GPU.
+        #[arg(long)]
+        experimental_mps: bool,
+
+        /// MPS thread percentage (1-100). Controls SM allocation per process.
+        /// Only effective with --experimental-mps. Default: 50.
+        #[arg(long, value_name = "PCT", default_value = "50")]
+        gpu_share: u32,
     },
     /// Prune model (structured/unstructured pruning) (GH-247)
     Prune {

--- a/crates/apr-cli/src/model_ops_commands.rs
+++ b/crates/apr-cli/src/model_ops_commands.rs
@@ -78,6 +78,11 @@ pub enum ModelOpsCommands {
         /// Wait for VRAM availability before training (timeout in seconds, 0 = no wait)
         #[arg(long, value_name = "SECS", default_value = "0")]
         wait_gpu: u64,
+        /// Multi-adapter training: data:checkpoint pairs (GPU-SHARE Phase 2)
+        /// Format: --adapters data/corpus-a.jsonl:checkpoints/adapter-a
+        /// Can be specified multiple times for concurrent adapter training.
+        #[arg(long, value_name = "DATA:CHECKPOINT")]
+        adapters: Vec<String>,
     },
     /// Prune model (structured/unstructured pruning) (GH-247)
     Prune {

--- a/crates/apr-cli/src/model_ops_commands.rs
+++ b/crates/apr-cli/src/model_ops_commands.rs
@@ -75,6 +75,9 @@ pub enum ModelOpsCommands {
         /// Expected number of workers (coordinator only)
         #[arg(long, value_name = "N")]
         expect_workers: Option<usize>,
+        /// Wait for VRAM availability before training (timeout in seconds, 0 = no wait)
+        #[arg(long, value_name = "SECS", default_value = "0")]
+        wait_gpu: u64,
     },
     /// Prune model (structured/unstructured pruning) (GH-247)
     Prune {

--- a/crates/apr-cli/src/train_commands.rs
+++ b/crates/apr-cli/src/train_commands.rs
@@ -227,4 +227,48 @@ pub enum TrainCommands {
         #[arg(long)]
         notes: Option<String>,
     },
+
+    /// Submit multi-adapter training jobs to a cluster (GPU-SHARE Phase 3).
+    ///
+    /// Reads a cluster.yaml config, places adapter jobs across nodes using
+    /// the greedy placement algorithm, and generates launch commands.
+    Submit {
+        /// Path to cluster config YAML
+        #[arg(long, value_name = "FILE")]
+        cluster: PathBuf,
+
+        /// Model checkpoint path (.apr)
+        #[arg(long, value_name = "FILE")]
+        model: PathBuf,
+
+        /// Adapter specs: DATA:CHECKPOINT pairs (one per adapter)
+        #[arg(long = "adapter", value_name = "DATA:CHECKPOINT")]
+        adapters: Vec<String>,
+
+        /// LoRA rank
+        #[arg(long, default_value = "16")]
+        rank: u32,
+
+        /// Number of training epochs
+        #[arg(long, default_value = "3")]
+        epochs: u32,
+
+        /// Estimated VRAM budget per adapter (MB)
+        #[arg(long, default_value = "6000")]
+        budget_mb: u64,
+
+        /// Dry run: show placement and commands without executing
+        #[arg(long)]
+        dry_run: bool,
+    },
+
+    /// Show cluster status: nodes, GPUs, adapter capacity (GPU-SHARE Phase 3).
+    ///
+    /// Reads a cluster.yaml config and displays node health, VRAM availability,
+    /// and adapter placement capacity.
+    ClusterStatus {
+        /// Path to cluster config YAML
+        #[arg(long, value_name = "FILE")]
+        cluster: PathBuf,
+    },
 }


### PR DESCRIPTION
## Summary
- Fix `serde_yaml_ng` → `serde_yaml` in train.rs (use Cargo.toml package alias)
- Make renacer non-optional (code uses it unconditionally in 6 files)
- Change `visualization` feature to only control `trueno-viz` (not renacer)

Enables Jetson Orin Nano canary pipeline: `cargo check --target aarch64-unknown-linux-gnu -p apr-cli --no-default-features --features "hf-hub,safetensors-compare,inference,zram"`

Refs #326

## Upstream PRs
- trueno#151: c_char type fix
- realizar#117: AVX-512 cfg gate
- trueno-viz#10: c_char type fix
- renacer#35: x86_64 ptrace module cfg gates

## Test plan
- [x] `cargo +nightly check --target aarch64-unknown-linux-gnu -p apr-cli --no-default-features --features "hf-hub,safetensors-compare,inference,zram"` passes
- [ ] CI gate on x86_64 (existing tests unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)