### PR TITLE
fix: sharded SafeTensors symlink resolution (GH-363)

### DIFF
--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -4617,3 +4617,20 @@ roadmap:
   estimated_effort: null
   labels: []
   notes: null
+- id: PMAT-367
+  github_issue: null
+  item_type: task
+  title: 'fix: TensorDType::from_u8 missing GGML Q4_0/Q5_0/Q5_1 dtype mappings (GH-375)'
+  status: completed
+  priority: medium
+  assigned_to: null
+  created: 2026-03-04T17:37:08Z
+  updated: 2026-03-04T17:48:18.366251734+00:00
+  spec: null
+  acceptance_criteria:
+  - Five-whys RCA + fix missing/wrong GGML quant type mappings in tensor_index_impl.rs
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels: []
+  notes: null

--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -4634,3 +4634,20 @@ roadmap:
   estimated_effort: null
   labels: []
   notes: null
+- id: PMAT-368
+  github_issue: null
+  item_type: task
+  title: 'fix: apr-qa dim-smoke G0 config.json resolution from HF cache (GH-360)'
+  status: completed
+  priority: medium
+  assigned_to: null
+  created: 2026-03-04T17:48:30Z
+  updated: 2026-03-04T17:50:33.356431402+00:00
+  spec: null
+  acceptance_criteria:
+  - 'Five-whys: dim-smoke scenarios look in workspace dir but config.json lives in HF cache. Fix: resolve config.json from HF cache path.'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels: []
+  notes: null

--- a/src/format/converter/safe_tensors_load_result.rs
+++ b/src/format/converter/safe_tensors_load_result.rs
@@ -254,7 +254,11 @@ pub(crate) fn load_sharded_safetensors(
         });
     }
 
-    let base_dir = index_path
+    // GH-363: Canonicalize index_path to resolve symlinks before extracting parent dir.
+    // When index.json is a symlink, parent() returns the symlink's directory (no shards).
+    // Canonicalize resolves to the real directory where shard files actually live.
+    let canonical_index = std::fs::canonicalize(index_path).unwrap_or_else(|_| index_path.to_path_buf());
+    let base_dir = canonical_index
         .parent()
         .ok_or_else(|| AprenderError::FormatError {
             message: format!(

--- a/src/format/converter/tests/sharded_import.rs
+++ b/src/format/converter/tests/sharded_import.rs
@@ -242,6 +242,43 @@ fn test_load_sharded_empty_index_error() {
 }
 
 // ============================================================================
+// GH-363: Symlink resolution for sharded SafeTensors
+// ============================================================================
+
+#[test]
+fn test_load_sharded_via_symlinked_index() {
+    // Real dir with shards + index
+    let real_dir = tempfile::tempdir().expect("create real dir");
+    let shard_path = real_dir.path().join("model-00001-of-00001.safetensors");
+    create_shard_file(&shard_path, &[("layer.0.weight", &[1.0, 2.0, 3.0, 4.0])]);
+    let real_index = real_dir.path().join("model.safetensors.index.json");
+    create_index_json(
+        &real_index,
+        &[("layer.0.weight", "model-00001-of-00001.safetensors")],
+    );
+
+    // Symlink dir: index.json symlinked, but shards NOT symlinked
+    let link_dir = tempfile::tempdir().expect("create link dir");
+    let link_index = link_dir.path().join("model.safetensors.index.json");
+    std::os::unix::fs::symlink(&real_index, &link_index).expect("create symlink");
+
+    let options = ImportOptions {
+        allow_no_config: true,
+        ..ImportOptions::default()
+    };
+    // Before fix: this fails with "shard not found" because base_dir is link_dir (no shards)
+    // After fix: canonicalize resolves to real_dir where shards exist
+    let result = import::load_sharded_safetensors(&link_index, &options);
+    assert!(
+        result.is_ok(),
+        "Sharded import via symlinked index should succeed, got: {}",
+        result.unwrap_err()
+    );
+    let loaded = result.unwrap();
+    assert!(loaded.tensors.contains_key("layer.0.weight"));
+}
+
+// ============================================================================
 // load_source_tensors: .index.json routing
 // ============================================================================
 


### PR DESCRIPTION
## Summary
- Canonicalize index.json path before resolving shard directory to handle symlinks
- Adds test: symlinked index.json correctly resolves to real shard directory

## Five-Whys Root Cause
`index_path.parent()` returns the symlink's directory, not the real directory where shard files live.

## Test plan
- [x] New test: `test_load_sharded_via_symlinked_index` 
- [x] All 29 sharded import tests pass

Closes #363