### PR TITLE
GH-471: O(1) serve startup + distill resume + test coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,7 +244,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -255,7 +255,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -305,7 +305,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tower 0.5.3",
- "trueno 0.16.2",
+ "trueno 0.16.3",
  "trueno-explain",
  "trueno-viz 0.2.3",
  "trueno-zram-core",
@@ -376,7 +376,7 @@ dependencies = [
  "sha2",
  "tempfile",
  "thiserror 2.0.18",
- "trueno 0.16.2",
+ "trueno 0.16.3",
  "trueno-quant",
  "trueno-rag",
  "trueno-zram-core",
@@ -384,6 +384,29 @@ dependencies = [
  "wasm-bindgen",
  "x25519-dalek",
  "zstd",
+]
+
+[[package]]
+name = "aprender"
+version = "0.27.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e171b81f0d7aac048e8d0a33c50a096698b6420ce6709e7cc28d36c5b7cabf7"
+dependencies = [
+ "batuta-common",
+ "bincode",
+ "getrandom 0.2.17",
+ "memmap2",
+ "minijinja",
+ "provable-contracts-macros",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "rayon",
+ "rmp-serde",
+ "serde",
+ "serde_json",
+ "serde_yaml_ng",
+ "trueno 0.16.3",
+ "trueno-quant",
 ]
 
 [[package]]
@@ -1277,12 +1300,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "borrow-or-share"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
-
-[[package]]
 name = "brotli"
 version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1571,7 +1588,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2206,7 +2223,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2242,12 +2259,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dyn-clone"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
-
-[[package]]
 name = "ed25519"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2279,15 +2290,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
-name = "email_address"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2296,49 +2298,43 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 [[package]]
 name = "entrenar"
 version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e777e2fd8a20a96a60c82e9449e340c9f9490146ffdc2ab4fdcffeaf683d69e"
 dependencies = [
  "alimentar 0.2.7",
- "aprender 0.27.4",
+ "aprender 0.27.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "arrow 57.3.0",
  "bytemuck",
  "chrono",
  "clap",
  "clap_complete",
- "ctrlc",
  "dirs 5.0.1",
  "ed25519-dalek",
- "fs4",
  "half",
  "hex",
- "hostname",
- "jsonschema",
  "ndarray",
- "presentar-core",
- "presentar-terminal",
  "rand 0.9.2",
  "realizar",
  "regex",
- "rusqlite",
  "safetensors 0.7.0",
- "schemars",
  "serde",
  "serde_json",
  "serde_yaml",
- "serde_yaml_ng",
  "sha2",
  "thiserror 2.0.18",
  "tokio",
  "toml",
- "trueno 0.16.2",
+ "trueno 0.16.3",
  "trueno-gpu",
  "trueno-viz 0.2.3",
- "validator",
  "zip",
 ]
 
 [[package]]
 name = "entrenar-common"
 version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8558b7437f5b1eb77bdc2d43c6a3ace5cc418effac4cbf1e395bf4f0f670e61a"
 dependencies = [
  "clap",
  "serde",
@@ -2350,6 +2346,8 @@ dependencies = [
 [[package]]
 name = "entrenar-lora"
 version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d768472539adac6d7ec1954eb9cefc77d5f61df93a11c5d2697cf9775cb0de"
 dependencies = [
  "clap",
  "entrenar",
@@ -2398,7 +2396,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2479,7 +2477,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2565,17 +2563,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fluent-uri"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1918b65d96df47d3591bed19c5cca17e3fa5d0707318e4b5ef2eae01764df7e5"
-dependencies = [
- "borrow-or-share",
- "ref-cast",
- "serde",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2627,26 +2614,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
-]
-
-[[package]]
-name = "fraction"
-version = "0.15.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f158e3ff0a1b334408dc9fb811cd99b446986f4d8b741bb08f9df1604085ae7"
-dependencies = [
- "lazy_static",
- "num",
-]
-
-[[package]]
-name = "fs4"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
-dependencies = [
- "rustix 1.1.4",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3561,7 +3528,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3636,31 +3603,6 @@ checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "jsonschema"
-version = "0.28.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b8f66fe41fa46a5c83ed1c717b7e0b4635988f427083108c8cf0a882cc13441"
-dependencies = [
- "ahash",
- "base64 0.22.1",
- "bytecount",
- "email_address",
- "fancy-regex",
- "fraction",
- "idna",
- "itoa",
- "num-cmp",
- "once_cell",
- "percent-encoding",
- "referencing",
- "regex-syntax",
- "reqwest",
- "serde",
- "serde_json",
- "uuid-simd",
 ]
 
 [[package]]
@@ -4332,7 +4274,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4358,12 +4300,6 @@ dependencies = [
  "num-integer",
  "num-traits",
 ]
-
-[[package]]
-name = "num-cmp"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
 
 [[package]]
 name = "num-complex"
@@ -4616,14 +4552,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "outref"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
-
-[[package]]
 name = "pacha"
 version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "873be034730a0b6ae567897812926b649f13f12d59d0f1805a7eb5f3622702a8"
 dependencies = [
  "anyhow",
  "blake3",
@@ -5056,28 +4988,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5150,8 +5060,9 @@ dependencies = [
 [[package]]
 name = "provable-contracts"
 version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25d845cee13c0160ff2d644c8bd4b65a8487f894a827d9d0fe23d47980a9fa5"
 dependencies = [
- "regex",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -5161,6 +5072,8 @@ dependencies = [
 [[package]]
 name = "provable-contracts-macros"
 version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c383d865124fe9fda96af4a04d0c2641bcb93e16eb5e13f7c665f98c15333447"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5467,9 +5380,11 @@ dependencies = [
 [[package]]
 name = "realizar"
 version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61bd54aa76506a65ff0f53df4798510229e95fc2557f59783b390f2fb3645082"
 dependencies = [
  "anyhow",
- "aprender 0.27.4",
+ "aprender 0.27.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "arc-swap",
  "async-stream",
  "axum",
@@ -5494,7 +5409,7 @@ dependencies = [
  "tokio-stream",
  "tower 0.4.13",
  "tracing",
- "trueno 0.16.2",
+ "trueno 0.16.3",
  "trueno-gpu",
  "trueno-quant",
  "uuid",
@@ -5561,39 +5476,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ref-cast"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
-dependencies = [
- "ref-cast-impl",
-]
-
-[[package]]
-name = "ref-cast-impl"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "referencing"
-version = "0.28.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0dcb5ab28989ad7c91eb1b9531a37a1a137cc69a0499aee4117cae4a107c464"
-dependencies = [
- "ahash",
- "fluent-uri",
- "once_cell",
- "percent-encoding",
- "serde_json",
-]
-
-[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5625,10 +5507,12 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 [[package]]
 name = "renacer"
 version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b29e60ecc0f423b24f6e68df5927e2632afe79c45725e541df38dbfeb8b9ea9a"
 dependencies = [
  "addr2line",
  "anyhow",
- "aprender 0.27.4",
+ "aprender 0.27.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "backtrace",
  "clap",
  "crossbeam",
@@ -5657,7 +5541,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
- "trueno 0.16.2",
+ "trueno 0.16.3",
  "trueno-db",
  "trueno-graph",
  "trueno-viz 0.2.3",
@@ -5859,7 +5743,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5872,7 +5756,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5966,30 +5850,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "schemars"
-version = "0.8.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
-dependencies = [
- "dyn-clone",
- "schemars_derive",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "schemars_derive"
-version = "0.8.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde_derive_internals",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6048,17 +5908,6 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "serde_derive_internals"
-version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6464,7 +6313,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7005,7 +6854,9 @@ dependencies = [
 
 [[package]]
 name = "trueno"
-version = "0.16.2"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e80f278053c36ac96c8a06dc5f816cddd594f97d4c6d90ddf12bd79c389ec678"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -7014,7 +6865,6 @@ dependencies = [
  "hostname",
  "num_cpus",
  "pollster",
- "rayon",
  "serde",
  "serde_json",
  "serde_yaml_ng",
@@ -7078,6 +6928,8 @@ dependencies = [
 [[package]]
 name = "trueno-gpu"
 version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d78c8155110048899ede5fe80747607cd08dd342491f889771bbcedd2a63d4e"
 dependencies = [
  "batuta-common",
  "libloading",
@@ -7103,6 +6955,8 @@ dependencies = [
 [[package]]
 name = "trueno-quant"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5da5ac788b596e45d1d3fa0991c04b0e1bac63ffe4ae2faf6ae7c0d9fdfc00eb"
 dependencies = [
  "half",
 ]
@@ -7142,6 +6996,8 @@ dependencies = [
 [[package]]
 name = "trueno-viz"
 version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac5b643c0c2924c22d708015dc3393877c992b39e6e67a42b2a26fa301d71b66"
 dependencies = [
  "base64 0.22.1",
  "batuta-common",
@@ -7153,7 +7009,7 @@ dependencies = [
  "serde",
  "serde_yaml_ng",
  "thiserror 2.0.18",
- "trueno 0.16.2",
+ "trueno 0.16.3",
 ]
 
 [[package]]
@@ -7345,17 +7201,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "uuid-simd"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
-dependencies = [
- "outref",
- "uuid",
- "vsimd",
-]
-
-[[package]]
 name = "v_frame"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7364,36 +7209,6 @@ dependencies = [
  "aligned-vec",
  "num-traits",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "validator"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43fb22e1a008ece370ce08a3e9e4447a910e92621bb49b85d6e48a45397e7cfa"
-dependencies = [
- "idna",
- "once_cell",
- "regex",
- "serde",
- "serde_derive",
- "serde_json",
- "url",
- "validator_derive",
-]
-
-[[package]]
-name = "validator_derive"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7df16e474ef958526d1205f6dda359fdfab79d9aa6d54bafcb92dcd07673dca"
-dependencies = [
- "darling 0.20.11",
- "once_cell",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -7413,12 +7228,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "vsimd"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vte"
@@ -7803,7 +7612,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/apr-cli/src/commands/finetune_tests.rs
+++ b/crates/apr-cli/src/commands/finetune_tests.rs
@@ -73,7 +73,12 @@ fn test_run_no_model() {
         None,
         None,
         None,
+        0,
+        &[],
+        None,
         false,
+        false,
+        0,
     );
     assert!(result.is_err());
 }
@@ -105,7 +110,12 @@ fn test_run_plan_with_model_size() {
         None,
         None,
         None,
+        0,
+        &[],
+        None,
         false,
+        false,
+        0,
     );
     assert!(result.is_ok());
 }
@@ -137,7 +147,12 @@ fn test_run_plan_json() {
         None,
         None,
         None,
+        0,
+        &[],
+        None,
         true,
+        false,
+        0,
     );
     assert!(result.is_ok());
 }
@@ -171,7 +186,12 @@ fn test_run_with_model_file() {
         None,
         None,
         None,
+        0,
+        &[],
+        None,
         false,
+        false,
+        0,
     );
     assert!(result.is_ok());
 }
@@ -286,7 +306,12 @@ fn test_run_training_creates_adapter() {
         None,
         None,
         None,
+        0,
+        &[],
+        None,
         true,
+        false,
+        0,
     );
     assert!(result.is_ok(), "Training should succeed: {result:?}");
 

--- a/crates/apr-cli/src/commands/kernel_explain.rs
+++ b/crates/apr-cli/src/commands/kernel_explain.rs
@@ -834,9 +834,10 @@ pub fn resolve_family(input: &str) -> Option<FamilyInfo> {
         }
         // Pass 2: family starts_with search (search is a prefix of family name)
         for search in &search_forms {
-            if let Some(f) = families.iter().find(|f| {
-                f.family.starts_with(*search) || search.starts_with(f.family.as_str())
-            }) {
+            if let Some(f) = families
+                .iter()
+                .find(|f| f.family.starts_with(*search) || search.starts_with(f.family.as_str()))
+            {
                 return Some(f.clone());
             }
         }
@@ -1137,7 +1138,11 @@ fn enrich_rationale(key: &str, value: &str, json: &str) -> Option<String> {
                             let nh = extract_json_string(json, "num_attention_heads")
                                 .and_then(|v| v.parse::<u64>().ok())
                                 .unwrap_or(1);
-                            if nh > 0 { n / nh } else { 0 }
+                            if nh > 0 {
+                                n / nh
+                            } else {
+                                0
+                            }
                         });
                     let num_heads = extract_json_string(json, "num_attention_heads")
                         .and_then(|v| v.parse::<u64>().ok())
@@ -1168,7 +1173,11 @@ fn enrich_rationale(key: &str, value: &str, json: &str) -> Option<String> {
                         } else {
                             0
                         };
-                        let mlp_total = if n_experts > 1 { expert_mlp + dense_mlp } else { dense_mlp };
+                        let mlp_total = if n_experts > 1 {
+                            expert_mlp + dense_mlp
+                        } else {
+                            dense_mlp
+                        };
                         // Per layer: attention + MLP + 2d (norms)
                         layers * (attn_params + mlp_total + 2 * n) + embed_params
                     } else {
@@ -1870,8 +1879,231 @@ pub fn print_human_output(
 mod tests {
     use super::*;
 
+    // ── yaml_str ────────────────────────────────────────────────────────
+
     #[test]
-    fn test_derive_kernel_class_a() {
+    fn yaml_str_plain_value() {
+        let yaml = "family: qwen2\ndisplay_name: \"Qwen2 / Qwen2.5-Coder\"\n";
+        assert_eq!(yaml_str(yaml, "family"), Some("qwen2".to_string()));
+        assert_eq!(
+            yaml_str(yaml, "display_name"),
+            Some("Qwen2 / Qwen2.5-Coder".to_string())
+        );
+    }
+
+    #[test]
+    fn yaml_str_missing_key() {
+        assert_eq!(yaml_str("family: bert\n", "missing"), None);
+    }
+
+    #[test]
+    fn yaml_str_inline_comment_stripped() {
+        let yaml = "attention_type: gqa  # MLA dispatches as GQA\n";
+        assert_eq!(yaml_str(yaml, "attention_type"), Some("gqa".to_string()));
+    }
+
+    #[test]
+    fn yaml_str_quoted_values() {
+        assert_eq!(
+            yaml_str("name: 'single'\n", "name"),
+            Some("single".to_string())
+        );
+        assert_eq!(
+            yaml_str("name: \"double\"\n", "name"),
+            Some("double".to_string())
+        );
+    }
+
+    #[test]
+    fn yaml_str_null_returns_none() {
+        assert_eq!(yaml_str("val: null\n", "val"), None);
+    }
+
+    #[test]
+    fn yaml_str_empty_value_returns_none() {
+        assert_eq!(yaml_str("val:\n", "val"), None);
+    }
+
+    #[test]
+    fn yaml_str_value_with_only_comment() {
+        // "val: # just a comment" → after stripping comment, value is empty → None
+        assert_eq!(yaml_str("val: # just a comment\n", "val"), None);
+    }
+
+    // ── yaml_bool ───────────────────────────────────────────────────────
+
+    #[test]
+    fn yaml_bool_true() {
+        assert!(yaml_bool("has_bias: true\n", "has_bias"));
+    }
+
+    #[test]
+    fn yaml_bool_false() {
+        assert!(!yaml_bool("has_bias: false\n", "has_bias"));
+    }
+
+    #[test]
+    fn yaml_bool_missing_is_false() {
+        assert!(!yaml_bool("other: true\n", "has_bias"));
+    }
+
+    // ── yaml_list ───────────────────────────────────────────────────────
+
+    #[test]
+    fn yaml_list_basic() {
+        let yaml =
+            "architectures:\n  - Qwen2ForCausalLM\n  - Qwen2ForTokenClassification\nother: val\n";
+        let items = yaml_list(yaml, "architectures");
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0], "Qwen2ForCausalLM");
+        assert_eq!(items[1], "Qwen2ForTokenClassification");
+    }
+
+    #[test]
+    fn yaml_list_stops_at_next_key() {
+        let yaml = "items:\n  - a\n  - b\nnext_key: val\n";
+        let items = yaml_list(yaml, "items");
+        assert_eq!(items.len(), 2);
+    }
+
+    #[test]
+    fn yaml_list_empty() {
+        let yaml = "items:\nother: val\n";
+        let items = yaml_list(yaml, "items");
+        assert!(items.is_empty());
+    }
+
+    #[test]
+    fn yaml_list_missing_key() {
+        let yaml = "other:\n  - a\n";
+        let items = yaml_list(yaml, "items");
+        assert!(items.is_empty());
+    }
+
+    #[test]
+    fn yaml_list_strips_quotes() {
+        let yaml = "items:\n  - \"quoted\"\n  - 'single'\n";
+        let items = yaml_list(yaml, "items");
+        assert_eq!(items[0], "quoted");
+        assert_eq!(items[1], "single");
+    }
+
+    // ── extract_constraints ─────────────────────────────────────────────
+
+    #[test]
+    fn extract_constraints_basic() {
+        let yaml = "\nconstraints:\n  attention_type: gqa\n  activation: silu\n  norm_type: rmsnorm\n  mlp_type: swiglu\n  positional_encoding: rope\n  has_bias: false\n  tied_embeddings: true\n";
+        let c = extract_constraints(yaml);
+        assert_eq!(c.attention_type, "gqa");
+        assert_eq!(c.activation, "silu");
+        assert_eq!(c.norm_type, "rmsnorm");
+        assert_eq!(c.mlp_type, "swiglu");
+        assert_eq!(c.positional_encoding, "rope");
+        assert!(!c.has_bias);
+        assert!(c.tied_embeddings);
+    }
+
+    #[test]
+    fn extract_constraints_missing_section_defaults() {
+        let yaml = "family: test\n";
+        let c = extract_constraints(yaml);
+        assert_eq!(c.attention_type, "");
+        assert!(!c.has_bias);
+    }
+
+    #[test]
+    fn extract_constraints_inline_comments() {
+        let yaml =
+            "\nconstraints:\n  attention_type: ssm  # state space model\n  activation: silu\n";
+        let c = extract_constraints(yaml);
+        assert_eq!(c.attention_type, "ssm");
+    }
+
+    // ── normalize_input ─────────────────────────────────────────────────
+
+    #[test]
+    fn normalize_input_hyphens() {
+        assert_eq!(normalize_input("falcon-h1"), "falcon_h1");
+    }
+
+    #[test]
+    fn normalize_input_dots() {
+        assert_eq!(normalize_input("qwen3.5"), "qwen3_5");
+    }
+
+    #[test]
+    fn normalize_input_uppercase() {
+        assert_eq!(normalize_input("Qwen2ForCausalLM"), "qwen2forcausallm");
+    }
+
+    #[test]
+    fn normalize_input_mixed() {
+        assert_eq!(normalize_input("Phi-3.5-mini"), "phi_3_5_mini");
+    }
+
+    #[test]
+    fn normalize_input_already_normal() {
+        assert_eq!(normalize_input("llama"), "llama");
+    }
+
+    // ── compact_input ───────────────────────────────────────────────────
+
+    #[test]
+    fn compact_input_removes_underscores() {
+        assert_eq!(compact_input("phi_3"), Some("phi3".to_string()));
+        assert_eq!(compact_input("gpt_2"), Some("gpt2".to_string()));
+        assert_eq!(compact_input("rwkv_7"), Some("rwkv7".to_string()));
+    }
+
+    #[test]
+    fn compact_input_no_underscores() {
+        assert_eq!(compact_input("llama"), None);
+        assert_eq!(compact_input("bert"), None);
+    }
+
+    #[test]
+    fn compact_input_multiple_underscores() {
+        assert_eq!(
+            compact_input("qwen3_5_mini"),
+            Some("qwen35mini".to_string())
+        );
+    }
+
+    // ── strip_arch_suffix ───────────────────────────────────────────────
+
+    #[test]
+    fn strip_forcausallm() {
+        assert_eq!(strip_arch_suffix("graniteforcausallm"), "granite");
+    }
+
+    #[test]
+    fn strip_forconditionalgeneration() {
+        assert_eq!(
+            strip_arch_suffix("whisperforconditionalgeneration"),
+            "whisper"
+        );
+    }
+
+    #[test]
+    fn strip_model_suffix() {
+        assert_eq!(strip_arch_suffix("distilbertmodel"), "distilbert");
+    }
+
+    #[test]
+    fn strip_no_match() {
+        assert_eq!(strip_arch_suffix("llama"), "llama");
+    }
+
+    #[test]
+    fn strip_empty_prefix_skipped() {
+        // "forcausallm" alone should NOT strip to empty string
+        assert_eq!(strip_arch_suffix("forcausallm"), "forcausallm");
+    }
+
+    // ── derive_kernel_class (all 9 classes) ─────────────────────────────
+
+    #[test]
+    fn derive_class_a_gqa() {
         let c = Constraints {
             attention_type: "gqa".into(),
             activation: "silu".into(),
@@ -1884,7 +2116,21 @@ mod tests {
     }
 
     #[test]
-    fn test_derive_kernel_class_b() {
+    fn derive_class_a_mha_degenerate() {
+        // MHA is degenerate GQA — same kernel dispatch
+        let c = Constraints {
+            attention_type: "mha".into(),
+            activation: "silu".into(),
+            norm_type: "rmsnorm".into(),
+            mlp_type: "swiglu".into(),
+            positional_encoding: "rope".into(),
+            ..Default::default()
+        };
+        assert_eq!(derive_kernel_class(&c), KernelClass::A);
+    }
+
+    #[test]
+    fn derive_class_b() {
         let c = Constraints {
             attention_type: "mha".into(),
             activation: "gelu".into(),
@@ -1897,7 +2143,46 @@ mod tests {
     }
 
     #[test]
-    fn test_derive_kernel_class_f() {
+    fn derive_class_c() {
+        let c = Constraints {
+            attention_type: "mqa".into(),
+            activation: "gelu".into(),
+            norm_type: "layernorm".into(),
+            mlp_type: "gelu_mlp".into(),
+            positional_encoding: "alibi".into(),
+            ..Default::default()
+        };
+        assert_eq!(derive_kernel_class(&c), KernelClass::C);
+    }
+
+    #[test]
+    fn derive_class_d_gqa_layernorm() {
+        let c = Constraints {
+            attention_type: "gqa".into(),
+            activation: "gelu".into(),
+            norm_type: "layernorm".into(),
+            mlp_type: "gelu_mlp".into(),
+            positional_encoding: "rope".into(),
+            ..Default::default()
+        };
+        assert_eq!(derive_kernel_class(&c), KernelClass::D);
+    }
+
+    #[test]
+    fn derive_class_d_silu_layernorm() {
+        let c = Constraints {
+            attention_type: "mha".into(),
+            activation: "silu".into(),
+            norm_type: "layernorm".into(),
+            mlp_type: "swiglu".into(),
+            positional_encoding: "rope".into(),
+            ..Default::default()
+        };
+        assert_eq!(derive_kernel_class(&c), KernelClass::D);
+    }
+
+    #[test]
+    fn derive_class_f() {
         let c = Constraints {
             attention_type: "gqa".into(),
             activation: "gelu".into(),
@@ -1910,104 +2195,62 @@ mod tests {
     }
 
     #[test]
-    fn test_derive_kernel_class_unknown() {
+    fn derive_class_f_checked_before_b() {
+        // F requires RMSNorm+GELU+GatedMlp+RoPE. If MHA+RMSNorm+GELU+GatedMlp+RoPE,
+        // should be F (not B, because B requires LayerNorm)
+        let c = Constraints {
+            attention_type: "mha".into(),
+            activation: "gelu".into(),
+            norm_type: "rmsnorm".into(),
+            mlp_type: "gated_mlp".into(),
+            positional_encoding: "rope".into(),
+            ..Default::default()
+        };
+        assert_eq!(derive_kernel_class(&c), KernelClass::F);
+    }
+
+    #[test]
+    fn derive_class_ssm() {
+        let c = Constraints {
+            attention_type: "ssm".into(),
+            activation: "silu".into(),
+            norm_type: "rmsnorm".into(),
+            ..Default::default()
+        };
+        assert_eq!(derive_kernel_class(&c), KernelClass::Ssm);
+    }
+
+    #[test]
+    fn derive_class_linear() {
+        let c = Constraints {
+            attention_type: "linear".into(),
+            activation: "gelu".into(),
+            norm_type: "layernorm".into(),
+            ..Default::default()
+        };
+        assert_eq!(derive_kernel_class(&c), KernelClass::Linear);
+    }
+
+    #[test]
+    fn derive_class_unknown_empty() {
         let c = Constraints::default();
         assert_eq!(derive_kernel_class(&c), KernelClass::Unknown);
     }
 
     #[test]
-    fn test_load_families_not_empty() {
-        let families = load_families();
-        assert!(!families.is_empty());
-        // Qwen2 should be Class A
-        let qwen2 = families.iter().find(|f| f.family == "qwen2").unwrap();
-        assert_eq!(qwen2.kernel_class, KernelClass::A);
+    fn derive_class_unknown_partial_match() {
+        // Partial constraints that don't fit any class
+        let c = Constraints {
+            attention_type: "gqa".into(),
+            activation: "relu".into(),
+            norm_type: "rmsnorm".into(),
+            ..Default::default()
+        };
+        assert_eq!(derive_kernel_class(&c), KernelClass::Unknown);
     }
 
     #[test]
-    fn test_resolve_family_direct() {
-        let f = resolve_family("qwen2").unwrap();
-        assert_eq!(f.family, "qwen2");
-        assert_eq!(f.kernel_class, KernelClass::A);
-    }
-
-    #[test]
-    fn test_resolve_family_architecture() {
-        let f = resolve_family("Qwen2ForCausalLM").unwrap();
-        assert_eq!(f.family, "qwen2");
-    }
-
-    #[test]
-    fn test_resolve_family_partial() {
-        let f = resolve_family("llama").unwrap();
-        assert_eq!(f.family, "llama");
-    }
-
-    #[test]
-    fn test_resolve_family_unknown() {
-        let f = resolve_family("nonexistent-family-xyz");
-        assert!(f.is_none());
-    }
-
-    #[test]
-    fn test_kernel_ops_class_a_has_rope() {
-        let ops = kernel_ops_for_class(KernelClass::A);
-        assert!(ops.iter().any(|o| o.kernel == "rope_forward"));
-    }
-
-    #[test]
-    fn test_kernel_ops_class_b_no_rope() {
-        let ops = kernel_ops_for_class(KernelClass::B);
-        assert!(!ops.iter().any(|o| o.kernel == "rope_forward"));
-    }
-
-    #[test]
-    fn test_proof_status_matvec() {
-        let proof = proof_status_for_contract("matvec-kernel-v1");
-        assert_ne!(proof.level, ProofLevel::Unknown);
-    }
-
-    #[test]
-    fn test_proof_status_unknown_contract() {
-        let proof = proof_status_for_contract("nonexistent-v1");
-        assert_eq!(proof.level, ProofLevel::Unknown);
-    }
-
-    #[test]
-    fn test_yaml_str_extraction() {
-        let yaml = "family: qwen2\ndisplay_name: \"Qwen2 / Qwen2.5-Coder\"\n";
-        assert_eq!(yaml_str(yaml, "family"), Some("qwen2".to_string()));
-        assert_eq!(
-            yaml_str(yaml, "display_name"),
-            Some("Qwen2 / Qwen2.5-Coder".to_string())
-        );
-        assert_eq!(yaml_str(yaml, "missing"), None);
-    }
-
-    #[test]
-    fn test_yaml_bool_extraction() {
-        let yaml = "has_bias: true\ntied_embeddings: false\n";
-        assert!(yaml_bool(yaml, "has_bias"));
-        assert!(!yaml_bool(yaml, "tied_embeddings"));
-    }
-
-    #[test]
-    fn test_extract_json_string() {
-        let json = r#"{"model_type": "qwen2", "hidden_act": "silu"}"#;
-        assert_eq!(
-            extract_json_string(json, "model_type"),
-            Some("qwen2".to_string())
-        );
-        assert_eq!(
-            extract_json_string(json, "hidden_act"),
-            Some("silu".to_string())
-        );
-        assert_eq!(extract_json_string(json, "missing"), None);
-    }
-
-    #[test]
-    fn test_deterministic_kernel_class() {
-        // FALSIFY-KE-001: Same constraints always produce same kernel class
+    fn derive_deterministic() {
         let c = Constraints {
             attention_type: "gqa".into(),
             activation: "silu".into(),
@@ -2016,47 +2259,1409 @@ mod tests {
             positional_encoding: "rope".into(),
             ..Default::default()
         };
-        let class1 = derive_kernel_class(&c);
-        let class2 = derive_kernel_class(&c);
-        assert_eq!(class1, class2);
+        assert_eq!(derive_kernel_class(&c), derive_kernel_class(&c));
     }
 
+    // ── KernelClass label/letter ────────────────────────────────────────
+
     #[test]
-    fn test_class_label_round_trip() {
-        for class in [
+    fn kernel_class_label_all_variants() {
+        let all = [
             KernelClass::A,
             KernelClass::B,
             KernelClass::C,
             KernelClass::D,
             KernelClass::E,
             KernelClass::F,
-        ] {
+            KernelClass::Ssm,
+            KernelClass::Linear,
+            KernelClass::Unknown,
+        ];
+        for class in all {
             assert!(!class.label().is_empty());
             assert!(!class.letter().is_empty());
         }
     }
 
     #[test]
-    fn test_equivalence_class_membership() {
-        let families = load_families();
-        // LLaMA and Qwen2 should be in the same kernel class (A)
-        let llama = families.iter().find(|f| f.family == "llama").unwrap();
-        let qwen2 = families.iter().find(|f| f.family == "qwen2").unwrap();
-        assert_eq!(llama.kernel_class, qwen2.kernel_class);
-        assert_eq!(llama.kernel_class, KernelClass::A);
+    fn kernel_class_letters_correct() {
+        assert_eq!(KernelClass::A.letter(), "A");
+        assert_eq!(KernelClass::Ssm.letter(), "SSM");
+        assert_eq!(KernelClass::Linear.letter(), "Linear");
+        assert_eq!(KernelClass::Unknown.letter(), "Unknown");
     }
 
     #[test]
-    fn test_gpt2_is_class_b() {
-        let families = load_families();
-        let gpt2 = families.iter().find(|f| f.family == "gpt2").unwrap();
-        assert_eq!(gpt2.kernel_class, KernelClass::B);
+    fn kernel_class_label_contains_letter() {
+        assert!(KernelClass::A.label().starts_with("A "));
+        assert!(KernelClass::Ssm.label().starts_with("SSM "));
+    }
+
+    // ── kernel_ops_for_class ────────────────────────────────────────────
+
+    #[test]
+    fn ops_class_a_has_gqa_rms_silu_swiglu_rope() {
+        let ops = kernel_ops_for_class(KernelClass::A);
+        assert!(ops.iter().any(|o| o.kernel == "gqa_forward"));
+        assert!(ops.iter().any(|o| o.kernel == "rms_norm"));
+        assert!(ops.iter().any(|o| o.kernel == "silu"));
+        assert!(ops.iter().any(|o| o.kernel == "swiglu"));
+        assert!(ops.iter().any(|o| o.kernel == "rope_forward"));
+        assert!(ops.iter().any(|o| o.kernel == "softmax"));
     }
 
     #[test]
-    fn test_gemma_is_class_f() {
+    fn ops_class_b_has_mha_layernorm_gelu() {
+        let ops = kernel_ops_for_class(KernelClass::B);
+        assert!(ops.iter().any(|o| o.kernel == "mha_forward"));
+        assert!(ops.iter().any(|o| o.kernel == "layer_norm"));
+        assert!(ops.iter().any(|o| o.kernel == "gelu"));
+        assert!(ops.iter().any(|o| o.kernel == "gelu_mlp"));
+        assert!(!ops.iter().any(|o| o.kernel == "rope_forward"));
+    }
+
+    #[test]
+    fn ops_class_c_has_mqa_alibi() {
+        let ops = kernel_ops_for_class(KernelClass::C);
+        assert!(ops.iter().any(|o| o.kernel == "mqa_forward"));
+        assert!(ops.iter().any(|o| o.kernel == "alibi"));
+    }
+
+    #[test]
+    fn ops_class_d_has_gated_mlp() {
+        let ops = kernel_ops_for_class(KernelClass::D);
+        assert!(ops.iter().any(|o| o.kernel == "gated_mlp"));
+        assert!(ops.iter().any(|o| o.kernel == "rope_forward"));
+    }
+
+    #[test]
+    fn ops_class_e_has_moe_router() {
+        let ops = kernel_ops_for_class(KernelClass::E);
+        assert!(ops.iter().any(|o| o.kernel == "moe_routing"));
+        assert!(ops.iter().any(|o| o.kernel == "swiglu"));
+    }
+
+    #[test]
+    fn ops_class_f_has_gelu_gated_mlp() {
+        let ops = kernel_ops_for_class(KernelClass::F);
+        assert!(ops.iter().any(|o| o.kernel == "gelu"));
+        assert!(ops.iter().any(|o| o.kernel == "gated_mlp"));
+        assert!(ops.iter().any(|o| o.kernel == "rms_norm"));
+    }
+
+    #[test]
+    fn ops_ssm_no_softmax() {
+        let ops = kernel_ops_for_class(KernelClass::Ssm);
+        assert!(!ops.iter().any(|o| o.kernel == "softmax"));
+        assert!(ops.iter().any(|o| o.kernel == "selective_scan"));
+        assert!(ops.iter().any(|o| o.kernel == "depthwise_conv1d"));
+    }
+
+    #[test]
+    fn ops_linear_no_softmax() {
+        let ops = kernel_ops_for_class(KernelClass::Linear);
+        assert!(!ops.iter().any(|o| o.kernel == "softmax"));
+        assert!(ops.iter().any(|o| o.kernel == "wkv_forward"));
+        assert!(ops.iter().any(|o| o.kernel == "token_shift"));
+        assert!(ops.iter().any(|o| o.kernel == "channel_mix"));
+    }
+
+    #[test]
+    fn ops_unknown_minimal() {
+        let ops = kernel_ops_for_class(KernelClass::Unknown);
+        // Should have base ops only (MatVec Q4K, Q6K, Softmax, Fusion)
+        assert_eq!(ops.len(), 4);
+    }
+
+    #[test]
+    fn ops_all_classes_have_matvec() {
+        let all = [
+            KernelClass::A,
+            KernelClass::B,
+            KernelClass::C,
+            KernelClass::D,
+            KernelClass::E,
+            KernelClass::F,
+            KernelClass::Ssm,
+            KernelClass::Linear,
+            KernelClass::Unknown,
+        ];
+        for class in all {
+            let ops = kernel_ops_for_class(class);
+            assert!(
+                ops.iter().any(|o| o.kernel == "fused_q4k_parallel_matvec"),
+                "Class {:?} missing Q4K matvec",
+                class
+            );
+        }
+    }
+
+    // ── kernel_ops_for_family (RoPE enrichment) ─────────────────────────
+
+    #[test]
+    fn family_ops_phi_gets_rope_enrichment() {
+        // Phi is Class B (no RoPE in base ops) but uses RoPE positional encoding
+        let c = Constraints {
+            attention_type: "mha".into(),
+            activation: "gelu".into(),
+            norm_type: "layernorm".into(),
+            mlp_type: "gelu_mlp".into(),
+            positional_encoding: "rope".into(),
+            ..Default::default()
+        };
+        let ops = kernel_ops_for_family(KernelClass::B, &c);
+        assert!(
+            ops.iter().any(|o| o.kernel == "rope_forward"),
+            "Phi (class B + rope) should get rope_forward enrichment"
+        );
+    }
+
+    #[test]
+    fn family_ops_no_double_rope() {
+        // Class A already has RoPE — enrichment should not duplicate it
+        let c = Constraints {
+            positional_encoding: "rope".into(),
+            ..Default::default()
+        };
+        let ops = kernel_ops_for_family(KernelClass::A, &c);
+        let rope_count = ops.iter().filter(|o| o.kernel == "rope_forward").count();
+        assert_eq!(rope_count, 1, "Should not duplicate rope_forward");
+    }
+
+    #[test]
+    fn family_ops_absolute_no_rope() {
+        let c = Constraints {
+            positional_encoding: "absolute".into(),
+            ..Default::default()
+        };
+        let ops = kernel_ops_for_family(KernelClass::B, &c);
+        assert!(!ops.iter().any(|o| o.kernel == "rope_forward"));
+    }
+
+    // ── load_families ───────────────────────────────────────────────────
+
+    #[test]
+    fn load_families_count() {
         let families = load_families();
-        let gemma = families.iter().find(|f| f.family == "gemma").unwrap();
-        assert_eq!(gemma.kernel_class, KernelClass::F);
+        assert_eq!(families.len(), FAMILY_YAMLS.len());
+    }
+
+    #[test]
+    fn load_families_expected_classes() {
+        let families = load_families();
+        let find = |name: &str| families.iter().find(|f| f.family == name).unwrap();
+
+        assert_eq!(find("llama").kernel_class, KernelClass::A);
+        assert_eq!(find("qwen2").kernel_class, KernelClass::A);
+        assert_eq!(find("qwen3").kernel_class, KernelClass::A);
+        assert_eq!(find("mistral").kernel_class, KernelClass::A);
+        assert_eq!(find("deepseek").kernel_class, KernelClass::A);
+        assert_eq!(find("falcon_h1").kernel_class, KernelClass::A);
+        assert_eq!(find("openelm").kernel_class, KernelClass::A);
+
+        assert_eq!(find("bert").kernel_class, KernelClass::B);
+        assert_eq!(find("gpt2").kernel_class, KernelClass::B);
+        assert_eq!(find("whisper").kernel_class, KernelClass::B);
+
+        assert_eq!(find("gemma").kernel_class, KernelClass::F);
+
+        assert_eq!(find("mamba").kernel_class, KernelClass::Ssm);
+        assert_eq!(find("rwkv7").kernel_class, KernelClass::Linear);
+    }
+
+    #[test]
+    fn load_families_all_have_display_name() {
+        for f in &load_families() {
+            assert!(
+                !f.display_name.is_empty(),
+                "Family {} missing display_name",
+                f.family
+            );
+        }
+    }
+
+    // ── resolve_family ──────────────────────────────────────────────────
+
+    // Direct matches
+    #[test]
+    fn resolve_direct_llama() {
+        let f = resolve_family("llama").unwrap();
+        assert_eq!(f.family, "llama");
+        assert_eq!(f.kernel_class, KernelClass::A);
+    }
+
+    #[test]
+    fn resolve_direct_bert() {
+        let f = resolve_family("bert").unwrap();
+        assert_eq!(f.family, "bert");
+        assert_eq!(f.kernel_class, KernelClass::B);
+    }
+
+    #[test]
+    fn resolve_direct_mamba() {
+        let f = resolve_family("mamba").unwrap();
+        assert_eq!(f.family, "mamba");
+        assert_eq!(f.kernel_class, KernelClass::Ssm);
+    }
+
+    #[test]
+    fn resolve_direct_rwkv7() {
+        let f = resolve_family("rwkv7").unwrap();
+        assert_eq!(f.family, "rwkv7");
+        assert_eq!(f.kernel_class, KernelClass::Linear);
+    }
+
+    // Normalized matches (hyphens, dots, case)
+    #[test]
+    fn resolve_normalized_hyphens() {
+        let f = resolve_family("falcon-h1").unwrap();
+        assert_eq!(f.family, "falcon_h1");
+    }
+
+    #[test]
+    fn resolve_normalized_dots() {
+        let f = resolve_family("qwen3.5").unwrap();
+        assert_eq!(f.family, "qwen3_5");
+    }
+
+    #[test]
+    fn resolve_normalized_uppercase() {
+        let f = resolve_family("LLAMA").unwrap();
+        assert_eq!(f.family, "llama");
+    }
+
+    // Cross-compact matches
+    #[test]
+    fn resolve_cross_compact_qwen_3_5() {
+        // "qwen-3-5" → normalized "qwen_3_5" → compact "qwen35"
+        // family "qwen3_5" → compact "qwen35" → match
+        let f = resolve_family("qwen-3-5").unwrap();
+        assert_eq!(f.family, "qwen3_5");
+    }
+
+    // Alias matches
+    #[test]
+    fn resolve_alias_mixtral() {
+        let f = resolve_family("mixtral").unwrap();
+        assert_eq!(f.family, "mistral");
+        assert!(f.display_name.contains("via"));
+    }
+
+    #[test]
+    fn resolve_alias_phi3() {
+        let f = resolve_family("phi3").unwrap();
+        assert_eq!(f.family, "llama");
+        assert!(f.display_name.contains("phi3"));
+    }
+
+    #[test]
+    fn resolve_alias_phi4() {
+        let f = resolve_family("phi4").unwrap();
+        assert_eq!(f.family, "llama");
+    }
+
+    #[test]
+    fn resolve_alias_bloom() {
+        let f = resolve_family("bloom").unwrap();
+        assert_eq!(f.family, "bert");
+    }
+
+    #[test]
+    fn resolve_alias_falcon() {
+        let f = resolve_family("falcon").unwrap();
+        assert_eq!(f.family, "bert");
+    }
+
+    #[test]
+    fn resolve_alias_smollm() {
+        let f = resolve_family("smollm").unwrap();
+        assert_eq!(f.family, "llama");
+    }
+
+    #[test]
+    fn resolve_alias_smollm2() {
+        let f = resolve_family("smollm2").unwrap();
+        assert_eq!(f.family, "llama");
+    }
+
+    #[test]
+    fn resolve_alias_codegemma() {
+        let f = resolve_family("codegemma").unwrap();
+        assert_eq!(f.family, "gemma");
+    }
+
+    #[test]
+    fn resolve_alias_gpt_neo() {
+        let f = resolve_family("gpt_neo").unwrap();
+        assert_eq!(f.family, "bert");
+    }
+
+    #[test]
+    fn resolve_alias_gptneo_compact() {
+        let f = resolve_family("gptneo").unwrap();
+        assert_eq!(f.family, "bert");
+    }
+
+    #[test]
+    fn resolve_alias_starcoder2() {
+        let f = resolve_family("starcoder2").unwrap();
+        assert_eq!(f.family, "qwen2");
+    }
+
+    #[test]
+    fn resolve_alias_vicuna() {
+        let f = resolve_family("vicuna").unwrap();
+        assert_eq!(f.family, "llama");
+    }
+
+    #[test]
+    fn resolve_alias_qwq() {
+        let f = resolve_family("qwq").unwrap();
+        assert_eq!(f.family, "qwen2");
+    }
+
+    #[test]
+    fn resolve_alias_qwen2_moe() {
+        let f = resolve_family("qwen2_moe").unwrap();
+        assert_eq!(f.family, "qwen2");
+    }
+
+    #[test]
+    fn resolve_alias_normalized_gpt_j_hyphen() {
+        let f = resolve_family("gpt-j").unwrap();
+        assert_eq!(f.family, "bert");
+    }
+
+    // Architecture string match
+    #[test]
+    fn resolve_arch_qwen2forcausallm() {
+        let f = resolve_family("Qwen2ForCausalLM").unwrap();
+        assert_eq!(f.family, "qwen2");
+    }
+
+    #[test]
+    fn resolve_arch_bertmodel() {
+        let f = resolve_family("BertModel").unwrap();
+        assert_eq!(f.family, "bert");
+    }
+
+    // Architecture string → stripped → alias re-check
+    #[test]
+    fn resolve_stripped_graniteforcausallm() {
+        let f = resolve_family("GraniteForCausalLM").unwrap();
+        assert_eq!(f.family, "llama");
+    }
+
+    // Partial match (3-pass)
+    #[test]
+    fn resolve_partial_qwen_matches_qwen2() {
+        // "qwen" is prefix of family "qwen2" → Pass 2
+        let f = resolve_family("qwen").unwrap();
+        assert_eq!(f.family, "qwen2");
+    }
+
+    #[test]
+    fn resolve_partial_phi3mini_via_alias() {
+        // "phi3mini" starts_with alias "phi3" → Pass 1
+        let f = resolve_family("phi-3-mini").unwrap();
+        assert_eq!(f.family, "llama");
+        assert!(f.display_name.contains("phi3"));
+    }
+
+    #[test]
+    fn resolve_partial_gpt_matches_gpt2() {
+        let f = resolve_family("gpt").unwrap();
+        assert_eq!(f.family, "gpt2");
+    }
+
+    // Edge cases
+    #[test]
+    fn resolve_empty_string() {
+        assert!(resolve_family("").is_none());
+    }
+
+    #[test]
+    fn resolve_whitespace_only() {
+        assert!(resolve_family("   ").is_none());
+    }
+
+    #[test]
+    fn resolve_emoji_stripped() {
+        // Non-ASCII chars stripped, leaving empty → None
+        assert!(resolve_family("🦙").is_none());
+    }
+
+    #[test]
+    fn resolve_emoji_with_text() {
+        // "🦙llama" → strip non-ASCII → "llama" → match
+        let f = resolve_family("🦙llama").unwrap();
+        assert_eq!(f.family, "llama");
+    }
+
+    #[test]
+    fn resolve_unknown_returns_none() {
+        assert!(resolve_family("nonexistent-xyz-123").is_none());
+    }
+
+    #[test]
+    fn resolve_short_input_no_partial() {
+        // "ab" is < 3 chars, partial matching skipped
+        assert!(resolve_family("ab").is_none());
+    }
+
+    // ── extract_json_string ─────────────────────────────────────────────
+
+    #[test]
+    fn json_string_value() {
+        let json = r#"{"model_type": "qwen2"}"#;
+        assert_eq!(
+            extract_json_string(json, "model_type"),
+            Some("qwen2".to_string())
+        );
+    }
+
+    #[test]
+    fn json_numeric_value() {
+        let json = r#"{"hidden_size": 4096, "other": 1}"#;
+        assert_eq!(
+            extract_json_string(json, "hidden_size"),
+            Some("4096".to_string())
+        );
+    }
+
+    #[test]
+    fn json_float_value() {
+        let json = r#"{"rms_norm_eps": 1e-06, "x": 1}"#;
+        assert_eq!(
+            extract_json_string(json, "rms_norm_eps"),
+            Some("1e-06".to_string())
+        );
+    }
+
+    #[test]
+    fn json_boolean_value() {
+        let json = r#"{"tie_word_embeddings": true, "x": 1}"#;
+        assert_eq!(
+            extract_json_string(json, "tie_word_embeddings"),
+            Some("true".to_string())
+        );
+    }
+
+    #[test]
+    fn json_null_returns_none() {
+        let json = r#"{"model_type": null, "x": 1}"#;
+        assert_eq!(extract_json_string(json, "model_type"), None);
+    }
+
+    #[test]
+    fn json_array_returns_none() {
+        let json = r#"{"architectures": ["QwenForCausalLM"], "x": 1}"#;
+        assert_eq!(extract_json_string(json, "architectures"), None);
+    }
+
+    #[test]
+    fn json_object_returns_none() {
+        let json = r#"{"rope_scaling": {"type": "yarn"}, "x": 1}"#;
+        assert_eq!(extract_json_string(json, "rope_scaling"), None);
+    }
+
+    #[test]
+    fn json_missing_key() {
+        let json = r#"{"model_type": "bert"}"#;
+        assert_eq!(extract_json_string(json, "hidden_act"), None);
+    }
+
+    #[test]
+    fn json_whitespace_around_colon() {
+        let json = "{\n  \"hidden_size\" : 4096,\n  \"x\": 1\n}";
+        assert_eq!(
+            extract_json_string(json, "hidden_size"),
+            Some("4096".to_string())
+        );
+    }
+
+    // ── enrich_rationale ────────────────────────────────────────────────
+
+    #[test]
+    fn enrich_hidden_act_silu() {
+        let r = enrich_rationale("hidden_act", "silu", "{}").unwrap();
+        assert!(r.contains("SiLU"));
+    }
+
+    #[test]
+    fn enrich_hidden_act_gelu() {
+        let r = enrich_rationale("hidden_act", "gelu", "{}").unwrap();
+        assert!(r.contains("GELU"));
+    }
+
+    #[test]
+    fn enrich_hidden_act_gelu_new() {
+        let r = enrich_rationale("hidden_act", "gelu_new", "{}").unwrap();
+        assert!(r.contains("GELU"));
+    }
+
+    #[test]
+    fn enrich_hidden_act_unknown() {
+        let r = enrich_rationale("hidden_act", "relu", "{}").unwrap();
+        assert!(r.contains("relu"));
+    }
+
+    #[test]
+    fn enrich_rms_norm_eps() {
+        let r = enrich_rationale("rms_norm_eps", "1e-06", "{}").unwrap();
+        assert!(r.contains("RMSNorm"));
+    }
+
+    #[test]
+    fn enrich_num_kv_heads_gqa() {
+        let json = r#"{"num_attention_heads": 32, "num_key_value_heads": 8}"#;
+        let r = enrich_rationale("num_key_value_heads", "8", json).unwrap();
+        assert!(r.contains("GQA"));
+        assert!(r.contains("8"));
+        assert!(r.contains("32"));
+    }
+
+    #[test]
+    fn enrich_num_kv_heads_mqa() {
+        let json = r#"{"num_attention_heads": 32, "num_key_value_heads": 1}"#;
+        let r = enrich_rationale("num_key_value_heads", "1", json).unwrap();
+        assert!(r.contains("MQA"));
+    }
+
+    #[test]
+    fn enrich_num_kv_heads_mha() {
+        let json = r#"{"num_attention_heads": 32, "num_key_value_heads": 32}"#;
+        let r = enrich_rationale("num_key_value_heads", "32", json).unwrap();
+        assert!(r.contains("MHA"));
+    }
+
+    #[test]
+    fn enrich_rope_theta() {
+        let r = enrich_rationale("rope_theta", "10000.0", "{}").unwrap();
+        assert!(r.contains("RoPE"));
+    }
+
+    #[test]
+    fn enrich_intermediate_size_swiglu() {
+        let json = r#"{"hidden_size": 4096, "intermediate_size": 11008, "hidden_act": "silu"}"#;
+        let r = enrich_rationale("intermediate_size", "11008", json).unwrap();
+        assert!(r.contains("SwiGLU"));
+    }
+
+    #[test]
+    fn enrich_intermediate_size_gelu() {
+        let json = r#"{"hidden_size": 768, "intermediate_size": 3072, "hidden_act": "gelu"}"#;
+        let r = enrich_rationale("intermediate_size", "3072", json).unwrap();
+        assert!(r.contains("GELU"));
+    }
+
+    #[test]
+    fn enrich_num_local_experts_moe() {
+        let r = enrich_rationale("num_local_experts", "8", "{}").unwrap();
+        assert!(r.contains("MoE"));
+        assert!(r.contains("8"));
+    }
+
+    #[test]
+    fn enrich_num_experts_single() {
+        let r = enrich_rationale("num_local_experts", "1", "{}").unwrap();
+        assert!(r.contains("dense"));
+    }
+
+    #[test]
+    fn enrich_num_experts_negative() {
+        let r = enrich_rationale("num_local_experts", "-1", "{}").unwrap();
+        assert!(r.contains("negative"));
+    }
+
+    #[test]
+    fn enrich_tie_word_embeddings_true() {
+        let r = enrich_rationale("tie_word_embeddings", "true", "{}").unwrap();
+        assert!(r.contains("Shared"));
+    }
+
+    #[test]
+    fn enrich_tie_word_embeddings_false() {
+        let r = enrich_rationale("tie_word_embeddings", "false", "{}").unwrap();
+        assert!(r.contains("Separate"));
+    }
+
+    #[test]
+    fn enrich_num_attention_heads_gqa() {
+        let json = r#"{"num_attention_heads": 32, "num_key_value_heads": 4}"#;
+        let r = enrich_rationale("num_attention_heads", "32", json).unwrap();
+        assert!(r.contains("GQA"));
+    }
+
+    #[test]
+    fn enrich_num_attention_heads_mha() {
+        let json = r#"{"num_attention_heads": 12, "num_key_value_heads": 12}"#;
+        let r = enrich_rationale("num_attention_heads", "12", json).unwrap();
+        assert!(r.contains("MHA"));
+    }
+
+    #[test]
+    fn enrich_hidden_size_with_params() {
+        let json = r#"{"hidden_size": 4096, "num_hidden_layers": 32, "intermediate_size": 11008, "hidden_act": "silu", "vocab_size": 32000, "num_attention_heads": 32, "num_key_value_heads": 8}"#;
+        let r = enrich_rationale("hidden_size", "4096", json).unwrap();
+        assert!(r.contains("Hidden dim"));
+        assert!(r.contains("params"));
+    }
+
+    #[test]
+    fn enrich_hidden_size_gelu_model() {
+        let json = r#"{"hidden_size": 768, "num_hidden_layers": 12, "intermediate_size": 3072, "hidden_act": "gelu", "vocab_size": 30522, "num_attention_heads": 12, "num_key_value_heads": 12}"#;
+        let r = enrich_rationale("hidden_size", "768", json).unwrap();
+        assert!(r.contains("Hidden dim"));
+        assert!(r.contains("params"));
+    }
+
+    #[test]
+    fn enrich_num_hidden_layers() {
+        let r = enrich_rationale("num_hidden_layers", "32", "{}").unwrap();
+        assert!(r.contains("32"));
+        assert!(r.contains("layers"));
+    }
+
+    #[test]
+    fn enrich_vocab_size_with_hidden() {
+        let json = r#"{"vocab_size": 32000, "hidden_size": 4096}"#;
+        let r = enrich_rationale("vocab_size", "32000", json).unwrap();
+        assert!(r.contains("32000"));
+        assert!(r.contains("MB"));
+    }
+
+    #[test]
+    fn enrich_max_position_1m() {
+        let r = enrich_rationale("max_position_embeddings", "1048576", "{}").unwrap();
+        assert!(r.contains("1M+"));
+    }
+
+    #[test]
+    fn enrich_max_position_128k() {
+        let r = enrich_rationale("max_position_embeddings", "131072", "{}").unwrap();
+        assert!(r.contains("128K+"));
+    }
+
+    #[test]
+    fn enrich_max_position_8k() {
+        let r = enrich_rationale("max_position_embeddings", "8192", "{}").unwrap();
+        assert!(r.contains("8K+"));
+    }
+
+    #[test]
+    fn enrich_max_position_small() {
+        let r = enrich_rationale("max_position_embeddings", "512", "{}").unwrap();
+        assert!(r.contains("512"));
+        assert!(!r.contains("K+"));
+    }
+
+    #[test]
+    fn enrich_unknown_key() {
+        assert!(enrich_rationale("unknown_key", "val", "{}").is_none());
+    }
+
+    #[test]
+    fn enrich_num_experts_per_tok() {
+        let r = enrich_rationale("num_experts_per_tok", "2", "{}").unwrap();
+        assert!(r.contains("2"));
+        assert!(r.contains("experts"));
+    }
+
+    #[test]
+    fn enrich_num_experts_per_tok_one() {
+        let r = enrich_rationale("num_experts_per_tok", "1", "{}").unwrap();
+        assert!(r.contains("1"));
+        assert!(r.contains("expert"));
+        // singular
+        assert!(!r.contains("experts"));
+    }
+
+    // ── detect_constraint_mismatches ────────────────────────────────────
+
+    fn make_family(name: &str, constraints: Constraints) -> FamilyInfo {
+        let kernel_class = derive_kernel_class(&constraints);
+        FamilyInfo {
+            family: name.to_string(),
+            display_name: name.to_string(),
+            architectures: vec![],
+            constraints,
+            kernel_class,
+        }
+    }
+
+    fn make_config(entries: &[(&str, &str)]) -> BTreeMap<String, ConfigField> {
+        entries
+            .iter()
+            .map(|(k, v)| {
+                (
+                    (*k).to_string(),
+                    ConfigField {
+                        value: (*v).to_string(),
+                        rationale: String::new(),
+                    },
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn mismatch_activation_silu_vs_gelu() {
+        let family = make_family(
+            "test",
+            Constraints {
+                activation: "silu".into(),
+                ..Default::default()
+            },
+        );
+        let config = make_config(&[("hidden_act", "gelu")]);
+        let warnings = detect_constraint_mismatches(&family, &config);
+        assert!(
+            warnings.iter().any(|w| w.contains("Activation mismatch")),
+            "Expected activation mismatch warning"
+        );
+    }
+
+    #[test]
+    fn mismatch_activation_gelu_vs_silu() {
+        let family = make_family(
+            "test",
+            Constraints {
+                activation: "gelu".into(),
+                ..Default::default()
+            },
+        );
+        let config = make_config(&[("hidden_act", "silu")]);
+        let warnings = detect_constraint_mismatches(&family, &config);
+        assert!(warnings.iter().any(|w| w.contains("Activation mismatch")));
+    }
+
+    #[test]
+    fn mismatch_activation_gegelu() {
+        let family = make_family(
+            "test",
+            Constraints {
+                activation: "gelu".into(),
+                ..Default::default()
+            },
+        );
+        let config = make_config(&[("hidden_act", "gegelu")]);
+        let warnings = detect_constraint_mismatches(&family, &config);
+        assert!(warnings.iter().any(|w| w.contains("gegelu")));
+    }
+
+    #[test]
+    fn mismatch_norm_rms_vs_layernorm() {
+        let family = make_family(
+            "test",
+            Constraints {
+                norm_type: "layernorm".into(),
+                ..Default::default()
+            },
+        );
+        let config = make_config(&[("rms_norm_eps", "1e-06")]);
+        let warnings = detect_constraint_mismatches(&family, &config);
+        assert!(warnings.iter().any(|w| w.contains("Norm mismatch")));
+    }
+
+    #[test]
+    fn mismatch_norm_layernorm_vs_rms() {
+        let family = make_family(
+            "test",
+            Constraints {
+                norm_type: "rmsnorm".into(),
+                ..Default::default()
+            },
+        );
+        let config = make_config(&[("layer_norm_epsilon", "1e-05")]);
+        let warnings = detect_constraint_mismatches(&family, &config);
+        assert!(warnings.iter().any(|w| w.contains("Norm mismatch")));
+    }
+
+    #[test]
+    fn mismatch_conflicting_norm_fields() {
+        let family = make_family("test", Constraints::default());
+        let config = make_config(&[("rms_norm_eps", "1e-06"), ("layer_norm_epsilon", "1e-05")]);
+        let warnings = detect_constraint_mismatches(&family, &config);
+        assert!(warnings.iter().any(|w| w.contains("Conflicting norm")));
+    }
+
+    #[test]
+    fn mismatch_attention_gqa_vs_mha() {
+        let family = make_family(
+            "test",
+            Constraints {
+                attention_type: "mha".into(),
+                ..Default::default()
+            },
+        );
+        let config = make_config(&[("num_key_value_heads", "4"), ("num_attention_heads", "32")]);
+        let warnings = detect_constraint_mismatches(&family, &config);
+        assert!(warnings.iter().any(|w| w.contains("Attention mismatch")));
+    }
+
+    #[test]
+    fn mismatch_mha_degenerate_gqa_suppressed() {
+        // MHA (kv==q) is degenerate GQA — no warning
+        let family = make_family(
+            "test",
+            Constraints {
+                attention_type: "gqa".into(),
+                ..Default::default()
+            },
+        );
+        let config = make_config(&[("num_key_value_heads", "32"), ("num_attention_heads", "32")]);
+        let warnings = detect_constraint_mismatches(&family, &config);
+        assert!(
+            !warnings.iter().any(|w| w.contains("Attention mismatch")),
+            "MHA-as-GQA should not warn"
+        );
+    }
+
+    #[test]
+    fn mismatch_kv_greater_than_q() {
+        let family = make_family("test", Constraints::default());
+        let config = make_config(&[("num_key_value_heads", "64"), ("num_attention_heads", "32")]);
+        let warnings = detect_constraint_mismatches(&family, &config);
+        assert!(warnings.iter().any(|w| w.contains("cannot exceed")));
+    }
+
+    #[test]
+    fn mismatch_invalid_gqa_grouping() {
+        let family = make_family("test", Constraints::default());
+        let config = make_config(&[("num_key_value_heads", "5"), ("num_attention_heads", "32")]);
+        let warnings = detect_constraint_mismatches(&family, &config);
+        assert!(warnings.iter().any(|w| w.contains("not divisible")));
+    }
+
+    #[test]
+    fn mismatch_multi_query_flag() {
+        let family = make_family(
+            "test",
+            Constraints {
+                attention_type: "mha".into(),
+                ..Default::default()
+            },
+        );
+        let config = make_config(&[("multi_query", "true")]);
+        let warnings = detect_constraint_mismatches(&family, &config);
+        assert!(warnings.iter().any(|w| w.contains("multi_query")));
+    }
+
+    #[test]
+    fn mismatch_moe_non_e_class() {
+        let family = make_family(
+            "test",
+            Constraints {
+                attention_type: "gqa".into(),
+                activation: "silu".into(),
+                norm_type: "rmsnorm".into(),
+                mlp_type: "swiglu".into(),
+                positional_encoding: "rope".into(),
+                ..Default::default()
+            },
+        );
+        let config = make_config(&[("num_local_experts", "8")]);
+        let warnings = detect_constraint_mismatches(&family, &config);
+        assert!(warnings.iter().any(|w| w.contains("MoE")));
+    }
+
+    #[test]
+    fn mismatch_moe_negative_experts() {
+        let family = make_family("test", Constraints::default());
+        let config = make_config(&[("num_local_experts", "-1")]);
+        let warnings = detect_constraint_mismatches(&family, &config);
+        assert!(warnings.iter().any(|w| w.contains("negative")));
+    }
+
+    #[test]
+    fn mismatch_negative_hidden_size() {
+        let family = make_family("test", Constraints::default());
+        let config = make_config(&[("hidden_size", "-1")]);
+        let warnings = detect_constraint_mismatches(&family, &config);
+        assert!(warnings.iter().any(|w| w.contains("negative")));
+    }
+
+    #[test]
+    fn mismatch_zero_hidden_size() {
+        let family = make_family("test", Constraints::default());
+        let config = make_config(&[("hidden_size", "0")]);
+        let warnings = detect_constraint_mismatches(&family, &config);
+        assert!(warnings.iter().any(|w| w.contains("zero")));
+    }
+
+    #[test]
+    fn mismatch_implausible_hidden_size() {
+        let family = make_family("test", Constraints::default());
+        let config = make_config(&[("hidden_size", "999999")]);
+        let warnings = detect_constraint_mismatches(&family, &config);
+        assert!(warnings.iter().any(|w| w.contains("Implausible")));
+    }
+
+    #[test]
+    fn mismatch_hidden_not_divisible_by_heads() {
+        let family = make_family("test", Constraints::default());
+        let config = make_config(&[("hidden_size", "5120"), ("num_attention_heads", "24")]);
+        let warnings = detect_constraint_mismatches(&family, &config);
+        assert!(warnings.iter().any(|w| w.contains("not divisible")));
+    }
+
+    #[test]
+    fn mismatch_hidden_divisibility_skipped_with_explicit_head_dim() {
+        let family = make_family("test", Constraints::default());
+        let config = make_config(&[
+            ("hidden_size", "5120"),
+            ("num_attention_heads", "24"),
+            ("head_dim", "256"),
+        ]);
+        let warnings = detect_constraint_mismatches(&family, &config);
+        assert!(
+            !warnings.iter().any(|w| w.contains("not divisible")),
+            "Should skip divisibility check when head_dim is explicit"
+        );
+    }
+
+    #[test]
+    fn mismatch_model_type_arch_conflict() {
+        let family = make_family("test", Constraints::default());
+        let config = make_config(&[
+            ("model_type", "llama"),
+            ("_architectures", "MistralForCausalLM"),
+        ]);
+        let warnings = detect_constraint_mismatches(&family, &config);
+        assert!(warnings.iter().any(|w| w.contains("conflicts")));
+    }
+
+    #[test]
+    fn mismatch_model_type_arch_no_conflict_deepseek() {
+        // deepseek_v2 vs DeepseekV2ForCausalLM: compact forms match
+        let family = make_family("test", Constraints::default());
+        let config = make_config(&[
+            ("model_type", "deepseek_v2"),
+            ("_architectures", "DeepseekV2ForCausalLM"),
+        ]);
+        let warnings = detect_constraint_mismatches(&family, &config);
+        assert!(
+            !warnings.iter().any(|w| w.contains("conflicts")),
+            "deepseek_v2 vs DeepseekV2 should not conflict"
+        );
+    }
+
+    #[test]
+    fn mismatch_moe_from_alias_name() {
+        let family = FamilyInfo {
+            family: "mistral".to_string(),
+            display_name: "mixtral (via mistral kernel pipeline)".to_string(),
+            architectures: vec![],
+            constraints: Constraints::default(),
+            kernel_class: KernelClass::A,
+        };
+        let config = make_config(&[]);
+        let warnings = detect_constraint_mismatches(&family, &config);
+        assert!(warnings.iter().any(|w| w.contains("MoE")));
+    }
+
+    #[test]
+    fn no_mismatch_clean_config() {
+        let family = make_family(
+            "test",
+            Constraints {
+                attention_type: "gqa".into(),
+                activation: "silu".into(),
+                norm_type: "rmsnorm".into(),
+                ..Default::default()
+            },
+        );
+        let config = make_config(&[
+            ("hidden_act", "silu"),
+            ("rms_norm_eps", "1e-06"),
+            ("num_key_value_heads", "8"),
+            ("num_attention_heads", "32"),
+            ("hidden_size", "4096"),
+        ]);
+        let warnings = detect_constraint_mismatches(&family, &config);
+        assert!(
+            warnings.is_empty(),
+            "Expected no warnings, got: {warnings:?}"
+        );
+    }
+
+    // ── extract_architecture_display ────────────────────────────────────
+
+    #[test]
+    fn arch_display_from_config_architectures() {
+        let family = make_family("test", Constraints::default());
+        let config = make_config(&[("_architectures", "LlamaForCausalLM")]);
+        assert_eq!(
+            extract_architecture_display(&family, &config),
+            "LlamaForCausalLM"
+        );
+    }
+
+    #[test]
+    fn arch_display_from_model_type() {
+        let family = make_family("test", Constraints::default());
+        let config = make_config(&[("model_type", "llama")]);
+        assert_eq!(extract_architecture_display(&family, &config), "llama");
+    }
+
+    #[test]
+    fn arch_display_alias_uses_alias_arch_table() {
+        let family = FamilyInfo {
+            family: "llama".to_string(),
+            display_name: "vicuna (via llama kernel pipeline)".to_string(),
+            architectures: vec!["LlamaForCausalLM".to_string()],
+            constraints: Constraints::default(),
+            kernel_class: KernelClass::A,
+        };
+        let config = make_config(&[]);
+        assert_eq!(
+            extract_architecture_display(&family, &config),
+            "LlamaForCausalLM"
+        );
+    }
+
+    #[test]
+    fn arch_display_fallback_to_family_arch() {
+        let family = FamilyInfo {
+            family: "llama".to_string(),
+            display_name: "LLaMA".to_string(),
+            architectures: vec!["LlamaForCausalLM".to_string()],
+            constraints: Constraints::default(),
+            kernel_class: KernelClass::A,
+        };
+        let config = make_config(&[]);
+        assert_eq!(
+            extract_architecture_display(&family, &config),
+            "LlamaForCausalLM"
+        );
+    }
+
+    #[test]
+    fn arch_display_no_archs() {
+        let family = make_family("test", Constraints::default());
+        let config = make_config(&[]);
+        assert_eq!(extract_architecture_display(&family, &config), "Unknown");
+    }
+
+    // ── proof_status ────────────────────────────────────────────────────
+
+    #[test]
+    fn proof_all_known_contracts() {
+        for (name, _) in KERNEL_CONTRACTS {
+            let proof = proof_status_for_contract(name);
+            assert_ne!(
+                proof.level,
+                ProofLevel::Unknown,
+                "Contract {name} should be known"
+            );
+        }
+    }
+
+    #[test]
+    fn proof_unknown_contract() {
+        let proof = proof_status_for_contract("does-not-exist-v1");
+        assert_eq!(proof.level, ProofLevel::Unknown);
+        assert!(proof.evidence.contains("No contract"));
+    }
+
+    #[test]
+    fn proof_level_symbols() {
+        assert_eq!(ProofLevel::Proven.symbol(), "✓");
+        assert_eq!(ProofLevel::Tested.symbol(), "◉");
+        assert_eq!(ProofLevel::Documented.symbol(), "○");
+        assert_eq!(ProofLevel::Unknown.symbol(), "?");
+    }
+
+    #[test]
+    fn proof_level_labels() {
+        assert_eq!(ProofLevel::Proven.label(), "Proven");
+        assert_eq!(ProofLevel::Tested.label(), "Tested");
+        assert_eq!(ProofLevel::Documented.label(), "Documented");
+        assert_eq!(ProofLevel::Unknown.label(), "Unknown");
+    }
+
+    // ── proof_status_for_class ──────────────────────────────────────────
+
+    #[test]
+    fn proof_class_deduplicates_contracts() {
+        let proofs = proof_status_for_class(KernelClass::A);
+        let names: Vec<&str> = proofs.iter().map(|p| p.contract.as_str()).collect();
+        // Verify no duplicates
+        let mut seen = Vec::new();
+        for name in &names {
+            assert!(
+                !seen.contains(name),
+                "Duplicate contract in proof list: {name}"
+            );
+            seen.push(*name);
+        }
+    }
+
+    #[test]
+    fn proof_class_unknown_has_some_proofs() {
+        // Unknown still has base ops (MatVec, Softmax, Fusion)
+        let proofs = proof_status_for_class(KernelClass::Unknown);
+        assert!(!proofs.is_empty());
+    }
+
+    // ── build_json_output ───────────────────────────────────────────────
+
+    #[test]
+    fn json_output_basic() {
+        let family = resolve_family("llama").unwrap();
+        let config = make_config(&[]);
+        let json = build_json_output(&family, config, false);
+        assert_eq!(json.family, "llama");
+        assert_eq!(json.kernel_class, "A");
+        assert_eq!(json.layout, "row_major");
+        assert!(json.proof_summary.is_none());
+    }
+
+    #[test]
+    fn json_output_with_proof() {
+        let family = resolve_family("llama").unwrap();
+        let config = make_config(&[]);
+        let json = build_json_output(&family, config, true);
+        assert!(json.proof_summary.is_some());
+        let ps = json.proof_summary.unwrap();
+        assert!(ps.total > 0);
+    }
+
+    #[test]
+    fn json_output_internal_fields_removed() {
+        let family = resolve_family("llama").unwrap();
+        let mut config = make_config(&[("_architectures", "LlamaForCausalLM")]);
+        config.insert(
+            "model_type".to_string(),
+            ConfigField {
+                value: "llama".to_string(),
+                rationale: "test".to_string(),
+            },
+        );
+        let json = build_json_output(&family, config, false);
+        assert!(
+            !json.config_mapping.contains_key("_architectures"),
+            "Internal fields should be stripped"
+        );
+    }
+
+    #[test]
+    fn json_output_equivalence_class() {
+        let family = resolve_family("qwen2").unwrap();
+        let json = build_json_output(&family, make_config(&[]), false);
+        // Class A has multiple families
+        assert!(json.equivalence_class_families.len() > 1);
+        assert!(json
+            .equivalence_class_families
+            .contains(&"llama".to_string()));
+    }
+
+    // ── FAMILY_ALIASES coverage ─────────────────────────────────────────
+
+    #[test]
+    fn all_aliases_resolve_to_valid_family() {
+        let families = load_families();
+        for (alias, target) in FAMILY_ALIASES {
+            assert!(
+                families.iter().any(|f| f.family == *target),
+                "Alias {alias} → {target}: target family not found in loaded families"
+            );
+        }
+    }
+
+    #[test]
+    fn all_aliases_resolvable() {
+        for (alias, target) in FAMILY_ALIASES {
+            let resolved = resolve_family(alias);
+            assert!(
+                resolved.is_some(),
+                "Alias {alias} should resolve (expected target: {target})"
+            );
+            assert_eq!(
+                resolved.unwrap().family,
+                *target,
+                "Alias {alias} resolved to wrong family"
+            );
+        }
+    }
+
+    // ── ALIAS_ARCHITECTURES coverage ────────────────────────────────────
+
+    #[test]
+    fn all_alias_architectures_have_matching_alias() {
+        for (alias_name, _hf_arch) in ALIAS_ARCHITECTURES {
+            assert!(
+                FAMILY_ALIASES.iter().any(|(a, _)| a == alias_name),
+                "ALIAS_ARCHITECTURES has {alias_name} but no matching FAMILY_ALIASES entry"
+            );
+        }
+    }
+
+    // ── Regression tests ────────────────────────────────────────────────
+
+    #[test]
+    fn regression_phi3_mini_resolves_to_class_a() {
+        // phi-3-mini was resolving to phi (Class B/D) instead of phi3 alias (Class A)
+        let f = resolve_family("phi-3-mini").unwrap();
+        assert_eq!(f.family, "llama");
+        assert_eq!(f.kernel_class, KernelClass::A);
+    }
+
+    #[test]
+    fn regression_qwen_resolves_to_qwen2_not_moe() {
+        // "qwen" was resolving to qwen2_moe alias before family match
+        let f = resolve_family("qwen").unwrap();
+        assert_eq!(f.family, "qwen2");
+    }
+
+    #[test]
+    fn regression_phi2_resolves_to_phi() {
+        // phi-2 is the phi family directly (Class B/D, NOT phi3→llama alias)
+        let f = resolve_family("phi").unwrap();
+        assert_eq!(f.family, "phi");
+    }
+
+    #[test]
+    fn regression_gemma2_alias() {
+        let f = resolve_family("gemma2").unwrap();
+        assert_eq!(f.family, "gemma");
+        assert_eq!(f.kernel_class, KernelClass::F);
+    }
+
+    #[test]
+    fn regression_mamba_is_ssm() {
+        let f = resolve_family("mamba").unwrap();
+        assert_eq!(f.kernel_class, KernelClass::Ssm);
+        let ops = kernel_ops_for_class(KernelClass::Ssm);
+        assert!(!ops.iter().any(|o| o.kernel == "softmax"));
+    }
+
+    #[test]
+    fn regression_rwkv7_is_linear() {
+        let f = resolve_family("rwkv7").unwrap();
+        assert_eq!(f.kernel_class, KernelClass::Linear);
+        let ops = kernel_ops_for_class(KernelClass::Linear);
+        assert!(!ops.iter().any(|o| o.kernel == "softmax"));
+    }
+
+    // ── Parameter estimate tests ────────────────────────────────────────
+
+    #[test]
+    fn param_estimate_gqa_model() {
+        // Qwen2.5-7B: hidden=3584, layers=28, inter=18944, heads=28, kv=4, vocab=152064
+        let json = r#"{"hidden_size": 3584, "num_hidden_layers": 28, "intermediate_size": 18944, "hidden_act": "silu", "vocab_size": 152064, "num_attention_heads": 28, "num_key_value_heads": 4}"#;
+        let r = enrich_rationale("hidden_size", "3584", json).unwrap();
+        // Should estimate ~7-8B
+        assert!(r.contains("B params"), "Expected B params in: {r}");
+    }
+
+    #[test]
+    fn param_estimate_gelu_model() {
+        // BERT-base: hidden=768, layers=12, inter=3072, heads=12, kv=12, vocab=30522
+        let json = r#"{"hidden_size": 768, "num_hidden_layers": 12, "intermediate_size": 3072, "hidden_act": "gelu", "vocab_size": 30522, "num_attention_heads": 12, "num_key_value_heads": 12, "tie_word_embeddings": "true"}"#;
+        let r = enrich_rationale("hidden_size", "768", json).unwrap();
+        // BERT-base is ~110M
+        assert!(r.contains("M params"), "Expected M params in: {r}");
+    }
+
+    #[test]
+    fn param_estimate_moe_model() {
+        // Model with experts should include expert weights
+        let json = r#"{"hidden_size": 4096, "num_hidden_layers": 32, "intermediate_size": 11008, "hidden_act": "silu", "vocab_size": 32000, "num_attention_heads": 32, "num_key_value_heads": 8, "num_local_experts": 8, "moe_intermediate_size": 4096}"#;
+        let r = enrich_rationale("hidden_size", "4096", json).unwrap();
+        assert!(r.contains("B params"), "MoE model should be large: {r}");
+    }
+
+    // ── ConfigField type ────────────────────────────────────────────────
+
+    #[test]
+    fn config_field_construction() {
+        let field = ConfigField {
+            value: "silu".to_string(),
+            rationale: "SiLU activation".to_string(),
+        };
+        assert_eq!(field.value, "silu");
+        assert_eq!(field.rationale, "SiLU activation");
+    }
+
+    // ── family_aliases() accessor ───────────────────────────────────────
+
+    #[test]
+    fn family_aliases_not_empty() {
+        assert!(!family_aliases().is_empty());
+        assert!(family_aliases().len() >= 50, "Expected at least 50 aliases");
+    }
+
+    // ── Constraints struct ──────────────────────────────────────────────
+
+    #[test]
+    fn constraints_default_all_empty() {
+        let c = Constraints::default();
+        assert_eq!(c.attention_type, "");
+        assert_eq!(c.activation, "");
+        assert_eq!(c.norm_type, "");
+        assert_eq!(c.mlp_type, "");
+        assert_eq!(c.positional_encoding, "");
+        assert!(!c.has_bias);
+        assert!(!c.tied_embeddings);
+    }
+
+    // ── FamilyInfo struct ───────────────────────────────────────────────
+
+    #[test]
+    fn family_info_clone_eq() {
+        let f = resolve_family("llama").unwrap();
+        let f2 = f.clone();
+        assert_eq!(f.family, f2.family);
+        assert_eq!(f.kernel_class, f2.kernel_class);
+    }
+
+    // ── Integration: round-trip family → class → ops → proof ────────────
+
+    #[test]
+    fn integration_llama_full_pipeline() {
+        let family = resolve_family("llama").unwrap();
+        assert_eq!(family.kernel_class, KernelClass::A);
+        let ops = kernel_ops_for_family(family.kernel_class, &family.constraints);
+        assert!(ops.len() > 4);
+        let proofs = proof_status_for_class(family.kernel_class);
+        assert!(!proofs.is_empty());
+        let json = build_json_output(&family, BTreeMap::new(), true);
+        assert_eq!(json.kernel_class, "A");
+        assert!(json.proof_summary.is_some());
+    }
+
+    #[test]
+    fn integration_bert_full_pipeline() {
+        let family = resolve_family("bert").unwrap();
+        assert_eq!(family.kernel_class, KernelClass::B);
+        let ops = kernel_ops_for_class(KernelClass::B);
+        assert!(!ops.iter().any(|o| o.kernel == "rope_forward"));
+    }
+
+    #[test]
+    fn integration_gemma_full_pipeline() {
+        let family = resolve_family("gemma").unwrap();
+        assert_eq!(family.kernel_class, KernelClass::F);
+        let ops = kernel_ops_for_class(KernelClass::F);
+        assert!(ops.iter().any(|o| o.kernel == "gated_mlp"));
+        assert!(ops.iter().any(|o| o.kernel == "gelu"));
+    }
+
+    #[test]
+    fn integration_mamba_full_pipeline() {
+        let family = resolve_family("mamba").unwrap();
+        assert_eq!(family.kernel_class, KernelClass::Ssm);
+        let ops = kernel_ops_for_class(KernelClass::Ssm);
+        assert!(ops.iter().any(|o| o.kernel == "selective_scan"));
+    }
+
+    #[test]
+    fn integration_alias_full_pipeline() {
+        let family = resolve_family("mixtral").unwrap();
+        assert!(family.display_name.contains("via"));
+        let json = build_json_output(&family, BTreeMap::new(), false);
+        assert!(json.display_name.contains("via"));
     }
 }

--- a/crates/apr-cli/src/commands/kernel_explain.rs
+++ b/crates/apr-cli/src/commands/kernel_explain.rs
@@ -3664,4 +3664,114 @@ mod tests {
         let json = build_json_output(&family, BTreeMap::new(), false);
         assert!(json.display_name.contains("via"));
     }
+
+    // ── resolve_from_config_json (filesystem tests) ─────────────────────
+
+    #[test]
+    fn resolve_config_json_valid() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        std::fs::write(&path, r#"{"model_type": "qwen2", "hidden_size": 4096}"#).unwrap();
+        let f = resolve_from_config_json(&path).unwrap();
+        assert_eq!(f.family, "qwen2");
+    }
+
+    #[test]
+    fn resolve_config_json_no_model_type_uses_architectures() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        std::fs::write(
+            &path,
+            r#"{"architectures": ["LlamaForCausalLM"], "hidden_size": 4096}"#,
+        )
+        .unwrap();
+        let f = resolve_from_config_json(&path).unwrap();
+        assert_eq!(f.family, "llama");
+    }
+
+    #[test]
+    fn resolve_config_json_missing_file() {
+        assert!(resolve_from_config_json(Path::new("/nonexistent/config.json")).is_none());
+    }
+
+    #[test]
+    fn resolve_config_json_array_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        std::fs::write(&path, r#"[{"model_type": "bert"}]"#).unwrap();
+        assert!(resolve_from_config_json(&path).is_none());
+    }
+
+    #[test]
+    fn resolve_config_json_unknown_model_type() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        std::fs::write(&path, r#"{"model_type": "totally_unknown_xyz"}"#).unwrap();
+        assert!(resolve_from_config_json(&path).is_none());
+    }
+
+    // ── extract_config_mapping (filesystem tests) ───────────────────────
+
+    #[test]
+    fn config_mapping_extracts_fields() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        std::fs::write(
+            &path,
+            r#"{
+                "model_type": "qwen2",
+                "hidden_act": "silu",
+                "hidden_size": 4096,
+                "num_hidden_layers": 32,
+                "num_attention_heads": 32,
+                "num_key_value_heads": 8,
+                "intermediate_size": 11008,
+                "vocab_size": 32000,
+                "rms_norm_eps": 1e-06,
+                "rope_theta": 10000.0,
+                "architectures": ["Qwen2ForCausalLM"]
+            }"#,
+        )
+        .unwrap();
+        let map = extract_config_mapping(&path);
+        assert!(map.contains_key("model_type"));
+        assert!(map.contains_key("hidden_act"));
+        assert!(map.contains_key("hidden_size"));
+        assert!(map.contains_key("num_attention_heads"));
+        assert!(map.contains_key("num_key_value_heads"));
+        assert!(map.contains_key("rms_norm_eps"));
+        assert!(map.contains_key("_architectures"));
+        // Enriched rationale
+        assert!(map["hidden_act"].rationale.contains("SiLU"));
+    }
+
+    #[test]
+    fn config_mapping_missing_file() {
+        let map = extract_config_mapping(Path::new("/nonexistent/config.json"));
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn config_mapping_enriches_gqa() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        std::fs::write(
+            &path,
+            r#"{"num_attention_heads": 32, "num_key_value_heads": 8}"#,
+        )
+        .unwrap();
+        let map = extract_config_mapping(&path);
+        assert!(map["num_key_value_heads"].rationale.contains("GQA"));
+    }
+
+    // ── print_human_output (smoke test) ─────────────────────────────────
+
+    #[test]
+    fn print_human_output_no_panic() {
+        let family = resolve_family("llama").unwrap();
+        let config = BTreeMap::new();
+        // Just verify it doesn't panic — output goes to stdout
+        print_human_output(&family, &config, false, false);
+        print_human_output(&family, &config, true, true);
+    }
 }

--- a/crates/apr-cli/src/lib_parse_eval.rs
+++ b/crates/apr-cli/src/lib_parse_eval.rs
@@ -28,6 +28,7 @@
                 model_size,
                 num_classes,
                 generate_card,
+                ..
             }) => {
                 assert_eq!(file, PathBuf::from("model.gguf"));
                 assert_eq!(dataset, "lambada");

--- a/crates/apr-cli/src/lib_parse_rosetta_02.rs
+++ b/crates/apr-cli/src/lib_parse_rosetta_02.rs
@@ -262,6 +262,9 @@
             model_size: None,
             num_classes: 5,
             generate_card: false,
+            device: "cpu".to_string(),
+            samples: 1,
+            temperature: 0.0,
         });
         let paths = extract_model_paths(&cmd);
         assert_eq!(paths, vec![PathBuf::from("model.gguf")]);

--- a/crates/apr-cli/src/lib_verbose_inheritance_parse.rs
+++ b/crates/apr-cli/src/lib_verbose_inheritance_parse.rs
@@ -288,6 +288,9 @@
             model_size: None,
             num_classes: 5,
             generate_card: false,
+            device: "cpu".to_string(),
+            samples: 1,
+            temperature: 0.0,
         }));
         let result = execute_command(&cli);
         assert!(result.is_err(), "Eval should fail with non-existent file");

--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -4685,3 +4685,20 @@ roadmap:
   estimated_effort: null
   labels: []
   notes: null
+- id: PMAT-371
+  github_issue: null
+  item_type: task
+  title: 'Fix nightly CI: patch alimentar path deps for standalone build'
+  status: inprogress
+  priority: medium
+  assigned_to: null
+  created: 2026-03-10T12:56:10Z
+  updated: 2026-03-10T12:56:13.020505189+00:00
+  spec: null
+  acceptance_criteria:
+  - Nightly workflow fails because Cargo.toml has path dependency on ../alimentar which doesn't exist in CI. Add sed/pwsh step to patch path deps before build.
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels: []
+  notes: null

--- a/src/format/model_family.rs
+++ b/src/format/model_family.rs
@@ -60,7 +60,9 @@ impl AttentionType {
             "ssm" => Ok(Self::Ssm),
             "linear" => Ok(Self::Linear),
             _ => Err(AprenderError::FormatError {
-                message: format!("Unknown attention type: {s}. Expected: mha, gqa, mqa, ssm, linear"),
+                message: format!(
+                    "Unknown attention type: {s}. Expected: mha, gqa, mqa, ssm, linear"
+                ),
             }),
         }
     }


### PR DESCRIPTION
## Summary
- O(1) metadata-only validation for APR and SafeTensors formats (was loading full 17 GB files)
- Distillation generate stage with resume support and retry on server errors
- 194 unit tests for kernel_explain.rs, filesystem + smoke tests
- Cargo.lock update, linter formatting

## Test plan
- [x] `apr serve run` starts instantly on 17 GB Q4K APR (verified)
- [x] `apr check` still validates normally (contract gate works)
- [x] Distillation resumes from existing records
- [x] Build passes (`cargo build --release -p apr-cli`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)