### PR TITLE
fix: remove provable-contracts checkout from nightly

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -62,13 +62,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
-
-      - name: Checkout provable-contracts (path dep)
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
-        with:
-          repository: paiml/provable-contracts
-          path: ../provable-contracts
-
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:


### PR DESCRIPTION
## Summary
- Remove `actions/checkout` for `paiml/provable-contracts` with `path: ../provable-contracts`
- GitHub Actions now rejects checkout paths outside the workspace directory
- Cargo falls back to crates.io `version = "0.2"` when path dep is absent — correct for release builds

Fixes paiml/infra#14

🤖 Generated with [Claude Code](https://claude.com/claude-code)