### PR TITLE
fix: add alimentar path dep to nightly workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -78,6 +78,21 @@ jobs:
         shell: pwsh
         run: New-Item -ItemType Junction -Path "$env:GITHUB_WORKSPACE\..\provable-contracts" -Target "$env:GITHUB_WORKSPACE\provable-contracts" -Force
 
+      - name: Checkout alimentar (path dep)
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          repository: paiml/alimentar
+          path: alimentar
+
+      - name: Symlink alimentar for Cargo path deps
+        if: runner.os != 'Windows'
+        run: ln -sf "$GITHUB_WORKSPACE/alimentar" "$GITHUB_WORKSPACE/../alimentar"
+
+      - name: Symlink alimentar (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: New-Item -ItemType Junction -Path "$env:GITHUB_WORKSPACE\..\alimentar" -Target "$env:GITHUB_WORKSPACE\alimentar" -Force
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:


### PR DESCRIPTION
## Summary
- Adds checkout + symlink steps for `paiml/alimentar` in the nightly build workflow
- Mirrors the existing `provable-contracts` sibling pattern (checkout into workspace, symlink to `../alimentar`)
- Fixes nightly build failure caused by Cargo requiring path deps to exist on disk even when a version fallback is specified

Refs aprender#593

## Test plan
- [ ] Trigger manual nightly dispatch and verify all 4 targets build successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)