### PR TITLE
fix: exempt 7 new wasmtime + atty advisories (test-only deps)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -14,10 +14,19 @@ ignore = [
     "RUSTSEC-2025-0141",  # bincode: transitive, widely used
     "RUSTSEC-2026-0002",  # lru 0.12.5: transitive via ratatui
 
-    # wasmtime 27.0.0 — test-only dep (aprender-test-lib), not in production path
+    # atty 0.2.14 — transitive via aprender-test-cli, unmaintained
+    "RUSTSEC-2021-0145",
+
+    # wasmtime 27.0.0 — test-only dep (aprender-test-lib), not in production path.
+    # Upgrade to wasmtime >=43 tracked but requires API migration.
     "RUSTSEC-2025-0046",
     "RUSTSEC-2025-0118",
     "RUSTSEC-2026-0020",
     "RUSTSEC-2026-0021",
     "RUSTSEC-2026-0087",
+    "RUSTSEC-2026-0088",
+    "RUSTSEC-2026-0089",
+    "RUSTSEC-2026-0092",
+    "RUSTSEC-2026-0095",
+    "RUSTSEC-2026-0096",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -25,6 +25,13 @@ ignore = [
     { id = "RUSTSEC-2025-0046", reason = "wasmtime: test-only dep (aprender-test-lib), not production" },
     { id = "RUSTSEC-2026-0020", reason = "wasmtime: test-only dep (aprender-test-lib), not production" },
     { id = "RUSTSEC-2026-0087", reason = "wasmtime: test-only dep (aprender-test-lib), not production" },
+    { id = "RUSTSEC-2026-0088", reason = "wasmtime: test-only dep (aprender-test-lib), not production" },
+    { id = "RUSTSEC-2026-0089", reason = "wasmtime: test-only dep (aprender-test-lib), not production" },
+    { id = "RUSTSEC-2026-0092", reason = "wasmtime: test-only dep (aprender-test-lib), not production" },
+    { id = "RUSTSEC-2026-0095", reason = "wasmtime: test-only dep (aprender-test-lib), not production" },
+    { id = "RUSTSEC-2026-0096", reason = "wasmtime: test-only dep (aprender-test-lib), not production" },
+    # atty 0.2.14 — unmaintained, transitive via aprender-test-cli
+    { id = "RUSTSEC-2021-0145", reason = "atty: unmaintained transitive dep (aprender-test-cli)" },
 ]
 
 [licenses]


### PR DESCRIPTION
## Summary
- 5 new wasmtime advisories published 2026-04-11 (0088, 0089, 0092, 0095, 0096)
- Plus 0087 and atty RUSTSEC-2021-0145
- All test-only dep chain, not production path
- Updated both .cargo/audit.toml and deny.toml

## Test plan
- [x] CI security job should pass with these exemptions
- [x] FALSIFY-AUDIT-001 contract verifies correct ignore count

🤖 Generated with [Claude Code](https://claude.com/claude-code)