### PR TITLE
fix: increase workspace test timeout 25→30 min (cold cache)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Workspace lib tests (25,300+)
         # Excluded: aprender-gpu (cuBLAS), aprender-cuda-edge (CUDA), aprender-compute (SIMD SIGSEGV at exit)
         run: cargo test --workspace --lib --exclude aprender-gpu --exclude aprender-cuda-edge --exclude aprender-compute
-        timeout-minutes: 25
+        timeout-minutes: 30
       - name: Compute tests (tolerate SIGSEGV at exit — all tests pass but harness crashes on cleanup)
         run: cargo test -p aprender-compute --lib 2>&1 | tee /tmp/compute-test.log; grep -q 'test result.*0 failed' /tmp/compute-test.log
       - name: Integration tests


### PR DESCRIPTION
## Summary

GitHub badge is red because workspace-test timed out at 25 min on cold cache (first main run after PR #734 merge).

- Warm cache: ~20 min
- Cold cache (fresh Docker container, no incremental): ~27 min  
- Old timeout: 25 min (too tight)
- New timeout: 30 min

## Test plan

- [x] Five-whys documented
- [ ] CI passes with new timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)