### PR TITLE
feat(apr): CPU inference uses per-tensor scratch dequant (GH-479)

### DIFF
--- a/crates/aprender-serve/src/apr/test_factory.rs
+++ b/crates/aprender-serve/src/apr/test_factory.rs
@@ -32,13 +32,17 @@ pub fn build_executable_pygmy_apr() -> Vec<u8> {
         "num_kv_heads": {num_kv_heads},
         "vocab_size": {vocab_size},
         "intermediate_size": {intermediate_size},
+        "max_position_embeddings": 512,
         "rms_norm_eps": 1e-6
     }}"#
     );
     let metadata_bytes = metadata.as_bytes();
     let metadata_padded_size = metadata_bytes.len().div_ceil(64) * 64;
 
-    // Tensors needed for forward pass (all F32):
+    // GH-317/GH-479: Contract-compliant HF tensor names (model.layers.N. prefix).
+    // The OwnedQuantizedModel::from_apr loader (gguf/loading.rs::load_apr_layer)
+    // looks up HF ("model.layers.N.*") then GGUF ("blk.N.*") — bare "layers.N.*"
+    // is NOT a supported naming convention.
     let tensor_defs: Vec<(&str, Vec<u64>, usize)> = vec![
         (
             "model.embed_tokens.weight",
@@ -46,51 +50,55 @@ pub fn build_executable_pygmy_apr() -> Vec<u8> {
             vocab_size * hidden_size * 4,
         ),
         (
-            "layers.0.input_layernorm.weight",
+            "model.layers.0.input_layernorm.weight",
             vec![hidden_size as u64],
             hidden_size * 4,
         ),
         (
-            "layers.0.self_attn.q_proj.weight",
+            "model.layers.0.self_attn.q_proj.weight",
             vec![hidden_size as u64, hidden_size as u64],
             hidden_size * hidden_size * 4,
         ),
         (
-            "layers.0.self_attn.k_proj.weight",
+            "model.layers.0.self_attn.k_proj.weight",
             vec![hidden_size as u64, hidden_size as u64],
             hidden_size * hidden_size * 4,
         ),
         (
-            "layers.0.self_attn.v_proj.weight",
+            "model.layers.0.self_attn.v_proj.weight",
             vec![hidden_size as u64, hidden_size as u64],
             hidden_size * hidden_size * 4,
         ),
         (
-            "layers.0.self_attn.o_proj.weight",
+            "model.layers.0.self_attn.o_proj.weight",
             vec![hidden_size as u64, hidden_size as u64],
             hidden_size * hidden_size * 4,
         ),
         (
-            "layers.0.post_attention_layernorm.weight",
+            "model.layers.0.post_attention_layernorm.weight",
             vec![hidden_size as u64],
             hidden_size * 4,
         ),
         (
-            "layers.0.mlp.gate_proj.weight",
+            "model.layers.0.mlp.gate_proj.weight",
             vec![intermediate_size as u64, hidden_size as u64],
             hidden_size * intermediate_size * 4,
         ),
         (
-            "layers.0.mlp.up_proj.weight",
+            "model.layers.0.mlp.up_proj.weight",
             vec![intermediate_size as u64, hidden_size as u64],
             hidden_size * intermediate_size * 4,
         ),
         (
-            "layers.0.mlp.down_proj.weight",
+            "model.layers.0.mlp.down_proj.weight",
             vec![hidden_size as u64, intermediate_size as u64],
             hidden_size * intermediate_size * 4,
         ),
-        ("norm.weight", vec![hidden_size as u64], hidden_size * 4),
+        (
+            "model.norm.weight",
+            vec![hidden_size as u64],
+            hidden_size * 4,
+        ),
         (
             "lm_head.weight",
             vec![vocab_size as u64, hidden_size as u64],
@@ -212,6 +220,7 @@ pub fn build_executable_pygmy_apr_gguf_names() -> Vec<u8> {
         "num_kv_heads": {num_kv_heads},
         "vocab_size": {vocab_size},
         "intermediate_size": {intermediate_size},
+        "max_position_embeddings": 512,
         "rms_norm_eps": 1e-6
     }}"#
     );
@@ -306,6 +315,7 @@ pub fn build_executable_pygmy_apr_embed_tied() -> Vec<u8> {
         "num_kv_heads": {num_kv_heads},
         "vocab_size": {vocab_size},
         "intermediate_size": {intermediate_size},
+        "max_position_embeddings": 512,
         "rms_norm_eps": 1e-6,
         "tie_word_embeddings": true
     }}"#
@@ -313,59 +323,63 @@ pub fn build_executable_pygmy_apr_embed_tied() -> Vec<u8> {
     let metadata_bytes = metadata.as_bytes();
     let metadata_padded_size = metadata_bytes.len().div_ceil(64) * 64;
 
-    // HuggingFace naming but with weight tying (no lm_head)
+    // GH-317/GH-479: HF-compliant names (model.layers.N. prefix) with weight tying
     let tensor_defs: Vec<(&str, Vec<u64>, usize)> = vec![
         (
-            "embed_tokens.weight",
+            "model.embed_tokens.weight",
             vec![vocab_size as u64, hidden_size as u64],
             vocab_size * hidden_size * 4,
         ),
         (
-            "layers.0.input_layernorm.weight",
+            "model.layers.0.input_layernorm.weight",
             vec![hidden_size as u64],
             hidden_size * 4,
         ),
         (
-            "layers.0.self_attn.q_proj.weight",
+            "model.layers.0.self_attn.q_proj.weight",
             vec![hidden_size as u64, hidden_size as u64],
             hidden_size * hidden_size * 4,
         ),
         (
-            "layers.0.self_attn.k_proj.weight",
+            "model.layers.0.self_attn.k_proj.weight",
             vec![hidden_size as u64, hidden_size as u64],
             hidden_size * hidden_size * 4,
         ),
         (
-            "layers.0.self_attn.v_proj.weight",
+            "model.layers.0.self_attn.v_proj.weight",
             vec![hidden_size as u64, hidden_size as u64],
             hidden_size * hidden_size * 4,
         ),
         (
-            "layers.0.self_attn.o_proj.weight",
+            "model.layers.0.self_attn.o_proj.weight",
             vec![hidden_size as u64, hidden_size as u64],
             hidden_size * hidden_size * 4,
         ),
         (
-            "layers.0.post_attention_layernorm.weight",
+            "model.layers.0.post_attention_layernorm.weight",
             vec![hidden_size as u64],
             hidden_size * 4,
         ),
         (
-            "layers.0.mlp.gate_proj.weight",
+            "model.layers.0.mlp.gate_proj.weight",
             vec![intermediate_size as u64, hidden_size as u64],
             hidden_size * intermediate_size * 4,
         ),
         (
-            "layers.0.mlp.up_proj.weight",
+            "model.layers.0.mlp.up_proj.weight",
             vec![intermediate_size as u64, hidden_size as u64],
             hidden_size * intermediate_size * 4,
         ),
         (
-            "layers.0.mlp.down_proj.weight",
+            "model.layers.0.mlp.down_proj.weight",
             vec![hidden_size as u64, intermediate_size as u64],
             hidden_size * intermediate_size * 4,
         ),
-        ("norm.weight", vec![hidden_size as u64], hidden_size * 4),
+        (
+            "model.norm.weight",
+            vec![hidden_size as u64],
+            hidden_size * 4,
+        ),
         // NO lm_head.weight - uses embed_tokens.weight (tied)
     ];
 

--- a/crates/aprender-serve/src/cli/apr_inference.rs
+++ b/crates/aprender-serve/src/cli/apr_inference.rs
@@ -15,11 +15,16 @@ pub fn run_apr_inference(
     verbose: bool,
     trace_config: Option<crate::inference_trace::TraceConfig>,
 ) -> Result<()> {
-    use crate::apr::AprV2Model;
-    use crate::apr_transformer::AprTransformer;
+    use crate::apr::{AprV2Model, MappedAprModel};
+    use crate::gguf::{OwnedQuantizedModel, QuantizedGenerateConfig};
     use crate::inference_trace::{InferenceTracer, ModelInfo, TraceStep};
     use std::path::Path;
     use std::time::Instant;
+
+    // GH-479: CPU path now loads via MappedAprModel + OwnedQuantizedModel (per-tensor
+    // scratch dequant from GH-478) instead of eager F32 AprTransformer. file_data is
+    // unused on both paths but kept in the signature for caller compatibility.
+    let _ = file_data;
 
     // APR-TRACE-001: Create tracer from config
     let mut tracer = trace_config
@@ -41,9 +46,7 @@ pub fn run_apr_inference(
     // Both AprF32ToGpuAdapter and forward_token_apr_q4k produce garbage on GPU.
     #[cfg(feature = "cuda")]
     if force_gpu {
-        use crate::apr::MappedAprModel;
-        use crate::gguf::{OwnedQuantizedModel, OwnedQuantizedModelCuda, QuantizedGenerateConfig};
-        use std::path::Path;
+        use crate::gguf::OwnedQuantizedModelCuda;
 
         let model_path = Path::new(model_ref);
 
@@ -81,27 +84,35 @@ pub fn run_apr_inference(
 
     let load_start = Instant::now();
 
-    // Load APR transformer (CPU path)
-    let transformer = AprTransformer::from_apr_bytes(file_data).map_err(|e| {
+    // GH-479: Load APR via MappedAprModel + OwnedQuantizedModel — per-tensor scratch
+    // dequant avoids eager F32 inflation (GH-478). Replaces AprTransformer::from_apr_bytes.
+    let model_path_for_load = Path::new(model_ref);
+    let mapped = MappedAprModel::from_path(model_path_for_load).map_err(|e| {
         crate::error::RealizarError::UnsupportedOperation {
             operation: "parse_apr".to_string(),
-            reason: format!("Failed to parse APR: {e}"),
+            reason: format!("Failed to map APR file: {e}"),
+        }
+    })?;
+    let model = OwnedQuantizedModel::from_apr(&mapped).map_err(|e| {
+        crate::error::RealizarError::UnsupportedOperation {
+            operation: "parse_apr".to_string(),
+            reason: format!("Failed to load APR as OwnedQuantizedModel: {e}"),
         }
     })?;
 
     // APR-TRACE-001: Set model info
     tracer.set_model_info(ModelInfo {
         name: model_ref.to_string(),
-        num_layers: transformer.config.num_layers,
-        hidden_dim: transformer.config.hidden_dim,
-        vocab_size: transformer.config.vocab_size,
-        num_heads: transformer.config.num_heads,
-        quant_type: Some("APR F32".to_string()),
+        num_layers: model.config.num_layers,
+        hidden_dim: model.config.hidden_dim,
+        vocab_size: model.config.vocab_size,
+        num_heads: model.config.num_heads,
+        quant_type: Some("APR scratch-dequant".to_string()),
     });
 
     let load_time = load_start.elapsed();
     if verbose {
-        println!("Backend: CPU (AVX2 + SIMD)");
+        println!("Backend: CPU (per-tensor scratch dequant)");
         println!("Model loaded in {:.2}ms", load_time.as_secs_f64() * 1000.0);
     }
 
@@ -122,39 +133,41 @@ pub fn run_apr_inference(
         .unwrap_or_else(|| prompt.chars().map(|c| c as u32).collect());
     let prompt_len = prompt_tokens.len();
 
-    tracer.trace_encode(prompt, &prompt_tokens, transformer.config.vocab_size);
+    tracer.trace_encode(prompt, &prompt_tokens, model.config.vocab_size);
 
     if verbose {
         println!("Prompt tokens: {}", prompt_len);
-        println!("Temperature: {:.1} (using greedy decoding)", temperature);
+        println!("Temperature: {:.1}", temperature);
         println!();
     }
 
     // APR-TRACE-001: Trace embedding (approximation - we don't have direct access)
     tracer.start_step(TraceStep::Embed);
-    tracer.trace_embed(prompt_len, transformer.config.hidden_dim, None);
+    tracer.trace_embed(prompt_len, model.config.hidden_dim, None);
 
     // APR-TRACE-001: Trace transformer blocks (high-level, generation is a black box)
     tracer.start_step(TraceStep::TransformerBlock);
 
-    // Run inference with timing
-    // PMAT-103 FIX: Use generate_with_cache for O(n) instead of O(n²) complexity
-    let gen_config = crate::apr_transformer::GenerateConfig {
+    // GH-479: OwnedQuantizedModel::generate_with_cache — O(n) autoregressive decode
+    // with per-tensor scratch dequant on each matmul (no eager F32 inflation).
+    let gen_config = QuantizedGenerateConfig {
         max_tokens,
         temperature,
+        top_k: if temperature == 0.0 { 1 } else { 40 },
+        trace: trace_config.is_some(),
         ..Default::default()
     };
     let gen_start = Instant::now();
-    let generated = transformer.generate_with_cache(&prompt_tokens, &gen_config)?;
+    let generated = model.generate_with_cache(&prompt_tokens, &gen_config)?;
     let gen_time = gen_start.elapsed();
 
     // Record transformer block completion (aggregate timing)
     tracer.trace_layer(
-        transformer.config.num_layers - 1,
+        model.config.num_layers - 1,
         0,
         None,
         1,
-        transformer.config.hidden_dim,
+        model.config.hidden_dim,
     );
 
     let tokens_generated = generated.len().saturating_sub(prompt_len);
@@ -175,7 +188,7 @@ pub fn run_apr_inference(
             .chars()
             .nth(i.min(output_text.len().saturating_sub(1)))
             .map_or_else(|| format!("<{token}>"), |c| c.to_string());
-        tracer.trace_decode(i, token, &decoded, transformer.config.vocab_size);
+        tracer.trace_decode(i, token, &decoded, model.config.vocab_size);
     }
 
     match format {

--- a/crates/aprender-serve/src/cli/mod_server_commands.rs
+++ b/crates/aprender-serve/src/cli/mod_server_commands.rs
@@ -374,28 +374,30 @@ mod server_commands {
             return prepare_gguf_cuda_state_from_apr(model_path);
         }
 
-        // F32 CPU path (original)
-        use crate::apr_transformer::AprTransformer;
-
-        let file_data = std::fs::read(model_path).map_err(|e| {
-            crate::error::RealizarError::UnsupportedOperation {
-                operation: "read_model_file".to_string(),
-                reason: format!("Failed to read {model_path}: {e}"),
-            }
-        })?;
-
-        let transformer = AprTransformer::from_apr_bytes(&file_data).map_err(|e| {
-            crate::error::RealizarError::UnsupportedOperation {
-                operation: "load_apr".to_string(),
-                reason: format!("Failed to load APR: {e}"),
-            }
-        })?;
-
-        println!("  Architecture: {}", transformer.config.architecture);
-        println!("  Layers: {}", transformer.config.num_layers);
-        println!("  Hidden: {}", transformer.config.hidden_dim);
+        // GH-479: CPU path loads via MappedAprModel + OwnedQuantizedModel (per-tensor
+        // scratch dequant from GH-478) instead of eager F32 AprTransformer. Serving
+        // routes through try_quantized_generate (batch.rs) via state.quantized_model().
+        use crate::apr::MappedAprModel;
+        use crate::gguf::OwnedQuantizedModel;
 
         let model_path_obj = Path::new(model_path);
+        let mapped = MappedAprModel::from_path(model_path_obj).map_err(|e| {
+            crate::error::RealizarError::UnsupportedOperation {
+                operation: "load_apr".to_string(),
+                reason: format!("Failed to map APR file {model_path}: {e}"),
+            }
+        })?;
+        let model = OwnedQuantizedModel::from_apr(&mapped).map_err(|e| {
+            crate::error::RealizarError::UnsupportedOperation {
+                operation: "load_apr".to_string(),
+                reason: format!("Failed to load APR as OwnedQuantizedModel: {e}"),
+            }
+        })?;
+
+        println!("  Architecture: {}", model.config.architecture);
+        println!("  Layers: {}", model.config.num_layers);
+        println!("  Hidden: {}", model.config.hidden_dim);
+
         let vocab = crate::apr::AprV2Model::load_tokenizer_from_sibling(model_path_obj)
             .map(|(v, _, _)| v)
             .or_else(|| {
@@ -406,15 +408,15 @@ mod server_commands {
             })
             .unwrap_or_else(|| {
                 println!("  Warning: No vocabulary found, using simple vocabulary");
-                (0..transformer.config.vocab_size)
+                (0..model.config.vocab_size)
                     .map(|i| format!("token{i}"))
                     .collect()
             });
 
         println!("  Vocab size: {}", vocab.len());
-        println!("  Mode: CPU (F32 inference)");
+        println!("  Mode: CPU (per-tensor scratch dequant)");
 
-        let state = crate::api::AppState::with_apr_transformer_and_vocab(transformer, vocab)?;
+        let state = crate::api::AppState::with_quantized_model_and_vocab(model, vocab)?;
 
         Ok(PreparedServer {
             state,


### PR DESCRIPTION
## Summary
- Migrate two production CPU APR inference call sites from eager F32 dequant (`AprTransformer::from_apr_bytes`) to per-tensor scratch dequant (`OwnedQuantizedModel::from_apr`), matching the production CUDA path and roughly halving CPU RAM pressure for APR models
- Also fixes the `build_executable_pygmy_apr` test fixture to use GH-317 canonical HF tensor names (`model.layers.N.*`) — the legacy fixture used bare `layers.N.*` which only worked because `AprTransformer::from_apr_bytes` silently zero-defaulted missing tensors

## Call sites migrated
- `crates/aprender-serve/src/cli/apr_inference.rs::run_apr_inference` — CPU branch now loads via `MappedAprModel::from_path` + `OwnedQuantizedModel::from_apr` and generates with `QuantizedGenerateConfig` + `generate_with_cache`
- `crates/aprender-serve/src/cli/mod_server_commands.rs::prepare_apr_serve_state` — CPU branch now installs via `AppState::with_quantized_model_and_vocab`; serving routes through `try_quantized_generate` (runs before `try_apr_generate` in batch dispatch)

## Deferred to follow-up
- `crates/aprender-serve/src/gguf/chat_generate_session_02.rs` still uses `AprTransformer` directly; needs a session-level CPU cache design change, not a drop-in swap — left for a separate ticket

## Test plan
- [x] `cargo test -p aprender-serve --lib` — 15,097 pass (CLI inference tests, cross-format fixture tests, serving dispatch tests)
- [x] `cargo fmt -p aprender-serve -- --check` clean
- [x] `cargo clippy -p aprender-serve --lib -- -D warnings` clean
- [ ] CI gate + workspace-test green

🤖 Generated with [Claude Code](https://claude.com/claude-code)