### PR TITLE
feat(apr-cli): chat session APR CPU path uses per-tensor scratch dequant (GH-479)

### DIFF
--- a/crates/apr-cli/src/commands/chat_generate_session_02.rs
+++ b/crates/apr-cli/src/commands/chat_generate_session_02.rs
@@ -334,23 +334,26 @@ impl ChatSession {
                 }
             }
 
-            // CPU path using AprTransformer (has temperature/top_p sampling + KV cache)
-            use realizar::apr_transformer::{AprTransformer, GenerateConfig};
+            // GH-479: CPU path now loads via MappedAprModel + OwnedQuantizedModel
+            // (per-tensor scratch dequant from GH-478) instead of eager F32 AprTransformer.
+            use realizar::apr::MappedAprModel;
+            use realizar::gguf::{OwnedQuantizedModel, QuantizedGenerateConfig};
 
-            let transformer = AprTransformer::from_apr_bytes(&self.model_bytes)
-                .map_err(|e| format!("Failed to load APR transformer: {e}"))?;
+            let mapped = MappedAprModel::from_path(&self.model_path)
+                .map_err(|e| format!("Failed to mmap APR: {e}"))?;
+            let model = OwnedQuantizedModel::from_apr(&mapped)
+                .map_err(|e| format!("Failed to load APR model: {e}"))?;
 
-            let gen_config = GenerateConfig {
+            let gen_config = QuantizedGenerateConfig {
                 max_tokens: config.max_tokens,
                 temperature: config.temperature,
                 top_p: config.top_p,
-                top_k: 0,
-                repetition_penalty: 1.0,
+                top_k: if config.temperature == 0.0 { 1 } else { 40 },
                 trace: config.trace,
-                stop_tokens: vec![],
+                ..Default::default()
             };
 
-            transformer
+            model
                 .generate_with_cache(prompt, &gen_config)
                 .map_err(|e| format!("APR generate failed: {e}"))
         }


### PR DESCRIPTION
## Summary
- Drop-in follow-up to #753 — migrates the chat session's APR CPU branch from `AprTransformer::from_apr_bytes(&self.model_bytes)` (eager F32 dequant of the full model per user message) to `MappedAprModel::from_path(&self.model_path)` + `OwnedQuantizedModel::from_apr(&mapped)` (per-tensor scratch dequant from GH-478).
- `QuantizedGenerateConfig` preserves temperature/top_p semantics; `top_k` follows PR #753 convention (1 when greedy, 40 otherwise). CUDA branch unchanged.
- Scope: 1 file, 12+/9-.

## Test plan
- [x] `cargo check -p apr-cli --features inference` — clean
- [x] `cargo clippy -p apr-cli --features inference --lib -- -D warnings` — clean
- [x] `cargo test -p apr-cli --features inference --lib` — 4,675 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)