### PR TITLE
refactor: split einsum_binary CC 13 → 5

### DIFF
--- a/crates/aprender-tensor/src/einsum.rs
+++ b/crates/aprender-tensor/src/einsum.rs
@@ -295,53 +295,22 @@ fn increment_indices(indices: &mut [usize], sizes: &[usize]) {
 /// Binary einsum (the core 2-input implementation).
 fn einsum_binary(subscripts: &str, a: &Tensor, b: &Tensor) -> Result<Tensor, TensorError> {
     let plan = parse_subscripts(subscripts)?;
-
     if plan.input_labels.len() != 2 {
         return Err(TensorError::InvalidSubscript(
             "binary einsum requires exactly 2 input operands in subscript".into(),
         ));
     }
 
-    let inputs = [a, b];
-    let index_sizes = build_index_sizes(&plan, &inputs)?;
-
+    let index_sizes = build_index_sizes(&plan, &[a, b])?;
     let a_labels = &plan.input_labels[0];
     let b_labels = &plan.input_labels[1];
     let out_labels = &plan.output_labels;
 
-    // Identify contracted indices (in inputs but not in output)
-    let contracted: Vec<char> = {
-        let mut c = Vec::new();
-        for &label in a_labels {
-            if !out_labels.contains(&label) && !c.contains(&label) {
-                c.push(label);
-            }
-        }
-        for &label in b_labels {
-            if !out_labels.contains(&label) && !c.contains(&label) {
-                c.push(label);
-            }
-        }
-        c
-    };
+    let contracted = collect_contracted_indices(a_labels, b_labels, out_labels);
+    validate_contracted_in_both(&contracted, a_labels, b_labels)?;
 
-    // Validate contracted indices appear in both tensors
-    for &c in &contracted {
-        let in_a = a_labels.contains(&c);
-        let in_b = b_labels.contains(&c);
-        if !in_a || !in_b {
-            return Err(TensorError::InvalidSubscript(format!(
-                "contracted index '{c}' must appear in both inputs"
-            )));
-        }
-    }
-
-    // Compute output shape
     let out_shape: Vec<usize> = out_labels.iter().map(|l| index_sizes[l]).collect();
-
     let mut output = Tensor::zeros(out_shape);
-
-    // Compute contraction via explicit nested iteration
     contract_tensors(
         a,
         b,
@@ -352,8 +321,40 @@ fn einsum_binary(subscripts: &str, a: &Tensor, b: &Tensor) -> Result<Tensor, Ten
         &contracted,
         &index_sizes,
     );
-
     Ok(output)
+}
+
+/// Return labels appearing in either input but not in the output (input order, deduped).
+fn collect_contracted_indices(
+    a_labels: &[char],
+    b_labels: &[char],
+    out_labels: &[char],
+) -> Vec<char> {
+    let mut contracted = Vec::new();
+    for labels in [a_labels, b_labels] {
+        for &label in labels {
+            if !out_labels.contains(&label) && !contracted.contains(&label) {
+                contracted.push(label);
+            }
+        }
+    }
+    contracted
+}
+
+/// Reject subscripts where a contracted index appears in only one operand.
+fn validate_contracted_in_both(
+    contracted: &[char],
+    a_labels: &[char],
+    b_labels: &[char],
+) -> Result<(), TensorError> {
+    for &c in contracted {
+        if !a_labels.contains(&c) || !b_labels.contains(&c) {
+            return Err(TensorError::InvalidSubscript(format!(
+                "contracted index '{c}' must appear in both inputs"
+            )));
+        }
+    }
+    Ok(())
 }
 
 /// Core contraction loop: iterate over all output and contracted indices.


### PR DESCRIPTION
## Summary
- Split `einsum_binary` CC 13 → 5 in `crates/aprender-tensor/src/einsum.rs`
- Extract `collect_contracted_indices` (iterates both label vecs, input-order dedupe) and `validate_contracted_in_both`
- Collapse 2-operand scratch array `[a, b]` directly into `build_index_sizes` call

## Complexity (pmat analyze complexity)
- Before: `einsum_binary` CC=13
- After: `einsum_binary` CC=5; helpers CC=4,5

## Behavior Preservation
- Same contracted-index order (a_labels first, then b_labels, deduped)
- Same "must appear in both inputs" error message
- All 16 `einsum` tests pass

## Test plan
- [x] `cargo check -p aprender-tensor` — clean
- [x] `cargo test -p aprender-tensor --lib einsum` — 16 passed, 0 failed
- [x] `pmat analyze complexity` — CC=5

🤖 Generated with [Claude Code](https://claude.com/claude-code)