### PR TITLE
refactor: split CorpusMerger::merge CC 16 -> 3

### DIFF
--- a/crates/aprender-core/src/online/corpus_merger.rs
+++ b/crates/aprender-core/src/online/corpus_merger.rs
@@ -78,80 +78,103 @@ impl CorpusMerger {
     /// Merge all sources into unified dataset
     pub fn merge(&self) -> Result<(CorpusBuffer, CorpusProvenance)> {
         let mut provenance = CorpusProvenance::new();
-        let mut all_samples: Vec<(Sample, u8)> = Vec::new(); // (sample, priority)
+        let mut all_samples: Vec<(Sample, u8)> = Vec::new();
 
-        // Collect all samples with weights applied
         for source in &self.sources {
-            let original_count = source.samples.len();
-            let effective_count = (original_count as f64 * source.weight).round() as usize;
-
-            // Sample with replacement if weight > 1, otherwise take all
-            if source.weight >= 1.0 {
-                // Take all and potentially repeat
-                let repeats = source.weight.floor() as usize;
-                let remainder = source.weight.fract();
-
-                for sample in &source.samples {
-                    for _ in 0..repeats {
-                        let mut s = sample.clone();
-                        s.weight *= source.weight;
-                        all_samples.push((s, source.priority));
-                    }
-                }
-
-                // Partial sampling for remainder
-                let extra = (source.samples.len() as f64 * remainder).round() as usize;
-                for sample in source.samples.iter().take(extra) {
-                    let mut s = sample.clone();
-                    s.weight *= source.weight;
-                    all_samples.push((s, source.priority));
-                }
-            } else {
-                // Subsample
-                let take = (source.samples.len() as f64 * source.weight).round() as usize;
-                for sample in source.samples.iter().take(take) {
-                    all_samples.push((sample.clone(), source.priority));
-                }
-            }
-
-            provenance.add_source(&source.name, original_count, effective_count);
+            collect_source_samples(source, &mut all_samples, &mut provenance);
         }
 
-        // Sort by priority (higher first) for deduplication
+        // Sort by priority (higher first) so dedup keeps the highest-priority copy.
         all_samples.sort_by(|a, b| b.1.cmp(&a.1));
 
-        // Create buffer and deduplicate
+        let (mut buffer, duplicates) = self.build_buffer(&all_samples);
+        provenance.duplicates_removed = duplicates;
+        provenance.set_final_size(buffer.len());
+
+        if let Some(seed) = self.shuffle_seed {
+            shuffle_buffer(&mut buffer, seed);
+        }
+
+        Ok((buffer, provenance))
+    }
+
+    fn build_buffer(
+        &self,
+        all_samples: &[(Sample, u8)],
+    ) -> (CorpusBuffer, usize) {
         let config = CorpusBufferConfig {
             max_size: all_samples.len(),
             deduplicate: self.deduplicate,
             policy: EvictionPolicy::FIFO,
             seed: self.shuffle_seed,
         };
-
         let mut buffer = CorpusBuffer::with_config(config);
         let mut duplicates = 0;
-
         for (sample, _) in all_samples {
-            if !buffer.add(sample) {
+            if !buffer.add(sample.clone()) {
                 duplicates += 1;
             }
         }
+        (buffer, duplicates)
+    }
+}
 
-        provenance.duplicates_removed = duplicates;
-        provenance.set_final_size(buffer.len());
+/// Expand one source's samples into the merge buffer per its `weight` and
+/// record the provenance row.
+fn collect_source_samples(
+    source: &CorpusSource,
+    all_samples: &mut Vec<(Sample, u8)>,
+    provenance: &mut CorpusProvenance,
+) {
+    let original_count = source.samples.len();
+    let effective_count = (original_count as f64 * source.weight).round() as usize;
 
-        // Shuffle if seed provided
-        if let Some(seed) = self.shuffle_seed {
-            buffer.rng_state = seed;
-            // Simple Fisher-Yates shuffle
-            let n = buffer.samples.len();
-            for i in (1..n).rev() {
-                let j = (buffer.next_random() as usize) % (i + 1);
-                buffer.samples.swap(i, j);
-            }
+    if source.weight >= 1.0 {
+        expand_oversampled_source(source, all_samples);
+    } else {
+        subsample_source(source, all_samples);
+    }
+
+    provenance.add_source(&source.name, original_count, effective_count);
+}
+
+/// Oversample: replicate each sample `floor(weight)` times then add a
+/// partial pass for the fractional remainder.
+fn expand_oversampled_source(source: &CorpusSource, all_samples: &mut Vec<(Sample, u8)>) {
+    let repeats = source.weight.floor() as usize;
+    let remainder = source.weight.fract();
+
+    for sample in &source.samples {
+        for _ in 0..repeats {
+            let mut s = sample.clone();
+            s.weight *= source.weight;
+            all_samples.push((s, source.priority));
         }
+    }
 
-        Ok((buffer, provenance))
+    let extra = (source.samples.len() as f64 * remainder).round() as usize;
+    for sample in source.samples.iter().take(extra) {
+        let mut s = sample.clone();
+        s.weight *= source.weight;
+        all_samples.push((s, source.priority));
+    }
+}
+
+/// Subsample: take the leading `len * weight` samples without re-weighting.
+fn subsample_source(source: &CorpusSource, all_samples: &mut Vec<(Sample, u8)>) {
+    let take = (source.samples.len() as f64 * source.weight).round() as usize;
+    for sample in source.samples.iter().take(take) {
+        all_samples.push((sample.clone(), source.priority));
+    }
+}
+
+/// In-place Fisher-Yates shuffle seeded by `seed`.
+fn shuffle_buffer(buffer: &mut CorpusBuffer, seed: u64) {
+    buffer.rng_state = seed;
+    let n = buffer.samples.len();
+    for i in (1..n).rev() {
+        let j = (buffer.next_random() as usize) % (i + 1);
+        buffer.samples.swap(i, j);
     }
 }
 


### PR DESCRIPTION
## Summary
- Extract five helpers: `collect_source_samples` (CC=3), `expand_oversampled_source` (CC=4), `subsample_source` (CC=2), `build_buffer` (CC=3), `shuffle_buffer` (CC=2)
- Oversample (weight≥1) and subsample (weight<1) paths now read as separate single-purpose functions

## Verification
- 47 online::corpus tests pass
- 420 online module tests pass

Drives Gate 10 V4 progress (CC>10 elimination tier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)