### PR TITLE
refactor: split output_flags + output_architecture CC 13 → ≤4

### DIFF
--- a/crates/apr-cli/src/commands/inspect_output_json.rs
+++ b/crates/apr-cli/src/commands/inspect_output_json.rs
@@ -101,38 +101,7 @@ fn flags_from_header(header: &HeaderData) -> FlagsInfo {
 }
 
 fn output_flags(header: &HeaderData) {
-    let mut flag_list = Vec::new();
-    if header.flags.is_lz4_compressed() {
-        flag_list.push("LZ4");
-    }
-    if header.flags.is_zstd_compressed() {
-        flag_list.push("ZSTD");
-    }
-    if header.flags.is_encrypted() {
-        flag_list.push("ENCRYPTED");
-    }
-    if header.flags.contains(AprV2Flags::SIGNED) {
-        flag_list.push("SIGNED");
-    }
-    if header.flags.is_sharded() {
-        flag_list.push("SHARDED");
-    }
-    if header.flags.is_quantized() {
-        flag_list.push("QUANTIZED");
-    }
-    if header.flags.contains(AprV2Flags::HAS_VOCAB) {
-        flag_list.push("HAS_VOCAB");
-    }
-    if header.flags.contains(AprV2Flags::HAS_FILTERBANK) {
-        flag_list.push("HAS_FILTERBANK");
-    }
-    if header.flags.contains(AprV2Flags::HAS_MODEL_CARD) {
-        flag_list.push("HAS_MODEL_CARD");
-    }
-    if header.flags.contains(AprV2Flags::STREAMING) {
-        flag_list.push("STREAMING");
-    }
-
+    let flag_list = collect_flag_labels(header);
     if flag_list.is_empty() {
         output::kv("Flags", "(none)");
     } else {
@@ -140,12 +109,31 @@ fn output_flags(header: &HeaderData) {
     }
 }
 
+/// Ordered list of (predicate, label) pairs. Order here is the display order.
+fn collect_flag_labels(header: &HeaderData) -> Vec<&'static str> {
+    type Pred = fn(&HeaderData) -> bool;
+    const TABLE: &[(Pred, &str)] = &[
+        (|h| h.flags.is_lz4_compressed(), "LZ4"),
+        (|h| h.flags.is_zstd_compressed(), "ZSTD"),
+        (|h| h.flags.is_encrypted(), "ENCRYPTED"),
+        (|h| h.flags.contains(AprV2Flags::SIGNED), "SIGNED"),
+        (|h| h.flags.is_sharded(), "SHARDED"),
+        (|h| h.flags.is_quantized(), "QUANTIZED"),
+        (|h| h.flags.contains(AprV2Flags::HAS_VOCAB), "HAS_VOCAB"),
+        (|h| h.flags.contains(AprV2Flags::HAS_FILTERBANK), "HAS_FILTERBANK"),
+        (|h| h.flags.contains(AprV2Flags::HAS_MODEL_CARD), "HAS_MODEL_CARD"),
+        (|h| h.flags.contains(AprV2Flags::STREAMING), "STREAMING"),
+    ];
+    TABLE
+        .iter()
+        .filter_map(|(pred, label)| pred(header).then_some(*label))
+        .collect()
+}
+
 fn output_architecture(metadata: &MetadataInfo) {
-    // Only show architecture section if we have transformer config
     let has_arch_info = metadata.architecture.is_some()
         || metadata.hidden_size.is_some()
         || metadata.num_layers.is_some();
-
     if !has_arch_info {
         return;
     }
@@ -157,26 +145,22 @@ fn output_architecture(metadata: &MetadataInfo) {
     if let Some(p) = metadata.param_count {
         println!("    Parameters: {}", format_param_count(p));
     }
-    if let Some(h) = metadata.hidden_size {
-        println!("    Hidden Size: {h}");
-    }
-    if let Some(n) = metadata.num_layers {
-        println!("    Layers: {n}");
-    }
-    if let Some(n) = metadata.num_heads {
-        println!("    Attention Heads: {n}");
-    }
-    if let Some(n) = metadata.num_kv_heads {
-        println!("    KV Heads: {n}");
-    }
-    if let Some(i) = metadata.intermediate_size {
-        println!("    Intermediate Size: {i}");
-    }
-    if let Some(v) = metadata.vocab_size {
-        println!("    Vocab Size: {v}");
-    }
-    if let Some(m) = metadata.max_position_embeddings {
-        println!("    Max Position: {m}");
+    print_arch_numeric_fields(metadata);
+}
+
+fn print_arch_numeric_fields(metadata: &MetadataInfo) {
+    for (label, value) in [
+        ("Hidden Size", metadata.hidden_size),
+        ("Layers", metadata.num_layers),
+        ("Attention Heads", metadata.num_heads),
+        ("KV Heads", metadata.num_kv_heads),
+        ("Intermediate Size", metadata.intermediate_size),
+        ("Vocab Size", metadata.vocab_size),
+        ("Max Position", metadata.max_position_embeddings),
+    ] {
+        if let Some(v) = value {
+            println!("    {label}: {v}");
+        }
     }
     if let Some(r) = metadata.rope_theta {
         println!("    RoPE Theta: {r}");


### PR DESCRIPTION
## Summary
Two CC hotspots in `apr-cli/src/commands/inspect_output_json.rs`.

### output_flags CC 13 → 2
Extract `collect_flag_labels` with a `(predicate, label)` table. Ten sequential `if` blocks collapse into `filter_map + then_some`. Order preserved.

### output_architecture CC 13 → 4
Pull seven `Some(..)`-string numeric fields into `print_arch_numeric_fields` as a single `for` loop over a `(label, value)` tuple slice. `rope_theta` stays inline because it prints a float, not a count.

## Test plan
- [x] `cargo build -p apr-cli` — clean
- [x] `pmat analyze complexity` — both functions below CC 5
- [x] Output format preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)