### PR TITLE
refactor: split parse_trailing_blocks CC 12 → 5

### DIFF
--- a/crates/aprender-data/src/format/mod.rs
+++ b/crates/aprender-data/src/format/mod.rs
@@ -985,56 +985,81 @@ fn parse_trailing_blocks(
     checksum_offset: usize,
     options: &LoadOptions,
 ) -> Result<(Option<[u8; 32]>, Option<license::LicenseBlock>)> {
-    #[allow(unused_mut)]
     let mut trailing_offset = payload_end;
-    #[allow(unused_mut)]
-    let mut signer_public_key: Option<[u8; 32]> = None;
-    let mut license_block: Option<license::LicenseBlock> = None;
 
-    if header.is_signed() {
-        #[cfg(feature = "format-signing")]
-        {
-            let sig_end = trailing_offset + signing::SignatureBlock::SIZE;
-            if sig_end > checksum_offset {
-                return Err(Error::Format(
-                    "Signature block extends beyond data".to_string(),
-                ));
-            }
+    let signer_public_key = if header.is_signed() {
+        parse_signature_block(all_data, &mut trailing_offset, checksum_offset, options)?
+    } else {
+        None
+    };
 
-            let sig_block =
-                signing::SignatureBlock::from_bytes(&all_data[trailing_offset..sig_end])?;
-
-            if !options.trusted_keys.is_empty() {
-                let signed_data = &all_data[..trailing_offset];
-                if !options.trusted_keys.contains(&sig_block.public_key) {
-                    return Err(Error::Format("Signer not in trusted keys list".to_string()));
-                }
-                sig_block.verify(signed_data)?;
-            }
-
-            signer_public_key = Some(sig_block.public_key);
-            trailing_offset = sig_end;
-        }
-        #[cfg(not(feature = "format-signing"))]
-        {
-            return Err(Error::Format(
-                "Dataset is signed but format-signing feature is not enabled".to_string(),
-            ));
-        }
-    }
-
-    if header.is_licensed() {
-        if trailing_offset >= checksum_offset {
-            return Err(Error::Format("Missing license block".to_string()));
-        }
-        let lic = license::LicenseBlock::from_bytes(&all_data[trailing_offset..checksum_offset])?;
-        if options.verify_license {
-            lic.verify()?;
-        }
-        license_block = Some(lic);
-    }
+    let license_block = if header.is_licensed() {
+        Some(parse_license_block(
+            all_data,
+            trailing_offset,
+            checksum_offset,
+            options,
+        )?)
+    } else {
+        None
+    };
 
     Ok((signer_public_key, license_block))
+}
+
+#[cfg(feature = "format-signing")]
+fn parse_signature_block(
+    all_data: &[u8],
+    trailing_offset: &mut usize,
+    checksum_offset: usize,
+    options: &LoadOptions,
+) -> Result<Option<[u8; 32]>> {
+    let sig_end = *trailing_offset + signing::SignatureBlock::SIZE;
+    if sig_end > checksum_offset {
+        return Err(Error::Format(
+            "Signature block extends beyond data".to_string(),
+        ));
+    }
+
+    let sig_block = signing::SignatureBlock::from_bytes(&all_data[*trailing_offset..sig_end])?;
+
+    if !options.trusted_keys.is_empty() {
+        if !options.trusted_keys.contains(&sig_block.public_key) {
+            return Err(Error::Format("Signer not in trusted keys list".to_string()));
+        }
+        sig_block.verify(&all_data[..*trailing_offset])?;
+    }
+
+    *trailing_offset = sig_end;
+    Ok(Some(sig_block.public_key))
+}
+
+#[cfg(not(feature = "format-signing"))]
+fn parse_signature_block(
+    _all_data: &[u8],
+    _trailing_offset: &mut usize,
+    _checksum_offset: usize,
+    _options: &LoadOptions,
+) -> Result<Option<[u8; 32]>> {
+    Err(Error::Format(
+        "Dataset is signed but format-signing feature is not enabled".to_string(),
+    ))
+}
+
+fn parse_license_block(
+    all_data: &[u8],
+    trailing_offset: usize,
+    checksum_offset: usize,
+    options: &LoadOptions,
+) -> Result<license::LicenseBlock> {
+    if trailing_offset >= checksum_offset {
+        return Err(Error::Format("Missing license block".to_string()));
+    }
+    let lic = license::LicenseBlock::from_bytes(&all_data[trailing_offset..checksum_offset])?;
+    if options.verify_license {
+        lic.verify()?;
+    }
+    Ok(lic)
 }
 
 /// Decompress a payload buffer using the specified compression method.


### PR DESCRIPTION
## Summary

Gate 10 V4 CC>10 hotspot elimination in `crates/aprender-data/src/format/mod.rs`.

`parse_trailing_blocks` did two conceptually separate jobs — signature block parsing and license block parsing — with inline `#[cfg(feature = \"format-signing\")]` branching inflating complexity.

Extract `parse_signature_block` (gated by `format-signing`) and `parse_license_block` as free functions. Main function now orchestrates two optional phases with if-let expressions.

**CC**:
- `parse_trailing_blocks` 12 → 5
- `parse_signature_block` 6 (feature-on) / 1 (feature-off)
- `parse_license_block` 5

## Test plan
- [x] `cargo test -p aprender-data --lib` — 1820 passing, 0 failed
- [x] `cargo test -p aprender-data --lib --features format-signing` — 1837 passing, 0 failed
- [x] `pmat analyze complexity` — all helpers ≤6, main ≤5

🤖 Generated with [Claude Code](https://claude.com/claude-code)