### PR TITLE
refactor(cli): reduce detect_size_from_inspection CC 13 → <5

### DIFF
--- a/crates/apr-cli/src/commands/oracle_family.rs
+++ b/crates/apr-cli/src/commands/oracle_family.rs
@@ -214,56 +214,63 @@ fn detect_size_from_inspection(
     family: &dyn ModelFamily,
     report: &aprender::format::rosetta::InspectionReport,
 ) -> Option<SizeVariantInfo> {
-    // Try to extract hidden_dim from metadata
-    let hidden_dim = report
+    let hidden_dim = hidden_dim_from_metadata(report).or_else(|| hidden_dim_from_tensors(report))?;
+    let num_layers = num_layers_from_metadata(report).or_else(|| num_layers_from_tensors(report))?;
+    let size_name = family.detect_size(hidden_dim, num_layers)?;
+    let sc = family.size_config(&size_name)?;
+    Some(build_size_info(&size_name, sc, family))
+}
+
+fn hidden_dim_from_metadata(report: &aprender::format::rosetta::InspectionReport) -> Option<usize> {
+    report
         .metadata
         .get("hidden_size")
         .or_else(|| report.metadata.get("embedding_length"))
         .or_else(|| report.metadata.get("hidden_dim"))
-        .and_then(|v| v.parse::<usize>().ok());
+        .and_then(|v| v.parse::<usize>().ok())
+}
 
-    let num_layers = report
+fn num_layers_from_metadata(report: &aprender::format::rosetta::InspectionReport) -> Option<usize> {
+    report
         .metadata
         .get("num_hidden_layers")
         .or_else(|| report.metadata.get("block_count"))
         .or_else(|| report.metadata.get("num_layers"))
-        .and_then(|v| v.parse::<usize>().ok());
+        .and_then(|v| v.parse::<usize>().ok())
+}
 
-    // Also try to infer from tensor shapes (embedding shape[1] = hidden_dim)
-    let hidden_from_tensors = report.tensors.iter().find_map(|t| {
+/// Infer hidden dim from 2D embedding-tensor shape: `shape[1]`.
+fn hidden_dim_from_tensors(report: &aprender::format::rosetta::InspectionReport) -> Option<usize> {
+    report.tensors.iter().find_map(|t| {
         if t.name.contains("embed") && t.shape.len() == 2 {
             Some(t.shape[1])
         } else {
             None
         }
-    });
+    })
+}
 
-    let layers_from_tensors = {
-        let mut max_layer: Option<usize> = None;
-        for t in &report.tensors {
-            // Match patterns like "layers.N." or "blk.N."
-            if let Some(rest) = t
-                .name
-                .strip_prefix("model.layers.")
-                .or_else(|| t.name.strip_prefix("blk."))
-                .or_else(|| t.name.strip_prefix("encoder.layers."))
-            {
-                if let Some(dot_pos) = rest.find('.') {
-                    if let Ok(n) = rest[..dot_pos].parse::<usize>() {
-                        max_layer = Some(max_layer.map_or(n, |m: usize| m.max(n)));
-                    }
-                }
-            }
-        }
-        max_layer.map(|m| m + 1) // 0-indexed → count
-    };
-
-    let h = hidden_dim.or(hidden_from_tensors)?;
-    let l = num_layers.or(layers_from_tensors)?;
-
-    let size_name = family.detect_size(h, l)?;
-    let sc = family.size_config(&size_name)?;
-    Some(build_size_info(&size_name, sc, family))
+/// Infer layer count by scanning "model.layers.N.", "blk.N.", or "encoder.layers.N." prefixes.
+fn num_layers_from_tensors(report: &aprender::format::rosetta::InspectionReport) -> Option<usize> {
+    let mut max_layer: Option<usize> = None;
+    for t in &report.tensors {
+        let Some(rest) = t
+            .name
+            .strip_prefix("model.layers.")
+            .or_else(|| t.name.strip_prefix("blk."))
+            .or_else(|| t.name.strip_prefix("encoder.layers."))
+        else {
+            continue;
+        };
+        let Some(dot_pos) = rest.find('.') else {
+            continue;
+        };
+        let Ok(n) = rest[..dot_pos].parse::<usize>() else {
+            continue;
+        };
+        max_layer = Some(max_layer.map_or(n, |m: usize| m.max(n)));
+    }
+    max_layer.map(|m| m + 1) // 0-indexed → count
 }
 
 fn build_compliance(


### PR DESCRIPTION
## Summary

Gate 10 V4 CC>10 hotspot cleanup for \`apr-cli/src/commands/oracle_family.rs\`.

Extracts four narrowly-scoped inference helpers:
- \`hidden_dim_from_metadata\` / \`num_layers_from_metadata\`: triple-alias metadata lookups
- \`hidden_dim_from_tensors\`: shape-based inference via embedding tensor
- \`num_layers_from_tensors\`: layer-prefix scan, flattened with let-else

Main function becomes a 5-line fallback chain (CC < 5).

## Validation

- \`cargo build -p apr-cli\`: clean
- \`cargo test -p apr-cli --lib\`: 4675 passed
- \`pmat analyze complexity\`: detect_size_from_inspection no longer appears in CC≥5 list

## Test plan

- [x] Build clean
- [x] Tests pass
- [x] CC verified via pmat
- [ ] CI green
- [ ] Auto-merge on green

🤖 Generated with [Claude Code](https://claude.com/claude-code)