### PR TITLE
refactor(serve): reduce DegradationManager::update_mode CC 11 → 1

### DIFF
--- a/crates/aprender-serve/src/gpu/mod_max_error_recovery.rs
+++ b/crates/aprender-serve/src/gpu/mod_max_error_recovery.rs
@@ -225,21 +225,31 @@ impl DegradationManager {
     }
 
     fn update_mode(&mut self) {
-        self.mode = if !self.gpu_available {
-            DegradationMode::CpuFallback
-        } else if self.latency_priority {
-            DegradationMode::LowLatency
-        } else if self.memory_pressure > 0.8 {
-            DegradationMode::MemoryPressure
-        } else if let Some(load) = &self.system_load {
-            if load.cpu_percent > 90.0 || load.memory_percent > 80.0 {
-                DegradationMode::MemoryPressure
-            } else {
-                DegradationMode::Normal
-            }
-        } else {
-            DegradationMode::Normal
-        };
+        self.mode = self.compute_mode();
+    }
+
+    /// Compute the degradation mode from current telemetry (priority order).
+    fn compute_mode(&self) -> DegradationMode {
+        if !self.gpu_available {
+            return DegradationMode::CpuFallback;
+        }
+        if self.latency_priority {
+            return DegradationMode::LowLatency;
+        }
+        if self.memory_pressure > 0.8 {
+            return DegradationMode::MemoryPressure;
+        }
+        if self.system_load_saturated() {
+            return DegradationMode::MemoryPressure;
+        }
+        DegradationMode::Normal
+    }
+
+    /// True iff observed system load exceeds the CPU/memory saturation thresholds.
+    fn system_load_saturated(&self) -> bool {
+        self.system_load
+            .as_ref()
+            .is_some_and(|load| load.cpu_percent > 90.0 || load.memory_percent > 80.0)
     }
 }
 


### PR DESCRIPTION
## Summary

Gate 10 V4 CC>10 hotspot cleanup for \`aprender-serve/src/gpu/mod_max_error_recovery.rs\`.

Extracts two methods from the nested if-let-or chain in \`DegradationManager::update_mode\`:

- \`compute_mode()\`: pure priority-ordered guard chain (CC=5)
- \`system_load_saturated()\`: Option-sourced saturation predicate via \`is_some_and\` (CC=3)

Main becomes a 1-line assignment. Behavior preserved.

## Validation

- \`cargo build -p aprender-serve\`: clean
- \`cargo test -p aprender-serve --lib\`: 15096 passed
- \`pmat analyze complexity\`: update_mode no longer in CC≥5 list

## Test plan

- [x] Build clean
- [x] Tests pass
- [x] CC verified via pmat
- [ ] CI green
- [ ] Auto-merge on green

🤖 Generated with [Claude Code](https://claude.com/claude-code)