### PR TITLE
refactor(data): save CC 28 → 7 via 9-helper extraction

### DIFF
--- a/crates/aprender-data/src/doctest/parser.rs
+++ b/crates/aprender-data/src/doctest/parser.rs
@@ -438,9 +438,10 @@ fn looks_like_code_output(trimmed: &str) -> bool {
         || trimmed.starts_with('(')
 }
 
-/// Returns true if a line looks like a continuation of a prose paragraph
-/// (lowercase first word, not a field/header marker) rather than the start
-/// of a new section, so multi-line descriptions merge correctly.
+/// Returns true if `line` looks like a continuation of a prose paragraph.
+///
+/// Lowercase first word with no field/header marker indicates the line should
+/// be merged into the preceding description rather than starting a new section.
 #[must_use]
 pub fn is_prose_continuation(line: &str) -> bool {
     let trimmed = line.trim();

--- a/crates/aprender-data/src/doctest/parser.rs
+++ b/crates/aprender-data/src/doctest/parser.rs
@@ -438,6 +438,9 @@ fn looks_like_code_output(trimmed: &str) -> bool {
         || trimmed.starts_with('(')
 }
 
+/// Returns true if a line looks like a continuation of a prose paragraph
+/// (lowercase first word, not a field/header marker) rather than the start
+/// of a new section, so multi-line descriptions merge correctly.
 #[must_use]
 pub fn is_prose_continuation(line: &str) -> bool {
     let trimmed = line.trim();

--- a/crates/aprender-data/src/format/mod.rs
+++ b/crates/aprender-data/src/format/mod.rs
@@ -605,83 +605,30 @@ impl LoadOptions {
 /// # Errors
 ///
 /// Returns error if serialization or I/O fails.
-#[allow(clippy::cast_possible_truncation, clippy::too_many_lines)]
+#[allow(clippy::cast_possible_truncation)]
 pub fn save<W: std::io::Write>(
     writer: &mut W,
     batches: &[arrow::array::RecordBatch],
     dataset_type: DatasetType,
     options: &SaveOptions,
 ) -> Result<()> {
-    use arrow::ipc::writer::StreamWriter;
-
     if batches.is_empty() {
         return Err(Error::EmptyDataset);
     }
 
     let schema = batches[0].schema();
-
-    // Serialize schema via Arrow IPC
-    let mut schema_buf = Vec::new();
-    {
-        let mut schema_writer =
-            StreamWriter::try_new(&mut schema_buf, &schema).map_err(Error::Arrow)?;
-        schema_writer.finish().map_err(Error::Arrow)?;
-    }
-
-    // Serialize payload via Arrow IPC
-    let mut payload_buf = Vec::new();
-    {
-        let mut payload_writer =
-            StreamWriter::try_new(&mut payload_buf, &schema).map_err(Error::Arrow)?;
-        for batch in batches {
-            payload_writer.write(batch).map_err(Error::Arrow)?;
-        }
-        payload_writer.finish().map_err(Error::Arrow)?;
-    }
-
+    let schema_buf = serialize_arrow_schema(&schema)?;
+    let payload_buf = serialize_arrow_payload(batches, &schema)?;
     let uncompressed_size = payload_buf.len() as u32;
-
-    // Compress payload if needed
     let compressed_payload = compress_payload(payload_buf, options.compression)?;
 
-    // Build flags
     let mut header_flags: u8 = 0;
+    let (final_payload, encryption_header) =
+        apply_encryption_if_requested(compressed_payload, options, &mut header_flags)?;
+    update_header_flags(&mut header_flags, options);
 
-    // Encryption: build block, split into header and ciphertext payload
-    #[cfg(feature = "format-encryption")]
-    let (final_payload, encryption_header) = if let Some(ref enc_params) = options.encryption {
-        header_flags |= flags::ENCRYPTED;
-        let block = build_encryption_block(&compressed_payload, enc_params)?;
-        let hdr_size = encryption_block_header_size(block[0]);
-        (block[hdr_size..].to_vec(), block[..hdr_size].to_vec())
-    } else {
-        (compressed_payload, Vec::new())
-    };
-    #[cfg(not(feature = "format-encryption"))]
-    let (final_payload, encryption_header): (Vec<u8>, Vec<u8>) = (compressed_payload, Vec::new());
-
-    // Signing setup
-    #[cfg(feature = "format-signing")]
-    if options.signing_key.is_some() {
-        header_flags |= flags::SIGNED;
-    }
-
-    // License setup
-    if options.license.is_some() {
-        header_flags |= flags::LICENSED;
-    }
-
-    // Serialize metadata
-    let metadata_buf = if let Some(ref meta) = options.metadata {
-        rmp_serde::to_vec(meta).map_err(|e| Error::Format(e.to_string()))?
-    } else {
-        rmp_serde::to_vec(&Metadata::default()).map_err(|e| Error::Format(e.to_string()))?
-    };
-
-    // Count total rows
+    let metadata_buf = serialize_save_metadata(options)?;
     let num_rows: u64 = batches.iter().map(|b| b.num_rows() as u64).sum();
-
-    // Build header
     let header = Header {
         version: (FORMAT_VERSION_MAJOR, FORMAT_VERSION_MINOR),
         dataset_type,
@@ -694,65 +641,151 @@ pub fn save<W: std::io::Write>(
         num_rows,
     };
 
-    // Build all data for checksum and signature
-    let mut all_data = Vec::new();
-    let header_bytes = header.to_bytes();
-    all_data.extend_from_slice(&header_bytes);
-    all_data.extend_from_slice(&metadata_buf);
-    all_data.extend_from_slice(&schema_buf);
-    all_data.extend_from_slice(&encryption_header);
-    all_data.extend_from_slice(&final_payload);
+    write_packed_output(
+        writer,
+        &header,
+        &metadata_buf,
+        &schema_buf,
+        &encryption_header,
+        &final_payload,
+        options,
+    )
+}
 
-    // Add signature block if signing
-    #[cfg(feature = "format-signing")]
-    let signature_block: Option<[u8; signing::SignatureBlock::SIZE]> =
-        if let Some(ref key) = options.signing_key {
-            let sig_block = signing::SignatureBlock::sign(&all_data, key);
-            let sig_bytes = sig_block.to_bytes();
-            all_data.extend_from_slice(&sig_bytes);
-            Some(sig_bytes)
-        } else {
-            None
-        };
-    #[cfg(not(feature = "format-signing"))]
-    let signature_block: Option<[u8; 96]> = None;
+fn serialize_arrow_schema(schema: &arrow::datatypes::SchemaRef) -> Result<Vec<u8>> {
+    use arrow::ipc::writer::StreamWriter;
+    let mut schema_buf = Vec::new();
+    let mut schema_writer =
+        StreamWriter::try_new(&mut schema_buf, schema).map_err(Error::Arrow)?;
+    schema_writer.finish().map_err(Error::Arrow)?;
+    Ok(schema_buf)
+}
 
-    // Add license block if present
-    let license_bytes: Option<Vec<u8>> = if let Some(ref lic) = options.license {
-        let lic_bytes = lic.to_bytes();
-        all_data.extend_from_slice(&lic_bytes);
-        Some(lic_bytes)
+fn serialize_arrow_payload(
+    batches: &[arrow::array::RecordBatch],
+    schema: &arrow::datatypes::SchemaRef,
+) -> Result<Vec<u8>> {
+    use arrow::ipc::writer::StreamWriter;
+    let mut payload_buf = Vec::new();
+    let mut payload_writer =
+        StreamWriter::try_new(&mut payload_buf, schema).map_err(Error::Arrow)?;
+    for batch in batches {
+        payload_writer.write(batch).map_err(Error::Arrow)?;
+    }
+    payload_writer.finish().map_err(Error::Arrow)?;
+    Ok(payload_buf)
+}
+
+#[cfg(feature = "format-encryption")]
+fn apply_encryption_if_requested(
+    compressed_payload: Vec<u8>,
+    options: &SaveOptions,
+    header_flags: &mut u8,
+) -> Result<(Vec<u8>, Vec<u8>)> {
+    if let Some(ref enc_params) = options.encryption {
+        *header_flags |= flags::ENCRYPTED;
+        let block = build_encryption_block(&compressed_payload, enc_params)?;
+        let hdr_size = encryption_block_header_size(block[0]);
+        Ok((block[hdr_size..].to_vec(), block[..hdr_size].to_vec()))
     } else {
-        None
-    };
+        Ok((compressed_payload, Vec::new()))
+    }
+}
 
-    // Calculate checksum over all preceding data
+#[cfg(not(feature = "format-encryption"))]
+fn apply_encryption_if_requested(
+    compressed_payload: Vec<u8>,
+    _options: &SaveOptions,
+    _header_flags: &mut u8,
+) -> Result<(Vec<u8>, Vec<u8>)> {
+    Ok((compressed_payload, Vec::new()))
+}
+
+fn update_header_flags(header_flags: &mut u8, options: &SaveOptions) {
+    #[cfg(feature = "format-signing")]
+    if options.signing_key.is_some() {
+        *header_flags |= flags::SIGNED;
+    }
+    if options.license.is_some() {
+        *header_flags |= flags::LICENSED;
+    }
+}
+
+fn serialize_save_metadata(options: &SaveOptions) -> Result<Vec<u8>> {
+    let meta = options.metadata.as_ref();
+    if let Some(m) = meta {
+        rmp_serde::to_vec(m).map_err(|e| Error::Format(e.to_string()))
+    } else {
+        rmp_serde::to_vec(&Metadata::default()).map_err(|e| Error::Format(e.to_string()))
+    }
+}
+
+fn write_packed_output<W: std::io::Write>(
+    writer: &mut W,
+    header: &Header,
+    metadata_buf: &[u8],
+    schema_buf: &[u8],
+    encryption_header: &[u8],
+    final_payload: &[u8],
+    options: &SaveOptions,
+) -> Result<()> {
+    let all_data = assemble_all_data(
+        header,
+        metadata_buf,
+        schema_buf,
+        encryption_header,
+        final_payload,
+        options,
+    );
     let checksum = crc32(&all_data);
-
-    // Write everything
-    writer.write_all(&header_bytes).map_err(Error::io_no_path)?;
-    writer.write_all(&metadata_buf).map_err(Error::io_no_path)?;
-    writer.write_all(&schema_buf).map_err(Error::io_no_path)?;
-    writer
-        .write_all(&encryption_header)
-        .map_err(Error::io_no_path)?;
-    writer
-        .write_all(&final_payload)
-        .map_err(Error::io_no_path)?;
-
-    if let Some(ref sig) = signature_block {
-        writer.write_all(sig).map_err(Error::io_no_path)?;
-    }
-
-    if let Some(ref lic) = license_bytes {
-        writer.write_all(lic).map_err(Error::io_no_path)?;
-    }
-
+    writer.write_all(&all_data).map_err(Error::io_no_path)?;
     writer
         .write_all(&checksum.to_le_bytes())
         .map_err(Error::io_no_path)?;
-
     Ok(())
+}
+
+fn assemble_all_data(
+    header: &Header,
+    metadata_buf: &[u8],
+    schema_buf: &[u8],
+    encryption_header: &[u8],
+    final_payload: &[u8],
+    options: &SaveOptions,
+) -> Vec<u8> {
+    let mut all_data = Vec::new();
+    all_data.extend_from_slice(&header.to_bytes());
+    all_data.extend_from_slice(metadata_buf);
+    all_data.extend_from_slice(schema_buf);
+    all_data.extend_from_slice(encryption_header);
+    all_data.extend_from_slice(final_payload);
+    append_signature_if_signing(&mut all_data, options);
+    append_license_if_present(&mut all_data, options);
+    all_data
+}
+
+#[cfg(feature = "format-signing")]
+fn append_signature_if_signing(
+    all_data: &mut Vec<u8>,
+    options: &SaveOptions,
+) -> Option<[u8; signing::SignatureBlock::SIZE]> {
+    let key = options.signing_key.as_ref()?;
+    let sig_block = signing::SignatureBlock::sign(all_data, key);
+    let sig_bytes = sig_block.to_bytes();
+    all_data.extend_from_slice(&sig_bytes);
+    Some(sig_bytes)
+}
+
+#[cfg(not(feature = "format-signing"))]
+fn append_signature_if_signing(_all_data: &mut Vec<u8>, _options: &SaveOptions) -> Option<[u8; 96]> {
+    None
+}
+
+fn append_license_if_present(all_data: &mut Vec<u8>, options: &SaveOptions) -> Option<Vec<u8>> {
+    let lic = options.license.as_ref()?;
+    let lic_bytes = lic.to_bytes();
+    all_data.extend_from_slice(&lic_bytes);
+    Some(lic_bytes)
 }
 
 /// Compress a payload buffer using the specified compression method.


### PR DESCRIPTION
## Summary
- Gate 10 V4 CC>10 hotspot refactor: `aprender-data` `format::save` CC 28 → 7
- Extracted 9 single-responsibility helpers (all CC ≤ 3)
- Main `save()` becomes a ~40-line linear dispatch
- Toyota Way: also fixed pre-existing `missing_docs` on `is_prose_continuation` (blocked `--all-features` build)

## Changes
| Helper | CC | Purpose |
|--------|----|---------|
| `serialize_arrow_schema` | 1 | schema → IPC bytes |
| `serialize_arrow_payload` | 1 | batches → IPC bytes |
| `apply_encryption_if_requested` | 1/3 | cfg-gated dual |
| `update_header_flags` | 1 | enc/sig bit flags |
| `serialize_save_metadata` | 2 | metadata block |
| `assemble_all_data` | 1 | combine header+schema+data+meta |
| `write_packed_output` | 3 | final file write |
| `append_signature_if_signing` | 1/2 | cfg-gated dual |
| `append_license_if_present` | 2 | license block |

## Test plan
- [x] `cargo build -p aprender-data --all-features` clean
- [x] `cargo test -p aprender-data --lib format` — 235 pass, 0 fail
- [x] `pmat analyze complexity` — all helpers CC ≤ 3; save CC = 7
- [x] Pre-commit PMAT gates pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)