### PR TITLE
refactor(qa-cli): log_environment CC 13→1

### DIFF
--- a/crates/aprender-qa-cli/src/main_display_results.rs
+++ b/crates/aprender-qa-cli/src/main_display_results.rs
@@ -92,7 +92,7 @@ fn save_playbook_evidence(result: &aprender_qa_runner::ExecutionResult, output_d
 
 /// Log environment information for fail-fast diagnostics (§12.5.3)
 fn log_environment() {
-    let tag = "[ENVIRONMENT]".dimmed().cyan();
+    let tag = "[ENVIRONMENT]".dimmed().cyan().to_string();
     eprintln!("\n{tag} {}", "=== Diagnostic Context ===".dimmed());
     eprintln!(
         "{tag} {} {} {}",
@@ -106,73 +106,55 @@ fn log_environment() {
         env!("CARGO_PKG_VERSION").dimmed()
     );
 
-    // Git context
-    if let Ok(output) = std::process::Command::new("git")
-        .args(["rev-parse", "--short", "HEAD"])
-        .output()
-    {
-        if output.status.success() {
-            let commit = String::from_utf8_lossy(&output.stdout);
-            eprintln!(
-                "{tag} {} {}",
-                "Git commit:".dimmed(),
-                commit.trim().dimmed()
-            );
-        }
-    }
-
-    if let Ok(output) = std::process::Command::new("git")
-        .args(["branch", "--show-current"])
-        .output()
-    {
-        if output.status.success() {
-            let branch = String::from_utf8_lossy(&output.stdout);
-            eprintln!(
-                "{tag} {} {}",
-                "Git branch:".dimmed(),
-                branch.trim().dimmed()
-            );
-        }
-    }
-
-    // Check for dirty files
-    if let Ok(output) = std::process::Command::new("git")
-        .args(["status", "--porcelain"])
-        .output()
-    {
-        if output.status.success() {
-            let status = String::from_utf8_lossy(&output.stdout);
-            let dirty_count = status.lines().count();
-            if dirty_count > 0 {
-                eprintln!(
-                    "{tag} {} {}",
-                    "Git dirty:".dimmed(),
-                    format!("{dirty_count} file(s) modified").dimmed()
-                );
-            }
-        }
-    }
-
-    // apr CLI version
-    if let Ok(output) = std::process::Command::new("apr").arg("--version").output() {
-        if output.status.success() {
-            let version = String::from_utf8_lossy(&output.stdout);
-            eprintln!("{tag} {} {}", "apr-cli:".dimmed(), version.trim().dimmed());
-        }
-    }
-
-    // Rust version
-    if let Ok(output) = std::process::Command::new("rustc")
-        .arg("--version")
-        .output()
-    {
-        if output.status.success() {
-            let version = String::from_utf8_lossy(&output.stdout);
-            eprintln!("{tag} {}", version.trim().dimmed());
-        }
-    }
+    log_git_short_line(&tag, "Git commit:", &["rev-parse", "--short", "HEAD"]);
+    log_git_short_line(&tag, "Git branch:", &["branch", "--show-current"]);
+    log_git_dirty_count(&tag);
+    log_command_short_line(&tag, "apr-cli:", "apr", &["--version"], false);
+    log_command_short_line(&tag, "", "rustc", &["--version"], true);
 
     eprintln!("{tag} {}\n", "===========================".dimmed());
+}
+
+/// Run a command, printing its trimmed stdout as `tag label <value>` on success.
+fn log_git_short_line(tag: &str, label: &str, args: &[&str]) {
+    log_command_short_line(tag, label, "git", args, false);
+}
+
+fn log_command_short_line(tag: &str, label: &str, cmd: &str, args: &[&str], value_only: bool) {
+    let Ok(output) = std::process::Command::new(cmd).args(args).output() else {
+        return;
+    };
+    if !output.status.success() {
+        return;
+    }
+    let value = String::from_utf8_lossy(&output.stdout);
+    let trimmed = value.trim();
+    if value_only {
+        eprintln!("{tag} {}", trimmed.dimmed());
+    } else {
+        eprintln!("{tag} {} {}", label.dimmed(), trimmed.dimmed());
+    }
+}
+
+fn log_git_dirty_count(tag: &str) {
+    let Ok(output) = std::process::Command::new("git")
+        .args(["status", "--porcelain"])
+        .output()
+    else {
+        return;
+    };
+    if !output.status.success() {
+        return;
+    }
+    let status = String::from_utf8_lossy(&output.stdout);
+    let dirty_count = status.lines().count();
+    if dirty_count > 0 {
+        eprintln!(
+            "{tag} {} {}",
+            "Git dirty:".dimmed(),
+            format!("{dirty_count} file(s) modified").dimmed()
+        );
+    }
 }
 
 /// Generate QA scenarios for a model and print them in the requested format


### PR DESCRIPTION
## Summary
- Decompose \`log_environment\` (CC 13 → 1) into 3 command-running helpers — Gate 10 V4 compliance

## Helpers extracted
- \`log_command_short_line\` (CC 5) — unified stdout-trim printer (let-else short-circuit replaces nested if-let + if-output.status.success)
- \`log_git_short_line\` (CC 1) — thin wrapper for git invocations
- \`log_git_dirty_count\` (CC 4) — specialized line-count variant

## Verification
- \`cargo check -p aprender-qa-cli\` ✅
- \`pmat analyze complexity\` → main CC=1, all helpers ≤5
- Behavior preserved: same output text, same failure-silent semantics, same tag formatting
- Pre-commit quality gates pass

Closes part of GH-716 (Gate 10 V4 hotspots).

## Test plan
- [x] Pre-commit hooks pass
- [ ] CI green on self-hosted runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)