### PR TITLE
refactor(cgp): run_bench CC 30→4

### DIFF
--- a/crates/aprender-cgp/src/analysis/bench.rs
+++ b/crates/aprender-cgp/src/analysis/bench.rs
@@ -14,26 +14,37 @@ pub fn run_bench(
     _roofline: bool,
 ) -> Result<()> {
     println!("\n=== CGP Bench: {bench_name} ===\n");
+    print_bench_header(bench_name, counters, check_regression, threshold);
 
-    // Build the cargo bench command
-    let mut cmd = Command::new("cargo");
-    cmd.arg("bench");
+    let output = run_cargo_bench(bench_name)?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
 
-    // Add criterion filter if the bench name contains a slash (bench_name/filter)
-    if let Some((bench, filter)) = bench_name.split_once('/') {
-        cmd.arg("--bench").arg(bench).arg("--").arg(filter);
-    } else {
-        cmd.arg("--bench").arg(bench_name);
+    if !output.status.success() {
+        handle_bench_failure(bench_name, &stderr);
+        return Ok(());
     }
 
-    cmd.arg("--no-fail-fast");
+    print_bench_results(&stdout);
+    run_perf_overlay_if_requested(bench_name, counters);
+    if check_regression {
+        print_regression_check(&stdout, threshold);
+    }
 
-    // If perf stat overlay requested and perf is available, wrap with perf stat
-    let use_perf = counters.is_some() && which::which("perf").is_ok();
-    if use_perf {
+    println!();
+    Ok(())
+}
+
+/// Print the pre-run configuration banner (counters/regression/perf availability).
+fn print_bench_header(
+    bench_name: &str,
+    counters: Option<&str>,
+    check_regression: bool,
+    threshold: f64,
+) {
+    if counters.is_some() && which::which("perf").is_ok() {
         println!("  Hardware counter overlay: enabled");
     }
-
     println!("  Running: cargo bench --bench {bench_name}");
     if let Some(c) = counters {
         println!("  Hardware counters: {c}");
@@ -41,54 +52,52 @@ pub fn run_bench(
     if check_regression {
         println!("  Regression check: threshold={threshold}%");
     }
+}
 
-    let output = cmd
+/// Invoke `cargo bench`, splitting `bench_name/filter` into a criterion filter if present.
+fn run_cargo_bench(bench_name: &str) -> Result<std::process::Output> {
+    let mut cmd = Command::new("cargo");
+    cmd.arg("bench");
+    if let Some((bench, filter)) = bench_name.split_once('/') {
+        cmd.arg("--bench").arg(bench).arg("--").arg(filter);
+    } else {
+        cmd.arg("--bench").arg(bench_name);
+    }
+    cmd.arg("--no-fail-fast");
+    cmd.output()
+        .with_context(|| format!("Failed to run cargo bench --bench {bench_name}"))
+}
+
+/// Handle a non-zero exit from cargo bench: list benches if missing, otherwise print stderr.
+fn handle_bench_failure(bench_name: &str, stderr: &str) {
+    if stderr.contains("no bench target") || stderr.contains("can't find") {
+        println!("  Benchmark '{bench_name}' not found.");
+        list_available_benches();
+        return;
+    }
+    eprintln!("  cargo bench failed:\n{stderr}");
+}
+
+/// Print cargo's list of available bench targets by triggering a deliberate miss.
+fn list_available_benches() {
+    println!("  Available benchmarks:");
+    let Ok(lo) = Command::new("cargo")
+        .args(["bench", "--bench", "nonexistent_xyz_123", "--", "--list"])
         .output()
-        .with_context(|| format!("Failed to run cargo bench --bench {bench_name}"))?;
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-
-    if !output.status.success() {
-        if stderr.contains("no bench target") || stderr.contains("can't find") {
-            println!("  Benchmark '{bench_name}' not found.");
-            println!("  Available benchmarks:");
-
-            let list_output = Command::new("cargo")
-                .args(["bench", "--bench", "nonexistent_xyz_123", "--", "--list"])
-                .output();
-            if let Ok(lo) = list_output {
-                let lo_stderr = String::from_utf8_lossy(&lo.stderr);
-                for line in lo_stderr.lines() {
-                    if line.contains("bench target") || line.contains("available") {
-                        println!("    {line}");
-                    }
-                }
-            }
-            return Ok(());
-        }
-        eprintln!("  cargo bench failed:\n{stderr}");
-        return Ok(());
-    }
-
-    // Parse criterion output for timing results
-    let mut results: Vec<BenchResult> = Vec::new();
-    for line in stdout.lines() {
-        if line.contains("time:") {
-            let parts: Vec<&str> = line.splitn(2, "time:").collect();
-            if parts.len() == 2 {
-                let name = parts[0].trim().to_string();
-                let timing = parts[1].trim().to_string();
-                let change = extract_change(line);
-                results.push(BenchResult {
-                    name,
-                    timing,
-                    change,
-                });
-            }
+    else {
+        return;
+    };
+    let lo_stderr = String::from_utf8_lossy(&lo.stderr);
+    for line in lo_stderr.lines() {
+        if line.contains("bench target") || line.contains("available") {
+            println!("    {line}");
         }
     }
+}
 
+/// Parse criterion output and print either structured results or a raw preview.
+fn print_bench_results(stdout: &str) {
+    let results = parse_bench_results(stdout);
     if results.is_empty() {
         println!("  Criterion output:");
         for line in stdout.lines().take(30) {
@@ -96,49 +105,72 @@ pub fn run_bench(
                 println!("  {line}");
             }
         }
+        return;
+    }
+    println!("  Results:");
+    for r in &results {
+        let change_str = match &r.change {
+            Some(c) => format!("  ({c})"),
+            None => String::new(),
+        };
+        println!("    {:40} {}{}", r.name, r.timing, change_str);
+    }
+}
+
+/// Extract `name — time: X ns (change: ±Y%)` triples from criterion stdout.
+fn parse_bench_results(stdout: &str) -> Vec<BenchResult> {
+    let mut results: Vec<BenchResult> = Vec::new();
+    for line in stdout.lines() {
+        if !line.contains("time:") {
+            continue;
+        }
+        let parts: Vec<&str> = line.splitn(2, "time:").collect();
+        if parts.len() != 2 {
+            continue;
+        }
+        let name = parts[0].trim().to_string();
+        let timing = parts[1].trim().to_string();
+        let change = extract_change(line);
+        results.push(BenchResult {
+            name,
+            timing,
+            change,
+        });
+    }
+    results
+}
+
+/// Run perf stat overlay if counters were requested; fall back to an informative message.
+fn run_perf_overlay_if_requested(bench_name: &str, counters: Option<&str>) {
+    let Some(counter_list) = counters else {
+        return;
+    };
+    if which::which("perf").is_ok() {
+        println!("\n  --- perf stat overlay ---");
+        run_perf_overlay(bench_name, counter_list);
     } else {
-        println!("  Results:");
-        for r in &results {
-            let change_str = match &r.change {
-                Some(c) => format!("  ({c})"),
-                None => String::new(),
-            };
-            println!("    {:40} {}{}", r.name, r.timing, change_str);
+        println!("\n  perf not available — skipping hardware counter overlay.");
+        println!("  Install linux-tools-common for hardware counter support.");
+    }
+}
+
+/// Scan stdout for criterion regression/improvement lines and print a summary.
+fn print_regression_check(stdout: &str, threshold: f64) {
+    println!("\n  Regression check (threshold={threshold}%):");
+    let mut regressions = 0;
+    for line in stdout.lines() {
+        if line.contains("regressed") || line.contains("Performance has regressed") {
+            println!("    \x1b[31mREGRESSION\x1b[0m: {line}");
+            regressions += 1;
+        } else if line.contains("improved") {
+            println!("    \x1b[32mIMPROVED\x1b[0m: {line}");
         }
     }
-
-    // Run perf stat overlay if requested
-    if let Some(counter_list) = counters {
-        if which::which("perf").is_ok() {
-            println!("\n  --- perf stat overlay ---");
-            run_perf_overlay(bench_name, counter_list);
-        } else {
-            println!("\n  perf not available — skipping hardware counter overlay.");
-            println!("  Install linux-tools-common for hardware counter support.");
-        }
+    if regressions > 0 {
+        println!("\n  \x1b[31m{regressions} regression(s) detected!\x1b[0m");
+    } else {
+        println!("  No regressions detected.");
     }
-
-    // Check regression
-    if check_regression {
-        println!("\n  Regression check (threshold={threshold}%):");
-        let mut regressions = 0;
-        for line in stdout.lines() {
-            if line.contains("regressed") || line.contains("Performance has regressed") {
-                println!("    \x1b[31mREGRESSION\x1b[0m: {line}");
-                regressions += 1;
-            } else if line.contains("improved") {
-                println!("    \x1b[32mIMPROVED\x1b[0m: {line}");
-            }
-        }
-        if regressions > 0 {
-            println!("\n  \x1b[31m{regressions} regression(s) detected!\x1b[0m");
-        } else {
-            println!("  No regressions detected.");
-        }
-    }
-
-    println!();
-    Ok(())
 }
 
 /// Benchmark result parsed from criterion output.


### PR DESCRIPTION
## Summary
- Drops run_bench cyclomatic complexity from 30 to 4 (well below Gate 10 V4 threshold).
- Extracts 8 focused helpers; all CC ≤ 6.
- Uses let-else pattern to flatten nested if let Ok inside list_available_benches.

## Helpers
- print_bench_header (CC 5)
- run_cargo_bench (CC 2)
- handle_bench_failure (CC 3)
- list_available_benches (CC 4)
- print_bench_results (CC 6)
- parse_bench_results (CC 4)
- run_perf_overlay_if_requested (CC 2)
- print_regression_check (CC 6)

## Test plan
- [x] cargo check -p aprender-cgp passes
- [x] pmat complexity verified CC 30 → 4
- [x] All helpers CC ≤ 6; file max now 10 (run_perf_overlay, unchanged)
- [x] No new unwrap()
- [ ] CI green on merge

Closes part of GH-716.

🤖 Generated with [Claude Code](https://claude.com/claude-code)