### PR TITLE
refactor(contracts-cli): infer.rs — run CC 16 → 3

### DIFF
--- a/crates/aprender-contracts-cli/src/commands/infer.rs
+++ b/crates/aprender-contracts-cli/src/commands/infer.rs
@@ -1,7 +1,10 @@
 use std::path::Path;
 
-use provable_contracts::infer::{format_binding_entry, format_contract_stub, infer};
-use provable_contracts::schema::parse_contract;
+use provable_contracts::infer::{
+    ContractSuggestion, InferResult, InferredBinding, format_binding_entry, format_contract_stub,
+    infer,
+};
+use provable_contracts::schema::{Contract, parse_contract};
 
 #[allow(clippy::unnecessary_wraps)]
 pub fn run(
@@ -10,32 +13,52 @@ pub fn run(
     contract_dir: &Path,
     top_n: usize,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    // Load all contracts
-    let mut contracts = Vec::new();
-    if let Ok(entries) = std::fs::read_dir(contract_dir) {
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if path.extension().and_then(|e| e.to_str()) == Some("yaml")
-                && !path.to_string_lossy().contains("binding")
-            {
-                let stem = path
-                    .file_stem()
-                    .and_then(|s| s.to_str())
-                    .unwrap_or("unknown")
-                    .to_string();
-                if let Ok(c) = parse_contract(&path) {
-                    contracts.push((stem, c));
-                }
-            }
-        }
-    }
-
-    let refs: Vec<(String, &provable_contracts::schema::Contract)> =
-        contracts.iter().map(|(s, c)| (s.clone(), c)).collect();
+    let contracts = load_contracts(contract_dir);
+    let refs: Vec<(String, &Contract)> = contracts.iter().map(|(s, c)| (s.clone(), c)).collect();
 
     let result = infer(crate_dir, binding_path, &refs);
 
-    // Header
+    print_header(crate_dir, &contracts, &result);
+    print_matched(&result.matched, top_n);
+    print_suggestions(&result.suggestions, top_n);
+
+    if result.matched.is_empty() && result.suggestions.is_empty() {
+        println!("No inferences found. All non-trivial functions are bound.");
+    }
+
+    Ok(())
+}
+
+/// Load all `*.yaml` contracts under `contract_dir` (excluding binding files).
+fn load_contracts(contract_dir: &Path) -> Vec<(String, Contract)> {
+    let mut contracts = Vec::new();
+    let Ok(entries) = std::fs::read_dir(contract_dir) else {
+        return contracts;
+    };
+    for entry in entries.flatten() {
+        if let Some(loaded) = load_one_contract(&entry.path()) {
+            contracts.push(loaded);
+        }
+    }
+    contracts
+}
+
+fn load_one_contract(path: &Path) -> Option<(String, Contract)> {
+    if path.extension().and_then(|e| e.to_str()) != Some("yaml") {
+        return None;
+    }
+    if path.to_string_lossy().contains("binding") {
+        return None;
+    }
+    let stem = path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("unknown")
+        .to_string();
+    parse_contract(path).ok().map(|c| (stem, c))
+}
+
+fn print_header(crate_dir: &Path, contracts: &[(String, Contract)], result: &InferResult) {
     println!("pv infer — Contract Inference Engine");
     println!("====================================\n");
     println!(
@@ -51,62 +74,55 @@ pub fn run(
         "Reverse coverage: {:.1}% ({}/{})\n",
         result.coverage.coverage_pct, result.coverage.bound_fns, result.coverage.total_pub_fns,
     );
+}
 
-    // Matched bindings
-    if !result.matched.is_empty() {
-        println!("=== Inferred Bindings ({}) ===\n", result.matched.len());
-        for (i, m) in result.matched.iter().take(top_n).enumerate() {
-            println!(
-                "[{}] {} → {}/{} ({:.0}%, {})",
-                i + 1,
-                m.function.path,
-                m.contract_stem,
-                m.equation,
-                m.confidence * 100.0,
-                m.strategy,
-            );
-            println!("    {}:{}", m.function.file, m.function.line);
-        }
-        if result.matched.len() > top_n {
-            println!("    ... and {} more", result.matched.len() - top_n);
-        }
-
-        println!("\n--- Suggested binding.yaml entries ---\n");
-        for m in result.matched.iter().take(top_n) {
-            println!("{}\n", format_binding_entry(m));
-        }
+fn print_matched(matched: &[InferredBinding], top_n: usize) {
+    if matched.is_empty() {
+        return;
     }
-
-    // New contract suggestions
-    if !result.suggestions.is_empty() {
+    println!("=== Inferred Bindings ({}) ===\n", matched.len());
+    for (i, m) in matched.iter().take(top_n).enumerate() {
         println!(
-            "=== New Contract Suggestions ({}) ===\n",
-            result.suggestions.len()
+            "[{}] {} → {}/{} ({:.0}%, {})",
+            i + 1,
+            m.function.path,
+            m.contract_stem,
+            m.equation,
+            m.confidence * 100.0,
+            m.strategy,
         );
-        for (i, s) in result.suggestions.iter().take(top_n).enumerate() {
-            println!(
-                "[{}] {} → {}.yaml (Tier {})",
-                i + 1,
-                s.function.path,
-                s.suggested_name,
-                s.suggested_tier,
-            );
-            println!("    {}:{}", s.function.file, s.function.line);
-            println!("    {}", s.reason);
-        }
-        if result.suggestions.len() > top_n {
-            println!("    ... and {} more", result.suggestions.len() - top_n);
-        }
-
-        if !result.suggestions.is_empty() {
-            println!("\n--- Sample contract stub ---\n");
-            println!("{}", format_contract_stub(&result.suggestions[0]));
-        }
+        println!("    {}:{}", m.function.file, m.function.line);
+    }
+    if matched.len() > top_n {
+        println!("    ... and {} more", matched.len() - top_n);
     }
 
-    if result.matched.is_empty() && result.suggestions.is_empty() {
-        println!("No inferences found. All non-trivial functions are bound.");
+    println!("\n--- Suggested binding.yaml entries ---\n");
+    for m in matched.iter().take(top_n) {
+        println!("{}\n", format_binding_entry(m));
+    }
+}
+
+fn print_suggestions(suggestions: &[ContractSuggestion], top_n: usize) {
+    if suggestions.is_empty() {
+        return;
+    }
+    println!("=== New Contract Suggestions ({}) ===\n", suggestions.len());
+    for (i, s) in suggestions.iter().take(top_n).enumerate() {
+        println!(
+            "[{}] {} → {}.yaml (Tier {})",
+            i + 1,
+            s.function.path,
+            s.suggested_name,
+            s.suggested_tier,
+        );
+        println!("    {}:{}", s.function.file, s.function.line);
+        println!("    {}", s.reason);
+    }
+    if suggestions.len() > top_n {
+        println!("    ... and {} more", suggestions.len() - top_n);
     }
 
-    Ok(())
+    println!("\n--- Sample contract stub ---\n");
+    println!("{}", format_contract_stub(&suggestions[0]));
 }


### PR DESCRIPTION
## Summary
- `commands/infer.rs::run` CC **16 → 3** — orchestrator delegates to `load_contracts`, `print_header`, `print_matched`, `print_suggestions`
- New helpers: `load_contracts`, `load_one_contract` (directory walk + filter), plus three print helpers
- All helpers CC ≤ 5. Behavior preserved.

## Test plan
- [x] `cargo check -p aprender-contracts-cli` clean
- [x] `pmat analyze complexity` reports no CC > 5 in `infer.rs`
- [x] PMAT pre-commit quality gates pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)