### PR TITLE
refactor(contracts-cli): migrate.rs — run CC 11 → 2

### DIFF
--- a/crates/aprender-contracts-cli/src/commands/migrate.rs
+++ b/crates/aprender-contracts-cli/src/commands/migrate.rs
@@ -1,38 +1,56 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 pub fn run(contract_dir: &Path, dry_run: bool) -> Result<(), Box<dyn std::error::Error>> {
     eprintln!("pv migrate — contract schema migration");
     eprintln!("=========================================\n");
+
+    let count = scan_and_report(contract_dir, dry_run)?;
+    print_summary(contract_dir, dry_run, count);
+    Ok(())
+}
+
+fn scan_and_report(contract_dir: &Path, dry_run: bool) -> std::io::Result<usize> {
     let mut count = 0;
     for entry in std::fs::read_dir(contract_dir)?.flatten() {
         let path = entry.path();
-        if path.extension().and_then(|e| e.to_str()) == Some("yaml") {
-            let content = std::fs::read_to_string(&path)?;
-            let needs = !content.contains("metadata:")
-                || (!content.contains("proof_obligations:") && !content.contains("registry: true"));
-            if needs {
-                if dry_run {
-                    eprintln!("  [MIGRATE] {}", path.display());
-                } else {
-                    eprintln!(
-                        "  [MIGRATE] {} (auto-fix not yet implemented)",
-                        path.display()
-                    );
-                }
-                count += 1;
-            }
+        if path.extension().and_then(|e| e.to_str()) != Some("yaml") {
+            continue;
+        }
+        if needs_migration(&path)? {
+            report_migration(&path, dry_run);
+            count += 1;
         }
     }
+    Ok(count)
+}
+
+fn needs_migration(path: &PathBuf) -> std::io::Result<bool> {
+    let content = std::fs::read_to_string(path)?;
+    Ok(!content.contains("metadata:")
+        || (!content.contains("proof_obligations:") && !content.contains("registry: true")))
+}
+
+fn report_migration(path: &Path, dry_run: bool) {
+    if dry_run {
+        eprintln!("  [MIGRATE] {}", path.display());
+    } else {
+        eprintln!(
+            "  [MIGRATE] {} (auto-fix not yet implemented)",
+            path.display()
+        );
+    }
+}
+
+fn print_summary(contract_dir: &Path, dry_run: bool, count: usize) {
     if count == 0 {
         eprintln!(
             "  All contracts in {} use current schema.",
             contract_dir.display()
         );
-    } else {
-        eprintln!("\n{count} contract(s) need migration.");
-        if dry_run {
-            eprintln!("Run without --dry-run to apply fixes.");
-        }
+        return;
     }
-    Ok(())
+    eprintln!("\n{count} contract(s) need migration.");
+    if dry_run {
+        eprintln!("Run without --dry-run to apply fixes.");
+    }
 }


### PR DESCRIPTION
## Summary
- `run` CC 11 → 2 (Gate 10 V4 CC>10 compliance)
- Extract `scan_and_report` (early-continue for non-yaml), `needs_migration`, `report_migration`, `print_summary` (early-return for count==0)

## Test plan
- [x] `cargo check -p aprender-contracts-cli` passes
- [x] `pmat analyze complexity` confirms run=2, all helpers ≤6

Refs GH-716.

🤖 Generated with [Claude Code](https://claude.com/claude-code)