### PR TITLE
fix(aprender-train): matmul #[should_panic] expected — unblocks queue

### DIFF
--- a/crates/aprender-train/src/autograd/ops/matmul.rs
+++ b/crates/aprender-train/src/autograd/ops/matmul.rs
@@ -781,7 +781,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "size mismatch")]
+    #[should_panic(expected = "Pre-condition violated")]
     fn test_matmul_size_mismatch_a() {
         let a = Tensor::new(Array1::from(vec![1.0, 2.0, 3.0]), false);
         let b = Tensor::new(Array1::from(vec![5.0, 6.0, 7.0, 8.0]), false);
@@ -789,7 +789,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "size mismatch")]
+    #[should_panic(expected = "Pre-condition violated")]
     fn test_matmul_size_mismatch_b() {
         let a = Tensor::new(Array1::from(vec![1.0, 2.0, 3.0, 4.0]), false);
         let b = Tensor::new(Array1::from(vec![5.0, 6.0, 7.0]), false);


### PR DESCRIPTION
## Summary
- The `matmul-v1` contract macro panics with \`Contract [matmul] Pre-condition violated: a.len() == m * k\` **before** the function body's `assert_eq!("Matrix A size mismatch")` fires
- `test_matmul_size_mismatch_{a,b}` therefore fail with "panic did not contain expected string" — their `expected = "size mismatch"` no longer matches
- This has been red on main for 3 consecutive CI runs, failing every PR's workspace-test
- Fix: update `expected` to `"Pre-condition violated"` (matches the contract macro's message)

## Test plan
- [x] `cargo test -p aprender-train --lib test_matmul_size_mismatch` — 2 passed ✅
- [ ] CI: `ci / gate` + `workspace-test` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)