### PR TITLE
feat(mcp): apr mcp M1 skeleton — MCP server over stdio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,6 +288,7 @@ version = "0.30.0"
 dependencies = [
  "alimentar",
  "aprender-core 0.30.0",
+ "aprender-mcp",
  "aprender-present-core",
  "aprender-present-terminal",
  "aprender-serve",
@@ -967,6 +968,15 @@ dependencies = [
  "criterion 0.7.0",
  "proptest",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "aprender-mcp"
+version = "0.30.0"
+dependencies = [
+ "anyhow",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,8 @@ members = [
     # "crates/aprender-train-canary",  # Excluded: sqlite3 link conflict with burn dep
     # --- APR-MONO Phase 2e: was batuta (orchestration) ---
     "crates/aprender-orchestrate",
+    # --- MCP server (Model Context Protocol) ---
+    "crates/aprender-mcp",
     # --- APR-MONO Phase 2f: satellite repos (main crates) ---
     "crates/aprender-profile",
     "crates/aprender-profile-core",

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ one `apr` binary, 57 commands covering the full ML lifecycle:
 
 ### Numbers
 
-- **75** workspace crates (was 20 separate repos)
+- **76** workspace crates (was 20 separate repos)
 - **28,700+** tests, all passing
 - **799** provable contracts (equation-based verification)
 - **57** CLI commands with contract coverage

--- a/contracts/apr-cli-commands-v1.yaml
+++ b/contracts/apr-cli-commands-v1.yaml
@@ -390,6 +390,12 @@ commands:
     requires_model: true
     side_effects: [filesystem]
 
+  - name: mcp
+    category: misc
+    description: "Run MCP (Model Context Protocol) server over stdio"
+    requires_model: false
+    side_effects: [stdio]
+
 # ── Falsification Conditions ──
 
 falsification:

--- a/crates/apr-cli/Cargo.toml
+++ b/crates/apr-cli/Cargo.toml
@@ -90,6 +90,9 @@ libc = "0.2"
 [dependencies]
 # Core aprender library
 aprender = { path = "../aprender-core", version = "0.30.0", package = "aprender-core", default-features = true, features = ["format-compression"] }
+
+# MCP (Model Context Protocol) server — `apr mcp` subcommand
+aprender-mcp = { path = "../aprender-mcp", version = "0.30.0" }
 async-stream = "0.3"
 provable-contracts-macros = "0.3"
 

--- a/crates/apr-cli/src/commands/mcp.rs
+++ b/crates/apr-cli/src/commands/mcp.rs
@@ -1,0 +1,15 @@
+//! `apr mcp` — start the aprender MCP server over stdio.
+//!
+//! Wraps `aprender_mcp::AprMcpServer::run_stdio` so that Claude Code, Cursor,
+//! Cline, and other MCP clients can configure `apr` as a tool server via
+//! `.mcp.json`.
+
+use crate::error::CliError;
+
+/// Start the MCP server on stdio (blocking until stdin closes).
+pub fn run() -> Result<(), CliError> {
+    let mut server = aprender_mcp::AprMcpServer::new();
+    server
+        .run_stdio()
+        .map_err(|e| CliError::Aprender(format!("mcp server: {e}")))
+}

--- a/crates/apr-cli/src/commands/mod.rs
+++ b/crates/apr-cli/src/commands/mod.rs
@@ -35,6 +35,7 @@ pub(crate) mod import;
 pub(crate) mod inspect;
 pub(crate) mod kernel_explain;
 pub(crate) mod lint;
+pub(crate) mod mcp;
 pub(crate) mod merge;
 #[cfg(feature = "training")]
 pub(crate) mod model_config;

--- a/crates/apr-cli/src/commands_enum.rs
+++ b/crates/apr-cli/src/commands_enum.rs
@@ -457,6 +457,11 @@ pub enum Commands {
     /// Model optimization commands (fine-tune, prune, distill)
     #[command(flatten)]
     ModelOps(ModelOpsCommands),
+    /// Start the MCP (Model Context Protocol) server over stdio
+    ///
+    /// Exposes `apr` as MCP tools for Claude Code, Cursor, Cline, and other
+    /// MCP clients. Configure via `.mcp.json` with `{"command":"apr","args":["mcp"]}`.
+    Mcp {},
     /// Interactive terminal UI
     Tui {
         /// Path to .apr model file

--- a/crates/apr-cli/src/dispatch.rs
+++ b/crates/apr-cli/src/dispatch.rs
@@ -599,6 +599,7 @@ fn dispatch_model_commands(cli: &Cli) -> Option<Result<(), CliError>> {
         Commands::List => pull::list(cli.json, cli.quiet),
         Commands::Rm { model_ref } => pull::remove(model_ref),
         Commands::Tui { file } => tui::run(file.clone()),
+        Commands::Mcp {} => mcp::run(),
 
         _ => return None,
     })

--- a/crates/apr-cli/src/lib.rs
+++ b/crates/apr-cli/src/lib.rs
@@ -46,7 +46,7 @@ pub mod federation;
 // Commands are crate-private, used internally by execute_command
 use commands::{
     bench, canary, canary::CanaryCommands, cbtop, chat, compare_hf, compile, convert, data, debug,
-    diagnose, diff, distill, eval, explain, export, flow, hex, import, inspect, lint, merge,
+    diagnose, diff, distill, eval, explain, export, flow, hex, import, inspect, lint, mcp, merge,
     oracle, pipeline, probar, profile, prune, publish, pull, qa, qualify, quantize, rosetta,
     rosetta::RosettaCommands, run, serve, showcase, tensors, tokenize, trace, tree, tui, validate,
 };

--- a/crates/apr-cli/tests/cli_commands.rs
+++ b/crates/apr-cli/tests/cli_commands.rs
@@ -71,6 +71,7 @@ fn registered_commands() -> Vec<&'static str> {
         "oracle",
         "encrypt",
         "decrypt",
+        "mcp",
     ];
     // Feature-gated commands — only expected when feature is enabled
     #[cfg(feature = "code")]

--- a/crates/aprender-mcp/Cargo.toml
+++ b/crates/aprender-mcp/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "aprender-mcp"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+rust-version.workspace = true
+description = "Model Context Protocol (MCP) server for aprender — exposes apr CLI as MCP tools"
+keywords = ["mcp", "llm", "inference", "aprender", "claude"]
+categories = ["command-line-utilities", "science"]
+readme = "README.md"
+
+[lib]
+name = "aprender_mcp"
+path = "src/lib.rs"
+
+[features]
+default = ["native"]
+native = ["dep:anyhow"]
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+anyhow = { workspace = true, optional = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/aprender-mcp/README.md
+++ b/crates/aprender-mcp/README.md
@@ -1,0 +1,50 @@
+# aprender-mcp
+
+Model Context Protocol (MCP) server for [aprender](https://github.com/paiml/aprender).
+Exposes the `apr` CLI as MCP tools for Claude Code, Cursor, Cline, and other
+MCP clients over JSON-RPC 2.0 stdio transport.
+
+- Spec: [`docs/specifications/apr-mcp-server-spec.md`](../../docs/specifications/apr-mcp-server-spec.md)
+- Protocol: [MCP v2024-11-05](https://spec.modelcontextprotocol.io/specification/2024-11-05/)
+
+## Usage
+
+### As a library
+
+```rust
+let mut server = aprender_mcp::AprMcpServer::new();
+server.run_stdio()?;
+```
+
+### As `apr mcp` subcommand
+
+```bash
+apr mcp
+```
+
+### `.mcp.json` for Claude Code / Cursor / Cline
+
+```json
+{
+  "mcpServers": {
+    "aprender": {
+      "command": "apr",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+## Milestones
+
+- **M1** (current): skeleton with `initialize` + `tools/list` + `apr.version`
+- **M2**: 8 Phase-1 tools (`apr.run`, `apr.serve`, `apr.qa`, `apr.trace`,
+  `apr.tensors`, `apr.validate`, `apr.bench`, `apr.finetune`)
+- **M3**: streaming progress notifications + cancellation
+- **M4**: Claude Code dogfood + contract promotion to ENFORCED
+
+## Falsification gates
+
+See [`contracts/apr-mcp-server-v1.yaml`](../../contracts/apr-mcp-server-v1.yaml)
+for the full set. M1 ships FALSIFY-MCP-001 (initialize latency) and a subset
+of FALSIFY-MCP-002 (tools/list schema).

--- a/crates/aprender-mcp/src/lib.rs
+++ b/crates/aprender-mcp/src/lib.rs
@@ -1,0 +1,41 @@
+//! Model Context Protocol (MCP) server for aprender.
+//!
+//! Exposes the `apr` CLI as MCP tools for Claude Code, Cursor, Cline, and
+//! other MCP clients over JSON-RPC 2.0 stdio transport.
+//!
+//! Spec: `docs/specifications/apr-mcp-server-spec.md`.
+//! Protocol: MCP v2024-11-05 (<https://spec.modelcontextprotocol.io>).
+//!
+//! # Example
+//!
+//! ```no_run
+//! # #[cfg(feature = "native")]
+//! # fn main() -> anyhow::Result<()> {
+//! let mut server = aprender_mcp::AprMcpServer::new();
+//! server.run_stdio()?;
+//! # Ok(())
+//! # }
+//! # #[cfg(not(feature = "native"))]
+//! # fn main() {}
+//! ```
+//!
+//! # M1 Scope
+//!
+//! M1 (skeleton) ships `initialize` + `tools/list` + 1 stub tool (`apr.version`).
+//! M2 adds the 8 Phase-1 tools. FALSIFY-MCP-001/-002 gate M1.
+
+pub mod server;
+pub mod tools;
+pub mod types;
+
+pub use server::AprMcpServer;
+pub use types::{
+    ContentBlock, InputSchema, JsonRpcError, JsonRpcRequest, JsonRpcResponse, PropertySchema,
+    ServerCapabilities, ToolCallResult, ToolDefinition, ToolsCapability,
+};
+
+/// MCP protocol version this server implements.
+pub const PROTOCOL_VERSION: &str = "2024-11-05";
+
+/// Server identity reported in `initialize` response.
+pub const SERVER_NAME: &str = "aprender-mcp";

--- a/crates/aprender-mcp/src/server.rs
+++ b/crates/aprender-mcp/src/server.rs
@@ -1,0 +1,224 @@
+//! `AprMcpServer` — JSON-RPC 2.0 dispatcher for aprender MCP tools.
+
+#![allow(clippy::disallowed_methods)] // serde_json::json! macro expands to .unwrap() internally
+
+use crate::tools;
+use crate::types::{JsonRpcRequest, JsonRpcResponse, ToolCallResult, ToolDefinition};
+
+/// MCP server exposing the `apr` CLI as tools.
+///
+/// M1: `initialize`, `tools/list`, `tools/call` with `apr.version`.
+#[derive(Debug, Default)]
+pub struct AprMcpServer {}
+
+impl AprMcpServer {
+    /// Construct a new server.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Dispatch a single JSON-RPC request.
+    #[must_use]
+    pub fn handle_request(&mut self, request: &JsonRpcRequest) -> JsonRpcResponse {
+        match request.method.as_str() {
+            "initialize" => self.handle_initialize(request),
+            "tools/list" => self.handle_tools_list(request),
+            "tools/call" => self.handle_tools_call(request),
+            other => JsonRpcResponse::error(
+                request.id.clone(),
+                -32601,
+                format!("Method not found: {other}"),
+            ),
+        }
+    }
+
+    fn handle_initialize(&self, request: &JsonRpcRequest) -> JsonRpcResponse {
+        JsonRpcResponse::success(
+            request.id.clone(),
+            serde_json::json!({
+                "protocolVersion": crate::PROTOCOL_VERSION,
+                "capabilities": {
+                    "tools": { "listChanged": false }
+                },
+                "serverInfo": {
+                    "name": crate::SERVER_NAME,
+                    "version": env!("CARGO_PKG_VERSION"),
+                },
+            }),
+        )
+    }
+
+    fn handle_tools_list(&self, request: &JsonRpcRequest) -> JsonRpcResponse {
+        let tools: Vec<ToolDefinition> = self.tool_definitions();
+        JsonRpcResponse::success(request.id.clone(), serde_json::json!({ "tools": tools }))
+    }
+
+    fn handle_tools_call(&mut self, request: &JsonRpcRequest) -> JsonRpcResponse {
+        let name = request.params.get("name").and_then(|v| v.as_str());
+        let arguments = request
+            .params
+            .get("arguments")
+            .cloned()
+            .unwrap_or_else(|| serde_json::json!({}));
+
+        let result = match name {
+            Some(tools::version::NAME) => tools::version::call(&arguments),
+            Some(other) => ToolCallResult::error(format!("Unknown tool: {other}")),
+            None => ToolCallResult::error("Missing tool name"),
+        };
+
+        JsonRpcResponse::success(
+            request.id.clone(),
+            serde_json::to_value(result).unwrap_or_else(|_| serde_json::json!({})),
+        )
+    }
+
+    /// All tool definitions registered on this server.
+    #[must_use]
+    pub fn tool_definitions(&self) -> Vec<ToolDefinition> {
+        vec![tools::version_tool_definition()]
+    }
+
+    /// Run the server over stdio (blocking).
+    ///
+    /// Reads one JSON-RPC request per line from stdin, writes one response per
+    /// line to stdout. Parse errors map to JSON-RPC code -32700.
+    ///
+    /// # Errors
+    /// Returns an error if stdin/stdout I/O fails.
+    #[cfg(feature = "native")]
+    pub fn run_stdio(&mut self) -> anyhow::Result<()> {
+        use std::io::{self, BufRead, Write};
+
+        let stdin = io::stdin();
+        let stdout = io::stdout();
+        let mut out = stdout.lock();
+
+        for line in stdin.lock().lines() {
+            let line = line?;
+            if line.trim().is_empty() {
+                continue;
+            }
+
+            let response = match serde_json::from_str::<JsonRpcRequest>(&line) {
+                Ok(req) => self.handle_request(&req),
+                Err(e) => JsonRpcResponse::error(None, -32700, format!("Parse error: {e}")),
+            };
+
+            let json = serde_json::to_string(&response)?;
+            writeln!(out, "{json}")?;
+            out.flush()?;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::disallowed_methods)] // serde_json::json! expands to code that hits unwrap()
+mod tests {
+    use super::*;
+
+    fn make_request(method: &str, params: serde_json::Value) -> JsonRpcRequest {
+        JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: Some(serde_json::json!(1)),
+            method: method.to_string(),
+            params,
+        }
+    }
+
+    /// FALSIFY-MCP-001: initialize returns protocolVersion "2024-11-05".
+    #[test]
+    fn initialize_returns_protocol_version() {
+        let mut server = AprMcpServer::new();
+        let req = make_request("initialize", serde_json::json!({}));
+        let resp = server.handle_request(&req);
+
+        assert!(resp.error.is_none());
+        let result = resp.result.expect("result present");
+        assert_eq!(result["protocolVersion"], "2024-11-05");
+        assert_eq!(result["serverInfo"]["name"], "aprender-mcp");
+        assert!(result["capabilities"]["tools"].is_object());
+    }
+
+    /// FALSIFY-MCP-002 (M1 subset): tools/list returns exactly the M1 tools.
+    #[test]
+    fn tools_list_returns_m1_tool_set() {
+        let mut server = AprMcpServer::new();
+        let req = make_request("tools/list", serde_json::json!({}));
+        let resp = server.handle_request(&req);
+
+        let result = resp.result.expect("result present");
+        let tools = result["tools"].as_array().expect("tools array");
+        assert_eq!(tools.len(), 1, "M1 ships only apr.version");
+        assert_eq!(tools[0]["name"], "apr.version");
+
+        let schema = &tools[0]["inputSchema"];
+        assert_eq!(schema["type"], "object");
+    }
+
+    #[test]
+    fn tools_call_version_returns_metadata() {
+        let mut server = AprMcpServer::new();
+        let req = make_request(
+            "tools/call",
+            serde_json::json!({ "name": "apr.version", "arguments": {} }),
+        );
+        let resp = server.handle_request(&req);
+
+        let result = resp.result.expect("result present");
+        let text = result["content"][0]["text"].as_str().expect("text");
+        let parsed: serde_json::Value = serde_json::from_str(text).expect("json");
+        assert_eq!(parsed["server"], "aprender-mcp");
+        assert_eq!(parsed["protocol_version"], "2024-11-05");
+    }
+
+    #[test]
+    fn unknown_method_returns_method_not_found() {
+        let mut server = AprMcpServer::new();
+        let req = make_request("tools/explode", serde_json::json!({}));
+        let resp = server.handle_request(&req);
+
+        assert!(resp.result.is_none());
+        let err = resp.error.expect("error present");
+        assert_eq!(err.code, -32601);
+    }
+
+    #[test]
+    fn tools_call_unknown_tool_returns_is_error() {
+        let mut server = AprMcpServer::new();
+        let req = make_request(
+            "tools/call",
+            serde_json::json!({ "name": "apr.nonexistent" }),
+        );
+        let resp = server.handle_request(&req);
+
+        let result = resp.result.expect("result present");
+        assert_eq!(result["isError"], true);
+    }
+
+    #[test]
+    fn tools_call_missing_name_returns_is_error() {
+        let mut server = AprMcpServer::new();
+        let req = make_request("tools/call", serde_json::json!({}));
+        let resp = server.handle_request(&req);
+
+        let result = resp.result.expect("result present");
+        assert_eq!(result["isError"], true);
+    }
+
+    #[test]
+    fn id_is_echoed_back() {
+        let mut server = AprMcpServer::new();
+        let req = JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: Some(serde_json::json!("req-42")),
+            method: "initialize".to_string(),
+            params: serde_json::json!({}),
+        };
+        let resp = server.handle_request(&req);
+        assert_eq!(resp.id, Some(serde_json::json!("req-42")));
+    }
+}

--- a/crates/aprender-mcp/src/tools/mod.rs
+++ b/crates/aprender-mcp/src/tools/mod.rs
@@ -1,0 +1,8 @@
+//! MCP tool implementations for aprender.
+//!
+//! M1 ships only `apr.version`. M2 will add 8 Phase-1 tools (apr.run, apr.qa,
+//! apr.serve, apr.trace, apr.tensors, apr.validate, apr.bench, apr.finetune).
+
+pub mod version;
+
+pub use version::version_tool_definition;

--- a/crates/aprender-mcp/src/tools/version.rs
+++ b/crates/aprender-mcp/src/tools/version.rs
@@ -1,0 +1,62 @@
+//! `apr.version` — M1 stub tool that reports the aprender-mcp crate version.
+
+#![allow(clippy::disallowed_methods)] // serde_json::json! macro expands to .unwrap() internally
+
+use crate::types::{InputSchema, ToolCallResult, ToolDefinition};
+use std::collections::HashMap;
+
+/// Tool name registered with MCP clients.
+pub const NAME: &str = "apr.version";
+
+/// Crate version baked in at compile time.
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Return the MCP tool definition for `apr.version`.
+#[must_use]
+pub fn version_tool_definition() -> ToolDefinition {
+    ToolDefinition {
+        name: NAME.to_string(),
+        description: "Return the aprender-mcp server version. Takes no arguments.".to_string(),
+        input_schema: InputSchema {
+            schema_type: "object".to_string(),
+            properties: HashMap::new(),
+            required: vec![],
+        },
+    }
+}
+
+/// Execute the `apr.version` tool.
+#[must_use]
+pub fn call(_args: &serde_json::Value) -> ToolCallResult {
+    let payload = serde_json::json!({
+        "server": crate::SERVER_NAME,
+        "version": VERSION,
+        "protocol_version": crate::PROTOCOL_VERSION,
+    });
+    ToolCallResult::success(payload.to_string())
+}
+
+#[cfg(test)]
+#[allow(clippy::disallowed_methods)] // serde_json::json! expands to code that hits unwrap()
+mod tests {
+    use super::*;
+
+    #[test]
+    fn definition_has_correct_name() {
+        let def = version_tool_definition();
+        assert_eq!(def.name, "apr.version");
+        assert!(def.input_schema.required.is_empty());
+        assert_eq!(def.input_schema.schema_type, "object");
+    }
+
+    #[test]
+    fn call_returns_version_payload() {
+        let result = call(&serde_json::json!({}));
+        assert!(result.is_error.is_none());
+        let text = &result.content[0].text;
+        let parsed: serde_json::Value = serde_json::from_str(text).expect("valid json");
+        assert_eq!(parsed["server"], "aprender-mcp");
+        assert_eq!(parsed["version"], VERSION);
+        assert_eq!(parsed["protocol_version"], "2024-11-05");
+    }
+}

--- a/crates/aprender-mcp/src/types.rs
+++ b/crates/aprender-mcp/src/types.rs
@@ -1,0 +1,207 @@
+//! JSON-RPC 2.0 + MCP protocol types.
+//!
+//! Mirrors `aprender-orchestrate::mcp::types` so downstream tools can depend on
+//! `aprender-mcp` without pulling the entire batuta dependency tree.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// JSON-RPC 2.0 request envelope.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JsonRpcRequest {
+    pub jsonrpc: String,
+    pub id: Option<serde_json::Value>,
+    pub method: String,
+    #[serde(default)]
+    pub params: serde_json::Value,
+}
+
+/// JSON-RPC 2.0 response envelope.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JsonRpcResponse {
+    pub jsonrpc: String,
+    pub id: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<JsonRpcError>,
+}
+
+/// JSON-RPC 2.0 error object.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JsonRpcError {
+    pub code: i64,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<serde_json::Value>,
+}
+
+impl JsonRpcResponse {
+    #[must_use]
+    pub fn success(id: Option<serde_json::Value>, result: serde_json::Value) -> Self {
+        Self {
+            jsonrpc: "2.0".to_string(),
+            id,
+            result: Some(result),
+            error: None,
+        }
+    }
+
+    pub fn error(id: Option<serde_json::Value>, code: i64, message: impl Into<String>) -> Self {
+        Self {
+            jsonrpc: "2.0".to_string(),
+            id,
+            result: None,
+            error: Some(JsonRpcError {
+                code,
+                message: message.into(),
+                data: None,
+            }),
+        }
+    }
+}
+
+/// `initialize` response capabilities block.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ServerCapabilities {
+    pub tools: ToolsCapability,
+}
+
+/// Tools capability flags.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolsCapability {
+    #[serde(rename = "listChanged")]
+    pub list_changed: bool,
+}
+
+/// MCP tool registration record.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolDefinition {
+    pub name: String,
+    pub description: String,
+    #[serde(rename = "inputSchema")]
+    pub input_schema: InputSchema,
+}
+
+/// JSON Schema for a tool's input.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InputSchema {
+    #[serde(rename = "type")]
+    pub schema_type: String,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub properties: HashMap<String, PropertySchema>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub required: Vec<String>,
+}
+
+/// JSON Schema for one input property.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PropertySchema {
+    #[serde(rename = "type")]
+    pub prop_type: String,
+    pub description: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub r#enum: Option<Vec<String>>,
+}
+
+/// Result returned by `tools/call`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolCallResult {
+    pub content: Vec<ContentBlock>,
+    #[serde(rename = "isError", skip_serializing_if = "Option::is_none")]
+    pub is_error: Option<bool>,
+}
+
+/// One content block in a tool result.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ContentBlock {
+    #[serde(rename = "type")]
+    pub content_type: String,
+    pub text: String,
+}
+
+impl ContentBlock {
+    pub fn text(content: impl Into<String>) -> Self {
+        Self {
+            content_type: "text".to_string(),
+            text: content.into(),
+        }
+    }
+}
+
+impl ToolCallResult {
+    pub fn success(text: impl Into<String>) -> Self {
+        Self {
+            content: vec![ContentBlock::text(text)],
+            is_error: None,
+        }
+    }
+
+    pub fn error(text: impl Into<String>) -> Self {
+        Self {
+            content: vec![ContentBlock::text(text)],
+            is_error: Some(true),
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::disallowed_methods)] // serde_json::json! expands to code that hits unwrap()
+mod tests {
+    use super::*;
+
+    #[test]
+    fn json_rpc_response_success_round_trips() {
+        let resp = JsonRpcResponse::success(Some(serde_json::json!(1)), serde_json::json!("ok"));
+        assert!(resp.result.is_some());
+        assert!(resp.error.is_none());
+        assert_eq!(resp.jsonrpc, "2.0");
+    }
+
+    #[test]
+    fn json_rpc_response_error_sets_code() {
+        let resp = JsonRpcResponse::error(Some(serde_json::json!(2)), -32600, "Invalid Request");
+        assert!(resp.result.is_none());
+        let err = resp.error.expect("error present");
+        assert_eq!(err.code, -32600);
+        assert_eq!(err.message, "Invalid Request");
+    }
+
+    #[test]
+    fn tool_call_result_success_has_no_error_flag() {
+        let result = ToolCallResult::success("hello");
+        assert_eq!(result.content.len(), 1);
+        assert_eq!(result.content[0].text, "hello");
+        assert!(result.is_error.is_none());
+    }
+
+    #[test]
+    fn tool_call_result_error_flags_error() {
+        let result = ToolCallResult::error("fail");
+        assert_eq!(result.is_error, Some(true));
+    }
+
+    #[test]
+    fn content_block_text_defaults_type() {
+        let block = ContentBlock::text("test");
+        assert_eq!(block.content_type, "text");
+    }
+
+    #[test]
+    fn json_rpc_request_deserializes_tools_list() {
+        let json = r#"{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}"#;
+        let req: JsonRpcRequest = serde_json::from_str(json).expect("deserialize");
+        assert_eq!(req.method, "tools/list");
+    }
+
+    #[test]
+    fn input_schema_serializes_object_type() {
+        let schema = InputSchema {
+            schema_type: "object".to_string(),
+            properties: HashMap::new(),
+            required: vec![],
+        };
+        let json = serde_json::to_string(&schema).expect("serialize");
+        assert!(json.contains("\"type\":\"object\""));
+    }
+}

--- a/crates/aprender-mcp/tests/falsify_m1.rs
+++ b/crates/aprender-mcp/tests/falsify_m1.rs
@@ -1,0 +1,95 @@
+//! FALSIFY-MCP-001 + FALSIFY-MCP-002 (M1 subset) — protocol-level gates.
+//!
+//! These mirror the spec in `docs/specifications/apr-mcp-server-spec.md` and
+//! exercise `AprMcpServer` through its public JSON-RPC surface only.
+
+#![allow(clippy::disallowed_methods)] // serde_json::json! expands to code that hits unwrap()
+
+use aprender_mcp::{AprMcpServer, JsonRpcRequest, PROTOCOL_VERSION};
+use std::time::Instant;
+
+fn request(id: u64, method: &str, params: serde_json::Value) -> JsonRpcRequest {
+    JsonRpcRequest {
+        jsonrpc: "2.0".to_string(),
+        id: Some(serde_json::json!(id)),
+        method: method.to_string(),
+        params,
+    }
+}
+
+/// FALSIFY-MCP-001: `initialize` responds within 500ms with the correct
+/// `protocolVersion`. In-process dispatch, no stdio overhead — the spec budget
+/// includes transport; we assert ≤50ms which is ~10× headroom for CI noise.
+#[test]
+fn falsify_mcp_001_initialize_under_500ms() {
+    let mut server = AprMcpServer::new();
+    let req = request(1, "initialize", serde_json::json!({}));
+
+    let t0 = Instant::now();
+    let resp = server.handle_request(&req);
+    let elapsed = t0.elapsed();
+
+    assert!(
+        elapsed.as_millis() < 50,
+        "initialize took {elapsed:?}, spec budget 500ms / test budget 50ms"
+    );
+
+    let result = resp.result.expect("initialize result");
+    assert_eq!(result["protocolVersion"], PROTOCOL_VERSION);
+}
+
+/// FALSIFY-MCP-002 (M1 subset): `tools/list` returns the M1 tool set and each
+/// schema is a valid JSON Schema object. Full 8-tool check lands in M2.
+#[test]
+fn falsify_mcp_002_tools_list_schema_shape() {
+    let mut server = AprMcpServer::new();
+    let resp = server.handle_request(&request(2, "tools/list", serde_json::json!({})));
+
+    let result = resp.result.expect("tools/list result");
+    let tools = result["tools"].as_array().expect("tools array");
+
+    assert_eq!(tools.len(), 1, "M1 registers exactly one tool");
+    for tool in tools {
+        assert!(tool["name"].is_string(), "name present");
+        assert!(tool["description"].is_string(), "description present");
+        let schema = &tool["inputSchema"];
+        assert_eq!(schema["type"], "object", "schema is object type");
+    }
+}
+
+/// Parse errors on malformed JSON must NOT panic — the stdio loop returns
+/// JSON-RPC code -32700. The types layer handles this; we assert at the
+/// dispatch layer that unknown methods return -32601.
+#[test]
+fn unknown_method_maps_to_minus_32601() {
+    let mut server = AprMcpServer::new();
+    let resp = server.handle_request(&request(3, "nonexistent/method", serde_json::json!({})));
+
+    assert!(resp.result.is_none());
+    assert_eq!(resp.error.expect("error").code, -32601);
+}
+
+/// End-to-end `initialize` → `tools/list` → `tools/call` works on one server
+/// instance without state leaking between requests.
+#[test]
+fn sequential_dispatch_keeps_server_healthy() {
+    let mut server = AprMcpServer::new();
+
+    let init = server.handle_request(&request(10, "initialize", serde_json::json!({})));
+    assert!(init.error.is_none());
+
+    let list = server.handle_request(&request(11, "tools/list", serde_json::json!({})));
+    assert!(list.error.is_none());
+
+    let call = server.handle_request(&request(
+        12,
+        "tools/call",
+        serde_json::json!({ "name": "apr.version", "arguments": {} }),
+    ));
+    let text = call.result.expect("call result")["content"][0]["text"]
+        .as_str()
+        .expect("text")
+        .to_string();
+    let payload: serde_json::Value = serde_json::from_str(&text).expect("json");
+    assert_eq!(payload["server"], "aprender-mcp");
+}


### PR DESCRIPTION
## Summary

- Creates new `aprender-mcp` crate implementing MCP v2024-11-05 over JSON-RPC 2.0 stdio
- Adds `apr mcp` subcommand wired to `aprender_mcp::AprMcpServer::run_stdio()`
- M1 scope: skeleton + 1 stub tool (`apr.version`); M2 will add 8 Phase-1 tools

## Why

aprender hits 1.43× Ollama decode at 128 tokens but no agentic client can invoke it. None of the local-inference tier (Ollama, llama.cpp, Unsloth) ships a first-party MCP server — shipping `apr mcp` first occupies that slot. Every competitor tool with ecosystem momentum in early 2026 is addressable via MCP except local inference.

## M1 surface

- `initialize` → `{"protocolVersion":"2024-11-05","serverInfo":{"name":"aprender-mcp",...}}`
- `tools/list` → `[apr.version]` with valid JSONSchema Draft 7
- `tools/call apr.version` → `{server, version, protocol_version}`
- Parse errors → `-32700`, method not found → `-32601`, unknown tool → `isError: true`

## Falsification gates passing

- **FALSIFY-MCP-001**: `initialize` responds in <50ms (in-process; spec budget 500ms, ~10× headroom for CI noise)
- **FALSIFY-MCP-002 (M1 subset)**: `tools/list` schema shape validates
- 21 tests total (16 unit + 4 integration + 1 doctest)

## Smoke test
\`\`\`console
\$ echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}' | apr mcp
{"jsonrpc":"2.0","id":1,"result":{"capabilities":{"tools":{"listChanged":false}},"protocolVersion":"2024-11-05","serverInfo":{"name":"aprender-mcp","version":"0.30.0"}}}
\`\`\`

## Files

- `crates/aprender-mcp/` — new crate (lib.rs, server.rs, types.rs, tools/version.rs, tests/falsify_m1.rs, README.md)
- `crates/apr-cli/src/commands/mcp.rs` — subcommand wrapper
- `crates/apr-cli/src/commands_enum.rs` — `Mcp {}` variant
- `crates/apr-cli/src/dispatch.rs` — dispatch arm
- `crates/apr-cli/Cargo.toml` — new `aprender-mcp` dep
- `Cargo.toml` — workspace members update

## Spec

Full design: [\`docs/specifications/apr-mcp-server-spec.md\`](docs/specifications/apr-mcp-server-spec.md)

## Milestones

- **M1 (this PR)**: skeleton + `apr.version` — \`cargo install aprender\` ships an MCP-capable binary
- **M2**: 8 Phase-1 tools (`apr.run`, `apr.serve`, `apr.qa`, `apr.trace`, `apr.tensors`, `apr.validate`, `apr.bench`, `apr.finetune`) with schema generation from \`contracts/apr-cli-commands-v1.yaml\`
- **M3**: streaming progress + cancellation (\`notifications/progress\`, \`notifications/cancelled\`)
- **M4**: Claude Code dogfood + promote contract to ENFORCED

## Test plan

- [x] \`cargo build -p aprender-mcp\` passes
- [x] \`cargo test -p aprender-mcp\` — 21/21 pass
- [x] \`cargo clippy -p aprender-mcp --all-targets -- -D warnings\` clean
- [x] \`cargo clippy -p apr-cli --lib\` clean
- [x] End-to-end stdio smoke test (see above)
- [ ] CI \`workspace-test\` green
- [ ] PMAT quality gates green

Tracks #863.

🤖 Generated with [Claude Code](https://claude.com/claude-code)