### PR TITLE
feat(mcp): M2 slice 1 — apr.validate subprocess wrapper

### DIFF
--- a/crates/aprender-mcp/README.md
+++ b/crates/aprender-mcp/README.md
@@ -37,14 +37,16 @@ apr mcp
 
 ## Milestones
 
-- **M1** (current): skeleton with `initialize` + `tools/list` + `apr.version`
-- **M2**: 8 Phase-1 tools (`apr.run`, `apr.serve`, `apr.qa`, `apr.trace`,
-  `apr.tensors`, `apr.validate`, `apr.bench`, `apr.finetune`)
+- **M1** (shipped): skeleton with `initialize` + `tools/list` + `apr.version`
+- **M2** (in progress): 8 Phase-1 tools as subprocess wrappers over
+  `apr <cmd> --json`. Shipped so far: `apr.validate`. Remaining: `apr.run`,
+  `apr.serve`, `apr.qa`, `apr.trace`, `apr.tensors`, `apr.bench`, `apr.finetune`
 - **M3**: streaming progress notifications + cancellation
 - **M4**: Claude Code dogfood + contract promotion to ENFORCED
 
 ## Falsification gates
 
 See [`contracts/apr-mcp-server-v1.yaml`](../../contracts/apr-mcp-server-v1.yaml)
-for the full set. M1 ships FALSIFY-MCP-001 (initialize latency) and a subset
-of FALSIFY-MCP-002 (tools/list schema).
+for the full set. Currently enforced: FALSIFY-MCP-001 (initialize latency),
+FALSIFY-MCP-002 (progressive — every registered tool has a valid schema),
+and FALSIFY-MCP-VALIDATE-001 (argument validation surfaces as tool error).

--- a/crates/aprender-mcp/src/server.rs
+++ b/crates/aprender-mcp/src/server.rs
@@ -64,6 +64,7 @@ impl AprMcpServer {
 
         let result = match name {
             Some(tools::version::NAME) => tools::version::call(&arguments),
+            Some(tools::validate::NAME) => tools::validate::call(&arguments),
             Some(other) => ToolCallResult::error(format!("Unknown tool: {other}")),
             None => ToolCallResult::error("Missing tool name"),
         };
@@ -77,7 +78,10 @@ impl AprMcpServer {
     /// All tool definitions registered on this server.
     #[must_use]
     pub fn tool_definitions(&self) -> Vec<ToolDefinition> {
-        vec![tools::version_tool_definition()]
+        vec![
+            tools::version_tool_definition(),
+            tools::validate_tool_definition(),
+        ]
     }
 
     /// Run the server over stdio (blocking).
@@ -143,20 +147,23 @@ mod tests {
         assert!(result["capabilities"]["tools"].is_object());
     }
 
-    /// FALSIFY-MCP-002 (M1 subset): tools/list returns exactly the M1 tools.
+    /// FALSIFY-MCP-002 (M2 slice 1): tools/list returns the currently-registered
+    /// tools (apr.version + apr.validate). Full 8-tool set lands when M2 completes.
     #[test]
-    fn tools_list_returns_m1_tool_set() {
+    fn tools_list_returns_registered_tools() {
         let mut server = AprMcpServer::new();
         let req = make_request("tools/list", serde_json::json!({}));
         let resp = server.handle_request(&req);
 
         let result = resp.result.expect("result present");
         let tools = result["tools"].as_array().expect("tools array");
-        assert_eq!(tools.len(), 1, "M1 ships only apr.version");
-        assert_eq!(tools[0]["name"], "apr.version");
+        let names: Vec<&str> = tools.iter().filter_map(|t| t["name"].as_str()).collect();
+        assert!(names.contains(&"apr.version"), "apr.version registered");
+        assert!(names.contains(&"apr.validate"), "apr.validate registered");
 
-        let schema = &tools[0]["inputSchema"];
-        assert_eq!(schema["type"], "object");
+        for tool in tools {
+            assert_eq!(tool["inputSchema"]["type"], "object");
+        }
     }
 
     #[test]
@@ -184,6 +191,23 @@ mod tests {
         assert!(resp.result.is_none());
         let err = resp.error.expect("error present");
         assert_eq!(err.code, -32601);
+    }
+
+    /// `apr.validate` without `model_path` must return `isError: true` via
+    /// the argument-validation branch (no subprocess spawn).
+    #[test]
+    fn tools_call_validate_missing_model_path_is_error() {
+        let mut server = AprMcpServer::new();
+        let req = make_request(
+            "tools/call",
+            serde_json::json!({ "name": "apr.validate", "arguments": {} }),
+        );
+        let resp = server.handle_request(&req);
+
+        let result = resp.result.expect("result present");
+        assert_eq!(result["isError"], true);
+        let text = result["content"][0]["text"].as_str().expect("text");
+        assert!(text.contains("model_path"));
     }
 
     #[test]

--- a/crates/aprender-mcp/src/tools/mod.rs
+++ b/crates/aprender-mcp/src/tools/mod.rs
@@ -1,8 +1,11 @@
 //! MCP tool implementations for aprender.
 //!
-//! M1 ships only `apr.version`. M2 will add 8 Phase-1 tools (apr.run, apr.qa,
-//! apr.serve, apr.trace, apr.tensors, apr.validate, apr.bench, apr.finetune).
+//! M1 shipped `apr.version`. M2 adds 8 Phase-1 tools as subprocess wrappers
+//! around `apr <cmd> --json`. This module is the first M2 slice: `apr.validate`.
+//! Follow-ups add run, serve, qa, trace, tensors, bench, finetune.
 
+pub mod validate;
 pub mod version;
 
+pub use validate::validate_tool_definition;
 pub use version::version_tool_definition;

--- a/crates/aprender-mcp/src/tools/validate.rs
+++ b/crates/aprender-mcp/src/tools/validate.rs
@@ -1,0 +1,104 @@
+//! `apr.validate` — M2 subprocess wrapper over `apr validate <model> --json`.
+//!
+//! This is the first M2 tool and exercises the subprocess pattern that the
+//! remaining 7 Phase-1 tools will follow: spawn `apr <subcommand> --json`,
+//! capture stdout, pass through to the MCP client as a single text content
+//! block. Non-zero exit maps to `isError: true` with stderr attached.
+
+#![allow(clippy::disallowed_methods)] // serde_json::json! macro expands to .unwrap() internally
+
+use crate::types::{InputSchema, PropertySchema, ToolCallResult, ToolDefinition};
+use std::collections::HashMap;
+use std::process::Command;
+
+/// Tool name registered with MCP clients.
+pub const NAME: &str = "apr.validate";
+
+/// Return the MCP tool definition for `apr.validate`.
+#[must_use]
+pub fn validate_tool_definition() -> ToolDefinition {
+    let mut properties = HashMap::new();
+    properties.insert(
+        "model_path".to_string(),
+        PropertySchema {
+            prop_type: "string".to_string(),
+            description: "Path to the model file (.apr, .gguf, or .safetensors)".to_string(),
+            r#enum: None,
+        },
+    );
+    ToolDefinition {
+        name: NAME.to_string(),
+        description:
+            "Validate a model file's integrity and quality. Wraps `apr validate <model> --json`."
+                .to_string(),
+        input_schema: InputSchema {
+            schema_type: "object".to_string(),
+            properties,
+            required: vec!["model_path".to_string()],
+        },
+    }
+}
+
+/// Execute `apr.validate` by spawning `apr validate <model_path> --json`.
+#[must_use]
+pub fn call(args: &serde_json::Value) -> ToolCallResult {
+    let Some(model_path) = args.get("model_path").and_then(|v| v.as_str()) else {
+        return ToolCallResult::error("Missing required argument: model_path");
+    };
+
+    let output = match Command::new("apr")
+        .args(["validate", model_path, "--json"])
+        .output()
+    {
+        Ok(o) => o,
+        Err(e) => return ToolCallResult::error(format!("Failed to spawn `apr validate`: {e}")),
+    };
+
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+
+    if output.status.success() {
+        // stdout is JSON from `apr validate --json`; pass through verbatim.
+        if stdout.trim().is_empty() {
+            ToolCallResult::error("apr validate produced no output")
+        } else {
+            ToolCallResult::success(stdout)
+        }
+    } else {
+        let code = output.status.code().unwrap_or(-1);
+        let detail = if stderr.trim().is_empty() {
+            stdout
+        } else {
+            stderr
+        };
+        ToolCallResult::error(format!("apr validate failed (exit {code}): {detail}"))
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::disallowed_methods)] // serde_json::json! expands to code that hits unwrap()
+mod tests {
+    use super::*;
+
+    #[test]
+    fn definition_has_correct_name_and_required_field() {
+        let def = validate_tool_definition();
+        assert_eq!(def.name, "apr.validate");
+        assert_eq!(def.input_schema.schema_type, "object");
+        assert_eq!(def.input_schema.required, vec!["model_path".to_string()]);
+        assert!(def.input_schema.properties.contains_key("model_path"));
+    }
+
+    #[test]
+    fn missing_model_path_returns_error() {
+        let result = call(&serde_json::json!({}));
+        assert_eq!(result.is_error, Some(true));
+        assert!(result.content[0].text.contains("model_path"));
+    }
+
+    #[test]
+    fn nonstring_model_path_returns_error() {
+        let result = call(&serde_json::json!({ "model_path": 42 }));
+        assert_eq!(result.is_error, Some(true));
+    }
+}

--- a/crates/aprender-mcp/tests/falsify_m1.rs
+++ b/crates/aprender-mcp/tests/falsify_m1.rs
@@ -38,8 +38,10 @@ fn falsify_mcp_001_initialize_under_500ms() {
     assert_eq!(result["protocolVersion"], PROTOCOL_VERSION);
 }
 
-/// FALSIFY-MCP-002 (M1 subset): `tools/list` returns the M1 tool set and each
-/// schema is a valid JSON Schema object. Full 8-tool check lands in M2.
+/// FALSIFY-MCP-002 (progressive): `tools/list` must include every tool that
+/// has shipped so far (apr.version from M1, apr.validate from M2 slice 1) and
+/// every registered schema must be a valid JSON Schema object. The full
+/// 8-tool check lands when M2 completes.
 #[test]
 fn falsify_mcp_002_tools_list_schema_shape() {
     let mut server = AprMcpServer::new();
@@ -48,7 +50,10 @@ fn falsify_mcp_002_tools_list_schema_shape() {
     let result = resp.result.expect("tools/list result");
     let tools = result["tools"].as_array().expect("tools array");
 
-    assert_eq!(tools.len(), 1, "M1 registers exactly one tool");
+    let names: Vec<&str> = tools.iter().filter_map(|t| t["name"].as_str()).collect();
+    assert!(names.contains(&"apr.version"), "apr.version registered");
+    assert!(names.contains(&"apr.validate"), "apr.validate registered");
+
     for tool in tools {
         assert!(tool["name"].is_string(), "name present");
         assert!(tool["description"].is_string(), "description present");
@@ -67,6 +72,29 @@ fn unknown_method_maps_to_minus_32601() {
 
     assert!(resp.result.is_none());
     assert_eq!(resp.error.expect("error").code, -32601);
+}
+
+/// FALSIFY-MCP-VALIDATE-001: calling `apr.validate` without `model_path` must
+/// surface a tool-level error (isError:true) rather than a JSON-RPC error —
+/// the MCP spec requires argument validation failures to come back as
+/// tool-call results so the LLM sees and can react to them.
+#[test]
+fn falsify_validate_missing_model_path_is_tool_error() {
+    let mut server = AprMcpServer::new();
+    let resp = server.handle_request(&request(
+        20,
+        "tools/call",
+        serde_json::json!({ "name": "apr.validate", "arguments": {} }),
+    ));
+
+    // JSON-RPC layer must succeed; the error belongs inside the result.
+    assert!(resp.error.is_none(), "JSON-RPC error should be none");
+    let result = resp.result.expect("tools/call result");
+    assert_eq!(result["isError"], true);
+    assert!(result["content"][0]["text"]
+        .as_str()
+        .expect("text")
+        .contains("model_path"));
 }
 
 /// End-to-end `initialize` → `tools/list` → `tools/call` works on one server


### PR DESCRIPTION
## Summary

First M2 tool for `aprender-mcp`. Proves the subprocess-wrapper pattern
the remaining seven Phase-1 tools will follow: spawn `apr validate <model> --json`,
capture stdout, return it verbatim as a text content block. Non-zero exit
maps to `isError: true` with stderr attached.

## Changes

- `tools/validate.rs` — definition + `call()` with required `model_path` arg
- `server.rs` — register in `tool_definitions()` and dispatch in `tools/call`
- `falsify_m1.rs` — FALSIFY-MCP-002 generalized to every shipped tool (apr.version + apr.validate); new **FALSIFY-MCP-VALIDATE-001** asserts that missing `model_path` surfaces as a tool-level error (`isError:true`) rather than a JSON-RPC error
- Unit tests: schema shape, missing arg, non-string arg

## Follow-ups (each its own PR)

- `apr.run`, `apr.serve`, `apr.qa`, `apr.trace`, `apr.tensors`, `apr.bench`, `apr.finetune`

## Test plan

- [x] `cargo test -p aprender-mcp` — 20 lib + 5 integration
- [x] `cargo clippy -p aprender-mcp --all-targets -- -D warnings`
- [x] `cargo fmt -p aprender-mcp --check`
- [x] `cargo test -p apr-cli --test cli_commands` — CLI contract still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)