### PR TITLE
feat(mcp): M2 slices 2+3 — apr.tensors, apr.bench + shared run_apr helper

### DIFF
--- a/crates/aprender-mcp/README.md
+++ b/crates/aprender-mcp/README.md
@@ -37,14 +37,16 @@ apr mcp
 
 ## Milestones
 
-- **M1** (current): skeleton with `initialize` + `tools/list` + `apr.version`
-- **M2**: 8 Phase-1 tools (`apr.run`, `apr.serve`, `apr.qa`, `apr.trace`,
-  `apr.tensors`, `apr.validate`, `apr.bench`, `apr.finetune`)
+- **M1** (shipped): skeleton with `initialize` + `tools/list` + `apr.version`
+- **M2** (in progress): 8 Phase-1 tools as subprocess wrappers over
+  `apr <cmd> --json`. Shipped so far: `apr.validate`. Remaining: `apr.run`,
+  `apr.serve`, `apr.qa`, `apr.trace`, `apr.tensors`, `apr.bench`, `apr.finetune`
 - **M3**: streaming progress notifications + cancellation
 - **M4**: Claude Code dogfood + contract promotion to ENFORCED
 
 ## Falsification gates
 
 See [`contracts/apr-mcp-server-v1.yaml`](../../contracts/apr-mcp-server-v1.yaml)
-for the full set. M1 ships FALSIFY-MCP-001 (initialize latency) and a subset
-of FALSIFY-MCP-002 (tools/list schema).
+for the full set. Currently enforced: FALSIFY-MCP-001 (initialize latency),
+FALSIFY-MCP-002 (progressive — every registered tool has a valid schema),
+and FALSIFY-MCP-VALIDATE-001 (argument validation surfaces as tool error).

--- a/crates/aprender-mcp/src/server.rs
+++ b/crates/aprender-mcp/src/server.rs
@@ -64,6 +64,7 @@ impl AprMcpServer {
 
         let result = match name {
             Some(tools::version::NAME) => tools::version::call(&arguments),
+            Some(tools::validate::NAME) => tools::validate::call(&arguments),
             Some(other) => ToolCallResult::error(format!("Unknown tool: {other}")),
             None => ToolCallResult::error("Missing tool name"),
         };
@@ -77,7 +78,10 @@ impl AprMcpServer {
     /// All tool definitions registered on this server.
     #[must_use]
     pub fn tool_definitions(&self) -> Vec<ToolDefinition> {
-        vec![tools::version_tool_definition()]
+        vec![
+            tools::version_tool_definition(),
+            tools::validate_tool_definition(),
+        ]
     }
 
     /// Run the server over stdio (blocking).
@@ -143,20 +147,23 @@ mod tests {
         assert!(result["capabilities"]["tools"].is_object());
     }
 
-    /// FALSIFY-MCP-002 (M1 subset): tools/list returns exactly the M1 tools.
+    /// FALSIFY-MCP-002 (M2 slice 1): tools/list returns the currently-registered
+    /// tools (apr.version + apr.validate). Full 8-tool set lands when M2 completes.
     #[test]
-    fn tools_list_returns_m1_tool_set() {
+    fn tools_list_returns_registered_tools() {
         let mut server = AprMcpServer::new();
         let req = make_request("tools/list", serde_json::json!({}));
         let resp = server.handle_request(&req);
 
         let result = resp.result.expect("result present");
         let tools = result["tools"].as_array().expect("tools array");
-        assert_eq!(tools.len(), 1, "M1 ships only apr.version");
-        assert_eq!(tools[0]["name"], "apr.version");
+        let names: Vec<&str> = tools.iter().filter_map(|t| t["name"].as_str()).collect();
+        assert!(names.contains(&"apr.version"), "apr.version registered");
+        assert!(names.contains(&"apr.validate"), "apr.validate registered");
 
-        let schema = &tools[0]["inputSchema"];
-        assert_eq!(schema["type"], "object");
+        for tool in tools {
+            assert_eq!(tool["inputSchema"]["type"], "object");
+        }
     }
 
     #[test]
@@ -184,6 +191,23 @@ mod tests {
         assert!(resp.result.is_none());
         let err = resp.error.expect("error present");
         assert_eq!(err.code, -32601);
+    }
+
+    /// `apr.validate` without `model_path` must return `isError: true` via
+    /// the argument-validation branch (no subprocess spawn).
+    #[test]
+    fn tools_call_validate_missing_model_path_is_error() {
+        let mut server = AprMcpServer::new();
+        let req = make_request(
+            "tools/call",
+            serde_json::json!({ "name": "apr.validate", "arguments": {} }),
+        );
+        let resp = server.handle_request(&req);
+
+        let result = resp.result.expect("result present");
+        assert_eq!(result["isError"], true);
+        let text = result["content"][0]["text"].as_str().expect("text");
+        assert!(text.contains("model_path"));
     }
 
     #[test]

--- a/crates/aprender-mcp/src/server.rs
+++ b/crates/aprender-mcp/src/server.rs
@@ -65,6 +65,8 @@ impl AprMcpServer {
         let result = match name {
             Some(tools::version::NAME) => tools::version::call(&arguments),
             Some(tools::validate::NAME) => tools::validate::call(&arguments),
+            Some(tools::tensors::NAME) => tools::tensors::call(&arguments),
+            Some(tools::bench::NAME) => tools::bench::call(&arguments),
             Some(other) => ToolCallResult::error(format!("Unknown tool: {other}")),
             None => ToolCallResult::error("Missing tool name"),
         };
@@ -81,6 +83,8 @@ impl AprMcpServer {
         vec![
             tools::version_tool_definition(),
             tools::validate_tool_definition(),
+            tools::tensors_tool_definition(),
+            tools::bench_tool_definition(),
         ]
     }
 
@@ -147,8 +151,8 @@ mod tests {
         assert!(result["capabilities"]["tools"].is_object());
     }
 
-    /// FALSIFY-MCP-002 (M2 slice 1): tools/list returns the currently-registered
-    /// tools (apr.version + apr.validate). Full 8-tool set lands when M2 completes.
+    /// FALSIFY-MCP-002 (progressive): tools/list returns every tool that has
+    /// shipped so far. Full 8-tool set lands when M2 completes.
     #[test]
     fn tools_list_returns_registered_tools() {
         let mut server = AprMcpServer::new();
@@ -158,8 +162,9 @@ mod tests {
         let result = resp.result.expect("result present");
         let tools = result["tools"].as_array().expect("tools array");
         let names: Vec<&str> = tools.iter().filter_map(|t| t["name"].as_str()).collect();
-        assert!(names.contains(&"apr.version"), "apr.version registered");
-        assert!(names.contains(&"apr.validate"), "apr.validate registered");
+        for expected in ["apr.version", "apr.validate", "apr.tensors", "apr.bench"] {
+            assert!(names.contains(&expected), "{expected} registered");
+        }
 
         for tool in tools {
             assert_eq!(tool["inputSchema"]["type"], "object");

--- a/crates/aprender-mcp/src/tools/bench.rs
+++ b/crates/aprender-mcp/src/tools/bench.rs
@@ -1,0 +1,118 @@
+//! `apr.bench` — M2 tool. Benchmark inference throughput (tok/s, latency percentiles).
+//!
+//! Wraps `apr bench <model> --json [--iterations N] [--max-tokens N] [--prompt X]`.
+
+#![allow(clippy::disallowed_methods)] // serde_json::json! macro expands to .unwrap() internally
+
+use crate::tools::subprocess::run_apr;
+use crate::types::{InputSchema, PropertySchema, ToolCallResult, ToolDefinition};
+use std::collections::HashMap;
+
+/// Tool name registered with MCP clients.
+pub const NAME: &str = "apr.bench";
+
+/// Return the MCP tool definition for `apr.bench`.
+#[must_use]
+pub fn bench_tool_definition() -> ToolDefinition {
+    let mut properties = HashMap::new();
+    properties.insert(
+        "model_path".to_string(),
+        PropertySchema {
+            prop_type: "string".to_string(),
+            description: "Path to the model file (.apr, .gguf, or .safetensors)".to_string(),
+            r#enum: None,
+        },
+    );
+    properties.insert(
+        "iterations".to_string(),
+        PropertySchema {
+            prop_type: "integer".to_string(),
+            description: "Measurement iterations (default 5)".to_string(),
+            r#enum: None,
+        },
+    );
+    properties.insert(
+        "max_tokens".to_string(),
+        PropertySchema {
+            prop_type: "integer".to_string(),
+            description: "Max tokens to generate per iteration (default 32)".to_string(),
+            r#enum: None,
+        },
+    );
+    properties.insert(
+        "prompt".to_string(),
+        PropertySchema {
+            prop_type: "string".to_string(),
+            description: "Test prompt (default: model-specific)".to_string(),
+            r#enum: None,
+        },
+    );
+    ToolDefinition {
+        name: NAME.to_string(),
+        description: "Benchmark model throughput and latency. Wraps `apr bench <model> --json`."
+            .to_string(),
+        input_schema: InputSchema {
+            schema_type: "object".to_string(),
+            properties,
+            required: vec!["model_path".to_string()],
+        },
+    }
+}
+
+/// Execute `apr.bench` by spawning `apr bench <model> --json [...flags]`.
+#[must_use]
+pub fn call(args: &serde_json::Value) -> ToolCallResult {
+    let Some(model_path) = args.get("model_path").and_then(|v| v.as_str()) else {
+        return ToolCallResult::error("Missing required argument: model_path");
+    };
+
+    let mut owned: Vec<String> = vec![
+        "bench".to_string(),
+        model_path.to_string(),
+        "--json".to_string(),
+    ];
+
+    if let Some(n) = args.get("iterations").and_then(serde_json::Value::as_u64) {
+        owned.push("--iterations".to_string());
+        owned.push(n.to_string());
+    }
+    if let Some(n) = args.get("max_tokens").and_then(serde_json::Value::as_u64) {
+        owned.push("--max-tokens".to_string());
+        owned.push(n.to_string());
+    }
+    let prompt = args.get("prompt").and_then(|v| v.as_str()).unwrap_or("");
+    if !prompt.is_empty() {
+        owned.push("--prompt".to_string());
+        owned.push(prompt.to_string());
+    }
+
+    let argv: Vec<&str> = owned.iter().map(String::as_str).collect();
+    run_apr(&argv)
+}
+
+#[cfg(test)]
+#[allow(clippy::disallowed_methods)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn definition_has_correct_name_and_required_field() {
+        let def = bench_tool_definition();
+        assert_eq!(def.name, "apr.bench");
+        assert_eq!(def.input_schema.schema_type, "object");
+        assert_eq!(def.input_schema.required, vec!["model_path".to_string()]);
+        for field in ["model_path", "iterations", "max_tokens", "prompt"] {
+            assert!(
+                def.input_schema.properties.contains_key(field),
+                "property {field} present"
+            );
+        }
+    }
+
+    #[test]
+    fn missing_model_path_returns_error() {
+        let result = call(&serde_json::json!({}));
+        assert_eq!(result.is_error, Some(true));
+        assert!(result.content[0].text.contains("model_path"));
+    }
+}

--- a/crates/aprender-mcp/src/tools/mod.rs
+++ b/crates/aprender-mcp/src/tools/mod.rs
@@ -1,11 +1,16 @@
 //! MCP tool implementations for aprender.
 //!
 //! M1 shipped `apr.version`. M2 adds 8 Phase-1 tools as subprocess wrappers
-//! around `apr <cmd> --json`. This module is the first M2 slice: `apr.validate`.
-//! Follow-ups add run, serve, qa, trace, tensors, bench, finetune.
+//! around `apr <cmd> --json`. Shipped: `apr.validate`, `apr.tensors`, `apr.bench`.
+//! Follow-ups: `apr.run`, `apr.serve`, `apr.qa`, `apr.trace`, `apr.finetune`.
 
+pub mod bench;
+pub mod subprocess;
+pub mod tensors;
 pub mod validate;
 pub mod version;
 
+pub use bench::bench_tool_definition;
+pub use tensors::tensors_tool_definition;
 pub use validate::validate_tool_definition;
 pub use version::version_tool_definition;

--- a/crates/aprender-mcp/src/tools/mod.rs
+++ b/crates/aprender-mcp/src/tools/mod.rs
@@ -1,8 +1,11 @@
 //! MCP tool implementations for aprender.
 //!
-//! M1 ships only `apr.version`. M2 will add 8 Phase-1 tools (apr.run, apr.qa,
-//! apr.serve, apr.trace, apr.tensors, apr.validate, apr.bench, apr.finetune).
+//! M1 shipped `apr.version`. M2 adds 8 Phase-1 tools as subprocess wrappers
+//! around `apr <cmd> --json`. This module is the first M2 slice: `apr.validate`.
+//! Follow-ups add run, serve, qa, trace, tensors, bench, finetune.
 
+pub mod validate;
 pub mod version;
 
+pub use validate::validate_tool_definition;
 pub use version::version_tool_definition;

--- a/crates/aprender-mcp/src/tools/subprocess.rs
+++ b/crates/aprender-mcp/src/tools/subprocess.rs
@@ -1,0 +1,63 @@
+//! Shared subprocess wrapper for M2 tools.
+//!
+//! Every M2 tool spawns `apr <subcommand> [...args] --json` and passes stdout
+//! through to the MCP client verbatim. Non-zero exit maps to `isError: true`
+//! with stderr attached. This module centralizes that pattern so each tool is
+//! a thin definition + a list of CLI args.
+
+use crate::types::ToolCallResult;
+use std::process::Command;
+
+/// Spawn `apr <args...>` and wrap the result as a `ToolCallResult`.
+///
+/// - Successful exit with non-empty stdout → `success(stdout)`
+/// - Successful exit with empty stdout → `error("apr ... produced no output")`
+/// - Non-zero exit → `error("apr ... failed (exit N): <stderr-or-stdout>")`
+/// - Spawn failure → `error("Failed to spawn apr ...: <io-err>")`
+#[must_use]
+pub fn run_apr(args: &[&str]) -> ToolCallResult {
+    let output = match Command::new("apr").args(args).output() {
+        Ok(o) => o,
+        Err(e) => {
+            let cmd = format!("apr {}", args.join(" "));
+            return ToolCallResult::error(format!("Failed to spawn `{cmd}`: {e}"));
+        }
+    };
+
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+
+    if output.status.success() {
+        if stdout.trim().is_empty() {
+            let cmd = format!("apr {}", args.join(" "));
+            ToolCallResult::error(format!("`{cmd}` produced no output"))
+        } else {
+            ToolCallResult::success(stdout)
+        }
+    } else {
+        let code = output.status.code().unwrap_or(-1);
+        let detail = if stderr.trim().is_empty() {
+            stdout
+        } else {
+            stderr
+        };
+        let cmd = format!("apr {}", args.join(" "));
+        ToolCallResult::error(format!("`{cmd}` failed (exit {code}): {detail}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Spawning a non-existent binary yields a spawn error, not a panic.
+    #[test]
+    fn spawn_failure_maps_to_tool_error() {
+        // Temporarily simulate missing binary by calling a clearly-absurd
+        // subcommand through the real `apr`. We can't easily swap the binary
+        // name without refactoring, so we exercise the non-zero-exit branch
+        // via an invalid argument instead.
+        let result = run_apr(&["this-subcommand-does-not-exist"]);
+        assert_eq!(result.is_error, Some(true));
+    }
+}

--- a/crates/aprender-mcp/src/tools/tensors.rs
+++ b/crates/aprender-mcp/src/tools/tensors.rs
@@ -1,9 +1,6 @@
-//! `apr.validate` — M2 subprocess wrapper over `apr validate <model> --json`.
+//! `apr.tensors` — M2 tool. List tensor names, shapes, and (optionally) stats.
 //!
-//! This is the first M2 tool and exercises the subprocess pattern that the
-//! remaining 7 Phase-1 tools will follow: spawn `apr <subcommand> --json`,
-//! capture stdout, pass through to the MCP client as a single text content
-//! block. Non-zero exit maps to `isError: true` with stderr attached.
+//! Wraps `apr tensors <model> --json [--stats] [--filter <pat>] [--limit <n>]`.
 
 #![allow(clippy::disallowed_methods)] // serde_json::json! macro expands to .unwrap() internally
 
@@ -12,11 +9,11 @@ use crate::types::{InputSchema, PropertySchema, ToolCallResult, ToolDefinition};
 use std::collections::HashMap;
 
 /// Tool name registered with MCP clients.
-pub const NAME: &str = "apr.validate";
+pub const NAME: &str = "apr.tensors";
 
-/// Return the MCP tool definition for `apr.validate`.
+/// Return the MCP tool definition for `apr.tensors`.
 #[must_use]
-pub fn validate_tool_definition() -> ToolDefinition {
+pub fn tensors_tool_definition() -> ToolDefinition {
     let mut properties = HashMap::new();
     properties.insert(
         "model_path".to_string(),
@@ -26,10 +23,26 @@ pub fn validate_tool_definition() -> ToolDefinition {
             r#enum: None,
         },
     );
+    properties.insert(
+        "stats".to_string(),
+        PropertySchema {
+            prop_type: "boolean".to_string(),
+            description: "Include tensor statistics (mean, std, min, max)".to_string(),
+            r#enum: None,
+        },
+    );
+    properties.insert(
+        "filter".to_string(),
+        PropertySchema {
+            prop_type: "string".to_string(),
+            description: "Filter tensors by name pattern (substring match)".to_string(),
+            r#enum: None,
+        },
+    );
     ToolDefinition {
         name: NAME.to_string(),
         description:
-            "Validate a model file's integrity and quality. Wraps `apr validate <model> --json`."
+            "List tensors in a model with shapes and dtypes. Wraps `apr tensors <model> --json`."
                 .to_string(),
         input_schema: InputSchema {
             schema_type: "object".to_string(),
@@ -39,27 +52,44 @@ pub fn validate_tool_definition() -> ToolDefinition {
     }
 }
 
-/// Execute `apr.validate` by spawning `apr validate <model_path> --json`.
+/// Execute `apr.tensors` by spawning `apr tensors <model> --json [...flags]`.
 #[must_use]
 pub fn call(args: &serde_json::Value) -> ToolCallResult {
     let Some(model_path) = args.get("model_path").and_then(|v| v.as_str()) else {
         return ToolCallResult::error("Missing required argument: model_path");
     };
-    run_apr(&["validate", model_path, "--json"])
+
+    let mut argv: Vec<&str> = vec!["tensors", model_path, "--json"];
+    if args
+        .get("stats")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false)
+    {
+        argv.push("--stats");
+    }
+    let filter = args.get("filter").and_then(|v| v.as_str()).unwrap_or("");
+    if !filter.is_empty() {
+        argv.push("--filter");
+        argv.push(filter);
+    }
+
+    run_apr(&argv)
 }
 
 #[cfg(test)]
-#[allow(clippy::disallowed_methods)] // serde_json::json! expands to code that hits unwrap()
+#[allow(clippy::disallowed_methods)]
 mod tests {
     use super::*;
 
     #[test]
     fn definition_has_correct_name_and_required_field() {
-        let def = validate_tool_definition();
-        assert_eq!(def.name, "apr.validate");
+        let def = tensors_tool_definition();
+        assert_eq!(def.name, "apr.tensors");
         assert_eq!(def.input_schema.schema_type, "object");
         assert_eq!(def.input_schema.required, vec!["model_path".to_string()]);
         assert!(def.input_schema.properties.contains_key("model_path"));
+        assert!(def.input_schema.properties.contains_key("stats"));
+        assert!(def.input_schema.properties.contains_key("filter"));
     }
 
     #[test]
@@ -67,11 +97,5 @@ mod tests {
         let result = call(&serde_json::json!({}));
         assert_eq!(result.is_error, Some(true));
         assert!(result.content[0].text.contains("model_path"));
-    }
-
-    #[test]
-    fn nonstring_model_path_returns_error() {
-        let result = call(&serde_json::json!({ "model_path": 42 }));
-        assert_eq!(result.is_error, Some(true));
     }
 }

--- a/crates/aprender-mcp/src/tools/validate.rs
+++ b/crates/aprender-mcp/src/tools/validate.rs
@@ -1,0 +1,104 @@
+//! `apr.validate` — M2 subprocess wrapper over `apr validate <model> --json`.
+//!
+//! This is the first M2 tool and exercises the subprocess pattern that the
+//! remaining 7 Phase-1 tools will follow: spawn `apr <subcommand> --json`,
+//! capture stdout, pass through to the MCP client as a single text content
+//! block. Non-zero exit maps to `isError: true` with stderr attached.
+
+#![allow(clippy::disallowed_methods)] // serde_json::json! macro expands to .unwrap() internally
+
+use crate::types::{InputSchema, PropertySchema, ToolCallResult, ToolDefinition};
+use std::collections::HashMap;
+use std::process::Command;
+
+/// Tool name registered with MCP clients.
+pub const NAME: &str = "apr.validate";
+
+/// Return the MCP tool definition for `apr.validate`.
+#[must_use]
+pub fn validate_tool_definition() -> ToolDefinition {
+    let mut properties = HashMap::new();
+    properties.insert(
+        "model_path".to_string(),
+        PropertySchema {
+            prop_type: "string".to_string(),
+            description: "Path to the model file (.apr, .gguf, or .safetensors)".to_string(),
+            r#enum: None,
+        },
+    );
+    ToolDefinition {
+        name: NAME.to_string(),
+        description:
+            "Validate a model file's integrity and quality. Wraps `apr validate <model> --json`."
+                .to_string(),
+        input_schema: InputSchema {
+            schema_type: "object".to_string(),
+            properties,
+            required: vec!["model_path".to_string()],
+        },
+    }
+}
+
+/// Execute `apr.validate` by spawning `apr validate <model_path> --json`.
+#[must_use]
+pub fn call(args: &serde_json::Value) -> ToolCallResult {
+    let Some(model_path) = args.get("model_path").and_then(|v| v.as_str()) else {
+        return ToolCallResult::error("Missing required argument: model_path");
+    };
+
+    let output = match Command::new("apr")
+        .args(["validate", model_path, "--json"])
+        .output()
+    {
+        Ok(o) => o,
+        Err(e) => return ToolCallResult::error(format!("Failed to spawn `apr validate`: {e}")),
+    };
+
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+
+    if output.status.success() {
+        // stdout is JSON from `apr validate --json`; pass through verbatim.
+        if stdout.trim().is_empty() {
+            ToolCallResult::error("apr validate produced no output")
+        } else {
+            ToolCallResult::success(stdout)
+        }
+    } else {
+        let code = output.status.code().unwrap_or(-1);
+        let detail = if stderr.trim().is_empty() {
+            stdout
+        } else {
+            stderr
+        };
+        ToolCallResult::error(format!("apr validate failed (exit {code}): {detail}"))
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::disallowed_methods)] // serde_json::json! expands to code that hits unwrap()
+mod tests {
+    use super::*;
+
+    #[test]
+    fn definition_has_correct_name_and_required_field() {
+        let def = validate_tool_definition();
+        assert_eq!(def.name, "apr.validate");
+        assert_eq!(def.input_schema.schema_type, "object");
+        assert_eq!(def.input_schema.required, vec!["model_path".to_string()]);
+        assert!(def.input_schema.properties.contains_key("model_path"));
+    }
+
+    #[test]
+    fn missing_model_path_returns_error() {
+        let result = call(&serde_json::json!({}));
+        assert_eq!(result.is_error, Some(true));
+        assert!(result.content[0].text.contains("model_path"));
+    }
+
+    #[test]
+    fn nonstring_model_path_returns_error() {
+        let result = call(&serde_json::json!({ "model_path": 42 }));
+        assert_eq!(result.is_error, Some(true));
+    }
+}

--- a/crates/aprender-mcp/tests/falsify_m1.rs
+++ b/crates/aprender-mcp/tests/falsify_m1.rs
@@ -38,8 +38,10 @@ fn falsify_mcp_001_initialize_under_500ms() {
     assert_eq!(result["protocolVersion"], PROTOCOL_VERSION);
 }
 
-/// FALSIFY-MCP-002 (M1 subset): `tools/list` returns the M1 tool set and each
-/// schema is a valid JSON Schema object. Full 8-tool check lands in M2.
+/// FALSIFY-MCP-002 (progressive): `tools/list` must include every tool that
+/// has shipped so far (apr.version from M1, apr.validate from M2 slice 1) and
+/// every registered schema must be a valid JSON Schema object. The full
+/// 8-tool check lands when M2 completes.
 #[test]
 fn falsify_mcp_002_tools_list_schema_shape() {
     let mut server = AprMcpServer::new();
@@ -48,7 +50,10 @@ fn falsify_mcp_002_tools_list_schema_shape() {
     let result = resp.result.expect("tools/list result");
     let tools = result["tools"].as_array().expect("tools array");
 
-    assert_eq!(tools.len(), 1, "M1 registers exactly one tool");
+    let names: Vec<&str> = tools.iter().filter_map(|t| t["name"].as_str()).collect();
+    assert!(names.contains(&"apr.version"), "apr.version registered");
+    assert!(names.contains(&"apr.validate"), "apr.validate registered");
+
     for tool in tools {
         assert!(tool["name"].is_string(), "name present");
         assert!(tool["description"].is_string(), "description present");
@@ -67,6 +72,29 @@ fn unknown_method_maps_to_minus_32601() {
 
     assert!(resp.result.is_none());
     assert_eq!(resp.error.expect("error").code, -32601);
+}
+
+/// FALSIFY-MCP-VALIDATE-001: calling `apr.validate` without `model_path` must
+/// surface a tool-level error (isError:true) rather than a JSON-RPC error —
+/// the MCP spec requires argument validation failures to come back as
+/// tool-call results so the LLM sees and can react to them.
+#[test]
+fn falsify_validate_missing_model_path_is_tool_error() {
+    let mut server = AprMcpServer::new();
+    let resp = server.handle_request(&request(
+        20,
+        "tools/call",
+        serde_json::json!({ "name": "apr.validate", "arguments": {} }),
+    ));
+
+    // JSON-RPC layer must succeed; the error belongs inside the result.
+    assert!(resp.error.is_none(), "JSON-RPC error should be none");
+    let result = resp.result.expect("tools/call result");
+    assert_eq!(result["isError"], true);
+    assert!(result["content"][0]["text"]
+        .as_str()
+        .expect("text")
+        .contains("model_path"));
 }
 
 /// End-to-end `initialize` → `tools/list` → `tools/call` works on one server

--- a/crates/aprender-mcp/tests/falsify_m1.rs
+++ b/crates/aprender-mcp/tests/falsify_m1.rs
@@ -51,8 +51,9 @@ fn falsify_mcp_002_tools_list_schema_shape() {
     let tools = result["tools"].as_array().expect("tools array");
 
     let names: Vec<&str> = tools.iter().filter_map(|t| t["name"].as_str()).collect();
-    assert!(names.contains(&"apr.version"), "apr.version registered");
-    assert!(names.contains(&"apr.validate"), "apr.validate registered");
+    for expected in ["apr.version", "apr.validate", "apr.tensors", "apr.bench"] {
+        assert!(names.contains(&expected), "{expected} registered");
+    }
 
     for tool in tools {
         assert!(tool["name"].is_string(), "name present");


### PR DESCRIPTION
## Summary

Stacked on #865. Adds two more M2 subprocess-wrapper tools and extracts the shared subprocess logic.

- `tools/subprocess.rs::run_apr(&[...])` — centralizes spawn + stdout passthrough + error mapping
- `tools/tensors.rs` — `apr.tensors` with optional `stats` + `filter`
- `tools/bench.rs` — `apr.bench` with optional `iterations`, `max_tokens`, `prompt`
- `validate.rs` refactored onto `run_apr` (drops ~25 lines of dup)
- Tests assert the four-tool registered set: version/validate/tensors/bench

Remaining M2 follow-ups: `apr.run`, `apr.serve`, `apr.qa`, `apr.trace`, `apr.finetune`.

## Test plan

- [x] `cargo test -p aprender-mcp` — 25 lib + 5 integration + 1 doctest
- [x] `cargo clippy -p aprender-mcp --all-targets -- -D warnings`
- [x] `cargo fmt -p aprender-mcp --check`

## Merge order

Will rebase onto main once #865 merges (GitHub will auto-retarget base to main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)