### PR TITLE
feat(mcp): M2 dispatcher hardening — FALSIFY-MCP-005 + -007 gates

### DIFF
--- a/crates/aprender-mcp/README.md
+++ b/crates/aprender-mcp/README.md
@@ -39,14 +39,20 @@ apr mcp
 
 - **M1** (shipped): skeleton with `initialize` + `tools/list` + `apr.version`
 - **M2** (in progress): 8 Phase-1 tools as subprocess wrappers over
-  `apr <cmd> --json`. Shipped so far: `apr.validate`. Remaining: `apr.run`,
-  `apr.serve`, `apr.qa`, `apr.trace`, `apr.tensors`, `apr.bench`, `apr.finetune`
+  `apr <cmd> --json`. Shipped: `apr.validate`, `apr.tensors`, `apr.bench`,
+  `apr.qa`, `apr.trace` + dispatcher hardening (jsonrpc/protocolVersion gates).
+  Remaining: `apr.run`, `apr.serve`, `apr.finetune` (streaming candidates).
 - **M3**: streaming progress notifications + cancellation
 - **M4**: Claude Code dogfood + contract promotion to ENFORCED
 
 ## Falsification gates
 
-See [`contracts/apr-mcp-server-v1.yaml`](../../contracts/apr-mcp-server-v1.yaml)
-for the full set. Currently enforced: FALSIFY-MCP-001 (initialize latency),
-FALSIFY-MCP-002 (progressive — every registered tool has a valid schema),
-and FALSIFY-MCP-VALIDATE-001 (argument validation surfaces as tool error).
+Currently enforced (see [`docs/specifications/apr-mcp-server-spec.md`](../../docs/specifications/apr-mcp-server-spec.md#falsification-conditions-for-apr-mcp-server-v1yaml)):
+
+| Gate | What it asserts |
+|------|-----------------|
+| FALSIFY-MCP-001 | `initialize` round-trip under 50ms (spec budget 500ms) |
+| FALSIFY-MCP-002 | every registered tool exposes a valid object-typed schema |
+| FALSIFY-MCP-005 | `jsonrpc != "2.0"` is rejected with `-32600 Invalid Request` |
+| FALSIFY-MCP-007 | `initialize.params.protocolVersion` mismatch returns `-32602 Invalid Params` (positive case verifies happy path) |
+| FALSIFY-MCP-VALIDATE-001 | tool argument validation surfaces as `isError:true`, not as a JSON-RPC error |

--- a/crates/aprender-mcp/src/server.rs
+++ b/crates/aprender-mcp/src/server.rs
@@ -19,8 +19,25 @@ impl AprMcpServer {
     }
 
     /// Dispatch a single JSON-RPC request.
+    ///
+    /// The dispatcher enforces two protocol-level invariants before routing:
+    /// FALSIFY-MCP-005 (`jsonrpc` must be exactly `"2.0"` or the response is
+    /// `-32600 Invalid Request`) and FALSIFY-MCP-007 (an `initialize` whose
+    /// `params.protocolVersion` mismatches ours returns `-32602 Invalid Params`
+    /// instead of advancing to tools/list).
     #[must_use]
     pub fn handle_request(&mut self, request: &JsonRpcRequest) -> JsonRpcResponse {
+        if request.jsonrpc != "2.0" {
+            return JsonRpcResponse::error(
+                request.id.clone(),
+                -32600,
+                format!(
+                    "Invalid Request: jsonrpc must be \"2.0\", got \"{}\"",
+                    request.jsonrpc
+                ),
+            );
+        }
+
         match request.method.as_str() {
             "initialize" => self.handle_initialize(request),
             "tools/list" => self.handle_tools_list(request),
@@ -34,6 +51,27 @@ impl AprMcpServer {
     }
 
     fn handle_initialize(&self, request: &JsonRpcRequest) -> JsonRpcResponse {
+        // FALSIFY-MCP-007: if the client advertises a protocolVersion, it must
+        // match ours. Missing field is permitted (some clients omit it on the
+        // very first handshake); only a *mismatch* is rejected.
+        if let Some(client_version) = request
+            .params
+            .get("protocolVersion")
+            .and_then(|v| v.as_str())
+        {
+            if client_version != crate::PROTOCOL_VERSION {
+                return JsonRpcResponse::error(
+                    request.id.clone(),
+                    -32602,
+                    format!(
+                        "Unsupported protocolVersion: client requested \"{}\", server speaks \"{}\"",
+                        client_version,
+                        crate::PROTOCOL_VERSION
+                    ),
+                );
+            }
+        }
+
         JsonRpcResponse::success(
             request.id.clone(),
             serde_json::json!({

--- a/crates/aprender-mcp/tests/falsify_m1.rs
+++ b/crates/aprender-mcp/tests/falsify_m1.rs
@@ -105,6 +105,74 @@ fn falsify_validate_missing_model_path_is_tool_error() {
         .contains("model_path"));
 }
 
+/// FALSIFY-MCP-005: a request whose `jsonrpc` field is not exactly `"2.0"` must
+/// be rejected with code `-32600 Invalid Request` BEFORE method dispatch — the
+/// server must not crash and must not attempt to route to `initialize` /
+/// `tools/list` / `tools/call`.
+#[test]
+fn falsify_mcp_005_invalid_jsonrpc_version_is_minus_32600() {
+    let mut server = AprMcpServer::new();
+    let req = JsonRpcRequest {
+        jsonrpc: "1.0".to_string(),
+        id: Some(serde_json::json!(40)),
+        method: "initialize".to_string(),
+        params: serde_json::json!({}),
+    };
+
+    let resp = server.handle_request(&req);
+
+    assert!(resp.result.is_none(), "must not produce a success result");
+    let err = resp.error.expect("error present");
+    assert_eq!(err.code, -32600, "JSON-RPC code must be Invalid Request");
+    assert!(
+        err.message.contains("jsonrpc"),
+        "message should mention jsonrpc field, got: {}",
+        err.message
+    );
+    assert_eq!(resp.id, Some(serde_json::json!(40)), "id echoed back");
+}
+
+/// FALSIFY-MCP-007: an `initialize` whose `params.protocolVersion` does not
+/// match the server's supported version must be rejected with `-32602 Invalid
+/// Params`. The server must not advance the connection — subsequent
+/// `tools/list` from the same client would also need to fail until a compatible
+/// version is negotiated, but here we only assert the negotiation-phase error.
+#[test]
+fn falsify_mcp_007_protocol_version_mismatch_is_minus_32602() {
+    let mut server = AprMcpServer::new();
+    let resp = server.handle_request(&request(
+        50,
+        "initialize",
+        serde_json::json!({ "protocolVersion": "1999-01-01" }),
+    ));
+
+    assert!(resp.result.is_none(), "must not return success");
+    let err = resp.error.expect("error present");
+    assert_eq!(err.code, -32602, "must be Invalid Params");
+    assert!(
+        err.message.contains("protocolVersion"),
+        "message should mention protocolVersion, got: {}",
+        err.message
+    );
+}
+
+/// FALSIFY-MCP-007 (negative): an `initialize` whose `params.protocolVersion`
+/// matches the server's version must succeed. Belt-and-braces against the
+/// guard above falsely tripping on the happy path.
+#[test]
+fn falsify_mcp_007_matching_protocol_version_succeeds() {
+    let mut server = AprMcpServer::new();
+    let resp = server.handle_request(&request(
+        51,
+        "initialize",
+        serde_json::json!({ "protocolVersion": PROTOCOL_VERSION }),
+    ));
+
+    assert!(resp.error.is_none(), "happy path must not error");
+    let result = resp.result.expect("result");
+    assert_eq!(result["protocolVersion"], PROTOCOL_VERSION);
+}
+
 /// End-to-end `initialize` → `tools/list` → `tools/call` works on one server
 /// instance without state leaking between requests.
 #[test]


### PR DESCRIPTION
## Summary

- Adds JSON-RPC version validation: requests with `jsonrpc != "2.0"` are rejected with `-32600 Invalid Request` before method dispatch (FALSIFY-MCP-005)
- Adds protocol version negotiation: `initialize.params.protocolVersion` mismatch returns `-32602 Invalid Params` (FALSIFY-MCP-007). Missing field is permitted; only mismatch is rejected.
- 3 new integration tests + happy-path positive case to guard against the new check tripping the normal flow.

## Why

The MCP spec lists 8 falsifiers; we had 1, 2, and the validate-001 negative test. -005 and -006 are bucketed under M3 in the milestone checklist, but **the content of -005** (malformed request handling) is dispatcher-level and independent of streaming. -007 (protocol-version mismatch) is similarly pure validation. Shipping these now closes two more gates without committing to M3 streaming work.

## Test plan

- [x] `cargo test -p aprender-mcp` — 29 lib + 8 integration tests pass
- [x] `cargo clippy -p aprender-mcp --all-targets -- -D warnings` clean
- [x] `cargo fmt -p aprender-mcp -- --check` clean
- [x] Pre-existing FALSIFY-MCP-001/-002/-VALIDATE-001 still pass (no behavior change to happy paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)