### PR TITLE
test(mcp): FALSIFY-MCP-002 strict — JSON Schema Draft 7 meta-validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -975,6 +975,7 @@ name = "aprender-mcp"
 version = "0.30.0"
 dependencies = [
  "anyhow",
+ "jsonschema 0.28.3",
  "serde",
  "serde_json",
 ]

--- a/crates/aprender-mcp/Cargo.toml
+++ b/crates/aprender-mcp/Cargo.toml
@@ -26,6 +26,9 @@ anyhow = { workspace = true, optional = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }
+# Test-only: validate every tool's inputSchema against JSON Schema Draft 7
+# (FALSIFY-MCP-002). Same major as aprender-train uses, so already in lockfile.
+jsonschema = "0.28"
 
 [lints]
 workspace = true

--- a/crates/aprender-mcp/tests/falsify_schema.rs
+++ b/crates/aprender-mcp/tests/falsify_schema.rs
@@ -1,0 +1,58 @@
+//! FALSIFY-MCP-002 (strict slice) — every registered tool's `inputSchema` must
+//! compile as a valid JSON Schema Draft 7 document.
+//!
+//! The base FALSIFY-MCP-002 in `falsify_m1.rs` only asserts that each schema
+//! has `type: "object"` — necessary but not sufficient. The MCP spec requires
+//! that the schema validates against JSONSchema Draft 7. Compiling with
+//! `jsonschema::validator_for` performs meta-schema validation as a side
+//! effect, so a successful compile proves the schema is well-formed.
+
+#![allow(clippy::disallowed_methods)] // serde_json::json! / to_value expand to unwrap()
+
+use aprender_mcp::AprMcpServer;
+
+/// FALSIFY-MCP-002 (strict): every tool's `inputSchema` is a valid JSON Schema.
+/// Failure mode caught by this test: a tool definition that names a
+/// nonexistent type, uses a malformed `properties` map, or otherwise emits
+/// JSON that no spec-compliant client would accept.
+#[test]
+fn every_tool_input_schema_is_valid_jsonschema_draft_7() {
+    let server = AprMcpServer::new();
+    let definitions = server.tool_definitions();
+    assert!(
+        !definitions.is_empty(),
+        "expected at least one tool registered"
+    );
+
+    for def in &definitions {
+        let schema_value = serde_json::to_value(&def.input_schema)
+            .unwrap_or_else(|e| panic!("serialize {}: {e}", def.name));
+
+        // Compiling is the validation: jsonschema rejects malformed schemas
+        // here. We do not validate any instance — just the schema itself.
+        jsonschema::validator_for(&schema_value).unwrap_or_else(|e| {
+            panic!(
+                "tool {} has an invalid JSON Schema inputSchema: {e}\nschema: {}",
+                def.name,
+                serde_json::to_string_pretty(&schema_value).unwrap_or_default()
+            )
+        });
+    }
+}
+
+/// Spot-check: a known-malformed schema must be rejected by the same
+/// validator-compile path. This is belt-and-braces: if some future
+/// `jsonschema` upgrade silently accepts garbage, the strict test above would
+/// give a false pass — this guard fails first.
+#[test]
+fn invalid_schema_is_rejected_by_validator_for() {
+    let bogus = serde_json::json!({
+        "type": "object",
+        "properties": "this-should-be-an-object-not-a-string"
+    });
+
+    assert!(
+        jsonschema::validator_for(&bogus).is_err(),
+        "validator_for should reject schema with non-object `properties`"
+    );
+}


### PR DESCRIPTION
## Summary

- Adds `tests/falsify_schema.rs` that compiles every shipped tool's `inputSchema` with `jsonschema::validator_for`. Compilation performs meta-schema validation, so any malformed schema fails before it can ship.
- Includes a guard test feeding a known-bad schema to the same path — protects against a future jsonschema upgrade that silently accepts garbage.

## Why

The base FALSIFY-MCP-002 only asserts `inputSchema.type == "object"`. The MCP spec demands the schema validates against JSONSchema Draft 7. A tool shipping with a malformed `properties` map or nonexistent `type` would pass the existing test today.

## Cargo.lock impact

Single dev-dep edge added. `jsonschema 0.28` is already in the lockfile via `aprender-train`, so zero new transitive crates.

## Test plan

- [x] `cargo test -p aprender-mcp --test falsify_schema` — both tests pass
- [x] Full `cargo test -p aprender-mcp` still green
- [x] `cargo clippy -p aprender-mcp --all-targets -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)