### PR TITLE
feat(mcp): M2 slice 6 — apr.run synchronous inference wrapper

### DIFF
--- a/crates/aprender-mcp/README.md
+++ b/crates/aprender-mcp/README.md
@@ -40,8 +40,8 @@ apr mcp
 - **M1** (shipped): skeleton with `initialize` + `tools/list` + `apr.version`
 - **M2** (in progress): 8 Phase-1 tools as subprocess wrappers over
   `apr <cmd> --json`. Shipped: `apr.validate`, `apr.tensors`, `apr.bench`,
-  `apr.qa`, `apr.trace` + dispatcher hardening (jsonrpc/protocolVersion gates).
-  Remaining: `apr.run`, `apr.serve`, `apr.finetune` (streaming candidates).
+  `apr.qa`, `apr.trace`, `apr.run` + dispatcher hardening (jsonrpc/protocolVersion gates).
+  Remaining: `apr.serve`, `apr.finetune` (streaming candidates).
 - **M3**: streaming progress notifications + cancellation
 - **M4**: Claude Code dogfood + contract promotion to ENFORCED
 

--- a/crates/aprender-mcp/src/server.rs
+++ b/crates/aprender-mcp/src/server.rs
@@ -107,6 +107,7 @@ impl AprMcpServer {
             Some(tools::bench::NAME) => tools::bench::call(&arguments),
             Some(tools::qa::NAME) => tools::qa::call(&arguments),
             Some(tools::trace::NAME) => tools::trace::call(&arguments),
+            Some(tools::run::NAME) => tools::run::call(&arguments),
             Some(other) => ToolCallResult::error(format!("Unknown tool: {other}")),
             None => ToolCallResult::error("Missing tool name"),
         };
@@ -127,6 +128,7 @@ impl AprMcpServer {
             tools::bench_tool_definition(),
             tools::qa_tool_definition(),
             tools::trace_tool_definition(),
+            tools::run_tool_definition(),
         ]
     }
 
@@ -211,6 +213,7 @@ mod tests {
             "apr.bench",
             "apr.qa",
             "apr.trace",
+            "apr.run",
         ] {
             assert!(names.contains(&expected), "{expected} registered");
         }

--- a/crates/aprender-mcp/src/tools/mod.rs
+++ b/crates/aprender-mcp/src/tools/mod.rs
@@ -2,11 +2,12 @@
 //!
 //! M1 shipped `apr.version`. M2 adds 8 Phase-1 tools as subprocess wrappers
 //! around `apr <cmd> --json`. Shipped: `apr.validate`, `apr.tensors`,
-//! `apr.bench`, `apr.qa`, `apr.trace`. Follow-ups: `apr.run`, `apr.serve`,
+//! `apr.bench`, `apr.qa`, `apr.trace`, `apr.run`. Follow-ups: `apr.serve`,
 //! `apr.finetune` (streaming candidates, likely land in M3).
 
 pub mod bench;
 pub mod qa;
+pub mod run;
 pub mod subprocess;
 pub mod tensors;
 pub mod trace;
@@ -15,6 +16,7 @@ pub mod version;
 
 pub use bench::bench_tool_definition;
 pub use qa::qa_tool_definition;
+pub use run::run_tool_definition;
 pub use tensors::tensors_tool_definition;
 pub use trace::trace_tool_definition;
 pub use validate::validate_tool_definition;

--- a/crates/aprender-mcp/src/tools/run.rs
+++ b/crates/aprender-mcp/src/tools/run.rs
@@ -1,0 +1,138 @@
+//! `apr.run` — M2 tool. Synchronous inference via subprocess wrapper.
+//!
+//! Wraps `apr run <model> --json [--prompt X] [--max-tokens N] [--temperature T] [--top-p P]`.
+//!
+//! M3 will extend this wrapper to stream `notifications/progress` per decoded
+//! token (spec `docs/specifications/apr-mcp-server-spec.md` line 156). Until
+//! then, the call blocks until decode completes and returns a single content
+//! block of the subprocess stdout.
+
+#![allow(clippy::disallowed_methods)] // serde_json::json! macro expands to .unwrap() internally
+
+use crate::tools::subprocess::run_apr;
+use crate::types::{InputSchema, PropertySchema, ToolCallResult, ToolDefinition};
+use std::collections::HashMap;
+
+/// Tool name registered with MCP clients.
+pub const NAME: &str = "apr.run";
+
+/// Return the MCP tool definition for `apr.run`.
+#[must_use]
+pub fn run_tool_definition() -> ToolDefinition {
+    let mut properties = HashMap::new();
+    properties.insert(
+        "model_path".to_string(),
+        PropertySchema {
+            prop_type: "string".to_string(),
+            description: "Path to the model file (.apr, .gguf, or .safetensors) or hf://org/repo"
+                .to_string(),
+            r#enum: None,
+        },
+    );
+    properties.insert(
+        "prompt".to_string(),
+        PropertySchema {
+            prop_type: "string".to_string(),
+            description: "Text prompt to generate from".to_string(),
+            r#enum: None,
+        },
+    );
+    properties.insert(
+        "max_tokens".to_string(),
+        PropertySchema {
+            prop_type: "integer".to_string(),
+            description: "Maximum tokens to generate (default 32)".to_string(),
+            r#enum: None,
+        },
+    );
+    properties.insert(
+        "temperature".to_string(),
+        PropertySchema {
+            prop_type: "number".to_string(),
+            description: "Sampling temperature (0.0 = greedy argmax, >0 = stochastic)".to_string(),
+            r#enum: None,
+        },
+    );
+    properties.insert(
+        "top_p".to_string(),
+        PropertySchema {
+            prop_type: "number".to_string(),
+            description: "Top-p nucleus sampling threshold (omit to disable)".to_string(),
+            r#enum: None,
+        },
+    );
+    ToolDefinition {
+        name: NAME.to_string(),
+        description:
+            "Run synchronous inference on a model. Wraps `apr run <model> --json` and returns tokens + tok/s + stop reason."
+                .to_string(),
+        input_schema: InputSchema {
+            schema_type: "object".to_string(),
+            properties,
+            required: vec!["model_path".to_string()],
+        },
+    }
+}
+
+/// Execute `apr.run` by spawning `apr run <model> --json [...flags]`.
+#[must_use]
+pub fn call(args: &serde_json::Value) -> ToolCallResult {
+    let Some(model_path) = args.get("model_path").and_then(|v| v.as_str()) else {
+        return ToolCallResult::error("Missing required argument: model_path");
+    };
+
+    let mut owned: Vec<String> = vec![
+        "run".to_string(),
+        model_path.to_string(),
+        "--json".to_string(),
+    ];
+
+    if let Some(prompt) = args.get("prompt").and_then(|v| v.as_str()) {
+        if !prompt.is_empty() {
+            owned.push("--prompt".to_string());
+            owned.push(prompt.to_string());
+        }
+    }
+    if let Some(n) = args.get("max_tokens").and_then(serde_json::Value::as_u64) {
+        owned.push("--max-tokens".to_string());
+        owned.push(n.to_string());
+    }
+    if let Some(t) = args.get("temperature").and_then(serde_json::Value::as_f64) {
+        owned.push("--temperature".to_string());
+        owned.push(t.to_string());
+    }
+    if let Some(p) = args.get("top_p").and_then(serde_json::Value::as_f64) {
+        owned.push("--top-p".to_string());
+        owned.push(p.to_string());
+    }
+
+    let argv: Vec<&str> = owned.iter().map(String::as_str).collect();
+    run_apr(&argv)
+}
+
+#[cfg(test)]
+#[allow(clippy::disallowed_methods)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn definition_has_correct_name_and_required_field() {
+        let def = run_tool_definition();
+        assert_eq!(def.name, "apr.run");
+        assert_eq!(def.input_schema.schema_type, "object");
+        assert_eq!(def.input_schema.required, vec!["model_path".to_string()]);
+        for field in ["model_path", "prompt", "max_tokens", "temperature", "top_p"] {
+            assert!(
+                def.input_schema.properties.contains_key(field),
+                "property {field} present"
+            );
+        }
+    }
+
+    #[test]
+    fn missing_model_path_returns_error() {
+        let result = call(&serde_json::json!({}));
+        assert_eq!(result.is_error, Some(true));
+        assert!(result.content[0].text.contains("model_path"));
+    }
+}

--- a/crates/aprender-mcp/tests/falsify_m1.rs
+++ b/crates/aprender-mcp/tests/falsify_m1.rs
@@ -58,6 +58,7 @@ fn falsify_mcp_002_tools_list_schema_shape() {
         "apr.bench",
         "apr.qa",
         "apr.trace",
+        "apr.run",
     ] {
         assert!(names.contains(&expected), "{expected} registered");
     }


### PR DESCRIPTION
## Summary

Sixth M2 tool for `aprender-mcp`. Adds `apr.run` as a synchronous
subprocess wrapper over `apr run <model> --json`, following the same
shape as the five already-shipped M2 tools (`apr.validate`,
`apr.tensors`, `apr.bench`, `apr.qa`, `apr.trace`).

- Inputs per spec: `model_path` (required), `prompt`, `max_tokens`,
  `temperature`, `top_p`
- Stdout passed through verbatim as a single text content block
- Missing `model_path` returns `isError: true` per
  FALSIFY-MCP-VALIDATE-001 — not a JSON-RPC error
- Streaming progress notifications (spec line 156) deferred to M3;
  doc-comment on `run.rs` flags the extension point

Reference: `docs/specifications/apr-mcp-server-spec.md` row
`apr.run` in the Tool Surface table.

## Changes

- `crates/aprender-mcp/src/tools/run.rs` — new file: definition +
  call() + 2 unit tests (schema shape, missing-arg error)
- `crates/aprender-mcp/src/tools/mod.rs` — register `run` module +
  re-export `run_tool_definition`
- `crates/aprender-mcp/src/server.rs` — dispatch arm +
  `tool_definitions()` entry; `tools_list_returns_registered_tools`
  test extended to assert `apr.run` is registered
- `crates/aprender-mcp/tests/falsify_m1.rs` —
  FALSIFY-MCP-002 expected-names list extended to include `apr.run`
- `crates/aprender-mcp/README.md` — move `apr.run` from Remaining
  to Shipped

## Test plan

- [x] `cargo test -p aprender-mcp` — 31 unit + 8 falsify + 1 doc test pass
- [x] `cargo clippy -p aprender-mcp --all-targets -- -D warnings` — clean
- [x] `cargo fmt -p aprender-mcp -- --check` — clean
- [x] FALSIFY-MCP-002 + -VALIDATE-001 still pass
- [ ] CI green (required before auto-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)