### PR TITLE
fix(ci): F-203 SIMD timing flake — main CI andon

### DIFF
--- a/crates/aprender-serve/src/contract_gate.rs
+++ b/crates/aprender-serve/src/contract_gate.rs
@@ -666,5 +666,4 @@ mod tests {
             assert!(mem.unwrap() > 0, "system memory should be > 0");
         }
     }
-
 }

--- a/crates/aprender-serve/src/quantize/tests/tests_25.rs
+++ b/crates/aprender-serve/src/quantize/tests/tests_25.rs
@@ -121,64 +121,82 @@ fn test_f202_avx2_small_vector_path() {
 ///
 /// Prohibition: If SIMD execution time ≥ scalar time, the "acceleration"
 /// claim is REFUTED. Silent fallback to scalar is a failure mode.
+///
+/// Methodology: single-shot timing is dominated by OS/CPU jitter in shared
+/// CI runners (cache state, frequency scaling, neighbor-process preemption).
+/// We therefore use warmup + best-of-N: discard the first round, then take
+/// the minimum time across `rounds` subsequent rounds. The minimum is a
+/// lower-jitter estimator of the underlying hardware cost — if SIMD's best
+/// measurement is still slower than scalar's best measurement, that's a
+/// real regression, not a flake.
 #[test]
 fn test_f203_simd_faster_than_scalar_q4_0() {
-    // Use a matrix large enough that SIMD should provide measurable benefit
-    // but small enough that the test completes quickly
     let in_dim = 256;
     let out_dim = 256;
     let bytes_per_row = (in_dim / 32) * 18;
     let iterations = 100;
+    let rounds = 5;
 
     let weight_data: Vec<u8> = (0..out_dim * bytes_per_row)
         .map(|i| (i % 256) as u8)
         .collect();
     let activations: Vec<f32> = (0..in_dim).map(|i| (i as f32) / 100.0).collect();
 
-    // Quantize activations once (shared between scalar and SIMD)
     let (q8_scales, q8_quants) = crate::quantize::quantize_activations_q8_0(&activations);
 
-    // Measure scalar time
-    let scalar_start = Instant::now();
-    for _ in 0..iterations {
-        let mut sum = 0.0f32;
-        for row in 0..out_dim {
-            let row_start = row * bytes_per_row;
-            let row_data = &weight_data[row_start..row_start + bytes_per_row];
-            sum += fused_q4_0_q8_0_dot_scalar(row_data, &q8_scales, &q8_quants, in_dim);
+    let measure_scalar = || {
+        let start = Instant::now();
+        for _ in 0..iterations {
+            let mut sum = 0.0f32;
+            for row in 0..out_dim {
+                let row_start = row * bytes_per_row;
+                let row_data = &weight_data[row_start..row_start + bytes_per_row];
+                sum += fused_q4_0_q8_0_dot_scalar(row_data, &q8_scales, &q8_quants, in_dim);
+            }
+            std::hint::black_box(sum);
         }
-        std::hint::black_box(sum);
-    }
-    let scalar_time = scalar_start.elapsed();
+        start.elapsed()
+    };
+    let measure_simd = || {
+        let start = Instant::now();
+        for _ in 0..iterations {
+            let result = fused_q4_0_q8_0_parallel_matvec(
+                &weight_data,
+                &activations,
+                in_dim,
+                out_dim,
+            )
+            .expect("test value should be present");
+            std::hint::black_box(result);
+        }
+        start.elapsed()
+    };
 
-    // Measure SIMD time (via parallel_matvec which uses SIMD internally)
-    let simd_start = Instant::now();
-    for _ in 0..iterations {
-        let result =
-            fused_q4_0_q8_0_parallel_matvec(&weight_data, &activations, in_dim, out_dim).expect("test value should be present");
-        std::hint::black_box(result);
-    }
-    let simd_time = simd_start.elapsed();
+    // Warmup round — primes caches, lets the rayon threadpool settle.
+    let _ = measure_scalar();
+    let _ = measure_simd();
+
+    let scalar_time = (0..rounds)
+        .map(|_| measure_scalar())
+        .min()
+        .expect("rounds >= 1");
+    let simd_time = (0..rounds)
+        .map(|_| measure_simd())
+        .min()
+        .expect("rounds >= 1");
 
     let speedup = scalar_time.as_nanos() as f64 / simd_time.as_nanos() as f64;
 
-    println!("F203: Q4_0 Performance Falsification");
-    println!("  Scalar: {:?}", scalar_time);
-    println!("  SIMD:   {:?}", simd_time);
-    println!("  Speedup: {:.2}x", speedup);
+    println!("F203: Q4_0 Performance Falsification (best-of-{rounds})");
+    println!("  Scalar (min): {scalar_time:?}");
+    println!("  SIMD   (min): {simd_time:?}");
+    println!("  Speedup: {speedup:.2}x");
 
-    // Prohibition: SIMD must be at least 1.5x faster for this to be
-    // considered a valid "acceleration" claim. If not, something is wrong.
-    // Note: On small matrices, overhead may dominate; we use relaxed threshold.
     assert!(
         speedup > 1.0,
-        "SIMD ({:?}) should be faster than scalar ({:?}), but speedup={:.2}x",
-        simd_time,
-        scalar_time,
-        speedup
+        "SIMD ({simd_time:?}) should be faster than scalar ({scalar_time:?}), but speedup={speedup:.2}x (best-of-{rounds})"
     );
 
-    // For larger matrices with proper SIMD, we expect 2-4x speedup
     if speedup > 1.5 {
         println!("  ✓ SIMD acceleration CORROBORATED (>{:.1}x)", 1.5);
     } else {


### PR DESCRIPTION
## ANDON: main has been red since 96d7349c (PR #869 merge)

Failing: `quantize::tests::tests_25::test_f203_simd_faster_than_scalar_q4_0`

## Root cause
Single-shot timing. The test measured exactly one 100-iteration run per path. On shared CI runners, one measurement is dominated by cache state, frequency scaling, and neighbor-process preemption — SIMD sometimes timed slower than scalar purely from environmental noise.

CI log snippet:
```
F203: Q4_0 Performance Falsification
  Scalar: 122.13127ms
  SIMD:   135.973634ms
  Speedup: 0.90x
```

Not a SIMD regression. The scalar and SIMD paths are unchanged.

## Fix
Warmup round + best-of-5, take the minimum of each path. The minimum is a lower-jitter estimator of the underlying hardware cost.

**The falsification assertion is unchanged** (`speedup > 1.0`). If SIMD's best-of-5 is still slower than scalar's best-of-5, that's a real regression — the Popperian intent of F-203 is preserved, not weakened.

## Verification (4090 Yoga runner, debug build)
```
F203: Q4_0 Performance Falsification (best-of-5)
  Scalar (min): 47.93ms
  SIMD   (min): 46.58ms
  Speedup: 1.03x
```

## Incidental change
`cargo fmt -p aprender-serve` corrected a pre-existing trailing-blank-line in `crates/aprender-serve/src/contract_gate.rs`. Included rather than reverted — the tree is now fmt-clean.

## Test plan
- [x] `cargo test -p aprender-serve --lib test_f203_simd_faster_than_scalar_q4_0 -- --nocapture` passes stably
- [ ] CI `workspace-test` green
- [ ] CI `ci / gate` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)