### PR TITLE
feat(mcp): M3 — FALSIFY-MCP-006 notifications/cancelled SIGTERM→SIGKILL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -976,6 +976,7 @@ version = "0.30.0"
 dependencies = [
  "anyhow",
  "jsonschema 0.28.3",
+ "nix 0.29.0",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/crates/aprender-mcp/Cargo.toml
+++ b/crates/aprender-mcp/Cargo.toml
@@ -23,6 +23,10 @@ native = ["dep:anyhow"]
 serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true, optional = true }
+# FALSIFY-MCP-006: SIGTERM/SIGKILL for cancelling in-flight `apr.run` subprocesses.
+# nix 0.29 is already in the workspace lockfile (pulled in by other crates).
+[target.'cfg(unix)'.dependencies]
+nix = { version = "0.29", default-features = false, features = ["signal"] }
 
 [build-dependencies]
 # FALSIFY-MCP-008: build.rs reads contracts/apr-mcp-tool-schemas-v1.yaml at

--- a/crates/aprender-mcp/src/server.rs
+++ b/crates/aprender-mcp/src/server.rs
@@ -1,15 +1,54 @@
 //! `AprMcpServer` — JSON-RPC 2.0 dispatcher for aprender MCP tools.
+//!
+//! # Cancellation model (FALSIFY-MCP-006)
+//!
+//! `tools/call` requests that target `apr.run` are dispatched on a worker
+//! thread so the main stdio loop can continue reading and honour
+//! `notifications/cancelled`. Each in-flight call registers a [`CancelHandle`]
+//! in [`AprMcpServer::in_flight`], keyed by request id. A matching
+//! `notifications/cancelled` signals the worker's cancel channel; the worker
+//! then SIGTERMs the spawned `apr` subprocess, waits
+//! [`crate::tools::subprocess::CANCEL_GRACE_MS`], and SIGKILLs if still alive.
+//!
+//! Non-cancellable tool calls still run on a worker (so future concurrent
+//! calls don't block notifications/cancelled routing) but their cancel
+//! channels are never signalled. `initialize`, `tools/list`, and other
+//! fast synchronous methods dispatch inline on the main thread.
 
 #![allow(clippy::disallowed_methods)] // serde_json::json! macro expands to .unwrap() internally
 
 use crate::tools;
 use crate::types::{JsonRpcRequest, JsonRpcResponse, ToolCallResult, ToolDefinition};
+use std::collections::HashMap;
+use std::sync::mpsc::{self, Sender};
+use std::sync::{Arc, Mutex};
+
+/// Per-request cancellation record held in [`AprMcpServer::in_flight`].
+///
+/// Only `apr.run` currently honours cancellation. Entries for other tools
+/// are still registered (so a stray `notifications/cancelled` doesn't log
+/// a warning) but their senders are never used.
+#[derive(Debug)]
+pub struct CancelHandle {
+    /// Sender side of the worker's cancel mpsc. `send(())` causes the
+    /// subprocess poll loop to SIGTERM its child.
+    pub cancel_tx: Sender<()>,
+}
+
+/// Map of in-flight `tools/call` requests keyed by JSON-RPC id.
+///
+/// The id is stored as a raw `serde_json::Value` because the MCP spec
+/// permits both integer and string ids.
+type InFlight = Arc<Mutex<HashMap<serde_json::Value, CancelHandle>>>;
 
 /// MCP server exposing the `apr` CLI as tools.
 ///
 /// M1: `initialize`, `tools/list`, `tools/call` with `apr.version`.
+/// M3: `notifications/cancelled` routed to in-flight `apr.run` workers.
 #[derive(Debug, Default)]
-pub struct AprMcpServer {}
+pub struct AprMcpServer {
+    in_flight: InFlight,
+}
 
 impl AprMcpServer {
     /// Construct a new server.
@@ -18,7 +57,12 @@ impl AprMcpServer {
         Self::default()
     }
 
-    /// Dispatch a single JSON-RPC request.
+    /// Dispatch a single JSON-RPC request synchronously.
+    ///
+    /// This is the in-process test entry point. It does NOT exercise the
+    /// threading / cancellation machinery — `apr.run` runs inline with a
+    /// dummy never-firing cancel receiver. Use [`Self::run_stdio`] for the
+    /// full M3 dispatcher.
     ///
     /// The dispatcher enforces two protocol-level invariants before routing:
     /// FALSIFY-MCP-005 (`jsonrpc` must be exactly `"2.0"` or the response is
@@ -41,7 +85,7 @@ impl AprMcpServer {
         match request.method.as_str() {
             "initialize" => self.handle_initialize(request),
             "tools/list" => self.handle_tools_list(request),
-            "tools/call" => self.handle_tools_call(request),
+            "tools/call" => self.handle_tools_call_sync(request),
             other => JsonRpcResponse::error(
                 request.id.clone(),
                 -32601,
@@ -92,28 +136,12 @@ impl AprMcpServer {
         JsonRpcResponse::success(request.id.clone(), serde_json::json!({ "tools": tools }))
     }
 
-    fn handle_tools_call(&mut self, request: &JsonRpcRequest) -> JsonRpcResponse {
-        let name = request.params.get("name").and_then(|v| v.as_str());
-        let arguments = request
-            .params
-            .get("arguments")
-            .cloned()
-            .unwrap_or_else(|| serde_json::json!({}));
-
-        let result = match name {
-            Some(tools::version::NAME) => tools::version::call(&arguments),
-            Some(tools::validate::NAME) => tools::validate::call(&arguments),
-            Some(tools::tensors::NAME) => tools::tensors::call(&arguments),
-            Some(tools::bench::NAME) => tools::bench::call(&arguments),
-            Some(tools::qa::NAME) => tools::qa::call(&arguments),
-            Some(tools::trace::NAME) => tools::trace::call(&arguments),
-            Some(tools::run::NAME) => tools::run::call(&arguments),
-            Some(tools::serve::NAME) => tools::serve::call(&arguments),
-            Some(tools::finetune::NAME) => tools::finetune::call(&arguments),
-            Some(other) => ToolCallResult::error(format!("Unknown tool: {other}")),
-            None => ToolCallResult::error("Missing tool name"),
-        };
-
+    /// Synchronous fallback used by [`Self::handle_request`]. `apr.run`
+    /// runs with a never-firing cancel receiver — cancellation is only
+    /// wired by the stdio loop in [`Self::run_stdio`].
+    fn handle_tools_call_sync(&self, request: &JsonRpcRequest) -> JsonRpcResponse {
+        let (_tx, rx) = mpsc::channel::<()>();
+        let result = dispatch_tool_call(&request.params, &rx);
         JsonRpcResponse::success(
             request.id.clone(),
             serde_json::to_value(result).unwrap_or_else(|_| serde_json::json!({})),
@@ -136,20 +164,64 @@ impl AprMcpServer {
         ]
     }
 
+    /// Register a new in-flight request and return its cancel receiver.
+    ///
+    /// Exposed for testing the cancellation routing without spawning a real
+    /// worker. Production code calls this from [`Self::run_stdio`].
+    #[must_use]
+    pub fn register_in_flight(in_flight: &InFlight, id: serde_json::Value) -> mpsc::Receiver<()> {
+        let (tx, rx) = mpsc::channel::<()>();
+        let mut guard = in_flight
+            .lock()
+            .expect("in_flight mutex not poisoned during register");
+        guard.insert(id, CancelHandle { cancel_tx: tx });
+        rx
+    }
+
+    /// Route a `notifications/cancelled` to the matching in-flight request.
+    ///
+    /// Idempotent: repeated cancels for the same id after the first are
+    /// silently dropped. References to completed / unknown ids are no-ops.
+    /// Returns `true` iff a live handle was signalled.
+    pub fn cancel_in_flight(in_flight: &InFlight, id: &serde_json::Value) -> bool {
+        let mut guard = in_flight
+            .lock()
+            .expect("in_flight mutex not poisoned during cancel");
+        if let Some(handle) = guard.remove(id) {
+            // Best-effort: if the worker already completed and dropped its
+            // receiver, the send fails silently — exactly the no-op we want.
+            let _ = handle.cancel_tx.send(());
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Deregister an in-flight id after its worker finishes. Safe to call
+    /// even if the id was already removed by a concurrent cancel.
+    fn deregister_in_flight(in_flight: &InFlight, id: &serde_json::Value) {
+        if let Ok(mut guard) = in_flight.lock() {
+            guard.remove(id);
+        }
+    }
+
     /// Run the server over stdio (blocking).
     ///
-    /// Reads one JSON-RPC request per line from stdin, writes one response per
-    /// line to stdout. Parse errors map to JSON-RPC code -32700.
+    /// Reads one JSON-RPC message per line from stdin. `initialize`,
+    /// `tools/list`, and unknown methods dispatch inline. `tools/call`
+    /// spawns a worker thread so a subsequent `notifications/cancelled`
+    /// message can flow through the main loop and signal the worker's
+    /// cancel channel. Workers write their responses directly to stdout
+    /// (guarded by a mutex) so the main loop never has to wait on them.
     ///
     /// # Errors
     /// Returns an error if stdin/stdout I/O fails.
     #[cfg(feature = "native")]
     pub fn run_stdio(&mut self) -> anyhow::Result<()> {
-        use std::io::{self, BufRead, Write};
+        use std::io::{self, BufRead};
 
         let stdin = io::stdin();
-        let stdout = io::stdout();
-        let mut out = stdout.lock();
+        let stdout = Arc::new(Mutex::new(io::stdout()));
 
         for line in stdin.lock().lines() {
             let line = line?;
@@ -157,18 +229,162 @@ impl AprMcpServer {
                 continue;
             }
 
-            let response = match serde_json::from_str::<JsonRpcRequest>(&line) {
-                Ok(req) => self.handle_request(&req),
-                Err(e) => JsonRpcResponse::error(None, -32700, format!("Parse error: {e}")),
-            };
-
-            let json = serde_json::to_string(&response)?;
-            writeln!(out, "{json}")?;
-            out.flush()?;
+            let parsed: Result<JsonRpcRequest, _> = serde_json::from_str(&line);
+            match parsed {
+                Ok(req) => self.route_stdio_message(req, &stdout)?,
+                Err(e) => {
+                    let resp = JsonRpcResponse::error(None, -32700, format!("Parse error: {e}"));
+                    write_response(&stdout, &resp)?;
+                }
+            }
         }
 
         Ok(())
     }
+
+    /// Dispatch one parsed request within the stdio loop. Separated from
+    /// [`Self::run_stdio`] for testability.
+    #[cfg(feature = "native")]
+    fn route_stdio_message(
+        &mut self,
+        req: JsonRpcRequest,
+        stdout: &Arc<Mutex<std::io::Stdout>>,
+    ) -> anyhow::Result<()> {
+        // FALSIFY-MCP-005: jsonrpc field gate runs before method dispatch.
+        if req.jsonrpc != "2.0" {
+            let resp = JsonRpcResponse::error(
+                req.id.clone(),
+                -32600,
+                format!(
+                    "Invalid Request: jsonrpc must be \"2.0\", got \"{}\"",
+                    req.jsonrpc
+                ),
+            );
+            return write_response(stdout, &resp);
+        }
+
+        match req.method.as_str() {
+            // Notifications have no `id` and MUST NOT receive a response.
+            "notifications/cancelled" => {
+                if let Some(request_id) = req.params.get("requestId").cloned() {
+                    let _ = Self::cancel_in_flight(&self.in_flight, &request_id);
+                }
+                Ok(())
+            }
+            "notifications/initialized" => {
+                // Client handshake ack — no response, no state change.
+                Ok(())
+            }
+            "tools/call" => self.spawn_tools_call_worker(req, stdout),
+            // Fast inline paths.
+            _ => {
+                let resp = self.handle_request(&req);
+                write_response(stdout, &resp)
+            }
+        }
+    }
+
+    #[cfg(feature = "native")]
+    fn spawn_tools_call_worker(
+        &mut self,
+        req: JsonRpcRequest,
+        stdout: &Arc<Mutex<std::io::Stdout>>,
+    ) -> anyhow::Result<()> {
+        // Notifications would arrive with id = None; tools/call must have
+        // an id per JSON-RPC. Defensive: if it's missing, respond inline
+        // with an error so the client sees the failure immediately.
+        let Some(id) = req.id.clone() else {
+            let resp =
+                JsonRpcResponse::error(None, -32600, "Invalid Request: tools/call requires an id");
+            return write_response(stdout, &resp);
+        };
+
+        let cancel_rx = Self::register_in_flight(&self.in_flight, id.clone());
+        let stdout_clone = Arc::clone(stdout);
+        let in_flight_clone = Arc::clone(&self.in_flight);
+        let params = req.params.clone();
+        let id_for_worker = id.clone();
+
+        // Thread spawn is infallible here in practice, but propagate the
+        // error rather than unwrapping so we stay in the "no panics" lane.
+        let builder = std::thread::Builder::new().name(format!("apr-mcp-call-{id}"));
+        let spawn_result = builder.spawn(move || {
+            let result = dispatch_tool_call(&params, &cancel_rx);
+            let resp = JsonRpcResponse::success(
+                Some(id_for_worker.clone()),
+                serde_json::to_value(result).unwrap_or_else(|_| serde_json::json!({})),
+            );
+            // Best-effort: a broken stdout means the client disconnected,
+            // which we can't recover from anyway.
+            let _ = write_response(&stdout_clone, &resp);
+            Self::deregister_in_flight(&in_flight_clone, &id_for_worker);
+        });
+
+        match spawn_result {
+            Ok(_handle) => Ok(()),
+            Err(e) => {
+                // Failed to spawn — clean up the registry entry we just
+                // inserted and report the failure inline.
+                Self::deregister_in_flight(&self.in_flight, &id);
+                let resp = JsonRpcResponse::error(
+                    Some(id),
+                    -32603,
+                    format!("Internal error: failed to spawn worker thread: {e}"),
+                );
+                write_response(stdout, &resp)
+            }
+        }
+    }
+
+    /// Handle for tests that want to inspect the in-flight registry.
+    #[must_use]
+    pub fn in_flight_handle(&self) -> InFlight {
+        Arc::clone(&self.in_flight)
+    }
+}
+
+/// Shared tool-call dispatch logic used by both the sync and stdio paths.
+///
+/// `cancel_rx` is forwarded to `apr.run` only; the other tools ignore it.
+fn dispatch_tool_call(
+    params: &serde_json::Value,
+    cancel_rx: &mpsc::Receiver<()>,
+) -> ToolCallResult {
+    let name = params.get("name").and_then(|v| v.as_str());
+    let arguments = params
+        .get("arguments")
+        .cloned()
+        .unwrap_or_else(|| serde_json::json!({}));
+
+    match name {
+        Some(tools::version::NAME) => tools::version::call(&arguments),
+        Some(tools::validate::NAME) => tools::validate::call(&arguments),
+        Some(tools::tensors::NAME) => tools::tensors::call(&arguments),
+        Some(tools::bench::NAME) => tools::bench::call(&arguments),
+        Some(tools::qa::NAME) => tools::qa::call(&arguments),
+        Some(tools::trace::NAME) => tools::trace::call(&arguments),
+        Some(tools::run::NAME) => tools::run::call(&arguments, cancel_rx),
+        Some(tools::serve::NAME) => tools::serve::call(&arguments),
+        Some(tools::finetune::NAME) => tools::finetune::call(&arguments),
+        Some(other) => ToolCallResult::error(format!("Unknown tool: {other}")),
+        None => ToolCallResult::error("Missing tool name"),
+    }
+}
+
+#[cfg(feature = "native")]
+fn write_response(
+    stdout: &Arc<Mutex<std::io::Stdout>>,
+    resp: &JsonRpcResponse,
+) -> anyhow::Result<()> {
+    use std::io::Write;
+
+    let json = serde_json::to_string(resp)?;
+    let mut guard = stdout
+        .lock()
+        .map_err(|e| anyhow::anyhow!("stdout mutex poisoned: {e}"))?;
+    writeln!(&mut *guard, "{json}")?;
+    guard.flush()?;
+    Ok(())
 }
 
 #[cfg(test)]
@@ -307,5 +523,38 @@ mod tests {
         };
         let resp = server.handle_request(&req);
         assert_eq!(resp.id, Some(serde_json::json!("req-42")));
+    }
+
+    /// FALSIFY-MCP-006 (unit): registering an id and then cancelling it
+    /// signals the receiver and removes the entry.
+    #[test]
+    fn cancel_in_flight_signals_and_deregisters() {
+        let server = AprMcpServer::new();
+        let id = serde_json::json!(99);
+        let rx = AprMcpServer::register_in_flight(&server.in_flight, id.clone());
+
+        let signalled = AprMcpServer::cancel_in_flight(&server.in_flight, &id);
+        assert!(signalled, "live id should signal");
+        // Sender was dropped by cancel_in_flight (removed from the map), so
+        // try_recv must see either the signal or a disconnected channel —
+        // both prove the cancel reached the receiver side.
+        let received = rx.try_recv();
+        assert!(received.is_ok(), "cancel signal must be deliverable");
+
+        // Idempotent: second call is a no-op.
+        let signalled_again = AprMcpServer::cancel_in_flight(&server.in_flight, &id);
+        assert!(
+            !signalled_again,
+            "cancelling an already-removed id is a no-op"
+        );
+    }
+
+    /// FALSIFY-MCP-006 (unit): cancelling an unknown id is a safe no-op.
+    #[test]
+    fn cancel_unknown_id_is_noop() {
+        let server = AprMcpServer::new();
+        let id = serde_json::json!("never-registered");
+        let signalled = AprMcpServer::cancel_in_flight(&server.in_flight, &id);
+        assert!(!signalled);
     }
 }

--- a/crates/aprender-mcp/src/tools/run.rs
+++ b/crates/aprender-mcp/src/tools/run.rs
@@ -2,16 +2,17 @@
 //!
 //! Wraps `apr run <model> --json [--prompt X] [--max-tokens N] [--temperature T] [--top-p P]`.
 //!
-//! M3 will extend this wrapper to stream `notifications/progress` per decoded
-//! token (spec `docs/specifications/apr-mcp-server-spec.md` line 156). Until
-//! then, the call blocks until decode completes and returns a single content
-//! block of the subprocess stdout.
+//! M3 (FALSIFY-MCP-006) adds cancellation: the call accepts a cancel receiver
+//! and forwards it to [`run_apr_cancellable`], which SIGTERMs the spawned
+//! subprocess on signal and SIGKILLs after the grace window. Progress
+//! notifications (streamed per-token) are a separate M3 slice.
 
 #![allow(clippy::disallowed_methods)] // serde_json::json! macro expands to .unwrap() internally
 
-use crate::tools::subprocess::run_apr;
+use crate::tools::subprocess::{run_apr_cancellable, CANCEL_GRACE_MS};
 use crate::types::{InputSchema, PropertySchema, ToolCallResult, ToolDefinition};
 use std::collections::HashMap;
+use std::sync::mpsc::Receiver;
 
 /// Tool name registered with MCP clients.
 pub const NAME: &str = "apr.run";
@@ -75,8 +76,12 @@ pub fn run_tool_definition() -> ToolDefinition {
 }
 
 /// Execute `apr.run` by spawning `apr run <model> --json [...flags]`.
+///
+/// `cancel_rx` is signalled by the MCP dispatcher when a matching
+/// `notifications/cancelled` arrives on the same request id (FALSIFY-MCP-006).
+/// Pass a never-firing channel for tests or direct non-MCP callers.
 #[must_use]
-pub fn call(args: &serde_json::Value) -> ToolCallResult {
+pub fn call(args: &serde_json::Value, cancel_rx: &Receiver<()>) -> ToolCallResult {
     let Some(model_path) = args.get("model_path").and_then(|v| v.as_str()) else {
         return ToolCallResult::error("Missing required argument: model_path");
     };
@@ -107,7 +112,7 @@ pub fn call(args: &serde_json::Value) -> ToolCallResult {
     }
 
     let argv: Vec<&str> = owned.iter().map(String::as_str).collect();
-    run_apr(&argv)
+    run_apr_cancellable(&argv, cancel_rx, CANCEL_GRACE_MS)
 }
 
 #[cfg(test)]
@@ -131,7 +136,8 @@ mod tests {
 
     #[test]
     fn missing_model_path_returns_error() {
-        let result = call(&serde_json::json!({}));
+        let (_tx, rx) = std::sync::mpsc::channel::<()>();
+        let result = call(&serde_json::json!({}), &rx);
         assert_eq!(result.is_error, Some(true));
         assert!(result.content[0].text.contains("model_path"));
     }

--- a/crates/aprender-mcp/src/tools/subprocess.rs
+++ b/crates/aprender-mcp/src/tools/subprocess.rs
@@ -1,14 +1,34 @@
-//! Shared subprocess wrapper for M2 tools.
+//! Shared subprocess wrapper for M2/M3 tools.
 //!
 //! Every M2 tool spawns `apr <subcommand> [...args] --json` and passes stdout
 //! through to the MCP client verbatim. Non-zero exit maps to `isError: true`
 //! with stderr attached. This module centralizes that pattern so each tool is
 //! a thin definition + a list of CLI args.
+//!
+//! M3 (FALSIFY-MCP-006) adds [`run_apr_cancellable`], which polls a
+//! [`std::sync::mpsc::Receiver`] between `try_wait` checks and escalates to
+//! SIGTERM → (grace window) → SIGKILL on the spawned subprocess when a
+//! cancellation is signalled. The non-cancellable [`run_apr`] is kept as a
+//! thin wrapper for tools that don't support cancellation yet.
 
 use crate::types::ToolCallResult;
-use std::process::Command;
+use std::io::Read;
+use std::process::{Command, Stdio};
+use std::sync::mpsc::{Receiver, TryRecvError};
+use std::time::{Duration, Instant};
 
-/// Spawn `apr <args...>` and wrap the result as a `ToolCallResult`.
+/// Default grace window between SIGTERM and SIGKILL for cancelled calls.
+///
+/// Per `docs/specifications/apr-mcp-server-spec.md`:
+/// > `notifications/cancelled` from client → kill the spawned `apr`
+/// > subprocess with SIGTERM (30s grace) → SIGKILL.
+pub const CANCEL_GRACE_MS: u64 = 30_000;
+
+/// Poll interval when waiting for subprocess exit / cancel signal.
+const POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+/// Spawn `apr <args...>` and wait synchronously. Shorthand for the
+/// non-cancellable path used by every tool except `apr.run`.
 ///
 /// - Successful exit with non-empty stdout → `success(stdout)`
 /// - Successful exit with empty stdout → `error("apr ... produced no output")`
@@ -46,18 +66,268 @@ pub fn run_apr(args: &[&str]) -> ToolCallResult {
     }
 }
 
+/// Spawn `apr <args...>` cancellable via `cancel_rx`.
+///
+/// On receipt of any value on `cancel_rx`, the subprocess is sent SIGTERM.
+/// If it hasn't exited within `grace_ms` milliseconds, SIGKILL is sent. The
+/// returned `ToolCallResult` carries whatever stdout was captured up to the
+/// point of cancellation and has `is_error: Some(true)` with a message that
+/// starts with `"Cancelled:"`.
+///
+/// Non-Unix targets do NOT support signalling; this function falls back to
+/// `child.kill()` (equivalent to SIGKILL on Windows).
+#[must_use]
+pub fn run_apr_cancellable(
+    args: &[&str],
+    cancel_rx: &Receiver<()>,
+    grace_ms: u64,
+) -> ToolCallResult {
+    spawn_cancellable("apr", args, cancel_rx, grace_ms)
+}
+
+/// Test-visible generic over the binary name. `run_apr_cancellable` is the
+/// `"apr"`-bound wrapper clients should use in production code.
+#[must_use]
+pub fn spawn_cancellable(
+    program: &str,
+    args: &[&str],
+    cancel_rx: &Receiver<()>,
+    grace_ms: u64,
+) -> ToolCallResult {
+    let cmd_display = format!("{program} {}", args.join(" "));
+
+    let mut child = match Command::new(program)
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            return ToolCallResult::error(format!("Failed to spawn `{cmd_display}`: {e}"));
+        }
+    };
+
+    let pid = child.id();
+
+    // Poll loop: check if the child exited, then check for a cancel signal.
+    // Sleep `POLL_INTERVAL` between iterations. This keeps cancel latency
+    // under ~10ms while the subprocess is alive.
+    let wait_status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break Ok(status),
+            Ok(None) => {}
+            Err(e) => {
+                return ToolCallResult::error(format!("Failed to poll `{cmd_display}`: {e}"));
+            }
+        }
+
+        match cancel_rx.try_recv() {
+            Ok(()) => break Err(CancelReason::Signalled),
+            Err(TryRecvError::Empty) => {}
+            Err(TryRecvError::Disconnected) => {
+                // Sender dropped without a cancel — treat as "no cancellation
+                // will ever come" and just wait for natural exit.
+            }
+        }
+
+        std::thread::sleep(POLL_INTERVAL);
+    };
+
+    match wait_status {
+        Ok(status) => {
+            // Natural exit: drain pipes and map to success/error.
+            let stdout = drain(&mut child.stdout.take());
+            let stderr = drain(&mut child.stderr.take());
+            if status.success() {
+                if stdout.trim().is_empty() {
+                    ToolCallResult::error(format!("`{cmd_display}` produced no output"))
+                } else {
+                    ToolCallResult::success(stdout)
+                }
+            } else {
+                let code = status.code().unwrap_or(-1);
+                let detail = if stderr.trim().is_empty() {
+                    stdout
+                } else {
+                    stderr
+                };
+                ToolCallResult::error(format!("`{cmd_display}` failed (exit {code}): {detail}"))
+            }
+        }
+        Err(CancelReason::Signalled) => {
+            // SIGTERM, grace window, then SIGKILL.
+            send_sigterm(pid);
+            let deadline = Instant::now() + Duration::from_millis(grace_ms);
+            let mut escalated = false;
+            loop {
+                match child.try_wait() {
+                    Ok(Some(_)) => break,
+                    Ok(None) => {}
+                    Err(_) => break,
+                }
+                if Instant::now() >= deadline {
+                    if !escalated {
+                        // Best-effort kill (SIGKILL on Unix, TerminateProcess
+                        // on Windows). Ignore errors — the process may have
+                        // exited between try_wait and here.
+                        let _ = child.kill();
+                        escalated = true;
+                    } else {
+                        // Even SIGKILL hasn't reaped it — give up after a
+                        // short extra window to avoid hanging the main
+                        // thread forever. In practice SIGKILL is immediate.
+                        break;
+                    }
+                }
+                std::thread::sleep(POLL_INTERVAL);
+            }
+            // Reap if still alive (keeps us from leaking a zombie).
+            let _ = child.wait();
+
+            let stdout = drain(&mut child.stdout.take());
+            let preview = truncate_for_preview(&stdout);
+            ToolCallResult::error(format!(
+                "Cancelled: `{cmd_display}` terminated by notifications/cancelled; partial stdout: {preview}"
+            ))
+        }
+    }
+}
+
+enum CancelReason {
+    Signalled,
+}
+
+fn drain<R: Read>(reader: &mut Option<R>) -> String {
+    let mut buf = String::new();
+    if let Some(r) = reader.as_mut() {
+        let _ = r.read_to_string(&mut buf);
+    }
+    buf
+}
+
+fn truncate_for_preview(s: &str) -> String {
+    const MAX: usize = 512;
+    if s.len() <= MAX {
+        s.to_string()
+    } else {
+        let truncated: String = s.chars().take(MAX).collect();
+        format!("{truncated}… (truncated)")
+    }
+}
+
+#[cfg(unix)]
+fn send_sigterm(pid: u32) {
+    use nix::sys::signal::{kill, Signal};
+    use nix::unistd::Pid;
+
+    // Cast is safe: u32 → i32 for PIDs in the valid pid_t range. Values
+    // above i32::MAX would be invalid PIDs on every Unix we support, so
+    // saturating is fine — `kill` will just fail with EINVAL and we move
+    // on to the SIGKILL branch.
+    #[allow(clippy::cast_possible_wrap)]
+    let raw = pid as i32;
+    let _ = kill(Pid::from_raw(raw), Signal::SIGTERM);
+}
+
+#[cfg(not(unix))]
+fn send_sigterm(_pid: u32) {
+    // Windows has no SIGTERM; we skip straight to the SIGKILL equivalent
+    // (`child.kill()`) in the escalation path above.
+}
+
 #[cfg(test)]
+#[allow(clippy::disallowed_methods)] // test helpers
 mod tests {
     use super::*;
+    use std::sync::mpsc;
+    use std::thread;
 
-    /// Spawning a non-existent binary yields a spawn error, not a panic.
+    /// Spawning `apr` with an unrecognised subcommand yields a tool error
+    /// (non-zero exit), not a panic.
     #[test]
     fn spawn_failure_maps_to_tool_error() {
-        // Temporarily simulate missing binary by calling a clearly-absurd
-        // subcommand through the real `apr`. We can't easily swap the binary
-        // name without refactoring, so we exercise the non-zero-exit branch
-        // via an invalid argument instead.
         let result = run_apr(&["this-subcommand-does-not-exist"]);
         assert_eq!(result.is_error, Some(true));
+    }
+
+    /// Cancellable path: a never-firing receiver lets the subprocess run to
+    /// natural completion, producing identical behaviour to `run_apr`.
+    #[test]
+    fn cancellable_natural_exit_matches_run_apr() {
+        let (_tx, rx) = mpsc::channel::<()>();
+        let result = spawn_cancellable("echo", &["hello"], &rx, CANCEL_GRACE_MS);
+        assert!(result.is_error.is_none(), "echo should succeed");
+        assert!(result.content[0].text.contains("hello"));
+    }
+
+    /// Cancellable path: a disconnected receiver (sender dropped) is
+    /// equivalent to "no cancellation will arrive" — behaviour should not
+    /// change vs the never-firing channel.
+    #[test]
+    fn cancellable_disconnected_channel_is_noop() {
+        let (tx, rx) = mpsc::channel::<()>();
+        drop(tx);
+        let result = spawn_cancellable("echo", &["world"], &rx, CANCEL_GRACE_MS);
+        assert!(result.is_error.is_none());
+        assert!(result.content[0].text.contains("world"));
+    }
+
+    /// Spawning a missing binary returns a spawn error without panic.
+    #[test]
+    fn cancellable_spawn_failure_maps_to_error() {
+        let (_tx, rx) = mpsc::channel::<()>();
+        let result = spawn_cancellable(
+            "/this/binary/does/not/exist/apr-mcp-test",
+            &[],
+            &rx,
+            CANCEL_GRACE_MS,
+        );
+        assert_eq!(result.is_error, Some(true));
+        assert!(result.content[0].text.contains("Failed to spawn"));
+    }
+
+    /// FALSIFY-MCP-006 (unit-level): sending a cancel signal to a
+    /// long-running `sleep 60` subprocess returns within the grace window
+    /// (SIGTERM is immediate for `sleep`, so we see natural reap well
+    /// before the SIGKILL escalation).
+    #[test]
+    #[cfg(unix)]
+    fn cancellable_stops_long_running_subprocess_within_grace() {
+        let (tx, rx) = mpsc::channel::<()>();
+
+        // Fire the cancel shortly after spawn to give the subprocess time
+        // to get into its sleep syscall.
+        let handle = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(100));
+            let _ = tx.send(());
+        });
+
+        let t0 = Instant::now();
+        // Grace of 2s: if SIGTERM fails for any reason we still fall back
+        // to SIGKILL well before the test's own timeout.
+        let result = spawn_cancellable("sleep", &["60"], &rx, 2_000);
+        let elapsed = t0.elapsed();
+
+        handle.join().expect("cancel-sender thread joins");
+
+        assert_eq!(result.is_error, Some(true), "cancelled calls are errors");
+        assert!(
+            result.content[0].text.starts_with("Cancelled:"),
+            "message should indicate cancellation, got: {}",
+            result.content[0].text
+        );
+        // 100ms fire + ~immediate SIGTERM response + cleanup — well under
+        // the 2s grace + 200ms test slack the spec calls for.
+        assert!(
+            elapsed < Duration::from_millis(2_500),
+            "cancel should finish within grace + slack, took {elapsed:?}"
+        );
+        // And it must finish meaningfully faster than the underlying
+        // `sleep 60` would have — this is the real falsification.
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "cancelled call must return far before sleep 60's natural exit"
+        );
     }
 }

--- a/crates/aprender-mcp/tests/falsify_mcp_006.rs
+++ b/crates/aprender-mcp/tests/falsify_mcp_006.rs
@@ -1,0 +1,128 @@
+//! FALSIFY-MCP-006 — `notifications/cancelled` during `apr.run` stops the
+//! spawned subprocess within the grace window and returns a partial result.
+//!
+//! Spec: `docs/specifications/apr-mcp-server-spec.md` lines 95, 137.
+//!
+//! This file exercises the cancellation machinery at two layers:
+//!
+//! 1. The subprocess poll loop — proves that sending a cancel signal to a
+//!    long-running child (`sleep 60`) triggers SIGTERM and the call returns
+//!    far faster than the child's natural lifetime.
+//! 2. The server's in-flight registry — proves that
+//!    `AprMcpServer::cancel_in_flight` signals the right worker's cancel
+//!    channel keyed by JSON-RPC id, is idempotent, and is a no-op for ids
+//!    that never existed.
+
+#![allow(clippy::disallowed_methods)] // serde_json::json! expands to code that hits unwrap()
+
+use aprender_mcp::AprMcpServer;
+use std::sync::mpsc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+/// FALSIFY-MCP-006 (core): cancelling a long-running subprocess returns
+/// within the configured grace window and flags the result as an error.
+///
+/// Uses `sleep 60` rather than a real `apr run` call because (a) we don't
+/// need a real model in the MCP crate's test suite and (b) the
+/// cancellation logic lives entirely in the spawn-and-signal poll loop —
+/// it's binary-agnostic. The equivalent with the `apr` binary would be
+/// tested end-to-end in the M4 integration suite.
+#[test]
+#[cfg(unix)]
+fn falsify_mcp_006_cancel_stops_subprocess_within_grace() {
+    let (tx, rx) = mpsc::channel::<()>();
+
+    // Fire the cancel 100ms after spawn.
+    let cancel_sender = thread::spawn(move || {
+        thread::sleep(Duration::from_millis(100));
+        let _ = tx.send(());
+    });
+
+    let t0 = Instant::now();
+    // Grace of 500ms — SIGTERM to `sleep` is immediate, so we should see
+    // the call return within ~150ms in practice.
+    let result = aprender_mcp::tools::subprocess::spawn_cancellable("sleep", &["60"], &rx, 500);
+    let elapsed = t0.elapsed();
+
+    cancel_sender.join().expect("cancel-sender joins cleanly");
+
+    assert_eq!(
+        result.is_error,
+        Some(true),
+        "cancelled calls return isError: true"
+    );
+    assert!(
+        result.content[0].text.starts_with("Cancelled:"),
+        "message must lead with 'Cancelled:', got: {}",
+        result.content[0].text
+    );
+    assert!(
+        result.content[0].text.contains("partial stdout"),
+        "message must acknowledge partial stdout, got: {}",
+        result.content[0].text
+    );
+    // Spec budget: grace_ms + 200ms slack. sleep 60 would otherwise take
+    // 60s to complete, so any elapsed << that is definitive.
+    assert!(
+        elapsed < Duration::from_millis(700),
+        "cancel must finish within grace_ms + slack, took {elapsed:?}"
+    );
+}
+
+/// FALSIFY-MCP-006 (registry): cancelling a live in-flight id signals the
+/// registered receiver, removes the entry, and is idempotent on repeat.
+#[test]
+fn falsify_mcp_006_registry_routes_cancel_by_id() {
+    let server = AprMcpServer::new();
+    let handle = server.in_flight_handle();
+
+    let id = serde_json::json!(42);
+    let rx = AprMcpServer::register_in_flight(&handle, id.clone());
+
+    // Live id → signalled, then removed.
+    let first = AprMcpServer::cancel_in_flight(&handle, &id);
+    assert!(first, "live id should be signalled");
+
+    // Receiver observes the signal (or a disconnected sender — either
+    // way, the signal reached it).
+    let received = rx.recv_timeout(Duration::from_millis(100));
+    assert!(
+        received.is_ok(),
+        "cancel signal must reach the receiver within 100ms, got: {received:?}"
+    );
+
+    // Idempotent: second cancel for the same id is a no-op.
+    let second = AprMcpServer::cancel_in_flight(&handle, &id);
+    assert!(!second, "cancelling an already-removed id is a no-op");
+}
+
+/// FALSIFY-MCP-006 (registry): cancelling an id that was never registered
+/// is a safe no-op — MCP notifications can arrive after a call completes
+/// and we must not panic or mis-route.
+#[test]
+fn falsify_mcp_006_registry_unknown_id_is_noop() {
+    let server = AprMcpServer::new();
+    let handle = server.in_flight_handle();
+
+    let never_registered = serde_json::json!("phantom");
+    let signalled = AprMcpServer::cancel_in_flight(&handle, &never_registered);
+    assert!(
+        !signalled,
+        "cancel for unknown id must return false, not panic"
+    );
+}
+
+/// FALSIFY-MCP-006 (registry): string-valued ids work just like numeric
+/// ids. MCP permits both and we key the registry on `serde_json::Value`.
+#[test]
+fn falsify_mcp_006_registry_accepts_string_ids() {
+    let server = AprMcpServer::new();
+    let handle = server.in_flight_handle();
+
+    let id = serde_json::json!("abc-123");
+    let _rx = AprMcpServer::register_in_flight(&handle, id.clone());
+
+    let signalled = AprMcpServer::cancel_in_flight(&handle, &id);
+    assert!(signalled, "string id should cancel like numeric id");
+}


### PR DESCRIPTION
## Summary

Implements the cancellation half of M3 for the `aprender-mcp` crate: an MCP `notifications/cancelled` from the client stops an in-flight `apr.run` call by signalling the worker, which sends SIGTERM to the spawned `apr` subprocess, waits `CANCEL_GRACE_MS` (30s, shortened in tests), then escalates to SIGKILL if the child hasn't exited. The client gets back a `ToolCallResult` flagged `isError: true` carrying whatever partial stdout was captured. Closes the FALSIFY-MCP-006 gate in `docs/specifications/apr-mcp-server-spec.md`.

## Threading model change

`tools/call` now spawns a worker thread (`std::thread`) per request so the main stdio loop can keep reading and honour notifications. Each worker registers a `CancelHandle` in `AprMcpServer.in_flight` keyed by JSON-RPC id (`serde_json::Value` to support MCP's int-or-string ids). Workers write responses directly to a shared `Arc<Mutex<Stdout>>` so no response channel is needed — main-thread stdin is the only serialisation point. Fast methods (`initialize`, `tools/list`, `notifications/initialized`, unknown) still dispatch inline. `notifications/cancelled` writes no response per JSON-RPC 2.0 + MCP spec.

## Scope (surgical by design)

- Only `apr.run` honours cancellation. Other 8 tools keep `call(arguments)` signatures unchanged — they flow through an unmodified `run_apr` wrapper.
- No progress notifications (separate M3 slice).
- No cancellation for `apr.finetune` or `apr.serve` (separate slices).
- No schema or dispatcher behaviour changes for existing gates — FALSIFY-MCP-001/-002/-005/-007/-008 still green.

## Test plan

- [x] `cargo test -p aprender-mcp --lib` — 44 passed (added 4: cancellable natural exit, disconnected channel no-op, spawn failure, SIGTERM-stops-long-running; plus 2 server-level registry tests)
- [x] `cargo test -p aprender-mcp` — all integration tests pass (`falsify_m1`, `falsify_mcp_006`, `falsify_mcp_008`, `falsify_schema`)
- [x] `cargo clippy -p aprender-mcp --all-targets -- -D warnings` — clean
- [x] `cargo fmt -p aprender-mcp -- --check` — clean
- [x] `cargo check -p apr-cli` — downstream consumer still builds
- [x] `cargo test -p aprender-contracts --lib` — 1371 passed, contracts intact
- [x] FALSIFY-MCP-006 core test fires a real SIGTERM at a real `sleep 60` subprocess and asserts elapsed <700ms (vs 60s natural lifetime). No mocks.

## Correctness guarantees

- `NO unwrap()` — `expect()` with context or `ToolCallResult::error(...)`.
- `nix 0.29` (`signal` feature only) gated under `target.'cfg(unix)'`; non-Unix targets fall back to `child.kill()` so the build stays portable even though MCP is Unix-only per spec Phase 1.
- Cancel is idempotent: `cancel_in_flight` removes the handle, so repeats are no-ops. Workers deregister on completion, so cancels arriving after a natural exit are also no-ops.
- Zombie prevention: `child.wait()` after SIGTERM/SIGKILL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)