### PR TITLE
feat(mcp): M3 — migrate 7 remaining tools to codegen schemas (FALSIFY-MCP-008 full)

### DIFF
--- a/crates/aprender-mcp/src/tools/bench.rs
+++ b/crates/aprender-mcp/src/tools/bench.rs
@@ -5,57 +5,30 @@
 #![allow(clippy::disallowed_methods)] // serde_json::json! macro expands to .unwrap() internally
 
 use crate::tools::subprocess::run_apr;
-use crate::types::{InputSchema, PropertySchema, ToolCallResult, ToolDefinition};
-use std::collections::HashMap;
+use crate::types::{InputSchema, ToolCallResult, ToolDefinition};
 
 /// Tool name registered with MCP clients.
 pub const NAME: &str = "apr.bench";
 
 /// Return the MCP tool definition for `apr.bench`.
+///
+/// FALSIFY-MCP-008: the `inputSchema` is parsed from the build-time codegen
+/// constant `crate::schemas::APR_BENCH_SCHEMA`, which `build.rs` emits from
+/// `contracts/apr-mcp-tool-schemas-v1.yaml`. The contract is the single
+/// source of truth — the live `tools/list` response and the YAML must agree
+/// byte-for-byte after JSON canonicalization (asserted by
+/// `tests/falsify_mcp_008.rs`).
 #[must_use]
 pub fn bench_tool_definition() -> ToolDefinition {
-    let mut properties = HashMap::new();
-    properties.insert(
-        "model_path".to_string(),
-        PropertySchema {
-            prop_type: "string".to_string(),
-            description: "Path to the model file (.apr, .gguf, or .safetensors)".to_string(),
-            r#enum: None,
-        },
-    );
-    properties.insert(
-        "iterations".to_string(),
-        PropertySchema {
-            prop_type: "integer".to_string(),
-            description: "Measurement iterations (default 5)".to_string(),
-            r#enum: None,
-        },
-    );
-    properties.insert(
-        "max_tokens".to_string(),
-        PropertySchema {
-            prop_type: "integer".to_string(),
-            description: "Max tokens to generate per iteration (default 32)".to_string(),
-            r#enum: None,
-        },
-    );
-    properties.insert(
-        "prompt".to_string(),
-        PropertySchema {
-            prop_type: "string".to_string(),
-            description: "Test prompt (default: model-specific)".to_string(),
-            r#enum: None,
-        },
+    let input_schema: InputSchema = serde_json::from_str(crate::schemas::APR_BENCH_SCHEMA).expect(
+        "FALSIFY-MCP-008: apr.bench codegen constant must parse as InputSchema; \
+             regenerate by editing contracts/apr-mcp-tool-schemas-v1.yaml and rebuilding",
     );
     ToolDefinition {
         name: NAME.to_string(),
         description: "Benchmark model throughput and latency. Wraps `apr bench <model> --json`."
             .to_string(),
-        input_schema: InputSchema {
-            schema_type: "object".to_string(),
-            properties,
-            required: vec!["model_path".to_string()],
-        },
+        input_schema,
     }
 }
 

--- a/crates/aprender-mcp/src/tools/finetune.rs
+++ b/crates/aprender-mcp/src/tools/finetune.rs
@@ -19,78 +19,32 @@
 #![allow(clippy::disallowed_methods)] // serde_json::json! macro expands to .unwrap() internally
 
 use crate::tools::subprocess::run_apr;
-use crate::types::{InputSchema, PropertySchema, ToolCallResult, ToolDefinition};
-use std::collections::HashMap;
+use crate::types::{InputSchema, ToolCallResult, ToolDefinition};
 
 /// Tool name registered with MCP clients.
 pub const NAME: &str = "apr.finetune";
 
 /// Return the MCP tool definition for `apr.finetune`.
+///
+/// FALSIFY-MCP-008: the `inputSchema` is parsed from the build-time codegen
+/// constant `crate::schemas::APR_FINETUNE_SCHEMA`, which `build.rs` emits from
+/// `contracts/apr-mcp-tool-schemas-v1.yaml`. The contract is the single
+/// source of truth — the live `tools/list` response and the YAML must agree
+/// byte-for-byte after JSON canonicalization (asserted by
+/// `tests/falsify_mcp_008.rs`).
 #[must_use]
 pub fn finetune_tool_definition() -> ToolDefinition {
-    let mut properties = HashMap::new();
-    properties.insert(
-        "base_model".to_string(),
-        PropertySchema {
-            prop_type: "string".to_string(),
-            description:
-                "Path to the base model file (.apr, .gguf, or .safetensors) or hf://org/repo"
-                    .to_string(),
-            r#enum: None,
-        },
-    );
-    properties.insert(
-        "dataset".to_string(),
-        PropertySchema {
-            prop_type: "string".to_string(),
-            description: "Path to training data (JSONL). Mapped to `apr finetune --data <path>`."
-                .to_string(),
-            r#enum: None,
-        },
-    );
-    properties.insert(
-        "lora_rank".to_string(),
-        PropertySchema {
-            prop_type: "integer".to_string(),
-            description: "LoRA rank. Mapped to `apr finetune --rank <N>`. Omit for auto."
-                .to_string(),
-            r#enum: None,
-        },
-    );
-    properties.insert(
-        "epochs".to_string(),
-        PropertySchema {
-            prop_type: "integer".to_string(),
-            description: "Training epochs (default 3)".to_string(),
-            r#enum: None,
-        },
-    );
-    properties.insert(
-        "method".to_string(),
-        PropertySchema {
-            prop_type: "string".to_string(),
-            description: "Fine-tuning method: auto, full, lora, qlora (default auto)".to_string(),
-            r#enum: None,
-        },
-    );
-    properties.insert(
-        "output".to_string(),
-        PropertySchema {
-            prop_type: "string".to_string(),
-            description: "Output path (adapter directory or merged model)".to_string(),
-            r#enum: None,
-        },
-    );
+    let input_schema: InputSchema = serde_json::from_str(crate::schemas::APR_FINETUNE_SCHEMA)
+        .expect(
+            "FALSIFY-MCP-008: apr.finetune codegen constant must parse as InputSchema; \
+             regenerate by editing contracts/apr-mcp-tool-schemas-v1.yaml and rebuilding",
+        );
     ToolDefinition {
         name: NAME.to_string(),
         description:
             "Fine-tune a base model with LoRA/QLoRA. Wraps `apr finetune <base_model> --json` and blocks until training completes. Progress streaming lands in a follow-up M3 slice."
                 .to_string(),
-        input_schema: InputSchema {
-            schema_type: "object".to_string(),
-            properties,
-            required: vec!["base_model".to_string()],
-        },
+        input_schema,
     }
 }
 

--- a/crates/aprender-mcp/src/tools/qa.rs
+++ b/crates/aprender-mcp/src/tools/qa.rs
@@ -5,59 +5,31 @@
 #![allow(clippy::disallowed_methods)] // serde_json::json! macro expands to .unwrap() internally
 
 use crate::tools::subprocess::run_apr;
-use crate::types::{InputSchema, PropertySchema, ToolCallResult, ToolDefinition};
-use std::collections::HashMap;
+use crate::types::{InputSchema, ToolCallResult, ToolDefinition};
 
 /// Tool name registered with MCP clients.
 pub const NAME: &str = "apr.qa";
 
 /// Return the MCP tool definition for `apr.qa`.
+///
+/// FALSIFY-MCP-008: the `inputSchema` is parsed from the build-time codegen
+/// constant `crate::schemas::APR_QA_SCHEMA`, which `build.rs` emits from
+/// `contracts/apr-mcp-tool-schemas-v1.yaml`. The contract is the single
+/// source of truth — the live `tools/list` response and the YAML must agree
+/// byte-for-byte after JSON canonicalization (asserted by
+/// `tests/falsify_mcp_008.rs`).
 #[must_use]
 pub fn qa_tool_definition() -> ToolDefinition {
-    let mut properties = HashMap::new();
-    properties.insert(
-        "model_path".to_string(),
-        PropertySchema {
-            prop_type: "string".to_string(),
-            description: "Path to the model file (.apr, .gguf, or .safetensors)".to_string(),
-            r#enum: None,
-        },
-    );
-    properties.insert(
-        "assert_tps".to_string(),
-        PropertySchema {
-            prop_type: "number".to_string(),
-            description: "Minimum throughput threshold in tok/s — gate fails below this"
-                .to_string(),
-            r#enum: None,
-        },
-    );
-    properties.insert(
-        "max_tokens".to_string(),
-        PropertySchema {
-            prop_type: "integer".to_string(),
-            description: "Maximum tokens to generate per iteration (default 32)".to_string(),
-            r#enum: None,
-        },
-    );
-    properties.insert(
-        "iterations".to_string(),
-        PropertySchema {
-            prop_type: "integer".to_string(),
-            description: "Benchmark iterations (default 10)".to_string(),
-            r#enum: None,
-        },
+    let input_schema: InputSchema = serde_json::from_str(crate::schemas::APR_QA_SCHEMA).expect(
+        "FALSIFY-MCP-008: apr.qa codegen constant must parse as InputSchema; \
+             regenerate by editing contracts/apr-mcp-tool-schemas-v1.yaml and rebuilding",
     );
     ToolDefinition {
         name: NAME.to_string(),
         description:
             "Run the 8-gate falsifiable QA checklist on a model. Wraps `apr qa <model> --json`."
                 .to_string(),
-        input_schema: InputSchema {
-            schema_type: "object".to_string(),
-            properties,
-            required: vec!["model_path".to_string()],
-        },
+        input_schema,
     }
 }
 

--- a/crates/aprender-mcp/src/tools/run.rs
+++ b/crates/aprender-mcp/src/tools/run.rs
@@ -10,68 +10,32 @@
 #![allow(clippy::disallowed_methods)] // serde_json::json! macro expands to .unwrap() internally
 
 use crate::tools::subprocess::{run_apr_cancellable, CANCEL_GRACE_MS};
-use crate::types::{InputSchema, PropertySchema, ToolCallResult, ToolDefinition};
-use std::collections::HashMap;
+use crate::types::{InputSchema, ToolCallResult, ToolDefinition};
 use std::sync::mpsc::Receiver;
 
 /// Tool name registered with MCP clients.
 pub const NAME: &str = "apr.run";
 
 /// Return the MCP tool definition for `apr.run`.
+///
+/// FALSIFY-MCP-008: the `inputSchema` is parsed from the build-time codegen
+/// constant `crate::schemas::APR_RUN_SCHEMA`, which `build.rs` emits from
+/// `contracts/apr-mcp-tool-schemas-v1.yaml`. The contract is the single
+/// source of truth — the live `tools/list` response and the YAML must agree
+/// byte-for-byte after JSON canonicalization (asserted by
+/// `tests/falsify_mcp_008.rs`).
 #[must_use]
 pub fn run_tool_definition() -> ToolDefinition {
-    let mut properties = HashMap::new();
-    properties.insert(
-        "model_path".to_string(),
-        PropertySchema {
-            prop_type: "string".to_string(),
-            description: "Path to the model file (.apr, .gguf, or .safetensors) or hf://org/repo"
-                .to_string(),
-            r#enum: None,
-        },
-    );
-    properties.insert(
-        "prompt".to_string(),
-        PropertySchema {
-            prop_type: "string".to_string(),
-            description: "Text prompt to generate from".to_string(),
-            r#enum: None,
-        },
-    );
-    properties.insert(
-        "max_tokens".to_string(),
-        PropertySchema {
-            prop_type: "integer".to_string(),
-            description: "Maximum tokens to generate (default 32)".to_string(),
-            r#enum: None,
-        },
-    );
-    properties.insert(
-        "temperature".to_string(),
-        PropertySchema {
-            prop_type: "number".to_string(),
-            description: "Sampling temperature (0.0 = greedy argmax, >0 = stochastic)".to_string(),
-            r#enum: None,
-        },
-    );
-    properties.insert(
-        "top_p".to_string(),
-        PropertySchema {
-            prop_type: "number".to_string(),
-            description: "Top-p nucleus sampling threshold (omit to disable)".to_string(),
-            r#enum: None,
-        },
+    let input_schema: InputSchema = serde_json::from_str(crate::schemas::APR_RUN_SCHEMA).expect(
+        "FALSIFY-MCP-008: apr.run codegen constant must parse as InputSchema; \
+             regenerate by editing contracts/apr-mcp-tool-schemas-v1.yaml and rebuilding",
     );
     ToolDefinition {
         name: NAME.to_string(),
         description:
             "Run synchronous inference on a model. Wraps `apr run <model> --json` and returns tokens + tok/s + stop reason."
                 .to_string(),
-        input_schema: InputSchema {
-            schema_type: "object".to_string(),
-            properties,
-            required: vec!["model_path".to_string()],
-        },
+        input_schema,
     }
 }
 

--- a/crates/aprender-mcp/src/tools/serve.rs
+++ b/crates/aprender-mcp/src/tools/serve.rs
@@ -12,8 +12,7 @@
 
 #![allow(clippy::disallowed_methods)] // serde_json::json! macro expands to .unwrap() internally
 
-use crate::types::{ContentBlock, InputSchema, PropertySchema, ToolCallResult, ToolDefinition};
-use std::collections::HashMap;
+use crate::types::{ContentBlock, InputSchema, ToolCallResult, ToolDefinition};
 use std::process::{Command, Stdio};
 
 /// Tool name registered with MCP clients.
@@ -23,36 +22,25 @@ pub const NAME: &str = "apr.serve";
 const DEFAULT_PORT: u16 = 8080;
 
 /// Return the MCP tool definition for `apr.serve`.
+///
+/// FALSIFY-MCP-008: the `inputSchema` is parsed from the build-time codegen
+/// constant `crate::schemas::APR_SERVE_SCHEMA`, which `build.rs` emits from
+/// `contracts/apr-mcp-tool-schemas-v1.yaml`. The contract is the single
+/// source of truth — the live `tools/list` response and the YAML must agree
+/// byte-for-byte after JSON canonicalization (asserted by
+/// `tests/falsify_mcp_008.rs`).
 #[must_use]
 pub fn serve_tool_definition() -> ToolDefinition {
-    let mut properties = HashMap::new();
-    properties.insert(
-        "model_path".to_string(),
-        PropertySchema {
-            prop_type: "string".to_string(),
-            description: "Path to the model file (.apr, .gguf, or .safetensors) or hf://org/repo"
-                .to_string(),
-            r#enum: None,
-        },
-    );
-    properties.insert(
-        "port".to_string(),
-        PropertySchema {
-            prop_type: "integer".to_string(),
-            description: "TCP port to bind the HTTP server on (default 8080)".to_string(),
-            r#enum: None,
-        },
+    let input_schema: InputSchema = serde_json::from_str(crate::schemas::APR_SERVE_SCHEMA).expect(
+        "FALSIFY-MCP-008: apr.serve codegen constant must parse as InputSchema; \
+             regenerate by editing contracts/apr-mcp-tool-schemas-v1.yaml and rebuilding",
     );
     ToolDefinition {
         name: NAME.to_string(),
         description:
             "Start an `apr serve` inference daemon in the background. Returns {pid, url}; kill the pid via OS to stop. Full lifecycle (cancel/SIGTERM) lands in M3."
                 .to_string(),
-        input_schema: InputSchema {
-            schema_type: "object".to_string(),
-            properties,
-            required: vec!["model_path".to_string()],
-        },
+        input_schema,
     }
 }
 

--- a/crates/aprender-mcp/src/tools/tensors.rs
+++ b/crates/aprender-mcp/src/tools/tensors.rs
@@ -5,50 +5,32 @@
 #![allow(clippy::disallowed_methods)] // serde_json::json! macro expands to .unwrap() internally
 
 use crate::tools::subprocess::run_apr;
-use crate::types::{InputSchema, PropertySchema, ToolCallResult, ToolDefinition};
-use std::collections::HashMap;
+use crate::types::{InputSchema, ToolCallResult, ToolDefinition};
 
 /// Tool name registered with MCP clients.
 pub const NAME: &str = "apr.tensors";
 
 /// Return the MCP tool definition for `apr.tensors`.
+///
+/// FALSIFY-MCP-008: the `inputSchema` is parsed from the build-time codegen
+/// constant `crate::schemas::APR_TENSORS_SCHEMA`, which `build.rs` emits from
+/// `contracts/apr-mcp-tool-schemas-v1.yaml`. The contract is the single
+/// source of truth — the live `tools/list` response and the YAML must agree
+/// byte-for-byte after JSON canonicalization (asserted by
+/// `tests/falsify_mcp_008.rs`).
 #[must_use]
 pub fn tensors_tool_definition() -> ToolDefinition {
-    let mut properties = HashMap::new();
-    properties.insert(
-        "model_path".to_string(),
-        PropertySchema {
-            prop_type: "string".to_string(),
-            description: "Path to the model file (.apr, .gguf, or .safetensors)".to_string(),
-            r#enum: None,
-        },
-    );
-    properties.insert(
-        "stats".to_string(),
-        PropertySchema {
-            prop_type: "boolean".to_string(),
-            description: "Include tensor statistics (mean, std, min, max)".to_string(),
-            r#enum: None,
-        },
-    );
-    properties.insert(
-        "filter".to_string(),
-        PropertySchema {
-            prop_type: "string".to_string(),
-            description: "Filter tensors by name pattern (substring match)".to_string(),
-            r#enum: None,
-        },
-    );
+    let input_schema: InputSchema = serde_json::from_str(crate::schemas::APR_TENSORS_SCHEMA)
+        .expect(
+            "FALSIFY-MCP-008: apr.tensors codegen constant must parse as InputSchema; \
+             regenerate by editing contracts/apr-mcp-tool-schemas-v1.yaml and rebuilding",
+        );
     ToolDefinition {
         name: NAME.to_string(),
         description:
             "List tensors in a model with shapes and dtypes. Wraps `apr tensors <model> --json`."
                 .to_string(),
-        input_schema: InputSchema {
-            schema_type: "object".to_string(),
-            properties,
-            required: vec!["model_path".to_string()],
-        },
+        input_schema,
     }
 }
 

--- a/crates/aprender-mcp/src/tools/trace.rs
+++ b/crates/aprender-mcp/src/tools/trace.rs
@@ -5,50 +5,31 @@
 #![allow(clippy::disallowed_methods)] // serde_json::json! macro expands to .unwrap() internally
 
 use crate::tools::subprocess::run_apr;
-use crate::types::{InputSchema, PropertySchema, ToolCallResult, ToolDefinition};
-use std::collections::HashMap;
+use crate::types::{InputSchema, ToolCallResult, ToolDefinition};
 
 /// Tool name registered with MCP clients.
 pub const NAME: &str = "apr.trace";
 
 /// Return the MCP tool definition for `apr.trace`.
+///
+/// FALSIFY-MCP-008: the `inputSchema` is parsed from the build-time codegen
+/// constant `crate::schemas::APR_TRACE_SCHEMA`, which `build.rs` emits from
+/// `contracts/apr-mcp-tool-schemas-v1.yaml`. The contract is the single
+/// source of truth — the live `tools/list` response and the YAML must agree
+/// byte-for-byte after JSON canonicalization (asserted by
+/// `tests/falsify_mcp_008.rs`).
 #[must_use]
 pub fn trace_tool_definition() -> ToolDefinition {
-    let mut properties = HashMap::new();
-    properties.insert(
-        "model_path".to_string(),
-        PropertySchema {
-            prop_type: "string".to_string(),
-            description: "Path to the model file (.apr, .gguf, or .safetensors)".to_string(),
-            r#enum: None,
-        },
-    );
-    properties.insert(
-        "layer".to_string(),
-        PropertySchema {
-            prop_type: "string".to_string(),
-            description: "Filter layers by name pattern (substring match)".to_string(),
-            r#enum: None,
-        },
-    );
-    properties.insert(
-        "reference".to_string(),
-        PropertySchema {
-            prop_type: "string".to_string(),
-            description: "Reference model to diff against (path)".to_string(),
-            r#enum: None,
-        },
+    let input_schema: InputSchema = serde_json::from_str(crate::schemas::APR_TRACE_SCHEMA).expect(
+        "FALSIFY-MCP-008: apr.trace codegen constant must parse as InputSchema; \
+             regenerate by editing contracts/apr-mcp-tool-schemas-v1.yaml and rebuilding",
     );
     ToolDefinition {
         name: NAME.to_string(),
         description:
             "Layer-by-layer tensor trace with per-layer stats. Wraps `apr trace <model> --json`."
                 .to_string(),
-        input_schema: InputSchema {
-            schema_type: "object".to_string(),
-            properties,
-            required: vec!["model_path".to_string()],
-        },
+        input_schema,
     }
 }
 

--- a/crates/aprender-mcp/src/tools/validate.rs
+++ b/crates/aprender-mcp/src/tools/validate.rs
@@ -8,34 +8,32 @@
 #![allow(clippy::disallowed_methods)] // serde_json::json! macro expands to .unwrap() internally
 
 use crate::tools::subprocess::run_apr;
-use crate::types::{InputSchema, PropertySchema, ToolCallResult, ToolDefinition};
-use std::collections::HashMap;
+use crate::types::{InputSchema, ToolCallResult, ToolDefinition};
 
 /// Tool name registered with MCP clients.
 pub const NAME: &str = "apr.validate";
 
 /// Return the MCP tool definition for `apr.validate`.
+///
+/// FALSIFY-MCP-008: the `inputSchema` is parsed from the build-time codegen
+/// constant `crate::schemas::APR_VALIDATE_SCHEMA`, which `build.rs` emits from
+/// `contracts/apr-mcp-tool-schemas-v1.yaml`. The contract is the single
+/// source of truth — the live `tools/list` response and the YAML must agree
+/// byte-for-byte after JSON canonicalization (asserted by
+/// `tests/falsify_mcp_008.rs`).
 #[must_use]
 pub fn validate_tool_definition() -> ToolDefinition {
-    let mut properties = HashMap::new();
-    properties.insert(
-        "model_path".to_string(),
-        PropertySchema {
-            prop_type: "string".to_string(),
-            description: "Path to the model file (.apr, .gguf, or .safetensors)".to_string(),
-            r#enum: None,
-        },
-    );
+    let input_schema: InputSchema = serde_json::from_str(crate::schemas::APR_VALIDATE_SCHEMA)
+        .expect(
+            "FALSIFY-MCP-008: apr.validate codegen constant must parse as InputSchema; \
+             regenerate by editing contracts/apr-mcp-tool-schemas-v1.yaml and rebuilding",
+        );
     ToolDefinition {
         name: NAME.to_string(),
         description:
             "Validate a model file's integrity and quality. Wraps `apr validate <model> --json`."
                 .to_string(),
-        input_schema: InputSchema {
-            schema_type: "object".to_string(),
-            properties,
-            required: vec!["model_path".to_string()],
-        },
+        input_schema,
     }
 }
 

--- a/crates/aprender-mcp/tests/falsify_mcp_008.rs
+++ b/crates/aprender-mcp/tests/falsify_mcp_008.rs
@@ -9,11 +9,11 @@
 //!   4. Fetches the live schema via the server's `tools/list` response.
 //!   5. Asserts `serde_json::Value` equality (order-independent object match).
 //!
-//! **Scope of this PR:** only `apr.version` is migrated to the codegen path.
-//! The other 5 tools in the contract still ship hand-written schemas;
-//! follow-up PRs migrate them tool-by-tool for reviewability. When a new
-//! tool is added to `MIGRATED_TOOLS` below, this harness automatically
-//! asserts byte-identity for it — no test edits required.
+//! **Scope (M3 completion — PR #881 follow-up):** all 8 Phase-1 tools are now
+//! wired through the build.rs codegen path (`crate::schemas::APR_*_SCHEMA`).
+//! `MIGRATED_TOOLS` below is sourced from `schemas::TOOL_NAMES` (itself
+//! derived from the YAML at build time), so adding a new tool to the YAML
+//! automatically pulls it into this harness with zero test edits.
 
 #![allow(clippy::disallowed_methods)] // test-only serde_json::json! / to_value expansions
 
@@ -23,8 +23,29 @@ use std::collections::BTreeSet;
 use std::path::PathBuf;
 
 /// Tools currently routed through the build.rs codegen (`crate::schemas::*`).
-/// Extend as follow-up PRs migrate the rest of the registry.
-const MIGRATED_TOOLS: &[&str] = &["apr.version"];
+///
+/// Sourced from the build-time `schemas::TOOL_NAMES` constant so that every
+/// tool in `contracts/apr-mcp-tool-schemas-v1.yaml` is covered by this gate
+/// automatically. When a new tool is added to the YAML, it is picked up here
+/// on the next build without editing this file.
+fn migrated_tools() -> Vec<&'static str> {
+    aprender_mcp::schemas::TOOL_NAMES.to_vec()
+}
+
+/// Per-tool codegen constants for the narrower parse-and-match test below.
+/// Must be kept in sync with `schemas::TOOL_NAMES` (guarded by
+/// `codegen_constants_cover_every_tool_name`).
+const CODEGEN_CONSTANTS: &[(&str, &str)] = &[
+    ("apr.version", aprender_mcp::schemas::APR_VERSION_SCHEMA),
+    ("apr.validate", aprender_mcp::schemas::APR_VALIDATE_SCHEMA),
+    ("apr.tensors", aprender_mcp::schemas::APR_TENSORS_SCHEMA),
+    ("apr.bench", aprender_mcp::schemas::APR_BENCH_SCHEMA),
+    ("apr.qa", aprender_mcp::schemas::APR_QA_SCHEMA),
+    ("apr.trace", aprender_mcp::schemas::APR_TRACE_SCHEMA),
+    ("apr.run", aprender_mcp::schemas::APR_RUN_SCHEMA),
+    ("apr.serve", aprender_mcp::schemas::APR_SERVE_SCHEMA),
+    ("apr.finetune", aprender_mcp::schemas::APR_FINETUNE_SCHEMA),
+];
 
 fn contract_path() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -121,16 +142,17 @@ fn live_schema(server: &AprMcpServer, tool_name: &str) -> Value {
 fn migrated_tools_match_yaml_contract_byte_for_byte() {
     let server = AprMcpServer::new();
     let contract_tools = load_contract_tools();
+    let tools = migrated_tools();
 
     assert!(
-        !MIGRATED_TOOLS.is_empty(),
+        !tools.is_empty(),
         "FALSIFY-MCP-008: at least one tool must be wired through the codegen path"
     );
 
-    for tool_name in MIGRATED_TOOLS {
+    for tool_name in &tools {
         let entry = contract_tools
             .iter()
-            .find(|t| t.get("name").and_then(|v| v.as_str()) == Some(tool_name))
+            .find(|t| t.get("name").and_then(|v| v.as_str()) == Some(*tool_name))
             .unwrap_or_else(|| panic!("FALSIFY-MCP-008: contract has no entry for {tool_name}"));
 
         let expected = expected_schema_from_yaml(entry);
@@ -148,24 +170,41 @@ fn migrated_tools_match_yaml_contract_byte_for_byte() {
     }
 }
 
-/// The codegen constant must itself parse as valid JSON and match the YAML
-/// — this is the narrower assertion that the build.rs output is usable.
+/// Each codegen constant must itself parse as valid JSON and match the YAML
+/// — this is the narrower assertion that the build.rs output is usable for
+/// every tool, independent of the live server wiring above.
 #[test]
-fn codegen_constant_parses_and_matches_yaml_for_apr_version() {
-    let parsed: Value = serde_json::from_str(aprender_mcp::schemas::APR_VERSION_SCHEMA)
-        .expect("APR_VERSION_SCHEMA must be valid JSON");
-
+fn codegen_constants_parse_and_match_yaml_for_every_tool() {
     let contract_tools = load_contract_tools();
-    let entry = contract_tools
-        .iter()
-        .find(|t| t.get("name").and_then(|v| v.as_str()) == Some("apr.version"))
-        .expect("contract has apr.version entry");
-    let expected = expected_schema_from_yaml(entry);
 
-    assert_eq!(
-        parsed, expected,
-        "codegen constant APR_VERSION_SCHEMA diverged from YAML contract"
-    );
+    for (tool_name, schema_json) in CODEGEN_CONSTANTS {
+        let parsed: Value = serde_json::from_str(schema_json)
+            .unwrap_or_else(|e| panic!("codegen constant for {tool_name} must be valid JSON: {e}"));
+        let entry = contract_tools
+            .iter()
+            .find(|t| t.get("name").and_then(|v| v.as_str()) == Some(*tool_name))
+            .unwrap_or_else(|| panic!("contract has no entry for {tool_name}"));
+        let expected = expected_schema_from_yaml(entry);
+
+        assert_eq!(
+            parsed, expected,
+            "codegen constant for {tool_name} diverged from YAML contract"
+        );
+    }
+}
+
+/// Guardrail: every name in `schemas::TOOL_NAMES` must have a matching entry
+/// in `CODEGEN_CONSTANTS`. Catches the case where a new tool is added to the
+/// YAML without being added to the narrower per-constant test above.
+#[test]
+fn codegen_constants_cover_every_tool_name() {
+    let covered: BTreeSet<&str> = CODEGEN_CONSTANTS.iter().map(|(n, _)| *n).collect();
+    for name in aprender_mcp::schemas::TOOL_NAMES {
+        assert!(
+            covered.contains(*name),
+            "CODEGEN_CONSTANTS is missing an entry for {name} (present in schemas::TOOL_NAMES)"
+        );
+    }
 }
 
 /// The exported `TOOL_NAMES` list must cover every `tools[*].name` in the
@@ -186,7 +225,7 @@ fn tool_names_constant_mirrors_yaml() {
 }
 
 /// Guardrail: every migrated tool must also be a contract entry. Catches a
-/// typo in `MIGRATED_TOOLS` before it becomes a silent false-pass.
+/// TOOL_NAMES/YAML desync before it becomes a silent false-pass.
 #[test]
 fn migrated_tools_are_all_in_contract() {
     let contract_tools = load_contract_tools();
@@ -194,10 +233,10 @@ fn migrated_tools_are_all_in_contract() {
         .iter()
         .filter_map(|t| t.get("name").and_then(|v| v.as_str()).map(String::from))
         .collect();
-    for name in MIGRATED_TOOLS {
+    for name in migrated_tools() {
         assert!(
-            contract_names.contains(*name),
-            "MIGRATED_TOOLS entry {name} is not in contracts/apr-mcp-tool-schemas-v1.yaml"
+            contract_names.contains(name),
+            "migrated tool {name} is not in contracts/apr-mcp-tool-schemas-v1.yaml"
         );
     }
 }


### PR DESCRIPTION
## Summary

Completes **FALSIFY-MCP-008** coverage across the full Phase-1 tool surface. Routes every tool's `inputSchema` through the build.rs-generated `crate::schemas::APR_*_SCHEMA` constants, mirroring the `apr.version` pattern from PR #880.

**Tools migrated (7):**
- `apr.validate`
- `apr.tensors`
- `apr.bench`
- `apr.qa`
- `apr.trace`
- `apr.run`
- `apr.serve`
- `apr.finetune`

Together with `apr.version` (migrated in #880), all 8 Phase-1 MCP tools now derive their `inputSchema` from `contracts/apr-mcp-tool-schemas-v1.yaml` at build time. Each tool file uses the same idiom:

```rust
let input_schema: InputSchema = serde_json::from_str(crate::schemas::APR_<TOOL>_SCHEMA)
    .expect("FALSIFY-MCP-008: ... codegen constant must parse as InputSchema; ...");
```

No `unwrap()`; `expect()` messages include actionable context (edit the YAML + rebuild).

## Schema drift audit

All 7 hand-written schemas were **byte-identical** to their YAML entries in `contracts/apr-mcp-tool-schemas-v1.yaml`. Property names, types, descriptions (including em-dash and backtick formatting), and `required` lists matched exactly. **No YAML corrections were needed** — YAML is faithfully authoritative for every migrated tool.

## Test harness

`tests/falsify_mcp_008.rs` extended (now 5 tests, all passing):

1. `migrated_tools_match_yaml_contract_byte_for_byte` — now iterates `schemas::TOOL_NAMES` (auto-covers every YAML entry; no hard-coded migrated-tool list).
2. `codegen_constants_parse_and_match_yaml_for_every_tool` — **new**: asserts each of the 9 `APR_*_SCHEMA` constants parses as valid JSON and matches the YAML derivation.
3. `codegen_constants_cover_every_tool_name` — **new**: guardrail so future tools added to YAML can't silently bypass the per-constant parse test.
4. `tool_names_constant_mirrors_yaml` — unchanged.
5. `migrated_tools_are_all_in_contract` — now sourced from `schemas::TOOL_NAMES`.

## Scope discipline

Schema source only. No tool behavior changes, no dispatch logic touched, no edits to `server.rs`. Hand-written `PropertySchema` / `HashMap` construction has been removed from every `*_tool_definition()` function (verified via grep).

## Test plan
- [x] `cargo build -p aprender-mcp` (triggers build.rs regen)
- [x] `cargo test -p aprender-mcp --lib --tests` — 44 lib + 5 FALSIFY-MCP-008 + 8 falsify_m1 + 4 falsify_mcp_006 + 2 falsify_schema tests all pass
- [x] `cargo clippy -p aprender-mcp --all-targets -- -D warnings` — clean
- [x] `cargo fmt -p aprender-mcp -- --check` — clean
- [ ] CI workspace-test + gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)