### PR TITLE
ci: enable sccache pilot (heavy workload — APR-MONO)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,11 @@ jobs:
     uses: paiml/.github/.github/workflows/sovereign-ci.yml@main
     with:
       repo: ${{ github.event.repository.name }}
+      # Phase 3 pilot (heavy workload) — build-performance.md §7 Phase 3.
+      # APR-MONO monorepo: 60+ crates, largest dep graph in the fleet.
+      # Highest expected sccache hit-rate lift — the signal that justifies
+      # fleet-wide rollout (or shelves it).
+      enable_sccache: true
     secrets: inherit
 
   # APR-MONO: Workspace-wide test (all 75 crates)


### PR DESCRIPTION
## Summary

- Enable sccache on APR-MONO as **heavy-workload** Phase 3 pilot (60+ crates, largest dep graph).
- Replaces paiml-mcp-agent-toolkit as heavy pilot — pmat's local bare-repo config + master-only policy made it unworkable.
- Completes the 3-repo pilot set: copia (light), bashrs (medium), aprender (heavy).

## Why

build-performance.md §7 Phase 3 requires diverse workloads to produce a representative hit-rate signal. APR-MONO delivers the upper bound — if sccache wins here, it wins everywhere.

## Falsifier

\`examples/falsify_f9_cache_hit_rate.rs\` — F9 gate in infra repo. >=20 samples, miss-rate delta vs baseline.

## Test plan

- [ ] Merge triggers container CI with \`enable_sccache: true\`
- [ ] \`/sccache\` volume mount active on self-hosted runner (already provisioned via forjar)
- [ ] \`~/.sccache-stats.json\` populated for F9 to ingest
- [ ] No CI regression (workspace-test still passes)

(Refs PMAT-151)

🤖 Generated with [Claude Code](https://claude.com/claude-code)