### PR TITLE
feat(ci): opt in to cargo nextest run (Phase 2 pilot)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
       # Highest expected sccache hit-rate lift — the signal that justifies
       # fleet-wide rollout (or shelves it).
       enable_sccache: true
+      use_nextest: true
     secrets: inherit
 
   # APR-MONO: Workspace-wide test (all 75 crates)


### PR DESCRIPTION
## Summary

Opt aprender into `use_nextest: true` in the reusable sovereign-ci workflow (Refs PMAT-155).

Phase 2 pilot — `use_nextest` was just added as a `workflow_call` boolean input to `paiml/.github/.github/workflows/sovereign-ci.yml` (default `false`). We're piloting it on the same cohort as the sccache Phase 3 pilot (PMAT-151): copia, bashrs, aprender.

aprender is the **heavy** pilot — APR-MONO monorepo with 60+ workspace crates, the largest dep graph in the fleet and a driver of fleet p95. This is the most interesting repo for nextest: parallel test execution should win big here. Measured F11 baseline **p95=449s** for aprender.

After 7 days of measurement via F11 falsifier (`cargo run --example falsify_f11_test_job_p95`), if p95 ≤ 300s we flip the reusable workflow's default to `true`. This PR is just the pilot enrollment — see paiml/infra#52 for the falsifier.

## Test plan

- [ ] CI passes (`ci / gate`, `workspace-test`)
- [ ] F11 falsifier records post-change p95 daily for 7 days
- [ ] If workspace-test (40m timeout) holds on cold path, pilot is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)