### PR TITLE
fix(workspace): jugar-probar dep needs version for clean-room A0 path-strip (Refs PMAT-157)

### DIFF
--- a/crates/aprender-qa-runner/Cargo.toml
+++ b/crates/aprender-qa-runner/Cargo.toml
@@ -7,6 +7,7 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
+publish = false
 
 [features]
 default = []
@@ -21,14 +22,14 @@ anyhow = { workspace = true }
 tokio = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }
 tracing = { workspace = true }
-aprender-qa-gen = { path = "../aprender-qa-gen" }
+aprender-qa-gen = { version = "0.31.0", path = "../aprender-qa-gen" }
 hostname = "0.4"
 rayon = "1.10"
 sha2 = "0.10"
 regex = { workspace = true }
 num_cpus = "1.16"
 safetensors = { workspace = true }
-jugar-probar = { path = "../aprender-test-lib", package = "aprender-test-lib", features = ["llm-types"] }
+jugar-probar = { version = "0.31.0", path = "../aprender-test-lib", package = "aprender-test-lib", features = ["llm-types"] }
 # Test fixtures dependencies (optional)
 tempfile = { version = "3", optional = true }
 half = { version = "2.4", optional = true }


### PR DESCRIPTION
## Summary

Clean-Room CI (paiml/infra run 24622014067) fails at Gate A1 with:
```
error: failed to load manifest for workspace member
  `/build/aprender/crates/aprender-qa-runner`
Caused by: dependency (jugar-probar) specified without providing a
  local path, Git repository, version, or workspace dependency to use
```

## Root Cause (Five Whys)

1. **Why A1 fail?** `cargo generate-lockfile` rejected `aprender-qa-runner`'s manifest.
2. **Why rejected?** `jugar-probar` had no version/git/path/workspace after A0 strip.
3. **Why no path?** Gate A0 runs `sed 's/path = "...", *//g'` on every Cargo.toml (simulate cargo publish).
4. **Why no version?** The original line lacked `version = "X"`:
   ```toml
   jugar-probar = { path = "../aprender-test-lib", package = "aprender-test-lib", features = ["llm-types"] }
   ```
5. **Why wasn't this caught?** This crate was added after the workspace established the `version = "X", path = "..."` pattern (see `aprender-test-cli/Cargo.toml:27` which already does it correctly).

## Fix

Add `version = "0.31.0"` to both local-path deps in `aprender-qa-runner/Cargo.toml`, matching the workspace version and the pattern used by sibling `aprender-test-cli`. After A0 path-strip, `version` remains, satisfying cargo.

Also adds `publish = false` to the crate (internal QA harness reached via `apr qa`; never published to crates.io) — this was added by the pmat pre-commit hook as a policy improvement.

## Verification

Simulated Clean-Room A0 + A1 locally on `/tmp/aprender-cleanroom-test`:
- **Before fix:** `error: failed to load manifest for workspace member aprender-qa-runner` (Gate A1 FAIL)
- **After fix:** `cargo metadata --no-deps --offline` succeeds, all 75 workspace members resolve including `aprender-qa-runner`.

Note: A subsequent, unrelated A1 error surfaces for `aprender-present-yaml = "^0.30.0"` (candidate 0.29.0). That is a separate version-mismatch bug outside PMAT-157's scope.

## Test Plan

- [x] `cargo check -p aprender-qa-runner` passes locally
- [x] Manifest parses under clean-room A0 strip (reproduced locally)
- [ ] Clean-Room CI run (paiml/infra) Gate A1 for aprender advances past qa-runner
- [ ] No regression on `cargo check --workspace`

Refs: PMAT-157