### PR TITLE
feat(mcp-m5): add pmcp v2.3 optional dep behind pmcp-dispatcher feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -982,6 +982,7 @@ dependencies = [
  "assert_cmd",
  "jsonschema 0.28.3",
  "nix 0.29.0",
+ "pmcp 2.3.0",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/crates/aprender-mcp/Cargo.toml
+++ b/crates/aprender-mcp/Cargo.toml
@@ -18,11 +18,22 @@ path = "src/lib.rs"
 [features]
 default = ["native"]
 native = ["dep:anyhow"]
+# M5 scaffold: enables the pmcp v2.3 dispatcher path alongside the hand-rolled
+# stdio loop. Off by default — PR 1 wires the dep, PR 2 lands the parity test
+# (FALSIFY-MCP-009), PR 3 extends cancellation, PR 4/5 add SSE/WebSocket
+# transports. See docs/specifications/apr-mcp-server-spec.md §M5.
+pmcp-dispatcher = ["dep:pmcp"]
 
 [dependencies]
 serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true, optional = true }
+# M5 prep: pmcp 2.3 is PAIML's Rust MCP SDK, already pinned in
+# aprender-orchestrate for the MCP client side. Pulled in here as an optional
+# dep so PR 1 is a zero-behaviour-change patch — the dispatcher still runs on
+# the hand-rolled JSON-RPC loop in server.rs until PR 2 wires pmcp::Server
+# behind the `pmcp-dispatcher` feature flag.
+pmcp = { version = "2.3", optional = true }
 # FALSIFY-MCP-006: SIGTERM/SIGKILL for cancelling in-flight `apr.run` subprocesses.
 # nix 0.29 is already in the workspace lockfile (pulled in by other crates).
 [target.'cfg(unix)'.dependencies]

--- a/docs/specifications/apr-mcp-server-spec.md
+++ b/docs/specifications/apr-mcp-server-spec.md
@@ -395,8 +395,8 @@ These gates live in `contracts/apr-claude-proxy-v1.yaml` — **outside** `apr-mc
 - [ ] Claude Code integration test (launch `apr mcp`, ask Claude to "run qwen2.5-0.5b with prompt X")
 - [ ] Cursor / Cline manual smoke test
 
-### M5: `pmcp` SDK migration + transport expansion — PLANNED
-- [ ] Add `pmcp = "2.3"` to `crates/aprender-mcp/Cargo.toml` (already in `aprender-orchestrate`, keep versions aligned)
+### M5: `pmcp` SDK migration + transport expansion — IN PROGRESS
+- [x] Add `pmcp = "2.3"` to `crates/aprender-mcp/Cargo.toml` (PR 1 — optional dep behind `pmcp-dispatcher` feature flag, zero behaviour change; matches `aprender-orchestrate`'s version pin for workspace coherence; `cargo tree -d` stays clean)
 - [ ] Port `server.rs` dispatcher to `pmcp::Server` with per-tool handler registration; retain `build.rs` schema codegen so `tools/list` output stays byte-identical (FALSIFY-MCP-008 unchanged)
 - [ ] Port worker-thread cancellation to pmcp's cancellation API if it ships one; otherwise keep the existing std::thread+mpsc path as a `pmcp::Server` extension
 - [ ] Extend cancellation to `apr.serve`: track daemon pid in a lifecycle registry, SIGTERM→SIGKILL on `notifications/cancelled` (today `apr.run` alone honours cancel — see `server.rs::CancelHandle`)


### PR DESCRIPTION
First slice of the **M5 dispatcher migration**. Zero behaviour change — the hand-rolled JSON-RPC stdio loop in `server.rs` still owns every request today. This PR only wires the dep so subsequent PRs can land the pmcp code paths incrementally behind a feature flag.

## What changes
- `crates/aprender-mcp/Cargo.toml`: add `pmcp = { version = "2.3", optional = true }` + new `pmcp-dispatcher` feature that selects it. **Off by default.**
- `Cargo.lock`: aprender-mcp entry now lists pmcp 2.3.0. **No new transitive deps** — pmcp 2.3.0 was already resolved in the workspace via `aprender-orchestrate` (MCP client side), so this is a single-line lock update, not a new tree branch. Workspace versions stay aligned per the spec's "M5+ will migrate the dispatcher to `pmcp` v2.x; workspace version must stay aligned" risk mitigation (§Risks).
- Spec §M5 first checkbox flipped; header moves PLANNED → IN PROGRESS.

## PR plan (per the M5 research brief, 2026-04-19)
1. **this PR** — pmcp optional dep, feature flag off. FALSIFY-MCP-009 deferred until PR 2 lands the actual parity test.
2. **PR 2 (next)** — `src/transports/{mod,stdio}.rs`: stdio wrapper that delegates to either the hand-rolled loop or `pmcp::Server` based on the feature; `tests/falsify_mcp_009.rs` asserts byte-identical `tools/list` + `tools/call` wire output across both paths.
3. PR 3 — per-tool `pmcp::Handler` registration (FALSIFY-MCP-010, preserving FALSIFY-MCP-008 codegen).
4. PR 4 — cancellation port + `apr.serve` daemon tracking (FALSIFY-MCP-011).
5. PR 5 — `--transport sse --port N` (FALSIFY-MCP-012).
6. PR 6 — `--transport websocket` (FALSIFY-MCP-013) + re-run the full falsification suite.

## Test plan
- [x] `cargo check -p aprender-mcp` green with default features
- [x] `cargo check -p aprender-mcp --features pmcp-dispatcher` green (pmcp 2.3.0 resolves from the existing workspace lockfile entry)
- [x] `cargo test -p aprender-mcp` all lib + integration + falsification tests PASS (51 lib, 78-across-suites, 1 doc)
- [x] `cargo tree -d -p aprender-mcp --features pmcp-dispatcher` no duplicate deps
- [ ] CI `ci/gate` + `workspace-test` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)