### PR TITLE
chore(release): v0.31.1 — QA format_parity SKIP fix + MCP M5 pmcp scaffold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,13 @@ jobs:
       # APR-MONO monorepo: 60+ crates, largest dep graph in the fleet.
       # Highest expected sccache hit-rate lift — the signal that justifies
       # fleet-wide rollout (or shelves it).
-      enable_sccache: true
+      #
+      # 2026-04-19: temporarily disabled — sovereign-ci:stable container image
+      # is missing the `rustc-sccache` wrapper script, so every sccache-gated
+      # job fails at toolchain probe ("No such file or directory"). Re-enable
+      # once paiml/.github runner image ships the wrapper again (tracked in
+      # paiml/.github infra issue — not this repo).
+      enable_sccache: false
       use_nextest: true
     secrets: inherit
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.31.1] - 2026-04-19
+
+### Fixed
+
+- **`apr qa` `format_parity` gate** now SKIPs when the primary model is non-GGUF (SafeTensors, APR, ONNX) instead of FAILing the overall QA run (#907). Matches the pre-existing SKIP semantics of the 5 other inference-only gates when golden-output / golden-input / reference tokenizer are unavailable. Regression tests assert `skipped=true && passed=true` for both SafeTensors and APR primaries.
+
+### Added
+
+- **MCP M5 scaffold** (#908) — optional `pmcp = "2.3"` dependency on `aprender-mcp` behind a new `pmcp-dispatcher` feature flag (default off). Zero behaviour change: the hand-rolled stdio dispatcher still runs by default. Unblocks the M5 migration path (pmcp::Server delegation + FALSIFY-MCP-009 byte-identical parity test + SSE/WebSocket transports).
+
 ## [0.31.0] - 2026-04-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,11 +284,11 @@ dependencies = [
 
 [[package]]
 name = "apr-cli"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "alimentar",
  "anyhow",
- "aprender-core 0.31.0",
+ "aprender-core 0.31.1",
  "aprender-mcp",
  "aprender-present-core",
  "aprender-present-terminal",
@@ -454,36 +454,36 @@ dependencies = [
 
 [[package]]
 name = "aprender"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "apr-cli",
- "aprender-core 0.31.0",
+ "aprender-core 0.31.1",
 ]
 
 [[package]]
 name = "aprender-bench-compute"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
- "aprender-core 0.31.0",
+ "aprender-core 0.31.1",
  "criterion 0.7.0",
  "ndarray 0.16.1",
 ]
 
 [[package]]
 name = "aprender-bench-tokenizer"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
- "aprender-core 0.31.0",
+ "aprender-core 0.31.1",
  "criterion 0.7.0",
  "tokenizers",
 ]
 
 [[package]]
 name = "aprender-cbtop"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "anyhow",
- "aprender-compute 0.31.0",
+ "aprender-compute 0.31.1",
  "aprender-gpu",
  "batuta-common",
  "chrono",
@@ -505,7 +505,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cgp"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "anyhow",
  "aprender-gpu",
@@ -525,7 +525,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-common"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "lz4_flex 0.11.6",
  "zstd",
@@ -553,14 +553,14 @@ dependencies = [
 
 [[package]]
 name = "aprender-compute"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "anyhow",
- "aprender-core 0.31.0",
+ "aprender-core 0.31.1",
  "aprender-cuda-edge",
- "aprender-gemm-codegen 0.31.0",
+ "aprender-gemm-codegen 0.31.1",
  "aprender-gpu",
- "aprender-quant 0.31.0",
+ "aprender-quant 0.31.1",
  "aprender-solve",
  "aprender-sparse",
  "bytemuck",
@@ -602,7 +602,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-compute-xtask"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "anyhow",
  "bashrs",
@@ -615,7 +615,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-contracts"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "aprender-contracts-macros",
  "criterion 0.5.1",
@@ -630,7 +630,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-contracts-cli"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "aprender-contracts",
  "clap",
@@ -641,7 +641,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-contracts-macros"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -675,7 +675,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-core"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "aes-gcm",
  "alimentar",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cuda-edge"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "aprender-gpu",
  "proptest",
@@ -737,7 +737,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cupti"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "bindgen 0.71.1",
  "bitflags 2.11.0",
@@ -747,7 +747,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-data"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-db"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "anyhow",
  "arrow 57.3.0",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-distribute"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "arrow 57.3.0",
  "bincode",
@@ -875,7 +875,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-explain"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "aprender-gpu",
  "clap",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-fft"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-gemm-codegen"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -922,7 +922,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-gpu"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "batuta-common",
  "bytemuck",
@@ -945,10 +945,10 @@ dependencies = [
 
 [[package]]
 name = "aprender-graph"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "anyhow",
- "aprender-core 0.31.0",
+ "aprender-core 0.31.1",
  "arrow 57.3.0",
  "bytemuck",
  "criterion 0.6.0",
@@ -967,7 +967,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-image"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -976,7 +976,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-mcp"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -990,9 +990,9 @@ dependencies = [
 
 [[package]]
 name = "aprender-monte-carlo"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
- "aprender 0.31.0",
+ "aprender 0.31.1",
  "assert_cmd",
  "chrono",
  "clap",
@@ -1009,11 +1009,11 @@ dependencies = [
 
 [[package]]
 name = "aprender-orchestrate"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "alimentar",
  "anyhow",
- "aprender-core 0.31.0",
+ "aprender-core 0.31.1",
  "assert_cmd",
  "async-stream",
  "async-trait",
@@ -1082,7 +1082,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-cli"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "aprender-present-yaml",
  "clap",
@@ -1095,9 +1095,9 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-core"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
- "aprender-compute 0.31.0",
+ "aprender-compute 0.31.1",
  "criterion 0.7.0",
  "proptest",
  "provable-contracts-macros 0.3.1",
@@ -1108,7 +1108,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-layout"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "aprender-present-core",
  "criterion 0.7.0",
@@ -1119,7 +1119,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-lib"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "aprender-present-core",
  "aprender-present-layout",
@@ -1148,7 +1148,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-terminal"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "aprender-present-core",
  "bitvec",
@@ -1170,7 +1170,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-test"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "aprender-present-core",
  "aprender-present-test-macros",
@@ -1181,7 +1181,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-test-macros"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1190,7 +1190,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-widgets"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "aprender-present-core",
  "aprender-present-yaml",
@@ -1202,7 +1202,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-yaml"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "aprender-present-core",
  "proptest",
@@ -1256,11 +1256,11 @@ dependencies = [
 
 [[package]]
 name = "aprender-profile"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "addr2line 0.25.1",
  "anyhow",
- "aprender-core 0.31.0",
+ "aprender-core 0.31.1",
  "arbitrary",
  "assert_cmd",
  "backtrace",
@@ -1309,7 +1309,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-profile-core"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "hex",
  "serde",
@@ -1319,7 +1319,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-ptx-debug"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "proptest",
  "thiserror 2.0.18",
@@ -1327,7 +1327,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-certify"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "chrono",
  "proptest",
@@ -1337,7 +1337,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-cli"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "aprender-qa-certify",
  "aprender-qa-gen",
@@ -1356,7 +1356,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-gen"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1373,7 +1373,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-report"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "anyhow",
  "aprender-qa-gen",
@@ -1391,7 +1391,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-runner"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "anyhow",
  "aprender-qa-gen",
@@ -1425,14 +1425,14 @@ dependencies = [
 
 [[package]]
 name = "aprender-quant"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "half",
 ]
 
 [[package]]
 name = "aprender-rag"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "async-trait",
  "batuta-common",
@@ -1461,7 +1461,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-rand"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1470,11 +1470,11 @@ dependencies = [
 
 [[package]]
 name = "aprender-registry"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "alimentar",
  "anyhow",
- "aprender-core 0.31.0",
+ "aprender-core 0.31.1",
  "argon2",
  "blake3",
  "chacha20poly1305",
@@ -1500,12 +1500,12 @@ dependencies = [
 
 [[package]]
 name = "aprender-serve"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "alimentar",
  "anyhow",
  "approx",
- "aprender-core 0.31.0",
+ "aprender-core 0.31.1",
  "arc-swap",
  "arrow 57.3.0",
  "assert_cmd",
@@ -1567,9 +1567,9 @@ dependencies = [
 
 [[package]]
 name = "aprender-shell"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
- "aprender-core 0.31.0",
+ "aprender-core 0.31.1",
  "assert_cmd",
  "clap",
  "criterion 0.7.0",
@@ -1584,7 +1584,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-simulate"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "bincode",
  "bitflags 2.11.0",
@@ -1623,7 +1623,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-solve"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1632,7 +1632,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-sparse"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1641,7 +1641,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-tensor"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1650,7 +1650,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-cli"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "aprender-test-lib",
  "assert_cmd",
@@ -1678,7 +1678,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-derive"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1688,7 +1688,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-js-gen"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "blake3",
  "chrono",
@@ -1704,9 +1704,9 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-lib"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
- "aprender-compute 0.31.0",
+ "aprender-compute 0.31.1",
  "aprender-present-core",
  "aprender-present-terminal",
  "async-trait",
@@ -1748,7 +1748,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-showcase"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "aprender-present-terminal",
  "console_error_panic_hook",
@@ -1765,11 +1765,11 @@ dependencies = [
 
 [[package]]
 name = "aprender-train"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "alimentar",
  "approx",
- "aprender-core 0.31.0",
+ "aprender-core 0.31.1",
  "arrow 57.3.0",
  "axum 0.8.8",
  "bytemuck",
@@ -1832,7 +1832,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-bench"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1849,7 +1849,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-common"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "clap",
  "proptest",
@@ -1861,7 +1861,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-distill"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1882,7 +1882,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-inspect"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1898,7 +1898,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-lora"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1914,7 +1914,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-shell"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1930,7 +1930,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-wasm"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "proptest",
  "serde",
@@ -1941,9 +1941,9 @@ dependencies = [
 
 [[package]]
 name = "aprender-tsp"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
- "aprender 0.31.0",
+ "aprender 0.31.1",
  "assert_cmd",
  "clap",
  "crc32fast",
@@ -1956,7 +1956,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-verify"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "chrono",
  "criterion 0.5.1",
@@ -1968,9 +1968,9 @@ dependencies = [
 
 [[package]]
 name = "aprender-verify-ml"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
- "aprender-core 0.31.0",
+ "aprender-core 0.31.1",
  "arrow 57.3.0",
  "clap",
  "criterion 0.7.0",
@@ -2012,10 +2012,10 @@ dependencies = [
 
 [[package]]
 name = "aprender-viz"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "approx",
- "aprender-core 0.31.0",
+ "aprender-core 0.31.1",
  "base64 0.22.1",
  "batuta-common",
  "criterion 0.6.0",
@@ -2047,7 +2047,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "aprender-zram-adaptive",
  "aprender-zram-core",
@@ -2057,7 +2057,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-adaptive"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "aprender-zram-core",
  "proptest",
@@ -2066,7 +2066,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-cli"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "aprender-zram-adaptive",
  "aprender-zram-core",
@@ -2080,7 +2080,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-core"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "aprender-gpu",
  "criterion 0.7.0",
@@ -2092,7 +2092,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-generator"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "aprender-zram-core",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.31.0"
+version = "0.31.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/paiml/aprender"
@@ -171,7 +171,7 @@ minijinja = { version = "2.14", features = ["loader", "serde"] }
 # Contracts
 provable-contracts = "0.3"
 provable-contracts-macros = "0.3"
-aprender-contracts-macros = { path = "crates/aprender-contracts-macros", version = "0.31.0" }
+aprender-contracts-macros = { path = "crates/aprender-contracts-macros", version = "0.31.1" }
 
 # YAML
 serde_yaml = "0.9"
@@ -183,30 +183,30 @@ hf-hub = { version = "0.4", default-features = false, features = ["ureq"] }
 hf-xet = "1.5.1"
 
 # Workspace-internal crates (paths within the monorepo)
-aprender-compute = { path = "crates/aprender-compute", version = "0.31.0" }
-aprender-gpu = { path = "crates/aprender-gpu", version = "0.31.0" }
-aprender-quant = { path = "crates/aprender-quant", version = "0.31.0" }
-aprender-serve = { path = "crates/aprender-serve", version = "0.31.0" }
-realizar = { path = "crates/aprender-serve", version = "0.31.0", package = "aprender-serve" }
-aprender-train = { path = "crates/aprender-train", version = "0.31.0" }
-entrenar = { path = "crates/aprender-train", version = "0.31.0", package = "aprender-train" }
-aprender-train-common = { path = "crates/aprender-train-common", version = "0.31.0" }
-aprender-orchestrate = { path = "crates/aprender-orchestrate", version = "0.31.0" }
-aprender-contracts = { path = "crates/aprender-contracts", version = "0.31.0" }
-aprender-profile = { path = "crates/aprender-profile", version = "0.31.0" }
-aprender-profile-core = { path = "crates/aprender-profile-core", version = "0.31.0" }
-aprender-zram-core = { path = "crates/aprender-zram-core", version = "0.31.0" }
-aprender-zram-adaptive = { path = "crates/aprender-zram-adaptive", version = "0.31.0" }
-aprender-present-core = { path = "crates/aprender-present-core", version = "0.31.0" }
-aprender-present-terminal = { path = "crates/aprender-present-terminal", version = "0.31.0" }
-aprender-present-widgets = { path = "crates/aprender-present-widgets", version = "0.31.0" }
-aprender-present-layout = { path = "crates/aprender-present-layout", version = "0.31.0" }
-aprender-present-yaml = { path = "crates/aprender-present-yaml", version = "0.31.0" }
-aprender-present-test = { path = "crates/aprender-present-test", version = "0.31.0" }
-aprender-db = { path = "crates/aprender-db", version = "0.31.0" }
-aprender-graph = { path = "crates/aprender-graph", version = "0.31.0" }
-aprender-rag = { path = "crates/aprender-rag", version = "0.31.0" }
-aprender-data = { path = "crates/aprender-data", version = "0.31.0" }
+aprender-compute = { path = "crates/aprender-compute", version = "0.31.1" }
+aprender-gpu = { path = "crates/aprender-gpu", version = "0.31.1" }
+aprender-quant = { path = "crates/aprender-quant", version = "0.31.1" }
+aprender-serve = { path = "crates/aprender-serve", version = "0.31.1" }
+realizar = { path = "crates/aprender-serve", version = "0.31.1", package = "aprender-serve" }
+aprender-train = { path = "crates/aprender-train", version = "0.31.1" }
+entrenar = { path = "crates/aprender-train", version = "0.31.1", package = "aprender-train" }
+aprender-train-common = { path = "crates/aprender-train-common", version = "0.31.1" }
+aprender-orchestrate = { path = "crates/aprender-orchestrate", version = "0.31.1" }
+aprender-contracts = { path = "crates/aprender-contracts", version = "0.31.1" }
+aprender-profile = { path = "crates/aprender-profile", version = "0.31.1" }
+aprender-profile-core = { path = "crates/aprender-profile-core", version = "0.31.1" }
+aprender-zram-core = { path = "crates/aprender-zram-core", version = "0.31.1" }
+aprender-zram-adaptive = { path = "crates/aprender-zram-adaptive", version = "0.31.1" }
+aprender-present-core = { path = "crates/aprender-present-core", version = "0.31.1" }
+aprender-present-terminal = { path = "crates/aprender-present-terminal", version = "0.31.1" }
+aprender-present-widgets = { path = "crates/aprender-present-widgets", version = "0.31.1" }
+aprender-present-layout = { path = "crates/aprender-present-layout", version = "0.31.1" }
+aprender-present-yaml = { path = "crates/aprender-present-yaml", version = "0.31.1" }
+aprender-present-test = { path = "crates/aprender-present-test", version = "0.31.1" }
+aprender-db = { path = "crates/aprender-db", version = "0.31.1" }
+aprender-graph = { path = "crates/aprender-graph", version = "0.31.1" }
+aprender-rag = { path = "crates/aprender-rag", version = "0.31.1" }
+aprender-data = { path = "crates/aprender-data", version = "0.31.1" }
 
 # Additional external deps needed by sub-crates
 serde_yaml_ng = "0.10"
@@ -251,18 +251,18 @@ wasmtime = "43"
 bollard = "0.17"
 
 # Old crate name aliases (workspace = true refs in migrated sub-crates)
-trueno-zram-core = { path = "crates/aprender-zram-core", version = "0.31.0", package = "aprender-zram-core" }
-trueno-zram-adaptive = { path = "crates/aprender-zram-adaptive", version = "0.31.0", package = "aprender-zram-adaptive" }
-trueno = { path = "crates/aprender-compute", version = "0.31.0", package = "aprender-compute" }
-presentar-core = { path = "crates/aprender-present-core", version = "0.31.0", package = "aprender-present-core" }
-presentar-terminal = { path = "crates/aprender-present-terminal", version = "0.31.0", package = "aprender-present-terminal" }
-presentar-widgets = { path = "crates/aprender-present-widgets", version = "0.31.0", package = "aprender-present-widgets" }
-presentar-layout = { path = "crates/aprender-present-layout", version = "0.31.0", package = "aprender-present-layout" }
-presentar-yaml = { path = "crates/aprender-present-yaml", version = "0.31.0", package = "aprender-present-yaml" }
-presentar-test = { path = "crates/aprender-present-test", version = "0.31.0", package = "aprender-present-test" }
-presentar-test-macros = { path = "crates/aprender-present-test-macros", version = "0.31.0", package = "aprender-present-test-macros" }
-jugar-probar-derive = { path = "crates/aprender-test-derive", version = "0.31.0", package = "aprender-test-derive" }
-batuta-common = { path = "crates/aprender-common", version = "0.31.0", package = "aprender-common" }
+trueno-zram-core = { path = "crates/aprender-zram-core", version = "0.31.1", package = "aprender-zram-core" }
+trueno-zram-adaptive = { path = "crates/aprender-zram-adaptive", version = "0.31.1", package = "aprender-zram-adaptive" }
+trueno = { path = "crates/aprender-compute", version = "0.31.1", package = "aprender-compute" }
+presentar-core = { path = "crates/aprender-present-core", version = "0.31.1", package = "aprender-present-core" }
+presentar-terminal = { path = "crates/aprender-present-terminal", version = "0.31.1", package = "aprender-present-terminal" }
+presentar-widgets = { path = "crates/aprender-present-widgets", version = "0.31.1", package = "aprender-present-widgets" }
+presentar-layout = { path = "crates/aprender-present-layout", version = "0.31.1", package = "aprender-present-layout" }
+presentar-yaml = { path = "crates/aprender-present-yaml", version = "0.31.1", package = "aprender-present-yaml" }
+presentar-test = { path = "crates/aprender-present-test", version = "0.31.1", package = "aprender-present-test" }
+presentar-test-macros = { path = "crates/aprender-present-test-macros", version = "0.31.1", package = "aprender-present-test-macros" }
+jugar-probar-derive = { path = "crates/aprender-test-derive", version = "0.31.1", package = "aprender-test-derive" }
+batuta-common = { path = "crates/aprender-common", version = "0.31.1", package = "aprender-common" }
 
 [workspace.lints.rust]
 # Safety
@@ -391,7 +391,7 @@ semicolon_if_nothing_returned = "allow"  # Style preference
 
 [package]
 name = "aprender"
-version = "0.31.0"
+version = "0.31.1"
 edition = "2021"
 rust-version = "1.89"
 authors = ["Noah Gift <noah@paiml.com>"]
@@ -416,7 +416,7 @@ name = "apr"
 path = "src/bin/apr.rs"
 
 [dependencies]
-apr-cli = { path = "crates/apr-cli", version = "0.31.0", default-features = true }
+apr-cli = { path = "crates/apr-cli", version = "0.31.1", default-features = true }
 # Core ML library (lib name = "aprender")
 aprender_ml = { path = "crates/aprender-core", version = ">=0.29", package = "aprender-core" }
 

--- a/crates/apr-cli/Cargo.toml
+++ b/crates/apr-cli/Cargo.toml
@@ -99,10 +99,10 @@ libc = "0.2"
 
 [dependencies]
 # Core aprender library
-aprender = { path = "../aprender-core", version = "0.31.0", package = "aprender-core", default-features = true, features = ["format-compression"] }
+aprender = { path = "../aprender-core", version = "0.31.1", package = "aprender-core", default-features = true, features = ["format-compression"] }
 
 # MCP (Model Context Protocol) server — `apr mcp` subcommand
-aprender-mcp = { path = "../aprender-mcp", version = "0.31.0" }
+aprender-mcp = { path = "../aprender-mcp", version = "0.31.1" }
 async-stream = "0.3"
 provable-contracts-macros = "0.3"
 

--- a/crates/aprender-bench-compute/Cargo.toml
+++ b/crates/aprender-bench-compute/Cargo.toml
@@ -11,7 +11,7 @@ disallowed_methods = "allow"
 
 [dependencies]
 # The implementation under test
-aprender = { path = "../aprender-core", version = "0.31.0", package = "aprender-core", features = ["format-quantize"] }
+aprender = { path = "../aprender-core", version = "0.31.1", package = "aprender-core", features = ["format-quantize"] }
 
 # Reference implementation for A/B comparison
 # Pure Rust (no BLAS) to keep comparison fair — both are pure Rust SIMD

--- a/crates/aprender-bench-tokenizer/Cargo.toml
+++ b/crates/aprender-bench-tokenizer/Cargo.toml
@@ -11,7 +11,7 @@ disallowed_methods = "allow"
 
 [dependencies]
 # The implementation under test
-aprender = { path = "../aprender-core", version = "0.31.0", package = "aprender-core" }
+aprender = { path = "../aprender-core", version = "0.31.1", package = "aprender-core" }
 
 # HuggingFace reference for A/B comparison
 # Regular dep (not dev-dep) because [[bench]] harness=false binaries can't see dev-deps

--- a/crates/aprender-cbtop/Cargo.toml
+++ b/crates/aprender-cbtop/Cargo.toml
@@ -23,8 +23,8 @@ presentar-core = "0.3"
 presentar-terminal = "0.3"
 
 # Compute backends
-trueno = { version = "0.31.0", path = "../aprender-compute", package = "aprender-compute" }
-trueno-gpu = { version = "0.31.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true }
+trueno = { version = "0.31.1", path = "../aprender-compute", package = "aprender-compute" }
+trueno-gpu = { version = "0.31.1", path = "../aprender-gpu", package = "aprender-gpu", optional = true }
 
 # Terminal handling
 crossterm = "0.28"

--- a/crates/aprender-cgp/Cargo.toml
+++ b/crates/aprender-cgp/Cargo.toml
@@ -36,7 +36,7 @@ num_cpus = "1.17"
 comfy-table = "7"
 colored = "3"
 # GPU profiling: direct cuBLAS measurement (OWN THE STACK)
-trueno-gpu = { path = "../aprender-gpu", version = "0.31.0", features = ["cuda"], optional = true, package = "aprender-gpu" }
+trueno-gpu = { path = "../aprender-gpu", version = "0.31.1", features = ["cuda"], optional = true, package = "aprender-gpu" }
 
 [features]
 default = []

--- a/crates/aprender-compute/Cargo.toml
+++ b/crates/aprender-compute/Cargo.toml
@@ -38,11 +38,11 @@ futures-intrusive = { version = "0.5", optional = true }
 wasm-bindgen-futures = { version = "0.4", optional = true }
 wasm-bindgen = { version = "0.2", optional = true }
 # Native CUDA monitoring via trueno-gpu (TRUENO-SPEC-010)
-trueno-gpu = { version = "0.31.0", path = "../aprender-gpu", optional = true, package = "aprender-gpu" }
+trueno-gpu = { version = "0.31.1", path = "../aprender-gpu", optional = true, package = "aprender-gpu" }
 # PMAT-336: Provable contracts compile-time enforcement
 provable-contracts-macros = "0.3"
 # P1a: Sovereign GEMM microkernel codegen (compile-time shape specialization)
-trueno-gemm-codegen = { version = "0.31.0", path = "../aprender-gemm-codegen", package = "aprender-gemm-codegen" }
+trueno-gemm-codegen = { version = "0.31.1", path = "../aprender-gemm-codegen", package = "aprender-gemm-codegen" }
 # Tracing/profiling support (renacer integration)
 tracing = { version = "0.1", optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"], optional = true }
@@ -54,7 +54,7 @@ presentar-core = { version = "0.3", optional = true }
 # Stress test reporting types compatible with renacer (TRUENO-SPEC-025)
 # Note: renacer 0.9.1 has compilation issue; using compatible local types instead
 dhat = { version = "0.3", optional = true }
-trueno-quant = { version = "0.31.0", path = "../aprender-quant", package = "aprender-quant" }
+trueno-quant = { version = "0.31.1", path = "../aprender-quant", package = "aprender-quant" }
 num_cpus = "1.17.0"
 anyhow = "1.0.100"
 # Hardware capability detection (PMAT-447)
@@ -62,7 +62,7 @@ chrono = "0.4"
 toml = "0.8"
 # ML tuner integration (SHOWCASE-BRICK-001, Section 12)
 # Uses aprender 0.24.0 RandomForest for learned optimization
-aprender = { path = "../aprender-core", version = "0.31.0", package = "aprender-core", optional = true, default-features = false }
+aprender = { path = "../aprender-core", version = "0.31.1", package = "aprender-core", optional = true, default-features = false }
 # Execution path graph (PAR-201, Section E.7)
 trueno-graph = { version = "0.1.17", optional = true }
 # TUI visualization for execution graphs (PAR-201)
@@ -90,10 +90,10 @@ nalgebra = "0.34"  # For eigendecomposition benchmark comparison
 simular = "0.2.0"
 regex = "1.11"  # For PTX/WGSL pattern validation in falsification tests
 # GPU edge-case test framework (TCE-001)
-trueno-cuda-edge = { version = "0.31.0", path = "../aprender-cuda-edge", package = "aprender-cuda-edge" }
+trueno-cuda-edge = { version = "0.31.1", path = "../aprender-cuda-edge", package = "aprender-cuda-edge" }
 # Sparse and solver crates for contract tests
-trueno-sparse = { version = "0.31.0", path = "../aprender-sparse", package = "aprender-sparse" }
-trueno-solve = { version = "0.31.0", path = "../aprender-solve", package = "aprender-solve" }
+trueno-sparse = { version = "0.31.1", path = "../aprender-sparse", package = "aprender-sparse" }
+trueno-solve = { version = "0.31.1", path = "../aprender-solve", package = "aprender-solve" }
 ndarray = "0.17.2"
 faer = "0.24"  # For GEMM benchmark comparison (fastest pure-Rust BLAS)
 matrixmultiply = "0.3"  # Direct matrixmultiply crate benchmark (engine behind ndarray)

--- a/crates/aprender-contracts-cli/Cargo.toml
+++ b/crates/aprender-contracts-cli/Cargo.toml
@@ -13,7 +13,7 @@ name = "pv"
 path = "src/main.rs"
 
 [dependencies]
-aprender-contracts = { path = "../aprender-contracts", version = "0.31.0" }
+aprender-contracts = { path = "../aprender-contracts", version = "0.31.1" }
 clap = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }

--- a/crates/aprender-contracts-cli/src/commands/check_parity.rs
+++ b/crates/aprender-contracts-cli/src/commands/check_parity.rs
@@ -160,11 +160,17 @@ fn check_row(row: &Value) -> RowResult {
     let min = row
         .get("expected_min_hits")
         .and_then(Value::as_u64)
-        .or_else(|| row.get("expected_variant_count_min").and_then(Value::as_u64));
+        .or_else(|| {
+            row.get("expected_variant_count_min")
+                .and_then(Value::as_u64)
+        });
     let max = row
         .get("expected_max_hits")
         .and_then(Value::as_u64)
-        .or_else(|| row.get("expected_variant_count_max").and_then(Value::as_u64));
+        .or_else(|| {
+            row.get("expected_variant_count_max")
+                .and_then(Value::as_u64)
+        });
 
     if let Some(m) = min {
         if hits < m {

--- a/crates/aprender-contracts/Cargo.toml
+++ b/crates/aprender-contracts/Cargo.toml
@@ -19,7 +19,7 @@ kani = []
 name = "provable_contracts"
 
 [dependencies]
-provable-contracts-macros = { path = "../aprender-contracts-macros", version = "0.31.0", package = "aprender-contracts-macros" }
+provable-contracts-macros = { path = "../aprender-contracts-macros", version = "0.31.1", package = "aprender-contracts-macros" }
 regex = "1"
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/aprender-core/examples/ch26_switch_ndarray.rs
+++ b/crates/aprender-core/examples/ch26_switch_ndarray.rs
@@ -41,7 +41,10 @@ fn main() {
     let pred = lr.predict(&x);
     let r2 = lr.score(&x, &y);
     println!();
-    println!("LinearRegression: R2 = {r2:.4}, first prediction = {:.4}", pred.as_slice()[0]);
+    println!(
+        "LinearRegression: R2 = {r2:.4}, first prediction = {:.4}",
+        pred.as_slice()[0]
+    );
     assert!(r2 > 0.99, "Perfect linear fit");
 
     // KMeans — same pattern as linfa

--- a/crates/aprender-cuda-edge/Cargo.toml
+++ b/crates/aprender-cuda-edge/Cargo.toml
@@ -15,7 +15,7 @@ name = "trueno_cuda_edge"
 [dependencies]
 thiserror = "2.0"
 serde = { version = "1.0", features = ["derive"] }
-trueno-gpu = { version = "0.31.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true }
+trueno-gpu = { version = "0.31.1", path = "../aprender-gpu", package = "aprender-gpu", optional = true }
 
 [dev-dependencies]
 proptest = "1.6"

--- a/crates/aprender-explain/Cargo.toml
+++ b/crates/aprender-explain/Cargo.toml
@@ -25,7 +25,7 @@ presentar-terminal = "0.3"
 crossterm = "0.28"
 
 # Internal dependency for PTX generation
-trueno-gpu = { version = "0.31.0", path = "../aprender-gpu", package = "aprender-gpu", features = ["cuda"] }
+trueno-gpu = { version = "0.31.1", path = "../aprender-gpu", package = "aprender-gpu", features = ["cuda"] }
 
 [dev-dependencies]
 proptest = "1.4"

--- a/crates/aprender-graph/Cargo.toml
+++ b/crates/aprender-graph/Cargo.toml
@@ -28,7 +28,7 @@ anyhow = "1"
 thiserror = "2"
 
 # Phase 2+ dependencies
-aprender = { path = "../aprender-core", version = "0.31.0", package = "aprender-core" }                                        # Sparse matrix ops, PageRank
+aprender = { path = "../aprender-core", version = "0.31.1", package = "aprender-core" }                                        # Sparse matrix ops, PageRank
 trueno = "0.17"                                          # SIMD primitives
 trueno-db = "0.3.17"                                     # Columnar storage
 

--- a/crates/aprender-mcp/tests/falsify_mcp_008.rs
+++ b/crates/aprender-mcp/tests/falsify_mcp_008.rs
@@ -62,15 +62,27 @@ const CODEGEN_CONSTANTS: &[(&str, &str)] = &[
 /// codegen path for tool descriptions matches YAML byte-for-byte, independent
 /// of the live `ToolDefinition` wiring.
 const CODEGEN_DESCRIPTIONS: &[(&str, &str)] = &[
-    ("apr.version", aprender_mcp::schemas::APR_VERSION_DESCRIPTION),
-    ("apr.validate", aprender_mcp::schemas::APR_VALIDATE_DESCRIPTION),
-    ("apr.tensors", aprender_mcp::schemas::APR_TENSORS_DESCRIPTION),
+    (
+        "apr.version",
+        aprender_mcp::schemas::APR_VERSION_DESCRIPTION,
+    ),
+    (
+        "apr.validate",
+        aprender_mcp::schemas::APR_VALIDATE_DESCRIPTION,
+    ),
+    (
+        "apr.tensors",
+        aprender_mcp::schemas::APR_TENSORS_DESCRIPTION,
+    ),
     ("apr.bench", aprender_mcp::schemas::APR_BENCH_DESCRIPTION),
     ("apr.qa", aprender_mcp::schemas::APR_QA_DESCRIPTION),
     ("apr.trace", aprender_mcp::schemas::APR_TRACE_DESCRIPTION),
     ("apr.run", aprender_mcp::schemas::APR_RUN_DESCRIPTION),
     ("apr.serve", aprender_mcp::schemas::APR_SERVE_DESCRIPTION),
-    ("apr.finetune", aprender_mcp::schemas::APR_FINETUNE_DESCRIPTION),
+    (
+        "apr.finetune",
+        aprender_mcp::schemas::APR_FINETUNE_DESCRIPTION,
+    ),
 ];
 
 fn contract_path() -> PathBuf {
@@ -329,7 +341,8 @@ fn codegen_description_constants_match_yaml() {
             .and_then(|v| v.as_str())
             .unwrap_or_else(|| panic!("contract entry for {tool_name} missing `description`"));
         assert_eq!(
-            *codegen_desc, yaml_desc,
+            *codegen_desc,
+            yaml_desc,
             "FALSIFY-MCP-008 FAIL: codegen APR_<{}>_DESCRIPTION drifted from YAML\n\
              expected (contracts/apr-mcp-tool-schemas-v1.yaml):\n{yaml_desc}\n\
              actual (schemas::APR_<TOOL>_DESCRIPTION emitted by build.rs):\n{codegen_desc}",

--- a/crates/aprender-monte-carlo/Cargo.toml
+++ b/crates/aprender-monte-carlo/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 name = "aprender-monte-carlo"
 
 [dependencies]
-aprender = { path = "../../", version = "0.31.0" }
+aprender = { path = "../../", version = "0.31.1" }
 clap = { version = "4", features = ["derive"] }
 rand = "0.9"
 rand_chacha = "0.9"

--- a/crates/aprender-orchestrate/Cargo.toml
+++ b/crates/aprender-orchestrate/Cargo.toml
@@ -113,7 +113,7 @@ pacha = { version = "0.2", optional = true }
 realizar = { version = "0.8", optional = true, features = ["cuda"] }
 
 # ML algorithms and training (native-only)
-aprender = { path = "../aprender-core", version = "0.31.0", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.31.1", package = "aprender-core", optional = true }
 entrenar = { version = "0.7", optional = true }
 alimentar = { version = "0.2", optional = true }
 

--- a/crates/aprender-orchestrate/src/agent/code.rs
+++ b/crates/aprender-orchestrate/src/agent/code.rs
@@ -410,14 +410,16 @@ fn register_mcp_client_tools(tools: &mut ToolRegistry, manifest: &AgentManifest)
                 return;
             }
         };
-        let discovered =
-            rt.block_on(crate::agent::tool::mcp_client::discover_mcp_tools(manifest));
+        let discovered = rt.block_on(crate::agent::tool::mcp_client::discover_mcp_tools(manifest));
         let count = discovered.len();
         for tool in discovered {
             tools.register(Box::new(tool));
         }
         if count > 0 {
-            eprintln!("✓ Registered {count} MCP tool(s) from {} server(s)", manifest.mcp_servers.len());
+            eprintln!(
+                "✓ Registered {count} MCP tool(s) from {} server(s)",
+                manifest.mcp_servers.len()
+            );
         }
     }
 }
@@ -476,9 +478,7 @@ fn register_web_tools(tools: &mut ToolRegistry, manifest: &AgentManifest) {
 
     #[cfg(feature = "agents-browser")]
     {
-        tools.register(Box::new(crate::agent::tool::browser::BrowserTool::new(
-            manifest.privacy,
-        )));
+        tools.register(Box::new(crate::agent::tool::browser::BrowserTool::new(manifest.privacy)));
     }
 }
 

--- a/crates/aprender-orchestrate/src/agent/code_tests.rs
+++ b/crates/aprender-orchestrate/src/agent/code_tests.rs
@@ -60,10 +60,7 @@ fn test_web_tools_registered_on_standard_privacy_with_allowlist() {
     m.privacy = PrivacyTier::Standard;
     m.allowed_hosts = vec!["docs.anthropic.com".into()];
     let tools = build_code_tools(&m);
-    assert!(
-        tools.get("network").is_some(),
-        "Standard + allowlist must register network tool"
-    );
+    assert!(tools.get("network").is_some(), "Standard + allowlist must register network tool");
 }
 
 #[test]
@@ -72,10 +69,7 @@ fn test_web_tools_registered_on_private_privacy_with_allowlist() {
     m.privacy = PrivacyTier::Private;
     m.allowed_hosts = vec!["github.com".into()];
     let tools = build_code_tools(&m);
-    assert!(
-        tools.get("network").is_some(),
-        "Private + allowlist must register network tool"
-    );
+    assert!(tools.get("network").is_some(), "Private + allowlist must register network tool");
 }
 
 #[test]
@@ -479,10 +473,7 @@ fn test_scale_prompt_large() {
 #[test]
 fn test_register_mcp_client_tools_noop_when_empty() {
     let manifest = build_default_manifest();
-    assert!(
-        manifest.mcp_servers.is_empty(),
-        "default manifest should declare zero mcp_servers"
-    );
+    assert!(manifest.mcp_servers.is_empty(), "default manifest should declare zero mcp_servers");
     let mut tools = build_code_tools(&manifest);
     let before = tools.len();
     register_mcp_client_tools(&mut tools, &manifest);

--- a/crates/aprender-orchestrate/src/agent/custom_agents.rs
+++ b/crates/aprender-orchestrate/src/agent/custom_agents.rs
@@ -222,11 +222,8 @@ fn split_at_fence(after_open: &str) -> Option<(&str, &str)> {
 }
 
 fn line_starts(s: &str) -> impl Iterator<Item = (usize, usize)> + '_ {
-    std::iter::once((0usize, 0usize)).chain(
-        s.match_indices('\n')
-            .enumerate()
-            .map(|(i, (pos, _))| (i + 1, pos + 1)),
-    )
+    std::iter::once((0usize, 0usize))
+        .chain(s.match_indices('\n').enumerate().map(|(i, (pos, _))| (i + 1, pos + 1)))
 }
 
 fn user_agents_dir() -> Option<PathBuf> {

--- a/crates/aprender-orchestrate/src/agent/custom_agents/tests.rs
+++ b/crates/aprender-orchestrate/src/agent/custom_agents/tests.rs
@@ -123,10 +123,7 @@ fn parse_agent_md_skips_comment_lines() {
 fn load_custom_agents_from_flat_layout() {
     let dir = tempfile::tempdir().expect("tempdir");
     write(&dir.path().join("reviewer.md"), VALID);
-    write(
-        &dir.path().join("planner.md"),
-        "---\nname: planner\ndescription: plans\n---\nbody\n",
-    );
+    write(&dir.path().join("planner.md"), "---\nname: planner\ndescription: plans\n---\nbody\n");
     // Non-md files are ignored
     write(&dir.path().join("README.txt"), "not an agent");
 
@@ -182,10 +179,7 @@ fn discover_standard_locations_finds_project_dir() {
 fn discover_standard_locations_falls_back_to_claude_dir() {
     let cwd = tempfile::tempdir().expect("tempdir");
     // No .apr/agents — only .claude/agents
-    write(
-        &cwd.path().join(".claude").join("agents").join("x.md"),
-        VALID,
-    );
+    write(&cwd.path().join(".claude").join("agents").join("x.md"), VALID);
 
     let specs = discover_standard_locations(cwd.path());
     assert!(

--- a/crates/aprender-orchestrate/src/agent/hooks.rs
+++ b/crates/aprender-orchestrate/src/agent/hooks.rs
@@ -161,18 +161,10 @@ impl HookRegistry {
 }
 
 fn run_single(cfg: &HookConfig, cwd: &Path) -> HookDecision {
-    let output = match Command::new("sh")
-        .arg("-c")
-        .arg(&cfg.command)
-        .current_dir(cwd)
-        .output()
-    {
+    let output = match Command::new("sh").arg("-c").arg(&cfg.command).current_dir(cwd).output() {
         Ok(o) => o,
         Err(e) => {
-            return HookDecision::Warn(format!(
-                "hook '{}' failed to spawn: {e}",
-                cfg.command
-            ));
+            return HookDecision::Warn(format!("hook '{}' failed to spawn: {e}", cfg.command));
         }
     };
     let code = output.status.code().unwrap_or(0);

--- a/crates/aprender-orchestrate/src/agent/hooks/tests.rs
+++ b/crates/aprender-orchestrate/src/agent/hooks/tests.rs
@@ -14,31 +14,19 @@ use std::env;
 
 #[test]
 fn test_decision_from_exit_code_allow() {
-    assert_eq!(
-        HookDecision::from_exit_code(0, "ignored".into()),
-        HookDecision::Allow
-    );
+    assert_eq!(HookDecision::from_exit_code(0, "ignored".into()), HookDecision::Allow);
 }
 
 #[test]
 fn test_decision_from_exit_code_warn() {
-    assert_eq!(
-        HookDecision::from_exit_code(1, "hi".into()),
-        HookDecision::Warn("hi".into())
-    );
+    assert_eq!(HookDecision::from_exit_code(1, "hi".into()), HookDecision::Warn("hi".into()));
 }
 
 #[test]
 fn test_decision_from_exit_code_block() {
-    assert_eq!(
-        HookDecision::from_exit_code(2, "no".into()),
-        HookDecision::Block("no".into())
-    );
+    assert_eq!(HookDecision::from_exit_code(2, "no".into()), HookDecision::Block("no".into()));
     // Anything other than 0/1 is also a block.
-    assert_eq!(
-        HookDecision::from_exit_code(42, "x".into()),
-        HookDecision::Block("x".into())
-    );
+    assert_eq!(HookDecision::from_exit_code(42, "x".into()), HookDecision::Block("x".into()));
 }
 
 #[test]
@@ -80,10 +68,7 @@ fn test_registry_from_configs() {
 fn test_registry_run_allow_when_empty() {
     let reg = HookRegistry::new();
     let cwd = env::temp_dir();
-    assert_eq!(
-        reg.run(HookEvent::PreToolUse, "shell", &cwd),
-        HookDecision::Allow
-    );
+    assert_eq!(reg.run(HookEvent::PreToolUse, "shell", &cwd), HookDecision::Allow);
 }
 
 #[test]

--- a/crates/aprender-orchestrate/src/agent/permission/tests.rs
+++ b/crates/aprender-orchestrate/src/agent/permission/tests.rs
@@ -46,10 +46,7 @@ fn parse_accepts_canonical_camel_case() {
     assert_eq!(PermissionMode::parse("default"), Some(PermissionMode::Default));
     assert_eq!(PermissionMode::parse("plan"), Some(PermissionMode::Plan));
     assert_eq!(PermissionMode::parse("acceptEdits"), Some(PermissionMode::AcceptEdits));
-    assert_eq!(
-        PermissionMode::parse("bypassPermissions"),
-        Some(PermissionMode::BypassPermissions)
-    );
+    assert_eq!(PermissionMode::parse("bypassPermissions"), Some(PermissionMode::BypassPermissions));
 }
 
 #[test]

--- a/crates/aprender-orchestrate/src/agent/repl.rs
+++ b/crates/aprender-orchestrate/src/agent/repl.rs
@@ -496,7 +496,9 @@ fn handle_slash_command(
             );
         }
         SlashCommand::Permissions => {
-            println!("  Permission modes not yet implemented — tracked by PMAT-CODE-PERMISSIONS-001.");
+            println!(
+                "  Permission modes not yet implemented — tracked by PMAT-CODE-PERMISSIONS-001."
+            );
         }
         SlashCommand::Hooks => {
             println!("  Hooks not yet implemented — tracked by PMAT-CODE-HOOKS-001.");
@@ -511,7 +513,9 @@ fn handle_slash_command(
             println!("  /add-dir not yet implemented — tracked by PMAT-CODE-ADDDIR-001.");
         }
         SlashCommand::Agents => {
-            println!("  Custom agents not yet implemented — tracked by PMAT-CODE-CUSTOM-AGENTS-001.");
+            println!(
+                "  Custom agents not yet implemented — tracked by PMAT-CODE-CUSTOM-AGENTS-001."
+            );
         }
         SlashCommand::Unknown(name) => {
             println!("  {} Unknown command: {name}. Type /help for commands.", "?".bright_yellow());

--- a/crates/aprender-orchestrate/src/agent/skill/tests.rs
+++ b/crates/aprender-orchestrate/src/agent/skill/tests.rs
@@ -113,10 +113,7 @@ fn parse_skill_md_empty_body_errors() {
 fn load_skills_flat_layout() {
     let dir = tempfile::tempdir().expect("tempdir");
     write(&dir.path().join("a.md"), VALID);
-    write(
-        &dir.path().join("b.md"),
-        "---\nname: b\ndescription: db\n---\ninstructions-b\n",
-    );
+    write(&dir.path().join("b.md"), "---\nname: b\ndescription: db\n---\ninstructions-b\n");
     write(&dir.path().join("readme.txt"), "skip");
 
     let skills = load_skills_from(dir.path());

--- a/crates/aprender-orchestrate/src/agent/status_line/tests.rs
+++ b/crates/aprender-orchestrate/src/agent/status_line/tests.rs
@@ -68,13 +68,8 @@ fn build_converts_permission_mode_to_canonical_string() {
 
 #[test]
 fn build_passes_through_optionals_untouched() {
-    let s = StatusLine::build(
-        "m",
-        PermissionMode::Plan,
-        0.5,
-        Some("br".into()),
-        Some("~/x".into()),
-    );
+    let s =
+        StatusLine::build("m", PermissionMode::Plan, 0.5, Some("br".into()), Some("~/x".into()));
     assert_eq!(s.branch.as_deref(), Some("br"));
     assert_eq!(s.cwd_short.as_deref(), Some("~/x"));
     assert_eq!(s.cost_usd, 0.5);

--- a/crates/aprender-orchestrate/src/agent/task_tool.rs
+++ b/crates/aprender-orchestrate/src/agent/task_tool.rs
@@ -56,17 +56,15 @@ impl SubagentSpec {
     pub fn general_purpose() -> Self {
         Self {
             name: "general-purpose".into(),
-            description:
-                "General-purpose agent for researching questions, searching for code, \
+            description: "General-purpose agent for researching questions, searching for code, \
                  and executing multi-step tasks. Use when the target is not known \
                  and you are not confident you will find the right match in the \
                  first few tries."
-                    .into(),
-            system_prompt:
-                "You are a general-purpose research subagent. Your job is to answer \
+                .into(),
+            system_prompt: "You are a general-purpose research subagent. Your job is to answer \
                  the user's question by gathering evidence from the codebase. Return \
                  a concise summary of findings, not running commentary."
-                    .into(),
+                .into(),
             max_iterations: 10,
         }
     }
@@ -75,16 +73,14 @@ impl SubagentSpec {
     pub fn explore() -> Self {
         Self {
             name: "explore".into(),
-            description:
-                "Fast agent specialized for exploring codebases. Use to find files \
+            description: "Fast agent specialized for exploring codebases. Use to find files \
                  by pattern, search code for keywords, or answer questions about \
                  structure. Returns a digest of findings."
-                    .into(),
-            system_prompt:
-                "You are a codebase exploration subagent. Prefer pmat_query over \
+                .into(),
+            system_prompt: "You are a codebase exploration subagent. Prefer pmat_query over \
                  raw grep. Never edit files. Return a short digest of what you found \
                  with file:line citations."
-                    .into(),
+                .into(),
             max_iterations: 8,
         }
     }
@@ -93,16 +89,14 @@ impl SubagentSpec {
     pub fn plan() -> Self {
         Self {
             name: "plan".into(),
-            description:
-                "Software architect subagent for designing implementation plans. \
+            description: "Software architect subagent for designing implementation plans. \
                  Use when you need a step-by-step plan, critical-file list, or \
                  architectural trade-offs before implementing."
-                    .into(),
-            system_prompt:
-                "You are a planning subagent. Read the relevant code, then return a \
+                .into(),
+            system_prompt: "You are a planning subagent. Read the relevant code, then return a \
                  numbered plan with (a) files to change, (b) order of changes, and \
                  (c) the key trade-off. Do not write code."
-                    .into(),
+                .into(),
             max_iterations: 6,
         }
     }

--- a/crates/aprender-orchestrate/src/agent/task_tool/tests.rs
+++ b/crates/aprender-orchestrate/src/agent/task_tool/tests.rs
@@ -94,9 +94,7 @@ async fn task_tool_missing_prompt_errors() {
     let pool = make_pool("x");
     let registry = Arc::new(default_registry());
     let tool = TaskTool::new(registry, pool, AgentManifest::default(), 0, 3);
-    let result = tool
-        .execute(serde_json::json!({ "subagent_type": "explore" }))
-        .await;
+    let result = tool.execute(serde_json::json!({ "subagent_type": "explore" })).await;
     assert!(result.is_error);
     assert!(result.content.contains("prompt"));
 }
@@ -163,11 +161,7 @@ async fn register_task_tool_adds_to_registry() {
 
 #[test]
 fn subagent_spec_presets_have_nonempty_system_prompts() {
-    for spec in [
-        SubagentSpec::general_purpose(),
-        SubagentSpec::explore(),
-        SubagentSpec::plan(),
-    ] {
+    for spec in [SubagentSpec::general_purpose(), SubagentSpec::explore(), SubagentSpec::plan()] {
         assert!(!spec.system_prompt.trim().is_empty(), "{}: system_prompt empty", spec.name);
         assert!(!spec.description.trim().is_empty(), "{}: description empty", spec.name);
         assert!(spec.max_iterations > 0);

--- a/crates/aprender-orchestrate/src/agent/worktree.rs
+++ b/crates/aprender-orchestrate/src/agent/worktree.rs
@@ -103,7 +103,9 @@ impl WorktreeSession {
             .map_err(|e| WorktreeError::SpawnFailed(e.to_string()))?;
 
         if !output.status.success() {
-            return Err(WorktreeError::CreateFailed(String::from_utf8_lossy(&output.stderr).into()));
+            return Err(WorktreeError::CreateFailed(
+                String::from_utf8_lossy(&output.stderr).into(),
+            ));
         }
 
         Ok(Self {
@@ -141,7 +143,9 @@ impl WorktreeSession {
             .map_err(|e| WorktreeError::SpawnFailed(e.to_string()))?;
 
         if !output.status.success() {
-            return Err(WorktreeError::StatusFailed(String::from_utf8_lossy(&output.stderr).into()));
+            return Err(WorktreeError::StatusFailed(
+                String::from_utf8_lossy(&output.stderr).into(),
+            ));
         }
 
         Ok(!output.stdout.is_empty())

--- a/crates/aprender-orchestrate/src/agent/worktree/tests.rs
+++ b/crates/aprender-orchestrate/src/agent/worktree/tests.rs
@@ -54,8 +54,7 @@ fn create_clean_worktree_and_auto_close_if_clean_cleans_up() {
         return;
     }
     let (_td, repo) = init_temp_repo();
-    let session =
-        WorktreeSession::create(&repo, "agent/clean").expect("create worktree");
+    let session = WorktreeSession::create(&repo, "agent/clean").expect("create worktree");
     let wt_path = session.path().to_path_buf();
     let wt_branch = session.branch().to_string();
 
@@ -74,10 +73,7 @@ fn create_clean_worktree_and_auto_close_if_clean_cleans_up() {
         .args(["branch", "--list", "agent/clean"])
         .output()
         .expect("git branch");
-    assert!(
-        String::from_utf8_lossy(&out.stdout).trim().is_empty(),
-        "branch must be deleted"
-    );
+    assert!(String::from_utf8_lossy(&out.stdout).trim().is_empty(), "branch must be deleted");
 }
 
 #[test]
@@ -86,8 +82,7 @@ fn create_dirty_worktree_and_auto_close_if_clean_keeps_it() {
         return;
     }
     let (_td, repo) = init_temp_repo();
-    let session =
-        WorktreeSession::create(&repo, "agent/dirty").expect("create worktree");
+    let session = WorktreeSession::create(&repo, "agent/dirty").expect("create worktree");
     let wt_path = session.path().to_path_buf();
     // Make the worktree dirty.
     fs::write(wt_path.join("scratch.txt"), "new file\n").expect("write scratch");
@@ -117,8 +112,7 @@ fn keep_returns_path_and_branch_without_removing() {
         return;
     }
     let (_td, repo) = init_temp_repo();
-    let session =
-        WorktreeSession::create(&repo, "agent/kept").expect("create worktree");
+    let session = WorktreeSession::create(&repo, "agent/kept").expect("create worktree");
     let wt_path = session.path().to_path_buf();
 
     let (kept_path, kept_branch) = session.keep();
@@ -140,8 +134,7 @@ fn auto_close_removes_even_if_dirty() {
         return;
     }
     let (_td, repo) = init_temp_repo();
-    let session =
-        WorktreeSession::create(&repo, "agent/force").expect("create worktree");
+    let session = WorktreeSession::create(&repo, "agent/force").expect("create worktree");
     let wt_path = session.path().to_path_buf();
     fs::write(wt_path.join("scratch.txt"), "dirty\n").expect("write scratch");
 
@@ -173,8 +166,7 @@ fn repo_root_accessor_returns_input_path() {
         return;
     }
     let (_td, repo) = init_temp_repo();
-    let session =
-        WorktreeSession::create(&repo, "agent/root-probe").expect("create worktree");
+    let session = WorktreeSession::create(&repo, "agent/root-probe").expect("create worktree");
     assert_eq!(session.repo_root(), repo.as_path());
     session.auto_close().expect("cleanup");
 }

--- a/crates/aprender-profile/Cargo.toml
+++ b/crates/aprender-profile/Cargo.toml
@@ -74,7 +74,7 @@ trueno = { version = "0.17" }
 
 # Machine learning for anomaly detection (Sprint 23)
 # GH-581: Use path dep to avoid trueno version skew with local workspace
-aprender = { path = "../aprender-core", version = "0.31.0", package = "aprender-core" }
+aprender = { path = "../aprender-core", version = "0.31.1", package = "aprender-core" }
 
 # Lock-free data structures for ring buffer (Sprint 40)
 crossbeam = { version = "0.8", default-features = false, features = ["crossbeam-channel", "crossbeam-queue", "std"] }

--- a/crates/aprender-registry/Cargo.toml
+++ b/crates/aprender-registry/Cargo.toml
@@ -42,7 +42,7 @@ zstd = { version = "0.13", optional = true }
 clap = { version = "4", features = ["derive"], optional = true }
 
 # Ecosystem integration
-aprender = { path = "../aprender-core", version = "0.31.0", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.31.1", package = "aprender-core", optional = true }
 alimentar = { version = "0.2.3", optional = true }
 
 # HTTP client (optional)

--- a/crates/aprender-serve/Cargo.toml
+++ b/crates/aprender-serve/Cargo.toml
@@ -53,7 +53,7 @@ renacer-core = { version = "0.1" }
 
 # ML algorithms and .apr model format (optional for aprender model serving)
 # v0.24.1: chat templates, GGUF tokenizer preservation (local may be newer)
-aprender = { path = "../aprender-core", version = "0.31.0", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.31.1", package = "aprender-core", optional = true }
 
 # Data loading library (optional for data pipeline examples)
 alimentar = { version = "0.2", optional = true, default-features = false, features = ["local", "shuffle"] }

--- a/crates/aprender-shell/Cargo.toml
+++ b/crates/aprender-shell/Cargo.toml
@@ -24,7 +24,7 @@ harness = false
 
 [dependencies]
 # Use path for local dev, crates.io for release
-aprender = { path = "../aprender-core", version = "0.31.0", package = "aprender-core", features = ["format-encryption", "format-compression", "format-homomorphic"] }
+aprender = { path = "../aprender-core", version = "0.31.1", package = "aprender-core", features = ["format-encryption", "format-compression", "format-homomorphic"] }
 clap = { version = "4", features = ["derive"] }
 dirs = "5"
 serde = { version = "1", features = ["derive"] }

--- a/crates/aprender-test-cli/Cargo.toml
+++ b/crates/aprender-test-cli/Cargo.toml
@@ -24,7 +24,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Core library (was: jugar-probar) — dep key preserves Rust identifier
-jugar-probar = { path = "../aprender-test-lib", version = "0.31.0", package = "aprender-test-lib" }
+jugar-probar = { path = "../aprender-test-lib", version = "0.31.1", package = "aprender-test-lib" }
 
 # CLI framework
 clap = { workspace = true }

--- a/crates/aprender-train-bench/Cargo.toml
+++ b/crates/aprender-train-bench/Cargo.toml
@@ -19,8 +19,8 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-entrenar = { version = "0.31.0", path = "../aprender-train", package = "aprender-train" }
-entrenar-common = { version = "0.31.0", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar = { version = "0.31.1", path = "../aprender-train", package = "aprender-train" }
+entrenar-common = { version = "0.31.1", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/aprender-train-distill/Cargo.toml
+++ b/crates/aprender-train-distill/Cargo.toml
@@ -23,8 +23,8 @@ default = []
 hub = ["entrenar/hub"]
 
 [dependencies]
-entrenar = { version = "0.31.0", path = "../aprender-train", package = "aprender-train" }
-entrenar-common = { version = "0.31.0", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar = { version = "0.31.1", path = "../aprender-train", package = "aprender-train" }
+entrenar-common = { version = "0.31.1", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/aprender-train-inspect/Cargo.toml
+++ b/crates/aprender-train-inspect/Cargo.toml
@@ -19,8 +19,8 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-entrenar = { version = "0.31.0", path = "../aprender-train", package = "aprender-train" }
-entrenar-common = { version = "0.31.0", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar = { version = "0.31.1", path = "../aprender-train", package = "aprender-train" }
+entrenar-common = { version = "0.31.1", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/aprender-train-lora/Cargo.toml
+++ b/crates/aprender-train-lora/Cargo.toml
@@ -19,8 +19,8 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-entrenar = { version = "0.31.0", path = "../aprender-train", package = "aprender-train" }
-entrenar-common = { version = "0.31.0", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar = { version = "0.31.1", path = "../aprender-train", package = "aprender-train" }
+entrenar-common = { version = "0.31.1", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/aprender-train-shell/Cargo.toml
+++ b/crates/aprender-train-shell/Cargo.toml
@@ -19,8 +19,8 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-entrenar = { version = "0.31.0", path = "../aprender-train", package = "aprender-train" }
-entrenar-common = { version = "0.31.0", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar = { version = "0.31.1", path = "../aprender-train", package = "aprender-train" }
+entrenar-common = { version = "0.31.1", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 rustyline = "14"
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/aprender-train/Cargo.toml
+++ b/crates/aprender-train/Cargo.toml
@@ -77,7 +77,7 @@ ndarray = "0.16"
 trueno = { version = "0.17", features = ["parallel"] }  # SIMD-accelerated compute
 trueno-gpu = { version = "0.4", optional = true }  # CUDA compute
 realizar = { version = "0.8", optional = true }  # CUDA inference engine
-aprender = { path = "../aprender-core", version = "0.31.0", package = "aprender-core" }  # ML interpret module + .apr format + tokenizers
+aprender = { path = "../aprender-core", version = "0.31.1", package = "aprender-core" }  # ML interpret module + .apr format + tokenizers
 trueno-viz = { version = "0.2", features = ["terminal"] }  # Terminal visualization
 presentar-terminal = { version = "0.3.5", optional = true }  # Sovereign TUI framework (gated by "tui" feature)
 presentar-core = "0.3.4"  # Presentar core traits (crates.io — path removed, presentar restructured)

--- a/crates/aprender-train/src/models/llama_370m.rs
+++ b/crates/aprender-train/src/models/llama_370m.rs
@@ -605,39 +605,15 @@ mod tests {
         out.push(("model.embed_tokens.weight".into(), vec![v, h]));
         out.push(("lm_head.weight".into(), vec![v, h]));
         for n in 0..layers {
-            out.push((
-                format!("model.layers.{n}.self_attn.q_proj.weight"),
-                vec![nh * hd, h],
-            ));
-            out.push((
-                format!("model.layers.{n}.self_attn.k_proj.weight"),
-                vec![nkv * hd, h],
-            ));
-            out.push((
-                format!("model.layers.{n}.self_attn.v_proj.weight"),
-                vec![nkv * hd, h],
-            ));
-            out.push((
-                format!("model.layers.{n}.self_attn.o_proj.weight"),
-                vec![h, nh * hd],
-            ));
-            out.push((
-                format!("model.layers.{n}.mlp.gate_proj.weight"),
-                vec![i, h],
-            ));
+            out.push((format!("model.layers.{n}.self_attn.q_proj.weight"), vec![nh * hd, h]));
+            out.push((format!("model.layers.{n}.self_attn.k_proj.weight"), vec![nkv * hd, h]));
+            out.push((format!("model.layers.{n}.self_attn.v_proj.weight"), vec![nkv * hd, h]));
+            out.push((format!("model.layers.{n}.self_attn.o_proj.weight"), vec![h, nh * hd]));
+            out.push((format!("model.layers.{n}.mlp.gate_proj.weight"), vec![i, h]));
             out.push((format!("model.layers.{n}.mlp.up_proj.weight"), vec![i, h]));
-            out.push((
-                format!("model.layers.{n}.mlp.down_proj.weight"),
-                vec![h, i],
-            ));
-            out.push((
-                format!("model.layers.{n}.input_layernorm.weight"),
-                vec![h],
-            ));
-            out.push((
-                format!("model.layers.{n}.post_attention_layernorm.weight"),
-                vec![h],
-            ));
+            out.push((format!("model.layers.{n}.mlp.down_proj.weight"), vec![h, i]));
+            out.push((format!("model.layers.{n}.input_layernorm.weight"), vec![h]));
+            out.push((format!("model.layers.{n}.post_attention_layernorm.weight"), vec![h]));
         }
         out.push(("model.norm.weight".into(), vec![h]));
         out
@@ -779,9 +755,8 @@ mod tests {
     fn falsify_ship_019_gate_arch_370m_004_has_partial_discharge_marker() {
         let doc: serde_yaml::Value =
             serde_yaml::from_str(SOVEREIGN_CONTRACT_YAML).expect("parse sovereign contract");
-        let gates = doc["gates"]
-            .as_sequence()
-            .expect("gates must be a sequence in sovereign contract");
+        let gates =
+            doc["gates"].as_sequence().expect("gates must be a sequence in sovereign contract");
         let gate = gates
             .iter()
             .find(|g| g["id"].as_str() == Some("GATE-ARCH-370M-004"))

--- a/crates/aprender-tsp/Cargo.toml
+++ b/crates/aprender-tsp/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 name = "aprender-tsp"
 
 [dependencies]
-aprender = { path = "../../", version = "0.31.0" }
+aprender = { path = "../../", version = "0.31.1" }
 clap = { version = "4", features = ["derive"] }
 rand = "0.9"
 crc32fast = "1.4"

--- a/crates/aprender-verify-ml/Cargo.toml
+++ b/crates/aprender-verify-ml/Cargo.toml
@@ -50,7 +50,7 @@ uuid = { version = "1.11", features = ["v4", "serde"] }
 trueno = "0.7.3"
 
 # Machine learning for bug prediction (optional)
-aprender = { path = "../aprender-core", version = "0.31.0", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.31.1", package = "aprender-core", optional = true }
 
 # LLM fine-tuning integration (optional)
 entrenar = { version = "0.2", optional = true }

--- a/crates/aprender-viz/Cargo.toml
+++ b/crates/aprender-viz/Cargo.toml
@@ -29,7 +29,7 @@ base64 = "0.22"
 thiserror = "2.0"
 
 # Optional: ML integration
-aprender = { path = "../aprender-core", version = "0.31.0", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.31.1", package = "aprender-core", optional = true }
 
 # Optional: Graph integration
 trueno-graph = { version = "0.1.17", optional = true, default-features = false }


### PR DESCRIPTION
## Summary

Cuts **v0.31.1** patch release combining two PRs that landed post-v0.31.0:

- **#907** — `apr qa format_parity` SKIPs non-GGUF primary instead of FAILing
- **#908** — MCP M5 PR 1: `pmcp = "2.3"` optional dep behind `pmcp-dispatcher` feature (default off)

Plus `cargo fmt --all` normalization (45 lines across 17 non-Cargo files; no semantic changes).

## Wire-level

- Workspace + root `aprender` package: 0.31.0 → 0.31.1
- All 60+ path-dep pins updated in lockstep
- `opentelemetry` family kept at 0.31.0 (external — not our bump)

## Pre-push gates

- `cargo fmt --all --check` — clean after format
- `cargo test -p aprender-contracts --lib` — 1371 passed / 0 failed
- `cargo deny check advisories` — `advisories ok`
- `cargo check --workspace` — clean build

## Post-merge

1. Tag `v0.31.1` on the squashed merge commit
2. Create GH Release
3. Publish to crates.io in dep order (pending this merge)

## Test plan

- [x] Workspace type-checks
- [x] Contract suite green (1371 tests)
- [x] fmt + deny clean
- [ ] CI `ci / gate` + `workspace-test` green before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)