### PR TITLE
fix(publish): bundle aprender-mcp contract YAML + build.rs escape guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,11 @@ jobs:
           cargo test -p aprender-core --test monorepo_invariants
           cargo test -p aprender-core --test readme_contract
           cargo test -p apr-cli --test cli_commands
+      - name: Build.rs crate-root escape check (v0.31.1 yank guard)
+        # Static Poka-Yoke: flags build.rs files that panic on files outside
+        # CARGO_MANIFEST_DIR, which break `cargo install` from crates.io.
+        # See scripts/check_build_rs_paths.sh for the full rationale.
+        run: bash scripts/check_build_rs_paths.sh
       - name: Fix file ownership (container runs as root, runner as noah:1000)
         if: always()
         run: |

--- a/Makefile
+++ b/Makefile
@@ -202,6 +202,8 @@ tier3:
 	@bash scripts/check_include_files.sh
 	@echo "Checking publish safety (symlinks, companion lookups)..."
 	@bash scripts/check_publish_safety.sh
+	@echo "Checking build.rs crate-root escapes (v0.31.1 yank class)..."
+	@bash scripts/check_build_rs_paths.sh
 	@if [ -d tests/golden ] && command -v apr >/dev/null 2>&1; then \
 		echo "Running probar golden regression with profiling..."; \
 		apr probar tests/golden/model.apr --golden tests/golden/ --assert --tolerance 0.98 2>/dev/null || true; \

--- a/crates/aprender-mcp/Cargo.toml
+++ b/crates/aprender-mcp/Cargo.toml
@@ -10,6 +10,19 @@ description = "Model Context Protocol (MCP) server for aprender — exposes apr 
 keywords = ["mcp", "llm", "inference", "aprender", "claude"]
 categories = ["command-line-utilities", "science"]
 readme = "README.md"
+# FALSIFY-PUBLISH-001 (v0.31.2): bundle the contract YAML read by build.rs so
+# `cargo install aprender` works from a crates.io tarball. v0.31.1 build read
+# `../../contracts/apr-mcp-tool-schemas-v1.yaml` (outside the package) and
+# panicked at install time. In-crate copy is drift-guarded by
+# tests/falsify_mcp_008.rs (`contract_copy_matches_workspace_root`).
+include = [
+    "src/**/*",
+    "tests/**/*",
+    "build.rs",
+    "Cargo.toml",
+    "README.md",
+    "contracts/*.yaml",
+]
 
 [lib]
 name = "aprender_mcp"

--- a/crates/aprender-mcp/build.rs
+++ b/crates/aprender-mcp/build.rs
@@ -85,14 +85,20 @@ fn main() {
     });
 }
 
-/// Resolve `contracts/apr-mcp-tool-schemas-v1.yaml` relative to this crate's
-/// manifest dir. Works for both in-tree builds and worktree copies.
+/// Resolve `apr-mcp-tool-schemas-v1.yaml` relative to this crate's
+/// manifest dir.
+///
+/// Single source of truth per-crate: `CARGO_MANIFEST_DIR/contracts/…`.
+/// Shipping the YAML inside the crate (via `Cargo.toml` `include`) is what
+/// makes `cargo install aprender` work — the workspace-root
+/// `contracts/apr-mcp-tool-schemas-v1.yaml` is outside the published
+/// package and would panic this build.rs at install time (v0.31.1 bug).
+/// A drift-guard test in `tests/falsify_mcp_008.rs` asserts the in-crate
+/// copy stays byte-identical to the workspace-root copy in-tree.
 fn locate_contract() -> PathBuf {
     let manifest_dir = std::env::var("CARGO_MANIFEST_DIR")
         .expect("FALSIFY-MCP-008: CARGO_MANIFEST_DIR unset in build.rs");
     Path::new(&manifest_dir)
-        .join("..")
-        .join("..")
         .join("contracts")
         .join("apr-mcp-tool-schemas-v1.yaml")
 }

--- a/crates/aprender-mcp/contracts/apr-mcp-tool-schemas-v1.yaml
+++ b/crates/aprender-mcp/contracts/apr-mcp-tool-schemas-v1.yaml
@@ -1,0 +1,334 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# apr-mcp-tool-schemas-v1
+#
+# SOURCE OF TRUTH for every `aprender-mcp` tool's MCP `inputSchema` (per-arg
+# name, type, required flag, description) AND its tool-level `description`
+# string. This contract exists separately from `contracts/apr-cli-commands-v1.yaml`
+# because the latter is a pure command registry: each of its 58 entries carries
+# only {name, category, description, requires_model, side_effects}. It
+# intentionally has no argument-level data and therefore cannot drive
+# JSON-Schema code generation.
+#
+# This contract fills that gap. `crates/aprender-mcp/build.rs` reads this YAML
+# and emits `$OUT_DIR/schemas.rs` containing, per tool, two constants:
+#   `pub const APR_<TOOL>_SCHEMA:      &str`  — serialized JSON Schema body
+#   `pub const APR_<TOOL>_DESCRIPTION: &str`  — tool-level description (PMAT-514)
+# Each tool's `*_tool_definition()` in `crates/aprender-mcp/src/tools/` parses
+# `APR_<TOOL>_SCHEMA` via `serde_json::from_str` and pulls in
+# `APR_<TOOL>_DESCRIPTION` via `.to_string()`. FALSIFY-MCP-008 asserts
+# byte-identity (after JSON canonicalization for the schema, raw-string
+# compare for the description) between the YAML, the codegen constants,
+# and the live `tools/list` response; enforced at 4 layers by
+# `tests/falsify_mcp_008.rs` (see the Gate-surface coverage note at end of
+# file for the full list).
+#
+# Direction: THIS YAML IS AUTHORITATIVE. Rust tool sources contain no
+# hand-written schemas OR descriptions — they only consume the codegen
+# constants. To change a schema or description: edit this file and rebuild.
+#
+# Scope (M3-complete, 2026-04-18): all 9 registered tools (`apr.version` +
+# 8 Phase-1 wrappers) migrated to full codegen for both `inputSchema` and
+# `description`. Related PRs: #880 (apr.version first), #881 (apr.finetune
+# + batch codegen), #884 (remaining 7 tools).
+# ─────────────────────────────────────────────────────────────────────────────
+
+metadata:
+  version: 1.1.0
+  created: '2026-04-18'
+  last_modified: '2026-04-18'
+  author: PAIML Engineering
+  registry: true
+  description: >
+    Per-tool MCP `inputSchema` and `description` source of truth for the
+    aprender-mcp server. Drives `crates/aprender-mcp/build.rs` codegen of
+    `APR_<TOOL>_SCHEMA` and `APR_<TOOL>_DESCRIPTION` constants; byte-identity
+    between codegen output and `tools/list` is asserted by FALSIFY-MCP-008
+    at 4 layers (crates/aprender-mcp/tests/falsify_mcp_008.rs). Authoritative
+    as of M3 (2026-04-18, PMAT-514) — Rust tool sources consume codegen
+    constants and contain no hand-written schemas or descriptions.
+  references:
+    - 'Model Context Protocol Specification v2024-11-05 (Anthropic)'
+    - 'JSON-RPC 2.0 Specification (ECMA-404)'
+    - 'crates/aprender-mcp/build.rs — reads this YAML, emits $OUT_DIR/schemas.rs (APR_<TOOL>_SCHEMA + APR_<TOOL>_DESCRIPTION)'
+    - 'crates/aprender-mcp/src/tools/*.rs — consume codegen constants from schemas.rs'
+    - 'crates/aprender-mcp/src/types.rs — InputSchema / PropertySchema shape'
+    - 'contracts/apr-cli-commands-v1.yaml — sibling command registry (no args)'
+    - 'contracts/aprender/mcp-tool-schema-v1.yaml — MCP session/error contract'
+    - 'docs/specifications/apr-mcp-server-spec.md — FALSIFY-MCP-008 gate'
+  depends_on:
+    - apr-cli-commands-v1
+    - mcp-tool-schema-v1
+
+kind: McpToolSchemaContract
+name: apr-mcp-tool-schemas
+version: "1.1.0"
+status: ENFORCED   # promoted in M3: build.rs + falsify_mcp_008.rs both landed 2026-04-18
+scope: "every tool returned by the aprender-mcp server's tools/list response"
+protocol_version: '2024-11-05'
+spec: docs/specifications/apr-mcp-server-spec.md
+
+# ── Tool registry ──
+# Each entry encodes: MCP tool name, human description, the `apr`
+# subcommand it wraps (null for server-synthesized tools), and the full
+# `inputSchema.properties` + `inputSchema.required` contents. The M3
+# build.rs codegen walks this list and emits, per tool, a
+# `schemas::APR_<TOOL>_SCHEMA` constant (serialized JSON Schema) and a
+# `schemas::APR_<TOOL>_DESCRIPTION` constant (raw description string) —
+# this YAML is the single source of truth for both fields.
+
+tools:
+  - name: apr.version
+    shipped_in: 'PR #864 (M1)'
+    source: crates/aprender-mcp/src/tools/version.rs
+    description: "Return the aprender-mcp server version. Takes no arguments."
+    cli_mapping: null   # server-synthesized; no subprocess
+    args: []
+    required: []
+
+  - name: apr.validate
+    shipped_in: 'PR #865 (M2 slice 1)'
+    source: crates/aprender-mcp/src/tools/validate.rs
+    description: "Validate a model file's integrity and quality. Wraps `apr validate <model> --json`."
+    cli_mapping: "apr validate <model_path> --json"
+    args:
+      - name: model_path
+        type: string
+        required: true
+        description: "Path to the model file (.apr, .gguf, or .safetensors)"
+    required:
+      - model_path
+
+  - name: apr.tensors
+    shipped_in: 'PR #866 (M2 slice 2)'
+    source: crates/aprender-mcp/src/tools/tensors.rs
+    description: "List tensors in a model with shapes and dtypes. Wraps `apr tensors <model> --json`."
+    cli_mapping: "apr tensors <model_path> --json [--stats] [--filter <pat>]"
+    args:
+      - name: model_path
+        type: string
+        required: true
+        description: "Path to the model file (.apr, .gguf, or .safetensors)"
+      - name: stats
+        type: boolean
+        required: false
+        description: "Include tensor statistics (mean, std, min, max)"
+      - name: filter
+        type: string
+        required: false
+        description: "Filter tensors by name pattern (substring match)"
+    required:
+      - model_path
+
+  - name: apr.bench
+    shipped_in: 'PR #866 (M2 slice 3)'
+    source: crates/aprender-mcp/src/tools/bench.rs
+    description: "Benchmark model throughput and latency. Wraps `apr bench <model> --json`."
+    cli_mapping: "apr bench <model_path> --json [--iterations N] [--max-tokens N] [--prompt X]"
+    args:
+      - name: model_path
+        type: string
+        required: true
+        description: "Path to the model file (.apr, .gguf, or .safetensors)"
+      - name: iterations
+        type: integer
+        required: false
+        description: "Measurement iterations (default 5)"
+      - name: max_tokens
+        type: integer
+        required: false
+        description: "Max tokens to generate per iteration (default 32)"
+      - name: prompt
+        type: string
+        required: false
+        description: "Test prompt (default: model-specific)"
+    required:
+      - model_path
+
+  - name: apr.qa
+    shipped_in: 'PR #867 (M2 slice 4)'
+    source: crates/aprender-mcp/src/tools/qa.rs
+    description: "Run the 8-gate falsifiable QA checklist on a model. Wraps `apr qa <model> --json`."
+    cli_mapping: "apr qa <model_path> --json [--assert-tps N] [--max-tokens N] [--iterations N]"
+    args:
+      - name: model_path
+        type: string
+        required: true
+        description: "Path to the model file (.apr, .gguf, or .safetensors)"
+      - name: assert_tps
+        type: number
+        required: false
+        description: "Minimum throughput threshold in tok/s — gate fails below this"
+      - name: max_tokens
+        type: integer
+        required: false
+        description: "Maximum tokens to generate per iteration (default 32)"
+      - name: iterations
+        type: integer
+        required: false
+        description: "Benchmark iterations (default 10)"
+    required:
+      - model_path
+
+  - name: apr.trace
+    shipped_in: 'PR #867 (M2 slice 5)'
+    source: crates/aprender-mcp/src/tools/trace.rs
+    description: "Layer-by-layer tensor trace with per-layer stats. Wraps `apr trace <model> --json`."
+    cli_mapping: "apr trace <model_path> --json [--layer <pat>] [--reference <path>]"
+    args:
+      - name: model_path
+        type: string
+        required: true
+        description: "Path to the model file (.apr, .gguf, or .safetensors)"
+      - name: layer
+        type: string
+        required: false
+        description: "Filter layers by name pattern (substring match)"
+      - name: reference
+        type: string
+        required: false
+        description: "Reference model to diff against (path)"
+    required:
+      - model_path
+
+  - name: apr.run
+    shipped_in: 'PR #870 (M2 slice 6)'
+    source: crates/aprender-mcp/src/tools/run.rs
+    description: "Run synchronous inference on a model. Wraps `apr run <model> --json` and returns generated text, tokens, tok/s, and timing. Cancellable via `notifications/cancelled`."
+    cli_mapping: "apr run <model_path> --json [--prompt X] [--max-tokens N] [--temperature T] [--top-p P]"
+    args:
+      - name: model_path
+        type: string
+        required: true
+        description: "Path to the model file (.apr, .gguf, or .safetensors) or hf://org/repo"
+      - name: prompt
+        type: string
+        required: false
+        description: "Text prompt to generate from"
+      - name: max_tokens
+        type: integer
+        required: false
+        description: "Maximum tokens to generate (default 32)"
+      - name: temperature
+        type: number
+        required: false
+        description: "Sampling temperature (0.0 = greedy argmax, >0 = stochastic)"
+      - name: top_p
+        type: number
+        required: false
+        description: "Top-p nucleus sampling threshold (omit to disable)"
+    required:
+      - model_path
+
+  - name: apr.serve
+    shipped_in: 'PR #872 (M2 slice 7)'
+    source: crates/aprender-mcp/src/tools/serve.rs
+    description: "Start an `apr serve` inference daemon in the background. Returns {pid, url}; kill the pid via OS to stop. Cancel-token lifecycle (SIGTERM) is a post-M3 follow-up; apr.run already honours notifications/cancelled."
+    cli_mapping: "apr serve <model_path> --port <port>"
+    args:
+      - name: model_path
+        type: string
+        required: true
+        description: "Path to the model file (.apr, .gguf, or .safetensors) or hf://org/repo"
+      - name: port
+        type: integer
+        required: false
+        description: "TCP port to bind the HTTP server on (default 8080)"
+    required:
+      - model_path
+
+  - name: apr.finetune
+    shipped_in: 'PR #881 (M3 slice 1: synchronous) + PR #887 (M3 slice 2: opt-in progress)'
+    source: crates/aprender-mcp/src/tools/finetune.rs
+    description: "Fine-tune a base model with LoRA/QLoRA. Wraps `apr finetune <base_model> --json` and blocks until training completes. Supply `params._meta.progressToken` in the `tools/call` request to opt into per-line `notifications/progress` events streamed before the final response (FALSIFY-MCP-PROGRESS-001)."
+    cli_mapping: "apr finetune <base_model> --json [--data <path>] [--rank <N>] [--epochs <N>] [--method <m>] [--output <path>]"
+    args:
+      - name: base_model
+        type: string
+        required: true
+        description: "Path to the base model file (.apr, .gguf, or .safetensors) or hf://org/repo"
+      - name: dataset
+        type: string
+        required: false
+        description: "Path to training data (JSONL). Mapped to `apr finetune --data <path>`."
+      - name: lora_rank
+        type: integer
+        required: false
+        description: "LoRA rank. Mapped to `apr finetune --rank <N>`. Omit for auto."
+      - name: epochs
+        type: integer
+        required: false
+        description: "Training epochs (default 3)"
+      - name: method
+        type: string
+        required: false
+        description: "Fine-tuning method: auto, full, lora, qlora (default auto)"
+      - name: output
+        type: string
+        required: false
+        description: "Output path (adapter directory or merged model)"
+    required:
+      - base_model
+
+# ── Falsification gates ──
+# FALSIFY-MCP-008 is the flagship gate this contract unblocks. It landed in M3
+# (2026-04-18) alongside `build.rs` + `tests/falsify_mcp_008.rs` and is now
+# ENFORCED. The other gates listed are existing MCP gates this contract
+# interacts with — they are not owned by this file.
+
+falsification:
+  FALSIFY-MCP-008:
+    status: ENFORCED
+    owned_by: apr-mcp-tool-schemas-v1
+    condition: |
+      For every entry `t` in the aprender-mcp server's `tools/list` response,
+      both the emitted `inputSchema` **and** the tool-level `description`
+      are byte-identical, after JSON canonicalization (RFC 8785 JCS or
+      equivalent: keys sorted, no trailing whitespace, UTF-8, no
+      insignificant whitespace), to the corresponding fields derived from
+      `contracts/apr-mcp-tool-schemas-v1.yaml`. Both fields flow through
+      the build-time code generator at `crates/aprender-mcp/build.rs`:
+      `inputSchema` is emitted as `schemas::APR_<TOOL>_SCHEMA` (a
+      serialized JSON Schema) and `description` as
+      `schemas::APR_<TOOL>_DESCRIPTION` (PMAT-514 extension, 2026-04-18).
+      Tool source files consume these constants directly; neither field
+      can be hand-coded in Rust source.
+    assertions:
+      - "tools/list returns exactly the tool names listed in `tools[].name`"
+      - "each tool's `description` matches `tools[*].description` byte-for-byte"
+      - "each tool's `inputSchema.type` is the literal string 'object'"
+      - "each tool's `inputSchema.properties.<arg>.type` matches `tools[*].args[*].type`"
+      - "each tool's `inputSchema.properties.<arg>.description` matches `tools[*].args[*].description` byte-for-byte"
+      - "each tool's `inputSchema.required` equals `tools[*].required` as a sorted set"
+    test_harness: "crates/aprender-mcp/tests/falsify_mcp_008.rs (landed in M3, PR #881; extended 2026-04-18 with `tool_descriptions_match_yaml_contract` for the live wiring and `codegen_description_constants_match_yaml` for the codegen constants — PMAT-514)"
+    codegen_consumer: "crates/aprender-mcp/build.rs (landed in M3, PR #881; extended 2026-04-18 to emit `APR_<TOOL>_DESCRIPTION` constants alongside `APR_<TOOL>_SCHEMA` — PMAT-514)"
+
+  related_gates:
+    FALSIFY-MCP-002:
+      owned_by: apr-mcp-server-v1
+      note: "Already ENFORCED — asserts every tool has a valid object-typed schema. FALSIFY-MCP-008 strengthens this from 'valid' to 'byte-identical to this contract'."
+    FALSIFY-CLI-002:
+      owned_by: apr-cli-commands-v1
+      note: "Asserts every `apr --help` command is registered. This contract extends that invariant into MCP tool-space for the subset wrapped as MCP tools."
+
+# ── Coverage note ──
+# 9 entries registered: `apr.version` (M1 scaffold) + the 8 Phase-1 workflow
+# tools (`apr.validate`, `apr.tensors`, `apr.bench`, `apr.qa`, `apr.trace`,
+# `apr.run`, `apr.serve`, `apr.finetune`). `apr.run` (PR #870), `apr.serve`
+# (PR #872), and `apr.finetune` (PR #881) were appended as they shipped. The
+# FALSIFY-MCP-008 harness (M3, `tests/falsify_mcp_008.rs`) iterates over
+# `tools[*].name` from this file — not a hard-coded list — so the gate
+# automatically tightens as new entries are appended.
+#
+# Gate surface (2026-04-18, PMAT-514 extension) — four independent tests
+# in `tests/falsify_mcp_008.rs`:
+#   * Live layer:
+#     - `migrated_tools_match_yaml_contract_byte_for_byte` (inputSchema)
+#     - `tool_descriptions_match_yaml_contract`            (description)
+#   * Codegen layer (compile-time source of truth):
+#     - `codegen_constants_parse_and_match_yaml_for_every_tool`
+#     - `codegen_description_constants_match_yaml`
+# Plus guardrails: `codegen_constants_cover_every_tool_name` and
+# `codegen_descriptions_cover_every_tool_name` catch a new tool added to
+# YAML but missing from the test-side codegen-constant tables.
+# All six assertions in the `falsification.FALSIFY-MCP-008.assertions`
+# block above are now load-bearing at both layers.

--- a/crates/aprender-mcp/tests/falsify_mcp_008.rs
+++ b/crates/aprender-mcp/tests/falsify_mcp_008.rs
@@ -87,10 +87,51 @@ const CODEGEN_DESCRIPTIONS: &[(&str, &str)] = &[
 
 fn contract_path() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("contracts")
+        .join("apr-mcp-tool-schemas-v1.yaml")
+}
+
+/// Workspace-root copy of the contract. Exists in-tree (monorepo) but NOT in
+/// the published tarball. Used only by the drift-guard test.
+fn workspace_contract_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("..")
         .join("..")
         .join("contracts")
         .join("apr-mcp-tool-schemas-v1.yaml")
+}
+
+/// Drift guard: the in-crate copy (what build.rs + published tarball read)
+/// must stay byte-identical to the workspace-root copy (what `pv` and other
+/// workspace-level tooling reads). Silent divergence was the failure mode
+/// that sank v0.31.1 — catch it at CI, not at `cargo install` time.
+///
+/// Skips gracefully when the workspace-root file is absent (e.g., the test is
+/// executing against an unpacked tarball or a sparse checkout).
+#[test]
+fn contract_copy_matches_workspace_root() {
+    let local = contract_path();
+    let root = workspace_contract_path();
+    if !root.exists() {
+        eprintln!(
+            "SKIP: workspace-root contract not present at {} (published-tarball mode)",
+            root.display()
+        );
+        return;
+    }
+    let local_bytes =
+        std::fs::read(&local).unwrap_or_else(|e| panic!("read local {}: {e}", local.display()));
+    let root_bytes = std::fs::read(&root)
+        .unwrap_or_else(|e| panic!("read workspace-root {}: {e}", root.display()));
+    assert_eq!(
+        local_bytes,
+        root_bytes,
+        "drift between in-crate {} and workspace-root {}: \
+         these must stay byte-identical — re-run `cp contracts/apr-mcp-tool-schemas-v1.yaml \
+         crates/aprender-mcp/contracts/` after any contract edit",
+        local.display(),
+        root.display()
+    );
 }
 
 /// Parse the YAML contract and return the `tools` list as a `serde_yaml::Value`.

--- a/scripts/check_build_rs_paths.sh
+++ b/scripts/check_build_rs_paths.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# check_build_rs_paths.sh — Poka-Yoke: flag build.rs files that PANIC when
+# a path outside the crate root is absent. Those break `cargo install`.
+#
+# Root cause this guards against (v0.31.1 release blocker):
+#   crates/aprender-mcp/build.rs resolved `CARGO_MANIFEST_DIR/../../contracts/…`
+#   and called `.unwrap_or_else(|e| panic!(...))` when the file was missing.
+#   That file lives in the monorepo tree but NOT in the published tarball
+#   (outside the package root). `cargo install aprender@0.31.1` panicked at
+#   build time for every external user. v0.31.1 was yanked.
+#
+# Acceptable patterns (NOT flagged):
+#   1. build.rs has `ALLOW_ESCAPE: <reason>` comment
+#   2. build.rs has `.exists()` + `return`/`Ok(())` graceful fallback
+#      (crates/aprender-core/build.rs does this for provable-contracts/)
+#   3. Path join of `".."` is inside a `#[cfg(test)]` block
+#
+# Failure pattern (FLAGGED):
+#   - build.rs joins `".."` AND calls `panic!`/`unwrap_or_else(|…| panic!)`
+#     AND has no `.exists()` guard before the read.
+#
+# Complementary gate: check_package_verify.sh runs `cargo package` per crate
+# which actually unpacks the tarball and compiles — the dynamic equivalent.
+#
+# Usage: bash scripts/check_build_rs_paths.sh
+# Exit 0 clean, exit 1 on any finding.
+
+set -uo pipefail
+
+errors=0
+checked=0
+suspects=0
+
+echo "Build.rs path safety gate (static)..."
+
+while IFS= read -r build_rs; do
+    checked=$((checked + 1))
+
+    # Skip if no `..` path escape at all.
+    if ! grep -qE '"\.\."' "$build_rs"; then
+        continue
+    fi
+    suspects=$((suspects + 1))
+
+    # Acceptable: explicit allow-escape annotation.
+    if grep -q 'ALLOW_ESCAPE' "$build_rs"; then
+        continue
+    fi
+    # Acceptable: graceful fallback — checks `.exists()` before reading.
+    # Pattern covers both `if path.exists()` and `if !path.exists() { return; }`.
+    if grep -qE '\.exists\(\)' "$build_rs"; then
+        continue
+    fi
+
+    # Hard-coded absolute paths are always wrong.
+    if grep -qE '"/(home|tmp|usr|var|opt|mnt|root)/' "$build_rs"; then
+        echo "  FAIL: $build_rs — hard-coded absolute path (portability bug)"
+        errors=$((errors + 1))
+        continue
+    fi
+
+    # Suspect: has `..` join AND panics on read failure, no .exists() guard.
+    if grep -qE 'panic!|unwrap_or_else\(\|.*\|\s*panic' "$build_rs"; then
+        echo "  FAIL: $build_rs"
+        echo "    joins \"..\" onto CARGO_MANIFEST_DIR AND panics on missing file;"
+        echo "    this class broke \`cargo install\` in v0.31.1 (aprender-mcp)."
+        echo "    Fix: either"
+        echo "      (a) copy the file inside the crate + update build.rs path, OR"
+        echo "      (b) add a \`.exists()\` guard with graceful fallback, OR"
+        echo "      (c) annotate with '// ALLOW_ESCAPE: <reason>' if only used in dev."
+        errors=$((errors + 1))
+    fi
+done < <(git ls-files '**/build.rs' 'build.rs')
+
+echo ""
+if [ "$errors" -eq 0 ]; then
+    echo "OK: $checked build.rs files checked ($suspects with \`..\` joins all have graceful fallbacks)."
+    exit 0
+else
+    echo "FAIL: $errors/$suspects suspect build.rs files WILL break \`cargo install\`."
+    echo ""
+    echo "v0.31.1 was yanked for exactly this class of bug. Do not ship without fixing."
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Fixes the v0.31.1 yank — `cargo install aprender@0.31.1` panicked at build
time because aprender-mcp's build.rs read
`CARGO_MANIFEST_DIR/../../contracts/apr-mcp-tool-schemas-v1.yaml`,
which lives in the monorepo tree but NOT in the published tarball.

**Three-layer defense so this class can't recur:**
1. In-crate YAML copy + \`include = [\"contracts/*.yaml\"]\` in Cargo.toml + drift-guard test asserting byte-identity with the workspace-root copy.
2. New \`scripts/check_build_rs_paths.sh\` — static Poka-Yoke that flags any build.rs joining \`\"..\"\` + \`panic!\` without an \`.exists()\` guard or \`ALLOW_ESCAPE\` annotation.
3. Wired into both \`make tier3\` (pre-push) and \`.github/workflows/ci.yml\` (workspace-test job).

Yank already executed — all 68 crates confirmed yanked on crates.io.

Refs: task #64 (yank), #65 (fix), #66 (prevention)

## Test plan
- [x] \`bash scripts/check_build_rs_paths.sh\` → OK: 22 build.rs checked
- [x] \`cargo test -p aprender-mcp --test falsify_mcp_008 contract_copy_matches_workspace_root\` passes
- [x] \`cargo fmt --all --check\` clean
- [x] \`cargo clippy -p aprender-mcp --all-targets -- -D warnings\` clean
- [x] Reverting aprender-mcp/build.rs to the broken version → gate exits 1 with remediation message (verified locally)
- [ ] CI green (\`ci / gate\` + \`workspace-test\`)

## After this lands
Cut v0.31.2, re-publish all 68 crates (paced at 40s/crate ≈ 45min), verify \`cargo install aprender --version 0.31.2\` installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)