### PR TITLE
chore(release): v0.31.2 — re-publish with aprender-mcp build.rs fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,11 +284,11 @@ dependencies = [
 
 [[package]]
 name = "apr-cli"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "alimentar",
  "anyhow",
- "aprender-core 0.31.1",
+ "aprender-core 0.31.2",
  "aprender-mcp",
  "aprender-present-core",
  "aprender-present-terminal",
@@ -454,36 +454,36 @@ dependencies = [
 
 [[package]]
 name = "aprender"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "apr-cli",
- "aprender-core 0.31.1",
+ "aprender-core 0.31.2",
 ]
 
 [[package]]
 name = "aprender-bench-compute"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
- "aprender-core 0.31.1",
+ "aprender-core 0.31.2",
  "criterion 0.7.0",
  "ndarray 0.16.1",
 ]
 
 [[package]]
 name = "aprender-bench-tokenizer"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
- "aprender-core 0.31.1",
+ "aprender-core 0.31.2",
  "criterion 0.7.0",
  "tokenizers",
 ]
 
 [[package]]
 name = "aprender-cbtop"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "anyhow",
- "aprender-compute 0.31.1",
+ "aprender-compute 0.31.2",
  "aprender-gpu",
  "batuta-common",
  "chrono",
@@ -505,7 +505,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cgp"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "anyhow",
  "aprender-gpu",
@@ -525,7 +525,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-common"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "lz4_flex 0.11.6",
  "zstd",
@@ -553,14 +553,14 @@ dependencies = [
 
 [[package]]
 name = "aprender-compute"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "anyhow",
- "aprender-core 0.31.1",
+ "aprender-core 0.31.2",
  "aprender-cuda-edge",
- "aprender-gemm-codegen 0.31.1",
+ "aprender-gemm-codegen 0.31.2",
  "aprender-gpu",
- "aprender-quant 0.31.1",
+ "aprender-quant 0.31.2",
  "aprender-solve",
  "aprender-sparse",
  "bytemuck",
@@ -602,7 +602,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-compute-xtask"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "anyhow",
  "bashrs",
@@ -615,7 +615,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-contracts"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "aprender-contracts-macros",
  "criterion 0.5.1",
@@ -630,7 +630,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-contracts-cli"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "aprender-contracts",
  "clap",
@@ -641,7 +641,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-contracts-macros"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -675,7 +675,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-core"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "aes-gcm",
  "alimentar",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cuda-edge"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "aprender-gpu",
  "proptest",
@@ -737,7 +737,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cupti"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "bindgen 0.71.1",
  "bitflags 2.11.0",
@@ -747,7 +747,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-data"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-db"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "anyhow",
  "arrow 57.3.0",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-distribute"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "arrow 57.3.0",
  "bincode",
@@ -875,7 +875,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-explain"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "aprender-gpu",
  "clap",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-fft"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-gemm-codegen"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -922,7 +922,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-gpu"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "batuta-common",
  "bytemuck",
@@ -945,10 +945,10 @@ dependencies = [
 
 [[package]]
 name = "aprender-graph"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "anyhow",
- "aprender-core 0.31.1",
+ "aprender-core 0.31.2",
  "arrow 57.3.0",
  "bytemuck",
  "criterion 0.6.0",
@@ -967,7 +967,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-image"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -976,7 +976,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-mcp"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -990,9 +990,9 @@ dependencies = [
 
 [[package]]
 name = "aprender-monte-carlo"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
- "aprender 0.31.1",
+ "aprender 0.31.2",
  "assert_cmd",
  "chrono",
  "clap",
@@ -1009,11 +1009,11 @@ dependencies = [
 
 [[package]]
 name = "aprender-orchestrate"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "alimentar",
  "anyhow",
- "aprender-core 0.31.1",
+ "aprender-core 0.31.2",
  "assert_cmd",
  "async-stream",
  "async-trait",
@@ -1082,7 +1082,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-cli"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "aprender-present-yaml",
  "clap",
@@ -1095,9 +1095,9 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-core"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
- "aprender-compute 0.31.1",
+ "aprender-compute 0.31.2",
  "criterion 0.7.0",
  "proptest",
  "provable-contracts-macros 0.3.1",
@@ -1108,7 +1108,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-layout"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "aprender-present-core",
  "criterion 0.7.0",
@@ -1119,7 +1119,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-lib"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "aprender-present-core",
  "aprender-present-layout",
@@ -1148,7 +1148,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-terminal"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "aprender-present-core",
  "bitvec",
@@ -1170,7 +1170,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-test"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "aprender-present-core",
  "aprender-present-test-macros",
@@ -1181,7 +1181,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-test-macros"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1190,7 +1190,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-widgets"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "aprender-present-core",
  "aprender-present-yaml",
@@ -1202,7 +1202,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-yaml"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "aprender-present-core",
  "proptest",
@@ -1256,11 +1256,11 @@ dependencies = [
 
 [[package]]
 name = "aprender-profile"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "addr2line 0.25.1",
  "anyhow",
- "aprender-core 0.31.1",
+ "aprender-core 0.31.2",
  "arbitrary",
  "assert_cmd",
  "backtrace",
@@ -1309,7 +1309,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-profile-core"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "hex",
  "serde",
@@ -1319,7 +1319,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-ptx-debug"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "proptest",
  "thiserror 2.0.18",
@@ -1327,7 +1327,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-certify"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "chrono",
  "proptest",
@@ -1337,7 +1337,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-cli"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "aprender-qa-certify",
  "aprender-qa-gen",
@@ -1356,7 +1356,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-gen"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1373,7 +1373,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-report"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "anyhow",
  "aprender-qa-gen",
@@ -1391,7 +1391,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-runner"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "anyhow",
  "aprender-qa-gen",
@@ -1425,14 +1425,14 @@ dependencies = [
 
 [[package]]
 name = "aprender-quant"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "half",
 ]
 
 [[package]]
 name = "aprender-rag"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "async-trait",
  "batuta-common",
@@ -1461,7 +1461,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-rand"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1470,11 +1470,11 @@ dependencies = [
 
 [[package]]
 name = "aprender-registry"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "alimentar",
  "anyhow",
- "aprender-core 0.31.1",
+ "aprender-core 0.31.2",
  "argon2",
  "blake3",
  "chacha20poly1305",
@@ -1500,12 +1500,12 @@ dependencies = [
 
 [[package]]
 name = "aprender-serve"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "alimentar",
  "anyhow",
  "approx",
- "aprender-core 0.31.1",
+ "aprender-core 0.31.2",
  "arc-swap",
  "arrow 57.3.0",
  "assert_cmd",
@@ -1567,9 +1567,9 @@ dependencies = [
 
 [[package]]
 name = "aprender-shell"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
- "aprender-core 0.31.1",
+ "aprender-core 0.31.2",
  "assert_cmd",
  "clap",
  "criterion 0.7.0",
@@ -1584,7 +1584,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-simulate"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "bincode",
  "bitflags 2.11.0",
@@ -1623,7 +1623,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-solve"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1632,7 +1632,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-sparse"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1641,7 +1641,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-tensor"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1650,7 +1650,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-cli"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "aprender-test-lib",
  "assert_cmd",
@@ -1678,7 +1678,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-derive"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1688,7 +1688,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-js-gen"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "blake3",
  "chrono",
@@ -1704,9 +1704,9 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-lib"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
- "aprender-compute 0.31.1",
+ "aprender-compute 0.31.2",
  "aprender-present-core",
  "aprender-present-terminal",
  "async-trait",
@@ -1748,7 +1748,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-showcase"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "aprender-present-terminal",
  "console_error_panic_hook",
@@ -1765,11 +1765,11 @@ dependencies = [
 
 [[package]]
 name = "aprender-train"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "alimentar",
  "approx",
- "aprender-core 0.31.1",
+ "aprender-core 0.31.2",
  "arrow 57.3.0",
  "axum 0.8.8",
  "bytemuck",
@@ -1832,7 +1832,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-bench"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1849,7 +1849,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-common"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "clap",
  "proptest",
@@ -1861,7 +1861,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-distill"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1882,7 +1882,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-inspect"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1898,7 +1898,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-lora"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1914,7 +1914,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-shell"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1930,7 +1930,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-wasm"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "proptest",
  "serde",
@@ -1941,9 +1941,9 @@ dependencies = [
 
 [[package]]
 name = "aprender-tsp"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
- "aprender 0.31.1",
+ "aprender 0.31.2",
  "assert_cmd",
  "clap",
  "crc32fast",
@@ -1956,7 +1956,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-verify"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "chrono",
  "criterion 0.5.1",
@@ -1968,9 +1968,9 @@ dependencies = [
 
 [[package]]
 name = "aprender-verify-ml"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
- "aprender-core 0.31.1",
+ "aprender-core 0.31.2",
  "arrow 57.3.0",
  "clap",
  "criterion 0.7.0",
@@ -2012,10 +2012,10 @@ dependencies = [
 
 [[package]]
 name = "aprender-viz"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "approx",
- "aprender-core 0.31.1",
+ "aprender-core 0.31.2",
  "base64 0.22.1",
  "batuta-common",
  "criterion 0.6.0",
@@ -2047,7 +2047,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "aprender-zram-adaptive",
  "aprender-zram-core",
@@ -2057,7 +2057,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-adaptive"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "aprender-zram-core",
  "proptest",
@@ -2066,7 +2066,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-cli"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "aprender-zram-adaptive",
  "aprender-zram-core",
@@ -2080,7 +2080,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-core"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "aprender-gpu",
  "criterion 0.7.0",
@@ -2092,7 +2092,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-generator"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "aprender-zram-core",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.31.1"
+version = "0.31.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/paiml/aprender"
@@ -171,7 +171,7 @@ minijinja = { version = "2.14", features = ["loader", "serde"] }
 # Contracts
 provable-contracts = "0.3"
 provable-contracts-macros = "0.3"
-aprender-contracts-macros = { path = "crates/aprender-contracts-macros", version = "0.31.1" }
+aprender-contracts-macros = { path = "crates/aprender-contracts-macros", version = "0.31.2" }
 
 # YAML
 serde_yaml = "0.9"
@@ -183,30 +183,30 @@ hf-hub = { version = "0.4", default-features = false, features = ["ureq"] }
 hf-xet = "1.5.1"
 
 # Workspace-internal crates (paths within the monorepo)
-aprender-compute = { path = "crates/aprender-compute", version = "0.31.1" }
-aprender-gpu = { path = "crates/aprender-gpu", version = "0.31.1" }
-aprender-quant = { path = "crates/aprender-quant", version = "0.31.1" }
-aprender-serve = { path = "crates/aprender-serve", version = "0.31.1" }
-realizar = { path = "crates/aprender-serve", version = "0.31.1", package = "aprender-serve" }
-aprender-train = { path = "crates/aprender-train", version = "0.31.1" }
-entrenar = { path = "crates/aprender-train", version = "0.31.1", package = "aprender-train" }
-aprender-train-common = { path = "crates/aprender-train-common", version = "0.31.1" }
-aprender-orchestrate = { path = "crates/aprender-orchestrate", version = "0.31.1" }
-aprender-contracts = { path = "crates/aprender-contracts", version = "0.31.1" }
-aprender-profile = { path = "crates/aprender-profile", version = "0.31.1" }
-aprender-profile-core = { path = "crates/aprender-profile-core", version = "0.31.1" }
-aprender-zram-core = { path = "crates/aprender-zram-core", version = "0.31.1" }
-aprender-zram-adaptive = { path = "crates/aprender-zram-adaptive", version = "0.31.1" }
-aprender-present-core = { path = "crates/aprender-present-core", version = "0.31.1" }
-aprender-present-terminal = { path = "crates/aprender-present-terminal", version = "0.31.1" }
-aprender-present-widgets = { path = "crates/aprender-present-widgets", version = "0.31.1" }
-aprender-present-layout = { path = "crates/aprender-present-layout", version = "0.31.1" }
-aprender-present-yaml = { path = "crates/aprender-present-yaml", version = "0.31.1" }
-aprender-present-test = { path = "crates/aprender-present-test", version = "0.31.1" }
-aprender-db = { path = "crates/aprender-db", version = "0.31.1" }
-aprender-graph = { path = "crates/aprender-graph", version = "0.31.1" }
-aprender-rag = { path = "crates/aprender-rag", version = "0.31.1" }
-aprender-data = { path = "crates/aprender-data", version = "0.31.1" }
+aprender-compute = { path = "crates/aprender-compute", version = "0.31.2" }
+aprender-gpu = { path = "crates/aprender-gpu", version = "0.31.2" }
+aprender-quant = { path = "crates/aprender-quant", version = "0.31.2" }
+aprender-serve = { path = "crates/aprender-serve", version = "0.31.2" }
+realizar = { path = "crates/aprender-serve", version = "0.31.2", package = "aprender-serve" }
+aprender-train = { path = "crates/aprender-train", version = "0.31.2" }
+entrenar = { path = "crates/aprender-train", version = "0.31.2", package = "aprender-train" }
+aprender-train-common = { path = "crates/aprender-train-common", version = "0.31.2" }
+aprender-orchestrate = { path = "crates/aprender-orchestrate", version = "0.31.2" }
+aprender-contracts = { path = "crates/aprender-contracts", version = "0.31.2" }
+aprender-profile = { path = "crates/aprender-profile", version = "0.31.2" }
+aprender-profile-core = { path = "crates/aprender-profile-core", version = "0.31.2" }
+aprender-zram-core = { path = "crates/aprender-zram-core", version = "0.31.2" }
+aprender-zram-adaptive = { path = "crates/aprender-zram-adaptive", version = "0.31.2" }
+aprender-present-core = { path = "crates/aprender-present-core", version = "0.31.2" }
+aprender-present-terminal = { path = "crates/aprender-present-terminal", version = "0.31.2" }
+aprender-present-widgets = { path = "crates/aprender-present-widgets", version = "0.31.2" }
+aprender-present-layout = { path = "crates/aprender-present-layout", version = "0.31.2" }
+aprender-present-yaml = { path = "crates/aprender-present-yaml", version = "0.31.2" }
+aprender-present-test = { path = "crates/aprender-present-test", version = "0.31.2" }
+aprender-db = { path = "crates/aprender-db", version = "0.31.2" }
+aprender-graph = { path = "crates/aprender-graph", version = "0.31.2" }
+aprender-rag = { path = "crates/aprender-rag", version = "0.31.2" }
+aprender-data = { path = "crates/aprender-data", version = "0.31.2" }
 
 # Additional external deps needed by sub-crates
 serde_yaml_ng = "0.10"
@@ -251,18 +251,18 @@ wasmtime = "43"
 bollard = "0.17"
 
 # Old crate name aliases (workspace = true refs in migrated sub-crates)
-trueno-zram-core = { path = "crates/aprender-zram-core", version = "0.31.1", package = "aprender-zram-core" }
-trueno-zram-adaptive = { path = "crates/aprender-zram-adaptive", version = "0.31.1", package = "aprender-zram-adaptive" }
-trueno = { path = "crates/aprender-compute", version = "0.31.1", package = "aprender-compute" }
-presentar-core = { path = "crates/aprender-present-core", version = "0.31.1", package = "aprender-present-core" }
-presentar-terminal = { path = "crates/aprender-present-terminal", version = "0.31.1", package = "aprender-present-terminal" }
-presentar-widgets = { path = "crates/aprender-present-widgets", version = "0.31.1", package = "aprender-present-widgets" }
-presentar-layout = { path = "crates/aprender-present-layout", version = "0.31.1", package = "aprender-present-layout" }
-presentar-yaml = { path = "crates/aprender-present-yaml", version = "0.31.1", package = "aprender-present-yaml" }
-presentar-test = { path = "crates/aprender-present-test", version = "0.31.1", package = "aprender-present-test" }
-presentar-test-macros = { path = "crates/aprender-present-test-macros", version = "0.31.1", package = "aprender-present-test-macros" }
-jugar-probar-derive = { path = "crates/aprender-test-derive", version = "0.31.1", package = "aprender-test-derive" }
-batuta-common = { path = "crates/aprender-common", version = "0.31.1", package = "aprender-common" }
+trueno-zram-core = { path = "crates/aprender-zram-core", version = "0.31.2", package = "aprender-zram-core" }
+trueno-zram-adaptive = { path = "crates/aprender-zram-adaptive", version = "0.31.2", package = "aprender-zram-adaptive" }
+trueno = { path = "crates/aprender-compute", version = "0.31.2", package = "aprender-compute" }
+presentar-core = { path = "crates/aprender-present-core", version = "0.31.2", package = "aprender-present-core" }
+presentar-terminal = { path = "crates/aprender-present-terminal", version = "0.31.2", package = "aprender-present-terminal" }
+presentar-widgets = { path = "crates/aprender-present-widgets", version = "0.31.2", package = "aprender-present-widgets" }
+presentar-layout = { path = "crates/aprender-present-layout", version = "0.31.2", package = "aprender-present-layout" }
+presentar-yaml = { path = "crates/aprender-present-yaml", version = "0.31.2", package = "aprender-present-yaml" }
+presentar-test = { path = "crates/aprender-present-test", version = "0.31.2", package = "aprender-present-test" }
+presentar-test-macros = { path = "crates/aprender-present-test-macros", version = "0.31.2", package = "aprender-present-test-macros" }
+jugar-probar-derive = { path = "crates/aprender-test-derive", version = "0.31.2", package = "aprender-test-derive" }
+batuta-common = { path = "crates/aprender-common", version = "0.31.2", package = "aprender-common" }
 
 [workspace.lints.rust]
 # Safety
@@ -391,7 +391,7 @@ semicolon_if_nothing_returned = "allow"  # Style preference
 
 [package]
 name = "aprender"
-version = "0.31.1"
+version = "0.31.2"
 edition = "2021"
 rust-version = "1.89"
 authors = ["Noah Gift <noah@paiml.com>"]
@@ -416,7 +416,7 @@ name = "apr"
 path = "src/bin/apr.rs"
 
 [dependencies]
-apr-cli = { path = "crates/apr-cli", version = "0.31.1", default-features = true }
+apr-cli = { path = "crates/apr-cli", version = "0.31.2", default-features = true }
 # Core ML library (lib name = "aprender")
 aprender_ml = { path = "crates/aprender-core", version = ">=0.29", package = "aprender-core" }
 

--- a/crates/apr-cli/Cargo.toml
+++ b/crates/apr-cli/Cargo.toml
@@ -99,10 +99,10 @@ libc = "0.2"
 
 [dependencies]
 # Core aprender library
-aprender = { path = "../aprender-core", version = "0.31.1", package = "aprender-core", default-features = true, features = ["format-compression"] }
+aprender = { path = "../aprender-core", version = "0.31.2", package = "aprender-core", default-features = true, features = ["format-compression"] }
 
 # MCP (Model Context Protocol) server — `apr mcp` subcommand
-aprender-mcp = { path = "../aprender-mcp", version = "0.31.1" }
+aprender-mcp = { path = "../aprender-mcp", version = "0.31.2" }
 async-stream = "0.3"
 provable-contracts-macros = "0.3"
 

--- a/crates/aprender-bench-compute/Cargo.toml
+++ b/crates/aprender-bench-compute/Cargo.toml
@@ -11,7 +11,7 @@ disallowed_methods = "allow"
 
 [dependencies]
 # The implementation under test
-aprender = { path = "../aprender-core", version = "0.31.1", package = "aprender-core", features = ["format-quantize"] }
+aprender = { path = "../aprender-core", version = "0.31.2", package = "aprender-core", features = ["format-quantize"] }
 
 # Reference implementation for A/B comparison
 # Pure Rust (no BLAS) to keep comparison fair — both are pure Rust SIMD

--- a/crates/aprender-bench-tokenizer/Cargo.toml
+++ b/crates/aprender-bench-tokenizer/Cargo.toml
@@ -11,7 +11,7 @@ disallowed_methods = "allow"
 
 [dependencies]
 # The implementation under test
-aprender = { path = "../aprender-core", version = "0.31.1", package = "aprender-core" }
+aprender = { path = "../aprender-core", version = "0.31.2", package = "aprender-core" }
 
 # HuggingFace reference for A/B comparison
 # Regular dep (not dev-dep) because [[bench]] harness=false binaries can't see dev-deps

--- a/crates/aprender-cbtop/Cargo.toml
+++ b/crates/aprender-cbtop/Cargo.toml
@@ -23,8 +23,8 @@ presentar-core = "0.3"
 presentar-terminal = "0.3"
 
 # Compute backends
-trueno = { version = "0.31.1", path = "../aprender-compute", package = "aprender-compute" }
-trueno-gpu = { version = "0.31.1", path = "../aprender-gpu", package = "aprender-gpu", optional = true }
+trueno = { version = "0.31.2", path = "../aprender-compute", package = "aprender-compute" }
+trueno-gpu = { version = "0.31.2", path = "../aprender-gpu", package = "aprender-gpu", optional = true }
 
 # Terminal handling
 crossterm = "0.28"

--- a/crates/aprender-cgp/Cargo.toml
+++ b/crates/aprender-cgp/Cargo.toml
@@ -36,7 +36,7 @@ num_cpus = "1.17"
 comfy-table = "7"
 colored = "3"
 # GPU profiling: direct cuBLAS measurement (OWN THE STACK)
-trueno-gpu = { path = "../aprender-gpu", version = "0.31.1", features = ["cuda"], optional = true, package = "aprender-gpu" }
+trueno-gpu = { path = "../aprender-gpu", version = "0.31.2", features = ["cuda"], optional = true, package = "aprender-gpu" }
 
 [features]
 default = []

--- a/crates/aprender-compute/Cargo.toml
+++ b/crates/aprender-compute/Cargo.toml
@@ -38,11 +38,11 @@ futures-intrusive = { version = "0.5", optional = true }
 wasm-bindgen-futures = { version = "0.4", optional = true }
 wasm-bindgen = { version = "0.2", optional = true }
 # Native CUDA monitoring via trueno-gpu (TRUENO-SPEC-010)
-trueno-gpu = { version = "0.31.1", path = "../aprender-gpu", optional = true, package = "aprender-gpu" }
+trueno-gpu = { version = "0.31.2", path = "../aprender-gpu", optional = true, package = "aprender-gpu" }
 # PMAT-336: Provable contracts compile-time enforcement
 provable-contracts-macros = "0.3"
 # P1a: Sovereign GEMM microkernel codegen (compile-time shape specialization)
-trueno-gemm-codegen = { version = "0.31.1", path = "../aprender-gemm-codegen", package = "aprender-gemm-codegen" }
+trueno-gemm-codegen = { version = "0.31.2", path = "../aprender-gemm-codegen", package = "aprender-gemm-codegen" }
 # Tracing/profiling support (renacer integration)
 tracing = { version = "0.1", optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"], optional = true }
@@ -54,7 +54,7 @@ presentar-core = { version = "0.3", optional = true }
 # Stress test reporting types compatible with renacer (TRUENO-SPEC-025)
 # Note: renacer 0.9.1 has compilation issue; using compatible local types instead
 dhat = { version = "0.3", optional = true }
-trueno-quant = { version = "0.31.1", path = "../aprender-quant", package = "aprender-quant" }
+trueno-quant = { version = "0.31.2", path = "../aprender-quant", package = "aprender-quant" }
 num_cpus = "1.17.0"
 anyhow = "1.0.100"
 # Hardware capability detection (PMAT-447)
@@ -62,7 +62,7 @@ chrono = "0.4"
 toml = "0.8"
 # ML tuner integration (SHOWCASE-BRICK-001, Section 12)
 # Uses aprender 0.24.0 RandomForest for learned optimization
-aprender = { path = "../aprender-core", version = "0.31.1", package = "aprender-core", optional = true, default-features = false }
+aprender = { path = "../aprender-core", version = "0.31.2", package = "aprender-core", optional = true, default-features = false }
 # Execution path graph (PAR-201, Section E.7)
 trueno-graph = { version = "0.1.17", optional = true }
 # TUI visualization for execution graphs (PAR-201)
@@ -90,10 +90,10 @@ nalgebra = "0.34"  # For eigendecomposition benchmark comparison
 simular = "0.2.0"
 regex = "1.11"  # For PTX/WGSL pattern validation in falsification tests
 # GPU edge-case test framework (TCE-001)
-trueno-cuda-edge = { version = "0.31.1", path = "../aprender-cuda-edge", package = "aprender-cuda-edge" }
+trueno-cuda-edge = { version = "0.31.2", path = "../aprender-cuda-edge", package = "aprender-cuda-edge" }
 # Sparse and solver crates for contract tests
-trueno-sparse = { version = "0.31.1", path = "../aprender-sparse", package = "aprender-sparse" }
-trueno-solve = { version = "0.31.1", path = "../aprender-solve", package = "aprender-solve" }
+trueno-sparse = { version = "0.31.2", path = "../aprender-sparse", package = "aprender-sparse" }
+trueno-solve = { version = "0.31.2", path = "../aprender-solve", package = "aprender-solve" }
 ndarray = "0.17.2"
 faer = "0.24"  # For GEMM benchmark comparison (fastest pure-Rust BLAS)
 matrixmultiply = "0.3"  # Direct matrixmultiply crate benchmark (engine behind ndarray)

--- a/crates/aprender-contracts-cli/Cargo.toml
+++ b/crates/aprender-contracts-cli/Cargo.toml
@@ -13,7 +13,7 @@ name = "pv"
 path = "src/main.rs"
 
 [dependencies]
-aprender-contracts = { path = "../aprender-contracts", version = "0.31.1" }
+aprender-contracts = { path = "../aprender-contracts", version = "0.31.2" }
 clap = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }

--- a/crates/aprender-contracts/Cargo.toml
+++ b/crates/aprender-contracts/Cargo.toml
@@ -19,7 +19,7 @@ kani = []
 name = "provable_contracts"
 
 [dependencies]
-provable-contracts-macros = { path = "../aprender-contracts-macros", version = "0.31.1", package = "aprender-contracts-macros" }
+provable-contracts-macros = { path = "../aprender-contracts-macros", version = "0.31.2", package = "aprender-contracts-macros" }
 regex = "1"
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/aprender-cuda-edge/Cargo.toml
+++ b/crates/aprender-cuda-edge/Cargo.toml
@@ -15,7 +15,7 @@ name = "trueno_cuda_edge"
 [dependencies]
 thiserror = "2.0"
 serde = { version = "1.0", features = ["derive"] }
-trueno-gpu = { version = "0.31.1", path = "../aprender-gpu", package = "aprender-gpu", optional = true }
+trueno-gpu = { version = "0.31.2", path = "../aprender-gpu", package = "aprender-gpu", optional = true }
 
 [dev-dependencies]
 proptest = "1.6"

--- a/crates/aprender-explain/Cargo.toml
+++ b/crates/aprender-explain/Cargo.toml
@@ -25,7 +25,7 @@ presentar-terminal = "0.3"
 crossterm = "0.28"
 
 # Internal dependency for PTX generation
-trueno-gpu = { version = "0.31.1", path = "../aprender-gpu", package = "aprender-gpu", features = ["cuda"] }
+trueno-gpu = { version = "0.31.2", path = "../aprender-gpu", package = "aprender-gpu", features = ["cuda"] }
 
 [dev-dependencies]
 proptest = "1.4"

--- a/crates/aprender-graph/Cargo.toml
+++ b/crates/aprender-graph/Cargo.toml
@@ -28,7 +28,7 @@ anyhow = "1"
 thiserror = "2"
 
 # Phase 2+ dependencies
-aprender = { path = "../aprender-core", version = "0.31.1", package = "aprender-core" }                                        # Sparse matrix ops, PageRank
+aprender = { path = "../aprender-core", version = "0.31.2", package = "aprender-core" }                                        # Sparse matrix ops, PageRank
 trueno = "0.17"                                          # SIMD primitives
 trueno-db = "0.3.17"                                     # Columnar storage
 

--- a/crates/aprender-monte-carlo/Cargo.toml
+++ b/crates/aprender-monte-carlo/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 name = "aprender-monte-carlo"
 
 [dependencies]
-aprender = { path = "../../", version = "0.31.1" }
+aprender = { path = "../../", version = "0.31.2" }
 clap = { version = "4", features = ["derive"] }
 rand = "0.9"
 rand_chacha = "0.9"

--- a/crates/aprender-orchestrate/Cargo.toml
+++ b/crates/aprender-orchestrate/Cargo.toml
@@ -113,7 +113,7 @@ pacha = { version = "0.2", optional = true }
 realizar = { version = "0.8", optional = true, features = ["cuda"] }
 
 # ML algorithms and training (native-only)
-aprender = { path = "../aprender-core", version = "0.31.1", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.31.2", package = "aprender-core", optional = true }
 entrenar = { version = "0.7", optional = true }
 alimentar = { version = "0.2", optional = true }
 

--- a/crates/aprender-profile/Cargo.toml
+++ b/crates/aprender-profile/Cargo.toml
@@ -74,7 +74,7 @@ trueno = { version = "0.17" }
 
 # Machine learning for anomaly detection (Sprint 23)
 # GH-581: Use path dep to avoid trueno version skew with local workspace
-aprender = { path = "../aprender-core", version = "0.31.1", package = "aprender-core" }
+aprender = { path = "../aprender-core", version = "0.31.2", package = "aprender-core" }
 
 # Lock-free data structures for ring buffer (Sprint 40)
 crossbeam = { version = "0.8", default-features = false, features = ["crossbeam-channel", "crossbeam-queue", "std"] }

--- a/crates/aprender-registry/Cargo.toml
+++ b/crates/aprender-registry/Cargo.toml
@@ -42,7 +42,7 @@ zstd = { version = "0.13", optional = true }
 clap = { version = "4", features = ["derive"], optional = true }
 
 # Ecosystem integration
-aprender = { path = "../aprender-core", version = "0.31.1", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.31.2", package = "aprender-core", optional = true }
 alimentar = { version = "0.2.3", optional = true }
 
 # HTTP client (optional)

--- a/crates/aprender-serve/Cargo.toml
+++ b/crates/aprender-serve/Cargo.toml
@@ -53,7 +53,7 @@ renacer-core = { version = "0.1" }
 
 # ML algorithms and .apr model format (optional for aprender model serving)
 # v0.24.1: chat templates, GGUF tokenizer preservation (local may be newer)
-aprender = { path = "../aprender-core", version = "0.31.1", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.31.2", package = "aprender-core", optional = true }
 
 # Data loading library (optional for data pipeline examples)
 alimentar = { version = "0.2", optional = true, default-features = false, features = ["local", "shuffle"] }

--- a/crates/aprender-shell/Cargo.toml
+++ b/crates/aprender-shell/Cargo.toml
@@ -24,7 +24,7 @@ harness = false
 
 [dependencies]
 # Use path for local dev, crates.io for release
-aprender = { path = "../aprender-core", version = "0.31.1", package = "aprender-core", features = ["format-encryption", "format-compression", "format-homomorphic"] }
+aprender = { path = "../aprender-core", version = "0.31.2", package = "aprender-core", features = ["format-encryption", "format-compression", "format-homomorphic"] }
 clap = { version = "4", features = ["derive"] }
 dirs = "5"
 serde = { version = "1", features = ["derive"] }

--- a/crates/aprender-test-cli/Cargo.toml
+++ b/crates/aprender-test-cli/Cargo.toml
@@ -24,7 +24,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Core library (was: jugar-probar) — dep key preserves Rust identifier
-jugar-probar = { path = "../aprender-test-lib", version = "0.31.1", package = "aprender-test-lib" }
+jugar-probar = { path = "../aprender-test-lib", version = "0.31.2", package = "aprender-test-lib" }
 
 # CLI framework
 clap = { workspace = true }

--- a/crates/aprender-train-bench/Cargo.toml
+++ b/crates/aprender-train-bench/Cargo.toml
@@ -19,8 +19,8 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-entrenar = { version = "0.31.1", path = "../aprender-train", package = "aprender-train" }
-entrenar-common = { version = "0.31.1", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar = { version = "0.31.2", path = "../aprender-train", package = "aprender-train" }
+entrenar-common = { version = "0.31.2", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/aprender-train-distill/Cargo.toml
+++ b/crates/aprender-train-distill/Cargo.toml
@@ -23,8 +23,8 @@ default = []
 hub = ["entrenar/hub"]
 
 [dependencies]
-entrenar = { version = "0.31.1", path = "../aprender-train", package = "aprender-train" }
-entrenar-common = { version = "0.31.1", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar = { version = "0.31.2", path = "../aprender-train", package = "aprender-train" }
+entrenar-common = { version = "0.31.2", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/aprender-train-inspect/Cargo.toml
+++ b/crates/aprender-train-inspect/Cargo.toml
@@ -19,8 +19,8 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-entrenar = { version = "0.31.1", path = "../aprender-train", package = "aprender-train" }
-entrenar-common = { version = "0.31.1", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar = { version = "0.31.2", path = "../aprender-train", package = "aprender-train" }
+entrenar-common = { version = "0.31.2", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/aprender-train-lora/Cargo.toml
+++ b/crates/aprender-train-lora/Cargo.toml
@@ -19,8 +19,8 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-entrenar = { version = "0.31.1", path = "../aprender-train", package = "aprender-train" }
-entrenar-common = { version = "0.31.1", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar = { version = "0.31.2", path = "../aprender-train", package = "aprender-train" }
+entrenar-common = { version = "0.31.2", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/aprender-train-shell/Cargo.toml
+++ b/crates/aprender-train-shell/Cargo.toml
@@ -19,8 +19,8 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-entrenar = { version = "0.31.1", path = "../aprender-train", package = "aprender-train" }
-entrenar-common = { version = "0.31.1", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar = { version = "0.31.2", path = "../aprender-train", package = "aprender-train" }
+entrenar-common = { version = "0.31.2", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 rustyline = "14"
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/aprender-train/Cargo.toml
+++ b/crates/aprender-train/Cargo.toml
@@ -77,7 +77,7 @@ ndarray = "0.16"
 trueno = { version = "0.17", features = ["parallel"] }  # SIMD-accelerated compute
 trueno-gpu = { version = "0.4", optional = true }  # CUDA compute
 realizar = { version = "0.8", optional = true }  # CUDA inference engine
-aprender = { path = "../aprender-core", version = "0.31.1", package = "aprender-core" }  # ML interpret module + .apr format + tokenizers
+aprender = { path = "../aprender-core", version = "0.31.2", package = "aprender-core" }  # ML interpret module + .apr format + tokenizers
 trueno-viz = { version = "0.2", features = ["terminal"] }  # Terminal visualization
 presentar-terminal = { version = "0.3.5", optional = true }  # Sovereign TUI framework (gated by "tui" feature)
 presentar-core = "0.3.4"  # Presentar core traits (crates.io — path removed, presentar restructured)

--- a/crates/aprender-tsp/Cargo.toml
+++ b/crates/aprender-tsp/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 name = "aprender-tsp"
 
 [dependencies]
-aprender = { path = "../../", version = "0.31.1" }
+aprender = { path = "../../", version = "0.31.2" }
 clap = { version = "4", features = ["derive"] }
 rand = "0.9"
 crc32fast = "1.4"

--- a/crates/aprender-verify-ml/Cargo.toml
+++ b/crates/aprender-verify-ml/Cargo.toml
@@ -50,7 +50,7 @@ uuid = { version = "1.11", features = ["v4", "serde"] }
 trueno = "0.7.3"
 
 # Machine learning for bug prediction (optional)
-aprender = { path = "../aprender-core", version = "0.31.1", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.31.2", package = "aprender-core", optional = true }
 
 # LLM fine-tuning integration (optional)
 entrenar = { version = "0.2", optional = true }

--- a/crates/aprender-viz/Cargo.toml
+++ b/crates/aprender-viz/Cargo.toml
@@ -29,7 +29,7 @@ base64 = "0.22"
 thiserror = "2.0"
 
 # Optional: ML integration
-aprender = { path = "../aprender-core", version = "0.31.1", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.31.2", package = "aprender-core", optional = true }
 
 # Optional: Graph integration
 trueno-graph = { version = "0.1.17", optional = true, default-features = false }


### PR DESCRIPTION
## Summary

v0.31.1 was yanked from crates.io because aprender-mcp/build.rs panicked
on an out-of-crate path (`../../contracts/…`) at \`cargo install\` time.
PR #910 landed the fix + Poka-Yoke; this PR cuts v0.31.2 so the published
tarballs reflect it.

**Verified locally:**
- \`cargo package -p aprender-mcp\` now runs unpack+compile verify cleanly on v0.31.2 (same command failed on v0.31.1 with the documented panic).
- \`bash scripts/check_build_rs_paths.sh\` → OK: 22 build.rs checked.
- 71 Cargo.toml files bumped 0.31.1 → 0.31.2; 0 stale pins remain.
- Cargo.lock regenerated via \`cargo update --workspace\`.

## Test plan
- [x] Workspace grep: 0 files contain \`\"0.31.1\"\`
- [x] \`cargo package -p aprender-mcp\` verify step passes
- [x] \`cargo fmt --all --check\` clean
- [ ] CI green (\`ci / gate\` + \`workspace-test\`)

## After merge
1. Tag \`v0.31.2\` at the merge commit and create GitHub Release.
2. Re-publish all 68 crates via the dep-ordered script at 40s/crate pacing (~45min, crates.io 30-per-10min window).
3. Wait ~2min for crates.io edge cache.
4. \`cargo install aprender --version 0.31.2 --force\` — must succeed.
5. Run \`/dogfood\` skill and require GO verdict (task #68).

Refs: task #67, feedback_post_publish_qa_required.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)