### PR TITLE
feat(crux-a-01): aliases.yaml + FALSIFY-CRUX-A-01-002 tests (1 of 5 gates)

### DIFF
--- a/configs/aliases.yaml
+++ b/configs/aliases.yaml
@@ -1,0 +1,23 @@
+# CRUX-A-01 — Pull-model short-name alias map.
+# Parity target: `ollama pull <short>` resolves canonical short names via
+# https://ollama.com/library. aprender parity: `apr pull <short>` resolves
+# via this file, shipped as a release asset and read at startup.
+#
+# Schema: str → str
+#   key:   canonical short name, no scheme prefix
+#   value: fully-qualified URL (hf:// or https://)
+#
+# Invariants (enforced by CRUX-A-01 v1.1.0 FALSIFY-002):
+# - {"llama3", "mistral", "phi3", "qwen2"} ⊆ keys(map)
+# - each value matches regex ^(hf|https)://
+# - resolution is deterministic across invocations
+
+llama2: hf://meta-llama/Llama-2-7b-chat-hf
+llama3: hf://meta-llama/Meta-Llama-3-8B-Instruct
+mistral: hf://mistralai/Mistral-7B-Instruct-v0.3
+phi3: hf://microsoft/Phi-3-mini-4k-instruct
+qwen2: hf://Qwen/Qwen2-7B-Instruct
+qwen2.5: hf://Qwen/Qwen2.5-7B-Instruct
+qwen2.5-coder: hf://Qwen/Qwen2.5-Coder-7B-Instruct
+gemma: hf://google/gemma-7b-it
+gemma2: hf://google/gemma-2-9b-it

--- a/crates/apr-cli/tests/falsification_crux_a_01.rs
+++ b/crates/apr-cli/tests/falsification_crux_a_01.rs
@@ -1,0 +1,74 @@
+//! Falsification tests for CRUX-A-01 — Pull model by short name.
+//!
+//! Contract: contracts/crux-A-01-v1.yaml
+//! This test closes FALSIFY-CRUX-A-01-002: `configs/aliases.yaml` ships with
+//! the repo, parses as YAML mapping str→str, and contains the four canonical
+//! short names required by the CRUX-A-01 invariants:
+//!   {"llama3", "mistral", "phi3", "qwen2"} ⊆ keys(map)
+//!
+//! Other FALSIFY-CRUX-A-01-{001, 003, 004, 005} gates still need the
+//! `apr pull --dry-run` + `apr registry aliases --json` surface and are
+//! tracked by the M1 epic (GitHub #918).
+
+#![allow(clippy::unwrap_used)]
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+fn repo_root() -> PathBuf {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    manifest
+        .ancestors()
+        .nth(2)
+        .expect("CARGO_MANIFEST_DIR has repo root 2 ancestors up")
+        .to_path_buf()
+}
+
+fn load_aliases() -> BTreeMap<String, String> {
+    let path = repo_root().join("configs").join("aliases.yaml");
+    let text = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("FALSIFY-CRUX-A-01-002: cannot read {path:?}: {e}"));
+    serde_yaml::from_str::<BTreeMap<String, String>>(&text)
+        .unwrap_or_else(|e| panic!("FALSIFY-CRUX-A-01-002: aliases.yaml not a str→str map: {e}"))
+}
+
+#[test]
+fn falsify_crux_a_01_002_aliases_yaml_present_and_parseable() {
+    let map = load_aliases();
+    assert!(
+        !map.is_empty(),
+        "FALSIFY-CRUX-A-01-002: aliases.yaml parsed empty"
+    );
+}
+
+#[test]
+fn falsify_crux_a_01_002_canonical_short_names_present() {
+    let map = load_aliases();
+    for canonical in ["llama3", "mistral", "phi3", "qwen2"] {
+        assert!(
+            map.contains_key(canonical),
+            "FALSIFY-CRUX-A-01-002: canonical short name '{canonical}' missing from aliases.yaml"
+        );
+    }
+}
+
+#[test]
+fn falsify_crux_a_01_002_every_value_has_known_scheme() {
+    let map = load_aliases();
+    for (name, url) in &map {
+        assert!(
+            url.starts_with("hf://") || url.starts_with("https://"),
+            "FALSIFY-CRUX-A-01-002: alias '{name}' → '{url}' does not start with hf:// or https://"
+        );
+    }
+}
+
+#[test]
+fn falsify_crux_a_01_002_resolution_deterministic() {
+    let a = load_aliases();
+    let b = load_aliases();
+    assert_eq!(
+        a, b,
+        "FALSIFY-CRUX-A-01-002: two reads of aliases.yaml must yield byte-identical maps"
+    );
+}


### PR DESCRIPTION
## Summary

First concrete implementation landing on the CRUX competitive-research-UX spec (250/250 contracts). Closes **FALSIFY-CRUX-A-01-002** (1 of 5 gates) for **CRUX-A-01** (\"pull model by short name\" — `apr pull <short>` parity with `ollama pull`).

- `configs/aliases.yaml` — 9 canonical short names (llama2/3, mistral, phi3, qwen2, qwen2.5, qwen2.5-coder, gemma, gemma2) → `hf://` URLs
- `crates/apr-cli/tests/falsification_crux_a_01.rs` — 4 Rust tests asserting the invariants documented in the YAML header

## Scope honesty

This PR closes **1 of 5** FALSIFY gates on CRUX-A-01. The remaining 4 remain open:

- FALSIFY-CRUX-A-01-001: `apr pull --dry-run <short>` emits the resolved URL
- FALSIFY-CRUX-A-01-003: did-you-mean suggestions on typo (Levenshtein ≤ 2)
- FALSIFY-CRUX-A-01-004: `apr registry aliases --json` subcommand
- FALSIFY-CRUX-A-01-005: invocation determinism

All four are tracked under M1 epic #918. CRUX-A-01 contract status stays `partial` until all 5 discharge.

## Invariants enforced

From the aliases.yaml header (enforced by the new tests):

- `{\"llama3\", \"mistral\", \"phi3\", \"qwen2\"} ⊆ keys(map)`
- every value matches regex `^(hf|https)://`
- resolution is deterministic across invocations

## Test plan

- [x] `cargo test -p apr-cli --test falsification_crux_a_01` → 4/4 pass locally
- [x] `pv validate contracts/crux-A-01-v1.yaml` → clean
- [x] `cargo fmt -p apr-cli -- --check` → clean
- [x] `cargo clippy -p apr-cli --test falsification_crux_a_01` → clean
- [ ] CI `ci/gate` + `workspace-test` green

## Contract

`contracts/crux-A-01-v1.yaml` (unchanged in this PR — evidence/discharge update to follow after merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)