### PR TITLE
feat(crux-a-01): complete lane — dry-run + did-you-mean + registry + promotion (5/5 FALSIFY gates)

### DIFF
--- a/contracts/apr-cli-commands-v1.yaml
+++ b/contracts/apr-cli-commands-v1.yaml
@@ -21,7 +21,7 @@ metadata:
 kind: CLICommandContract
 name: apr-cli-commands
 version: "1.0.0"
-scope: "all apr CLI subcommands (58 commands — original 57 + `mcp` added 2026-04-17 via PR #864)"
+scope: "all apr CLI subcommands (59 commands — original 57 + `mcp` added 2026-04-17 via PR #864 + `registry` added 2026-04-20 via CRUX-A-01)"
 binary: "apr"
 install: "cargo install aprender"
 
@@ -197,6 +197,12 @@ commands:
     description: "Remove model from cache"
     requires_model: false
     side_effects: [filesystem]
+
+  - name: registry
+    category: registry
+    description: "Registry operations (CRUX-A-01): inspect alias map, etc."
+    requires_model: false
+    side_effects: []
 
   - name: publish
     category: registry

--- a/contracts/crux-A-01-v1.yaml
+++ b/contracts/crux-A-01-v1.yaml
@@ -113,7 +113,6 @@ falsification_tests:
   rule: apr registry aliases lists all short names
   prediction: "apr registry aliases --json returns {name: url} map"
   test: |
-    # TODO: wire `apr registry aliases` subcommand
     OUT=$(apr registry aliases --json 2>&1) || { echo "FAIL: subcommand missing" >&2; exit 1; }
     echo "$OUT" | jq -e 'type == "object" and (keys | length > 0)' >/dev/null || {
       echo "FAIL: aliases --json output not a non-empty object" >&2

--- a/contracts/crux-A-01-v1.yaml
+++ b/contracts/crux-A-01-v1.yaml
@@ -1,22 +1,21 @@
 # CRUX-A-01 — Pull model by short name
-# Auto-scaffolded from crux-competitive-research-ux-v1.yaml (DRAFT).
-# DO NOT promote to ACTIVE until: (1) evidence collected, (2) falsification
-# body reflects competitor's canonical CLI, (3) apr surface mapped or gap
-# tracked in pmat work (see master §12).
+# Promoted to ACTIVE 2026-04-20 after all 5 FALSIFY gates discharge via
+# Rust integration tests in crates/apr-cli/tests/falsification_crux_a_01.rs.
 
 metadata:
   id: CRUX-A-01
-  version: "1.0.0-draft"
+  version: "1.1.0"
   created: "2026-04-18"
+  updated: "2026-04-20"
   author: PAIML Engineering
   registry: true
-  status: draft
+  status: active
   parent_contracts:
   - crux-competitive-research-ux-v1
   category: "A — Model Intake & Discovery"
   competitor: ollama
   demand_score: 5  # 1..5, critical priority in pmat work
-  intake_status: partial
+  intake_status: supported
   description: >
     Pull model by short name. Competitor `ollama pull llama3` resolves the
     short name through Ollama's library registry (https://ollama.com/library)
@@ -145,8 +144,29 @@ proof_obligations:
 verification_summary:
   total_obligations: 5
   proven: 0
-  tested: 0
-  status: spec-complete
+  tested: 5
+  status: supported
+  evidence:
+    rust_tests: crates/apr-cli/tests/falsification_crux_a_01.rs
+    unit_tests: crates/apr-cli/src/commands/aliases.rs
+    commands:
+    - apr pull <short> --dry-run
+    - apr registry aliases --json
+    coverage:
+    - falsify-001: falsify_crux_a_01_001_dry_run_emits_canonical_url_for_llama3
+    - falsify-001: falsify_crux_a_01_001_dry_run_resolution_is_deterministic
+    - falsify-001: falsify_crux_a_01_001_dry_run_every_canonical_name_resolves
+    - falsify-002: falsify_crux_a_01_002_aliases_yaml_present_and_parseable
+    - falsify-002: falsify_crux_a_01_002_canonical_short_names_present
+    - falsify-002: falsify_crux_a_01_002_every_value_has_known_scheme
+    - falsify-002: falsify_crux_a_01_002_resolution_deterministic
+    - falsify-003: falsify_crux_a_01_003_typo_exits_nonzero
+    - falsify-003: falsify_crux_a_01_003_typo_suggests_llama3
+    - falsify-003: falsify_crux_a_01_003_far_typo_has_no_suggestion
+    - falsify-004: falsify_crux_a_01_004_registry_aliases_json_is_object
+    - falsify-004: falsify_crux_a_01_004_registry_aliases_contains_canonical_names
+    - falsify-004: falsify_crux_a_01_004_registry_aliases_is_deterministic
+    - falsify-005: falsify_crux_a_01_005_cross_process_determinism
 
 pmat_work_tracking:
   # Managed by master contract §12. If intake_status == "missing", a ticket

--- a/contracts/crux-competitive-research-ux-v1.yaml
+++ b/contracts/crux-competitive-research-ux-v1.yaml
@@ -159,7 +159,7 @@ equations:
 # ─────────────────────────────────────────────────────────────
 stories:
   # Category A — Model Acquisition & Registry (25)
-  - { id: CRUX-A-01, title: "Pull model by short name",            competitor: ollama,      demand_score: 5, status: partial,   contract: crux-A-01-v1.yaml }
+  - { id: CRUX-A-01, title: "Pull model by short name",            competitor: ollama,      demand_score: 5, status: supported, contract: crux-A-01-v1.yaml }
   - { id: CRUX-A-02, title: "Pull HF repo by hf://org/name",       competitor: huggingface, demand_score: 5, status: supported, contract: crux-A-02-v1.yaml }
   - { id: CRUX-A-03, title: "Pin to revision/branch/SHA",          competitor: huggingface, demand_score: 4, status: partial,   contract: crux-A-03-v1.yaml }
   - { id: CRUX-A-04, title: "Include/exclude file globs",          competitor: huggingface, demand_score: 4, status: missing,   contract: crux-A-04-v1.yaml }
@@ -439,8 +439,8 @@ stories:
 # Coverage — intake v2.0.0 (verified by awk over §5 of subspec)
 # ─────────────────────────────────────────────────────────────
 coverage_intake:
-  supported: 38
-  partial:   72
+  supported: 39
+  partial:   71
   missing:   140
   unclear:    0
   total:    250

--- a/crates/apr-cli/src/commands/aliases.rs
+++ b/crates/apr-cli/src/commands/aliases.rs
@@ -37,6 +37,51 @@ pub fn alias_map() -> &'static BTreeMap<String, String> {
     aliases()
 }
 
+/// Levenshtein edit distance between two ASCII strings (iterative, O(|a|·|b|) time,
+/// O(min(|a|,|b|)) space).
+///
+/// Pure helper for FALSIFY-CRUX-A-01-003 (did-you-mean suggestions). No Unicode
+/// normalization is performed — alias keys are ASCII-only by contract.
+pub fn levenshtein(a: &str, b: &str) -> usize {
+    let (a, b) = (a.as_bytes(), b.as_bytes());
+    if a.is_empty() {
+        return b.len();
+    }
+    if b.is_empty() {
+        return a.len();
+    }
+    let mut prev: Vec<usize> = (0..=b.len()).collect();
+    let mut curr: Vec<usize> = vec![0; b.len() + 1];
+    for (i, &ca) in a.iter().enumerate() {
+        curr[0] = i + 1;
+        for (j, &cb) in b.iter().enumerate() {
+            let cost = usize::from(ca != cb);
+            curr[j + 1] = (prev[j + 1] + 1)
+                .min(curr[j] + 1)
+                .min(prev[j] + cost);
+        }
+        std::mem::swap(&mut prev, &mut curr);
+    }
+    prev[b.len()]
+}
+
+/// Return alias-map keys within `max_distance` Levenshtein edits of `query`,
+/// sorted ascending by distance (ties broken alphabetically). Used by
+/// `apr pull <typo> --dry-run` to emit "did you mean …" hints.
+///
+/// Closes FALSIFY-CRUX-A-01-003 suggestion logic.
+pub fn did_you_mean(query: &str, max_distance: usize) -> Vec<&'static str> {
+    let mut hits: Vec<(usize, &str)> = aliases()
+        .keys()
+        .filter_map(|k| {
+            let d = levenshtein(query, k);
+            (d <= max_distance).then_some((d, k.as_str()))
+        })
+        .collect();
+    hits.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(b.1)));
+    hits.into_iter().map(|(_, k)| k).collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -69,5 +114,51 @@ mod tests {
         let a = resolve_short_name("llama3");
         let b = resolve_short_name("llama3");
         assert_eq!(a, b, "CRUX-A-01: resolution must be deterministic");
+    }
+
+    #[test]
+    fn levenshtein_empty_strings() {
+        assert_eq!(levenshtein("", ""), 0);
+        assert_eq!(levenshtein("abc", ""), 3);
+        assert_eq!(levenshtein("", "xyz"), 3);
+    }
+
+    #[test]
+    fn levenshtein_identity_and_basic_edits() {
+        assert_eq!(levenshtein("llama3", "llama3"), 0);
+        assert_eq!(levenshtein("lama3", "llama3"), 1); // insertion
+        assert_eq!(levenshtein("llamma3", "llama3"), 1); // deletion
+        assert_eq!(levenshtein("llana3", "llama3"), 1); // substitution
+        assert_eq!(levenshtein("ab", "cd"), 2); // two substitutions
+        assert_eq!(levenshtein("lam3", "llama3"), 2); // two insertions
+    }
+
+    #[test]
+    fn did_you_mean_finds_llama3_for_typo() {
+        let suggestions = did_you_mean("lama3", 2);
+        assert!(
+            suggestions.contains(&"llama3"),
+            "CRUX-A-01 FALSIFY-003: 'lama3' must suggest 'llama3', got {suggestions:?}"
+        );
+    }
+
+    #[test]
+    fn did_you_mean_empty_when_too_far() {
+        let suggestions = did_you_mean("completely-unrelated-xyz", 2);
+        assert!(
+            suggestions.is_empty(),
+            "CRUX-A-01 FALSIFY-003: unrelated names must not produce suggestions, got {suggestions:?}"
+        );
+    }
+
+    #[test]
+    fn did_you_mean_ranks_closer_first() {
+        // "qwem2" is 1 edit from "qwen2" and 2 edits from "qwen2.5"
+        let suggestions = did_you_mean("qwem2", 2);
+        assert_eq!(
+            suggestions.first(),
+            Some(&"qwen2"),
+            "CRUX-A-01 FALSIFY-003: closest match must rank first, got {suggestions:?}"
+        );
     }
 }

--- a/crates/apr-cli/src/commands/aliases.rs
+++ b/crates/apr-cli/src/commands/aliases.rs
@@ -1,0 +1,73 @@
+//! Short-name alias resolution for `apr pull` (CRUX-A-01).
+//!
+//! Contract: `contracts/crux-A-01-v1.yaml` — closes FALSIFY-CRUX-A-01-001
+//! (`apr pull <short> --dry-run` emits the resolved canonical URL).
+//!
+//! The alias map is embedded at compile time via `include_str!` so the
+//! invariant "alias_map is loaded from configs/aliases.yaml" holds for every
+//! build artifact (source build, `cargo install aprender`, release tarball).
+
+use std::collections::BTreeMap;
+use std::sync::OnceLock;
+
+const ALIASES_YAML: &str = include_str!("../../../../configs/aliases.yaml");
+
+fn aliases() -> &'static BTreeMap<String, String> {
+    static MAP: OnceLock<BTreeMap<String, String>> = OnceLock::new();
+    MAP.get_or_init(|| {
+        serde_yaml::from_str::<BTreeMap<String, String>>(ALIASES_YAML)
+            .expect("CRUX-A-01: embedded configs/aliases.yaml must parse as str→str map")
+    })
+}
+
+/// Resolve a short name to its canonical URL.
+///
+/// - If `name` already contains a scheme (`://`) it is returned as-is.
+/// - Otherwise the embedded alias map is consulted; `None` is returned when
+///   the short name is unknown (caller handles did-you-mean).
+pub fn resolve_short_name(name: &str) -> Option<String> {
+    if name.contains("://") {
+        return Some(name.to_string());
+    }
+    aliases().get(name).cloned()
+}
+
+/// Borrow the full alias map (used by future `apr registry aliases --json`).
+pub fn alias_map() -> &'static BTreeMap<String, String> {
+    aliases()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_canonical_short_names() {
+        for canonical in ["llama3", "mistral", "phi3", "qwen2"] {
+            let url = resolve_short_name(canonical)
+                .unwrap_or_else(|| panic!("CRUX-A-01: {canonical} must resolve"));
+            assert!(
+                url.starts_with("hf://") || url.starts_with("https://"),
+                "CRUX-A-01: {canonical} → {url} must be fully-qualified"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_short_name_returns_none() {
+        assert!(resolve_short_name("not-a-real-model-xyz").is_none());
+    }
+
+    #[test]
+    fn scheme_qualified_input_passes_through() {
+        let input = "hf://org/repo/file.gguf";
+        assert_eq!(resolve_short_name(input).as_deref(), Some(input));
+    }
+
+    #[test]
+    fn resolution_is_deterministic() {
+        let a = resolve_short_name("llama3");
+        let b = resolve_short_name("llama3");
+        assert_eq!(a, b, "CRUX-A-01: resolution must be deterministic");
+    }
+}

--- a/crates/apr-cli/src/commands/mod.rs
+++ b/crates/apr-cli/src/commands/mod.rs
@@ -5,6 +5,7 @@
 //! - Jidoka: Stop on quality issues
 //! - Visualization: Make problems visible
 
+pub(crate) mod aliases;
 pub mod bench;
 pub mod canary;
 pub mod cbtop;

--- a/crates/apr-cli/src/commands/mod.rs
+++ b/crates/apr-cli/src/commands/mod.rs
@@ -61,6 +61,7 @@ pub(crate) mod qa;
 pub(crate) mod qa_capability;
 pub(crate) mod qualify;
 pub(crate) mod quantize;
+pub(crate) mod registry;
 pub(crate) mod rosetta;
 pub(crate) mod run;
 #[cfg(feature = "training")]

--- a/crates/apr-cli/src/commands/pull.rs
+++ b/crates/apr-cli/src/commands/pull.rs
@@ -48,10 +48,16 @@ pub struct FileChecksum {
     "apr-cli-operations-v1",
     equation = "mutating_output_contract"
 )]
-pub fn run(model_ref: &str, force: bool) -> Result<()> {
+pub fn run(model_ref: &str, force: bool, dry_run: bool) -> Result<()> {
     contract_pre_pull_cache_integrity!();
     println!("{}", "=== APR Pull ===".cyan().bold());
     println!();
+
+    // CRUX-A-01 FALSIFY-CRUX-A-01-001: --dry-run resolves short name to
+    // canonical URL and exits with zero network I/O.
+    if dry_run {
+        return run_dry_run(model_ref);
+    }
 
     // GH-213: Resolve HuggingFace URI — detect single vs sharded models
     let resolved = resolve_hf_model(model_ref)?;
@@ -524,6 +530,32 @@ fn write_shard_manifest(
         .map_err(|e| CliError::ValidationFailed(format!("Failed to serialize manifest: {e}")))?;
     std::fs::write(manifest_path, manifest_json)?;
     println!("  {} .apr-manifest.json (integrity checksums)", "✓".green());
+    Ok(())
+}
+
+/// CRUX-A-01 FALSIFY-CRUX-A-01-001: `--dry-run` resolver.
+///
+/// Emits the resolved canonical URL on stdout and returns `Ok(())` with zero
+/// network I/O. Short names are resolved via the embedded alias map
+/// (`configs/aliases.yaml`); scheme-qualified inputs (`hf://…`,
+/// `https://…`) and bare `org/repo` inputs echo as their canonical forms.
+fn run_dry_run(model_ref: &str) -> Result<()> {
+    use super::aliases;
+
+    let resolved = if let Some(url) = aliases::resolve_short_name(model_ref) {
+        url
+    } else if !model_ref.contains("://") && model_ref.contains('/') {
+        format!("hf://{model_ref}")
+    } else {
+        return Err(CliError::ValidationFailed(format!(
+            "CRUX-A-01: unknown short name '{model_ref}' and not a fully-qualified URI. \
+             Run `apr registry aliases --json` to list known short names."
+        )));
+    };
+
+    println!("Model:    {}", model_ref.cyan());
+    println!("Resolved: {}", resolved.green());
+    println!("Mode:     {} (no network I/O)", "dry-run".yellow());
     Ok(())
 }
 

--- a/crates/apr-cli/src/commands/pull.rs
+++ b/crates/apr-cli/src/commands/pull.rs
@@ -539,6 +539,9 @@ fn write_shard_manifest(
 /// network I/O. Short names are resolved via the embedded alias map
 /// (`configs/aliases.yaml`); scheme-qualified inputs (`hf://…`,
 /// `https://…`) and bare `org/repo` inputs echo as their canonical forms.
+///
+/// CRUX-A-01 FALSIFY-CRUX-A-01-003: unknown short names (no scheme, no `/`)
+/// return an error that includes a Levenshtein ≤ 2 "did you mean …" hint.
 fn run_dry_run(model_ref: &str) -> Result<()> {
     use super::aliases;
 
@@ -547,16 +550,36 @@ fn run_dry_run(model_ref: &str) -> Result<()> {
     } else if !model_ref.contains("://") && model_ref.contains('/') {
         format!("hf://{model_ref}")
     } else {
-        return Err(CliError::ValidationFailed(format!(
-            "CRUX-A-01: unknown short name '{model_ref}' and not a fully-qualified URI. \
-             Run `apr registry aliases --json` to list known short names."
-        )));
+        return Err(unknown_short_name_error(model_ref));
     };
 
     println!("Model:    {}", model_ref.cyan());
     println!("Resolved: {}", resolved.green());
     println!("Mode:     {} (no network I/O)", "dry-run".yellow());
     Ok(())
+}
+
+/// CRUX-A-01 FALSIFY-CRUX-A-01-003: build an error carrying a did-you-mean
+/// hint derived from Levenshtein ≤ 2 matches against the alias map.
+fn unknown_short_name_error(name: &str) -> CliError {
+    use super::aliases;
+
+    let suggestions = aliases::did_you_mean(name, 2);
+    let hint = if suggestions.is_empty() {
+        "Run `apr registry aliases --json` to list known short names.".to_string()
+    } else {
+        format!(
+            "did you mean {}? (run `apr registry aliases --json` for the full list)",
+            suggestions
+                .iter()
+                .map(|s| format!("`{s}`"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
+    };
+    CliError::ValidationFailed(format!(
+        "CRUX-A-01: unknown short name '{name}' and not a fully-qualified URI. {hint}"
+    ))
 }
 
 include!("pull_list.rs");

--- a/crates/apr-cli/src/commands/registry.rs
+++ b/crates/apr-cli/src/commands/registry.rs
@@ -1,0 +1,38 @@
+//! `apr registry` subcommand — operations over the local model registry.
+//!
+//! Contract: `contracts/crux-A-01-v1.yaml` — closes FALSIFY-CRUX-A-01-004
+//! (`apr registry aliases --json` emits the full str→str alias map).
+
+use crate::error::Result;
+use clap::Subcommand;
+
+#[derive(Subcommand, Clone, Debug)]
+pub enum RegistryCommands {
+    /// List short-name → canonical-URL aliases from configs/aliases.yaml.
+    Aliases {
+        /// Emit the alias map as a single JSON object on stdout.
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+pub fn run(command: RegistryCommands) -> Result<()> {
+    match command {
+        RegistryCommands::Aliases { json } => aliases(json),
+    }
+}
+
+fn aliases(json: bool) -> Result<()> {
+    use super::aliases;
+    let map = aliases::alias_map();
+    if json {
+        let value = serde_json::to_string(map)
+            .expect("CRUX-A-01 FALSIFY-004: BTreeMap<String, String> always serializes");
+        println!("{value}");
+    } else {
+        for (name, url) in map {
+            println!("{name}\t{url}");
+        }
+    }
+    Ok(())
+}

--- a/crates/apr-cli/src/commands_enum.rs
+++ b/crates/apr-cli/src/commands_enum.rs
@@ -366,6 +366,11 @@ pub enum Commands {
         #[arg(long)]
         dry_run: bool,
     },
+    /// Registry operations (CRUX-A-01): inspect alias map, etc.
+    Registry {
+        #[command(subcommand)]
+        command: crate::commands::registry::RegistryCommands,
+    },
     /// List cached models
     #[command(name = "list", alias = "ls")]
     List,

--- a/crates/apr-cli/src/commands_enum.rs
+++ b/crates/apr-cli/src/commands_enum.rs
@@ -361,6 +361,10 @@ pub enum Commands {
         /// Force re-download even if cached
         #[arg(long)]
         force: bool,
+        /// CRUX-A-01: resolve short name to canonical URL and exit without
+        /// performing any network I/O.
+        #[arg(long)]
+        dry_run: bool,
     },
     /// List cached models
     #[command(name = "list", alias = "ls")]

--- a/crates/apr-cli/src/dispatch.rs
+++ b/crates/apr-cli/src/dispatch.rs
@@ -604,7 +604,11 @@ fn dispatch_model_commands(cli: &Cli) -> Option<Result<(), CliError>> {
             stage.as_deref(),
             cli.json,
         ),
-        Commands::Pull { model_ref, force } => pull::run(model_ref, *force),
+        Commands::Pull {
+            model_ref,
+            force,
+            dry_run,
+        } => pull::run(model_ref, *force, *dry_run),
         Commands::List => pull::list(cli.json, cli.quiet),
         Commands::Rm { model_ref } => pull::remove(model_ref),
         Commands::Tui { file } => tui::run(file.clone()),

--- a/crates/apr-cli/src/dispatch.rs
+++ b/crates/apr-cli/src/dispatch.rs
@@ -609,6 +609,9 @@ fn dispatch_model_commands(cli: &Cli) -> Option<Result<(), CliError>> {
             force,
             dry_run,
         } => pull::run(model_ref, *force, *dry_run),
+        Commands::Registry { command } => {
+            crate::commands::registry::run(command.clone())
+        }
         Commands::List => pull::list(cli.json, cli.quiet),
         Commands::Rm { model_ref } => pull::remove(model_ref),
         Commands::Tui { file } => tui::run(file.clone()),

--- a/crates/apr-cli/src/lib_dispatch_coverage.rs
+++ b/crates/apr-cli/src/lib_dispatch_coverage.rs
@@ -33,6 +33,7 @@
         let cli = make_cli(Commands::Pull {
             model_ref: "nonexistent-model-that-does-not-exist-xyz123".to_string(),
             force: false,
+            dry_run: false,
         });
         let result = dispatch_model_commands(&cli);
         assert!(result.is_some(), "Pull should be handled by dispatch_model_commands");

--- a/crates/apr-cli/src/lib_extract_paths.rs
+++ b/crates/apr-cli/src/lib_extract_paths.rs
@@ -81,6 +81,7 @@
         let cmd = Commands::Pull {
             model_ref: "hf://org/repo".to_string(),
             force: false,
+            dry_run: false,
         };
         let paths = extract_model_paths(&cmd);
         assert!(paths.is_empty(), "Pull is a diagnostic command (exempt)");

--- a/crates/apr-cli/src/lib_parse_export.rs
+++ b/crates/apr-cli/src/lib_parse_export.rs
@@ -299,9 +299,14 @@
         let args = vec!["apr", "pull", "hf://Qwen/Qwen2.5-Coder-1.5B", "--force"];
         let cli = parse_cli(args).expect("Failed to parse");
         match *cli.command {
-            Commands::Pull { model_ref, force } => {
+            Commands::Pull {
+                model_ref,
+                force,
+                dry_run,
+            } => {
                 assert_eq!(model_ref, "hf://Qwen/Qwen2.5-Coder-1.5B");
                 assert!(force);
+                assert!(!dry_run);
             }
             _ => panic!("Expected Pull command"),
         }
@@ -313,9 +318,33 @@
         let args = vec!["apr", "pull", "qwen2.5-coder"];
         let cli = parse_cli(args).expect("Failed to parse");
         match *cli.command {
-            Commands::Pull { model_ref, force } => {
+            Commands::Pull {
+                model_ref,
+                force,
+                dry_run,
+            } => {
                 assert_eq!(model_ref, "qwen2.5-coder");
                 assert!(!force);
+                assert!(!dry_run);
+            }
+            _ => panic!("Expected Pull command"),
+        }
+    }
+
+    /// CRUX-A-01: `apr pull --dry-run` parses
+    #[test]
+    fn test_parse_pull_dry_run() {
+        let args = vec!["apr", "pull", "llama3", "--dry-run"];
+        let cli = parse_cli(args).expect("Failed to parse");
+        match *cli.command {
+            Commands::Pull {
+                model_ref,
+                force,
+                dry_run,
+            } => {
+                assert_eq!(model_ref, "llama3");
+                assert!(!force);
+                assert!(dry_run, "CRUX-A-01: --dry-run flag must parse");
             }
             _ => panic!("Expected Pull command"),
         }

--- a/crates/apr-cli/tests/cli_commands.rs
+++ b/crates/apr-cli/tests/cli_commands.rs
@@ -41,6 +41,7 @@ fn registered_commands() -> Vec<&'static str> {
         "pull",
         "list",
         "rm",
+        "registry",
         "publish",
         "finetune",
         "prune",

--- a/crates/apr-cli/tests/falsification_crux_a_01.rs
+++ b/crates/apr-cli/tests/falsification_crux_a_01.rs
@@ -9,10 +9,10 @@
 //!   {"llama3", "mistral", "phi3", "qwen2"} ⊆ keys(map).
 //! - FALSIFY-CRUX-A-01-003: unknown short name exits non-zero with a
 //!   "did you mean …" hint (Levenshtein ≤ 2 against alias-map keys).
-//!
-//! Remaining FALSIFY-CRUX-A-01-{004, 005} gates (`apr registry aliases
-//! --json`, invocation determinism across binary runs) are tracked by the
-//! M1 epic (GitHub #918).
+//! - FALSIFY-CRUX-A-01-004: `apr registry aliases --json` emits the full
+//!   alias map as a JSON object with every value carrying a known scheme.
+//! - FALSIFY-CRUX-A-01-005: three back-to-back process invocations of
+//!   `apr pull llama3 --dry-run` emit byte-identical canonical URLs.
 
 #![allow(clippy::unwrap_used)]
 
@@ -199,5 +199,101 @@ fn falsify_crux_a_01_003_far_typo_has_no_suggestion() {
     assert!(
         !combined.contains("did you mean"),
         "FALSIFY-CRUX-A-01-003: far typo must NOT fabricate a suggestion, got:\n{combined}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// FALSIFY-CRUX-A-01-004 — `apr registry aliases --json` emits the full
+// alias map as a JSON object; every value starts with a known scheme.
+// ---------------------------------------------------------------------------
+
+fn run_registry_aliases_json() -> (std::process::Output, String) {
+    let output = Command::new(env!("CARGO_BIN_EXE_apr"))
+        .args(["registry", "aliases", "--json"])
+        .output()
+        .unwrap_or_else(|e| panic!("FALSIFY-CRUX-A-01-004: failed to spawn apr: {e}"));
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    (output, stdout)
+}
+
+#[test]
+fn falsify_crux_a_01_004_registry_aliases_json_is_object() {
+    let (output, stdout) = run_registry_aliases_json();
+    assert!(
+        output.status.success(),
+        "FALSIFY-CRUX-A-01-004: exit 0 required, stdout=\n{stdout}\nstderr=\n{}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let json: serde_json::Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("FALSIFY-CRUX-A-01-004: stdout not valid JSON: {e}\n{stdout}"));
+    let obj = json
+        .as_object()
+        .expect("FALSIFY-CRUX-A-01-004: top-level JSON must be an object");
+    assert!(
+        !obj.is_empty(),
+        "FALSIFY-CRUX-A-01-004: alias map must be non-empty"
+    );
+}
+
+#[test]
+fn falsify_crux_a_01_004_registry_aliases_contains_canonical_names() {
+    let (_, stdout) = run_registry_aliases_json();
+    let json: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+    let obj = json.as_object().unwrap();
+    for canonical in ["llama3", "mistral", "phi3", "qwen2"] {
+        let val = obj.get(canonical).unwrap_or_else(|| {
+            panic!("FALSIFY-CRUX-A-01-004: '{canonical}' missing from registry aliases --json")
+        });
+        let url = val
+            .as_str()
+            .unwrap_or_else(|| panic!("FALSIFY-CRUX-A-01-004: '{canonical}' value is not a string"));
+        assert!(
+            url.starts_with("hf://") || url.starts_with("https://"),
+            "FALSIFY-CRUX-A-01-004: '{canonical}' → '{url}' missing known scheme"
+        );
+    }
+}
+
+#[test]
+fn falsify_crux_a_01_004_registry_aliases_is_deterministic() {
+    let (_, a) = run_registry_aliases_json();
+    let (_, b) = run_registry_aliases_json();
+    assert_eq!(
+        a.trim(),
+        b.trim(),
+        "FALSIFY-CRUX-A-01-004: two invocations of `apr registry aliases --json` must be byte-identical"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// FALSIFY-CRUX-A-01-005 — two separate process invocations of
+// `apr pull llama3 --dry-run` emit byte-identical canonical URLs.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn falsify_crux_a_01_005_cross_process_determinism() {
+    let extract = |s: &str| -> String {
+        s.lines()
+            .find_map(|l| {
+                l.split_whitespace()
+                    .find(|w| w.starts_with("hf://") || w.starts_with("https://"))
+                    .map(str::to_string)
+            })
+            .unwrap_or_default()
+    };
+    let (_, a) = run_apr_pull_dry_run("llama3");
+    let (_, b) = run_apr_pull_dry_run("llama3");
+    let (_, c) = run_apr_pull_dry_run("llama3");
+    let ua = extract(&a);
+    let ub = extract(&b);
+    let uc = extract(&c);
+    assert!(!ua.is_empty(), "FALSIFY-CRUX-A-01-005: no canonical URL:\n{a}");
+    assert_eq!(
+        ua, ub,
+        "FALSIFY-CRUX-A-01-005: invocation 1 vs 2 differ ({ua} vs {ub})"
+    );
+    assert_eq!(
+        ub, uc,
+        "FALSIFY-CRUX-A-01-005: invocation 2 vs 3 differ ({ub} vs {uc})"
     );
 }

--- a/crates/apr-cli/tests/falsification_crux_a_01.rs
+++ b/crates/apr-cli/tests/falsification_crux_a_01.rs
@@ -1,19 +1,22 @@
 //! Falsification tests for CRUX-A-01 — Pull model by short name.
 //!
 //! Contract: contracts/crux-A-01-v1.yaml
-//! This test closes FALSIFY-CRUX-A-01-002: `configs/aliases.yaml` ships with
-//! the repo, parses as YAML mapping str→str, and contains the four canonical
-//! short names required by the CRUX-A-01 invariants:
-//!   {"llama3", "mistral", "phi3", "qwen2"} ⊆ keys(map)
+//! Closes:
+//! - FALSIFY-CRUX-A-01-001: `apr pull <short> --dry-run` emits the canonical
+//!   URL on stdout and performs zero network I/O.
+//! - FALSIFY-CRUX-A-01-002: `configs/aliases.yaml` ships with the repo,
+//!   parses as str→str, and contains the four canonical short names:
+//!   {"llama3", "mistral", "phi3", "qwen2"} ⊆ keys(map).
 //!
-//! Other FALSIFY-CRUX-A-01-{001, 003, 004, 005} gates still need the
-//! `apr pull --dry-run` + `apr registry aliases --json` surface and are
+//! Remaining FALSIFY-CRUX-A-01-{003, 004, 005} gates (did-you-mean, `apr
+//! registry aliases --json`, invocation determinism across binary runs) are
 //! tracked by the M1 epic (GitHub #918).
 
 #![allow(clippy::unwrap_used)]
 
 use std::collections::BTreeMap;
 use std::path::PathBuf;
+use std::process::Command;
 
 fn repo_root() -> PathBuf {
     let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -71,4 +74,68 @@ fn falsify_crux_a_01_002_resolution_deterministic() {
         a, b,
         "FALSIFY-CRUX-A-01-002: two reads of aliases.yaml must yield byte-identical maps"
     );
+}
+
+// ---------------------------------------------------------------------------
+// FALSIFY-CRUX-A-01-001 — `apr pull <short> --dry-run` emits canonical URL.
+// ---------------------------------------------------------------------------
+
+fn run_apr_pull_dry_run(short: &str) -> (std::process::Output, String) {
+    let output = Command::new(env!("CARGO_BIN_EXE_apr"))
+        .args(["pull", short, "--dry-run"])
+        .output()
+        .unwrap_or_else(|e| panic!("FALSIFY-CRUX-A-01-001: failed to spawn apr: {e}"));
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    (output, stdout)
+}
+
+#[test]
+fn falsify_crux_a_01_001_dry_run_emits_canonical_url_for_llama3() {
+    let (output, stdout) = run_apr_pull_dry_run("llama3");
+    assert!(
+        output.status.success(),
+        "FALSIFY-CRUX-A-01-001: apr pull llama3 --dry-run must exit 0, stdout=\n{stdout}\nstderr=\n{}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert!(
+        stdout.contains("hf://") || stdout.contains("https://"),
+        "FALSIFY-CRUX-A-01-001: --dry-run stdout must contain a canonical URL, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn falsify_crux_a_01_001_dry_run_resolution_is_deterministic() {
+    let (_, a) = run_apr_pull_dry_run("llama3");
+    let (_, b) = run_apr_pull_dry_run("llama3");
+    let extract = |s: &str| -> String {
+        s.lines()
+            .find_map(|l| {
+                l.split_whitespace()
+                    .find(|w| w.starts_with("hf://") || w.starts_with("https://"))
+                    .map(str::to_string)
+            })
+            .unwrap_or_default()
+    };
+    let url_a = extract(&a);
+    let url_b = extract(&b);
+    assert!(!url_a.is_empty(), "no canonical URL in first run:\n{a}");
+    assert_eq!(
+        url_a, url_b,
+        "FALSIFY-CRUX-A-01-001: two back-to-back --dry-run invocations must be byte-identical"
+    );
+}
+
+#[test]
+fn falsify_crux_a_01_001_dry_run_every_canonical_name_resolves() {
+    for canonical in ["llama3", "mistral", "phi3", "qwen2"] {
+        let (output, stdout) = run_apr_pull_dry_run(canonical);
+        assert!(
+            output.status.success(),
+            "FALSIFY-CRUX-A-01-001: {canonical} --dry-run must exit 0"
+        );
+        assert!(
+            stdout.contains("hf://") || stdout.contains("https://"),
+            "FALSIFY-CRUX-A-01-001: {canonical} --dry-run must emit canonical URL, got:\n{stdout}"
+        );
+    }
 }

--- a/crates/apr-cli/tests/falsification_crux_a_01.rs
+++ b/crates/apr-cli/tests/falsification_crux_a_01.rs
@@ -7,10 +7,12 @@
 //! - FALSIFY-CRUX-A-01-002: `configs/aliases.yaml` ships with the repo,
 //!   parses as str→str, and contains the four canonical short names:
 //!   {"llama3", "mistral", "phi3", "qwen2"} ⊆ keys(map).
+//! - FALSIFY-CRUX-A-01-003: unknown short name exits non-zero with a
+//!   "did you mean …" hint (Levenshtein ≤ 2 against alias-map keys).
 //!
-//! Remaining FALSIFY-CRUX-A-01-{003, 004, 005} gates (did-you-mean, `apr
-//! registry aliases --json`, invocation determinism across binary runs) are
-//! tracked by the M1 epic (GitHub #918).
+//! Remaining FALSIFY-CRUX-A-01-{004, 005} gates (`apr registry aliases
+//! --json`, invocation determinism across binary runs) are tracked by the
+//! M1 epic (GitHub #918).
 
 #![allow(clippy::unwrap_used)]
 
@@ -138,4 +140,64 @@ fn falsify_crux_a_01_001_dry_run_every_canonical_name_resolves() {
             "FALSIFY-CRUX-A-01-001: {canonical} --dry-run must emit canonical URL, got:\n{stdout}"
         );
     }
+}
+
+// ---------------------------------------------------------------------------
+// FALSIFY-CRUX-A-01-003 — unknown short name emits a did-you-mean hint
+// (Levenshtein ≤ 2 against the alias map) and exits non-zero.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn falsify_crux_a_01_003_typo_exits_nonzero() {
+    let (output, _stdout) = run_apr_pull_dry_run("lama3");
+    assert!(
+        !output.status.success(),
+        "FALSIFY-CRUX-A-01-003: unknown short name 'lama3' must exit non-zero"
+    );
+}
+
+#[test]
+fn falsify_crux_a_01_003_typo_suggests_llama3() {
+    let output = Command::new(env!("CARGO_BIN_EXE_apr"))
+        .args(["pull", "lama3", "--dry-run"])
+        .output()
+        .unwrap();
+    let combined = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let lower = combined.to_lowercase();
+    assert!(
+        lower.contains("did you mean"),
+        "FALSIFY-CRUX-A-01-003: output must contain 'did you mean', got:\n{combined}"
+    );
+    assert!(
+        lower.contains("llama3"),
+        "FALSIFY-CRUX-A-01-003: suggestion must include 'llama3', got:\n{combined}"
+    );
+}
+
+#[test]
+fn falsify_crux_a_01_003_far_typo_has_no_suggestion() {
+    // A name with edit distance > 2 from every alias should NOT emit a
+    // concrete suggestion — the error should fall back to the generic hint.
+    let output = Command::new(env!("CARGO_BIN_EXE_apr"))
+        .args(["pull", "completely-unrelated-xyz-model", "--dry-run"])
+        .output()
+        .unwrap();
+    assert!(
+        !output.status.success(),
+        "FALSIFY-CRUX-A-01-003: far typo must still exit non-zero"
+    );
+    let combined = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+    .to_lowercase();
+    assert!(
+        !combined.contains("did you mean"),
+        "FALSIFY-CRUX-A-01-003: far typo must NOT fabricate a suggestion, got:\n{combined}"
+    );
 }


### PR DESCRIPTION
## Summary
- Complete CRUX-A-01 lane: all 5 FALSIFY gates discharged via Rust integration tests; contract promotes `partial` → `supported`.
- Stack consolidated into this one squash-merge via stacked sub-PRs: #929 (FALSIFY-003) + #930 (FALSIFY-004/005) + #931 (promotion).

## What landed
| Commit | Gate | Evidence |
|--------|------|----------|
| 802080bf0 | 001 | `apr pull <short> --dry-run` resolves canonical URL, zero I/O |
| 9dac6e918 | 003 | did-you-mean Levenshtein ≤ 2 suggestions |
| 89df63084 | 004/005 | `apr registry aliases --json` + cross-process determinism |
| 04efd0bff | promote | contract status draft → active, intake_status partial → supported |

002 already merged on main via #927.

## Contract bookkeeping
- `contracts/crux-A-01-v1.yaml` v1.1.0 ACTIVE with full evidence block (14 Rust integration tests + 9 unit tests named in `verification_summary.evidence.coverage`).
- `contracts/crux-competitive-research-ux-v1.yaml` `coverage_intake`: supported 38 → 39, partial 72 → 71 (total 250 preserved; grep-and-sum verified).

## Verification
- [x] `pv validate contracts/crux-A-01-v1.yaml` → 0/0
- [x] `pv validate contracts/crux-competitive-research-ux-v1.yaml` → 0/0
- [x] `cargo test -p apr-cli --test falsification_crux_a_01` → 14/14
- [x] `cargo test -p apr-cli --lib` → 4752/4752 (no regressions)
- [x] `apr registry aliases --json` dogfood → valid JSON object
- [ ] CI: `ci / gate` + `workspace-test` required checks green

## Scope honesty
First CRUX story to flip `partial` → `supported` since the epic opened. 211 stories still `partial`/`missing` (71 + 140); this PR does not touch them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)