### PR TITLE
feat(crux-a-01): did-you-mean Levenshtein ≤ 2 (FALSIFY-003, 3 of 5 gates)

### DIFF
--- a/crates/apr-cli/src/commands/aliases.rs
+++ b/crates/apr-cli/src/commands/aliases.rs
@@ -37,6 +37,51 @@ pub fn alias_map() -> &'static BTreeMap<String, String> {
     aliases()
 }
 
+/// Levenshtein edit distance between two ASCII strings (iterative, O(|a|·|b|) time,
+/// O(min(|a|,|b|)) space).
+///
+/// Pure helper for FALSIFY-CRUX-A-01-003 (did-you-mean suggestions). No Unicode
+/// normalization is performed — alias keys are ASCII-only by contract.
+pub fn levenshtein(a: &str, b: &str) -> usize {
+    let (a, b) = (a.as_bytes(), b.as_bytes());
+    if a.is_empty() {
+        return b.len();
+    }
+    if b.is_empty() {
+        return a.len();
+    }
+    let mut prev: Vec<usize> = (0..=b.len()).collect();
+    let mut curr: Vec<usize> = vec![0; b.len() + 1];
+    for (i, &ca) in a.iter().enumerate() {
+        curr[0] = i + 1;
+        for (j, &cb) in b.iter().enumerate() {
+            let cost = usize::from(ca != cb);
+            curr[j + 1] = (prev[j + 1] + 1)
+                .min(curr[j] + 1)
+                .min(prev[j] + cost);
+        }
+        std::mem::swap(&mut prev, &mut curr);
+    }
+    prev[b.len()]
+}
+
+/// Return alias-map keys within `max_distance` Levenshtein edits of `query`,
+/// sorted ascending by distance (ties broken alphabetically). Used by
+/// `apr pull <typo> --dry-run` to emit "did you mean …" hints.
+///
+/// Closes FALSIFY-CRUX-A-01-003 suggestion logic.
+pub fn did_you_mean(query: &str, max_distance: usize) -> Vec<&'static str> {
+    let mut hits: Vec<(usize, &str)> = aliases()
+        .keys()
+        .filter_map(|k| {
+            let d = levenshtein(query, k);
+            (d <= max_distance).then_some((d, k.as_str()))
+        })
+        .collect();
+    hits.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(b.1)));
+    hits.into_iter().map(|(_, k)| k).collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -69,5 +114,51 @@ mod tests {
         let a = resolve_short_name("llama3");
         let b = resolve_short_name("llama3");
         assert_eq!(a, b, "CRUX-A-01: resolution must be deterministic");
+    }
+
+    #[test]
+    fn levenshtein_empty_strings() {
+        assert_eq!(levenshtein("", ""), 0);
+        assert_eq!(levenshtein("abc", ""), 3);
+        assert_eq!(levenshtein("", "xyz"), 3);
+    }
+
+    #[test]
+    fn levenshtein_identity_and_basic_edits() {
+        assert_eq!(levenshtein("llama3", "llama3"), 0);
+        assert_eq!(levenshtein("lama3", "llama3"), 1); // insertion
+        assert_eq!(levenshtein("llamma3", "llama3"), 1); // deletion
+        assert_eq!(levenshtein("llana3", "llama3"), 1); // substitution
+        assert_eq!(levenshtein("ab", "cd"), 2); // two substitutions
+        assert_eq!(levenshtein("lam3", "llama3"), 2); // two insertions
+    }
+
+    #[test]
+    fn did_you_mean_finds_llama3_for_typo() {
+        let suggestions = did_you_mean("lama3", 2);
+        assert!(
+            suggestions.contains(&"llama3"),
+            "CRUX-A-01 FALSIFY-003: 'lama3' must suggest 'llama3', got {suggestions:?}"
+        );
+    }
+
+    #[test]
+    fn did_you_mean_empty_when_too_far() {
+        let suggestions = did_you_mean("completely-unrelated-xyz", 2);
+        assert!(
+            suggestions.is_empty(),
+            "CRUX-A-01 FALSIFY-003: unrelated names must not produce suggestions, got {suggestions:?}"
+        );
+    }
+
+    #[test]
+    fn did_you_mean_ranks_closer_first() {
+        // "qwem2" is 1 edit from "qwen2" and 2 edits from "qwen2.5"
+        let suggestions = did_you_mean("qwem2", 2);
+        assert_eq!(
+            suggestions.first(),
+            Some(&"qwen2"),
+            "CRUX-A-01 FALSIFY-003: closest match must rank first, got {suggestions:?}"
+        );
     }
 }

--- a/crates/apr-cli/src/commands/pull.rs
+++ b/crates/apr-cli/src/commands/pull.rs
@@ -539,6 +539,9 @@ fn write_shard_manifest(
 /// network I/O. Short names are resolved via the embedded alias map
 /// (`configs/aliases.yaml`); scheme-qualified inputs (`hf://…`,
 /// `https://…`) and bare `org/repo` inputs echo as their canonical forms.
+///
+/// CRUX-A-01 FALSIFY-CRUX-A-01-003: unknown short names (no scheme, no `/`)
+/// return an error that includes a Levenshtein ≤ 2 "did you mean …" hint.
 fn run_dry_run(model_ref: &str) -> Result<()> {
     use super::aliases;
 
@@ -547,16 +550,36 @@ fn run_dry_run(model_ref: &str) -> Result<()> {
     } else if !model_ref.contains("://") && model_ref.contains('/') {
         format!("hf://{model_ref}")
     } else {
-        return Err(CliError::ValidationFailed(format!(
-            "CRUX-A-01: unknown short name '{model_ref}' and not a fully-qualified URI. \
-             Run `apr registry aliases --json` to list known short names."
-        )));
+        return Err(unknown_short_name_error(model_ref));
     };
 
     println!("Model:    {}", model_ref.cyan());
     println!("Resolved: {}", resolved.green());
     println!("Mode:     {} (no network I/O)", "dry-run".yellow());
     Ok(())
+}
+
+/// CRUX-A-01 FALSIFY-CRUX-A-01-003: build an error carrying a did-you-mean
+/// hint derived from Levenshtein ≤ 2 matches against the alias map.
+fn unknown_short_name_error(name: &str) -> CliError {
+    use super::aliases;
+
+    let suggestions = aliases::did_you_mean(name, 2);
+    let hint = if suggestions.is_empty() {
+        "Run `apr registry aliases --json` to list known short names.".to_string()
+    } else {
+        format!(
+            "did you mean {}? (run `apr registry aliases --json` for the full list)",
+            suggestions
+                .iter()
+                .map(|s| format!("`{s}`"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
+    };
+    CliError::ValidationFailed(format!(
+        "CRUX-A-01: unknown short name '{name}' and not a fully-qualified URI. {hint}"
+    ))
 }
 
 include!("pull_list.rs");

--- a/crates/apr-cli/tests/falsification_crux_a_01.rs
+++ b/crates/apr-cli/tests/falsification_crux_a_01.rs
@@ -7,10 +7,12 @@
 //! - FALSIFY-CRUX-A-01-002: `configs/aliases.yaml` ships with the repo,
 //!   parses as str→str, and contains the four canonical short names:
 //!   {"llama3", "mistral", "phi3", "qwen2"} ⊆ keys(map).
+//! - FALSIFY-CRUX-A-01-003: unknown short name exits non-zero with a
+//!   "did you mean …" hint (Levenshtein ≤ 2 against alias-map keys).
 //!
-//! Remaining FALSIFY-CRUX-A-01-{003, 004, 005} gates (did-you-mean, `apr
-//! registry aliases --json`, invocation determinism across binary runs) are
-//! tracked by the M1 epic (GitHub #918).
+//! Remaining FALSIFY-CRUX-A-01-{004, 005} gates (`apr registry aliases
+//! --json`, invocation determinism across binary runs) are tracked by the
+//! M1 epic (GitHub #918).
 
 #![allow(clippy::unwrap_used)]
 
@@ -138,4 +140,64 @@ fn falsify_crux_a_01_001_dry_run_every_canonical_name_resolves() {
             "FALSIFY-CRUX-A-01-001: {canonical} --dry-run must emit canonical URL, got:\n{stdout}"
         );
     }
+}
+
+// ---------------------------------------------------------------------------
+// FALSIFY-CRUX-A-01-003 — unknown short name emits a did-you-mean hint
+// (Levenshtein ≤ 2 against the alias map) and exits non-zero.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn falsify_crux_a_01_003_typo_exits_nonzero() {
+    let (output, _stdout) = run_apr_pull_dry_run("lama3");
+    assert!(
+        !output.status.success(),
+        "FALSIFY-CRUX-A-01-003: unknown short name 'lama3' must exit non-zero"
+    );
+}
+
+#[test]
+fn falsify_crux_a_01_003_typo_suggests_llama3() {
+    let output = Command::new(env!("CARGO_BIN_EXE_apr"))
+        .args(["pull", "lama3", "--dry-run"])
+        .output()
+        .unwrap();
+    let combined = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let lower = combined.to_lowercase();
+    assert!(
+        lower.contains("did you mean"),
+        "FALSIFY-CRUX-A-01-003: output must contain 'did you mean', got:\n{combined}"
+    );
+    assert!(
+        lower.contains("llama3"),
+        "FALSIFY-CRUX-A-01-003: suggestion must include 'llama3', got:\n{combined}"
+    );
+}
+
+#[test]
+fn falsify_crux_a_01_003_far_typo_has_no_suggestion() {
+    // A name with edit distance > 2 from every alias should NOT emit a
+    // concrete suggestion — the error should fall back to the generic hint.
+    let output = Command::new(env!("CARGO_BIN_EXE_apr"))
+        .args(["pull", "completely-unrelated-xyz-model", "--dry-run"])
+        .output()
+        .unwrap();
+    assert!(
+        !output.status.success(),
+        "FALSIFY-CRUX-A-01-003: far typo must still exit non-zero"
+    );
+    let combined = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+    .to_lowercase();
+    assert!(
+        !combined.contains("did you mean"),
+        "FALSIFY-CRUX-A-01-003: far typo must NOT fabricate a suggestion, got:\n{combined}"
+    );
 }


### PR DESCRIPTION
## Summary
- Discharges **FALSIFY-CRUX-A-01-003** in `contracts/crux-A-01-v1.yaml`: unknown short names exit non-zero and emit `did you mean \`<name>\`` suggestions for alias-map keys within Levenshtein ≤ 2.
- Adds pure `aliases::levenshtein(a, b)` (iterative, O(|a|·|b|) time, O(min) space) + `aliases::did_you_mean(query, max_distance)`.
- Wires suggestions into `pull::run_dry_run` via `unknown_short_name_error(name)`; unrelated inputs fall back to the generic `apr registry aliases --json` hint.

## Scope honesty
- **3 of 5 FALSIFY gates** now close on CRUX-A-01 (001 + 002 + 003).
- FALSIFY-004 (`apr registry aliases --json`) and FALSIFY-005 (invocation determinism) are tracked by M1 (#918) and land as follow-up PRs.
- Contract `status.current` stays `partial`; master `contracts/crux-competitive-research-ux-v1.yaml` `supported_count` unchanged — promotion happens only when all five gates discharge.

## Stacked on
- Base: `feat/crux-a-01-dry-run` (PR #928 — FALSIFY-001)
- Parent-parent: PR #927 (merged — FALSIFY-002)

## Test plan
- [x] `pv validate contracts/crux-A-01-v1.yaml` → 0 errors, 0 warnings
- [x] `cargo test -p apr-cli --test falsification_crux_a_01` → 10/10 pass (incl. 3 new FALSIFY-003 tests)
- [x] `cargo test -p apr-cli --lib aliases` → 9/9 pass (incl. 2 Levenshtein + 3 did-you-mean unit tests)
- [x] `apr pull lama3 --dry-run` → exits 1, stderr contains \`did you mean \`llama3\`\`
- [x] `apr pull completely-unrelated-xyz-model --dry-run` → exits 1, no fabricated suggestion
- [ ] CI: `ci / gate` + `workspace-test` required checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)