### PR TITLE
feat(crux-a-01): registry aliases --json + cross-process determinism (FALSIFY-004, 005 of 5)

### DIFF
--- a/contracts/crux-A-01-v1.yaml
+++ b/contracts/crux-A-01-v1.yaml
@@ -113,7 +113,6 @@ falsification_tests:
   rule: apr registry aliases lists all short names
   prediction: "apr registry aliases --json returns {name: url} map"
   test: |
-    # TODO: wire `apr registry aliases` subcommand
     OUT=$(apr registry aliases --json 2>&1) || { echo "FAIL: subcommand missing" >&2; exit 1; }
     echo "$OUT" | jq -e 'type == "object" and (keys | length > 0)' >/dev/null || {
       echo "FAIL: aliases --json output not a non-empty object" >&2

--- a/crates/apr-cli/src/commands/mod.rs
+++ b/crates/apr-cli/src/commands/mod.rs
@@ -61,6 +61,7 @@ pub(crate) mod qa;
 pub(crate) mod qa_capability;
 pub(crate) mod qualify;
 pub(crate) mod quantize;
+pub(crate) mod registry;
 pub(crate) mod rosetta;
 pub(crate) mod run;
 #[cfg(feature = "training")]

--- a/crates/apr-cli/src/commands/registry.rs
+++ b/crates/apr-cli/src/commands/registry.rs
@@ -1,0 +1,38 @@
+//! `apr registry` subcommand — operations over the local model registry.
+//!
+//! Contract: `contracts/crux-A-01-v1.yaml` — closes FALSIFY-CRUX-A-01-004
+//! (`apr registry aliases --json` emits the full str→str alias map).
+
+use crate::error::Result;
+use clap::Subcommand;
+
+#[derive(Subcommand, Clone, Debug)]
+pub enum RegistryCommands {
+    /// List short-name → canonical-URL aliases from configs/aliases.yaml.
+    Aliases {
+        /// Emit the alias map as a single JSON object on stdout.
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+pub fn run(command: RegistryCommands) -> Result<()> {
+    match command {
+        RegistryCommands::Aliases { json } => aliases(json),
+    }
+}
+
+fn aliases(json: bool) -> Result<()> {
+    use super::aliases;
+    let map = aliases::alias_map();
+    if json {
+        let value = serde_json::to_string(map)
+            .expect("CRUX-A-01 FALSIFY-004: BTreeMap<String, String> always serializes");
+        println!("{value}");
+    } else {
+        for (name, url) in map {
+            println!("{name}\t{url}");
+        }
+    }
+    Ok(())
+}

--- a/crates/apr-cli/src/commands_enum.rs
+++ b/crates/apr-cli/src/commands_enum.rs
@@ -366,6 +366,11 @@ pub enum Commands {
         #[arg(long)]
         dry_run: bool,
     },
+    /// Registry operations (CRUX-A-01): inspect alias map, etc.
+    Registry {
+        #[command(subcommand)]
+        command: crate::commands::registry::RegistryCommands,
+    },
     /// List cached models
     #[command(name = "list", alias = "ls")]
     List,

--- a/crates/apr-cli/src/dispatch.rs
+++ b/crates/apr-cli/src/dispatch.rs
@@ -609,6 +609,9 @@ fn dispatch_model_commands(cli: &Cli) -> Option<Result<(), CliError>> {
             force,
             dry_run,
         } => pull::run(model_ref, *force, *dry_run),
+        Commands::Registry { command } => {
+            crate::commands::registry::run(command.clone())
+        }
         Commands::List => pull::list(cli.json, cli.quiet),
         Commands::Rm { model_ref } => pull::remove(model_ref),
         Commands::Tui { file } => tui::run(file.clone()),

--- a/crates/apr-cli/tests/falsification_crux_a_01.rs
+++ b/crates/apr-cli/tests/falsification_crux_a_01.rs
@@ -9,10 +9,10 @@
 //!   {"llama3", "mistral", "phi3", "qwen2"} ⊆ keys(map).
 //! - FALSIFY-CRUX-A-01-003: unknown short name exits non-zero with a
 //!   "did you mean …" hint (Levenshtein ≤ 2 against alias-map keys).
-//!
-//! Remaining FALSIFY-CRUX-A-01-{004, 005} gates (`apr registry aliases
-//! --json`, invocation determinism across binary runs) are tracked by the
-//! M1 epic (GitHub #918).
+//! - FALSIFY-CRUX-A-01-004: `apr registry aliases --json` emits the full
+//!   alias map as a JSON object with every value carrying a known scheme.
+//! - FALSIFY-CRUX-A-01-005: three back-to-back process invocations of
+//!   `apr pull llama3 --dry-run` emit byte-identical canonical URLs.
 
 #![allow(clippy::unwrap_used)]
 
@@ -199,5 +199,101 @@ fn falsify_crux_a_01_003_far_typo_has_no_suggestion() {
     assert!(
         !combined.contains("did you mean"),
         "FALSIFY-CRUX-A-01-003: far typo must NOT fabricate a suggestion, got:\n{combined}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// FALSIFY-CRUX-A-01-004 — `apr registry aliases --json` emits the full
+// alias map as a JSON object; every value starts with a known scheme.
+// ---------------------------------------------------------------------------
+
+fn run_registry_aliases_json() -> (std::process::Output, String) {
+    let output = Command::new(env!("CARGO_BIN_EXE_apr"))
+        .args(["registry", "aliases", "--json"])
+        .output()
+        .unwrap_or_else(|e| panic!("FALSIFY-CRUX-A-01-004: failed to spawn apr: {e}"));
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    (output, stdout)
+}
+
+#[test]
+fn falsify_crux_a_01_004_registry_aliases_json_is_object() {
+    let (output, stdout) = run_registry_aliases_json();
+    assert!(
+        output.status.success(),
+        "FALSIFY-CRUX-A-01-004: exit 0 required, stdout=\n{stdout}\nstderr=\n{}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let json: serde_json::Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("FALSIFY-CRUX-A-01-004: stdout not valid JSON: {e}\n{stdout}"));
+    let obj = json
+        .as_object()
+        .expect("FALSIFY-CRUX-A-01-004: top-level JSON must be an object");
+    assert!(
+        !obj.is_empty(),
+        "FALSIFY-CRUX-A-01-004: alias map must be non-empty"
+    );
+}
+
+#[test]
+fn falsify_crux_a_01_004_registry_aliases_contains_canonical_names() {
+    let (_, stdout) = run_registry_aliases_json();
+    let json: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+    let obj = json.as_object().unwrap();
+    for canonical in ["llama3", "mistral", "phi3", "qwen2"] {
+        let val = obj.get(canonical).unwrap_or_else(|| {
+            panic!("FALSIFY-CRUX-A-01-004: '{canonical}' missing from registry aliases --json")
+        });
+        let url = val
+            .as_str()
+            .unwrap_or_else(|| panic!("FALSIFY-CRUX-A-01-004: '{canonical}' value is not a string"));
+        assert!(
+            url.starts_with("hf://") || url.starts_with("https://"),
+            "FALSIFY-CRUX-A-01-004: '{canonical}' → '{url}' missing known scheme"
+        );
+    }
+}
+
+#[test]
+fn falsify_crux_a_01_004_registry_aliases_is_deterministic() {
+    let (_, a) = run_registry_aliases_json();
+    let (_, b) = run_registry_aliases_json();
+    assert_eq!(
+        a.trim(),
+        b.trim(),
+        "FALSIFY-CRUX-A-01-004: two invocations of `apr registry aliases --json` must be byte-identical"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// FALSIFY-CRUX-A-01-005 — two separate process invocations of
+// `apr pull llama3 --dry-run` emit byte-identical canonical URLs.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn falsify_crux_a_01_005_cross_process_determinism() {
+    let extract = |s: &str| -> String {
+        s.lines()
+            .find_map(|l| {
+                l.split_whitespace()
+                    .find(|w| w.starts_with("hf://") || w.starts_with("https://"))
+                    .map(str::to_string)
+            })
+            .unwrap_or_default()
+    };
+    let (_, a) = run_apr_pull_dry_run("llama3");
+    let (_, b) = run_apr_pull_dry_run("llama3");
+    let (_, c) = run_apr_pull_dry_run("llama3");
+    let ua = extract(&a);
+    let ub = extract(&b);
+    let uc = extract(&c);
+    assert!(!ua.is_empty(), "FALSIFY-CRUX-A-01-005: no canonical URL:\n{a}");
+    assert_eq!(
+        ua, ub,
+        "FALSIFY-CRUX-A-01-005: invocation 1 vs 2 differ ({ua} vs {ub})"
+    );
+    assert_eq!(
+        ub, uc,
+        "FALSIFY-CRUX-A-01-005: invocation 2 vs 3 differ ({ub} vs {uc})"
     );
 }


### PR DESCRIPTION
## Summary
- Discharges **FALSIFY-CRUX-A-01-004** and **FALSIFY-CRUX-A-01-005** in `contracts/crux-A-01-v1.yaml`.
- New `apr registry aliases [--json]` subcommand prints the embedded `configs/aliases.yaml` alias map. `--json` emits a single serde_json object on stdout; plain output is `name\turl\n`.
- Invocation-determinism test: three back-to-back `apr pull llama3 --dry-run` processes must emit byte-identical canonical URLs (guaranteed by OnceLock-cached BTreeMap).

## Scope honesty
- **All 5 FALSIFY gates** for CRUX-A-01 now have Rust-test evidence (001 dry-run, 002 alias map, 003 did-you-mean, 004 registry subcommand, 005 cross-process determinism).
- Contract `status.current` stays `partial` on this PR — flipping to `supported` happens in a follow-up that updates both `contracts/crux-A-01-v1.yaml` and the master `contracts/crux-competitive-research-ux-v1.yaml` `supported_count`, once this stack is green on main.
- FALSIFY-004 `TODO: wire subcommand` comment dropped from the contract test body.

## Stacked on
- Base: `feat/crux-a-01-dry-run` (PR #928 — FALSIFY-001 + FALSIFY-003 already squashed in)
- Grand-parent: `main` (PR #927 — FALSIFY-002 already merged)

## Test plan
- [x] `pv validate contracts/crux-A-01-v1.yaml` → 0 errors, 0 warnings
- [x] `cargo test -p apr-cli --test falsification_crux_a_01` → 14/14 pass (4 new tests)
- [x] `cargo test -p apr-cli --lib` → 4752/4752 pass (no regressions)
- [x] `apr registry aliases --json` → valid JSON object with `llama3`/`mistral`/`phi3`/`qwen2` keys
- [ ] CI: `ci / gate` + `workspace-test` required checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)