### PR TITLE
feat(crux-c-34): /health endpoint — vLLM+llama.cpp+k8s parity, 5/5 FALSIFY gates

### DIFF
--- a/contracts/crux-C-34-v1.yaml
+++ b/contracts/crux-C-34-v1.yaml
@@ -6,17 +6,18 @@
 
 metadata:
   id: CRUX-C-34
-  version: "1.0.0-draft"
+  version: "1.0.0"
   created: "2026-04-18"
+  promoted: "2026-04-20"
   author: PAIML Engineering
   registry: true
-  status: draft
+  status: active
   parent_contracts:
   - crux-competitive-research-ux-v1
   category: "C — Serving & Chat UX"
   competitor: vllm
   demand_score: 5  # 1..5, critical priority in pmat work
-  intake_status: partial
+  intake_status: supported
   description: >
     /health endpoint. Competitors vLLM (GET /health → 200 once the engine is
     up) and llama.cpp server (GET /health → {"status":"ok"}) expose a cheap
@@ -180,8 +181,35 @@ proof_obligations:
 verification_summary:
   total_obligations: 5
   proven: 0
-  tested: 0
-  status: spec-complete
+  tested: 5
+  status: discharged
+
+discharge_evidence:
+  harness: crates/aprender-serve/tests/falsification_crux_c_34.rs
+  framework: tokio::test + tower::ServiceExt::oneshot (in-process axum)
+  test_count: 12
+  falsify_crux_c_34_001:
+  - falsify_crux_c_34_001_health_schema_200
+  falsify_crux_c_34_002:
+  - falsify_crux_c_34_002_status_enum_ready
+  - falsify_crux_c_34_002_status_enum_loading
+  - falsify_crux_c_34_002_loading_returns_503
+  falsify_crux_c_34_003:
+  - falsify_crux_c_34_003_uptime_monotonic
+  falsify_crux_c_34_004:
+  - falsify_crux_c_34_004_live_always_200_ready_server
+  - falsify_crux_c_34_004_live_always_200_loading_server
+  - falsify_crux_c_34_004_ready_200_when_model_loaded
+  - falsify_crux_c_34_004_ready_503_when_no_model
+  - falsify_crux_c_34_004_main_health_agrees_with_ready
+  falsify_crux_c_34_005:
+  - falsify_crux_c_34_005_force_loading_env_flips_status
+  - falsify_crux_c_34_005_force_loading_ready_is_503
+  implementation:
+  - crates/aprender-serve/src/api/router.rs  # handlers + OnceLock uptime + force_loading hook
+  - crates/aprender-serve/src/api/types.rs   # HealthResponse schema
+  - crates/aprender-serve/src/api/mod_app_state_gpu.rs  # AppState::model_loaded()
+  loading_hook: APR_TEST_FORCE_LOADING=1
 
 pmat_work_tracking:
   # Managed by master contract §12. If intake_status == "missing", a ticket

--- a/contracts/crux-competitive-research-ux-v1.yaml
+++ b/contracts/crux-competitive-research-ux-v1.yaml
@@ -241,7 +241,7 @@ stories:
   - { id: CRUX-C-31, title: "FlashAttention-2 enabled path",       competitor: vllm,        demand_score: 5, status: partial,   contract: crux-C-31-v1.yaml }
   - { id: CRUX-C-32, title: "Chunked prefill long contexts",       competitor: vllm,        demand_score: 4, status: partial,   contract: crux-C-32-v1.yaml }
   - { id: CRUX-C-33, title: "/v1/models endpoint",                 competitor: vllm,        demand_score: 5, status: partial,   contract: crux-C-33-v1.yaml }
-  - { id: CRUX-C-34, title: "/health endpoint",                    competitor: vllm,        demand_score: 5, status: partial,   contract: crux-C-34-v1.yaml }
+  - { id: CRUX-C-34, title: "/health endpoint",                    competitor: vllm,        demand_score: 5, status: supported, contract: crux-C-34-v1.yaml }
   - { id: CRUX-C-35, title: "Graceful shutdown in-flight drain",   competitor: vllm,        demand_score: 4, status: partial,   contract: crux-C-35-v1.yaml }
   - { id: CRUX-C-36, title: "Cancel in-flight requests",           competitor: vllm,        demand_score: 4, status: partial,   contract: crux-C-36-v1.yaml }
 
@@ -439,8 +439,8 @@ stories:
 # Coverage — intake v2.0.0 (verified by awk over §5 of subspec)
 # ─────────────────────────────────────────────────────────────
 coverage_intake:
-  supported: 39
-  partial:   71
+  supported: 40
+  partial:   70
   missing:   140
   unclear:    0
   total:    250

--- a/crates/aprender-serve/src/api/mod_app_state_gpu.rs
+++ b/crates/aprender-serve/src/api/mod_app_state_gpu.rs
@@ -371,6 +371,30 @@ impl AppState {
         self.apr_transformer.is_some()
     }
 
+    /// Whether any inference-capable model is resident.
+    ///
+    /// Gates the `model_loaded` field of `HealthResponse` and the
+    /// `/health/ready` k8s readiness probe (CRUX-C-34 contract).
+    #[must_use]
+    pub fn model_loaded(&self) -> bool {
+        if self.model.is_some()
+            || self.apr_model.is_some()
+            || self.quantized_model.is_some()
+            || self.apr_transformer.is_some()
+        {
+            return true;
+        }
+        #[cfg(feature = "gpu")]
+        if self.gpu_model.is_some() || self.cached_model.is_some() {
+            return true;
+        }
+        #[cfg(feature = "cuda")]
+        if self.cuda_model.is_some() || self.safetensors_cuda_model.is_some() {
+            return true;
+        }
+        false
+    }
+
     /// Get the APR transformer for inference (PMAT-SERVE-FIX-001)
     pub fn apr_transformer(&self) -> Option<&Arc<crate::apr_transformer::AprTransformer>> {
         self.apr_transformer.as_ref()

--- a/crates/aprender-serve/src/api/router.rs
+++ b/crates/aprender-serve/src/api/router.rs
@@ -56,8 +56,10 @@ pub fn create_router(state: AppState) -> Router {
 /// * `config` - Router configuration (controls which route groups are enabled)
 pub fn create_router_with_config(state: AppState, config: RouterConfig) -> Router {
     let mut router = Router::new()
-        // Health and metrics
+        // Health and metrics (CRUX-C-34: /health, /health/live, /health/ready)
         .route("/health", get(health_handler))
+        .route("/health/live", get(health_live_handler))
+        .route("/health/ready", get(health_ready_handler))
         .route("/metrics", get(metrics_handler))
         .route("/metrics/dispatch", get(dispatch_metrics_handler))
         .route("/metrics/dispatch/reset", post(dispatch_reset_handler))
@@ -156,42 +158,116 @@ async fn sanitize_json_rejection(
     response
 }
 
-/// Health check handler
-async fn health_handler(State(state): State<AppState>) -> Json<HealthResponse> {
-    // GH-152: Verbose request logging
-    if state.is_verbose() {
-        eprintln!("[VERBOSE] GET /health");
-    }
+/// Process-wide server start instant.
+///
+/// Initialised lazily on the first `/health*` hit. `Instant` is
+/// monotonic in `std` — see `std::time::Instant` docs — which
+/// discharges FALSIFY-CRUX-C-34-003 (monotonic `uptime_sec`).
+fn server_uptime_sec() -> f64 {
+    static SERVER_START: std::sync::OnceLock<std::time::Instant> = std::sync::OnceLock::new();
+    SERVER_START
+        .get_or_init(std::time::Instant::now)
+        .elapsed()
+        .as_secs_f64()
+}
 
-    // Determine compute mode based on what's available
-    // BUG-HEALTH-001: Must check all GPU dispatch paths.
-    // - has_gpu_model(): legacy wgpu path
-    // - cached_model: batched GPU inference
-    // - has_cuda_model(): PAR-111 CUDA path (stores in AppState.cuda_model)
+/// Test-only hook: force the health handler to report `status = "loading"`.
+///
+/// Wired by `APR_TEST_FORCE_LOADING=1`. Present in all builds so
+/// FALSIFY-CRUX-C-34-005 can drive the loading/503 branch without a
+/// separate test-only feature.
+fn force_loading() -> bool {
+    std::env::var("APR_TEST_FORCE_LOADING").is_ok_and(|v| v == "1")
+}
+
+/// Build a `HealthResponse` consistent with the CRUX-C-34 contract.
+///
+/// Caller picks the HTTP status via `health_status_code(&response)`.
+fn build_health_response(state: &AppState) -> HealthResponse {
+    // BUG-HEALTH-001: all GPU dispatch paths must register as "gpu".
     let mut compute_mode = "cpu";
-
     #[cfg(feature = "gpu")]
-    if state.has_gpu_model() || state.cached_model.is_some() {
+    if state.has_gpu_model() || state.has_cached_model() {
         compute_mode = "gpu";
     }
-
     #[cfg(feature = "cuda")]
     if state.has_cuda_model() {
         compute_mode = "gpu";
     }
 
-    let response = HealthResponse {
-        status: "healthy".to_string(),
-        version: crate::VERSION.to_string(),
-        compute_mode: compute_mode.to_string(),
+    let model_loaded = state.model_loaded();
+    // Contract §health_response_schema:
+    //   status == "ok"       ⇒ ready to serve (HTTP 200)
+    //   status == "loading"  ⇒ model not yet resident (HTTP 503)
+    //   status == "degraded" ⇒ reserved for partial failure modes
+    let status = if force_loading() || !model_loaded {
+        "loading"
+    } else {
+        "ok"
     };
 
-    // GH-152: Verbose response logging
-    if state.is_verbose() {
-        eprintln!("[VERBOSE] GET /health -> status={}", response.status);
+    HealthResponse {
+        status: status.to_string(),
+        version: crate::VERSION.to_string(),
+        compute_mode: compute_mode.to_string(),
+        model_loaded,
+        uptime_sec: server_uptime_sec(),
     }
+}
 
-    Json(response)
+/// HTTP status derived from the body's `status` field.
+///
+/// Contract §health_response_schema: 200 iff `status == "ok"`; 503 for
+/// every non-`ok` status (loading, degraded).
+fn health_status_code(body: &HealthResponse) -> StatusCode {
+    if body.status == "ok" {
+        StatusCode::OK
+    } else {
+        StatusCode::SERVICE_UNAVAILABLE
+    }
+}
+
+/// `GET /health` — vLLM / llama.cpp-parity liveness probe.
+///
+/// Discharges FALSIFY-CRUX-C-34-001/002/003.
+async fn health_handler(State(state): State<AppState>) -> (StatusCode, Json<HealthResponse>) {
+    if state.is_verbose() {
+        eprintln!("[VERBOSE] GET /health");
+    }
+    let body = build_health_response(&state);
+    let code = health_status_code(&body);
+    if state.is_verbose() {
+        eprintln!("[VERBOSE] GET /health -> {} status={}", code, body.status);
+    }
+    (code, Json(body))
+}
+
+/// `GET /health/live` — k8s liveness probe.
+///
+/// Always returns 200 once the HTTP port is bound (CRUX-C-34
+/// §liveness_vs_readiness). Body mirrors `/health` for debuggability.
+async fn health_live_handler(State(state): State<AppState>) -> (StatusCode, Json<HealthResponse>) {
+    if state.is_verbose() {
+        eprintln!("[VERBOSE] GET /health/live");
+    }
+    (StatusCode::OK, Json(build_health_response(&state)))
+}
+
+/// `GET /health/ready` — k8s readiness probe.
+///
+/// 200 iff `status == "ok"` AND `model_loaded == true`; 503 otherwise.
+/// Discharges FALSIFY-CRUX-C-34-004.
+async fn health_ready_handler(State(state): State<AppState>) -> (StatusCode, Json<HealthResponse>) {
+    if state.is_verbose() {
+        eprintln!("[VERBOSE] GET /health/ready");
+    }
+    let body = build_health_response(&state);
+    let code = if body.status == "ok" && body.model_loaded {
+        StatusCode::OK
+    } else {
+        StatusCode::SERVICE_UNAVAILABLE
+    };
+    (code, Json(body))
 }
 
 /// Metrics handler - returns Prometheus-formatted metrics

--- a/crates/aprender-serve/src/api/tests/batch_generate_03.rs
+++ b/crates/aprender-serve/src/api/tests/batch_generate_03.rs
@@ -80,7 +80,9 @@ async fn test_apr_explain_handler_via_http() {
 
 #[tokio::test]
 async fn test_health_endpoint() {
-    let app = create_test_app_shared();
+    // CRUX-C-34: /health returns 200 only when model is loaded.
+    // Use create_test_app() (demo state with model), not shared mock state.
+    let app = create_test_app();
     let response = app
         .oneshot(
             Request::builder()

--- a/crates/aprender-serve/src/api/tests/chat_completion_03.rs
+++ b/crates/aprender-serve/src/api/tests/chat_completion_03.rs
@@ -390,14 +390,17 @@ fn test_embedding_request_fields_cov() {
 #[test]
 fn test_health_response_serialize_cov() {
     let resp = HealthResponse {
-        status: "healthy".to_string(),
+        status: "ok".to_string(),
         version: "1.0.0".to_string(),
         compute_mode: "cpu".to_string(),
+        model_loaded: true,
+        uptime_sec: 2.5,
     };
     let json = serde_json::to_string(&resp).expect("serialize");
-    assert!(json.contains("healthy"));
+    assert!(json.contains("\"ok\""));
     assert!(json.contains("1.0.0"));
     assert!(json.contains("cpu"));
+    assert!(json.contains("model_loaded"));
 }
 
 // =========================================================================

--- a/crates/aprender-serve/src/api/tests/completion_request_response.rs
+++ b/crates/aprender-serve/src/api/tests/completion_request_response.rs
@@ -180,6 +180,8 @@ fn test_health_response_serde() {
         status: "ok".to_string(),
         version: "1.0.0".to_string(),
         compute_mode: "cpu".to_string(),
+        model_loaded: true,
+        uptime_sec: 1.0,
     };
     let json = serde_json::to_string(&resp).expect("serialize");
     let parsed: crate::api::HealthResponse = serde_json::from_str(&json).expect("deserialize");

--- a/crates/aprender-serve/src/api/tests/context_window_serde.rs
+++ b/crates/aprender-serve/src/api/tests/context_window_serde.rs
@@ -6,7 +6,7 @@
 //! struct serde round-trips, GPU/batch handler routing.
 
 use crate::api::realize_handlers::*;
-use crate::api::test_helpers::create_test_app_shared;
+use crate::api::test_helpers::{create_test_app, create_test_app_shared};
 use crate::api::*;
 use axum::body::Body;
 use axum::http::{Request, StatusCode};

--- a/crates/aprender-serve/src/api/tests/deep_apicov_02.rs
+++ b/crates/aprender-serve/src/api/tests/deep_apicov_02.rs
@@ -232,14 +232,18 @@ fn test_deep_apicov_context_window_large_system_message() {
 #[test]
 fn test_deep_apicov_health_response_structure() {
     let resp = HealthResponse {
-        status: "healthy".to_string(),
+        status: "ok".to_string(),
         version: "0.1.0".to_string(),
         compute_mode: "cpu".to_string(),
+        model_loaded: true,
+        uptime_sec: 3.14,
     };
     let json = serde_json::to_string(&resp).expect("serialize");
-    assert!(json.contains("healthy"));
+    assert!(json.contains("\"ok\""));
     assert!(json.contains("0.1.0"));
     assert!(json.contains("cpu"));
+    assert!(json.contains("model_loaded"));
+    assert!(json.contains("uptime_sec"));
 }
 
 #[test]

--- a/crates/aprender-serve/src/api/tests/format_chat_02.rs
+++ b/crates/aprender-serve/src/api/tests/format_chat_02.rs
@@ -383,6 +383,8 @@ fn test_health_response_serde() {
         status: "ok".to_string(),
         version: "0.3.5".to_string(),
         compute_mode: "cpu".to_string(),
+        model_loaded: true,
+        uptime_sec: 1.0,
     };
     let json = serde_json::to_string(&health).expect("JSON serialization failed");
     let deserialized: crate::api::HealthResponse = serde_json::from_str(&json).expect("JSON deserialization failed");

--- a/crates/aprender-serve/src/api/tests/imp_140c.rs
+++ b/crates/aprender-serve/src/api/tests/imp_140c.rs
@@ -314,14 +314,18 @@ fn test_parity022e_router_has_gpu_batch_routes() {
 #[test]
 fn test_health_response_serialize() {
     let response = HealthResponse {
-        status: "healthy".to_string(),
+        status: "ok".to_string(),
         version: "1.0.0".to_string(),
         compute_mode: "cpu".to_string(),
+        model_loaded: true,
+        uptime_sec: 1.0,
     };
     let json = serde_json::to_string(&response).expect("test");
-    assert!(json.contains("healthy"));
+    assert!(json.contains("\"ok\""));
     assert!(json.contains("1.0.0"));
     assert!(json.contains("cpu"));
+    assert!(json.contains("model_loaded"));
+    assert!(json.contains("uptime_sec"));
 }
 
 #[test]

--- a/crates/aprender-serve/src/api/tests/model_metadata.rs
+++ b/crates/aprender-serve/src/api/tests/model_metadata.rs
@@ -289,11 +289,13 @@ fn test_batch_process_result_debug_cov() {
 
 #[test]
 fn test_health_response_roundtrip_ext_cov() {
-    let json = r#"{"status":"ok","version":"2.0.0","compute_mode":"gpu"}"#;
+    let json = r#"{"status":"ok","version":"2.0.0","compute_mode":"gpu","model_loaded":true,"uptime_sec":1.5}"#;
     let resp: HealthResponse = serde_json::from_str(json).expect("parse failed");
     assert_eq!(resp.status, "ok");
     assert_eq!(resp.version, "2.0.0");
     assert_eq!(resp.compute_mode, "gpu");
+    assert!(resp.model_loaded);
+    assert_eq!(resp.uptime_sec, 1.5);
 }
 
 #[test]

--- a/crates/aprender-serve/src/api/tests/serde.rs
+++ b/crates/aprender-serve/src/api/tests/serde.rs
@@ -14,7 +14,7 @@ use axum::{
 };
 use tower::util::ServiceExt;
 
-use crate::api::test_helpers::create_test_app_shared;
+use crate::api::test_helpers::{create_test_app, create_test_app_shared};
 use crate::api::AppState;
 
 // ============================================================================

--- a/crates/aprender-serve/src/api/tests/tests_01.rs
+++ b/crates/aprender-serve/src/api/tests/tests_01.rs
@@ -92,7 +92,7 @@ async fn test_health_endpoint() {
         Ok(v) => v,
         Err(_) => return, // Mock state: error response, skip body assertions
     };
-    assert_eq!(health.status, "healthy");
+    assert_eq!(health.status, "ok");
 }
 
 #[tokio::test]

--- a/crates/aprender-serve/src/api/tests/usage_serde_health.rs
+++ b/crates/aprender-serve/src/api/tests/usage_serde_health.rs
@@ -17,7 +17,9 @@ fn test_usage_serde() {
 
 #[tokio::test]
 async fn test_health_endpoint() {
-    let app = create_test_app_shared();
+    // CRUX-C-34: /health returns 200 only when model is loaded.
+    // Use create_test_app() (demo state with model), not shared mock state.
+    let app = create_test_app();
     let request = Request::builder()
         .method("GET")
         .uri("/health")

--- a/crates/aprender-serve/src/api/types.rs
+++ b/crates/aprender-serve/src/api/types.rs
@@ -6,15 +6,30 @@
 use crate::registry::ModelInfo;
 use serde::{Deserialize, Serialize};
 
-/// Health check response
+/// Health check response.
+///
+/// Schema is defined by `contracts/crux-C-34-v1.yaml` (CRUX-C-34,
+/// competitor parity: vLLM `/health`, llama.cpp server `/health`).
+///
+/// * `status ∈ {"ok", "loading", "degraded"}`
+/// * HTTP 200 iff `status == "ok"`; 503 for `loading` / `degraded`.
+/// * `model_loaded` gates `/health/ready` (k8s readiness probe).
+/// * `uptime_sec > 0` and strictly monotonic across sequential GETs.
+///
+/// `version` and `compute_mode` are aprender extensions (not forbidden
+/// by the contract) and remain for operator diagnostics.
 #[derive(Serialize, Deserialize)]
 pub struct HealthResponse {
-    /// Service status
+    /// Service status: `"ok"`, `"loading"`, or `"degraded"`.
     pub status: String,
     /// Service version
     pub version: String,
     /// Compute mode: "cpu" or "gpu"
     pub compute_mode: String,
+    /// Whether a model is resident and ready for inference.
+    pub model_loaded: bool,
+    /// Seconds since the server process first bound a router.
+    pub uptime_sec: f64,
 }
 
 /// Tokenize request

--- a/crates/aprender-serve/tests/api_coverage.rs
+++ b/crates/aprender-serve/tests/api_coverage.rs
@@ -34,18 +34,22 @@ use realizar::registry::ModelInfo;
 #[test]
 fn test_health_response_serialization() {
     let response = HealthResponse {
-        status: "healthy".to_string(),
+        status: "ok".to_string(),
         version: "1.0.0".to_string(),
         compute_mode: "cpu".to_string(),
+        model_loaded: true,
+        uptime_sec: 1.0,
     };
 
     let json = serde_json::to_string(&response).expect("should serialize");
-    assert!(json.contains(r#""status":"healthy""#));
+    assert!(json.contains(r#""status":"ok""#));
     assert!(json.contains(r#""version":"1.0.0""#));
+    assert!(json.contains(r#""model_loaded":true"#));
 
     let deserialized: HealthResponse = serde_json::from_str(&json).expect("should deserialize");
-    assert_eq!(deserialized.status, "healthy");
+    assert_eq!(deserialized.status, "ok");
     assert_eq!(deserialized.version, "1.0.0");
+    assert!(deserialized.model_loaded);
 }
 
 #[test]
@@ -2896,6 +2900,8 @@ fn test_health_response_custom_status() {
         status: "degraded".to_string(),
         version: "0.0.0-dev".to_string(),
         compute_mode: "cpu".to_string(),
+        model_loaded: false,
+        uptime_sec: 0.5,
     };
 
     let json = serde_json::to_string(&response).expect("should serialize");
@@ -4748,14 +4754,18 @@ fn test_dispatch_metrics_response_clone() {
 #[test]
 fn test_health_response_roundtrip() {
     let original = HealthResponse {
-        status: "healthy".to_string(),
+        status: "ok".to_string(),
         version: "1.2.3".to_string(),
         compute_mode: "cpu".to_string(),
+        model_loaded: true,
+        uptime_sec: 42.0,
     };
     let json = serde_json::to_string(&original).expect("serialize");
     let restored: HealthResponse = serde_json::from_str(&json).expect("deserialize");
     assert_eq!(original.status, restored.status);
     assert_eq!(original.version, restored.version);
+    assert_eq!(original.model_loaded, restored.model_loaded);
+    assert!((original.uptime_sec - restored.uptime_sec).abs() < 1e-9);
 }
 
 #[test]

--- a/crates/aprender-serve/tests/api_deep_coverage.rs
+++ b/crates/aprender-serve/tests/api_deep_coverage.rs
@@ -923,10 +923,13 @@ fn test_health_response_roundtrip_custom() {
         status: "degraded".to_string(),
         version: "0.5.0-beta".to_string(),
         compute_mode: "cpu".to_string(),
+        model_loaded: true,
+        uptime_sec: 10.0,
     };
     let json = serde_json::to_string(&response).expect("serialize");
     let rt: HealthResponse = serde_json::from_str(&json).expect("deserialize");
     assert_eq!(rt.status, "degraded");
+    assert!(rt.model_loaded);
 }
 
 #[test]
@@ -1535,6 +1538,8 @@ fn test_empty_strings_everywhere() {
         status: String::new(),
         version: String::new(),
         compute_mode: "cpu".to_string(),
+        model_loaded: false,
+        uptime_sec: 0.0,
     };
     let json = serde_json::to_string(&response).expect("serialize");
     let rt: HealthResponse = serde_json::from_str(&json).expect("deserialize");

--- a/crates/aprender-serve/tests/api_integration.rs
+++ b/crates/aprender-serve/tests/api_integration.rs
@@ -53,7 +53,9 @@ async fn test_health_endpoint_returns_200() {
 
     let body = response.into_body().collect().await.unwrap().to_bytes();
     let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
-    assert_eq!(json["status"], "healthy");
+    assert_eq!(json["status"], "ok");
+    assert_eq!(json["model_loaded"], true);
+    assert!(json["uptime_sec"].as_f64().unwrap() > 0.0);
 }
 
 #[tokio::test]

--- a/crates/aprender-serve/tests/falsification_crux_c_34.rs
+++ b/crates/aprender-serve/tests/falsification_crux_c_34.rs
@@ -1,0 +1,323 @@
+//! CRUX-C-34 falsification tests — `/health`, `/health/live`, `/health/ready`.
+//!
+//! Contract: `contracts/crux-C-34-v1.yaml` (competitor parity: vLLM + llama.cpp
+//! server + k8s probe idioms).
+//!
+//! These tests exercise the axum router via `tower::ServiceExt::oneshot` so
+//! they run entirely in-process (no TCP, no network). Every gate below is
+//! enforced on the same router the `apr serve` CLI builds.
+
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+};
+use http_body_util::BodyExt;
+use realizar::api::{create_router, AppState};
+use std::sync::Mutex;
+use tower::ServiceExt;
+
+/// Serializes every test that reads or writes `APR_TEST_FORCE_LOADING` so the
+/// process-wide env var can't bleed between parallel tokio tests.
+/// FALSIFY-001/004 tests expect the env var *unset*; FALSIFY-005 tests set it.
+/// Both sides take this lock.
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+fn router_with_model() -> axum::Router {
+    let state = AppState::demo().expect("demo state should build");
+    create_router(state)
+}
+
+fn router_without_model() -> axum::Router {
+    let state = AppState::demo_mock().expect("mock state should build");
+    create_router(state)
+}
+
+fn get(uri: &str) -> Request<Body> {
+    Request::builder()
+        .method("GET")
+        .uri(uri)
+        .body(Body::empty())
+        .expect("request build")
+}
+
+async fn json_body(resp: axum::http::Response<Body>) -> serde_json::Value {
+    let bytes = resp
+        .into_body()
+        .collect()
+        .await
+        .expect("collect")
+        .to_bytes();
+    serde_json::from_slice(&bytes).expect("json decode")
+}
+
+// ---------------------------------------------------------------------------
+// FALSIFY-CRUX-C-34-001: GET /health returns 200 with contract-shaped body.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn falsify_crux_c_34_001_health_schema_200() {
+    let _guard = ENV_LOCK.lock().expect("env lock");
+    let app = router_with_model();
+    let resp = app.oneshot(get("/health")).await.expect("oneshot");
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "FALSIFY-CRUX-C-34-001: ready server must return 200 on /health"
+    );
+    let json = json_body(resp).await;
+
+    let status = json["status"].as_str().expect("status is string");
+    assert_eq!(
+        status, "ok",
+        "FALSIFY-CRUX-C-34-001: ready server body.status must be \"ok\""
+    );
+    assert_eq!(
+        json["model_loaded"].as_bool(),
+        Some(true),
+        "FALSIFY-CRUX-C-34-001: demo() state has a model loaded"
+    );
+    let uptime = json["uptime_sec"].as_f64().expect("uptime_sec is number");
+    assert!(
+        uptime > 0.0,
+        "FALSIFY-CRUX-C-34-001: uptime_sec must be strictly positive, got {uptime}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// FALSIFY-CRUX-C-34-002: body.status ∈ {ok, loading, degraded} — enum check.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn falsify_crux_c_34_002_status_enum_ready() {
+    let _guard = ENV_LOCK.lock().expect("env lock");
+    let app = router_with_model();
+    let resp = app.oneshot(get("/health")).await.expect("oneshot");
+    let json = json_body(resp).await;
+    let status = json["status"].as_str().expect("string");
+    assert!(
+        matches!(status, "ok" | "loading" | "degraded"),
+        "FALSIFY-CRUX-C-34-002: status \"{status}\" ∉ {{ok, loading, degraded}}"
+    );
+}
+
+#[tokio::test]
+async fn falsify_crux_c_34_002_status_enum_loading() {
+    let _guard = ENV_LOCK.lock().expect("env lock");
+    // No model resident ⇒ status must be the "loading" enum variant, not a
+    // free-form string like the legacy "healthy".
+    let app = router_without_model();
+    let resp = app.oneshot(get("/health")).await.expect("oneshot");
+    let json = json_body(resp).await;
+    let status = json["status"].as_str().expect("string");
+    assert_eq!(
+        status, "loading",
+        "FALSIFY-CRUX-C-34-002: unloaded server must report status=\"loading\""
+    );
+    assert!(
+        matches!(status, "ok" | "loading" | "degraded"),
+        "FALSIFY-CRUX-C-34-002: status \"{status}\" ∉ {{ok, loading, degraded}}"
+    );
+}
+
+#[tokio::test]
+async fn falsify_crux_c_34_002_loading_returns_503() {
+    let _guard = ENV_LOCK.lock().expect("env lock");
+    let app = router_without_model();
+    let resp = app.oneshot(get("/health")).await.expect("oneshot");
+    // Contract §health_response_schema: status==503 ⇔ body.status ∈ {loading, degraded}.
+    assert_eq!(
+        resp.status(),
+        StatusCode::SERVICE_UNAVAILABLE,
+        "FALSIFY-CRUX-C-34-002: loading state must map to HTTP 503"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// FALSIFY-CRUX-C-34-003: uptime_sec is strictly monotonic across GETs.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn falsify_crux_c_34_003_uptime_monotonic() {
+    let _guard = ENV_LOCK.lock().expect("env lock");
+    // Two sequential oneshots on the SAME process must see uptime_sec advance.
+    // Router is rebuilt each call but the OnceLock<Instant> is process-wide,
+    // so start time is shared.
+    let a = router_with_model()
+        .oneshot(get("/health"))
+        .await
+        .expect("oneshot 1");
+    let json_a = json_body(a).await;
+    let u1 = json_a["uptime_sec"].as_f64().expect("u1");
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    let b = router_with_model()
+        .oneshot(get("/health"))
+        .await
+        .expect("oneshot 2");
+    let json_b = json_body(b).await;
+    let u2 = json_b["uptime_sec"].as_f64().expect("u2");
+
+    assert!(
+        u2 > u1,
+        "FALSIFY-CRUX-C-34-003: uptime must strictly increase, got u1={u1} u2={u2}"
+    );
+    let delta = u2 - u1;
+    assert!(
+        (0.01..=5.0).contains(&delta),
+        "FALSIFY-CRUX-C-34-003: delta {delta}s outside plausible [0.01, 5.0] window"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// FALSIFY-CRUX-C-34-004: /health/live (liveness) + /health/ready (readiness).
+// k8s idioms: /health/live is always-200 once bound; /health/ready gates on
+// model_loaded == true.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn falsify_crux_c_34_004_live_always_200_ready_server() {
+    let _guard = ENV_LOCK.lock().expect("env lock");
+    // Ready server: /health/live MUST return 200 (process is alive).
+    let app = router_with_model();
+    let resp = app.oneshot(get("/health/live")).await.expect("oneshot");
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "FALSIFY-CRUX-C-34-004: /health/live must return 200 on a ready server"
+    );
+}
+
+#[tokio::test]
+async fn falsify_crux_c_34_004_live_always_200_loading_server() {
+    let _guard = ENV_LOCK.lock().expect("env lock");
+    // Even when model is NOT loaded, /health/live MUST still return 200 —
+    // this is what makes it a valid k8s liveness probe (process is alive
+    // regardless of model readiness).
+    let app = router_without_model();
+    let resp = app.oneshot(get("/health/live")).await.expect("oneshot");
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "FALSIFY-CRUX-C-34-004: /health/live must return 200 even when model not loaded"
+    );
+}
+
+#[tokio::test]
+async fn falsify_crux_c_34_004_ready_200_when_model_loaded() {
+    let _guard = ENV_LOCK.lock().expect("env lock");
+    let app = router_with_model();
+    let resp = app.oneshot(get("/health/ready")).await.expect("oneshot");
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "FALSIFY-CRUX-C-34-004: /health/ready must return 200 iff model is loaded"
+    );
+}
+
+#[tokio::test]
+async fn falsify_crux_c_34_004_ready_503_when_no_model() {
+    let _guard = ENV_LOCK.lock().expect("env lock");
+    let app = router_without_model();
+    let resp = app.oneshot(get("/health/ready")).await.expect("oneshot");
+    assert_eq!(
+        resp.status(),
+        StatusCode::SERVICE_UNAVAILABLE,
+        "FALSIFY-CRUX-C-34-004: /health/ready must return 503 when no model (k8s readiness)"
+    );
+}
+
+#[tokio::test]
+async fn falsify_crux_c_34_004_main_health_agrees_with_ready() {
+    let _guard = ENV_LOCK.lock().expect("env lock");
+    // If /health==200 (status=ok) then /health/ready MUST also be 200.
+    let app_ready = router_with_model();
+    let main = app_ready.oneshot(get("/health")).await.expect("oneshot");
+    assert_eq!(main.status(), StatusCode::OK);
+    let main_json = json_body(main).await;
+    assert_eq!(main_json["status"].as_str(), Some("ok"));
+
+    let app_ready2 = router_with_model();
+    let ready = app_ready2
+        .oneshot(get("/health/ready"))
+        .await
+        .expect("oneshot");
+    assert_eq!(
+        ready.status(),
+        StatusCode::OK,
+        "FALSIFY-CRUX-C-34-004: /health=ok implies /health/ready=200"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// FALSIFY-CRUX-C-34-005: startup loading state observable via test-only env.
+// APR_TEST_FORCE_LOADING=1 forces status=loading + HTTP 503, independent of
+// model presence. This gives k8s operators and our own integration harness a
+// way to exercise the loading branch without racing against real model init.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn falsify_crux_c_34_005_force_loading_env_flips_status() {
+    let _guard = ENV_LOCK.lock().expect("env lock");
+
+    let prior = std::env::var("APR_TEST_FORCE_LOADING").ok();
+    // SAFETY: std::env::{set_var, remove_var} are marked unsafe as of the
+    // 2024 edition due to threading concerns. We serialize access through
+    // ENV_LOCK above, and the env var is scoped to this single test.
+    unsafe {
+        std::env::set_var("APR_TEST_FORCE_LOADING", "1");
+    }
+
+    // Even with a model loaded, the force-loading hook MUST dominate.
+    let app = router_with_model();
+    let resp = app.oneshot(get("/health")).await.expect("oneshot");
+    let status = resp.status();
+    let json = json_body(resp).await;
+
+    // Restore env before asserting (so a panic still cleans up).
+    unsafe {
+        match prior {
+            Some(v) => std::env::set_var("APR_TEST_FORCE_LOADING", v),
+            None => std::env::remove_var("APR_TEST_FORCE_LOADING"),
+        }
+    }
+
+    assert_eq!(
+        status,
+        StatusCode::SERVICE_UNAVAILABLE,
+        "FALSIFY-CRUX-C-34-005: APR_TEST_FORCE_LOADING=1 must force HTTP 503"
+    );
+    assert_eq!(
+        json["status"].as_str(),
+        Some("loading"),
+        "FALSIFY-CRUX-C-34-005: APR_TEST_FORCE_LOADING=1 must force body.status=loading"
+    );
+}
+
+#[tokio::test]
+async fn falsify_crux_c_34_005_force_loading_ready_is_503() {
+    let _guard = ENV_LOCK.lock().expect("env lock");
+    // The readiness probe MUST also flip to 503 under the force-loading hook.
+
+    let prior = std::env::var("APR_TEST_FORCE_LOADING").ok();
+    unsafe {
+        std::env::set_var("APR_TEST_FORCE_LOADING", "1");
+    }
+
+    let app = router_with_model();
+    let resp = app.oneshot(get("/health/ready")).await.expect("oneshot");
+    let status = resp.status();
+
+    unsafe {
+        match prior {
+            Some(v) => std::env::set_var("APR_TEST_FORCE_LOADING", v),
+            None => std::env::remove_var("APR_TEST_FORCE_LOADING"),
+        }
+    }
+
+    assert_eq!(
+        status,
+        StatusCode::SERVICE_UNAVAILABLE,
+        "FALSIFY-CRUX-C-34-005: force-loading must also flip /health/ready to 503"
+    );
+}

--- a/crates/aprender-serve/tests/integration_api.rs
+++ b/crates/aprender-serve/tests/integration_api.rs
@@ -60,7 +60,7 @@ async fn test_real_server_health_endpoint() {
     assert_eq!(resp.status(), 200);
 
     let body: Value = resp.json().await.expect("json");
-    assert_eq!(body["status"], "healthy");
+    assert_eq!(body["status"], "ok");
 
     handle.abort();
 }

--- a/crates/aprender-serve/tests/property_api.rs
+++ b/crates/aprender-serve/tests/property_api.rs
@@ -21,14 +21,18 @@ use realizar::api::{
 #[test]
 fn test_health_response_creation() {
     let resp = HealthResponse {
-        status: "healthy".to_string(),
+        status: "ok".to_string(),
         version: "1.0.0".to_string(),
         compute_mode: "cpu".to_string(),
+        model_loaded: true,
+        uptime_sec: 1.5,
     };
 
-    assert_eq!(resp.status, "healthy");
+    assert_eq!(resp.status, "ok");
     assert_eq!(resp.version, "1.0.0");
     assert_eq!(resp.compute_mode, "cpu");
+    assert!(resp.model_loaded);
+    assert_eq!(resp.uptime_sec, 1.5);
 }
 
 #[test]
@@ -37,13 +41,16 @@ fn test_health_response_serialization() {
         status: "ok".to_string(),
         version: "2.0.0".to_string(),
         compute_mode: "cpu".to_string(),
+        model_loaded: true,
+        uptime_sec: 2.0,
     };
 
     let json = serde_json::to_string(&resp).unwrap();
-    assert!(json.contains("ok"));
+    assert!(json.contains("\"ok\""));
 
     let parsed: HealthResponse = serde_json::from_str(&json).unwrap();
     assert_eq!(parsed.status, "ok");
+    assert!(parsed.model_loaded);
 }
 
 proptest! {
@@ -52,13 +59,23 @@ proptest! {
     #[test]
     fn prop_health_response_roundtrip(
         status in "[a-z]{3,20}",
-        version in "[0-9]+\\.[0-9]+\\.[0-9]+"
+        version in "[0-9]+\\.[0-9]+\\.[0-9]+",
+        model_loaded in any::<bool>(),
+        uptime_sec in 0.0f64..1e6,
     ) {
-        let resp = HealthResponse { status: status.clone(), version: version.clone(), compute_mode: "cpu".to_string() };
+        let resp = HealthResponse {
+            status: status.clone(),
+            version: version.clone(),
+            compute_mode: "cpu".to_string(),
+            model_loaded,
+            uptime_sec,
+        };
         let json = serde_json::to_string(&resp).unwrap();
         let parsed: HealthResponse = serde_json::from_str(&json).unwrap();
         prop_assert_eq!(parsed.status, status);
         prop_assert_eq!(parsed.version, version);
+        prop_assert_eq!(parsed.model_loaded, model_loaded);
+        prop_assert!((parsed.uptime_sec - uptime_sec).abs() < 1e-9);
     }
 }
 


### PR DESCRIPTION
## Contract

**`contracts/crux-C-34-v1.yaml`** promoted `1.0.0-draft` → `1.0.0` ACTIVE, `intake_status: partial → supported`. Master inventory (`crux-competitive-research-ux-v1.yaml`) bumped: **supported 39→40, partial 71→70**.

`pv validate` green on both.

## Scope honesty

Implements `apr serve` `/health`, `/health/live`, `/health/ready` with the exact CRUX-C-34 contract schema + k8s probe idioms. Bash FALSIFY recipes in the contract are kept for operator/external-CI dogfood; the in-tree discharge is **12 Rust tests** hitting the same axum router `apr serve` builds.

Not in scope: prometheus-scoped counters, third-party backend liveness polling, `/health?wait=N` blocking variant. Out of scope stays out.

## Summary

- `api::types::HealthResponse` now matches contract schema: `{status ∈ {"ok","loading","degraded"}, model_loaded: bool, uptime_sec: float>0, version, compute_mode}`.
- `HTTP 200` ⇔ `body.status == "ok"`; `HTTP 503` ⇔ `body.status ∈ {loading, degraded}`.
- `GET /health/live` always returns 200 once bound (k8s liveness).
- `GET /health/ready` returns 200 iff `status==ok AND model_loaded==true`, else 503 (k8s readiness).
- `APR_TEST_FORCE_LOADING=1` forces loading branch for FALSIFY-005 observability (no feature gate — the hook must exist in every build so k8s smokes + CI can dispatch it).
- `server_uptime_sec()` uses process-wide `OnceLock<Instant>` — monotonic by Rust contract → FALSIFY-003 by construction.
- `AppState::model_loaded()` checks every model-holding `Option` across cpu / `cfg(feature="gpu")` / `cfg(feature="cuda")` gates.

## Discharge evidence

`crates/aprender-serve/tests/falsification_crux_c_34.rs` — 12 tests, in-process axum via `tower::ServiceExt::oneshot`, no TCP:

| Gate | Tests |
| --- | --- |
| FALSIFY-CRUX-C-34-001 (schema+200 ready) | 1 |
| FALSIFY-CRUX-C-34-002 (enum + loading + 503) | 3 |
| FALSIFY-CRUX-C-34-003 (uptime monotonic) | 1 |
| FALSIFY-CRUX-C-34-004 (/live always-200, /ready gates) | 5 |
| FALSIFY-CRUX-C-34-005 (APR_TEST_FORCE_LOADING override) | 2 |

Single `ENV_LOCK: Mutex<()>` serializes every test that reads the env var so parallel tokio tasks can't bleed.

Plus `15096` pre-existing lib tests pass unchanged. Three legacy `test_health_endpoint` tests were rebound to `create_test_app()` (model present) since the contract now correctly returns 503 on mock state; one deserde round-trip was widened with the two new fields.

## Test plan

- [x] `cargo test -p aprender-serve --lib` — 15096 pass, 0 fail
- [x] `cargo test -p aprender-serve --test falsification_crux_c_34` — 12 pass, 0 fail
- [x] `cargo fmt --all -- --check`
- [x] `pv validate contracts/crux-C-34-v1.yaml`
- [x] `pv validate contracts/crux-competitive-research-ux-v1.yaml`

## Pre-existing failures (out of scope)

`tests/parity_contract_falsify.rs` and `tests/fusion_gate_contract_falsify.rs` have broken `include_str!` paths from the APR-MONO Phase 2c subtree merge (`../../aprender/contracts/…`). Confirmed present on `origin/main`. Separate ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)