### PR TITLE
feat(pretrain): task #124 — regime-aware INV-TRAIN-005 epoch-zero cap

### DIFF
--- a/contracts/training-loop-pretrain-v1.yaml
+++ b/contracts/training-loop-pretrain-v1.yaml
@@ -35,17 +35,24 @@
 # ─────────────────────────────────────────────────────────────
 
 contract_id: C-TRAIN-PRETRAIN
-version: 1.1.0
+version: 1.2.0
 status: ACTIVE
 
 metadata:
-  version: "1.1.0"
+  version: "1.2.0"
   created: "2026-04-18"
-  updated: "2026-04-19"
+  updated: "2026-04-20"
   changelog:
     - "1.1.0 (2026-04-19): GATE-TRAIN-006 / INV-TRAIN-006 discharged via
        falsify_ship_021_* Rust tests; seed-plumbing race fixed by
        lock_init_seed mutex in transformer/init.rs; status PROPOSED → ACTIVE"
+    - "1.2.0 (2026-04-20): INV-TRAIN-005 / GATE-TRAIN-005 epoch-zero cap
+       becomes regime-dependent — `finetune` keeps the MODEL-1 literal
+       10.0, `from_scratch` uses 2.0 × ln(vocab_size). Motivation: task
+       #119 smoke run tripped the guard because uniform-random baseline
+       for vocab=50257 is ln(50257) ≈ 10.82, already over a hardcoded
+       10.0. The doubling rule at N ≥ 1 is unchanged across regimes.
+       Falsifier FALSIFY-SHIP-021B covers the from_scratch regime."
   author: PAIML Engineering
   description: >
     Pretraining loop contract: required per-step metrics, required
@@ -151,18 +158,34 @@ non_divergence:
         status = FAIL
         exit_code = nonzero
 
-    Special case for N == 1:
-      if val_loss[0] > 10.0 OR val_loss[0] is NaN/Inf:
-        abort immediately after epoch 0
+    Special case for N == 0 (regime-dependent, v1.2.0):
+      FINETUNE regime (base weights already pretrained):
+        if val_loss[0] > 10.0 OR val_loss[0] is NaN/Inf:
+          abort immediately after epoch 0
+      FROM_SCRATCH regime (random init, vocab-dependent baseline):
+        if val_loss[0] > 2.0 * ln(vocab_size) OR val_loss[0] is NaN/Inf:
+          abort immediately after epoch 0
 
-    The check is MANDATORY and UNCONFIGURABLE. There is NO flag to
-    disable it. There is NO "warning" mode. Exceeding the threshold
-    is always fatal.
+    Rationale for the regime split: uniform-random baseline for a
+    vocab_size-V next-token predictor is ln(V). For V=50257 that is
+    10.82 — already over the MODEL-1 literal 10.0 before any training.
+    A finetune start should be much lower than ln(V) (base weights
+    already learned token distribution); a from-scratch start should
+    be within 2× ln(V) for the init to be considered usable. The 2×
+    safety margin catches truly broken inits (val_loss[0] > 2·ln(V)
+    means the model is worse than random by a log-factor).
 
-    Rationale: MODEL-1 v2 crossed this exact threshold silently
-    (val_loss 31.99 vs a healthy baseline of ~3.5 expected after
-    epoch 0). A compile-time-enforced abort would have saved 14
-    days and all downstream distillation compute.
+    The check is MANDATORY. The regime is configurable (operator
+    picks finetune vs from_scratch) but the thresholds for each
+    regime are not. There is NO "warning" mode. Exceeding the
+    chosen-regime threshold is always fatal.
+
+    Historical context: MODEL-1 v2 was a FINETUNE run (base weights
+    were Qwen2.5-Coder-7B-Instruct, already pretrained) and crossed
+    val_loss=31.99 — 3× the finetune threshold. The regime split
+    here does not weaken the MODEL-1 lesson: a finetune with
+    val_loss[0] > 10.0 still aborts. It only permits the from-scratch
+    case (MODEL-2 370M) to start above 10.0 without false abort.
 
 # ─────────────────────────────────────────────────────────────
 # Invariants — machine-checkable properties of the training loop
@@ -214,16 +237,23 @@ invariants:
 
   - id: INV-TRAIN-005
     description: >
-      NON-DIVERGENCE (the MODEL-1 lesson): for every epoch boundary
-      N ≥ 1, val_loss[N] ≤ 2.0 × val_loss[N-1]. For N == 1,
-      val_loss[0] is finite and ≤ 10.0. Any violation triggers an
-      immediate abort with exit status = DIVERGENCE.
+      NON-DIVERGENCE (the MODEL-1 lesson, regime-aware in v1.2.0):
+      for every epoch boundary N ≥ 1, val_loss[N] ≤ 2.0 × val_loss[N-1].
+      For N == 0, val_loss[0] is finite AND ≤ regime-dependent cap:
+        - finetune    regime: 10.0 (MODEL-1 literal)
+        - from_scratch regime: 2.0 × ln(vocab_size)
+      Any violation triggers an immediate abort with exit status =
+      DIVERGENCE.
     falsifier: >
-      Artificial harness: inject a synthetic epoch log where
-      val_loss doubles (e.g. [3.5, 7.1]). Run the training-loop
-      guard function; assert it returns Err(DivergenceAbort) and
-      the CLI exits nonzero. If the guard permits the run to
-      continue, this contract is violated.
+      Two harnesses (regime coverage):
+      (a) finetune regime: inject `[3.5, 7.1]` as val-loss trace,
+          assert `check_non_divergence(1, trace, Finetune)` returns
+          Err(Divergence). Inject `[11.0]`, assert epoch-0 abort.
+      (b) from_scratch regime: for vocab_size=50257 (ln ≈ 10.82,
+          2·ln ≈ 21.64), assert `check_non_divergence(0, [18.0],
+          FromScratch{vocab_size: 50257})` returns Ok (below cap)
+          but `check_non_divergence(0, [25.0], FromScratch{...})`
+          returns Err. Same doubling rule at N ≥ 1 in both regimes.
 
   - id: INV-TRAIN-006
     description: >
@@ -315,19 +345,27 @@ gates:
 
   - id: GATE-TRAIN-005
     rule: >
-      NON-DIVERGENCE: val_loss[N] ≤ 2.0 × val_loss[N-1] at every
-      epoch boundary; val_loss[0] ≤ 10.0 and finite (INV-TRAIN-005).
-      This is the MODEL-1 v2 lesson codified as a ship-blocker.
+      NON-DIVERGENCE (regime-aware in v1.2.0): val_loss[N] ≤ 2.0 ×
+      val_loss[N-1] at every epoch boundary N ≥ 1; val_loss[0] finite
+      AND ≤ regime-dependent cap (finetune: 10.0; from_scratch: 2·ln
+      vocab_size). INV-TRAIN-005. MODEL-1 v2 ship-blocker retained.
     evidence_required: >
       (1) Live: the training CLI exits nonzero with status =
       DIVERGENCE the moment the threshold is crossed — proven by a
-      harness test that synthesizes a doubling val_loss trace.
+      harness test that synthesizes a doubling val_loss trace AND
+      by regime-specific epoch-0 tests (finetune over 10.0 aborts,
+      from_scratch over 2·ln(vocab_size) aborts but within cap passes).
       (2) Post-hoc: `apr qa --check-non-divergence {run_dir}` over
       the real training run exits 0 for a shipped checkpoint.
     verdict: pass
     binds_to: AC-SHIP2-003
     ship_blocking: true
     motivation: "memory/project_ship_two_001_model1_qlora_divergence.md"
+    evidence_discharged_by:
+      - "crates/aprender-train/src/train/pretrain.rs::tests::gate_train_005_aborts_on_doubling_val_loss"
+      - "crates/aprender-train/src/train/pretrain.rs::tests::gate_train_005_aborts_on_epoch_zero_blowup"
+      - "crates/aprender-train/src/train/pretrain.rs::tests::gate_train_005_from_scratch_permits_near_random_baseline"
+      - "crates/aprender-train/src/train/pretrain.rs::tests::gate_train_005_from_scratch_aborts_above_2_ln_vocab"
 
   - id: GATE-TRAIN-006
     rule: >

--- a/crates/apr-cli/src/commands/pretrain.rs
+++ b/crates/apr-cli/src/commands/pretrain.rs
@@ -83,6 +83,8 @@ pub(crate) fn run(
         target_val_loss,
         patience_epochs: 2,
         min_epochs_before_early_stop: 1,
+        // v1.2.0: default to Finetune until #125 wires a --regime CLI flag.
+        regime: entrenar::train::pretrain::TrainingRegime::Finetune,
     };
 
     if !json_output {

--- a/crates/aprender-train/src/train/mod.rs
+++ b/crates/aprender-train/src/train/mod.rs
@@ -64,7 +64,7 @@ pub use metrics::{Accuracy, F1Score, Metric, Precision, R2Score, Recall, MAE, RM
 pub use pretrain::{
     check_non_divergence, check_numerical_stability, CheckpointFn, EpochArtifact, EpochMetadata,
     LinearDecaySynthetic, NanAtStepSynthetic, PretrainAbort, PretrainConfig, PretrainLoop,
-    RunStatus, ScriptedVal, StepFn, StepMetrics, ValFn, DIVERGENCE_RATIO_LIMIT,
+    RunStatus, ScriptedVal, StepFn, StepMetrics, TrainingRegime, ValFn, DIVERGENCE_RATIO_LIMIT,
     EPOCH_ZERO_VAL_LOSS_LIMIT,
 };
 pub use trainer::{TrainResult, Trainer};

--- a/crates/aprender-train/src/train/pretrain.rs
+++ b/crates/aprender-train/src/train/pretrain.rs
@@ -216,29 +216,78 @@ impl EpochArtifact {
 /// `non_divergence.rule` block in `training-loop-pretrain-v1.yaml`.
 pub const DIVERGENCE_RATIO_LIMIT: f32 = 2.0;
 
-/// Hard cap on `val_loss[0]`. The contract literal is 10.0. Beyond this
-/// the loop aborts even without a prior epoch to compare against — the
-/// MODEL-1 v2 failure mode.
+/// Finetune-regime hard cap on `val_loss[0]`. The contract literal is
+/// 10.0 (MODEL-1 v2 failure mode: val_loss=31.99 at epoch 0 with base
+/// weights already pretrained). Kept as the `TrainingRegime::Finetune`
+/// threshold so downstream callers and tests can still refer to the
+/// literal.
 pub const EPOCH_ZERO_VAL_LOSS_LIMIT: f32 = 10.0;
+
+/// Training regime selects which epoch-zero val_loss cap INV-TRAIN-005
+/// enforces. The doubling rule at N ≥ 1 is identical across regimes.
+///
+/// Contract: `training-loop-pretrain-v1.yaml` v1.2.0 `non_divergence`.
+///
+/// - [`TrainingRegime::Finetune`] — base weights pretrained; epoch-zero
+///   cap is 10.0, matching the MODEL-1 literal.
+/// - [`TrainingRegime::FromScratch`] — random init; epoch-zero cap is
+///   `2.0 × ln(vocab_size)`, i.e. 2× the uniform-random cross-entropy
+///   baseline. For vocab=50257 the cap is ≈21.64.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum TrainingRegime {
+    Finetune,
+    FromScratch { vocab_size: u32 },
+}
+
+impl TrainingRegime {
+    /// Regime-dependent cap on `val_loss[0]` — the v1.2.0 amendment.
+    ///
+    /// Finetune: [`EPOCH_ZERO_VAL_LOSS_LIMIT`] (10.0, MODEL-1 literal).
+    /// FromScratch: `DIVERGENCE_RATIO_LIMIT × ln(vocab_size)`. For
+    /// `vocab_size=50257` this is ≈21.64. `vocab_size < 2` is clamped
+    /// to 2 so `ln` stays positive — operator misuse, not worth a panic.
+    pub fn epoch_zero_val_loss_limit(&self) -> f32 {
+        match self {
+            Self::Finetune => EPOCH_ZERO_VAL_LOSS_LIMIT,
+            Self::FromScratch { vocab_size } => {
+                let v = (*vocab_size).max(2) as f32;
+                DIVERGENCE_RATIO_LIMIT * v.ln()
+            }
+        }
+    }
+}
+
+impl Default for TrainingRegime {
+    fn default() -> Self {
+        Self::Finetune
+    }
+}
 
 /// GATE-TRAIN-005 — the non-divergence guard, verbatim from the contract.
 ///
 /// For every epoch boundary N ≥ 1, check that `val_loss[N] ≤ 2.0 × val_loss[N-1]`.
-/// For N == 0, check that `val_loss[0]` is finite and ≤ `EPOCH_ZERO_VAL_LOSS_LIMIT`.
+/// For N == 0, check that `val_loss[0]` is finite and within the
+/// regime-dependent cap (see [`TrainingRegime::epoch_zero_val_loss_limit`]).
 /// Any violation returns `Err(PretrainAbort::Divergence{,AtEpochZero})`.
 ///
 /// This function is the falsifier harness for `FALSIFY-SHIP-013`:
 /// inject `[3.5, 7.1]` as the val-loss trace, call this on N=1, and the
-/// return value MUST be `Err(Divergence)`. See the unit test below.
-pub fn check_non_divergence(epoch: usize, val_loss_history: &[f32]) -> Result<(), PretrainAbort> {
+/// return value MUST be `Err(Divergence)`. See the unit tests below.
+pub fn check_non_divergence(
+    epoch: usize,
+    val_loss_history: &[f32],
+    regime: &TrainingRegime,
+) -> Result<(), PretrainAbort> {
     let Some(&curr) = val_loss_history.get(epoch) else {
         // Nothing at this epoch yet — caller error, not divergence.
         return Ok(());
     };
 
-    // Special case N == 0.
+    // Special case N == 0 — regime-dependent cap (v1.2.0).
     if epoch == 0 {
-        if !curr.is_finite() || curr > EPOCH_ZERO_VAL_LOSS_LIMIT {
+        let cap = regime.epoch_zero_val_loss_limit();
+        if !curr.is_finite() || curr > cap {
             return Err(PretrainAbort::DivergenceAtEpochZero { val_loss: curr });
         }
         return Ok(());
@@ -334,11 +383,17 @@ pub struct PretrainConfig {
     pub patience_epochs: usize,
     /// Minimum epochs before early-stop can trigger (contract default 3).
     pub min_epochs_before_early_stop: usize,
+    /// INV-TRAIN-005 regime — selects the epoch-zero val_loss cap.
+    /// Defaults to `Finetune` (10.0) to preserve v1.1.0 behavior.
+    #[serde(default)]
+    pub regime: TrainingRegime,
 }
 
 impl PretrainConfig {
     /// Recipe that aligns with the MODEL-1 v2 post-mortem remedy:
-    /// LR=5e-5, rank=32 (moot here — not LoRA), seed=42.
+    /// LR=5e-5, rank=32 (moot here — not LoRA), seed=42. Defaults
+    /// `regime` to `Finetune` (MODEL-1-style). Use
+    /// [`PretrainConfig::from_scratch`] to flip to the MODEL-2 regime.
     pub fn model_2_defaults(
         dataset_path: PathBuf,
         tokenizer_dir: PathBuf,
@@ -361,6 +416,7 @@ impl PretrainConfig {
             target_val_loss: 2.2,
             patience_epochs: 2,
             min_epochs_before_early_stop: 3,
+            regime: TrainingRegime::Finetune,
         }
     }
 }
@@ -569,7 +625,8 @@ impl<S: StepFn, V: ValFn> PretrainLoop<S, V> {
         self.val_loss_history.push(val_loss);
 
         // GATE-TRAIN-005 — ship-blocking divergence guard.
-        check_non_divergence(epoch, &self.val_loss_history)?;
+        // v1.2.0: epoch-zero cap is regime-dependent.
+        check_non_divergence(epoch, &self.val_loss_history, &self.config.regime)?;
 
         let wall_seconds = t0.elapsed().as_secs_f32();
         // INV-TRAIN-003: prefer the real AdamW-state digest if the
@@ -768,6 +825,7 @@ mod tests {
             target_val_loss: 2.2,
             patience_epochs: 2,
             min_epochs_before_early_stop: 1,
+            regime: TrainingRegime::Finetune,
         }
     }
 
@@ -778,7 +836,7 @@ mod tests {
     #[test]
     fn gate_train_005_aborts_on_doubling_val_loss() {
         let trace = vec![3.5, 7.1];
-        let res = check_non_divergence(1, &trace);
+        let res = check_non_divergence(1, &trace, &TrainingRegime::Finetune);
         match res {
             Err(PretrainAbort::Divergence { epoch, prev_val_loss, curr_val_loss, ratio }) => {
                 assert_eq!(epoch, 1);
@@ -795,7 +853,7 @@ mod tests {
     #[test]
     fn gate_train_005_aborts_on_epoch_zero_blowup() {
         let trace = vec![31.99];
-        let res = check_non_divergence(0, &trace);
+        let res = check_non_divergence(0, &trace, &TrainingRegime::Finetune);
         match res {
             Err(PretrainAbort::DivergenceAtEpochZero { val_loss }) => {
                 assert!((val_loss - 31.99).abs() < 1e-4);
@@ -809,7 +867,7 @@ mod tests {
     fn gate_train_005_allows_healthy_decrease() {
         let trace = vec![3.5, 3.0, 2.5, 2.2];
         for epoch in 0..trace.len() {
-            assert!(check_non_divergence(epoch, &trace).is_ok());
+            assert!(check_non_divergence(epoch, &trace, &TrainingRegime::Finetune).is_ok());
         }
     }
 
@@ -817,7 +875,62 @@ mod tests {
     #[test]
     fn gate_train_005_allows_exact_two_x() {
         let trace = vec![2.0, 4.0];
-        assert!(check_non_divergence(1, &trace).is_ok());
+        assert!(check_non_divergence(1, &trace, &TrainingRegime::Finetune).is_ok());
+    }
+
+    // ── INV-TRAIN-005 v1.2.0 regime split — from_scratch epoch-zero cap ──
+
+    /// v1.2.0: from_scratch epoch-zero cap is 2·ln(vocab_size). For
+    /// vocab=50257 this is ≈21.64. `val_loss[0]=18.0` is below cap and
+    /// would trip the old 10.0 literal — must be allowed in the new regime.
+    #[test]
+    fn gate_train_005_from_scratch_permits_near_random_baseline() {
+        let trace = vec![18.0_f32];
+        let regime = TrainingRegime::FromScratch { vocab_size: 50_257 };
+        assert!(
+            check_non_divergence(0, &trace, &regime).is_ok(),
+            "val_loss[0]=18 must be within 2·ln(50257)≈21.64 from_scratch cap"
+        );
+        // Same trace under Finetune still aborts — regime split is not a weakening.
+        assert!(matches!(
+            check_non_divergence(0, &trace, &TrainingRegime::Finetune),
+            Err(PretrainAbort::DivergenceAtEpochZero { .. }),
+        ));
+    }
+
+    /// v1.2.0: from_scratch above 2·ln(vocab_size) still aborts. Confirms
+    /// the gate is not degenerate — it catches truly broken inits.
+    #[test]
+    fn gate_train_005_from_scratch_aborts_above_2_ln_vocab() {
+        let trace = vec![25.0_f32];
+        let regime = TrainingRegime::FromScratch { vocab_size: 50_257 };
+        match check_non_divergence(0, &trace, &regime) {
+            Err(PretrainAbort::DivergenceAtEpochZero { val_loss }) => {
+                assert!((val_loss - 25.0).abs() < 1e-4);
+            }
+            other => panic!("from_scratch cap missed: got {other:?}"),
+        }
+    }
+
+    /// v1.2.0: the computed cap matches the formula 2·ln(vocab_size).
+    /// Locks the threshold so a silent code change cannot relax it.
+    #[test]
+    fn training_regime_from_scratch_cap_matches_formula() {
+        let v = 50_257u32;
+        let regime = TrainingRegime::FromScratch { vocab_size: v };
+        let expected = DIVERGENCE_RATIO_LIMIT * (v as f32).ln();
+        assert!(
+            (regime.epoch_zero_val_loss_limit() - expected).abs() < 1e-4,
+            "cap formula drift: got {} expected {}",
+            regime.epoch_zero_val_loss_limit(),
+            expected
+        );
+        // Finetune stays on the MODEL-1 literal.
+        assert!(
+            (TrainingRegime::Finetune.epoch_zero_val_loss_limit() - EPOCH_ZERO_VAL_LOSS_LIMIT)
+                .abs()
+                < 1e-6
+        );
     }
 
     // ── GATE-TRAIN-007 falsifier — NaN poisoning ──


### PR DESCRIPTION
## Summary

- Contract `training-loop-pretrain-v1` v1.1.0 → v1.2.0: `INV-TRAIN-005` / `GATE-TRAIN-005` epoch-zero cap is now regime-dependent (`finetune` keeps the MODEL-1 literal 10.0; `from_scratch` uses `2.0 × ln(vocab_size)` ≈ 21.64 for vocab=50257). `pv validate` green.
- New `TrainingRegime` enum threaded through `check_non_divergence`, `PretrainConfig`, `run_epoch`, `test_config`, and all 4 existing call sites. Default `Finetune`.
- 3 new falsifier tests lock the from-scratch regime: near-random baseline passes, >2·ln(vocab) aborts, formula is `2.0 × ln(vocab_size)`.
- CLI `apr pretrain` defaults `regime: Finetune`; task #125 will wire `--mode {finetune|from-scratch}` to flip regime alongside LR / warmup / target_val_loss.

## Why

The hardcoded `val_loss[0] ≤ 10.0` cap was calibrated for MODEL-1 finetuning. Any from-scratch pretrain starts at uniform-random cross-entropy = `ln(vocab_size)` ≈ 10.82 for vocab=50257, so every legitimate cold start trips the divergence abort. This is a blocker for task #119-onwards real-compute pretrain dispatches.

## Test plan

- [x] `pv validate contracts/training-loop-pretrain-v1.yaml` — 0 errors, 0 warnings
- [x] `cargo test -p aprender-contracts --lib` — 1371 pass
- [x] `cargo test -p aprender-train --lib pretrain::` — 22 pass (incl. 3 new)
- [x] `cargo test -p apr-cli --lib pretrain` — 3 pass
- [x] `cargo clippy -p aprender-train --lib --no-deps -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] CI `ci / gate` + `workspace-test` green
- [ ] Auto-merge fires on green checks

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)