### PR TITLE
feat(crux-a-20): --offline flag + algorithm-level discharge (3 of 5 FALSIFY at PARTIAL_ALGORITHM_LEVEL)

### DIFF
--- a/contracts/crux-A-20-v1.yaml
+++ b/contracts/crux-A-20-v1.yaml
@@ -6,11 +6,12 @@
 
 metadata:
   id: CRUX-A-20
-  version: "1.0.0-draft"
+  version: "1.1.0"
   created: "2026-04-18"
+  last_updated: "2026-04-20"
   author: PAIML Engineering
   registry: true
-  status: draft
+  status: partial
   parent_contracts:
   - crux-competitive-research-ux-v1
   category: "A — Model Intake & Discovery"
@@ -93,6 +94,20 @@ falsification_tests:
       head -20 "$TRACE" >&2; exit 1
     }
   if_fails: "APR_OFFLINE=1 did not prevent outbound network I/O"
+  discharge_status: PARTIAL_ALGORITHM_LEVEL
+  evidence_discharged_by:
+    harness: crates/apr-cli/tests/falsification_crux_a_20.rs
+    tests:
+    - falsify_crux_a_20_algo_002_apr_offline_env_triggers_offline
+    - falsify_crux_a_20_algo_002_apr_offline_env_zero_is_false
+    - falsify_crux_a_20_algo_001_dry_run_offline_flag_accepted
+    classifier: crates/apr-cli/src/commands/offline.rs
+    scope: >
+      Algorithm-level discharge: `APR_OFFLINE=1` is observed by the CLI
+      dry-run path and produces `Offline: true` without network I/O;
+      `APR_OFFLINE=0` / empty / unrelated values leave the signal off.
+      NOT YET DISCHARGED: strace-verified zero outbound TCP connects in
+      the full pull path (requires primed cache + real download path).
 
 - id: FALSIFY-CRUX-A-20-002
   rule: HF_HUB_OFFLINE=1 env var is honored (HF compat)
@@ -107,6 +122,19 @@ falsification_tests:
     BAD=$(grep -E 'connect\(.*sin_(addr|port)' "$TRACE" | grep -vE '127\.0\.0\.1|::1|AF_UNIX' | wc -l)
     [ "$BAD" -eq 0 ] || { echo "FAIL: HF_HUB_OFFLINE=1 not honored ($BAD connects)" >&2; exit 1; }
   if_fails: "HF-compatible env var did not trigger offline mode"
+  discharge_status: PARTIAL_ALGORITHM_LEVEL
+  evidence_discharged_by:
+    harness: crates/apr-cli/tests/falsification_crux_a_20.rs
+    tests:
+    - falsify_crux_a_20_algo_003_hf_hub_offline_env_triggers_offline
+    - falsify_crux_a_20_algo_004_all_three_offline_signals_equivalent
+    classifier: crates/apr-cli/src/commands/offline.rs
+    scope: >
+      Algorithm-level discharge: `HF_HUB_OFFLINE=1` is observed by the
+      CLI dry-run path and is observationally equivalent to both
+      `APR_OFFLINE=1` and `--offline` (byte-identical `Offline:` line).
+      NOT YET DISCHARGED: strace-verified zero TCP connects under
+      `HF_HUB_OFFLINE=1` in the full pull path (follow-up network harness).
 
 - id: FALSIFY-CRUX-A-20-003
   rule: offline cache miss exits non-zero with actionable message
@@ -124,6 +152,9 @@ falsification_tests:
     grep -qiE 'cache|not.?found|missing' "$LOG" || { echo "FAIL: no cache-miss keyword" >&2; exit 1; }
     grep -qi 'gpt2\|config.json' "$LOG" || { echo "FAIL: error does not name missing repo/file" >&2; exit 1; }
   if_fails: "offline cache miss lacked non-zero exit or actionable message"
+  # No algorithm-level sub-claim: this gate requires a real cache layer +
+  # populated/empty cache states + actual pull path execution. Discharge
+  # deferred to the follow-up network-gated harness.
 
 - id: FALSIFY-CRUX-A-20-004
   rule: --offline flag is equivalent to APR_OFFLINE=1
@@ -139,6 +170,20 @@ falsification_tests:
     [ "$BAD" -eq 0 ] || { echo "FAIL: --offline flag made $BAD network calls" >&2; exit 1; }
     [ -f "$OUT2/config.json" ] || { echo "FAIL: cached file not materialized" >&2; exit 1; }
   if_fails: "--offline flag did not behave equivalently to env var"
+  discharge_status: PARTIAL_ALGORITHM_LEVEL
+  evidence_discharged_by:
+    harness: crates/apr-cli/tests/falsification_crux_a_20.rs
+    tests:
+    - falsify_crux_a_20_algo_001_dry_run_offline_flag_accepted
+    - falsify_crux_a_20_algo_004_all_three_offline_signals_equivalent
+    - falsify_crux_a_20_algo_001_dry_run_offline_is_deterministic
+    classifier: crates/apr-cli/src/commands/offline.rs
+    scope: >
+      Algorithm-level discharge: `--offline` CLI flag is parsed, plumbed
+      through dispatch, and produces a byte-identical `Offline:` line
+      to the env-var paths. Back-to-back invocations are deterministic.
+      NOT YET DISCHARGED: strace-verified zero TCP connects under
+      `--offline` in the full pull path with a primed cache (follow-up).
 
 - id: FALSIFY-CRUX-A-20-005
   rule: parity with huggingface_hub on cache-hit offline reads
@@ -175,8 +220,34 @@ proof_obligations:
 verification_summary:
   total_obligations: 5
   proven: 0
-  tested: 0
-  status: spec-complete
+  tested: 3  # FALSIFY-001/002/004 at PARTIAL_ALGORITHM_LEVEL
+  status: partial
+  evidence:
+    rust_tests: crates/apr-cli/tests/falsification_crux_a_20.rs
+    unit_tests: crates/apr-cli/src/commands/offline.rs
+    commands:
+    - apr pull <short> --dry-run --offline
+    - APR_OFFLINE=1 apr pull <short> --dry-run
+    - HF_HUB_OFFLINE=1 apr pull <short> --dry-run
+    coverage:
+    - falsify-001: falsify_crux_a_20_algo_002_apr_offline_env_triggers_offline
+    - falsify-001: falsify_crux_a_20_algo_002_apr_offline_env_zero_is_false
+    - falsify-002: falsify_crux_a_20_algo_003_hf_hub_offline_env_triggers_offline
+    - falsify-002: falsify_crux_a_20_algo_004_all_three_offline_signals_equivalent
+    - falsify-004: falsify_crux_a_20_algo_001_dry_run_offline_flag_accepted
+    - falsify-004: falsify_crux_a_20_algo_001_dry_run_offline_is_deterministic
+    - algo-005: falsify_crux_a_20_algo_005_default_offline_is_false
+  scope_honesty: >
+    FALSIFY-CRUX-A-20-001/002/004 are discharged at PARTIAL_ALGORITHM_LEVEL
+    — the Rust harness proves the offline sub-claims (CLI flag / env var
+    parsing, observational equivalence of `--offline` vs `APR_OFFLINE=1`
+    vs `HF_HUB_OFFLINE=1`, default-online behavior). The network-level
+    sub-claims (strace-verified zero non-loopback TCP connect() syscalls,
+    DNS suppression) remain TODO and require a separate strace-gated
+    harness with a primed cache. FALSIFY-CRUX-A-20-003 (cache-miss hard
+    error) and FALSIFY-CRUX-A-20-005 (huggingface_hub byte parity) are
+    NOT yet discharged — both need cache-layer + real pull-path wiring.
+    Contract stays `status: partial`.
 
 pmat_work_tracking:
   # Managed by master contract §12. If intake_status == "missing", a ticket

--- a/crates/apr-cli/src/commands/mod.rs
+++ b/crates/apr-cli/src/commands/mod.rs
@@ -44,6 +44,7 @@ pub(crate) mod model_config;
 pub(crate) mod monitor;
 #[cfg(feature = "dev")]
 pub mod mono;
+pub(crate) mod offline;
 pub(crate) mod oracle;
 pub(crate) mod parity;
 pub(crate) mod pipeline;

--- a/crates/apr-cli/src/commands/offline.rs
+++ b/crates/apr-cli/src/commands/offline.rs
@@ -1,0 +1,129 @@
+//! Offline mode detection for `apr pull --offline` (CRUX-A-20).
+//!
+//! Contract: `contracts/crux-A-20-v1.yaml`.
+//!
+//! Pure classifier — takes the parsed `--offline` flag and a slice of
+//! environment variables, returns a `bool`. No I/O. Unit-testable offline.
+//! The actual network-gating behavior (zero TCP connects, cache-miss
+//! error messages) is discharged by a separate strace-gated harness.
+
+/// Environment variables that trigger offline mode. APR-native and
+/// HF-compatible. Both MUST be observationally equivalent to the
+/// `--offline` CLI flag per FALSIFY-CRUX-A-20-004.
+pub const OFFLINE_ENV_VARS: &[&str] = &["APR_OFFLINE", "HF_HUB_OFFLINE"];
+
+/// Return true iff the raw env value is a truthy offline signal.
+/// HF's own convention (`huggingface_hub.constants.HF_HUB_OFFLINE`) treats
+/// "1", "true", "TRUE", "yes" as true and "0", "false", "" as false.
+fn env_is_truthy(value: &str) -> bool {
+    matches!(
+        value.trim().to_ascii_lowercase().as_str(),
+        "1" | "true" | "yes" | "on"
+    )
+}
+
+/// Resolve offline mode from the CLI flag + environment snapshot.
+///
+/// Precedence: `cli_flag=true` OR any offline env var truthy → offline.
+/// If none are set, or all env vars are falsy and the flag is false,
+/// offline is false (default online behavior).
+///
+/// The environment snapshot is passed in explicitly (rather than read
+/// from `std::env`) so callers can test this function deterministically
+/// without mutating process-global state.
+pub fn is_offline<'a, I>(cli_flag: bool, env: I) -> bool
+where
+    I: IntoIterator<Item = (&'a str, &'a str)>,
+{
+    if cli_flag {
+        return true;
+    }
+    for (k, v) in env {
+        if OFFLINE_ENV_VARS.contains(&k) && env_is_truthy(v) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Read the two offline-relevant env vars out of the real process
+/// environment. Thin wrapper so callers don't sprinkle `std::env::var`
+/// across the codebase.
+pub fn read_offline_env() -> Vec<(String, String)> {
+    OFFLINE_ENV_VARS
+        .iter()
+        .filter_map(|k| std::env::var(k).ok().map(|v| ((*k).to_string(), v)))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn flag_alone_triggers_offline() {
+        assert!(is_offline(true, std::iter::empty::<(&str, &str)>()));
+    }
+
+    #[test]
+    fn no_flag_no_env_is_online() {
+        assert!(!is_offline(false, std::iter::empty::<(&str, &str)>()));
+    }
+
+    #[test]
+    fn apr_offline_one_triggers_offline() {
+        assert!(is_offline(false, [("APR_OFFLINE", "1")]));
+    }
+
+    #[test]
+    fn hf_hub_offline_one_triggers_offline() {
+        assert!(is_offline(false, [("HF_HUB_OFFLINE", "1")]));
+    }
+
+    #[test]
+    fn apr_offline_zero_is_online() {
+        assert!(!is_offline(false, [("APR_OFFLINE", "0")]));
+    }
+
+    #[test]
+    fn apr_offline_empty_is_online() {
+        assert!(!is_offline(false, [("APR_OFFLINE", "")]));
+    }
+
+    #[test]
+    fn truthy_variants_all_work() {
+        for v in ["1", "true", "TRUE", "yes", "on", "  1  "] {
+            assert!(
+                is_offline(false, [("APR_OFFLINE", v)]),
+                "APR_OFFLINE={v:?} must be truthy",
+            );
+        }
+    }
+
+    #[test]
+    fn falsy_variants_all_fail() {
+        for v in ["0", "false", "no", "off", "", "random-string"] {
+            assert!(
+                !is_offline(false, [("APR_OFFLINE", v)]),
+                "APR_OFFLINE={v:?} must be falsy",
+            );
+        }
+    }
+
+    #[test]
+    fn unrelated_env_var_ignored() {
+        assert!(!is_offline(false, [("SOME_OTHER_VAR", "1")]));
+    }
+
+    #[test]
+    fn flag_overrides_falsy_env() {
+        assert!(is_offline(true, [("APR_OFFLINE", "0")]));
+    }
+
+    #[test]
+    fn is_deterministic() {
+        let a = is_offline(false, [("HF_HUB_OFFLINE", "1")]);
+        let b = is_offline(false, [("HF_HUB_OFFLINE", "1")]);
+        assert_eq!(a, b);
+    }
+}

--- a/crates/apr-cli/src/commands/pull.rs
+++ b/crates/apr-cli/src/commands/pull.rs
@@ -48,7 +48,7 @@ pub struct FileChecksum {
     "apr-cli-operations-v1",
     equation = "mutating_output_contract"
 )]
-pub fn run(model_ref: &str, force: bool, dry_run: bool, revision: Option<&str>) -> Result<()> {
+pub fn run(model_ref: &str, force: bool, dry_run: bool, revision: Option<&str>, offline: bool) -> Result<()> {
     contract_pre_pull_cache_integrity!();
     println!("{}", "=== APR Pull ===".cyan().bold());
     println!();
@@ -57,8 +57,10 @@ pub fn run(model_ref: &str, force: bool, dry_run: bool, revision: Option<&str>) 
     // canonical URL and exits with zero network I/O.
     // CRUX-A-03 ALGO-001..003: --dry-run echoes the revision spec the user
     // supplied (or the default "main") and validates its local form.
+    // CRUX-A-20 ALGO-001..005: --dry-run also echoes the resolved offline
+    // mode so callers can assert CLI-flag / env-var equivalence offline.
     if dry_run {
-        return run_dry_run(model_ref, revision);
+        return run_dry_run(model_ref, revision, offline);
     }
 
     // GH-213: Resolve HuggingFace URI — detect single vs sharded models
@@ -547,8 +549,12 @@ fn write_shard_manifest(
 /// CRUX-A-03 ALGO-001..003: `--revision` is classified locally and echoed
 /// in the dry-run output. Malformed revisions (empty, whitespace, URL)
 /// fail fast without touching the network.
-fn run_dry_run(model_ref: &str, revision: Option<&str>) -> Result<()> {
+///
+/// CRUX-A-20 ALGO-001..005: the effective offline signal (CLI flag OR
+/// `APR_OFFLINE` OR `HF_HUB_OFFLINE` truthy) is echoed too.
+fn run_dry_run(model_ref: &str, revision: Option<&str>, offline_flag: bool) -> Result<()> {
     use super::aliases;
+    use super::offline;
     use super::revision as rev;
 
     let resolved = if let Some(url) = aliases::resolve_short_name(model_ref) {
@@ -566,9 +572,16 @@ fn run_dry_run(model_ref: &str, revision: Option<&str>) -> Result<()> {
         ))
     })?;
 
+    // CRUX-A-20: resolve offline signal from CLI flag + env vars.
+    let env = offline::read_offline_env();
+    let env_borrowed: Vec<(&str, &str)> =
+        env.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();
+    let is_offline = offline::is_offline(offline_flag, env_borrowed.iter().copied());
+
     println!("Model:    {}", model_ref.cyan());
     println!("Resolved: {}", resolved.green());
     println!("Revision: {} ({:?})", rev_spec.green(), rev_kind);
+    println!("Offline:  {}", if is_offline { "true".green() } else { "false".yellow() });
     println!("Mode:     {} (no network I/O)", "dry-run".yellow());
     Ok(())
 }

--- a/crates/apr-cli/src/commands_enum.rs
+++ b/crates/apr-cli/src/commands_enum.rs
@@ -369,6 +369,10 @@ pub enum Commands {
         /// (HuggingFace Hub). Defaults to "main" when omitted.
         #[arg(long, value_name = "REV")]
         revision: Option<String>,
+        /// CRUX-A-20: offline mode — forbid any outbound network I/O.
+        /// Equivalent to APR_OFFLINE=1 or HF_HUB_OFFLINE=1 in the environment.
+        #[arg(long)]
+        offline: bool,
     },
     /// Registry operations (CRUX-A-01): inspect alias map, etc.
     Registry {

--- a/crates/apr-cli/src/dispatch.rs
+++ b/crates/apr-cli/src/dispatch.rs
@@ -609,7 +609,8 @@ fn dispatch_model_commands(cli: &Cli) -> Option<Result<(), CliError>> {
             force,
             dry_run,
             revision,
-        } => pull::run(model_ref, *force, *dry_run, revision.as_deref()),
+            offline,
+        } => pull::run(model_ref, *force, *dry_run, revision.as_deref(), *offline),
         Commands::Registry { command } => {
             crate::commands::registry::run(command.clone())
         }

--- a/crates/apr-cli/src/lib_dispatch_coverage.rs
+++ b/crates/apr-cli/src/lib_dispatch_coverage.rs
@@ -35,6 +35,7 @@
             force: false,
             dry_run: false,
             revision: None,
+            offline: false,
         });
         let result = dispatch_model_commands(&cli);
         assert!(result.is_some(), "Pull should be handled by dispatch_model_commands");

--- a/crates/apr-cli/src/lib_extract_paths.rs
+++ b/crates/apr-cli/src/lib_extract_paths.rs
@@ -83,6 +83,7 @@
             force: false,
             dry_run: false,
             revision: None,
+            offline: false,
         };
         let paths = extract_model_paths(&cmd);
         assert!(paths.is_empty(), "Pull is a diagnostic command (exempt)");

--- a/crates/apr-cli/src/lib_parse_export.rs
+++ b/crates/apr-cli/src/lib_parse_export.rs
@@ -304,6 +304,7 @@
                 force,
                 dry_run,
                 revision: _,
+                offline: _,
             } => {
                 assert_eq!(model_ref, "hf://Qwen/Qwen2.5-Coder-1.5B");
                 assert!(force);
@@ -324,6 +325,7 @@
                 force,
                 dry_run,
                 revision: _,
+                offline: _,
             } => {
                 assert_eq!(model_ref, "qwen2.5-coder");
                 assert!(!force);
@@ -344,6 +346,7 @@
                 force,
                 dry_run,
                 revision: _,
+                offline: _,
             } => {
                 assert_eq!(model_ref, "llama3");
                 assert!(!force);

--- a/crates/apr-cli/tests/falsification_crux_a_20.rs
+++ b/crates/apr-cli/tests/falsification_crux_a_20.rs
@@ -1,0 +1,212 @@
+//! Falsification tests for CRUX-A-20 — Offline mode, zero network calls.
+//!
+//! Contract: `contracts/crux-A-20-v1.yaml`.
+//!
+//! Scope honesty (READ THIS):
+//!
+//! The canonical FALSIFY-CRUX-A-20-{001,002,003,004} gates in the contract
+//! assert behavior verified via `strace -e trace=connect` — "zero outbound
+//! TCP connect() syscalls under offline mode". That strace-level
+//! verification is a separate follow-up harness (requires strace, a primed
+//! cache, and a live comparison against the online path).
+//!
+//! What this harness discharges at `PARTIAL_ALGORITHM_LEVEL` are the
+//! offline sub-claims that MUST hold before any strace verification can
+//! succeed:
+//!   - ALGO-001: `--offline` flag is accepted by the CLI parser and
+//!     echoed as `Offline: true` in `--dry-run` output (no network I/O).
+//!   - ALGO-002: `APR_OFFLINE=1` env var triggers the same offline signal
+//!     in `--dry-run` output without `--offline` on the argv.
+//!   - ALGO-003: `HF_HUB_OFFLINE=1` env var (HuggingFace compat) triggers
+//!     the same offline signal.
+//!   - ALGO-004: `--offline` flag, `APR_OFFLINE=1`, and `HF_HUB_OFFLINE=1`
+//!     all produce byte-identical `Offline:` lines (observational
+//!     equivalence).
+//!   - ALGO-005: Without any offline signal, default is `Offline: false`.
+//!
+//! The full-network discharge of FALSIFY-001/002/003/004/005 is tracked as
+//! follow-up and will live in a separate (strace-gated) harness.
+
+#![allow(clippy::unwrap_used)]
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn repo_root() -> PathBuf {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    manifest
+        .ancestors()
+        .nth(2)
+        .expect("CARGO_MANIFEST_DIR has repo root 2 ancestors up")
+        .to_path_buf()
+}
+
+fn run_apr_pull_with_env(
+    args: &[&str],
+    extra_env: &[(&str, &str)],
+    clear_offline_env: bool,
+) -> (std::process::Output, String, String) {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_apr"));
+    cmd.current_dir(repo_root()).arg("pull").args(args);
+    if clear_offline_env {
+        cmd.env_remove("APR_OFFLINE").env_remove("HF_HUB_OFFLINE");
+    }
+    for (k, v) in extra_env {
+        cmd.env(k, *v);
+    }
+    let output = cmd
+        .output()
+        .unwrap_or_else(|e| panic!("CRUX-A-20: failed to spawn apr: {e}"));
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    (output, stdout, stderr)
+}
+
+fn offline_line(stdout: &str) -> String {
+    stdout
+        .lines()
+        .find(|l| l.contains("Offline:"))
+        .unwrap_or_else(|| panic!("CRUX-A-20: stdout must contain an 'Offline:' line, got:\n{stdout}"))
+        .to_string()
+}
+
+// ---------------------------------------------------------------------------
+// ALGO-001: `apr pull <short> --dry-run --offline` is accepted and echoed.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn falsify_crux_a_20_algo_001_dry_run_offline_flag_accepted() {
+    let (output, stdout, stderr) = run_apr_pull_with_env(
+        &["llama3", "--dry-run", "--offline"],
+        &[],
+        true, // clear APR_OFFLINE/HF_HUB_OFFLINE
+    );
+    assert!(
+        output.status.success(),
+        "CRUX-A-20 ALGO-001: --offline --dry-run must exit 0\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let line = offline_line(&stdout);
+    assert!(
+        line.contains("true"),
+        "CRUX-A-20 ALGO-001: --offline line must contain 'true', got: {line:?}"
+    );
+}
+
+#[test]
+fn falsify_crux_a_20_algo_005_default_offline_is_false() {
+    let (output, stdout, _stderr) = run_apr_pull_with_env(
+        &["llama3", "--dry-run"],
+        &[],
+        true, // clear both env vars
+    );
+    assert!(output.status.success());
+    let line = offline_line(&stdout);
+    assert!(
+        line.contains("false"),
+        "CRUX-A-20 ALGO-005: default offline line must contain 'false', got: {line:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// ALGO-002: APR_OFFLINE=1 alone triggers offline signal.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn falsify_crux_a_20_algo_002_apr_offline_env_triggers_offline() {
+    let (output, stdout, _stderr) = run_apr_pull_with_env(
+        &["llama3", "--dry-run"],
+        &[("APR_OFFLINE", "1")],
+        true, // clear both, then set APR_OFFLINE=1
+    );
+    assert!(output.status.success());
+    let line = offline_line(&stdout);
+    assert!(
+        line.contains("true"),
+        "CRUX-A-20 ALGO-002: APR_OFFLINE=1 line must contain 'true', got: {line:?}"
+    );
+}
+
+#[test]
+fn falsify_crux_a_20_algo_002_apr_offline_env_zero_is_false() {
+    let (output, stdout, _stderr) = run_apr_pull_with_env(
+        &["llama3", "--dry-run"],
+        &[("APR_OFFLINE", "0")],
+        true,
+    );
+    assert!(output.status.success());
+    let line = offline_line(&stdout);
+    assert!(
+        line.contains("false"),
+        "CRUX-A-20 ALGO-002: APR_OFFLINE=0 must NOT trigger offline, got: {line:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// ALGO-003: HF_HUB_OFFLINE=1 (HF compat) triggers offline signal.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn falsify_crux_a_20_algo_003_hf_hub_offline_env_triggers_offline() {
+    let (output, stdout, _stderr) = run_apr_pull_with_env(
+        &["llama3", "--dry-run"],
+        &[("HF_HUB_OFFLINE", "1")],
+        true,
+    );
+    assert!(output.status.success());
+    let line = offline_line(&stdout);
+    assert!(
+        line.contains("true"),
+        "CRUX-A-20 ALGO-003: HF_HUB_OFFLINE=1 line must contain 'true', got: {line:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// ALGO-004: --offline, APR_OFFLINE=1, HF_HUB_OFFLINE=1 are equivalent.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn falsify_crux_a_20_algo_004_all_three_offline_signals_equivalent() {
+    let (_, flag_stdout, _) = run_apr_pull_with_env(
+        &["llama3", "--dry-run", "--offline"],
+        &[],
+        true,
+    );
+    let (_, apr_env_stdout, _) = run_apr_pull_with_env(
+        &["llama3", "--dry-run"],
+        &[("APR_OFFLINE", "1")],
+        true,
+    );
+    let (_, hf_env_stdout, _) = run_apr_pull_with_env(
+        &["llama3", "--dry-run"],
+        &[("HF_HUB_OFFLINE", "1")],
+        true,
+    );
+    let flag_line = offline_line(&flag_stdout);
+    let apr_env_line = offline_line(&apr_env_stdout);
+    let hf_env_line = offline_line(&hf_env_stdout);
+    assert_eq!(
+        flag_line, apr_env_line,
+        "CRUX-A-20 ALGO-004: --offline must equal APR_OFFLINE=1 (observationally)"
+    );
+    assert_eq!(
+        apr_env_line, hf_env_line,
+        "CRUX-A-20 ALGO-004: APR_OFFLINE=1 must equal HF_HUB_OFFLINE=1 (observationally)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Determinism: two back-to-back --offline invocations emit byte-identical
+// Offline lines. Mirrors A-01/A-03 determinism gates.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn falsify_crux_a_20_algo_001_dry_run_offline_is_deterministic() {
+    let args: &[&str] = &["llama3", "--dry-run", "--offline"];
+    let (_, a, _) = run_apr_pull_with_env(args, &[], true);
+    let (_, b, _) = run_apr_pull_with_env(args, &[], true);
+    assert_eq!(
+        offline_line(&a),
+        offline_line(&b),
+        "CRUX-A-20: back-to-back --dry-run --offline must be byte-identical"
+    );
+}


### PR DESCRIPTION
## Summary

Contract: `contracts/crux-A-20-v1.yaml` — Offline mode, zero network calls (HuggingFace `HF_HUB_OFFLINE=1` parity).

Promotes `v1.0.0-draft` (status: `draft`) → `v1.1.0` (status: `partial`) by wiring an `--offline` flag into `apr pull`, honouring the `APR_OFFLINE=1` / `HF_HUB_OFFLINE=1` env vars, and discharging **3 of 5 FALSIFY gates at `PARTIAL_ALGORITHM_LEVEL`**.

## Scope Honesty (READ THIS)

The canonical `FALSIFY-CRUX-A-20-{001,002,004}` gates assert **strace-verified zero non-loopback TCP connect() syscalls**. That strace-level verification is a separate follow-up harness.

What this PR discharges at `PARTIAL_ALGORITHM_LEVEL`:

| Gate | Algorithm-level claim proven offline | Full claim still TODO |
|------|---|---|
| **FALSIFY-001** | `APR_OFFLINE=1` parses + triggers `Offline: true`; `APR_OFFLINE=0` leaves it off | strace-verified zero non-loopback TCP connects under env |
| **FALSIFY-002** | `HF_HUB_OFFLINE=1` parses + is byte-equal to `APR_OFFLINE=1`/`--offline` output | strace path under HF-compat env |
| **FALSIFY-003** | — (not touched) | Cache-miss hard error with "offline"+"cache"+filename message |
| **FALSIFY-004** | `--offline` flag parses + is observationally equivalent to env vars + deterministic | strace path under CLI flag |
| **FALSIFY-005** | — (not touched) | Byte-for-byte parity with `huggingface_hub(local_files_only=True)` goldens |

Contract retains `status: partial`. **Follow-up strace-gated harness closes the full discharge.**

## Implementation

**New:** `crates/apr-cli/src/commands/offline.rs` — pure `is_offline(cli_flag, env) -> bool` classifier + `read_offline_env()` helper. 11 unit tests. Zero I/O.

**Wired into:** `commands_enum.rs` (Pull gets `offline: bool`), `dispatch.rs`, `commands/pull.rs::run_dry_run` (echoes `Offline:  true|false`).

**Harness:** `crates/apr-cli/tests/falsification_crux_a_20.rs` — 7 integration tests spawning `CARGO_BIN_EXE_apr`:

- `falsify_crux_a_20_algo_001_dry_run_offline_flag_accepted`
- `falsify_crux_a_20_algo_001_dry_run_offline_is_deterministic`
- `falsify_crux_a_20_algo_002_apr_offline_env_triggers_offline`
- `falsify_crux_a_20_algo_002_apr_offline_env_zero_is_false`
- `falsify_crux_a_20_algo_003_hf_hub_offline_env_triggers_offline`
- `falsify_crux_a_20_algo_004_all_three_offline_signals_equivalent`
- `falsify_crux_a_20_algo_005_default_offline_is_false`

## Verification

```
$ cargo test -p apr-cli --test falsification_crux_a_20
running 7 tests ... test result: ok. 7 passed; 0 failed

$ cargo test -p apr-cli --lib commands::offline
running 11 tests ... test result: ok. 11 passed; 0 failed

$ pv validate contracts/crux-A-20-v1.yaml
0 error(s), 0 warning(s). Contract is valid.
```

## What this does NOT claim

- Does **not** bump CRUX master `supported_count` (A-20 stays `partial`).
- Does **not** run any strace / network verification in CI.
- Does **not** discharge FALSIFY-003 (cache-miss error) or FALSIFY-005 (byte parity).
- Does **not** prevent the actual pull-path (non-dry-run) from reaching network — that gating is the follow-up's job.

## Test plan

- [x] `cargo test -p apr-cli --test falsification_crux_a_20` green (7/7)
- [x] `cargo test -p apr-cli --lib commands::offline` green (11/11)
- [x] `pv validate contracts/crux-A-20-v1.yaml` passes
- [x] All existing `Commands::Pull {…}` destructure sites updated (`lib_parse_export.rs`, `lib_extract_paths.rs`, `lib_dispatch_coverage.rs`)
- [ ] CI `ci / gate` + `workspace-test` green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)