### PR TITLE
feat(crux-a-15): pull-source URL-scheme classifier (1 of 4 FALSIFY at PARTIAL_ALGORITHM_LEVEL, classifier-only)

### DIFF
--- a/contracts/crux-A-15-v1.yaml
+++ b/contracts/crux-A-15-v1.yaml
@@ -6,11 +6,12 @@
 
 metadata:
   id: CRUX-A-15
-  version: "1.0.0-draft"
+  version: "1.1.0"
   created: "2026-04-18"
+  last_updated: "2026-04-20"
   author: PAIML Engineering
   registry: true
-  status: draft
+  status: partial
   parent_contracts:
   - crux-competitive-research-ux-v1
   category: "A — Model Intake & Discovery"
@@ -95,6 +96,31 @@ falsification_tests:
     [ -f "$OUT/config.json" ] || { echo "FAIL: config.json not copied" >&2; exit 1; }
     diff "$SRC/config.json" "$OUT/config.json"
   if_fails: "apr pull file:// made outbound network calls or did not copy files"
+  discharge_status: PARTIAL_ALGORITHM_LEVEL
+  evidence_discharged_by:
+    sub_claim: >
+      A necessary condition for "zero outbound TCP" is that any `file://`
+      URL is classified as the Local transport and therefore never reaches
+      the HTTP dispatch layer. This sub-claim is discharged by the pure
+      classifier `commands::pull_scheme::classify_pull_source`.
+    tests:
+    - file: crates/apr-cli/src/commands/pull_scheme.rs
+      tests:
+      - commands::pull_scheme::tests::file_scheme_absolute_path
+      - commands::pull_scheme::tests::file_scheme_relative_path
+      - commands::pull_scheme::tests::file_scheme_is_always_local_transport
+      - commands::pull_scheme::tests::is_local_transport_rejects_non_local
+    - file: crates/apr-cli/src/commands/pull_scheme.rs
+      properties:
+      - "∀ src starting with 'file://': is_local_transport(classify(src)) == true"
+      - "∀ src starting with 'hf://' | 'https://' | 'http://' | bare org/repo | short-name:
+         is_local_transport(classify(src)) == false"
+    scope: >
+      ONLY the classification step is discharged. The actual filesystem
+      copy that preserves sha256 (FALSIFY-001 full), the strace-verified
+      absence of AF_INET connect() syscalls during a real `apr pull`, and
+      the `--out` integration are NOT discharged here — they require a
+      file:// transport implementation in `commands::pull` itself.
 
 - id: FALSIFY-CRUX-A-15-002
   rule: HF_HUB_OFFLINE=1 hits cache and makes zero network calls
@@ -166,8 +192,32 @@ proof_obligations:
 verification_summary:
   total_obligations: 5
   proven: 0
-  tested: 0
-  status: spec-complete
+  tested: 1  # FALSIFY-001 at PARTIAL_ALGORITHM_LEVEL (classifier sub-claim only)
+  status: partial
+  evidence:
+    unit_tests: crates/apr-cli/src/commands/pull_scheme.rs
+    functions:
+    - commands::pull_scheme::classify_pull_source
+    - commands::pull_scheme::is_local_transport
+    coverage:
+    - falsify-001: commands::pull_scheme::tests::file_scheme_absolute_path
+    - falsify-001: commands::pull_scheme::tests::file_scheme_relative_path
+    - falsify-001: commands::pull_scheme::tests::file_scheme_is_always_local_transport
+    - falsify-001: commands::pull_scheme::tests::is_local_transport_rejects_non_local
+    - negative-space: commands::pull_scheme::tests::unsupported_scheme_is_error
+    - negative-space: commands::pull_scheme::tests::file_without_slash_slash_is_error
+    - determinism: commands::pull_scheme::tests::is_deterministic
+  scope_honesty: >
+    ONLY the URL-scheme CLASSIFIER is discharged at PARTIAL_ALGORITHM_LEVEL.
+    A `file://` input provably classifies as the Local transport variant,
+    which is a NECESSARY condition for FALSIFY-001's "zero outbound TCP
+    connect()" invariant but not sufficient on its own. FALSIFY-002
+    (HF_HUB_OFFLINE=1 cache hit), FALSIFY-003 (offline cache-miss exits
+    non-zero), and FALSIFY-004 (hf-cli byte-parity on goldens) are NOT
+    discharged — they require a `file://` filesystem-copy transport, an
+    HF cache model, and a live `huggingface-cli` golden set respectively.
+    NO INTEGRATION DISCHARGE — the classifier is not yet wired into the
+    real `apr pull` dispatch path. Contract retains `status: partial`.
 
 pmat_work_tracking:
   # Managed by master contract §12. If intake_status == "missing", a ticket

--- a/crates/apr-cli/src/commands/mod.rs
+++ b/crates/apr-cli/src/commands/mod.rs
@@ -58,6 +58,7 @@ pub(crate) mod ptx_explain;
 pub(crate) mod ptx_map;
 pub(crate) mod publish;
 pub(crate) mod pull;
+pub(crate) mod pull_scheme;
 pub(crate) mod qa;
 pub(crate) mod qa_capability;
 pub(crate) mod qualify;

--- a/crates/apr-cli/src/commands/pull_scheme.rs
+++ b/crates/apr-cli/src/commands/pull_scheme.rs
@@ -1,0 +1,241 @@
+//! Pull-source URL scheme classifier for `apr pull` (CRUX-A-15).
+//!
+//! Contract: `contracts/crux-A-15-v1.yaml`.
+//!
+//! Pure classifier — takes the raw string passed to `apr pull` and returns
+//! the transport category the caller should use. No I/O, no filesystem,
+//! no network.
+//!
+//! The actual filesystem walk for `file://` paths, the HF cache lookup for
+//! `hf://` with `HF_HUB_OFFLINE=1`, and the byte-identical copy are all
+//! discharged by separate network/strace-gated harnesses (follow-up).
+//!
+//! The algorithm-level sub-claim we DO discharge here: a `file://` URL is
+//! classified as `Local(path)` and therefore will not be sent to any HTTP
+//! transport. This is a necessary (not sufficient) condition for the full
+//! "zero outbound TCP" invariant of FALSIFY-CRUX-A-15-001.
+
+use std::path::PathBuf;
+
+/// Classification of a user-supplied pull source string.
+///
+/// The variants map 1:1 to the transport that `apr pull` should dispatch:
+/// `Local` → filesystem copy; `HfHub` → HuggingFace Hub HTTPS; `Https` →
+/// direct HTTPS; `BareOrgRepo` / `ShortName` → resolved via the alias map
+/// before dispatch.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PullScheme {
+    /// `file:///path/to/dir` → pure filesystem copy, never touches network.
+    Local(PathBuf),
+    /// `hf://org/repo[@rev]` → HuggingFace Hub transport.
+    HfHub(String),
+    /// `https://host/...` → direct HTTPS download.
+    Https(String),
+    /// `org/repo` (no scheme, contains slash) → treat as `hf://org/repo`.
+    BareOrgRepo(String),
+    /// Single token, no scheme, no slash → alias lookup required.
+    ShortName(String),
+}
+
+/// Classify a raw pull-source string.
+///
+/// Returns `Err` when the scheme is obviously malformed (empty string,
+/// unsupported scheme, `file:` without the `//` separator).
+///
+/// No I/O — this is a pure function. It does NOT check whether the
+/// `file://` path exists on disk; that is the caller's concern.
+pub fn classify_pull_source(src: &str) -> Result<PullScheme, String> {
+    let trimmed = src.trim();
+    if trimmed.is_empty() {
+        return Err("empty pull source".to_string());
+    }
+
+    if let Some(rest) = trimmed.strip_prefix("file://") {
+        return Ok(PullScheme::Local(PathBuf::from(rest)));
+    }
+    if let Some(rest) = trimmed.strip_prefix("hf://") {
+        if rest.is_empty() {
+            return Err("hf:// with empty repo".to_string());
+        }
+        return Ok(PullScheme::HfHub(rest.to_string()));
+    }
+    if trimmed.starts_with("https://") || trimmed.starts_with("http://") {
+        return Ok(PullScheme::Https(trimmed.to_string()));
+    }
+
+    // Scheme-bearing but unsupported? Any `scheme:` prefix that isn't one
+    // of the known ones is an error. We detect this via `://` rather than
+    // `:` alone so `org/repo` with a colon in the repo name still flows
+    // through. (HF repo names can contain colons in tags but not here.)
+    if let Some(idx) = trimmed.find("://") {
+        let scheme = &trimmed[..idx];
+        return Err(format!("unsupported URL scheme: {scheme:?}"));
+    }
+
+    // `file:` without the `//` separator is almost certainly a typo.
+    if trimmed.starts_with("file:") {
+        return Err("file: scheme requires file:// prefix".to_string());
+    }
+
+    // No scheme, has a slash → bare `org/repo`.
+    if trimmed.contains('/') {
+        return Ok(PullScheme::BareOrgRepo(trimmed.to_string()));
+    }
+
+    // No scheme, no slash → short alias.
+    Ok(PullScheme::ShortName(trimmed.to_string()))
+}
+
+/// True iff the classification corresponds to a filesystem-only transport.
+/// Callers use this to skip any network-layer setup for local pulls.
+///
+/// The CRUX-A-15 ALGO-001 sub-claim of FALSIFY-CRUX-A-15-001 is exactly:
+/// "for any `src` starting with `file://`, `is_local_transport(classify)`
+/// returns true". This is a necessary condition for zero outbound TCP.
+pub fn is_local_transport(scheme: &PullScheme) -> bool {
+    matches!(scheme, PullScheme::Local(_))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn file_scheme_absolute_path() {
+        let r = classify_pull_source("file:///tmp/models/a").unwrap();
+        assert_eq!(r, PullScheme::Local(PathBuf::from("/tmp/models/a")));
+        assert!(is_local_transport(&r));
+    }
+
+    #[test]
+    fn file_scheme_relative_path() {
+        let r = classify_pull_source("file://models/a").unwrap();
+        assert_eq!(r, PullScheme::Local(PathBuf::from("models/a")));
+        assert!(is_local_transport(&r));
+    }
+
+    #[test]
+    fn hf_scheme_classifies_as_hf_hub() {
+        let r = classify_pull_source("hf://Qwen/Qwen2.5-Coder-1.5B").unwrap();
+        assert_eq!(r, PullScheme::HfHub("Qwen/Qwen2.5-Coder-1.5B".to_string()));
+        assert!(!is_local_transport(&r));
+    }
+
+    #[test]
+    fn https_scheme_classifies_as_https() {
+        let r =
+            classify_pull_source("https://huggingface.co/org/repo/resolve/main/config.json")
+                .unwrap();
+        assert!(matches!(r, PullScheme::Https(_)));
+        assert!(!is_local_transport(&r));
+    }
+
+    #[test]
+    fn bare_org_slash_repo_classifies_as_bare() {
+        let r = classify_pull_source("openai-community/gpt2").unwrap();
+        assert_eq!(r, PullScheme::BareOrgRepo("openai-community/gpt2".to_string()));
+        assert!(!is_local_transport(&r));
+    }
+
+    #[test]
+    fn short_name_classifies_as_short_name() {
+        let r = classify_pull_source("qwen2.5-coder").unwrap();
+        assert_eq!(r, PullScheme::ShortName("qwen2.5-coder".to_string()));
+        assert!(!is_local_transport(&r));
+    }
+
+    #[test]
+    fn empty_input_is_error() {
+        assert!(classify_pull_source("").is_err());
+        assert!(classify_pull_source("   ").is_err());
+    }
+
+    #[test]
+    fn unsupported_scheme_is_error() {
+        let err = classify_pull_source("ftp://example.com/x").unwrap_err();
+        assert!(err.contains("ftp"), "error should name the scheme: {err}");
+        let err = classify_pull_source("s3://bucket/key").unwrap_err();
+        assert!(err.contains("s3"), "error should name the scheme: {err}");
+    }
+
+    #[test]
+    fn file_without_slash_slash_is_error() {
+        let err = classify_pull_source("file:/tmp/x").unwrap_err();
+        assert!(
+            err.contains("file://"),
+            "error should hint at correct prefix: {err}"
+        );
+    }
+
+    #[test]
+    fn hf_with_empty_repo_is_error() {
+        assert!(classify_pull_source("hf://").is_err());
+    }
+
+    #[test]
+    fn leading_and_trailing_whitespace_ignored() {
+        let r = classify_pull_source("  file:///tmp/a  ").unwrap();
+        assert_eq!(r, PullScheme::Local(PathBuf::from("/tmp/a")));
+    }
+
+    #[test]
+    fn is_local_transport_rejects_non_local() {
+        for src in [
+            "hf://a/b",
+            "https://x/y",
+            "openai/gpt2",
+            "qwen2.5-coder",
+        ] {
+            let r = classify_pull_source(src).unwrap();
+            assert!(
+                !is_local_transport(&r),
+                "{src:?} must not be classified as Local transport"
+            );
+        }
+    }
+
+    #[test]
+    fn file_scheme_is_always_local_transport() {
+        // CRUX-A-15 ALGO-001 sub-claim of FALSIFY-001: any input starting
+        // with `file://` must classify as Local and therefore route to the
+        // filesystem transport, not HTTP. This is a necessary condition
+        // for "zero outbound TCP connect()".
+        for src in [
+            "file:///",
+            "file:///a",
+            "file:///tmp/models/a",
+            "file://relative/path",
+            "file:///path/with/many/segments/model.apr",
+        ] {
+            let r = classify_pull_source(src).unwrap();
+            assert!(
+                is_local_transport(&r),
+                "{src:?} must be classified as Local transport"
+            );
+        }
+    }
+
+    #[test]
+    fn is_deterministic() {
+        let a = classify_pull_source("file:///tmp/x").unwrap();
+        let b = classify_pull_source("file:///tmp/x").unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn classification_is_total_over_all_strings() {
+        // Every non-empty classification either returns Ok or a specific
+        // Err — never panics. Exercise a small bag of weird inputs.
+        for src in [
+            "🎉",
+            "x",
+            "a/b/c",
+            "https://",
+            "hf://",
+            "file://",
+            "arbitrary-nonsense::with::colons",
+        ] {
+            let _ = classify_pull_source(src); // must not panic
+        }
+    }
+}


### PR DESCRIPTION
## Summary

CRUX-A-15 pull-source URL-scheme classifier: pure, deterministic decision
function `classify_pull_source(&str) -> Result<PullScheme, String>` over
`{Local(PathBuf), HfHub(String), Https(String), BareOrgRepo(String),
ShortName(String)}`. No I/O, exhaustively unit-tested.
`is_local_transport(&PullScheme) -> bool` is the hook sub-claim hooks
hang off.

Contract: `contracts/crux-A-15-v1.yaml` v1.0.0-draft → **v1.1.0, status: partial**.
`pv validate`: 0 errors, 0 warnings.

## Discharge status (scope-honest)

| Gate | Status | Notes |
|------|--------|-------|
| FALSIFY-001 (file:// → zero outbound TCP) | ✅ PARTIAL_ALGORITHM_LEVEL | Classifier sub-claim: `file://` provably classifies as Local therefore never reaches HTTP dispatch. Necessary not sufficient. Tests: `file_scheme_absolute_path`, `file_scheme_relative_path`, `file_scheme_is_always_local_transport`, `is_local_transport_rejects_non_local` |
| FALSIFY-002 (HF_HUB_OFFLINE=1 cache hit) | ❌ NOT discharged | Needs HF cache model |
| FALSIFY-003 (offline cache-miss exits non-zero) | ❌ NOT discharged | Needs HF cache model |
| FALSIFY-004 (hf-cli byte-parity on goldens) | ❌ NOT discharged | Needs live HF + golden set |

**NO INTEGRATION DISCHARGE** — the classifier is not yet wired into the
real `apr pull` dispatch path. Only the pure decision logic is proven.
The contract retains `status: partial`; master `supported_count` stays
at its current value.

Zero conflicts with #941 — this PR only adds a new module and a single
line to `commands/mod.rs`; it does not touch the Pull variant or any
file modified by the in-flight A-20 PR.

## Test plan

- [x] `pv validate contracts/crux-A-15-v1.yaml` → 0 errors
- [x] `cargo test -p apr-cli --lib commands::pull_scheme` → 15/15 green
- [ ] CI `ci / gate` green
- [ ] CI `workspace-test` green
- [ ] Full discharge of FALSIFY-001/002/003/004 in follow-up (file:// transport + HF cache model + live goldens)

🤖 Generated with [Claude Code](https://claude.com/claude-code)