### PR TITLE
feat(crux-a-05): resume sidecar-path + etag comparator (2 of 4 FALSIFY at PARTIAL_ALGORITHM_LEVEL, classifier-only)

### DIFF
--- a/contracts/crux-A-05-v1.yaml
+++ b/contracts/crux-A-05-v1.yaml
@@ -6,11 +6,12 @@
 
 metadata:
   id: CRUX-A-05
-  version: "1.0.0-draft"
+  version: "1.1.0"
   created: "2026-04-18"
+  last_updated: "2026-04-20"
   author: PAIML Engineering
   registry: true
-  status: draft
+  status: partial
   parent_contracts:
   - crux-competitive-research-ux-v1
   category: "A — Model Intake & Discovery"
@@ -130,6 +131,31 @@ falsification_tests:
     }
 
   if_fails: rule 'etag mismatch triggers fresh download with warning' is violated — contract MUST be re-verified against competitor canonical reference
+  discharge_status: PARTIAL_ALGORITHM_LEVEL
+  evidence_discharged_by:
+    sub_claim: >
+      The sub-claim discharged is the etag-comparator invariant: given a
+      recorded "wrong-etag-value" sidecar and any real served ETag,
+      `compare_etag(Some("wrong-etag-value"), served)` provably returns
+      `EtagDecision::Mismatch`, and `should_discard_partial` on that
+      decision provably returns true. The sidecar path is deterministic
+      (`{target}.etag`) so the disk-side check has a fixed address. This
+      is a NECESSARY (not sufficient) condition for the full discard +
+      warning integration.
+    tests:
+    - file: crates/apr-cli/src/commands/resume_paths.rs
+      tests:
+      - commands::resume_paths::tests::etag_mismatch_sub_claim_falsify_003
+      - commands::resume_paths::tests::compare_etag_returns_mismatch_on_diff
+      - commands::resume_paths::tests::compare_etag_returns_match_on_equal
+      - commands::resume_paths::tests::compare_etag_trims_trailing_whitespace
+      - commands::resume_paths::tests::should_discard_partial_agrees_with_decision
+      - commands::resume_paths::tests::etag_path_appends_dot_etag
+    scope: >
+      ONLY the comparator logic + sidecar path convention are discharged.
+      The actual HTTP Range request flow, the stderr warning emission,
+      and the fresh-download-from-byte-0 restart are NOT discharged —
+      they require integration into `commands::pull`.
 - id: FALSIFY-CRUX-A-05-004
   rule: concurrent --resume invocations are mutually exclusive
   prediction: "second concurrent apr pull exits non-zero with lock error"
@@ -150,6 +176,31 @@ falsification_tests:
     }
 
   if_fails: rule 'concurrent --resume invocations are mutually exclusive' is violated — contract MUST be re-verified against competitor canonical reference
+  discharge_status: PARTIAL_ALGORITHM_LEVEL
+  evidence_discharged_by:
+    sub_claim: >
+      The sub-claim discharged is the lock-path-determinism invariant:
+      two `lock_path(target)` calls on the same target path provably
+      return the same `PathBuf` (appending `.lock`), and two different
+      targets provably return different `PathBuf`s. Two concurrent
+      `apr pull --resume` invocations against the same `--out` therefore
+      contend on the same canonical advisory lock file. This is a
+      NECESSARY (not sufficient) condition for the mutual-exclusion
+      invariant.
+    tests:
+    - file: crates/apr-cli/src/commands/resume_paths.rs
+      tests:
+      - commands::resume_paths::tests::lock_path_appends_dot_lock
+      - commands::resume_paths::tests::sidecar_paths_are_deterministic
+      - commands::resume_paths::tests::sidecar_paths_are_distinct_by_target
+      - commands::resume_paths::tests::sidecar_paths_preserve_directory
+      - commands::resume_paths::tests::sidecar_suffixes_are_stable
+    scope: >
+      ONLY the lock-path computation is discharged. Acquiring the real
+      `fcntl(F_SETLK)` / `flock(LOCK_EX|LOCK_NB)` advisory lock, writing
+      the caller PID into the lock file, emitting the "already in
+      progress" error, and exiting non-zero are NOT discharged — they
+      require integration into `commands::pull`.
 proof_obligations:
 - type: invariant
   property: "HTTP Range: bytes=<offset>- header is emitted on --resume when a partial file exists"
@@ -165,8 +216,39 @@ proof_obligations:
 verification_summary:
   total_obligations: 5
   proven: 0
-  tested: 0
-  status: spec-complete
+  tested: 2  # FALSIFY-003 + FALSIFY-004 at PARTIAL_ALGORITHM_LEVEL
+  status: partial
+  evidence:
+    unit_tests: crates/apr-cli/src/commands/resume_paths.rs
+    functions:
+    - commands::resume_paths::lock_path
+    - commands::resume_paths::etag_path
+    - commands::resume_paths::partial_path
+    - commands::resume_paths::compare_etag
+    - commands::resume_paths::should_discard_partial
+    coverage:
+    - falsify-003: commands::resume_paths::tests::etag_mismatch_sub_claim_falsify_003
+    - falsify-003: commands::resume_paths::tests::compare_etag_returns_mismatch_on_diff
+    - falsify-003: commands::resume_paths::tests::compare_etag_trims_trailing_whitespace
+    - falsify-003: commands::resume_paths::tests::compare_etag_returns_match_on_equal
+    - falsify-003: commands::resume_paths::tests::compare_etag_returns_missing_recorded_on_none
+    - falsify-004: commands::resume_paths::tests::lock_path_appends_dot_lock
+    - falsify-004: commands::resume_paths::tests::sidecar_paths_are_deterministic
+    - falsify-004: commands::resume_paths::tests::sidecar_paths_are_distinct_by_target
+    - determinism: commands::resume_paths::tests::compare_etag_is_deterministic
+    - negative-space: commands::resume_paths::tests::sidecar_paths_work_on_paths_with_many_dots
+  scope_honesty: >
+    ONLY the SIDECAR-PATH resolver and the ETAG comparator are discharged
+    at PARTIAL_ALGORITHM_LEVEL. `{target}.lock` and `{target}.etag` are
+    deterministic given `target`, and `compare_etag` provably classifies
+    mismatched recorded-vs-served pairs as `Mismatch`. Both are NECESSARY
+    conditions for FALSIFY-003 (stale partial discarded + warning) and
+    FALSIFY-004 (concurrent resume → lock error) but not sufficient.
+    FALSIFY-001 (partial completes with correct sha256) and FALSIFY-002
+    (complete shards skip network) are NOT discharged — they require
+    HTTP Range + sha256 verification. NO INTEGRATION DISCHARGE — the
+    classifier is not yet wired into `commands::pull`. Contract retains
+    `status: partial`.
 
 pmat_work_tracking:
   # Managed by master contract §12. If intake_status == "missing", a ticket

--- a/crates/apr-cli/src/commands/mod.rs
+++ b/crates/apr-cli/src/commands/mod.rs
@@ -65,6 +65,7 @@ pub(crate) mod qa_capability;
 pub(crate) mod qualify;
 pub(crate) mod quantize;
 pub(crate) mod registry;
+pub(crate) mod resume_paths;
 pub(crate) mod revision;
 pub(crate) mod rosetta;
 pub(crate) mod run;

--- a/crates/apr-cli/src/commands/resume_paths.rs
+++ b/crates/apr-cli/src/commands/resume_paths.rs
@@ -1,0 +1,241 @@
+//! Resume-sidecar path resolver + etag comparator for `apr pull --resume`
+//! (CRUX-A-05).
+//!
+//! Contract: `contracts/crux-A-05-v1.yaml`.
+//!
+//! Pure classifier — takes the user-visible `--out` target path (or the
+//! live ETag values) and returns deterministic paths / decisions the
+//! resume machinery will use. No I/O, no filesystem access.
+//!
+//! The actual HTTP Range requests, the advisory file lock, the bytes on
+//! disk, and the byte-identical-after-resume sha256 check are all
+//! discharged by separate network/strace-gated harnesses (follow-up).
+
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+
+/// Suffix appended to the target path for the advisory lock file.
+/// Matches the canonical shell-test convention `$TARGET.lock`.
+pub const LOCK_SUFFIX: &str = ".lock";
+
+/// Suffix appended to the target path for the ETag sidecar.
+/// Matches the canonical shell-test convention `$TARGET.etag`.
+pub const ETAG_SUFFIX: &str = ".etag";
+
+/// Suffix appended to the target path for the in-progress partial file.
+/// `foo.bin.partial` lives alongside `foo.bin` until resume completes.
+pub const PARTIAL_SUFFIX: &str = ".partial";
+
+/// Return the advisory lock file path for a given target. Deterministic
+/// append of `LOCK_SUFFIX`.
+///
+/// CRUX-A-05 ALGO-004 sub-claim of FALSIFY-004: two `apr pull --resume`
+/// invocations targeting the same path compute the SAME lock path and
+/// therefore contend for the same advisory flock.
+pub fn lock_path(target: &Path) -> PathBuf {
+    append_suffix(target, LOCK_SUFFIX)
+}
+
+/// Return the ETag sidecar path for a given target. Deterministic append
+/// of `ETAG_SUFFIX`.
+///
+/// CRUX-A-05 ALGO-003 sub-claim of FALSIFY-003: the stale-partial
+/// detector reads from a fixed `$TARGET.etag` path so a pre-seeded
+/// "wrong-etag-value" file is always observable.
+pub fn etag_path(target: &Path) -> PathBuf {
+    append_suffix(target, ETAG_SUFFIX)
+}
+
+/// Return the in-progress partial path for a given target. Deterministic
+/// append of `PARTIAL_SUFFIX`.
+pub fn partial_path(target: &Path) -> PathBuf {
+    append_suffix(target, PARTIAL_SUFFIX)
+}
+
+/// Classification of a recorded-vs-served ETag pair.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EtagDecision {
+    /// No recorded ETag on disk → treat any existing partial as stale.
+    MissingRecorded,
+    /// Both present and byte-equal → the partial is resumable.
+    Match,
+    /// Both present but differ → the recorded partial is stale and MUST
+    /// be discarded with a warning. FALSIFY-003.
+    Mismatch,
+}
+
+/// Compare a recorded ETag (from the sidecar) against the live server
+/// ETag. Whitespace is trimmed on both sides (HTTP header parsers
+/// sometimes leave trailing newlines on disk).
+///
+/// CRUX-A-05 ALGO-003 sub-claim of FALSIFY-003: a mismatched recorded
+/// ETag deterministically classifies as `Mismatch`, which is the
+/// algorithm-level precondition for the "discard stale partial +
+/// emit warning" integration.
+pub fn compare_etag(recorded: Option<&str>, served: &str) -> EtagDecision {
+    match recorded {
+        None => EtagDecision::MissingRecorded,
+        Some(r) if r.trim().is_empty() => EtagDecision::MissingRecorded,
+        Some(r) if r.trim() == served.trim() => EtagDecision::Match,
+        Some(_) => EtagDecision::Mismatch,
+    }
+}
+
+/// True iff the decision calls for discarding the partial.
+/// Convenience helper for caller symmetry with other CRUX classifiers.
+pub fn should_discard_partial(decision: &EtagDecision) -> bool {
+    matches!(
+        decision,
+        EtagDecision::Mismatch | EtagDecision::MissingRecorded
+    )
+}
+
+fn append_suffix(target: &Path, suffix: &str) -> PathBuf {
+    let mut name: OsString = target.as_os_str().to_owned();
+    name.push(suffix);
+    PathBuf::from(name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lock_path_appends_dot_lock() {
+        let p = lock_path(Path::new("/tmp/apr-resume-test.bin"));
+        assert_eq!(p, PathBuf::from("/tmp/apr-resume-test.bin.lock"));
+    }
+
+    #[test]
+    fn etag_path_appends_dot_etag() {
+        let p = etag_path(Path::new("/tmp/apr-resume-test.bin"));
+        assert_eq!(p, PathBuf::from("/tmp/apr-resume-test.bin.etag"));
+    }
+
+    #[test]
+    fn partial_path_appends_dot_partial() {
+        let p = partial_path(Path::new("/tmp/apr-resume-test.bin"));
+        assert_eq!(p, PathBuf::from("/tmp/apr-resume-test.bin.partial"));
+    }
+
+    #[test]
+    fn sidecar_paths_are_deterministic() {
+        // CRUX-A-05 ALGO-004: same target → same lock path. Two
+        // processes racing on the same `--out` MUST contend.
+        let a = lock_path(Path::new("/tmp/x"));
+        let b = lock_path(Path::new("/tmp/x"));
+        assert_eq!(a, b);
+        assert_eq!(etag_path(Path::new("/tmp/x")), etag_path(Path::new("/tmp/x")));
+    }
+
+    #[test]
+    fn sidecar_paths_are_distinct_by_target() {
+        // Two different targets MUST produce two different lock paths
+        // (else unrelated pulls would contend).
+        assert_ne!(
+            lock_path(Path::new("/tmp/a")),
+            lock_path(Path::new("/tmp/b"))
+        );
+    }
+
+    #[test]
+    fn sidecar_paths_preserve_directory() {
+        let p = lock_path(Path::new("/var/cache/apr/model.bin"));
+        assert_eq!(p.parent(), Some(Path::new("/var/cache/apr")));
+    }
+
+    #[test]
+    fn sidecar_paths_work_on_relative_paths() {
+        let p = lock_path(Path::new("model.bin"));
+        assert_eq!(p, PathBuf::from("model.bin.lock"));
+    }
+
+    #[test]
+    fn sidecar_paths_work_on_paths_with_many_dots() {
+        // Sanity: we do not strip extensions. `foo.tar.gz` gets
+        // `foo.tar.gz.lock`, not `foo.tar.lock`.
+        let p = lock_path(Path::new("/tmp/foo.tar.gz"));
+        assert_eq!(p, PathBuf::from("/tmp/foo.tar.gz.lock"));
+    }
+
+    #[test]
+    fn compare_etag_returns_missing_recorded_on_none() {
+        assert_eq!(
+            compare_etag(None, "W/\"abc\""),
+            EtagDecision::MissingRecorded
+        );
+    }
+
+    #[test]
+    fn compare_etag_returns_missing_recorded_on_empty_string() {
+        assert_eq!(
+            compare_etag(Some(""), "W/\"abc\""),
+            EtagDecision::MissingRecorded
+        );
+        assert_eq!(
+            compare_etag(Some("   "), "W/\"abc\""),
+            EtagDecision::MissingRecorded
+        );
+    }
+
+    #[test]
+    fn compare_etag_returns_match_on_equal() {
+        assert_eq!(
+            compare_etag(Some("W/\"abc\""), "W/\"abc\""),
+            EtagDecision::Match
+        );
+    }
+
+    #[test]
+    fn compare_etag_trims_trailing_whitespace() {
+        // HTTP header writes often leave trailing newlines on disk.
+        assert_eq!(
+            compare_etag(Some("W/\"abc\"\n"), "W/\"abc\""),
+            EtagDecision::Match
+        );
+    }
+
+    #[test]
+    fn compare_etag_returns_mismatch_on_diff() {
+        assert_eq!(
+            compare_etag(Some("wrong-etag-value"), "W/\"served-etag\""),
+            EtagDecision::Mismatch
+        );
+    }
+
+    #[test]
+    fn should_discard_partial_agrees_with_decision() {
+        assert!(should_discard_partial(&EtagDecision::Mismatch));
+        assert!(should_discard_partial(&EtagDecision::MissingRecorded));
+        assert!(!should_discard_partial(&EtagDecision::Match));
+    }
+
+    #[test]
+    fn compare_etag_is_deterministic() {
+        let a = compare_etag(Some("x"), "y");
+        let b = compare_etag(Some("x"), "y");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn etag_mismatch_sub_claim_falsify_003() {
+        // CRUX-A-05 ALGO-003 sub-claim of FALSIFY-003: a pre-seeded
+        // stale etag "wrong-etag-value" on disk against a real served
+        // etag MUST classify as Mismatch, which is the precondition for
+        // the "discard + warn" integration path.
+        let decision = compare_etag(
+            Some("wrong-etag-value"),
+            "\"d41d8cd98f00b204e9800998ecf8427e\"",
+        );
+        assert_eq!(decision, EtagDecision::Mismatch);
+        assert!(should_discard_partial(&decision));
+    }
+
+    #[test]
+    fn sidecar_suffixes_are_stable() {
+        // Downstream shell tests grep for these exact suffixes.
+        assert_eq!(LOCK_SUFFIX, ".lock");
+        assert_eq!(ETAG_SUFFIX, ".etag");
+        assert_eq!(PARTIAL_SUFFIX, ".partial");
+    }
+}


### PR DESCRIPTION
## Summary

CRUX-A-05 resume sidecar path classifier + ETag comparator. Pure,
deterministic functions over paths and ETag strings — no I/O, no FS, no
network.

- `lock_path(target)` → `{target}.lock`
- `etag_path(target)` → `{target}.etag`
- `partial_path(target)` → `{target}.partial`
- `compare_etag(Option<&str>, &str) -> EtagDecision` ∈ `{MissingRecorded, Match, Mismatch}`
- `should_discard_partial(&EtagDecision) -> bool`

Contract: `contracts/crux-A-05-v1.yaml` v1.0.0-draft → **v1.1.0, status: partial**.
`pv validate`: 0 errors, 0 warnings.

## Discharge status (scope-honest)

| Gate | Status | Notes |
|------|--------|-------|
| FALSIFY-001 (partial → correct sha256) | ❌ NOT discharged | Needs HTTP Range + sha256 verify |
| FALSIFY-002 (complete shards → zero network) | ❌ NOT discharged | Needs HTTP |
| FALSIFY-003 (etag mismatch → discard + warn) | ✅ PARTIAL_ALGORITHM_LEVEL | Comparator returns Mismatch on wrong-etag-value; discard decision fires. Necessary not sufficient. |
| FALSIFY-004 (concurrent --resume mutex) | ✅ PARTIAL_ALGORITHM_LEVEL | `lock_path` is deterministic so racing processes contend on same canonical file. Necessary not sufficient. |

**NO INTEGRATION DISCHARGE** — the classifier is not yet wired into the
real `apr pull --resume` code path. No `fcntl`/`flock` acquisition, no
HTTP Range request, no stderr warning emission. Every existing write
site still needs a follow-up. Contract retains `status: partial`;
master `supported_count` stays at its current value.

Zero conflicts with any in-flight CRUX PR — this only adds a new module
and a single line to `commands/mod.rs`.

## Test plan

- [x] `pv validate contracts/crux-A-05-v1.yaml` → 0 errors
- [x] `cargo test -p apr-cli --lib commands::resume_paths` → 17/17 green
- [ ] CI `ci / gate` green
- [ ] CI `workspace-test` green
- [ ] Full discharge of FALSIFY-001..004 in follow-up (HTTP Range + advisory lock + stderr warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)