### PR TITLE
fix(pretrain): default to drive_real; add GATE-TRAIN-010 falsifier

### DIFF
--- a/contracts/training-loop-pretrain-v1.yaml
+++ b/contracts/training-loop-pretrain-v1.yaml
@@ -35,11 +35,11 @@
 # ─────────────────────────────────────────────────────────────
 
 contract_id: C-TRAIN-PRETRAIN
-version: 1.3.0
+version: 1.4.0
 status: ACTIVE
 
 metadata:
-  version: "1.3.0"
+  version: "1.4.0"
   created: "2026-04-18"
   updated: "2026-04-20"
   changelog:
@@ -63,6 +63,20 @@ metadata:
        over mode defaults. Motivation: task #119 used MODEL-1 finetune
        defaults (lr=5e-5, target=2.2) for a cold-start run — wrong LR
        band AND unreachable target. INV-TRAIN-005 is unchanged."
+    - "1.4.0 (2026-04-20): CLI default-routing gate. Adds
+       INV-TRAIN-010 / GATE-TRAIN-010 / FALSIFY-TRAIN-010 binding the
+       `apr pretrain` clap surface to its two drive paths:
+       `apr pretrain` (no --synthetic) MUST route to drive_real;
+       `apr pretrain --synthetic` MUST route to drive_synthetic.
+       Motivation: task #105's extended_commands.rs shipped
+       `#[arg(long, default_value = \"true\")] synthetic: bool` and
+       no `--synthetic=false` companion, so EVERY `apr pretrain`
+       invocation silently routed to the scripted-loss synthetic
+       path. Tasks #119 / #124 / #125 captured val_loss values that
+       exactly match the synthetic formula `target × 1.8` linear-
+       decayed — their 'real-compute' claims were actually synthetic.
+       Fix: `synthetic` becomes an explicit clap::ArgAction::SetTrue
+       flag (absent = false = real, present = true = synthetic)."
   author: PAIML Engineering
   description: >
     Pretraining loop contract: required per-step metrics, required
@@ -355,6 +369,28 @@ invariants:
       (c) `--mode finetune` (or no --mode) → regime=Finetune, lr_max=5e-5,
           warmup_steps=100, target_val_loss=2.2.
 
+  - id: INV-TRAIN-010
+    description: >
+      CLI default routing MUST reach drive_real. `apr pretrain`
+      without the `--synthetic` flag MUST parse to a Pretrain
+      command whose `synthetic` field is `false`, which routes
+      execution through drive_real (real 370M forward + backward +
+      AdamW over the dataset shards). `apr pretrain --synthetic`
+      MUST parse to `synthetic=true`, which routes through
+      drive_synthetic (scripted-loss sequence, no compute). No
+      intermediate CLI shape may silently coerce `--synthetic`
+      absent into `synthetic=true` — this was the defect that
+      caused tasks #119 / #124 / #125 to capture scripted-loss
+      values and mis-label them "real compute".
+    falsifier: >
+      CLI-parse-level harness: build an `apr pretrain --dataset X
+      --tokenizer Y --run-dir Z` argv, parse via `Cli::parse_from`,
+      destructure the resulting `ExtendedCommands::Pretrain`
+      variant, and assert `synthetic == false`. Then parse the
+      same argv with `--synthetic` appended and assert
+      `synthetic == true`. Any clap default that silently flips
+      the absent case to `true` fails the first assert.
+
 # ─────────────────────────────────────────────────────────────
 # Acceptance gates (bind to AC-SHIP2-* in the spec)
 # ─────────────────────────────────────────────────────────────
@@ -476,6 +512,34 @@ gates:
       - "crates/apr-cli/src/commands/pretrain.rs::tests::mode_from_scratch_applies_all_four_defaults"
       - "crates/apr-cli/src/commands/pretrain.rs::tests::mode_from_scratch_honors_explicit_lr_override"
       - "crates/apr-cli/src/commands/pretrain.rs::tests::mode_finetune_is_default_and_matches_contract"
+
+  - id: GATE-TRAIN-010
+    rule: >
+      `apr pretrain` (no --synthetic flag) routes execution through
+      drive_real (real 370M forward + backward + AdamW on dataset
+      shards). `apr pretrain --synthetic` routes through
+      drive_synthetic. INV-TRAIN-010. Ship-blocking: without this
+      gate, every real-compute claim is falsifiable as scripted-
+      loss output.
+    evidence_required: >
+      apr-cli parse-level harness: build argv for
+      `apr pretrain --dataset … --tokenizer … --run-dir …`, parse
+      with `Cli::parse_from`, destructure the Pretrain variant,
+      and assert `synthetic == false`. Add `--synthetic` to the
+      argv, re-parse, assert `synthetic == true`.
+    verdict: pass
+    binds_to: AC-SHIP2-003
+    ship_blocking: true
+    motivation: >
+      task #105 shipped `default_value = "true"` on the synthetic
+      flag with no `--synthetic=false` companion, so every
+      `apr pretrain` ran the scripted-loss path. The reported
+      val_loss values (e.g. 18 at target=10, 4.2 at target=3)
+      match the synthetic formula target × 1.8 linear-decayed,
+      proving no real compute happened.
+    evidence_discharged_by:
+      - "crates/apr-cli/src/commands/pretrain.rs::tests::cli_pretrain_defaults_to_real_compute"
+      - "crates/apr-cli/src/commands/pretrain.rs::tests::cli_pretrain_synthetic_flag_routes_to_synthetic"
 
 # ─────────────────────────────────────────────────────────────
 # Failure modes (documented so future operators can recognize them)

--- a/crates/apr-cli/src/commands/pretrain.rs
+++ b/crates/apr-cli/src/commands/pretrain.rs
@@ -569,4 +569,69 @@ mod tests {
         assert_eq!(hp.warmup_steps, 1000);
         assert!((hp.target_val_loss - 3.0).abs() < 1.0e-6);
     }
+
+    // ── GATE-TRAIN-010 / INV-TRAIN-010 falsifiers ──────────────────────
+    // Contract: training-loop-pretrain-v1 v1.4.0 §INV-TRAIN-010
+    //
+    // Task #105's original wiring shipped `synthetic: bool` with
+    // `default_value = "true"`. The `--synthetic` flag had no
+    // companion to turn it off, so every invocation of `apr pretrain`
+    // silently routed to drive_synthetic. Tasks #119 / #124 / #125
+    // all captured scripted-loss output and mis-labeled it real
+    // compute. These two tests parse actual argv through clap and
+    // assert the routing discriminator byte-for-byte.
+
+    fn parse_pretrain_synthetic(extra: &[&str]) -> bool {
+        // The `Commands` enum is large enough in debug builds to overflow
+        // the default 2 MiB test-thread stack during clap's recursive
+        // destructuring. Run the parse on a worker thread with a 16 MiB
+        // stack so this falsifier passes in both debug and release.
+        let extra: Vec<String> = extra.iter().map(|s| (*s).to_string()).collect();
+        std::thread::Builder::new()
+            .stack_size(16 * 1024 * 1024)
+            .spawn(move || {
+                use clap::Parser;
+                let mut argv: Vec<String> = vec![
+                    "apr".to_string(),
+                    "pretrain".to_string(),
+                    "--dataset".to_string(),
+                    "/tmp/_gate_train_010/ds".to_string(),
+                    "--tokenizer".to_string(),
+                    "/tmp/_gate_train_010/tok".to_string(),
+                    "--run-dir".to_string(),
+                    "/tmp/_gate_train_010/run".to_string(),
+                ];
+                argv.extend(extra);
+                let cli = crate::Cli::try_parse_from(&argv).expect("clap parse must succeed");
+                match *cli.command {
+                    crate::Commands::Extended(crate::ExtendedCommands::Pretrain {
+                        synthetic,
+                        ..
+                    }) => synthetic,
+                    other => panic!("expected ExtendedCommands::Pretrain, got {other:?}"),
+                }
+            })
+            .expect("spawn parse thread")
+            .join()
+            .expect("parse thread must not panic")
+    }
+
+    #[test]
+    fn cli_pretrain_defaults_to_real_compute() {
+        // Absent `--synthetic` MUST parse to synthetic=false so the
+        // dispatcher routes through drive_real.
+        assert!(
+            !parse_pretrain_synthetic(&[]),
+            "INV-TRAIN-010: `apr pretrain` (no --synthetic) must parse to synthetic=false"
+        );
+    }
+
+    #[test]
+    fn cli_pretrain_synthetic_flag_routes_to_synthetic() {
+        // `--synthetic` present MUST parse to synthetic=true.
+        assert!(
+            parse_pretrain_synthetic(&["--synthetic"]),
+            "INV-TRAIN-010: `apr pretrain --synthetic` must parse to synthetic=true"
+        );
+    }
 }

--- a/crates/apr-cli/src/extended_commands.rs
+++ b/crates/apr-cli/src/extended_commands.rs
@@ -1,4 +1,3 @@
-
 /// Extended CLI commands (analysis, profiling, QA, benchmarks, and advanced tools).
 ///
 /// Flattened into `Commands` via `#[command(flatten)]` so all subcommands remain
@@ -677,7 +676,8 @@ pub enum ExtendedCommands {
         #[arg(long, default_value = "50257")]
         vocab_size: u32,
         /// Synthetic-drive only — do not attempt real compute, exercise loop gates only.
-        #[arg(long, default_value = "true")]
+        /// INV-TRAIN-010: absent = real compute (drive_real), present = synthetic (drive_synthetic).
+        #[arg(long, action = clap::ArgAction::SetTrue)]
         synthetic: bool,
     },
     /// Tokenizer training pipeline (plan/apply) — BPE vocabulary learning


### PR DESCRIPTION
## Summary
- **Root cause**: `apr pretrain` shipped with `#[arg(long, default_value = "true")] synthetic: bool` and no `--synthetic=false` companion. Every invocation silently routed to `drive_synthetic` (scripted-loss), so tasks #119 / #124 / #125 captured synthetic output and mis-labeled it real compute. val_loss=18 at target=10 and val_loss=4.2 at target=3 match the synthetic formula `target × 1.8` linear-decayed — proving no real compute ran.
- **Fix**: `action = ArgAction::SetTrue` → absent = false = drive_real, present = true = drive_synthetic.
- **Contract-first**: bump `training-loop-pretrain-v1` v1.3.0 → v1.4.0 with **INV-TRAIN-010** (CLI default routing) and **GATE-TRAIN-010** (ship_blocking, binds AC-SHIP2-003). Two parse-level falsifier tests assert the routing discriminator byte-for-byte.

## Why parse-level tests?
Existing `mode_*` tests call `run(...)` directly with explicit `synthetic: bool` — they never exercise the clap surface, which is exactly why the defect slipped through task #105. The new tests drive `Cli::try_parse_from` so any future regression in the clap attribute fails a unit test before it reaches CI.

## Test plan
- [x] `cargo test -p apr-cli --features training --lib pretrain` → 8/8 pass (debug + release)
- [x] `pv validate contracts/training-loop-pretrain-v1.yaml` → 0 errors, 0 warnings
- [x] `cargo build -p apr-cli --features training` → clean
- [ ] CI `ci / gate` + `workspace-test` green
- [ ] After merge: rebuild canonical binary on lambda-labs, re-dispatch task #126

## Unblocks
Task #126 — MODEL-2 from-scratch pretrain on lambda-labs RTX 4090.

🤖 Generated with [Claude Code](https://claude.com/claude-code)