### PR TITLE
fix(aprender-serve): QA-011 threshold 3x → 10x (second perf-flake chain blocker)

### DIFF
--- a/crates/aprender-serve/src/layers/tests/qa_perf_tests.rs
+++ b/crates/aprender-serve/src/layers/tests/qa_perf_tests.rs
@@ -46,21 +46,25 @@ fn test_qa_011_throughput_regression_detection() {
     current_times.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
     let current_time = current_times[2]; // Median
 
-    // Current time should not be significantly slower than baseline
-    // Using 3x threshold to account for:
-    // - Coverage instrumentation overhead
-    // - CI system load variability
-    // - CPU frequency scaling during test
-    // per Hoefler & Belli [2] recommendations for CV-based stopping
-    // Note: Real regression detection would compare against stored historical baseline
-    let regression_threshold = 3.0;
+    // Current time should not be CATASTROPHICALLY slower than baseline.
+    //
+    // This test compares two adjacent runs from the same commit, so it cannot
+    // actually detect a real perf regression — at best it detects noise-
+    // bounded throughput. A 3x threshold was previously used and observed to
+    // flake on shared self-hosted runners at 3.25x under tenant contention
+    // (qa_perf_tests.rs:59 failure, chain blocker 2026-04-20).
+    //
+    // We bump the threshold to 10x so the test only fires on catastrophic
+    // regressions (e.g., an accidental O(n^2) in LayerNorm). Sub-10x drift is
+    // scheduler/frequency-scaling jitter, NOT a regression signal, and real
+    // regression detection belongs in the benchmark suite with stored
+    // historical baselines — not a unit test.
+    let regression_threshold = 10.0;
     let ratio = current_time / baseline_time;
 
     assert!(
         ratio < regression_threshold,
-        "QA-011: Throughput regression detected: {:.2}x slower (threshold: {}x)",
-        ratio,
-        regression_threshold
+        "QA-011: Throughput regression detected: {ratio:.2}x slower (threshold: {regression_threshold}x)",
     );
 }
 


### PR DESCRIPTION
## Problem

`test_qa_011_throughput_regression_detection` at `crates/aprender-serve/src/layers/tests/qa_perf_tests.rs:59` fails intermittently on shared self-hosted runners:

```
thread '...test_qa_011_throughput_regression_detection' panicked:
QA-011: Throughput regression detected: 3.25x slower (threshold: 3x)
```

This is the second perf-timing flake blocking the CRUX classifier chain (#950–#954); first was imp-080 fixed in #955.

## Root Cause

The test measures `LayerNorm::forward` throughput twice, takes the median of 5 trials each time, and asserts the second median is < 3x the first. But:

1. Both runs come from the **same commit**, so this cannot detect a real regression — it only bounds noise.
2. On a shared self-hosted runner under tenant contention, CPU frequency scaling + scheduler jitter can easily widen the ratio past 3x (observed 3.25x).
3. The existing comment already acknowledged this was a compromise. Observed 3.25x invalidates the 3x choice.

## Fix

- Bump threshold `3.0` → `10.0`. A 10x slowdown is catastrophic (e.g., accidental O(n²)) and is the only regression class this test can actually detect from same-commit adjacent runs.
- Document in the comment that real regression detection belongs in the benchmark suite with stored historical baselines.
- Inline format-args (clippy).

## Verification

```
$ cargo test -p aprender-serve --lib test_qa_011_throughput_regression_detection
test layers::tests::qa_012_latency::test_qa_011_throughput_regression_detection ... ok
```

## Andon

Per `main CI andon` rule: red main preempts feature work; `#[ignore]` banned for flakes. This is the root-cause fix — the test still runs and still catches catastrophic regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)