### PR TITLE
feat(gate-arch-370m-011): pre-flight tokenizer↔model vocab parity gate (task #128)

### DIFF
--- a/contracts/model-families/llama-370m-sovereign-v1.yaml
+++ b/contracts/model-families/llama-370m-sovereign-v1.yaml
@@ -36,14 +36,29 @@
 # ─────────────────────────────────────────────────────────────
 
 contract_id: C-LLAMA-370M-SOVEREIGN
-version: 1.3.0
+version: 1.4.0
 status: ACTIVE
 
 metadata:
-  version: "1.3.0"
+  version: "1.4.0"
   created: "2026-04-18"
-  updated: "2026-04-19"
+  updated: "2026-04-21"
   changelog:
+    - "1.4.0 (2026-04-21): Added GATE-ARCH-370M-011 operationalizing
+       INV-ARCH-370M-006 as a pre-flight gate on the `apr pretrain`
+       dispatch path. Motivation: first real-compute MODEL-2 dispatch
+       (commit 29607ed33, task #126) fired the N-09 OOB escape guard
+       on the first forward pass because the tokenizer artifact at
+       /mnt/nvme-raid0/models/model-2-tokenizer-v1/ has 50_257 vocab
+       entries but this contract pins VOCAB_SIZE=50_000 exact. The
+       INV-ARCH-370M-006 invariant named the required check but had
+       no enforced falsifier — training would silently emit garbage
+       gradients. GATE-ARCH-370M-011 wires a hard pre-flight in
+       drive_real (crates/apr-cli/src/commands/pretrain.rs) that
+       reads tokenizer/vocab.json, counts entries, and refuses to
+       start training when tokenizer.vocab_size() != model.vocab_size.
+       Contract stays ACTIVE — the new gate hardens an existing
+       invariant rather than introducing a new architectural claim."
     - "1.0.0 (2026-04-18): Initial contract drafted as PROPOSED — froze
        albor 370M architectural constants before pretraining begins."
     - "1.1.0 (2026-04-19): Promoted to ACTIVE. FALSIFY-SHIP-011
@@ -441,6 +456,33 @@ gates:
     verdict: pass
     binds_to: AC-SHIP2-009
     falsification_id: FALSIFY-SHIP-019
+    ship_blocking: true
+
+  - id: GATE-ARCH-370M-011
+    rule: >
+      At the entry point of every `apr pretrain` dispatch, the paired
+      tokenizer's vocab size (loaded from tokenizer_dir/vocab.json)
+      MUST equal the 370M Llama model's vocab_size
+      (`Llama370MConfig::VOCAB_SIZE`). Mismatch is a ship-blocker:
+      dispatch aborts with a clear error before the first forward
+      pass. Operationalizes INV-ARCH-370M-006.
+    evidence_required: >
+      `cargo test -p apr-cli --lib pretrain` exercises the pre-flight:
+      (1) tokenizer vocab == model vocab → dispatch proceeds
+      (2) tokenizer vocab != model vocab → CliError::ValidationFailed
+          with a message citing GATE-ARCH-370M-011 and naming both
+          numbers. And `cargo test -p aprender-train --lib llama_370m`
+          passes `falsify_gate_arch_370m_011_helper_rejects_mismatch`
+          which asserts the pure vocab-parity helper rejects any
+          (tokenizer_vocab, model_vocab) pair where they differ.
+    evidence_discharged_by:
+      - "crates/apr-cli/src/commands/pretrain.rs::assert_tokenizer_vocab_matches_model"
+      - "crates/apr-cli/src/commands/pretrain.rs::tests::preflight_rejects_tokenizer_vocab_mismatch"
+      - "crates/apr-cli/src/commands/pretrain.rs::tests::preflight_accepts_matching_vocab"
+      - "crates/aprender-train/src/models/llama_370m.rs::tests::falsify_gate_arch_370m_011_helper_rejects_mismatch"
+    verdict: pass
+    binds_to: AC-SHIP2-003
+    falsification_id: FALSIFY-ARCH-370M-011
     ship_blocking: true
 
 references:

--- a/crates/apr-cli/src/commands/pretrain.rs
+++ b/crates/apr-cli/src/commands/pretrain.rs
@@ -16,6 +16,7 @@ use crate::error::{CliError, Result};
 use crate::output;
 use clap::ValueEnum;
 use colored::Colorize;
+use entrenar::models::llama_370m::{assert_tokenizer_vocab_matches_model, Llama370MConfig};
 use entrenar::train::pretrain::{
     CheckpointFn, LinearDecaySynthetic, PretrainAbort, PretrainConfig, PretrainLoop, RunStatus,
     ScriptedVal, StepFn, TrainingRegime, ValFn,
@@ -199,6 +200,30 @@ fn drive_synthetic(
     run_and_report(config, step_fn, val_fn, None, json_output)
 }
 
+/// GATE-ARCH-370M-011 pre-flight: count the tokenizer's vocabulary entries
+/// from `vocab.json` and assert the count matches `Llama370MConfig::VOCAB_SIZE`
+/// before any trainer allocation. Any mismatch aborts the dispatch with a
+/// clear error naming both values and the violated invariant — the N-09 OOB
+/// escape in `Embedding::forward` would otherwise silently corrupt training.
+fn preflight_tokenizer_vocab_matches_model(tokenizer_dir: &Path) -> Result<()> {
+    let vocab_path = tokenizer_dir.join("vocab.json");
+    let vocab_json = std::fs::read_to_string(&vocab_path).map_err(|e| {
+        CliError::ValidationFailed(format!(
+            "GATE-ARCH-370M-011 pre-flight: cannot read {} ({e})",
+            vocab_path.display()
+        ))
+    })?;
+    let vocab: serde_json::Map<String, serde_json::Value> = serde_json::from_str(&vocab_json)
+        .map_err(|e| {
+            CliError::ValidationFailed(format!(
+                "GATE-ARCH-370M-011 pre-flight: {} is not a valid vocab.json: {e}",
+                vocab_path.display()
+            ))
+        })?;
+    assert_tokenizer_vocab_matches_model(vocab.len(), Llama370MConfig::VOCAB_SIZE)
+        .map_err(CliError::ValidationFailed)
+}
+
 /// Real-corpus drive: build a shared 370M `TransformerTrainer`, split
 /// the shard stream head-off into a held-out validation set, and run a
 /// full forward + backward + AdamW step per training batch.
@@ -211,6 +236,13 @@ fn drive_real(
     seed: u64,
     json_output: bool,
 ) -> Result<RunStatus> {
+    // GATE-ARCH-370M-011 / INV-ARCH-370M-006 — refuse to dispatch a real
+    // training step when the tokenizer vocab_size and the model vocab_size
+    // disagree. The N-09 OOB escape guard in Embedding::forward masks the
+    // mismatch at runtime → silent garbage gradients otherwise. Synthetic
+    // drive skips this check because it never touches the real model.
+    preflight_tokenizer_vocab_matches_model(&config.tokenizer_dir)?;
+
     // MVP: pad_id/eos_id both 0. All sequences are uniform length
     // (seq_length + 1) so LMBatch::from_sequences takes the shared
     // layout path and pad_id is never used for padding. The real
@@ -415,6 +447,79 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
+    /// Stage a `vocab.json` with exactly `n` distinct integer-string tokens at
+    /// `<dir>/vocab.json`. Used by pre-flight gate tests + by other tests that
+    /// need to get PAST the GATE-ARCH-370M-011 pre-flight to exercise a later
+    /// failure mode (e.g. empty dataset shards).
+    fn stage_vocab_json(dir: &std::path::Path, n: usize) {
+        std::fs::create_dir_all(dir).expect("mkdir tokenizer dir");
+        let mut obj = serde_json::Map::with_capacity(n);
+        for i in 0..n {
+            obj.insert(format!("t{i}"), serde_json::Value::from(i as u64));
+        }
+        let json = serde_json::to_string(&obj).expect("serialize");
+        std::fs::write(dir.join("vocab.json"), json).expect("write vocab.json");
+    }
+
+    #[test]
+    fn preflight_accepts_matching_vocab() {
+        // GATE-ARCH-370M-011 acceptance case: tokenizer vocab.json with
+        // exactly Llama370MConfig::VOCAB_SIZE entries must pass pre-flight.
+        let tmp = TempDir::new().expect("tempdir");
+        stage_vocab_json(tmp.path(), Llama370MConfig::VOCAB_SIZE);
+        preflight_tokenizer_vocab_matches_model(tmp.path())
+            .expect("matching vocab must pass GATE-ARCH-370M-011");
+    }
+
+    #[test]
+    fn preflight_rejects_tokenizer_vocab_mismatch() {
+        // FALSIFY-ARCH-370M-011: a tokenizer at 50_257 paired with the
+        // 370M model (VOCAB_SIZE=50_000) MUST abort dispatch with an
+        // error message that names both values and the gate id, so the
+        // operator can see the mismatch without stepping through code.
+        let tmp = TempDir::new().expect("tempdir");
+        stage_vocab_json(tmp.path(), 50_257);
+        let err = preflight_tokenizer_vocab_matches_model(tmp.path())
+            .expect_err("50_257 vs 50_000 must be rejected");
+        match err {
+            CliError::ValidationFailed(msg) => {
+                assert!(
+                    msg.contains("GATE-ARCH-370M-011"),
+                    "msg must cite gate: {msg}"
+                );
+                assert!(
+                    msg.contains("50257"),
+                    "msg must name tokenizer vocab: {msg}"
+                );
+                assert!(msg.contains("50000"), "msg must name model vocab: {msg}");
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn preflight_rejects_missing_vocab_json() {
+        // Missing vocab.json is a pre-flight failure (not a later shard
+        // error) — the operator should know the tokenizer layout is
+        // wrong, not that the dataset is empty.
+        let tmp = TempDir::new().expect("tempdir");
+        let err = preflight_tokenizer_vocab_matches_model(tmp.path())
+            .expect_err("missing vocab.json must be rejected");
+        match err {
+            CliError::ValidationFailed(msg) => {
+                assert!(
+                    msg.contains("GATE-ARCH-370M-011"),
+                    "msg must cite gate: {msg}"
+                );
+                assert!(
+                    msg.contains("cannot read"),
+                    "msg must name I/O failure: {msg}"
+                );
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
     #[test]
     fn synthetic_pretrain_end_to_end_happy_path() {
         let tmp = TempDir::new().expect("tempdir");
@@ -450,10 +555,14 @@ mod tests {
         // When --synthetic is off, the real-corpus branch must surface a
         // clear error if the dataset directory has no .bin shards. This
         // supersedes the old "non-synthetic is not implemented" guard.
+        // Stage a valid vocab.json first so GATE-ARCH-370M-011 pre-flight
+        // passes — otherwise the shard-iterator error below is never reached.
         let tmp = TempDir::new().expect("tempdir");
+        let tok_dir = tmp.path().join("tok");
+        stage_vocab_json(&tok_dir, Llama370MConfig::VOCAB_SIZE);
         let err = run(
             tmp.path(),
-            tmp.path(),
+            &tok_dir,
             tmp.path(),
             PretrainMode::Finetune,
             Some(5.0e-5),

--- a/crates/aprender-train/src/models/llama_370m.rs
+++ b/crates/aprender-train/src/models/llama_370m.rs
@@ -361,6 +361,28 @@ pub const fn estimated_stored_param_count() -> usize {
     embedding + l * per_layer + final_norm
 }
 
+/// Pure helper that enforces GATE-ARCH-370M-011 / INV-ARCH-370M-006:
+/// the tokenizer's vocabulary size MUST exactly match the model's
+/// `vocab_size` before pretraining dispatches. Returns `Ok(())` when
+/// they match, `Err(String)` with a machine-diffable message when they
+/// do not. The caller is expected to surface the error to the user
+/// and abort the dispatch before any forward pass.
+pub fn assert_tokenizer_vocab_matches_model(
+    tokenizer_vocab_size: usize,
+    model_vocab_size: usize,
+) -> Result<(), String> {
+    if tokenizer_vocab_size == model_vocab_size {
+        return Ok(());
+    }
+    Err(format!(
+        "GATE-ARCH-370M-011 (INV-ARCH-370M-006) violated: \
+         tokenizer vocab_size ({tokenizer_vocab_size}) != model vocab_size \
+         ({model_vocab_size}). See contracts/model-families/llama-370m-sovereign-v1.yaml \
+         and contracts/tokenizer-bpe-v1.yaml — retrain the tokenizer or amend both contracts \
+         in lockstep before resuming pretraining."
+    ))
+}
+
 // ─────────────────────────────────────────────────────────────
 // Unit tests
 // ─────────────────────────────────────────────────────────────
@@ -394,6 +416,35 @@ mod tests {
             Llama370MConfig::HIDDEN_DIM,
         );
         assert_eq!(Llama370MConfig::NUM_HEADS % Llama370MConfig::NUM_KV_HEADS, 0);
+    }
+
+    /// GATE-ARCH-370M-011 / INV-ARCH-370M-006 — pure vocab-parity helper
+    /// MUST reject any mismatch between tokenizer vocab_size and model
+    /// vocab_size, and MUST accept equal values. The real-compute MODEL-2
+    /// dispatch at commit 29607ed33 surfaced this when a tokenizer at
+    /// vocab=50_257 was paired with a model pinned at VOCAB_SIZE=50_000;
+    /// the N-09 OOB escape masked the mismatch → garbage gradients.
+    #[test]
+    fn falsify_gate_arch_370m_011_helper_rejects_mismatch() {
+        assert!(assert_tokenizer_vocab_matches_model(
+            Llama370MConfig::VOCAB_SIZE,
+            Llama370MConfig::VOCAB_SIZE,
+        )
+        .is_ok());
+
+        let err = assert_tokenizer_vocab_matches_model(50_257, Llama370MConfig::VOCAB_SIZE)
+            .expect_err("mismatch must return Err");
+        assert!(
+            err.contains("GATE-ARCH-370M-011") && err.contains("50257") && err.contains("50000"),
+            "error must name the gate and both vocab sizes for forensics, got: {err}",
+        );
+
+        assert!(assert_tokenizer_vocab_matches_model(0, 1).is_err());
+        assert!(assert_tokenizer_vocab_matches_model(
+            Llama370MConfig::VOCAB_SIZE + 1,
+            Llama370MConfig::VOCAB_SIZE
+        )
+        .is_err());
     }
 
     /// INV-ARCH-370M-001 — estimated param count within [366M, 374M].


### PR DESCRIPTION
## Summary
- Ships orthogonal pre-flight gate `GATE-ARCH-370M-011` that refuses `apr pretrain` real-compute dispatch when `tokenizer.vocab_size != Llama370MConfig::VOCAB_SIZE`.
- Discovered after re-dispatching task #126 post-PR #949: first real MODEL-2 run at commit 29607ed33 fired `Embedding::forward token_id 50241 >= vocab_size 50000. N-09 OOB escape.` on step 1 — silently corrupts gradients via the N-09 escape path.
- Root cause decomposes 3 ways (tokenizer artifact @50_257 vs contracts pinned @50_000, hardcoded `VOCAB_SIZE` const, no pre-flight gate). This PR fixes only the gate (D3). D1/D2 need an A/B decision and will follow.

## Changes
- `contracts/model-families/llama-370m-sovereign-v1.yaml` v1.3.0 → v1.4.0: new `GATE-ARCH-370M-011` + `FALSIFY-ARCH-370M-011`, `ship_blocking: true`, `binds_to: AC-SHIP2-003`. `pv validate` → 0 errors.
- `crates/aprender-train/src/models/llama_370m.rs`: pure algorithm-level helper `assert_tokenizer_vocab_matches_model` + `falsify_gate_arch_370m_011_helper_rejects_mismatch` test covering match, 50_257 vs 50_000 mismatch, and edge cases.
- `crates/apr-cli/src/commands/pretrain.rs`: CLI wrapper `preflight_tokenizer_vocab_matches_model` reads `<tokenizer_dir>/vocab.json`, delegates to pure helper. Called at top of `drive_real` before `ShardBatchIter::new`. Synthetic drive is intentionally exempt (never touches the real model). 3 new tests + 1 fixed test (staged valid vocab.json so the intended shard-iterator failure path is still reachable).

## Verification
- [x] `cargo test -p aprender-train --lib llama_370m` → 10 passed
- [x] `cargo test -p apr-cli --lib commands::pretrain` → 11 passed (4 new)
- [x] `cargo run -p aprender-contracts-cli --bin pv -- validate contracts/model-families/llama-370m-sovereign-v1.yaml` → valid
- [x] `cargo clippy -p aprender-train -p apr-cli --lib -- -D warnings` → clean
- [x] `cargo fmt -- --check` on affected files → clean

## Test plan
- [ ] CI `ci / gate` passes
- [ ] CI `workspace-test` passes
- [ ] Post-merge: dispatch `apr pretrain --mode from-scratch` with mismatched tokenizer → verify refusal message cites GATE-ARCH-370M-011 and both vocab sizes
- [ ] Post-merge: follow-up PR to resolve D1/D2 (A: bump contracts to 50_257, B: retrain tokenizer to 50_000)

## Unblocks
- task #126 (MODEL-2 from-scratch real-compute dispatch) — pending D1/D2 A/B decision

🤖 Generated with [Claude Code](https://claude.com/claude-code)