### PR TITLE
feat(crux-a-21): APR_MODELS shared cache + sha256 blob-dedup + EACCES exit-13 classifier (2 of 2 FALSIFY at PARTIAL_ALGORITHM_LEVEL)

### DIFF
--- a/contracts/apr-cli-commands-v1.yaml
+++ b/contracts/apr-cli-commands-v1.yaml
@@ -21,7 +21,7 @@ metadata:
 kind: CLICommandContract
 name: apr-cli-commands
 version: "1.0.0"
-scope: "all apr CLI subcommands (75 commands — original 57 + `mcp` added 2026-04-17 via PR #864 + `registry` added 2026-04-20 via CRUX-A-01 + `ollama-chat-lint` added 2026-04-21 via CRUX-C-04 SHIP-001 retrofit + `dry-sampling-lint` added 2026-04-21 via CRUX-C-23 SHIP-001 retrofit + `awq-lint` added 2026-04-21 via CRUX-B-08 SHIP-001 retrofit + `oom-lint` added 2026-04-21 via CRUX-F-13 SHIP-001 + `tool-use-lint` added 2026-04-21 via CRUX-C-11 SHIP-001 retrofit + `gbnf-lint` added 2026-04-21 via CRUX-C-10 SHIP-001 retrofit + `typical-p-lint` added 2026-04-21 via CRUX-C-22 SHIP-001 retrofit + `grad-norm` added 2026-04-21 via CRUX-F-09 + `registry-quota-lint` added 2026-04-21 via CRUX-A-22 SHIP-001 retrofit + `fp8-lint` added 2026-04-22 via CRUX-B-11 SHIP-001 retrofit + `imatrix-lint` added 2026-04-22 via CRUX-B-07 SHIP-001 retrofit + `nf4-lint` added 2026-04-22 via CRUX-B-10 SHIP-001 retrofit + `gptq-lint` added 2026-04-22 via CRUX-B-09 SHIP-001 retrofit + `embeddings-lint` added 2026-04-23 via CRUX-C-13 SHIP-001 retrofit + `unified-search-lint` added 2026-04-23 via CRUX-A-23 SHIP-001 retrofit + `rm-gc-lint` added 2026-04-23 via CRUX-A-25 SHIP-001 retrofit)"
+scope: "all apr CLI subcommands (76 commands — original 57 + `mcp` added 2026-04-17 via PR #864 + `registry` added 2026-04-20 via CRUX-A-01 + `ollama-chat-lint` added 2026-04-21 via CRUX-C-04 SHIP-001 retrofit + `dry-sampling-lint` added 2026-04-21 via CRUX-C-23 SHIP-001 retrofit + `awq-lint` added 2026-04-21 via CRUX-B-08 SHIP-001 retrofit + `oom-lint` added 2026-04-21 via CRUX-F-13 SHIP-001 + `tool-use-lint` added 2026-04-21 via CRUX-C-11 SHIP-001 retrofit + `gbnf-lint` added 2026-04-21 via CRUX-C-10 SHIP-001 retrofit + `typical-p-lint` added 2026-04-21 via CRUX-C-22 SHIP-001 retrofit + `grad-norm` added 2026-04-21 via CRUX-F-09 + `registry-quota-lint` added 2026-04-21 via CRUX-A-22 SHIP-001 retrofit + `fp8-lint` added 2026-04-22 via CRUX-B-11 SHIP-001 retrofit + `imatrix-lint` added 2026-04-22 via CRUX-B-07 SHIP-001 retrofit + `nf4-lint` added 2026-04-22 via CRUX-B-10 SHIP-001 retrofit + `gptq-lint` added 2026-04-22 via CRUX-B-09 SHIP-001 retrofit + `embeddings-lint` added 2026-04-23 via CRUX-C-13 SHIP-001 retrofit + `unified-search-lint` added 2026-04-23 via CRUX-A-23 SHIP-001 retrofit + `rm-gc-lint` added 2026-04-23 via CRUX-A-25 SHIP-001 retrofit + `shared-cache-lint` added 2026-04-23 via CRUX-A-21 SHIP-001 retrofit)"
 binary: "apr"
 install: "cargo install aprender"
 
@@ -483,6 +483,12 @@ commands:
   - name: rm-gc-lint
     category: inspection
     description: "Lint a captured `apr rm` / `apr gc` blob-GC observation (CRUX-A-25)"
+    requires_model: false
+    side_effects: []
+
+  - name: shared-cache-lint
+    category: inspection
+    description: "Lint a captured APR_MODELS shared-cache observation (CRUX-A-21)"
     requires_model: false
     side_effects: []
 

--- a/contracts/crux-A-21-v1.yaml
+++ b/contracts/crux-A-21-v1.yaml
@@ -2,8 +2,9 @@
 
 metadata:
   id: CRUX-A-21
-  version: "1.2.0"
+  version: "1.3.0"
   created: "2026-04-18"
+  updated: "2026-04-21"
   author: PAIML Engineering
   registry: true
   status: partial
@@ -79,6 +80,14 @@ falsification_tests:
     scope: registry-root resolution + content-addressed blob path (pure functions)
     discharge_status: PARTIAL_ALGORITHM_LEVEL
     full_discharge_blocked_on: two-user integration harness on a shared filesystem with APR_MODELS set
+    cli_path: crates/apr-cli/src/commands/shared_cache_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_a_21.rs
+    e2e_tests:
+    - falsify_crux_a_21_001_dedup_env_wins_and_paths_collapse
+    - falsify_crux_a_21_001_dedup_home_fallback_when_env_absent
+    - falsify_crux_a_21_001_dedup_wrong_expected_root_fails
+    - falsify_crux_a_21_001_dedup_invalid_hex_fails
+    - falsify_crux_a_21_001_dedup_missing_home_errors
 - id: FALSIFY-CRUX-A-21-002
   rule: read-only user can still load, but pull fails with exit 13
   prediction: "unprivileged user gets EACCES with actionable hint"
@@ -109,6 +118,16 @@ falsification_tests:
     scope: EACCES → exit-13 classifier (pure function over ErrorKind)
     discharge_status: PARTIAL_ALGORITHM_LEVEL
     full_discharge_blocked_on: end-to-end `apr pull` harness with a 0555-mode APR_MODELS dir asserting the process exits 13
+    cli_path: crates/apr-cli/src/commands/shared_cache_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_a_21.rs
+    e2e_tests:
+    - falsify_crux_a_21_002_permission_eacces_exit_13
+    - falsify_crux_a_21_002_permission_not_found_exit_1
+    - falsify_crux_a_21_002_permission_timed_out_is_other
+    - falsify_crux_a_21_002_permission_wrong_exit_code_fails
+    - falsify_crux_a_21_002_permission_wrong_hint_substring_fails
+    - falsify_crux_a_21_002_permission_declaring_ok_on_eacces_fails
+    - falsify_crux_a_21_002_permission_unknown_kind_fails
 proof_obligations:
 - type: equivalence
   property: "APR_MODELS honored exactly like OLLAMA_MODELS on systemd deploys"
@@ -129,6 +148,24 @@ verification_summary:
   - falsify_id: FALSIFY-CRUX-A-21-002
     discharge_status: PARTIAL_ALGORITHM_LEVEL
     blocked_on: end-to-end apr pull EACCES exit-13 harness
+
+ship_discipline:
+  retrofit_applied: "2026-04-21"
+  merge_gates:
+    g1_classifier_green:
+      status: satisfied
+      evidence: crates/apr-cli/src/commands/shared_cache.rs
+    g2_cli_reachable:
+      status: satisfied
+      evidence: "apr shared-cache-lint --help advertises --observation-file"
+      dispatcher: crates/apr-cli/src/commands/shared_cache_lint.rs
+    g3_e2e_runs:
+      status: satisfied
+      evidence: crates/apr-cli/tests/falsification_crux_a_21.rs
+      test_count: 20
+    g4_contract_discharged:
+      status: satisfied
+      evidence: "both FALSIFY blocks carry cli_path + e2e_path + e2e_tests"
 
 pmat_work_tracking:
   ticket_tag: crux-crux-a-21

--- a/contracts/crux-A-21-v1.yaml
+++ b/contracts/crux-A-21-v1.yaml
@@ -2,11 +2,11 @@
 
 metadata:
   id: CRUX-A-21
-  version: "1.1.0"
+  version: "1.2.0"
   created: "2026-04-18"
   author: PAIML Engineering
   registry: true
-  status: draft
+  status: partial
   parent_contracts:
   - crux-competitive-research-ux-v1
   category: "A — Model Intake & Discovery"
@@ -52,6 +52,33 @@ falsification_tests:
     count2=$(find "$APR_MODELS/blobs" -type f 2>/dev/null | wc -l)
     [ "$count1" = "$count2" ]
   if_fails: rule 'two pulls to shared cache dedup to one blob' is violated — contract MUST be re-verified against competitor canonical reference
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/shared_cache.rs
+    sub_claim: |
+      Algorithm-level necessary condition: `blob_path_for(root, sha256_hex)`
+      is a pure function of (root, hex). Two processes computing the path
+      for the same content-addressed blob get byte-identical paths, so the
+      filesystem collapses concurrent pulls to one inode automatically.
+      Also proven: `resolve_registry_root` is deterministic and honors
+      `APR_MODELS` over `$HOME/.apr/models`, which is the precondition
+      for the dedup path to actually be shared across users.
+    tests:
+    - env_wins_when_set
+    - env_whitespace_trimmed
+    - empty_env_falls_back_to_home
+    - missing_home_without_env_errors
+    - env_alone_sufficient_even_without_home
+    - resolve_is_deterministic
+    - blob_path_uses_sha256_prefix
+    - blob_path_dedup_is_by_construction
+    - blob_path_different_hash_yields_different_path
+    - blob_path_rejects_wrong_length
+    - blob_path_rejects_uppercase_hex
+    - blob_path_rejects_non_hex_bytes
+    - blob_dir_is_always_under_root
+    scope: registry-root resolution + content-addressed blob path (pure functions)
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: two-user integration harness on a shared filesystem with APR_MODELS set
 - id: FALSIFY-CRUX-A-21-002
   rule: read-only user can still load, but pull fails with exit 13
   prediction: "unprivileged user gets EACCES with actionable hint"
@@ -64,6 +91,24 @@ falsification_tests:
     grep -E "permission|daemon" /tmp/err
 
   if_fails: rule 'read-only user can still load, but pull fails with exit 13' is violated — contract MUST be re-verified against competitor canonical reference
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/shared_cache.rs
+    sub_claim: |
+      Algorithm-level necessary condition: `classify_pull_permission_outcome`
+      maps `ErrorKind::PermissionDenied` to `PullPermissionOutcome::PermissionDenied`
+      with exit_code=13 and an actionable daemon-user hint. No code path
+      through the classifier returns `Ok` or a silent fall-through when
+      EACCES is observed — the silent-$HOME-fallback bug that motivated
+      the gate is structurally impossible at this layer.
+    tests:
+    - permission_denied_yields_exit_13_with_hint
+    - not_found_yields_exit_1
+    - generic_io_errors_yield_exit_1
+    - permission_classifier_is_deterministic
+    - permission_classifier_never_returns_ok_on_eacces
+    scope: EACCES → exit-13 classifier (pure function over ErrorKind)
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: end-to-end `apr pull` harness with a 0555-mode APR_MODELS dir asserting the process exits 13
 proof_obligations:
 - type: equivalence
   property: "APR_MODELS honored exactly like OLLAMA_MODELS on systemd deploys"
@@ -77,6 +122,13 @@ verification_summary:
   proven: 0
   tested: 0
   status: spec-complete
+  discharge_ledger:
+  - falsify_id: FALSIFY-CRUX-A-21-001
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    blocked_on: two-user integration harness on a shared filesystem
+  - falsify_id: FALSIFY-CRUX-A-21-002
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    blocked_on: end-to-end apr pull EACCES exit-13 harness
 
 pmat_work_tracking:
   ticket_tag: crux-crux-a-21

--- a/crates/apr-cli/src/commands/mod.rs
+++ b/crates/apr-cli/src/commands/mod.rs
@@ -111,6 +111,7 @@ pub(crate) mod unified_search_lint;
 pub(crate) mod serve;
 pub(crate) mod serve_plan;
 pub(crate) mod serve_plan_output;
+pub(crate) mod shared_cache;
 pub(crate) mod showcase;
 pub(crate) mod sign_artifacts;
 pub(crate) mod stop_op;

--- a/crates/apr-cli/src/commands/mod.rs
+++ b/crates/apr-cli/src/commands/mod.rs
@@ -112,6 +112,7 @@ pub(crate) mod serve;
 pub(crate) mod serve_plan;
 pub(crate) mod serve_plan_output;
 pub(crate) mod shared_cache;
+pub(crate) mod shared_cache_lint;
 pub(crate) mod showcase;
 pub(crate) mod sign_artifacts;
 pub(crate) mod stop_op;

--- a/crates/apr-cli/src/commands/shared_cache.rs
+++ b/crates/apr-cli/src/commands/shared_cache.rs
@@ -1,0 +1,309 @@
+//! Shared model-cache root + blob-dedup-key classifier for `APR_MODELS`
+//! (CRUX-A-21). Parity with Ollama's `OLLAMA_MODELS` for multi-user /
+//! systemd-managed deployments.
+//!
+//! Contract: `contracts/crux-A-21-v1.yaml`.
+//!
+//! Three pure algorithm-level sub-claims live here:
+//!
+//! 1. `resolve_registry_root(env, home)` is deterministic: if `APR_MODELS`
+//!    is set non-empty it wins; otherwise `$HOME/.apr/models`. No I/O —
+//!    the caller is responsible for creating the directory.
+//!
+//! 2. `blob_path_for(root, sha256_hex)` produces `{root}/blobs/sha256-<hex>`.
+//!    Dedup across users is guaranteed *by construction*: two processes
+//!    pulling the same content-addressed blob write to the same path, so
+//!    the filesystem collapses to one inode — the necessary condition
+//!    for FALSIFY-CRUX-A-21-001.
+//!
+//! 3. `classify_pull_permission_outcome(io_err_kind)` maps an
+//!    I/O-error variant onto the contract-defined exit code (13 for
+//!    permission-denied, with an actionable daemon-user hint). This is
+//!    the necessary condition for FALSIFY-CRUX-A-21-002: the pipeline
+//!    must exit 13 on EACCES, not silently fall back to `$HOME`.
+
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
+
+/// Well-known env var names. Matches Ollama's convention for parity.
+pub const APR_MODELS_ENV: &str = "APR_MODELS";
+/// Default subdirectory under the user's home when `APR_MODELS` is unset.
+pub const DEFAULT_REGISTRY_SUBDIR: &str = ".apr/models";
+/// Subdirectory inside the registry root where content-addressed blobs live.
+pub const BLOBS_SUBDIR: &str = "blobs";
+
+/// Resolve the registry root for `apr pull`.
+///
+/// Precedence:
+///   1. `apr_models_env` if `Some(...)` and non-empty after trim
+///   2. `home/.apr/models`
+///
+/// Returns `Err` if `home` is empty (no fallback available).
+pub fn resolve_registry_root(
+    apr_models_env: Option<&str>,
+    home: &Path,
+) -> Result<PathBuf, RegistryRootError> {
+    if let Some(env) = apr_models_env {
+        let trimmed = env.trim();
+        if !trimmed.is_empty() {
+            return Ok(PathBuf::from(trimmed));
+        }
+    }
+    if home.as_os_str().is_empty() {
+        return Err(RegistryRootError::MissingHome);
+    }
+    Ok(home.join(DEFAULT_REGISTRY_SUBDIR))
+}
+
+/// Error cases for `resolve_registry_root`.
+#[derive(Debug, PartialEq, Eq)]
+pub enum RegistryRootError {
+    /// Neither `APR_MODELS` nor `home` was usable. Callers MUST exit with
+    /// a configuration error rather than silently picking `/tmp` or similar.
+    MissingHome,
+}
+
+/// Compute the on-disk path for a content-addressed blob.
+///
+/// The `sha256_hex` must be the lowercase 64-character hex digest of the
+/// blob contents. Returns `Err` for empty / malformed digests because
+/// collapsing a malformed digest into a shared blob dir would silently
+/// lose dedup correctness.
+pub fn blob_path_for(root: &Path, sha256_hex: &str) -> Result<PathBuf, BlobPathError> {
+    if sha256_hex.len() != 64 {
+        return Err(BlobPathError::WrongLength(sha256_hex.len()));
+    }
+    if !sha256_hex
+        .bytes()
+        .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+    {
+        return Err(BlobPathError::NonHexLower);
+    }
+    let filename = format!("sha256-{sha256_hex}");
+    Ok(root.join(BLOBS_SUBDIR).join(filename))
+}
+
+/// Error cases for `blob_path_for`.
+#[derive(Debug, PartialEq, Eq)]
+pub enum BlobPathError {
+    /// sha256 hex must be exactly 64 characters.
+    WrongLength(usize),
+    /// Must be lowercase ASCII hex; uppercase or non-hex bytes are rejected.
+    NonHexLower,
+}
+
+/// Contract-defined exit outcome for an `apr pull` permission scenario.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PullPermissionOutcome {
+    /// All good — proceed with the fetch.
+    Ok,
+    /// EACCES on the registry root → exit 13 with a daemon-user hint.
+    /// The hint is the fixed string returned here so callers emit a
+    /// consistent user-facing message across platforms.
+    PermissionDenied { exit_code: i32, hint: &'static str },
+    /// Registry root is missing and cannot be created.
+    NotFound { exit_code: i32 },
+    /// Any other I/O failure — generic exit 1.
+    Other { exit_code: i32, kind: ErrorKind },
+}
+
+/// Map an `std::io::ErrorKind` onto the contract's exit-code table.
+///
+/// Contract FALSIFY-CRUX-A-21-002: an unprivileged user must see exit
+/// code 13 (Unix convention for EACCES) with a hint pointing at the
+/// daemon user, not a silent fall-through that writes to `$HOME`.
+pub fn classify_pull_permission_outcome(kind: ErrorKind) -> PullPermissionOutcome {
+    match kind {
+        ErrorKind::PermissionDenied => PullPermissionOutcome::PermissionDenied {
+            exit_code: 13,
+            hint: "permission denied on APR_MODELS — run as daemon user or adjust mode",
+        },
+        ErrorKind::NotFound => PullPermissionOutcome::NotFound { exit_code: 1 },
+        other => PullPermissionOutcome::Other {
+            exit_code: 1,
+            kind: other,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ===== resolve_registry_root =====
+
+    #[test]
+    fn env_wins_when_set() {
+        let got =
+            resolve_registry_root(Some("/var/lib/apr/models"), Path::new("/home/user")).unwrap();
+        assert_eq!(got, PathBuf::from("/var/lib/apr/models"));
+    }
+
+    #[test]
+    fn env_whitespace_trimmed() {
+        let got = resolve_registry_root(Some("  /srv/apr  "), Path::new("/home/u")).unwrap();
+        assert_eq!(got, PathBuf::from("/srv/apr"));
+    }
+
+    #[test]
+    fn empty_env_falls_back_to_home() {
+        for env in [Some(""), Some("   "), None] {
+            let got = resolve_registry_root(env, Path::new("/home/u")).unwrap();
+            assert_eq!(got, PathBuf::from("/home/u/.apr/models"));
+        }
+    }
+
+    #[test]
+    fn missing_home_without_env_errors() {
+        let err = resolve_registry_root(None, Path::new("")).unwrap_err();
+        assert_eq!(err, RegistryRootError::MissingHome);
+    }
+
+    #[test]
+    fn env_alone_sufficient_even_without_home() {
+        // If APR_MODELS is set, we do NOT need $HOME at all — systemd
+        // deploys often have a fictitious daemon $HOME.
+        let got = resolve_registry_root(Some("/var/apr"), Path::new("")).unwrap();
+        assert_eq!(got, PathBuf::from("/var/apr"));
+    }
+
+    #[test]
+    fn resolve_is_deterministic() {
+        let a = resolve_registry_root(Some("/x"), Path::new("/h")).unwrap();
+        let b = resolve_registry_root(Some("/x"), Path::new("/h")).unwrap();
+        assert_eq!(a, b);
+    }
+
+    // ===== blob_path_for =====
+
+    #[test]
+    fn blob_path_uses_sha256_prefix() {
+        let hex = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+        let p = blob_path_for(Path::new("/var/apr"), hex).unwrap();
+        assert_eq!(
+            p,
+            PathBuf::from(
+                "/var/apr/blobs/sha256-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+            )
+        );
+    }
+
+    #[test]
+    fn blob_path_dedup_is_by_construction() {
+        // FALSIFY-CRUX-A-21-001 sub-claim: identical sha256 under the
+        // same root produces identical path. The filesystem collapses
+        // two concurrent pulls to one inode automatically.
+        let hex = "a".repeat(64);
+        let a = blob_path_for(Path::new("/shared"), &hex).unwrap();
+        let b = blob_path_for(Path::new("/shared"), &hex).unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn blob_path_different_hash_yields_different_path() {
+        let a = blob_path_for(Path::new("/r"), &"a".repeat(64)).unwrap();
+        let b = blob_path_for(Path::new("/r"), &"b".repeat(64)).unwrap();
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn blob_path_rejects_wrong_length() {
+        for hex in ["", "abc", &"a".repeat(63), &"a".repeat(65)] {
+            let err = blob_path_for(Path::new("/r"), hex).unwrap_err();
+            assert!(matches!(err, BlobPathError::WrongLength(_)));
+        }
+    }
+
+    #[test]
+    fn blob_path_rejects_uppercase_hex() {
+        // Mixed case would break dedup (two different paths for the
+        // same content). Reject uppercase outright.
+        let hex = "A".repeat(64);
+        assert_eq!(
+            blob_path_for(Path::new("/r"), &hex).unwrap_err(),
+            BlobPathError::NonHexLower
+        );
+    }
+
+    #[test]
+    fn blob_path_rejects_non_hex_bytes() {
+        let mut hex = "a".repeat(63);
+        hex.push('z');
+        assert_eq!(
+            blob_path_for(Path::new("/r"), &hex).unwrap_err(),
+            BlobPathError::NonHexLower
+        );
+    }
+
+    #[test]
+    fn blob_dir_is_always_under_root() {
+        let hex = "0".repeat(64);
+        let root = Path::new("/some/registry/root");
+        let p = blob_path_for(root, &hex).unwrap();
+        assert!(p.starts_with(root));
+        assert_eq!(p.parent().unwrap(), root.join(BLOBS_SUBDIR));
+    }
+
+    // ===== classify_pull_permission_outcome =====
+
+    #[test]
+    fn permission_denied_yields_exit_13_with_hint() {
+        // FALSIFY-CRUX-A-21-002: EACCES must exit 13 with actionable hint.
+        let r = classify_pull_permission_outcome(ErrorKind::PermissionDenied);
+        match r {
+            PullPermissionOutcome::PermissionDenied { exit_code, hint } => {
+                assert_eq!(exit_code, 13);
+                assert!(
+                    hint.to_lowercase().contains("permission"),
+                    "hint should mention permission: {hint}"
+                );
+                assert!(
+                    hint.to_lowercase().contains("daemon")
+                        || hint.to_lowercase().contains("mode"),
+                    "hint should be actionable (daemon/mode): {hint}"
+                );
+            }
+            other => panic!("expected PermissionDenied, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn not_found_yields_exit_1() {
+        let r = classify_pull_permission_outcome(ErrorKind::NotFound);
+        assert_eq!(r, PullPermissionOutcome::NotFound { exit_code: 1 });
+    }
+
+    #[test]
+    fn generic_io_errors_yield_exit_1() {
+        for k in [
+            ErrorKind::UnexpectedEof,
+            ErrorKind::Interrupted,
+            ErrorKind::TimedOut,
+        ] {
+            match classify_pull_permission_outcome(k) {
+                PullPermissionOutcome::Other { exit_code, kind } => {
+                    assert_eq!(exit_code, 1);
+                    assert_eq!(kind, k);
+                }
+                other => panic!("expected Other for {k:?}, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn permission_classifier_is_deterministic() {
+        let a = classify_pull_permission_outcome(ErrorKind::PermissionDenied);
+        let b = classify_pull_permission_outcome(ErrorKind::PermissionDenied);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn permission_classifier_never_returns_ok_on_eacces() {
+        // Strengthens FALSIFY-CRUX-A-21-002: no path through the
+        // classifier returns `Ok` when `ErrorKind::PermissionDenied` is
+        // passed. The silent-fall-through bug that motivated the gate
+        // is structurally impossible here.
+        let r = classify_pull_permission_outcome(ErrorKind::PermissionDenied);
+        assert!(!matches!(r, PullPermissionOutcome::Ok));
+    }
+}

--- a/crates/apr-cli/src/commands/shared_cache_lint.rs
+++ b/crates/apr-cli/src/commands/shared_cache_lint.rs
@@ -1,0 +1,293 @@
+//! CRUX-A-21 — `apr shared-cache-lint` CLI wiring (CRUX-SHIP-001 g2/g3).
+//!
+//! Dispatches the pure `shared_cache` classifier over a captured JSON
+//! observation file covering the two FALSIFY gates:
+//!
+//! ```jsonc
+//! {
+//!   "dedup": {
+//!     "apr_models_env": "/var/lib/apr/models",
+//!     "home":           "/home/user",
+//!     "expected_root":  "/var/lib/apr/models",
+//!     "sha256_hex_a":   "a...64 chars",
+//!     "sha256_hex_b":   "a...64 chars",
+//!     "expected_same_path": true
+//!   },
+//!   "permission": {
+//!     "kind":              "permission_denied",
+//!     "expected_outcome":  "permission_denied",
+//!     "expected_exit_code": 13,
+//!     "expected_hint_substring": "daemon"
+//!   }
+//! }
+//! ```
+//!
+//! Any missing top-level key is skipped. Non-zero exit + FALSIFY-CRUX-A-21
+//! stderr stamp on any failing gate.
+
+use crate::commands::shared_cache::{
+    blob_path_for, classify_pull_permission_outcome, resolve_registry_root, PullPermissionOutcome,
+};
+use serde_json::Value;
+use std::fs;
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone)]
+pub struct SharedCacheLintArgs {
+    pub observation_file: String,
+    pub json: bool,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+struct GateReport {
+    gate: &'static str,
+    falsify_id: &'static str,
+    outcome: String,
+    passed: bool,
+}
+
+pub fn run(args: SharedCacheLintArgs) -> Result<(), String> {
+    let path = Path::new(&args.observation_file);
+    if !path.exists() {
+        return Err(format!(
+            "FALSIFY-CRUX-A-21: observation file not found: {}",
+            args.observation_file
+        ));
+    }
+    let raw = fs::read_to_string(path)
+        .map_err(|e| format!("FALSIFY-CRUX-A-21: failed to read observation: {e}"))?;
+    if raw.trim().is_empty() {
+        return Err("FALSIFY-CRUX-A-21: observation file is empty".to_string());
+    }
+    let obs: Value = serde_json::from_str(&raw)
+        .map_err(|e| format!("FALSIFY-CRUX-A-21: observation is not valid JSON: {e}"))?;
+
+    let mut reports: Vec<GateReport> = Vec::new();
+    let mut failures: Vec<String> = Vec::new();
+
+    if let Some(v) = obs.get("dedup") {
+        let (r, err) = run_dedup_gate(v);
+        reports.push(r);
+        if let Some(e) = err {
+            failures.push(e);
+        }
+    }
+    if let Some(v) = obs.get("permission") {
+        let (r, err) = run_permission_gate(v);
+        reports.push(r);
+        if let Some(e) = err {
+            failures.push(e);
+        }
+    }
+
+    if reports.is_empty() {
+        return Err("FALSIFY-CRUX-A-21: observation has none of dedup/permission".into());
+    }
+
+    if args.json {
+        let payload = serde_json::json!({
+            "contract": "CRUX-A-21",
+            "gates": reports,
+        });
+        println!("{}", serde_json::to_string_pretty(&payload).unwrap());
+    } else {
+        for r in &reports {
+            let tag = if r.passed { "PASS" } else { "FAIL" };
+            println!("[{tag}] {} ({}): {}", r.gate, r.falsify_id, r.outcome);
+        }
+    }
+
+    if !failures.is_empty() {
+        return Err(failures.join("\n"));
+    }
+    Ok(())
+}
+
+fn parse_str(v: Option<&Value>) -> Option<String> {
+    v.and_then(|x| x.as_str()).map(|s| s.to_string())
+}
+
+fn run_dedup_gate(v: &Value) -> (GateReport, Option<String>) {
+    let apr_models_env = parse_str(v.get("apr_models_env"));
+    let home = parse_str(v.get("home")).unwrap_or_default();
+    let expected_root = parse_str(v.get("expected_root"));
+    let hex_a = parse_str(v.get("sha256_hex_a"));
+    let hex_b = parse_str(v.get("sha256_hex_b"));
+    let expected_same_path = v
+        .get("expected_same_path")
+        .and_then(|x| x.as_bool())
+        .unwrap_or(true);
+
+    // (1) Resolve registry root.
+    let root = match resolve_registry_root(apr_models_env.as_deref(), Path::new(&home)) {
+        Ok(r) => r,
+        Err(e) => {
+            let desc = format!("resolve_registry_root error: {e:?}");
+            return (
+                GateReport {
+                    gate: "dedup",
+                    falsify_id: "FALSIFY-CRUX-A-21-001",
+                    outcome: desc.clone(),
+                    passed: false,
+                },
+                Some(format!("FALSIFY-CRUX-A-21-001 dedup gate failed: {desc}")),
+            );
+        }
+    };
+    let root_ok = expected_root
+        .as_ref()
+        .map(|want| PathBuf::from(want) == root)
+        .unwrap_or(true);
+
+    // (2) Compute blob paths for the two digests, if provided.
+    let (path_a, path_b, parse_ok) = match (hex_a.as_deref(), hex_b.as_deref()) {
+        (Some(a), Some(b)) => {
+            let pa = blob_path_for(&root, a);
+            let pb = blob_path_for(&root, b);
+            match (pa, pb) {
+                (Ok(pa), Ok(pb)) => (Some(pa), Some(pb), true),
+                _ => (None, None, false),
+            }
+        }
+        (None, None) => (None, None, true),
+        _ => (None, None, false),
+    };
+
+    let same_path_ok = match (&path_a, &path_b) {
+        (Some(a), Some(b)) => (a == b) == expected_same_path,
+        _ => true, // hashes not both supplied → skip path-equality check
+    };
+
+    let passed = root_ok && parse_ok && same_path_ok;
+    let path_a_str = path_a
+        .as_ref()
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|| "(none)".to_string());
+    let path_b_str = path_b
+        .as_ref()
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|| "(none)".to_string());
+    let desc = format!(
+        "resolved={} expected_root={} same_path_ok={same_path_ok} parse_ok={parse_ok} path_a={path_a_str} path_b={path_b_str}",
+        root.display(),
+        expected_root.as_deref().unwrap_or("(unspecified)")
+    );
+    let err = if passed {
+        None
+    } else {
+        Some(format!("FALSIFY-CRUX-A-21-001 dedup gate failed: {desc}"))
+    };
+    (
+        GateReport {
+            gate: "dedup",
+            falsify_id: "FALSIFY-CRUX-A-21-001",
+            outcome: desc,
+            passed,
+        },
+        err,
+    )
+}
+
+fn parse_kind(s: &str) -> Option<ErrorKind> {
+    match s.to_ascii_lowercase().as_str() {
+        "permission_denied" | "permissiondenied" | "eacces" => Some(ErrorKind::PermissionDenied),
+        "not_found" | "notfound" | "enoent" => Some(ErrorKind::NotFound),
+        "unexpected_eof" | "unexpectedeof" => Some(ErrorKind::UnexpectedEof),
+        "interrupted" => Some(ErrorKind::Interrupted),
+        "timed_out" | "timedout" => Some(ErrorKind::TimedOut),
+        "already_exists" | "alreadyexists" => Some(ErrorKind::AlreadyExists),
+        _ => None,
+    }
+}
+
+fn outcome_tag(o: &PullPermissionOutcome) -> &'static str {
+    match o {
+        PullPermissionOutcome::Ok => "ok",
+        PullPermissionOutcome::PermissionDenied { .. } => "permission_denied",
+        PullPermissionOutcome::NotFound { .. } => "not_found",
+        PullPermissionOutcome::Other { .. } => "other",
+    }
+}
+
+fn outcome_exit_code(o: &PullPermissionOutcome) -> i32 {
+    match o {
+        PullPermissionOutcome::Ok => 0,
+        PullPermissionOutcome::PermissionDenied { exit_code, .. } => *exit_code,
+        PullPermissionOutcome::NotFound { exit_code } => *exit_code,
+        PullPermissionOutcome::Other { exit_code, .. } => *exit_code,
+    }
+}
+
+fn run_permission_gate(v: &Value) -> (GateReport, Option<String>) {
+    let kind_str = parse_str(v.get("kind"));
+    let expected_outcome = parse_str(v.get("expected_outcome")).map(|s| s.to_ascii_lowercase());
+    let expected_exit_code = v.get("expected_exit_code").and_then(|x| x.as_i64());
+    let expected_hint_substr = parse_str(v.get("expected_hint_substring"));
+
+    let kind = match kind_str.as_deref().and_then(parse_kind) {
+        Some(k) => k,
+        None => {
+            let desc = format!(
+                "unknown or missing ErrorKind: {:?}",
+                kind_str.as_deref().unwrap_or("(unspecified)")
+            );
+            return (
+                GateReport {
+                    gate: "permission",
+                    falsify_id: "FALSIFY-CRUX-A-21-002",
+                    outcome: desc.clone(),
+                    passed: false,
+                },
+                Some(format!(
+                    "FALSIFY-CRUX-A-21-002 permission gate failed: {desc}"
+                )),
+            );
+        }
+    };
+
+    let result = classify_pull_permission_outcome(kind);
+    let got_tag = outcome_tag(&result);
+    let got_exit = outcome_exit_code(&result);
+
+    let outcome_ok = expected_outcome
+        .as_deref()
+        .map(|want| want == got_tag)
+        .unwrap_or(true);
+    let exit_ok = expected_exit_code
+        .map(|want| want as i32 == got_exit)
+        .unwrap_or(true);
+    let hint_ok = match (&result, &expected_hint_substr) {
+        (PullPermissionOutcome::PermissionDenied { hint, .. }, Some(sub)) => {
+            hint.to_ascii_lowercase().contains(&sub.to_ascii_lowercase())
+        }
+        _ => true,
+    };
+    // Strengthened invariant from the classifier: EACCES must never → Ok.
+    let never_ok_on_eacces = !matches!(
+        (kind, &result),
+        (ErrorKind::PermissionDenied, PullPermissionOutcome::Ok)
+    );
+
+    let passed = outcome_ok && exit_ok && hint_ok && never_ok_on_eacces;
+    let desc = format!(
+        "kind={} classified={got_tag} exit={got_exit} outcome_ok={outcome_ok} exit_ok={exit_ok} hint_ok={hint_ok}",
+        kind_str.as_deref().unwrap_or("(unspecified)")
+    );
+    let err = if passed {
+        None
+    } else {
+        Some(format!(
+            "FALSIFY-CRUX-A-21-002 permission gate failed: {desc}"
+        ))
+    };
+    (
+        GateReport {
+            gate: "permission",
+            falsify_id: "FALSIFY-CRUX-A-21-002",
+            outcome: desc,
+            passed,
+        },
+        err,
+    )
+}

--- a/crates/apr-cli/src/dispatch_analysis.rs
+++ b/crates/apr-cli/src/dispatch_analysis.rs
@@ -218,6 +218,14 @@ fn dispatch_analysis_commands(cli: &Cli) -> Option<Result<(), CliError>> {
         )
         .map_err(crate::error::CliError::Aprender),
 
+        ExtendedCommands::SharedCacheLint { observation_file } => {
+            commands::shared_cache_lint::run(commands::shared_cache_lint::SharedCacheLintArgs {
+                observation_file: observation_file.to_string_lossy().to_string(),
+                json: cli.json,
+            })
+            .map_err(crate::error::CliError::Aprender)
+        }
+
         ExtendedCommands::Hex {
             file,
             tensor,

--- a/crates/apr-cli/src/extended_commands.rs
+++ b/crates/apr-cli/src/extended_commands.rs
@@ -843,6 +843,12 @@ pub enum ExtendedCommands {
         #[arg(long, value_name = "FILE")]
         observation_file: PathBuf,
     },
+    /// Lint a captured APR_MODELS shared-cache observation (CRUX-A-21)
+    SharedCacheLint {
+        /// Path to captured dedup/permission observation JSON
+        #[arg(long, value_name = "FILE")]
+        observation_file: PathBuf,
+    },
     /// Publishing, conversion, and analysis tools
     #[command(flatten)]
     Tools(ToolCommands),

--- a/crates/apr-cli/tests/cli_commands.rs
+++ b/crates/apr-cli/tests/cli_commands.rs
@@ -103,6 +103,7 @@ fn registered_commands() -> Vec<&'static str> {
         "embeddings-lint",
         "unified-search-lint",
         "rm-gc-lint",
+        "shared-cache-lint",
         "oracle",
         "grad-norm",
         "encrypt",

--- a/crates/apr-cli/tests/falsification_crux_a_21.rs
+++ b/crates/apr-cli/tests/falsification_crux_a_21.rs
@@ -1,0 +1,472 @@
+//! CRUX-A-21 — end-to-end falsification harness for `apr shared-cache-lint`.
+//!
+//! CRUX-SHIP-001 gate g3 evidence: every FALSIFY-CRUX-A-21-{001,002}
+//! gate the classifier discharges has a matching e2e JSON observation
+//! that the binary must classify exactly as the harness expects.
+
+use serde_json::json;
+use std::io::Write;
+use std::process::Command;
+
+fn apr_binary() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_apr"));
+    cmd.env("NO_COLOR", "1");
+    cmd
+}
+
+fn write_obs(json_body: &serde_json::Value) -> tempfile::NamedTempFile {
+    let mut f = tempfile::Builder::new()
+        .prefix("crux-a-21-obs-")
+        .suffix(".json")
+        .tempfile()
+        .expect("tempfile");
+    f.write_all(serde_json::to_vec_pretty(json_body).unwrap().as_slice())
+        .expect("write obs");
+    f.flush().expect("flush");
+    f
+}
+
+const HEX_A: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const HEX_B: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+// ===== g2: CLI shape =====
+
+#[test]
+fn falsify_crux_a_21_cli_help_advertises_observation_file() {
+    let out = apr_binary()
+        .args(["shared-cache-lint", "--help"])
+        .output()
+        .expect("run");
+    assert!(out.status.success(), "--help must exit 0");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("--observation-file"),
+        "--help must advertise --observation-file; got:\n{stdout}"
+    );
+}
+
+#[test]
+fn falsify_crux_a_21_cli_bare_invocation_is_usage_error() {
+    let out = apr_binary().arg("shared-cache-lint").output().expect("run");
+    assert!(
+        !out.status.success(),
+        "bare invocation must not exit 0 — missing required --observation-file"
+    );
+}
+
+#[test]
+fn falsify_crux_a_21_cli_missing_file_fails_with_stamp() {
+    let out = apr_binary()
+        .args([
+            "shared-cache-lint",
+            "--observation-file",
+            "/nonexistent/crux-a-21-missing.json",
+        ])
+        .output()
+        .expect("run");
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("FALSIFY-CRUX-A-21") || stderr.contains("not found"),
+        "stderr must stamp FALSIFY-CRUX-A-21; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn falsify_crux_a_21_cli_empty_file_fails() {
+    let tmp = tempfile::Builder::new()
+        .prefix("crux-a-21-empty-")
+        .suffix(".json")
+        .tempfile()
+        .unwrap();
+    let out = apr_binary()
+        .args([
+            "shared-cache-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(!out.status.success());
+}
+
+#[test]
+fn falsify_crux_a_21_cli_invalid_json_fails() {
+    let mut tmp = tempfile::Builder::new()
+        .prefix("crux-a-21-bad-")
+        .suffix(".json")
+        .tempfile()
+        .unwrap();
+    tmp.write_all(b"{not json").unwrap();
+    tmp.flush().unwrap();
+    let out = apr_binary()
+        .args([
+            "shared-cache-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(!out.status.success());
+}
+
+#[test]
+fn falsify_crux_a_21_cli_no_gates_fails() {
+    let tmp = write_obs(&json!({"unrelated": true}));
+    let out = apr_binary()
+        .args([
+            "shared-cache-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(!out.status.success());
+}
+
+// ===== FALSIFY-CRUX-A-21-001 dedup (resolve + blob_path_for) =====
+
+#[test]
+fn falsify_crux_a_21_001_dedup_env_wins_and_paths_collapse() {
+    let obs = json!({
+        "dedup": {
+            "apr_models_env": "/var/lib/apr/models",
+            "home":           "/home/user",
+            "expected_root":  "/var/lib/apr/models",
+            "sha256_hex_a":   HEX_A,
+            "sha256_hex_b":   HEX_A,
+            "expected_same_path": true
+        }
+    });
+    let tmp = write_obs(&obs);
+    let out = apr_binary()
+        .args([
+            "shared-cache-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "env wins + identical hashes must pass; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("[PASS] dedup"));
+}
+
+#[test]
+fn falsify_crux_a_21_001_dedup_home_fallback_when_env_absent() {
+    let obs = json!({
+        "dedup": {
+            "home":           "/home/u",
+            "expected_root":  "/home/u/.apr/models",
+            "sha256_hex_a":   HEX_A,
+            "sha256_hex_b":   HEX_B,
+            "expected_same_path": false
+        }
+    });
+    let tmp = write_obs(&obs);
+    let out = apr_binary()
+        .args([
+            "shared-cache-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(out.status.success(), "home fallback must resolve");
+}
+
+#[test]
+fn falsify_crux_a_21_001_dedup_wrong_expected_root_fails() {
+    let obs = json!({
+        "dedup": {
+            "apr_models_env": "/var/lib/apr/models",
+            "home":           "/home/u",
+            "expected_root":  "/home/u/.apr/models"
+        }
+    });
+    let tmp = write_obs(&obs);
+    let out = apr_binary()
+        .args([
+            "shared-cache-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-A-21-001"));
+}
+
+#[test]
+fn falsify_crux_a_21_001_dedup_invalid_hex_fails() {
+    let obs = json!({
+        "dedup": {
+            "apr_models_env": "/var/apr",
+            "home":           "/home/u",
+            "expected_root":  "/var/apr",
+            "sha256_hex_a":   "not-hex",
+            "sha256_hex_b":   HEX_A,
+            "expected_same_path": true
+        }
+    });
+    let tmp = write_obs(&obs);
+    let out = apr_binary()
+        .args([
+            "shared-cache-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "malformed hex must fail");
+}
+
+#[test]
+fn falsify_crux_a_21_001_dedup_missing_home_errors() {
+    let obs = json!({
+        "dedup": {
+            "home": "",
+            "expected_root": "/anything"
+        }
+    });
+    let tmp = write_obs(&obs);
+    let out = apr_binary()
+        .args([
+            "shared-cache-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "no env and empty home must fail");
+}
+
+// ===== FALSIFY-CRUX-A-21-002 permission (EACCES → exit 13) =====
+
+#[test]
+fn falsify_crux_a_21_002_permission_eacces_exit_13() {
+    let obs = json!({
+        "permission": {
+            "kind":              "permission_denied",
+            "expected_outcome":  "permission_denied",
+            "expected_exit_code": 13,
+            "expected_hint_substring": "daemon"
+        }
+    });
+    let tmp = write_obs(&obs);
+    let out = apr_binary()
+        .args([
+            "shared-cache-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "EACCES → exit 13 must pass; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("[PASS] permission"));
+}
+
+#[test]
+fn falsify_crux_a_21_002_permission_not_found_exit_1() {
+    let obs = json!({
+        "permission": {
+            "kind":              "not_found",
+            "expected_outcome":  "not_found",
+            "expected_exit_code": 1
+        }
+    });
+    let tmp = write_obs(&obs);
+    let out = apr_binary()
+        .args([
+            "shared-cache-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(out.status.success());
+}
+
+#[test]
+fn falsify_crux_a_21_002_permission_timed_out_is_other() {
+    let obs = json!({
+        "permission": {
+            "kind":              "timed_out",
+            "expected_outcome":  "other",
+            "expected_exit_code": 1
+        }
+    });
+    let tmp = write_obs(&obs);
+    let out = apr_binary()
+        .args([
+            "shared-cache-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(out.status.success());
+}
+
+#[test]
+fn falsify_crux_a_21_002_permission_wrong_exit_code_fails() {
+    let obs = json!({
+        "permission": {
+            "kind":              "permission_denied",
+            "expected_outcome":  "permission_denied",
+            "expected_exit_code": 1
+        }
+    });
+    let tmp = write_obs(&obs);
+    let out = apr_binary()
+        .args([
+            "shared-cache-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-A-21-002"));
+}
+
+#[test]
+fn falsify_crux_a_21_002_permission_wrong_hint_substring_fails() {
+    let obs = json!({
+        "permission": {
+            "kind":              "permission_denied",
+            "expected_outcome":  "permission_denied",
+            "expected_exit_code": 13,
+            "expected_hint_substring": "kittens"
+        }
+    });
+    let tmp = write_obs(&obs);
+    let out = apr_binary()
+        .args([
+            "shared-cache-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "wrong hint must fail");
+}
+
+#[test]
+fn falsify_crux_a_21_002_permission_declaring_ok_on_eacces_fails() {
+    let obs = json!({
+        "permission": {
+            "kind":              "permission_denied",
+            "expected_outcome":  "ok"
+        }
+    });
+    let tmp = write_obs(&obs);
+    let out = apr_binary()
+        .args([
+            "shared-cache-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "EACCES can never be Ok");
+}
+
+#[test]
+fn falsify_crux_a_21_002_permission_unknown_kind_fails() {
+    let obs = json!({
+        "permission": {
+            "kind": "banana",
+            "expected_outcome": "other"
+        }
+    });
+    let tmp = write_obs(&obs);
+    let out = apr_binary()
+        .args([
+            "shared-cache-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(!out.status.success());
+}
+
+// ===== Multi-gate + JSON shape =====
+
+#[test]
+fn falsify_crux_a_21_multi_gate_all_pass() {
+    let obs = json!({
+        "dedup": {
+            "apr_models_env": "/var/lib/apr/models",
+            "home":           "/home/u",
+            "expected_root":  "/var/lib/apr/models",
+            "sha256_hex_a":   HEX_A,
+            "sha256_hex_b":   HEX_A,
+            "expected_same_path": true
+        },
+        "permission": {
+            "kind":              "permission_denied",
+            "expected_outcome":  "permission_denied",
+            "expected_exit_code": 13,
+            "expected_hint_substring": "daemon"
+        }
+    });
+    let tmp = write_obs(&obs);
+    let out = apr_binary()
+        .args([
+            "shared-cache-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "both gates green must exit 0; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("[PASS] dedup"));
+    assert!(stdout.contains("[PASS] permission"));
+}
+
+#[test]
+fn falsify_crux_a_21_json_output_shape() {
+    let obs = json!({
+        "dedup": {
+            "apr_models_env": "/var/apr",
+            "home":           "/home/u",
+            "expected_root":  "/var/apr"
+        }
+    });
+    let tmp = write_obs(&obs);
+    let out = apr_binary()
+        .args([
+            "--json",
+            "shared-cache-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).expect("--json must emit valid JSON");
+    assert_eq!(parsed["contract"], "CRUX-A-21");
+    assert_eq!(parsed["gates"][0]["gate"], "dedup");
+    assert_eq!(parsed["gates"][0]["falsify_id"], "FALSIFY-CRUX-A-21-001");
+    assert_eq!(parsed["gates"][0]["passed"], true);
+}


### PR DESCRIPTION
## Summary

Discharges CRUX-A-21 (parity with \`OLLAMA_MODELS\` for multi-user / systemd-managed deployments) at PARTIAL_ALGORITHM_LEVEL for both FALSIFY gates.

Three pure classifiers in \`crates/apr-cli/src/commands/shared_cache.rs\`:

1. **\`resolve_registry_root(env, home)\`** — APR_MODELS wins if set and non-empty after trim; else \`\$HOME/.apr/models\`. Errs on missing-home-without-env. Deterministic.
2. **\`blob_path_for(root, sha256_hex)\`** — content-addressed \`{root}/blobs/sha256-<hex>\`. Dedup is by construction: identical hex under identical root → byte-identical path. Rejects wrong-length, uppercase, and non-hex digests.
3. **\`classify_pull_permission_outcome(ErrorKind)\`** — maps EACCES → exit 13 with a daemon-user hint. Silent \$HOME fallback on EACCES is structurally impossible.

## Contract status

\`contracts/crux-A-21-v1.yaml\` v1.1.0 → v1.2.0, status \`draft\` → \`partial\`.

- FALSIFY-CRUX-A-21-001 (two pulls dedup to one blob) → PARTIAL_ALGORITHM_LEVEL via 13 tests
- FALSIFY-CRUX-A-21-002 (EACCES → exit 13) → PARTIAL_ALGORITHM_LEVEL via 5 tests

Full discharge blocks on a two-user integration harness on a shared filesystem + an end-to-end \`apr pull\` EACCES exit-13 harness.

## Test plan

- [x] 18/18 unit tests pass (\`cargo test -p apr-cli --lib commands::shared_cache\`)
- [x] \`pv validate contracts/crux-A-21-v1.yaml\` → 0 errors, 0 warnings
- [x] PMAT pre-commit quality gates pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)