### PR TITLE
feat(crux-a-25): refcount-safe blob GC planner (3 of 3 FALSIFY at PARTIAL_ALGORITHM_LEVEL)

### DIFF
--- a/contracts/apr-cli-commands-v1.yaml
+++ b/contracts/apr-cli-commands-v1.yaml
@@ -21,7 +21,7 @@ metadata:
 kind: CLICommandContract
 name: apr-cli-commands
 version: "1.0.0"
-scope: "all apr CLI subcommands (74 commands — original 57 + `mcp` added 2026-04-17 via PR #864 + `registry` added 2026-04-20 via CRUX-A-01 + `ollama-chat-lint` added 2026-04-21 via CRUX-C-04 SHIP-001 retrofit + `dry-sampling-lint` added 2026-04-21 via CRUX-C-23 SHIP-001 retrofit + `awq-lint` added 2026-04-21 via CRUX-B-08 SHIP-001 retrofit + `oom-lint` added 2026-04-21 via CRUX-F-13 SHIP-001 + `tool-use-lint` added 2026-04-21 via CRUX-C-11 SHIP-001 retrofit + `gbnf-lint` added 2026-04-21 via CRUX-C-10 SHIP-001 retrofit + `typical-p-lint` added 2026-04-21 via CRUX-C-22 SHIP-001 retrofit + `grad-norm` added 2026-04-21 via CRUX-F-09 + `registry-quota-lint` added 2026-04-21 via CRUX-A-22 SHIP-001 retrofit + `fp8-lint` added 2026-04-22 via CRUX-B-11 SHIP-001 retrofit + `imatrix-lint` added 2026-04-22 via CRUX-B-07 SHIP-001 retrofit + `nf4-lint` added 2026-04-22 via CRUX-B-10 SHIP-001 retrofit + `gptq-lint` added 2026-04-22 via CRUX-B-09 SHIP-001 retrofit + `embeddings-lint` added 2026-04-23 via CRUX-C-13 SHIP-001 retrofit + `unified-search-lint` added 2026-04-23 via CRUX-A-23 SHIP-001 retrofit)"
+scope: "all apr CLI subcommands (75 commands — original 57 + `mcp` added 2026-04-17 via PR #864 + `registry` added 2026-04-20 via CRUX-A-01 + `ollama-chat-lint` added 2026-04-21 via CRUX-C-04 SHIP-001 retrofit + `dry-sampling-lint` added 2026-04-21 via CRUX-C-23 SHIP-001 retrofit + `awq-lint` added 2026-04-21 via CRUX-B-08 SHIP-001 retrofit + `oom-lint` added 2026-04-21 via CRUX-F-13 SHIP-001 + `tool-use-lint` added 2026-04-21 via CRUX-C-11 SHIP-001 retrofit + `gbnf-lint` added 2026-04-21 via CRUX-C-10 SHIP-001 retrofit + `typical-p-lint` added 2026-04-21 via CRUX-C-22 SHIP-001 retrofit + `grad-norm` added 2026-04-21 via CRUX-F-09 + `registry-quota-lint` added 2026-04-21 via CRUX-A-22 SHIP-001 retrofit + `fp8-lint` added 2026-04-22 via CRUX-B-11 SHIP-001 retrofit + `imatrix-lint` added 2026-04-22 via CRUX-B-07 SHIP-001 retrofit + `nf4-lint` added 2026-04-22 via CRUX-B-10 SHIP-001 retrofit + `gptq-lint` added 2026-04-22 via CRUX-B-09 SHIP-001 retrofit + `embeddings-lint` added 2026-04-23 via CRUX-C-13 SHIP-001 retrofit + `unified-search-lint` added 2026-04-23 via CRUX-A-23 SHIP-001 retrofit + `rm-gc-lint` added 2026-04-23 via CRUX-A-25 SHIP-001 retrofit)"
 binary: "apr"
 install: "cargo install aprender"
 
@@ -477,6 +477,12 @@ commands:
   - name: unified-search-lint
     category: inspection
     description: "Lint a captured Hub+local unified-search merge observation (CRUX-A-23)"
+    requires_model: false
+    side_effects: []
+
+  - name: rm-gc-lint
+    category: inspection
+    description: "Lint a captured `apr rm` / `apr gc` blob-GC observation (CRUX-A-25)"
     requires_model: false
     side_effects: []
 

--- a/contracts/crux-A-25-v1.yaml
+++ b/contracts/crux-A-25-v1.yaml
@@ -2,11 +2,11 @@
 
 metadata:
   id: CRUX-A-25
-  version: "1.1.0"
+  version: "1.2.0"
   created: "2026-04-18"
   author: PAIML Engineering
   registry: true
-  status: draft
+  status: partial
   parent_contracts:
   - crux-competitive-research-ux-v1
   category: "A — Model Intake & Discovery"
@@ -52,6 +52,23 @@ falsification_tests:
     freed=$((before - after))
     [ "$freed" -gt 100000000 ]
   if_fails: rule 'gc frees bytes after rm of last referrer' is violated — contract MUST be re-verified against competitor canonical reference
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/blob_gc.rs
+    sub_claim: |
+      Algorithm-level necessary condition: `apply_rm(manifests, tag)`
+      followed by `plan_gc(all_blobs, compute_refcounts(reduced))`
+      yields a plan containing exactly the blobs that were uniquely
+      owned by the removed manifest. The composition is a pure
+      function chain on in-memory data — no filesystem I/O required
+      to prove the orphan-detection algorithm is correct.
+    tests:
+    - rm_then_gc_frees_unique_owned_blobs
+    - plan_gc_flags_orphaned_blob
+    - refcount_counts_unique_referrers
+    - refcount_duplicate_blob_in_manifest_counts_once
+    scope: rm → refcount → plan composition (pure functions)
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: end-to-end pull/rm/gc harness against a real HF fixture
 - id: FALSIFY-CRUX-A-25-002
   rule: gc never deletes referenced blobs
   prediction: "gc after rm of one of two copies frees 0 bytes (blob still referenced)"
@@ -66,6 +83,22 @@ falsification_tests:
     delta=$((before - after))
     [ "$delta" -lt 8192 ]
   if_fails: rule 'gc never deletes referenced blobs' is violated — contract MUST be re-verified against competitor canonical reference
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/blob_gc.rs
+    sub_claim: |
+      Algorithm-level necessary condition: `plan_gc` filters blobs to
+      those with refcount==0, so a blob referenced by any surviving
+      manifest cannot appear in the candidate list. The duplicate-tag
+      case (rm of one of two aliases) is explicitly proven to produce
+      an empty plan, which is the exact safety invariant on test.
+    tests:
+    - plan_gc_never_flags_referenced_blob
+    - rm_of_one_of_two_duplicate_tags_frees_nothing
+    - apply_plan_removes_exactly_the_candidates
+    - apply_plan_preserves_blobs_not_in_plan
+    scope: refcount safety filter (pure function)
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: end-to-end duplicate-tag rm/gc harness against a real HF fixture
 - id: FALSIFY-CRUX-A-25-003
   rule: --dry-run prints but does not delete
   prediction: "apr gc --dry-run leaves disk usage unchanged"
@@ -80,6 +113,23 @@ falsification_tests:
     grep -E "would free|candidate" /tmp/plan.txt
 
   if_fails: rule '--dry-run prints but does not delete' is violated — contract MUST be re-verified against competitor canonical reference
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/blob_gc.rs
+    sub_claim: |
+      Algorithm-level necessary condition: the plan/apply separation
+      is structural — `plan_gc` is a pure query returning a `GcPlan`
+      and `apply_plan` is the only mutator. A --dry-run that emits
+      the plan without calling `apply_plan` cannot mutate disk state
+      because the plan data structure itself carries no filesystem
+      effect. Dry-run and real-run produce byte-identical plans.
+    tests:
+    - dry_run_plan_equals_real_run_plan
+    - gc_is_idempotent_second_run_is_noop
+    - plan_gc_candidates_are_sorted
+    - plan_serializes_to_stable_json
+    scope: plan/apply separation + dry-run purity (pure functions)
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: end-to-end `apr gc --dry-run` harness asserting disk usage unchanged
 proof_obligations:
 - type: equivalence
   property: "apr rm + apr gc together match `ollama rm` refcount semantics"
@@ -93,6 +143,16 @@ verification_summary:
   proven: 0
   tested: 0
   status: spec-complete
+  discharge_ledger:
+  - falsify_id: FALSIFY-CRUX-A-25-001
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    blocked_on: end-to-end pull/rm/gc harness against a real HF fixture
+  - falsify_id: FALSIFY-CRUX-A-25-002
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    blocked_on: end-to-end duplicate-tag rm/gc harness
+  - falsify_id: FALSIFY-CRUX-A-25-003
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    blocked_on: "`apr gc --dry-run` disk-usage-unchanged harness"
 
 pmat_work_tracking:
   ticket_tag: crux-crux-a-25

--- a/contracts/crux-A-25-v1.yaml
+++ b/contracts/crux-A-25-v1.yaml
@@ -2,8 +2,9 @@
 
 metadata:
   id: CRUX-A-25
-  version: "1.2.0"
+  version: "1.3.0"
   created: "2026-04-18"
+  updated: "2026-04-21"
   author: PAIML Engineering
   registry: true
   status: partial
@@ -54,13 +55,21 @@ falsification_tests:
   if_fails: rule 'gc frees bytes after rm of last referrer' is violated — contract MUST be re-verified against competitor canonical reference
   evidence_discharged_by:
     classifier_path: crates/apr-cli/src/commands/blob_gc.rs
+    cli_path: crates/apr-cli/src/commands/rm_gc_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_a_25.rs
+    e2e_tests:
+    - falsify_crux_a_25_001_rm_frees_unique_owned_blobs
+    - falsify_crux_a_25_001_rm_absent_tag_frees_nothing
+    - falsify_crux_a_25_001_rm_count_mismatch_fails
     sub_claim: |
       Algorithm-level necessary condition: `apply_rm(manifests, tag)`
       followed by `plan_gc(all_blobs, compute_refcounts(reduced))`
       yields a plan containing exactly the blobs that were uniquely
       owned by the removed manifest. The composition is a pure
       function chain on in-memory data — no filesystem I/O required
-      to prove the orphan-detection algorithm is correct.
+      to prove the orphan-detection algorithm is correct. The
+      `apr rm-gc-lint` CLI dispatches this pipeline over an observed
+      rm scenario and exit-codes the FALSIFY-CRUX-A-25-001 gate.
     tests:
     - rm_then_gc_frees_unique_owned_blobs
     - plan_gc_flags_orphaned_blob
@@ -85,12 +94,22 @@ falsification_tests:
   if_fails: rule 'gc never deletes referenced blobs' is violated — contract MUST be re-verified against competitor canonical reference
   evidence_discharged_by:
     classifier_path: crates/apr-cli/src/commands/blob_gc.rs
+    cli_path: crates/apr-cli/src/commands/rm_gc_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_a_25.rs
+    e2e_tests:
+    - falsify_crux_a_25_002_safety_duplicate_tag_frees_nothing
+    - falsify_crux_a_25_002_safety_wrong_expected_fails
+    - falsify_crux_a_25_002_safety_preserves_disjoint_manifests
     sub_claim: |
       Algorithm-level necessary condition: `plan_gc` filters blobs to
       those with refcount==0, so a blob referenced by any surviving
       manifest cannot appear in the candidate list. The duplicate-tag
       case (rm of one of two aliases) is explicitly proven to produce
-      an empty plan, which is the exact safety invariant on test.
+      an empty plan, which is the exact safety invariant on test. The
+      `apr rm-gc-lint` CLI additionally enforces the intersection
+      invariant (no candidate SHA may appear in any surviving
+      manifest's blob set) and exit-codes the FALSIFY-CRUX-A-25-002
+      gate on violation.
     tests:
     - plan_gc_never_flags_referenced_blob
     - rm_of_one_of_two_duplicate_tags_frees_nothing
@@ -115,13 +134,23 @@ falsification_tests:
   if_fails: rule '--dry-run prints but does not delete' is violated — contract MUST be re-verified against competitor canonical reference
   evidence_discharged_by:
     classifier_path: crates/apr-cli/src/commands/blob_gc.rs
+    cli_path: crates/apr-cli/src/commands/rm_gc_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_a_25.rs
+    e2e_tests:
+    - falsify_crux_a_25_003_dryrun_idempotent_on_orphan
+    - falsify_crux_a_25_003_dryrun_all_live_is_noop
+    - falsify_crux_a_25_003_dryrun_wrong_expected_fails
+    - falsify_crux_a_25_003_dryrun_empty_blobs_is_noop
     sub_claim: |
       Algorithm-level necessary condition: the plan/apply separation
       is structural — `plan_gc` is a pure query returning a `GcPlan`
       and `apply_plan` is the only mutator. A --dry-run that emits
       the plan without calling `apply_plan` cannot mutate disk state
       because the plan data structure itself carries no filesystem
-      effect. Dry-run and real-run produce byte-identical plans.
+      effect. Dry-run and real-run produce byte-identical plans. The
+      `apr rm-gc-lint` CLI asserts `plan1 == plan2` (purity) and
+      `is_noop(plan_gc(apply_plan(plan1)))` (idempotence) and
+      exit-codes the FALSIFY-CRUX-A-25-003 gate.
     tests:
     - dry_run_plan_equals_real_run_plan
     - gc_is_idempotent_second_run_is_noop
@@ -153,6 +182,31 @@ verification_summary:
   - falsify_id: FALSIFY-CRUX-A-25-003
     discharge_status: PARTIAL_ALGORITHM_LEVEL
     blocked_on: "`apr gc --dry-run` disk-usage-unchanged harness"
+
+ship_discipline:
+  # CRUX-SHIP-001 retrofit: every classifier-only CRUX PR must ship pure-Rust
+  # classifier AND working `apr` CLI wiring + e2e test in the same commit.
+  policy: CRUX-SHIP-001
+  merge_gates:
+    g1_classifier_green:
+      status: PASS
+      evidence: crates/apr-cli/src/commands/blob_gc.rs (unit tests)
+    g2_cli_reachable:
+      status: PASS
+      evidence: "`apr rm-gc-lint --help` advertises --observation-file"
+      wired_in:
+      - crates/apr-cli/src/commands/mod.rs
+      - crates/apr-cli/src/commands/rm_gc_lint.rs
+      - crates/apr-cli/src/extended_commands.rs
+      - crates/apr-cli/src/dispatch_analysis.rs
+      - crates/apr-cli/tests/cli_commands.rs
+      - contracts/apr-cli-commands-v1.yaml
+    g3_e2e_runs:
+      status: PASS
+      evidence: crates/apr-cli/tests/falsification_crux_a_25.rs (18 tests)
+    g4_contract_discharged:
+      status: PASS
+      evidence: "FALSIFY-CRUX-A-25-{001,002,003} carry cli_path + e2e_path + e2e_tests"
 
 pmat_work_tracking:
   ticket_tag: crux-crux-a-25

--- a/crates/apr-cli/src/commands/blob_gc.rs
+++ b/crates/apr-cli/src/commands/blob_gc.rs
@@ -1,0 +1,343 @@
+//! Refcount-safe blob GC planner for `apr rm` / `apr gc` (CRUX-A-25).
+//!
+//! Contract: `contracts/crux-A-25-v1.yaml`.
+//!
+//! Three pure algorithm-level necessary conditions:
+//!
+//! 1. `compute_refcounts(manifests)` derives `sha256 → usize` from the
+//!    current set of live manifests. A blob's refcount is the number of
+//!    live manifests that reference it. This is the data source for
+//!    every downstream GC decision.
+//!
+//! 2. `plan_gc(all_blobs, refcounts)` returns the set of blobs with
+//!    refcount==0 (candidates for unlink). `apply_rm(manifests, tag)`
+//!    removes a single manifest and returns the new manifest set so
+//!    `plan_gc` can be re-run on the reduced state. Composed: rm then
+//!    gc frees exactly the blobs the removed manifest uniquely owned.
+//!
+//! 3. `plan_gc` is idempotent — a second call on the same post-unlink
+//!    state returns the empty candidate list. `--dry-run` is modelled
+//!    as "compute the plan, but do not apply it" and the plan string
+//!    is the same identifiable object whether the caller unlinks or not,
+//!    so the plan/apply separation makes the dry-run invariant
+//!    structurally impossible to violate at this layer.
+
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+
+/// A single live manifest in the registry.
+///
+/// A manifest's identity is its `tag`; its payload is the set of blob
+/// digests it references. Duplicate digests within one manifest count
+/// as a single reference (this matches Ollama's behavior where a
+/// manifest links each blob once regardless of how many tensors live
+/// inside).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Manifest {
+    pub tag: String,
+    pub blobs: BTreeSet<String>,
+}
+
+impl Manifest {
+    pub fn new(tag: impl Into<String>, blobs: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        Self {
+            tag: tag.into(),
+            blobs: blobs.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+/// Compute the refcount table for the current set of live manifests.
+///
+/// Output is a `BTreeMap` so iteration order is stable — required for
+/// deterministic plan output and for the dry-run/real-run equality
+/// invariant (FALSIFY-CRUX-A-25-003).
+pub fn compute_refcounts(manifests: &[Manifest]) -> BTreeMap<String, usize> {
+    let mut counts: BTreeMap<String, usize> = BTreeMap::new();
+    for m in manifests {
+        for blob in &m.blobs {
+            *counts.entry(blob.clone()).or_insert(0) += 1;
+        }
+    }
+    counts
+}
+
+/// A blob marked for unlink by the GC planner.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GcCandidate {
+    pub sha256: String,
+    pub refcount: usize,
+}
+
+/// A deterministic GC plan, ready for either `--dry-run` print or
+/// `apply_plan` execution.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GcPlan {
+    pub candidates: Vec<GcCandidate>,
+}
+
+impl GcPlan {
+    /// True iff the plan would free nothing — a second gc after a
+    /// successful one, or a gc with no orphans.
+    pub fn is_noop(&self) -> bool {
+        self.candidates.is_empty()
+    }
+}
+
+/// Compute the GC plan: every blob in `all_blobs` whose refcount is
+/// zero (or absent from the refcount table) is a candidate for unlink.
+///
+/// `all_blobs` is the filesystem's current set of blob digests; the
+/// classifier takes it as input so it remains pure (no I/O).
+pub fn plan_gc(all_blobs: &BTreeSet<String>, refcounts: &BTreeMap<String, usize>) -> GcPlan {
+    let candidates: Vec<GcCandidate> = all_blobs
+        .iter()
+        .filter_map(|sha| {
+            let rc = refcounts.get(sha).copied().unwrap_or(0);
+            if rc == 0 {
+                Some(GcCandidate {
+                    sha256: sha.clone(),
+                    refcount: 0,
+                })
+            } else {
+                None
+            }
+        })
+        .collect();
+    GcPlan { candidates }
+}
+
+/// Remove a manifest by tag, returning the reduced manifest set.
+///
+/// No-op if the tag is not present — callers decide whether that is
+/// an error or a benign idempotent re-run.
+pub fn apply_rm(manifests: &[Manifest], tag: &str) -> Vec<Manifest> {
+    manifests
+        .iter()
+        .filter(|m| m.tag != tag)
+        .cloned()
+        .collect()
+}
+
+/// Apply a GC plan by returning the reduced blob set. Pure — callers
+/// are responsible for the filesystem unlink separately, but the
+/// post-state set produced here is the exact set the filesystem
+/// should contain after gc completes.
+pub fn apply_plan(all_blobs: &BTreeSet<String>, plan: &GcPlan) -> BTreeSet<String> {
+    let to_drop: BTreeSet<&str> = plan.candidates.iter().map(|c| c.sha256.as_str()).collect();
+    all_blobs
+        .iter()
+        .filter(|sha| !to_drop.contains(sha.as_str()))
+        .cloned()
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn blobs(xs: &[&str]) -> BTreeSet<String> {
+        xs.iter().map(|s| s.to_string()).collect()
+    }
+
+    // ===== compute_refcounts =====
+
+    #[test]
+    fn refcount_counts_unique_referrers() {
+        let ms = vec![
+            Manifest::new("gpt2:latest", ["a", "b"]),
+            Manifest::new("gpt2:dup", ["a", "b"]),
+            Manifest::new("other", ["c"]),
+        ];
+        let rc = compute_refcounts(&ms);
+        assert_eq!(rc.get("a"), Some(&2));
+        assert_eq!(rc.get("b"), Some(&2));
+        assert_eq!(rc.get("c"), Some(&1));
+    }
+
+    #[test]
+    fn refcount_empty_manifest_set_has_no_refs() {
+        let rc = compute_refcounts(&[]);
+        assert!(rc.is_empty());
+    }
+
+    #[test]
+    fn refcount_duplicate_blob_in_manifest_counts_once() {
+        // BTreeSet dedups within a manifest, so the refcount should be 1.
+        let m = Manifest::new("x", ["a", "a", "a"]);
+        let rc = compute_refcounts(&[m]);
+        assert_eq!(rc.get("a"), Some(&1));
+    }
+
+    #[test]
+    fn refcount_is_deterministic() {
+        let ms = vec![Manifest::new("a", ["x", "y"])];
+        assert_eq!(compute_refcounts(&ms), compute_refcounts(&ms));
+    }
+
+    // ===== plan_gc =====
+
+    #[test]
+    fn plan_gc_flags_orphaned_blob() {
+        // FALSIFY-CRUX-A-25-001 sub-claim: after rm of the last
+        // referrer, the orphan shows up in the plan.
+        let all = blobs(&["a", "b", "c"]);
+        let rc = compute_refcounts(&[Manifest::new("live", ["a", "b"])]);
+        let plan = plan_gc(&all, &rc);
+        let shas: Vec<_> = plan.candidates.iter().map(|c| c.sha256.as_str()).collect();
+        assert_eq!(shas, vec!["c"]);
+    }
+
+    #[test]
+    fn plan_gc_never_flags_referenced_blob() {
+        // FALSIFY-CRUX-A-25-002: the core safety property.
+        let all = blobs(&["a", "b"]);
+        let rc = compute_refcounts(&[Manifest::new("live", ["a", "b"])]);
+        let plan = plan_gc(&all, &rc);
+        assert!(plan.is_noop());
+    }
+
+    #[test]
+    fn plan_gc_empty_when_registry_is_empty() {
+        let all = blobs(&[]);
+        let rc = BTreeMap::new();
+        assert!(plan_gc(&all, &rc).is_noop());
+    }
+
+    #[test]
+    fn plan_gc_is_deterministic() {
+        let all = blobs(&["c", "a", "b"]);
+        let rc = compute_refcounts(&[]);
+        let a = plan_gc(&all, &rc);
+        let b = plan_gc(&all, &rc);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn plan_gc_candidates_are_sorted() {
+        // BTreeSet iteration is sorted — plan output must be stable so
+        // dry-run and real-run emit identical strings.
+        let all = blobs(&["z", "a", "m"]);
+        let rc = compute_refcounts(&[]);
+        let plan = plan_gc(&all, &rc);
+        let shas: Vec<_> = plan.candidates.iter().map(|c| c.sha256.as_str()).collect();
+        assert_eq!(shas, vec!["a", "m", "z"]);
+    }
+
+    // ===== apply_rm + end-to-end compose =====
+
+    #[test]
+    fn rm_then_gc_frees_unique_owned_blobs() {
+        // Two manifests share some blobs; rm should free only blobs
+        // uniquely owned by the removed manifest.
+        let ms = vec![
+            Manifest::new("a", ["x", "y", "z"]),
+            Manifest::new("b", ["y", "z"]),
+        ];
+        let all = blobs(&["x", "y", "z"]);
+        let ms = apply_rm(&ms, "a");
+        let rc = compute_refcounts(&ms);
+        let plan = plan_gc(&all, &rc);
+        let shas: Vec<_> = plan.candidates.iter().map(|c| c.sha256.as_str()).collect();
+        assert_eq!(shas, vec!["x"]);
+    }
+
+    #[test]
+    fn rm_of_one_of_two_duplicate_tags_frees_nothing() {
+        // FALSIFY-CRUX-A-25-002 integration: two tags alias the same
+        // blob set. rm of one leaves the other, gc frees nothing.
+        let ms = vec![
+            Manifest::new("gpt2:latest", ["a", "b"]),
+            Manifest::new("gpt2:dup", ["a", "b"]),
+        ];
+        let all = blobs(&["a", "b"]);
+        let ms = apply_rm(&ms, "gpt2:latest");
+        let plan = plan_gc(&all, &compute_refcounts(&ms));
+        assert!(plan.is_noop(), "plan must be noop, got {plan:?}");
+    }
+
+    #[test]
+    fn rm_missing_tag_is_idempotent() {
+        let ms = vec![Manifest::new("a", ["x"])];
+        let reduced = apply_rm(&ms, "does-not-exist");
+        assert_eq!(reduced, ms);
+    }
+
+    // ===== idempotence and dry-run invariant =====
+
+    #[test]
+    fn gc_is_idempotent_second_run_is_noop() {
+        // FALSIFY contract invariant: gc is idempotent — second run
+        // frees 0 bytes.
+        let all = blobs(&["a", "b", "c"]);
+        let rc = compute_refcounts(&[Manifest::new("live", ["a"])]);
+        let plan1 = plan_gc(&all, &rc);
+        assert!(!plan1.is_noop());
+        let after = apply_plan(&all, &plan1);
+        // Second plan run on the reduced state.
+        let plan2 = plan_gc(&after, &rc);
+        assert!(plan2.is_noop());
+    }
+
+    #[test]
+    fn dry_run_plan_equals_real_run_plan() {
+        // FALSIFY-CRUX-A-25-003: the dry-run plan must equal the real
+        // plan that would be executed. Since they are produced by the
+        // same pure function, equality is by construction.
+        let all = blobs(&["a", "b", "c"]);
+        let rc = compute_refcounts(&[Manifest::new("live", ["a"])]);
+        let dry = plan_gc(&all, &rc);
+        let real = plan_gc(&all, &rc);
+        assert_eq!(dry, real);
+    }
+
+    #[test]
+    fn apply_plan_removes_exactly_the_candidates() {
+        let all = blobs(&["a", "b", "c", "d"]);
+        let plan = GcPlan {
+            candidates: vec![
+                GcCandidate {
+                    sha256: "b".into(),
+                    refcount: 0,
+                },
+                GcCandidate {
+                    sha256: "d".into(),
+                    refcount: 0,
+                },
+            ],
+        };
+        let after = apply_plan(&all, &plan);
+        assert_eq!(after, blobs(&["a", "c"]));
+    }
+
+    #[test]
+    fn apply_plan_preserves_blobs_not_in_plan() {
+        // Safety regression: applying a plan must never remove a blob
+        // that is absent from the plan, even if the plan mentions a
+        // sha not currently on disk.
+        let all = blobs(&["a", "b"]);
+        let plan = GcPlan {
+            candidates: vec![GcCandidate {
+                sha256: "z-not-on-disk".into(),
+                refcount: 0,
+            }],
+        };
+        let after = apply_plan(&all, &plan);
+        assert_eq!(after, all);
+    }
+
+    #[test]
+    fn plan_serializes_to_stable_json() {
+        // Dry-run output is human-parseable — the plan must round-trip
+        // through serde_json deterministically.
+        let plan = GcPlan {
+            candidates: vec![GcCandidate {
+                sha256: "abc".into(),
+                refcount: 0,
+            }],
+        };
+        let s = serde_json::to_string(&plan).unwrap();
+        let parsed: GcPlan = serde_json::from_str(&s).unwrap();
+        assert_eq!(plan, parsed);
+    }
+}

--- a/crates/apr-cli/src/commands/mod.rs
+++ b/crates/apr-cli/src/commands/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod auto_quant;
 pub(crate) mod awq_classifier;
 pub(crate) mod awq_lint;
 pub mod bench;
+pub(crate) mod blob_gc;
 pub mod canary;
 pub mod cbtop;
 pub mod chat;

--- a/crates/apr-cli/src/commands/mod.rs
+++ b/crates/apr-cli/src/commands/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod awq_classifier;
 pub(crate) mod awq_lint;
 pub mod bench;
 pub(crate) mod blob_gc;
+pub(crate) mod rm_gc_lint;
 pub mod canary;
 pub mod cbtop;
 pub mod chat;

--- a/crates/apr-cli/src/commands/rm_gc_lint.rs
+++ b/crates/apr-cli/src/commands/rm_gc_lint.rs
@@ -1,0 +1,312 @@
+//! CRUX-A-25 — `apr rm-gc-lint` CLI wiring (CRUX-SHIP-001 g2/g3 proof).
+//!
+//! Dispatches the pure `blob_gc` classifier over a captured JSON
+//! observation file covering the three FALSIFY gates:
+//!
+//! ```jsonc
+//! {
+//!   "rm": {
+//!     "manifests":      [{"tag": "gpt2:latest", "blobs": ["sha1", "sha2"]}],
+//!     "tag_to_rm":      "gpt2:latest",
+//!     "all_blobs":      ["sha1", "sha2"],
+//!     "expected_freed": ["sha1", "sha2"]
+//!   },
+//!   "safety": {
+//!     "manifests":      [
+//!       {"tag": "gpt2:latest", "blobs": ["sha1"]},
+//!       {"tag": "gpt2:dup",    "blobs": ["sha1"]}
+//!     ],
+//!     "tag_to_rm":      "gpt2:latest",
+//!     "all_blobs":      ["sha1"],
+//!     "expected_freed": []
+//!   },
+//!   "dryrun": {
+//!     "manifests":           [{"tag": "x", "blobs": []}],
+//!     "all_blobs":           ["sha-orphan"],
+//!     "expected_idempotent": true
+//!   }
+//! }
+//! ```
+//!
+//! Any missing top-level key is skipped. Non-zero exit + FALSIFY-CRUX-A-25
+//! stderr stamp on any failing gate.
+
+use crate::commands::blob_gc::{
+    apply_plan, apply_rm, compute_refcounts, plan_gc, GcPlan, Manifest,
+};
+use serde_json::Value;
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::Path;
+
+#[derive(Debug, Clone)]
+pub struct RmGcLintArgs {
+    pub observation_file: String,
+    pub json: bool,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+struct GateReport {
+    gate: &'static str,
+    falsify_id: &'static str,
+    outcome: String,
+    passed: bool,
+}
+
+pub fn run(args: RmGcLintArgs) -> Result<(), String> {
+    let path = Path::new(&args.observation_file);
+    if !path.exists() {
+        return Err(format!(
+            "FALSIFY-CRUX-A-25: observation file not found: {}",
+            args.observation_file
+        ));
+    }
+    let raw = fs::read_to_string(path)
+        .map_err(|e| format!("FALSIFY-CRUX-A-25: failed to read observation: {e}"))?;
+    if raw.trim().is_empty() {
+        return Err("FALSIFY-CRUX-A-25: observation file is empty".to_string());
+    }
+    let obs: Value = serde_json::from_str(&raw)
+        .map_err(|e| format!("FALSIFY-CRUX-A-25: observation is not valid JSON: {e}"))?;
+
+    let mut reports: Vec<GateReport> = Vec::new();
+    let mut failures: Vec<String> = Vec::new();
+
+    if let Some(v) = obs.get("rm") {
+        let (r, err) = run_rm_gate(v);
+        reports.push(r);
+        if let Some(e) = err {
+            failures.push(e);
+        }
+    }
+    if let Some(v) = obs.get("safety") {
+        let (r, err) = run_safety_gate(v);
+        reports.push(r);
+        if let Some(e) = err {
+            failures.push(e);
+        }
+    }
+    if let Some(v) = obs.get("dryrun") {
+        let (r, err) = run_dryrun_gate(v);
+        reports.push(r);
+        if let Some(e) = err {
+            failures.push(e);
+        }
+    }
+
+    if reports.is_empty() {
+        return Err("FALSIFY-CRUX-A-25: observation has none of rm/safety/dryrun".into());
+    }
+
+    if args.json {
+        let payload = serde_json::json!({
+            "contract": "CRUX-A-25",
+            "gates": reports,
+        });
+        println!("{}", serde_json::to_string_pretty(&payload).unwrap());
+    } else {
+        for r in &reports {
+            let tag = if r.passed { "PASS" } else { "FAIL" };
+            println!("[{tag}] {} ({}): {}", r.gate, r.falsify_id, r.outcome);
+        }
+    }
+
+    if !failures.is_empty() {
+        return Err(failures.join("\n"));
+    }
+    Ok(())
+}
+
+fn parse_manifests(v: Option<&Value>) -> Result<Vec<Manifest>, String> {
+    let arr = v
+        .and_then(|x| x.as_array())
+        .ok_or_else(|| "manifests must be a JSON array".to_string())?;
+    arr.iter()
+        .map(|m| {
+            let tag = m
+                .get("tag")
+                .and_then(|x| x.as_str())
+                .ok_or_else(|| "manifest.tag must be a string".to_string())?;
+            let blobs: Vec<String> = m
+                .get("blobs")
+                .and_then(|x| x.as_array())
+                .map(|a| {
+                    a.iter()
+                        .filter_map(|s| s.as_str().map(|s| s.to_string()))
+                        .collect()
+                })
+                .unwrap_or_default();
+            Ok(Manifest::new(tag, blobs))
+        })
+        .collect()
+}
+
+fn parse_blobs(v: Option<&Value>) -> BTreeSet<String> {
+    v.and_then(|x| x.as_array())
+        .map(|a| {
+            a.iter()
+                .filter_map(|s| s.as_str().map(|s| s.to_string()))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn candidate_set(plan: &GcPlan) -> BTreeSet<String> {
+    plan.candidates
+        .iter()
+        .map(|c| c.sha256.clone())
+        .collect()
+}
+
+fn run_rm_gate(v: &Value) -> (GateReport, Option<String>) {
+    let manifests = match parse_manifests(v.get("manifests")) {
+        Ok(m) => m,
+        Err(e) => {
+            let desc = format!("parse error: {e}");
+            return (
+                GateReport {
+                    gate: "rm",
+                    falsify_id: "FALSIFY-CRUX-A-25-001",
+                    outcome: desc.clone(),
+                    passed: false,
+                },
+                Some(format!("FALSIFY-CRUX-A-25-001 rm gate failed: {desc}")),
+            );
+        }
+    };
+    let tag = v.get("tag_to_rm").and_then(|x| x.as_str()).unwrap_or("");
+    let all_blobs = parse_blobs(v.get("all_blobs"));
+    let expected: BTreeSet<String> = parse_blobs(v.get("expected_freed"));
+
+    let reduced = apply_rm(&manifests, tag);
+    let rc = compute_refcounts(&reduced);
+    let plan = plan_gc(&all_blobs, &rc);
+    let got = candidate_set(&plan);
+    let passed = got == expected;
+    let desc = format!("freed={got:?} expected={expected:?}");
+    let err = if passed {
+        None
+    } else {
+        Some(format!("FALSIFY-CRUX-A-25-001 rm gate failed: {desc}"))
+    };
+    (
+        GateReport {
+            gate: "rm",
+            falsify_id: "FALSIFY-CRUX-A-25-001",
+            outcome: desc,
+            passed,
+        },
+        err,
+    )
+}
+
+fn run_safety_gate(v: &Value) -> (GateReport, Option<String>) {
+    let manifests = match parse_manifests(v.get("manifests")) {
+        Ok(m) => m,
+        Err(e) => {
+            let desc = format!("parse error: {e}");
+            return (
+                GateReport {
+                    gate: "safety",
+                    falsify_id: "FALSIFY-CRUX-A-25-002",
+                    outcome: desc.clone(),
+                    passed: false,
+                },
+                Some(format!("FALSIFY-CRUX-A-25-002 safety gate failed: {desc}")),
+            );
+        }
+    };
+    let tag = v.get("tag_to_rm").and_then(|x| x.as_str()).unwrap_or("");
+    let all_blobs = parse_blobs(v.get("all_blobs"));
+    let expected: BTreeSet<String> = parse_blobs(v.get("expected_freed"));
+
+    let reduced = apply_rm(&manifests, tag);
+    let rc = compute_refcounts(&reduced);
+    let plan = plan_gc(&all_blobs, &rc);
+    let got = candidate_set(&plan);
+
+    // Additional safety invariant: no surviving-manifest blob may appear
+    // in the candidate list, regardless of what the observer expected.
+    let surviving_blobs: BTreeSet<String> = reduced
+        .iter()
+        .flat_map(|m| m.blobs.iter().cloned())
+        .collect();
+    let violated: BTreeSet<&String> = got.intersection(&surviving_blobs).collect();
+
+    let passed = got == expected && violated.is_empty();
+    let desc = if violated.is_empty() {
+        format!("freed={got:?} expected={expected:?}")
+    } else {
+        format!(
+            "SAFETY VIOLATION: plan candidates {violated:?} are still referenced"
+        )
+    };
+    let err = if passed {
+        None
+    } else {
+        Some(format!("FALSIFY-CRUX-A-25-002 safety gate failed: {desc}"))
+    };
+    (
+        GateReport {
+            gate: "safety",
+            falsify_id: "FALSIFY-CRUX-A-25-002",
+            outcome: desc,
+            passed,
+        },
+        err,
+    )
+}
+
+fn run_dryrun_gate(v: &Value) -> (GateReport, Option<String>) {
+    let manifests = match parse_manifests(v.get("manifests")) {
+        Ok(m) => m,
+        Err(e) => {
+            let desc = format!("parse error: {e}");
+            return (
+                GateReport {
+                    gate: "dryrun",
+                    falsify_id: "FALSIFY-CRUX-A-25-003",
+                    outcome: desc.clone(),
+                    passed: false,
+                },
+                Some(format!("FALSIFY-CRUX-A-25-003 dryrun gate failed: {desc}")),
+            );
+        }
+    };
+    let all_blobs = parse_blobs(v.get("all_blobs"));
+    let expected_idempotent = v
+        .get("expected_idempotent")
+        .and_then(|x| x.as_bool())
+        .unwrap_or(true);
+
+    let rc = compute_refcounts(&manifests);
+    let plan1 = plan_gc(&all_blobs, &rc);
+    let plan2 = plan_gc(&all_blobs, &rc); // "dry-run" == same pure call
+    let post = apply_plan(&all_blobs, &plan1);
+    let rc_post = compute_refcounts(&manifests); // manifests unchanged
+    let plan3 = plan_gc(&post, &rc_post); // second gc over post-state
+
+    let dryrun_eq = plan1 == plan2;
+    let idempotent = plan3.is_noop();
+    let matches_expected = idempotent == expected_idempotent;
+
+    let passed = dryrun_eq && matches_expected;
+    let desc = format!(
+        "dryrun_eq={dryrun_eq} idempotent={idempotent} expected_idempotent={expected_idempotent} first_plan={} candidates",
+        plan1.candidates.len()
+    );
+    let err = if passed {
+        None
+    } else {
+        Some(format!("FALSIFY-CRUX-A-25-003 dryrun gate failed: {desc}"))
+    };
+    (
+        GateReport {
+            gate: "dryrun",
+            falsify_id: "FALSIFY-CRUX-A-25-003",
+            outcome: desc,
+            passed,
+        },
+        err,
+    )
+}

--- a/crates/apr-cli/src/dispatch_analysis.rs
+++ b/crates/apr-cli/src/dispatch_analysis.rs
@@ -210,6 +210,14 @@ fn dispatch_analysis_commands(cli: &Cli) -> Option<Result<(), CliError>> {
             .map_err(crate::error::CliError::Aprender)
         }
 
+        ExtendedCommands::RmGcLint { observation_file } => commands::rm_gc_lint::run(
+            commands::rm_gc_lint::RmGcLintArgs {
+                observation_file: observation_file.to_string_lossy().to_string(),
+                json: cli.json,
+            },
+        )
+        .map_err(crate::error::CliError::Aprender),
+
         ExtendedCommands::Hex {
             file,
             tensor,

--- a/crates/apr-cli/src/extended_commands.rs
+++ b/crates/apr-cli/src/extended_commands.rs
@@ -837,6 +837,12 @@ pub enum ExtendedCommands {
         #[arg(long, value_name = "FILE")]
         observation_file: PathBuf,
     },
+    /// Lint a captured `apr rm` / `apr gc` blob-GC observation (CRUX-A-25)
+    RmGcLint {
+        /// Path to captured rm/gc observation JSON
+        #[arg(long, value_name = "FILE")]
+        observation_file: PathBuf,
+    },
     /// Publishing, conversion, and analysis tools
     #[command(flatten)]
     Tools(ToolCommands),

--- a/crates/apr-cli/tests/cli_commands.rs
+++ b/crates/apr-cli/tests/cli_commands.rs
@@ -102,6 +102,7 @@ fn registered_commands() -> Vec<&'static str> {
         "imatrix-lint",
         "embeddings-lint",
         "unified-search-lint",
+        "rm-gc-lint",
         "oracle",
         "grad-norm",
         "encrypt",

--- a/crates/apr-cli/tests/falsification_crux_a_25.rs
+++ b/crates/apr-cli/tests/falsification_crux_a_25.rs
@@ -1,0 +1,470 @@
+//! CRUX-A-25 — end-to-end falsification harness for `apr rm-gc-lint`.
+//!
+//! CRUX-SHIP-001 gate g3 evidence: every FALSIFY-CRUX-A-25-{001,002,003}
+//! gate the classifier discharges has a matching e2e JSON observation
+//! that the binary must classify exactly as the harness expects.
+
+use serde_json::json;
+use std::io::Write;
+use std::process::Command;
+
+fn apr_binary() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_apr"));
+    cmd.env("NO_COLOR", "1");
+    cmd
+}
+
+fn write_obs(json_body: &serde_json::Value) -> tempfile::NamedTempFile {
+    let mut f = tempfile::Builder::new()
+        .prefix("crux-a-25-obs-")
+        .suffix(".json")
+        .tempfile()
+        .expect("tempfile");
+    f.write_all(serde_json::to_vec_pretty(json_body).unwrap().as_slice())
+        .expect("write obs");
+    f.flush().expect("flush");
+    f
+}
+
+// ===== g2: CLI shape =====
+
+#[test]
+fn falsify_crux_a_25_cli_help_advertises_observation_file() {
+    let out = apr_binary()
+        .args(["rm-gc-lint", "--help"])
+        .output()
+        .expect("run");
+    assert!(out.status.success(), "--help must exit 0");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("--observation-file"),
+        "--help must advertise --observation-file; got:\n{stdout}"
+    );
+}
+
+#[test]
+fn falsify_crux_a_25_cli_bare_invocation_is_usage_error() {
+    let out = apr_binary().arg("rm-gc-lint").output().expect("run");
+    assert!(
+        !out.status.success(),
+        "bare invocation must not exit 0 — missing required --observation-file"
+    );
+}
+
+#[test]
+fn falsify_crux_a_25_cli_missing_file_fails_with_stamp() {
+    let out = apr_binary()
+        .args([
+            "rm-gc-lint",
+            "--observation-file",
+            "/nonexistent/crux-a-25-missing.json",
+        ])
+        .output()
+        .expect("run");
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("FALSIFY-CRUX-A-25") || stderr.contains("not found"),
+        "stderr must stamp FALSIFY-CRUX-A-25; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn falsify_crux_a_25_cli_empty_file_fails() {
+    let tmp = tempfile::Builder::new()
+        .prefix("crux-a-25-empty-")
+        .suffix(".json")
+        .tempfile()
+        .unwrap();
+    let out = apr_binary()
+        .args([
+            "rm-gc-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(!out.status.success());
+}
+
+#[test]
+fn falsify_crux_a_25_cli_invalid_json_fails() {
+    let mut tmp = tempfile::Builder::new()
+        .prefix("crux-a-25-bad-")
+        .suffix(".json")
+        .tempfile()
+        .unwrap();
+    tmp.write_all(b"{not json").unwrap();
+    tmp.flush().unwrap();
+    let out = apr_binary()
+        .args([
+            "rm-gc-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(!out.status.success());
+}
+
+#[test]
+fn falsify_crux_a_25_cli_no_gates_fails() {
+    let tmp = write_obs(&json!({"unrelated": true}));
+    let out = apr_binary()
+        .args([
+            "rm-gc-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(!out.status.success());
+}
+
+// ===== FALSIFY-CRUX-A-25-001 rm frees unique-owned blobs =====
+
+#[test]
+fn falsify_crux_a_25_001_rm_frees_unique_owned_blobs() {
+    // Two blobs owned only by gpt2:latest → rm should flag both as orphans.
+    let obs = json!({
+        "rm": {
+            "manifests": [
+                { "tag": "gpt2:latest", "blobs": ["sha1", "sha2"] }
+            ],
+            "tag_to_rm": "gpt2:latest",
+            "all_blobs": ["sha1", "sha2"],
+            "expected_freed": ["sha1", "sha2"]
+        }
+    });
+    let tmp = write_obs(&obs);
+    let out = apr_binary()
+        .args([
+            "rm-gc-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "rm of last referrer must free both blobs; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("[PASS] rm"));
+}
+
+#[test]
+fn falsify_crux_a_25_001_rm_absent_tag_frees_nothing() {
+    // tag_to_rm doesn't match any manifest → no change, no orphans.
+    let obs = json!({
+        "rm": {
+            "manifests": [
+                { "tag": "gpt2:latest", "blobs": ["sha1"] }
+            ],
+            "tag_to_rm": "nonexistent:tag",
+            "all_blobs": ["sha1"],
+            "expected_freed": []
+        }
+    });
+    let tmp = write_obs(&obs);
+    let out = apr_binary()
+        .args([
+            "rm-gc-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(out.status.success(), "rm of absent tag must free nothing");
+}
+
+#[test]
+fn falsify_crux_a_25_001_rm_count_mismatch_fails() {
+    // Observer claims freed=[sha1,sha2] but classifier will compute [sha1] only.
+    let obs = json!({
+        "rm": {
+            "manifests": [
+                { "tag": "a", "blobs": ["sha1"] },
+                { "tag": "b", "blobs": ["sha2"] }
+            ],
+            "tag_to_rm": "a",
+            "all_blobs": ["sha1", "sha2"],
+            "expected_freed": ["sha1", "sha2"]
+        }
+    });
+    let tmp = write_obs(&obs);
+    let out = apr_binary()
+        .args([
+            "rm-gc-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "wrong expected_freed must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-A-25-001"));
+}
+
+// ===== FALSIFY-CRUX-A-25-002 safety — referenced blobs never freed =====
+
+#[test]
+fn falsify_crux_a_25_002_safety_duplicate_tag_frees_nothing() {
+    // gpt2:latest and gpt2:dup share sha1; rm of :latest leaves :dup, frees nothing.
+    let obs = json!({
+        "safety": {
+            "manifests": [
+                { "tag": "gpt2:latest", "blobs": ["sha1"] },
+                { "tag": "gpt2:dup",    "blobs": ["sha1"] }
+            ],
+            "tag_to_rm": "gpt2:latest",
+            "all_blobs": ["sha1"],
+            "expected_freed": []
+        }
+    });
+    let tmp = write_obs(&obs);
+    let out = apr_binary()
+        .args([
+            "rm-gc-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "duplicate-tag rm must preserve shared blob; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("[PASS] safety"));
+}
+
+#[test]
+fn falsify_crux_a_25_002_safety_wrong_expected_fails() {
+    // Observer wrongly claims the surviving-shared blob is freed → violates invariant.
+    let obs = json!({
+        "safety": {
+            "manifests": [
+                { "tag": "x", "blobs": ["sha1"] },
+                { "tag": "y", "blobs": ["sha1"] }
+            ],
+            "tag_to_rm": "x",
+            "all_blobs": ["sha1"],
+            "expected_freed": ["sha1"]
+        }
+    });
+    let tmp = write_obs(&obs);
+    let out = apr_binary()
+        .args([
+            "rm-gc-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-A-25-002"));
+}
+
+#[test]
+fn falsify_crux_a_25_002_safety_preserves_disjoint_manifests() {
+    // rm of tag-a must not touch tag-b's blobs; orphans=[sha-a] only.
+    let obs = json!({
+        "safety": {
+            "manifests": [
+                { "tag": "a", "blobs": ["sha-a"] },
+                { "tag": "b", "blobs": ["sha-b"] }
+            ],
+            "tag_to_rm": "a",
+            "all_blobs": ["sha-a", "sha-b"],
+            "expected_freed": ["sha-a"]
+        }
+    });
+    let tmp = write_obs(&obs);
+    let out = apr_binary()
+        .args([
+            "rm-gc-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(out.status.success());
+}
+
+// ===== FALSIFY-CRUX-A-25-003 dry-run purity + idempotence =====
+
+#[test]
+fn falsify_crux_a_25_003_dryrun_idempotent_on_orphan() {
+    // One orphan blob + no referencing manifests → plan ≠ empty, post-gc is idempotent.
+    let obs = json!({
+        "dryrun": {
+            "manifests": [ { "tag": "x", "blobs": [] } ],
+            "all_blobs": ["sha-orphan"],
+            "expected_idempotent": true
+        }
+    });
+    let tmp = write_obs(&obs);
+    let out = apr_binary()
+        .args([
+            "rm-gc-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "dry-run + idempotence must pass; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("[PASS] dryrun"));
+}
+
+#[test]
+fn falsify_crux_a_25_003_dryrun_all_live_is_noop() {
+    // All blobs referenced → plan is empty, second pass is trivially idempotent.
+    let obs = json!({
+        "dryrun": {
+            "manifests": [ { "tag": "a", "blobs": ["sha1", "sha2"] } ],
+            "all_blobs": ["sha1", "sha2"],
+            "expected_idempotent": true
+        }
+    });
+    let tmp = write_obs(&obs);
+    let out = apr_binary()
+        .args([
+            "rm-gc-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(out.status.success(), "all-live must pass");
+}
+
+#[test]
+fn falsify_crux_a_25_003_dryrun_wrong_expected_fails() {
+    // Observer claims non-idempotent; classifier will compute idempotent=true → mismatch.
+    let obs = json!({
+        "dryrun": {
+            "manifests": [ { "tag": "x", "blobs": [] } ],
+            "all_blobs": ["sha-orphan"],
+            "expected_idempotent": false
+        }
+    });
+    let tmp = write_obs(&obs);
+    let out = apr_binary()
+        .args([
+            "rm-gc-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-A-25-003"));
+}
+
+#[test]
+fn falsify_crux_a_25_003_dryrun_empty_blobs_is_noop() {
+    // Nothing to GC at all → plan is empty, idempotent trivially.
+    let obs = json!({
+        "dryrun": {
+            "manifests": [],
+            "all_blobs": [],
+            "expected_idempotent": true
+        }
+    });
+    let tmp = write_obs(&obs);
+    let out = apr_binary()
+        .args([
+            "rm-gc-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(out.status.success());
+}
+
+// ===== Multi-gate + JSON shape =====
+
+#[test]
+fn falsify_crux_a_25_multi_gate_all_pass() {
+    let obs = json!({
+        "rm": {
+            "manifests": [ { "tag": "gpt2:latest", "blobs": ["sha1"] } ],
+            "tag_to_rm": "gpt2:latest",
+            "all_blobs": ["sha1"],
+            "expected_freed": ["sha1"]
+        },
+        "safety": {
+            "manifests": [
+                { "tag": "a", "blobs": ["shared"] },
+                { "tag": "b", "blobs": ["shared"] }
+            ],
+            "tag_to_rm": "a",
+            "all_blobs": ["shared"],
+            "expected_freed": []
+        },
+        "dryrun": {
+            "manifests": [ { "tag": "z", "blobs": [] } ],
+            "all_blobs": ["sha-orphan"],
+            "expected_idempotent": true
+        }
+    });
+    let tmp = write_obs(&obs);
+    let out = apr_binary()
+        .args([
+            "rm-gc-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "all three gates green must exit 0; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("[PASS] rm"));
+    assert!(stdout.contains("[PASS] safety"));
+    assert!(stdout.contains("[PASS] dryrun"));
+}
+
+#[test]
+fn falsify_crux_a_25_json_output_shape() {
+    let obs = json!({
+        "rm": {
+            "manifests": [ { "tag": "gpt2:latest", "blobs": ["sha1"] } ],
+            "tag_to_rm": "gpt2:latest",
+            "all_blobs": ["sha1"],
+            "expected_freed": ["sha1"]
+        }
+    });
+    let tmp = write_obs(&obs);
+    let out = apr_binary()
+        .args([
+            "--json",
+            "rm-gc-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).expect("--json must emit valid JSON");
+    assert_eq!(parsed["contract"], "CRUX-A-25");
+    assert_eq!(parsed["gates"][0]["gate"], "rm");
+    assert_eq!(parsed["gates"][0]["falsify_id"], "FALSIFY-CRUX-A-25-001");
+    assert_eq!(parsed["gates"][0]["passed"], true);
+}


### PR DESCRIPTION
## Summary

Discharges CRUX-A-25 (\`apr rm\` + \`apr gc\` with Ollama refcount parity) at PARTIAL_ALGORITHM_LEVEL for all three FALSIFY gates.

Three pure classifiers in \`crates/apr-cli/src/commands/blob_gc.rs\`:

1. **\`compute_refcounts(manifests)\`** — derives \`sha256 → usize\` from the live manifest set. Duplicate digests within one manifest count once.
2. **\`plan_gc(all_blobs, refcounts)\`** — pure query returning a \`GcPlan\` of blobs whose refcount is zero. Sorted iteration guarantees deterministic output.
3. **\`apply_rm\` + \`apply_plan\`** — structural plan/apply separation. The plan is a pure data structure carrying no filesystem effect, so \`--dry-run\` cannot mutate disk state by construction.

## Contract status

\`contracts/crux-A-25-v1.yaml\` v1.1.0 → v1.2.0, status \`draft\` → \`partial\`.

- FALSIFY-001 (gc frees bytes after rm of last referrer) → PARTIAL_ALGORITHM_LEVEL via 4 tests
- FALSIFY-002 (gc never deletes referenced blobs) → PARTIAL_ALGORITHM_LEVEL via 4 tests
- FALSIFY-003 (--dry-run prints but does not delete) → PARTIAL_ALGORITHM_LEVEL via 4 tests

Full discharge blocks on end-to-end pull/rm/gc harnesses against real HF fixtures.

## Test plan

- [x] 17/17 unit tests pass (\`cargo test -p apr-cli --lib commands::blob_gc\`)
- [x] \`pv validate contracts/crux-A-25-v1.yaml\` → 0 errors, 0 warnings
- [x] PMAT pre-commit quality gates pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)