### PR TITLE
feat(crux-a-23): hub+local unified search merger (2 of 2 FALSIFY at PARTIAL_ALGORITHM_LEVEL)

### DIFF
--- a/contracts/apr-cli-commands-v1.yaml
+++ b/contracts/apr-cli-commands-v1.yaml
@@ -21,7 +21,7 @@ metadata:
 kind: CLICommandContract
 name: apr-cli-commands
 version: "1.0.0"
-scope: "all apr CLI subcommands (73 commands — original 57 + `mcp` added 2026-04-17 via PR #864 + `registry` added 2026-04-20 via CRUX-A-01 + `ollama-chat-lint` added 2026-04-21 via CRUX-C-04 SHIP-001 retrofit + `dry-sampling-lint` added 2026-04-21 via CRUX-C-23 SHIP-001 retrofit + `awq-lint` added 2026-04-21 via CRUX-B-08 SHIP-001 retrofit + `oom-lint` added 2026-04-21 via CRUX-F-13 SHIP-001 + `tool-use-lint` added 2026-04-21 via CRUX-C-11 SHIP-001 retrofit + `gbnf-lint` added 2026-04-21 via CRUX-C-10 SHIP-001 retrofit + `typical-p-lint` added 2026-04-21 via CRUX-C-22 SHIP-001 retrofit + `grad-norm` added 2026-04-21 via CRUX-F-09 + `registry-quota-lint` added 2026-04-21 via CRUX-A-22 SHIP-001 retrofit + `fp8-lint` added 2026-04-22 via CRUX-B-11 SHIP-001 retrofit + `imatrix-lint` added 2026-04-22 via CRUX-B-07 SHIP-001 retrofit + `nf4-lint` added 2026-04-22 via CRUX-B-10 SHIP-001 retrofit + `gptq-lint` added 2026-04-22 via CRUX-B-09 SHIP-001 retrofit + `embeddings-lint` added 2026-04-23 via CRUX-C-13 SHIP-001 retrofit)"
+scope: "all apr CLI subcommands (74 commands — original 57 + `mcp` added 2026-04-17 via PR #864 + `registry` added 2026-04-20 via CRUX-A-01 + `ollama-chat-lint` added 2026-04-21 via CRUX-C-04 SHIP-001 retrofit + `dry-sampling-lint` added 2026-04-21 via CRUX-C-23 SHIP-001 retrofit + `awq-lint` added 2026-04-21 via CRUX-B-08 SHIP-001 retrofit + `oom-lint` added 2026-04-21 via CRUX-F-13 SHIP-001 + `tool-use-lint` added 2026-04-21 via CRUX-C-11 SHIP-001 retrofit + `gbnf-lint` added 2026-04-21 via CRUX-C-10 SHIP-001 retrofit + `typical-p-lint` added 2026-04-21 via CRUX-C-22 SHIP-001 retrofit + `grad-norm` added 2026-04-21 via CRUX-F-09 + `registry-quota-lint` added 2026-04-21 via CRUX-A-22 SHIP-001 retrofit + `fp8-lint` added 2026-04-22 via CRUX-B-11 SHIP-001 retrofit + `imatrix-lint` added 2026-04-22 via CRUX-B-07 SHIP-001 retrofit + `nf4-lint` added 2026-04-22 via CRUX-B-10 SHIP-001 retrofit + `gptq-lint` added 2026-04-22 via CRUX-B-09 SHIP-001 retrofit + `embeddings-lint` added 2026-04-23 via CRUX-C-13 SHIP-001 retrofit + `unified-search-lint` added 2026-04-23 via CRUX-A-23 SHIP-001 retrofit)"
 binary: "apr"
 install: "cargo install aprender"
 
@@ -471,6 +471,12 @@ commands:
   - name: embeddings-lint
     category: inspection
     description: "Lint a captured /v1/embeddings observation (CRUX-C-13)"
+    requires_model: false
+    side_effects: []
+
+  - name: unified-search-lint
+    category: inspection
+    description: "Lint a captured Hub+local unified-search merge observation (CRUX-A-23)"
     requires_model: false
     side_effects: []
 

--- a/contracts/crux-A-23-v1.yaml
+++ b/contracts/crux-A-23-v1.yaml
@@ -2,11 +2,11 @@
 
 metadata:
   id: CRUX-A-23
-  version: "1.1.0"
+  version: "1.2.0"
   created: "2026-04-18"
   author: PAIML Engineering
   registry: true
-  status: draft
+  status: partial
   parent_contracts:
   - crux-competitive-research-ux-v1
   category: "A — Model Intake & Discovery"
@@ -48,6 +48,25 @@ falsification_tests:
     apr search gpt --offline --format json > /tmp/res.json
     jq -e '.[] | select(.repo=="gpt2") | .source=="LOCAL" or .source=="BOTH"' /tmp/res.json
   if_fails: rule 'local cache entries appear without network' is violated — contract MUST be re-verified against competitor canonical reference
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/search_merge.rs
+    sub_claim: |
+      Algorithm-level necessary condition: `merge_search_results(&[], local)`
+      preserves every local row with `Source::Local` and `cached=true`,
+      which is exactly the state `--offline` produces (hub half
+      collapses to empty). No code path through the merger returns an
+      error or drops rows when the Hub half is empty — the
+      NetworkError-free-offline invariant holds by construction at
+      this layer.
+    tests:
+    - local_only_repo_keeps_local_source
+    - offline_mode_modeled_as_empty_hub_never_errors
+    - local_entries_always_surface_even_with_nonempty_hub_miss
+    - empty_hub_and_empty_local_returns_empty
+    - classify_local_only
+    scope: offline-safety merge (pure function, no I/O)
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: end-to-end `apr search --offline` CLI harness
 - id: FALSIFY-CRUX-A-23-002
   rule: hub + local merge is deduplicated
   prediction: "a repo cached locally AND on Hub appears once with source=BOTH"
@@ -59,6 +78,27 @@ falsification_tests:
     [ "$count" = "1" ]
 
   if_fails: rule 'hub + local merge is deduplicated' is violated — contract MUST be re-verified against competitor canonical reference
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/search_merge.rs
+    sub_claim: |
+      Algorithm-level necessary condition: the merger keys rows by
+      `repo` in a BTreeMap, so any repo appearing in both halves
+      collapses to a single row tagged `Source::Both`. The output
+      length equals |hub_repos ∪ local_repos| by construction.
+      Sort is deterministic (downloads DESC, likes DESC, repo ASC)
+      so the merged list is byte-stable across runs.
+    tests:
+    - repo_in_both_halves_appears_once_as_both
+    - merged_row_count_equals_union_of_repos
+    - merge_preserves_max_downloads_on_both
+    - merge_is_deterministic
+    - sort_is_by_downloads_descending
+    - sort_breaks_ties_by_likes_then_repo
+    - classify_both_halves
+    - merge_serializes_to_stable_json
+    scope: hub+local join + dedup + sort (pure function)
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: end-to-end `apr search` CLI harness against a real HF API + local cache
 proof_obligations:
 - type: equivalence
   property: "apr search matches `huggingface_hub.list_models(search=...)` for Hub half"
@@ -72,6 +112,13 @@ verification_summary:
   proven: 0
   tested: 0
   status: spec-complete
+  discharge_ledger:
+  - falsify_id: FALSIFY-CRUX-A-23-001
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    blocked_on: "`apr search --offline` CLI harness"
+  - falsify_id: FALSIFY-CRUX-A-23-002
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    blocked_on: end-to-end apr search CLI harness against a real HF API
 
 pmat_work_tracking:
   ticket_tag: crux-crux-a-23

--- a/contracts/crux-A-23-v1.yaml
+++ b/contracts/crux-A-23-v1.yaml
@@ -2,8 +2,9 @@
 
 metadata:
   id: CRUX-A-23
-  version: "1.2.0"
+  version: "1.3.0"
   created: "2026-04-18"
+  updated: "2026-04-21"
   author: PAIML Engineering
   registry: true
   status: partial
@@ -50,6 +51,13 @@ falsification_tests:
   if_fails: rule 'local cache entries appear without network' is violated — contract MUST be re-verified against competitor canonical reference
   evidence_discharged_by:
     classifier_path: crates/apr-cli/src/commands/search_merge.rs
+    cli_path: crates/apr-cli/src/commands/unified_search_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_a_23.rs
+    e2e_tests:
+    - falsify_crux_a_23_001_offline_local_only_surfaces
+    - falsify_crux_a_23_001_offline_empty_hub_and_local_is_empty
+    - falsify_crux_a_23_001_offline_count_mismatch_fails
+    - falsify_crux_a_23_001_offline_wrong_source_fails
     sub_claim: |
       Algorithm-level necessary condition: `merge_search_results(&[], local)`
       preserves every local row with `Source::Local` and `cached=true`,
@@ -57,7 +65,9 @@ falsification_tests:
       collapses to empty). No code path through the merger returns an
       error or drops rows when the Hub half is empty — the
       NetworkError-free-offline invariant holds by construction at
-      this layer.
+      this layer. The `apr unified-search-lint` CLI dispatches the
+      merger over an observed offline-scenario (empty hub + non-empty
+      local) and exit-codes the FALSIFY-CRUX-A-23-001 gate.
     tests:
     - local_only_repo_keeps_local_source
     - offline_mode_modeled_as_empty_hub_never_errors
@@ -80,13 +90,24 @@ falsification_tests:
   if_fails: rule 'hub + local merge is deduplicated' is violated — contract MUST be re-verified against competitor canonical reference
   evidence_discharged_by:
     classifier_path: crates/apr-cli/src/commands/search_merge.rs
+    cli_path: crates/apr-cli/src/commands/unified_search_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_a_23.rs
+    e2e_tests:
+    - falsify_crux_a_23_002_dedup_repo_in_both_halves_is_both
+    - falsify_crux_a_23_002_dedup_disjoint_halves_both_appear
+    - falsify_crux_a_23_002_dedup_count_mismatch_fails
+    - falsify_crux_a_23_002_dedup_source_both_not_hub
+    - falsify_crux_a_23_002_dedup_missing_repo_fails
     sub_claim: |
       Algorithm-level necessary condition: the merger keys rows by
       `repo` in a BTreeMap, so any repo appearing in both halves
       collapses to a single row tagged `Source::Both`. The output
       length equals |hub_repos ∪ local_repos| by construction.
       Sort is deterministic (downloads DESC, likes DESC, repo ASC)
-      so the merged list is byte-stable across runs.
+      so the merged list is byte-stable across runs. The
+      `apr unified-search-lint` CLI dispatches the merger over an
+      observed hub+local overlap and exit-codes the
+      FALSIFY-CRUX-A-23-002 gate.
     tests:
     - repo_in_both_halves_appears_once_as_both
     - merged_row_count_equals_union_of_repos
@@ -119,6 +140,31 @@ verification_summary:
   - falsify_id: FALSIFY-CRUX-A-23-002
     discharge_status: PARTIAL_ALGORITHM_LEVEL
     blocked_on: end-to-end apr search CLI harness against a real HF API
+
+ship_discipline:
+  # CRUX-SHIP-001 retrofit: every classifier-only CRUX PR must ship pure-Rust
+  # classifier AND working `apr` CLI wiring + e2e test in the same commit.
+  policy: CRUX-SHIP-001
+  merge_gates:
+    g1_classifier_green:
+      status: PASS
+      evidence: crates/apr-cli/src/commands/search_merge.rs (unit tests)
+    g2_cli_reachable:
+      status: PASS
+      evidence: "`apr unified-search-lint --help` advertises --observation-file"
+      wired_in:
+      - crates/apr-cli/src/commands/mod.rs
+      - crates/apr-cli/src/commands/unified_search_lint.rs
+      - crates/apr-cli/src/extended_commands.rs
+      - crates/apr-cli/src/dispatch_analysis.rs
+      - crates/apr-cli/tests/cli_commands.rs
+      - contracts/apr-cli-commands-v1.yaml
+    g3_e2e_runs:
+      status: PASS
+      evidence: crates/apr-cli/tests/falsification_crux_a_23.rs (17 tests)
+    g4_contract_discharged:
+      status: PASS
+      evidence: "FALSIFY-CRUX-A-23-{001,002} carry cli_path + e2e_path + e2e_tests"
 
 pmat_work_tracking:
   ticket_tag: crux-crux-a-23

--- a/crates/apr-cli/src/commands/mod.rs
+++ b/crates/apr-cli/src/commands/mod.rs
@@ -104,6 +104,7 @@ pub(crate) mod rosetta;
 pub(crate) mod run;
 #[cfg(feature = "training")]
 pub(crate) mod runs;
+pub(crate) mod search_merge;
 pub(crate) mod serve;
 pub(crate) mod serve_plan;
 pub(crate) mod serve_plan_output;

--- a/crates/apr-cli/src/commands/mod.rs
+++ b/crates/apr-cli/src/commands/mod.rs
@@ -105,6 +105,7 @@ pub(crate) mod run;
 #[cfg(feature = "training")]
 pub(crate) mod runs;
 pub(crate) mod search_merge;
+pub(crate) mod unified_search_lint;
 pub(crate) mod serve;
 pub(crate) mod serve_plan;
 pub(crate) mod serve_plan_output;

--- a/crates/apr-cli/src/commands/search_merge.rs
+++ b/crates/apr-cli/src/commands/search_merge.rs
@@ -1,0 +1,307 @@
+//! Hub + local search-result merger for `apr search` (CRUX-A-23).
+//!
+//! Contract: `contracts/crux-A-23-v1.yaml`.
+//!
+//! Three pure algorithm-level necessary conditions:
+//!
+//! 1. `classify_source(repo, hub_hit, local_hit)` produces
+//!    `Source::{Hub, Local, Both}` deterministically. A repo present
+//!    in both halves MUST collapse to `Both` — never two rows.
+//!
+//! 2. `merge_search_results(hub, local)` joins the two input lists on
+//!    `repo`, tags each row with its origin, sorts by (match_score DESC,
+//!    downloads DESC, repo ASC), and returns a single deduplicated list.
+//!    Invariant: output length == |hub ∪ local| (set union on repo).
+//!
+//! 3. `merge_search_results(&[], local)` returns the local half verbatim
+//!    (with `Source::Local`). This is the algorithm-level necessary
+//!    condition for FALSIFY-CRUX-A-23-001 (offline mode returns local-
+//!    only results, never errors): when the Hub half is empty — which
+//!    is exactly what `--offline` produces — the merger still yields
+//!    the local cache entries as `Source::Local`.
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+/// Origin of a search result row. `Both` wins over either half alone
+/// so the caller does not double-render identical repos.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum Source {
+    Hub,
+    Local,
+    Both,
+}
+
+/// A search-result row before merge. Hub rows carry downloads/likes
+/// counts; local rows set `cached=true` and typically have zero
+/// downloads (we did not fetch Hub stats).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SearchHit {
+    pub repo: String,
+    #[serde(default)]
+    pub downloads: u64,
+    #[serde(default)]
+    pub likes: u64,
+    #[serde(default)]
+    pub cached: bool,
+}
+
+/// A merged search-result row carrying origin tag and aggregated
+/// downloads/likes from whichever half had the higher count.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MergedRow {
+    pub repo: String,
+    pub downloads: u64,
+    pub likes: u64,
+    pub source: Source,
+    pub cached: bool,
+}
+
+/// Classify a repo's origin given which half(s) it appeared in.
+pub fn classify_source(hub_hit: bool, local_hit: bool) -> Option<Source> {
+    match (hub_hit, local_hit) {
+        (true, true) => Some(Source::Both),
+        (true, false) => Some(Source::Hub),
+        (false, true) => Some(Source::Local),
+        (false, false) => None,
+    }
+}
+
+/// Merge Hub and local search halves into a single deduplicated list,
+/// sorted deterministically.
+///
+/// Sort order: downloads DESC, then likes DESC, then repo ASC for
+/// ties. Ties on (downloads, likes) are broken by repo name so
+/// output is byte-stable regardless of input order — this is a
+/// necessary condition for any downstream determinism tests.
+pub fn merge_search_results(hub: &[SearchHit], local: &[SearchHit]) -> Vec<MergedRow> {
+    let mut acc: BTreeMap<String, MergedRow> = BTreeMap::new();
+
+    for h in hub {
+        acc.insert(
+            h.repo.clone(),
+            MergedRow {
+                repo: h.repo.clone(),
+                downloads: h.downloads,
+                likes: h.likes,
+                source: Source::Hub,
+                cached: h.cached,
+            },
+        );
+    }
+
+    for l in local {
+        acc.entry(l.repo.clone())
+            .and_modify(|row| {
+                row.source = Source::Both;
+                row.cached = true;
+                row.downloads = row.downloads.max(l.downloads);
+                row.likes = row.likes.max(l.likes);
+            })
+            .or_insert(MergedRow {
+                repo: l.repo.clone(),
+                downloads: l.downloads,
+                likes: l.likes,
+                source: Source::Local,
+                cached: true,
+            });
+    }
+
+    let mut rows: Vec<MergedRow> = acc.into_values().collect();
+    rows.sort_by(|a, b| {
+        b.downloads
+            .cmp(&a.downloads)
+            .then_with(|| b.likes.cmp(&a.likes))
+            .then_with(|| a.repo.cmp(&b.repo))
+    });
+    rows
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hit(repo: &str, downloads: u64, likes: u64, cached: bool) -> SearchHit {
+        SearchHit {
+            repo: repo.into(),
+            downloads,
+            likes,
+            cached,
+        }
+    }
+
+    // ===== classify_source =====
+
+    #[test]
+    fn classify_hub_only() {
+        assert_eq!(classify_source(true, false), Some(Source::Hub));
+    }
+
+    #[test]
+    fn classify_local_only() {
+        assert_eq!(classify_source(false, true), Some(Source::Local));
+    }
+
+    #[test]
+    fn classify_both_halves() {
+        assert_eq!(classify_source(true, true), Some(Source::Both));
+    }
+
+    #[test]
+    fn classify_neither_returns_none() {
+        assert_eq!(classify_source(false, false), None);
+    }
+
+    #[test]
+    fn classify_is_deterministic() {
+        for (h, l) in [(true, true), (true, false), (false, true), (false, false)] {
+            assert_eq!(classify_source(h, l), classify_source(h, l));
+        }
+    }
+
+    // ===== merge_search_results: dedup =====
+
+    #[test]
+    fn repo_in_both_halves_appears_once_as_both() {
+        // FALSIFY-CRUX-A-23-002: a repo cached locally AND on Hub
+        // appears exactly once with source=BOTH.
+        let hub = vec![hit("bert-base-uncased", 1_000_000, 50, false)];
+        let local = vec![hit("bert-base-uncased", 0, 0, true)];
+        let out = merge_search_results(&hub, &local);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].source, Source::Both);
+        assert_eq!(out[0].repo, "bert-base-uncased");
+        assert!(out[0].cached);
+    }
+
+    #[test]
+    fn hub_only_repo_keeps_hub_source() {
+        let hub = vec![hit("gpt-4", 500, 10, false)];
+        let out = merge_search_results(&hub, &[]);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].source, Source::Hub);
+        assert!(!out[0].cached);
+    }
+
+    #[test]
+    fn local_only_repo_keeps_local_source() {
+        // FALSIFY-CRUX-A-23-001 core sub-claim: local entries survive
+        // an empty Hub half (the exact state --offline produces).
+        let local = vec![hit("gpt2", 0, 0, true)];
+        let out = merge_search_results(&[], &local);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].source, Source::Local);
+        assert_eq!(out[0].repo, "gpt2");
+        assert!(out[0].cached);
+    }
+
+    #[test]
+    fn empty_hub_and_empty_local_returns_empty() {
+        let out = merge_search_results(&[], &[]);
+        assert!(out.is_empty());
+    }
+
+    // ===== merge_search_results: offline safety =====
+
+    #[test]
+    fn offline_mode_modeled_as_empty_hub_never_errors() {
+        // --offline mode calls merge with hub=&[]. We prove the
+        // merger returns Ok-shaped output with every local row
+        // preserved.
+        let local = vec![
+            hit("gpt2", 0, 0, true),
+            hit("bert-base-uncased", 0, 0, true),
+        ];
+        let out = merge_search_results(&[], &local);
+        assert_eq!(out.len(), 2);
+        for row in &out {
+            assert_eq!(row.source, Source::Local);
+            assert!(row.cached);
+        }
+    }
+
+    #[test]
+    fn local_entries_always_surface_even_with_nonempty_hub_miss() {
+        // Hub may return matches for query "gpt" but miss the locally
+        // cached gpt2. The merger must still surface gpt2.
+        let hub = vec![
+            hit("openai/gpt-oss", 5000, 10, false),
+            hit("tiiuae/gpt-neox", 2000, 5, false),
+        ];
+        let local = vec![hit("gpt2", 0, 0, true)];
+        let out = merge_search_results(&hub, &local);
+        let repos: Vec<&str> = out.iter().map(|r| r.repo.as_str()).collect();
+        assert!(repos.contains(&"gpt2"));
+    }
+
+    // ===== merge_search_results: sort order + determinism =====
+
+    #[test]
+    fn sort_is_by_downloads_descending() {
+        let hub = vec![
+            hit("c", 100, 0, false),
+            hit("a", 300, 0, false),
+            hit("b", 200, 0, false),
+        ];
+        let out = merge_search_results(&hub, &[]);
+        let order: Vec<&str> = out.iter().map(|r| r.repo.as_str()).collect();
+        assert_eq!(order, vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn sort_breaks_ties_by_likes_then_repo() {
+        let hub = vec![
+            hit("zzz", 100, 10, false),
+            hit("aaa", 100, 10, false),
+            hit("mmm", 100, 20, false),
+        ];
+        let out = merge_search_results(&hub, &[]);
+        let order: Vec<&str> = out.iter().map(|r| r.repo.as_str()).collect();
+        assert_eq!(order, vec!["mmm", "aaa", "zzz"]);
+    }
+
+    #[test]
+    fn merge_is_deterministic() {
+        let hub = vec![hit("a", 1, 1, false), hit("b", 2, 2, false)];
+        let local = vec![hit("b", 0, 0, true)];
+        assert_eq!(
+            merge_search_results(&hub, &local),
+            merge_search_results(&hub, &local)
+        );
+    }
+
+    #[test]
+    fn merge_preserves_max_downloads_on_both() {
+        // When a repo appears in both halves, the merged row should
+        // carry the higher downloads count (usually Hub, but if the
+        // local half happens to carry a bigger number for any reason
+        // we don't lose it).
+        let hub = vec![hit("x", 100, 0, false)];
+        let local = vec![hit("x", 999, 0, true)];
+        let out = merge_search_results(&hub, &local);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].downloads, 999);
+        assert_eq!(out[0].source, Source::Both);
+    }
+
+    #[test]
+    fn merged_row_count_equals_union_of_repos() {
+        // Fundamental invariant: output length is the size of
+        // {hub.repo} ∪ {local.repo}. Overlapping repos collapse.
+        let hub = vec![hit("a", 0, 0, false), hit("b", 0, 0, false)];
+        let local = vec![hit("b", 0, 0, true), hit("c", 0, 0, true)];
+        let out = merge_search_results(&hub, &local);
+        // Union = {a, b, c}
+        assert_eq!(out.len(), 3);
+    }
+
+    #[test]
+    fn merge_serializes_to_stable_json() {
+        let hub = vec![hit("a", 1, 0, false)];
+        let out = merge_search_results(&hub, &[]);
+        let s = serde_json::to_string(&out).unwrap();
+        let parsed: Vec<MergedRow> = serde_json::from_str(&s).unwrap();
+        assert_eq!(out, parsed);
+    }
+}

--- a/crates/apr-cli/src/commands/unified_search_lint.rs
+++ b/crates/apr-cli/src/commands/unified_search_lint.rs
@@ -1,0 +1,230 @@
+//! CRUX-A-23 — `apr unified-search-lint` CLI wiring (CRUX-SHIP-001 g2/g3 proof).
+//!
+//! Dispatches the pure `search_merge` classifier over a captured JSON
+//! observation file covering the two FALSIFY gates:
+//!
+//! ```jsonc
+//! {
+//!   "offline": {
+//!     "local":            [{"repo": "gpt2", "downloads": 0, "likes": 0, "cached": true}],
+//!     "expected_count":   1,
+//!     "expected_sources": { "gpt2": "LOCAL" }
+//!   },
+//!   "dedup": {
+//!     "hub":              [{"repo": "gpt2", "downloads": 1000, "likes": 10}],
+//!     "local":            [{"repo": "gpt2", "cached": true}],
+//!     "expected_count":   1,
+//!     "expected_sources": { "gpt2": "BOTH" }
+//!   }
+//! }
+//! ```
+//!
+//! Any missing top-level key is skipped. Non-zero exit + FALSIFY-CRUX-A-23
+//! stderr stamp on any failing gate.
+
+use crate::commands::search_merge::{merge_search_results, MergedRow, SearchHit, Source};
+use serde_json::Value;
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+
+#[derive(Debug, Clone)]
+pub struct UnifiedSearchLintArgs {
+    pub observation_file: String,
+    pub json: bool,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+struct GateReport {
+    gate: &'static str,
+    falsify_id: &'static str,
+    outcome: String,
+    passed: bool,
+}
+
+pub fn run(args: UnifiedSearchLintArgs) -> Result<(), String> {
+    let path = Path::new(&args.observation_file);
+    if !path.exists() {
+        return Err(format!(
+            "FALSIFY-CRUX-A-23: observation file not found: {}",
+            args.observation_file
+        ));
+    }
+    let raw = fs::read_to_string(path)
+        .map_err(|e| format!("FALSIFY-CRUX-A-23: failed to read observation: {e}"))?;
+    if raw.trim().is_empty() {
+        return Err("FALSIFY-CRUX-A-23: observation file is empty".to_string());
+    }
+    let obs: Value = serde_json::from_str(&raw)
+        .map_err(|e| format!("FALSIFY-CRUX-A-23: observation is not valid JSON: {e}"))?;
+
+    let mut reports: Vec<GateReport> = Vec::new();
+    let mut failures: Vec<String> = Vec::new();
+
+    if let Some(v) = obs.get("offline") {
+        let (r, err) = run_offline_gate(v);
+        reports.push(r);
+        if let Some(e) = err {
+            failures.push(e);
+        }
+    }
+    if let Some(v) = obs.get("dedup") {
+        let (r, err) = run_dedup_gate(v);
+        reports.push(r);
+        if let Some(e) = err {
+            failures.push(e);
+        }
+    }
+
+    if reports.is_empty() {
+        return Err("FALSIFY-CRUX-A-23: observation has none of offline/dedup".into());
+    }
+
+    if args.json {
+        let payload = serde_json::json!({
+            "contract": "CRUX-A-23",
+            "gates": reports,
+        });
+        println!("{}", serde_json::to_string_pretty(&payload).unwrap());
+    } else {
+        for r in &reports {
+            let tag = if r.passed { "PASS" } else { "FAIL" };
+            println!("[{tag}] {} ({}): {}", r.gate, r.falsify_id, r.outcome);
+        }
+    }
+
+    if !failures.is_empty() {
+        return Err(failures.join("\n"));
+    }
+    Ok(())
+}
+
+fn parse_hits(v: Option<&Value>) -> Vec<SearchHit> {
+    v.and_then(|x| x.as_array())
+        .map(|a| {
+            a.iter()
+                .filter_map(|h| {
+                    let repo = h.get("repo")?.as_str()?.to_string();
+                    let downloads = h.get("downloads").and_then(|x| x.as_u64()).unwrap_or(0);
+                    let likes = h.get("likes").and_then(|x| x.as_u64()).unwrap_or(0);
+                    let cached = h.get("cached").and_then(|x| x.as_bool()).unwrap_or(false);
+                    Some(SearchHit {
+                        repo,
+                        downloads,
+                        likes,
+                        cached,
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn parse_expected_sources(v: Option<&Value>) -> BTreeMap<String, String> {
+    v.and_then(|x| x.as_object())
+        .map(|o| {
+            o.iter()
+                .filter_map(|(k, val)| val.as_str().map(|s| (k.clone(), s.to_string())))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn source_tag(s: Source) -> &'static str {
+    match s {
+        Source::Hub => "HUB",
+        Source::Local => "LOCAL",
+        Source::Both => "BOTH",
+    }
+}
+
+fn compare_merge(
+    rows: &[MergedRow],
+    expected_count: Option<u64>,
+    expected_sources: &BTreeMap<String, String>,
+) -> Result<String, String> {
+    if let Some(want) = expected_count {
+        if rows.len() as u64 != want {
+            return Err(format!(
+                "expected_count={want}, got {} (repos={:?})",
+                rows.len(),
+                rows.iter().map(|r| &r.repo).collect::<Vec<_>>()
+            ));
+        }
+    }
+    for (repo, want_source) in expected_sources {
+        match rows.iter().find(|r| &r.repo == repo) {
+            None => {
+                return Err(format!("expected repo {repo:?} missing from merged rows"));
+            }
+            Some(r) => {
+                let got = source_tag(r.source);
+                if got != want_source.as_str() {
+                    return Err(format!(
+                        "repo {repo:?} expected source={want_source} got={got}"
+                    ));
+                }
+            }
+        }
+    }
+    Ok(format!(
+        "rows={} expected_count_ok={} sources_ok={}",
+        rows.len(),
+        expected_count.is_some(),
+        expected_sources.len()
+    ))
+}
+
+fn run_offline_gate(v: &Value) -> (GateReport, Option<String>) {
+    let hub = parse_hits(v.get("hub")); // absent → empty (offline)
+    let local = parse_hits(v.get("local"));
+    let expected_count = v.get("expected_count").and_then(|x| x.as_u64());
+    let expected_sources = parse_expected_sources(v.get("expected_sources"));
+
+    let rows = merge_search_results(&hub, &local);
+    let (passed, desc) = match compare_merge(&rows, expected_count, &expected_sources) {
+        Ok(msg) => (true, msg),
+        Err(msg) => (false, msg),
+    };
+    let err = if passed {
+        None
+    } else {
+        Some(format!("FALSIFY-CRUX-A-23-001 offline gate failed: {desc}"))
+    };
+    (
+        GateReport {
+            gate: "offline",
+            falsify_id: "FALSIFY-CRUX-A-23-001",
+            outcome: desc,
+            passed,
+        },
+        err,
+    )
+}
+
+fn run_dedup_gate(v: &Value) -> (GateReport, Option<String>) {
+    let hub = parse_hits(v.get("hub"));
+    let local = parse_hits(v.get("local"));
+    let expected_count = v.get("expected_count").and_then(|x| x.as_u64());
+    let expected_sources = parse_expected_sources(v.get("expected_sources"));
+
+    let rows = merge_search_results(&hub, &local);
+    let (passed, desc) = match compare_merge(&rows, expected_count, &expected_sources) {
+        Ok(msg) => (true, msg),
+        Err(msg) => (false, msg),
+    };
+    let err = if passed {
+        None
+    } else {
+        Some(format!("FALSIFY-CRUX-A-23-002 dedup gate failed: {desc}"))
+    };
+    (
+        GateReport {
+            gate: "dedup",
+            falsify_id: "FALSIFY-CRUX-A-23-002",
+            outcome: desc,
+            passed,
+        },
+        err,
+    )
+}

--- a/crates/apr-cli/src/dispatch_analysis.rs
+++ b/crates/apr-cli/src/dispatch_analysis.rs
@@ -202,6 +202,14 @@ fn dispatch_analysis_commands(cli: &Cli) -> Option<Result<(), CliError>> {
             .map_err(crate::error::CliError::Aprender)
         }
 
+        ExtendedCommands::UnifiedSearchLint { observation_file } => {
+            commands::unified_search_lint::run(commands::unified_search_lint::UnifiedSearchLintArgs {
+                observation_file: observation_file.to_string_lossy().to_string(),
+                json: cli.json,
+            })
+            .map_err(crate::error::CliError::Aprender)
+        }
+
         ExtendedCommands::Hex {
             file,
             tensor,

--- a/crates/apr-cli/src/extended_commands.rs
+++ b/crates/apr-cli/src/extended_commands.rs
@@ -831,6 +831,12 @@ pub enum ExtendedCommands {
         #[arg(long, value_name = "FILE")]
         observation_file: PathBuf,
     },
+    /// Lint a captured Hub+local unified-search merge observation (CRUX-A-23)
+    UnifiedSearchLint {
+        /// Path to captured unified-search observation JSON
+        #[arg(long, value_name = "FILE")]
+        observation_file: PathBuf,
+    },
     /// Publishing, conversion, and analysis tools
     #[command(flatten)]
     Tools(ToolCommands),

--- a/crates/apr-cli/tests/cli_commands.rs
+++ b/crates/apr-cli/tests/cli_commands.rs
@@ -101,6 +101,7 @@ fn registered_commands() -> Vec<&'static str> {
         "registry-quota-lint",
         "imatrix-lint",
         "embeddings-lint",
+        "unified-search-lint",
         "oracle",
         "grad-norm",
         "encrypt",

--- a/crates/apr-cli/tests/falsification_crux_a_23.rs
+++ b/crates/apr-cli/tests/falsification_crux_a_23.rs
@@ -1,0 +1,407 @@
+//! CRUX-A-23 — end-to-end falsification harness for `apr unified-search-lint`.
+//!
+//! CRUX-SHIP-001 gate g3 evidence: every FALSIFY-CRUX-A-23-{001,002}
+//! gate the classifier discharges has a matching e2e JSON observation
+//! that the binary must classify exactly as the harness expects.
+
+use serde_json::json;
+use std::io::Write;
+use std::process::Command;
+
+fn apr_binary() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_apr"));
+    cmd.env("NO_COLOR", "1");
+    cmd
+}
+
+fn write_obs(json_body: &serde_json::Value) -> tempfile::NamedTempFile {
+    let mut f = tempfile::Builder::new()
+        .prefix("crux-a-23-obs-")
+        .suffix(".json")
+        .tempfile()
+        .expect("tempfile");
+    f.write_all(serde_json::to_vec_pretty(json_body).unwrap().as_slice())
+        .expect("write obs");
+    f.flush().expect("flush");
+    f
+}
+
+// ===== g2: CLI shape =====
+
+#[test]
+fn falsify_crux_a_23_cli_help_advertises_observation_file() {
+    let out = apr_binary()
+        .args(["unified-search-lint", "--help"])
+        .output()
+        .expect("run");
+    assert!(out.status.success(), "--help must exit 0");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("--observation-file"),
+        "--help must advertise --observation-file; got:\n{stdout}"
+    );
+}
+
+#[test]
+fn falsify_crux_a_23_cli_bare_invocation_is_usage_error() {
+    let out = apr_binary()
+        .arg("unified-search-lint")
+        .output()
+        .expect("run");
+    assert!(
+        !out.status.success(),
+        "bare invocation must not exit 0 — missing required --observation-file"
+    );
+}
+
+#[test]
+fn falsify_crux_a_23_cli_missing_file_fails_with_stamp() {
+    let out = apr_binary()
+        .args([
+            "unified-search-lint",
+            "--observation-file",
+            "/nonexistent/crux-a-23-missing.json",
+        ])
+        .output()
+        .expect("run");
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("FALSIFY-CRUX-A-23") || stderr.contains("not found"),
+        "stderr must stamp FALSIFY-CRUX-A-23; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn falsify_crux_a_23_cli_empty_file_fails() {
+    let tmp = tempfile::Builder::new()
+        .prefix("crux-a-23-empty-")
+        .suffix(".json")
+        .tempfile()
+        .unwrap();
+    let out = apr_binary()
+        .args([
+            "unified-search-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(!out.status.success());
+}
+
+#[test]
+fn falsify_crux_a_23_cli_invalid_json_fails() {
+    let mut tmp = tempfile::Builder::new()
+        .prefix("crux-a-23-bad-")
+        .suffix(".json")
+        .tempfile()
+        .unwrap();
+    tmp.write_all(b"{bad json").unwrap();
+    tmp.flush().unwrap();
+    let out = apr_binary()
+        .args([
+            "unified-search-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(!out.status.success());
+}
+
+#[test]
+fn falsify_crux_a_23_cli_no_gates_fails() {
+    let tmp = write_obs(&json!({"unrelated": true}));
+    let out = apr_binary()
+        .args([
+            "unified-search-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(!out.status.success());
+}
+
+// ===== FALSIFY-CRUX-A-23-001 offline =====
+
+#[test]
+fn falsify_crux_a_23_001_offline_local_only_surfaces() {
+    // Hub absent (offline); local rows must appear with source=LOCAL.
+    let obs = json!({
+        "offline": {
+            "local": [
+                { "repo": "gpt2",              "cached": true },
+                { "repo": "bert-base-uncased", "cached": true }
+            ],
+            "expected_count": 2,
+            "expected_sources": { "gpt2": "LOCAL", "bert-base-uncased": "LOCAL" }
+        }
+    });
+    let tmp = write_obs(&obs);
+    let out = apr_binary()
+        .args([
+            "unified-search-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "offline with 2 local rows must pass; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("[PASS] offline"));
+}
+
+#[test]
+fn falsify_crux_a_23_001_offline_empty_hub_and_local_is_empty() {
+    // Classifier returns 0 rows, observer pre-declared expected_count=0 — PASS.
+    let obs = json!({
+        "offline": {
+            "local": [],
+            "expected_count": 0,
+            "expected_sources": {}
+        }
+    });
+    let tmp = write_obs(&obs);
+    let out = apr_binary()
+        .args([
+            "unified-search-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(out.status.success(), "empty-both expected empty must pass");
+}
+
+#[test]
+fn falsify_crux_a_23_001_offline_count_mismatch_fails() {
+    let obs = json!({
+        "offline": {
+            "local": [{ "repo": "gpt2", "cached": true }],
+            "expected_count": 2
+        }
+    });
+    let tmp = write_obs(&obs);
+    let out = apr_binary()
+        .args([
+            "unified-search-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "count mismatch must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-A-23-001"));
+}
+
+#[test]
+fn falsify_crux_a_23_001_offline_wrong_source_fails() {
+    // local-only repo but observer claimed source=HUB → classifier reports LOCAL → FAIL.
+    let obs = json!({
+        "offline": {
+            "local": [{ "repo": "gpt2", "cached": true }],
+            "expected_count": 1,
+            "expected_sources": { "gpt2": "HUB" }
+        }
+    });
+    let tmp = write_obs(&obs);
+    let out = apr_binary()
+        .args([
+            "unified-search-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "wrong expected source must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-A-23-001"));
+}
+
+// ===== FALSIFY-CRUX-A-23-002 dedup =====
+
+#[test]
+fn falsify_crux_a_23_002_dedup_repo_in_both_halves_is_both() {
+    let obs = json!({
+        "dedup": {
+            "hub":   [{ "repo": "gpt2", "downloads": 1000, "likes": 10 }],
+            "local": [{ "repo": "gpt2", "cached": true }],
+            "expected_count": 1,
+            "expected_sources": { "gpt2": "BOTH" }
+        }
+    });
+    let tmp = write_obs(&obs);
+    let out = apr_binary()
+        .args([
+            "unified-search-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "hub+local overlap must collapse to BOTH; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn falsify_crux_a_23_002_dedup_disjoint_halves_both_appear() {
+    let obs = json!({
+        "dedup": {
+            "hub":   [{ "repo": "gpt2", "downloads": 500 }],
+            "local": [{ "repo": "bert", "cached": true }],
+            "expected_count": 2,
+            "expected_sources": { "gpt2": "HUB", "bert": "LOCAL" }
+        }
+    });
+    let tmp = write_obs(&obs);
+    let out = apr_binary()
+        .args([
+            "unified-search-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(out.status.success());
+}
+
+#[test]
+fn falsify_crux_a_23_002_dedup_count_mismatch_fails() {
+    let obs = json!({
+        "dedup": {
+            "hub":   [{ "repo": "gpt2" }],
+            "local": [{ "repo": "gpt2" }],
+            "expected_count": 2
+        }
+    });
+    let tmp = write_obs(&obs);
+    let out = apr_binary()
+        .args([
+            "unified-search-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "dedup forces count=1, not 2");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-A-23-002"));
+}
+
+#[test]
+fn falsify_crux_a_23_002_dedup_source_both_not_hub() {
+    // Overlap → source=BOTH; declaring HUB must FAIL.
+    let obs = json!({
+        "dedup": {
+            "hub":   [{ "repo": "gpt2" }],
+            "local": [{ "repo": "gpt2" }],
+            "expected_count": 1,
+            "expected_sources": { "gpt2": "HUB" }
+        }
+    });
+    let tmp = write_obs(&obs);
+    let out = apr_binary()
+        .args([
+            "unified-search-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "BOTH claimed as HUB must fail");
+}
+
+#[test]
+fn falsify_crux_a_23_002_dedup_missing_repo_fails() {
+    let obs = json!({
+        "dedup": {
+            "hub":   [{ "repo": "gpt2" }],
+            "local": [],
+            "expected_sources": { "nonexistent-repo": "HUB" }
+        }
+    });
+    let tmp = write_obs(&obs);
+    let out = apr_binary()
+        .args([
+            "unified-search-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "declaring missing repo must fail");
+}
+
+// ===== Multi-gate + JSON shape =====
+
+#[test]
+fn falsify_crux_a_23_multi_gate_all_pass() {
+    let obs = json!({
+        "offline": {
+            "local": [{ "repo": "gpt2", "cached": true }],
+            "expected_count": 1,
+            "expected_sources": { "gpt2": "LOCAL" }
+        },
+        "dedup": {
+            "hub":   [{ "repo": "bert" }],
+            "local": [{ "repo": "bert", "cached": true }],
+            "expected_count": 1,
+            "expected_sources": { "bert": "BOTH" }
+        }
+    });
+    let tmp = write_obs(&obs);
+    let out = apr_binary()
+        .args([
+            "unified-search-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "both gates green must exit 0; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("[PASS] offline"));
+    assert!(stdout.contains("[PASS] dedup"));
+}
+
+#[test]
+fn falsify_crux_a_23_json_output_shape() {
+    let obs = json!({
+        "offline": {
+            "local": [{ "repo": "gpt2", "cached": true }],
+            "expected_count": 1
+        }
+    });
+    let tmp = write_obs(&obs);
+    let out = apr_binary()
+        .args([
+            "--json",
+            "unified-search-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).expect("--json must emit valid JSON");
+    assert_eq!(parsed["contract"], "CRUX-A-23");
+    assert_eq!(parsed["gates"][0]["gate"], "offline");
+    assert_eq!(parsed["gates"][0]["falsify_id"], "FALSIFY-CRUX-A-23-001");
+    assert_eq!(parsed["gates"][0]["passed"], true);
+}


### PR DESCRIPTION
## Summary

Discharges CRUX-A-23 (\`apr search QUERY\` returning hub + local cache in one unified list, parity with \`huggingface_hub.list_models\`) at PARTIAL_ALGORITHM_LEVEL for both FALSIFY gates.

Two pure classifiers in \`crates/apr-cli/src/commands/search_merge.rs\`:

1. **\`classify_source(hub_hit, local_hit)\`** — three-way tag over \`Source::{Hub, Local, Both}\` based on membership in each half.
2. **\`merge_search_results(hub, local)\`** — keys rows by repo in a \`BTreeMap\`, collapses overlaps to one \`Source::Both\` row, sorts by \`(downloads DESC, likes DESC, repo ASC)\`. Output length = |hub_repos ∪ local_repos| by construction.

Offline safety is structural: \`merge_search_results(&[], local)\` is exactly what \`--offline\` produces. Every local row survives with \`Source::Local\` and \`cached=true\`; no code path errors or drops rows when the Hub half is empty.

## Contract status

\`contracts/crux-A-23-v1.yaml\` v1.1.0 → v1.2.0, status \`draft\` → \`partial\`.

- FALSIFY-001 (local entries appear without network) → PARTIAL_ALGORITHM_LEVEL via 5 tests
- FALSIFY-002 (hub+local merge deduplicated) → PARTIAL_ALGORITHM_LEVEL via 8 tests

Full discharge blocks on end-to-end \`apr search\` CLI harnesses against a real HF API + local cache.

## Test plan

- [x] 17/17 unit tests pass (\`cargo test -p apr-cli --lib commands::search_merge\`)
- [x] \`pv validate contracts/crux-A-23-v1.yaml\` → 0 errors, 0 warnings
- [x] PMAT pre-commit quality gates pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)