### PR TITLE
feat(crux-b-02): GGUF→safetensors layout + metadata + PEFT classifier (3 of 4 FALSIFY at PARTIAL_ALGORITHM_LEVEL)

### DIFF
--- a/contracts/apr-cli-commands-v1.yaml
+++ b/contracts/apr-cli-commands-v1.yaml
@@ -21,7 +21,7 @@ metadata:
 kind: CLICommandContract
 name: apr-cli-commands
 version: "1.0.0"
-scope: "all apr CLI subcommands (66 commands — original 57 + `mcp` added 2026-04-17 via PR #864 + `registry` added 2026-04-20 via CRUX-A-01 + `ollama-chat-lint` added 2026-04-21 via CRUX-C-04 SHIP-001 retrofit + `dry-sampling-lint` added 2026-04-21 via CRUX-C-23 SHIP-001 retrofit + `awq-lint` added 2026-04-21 via CRUX-B-08 SHIP-001 retrofit + `oom-lint` added 2026-04-21 via CRUX-F-13 SHIP-001 + `tool-use-lint` added 2026-04-21 via CRUX-C-11 SHIP-001 retrofit + `gbnf-lint` added 2026-04-21 via CRUX-C-10 SHIP-001 retrofit + `typical-p-lint` added 2026-04-21 via CRUX-C-22 SHIP-001 retrofit)"
+scope: "all apr CLI subcommands (67 commands — original 57 + `mcp` added 2026-04-17 via PR #864 + `registry` added 2026-04-20 via CRUX-A-01 + `ollama-chat-lint` added 2026-04-21 via CRUX-C-04 SHIP-001 retrofit + `dry-sampling-lint` added 2026-04-21 via CRUX-C-23 SHIP-001 retrofit + `awq-lint` added 2026-04-21 via CRUX-B-08 SHIP-001 retrofit + `oom-lint` added 2026-04-21 via CRUX-F-13 SHIP-001 + `tool-use-lint` added 2026-04-21 via CRUX-C-11 SHIP-001 retrofit + `gbnf-lint` added 2026-04-21 via CRUX-C-10 SHIP-001 retrofit + `typical-p-lint` added 2026-04-21 via CRUX-C-22 SHIP-001 retrofit + `gguf-safetensors-lint` added 2026-04-21 via CRUX-B-02 SHIP-001 retrofit)"
 binary: "apr"
 install: "cargo install aprender"
 
@@ -429,6 +429,12 @@ commands:
   - name: typical-p-lint
     category: inspection
     description: "Lint a captured typical-p sampling observation (CRUX-C-22)"
+    requires_model: false
+    side_effects: []
+
+  - name: gguf-safetensors-lint
+    category: inspection
+    description: "Lint a captured GGUF→safetensors layout/metadata/PEFT observation (CRUX-B-02)"
     requires_model: false
     side_effects: []
 

--- a/contracts/crux-B-02-v1.yaml
+++ b/contracts/crux-B-02-v1.yaml
@@ -6,11 +6,11 @@
 
 metadata:
   id: CRUX-B-02
-  version: "1.0.0-draft"
+  version: "1.1.0"
   created: "2026-04-18"
   author: PAIML Engineering
   registry: true
-  status: draft
+  status: partial
   parent_contracts:
   - crux-competitive-research-ux-v1
   category: "B — Inspection & Debugging"
@@ -80,6 +80,23 @@ falsification_tests:
       [ -f "$TMP/$f" ] || { echo "missing $f"; exit 1; }
     done
   if_fails: "converted directory is missing required HuggingFace files"
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/gguf_to_safetensors.rs
+    sub_claim: |
+      Algorithm-level necessary condition: `hf_required_files()` is the
+      canonical trio HF transformers expects, and `missing_hf_files`
+      reports the exact subset absent from any candidate directory
+      listing. Without these filenames present, no downstream byte-
+      level load work can succeed.
+    tests:
+    - required_files_set_is_canonical
+    - missing_files_empty_on_complete_output
+    - missing_files_flags_each_omission
+    - missing_files_flags_all_when_empty
+    - required_files_set_is_deterministic
+    scope: output-directory file-layout (pure set)
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: end-to-end `apr convert --format safetensors` fixture harness
 
 - id: FALSIFY-CRUX-B-02-002
   rule: dequant numerical bound
@@ -112,6 +129,28 @@ falsification_tests:
     assert m is not None
     "
   if_fails: "transformers cannot load the converted safetensors directory"
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/gguf_to_safetensors.rs
+    sub_claim: |
+      Algorithm-level necessary condition: `translate_gguf_metadata`
+      produces a well-typed `HfLlamaConfig` with the four required
+      fields (architectures, hidden_size, num_hidden_layers,
+      num_attention_heads) and serializes round-trip clean through
+      serde_json. Missing keys return Err rather than silently
+      defaulting, which would hide upstream bugs and let
+      `from_pretrained` succeed with the wrong layer count.
+    tests:
+    - translate_full_metadata_succeeds
+    - translate_missing_architecture_errors
+    - translate_missing_hidden_size_errors
+    - translate_missing_layer_count_errors
+    - translate_missing_head_count_errors
+    - translate_wrong_type_errors
+    - translate_is_deterministic
+    - translate_config_roundtrips_through_json
+    scope: GGUF KV → HF config.json translator (pure function)
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: uv run transformers AutoModelForCausalLM.from_pretrained harness
 
 - id: FALSIFY-CRUX-B-02-004
   rule: peft LoRA attaches without shape errors
@@ -127,6 +166,24 @@ falsification_tests:
     assert sum(p.numel() for p in m2.parameters() if p.requires_grad) > 0
     "
   if_fails: "PEFT LoRA attachment failed — converted output is not PEFT-ready"
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/gguf_to_safetensors.rs
+    sub_claim: |
+      Algorithm-level necessary condition: `peft_target_modules_resolve`
+      checks that every target module name (q_proj, v_proj, etc.)
+      matches at least one tensor in the safetensors archive via
+      substring containment, mirroring PEFT's own name-matching rule.
+      If every target resolves, `peft.get_peft_model` has the
+      precondition it needs to attach LoRA adapters.
+    tests:
+    - peft_default_targets_resolve_on_llama_layout
+    - peft_unknown_target_module_flagged
+    - peft_empty_tensor_list_fails_all_targets
+    - peft_empty_target_list_trivially_resolves
+    - peft_resolution_is_deterministic
+    scope: PEFT target-module resolver (pure function over tensor names)
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: uv run peft get_peft_model attach harness
 
 proof_obligations:
 - type: invariant
@@ -143,6 +200,19 @@ verification_summary:
   proven: 0
   tested: 0
   status: spec-complete
+  discharge_ledger:
+  - falsify_id: FALSIFY-CRUX-B-02-001
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    blocked_on: end-to-end apr convert --format safetensors fixture harness
+  - falsify_id: FALSIFY-CRUX-B-02-002
+    discharge_status: NOT_DISCHARGED
+    blocked_on: Q4_K_M dequant numerical harness vs reference f32
+  - falsify_id: FALSIFY-CRUX-B-02-003
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    blocked_on: uv run transformers AutoModelForCausalLM.from_pretrained harness
+  - falsify_id: FALSIFY-CRUX-B-02-004
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    blocked_on: uv run peft get_peft_model attach harness
 
 pmat_work_tracking:
   # Managed by master contract §12. If intake_status == "missing", a ticket

--- a/contracts/crux-B-02-v1.yaml
+++ b/contracts/crux-B-02-v1.yaml
@@ -6,8 +6,9 @@
 
 metadata:
   id: CRUX-B-02
-  version: "1.1.0"
+  version: "1.2.0"
   created: "2026-04-18"
+  updated: "2026-04-21"
   author: PAIML Engineering
   registry: true
   status: partial
@@ -82,12 +83,20 @@ falsification_tests:
   if_fails: "converted directory is missing required HuggingFace files"
   evidence_discharged_by:
     classifier_path: crates/apr-cli/src/commands/gguf_to_safetensors.rs
+    cli_path: crates/apr-cli/src/commands/gguf_safetensors_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_b_02.rs
+    e2e_tests:
+    - falsify_crux_b_02_001_layout_complete_passes
+    - falsify_crux_b_02_001_layout_missing_safetensors_fails
+    - falsify_crux_b_02_001_layout_empty_listing_fails_all
     sub_claim: |
       Algorithm-level necessary condition: `hf_required_files()` is the
       canonical trio HF transformers expects, and `missing_hf_files`
       reports the exact subset absent from any candidate directory
       listing. Without these filenames present, no downstream byte-
-      level load work can succeed.
+      level load work can succeed. The `apr gguf-safetensors-lint`
+      CLI dispatches the classifier over an observed layout listing
+      and exit-codes the FALSIFY-CRUX-B-02-001 gate.
     tests:
     - required_files_set_is_canonical
     - missing_files_empty_on_complete_output
@@ -131,6 +140,14 @@ falsification_tests:
   if_fails: "transformers cannot load the converted safetensors directory"
   evidence_discharged_by:
     classifier_path: crates/apr-cli/src/commands/gguf_to_safetensors.rs
+    cli_path: crates/apr-cli/src/commands/gguf_safetensors_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_b_02.rs
+    e2e_tests:
+    - falsify_crux_b_02_003_metadata_full_passes
+    - falsify_crux_b_02_003_metadata_missing_architecture_expected_missing_key_passes
+    - falsify_crux_b_02_003_metadata_missing_key_with_wrong_expectation_fails
+    - falsify_crux_b_02_003_metadata_wrong_type_expected_wrong_type_passes
+    - falsify_crux_b_02_003_metadata_string_for_embedding_length_is_wrong_type
     sub_claim: |
       Algorithm-level necessary condition: `translate_gguf_metadata`
       produces a well-typed `HfLlamaConfig` with the four required
@@ -138,7 +155,10 @@ falsification_tests:
       num_attention_heads) and serializes round-trip clean through
       serde_json. Missing keys return Err rather than silently
       defaulting, which would hide upstream bugs and let
-      `from_pretrained` succeed with the wrong layer count.
+      `from_pretrained` succeed with the wrong layer count. The
+      `apr gguf-safetensors-lint` CLI dispatches the translator over
+      an observed GGUF KV map and exit-codes the
+      FALSIFY-CRUX-B-02-003 gate.
     tests:
     - translate_full_metadata_succeeds
     - translate_missing_architecture_errors
@@ -168,13 +188,23 @@ falsification_tests:
   if_fails: "PEFT LoRA attachment failed — converted output is not PEFT-ready"
   evidence_discharged_by:
     classifier_path: crates/apr-cli/src/commands/gguf_to_safetensors.rs
+    cli_path: crates/apr-cli/src/commands/gguf_safetensors_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_b_02.rs
+    e2e_tests:
+    - falsify_crux_b_02_004_peft_default_targets_resolve
+    - falsify_crux_b_02_004_peft_unknown_target_is_unresolved
+    - falsify_crux_b_02_004_peft_unknown_target_with_wrong_expectation_fails
+    - falsify_crux_b_02_004_peft_empty_target_list_trivially_resolves
     sub_claim: |
       Algorithm-level necessary condition: `peft_target_modules_resolve`
       checks that every target module name (q_proj, v_proj, etc.)
       matches at least one tensor in the safetensors archive via
       substring containment, mirroring PEFT's own name-matching rule.
       If every target resolves, `peft.get_peft_model` has the
-      precondition it needs to attach LoRA adapters.
+      precondition it needs to attach LoRA adapters. The
+      `apr gguf-safetensors-lint` CLI dispatches the resolver over
+      an observed tensor listing and exit-codes the
+      FALSIFY-CRUX-B-02-004 gate.
     tests:
     - peft_default_targets_resolve_on_llama_layout
     - peft_unknown_target_module_flagged
@@ -213,6 +243,39 @@ verification_summary:
   - falsify_id: FALSIFY-CRUX-B-02-004
     discharge_status: PARTIAL_ALGORITHM_LEVEL
     blocked_on: uv run peft get_peft_model attach harness
+
+ship_discipline:
+  # CRUX-SHIP-001 retrofit: every classifier-only CRUX PR must ship pure-Rust
+  # classifier AND working `apr` CLI wiring + e2e test in the same commit.
+  policy: CRUX-SHIP-001
+  merge_gates:
+    g1_classifier_green:
+      status: PASS
+      evidence: crates/apr-cli/src/commands/gguf_to_safetensors.rs (unit tests)
+    g2_cli_reachable:
+      status: PASS
+      evidence: "`apr gguf-safetensors-lint --help` advertises --observation-file"
+      wired_in:
+      - crates/apr-cli/src/commands/mod.rs
+      - crates/apr-cli/src/commands/gguf_safetensors_lint.rs
+      - crates/apr-cli/src/extended_commands.rs
+      - crates/apr-cli/src/dispatch_analysis.rs
+      - crates/apr-cli/tests/cli_commands.rs
+      - contracts/apr-cli-commands-v1.yaml
+    g3_e2e_runs:
+      status: PASS
+      evidence: crates/apr-cli/tests/falsification_crux_b_02.rs (20 tests)
+    g4_contract_discharged:
+      status: PASS
+      evidence: "FALSIFY-CRUX-B-02-{001,003,004} carry cli_path + e2e_path + e2e_tests; FALSIFY-CRUX-B-02-002 remains NOT_DISCHARGED (blocked on Q4_K_M dequant numerical harness)"
+  partial_scope_rationale: |
+    Three of four FALSIFY gates ship with PARTIAL_ALGORITHM_LEVEL
+    discharge. FALSIFY-CRUX-B-02-002 (dequant numerical bound) has no
+    algorithm-level proxy in the classifier — it requires a real
+    Q4_K_M .gguf fixture and a reference f32 .safetensors file. That
+    gate is correctly kept at NOT_DISCHARGED under
+    BLOCKER-FIXTURE-ABSENT rather than forced to PARTIAL with no
+    backing algorithm.
 
 pmat_work_tracking:
   # Managed by master contract §12. If intake_status == "missing", a ticket

--- a/crates/apr-cli/src/commands/gguf_safetensors_lint.rs
+++ b/crates/apr-cli/src/commands/gguf_safetensors_lint.rs
@@ -1,0 +1,290 @@
+//! CRUX-B-02 — `apr gguf-safetensors-lint` CLI wiring (CRUX-SHIP-001 g2/g3 proof).
+//!
+//! Dispatches three pure classifiers in `gguf_to_safetensors.rs` over a
+//! captured JSON observation file:
+//!
+//! ```jsonc
+//! {
+//!   "layout": {
+//!     "listing": ["model.safetensors", "config.json", "tokenizer.json"]
+//!   },
+//!   "metadata": {
+//!     "kv": {
+//!       "general.architecture":       { "str": "llama" },
+//!       "llama.embedding_length":     { "u32": 4096 },
+//!       "llama.block_count":          { "u32": 32 },
+//!       "llama.attention.head_count": { "u32": 32 }
+//!     },
+//!     "expected_outcome": "ok"   // ok | missing_key | wrong_type
+//!   },
+//!   "peft": {
+//!     "tensor_names":     ["model.layers.0.self_attn.q_proj.weight", "..."],
+//!     "target_modules":   ["q_proj", "v_proj"],
+//!     "expected_outcome": "resolved"   // resolved | unresolved
+//!   }
+//! }
+//! ```
+//!
+//! Any missing top-level key is skipped. Non-zero exit + FALSIFY-CRUX-B-02
+//! stderr stamp on any failing gate.
+
+use crate::commands::gguf_to_safetensors::{
+    hf_required_files, missing_hf_files, peft_target_modules_resolve, translate_gguf_metadata,
+    GgufValue, MetadataError, PeftResolution,
+};
+use serde_json::Value;
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::Path;
+
+#[derive(Debug, Clone)]
+pub struct GgufSafetensorsLintArgs {
+    pub observation_file: String,
+    pub json: bool,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+struct GateReport {
+    gate: &'static str,
+    falsify_id: &'static str,
+    outcome: String,
+    passed: bool,
+}
+
+pub fn run(args: GgufSafetensorsLintArgs) -> Result<(), String> {
+    let path = Path::new(&args.observation_file);
+    if !path.exists() {
+        return Err(format!(
+            "FALSIFY-CRUX-B-02: observation file not found: {}",
+            args.observation_file
+        ));
+    }
+    let raw = fs::read_to_string(path)
+        .map_err(|e| format!("FALSIFY-CRUX-B-02: failed to read observation: {e}"))?;
+    if raw.trim().is_empty() {
+        return Err("FALSIFY-CRUX-B-02: observation file is empty".to_string());
+    }
+    let obs: Value = serde_json::from_str(&raw)
+        .map_err(|e| format!("FALSIFY-CRUX-B-02: observation is not valid JSON: {e}"))?;
+
+    let mut reports: Vec<GateReport> = Vec::new();
+    let mut failures: Vec<String> = Vec::new();
+
+    if let Some(v) = obs.get("layout") {
+        let (r, err) = run_layout_gate(v);
+        reports.push(r);
+        if let Some(e) = err {
+            failures.push(e);
+        }
+    }
+    if let Some(v) = obs.get("metadata") {
+        let (r, err) = run_metadata_gate(v);
+        reports.push(r);
+        if let Some(e) = err {
+            failures.push(e);
+        }
+    }
+    if let Some(v) = obs.get("peft") {
+        let (r, err) = run_peft_gate(v);
+        reports.push(r);
+        if let Some(e) = err {
+            failures.push(e);
+        }
+    }
+
+    if reports.is_empty() {
+        return Err("FALSIFY-CRUX-B-02: observation has none of layout/metadata/peft".into());
+    }
+
+    if args.json {
+        let payload = serde_json::json!({
+            "contract": "CRUX-B-02",
+            "gates": reports,
+        });
+        println!("{}", serde_json::to_string_pretty(&payload).unwrap());
+    } else {
+        for r in &reports {
+            let tag = if r.passed { "PASS" } else { "FAIL" };
+            println!("[{tag}] {} ({}): {}", r.gate, r.falsify_id, r.outcome);
+        }
+    }
+
+    if !failures.is_empty() {
+        return Err(failures.join("\n"));
+    }
+    Ok(())
+}
+
+fn run_layout_gate(v: &Value) -> (GateReport, Option<String>) {
+    let listing: BTreeSet<String> = v
+        .get("listing")
+        .and_then(|x| x.as_array())
+        .map(|a| {
+            a.iter()
+                .filter_map(|s| s.as_str().map(|s| s.to_string()))
+                .collect()
+        })
+        .unwrap_or_default();
+    let missing = missing_hf_files(&listing);
+    let required = hf_required_files();
+    let passed = missing.is_empty();
+    let desc = if passed {
+        format!(
+            "listing={} covers required trio ({})",
+            listing.len(),
+            required.len()
+        )
+    } else {
+        let mut sorted: Vec<&&str> = missing.iter().collect();
+        sorted.sort();
+        format!("missing={sorted:?}")
+    };
+    let err = if passed {
+        None
+    } else {
+        Some(format!("FALSIFY-CRUX-B-02-001 layout gate failed: {desc}"))
+    };
+    (
+        GateReport {
+            gate: "layout",
+            falsify_id: "FALSIFY-CRUX-B-02-001",
+            outcome: desc,
+            passed,
+        },
+        err,
+    )
+}
+
+fn run_metadata_gate(v: &Value) -> (GateReport, Option<String>) {
+    let kv = match parse_kv(v.get("kv")) {
+        Ok(m) => m,
+        Err(e) => {
+            let desc = format!("kv parse error: {e}");
+            return (
+                GateReport {
+                    gate: "metadata",
+                    falsify_id: "FALSIFY-CRUX-B-02-003",
+                    outcome: desc.clone(),
+                    passed: false,
+                },
+                Some(format!(
+                    "FALSIFY-CRUX-B-02-003 metadata gate failed: {desc}"
+                )),
+            );
+        }
+    };
+    let result = translate_gguf_metadata(&kv);
+    let got = match &result {
+        Ok(_) => "ok",
+        Err(MetadataError::MissingKey(_)) => "missing_key",
+        Err(MetadataError::WrongType { .. }) => "wrong_type",
+    };
+    let expected = v
+        .get("expected_outcome")
+        .and_then(|x| x.as_str())
+        .unwrap_or("ok");
+    let passed = got == expected;
+    let detail = match &result {
+        Ok(cfg) => format!(
+            "arch={:?} hidden={} layers={} heads={}",
+            cfg.architectures, cfg.hidden_size, cfg.num_hidden_layers, cfg.num_attention_heads
+        ),
+        Err(MetadataError::MissingKey(k)) => format!("missing={k}"),
+        Err(MetadataError::WrongType { key, got }) => format!("key={key} got={got}"),
+    };
+    let desc = format!("expected={expected} got={got} ({detail})");
+    let err = if passed {
+        None
+    } else {
+        Some(format!(
+            "FALSIFY-CRUX-B-02-003 metadata gate failed: {desc}"
+        ))
+    };
+    (
+        GateReport {
+            gate: "metadata",
+            falsify_id: "FALSIFY-CRUX-B-02-003",
+            outcome: desc,
+            passed,
+        },
+        err,
+    )
+}
+
+fn parse_kv(v: Option<&Value>) -> Result<BTreeMap<String, GgufValue>, String> {
+    let obj = v
+        .and_then(|x| x.as_object())
+        .ok_or_else(|| "kv must be a JSON object".to_string())?;
+    let mut out = BTreeMap::new();
+    for (k, val) in obj {
+        let inner = val
+            .as_object()
+            .ok_or_else(|| format!("kv[{k}] must be an object with one of str|u32"))?;
+        if let Some(s) = inner.get("str").and_then(|x| x.as_str()) {
+            out.insert(k.clone(), GgufValue::Str(s.to_string()));
+        } else if let Some(n) = inner.get("u32").and_then(|x| x.as_u64()) {
+            let n: u32 = n
+                .try_into()
+                .map_err(|_| format!("kv[{k}].u32 out of range"))?;
+            out.insert(k.clone(), GgufValue::U32(n));
+        } else {
+            return Err(format!("kv[{k}] must have a 'str' or 'u32' field"));
+        }
+    }
+    Ok(out)
+}
+
+fn run_peft_gate(v: &Value) -> (GateReport, Option<String>) {
+    let tensor_names: Vec<String> = v
+        .get("tensor_names")
+        .and_then(|x| x.as_array())
+        .map(|a| {
+            a.iter()
+                .filter_map(|s| s.as_str().map(|s| s.to_string()))
+                .collect()
+        })
+        .unwrap_or_default();
+    let target_owned: Vec<String> = v
+        .get("target_modules")
+        .and_then(|x| x.as_array())
+        .map(|a| {
+            a.iter()
+                .filter_map(|s| s.as_str().map(|s| s.to_string()))
+                .collect()
+        })
+        .unwrap_or_default();
+    let target_refs: Vec<&str> = target_owned.iter().map(|s| s.as_str()).collect();
+    let res = peft_target_modules_resolve(&tensor_names, &target_refs);
+    let got = match &res {
+        PeftResolution::AllResolved => "resolved",
+        PeftResolution::Unresolved { .. } => "unresolved",
+    };
+    let expected = v
+        .get("expected_outcome")
+        .and_then(|x| x.as_str())
+        .unwrap_or("resolved");
+    let passed = got == expected;
+    let detail = match &res {
+        PeftResolution::AllResolved => format!(
+            "targets={} resolved over tensors={}",
+            target_owned.len(),
+            tensor_names.len()
+        ),
+        PeftResolution::Unresolved { missing } => format!("missing={missing:?}"),
+    };
+    let desc = format!("expected={expected} got={got} ({detail})");
+    let err = if passed {
+        None
+    } else {
+        Some(format!("FALSIFY-CRUX-B-02-004 peft gate failed: {desc}"))
+    };
+    (
+        GateReport {
+            gate: "peft",
+            falsify_id: "FALSIFY-CRUX-B-02-004",
+            outcome: desc,
+            passed,
+        },
+        err,
+    )
+}

--- a/crates/apr-cli/src/commands/gguf_to_safetensors.rs
+++ b/crates/apr-cli/src/commands/gguf_to_safetensors.rs
@@ -1,0 +1,356 @@
+//! GGUF → Safetensors output-layout + metadata-translation classifier
+//! for `apr convert --format safetensors` (CRUX-B-02).
+//!
+//! Contract: `contracts/crux-B-02-v1.yaml`.
+//!
+//! Three pure algorithm-level necessary conditions:
+//!
+//! 1. `hf_required_files()` is the canonical set of filenames a
+//!    converted output directory must contain for HuggingFace
+//!    `AutoModelForCausalLM.from_pretrained` to succeed. Without this
+//!    exact set, FALSIFY-CRUX-B-02-001 fails at the file-layout layer
+//!    before any byte-level load work begins.
+//!
+//! 2. `translate_gguf_metadata(kv)` is a pure function mapping the
+//!    GGUF `llama.*` metadata keys onto HuggingFace `config.json`
+//!    fields. If any required field is missing the function returns
+//!    `Err(MissingKey)` rather than silently defaulting — a silent
+//!    default would let `transformers.from_pretrained` succeed with
+//!    the wrong hidden_size / layer count and produce garbage.
+//!
+//! 3. `peft_target_modules_resolve(tensor_names, target_modules)`
+//!    checks that every PEFT target module name (e.g. `q_proj`,
+//!    `v_proj`) resolves to at least one tensor in the safetensors
+//!    archive. This is a necessary condition for FALSIFY-CRUX-B-02-004
+//!    (`peft.get_peft_model` attaches without shape errors): if no
+//!    tensor matches the target, the attach fails.
+
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+
+/// Canonical set of files a HuggingFace transformers-loadable
+/// directory must contain.
+pub fn hf_required_files() -> BTreeSet<&'static str> {
+    ["model.safetensors", "config.json", "tokenizer.json"]
+        .into_iter()
+        .collect()
+}
+
+/// Check that a candidate directory listing contains every required
+/// HuggingFace file. Returns the missing files (empty when complete).
+pub fn missing_hf_files(listing: &BTreeSet<String>) -> BTreeSet<&'static str> {
+    hf_required_files()
+        .into_iter()
+        .filter(|name| !listing.contains(*name))
+        .collect()
+}
+
+/// HuggingFace `config.json` fields we translate from GGUF metadata.
+/// Kept as an owned struct (not `serde_json::Value`) so the shape is
+/// compile-time checked.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HfLlamaConfig {
+    pub architectures: Vec<String>,
+    pub hidden_size: u32,
+    pub num_hidden_layers: u32,
+    pub num_attention_heads: u32,
+}
+
+/// Error variants for `translate_gguf_metadata`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MetadataError {
+    /// A required GGUF key is missing; silent defaults would produce
+    /// a loadable-but-wrong HF model.
+    MissingKey(&'static str),
+    /// The value was present but of an unexpected type.
+    WrongType {
+        key: &'static str,
+        got: &'static str,
+    },
+}
+
+/// Translate GGUF `llama.*` metadata onto HF `config.json` fields.
+///
+/// Required keys:
+///   - `general.architecture` → `architectures[0]`
+///   - `llama.embedding_length` → `hidden_size`
+///   - `llama.block_count` → `num_hidden_layers`
+///   - `llama.attention.head_count` → `num_attention_heads`
+pub fn translate_gguf_metadata(
+    kv: &BTreeMap<String, GgufValue>,
+) -> Result<HfLlamaConfig, MetadataError> {
+    let arch = take_string(kv, "general.architecture")?;
+    let hidden_size = take_u32(kv, "llama.embedding_length")?;
+    let num_hidden_layers = take_u32(kv, "llama.block_count")?;
+    let num_attention_heads = take_u32(kv, "llama.attention.head_count")?;
+    Ok(HfLlamaConfig {
+        architectures: vec![format!("{}ForCausalLM", capitalize(&arch))],
+        hidden_size,
+        num_hidden_layers,
+        num_attention_heads,
+    })
+}
+
+/// A tiny GGUF metadata value model — enough to prove the translator
+/// is pure without pulling in the real gguf crate.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GgufValue {
+    Str(String),
+    U32(u32),
+}
+
+fn take_string(kv: &BTreeMap<String, GgufValue>, key: &'static str) -> Result<String, MetadataError> {
+    match kv.get(key) {
+        None => Err(MetadataError::MissingKey(key)),
+        Some(GgufValue::Str(s)) => Ok(s.clone()),
+        Some(GgufValue::U32(_)) => Err(MetadataError::WrongType { key, got: "u32" }),
+    }
+}
+
+fn take_u32(kv: &BTreeMap<String, GgufValue>, key: &'static str) -> Result<u32, MetadataError> {
+    match kv.get(key) {
+        None => Err(MetadataError::MissingKey(key)),
+        Some(GgufValue::U32(n)) => Ok(*n),
+        Some(GgufValue::Str(_)) => Err(MetadataError::WrongType { key, got: "str" }),
+    }
+}
+
+fn capitalize(s: &str) -> String {
+    let mut chars = s.chars();
+    match chars.next() {
+        None => String::new(),
+        Some(c) => c.to_ascii_uppercase().to_string() + chars.as_str(),
+    }
+}
+
+/// Outcome of the PEFT target-module-resolution pre-check.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PeftResolution {
+    /// Every target module resolves to at least one tensor.
+    AllResolved,
+    /// At least one target module has no matching tensor — PEFT
+    /// attach would fail.
+    Unresolved { missing: Vec<String> },
+}
+
+/// Check that every PEFT target module has at least one tensor whose
+/// name contains the module string. HuggingFace PEFT uses
+/// suffix-matching on module names like `q_proj`, so we mirror that
+/// with a substring check — consistent with what PEFT itself does.
+pub fn peft_target_modules_resolve(
+    tensor_names: &[String],
+    target_modules: &[&str],
+) -> PeftResolution {
+    let missing: Vec<String> = target_modules
+        .iter()
+        .filter(|m| !tensor_names.iter().any(|t| t.contains(*m)))
+        .map(|m| m.to_string())
+        .collect();
+    if missing.is_empty() {
+        PeftResolution::AllResolved
+    } else {
+        PeftResolution::Unresolved { missing }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ===== hf_required_files / missing_hf_files =====
+
+    #[test]
+    fn required_files_set_is_canonical() {
+        // FALSIFY-CRUX-B-02-001: the exact trio expected by HF.
+        let files = hf_required_files();
+        assert!(files.contains("model.safetensors"));
+        assert!(files.contains("config.json"));
+        assert!(files.contains("tokenizer.json"));
+    }
+
+    #[test]
+    fn missing_files_empty_on_complete_output() {
+        let listing: BTreeSet<String> = ["model.safetensors", "config.json", "tokenizer.json"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        assert!(missing_hf_files(&listing).is_empty());
+    }
+
+    #[test]
+    fn missing_files_flags_each_omission() {
+        let listing: BTreeSet<String> = ["config.json"].iter().map(|s| s.to_string()).collect();
+        let missing = missing_hf_files(&listing);
+        assert!(missing.contains("model.safetensors"));
+        assert!(missing.contains("tokenizer.json"));
+        assert!(!missing.contains("config.json"));
+    }
+
+    #[test]
+    fn missing_files_flags_all_when_empty() {
+        let listing: BTreeSet<String> = BTreeSet::new();
+        let missing = missing_hf_files(&listing);
+        assert_eq!(missing.len(), 3);
+    }
+
+    #[test]
+    fn required_files_set_is_deterministic() {
+        assert_eq!(hf_required_files(), hf_required_files());
+    }
+
+    // ===== translate_gguf_metadata =====
+
+    fn minimal_kv() -> BTreeMap<String, GgufValue> {
+        let mut kv = BTreeMap::new();
+        kv.insert(
+            "general.architecture".into(),
+            GgufValue::Str("llama".into()),
+        );
+        kv.insert("llama.embedding_length".into(), GgufValue::U32(4096));
+        kv.insert("llama.block_count".into(), GgufValue::U32(32));
+        kv.insert("llama.attention.head_count".into(), GgufValue::U32(32));
+        kv
+    }
+
+    #[test]
+    fn translate_full_metadata_succeeds() {
+        let cfg = translate_gguf_metadata(&minimal_kv()).unwrap();
+        assert_eq!(cfg.architectures, vec!["LlamaForCausalLM".to_string()]);
+        assert_eq!(cfg.hidden_size, 4096);
+        assert_eq!(cfg.num_hidden_layers, 32);
+        assert_eq!(cfg.num_attention_heads, 32);
+    }
+
+    #[test]
+    fn translate_missing_architecture_errors() {
+        let mut kv = minimal_kv();
+        kv.remove("general.architecture");
+        assert_eq!(
+            translate_gguf_metadata(&kv).unwrap_err(),
+            MetadataError::MissingKey("general.architecture")
+        );
+    }
+
+    #[test]
+    fn translate_missing_hidden_size_errors() {
+        let mut kv = minimal_kv();
+        kv.remove("llama.embedding_length");
+        assert_eq!(
+            translate_gguf_metadata(&kv).unwrap_err(),
+            MetadataError::MissingKey("llama.embedding_length")
+        );
+    }
+
+    #[test]
+    fn translate_missing_layer_count_errors() {
+        let mut kv = minimal_kv();
+        kv.remove("llama.block_count");
+        assert_eq!(
+            translate_gguf_metadata(&kv).unwrap_err(),
+            MetadataError::MissingKey("llama.block_count")
+        );
+    }
+
+    #[test]
+    fn translate_missing_head_count_errors() {
+        let mut kv = minimal_kv();
+        kv.remove("llama.attention.head_count");
+        assert_eq!(
+            translate_gguf_metadata(&kv).unwrap_err(),
+            MetadataError::MissingKey("llama.attention.head_count")
+        );
+    }
+
+    #[test]
+    fn translate_wrong_type_errors() {
+        // If embedding_length is a string, refuse — silently parsing
+        // "4096" would be convenient but would hide a upstream bug.
+        let mut kv = minimal_kv();
+        kv.insert("llama.embedding_length".into(), GgufValue::Str("x".into()));
+        assert_eq!(
+            translate_gguf_metadata(&kv).unwrap_err(),
+            MetadataError::WrongType {
+                key: "llama.embedding_length",
+                got: "str",
+            }
+        );
+    }
+
+    #[test]
+    fn translate_is_deterministic() {
+        let kv = minimal_kv();
+        assert_eq!(
+            translate_gguf_metadata(&kv).unwrap(),
+            translate_gguf_metadata(&kv).unwrap()
+        );
+    }
+
+    #[test]
+    fn translate_config_roundtrips_through_json() {
+        let cfg = translate_gguf_metadata(&minimal_kv()).unwrap();
+        let s = serde_json::to_string(&cfg).unwrap();
+        let parsed: HfLlamaConfig = serde_json::from_str(&s).unwrap();
+        assert_eq!(cfg, parsed);
+    }
+
+    // ===== peft_target_modules_resolve =====
+
+    fn llama_tensor_names() -> Vec<String> {
+        vec![
+            "model.layers.0.self_attn.q_proj.weight".into(),
+            "model.layers.0.self_attn.k_proj.weight".into(),
+            "model.layers.0.self_attn.v_proj.weight".into(),
+            "model.layers.0.self_attn.o_proj.weight".into(),
+        ]
+    }
+
+    #[test]
+    fn peft_default_targets_resolve_on_llama_layout() {
+        // FALSIFY-CRUX-B-02-004 necessary condition: q_proj / v_proj
+        // both have matching tensors, so PEFT attach can succeed.
+        let r = peft_target_modules_resolve(&llama_tensor_names(), &["q_proj", "v_proj"]);
+        assert_eq!(r, PeftResolution::AllResolved);
+    }
+
+    #[test]
+    fn peft_unknown_target_module_flagged() {
+        let r = peft_target_modules_resolve(
+            &llama_tensor_names(),
+            &["q_proj", "nonexistent_proj"],
+        );
+        match r {
+            PeftResolution::Unresolved { missing } => {
+                assert_eq!(missing, vec!["nonexistent_proj".to_string()]);
+            }
+            other => panic!("expected Unresolved, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn peft_empty_tensor_list_fails_all_targets() {
+        let r = peft_target_modules_resolve(&[], &["q_proj", "v_proj"]);
+        match r {
+            PeftResolution::Unresolved { missing } => {
+                assert_eq!(missing.len(), 2);
+            }
+            other => panic!("expected Unresolved, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn peft_empty_target_list_trivially_resolves() {
+        // Vacuous true: no targets required → nothing to resolve.
+        let r = peft_target_modules_resolve(&llama_tensor_names(), &[]);
+        assert_eq!(r, PeftResolution::AllResolved);
+    }
+
+    #[test]
+    fn peft_resolution_is_deterministic() {
+        let names = llama_tensor_names();
+        let targets = &["q_proj", "v_proj"];
+        assert_eq!(
+            peft_target_modules_resolve(&names, targets),
+            peft_target_modules_resolve(&names, targets)
+        );
+    }
+}

--- a/crates/apr-cli/src/commands/mod.rs
+++ b/crates/apr-cli/src/commands/mod.rs
@@ -35,6 +35,7 @@ pub(crate) mod export;
 #[cfg(feature = "training")]
 pub(crate) mod finetune;
 pub(crate) mod flow;
+pub(crate) mod gguf_safetensors_lint;
 pub(crate) mod gguf_to_safetensors;
 pub(crate) mod glob_filter;
 pub(crate) mod gbnf_classifier;

--- a/crates/apr-cli/src/commands/mod.rs
+++ b/crates/apr-cli/src/commands/mod.rs
@@ -35,6 +35,7 @@ pub(crate) mod export;
 #[cfg(feature = "training")]
 pub(crate) mod finetune;
 pub(crate) mod flow;
+pub(crate) mod gguf_to_safetensors;
 pub(crate) mod glob_filter;
 pub(crate) mod gbnf_classifier;
 pub(crate) mod gbnf_lint;

--- a/crates/apr-cli/src/dispatch_analysis.rs
+++ b/crates/apr-cli/src/dispatch_analysis.rs
@@ -130,6 +130,14 @@ fn dispatch_analysis_commands(cli: &Cli) -> Option<Result<(), CliError>> {
             commands::typical_p_lint::run(observation_file, cli.json)
         }
 
+        ExtendedCommands::GgufSafetensorsLint { observation_file } => {
+            commands::gguf_safetensors_lint::run(commands::gguf_safetensors_lint::GgufSafetensorsLintArgs {
+                observation_file: observation_file.to_string_lossy().to_string(),
+                json: cli.json,
+            })
+            .map_err(crate::error::CliError::Aprender)
+        }
+
 
         ExtendedCommands::Hex {
             file,

--- a/crates/apr-cli/src/extended_commands.rs
+++ b/crates/apr-cli/src/extended_commands.rs
@@ -768,6 +768,11 @@ pub enum ExtendedCommands {
         #[arg(long, value_name = "FILE")]
         observation_file: PathBuf,
     },
+    /// Lint a captured GGUF→safetensors observation (CRUX-B-02)
+    GgufSafetensorsLint {
+        #[arg(long, value_name = "FILE")]
+        observation_file: PathBuf,
+    },
     /// Publishing, conversion, and analysis tools
     #[command(flatten)]
     Tools(ToolCommands),

--- a/crates/apr-cli/tests/cli_commands.rs
+++ b/crates/apr-cli/tests/cli_commands.rs
@@ -79,6 +79,7 @@ fn registered_commands() -> Vec<&'static str> {
         "tool-use-lint",
         "gbnf-lint",
         "typical-p-lint",
+        "gguf-safetensors-lint",
         "oracle",
         "encrypt",
         "decrypt",

--- a/crates/apr-cli/tests/falsification_crux_b_02.rs
+++ b/crates/apr-cli/tests/falsification_crux_b_02.rs
@@ -1,0 +1,514 @@
+//! CRUX-B-02 — end-to-end falsification harness for `apr gguf-safetensors-lint`.
+//!
+//! CRUX-SHIP-001 gate g3 evidence: every FALSIFY-CRUX-B-02-{001,003,004}
+//! gate the classifier discharges has a matching e2e JSON observation
+//! that the binary must classify exactly as the harness expects.
+
+use serde_json::json;
+use std::io::Write;
+use std::process::Command;
+
+fn apr_binary() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_apr"));
+    cmd.env("NO_COLOR", "1");
+    cmd
+}
+
+fn write_obs(json_body: &serde_json::Value) -> tempfile::NamedTempFile {
+    let mut f = tempfile::Builder::new()
+        .prefix("crux-b-02-obs-")
+        .suffix(".json")
+        .tempfile()
+        .expect("tempfile");
+    f.write_all(serde_json::to_vec_pretty(json_body).unwrap().as_slice())
+        .expect("write obs");
+    f.flush().expect("flush");
+    f
+}
+
+// ===== g2: CLI shape =====
+
+#[test]
+fn falsify_crux_b_02_cli_help_advertises_observation_file() {
+    let out = apr_binary()
+        .args(["gguf-safetensors-lint", "--help"])
+        .output()
+        .expect("run");
+    assert!(out.status.success(), "--help must exit 0");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("--observation-file"),
+        "--help must advertise --observation-file; got:\n{stdout}"
+    );
+}
+
+#[test]
+fn falsify_crux_b_02_cli_bare_invocation_is_usage_error() {
+    let out = apr_binary()
+        .arg("gguf-safetensors-lint")
+        .output()
+        .expect("run");
+    assert!(
+        !out.status.success(),
+        "bare invocation must not exit 0 — missing required --observation-file"
+    );
+}
+
+#[test]
+fn falsify_crux_b_02_cli_missing_file_fails_with_stamp() {
+    let out = apr_binary()
+        .args([
+            "gguf-safetensors-lint",
+            "--observation-file",
+            "/nonexistent/crux-b-02-missing.json",
+        ])
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "nonexistent file must not exit 0");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("FALSIFY-CRUX-B-02") || stderr.contains("not found"),
+        "stderr must stamp FALSIFY-CRUX-B-02; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn falsify_crux_b_02_cli_empty_file_fails() {
+    let tmp = tempfile::Builder::new()
+        .prefix("crux-b-02-empty-")
+        .suffix(".json")
+        .tempfile()
+        .unwrap();
+    let out = apr_binary()
+        .args([
+            "gguf-safetensors-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "empty observation must not exit 0");
+}
+
+#[test]
+fn falsify_crux_b_02_cli_invalid_json_fails() {
+    let mut tmp = tempfile::Builder::new()
+        .prefix("crux-b-02-bad-")
+        .suffix(".json")
+        .tempfile()
+        .unwrap();
+    tmp.write_all(b"{not json").unwrap();
+    tmp.flush().unwrap();
+    let out = apr_binary()
+        .args([
+            "gguf-safetensors-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "invalid JSON must not exit 0");
+}
+
+#[test]
+fn falsify_crux_b_02_cli_no_gates_present_fails() {
+    let obs = json!({ "unrelated": "field" });
+    let tmp = write_obs(&obs);
+    let out = apr_binary()
+        .args([
+            "gguf-safetensors-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "no known gates must not exit 0");
+}
+
+// ===== FALSIFY-CRUX-B-02-001 layout =====
+
+#[test]
+fn falsify_crux_b_02_001_layout_complete_passes() {
+    let obs = json!({
+        "layout": {
+            "listing": ["model.safetensors", "config.json", "tokenizer.json", "generation_config.json"]
+        }
+    });
+    let tmp = write_obs(&obs);
+    let out = apr_binary()
+        .args([
+            "gguf-safetensors-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "complete layout must pass; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("[PASS] layout"), "expected layout PASS");
+}
+
+#[test]
+fn falsify_crux_b_02_001_layout_missing_safetensors_fails() {
+    let obs = json!({
+        "layout": {
+            "listing": ["config.json", "tokenizer.json"]
+        }
+    });
+    let tmp = write_obs(&obs);
+    let out = apr_binary()
+        .args([
+            "gguf-safetensors-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "missing safetensors must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("FALSIFY-CRUX-B-02-001"),
+        "stderr must stamp FALSIFY-CRUX-B-02-001; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn falsify_crux_b_02_001_layout_empty_listing_fails_all() {
+    let obs = json!({ "layout": { "listing": [] } });
+    let tmp = write_obs(&obs);
+    let out = apr_binary()
+        .args([
+            "gguf-safetensors-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "empty listing must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-B-02-001"));
+}
+
+// ===== FALSIFY-CRUX-B-02-003 metadata =====
+
+#[test]
+fn falsify_crux_b_02_003_metadata_full_passes() {
+    let obs = json!({
+        "metadata": {
+            "kv": {
+                "general.architecture":       { "str": "llama" },
+                "llama.embedding_length":     { "u32": 4096 },
+                "llama.block_count":          { "u32": 32 },
+                "llama.attention.head_count": { "u32": 32 }
+            },
+            "expected_outcome": "ok"
+        }
+    });
+    let tmp = write_obs(&obs);
+    let out = apr_binary()
+        .args([
+            "gguf-safetensors-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "full metadata must pass; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn falsify_crux_b_02_003_metadata_missing_architecture_expected_missing_key_passes() {
+    // Absence-of-key IS expected — classifier reports missing_key, observer
+    // pre-declared missing_key, gate PASSES.
+    let obs = json!({
+        "metadata": {
+            "kv": {
+                "llama.embedding_length":     { "u32": 4096 },
+                "llama.block_count":          { "u32": 32 },
+                "llama.attention.head_count": { "u32": 32 }
+            },
+            "expected_outcome": "missing_key"
+        }
+    });
+    let tmp = write_obs(&obs);
+    let out = apr_binary()
+        .args([
+            "gguf-safetensors-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "expected missing_key must pass when key is missing; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn falsify_crux_b_02_003_metadata_missing_key_with_wrong_expectation_fails() {
+    // Classifier reports missing_key, observer expected ok — FAIL.
+    let obs = json!({
+        "metadata": {
+            "kv": {
+                "llama.embedding_length":     { "u32": 4096 },
+                "llama.block_count":          { "u32": 32 },
+                "llama.attention.head_count": { "u32": 32 }
+            },
+            "expected_outcome": "ok"
+        }
+    });
+    let tmp = write_obs(&obs);
+    let out = apr_binary()
+        .args([
+            "gguf-safetensors-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "expected ok with missing key must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-B-02-003"));
+}
+
+#[test]
+fn falsify_crux_b_02_003_metadata_wrong_type_expected_wrong_type_passes() {
+    let obs = json!({
+        "metadata": {
+            "kv": {
+                "general.architecture":       { "u32": 7 },  // should be str
+                "llama.embedding_length":     { "u32": 4096 },
+                "llama.block_count":          { "u32": 32 },
+                "llama.attention.head_count": { "u32": 32 }
+            },
+            "expected_outcome": "wrong_type"
+        }
+    });
+    let tmp = write_obs(&obs);
+    let out = apr_binary()
+        .args([
+            "gguf-safetensors-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "expected wrong_type with u32 for architecture must pass; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn falsify_crux_b_02_003_metadata_string_for_embedding_length_is_wrong_type() {
+    let obs = json!({
+        "metadata": {
+            "kv": {
+                "general.architecture":       { "str": "llama" },
+                "llama.embedding_length":     { "str": "4096" },  // should be u32
+                "llama.block_count":          { "u32": 32 },
+                "llama.attention.head_count": { "u32": 32 }
+            },
+            "expected_outcome": "wrong_type"
+        }
+    });
+    let tmp = write_obs(&obs);
+    let out = apr_binary()
+        .args([
+            "gguf-safetensors-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "str for u32 field must classify as wrong_type; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+// ===== FALSIFY-CRUX-B-02-004 peft =====
+
+#[test]
+fn falsify_crux_b_02_004_peft_default_targets_resolve() {
+    let obs = json!({
+        "peft": {
+            "tensor_names": [
+                "model.layers.0.self_attn.q_proj.weight",
+                "model.layers.0.self_attn.v_proj.weight",
+                "model.layers.0.mlp.up_proj.weight"
+            ],
+            "target_modules":   ["q_proj", "v_proj"],
+            "expected_outcome": "resolved"
+        }
+    });
+    let tmp = write_obs(&obs);
+    let out = apr_binary()
+        .args([
+            "gguf-safetensors-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "q_proj+v_proj over llama layout must resolve; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn falsify_crux_b_02_004_peft_unknown_target_is_unresolved() {
+    // Classifier reports unresolved, observer pre-declared unresolved — PASS.
+    let obs = json!({
+        "peft": {
+            "tensor_names":     ["model.layers.0.self_attn.q_proj.weight"],
+            "target_modules":   ["q_proj", "missing_module"],
+            "expected_outcome": "unresolved"
+        }
+    });
+    let tmp = write_obs(&obs);
+    let out = apr_binary()
+        .args([
+            "gguf-safetensors-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "unknown target module with expected=unresolved must pass; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn falsify_crux_b_02_004_peft_unknown_target_with_wrong_expectation_fails() {
+    let obs = json!({
+        "peft": {
+            "tensor_names":     ["model.layers.0.self_attn.q_proj.weight"],
+            "target_modules":   ["q_proj", "missing_module"],
+            "expected_outcome": "resolved"
+        }
+    });
+    let tmp = write_obs(&obs);
+    let out = apr_binary()
+        .args([
+            "gguf-safetensors-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "unresolved with expected=resolved must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-B-02-004"));
+}
+
+#[test]
+fn falsify_crux_b_02_004_peft_empty_target_list_trivially_resolves() {
+    let obs = json!({
+        "peft": {
+            "tensor_names":     ["anything"],
+            "target_modules":   [],
+            "expected_outcome": "resolved"
+        }
+    });
+    let tmp = write_obs(&obs);
+    let out = apr_binary()
+        .args([
+            "gguf-safetensors-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "empty target_modules must resolve vacuously; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+// ===== Multi-gate + JSON shape =====
+
+#[test]
+fn falsify_crux_b_02_multi_gate_all_pass() {
+    let obs = json!({
+        "layout": {
+            "listing": ["model.safetensors", "config.json", "tokenizer.json"]
+        },
+        "metadata": {
+            "kv": {
+                "general.architecture":       { "str": "llama" },
+                "llama.embedding_length":     { "u32": 4096 },
+                "llama.block_count":          { "u32": 32 },
+                "llama.attention.head_count": { "u32": 32 }
+            },
+            "expected_outcome": "ok"
+        },
+        "peft": {
+            "tensor_names":     ["model.layers.0.self_attn.q_proj.weight"],
+            "target_modules":   ["q_proj"],
+            "expected_outcome": "resolved"
+        }
+    });
+    let tmp = write_obs(&obs);
+    let out = apr_binary()
+        .args([
+            "gguf-safetensors-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "all three gates green must exit 0; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("[PASS] layout"));
+    assert!(stdout.contains("[PASS] metadata"));
+    assert!(stdout.contains("[PASS] peft"));
+}
+
+#[test]
+fn falsify_crux_b_02_json_output_shape() {
+    let obs = json!({
+        "layout": { "listing": ["model.safetensors", "config.json", "tokenizer.json"] }
+    });
+    let tmp = write_obs(&obs);
+    let out = apr_binary()
+        .args([
+            "--json",
+            "gguf-safetensors-lint",
+            "--observation-file",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run");
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).expect("--json must emit valid JSON");
+    assert_eq!(parsed["contract"], "CRUX-B-02");
+    assert!(parsed["gates"].is_array());
+    assert_eq!(parsed["gates"][0]["gate"], "layout");
+    assert_eq!(parsed["gates"][0]["falsify_id"], "FALSIFY-CRUX-B-02-001");
+    assert_eq!(parsed["gates"][0]["passed"], true);
+}


### PR DESCRIPTION
## Summary

Discharges CRUX-B-02 (\`apr convert --format safetensors\` producing a HuggingFace-loadable directory) at PARTIAL_ALGORITHM_LEVEL for 3 of 4 FALSIFY gates.

Three pure classifiers in \`crates/apr-cli/src/commands/gguf_to_safetensors.rs\`:

1. **\`hf_required_files()\` + \`missing_hf_files(listing)\`** — canonical trio \`{model.safetensors, config.json, tokenizer.json}\` required by \`transformers.from_pretrained\`.
2. **\`translate_gguf_metadata(gguf_kv) → HfLlamaConfig\`** — pure GGUF \`llama.*\` → HF \`config.json\` mapping. Missing keys return \`Err(MissingKey)\` rather than silently defaulting.
3. **\`peft_target_modules_resolve(tensor_names, target_modules)\`** — substring match that every PEFT target resolves to at least one tensor, mirroring PEFT's own matching rule.

## Contract status

\`contracts/crux-B-02-v1.yaml\` v1.0.0-draft → v1.1.0, status \`draft\` → \`partial\`.

- FALSIFY-001 (required files present) → PARTIAL_ALGORITHM_LEVEL via 5 tests
- FALSIFY-002 (dequant numerical bound) → NOT_DISCHARGED (needs Q4_K_M harness)
- FALSIFY-003 (transformers loads output) → PARTIAL_ALGORITHM_LEVEL via 8 tests
- FALSIFY-004 (PEFT LoRA attaches) → PARTIAL_ALGORITHM_LEVEL via 5 tests

Full discharge blocks on Q4_K_M dequant vs reference f32 harness + uv-run transformers/peft end-to-end harnesses.

## Test plan

- [x] 18/18 unit tests pass (\`cargo test -p apr-cli --lib commands::gguf_to_safetensors\`)
- [x] \`pv validate contracts/crux-B-02-v1.yaml\` → 0 errors, 0 warnings
- [x] PMAT pre-commit quality gates pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)