### PR TITLE
feat(crux-b-08): AWQ quantization classifier (3 of 3 FALSIFY at PARTIAL_ALGORITHM_LEVEL)

### DIFF
--- a/contracts/apr-cli-commands-v1.yaml
+++ b/contracts/apr-cli-commands-v1.yaml
@@ -21,7 +21,7 @@ metadata:
 kind: CLICommandContract
 name: apr-cli-commands
 version: "1.0.0"
-scope: "all apr CLI subcommands (61 commands — original 57 + `mcp` added 2026-04-17 via PR #864 + `registry` added 2026-04-20 via CRUX-A-01 + `ollama-chat-lint` added 2026-04-21 via CRUX-C-04 SHIP-001 retrofit + `dry-sampling-lint` added 2026-04-21 via CRUX-C-23 SHIP-001 retrofit)"
+scope: "all apr CLI subcommands (62 commands — original 57 + `mcp` added 2026-04-17 via PR #864 + `registry` added 2026-04-20 via CRUX-A-01 + `ollama-chat-lint` added 2026-04-21 via CRUX-C-04 SHIP-001 retrofit + `dry-sampling-lint` added 2026-04-21 via CRUX-C-23 SHIP-001 retrofit + `awq-lint` added 2026-04-21 via CRUX-B-08 SHIP-001 retrofit)"
 binary: "apr"
 install: "cargo install aprender"
 
@@ -399,6 +399,12 @@ commands:
   - name: dry-sampling-lint
     category: inspection
     description: "Lint a captured DRY-sampling observation (CRUX-C-23)"
+    requires_model: false
+    side_effects: []
+
+  - name: awq-lint
+    category: inspection
+    description: "Lint a captured AWQ quality/compression/flags observation (CRUX-B-08)"
     requires_model: false
     side_effects: []
 

--- a/contracts/crux-B-08-v1.yaml
+++ b/contracts/crux-B-08-v1.yaml
@@ -3,8 +3,9 @@
 
 metadata:
   id: CRUX-B-08
-  version: "1.1.0"
+  version: "1.2.0"
   created: "2026-04-18"
+  updated: "2026-04-21"
   author: PAIML Engineering
   registry: true
   status: partial
@@ -66,6 +67,12 @@ falsification_tests:
   if_fails: "AWQ 4-bit degraded quality below 80% of fp16 baseline; salient-weight scaling ineffective"
   evidence_discharged_by:
     classifier_path: crates/apr-cli/src/commands/awq_classifier.rs
+    cli_path: crates/apr-cli/src/commands/awq_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_b_08.rs
+    e2e_tests:
+    - falsify_crux_b_08_001_quality_retained_ok
+    - falsify_crux_b_08_001_quality_rejects_degraded
+    - falsify_crux_b_08_001_quality_rejects_zero_baseline
     sub_claim: |
       Algorithm-level necessary condition: `classify_quality_retention`
       computes the retention ratio ρ = P_awq / P_fp16 and admits only
@@ -93,6 +100,16 @@ falsification_tests:
   if_fails: "apr quantize missing AWQ-equivalent flags; competitor parity broken"
   evidence_discharged_by:
     classifier_path: crates/apr-cli/src/commands/awq_classifier.rs
+    cli_path: crates/apr-cli/src/commands/awq_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_b_08.rs
+    e2e_tests:
+    - falsify_crux_b_08_002_flags_ok_canonical
+    - falsify_crux_b_08_002_flags_ok_equals_form
+    - falsify_crux_b_08_002_flags_rejects_wrong_method
+    - falsify_crux_b_08_002_flags_rejects_invalid_bits
+    - falsify_crux_b_08_002_flags_rejects_missing_bits
+    - falsify_crux_b_08_002_flags_rejects_invalid_group_size
+    - falsify_crux_b_08_002_flags_observer_can_assert_expected_failure
     sub_claim: |
       Algorithm-level necessary condition: `parse_awq_flags` extracts
       all three flags (`--method`, `--bits`, `--group-size`) in both
@@ -128,6 +145,12 @@ falsification_tests:
   if_fails: "AWQ output not compressed to ~4 bits/weight; packing bug"
   evidence_discharged_by:
     classifier_path: crates/apr-cli/src/commands/awq_classifier.rs
+    cli_path: crates/apr-cli/src/commands/awq_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_b_08.rs
+    e2e_tests:
+    - falsify_crux_b_08_003_compression_ok
+    - falsify_crux_b_08_003_compression_rejects_over_ceiling
+    - falsify_crux_b_08_003_compression_rejects_zero_source
     sub_claim: |
       Algorithm-level necessary condition: `classify_compression_ratio`
       computes ρ = awq_bytes / fp16_bytes and admits only ρ <=
@@ -168,6 +191,32 @@ verification_summary:
   - falsify_id: FALSIFY-CRUX-B-08-003
     discharge_status: PARTIAL_ALGORITHM_LEVEL
     blocked_on: real AWQ 4-bit packer + fp16 source pair on disk
+
+ship_discipline:
+  ship_rule: CRUX-SHIP-001
+  deliverables_present:
+    classifier: crates/apr-cli/src/commands/awq_classifier.rs
+    cli_wiring: crates/apr-cli/src/commands/awq_lint.rs
+    e2e_test: crates/apr-cli/tests/falsification_crux_b_08.rs
+    contract: contracts/crux-B-08-v1.yaml
+  merge_gates:
+    g1_classifier_green: true
+    g2_cli_reachable: true
+    g3_e2e_runs: true
+    g4_contract_discharged: PARTIAL_ALGORITHM_LEVEL
+  notes: >
+    `apr awq-lint --observation-file <obs.json>` dispatches three
+    classifiers (quality, compression, flags) over captured JSON; each
+    missing top-level key is skipped so observations can exercise any
+    subset of FALSIFY-CRUX-B-08-001/002/003 independently. e2e suite
+    (19 tests) covers help surface, bare-invocation rejection, per-gate
+    ok+reject paths (quality retained/degraded/zero-baseline,
+    compression under/over-ceiling/zero-source, flags
+    canonical/equals/wrong-method/invalid-bits/missing-bits/invalid-gs
+    + observer-asserts-expected-failure), empty/nonexistent/unknown-keys
+    input rejection, and --json shape. Full ACTIVE discharge remains
+    blocked on a real AWQ 4-bit quantizer + HumanEval/0..9 scorer +
+    `apr quantize --help` surface.
 
 pmat_work_tracking:
   ticket_tag: crux-crux-b-08

--- a/contracts/crux-B-08-v1.yaml
+++ b/contracts/crux-B-08-v1.yaml
@@ -1,33 +1,33 @@
 # CRUX-B-08 — AWQ quantization
-# Auto-scaffolded from crux-competitive-research-ux-v1.yaml (DRAFT).
-# DO NOT promote to ACTIVE until: (1) evidence collected, (2) falsification
-# body reflects competitor's canonical CLI, (3) apr surface mapped or gap
-# tracked in pmat work (see master §12).
+# Auto-scaffolded from crux-competitive-research-ux-v1.yaml.
 
 metadata:
   id: CRUX-B-08
-  version: "1.0.0-draft"
+  version: "1.1.0"
   created: "2026-04-18"
   author: PAIML Engineering
   registry: true
-  status: draft
+  status: partial
   parent_contracts:
   - crux-competitive-research-ux-v1
   category: "B — Inspection & Debugging"
   competitor: vllm
-  demand_score: 5  # 1..5, critical priority in pmat work
+  demand_score: 5
   intake_status: missing
   description: >
-    AWQ quantization. Root-cause workflow extracted from vllm UX — see master
-    subspec §5.B and §2 Five Whys methodology for rationale. This
-    draft contract exists to satisfy the Iron Rule "no contract → no user
-    story"; the falsification body below is a placeholder and MUST be
-    replaced with the competitor's canonical CLI transcript before promotion.
+    AWQ (Activation-aware Weight Quantization) parity. vllm exposes
+    `python -m awq.quantize --model-path M --w-bit 4 --q-group-size 128`;
+    the aprender surface is `apr quantize M.apr --method awq --bits 4
+    --group-size 128 -o out.apr`. Per Lin et al. 2023 (arXiv:2306.00978),
+    salient-weight-aware scaling preserves >=80% of fp16 quality at <=0.30x
+    the file size on HumanEval-style tasks.
 
   references:
   - 'master: contracts/crux-competitive-research-ux-v1.yaml — §5 + §12'
-  - github.com/huggingface/peft — LoRA/PEFT
-  - arXiv:2106.09685 — LoRA
+  - "https://arxiv.org/abs/2306.00978 — AWQ paper"
+  - "https://github.com/mit-han-lab/llm-awq — reference implementation"
+  - "https://docs.vllm.ai/en/latest/quantization/auto_awq.html"
+
 equations:
   awq_quality_retention:
     formula: |
@@ -35,7 +35,6 @@ equations:
       Let P_awq  = pass@1(quantize(M, method=AWQ, w_bit=4, q_group_size=128), HumanEval[0..9])
       Contract: P_awq >= 0.80 * P_fp16
       (AWQ 4-bit MUST retain >= 80% of fp16 baseline pass@1 on HumanEval/0..9)
-      Ref: Lin et al. 2023 (arXiv:2306.00978) — salient-weight-aware scaling.
     domain: (model M, HumanEval prompts[0..9])
     codomain: pass@1 score ∈ [0,1]
     invariants:
@@ -65,6 +64,24 @@ falsification_tests:
     P_AWQ=$(apr qa /tmp/model-awq.apr --eval humaneval --shard 0..9 --require-golden-output --json | jq '.pass_at_1')
     python3 -c "import sys; sys.exit(0 if $P_AWQ >= 0.80 * $P_FP16 else 1)"
   if_fails: "AWQ 4-bit degraded quality below 80% of fp16 baseline; salient-weight scaling ineffective"
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/awq_classifier.rs
+    sub_claim: |
+      Algorithm-level necessary condition: `classify_quality_retention`
+      computes the retention ratio ρ = P_awq / P_fp16 and admits only
+      ρ >= `AWQ_MIN_QUALITY_RETENTION` (0.80) as the `Retained` verdict.
+      Below-threshold retention and zero-baseline inputs return
+      `Degraded` rather than panicking, so a broken fp16 baseline fails
+      the gate visibly instead of being silently masked.
+    tests:
+    - retention_above_threshold_is_retained
+    - retention_exactly_at_threshold_is_retained
+    - retention_below_threshold_is_degraded
+    - retention_zero_baseline_is_degraded_not_panic
+    - retention_is_deterministic
+    scope: pass@1 retention threshold (pure ratio classifier)
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: real AWQ quantizer + HumanEval/0..9 scoring harness
 
 - id: FALSIFY-CRUX-B-08-002
   rule: CLI surface matches vllm
@@ -74,6 +91,32 @@ falsification_tests:
     apr quantize --help 2>&1 | grep -qE -- '--bits[[:space:]<]'
     apr quantize --help 2>&1 | grep -qE -- '--group-size[[:space:]<]'
   if_fails: "apr quantize missing AWQ-equivalent flags; competitor parity broken"
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/awq_classifier.rs
+    sub_claim: |
+      Algorithm-level necessary condition: `parse_awq_flags` extracts
+      all three flags (`--method`, `--bits`, `--group-size`) in both
+      space and `=` forms; `validate_awq_flags` enforces the full
+      contract envelope — bits ∈ {3,4,8}, group_size ∈ {64,128},
+      default group_size = `AWQ_DEFAULT_GROUP_SIZE` (128, matching
+      vllm/awq reference). Missing method, unknown method, and invalid
+      bits/group_size each map to a distinct error variant.
+    tests:
+    - parse_all_three_space_form
+    - parse_all_three_equals_form
+    - parse_absent_bits_yields_none
+    - validate_ok_with_default_group_size
+    - validate_ok_with_explicit_group_size
+    - validate_rejects_missing_method
+    - validate_rejects_unknown_method
+    - validate_rejects_invalid_bits
+    - validate_rejects_missing_bits
+    - validate_rejects_invalid_group_size
+    - allowed_sets_include_reference_values
+    - validate_is_deterministic
+    scope: argv → AwqFlags → AwqFlagValidation (pure)
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: "clap `apr quantize --help` subcommand surface"
 
 - id: FALSIFY-CRUX-B-08-003
   rule: AWQ artifact size <= 0.3x fp16
@@ -83,6 +126,22 @@ falsification_tests:
     AWQ=$(stat -c%s /tmp/model-awq.apr)
     python3 -c "import sys; sys.exit(0 if $AWQ <= 0.30 * $FP16 else 1)"
   if_fails: "AWQ output not compressed to ~4 bits/weight; packing bug"
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/awq_classifier.rs
+    sub_claim: |
+      Algorithm-level necessary condition: `classify_compression_ratio`
+      computes ρ = awq_bytes / fp16_bytes and admits only ρ <=
+      `AWQ_MAX_COMPRESSION_RATIO` (0.30) as `Compressed`. Zero-byte
+      fp16 source is handled as `Insufficient { ratio: ∞ }` rather
+      than a division-by-zero panic.
+    tests:
+    - compression_well_under_ceiling_is_compressed
+    - compression_exactly_at_ceiling_is_compressed
+    - compression_over_ceiling_is_insufficient
+    - compression_zero_source_is_insufficient
+    scope: byte-ratio ceiling (pure comparator)
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: real AWQ 4-bit packer + fp16 source pair on disk
 
 proof_obligations:
 - type: invariant
@@ -99,10 +158,18 @@ verification_summary:
   proven: 0
   tested: 0
   status: spec-complete
+  discharge_ledger:
+  - falsify_id: FALSIFY-CRUX-B-08-001
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    blocked_on: real AWQ quantizer + HumanEval/0..9 scoring harness
+  - falsify_id: FALSIFY-CRUX-B-08-002
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    blocked_on: "clap `apr quantize --help` subcommand surface"
+  - falsify_id: FALSIFY-CRUX-B-08-003
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    blocked_on: real AWQ 4-bit packer + fp16 source pair on disk
 
 pmat_work_tracking:
-  # Managed by master contract §12. If intake_status == "missing", a ticket
-  # tagged `crux-crux-b-08` is auto-created by scripts/crux_bulk_pmat_work.sh.
   ticket_tag: crux-crux-b-08
   priority: critical
   auto_created: true

--- a/crates/apr-cli/src/commands/awq_classifier.rs
+++ b/crates/apr-cli/src/commands/awq_classifier.rs
@@ -1,0 +1,327 @@
+//! CRUX-B-08 AWQ quantization — algorithm-level classifiers.
+//!
+//! Partial discharge for the `apr quantize --method awq` contract
+//! (`contracts/crux-B-08-v1.yaml`). Three pure classifiers cover:
+//!
+//! 1. Quality retention (pass@1 AWQ ≥ 0.80 × pass@1 fp16) — FALSIFY-001.
+//! 2. CLI flag parser + validation (`--method`, `--bits`, `--group-size`) — FALSIFY-002.
+//! 3. Compression ratio (AWQ bytes ≤ 0.30 × fp16 bytes) — FALSIFY-003.
+//!
+//! Full discharge still requires a real AWQ quantizer and real
+//! HumanEval scoring — neither lives in the CLI crate.
+
+/// Default AWQ group size, matching vllm/awq reference implementation.
+pub const AWQ_DEFAULT_GROUP_SIZE: u32 = 128;
+
+/// Minimum quality-retention ratio the contract demands.
+pub const AWQ_MIN_QUALITY_RETENTION: f64 = 0.80;
+
+/// Maximum compressed-to-source byte ratio for 4-bit AWQ.
+pub const AWQ_MAX_COMPRESSION_RATIO: f64 = 0.30;
+
+/// Allowed AWQ bit widths.
+pub const AWQ_ALLOWED_BITS: &[u32] = &[3, 4, 8];
+
+/// Allowed AWQ group sizes.
+pub const AWQ_ALLOWED_GROUP_SIZES: &[u32] = &[64, 128];
+
+/// Outcome of comparing fp16 vs AWQ pass@1.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum QualityRetention {
+    Retained { ratio: f64 },
+    Degraded { ratio: f64, threshold: f64 },
+}
+
+/// Classify whether AWQ retained enough of fp16's pass@1 to meet contract.
+///
+/// Returns `Degraded` (not panic) when `p_fp16 <= 0.0` — the baseline
+/// itself is broken, not the AWQ output, but the gate still fails.
+#[must_use]
+pub fn classify_quality_retention(p_fp16: f64, p_awq: f64, threshold: f64) -> QualityRetention {
+    if !p_fp16.is_finite() || p_fp16 <= 0.0 {
+        return QualityRetention::Degraded { ratio: f64::NAN, threshold };
+    }
+    let ratio = p_awq / p_fp16;
+    if ratio >= threshold {
+        QualityRetention::Retained { ratio }
+    } else {
+        QualityRetention::Degraded { ratio, threshold }
+    }
+}
+
+/// Outcome of comparing artifact size against the compression ceiling.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum CompressionOutcome {
+    Compressed { ratio: f64 },
+    Insufficient { ratio: f64, max_ratio: f64 },
+}
+
+/// Classify whether the AWQ output is small enough relative to fp16.
+/// `ratio = awq_bytes / fp16_bytes`; contract wants `ratio <= 0.30`.
+#[must_use]
+pub fn classify_compression_ratio(
+    fp16_bytes: u64,
+    awq_bytes: u64,
+    max_ratio: f64,
+) -> CompressionOutcome {
+    if fp16_bytes == 0 {
+        return CompressionOutcome::Insufficient { ratio: f64::INFINITY, max_ratio };
+    }
+    let ratio = awq_bytes as f64 / fp16_bytes as f64;
+    if ratio <= max_ratio {
+        CompressionOutcome::Compressed { ratio }
+    } else {
+        CompressionOutcome::Insufficient { ratio, max_ratio }
+    }
+}
+
+/// Parsed AWQ CLI surface.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AwqFlags {
+    pub method: Option<String>,
+    pub bits: Option<u32>,
+    pub group_size: Option<u32>,
+}
+
+/// Parse `--method`, `--bits`, `--group-size` from argv.
+/// Accepts both space and `=` separated forms.
+#[must_use]
+pub fn parse_awq_flags(argv: &[&str]) -> AwqFlags {
+    let mut out = AwqFlags {
+        method: None,
+        bits: None,
+        group_size: None,
+    };
+    let mut i = 0;
+    while i < argv.len() {
+        let a = argv[i];
+        match a {
+            "--method" => {
+                out.method = argv.get(i + 1).map(|s| (*s).to_string());
+            }
+            "--bits" => {
+                out.bits = argv.get(i + 1).and_then(|s| s.parse::<u32>().ok());
+            }
+            "--group-size" => {
+                out.group_size = argv.get(i + 1).and_then(|s| s.parse::<u32>().ok());
+            }
+            _ => {
+                if let Some(rest) = a.strip_prefix("--method=") {
+                    out.method = Some(rest.to_string());
+                } else if let Some(rest) = a.strip_prefix("--bits=") {
+                    if let Ok(v) = rest.parse::<u32>() {
+                        out.bits = Some(v);
+                    }
+                } else if let Some(rest) = a.strip_prefix("--group-size=") {
+                    if let Ok(v) = rest.parse::<u32>() {
+                        out.group_size = Some(v);
+                    }
+                }
+            }
+        }
+        i += 1;
+    }
+    out
+}
+
+/// Validation outcome for a parsed AWQ flag set.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AwqFlagValidation {
+    Ok { bits: u32, group_size: u32 },
+    MissingMethod,
+    UnknownMethod { got: String },
+    InvalidBits { got: u32, allowed: &'static [u32] },
+    InvalidGroupSize { got: u32, allowed: &'static [u32] },
+}
+
+/// Validate parsed AWQ flags. Applies `AWQ_DEFAULT_GROUP_SIZE` when
+/// `--group-size` is omitted. `--bits` has no default (must be given).
+#[must_use]
+pub fn validate_awq_flags(flags: &AwqFlags) -> AwqFlagValidation {
+    let Some(method) = flags.method.as_deref() else {
+        return AwqFlagValidation::MissingMethod;
+    };
+    if method != "awq" {
+        return AwqFlagValidation::UnknownMethod {
+            got: method.to_string(),
+        };
+    }
+    let bits = match flags.bits {
+        Some(b) if AWQ_ALLOWED_BITS.contains(&b) => b,
+        Some(b) => return AwqFlagValidation::InvalidBits { got: b, allowed: AWQ_ALLOWED_BITS },
+        None => return AwqFlagValidation::InvalidBits { got: 0, allowed: AWQ_ALLOWED_BITS },
+    };
+    let group_size = flags.group_size.unwrap_or(AWQ_DEFAULT_GROUP_SIZE);
+    if !AWQ_ALLOWED_GROUP_SIZES.contains(&group_size) {
+        return AwqFlagValidation::InvalidGroupSize {
+            got: group_size,
+            allowed: AWQ_ALLOWED_GROUP_SIZES,
+        };
+    }
+    AwqFlagValidation::Ok { bits, group_size }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---- FALSIFY-001 (quality retention) ----
+
+    #[test]
+    fn retention_above_threshold_is_retained() {
+        let r = classify_quality_retention(0.50, 0.45, AWQ_MIN_QUALITY_RETENTION);
+        assert!(matches!(r, QualityRetention::Retained { .. }));
+    }
+
+    #[test]
+    fn retention_exactly_at_threshold_is_retained() {
+        let r = classify_quality_retention(0.50, 0.40, AWQ_MIN_QUALITY_RETENTION);
+        match r {
+            QualityRetention::Retained { ratio } => assert!((ratio - 0.80).abs() < 1e-9),
+            _ => panic!("expected Retained at exact threshold"),
+        }
+    }
+
+    #[test]
+    fn retention_below_threshold_is_degraded() {
+        let r = classify_quality_retention(0.50, 0.30, AWQ_MIN_QUALITY_RETENTION);
+        assert!(matches!(r, QualityRetention::Degraded { .. }));
+    }
+
+    #[test]
+    fn retention_zero_baseline_is_degraded_not_panic() {
+        let r = classify_quality_retention(0.0, 0.45, AWQ_MIN_QUALITY_RETENTION);
+        assert!(matches!(r, QualityRetention::Degraded { .. }));
+    }
+
+    #[test]
+    fn retention_is_deterministic() {
+        let a = classify_quality_retention(0.42, 0.35, AWQ_MIN_QUALITY_RETENTION);
+        let b = classify_quality_retention(0.42, 0.35, AWQ_MIN_QUALITY_RETENTION);
+        assert_eq!(format!("{:?}", a), format!("{:?}", b));
+    }
+
+    // ---- FALSIFY-003 (compression) ----
+
+    #[test]
+    fn compression_well_under_ceiling_is_compressed() {
+        let r = classify_compression_ratio(1_000_000, 200_000, AWQ_MAX_COMPRESSION_RATIO);
+        assert!(matches!(r, CompressionOutcome::Compressed { .. }));
+    }
+
+    #[test]
+    fn compression_exactly_at_ceiling_is_compressed() {
+        let r = classify_compression_ratio(1_000_000, 300_000, AWQ_MAX_COMPRESSION_RATIO);
+        match r {
+            CompressionOutcome::Compressed { ratio } => assert!((ratio - 0.30).abs() < 1e-9),
+            _ => panic!("expected Compressed at exact ceiling"),
+        }
+    }
+
+    #[test]
+    fn compression_over_ceiling_is_insufficient() {
+        let r = classify_compression_ratio(1_000_000, 400_000, AWQ_MAX_COMPRESSION_RATIO);
+        assert!(matches!(r, CompressionOutcome::Insufficient { .. }));
+    }
+
+    #[test]
+    fn compression_zero_source_is_insufficient() {
+        let r = classify_compression_ratio(0, 100, AWQ_MAX_COMPRESSION_RATIO);
+        assert!(matches!(r, CompressionOutcome::Insufficient { .. }));
+    }
+
+    // ---- FALSIFY-002 (CLI parsing + validation) ----
+
+    #[test]
+    fn parse_all_three_space_form() {
+        let argv = &[
+            "quantize", "model.apr",
+            "--method", "awq",
+            "--bits", "4",
+            "--group-size", "128",
+        ];
+        let f = parse_awq_flags(argv);
+        assert_eq!(f.method.as_deref(), Some("awq"));
+        assert_eq!(f.bits, Some(4));
+        assert_eq!(f.group_size, Some(128));
+    }
+
+    #[test]
+    fn parse_all_three_equals_form() {
+        let argv = &["quantize", "--method=awq", "--bits=4", "--group-size=128"];
+        let f = parse_awq_flags(argv);
+        assert_eq!(f.method.as_deref(), Some("awq"));
+        assert_eq!(f.bits, Some(4));
+        assert_eq!(f.group_size, Some(128));
+    }
+
+    #[test]
+    fn parse_absent_bits_yields_none() {
+        let argv = &["quantize", "--method", "awq"];
+        let f = parse_awq_flags(argv);
+        assert_eq!(f.bits, None);
+    }
+
+    #[test]
+    fn validate_ok_with_default_group_size() {
+        let f = AwqFlags { method: Some("awq".into()), bits: Some(4), group_size: None };
+        assert_eq!(
+            validate_awq_flags(&f),
+            AwqFlagValidation::Ok { bits: 4, group_size: AWQ_DEFAULT_GROUP_SIZE }
+        );
+    }
+
+    #[test]
+    fn validate_ok_with_explicit_group_size() {
+        let f = AwqFlags { method: Some("awq".into()), bits: Some(4), group_size: Some(64) };
+        assert_eq!(
+            validate_awq_flags(&f),
+            AwqFlagValidation::Ok { bits: 4, group_size: 64 }
+        );
+    }
+
+    #[test]
+    fn validate_rejects_missing_method() {
+        let f = AwqFlags { method: None, bits: Some(4), group_size: Some(128) };
+        assert_eq!(validate_awq_flags(&f), AwqFlagValidation::MissingMethod);
+    }
+
+    #[test]
+    fn validate_rejects_unknown_method() {
+        let f = AwqFlags { method: Some("gptq".into()), bits: Some(4), group_size: Some(128) };
+        assert!(matches!(validate_awq_flags(&f), AwqFlagValidation::UnknownMethod { .. }));
+    }
+
+    #[test]
+    fn validate_rejects_invalid_bits() {
+        let f = AwqFlags { method: Some("awq".into()), bits: Some(5), group_size: Some(128) };
+        assert!(matches!(validate_awq_flags(&f), AwqFlagValidation::InvalidBits { got: 5, .. }));
+    }
+
+    #[test]
+    fn validate_rejects_missing_bits() {
+        let f = AwqFlags { method: Some("awq".into()), bits: None, group_size: Some(128) };
+        assert!(matches!(validate_awq_flags(&f), AwqFlagValidation::InvalidBits { got: 0, .. }));
+    }
+
+    #[test]
+    fn validate_rejects_invalid_group_size() {
+        let f = AwqFlags { method: Some("awq".into()), bits: Some(4), group_size: Some(96) };
+        assert!(matches!(validate_awq_flags(&f), AwqFlagValidation::InvalidGroupSize { got: 96, .. }));
+    }
+
+    #[test]
+    fn allowed_sets_include_reference_values() {
+        assert!(AWQ_ALLOWED_BITS.contains(&4));
+        assert!(AWQ_ALLOWED_GROUP_SIZES.contains(&128));
+        assert_eq!(AWQ_DEFAULT_GROUP_SIZE, 128);
+    }
+
+    #[test]
+    fn validate_is_deterministic() {
+        let f = AwqFlags { method: Some("awq".into()), bits: Some(4), group_size: None };
+        let a = validate_awq_flags(&f);
+        let b = validate_awq_flags(&f);
+        assert_eq!(a, b);
+    }
+}

--- a/crates/apr-cli/src/commands/awq_lint.rs
+++ b/crates/apr-cli/src/commands/awq_lint.rs
@@ -1,0 +1,226 @@
+//! CRUX-B-08 — `apr awq-lint` CLI wiring (CRUX-SHIP-001 g2/g3 proof).
+//!
+//! Dispatches the three AWQ classifiers in `awq_classifier.rs` over a
+//! captured JSON observation file:
+//!
+//! ```jsonc
+//! {
+//!   "quality": {
+//!     "p_fp16":    0.50,
+//!     "p_awq":     0.45,
+//!     "threshold": 0.80
+//!   },
+//!   "compression": {
+//!     "fp16_bytes":  1_000_000_000,
+//!     "awq_bytes":     250_000_000,
+//!     "max_ratio":           0.30
+//!   },
+//!   "flags": {
+//!     "argv":             ["--method", "awq", "--bits", "4", "--group-size", "128"],
+//!     "expected_outcome": "ok"    // ok | missing_method | unknown_method | invalid_bits | invalid_group_size
+//!   }
+//! }
+//! ```
+//!
+//! Any missing top-level key is skipped. Non-zero exit + FALSIFY-CRUX-B-08
+//! stderr stamp on any failing gate.
+
+use crate::commands::awq_classifier::{
+    classify_compression_ratio, classify_quality_retention, parse_awq_flags, validate_awq_flags,
+    AwqFlagValidation, CompressionOutcome, QualityRetention, AWQ_MAX_COMPRESSION_RATIO,
+    AWQ_MIN_QUALITY_RETENTION,
+};
+use serde_json::Value;
+use std::fs;
+use std::path::Path;
+
+#[derive(Debug, Clone)]
+pub struct AwqLintArgs {
+    pub observation_file: String,
+    pub json: bool,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+struct GateReport {
+    gate: &'static str,
+    falsify_id: &'static str,
+    outcome: String,
+    passed: bool,
+}
+
+pub fn run(args: AwqLintArgs) -> Result<(), String> {
+    let path = Path::new(&args.observation_file);
+    if !path.exists() {
+        return Err(format!(
+            "FALSIFY-CRUX-B-08: observation file not found: {}",
+            args.observation_file
+        ));
+    }
+    let raw = fs::read_to_string(path)
+        .map_err(|e| format!("FALSIFY-CRUX-B-08: failed to read observation: {e}"))?;
+    if raw.trim().is_empty() {
+        return Err("FALSIFY-CRUX-B-08: observation file is empty".to_string());
+    }
+    let obs: Value = serde_json::from_str(&raw)
+        .map_err(|e| format!("FALSIFY-CRUX-B-08: observation is not valid JSON: {e}"))?;
+
+    let mut reports: Vec<GateReport> = Vec::new();
+    let mut failures: Vec<String> = Vec::new();
+
+    if let Some(q) = obs.get("quality") {
+        let (report, err) = run_quality_gate(q);
+        reports.push(report);
+        if let Some(e) = err {
+            failures.push(e);
+        }
+    }
+    if let Some(c) = obs.get("compression") {
+        let (report, err) = run_compression_gate(c);
+        reports.push(report);
+        if let Some(e) = err {
+            failures.push(e);
+        }
+    }
+    if let Some(f) = obs.get("flags") {
+        let (report, err) = run_flags_gate(f);
+        reports.push(report);
+        if let Some(e) = err {
+            failures.push(e);
+        }
+    }
+
+    if reports.is_empty() {
+        return Err("FALSIFY-CRUX-B-08: observation has none of quality/compression/flags".into());
+    }
+
+    if args.json {
+        let payload = serde_json::json!({
+            "contract": "CRUX-B-08",
+            "gates": reports,
+        });
+        println!("{}", serde_json::to_string_pretty(&payload).unwrap());
+    } else {
+        for r in &reports {
+            let tag = if r.passed { "PASS" } else { "FAIL" };
+            println!("[{tag}] {} ({}): {}", r.gate, r.falsify_id, r.outcome);
+        }
+    }
+
+    if !failures.is_empty() {
+        return Err(failures.join("\n"));
+    }
+    Ok(())
+}
+
+fn run_quality_gate(v: &Value) -> (GateReport, Option<String>) {
+    let p_fp16 = v.get("p_fp16").and_then(|x| x.as_f64()).unwrap_or(0.0);
+    let p_awq = v.get("p_awq").and_then(|x| x.as_f64()).unwrap_or(0.0);
+    let threshold = v
+        .get("threshold")
+        .and_then(|x| x.as_f64())
+        .unwrap_or(AWQ_MIN_QUALITY_RETENTION);
+    let outcome = classify_quality_retention(p_fp16, p_awq, threshold);
+    let (passed, desc) = match outcome {
+        QualityRetention::Retained { ratio } => (
+            true,
+            format!("ratio={ratio:.4} >= {threshold} (p_fp16={p_fp16}, p_awq={p_awq})"),
+        ),
+        QualityRetention::Degraded { ratio, threshold } => (
+            false,
+            format!("ratio={ratio:.4} < {threshold} (p_fp16={p_fp16}, p_awq={p_awq})"),
+        ),
+    };
+    let err = if passed {
+        None
+    } else {
+        Some(format!("FALSIFY-CRUX-B-08-001 quality gate failed: {desc}"))
+    };
+    (
+        GateReport {
+            gate: "quality",
+            falsify_id: "FALSIFY-CRUX-B-08-001",
+            outcome: desc,
+            passed,
+        },
+        err,
+    )
+}
+
+fn run_compression_gate(v: &Value) -> (GateReport, Option<String>) {
+    let fp16 = v.get("fp16_bytes").and_then(|x| x.as_u64()).unwrap_or(0);
+    let awq = v.get("awq_bytes").and_then(|x| x.as_u64()).unwrap_or(0);
+    let max_ratio = v
+        .get("max_ratio")
+        .and_then(|x| x.as_f64())
+        .unwrap_or(AWQ_MAX_COMPRESSION_RATIO);
+    let outcome = classify_compression_ratio(fp16, awq, max_ratio);
+    let (passed, desc) = match outcome {
+        CompressionOutcome::Compressed { ratio } => (
+            true,
+            format!("ratio={ratio:.4} (max={max_ratio}, fp16={fp16}, awq={awq})"),
+        ),
+        CompressionOutcome::Insufficient { ratio, max_ratio } => (
+            false,
+            format!("ratio={ratio:.4} > max={max_ratio} (fp16={fp16}, awq={awq})"),
+        ),
+    };
+    let err = if passed {
+        None
+    } else {
+        Some(format!(
+            "FALSIFY-CRUX-B-08-003 compression gate failed: {desc}"
+        ))
+    };
+    (
+        GateReport {
+            gate: "compression",
+            falsify_id: "FALSIFY-CRUX-B-08-003",
+            outcome: desc,
+            passed,
+        },
+        err,
+    )
+}
+
+fn run_flags_gate(v: &Value) -> (GateReport, Option<String>) {
+    let argv_owned: Vec<String> = v
+        .get("argv")
+        .and_then(|x| x.as_array())
+        .map(|a| {
+            a.iter()
+                .filter_map(|s| s.as_str().map(|s| s.to_string()))
+                .collect()
+        })
+        .unwrap_or_default();
+    let argv: Vec<&str> = argv_owned.iter().map(|s| s.as_str()).collect();
+    let flags = parse_awq_flags(&argv);
+    let validation = validate_awq_flags(&flags);
+
+    let expected = v
+        .get("expected_outcome")
+        .and_then(|x| x.as_str())
+        .unwrap_or("ok");
+    let got = match &validation {
+        AwqFlagValidation::Ok { .. } => "ok",
+        AwqFlagValidation::MissingMethod => "missing_method",
+        AwqFlagValidation::UnknownMethod { .. } => "unknown_method",
+        AwqFlagValidation::InvalidBits { .. } => "invalid_bits",
+        AwqFlagValidation::InvalidGroupSize { .. } => "invalid_group_size",
+    };
+    let passed = got == expected;
+    let desc = format!("expected={expected} got={got} ({validation:?})");
+    let err = if passed {
+        None
+    } else {
+        Some(format!("FALSIFY-CRUX-B-08-002 flags gate failed: {desc}"))
+    };
+    (
+        GateReport {
+            gate: "flags",
+            falsify_id: "FALSIFY-CRUX-B-08-002",
+            outcome: desc,
+            passed,
+        },
+        err,
+    )
+}

--- a/crates/apr-cli/src/commands/mod.rs
+++ b/crates/apr-cli/src/commands/mod.rs
@@ -7,6 +7,7 @@
 
 pub(crate) mod aliases;
 pub(crate) mod auto_quant;
+pub(crate) mod awq_classifier;
 pub mod bench;
 pub mod canary;
 pub mod cbtop;

--- a/crates/apr-cli/src/commands/mod.rs
+++ b/crates/apr-cli/src/commands/mod.rs
@@ -8,6 +8,7 @@
 pub(crate) mod aliases;
 pub(crate) mod auto_quant;
 pub(crate) mod awq_classifier;
+pub(crate) mod awq_lint;
 pub mod bench;
 pub mod canary;
 pub mod cbtop;

--- a/crates/apr-cli/src/dispatch_analysis.rs
+++ b/crates/apr-cli/src/dispatch_analysis.rs
@@ -105,6 +105,14 @@ fn dispatch_analysis_commands(cli: &Cli) -> Option<Result<(), CliError>> {
             commands::dry_sampling_lint::run(observation_file, cli.json)
         }
 
+        ExtendedCommands::AwqLint { observation_file } => commands::awq_lint::run(
+            commands::awq_lint::AwqLintArgs {
+                observation_file: observation_file.to_string_lossy().to_string(),
+                json: cli.json,
+            },
+        )
+        .map_err(crate::error::CliError::Aprender),
+
         ExtendedCommands::Hex {
             file,
             tensor,

--- a/crates/apr-cli/src/extended_commands.rs
+++ b/crates/apr-cli/src/extended_commands.rs
@@ -729,6 +729,12 @@ pub enum ExtendedCommands {
         #[arg(long, value_name = "FILE")]
         observation_file: PathBuf,
     },
+    /// Lint a captured AWQ quality/compression/flags observation (CRUX-B-08)
+    AwqLint {
+        /// Path to captured AWQ observation JSON
+        #[arg(long, value_name = "FILE")]
+        observation_file: PathBuf,
+    },
     /// Publishing, conversion, and analysis tools
     #[command(flatten)]
     Tools(ToolCommands),

--- a/crates/apr-cli/tests/cli_commands.rs
+++ b/crates/apr-cli/tests/cli_commands.rs
@@ -74,6 +74,7 @@ fn registered_commands() -> Vec<&'static str> {
         "diagnose",
         "ollama-chat-lint",
         "dry-sampling-lint",
+        "awq-lint",
         "oracle",
         "encrypt",
         "decrypt",

--- a/crates/apr-cli/tests/falsification_crux_b_08.rs
+++ b/crates/apr-cli/tests/falsification_crux_b_08.rs
@@ -1,0 +1,389 @@
+//! E2E falsification tests for `apr awq-lint` (CRUX-B-08).
+//!
+//! Discharges g3 of CRUX-SHIP-001 for PR #969: exercise the CLI surface
+//! end-to-end on captured JSON observations and assert the classifier
+//! verdicts + non-zero exit codes on known-bad input.
+//!
+//! Observation shape:
+//! ```jsonc
+//! {
+//!   "quality":     { "p_fp16", "p_awq", "threshold" },         // FALSIFY-CRUX-B-08-001
+//!   "flags":       { "argv": [..], "expected_outcome": "ok" }, // FALSIFY-CRUX-B-08-002
+//!   "compression": { "fp16_bytes", "awq_bytes", "max_ratio" }  // FALSIFY-CRUX-B-08-003
+//! }
+//! ```
+
+use std::io::Write;
+use std::process::Command;
+
+fn apr_binary() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_apr"));
+    cmd.env("NO_COLOR", "1");
+    cmd
+}
+
+fn write_tmp_json(name: &str, body: &str) -> tempfile::NamedTempFile {
+    let mut f = tempfile::Builder::new()
+        .prefix(name)
+        .suffix(".json")
+        .tempfile()
+        .expect("create tempfile");
+    f.write_all(body.as_bytes()).expect("write tempfile");
+    f.flush().expect("flush tempfile");
+    f
+}
+
+// ---- help surface (g2 proof) ----------------------------------------------
+
+#[test]
+fn falsify_crux_b_08_help_advertises_observation_file_flag() {
+    let out = apr_binary()
+        .args(["awq-lint", "--help"])
+        .output()
+        .expect("run apr awq-lint --help");
+    assert!(out.status.success(), "apr awq-lint --help must exit 0");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("--observation-file"),
+        "--help must advertise --observation-file; got:\n{stdout}"
+    );
+}
+
+#[test]
+fn falsify_crux_b_08_rejects_bare_invocation_without_file() {
+    let out = apr_binary()
+        .arg("awq-lint")
+        .output()
+        .expect("run apr awq-lint without args");
+    assert!(
+        !out.status.success(),
+        "bare `apr awq-lint` must exit non-zero"
+    );
+}
+
+// ---- quality gate (FALSIFY-CRUX-B-08-001) ---------------------------------
+
+#[test]
+fn falsify_crux_b_08_001_quality_retained_ok() {
+    // ratio = 0.45/0.50 = 0.90 ≥ 0.80 → Retained
+    let tmp = write_tmp_json(
+        "awq-quality-ok",
+        r#"{ "quality": { "p_fp16": 0.50, "p_awq": 0.45, "threshold": 0.80 } }"#,
+    );
+    let out = apr_binary()
+        .args(["awq-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr awq-lint");
+    assert!(
+        out.status.success(),
+        "retained quality must pass; stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn falsify_crux_b_08_001_quality_rejects_degraded() {
+    // ratio = 0.30/0.50 = 0.60 < 0.80 → Degraded
+    let tmp = write_tmp_json(
+        "awq-quality-bad",
+        r#"{ "quality": { "p_fp16": 0.50, "p_awq": 0.30, "threshold": 0.80 } }"#,
+    );
+    let out = apr_binary()
+        .args(["awq-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr awq-lint");
+    assert!(!out.status.success(), "degraded quality must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("FALSIFY-CRUX-B-08-001"),
+        "stderr must stamp FALSIFY-CRUX-B-08-001; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn falsify_crux_b_08_001_quality_rejects_zero_baseline() {
+    // p_fp16 = 0 → Degraded (NaN ratio, baseline broken)
+    let tmp = write_tmp_json(
+        "awq-quality-zero",
+        r#"{ "quality": { "p_fp16": 0.0, "p_awq": 0.45, "threshold": 0.80 } }"#,
+    );
+    let out = apr_binary()
+        .args(["awq-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr awq-lint");
+    assert!(!out.status.success(), "zero baseline must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-B-08-001"));
+}
+
+// ---- compression gate (FALSIFY-CRUX-B-08-003) -----------------------------
+
+#[test]
+fn falsify_crux_b_08_003_compression_ok() {
+    // 250M / 1G = 0.25 ≤ 0.30 → Compressed
+    let tmp = write_tmp_json(
+        "awq-comp-ok",
+        r#"{ "compression": { "fp16_bytes": 1000000000, "awq_bytes": 250000000, "max_ratio": 0.30 } }"#,
+    );
+    let out = apr_binary()
+        .args(["awq-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr awq-lint");
+    assert!(
+        out.status.success(),
+        "compression under ceiling must pass; stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn falsify_crux_b_08_003_compression_rejects_over_ceiling() {
+    // 400M / 1G = 0.40 > 0.30 → Insufficient
+    let tmp = write_tmp_json(
+        "awq-comp-bad",
+        r#"{ "compression": { "fp16_bytes": 1000000000, "awq_bytes": 400000000, "max_ratio": 0.30 } }"#,
+    );
+    let out = apr_binary()
+        .args(["awq-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr awq-lint");
+    assert!(!out.status.success(), "compression over ceiling must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-B-08-003"));
+}
+
+#[test]
+fn falsify_crux_b_08_003_compression_rejects_zero_source() {
+    // fp16_bytes = 0 → Insufficient (∞ ratio, source missing)
+    let tmp = write_tmp_json(
+        "awq-comp-zero",
+        r#"{ "compression": { "fp16_bytes": 0, "awq_bytes": 100, "max_ratio": 0.30 } }"#,
+    );
+    let out = apr_binary()
+        .args(["awq-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr awq-lint");
+    assert!(!out.status.success(), "zero source must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-B-08-003"));
+}
+
+// ---- flags gate (FALSIFY-CRUX-B-08-002) -----------------------------------
+
+#[test]
+fn falsify_crux_b_08_002_flags_ok_canonical() {
+    // --method awq --bits 4 --group-size 128 → Ok
+    let tmp = write_tmp_json(
+        "awq-flags-ok",
+        r#"{ "flags": { "argv": ["--method", "awq", "--bits", "4", "--group-size", "128"],
+                        "expected_outcome": "ok" } }"#,
+    );
+    let out = apr_binary()
+        .args(["awq-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr awq-lint");
+    assert!(
+        out.status.success(),
+        "canonical flags must pass; stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn falsify_crux_b_08_002_flags_ok_equals_form() {
+    // --method=awq --bits=4 → Ok (group_size defaults to 128)
+    let tmp = write_tmp_json(
+        "awq-flags-eq",
+        r#"{ "flags": { "argv": ["--method=awq", "--bits=4"],
+                        "expected_outcome": "ok" } }"#,
+    );
+    let out = apr_binary()
+        .args(["awq-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr awq-lint");
+    assert!(
+        out.status.success(),
+        "equals-form flags must pass; stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn falsify_crux_b_08_002_flags_rejects_wrong_method() {
+    // Observer expected ok, but method=gptq → UnknownMethod → mismatch fails
+    let tmp = write_tmp_json(
+        "awq-flags-wrongmethod",
+        r#"{ "flags": { "argv": ["--method", "gptq", "--bits", "4"],
+                        "expected_outcome": "ok" } }"#,
+    );
+    let out = apr_binary()
+        .args(["awq-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr awq-lint");
+    assert!(!out.status.success(), "wrong method must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-B-08-002"));
+}
+
+#[test]
+fn falsify_crux_b_08_002_flags_rejects_invalid_bits() {
+    // --bits 5 is not in AWQ_ALLOWED_BITS → InvalidBits
+    let tmp = write_tmp_json(
+        "awq-flags-bits",
+        r#"{ "flags": { "argv": ["--method", "awq", "--bits", "5"],
+                        "expected_outcome": "ok" } }"#,
+    );
+    let out = apr_binary()
+        .args(["awq-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr awq-lint");
+    assert!(!out.status.success(), "invalid bits must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-B-08-002"));
+}
+
+#[test]
+fn falsify_crux_b_08_002_flags_rejects_missing_bits() {
+    // Missing --bits → InvalidBits { got: 0 }
+    let tmp = write_tmp_json(
+        "awq-flags-nobits",
+        r#"{ "flags": { "argv": ["--method", "awq"],
+                        "expected_outcome": "ok" } }"#,
+    );
+    let out = apr_binary()
+        .args(["awq-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr awq-lint");
+    assert!(!out.status.success(), "missing bits must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-B-08-002"));
+}
+
+#[test]
+fn falsify_crux_b_08_002_flags_rejects_invalid_group_size() {
+    // --group-size 96 is not in AWQ_ALLOWED_GROUP_SIZES → InvalidGroupSize
+    let tmp = write_tmp_json(
+        "awq-flags-gs",
+        r#"{ "flags": { "argv": ["--method", "awq", "--bits", "4", "--group-size", "96"],
+                        "expected_outcome": "ok" } }"#,
+    );
+    let out = apr_binary()
+        .args(["awq-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr awq-lint");
+    assert!(!out.status.success(), "invalid group size must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-B-08-002"));
+}
+
+#[test]
+fn falsify_crux_b_08_002_flags_observer_can_assert_expected_failure() {
+    // Observer deliberately captured a wrong-method case and expects that
+    // classification → PASS (the captured outcome matches expectation).
+    let tmp = write_tmp_json(
+        "awq-flags-negobs",
+        r#"{ "flags": { "argv": ["--method", "gptq", "--bits", "4"],
+                        "expected_outcome": "unknown_method" } }"#,
+    );
+    let out = apr_binary()
+        .args(["awq-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr awq-lint");
+    assert!(
+        out.status.success(),
+        "observer-asserts-expected-failure must pass; stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+// ---- input validation -----------------------------------------------------
+
+#[test]
+fn falsify_crux_b_08_empty_file_rejected() {
+    let tmp = write_tmp_json("awq-empty", "");
+    let out = apr_binary()
+        .args(["awq-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr awq-lint");
+    assert!(!out.status.success(), "empty file must be rejected");
+}
+
+#[test]
+fn falsify_crux_b_08_nonexistent_file_rejected() {
+    let out = apr_binary()
+        .args([
+            "awq-lint",
+            "--observation-file",
+            "/nonexistent/path/awq-obs.json",
+        ])
+        .output()
+        .expect("run apr awq-lint");
+    assert!(!out.status.success(), "missing file must be rejected");
+}
+
+#[test]
+fn falsify_crux_b_08_only_unknown_keys_rejected() {
+    // No quality/compression/flags → nothing to classify
+    let tmp = write_tmp_json(
+        "awq-nogates",
+        r#"{ "unrelated": 1, "also_irrelevant": "hi" }"#,
+    );
+    let out = apr_binary()
+        .args(["awq-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr awq-lint");
+    assert!(
+        !out.status.success(),
+        "observation without any gate keys must be rejected"
+    );
+}
+
+// ---- --json shape ---------------------------------------------------------
+
+#[test]
+fn falsify_crux_b_08_json_output_shape() {
+    let tmp = write_tmp_json(
+        "awq-json",
+        r#"{
+          "quality":     { "p_fp16": 0.50, "p_awq": 0.45, "threshold": 0.80 },
+          "compression": { "fp16_bytes": 1000000000, "awq_bytes": 250000000, "max_ratio": 0.30 },
+          "flags":       { "argv": ["--method", "awq", "--bits", "4", "--group-size", "128"],
+                           "expected_outcome": "ok" }
+        }"#,
+    );
+    let out = apr_binary()
+        .args(["--json", "awq-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr awq-lint --json");
+    assert!(
+        out.status.success(),
+        "all-pass bundle under --json must exit 0; stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("\"contract\""), "stdout:\n{stdout}");
+    assert!(stdout.contains("\"CRUX-B-08\""));
+    assert!(stdout.contains("\"gates\""));
+    assert!(stdout.contains("\"quality\""));
+    assert!(stdout.contains("\"compression\""));
+    assert!(stdout.contains("\"flags\""));
+    assert!(stdout.contains("FALSIFY-CRUX-B-08-001"));
+    assert!(stdout.contains("FALSIFY-CRUX-B-08-002"));
+    assert!(stdout.contains("FALSIFY-CRUX-B-08-003"));
+}


### PR DESCRIPTION
## Summary
Algorithm-level discharge for `apr quantize --method awq` — vllm `awq.quantize` parity (Lin et al. 2023, arXiv:2306.00978):

- **FALSIFY-001 (pass@1 retention ≥80%)** — `classify_quality_retention` (ρ=P_awq/P_fp16)
- **FALSIFY-002 (CLI surface)** — `parse_awq_flags` + `validate_awq_flags` (bits ∈ {3,4,8}, group_size ∈ {64,128}, default 128)
- **FALSIFY-003 (compression ≤0.30×)** — `classify_compression_ratio`

## Test evidence
21 classifier tests PASS (`cargo test -p apr-cli --lib commands::awq_classifier`).

## Contract
`contracts/crux-B-08-v1.yaml` v1.0.0-draft → **v1.1.0**, status **draft → partial**. `pv validate` 0 errors / 0 warnings.

## Full discharge still blocks on
- Real AWQ 4-bit packer + fp16 source pair
- HumanEval/0..9 scoring harness
- clap `apr quantize --help` subcommand surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)