### PR TITLE
feat(crux-b-09): GPTQ quantization classifier (3 of 3 FALSIFY at PARTIAL_ALGORITHM_LEVEL)

### DIFF
--- a/contracts/apr-cli-commands-v1.yaml
+++ b/contracts/apr-cli-commands-v1.yaml
@@ -21,7 +21,7 @@ metadata:
 kind: CLICommandContract
 name: apr-cli-commands
 version: "1.0.0"
-scope: "all apr CLI subcommands (71 commands — original 57 + `mcp` added 2026-04-17 via PR #864 + `registry` added 2026-04-20 via CRUX-A-01 + `ollama-chat-lint` added 2026-04-21 via CRUX-C-04 SHIP-001 retrofit + `dry-sampling-lint` added 2026-04-21 via CRUX-C-23 SHIP-001 retrofit + `awq-lint` added 2026-04-21 via CRUX-B-08 SHIP-001 retrofit + `oom-lint` added 2026-04-21 via CRUX-F-13 SHIP-001 + `tool-use-lint` added 2026-04-21 via CRUX-C-11 SHIP-001 retrofit + `gbnf-lint` added 2026-04-21 via CRUX-C-10 SHIP-001 retrofit + `typical-p-lint` added 2026-04-21 via CRUX-C-22 SHIP-001 retrofit + `grad-norm` added 2026-04-21 via CRUX-F-09 + `registry-quota-lint` added 2026-04-21 via CRUX-A-22 SHIP-001 retrofit + `fp8-lint` added 2026-04-22 via CRUX-B-11 SHIP-001 retrofit + `imatrix-lint` added 2026-04-22 via CRUX-B-07 SHIP-001 retrofit + `nf4-lint` added 2026-04-22 via CRUX-B-10 SHIP-001 retrofit)"
+scope: "all apr CLI subcommands (72 commands — original 57 + `mcp` added 2026-04-17 via PR #864 + `registry` added 2026-04-20 via CRUX-A-01 + `ollama-chat-lint` added 2026-04-21 via CRUX-C-04 SHIP-001 retrofit + `dry-sampling-lint` added 2026-04-21 via CRUX-C-23 SHIP-001 retrofit + `awq-lint` added 2026-04-21 via CRUX-B-08 SHIP-001 retrofit + `oom-lint` added 2026-04-21 via CRUX-F-13 SHIP-001 + `tool-use-lint` added 2026-04-21 via CRUX-C-11 SHIP-001 retrofit + `gbnf-lint` added 2026-04-21 via CRUX-C-10 SHIP-001 retrofit + `typical-p-lint` added 2026-04-21 via CRUX-C-22 SHIP-001 retrofit + `grad-norm` added 2026-04-21 via CRUX-F-09 + `registry-quota-lint` added 2026-04-21 via CRUX-A-22 SHIP-001 retrofit + `fp8-lint` added 2026-04-22 via CRUX-B-11 SHIP-001 retrofit + `imatrix-lint` added 2026-04-22 via CRUX-B-07 SHIP-001 retrofit + `nf4-lint` added 2026-04-22 via CRUX-B-10 SHIP-001 retrofit + `gptq-lint` added 2026-04-22 via CRUX-B-09 SHIP-001 retrofit)"
 binary: "apr"
 install: "cargo install aprender"
 
@@ -459,6 +459,12 @@ commands:
   - name: imatrix-lint
     category: inspection
     description: "Lint a captured imatrix calibration observation (CRUX-B-07)"
+    requires_model: false
+    side_effects: []
+
+  - name: gptq-lint
+    category: inspection
+    description: "Lint a captured GPTQ compression/cosine/flags observation (CRUX-B-09)"
     requires_model: false
     side_effects: []
 

--- a/contracts/crux-B-09-v1.yaml
+++ b/contracts/crux-B-09-v1.yaml
@@ -1,33 +1,32 @@
 # CRUX-B-09 — GPTQ quantization
-# Auto-scaffolded from crux-competitive-research-ux-v1.yaml (DRAFT).
-# DO NOT promote to ACTIVE until: (1) evidence collected, (2) falsification
-# body reflects competitor's canonical CLI, (3) apr surface mapped or gap
-# tracked in pmat work (see master §12).
+# Auto-scaffolded from crux-competitive-research-ux-v1.yaml.
 
 metadata:
   id: CRUX-B-09
-  version: "1.0.0-draft"
+  version: "1.1.0"
   created: "2026-04-18"
   author: PAIML Engineering
   registry: true
-  status: draft
+  status: partial
   parent_contracts:
   - crux-competitive-research-ux-v1
   category: "B — Inspection & Debugging"
   competitor: vllm
-  demand_score: 5  # 1..5, critical priority in pmat work
+  demand_score: 5
   intake_status: missing
   description: >
-    GPTQ quantization. Root-cause workflow extracted from vllm UX — see master
-    subspec §5.B and §2 Five Whys methodology for rationale. This
-    draft contract exists to satisfy the Iron Rule "no contract → no user
-    story"; the falsification body below is a placeholder and MUST be
-    replaced with the competitor's canonical CLI transcript before promotion.
+    GPTQ (Generative Pre-trained Transformer Quantization, Frantar et al. 2022,
+    arXiv:2210.17323) parity. auto-gptq and vllm expose
+    `python -m auto_gptq --model-path M --bits 4 --group-size 128`; the
+    aprender surface is `apr quantize M.apr --method gptq --bits 4
+    --group-size 128 -o out.apr`. OBS-based layer-wise quantization
+    preserves fp16 logit direction at >= 0.98 cosine on held-out prompts.
 
   references:
   - 'master: contracts/crux-competitive-research-ux-v1.yaml — §5 + §12'
-  - github.com/huggingface/peft — LoRA/PEFT
-  - arXiv:2106.09685 — LoRA
+  - "https://arxiv.org/abs/2210.17323 — GPTQ paper"
+  - "https://github.com/AutoGPTQ/AutoGPTQ — reference implementation"
+
 equations:
   gptq_size_and_cosine:
     formula: |
@@ -39,7 +38,6 @@ equations:
       Contract:
         (1) size(GPTQ) / size(fp16) <= 0.30
         (2) mean(cos_i) >= 0.98 across all 64 prompts
-      Ref: Frantar et al. 2022 (arXiv:2210.17323) — OBS-based layer-wise quantization.
     domain: (model M, 64 held-out prompts P)
     codomain: (size_ratio ∈ ℝ+, mean_cosine ∈ [-1,1])
     invariants:
@@ -69,19 +67,57 @@ falsification_tests:
     GPTQ=$(stat -c%s /tmp/model-gptq.apr)
     python3 -c "import sys; sys.exit(0 if $GPTQ <= 0.30 * $FP16 else 1)"
   if_fails: "GPTQ 4-bit artifact not compressed to expected 4 bits/weight; packing or metadata bloat bug"
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/gptq_classifier.rs
+    sub_claim: |
+      Algorithm-level necessary condition: `classify_compression_ratio`
+      computes ρ = gptq_bytes / fp16_bytes and admits only
+      ρ <= `GPTQ_MAX_COMPRESSION_RATIO` (0.30). Zero-byte source
+      returns `Insufficient { ratio: ∞ }` rather than divide-by-zero.
+    tests:
+    - compression_under_ceiling_ok
+    - compression_at_exact_ceiling_ok
+    - compression_over_ceiling_flagged
+    - compression_zero_source_is_insufficient
+    scope: byte-ratio ceiling (pure comparator)
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: real GPTQ 4-bit packer + fp16 source pair on disk
 
 - id: FALSIFY-CRUX-B-09-002
   rule: GPTQ logit cosine >= 0.98
   prediction: "mean cosine(logits_fp16, logits_gptq) >= 0.98 on 64 random prompts"
   test: |
     set -euo pipefail
-    # TODO: evidence/crux/vllm/gptq/prompts-64.jsonl — 64 held-out prompts
     apr diff model.apr /tmp/model-gptq.apr \
       --prompts evidence/crux/vllm/gptq/prompts-64.jsonl \
       --metric logit-cosine --json > /tmp/gptq-cos.json
     MEAN=$(jq '.mean_cosine' /tmp/gptq-cos.json)
     python3 -c "import sys; sys.exit(0 if $MEAN >= 0.98 else 1)"
   if_fails: "GPTQ logit cosine below 0.98; Hessian-driven calibration is broken or omitted"
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/gptq_classifier.rs
+    sub_claim: |
+      Algorithm-level necessary condition: `cosine_similarity` implements
+      the standard <a,b>/(‖a‖·‖b‖) formula (verified on identical,
+      orthogonal, and opposite-direction pairs); `classify_mean_cosine`
+      filters length-mismatched pairs, computes the arithmetic mean over
+      the valid subset, and admits only mean >= `GPTQ_MIN_MEAN_COSINE`
+      (0.98) as `Ok`. Zero-norm inputs yield `None` from
+      `cosine_similarity`; if every pair is invalid the classifier
+      returns `NoSamples` instead of silently passing.
+    tests:
+    - cosine_identical_vectors_is_one
+    - cosine_orthogonal_is_zero
+    - cosine_opposite_is_negative_one
+    - cosine_mismatched_length_is_none
+    - cosine_zero_norm_is_none
+    - mean_cosine_all_perfect_meets_threshold
+    - mean_cosine_degraded_below_threshold
+    - mean_cosine_no_valid_pairs_is_no_samples
+    - mean_cosine_skips_invalid_pairs_but_counts_rest
+    scope: cosine + mean-threshold classifier (pure vector math)
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: "evidence/crux/vllm/gptq/prompts-64.jsonl + `apr diff --metric logit-cosine` harness"
 
 - id: FALSIFY-CRUX-B-09-003
   rule: GPTQ CLI surface parity with vllm/auto-gptq
@@ -90,6 +126,30 @@ falsification_tests:
     apr quantize --help 2>&1 | grep -qE -- '--method[[:space:]<]'
     apr quantize --help 2>&1 | grep -qE 'gptq'
   if_fails: "apr quantize lacks --method gptq; vllm/auto-gptq path not exposed"
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/gptq_classifier.rs
+    sub_claim: |
+      Algorithm-level necessary condition: `parse_gptq_flags` handles
+      both `--method gptq` and `--method=gptq`; accepts the auto-gptq
+      convention `--group-size=-1` (per-tensor). `validate_gptq_flags`
+      enforces bits ∈ {2,3,4,8}, group_size ∈ {-1,32,64,128}, default
+      = `GPTQ_DEFAULT_GROUP_SIZE` (128). Missing method, wrong method,
+      missing/invalid bits, and invalid group_size each map to a
+      distinct error variant.
+    tests:
+    - parse_all_three_space_form
+    - parse_group_size_neg_one_is_per_tensor
+    - validate_ok_with_default_group_size
+    - validate_ok_with_per_tensor_group_size
+    - validate_rejects_wrong_method
+    - validate_rejects_missing_bits
+    - validate_rejects_invalid_bits
+    - validate_rejects_invalid_group_size
+    - validate_is_deterministic
+    - reference_constants_match_spec
+    scope: argv → GptqFlags → GptqFlagValidation (pure)
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: "clap `apr quantize --help` subcommand surface + gptq method enum"
 
 proof_obligations:
 - type: invariant
@@ -106,10 +166,18 @@ verification_summary:
   proven: 0
   tested: 0
   status: spec-complete
+  discharge_ledger:
+  - falsify_id: FALSIFY-CRUX-B-09-001
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    blocked_on: real GPTQ 4-bit packer + fp16 source pair on disk
+  - falsify_id: FALSIFY-CRUX-B-09-002
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    blocked_on: "evidence/crux/vllm/gptq/prompts-64.jsonl + `apr diff --metric logit-cosine` harness"
+  - falsify_id: FALSIFY-CRUX-B-09-003
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    blocked_on: "clap `apr quantize --help` subcommand surface + gptq method enum"
 
 pmat_work_tracking:
-  # Managed by master contract §12. If intake_status == "missing", a ticket
-  # tagged `crux-crux-b-09` is auto-created by scripts/crux_bulk_pmat_work.sh.
   ticket_tag: crux-crux-b-09
   priority: critical
   auto_created: true

--- a/contracts/crux-B-09-v1.yaml
+++ b/contracts/crux-B-09-v1.yaml
@@ -3,7 +3,7 @@
 
 metadata:
   id: CRUX-B-09
-  version: "1.1.0"
+  version: "1.2.0"
   created: "2026-04-18"
   author: PAIML Engineering
   registry: true
@@ -69,6 +69,12 @@ falsification_tests:
   if_fails: "GPTQ 4-bit artifact not compressed to expected 4 bits/weight; packing or metadata bloat bug"
   evidence_discharged_by:
     classifier_path: crates/apr-cli/src/commands/gptq_classifier.rs
+    cli_path: crates/apr-cli/src/commands/gptq_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_b_09.rs
+    e2e_tests:
+    - falsify_crux_b_09_001_compression_ok_under_ceiling
+    - falsify_crux_b_09_001_compression_rejects_over_ceiling
+    - falsify_crux_b_09_001_compression_rejects_zero_source
     sub_claim: |
       Algorithm-level necessary condition: `classify_compression_ratio`
       computes ρ = gptq_bytes / fp16_bytes and admits only
@@ -96,6 +102,13 @@ falsification_tests:
   if_fails: "GPTQ logit cosine below 0.98; Hessian-driven calibration is broken or omitted"
   evidence_discharged_by:
     classifier_path: crates/apr-cli/src/commands/gptq_classifier.rs
+    cli_path: crates/apr-cli/src/commands/gptq_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_b_09.rs
+    e2e_tests:
+    - falsify_crux_b_09_002_cosine_ok_on_identical_logits
+    - falsify_crux_b_09_002_cosine_rejects_orthogonal_pair
+    - falsify_crux_b_09_002_cosine_rejects_all_mismatched_lengths
+    - falsify_crux_b_09_002_cosine_rejects_missing_pairs_key
     sub_claim: |
       Algorithm-level necessary condition: `cosine_similarity` implements
       the standard <a,b>/(‖a‖·‖b‖) formula (verified on identical,
@@ -128,6 +141,15 @@ falsification_tests:
   if_fails: "apr quantize lacks --method gptq; vllm/auto-gptq path not exposed"
   evidence_discharged_by:
     classifier_path: crates/apr-cli/src/commands/gptq_classifier.rs
+    cli_path: crates/apr-cli/src/commands/gptq_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_b_09.rs
+    e2e_tests:
+    - falsify_crux_b_09_003_flags_ok_on_canonical_argv
+    - falsify_crux_b_09_003_flags_ok_on_equals_form
+    - falsify_crux_b_09_003_flags_rejects_wrong_method
+    - falsify_crux_b_09_003_flags_rejects_invalid_bits
+    - falsify_crux_b_09_003_flags_rejects_missing_bits
+    - falsify_crux_b_09_003_flags_observer_can_assert_expected_failure
     sub_claim: |
       Algorithm-level necessary condition: `parse_gptq_flags` handles
       both `--method gptq` and `--method=gptq`; accepts the auto-gptq
@@ -176,6 +198,33 @@ verification_summary:
   - falsify_id: FALSIFY-CRUX-B-09-003
     discharge_status: PARTIAL_ALGORITHM_LEVEL
     blocked_on: "clap `apr quantize --help` subcommand surface + gptq method enum"
+
+ship_discipline:
+  ship_rule: CRUX-SHIP-001
+  deliverables_present:
+    classifier: crates/apr-cli/src/commands/gptq_classifier.rs
+    cli_wiring: crates/apr-cli/src/commands/gptq_lint.rs
+    e2e_test: crates/apr-cli/tests/falsification_crux_b_09.rs
+    contract: contracts/crux-B-09-v1.yaml
+  merge_gates:
+    g1_classifier_green: true
+    g2_cli_reachable: true
+    g3_e2e_runs: true
+    g4_contract_discharged: PARTIAL_ALGORITHM_LEVEL
+  notes: >
+    `apr gptq-lint --observation-file <obs.json>` dispatches three GPTQ
+    classifiers (compression ratio, logit-cosine fidelity, CLI flag
+    validation) over a captured JSON observation. e2e suite (19 tests)
+    exercises help surface, bare-invocation rejection, ok+reject paths
+    on all three gates (under-ceiling/over-ceiling/zero-source
+    compression; identical-logits/orthogonal/length-mismatch/missing-pairs
+    cosine; canonical/equals-form/wrong-method/invalid-bits/missing-bits
+    flags + observer-asserted negative case), empty/nonexistent file
+    rejection, observation-without-known-keys rejection, and --json
+    shape. Full ACTIVE discharge remains blocked on real GPTQ 4-bit
+    packer, `evidence/crux/vllm/gptq/prompts-64.jsonl`, `apr diff
+    --metric logit-cosine` harness, and `apr quantize --method gptq`
+    clap surface.
 
 pmat_work_tracking:
   ticket_tag: crux-crux-b-09

--- a/crates/apr-cli/src/commands/gptq_classifier.rs
+++ b/crates/apr-cli/src/commands/gptq_classifier.rs
@@ -1,0 +1,371 @@
+//! CRUX-B-09 GPTQ quantization — algorithm-level classifiers.
+//!
+//! Partial discharge for the `apr quantize --method gptq` contract
+//! (`contracts/crux-B-09-v1.yaml`). Three pure classifiers cover:
+//!
+//! 1. Compression ratio (GPTQ bytes ≤ 0.30 × fp16 bytes) — FALSIFY-001.
+//! 2. Logit-fidelity cosine (mean cos ≥ 0.98 across N held-out prompts) — FALSIFY-002.
+//! 3. CLI surface — `--method gptq --bits --group-size` — FALSIFY-003.
+
+/// Maximum GPTQ-to-fp16 byte ratio.
+pub const GPTQ_MAX_COMPRESSION_RATIO: f64 = 0.30;
+
+/// Minimum mean logit-cosine the contract demands.
+pub const GPTQ_MIN_MEAN_COSINE: f64 = 0.98;
+
+/// Allowed GPTQ bit widths (matches auto-gptq reference).
+pub const GPTQ_ALLOWED_BITS: &[u32] = &[2, 3, 4, 8];
+
+/// Allowed GPTQ group sizes.
+pub const GPTQ_ALLOWED_GROUP_SIZES: &[i32] = &[-1, 32, 64, 128];
+
+/// Default group size (auto-gptq / GPTQ-for-LLaMa default).
+pub const GPTQ_DEFAULT_GROUP_SIZE: i32 = 128;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum CompressionOutcome {
+    Compressed { ratio: f64 },
+    Insufficient { ratio: f64, max_ratio: f64 },
+}
+
+#[must_use]
+pub fn classify_compression_ratio(
+    fp16_bytes: u64,
+    gptq_bytes: u64,
+    max_ratio: f64,
+) -> CompressionOutcome {
+    if fp16_bytes == 0 {
+        return CompressionOutcome::Insufficient { ratio: f64::INFINITY, max_ratio };
+    }
+    let ratio = gptq_bytes as f64 / fp16_bytes as f64;
+    if ratio <= max_ratio {
+        CompressionOutcome::Compressed { ratio }
+    } else {
+        CompressionOutcome::Insufficient { ratio, max_ratio }
+    }
+}
+
+/// Cosine similarity of two equal-length vectors.
+/// Returns `None` if lengths differ or either norm is zero.
+#[must_use]
+pub fn cosine_similarity(a: &[f64], b: &[f64]) -> Option<f64> {
+    if a.len() != b.len() || a.is_empty() {
+        return None;
+    }
+    let mut dot = 0.0;
+    let mut na = 0.0;
+    let mut nb = 0.0;
+    for (x, y) in a.iter().zip(b.iter()) {
+        dot += x * y;
+        na += x * x;
+        nb += y * y;
+    }
+    if na == 0.0 || nb == 0.0 {
+        return None;
+    }
+    Some(dot / (na.sqrt() * nb.sqrt()))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum CosineFidelity {
+    Ok { mean: f64, n: usize },
+    Degraded { mean: f64, threshold: f64, n: usize },
+    /// No valid per-prompt pairs (e.g. length mismatches only).
+    NoSamples,
+}
+
+/// Classify per-prompt logit cosine fidelity across N prompts.
+/// `pairs` holds matched (fp16_logits, gptq_logits) per prompt.
+#[must_use]
+pub fn classify_mean_cosine(pairs: &[(&[f64], &[f64])], threshold: f64) -> CosineFidelity {
+    let cosines: Vec<f64> = pairs
+        .iter()
+        .filter_map(|(a, b)| cosine_similarity(a, b))
+        .collect();
+    let n = cosines.len();
+    if n == 0 {
+        return CosineFidelity::NoSamples;
+    }
+    let mean = cosines.iter().sum::<f64>() / n as f64;
+    if mean >= threshold {
+        CosineFidelity::Ok { mean, n }
+    } else {
+        CosineFidelity::Degraded { mean, threshold, n }
+    }
+}
+
+// ---- CLI surface ----
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GptqFlags {
+    pub method: Option<String>,
+    pub bits: Option<u32>,
+    pub group_size: Option<i32>,
+}
+
+#[must_use]
+pub fn parse_gptq_flags(argv: &[&str]) -> GptqFlags {
+    let mut f = GptqFlags { method: None, bits: None, group_size: None };
+    let mut i = 0;
+    while i < argv.len() {
+        let a = argv[i];
+        match a {
+            "--method" => f.method = argv.get(i + 1).map(|s| (*s).to_string()),
+            "--bits" => f.bits = argv.get(i + 1).and_then(|s| s.parse::<u32>().ok()),
+            "--group-size" => f.group_size = argv.get(i + 1).and_then(|s| s.parse::<i32>().ok()),
+            _ => {
+                if let Some(rest) = a.strip_prefix("--method=") {
+                    f.method = Some(rest.to_string());
+                } else if let Some(rest) = a.strip_prefix("--bits=") {
+                    if let Ok(v) = rest.parse::<u32>() { f.bits = Some(v); }
+                } else if let Some(rest) = a.strip_prefix("--group-size=") {
+                    if let Ok(v) = rest.parse::<i32>() { f.group_size = Some(v); }
+                }
+            }
+        }
+        i += 1;
+    }
+    f
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GptqFlagValidation {
+    Ok { bits: u32, group_size: i32 },
+    MissingMethod,
+    WrongMethod { got: String },
+    InvalidBits { got: u32, allowed: &'static [u32] },
+    MissingBits,
+    InvalidGroupSize { got: i32, allowed: &'static [i32] },
+}
+
+#[must_use]
+pub fn validate_gptq_flags(flags: &GptqFlags) -> GptqFlagValidation {
+    let Some(method) = flags.method.as_deref() else {
+        return GptqFlagValidation::MissingMethod;
+    };
+    if method != "gptq" {
+        return GptqFlagValidation::WrongMethod { got: method.to_string() };
+    }
+    let Some(bits) = flags.bits else {
+        return GptqFlagValidation::MissingBits;
+    };
+    if !GPTQ_ALLOWED_BITS.contains(&bits) {
+        return GptqFlagValidation::InvalidBits { got: bits, allowed: GPTQ_ALLOWED_BITS };
+    }
+    let group_size = flags.group_size.unwrap_or(GPTQ_DEFAULT_GROUP_SIZE);
+    if !GPTQ_ALLOWED_GROUP_SIZES.contains(&group_size) {
+        return GptqFlagValidation::InvalidGroupSize {
+            got: group_size,
+            allowed: GPTQ_ALLOWED_GROUP_SIZES,
+        };
+    }
+    GptqFlagValidation::Ok { bits, group_size }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---- FALSIFY-001 (compression) ----
+
+    #[test]
+    fn compression_under_ceiling_ok() {
+        assert!(matches!(
+            classify_compression_ratio(1_000_000, 200_000, GPTQ_MAX_COMPRESSION_RATIO),
+            CompressionOutcome::Compressed { .. }
+        ));
+    }
+
+    #[test]
+    fn compression_at_exact_ceiling_ok() {
+        match classify_compression_ratio(1_000_000, 300_000, GPTQ_MAX_COMPRESSION_RATIO) {
+            CompressionOutcome::Compressed { ratio } => assert!((ratio - 0.30).abs() < 1e-9),
+            _ => panic!("expected Compressed at exact ceiling"),
+        }
+    }
+
+    #[test]
+    fn compression_over_ceiling_flagged() {
+        assert!(matches!(
+            classify_compression_ratio(1_000_000, 400_000, GPTQ_MAX_COMPRESSION_RATIO),
+            CompressionOutcome::Insufficient { .. }
+        ));
+    }
+
+    #[test]
+    fn compression_zero_source_is_insufficient() {
+        assert!(matches!(
+            classify_compression_ratio(0, 100, GPTQ_MAX_COMPRESSION_RATIO),
+            CompressionOutcome::Insufficient { .. }
+        ));
+    }
+
+    // ---- FALSIFY-002 (cosine fidelity) ----
+
+    #[test]
+    fn cosine_identical_vectors_is_one() {
+        let v = vec![1.0, 2.0, 3.0];
+        let c = cosine_similarity(&v, &v).unwrap();
+        assert!((c - 1.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn cosine_orthogonal_is_zero() {
+        let a = vec![1.0, 0.0];
+        let b = vec![0.0, 1.0];
+        let c = cosine_similarity(&a, &b).unwrap();
+        assert!(c.abs() < 1e-12);
+    }
+
+    #[test]
+    fn cosine_opposite_is_negative_one() {
+        let a = vec![1.0, 2.0];
+        let b = vec![-1.0, -2.0];
+        let c = cosine_similarity(&a, &b).unwrap();
+        assert!((c - (-1.0)).abs() < 1e-12);
+    }
+
+    #[test]
+    fn cosine_mismatched_length_is_none() {
+        assert!(cosine_similarity(&[1.0, 2.0], &[1.0]).is_none());
+    }
+
+    #[test]
+    fn cosine_zero_norm_is_none() {
+        assert!(cosine_similarity(&[0.0, 0.0], &[1.0, 2.0]).is_none());
+    }
+
+    #[test]
+    fn mean_cosine_all_perfect_meets_threshold() {
+        let v1 = vec![1.0, 2.0, 3.0];
+        let v2 = vec![0.5, 1.0, 1.5]; // same direction, scaled
+        let pairs: Vec<(&[f64], &[f64])> = vec![
+            (v1.as_slice(), v2.as_slice()),
+            (v1.as_slice(), v2.as_slice()),
+        ];
+        let r = classify_mean_cosine(&pairs, GPTQ_MIN_MEAN_COSINE);
+        match r {
+            CosineFidelity::Ok { mean, n } => {
+                assert!(mean >= GPTQ_MIN_MEAN_COSINE);
+                assert_eq!(n, 2);
+            }
+            o => panic!("expected Ok, got {:?}", o),
+        }
+    }
+
+    #[test]
+    fn mean_cosine_degraded_below_threshold() {
+        let a = vec![1.0, 0.0];
+        let b = vec![0.0, 1.0]; // cosine = 0
+        let pairs: Vec<(&[f64], &[f64])> = vec![(a.as_slice(), b.as_slice())];
+        assert!(matches!(
+            classify_mean_cosine(&pairs, GPTQ_MIN_MEAN_COSINE),
+            CosineFidelity::Degraded { .. }
+        ));
+    }
+
+    #[test]
+    fn mean_cosine_no_valid_pairs_is_no_samples() {
+        // All pairs length-mismatched → filtered away.
+        let a = vec![1.0];
+        let b = vec![1.0, 2.0];
+        let pairs: Vec<(&[f64], &[f64])> = vec![(a.as_slice(), b.as_slice())];
+        assert_eq!(
+            classify_mean_cosine(&pairs, GPTQ_MIN_MEAN_COSINE),
+            CosineFidelity::NoSamples
+        );
+    }
+
+    #[test]
+    fn mean_cosine_skips_invalid_pairs_but_counts_rest() {
+        // One valid + one length-mismatch — mean is over the valid subset only.
+        let a = vec![1.0, 2.0];
+        let b = vec![1.0, 2.0];
+        let bad_a = vec![1.0];
+        let bad_b = vec![1.0, 2.0];
+        let pairs: Vec<(&[f64], &[f64])> =
+            vec![(a.as_slice(), b.as_slice()), (bad_a.as_slice(), bad_b.as_slice())];
+        match classify_mean_cosine(&pairs, GPTQ_MIN_MEAN_COSINE) {
+            CosineFidelity::Ok { n, .. } => assert_eq!(n, 1),
+            o => panic!("expected Ok with n=1, got {:?}", o),
+        }
+    }
+
+    // ---- FALSIFY-003 (CLI) ----
+
+    #[test]
+    fn parse_all_three_space_form() {
+        let argv = &["quantize", "--method", "gptq", "--bits", "4", "--group-size", "128"];
+        let f = parse_gptq_flags(argv);
+        assert_eq!(f.method.as_deref(), Some("gptq"));
+        assert_eq!(f.bits, Some(4));
+        assert_eq!(f.group_size, Some(128));
+    }
+
+    #[test]
+    fn parse_group_size_neg_one_is_per_tensor() {
+        // auto-gptq convention: group_size=-1 means per-tensor.
+        let argv = &["--method=gptq", "--bits=4", "--group-size=-1"];
+        let f = parse_gptq_flags(argv);
+        assert_eq!(f.group_size, Some(-1));
+    }
+
+    #[test]
+    fn validate_ok_with_default_group_size() {
+        let f = GptqFlags { method: Some("gptq".into()), bits: Some(4), group_size: None };
+        assert_eq!(
+            validate_gptq_flags(&f),
+            GptqFlagValidation::Ok { bits: 4, group_size: GPTQ_DEFAULT_GROUP_SIZE }
+        );
+    }
+
+    #[test]
+    fn validate_ok_with_per_tensor_group_size() {
+        let f = GptqFlags { method: Some("gptq".into()), bits: Some(4), group_size: Some(-1) };
+        assert_eq!(
+            validate_gptq_flags(&f),
+            GptqFlagValidation::Ok { bits: 4, group_size: -1 }
+        );
+    }
+
+    #[test]
+    fn validate_rejects_wrong_method() {
+        let f = GptqFlags { method: Some("awq".into()), bits: Some(4), group_size: Some(128) };
+        assert!(matches!(validate_gptq_flags(&f), GptqFlagValidation::WrongMethod { .. }));
+    }
+
+    #[test]
+    fn validate_rejects_missing_bits() {
+        let f = GptqFlags { method: Some("gptq".into()), bits: None, group_size: Some(128) };
+        assert_eq!(validate_gptq_flags(&f), GptqFlagValidation::MissingBits);
+    }
+
+    #[test]
+    fn validate_rejects_invalid_bits() {
+        let f = GptqFlags { method: Some("gptq".into()), bits: Some(5), group_size: Some(128) };
+        assert!(matches!(validate_gptq_flags(&f), GptqFlagValidation::InvalidBits { got: 5, .. }));
+    }
+
+    #[test]
+    fn validate_rejects_invalid_group_size() {
+        let f = GptqFlags { method: Some("gptq".into()), bits: Some(4), group_size: Some(96) };
+        assert!(matches!(
+            validate_gptq_flags(&f),
+            GptqFlagValidation::InvalidGroupSize { got: 96, .. }
+        ));
+    }
+
+    #[test]
+    fn validate_is_deterministic() {
+        let f = GptqFlags { method: Some("gptq".into()), bits: Some(4), group_size: None };
+        assert_eq!(validate_gptq_flags(&f), validate_gptq_flags(&f));
+    }
+
+    #[test]
+    fn reference_constants_match_spec() {
+        assert!(GPTQ_ALLOWED_BITS.contains(&4));
+        assert!(GPTQ_ALLOWED_GROUP_SIZES.contains(&128));
+        assert!(GPTQ_ALLOWED_GROUP_SIZES.contains(&-1));
+        assert_eq!(GPTQ_DEFAULT_GROUP_SIZE, 128);
+    }
+}

--- a/crates/apr-cli/src/commands/gptq_lint.rs
+++ b/crates/apr-cli/src/commands/gptq_lint.rs
@@ -1,0 +1,260 @@
+//! CRUX-B-09 — `apr gptq-lint` CLI wiring (CRUX-SHIP-001 g2/g3 proof).
+//!
+//! Dispatches the three GPTQ classifiers in `gptq_classifier.rs` over a
+//! captured JSON observation file:
+//!
+//! ```jsonc
+//! {
+//!   "compression": {
+//!     "fp16_bytes":  1_000_000_000,
+//!     "gptq_bytes":    250_000_000,
+//!     "max_ratio":          0.30
+//!   },
+//!   "cosine": {
+//!     "pairs": [
+//!       { "fp16": [..], "gptq": [..] },
+//!       ...
+//!     ],
+//!     "threshold": 0.98
+//!   },
+//!   "flags": {
+//!     "argv":             ["--method", "gptq", "--bits", "4", "--group-size", "128"],
+//!     "expected_outcome": "ok"    // ok | missing_method | wrong_method | invalid_bits | missing_bits | invalid_group_size
+//!   }
+//! }
+//! ```
+//!
+//! Any missing top-level key is skipped. Non-zero exit + FALSIFY-CRUX-B-09
+//! stderr stamp on any failing gate.
+
+use crate::commands::gptq_classifier::{
+    classify_compression_ratio, classify_mean_cosine, parse_gptq_flags, validate_gptq_flags,
+    CompressionOutcome, CosineFidelity, GptqFlagValidation, GPTQ_MAX_COMPRESSION_RATIO,
+    GPTQ_MIN_MEAN_COSINE,
+};
+use serde_json::Value;
+use std::fs;
+use std::path::Path;
+
+#[derive(Debug, Clone)]
+pub struct GptqLintArgs {
+    pub observation_file: String,
+    pub json: bool,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+struct GateReport {
+    gate: &'static str,
+    falsify_id: &'static str,
+    outcome: String,
+    passed: bool,
+}
+
+pub fn run(args: GptqLintArgs) -> Result<(), String> {
+    let path = Path::new(&args.observation_file);
+    if !path.exists() {
+        return Err(format!(
+            "FALSIFY-CRUX-B-09: observation file not found: {}",
+            args.observation_file
+        ));
+    }
+    let raw = fs::read_to_string(path)
+        .map_err(|e| format!("FALSIFY-CRUX-B-09: failed to read observation: {e}"))?;
+    if raw.trim().is_empty() {
+        return Err("FALSIFY-CRUX-B-09: observation file is empty".to_string());
+    }
+    let obs: Value = serde_json::from_str(&raw)
+        .map_err(|e| format!("FALSIFY-CRUX-B-09: observation is not valid JSON: {e}"))?;
+
+    let mut reports: Vec<GateReport> = Vec::new();
+    let mut failures: Vec<String> = Vec::new();
+
+    if let Some(cmp) = obs.get("compression") {
+        let (report, err) = run_compression_gate(cmp);
+        reports.push(report);
+        if let Some(e) = err {
+            failures.push(e);
+        }
+    }
+    if let Some(cos) = obs.get("cosine") {
+        let (report, err) = run_cosine_gate(cos);
+        reports.push(report);
+        if let Some(e) = err {
+            failures.push(e);
+        }
+    }
+    if let Some(fl) = obs.get("flags") {
+        let (report, err) = run_flags_gate(fl);
+        reports.push(report);
+        if let Some(e) = err {
+            failures.push(e);
+        }
+    }
+
+    if reports.is_empty() {
+        return Err("FALSIFY-CRUX-B-09: observation has none of compression/cosine/flags".into());
+    }
+
+    if args.json {
+        let payload = serde_json::json!({
+            "contract": "CRUX-B-09",
+            "gates": reports,
+        });
+        println!("{}", serde_json::to_string_pretty(&payload).unwrap());
+    } else {
+        for r in &reports {
+            let tag = if r.passed { "PASS" } else { "FAIL" };
+            println!("[{tag}] {} ({}): {}", r.gate, r.falsify_id, r.outcome);
+        }
+    }
+
+    if !failures.is_empty() {
+        return Err(failures.join("\n"));
+    }
+    Ok(())
+}
+
+fn run_compression_gate(v: &Value) -> (GateReport, Option<String>) {
+    let fp16 = v.get("fp16_bytes").and_then(|x| x.as_u64()).unwrap_or(0);
+    let gptq = v.get("gptq_bytes").and_then(|x| x.as_u64()).unwrap_or(0);
+    let max_ratio = v
+        .get("max_ratio")
+        .and_then(|x| x.as_f64())
+        .unwrap_or(GPTQ_MAX_COMPRESSION_RATIO);
+    let outcome = classify_compression_ratio(fp16, gptq, max_ratio);
+    let (passed, desc) = match outcome {
+        CompressionOutcome::Compressed { ratio } => (
+            true,
+            format!("ratio={ratio:.4} (max={max_ratio}, fp16={fp16}, gptq={gptq})"),
+        ),
+        CompressionOutcome::Insufficient { ratio, max_ratio } => (
+            false,
+            format!("ratio={ratio:.4} > max={max_ratio} (fp16={fp16}, gptq={gptq})"),
+        ),
+    };
+    let err = if passed {
+        None
+    } else {
+        Some(format!(
+            "FALSIFY-CRUX-B-09-001 compression gate failed: {desc}"
+        ))
+    };
+    (
+        GateReport {
+            gate: "compression",
+            falsify_id: "FALSIFY-CRUX-B-09-001",
+            outcome: desc,
+            passed,
+        },
+        err,
+    )
+}
+
+fn read_f64_array(v: &Value) -> Vec<f64> {
+    v.as_array()
+        .map(|a| a.iter().filter_map(|n| n.as_f64()).collect())
+        .unwrap_or_default()
+}
+
+fn run_cosine_gate(v: &Value) -> (GateReport, Option<String>) {
+    let threshold = v
+        .get("threshold")
+        .and_then(|x| x.as_f64())
+        .unwrap_or(GPTQ_MIN_MEAN_COSINE);
+    let Some(pairs_val) = v.get("pairs").and_then(|x| x.as_array()) else {
+        let desc = "cosine.pairs missing".to_string();
+        return (
+            GateReport {
+                gate: "cosine",
+                falsify_id: "FALSIFY-CRUX-B-09-002",
+                outcome: desc.clone(),
+                passed: false,
+            },
+            Some(format!("FALSIFY-CRUX-B-09-002 cosine gate failed: {desc}")),
+        );
+    };
+
+    let vecs: Vec<(Vec<f64>, Vec<f64>)> = pairs_val
+        .iter()
+        .map(|p| {
+            (
+                p.get("fp16").map(read_f64_array).unwrap_or_default(),
+                p.get("gptq").map(read_f64_array).unwrap_or_default(),
+            )
+        })
+        .collect();
+    let borrowed: Vec<(&[f64], &[f64])> = vecs
+        .iter()
+        .map(|(a, b)| (a.as_slice(), b.as_slice()))
+        .collect();
+    let fidelity = classify_mean_cosine(&borrowed, threshold);
+
+    let (passed, desc) = match fidelity {
+        CosineFidelity::Ok { mean, n } => {
+            (true, format!("mean_cos={mean:.6} >= {threshold} (n={n})"))
+        }
+        CosineFidelity::Degraded { mean, threshold, n } => {
+            (false, format!("mean_cos={mean:.6} < {threshold} (n={n})"))
+        }
+        CosineFidelity::NoSamples => (false, "no valid pairs (all length-mismatched)".to_string()),
+    };
+    let err = if passed {
+        None
+    } else {
+        Some(format!("FALSIFY-CRUX-B-09-002 cosine gate failed: {desc}"))
+    };
+    (
+        GateReport {
+            gate: "cosine",
+            falsify_id: "FALSIFY-CRUX-B-09-002",
+            outcome: desc,
+            passed,
+        },
+        err,
+    )
+}
+
+fn run_flags_gate(v: &Value) -> (GateReport, Option<String>) {
+    let argv_owned: Vec<String> = v
+        .get("argv")
+        .and_then(|x| x.as_array())
+        .map(|a| {
+            a.iter()
+                .filter_map(|s| s.as_str().map(|s| s.to_string()))
+                .collect()
+        })
+        .unwrap_or_default();
+    let argv: Vec<&str> = argv_owned.iter().map(|s| s.as_str()).collect();
+    let flags = parse_gptq_flags(&argv);
+    let validation = validate_gptq_flags(&flags);
+
+    let expected = v
+        .get("expected_outcome")
+        .and_then(|x| x.as_str())
+        .unwrap_or("ok");
+
+    let got = match &validation {
+        GptqFlagValidation::Ok { .. } => "ok",
+        GptqFlagValidation::MissingMethod => "missing_method",
+        GptqFlagValidation::WrongMethod { .. } => "wrong_method",
+        GptqFlagValidation::InvalidBits { .. } => "invalid_bits",
+        GptqFlagValidation::MissingBits => "missing_bits",
+        GptqFlagValidation::InvalidGroupSize { .. } => "invalid_group_size",
+    };
+    let passed = got == expected;
+    let desc = format!("expected={expected} got={got} ({validation:?})");
+    let err = if passed {
+        None
+    } else {
+        Some(format!("FALSIFY-CRUX-B-09-003 flags gate failed: {desc}"))
+    };
+    (
+        GateReport {
+            gate: "flags",
+            falsify_id: "FALSIFY-CRUX-B-09-003",
+            outcome: desc,
+            passed,
+        },
+        err,
+    )
+}

--- a/crates/apr-cli/src/commands/mod.rs
+++ b/crates/apr-cli/src/commands/mod.rs
@@ -43,6 +43,7 @@ pub(crate) mod gbnf_lint;
 #[cfg(feature = "training")]
 pub(crate) mod gpu;
 pub(crate) mod gptq_classifier;
+pub(crate) mod gptq_lint;
 pub(crate) mod grad_norm;
 pub(crate) mod hex;
 pub(crate) mod hf_endpoint;

--- a/crates/apr-cli/src/commands/mod.rs
+++ b/crates/apr-cli/src/commands/mod.rs
@@ -42,6 +42,7 @@ pub(crate) mod gbnf_classifier;
 pub(crate) mod gbnf_lint;
 #[cfg(feature = "training")]
 pub(crate) mod gpu;
+pub(crate) mod gptq_classifier;
 pub(crate) mod grad_norm;
 pub(crate) mod hex;
 pub(crate) mod hf_endpoint;

--- a/crates/apr-cli/src/dispatch_analysis.rs
+++ b/crates/apr-cli/src/dispatch_analysis.rs
@@ -140,6 +140,14 @@ fn dispatch_analysis_commands(cli: &Cli) -> Option<Result<(), CliError>> {
         )
         .map_err(crate::error::CliError::Aprender),
 
+        ExtendedCommands::GptqLint { observation_file } => commands::gptq_lint::run(
+            commands::gptq_lint::GptqLintArgs {
+                observation_file: observation_file.to_string_lossy().to_string(),
+                json: cli.json,
+            },
+        )
+        .map_err(crate::error::CliError::Aprender),
+
         ExtendedCommands::OomLint {
             report_file,
             stderr_file,

--- a/crates/apr-cli/src/extended_commands.rs
+++ b/crates/apr-cli/src/extended_commands.rs
@@ -767,6 +767,12 @@ pub enum ExtendedCommands {
         #[arg(long, value_name = "FILE")]
         observation_file: PathBuf,
     },
+    /// Lint a captured GPTQ compression/cosine/flags observation (CRUX-B-09)
+    GptqLint {
+        /// Path to captured GPTQ observation JSON
+        #[arg(long, value_name = "FILE")]
+        observation_file: PathBuf,
+    },
     /// Lint a captured CUDA OOM postmortem report (CRUX-F-13)
     OomLint {
         /// Path to captured OOM postmortem JSON (e.g. /tmp/apr-oom-<ts>.json)

--- a/crates/apr-cli/tests/cli_commands.rs
+++ b/crates/apr-cli/tests/cli_commands.rs
@@ -93,6 +93,7 @@ fn registered_commands() -> Vec<&'static str> {
         "awq-lint",
         "fp8-lint",
         "nf4-lint",
+        "gptq-lint",
         "oom-lint",
         "tool-use-lint",
         "gbnf-lint",

--- a/crates/apr-cli/tests/falsification_crux_b_09.rs
+++ b/crates/apr-cli/tests/falsification_crux_b_09.rs
@@ -1,0 +1,372 @@
+//! E2E falsification tests for `apr gptq-lint` (CRUX-B-09).
+//!
+//! Discharges g3 of CRUX-SHIP-001 for PR #970: exercise the CLI surface
+//! end-to-end on captured JSON observations and assert the classifier
+//! verdicts + non-zero exit codes on known-bad input.
+
+use std::io::Write;
+use std::process::Command;
+
+fn apr_binary() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_apr"));
+    cmd.env("NO_COLOR", "1");
+    cmd
+}
+
+fn write_tmp_json(name: &str, body: &str) -> tempfile::NamedTempFile {
+    let mut f = tempfile::Builder::new()
+        .prefix(name)
+        .suffix(".json")
+        .tempfile()
+        .expect("create tempfile");
+    f.write_all(body.as_bytes()).expect("write tempfile");
+    f.flush().expect("flush tempfile");
+    f
+}
+
+// ---- help surface (g2 proof) ----------------------------------------------
+
+#[test]
+fn falsify_crux_b_09_help_advertises_observation_file_flag() {
+    let out = apr_binary()
+        .args(["gptq-lint", "--help"])
+        .output()
+        .expect("run apr gptq-lint --help");
+    assert!(out.status.success(), "apr gptq-lint --help must exit 0");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("--observation-file"),
+        "--help must advertise --observation-file; got:\n{stdout}"
+    );
+}
+
+#[test]
+fn falsify_crux_b_09_rejects_bare_invocation_without_file() {
+    let out = apr_binary()
+        .arg("gptq-lint")
+        .output()
+        .expect("run apr gptq-lint without args");
+    assert!(
+        !out.status.success(),
+        "bare `apr gptq-lint` must exit non-zero"
+    );
+}
+
+// ---- compression gate (FALSIFY-CRUX-B-09-001) -----------------------------
+
+#[test]
+fn falsify_crux_b_09_001_compression_ok_under_ceiling() {
+    let tmp = write_tmp_json(
+        "gptq-cmp-ok",
+        r#"{ "compression": { "fp16_bytes": 1000000, "gptq_bytes": 200000, "max_ratio": 0.30 } }"#,
+    );
+    let out = apr_binary()
+        .args(["gptq-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr gptq-lint");
+    assert!(
+        out.status.success(),
+        "20% ratio must pass 30% ceiling; stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn falsify_crux_b_09_001_compression_rejects_over_ceiling() {
+    let tmp = write_tmp_json(
+        "gptq-cmp-bad",
+        r#"{ "compression": { "fp16_bytes": 1000000, "gptq_bytes": 400000, "max_ratio": 0.30 } }"#,
+    );
+    let out = apr_binary()
+        .args(["gptq-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr gptq-lint");
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-B-09-001"));
+}
+
+#[test]
+fn falsify_crux_b_09_001_compression_rejects_zero_source() {
+    let tmp = write_tmp_json(
+        "gptq-cmp-zero",
+        r#"{ "compression": { "fp16_bytes": 0, "gptq_bytes": 100 } }"#,
+    );
+    let out = apr_binary()
+        .args(["gptq-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr gptq-lint");
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-B-09-001"));
+}
+
+// ---- cosine gate (FALSIFY-CRUX-B-09-002) ----------------------------------
+
+#[test]
+fn falsify_crux_b_09_002_cosine_ok_on_identical_logits() {
+    let tmp = write_tmp_json(
+        "gptq-cos-ok",
+        r#"{ "cosine": {
+               "pairs": [
+                 { "fp16": [1.0, 0.0, 0.5, -0.3], "gptq": [1.0, 0.0, 0.5, -0.3] },
+                 { "fp16": [0.2, 0.7, 0.1, 0.9], "gptq": [0.2, 0.7, 0.1, 0.9] }
+               ],
+               "threshold": 0.98
+             } }"#,
+    );
+    let out = apr_binary()
+        .args(["gptq-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr gptq-lint");
+    assert!(
+        out.status.success(),
+        "identical logits must pass; stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn falsify_crux_b_09_002_cosine_rejects_orthogonal_pair() {
+    let tmp = write_tmp_json(
+        "gptq-cos-bad",
+        r#"{ "cosine": {
+               "pairs": [ { "fp16": [1.0, 0.0], "gptq": [0.0, 1.0] } ],
+               "threshold": 0.98
+             } }"#,
+    );
+    let out = apr_binary()
+        .args(["gptq-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr gptq-lint");
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-B-09-002"));
+}
+
+#[test]
+fn falsify_crux_b_09_002_cosine_rejects_all_mismatched_lengths() {
+    let tmp = write_tmp_json(
+        "gptq-cos-mis",
+        r#"{ "cosine": {
+               "pairs": [ { "fp16": [1.0, 0.0], "gptq": [1.0, 0.0, 0.5] } ],
+               "threshold": 0.98
+             } }"#,
+    );
+    let out = apr_binary()
+        .args(["gptq-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr gptq-lint");
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-B-09-002"));
+}
+
+#[test]
+fn falsify_crux_b_09_002_cosine_rejects_missing_pairs_key() {
+    let tmp = write_tmp_json("gptq-cos-nopairs", r#"{ "cosine": { "threshold": 0.98 } }"#);
+    let out = apr_binary()
+        .args(["gptq-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr gptq-lint");
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-B-09-002"));
+}
+
+// ---- flags gate (FALSIFY-CRUX-B-09-003) -----------------------------------
+
+#[test]
+fn falsify_crux_b_09_003_flags_ok_on_canonical_argv() {
+    let tmp = write_tmp_json(
+        "gptq-flg-ok",
+        r#"{ "flags": {
+               "argv": ["--method", "gptq", "--bits", "4", "--group-size", "128"],
+               "expected_outcome": "ok"
+             } }"#,
+    );
+    let out = apr_binary()
+        .args(["gptq-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr gptq-lint");
+    assert!(
+        out.status.success(),
+        "canonical flags must pass; stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn falsify_crux_b_09_003_flags_ok_on_equals_form() {
+    let tmp = write_tmp_json(
+        "gptq-flg-eq",
+        r#"{ "flags": {
+               "argv": ["--method=gptq", "--bits=4", "--group-size=-1"],
+               "expected_outcome": "ok"
+             } }"#,
+    );
+    let out = apr_binary()
+        .args(["gptq-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr gptq-lint");
+    assert!(
+        out.status.success(),
+        "--method=gptq per-tensor group_size must pass; stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn falsify_crux_b_09_003_flags_rejects_wrong_method() {
+    let tmp = write_tmp_json(
+        "gptq-flg-wm",
+        r#"{ "flags": {
+               "argv": ["--method", "awq", "--bits", "4"],
+               "expected_outcome": "ok"
+             } }"#,
+    );
+    let out = apr_binary()
+        .args(["gptq-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr gptq-lint");
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-B-09-003"));
+}
+
+#[test]
+fn falsify_crux_b_09_003_flags_rejects_invalid_bits() {
+    let tmp = write_tmp_json(
+        "gptq-flg-bits",
+        r#"{ "flags": {
+               "argv": ["--method", "gptq", "--bits", "5"],
+               "expected_outcome": "ok"
+             } }"#,
+    );
+    let out = apr_binary()
+        .args(["gptq-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr gptq-lint");
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-B-09-003"));
+}
+
+#[test]
+fn falsify_crux_b_09_003_flags_rejects_missing_bits() {
+    let tmp = write_tmp_json(
+        "gptq-flg-mb",
+        r#"{ "flags": {
+               "argv": ["--method", "gptq"],
+               "expected_outcome": "ok"
+             } }"#,
+    );
+    let out = apr_binary()
+        .args(["gptq-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr gptq-lint");
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-B-09-003"));
+}
+
+#[test]
+fn falsify_crux_b_09_003_flags_observer_can_assert_expected_failure() {
+    // Observer captured a deliberate negative case: argv has wrong method,
+    // and the observation asserts that the gate SHOULD produce wrong_method.
+    let tmp = write_tmp_json(
+        "gptq-flg-neg",
+        r#"{ "flags": {
+               "argv": ["--method", "awq", "--bits", "4"],
+               "expected_outcome": "wrong_method"
+             } }"#,
+    );
+    let out = apr_binary()
+        .args(["gptq-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr gptq-lint");
+    assert!(
+        out.status.success(),
+        "expected_outcome=wrong_method must match observed wrong_method; stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+// ---- input validation -----------------------------------------------------
+
+#[test]
+fn falsify_crux_b_09_empty_file_rejected_via_cli() {
+    let tmp = write_tmp_json("gptq-empty", "");
+    let out = apr_binary()
+        .args(["gptq-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr gptq-lint");
+    assert!(!out.status.success(), "empty file must be rejected");
+}
+
+#[test]
+fn falsify_crux_b_09_nonexistent_file_rejected() {
+    let out = apr_binary()
+        .args([
+            "gptq-lint",
+            "--observation-file",
+            "/nonexistent/path/obs.json",
+        ])
+        .output()
+        .expect("run apr gptq-lint");
+    assert!(!out.status.success());
+}
+
+#[test]
+fn falsify_crux_b_09_observation_without_known_keys_rejected() {
+    let tmp = write_tmp_json("gptq-emptyobj", r#"{ "other": 1 }"#);
+    let out = apr_binary()
+        .args(["gptq-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr gptq-lint");
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-B-09"));
+}
+
+// ---- --json shape ---------------------------------------------------------
+
+#[test]
+fn falsify_crux_b_09_json_output_shape() {
+    let tmp = write_tmp_json(
+        "gptq-json",
+        r#"{
+          "compression": { "fp16_bytes": 1000000, "gptq_bytes": 250000, "max_ratio": 0.30 },
+          "flags":       { "argv": ["--method","gptq","--bits","4"], "expected_outcome": "ok" }
+        }"#,
+    );
+    let out = apr_binary()
+        .args(["--json", "gptq-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr gptq-lint --json");
+    assert!(
+        out.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("\"compression\""));
+    assert!(stdout.contains("\"flags\""));
+    assert!(stdout.contains("CRUX-B-09"));
+}


### PR DESCRIPTION
## Summary
Algorithm-level discharge for `apr quantize --method gptq` — auto-gptq / vllm parity (Frantar et al. 2022, arXiv:2210.17323):

- **FALSIFY-001 (size ≤0.30×)** — `classify_compression_ratio` byte-ratio comparator
- **FALSIFY-002 (mean logit cosine ≥0.98)** — `cosine_similarity` + `classify_mean_cosine`
- **FALSIFY-003 (CLI surface)** — `parse_gptq_flags` + `validate_gptq_flags`; supports `group_size=-1` (auto-gptq per-tensor convention)

## Test evidence
23 classifier tests PASS (`cargo test -p apr-cli --lib commands::gptq_classifier`).

## Contract
`contracts/crux-B-09-v1.yaml` v1.0.0-draft → **v1.1.0**, status **draft → partial**. `pv validate` 0 errors / 0 warnings.

## Full discharge still blocks on
- Real GPTQ 4-bit packer + fp16 source pair
- 64-prompt logit-fidelity harness (`apr diff --metric logit-cosine`)
- clap `apr quantize --help` gptq method enum

🤖 Generated with [Claude Code](https://claude.com/claude-code)