### PR TITLE
feat(crux-c-13): /v1/embeddings response-shape+determinism+usage+flag classifier (4 of 4 FALSIFY at PARTIAL_ALGORITHM_LEVEL)

### DIFF
--- a/contracts/apr-cli-commands-v1.yaml
+++ b/contracts/apr-cli-commands-v1.yaml
@@ -21,7 +21,7 @@ metadata:
 kind: CLICommandContract
 name: apr-cli-commands
 version: "1.0.0"
-scope: "all apr CLI subcommands (72 commands — original 57 + `mcp` added 2026-04-17 via PR #864 + `registry` added 2026-04-20 via CRUX-A-01 + `ollama-chat-lint` added 2026-04-21 via CRUX-C-04 SHIP-001 retrofit + `dry-sampling-lint` added 2026-04-21 via CRUX-C-23 SHIP-001 retrofit + `awq-lint` added 2026-04-21 via CRUX-B-08 SHIP-001 retrofit + `oom-lint` added 2026-04-21 via CRUX-F-13 SHIP-001 + `tool-use-lint` added 2026-04-21 via CRUX-C-11 SHIP-001 retrofit + `gbnf-lint` added 2026-04-21 via CRUX-C-10 SHIP-001 retrofit + `typical-p-lint` added 2026-04-21 via CRUX-C-22 SHIP-001 retrofit + `grad-norm` added 2026-04-21 via CRUX-F-09 + `registry-quota-lint` added 2026-04-21 via CRUX-A-22 SHIP-001 retrofit + `fp8-lint` added 2026-04-22 via CRUX-B-11 SHIP-001 retrofit + `imatrix-lint` added 2026-04-22 via CRUX-B-07 SHIP-001 retrofit + `nf4-lint` added 2026-04-22 via CRUX-B-10 SHIP-001 retrofit + `gptq-lint` added 2026-04-22 via CRUX-B-09 SHIP-001 retrofit)"
+scope: "all apr CLI subcommands (73 commands — original 57 + `mcp` added 2026-04-17 via PR #864 + `registry` added 2026-04-20 via CRUX-A-01 + `ollama-chat-lint` added 2026-04-21 via CRUX-C-04 SHIP-001 retrofit + `dry-sampling-lint` added 2026-04-21 via CRUX-C-23 SHIP-001 retrofit + `awq-lint` added 2026-04-21 via CRUX-B-08 SHIP-001 retrofit + `oom-lint` added 2026-04-21 via CRUX-F-13 SHIP-001 + `tool-use-lint` added 2026-04-21 via CRUX-C-11 SHIP-001 retrofit + `gbnf-lint` added 2026-04-21 via CRUX-C-10 SHIP-001 retrofit + `typical-p-lint` added 2026-04-21 via CRUX-C-22 SHIP-001 retrofit + `grad-norm` added 2026-04-21 via CRUX-F-09 + `registry-quota-lint` added 2026-04-21 via CRUX-A-22 SHIP-001 retrofit + `fp8-lint` added 2026-04-22 via CRUX-B-11 SHIP-001 retrofit + `imatrix-lint` added 2026-04-22 via CRUX-B-07 SHIP-001 retrofit + `nf4-lint` added 2026-04-22 via CRUX-B-10 SHIP-001 retrofit + `gptq-lint` added 2026-04-22 via CRUX-B-09 SHIP-001 retrofit + `embeddings-lint` added 2026-04-23 via CRUX-C-13 SHIP-001 retrofit)"
 binary: "apr"
 install: "cargo install aprender"
 
@@ -465,6 +465,12 @@ commands:
   - name: gptq-lint
     category: inspection
     description: "Lint a captured GPTQ compression/cosine/flags observation (CRUX-B-09)"
+    requires_model: false
+    side_effects: []
+
+  - name: embeddings-lint
+    category: inspection
+    description: "Lint a captured /v1/embeddings observation (CRUX-C-13)"
     requires_model: false
     side_effects: []
 

--- a/contracts/crux-C-13-v1.yaml
+++ b/contracts/crux-C-13-v1.yaml
@@ -2,7 +2,7 @@
 
 metadata:
   id: CRUX-C-13
-  version: "1.1.0"
+  version: "1.2.0"
   created: "2026-04-18"
   author: PAIML Engineering
   registry: true
@@ -75,6 +75,13 @@ falsification_tests:
   if_fails: "/v1/embeddings response length or vector dimension mismatches spec"
   evidence_discharged_by:
     classifier_path: crates/apr-cli/src/commands/embeddings_classifier.rs
+    cli_path: crates/apr-cli/src/commands/embeddings_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_c_13.rs
+    e2e_tests:
+    - falsify_crux_c_13_001_shape_ok_on_three_rows
+    - falsify_crux_c_13_001_shape_rejects_row_count_mismatch
+    - falsify_crux_c_13_001_shape_rejects_vector_dim_mismatch
+    - falsify_crux_c_13_001_shape_rejects_index_out_of_order
     sub_claim: |
       Algorithm-level necessary condition: `classify_embeddings_response_shape`
       enforces three invariants in sequence, surfacing the first violation
@@ -119,6 +126,12 @@ falsification_tests:
   if_fails: "Embeddings non-deterministic for identical input; stochastic path leaked into embedding model"
   evidence_discharged_by:
     classifier_path: crates/apr-cli/src/commands/embeddings_classifier.rs
+    cli_path: crates/apr-cli/src/commands/embeddings_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_c_13.rs
+    e2e_tests:
+    - falsify_crux_c_13_002_determinism_ok_on_identical
+    - falsify_crux_c_13_002_determinism_rejects_drift
+    - falsify_crux_c_13_002_determinism_rejects_zero_vector
     sub_claim: |
       Algorithm-level necessary conditions:
         (a) `cosine_similarity` implements the standard <a,b>/(‖a‖·‖b‖)
@@ -163,6 +176,12 @@ falsification_tests:
   if_fails: "usage fields inconsistent; billing/metering clients will mis-account tokens"
   evidence_discharged_by:
     classifier_path: crates/apr-cli/src/commands/embeddings_classifier.rs
+    cli_path: crates/apr-cli/src/commands/embeddings_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_c_13.rs
+    e2e_tests:
+    - falsify_crux_c_13_003_usage_ok_on_matching_prompt_total
+    - falsify_crux_c_13_003_usage_rejects_mismatch
+    - falsify_crux_c_13_003_usage_rejects_zero_prompt
     sub_claim: |
       Algorithm-level necessary condition: `classify_usage_tokens(prompt, total)`
       admits `Ok{prompt, total}` iff prompt ≥ 1 AND total == prompt; else
@@ -188,6 +207,13 @@ falsification_tests:
   if_fails: "apr serve lacks --embeddings-enabled flag; endpoint cannot be exposed as documented"
   evidence_discharged_by:
     classifier_path: crates/apr-cli/src/commands/embeddings_classifier.rs
+    cli_path: crates/apr-cli/src/commands/embeddings_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_c_13.rs
+    e2e_tests:
+    - falsify_crux_c_13_004_flag_bare_form_enabled
+    - falsify_crux_c_13_004_flag_equals_false_disabled
+    - falsify_crux_c_13_004_flag_rejects_wrong_expectation
+    - falsify_crux_c_13_004_flag_malformed_is_rejected
     sub_claim: |
       Algorithm-level necessary condition: `parse_embeddings_flag(argv)`
       accepts both bare (`--embeddings-enabled`) and equals forms
@@ -238,6 +264,27 @@ verification_summary:
   - falsify_id: FALSIFY-CRUX-C-13-004
     discharge_status: PARTIAL_ALGORITHM_LEVEL
     blocked_on: "clap `apr serve --embeddings-enabled` surface"
+
+ship_discipline:
+  ship_rule: CRUX-SHIP-001
+  deliverables_present:
+    classifier: crates/apr-cli/src/commands/embeddings_classifier.rs
+    cli_wiring: crates/apr-cli/src/commands/embeddings_lint.rs
+    e2e_test: crates/apr-cli/tests/falsification_crux_c_13.rs
+    contract: contracts/crux-C-13-v1.yaml
+  merge_gates:
+    g1_classifier_green: true
+    g2_cli_reachable: true
+    g3_e2e_runs: true
+    g4_contract_discharged: PARTIAL_ALGORITHM_LEVEL
+  notes: >
+    `apr embeddings-lint --observation-file <obs.json>` dispatches four
+    classifiers (shape, determinism, usage, flag) over a captured JSON
+    observation. e2e suite (19 tests) exercises help surface, bare-
+    invocation rejection, per-gate ok+reject paths, empty/nonexistent
+    file rejection, and --json shape. Full ACTIVE discharge remains
+    blocked on live /v1/embeddings handler in aprender-serve + clap
+    `--embeddings-enabled` surface on `apr serve`.
 
 pmat_work_tracking:
   ticket_tag: crux-crux-c-13

--- a/contracts/crux-C-13-v1.yaml
+++ b/contracts/crux-C-13-v1.yaml
@@ -1,33 +1,29 @@
 # CRUX-C-13 — /v1/embeddings endpoint
-# Auto-scaffolded from crux-competitive-research-ux-v1.yaml (DRAFT).
-# DO NOT promote to ACTIVE until: (1) evidence collected, (2) falsification
-# body reflects competitor's canonical CLI, (3) apr surface mapped or gap
-# tracked in pmat work (see master §12).
 
 metadata:
   id: CRUX-C-13
-  version: "1.0.0-draft"
+  version: "1.1.0"
   created: "2026-04-18"
   author: PAIML Engineering
   registry: true
-  status: draft
+  status: partial
   parent_contracts:
   - crux-competitive-research-ux-v1
   category: "C — Serving & Chat UX"
   competitor: llama_cpp
-  demand_score: 5  # 1..5, critical priority in pmat work
+  demand_score: 5
   intake_status: missing
   description: >
-    /v1/embeddings endpoint. Root-cause workflow extracted from llama_cpp UX — see master
-    subspec §5.C and §2 Five Whys methodology for rationale. This
-    draft contract exists to satisfy the Iron Rule "no contract → no user
-    story"; the falsification body below is a placeholder and MUST be
-    replaced with the competitor's canonical CLI transcript before promotion.
+    /v1/embeddings endpoint. Root-cause workflow extracted from
+    llama_cpp UX — see master subspec §5.C. OpenAI-compatible response
+    shape; deterministic embeddings; honest usage accounting; CLI
+    `--embeddings-enabled` surface.
 
   references:
   - 'master: contracts/crux-competitive-research-ux-v1.yaml — §5 + §12'
-  - github.com/huggingface/accelerate
-  - github.com/pytorch/pytorch — DDP/FSDP
+  - 'https://platform.openai.com/docs/api-reference/embeddings'
+  - 'https://github.com/ggerganov/llama.cpp/blob/master/examples/server/README.md'
+
 equations:
   embeddings_response_schema:
     formula: |
@@ -42,7 +38,6 @@ equations:
         len(response.data) == len(request.input)      (1 vector per input)
         ∀ i: len(response.data[i].embedding) == H      (H = model.hidden_size)
         response.data[i].index == i                    (preserves request order)
-      Ref: https://platform.openai.com/docs/api-reference/embeddings
     domain: POST /v1/embeddings request
     codomain: JSON response with embeddings array
     invariants:
@@ -54,12 +49,11 @@ equations:
   embedding_determinism:
     formula: |
       For identical input s at temperature-independent endpoint:
-        cosine(embed(s), embed(s)) == 1.0 ± 1e-6
-      (Embeddings MUST be deterministic for the same input on the same model.)
+        cosine(embed(s), embed(s)) >= 1 - 1e-6
     domain: string s ∈ text
     codomain: cosine similarity ∈ [-1, 1]
     invariants:
-    - "Repeated calls with identical input produce cosine == 1.0 ± 1e-6"
+    - "Repeated calls with identical input produce cosine >= 1 - 1e-6"
     - "Embedding model runs with deterministic (no-sampling) forward pass"
 
 falsification_tests:
@@ -72,7 +66,6 @@ falsification_tests:
       -d '{"model":"all-minilm","input":["text1","text2","text3"]}')
     echo "$R" | jq -e '.object == "list"' >/dev/null
     echo "$R" | jq -e '.data | length == 3' >/dev/null
-    # Hidden size is model-dependent; query metadata
     H=$(apr inspect all-minilm.apr --json | jq '.metadata.hidden_size')
     for i in 0 1 2; do
       echo "$R" | jq -e --argjson i "$i" --argjson h "$H" \
@@ -80,10 +73,33 @@ falsification_tests:
       echo "$R" | jq -e --argjson i "$i" '.data[$i].index == $i' >/dev/null
     done
   if_fails: "/v1/embeddings response length or vector dimension mismatches spec"
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/embeddings_classifier.rs
+    sub_claim: |
+      Algorithm-level necessary condition: `classify_embeddings_response_shape`
+      enforces three invariants in sequence, surfacing the first violation
+      with all fields needed to debug:
+        (a) `data.len() == input_len`  → else `RowCountMismatch`;
+        (b) ∀ row r, `r.embedding.len() == hidden_size` → else
+            `VectorDimensionMismatch { row, expected, got }`;
+        (c) ∀ row r at position i, `r.index == i` → else
+            `IndexOutOfOrder { row, expected_index, got_index }`.
+      Empty input/data pair returns `Ok{n_rows:0}` (no vacuous truth, but
+      also no spurious failure). Classifier is a pure function of the
+      (input_len, data, hidden_size) triple and thus deterministic.
+    tests:
+    - shape_ok_for_three_rows_of_hidden_size_4
+    - shape_row_count_mismatch_is_reported
+    - shape_vector_dim_mismatch_is_reported_with_row
+    - shape_index_out_of_order_is_reported
+    - shape_empty_input_empty_data_is_ok
+    scope: "(input_len, data[EmbeddingRow{index, embedding}], hidden_size) → EmbeddingsShapeOutcome (pure)"
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: "live POST /v1/embeddings handler in aprender-serve + `apr inspect --json` hidden_size surface"
 
 - id: FALSIFY-CRUX-C-13-002
-  rule: determinism — identical inputs cosine == 1.0
-  prediction: "cosine(embed(s), embed(s)) == 1.0 ± 1e-6"
+  rule: determinism — identical inputs cosine >= 1 - 1e-6
+  prediction: "cosine(embed(s), embed(s)) >= 1 - 1e-6"
   test: |
     set -euo pipefail
     R1=$(curl -s http://localhost:8080/v1/embeddings -H 'Content-Type: application/json' \
@@ -98,9 +114,42 @@ falsification_tests:
     n1 = math.sqrt(sum(a*a for a in v1))
     n2 = math.sqrt(sum(b*b for b in v2))
     cos = dot/(n1*n2)
-    assert abs(cos - 1.0) < 1e-6, f"cosine={cos}, expected 1.0"
+    assert cos >= 1.0 - 1e-6, f"cosine={cos}, expected >= 1 - 1e-6"
     PY
   if_fails: "Embeddings non-deterministic for identical input; stochastic path leaked into embedding model"
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/embeddings_classifier.rs
+    sub_claim: |
+      Algorithm-level necessary conditions:
+        (a) `cosine_similarity` implements the standard <a,b>/(‖a‖·‖b‖)
+            formula (verified on identical-nonzero, orthogonal, and
+            opposite-direction pairs); returns `None` on length
+            mismatch, empty input, or zero norm — surfacing pipeline
+            errors instead of emitting silent 0.0.
+        (b) `classify_determinism` emits `Deterministic { cosine }`
+            iff cosine ≥ 1 − tolerance (with `EMBEDDINGS_COSINE_TOLERANCE
+            = 1e-6` matching the spec); `NonDeterministic { cosine,
+            tolerance }` records the observed drift; `InvalidInput` on
+            pipeline errors.
+        (c) Tiny-perturbation test (1e-7 along a unit vector) stays
+            Deterministic at 1e-6 tolerance, proving the classifier does
+            not demand exact bit-parity.
+    tests:
+    - cosine_identical_nonzero_is_one
+    - cosine_orthogonal_is_zero
+    - cosine_opposite_is_negative_one
+    - cosine_length_mismatch_is_none
+    - cosine_zero_norm_is_none
+    - cosine_empty_vectors_is_none
+    - determinism_identical_vector_is_deterministic
+    - determinism_tiny_noise_within_tolerance_is_deterministic
+    - determinism_large_drift_is_non_deterministic
+    - determinism_zero_vector_is_invalid
+    - determinism_length_mismatch_is_invalid
+    - tolerance_constant_matches_spec
+    scope: "cosine + determinism classifier (pure f64 math over f32 vectors)"
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: "real embedding model + /v1/embeddings handler with deterministic forward pass"
 
 - id: FALSIFY-CRUX-C-13-003
   rule: usage token accounting
@@ -112,6 +161,24 @@ falsification_tests:
     echo "$R" | jq -e '.usage.total_tokens == .usage.prompt_tokens' >/dev/null
     echo "$R" | jq -e '.usage.prompt_tokens >= 1' >/dev/null
   if_fails: "usage fields inconsistent; billing/metering clients will mis-account tokens"
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/embeddings_classifier.rs
+    sub_claim: |
+      Algorithm-level necessary condition: `classify_usage_tokens(prompt, total)`
+      admits `Ok{prompt, total}` iff prompt ≥ 1 AND total == prompt; else
+      returns `PromptTokensZero` (catches the zero-input billing bug) or
+      `TotalMismatchesPrompt{prompt, total}` (catches silent completion-
+      token leakage in either direction: total > prompt OR total < prompt).
+      Deterministic on its (u64, u64) input pair.
+    tests:
+    - usage_equal_prompt_and_total_is_ok
+    - usage_zero_prompt_is_rejected_even_if_total_matches
+    - usage_total_exceeds_prompt_is_mismatch
+    - usage_total_below_prompt_is_mismatch
+    - usage_classifier_is_deterministic
+    scope: "(prompt_tokens, total_tokens) → UsageOutcome (pure u64 comparator)"
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: "/v1/embeddings handler emitting the `usage` JSON block"
 
 - id: FALSIFY-CRUX-C-13-004
   rule: CLI surface exposes --embeddings-enabled
@@ -119,6 +186,29 @@ falsification_tests:
   test: |
     apr serve --help 2>&1 | grep -qE -- '--embeddings-enabled'
   if_fails: "apr serve lacks --embeddings-enabled flag; endpoint cannot be exposed as documented"
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/embeddings_classifier.rs
+    sub_claim: |
+      Algorithm-level necessary condition: `parse_embeddings_flag(argv)`
+      accepts both bare (`--embeddings-enabled`) and equals forms
+      (`--embeddings-enabled=true|1|yes|on` / `=false|0|no|off`,
+      case-insensitive); absent ⇒ `Disabled` (default-off, matching
+      llama.cpp/vllm); unknown value ⇒ `MalformedFlag{raw}` (no silent
+      default-true, no silent default-false — the user's intent is
+      surfaced). Parser is a pure function of argv slice and
+      deterministic.
+    tests:
+    - flag_bare_form_enables
+    - flag_equals_true_enables
+    - flag_equals_1_yes_on_enable
+    - flag_equals_false_disables
+    - flag_equals_zero_no_off_disable
+    - flag_equals_garbage_is_malformed
+    - flag_absent_defaults_to_disabled
+    - flag_parser_is_deterministic
+    scope: "argv → EmbeddingsFlagOutcome (pure)"
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: "clap wiring on `apr serve --embeddings-enabled` in crates/apr-cli/src/commands/serve.rs"
 
 proof_obligations:
 - type: invariant
@@ -126,7 +216,7 @@ proof_obligations:
 - type: invariant
   property: "Every embedding vector length equals model.hidden_size"
 - type: invariant
-  property: "cosine(embed(s), embed(s)) == 1.0 ± 1e-6 (determinism)"
+  property: "cosine(embed(s), embed(s)) >= 1 - 1e-6 (determinism)"
 - type: invariant
   property: "usage.total_tokens == usage.prompt_tokens on embedding responses"
 
@@ -135,10 +225,21 @@ verification_summary:
   proven: 0
   tested: 0
   status: spec-complete
+  discharge_ledger:
+  - falsify_id: FALSIFY-CRUX-C-13-001
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    blocked_on: "live /v1/embeddings handler + `apr inspect --json` hidden_size"
+  - falsify_id: FALSIFY-CRUX-C-13-002
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    blocked_on: "real embedding model with deterministic forward pass"
+  - falsify_id: FALSIFY-CRUX-C-13-003
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    blocked_on: "/v1/embeddings handler emitting `usage` block"
+  - falsify_id: FALSIFY-CRUX-C-13-004
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    blocked_on: "clap `apr serve --embeddings-enabled` surface"
 
 pmat_work_tracking:
-  # Managed by master contract §12. If intake_status == "missing", a ticket
-  # tagged `crux-crux-c-13` is auto-created by scripts/crux_bulk_pmat_work.sh.
   ticket_tag: crux-crux-c-13
   priority: critical
   auto_created: true

--- a/crates/apr-cli/src/commands/embeddings_classifier.rs
+++ b/crates/apr-cli/src/commands/embeddings_classifier.rs
@@ -1,0 +1,480 @@
+//! CRUX-C-13 — /v1/embeddings endpoint classifier (PARTIAL_ALGORITHM_LEVEL)
+//!
+//! Pure algorithm-level discharge of the FALSIFY gates in
+//! `contracts/crux-C-13-v1.yaml`:
+//!   * FALSIFY-001 — response shape: len(data)==len(input), every vector
+//!     length == hidden_size, indices are 0..N-1 in order.
+//!   * FALSIFY-002 — determinism: cosine(v, v) ≈ 1.0 for non-zero v.
+//!   * FALSIFY-003 — usage accounting: total == prompt, prompt >= 1.
+//!   * FALSIFY-004 — CLI surface parses `--embeddings-enabled`.
+
+/// OpenAI-style embeddings determinism bound.
+pub const EMBEDDINGS_COSINE_TOLERANCE: f64 = 1e-6;
+
+/// ─── FALSIFY-C-13-001 response shape ────────────────────────────────────
+
+/// One row of `.data[]` as extracted from the JSON response.
+#[derive(Debug, Clone, PartialEq)]
+pub struct EmbeddingRow<'a> {
+    pub index: u64,
+    pub embedding: &'a [f32],
+}
+
+/// Outcome of the response-shape classifier.
+#[derive(Debug, Clone, PartialEq)]
+pub enum EmbeddingsShapeOutcome {
+    Ok {
+        n_rows: usize,
+    },
+    RowCountMismatch {
+        input_len: usize,
+        data_len: usize,
+    },
+    VectorDimensionMismatch {
+        row: usize,
+        expected: usize,
+        got: usize,
+    },
+    IndexOutOfOrder {
+        row: usize,
+        expected_index: u64,
+        got_index: u64,
+    },
+}
+
+/// Validate the response against `input_len` and `hidden_size`.
+pub fn classify_embeddings_response_shape(
+    input_len: usize,
+    data: &[EmbeddingRow<'_>],
+    hidden_size: usize,
+) -> EmbeddingsShapeOutcome {
+    if data.len() != input_len {
+        return EmbeddingsShapeOutcome::RowCountMismatch {
+            input_len,
+            data_len: data.len(),
+        };
+    }
+    for (i, row) in data.iter().enumerate() {
+        if row.embedding.len() != hidden_size {
+            return EmbeddingsShapeOutcome::VectorDimensionMismatch {
+                row: i,
+                expected: hidden_size,
+                got: row.embedding.len(),
+            };
+        }
+        if row.index != i as u64 {
+            return EmbeddingsShapeOutcome::IndexOutOfOrder {
+                row: i,
+                expected_index: i as u64,
+                got_index: row.index,
+            };
+        }
+    }
+    EmbeddingsShapeOutcome::Ok { n_rows: data.len() }
+}
+
+/// ─── FALSIFY-C-13-002 determinism / cosine ──────────────────────────────
+
+/// Cosine similarity of two vectors; `None` on length mismatch, empty
+/// input, or zero-norm on either side (ill-defined ratio).
+pub fn cosine_similarity(a: &[f32], b: &[f32]) -> Option<f64> {
+    if a.len() != b.len() || a.is_empty() {
+        return None;
+    }
+    let mut dot = 0.0f64;
+    let mut na = 0.0f64;
+    let mut nb = 0.0f64;
+    for (x, y) in a.iter().zip(b.iter()) {
+        let xf = *x as f64;
+        let yf = *y as f64;
+        dot += xf * yf;
+        na += xf * xf;
+        nb += yf * yf;
+    }
+    if na == 0.0 || nb == 0.0 {
+        return None;
+    }
+    Some(dot / (na.sqrt() * nb.sqrt()))
+}
+
+/// Outcome of the determinism classifier.
+#[derive(Debug, Clone, PartialEq)]
+pub enum DeterminismOutcome {
+    Deterministic { cosine: f64 },
+    NonDeterministic { cosine: f64, tolerance: f64 },
+    InvalidInput,
+}
+
+/// Compare two embedding vectors produced by repeated calls with the
+/// same input. Deterministic iff cosine ≥ 1.0 − tolerance (floating
+/// point wobble is tolerated within the spec's 1e-6 window).
+pub fn classify_determinism(v1: &[f32], v2: &[f32], tolerance: f64) -> DeterminismOutcome {
+    match cosine_similarity(v1, v2) {
+        None => DeterminismOutcome::InvalidInput,
+        Some(c) if c >= 1.0 - tolerance => DeterminismOutcome::Deterministic { cosine: c },
+        Some(c) => DeterminismOutcome::NonDeterministic {
+            cosine: c,
+            tolerance,
+        },
+    }
+}
+
+/// ─── FALSIFY-C-13-003 usage accounting ──────────────────────────────────
+
+/// Outcome of the usage-token classifier.
+#[derive(Debug, Clone, PartialEq)]
+pub enum UsageOutcome {
+    Ok { prompt: u64, total: u64 },
+    TotalMismatchesPrompt { prompt: u64, total: u64 },
+    PromptTokensZero,
+}
+
+/// Validate an OpenAI-style `usage` block: `total == prompt` and
+/// `prompt >= 1`. Embeddings never produce completion tokens, so any
+/// drift between total and prompt indicates mis-accounting that
+/// downstream metering clients will incorrectly bill.
+pub fn classify_usage_tokens(prompt: u64, total: u64) -> UsageOutcome {
+    if prompt == 0 {
+        return UsageOutcome::PromptTokensZero;
+    }
+    if total != prompt {
+        return UsageOutcome::TotalMismatchesPrompt { prompt, total };
+    }
+    UsageOutcome::Ok { prompt, total }
+}
+
+/// ─── FALSIFY-C-13-004 CLI surface ───────────────────────────────────────
+
+/// Outcome of the `--embeddings-enabled` argv parser.
+#[derive(Debug, Clone, PartialEq)]
+pub enum EmbeddingsFlagOutcome {
+    Enabled,
+    Disabled,
+    MalformedFlag { raw: String },
+}
+
+/// Parse `apr serve` argv looking for the `--embeddings-enabled` flag.
+/// Accepts bare (`--embeddings-enabled`) and `=` forms
+/// (`--embeddings-enabled=true|false`). Absent ⇒ `Disabled` (default off,
+/// as in llama.cpp/vllm).
+pub fn parse_embeddings_flag(argv: &[&str]) -> EmbeddingsFlagOutcome {
+    for arg in argv {
+        if *arg == "--embeddings-enabled" {
+            return EmbeddingsFlagOutcome::Enabled;
+        }
+        if let Some(val) = arg.strip_prefix("--embeddings-enabled=") {
+            return match val.to_ascii_lowercase().as_str() {
+                "true" | "1" | "yes" | "on" => EmbeddingsFlagOutcome::Enabled,
+                "false" | "0" | "no" | "off" => EmbeddingsFlagOutcome::Disabled,
+                _ => EmbeddingsFlagOutcome::MalformedFlag {
+                    raw: (*arg).to_string(),
+                },
+            };
+        }
+    }
+    EmbeddingsFlagOutcome::Disabled
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn row(index: u64, v: &[f32]) -> EmbeddingRow<'_> {
+        EmbeddingRow {
+            index,
+            embedding: v,
+        }
+    }
+
+    // ─── shape classifier ─────────────────────────────────────────────────
+
+    #[test]
+    fn shape_ok_for_three_rows_of_hidden_size_4() {
+        let a = [0.1f32; 4];
+        let b = [0.2f32; 4];
+        let c = [0.3f32; 4];
+        let data = vec![row(0, &a), row(1, &b), row(2, &c)];
+        assert_eq!(
+            classify_embeddings_response_shape(3, &data, 4),
+            EmbeddingsShapeOutcome::Ok { n_rows: 3 }
+        );
+    }
+
+    #[test]
+    fn shape_row_count_mismatch_is_reported() {
+        let a = [0.0f32; 4];
+        let data = vec![row(0, &a)];
+        assert_eq!(
+            classify_embeddings_response_shape(2, &data, 4),
+            EmbeddingsShapeOutcome::RowCountMismatch {
+                input_len: 2,
+                data_len: 1,
+            }
+        );
+    }
+
+    #[test]
+    fn shape_vector_dim_mismatch_is_reported_with_row() {
+        let a = [0.0f32; 4];
+        let b = [0.0f32; 3]; // wrong
+        let data = vec![row(0, &a), row(1, &b)];
+        assert_eq!(
+            classify_embeddings_response_shape(2, &data, 4),
+            EmbeddingsShapeOutcome::VectorDimensionMismatch {
+                row: 1,
+                expected: 4,
+                got: 3,
+            }
+        );
+    }
+
+    #[test]
+    fn shape_index_out_of_order_is_reported() {
+        let a = [0.0f32; 4];
+        let b = [0.0f32; 4];
+        let data = vec![row(0, &a), row(5, &b)];
+        assert_eq!(
+            classify_embeddings_response_shape(2, &data, 4),
+            EmbeddingsShapeOutcome::IndexOutOfOrder {
+                row: 1,
+                expected_index: 1,
+                got_index: 5,
+            }
+        );
+    }
+
+    #[test]
+    fn shape_empty_input_empty_data_is_ok() {
+        let data: Vec<EmbeddingRow<'_>> = vec![];
+        assert_eq!(
+            classify_embeddings_response_shape(0, &data, 4),
+            EmbeddingsShapeOutcome::Ok { n_rows: 0 }
+        );
+    }
+
+    // ─── cosine_similarity ────────────────────────────────────────────────
+
+    #[test]
+    fn cosine_identical_nonzero_is_one() {
+        let v = vec![1.0f32, 2.0, 3.0];
+        let c = cosine_similarity(&v, &v).unwrap();
+        assert!((c - 1.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn cosine_orthogonal_is_zero() {
+        let a = vec![1.0f32, 0.0];
+        let b = vec![0.0f32, 1.0];
+        assert!((cosine_similarity(&a, &b).unwrap()).abs() < 1e-12);
+    }
+
+    #[test]
+    fn cosine_opposite_is_negative_one() {
+        let a = vec![1.0f32, 2.0];
+        let b = vec![-1.0f32, -2.0];
+        assert!((cosine_similarity(&a, &b).unwrap() + 1.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn cosine_length_mismatch_is_none() {
+        let a = vec![1.0f32, 2.0];
+        let b = vec![1.0f32, 2.0, 3.0];
+        assert_eq!(cosine_similarity(&a, &b), None);
+    }
+
+    #[test]
+    fn cosine_zero_norm_is_none() {
+        let a = vec![0.0f32; 3];
+        let b = vec![1.0f32, 2.0, 3.0];
+        assert_eq!(cosine_similarity(&a, &b), None);
+        assert_eq!(cosine_similarity(&b, &a), None);
+    }
+
+    #[test]
+    fn cosine_empty_vectors_is_none() {
+        let a: Vec<f32> = vec![];
+        assert_eq!(cosine_similarity(&a, &a), None);
+    }
+
+    // ─── determinism classifier ───────────────────────────────────────────
+
+    #[test]
+    fn determinism_identical_vector_is_deterministic() {
+        let v = vec![0.1f32, 0.2, 0.3, 0.4];
+        match classify_determinism(&v, &v, EMBEDDINGS_COSINE_TOLERANCE) {
+            DeterminismOutcome::Deterministic { cosine } => {
+                assert!((cosine - 1.0).abs() < EMBEDDINGS_COSINE_TOLERANCE);
+            }
+            other => panic!("expected Deterministic, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn determinism_tiny_noise_within_tolerance_is_deterministic() {
+        // 1e-7 perturbation ⇒ cosine drop < 1e-6 for a unit-norm vector.
+        let v1 = vec![1.0f32, 0.0, 0.0];
+        let v2 = vec![1.0f32 - 1e-7, 0.0, 0.0];
+        match classify_determinism(&v1, &v2, EMBEDDINGS_COSINE_TOLERANCE) {
+            DeterminismOutcome::Deterministic { .. } => {}
+            other => panic!("expected Deterministic, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn determinism_large_drift_is_non_deterministic() {
+        let v1 = vec![1.0f32, 0.0, 0.0];
+        let v2 = vec![0.0f32, 1.0, 0.0];
+        match classify_determinism(&v1, &v2, EMBEDDINGS_COSINE_TOLERANCE) {
+            DeterminismOutcome::NonDeterministic { cosine, tolerance } => {
+                assert!(cosine < 1.0 - tolerance);
+                assert_eq!(tolerance, EMBEDDINGS_COSINE_TOLERANCE);
+            }
+            other => panic!("expected NonDeterministic, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn determinism_zero_vector_is_invalid() {
+        let z = vec![0.0f32; 3];
+        assert_eq!(
+            classify_determinism(&z, &z, EMBEDDINGS_COSINE_TOLERANCE),
+            DeterminismOutcome::InvalidInput
+        );
+    }
+
+    #[test]
+    fn determinism_length_mismatch_is_invalid() {
+        let a = vec![1.0f32, 2.0];
+        let b = vec![1.0f32, 2.0, 3.0];
+        assert_eq!(
+            classify_determinism(&a, &b, EMBEDDINGS_COSINE_TOLERANCE),
+            DeterminismOutcome::InvalidInput
+        );
+    }
+
+    // ─── usage classifier ─────────────────────────────────────────────────
+
+    #[test]
+    fn usage_equal_prompt_and_total_is_ok() {
+        assert_eq!(
+            classify_usage_tokens(8, 8),
+            UsageOutcome::Ok {
+                prompt: 8,
+                total: 8
+            }
+        );
+    }
+
+    #[test]
+    fn usage_zero_prompt_is_rejected_even_if_total_matches() {
+        assert_eq!(classify_usage_tokens(0, 0), UsageOutcome::PromptTokensZero);
+    }
+
+    #[test]
+    fn usage_total_exceeds_prompt_is_mismatch() {
+        assert_eq!(
+            classify_usage_tokens(5, 6),
+            UsageOutcome::TotalMismatchesPrompt {
+                prompt: 5,
+                total: 6
+            }
+        );
+    }
+
+    #[test]
+    fn usage_total_below_prompt_is_mismatch() {
+        assert_eq!(
+            classify_usage_tokens(5, 3),
+            UsageOutcome::TotalMismatchesPrompt {
+                prompt: 5,
+                total: 3
+            }
+        );
+    }
+
+    #[test]
+    fn usage_classifier_is_deterministic() {
+        assert_eq!(classify_usage_tokens(7, 7), classify_usage_tokens(7, 7));
+    }
+
+    // ─── flag parser ──────────────────────────────────────────────────────
+
+    #[test]
+    fn flag_bare_form_enables() {
+        assert_eq!(
+            parse_embeddings_flag(&["apr", "serve", "--embeddings-enabled"]),
+            EmbeddingsFlagOutcome::Enabled
+        );
+    }
+
+    #[test]
+    fn flag_equals_true_enables() {
+        assert_eq!(
+            parse_embeddings_flag(&["apr", "serve", "--embeddings-enabled=true"]),
+            EmbeddingsFlagOutcome::Enabled
+        );
+    }
+
+    #[test]
+    fn flag_equals_1_yes_on_enable() {
+        for v in ["1", "yes", "on", "True", "YES"] {
+            let arg = format!("--embeddings-enabled={}", v);
+            assert_eq!(
+                parse_embeddings_flag(&["apr", "serve", &arg]),
+                EmbeddingsFlagOutcome::Enabled,
+                "form {:?} should enable",
+                arg
+            );
+        }
+    }
+
+    #[test]
+    fn flag_equals_false_disables() {
+        assert_eq!(
+            parse_embeddings_flag(&["apr", "serve", "--embeddings-enabled=false"]),
+            EmbeddingsFlagOutcome::Disabled
+        );
+    }
+
+    #[test]
+    fn flag_equals_zero_no_off_disable() {
+        for v in ["0", "no", "off", "False", "NO"] {
+            let arg = format!("--embeddings-enabled={}", v);
+            assert_eq!(
+                parse_embeddings_flag(&["apr", "serve", &arg]),
+                EmbeddingsFlagOutcome::Disabled,
+                "form {:?} should disable",
+                arg
+            );
+        }
+    }
+
+    #[test]
+    fn flag_equals_garbage_is_malformed() {
+        match parse_embeddings_flag(&["apr", "serve", "--embeddings-enabled=maybe"]) {
+            EmbeddingsFlagOutcome::MalformedFlag { raw } => {
+                assert_eq!(raw, "--embeddings-enabled=maybe");
+            }
+            other => panic!("expected MalformedFlag, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn flag_absent_defaults_to_disabled() {
+        assert_eq!(
+            parse_embeddings_flag(&["apr", "serve", "--port", "8080"]),
+            EmbeddingsFlagOutcome::Disabled
+        );
+    }
+
+    #[test]
+    fn flag_parser_is_deterministic() {
+        let argv = &["apr", "serve", "--embeddings-enabled"];
+        assert_eq!(parse_embeddings_flag(argv), parse_embeddings_flag(argv));
+    }
+
+    #[test]
+    fn tolerance_constant_matches_spec() {
+        assert_eq!(EMBEDDINGS_COSINE_TOLERANCE, 1e-6);
+    }
+}

--- a/crates/apr-cli/src/commands/embeddings_lint.rs
+++ b/crates/apr-cli/src/commands/embeddings_lint.rs
@@ -1,0 +1,275 @@
+//! CRUX-C-13 — `apr embeddings-lint` CLI wiring (CRUX-SHIP-001 g2/g3 proof).
+//!
+//! Dispatches the four pure classifiers in `embeddings_classifier.rs` over a
+//! captured JSON observation file:
+//!
+//! ```jsonc
+//! {
+//!   "shape":       { "input_len": 3, "hidden_size": 4,
+//!                    "data": [{ "index": 0, "embedding": [0.1, 0.2, 0.3, 0.4] }, ...] },
+//!   "determinism": { "v1": [...], "v2": [...] },
+//!   "usage":       { "prompt": 8, "total": 8 },
+//!   "flag":        { "argv": ["apr", "serve", "--embeddings-enabled"] }
+//! }
+//! ```
+//!
+//! Any missing top-level key is skipped (captured observations may only
+//! cover one gate at a time). The CLI exits non-zero on any failing gate
+//! and stamps the FALSIFY id in stderr so CI log scrapers can pinpoint
+//! the violation.
+
+use crate::commands::embeddings_classifier::{
+    classify_determinism, classify_embeddings_response_shape, classify_usage_tokens,
+    parse_embeddings_flag, DeterminismOutcome, EmbeddingRow, EmbeddingsFlagOutcome,
+    EmbeddingsShapeOutcome, UsageOutcome, EMBEDDINGS_COSINE_TOLERANCE,
+};
+use serde_json::Value;
+use std::fs;
+use std::path::Path;
+
+#[derive(Debug, Clone)]
+pub struct EmbeddingsLintArgs {
+    pub observation_file: String,
+    pub json: bool,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+struct GateReport {
+    gate: &'static str,
+    falsify_id: &'static str,
+    outcome: String,
+    passed: bool,
+}
+
+pub fn run(args: EmbeddingsLintArgs) -> Result<(), String> {
+    let path = Path::new(&args.observation_file);
+    if !path.exists() {
+        return Err(format!(
+            "FALSIFY-CRUX-C-13: observation file not found: {}",
+            args.observation_file
+        ));
+    }
+    let raw = fs::read_to_string(path)
+        .map_err(|e| format!("FALSIFY-CRUX-C-13: failed to read observation: {e}"))?;
+    if raw.trim().is_empty() {
+        return Err("FALSIFY-CRUX-C-13: observation file is empty".to_string());
+    }
+    let obs: Value = serde_json::from_str(&raw)
+        .map_err(|e| format!("FALSIFY-CRUX-C-13: observation is not valid JSON: {e}"))?;
+
+    let mut reports: Vec<GateReport> = Vec::new();
+    let mut failures: Vec<String> = Vec::new();
+
+    if let Some(shape) = obs.get("shape") {
+        let (report, err) = run_shape_gate(shape);
+        reports.push(report);
+        if let Some(e) = err {
+            failures.push(e);
+        }
+    }
+    if let Some(det) = obs.get("determinism") {
+        let (report, err) = run_determinism_gate(det);
+        reports.push(report);
+        if let Some(e) = err {
+            failures.push(e);
+        }
+    }
+    if let Some(usage) = obs.get("usage") {
+        let (report, err) = run_usage_gate(usage);
+        reports.push(report);
+        if let Some(e) = err {
+            failures.push(e);
+        }
+    }
+    if let Some(flag) = obs.get("flag") {
+        let (report, err) = run_flag_gate(flag);
+        reports.push(report);
+        if let Some(e) = err {
+            failures.push(e);
+        }
+    }
+
+    if reports.is_empty() {
+        return Err(
+            "FALSIFY-CRUX-C-13: observation has none of shape/determinism/usage/flag".to_string(),
+        );
+    }
+
+    if args.json {
+        let payload = serde_json::json!({
+            "contract": "CRUX-C-13",
+            "gates": reports,
+        });
+        println!("{}", serde_json::to_string_pretty(&payload).unwrap());
+    } else {
+        for r in &reports {
+            let tag = if r.passed { "PASS" } else { "FAIL" };
+            println!("[{tag}] {} ({}): {}", r.gate, r.falsify_id, r.outcome);
+        }
+    }
+
+    if !failures.is_empty() {
+        return Err(failures.join("\n"));
+    }
+    Ok(())
+}
+
+fn run_shape_gate(v: &Value) -> (GateReport, Option<String>) {
+    let input_len = v.get("input_len").and_then(|x| x.as_u64()).unwrap_or(0) as usize;
+    let hidden_size = v.get("hidden_size").and_then(|x| x.as_u64()).unwrap_or(0) as usize;
+
+    let rows_raw: Vec<(u64, Vec<f32>)> = v
+        .get("data")
+        .and_then(|x| x.as_array())
+        .map(|arr| {
+            arr.iter()
+                .map(|row| {
+                    let index = row.get("index").and_then(|x| x.as_u64()).unwrap_or(0);
+                    let embedding: Vec<f32> = row
+                        .get("embedding")
+                        .and_then(|x| x.as_array())
+                        .map(|a| {
+                            a.iter()
+                                .filter_map(|n| n.as_f64().map(|f| f as f32))
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    (index, embedding)
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let rows: Vec<EmbeddingRow<'_>> = rows_raw
+        .iter()
+        .map(|(i, e)| EmbeddingRow {
+            index: *i,
+            embedding: e.as_slice(),
+        })
+        .collect();
+
+    let outcome = classify_embeddings_response_shape(input_len, &rows, hidden_size);
+    let passed = matches!(outcome, EmbeddingsShapeOutcome::Ok { .. });
+    let desc = format!("{outcome:?}");
+    let err = if passed {
+        None
+    } else {
+        Some(format!(
+            "FALSIFY-CRUX-C-13-001 shape gate failed: {desc}"
+        ))
+    };
+    (
+        GateReport {
+            gate: "shape",
+            falsify_id: "FALSIFY-CRUX-C-13-001",
+            outcome: desc,
+            passed,
+        },
+        err,
+    )
+}
+
+fn run_determinism_gate(v: &Value) -> (GateReport, Option<String>) {
+    let v1: Vec<f32> = v
+        .get("v1")
+        .and_then(|x| x.as_array())
+        .map(|a| {
+            a.iter()
+                .filter_map(|n| n.as_f64().map(|f| f as f32))
+                .collect()
+        })
+        .unwrap_or_default();
+    let v2: Vec<f32> = v
+        .get("v2")
+        .and_then(|x| x.as_array())
+        .map(|a| {
+            a.iter()
+                .filter_map(|n| n.as_f64().map(|f| f as f32))
+                .collect()
+        })
+        .unwrap_or_default();
+    let outcome = classify_determinism(&v1, &v2, EMBEDDINGS_COSINE_TOLERANCE);
+    let passed = matches!(outcome, DeterminismOutcome::Deterministic { .. });
+    let desc = format!("{outcome:?}");
+    let err = if passed {
+        None
+    } else {
+        Some(format!(
+            "FALSIFY-CRUX-C-13-002 determinism gate failed: {desc}"
+        ))
+    };
+    (
+        GateReport {
+            gate: "determinism",
+            falsify_id: "FALSIFY-CRUX-C-13-002",
+            outcome: desc,
+            passed,
+        },
+        err,
+    )
+}
+
+fn run_usage_gate(v: &Value) -> (GateReport, Option<String>) {
+    let prompt = v.get("prompt").and_then(|x| x.as_u64()).unwrap_or(0);
+    let total = v.get("total").and_then(|x| x.as_u64()).unwrap_or(0);
+    let outcome = classify_usage_tokens(prompt, total);
+    let passed = matches!(outcome, UsageOutcome::Ok { .. });
+    let desc = format!("{outcome:?}");
+    let err = if passed {
+        None
+    } else {
+        Some(format!(
+            "FALSIFY-CRUX-C-13-003 usage gate failed: {desc}"
+        ))
+    };
+    (
+        GateReport {
+            gate: "usage",
+            falsify_id: "FALSIFY-CRUX-C-13-003",
+            outcome: desc,
+            passed,
+        },
+        err,
+    )
+}
+
+fn run_flag_gate(v: &Value) -> (GateReport, Option<String>) {
+    let argv: Vec<String> = v
+        .get("argv")
+        .and_then(|x| x.as_array())
+        .map(|a| {
+            a.iter()
+                .filter_map(|n| n.as_str().map(|s| s.to_string()))
+                .collect()
+        })
+        .unwrap_or_default();
+    let argv_refs: Vec<&str> = argv.iter().map(String::as_str).collect();
+    let expected = v
+        .get("expected")
+        .and_then(|x| x.as_str())
+        .unwrap_or("enabled");
+    let outcome = parse_embeddings_flag(&argv_refs);
+    let observed = match &outcome {
+        EmbeddingsFlagOutcome::Enabled => "enabled",
+        EmbeddingsFlagOutcome::Disabled => "disabled",
+        EmbeddingsFlagOutcome::MalformedFlag { .. } => "malformed",
+    };
+    let passed = observed == expected;
+    let desc = format!("{outcome:?} (expected={expected}, observed={observed})");
+    let err = if passed {
+        None
+    } else {
+        Some(format!(
+            "FALSIFY-CRUX-C-13-004 flag gate failed: {desc}"
+        ))
+    };
+    (
+        GateReport {
+            gate: "flag",
+            falsify_id: "FALSIFY-CRUX-C-13-004",
+            outcome: desc,
+            passed,
+        },
+        err,
+    )
+}

--- a/crates/apr-cli/src/commands/mod.rs
+++ b/crates/apr-cli/src/commands/mod.rs
@@ -28,6 +28,7 @@ pub(crate) mod diagnose;
 pub(crate) mod dry_sampling_classifier;
 pub(crate) mod dry_sampling_lint;
 pub(crate) mod embeddings_classifier;
+pub(crate) mod embeddings_lint;
 pub(crate) mod eval;
 #[cfg(feature = "training")]
 pub(crate) mod experiment;

--- a/crates/apr-cli/src/commands/mod.rs
+++ b/crates/apr-cli/src/commands/mod.rs
@@ -27,6 +27,7 @@ pub(crate) mod diagnose;
 
 pub(crate) mod dry_sampling_classifier;
 pub(crate) mod dry_sampling_lint;
+pub(crate) mod embeddings_classifier;
 pub(crate) mod eval;
 #[cfg(feature = "training")]
 pub(crate) mod experiment;

--- a/crates/apr-cli/src/dispatch_analysis.rs
+++ b/crates/apr-cli/src/dispatch_analysis.rs
@@ -194,6 +194,14 @@ fn dispatch_analysis_commands(cli: &Cli) -> Option<Result<(), CliError>> {
         )
         .map_err(crate::error::CliError::Aprender),
 
+        ExtendedCommands::EmbeddingsLint { observation_file } => {
+            commands::embeddings_lint::run(commands::embeddings_lint::EmbeddingsLintArgs {
+                observation_file: observation_file.to_string_lossy().into_owned(),
+                json: cli.json,
+            })
+            .map_err(crate::error::CliError::Aprender)
+        }
+
         ExtendedCommands::Hex {
             file,
             tensor,

--- a/crates/apr-cli/src/extended_commands.rs
+++ b/crates/apr-cli/src/extended_commands.rs
@@ -826,6 +826,11 @@ pub enum ExtendedCommands {
         #[arg(long, value_name = "FILE")]
         observation_file: PathBuf,
     },
+    /// Lint a captured /v1/embeddings observation (CRUX-C-13)
+    EmbeddingsLint {
+        #[arg(long, value_name = "FILE")]
+        observation_file: PathBuf,
+    },
     /// Publishing, conversion, and analysis tools
     #[command(flatten)]
     Tools(ToolCommands),

--- a/crates/apr-cli/tests/cli_commands.rs
+++ b/crates/apr-cli/tests/cli_commands.rs
@@ -100,6 +100,7 @@ fn registered_commands() -> Vec<&'static str> {
         "typical-p-lint",
         "registry-quota-lint",
         "imatrix-lint",
+        "embeddings-lint",
         "oracle",
         "grad-norm",
         "encrypt",

--- a/crates/apr-cli/tests/falsification_crux_c_13.rs
+++ b/crates/apr-cli/tests/falsification_crux_c_13.rs
@@ -1,0 +1,401 @@
+//! E2E falsification tests for `apr embeddings-lint` (CRUX-C-13).
+//!
+//! Discharges g3 of CRUX-SHIP-001 for PR #973: exercise the CLI surface
+//! end-to-end on captured JSON observations and assert the classifier
+//! verdicts + non-zero exit codes on known-bad input.
+
+use std::io::Write;
+use std::process::Command;
+
+fn apr_binary() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_apr"));
+    cmd.env("NO_COLOR", "1");
+    cmd
+}
+
+fn write_tmp_json(name: &str, body: &str) -> tempfile::NamedTempFile {
+    let mut f = tempfile::Builder::new()
+        .prefix(name)
+        .suffix(".json")
+        .tempfile()
+        .expect("create tempfile");
+    f.write_all(body.as_bytes()).expect("write tempfile");
+    f.flush().expect("flush tempfile");
+    f
+}
+
+// ---- help surface (g2 proof) ----------------------------------------------
+
+#[test]
+fn falsify_crux_c_13_help_advertises_observation_file_flag() {
+    let out = apr_binary()
+        .args(["embeddings-lint", "--help"])
+        .output()
+        .expect("run apr embeddings-lint --help");
+    assert!(out.status.success(), "apr embeddings-lint --help must exit 0");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("--observation-file"),
+        "--help must advertise --observation-file; got:\n{stdout}"
+    );
+}
+
+#[test]
+fn falsify_crux_c_13_rejects_bare_invocation_without_file() {
+    let out = apr_binary()
+        .arg("embeddings-lint")
+        .output()
+        .expect("run apr embeddings-lint without args");
+    assert!(
+        !out.status.success(),
+        "bare `apr embeddings-lint` must exit non-zero"
+    );
+}
+
+// ---- shape gate (FALSIFY-CRUX-C-13-001) -----------------------------------
+
+#[test]
+fn falsify_crux_c_13_001_shape_ok_on_three_rows() {
+    let tmp = write_tmp_json(
+        "em-shape-ok",
+        r#"{ "shape": {
+               "input_len": 3,
+               "hidden_size": 4,
+               "data": [
+                 { "index": 0, "embedding": [0.1, 0.2, 0.3, 0.4] },
+                 { "index": 1, "embedding": [0.5, 0.6, 0.7, 0.8] },
+                 { "index": 2, "embedding": [0.9, 1.0, 1.1, 1.2] }
+               ]
+             } }"#,
+    );
+    let out = apr_binary()
+        .args(["embeddings-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr embeddings-lint");
+    assert!(
+        out.status.success(),
+        "shape well-formed must pass; stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn falsify_crux_c_13_001_shape_rejects_row_count_mismatch() {
+    let tmp = write_tmp_json(
+        "em-shape-rc",
+        r#"{ "shape": {
+               "input_len": 2, "hidden_size": 4,
+               "data": [ { "index": 0, "embedding": [0.1, 0.2, 0.3, 0.4] } ]
+             } }"#,
+    );
+    let out = apr_binary()
+        .args(["embeddings-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr embeddings-lint");
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-C-13-001"));
+}
+
+#[test]
+fn falsify_crux_c_13_001_shape_rejects_vector_dim_mismatch() {
+    let tmp = write_tmp_json(
+        "em-shape-dim",
+        r#"{ "shape": {
+               "input_len": 2, "hidden_size": 4,
+               "data": [
+                 { "index": 0, "embedding": [0.1, 0.2, 0.3, 0.4] },
+                 { "index": 1, "embedding": [0.5, 0.6, 0.7] }
+               ]
+             } }"#,
+    );
+    let out = apr_binary()
+        .args(["embeddings-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr embeddings-lint");
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-C-13-001"));
+}
+
+#[test]
+fn falsify_crux_c_13_001_shape_rejects_index_out_of_order() {
+    let tmp = write_tmp_json(
+        "em-shape-idx",
+        r#"{ "shape": {
+               "input_len": 2, "hidden_size": 2,
+               "data": [
+                 { "index": 0, "embedding": [0.1, 0.2] },
+                 { "index": 5, "embedding": [0.3, 0.4] }
+               ]
+             } }"#,
+    );
+    let out = apr_binary()
+        .args(["embeddings-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr embeddings-lint");
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-C-13-001"));
+}
+
+// ---- determinism gate (FALSIFY-CRUX-C-13-002) -----------------------------
+
+#[test]
+fn falsify_crux_c_13_002_determinism_ok_on_identical() {
+    let tmp = write_tmp_json(
+        "em-det-ok",
+        r#"{ "determinism": {
+               "v1": [0.1, 0.2, 0.3, 0.4],
+               "v2": [0.1, 0.2, 0.3, 0.4]
+             } }"#,
+    );
+    let out = apr_binary()
+        .args(["embeddings-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr embeddings-lint");
+    assert!(
+        out.status.success(),
+        "identical vectors must pass; stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn falsify_crux_c_13_002_determinism_rejects_drift() {
+    let tmp = write_tmp_json(
+        "em-det-drift",
+        r#"{ "determinism": {
+               "v1": [1.0, 0.0, 0.0],
+               "v2": [0.0, 1.0, 0.0]
+             } }"#,
+    );
+    let out = apr_binary()
+        .args(["embeddings-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr embeddings-lint");
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-C-13-002"));
+}
+
+#[test]
+fn falsify_crux_c_13_002_determinism_rejects_zero_vector() {
+    let tmp = write_tmp_json(
+        "em-det-zero",
+        r#"{ "determinism": { "v1": [0.0, 0.0, 0.0], "v2": [0.0, 0.0, 0.0] } }"#,
+    );
+    let out = apr_binary()
+        .args(["embeddings-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr embeddings-lint");
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-C-13-002"));
+}
+
+// ---- usage gate (FALSIFY-CRUX-C-13-003) -----------------------------------
+
+#[test]
+fn falsify_crux_c_13_003_usage_ok_on_matching_prompt_total() {
+    let tmp = write_tmp_json(
+        "em-usage-ok",
+        r#"{ "usage": { "prompt": 8, "total": 8 } }"#,
+    );
+    let out = apr_binary()
+        .args(["embeddings-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr embeddings-lint");
+    assert!(
+        out.status.success(),
+        "matching usage must pass; stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn falsify_crux_c_13_003_usage_rejects_mismatch() {
+    let tmp = write_tmp_json(
+        "em-usage-mis",
+        r#"{ "usage": { "prompt": 5, "total": 7 } }"#,
+    );
+    let out = apr_binary()
+        .args(["embeddings-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr embeddings-lint");
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-C-13-003"));
+}
+
+#[test]
+fn falsify_crux_c_13_003_usage_rejects_zero_prompt() {
+    let tmp = write_tmp_json(
+        "em-usage-zero",
+        r#"{ "usage": { "prompt": 0, "total": 0 } }"#,
+    );
+    let out = apr_binary()
+        .args(["embeddings-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr embeddings-lint");
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-C-13-003"));
+}
+
+// ---- flag gate (FALSIFY-CRUX-C-13-004) ------------------------------------
+
+#[test]
+fn falsify_crux_c_13_004_flag_bare_form_enabled() {
+    let tmp = write_tmp_json(
+        "em-flag-bare",
+        r#"{ "flag": {
+               "argv": ["apr", "serve", "--embeddings-enabled"],
+               "expected": "enabled"
+             } }"#,
+    );
+    let out = apr_binary()
+        .args(["embeddings-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr embeddings-lint");
+    assert!(
+        out.status.success(),
+        "bare flag must enable; stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn falsify_crux_c_13_004_flag_equals_false_disabled() {
+    let tmp = write_tmp_json(
+        "em-flag-false",
+        r#"{ "flag": {
+               "argv": ["apr", "serve", "--embeddings-enabled=false"],
+               "expected": "disabled"
+             } }"#,
+    );
+    let out = apr_binary()
+        .args(["embeddings-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr embeddings-lint");
+    assert!(
+        out.status.success(),
+        "=false must be disabled; stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn falsify_crux_c_13_004_flag_rejects_wrong_expectation() {
+    let tmp = write_tmp_json(
+        "em-flag-wrong",
+        r#"{ "flag": {
+               "argv": ["apr", "serve", "--embeddings-enabled=false"],
+               "expected": "enabled"
+             } }"#,
+    );
+    let out = apr_binary()
+        .args(["embeddings-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr embeddings-lint");
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-C-13-004"));
+}
+
+#[test]
+fn falsify_crux_c_13_004_flag_malformed_is_rejected() {
+    let tmp = write_tmp_json(
+        "em-flag-malformed",
+        r#"{ "flag": {
+               "argv": ["apr", "serve", "--embeddings-enabled=maybe"],
+               "expected": "enabled"
+             } }"#,
+    );
+    let out = apr_binary()
+        .args(["embeddings-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr embeddings-lint");
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-C-13-004"));
+}
+
+// ---- input validation -----------------------------------------------------
+
+#[test]
+fn falsify_crux_c_13_empty_file_rejected_via_cli() {
+    let tmp = write_tmp_json("em-empty", "");
+    let out = apr_binary()
+        .args(["embeddings-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr embeddings-lint");
+    assert!(!out.status.success(), "empty file must be rejected");
+}
+
+#[test]
+fn falsify_crux_c_13_nonexistent_file_rejected() {
+    let out = apr_binary()
+        .args([
+            "embeddings-lint",
+            "--observation-file",
+            "/nonexistent/path/obs.json",
+        ])
+        .output()
+        .expect("run apr embeddings-lint");
+    assert!(!out.status.success());
+}
+
+// ---- --json shape ---------------------------------------------------------
+
+#[test]
+fn falsify_crux_c_13_json_output_shape() {
+    let tmp = write_tmp_json(
+        "em-json",
+        r#"{
+          "shape": {
+            "input_len": 1, "hidden_size": 2,
+            "data": [ { "index": 0, "embedding": [0.1, 0.2] } ]
+          },
+          "determinism": {
+            "v1": [0.1, 0.2, 0.3],
+            "v2": [0.1, 0.2, 0.3]
+          },
+          "usage": { "prompt": 4, "total": 4 },
+          "flag": {
+            "argv": ["apr", "serve", "--embeddings-enabled"],
+            "expected": "enabled"
+          }
+        }"#,
+    );
+    let out = apr_binary()
+        .args(["--json", "embeddings-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr embeddings-lint --json");
+    assert!(
+        out.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("\"shape\""));
+    assert!(stdout.contains("\"determinism\""));
+    assert!(stdout.contains("\"usage\""));
+    assert!(stdout.contains("\"flag\""));
+}


### PR DESCRIPTION
## Summary

Discharges `contracts/crux-C-13-v1.yaml` FALSIFY gates at the pure algorithm level. Full discharge blocks on the live `/v1/embeddings` handler in `aprender-serve` + a real embedding model with deterministic forward pass.

- **FALSIFY-CRUX-C-13-001** — response shape: `len(data)==len(input)`, every vector length equals `hidden_size`, indices preserve request order.
- **FALSIFY-CRUX-C-13-002** — determinism: `cosine(embed(s), embed(s)) >= 1 − 1e-6`.
- **FALSIFY-CRUX-C-13-003** — usage accounting: `total == prompt`, `prompt >= 1`.
- **FALSIFY-CRUX-C-13-004** — `--embeddings-enabled` CLI surface.

Contract: v1.0.0-draft → v1.1.0, status `draft` → `partial`.

## Approach

Pure algorithm-level discharge in `crates/apr-cli/src/commands/embeddings_classifier.rs`:

| Classifier | Inputs | Guarantees |
|---|---|---|
| `classify_embeddings_response_shape` | `(input_len, data[EmbeddingRow], hidden_size)` | Sequentially checks row-count, per-row dimension, index order. First failure surfaced with context. |
| `cosine_similarity` | `(a: &[f32], b: &[f32])` | Returns `Option<f64>`; `None` on length mismatch, empty, or zero-norm. |
| `classify_determinism` | `(v1, v2, tolerance)` | `Deterministic` iff cosine ≥ 1 − tolerance; tiny 1e-7 noise still OK. |
| `classify_usage_tokens` | `(prompt: u64, total: u64)` | Rejects `prompt=0` and any `total != prompt` (both directions). |
| `parse_embeddings_flag` | `argv: &[&str]` | Bare + `=` forms, case-insensitive bool; absent → Disabled; garbage → `MalformedFlag{raw}`. |

## Key design decisions

- **No silent zeros**: `cosine_similarity` returning `Option` instead of 0.0 on ill-defined input surfaces pipeline bugs instead of masking them as "orthogonal".
- **No silent defaults on malformed flag**: `--embeddings-enabled=maybe` returns `MalformedFlag`, not a falsely confident Enabled/Disabled.
- **Absent flag = Disabled** matches llama.cpp/vllm default-off behavior.

## Tests (30 pass, 0 fail)

Shape (5) • cosine (6) • determinism (5) • usage (5) • flag parser (8) • tolerance constant (1).

## Validation

`pv validate contracts/crux-C-13-v1.yaml` → `0 error(s), 0 warning(s)`.

## Test plan

- [x] `cargo test -p apr-cli --lib commands::embeddings_classifier` → 30/30 green
- [x] `cargo clippy -p apr-cli --lib -- -D warnings` clean
- [x] `pv validate` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)