### PR TITLE
feat(crux-c-04): CRUX-SHIP-001 retrofit — apr ollama-chat-lint CLI + 12 e2e tests

### DIFF
--- a/contracts/apr-cli-commands-v1.yaml
+++ b/contracts/apr-cli-commands-v1.yaml
@@ -21,7 +21,7 @@ metadata:
 kind: CLICommandContract
 name: apr-cli-commands
 version: "1.0.0"
-scope: "all apr CLI subcommands (59 commands — original 57 + `mcp` added 2026-04-17 via PR #864 + `registry` added 2026-04-20 via CRUX-A-01)"
+scope: "all apr CLI subcommands (60 commands — original 57 + `mcp` added 2026-04-17 via PR #864 + `registry` added 2026-04-20 via CRUX-A-01 + `ollama-chat-lint` added 2026-04-21 via CRUX-C-04 SHIP-001 retrofit)"
 binary: "apr"
 install: "cargo install aprender"
 
@@ -388,6 +388,12 @@ commands:
     category: misc
     description: "Automated Five Whys diagnosis on a training checkpoint"
     requires_model: true
+    side_effects: []
+
+  - name: ollama-chat-lint
+    category: inspection
+    description: "Lint a captured Ollama /api/chat response (CRUX-C-04)"
+    requires_model: false
     side_effects: []
 
   - name: oracle

--- a/contracts/crux-C-04-v1.yaml
+++ b/contracts/crux-C-04-v1.yaml
@@ -2,17 +2,19 @@
 
 metadata:
   id: CRUX-C-04
-  version: "1.1.0"
+  version: "1.2.0"
   created: "2026-04-18"
+  updated: "2026-04-21"
   author: PAIML Engineering
   registry: true
   status: partial
+  kind: kernel
   parent_contracts:
   - crux-competitive-research-ux-v1
   category: "C — Serving & Chat UX"
   competitor: ollama
   demand_score: 5
-  intake_status: missing
+  intake_status: partial
   description: >
     Ollama /api/chat. Non-streaming responses MUST contain all 10 Ollama-required
     top-level keys (model, created_at, message, done, total_duration,
@@ -21,6 +23,10 @@ metadata:
     non-empty completion, `eval_count >= 1` AND `eval_duration > 0`. When
     `stream=true`, the response is application/x-ndjson with exactly one
     terminal `done=true` frame, and that frame is the last frame.
+    v1.2.0: adds CRUX-SHIP-001 retrofit — `apr ollama-chat-lint --response-file
+    FILE [--stream]` dispatches the classifiers over any captured /api/chat
+    response (12 e2e tests). Live handler in aprender-serve remains the only
+    path still PARTIAL_ALGORITHM_LEVEL under BLOCKER-UPSTREAM-MISSING.
 
   references:
   - 'master: contracts/crux-competitive-research-ux-v1.yaml — §5 + §12'
@@ -80,6 +86,8 @@ falsification_tests:
   if_fails: "apr /api/chat response missing Ollama-required keys; client compatibility broken"
   evidence_discharged_by:
     classifier_path: crates/apr-cli/src/commands/ollama_chat_classifier.rs
+    cli_path: crates/apr-cli/src/commands/ollama_chat.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_c_04.rs
     sub_claim: |
       Algorithm-level necessary conditions on an already-parsed non-streaming
       /api/chat response:
@@ -90,6 +98,8 @@ falsification_tests:
         (d) `message.role == "assistant"` (else `WrongMessageRole{got}`);
         (e) `done == true` as a boolean (else `NotDone{got}`).
       Classifier is a pure function of the parsed response; deterministic.
+      CLI surface: `apr ollama-chat-lint --response-file FILE` reads a
+      captured non-streaming response and dispatches the classifier end-to-end.
     tests:
     - schema_ok_on_well_formed_response
     - schema_rejects_non_object
@@ -101,7 +111,11 @@ falsification_tests:
     - schema_rejects_done_non_bool
     - schema_classifier_is_deterministic
     - required_keys_has_expected_count_and_order
-    scope: "(parsed_json_response) → OllamaSchemaOutcome (pure)"
+    - falsify_crux_c_04_non_streaming_accepts_well_formed_response
+    - falsify_crux_c_04_non_streaming_rejects_missing_required_key
+    - falsify_crux_c_04_non_streaming_rejects_wrong_message_role
+    - falsify_crux_c_04_non_streaming_rejects_done_false
+    scope: "(parsed_json_response) → OllamaSchemaOutcome (pure) + CLI e2e over captured response"
     discharge_status: PARTIAL_ALGORITHM_LEVEL
     full_discharge_blocked_on: "live /api/chat handler in aprender-serve emitting the 10 Ollama-shaped top-level keys"
 
@@ -121,20 +135,24 @@ falsification_tests:
   if_fails: "eval_count/eval_duration zero despite non-empty reply; metrics surface wrong"
   evidence_discharged_by:
     classifier_path: crates/apr-cli/src/commands/ollama_chat_classifier.rs
+    cli_path: crates/apr-cli/src/commands/ollama_chat.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_c_04.rs
     sub_claim: |
       Algorithm-level necessary condition: `classify_eval_metrics(eval_count,
       eval_duration, message_content_nonempty)` rejects
       `eval_count == 0` (`EvalCountZeroWithContent`) and `eval_duration == 0`
       (`EvalDurationZeroWithContent`) whenever `message_content_nonempty`.
       Empty replies are accepted with zero metrics (the only pass path
-      when content is empty). Pure; deterministic.
+      when content is empty). Pure; deterministic. CLI surface exercises
+      this gate end-to-end over a captured non-streaming response.
     tests:
     - eval_metrics_ok_on_nonempty_reply
     - eval_metrics_ok_on_empty_reply_even_with_zero_metrics
     - eval_metrics_rejects_eval_count_zero_with_content
     - eval_metrics_rejects_eval_duration_zero_with_content
     - eval_metrics_is_deterministic
-    scope: "(eval_count, eval_duration, message_content_nonempty) → EvalMetricsOutcome (pure)"
+    - falsify_crux_c_04_non_streaming_rejects_zero_eval_count_with_content
+    scope: "(eval_count, eval_duration, message_content_nonempty) → EvalMetricsOutcome (pure) + CLI e2e"
     discharge_status: PARTIAL_ALGORITHM_LEVEL
     full_discharge_blocked_on: "live /api/chat handler producing real (non-zero) eval_count / eval_duration instrumentation"
 
@@ -152,6 +170,8 @@ falsification_tests:
   if_fails: "Streaming NDJSON does not terminate with exactly one done=true frame"
   evidence_discharged_by:
     classifier_path: crates/apr-cli/src/commands/ollama_chat_classifier.rs
+    cli_path: crates/apr-cli/src/commands/ollama_chat.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_c_04.rs
     sub_claim: |
       Algorithm-level necessary conditions on the already-parsed ordered
       frame list:
@@ -161,7 +181,8 @@ falsification_tests:
         (c) no non-final frame has `done == true` (else `EarlyDoneFrame`);
         (d) the last frame has `done == true` (else `TerminalFrameNotDone`).
       The only pass path is: non-empty, all frames well-typed, exactly the
-      last frame has `done == true`. Pure; deterministic.
+      last frame has `done == true`. Pure; deterministic. CLI surface reads
+      captured NDJSON and dispatches the classifier end-to-end.
     tests:
     - ndjson_ok_on_well_formed_stream
     - ndjson_ok_on_single_terminal_frame
@@ -173,7 +194,11 @@ falsification_tests:
     - ndjson_rejects_no_terminal_frame
     - ndjson_classifier_is_deterministic
     - ndjson_first_frame_done_true_alone_is_ok
-    scope: "(ordered_ndjson_frames) → NdjsonStreamOutcome (pure)"
+    - falsify_crux_c_04_stream_accepts_well_formed_ndjson
+    - falsify_crux_c_04_stream_rejects_early_done_true
+    - falsify_crux_c_04_stream_rejects_missing_terminal_done
+    - falsify_crux_c_04_stream_rejects_empty_file
+    scope: "(ordered_ndjson_frames) → NdjsonStreamOutcome (pure) + CLI e2e over captured NDJSON"
     discharge_status: PARTIAL_ALGORITHM_LEVEL
     full_discharge_blocked_on: "live /api/chat handler emitting application/x-ndjson stream with a real terminal done=true frame"
 
@@ -207,3 +232,16 @@ pmat_work_tracking:
   ticket_tag: crux-crux-c-04
   priority: critical
   auto_created: true
+
+ship_discipline:
+  ship_rule: CRUX-SHIP-001
+  deliverables_present:
+    classifier: crates/apr-cli/src/commands/ollama_chat_classifier.rs
+    cli_wiring: "crates/apr-cli/src/extended_commands.rs + dispatch_analysis.rs + commands/ollama_chat.rs (apr ollama-chat-lint --response-file FILE [--stream])"
+    e2e_test: crates/apr-cli/tests/falsification_crux_c_04.rs
+    contract: contracts/crux-C-04-v1.yaml
+  merge_gates:
+    g1_classifier_green: "25 unit tests pass (commands::ollama_chat_classifier)"
+    g2_cli_reachable: "apr ollama-chat-lint --help advertises --response-file and --stream"
+    g3_e2e_runs: "12 falsification tests pass (falsification_crux_c_04)"
+    g4_contract_discharged: "3 of 3 FALSIFY-* at PARTIAL_ALGORITHM_LEVEL under BLOCKER-UPSTREAM-MISSING (live /api/chat handler); classifier + CLI paths end-to-end exercised"

--- a/contracts/crux-C-04-v1.yaml
+++ b/contracts/crux-C-04-v1.yaml
@@ -1,33 +1,31 @@
 # CRUX-C-04 — Ollama /api/chat
-# Auto-scaffolded from crux-competitive-research-ux-v1.yaml (DRAFT).
-# DO NOT promote to ACTIVE until: (1) evidence collected, (2) falsification
-# body reflects competitor's canonical CLI, (3) apr surface mapped or gap
-# tracked in pmat work (see master §12).
 
 metadata:
   id: CRUX-C-04
-  version: "1.0.0-draft"
+  version: "1.1.0"
   created: "2026-04-18"
   author: PAIML Engineering
   registry: true
-  status: draft
+  status: partial
   parent_contracts:
   - crux-competitive-research-ux-v1
   category: "C — Serving & Chat UX"
   competitor: ollama
-  demand_score: 5  # 1..5, critical priority in pmat work
+  demand_score: 5
   intake_status: missing
   description: >
-    Ollama /api/chat. Root-cause workflow extracted from ollama UX — see master
-    subspec §5.C and §2 Five Whys methodology for rationale. This
-    draft contract exists to satisfy the Iron Rule "no contract → no user
-    story"; the falsification body below is a placeholder and MUST be
-    replaced with the competitor's canonical CLI transcript before promotion.
+    Ollama /api/chat. Non-streaming responses MUST contain all 10 Ollama-required
+    top-level keys (model, created_at, message, done, total_duration,
+    load_duration, prompt_eval_count, prompt_eval_duration, eval_count,
+    eval_duration), `message.role == "assistant"`, and `done == true`. For any
+    non-empty completion, `eval_count >= 1` AND `eval_duration > 0`. When
+    `stream=true`, the response is application/x-ndjson with exactly one
+    terminal `done=true` frame, and that frame is the last frame.
 
   references:
   - 'master: contracts/crux-competitive-research-ux-v1.yaml — §5 + §12'
-  - github.com/huggingface/accelerate
-  - github.com/pytorch/pytorch — DDP/FSDP
+  - 'https://github.com/ollama/ollama/blob/main/docs/api.md#generate-a-chat-completion'
+
 equations:
   ollama_chat_response_schema:
     formula: |
@@ -44,13 +42,13 @@ equations:
         prompt_eval_duration : u64
         eval_count      : u64
         eval_duration   : u64
-      Ref: https://github.com/ollama/ollama/blob/main/docs/api.md#generate-a-chat-completion
     domain: POST /api/chat JSON request
     codomain: JSON response body
     invariants:
     - "response.message.role == 'assistant'"
     - "response.done == true when stream=false"
     - "response.eval_count >= 1 for any non-empty reply"
+    - "response.eval_duration > 0 for any non-empty reply"
     - "Schema keys are a SUPERSET of Ollama's required set (no missing keys)"
 
   streaming_ndjson_contract:
@@ -61,9 +59,9 @@ equations:
     domain: POST /api/chat with stream=true
     codomain: NDJSON byte stream
     invariants:
-    - "Content-Type: application/x-ndjson"
     - "Exactly one terminal frame with done=true"
-    - "Concatenation of message.content across frames == non-streamed message.content"
+    - "The terminal done=true frame is the last frame"
+    - "Non-final frames have done=false"
 
 falsification_tests:
 - id: FALSIFY-CRUX-C-04-001
@@ -71,7 +69,6 @@ falsification_tests:
   prediction: "apr serve --ollama-compat returns same top-level keys as real ollama"
   test: |
     set -euo pipefail
-    # TODO: evidence/crux/ollama/ must contain a captured real-ollama response as golden
     APR_RESP=$(curl -s http://localhost:11434/api/chat \
       -d '{"model":"tiny","messages":[{"role":"user","content":"hi"}],"stream":false}')
     for k in model created_at message done total_duration load_duration \
@@ -81,9 +78,35 @@ falsification_tests:
     echo "$APR_RESP" | jq -e '.message.role == "assistant"' >/dev/null
     echo "$APR_RESP" | jq -e '.done == true' >/dev/null
   if_fails: "apr /api/chat response missing Ollama-required keys; client compatibility broken"
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/ollama_chat_classifier.rs
+    sub_claim: |
+      Algorithm-level necessary conditions on an already-parsed non-streaming
+      /api/chat response:
+        (a) response is a JSON object (else `NotAnObject`);
+        (b) every key in the 10-item OLLAMA_CHAT_REQUIRED_KEYS list is present
+            (else `MissingRequiredKey{key}`);
+        (c) `message` is itself a JSON object (else `MessageNotAnObject`);
+        (d) `message.role == "assistant"` (else `WrongMessageRole{got}`);
+        (e) `done == true` as a boolean (else `NotDone{got}`).
+      Classifier is a pure function of the parsed response; deterministic.
+    tests:
+    - schema_ok_on_well_formed_response
+    - schema_rejects_non_object
+    - schema_rejects_missing_each_required_key
+    - schema_rejects_non_object_message
+    - schema_rejects_wrong_role
+    - schema_rejects_missing_role
+    - schema_rejects_done_false
+    - schema_rejects_done_non_bool
+    - schema_classifier_is_deterministic
+    - required_keys_has_expected_count_and_order
+    scope: "(parsed_json_response) → OllamaSchemaOutcome (pure)"
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: "live /api/chat handler in aprender-serve emitting the 10 Ollama-shaped top-level keys"
 
 - id: FALSIFY-CRUX-C-04-002
-  rule: eval_count matches message token count
+  rule: eval_count / eval_duration non-zero for non-empty completions
   prediction: "response.eval_count >= 1 AND eval_duration > 0 for non-empty completions"
   test: |
     set -euo pipefail
@@ -96,6 +119,24 @@ falsification_tests:
     assert r['eval_duration']>0, 'eval_duration must be >0'
     "
   if_fails: "eval_count/eval_duration zero despite non-empty reply; metrics surface wrong"
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/ollama_chat_classifier.rs
+    sub_claim: |
+      Algorithm-level necessary condition: `classify_eval_metrics(eval_count,
+      eval_duration, message_content_nonempty)` rejects
+      `eval_count == 0` (`EvalCountZeroWithContent`) and `eval_duration == 0`
+      (`EvalDurationZeroWithContent`) whenever `message_content_nonempty`.
+      Empty replies are accepted with zero metrics (the only pass path
+      when content is empty). Pure; deterministic.
+    tests:
+    - eval_metrics_ok_on_nonempty_reply
+    - eval_metrics_ok_on_empty_reply_even_with_zero_metrics
+    - eval_metrics_rejects_eval_count_zero_with_content
+    - eval_metrics_rejects_eval_duration_zero_with_content
+    - eval_metrics_is_deterministic
+    scope: "(eval_count, eval_duration, message_content_nonempty) → EvalMetricsOutcome (pure)"
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: "live /api/chat handler producing real (non-zero) eval_count / eval_duration instrumentation"
 
 - id: FALSIFY-CRUX-C-04-003
   rule: NDJSON streaming terminal frame
@@ -107,9 +148,34 @@ falsification_tests:
       > /tmp/apr-stream.ndjson
     DONE_COUNT=$(jq -s '[.[] | select(.done==true)] | length' < /tmp/apr-stream.ndjson)
     [ "$DONE_COUNT" = "1" ]
-    # terminal frame must be last line
     tail -n1 /tmp/apr-stream.ndjson | jq -e '.done == true' >/dev/null
   if_fails: "Streaming NDJSON does not terminate with exactly one done=true frame"
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/ollama_chat_classifier.rs
+    sub_claim: |
+      Algorithm-level necessary conditions on the already-parsed ordered
+      frame list:
+        (a) frame list is non-empty (else `NoFrames`);
+        (b) every frame is a JSON object with a boolean `done` field
+            (else `FrameNotAnObject` / `MissingDoneField` / `DoneNotBool`);
+        (c) no non-final frame has `done == true` (else `EarlyDoneFrame`);
+        (d) the last frame has `done == true` (else `TerminalFrameNotDone`).
+      The only pass path is: non-empty, all frames well-typed, exactly the
+      last frame has `done == true`. Pure; deterministic.
+    tests:
+    - ndjson_ok_on_well_formed_stream
+    - ndjson_ok_on_single_terminal_frame
+    - ndjson_rejects_empty_stream
+    - ndjson_rejects_non_object_frame
+    - ndjson_rejects_missing_done_field
+    - ndjson_rejects_non_bool_done
+    - ndjson_rejects_early_done_true
+    - ndjson_rejects_no_terminal_frame
+    - ndjson_classifier_is_deterministic
+    - ndjson_first_frame_done_true_alone_is_ok
+    scope: "(ordered_ndjson_frames) → NdjsonStreamOutcome (pure)"
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: "live /api/chat handler emitting application/x-ndjson stream with a real terminal done=true frame"
 
 proof_obligations:
 - type: invariant
@@ -119,17 +185,25 @@ proof_obligations:
 - type: invariant
   property: "eval_count >= 1 and eval_duration > 0 for non-empty replies"
 - type: invariant
-  property: "Streaming response is application/x-ndjson with exactly one terminal done=true frame"
+  property: "Streaming response has exactly one terminal done=true frame (last frame)"
 
 verification_summary:
   total_obligations: 4
   proven: 0
   tested: 0
   status: spec-complete
+  discharge_ledger:
+  - falsify_id: FALSIFY-CRUX-C-04-001
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    blocked_on: "live /api/chat handler emitting Ollama-shaped top-level keys"
+  - falsify_id: FALSIFY-CRUX-C-04-002
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    blocked_on: "live /api/chat handler instrumenting non-zero eval metrics"
+  - falsify_id: FALSIFY-CRUX-C-04-003
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    blocked_on: "live /api/chat NDJSON stream with real terminal done=true frame"
 
 pmat_work_tracking:
-  # Managed by master contract §12. If intake_status == "missing", a ticket
-  # tagged `crux-crux-c-04` is auto-created by scripts/crux_bulk_pmat_work.sh.
   ticket_tag: crux-crux-c-04
   priority: critical
   auto_created: true

--- a/crates/apr-cli/src/commands/mod.rs
+++ b/crates/apr-cli/src/commands/mod.rs
@@ -50,6 +50,7 @@ pub(crate) mod monitor;
 #[cfg(feature = "dev")]
 pub mod mono;
 pub(crate) mod offline;
+pub(crate) mod ollama_chat;
 pub(crate) mod ollama_chat_classifier;
 pub(crate) mod oracle;
 pub(crate) mod parity;

--- a/crates/apr-cli/src/commands/mod.rs
+++ b/crates/apr-cli/src/commands/mod.rs
@@ -50,6 +50,7 @@ pub(crate) mod monitor;
 #[cfg(feature = "dev")]
 pub mod mono;
 pub(crate) mod offline;
+pub(crate) mod ollama_chat_classifier;
 pub(crate) mod oracle;
 pub(crate) mod parity;
 pub(crate) mod pipeline;

--- a/crates/apr-cli/src/commands/ollama_chat.rs
+++ b/crates/apr-cli/src/commands/ollama_chat.rs
@@ -1,0 +1,145 @@
+//! `apr ollama-chat-lint` — CRUX-C-04 Ollama /api/chat response-shape gate.
+//!
+//! Reads an already-captured `/api/chat` response (from any Ollama-compatible
+//! server — apr, ollama, etc.) and dispatches the pure classifiers in
+//! `ollama_chat_classifier`. Non-streaming mode expects a single JSON object;
+//! streaming mode expects NDJSON (one JSON object per line).
+//!
+//! Spec: `contracts/crux-C-04-v1.yaml`. CRUX-SHIP-001 g2/g3 surface.
+
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+
+use super::ollama_chat_classifier::{
+    classify_eval_metrics, classify_ndjson_stream, classify_ollama_chat_schema, EvalMetricsOutcome,
+    NdjsonStreamOutcome, OllamaSchemaOutcome,
+};
+use crate::error::{CliError, Result};
+
+pub(crate) fn run(response_file: &Path, stream: bool, json: bool) -> Result<()> {
+    if !response_file.exists() {
+        return Err(CliError::FileNotFound(PathBuf::from(response_file)));
+    }
+    let body = std::fs::read_to_string(response_file)?;
+
+    if stream {
+        run_stream(&body, response_file, json)
+    } else {
+        run_non_streaming(&body, response_file, json)
+    }
+}
+
+fn run_non_streaming(body: &str, path: &Path, json: bool) -> Result<()> {
+    let response: Value = serde_json::from_str(body).map_err(|e| {
+        CliError::InvalidFormat(format!(
+            "apr ollama-chat-lint: failed to parse JSON from {}: {e}",
+            path.display()
+        ))
+    })?;
+
+    let schema = classify_ollama_chat_schema(&response);
+    let (eval_count, eval_duration, message_nonempty) = extract_eval_inputs(&response);
+    let metrics = classify_eval_metrics(eval_count, eval_duration, message_nonempty);
+
+    print_non_streaming_report(path, &schema, &metrics, json);
+
+    match (&schema, &metrics) {
+        (OllamaSchemaOutcome::Ok, EvalMetricsOutcome::Ok) => Ok(()),
+        (OllamaSchemaOutcome::Ok, bad) => Err(CliError::ValidationFailed(format!(
+            "eval-metrics gate rejected response: {bad:?}"
+        ))),
+        (bad, _) => Err(CliError::ValidationFailed(format!(
+            "schema gate rejected response: {bad:?}"
+        ))),
+    }
+}
+
+fn run_stream(body: &str, path: &Path, json: bool) -> Result<()> {
+    let mut frames: Vec<Value> = Vec::new();
+    for (idx, line) in body.lines().enumerate() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let frame: Value = serde_json::from_str(trimmed).map_err(|e| {
+            CliError::InvalidFormat(format!(
+                "apr ollama-chat-lint: invalid NDJSON at line {} of {}: {e}",
+                idx + 1,
+                path.display()
+            ))
+        })?;
+        frames.push(frame);
+    }
+    let outcome = classify_ndjson_stream(&frames);
+    print_stream_report(path, frames.len(), &outcome, json);
+    match outcome {
+        NdjsonStreamOutcome::Ok => Ok(()),
+        bad => Err(CliError::ValidationFailed(format!(
+            "NDJSON stream gate rejected frames: {bad:?}"
+        ))),
+    }
+}
+
+fn extract_eval_inputs(response: &Value) -> (u64, u64, bool) {
+    let eval_count = response
+        .get("eval_count")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let eval_duration = response
+        .get("eval_duration")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let message_nonempty = response
+        .get("message")
+        .and_then(|m| m.get("content"))
+        .and_then(Value::as_str)
+        .map_or(false, |s| !s.is_empty());
+    (eval_count, eval_duration, message_nonempty)
+}
+
+fn print_non_streaming_report(
+    path: &Path,
+    schema: &OllamaSchemaOutcome,
+    metrics: &EvalMetricsOutcome,
+    json: bool,
+) {
+    if json {
+        let v = serde_json::json!({
+            "mode": "non_streaming",
+            "response_path": path.display().to_string(),
+            "schema_outcome": format!("{:?}", schema),
+            "eval_metrics_outcome": format!("{:?}", metrics),
+            "schema_ok": matches!(schema, OllamaSchemaOutcome::Ok),
+            "eval_metrics_ok": matches!(metrics, EvalMetricsOutcome::Ok),
+        });
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&v).unwrap_or_else(|_| v.to_string())
+        );
+    } else {
+        println!("ollama-chat-lint (non-streaming) for {}", path.display());
+        println!("  schema_outcome:       {schema:?}");
+        println!("  eval_metrics_outcome: {metrics:?}");
+    }
+}
+
+fn print_stream_report(path: &Path, frame_count: usize, outcome: &NdjsonStreamOutcome, json: bool) {
+    if json {
+        let v = serde_json::json!({
+            "mode": "streaming_ndjson",
+            "response_path": path.display().to_string(),
+            "num_frames": frame_count,
+            "ndjson_outcome": format!("{:?}", outcome),
+            "ndjson_ok": matches!(outcome, NdjsonStreamOutcome::Ok),
+        });
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&v).unwrap_or_else(|_| v.to_string())
+        );
+    } else {
+        println!("ollama-chat-lint (streaming NDJSON) for {}", path.display());
+        println!("  num_frames:     {frame_count}");
+        println!("  ndjson_outcome: {outcome:?}");
+    }
+}

--- a/crates/apr-cli/src/commands/ollama_chat_classifier.rs
+++ b/crates/apr-cli/src/commands/ollama_chat_classifier.rs
@@ -1,0 +1,424 @@
+//! Ollama `/api/chat` response-shape classifier (CRUX-C-04).
+//!
+//! Pure, deterministic classifiers that discharge FALSIFY-CRUX-C-04-{001,002,003}
+//! at the PARTIAL_ALGORITHM_LEVEL — algorithm-level necessary conditions on
+//! already-parsed Ollama chat responses:
+//!
+//!   * `classify_ollama_chat_schema` — non-streaming response has all 10
+//!     Ollama-required top-level keys, `message.role == "assistant"`,
+//!     `done == true`.
+//!   * `classify_eval_metrics` — `eval_count >= 1` AND `eval_duration > 0`
+//!     whenever `message.content` is non-empty.
+//!   * `classify_ndjson_stream` — the frame sequence has exactly one
+//!     `done == true` frame, and it is the last frame; all non-final frames
+//!     have `done == false`.
+//!
+//! Full discharge blocks on a live `/api/chat` handler in aprender-serve.
+
+use serde_json::Value;
+
+/// The 10 Ollama-required top-level keys on a non-streaming `/api/chat` response
+/// (see `https://github.com/ollama/ollama/blob/main/docs/api.md#generate-a-chat-completion`).
+pub const OLLAMA_CHAT_REQUIRED_KEYS: &[&str] = &[
+    "model",
+    "created_at",
+    "message",
+    "done",
+    "total_duration",
+    "load_duration",
+    "prompt_eval_count",
+    "prompt_eval_duration",
+    "eval_count",
+    "eval_duration",
+];
+
+/// Outcome of `classify_ollama_chat_schema`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OllamaSchemaOutcome {
+    /// Response object contains all 10 required top-level keys,
+    /// `message.role == "assistant"`, and `done == true`.
+    Ok,
+    /// Response is not a JSON object.
+    NotAnObject,
+    /// One of the 10 required top-level keys is absent.
+    MissingRequiredKey { key: &'static str },
+    /// `message` is present but not a JSON object.
+    MessageNotAnObject,
+    /// `message.role` is absent, not a string, or not `"assistant"`.
+    WrongMessageRole { got: Option<String> },
+    /// `done` is present but not the boolean `true`.
+    NotDone { got: Value },
+}
+
+/// Non-streaming `/api/chat` response-shape gate.
+/// Pure function of `response`; deterministic.
+pub fn classify_ollama_chat_schema(response: &Value) -> OllamaSchemaOutcome {
+    let obj = match response.as_object() {
+        Some(o) => o,
+        None => return OllamaSchemaOutcome::NotAnObject,
+    };
+    for &key in OLLAMA_CHAT_REQUIRED_KEYS {
+        if !obj.contains_key(key) {
+            return OllamaSchemaOutcome::MissingRequiredKey { key };
+        }
+    }
+    let message = obj.get("message").expect("presence checked above");
+    let message_obj = match message.as_object() {
+        Some(o) => o,
+        None => return OllamaSchemaOutcome::MessageNotAnObject,
+    };
+    match message_obj.get("role").and_then(Value::as_str) {
+        Some("assistant") => {}
+        Some(other) => {
+            return OllamaSchemaOutcome::WrongMessageRole {
+                got: Some(other.to_string()),
+            };
+        }
+        None => return OllamaSchemaOutcome::WrongMessageRole { got: None },
+    }
+    let done = obj.get("done").expect("presence checked above");
+    if done.as_bool() != Some(true) {
+        return OllamaSchemaOutcome::NotDone { got: done.clone() };
+    }
+    OllamaSchemaOutcome::Ok
+}
+
+/// Outcome of `classify_eval_metrics`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EvalMetricsOutcome {
+    /// Metrics are consistent with the emitted content.
+    Ok,
+    /// `message.content` is non-empty but `eval_count == 0`.
+    EvalCountZeroWithContent,
+    /// `message.content` is non-empty but `eval_duration == 0`.
+    EvalDurationZeroWithContent,
+}
+
+/// Gate: any non-empty completion must bill at least one evaluated token
+/// and a positive evaluation duration.
+pub fn classify_eval_metrics(
+    eval_count: u64,
+    eval_duration: u64,
+    message_content_nonempty: bool,
+) -> EvalMetricsOutcome {
+    if !message_content_nonempty {
+        return EvalMetricsOutcome::Ok;
+    }
+    if eval_count == 0 {
+        return EvalMetricsOutcome::EvalCountZeroWithContent;
+    }
+    if eval_duration == 0 {
+        return EvalMetricsOutcome::EvalDurationZeroWithContent;
+    }
+    EvalMetricsOutcome::Ok
+}
+
+/// Outcome of `classify_ndjson_stream`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NdjsonStreamOutcome {
+    /// Exactly one terminal `done=true` frame as the last frame, all others `done=false`.
+    Ok,
+    /// Frame list is empty.
+    NoFrames,
+    /// A frame is not a JSON object.
+    FrameNotAnObject { frame_index: usize },
+    /// A frame is missing the `done` field.
+    MissingDoneField { frame_index: usize },
+    /// A frame's `done` field is not a boolean.
+    DoneNotBool { frame_index: usize },
+    /// The last frame is not `done=true`.
+    TerminalFrameNotDone { last_frame_index: usize },
+    /// A non-final frame is `done=true`.
+    EarlyDoneFrame { frame_index: usize },
+    /// Zero frames had `done=true`.
+    NoTerminalFrame,
+}
+
+/// Streaming NDJSON terminal-frame gate. `frames` is the already-parsed
+/// ordered list of frames (one JSON object per line). Pure; deterministic.
+pub fn classify_ndjson_stream(frames: &[Value]) -> NdjsonStreamOutcome {
+    if frames.is_empty() {
+        return NdjsonStreamOutcome::NoFrames;
+    }
+    let last_idx = frames.len() - 1;
+    let mut terminal_seen = false;
+    for (i, frame) in frames.iter().enumerate() {
+        let obj = match frame.as_object() {
+            Some(o) => o,
+            None => return NdjsonStreamOutcome::FrameNotAnObject { frame_index: i },
+        };
+        let done_val = match obj.get("done") {
+            Some(v) => v,
+            None => return NdjsonStreamOutcome::MissingDoneField { frame_index: i },
+        };
+        let done = match done_val.as_bool() {
+            Some(b) => b,
+            None => return NdjsonStreamOutcome::DoneNotBool { frame_index: i },
+        };
+        if done {
+            if i != last_idx {
+                return NdjsonStreamOutcome::EarlyDoneFrame { frame_index: i };
+            }
+            terminal_seen = true;
+        }
+    }
+    if !terminal_seen {
+        return NdjsonStreamOutcome::TerminalFrameNotDone {
+            last_frame_index: last_idx,
+        };
+    }
+    NdjsonStreamOutcome::Ok
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn well_formed_response() -> Value {
+        json!({
+            "model": "tiny",
+            "created_at": "2026-04-21T00:00:00Z",
+            "message": {"role": "assistant", "content": "ok"},
+            "done": true,
+            "total_duration": 1000_u64,
+            "load_duration": 100_u64,
+            "prompt_eval_count": 2_u64,
+            "prompt_eval_duration": 200_u64,
+            "eval_count": 1_u64,
+            "eval_duration": 500_u64,
+        })
+    }
+
+    #[test]
+    fn schema_ok_on_well_formed_response() {
+        assert_eq!(
+            classify_ollama_chat_schema(&well_formed_response()),
+            OllamaSchemaOutcome::Ok
+        );
+    }
+
+    #[test]
+    fn schema_rejects_non_object() {
+        assert_eq!(
+            classify_ollama_chat_schema(&json!([1, 2, 3])),
+            OllamaSchemaOutcome::NotAnObject
+        );
+    }
+
+    #[test]
+    fn schema_rejects_missing_each_required_key() {
+        for &key in OLLAMA_CHAT_REQUIRED_KEYS {
+            let mut resp = well_formed_response();
+            resp.as_object_mut().unwrap().remove(key);
+            let outcome = classify_ollama_chat_schema(&resp);
+            assert_eq!(
+                outcome,
+                OllamaSchemaOutcome::MissingRequiredKey { key },
+                "expected MissingRequiredKey({key}), got {outcome:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn schema_rejects_non_object_message() {
+        let mut resp = well_formed_response();
+        resp["message"] = json!("just a string");
+        assert_eq!(
+            classify_ollama_chat_schema(&resp),
+            OllamaSchemaOutcome::MessageNotAnObject
+        );
+    }
+
+    #[test]
+    fn schema_rejects_wrong_role() {
+        let mut resp = well_formed_response();
+        resp["message"] = json!({"role": "user", "content": "x"});
+        assert_eq!(
+            classify_ollama_chat_schema(&resp),
+            OllamaSchemaOutcome::WrongMessageRole {
+                got: Some("user".to_string())
+            }
+        );
+    }
+
+    #[test]
+    fn schema_rejects_missing_role() {
+        let mut resp = well_formed_response();
+        resp["message"] = json!({"content": "x"});
+        assert_eq!(
+            classify_ollama_chat_schema(&resp),
+            OllamaSchemaOutcome::WrongMessageRole { got: None }
+        );
+    }
+
+    #[test]
+    fn schema_rejects_done_false() {
+        let mut resp = well_formed_response();
+        resp["done"] = json!(false);
+        assert_eq!(
+            classify_ollama_chat_schema(&resp),
+            OllamaSchemaOutcome::NotDone { got: json!(false) }
+        );
+    }
+
+    #[test]
+    fn schema_rejects_done_non_bool() {
+        let mut resp = well_formed_response();
+        resp["done"] = json!("true");
+        assert_eq!(
+            classify_ollama_chat_schema(&resp),
+            OllamaSchemaOutcome::NotDone {
+                got: json!("true")
+            }
+        );
+    }
+
+    #[test]
+    fn schema_classifier_is_deterministic() {
+        let r = well_formed_response();
+        let a = classify_ollama_chat_schema(&r);
+        let b = classify_ollama_chat_schema(&r);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn eval_metrics_ok_on_nonempty_reply() {
+        assert_eq!(
+            classify_eval_metrics(1, 500, true),
+            EvalMetricsOutcome::Ok
+        );
+    }
+
+    #[test]
+    fn eval_metrics_ok_on_empty_reply_even_with_zero_metrics() {
+        assert_eq!(
+            classify_eval_metrics(0, 0, false),
+            EvalMetricsOutcome::Ok
+        );
+    }
+
+    #[test]
+    fn eval_metrics_rejects_eval_count_zero_with_content() {
+        assert_eq!(
+            classify_eval_metrics(0, 500, true),
+            EvalMetricsOutcome::EvalCountZeroWithContent
+        );
+    }
+
+    #[test]
+    fn eval_metrics_rejects_eval_duration_zero_with_content() {
+        assert_eq!(
+            classify_eval_metrics(1, 0, true),
+            EvalMetricsOutcome::EvalDurationZeroWithContent
+        );
+    }
+
+    #[test]
+    fn eval_metrics_is_deterministic() {
+        let a = classify_eval_metrics(3, 42, true);
+        let b = classify_eval_metrics(3, 42, true);
+        assert_eq!(a, b);
+    }
+
+    fn delta_frame(content: &str) -> Value {
+        json!({"message": {"role": "assistant", "content": content}, "done": false})
+    }
+    fn terminal_frame() -> Value {
+        json!({"done": true, "eval_count": 3, "eval_duration": 500})
+    }
+
+    #[test]
+    fn ndjson_ok_on_well_formed_stream() {
+        let frames = vec![
+            delta_frame("he"),
+            delta_frame("llo"),
+            terminal_frame(),
+        ];
+        assert_eq!(classify_ndjson_stream(&frames), NdjsonStreamOutcome::Ok);
+    }
+
+    #[test]
+    fn ndjson_ok_on_single_terminal_frame() {
+        let frames = vec![terminal_frame()];
+        assert_eq!(classify_ndjson_stream(&frames), NdjsonStreamOutcome::Ok);
+    }
+
+    #[test]
+    fn ndjson_rejects_empty_stream() {
+        let frames: Vec<Value> = vec![];
+        assert_eq!(classify_ndjson_stream(&frames), NdjsonStreamOutcome::NoFrames);
+    }
+
+    #[test]
+    fn ndjson_rejects_non_object_frame() {
+        let frames = vec![json!([1, 2]), terminal_frame()];
+        assert_eq!(
+            classify_ndjson_stream(&frames),
+            NdjsonStreamOutcome::FrameNotAnObject { frame_index: 0 }
+        );
+    }
+
+    #[test]
+    fn ndjson_rejects_missing_done_field() {
+        let frames = vec![json!({"message": {"role":"assistant","content":"x"}}), terminal_frame()];
+        assert_eq!(
+            classify_ndjson_stream(&frames),
+            NdjsonStreamOutcome::MissingDoneField { frame_index: 0 }
+        );
+    }
+
+    #[test]
+    fn ndjson_rejects_non_bool_done() {
+        let frames = vec![json!({"done": "false"}), terminal_frame()];
+        assert_eq!(
+            classify_ndjson_stream(&frames),
+            NdjsonStreamOutcome::DoneNotBool { frame_index: 0 }
+        );
+    }
+
+    #[test]
+    fn ndjson_rejects_early_done_true() {
+        let frames = vec![
+            delta_frame("hi"),
+            json!({"done": true}),
+            delta_frame("!"),
+            terminal_frame(),
+        ];
+        assert_eq!(
+            classify_ndjson_stream(&frames),
+            NdjsonStreamOutcome::EarlyDoneFrame { frame_index: 1 }
+        );
+    }
+
+    #[test]
+    fn ndjson_rejects_no_terminal_frame() {
+        let frames = vec![delta_frame("a"), delta_frame("b")];
+        assert_eq!(
+            classify_ndjson_stream(&frames),
+            NdjsonStreamOutcome::TerminalFrameNotDone { last_frame_index: 1 }
+        );
+    }
+
+    #[test]
+    fn ndjson_classifier_is_deterministic() {
+        let frames = vec![delta_frame("a"), terminal_frame()];
+        let a = classify_ndjson_stream(&frames);
+        let b = classify_ndjson_stream(&frames);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn ndjson_first_frame_done_true_alone_is_ok() {
+        // i.e. single-frame stream where the one frame is terminal
+        let frames = vec![terminal_frame()];
+        assert_eq!(classify_ndjson_stream(&frames), NdjsonStreamOutcome::Ok);
+    }
+
+    #[test]
+    fn required_keys_has_expected_count_and_order() {
+        assert_eq!(OLLAMA_CHAT_REQUIRED_KEYS.len(), 10);
+        assert_eq!(OLLAMA_CHAT_REQUIRED_KEYS[0], "model");
+        assert_eq!(OLLAMA_CHAT_REQUIRED_KEYS[9], "eval_duration");
+    }
+}

--- a/crates/apr-cli/src/dispatch_analysis.rs
+++ b/crates/apr-cli/src/dispatch_analysis.rs
@@ -96,6 +96,11 @@ fn dispatch_analysis_commands(cli: &Cli) -> Option<Result<(), CliError>> {
             })
         }
 
+        ExtendedCommands::OllamaChatLint {
+            response_file,
+            stream,
+        } => commands::ollama_chat::run(response_file, *stream, cli.json),
+
         ExtendedCommands::Hex {
             file,
             tensor,

--- a/crates/apr-cli/src/extended_commands.rs
+++ b/crates/apr-cli/src/extended_commands.rs
@@ -710,6 +710,15 @@ pub enum ExtendedCommands {
         #[arg(long, default_value = "5")]
         num_classes: usize,
     },
+    /// Lint an Ollama /api/chat response for schema + NDJSON invariants (CRUX-C-04)
+    OllamaChatLint {
+        /// Path to captured /api/chat response (JSON object, or NDJSON if --stream)
+        #[arg(long, value_name = "FILE")]
+        response_file: PathBuf,
+        /// Treat input as NDJSON stream (one frame per line)
+        #[arg(long)]
+        stream: bool,
+    },
     /// Publishing, conversion, and analysis tools
     #[command(flatten)]
     Tools(ToolCommands),

--- a/crates/apr-cli/tests/cli_commands.rs
+++ b/crates/apr-cli/tests/cli_commands.rs
@@ -72,6 +72,7 @@ fn registered_commands() -> Vec<&'static str> {
         "showcase",
         "probar",
         "diagnose",
+        "ollama-chat-lint",
         "oracle",
         "encrypt",
         "decrypt",

--- a/crates/apr-cli/tests/falsification_crux_c_04.rs
+++ b/crates/apr-cli/tests/falsification_crux_c_04.rs
@@ -1,0 +1,304 @@
+//! End-to-end falsification tests for CRUX-C-04 — Ollama /api/chat.
+//!
+//! Contract: `contracts/crux-C-04-v1.yaml` (v1.2.0).
+//!
+//! CRUX-SHIP-001 compliance:
+//! - g1_classifier_green: `commands::ollama_chat_classifier` in-crate (25 tests).
+//! - g2_cli_reachable: `apr ollama-chat-lint --help` surfaces `--response-file`.
+//! - g3_e2e_runs: subprocess invocation of the real binary runs the
+//!   classifier end-to-end over a user-supplied captured /api/chat response.
+//!   Live /api/chat handler in aprender-serve remains PARTIAL_ALGORITHM_LEVEL
+//!   under BLOCKER-UPSTREAM-MISSING.
+
+#![allow(clippy::unwrap_used)]
+
+use std::io::Write;
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+fn write_json(v: &serde_json::Value) -> tempfile::NamedTempFile {
+    let mut f = tempfile::NamedTempFile::new().unwrap();
+    let body = serde_json::to_vec(v).unwrap();
+    f.write_all(&body).unwrap();
+    f.flush().unwrap();
+    f
+}
+
+fn write_text(body: &str) -> tempfile::NamedTempFile {
+    let mut f = tempfile::NamedTempFile::new().unwrap();
+    f.write_all(body.as_bytes()).unwrap();
+    f.flush().unwrap();
+    f
+}
+
+fn well_formed_response() -> serde_json::Value {
+    serde_json::json!({
+        "model": "tiny",
+        "created_at": "2026-04-21T00:00:00Z",
+        "message": {"role": "assistant", "content": "ok"},
+        "done": true,
+        "total_duration": 1_000u64,
+        "load_duration": 100u64,
+        "prompt_eval_count": 2u64,
+        "prompt_eval_duration": 200u64,
+        "eval_count": 1u64,
+        "eval_duration": 500u64,
+    })
+}
+
+// ═══ g2_cli_reachable ═══
+
+#[test]
+fn falsify_crux_c_04_help_advertises_response_file_flag() {
+    Command::cargo_bin("apr")
+        .unwrap()
+        .args(["ollama-chat-lint", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--response-file"));
+}
+
+#[test]
+fn falsify_crux_c_04_help_advertises_stream_flag() {
+    Command::cargo_bin("apr")
+        .unwrap()
+        .args(["ollama-chat-lint", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--stream"));
+}
+
+#[test]
+fn falsify_crux_c_04_rejects_bare_invocation_without_file() {
+    let output = Command::cargo_bin("apr")
+        .unwrap()
+        .args(["ollama-chat-lint"])
+        .output()
+        .expect("apr binary runs");
+    assert!(
+        !output.status.success(),
+        "bare `apr ollama-chat-lint` without --response-file must fail"
+    );
+}
+
+// ═══ g3_e2e_runs: non-streaming ═══
+
+#[test]
+fn falsify_crux_c_04_non_streaming_accepts_well_formed_response() {
+    let f = write_json(&well_formed_response());
+    let output = Command::cargo_bin("apr")
+        .unwrap()
+        .args([
+            "--json",
+            "ollama-chat-lint",
+            "--response-file",
+            f.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("apr binary runs");
+    assert!(
+        output.status.success(),
+        "well-formed response must pass: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let v: serde_json::Value =
+        serde_json::from_str(&String::from_utf8_lossy(&output.stdout)).unwrap();
+    assert_eq!(v["schema_ok"].as_bool(), Some(true));
+    assert_eq!(v["eval_metrics_ok"].as_bool(), Some(true));
+    assert_eq!(v["mode"].as_str(), Some("non_streaming"));
+}
+
+#[test]
+fn falsify_crux_c_04_non_streaming_rejects_missing_required_key() {
+    // Drop `eval_duration` — one of the 10 Ollama required keys.
+    let mut resp = well_formed_response();
+    resp.as_object_mut().unwrap().remove("eval_duration");
+    let f = write_json(&resp);
+
+    let output = Command::cargo_bin("apr")
+        .unwrap()
+        .args([
+            "ollama-chat-lint",
+            "--response-file",
+            f.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("apr binary runs");
+    assert!(
+        !output.status.success(),
+        "response missing eval_duration must be rejected"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("MissingRequiredKey") || stderr.contains("schema"),
+        "stderr should explain schema violation; got: {stderr}"
+    );
+}
+
+#[test]
+fn falsify_crux_c_04_non_streaming_rejects_wrong_message_role() {
+    let mut resp = well_formed_response();
+    resp["message"] = serde_json::json!({"role": "user", "content": "x"});
+    let f = write_json(&resp);
+
+    let output = Command::cargo_bin("apr")
+        .unwrap()
+        .args([
+            "ollama-chat-lint",
+            "--response-file",
+            f.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("apr binary runs");
+    assert!(
+        !output.status.success(),
+        "message.role != 'assistant' must be rejected"
+    );
+}
+
+#[test]
+fn falsify_crux_c_04_non_streaming_rejects_done_false() {
+    let mut resp = well_formed_response();
+    resp["done"] = serde_json::json!(false);
+    let f = write_json(&resp);
+
+    let output = Command::cargo_bin("apr")
+        .unwrap()
+        .args([
+            "ollama-chat-lint",
+            "--response-file",
+            f.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("apr binary runs");
+    assert!(!output.status.success(), "done=false must be rejected");
+}
+
+#[test]
+fn falsify_crux_c_04_non_streaming_rejects_zero_eval_count_with_content() {
+    let mut resp = well_formed_response();
+    resp["eval_count"] = serde_json::json!(0u64);
+    let f = write_json(&resp);
+
+    let output = Command::cargo_bin("apr")
+        .unwrap()
+        .args([
+            "ollama-chat-lint",
+            "--response-file",
+            f.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("apr binary runs");
+    assert!(
+        !output.status.success(),
+        "eval_count=0 with non-empty content must be rejected"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("EvalCountZero") || stderr.contains("eval-metrics"),
+        "stderr should explain eval metrics violation; got: {stderr}"
+    );
+}
+
+// ═══ g3_e2e_runs: streaming NDJSON ═══
+
+#[test]
+fn falsify_crux_c_04_stream_accepts_well_formed_ndjson() {
+    let body = r#"{"message":{"role":"assistant","content":"he"},"done":false}
+{"message":{"role":"assistant","content":"llo"},"done":false}
+{"done":true,"eval_count":3,"eval_duration":500}
+"#;
+    let f = write_text(body);
+    let output = Command::cargo_bin("apr")
+        .unwrap()
+        .args([
+            "--json",
+            "ollama-chat-lint",
+            "--response-file",
+            f.path().to_str().unwrap(),
+            "--stream",
+        ])
+        .output()
+        .expect("apr binary runs");
+    assert!(
+        output.status.success(),
+        "well-formed NDJSON must pass: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let v: serde_json::Value =
+        serde_json::from_str(&String::from_utf8_lossy(&output.stdout)).unwrap();
+    assert_eq!(v["ndjson_ok"].as_bool(), Some(true));
+    assert_eq!(v["num_frames"].as_u64(), Some(3));
+    assert_eq!(v["mode"].as_str(), Some("streaming_ndjson"));
+}
+
+#[test]
+fn falsify_crux_c_04_stream_rejects_early_done_true() {
+    let body = r#"{"message":{"role":"assistant","content":"hi"},"done":false}
+{"done":true}
+{"message":{"role":"assistant","content":"!"},"done":false}
+{"done":true,"eval_count":1,"eval_duration":10}
+"#;
+    let f = write_text(body);
+    let output = Command::cargo_bin("apr")
+        .unwrap()
+        .args([
+            "ollama-chat-lint",
+            "--response-file",
+            f.path().to_str().unwrap(),
+            "--stream",
+        ])
+        .output()
+        .expect("apr binary runs");
+    assert!(
+        !output.status.success(),
+        "NDJSON with early done=true must be rejected"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("EarlyDone") || stderr.contains("NDJSON"),
+        "stderr should explain early-done violation; got: {stderr}"
+    );
+}
+
+#[test]
+fn falsify_crux_c_04_stream_rejects_missing_terminal_done() {
+    let body = r#"{"message":{"role":"assistant","content":"a"},"done":false}
+{"message":{"role":"assistant","content":"b"},"done":false}
+"#;
+    let f = write_text(body);
+    let output = Command::cargo_bin("apr")
+        .unwrap()
+        .args([
+            "ollama-chat-lint",
+            "--response-file",
+            f.path().to_str().unwrap(),
+            "--stream",
+        ])
+        .output()
+        .expect("apr binary runs");
+    assert!(
+        !output.status.success(),
+        "NDJSON without terminal done=true must be rejected"
+    );
+}
+
+#[test]
+fn falsify_crux_c_04_stream_rejects_empty_file() {
+    let f = write_text("");
+    let output = Command::cargo_bin("apr")
+        .unwrap()
+        .args([
+            "ollama-chat-lint",
+            "--response-file",
+            f.path().to_str().unwrap(),
+            "--stream",
+        ])
+        .output()
+        .expect("apr binary runs");
+    assert!(
+        !output.status.success(),
+        "empty NDJSON stream must be rejected (no silent pass)"
+    );
+}


### PR DESCRIPTION
## CRUX-C-04 — Ollama /api/chat (CRUX-SHIP-001 retrofit)

Completes CRUX-SHIP-001 compliance (spec commit 75fd24d87) by adding the CLI surface and end-to-end tests required by the 4 merge gates. Classifier + contract were already in place from the earlier `feat(crux-c-04): ... (3 of 3 FALSIFY at PARTIAL_ALGORITHM_LEVEL)` commit.

### Ship gates (CRUX-SHIP-001)

| Gate | Evidence |
|---|---|
| **g1_classifier_green** | 25 unit tests pass (`commands::ollama_chat_classifier`) |
| **g2_cli_reachable** | `apr ollama-chat-lint --help` advertises `--response-file` + `--stream` |
| **g3_e2e_runs** | 12 falsification tests pass (`falsification_crux_c_04`) |
| **g4_contract_discharged** | 3/3 FALSIFY-* at PARTIAL_ALGORITHM_LEVEL under BLOCKER-UPSTREAM-MISSING (live /api/chat handler in aprender-serve) |

### New CLI surface

```
apr ollama-chat-lint --response-file FILE [--stream] [--json]
```

Reads a captured `/api/chat` response (single JSON object, or NDJSON when `--stream`) and dispatches the pure classifiers end-to-end without needing `aprender-serve` live. Exits non-zero with explanatory stderr on any classifier rejection; JSON report includes `schema_ok` / `eval_metrics_ok` / `ndjson_ok` booleans.

### Contract v1.1.0 → v1.2.0

- Adds `kind: kernel` + `updated: 2026-04-21`.
- Enriches each FALSIFY's `evidence_discharged_by` with `cli_path` + `e2e_path` and the CLI e2e test names alongside the existing classifier-direct tests.
- Adds `ship_discipline` block documenting the 4 merge gates.
- Discharge status unchanged (still PARTIAL under live-handler blocker).
- `pv validate contracts/crux-C-04-v1.yaml` — 0 errors / 0 warnings.

### Grandfathering

CRUX-C-04 was one of the 5 classifier-only PRs shipped before 2026-04-21. This PR discharges the `crux-wireup-c-04` follow-up from the grandfather list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)