### PR TITLE
feat(crux-c-09): speculative-decoding parity+uplift+compat+acceptance_rate classifier (4 of 4 FALSIFY at PARTIAL_ALGORITHM_LEVEL)

### DIFF
--- a/contracts/apr-cli-commands-v1.yaml
+++ b/contracts/apr-cli-commands-v1.yaml
@@ -21,7 +21,7 @@ metadata:
 kind: CLICommandContract
 name: apr-cli-commands
 version: "1.0.0"
-scope: "all apr CLI subcommands (66 commands — original 57 + `mcp` added 2026-04-17 via PR #864 + `registry` added 2026-04-20 via CRUX-A-01 + `ollama-chat-lint` added 2026-04-21 via CRUX-C-04 SHIP-001 retrofit + `dry-sampling-lint` added 2026-04-21 via CRUX-C-23 SHIP-001 retrofit + `awq-lint` added 2026-04-21 via CRUX-B-08 SHIP-001 retrofit + `oom-lint` added 2026-04-21 via CRUX-F-13 SHIP-001 + `tool-use-lint` added 2026-04-21 via CRUX-C-11 SHIP-001 retrofit + `gbnf-lint` added 2026-04-21 via CRUX-C-10 SHIP-001 retrofit + `typical-p-lint` added 2026-04-21 via CRUX-C-22 SHIP-001 retrofit)"
+scope: "all apr CLI subcommands (67 commands — original 57 + `mcp` added 2026-04-17 via PR #864 + `registry` added 2026-04-20 via CRUX-A-01 + `ollama-chat-lint` added 2026-04-21 via CRUX-C-04 SHIP-001 retrofit + `dry-sampling-lint` added 2026-04-21 via CRUX-C-23 SHIP-001 retrofit + `awq-lint` added 2026-04-21 via CRUX-B-08 SHIP-001 retrofit + `oom-lint` added 2026-04-21 via CRUX-F-13 SHIP-001 + `tool-use-lint` added 2026-04-21 via CRUX-C-11 SHIP-001 retrofit + `gbnf-lint` added 2026-04-21 via CRUX-C-10 SHIP-001 retrofit + `typical-p-lint` added 2026-04-21 via CRUX-C-22 SHIP-001 retrofit + `speculative-lint` added 2026-04-21 via CRUX-C-09 SHIP-001 retrofit)"
 binary: "apr"
 install: "cargo install aprender"
 
@@ -429,6 +429,12 @@ commands:
   - name: typical-p-lint
     category: inspection
     description: "Lint a captured typical-p sampling observation (CRUX-C-22)"
+    requires_model: false
+    side_effects: []
+
+  - name: speculative-lint
+    category: inspection
+    description: "Lint a speculative-decoding observation (CRUX-C-09)"
     requires_model: false
     side_effects: []
 

--- a/contracts/crux-C-09-v1.yaml
+++ b/contracts/crux-C-09-v1.yaml
@@ -1,29 +1,27 @@
 # CRUX-C-09 — Speculative decoding draft model
-# Auto-scaffolded from crux-competitive-research-ux-v1.yaml (DRAFT).
-# DO NOT promote to ACTIVE until: (1) evidence collected, (2) falsification
-# body reflects competitor's canonical CLI, (3) apr surface mapped or gap
-# tracked in pmat work (see master §12).
 
 metadata:
   id: CRUX-C-09
-  version: "1.0.0-draft"
+  version: "1.1.0"
   created: "2026-04-18"
   author: PAIML Engineering
   registry: true
-  status: draft
+  status: partial
   parent_contracts:
   - crux-competitive-research-ux-v1
   category: "C — Serving & Chat UX"
   competitor: vllm
-  demand_score: 4  # 1..5, high priority in pmat work
+  demand_score: 4
   intake_status: missing
   description: >
     Speculative decoding with a small draft model to accelerate decoding of
     a larger target model. vLLM exposes this via `--speculative-model` and
     `--num-speculative-tokens` flags (SpecDecodeWorker, see vLLM docs
     "Speculative Decoding"). Map to `apr serve --draft-model <path>
-    --spec-tokens N` producing identical token output as the non-spec path
-    (within sampling noise at temp=0) with measurable tok/s uplift.
+    --spec-tokens N` producing identical token output as the non-spec path at
+    temp=0 top_k=1, with measurable tok/s uplift and sha+vocab tokenizer
+    compatibility enforced before the first decode step.
+
   references:
   - "https://docs.vllm.ai/en/latest/models/spec_decode.html"
   - "Leviathan et al. 2022 — 'Fast Inference from Transformers via Speculative Decoding'"
@@ -31,11 +29,11 @@ metadata:
 equations:
   speculative_decoding_parity:
     formula: |
-      ∀ prompt p, temperature=0.0:
+      ∀ prompt p, temperature=0.0 top_k=1:
         decode(target, p) ≡ decode(target + draft, p)
       i.e. speculative path MUST produce byte-identical tokens to
       target-only path at greedy sampling.
-    domain: (target_model, draft_model, prompt, temp=0.0)
+    domain: (target_model, draft_model, prompt, temp=0.0, top_k=1)
     codomain: token sequence
     invariants:
     - "temp=0.0 top_k=1: speculative output == non-speculative output (exact match)"
@@ -51,7 +49,7 @@ equations:
     invariants:
     - "uplift alpha >= 0.3 on deterministic workloads"
     - "acceptance_rate ∈ [0.0, 1.0] reported in --json output"
-    - "no uplift allowed to be a regression (alpha >= 0 floor)"
+    - "regression (spec_tps < base_tps) is never classified as uplift"
 
   draft_model_compatibility:
     formula: |
@@ -62,13 +60,14 @@ equations:
     invariants:
     - "mismatched tokenizers MUST fail fast with actionable error"
     - "vocab mismatch MUST be rejected before first decode step"
+    - "empty sha256 or zero vocab_size MUST be rejected"
 
 falsification_tests:
 - id: FALSIFY-CRUX-C-09-001
-  rule: speculative parity at temp=0
-  prediction: "apr serve --draft-model produces identical tokens to non-spec path"
+  rule: speculative parity at temp=0 top_k=1
+  prediction: "apr serve --draft-model produces byte-identical tokens to non-spec path"
   test: |
-    # TODO: requires apr --draft-model flag (not yet implemented)
+    set -euo pipefail
     BASE=$(apr run target.gguf --prompt "def fibonacci(n):" --max-tokens 64 \
       --temperature 0.0 --top-k 1 --json | jq -r '.tokens | join(",")')
     SPEC=$(apr run target.gguf --draft-model draft.gguf --spec-tokens 5 \
@@ -76,40 +75,140 @@ falsification_tests:
       --json | jq -r '.tokens | join(",")')
     [ "$BASE" = "$SPEC" ]
   if_fails: "speculative path diverges from target-only at temp=0 — sampling bug"
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/speculative_decoding_classifier.rs
+    sub_claim: |
+      Algorithm-level necessary condition: `classify_speculative_parity`
+      accepts two token-id sequences iff they have equal length and all
+      positions match pairwise.
+        (a) unequal lengths reject with `LengthMismatch{base_len, spec_len}`;
+        (b) equal lengths with any divergent position reject with
+            `TokenDivergence{at_index, base_token, spec_token}` at the
+            first divergence index (deterministic);
+        (c) equal empty sequences accept as `Ok`.
+      Pure function of `(base_tokens, spec_tokens)`; deterministic.
+    tests:
+    - parity_ok_on_identical_sequences
+    - parity_ok_on_two_empty_sequences
+    - parity_rejects_length_mismatch
+    - parity_rejects_token_divergence
+    - parity_classifier_is_deterministic
+    scope: "(base_tokens: &[u32], spec_tokens: &[u32]) → SpecParityOutcome (pure)"
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: "apr run --draft-model / apr serve --draft-model surfaces emitting real target+speculative token streams"
 
 - id: FALSIFY-CRUX-C-09-002
-  rule: throughput uplift
-  prediction: "K=5 spec decoding delivers >=30% tok/s uplift on code workload"
+  rule: throughput uplift alpha >= 0.30 (no regression)
+  prediction: "K=5 spec decoding delivers >=30% tok/s uplift on code workload, never a regression"
   test: |
-    # TODO: blocked until --draft-model wired; smoke via external harness
+    set -euo pipefail
     BASE_TPS=$(apr bench target.gguf --prompt-file code-bench.txt \
       --max-tokens 128 --json | jq '.tokens_per_sec')
     SPEC_TPS=$(apr bench target.gguf --draft-model draft.gguf --spec-tokens 5 \
       --prompt-file code-bench.txt --max-tokens 128 --json | jq '.tokens_per_sec')
     python3 -c "import sys; sys.exit(0 if $SPEC_TPS / $BASE_TPS >= 1.30 else 1)"
   if_fails: "speculative decoding failed to deliver >=30% tok/s uplift vs baseline"
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/speculative_decoding_classifier.rs
+    sub_claim: |
+      Algorithm-level necessary condition: `classify_throughput_uplift`
+      computes observed_alpha = spec_tps / base_tps - 1 and:
+        (a) rejects non-finite / non-positive `base_tps`, negative
+            `spec_tps`, or negative `alpha_min` as `InvalidInput`;
+        (b) classifies `spec_tps < base_tps` as a `Regression` (never
+            accepted, even with near-zero observed_alpha);
+        (c) classifies `observed_alpha < alpha_min` (but ≥ 0) as
+            `BelowThreshold`;
+        (d) only `observed_alpha >= alpha_min` yields `Ok{observed_alpha}`.
+      The bi-directional split means "barely positive" cannot masquerade
+      as uplift. Pure; deterministic.
+    tests:
+    - uplift_ok_at_exactly_30_percent
+    - uplift_ok_above_threshold
+    - uplift_below_threshold_rejected
+    - uplift_regression_is_never_ok
+    - uplift_rejects_nonfinite_base
+    - uplift_rejects_zero_or_negative_base_tps
+    - uplift_rejects_negative_spec_tps
+    - uplift_rejects_negative_alpha_min
+    - uplift_classifier_is_deterministic
+    scope: "(base_tps: f64, spec_tps: f64, alpha_min: f64) → ThroughputUpliftOutcome (pure)"
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: "apr bench --draft-model emitting real (target, target+draft) tokens_per_sec on a code/math workload"
 
 - id: FALSIFY-CRUX-C-09-003
-  rule: tokenizer mismatch rejected
-  prediction: "draft+target with different tokenizers MUST exit non-zero with clear error"
+  rule: tokenizer + vocab mismatch rejected before first decode step
+  prediction: "draft+target with different tokenizer sha OR vocab_size MUST reject fast"
   test: |
-    # TODO: blocked until --draft-model flag implemented
     set +e
     apr run target-qwen.gguf --draft-model draft-llama.gguf --prompt "hi" 2>err.log
     rc=$?
     set -e
     [ "$rc" -ne 0 ] && grep -qi "tokenizer" err.log
   if_fails: "tokenizer mismatch silently accepted — will produce garbage tokens"
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/speculative_decoding_classifier.rs
+    sub_claim: |
+      Algorithm-level necessary condition:
+      `classify_tokenizer_compatibility` accepts `Ok` only when
+      `draft_sha256 == target_sha256` (case-insensitive) AND
+      `draft_vocab_size == target_vocab_size` AND both sha256 values are
+      non-empty AND both vocab sizes are non-zero. Rejection paths:
+        (a) empty sha → `MalformedSha{reason}`;
+        (b) zero draft or target vocab → `ZeroVocab{which}`;
+        (c) sha mismatch → `TokenizerShaMismatch`;
+        (d) vocab-size mismatch → `VocabSizeMismatch{draft, target}`.
+      Pure; deterministic.
+    tests:
+    - compat_ok_on_matching_sha_and_vocab
+    - compat_ok_case_insensitive_sha_match
+    - compat_rejects_empty_sha
+    - compat_rejects_zero_draft_vocab
+    - compat_rejects_zero_target_vocab
+    - compat_rejects_sha_mismatch
+    - compat_rejects_vocab_size_mismatch
+    - compat_classifier_is_deterministic
+    scope: "(draft_sha, target_sha, draft_vocab, target_vocab) → TokenizerCompatOutcome (pure)"
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: "live tokenizer-metadata extraction in apr run/serve that actually invokes this classifier before the first decode step"
 
 - id: FALSIFY-CRUX-C-09-004
-  rule: acceptance_rate reported
+  rule: acceptance_rate present and in [0,1]
   prediction: "--json output includes speculative.acceptance_rate ∈ [0,1]"
   test: |
-    # TODO: blocked until --draft-model + --json schema extended
     apr run target.gguf --draft-model draft.gguf --spec-tokens 5 \
       --prompt "hello" --max-tokens 32 --json | \
       jq -e '.speculative.acceptance_rate >= 0 and .speculative.acceptance_rate <= 1'
   if_fails: "acceptance_rate missing or out of [0,1] range in JSON schema"
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/speculative_decoding_classifier.rs
+    sub_claim: |
+      Algorithm-level necessary conditions on the already-parsed `apr run
+      --json` response:
+        (a) top-level JSON is an object (else `NotAnObject`);
+        (b) `speculative` key is present and an object (else
+            `MissingSpeculative` / `SpeculativeNotAnObject`);
+        (c) `speculative.acceptance_rate` is present and numeric (else
+            `MissingAcceptanceRate` / `AcceptanceRateNotNumeric`);
+        (d) value is not NaN (else `NaN`);
+        (e) value ∈ `[0.0, 1.0]` (else `OutOfRange{value}`).
+      Pure; deterministic. NaN is distinguished from OutOfRange so the
+      error surface matches the actual bug class ("silent NaN" vs
+      "numerically out-of-range").
+    tests:
+    - acceptance_ok_at_boundaries
+    - acceptance_ok_at_midrange
+    - acceptance_rejects_non_object_top
+    - acceptance_rejects_missing_speculative
+    - acceptance_rejects_non_object_speculative
+    - acceptance_rejects_missing_acceptance_rate
+    - acceptance_rejects_non_numeric_acceptance_rate
+    - acceptance_rejects_out_of_range_high
+    - acceptance_rejects_out_of_range_low
+    - acceptance_classifier_is_deterministic
+    scope: "(parsed_json_response) → AcceptanceRateOutcome (pure)"
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: "apr run --json schema extended with a speculative.acceptance_rate field (driven by a live SpecDecodeWorker)"
 
 proof_obligations:
 - type: equivalence
@@ -117,19 +216,30 @@ proof_obligations:
 - type: invariant
   property: "spec_tokens ∈ [1,16]; tokenizer+vocab match enforced before decode"
 - type: bound
-  property: "K=5 delivers tok/s uplift alpha >= 0.3 on code/math workloads"
+  property: "K=5 delivers tok/s uplift alpha >= 0.3 on code/math workloads (no regression)"
 - type: invariant
-  property: "--json output includes speculative.{acceptance_rate, num_accepted, num_proposed}"
+  property: "--json output includes speculative.acceptance_rate ∈ [0,1]"
 
 verification_summary:
   total_obligations: 4
   proven: 0
   tested: 0
   status: spec-complete
+  discharge_ledger:
+  - falsify_id: FALSIFY-CRUX-C-09-001
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    blocked_on: "apr run --draft-model / apr serve --draft-model surfaces"
+  - falsify_id: FALSIFY-CRUX-C-09-002
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    blocked_on: "apr bench --draft-model emitting real tokens_per_sec pairs"
+  - falsify_id: FALSIFY-CRUX-C-09-003
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    blocked_on: "live tokenizer-metadata extraction invoking the classifier before decode"
+  - falsify_id: FALSIFY-CRUX-C-09-004
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    blocked_on: "apr run --json schema extended with speculative.acceptance_rate"
 
 pmat_work_tracking:
-  # Managed by master contract §12. If intake_status == "missing", a ticket
-  # tagged `crux-crux-c-09` is auto-created by scripts/crux_bulk_pmat_work.sh.
   ticket_tag: crux-crux-c-09
   priority: high
   auto_created: true

--- a/contracts/crux-C-09-v1.yaml
+++ b/contracts/crux-C-09-v1.yaml
@@ -2,7 +2,7 @@
 
 metadata:
   id: CRUX-C-09
-  version: "1.1.0"
+  version: "1.2.0"
   created: "2026-04-18"
   author: PAIML Engineering
   registry: true
@@ -77,6 +77,8 @@ falsification_tests:
   if_fails: "speculative path diverges from target-only at temp=0 — sampling bug"
   evidence_discharged_by:
     classifier_path: crates/apr-cli/src/commands/speculative_decoding_classifier.rs
+    cli_path: crates/apr-cli/src/commands/speculative_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_c_09.rs
     sub_claim: |
       Algorithm-level necessary condition: `classify_speculative_parity`
       accepts two token-id sequences iff they have equal length and all
@@ -93,6 +95,10 @@ falsification_tests:
     - parity_rejects_length_mismatch
     - parity_rejects_token_divergence
     - parity_classifier_is_deterministic
+    e2e_tests:
+    - falsify_crux_c_09_001_parity_ok_on_matching_tokens
+    - falsify_crux_c_09_001_parity_rejects_length_mismatch
+    - falsify_crux_c_09_001_parity_rejects_token_divergence
     scope: "(base_tokens: &[u32], spec_tokens: &[u32]) → SpecParityOutcome (pure)"
     discharge_status: PARTIAL_ALGORITHM_LEVEL
     full_discharge_blocked_on: "apr run --draft-model / apr serve --draft-model surfaces emitting real target+speculative token streams"
@@ -110,6 +116,8 @@ falsification_tests:
   if_fails: "speculative decoding failed to deliver >=30% tok/s uplift vs baseline"
   evidence_discharged_by:
     classifier_path: crates/apr-cli/src/commands/speculative_decoding_classifier.rs
+    cli_path: crates/apr-cli/src/commands/speculative_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_c_09.rs
     sub_claim: |
       Algorithm-level necessary condition: `classify_throughput_uplift`
       computes observed_alpha = spec_tps / base_tps - 1 and:
@@ -132,6 +140,9 @@ falsification_tests:
     - uplift_rejects_negative_spec_tps
     - uplift_rejects_negative_alpha_min
     - uplift_classifier_is_deterministic
+    e2e_tests:
+    - falsify_crux_c_09_002_uplift_ok_above_threshold
+    - falsify_crux_c_09_002_uplift_rejects_regression
     scope: "(base_tps: f64, spec_tps: f64, alpha_min: f64) → ThroughputUpliftOutcome (pure)"
     discharge_status: PARTIAL_ALGORITHM_LEVEL
     full_discharge_blocked_on: "apr bench --draft-model emitting real (target, target+draft) tokens_per_sec on a code/math workload"
@@ -148,6 +159,8 @@ falsification_tests:
   if_fails: "tokenizer mismatch silently accepted — will produce garbage tokens"
   evidence_discharged_by:
     classifier_path: crates/apr-cli/src/commands/speculative_decoding_classifier.rs
+    cli_path: crates/apr-cli/src/commands/speculative_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_c_09.rs
     sub_claim: |
       Algorithm-level necessary condition:
       `classify_tokenizer_compatibility` accepts `Ok` only when
@@ -168,6 +181,9 @@ falsification_tests:
     - compat_rejects_sha_mismatch
     - compat_rejects_vocab_size_mismatch
     - compat_classifier_is_deterministic
+    e2e_tests:
+    - falsify_crux_c_09_003_compat_ok_on_matching_tokenizers
+    - falsify_crux_c_09_003_compat_rejects_vocab_mismatch
     scope: "(draft_sha, target_sha, draft_vocab, target_vocab) → TokenizerCompatOutcome (pure)"
     discharge_status: PARTIAL_ALGORITHM_LEVEL
     full_discharge_blocked_on: "live tokenizer-metadata extraction in apr run/serve that actually invokes this classifier before the first decode step"
@@ -182,6 +198,8 @@ falsification_tests:
   if_fails: "acceptance_rate missing or out of [0,1] range in JSON schema"
   evidence_discharged_by:
     classifier_path: crates/apr-cli/src/commands/speculative_decoding_classifier.rs
+    cli_path: crates/apr-cli/src/commands/speculative_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_c_09.rs
     sub_claim: |
       Algorithm-level necessary conditions on the already-parsed `apr run
       --json` response:
@@ -206,6 +224,9 @@ falsification_tests:
     - acceptance_rejects_out_of_range_high
     - acceptance_rejects_out_of_range_low
     - acceptance_classifier_is_deterministic
+    e2e_tests:
+    - falsify_crux_c_09_004_acceptance_rate_rejects_out_of_range
+    - falsify_crux_c_09_json_output_shape
     scope: "(parsed_json_response) → AcceptanceRateOutcome (pure)"
     discharge_status: PARTIAL_ALGORITHM_LEVEL
     full_discharge_blocked_on: "apr run --json schema extended with a speculative.acceptance_rate field (driven by a live SpecDecodeWorker)"
@@ -238,6 +259,19 @@ verification_summary:
   - falsify_id: FALSIFY-CRUX-C-09-004
     discharge_status: PARTIAL_ALGORITHM_LEVEL
     blocked_on: "apr run --json schema extended with speculative.acceptance_rate"
+
+ship_discipline:
+  ship_rule: CRUX-SHIP-001
+  deliverables_present:
+    classifier: crates/apr-cli/src/commands/speculative_decoding_classifier.rs
+    cli_wiring: "crates/apr-cli/src/extended_commands.rs + dispatch_analysis.rs + commands/speculative_lint.rs (apr speculative-lint --observation-file FILE [--alpha-min F])"
+    e2e_test: crates/apr-cli/tests/falsification_crux_c_09.rs
+    contract: contracts/crux-C-09-v1.yaml
+  merge_gates:
+    g1_classifier_green: "speculative_decoding_classifier unit tests pass (parity/uplift/compat/acceptance determinism + boundary coverage)"
+    g2_cli_reachable: "apr speculative-lint --help advertises --observation-file and --alpha-min"
+    g3_e2e_runs: "13 falsification tests pass (falsification_crux_c_09) — help surface, bare-invocation reject, 4 FALSIFY gates, empty/nonexistent file rejection, --json shape"
+    g4_contract_discharged: "4 of 4 FALSIFY-CRUX-C-09-00{1,2,3,4} at PARTIAL_ALGORITHM_LEVEL under BLOCKER-UPSTREAM-MISSING (live SpecDecodeWorker surfaces); classifier + CLI + e2e paths all exercised end-to-end on captured JSON observations"
 
 pmat_work_tracking:
   ticket_tag: crux-crux-c-09

--- a/crates/apr-cli/src/commands/mod.rs
+++ b/crates/apr-cli/src/commands/mod.rs
@@ -94,6 +94,7 @@ pub(crate) mod serve_plan;
 pub(crate) mod serve_plan_output;
 pub(crate) mod showcase;
 pub(crate) mod sign_artifacts;
+pub(crate) mod speculative_decoding_classifier;
 pub(crate) mod stop_op;
 pub(crate) mod tensors;
 pub(crate) mod token_redactor;

--- a/crates/apr-cli/src/commands/mod.rs
+++ b/crates/apr-cli/src/commands/mod.rs
@@ -95,6 +95,7 @@ pub(crate) mod serve_plan_output;
 pub(crate) mod showcase;
 pub(crate) mod sign_artifacts;
 pub(crate) mod speculative_decoding_classifier;
+pub(crate) mod speculative_lint;
 pub(crate) mod stop_op;
 pub(crate) mod tensors;
 pub(crate) mod token_redactor;

--- a/crates/apr-cli/src/commands/speculative_decoding_classifier.rs
+++ b/crates/apr-cli/src/commands/speculative_decoding_classifier.rs
@@ -1,0 +1,568 @@
+//! Speculative-decoding parity + uplift + compatibility classifier (CRUX-C-09).
+//!
+//! Four pure, deterministic classifiers that discharge FALSIFY-CRUX-C-09-{001..004}
+//! at the PARTIAL_ALGORITHM_LEVEL — algorithm-level necessary conditions on
+//! already-captured speculative-decoding observations:
+//!
+//!   * `classify_speculative_parity` — at temperature=0 top_k=1, the
+//!     speculative and target-only decode paths emit byte-identical token
+//!     sequences.
+//!   * `classify_throughput_uplift` — at a fixed K, `spec_tps >= base_tps *
+//!     (1 + alpha_min)`; we never accept a regression as "uplift".
+//!   * `classify_tokenizer_compatibility` — before the first decode step,
+//!     the draft and target tokenizers must have equal sha256 and equal
+//!     vocab_size; mismatches are rejected with a specific reason.
+//!   * `classify_acceptance_rate` — `--json` output contains a
+//!     `speculative.acceptance_rate` field, numeric, in `[0.0, 1.0]`.
+//!
+//! Full discharge blocks on a live `apr serve --draft-model` / `apr run
+//! --draft-model` surface and an extended `--json` schema emitting
+//! `speculative.acceptance_rate`.
+
+use serde_json::Value;
+
+/// vLLM default value of K (speculative tokens per step).
+pub const DEFAULT_SPEC_TOKENS_K: u32 = 5;
+/// Minimum uplift alpha (30%) required on code/math workloads at K=5.
+pub const MIN_SPEC_UPLIFT_ALPHA: f64 = 0.30;
+/// Allowed range for `spec_tokens` per vLLM's SpecDecodeWorker.
+pub const SPEC_TOKENS_MIN: u32 = 1;
+pub const SPEC_TOKENS_MAX: u32 = 16;
+
+/// Outcome of `classify_speculative_parity`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SpecParityOutcome {
+    /// Token sequences are byte-identical (same length, same IDs in order).
+    Ok,
+    /// Different lengths — spec path truncated or over-emitted.
+    LengthMismatch { base_len: usize, spec_len: usize },
+    /// Same length but a divergent token ID at some position.
+    TokenDivergence {
+        at_index: usize,
+        base_token: u32,
+        spec_token: u32,
+    },
+}
+
+/// Greedy parity gate: `temp==0.0` `top_k==1` requires byte-identical token
+/// sequences between the base (target-only) and speculative paths.
+pub fn classify_speculative_parity(base: &[u32], spec: &[u32]) -> SpecParityOutcome {
+    if base.len() != spec.len() {
+        return SpecParityOutcome::LengthMismatch {
+            base_len: base.len(),
+            spec_len: spec.len(),
+        };
+    }
+    for (i, (&b, &s)) in base.iter().zip(spec.iter()).enumerate() {
+        if b != s {
+            return SpecParityOutcome::TokenDivergence {
+                at_index: i,
+                base_token: b,
+                spec_token: s,
+            };
+        }
+    }
+    SpecParityOutcome::Ok
+}
+
+/// Outcome of `classify_throughput_uplift`.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ThroughputUpliftOutcome {
+    /// Observed alpha ≥ `alpha_min`. Reports the observed alpha.
+    Ok { observed_alpha: f64 },
+    /// Observed alpha < `alpha_min` but ≥ 0.
+    BelowThreshold {
+        observed_alpha: f64,
+        required_alpha: f64,
+    },
+    /// `spec_tps < base_tps` — a regression, never allowed.
+    Regression {
+        base_tps: f64,
+        spec_tps: f64,
+        observed_alpha: f64,
+    },
+    /// Inputs are non-finite or non-positive.
+    InvalidInput { reason: &'static str },
+}
+
+/// Throughput-uplift gate. `spec_tps / base_tps >= 1 + alpha_min`, with the
+/// explicit regression case split out so "barely-positive" never masks a
+/// genuine regression.
+pub fn classify_throughput_uplift(
+    base_tps: f64,
+    spec_tps: f64,
+    alpha_min: f64,
+) -> ThroughputUpliftOutcome {
+    if !base_tps.is_finite() || !spec_tps.is_finite() || !alpha_min.is_finite() {
+        return ThroughputUpliftOutcome::InvalidInput {
+            reason: "non-finite input",
+        };
+    }
+    if base_tps <= 0.0 {
+        return ThroughputUpliftOutcome::InvalidInput {
+            reason: "base_tps must be positive",
+        };
+    }
+    if spec_tps < 0.0 {
+        return ThroughputUpliftOutcome::InvalidInput {
+            reason: "spec_tps must be non-negative",
+        };
+    }
+    if alpha_min < 0.0 {
+        return ThroughputUpliftOutcome::InvalidInput {
+            reason: "alpha_min must be non-negative",
+        };
+    }
+    let observed_alpha = spec_tps / base_tps - 1.0;
+    if spec_tps < base_tps {
+        return ThroughputUpliftOutcome::Regression {
+            base_tps,
+            spec_tps,
+            observed_alpha,
+        };
+    }
+    if observed_alpha + f64::EPSILON < alpha_min {
+        return ThroughputUpliftOutcome::BelowThreshold {
+            observed_alpha,
+            required_alpha: alpha_min,
+        };
+    }
+    ThroughputUpliftOutcome::Ok { observed_alpha }
+}
+
+/// Outcome of `classify_tokenizer_compatibility`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TokenizerCompatOutcome {
+    /// sha256 and vocab_size match.
+    Ok,
+    /// Tokenizer hash mismatch — drafts cannot tokenize input consistently.
+    TokenizerShaMismatch,
+    /// Vocab size mismatch — draft logits can't remap onto target IDs.
+    VocabSizeMismatch { draft: u32, target: u32 },
+    /// One or both sha256 values are empty / obviously malformed.
+    MalformedSha { reason: &'static str },
+    /// Vocab size was reported as zero.
+    ZeroVocab { which: &'static str },
+}
+
+/// Compatibility gate: draft+target must share tokenizer sha256 AND vocab size.
+pub fn classify_tokenizer_compatibility(
+    draft_tokenizer_sha256: &str,
+    target_tokenizer_sha256: &str,
+    draft_vocab_size: u32,
+    target_vocab_size: u32,
+) -> TokenizerCompatOutcome {
+    if draft_tokenizer_sha256.is_empty() || target_tokenizer_sha256.is_empty() {
+        return TokenizerCompatOutcome::MalformedSha {
+            reason: "empty sha256",
+        };
+    }
+    if draft_vocab_size == 0 {
+        return TokenizerCompatOutcome::ZeroVocab { which: "draft" };
+    }
+    if target_vocab_size == 0 {
+        return TokenizerCompatOutcome::ZeroVocab { which: "target" };
+    }
+    if !draft_tokenizer_sha256.eq_ignore_ascii_case(target_tokenizer_sha256) {
+        return TokenizerCompatOutcome::TokenizerShaMismatch;
+    }
+    if draft_vocab_size != target_vocab_size {
+        return TokenizerCompatOutcome::VocabSizeMismatch {
+            draft: draft_vocab_size,
+            target: target_vocab_size,
+        };
+    }
+    TokenizerCompatOutcome::Ok
+}
+
+/// Outcome of `classify_acceptance_rate`.
+#[derive(Debug, Clone, PartialEq)]
+pub enum AcceptanceRateOutcome {
+    /// `speculative.acceptance_rate` is present, numeric, and within `[0,1]`.
+    Ok { rate: f64 },
+    /// Top-level response is not a JSON object.
+    NotAnObject,
+    /// `speculative` key is absent.
+    MissingSpeculative,
+    /// `speculative` is present but not an object.
+    SpeculativeNotAnObject,
+    /// `speculative.acceptance_rate` is absent.
+    MissingAcceptanceRate,
+    /// `speculative.acceptance_rate` is present but not a number.
+    AcceptanceRateNotNumeric,
+    /// Value is a number but outside `[0.0, 1.0]`.
+    OutOfRange { value: f64 },
+    /// Value is NaN (parses as number but unusable).
+    NaN,
+}
+
+/// `--json` output must include `speculative.acceptance_rate` ∈ `[0, 1]`.
+pub fn classify_acceptance_rate(json: &Value) -> AcceptanceRateOutcome {
+    let obj = match json.as_object() {
+        Some(o) => o,
+        None => return AcceptanceRateOutcome::NotAnObject,
+    };
+    let spec = match obj.get("speculative") {
+        Some(v) => v,
+        None => return AcceptanceRateOutcome::MissingSpeculative,
+    };
+    let spec_obj = match spec.as_object() {
+        Some(o) => o,
+        None => return AcceptanceRateOutcome::SpeculativeNotAnObject,
+    };
+    let ar_val = match spec_obj.get("acceptance_rate") {
+        Some(v) => v,
+        None => return AcceptanceRateOutcome::MissingAcceptanceRate,
+    };
+    let rate = match ar_val.as_f64() {
+        Some(f) => f,
+        None => return AcceptanceRateOutcome::AcceptanceRateNotNumeric,
+    };
+    if rate.is_nan() {
+        return AcceptanceRateOutcome::NaN;
+    }
+    if !(0.0..=1.0).contains(&rate) {
+        return AcceptanceRateOutcome::OutOfRange { value: rate };
+    }
+    AcceptanceRateOutcome::Ok { rate }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // ---- parity -----------------------------------------------------------
+
+    #[test]
+    fn parity_ok_on_identical_sequences() {
+        let base = [1, 2, 3, 4, 5];
+        let spec = [1, 2, 3, 4, 5];
+        assert_eq!(
+            classify_speculative_parity(&base, &spec),
+            SpecParityOutcome::Ok
+        );
+    }
+
+    #[test]
+    fn parity_ok_on_two_empty_sequences() {
+        assert_eq!(
+            classify_speculative_parity(&[], &[]),
+            SpecParityOutcome::Ok
+        );
+    }
+
+    #[test]
+    fn parity_rejects_length_mismatch() {
+        assert_eq!(
+            classify_speculative_parity(&[1, 2, 3], &[1, 2]),
+            SpecParityOutcome::LengthMismatch {
+                base_len: 3,
+                spec_len: 2
+            }
+        );
+    }
+
+    #[test]
+    fn parity_rejects_token_divergence() {
+        assert_eq!(
+            classify_speculative_parity(&[1, 2, 3, 4], &[1, 2, 99, 4]),
+            SpecParityOutcome::TokenDivergence {
+                at_index: 2,
+                base_token: 3,
+                spec_token: 99,
+            }
+        );
+    }
+
+    #[test]
+    fn parity_classifier_is_deterministic() {
+        let base = [5, 6, 7];
+        let spec = [5, 6, 7];
+        let a = classify_speculative_parity(&base, &spec);
+        let b = classify_speculative_parity(&base, &spec);
+        assert_eq!(a, b);
+    }
+
+    // ---- throughput uplift ------------------------------------------------
+
+    #[test]
+    fn uplift_ok_at_exactly_30_percent() {
+        let r = classify_throughput_uplift(100.0, 130.0, MIN_SPEC_UPLIFT_ALPHA);
+        match r {
+            ThroughputUpliftOutcome::Ok { observed_alpha } => {
+                assert!((observed_alpha - 0.30).abs() < 1e-9);
+            }
+            _ => panic!("expected Ok, got {r:?}"),
+        }
+    }
+
+    #[test]
+    fn uplift_ok_above_threshold() {
+        let r = classify_throughput_uplift(100.0, 200.0, MIN_SPEC_UPLIFT_ALPHA);
+        assert!(matches!(r, ThroughputUpliftOutcome::Ok { .. }));
+    }
+
+    #[test]
+    fn uplift_below_threshold_rejected() {
+        let r = classify_throughput_uplift(100.0, 120.0, MIN_SPEC_UPLIFT_ALPHA);
+        match r {
+            ThroughputUpliftOutcome::BelowThreshold {
+                observed_alpha,
+                required_alpha,
+            } => {
+                assert!((observed_alpha - 0.20).abs() < 1e-9);
+                assert!((required_alpha - 0.30).abs() < 1e-9);
+            }
+            _ => panic!("expected BelowThreshold, got {r:?}"),
+        }
+    }
+
+    #[test]
+    fn uplift_regression_is_never_ok() {
+        let r = classify_throughput_uplift(100.0, 80.0, MIN_SPEC_UPLIFT_ALPHA);
+        match r {
+            ThroughputUpliftOutcome::Regression {
+                base_tps,
+                spec_tps,
+                observed_alpha,
+            } => {
+                assert!((base_tps - 100.0).abs() < 1e-9);
+                assert!((spec_tps - 80.0).abs() < 1e-9);
+                assert!(observed_alpha < 0.0);
+            }
+            _ => panic!("expected Regression, got {r:?}"),
+        }
+    }
+
+    #[test]
+    fn uplift_rejects_nonfinite_base() {
+        assert_eq!(
+            classify_throughput_uplift(f64::INFINITY, 200.0, 0.3),
+            ThroughputUpliftOutcome::InvalidInput {
+                reason: "non-finite input"
+            }
+        );
+        assert_eq!(
+            classify_throughput_uplift(f64::NAN, 200.0, 0.3),
+            ThroughputUpliftOutcome::InvalidInput {
+                reason: "non-finite input"
+            }
+        );
+    }
+
+    #[test]
+    fn uplift_rejects_zero_or_negative_base_tps() {
+        assert_eq!(
+            classify_throughput_uplift(0.0, 200.0, 0.3),
+            ThroughputUpliftOutcome::InvalidInput {
+                reason: "base_tps must be positive"
+            }
+        );
+        assert_eq!(
+            classify_throughput_uplift(-1.0, 200.0, 0.3),
+            ThroughputUpliftOutcome::InvalidInput {
+                reason: "base_tps must be positive"
+            }
+        );
+    }
+
+    #[test]
+    fn uplift_rejects_negative_spec_tps() {
+        assert_eq!(
+            classify_throughput_uplift(100.0, -1.0, 0.3),
+            ThroughputUpliftOutcome::InvalidInput {
+                reason: "spec_tps must be non-negative"
+            }
+        );
+    }
+
+    #[test]
+    fn uplift_rejects_negative_alpha_min() {
+        assert_eq!(
+            classify_throughput_uplift(100.0, 200.0, -0.1),
+            ThroughputUpliftOutcome::InvalidInput {
+                reason: "alpha_min must be non-negative"
+            }
+        );
+    }
+
+    #[test]
+    fn uplift_classifier_is_deterministic() {
+        let a = classify_throughput_uplift(100.0, 150.0, 0.3);
+        let b = classify_throughput_uplift(100.0, 150.0, 0.3);
+        assert_eq!(a, b);
+    }
+
+    // ---- tokenizer compatibility -----------------------------------------
+
+    #[test]
+    fn compat_ok_on_matching_sha_and_vocab() {
+        assert_eq!(
+            classify_tokenizer_compatibility("deadbeef", "deadbeef", 151936, 151936),
+            TokenizerCompatOutcome::Ok
+        );
+    }
+
+    #[test]
+    fn compat_ok_case_insensitive_sha_match() {
+        assert_eq!(
+            classify_tokenizer_compatibility("DEADBEEF", "deadbeef", 1000, 1000),
+            TokenizerCompatOutcome::Ok
+        );
+    }
+
+    #[test]
+    fn compat_rejects_empty_sha() {
+        assert_eq!(
+            classify_tokenizer_compatibility("", "deadbeef", 1000, 1000),
+            TokenizerCompatOutcome::MalformedSha {
+                reason: "empty sha256"
+            }
+        );
+        assert_eq!(
+            classify_tokenizer_compatibility("deadbeef", "", 1000, 1000),
+            TokenizerCompatOutcome::MalformedSha {
+                reason: "empty sha256"
+            }
+        );
+    }
+
+    #[test]
+    fn compat_rejects_zero_draft_vocab() {
+        assert_eq!(
+            classify_tokenizer_compatibility("aa", "aa", 0, 1000),
+            TokenizerCompatOutcome::ZeroVocab { which: "draft" }
+        );
+    }
+
+    #[test]
+    fn compat_rejects_zero_target_vocab() {
+        assert_eq!(
+            classify_tokenizer_compatibility("aa", "aa", 1000, 0),
+            TokenizerCompatOutcome::ZeroVocab { which: "target" }
+        );
+    }
+
+    #[test]
+    fn compat_rejects_sha_mismatch() {
+        assert_eq!(
+            classify_tokenizer_compatibility("aa", "bb", 1000, 1000),
+            TokenizerCompatOutcome::TokenizerShaMismatch
+        );
+    }
+
+    #[test]
+    fn compat_rejects_vocab_size_mismatch() {
+        assert_eq!(
+            classify_tokenizer_compatibility("aa", "aa", 32000, 151936),
+            TokenizerCompatOutcome::VocabSizeMismatch {
+                draft: 32000,
+                target: 151936,
+            }
+        );
+    }
+
+    #[test]
+    fn compat_classifier_is_deterministic() {
+        let a = classify_tokenizer_compatibility("abc", "abc", 100, 100);
+        let b = classify_tokenizer_compatibility("abc", "abc", 100, 100);
+        assert_eq!(a, b);
+    }
+
+    // ---- acceptance rate --------------------------------------------------
+
+    #[test]
+    fn acceptance_ok_at_boundaries() {
+        assert_eq!(
+            classify_acceptance_rate(&json!({"speculative": {"acceptance_rate": 0.0}})),
+            AcceptanceRateOutcome::Ok { rate: 0.0 }
+        );
+        assert_eq!(
+            classify_acceptance_rate(&json!({"speculative": {"acceptance_rate": 1.0}})),
+            AcceptanceRateOutcome::Ok { rate: 1.0 }
+        );
+    }
+
+    #[test]
+    fn acceptance_ok_at_midrange() {
+        match classify_acceptance_rate(&json!({"speculative": {"acceptance_rate": 0.72}})) {
+            AcceptanceRateOutcome::Ok { rate } => assert!((rate - 0.72).abs() < 1e-9),
+            other => panic!("expected Ok, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn acceptance_rejects_non_object_top() {
+        assert_eq!(
+            classify_acceptance_rate(&json!([1, 2, 3])),
+            AcceptanceRateOutcome::NotAnObject
+        );
+    }
+
+    #[test]
+    fn acceptance_rejects_missing_speculative() {
+        assert_eq!(
+            classify_acceptance_rate(&json!({"other": {}})),
+            AcceptanceRateOutcome::MissingSpeculative
+        );
+    }
+
+    #[test]
+    fn acceptance_rejects_non_object_speculative() {
+        assert_eq!(
+            classify_acceptance_rate(&json!({"speculative": "0.5"})),
+            AcceptanceRateOutcome::SpeculativeNotAnObject
+        );
+    }
+
+    #[test]
+    fn acceptance_rejects_missing_acceptance_rate() {
+        assert_eq!(
+            classify_acceptance_rate(&json!({"speculative": {"num_accepted": 1}})),
+            AcceptanceRateOutcome::MissingAcceptanceRate
+        );
+    }
+
+    #[test]
+    fn acceptance_rejects_non_numeric_acceptance_rate() {
+        assert_eq!(
+            classify_acceptance_rate(&json!({"speculative": {"acceptance_rate": "0.5"}})),
+            AcceptanceRateOutcome::AcceptanceRateNotNumeric
+        );
+    }
+
+    #[test]
+    fn acceptance_rejects_out_of_range_high() {
+        assert_eq!(
+            classify_acceptance_rate(&json!({"speculative": {"acceptance_rate": 1.5}})),
+            AcceptanceRateOutcome::OutOfRange { value: 1.5 }
+        );
+    }
+
+    #[test]
+    fn acceptance_rejects_out_of_range_low() {
+        assert_eq!(
+            classify_acceptance_rate(&json!({"speculative": {"acceptance_rate": -0.1}})),
+            AcceptanceRateOutcome::OutOfRange { value: -0.1 }
+        );
+    }
+
+    #[test]
+    fn acceptance_classifier_is_deterministic() {
+        let v = json!({"speculative": {"acceptance_rate": 0.42}});
+        let a = classify_acceptance_rate(&v);
+        let b = classify_acceptance_rate(&v);
+        assert_eq!(a, b);
+    }
+
+    // ---- constants sanity -------------------------------------------------
+
+    #[test]
+    fn constants_have_expected_values() {
+        assert_eq!(DEFAULT_SPEC_TOKENS_K, 5);
+        assert!((MIN_SPEC_UPLIFT_ALPHA - 0.30).abs() < 1e-12);
+        assert_eq!(SPEC_TOKENS_MIN, 1);
+        assert_eq!(SPEC_TOKENS_MAX, 16);
+    }
+}

--- a/crates/apr-cli/src/commands/speculative_lint.rs
+++ b/crates/apr-cli/src/commands/speculative_lint.rs
@@ -1,0 +1,232 @@
+//! `apr speculative-lint` — CRUX-C-09 speculative-decoding observation linter.
+//!
+//! Reads a JSON observation file that captures a single speculative-decoding
+//! run and dispatches all four classifiers (parity, uplift, compat,
+//! acceptance_rate). Emits a text or `--json` report.
+//!
+//! Spec: `contracts/crux-C-09-v1.yaml`. CRUX-SHIP-001 g2/g3 surface.
+//!
+//! Observation schema (top-level keys; all optional — missing fields skip the
+//! corresponding classifier):
+//!
+//!   {
+//!     "base_tokens":                 [u32, ...],       // parity input 1
+//!     "spec_tokens":                 [u32, ...],       // parity input 2
+//!     "base_tps":                    f64,              // uplift input 1
+//!     "spec_tps":                    f64,              // uplift input 2
+//!     "draft_tokenizer_sha256":      "hex",            // compat input 1
+//!     "target_tokenizer_sha256":     "hex",            // compat input 2
+//!     "draft_vocab_size":            u32,              // compat input 3
+//!     "target_vocab_size":           u32,              // compat input 4
+//!     "speculative": { "acceptance_rate": f64 }        // ar input
+//!   }
+
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+
+use crate::commands::speculative_decoding_classifier as clf;
+use crate::error::{CliError, Result};
+
+pub(crate) fn run(observation_file: &Path, alpha_min: f64, json: bool) -> Result<()> {
+    if !observation_file.exists() {
+        return Err(CliError::FileNotFound(PathBuf::from(observation_file)));
+    }
+
+    let body = std::fs::read_to_string(observation_file)?;
+    let obs: Value = serde_json::from_str(&body).map_err(|e| {
+        CliError::InvalidFormat(format!(
+            "apr speculative-lint: failed to parse JSON from {}: {e}",
+            observation_file.display()
+        ))
+    })?;
+
+    if !alpha_min.is_finite() || alpha_min < 0.0 {
+        return Err(CliError::ValidationFailed(format!(
+            "--alpha-min must be finite and >= 0 (got {alpha_min})"
+        )));
+    }
+
+    let parity = classify_parity(&obs);
+    let uplift = classify_uplift(&obs, alpha_min);
+    let compat = classify_compat(&obs);
+    let acceptance = classify_acceptance(&obs);
+
+    let fail_reasons: Vec<String> = [
+        parity.as_ref().and_then(parity_fail_reason),
+        uplift.as_ref().and_then(uplift_fail_reason),
+        compat.as_ref().and_then(compat_fail_reason),
+        acceptance.as_ref().and_then(acceptance_fail_reason),
+    ]
+    .into_iter()
+    .flatten()
+    .collect();
+
+    print_report(
+        observation_file,
+        parity.as_ref(),
+        uplift.as_ref(),
+        compat.as_ref(),
+        acceptance.as_ref(),
+        alpha_min,
+        json,
+    );
+
+    if fail_reasons.is_empty() {
+        Ok(())
+    } else {
+        Err(CliError::ValidationFailed(fail_reasons.join("; ")))
+    }
+}
+
+fn classify_parity(obs: &Value) -> Option<clf::SpecParityOutcome> {
+    let base = obs.get("base_tokens")?.as_array()?;
+    let spec = obs.get("spec_tokens")?.as_array()?;
+    let base: Vec<u32> = base.iter().filter_map(|v| v.as_u64().map(|x| x as u32)).collect();
+    let spec: Vec<u32> = spec.iter().filter_map(|v| v.as_u64().map(|x| x as u32)).collect();
+    Some(clf::classify_speculative_parity(&base, &spec))
+}
+
+fn classify_uplift(obs: &Value, alpha_min: f64) -> Option<clf::ThroughputUpliftOutcome> {
+    let base_tps = obs.get("base_tps")?.as_f64()?;
+    let spec_tps = obs.get("spec_tps")?.as_f64()?;
+    Some(clf::classify_throughput_uplift(base_tps, spec_tps, alpha_min))
+}
+
+fn classify_compat(obs: &Value) -> Option<clf::TokenizerCompatOutcome> {
+    let draft_sha = obs.get("draft_tokenizer_sha256")?.as_str()?;
+    let target_sha = obs.get("target_tokenizer_sha256")?.as_str()?;
+    let draft_vocab = obs.get("draft_vocab_size")?.as_u64()? as u32;
+    let target_vocab = obs.get("target_vocab_size")?.as_u64()? as u32;
+    Some(clf::classify_tokenizer_compatibility(
+        draft_sha,
+        target_sha,
+        draft_vocab,
+        target_vocab,
+    ))
+}
+
+fn classify_acceptance(obs: &Value) -> Option<clf::AcceptanceRateOutcome> {
+    obs.get("speculative")?;
+    Some(clf::classify_acceptance_rate(obs))
+}
+
+fn parity_fail_reason(o: &clf::SpecParityOutcome) -> Option<String> {
+    match o {
+        clf::SpecParityOutcome::Ok => None,
+        clf::SpecParityOutcome::LengthMismatch { base_len, spec_len } => Some(format!(
+            "FALSIFY-CRUX-C-09-001 parity: length mismatch base={base_len} spec={spec_len}"
+        )),
+        clf::SpecParityOutcome::TokenDivergence {
+            at_index,
+            base_token,
+            spec_token,
+        } => Some(format!(
+            "FALSIFY-CRUX-C-09-001 parity: divergence at idx {at_index}: base={base_token} spec={spec_token}"
+        )),
+    }
+}
+
+fn uplift_fail_reason(o: &clf::ThroughputUpliftOutcome) -> Option<String> {
+    match o {
+        clf::ThroughputUpliftOutcome::Ok { .. } => None,
+        clf::ThroughputUpliftOutcome::BelowThreshold {
+            observed_alpha,
+            required_alpha,
+        } => Some(format!(
+            "FALSIFY-CRUX-C-09-002 uplift: alpha={observed_alpha:.3} < required {required_alpha:.3}"
+        )),
+        clf::ThroughputUpliftOutcome::Regression { base_tps, spec_tps, .. } => Some(format!(
+            "FALSIFY-CRUX-C-09-002 uplift: regression (base_tps={base_tps:.3}, spec_tps={spec_tps:.3})"
+        )),
+        clf::ThroughputUpliftOutcome::InvalidInput { reason } => Some(format!(
+            "FALSIFY-CRUX-C-09-002 uplift: invalid input: {reason}"
+        )),
+    }
+}
+
+fn compat_fail_reason(o: &clf::TokenizerCompatOutcome) -> Option<String> {
+    match o {
+        clf::TokenizerCompatOutcome::Ok => None,
+        clf::TokenizerCompatOutcome::TokenizerShaMismatch => Some(
+            "FALSIFY-CRUX-C-09-003 compat: draft+target tokenizer sha256 differ".to_string(),
+        ),
+        clf::TokenizerCompatOutcome::VocabSizeMismatch { draft, target } => Some(format!(
+            "FALSIFY-CRUX-C-09-003 compat: vocab_size mismatch draft={draft} target={target}"
+        )),
+        clf::TokenizerCompatOutcome::MalformedSha { reason } => Some(format!(
+            "FALSIFY-CRUX-C-09-003 compat: malformed sha: {reason}"
+        )),
+        clf::TokenizerCompatOutcome::ZeroVocab { which } => Some(format!(
+            "FALSIFY-CRUX-C-09-003 compat: {which} vocab_size is zero"
+        )),
+    }
+}
+
+fn acceptance_fail_reason(o: &clf::AcceptanceRateOutcome) -> Option<String> {
+    match o {
+        clf::AcceptanceRateOutcome::Ok { .. } => None,
+        clf::AcceptanceRateOutcome::NotAnObject => Some(
+            "FALSIFY-CRUX-C-09-004 acceptance: top-level is not a JSON object".to_string(),
+        ),
+        clf::AcceptanceRateOutcome::MissingSpeculative => Some(
+            "FALSIFY-CRUX-C-09-004 acceptance: `speculative` key absent".to_string(),
+        ),
+        clf::AcceptanceRateOutcome::SpeculativeNotAnObject => Some(
+            "FALSIFY-CRUX-C-09-004 acceptance: `speculative` is not an object".to_string(),
+        ),
+        clf::AcceptanceRateOutcome::MissingAcceptanceRate => Some(
+            "FALSIFY-CRUX-C-09-004 acceptance: `speculative.acceptance_rate` absent".to_string(),
+        ),
+        clf::AcceptanceRateOutcome::AcceptanceRateNotNumeric => Some(
+            "FALSIFY-CRUX-C-09-004 acceptance: `speculative.acceptance_rate` is not numeric"
+                .to_string(),
+        ),
+        clf::AcceptanceRateOutcome::OutOfRange { value } => Some(format!(
+            "FALSIFY-CRUX-C-09-004 acceptance: rate {value} out of [0,1]"
+        )),
+        clf::AcceptanceRateOutcome::NaN => Some(
+            "FALSIFY-CRUX-C-09-004 acceptance: rate is NaN".to_string(),
+        ),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn print_report(
+    path: &Path,
+    parity: Option<&clf::SpecParityOutcome>,
+    uplift: Option<&clf::ThroughputUpliftOutcome>,
+    compat: Option<&clf::TokenizerCompatOutcome>,
+    acceptance: Option<&clf::AcceptanceRateOutcome>,
+    alpha_min: f64,
+    json: bool,
+) {
+    if json {
+        let v = serde_json::json!({
+            "observation_path": path.display().to_string(),
+            "alpha_min": alpha_min,
+            "parity":     parity.map(|o| format!("{o:?}")),
+            "uplift":     uplift.map(|o| format!("{o:?}")),
+            "compat":     compat.map(|o| format!("{o:?}")),
+            "acceptance": acceptance.map(|o| format!("{o:?}")),
+        });
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&v).unwrap_or_else(|_| v.to_string())
+        );
+    } else {
+        println!("speculative-lint report for {}", path.display());
+        println!("  alpha_min:  {alpha_min:.3}");
+        print_line("  parity:     ", parity.map(|o| format!("{o:?}")));
+        print_line("  uplift:     ", uplift.map(|o| format!("{o:?}")));
+        print_line("  compat:     ", compat.map(|o| format!("{o:?}")));
+        print_line("  acceptance: ", acceptance.map(|o| format!("{o:?}")));
+    }
+}
+
+fn print_line(prefix: &str, v: Option<String>) {
+    match v {
+        Some(s) => println!("{prefix}{s}"),
+        None => println!("{prefix}(missing fields — classifier skipped)"),
+    }
+}

--- a/crates/apr-cli/src/dispatch_analysis.rs
+++ b/crates/apr-cli/src/dispatch_analysis.rs
@@ -130,6 +130,10 @@ fn dispatch_analysis_commands(cli: &Cli) -> Option<Result<(), CliError>> {
             commands::typical_p_lint::run(observation_file, cli.json)
         }
 
+        ExtendedCommands::SpeculativeLint {
+            observation_file,
+            alpha_min,
+        } => commands::speculative_lint::run(observation_file, *alpha_min, cli.json),
 
         ExtendedCommands::Hex {
             file,

--- a/crates/apr-cli/src/extended_commands.rs
+++ b/crates/apr-cli/src/extended_commands.rs
@@ -768,6 +768,13 @@ pub enum ExtendedCommands {
         #[arg(long, value_name = "FILE")]
         observation_file: PathBuf,
     },
+    /// Lint a speculative-decoding observation (CRUX-C-09)
+    SpeculativeLint {
+        #[arg(long, value_name = "FILE")]
+        observation_file: PathBuf,
+        #[arg(long, default_value = "0.30")]
+        alpha_min: f64,
+    },
     /// Publishing, conversion, and analysis tools
     #[command(flatten)]
     Tools(ToolCommands),

--- a/crates/apr-cli/tests/cli_commands.rs
+++ b/crates/apr-cli/tests/cli_commands.rs
@@ -79,6 +79,7 @@ fn registered_commands() -> Vec<&'static str> {
         "tool-use-lint",
         "gbnf-lint",
         "typical-p-lint",
+        "speculative-lint",
         "oracle",
         "encrypt",
         "decrypt",

--- a/crates/apr-cli/tests/falsification_crux_c_09.rs
+++ b/crates/apr-cli/tests/falsification_crux_c_09.rs
@@ -1,0 +1,262 @@
+//! E2E falsification tests for `apr speculative-lint` (CRUX-C-09).
+//!
+//! Discharges g3 of CRUX-SHIP-001 for PR #976: exercise the CLI surface
+//! end-to-end on captured JSON observations and assert the classifier
+//! verdicts + non-zero exit codes on known-bad input.
+
+use std::io::Write;
+use std::process::Command;
+
+fn apr_binary() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_apr"));
+    cmd.env("NO_COLOR", "1");
+    cmd
+}
+
+fn write_tmp_json(name: &str, body: &str) -> tempfile::NamedTempFile {
+    let mut f = tempfile::Builder::new()
+        .prefix(name)
+        .suffix(".json")
+        .tempfile()
+        .expect("create tempfile");
+    f.write_all(body.as_bytes()).expect("write tempfile");
+    f.flush().expect("flush tempfile");
+    f
+}
+
+// ---- help surface (g2 proof) ----------------------------------------------
+
+#[test]
+fn falsify_crux_c_09_help_advertises_observation_file_flag() {
+    let out = apr_binary()
+        .args(["speculative-lint", "--help"])
+        .output()
+        .expect("run apr speculative-lint --help");
+    assert!(out.status.success(), "apr speculative-lint --help must exit 0");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("--observation-file"),
+        "--help must advertise --observation-file; got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("--alpha-min"),
+        "--help must advertise --alpha-min; got:\n{stdout}"
+    );
+}
+
+#[test]
+fn falsify_crux_c_09_rejects_bare_invocation_without_file() {
+    let out = apr_binary()
+        .arg("speculative-lint")
+        .output()
+        .expect("run apr speculative-lint without args");
+    assert!(
+        !out.status.success(),
+        "bare `apr speculative-lint` must exit non-zero"
+    );
+}
+
+// ---- parity gate (FALSIFY-CRUX-C-09-001) ----------------------------------
+
+#[test]
+fn falsify_crux_c_09_001_parity_ok_on_matching_tokens() {
+    let tmp = write_tmp_json(
+        "spec-parity-ok",
+        r#"{ "base_tokens": [1,2,3], "spec_tokens": [1,2,3] }"#,
+    );
+    let out = apr_binary()
+        .args(["speculative-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr speculative-lint");
+    assert!(
+        out.status.success(),
+        "matching parity must exit 0; stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn falsify_crux_c_09_001_parity_rejects_length_mismatch() {
+    let tmp = write_tmp_json(
+        "spec-parity-len",
+        r#"{ "base_tokens": [1,2,3], "spec_tokens": [1,2,3,4] }"#,
+    );
+    let out = apr_binary()
+        .args(["speculative-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr speculative-lint");
+    assert!(!out.status.success(), "length mismatch must exit non-zero");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("FALSIFY-CRUX-C-09-001"),
+        "stderr must cite FALSIFY-CRUX-C-09-001; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn falsify_crux_c_09_001_parity_rejects_token_divergence() {
+    let tmp = write_tmp_json(
+        "spec-parity-div",
+        r#"{ "base_tokens": [1,2,3], "spec_tokens": [1,2,9] }"#,
+    );
+    let out = apr_binary()
+        .args(["speculative-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr speculative-lint");
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-C-09-001"));
+}
+
+// ---- uplift gate (FALSIFY-CRUX-C-09-002) ----------------------------------
+
+#[test]
+fn falsify_crux_c_09_002_uplift_ok_above_threshold() {
+    let tmp = write_tmp_json(
+        "spec-uplift-ok",
+        r#"{ "base_tps": 100.0, "spec_tps": 140.0 }"#,
+    );
+    let out = apr_binary()
+        .args(["speculative-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr speculative-lint");
+    assert!(out.status.success(), "40% uplift must pass 30% threshold");
+}
+
+#[test]
+fn falsify_crux_c_09_002_uplift_rejects_regression() {
+    let tmp = write_tmp_json(
+        "spec-uplift-reg",
+        r#"{ "base_tps": 100.0, "spec_tps": 80.0 }"#,
+    );
+    let out = apr_binary()
+        .args(["speculative-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr speculative-lint");
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-C-09-002"));
+}
+
+// ---- compat gate (FALSIFY-CRUX-C-09-003) ----------------------------------
+
+#[test]
+fn falsify_crux_c_09_003_compat_ok_on_matching_tokenizers() {
+    let tmp = write_tmp_json(
+        "spec-compat-ok",
+        r#"{
+          "draft_tokenizer_sha256":  "abc123",
+          "target_tokenizer_sha256": "abc123",
+          "draft_vocab_size":        50000,
+          "target_vocab_size":       50000
+        }"#,
+    );
+    let out = apr_binary()
+        .args(["speculative-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr speculative-lint");
+    assert!(out.status.success());
+}
+
+#[test]
+fn falsify_crux_c_09_003_compat_rejects_vocab_mismatch() {
+    let tmp = write_tmp_json(
+        "spec-compat-vocab",
+        r#"{
+          "draft_tokenizer_sha256":  "abc123",
+          "target_tokenizer_sha256": "abc123",
+          "draft_vocab_size":        50000,
+          "target_vocab_size":       32000
+        }"#,
+    );
+    let out = apr_binary()
+        .args(["speculative-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr speculative-lint");
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-C-09-003"));
+}
+
+// ---- acceptance_rate gate (FALSIFY-CRUX-C-09-004) -------------------------
+
+#[test]
+fn falsify_crux_c_09_004_acceptance_rate_rejects_out_of_range() {
+    let tmp = write_tmp_json(
+        "spec-ar-oor",
+        r#"{ "speculative": { "acceptance_rate": 1.5 } }"#,
+    );
+    let out = apr_binary()
+        .args(["speculative-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr speculative-lint");
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-C-09-004"));
+}
+
+// ---- input validation -----------------------------------------------------
+
+#[test]
+fn falsify_crux_c_09_empty_file_rejected_via_cli() {
+    let tmp = write_tmp_json("spec-empty", "");
+    let out = apr_binary()
+        .args(["speculative-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr speculative-lint");
+    assert!(!out.status.success(), "empty file must be rejected");
+}
+
+#[test]
+fn falsify_crux_c_09_nonexistent_file_rejected() {
+    let out = apr_binary()
+        .args([
+            "speculative-lint",
+            "--observation-file",
+            "/nonexistent/path/obs.json",
+        ])
+        .output()
+        .expect("run apr speculative-lint");
+    assert!(!out.status.success());
+}
+
+// ---- --json shape ---------------------------------------------------------
+
+#[test]
+fn falsify_crux_c_09_json_output_shape() {
+    let tmp = write_tmp_json(
+        "spec-json-ok",
+        r#"{
+          "base_tokens": [1,2], "spec_tokens": [1,2],
+          "base_tps": 100.0, "spec_tps": 140.0,
+          "draft_tokenizer_sha256":  "abc",
+          "target_tokenizer_sha256": "abc",
+          "draft_vocab_size":        100,
+          "target_vocab_size":       100,
+          "speculative": { "acceptance_rate": 0.75 }
+        }"#,
+    );
+    let out = apr_binary()
+        .args(["--json", "speculative-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr speculative-lint --json");
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("\"parity\""), "--json must emit parity key");
+    assert!(stdout.contains("\"uplift\""), "--json must emit uplift key");
+    assert!(stdout.contains("\"compat\""), "--json must emit compat key");
+    assert!(
+        stdout.contains("\"acceptance\""),
+        "--json must emit acceptance key"
+    );
+}


### PR DESCRIPTION
## Summary
- CRUX-C-09 (vLLM speculative decoding, demand=4) promoted from `1.0.0-draft/draft` → `1.1.0/partial`.
- Four pure, deterministic classifiers in `crates/apr-cli/src/commands/speculative_decoding_classifier.rs` discharge FALSIFY-CRUX-C-09-{001,002,003,004} at the PARTIAL_ALGORITHM_LEVEL.
- All four FALSIFY gates now carry `evidence_discharged_by` with classifier path, sub-claim, test list, scope, and full-discharge blockers recorded in the ledger.

## What the classifiers check
- `classify_speculative_parity(base, spec)` — byte-identical length+positions; first-divergence index reported (deterministic).
- `classify_throughput_uplift(base_tps, spec_tps, alpha_min)` — observed_alpha = spec/base−1; splits `Regression` (spec<base), `BelowThreshold` (0 ≤ alpha < alpha_min), `Ok`. Rejects non-finite / non-positive base / negative spec / negative alpha_min as `InvalidInput`.
- `classify_tokenizer_compatibility(draft_sha, target_sha, draft_vocab, target_vocab)` — sha equal (case-insensitive) AND vocab_size equal; empty-sha and zero-vocab explicitly rejected.
- `classify_acceptance_rate(json)` — `speculative.acceptance_rate` present, numeric, non-NaN, ∈ `[0, 1]`; `NaN` distinguished from `OutOfRange`.

## Test plan
- [x] `pv validate contracts/crux-C-09-v1.yaml` passes (0 error, 0 warning)
- [x] `cargo test -p apr-cli --lib speculative_decoding_classifier` — 33/33 green
- [x] `cargo clippy -p apr-cli --lib -- -D warnings` — clean
- [ ] Full discharge requires live `apr run --draft-model` / `apr serve --draft-model` surfaces, `apr bench --draft-model` real tokens_per_sec, and `apr run --json` emitting `speculative.acceptance_rate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)