### PR TITLE
feat(crux-c-10): GBNF grammar-constrained output (JSON+diagnostic+logit-mask) classifier (2 of 2 FALSIFY at PARTIAL_ALGORITHM_LEVEL)

### DIFF
--- a/contracts/apr-cli-commands-v1.yaml
+++ b/contracts/apr-cli-commands-v1.yaml
@@ -21,7 +21,7 @@ metadata:
 kind: CLICommandContract
 name: apr-cli-commands
 version: "1.0.0"
-scope: "all apr CLI subcommands (64 commands — original 57 + `mcp` added 2026-04-17 via PR #864 + `registry` added 2026-04-20 via CRUX-A-01 + `ollama-chat-lint` added 2026-04-21 via CRUX-C-04 SHIP-001 retrofit + `dry-sampling-lint` added 2026-04-21 via CRUX-C-23 SHIP-001 retrofit + `awq-lint` added 2026-04-21 via CRUX-B-08 SHIP-001 retrofit + `oom-lint` added 2026-04-21 via CRUX-F-13 SHIP-001 + `tool-use-lint` added 2026-04-21 via CRUX-C-11 SHIP-001 retrofit)"
+scope: "all apr CLI subcommands (65 commands — original 57 + `mcp` added 2026-04-17 via PR #864 + `registry` added 2026-04-20 via CRUX-A-01 + `ollama-chat-lint` added 2026-04-21 via CRUX-C-04 SHIP-001 retrofit + `dry-sampling-lint` added 2026-04-21 via CRUX-C-23 SHIP-001 retrofit + `awq-lint` added 2026-04-21 via CRUX-B-08 SHIP-001 retrofit + `oom-lint` added 2026-04-21 via CRUX-F-13 SHIP-001 + `tool-use-lint` added 2026-04-21 via CRUX-C-11 SHIP-001 retrofit + `gbnf-lint` added 2026-04-21 via CRUX-C-10 SHIP-001 retrofit)"
 binary: "apr"
 install: "cargo install aprender"
 
@@ -417,6 +417,12 @@ commands:
   - name: tool-use-lint
     category: inspection
     description: "Lint a captured OpenAI tool-use response (CRUX-C-11)"
+    requires_model: false
+    side_effects: []
+
+  - name: gbnf-lint
+    category: inspection
+    description: "Lint a GBNF grammar-constrained observation (CRUX-C-10)"
     requires_model: false
     side_effects: []
 

--- a/contracts/crux-C-10-v1.yaml
+++ b/contracts/crux-C-10-v1.yaml
@@ -1,53 +1,51 @@
 # CRUX-C-10 — Grammar-constrained GBNF output
-# Auto-scaffolded from crux-competitive-research-ux-v1.yaml (DRAFT).
-# DO NOT promote to ACTIVE until: (1) evidence collected, (2) falsification
-# body reflects competitor's canonical CLI, (3) apr surface mapped or gap
-# tracked in pmat work (see master §12).
 
 metadata:
   id: CRUX-C-10
-  version: "1.0.0-draft"
+  version: "1.1.0"
   created: "2026-04-18"
   author: PAIML Engineering
   registry: true
-  status: draft
+  status: partial
   parent_contracts:
   - crux-competitive-research-ux-v1
   category: "C — Serving & Chat UX"
   competitor: llama_cpp
-  demand_score: 4  # 1..5, high priority in pmat work
+  demand_score: 4
   intake_status: partial
   description: >
-    Grammar-constrained GBNF output. Root-cause workflow extracted from llama_cpp UX — see master
-    subspec §5.C and §2 Five Whys methodology for rationale. This
-    draft contract exists to satisfy the Iron Rule "no contract → no user
-    story"; the falsification body below is a placeholder and MUST be
-    replaced with the competitor's canonical CLI transcript before promotion.
+    Grammar-constrained GBNF output. llama.cpp canonical:
+    `llama-cli --grammar-file grammar.gbnf --prompt "..."`. apr parity:
+    `apr run <model> --grammar-file grammar.gbnf --prompt "..."` and
+    HTTP POST /v1/chat/completions with `{"grammar": "<gbnf-string>"}`.
+    Output MUST parse as the grammar's start symbol; every emitted token
+    MUST be drawn from the legal set at the current parser state, which
+    requires illegal-position logits to be masked to -INFINITY before
+    sampling. Malformed grammars MUST fail with a `grammar`-tagged
+    diagnostic on stderr.
 
   references:
-  - 'master: contracts/crux-competitive-research-ux-v1.yaml — §5 + §12'
-  - github.com/huggingface/accelerate
-  - github.com/pytorch/pytorch — DDP/FSDP
+  - "https://github.com/ggerganov/llama.cpp/blob/master/grammars/README.md"
+  - "https://github.com/ggerganov/llama.cpp/blob/master/grammars/json.gbnf"
+
 equations:
   gbnf_grammar_constraint:
     formula: |
       llama.cpp canonical:
-        llama-cli --grammar-file grammar.gbnf --prompt "..."  (or --grammar "root ::= ...")
-        Reference: https://github.com/ggerganov/llama.cpp/blob/master/grammars/README.md
+        llama-cli --grammar-file grammar.gbnf --prompt "..."
       apr parity target:
         apr run <model> --grammar-file grammar.gbnf --prompt "..." [--json]
         apr serve HTTP: POST /v1/chat/completions with "grammar": "<gbnf-string>"
       Output MUST parse as the grammar's start symbol (root ::= ...).
       Every emitted token MUST be drawn from the token set legal at the
       current grammar parser state; tokens outside that set have their
-      logits masked to -inf before sampling.
+      logits masked to -INFINITY before sampling.
     domain: "(model, prompt, gbnf_grammar_string)"
     codomain: generated_text:string
     invariants:
     - "Output string is accepted by a conforming GBNF parser for the supplied grammar"
-    - "Rejected tokens (outside legal set at state s) have sampling probability == 0"
-    - "If grammar is unsatisfiable, apr returns non-zero exit and stderr contains 'grammar'"
-    - "Reference: llama.cpp grammars/README.md and examples/json.gbnf"
+    - "Rejected tokens (outside legal set at state s) have logit == -INFINITY"
+    - "If grammar is unsatisfiable/malformed, apr returns non-zero exit and stderr contains 'grammar'"
 
   gbnf_json_output_wellformed:
     formula: |
@@ -64,8 +62,6 @@ falsification_tests:
   rule: grammar-constrained output parses as JSON when grammar=json.gbnf
   prediction: "apr run --grammar-file json.gbnf emits text that json.loads() accepts"
   test: |
-    # Golden: llama.cpp's own json.gbnf grammar
-    # Reference: https://github.com/ggerganov/llama.cpp/blob/master/grammars/json.gbnf
     GRAMMAR=/tmp/crux-c-10-json.gbnf
     cat >"$GRAMMAR" <<'EOF'
     root   ::= object
@@ -84,9 +80,46 @@ falsification_tests:
     python3 -c "import json,sys; json.loads(sys.argv[1])" "$OUT" \
       || { echo "FAIL: output not valid JSON: $OUT" >&2; exit 1; }
   if_fails: "Grammar-constrained output does not parse under the supplied GBNF (apr does not mask illegal tokens)"
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/gbnf_classifier.rs
+    sub_claim: |
+      Two algorithm-level necessary conditions:
+      (1) `classify_json_grammar_output(output, finish_reason)` accepts iff
+          `output` is non-empty, `finish_reason ∈ {"stop", "length"}`, and
+          `serde_json::from_str::<Value>(output)` succeeds. Rejection paths
+          distinguish `EmptyOutput`, `NotJson{error}`, and
+          `WrongFinishReason{got}` so a wrong-cause bug cannot be mistaken
+          for a JSON parse bug.
+      (2) `classify_illegal_token_masking(logits, legal_mask)` is the
+          mechanism condition behind (1): every illegal-at-state-s position
+          must have logit == -INFINITY (finite values, +INF, and NaN are
+          all rejected as `IllegalTokenNotMasked{token_index, logit}`).
+          Length mismatch and an all-false mask are distinct defect
+          classes (`LengthMismatch`, `NoLegalTokens`).
+      Both classifiers are pure; deterministic.
+    tests:
+    - json_grammar_ok_on_object_with_stop
+    - json_grammar_ok_on_array_with_length
+    - json_grammar_rejects_empty_output
+    - json_grammar_rejects_non_json_text
+    - json_grammar_rejects_wrong_finish_reason
+    - json_grammar_rejects_content_filter_reason
+    - json_grammar_classifier_is_deterministic
+    - masking_ok_when_illegal_positions_are_neg_infinity
+    - masking_ok_when_all_positions_legal
+    - masking_rejects_length_mismatch
+    - masking_rejects_empty_legal_mask
+    - masking_rejects_finite_logit_at_illegal_position
+    - masking_rejects_positive_infinity_at_illegal_position
+    - masking_rejects_nan_at_illegal_position
+    - masking_classifier_is_deterministic
+    - allowed_finish_reasons_are_stop_or_length
+    scope: "(output, finish_reason) and (logits, legal_mask) — both pure"
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: "apr run --grammar-file surface integrating a real GBNF parser + sampler that consults legal_mask"
 
 - id: FALSIFY-CRUX-C-10-002
-  rule: unsupported/unsatisfiable grammar surfaces clear error
+  rule: malformed grammar surfaces a non-zero exit with 'grammar' diagnostic
   prediction: "apr run with malformed grammar exits non-zero and mentions 'grammar' in stderr"
   test: |
     BAD=/tmp/crux-c-10-bad.gbnf
@@ -98,6 +131,28 @@ falsification_tests:
     grep -i grammar /tmp/crux-c-10-err.log >/dev/null \
       || { echo "FAIL: stderr missing 'grammar' diagnostic" >&2; exit 1; }
   if_fails: "apr accepted malformed GBNF silently or emitted no diagnostic"
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/gbnf_classifier.rs
+    sub_claim: |
+      Algorithm-level necessary condition:
+      `classify_grammar_error_diagnostic(exit_code, stderr)` accepts iff
+      `exit_code != 0` AND the lowercased stderr contains the substring
+      "grammar". Rejection paths:
+        (a) `exit_code == 0` → `ZeroExitCode` (silent accept bug);
+        (b) non-zero but no keyword → `MissingGrammarDiagnostic{stderr_snippet}`
+            with a deterministic 160-char snippet so the actionable error is
+            visible without flooding the classifier's telemetry.
+      Pure; deterministic.
+    tests:
+    - grammar_error_ok_on_nonzero_exit_with_keyword
+    - grammar_error_ok_case_insensitive
+    - grammar_error_rejects_zero_exit
+    - grammar_error_rejects_missing_keyword
+    - grammar_error_snippet_is_truncated_to_160_chars
+    - grammar_error_classifier_is_deterministic
+    scope: "(exit_code: i32, stderr: &str) → GrammarErrorDiagnosticOutcome (pure)"
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: "apr run --grammar-file surface that actually rejects malformed GBNF with a 'grammar'-tagged diagnostic"
 
 proof_obligations:
 - type: equivalence
@@ -105,17 +160,24 @@ proof_obligations:
 - type: invariant
   property: "Generated text parses under supplied GBNF grammar (root accept state reached or max_tokens)"
 - type: invariant
+  property: "Illegal-at-state-s tokens have logit == -INFINITY"
+- type: invariant
   property: "Malformed grammar produces non-zero exit with 'grammar' diagnostic in stderr"
 
 verification_summary:
-  total_obligations: 3
+  total_obligations: 4
   proven: 0
   tested: 0
   status: spec-complete
+  discharge_ledger:
+  - falsify_id: FALSIFY-CRUX-C-10-001
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    blocked_on: "apr run --grammar-file surface + real GBNF parser wired to sampler"
+  - falsify_id: FALSIFY-CRUX-C-10-002
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    blocked_on: "apr run --grammar-file surface rejecting malformed GBNF with a tagged diagnostic"
 
 pmat_work_tracking:
-  # Managed by master contract §12. If intake_status == "missing", a ticket
-  # tagged `crux-crux-c-10` is auto-created by scripts/crux_bulk_pmat_work.sh.
   ticket_tag: crux-crux-c-10
   priority: high
   auto_created: false

--- a/contracts/crux-C-10-v1.yaml
+++ b/contracts/crux-C-10-v1.yaml
@@ -2,7 +2,7 @@
 
 metadata:
   id: CRUX-C-10
-  version: "1.1.0"
+  version: "1.2.0"
   created: "2026-04-18"
   author: PAIML Engineering
   registry: true
@@ -82,6 +82,8 @@ falsification_tests:
   if_fails: "Grammar-constrained output does not parse under the supplied GBNF (apr does not mask illegal tokens)"
   evidence_discharged_by:
     classifier_path: crates/apr-cli/src/commands/gbnf_classifier.rs
+    cli_path: crates/apr-cli/src/commands/gbnf_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_c_10.rs
     sub_claim: |
       Two algorithm-level necessary conditions:
       (1) `classify_json_grammar_output(output, finish_reason)` accepts iff
@@ -97,6 +99,14 @@ falsification_tests:
           Length mismatch and an all-false mask are distinct defect
           classes (`LengthMismatch`, `NoLegalTokens`).
       Both classifiers are pure; deterministic.
+    e2e_tests:
+    - falsify_crux_c_10_001_json_ok_on_valid_json_with_stop
+    - falsify_crux_c_10_001_json_rejects_non_json_output
+    - falsify_crux_c_10_001_json_rejects_wrong_finish_reason
+    - falsify_crux_c_10_001_masking_ok_when_illegal_positions_are_null
+    - falsify_crux_c_10_001_masking_rejects_finite_at_illegal_position
+    - falsify_crux_c_10_001_masking_rejects_length_mismatch
+    - falsify_crux_c_10_json_output_shape
     tests:
     - json_grammar_ok_on_object_with_stop
     - json_grammar_ok_on_array_with_length
@@ -133,6 +143,8 @@ falsification_tests:
   if_fails: "apr accepted malformed GBNF silently or emitted no diagnostic"
   evidence_discharged_by:
     classifier_path: crates/apr-cli/src/commands/gbnf_classifier.rs
+    cli_path: crates/apr-cli/src/commands/gbnf_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_c_10.rs
     sub_claim: |
       Algorithm-level necessary condition:
       `classify_grammar_error_diagnostic(exit_code, stderr)` accepts iff
@@ -143,6 +155,10 @@ falsification_tests:
             with a deterministic 160-char snippet so the actionable error is
             visible without flooding the classifier's telemetry.
       Pure; deterministic.
+    e2e_tests:
+    - falsify_crux_c_10_002_diagnostic_ok_on_nonzero_exit_with_keyword
+    - falsify_crux_c_10_002_diagnostic_rejects_zero_exit
+    - falsify_crux_c_10_002_diagnostic_rejects_missing_keyword
     tests:
     - grammar_error_ok_on_nonzero_exit_with_keyword
     - grammar_error_ok_case_insensitive
@@ -176,6 +192,19 @@ verification_summary:
   - falsify_id: FALSIFY-CRUX-C-10-002
     discharge_status: PARTIAL_ALGORITHM_LEVEL
     blocked_on: "apr run --grammar-file surface rejecting malformed GBNF with a tagged diagnostic"
+
+ship_discipline:
+  ship_rule: CRUX-SHIP-001
+  deliverables_present:
+    classifier: crates/apr-cli/src/commands/gbnf_classifier.rs
+    cli_wiring: "crates/apr-cli/src/extended_commands.rs + dispatch_analysis.rs + commands/gbnf_lint.rs (apr gbnf-lint --observation-file FILE)"
+    e2e_test: crates/apr-cli/tests/falsification_crux_c_10.rs
+    contract: contracts/crux-C-10-v1.yaml
+  merge_gates:
+    g1_classifier_green: "gbnf_classifier unit tests pass (3 classifiers × determinism + boundary coverage)"
+    g2_cli_reachable: "apr gbnf-lint --help advertises --observation-file"
+    g3_e2e_runs: "14 falsification tests pass (falsification_crux_c_10) — help surface, bare-invocation reject, 3 gates × ok+reject, length-mismatch, empty/nonexistent file, --json shape"
+    g4_contract_discharged: "2 of 2 FALSIFY-CRUX-C-10-00{1,2} at PARTIAL_ALGORITHM_LEVEL under BLOCKER-UPSTREAM-MISSING (live apr run/serve --grammar-file surface); classifier + CLI + e2e paths all exercised end-to-end on captured JSON observations. Masking gate exercised at e2e via null-as-(-Infinity) JSON convention"
 
 pmat_work_tracking:
   ticket_tag: crux-crux-c-10

--- a/crates/apr-cli/src/commands/gbnf_classifier.rs
+++ b/crates/apr-cli/src/commands/gbnf_classifier.rs
@@ -1,0 +1,350 @@
+//! Grammar-constrained (GBNF) output classifier (CRUX-C-10).
+//!
+//! Three pure, deterministic classifiers that discharge
+//! FALSIFY-CRUX-C-10-{001,002} at the PARTIAL_ALGORITHM_LEVEL:
+//!
+//!   * `classify_json_grammar_output` — given an already-emitted completion
+//!     string and its finish_reason, the string parses as JSON and the
+//!     finish_reason is one of {"stop", "length"}.
+//!   * `classify_grammar_error_diagnostic` — given `(exit_code, stderr_text)`,
+//!     a malformed-grammar invocation exits non-zero and stderr mentions
+//!     "grammar" (case-insensitive).
+//!   * `classify_illegal_token_masking` — given a proposed next-token logits
+//!     row and a `legal_mask` computed by the grammar parser, every illegal
+//!     position has a logit that is strictly `-INFINITY` (NaN and any finite
+//!     value rejected).
+//!
+//! Full discharge blocks on `apr run --grammar-file` and
+//! `apr serve POST /v1/chat/completions {"grammar": ...}` surfaces
+//! integrating a real GBNF parser.
+
+use serde_json::Value;
+
+/// Allowed finish_reason values for grammar-constrained completions.
+pub const GBNF_ALLOWED_FINISH_REASONS: &[&str] = &["stop", "length"];
+
+/// Outcome of `classify_json_grammar_output`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum JsonGrammarOutputOutcome {
+    /// Completion parses as JSON and finish_reason is stop|length.
+    Ok,
+    /// The completion string is empty.
+    EmptyOutput,
+    /// The completion string does not parse as JSON.
+    NotJson { error: String },
+    /// finish_reason is not one of {"stop", "length"}.
+    WrongFinishReason { got: String },
+}
+
+/// Grammar-parity gate: output must be valid JSON and finish must be clean.
+pub fn classify_json_grammar_output(
+    output: &str,
+    finish_reason: &str,
+) -> JsonGrammarOutputOutcome {
+    if output.is_empty() {
+        return JsonGrammarOutputOutcome::EmptyOutput;
+    }
+    if !GBNF_ALLOWED_FINISH_REASONS.contains(&finish_reason) {
+        return JsonGrammarOutputOutcome::WrongFinishReason {
+            got: finish_reason.to_string(),
+        };
+    }
+    match serde_json::from_str::<Value>(output) {
+        Ok(_) => JsonGrammarOutputOutcome::Ok,
+        Err(e) => JsonGrammarOutputOutcome::NotJson {
+            error: e.to_string(),
+        },
+    }
+}
+
+/// Outcome of `classify_grammar_error_diagnostic`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GrammarErrorDiagnosticOutcome {
+    /// Exit code non-zero AND stderr mentions "grammar".
+    Ok,
+    /// Exit code was zero — malformed grammar was silently accepted.
+    ZeroExitCode,
+    /// Exit code non-zero but stderr does not mention "grammar".
+    MissingGrammarDiagnostic { stderr_snippet: String },
+}
+
+/// Malformed-grammar gate: non-zero exit AND "grammar" mentioned in stderr.
+pub fn classify_grammar_error_diagnostic(
+    exit_code: i32,
+    stderr: &str,
+) -> GrammarErrorDiagnosticOutcome {
+    if exit_code == 0 {
+        return GrammarErrorDiagnosticOutcome::ZeroExitCode;
+    }
+    if stderr.to_lowercase().contains("grammar") {
+        return GrammarErrorDiagnosticOutcome::Ok;
+    }
+    let snippet = stderr.chars().take(160).collect::<String>();
+    GrammarErrorDiagnosticOutcome::MissingGrammarDiagnostic {
+        stderr_snippet: snippet,
+    }
+}
+
+/// Outcome of `classify_illegal_token_masking`.
+#[derive(Debug, Clone, PartialEq)]
+pub enum IllegalTokenMaskingOutcome {
+    /// Every illegal position has logit == -INFINITY.
+    Ok,
+    /// Logits row and legal_mask have different lengths.
+    LengthMismatch { logits_len: usize, mask_len: usize },
+    /// No legal tokens in the mask (grammar stuck — different defect class).
+    NoLegalTokens,
+    /// An illegal position has a finite (or +INF, or NaN) logit.
+    IllegalTokenNotMasked {
+        token_index: usize,
+        logit: f32,
+    },
+}
+
+/// Logit-masking gate: illegal-at-state-s tokens have logit = `-INFINITY`.
+/// Any finite value, `+INFINITY`, or `NaN` at an illegal position is rejected.
+pub fn classify_illegal_token_masking(
+    logits: &[f32],
+    legal_mask: &[bool],
+) -> IllegalTokenMaskingOutcome {
+    if logits.len() != legal_mask.len() {
+        return IllegalTokenMaskingOutcome::LengthMismatch {
+            logits_len: logits.len(),
+            mask_len: legal_mask.len(),
+        };
+    }
+    if !legal_mask.iter().any(|&b| b) {
+        return IllegalTokenMaskingOutcome::NoLegalTokens;
+    }
+    for (i, (&lg, &ok)) in logits.iter().zip(legal_mask.iter()).enumerate() {
+        if !ok && lg != f32::NEG_INFINITY {
+            return IllegalTokenMaskingOutcome::IllegalTokenNotMasked {
+                token_index: i,
+                logit: lg,
+            };
+        }
+    }
+    IllegalTokenMaskingOutcome::Ok
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---- JSON grammar output ---------------------------------------------
+
+    #[test]
+    fn json_grammar_ok_on_object_with_stop() {
+        assert_eq!(
+            classify_json_grammar_output("{\"a\":1}", "stop"),
+            JsonGrammarOutputOutcome::Ok
+        );
+    }
+
+    #[test]
+    fn json_grammar_ok_on_array_with_length() {
+        assert_eq!(
+            classify_json_grammar_output("[1,2,3]", "length"),
+            JsonGrammarOutputOutcome::Ok
+        );
+    }
+
+    #[test]
+    fn json_grammar_rejects_empty_output() {
+        assert_eq!(
+            classify_json_grammar_output("", "stop"),
+            JsonGrammarOutputOutcome::EmptyOutput
+        );
+    }
+
+    #[test]
+    fn json_grammar_rejects_non_json_text() {
+        match classify_json_grammar_output("not valid json", "stop") {
+            JsonGrammarOutputOutcome::NotJson { error } => {
+                assert!(!error.is_empty());
+            }
+            other => panic!("expected NotJson, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn json_grammar_rejects_wrong_finish_reason() {
+        assert_eq!(
+            classify_json_grammar_output("{}", "tool_calls"),
+            JsonGrammarOutputOutcome::WrongFinishReason {
+                got: "tool_calls".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn json_grammar_rejects_content_filter_reason() {
+        assert_eq!(
+            classify_json_grammar_output("{}", "content_filter"),
+            JsonGrammarOutputOutcome::WrongFinishReason {
+                got: "content_filter".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn json_grammar_classifier_is_deterministic() {
+        let a = classify_json_grammar_output("{\"k\":null}", "stop");
+        let b = classify_json_grammar_output("{\"k\":null}", "stop");
+        assert_eq!(a, b);
+    }
+
+    // ---- malformed-grammar diagnostic ------------------------------------
+
+    #[test]
+    fn grammar_error_ok_on_nonzero_exit_with_keyword() {
+        assert_eq!(
+            classify_grammar_error_diagnostic(1, "error: invalid grammar at line 1"),
+            GrammarErrorDiagnosticOutcome::Ok
+        );
+    }
+
+    #[test]
+    fn grammar_error_ok_case_insensitive() {
+        assert_eq!(
+            classify_grammar_error_diagnostic(2, "GRAMMAR parse error"),
+            GrammarErrorDiagnosticOutcome::Ok
+        );
+    }
+
+    #[test]
+    fn grammar_error_rejects_zero_exit() {
+        assert_eq!(
+            classify_grammar_error_diagnostic(0, "grammar was fine"),
+            GrammarErrorDiagnosticOutcome::ZeroExitCode
+        );
+    }
+
+    #[test]
+    fn grammar_error_rejects_missing_keyword() {
+        match classify_grammar_error_diagnostic(1, "unrelated parse error") {
+            GrammarErrorDiagnosticOutcome::MissingGrammarDiagnostic { stderr_snippet } => {
+                assert!(stderr_snippet.contains("unrelated"));
+            }
+            other => panic!("expected MissingGrammarDiagnostic, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn grammar_error_snippet_is_truncated_to_160_chars() {
+        let long = "x".repeat(500);
+        match classify_grammar_error_diagnostic(1, &long) {
+            GrammarErrorDiagnosticOutcome::MissingGrammarDiagnostic { stderr_snippet } => {
+                assert_eq!(stderr_snippet.len(), 160);
+            }
+            other => panic!("expected MissingGrammarDiagnostic, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn grammar_error_classifier_is_deterministic() {
+        let a = classify_grammar_error_diagnostic(1, "grammar bad");
+        let b = classify_grammar_error_diagnostic(1, "grammar bad");
+        assert_eq!(a, b);
+    }
+
+    // ---- illegal-token masking -------------------------------------------
+
+    #[test]
+    fn masking_ok_when_illegal_positions_are_neg_infinity() {
+        let logits = [1.0, f32::NEG_INFINITY, 2.0, f32::NEG_INFINITY];
+        let legal = [true, false, true, false];
+        assert_eq!(
+            classify_illegal_token_masking(&logits, &legal),
+            IllegalTokenMaskingOutcome::Ok
+        );
+    }
+
+    #[test]
+    fn masking_ok_when_all_positions_legal() {
+        let logits = [1.0, 2.0, 3.0];
+        let legal = [true, true, true];
+        assert_eq!(
+            classify_illegal_token_masking(&logits, &legal),
+            IllegalTokenMaskingOutcome::Ok
+        );
+    }
+
+    #[test]
+    fn masking_rejects_length_mismatch() {
+        let logits = [1.0, 2.0];
+        let legal = [true, true, false];
+        assert_eq!(
+            classify_illegal_token_masking(&logits, &legal),
+            IllegalTokenMaskingOutcome::LengthMismatch {
+                logits_len: 2,
+                mask_len: 3
+            }
+        );
+    }
+
+    #[test]
+    fn masking_rejects_empty_legal_mask() {
+        let logits = [f32::NEG_INFINITY, f32::NEG_INFINITY, f32::NEG_INFINITY];
+        let legal = [false, false, false];
+        assert_eq!(
+            classify_illegal_token_masking(&logits, &legal),
+            IllegalTokenMaskingOutcome::NoLegalTokens
+        );
+    }
+
+    #[test]
+    fn masking_rejects_finite_logit_at_illegal_position() {
+        let logits = [1.0, 2.0, 3.0];
+        let legal = [true, false, true];
+        match classify_illegal_token_masking(&logits, &legal) {
+            IllegalTokenMaskingOutcome::IllegalTokenNotMasked { token_index, logit } => {
+                assert_eq!(token_index, 1);
+                assert!((logit - 2.0).abs() < 1e-9);
+            }
+            other => panic!("expected IllegalTokenNotMasked, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn masking_rejects_positive_infinity_at_illegal_position() {
+        let logits = [1.0, f32::INFINITY, 3.0];
+        let legal = [true, false, true];
+        match classify_illegal_token_masking(&logits, &legal) {
+            IllegalTokenMaskingOutcome::IllegalTokenNotMasked { token_index, logit } => {
+                assert_eq!(token_index, 1);
+                assert!(logit.is_infinite() && logit.is_sign_positive());
+            }
+            other => panic!("expected IllegalTokenNotMasked, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn masking_rejects_nan_at_illegal_position() {
+        let logits = [1.0, f32::NAN, 3.0];
+        let legal = [true, false, true];
+        match classify_illegal_token_masking(&logits, &legal) {
+            IllegalTokenMaskingOutcome::IllegalTokenNotMasked { token_index, logit } => {
+                assert_eq!(token_index, 1);
+                assert!(logit.is_nan());
+            }
+            other => panic!("expected IllegalTokenNotMasked, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn masking_classifier_is_deterministic() {
+        let logits = [1.0, f32::NEG_INFINITY];
+        let legal = [true, false];
+        let a = classify_illegal_token_masking(&logits, &legal);
+        let b = classify_illegal_token_masking(&logits, &legal);
+        assert_eq!(a, b);
+    }
+
+    // ---- constants -------------------------------------------------------
+
+    #[test]
+    fn allowed_finish_reasons_are_stop_or_length() {
+        assert_eq!(GBNF_ALLOWED_FINISH_REASONS, &["stop", "length"]);
+    }
+}

--- a/crates/apr-cli/src/commands/gbnf_lint.rs
+++ b/crates/apr-cli/src/commands/gbnf_lint.rs
@@ -1,0 +1,189 @@
+//! `apr gbnf-lint` — CRUX-C-10 grammar-constrained output linter.
+//!
+//! Reads a JSON observation file that captures a single grammar-constrained
+//! run and dispatches three classifiers (json output, grammar-error
+//! diagnostic, illegal-token masking). Emits a text or `--json` report.
+//!
+//! Spec: `contracts/crux-C-10-v1.yaml`. CRUX-SHIP-001 g2/g3 surface.
+//!
+//! Observation schema (top-level keys; all optional — missing fields skip
+//! the corresponding classifier):
+//!
+//!   {
+//!     "output":        "{...}",                    // json gate input 1
+//!     "finish_reason": "stop",                     // json gate input 2
+//!     "grammar_error": {                           // error gate
+//!       "exit_code": 1,
+//!       "stderr":    "invalid grammar at line 1"
+//!     },
+//!     "masking": {                                 // masking gate
+//!       "logits":     [1.0, null, 2.0],            // null == -Infinity
+//!       "legal_mask": [true, false, true]
+//!     }
+//!   }
+
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+
+use crate::commands::gbnf_classifier as clf;
+use crate::error::{CliError, Result};
+
+pub(crate) fn run(observation_file: &Path, json: bool) -> Result<()> {
+    if !observation_file.exists() {
+        return Err(CliError::FileNotFound(PathBuf::from(observation_file)));
+    }
+
+    let body = std::fs::read_to_string(observation_file)?;
+    let obs: Value = serde_json::from_str(&body).map_err(|e| {
+        CliError::InvalidFormat(format!(
+            "apr gbnf-lint: failed to parse JSON from {}: {e}",
+            observation_file.display()
+        ))
+    })?;
+
+    let json_out = classify_json(&obs);
+    let err_diag = classify_error_diagnostic(&obs);
+    let masking = classify_masking(&obs);
+
+    let fail_reasons: Vec<String> = [
+        json_out.as_ref().and_then(json_fail_reason),
+        err_diag.as_ref().and_then(error_fail_reason),
+        masking.as_ref().and_then(masking_fail_reason),
+    ]
+    .into_iter()
+    .flatten()
+    .collect();
+
+    print_report(
+        observation_file,
+        json_out.as_ref(),
+        err_diag.as_ref(),
+        masking.as_ref(),
+        json,
+    );
+
+    if fail_reasons.is_empty() {
+        Ok(())
+    } else {
+        Err(CliError::ValidationFailed(fail_reasons.join("; ")))
+    }
+}
+
+fn classify_json(obs: &Value) -> Option<clf::JsonGrammarOutputOutcome> {
+    let output = obs.get("output")?.as_str()?;
+    let finish = obs.get("finish_reason")?.as_str()?;
+    Some(clf::classify_json_grammar_output(output, finish))
+}
+
+fn classify_error_diagnostic(obs: &Value) -> Option<clf::GrammarErrorDiagnosticOutcome> {
+    let ge = obs.get("grammar_error")?.as_object()?;
+    let exit_code = ge.get("exit_code")?.as_i64()? as i32;
+    let stderr = ge.get("stderr")?.as_str()?;
+    Some(clf::classify_grammar_error_diagnostic(exit_code, stderr))
+}
+
+fn classify_masking(obs: &Value) -> Option<clf::IllegalTokenMaskingOutcome> {
+    let m = obs.get("masking")?.as_object()?;
+    let logits_raw = m.get("logits")?.as_array()?;
+    let mask_raw = m.get("legal_mask")?.as_array()?;
+
+    let logits: Vec<f32> = logits_raw
+        .iter()
+        .map(|v| match v {
+            Value::Null => f32::NEG_INFINITY,
+            Value::Number(n) => n.as_f64().map(|x| x as f32).unwrap_or(f32::NAN),
+            _ => f32::NAN,
+        })
+        .collect();
+    let mask: Vec<bool> = mask_raw.iter().filter_map(|v| v.as_bool()).collect();
+
+    if mask.len() != mask_raw.len() {
+        return None;
+    }
+    Some(clf::classify_illegal_token_masking(&logits, &mask))
+}
+
+fn json_fail_reason(o: &clf::JsonGrammarOutputOutcome) -> Option<String> {
+    match o {
+        clf::JsonGrammarOutputOutcome::Ok => None,
+        clf::JsonGrammarOutputOutcome::EmptyOutput => Some(
+            "FALSIFY-CRUX-C-10-001 json: empty output string".to_string(),
+        ),
+        clf::JsonGrammarOutputOutcome::NotJson { error } => Some(format!(
+            "FALSIFY-CRUX-C-10-001 json: output does not parse as JSON: {error}"
+        )),
+        clf::JsonGrammarOutputOutcome::WrongFinishReason { got } => Some(format!(
+            "FALSIFY-CRUX-C-10-001 json: finish_reason={got:?} not in {{stop, length}}"
+        )),
+    }
+}
+
+fn error_fail_reason(o: &clf::GrammarErrorDiagnosticOutcome) -> Option<String> {
+    match o {
+        clf::GrammarErrorDiagnosticOutcome::Ok => None,
+        clf::GrammarErrorDiagnosticOutcome::ZeroExitCode => Some(
+            "FALSIFY-CRUX-C-10-002 diagnostic: malformed grammar silently accepted (exit 0)"
+                .to_string(),
+        ),
+        clf::GrammarErrorDiagnosticOutcome::MissingGrammarDiagnostic { stderr_snippet } => {
+            Some(format!(
+                "FALSIFY-CRUX-C-10-002 diagnostic: stderr missing 'grammar' keyword; snippet={stderr_snippet:?}"
+            ))
+        }
+    }
+}
+
+fn masking_fail_reason(o: &clf::IllegalTokenMaskingOutcome) -> Option<String> {
+    match o {
+        clf::IllegalTokenMaskingOutcome::Ok => None,
+        clf::IllegalTokenMaskingOutcome::LengthMismatch {
+            logits_len,
+            mask_len,
+        } => Some(format!(
+            "FALSIFY-CRUX-C-10-001 masking: length mismatch logits={logits_len} mask={mask_len}"
+        )),
+        clf::IllegalTokenMaskingOutcome::NoLegalTokens => Some(
+            "FALSIFY-CRUX-C-10-001 masking: legal_mask has no legal positions".to_string(),
+        ),
+        clf::IllegalTokenMaskingOutcome::IllegalTokenNotMasked {
+            token_index,
+            logit,
+        } => Some(format!(
+            "FALSIFY-CRUX-C-10-001 masking: illegal token at idx {token_index} has logit={logit} (expected -Infinity)"
+        )),
+    }
+}
+
+fn print_report(
+    path: &Path,
+    json_out: Option<&clf::JsonGrammarOutputOutcome>,
+    err_diag: Option<&clf::GrammarErrorDiagnosticOutcome>,
+    masking: Option<&clf::IllegalTokenMaskingOutcome>,
+    json: bool,
+) {
+    if json {
+        let v = serde_json::json!({
+            "observation_path": path.display().to_string(),
+            "json":      json_out.map(|o| format!("{o:?}")),
+            "diagnostic": err_diag.map(|o| format!("{o:?}")),
+            "masking":   masking.map(|o| format!("{o:?}")),
+        });
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&v).unwrap_or_else(|_| v.to_string())
+        );
+    } else {
+        println!("gbnf-lint report for {}", path.display());
+        print_line("  json:        ", json_out.map(|o| format!("{o:?}")));
+        print_line("  diagnostic:  ", err_diag.map(|o| format!("{o:?}")));
+        print_line("  masking:     ", masking.map(|o| format!("{o:?}")));
+    }
+}
+
+fn print_line(prefix: &str, v: Option<String>) {
+    match v {
+        Some(s) => println!("{prefix}{s}"),
+        None => println!("{prefix}(missing fields — classifier skipped)"),
+    }
+}

--- a/crates/apr-cli/src/commands/mod.rs
+++ b/crates/apr-cli/src/commands/mod.rs
@@ -36,6 +36,7 @@ pub(crate) mod export;
 pub(crate) mod finetune;
 pub(crate) mod flow;
 pub(crate) mod glob_filter;
+pub(crate) mod gbnf_classifier;
 #[cfg(feature = "training")]
 pub(crate) mod gpu;
 pub(crate) mod hex;

--- a/crates/apr-cli/src/commands/mod.rs
+++ b/crates/apr-cli/src/commands/mod.rs
@@ -37,6 +37,7 @@ pub(crate) mod finetune;
 pub(crate) mod flow;
 pub(crate) mod glob_filter;
 pub(crate) mod gbnf_classifier;
+pub(crate) mod gbnf_lint;
 #[cfg(feature = "training")]
 pub(crate) mod gpu;
 pub(crate) mod hex;

--- a/crates/apr-cli/src/dispatch_analysis.rs
+++ b/crates/apr-cli/src/dispatch_analysis.rs
@@ -122,6 +122,10 @@ fn dispatch_analysis_commands(cli: &Cli) -> Option<Result<(), CliError>> {
             commands::tool_use_lint::run(observation_file, cli.json)
         }
 
+        ExtendedCommands::GbnfLint { observation_file } => {
+            commands::gbnf_lint::run(observation_file, cli.json)
+        }
+
 
         ExtendedCommands::Hex {
             file,

--- a/crates/apr-cli/src/extended_commands.rs
+++ b/crates/apr-cli/src/extended_commands.rs
@@ -757,6 +757,12 @@ pub enum ExtendedCommands {
         #[arg(long, value_name = "FILE")]
         observation_file: PathBuf,
     },
+    /// Lint a GBNF grammar-constrained observation (CRUX-C-10)
+    GbnfLint {
+        /// Path to captured GBNF observation JSON
+        #[arg(long, value_name = "FILE")]
+        observation_file: PathBuf,
+    },
     /// Publishing, conversion, and analysis tools
     #[command(flatten)]
     Tools(ToolCommands),

--- a/crates/apr-cli/tests/cli_commands.rs
+++ b/crates/apr-cli/tests/cli_commands.rs
@@ -77,6 +77,7 @@ fn registered_commands() -> Vec<&'static str> {
         "awq-lint",
         "oom-lint",
         "tool-use-lint",
+        "gbnf-lint",
         "oracle",
         "encrypt",
         "decrypt",

--- a/crates/apr-cli/tests/falsification_crux_c_10.rs
+++ b/crates/apr-cli/tests/falsification_crux_c_10.rs
@@ -1,0 +1,303 @@
+//! E2E falsification tests for `apr gbnf-lint` (CRUX-C-10).
+//!
+//! Discharges g3 of CRUX-SHIP-001 for PR #977: exercise the CLI surface
+//! end-to-end on captured JSON observations and assert the classifier
+//! verdicts + non-zero exit codes on known-bad input.
+
+use std::io::Write;
+use std::process::Command;
+
+fn apr_binary() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_apr"));
+    cmd.env("NO_COLOR", "1");
+    cmd
+}
+
+fn write_tmp_json(name: &str, body: &str) -> tempfile::NamedTempFile {
+    let mut f = tempfile::Builder::new()
+        .prefix(name)
+        .suffix(".json")
+        .tempfile()
+        .expect("create tempfile");
+    f.write_all(body.as_bytes()).expect("write tempfile");
+    f.flush().expect("flush tempfile");
+    f
+}
+
+// ---- help surface (g2 proof) ----------------------------------------------
+
+#[test]
+fn falsify_crux_c_10_help_advertises_observation_file_flag() {
+    let out = apr_binary()
+        .args(["gbnf-lint", "--help"])
+        .output()
+        .expect("run apr gbnf-lint --help");
+    assert!(out.status.success(), "apr gbnf-lint --help must exit 0");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("--observation-file"),
+        "--help must advertise --observation-file; got:\n{stdout}"
+    );
+}
+
+#[test]
+fn falsify_crux_c_10_rejects_bare_invocation_without_file() {
+    let out = apr_binary()
+        .arg("gbnf-lint")
+        .output()
+        .expect("run apr gbnf-lint without args");
+    assert!(
+        !out.status.success(),
+        "bare `apr gbnf-lint` must exit non-zero"
+    );
+}
+
+// ---- json-output gate (FALSIFY-CRUX-C-10-001) -----------------------------
+
+#[test]
+fn falsify_crux_c_10_001_json_ok_on_valid_json_with_stop() {
+    let tmp = write_tmp_json(
+        "gbnf-json-ok",
+        r#"{ "output": "{\"a\":1}", "finish_reason": "stop" }"#,
+    );
+    let out = apr_binary()
+        .args(["gbnf-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr gbnf-lint");
+    assert!(
+        out.status.success(),
+        "valid JSON + stop must exit 0; stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn falsify_crux_c_10_001_json_rejects_non_json_output() {
+    let tmp = write_tmp_json(
+        "gbnf-json-notjson",
+        r#"{ "output": "not valid json", "finish_reason": "stop" }"#,
+    );
+    let out = apr_binary()
+        .args(["gbnf-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr gbnf-lint");
+    assert!(!out.status.success(), "non-JSON output must exit non-zero");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("FALSIFY-CRUX-C-10-001"),
+        "stderr must cite FALSIFY-CRUX-C-10-001; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn falsify_crux_c_10_001_json_rejects_wrong_finish_reason() {
+    let tmp = write_tmp_json(
+        "gbnf-json-wrongfinish",
+        r#"{ "output": "{}", "finish_reason": "tool_calls" }"#,
+    );
+    let out = apr_binary()
+        .args(["gbnf-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr gbnf-lint");
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-C-10-001"));
+}
+
+// ---- diagnostic gate (FALSIFY-CRUX-C-10-002) ------------------------------
+
+#[test]
+fn falsify_crux_c_10_002_diagnostic_ok_on_nonzero_exit_with_keyword() {
+    let tmp = write_tmp_json(
+        "gbnf-diag-ok",
+        r#"{
+          "grammar_error": {
+            "exit_code": 1,
+            "stderr":    "error: invalid grammar at line 1"
+          }
+        }"#,
+    );
+    let out = apr_binary()
+        .args(["gbnf-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr gbnf-lint");
+    assert!(
+        out.status.success(),
+        "nonzero exit + 'grammar' keyword must pass; stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn falsify_crux_c_10_002_diagnostic_rejects_zero_exit() {
+    let tmp = write_tmp_json(
+        "gbnf-diag-zero",
+        r#"{
+          "grammar_error": {
+            "exit_code": 0,
+            "stderr":    "grammar was fine"
+          }
+        }"#,
+    );
+    let out = apr_binary()
+        .args(["gbnf-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr gbnf-lint");
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-C-10-002"));
+}
+
+#[test]
+fn falsify_crux_c_10_002_diagnostic_rejects_missing_keyword() {
+    let tmp = write_tmp_json(
+        "gbnf-diag-nokw",
+        r#"{
+          "grammar_error": {
+            "exit_code": 1,
+            "stderr":    "unrelated parse error"
+          }
+        }"#,
+    );
+    let out = apr_binary()
+        .args(["gbnf-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr gbnf-lint");
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-C-10-002"));
+}
+
+// ---- masking gate (FALSIFY-CRUX-C-10-001 illegal-token sub-claim) ---------
+
+#[test]
+fn falsify_crux_c_10_001_masking_ok_when_illegal_positions_are_null() {
+    // null → -Infinity per the CLI convention.
+    let tmp = write_tmp_json(
+        "gbnf-mask-ok",
+        r#"{
+          "masking": {
+            "logits":     [1.0, null, 2.0, null],
+            "legal_mask": [true, false, true, false]
+          }
+        }"#,
+    );
+    let out = apr_binary()
+        .args(["gbnf-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr gbnf-lint");
+    assert!(
+        out.status.success(),
+        "null (= -Infinity) at illegal positions must pass; stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn falsify_crux_c_10_001_masking_rejects_finite_at_illegal_position() {
+    let tmp = write_tmp_json(
+        "gbnf-mask-finite",
+        r#"{
+          "masking": {
+            "logits":     [1.0, 2.0, 3.0],
+            "legal_mask": [true, false, true]
+          }
+        }"#,
+    );
+    let out = apr_binary()
+        .args(["gbnf-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr gbnf-lint");
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-C-10-001"));
+}
+
+#[test]
+fn falsify_crux_c_10_001_masking_rejects_length_mismatch() {
+    let tmp = write_tmp_json(
+        "gbnf-mask-lenmismatch",
+        r#"{
+          "masking": {
+            "logits":     [1.0, 2.0],
+            "legal_mask": [true, false, true]
+          }
+        }"#,
+    );
+    let out = apr_binary()
+        .args(["gbnf-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr gbnf-lint");
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-C-10-001"));
+}
+
+// ---- input validation -----------------------------------------------------
+
+#[test]
+fn falsify_crux_c_10_empty_file_rejected_via_cli() {
+    let tmp = write_tmp_json("gbnf-empty", "");
+    let out = apr_binary()
+        .args(["gbnf-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr gbnf-lint");
+    assert!(!out.status.success(), "empty file must be rejected");
+}
+
+#[test]
+fn falsify_crux_c_10_nonexistent_file_rejected() {
+    let out = apr_binary()
+        .args([
+            "gbnf-lint",
+            "--observation-file",
+            "/nonexistent/path/obs.json",
+        ])
+        .output()
+        .expect("run apr gbnf-lint");
+    assert!(!out.status.success());
+}
+
+// ---- --json shape ---------------------------------------------------------
+
+#[test]
+fn falsify_crux_c_10_json_output_shape() {
+    let tmp = write_tmp_json(
+        "gbnf-json-shape",
+        r#"{
+          "output": "{\"k\":1}",
+          "finish_reason": "stop",
+          "grammar_error": { "exit_code": 1, "stderr": "grammar bad" },
+          "masking": {
+            "logits":     [1.0, null],
+            "legal_mask": [true, false]
+          }
+        }"#,
+    );
+    let out = apr_binary()
+        .args(["--json", "gbnf-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr gbnf-lint --json");
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("\"json\""), "--json must emit json key");
+    assert!(
+        stdout.contains("\"diagnostic\""),
+        "--json must emit diagnostic key"
+    );
+    assert!(
+        stdout.contains("\"masking\""),
+        "--json must emit masking key"
+    );
+}


### PR DESCRIPTION
## Summary
- CRUX-C-10 (llama.cpp GBNF, demand=4) promoted from `1.0.0-draft/draft` → `1.1.0/partial`.
- Three pure, deterministic classifiers in `crates/apr-cli/src/commands/gbnf_classifier.rs` discharge FALSIFY-CRUX-C-10-{001,002} at the PARTIAL_ALGORITHM_LEVEL.
- Both FALSIFY gates now carry `evidence_discharged_by` with classifier path, sub-claim, test list, scope, and full-discharge blockers recorded in the ledger.

## What the classifiers check
- `classify_json_grammar_output(output, finish_reason)` — non-empty output parses as JSON AND `finish_reason ∈ {"stop", "length"}`; rejects `EmptyOutput` / `NotJson{error}` / `WrongFinishReason{got}`.
- `classify_grammar_error_diagnostic(exit_code, stderr)` — non-zero exit AND stderr contains "grammar" (case-insensitive); rejects `ZeroExitCode` and `MissingGrammarDiagnostic{stderr_snippet}` (160-char deterministic snippet).
- `classify_illegal_token_masking(logits, legal_mask)` — mechanism condition for the JSON output gate: every illegal-at-state-s position has logit `== -INFINITY`; `+INF`, finite, and NaN all reject as `IllegalTokenNotMasked{token_index, logit}`. Length mismatch and empty legal mask are distinct defect classes.

## Test plan
- [x] `pv validate contracts/crux-C-10-v1.yaml` passes
- [x] `cargo test -p apr-cli --lib gbnf_classifier` — 22/22 green
- [x] `cargo clippy -p apr-cli --lib -- -D warnings` — clean
- [ ] Full discharge requires `apr run --grammar-file` integrating a real GBNF parser wired into the sampler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)