### PR TITLE
feat(crux-c-16): LoRA hotswap (parity+latency+compat+unload) classifier (4 of 4 FALSIFY at PARTIAL_ALGORITHM_LEVEL)

### DIFF
--- a/contracts/apr-cli-commands-v1.yaml
+++ b/contracts/apr-cli-commands-v1.yaml
@@ -21,7 +21,7 @@ metadata:
 kind: CLICommandContract
 name: apr-cli-commands
 version: "1.0.0"
-scope: "all apr CLI subcommands (66 commands — original 57 + `mcp` added 2026-04-17 via PR #864 + `registry` added 2026-04-20 via CRUX-A-01 + `ollama-chat-lint` added 2026-04-21 via CRUX-C-04 SHIP-001 retrofit + `dry-sampling-lint` added 2026-04-21 via CRUX-C-23 SHIP-001 retrofit + `awq-lint` added 2026-04-21 via CRUX-B-08 SHIP-001 retrofit + `oom-lint` added 2026-04-21 via CRUX-F-13 SHIP-001 + `tool-use-lint` added 2026-04-21 via CRUX-C-11 SHIP-001 retrofit + `gbnf-lint` added 2026-04-21 via CRUX-C-10 SHIP-001 retrofit + `typical-p-lint` added 2026-04-21 via CRUX-C-22 SHIP-001 retrofit)"
+scope: "all apr CLI subcommands (67 commands — original 57 + `mcp` added 2026-04-17 via PR #864 + `registry` added 2026-04-20 via CRUX-A-01 + `ollama-chat-lint` added 2026-04-21 via CRUX-C-04 SHIP-001 retrofit + `dry-sampling-lint` added 2026-04-21 via CRUX-C-23 SHIP-001 retrofit + `awq-lint` added 2026-04-21 via CRUX-B-08 SHIP-001 retrofit + `oom-lint` added 2026-04-21 via CRUX-F-13 SHIP-001 + `tool-use-lint` added 2026-04-21 via CRUX-C-11 SHIP-001 retrofit + `gbnf-lint` added 2026-04-21 via CRUX-C-10 SHIP-001 retrofit + `typical-p-lint` added 2026-04-21 via CRUX-C-22 SHIP-001 retrofit + `lora-hotswap-lint` added 2026-04-21 via CRUX-C-16 SHIP-001 retrofit)"
 binary: "apr"
 install: "cargo install aprender"
 
@@ -429,6 +429,12 @@ commands:
   - name: typical-p-lint
     category: inspection
     description: "Lint a captured typical-p sampling observation (CRUX-C-22)"
+    requires_model: false
+    side_effects: []
+
+  - name: lora-hotswap-lint
+    category: inspection
+    description: "Lint a captured LoRA hotswap observation (CRUX-C-16)"
     requires_model: false
     side_effects: []
 

--- a/contracts/crux-C-16-v1.yaml
+++ b/contracts/crux-C-16-v1.yaml
@@ -2,7 +2,7 @@
 
 metadata:
   id: CRUX-C-16
-  version: "1.1.0"
+  version: "1.2.0"
   created: "2026-04-18"
   author: PAIML Engineering
   registry: true
@@ -81,6 +81,11 @@ falsification_tests:
   if_fails: "hotswapped adapter diverges from offline-merged baseline — LoRA math bug"
   evidence_discharged_by:
     classifier_path: crates/apr-cli/src/commands/lora_hotswap_classifier.rs
+    cli_path: crates/apr-cli/src/commands/lora_hotswap_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_c_16.rs
+    e2e_tests:
+    - falsify_crux_c_16_001_hotswap_parity_ok_on_identical
+    - falsify_crux_c_16_001_hotswap_parity_rejects_token_divergence
     sub_claim: |
       Algorithm-level necessary condition: `classify_hotswap_parity(merged,
       hotswap)` accepts iff the two token streams are byte-identical.
@@ -121,6 +126,12 @@ falsification_tests:
   if_fails: "LoRA load latency P99 exceeds 2s budget"
   evidence_discharged_by:
     classifier_path: crates/apr-cli/src/commands/lora_hotswap_classifier.rs
+    cli_path: crates/apr-cli/src/commands/lora_hotswap_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_c_16.rs
+    e2e_tests:
+    - falsify_crux_c_16_002_load_latency_ok_under_budget
+    - falsify_crux_c_16_002_load_latency_rejects_exceeded
+    - falsify_crux_c_16_002_load_latency_rejects_invalid_budget
     sub_claim: |
       Algorithm-level necessary condition: `classify_load_latency(samples,
       budget)` computes nearest-rank P99 (deterministic; no interpolation;
@@ -162,6 +173,13 @@ falsification_tests:
   if_fails: "mismatched-base adapter silently loaded — will produce garbage output"
   evidence_discharged_by:
     classifier_path: crates/apr-cli/src/commands/lora_hotswap_classifier.rs
+    cli_path: crates/apr-cli/src/commands/lora_hotswap_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_c_16.rs
+    e2e_tests:
+    - falsify_crux_c_16_003_adapter_compat_ok_on_matching
+    - falsify_crux_c_16_003_adapter_compat_rejects_sha_mismatch
+    - falsify_crux_c_16_003_adapter_compat_rejects_rank_too_large
+    - falsify_crux_c_16_003_adapter_compat_rejects_unknown_modules
     sub_claim: |
       Algorithm-level necessary condition: `classify_adapter_compat(
       base_sha, adapter_base_sha, base_modules, adapter_targets, rank)`
@@ -214,6 +232,11 @@ falsification_tests:
   if_fails: "base model state contaminated after LoRA unload"
   evidence_discharged_by:
     classifier_path: crates/apr-cli/src/commands/lora_hotswap_classifier.rs
+    cli_path: crates/apr-cli/src/commands/lora_hotswap_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_c_16.rs
+    e2e_tests:
+    - falsify_crux_c_16_004_unload_restore_ok_on_identical
+    - falsify_crux_c_16_004_unload_restore_rejects_divergence
     sub_claim: |
       Algorithm-level necessary condition: `classify_unload_restore(fresh,
       after_unload)` accepts iff the two token streams are byte-identical.
@@ -267,6 +290,27 @@ verification_summary:
   - falsify_id: FALSIFY-CRUX-C-16-004
     discharge_status: PARTIAL_ALGORITHM_LEVEL
     blocked_on: "apr serve --enable-lora + /v1/lora/unload returning base to pristine state"
+
+ship_discipline:
+  ship_rule: CRUX-SHIP-001
+  deliverables_present:
+    classifier: crates/apr-cli/src/commands/lora_hotswap_classifier.rs
+    cli_wiring: crates/apr-cli/src/commands/lora_hotswap_lint.rs
+    e2e_test: crates/apr-cli/tests/falsification_crux_c_16.rs
+    contract: contracts/crux-C-16-v1.yaml
+  merge_gates:
+    g1_classifier_green: true
+    g2_cli_reachable: true
+    g3_e2e_runs: true
+    g4_contract_discharged: PARTIAL_ALGORITHM_LEVEL
+  notes: >
+    `apr lora-hotswap-lint --observation-file <obs.json>` dispatches all four
+    classifiers (hotswap_parity, load_latency, adapter_compat,
+    unload_restore) over captured JSON. e2e suite (16 tests) exercises help
+    surface, bare-invocation rejection, per-gate ok+reject paths,
+    empty/nonexistent file rejection, and --json shape. Full ACTIVE
+    discharge remains blocked on an actual `apr serve --enable-lora` +
+    /v1/lora/load,unload runtime.
 
 pmat_work_tracking:
   ticket_tag: crux-crux-c-16

--- a/contracts/crux-C-16-v1.yaml
+++ b/contracts/crux-C-16-v1.yaml
@@ -1,21 +1,17 @@
 # CRUX-C-16 — LoRA hotswap at runtime
-# Auto-scaffolded from crux-competitive-research-ux-v1.yaml (DRAFT).
-# DO NOT promote to ACTIVE until: (1) evidence collected, (2) falsification
-# body reflects competitor's canonical CLI, (3) apr surface mapped or gap
-# tracked in pmat work (see master §12).
 
 metadata:
   id: CRUX-C-16
-  version: "1.0.0-draft"
+  version: "1.1.0"
   created: "2026-04-18"
   author: PAIML Engineering
   registry: true
-  status: draft
+  status: partial
   parent_contracts:
   - crux-competitive-research-ux-v1
   category: "C — Serving & Chat UX"
   competitor: vllm
-  demand_score: 4  # 1..5, high priority in pmat work
+  demand_score: 4
   intake_status: missing
   description: >
     LoRA adapter hotswap at runtime — load, switch, and unload LoRA adapters
@@ -69,7 +65,6 @@ falsification_tests:
   rule: hotswap output parity with offline merge
   prediction: "served+adapter output ≡ offline-merged base+adapter output at temp=0"
   test: |
-    # TODO: blocked until apr serve --enable-lora + /v1/lora/load wired
     apr merge base.gguf adapter.gguf -o merged.gguf
     REF=$(apr run merged.gguf --prompt "task:" --max-tokens 32 \
       --temperature 0.0 --top-k 1 --json | jq -r '.tokens | join(",")')
@@ -84,12 +79,36 @@ falsification_tests:
     kill %1
     [ "$REF" = "$HOT" ]
   if_fails: "hotswapped adapter diverges from offline-merged baseline — LoRA math bug"
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/lora_hotswap_classifier.rs
+    sub_claim: |
+      Algorithm-level necessary condition: `classify_hotswap_parity(merged,
+      hotswap)` accepts iff the two token streams are byte-identical.
+      Rejection paths distinguish root causes deterministically:
+        (a) one-sided emptiness → `EmptinessMismatch{merged_empty,
+            hotswap_empty}` (vs "silent divergence at position 0" — an
+            empty hotswap is a different bug from "first token wrong");
+        (b) unequal length → `LengthMismatch{merged_len, hotswap_len}`;
+        (c) equal length but diverges at some index → `TokenDivergence
+            {at_index, merged_token, hotswap_token}` at the FIRST
+            mismatch (deterministic; bisection-friendly for LoRA-math
+            and routing debugging).
+      Pure; deterministic.
+    tests:
+    - hotswap_parity_ok_on_identical
+    - hotswap_parity_ok_on_two_empty
+    - hotswap_parity_rejects_emptiness_mismatch
+    - hotswap_parity_rejects_length_mismatch
+    - hotswap_parity_rejects_first_divergence
+    - hotswap_parity_is_deterministic
+    scope: "(merged_tokens, hotswap_tokens) → HotswapParityOutcome (pure)"
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: "apr serve --enable-lora + /v1/lora/load + X-LoRA-Adapter request-time selection surface emitting token_ids"
 
 - id: FALSIFY-CRUX-C-16-002
   rule: load latency P99 <2s
   prediction: "rank-64 adapter load completes in <2s P99"
   test: |
-    # TODO: blocked until /v1/lora/load endpoint
     apr serve base.gguf --enable-lora --port 18080 &
     sleep 5
     for i in $(seq 1 20); do
@@ -100,12 +119,40 @@ falsification_tests:
     kill %1
     python3 -c "import numpy as np; t=np.loadtxt('times.txt'); assert np.percentile(t,99) < 2.0, f'P99={np.percentile(t,99):.2f}s'"
   if_fails: "LoRA load latency P99 exceeds 2s budget"
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/lora_hotswap_classifier.rs
+    sub_claim: |
+      Algorithm-level necessary condition: `classify_load_latency(samples,
+      budget)` computes nearest-rank P99 (deterministic; no interpolation;
+      P99 index = ceil(0.99 * N) - 1, clamped to [0, N-1]) and accepts
+      iff that P99 <= budget. Rejection paths:
+        (a) non-finite, non-positive, or empty-sample input →
+            `InvalidInput{reason}` so measurement-pipeline bugs cannot
+            masquerade as latency regressions;
+        (b) NaN or negative samples → `InvalidInput` with a distinct
+            reason string (time measurements are non-negative finite);
+        (c) valid samples with P99 > budget → `Exceeded{p99_seconds,
+            budget_seconds}` (the only way to "fail" on valid input).
+      LORA_LOAD_LATENCY_P99_S = 2.0s is the contract's budget.
+      Pure; deterministic.
+    tests:
+    - load_latency_ok_under_budget
+    - load_latency_ok_single_sample
+    - load_latency_rejects_exceeded_budget
+    - load_latency_nearest_rank_p99_is_99th_smallest_of_100
+    - load_latency_rejects_zero_budget
+    - load_latency_rejects_empty_samples
+    - load_latency_rejects_nan_sample
+    - load_latency_rejects_negative_sample
+    - load_latency_is_deterministic
+    scope: "(samples_seconds: &[f64], budget_seconds: f64) → LoadLatencyOutcome (pure)"
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: "apr serve --enable-lora + /v1/lora/load endpoint emitting load-timing telemetry; 50ms decode-spike bound is a runtime-scheduler property out of scope for this pure gate"
 
 - id: FALSIFY-CRUX-C-16-003
   rule: mismatched base model rejected
   prediction: "adapter trained on model X rejected when served with model Y"
   test: |
-    # TODO: blocked until /v1/lora/load endpoint
     apr serve qwen-7b.gguf --enable-lora --port 18080 &
     sleep 5
     RES=$(curl -sX POST localhost:18080/v1/lora/load \
@@ -113,12 +160,49 @@ falsification_tests:
     kill %1
     echo "$RES" | jq -e '.error' && echo "$RES" | grep -qiE "base.?model|sha256|mismatch"
   if_fails: "mismatched-base adapter silently loaded — will produce garbage output"
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/lora_hotswap_classifier.rs
+    sub_claim: |
+      Algorithm-level necessary condition: `classify_adapter_compat(
+      base_sha, adapter_base_sha, base_modules, adapter_targets, rank)`
+      accepts iff all of:
+        - `base_sha` non-empty;
+        - `adapter_base_sha` non-empty;
+        - case-insensitive sha256 equality (`eq_ignore_ascii_case`);
+        - `adapter_target_modules` non-empty;
+        - every `adapter_target_modules[i]` appears in `base_module_names`;
+        - rank ∈ [LORA_RANK_MIN=1, LORA_RANK_MAX=512].
+      Rejection paths distinguish six distinct defect classes:
+        (a) `EmptyBaseSha256` (base-metadata load bug);
+        (b) `EmptyAdapterBaseSha256` (adapter-metadata load bug);
+        (c) `BaseSha256Mismatch` (true compatibility failure);
+        (d) `EmptyTargetModules` (malformed adapter);
+        (e) `UnknownTargetModules{unknown}` with the offending names so
+            the error is actionable;
+        (f) `RankTooSmall{rank}` / `RankTooLarge{rank}` (adapter outside
+            [1, 512] window).
+      Pure; deterministic.
+    tests:
+    - adapter_compat_ok_on_matching_everything
+    - adapter_compat_ok_case_insensitive_sha
+    - adapter_compat_rejects_empty_base_sha
+    - adapter_compat_rejects_empty_adapter_sha
+    - adapter_compat_rejects_sha_mismatch
+    - adapter_compat_rejects_empty_target_modules
+    - adapter_compat_rejects_unknown_target_modules
+    - adapter_compat_rejects_rank_too_small
+    - adapter_compat_rejects_rank_too_large
+    - adapter_compat_ok_at_rank_boundaries
+    - adapter_compat_is_deterministic
+    - lora_constants_are_canonical
+    scope: "(base_sha, adapter_sha, base_mods, adapter_targets, rank) → AdapterCompatOutcome (pure)"
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: "apr serve --enable-lora + /v1/lora/load invoking this classifier on adapter metadata BEFORE splicing LoRA weights into the base graph"
 
 - id: FALSIFY-CRUX-C-16-004
   rule: unload restores base model
   prediction: "after unload, requests without X-LoRA-Adapter ≡ fresh base load"
   test: |
-    # TODO: blocked until /v1/lora/{load,unload}
     REF=$(apr run base.gguf --prompt "hi" --max-tokens 16 --temperature 0.0 --top-k 1 --json | jq -r '.tokens | join(",")')
     apr serve base.gguf --enable-lora --port 18080 &
     sleep 5
@@ -128,6 +212,32 @@ falsification_tests:
     kill %1
     [ "$REF" = "$AFTER" ]
   if_fails: "base model state contaminated after LoRA unload"
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/lora_hotswap_classifier.rs
+    sub_claim: |
+      Algorithm-level necessary condition: `classify_unload_restore(fresh,
+      after_unload)` accepts iff the two token streams are byte-identical.
+      Rejection paths distinguish:
+        (a) one-sided emptiness → `EmptinessMismatch{fresh_empty,
+            after_unload_empty}` (a completely-broken unload that
+            produces no output is a different defect from "drift");
+        (b) unequal length → `LengthMismatch{fresh_len,
+            after_unload_len}`;
+        (c) equal length but diverges at some index → `TokenDivergence
+            {at_index, fresh_token, after_unload_token}` at the FIRST
+            mismatch (deterministic; bisection-friendly for weight-
+            contamination debugging).
+      Pure; deterministic.
+    tests:
+    - unload_restore_ok_on_identical
+    - unload_restore_ok_on_two_empty
+    - unload_restore_rejects_emptiness_mismatch
+    - unload_restore_rejects_length_mismatch
+    - unload_restore_rejects_first_divergence
+    - unload_restore_is_deterministic
+    scope: "(fresh_tokens, after_unload_tokens) → UnloadRestoreOutcome (pure)"
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: "apr serve --enable-lora + /v1/lora/unload surface that returns base weights to pristine state"
 
 proof_obligations:
 - type: equivalence
@@ -144,10 +254,21 @@ verification_summary:
   proven: 0
   tested: 0
   status: spec-complete
+  discharge_ledger:
+  - falsify_id: FALSIFY-CRUX-C-16-001
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    blocked_on: "apr serve --enable-lora + /v1/lora/load + X-LoRA-Adapter request selection"
+  - falsify_id: FALSIFY-CRUX-C-16-002
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    blocked_on: "apr serve --enable-lora + /v1/lora/load emitting load-timing telemetry"
+  - falsify_id: FALSIFY-CRUX-C-16-003
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    blocked_on: "apr serve --enable-lora + /v1/lora/load invoking this classifier on adapter metadata before splice"
+  - falsify_id: FALSIFY-CRUX-C-16-004
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    blocked_on: "apr serve --enable-lora + /v1/lora/unload returning base to pristine state"
 
 pmat_work_tracking:
-  # Managed by master contract §12. If intake_status == "missing", a ticket
-  # tagged `crux-crux-c-16` is auto-created by scripts/crux_bulk_pmat_work.sh.
   ticket_tag: crux-crux-c-16
   priority: high
   auto_created: true

--- a/crates/apr-cli/src/commands/lora_hotswap_classifier.rs
+++ b/crates/apr-cli/src/commands/lora_hotswap_classifier.rs
@@ -1,0 +1,546 @@
+//! CRUX-C-16 — LoRA hotswap classifiers.
+//!
+//! Pure, deterministic algorithm-level gates discharging FALSIFY-CRUX-C-16-001..004
+//! at PARTIAL_ALGORITHM_LEVEL. Full discharge is blocked on `apr serve --enable-lora`
+//! + `/v1/lora/{load,unload}` HTTP endpoints wired to a real adapter-hotswap runtime.
+//!
+//! Design rule: no silent passes — every ill-formed input maps to a distinct
+//! Outcome variant so defect classes cannot collapse into each other.
+
+/// Contract-pinned rank window. Adapters outside are rejected as "likely malformed".
+pub const LORA_RANK_MIN: u32 = 1;
+pub const LORA_RANK_MAX: u32 = 512;
+
+/// Contract-pinned P99 load-latency budget (seconds).
+pub const LORA_LOAD_LATENCY_P99_S: f64 = 2.0;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Classifier 1: hotswap token parity vs offline-merged baseline
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HotswapParityOutcome {
+    Ok,
+    EmptinessMismatch { merged_empty: bool, hotswap_empty: bool },
+    LengthMismatch { merged_len: usize, hotswap_len: usize },
+    TokenDivergence { at_index: usize, merged_token: u32, hotswap_token: u32 },
+}
+
+pub fn classify_hotswap_parity(
+    merged_tokens: &[u32],
+    hotswap_tokens: &[u32],
+) -> HotswapParityOutcome {
+    let merged_empty = merged_tokens.is_empty();
+    let hotswap_empty = hotswap_tokens.is_empty();
+    if merged_empty != hotswap_empty {
+        return HotswapParityOutcome::EmptinessMismatch { merged_empty, hotswap_empty };
+    }
+    if merged_tokens.len() != hotswap_tokens.len() {
+        return HotswapParityOutcome::LengthMismatch {
+            merged_len: merged_tokens.len(),
+            hotswap_len: hotswap_tokens.len(),
+        };
+    }
+    for (i, (m, h)) in merged_tokens.iter().zip(hotswap_tokens.iter()).enumerate() {
+        if m != h {
+            return HotswapParityOutcome::TokenDivergence {
+                at_index: i,
+                merged_token: *m,
+                hotswap_token: *h,
+            };
+        }
+    }
+    HotswapParityOutcome::Ok
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Classifier 2: load-latency P99 budget
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum LoadLatencyOutcome {
+    Ok { p99_seconds: f64 },
+    InvalidInput { reason: &'static str },
+    Exceeded { p99_seconds: f64, budget_seconds: f64 },
+}
+
+/// Compute P99 with nearest-rank (ceiling) method: P99 = sorted[ceil(0.99 * N) - 1].
+/// Deterministic; no randomness; no interpolation.
+pub fn classify_load_latency(samples_seconds: &[f64], budget_seconds: f64) -> LoadLatencyOutcome {
+    if !budget_seconds.is_finite() || budget_seconds <= 0.0 {
+        return LoadLatencyOutcome::InvalidInput { reason: "budget_seconds must be > 0" };
+    }
+    if samples_seconds.is_empty() {
+        return LoadLatencyOutcome::InvalidInput { reason: "samples_seconds is empty" };
+    }
+    if samples_seconds.iter().any(|s| !s.is_finite() || *s < 0.0) {
+        return LoadLatencyOutcome::InvalidInput {
+            reason: "sample contains NaN/inf or negative",
+        };
+    }
+
+    let mut sorted: Vec<f64> = samples_seconds.to_vec();
+    sorted.sort_by(|a, b| a.partial_cmp(b).expect("finite after guard"));
+    let n = sorted.len();
+    // Nearest-rank P99: index = ceil(0.99 * N) - 1, clamped to [0, N-1].
+    let rank_f = 0.99_f64 * (n as f64);
+    let rank_ceil = rank_f.ceil() as usize;
+    let idx = rank_ceil.saturating_sub(1).min(n - 1);
+    let p99 = sorted[idx];
+
+    if p99 > budget_seconds {
+        return LoadLatencyOutcome::Exceeded {
+            p99_seconds: p99,
+            budget_seconds,
+        };
+    }
+    LoadLatencyOutcome::Ok { p99_seconds: p99 }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Classifier 3: adapter↔base compatibility (sha256, target modules, rank window)
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AdapterCompatOutcome {
+    Ok,
+    EmptyBaseSha256,
+    EmptyAdapterBaseSha256,
+    BaseSha256Mismatch,
+    EmptyTargetModules,
+    UnknownTargetModules { unknown: Vec<String> },
+    RankTooSmall { rank: u32 },
+    RankTooLarge { rank: u32 },
+}
+
+pub fn classify_adapter_compat(
+    base_sha256: &str,
+    adapter_base_sha256: &str,
+    base_module_names: &[&str],
+    adapter_target_modules: &[&str],
+    adapter_rank: u32,
+) -> AdapterCompatOutcome {
+    if base_sha256.is_empty() {
+        return AdapterCompatOutcome::EmptyBaseSha256;
+    }
+    if adapter_base_sha256.is_empty() {
+        return AdapterCompatOutcome::EmptyAdapterBaseSha256;
+    }
+    // sha256 hex is case-insensitive — follow same rule used by C-09 spec-dec.
+    if !base_sha256.eq_ignore_ascii_case(adapter_base_sha256) {
+        return AdapterCompatOutcome::BaseSha256Mismatch;
+    }
+    if adapter_target_modules.is_empty() {
+        return AdapterCompatOutcome::EmptyTargetModules;
+    }
+    let unknown: Vec<String> = adapter_target_modules
+        .iter()
+        .filter(|m| !base_module_names.contains(m))
+        .map(|m| (*m).to_string())
+        .collect();
+    if !unknown.is_empty() {
+        return AdapterCompatOutcome::UnknownTargetModules { unknown };
+    }
+    if adapter_rank < LORA_RANK_MIN {
+        return AdapterCompatOutcome::RankTooSmall { rank: adapter_rank };
+    }
+    if adapter_rank > LORA_RANK_MAX {
+        return AdapterCompatOutcome::RankTooLarge { rank: adapter_rank };
+    }
+    AdapterCompatOutcome::Ok
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Classifier 4: unload restores base model (pristine-state check)
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UnloadRestoreOutcome {
+    Ok,
+    EmptinessMismatch { fresh_empty: bool, after_unload_empty: bool },
+    LengthMismatch { fresh_len: usize, after_unload_len: usize },
+    TokenDivergence { at_index: usize, fresh_token: u32, after_unload_token: u32 },
+}
+
+pub fn classify_unload_restore(
+    fresh_tokens: &[u32],
+    after_unload_tokens: &[u32],
+) -> UnloadRestoreOutcome {
+    let fresh_empty = fresh_tokens.is_empty();
+    let after_unload_empty = after_unload_tokens.is_empty();
+    if fresh_empty != after_unload_empty {
+        return UnloadRestoreOutcome::EmptinessMismatch {
+            fresh_empty,
+            after_unload_empty,
+        };
+    }
+    if fresh_tokens.len() != after_unload_tokens.len() {
+        return UnloadRestoreOutcome::LengthMismatch {
+            fresh_len: fresh_tokens.len(),
+            after_unload_len: after_unload_tokens.len(),
+        };
+    }
+    for (i, (f, a)) in fresh_tokens.iter().zip(after_unload_tokens.iter()).enumerate() {
+        if f != a {
+            return UnloadRestoreOutcome::TokenDivergence {
+                at_index: i,
+                fresh_token: *f,
+                after_unload_token: *a,
+            };
+        }
+    }
+    UnloadRestoreOutcome::Ok
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests — pure, deterministic.
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── hotswap parity ─────────────────────────────────────────────────────
+
+    #[test]
+    fn hotswap_parity_ok_on_identical() {
+        assert_eq!(
+            classify_hotswap_parity(&[10, 20, 30], &[10, 20, 30]),
+            HotswapParityOutcome::Ok
+        );
+    }
+
+    #[test]
+    fn hotswap_parity_ok_on_two_empty() {
+        assert_eq!(classify_hotswap_parity(&[], &[]), HotswapParityOutcome::Ok);
+    }
+
+    #[test]
+    fn hotswap_parity_rejects_emptiness_mismatch() {
+        assert_eq!(
+            classify_hotswap_parity(&[], &[1]),
+            HotswapParityOutcome::EmptinessMismatch {
+                merged_empty: true,
+                hotswap_empty: false,
+            }
+        );
+    }
+
+    #[test]
+    fn hotswap_parity_rejects_length_mismatch() {
+        assert_eq!(
+            classify_hotswap_parity(&[1, 2], &[1, 2, 3]),
+            HotswapParityOutcome::LengthMismatch {
+                merged_len: 2,
+                hotswap_len: 3,
+            }
+        );
+    }
+
+    #[test]
+    fn hotswap_parity_rejects_first_divergence() {
+        assert_eq!(
+            classify_hotswap_parity(&[1, 2, 3, 4], &[1, 9, 3, 9]),
+            HotswapParityOutcome::TokenDivergence {
+                at_index: 1,
+                merged_token: 2,
+                hotswap_token: 9,
+            }
+        );
+    }
+
+    #[test]
+    fn hotswap_parity_is_deterministic() {
+        for _ in 0..5 {
+            assert_eq!(
+                classify_hotswap_parity(&[7, 8, 9], &[7, 8, 9]),
+                HotswapParityOutcome::Ok
+            );
+        }
+    }
+
+    // ── load latency ───────────────────────────────────────────────────────
+
+    #[test]
+    fn load_latency_ok_under_budget() {
+        let samples = vec![0.1_f64; 100];
+        match classify_load_latency(&samples, 2.0) {
+            LoadLatencyOutcome::Ok { p99_seconds } => {
+                assert!((p99_seconds - 0.1).abs() < 1e-9);
+            }
+            other => panic!("expected Ok, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn load_latency_ok_single_sample() {
+        // P99 of a single sample is that sample.
+        match classify_load_latency(&[1.5], 2.0) {
+            LoadLatencyOutcome::Ok { p99_seconds } => assert_eq!(p99_seconds, 1.5),
+            other => panic!("expected Ok, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn load_latency_rejects_exceeded_budget() {
+        // Nearest-rank P99 with 10 samples: ceil(0.99 * 10) = 10, idx = 9 = max.
+        // 9 fast + 1 slow → P99 == slow.
+        let mut samples = vec![0.1_f64; 9];
+        samples.push(2.5);
+        match classify_load_latency(&samples, 2.0) {
+            LoadLatencyOutcome::Exceeded { p99_seconds, budget_seconds } => {
+                assert_eq!(p99_seconds, 2.5);
+                assert_eq!(budget_seconds, 2.0);
+            }
+            other => panic!("expected Exceeded, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn load_latency_nearest_rank_p99_is_99th_smallest_of_100() {
+        // 100 samples: ceil(0.99 * 100) = 99, idx = 98 = sorted[98].
+        // 99 fast + 1 slow → P99 == fast (99% of samples are ≤ 0.1).
+        let mut samples = vec![0.1_f64; 99];
+        samples.push(2.5);
+        match classify_load_latency(&samples, 2.0) {
+            LoadLatencyOutcome::Ok { p99_seconds } => assert_eq!(p99_seconds, 0.1),
+            other => panic!("expected Ok (99th of 100 is 0.1), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn load_latency_rejects_zero_budget() {
+        match classify_load_latency(&[0.1], 0.0) {
+            LoadLatencyOutcome::InvalidInput { reason } => assert!(reason.contains("budget")),
+            other => panic!("expected InvalidInput, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn load_latency_rejects_empty_samples() {
+        match classify_load_latency(&[], 2.0) {
+            LoadLatencyOutcome::InvalidInput { reason } => assert!(reason.contains("empty")),
+            other => panic!("expected InvalidInput, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn load_latency_rejects_nan_sample() {
+        match classify_load_latency(&[0.1, f64::NAN], 2.0) {
+            LoadLatencyOutcome::InvalidInput { reason } => assert!(reason.contains("NaN")),
+            other => panic!("expected InvalidInput, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn load_latency_rejects_negative_sample() {
+        match classify_load_latency(&[-0.1, 0.2], 2.0) {
+            LoadLatencyOutcome::InvalidInput { reason } => assert!(reason.contains("negative")),
+            other => panic!("expected InvalidInput, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn load_latency_is_deterministic() {
+        let samples = [1.0, 0.1, 0.2, 0.5, 0.3];
+        for _ in 0..5 {
+            match classify_load_latency(&samples, 2.0) {
+                LoadLatencyOutcome::Ok { .. } => {}
+                other => panic!("expected Ok, got {other:?}"),
+            }
+        }
+    }
+
+    // ── adapter compat ─────────────────────────────────────────────────────
+
+    #[test]
+    fn adapter_compat_ok_on_matching_everything() {
+        assert_eq!(
+            classify_adapter_compat(
+                "abc123",
+                "abc123",
+                &["q_proj", "k_proj", "v_proj"],
+                &["q_proj", "v_proj"],
+                64,
+            ),
+            AdapterCompatOutcome::Ok
+        );
+    }
+
+    #[test]
+    fn adapter_compat_ok_case_insensitive_sha() {
+        assert_eq!(
+            classify_adapter_compat(
+                "ABC123",
+                "abc123",
+                &["q_proj"],
+                &["q_proj"],
+                16,
+            ),
+            AdapterCompatOutcome::Ok
+        );
+    }
+
+    #[test]
+    fn adapter_compat_rejects_empty_base_sha() {
+        assert_eq!(
+            classify_adapter_compat("", "abc", &["q_proj"], &["q_proj"], 16),
+            AdapterCompatOutcome::EmptyBaseSha256
+        );
+    }
+
+    #[test]
+    fn adapter_compat_rejects_empty_adapter_sha() {
+        assert_eq!(
+            classify_adapter_compat("abc", "", &["q_proj"], &["q_proj"], 16),
+            AdapterCompatOutcome::EmptyAdapterBaseSha256
+        );
+    }
+
+    #[test]
+    fn adapter_compat_rejects_sha_mismatch() {
+        assert_eq!(
+            classify_adapter_compat("abc", "def", &["q_proj"], &["q_proj"], 16),
+            AdapterCompatOutcome::BaseSha256Mismatch
+        );
+    }
+
+    #[test]
+    fn adapter_compat_rejects_empty_target_modules() {
+        assert_eq!(
+            classify_adapter_compat("abc", "abc", &["q_proj"], &[], 16),
+            AdapterCompatOutcome::EmptyTargetModules
+        );
+    }
+
+    #[test]
+    fn adapter_compat_rejects_unknown_target_modules() {
+        match classify_adapter_compat(
+            "abc",
+            "abc",
+            &["q_proj", "k_proj"],
+            &["q_proj", "x_proj"],
+            16,
+        ) {
+            AdapterCompatOutcome::UnknownTargetModules { unknown } => {
+                assert_eq!(unknown, vec!["x_proj".to_string()]);
+            }
+            other => panic!("expected UnknownTargetModules, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn adapter_compat_rejects_rank_too_small() {
+        assert_eq!(
+            classify_adapter_compat("abc", "abc", &["q_proj"], &["q_proj"], 0),
+            AdapterCompatOutcome::RankTooSmall { rank: 0 }
+        );
+    }
+
+    #[test]
+    fn adapter_compat_rejects_rank_too_large() {
+        assert_eq!(
+            classify_adapter_compat("abc", "abc", &["q_proj"], &["q_proj"], 513),
+            AdapterCompatOutcome::RankTooLarge { rank: 513 }
+        );
+    }
+
+    #[test]
+    fn adapter_compat_ok_at_rank_boundaries() {
+        assert_eq!(
+            classify_adapter_compat("abc", "abc", &["q_proj"], &["q_proj"], LORA_RANK_MIN),
+            AdapterCompatOutcome::Ok
+        );
+        assert_eq!(
+            classify_adapter_compat("abc", "abc", &["q_proj"], &["q_proj"], LORA_RANK_MAX),
+            AdapterCompatOutcome::Ok
+        );
+    }
+
+    #[test]
+    fn adapter_compat_is_deterministic() {
+        for _ in 0..5 {
+            assert_eq!(
+                classify_adapter_compat(
+                    "abc",
+                    "abc",
+                    &["q_proj", "v_proj"],
+                    &["q_proj"],
+                    32,
+                ),
+                AdapterCompatOutcome::Ok
+            );
+        }
+    }
+
+    // ── unload restore ─────────────────────────────────────────────────────
+
+    #[test]
+    fn unload_restore_ok_on_identical() {
+        assert_eq!(
+            classify_unload_restore(&[1, 2, 3], &[1, 2, 3]),
+            UnloadRestoreOutcome::Ok
+        );
+    }
+
+    #[test]
+    fn unload_restore_ok_on_two_empty() {
+        assert_eq!(
+            classify_unload_restore(&[], &[]),
+            UnloadRestoreOutcome::Ok
+        );
+    }
+
+    #[test]
+    fn unload_restore_rejects_emptiness_mismatch() {
+        assert_eq!(
+            classify_unload_restore(&[1, 2], &[]),
+            UnloadRestoreOutcome::EmptinessMismatch {
+                fresh_empty: false,
+                after_unload_empty: true,
+            }
+        );
+    }
+
+    #[test]
+    fn unload_restore_rejects_length_mismatch() {
+        assert_eq!(
+            classify_unload_restore(&[1, 2, 3], &[1, 2]),
+            UnloadRestoreOutcome::LengthMismatch {
+                fresh_len: 3,
+                after_unload_len: 2,
+            }
+        );
+    }
+
+    #[test]
+    fn unload_restore_rejects_first_divergence() {
+        assert_eq!(
+            classify_unload_restore(&[1, 2, 3], &[1, 9, 3]),
+            UnloadRestoreOutcome::TokenDivergence {
+                at_index: 1,
+                fresh_token: 2,
+                after_unload_token: 9,
+            }
+        );
+    }
+
+    #[test]
+    fn unload_restore_is_deterministic() {
+        for _ in 0..5 {
+            assert_eq!(
+                classify_unload_restore(&[1, 2, 3], &[1, 2, 3]),
+                UnloadRestoreOutcome::Ok
+            );
+        }
+    }
+
+    // ── constants ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn lora_constants_are_canonical() {
+        assert_eq!(LORA_RANK_MIN, 1);
+        assert_eq!(LORA_RANK_MAX, 512);
+        assert!((LORA_LOAD_LATENCY_P99_S - 2.0).abs() < 1e-9);
+    }
+}

--- a/crates/apr-cli/src/commands/lora_hotswap_lint.rs
+++ b/crates/apr-cli/src/commands/lora_hotswap_lint.rs
@@ -1,0 +1,289 @@
+//! `apr lora-hotswap-lint` — CRUX-C-16 LoRA hotswap observation linter.
+//!
+//! Reads a JSON observation file that captures a single LoRA hotswap run
+//! and dispatches four classifiers (hotswap_parity, load_latency,
+//! adapter_compat, unload_restore). Emits a text or `--json` report.
+//!
+//! Spec: `contracts/crux-C-16-v1.yaml`. CRUX-SHIP-001 g2/g3 surface.
+//!
+//! Observation schema (top-level keys; all optional — missing sections
+//! skip the corresponding classifier):
+//!
+//!   {
+//!     "hotswap_parity": {
+//!       "merged_tokens":  [1, 2, 3],
+//!       "hotswap_tokens": [1, 2, 3]
+//!     },
+//!     "load_latency": {
+//!       "samples_seconds": [0.1, 0.2, 0.5],
+//!       "budget_seconds":  2.0
+//!     },
+//!     "adapter_compat": {
+//!       "base_sha256":              "abc123",
+//!       "adapter_base_sha256":      "abc123",
+//!       "base_module_names":        ["q_proj", "k_proj", "v_proj"],
+//!       "adapter_target_modules":   ["q_proj", "v_proj"],
+//!       "adapter_rank":             64
+//!     },
+//!     "unload_restore": {
+//!       "fresh_tokens":        [1, 2, 3],
+//!       "after_unload_tokens": [1, 2, 3]
+//!     }
+//!   }
+
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+
+use crate::commands::lora_hotswap_classifier as clf;
+use crate::error::{CliError, Result};
+
+pub(crate) fn run(observation_file: &Path, json: bool) -> Result<()> {
+    if !observation_file.exists() {
+        return Err(CliError::FileNotFound(PathBuf::from(observation_file)));
+    }
+
+    let body = std::fs::read_to_string(observation_file)?;
+    let obs: Value = serde_json::from_str(&body).map_err(|e| {
+        CliError::InvalidFormat(format!(
+            "apr lora-hotswap-lint: failed to parse JSON from {}: {e}",
+            observation_file.display()
+        ))
+    })?;
+
+    let hotswap_parity = classify_hotswap_parity(&obs);
+    let load_latency = classify_load_latency(&obs);
+    let adapter_compat = classify_adapter_compat(&obs);
+    let unload_restore = classify_unload_restore(&obs);
+
+    let fail_reasons: Vec<String> = [
+        hotswap_parity.as_ref().and_then(hotswap_parity_fail_reason),
+        load_latency.as_ref().and_then(load_latency_fail_reason),
+        adapter_compat.as_ref().and_then(adapter_compat_fail_reason),
+        unload_restore.as_ref().and_then(unload_restore_fail_reason),
+    ]
+    .into_iter()
+    .flatten()
+    .collect();
+
+    print_report(
+        observation_file,
+        hotswap_parity.as_ref(),
+        load_latency.as_ref(),
+        adapter_compat.as_ref(),
+        unload_restore.as_ref(),
+        json,
+    );
+
+    if fail_reasons.is_empty() {
+        Ok(())
+    } else {
+        Err(CliError::ValidationFailed(fail_reasons.join("; ")))
+    }
+}
+
+fn classify_hotswap_parity(obs: &Value) -> Option<clf::HotswapParityOutcome> {
+    let sec = obs.get("hotswap_parity")?.as_object()?;
+    let merged = tokens_array(sec.get("merged_tokens")?)?;
+    let hotswap = tokens_array(sec.get("hotswap_tokens")?)?;
+    Some(clf::classify_hotswap_parity(&merged, &hotswap))
+}
+
+fn classify_load_latency(obs: &Value) -> Option<clf::LoadLatencyOutcome> {
+    let sec = obs.get("load_latency")?.as_object()?;
+    let samples: Vec<f64> = sec
+        .get("samples_seconds")?
+        .as_array()?
+        .iter()
+        .map(|v| v.as_f64().unwrap_or(f64::NAN))
+        .collect();
+    let budget = sec.get("budget_seconds")?.as_f64()?;
+    Some(clf::classify_load_latency(&samples, budget))
+}
+
+fn classify_adapter_compat(obs: &Value) -> Option<clf::AdapterCompatOutcome> {
+    let sec = obs.get("adapter_compat")?.as_object()?;
+    let base_sha = sec.get("base_sha256")?.as_str()?;
+    let adapter_sha = sec.get("adapter_base_sha256")?.as_str()?;
+    let base_modules: Vec<String> = sec
+        .get("base_module_names")?
+        .as_array()?
+        .iter()
+        .filter_map(|v| v.as_str().map(|s| s.to_string()))
+        .collect();
+    let adapter_modules: Vec<String> = sec
+        .get("adapter_target_modules")?
+        .as_array()?
+        .iter()
+        .filter_map(|v| v.as_str().map(|s| s.to_string()))
+        .collect();
+    let rank = sec.get("adapter_rank")?.as_u64()? as u32;
+
+    let base_refs: Vec<&str> = base_modules.iter().map(String::as_str).collect();
+    let adapter_refs: Vec<&str> = adapter_modules.iter().map(String::as_str).collect();
+
+    Some(clf::classify_adapter_compat(
+        base_sha,
+        adapter_sha,
+        &base_refs,
+        &adapter_refs,
+        rank,
+    ))
+}
+
+fn classify_unload_restore(obs: &Value) -> Option<clf::UnloadRestoreOutcome> {
+    let sec = obs.get("unload_restore")?.as_object()?;
+    let fresh = tokens_array(sec.get("fresh_tokens")?)?;
+    let after = tokens_array(sec.get("after_unload_tokens")?)?;
+    Some(clf::classify_unload_restore(&fresh, &after))
+}
+
+fn tokens_array(v: &Value) -> Option<Vec<u32>> {
+    Some(
+        v.as_array()?
+            .iter()
+            .filter_map(|t| t.as_u64().map(|n| n as u32))
+            .collect(),
+    )
+}
+
+fn hotswap_parity_fail_reason(o: &clf::HotswapParityOutcome) -> Option<String> {
+    match o {
+        clf::HotswapParityOutcome::Ok => None,
+        clf::HotswapParityOutcome::EmptinessMismatch {
+            merged_empty,
+            hotswap_empty,
+        } => Some(format!(
+            "FALSIFY-CRUX-C-16-001 hotswap_parity: emptiness mismatch merged_empty={merged_empty} hotswap_empty={hotswap_empty}"
+        )),
+        clf::HotswapParityOutcome::LengthMismatch {
+            merged_len,
+            hotswap_len,
+        } => Some(format!(
+            "FALSIFY-CRUX-C-16-001 hotswap_parity: length mismatch merged={merged_len} hotswap={hotswap_len}"
+        )),
+        clf::HotswapParityOutcome::TokenDivergence {
+            at_index,
+            merged_token,
+            hotswap_token,
+        } => Some(format!(
+            "FALSIFY-CRUX-C-16-001 hotswap_parity: token divergence at idx {at_index}: merged={merged_token} hotswap={hotswap_token}"
+        )),
+    }
+}
+
+fn load_latency_fail_reason(o: &clf::LoadLatencyOutcome) -> Option<String> {
+    match o {
+        clf::LoadLatencyOutcome::Ok { .. } => None,
+        clf::LoadLatencyOutcome::InvalidInput { reason } => Some(format!(
+            "FALSIFY-CRUX-C-16-002 load_latency: invalid input: {reason}"
+        )),
+        clf::LoadLatencyOutcome::Exceeded {
+            p99_seconds,
+            budget_seconds,
+        } => Some(format!(
+            "FALSIFY-CRUX-C-16-002 load_latency: P99 {p99_seconds:.3}s exceeds budget {budget_seconds:.3}s"
+        )),
+    }
+}
+
+fn adapter_compat_fail_reason(o: &clf::AdapterCompatOutcome) -> Option<String> {
+    match o {
+        clf::AdapterCompatOutcome::Ok => None,
+        clf::AdapterCompatOutcome::EmptyBaseSha256 => Some(
+            "FALSIFY-CRUX-C-16-003 adapter_compat: base_sha256 is empty".to_string(),
+        ),
+        clf::AdapterCompatOutcome::EmptyAdapterBaseSha256 => Some(
+            "FALSIFY-CRUX-C-16-003 adapter_compat: adapter_base_sha256 is empty".to_string(),
+        ),
+        clf::AdapterCompatOutcome::BaseSha256Mismatch => Some(
+            "FALSIFY-CRUX-C-16-003 adapter_compat: base sha256 mismatch".to_string(),
+        ),
+        clf::AdapterCompatOutcome::EmptyTargetModules => Some(
+            "FALSIFY-CRUX-C-16-003 adapter_compat: adapter target modules list is empty"
+                .to_string(),
+        ),
+        clf::AdapterCompatOutcome::UnknownTargetModules { unknown } => Some(format!(
+            "FALSIFY-CRUX-C-16-003 adapter_compat: unknown target modules: {unknown:?}"
+        )),
+        clf::AdapterCompatOutcome::RankTooSmall { rank } => Some(format!(
+            "FALSIFY-CRUX-C-16-003 adapter_compat: rank {rank} below LORA_RANK_MIN={}",
+            clf::LORA_RANK_MIN
+        )),
+        clf::AdapterCompatOutcome::RankTooLarge { rank } => Some(format!(
+            "FALSIFY-CRUX-C-16-003 adapter_compat: rank {rank} above LORA_RANK_MAX={}",
+            clf::LORA_RANK_MAX
+        )),
+    }
+}
+
+fn unload_restore_fail_reason(o: &clf::UnloadRestoreOutcome) -> Option<String> {
+    match o {
+        clf::UnloadRestoreOutcome::Ok => None,
+        clf::UnloadRestoreOutcome::EmptinessMismatch {
+            fresh_empty,
+            after_unload_empty,
+        } => Some(format!(
+            "FALSIFY-CRUX-C-16-004 unload_restore: emptiness mismatch fresh_empty={fresh_empty} after_unload_empty={after_unload_empty}"
+        )),
+        clf::UnloadRestoreOutcome::LengthMismatch {
+            fresh_len,
+            after_unload_len,
+        } => Some(format!(
+            "FALSIFY-CRUX-C-16-004 unload_restore: length mismatch fresh={fresh_len} after_unload={after_unload_len}"
+        )),
+        clf::UnloadRestoreOutcome::TokenDivergence {
+            at_index,
+            fresh_token,
+            after_unload_token,
+        } => Some(format!(
+            "FALSIFY-CRUX-C-16-004 unload_restore: token divergence at idx {at_index}: fresh={fresh_token} after_unload={after_unload_token}"
+        )),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn print_report(
+    path: &Path,
+    hotswap_parity: Option<&clf::HotswapParityOutcome>,
+    load_latency: Option<&clf::LoadLatencyOutcome>,
+    adapter_compat: Option<&clf::AdapterCompatOutcome>,
+    unload_restore: Option<&clf::UnloadRestoreOutcome>,
+    json: bool,
+) {
+    if json {
+        let v = serde_json::json!({
+            "observation_path": path.display().to_string(),
+            "hotswap_parity":   hotswap_parity.map(|o| format!("{o:?}")),
+            "load_latency":     load_latency.map(|o| format!("{o:?}")),
+            "adapter_compat":   adapter_compat.map(|o| format!("{o:?}")),
+            "unload_restore":   unload_restore.map(|o| format!("{o:?}")),
+        });
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&v).unwrap_or_else(|_| v.to_string())
+        );
+    } else {
+        println!("lora-hotswap-lint report for {}", path.display());
+        print_line(
+            "  hotswap_parity: ",
+            hotswap_parity.map(|o| format!("{o:?}")),
+        );
+        print_line("  load_latency:   ", load_latency.map(|o| format!("{o:?}")));
+        print_line(
+            "  adapter_compat: ",
+            adapter_compat.map(|o| format!("{o:?}")),
+        );
+        print_line(
+            "  unload_restore: ",
+            unload_restore.map(|o| format!("{o:?}")),
+        );
+    }
+}
+
+fn print_line(prefix: &str, v: Option<String>) {
+    match v {
+        Some(s) => println!("{prefix}{s}"),
+        None => println!("{prefix}(missing fields — classifier skipped)"),
+    }
+}

--- a/crates/apr-cli/src/commands/mod.rs
+++ b/crates/apr-cli/src/commands/mod.rs
@@ -47,6 +47,7 @@ pub(crate) mod inspect;
 pub(crate) mod kernel_explain;
 pub(crate) mod lint;
 pub(crate) mod lora_hotswap_classifier;
+pub(crate) mod lora_hotswap_lint;
 pub(crate) mod mcp;
 pub(crate) mod merge;
 #[cfg(feature = "training")]

--- a/crates/apr-cli/src/commands/mod.rs
+++ b/crates/apr-cli/src/commands/mod.rs
@@ -46,6 +46,7 @@ pub(crate) mod import;
 pub(crate) mod inspect;
 pub(crate) mod kernel_explain;
 pub(crate) mod lint;
+pub(crate) mod lora_hotswap_classifier;
 pub(crate) mod mcp;
 pub(crate) mod merge;
 #[cfg(feature = "training")]

--- a/crates/apr-cli/src/dispatch_analysis.rs
+++ b/crates/apr-cli/src/dispatch_analysis.rs
@@ -130,6 +130,10 @@ fn dispatch_analysis_commands(cli: &Cli) -> Option<Result<(), CliError>> {
             commands::typical_p_lint::run(observation_file, cli.json)
         }
 
+        ExtendedCommands::LoraHotswapLint { observation_file } => {
+            commands::lora_hotswap_lint::run(observation_file, cli.json)
+        }
+
 
         ExtendedCommands::Hex {
             file,

--- a/crates/apr-cli/src/extended_commands.rs
+++ b/crates/apr-cli/src/extended_commands.rs
@@ -768,6 +768,11 @@ pub enum ExtendedCommands {
         #[arg(long, value_name = "FILE")]
         observation_file: PathBuf,
     },
+    /// Lint a LoRA hotswap observation (CRUX-C-16)
+    LoraHotswapLint {
+        #[arg(long, value_name = "FILE")]
+        observation_file: PathBuf,
+    },
     /// Publishing, conversion, and analysis tools
     #[command(flatten)]
     Tools(ToolCommands),

--- a/crates/apr-cli/tests/cli_commands.rs
+++ b/crates/apr-cli/tests/cli_commands.rs
@@ -79,6 +79,7 @@ fn registered_commands() -> Vec<&'static str> {
         "tool-use-lint",
         "gbnf-lint",
         "typical-p-lint",
+        "lora-hotswap-lint",
         "oracle",
         "encrypt",
         "decrypt",

--- a/crates/apr-cli/tests/falsification_crux_c_16.rs
+++ b/crates/apr-cli/tests/falsification_crux_c_16.rs
@@ -1,0 +1,336 @@
+//! E2E falsification tests for `apr lora-hotswap-lint` (CRUX-C-16).
+//!
+//! Discharges g3 of CRUX-SHIP-001 for PR #980: exercise the CLI surface
+//! end-to-end on captured JSON observations and assert the classifier
+//! verdicts + non-zero exit codes on known-bad input.
+
+use std::io::Write;
+use std::process::Command;
+
+fn apr_binary() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_apr"));
+    cmd.env("NO_COLOR", "1");
+    cmd
+}
+
+fn write_tmp_json(name: &str, body: &str) -> tempfile::NamedTempFile {
+    let mut f = tempfile::Builder::new()
+        .prefix(name)
+        .suffix(".json")
+        .tempfile()
+        .expect("create tempfile");
+    f.write_all(body.as_bytes()).expect("write tempfile");
+    f.flush().expect("flush tempfile");
+    f
+}
+
+// ---- help surface (g2 proof) ----------------------------------------------
+
+#[test]
+fn falsify_crux_c_16_help_advertises_observation_file_flag() {
+    let out = apr_binary()
+        .args(["lora-hotswap-lint", "--help"])
+        .output()
+        .expect("run apr lora-hotswap-lint --help");
+    assert!(
+        out.status.success(),
+        "apr lora-hotswap-lint --help must exit 0"
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("--observation-file"),
+        "--help must advertise --observation-file; got:\n{stdout}"
+    );
+}
+
+#[test]
+fn falsify_crux_c_16_rejects_bare_invocation_without_file() {
+    let out = apr_binary()
+        .arg("lora-hotswap-lint")
+        .output()
+        .expect("run apr lora-hotswap-lint without args");
+    assert!(
+        !out.status.success(),
+        "bare `apr lora-hotswap-lint` must exit non-zero"
+    );
+}
+
+// ---- hotswap_parity gate (FALSIFY-CRUX-C-16-001) --------------------------
+
+#[test]
+fn falsify_crux_c_16_001_hotswap_parity_ok_on_identical() {
+    let tmp = write_tmp_json(
+        "lora-parity-ok",
+        r#"{ "hotswap_parity": { "merged_tokens": [1,2,3], "hotswap_tokens": [1,2,3] } }"#,
+    );
+    let out = apr_binary()
+        .args(["lora-hotswap-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr lora-hotswap-lint");
+    assert!(
+        out.status.success(),
+        "identical tokens must pass; stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn falsify_crux_c_16_001_hotswap_parity_rejects_token_divergence() {
+    let tmp = write_tmp_json(
+        "lora-parity-div",
+        r#"{ "hotswap_parity": { "merged_tokens": [1,2,3], "hotswap_tokens": [1,9,3] } }"#,
+    );
+    let out = apr_binary()
+        .args(["lora-hotswap-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr lora-hotswap-lint");
+    assert!(!out.status.success(), "divergent tokens must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("FALSIFY-CRUX-C-16-001"),
+        "stderr must cite FALSIFY-CRUX-C-16-001; got:\n{stderr}"
+    );
+}
+
+// ---- load_latency gate (FALSIFY-CRUX-C-16-002) ----------------------------
+
+#[test]
+fn falsify_crux_c_16_002_load_latency_ok_under_budget() {
+    let tmp = write_tmp_json(
+        "lora-lat-ok",
+        r#"{ "load_latency": { "samples_seconds": [0.1, 0.15, 0.2], "budget_seconds": 2.0 } }"#,
+    );
+    let out = apr_binary()
+        .args(["lora-hotswap-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr lora-hotswap-lint");
+    assert!(out.status.success());
+}
+
+#[test]
+fn falsify_crux_c_16_002_load_latency_rejects_exceeded() {
+    // 9x 0.1 + 1x 2.5 → 10-sample nearest-rank P99 = 2.5 > budget 2.0
+    let tmp = write_tmp_json(
+        "lora-lat-ex",
+        r#"{ "load_latency": {
+             "samples_seconds": [0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 2.5],
+             "budget_seconds": 2.0
+           } }"#,
+    );
+    let out = apr_binary()
+        .args(["lora-hotswap-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr lora-hotswap-lint");
+    assert!(!out.status.success(), "exceeded budget must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-C-16-002"));
+}
+
+#[test]
+fn falsify_crux_c_16_002_load_latency_rejects_invalid_budget() {
+    let tmp = write_tmp_json(
+        "lora-lat-bad-budget",
+        r#"{ "load_latency": { "samples_seconds": [0.1], "budget_seconds": 0.0 } }"#,
+    );
+    let out = apr_binary()
+        .args(["lora-hotswap-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr lora-hotswap-lint");
+    assert!(!out.status.success(), "zero budget must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-C-16-002"));
+}
+
+// ---- adapter_compat gate (FALSIFY-CRUX-C-16-003) --------------------------
+
+#[test]
+fn falsify_crux_c_16_003_adapter_compat_ok_on_matching() {
+    let tmp = write_tmp_json(
+        "lora-compat-ok",
+        r#"{ "adapter_compat": {
+             "base_sha256": "abc123",
+             "adapter_base_sha256": "abc123",
+             "base_module_names": ["q_proj", "k_proj", "v_proj"],
+             "adapter_target_modules": ["q_proj", "v_proj"],
+             "adapter_rank": 64
+           } }"#,
+    );
+    let out = apr_binary()
+        .args(["lora-hotswap-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr lora-hotswap-lint");
+    assert!(
+        out.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn falsify_crux_c_16_003_adapter_compat_rejects_sha_mismatch() {
+    let tmp = write_tmp_json(
+        "lora-compat-sha",
+        r#"{ "adapter_compat": {
+             "base_sha256": "abc123",
+             "adapter_base_sha256": "def456",
+             "base_module_names": ["q_proj"],
+             "adapter_target_modules": ["q_proj"],
+             "adapter_rank": 16
+           } }"#,
+    );
+    let out = apr_binary()
+        .args(["lora-hotswap-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr lora-hotswap-lint");
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-C-16-003"));
+}
+
+#[test]
+fn falsify_crux_c_16_003_adapter_compat_rejects_rank_too_large() {
+    let tmp = write_tmp_json(
+        "lora-compat-rank",
+        r#"{ "adapter_compat": {
+             "base_sha256": "abc",
+             "adapter_base_sha256": "abc",
+             "base_module_names": ["q_proj"],
+             "adapter_target_modules": ["q_proj"],
+             "adapter_rank": 1024
+           } }"#,
+    );
+    let out = apr_binary()
+        .args(["lora-hotswap-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr lora-hotswap-lint");
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-C-16-003"));
+}
+
+#[test]
+fn falsify_crux_c_16_003_adapter_compat_rejects_unknown_modules() {
+    let tmp = write_tmp_json(
+        "lora-compat-unknown",
+        r#"{ "adapter_compat": {
+             "base_sha256": "abc",
+             "adapter_base_sha256": "abc",
+             "base_module_names": ["q_proj", "k_proj"],
+             "adapter_target_modules": ["q_proj", "x_proj"],
+             "adapter_rank": 16
+           } }"#,
+    );
+    let out = apr_binary()
+        .args(["lora-hotswap-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr lora-hotswap-lint");
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-C-16-003"));
+}
+
+// ---- unload_restore gate (FALSIFY-CRUX-C-16-004) --------------------------
+
+#[test]
+fn falsify_crux_c_16_004_unload_restore_ok_on_identical() {
+    let tmp = write_tmp_json(
+        "lora-unload-ok",
+        r#"{ "unload_restore": { "fresh_tokens": [1,2,3], "after_unload_tokens": [1,2,3] } }"#,
+    );
+    let out = apr_binary()
+        .args(["lora-hotswap-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr lora-hotswap-lint");
+    assert!(out.status.success());
+}
+
+#[test]
+fn falsify_crux_c_16_004_unload_restore_rejects_divergence() {
+    let tmp = write_tmp_json(
+        "lora-unload-div",
+        r#"{ "unload_restore": { "fresh_tokens": [1,2,3], "after_unload_tokens": [1,9,3] } }"#,
+    );
+    let out = apr_binary()
+        .args(["lora-hotswap-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr lora-hotswap-lint");
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-C-16-004"));
+}
+
+// ---- input validation -----------------------------------------------------
+
+#[test]
+fn falsify_crux_c_16_empty_file_rejected_via_cli() {
+    let tmp = write_tmp_json("lora-empty", "");
+    let out = apr_binary()
+        .args(["lora-hotswap-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr lora-hotswap-lint");
+    assert!(!out.status.success(), "empty file must be rejected");
+}
+
+#[test]
+fn falsify_crux_c_16_nonexistent_file_rejected() {
+    let out = apr_binary()
+        .args([
+            "lora-hotswap-lint",
+            "--observation-file",
+            "/nonexistent/path/obs.json",
+        ])
+        .output()
+        .expect("run apr lora-hotswap-lint");
+    assert!(!out.status.success());
+}
+
+// ---- --json shape ---------------------------------------------------------
+
+#[test]
+fn falsify_crux_c_16_json_output_shape() {
+    let tmp = write_tmp_json(
+        "lora-json-shape",
+        r#"{
+          "hotswap_parity": { "merged_tokens": [1], "hotswap_tokens": [1] },
+          "load_latency":   { "samples_seconds": [0.1], "budget_seconds": 2.0 },
+          "adapter_compat": {
+            "base_sha256": "abc",
+            "adapter_base_sha256": "abc",
+            "base_module_names": ["q_proj"],
+            "adapter_target_modules": ["q_proj"],
+            "adapter_rank": 16
+          },
+          "unload_restore": { "fresh_tokens": [1], "after_unload_tokens": [1] }
+        }"#,
+    );
+    let out = apr_binary()
+        .args(["--json", "lora-hotswap-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr lora-hotswap-lint --json");
+    assert!(
+        out.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("\"hotswap_parity\""),
+        "--json must emit hotswap_parity key"
+    );
+    assert!(stdout.contains("\"load_latency\""));
+    assert!(stdout.contains("\"adapter_compat\""));
+    assert!(stdout.contains("\"unload_restore\""));
+}


### PR DESCRIPTION
## Summary

Discharges FALSIFY-CRUX-C-16-001..004 at **PARTIAL_ALGORITHM_LEVEL** via pure Rust classifiers for LoRA adapter hotswap. Full discharge blocks on `apr serve --enable-lora` + `/v1/lora/{load,unload}` HTTP surface wired to a real adapter-hotswap runtime.

## Contract

- `contracts/crux-C-16-v1.yaml`: v1.0.0-draft → **v1.1.0**, status draft → **partial**
- All 4 FALSIFY gates now carry `evidence_discharged_by` with `classifier_path`, `sub_claim`, `tests[]`, `scope`, `discharge_status`, `full_discharge_blocked_on`
- `pv validate` → 0 error(s), 0 warning(s)

## Classifiers (pure, deterministic)

| Gate | Classifier | Discriminating Outcome variants |
|------|------------|---------------------------------|
| 001 hotswap parity | `classify_hotswap_parity` | `EmptinessMismatch` / `LengthMismatch` / `TokenDivergence{at_index, merged, hotswap}` |
| 002 load latency | `classify_load_latency` | `InvalidInput` / `Exceeded{p99, budget}` (nearest-rank P99, deterministic) |
| 003 compat | `classify_adapter_compat` | 6 variants: `EmptyBaseSha256`, `EmptyAdapterBaseSha256`, `BaseSha256Mismatch`, `EmptyTargetModules`, `UnknownTargetModules{unknown}`, `RankTooSmall` / `RankTooLarge` |
| 004 unload restore | `classify_unload_restore` | `EmptinessMismatch` / `LengthMismatch` / `TokenDivergence` |

Constants: `LORA_RANK_MIN = 1`, `LORA_RANK_MAX = 512`, `LORA_LOAD_LATENCY_P99_S = 2.0`.

## Tests

**33 new pure-classifier tests, all passing.** Deterministic (5× repeat per classifier); zero new deps.

## Test plan

- [x] `cargo test -p apr-cli --lib commands::lora_hotswap_classifier` → 33/33 PASS
- [x] `cargo clippy -p apr-cli --lib -- -D warnings` → clean
- [x] `pv validate contracts/crux-C-16-v1.yaml` → valid
- [ ] CI required checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)