### PR TITLE
feat(crux-c-17): multi-LoRA batched (parity+throughput+404+capacity) classifier (4 of 4 FALSIFY at PARTIAL_ALGORITHM_LEVEL)

### DIFF
--- a/contracts/crux-C-17-v1.yaml
+++ b/contracts/crux-C-17-v1.yaml
@@ -1,21 +1,17 @@
 # CRUX-C-17 — Multi-LoRA serving N adapters
-# Auto-scaffolded from crux-competitive-research-ux-v1.yaml (DRAFT).
-# DO NOT promote to ACTIVE until: (1) evidence collected, (2) falsification
-# body reflects competitor's canonical CLI, (3) apr surface mapped or gap
-# tracked in pmat work (see master §12).
 
 metadata:
   id: CRUX-C-17
-  version: "1.0.0-draft"
+  version: "1.1.0"
   created: "2026-04-18"
   author: PAIML Engineering
   registry: true
-  status: draft
+  status: partial
   parent_contracts:
   - crux-competitive-research-ux-v1
   category: "C — Serving & Chat UX"
   competitor: vllm
-  demand_score: 4  # 1..5, high priority in pmat work
+  demand_score: 4
   intake_status: missing
   description: >
     Multi-LoRA serving — batched inference where concurrent requests each
@@ -69,14 +65,11 @@ falsification_tests:
   rule: batched output ≡ serial output per request
   prediction: "batch with {A1,A2,A3} produces per-request outputs matching serial"
   test: |
-    # TODO: blocked until apr serve --enable-lora + batched multi-LoRA
     apr serve base.gguf --enable-lora --lora a1=ad1.gguf --lora a2=ad2.gguf --lora a3=ad3.gguf --port 18080 &
     sleep 5
-    # Serial baseline
     S1=$(curl -sX POST localhost:18080/v1/completions -H 'X-LoRA-Adapter: a1' -d '{"prompt":"q1","max_tokens":16,"temperature":0.0,"top_k":1}' | jq -r '.choices[0].token_ids | join(",")')
     S2=$(curl -sX POST localhost:18080/v1/completions -H 'X-LoRA-Adapter: a2' -d '{"prompt":"q2","max_tokens":16,"temperature":0.0,"top_k":1}' | jq -r '.choices[0].token_ids | join(",")')
     S3=$(curl -sX POST localhost:18080/v1/completions -H 'X-LoRA-Adapter: a3' -d '{"prompt":"q3","max_tokens":16,"temperature":0.0,"top_k":1}' | jq -r '.choices[0].token_ids | join(",")')
-    # Concurrent batch (all 3 hit in flight)
     (curl -sX POST localhost:18080/v1/completions -H 'X-LoRA-Adapter: a1' -d '{"prompt":"q1","max_tokens":16,"temperature":0.0,"top_k":1}' > r1.json) &
     (curl -sX POST localhost:18080/v1/completions -H 'X-LoRA-Adapter: a2' -d '{"prompt":"q2","max_tokens":16,"temperature":0.0,"top_k":1}' > r2.json) &
     (curl -sX POST localhost:18080/v1/completions -H 'X-LoRA-Adapter: a3' -d '{"prompt":"q3","max_tokens":16,"temperature":0.0,"top_k":1}' > r3.json) &
@@ -87,22 +80,80 @@ falsification_tests:
     B3=$(jq -r '.choices[0].token_ids | join(",")' r3.json)
     [ "$S1" = "$B1" ] && [ "$S2" = "$B2" ] && [ "$S3" = "$B3" ]
   if_fails: "batched multi-LoRA cross-contamination — S-LoRA/Punica kernel bug"
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/multi_lora_classifier.rs
+    sub_claim: |
+      Algorithm-level necessary condition: `classify_batched_parity(serial,
+      batched)` accepts iff `|serial| == |batched|` AND for every request
+      index `i`, `serial[i]` is byte-identical to `batched[i]`. Rejection
+      paths distinguish five defect classes deterministically:
+        (a) `CountMismatch{serial_len, batched_len}` — scheduler dropped
+            or duplicated a request (batch-plumbing bug);
+        (b) `EmptinessMismatch{at_index, serial_empty, batched_empty}` —
+            one side produced no output for request i (a request
+            silently eaten by S-LoRA dispatch is a different defect from
+            "wrong first token");
+        (c) `LengthMismatch{at_index, serial_len, batched_len}` — length
+            disagrees before any token comparison;
+        (d) `TokenDivergence{request_index, at_token_index, serial_token,
+            batched_token}` — cross-contamination at the FIRST diverging
+            token of the FIRST diverging request (deterministic; bisection-
+            friendly for Punica-kernel debugging).
+      Pure; deterministic.
+    tests:
+    - batched_parity_ok_on_identical_per_request
+    - batched_parity_ok_on_two_empty_vectors
+    - batched_parity_rejects_count_mismatch
+    - batched_parity_rejects_per_request_emptiness_mismatch
+    - batched_parity_rejects_per_request_length_mismatch
+    - batched_parity_rejects_cross_contamination_first_index
+    - batched_parity_is_deterministic
+    scope: "(serial_outputs: &[&[u32]], batched_outputs: &[&[u32]]) → BatchedParityOutcome (pure)"
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: "apr serve --enable-lora with S-LoRA/Punica batched kernel + X-LoRA-Adapter request-time selection emitting token_ids"
 
 - id: FALSIFY-CRUX-C-17-002
   rule: throughput degradation sublinear in N
   prediction: "N=8 concurrent LoRA batch >= 80% of base-only batch throughput"
   test: |
-    # TODO: blocked until multi-LoRA batching
     BASE_TPS=$(apr bench base.gguf --batch-size 8 --json | jq '.tokens_per_sec')
     MULTI_TPS=$(apr bench base.gguf --enable-lora --loras 8 --batch-size 8 --json | jq '.tokens_per_sec')
     python3 -c "import sys; sys.exit(0 if $MULTI_TPS / $BASE_TPS >= 0.8 else 1)"
   if_fails: "multi-LoRA throughput degradation exceeds 20%"
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/multi_lora_classifier.rs
+    sub_claim: |
+      Algorithm-level necessary condition:
+      `classify_multi_lora_throughput(base_tps, multi_tps, min_alpha)`
+      accepts iff `multi_tps / base_tps >= min_alpha` AND inputs are
+      finite with `base_tps > 0`, `multi_tps >= 0`, `min_alpha ∈ [0,1]`.
+      Rejection paths:
+        (a) non-finite, non-positive-base, or out-of-range-alpha →
+            `InvalidInput{reason}` with a distinct reason string per
+            violation (measurement-pipeline bugs cannot masquerade as
+            throughput regressions);
+        (b) finite-valid but alpha < min → `BelowThreshold{observed,
+            required}`.
+      MIN_MULTI_LORA_THROUGHPUT_ALPHA = 0.80 is the contract's 80% floor.
+      Pure; deterministic.
+    tests:
+    - multi_lora_throughput_ok_above_floor
+    - multi_lora_throughput_ok_exactly_at_floor
+    - multi_lora_throughput_rejects_below_floor
+    - multi_lora_throughput_rejects_nan
+    - multi_lora_throughput_rejects_zero_base
+    - multi_lora_throughput_rejects_negative_multi
+    - multi_lora_throughput_rejects_alpha_out_of_range
+    - multi_lora_throughput_is_deterministic
+    - multi_lora_constants_are_canonical
+    scope: "(base_tps, multi_tps, min_alpha) → MultiLoraThroughputOutcome (pure)"
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: "apr bench --enable-lora --loras N surface emitting tokens_per_sec under concurrent batch"
 
 - id: FALSIFY-CRUX-C-17-003
   rule: unknown adapter returns HTTP 404
   prediction: "request with X-LoRA-Adapter: missing returns HTTP 404"
   test: |
-    # TODO: blocked until multi-LoRA endpoints
     apr serve base.gguf --enable-lora --lora a1=ad1.gguf --port 18080 &
     sleep 5
     STATUS=$(curl -sw "%{http_code}" -o /dev/null -X POST localhost:18080/v1/completions \
@@ -110,12 +161,39 @@ falsification_tests:
     kill %1
     [ "$STATUS" = "404" ]
   if_fails: "unknown LoRA adapter accepted (silently falls back to base or 500)"
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/multi_lora_classifier.rs
+    sub_claim: |
+      Algorithm-level necessary condition:
+      `classify_unknown_adapter_response(requested, loaded, status, body)`
+      accepts iff `requested` is non-empty AND `requested ∉ loaded` AND
+      `status == 404` AND `body.contains(requested)`. Rejection paths:
+        (a) empty requested name → `EmptyAdapterName`;
+        (b) test-harness bug: adapter actually loaded →
+            `AdapterIsLoaded{adapter_name}`;
+        (c) wrong status (e.g. 500 server error or 200 silent fallback
+            to base model — a critical defect) → `WrongStatusCode{got,
+            expected: 404}`;
+        (d) 404 present but adapter name absent from error body →
+            `MissingNameInBody` (actionability gate — user must be able
+            to see WHICH adapter was missing).
+      Pure; deterministic.
+    tests:
+    - unknown_adapter_ok_on_404_with_name_in_body
+    - unknown_adapter_rejects_empty_name
+    - unknown_adapter_rejects_when_actually_loaded
+    - unknown_adapter_rejects_wrong_status_500
+    - unknown_adapter_rejects_silent_fallback_200
+    - unknown_adapter_rejects_missing_name_in_body
+    - unknown_adapter_is_deterministic
+    scope: "(requested: &str, loaded: &[&str], status_code: u16, error_body: &str) → UnknownAdapterResponseOutcome (pure)"
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: "apr serve --enable-lora + X-LoRA-Adapter request-time dispatch returning HTTP 404 with actionable body"
 
 - id: FALSIFY-CRUX-C-17-004
   rule: max_loras bound enforced
   prediction: "loading adapter N+1 when max_loras=N returns HTTP 429/503"
   test: |
-    # TODO: blocked until /v1/lora/load + max_loras flag
     apr serve base.gguf --enable-lora --max-loras 2 --port 18080 &
     sleep 5
     curl -sX POST localhost:18080/v1/lora/load -d '{"adapter_name":"a1","lora_path":"ad.gguf"}'
@@ -125,6 +203,36 @@ falsification_tests:
     kill %1
     [ "$STATUS" = "429" ] || [ "$STATUS" = "503" ]
   if_fails: "max_loras bound not enforced — OOM risk when capacity exceeded"
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/multi_lora_classifier.rs
+    sub_claim: |
+      Algorithm-level necessary condition:
+      `classify_max_loras_capacity(loaded_count, max_loras, status_code)`
+      accepts iff `max_loras >= 1` AND `loaded_count >= max_loras` AND
+      `status_code ∈ OVER_CAPACITY_STATUS_CODES = [429, 503]`. Rejection
+      paths distinguish:
+        (a) `ZeroMaxLoras` — degenerate-config bug (server should not
+            start with max_loras=0);
+        (b) `AcceptedWithinCapacity{loaded_count, max_loras}` — the
+            request should have SUCCEEDED (calling this classifier on
+            in-capacity requests means the harness is asking the wrong
+            question; distinct from a true defect);
+        (c) `WrongStatusCode{got, allowed}` — the actual defect class:
+            e.g. 200 (silent over-capacity OOM risk) or 500 (unhandled
+            exception) when we expect a polite throttle.
+      OVER_CAPACITY_STATUS_CODES = [429, 503] per contract.
+      Pure; deterministic.
+    tests:
+    - max_loras_ok_at_capacity_with_429
+    - max_loras_ok_at_capacity_with_503
+    - max_loras_rejects_zero_max
+    - max_loras_rejects_rejected_while_within_capacity
+    - max_loras_rejects_wrong_status_200_at_capacity
+    - max_loras_rejects_wrong_status_500_at_capacity
+    - max_loras_is_deterministic
+    scope: "(loaded_count: u32, max_loras: u32, status_code: u16) → MaxLorasCapacityOutcome (pure)"
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: "apr serve --enable-lora --max-loras N surface with /v1/lora/load enforcing capacity via 429/503 response"
 
 proof_obligations:
 - type: equivalence
@@ -141,10 +249,21 @@ verification_summary:
   proven: 0
   tested: 0
   status: spec-complete
+  discharge_ledger:
+  - falsify_id: FALSIFY-CRUX-C-17-001
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    blocked_on: "apr serve --enable-lora with S-LoRA/Punica batched kernel + X-LoRA-Adapter dispatch"
+  - falsify_id: FALSIFY-CRUX-C-17-002
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    blocked_on: "apr bench --enable-lora --loras N surface emitting tokens_per_sec"
+  - falsify_id: FALSIFY-CRUX-C-17-003
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    blocked_on: "apr serve --enable-lora returning HTTP 404 on unknown X-LoRA-Adapter with actionable body"
+  - falsify_id: FALSIFY-CRUX-C-17-004
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    blocked_on: "apr serve --enable-lora --max-loras N with /v1/lora/load enforcing capacity via 429/503"
 
 pmat_work_tracking:
-  # Managed by master contract §12. If intake_status == "missing", a ticket
-  # tagged `crux-crux-c-17` is auto-created by scripts/crux_bulk_pmat_work.sh.
   ticket_tag: crux-crux-c-17
   priority: high
   auto_created: true

--- a/crates/apr-cli/src/commands/mod.rs
+++ b/crates/apr-cli/src/commands/mod.rs
@@ -42,6 +42,7 @@ pub(crate) mod kernel_explain;
 pub(crate) mod lint;
 pub(crate) mod mcp;
 pub(crate) mod merge;
+pub(crate) mod multi_lora_classifier;
 #[cfg(feature = "training")]
 pub(crate) mod model_config;
 #[cfg(feature = "training")]

--- a/crates/apr-cli/src/commands/multi_lora_classifier.rs
+++ b/crates/apr-cli/src/commands/multi_lora_classifier.rs
@@ -1,0 +1,515 @@
+//! CRUX-C-17 — Multi-LoRA batched serving classifiers (S-LoRA / Punica).
+//!
+//! Pure, deterministic algorithm-level gates discharging FALSIFY-CRUX-C-17-001..004
+//! at PARTIAL_ALGORITHM_LEVEL. Full discharge is blocked on `apr serve --enable-lora`
+//! + per-request `X-LoRA-Adapter` header + the S-LoRA/Punica batched kernel.
+//!
+//! Design rule: no silent passes — every ill-formed input maps to a distinct
+//! Outcome variant so defect classes cannot collapse into each other.
+
+/// Contract-pinned multi-LoRA throughput floor (80% of base-only batched throughput).
+pub const MIN_MULTI_LORA_THROUGHPUT_ALPHA: f64 = 0.80;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Classifier 1: batched ≡ serial per-request parity
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BatchedParityOutcome {
+    Ok,
+    CountMismatch { serial_len: usize, batched_len: usize },
+    EmptinessMismatch { at_index: usize, serial_empty: bool, batched_empty: bool },
+    LengthMismatch { at_index: usize, serial_len: usize, batched_len: usize },
+    TokenDivergence {
+        request_index: usize,
+        at_token_index: usize,
+        serial_token: u32,
+        batched_token: u32,
+    },
+}
+
+pub fn classify_batched_parity(
+    serial_outputs: &[&[u32]],
+    batched_outputs: &[&[u32]],
+) -> BatchedParityOutcome {
+    if serial_outputs.len() != batched_outputs.len() {
+        return BatchedParityOutcome::CountMismatch {
+            serial_len: serial_outputs.len(),
+            batched_len: batched_outputs.len(),
+        };
+    }
+    for (i, (s, b)) in serial_outputs.iter().zip(batched_outputs.iter()).enumerate() {
+        let s_empty = s.is_empty();
+        let b_empty = b.is_empty();
+        if s_empty != b_empty {
+            return BatchedParityOutcome::EmptinessMismatch {
+                at_index: i,
+                serial_empty: s_empty,
+                batched_empty: b_empty,
+            };
+        }
+        if s.len() != b.len() {
+            return BatchedParityOutcome::LengthMismatch {
+                at_index: i,
+                serial_len: s.len(),
+                batched_len: b.len(),
+            };
+        }
+        for (j, (sv, bv)) in s.iter().zip(b.iter()).enumerate() {
+            if sv != bv {
+                return BatchedParityOutcome::TokenDivergence {
+                    request_index: i,
+                    at_token_index: j,
+                    serial_token: *sv,
+                    batched_token: *bv,
+                };
+            }
+        }
+    }
+    BatchedParityOutcome::Ok
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Classifier 2: multi-LoRA throughput floor (80% of base)
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum MultiLoraThroughputOutcome {
+    Ok { observed_alpha: f64 },
+    InvalidInput { reason: &'static str },
+    BelowThreshold { observed_alpha: f64, required_alpha: f64 },
+}
+
+pub fn classify_multi_lora_throughput(
+    base_tps: f64,
+    multi_tps: f64,
+    min_alpha: f64,
+) -> MultiLoraThroughputOutcome {
+    if !base_tps.is_finite() || !multi_tps.is_finite() || !min_alpha.is_finite() {
+        return MultiLoraThroughputOutcome::InvalidInput { reason: "non-finite input" };
+    }
+    if base_tps <= 0.0 {
+        return MultiLoraThroughputOutcome::InvalidInput { reason: "base_tps <= 0" };
+    }
+    if multi_tps < 0.0 {
+        return MultiLoraThroughputOutcome::InvalidInput { reason: "multi_tps < 0" };
+    }
+    if !(0.0..=1.0).contains(&min_alpha) {
+        return MultiLoraThroughputOutcome::InvalidInput {
+            reason: "min_alpha out of [0.0, 1.0]",
+        };
+    }
+    let observed_alpha = multi_tps / base_tps;
+    if observed_alpha < min_alpha {
+        return MultiLoraThroughputOutcome::BelowThreshold {
+            observed_alpha,
+            required_alpha: min_alpha,
+        };
+    }
+    MultiLoraThroughputOutcome::Ok { observed_alpha }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Classifier 3: unknown-adapter HTTP status discipline
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UnknownAdapterResponseOutcome {
+    Ok,
+    EmptyAdapterName,
+    AdapterIsLoaded { adapter_name: String },
+    WrongStatusCode { got: u16, expected: u16 },
+    MissingNameInBody,
+}
+
+pub fn classify_unknown_adapter_response(
+    requested_adapter: &str,
+    loaded_adapters: &[&str],
+    status_code: u16,
+    error_body: &str,
+) -> UnknownAdapterResponseOutcome {
+    if requested_adapter.is_empty() {
+        return UnknownAdapterResponseOutcome::EmptyAdapterName;
+    }
+    // If adapter is in fact loaded, the 404 discipline doesn't apply —
+    // calling this classifier would be a test-harness bug.
+    if loaded_adapters.iter().any(|a| *a == requested_adapter) {
+        return UnknownAdapterResponseOutcome::AdapterIsLoaded {
+            adapter_name: requested_adapter.to_string(),
+        };
+    }
+    if status_code != 404 {
+        return UnknownAdapterResponseOutcome::WrongStatusCode {
+            got: status_code,
+            expected: 404,
+        };
+    }
+    if !error_body.contains(requested_adapter) {
+        return UnknownAdapterResponseOutcome::MissingNameInBody;
+    }
+    UnknownAdapterResponseOutcome::Ok
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Classifier 4: max_loras capacity discipline
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MaxLorasCapacityOutcome {
+    Ok,
+    ZeroMaxLoras,
+    AcceptedWithinCapacity { loaded_count: u32, max_loras: u32 },
+    WrongStatusCode { got: u16, allowed: &'static [u16] },
+}
+
+/// Valid HTTP status codes for "over-capacity" rejection per contract v1.1.0:
+/// 429 Too Many Requests or 503 Service Unavailable.
+pub const OVER_CAPACITY_STATUS_CODES: &[u16] = &[429, 503];
+
+pub fn classify_max_loras_capacity(
+    loaded_count: u32,
+    max_loras: u32,
+    status_code: u16,
+) -> MaxLorasCapacityOutcome {
+    if max_loras == 0 {
+        return MaxLorasCapacityOutcome::ZeroMaxLoras;
+    }
+    if loaded_count < max_loras {
+        // Request to load another adapter should succeed (200/202), not be
+        // rejected as over-capacity.
+        return MaxLorasCapacityOutcome::AcceptedWithinCapacity {
+            loaded_count,
+            max_loras,
+        };
+    }
+    // At/above capacity — MUST respond with 429 or 503.
+    if !OVER_CAPACITY_STATUS_CODES.contains(&status_code) {
+        return MaxLorasCapacityOutcome::WrongStatusCode {
+            got: status_code,
+            allowed: OVER_CAPACITY_STATUS_CODES,
+        };
+    }
+    MaxLorasCapacityOutcome::Ok
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests — pure, deterministic.
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── batched parity ─────────────────────────────────────────────────────
+
+    #[test]
+    fn batched_parity_ok_on_identical_per_request() {
+        let s: Vec<&[u32]> = vec![&[1, 2, 3], &[4, 5], &[6]];
+        let b: Vec<&[u32]> = vec![&[1, 2, 3], &[4, 5], &[6]];
+        assert_eq!(classify_batched_parity(&s, &b), BatchedParityOutcome::Ok);
+    }
+
+    #[test]
+    fn batched_parity_ok_on_two_empty_vectors() {
+        let s: Vec<&[u32]> = vec![];
+        let b: Vec<&[u32]> = vec![];
+        assert_eq!(classify_batched_parity(&s, &b), BatchedParityOutcome::Ok);
+    }
+
+    #[test]
+    fn batched_parity_rejects_count_mismatch() {
+        let s: Vec<&[u32]> = vec![&[1], &[2]];
+        let b: Vec<&[u32]> = vec![&[1]];
+        assert_eq!(
+            classify_batched_parity(&s, &b),
+            BatchedParityOutcome::CountMismatch { serial_len: 2, batched_len: 1 }
+        );
+    }
+
+    #[test]
+    fn batched_parity_rejects_per_request_emptiness_mismatch() {
+        let s: Vec<&[u32]> = vec![&[1], &[]];
+        let b: Vec<&[u32]> = vec![&[1], &[7]];
+        assert_eq!(
+            classify_batched_parity(&s, &b),
+            BatchedParityOutcome::EmptinessMismatch {
+                at_index: 1,
+                serial_empty: true,
+                batched_empty: false,
+            }
+        );
+    }
+
+    #[test]
+    fn batched_parity_rejects_per_request_length_mismatch() {
+        let s: Vec<&[u32]> = vec![&[1, 2], &[3]];
+        let b: Vec<&[u32]> = vec![&[1, 2], &[3, 4]];
+        assert_eq!(
+            classify_batched_parity(&s, &b),
+            BatchedParityOutcome::LengthMismatch {
+                at_index: 1,
+                serial_len: 1,
+                batched_len: 2,
+            }
+        );
+    }
+
+    #[test]
+    fn batched_parity_rejects_cross_contamination_first_index() {
+        // Request 0 matches; request 1 diverges at token 0. Report request 1.
+        let s: Vec<&[u32]> = vec![&[10, 20], &[30, 40]];
+        let b: Vec<&[u32]> = vec![&[10, 20], &[99, 40]];
+        assert_eq!(
+            classify_batched_parity(&s, &b),
+            BatchedParityOutcome::TokenDivergence {
+                request_index: 1,
+                at_token_index: 0,
+                serial_token: 30,
+                batched_token: 99,
+            }
+        );
+    }
+
+    #[test]
+    fn batched_parity_is_deterministic() {
+        let s: Vec<&[u32]> = vec![&[1, 2], &[3, 4]];
+        let b: Vec<&[u32]> = vec![&[1, 2], &[3, 4]];
+        for _ in 0..5 {
+            assert_eq!(classify_batched_parity(&s, &b), BatchedParityOutcome::Ok);
+        }
+    }
+
+    // ── throughput floor ───────────────────────────────────────────────────
+
+    #[test]
+    fn multi_lora_throughput_ok_above_floor() {
+        match classify_multi_lora_throughput(100.0, 85.0, 0.80) {
+            MultiLoraThroughputOutcome::Ok { observed_alpha } => {
+                assert!((observed_alpha - 0.85).abs() < 1e-9);
+            }
+            other => panic!("expected Ok, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn multi_lora_throughput_ok_exactly_at_floor() {
+        match classify_multi_lora_throughput(100.0, 80.0, 0.80) {
+            MultiLoraThroughputOutcome::Ok { observed_alpha } => {
+                assert!((observed_alpha - 0.80).abs() < 1e-9);
+            }
+            other => panic!("expected Ok, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn multi_lora_throughput_rejects_below_floor() {
+        match classify_multi_lora_throughput(100.0, 70.0, 0.80) {
+            MultiLoraThroughputOutcome::BelowThreshold { observed_alpha, required_alpha } => {
+                assert!((observed_alpha - 0.70).abs() < 1e-9);
+                assert_eq!(required_alpha, 0.80);
+            }
+            other => panic!("expected BelowThreshold, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn multi_lora_throughput_rejects_nan() {
+        match classify_multi_lora_throughput(f64::NAN, 100.0, 0.80) {
+            MultiLoraThroughputOutcome::InvalidInput { reason } => {
+                assert!(reason.contains("non-finite"));
+            }
+            other => panic!("expected InvalidInput, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn multi_lora_throughput_rejects_zero_base() {
+        match classify_multi_lora_throughput(0.0, 10.0, 0.80) {
+            MultiLoraThroughputOutcome::InvalidInput { reason } => {
+                assert!(reason.contains("base_tps"));
+            }
+            other => panic!("expected InvalidInput, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn multi_lora_throughput_rejects_negative_multi() {
+        match classify_multi_lora_throughput(100.0, -1.0, 0.80) {
+            MultiLoraThroughputOutcome::InvalidInput { reason } => {
+                assert!(reason.contains("multi_tps"));
+            }
+            other => panic!("expected InvalidInput, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn multi_lora_throughput_rejects_alpha_out_of_range() {
+        match classify_multi_lora_throughput(100.0, 100.0, 1.5) {
+            MultiLoraThroughputOutcome::InvalidInput { reason } => {
+                assert!(reason.contains("min_alpha"));
+            }
+            other => panic!("expected InvalidInput, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn multi_lora_throughput_is_deterministic() {
+        for _ in 0..5 {
+            match classify_multi_lora_throughput(100.0, 90.0, 0.80) {
+                MultiLoraThroughputOutcome::Ok { .. } => {}
+                other => panic!("expected Ok, got {other:?}"),
+            }
+        }
+    }
+
+    // ── unknown-adapter response ───────────────────────────────────────────
+
+    #[test]
+    fn unknown_adapter_ok_on_404_with_name_in_body() {
+        assert_eq!(
+            classify_unknown_adapter_response(
+                "missing",
+                &["a1", "a2"],
+                404,
+                "adapter 'missing' not found",
+            ),
+            UnknownAdapterResponseOutcome::Ok
+        );
+    }
+
+    #[test]
+    fn unknown_adapter_rejects_empty_name() {
+        assert_eq!(
+            classify_unknown_adapter_response("", &["a1"], 404, "not found"),
+            UnknownAdapterResponseOutcome::EmptyAdapterName
+        );
+    }
+
+    #[test]
+    fn unknown_adapter_rejects_when_actually_loaded() {
+        match classify_unknown_adapter_response("a1", &["a1", "a2"], 404, "not found") {
+            UnknownAdapterResponseOutcome::AdapterIsLoaded { adapter_name } => {
+                assert_eq!(adapter_name, "a1");
+            }
+            other => panic!("expected AdapterIsLoaded, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unknown_adapter_rejects_wrong_status_500() {
+        assert_eq!(
+            classify_unknown_adapter_response("missing", &["a1"], 500, "server error"),
+            UnknownAdapterResponseOutcome::WrongStatusCode { got: 500, expected: 404 }
+        );
+    }
+
+    #[test]
+    fn unknown_adapter_rejects_silent_fallback_200() {
+        // Silent fallback to base model — a real defect, not a 404.
+        assert_eq!(
+            classify_unknown_adapter_response("missing", &["a1"], 200, "ok"),
+            UnknownAdapterResponseOutcome::WrongStatusCode { got: 200, expected: 404 }
+        );
+    }
+
+    #[test]
+    fn unknown_adapter_rejects_missing_name_in_body() {
+        assert_eq!(
+            classify_unknown_adapter_response("missing", &["a1"], 404, "not found"),
+            UnknownAdapterResponseOutcome::MissingNameInBody
+        );
+    }
+
+    #[test]
+    fn unknown_adapter_is_deterministic() {
+        for _ in 0..5 {
+            assert_eq!(
+                classify_unknown_adapter_response(
+                    "missing",
+                    &["a1"],
+                    404,
+                    "adapter 'missing' not found"
+                ),
+                UnknownAdapterResponseOutcome::Ok
+            );
+        }
+    }
+
+    // ── max_loras capacity ─────────────────────────────────────────────────
+
+    #[test]
+    fn max_loras_ok_at_capacity_with_429() {
+        assert_eq!(
+            classify_max_loras_capacity(2, 2, 429),
+            MaxLorasCapacityOutcome::Ok
+        );
+    }
+
+    #[test]
+    fn max_loras_ok_at_capacity_with_503() {
+        assert_eq!(
+            classify_max_loras_capacity(2, 2, 503),
+            MaxLorasCapacityOutcome::Ok
+        );
+    }
+
+    #[test]
+    fn max_loras_rejects_zero_max() {
+        assert_eq!(
+            classify_max_loras_capacity(0, 0, 429),
+            MaxLorasCapacityOutcome::ZeroMaxLoras
+        );
+    }
+
+    #[test]
+    fn max_loras_rejects_rejected_while_within_capacity() {
+        assert_eq!(
+            classify_max_loras_capacity(1, 2, 429),
+            MaxLorasCapacityOutcome::AcceptedWithinCapacity {
+                loaded_count: 1,
+                max_loras: 2,
+            }
+        );
+    }
+
+    #[test]
+    fn max_loras_rejects_wrong_status_200_at_capacity() {
+        // Silent acceptance above capacity — OOM risk.
+        assert_eq!(
+            classify_max_loras_capacity(2, 2, 200),
+            MaxLorasCapacityOutcome::WrongStatusCode {
+                got: 200,
+                allowed: OVER_CAPACITY_STATUS_CODES,
+            }
+        );
+    }
+
+    #[test]
+    fn max_loras_rejects_wrong_status_500_at_capacity() {
+        assert_eq!(
+            classify_max_loras_capacity(3, 2, 500),
+            MaxLorasCapacityOutcome::WrongStatusCode {
+                got: 500,
+                allowed: OVER_CAPACITY_STATUS_CODES,
+            }
+        );
+    }
+
+    #[test]
+    fn max_loras_is_deterministic() {
+        for _ in 0..5 {
+            assert_eq!(
+                classify_max_loras_capacity(5, 5, 503),
+                MaxLorasCapacityOutcome::Ok
+            );
+        }
+    }
+
+    // ── constants ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn multi_lora_constants_are_canonical() {
+        assert!((MIN_MULTI_LORA_THROUGHPUT_ALPHA - 0.80).abs() < 1e-9);
+        assert_eq!(OVER_CAPACITY_STATUS_CODES, &[429, 503]);
+    }
+}


### PR DESCRIPTION
## Summary

Discharges FALSIFY-CRUX-C-17-001..004 at **PARTIAL_ALGORITHM_LEVEL** via pure Rust classifiers for multi-LoRA batched serving (S-LoRA / Punica). Full discharge blocks on `apr serve --enable-lora` + batched kernel + `X-LoRA-Adapter` dispatch.

## Contract

- `contracts/crux-C-17-v1.yaml`: v1.0.0-draft → **v1.1.0**, status draft → **partial**
- All 4 FALSIFY gates now carry `evidence_discharged_by` with `classifier_path`, `sub_claim`, `tests[]`, `scope`, `discharge_status`, `full_discharge_blocked_on`
- `pv validate` → 0 error(s), 0 warning(s)

## Classifiers (pure, deterministic)

| Gate | Classifier | Discriminating Outcome variants |
|------|------------|---------------------------------|
| 001 batched parity | `classify_batched_parity` | `CountMismatch` / `EmptinessMismatch{at_index}` / `LengthMismatch{at_index}` / `TokenDivergence{request_index, at_token_index, ...}` |
| 002 throughput | `classify_multi_lora_throughput` | `InvalidInput` / `BelowThreshold{observed, required}` (80% floor) |
| 003 unknown adapter | `classify_unknown_adapter_response` | `EmptyAdapterName` / `AdapterIsLoaded` / `WrongStatusCode{got, expected: 404}` / `MissingNameInBody` |
| 004 capacity | `classify_max_loras_capacity` | `ZeroMaxLoras` / `AcceptedWithinCapacity` / `WrongStatusCode{got, allowed: [429,503]}` |

Constants: `MIN_MULTI_LORA_THROUGHPUT_ALPHA = 0.80`, `OVER_CAPACITY_STATUS_CODES = &[429, 503]`.

## Tests

**30 new pure-classifier tests, all passing.** Deterministic (5× repeat per classifier); zero new deps.

## Test plan

- [x] `cargo test -p apr-cli --lib commands::multi_lora_classifier` → 30/30 PASS
- [x] `cargo clippy -p apr-cli --lib -- -D warnings` → clean
- [x] `pv validate contracts/crux-C-17-v1.yaml` → valid
- [ ] CI required checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)