### PR TITLE
feat(crux-c-22): typical-p (identity+mass+sort+renorm) classifier (2 of 2 FALSIFY at PARTIAL_ALGORITHM_LEVEL)

### DIFF
--- a/contracts/apr-cli-commands-v1.yaml
+++ b/contracts/apr-cli-commands-v1.yaml
@@ -21,7 +21,7 @@ metadata:
 kind: CLICommandContract
 name: apr-cli-commands
 version: "1.0.0"
-scope: "all apr CLI subcommands (65 commands — original 57 + `mcp` added 2026-04-17 via PR #864 + `registry` added 2026-04-20 via CRUX-A-01 + `ollama-chat-lint` added 2026-04-21 via CRUX-C-04 SHIP-001 retrofit + `dry-sampling-lint` added 2026-04-21 via CRUX-C-23 SHIP-001 retrofit + `awq-lint` added 2026-04-21 via CRUX-B-08 SHIP-001 retrofit + `oom-lint` added 2026-04-21 via CRUX-F-13 SHIP-001 + `tool-use-lint` added 2026-04-21 via CRUX-C-11 SHIP-001 retrofit + `gbnf-lint` added 2026-04-21 via CRUX-C-10 SHIP-001 retrofit)"
+scope: "all apr CLI subcommands (66 commands — original 57 + `mcp` added 2026-04-17 via PR #864 + `registry` added 2026-04-20 via CRUX-A-01 + `ollama-chat-lint` added 2026-04-21 via CRUX-C-04 SHIP-001 retrofit + `dry-sampling-lint` added 2026-04-21 via CRUX-C-23 SHIP-001 retrofit + `awq-lint` added 2026-04-21 via CRUX-B-08 SHIP-001 retrofit + `oom-lint` added 2026-04-21 via CRUX-F-13 SHIP-001 + `tool-use-lint` added 2026-04-21 via CRUX-C-11 SHIP-001 retrofit + `gbnf-lint` added 2026-04-21 via CRUX-C-10 SHIP-001 retrofit + `typical-p-lint` added 2026-04-21 via CRUX-C-22 SHIP-001 retrofit)"
 binary: "apr"
 install: "cargo install aprender"
 
@@ -423,6 +423,12 @@ commands:
   - name: gbnf-lint
     category: inspection
     description: "Lint a GBNF grammar-constrained observation (CRUX-C-10)"
+    requires_model: false
+    side_effects: []
+
+  - name: typical-p-lint
+    category: inspection
+    description: "Lint a captured typical-p sampling observation (CRUX-C-22)"
     requires_model: false
     side_effects: []
 

--- a/contracts/crux-C-22-v1.yaml
+++ b/contracts/crux-C-22-v1.yaml
@@ -2,7 +2,7 @@
 
 metadata:
   id: CRUX-C-22
-  version: "1.1.0"
+  version: "1.2.0"
   created: "2026-04-18"
   updated: "2026-04-21"
   author: PAIML Engineering
@@ -53,6 +53,14 @@ falsification_tests:
   if_fails: rule 'p=1.0 is identity (no change from greedy/temperature-only)' is violated — contract MUST be re-verified against competitor canonical reference
   evidence_discharged_by:
     classifier_path: crates/apr-cli/src/commands/typical_p_classifier.rs
+    cli_path: crates/apr-cli/src/commands/typical_p_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_c_22.rs
+    e2e_tests:
+    - falsify_crux_c_22_001_range_ok_on_valid_p
+    - falsify_crux_c_22_001_range_rejects_zero_p
+    - falsify_crux_c_22_001_range_rejects_above_one
+    - falsify_crux_c_22_001_identity_ok_on_all_kept
+    - falsify_crux_c_22_001_identity_rejects_dropped_tokens
     sub_claim: "p=1.0 identity + parameter-range invariants captured by pure classifiers"
     tests:
     - identity_ok_when_all_kept
@@ -95,6 +103,14 @@ falsification_tests:
   if_fails: rule 'matches HF TypicalLogitsWarper on identical logits' is violated — contract MUST be re-verified against competitor canonical reference
   evidence_discharged_by:
     classifier_path: crates/apr-cli/src/commands/typical_p_classifier.rs
+    cli_path: crates/apr-cli/src/commands/typical_p_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_c_22.rs
+    e2e_tests:
+    - falsify_crux_c_22_002_mass_ok_when_meets_threshold
+    - falsify_crux_c_22_002_mass_rejects_insufficient
+    - falsify_crux_c_22_002_renorm_ok_when_sums_to_one
+    - falsify_crux_c_22_002_renorm_rejects_under_normalized
+    - falsify_crux_c_22_002_sort_ok_on_uniform
     sub_claim: "mass-coverage, sort-by-c_i ASC, and renormalization sum=1.0±1e-6 properties captured by pure classifiers"
     tests:
     - mass_ok_when_kept_meets_threshold
@@ -138,6 +154,27 @@ verification_summary:
   proven: 0
   tested: 2
   status: partial
+
+ship_discipline:
+  ship_rule: CRUX-SHIP-001
+  deliverables_present:
+    classifier: crates/apr-cli/src/commands/typical_p_classifier.rs
+    cli_wiring: crates/apr-cli/src/commands/typical_p_lint.rs
+    e2e_test: crates/apr-cli/tests/falsification_crux_c_22.rs
+    contract: contracts/crux-C-22-v1.yaml
+  merge_gates:
+    g1_classifier_green: true
+    g2_cli_reachable: true
+    g3_e2e_runs: true
+    g4_contract_discharged: PARTIAL_ALGORITHM_LEVEL
+  notes: >
+    `apr typical-p-lint --observation-file <obs.json>` dispatches five
+    classifiers (range, identity, mass-coverage, sort-order,
+    renormalization) over captured JSON. e2e suite (15 tests) exercises
+    help surface, bare-invocation rejection, per-gate ok+reject paths,
+    empty/nonexistent file rejection, and --json shape. Full ACTIVE
+    discharge remains blocked on `apr run --typical` identity test against
+    a real GGUF fixture + Python HF TypicalLogitsWarper reference parity.
 
 pmat_work_tracking:
   ticket_tag: crux-crux-c-22

--- a/contracts/crux-C-22-v1.yaml
+++ b/contracts/crux-C-22-v1.yaml
@@ -1,12 +1,14 @@
-# CRUX-C-22 — Typical sampling
+# CRUX-C-22 — Typical-p (locally typical) sampling
 
 metadata:
   id: CRUX-C-22
   version: "1.1.0"
   created: "2026-04-18"
+  updated: "2026-04-21"
   author: PAIML Engineering
   registry: true
-  status: draft
+  status: partial
+  kind: kernel
   parent_contracts:
   - crux-competitive-research-ux-v1
   category: "C — Serving & Chat UX"
@@ -20,8 +22,10 @@ metadata:
 
   references:
   - 'master: contracts/crux-competitive-research-ux-v1.yaml — §5 + §12'
-  - github.com/huggingface/accelerate
-  - github.com/pytorch/pytorch — DDP/FSDP
+  - 'paper: https://arxiv.org/abs/2202.00666 — Meister et al., Typical Decoding'
+  - 'impl: transformers.TypicalLogitsWarper'
+  - 'impl: llama.cpp --typical flag'
+
 equations:
   typical_p:
     formula: |
@@ -35,6 +39,7 @@ equations:
     - "p = 1.0 → no filtering (identity)"
     - "tokens kept are exactly those whose |−log p − H| is smallest cumulative sum ≥ p"
     - "matches HF `TypicalLogitsWarper` bit-for-bit on f32 logits"
+    - "filtered distribution renormalizes to sum=1.0 ± 1e-6"
 
 falsification_tests:
 - id: FALSIFY-CRUX-C-22-001
@@ -46,12 +51,35 @@ falsification_tests:
     apr run tests/fixtures/tinyllama-q4_k_m.gguf --prompt "The" --seed 5 --max-tokens 16 --format json > /tmp/base.json
     diff <(jq .token_ids /tmp/typ.json) <(jq .token_ids /tmp/base.json)
   if_fails: rule 'p=1.0 is identity (no change from greedy/temperature-only)' is violated — contract MUST be re-verified against competitor canonical reference
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/typical_p_classifier.rs
+    sub_claim: "p=1.0 identity + parameter-range invariants captured by pure classifiers"
+    tests:
+    - identity_ok_when_all_kept
+    - identity_ok_order_insensitive
+    - identity_flags_dropped_tokens
+    - identity_rejects_non_unity_p
+    - identity_rejects_oob_index
+    - identity_rejects_duplicate_index
+    - identity_rejects_empty_total
+    - identity_p_one_and_mass_coverage_coincide
+    - range_valid_for_one
+    - range_valid_for_half
+    - range_valid_for_canonical_0_95
+    - range_rejects_zero
+    - range_rejects_negative
+    - range_rejects_above_one
+    - range_rejects_nan
+    - range_rejects_infinity
+    scope: PARTIAL_ALGORITHM_LEVEL
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: "end-to-end `apr run --typical 1.0` identity test against real GGUF fixture (requires fixtures/tinyllama-q4_k_m.gguf on CI runner)"
+
 - id: FALSIFY-CRUX-C-22-002
   rule: matches HF TypicalLogitsWarper on identical logits
   prediction: "kept-token set identical to HF reference on a captured logits tensor"
   test: |
     set -euo pipefail
-    # apr writes the post-filter prob vector for introspection
     apr debug sample --logits tests/fixtures/logits_row.npy --typical 0.95 --format json > /tmp/apr.json
     python3 - <<'PY'
     import numpy as np, json
@@ -64,8 +92,39 @@ falsification_tests:
     diffs = [abs(a-b) for a,b in zip(apr, hf)]
     assert max(diffs) < 1e-5, max(diffs)
     PY
-
   if_fails: rule 'matches HF TypicalLogitsWarper on identical logits' is violated — contract MUST be re-verified against competitor canonical reference
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/typical_p_classifier.rs
+    sub_claim: "mass-coverage, sort-by-c_i ASC, and renormalization sum=1.0±1e-6 properties captured by pure classifiers"
+    tests:
+    - mass_ok_when_kept_meets_threshold
+    - mass_rejects_under_threshold
+    - mass_rejects_above_one
+    - mass_rejects_empty
+    - mass_rejects_invalid_p_zero
+    - mass_rejects_prob_above_one
+    - mass_rejects_negative_prob
+    - mass_rejects_nan_prob
+    - sort_ok_when_kept_empty_is_rejected
+    - sort_ok_uniform_distribution_any_order
+    - sort_ok_when_kept_ordered_ascending_by_c
+    - sort_flags_descending_order
+    - sort_rejects_zero_prob
+    - sort_rejects_nan_kept
+    - sort_rejects_nan_all_probs
+    - sort_rejects_empty_all_probs
+    - renorm_ok_when_sums_to_one
+    - renorm_ok_within_tolerance
+    - renorm_flags_under_normalization
+    - renorm_flags_negative_prob
+    - renorm_rejects_nan
+    - renorm_rejects_infinity
+    - renorm_rejects_empty
+    - renormalized_two_token_distribution_parity
+    scope: PARTIAL_ALGORITHM_LEVEL
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: "Python HF reference parity run against `tests/fixtures/logits_row.npy` (requires transformers, fixture, and `apr debug sample --typical` CLI wiring)"
+
 proof_obligations:
 - type: equivalence
   property: "apr --typical matches HF `TypicalLogitsWarper` and llama.cpp `--typical` on identical logits"
@@ -77,8 +136,8 @@ proof_obligations:
 verification_summary:
   total_obligations: 3
   proven: 0
-  tested: 0
-  status: spec-complete
+  tested: 2
+  status: partial
 
 pmat_work_tracking:
   ticket_tag: crux-crux-c-22

--- a/crates/apr-cli/src/commands/mod.rs
+++ b/crates/apr-cli/src/commands/mod.rs
@@ -48,6 +48,8 @@ pub(crate) mod kernel_explain;
 pub(crate) mod lint;
 pub(crate) mod mcp;
 pub(crate) mod merge;
+pub(crate) mod multi_lora_classifier;
+pub(crate) mod typical_p_classifier;
 #[cfg(feature = "training")]
 pub(crate) mod model_config;
 #[cfg(feature = "training")]

--- a/crates/apr-cli/src/commands/mod.rs
+++ b/crates/apr-cli/src/commands/mod.rs
@@ -48,8 +48,6 @@ pub(crate) mod kernel_explain;
 pub(crate) mod lint;
 pub(crate) mod mcp;
 pub(crate) mod merge;
-pub(crate) mod multi_lora_classifier;
-pub(crate) mod typical_p_classifier;
 #[cfg(feature = "training")]
 pub(crate) mod model_config;
 #[cfg(feature = "training")]
@@ -103,6 +101,8 @@ pub(crate) mod tokenize;
 pub(crate) mod tp_pp_classifier;
 pub(crate) mod tool_use_classifier;
 pub(crate) mod tool_use_lint;
+pub(crate) mod typical_p_classifier;
+pub(crate) mod typical_p_lint;
 pub(crate) mod trace;
 #[cfg(feature = "training")]
 pub(crate) mod train;

--- a/crates/apr-cli/src/commands/typical_p_classifier.rs
+++ b/crates/apr-cli/src/commands/typical_p_classifier.rs
@@ -1,0 +1,675 @@
+//! CRUX-C-22 — Typical-p (locally typical) sampling classifiers
+//!
+//! Discharges `contracts/crux-C-22-v1.yaml` FALSIFY gates at PARTIAL_ALGORITHM_LEVEL:
+//! - FALSIFY-CRUX-C-22-001: p=1.0 is identity (no filtering)
+//! - FALSIFY-CRUX-C-22-002: kept-token set matches HF `TypicalLogitsWarper`
+//!
+//! Algorithm (arXiv:2202.00666):
+//!   p_i = softmax(logits)
+//!   H   = -sum(p_i * log p_i)
+//!   c_i = |-log p_i - H|
+//!   sort tokens by c_i ASC; keep smallest-cumulative-mass set S s.t. sum >= p
+//!   renormalize kept probs; discard rest
+
+#![allow(dead_code)]
+
+/// Minimum valid typical-p value (exclusive zero per arXiv:2202.00666).
+pub(crate) const TYPICAL_P_MIN_EXCLUSIVE: f64 = 0.0;
+/// Maximum valid typical-p value (inclusive).
+pub(crate) const TYPICAL_P_MAX_INCLUSIVE: f64 = 1.0;
+/// Renormalization sum tolerance (per contract v1.1.0).
+pub(crate) const RENORM_TOLERANCE: f64 = 1e-6;
+
+/// Parameter-range gate: p must be finite and in (0, 1].
+#[derive(Debug, PartialEq)]
+pub(crate) enum TypicalPRangeOutcome {
+    Valid,
+    NotFinite,
+    BelowMinimum { p: f64 },
+    AboveMaximum { p: f64 },
+}
+
+pub(crate) fn classify_typical_p_range(p: f64) -> TypicalPRangeOutcome {
+    if !p.is_finite() {
+        return TypicalPRangeOutcome::NotFinite;
+    }
+    if p <= TYPICAL_P_MIN_EXCLUSIVE {
+        return TypicalPRangeOutcome::BelowMinimum { p };
+    }
+    if p > TYPICAL_P_MAX_INCLUSIVE {
+        return TypicalPRangeOutcome::AboveMaximum { p };
+    }
+    TypicalPRangeOutcome::Valid
+}
+
+/// Identity gate (FALSIFY-CRUX-C-22-001): p=1.0 returns every token.
+#[derive(Debug, PartialEq)]
+pub(crate) enum IdentityOutcome {
+    Ok {
+        kept_count: usize,
+        total_count: usize,
+    },
+    InvalidInput {
+        reason: &'static str,
+    },
+    DroppedTokens {
+        kept_count: usize,
+        total_count: usize,
+    },
+}
+
+pub(crate) fn classify_typical_p_identity(
+    kept_indices: &[usize],
+    total_tokens: usize,
+    p: f64,
+) -> IdentityOutcome {
+    if total_tokens == 0 {
+        return IdentityOutcome::InvalidInput {
+            reason: "total_tokens == 0",
+        };
+    }
+    if !p.is_finite() || (p - 1.0).abs() > f64::EPSILON {
+        return IdentityOutcome::InvalidInput {
+            reason: "p != 1.0",
+        };
+    }
+    if kept_indices.len() != total_tokens {
+        return IdentityOutcome::DroppedTokens {
+            kept_count: kept_indices.len(),
+            total_count: total_tokens,
+        };
+    }
+    let mut seen = vec![false; total_tokens];
+    for &idx in kept_indices {
+        if idx >= total_tokens {
+            return IdentityOutcome::InvalidInput {
+                reason: "kept_index out of range",
+            };
+        }
+        if seen[idx] {
+            return IdentityOutcome::InvalidInput {
+                reason: "duplicate kept_index",
+            };
+        }
+        seen[idx] = true;
+    }
+    IdentityOutcome::Ok {
+        kept_count: kept_indices.len(),
+        total_count: total_tokens,
+    }
+}
+
+/// Mass-coverage gate: kept probabilities must sum to ≥ p (minimal typical set).
+#[derive(Debug, PartialEq)]
+pub(crate) enum MassCoverageOutcome {
+    Ok { kept_mass: f64 },
+    InvalidInput { reason: &'static str },
+    InsufficientMass { kept_mass: f64, required: f64 },
+    TooLarge { kept_mass: f64, excess: f64 },
+}
+
+/// kept_probs are the ORIGINAL (pre-renormalization) probabilities
+/// of the tokens kept by the typical-p filter.
+pub(crate) fn classify_typical_p_mass_coverage(
+    kept_probs: &[f64],
+    p: f64,
+) -> MassCoverageOutcome {
+    if kept_probs.is_empty() {
+        return MassCoverageOutcome::InvalidInput {
+            reason: "kept_probs is empty",
+        };
+    }
+    if !p.is_finite() || p <= 0.0 || p > 1.0 {
+        return MassCoverageOutcome::InvalidInput {
+            reason: "p out of (0, 1]",
+        };
+    }
+    if !kept_probs.iter().all(|&x| x.is_finite() && (0.0..=1.0).contains(&x)) {
+        return MassCoverageOutcome::InvalidInput {
+            reason: "prob not in [0, 1]",
+        };
+    }
+    let kept_mass: f64 = kept_probs.iter().sum();
+    if kept_mass < p - RENORM_TOLERANCE {
+        return MassCoverageOutcome::InsufficientMass {
+            kept_mass,
+            required: p,
+        };
+    }
+    if kept_mass > 1.0 + RENORM_TOLERANCE {
+        return MassCoverageOutcome::TooLarge {
+            kept_mass,
+            excess: kept_mass - 1.0,
+        };
+    }
+    MassCoverageOutcome::Ok { kept_mass }
+}
+
+/// Renormalization gate: filtered distribution sums to 1.0 ± 1e-6.
+#[derive(Debug, PartialEq)]
+pub(crate) enum RenormOutcome {
+    Ok { sum: f64 },
+    InvalidInput { reason: &'static str },
+    NotNormalized { sum: f64, deviation: f64 },
+    ContainsNegative { first_bad_index: usize, value: f64 },
+}
+
+pub(crate) fn classify_typical_p_renormalization(filtered_probs: &[f64]) -> RenormOutcome {
+    if filtered_probs.is_empty() {
+        return RenormOutcome::InvalidInput {
+            reason: "filtered_probs is empty",
+        };
+    }
+    for (i, &x) in filtered_probs.iter().enumerate() {
+        if !x.is_finite() {
+            return RenormOutcome::InvalidInput {
+                reason: "non-finite probability",
+            };
+        }
+        if x < 0.0 {
+            return RenormOutcome::ContainsNegative {
+                first_bad_index: i,
+                value: x,
+            };
+        }
+    }
+    let sum: f64 = filtered_probs.iter().sum();
+    let deviation = (sum - 1.0).abs();
+    if deviation > RENORM_TOLERANCE {
+        return RenormOutcome::NotNormalized { sum, deviation };
+    }
+    RenormOutcome::Ok { sum }
+}
+
+/// Sort-order gate: kept tokens must be sorted by c_i = |−log p_i − H| ASC.
+/// `kept_probs_in_sort_order` lists the original probabilities of kept tokens
+/// in the order the filter emits them (should be c_i ASC).
+#[derive(Debug, PartialEq)]
+pub(crate) enum SortOrderOutcome {
+    Ok,
+    InvalidInput { reason: &'static str },
+    OutOfOrder {
+        at_index: usize,
+        prev_c: f64,
+        curr_c: f64,
+    },
+}
+
+pub(crate) fn classify_typical_p_sort_order(
+    all_probs: &[f64],
+    kept_probs_in_sort_order: &[f64],
+) -> SortOrderOutcome {
+    if all_probs.is_empty() || kept_probs_in_sort_order.is_empty() {
+        return SortOrderOutcome::InvalidInput {
+            reason: "empty input",
+        };
+    }
+    if !all_probs.iter().all(|&x| x.is_finite() && x > 0.0 && x <= 1.0) {
+        return SortOrderOutcome::InvalidInput {
+            reason: "all_probs must be strictly positive and finite",
+        };
+    }
+    if !kept_probs_in_sort_order
+        .iter()
+        .all(|&x| x.is_finite() && x > 0.0 && x <= 1.0)
+    {
+        return SortOrderOutcome::InvalidInput {
+            reason: "kept_probs must be strictly positive and finite",
+        };
+    }
+    let entropy: f64 = -all_probs.iter().map(|&p| p * p.ln()).sum::<f64>();
+    let c = |prob: f64| (-prob.ln() - entropy).abs();
+
+    for i in 1..kept_probs_in_sort_order.len() {
+        let prev_c = c(kept_probs_in_sort_order[i - 1]);
+        let curr_c = c(kept_probs_in_sort_order[i]);
+        if curr_c < prev_c - RENORM_TOLERANCE {
+            return SortOrderOutcome::OutOfOrder {
+                at_index: i,
+                prev_c,
+                curr_c,
+            };
+        }
+    }
+    SortOrderOutcome::Ok
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -------- range --------
+
+    #[test]
+    fn range_valid_for_one() {
+        assert_eq!(classify_typical_p_range(1.0), TypicalPRangeOutcome::Valid);
+    }
+
+    #[test]
+    fn range_valid_for_half() {
+        assert_eq!(classify_typical_p_range(0.5), TypicalPRangeOutcome::Valid);
+    }
+
+    #[test]
+    fn range_valid_for_canonical_0_95() {
+        assert_eq!(classify_typical_p_range(0.95), TypicalPRangeOutcome::Valid);
+    }
+
+    #[test]
+    fn range_rejects_zero() {
+        assert_eq!(
+            classify_typical_p_range(0.0),
+            TypicalPRangeOutcome::BelowMinimum { p: 0.0 }
+        );
+    }
+
+    #[test]
+    fn range_rejects_negative() {
+        assert_eq!(
+            classify_typical_p_range(-0.1),
+            TypicalPRangeOutcome::BelowMinimum { p: -0.1 }
+        );
+    }
+
+    #[test]
+    fn range_rejects_above_one() {
+        assert_eq!(
+            classify_typical_p_range(1.5),
+            TypicalPRangeOutcome::AboveMaximum { p: 1.5 }
+        );
+    }
+
+    #[test]
+    fn range_rejects_nan() {
+        assert_eq!(
+            classify_typical_p_range(f64::NAN),
+            TypicalPRangeOutcome::NotFinite
+        );
+    }
+
+    #[test]
+    fn range_rejects_infinity() {
+        assert_eq!(
+            classify_typical_p_range(f64::INFINITY),
+            TypicalPRangeOutcome::NotFinite
+        );
+    }
+
+    // -------- identity (p = 1.0) --------
+
+    #[test]
+    fn identity_ok_when_all_kept() {
+        let kept: Vec<usize> = (0..4).collect();
+        assert_eq!(
+            classify_typical_p_identity(&kept, 4, 1.0),
+            IdentityOutcome::Ok {
+                kept_count: 4,
+                total_count: 4,
+            }
+        );
+    }
+
+    #[test]
+    fn identity_ok_order_insensitive() {
+        let kept = vec![3, 1, 0, 2];
+        assert_eq!(
+            classify_typical_p_identity(&kept, 4, 1.0),
+            IdentityOutcome::Ok {
+                kept_count: 4,
+                total_count: 4,
+            }
+        );
+    }
+
+    #[test]
+    fn identity_flags_dropped_tokens() {
+        let kept = vec![0, 1, 2];
+        assert_eq!(
+            classify_typical_p_identity(&kept, 4, 1.0),
+            IdentityOutcome::DroppedTokens {
+                kept_count: 3,
+                total_count: 4,
+            }
+        );
+    }
+
+    #[test]
+    fn identity_rejects_non_unity_p() {
+        let kept = vec![0, 1];
+        assert_eq!(
+            classify_typical_p_identity(&kept, 2, 0.95),
+            IdentityOutcome::InvalidInput { reason: "p != 1.0" }
+        );
+    }
+
+    #[test]
+    fn identity_rejects_oob_index() {
+        let kept = vec![0, 5];
+        assert_eq!(
+            classify_typical_p_identity(&kept, 2, 1.0),
+            IdentityOutcome::InvalidInput {
+                reason: "kept_index out of range"
+            }
+        );
+    }
+
+    #[test]
+    fn identity_rejects_duplicate_index() {
+        let kept = vec![0, 1, 1];
+        assert_eq!(
+            classify_typical_p_identity(&kept, 3, 1.0),
+            IdentityOutcome::InvalidInput {
+                reason: "duplicate kept_index"
+            }
+        );
+    }
+
+    #[test]
+    fn identity_rejects_empty_total() {
+        assert_eq!(
+            classify_typical_p_identity(&[], 0, 1.0),
+            IdentityOutcome::InvalidInput {
+                reason: "total_tokens == 0"
+            }
+        );
+    }
+
+    // -------- mass coverage --------
+
+    #[test]
+    fn mass_ok_when_kept_meets_threshold() {
+        let kept = vec![0.4, 0.3, 0.25];
+        assert_eq!(
+            classify_typical_p_mass_coverage(&kept, 0.95),
+            MassCoverageOutcome::Ok { kept_mass: 0.95 }
+        );
+    }
+
+    #[test]
+    fn mass_rejects_under_threshold() {
+        let kept = vec![0.3, 0.2];
+        let outcome = classify_typical_p_mass_coverage(&kept, 0.95);
+        match outcome {
+            MassCoverageOutcome::InsufficientMass { kept_mass, required } => {
+                assert!((kept_mass - 0.5).abs() < 1e-9);
+                assert!((required - 0.95).abs() < 1e-9);
+            }
+            other => panic!("expected InsufficientMass, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn mass_rejects_above_one() {
+        let kept = vec![0.6, 0.6];
+        match classify_typical_p_mass_coverage(&kept, 0.95) {
+            MassCoverageOutcome::TooLarge { kept_mass, excess } => {
+                assert!((kept_mass - 1.2).abs() < 1e-9);
+                assert!((excess - 0.2).abs() < 1e-9);
+            }
+            other => panic!("expected TooLarge, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn mass_rejects_empty() {
+        assert_eq!(
+            classify_typical_p_mass_coverage(&[], 0.95),
+            MassCoverageOutcome::InvalidInput {
+                reason: "kept_probs is empty"
+            }
+        );
+    }
+
+    #[test]
+    fn mass_rejects_invalid_p_zero() {
+        assert_eq!(
+            classify_typical_p_mass_coverage(&[0.5], 0.0),
+            MassCoverageOutcome::InvalidInput {
+                reason: "p out of (0, 1]"
+            }
+        );
+    }
+
+    #[test]
+    fn mass_rejects_prob_above_one() {
+        assert_eq!(
+            classify_typical_p_mass_coverage(&[1.5], 0.95),
+            MassCoverageOutcome::InvalidInput {
+                reason: "prob not in [0, 1]"
+            }
+        );
+    }
+
+    #[test]
+    fn mass_rejects_negative_prob() {
+        assert_eq!(
+            classify_typical_p_mass_coverage(&[-0.1, 0.9], 0.5),
+            MassCoverageOutcome::InvalidInput {
+                reason: "prob not in [0, 1]"
+            }
+        );
+    }
+
+    #[test]
+    fn mass_rejects_nan_prob() {
+        assert_eq!(
+            classify_typical_p_mass_coverage(&[f64::NAN], 0.5),
+            MassCoverageOutcome::InvalidInput {
+                reason: "prob not in [0, 1]"
+            }
+        );
+    }
+
+    // -------- renormalization --------
+
+    #[test]
+    fn renorm_ok_when_sums_to_one() {
+        let probs = vec![0.4, 0.3, 0.3];
+        assert_eq!(
+            classify_typical_p_renormalization(&probs),
+            RenormOutcome::Ok { sum: 1.0 }
+        );
+    }
+
+    #[test]
+    fn renorm_ok_within_tolerance() {
+        let probs = vec![0.333_333, 0.333_333, 0.333_334];
+        match classify_typical_p_renormalization(&probs) {
+            RenormOutcome::Ok { sum } => assert!((sum - 1.0).abs() <= RENORM_TOLERANCE),
+            other => panic!("expected Ok, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn renorm_flags_under_normalization() {
+        let probs = vec![0.4, 0.3, 0.2];
+        match classify_typical_p_renormalization(&probs) {
+            RenormOutcome::NotNormalized { sum, deviation } => {
+                assert!((sum - 0.9).abs() < 1e-9);
+                assert!((deviation - 0.1).abs() < 1e-9);
+            }
+            other => panic!("expected NotNormalized, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn renorm_flags_negative_prob() {
+        let probs = vec![0.5, -0.1, 0.6];
+        assert_eq!(
+            classify_typical_p_renormalization(&probs),
+            RenormOutcome::ContainsNegative {
+                first_bad_index: 1,
+                value: -0.1,
+            }
+        );
+    }
+
+    #[test]
+    fn renorm_rejects_nan() {
+        assert_eq!(
+            classify_typical_p_renormalization(&[f64::NAN, 0.5]),
+            RenormOutcome::InvalidInput {
+                reason: "non-finite probability"
+            }
+        );
+    }
+
+    #[test]
+    fn renorm_rejects_infinity() {
+        assert_eq!(
+            classify_typical_p_renormalization(&[f64::INFINITY, 0.0]),
+            RenormOutcome::InvalidInput {
+                reason: "non-finite probability"
+            }
+        );
+    }
+
+    #[test]
+    fn renorm_rejects_empty() {
+        assert_eq!(
+            classify_typical_p_renormalization(&[]),
+            RenormOutcome::InvalidInput {
+                reason: "filtered_probs is empty"
+            }
+        );
+    }
+
+    // -------- sort order by c_i --------
+
+    #[test]
+    fn sort_ok_when_kept_empty_is_rejected() {
+        let all = vec![0.25, 0.25, 0.25, 0.25];
+        assert_eq!(
+            classify_typical_p_sort_order(&all, &[]),
+            SortOrderOutcome::InvalidInput { reason: "empty input" }
+        );
+    }
+
+    #[test]
+    fn sort_ok_uniform_distribution_any_order() {
+        // Uniform distribution: H = -ln(1/4) = ln 4; c_i = |-ln(0.25) - ln 4| = 0 for all.
+        // Any order is equally valid because all c_i are equal.
+        let all = vec![0.25; 4];
+        let kept = vec![0.25, 0.25, 0.25, 0.25];
+        assert_eq!(
+            classify_typical_p_sort_order(&all, &kept),
+            SortOrderOutcome::Ok
+        );
+    }
+
+    #[test]
+    fn sort_ok_when_kept_ordered_ascending_by_c() {
+        // Skewed dist: one dominant token has lowest c_i.
+        // all = [0.7, 0.15, 0.1, 0.05]
+        // H = -sum(p ln p). Typical tokens are those with p closest to exp(-H).
+        // Compute c_i for each:
+        //   -ln(0.7)=0.357, -ln(0.15)=1.897, -ln(0.1)=2.303, -ln(0.05)=2.996
+        //   H = 0.7*0.357 + 0.15*1.897 + 0.1*2.303 + 0.05*2.996
+        //     = 0.2499 + 0.2846 + 0.2303 + 0.1498 ≈ 0.9146
+        //   c_i: |0.357-0.915|=0.558, |1.897-0.915|=0.982,
+        //        |2.303-0.915|=1.388, |2.996-0.915|=2.081
+        // Sorted c_i ASC: 0.7, 0.15, 0.1, 0.05
+        let all = vec![0.7, 0.15, 0.1, 0.05];
+        let kept = vec![0.7, 0.15, 0.1, 0.05];
+        assert_eq!(
+            classify_typical_p_sort_order(&all, &kept),
+            SortOrderOutcome::Ok
+        );
+    }
+
+    #[test]
+    fn sort_flags_descending_order() {
+        // Reverse of the skewed dist above: c_i DESC which is wrong direction.
+        let all = vec![0.7, 0.15, 0.1, 0.05];
+        let kept = vec![0.05, 0.1, 0.15, 0.7];
+        match classify_typical_p_sort_order(&all, &kept) {
+            SortOrderOutcome::OutOfOrder {
+                at_index,
+                prev_c,
+                curr_c,
+            } => {
+                assert_eq!(at_index, 1);
+                assert!(prev_c > curr_c);
+            }
+            other => panic!("expected OutOfOrder, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sort_rejects_zero_prob() {
+        let all = vec![0.5, 0.5];
+        let kept = vec![0.0];
+        assert_eq!(
+            classify_typical_p_sort_order(&all, &kept),
+            SortOrderOutcome::InvalidInput {
+                reason: "kept_probs must be strictly positive and finite"
+            }
+        );
+    }
+
+    #[test]
+    fn sort_rejects_nan_kept() {
+        let all = vec![0.5, 0.5];
+        let kept = vec![f64::NAN];
+        assert_eq!(
+            classify_typical_p_sort_order(&all, &kept),
+            SortOrderOutcome::InvalidInput {
+                reason: "kept_probs must be strictly positive and finite"
+            }
+        );
+    }
+
+    #[test]
+    fn sort_rejects_nan_all_probs() {
+        let all = vec![f64::NAN, 0.5];
+        let kept = vec![0.5];
+        assert_eq!(
+            classify_typical_p_sort_order(&all, &kept),
+            SortOrderOutcome::InvalidInput {
+                reason: "all_probs must be strictly positive and finite"
+            }
+        );
+    }
+
+    #[test]
+    fn sort_rejects_empty_all_probs() {
+        assert_eq!(
+            classify_typical_p_sort_order(&[], &[0.5]),
+            SortOrderOutcome::InvalidInput { reason: "empty input" }
+        );
+    }
+
+    // -------- integration-level properties --------
+
+    #[test]
+    fn identity_p_one_and_mass_coverage_coincide() {
+        // When p=1.0, mass coverage requires kept_mass >= 1.0, which means
+        // ALL tokens must be kept → consistent with IdentityOutcome::Ok.
+        let probs = vec![0.4, 0.3, 0.2, 0.1];
+        let indices: Vec<usize> = (0..probs.len()).collect();
+
+        assert_eq!(
+            classify_typical_p_identity(&indices, probs.len(), 1.0),
+            IdentityOutcome::Ok {
+                kept_count: 4,
+                total_count: 4
+            }
+        );
+        match classify_typical_p_mass_coverage(&probs, 1.0) {
+            MassCoverageOutcome::Ok { kept_mass } => {
+                assert!((kept_mass - 1.0).abs() < 1e-9);
+            }
+            other => panic!("expected Ok, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn renormalized_two_token_distribution_parity() {
+        // Original kept probs: [0.4, 0.3]; renormalized: [4/7, 3/7]
+        let renormalized = vec![4.0 / 7.0, 3.0 / 7.0];
+        match classify_typical_p_renormalization(&renormalized) {
+            RenormOutcome::Ok { sum } => assert!((sum - 1.0).abs() <= RENORM_TOLERANCE),
+            other => panic!("expected Ok, got {other:?}"),
+        }
+    }
+}

--- a/crates/apr-cli/src/commands/typical_p_lint.rs
+++ b/crates/apr-cli/src/commands/typical_p_lint.rs
@@ -1,0 +1,251 @@
+//! `apr typical-p-lint` — CRUX-C-22 typical-p sampling observation linter.
+//!
+//! Reads a JSON observation file that captures a single typical-p sampling
+//! run and dispatches five classifiers (range, identity, mass coverage,
+//! sort order, renormalization). Emits a text or `--json` report.
+//!
+//! Spec: `contracts/crux-C-22-v1.yaml`. CRUX-SHIP-001 g2/g3 surface.
+//!
+//! Observation schema (top-level keys; all optional — missing sections
+//! skip the corresponding classifier):
+//!
+//!   {
+//!     "range":    { "p": 0.95 },
+//!     "identity": { "kept_indices": [0,1,2], "total_tokens": 3, "p": 1.0 },
+//!     "mass":     { "kept_probs": [0.5, 0.3, 0.15], "p": 0.9 },
+//!     "sort":     { "all_probs": [0.5, 0.3, 0.2],
+//!                   "kept_probs_in_sort_order": [0.3, 0.2] },
+//!     "renorm":   { "filtered_probs": [0.6, 0.4] }
+//!   }
+
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+
+use crate::commands::typical_p_classifier as clf;
+use crate::error::{CliError, Result};
+
+pub(crate) fn run(observation_file: &Path, json: bool) -> Result<()> {
+    if !observation_file.exists() {
+        return Err(CliError::FileNotFound(PathBuf::from(observation_file)));
+    }
+
+    let body = std::fs::read_to_string(observation_file)?;
+    let obs: Value = serde_json::from_str(&body).map_err(|e| {
+        CliError::InvalidFormat(format!(
+            "apr typical-p-lint: failed to parse JSON from {}: {e}",
+            observation_file.display()
+        ))
+    })?;
+
+    let range = classify_range(&obs);
+    let identity = classify_identity(&obs);
+    let mass = classify_mass(&obs);
+    let sort = classify_sort(&obs);
+    let renorm = classify_renorm(&obs);
+
+    let fail_reasons: Vec<String> = [
+        range.as_ref().and_then(range_fail_reason),
+        identity.as_ref().and_then(identity_fail_reason),
+        mass.as_ref().and_then(mass_fail_reason),
+        sort.as_ref().and_then(sort_fail_reason),
+        renorm.as_ref().and_then(renorm_fail_reason),
+    ]
+    .into_iter()
+    .flatten()
+    .collect();
+
+    print_report(
+        observation_file,
+        range.as_ref(),
+        identity.as_ref(),
+        mass.as_ref(),
+        sort.as_ref(),
+        renorm.as_ref(),
+        json,
+    );
+
+    if fail_reasons.is_empty() {
+        Ok(())
+    } else {
+        Err(CliError::ValidationFailed(fail_reasons.join("; ")))
+    }
+}
+
+fn classify_range(obs: &Value) -> Option<clf::TypicalPRangeOutcome> {
+    let sec = obs.get("range")?.as_object()?;
+    let p = sec.get("p")?.as_f64()?;
+    Some(clf::classify_typical_p_range(p))
+}
+
+fn classify_identity(obs: &Value) -> Option<clf::IdentityOutcome> {
+    let sec = obs.get("identity")?.as_object()?;
+    let kept: Vec<usize> = sec
+        .get("kept_indices")?
+        .as_array()?
+        .iter()
+        .filter_map(|v| v.as_u64().map(|n| n as usize))
+        .collect();
+    let total = sec.get("total_tokens")?.as_u64()? as usize;
+    let p = sec.get("p")?.as_f64()?;
+    Some(clf::classify_typical_p_identity(&kept, total, p))
+}
+
+fn classify_mass(obs: &Value) -> Option<clf::MassCoverageOutcome> {
+    let sec = obs.get("mass")?.as_object()?;
+    let kept_probs: Vec<f64> = sec
+        .get("kept_probs")?
+        .as_array()?
+        .iter()
+        .map(|v| v.as_f64().unwrap_or(f64::NAN))
+        .collect();
+    let p = sec.get("p")?.as_f64()?;
+    Some(clf::classify_typical_p_mass_coverage(&kept_probs, p))
+}
+
+fn classify_sort(obs: &Value) -> Option<clf::SortOrderOutcome> {
+    let sec = obs.get("sort")?.as_object()?;
+    let all_probs: Vec<f64> = sec
+        .get("all_probs")?
+        .as_array()?
+        .iter()
+        .map(|v| v.as_f64().unwrap_or(f64::NAN))
+        .collect();
+    let kept: Vec<f64> = sec
+        .get("kept_probs_in_sort_order")?
+        .as_array()?
+        .iter()
+        .map(|v| v.as_f64().unwrap_or(f64::NAN))
+        .collect();
+    Some(clf::classify_typical_p_sort_order(&all_probs, &kept))
+}
+
+fn classify_renorm(obs: &Value) -> Option<clf::RenormOutcome> {
+    let sec = obs.get("renorm")?.as_object()?;
+    let filtered: Vec<f64> = sec
+        .get("filtered_probs")?
+        .as_array()?
+        .iter()
+        .map(|v| v.as_f64().unwrap_or(f64::NAN))
+        .collect();
+    Some(clf::classify_typical_p_renormalization(&filtered))
+}
+
+fn range_fail_reason(o: &clf::TypicalPRangeOutcome) -> Option<String> {
+    match o {
+        clf::TypicalPRangeOutcome::Valid => None,
+        clf::TypicalPRangeOutcome::NotFinite => Some(
+            "FALSIFY-CRUX-C-22-001 range: p is not finite".to_string(),
+        ),
+        clf::TypicalPRangeOutcome::BelowMinimum { p } => Some(format!(
+            "FALSIFY-CRUX-C-22-001 range: p={p} <= 0.0 (must be > 0)"
+        )),
+        clf::TypicalPRangeOutcome::AboveMaximum { p } => Some(format!(
+            "FALSIFY-CRUX-C-22-001 range: p={p} > 1.0"
+        )),
+    }
+}
+
+fn identity_fail_reason(o: &clf::IdentityOutcome) -> Option<String> {
+    match o {
+        clf::IdentityOutcome::Ok { .. } => None,
+        clf::IdentityOutcome::InvalidInput { reason } => Some(format!(
+            "FALSIFY-CRUX-C-22-001 identity: invalid input: {reason}"
+        )),
+        clf::IdentityOutcome::DroppedTokens {
+            kept_count,
+            total_count,
+        } => Some(format!(
+            "FALSIFY-CRUX-C-22-001 identity: p=1.0 dropped tokens (kept={kept_count}, total={total_count})"
+        )),
+    }
+}
+
+fn mass_fail_reason(o: &clf::MassCoverageOutcome) -> Option<String> {
+    match o {
+        clf::MassCoverageOutcome::Ok { .. } => None,
+        clf::MassCoverageOutcome::InvalidInput { reason } => Some(format!(
+            "FALSIFY-CRUX-C-22-002 mass: invalid input: {reason}"
+        )),
+        clf::MassCoverageOutcome::InsufficientMass { kept_mass, required } => Some(format!(
+            "FALSIFY-CRUX-C-22-002 mass: kept_mass={kept_mass} < required={required}"
+        )),
+        clf::MassCoverageOutcome::TooLarge { kept_mass, excess } => Some(format!(
+            "FALSIFY-CRUX-C-22-002 mass: kept_mass={kept_mass} > 1.0 (excess={excess})"
+        )),
+    }
+}
+
+fn sort_fail_reason(o: &clf::SortOrderOutcome) -> Option<String> {
+    match o {
+        clf::SortOrderOutcome::Ok => None,
+        clf::SortOrderOutcome::InvalidInput { reason } => Some(format!(
+            "FALSIFY-CRUX-C-22-002 sort: invalid input: {reason}"
+        )),
+        clf::SortOrderOutcome::OutOfOrder {
+            at_index,
+            prev_c,
+            curr_c,
+        } => Some(format!(
+            "FALSIFY-CRUX-C-22-002 sort: out of order at idx {at_index}: prev_c={prev_c} > curr_c={curr_c}"
+        )),
+    }
+}
+
+fn renorm_fail_reason(o: &clf::RenormOutcome) -> Option<String> {
+    match o {
+        clf::RenormOutcome::Ok { .. } => None,
+        clf::RenormOutcome::InvalidInput { reason } => Some(format!(
+            "FALSIFY-CRUX-C-22-002 renorm: invalid input: {reason}"
+        )),
+        clf::RenormOutcome::NotNormalized { sum, deviation } => Some(format!(
+            "FALSIFY-CRUX-C-22-002 renorm: sum={sum} deviates from 1.0 by {deviation} (> 1e-6)"
+        )),
+        clf::RenormOutcome::ContainsNegative {
+            first_bad_index,
+            value,
+        } => Some(format!(
+            "FALSIFY-CRUX-C-22-002 renorm: negative prob at idx {first_bad_index}: {value}"
+        )),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn print_report(
+    path: &Path,
+    range: Option<&clf::TypicalPRangeOutcome>,
+    identity: Option<&clf::IdentityOutcome>,
+    mass: Option<&clf::MassCoverageOutcome>,
+    sort: Option<&clf::SortOrderOutcome>,
+    renorm: Option<&clf::RenormOutcome>,
+    json: bool,
+) {
+    if json {
+        let v = serde_json::json!({
+            "observation_path": path.display().to_string(),
+            "range":    range.map(|o| format!("{o:?}")),
+            "identity": identity.map(|o| format!("{o:?}")),
+            "mass":     mass.map(|o| format!("{o:?}")),
+            "sort":     sort.map(|o| format!("{o:?}")),
+            "renorm":   renorm.map(|o| format!("{o:?}")),
+        });
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&v).unwrap_or_else(|_| v.to_string())
+        );
+    } else {
+        println!("typical-p-lint report for {}", path.display());
+        print_line("  range:    ", range.map(|o| format!("{o:?}")));
+        print_line("  identity: ", identity.map(|o| format!("{o:?}")));
+        print_line("  mass:     ", mass.map(|o| format!("{o:?}")));
+        print_line("  sort:     ", sort.map(|o| format!("{o:?}")));
+        print_line("  renorm:   ", renorm.map(|o| format!("{o:?}")));
+    }
+}
+
+fn print_line(prefix: &str, v: Option<String>) {
+    match v {
+        Some(s) => println!("{prefix}{s}"),
+        None => println!("{prefix}(missing fields — classifier skipped)"),
+    }
+}

--- a/crates/apr-cli/src/dispatch_analysis.rs
+++ b/crates/apr-cli/src/dispatch_analysis.rs
@@ -126,6 +126,10 @@ fn dispatch_analysis_commands(cli: &Cli) -> Option<Result<(), CliError>> {
             commands::gbnf_lint::run(observation_file, cli.json)
         }
 
+        ExtendedCommands::TypicalPLint { observation_file } => {
+            commands::typical_p_lint::run(observation_file, cli.json)
+        }
+
 
         ExtendedCommands::Hex {
             file,

--- a/crates/apr-cli/src/extended_commands.rs
+++ b/crates/apr-cli/src/extended_commands.rs
@@ -763,6 +763,11 @@ pub enum ExtendedCommands {
         #[arg(long, value_name = "FILE")]
         observation_file: PathBuf,
     },
+    /// Lint a typical-p sampling observation (CRUX-C-22)
+    TypicalPLint {
+        #[arg(long, value_name = "FILE")]
+        observation_file: PathBuf,
+    },
     /// Publishing, conversion, and analysis tools
     #[command(flatten)]
     Tools(ToolCommands),

--- a/crates/apr-cli/tests/cli_commands.rs
+++ b/crates/apr-cli/tests/cli_commands.rs
@@ -78,6 +78,7 @@ fn registered_commands() -> Vec<&'static str> {
         "oom-lint",
         "tool-use-lint",
         "gbnf-lint",
+        "typical-p-lint",
         "oracle",
         "encrypt",
         "decrypt",

--- a/crates/apr-cli/tests/falsification_crux_c_22.rs
+++ b/crates/apr-cli/tests/falsification_crux_c_22.rs
@@ -1,0 +1,272 @@
+//! E2E falsification tests for `apr typical-p-lint` (CRUX-C-22).
+//!
+//! Discharges g3 of CRUX-SHIP-001 for PR #982: exercise the CLI surface
+//! end-to-end on captured JSON observations and assert the classifier
+//! verdicts + non-zero exit codes on known-bad input.
+
+use std::io::Write;
+use std::process::Command;
+
+fn apr_binary() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_apr"));
+    cmd.env("NO_COLOR", "1");
+    cmd
+}
+
+fn write_tmp_json(name: &str, body: &str) -> tempfile::NamedTempFile {
+    let mut f = tempfile::Builder::new()
+        .prefix(name)
+        .suffix(".json")
+        .tempfile()
+        .expect("create tempfile");
+    f.write_all(body.as_bytes()).expect("write tempfile");
+    f.flush().expect("flush tempfile");
+    f
+}
+
+// ---- help surface (g2 proof) ----------------------------------------------
+
+#[test]
+fn falsify_crux_c_22_help_advertises_observation_file_flag() {
+    let out = apr_binary()
+        .args(["typical-p-lint", "--help"])
+        .output()
+        .expect("run apr typical-p-lint --help");
+    assert!(out.status.success(), "apr typical-p-lint --help must exit 0");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("--observation-file"),
+        "--help must advertise --observation-file; got:\n{stdout}"
+    );
+}
+
+#[test]
+fn falsify_crux_c_22_rejects_bare_invocation_without_file() {
+    let out = apr_binary()
+        .arg("typical-p-lint")
+        .output()
+        .expect("run apr typical-p-lint without args");
+    assert!(
+        !out.status.success(),
+        "bare `apr typical-p-lint` must exit non-zero"
+    );
+}
+
+// ---- range gate (FALSIFY-CRUX-C-22-001 — parameter range) -----------------
+
+#[test]
+fn falsify_crux_c_22_001_range_ok_on_valid_p() {
+    let tmp = write_tmp_json("typ-range-ok", r#"{ "range": { "p": 0.95 } }"#);
+    let out = apr_binary()
+        .args(["typical-p-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr typical-p-lint");
+    assert!(
+        out.status.success(),
+        "p=0.95 must pass; stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn falsify_crux_c_22_001_range_rejects_zero_p() {
+    let tmp = write_tmp_json("typ-range-0", r#"{ "range": { "p": 0.0 } }"#);
+    let out = apr_binary()
+        .args(["typical-p-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr typical-p-lint");
+    assert!(!out.status.success(), "p=0 must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-C-22-001"));
+}
+
+#[test]
+fn falsify_crux_c_22_001_range_rejects_above_one() {
+    let tmp = write_tmp_json("typ-range-above", r#"{ "range": { "p": 1.5 } }"#);
+    let out = apr_binary()
+        .args(["typical-p-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr typical-p-lint");
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-C-22-001"));
+}
+
+// ---- identity gate (FALSIFY-CRUX-C-22-001) --------------------------------
+
+#[test]
+fn falsify_crux_c_22_001_identity_ok_on_all_kept() {
+    let tmp = write_tmp_json(
+        "typ-id-ok",
+        r#"{ "identity": { "kept_indices": [0,1,2,3], "total_tokens": 4, "p": 1.0 } }"#,
+    );
+    let out = apr_binary()
+        .args(["typical-p-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr typical-p-lint");
+    assert!(out.status.success());
+}
+
+#[test]
+fn falsify_crux_c_22_001_identity_rejects_dropped_tokens() {
+    let tmp = write_tmp_json(
+        "typ-id-drop",
+        r#"{ "identity": { "kept_indices": [0,1], "total_tokens": 4, "p": 1.0 } }"#,
+    );
+    let out = apr_binary()
+        .args(["typical-p-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr typical-p-lint");
+    assert!(!out.status.success(), "dropped tokens at p=1.0 must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-C-22-001"));
+}
+
+// ---- mass coverage gate (FALSIFY-CRUX-C-22-002) ---------------------------
+
+#[test]
+fn falsify_crux_c_22_002_mass_ok_when_meets_threshold() {
+    let tmp = write_tmp_json(
+        "typ-mass-ok",
+        r#"{ "mass": { "kept_probs": [0.5, 0.3, 0.15], "p": 0.9 } }"#,
+    );
+    let out = apr_binary()
+        .args(["typical-p-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr typical-p-lint");
+    assert!(out.status.success());
+}
+
+#[test]
+fn falsify_crux_c_22_002_mass_rejects_insufficient() {
+    let tmp = write_tmp_json(
+        "typ-mass-low",
+        r#"{ "mass": { "kept_probs": [0.3, 0.2], "p": 0.9 } }"#,
+    );
+    let out = apr_binary()
+        .args(["typical-p-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr typical-p-lint");
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-C-22-002"));
+}
+
+// ---- renormalization gate (FALSIFY-CRUX-C-22-002) -------------------------
+
+#[test]
+fn falsify_crux_c_22_002_renorm_ok_when_sums_to_one() {
+    let tmp = write_tmp_json(
+        "typ-renorm-ok",
+        r#"{ "renorm": { "filtered_probs": [0.6, 0.4] } }"#,
+    );
+    let out = apr_binary()
+        .args(["typical-p-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr typical-p-lint");
+    assert!(out.status.success());
+}
+
+#[test]
+fn falsify_crux_c_22_002_renorm_rejects_under_normalized() {
+    let tmp = write_tmp_json(
+        "typ-renorm-under",
+        r#"{ "renorm": { "filtered_probs": [0.3, 0.3] } }"#,
+    );
+    let out = apr_binary()
+        .args(["typical-p-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr typical-p-lint");
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-C-22-002"));
+}
+
+// ---- sort order gate (FALSIFY-CRUX-C-22-002) ------------------------------
+
+#[test]
+fn falsify_crux_c_22_002_sort_ok_on_uniform() {
+    // uniform: all c_i equal → any order is valid
+    let tmp = write_tmp_json(
+        "typ-sort-uniform",
+        r#"{ "sort": {
+             "all_probs": [0.25, 0.25, 0.25, 0.25],
+             "kept_probs_in_sort_order": [0.25, 0.25]
+           } }"#,
+    );
+    let out = apr_binary()
+        .args(["typical-p-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr typical-p-lint");
+    assert!(
+        out.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+// ---- input validation -----------------------------------------------------
+
+#[test]
+fn falsify_crux_c_22_empty_file_rejected_via_cli() {
+    let tmp = write_tmp_json("typ-empty", "");
+    let out = apr_binary()
+        .args(["typical-p-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr typical-p-lint");
+    assert!(!out.status.success(), "empty file must be rejected");
+}
+
+#[test]
+fn falsify_crux_c_22_nonexistent_file_rejected() {
+    let out = apr_binary()
+        .args([
+            "typical-p-lint",
+            "--observation-file",
+            "/nonexistent/path/obs.json",
+        ])
+        .output()
+        .expect("run apr typical-p-lint");
+    assert!(!out.status.success());
+}
+
+// ---- --json shape ---------------------------------------------------------
+
+#[test]
+fn falsify_crux_c_22_json_output_shape() {
+    let tmp = write_tmp_json(
+        "typ-json-shape",
+        r#"{
+          "range":    { "p": 0.95 },
+          "identity": { "kept_indices": [0,1,2], "total_tokens": 3, "p": 1.0 },
+          "mass":     { "kept_probs": [0.5, 0.3, 0.15], "p": 0.9 },
+          "renorm":   { "filtered_probs": [0.6, 0.4] }
+        }"#,
+    );
+    let out = apr_binary()
+        .args(["--json", "typical-p-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr typical-p-lint --json");
+    assert!(
+        out.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("\"range\""));
+    assert!(stdout.contains("\"identity\""));
+    assert!(stdout.contains("\"mass\""));
+    assert!(stdout.contains("\"renorm\""));
+}


### PR DESCRIPTION
## Summary

- 5 pure classifiers in `crates/apr-cli/src/commands/typical_p_classifier.rs` covering typical-p (locally typical) sampling invariants (arXiv:2202.00666)
- Both `FALSIFY-CRUX-C-22-001` (p=1.0 identity) and `FALSIFY-CRUX-C-22-002` (HF parity / mass / sort / renorm) discharged at PARTIAL_ALGORITHM_LEVEL
- Contract `contracts/crux-C-22-v1.yaml` promoted draft → partial (v1.1.0); `pv validate` 0 errors, 0 warnings
- 40 new tests, no silent passes — every malformed input lands in a distinct `Outcome` variant

## Discharged FALSIFY gates

| ID | Scope | Tests |
|----|-------|-------|
| FALSIFY-CRUX-C-22-001 | p=1.0 identity + parameter range | identity + range families (16) |
| FALSIFY-CRUX-C-22-002 | mass coverage ≥ p, sort by c_i ASC, renorm sum=1±1e-6 | mass + sort + renorm families (24) |

`full_discharge_blocked_on` records what end-to-end evidence (GGUF fixture run, HF Python parity on `logits_row.npy`) would promote to FULL.

## Test plan

- [x] `cargo test -p apr-cli --lib typical_p` → 40/40 pass
- [x] `pv validate contracts/crux-C-22-v1.yaml` → 0 errors, 0 warnings
- [x] Every bad input (empty, NaN, Inf, negative prob, prob > 1, duplicate/OOB index, p ≤ 0, p > 1) maps to a distinct variant

🤖 Generated with [Claude Code](https://claude.com/claude-code)