### PR TITLE
feat(crux-c-23): DRY-sampling (match_len+penalty+seq-breakers+monotone) classifier (2 of 2 FALSIFY at PARTIAL_ALGORITHM_LEVEL)

### DIFF
--- a/contracts/apr-cli-commands-v1.yaml
+++ b/contracts/apr-cli-commands-v1.yaml
@@ -21,7 +21,7 @@ metadata:
 kind: CLICommandContract
 name: apr-cli-commands
 version: "1.0.0"
-scope: "all apr CLI subcommands (60 commands — original 57 + `mcp` added 2026-04-17 via PR #864 + `registry` added 2026-04-20 via CRUX-A-01 + `ollama-chat-lint` added 2026-04-21 via CRUX-C-04 SHIP-001 retrofit)"
+scope: "all apr CLI subcommands (61 commands — original 57 + `mcp` added 2026-04-17 via PR #864 + `registry` added 2026-04-20 via CRUX-A-01 + `ollama-chat-lint` added 2026-04-21 via CRUX-C-04 SHIP-001 retrofit + `dry-sampling-lint` added 2026-04-21 via CRUX-C-23 SHIP-001 retrofit)"
 binary: "apr"
 install: "cargo install aprender"
 
@@ -393,6 +393,12 @@ commands:
   - name: ollama-chat-lint
     category: inspection
     description: "Lint a captured Ollama /api/chat response (CRUX-C-04)"
+    requires_model: false
+    side_effects: []
+
+  - name: dry-sampling-lint
+    category: inspection
+    description: "Lint a captured DRY-sampling observation (CRUX-C-23)"
     requires_model: false
     side_effects: []
 

--- a/contracts/crux-C-23-v1.yaml
+++ b/contracts/crux-C-23-v1.yaml
@@ -4,9 +4,11 @@ metadata:
   id: CRUX-C-23
   version: "1.1.0"
   created: "2026-04-18"
+  updated: "2026-04-21"
   author: PAIML Engineering
   registry: true
-  status: draft
+  status: partial
+  kind: kernel
   parent_contracts:
   - crux-competitive-research-ux-v1
   category: "C — Serving & Chat UX"
@@ -20,8 +22,8 @@ metadata:
 
   references:
   - 'master: contracts/crux-competitive-research-ux-v1.yaml — §5 + §12'
-  - github.com/huggingface/accelerate
-  - github.com/pytorch/pytorch — DDP/FSDP
+  - 'impl: llama.cpp DRY sampler (--dry-multiplier, --dry-base, --dry-allowed-length, --dry-penalty-last-n, --dry-sequence-breakers)'
+
 equations:
   dry_penalty:
     formula: |
@@ -36,6 +38,8 @@ equations:
     - "multiplier=0 → identity (penalty disabled)"
     - "tokens in seq_breakers reset the match_len counter"
     - "penalty is always ≥ 0; never boosts any token"
+    - "penalty is monotone non-decreasing in match_len for fixed (allowed, multiplier, base)"
+    - "base must be ≥ 1; multiplier must be ≥ 0; allowed_length must be ≥ 1"
 
 falsification_tests:
 - id: FALSIFY-CRUX-C-23-001
@@ -48,6 +52,30 @@ falsification_tests:
     apr run tests/fixtures/tinyllama-q4_k_m.gguf --prompt "$PROMPT" --seed 1 --max-tokens 16 --format json > /tmp/base.json
     diff <(jq .token_ids /tmp/off.json) <(jq .token_ids /tmp/base.json)
   if_fails: rule 'multiplier=0 is identity' is violated — contract MUST be re-verified against competitor canonical reference
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/dry_sampling_classifier.rs
+    sub_claim: "multiplier=0 identity + parameter-range invariants captured by pure classifiers"
+    tests:
+    - identity_ok_when_logits_unchanged
+    - identity_flags_changed_logit
+    - identity_rejects_non_zero_multiplier
+    - identity_rejects_length_mismatch
+    - identity_rejects_empty
+    - identity_rejects_nan
+    - penalty_zero_when_multiplier_zero
+    - identity_and_penalty_zero_multiplier_coincide
+    - params_valid_defaults
+    - params_valid_zero_multiplier
+    - params_rejects_negative_multiplier
+    - params_rejects_base_below_one
+    - params_rejects_allowed_length_zero
+    - params_rejects_nan_multiplier
+    - params_rejects_nan_base
+    - params_rejects_infinity
+    scope: PARTIAL_ALGORITHM_LEVEL
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: "end-to-end `apr run --dry-multiplier 0` identity test against real GGUF fixture (requires fixtures/tinyllama-q4_k_m.gguf + DRY CLI wiring)"
+
 - id: FALSIFY-CRUX-C-23-002
   rule: DRY reduces exact-phrase repetition on adversarial prompt
   prediction: "repetition-heavy prompt with DRY has fewer 4-gram repeats than without"
@@ -65,6 +93,34 @@ falsification_tests:
     PY
 
   if_fails: rule 'DRY reduces exact-phrase repetition on adversarial prompt' is violated — contract MUST be re-verified against competitor canonical reference
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/dry_sampling_classifier.rs
+    sub_claim: "suffix-match length, penalty formula, seq-breaker reset, and monotonicity-in-match_len captured by pure classifiers"
+    tests:
+    - match_len_zero_when_ctx_empty
+    - match_len_zero_when_candidate_not_in_ctx
+    - match_len_one_when_candidate_matches_single_token
+    - match_len_detects_repeated_bigram
+    - match_len_detects_repeated_trigram
+    - match_len_seq_breaker_stops_extension
+    - match_len_repeated_trigram_twice
+    - penalty_zero_below_threshold
+    - penalty_equals_multiplier_at_threshold
+    - penalty_exponential_growth
+    - penalty_rejects_negative_multiplier
+    - penalty_rejects_base_below_one
+    - penalty_rejects_allowed_zero
+    - penalty_rejects_nan
+    - monotone_ok_below_threshold_both_zero
+    - monotone_ok_below_to_at_threshold
+    - monotone_ok_strict_growth_above_threshold
+    - monotone_rejects_decreasing_args
+    - monotone_ok_equal_match_len
+    - match_len_above_allowed_triggers_positive_penalty
+    scope: PARTIAL_ALGORITHM_LEVEL
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: "adversarial-prompt 4-gram uniqueness test against real GGUF fixture with DRY sampler wired into apr run CLI"
+
 proof_obligations:
 - type: equivalence
   property: "apr --dry-* matches llama.cpp DRY sampler on identical (ctx, multiplier, base, allowed)"
@@ -76,8 +132,8 @@ proof_obligations:
 verification_summary:
   total_obligations: 3
   proven: 0
-  tested: 0
-  status: spec-complete
+  tested: 2
+  status: partial
 
 pmat_work_tracking:
   ticket_tag: crux-crux-c-23

--- a/contracts/crux-C-23-v1.yaml
+++ b/contracts/crux-C-23-v1.yaml
@@ -2,7 +2,7 @@
 
 metadata:
   id: CRUX-C-23
-  version: "1.1.0"
+  version: "1.2.0"
   created: "2026-04-18"
   updated: "2026-04-21"
   author: PAIML Engineering
@@ -54,6 +54,15 @@ falsification_tests:
   if_fails: rule 'multiplier=0 is identity' is violated — contract MUST be re-verified against competitor canonical reference
   evidence_discharged_by:
     classifier_path: crates/apr-cli/src/commands/dry_sampling_classifier.rs
+    cli_path: crates/apr-cli/src/commands/dry_sampling_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_c_23.rs
+    e2e_tests:
+    - falsify_crux_c_23_001_params_ok_on_defaults
+    - falsify_crux_c_23_001_params_rejects_negative_multiplier
+    - falsify_crux_c_23_001_params_rejects_base_below_one
+    - falsify_crux_c_23_001_params_rejects_allowed_length_zero
+    - falsify_crux_c_23_001_identity_ok_when_unchanged
+    - falsify_crux_c_23_001_identity_rejects_changed_logit
     sub_claim: "multiplier=0 identity + parameter-range invariants captured by pure classifiers"
     tests:
     - identity_ok_when_logits_unchanged
@@ -95,6 +104,16 @@ falsification_tests:
   if_fails: rule 'DRY reduces exact-phrase repetition on adversarial prompt' is violated — contract MUST be re-verified against competitor canonical reference
   evidence_discharged_by:
     classifier_path: crates/apr-cli/src/commands/dry_sampling_classifier.rs
+    cli_path: crates/apr-cli/src/commands/dry_sampling_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_c_23.rs
+    e2e_tests:
+    - falsify_crux_c_23_002_match_len_ok_on_repeated_trigram
+    - falsify_crux_c_23_002_match_len_rejects_wrong_expected
+    - falsify_crux_c_23_002_match_len_seq_breaker_zero
+    - falsify_crux_c_23_002_penalty_ok_at_threshold
+    - falsify_crux_c_23_002_penalty_rejects_invalid_input
+    - falsify_crux_c_23_002_monotone_ok_non_decreasing
+    - falsify_crux_c_23_002_monotone_rejects_decreasing_args
     sub_claim: "suffix-match length, penalty formula, seq-breaker reset, and monotonicity-in-match_len captured by pure classifiers"
     tests:
     - match_len_zero_when_ctx_empty
@@ -134,6 +153,27 @@ verification_summary:
   proven: 0
   tested: 2
   status: partial
+
+ship_discipline:
+  ship_rule: CRUX-SHIP-001
+  deliverables_present:
+    classifier: crates/apr-cli/src/commands/dry_sampling_classifier.rs
+    cli_wiring: crates/apr-cli/src/commands/dry_sampling_lint.rs
+    e2e_test: crates/apr-cli/tests/falsification_crux_c_23.rs
+    contract: contracts/crux-C-23-v1.yaml
+  merge_gates:
+    g1_classifier_green: true
+    g2_cli_reachable: true
+    g3_e2e_runs: true
+    g4_contract_discharged: PARTIAL_ALGORITHM_LEVEL
+  notes: >
+    `apr dry-sampling-lint --observation-file <obs.json>` dispatches five
+    classifiers (params, identity, match_len, penalty, monotone) over
+    captured JSON. e2e suite (18 tests) exercises help surface,
+    bare-invocation rejection, per-gate ok+reject paths,
+    empty/nonexistent file rejection, and --json shape. Full ACTIVE
+    discharge remains blocked on `apr run --dry-*` identity test against
+    a real GGUF fixture + llama.cpp DRY sampler parity.
 
 pmat_work_tracking:
   ticket_tag: crux-crux-c-23

--- a/crates/apr-cli/src/commands/dry_sampling_classifier.rs
+++ b/crates/apr-cli/src/commands/dry_sampling_classifier.rs
@@ -1,0 +1,637 @@
+//! CRUX-C-23 — DRY (Don't Repeat Yourself) sampling classifiers
+//!
+//! Discharges `contracts/crux-C-23-v1.yaml` FALSIFY gates at PARTIAL_ALGORITHM_LEVEL:
+//! - FALSIFY-CRUX-C-23-001: multiplier=0 is identity (penalty disabled)
+//! - FALSIFY-CRUX-C-23-002: DRY reduces exact-phrase repetition
+//!
+//! Algorithm (llama.cpp DRY sampler):
+//!   for candidate token t:
+//!     match_len = longest suffix-match of (ctx + [t]) ending earlier in ctx
+//!     if match_len >= allowed_length:
+//!       penalty = multiplier * base^(match_len - allowed_length)
+//!       logit[t] -= penalty
+
+#![allow(dead_code)]
+
+use std::collections::HashSet;
+
+pub(crate) const DEFAULT_DRY_MULTIPLIER: f64 = 0.8;
+pub(crate) const DEFAULT_DRY_BASE: f64 = 1.75;
+pub(crate) const DEFAULT_DRY_ALLOWED_LENGTH: u32 = 2;
+
+/// Parameter-range gate: multiplier ≥ 0, base ≥ 1, allowed_length ≥ 1.
+#[derive(Debug, PartialEq)]
+pub(crate) enum DryParamOutcome {
+    Valid,
+    NotFinite { field: &'static str },
+    MultiplierNegative { multiplier: f64 },
+    BaseBelowOne { base: f64 },
+    AllowedLengthZero,
+}
+
+pub(crate) fn classify_dry_params(
+    multiplier: f64,
+    base: f64,
+    allowed_length: u32,
+) -> DryParamOutcome {
+    if !multiplier.is_finite() {
+        return DryParamOutcome::NotFinite { field: "multiplier" };
+    }
+    if !base.is_finite() {
+        return DryParamOutcome::NotFinite { field: "base" };
+    }
+    if multiplier < 0.0 {
+        return DryParamOutcome::MultiplierNegative { multiplier };
+    }
+    if base < 1.0 {
+        return DryParamOutcome::BaseBelowOne { base };
+    }
+    if allowed_length == 0 {
+        return DryParamOutcome::AllowedLengthZero;
+    }
+    DryParamOutcome::Valid
+}
+
+/// Identity gate (FALSIFY-CRUX-C-23-001): multiplier=0 → every token unchanged.
+#[derive(Debug, PartialEq)]
+pub(crate) enum IdentityOutcome {
+    Ok,
+    InvalidInput { reason: &'static str },
+    LogitsChanged {
+        first_diff_index: usize,
+        before: f64,
+        after: f64,
+    },
+}
+
+pub(crate) fn classify_dry_identity_zero_multiplier(
+    logits_before: &[f64],
+    logits_after: &[f64],
+    multiplier: f64,
+) -> IdentityOutcome {
+    if logits_before.is_empty() {
+        return IdentityOutcome::InvalidInput {
+            reason: "logits_before is empty",
+        };
+    }
+    if logits_before.len() != logits_after.len() {
+        return IdentityOutcome::InvalidInput {
+            reason: "logits length mismatch",
+        };
+    }
+    if !multiplier.is_finite() || multiplier != 0.0 {
+        return IdentityOutcome::InvalidInput {
+            reason: "multiplier != 0.0",
+        };
+    }
+    for (i, (&b, &a)) in logits_before.iter().zip(logits_after.iter()).enumerate() {
+        if !b.is_finite() || !a.is_finite() {
+            return IdentityOutcome::InvalidInput {
+                reason: "non-finite logit",
+            };
+        }
+        if (b - a).abs() > f64::EPSILON * b.abs().max(1.0) {
+            return IdentityOutcome::LogitsChanged {
+                first_diff_index: i,
+                before: b,
+                after: a,
+            };
+        }
+    }
+    IdentityOutcome::Ok
+}
+
+/// Computes the longest suffix of (ctx + [candidate]) that matches a substring
+/// ending earlier in ctx. This is the classifier-level specification of
+/// llama.cpp's DRY match_len.
+///
+/// Returns 0 if no match ≥ 1 token is found.
+pub(crate) fn classify_dry_match_len(
+    ctx: &[u32],
+    candidate: u32,
+    seq_breakers: &HashSet<u32>,
+) -> u32 {
+    // Build extended context with candidate appended.
+    let mut ext: Vec<u32> = ctx.to_vec();
+    ext.push(candidate);
+
+    // Walk back looking for a suffix-of-ext match ending earlier in ctx.
+    // max_len can be at most ctx.len() (match must end BEFORE position ctx.len()).
+    let ctx_len = ctx.len();
+    if ctx_len == 0 {
+        return 0;
+    }
+    let mut best: u32 = 0;
+
+    // For each possible earlier-ending position j < ctx_len:
+    //   match_len = longest L s.t. ext[ext.len()-L ..] == ctx[j+1-L .. j+1]
+    // Scan j from ctx_len-1 down; stop if we see a seq_breaker at ctx[j].
+    for j in (0..ctx_len).rev() {
+        if seq_breakers.contains(&ctx[j]) {
+            // Seq breaker resets counter for THIS branch; skip to earlier j.
+            continue;
+        }
+        // Compare ctx[..=j] tail with ext tail.
+        let mut l: usize = 0;
+        loop {
+            let ext_idx = ext.len() - 1 - l;
+            let ctx_idx_opt = j.checked_sub(l);
+            match ctx_idx_opt {
+                None => break,
+                Some(ctx_idx) => {
+                    if seq_breakers.contains(&ctx[ctx_idx]) {
+                        break;
+                    }
+                    if ext[ext_idx] != ctx[ctx_idx] {
+                        break;
+                    }
+                    l += 1;
+                    if ext_idx == 0 {
+                        break;
+                    }
+                }
+            }
+        }
+        let l_u32 = u32::try_from(l).unwrap_or(u32::MAX);
+        if l_u32 > best {
+            best = l_u32;
+        }
+    }
+    best
+}
+
+/// Penalty-formula gate: penalty = multiplier * base^(match_len - allowed_length)
+/// when match_len >= allowed_length; 0 otherwise; penalty ≥ 0 always.
+#[derive(Debug, PartialEq)]
+pub(crate) enum PenaltyOutcome {
+    Ok { penalty: f64 },
+    InvalidInput { reason: &'static str },
+    Negative { penalty: f64 },
+}
+
+pub(crate) fn classify_dry_penalty(
+    match_len: u32,
+    allowed_length: u32,
+    multiplier: f64,
+    base: f64,
+) -> PenaltyOutcome {
+    if !multiplier.is_finite() || !base.is_finite() {
+        return PenaltyOutcome::InvalidInput {
+            reason: "non-finite multiplier or base",
+        };
+    }
+    if multiplier < 0.0 {
+        return PenaltyOutcome::InvalidInput {
+            reason: "multiplier negative",
+        };
+    }
+    if base < 1.0 {
+        return PenaltyOutcome::InvalidInput {
+            reason: "base < 1.0",
+        };
+    }
+    if allowed_length == 0 {
+        return PenaltyOutcome::InvalidInput {
+            reason: "allowed_length == 0",
+        };
+    }
+    if match_len < allowed_length {
+        // Below threshold — penalty is zero by spec.
+        return PenaltyOutcome::Ok { penalty: 0.0 };
+    }
+    let exponent = f64::from(match_len - allowed_length);
+    let penalty = multiplier * base.powf(exponent);
+    if !penalty.is_finite() {
+        return PenaltyOutcome::InvalidInput {
+            reason: "penalty overflow",
+        };
+    }
+    if penalty < 0.0 {
+        return PenaltyOutcome::Negative { penalty };
+    }
+    PenaltyOutcome::Ok { penalty }
+}
+
+/// Monotonicity gate: penalty grows monotonically (non-strictly) with match_len.
+/// This captures "DRY reduces exact-phrase repetition" algebraically.
+#[derive(Debug, PartialEq)]
+pub(crate) enum MonotonicityOutcome {
+    Ok,
+    InvalidInput { reason: &'static str },
+    Violation {
+        match_len_a: u32,
+        match_len_b: u32,
+        penalty_a: f64,
+        penalty_b: f64,
+    },
+}
+
+pub(crate) fn classify_dry_penalty_monotone_in_match_len(
+    match_len_a: u32,
+    match_len_b: u32,
+    allowed_length: u32,
+    multiplier: f64,
+    base: f64,
+) -> MonotonicityOutcome {
+    if match_len_a > match_len_b {
+        return MonotonicityOutcome::InvalidInput {
+            reason: "match_len_a must be <= match_len_b",
+        };
+    }
+    let pa = match classify_dry_penalty(match_len_a, allowed_length, multiplier, base) {
+        PenaltyOutcome::Ok { penalty } => penalty,
+        PenaltyOutcome::InvalidInput { reason } => {
+            return MonotonicityOutcome::InvalidInput { reason }
+        }
+        PenaltyOutcome::Negative { .. } => {
+            return MonotonicityOutcome::InvalidInput {
+                reason: "penalty_a negative",
+            }
+        }
+    };
+    let pb = match classify_dry_penalty(match_len_b, allowed_length, multiplier, base) {
+        PenaltyOutcome::Ok { penalty } => penalty,
+        PenaltyOutcome::InvalidInput { reason } => {
+            return MonotonicityOutcome::InvalidInput { reason }
+        }
+        PenaltyOutcome::Negative { .. } => {
+            return MonotonicityOutcome::InvalidInput {
+                reason: "penalty_b negative",
+            }
+        }
+    };
+    if pb + f64::EPSILON < pa {
+        return MonotonicityOutcome::Violation {
+            match_len_a,
+            match_len_b,
+            penalty_a: pa,
+            penalty_b: pb,
+        };
+    }
+    MonotonicityOutcome::Ok
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn breakers(ids: &[u32]) -> HashSet<u32> {
+        ids.iter().copied().collect()
+    }
+
+    // -------- parameter range --------
+
+    #[test]
+    fn params_valid_defaults() {
+        assert_eq!(
+            classify_dry_params(
+                DEFAULT_DRY_MULTIPLIER,
+                DEFAULT_DRY_BASE,
+                DEFAULT_DRY_ALLOWED_LENGTH
+            ),
+            DryParamOutcome::Valid
+        );
+    }
+
+    #[test]
+    fn params_valid_zero_multiplier() {
+        assert_eq!(
+            classify_dry_params(0.0, 1.75, 2),
+            DryParamOutcome::Valid
+        );
+    }
+
+    #[test]
+    fn params_rejects_negative_multiplier() {
+        assert_eq!(
+            classify_dry_params(-0.1, 1.75, 2),
+            DryParamOutcome::MultiplierNegative { multiplier: -0.1 }
+        );
+    }
+
+    #[test]
+    fn params_rejects_base_below_one() {
+        assert_eq!(
+            classify_dry_params(0.8, 0.5, 2),
+            DryParamOutcome::BaseBelowOne { base: 0.5 }
+        );
+    }
+
+    #[test]
+    fn params_rejects_allowed_length_zero() {
+        assert_eq!(
+            classify_dry_params(0.8, 1.75, 0),
+            DryParamOutcome::AllowedLengthZero
+        );
+    }
+
+    #[test]
+    fn params_rejects_nan_multiplier() {
+        assert_eq!(
+            classify_dry_params(f64::NAN, 1.75, 2),
+            DryParamOutcome::NotFinite { field: "multiplier" }
+        );
+    }
+
+    #[test]
+    fn params_rejects_nan_base() {
+        assert_eq!(
+            classify_dry_params(0.8, f64::NAN, 2),
+            DryParamOutcome::NotFinite { field: "base" }
+        );
+    }
+
+    #[test]
+    fn params_rejects_infinity() {
+        assert_eq!(
+            classify_dry_params(f64::INFINITY, 1.75, 2),
+            DryParamOutcome::NotFinite { field: "multiplier" }
+        );
+    }
+
+    // -------- identity: multiplier = 0 --------
+
+    #[test]
+    fn identity_ok_when_logits_unchanged() {
+        let before = vec![0.1, 0.5, -0.3];
+        let after = before.clone();
+        assert_eq!(
+            classify_dry_identity_zero_multiplier(&before, &after, 0.0),
+            IdentityOutcome::Ok
+        );
+    }
+
+    #[test]
+    fn identity_flags_changed_logit() {
+        let before = vec![0.1, 0.5, -0.3];
+        let after = vec![0.1, 0.3, -0.3];
+        match classify_dry_identity_zero_multiplier(&before, &after, 0.0) {
+            IdentityOutcome::LogitsChanged {
+                first_diff_index,
+                before,
+                after,
+            } => {
+                assert_eq!(first_diff_index, 1);
+                assert!((before - 0.5).abs() < 1e-9);
+                assert!((after - 0.3).abs() < 1e-9);
+            }
+            other => panic!("expected LogitsChanged, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn identity_rejects_non_zero_multiplier() {
+        let lg = vec![0.1, 0.5];
+        assert_eq!(
+            classify_dry_identity_zero_multiplier(&lg, &lg, 0.8),
+            IdentityOutcome::InvalidInput {
+                reason: "multiplier != 0.0"
+            }
+        );
+    }
+
+    #[test]
+    fn identity_rejects_length_mismatch() {
+        let before = vec![0.1, 0.5];
+        let after = vec![0.1];
+        assert_eq!(
+            classify_dry_identity_zero_multiplier(&before, &after, 0.0),
+            IdentityOutcome::InvalidInput {
+                reason: "logits length mismatch"
+            }
+        );
+    }
+
+    #[test]
+    fn identity_rejects_empty() {
+        assert_eq!(
+            classify_dry_identity_zero_multiplier(&[], &[], 0.0),
+            IdentityOutcome::InvalidInput {
+                reason: "logits_before is empty"
+            }
+        );
+    }
+
+    #[test]
+    fn identity_rejects_nan() {
+        let before = vec![f64::NAN];
+        let after = vec![f64::NAN];
+        assert_eq!(
+            classify_dry_identity_zero_multiplier(&before, &after, 0.0),
+            IdentityOutcome::InvalidInput {
+                reason: "non-finite logit"
+            }
+        );
+    }
+
+    // -------- match length --------
+
+    #[test]
+    fn match_len_zero_when_ctx_empty() {
+        let bl = HashSet::new();
+        assert_eq!(classify_dry_match_len(&[], 1, &bl), 0);
+    }
+
+    #[test]
+    fn match_len_zero_when_candidate_not_in_ctx() {
+        let ctx = vec![1, 2, 3];
+        let bl = HashSet::new();
+        assert_eq!(classify_dry_match_len(&ctx, 99, &bl), 0);
+    }
+
+    #[test]
+    fn match_len_one_when_candidate_matches_single_token() {
+        // ctx = [5, 7, 3], candidate = 3. ext = [5, 7, 3, 3].
+        // Suffix "3" matches ctx[2] — a one-token repetition. match_len = 1.
+        // (Matches llama.cpp semantics: any suffix-of-ext ending anywhere in ctx.)
+        let ctx = vec![5, 7, 3];
+        let bl = HashSet::new();
+        assert_eq!(classify_dry_match_len(&ctx, 3, &bl), 1);
+    }
+
+    #[test]
+    fn match_len_detects_repeated_bigram() {
+        // ctx = [A, B, A], candidate = B → suffix "A B" matches earlier "A B" at
+        // positions 0,1. So match_len should be 2.
+        let ctx = vec![1, 2, 1];
+        let bl = HashSet::new();
+        assert_eq!(classify_dry_match_len(&ctx, 2, &bl), 2);
+    }
+
+    #[test]
+    fn match_len_detects_repeated_trigram() {
+        // ctx = [1, 2, 3, 1, 2], candidate = 3 → suffix "1 2 3" matches "1 2 3" at
+        // positions 0..=2 → match_len 3.
+        let ctx = vec![1, 2, 3, 1, 2];
+        let bl = HashSet::new();
+        assert_eq!(classify_dry_match_len(&ctx, 3, &bl), 3);
+    }
+
+    #[test]
+    fn match_len_seq_breaker_stops_extension() {
+        // ctx = [1, 2, 9, 1, 2], candidate = 3, where 9 is a seq_breaker.
+        // Suffix "1 2 3" would need to match at ctx[0..=2] but ctx[2]=9 is a breaker,
+        // stopping the extension. No match_len >= 3 is possible; match_len = 0.
+        let ctx = vec![1, 2, 9, 1, 2];
+        let bl = breakers(&[9]);
+        assert_eq!(classify_dry_match_len(&ctx, 3, &bl), 0);
+    }
+
+    #[test]
+    fn match_len_repeated_trigram_twice() {
+        // ctx = [1 2 3 1 2 3 1 2], candidate = 3 → ext = [1 2 3 1 2 3 1 2 3].
+        // The suffix "1 2 3 1 2 3" (6 tokens) is also a substring of ctx ending at
+        // position 5, so the longest suffix-match is 6 — the algorithm picks up the
+        // DOUBLE repetition, not just the last trigram.
+        let ctx = vec![1, 2, 3, 1, 2, 3, 1, 2];
+        let bl = HashSet::new();
+        assert_eq!(classify_dry_match_len(&ctx, 3, &bl), 6);
+    }
+
+    // -------- penalty formula --------
+
+    #[test]
+    fn penalty_zero_below_threshold() {
+        assert_eq!(
+            classify_dry_penalty(1, 2, 0.8, 1.75),
+            PenaltyOutcome::Ok { penalty: 0.0 }
+        );
+    }
+
+    #[test]
+    fn penalty_equals_multiplier_at_threshold() {
+        // match_len == allowed_length → exponent = 0 → base^0 = 1 → penalty = multiplier.
+        match classify_dry_penalty(2, 2, 0.8, 1.75) {
+            PenaltyOutcome::Ok { penalty } => assert!((penalty - 0.8).abs() < 1e-12),
+            other => panic!("expected Ok, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn penalty_exponential_growth() {
+        // match_len=5, allowed=2 → exponent=3 → 0.8 * 1.75^3 = 0.8 * 5.359375 = 4.2875.
+        match classify_dry_penalty(5, 2, 0.8, 1.75) {
+            PenaltyOutcome::Ok { penalty } => assert!((penalty - 4.287_5).abs() < 1e-9),
+            other => panic!("expected Ok, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn penalty_zero_when_multiplier_zero() {
+        assert_eq!(
+            classify_dry_penalty(10, 2, 0.0, 1.75),
+            PenaltyOutcome::Ok { penalty: 0.0 }
+        );
+    }
+
+    #[test]
+    fn penalty_rejects_negative_multiplier() {
+        assert_eq!(
+            classify_dry_penalty(5, 2, -0.1, 1.75),
+            PenaltyOutcome::InvalidInput {
+                reason: "multiplier negative"
+            }
+        );
+    }
+
+    #[test]
+    fn penalty_rejects_base_below_one() {
+        assert_eq!(
+            classify_dry_penalty(5, 2, 0.8, 0.5),
+            PenaltyOutcome::InvalidInput {
+                reason: "base < 1.0"
+            }
+        );
+    }
+
+    #[test]
+    fn penalty_rejects_allowed_zero() {
+        assert_eq!(
+            classify_dry_penalty(5, 0, 0.8, 1.75),
+            PenaltyOutcome::InvalidInput {
+                reason: "allowed_length == 0"
+            }
+        );
+    }
+
+    #[test]
+    fn penalty_rejects_nan() {
+        assert_eq!(
+            classify_dry_penalty(5, 2, f64::NAN, 1.75),
+            PenaltyOutcome::InvalidInput {
+                reason: "non-finite multiplier or base"
+            }
+        );
+    }
+
+    // -------- monotonicity (non-decreasing in match_len) --------
+
+    #[test]
+    fn monotone_ok_below_threshold_both_zero() {
+        assert_eq!(
+            classify_dry_penalty_monotone_in_match_len(0, 1, 2, 0.8, 1.75),
+            MonotonicityOutcome::Ok
+        );
+    }
+
+    #[test]
+    fn monotone_ok_below_to_at_threshold() {
+        // 1→2 crosses threshold: 0 → 0.8.
+        assert_eq!(
+            classify_dry_penalty_monotone_in_match_len(1, 2, 2, 0.8, 1.75),
+            MonotonicityOutcome::Ok
+        );
+    }
+
+    #[test]
+    fn monotone_ok_strict_growth_above_threshold() {
+        // 3→5 above threshold; exponent grows 1→3.
+        assert_eq!(
+            classify_dry_penalty_monotone_in_match_len(3, 5, 2, 0.8, 1.75),
+            MonotonicityOutcome::Ok
+        );
+    }
+
+    #[test]
+    fn monotone_rejects_decreasing_args() {
+        assert_eq!(
+            classify_dry_penalty_monotone_in_match_len(5, 3, 2, 0.8, 1.75),
+            MonotonicityOutcome::InvalidInput {
+                reason: "match_len_a must be <= match_len_b"
+            }
+        );
+    }
+
+    #[test]
+    fn monotone_ok_equal_match_len() {
+        assert_eq!(
+            classify_dry_penalty_monotone_in_match_len(4, 4, 2, 0.8, 1.75),
+            MonotonicityOutcome::Ok
+        );
+    }
+
+    // -------- integration-level consistency --------
+
+    #[test]
+    fn identity_and_penalty_zero_multiplier_coincide() {
+        // multiplier=0 → penalty=0 for any match_len.
+        for m in 0..10 {
+            match classify_dry_penalty(m, 2, 0.0, 1.75) {
+                PenaltyOutcome::Ok { penalty } => assert_eq!(penalty, 0.0),
+                other => panic!("expected Ok, got {other:?} at match_len={m}"),
+            }
+        }
+    }
+
+    #[test]
+    fn match_len_above_allowed_triggers_positive_penalty() {
+        let ctx = vec![1, 2, 3, 1, 2];
+        let ml = classify_dry_match_len(&ctx, 3, &HashSet::new());
+        // Verify bridge from match_len to penalty.
+        assert_eq!(ml, 3);
+        match classify_dry_penalty(ml, 2, 0.8, 1.75) {
+            PenaltyOutcome::Ok { penalty } => assert!(penalty > 0.0),
+            other => panic!("expected Ok, got {other:?}"),
+        }
+    }
+}

--- a/crates/apr-cli/src/commands/dry_sampling_lint.rs
+++ b/crates/apr-cli/src/commands/dry_sampling_lint.rs
@@ -1,0 +1,281 @@
+//! `apr dry-sampling-lint` — CRUX-C-23 DRY-sampling observation linter.
+//!
+//! Reads a JSON observation file that captures a single DRY-sampling run and
+//! dispatches five classifiers (params, identity, match_len, penalty,
+//! monotone). Emits a text or `--json` report.
+//!
+//! Spec: `contracts/crux-C-23-v1.yaml`. CRUX-SHIP-001 g2/g3 surface.
+//!
+//! Observation schema (top-level keys; all optional — missing sections skip
+//! the corresponding classifier):
+//!
+//!   {
+//!     "params":    { "multiplier": 0.8, "base": 1.75, "allowed_length": 2 },
+//!     "identity":  { "logits_before": [0.1, 0.5], "logits_after": [0.1, 0.5],
+//!                    "multiplier": 0.0 },
+//!     "match_len": { "ctx": [1,2,3,1,2], "candidate": 3,
+//!                    "seq_breakers": [], "expected_match_len": 3 },
+//!     "penalty":   { "match_len": 5, "allowed_length": 2,
+//!                    "multiplier": 0.8, "base": 1.75 },
+//!     "monotone":  { "match_len_a": 2, "match_len_b": 5,
+//!                    "allowed_length": 2, "multiplier": 0.8, "base": 1.75 }
+//!   }
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+
+use crate::commands::dry_sampling_classifier as clf;
+use crate::error::{CliError, Result};
+
+pub(crate) fn run(observation_file: &Path, json: bool) -> Result<()> {
+    if !observation_file.exists() {
+        return Err(CliError::FileNotFound(PathBuf::from(observation_file)));
+    }
+
+    let body = std::fs::read_to_string(observation_file)?;
+    let obs: Value = serde_json::from_str(&body).map_err(|e| {
+        CliError::InvalidFormat(format!(
+            "apr dry-sampling-lint: failed to parse JSON from {}: {e}",
+            observation_file.display()
+        ))
+    })?;
+
+    let params = classify_params(&obs);
+    let identity = classify_identity(&obs);
+    let match_len = classify_match_len(&obs);
+    let penalty = classify_penalty(&obs);
+    let monotone = classify_monotone(&obs);
+
+    let fail_reasons: Vec<String> = [
+        params.as_ref().and_then(params_fail_reason),
+        identity.as_ref().and_then(identity_fail_reason),
+        match_len.as_ref().and_then(match_len_fail_reason),
+        penalty.as_ref().and_then(penalty_fail_reason),
+        monotone.as_ref().and_then(monotone_fail_reason),
+    ]
+    .into_iter()
+    .flatten()
+    .collect();
+
+    print_report(
+        observation_file,
+        params.as_ref(),
+        identity.as_ref(),
+        match_len.as_ref(),
+        penalty.as_ref(),
+        monotone.as_ref(),
+        json,
+    );
+
+    if fail_reasons.is_empty() {
+        Ok(())
+    } else {
+        Err(CliError::ValidationFailed(fail_reasons.join("; ")))
+    }
+}
+
+fn classify_params(obs: &Value) -> Option<clf::DryParamOutcome> {
+    let sec = obs.get("params")?.as_object()?;
+    let multiplier = sec.get("multiplier")?.as_f64()?;
+    let base = sec.get("base")?.as_f64()?;
+    let allowed_length = u32::try_from(sec.get("allowed_length")?.as_u64()?).ok()?;
+    Some(clf::classify_dry_params(multiplier, base, allowed_length))
+}
+
+fn classify_identity(obs: &Value) -> Option<clf::IdentityOutcome> {
+    let sec = obs.get("identity")?.as_object()?;
+    let before: Vec<f64> = sec
+        .get("logits_before")?
+        .as_array()?
+        .iter()
+        .map(|v| v.as_f64().unwrap_or(f64::NAN))
+        .collect();
+    let after: Vec<f64> = sec
+        .get("logits_after")?
+        .as_array()?
+        .iter()
+        .map(|v| v.as_f64().unwrap_or(f64::NAN))
+        .collect();
+    let multiplier = sec.get("multiplier")?.as_f64()?;
+    Some(clf::classify_dry_identity_zero_multiplier(
+        &before, &after, multiplier,
+    ))
+}
+
+/// Outcome wrapper for match_len gate (comparison with declared expected value).
+#[derive(Debug)]
+pub(crate) enum MatchLenOutcome {
+    Ok { match_len: u32 },
+    Mismatch { expected: u32, actual: u32 },
+}
+
+fn classify_match_len(obs: &Value) -> Option<MatchLenOutcome> {
+    let sec = obs.get("match_len")?.as_object()?;
+    let ctx: Vec<u32> = sec
+        .get("ctx")?
+        .as_array()?
+        .iter()
+        .filter_map(|v| u32::try_from(v.as_u64()?).ok())
+        .collect();
+    let candidate = u32::try_from(sec.get("candidate")?.as_u64()?).ok()?;
+    let seq_breakers: HashSet<u32> = sec
+        .get("seq_breakers")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| u32::try_from(v.as_u64()?).ok())
+                .collect()
+        })
+        .unwrap_or_default();
+    let expected = u32::try_from(sec.get("expected_match_len")?.as_u64()?).ok()?;
+    let actual = clf::classify_dry_match_len(&ctx, candidate, &seq_breakers);
+    if actual == expected {
+        Some(MatchLenOutcome::Ok { match_len: actual })
+    } else {
+        Some(MatchLenOutcome::Mismatch { expected, actual })
+    }
+}
+
+fn classify_penalty(obs: &Value) -> Option<clf::PenaltyOutcome> {
+    let sec = obs.get("penalty")?.as_object()?;
+    let match_len = u32::try_from(sec.get("match_len")?.as_u64()?).ok()?;
+    let allowed_length = u32::try_from(sec.get("allowed_length")?.as_u64()?).ok()?;
+    let multiplier = sec.get("multiplier")?.as_f64()?;
+    let base = sec.get("base")?.as_f64()?;
+    Some(clf::classify_dry_penalty(
+        match_len,
+        allowed_length,
+        multiplier,
+        base,
+    ))
+}
+
+fn classify_monotone(obs: &Value) -> Option<clf::MonotonicityOutcome> {
+    let sec = obs.get("monotone")?.as_object()?;
+    let a = u32::try_from(sec.get("match_len_a")?.as_u64()?).ok()?;
+    let b = u32::try_from(sec.get("match_len_b")?.as_u64()?).ok()?;
+    let allowed_length = u32::try_from(sec.get("allowed_length")?.as_u64()?).ok()?;
+    let multiplier = sec.get("multiplier")?.as_f64()?;
+    let base = sec.get("base")?.as_f64()?;
+    Some(clf::classify_dry_penalty_monotone_in_match_len(
+        a,
+        b,
+        allowed_length,
+        multiplier,
+        base,
+    ))
+}
+
+fn params_fail_reason(o: &clf::DryParamOutcome) -> Option<String> {
+    match o {
+        clf::DryParamOutcome::Valid => None,
+        clf::DryParamOutcome::NotFinite { field } => Some(format!(
+            "FALSIFY-CRUX-C-23-001 params: {field} is not finite"
+        )),
+        clf::DryParamOutcome::MultiplierNegative { multiplier } => Some(format!(
+            "FALSIFY-CRUX-C-23-001 params: multiplier={multiplier} < 0.0"
+        )),
+        clf::DryParamOutcome::BaseBelowOne { base } => Some(format!(
+            "FALSIFY-CRUX-C-23-001 params: base={base} < 1.0"
+        )),
+        clf::DryParamOutcome::AllowedLengthZero => Some(
+            "FALSIFY-CRUX-C-23-001 params: allowed_length == 0".to_string(),
+        ),
+    }
+}
+
+fn identity_fail_reason(o: &clf::IdentityOutcome) -> Option<String> {
+    match o {
+        clf::IdentityOutcome::Ok => None,
+        clf::IdentityOutcome::InvalidInput { reason } => Some(format!(
+            "FALSIFY-CRUX-C-23-001 identity: invalid input: {reason}"
+        )),
+        clf::IdentityOutcome::LogitsChanged {
+            first_diff_index,
+            before,
+            after,
+        } => Some(format!(
+            "FALSIFY-CRUX-C-23-001 identity: logit changed at idx {first_diff_index}: before={before} after={after}"
+        )),
+    }
+}
+
+fn match_len_fail_reason(o: &MatchLenOutcome) -> Option<String> {
+    match o {
+        MatchLenOutcome::Ok { .. } => None,
+        MatchLenOutcome::Mismatch { expected, actual } => Some(format!(
+            "FALSIFY-CRUX-C-23-002 match_len: expected={expected} actual={actual}"
+        )),
+    }
+}
+
+fn penalty_fail_reason(o: &clf::PenaltyOutcome) -> Option<String> {
+    match o {
+        clf::PenaltyOutcome::Ok { .. } => None,
+        clf::PenaltyOutcome::InvalidInput { reason } => Some(format!(
+            "FALSIFY-CRUX-C-23-002 penalty: invalid input: {reason}"
+        )),
+        clf::PenaltyOutcome::Negative { penalty } => Some(format!(
+            "FALSIFY-CRUX-C-23-002 penalty: penalty={penalty} < 0.0"
+        )),
+    }
+}
+
+fn monotone_fail_reason(o: &clf::MonotonicityOutcome) -> Option<String> {
+    match o {
+        clf::MonotonicityOutcome::Ok => None,
+        clf::MonotonicityOutcome::InvalidInput { reason } => Some(format!(
+            "FALSIFY-CRUX-C-23-002 monotone: invalid input: {reason}"
+        )),
+        clf::MonotonicityOutcome::Violation {
+            match_len_a,
+            match_len_b,
+            penalty_a,
+            penalty_b,
+        } => Some(format!(
+            "FALSIFY-CRUX-C-23-002 monotone: violation a={match_len_a}(p={penalty_a}) > b={match_len_b}(p={penalty_b})"
+        )),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn print_report(
+    path: &Path,
+    params: Option<&clf::DryParamOutcome>,
+    identity: Option<&clf::IdentityOutcome>,
+    match_len: Option<&MatchLenOutcome>,
+    penalty: Option<&clf::PenaltyOutcome>,
+    monotone: Option<&clf::MonotonicityOutcome>,
+    json: bool,
+) {
+    if json {
+        let v = serde_json::json!({
+            "observation_path": path.display().to_string(),
+            "params":    params.map(|o| format!("{o:?}")),
+            "identity":  identity.map(|o| format!("{o:?}")),
+            "match_len": match_len.map(|o| format!("{o:?}")),
+            "penalty":   penalty.map(|o| format!("{o:?}")),
+            "monotone":  monotone.map(|o| format!("{o:?}")),
+        });
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&v).unwrap_or_else(|_| v.to_string())
+        );
+    } else {
+        println!("dry-sampling-lint report for {}", path.display());
+        print_line("  params:    ", params.map(|o| format!("{o:?}")));
+        print_line("  identity:  ", identity.map(|o| format!("{o:?}")));
+        print_line("  match_len: ", match_len.map(|o| format!("{o:?}")));
+        print_line("  penalty:   ", penalty.map(|o| format!("{o:?}")));
+        print_line("  monotone:  ", monotone.map(|o| format!("{o:?}")));
+    }
+}
+
+fn print_line(prefix: &str, v: Option<String>) {
+    match v {
+        Some(s) => println!("{prefix}{s}"),
+        None => println!("{prefix}(missing fields — classifier skipped)"),
+    }
+}

--- a/crates/apr-cli/src/commands/mod.rs
+++ b/crates/apr-cli/src/commands/mod.rs
@@ -43,6 +43,7 @@ pub(crate) mod lint;
 pub(crate) mod mcp;
 pub(crate) mod merge;
 pub(crate) mod dry_sampling_classifier;
+pub(crate) mod dry_sampling_lint;
 pub(crate) mod multi_lora_classifier;
 #[cfg(feature = "training")]
 pub(crate) mod model_config;

--- a/crates/apr-cli/src/commands/mod.rs
+++ b/crates/apr-cli/src/commands/mod.rs
@@ -42,6 +42,7 @@ pub(crate) mod kernel_explain;
 pub(crate) mod lint;
 pub(crate) mod mcp;
 pub(crate) mod merge;
+pub(crate) mod dry_sampling_classifier;
 pub(crate) mod multi_lora_classifier;
 #[cfg(feature = "training")]
 pub(crate) mod model_config;

--- a/crates/apr-cli/src/dispatch_analysis.rs
+++ b/crates/apr-cli/src/dispatch_analysis.rs
@@ -101,6 +101,10 @@ fn dispatch_analysis_commands(cli: &Cli) -> Option<Result<(), CliError>> {
             stream,
         } => commands::ollama_chat::run(response_file, *stream, cli.json),
 
+        ExtendedCommands::DrySamplingLint { observation_file } => {
+            commands::dry_sampling_lint::run(observation_file, cli.json)
+        }
+
         ExtendedCommands::Hex {
             file,
             tensor,

--- a/crates/apr-cli/src/extended_commands.rs
+++ b/crates/apr-cli/src/extended_commands.rs
@@ -723,6 +723,12 @@ pub enum ExtendedCommands {
         #[arg(long)]
         stream: bool,
     },
+    /// Lint a captured DRY-sampling observation (CRUX-C-23)
+    DrySamplingLint {
+        /// Path to observation JSON
+        #[arg(long, value_name = "FILE")]
+        observation_file: PathBuf,
+    },
     /// Publishing, conversion, and analysis tools
     #[command(flatten)]
     Tools(ToolCommands),

--- a/crates/apr-cli/tests/cli_commands.rs
+++ b/crates/apr-cli/tests/cli_commands.rs
@@ -73,6 +73,7 @@ fn registered_commands() -> Vec<&'static str> {
         "probar",
         "diagnose",
         "ollama-chat-lint",
+        "dry-sampling-lint",
         "oracle",
         "encrypt",
         "decrypt",

--- a/crates/apr-cli/tests/falsification_crux_c_23.rs
+++ b/crates/apr-cli/tests/falsification_crux_c_23.rs
@@ -1,0 +1,367 @@
+//! E2E falsification tests for `apr dry-sampling-lint` (CRUX-C-23).
+//!
+//! Discharges g3 of CRUX-SHIP-001 for PR #983: exercise the CLI surface
+//! end-to-end on captured JSON observations and assert the classifier
+//! verdicts + non-zero exit codes on known-bad input.
+
+use std::io::Write;
+use std::process::Command;
+
+fn apr_binary() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_apr"));
+    cmd.env("NO_COLOR", "1");
+    cmd
+}
+
+fn write_tmp_json(name: &str, body: &str) -> tempfile::NamedTempFile {
+    let mut f = tempfile::Builder::new()
+        .prefix(name)
+        .suffix(".json")
+        .tempfile()
+        .expect("create tempfile");
+    f.write_all(body.as_bytes()).expect("write tempfile");
+    f.flush().expect("flush tempfile");
+    f
+}
+
+// ---- help surface (g2 proof) ----------------------------------------------
+
+#[test]
+fn falsify_crux_c_23_help_advertises_observation_file_flag() {
+    let out = apr_binary()
+        .args(["dry-sampling-lint", "--help"])
+        .output()
+        .expect("run apr dry-sampling-lint --help");
+    assert!(
+        out.status.success(),
+        "apr dry-sampling-lint --help must exit 0"
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("--observation-file"),
+        "--help must advertise --observation-file; got:\n{stdout}"
+    );
+}
+
+#[test]
+fn falsify_crux_c_23_rejects_bare_invocation_without_file() {
+    let out = apr_binary()
+        .arg("dry-sampling-lint")
+        .output()
+        .expect("run apr dry-sampling-lint without args");
+    assert!(
+        !out.status.success(),
+        "bare `apr dry-sampling-lint` must exit non-zero"
+    );
+}
+
+// ---- params gate (FALSIFY-CRUX-C-23-001) ----------------------------------
+
+#[test]
+fn falsify_crux_c_23_001_params_ok_on_defaults() {
+    let tmp = write_tmp_json(
+        "dry-params-ok",
+        r#"{ "params": { "multiplier": 0.8, "base": 1.75, "allowed_length": 2 } }"#,
+    );
+    let out = apr_binary()
+        .args(["dry-sampling-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr dry-sampling-lint");
+    assert!(
+        out.status.success(),
+        "defaults must pass; stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn falsify_crux_c_23_001_params_rejects_negative_multiplier() {
+    let tmp = write_tmp_json(
+        "dry-params-negmul",
+        r#"{ "params": { "multiplier": -0.1, "base": 1.75, "allowed_length": 2 } }"#,
+    );
+    let out = apr_binary()
+        .args(["dry-sampling-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr dry-sampling-lint");
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-C-23-001"));
+}
+
+#[test]
+fn falsify_crux_c_23_001_params_rejects_base_below_one() {
+    let tmp = write_tmp_json(
+        "dry-params-base",
+        r#"{ "params": { "multiplier": 0.8, "base": 0.5, "allowed_length": 2 } }"#,
+    );
+    let out = apr_binary()
+        .args(["dry-sampling-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr dry-sampling-lint");
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-C-23-001"));
+}
+
+#[test]
+fn falsify_crux_c_23_001_params_rejects_allowed_length_zero() {
+    let tmp = write_tmp_json(
+        "dry-params-al0",
+        r#"{ "params": { "multiplier": 0.8, "base": 1.75, "allowed_length": 0 } }"#,
+    );
+    let out = apr_binary()
+        .args(["dry-sampling-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr dry-sampling-lint");
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-C-23-001"));
+}
+
+// ---- identity gate (FALSIFY-CRUX-C-23-001) --------------------------------
+
+#[test]
+fn falsify_crux_c_23_001_identity_ok_when_unchanged() {
+    let tmp = write_tmp_json(
+        "dry-id-ok",
+        r#"{ "identity": { "logits_before": [0.1, 0.5, -0.3],
+                          "logits_after":  [0.1, 0.5, -0.3],
+                          "multiplier": 0.0 } }"#,
+    );
+    let out = apr_binary()
+        .args(["dry-sampling-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr dry-sampling-lint");
+    assert!(
+        out.status.success(),
+        "identity must pass; stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn falsify_crux_c_23_001_identity_rejects_changed_logit() {
+    let tmp = write_tmp_json(
+        "dry-id-chg",
+        r#"{ "identity": { "logits_before": [0.1, 0.5, -0.3],
+                          "logits_after":  [0.1, 0.3, -0.3],
+                          "multiplier": 0.0 } }"#,
+    );
+    let out = apr_binary()
+        .args(["dry-sampling-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr dry-sampling-lint");
+    assert!(!out.status.success(), "changed logits at mul=0 must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-C-23-001"));
+}
+
+// ---- match_len gate (FALSIFY-CRUX-C-23-002) -------------------------------
+
+#[test]
+fn falsify_crux_c_23_002_match_len_ok_on_repeated_trigram() {
+    // ctx = [1 2 3 1 2], candidate = 3 → expected match_len = 3
+    let tmp = write_tmp_json(
+        "dry-ml-ok",
+        r#"{ "match_len": { "ctx": [1,2,3,1,2], "candidate": 3,
+                            "seq_breakers": [], "expected_match_len": 3 } }"#,
+    );
+    let out = apr_binary()
+        .args(["dry-sampling-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr dry-sampling-lint");
+    assert!(
+        out.status.success(),
+        "match_len=3 expected; stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn falsify_crux_c_23_002_match_len_rejects_wrong_expected() {
+    // actual = 3, expected = 7 → mismatch
+    let tmp = write_tmp_json(
+        "dry-ml-mismatch",
+        r#"{ "match_len": { "ctx": [1,2,3,1,2], "candidate": 3,
+                            "seq_breakers": [], "expected_match_len": 7 } }"#,
+    );
+    let out = apr_binary()
+        .args(["dry-sampling-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr dry-sampling-lint");
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-C-23-002"));
+}
+
+#[test]
+fn falsify_crux_c_23_002_match_len_seq_breaker_zero() {
+    // ctx = [1,2,9,1,2] with 9 as a breaker → expected match_len = 0
+    let tmp = write_tmp_json(
+        "dry-ml-breaker",
+        r#"{ "match_len": { "ctx": [1,2,9,1,2], "candidate": 3,
+                            "seq_breakers": [9], "expected_match_len": 0 } }"#,
+    );
+    let out = apr_binary()
+        .args(["dry-sampling-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr dry-sampling-lint");
+    assert!(
+        out.status.success(),
+        "seq_breaker reset should pass; stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+// ---- penalty gate (FALSIFY-CRUX-C-23-002) ---------------------------------
+
+#[test]
+fn falsify_crux_c_23_002_penalty_ok_at_threshold() {
+    // match_len=2, allowed=2 → exponent=0 → penalty = multiplier
+    let tmp = write_tmp_json(
+        "dry-pen-ok",
+        r#"{ "penalty": { "match_len": 2, "allowed_length": 2,
+                          "multiplier": 0.8, "base": 1.75 } }"#,
+    );
+    let out = apr_binary()
+        .args(["dry-sampling-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr dry-sampling-lint");
+    assert!(
+        out.status.success(),
+        "penalty at threshold should pass; stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn falsify_crux_c_23_002_penalty_rejects_invalid_input() {
+    // multiplier negative is InvalidInput, not Negative — but still fails
+    let tmp = write_tmp_json(
+        "dry-pen-neg",
+        r#"{ "penalty": { "match_len": 5, "allowed_length": 2,
+                          "multiplier": -0.1, "base": 1.75 } }"#,
+    );
+    let out = apr_binary()
+        .args(["dry-sampling-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr dry-sampling-lint");
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-C-23-002"));
+}
+
+// ---- monotone gate (FALSIFY-CRUX-C-23-002) --------------------------------
+
+#[test]
+fn falsify_crux_c_23_002_monotone_ok_non_decreasing() {
+    // 3 → 5 above threshold, penalty grows
+    let tmp = write_tmp_json(
+        "dry-mono-ok",
+        r#"{ "monotone": { "match_len_a": 3, "match_len_b": 5,
+                           "allowed_length": 2, "multiplier": 0.8, "base": 1.75 } }"#,
+    );
+    let out = apr_binary()
+        .args(["dry-sampling-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr dry-sampling-lint");
+    assert!(
+        out.status.success(),
+        "monotone non-decreasing should pass; stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn falsify_crux_c_23_002_monotone_rejects_decreasing_args() {
+    // a > b is InvalidInput — fails
+    let tmp = write_tmp_json(
+        "dry-mono-bad",
+        r#"{ "monotone": { "match_len_a": 5, "match_len_b": 3,
+                           "allowed_length": 2, "multiplier": 0.8, "base": 1.75 } }"#,
+    );
+    let out = apr_binary()
+        .args(["dry-sampling-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr dry-sampling-lint");
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-C-23-002"));
+}
+
+// ---- input validation -----------------------------------------------------
+
+#[test]
+fn falsify_crux_c_23_empty_file_rejected_via_cli() {
+    let tmp = write_tmp_json("dry-empty", "");
+    let out = apr_binary()
+        .args(["dry-sampling-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr dry-sampling-lint");
+    assert!(!out.status.success(), "empty file must be rejected");
+}
+
+#[test]
+fn falsify_crux_c_23_nonexistent_file_rejected() {
+    let out = apr_binary()
+        .args([
+            "dry-sampling-lint",
+            "--observation-file",
+            "/nonexistent/path/obs.json",
+        ])
+        .output()
+        .expect("run apr dry-sampling-lint");
+    assert!(!out.status.success());
+}
+
+// ---- --json shape ---------------------------------------------------------
+
+#[test]
+fn falsify_crux_c_23_json_output_shape() {
+    let tmp = write_tmp_json(
+        "dry-json",
+        r#"{
+          "params":    { "multiplier": 0.8, "base": 1.75, "allowed_length": 2 },
+          "identity":  { "logits_before": [0.1, 0.5],
+                         "logits_after":  [0.1, 0.5],
+                         "multiplier": 0.0 },
+          "match_len": { "ctx": [1,2,3,1,2], "candidate": 3,
+                         "seq_breakers": [], "expected_match_len": 3 },
+          "penalty":   { "match_len": 5, "allowed_length": 2,
+                         "multiplier": 0.8, "base": 1.75 },
+          "monotone":  { "match_len_a": 3, "match_len_b": 5,
+                         "allowed_length": 2, "multiplier": 0.8, "base": 1.75 }
+        }"#,
+    );
+    let out = apr_binary()
+        .args(["--json", "dry-sampling-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr dry-sampling-lint --json");
+    assert!(
+        out.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("\"params\""));
+    assert!(stdout.contains("\"identity\""));
+    assert!(stdout.contains("\"match_len\""));
+    assert!(stdout.contains("\"penalty\""));
+    assert!(stdout.contains("\"monotone\""));
+}


### PR DESCRIPTION
## Summary

- 5 pure classifiers in `crates/apr-cli/src/commands/dry_sampling_classifier.rs` covering llama.cpp DRY sampler invariants
- Both `FALSIFY-CRUX-C-23-001` (multiplier=0 identity) and `FALSIFY-CRUX-C-23-002` (exact-phrase repetition reduction) discharged at PARTIAL_ALGORITHM_LEVEL
- Contract `contracts/crux-C-23-v1.yaml` promoted draft → partial (v1.1.0); `pv validate` 0 errors, 0 warnings
- 36 new tests — identity, match_len (bigram/trigram/double-trigram), seq-breaker resets, penalty formula, monotonicity
- Every malformed input (NaN/Inf, negative multiplier, base<1, allowed=0, empty ctx, length mismatch) lands in a distinct `Outcome` variant

## Discharged FALSIFY gates

| ID | Scope | Tests |
|----|-------|-------|
| FALSIFY-CRUX-C-23-001 | multiplier=0 identity + parameter-range | identity + params families (16) |
| FALSIFY-CRUX-C-23-002 | match_len + penalty formula + seq-breaker reset + monotonicity | match + penalty + monotone families (20) |

`full_discharge_blocked_on` records what end-to-end evidence (GGUF fixture, 4-gram uniqueness test) would promote each gate to FULL.

## Test plan

- [x] `cargo test -p apr-cli --lib dry_sampling` → 36/36 pass
- [x] `pv validate contracts/crux-C-23-v1.yaml` → 0 errors, 0 warnings
- [x] Every bad input maps to a distinct variant (no silent pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)