### PR TITLE
feat(vocab-50257): bump 370M vocab_size 50_000 → 50_257 (Option A, task #131)

### DIFF
--- a/contracts/model-families/llama-370m-sovereign-v1.yaml
+++ b/contracts/model-families/llama-370m-sovereign-v1.yaml
@@ -36,14 +36,31 @@
 # ─────────────────────────────────────────────────────────────
 
 contract_id: C-LLAMA-370M-SOVEREIGN
-version: 1.4.0
+version: 1.5.0
 status: ACTIVE
 
 metadata:
-  version: "1.4.0"
+  version: "1.5.0"
   created: "2026-04-18"
   updated: "2026-04-21"
   changelog:
+    - "1.5.0 (2026-04-21): Option-A vocab alignment (task #131).
+       Bumped vocab_size 50_000 → 50_257 to match the MODEL-2
+       tokenizer artifact (trained in task #118) and the GPT-2
+       industry convention (50_000 BPE merges + 256 byte-level
+       fallback tokens + 1 sentinel). Option B (retrain tokenizer
+       at 50_000) was rejected — it would have burned task #118
+       compute to honor a contract number that had no physical
+       grounding; Option A honors the actual artifact instead.
+       INV-ARCH-370M-006 description + falsifier updated in
+       lockstep; INV-ARCH-370M-009 example shape strings updated
+       from [50000, 1024] to [50257, 1024] (layout unchanged —
+       still row-major [vocab_size, hidden_dim]). Paired with
+       tokenizer-bpe-v1 v1.2.0 and Llama370MConfig::VOCAB_SIZE=50_257 —
+       all three artifacts move in lockstep via GATE-ARCH-370M-011
+       pre-flight. Parameter count shifts by
+       (257 × 1024) = 263_168 = 0.07%, well inside the
+       INV-ARCH-370M-001 [366M, 374M] band."
     - "1.4.0 (2026-04-21): Added GATE-ARCH-370M-011 operationalizing
        INV-ARCH-370M-006 as a pre-flight gate on the `apr pretrain`
        dispatch path. Motivation: first real-compute MODEL-2 dispatch
@@ -149,7 +166,7 @@ architecture:
   num_kv_heads: 4              # GQA — kv_heads = heads / 4
   head_dim: 64                 # hidden_dim / num_heads
   intermediate_dim: 2816       # ~2.75 × hidden (SwiGLU convention)
-  vocab_size: 50000            # BPE trained on Python corpus (see tokenizer-bpe-v1)
+  vocab_size: 50257            # BPE trained on Python corpus (see tokenizer-bpe-v1)
   max_position_embeddings: 4096
   rope_theta: 10000.0          # Llama-1 convention (not 500_000 like Llama-3 — short ctx)
   rms_norm_eps: 0.00001
@@ -291,12 +308,12 @@ invariants:
 
   - id: INV-ARCH-370M-006
     description: >
-      vocab_size == 50000 and exactly matches the paired BPE tokenizer
+      vocab_size == 50257 and exactly matches the paired BPE tokenizer
       (contracts/tokenizer-bpe-v1.yaml INV-BPE-001). Drift between
       tokenizer vocab and embedding row count produces silent garbage.
     falsifier: >
-      Load tokenizer, assert tokenizer.vocab_size() == 50000 AND load
-      model embedding, assert embedding.shape[0] == 50000. If either
+      Load tokenizer, assert tokenizer.vocab_size() == 50257 AND load
+      model embedding, assert embedding.shape[0] == 50257. If either
       differs, mark FAIL — refuse to start training.
 
   - id: INV-ARCH-370M-007
@@ -323,11 +340,11 @@ invariants:
   - id: INV-ARCH-370M-009
     description: >
       Row-major APR layout (LAYOUT-001). Embedding shape is
-      [vocab_size, hidden_dim] = [50000, 1024], NOT [1024, 50000].
+      [vocab_size, hidden_dim] = [50257, 1024], NOT [1024, 50257].
       This is the most-bitten bug in the project (100+ occurrences);
       import from column-major GGUF MUST transpose.
     falsifier: >
-      Assert APR header shape == [50000, 1024] for embedding tensor.
+      Assert APR header shape == [50257, 1024] for embedding tensor.
       Reversed shape triggers layout_contract::CONTRACT.validate_apr_shape
       failure at load time.
 

--- a/contracts/tokenizer-bpe-v1.yaml
+++ b/contracts/tokenizer-bpe-v1.yaml
@@ -38,13 +38,13 @@
 # ─────────────────────────────────────────────────────────────
 
 contract_id: C-TOK-BPE
-version: 1.1.0
+version: 1.2.0
 status: PROPOSED
 
 metadata:
-  version: "1.1.0"
+  version: "1.2.0"
   created: "2026-04-18"
-  updated: "2026-04-19"
+  updated: "2026-04-21"
   changelog:
     - "1.0.0 (2026-04-18): Initial contract drafted as PROPOSED — froze
        albor 370M tokenizer choices (vocab=50K, 4 special tokens,
@@ -59,6 +59,24 @@ metadata:
        materialization) — when that data lands, the fixture swap is
        data-only, no harness rewrite. Status intentionally kept PROPOSED
        until the 10K corpus runs clean."
+    - "1.2.0 (2026-04-21): Option-A vocab alignment (task #131). Bumped
+       vocab_size 50_000 → 50_257 to match the actual MODEL-2 tokenizer
+       artifact trained in task #118 and the GPT-2 convention
+       (50_000 BPE merges + 256 byte-level fallback tokens +
+       1 sentinel, accommodating our 4 special tokens). The incident
+       that surfaced this (task #126: first real-compute MODEL-2
+       dispatch at commit 29607ed33 fired N-09 OOB escape on token
+       id 50_241 because tokenizer@50_257 disagreed with contract@50_000)
+       confirmed that the artifact, not the contract, was
+       industry-canonical. Option B (retrain tokenizer at 50_000) would
+       have burned task #118 compute. merge_rules_count_expected
+       updated 49_996 → 49_997 (vocab − 4 special − 256 byte-level
+       fallback); merge-rules tolerance window slid from [49992, 50000]
+       to [49993, 50001]. INV-BPE-001 / INV-BPE-004 / GATE-BPE-001 /
+       GATE-BPE-004 narratives updated in lockstep. Paired with
+       llama-370m-sovereign-v1 v1.5.0 (vocab_size=50_257) and
+       Llama370MConfig::VOCAB_SIZE=50_257 — all three artifacts move
+       byte-in-lockstep via GATE-ARCH-370M-011 pre-flight."
   author: PAIML Engineering
   description: >
     Concrete BPE tokenizer contract for SHIP-TWO-001 MODEL-2 (albor
@@ -99,11 +117,11 @@ motivation: >
 
 tokenizer:
   algorithm: bpe
-  vocab_size: 50000
+  vocab_size: 50257
   vocab_size_bounds:
     min: 32000          # below this, Python keyword coverage collapses
     max: 65536          # above this, u16 token-id optimization breaks
-  merge_rules_count_expected: 49996    # vocab_size - (4 special tokens)
+  merge_rules_count_expected: 49997    # vocab_size − 4 special − 256 byte-level fallback tokens
   merge_rules_count_tolerance: 4       # ± for byte-fallback edge cases
 
   required_special_tokens:
@@ -132,7 +150,9 @@ invariants:
     description: >
       vocab_size ∈ [32000, 65536] and matches the paired model's
       embedding row count (see llama-370m-sovereign-v1 INV-ARCH-370M-006).
-      Default: exactly 50000.
+      Default: exactly 50257 (GPT-2 canonical — 50_000 BPE merges
+      + 256 byte-level fallback tokens + 1 sentinel, with our 4
+      special tokens allocated from the non-mergeable slots).
     falsifier: >
       Load tokenizer, assert tokenizer.vocab_size() ∈ [32000, 65536].
       Further: if shipped with a 370M checkpoint, assert equality with
@@ -159,12 +179,13 @@ invariants:
 
   - id: INV-BPE-004
     description: >
-      Merge rules count equals (vocab_size − |special_tokens|) ± 4.
-      The ±4 slack covers byte-level fallback edge cases where a byte
-      ID is added directly without a merge.
+      Merge rules count equals (vocab_size − |special_tokens| − 256
+      byte-level fallback) ± 4. The ±4 slack covers byte-level
+      fallback edge cases where a byte ID is added directly without
+      a merge.
     falsifier: >
       Load merges.txt (or equivalent from tokenizer.json), count lines.
-      Assert |merges| ∈ [49992, 50000]. Outside range fails.
+      Assert |merges| ∈ [49993, 50001]. Outside range fails.
 
   - id: INV-BPE-005
     description: >
@@ -210,7 +231,7 @@ gates:
       Vocabulary size and bounds are satisfied (INV-BPE-001).
     evidence_required: >
       `apr tokenize --info tokenizer.json | jq '.vocab_size'` returns
-      50000; `.bounds_ok` is true.
+      50257; `.bounds_ok` is true.
     verdict: pass
     binds_to: AC-SHIP2-002
 
@@ -257,7 +278,7 @@ gates:
       Merge rules count is within expected tolerance (INV-BPE-004).
     evidence_required: >
       `apr tokenize --info tokenizer.json | jq '.merges_count'` returns
-      an integer in [49992, 50000].
+      an integer in [49993, 50001].
     verdict: pass
     binds_to: AC-SHIP2-002
 

--- a/crates/apr-cli/src/commands/pretrain.rs
+++ b/crates/apr-cli/src/commands/pretrain.rs
@@ -16,13 +16,13 @@ use crate::error::{CliError, Result};
 use crate::output;
 use clap::ValueEnum;
 use colored::Colorize;
-use entrenar::models::llama_370m::{assert_tokenizer_vocab_matches_model, Llama370MConfig};
+use entrenar::models::llama_370m::{Llama370MConfig, assert_tokenizer_vocab_matches_model};
 use entrenar::train::pretrain::{
     CheckpointFn, LinearDecaySynthetic, PretrainAbort, PretrainConfig, PretrainLoop, RunStatus,
     ScriptedVal, StepFn, TrainingRegime, ValFn,
 };
 use entrenar::train::pretrain_real::{
-    build_shared_trainer, AprCheckpointFn, RealStepFn, RealValFn,
+    AprCheckpointFn, RealStepFn, RealValFn, build_shared_trainer,
 };
 use entrenar::train::shard_reader::ShardBatchIter;
 use entrenar::train::transformer_trainer::LMBatch;
@@ -473,14 +473,17 @@ mod tests {
 
     #[test]
     fn preflight_rejects_tokenizer_vocab_mismatch() {
-        // FALSIFY-ARCH-370M-011: a tokenizer at 50_257 paired with the
-        // 370M model (VOCAB_SIZE=50_000) MUST abort dispatch with an
-        // error message that names both values and the gate id, so the
-        // operator can see the mismatch without stepping through code.
+        // FALSIFY-ARCH-370M-011: a tokenizer whose vocab size drifts from
+        // the model's pinned VOCAB_SIZE MUST abort dispatch with an error
+        // message that names both values and the gate id, so the operator
+        // can see the mismatch without stepping through code. Task #131
+        // bumped VOCAB_SIZE to 50_257 (Option A) — the counter-example
+        // below now exercises a tokenizer one token short of contract.
         let tmp = TempDir::new().expect("tempdir");
-        stage_vocab_json(tmp.path(), 50_257);
+        let mismatch = Llama370MConfig::VOCAB_SIZE - 1;
+        stage_vocab_json(tmp.path(), mismatch);
         let err = preflight_tokenizer_vocab_matches_model(tmp.path())
-            .expect_err("50_257 vs 50_000 must be rejected");
+            .expect_err("tokenizer/model vocab mismatch must be rejected");
         match err {
             CliError::ValidationFailed(msg) => {
                 assert!(
@@ -488,10 +491,13 @@ mod tests {
                     "msg must cite gate: {msg}"
                 );
                 assert!(
-                    msg.contains("50257"),
+                    msg.contains(&mismatch.to_string()),
                     "msg must name tokenizer vocab: {msg}"
                 );
-                assert!(msg.contains("50000"), "msg must name model vocab: {msg}");
+                assert!(
+                    msg.contains(&Llama370MConfig::VOCAB_SIZE.to_string()),
+                    "msg must name model vocab: {msg}"
+                );
             }
             other => panic!("unexpected error: {other:?}"),
         }

--- a/crates/apr-cli/src/tokenize_commands.rs
+++ b/crates/apr-cli/src/tokenize_commands.rs
@@ -1,4 +1,3 @@
-
 /// Tokenizer training pipeline subcommands (forjar-style plan/apply).
 ///
 /// Thin CLI wrappers around aprender's BPE training infrastructure.
@@ -66,8 +65,10 @@ pub enum TokenizeCommands {
         /// Each line must be a JSON object with a `content` field.
         #[arg(long, value_name = "PATH")]
         corpus: PathBuf,
-        /// Target vocabulary size
-        #[arg(long, default_value = "50000")]
+        /// Target vocabulary size. Default 50_257 matches GPT-2 convention
+        /// (50_000 BPE merges + 256 byte-level fallback tokens + 1 sentinel)
+        /// and the MODEL-2 albor tokenizer contract (tokenizer-bpe-v1 v1.2.0).
+        #[arg(long, default_value = "50257")]
         vocab_size: usize,
         /// Minimum frequency a byte-pair must reach before BPE merges it into
         /// a new vocabulary token (honored by `entrenar::tokenizer::BPETokenizer`

--- a/crates/aprender-train/src/models/llama_370m.rs
+++ b/crates/aprender-train/src/models/llama_370m.rs
@@ -29,7 +29,7 @@
 //!                          `TIED_EMBEDDINGS` const.
 //! - **INV-ARCH-370M-005**  `rope_theta == 10000.0` exactly (Llama-1 convention).
 //!                          Compile-time enforced as a `const f32`.
-//! - **INV-ARCH-370M-006**  `vocab_size == 50_000` and matches the paired
+//! - **INV-ARCH-370M-006**  `vocab_size == 50_257` and matches the paired
 //!                          tokenizer-bpe-v1 contract. Tokenizer coupling
 //!                          cannot be checked at compile time — runtime
 //!                          `debug_assert_eq!` at model load.
@@ -185,7 +185,7 @@ impl Llama370MConfig {
     pub const NUM_KV_HEADS: usize = 4; // GQA: heads / 4
     pub const HEAD_DIM: usize = 64; // hidden_dim / num_heads
     pub const INTERMEDIATE_DIM: usize = 2816; // ~2.75 * hidden
-    pub const VOCAB_SIZE: usize = 50_000;
+    pub const VOCAB_SIZE: usize = 50_257;
     pub const MAX_POSITION_EMBEDDINGS: usize = 4096;
 
     /// RoPE base frequency — Llama-1 convention (INV-ARCH-370M-005).
@@ -210,7 +210,7 @@ impl Llama370MConfig {
     ///   INV-ARCH-370M-003  num_kv_heads divides num_heads
     ///   INV-ARCH-370M-004  tied_embeddings == true
     ///   INV-ARCH-370M-005  rope_theta == 10000.0
-    ///   INV-ARCH-370M-006  vocab_size == 50_000
+    ///   INV-ARCH-370M-006  vocab_size == 50_257
     ///   INV-ARCH-370M-008  has_bias == false
     ///
     /// Invariants NOT encodable at compile time (documented as runtime
@@ -253,8 +253,8 @@ impl Llama370MConfig {
 
         // INV-ARCH-370M-006
         assert!(
-            Self::VOCAB_SIZE == 50_000,
-            "INV-ARCH-370M-006 violated: vocab_size must equal 50_000",
+            Self::VOCAB_SIZE == 50_257,
+            "INV-ARCH-370M-006 violated: vocab_size must equal 50_257",
         );
 
         // INV-ARCH-370M-008
@@ -401,7 +401,7 @@ mod tests {
         assert_eq!(Llama370MConfig::NUM_KV_HEADS, 4);
         assert_eq!(Llama370MConfig::HEAD_DIM, 64);
         assert_eq!(Llama370MConfig::INTERMEDIATE_DIM, 2816);
-        assert_eq!(Llama370MConfig::VOCAB_SIZE, 50_000);
+        assert_eq!(Llama370MConfig::VOCAB_SIZE, 50_257);
         assert_eq!(Llama370MConfig::MAX_POSITION_EMBEDDINGS, 4096);
         assert!((Llama370MConfig::ROPE_THETA - 10_000.0_f32).abs() < 1e-6);
         assert!((Llama370MConfig::RMS_NORM_EPS - 1.0e-5_f32).abs() < 1e-9);
@@ -424,27 +424,37 @@ mod tests {
     /// dispatch at commit 29607ed33 surfaced this when a tokenizer at
     /// vocab=50_257 was paired with a model pinned at VOCAB_SIZE=50_000;
     /// the N-09 OOB escape masked the mismatch → garbage gradients.
+    /// Task #131 bumped VOCAB_SIZE to 50_257 (Option A); the counter-example
+    /// value below now exercises the opposite drift (a tokenizer one token
+    /// short of contract) so the helper is still exercised on real mismatch.
     #[test]
     fn falsify_gate_arch_370m_011_helper_rejects_mismatch() {
-        assert!(assert_tokenizer_vocab_matches_model(
-            Llama370MConfig::VOCAB_SIZE,
-            Llama370MConfig::VOCAB_SIZE,
-        )
-        .is_ok());
+        assert!(
+            assert_tokenizer_vocab_matches_model(
+                Llama370MConfig::VOCAB_SIZE,
+                Llama370MConfig::VOCAB_SIZE,
+            )
+            .is_ok()
+        );
 
-        let err = assert_tokenizer_vocab_matches_model(50_257, Llama370MConfig::VOCAB_SIZE)
+        let mismatch = Llama370MConfig::VOCAB_SIZE - 1;
+        let err = assert_tokenizer_vocab_matches_model(mismatch, Llama370MConfig::VOCAB_SIZE)
             .expect_err("mismatch must return Err");
         assert!(
-            err.contains("GATE-ARCH-370M-011") && err.contains("50257") && err.contains("50000"),
+            err.contains("GATE-ARCH-370M-011")
+                && err.contains(&mismatch.to_string())
+                && err.contains(&Llama370MConfig::VOCAB_SIZE.to_string()),
             "error must name the gate and both vocab sizes for forensics, got: {err}",
         );
 
         assert!(assert_tokenizer_vocab_matches_model(0, 1).is_err());
-        assert!(assert_tokenizer_vocab_matches_model(
-            Llama370MConfig::VOCAB_SIZE + 1,
-            Llama370MConfig::VOCAB_SIZE
-        )
-        .is_err());
+        assert!(
+            assert_tokenizer_vocab_matches_model(
+                Llama370MConfig::VOCAB_SIZE + 1,
+                Llama370MConfig::VOCAB_SIZE
+            )
+            .is_err()
+        );
     }
 
     /// INV-ARCH-370M-001 — estimated param count within [366M, 374M].
@@ -519,7 +529,7 @@ mod tests {
         assert_eq!(Head::VALUE, 64);
         assert_eq!(Inter::VALUE, 2816);
         assert_eq!(Layers::VALUE, 24);
-        assert_eq!(Vocab::VALUE, 50_000);
+        assert_eq!(Vocab::VALUE, 50_257);
 
         // Zero-sized: all shape newtypes cost nothing at runtime.
         assert_eq!(std::mem::size_of::<Hidden>(), 0);


### PR DESCRIPTION
## Summary

Closes the 3-way parity defect surfaced by task #126 at commit 29607ed33. The MODEL-2 tokenizer artifact (trained in task #118) has **50_257** entries per GPT-2 industry convention (50_000 BPE merges + 256 byte-level fallback tokens + 1 sentinel). Both pre-existing contracts pinned 50_000 exactly, and `Llama370MConfig::VOCAB_SIZE` was hardcoded 50_000 — a mismatch that `GATE-ARCH-370M-011` (PR #961) now catches pre-flight but previously let through silently via the N-09 OOB escape guard in `Embedding::forward`.

**Option A** (this PR) honors the real-world artifact and burns no tokenizer re-training compute. Option B (retrain tokenizer at 50_000) was rejected as muda.

## Byte-lockstep changes across three artifacts

- `contracts/tokenizer-bpe-v1.yaml` 1.1.0 → **1.2.0**: `vocab_size: 50257`, `merge_rules_count_expected: 49997`, INV-BPE-001/004 bounds updated, v1.2.0 changelog entry added.
- `contracts/model-families/llama-370m-sovereign-v1.yaml` 1.4.0 → **1.5.0**: `vocab_size: 50257`, INV-ARCH-370M-006 / INV-ARCH-370M-009 equations + falsifiers updated, v1.5.0 changelog entry added.
- `crates/aprender-train/src/models/llama_370m.rs`: `pub const VOCAB_SIZE: usize = 50_257`, `validate()` const panic + all doctests updated.

INV-ARCH-370M-001 param-count band [366M, 374M] still holds — delta of (257 × 1024) = 263_168 params = 0.07% of lower bound.

## Test plan
- [x] `cargo test -p aprender-train --lib models::llama_370m` — **9/9 pass**
- [x] `cargo test -p apr-cli --lib commands::pretrain` — **11/11 pass** (incl. rewritten `preflight_rejects_tokenizer_vocab_mismatch` that uses `VOCAB_SIZE - 1` as the rot-proof counter-example)
- [x] `pv validate contracts/tokenizer-bpe-v1.yaml` — green
- [x] `pv validate contracts/model-families/llama-370m-sovereign-v1.yaml` — green
- [ ] CI required checks (workspace-test + ci/gate) green on this PR

## Unblocks
- Task #126: MODEL-2 from-scratch real-compute pretrain on lambda-labs RTX 4090