### PR TITLE
feat(task-132): Phase 1 — Device enum + --device CLI flag

### DIFF
--- a/contracts/entrenar/gpu-training-backend-v1.yaml
+++ b/contracts/entrenar/gpu-training-backend-v1.yaml
@@ -392,17 +392,17 @@ implementation_plan:
 
   phase_1:
     title: "Device enum + dispatch helper"
-    status: pending
+    status: complete
     deliverables:
-      - "crates/aprender-train/src/train/device.rs: Device enum + resolve_device() with FALSIFY-GPUTRAIN-001/002 tests"
-      - "--device CLI flag wired in crates/apr-cli/src/commands/pretrain.rs"
-      - "SharedTrainer enum extended with CudaVariant (NotImplemented stub)"
+      - "crates/aprender-train/src/train/device.rs: Device enum + resolve_device() with FALSIFY-GPUTRAIN-001/002 tests (17 tests PASS)"
+      - "--device CLI flag wired in crates/apr-cli/src/extended_commands.rs (default `auto`, 3 cli_pretrain_device_* tests PASS)"
+      - "drive_real NotImplemented stub when Device::is_cuda() — GATE-GPUTRAIN-002 hard-fail before any trainer allocation"
 
   phase_2:
     title: "Wire existing CudaTransformerTrainer"
     status: pending
     deliverables:
-      - "SharedTrainer::CudaVariant dispatches to crates/aprender-train/src/train/transformer_trainer/cuda_trainer.rs"
+      - "Replace Phase 1 drive_real NotImplemented stub with SharedTrainer::CudaVariant dispatch (extend pretrain_real.rs with CudaRealStepFn / CudaRealValFn / CudaAprCheckpointFn)"
       - "drive_real branches on Device in pretrain.rs (mirror loader/mod.rs:227)"
       - "nvidia-smi residency probe + GATE-GPUTRAIN-003 harness"
 

--- a/crates/apr-cli/src/commands/pretrain.rs
+++ b/crates/apr-cli/src/commands/pretrain.rs
@@ -17,6 +17,7 @@ use crate::output;
 use clap::ValueEnum;
 use colored::Colorize;
 use entrenar::models::llama_370m::{Llama370MConfig, assert_tokenizer_vocab_matches_model};
+use entrenar::train::device::{Device, resolve_device};
 use entrenar::train::pretrain::{
     CheckpointFn, LinearDecaySynthetic, PretrainAbort, PretrainConfig, PretrainLoop, RunStatus,
     ScriptedVal, StepFn, TrainingRegime, ValFn,
@@ -99,8 +100,17 @@ pub(crate) fn run(
     target_val_loss: Option<f32>,
     vocab_size: u32,
     synthetic: bool,
+    device: &str,
     json_output: bool,
 ) -> Result<()> {
+    // Contract gpu-training-backend-v1 INV-GPUTRAIN-001 / GATE-GPUTRAIN-002:
+    // parse --device BEFORE any trainer allocation so an invalid spec
+    // or an explicit `cuda` on a CPU-only host fails fast with a clear
+    // diagnostic. Synthetic drive still honours --device (for parity
+    // with real compute) but the stub error surface is identical.
+    let resolved_device =
+        resolve_device(device).map_err(|e| CliError::ValidationFailed(e.to_string()))?;
+
     let hp = mode_defaults(mode, vocab_size, lr, warmup_steps, target_val_loss);
 
     // Validation: GATE-TRAIN-003 requires target_val_loss > 0.
@@ -143,6 +153,12 @@ pub(crate) fn run(
 
     if !json_output {
         print_header(&config);
+        // GATE-GPUTRAIN-002 visibility: print the resolved Device so the
+        // operator can confirm which backend was selected. `auto` is the
+        // only spec that may silently fall back, and this print makes
+        // the fall-back visible at startup.
+        output::kv("  Device", resolved_device.to_string());
+        println!();
     }
 
     let status = if synthetic {
@@ -161,6 +177,7 @@ pub(crate) fn run(
             seq_length,
             batch_size,
             seed,
+            resolved_device,
             json_output,
         )?
     };
@@ -227,6 +244,7 @@ fn preflight_tokenizer_vocab_matches_model(tokenizer_dir: &Path) -> Result<()> {
 /// Real-corpus drive: build a shared 370M `TransformerTrainer`, split
 /// the shard stream head-off into a held-out validation set, and run a
 /// full forward + backward + AdamW step per training batch.
+#[allow(clippy::too_many_arguments)]
 fn drive_real(
     config: PretrainConfig,
     dataset: &Path,
@@ -234,8 +252,26 @@ fn drive_real(
     seq_length: usize,
     batch_size: usize,
     seed: u64,
+    device: Device,
     json_output: bool,
 ) -> Result<RunStatus> {
+    // Phase 1 stub (contract gpu-training-backend-v1 §implementation_plan
+    // phase 1 / peer_contracts apr-cli-commands-v1): CLI surface accepts
+    // `--device cuda[:N]` and resolves it, but the CUDA training path is
+    // not yet wired — Phase 2 will extend `SharedTrainer` to dispatch to
+    // `CudaTransformerTrainer`. Until then, any resolved CUDA device
+    // must surface a clear NotImplemented error rather than silently
+    // using the CPU path (GATE-GPUTRAIN-002).
+    if device.is_cuda() {
+        return Err(CliError::ValidationFailed(format!(
+            "--device {device} resolved, but the CUDA training backend \
+             is not yet wired in `apr pretrain` (contract \
+             gpu-training-backend-v1 phase 2 pending, task #132). \
+             Pass `--device cpu` to opt in to the CPU path, or wait for \
+             Phase 2 to land.",
+        )));
+    }
+
     // GATE-ARCH-370M-011 / INV-ARCH-370M-006 — refuse to dispatch a real
     // training step when the tokenizer vocab_size and the model vocab_size
     // disagree. The N-09 OOB escape guard in Embedding::forward masks the
@@ -548,6 +584,7 @@ mod tests {
             Some(2.2),
             50257,
             true,
+            "cpu",
             true,
         );
         assert!(
@@ -581,6 +618,7 @@ mod tests {
             Some(2.2),
             50257,
             false,
+            "cpu",
             true,
         )
         .expect_err("empty dataset dir must fail to initialise the shard iterator");
@@ -613,6 +651,7 @@ mod tests {
             Some(-1.0),
             50257,
             true,
+            "cpu",
             true,
         )
         .expect_err("negative target_val_loss must be rejected");
@@ -748,5 +787,72 @@ mod tests {
             parse_pretrain_synthetic(&["--synthetic"]),
             "INV-TRAIN-010: `apr pretrain --synthetic` must parse to synthetic=true"
         );
+    }
+
+    // ── FALSIFY-GPUTRAIN-001 / 002 CLI surface (contract phase 1) ────
+    // Contract: gpu-training-backend-v1 §device_dispatch
+    //
+    // These tests parse actual `apr pretrain --device …` argv through
+    // clap and assert the string is surfaced byte-for-byte to the
+    // dispatcher. `resolve_device()` itself is exercised by
+    // `aprender-train::train::device::tests` — these tests verify that
+    // the CLI flag exists and that its default is `auto` (the only
+    // spec allowed to fall back).
+
+    fn parse_pretrain_device(extra: &[&str]) -> String {
+        let extra: Vec<String> = extra.iter().map(|s| (*s).to_string()).collect();
+        std::thread::Builder::new()
+            .stack_size(16 * 1024 * 1024)
+            .spawn(move || {
+                use clap::Parser;
+                let mut argv: Vec<String> = vec![
+                    "apr".to_string(),
+                    "pretrain".to_string(),
+                    "--dataset".to_string(),
+                    "/tmp/_gputrain_device/ds".to_string(),
+                    "--tokenizer".to_string(),
+                    "/tmp/_gputrain_device/tok".to_string(),
+                    "--run-dir".to_string(),
+                    "/tmp/_gputrain_device/run".to_string(),
+                ];
+                argv.extend(extra);
+                let cli = crate::Cli::try_parse_from(&argv).expect("clap parse must succeed");
+                match *cli.command {
+                    crate::Commands::Extended(crate::ExtendedCommands::Pretrain {
+                        device,
+                        ..
+                    }) => device,
+                    other => panic!("expected ExtendedCommands::Pretrain, got {other:?}"),
+                }
+            })
+            .expect("spawn parse thread")
+            .join()
+            .expect("parse thread must not panic")
+    }
+
+    #[test]
+    fn cli_pretrain_device_defaults_to_auto() {
+        // Absent `--device`, the flag MUST parse to `"auto"` — the only
+        // spec allowed to silently fall back to CPU when CUDA is not
+        // available. Any other default would violate the contract's
+        // "explicit request → hard-fail" invariant.
+        assert_eq!(
+            parse_pretrain_device(&[]),
+            "auto",
+            "gpu-training-backend-v1 INV-GPUTRAIN-002: default --device must be `auto`",
+        );
+    }
+
+    #[test]
+    fn cli_pretrain_device_accepts_cpu() {
+        // `--device cpu` MUST round-trip through clap unchanged.
+        assert_eq!(parse_pretrain_device(&["--device", "cpu"]), "cpu");
+    }
+
+    #[test]
+    fn cli_pretrain_device_accepts_cuda_index() {
+        // `--device cuda:7` MUST round-trip unchanged; grammar
+        // enforcement happens in `resolve_device`, not at clap.
+        assert_eq!(parse_pretrain_device(&["--device", "cuda:7"]), "cuda:7");
     }
 }

--- a/crates/apr-cli/src/dispatch_analysis.rs
+++ b/crates/apr-cli/src/dispatch_analysis.rs
@@ -233,6 +233,7 @@ fn dispatch_analysis_commands(cli: &Cli) -> Option<Result<(), CliError>> {
             target_val_loss,
             vocab_size,
             synthetic,
+            device,
         } => commands::pretrain::run(
             dataset,
             tokenizer,
@@ -248,6 +249,7 @@ fn dispatch_analysis_commands(cli: &Cli) -> Option<Result<(), CliError>> {
             *target_val_loss,
             *vocab_size,
             *synthetic,
+            device,
             cli.json,
         ),
         ExtendedCommands::Tokenize { command } => dispatch_tokenize_command(command, cli),

--- a/crates/apr-cli/src/extended_commands.rs
+++ b/crates/apr-cli/src/extended_commands.rs
@@ -679,6 +679,13 @@ pub enum ExtendedCommands {
         /// INV-TRAIN-010: absent = real compute (drive_real), present = synthetic (drive_synthetic).
         #[arg(long, action = clap::ArgAction::SetTrue)]
         synthetic: bool,
+        /// Training backend. Grammar (contract gpu-training-backend-v1
+        /// INV-GPUTRAIN-001): `^(cpu|cuda(:[0-9]|:1[0-5])?|auto)$`.
+        /// Default `auto` uses CUDA if available, else CPU (the only
+        /// spelling that may fall back silently — all other values
+        /// hard-fail on missing runtime per GATE-GPUTRAIN-002).
+        #[arg(long, default_value = "auto")]
+        device: String,
     },
     /// Tokenizer training pipeline (plan/apply) — BPE vocabulary learning
     Tokenize {

--- a/crates/aprender-train/src/train/device.rs
+++ b/crates/aprender-train/src/train/device.rs
@@ -1,0 +1,325 @@
+//! `Device` — selector for the training backend (`apr pretrain`).
+//!
+//! Contract binding: `contracts/entrenar/gpu-training-backend-v1.yaml`
+//! §device_dispatch.
+//!
+//! The string grammar accepted by `resolve_device` is fixed by
+//! INV-GPUTRAIN-001 / §device_dispatch.requested_device.grammar:
+//!
+//! ```text
+//! ^(cpu|cuda(:[0-9]|:1[0-5])?|auto)$
+//! ```
+//!
+//! - `cpu`            — force the CPU (trueno SIMD) training path.
+//! - `cuda`           — alias for `cuda:0`.
+//! - `cuda:N` (0..=15)— explicit CUDA device index.
+//! - `auto`           — `cuda:0` if `cuda_training_available()`, else `cpu`.
+//!
+//! The `auto` resolution is NOT a silent fallback: callers are obliged
+//! by GATE-GPUTRAIN-002 to print the resolved `Device` before starting
+//! training so the operator sees which backend was actually selected.
+//!
+//! Explicit `cuda` / `cuda:N` on a host without a usable CUDA runtime
+//! MUST return `DeviceError::CudaNotAvailable`. FALSIFY-GPUTRAIN-002
+//! binds this invariant.
+
+use std::fmt;
+
+use crate::autograd::cuda_training_available;
+
+/// Training backend selection.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Device {
+    /// CPU (trueno SIMD) — `TransformerTrainer`.
+    Cpu,
+    /// CUDA device `index` — `CudaTransformerTrainer`.
+    Cuda { index: u8 },
+}
+
+impl Device {
+    /// Short human-readable tag used in CLI banners and run-dir metadata.
+    #[must_use]
+    pub fn tag(&self) -> String {
+        match self {
+            Device::Cpu => "cpu".to_string(),
+            Device::Cuda { index } => format!("cuda:{index}"),
+        }
+    }
+
+    /// Is this device a CUDA device (any index)?
+    #[must_use]
+    pub fn is_cuda(&self) -> bool {
+        matches!(self, Device::Cuda { .. })
+    }
+}
+
+impl fmt::Display for Device {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.tag())
+    }
+}
+
+/// Failure modes for `resolve_device`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DeviceError {
+    /// Input string did not match
+    /// `^(cpu|cuda(:[0-9]|:1[0-5])?|auto)$`.
+    InvalidSpec(String),
+    /// Caller explicitly requested CUDA (or `auto` resolved to CUDA on a
+    /// host advertising CUDA) but `cuda_training_available()` returned
+    /// false. GATE-GPUTRAIN-002 forbids silent CPU fallback on explicit
+    /// CUDA requests — this variant IS the hard failure.
+    CudaNotAvailable { requested: String },
+}
+
+impl fmt::Display for DeviceError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DeviceError::InvalidSpec(s) => write!(
+                f,
+                "--device `{s}` does not match grammar \
+                 ^(cpu|cuda(:[0-9]|:1[0-5])?|auto)$ \
+                 (contract gpu-training-backend-v1 INV-GPUTRAIN-001)",
+            ),
+            DeviceError::CudaNotAvailable { requested } => write!(
+                f,
+                "--device `{requested}` requested but CUDA runtime is \
+                 not available on this host \
+                 (contract gpu-training-backend-v1 GATE-GPUTRAIN-002: \
+                 no silent CPU fallback). Rebuild with `--features cuda` \
+                 or pass `--device cpu` to opt in to the CPU path.",
+            ),
+        }
+    }
+}
+
+impl std::error::Error for DeviceError {}
+
+/// Resolve a CLI `--device` string into a concrete `Device`.
+///
+/// Contract: this function is THE single binding point for
+/// INV-GPUTRAIN-001 (grammar) and GATE-GPUTRAIN-002 (no silent CPU
+/// fallback on explicit CUDA request).
+///
+/// # Errors
+/// - [`DeviceError::InvalidSpec`] — `spec` is not one of `cpu`,
+///   `cuda`, `cuda:N` (0..=15), or `auto`.
+/// - [`DeviceError::CudaNotAvailable`] — `spec` explicitly asked for
+///   CUDA (or `auto` chose CUDA) but `cuda_training_available()`
+///   returned `false`.
+pub fn resolve_device(spec: &str) -> Result<Device, DeviceError> {
+    let parsed = parse_device_spec(spec).ok_or_else(|| DeviceError::InvalidSpec(spec.to_string()))?;
+
+    match parsed {
+        ParsedSpec::Cpu => Ok(Device::Cpu),
+        ParsedSpec::Cuda(index) => {
+            if cuda_training_available() {
+                Ok(Device::Cuda { index })
+            } else {
+                Err(DeviceError::CudaNotAvailable { requested: spec.to_string() })
+            }
+        }
+        ParsedSpec::Auto => {
+            if cuda_training_available() {
+                Ok(Device::Cuda { index: 0 })
+            } else {
+                Ok(Device::Cpu)
+            }
+        }
+    }
+}
+
+/// Pure-function parser: string → `ParsedSpec`. Separated from the
+/// availability probe so FALSIFY-GPUTRAIN-001 (grammar) can be
+/// exercised deterministically regardless of whether the host has CUDA.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum ParsedSpec {
+    Cpu,
+    Cuda(u8),
+    Auto,
+}
+
+fn parse_device_spec(spec: &str) -> Option<ParsedSpec> {
+    match spec {
+        "cpu" => Some(ParsedSpec::Cpu),
+        "auto" => Some(ParsedSpec::Auto),
+        "cuda" => Some(ParsedSpec::Cuda(0)),
+        other => {
+            let rest = other.strip_prefix("cuda:")?;
+            // Grammar `:[0-9]|:1[0-5]` — one digit 0-9 OR "1" then 0-5.
+            // `u8::from_str` rejects leading zeros ("cuda:01") by parsing
+            // them, but the grammar does not: "01" is NOT in
+            // `[0-9]|1[0-5]`. We therefore reject any multi-char string
+            // whose first char is `0` or whose value is outside [0, 15].
+            let idx: u8 = rest.parse().ok()?;
+            if idx > 15 {
+                return None;
+            }
+            // Reject leading-zero spellings that happen to parse
+            // (e.g. "cuda:01"). Grammar allows only 1-2 chars AND
+            // 2-char forms must start with '1'.
+            match rest.len() {
+                1 => {}
+                2 if rest.starts_with('1') => {}
+                _ => return None,
+            }
+            Some(ParsedSpec::Cuda(idx))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ─── FALSIFY-GPUTRAIN-001: grammar ──────────────────────────────────
+    //
+    // Binds contract `gpu-training-backend-v1` INV-GPUTRAIN-001. Any
+    // string that does NOT match
+    // `^(cpu|cuda(:[0-9]|:1[0-5])?|auto)$` MUST be rejected with
+    // `DeviceError::InvalidSpec`; any string that DOES match MUST parse.
+
+    #[test]
+    fn falsify_gputrain_001_accepts_cpu() {
+        assert_eq!(parse_device_spec("cpu"), Some(ParsedSpec::Cpu));
+    }
+
+    #[test]
+    fn falsify_gputrain_001_accepts_auto() {
+        assert_eq!(parse_device_spec("auto"), Some(ParsedSpec::Auto));
+    }
+
+    #[test]
+    fn falsify_gputrain_001_accepts_cuda_alias() {
+        assert_eq!(parse_device_spec("cuda"), Some(ParsedSpec::Cuda(0)));
+    }
+
+    #[test]
+    fn falsify_gputrain_001_accepts_cuda_single_digit() {
+        for i in 0..=9u8 {
+            let spec = format!("cuda:{i}");
+            assert_eq!(
+                parse_device_spec(&spec),
+                Some(ParsedSpec::Cuda(i)),
+                "grammar must accept {spec}",
+            );
+        }
+    }
+
+    #[test]
+    fn falsify_gputrain_001_accepts_cuda_10_through_15() {
+        for i in 10..=15u8 {
+            let spec = format!("cuda:{i}");
+            assert_eq!(
+                parse_device_spec(&spec),
+                Some(ParsedSpec::Cuda(i)),
+                "grammar must accept {spec}",
+            );
+        }
+    }
+
+    #[test]
+    fn falsify_gputrain_001_rejects_index_16() {
+        assert_eq!(parse_device_spec("cuda:16"), None);
+    }
+
+    #[test]
+    fn falsify_gputrain_001_rejects_index_99() {
+        assert_eq!(parse_device_spec("cuda:99"), None);
+    }
+
+    #[test]
+    fn falsify_gputrain_001_rejects_leading_zero() {
+        // Grammar allows one digit [0-9] or two chars 1[0-5]; "01"
+        // matches neither.
+        assert_eq!(parse_device_spec("cuda:01"), None);
+    }
+
+    #[test]
+    fn falsify_gputrain_001_rejects_empty_index() {
+        assert_eq!(parse_device_spec("cuda:"), None);
+    }
+
+    #[test]
+    fn falsify_gputrain_001_rejects_negative_index() {
+        assert_eq!(parse_device_spec("cuda:-1"), None);
+    }
+
+    #[test]
+    fn falsify_gputrain_001_rejects_typo() {
+        assert_eq!(parse_device_spec("gpu"), None);
+        assert_eq!(parse_device_spec("CUDA"), None);
+        assert_eq!(parse_device_spec("cudaa"), None);
+        assert_eq!(parse_device_spec(""), None);
+        assert_eq!(parse_device_spec(" cpu"), None);
+    }
+
+    #[test]
+    fn falsify_gputrain_001_resolve_wraps_invalid_as_device_error() {
+        let err = resolve_device("gpu").unwrap_err();
+        assert!(matches!(err, DeviceError::InvalidSpec(ref s) if s == "gpu"));
+    }
+
+    // ─── FALSIFY-GPUTRAIN-002: no silent CPU fallback ──────────────────
+    //
+    // Binds contract `gpu-training-backend-v1` INV-GPUTRAIN-002 /
+    // GATE-GPUTRAIN-002. Explicit `--device cuda` / `cuda:N` MUST hard-
+    // fail when the host has no CUDA runtime. `auto` is the ONLY spec
+    // allowed to fall back.
+
+    #[test]
+    fn falsify_gputrain_002_explicit_cuda_without_runtime_errors() {
+        if cuda_training_available() {
+            // On a CUDA host this branch is a positive assertion:
+            // explicit `cuda:0` must resolve successfully, and `auto`
+            // must choose CUDA (not silently downgrade).
+            assert_eq!(resolve_device("cuda:0"), Ok(Device::Cuda { index: 0 }));
+            assert_eq!(resolve_device("auto"), Ok(Device::Cuda { index: 0 }));
+        } else {
+            // On a CPU-only host:
+            // - explicit `cuda:0` MUST hard-fail (no silent fallback)
+            // - explicit `cuda` MUST hard-fail (alias for `cuda:0`)
+            // - `auto` MAY fall back to CPU (this is the documented
+            //   safe-default escape hatch)
+            let err = resolve_device("cuda:0").unwrap_err();
+            assert!(matches!(err, DeviceError::CudaNotAvailable { .. }));
+            let err = resolve_device("cuda").unwrap_err();
+            assert!(matches!(err, DeviceError::CudaNotAvailable { .. }));
+            assert_eq!(resolve_device("auto"), Ok(Device::Cpu));
+        }
+    }
+
+    #[test]
+    fn falsify_gputrain_002_cpu_always_resolves() {
+        // `--device cpu` must always return `Device::Cpu`, regardless of
+        // whether CUDA is available — it is an explicit opt-in to the
+        // CPU path (for falsification parity runs, reproducibility, or
+        // hosts without a usable GPU).
+        assert_eq!(resolve_device("cpu"), Ok(Device::Cpu));
+    }
+
+    #[test]
+    fn device_tag_round_trips() {
+        assert_eq!(Device::Cpu.tag(), "cpu");
+        assert_eq!(Device::Cuda { index: 0 }.tag(), "cuda:0");
+        assert_eq!(Device::Cuda { index: 7 }.tag(), "cuda:7");
+        assert_eq!(Device::Cuda { index: 15 }.tag(), "cuda:15");
+    }
+
+    #[test]
+    fn device_is_cuda_discriminator() {
+        assert!(!Device::Cpu.is_cuda());
+        assert!(Device::Cuda { index: 0 }.is_cuda());
+    }
+
+    #[test]
+    fn device_error_display_mentions_contract() {
+        let invalid = DeviceError::InvalidSpec("bogus".into()).to_string();
+        assert!(invalid.contains("INV-GPUTRAIN-001"));
+        assert!(invalid.contains("bogus"));
+        let unavail =
+            DeviceError::CudaNotAvailable { requested: "cuda:0".into() }.to_string();
+        assert!(unavail.contains("GATE-GPUTRAIN-002"));
+        assert!(unavail.contains("cuda:0"));
+    }
+}

--- a/crates/aprender-train/src/train/mod.rs
+++ b/crates/aprender-train/src/train/mod.rs
@@ -33,6 +33,7 @@ mod batch;
 pub mod callback;
 mod config;
 mod curriculum;
+pub mod device;
 mod loss;
 mod metrics;
 pub mod pretrain;
@@ -52,6 +53,7 @@ pub use callback::{
     MonitorCallback, ProgressCallback, TrainerCallback,
 };
 pub use config::{MetricsTracker, TrainConfig};
+pub use device::{resolve_device, Device, DeviceError};
 pub use curriculum::{
     efficiency_score, select_optimal_tier, AdaptiveCurriculum, CurriculumScheduler,
     LinearCurriculum, TieredCurriculum,


### PR DESCRIPTION
## Summary

Phase 1 of task #132 (CUDA training backend gap). Builds on Phase 0 (PR #989, merged).

- Add `Device` enum (`Cpu` / `Cuda { index: u8 }`) + `DeviceError` + `resolve_device()` in `crates/aprender-train/src/train/device.rs`
- Wire `--device <spec>` flag into `apr pretrain` (default `auto`)
- Emit explicit `NotImplemented` error when CUDA resolves, so no silent CPU fallback (GATE-GPUTRAIN-002)
- Flip contract `gpu-training-backend-v1.yaml` phase 1 → complete; rescope phase 2 to wire real CUDA dispatch
- FALSIFY-GPUTRAIN-001 grammar coverage via 17 device unit tests + 3 new CLI tests

## What Phase 1 does NOT ship

- Real CUDA training dispatch — Phase 2 (~2 days), replaces the `drive_real` NotImplemented stub with `CudaTransformerTrainer`
- nvidia-smi residency probe (GATE-GPUTRAIN-003) — Phase 2
- Lambda-labs RTX 4090 evidence — Phase 3
- Contract PROPOSED → ACTIVE promotion — Phase 4

## Test plan

- [x] `cargo test -p aprender-train --lib train::device::` → 17/17 PASS
- [x] `cargo test -p apr-cli --lib pretrain::` → 14/14 PASS (3 new)
- [x] `cargo build --workspace` clean
- [x] `cargo clippy -p aprender-train -p apr-cli --lib` no new warnings
- [x] `pv validate contracts/entrenar/gpu-training-backend-v1.yaml` 0/0
- [ ] CI `gate` + `workspace-test` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)