### PR TITLE
chore(task-132): document Phase 2 CudaTransformerTrainer API prerequisites

### DIFF
--- a/contracts/entrenar/gpu-training-backend-v1.yaml
+++ b/contracts/entrenar/gpu-training-backend-v1.yaml
@@ -401,6 +401,20 @@ implementation_plan:
   phase_2:
     title: "Wire existing CudaTransformerTrainer"
     status: pending
+    prerequisites:
+      # Phase 2 design-surface audit (2026-04-21): CudaTransformerTrainer
+      # HAS train_batch() + save_apr() + model()/model_mut(), but is
+      # MISSING two methods the existing CPU adapter chain relies on:
+      #   1. forward_single(inp: &[u32], tgt: &[u32]) -> (f32, Tensor, Tensor)
+      #      — required by RealValFn::validate() for held-out forward-only
+      #        loss (INV-TRAIN-004).
+      #   2. optimizer_state_sha256() -> String
+      #      — required by StepFn::optimizer_state_sha256() override
+      #        (INV-TRAIN-003 reproducibility discharge).
+      # These MUST land on CudaTransformerTrainer before the Cuda* adapters
+      # can discharge the same invariants as their CPU counterparts.
+      - "Add CudaTransformerTrainer::forward_single (forward-only held-out eval; signature matches TransformerTrainer::forward_single)"
+      - "Add CudaTransformerTrainer::optimizer_state_sha256 (hash AdamW (t, m, v) buffers after D2H copy)"
     deliverables:
       - "Replace Phase 1 drive_real NotImplemented stub with SharedTrainer::CudaVariant dispatch (extend pretrain_real.rs with CudaRealStepFn / CudaRealValFn / CudaAprCheckpointFn)"
       - "drive_real branches on Device in pretrain.rs (mirror loader/mod.rs:227)"


### PR DESCRIPTION
## Summary
- Phase 2 design-surface audit surfaced two missing methods on `CudaTransformerTrainer` that the CPU adapter chain relies on
- Records them as `phase_2.prerequisites` in `contracts/entrenar/gpu-training-backend-v1.yaml` so the scope is honest + machine-readable
- No Rust change — pure contract amendment; parallel + safe alongside PR #990 (Phase 1) and PR #991 (roadmap schema fix)

## Discovered Prerequisites

Phase 2 cannot dispatch until `CudaTransformerTrainer` grows:

1. **`forward_single(inp: &[u32], tgt: &[u32]) -> (f32, Tensor, Tensor)`**
   — required by `RealValFn::validate()` for held-out forward-only loss (INV-TRAIN-004)

2. **`optimizer_state_sha256() -> String`**
   — required by `StepFn::optimizer_state_sha256()` override (INV-TRAIN-003 reproducibility discharge)

Both ship on `TransformerTrainer` (CPU) today. The Cuda variant must match.

## Verification
- `pv validate contracts/entrenar/gpu-training-backend-v1.yaml` → 0 errors, 0 warnings
- PMAT pre-commit quality gates: all pass

## Test plan
- [x] `pv validate` on the amended contract
- [x] PMAT pre-commit gates
- [ ] `ci / gate` green
- [ ] `workspace-test` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)