### PR TITLE
fix(task-133): widen QA-018 batch_scaling flake threshold 100→1000

### DIFF
--- a/crates/aprender-serve/src/layers/tests/qa_perf_tests.rs
+++ b/crates/aprender-serve/src/layers/tests/qa_perf_tests.rs
@@ -212,9 +212,12 @@ fn test_qa_018_batch_scaling() {
     // Batch=8 processing 8x data - allow high variance under coverage
     let ratio = batch_time.as_secs_f64() / single_time.as_secs_f64();
 
-    // Just verify ratio is reasonable (not infinite or negative)
+    // Sanity check: ratio must be finite and positive. The 1000x upper bound
+    // catches infinity / NaN / catastrophic batch regressions while
+    // tolerating CI-runner scheduling noise (microsecond-scale measurements
+    // on 128-dim LayerNorm can spike to 100+x under load — task #133).
     assert!(
-        ratio > 0.0 && ratio < 100.0,
+        ratio > 0.0 && ratio < 1000.0,
         "QA-018: Batch=8 ratio ({:.2}x) should be in reasonable bounds",
         ratio
     );


### PR DESCRIPTION
## Summary
- CI run [24720679600](https://github.com/paiml/aprender/actions/runs/24720679600) on PR #991 failed with \`ratio=114.27x\`, just above the 100x threshold in \`test_qa_018_batch_scaling\`
- The test's stated goal is "verify ratio is reasonable (not infinite or negative)" — a sanity check, not a throughput gate
- Widening 100x → 1000x preserves the infinity/NaN/catastrophic-regression bound while tolerating CI noise on microsecond-scale measurements
- Unrelated to PR #991 or #990 content (both pure scaffolding/schema changes)
- Same class as #129 (\`test_mmap_writer_no_blocking\`) and #130 (\`test_imp_005_batch_prefill\`)

## Policy Compliance
- NOT \`#[ignore]\`'d (feedback memory: "#[ignore] banned for flakes", 2026-04-18)
- Threshold widened, not removed — still catches catastrophic regressions

## Verification
\`\`\`
cargo test -p aprender-serve --lib test_qa_018_batch_scaling
→ 1 passed in 0.01s
\`\`\`

## Test plan
- [x] Local: passes
- [ ] \`ci / gate\` green
- [ ] \`workspace-test\` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)