### PR TITLE
fix(task-134): per-PR target dir + drop CARGO_INCREMENTAL (CI root cause)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,11 +47,20 @@ jobs:
       image: localhost:5000/sovereign-ci:stable
       volumes:
         - /home/noah/.cargo/registry:/usr/local/cargo/registry
-        - /mnt/nvme-raid0/targets/aprender-ci:/workspace/target
+        # Per-PR (or per-branch) target dir. Before task #134, ALL concurrent PRs
+        # bind-mounted the same /workspace/target and stomped each other's
+        # incremental cache, pushing every run to the 45-min timeout. Isolating
+        # the target dir per PR number removes the contention at the source.
+        # Push-to-main uses ref_name ("main"); PRs use PR number.
+        - /mnt/nvme-raid0/targets/aprender-ci/${{ github.event.pull_request.number || github.ref_name }}:/workspace/target
     timeout-minutes: 45
     env:
       CARGO_TARGET_DIR: /workspace/target
-      CARGO_INCREMENTAL: 1
+      # CARGO_INCREMENTAL intentionally disabled in CI: incremental compilation
+      # tracks per-function dirty state for dev-loop speed, but on PR-scale
+      # diffs that touch many files the overhead outweighs savings, and the
+      # state file is a further contention point under parallelism.
+      CARGO_INCREMENTAL: 0
     steps:
       - uses: actions/checkout@v4
       - name: Workspace check (all 70 crates)


### PR DESCRIPTION
## Summary

Root-cause fix for the workspace-test 45-min timeouts. Previously I submitted #993 to widen one flaky test's threshold — that fix is valid and still needed (QA-018 passed on #993), but the _actual_ reason jobs were being killed is shared target-dir contention across concurrent PRs.

## Root cause

Every workspace-test container bind-mounts the **same** path:
```yaml
- /mnt/nvme-raid0/targets/aprender-ci:/workspace/target
```

With 6–7 PRs running workspace-test concurrently, all their cargo processes write to overlapping compilation units. `CARGO_INCREMENTAL=1` on a shared writable cache is actively harmful — each PR invalidates sibling PRs' incremental state, so cargo keeps rebuilding what another run just touched. That's what pushes a job that takes 43m41s on `main` in isolation past the 45-min cap under load.

### Evidence from PR #993 (run 24722612204)

| Time | Event |
|------|-------|
| 13:08:29 | QA-018 test passed (task #133 threshold fix held) |
| 13:18:08 | 3497/3497 compute tests passed |
| 13:20:31 | First integration test passed |
| 13:22:26 | Job cancelled — 45-min cap hit mid-integration-tests |

Individual tests weren't slow. The whole workspace rebuilding itself repeatedly was.

## Fix (one file, ~10 lines)

```diff
-        - /mnt/nvme-raid0/targets/aprender-ci:/workspace/target
+        - /mnt/nvme-raid0/targets/aprender-ci/${{ github.event.pull_request.number || github.ref_name }}:/workspace/target
     timeout-minutes: 45
     env:
       CARGO_TARGET_DIR: /workspace/target
-      CARGO_INCREMENTAL: 1
+      CARGO_INCREMENTAL: 0
```

1. Per-PR target dir — PRs use their number, push-to-main uses `main`. Zero cross-PR contention.
2. `CARGO_INCREMENTAL=0` — incremental is a dev-loop optimization; on PR-scale diffs it's overhead, and the state file is another contention point.

## Why not raise the timeout

My first instinct was to bump 45 → 60 min. User correctly rejected that: "45 per pull request is insane". The timeout isn't the problem — concurrent cache corruption is. Fixing the cause makes runs _faster_, not require more headroom.

## Not in this PR (follow-ups)

- Re-enable sccache once paiml/.github ships the missing `rustc-sccache` wrapper (ci.yml:34-39 already tracks this).
- Periodic cleanup of `/mnt/nvme-raid0/targets/aprender-ci/<pr-number>` dirs for closed PRs.
- Optional: shard workspace-test into parallel jobs by crate group for further wall-time reduction.

## Test plan

- [ ] Merge this first — unblocks every other PR's workspace-test.
- [ ] Rebase #993 (QA-018 fix), #990/#991/#992 (task #132 Phase 1+2) onto main.
- [ ] Confirm next workspace-test run completes well under 45 min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)