### PR TITLE
fix(task-135): serialize workspace-test via repo-wide concurrency group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,15 @@ jobs:
   # APR-MONO: Workspace-wide test (all 75 crates)
   workspace-test:
     runs-on: [self-hosted, X64, Linux]
+    # Repo-wide serialization. #994's per-PR target dir removed cache stomping,
+    # but 3 PRs × 70 cold crates still saturated the self-hosted runner's CPU
+    # and all three timed out at 45min simultaneously. Serializing this one
+    # job (not the whole workflow — ci/gate/lint still run in parallel) trades
+    # backlog latency for reliable cold-compile completion. `cancel-in-progress:
+    # false` means queued runs wait instead of being dropped.
+    concurrency:
+      group: workspace-test-serial
+      cancel-in-progress: false
     container:
       image: localhost:5000/sovereign-ci:stable
       volumes:


### PR DESCRIPTION
## Summary
- #994's per-PR target dir fix eliminated cache contention, but shifted the bottleneck to self-hosted runner CPU
- Three PRs (#991, #992, #993) with cold 70-crate compiles timed out at 45m25s **simultaneously** — classic parallel-load thrash
- Fix: job-level concurrency group `workspace-test-serial` with `cancel-in-progress: false` so only one cold compile runs at a time across the whole repo
- Other jobs (`ci`, `gate`, `lint`, `test`) keep per-PR concurrency and still run in parallel — only the heavy workspace-test serializes

## Root cause timeline
1. Pre-#994: shared `/workspace/target`, concurrent PRs stomped incremental cache → 45m timeouts from contention
2. Post-#994: per-PR target dirs eliminated stomping, but 3 parallel cold compiles (70 crates × 3 = ~210 cargo jobs) saturated runner CPU → 45m timeouts from thrash
3. This PR: serialize the workspace-test job itself → one cold compile at a time → reliable completion

## Tradeoff
Backlog latency goes up when multiple PRs queue (3 queued = ~60-90min e2e), but each individual run actually completes instead of timing out. For the heaviest job in CI, reliability > throughput.

## Test plan
- [x] `cargo fmt --check`
- [ ] Watch this PR's own workspace-test complete (it's the first under serialization)
- [ ] Confirm #991/#992/#993 complete sequentially after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)