### PR TITLE
feat(task-132): Phase 2 — wire CUDA dispatch into apr pretrain

### DIFF
--- a/crates/apr-cli/src/commands/pretrain.rs
+++ b/crates/apr-cli/src/commands/pretrain.rs
@@ -241,9 +241,13 @@ fn preflight_tokenizer_vocab_matches_model(tokenizer_dir: &Path) -> Result<()> {
         .map_err(CliError::ValidationFailed)
 }
 
-/// Real-corpus drive: build a shared 370M `TransformerTrainer`, split
+/// Real-corpus drive: build a shared 370M trainer (CPU or CUDA), split
 /// the shard stream head-off into a held-out validation set, and run a
 /// full forward + backward + AdamW step per training batch.
+///
+/// When `device.is_cuda()`, the `cuda` feature must be compiled in —
+/// otherwise this surfaces a clear error rather than silently falling
+/// back to CPU (GATE-GPUTRAIN-002, contract gpu-training-backend-v1).
 #[allow(clippy::too_many_arguments)]
 fn drive_real(
     config: PretrainConfig,
@@ -255,23 +259,6 @@ fn drive_real(
     device: Device,
     json_output: bool,
 ) -> Result<RunStatus> {
-    // Phase 1 stub (contract gpu-training-backend-v1 §implementation_plan
-    // phase 1 / peer_contracts apr-cli-commands-v1): CLI surface accepts
-    // `--device cuda[:N]` and resolves it, but the CUDA training path is
-    // not yet wired — Phase 2 will extend `SharedTrainer` to dispatch to
-    // `CudaTransformerTrainer`. Until then, any resolved CUDA device
-    // must surface a clear NotImplemented error rather than silently
-    // using the CPU path (GATE-GPUTRAIN-002).
-    if device.is_cuda() {
-        return Err(CliError::ValidationFailed(format!(
-            "--device {device} resolved, but the CUDA training backend \
-             is not yet wired in `apr pretrain` (contract \
-             gpu-training-backend-v1 phase 2 pending, task #132). \
-             Pass `--device cpu` to opt in to the CPU path, or wait for \
-             Phase 2 to land.",
-        )));
-    }
-
     // GATE-ARCH-370M-011 / INV-ARCH-370M-006 — refuse to dispatch a real
     // training step when the tokenizer vocab_size and the model vocab_size
     // disagree. The N-09 OOB escape guard in Embedding::forward masks the
@@ -306,16 +293,102 @@ fn drive_real(
         )));
     }
 
+    if device.is_cuda() {
+        drive_real_cuda(config, iter, held_out, lr, seq_length, seed, json_output)
+    } else {
+        drive_real_cpu(config, iter, held_out, lr, seq_length, seed, json_output)
+    }
+}
+
+/// CPU backend for `drive_real` — builds a `TransformerTrainer`
+/// (`aprender::Tensor` + trueno SIMD) and wires `RealStepFn` /
+/// `RealValFn` / `AprCheckpointFn`.
+#[allow(clippy::too_many_arguments)]
+fn drive_real_cpu(
+    config: PretrainConfig,
+    iter: entrenar::train::shard_reader::ShardBatchIter,
+    held_out: Vec<LMBatch>,
+    lr: f32,
+    seq_length: usize,
+    seed: u64,
+    json_output: bool,
+) -> Result<RunStatus> {
     let trainer = build_shared_trainer(lr, seq_length, seed);
     let step_fn = RealStepFn::new(trainer.clone(), Box::new(iter));
     let val_fn = RealValFn::new(trainer.clone(), held_out);
-    // Task #111 step 7: per-epoch APR checkpoint on GATE-TRAIN-005 pass.
     let ckpt: Box<dyn CheckpointFn> = Box::new(AprCheckpointFn::new(
         trainer,
         "llama-370m-pretrain",
         "LlamaForCausalLM",
     ));
     run_and_report(config, step_fn, val_fn, Some(ckpt), json_output)
+}
+
+/// CUDA backend for `drive_real` — builds a `CudaTransformerTrainer`
+/// and wires `CudaRealStepFn` / `CudaRealValFn` / `CudaAprCheckpointFn`
+/// (task #132 Phase 2, contract gpu-training-backend-v1).
+///
+/// When the `cuda` feature is NOT compiled in, this returns a clear
+/// build-time error so operators who asked for `--device cuda` do not
+/// silently get the CPU path (GATE-GPUTRAIN-002 / FM-GPUTRAIN-SILENT-CPU).
+#[cfg(feature = "cuda")]
+#[allow(clippy::too_many_arguments)]
+fn drive_real_cuda(
+    config: PretrainConfig,
+    iter: entrenar::train::shard_reader::ShardBatchIter,
+    held_out: Vec<LMBatch>,
+    lr: f32,
+    seq_length: usize,
+    seed: u64,
+    json_output: bool,
+) -> Result<RunStatus> {
+    use entrenar::train::pretrain_real_cuda::{
+        build_shared_cuda_trainer, CudaAprCheckpointFn, CudaRealStepFn, CudaRealValFn,
+    };
+    let trainer = build_shared_cuda_trainer(lr, seq_length, seed).map_err(|e| {
+        CliError::ValidationFailed(format!(
+            "GATE-GPUTRAIN-002: CUDA trainer allocation failed: {e}. \
+             See contracts/entrenar/gpu-training-backend-v1.yaml and \
+             memory/feedback_cuda_feature_footgun.md — this path is \
+             only reachable when the binary was built with `--features cuda`.",
+        ))
+    })?;
+    let step_fn = CudaRealStepFn::new(trainer.clone(), Box::new(iter));
+    let val_fn = CudaRealValFn::new(trainer.clone(), held_out);
+    let ckpt: Box<dyn CheckpointFn> = Box::new(CudaAprCheckpointFn::new(
+        trainer,
+        "llama-370m-pretrain",
+        "LlamaForCausalLM",
+    ));
+    run_and_report(config, step_fn, val_fn, Some(ckpt), json_output)
+}
+
+/// CUDA backend stub when the `cuda` feature is NOT compiled in.
+///
+/// This is the load-bearing gate that prevents FM-GPUTRAIN-SILENT-CPU:
+/// if a user passes `--device cuda` on an apr binary built without
+/// CUDA support, they see a clear "rebuild with --features cuda" error
+/// rather than a 14-minute CPU run masquerading as GPU training
+/// (task #132 lambda-labs incident, 2026-04-21).
+#[cfg(not(feature = "cuda"))]
+#[allow(clippy::too_many_arguments)]
+fn drive_real_cuda(
+    _config: PretrainConfig,
+    _iter: entrenar::train::shard_reader::ShardBatchIter,
+    _held_out: Vec<LMBatch>,
+    _lr: f32,
+    _seq_length: usize,
+    _seed: u64,
+    _json_output: bool,
+) -> Result<RunStatus> {
+    Err(CliError::ValidationFailed(
+        "GATE-GPUTRAIN-002: --device cuda was requested but this `apr` \
+         binary was built WITHOUT the `cuda` feature. \
+         Rebuild with `cargo build --release --features cuda` or use \
+         `--device cpu`. See memory/feedback_cuda_feature_footgun.md \
+         (contract gpu-training-backend-v1 / task #132 Phase 2)."
+            .into(),
+    ))
 }
 
 /// Shared helper: construct the `PretrainLoop`, run it, print the

--- a/crates/aprender-train/src/train/mod.rs
+++ b/crates/aprender-train/src/train/mod.rs
@@ -38,6 +38,8 @@ mod loss;
 mod metrics;
 pub mod pretrain;
 pub mod pretrain_real;
+#[cfg(feature = "cuda")]
+pub mod pretrain_real_cuda;
 pub mod shard_reader;
 mod trainer;
 pub mod transformer_trainer;
@@ -53,11 +55,11 @@ pub use callback::{
     MonitorCallback, ProgressCallback, TrainerCallback,
 };
 pub use config::{MetricsTracker, TrainConfig};
-pub use device::{resolve_device, Device, DeviceError};
 pub use curriculum::{
     efficiency_score, select_optimal_tier, AdaptiveCurriculum, CurriculumScheduler,
     LinearCurriculum, TieredCurriculum,
 };
+pub use device::{resolve_device, Device, DeviceError};
 pub use loss::{
     BCEWithLogitsLoss, CausalLMLoss, CrossEntropyLoss, HuberLoss, L1Loss, LossFn, MSELoss,
     SampleWeightedLoss, SmoothL1Loss, WeightedLoss,

--- a/crates/aprender-train/src/train/pretrain_real_cuda.rs
+++ b/crates/aprender-train/src/train/pretrain_real_cuda.rs
@@ -1,0 +1,169 @@
+//! CUDA-backend `StepFn` / `ValFn` / `CheckpointFn` for the 370M pretrain
+//! loop (task #132 Phase 2, contract `gpu-training-backend-v1`).
+//!
+//! Mirrors `pretrain_real.rs` but swaps `TransformerTrainer`
+//! (CPU + trueno SIMD) for `CudaTransformerTrainer` (GPU-resident
+//! AdamW + fused CE). The entire module is gated on
+//! `#[cfg(feature = "cuda")]` because `CudaTransformerTrainer::new`
+//! / `train_batch` / `eval_batch` / `save_apr` only exist in the
+//! cuda build — the non-cuda stub returns an error from `new()` and
+//! exposes no step/eval/save methods.
+//!
+//! Contract obligations discharged / strengthened vs the CPU path:
+//! - INV-ARCH-370M-001 (param count ∈ [366M, 374M]) via `debug_assert`
+//!   on `CudaTransformerTrainer::model().parameters()`, matching
+//!   the CPU guard.
+//! - INV-TRAIN-007 (no NaN/Inf): `train_batch` / `eval_batch` return
+//!   finite loss by construction; non-finite outputs abort via
+//!   `PretrainLoop`'s guards.
+//! - INV-TRAIN-008 (grad_norm ≥ 0): `last_grad_norm()` returns the
+//!   real LM-head L2 norm. Strictly stronger than the CPU path's
+//!   `1.0` placeholder.
+//!
+//! Deferred to a follow-up:
+//! - INV-TRAIN-003 (AdamW-state sha256). `CudaTransformerTrainer`
+//!   keeps (m, v, t) on the GPU; discharging this cleanly needs a
+//!   D2H sync that `save_apr` already pays for but `StepFn` does
+//!   not want to pay per-step. Until that sync is factored out,
+//!   the trait default `optimizer_state_sha256 -> None` is used,
+//!   and GATE-TRAIN-006 runs only on the CPU path.
+
+#![cfg(feature = "cuda")]
+
+use crate::train::pretrain::{CheckpointFn, EpochArtifact, StepFn, ValFn};
+use crate::train::pretrain_real::llama_370m_train_config;
+use crate::train::transformer_trainer::{CudaTransformerTrainer, LMBatch};
+use std::cell::RefCell;
+use std::rc::Rc;
+
+/// Shared mutable ownership of a GPU-resident trainer. Both
+/// `CudaRealStepFn` (train steps) and `CudaRealValFn` (eval) clone
+/// this `Rc` so the three hooks see the same GPU memory.
+pub type SharedCudaTrainer = Rc<RefCell<CudaTransformerTrainer>>;
+
+/// Allocate a `CudaTransformerTrainer` with MODEL-2 v2-remedy defaults
+/// and verify INV-ARCH-370M-001 in debug builds.
+///
+/// Returns a `crate::Result` because `CudaTransformerTrainer::new`
+/// can fail on missing CUDA runtime, kernel pre-warm failure, or
+/// block upload failure — the CLI surfaces this as a
+/// GATE-GPUTRAIN-002 error so the operator knows to check their
+/// `--features cuda` build or their GPU.
+pub fn build_shared_cuda_trainer(
+    lr: f32,
+    seq_length: usize,
+    seed: u64,
+) -> crate::Result<SharedCudaTrainer> {
+    let cfg = llama_370m_train_config(lr, seq_length, seed);
+    let trainer = CudaTransformerTrainer::new(cfg)?;
+    #[cfg(debug_assertions)]
+    {
+        let param_count: usize = trainer.model().parameters().iter().map(|t| t.len()).sum();
+        debug_assert!(
+            (366_000_000..=374_000_000).contains(&param_count),
+            "INV-ARCH-370M-001: parameter count {param_count} outside [366M, 374M] band",
+        );
+    }
+    Ok(Rc::new(RefCell::new(trainer)))
+}
+
+/// CUDA `StepFn` — pulls one `LMBatch` from the shard iterator and
+/// runs a real GPU forward + backward + AdamW step.
+pub struct CudaRealStepFn {
+    trainer: SharedCudaTrainer,
+    batches: Box<dyn Iterator<Item = LMBatch>>,
+}
+
+impl CudaRealStepFn {
+    pub fn new(trainer: SharedCudaTrainer, batches: Box<dyn Iterator<Item = LMBatch>>) -> Self {
+        Self { trainer, batches }
+    }
+}
+
+impl StepFn for CudaRealStepFn {
+    fn step(&mut self, _step: u64, _lr: f32, _batch_tokens: u64) -> (f32, f32) {
+        // Exhausted shard stream: emit a finite placeholder so the
+        // NaN/Inf guard (INV-TRAIN-007) doesn't mis-fire and the
+        // divergence guard (GATE-TRAIN-005) correctly does not abort.
+        let Some(batch) = self.batches.next() else {
+            return (1.0, 1.0);
+        };
+        let mut trainer = self.trainer.borrow_mut();
+        let loss = trainer.train_batch(&batch);
+        // Real LM-head L2 norm — strictly more informative than the
+        // CPU path's `1.0` placeholder for GATE-TRAIN-008 monitoring.
+        let grad_norm = trainer.last_grad_norm();
+        (loss, grad_norm)
+    }
+
+    // INV-TRAIN-003 intentionally deferred for the GPU path — see
+    // module docs. Uses trait default `-> None`, so the CPU gate
+    // (`--device cpu`) is the one that exercises AdamW-state parity.
+}
+
+/// CUDA `ValFn` — forward-only eval across pre-loaded held-out
+/// batches. Uses `eval_batch` (fused GPU cross-entropy, no logits
+/// D2H) and averages across batches.
+pub struct CudaRealValFn {
+    trainer: SharedCudaTrainer,
+    held_out: Vec<LMBatch>,
+}
+
+impl CudaRealValFn {
+    pub fn new(trainer: SharedCudaTrainer, held_out: Vec<LMBatch>) -> Self {
+        Self { trainer, held_out }
+    }
+}
+
+impl ValFn for CudaRealValFn {
+    fn validate(&mut self, _epoch: usize) -> f32 {
+        if self.held_out.is_empty() {
+            return f32::NAN;
+        }
+        let mut trainer = self.trainer.borrow_mut();
+        let mut total_loss = 0.0_f32;
+        let mut count = 0_usize;
+        for batch in &self.held_out {
+            if batch.batch_size == 0 {
+                continue;
+            }
+            total_loss += trainer.eval_batch(batch);
+            count += 1;
+        }
+        if count == 0 {
+            f32::NAN
+        } else {
+            total_loss / count as f32
+        }
+    }
+}
+
+/// CUDA `CheckpointFn` — writes the 370M weights to
+/// `artifact.checkpoint_path` in APR format. `save_apr` takes
+/// `&mut self` on the CUDA path because it syncs GPU→CPU before
+/// writing, which is why this holds the `SharedCudaTrainer` instead
+/// of cloning the trainer out.
+pub struct CudaAprCheckpointFn {
+    trainer: SharedCudaTrainer,
+    model_name: String,
+    architecture: String,
+}
+
+impl CudaAprCheckpointFn {
+    pub fn new(
+        trainer: SharedCudaTrainer,
+        model_name: impl Into<String>,
+        architecture: impl Into<String>,
+    ) -> Self {
+        Self { trainer, model_name: model_name.into(), architecture: architecture.into() }
+    }
+}
+
+impl CheckpointFn for CudaAprCheckpointFn {
+    fn save(&mut self, _epoch: usize, artifact: &EpochArtifact) -> Result<(), String> {
+        let mut trainer = self.trainer.borrow_mut();
+        trainer
+            .save_apr(&artifact.checkpoint_path, &self.model_name, &self.architecture)
+            .map_err(|e| format!("save_apr (cuda) failed: {e}"))
+    }
+}


### PR DESCRIPTION
## Summary

Phase 2 of [task #132](https://github.com/paiml/aprender/issues/132) / contract [`gpu-training-backend-v1`](contracts/entrenar/gpu-training-backend-v1.yaml): replace the Phase 1 `NotImplemented` stub in `apr pretrain`'s `drive_real` with a real `CudaTransformerTrainer` dispatch so `--device cuda` actually trains on GPU.

Unblocks task #126 (lambda-labs MODEL-2 from-scratch pretrain, currently 14 min CPU-only with 0 MiB GPU).

## Changes

- **New `entrenar::train::pretrain_real_cuda`** (feature-gated on `cuda`):
  - `CudaRealStepFn` / `CudaRealValFn` / `CudaAprCheckpointFn` — mirror the CPU trio but dispatch through `CudaTransformerTrainer::{train_batch, eval_batch, save_apr}`.
  - `build_shared_cuda_trainer(lr, seq_length, seed)` — returns `crate::Result<SharedCudaTrainer>`; verifies INV-ARCH-370M-001 param-count band in debug builds (same guard as the CPU path).
- **`apr-cli drive_real` refactor**: dispatcher now branches on `Device::is_cuda()` into `drive_real_cpu` / `drive_real_cuda`.
  - `#[cfg(feature = "cuda")] drive_real_cuda`: real wiring.
  - `#[cfg(not(feature = "cuda"))] drive_real_cuda`: surfaces a clear GATE-GPUTRAIN-002 / FM-GPUTRAIN-SILENT-CPU error instructing the operator to rebuild with `--features cuda` — **no silent CPU fallback**.

## Contract obligations

Strengthened vs CPU:
- **INV-TRAIN-008** (grad_norm ≥ 0): GPU path reports the real LM-head L2 norm via `last_grad_norm()` (CPU path still uses the `1.0` placeholder).

Deferred (follow-up):
- **INV-TRAIN-003** (AdamW-state sha256): GPU path uses trait default `-> None`; GATE-TRAIN-006 runs on CPU only until per-step D2H sync is factored out of `save_apr`.
- **GATE-GPUTRAIN-003** (`nvidia-smi` residency probe): lands in a follow-up PR on a host with a NVIDIA toolchain.

## Test plan

Local (this sandbox has no NVIDIA runtime, so only the non-cuda paths were exercised):

- [x] `cargo fmt --check -p apr-cli -p aprender-train`
- [x] `cargo check -p aprender-train -p apr-cli` (non-cuda)
- [x] `cargo test -p aprender-train --lib pretrain_real` → 3/3 pass
- [x] Non-cuda `drive_real_cuda` stub compiles and returns the GATE-GPUTRAIN-002 error.

CI / follow-up:

- [ ] `workspace-test` (self-hosted runner with `cuda` feature exercised)
- [ ] `ci / gate` green
- [ ] Follow-up PR: GATE-GPUTRAIN-003 `nvidia-smi` residency harness
- [ ] Follow-up: lambda-labs redispatch of task #126 with `--device cuda:0` + residency proof

🤖 Generated with [Claude Code](https://claude.com/claude-code)