### PR TITLE
chore(infra): self-hosted runner disk-guard automation

### DIFF
--- a/scripts/runner-infra/README.md
+++ b/scripts/runner-infra/README.md
@@ -1,0 +1,72 @@
+# Self-hosted runner disk-guard infra
+
+Automation preventing the `/` = 100% full class of failure that took 16 runners
+offline on 2026-04-22. Two layers:
+
+1. **Per-job pre-hook** (`runner-pre-job.sh`) — runs via
+   `ACTIONS_RUNNER_HOOK_JOB_STARTED`. Checks disk; if usage ≥ 85%, aggressively
+   prunes `_work/*/target/` before the job starts. Also chowns any root-owned
+   leftovers from prior container builds.
+
+2. **Nightly safety net** (`runner-disk-guard.service` + `.timer`) — at 04:00
+   local daily, prunes any `_work/*/target/` that hasn't been modified in 7+
+   days, regardless of disk usage.
+
+## Installation
+
+```bash
+host=intel  # or whichever runner host
+scp scripts/runner-infra/{runner-disk-guard.sh,runner-pre-job.sh,runner-disk-guard.service,runner-disk-guard.timer} "$host:/tmp/"
+ssh "$host" '
+  sudo install -m 0755 /tmp/runner-disk-guard.sh /usr/local/bin/runner-disk-guard.sh &&
+  sudo install -m 0755 /tmp/runner-pre-job.sh    /usr/local/bin/runner-pre-job.sh &&
+  sudo install -m 0644 /tmp/runner-disk-guard.service /etc/systemd/system/ &&
+  sudo install -m 0644 /tmp/runner-disk-guard.timer   /etc/systemd/system/ &&
+  sudo systemctl daemon-reload &&
+  sudo systemctl enable --now runner-disk-guard.timer
+'
+```
+
+Each runner's `.env` must point to the pre-job hook:
+
+```
+ACTIONS_RUNNER_HOOK_JOB_STARTED=/usr/local/bin/runner-pre-job.sh
+```
+
+(Already wired on intel's 16 clean-room runners as of 2026-04-22.)
+
+## Tuning
+
+Environment variables honored by `runner-disk-guard.sh`:
+
+| Var | Default | Meaning |
+|---|---|---|
+| `HIGH_WATER_PCT` | 85 | Pre-job prune threshold |
+| `STALE_DAYS` | 7 | Nightly: mtime age cutoff for target/ |
+| `RUNNERS_ROOT` | `/home/noah/data` | Parent of `actions-runner*` dirs |
+
+## Manual recovery
+
+If `/` goes 100% full before the guard can run:
+
+```bash
+ssh intel 'for svc in actions.runner.paiml.intel-clean-room.service \
+                       actions.runner.paiml.intel-clean-room-{2..16}.service; do
+  sudo systemctl stop "$svc"
+done
+sudo bash -c "for i in \"\" 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16; do
+  rm -rf /home/noah/data/actions-runner\${i:+-}\${i}/_work
+done"
+for svc in actions.runner.paiml.intel-clean-room.service \
+           actions.runner.paiml.intel-clean-room-{2..16}.service; do
+  sudo systemctl start "$svc"
+done'
+```
+
+## Why `target/` and not the whole `_work/`
+
+`target/` is the Rust build directory — by far the biggest consumer (70–110 GB
+per runner). It is fully reproducible from source. The rest of `_work/`
+(checkouts, `_tool`, `_actions`) is small (~1 GB total). Leaving checkouts
+intact lets GitHub's fetch-only diff pull work instead of a fresh clone per
+job.

--- a/scripts/runner-infra/runner-disk-guard.service
+++ b/scripts/runner-infra/runner-disk-guard.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=GitHub Actions runner disk guard (nightly target/ prune)
+After=network.target
+
+[Service]
+Type=oneshot
+User=noah
+Group=noah
+ExecStart=/usr/local/bin/runner-disk-guard.sh --nightly
+Nice=10
+IOSchedulingClass=idle

--- a/scripts/runner-infra/runner-disk-guard.sh
+++ b/scripts/runner-infra/runner-disk-guard.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Self-hosted GitHub Actions runner disk guard.
+# Two modes:
+#   --pre-job        Called from ACTIONS_RUNNER_HOOK_JOB_STARTED. Only acts when
+#                    disk usage on / exceeds HIGH_WATER_PCT (default 85).
+#   --nightly        Called from systemd timer. Unconditional prune of idle
+#                    target/ dirs older than STALE_DAYS (default 7) across all
+#                    /home/noah/data/actions-runner*/_work trees.
+#
+# Safe by design: only touches target/, .rustup/tmp, .cache/cargo/registry/cache,
+# and _tool. Never the repo checkout itself. Exits 0 even if nothing to prune.
+set -euo pipefail
+
+HIGH_WATER_PCT="${HIGH_WATER_PCT:-85}"
+STALE_DAYS="${STALE_DAYS:-7}"
+RUNNERS_ROOT="${RUNNERS_ROOT:-/home/noah/data}"
+LOG_TAG="runner-disk-guard"
+
+log() { logger -t "$LOG_TAG" -- "$*" || true; echo "[$LOG_TAG] $*"; }
+
+disk_pct() { df --output=pcent / | tail -1 | tr -dc '0-9'; }
+
+prune_target_dirs() {
+    local mode="$1"  # "aggressive" or "stale"
+    local total_freed_kb=0
+    local before_kb after_kb
+
+    before_kb="$(df --output=avail / | tail -1 | tr -dc '0-9')"
+
+    # Find all */target/ under runner _work trees
+    while IFS= read -r -d '' tgt; do
+        if [ "$mode" = "stale" ]; then
+            # Only prune if nothing touched in STALE_DAYS days
+            if find "$tgt" -maxdepth 0 -mtime +"$STALE_DAYS" | grep -q .; then
+                log "pruning stale target: $tgt"
+                rm -rf --one-file-system "$tgt" 2>/dev/null || sudo rm -rf --one-file-system "$tgt" 2>/dev/null || true
+            fi
+        else
+            log "aggressive prune: $tgt"
+            rm -rf --one-file-system "$tgt" 2>/dev/null || sudo rm -rf --one-file-system "$tgt" 2>/dev/null || true
+        fi
+    done < <(find "$RUNNERS_ROOT"/actions-runner*/_work -mindepth 3 -maxdepth 4 -type d -name target -print0 2>/dev/null)
+
+    after_kb="$(df --output=avail / | tail -1 | tr -dc '0-9')"
+    total_freed_kb=$(( after_kb - before_kb ))
+    log "freed approximately ${total_freed_kb} KiB (mode=$mode)"
+}
+
+case "${1:-}" in
+    --pre-job)
+        pct="$(disk_pct)"
+        if [ "$pct" -ge "$HIGH_WATER_PCT" ]; then
+            log "pre-job: / at ${pct}% ≥ ${HIGH_WATER_PCT}% — pruning target/ dirs"
+            prune_target_dirs aggressive
+        fi
+        ;;
+    --nightly)
+        log "nightly: / at $(disk_pct)% — pruning target/ older than ${STALE_DAYS}d"
+        prune_target_dirs stale
+        ;;
+    *)
+        echo "usage: $0 --pre-job | --nightly" >&2
+        exit 2
+        ;;
+esac

--- a/scripts/runner-infra/runner-disk-guard.sh
+++ b/scripts/runner-infra/runner-disk-guard.sh
@@ -7,8 +7,18 @@
 #                    target/ dirs older than STALE_DAYS (default 7) across all
 #                    /home/noah/data/actions-runner*/_work trees.
 #
-# Safe by design: only touches target/, .rustup/tmp, .cache/cargo/registry/cache,
-# and _tool. Never the repo checkout itself. Exits 0 even if nothing to prune.
+# Safe by design:
+#   - only touches target/ under _work trees — never the repo checkout itself
+#   - in --pre-job mode, SKIPS target/ dirs on runners that currently have an
+#     active Runner.Worker process (prevents clobbering mid-compile jobs on
+#     sibling runners when disk crosses the high-water mark)
+#   - exits 0 even if nothing to prune
+#
+# Rationale for skip-active: on a shared host with ≥2 runners, an unconditional
+# rm -rf on every target/ deleted .rlib files out from under in-progress cargo
+# builds on sibling runners, producing "No such file or directory" errors for
+# hours at a time. A skipped active runner keeps its own target/ — it is the
+# runner that "owns" that target for the duration of its job.
 set -euo pipefail
 
 HIGH_WATER_PCT="${HIGH_WATER_PCT:-85}"
@@ -20,6 +30,30 @@ log() { logger -t "$LOG_TAG" -- "$*" || true; echo "[$LOG_TAG] $*"; }
 
 disk_pct() { df --output=pcent / | tail -1 | tr -dc '0-9'; }
 
+# Returns 0 if $1 (runner_dir, e.g. /home/noah/data/actions-runner-5) has an
+# active Runner.Worker process; 1 if idle. Runner.Listener is always running
+# and does NOT count as "active" — only the Worker (spawned per job) does.
+runner_has_active_worker() {
+    local runner_dir="$1"
+    local pid cwd
+    # pgrep -f matches the process command line; Runner.Worker is the per-job
+    # binary that the Listener spawns and its cwd is under the runner's tree.
+    for pid in $(pgrep -f "Runner\.Worker" 2>/dev/null || true); do
+        cwd="$(readlink "/proc/$pid/cwd" 2>/dev/null || echo "")"
+        if [ -n "$cwd" ] && [[ "$cwd" == "$runner_dir"* ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Extract runner dir (/home/noah/data/actions-runner-N) from a target path
+# like /home/noah/data/actions-runner-5/_work/aprender/aprender/target
+runner_dir_of() {
+    local tgt="$1"
+    echo "$tgt" | sed -E "s|($RUNNERS_ROOT/actions-runner[^/]+)/.*|\\1|"
+}
+
 prune_target_dirs() {
     local mode="$1"  # "aggressive" or "stale"
     local total_freed_kb=0
@@ -27,8 +61,17 @@ prune_target_dirs() {
 
     before_kb="$(df --output=avail / | tail -1 | tr -dc '0-9')"
 
-    # Find all */target/ under runner _work trees
     while IFS= read -r -d '' tgt; do
+        local runner_dir
+        runner_dir="$(runner_dir_of "$tgt")"
+
+        # Never prune a target/ belonging to a runner with an active Worker
+        # (skipping protects in-progress cargo builds from rlib deletion races).
+        if runner_has_active_worker "$runner_dir"; then
+            log "skip (runner active): $tgt"
+            continue
+        fi
+
         if [ "$mode" = "stale" ]; then
             # Only prune if nothing touched in STALE_DAYS days
             if find "$tgt" -maxdepth 0 -mtime +"$STALE_DAYS" | grep -q .; then

--- a/scripts/runner-infra/runner-disk-guard.timer
+++ b/scripts/runner-infra/runner-disk-guard.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Nightly runner disk guard
+Requires=runner-disk-guard.service
+
+[Timer]
+OnCalendar=*-*-* 04:00:00
+RandomizedDelaySec=30min
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/scripts/runner-infra/runner-pre-job.sh
+++ b/scripts/runner-infra/runner-pre-job.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# GitHub Actions pre-job hook.
+# 1. Disk-pressure guard: prune target/ if / > HIGH_WATER_PCT.
+# 2. Fix root-owned files in the workspace (container builds leave root-owned).
+set -u
+
+# 1. Disk guard (best-effort, never block the job)
+/usr/local/bin/runner-disk-guard.sh --pre-job 2>&1 || true
+
+# 2. Chown container-leftover files
+WORKSPACE="${GITHUB_WORKSPACE:-}"
+if [ -n "$WORKSPACE" ] && [ -d "$WORKSPACE" ]; then
+  sudo chown -R noah:noah "$WORKSPACE" 2>/dev/null || true
+fi
+RUNNER_DIR="$(dirname "$(dirname "$WORKSPACE")" 2>/dev/null)"
+if [ -n "$RUNNER_DIR" ] && [ -d "$RUNNER_DIR" ]; then
+  sudo find "$RUNNER_DIR" -maxdepth 3 -user root -exec chown -R noah:noah {} + 2>/dev/null || true
+fi


### PR DESCRIPTION
## Summary

Prevents the `/` = 100% full failure class that took all 16 `intel-clean-room-*` runners offline on 2026-04-22 (diagnosed via `gh api /orgs/paiml/actions/runners` showing 16/16 offline, root cause: `/` at 3.5T/3.6T → runner `_diag` logs unwritable → GitHub marks runners offline).

Two-layer defence installed on intel as of this commit:

1. **Pre-job hook** (`runner-pre-job.sh`, wired via each runner's existing `ACTIONS_RUNNER_HOOK_JOB_STARTED`): when `/` ≥ 85%, aggressively prune `_work/*/target/` before the job starts. Also retains the prior root-owned-file chown logic.
2. **Nightly systemd timer** (`runner-disk-guard.timer` → `.service`): at 04:00 local, prune any `_work/*/target/` untouched for ≥ 7 days.

Emergency recovery (2026-04-22) freed 1.3 TB on intel by stopping all 16 runners, `rm -rf _work`, restarting. Without this automation the next fill-up would repeat that outage.

## Test plan

- [x] 16/16 runners `online` on GitHub after recovery + script install
- [x] `systemctl list-timers` shows `runner-disk-guard.timer` next fire at 04:15 UTC (04:00 + randomized delay)
- [x] Each runner `.env` already references `/usr/local/bin/runner-pre-job.sh` (verified on all 16)
- [ ] Next job on any runner will exercise the pre-job hook (observable via `logger -t runner-disk-guard` in syslog)

🤖 Generated with [Claude Code](https://claude.com/claude-code)