### PR TITLE
falsify(ship): SHIP-018 PARTIAL — humaneval pass@1 ≥30.0% threshold fn

### DIFF
--- a/contracts/model-families/llama-370m-sovereign-v1.yaml
+++ b/contracts/model-families/llama-370m-sovereign-v1.yaml
@@ -36,14 +36,37 @@
 # ─────────────────────────────────────────────────────────────
 
 contract_id: C-LLAMA-370M-SOVEREIGN
-version: 1.5.0
+version: 1.6.0
 status: ACTIVE
 
 metadata:
-  version: "1.5.0"
+  version: "1.6.0"
   created: "2026-04-18"
-  updated: "2026-04-21"
+  updated: "2026-04-22"
   changelog:
+    - "1.6.0 (2026-04-22): Algorithm-level PARTIAL discharge of
+       FALSIFY-SHIP-018 (GATE-ARCH-370M-007, AC-SHIP2-008).
+       Wired `verdict_from_pass_at_1(correct, total, threshold_pct)`
+       pure threshold function in
+       crates/aprender-train/src/models/llama_370m.rs — proves the
+       decision rule behind the spec's 'HumanEval pass@1 ≥ 30.0%'
+       gate at `cargo test` time without needing a trained 370M
+       artifact. Boundary (f32-exact at 50.0%, inclusive-floor
+       proof), monotonicity, div-by-zero + correct>total sanity,
+       non-finite threshold conservative-Fail, and provenance
+       pinning (const = 30.0) all asserted. Full discharge on the
+       real `apr eval --benchmark humaneval` harness (164 tasks ×
+       greedy sampling) remains PENDING on trained 370M .apr from
+       AC-SHIP2-003/004 compute-dispatch — fixture swap is
+       data-only once an artifact exists. This is the **6th
+       PARTIAL** for MODEL-2 after SHIP-015/017/019/020 (plus
+       SHIP-012 via tokenizer-bpe-v1), pushing coverage to
+       **3/12 ACTIVE + 6/12 PARTIAL = 9/12 touched (75%)**.
+       The 'exhausted' verdict from spec v2.22.0 has now been
+       falsified *four* times — remaining AC-SHIP2 gates worth a
+       5th survey pass are SHIP-016 (apr qa aggregate 8-of-8)
+       and SHIP-013/014 (loss + wall-clock budget, but both need
+       real compute)."
     - "1.5.0 (2026-04-21): Option-A vocab alignment (task #131).
        Bumped vocab_size 50_000 → 50_257 to match the MODEL-2
        tokenizer artifact (trained in task #118) and the GPT-2
@@ -473,6 +496,57 @@ gates:
     verdict: pass
     binds_to: AC-SHIP2-009
     falsification_id: FALSIFY-SHIP-019
+    ship_blocking: true
+
+  - id: GATE-ARCH-370M-007
+    rule: >
+      `apr eval --benchmark humaneval` executed against the trained
+      370M .apr reports pass@1 ≥ 30.0% (inclusive floor). Pass@1 is
+      computed per Chen et al. 2021 with k=1; temperature=0.0 and
+      top-k=1 greedy sampling so the score is deterministic. Spec
+      §5.2 AC-SHIP2-008.
+    evidence_required: >
+      `apr eval --benchmark humaneval --json` median pass@1 across
+      three consecutive seed=0 runs is ≥ 30.0%. Per-run determinism
+      is enforced by spec §6 GATE-SHIP-004 (two consecutive runs
+      produce identical scores).
+    evidence_discharged_by:
+      - "crates/aprender-train/src/models/llama_370m.rs::verdict_from_pass_at_1"
+      - "crates/aprender-train/src/models/llama_370m.rs::AC_SHIP2_008_MIN_HUMANEVAL_PASS_AT_1_PCT (=30.0)"
+      - "crates/aprender-train/src/models/llama_370m.rs::tests::falsify_ship_018_humaneval_pass_at_1_threshold_logic"
+      - "crates/aprender-train/src/models/llama_370m.rs::tests::falsify_ship_018_gate_arch_370m_007_has_partial_discharge_marker"
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    partial_discharge_note: >
+      Algorithm level proven today: the decision rule behind
+      AC-SHIP2-008 is a pure (correct, total, threshold_pct) → pct
+      comparison. `verdict_from_pass_at_1` lifts the rule into a
+      Rust `const`-stable fn with five invariants asserted without
+      training:
+        (1) **Inclusive floor** — `ratio_pct >= threshold_pct`
+            with f32-exact 50/100 boundary proof (+ULP fails,
+            −ULP passes, exactly-at-50.0 passes).
+        (2) **Below-floor rejection** — 49/164 ≈ 29.88% and
+            29/100 = 29.0% both Fail the 30.0 floor.
+        (3) **Monotonicity** — sweeping correct ∈ 0..=164 with
+            total=164 (canonical HumanEval) allows Fail→Pass
+            once and forbids Pass→Fail inversions (no oscillation).
+        (4) **Div-safety + sanity** — `total == 0` fails closed
+            (no empty-run false-green); `correct > total` fails
+            closed (broken-harness guard).
+        (5) **Non-finite guard** — NaN / +∞ / −∞ thresholds all
+            Fail conservatively; no real spec floor can be
+            non-finite.
+      Full discharge (three seed=0 `apr eval --benchmark humaneval
+      --json` runs each feeding `verdict_from_pass_at_1` → all
+      three Pass) blocks on real 370M .apr from AC-SHIP2-003/004
+      compute-dispatch. Fixture swap is data-only — no harness
+      rewrite required. This is the 6th PARTIAL for MODEL-2
+      (SHIP-012/015/017/019/020 were prior PARTIALs); v2.22.0's
+      "exhausted" verdict has now been falsified four times.
+    full_discharge_blocks_on: "real 370M .apr checkpoint from AC-SHIP2-003/004 compute-dispatch + three independent `apr eval --benchmark humaneval --json` runs at seed=0 on the SHIP-TWO-001 canonical host; feed each pass@1 into verdict_from_pass_at_1 and require all three Pass"
+    verdict: pass
+    binds_to: AC-SHIP2-008
+    falsification_id: FALSIFY-SHIP-018
     ship_blocking: true
 
   - id: GATE-ARCH-370M-011

--- a/crates/aprender-train/src/models/llama_370m.rs
+++ b/crates/aprender-train/src/models/llama_370m.rs
@@ -384,6 +384,70 @@ pub fn assert_tokenizer_vocab_matches_model(
 }
 
 // ─────────────────────────────────────────────────────────────
+// AC-SHIP2-008 / FALSIFY-SHIP-018 — HumanEval pass@1 threshold
+// ─────────────────────────────────────────────────────────────
+//
+// Spec §5.2 AC-SHIP2-008 states: `apr eval --benchmark humaneval`
+// must report pass@1 ≥ 30.0% for the trained 370M `.apr` artifact.
+// The decision rule is a pure (correct, total) → pct comparison;
+// the compute-heavy harness (164 HumanEval tasks × `apr run` ×
+// greedy sampling) is fixture-swappable once a trained artifact
+// exists. Landing the threshold function today discharges
+// GATE-ARCH-370M-007 at PARTIAL_ALGORITHM_LEVEL and catches any
+// future drift in the 30.0 floor at `cargo test` time — before a
+// single HumanEval task is dispatched.
+
+/// Contract-frozen floor for AC-SHIP2-008: HumanEval pass@1 must
+/// reach **30.0%** on the trained 370M artifact. The numeric floor
+/// mirrors `contracts/model-families/llama-370m-sovereign-v1.yaml`
+/// GATE-ARCH-370M-007 rule body and spec §5.2 AC-SHIP2-008.
+pub const AC_SHIP2_008_MIN_HUMANEVAL_PASS_AT_1_PCT: f32 = 30.0;
+
+/// Binary verdict emitted by [`verdict_from_pass_at_1`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Ship018Verdict {
+    /// `correct / total * 100 ≥ threshold_pct` and inputs are well-formed.
+    Pass,
+    /// Any of: ratio < threshold, `total == 0`, non-finite threshold.
+    Fail,
+}
+
+/// Decision function for AC-SHIP2-008 / FALSIFY-SHIP-018.
+///
+/// Returns [`Ship018Verdict::Pass`] iff `correct / total * 100`
+/// is ≥ `threshold_pct`. Conservative-Fail guards:
+///
+///   - `total == 0` → Fail (avoid division-by-zero; an empty run
+///     cannot satisfy a positive threshold).
+///   - `correct > total` → Fail (nonsensical input; a real
+///     harness can never report more passes than attempts).
+///   - `!threshold_pct.is_finite()` → Fail (NaN / ±∞ contract
+///     drift — no real contract floor can be non-finite).
+///
+/// Stored per-ULP ratio comparisons use f32 arithmetic to keep the
+/// verdict a pure function of its inputs with no harness state.
+#[must_use]
+pub fn verdict_from_pass_at_1(correct: usize, total: usize, threshold_pct: f32) -> Ship018Verdict {
+    if total == 0 {
+        return Ship018Verdict::Fail;
+    }
+    if correct > total {
+        return Ship018Verdict::Fail;
+    }
+    if !threshold_pct.is_finite() {
+        return Ship018Verdict::Fail;
+    }
+    // Safe: correct ≤ total ≤ usize::MAX; f32 cast preserves ordering
+    // within the humaneval range (total ≤ 164 for canonical HumanEval).
+    let ratio_pct = (correct as f32 / total as f32) * 100.0_f32;
+    if ratio_pct >= threshold_pct {
+        Ship018Verdict::Pass
+    } else {
+        Ship018Verdict::Fail
+    }
+}
+
+// ─────────────────────────────────────────────────────────────
 // Unit tests
 // ─────────────────────────────────────────────────────────────
 
@@ -429,13 +493,11 @@ mod tests {
     /// short of contract) so the helper is still exercised on real mismatch.
     #[test]
     fn falsify_gate_arch_370m_011_helper_rejects_mismatch() {
-        assert!(
-            assert_tokenizer_vocab_matches_model(
-                Llama370MConfig::VOCAB_SIZE,
-                Llama370MConfig::VOCAB_SIZE,
-            )
-            .is_ok()
-        );
+        assert!(assert_tokenizer_vocab_matches_model(
+            Llama370MConfig::VOCAB_SIZE,
+            Llama370MConfig::VOCAB_SIZE,
+        )
+        .is_ok());
 
         let mismatch = Llama370MConfig::VOCAB_SIZE - 1;
         let err = assert_tokenizer_vocab_matches_model(mismatch, Llama370MConfig::VOCAB_SIZE)
@@ -448,13 +510,11 @@ mod tests {
         );
 
         assert!(assert_tokenizer_vocab_matches_model(0, 1).is_err());
-        assert!(
-            assert_tokenizer_vocab_matches_model(
-                Llama370MConfig::VOCAB_SIZE + 1,
-                Llama370MConfig::VOCAB_SIZE
-            )
-            .is_err()
-        );
+        assert!(assert_tokenizer_vocab_matches_model(
+            Llama370MConfig::VOCAB_SIZE + 1,
+            Llama370MConfig::VOCAB_SIZE
+        )
+        .is_err());
     }
 
     /// INV-ARCH-370M-001 — estimated param count within [366M, 374M].
@@ -856,6 +916,239 @@ mod tests {
             Some(true),
             "GATE-ARCH-370M-004 must advertise ship_blocking:true — the \
              gate's `verdict:pass` alone is insufficient green while \
+             discharge_status == PARTIAL_ALGORITHM_LEVEL",
+        );
+    }
+
+    // ========================================================================
+    // FALSIFY-SHIP-018 / AC-SHIP2-008 / GATE-ARCH-370M-007 — pass@1 threshold
+    // ========================================================================
+
+    /// Algorithm-level proof that `verdict_from_pass_at_1` enforces the
+    /// spec §5.2 AC-SHIP2-008 rule "HumanEval pass@1 ≥ 30.0%" correctly:
+    ///
+    ///   1. Exactly-at-floor passes (30/100, 60/200, 1/1 at threshold 100).
+    ///   2. One f32 ULP below the floor fails.
+    ///   3. Generous-green (50/100, 164/164) passes.
+    ///   4. Hard-red (0/100, 1/100) fails.
+    ///   5. Monotonicity: sweeping `correct` upward from 0 with total fixed
+    ///      at 164 (canonical HumanEval) never flips Pass → Fail.
+    ///   6. Div-safety guard: `total == 0` always fails, even with 0 correct.
+    ///   7. Sanity guard: `correct > total` always fails (impossible harness).
+    ///   8. Non-finite threshold guard: NaN / ±∞ always fail.
+    ///   9. Provenance: the contract floor const is pinned to 30.0 (edit
+    ///      to the const without amending the contract is caught here).
+    ///
+    /// Full `apr eval --benchmark humaneval` discharge blocks on the trained
+    /// 370M .apr from AC-SHIP2-003/004 compute-dispatch — fixture swap only.
+    #[test]
+    fn falsify_ship_018_humaneval_pass_at_1_threshold_logic() {
+        // ── (1) Exactly-at-floor → Pass
+        assert_eq!(
+            verdict_from_pass_at_1(30, 100, AC_SHIP2_008_MIN_HUMANEVAL_PASS_AT_1_PCT),
+            Ship018Verdict::Pass,
+            "30/100 = 30.0% must pass the 30.0 floor",
+        );
+        assert_eq!(
+            verdict_from_pass_at_1(60, 200, AC_SHIP2_008_MIN_HUMANEVAL_PASS_AT_1_PCT),
+            Ship018Verdict::Pass,
+            "60/200 = 30.0% must pass the 30.0 floor",
+        );
+        // HumanEval canonical N=164 at-floor: ⌈0.3 × 164⌉ = 50 → 50/164 = 30.49%
+        assert_eq!(
+            verdict_from_pass_at_1(50, 164, AC_SHIP2_008_MIN_HUMANEVAL_PASS_AT_1_PCT),
+            Ship018Verdict::Pass,
+            "50/164 ≈ 30.49% must pass the 30.0 floor",
+        );
+
+        // ── (2a) Just below the floor → Fail.
+        //
+        // 49/164 ≈ 29.878% computes to a ratio strictly less than 30.0 in
+        // f32 (see below) and must therefore fail against the 30.0 floor.
+        // (Note: 30/100 in f32 rounds to ~30.000002, slightly *above* 30.0,
+        // so "exactly-at-floor" must be tested with ratios that are exact
+        // in f32 — see case (2b).)
+        assert_eq!(
+            verdict_from_pass_at_1(49, 164, AC_SHIP2_008_MIN_HUMANEVAL_PASS_AT_1_PCT),
+            Ship018Verdict::Fail,
+            "49/164 ≈ 29.88% must fail the 30.0 floor",
+        );
+        assert_eq!(
+            verdict_from_pass_at_1(29, 100, AC_SHIP2_008_MIN_HUMANEVAL_PASS_AT_1_PCT),
+            Ship018Verdict::Fail,
+            "29/100 = 29.0% must fail the 30.0 floor",
+        );
+
+        // ── (2b) Inclusive-floor proof at an f32-exact ratio.
+        //
+        // 50/100 → exactly 50.0% in f32 (both operands integer-exact, the
+        // quotient 0.5 is a power of two, and 0.5 × 100.0 = 50.0 exactly).
+        // This lets us prove the comparison is `>=` (inclusive), not `>`:
+        //   - Threshold = 50.0              → Pass (exact equality).
+        //   - Threshold = 50.0 + one ULP    → Fail (strictly above ratio).
+        //   - Threshold = 50.0 - one ULP    → Pass (strictly below ratio).
+        let exact_50 = 50.0_f32;
+        assert_eq!(50.0_f32 * 2.0_f32, 100.0_f32, "sanity: 50.0 is exact in f32");
+        let fifty_plus_ulp = f32::from_bits(exact_50.to_bits() + 1);
+        let fifty_minus_ulp = f32::from_bits(exact_50.to_bits() - 1);
+        assert!(fifty_plus_ulp > exact_50, "sanity: +ULP is strictly above");
+        assert!(fifty_minus_ulp < exact_50, "sanity: −ULP is strictly below");
+        assert_eq!(
+            verdict_from_pass_at_1(50, 100, exact_50),
+            Ship018Verdict::Pass,
+            "inclusive floor: 50.0% ≥ 50.0 must Pass (proves `>=`, not `>`)",
+        );
+        assert_eq!(
+            verdict_from_pass_at_1(50, 100, fifty_plus_ulp),
+            Ship018Verdict::Fail,
+            "50/100 must fail when threshold is one ULP above 50.0",
+        );
+        assert_eq!(
+            verdict_from_pass_at_1(50, 100, fifty_minus_ulp),
+            Ship018Verdict::Pass,
+            "50/100 must pass when threshold is one ULP below 50.0",
+        );
+
+        // ── (3) Generous-green
+        assert_eq!(
+            verdict_from_pass_at_1(82, 164, AC_SHIP2_008_MIN_HUMANEVAL_PASS_AT_1_PCT),
+            Ship018Verdict::Pass,
+            "82/164 = 50% must pass",
+        );
+        assert_eq!(
+            verdict_from_pass_at_1(164, 164, AC_SHIP2_008_MIN_HUMANEVAL_PASS_AT_1_PCT),
+            Ship018Verdict::Pass,
+            "perfect score must pass",
+        );
+
+        // ── (4) Hard-red
+        assert_eq!(
+            verdict_from_pass_at_1(0, 164, AC_SHIP2_008_MIN_HUMANEVAL_PASS_AT_1_PCT),
+            Ship018Verdict::Fail,
+            "zero-correct run must fail",
+        );
+        assert_eq!(
+            verdict_from_pass_at_1(1, 164, AC_SHIP2_008_MIN_HUMANEVAL_PASS_AT_1_PCT),
+            Ship018Verdict::Fail,
+            "1/164 ≈ 0.6% must fail",
+        );
+
+        // ── (5) Monotonicity sweep: correct ∈ 0..=164, total = 164
+        //
+        // Over an increasing `correct` axis the verdict is allowed to flip
+        // Fail → Pass exactly once; it must never flip Pass → Fail.
+        let total = 164usize;
+        let mut already_passed = false;
+        for correct in 0..=total {
+            let v =
+                verdict_from_pass_at_1(correct, total, AC_SHIP2_008_MIN_HUMANEVAL_PASS_AT_1_PCT);
+            match v {
+                Ship018Verdict::Pass => {
+                    already_passed = true;
+                }
+                Ship018Verdict::Fail => {
+                    assert!(
+                        !already_passed,
+                        "monotonicity violated: correct={correct} reverted Pass→Fail",
+                    );
+                }
+            }
+        }
+
+        // ── (6) Div-safety: total=0 must always fail
+        assert_eq!(
+            verdict_from_pass_at_1(0, 0, AC_SHIP2_008_MIN_HUMANEVAL_PASS_AT_1_PCT),
+            Ship018Verdict::Fail,
+            "empty run (total=0) must fail — a positive floor is unsatisfiable",
+        );
+        assert_eq!(
+            verdict_from_pass_at_1(0, 0, 0.0_f32),
+            Ship018Verdict::Fail,
+            "empty run must fail even with a zero threshold — the harness \
+             is broken if it reports an empty denominator",
+        );
+
+        // ── (7) Sanity guard: correct > total
+        assert_eq!(
+            verdict_from_pass_at_1(165, 164, AC_SHIP2_008_MIN_HUMANEVAL_PASS_AT_1_PCT),
+            Ship018Verdict::Fail,
+            "correct > total is a broken harness report; must fail closed",
+        );
+
+        // ── (8) Non-finite threshold → Fail
+        assert_eq!(
+            verdict_from_pass_at_1(164, 164, f32::NAN),
+            Ship018Verdict::Fail,
+            "NaN threshold must fail",
+        );
+        assert_eq!(
+            verdict_from_pass_at_1(164, 164, f32::INFINITY),
+            Ship018Verdict::Fail,
+            "+∞ threshold must fail",
+        );
+        assert_eq!(
+            verdict_from_pass_at_1(164, 164, f32::NEG_INFINITY),
+            Ship018Verdict::Fail,
+            "−∞ threshold must fail",
+        );
+
+        // ── (9) Provenance pin
+        assert!(
+            (AC_SHIP2_008_MIN_HUMANEVAL_PASS_AT_1_PCT - 30.0_f32).abs() < f32::EPSILON,
+            "contract floor drift: AC_SHIP2_008_MIN_HUMANEVAL_PASS_AT_1_PCT \
+             must stay pinned to 30.0 (spec §5.2 AC-SHIP2-008)",
+        );
+    }
+
+    /// Binds the YAML contract's `GATE-ARCH-370M-007` block to this test
+    /// binary: any rename, removal, or discharge_status regression in
+    /// `contracts/model-families/llama-370m-sovereign-v1.yaml` is caught
+    /// at `cargo test` time.
+    #[test]
+    fn falsify_ship_018_gate_arch_370m_007_has_partial_discharge_marker() {
+        let doc: serde_yaml::Value =
+            serde_yaml::from_str(SOVEREIGN_CONTRACT_YAML).expect("parse sovereign contract");
+
+        let gates = doc["gates"].as_sequence().expect("contract must have `gates:` sequence");
+
+        let gate = gates
+            .iter()
+            .find(|g| g["id"].as_str() == Some("GATE-ARCH-370M-007"))
+            .expect("GATE-ARCH-370M-007 (SHIP-018 humaneval pass@1) must be present");
+
+        assert_eq!(
+            gate["binds_to"].as_str(),
+            Some("AC-SHIP2-008"),
+            "GATE-ARCH-370M-007 must bind AC-SHIP2-008",
+        );
+        assert_eq!(
+            gate["falsification_id"].as_str(),
+            Some("FALSIFY-SHIP-018"),
+            "GATE-ARCH-370M-007 must bind FALSIFY-SHIP-018",
+        );
+        assert_eq!(
+            gate["discharge_status"].as_str(),
+            Some("PARTIAL_ALGORITHM_LEVEL"),
+            "GATE-ARCH-370M-007 must advertise PARTIAL_ALGORITHM_LEVEL — \
+             full discharge blocks on trained 370M .apr + real apr eval",
+        );
+        let evidence = gate["evidence_discharged_by"]
+            .as_sequence()
+            .expect("GATE-ARCH-370M-007 must have evidence_discharged_by");
+        assert!(
+            !evidence.is_empty(),
+            "GATE-ARCH-370M-007 evidence_discharged_by must list at least \
+             one test function or const pin",
+        );
+        assert!(
+            gate["full_discharge_blocks_on"].as_str().is_some(),
+            "PARTIAL gate must document full_discharge_blocks_on",
+        );
+        assert_eq!(
+            gate["ship_blocking"].as_bool(),
+            Some(true),
+            "GATE-ARCH-370M-007 must advertise ship_blocking:true — \
+             verdict:pass alone is insufficient green while \
              discharge_status == PARTIAL_ALGORITHM_LEVEL",
         );
     }

--- a/crates/aprender-train/src/train/device.rs
+++ b/crates/aprender-train/src/train/device.rs
@@ -108,7 +108,8 @@ impl std::error::Error for DeviceError {}
 ///   CUDA (or `auto` chose CUDA) but `cuda_training_available()`
 ///   returned `false`.
 pub fn resolve_device(spec: &str) -> Result<Device, DeviceError> {
-    let parsed = parse_device_spec(spec).ok_or_else(|| DeviceError::InvalidSpec(spec.to_string()))?;
+    let parsed =
+        parse_device_spec(spec).ok_or_else(|| DeviceError::InvalidSpec(spec.to_string()))?;
 
     match parsed {
         ParsedSpec::Cpu => Ok(Device::Cpu),
@@ -317,8 +318,7 @@ mod tests {
         let invalid = DeviceError::InvalidSpec("bogus".into()).to_string();
         assert!(invalid.contains("INV-GPUTRAIN-001"));
         assert!(invalid.contains("bogus"));
-        let unavail =
-            DeviceError::CudaNotAvailable { requested: "cuda:0".into() }.to_string();
+        let unavail = DeviceError::CudaNotAvailable { requested: "cuda:0".into() }.to_string();
         assert!(unavail.contains("GATE-GPUTRAIN-002"));
         assert!(unavail.contains("cuda:0"));
     }

--- a/docs/specifications/aprender-train/ship-two-models-spec.md
+++ b/docs/specifications/aprender-train/ship-two-models-spec.md
@@ -1,11 +1,49 @@
 # Specification: Ship Two Models — Sovereign AI Stack Proof
 
 **Document ID:** SPEC-SHIP-TWO-001
-**Version:** 2.23.0
+**Version:** 2.24.0
 **Status:** SHIP-TWO-001-MODEL-1-TEACHER **RELEASED**; MODEL-2 pretraining **loop driver landed** (task #105 CLOSED — commit `9a5af3ac2`); 370M Llama scaffold + pretrain loop + `apr pretrain` CLI all dogfood-ready; Zero-Tolerance design principle codified (§3 row #8); `pv validate` dogfooded across all 760 contracts (task #101); 8 legacy contracts backfilled with kani_harnesses + falsification parity (task #102 CLOSED); MODEL-2 `--min-frequency` threaded end-to-end through aprender-train BPE (task #103 CLOSED); gx10 third-party framework capacity gate PASS at 38.0 tok/s decode with 26.7% margin (task #104 CLOSED); loader hardened to ignore co-located ModelFamilyVariant contracts (task #108 CLOSED — 32→0 workspace-test failures); **task #132 BLOCKER surfaced 2026-04-21** on lambda-labs RTX 4090 — `apr pretrain --mode from-scratch` ran 14 min at 114% CPU + 0 MiB GPU memory because `TransformerTrainer::new` has no Device argument; `contracts/entrenar/gpu-training-backend-v1.yaml` PROPOSED (task #132 Phase 0) with INV-GPUTRAIN-001..007 + GATE-GPUTRAIN-001..006, ship-blocks task #126 real-compute dispatch
 **Author:** PAIML Engineering
 **Reviewer:** Noah Gift
-**Date:** 2026-04-17 (v1.0.0) / 2026-04-17 (v2.0.0 audit + pivot) / 2026-04-18 (v2.5.0 pre-flight Poka-Yoke) / 2026-04-18 (v2.6.0 PM-008 GGUF tensor-type Poka-Yoke) / 2026-04-18 (v2.7.0 PM-009 APR magic-bytes Poka-Yoke) / 2026-04-18 (v2.8.0 HF Hub Xet large-file upload contract) / 2026-04-18 (v2.8.1 Xet impl landed) / 2026-04-18 (v2.9.0 EX-04 DISCHARGED via NDJSON lfsFile schema) / 2026-04-18 (v2.10.0 MODEL-1 v2 QLoRA divergence root cause — teacher-only ship) / 2026-04-18 (v2.11.0 EX-05/06/07 DISCHARGED — teacher tagged SHIP-TWO-001-MODEL-1-TEACHER) / 2026-04-18 (v2.12.0 post-ship artifacts — MODEL-2 contracts + MODEL-1 retry plan + SHARD-003 probe) / 2026-04-18 (v2.13.0 FALSIFY-SHARD-003 DISCHARGED live yoga vs gx10) / 2026-04-18 (v2.14.0 MODEL-2 dataset contract drafted + BPE NFC gap identified) / 2026-04-18 (v2.15.0 MODEL-2 scaffold LANDED — BPE NFC + tokenizer CLI + corpus ingest binary) / 2026-04-18 (v2.16.0 Zero-Tolerance design principle codified — no bugs, no perf regressions, no carve-outs) / 2026-04-18 (v2.17.0 contracts schema harmonization shipped — pv validate works across all 760 contracts, unblocks dogfooded gate) / 2026-04-18 (v2.18.0 parallel dispatch lanes #102/#103/#104 all closed — 8 contracts backfilled + MODEL-2 --min-frequency plumbed + gx10 38.0 tok/s PASS) / 2026-04-18 (v2.19.0 MODEL-2 pretrain loop driver landed via task #105 sub-agent — GATE-TRAIN-005 + INV-TRAIN-007 wired; `apr pretrain` CLI gated by `training` feature; loader hardened for ModelFamilyVariant contracts via task #108) / 2026-04-19 (v2.20.0 FALSIFY-SHIP-021 + FALSIFY-SHIP-022 DISCHARGED — MODEL-2 seed-reproducibility harness + apr inspect provenance block wired; tasks #112 #113 closed on chore/post-v2.19-evidence) / 2026-04-19 (v2.21.0 FALSIFY-SHIP-011 DISCHARGED + FALSIFY-SHIP-012/015 PARTIAL_ALGORITHM_LEVEL — C-LLAMA-370M-SOVEREIGN v1.0.0 PROPOSED → v1.2.0 ACTIVE with Rust-YAML byte-equality binding + param-count algorithm proof; C-TOK-BPE v1.1.0 wires 3 tokenizer tests; tasks #114 #115 #116 closed; 3/12 ACTIVE + 2/12 PARTIAL) / 2026-04-19 (v2.22.0 FALSIFY-SHIP-019 PARTIAL_ALGORITHM_LEVEL — C-LLAMA-370M-SOVEREIGN v1.2.0 → v1.3.0 stays ACTIVE; GATE-ARCH-370M-004 wired to 3 algorithm proofs reusing `layout_contract.rs` per Spec §9 Risk #2; task #117 closed on commit `846cc1dbb`; 3/12 ACTIVE + 3/12 PARTIAL = 6/12 touched) / 2026-04-21 (v2.23.0 **task #132 CUDA training backend gap** surfaced on lambda-labs RTX 4090 real-compute dispatch at commit `f7ad11408` — `apr pretrain --mode from-scratch` 14min on CPU (0 MiB GPU memory) because `TransformerTrainer` has no Device awareness; `contracts/entrenar/gpu-training-backend-v1.yaml` PROPOSED (Phase 0) with INV-GPUTRAIN-001..007 + GATE-GPUTRAIN-001..006 + FALSIFY-GPUTRAIN-001..007; production `CudaTransformerTrainer` already exists at `crates/aprender-train/src/train/transformer_trainer/cuda_trainer.rs` — gap is wiring, not kernels; task #126 real-compute dispatch BLOCKED until Phase 3 residency-proof evidence lands)
+**Date:** 2026-04-17 (v1.0.0) / 2026-04-17 (v2.0.0 audit + pivot) / 2026-04-18 (v2.5.0 pre-flight Poka-Yoke) / 2026-04-18 (v2.6.0 PM-008 GGUF tensor-type Poka-Yoke) / 2026-04-18 (v2.7.0 PM-009 APR magic-bytes Poka-Yoke) / 2026-04-18 (v2.8.0 HF Hub Xet large-file upload contract) / 2026-04-18 (v2.8.1 Xet impl landed) / 2026-04-18 (v2.9.0 EX-04 DISCHARGED via NDJSON lfsFile schema) / 2026-04-18 (v2.10.0 MODEL-1 v2 QLoRA divergence root cause — teacher-only ship) / 2026-04-18 (v2.11.0 EX-05/06/07 DISCHARGED — teacher tagged SHIP-TWO-001-MODEL-1-TEACHER) / 2026-04-18 (v2.12.0 post-ship artifacts — MODEL-2 contracts + MODEL-1 retry plan + SHARD-003 probe) / 2026-04-18 (v2.13.0 FALSIFY-SHARD-003 DISCHARGED live yoga vs gx10) / 2026-04-18 (v2.14.0 MODEL-2 dataset contract drafted + BPE NFC gap identified) / 2026-04-18 (v2.15.0 MODEL-2 scaffold LANDED — BPE NFC + tokenizer CLI + corpus ingest binary) / 2026-04-18 (v2.16.0 Zero-Tolerance design principle codified — no bugs, no perf regressions, no carve-outs) / 2026-04-18 (v2.17.0 contracts schema harmonization shipped — pv validate works across all 760 contracts, unblocks dogfooded gate) / 2026-04-18 (v2.18.0 parallel dispatch lanes #102/#103/#104 all closed — 8 contracts backfilled + MODEL-2 --min-frequency plumbed + gx10 38.0 tok/s PASS) / 2026-04-18 (v2.19.0 MODEL-2 pretrain loop driver landed via task #105 sub-agent — GATE-TRAIN-005 + INV-TRAIN-007 wired; `apr pretrain` CLI gated by `training` feature; loader hardened for ModelFamilyVariant contracts via task #108) / 2026-04-19 (v2.20.0 FALSIFY-SHIP-021 + FALSIFY-SHIP-022 DISCHARGED — MODEL-2 seed-reproducibility harness + apr inspect provenance block wired; tasks #112 #113 closed on chore/post-v2.19-evidence) / 2026-04-19 (v2.21.0 FALSIFY-SHIP-011 DISCHARGED + FALSIFY-SHIP-012/015 PARTIAL_ALGORITHM_LEVEL — C-LLAMA-370M-SOVEREIGN v1.0.0 PROPOSED → v1.2.0 ACTIVE with Rust-YAML byte-equality binding + param-count algorithm proof; C-TOK-BPE v1.1.0 wires 3 tokenizer tests; tasks #114 #115 #116 closed; 3/12 ACTIVE + 2/12 PARTIAL) / 2026-04-19 (v2.22.0 FALSIFY-SHIP-019 PARTIAL_ALGORITHM_LEVEL — C-LLAMA-370M-SOVEREIGN v1.2.0 → v1.3.0 stays ACTIVE; GATE-ARCH-370M-004 wired to 3 algorithm proofs reusing `layout_contract.rs` per Spec §9 Risk #2; task #117 closed on commit `846cc1dbb`; 3/12 ACTIVE + 3/12 PARTIAL = 6/12 touched) / 2026-04-21 (v2.23.0 **task #132 CUDA training backend gap** surfaced on lambda-labs RTX 4090 real-compute dispatch at commit `f7ad11408` — `apr pretrain --mode from-scratch` 14min on CPU (0 MiB GPU memory) because `TransformerTrainer` has no Device awareness; `contracts/entrenar/gpu-training-backend-v1.yaml` PROPOSED (Phase 0) with INV-GPUTRAIN-001..007 + GATE-GPUTRAIN-001..006 + FALSIFY-GPUTRAIN-001..007; production `CudaTransformerTrainer` already exists at `crates/aprender-train/src/train/transformer_trainer/cuda_trainer.rs` — gap is wiring, not kernels; task #126 real-compute dispatch BLOCKED until Phase 3 residency-proof evidence lands) / 2026-04-22 (v2.24.0 FALSIFY-SHIP-018 PARTIAL_ALGORITHM_LEVEL — `verdict_from_pass_at_1` pure threshold fn lands GATE-ARCH-370M-007 binding AC-SHIP2-008 to a `cargo test`-enforceable 30.0% HumanEval pass@1 floor; C-LLAMA-370M-SOVEREIGN v1.5.0 → v1.6.0 stays ACTIVE; task #151 closed; **6th PARTIAL** — exhausted verdict falsified 4×; 3/12 ACTIVE + 6/12 PARTIAL = 9/12 touched (75%))
+
+**v2.24.0 amendment (2026-04-22):** FALSIFY-SHIP-018 PARTIAL_ALGORITHM_LEVEL
+discharge (task #151) — **6th PARTIAL** for MODEL-2. AC-SHIP2-008 is bound
+to GATE-ARCH-370M-007 via a pure threshold function
+`verdict_from_pass_at_1(correct, total, threshold_pct) -> Ship018Verdict`
+in `crates/aprender-train/src/models/llama_370m.rs`. The decision rule
+behind the spec's "HumanEval pass@1 ≥ 30.0%" gate is now proven at
+`cargo test` time — boundary (f32-exact 50/100 with ±ULP), below-floor
+rejection, monotonicity, div-by-zero + correct>total sanity, non-finite
+threshold conservative-Fail, and provenance pinning (const = 30.0) all
+asserted without needing a trained 370M artifact.
+`contracts/model-families/llama-370m-sovereign-v1.yaml` v1.5.0 → v1.6.0
+(stays ACTIVE). Evidence: `tests::falsify_ship_018_humaneval_pass_at_1_threshold_logic`
++ `tests::falsify_ship_018_gate_arch_370m_007_has_partial_discharge_marker`.
+Full discharge blocks on a trained 370M `.apr` + three independent
+seed=0 `apr eval --benchmark humaneval --json` median pass@1 values
+fed into `verdict_from_pass_at_1` — all three must Pass (fixture swap
+only; no harness rewrite).
+
+**Pattern lesson.** The v2.22.0 "exhausted" verdict has now been
+falsified **four** times: SHIP-019 (v2.22) → SHIP-017 (PR #1004) →
+SHIP-020 (PR #1005) → SHIP-018 (this PR). Whenever a SHIP-spec gate
+names a threshold/tolerance/ratio/cut-off and the compute-heavy
+harness is separable from the decision function, the threshold
+function can land today as a pure fn + boundary + monotonicity tests
++ contract-marker test — even when the full end-to-end harness is
+blocked on compute. Keep `full_discharge_blocks_on` explicit so the
+PARTIAL-vs-ACTIVE distinction remains surfaced. Remaining AC-SHIP2
+gates worth a 5th survey pass: SHIP-016 (`apr qa` aggregate 8-of-8 —
+aggregate-dispatch proof, not a single threshold) — remaining 013/014
+both genuinely need real compute (loss + wall-clock on RTX 4090).
+
+**Status after v2.24.0.** MODEL-2 ship-gates now **3/12 ACTIVE
+(001, 011, 012) + 6/12 PARTIAL (002 via SHIP-012, 005 via SHIP-015,
+007 via SHIP-017, 008 via SHIP-018, 009 via SHIP-019, 010 via
+SHIP-020) = 9/12 touched (75.0%)**. Remaining 3 truly compute-blocked:
+003 (CE ≤ 2.2 val loss), 004 (≤21-day wall-clock), 006 (`apr qa`
+aggregate — separable but not a single-threshold proof).
 
 **v2.21.0 amendment (2026-04-19):** Three MODEL-2 architecture + tokenizer
 gates landed in the same post-v2.19 evidence window, on branch


### PR DESCRIPTION
## Summary

Discharges **FALSIFY-SHIP-018 / AC-SHIP2-008 / GATE-ARCH-370M-007** at
PARTIAL_ALGORITHM_LEVEL. Lands a pure two-number threshold function
`verdict_from_pass_at_1(correct, total, threshold_pct) -> Ship018Verdict`
in `crates/aprender-train/src/models/llama_370m.rs` plus const
`AC_SHIP2_008_MIN_HUMANEVAL_PASS_AT_1_PCT = 30.0` pinning the spec
§5.2 AC-SHIP2-008 floor — proves the HumanEval pass@1 decision rule
at `cargo test` time, independent of a trained 370M artifact.

This is the **6th PARTIAL** for MODEL-2 (after SHIP-012/015/017/019/020).
Spec v2.22.0's "exhausted" verdict is now falsified **4 times**.

## What ships today

- `verdict_from_pass_at_1(correct: usize, total: usize, threshold_pct: f32) -> Ship018Verdict`
  — inclusive-floor comparison with conservative-Fail guards.
- `Ship018Verdict` enum `{ Pass, Fail }`.
- `AC_SHIP2_008_MIN_HUMANEVAL_PASS_AT_1_PCT: f32 = 30.0` (contract floor).
- Two unit tests:
  - `falsify_ship_018_humaneval_pass_at_1_threshold_logic` — boundary
    (f32-exact 50/100 = 50.0% with ±ULP proving inclusive `>=`),
    below-floor rejection (49/164 ≈ 29.88%, 29/100 = 29.0%), generous
    pass (82/164, 164/164), hard-red (0/164, 1/164), monotonicity
    sweep (correct ∈ 0..=164 at total=164 never flips Pass → Fail),
    div-safety (total=0 fails closed), correct>total sanity, non-finite
    threshold guard (NaN / ±∞ all Fail), provenance pinning (const
    stays = 30.0).
  - `falsify_ship_018_gate_arch_370m_007_has_partial_discharge_marker`
    — parses `SOVEREIGN_CONTRACT_YAML` via `serde_yaml`, asserts the
    gate binds FALSIFY-SHIP-018 / AC-SHIP2-008,
    `discharge_status == PARTIAL_ALGORITHM_LEVEL`,
    `evidence_discharged_by` non-empty, `full_discharge_blocks_on`
    present, `ship_blocking: true`.
- `contracts/model-families/llama-370m-sovereign-v1.yaml` v1.5.0 →
  v1.6.0 (stays ACTIVE) with new GATE-ARCH-370M-007 block + changelog
  entry.
- `docs/specifications/aprender-train/ship-two-models-spec.md` v2.23.0
  → v2.24.0 with amendment block.

## Pattern lesson

The "exhausted" verdict has now been falsified 4 times:
**SHIP-019 → SHIP-017 → SHIP-020 → SHIP-018.** Whenever a SHIP-spec
gate names a threshold/tolerance/ratio/cut-off and the compute-heavy
harness is separable from the decision function, the threshold
function can land today. Remaining 5th-PARTIAL candidate worth a
survey pass: **SHIP-016** (`apr qa` 8-of-8 aggregate — separable
but not a single-threshold proof). SHIP-013/014 genuinely need real
RTX 4090 compute (CE loss + 21-day wall-clock).

## Full discharge blocks on

Real 370M .apr checkpoint from AC-SHIP2-003/004 compute-dispatch +
three independent `apr eval --benchmark humaneval --json` median
pass@1 values at seed=0 on the SHIP-TWO-001 canonical host; feed
each into `verdict_from_pass_at_1` and require all three Pass.
Fixture-swap only — no harness rewrite required.

## Status after this PR

MODEL-2 ship-gates: **3/12 ACTIVE (001, 011, 012) + 6/12 PARTIAL
(002 via SHIP-012, 005 via SHIP-015, 007 via SHIP-017, 008 via
SHIP-018, 009 via SHIP-019, 010 via SHIP-020) = 9/12 touched (75.0%)**.
Remaining 3 genuinely compute-blocked: 003 (CE ≤ 2.2 val loss),
004 (≤21-day wall-clock), 006 (`apr qa` aggregate).

## Also bundled

A 6-line pre-existing fmt fix in `crates/aprender-train/src/train/device.rs`
under Toyota Way "all defects are your defects" — same pattern as
PR #1005. Without it, `cargo fmt -p aprender-train --check` fails on
main for reasons unrelated to this PR.

## Test plan

- [x] `cargo test -p aprender-train --lib models::llama_370m` →
      11/11 pass (2 new + 9 existing).
- [x] `pv validate contracts/model-families/llama-370m-sovereign-v1.yaml`
      → `Contract is valid.`
- [x] `cargo fmt -p aprender-train --check` → clean.
- [x] `cargo clippy -p aprender-train --lib -- -D warnings` → clean.
- [ ] CI (workspace-test, ci/test, ci/lint, ci/coverage) green.

Refs: SHIP-TWO-001, task #151, FALSIFY-SHIP-018, GATE-ARCH-370M-007.

🤖 Generated with [Claude Code](https://claude.com/claude-code)