### PR TITLE
fix(nightly): gate EncodeCorpus on training feature (restore Windows green)

### DIFF
--- a/crates/apr-cli/src/dispatch_analysis.rs
+++ b/crates/apr-cli/src/dispatch_analysis.rs
@@ -653,6 +653,7 @@ fn dispatch_tokenize_command(
             normalization,
             cli.json,
         ),
+        #[cfg(feature = "training")]
         TokenizeCommands::EncodeCorpus {
             corpus,
             tokenizer,

--- a/crates/apr-cli/src/tokenize_commands.rs
+++ b/crates/apr-cli/src/tokenize_commands.rs
@@ -96,6 +96,7 @@ pub enum TokenizeCommands {
     /// Root-cause fix for the pretokenize-to-bin gap documented in
     /// memory/project_shard_reader_bin_format.md — replaces a Python shim
     /// that was flagged as MUDA on 2026-04-19.
+    #[cfg(feature = "training")]
     EncodeCorpus {
         /// Path to JSONL corpus file or directory of `.jsonl` files.
         #[arg(long, value_name = "PATH")]


### PR DESCRIPTION
## Summary

- `tokenize::run_encode_corpus` is gated behind `#[cfg(feature = \"training\")]` (depends on `entrenar::tokenizer::BPETokenizer`).
- The enum variant `TokenizeCommands::EncodeCorpus` and its match arm in `dispatch_analysis.rs` were **unconditional**, so Windows Nightly (`build (x86_64-pc-windows-msvc, windows-latest)`) — which builds without the `training` feature — has been failing since commit 2de45469f (task-123) on 2026-04-21.
- Error: `E0425: cannot find function \`run_encode_corpus\` in module \`tokenize\``.
- Fix is 2 lines: add `#[cfg(feature = \"training\")]` to both the variant and the match arm so clap, the enum, and the handler stay consistent.

## Andon context

Nightly has been red 3 days running (2026-04-21, 2026-04-22, 2026-04-23). Toyota Way main-green rule applies to main-CI-on-schedule too. Closes task #109.

## Test plan

- [x] `cargo check -p apr-cli --no-default-features` (simulates Windows nightly no-training path) — **PASS**, 11.03s.
- [x] `cargo check -p apr-cli` (default features, training included) — **PASS**, 24.95s.
- [ ] PR CI (ci/test, ci/lint, ci/coverage, workspace-test) green on self-hosted runners.
- [ ] Post-merge: next Nightly run (2026-04-24 ~05:00Z) flips x86_64-pc-windows-msvc back to SUCCESS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)