### PR TITLE
fix(ci): per-PR cargo registry to break intel-runner concurrent-write race (ANDON paiml/infra#77)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,17 @@ jobs:
     container:
       image: localhost:5000/sovereign-ci:stable
       volumes:
-        - /home/noah/.cargo/registry:/usr/local/cargo/registry
+        # Per-PR (or per-branch) cargo registry. Before ANDON 2026-04-24 (paiml/infra#77),
+        # ALL 16 intel-clean-room-* runners bind-mounted the SAME host
+        # /home/noah/.cargo/registry, which produced EACCES "couldn't read
+        # <crate>/lib.rs: Permission denied" when a concurrent job extracted,
+        # GC'd, or partially wrote the same src/ directory (root-owned crate
+        # extractions from one container were unreadable by another runner's
+        # noah:1000 reaper sweep; partial extractions left .cargo-ok markers
+        # without src/). Mirroring the target-dir isolation below removes the
+        # contention at the source — each PR owns its registry lifecycle and
+        # there is no cross-PR write concurrency.
+        - /mnt/nvme-raid0/cargo-ci/registry/${{ github.event.pull_request.number || github.ref_name }}:/usr/local/cargo/registry
         # Per-PR (or per-branch) target dir. Before task #134, ALL concurrent PRs
         # bind-mounted the same /workspace/target and stomped each other's
         # incremental cache, pushing every run to the 45-min timeout. Isolating


### PR DESCRIPTION
## Summary
Stop-the-line fix for the intel-runner shared cargo registry race that is blocking aprender PRs #1031..#1042 (11 PRs, SHIP-TWO-001 algorithmic coverage).

## Problem

All 11 stacked PRs (plus unrelated PR #1025 itself) currently fail `ci / security` or `workspace-test` with variants of:

```
error: couldn't read /home/noah/.cargo/registry/src/<crate>/lib.rs: Permission denied (os error 13)
error: could not compile `fnv` (lib) due to 1 previous error
```

or the rustix-0.38 version (`E0432: unresolved import libc` / `libc_errno` from the `syscall` macro that regenerates from extracted src/).

## Root cause (five whys — full write-up in paiml/infra#77)

1. `ci / security` fails → `cargo install cargo-audit` can't read `fnv-1.0.7/lib.rs`.
2. EACCES → file is missing or owned by a different UID.
3. Who else writes? → the 16 `intel-clean-room-*` runners that ALL bind-mount the SAME host `/home/noah/.cargo/registry`, plus `ci-reaper.sh` sweeping `src/` on a TTL.
4. Why shared? → `ci.yml:49` was authored for throughput (avoid ~200 MB crate re-download per job). Race class not modeled.
5. Why not fixed sooner? → `target/` hit the exact same race (task #134) and was fixed by per-PR isolation on `/mnt/nvme-raid0/targets/aprender-ci/<pr#>`. The registry never got the same treatment.

PR #1025's self-heal is a band-aid that only runs inside `ci / security` and itself races with concurrent jobs. It does not close the class.

## Fix

Mirror the existing target-dir pattern (ci.yml:55) for the cargo registry:

```diff
       volumes:
-        - /home/noah/.cargo/registry:/usr/local/cargo/registry
+        - /mnt/nvme-raid0/cargo-ci/registry/${{ github.event.pull_request.number || github.ref_name }}:/usr/local/cargo/registry
```

Each PR now owns its registry lifecycle. No cross-PR writes → no race.

## Cost
- First-run cache miss: ~200 MB crate download per PR. Same profile the fleet already absorbed for the `target/` fix.
- Run 2+ on the same PR: cache hit, no extra cost.

## Follow-up (paiml/infra#77)
- Forjar recipe: pre-create `/mnt/nvme-raid0/cargo-ci/` owner=noah:noah, 0755, on all 16 intel runners.
- Reaper: extend `machines/intel/sovereign-ci/systemd/reaper/ci-reaper.sh:308` TTL sweep to include `/mnt/nvme-raid0/cargo-ci/registry/*/src`.
- Once infra PR lands, drop the ANDON comment in this ci.yml.

Docker auto-creates the mount-source leaf dir on first run, so this PR is landable standalone; infra PR only improves GC.

## Test plan
- [ ] Own CI runs to completion on `ci / security` and `workspace-test` on the new mount (proves the race is gone on the fresh per-PR path).
- [ ] After merge, aprender #1031..#1042 rebase onto new main; CI passes end-to-end.
- [ ] 24h soak: confirm no EACCES recurrence across next 20+ PR runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)