### PR TITLE
feat(format): apr_v2 stamp_provenance_bytes helper — SHIP-009 full-discharge enabler

### DIFF
--- a/contracts/apr-cli-commands-v1.yaml
+++ b/contracts/apr-cli-commands-v1.yaml
@@ -155,6 +155,12 @@ commands:
     requires_model: true
     side_effects: [filesystem]
 
+  - name: stamp
+    category: model_ops
+    description: "Stamp provenance fields (license, data_source, data_license) onto an existing .apr file"
+    requires_model: true
+    side_effects: [filesystem]
+
   - name: compile
     category: model_ops
     description: "Compile model into standalone executable"

--- a/crates/apr-cli/src/commands/mod.rs
+++ b/crates/apr-cli/src/commands/mod.rs
@@ -114,6 +114,7 @@ pub(crate) mod shared_cache;
 pub(crate) mod shared_cache_lint;
 pub(crate) mod showcase;
 pub(crate) mod sign_artifacts;
+pub(crate) mod stamp;
 pub(crate) mod stop_op;
 pub(crate) mod tensors;
 pub(crate) mod token_redactor;

--- a/crates/apr-cli/src/commands/stamp.rs
+++ b/crates/apr-cli/src/commands/stamp.rs
@@ -1,0 +1,254 @@
+//! `apr stamp` — write provenance fields onto an existing APR v2 file.
+//!
+//! Wraps `aprender::format::v2::stamp_provenance_bytes` (PR #1050) so the
+//! shipped MODEL-1 teacher (and any other pre-`GATE-APR-PROV-001..003`
+//! `.apr`) can have its `license` / `data_source` / `data_license`
+//! populated post-hoc, unblocking SHIP-009 full discharge.
+//!
+//! Spec: `docs/specifications/aprender-train/ship-two-models-spec.md`
+//! §v2.52.0 atomic next action (2) "Teacher provenance gap".
+//! Helper: `aprender::format::v2::stamp_provenance_bytes`.
+
+use crate::error::{CliError, Result};
+use aprender::format::v2::{stamp_provenance_bytes, AprV2Reader, ProvenancePatch};
+use std::fs;
+use std::path::Path;
+
+/// Run the stamp command — read input `.apr`, patch the three provenance
+/// fields if any are provided, write to output, then verify by re-reading.
+///
+/// At least one of `license` / `data_source` / `data_license` must be
+/// `Some(...)`; the helper rejects an empty patch on its own, but we
+/// also surface a clear CLI error message to keep the failure mode
+/// human-readable.
+pub(crate) fn run(
+    file: &Path,
+    license: Option<&str>,
+    data_source: Option<&str>,
+    data_license: Option<&str>,
+    output: &Path,
+    force: bool,
+    json_output: bool,
+) -> Result<()> {
+    if license.is_none() && data_source.is_none() && data_license.is_none() {
+        return Err(CliError::ValidationFailed(
+            "apr stamp: at least one of --license, --data-source, --data-license \
+             must be specified — refusing to rewrite without changes"
+                .to_string(),
+        ));
+    }
+
+    if !file.exists() {
+        return Err(CliError::FileNotFound(file.to_path_buf()));
+    }
+    if output.exists() && !force {
+        return Err(CliError::ValidationFailed(format!(
+            "Output file '{}' already exists. Use --force to overwrite.",
+            output.display()
+        )));
+    }
+
+    if !json_output {
+        eprintln!("Reading {}", file.display());
+    }
+    let input = fs::read(file)
+        .map_err(|e| CliError::ValidationFailed(format!("read failed: {e}")))?;
+
+    let patch = ProvenancePatch {
+        license: license.map(str::to_string),
+        data_source: data_source.map(str::to_string),
+        data_license: data_license.map(str::to_string),
+    };
+
+    let stamped = stamp_provenance_bytes(&input, &patch)
+        .map_err(|e| CliError::ValidationFailed(format!("stamp failed: {e:?}")))?;
+
+    fs::write(output, &stamped)
+        .map_err(|e| CliError::ValidationFailed(format!("write failed: {e}")))?;
+
+    // Re-read to confirm round-trip succeeded — a stamp that produces a
+    // file that doesn't parse back is a hard ship-blocker, fail fast.
+    let verify_reader = AprV2Reader::from_bytes(&stamped)
+        .map_err(|e| CliError::ValidationFailed(format!("post-stamp verify failed: {e:?}")))?;
+
+    if json_output {
+        let summary = serde_json::json!({
+            "command":      "stamp",
+            "input":        file.display().to_string(),
+            "output":       output.display().to_string(),
+            "input_bytes":  input.len(),
+            "output_bytes": stamped.len(),
+            "tensor_count": verify_reader.tensor_names().len(),
+            "stamped":      {
+                "license":      verify_reader.metadata().license,
+                "data_source":  verify_reader.metadata().data_source,
+                "data_license": verify_reader.metadata().data_license,
+            },
+            "header_flags_bits": verify_reader.header().flags.bits(),
+        });
+        println!("{}", serde_json::to_string_pretty(&summary).unwrap_or_default());
+    } else {
+        println!(
+            "✓ Stamped {} → {} ({} tensors, {} → {} bytes)",
+            file.display(),
+            output.display(),
+            verify_reader.tensor_names().len(),
+            input.len(),
+            stamped.len(),
+        );
+        println!("  license:      {:?}", verify_reader.metadata().license);
+        println!("  data_source:  {:?}", verify_reader.metadata().data_source);
+        println!("  data_license: {:?}", verify_reader.metadata().data_license);
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aprender::format::v2::{AprV2Metadata, AprV2Writer, TensorDType};
+    use tempfile::TempDir;
+
+    /// Build a minimal valid APR v2 file at `path` with no provenance fields set.
+    fn write_unpopulated_apr(path: &Path) {
+        let metadata = AprV2Metadata::new("stamp-cli-test");
+        let mut writer = AprV2Writer::new(metadata);
+        writer.add_tensor(
+            "weight",
+            TensorDType::F32,
+            vec![2, 3],
+            vec![0u8; 24],
+        );
+        let bytes = writer.write().expect("write test apr");
+        fs::write(path, &bytes).expect("write test apr to disk");
+    }
+
+    #[test]
+    fn stamp_cli_populates_all_three_fields() {
+        let dir = TempDir::new().unwrap();
+        let input = dir.path().join("input.apr");
+        let output = dir.path().join("output.apr");
+        write_unpopulated_apr(&input);
+
+        let result = run(
+            &input,
+            Some("Apache-2.0"),
+            Some("huggingface.co/Qwen/Qwen2.5-Coder-7B-Instruct"),
+            Some("Apache-2.0"),
+            &output,
+            false,
+            true, // json_output to keep stdout structured
+        );
+        assert!(result.is_ok(), "stamp run must succeed: {result:?}");
+
+        let bytes = fs::read(&output).unwrap();
+        let reader = AprV2Reader::from_bytes(&bytes).unwrap();
+        assert_eq!(reader.metadata().license.as_deref(), Some("Apache-2.0"));
+        assert_eq!(
+            reader.metadata().data_source.as_deref(),
+            Some("huggingface.co/Qwen/Qwen2.5-Coder-7B-Instruct")
+        );
+        assert_eq!(
+            reader.metadata().data_license.as_deref(),
+            Some("Apache-2.0")
+        );
+    }
+
+    #[test]
+    fn stamp_cli_rejects_empty_patch() {
+        let dir = TempDir::new().unwrap();
+        let input = dir.path().join("input.apr");
+        let output = dir.path().join("output.apr");
+        write_unpopulated_apr(&input);
+
+        let result = run(&input, None, None, None, &output, false, true);
+        let err = result.unwrap_err();
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("at least one"),
+            "empty-patch CLI error must be explicit: {msg}"
+        );
+        // Output file must NOT have been written.
+        assert!(
+            !output.exists(),
+            "rejected stamp must not create the output file"
+        );
+    }
+
+    #[test]
+    fn stamp_cli_rejects_missing_input() {
+        let dir = TempDir::new().unwrap();
+        let input = dir.path().join("does-not-exist.apr");
+        let output = dir.path().join("output.apr");
+
+        let result = run(
+            &input,
+            Some("Apache-2.0"),
+            None,
+            None,
+            &output,
+            false,
+            true,
+        );
+        let err = result.unwrap_err();
+        // CliError::FileNotFound — exact variant, not just substring match.
+        assert!(
+            matches!(err, CliError::FileNotFound(_)),
+            "missing-input must surface FileNotFound, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn stamp_cli_rejects_existing_output_without_force() {
+        let dir = TempDir::new().unwrap();
+        let input = dir.path().join("input.apr");
+        let output = dir.path().join("output.apr");
+        write_unpopulated_apr(&input);
+        fs::write(&output, b"pre-existing").unwrap();
+
+        let result = run(
+            &input,
+            Some("Apache-2.0"),
+            None,
+            None,
+            &output,
+            false, // force=false
+            true,
+        );
+        let err = result.unwrap_err();
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("already exists") && msg.contains("--force"),
+            "existing-output error must mention --force: {msg}"
+        );
+        // Pre-existing content must be untouched.
+        let still_there = fs::read(&output).unwrap();
+        assert_eq!(still_there, b"pre-existing");
+    }
+
+    #[test]
+    fn stamp_cli_overwrites_existing_output_with_force() {
+        let dir = TempDir::new().unwrap();
+        let input = dir.path().join("input.apr");
+        let output = dir.path().join("output.apr");
+        write_unpopulated_apr(&input);
+        fs::write(&output, b"pre-existing").unwrap();
+
+        let result = run(
+            &input,
+            Some("MIT"),
+            None,
+            None,
+            &output,
+            true, // force=true
+            true,
+        );
+        assert!(result.is_ok(), "stamp with --force must succeed: {result:?}");
+
+        // Output must now be a valid APR file with the patched license.
+        let bytes = fs::read(&output).unwrap();
+        let reader = AprV2Reader::from_bytes(&bytes).expect("force-overwritten file must parse");
+        assert_eq!(reader.metadata().license.as_deref(), Some("MIT"));
+    }
+}

--- a/crates/apr-cli/src/commands_enum.rs
+++ b/crates/apr-cli/src/commands_enum.rs
@@ -407,6 +407,32 @@ pub enum Commands {
         #[arg(short, long)]
         force: bool,
     },
+    /// Stamp provenance fields (license, data_source, data_license) onto an existing .apr file
+    ///
+    /// SHIP-009 full-discharge enabler — patches the three provenance fields on
+    /// a pre-built APR v2 artifact (e.g., the shipped MODEL-1 teacher whose
+    /// fields are all (missing) because it was built before GATE-APR-PROV-001..003
+    /// shipped). Tensor bytes and header flags are preserved verbatim.
+    Stamp {
+        /// Path to input .apr model file
+        #[arg(value_name = "FILE")]
+        file: PathBuf,
+        /// SPDX license identifier (e.g., Apache-2.0)
+        #[arg(long)]
+        license: Option<String>,
+        /// Training-data source (e.g., huggingface.co/Qwen/Qwen2.5-Coder-7B-Instruct)
+        #[arg(long = "data-source")]
+        data_source: Option<String>,
+        /// SPDX license for data_source (e.g., Apache-2.0)
+        #[arg(long = "data-license")]
+        data_license: Option<String>,
+        /// Output file path
+        #[arg(short, long)]
+        output: PathBuf,
+        /// Force overwrite existing files
+        #[arg(short, long)]
+        force: bool,
+    },
     /// Compile model into standalone executable (APR-SPEC §4.16)
     Compile {
         /// Input .apr model file

--- a/crates/apr-cli/src/dispatch.rs
+++ b/crates/apr-cli/src/dispatch.rs
@@ -392,6 +392,24 @@ fn dispatch_format_commands(cli: &Cli) -> Option<Result<(), CliError>> {
                 cli.json,
             )
         }),
+        Commands::Stamp {
+            file,
+            license,
+            data_source,
+            data_license,
+            output,
+            force,
+        } => crate::error::resolve_model_path(file).and_then(|r| {
+            stamp::run(
+                &r,
+                license.as_deref(),
+                data_source.as_deref(),
+                data_license.as_deref(),
+                output,
+                *force,
+                cli.json,
+            )
+        }),
         Commands::Compile {
             file,
             output,

--- a/crates/apr-cli/src/lib.rs
+++ b/crates/apr-cli/src/lib.rs
@@ -48,8 +48,8 @@ use commands::{
     bench, canary, canary::CanaryCommands, cbtop, chat, compare_hf, compile, convert, data, debug,
     diagnose, diff, distill, eval, explain, export, flow, hex, import, inspect, lint, mcp, merge,
     oracle, pipeline, probar, profile, prune, publish, pull, qa, qualify, quantize, rosetta,
-    rosetta::RosettaCommands, run, serve, showcase, tensors, tokenize, trace, tree, tui, validate,
-    validate_manifest,
+    rosetta::RosettaCommands, run, serve, showcase, stamp, tensors, tokenize, trace, tree, tui,
+    validate, validate_manifest,
 };
 #[cfg(feature = "training")]
 use commands::{finetune, gpu, train, tune};

--- a/crates/apr-cli/tests/cli_commands.rs
+++ b/crates/apr-cli/tests/cli_commands.rs
@@ -49,6 +49,7 @@ fn registered_commands() -> Vec<&'static str> {
         "export",
         "import",
         "convert",
+        "stamp",
         "compile",
         "merge",
         "quantize",

--- a/crates/aprender-core/src/format/v2/mod.rs
+++ b/crates/aprender-core/src/format/v2/mod.rs
@@ -360,3 +360,10 @@ include!("writer.rs");
 include!("streaming_writer.rs");
 include!("reader_impl.rs");
 include!("v2format_error.rs");
+
+// Provenance stamping — SHIP-009 full-discharge enabler (task #141).
+// Lives as a real submodule (not `include!`) so its inline tests nest
+// cleanly under `v2::stamp::tests` rather than colliding with the
+// flat-scope tests already in `v2::tests`.
+pub mod stamp;
+pub use stamp::{stamp_provenance_bytes, ProvenancePatch};

--- a/crates/aprender-core/src/format/v2/stamp.rs
+++ b/crates/aprender-core/src/format/v2/stamp.rs
@@ -1,0 +1,279 @@
+//! APR v2 provenance stamping — SHIP-009 full-discharge enabler.
+//!
+//! Read an APR v2 file, patch its provenance metadata (`license`,
+//! `data_source`, `data_license`), re-serialize. Tensor bytes are copied
+//! verbatim; header flags (`QUANTIZED`, `HAS_VOCAB`, …) are preserved so
+//! round-tripping a quantized model does not silently drop the flag that
+//! downstream consumers branch on.
+//!
+//! Motivates: the 7B Q4_K teacher shipped at commit `06a3eae38` predates
+//! `GATE-APR-PROV-001/002/003` (commit `8f0607d42`), so its `.apr` has
+//! `license: None / data_source: None / data_license: None`. `apr inspect`
+//! renders those as `(missing)`, and `GATE-APR-PROV-004` — the algorithm
+//! gate for `AC-SHIP1-009` — rejects the `(None, None, None)` triple at
+//! full-discharge time. This helper closes the tooling gap; the release
+//! cycle (re-stamp → re-upload → manifest-sha256 refresh) is a follow-up.
+//!
+//! Contract reference: `contracts/apr-provenance-v1.yaml` (v1.1.0,
+//! GATE-APR-PROV-001..004). Spec reference:
+//! `docs/specifications/aprender-train/ship-two-models-spec.md` §4.2
+//! AC-SHIP1-009 + v2.52.0 amendment (teacher provenance gap).
+
+use super::{AprV2Reader, AprV2Writer, V2FormatError};
+
+/// In-place field patches. `None` means "leave unchanged"; `Some("")` is a
+/// legitimate explicit clear (not currently contract-approved but kept
+/// distinct from `None` so callers can express intent).
+#[derive(Debug, Clone, Default)]
+pub struct ProvenancePatch {
+    pub license: Option<String>,
+    pub data_source: Option<String>,
+    pub data_license: Option<String>,
+}
+
+impl ProvenancePatch {
+    /// `true` iff at least one field would change. Guards against a
+    /// no-op rewrite producing a pointless new file.
+    #[must_use]
+    pub fn has_any(&self) -> bool {
+        self.license.is_some() || self.data_source.is_some() || self.data_license.is_some()
+    }
+}
+
+/// Patch provenance metadata on an existing APR v2 buffer and return the
+/// re-serialized bytes.
+///
+/// # Errors
+/// Returns `V2FormatError::InvalidHeader` if:
+///   - `input` is not a valid APR v2 buffer (propagated from
+///     `AprV2Reader::from_bytes`)
+///   - `patch.has_any()` is `false` — a no-op stamp is rejected
+///     up-front so callers cannot accidentally rewrite without
+///     changing the artifact
+///
+/// # Guarantees
+///   - Header flags from `input` are preserved in the output (LAYOUT_ROW_MAJOR
+///     is always added regardless of input, per LAYOUT-002 jidoka)
+///   - Tensor bytes are copied verbatim — no quantize/dequantize round-trip
+///   - Sort-by-name ordering matches `AprV2Writer::write()` (tensor index
+///     is sorted, so the re-serialized index is canonical)
+///
+/// # Non-guarantees
+///   - Footer checksum WILL change (metadata bytes moved)
+///   - sha256 of the output file WILL differ from the input (by design —
+///     that is the whole point of a stamp operation)
+pub fn stamp_provenance_bytes(
+    input: &[u8],
+    patch: &ProvenancePatch,
+) -> Result<Vec<u8>, V2FormatError> {
+    if !patch.has_any() {
+        return Err(V2FormatError::InvalidHeader(
+            "stamp_provenance_bytes: patch has no fields set — \
+             refusing to rewrite without changes"
+                .to_string(),
+        ));
+    }
+
+    let reader = AprV2Reader::from_bytes(input)?;
+
+    let original_flags = reader.header().flags;
+    let mut new_metadata = reader.metadata().clone();
+
+    if let Some(ref lic) = patch.license {
+        new_metadata.license = Some(lic.clone());
+    }
+    if let Some(ref ds) = patch.data_source {
+        new_metadata.data_source = Some(ds.clone());
+    }
+    if let Some(ref dl) = patch.data_license {
+        new_metadata.data_license = Some(dl.clone());
+    }
+
+    let mut writer = AprV2Writer::new(new_metadata);
+    writer.set_header_flags(original_flags);
+
+    // Copy every tensor by name; AprV2Writer sorts by name internally on
+    // write(), so input ordering is irrelevant here.
+    for name in reader.tensor_names() {
+        let entry = reader
+            .get_tensor(name)
+            .ok_or_else(|| V2FormatError::InvalidHeader(format!("tensor {name} vanished")))?;
+        let data = reader
+            .get_tensor_data(name)
+            .ok_or_else(|| V2FormatError::InvalidHeader(format!("tensor {name} has no data")))?;
+        writer.add_tensor(
+            name.to_string(),
+            entry.dtype,
+            entry.shape.clone(),
+            data.to_vec(),
+        );
+    }
+
+    writer.write()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use super::super::{AprV2Flags, AprV2Metadata, TensorDType};
+
+    /// Build a minimal valid APR v2 buffer for round-trip tests.
+    fn minimal_apr_with_flags(flags: u16) -> Vec<u8> {
+        let metadata = AprV2Metadata::new("stamp-test");
+        let mut writer = AprV2Writer::new(metadata);
+        writer.set_header_flags(AprV2Flags::from_bits(flags));
+        writer.add_tensor(
+            "weight",
+            TensorDType::F32,
+            vec![2, 3],
+            vec![0u8; 24], // 2 * 3 * 4 bytes
+        );
+        writer.write().expect("write test apr")
+    }
+
+    #[test]
+    fn stamp_populates_all_three_fields_when_source_is_unpopulated() {
+        let input = minimal_apr_with_flags(0);
+        let patch = ProvenancePatch {
+            license: Some("Apache-2.0".into()),
+            data_source: Some("huggingface.co/Qwen/Qwen2.5-Coder-7B-Instruct".into()),
+            data_license: Some("Qwen-License-Agreement-v1".into()),
+        };
+
+        let output = stamp_provenance_bytes(&input, &patch).expect("stamp must succeed");
+
+        let reader = AprV2Reader::from_bytes(&output).expect("stamped buffer must parse");
+        let md = reader.metadata();
+        assert_eq!(md.license.as_deref(), Some("Apache-2.0"));
+        assert_eq!(
+            md.data_source.as_deref(),
+            Some("huggingface.co/Qwen/Qwen2.5-Coder-7B-Instruct")
+        );
+        assert_eq!(md.data_license.as_deref(), Some("Qwen-License-Agreement-v1"));
+    }
+
+    #[test]
+    fn stamp_preserves_tensor_data_byte_for_byte() {
+        let input = minimal_apr_with_flags(0);
+        let input_reader = AprV2Reader::from_bytes(&input).unwrap();
+        let original_bytes: Vec<u8> = input_reader
+            .get_tensor_data("weight")
+            .expect("input has weight")
+            .to_vec();
+
+        let patch = ProvenancePatch {
+            license: Some("MIT".into()),
+            ..Default::default()
+        };
+        let output = stamp_provenance_bytes(&input, &patch).unwrap();
+
+        let out_reader = AprV2Reader::from_bytes(&output).unwrap();
+        let round_tripped = out_reader
+            .get_tensor_data("weight")
+            .expect("output has weight");
+
+        assert_eq!(
+            original_bytes.as_slice(),
+            round_tripped,
+            "tensor bytes must survive stamp verbatim"
+        );
+    }
+
+    #[test]
+    fn stamp_preserves_header_flags() {
+        // Simulate a quantized source: set QUANTIZED | HAS_VOCAB on input.
+        let flags = AprV2Flags::QUANTIZED | AprV2Flags::HAS_VOCAB;
+        let input = minimal_apr_with_flags(flags);
+
+        let in_reader = AprV2Reader::from_bytes(&input).unwrap();
+        assert!(in_reader.header().flags.contains(AprV2Flags::QUANTIZED));
+        assert!(in_reader.header().flags.contains(AprV2Flags::HAS_VOCAB));
+
+        let patch = ProvenancePatch {
+            license: Some("Apache-2.0".into()),
+            ..Default::default()
+        };
+        let output = stamp_provenance_bytes(&input, &patch).unwrap();
+
+        let out_reader = AprV2Reader::from_bytes(&output).unwrap();
+        // Input flags preserved:
+        assert!(
+            out_reader.header().flags.contains(AprV2Flags::QUANTIZED),
+            "QUANTIZED flag must survive stamp"
+        );
+        assert!(
+            out_reader.header().flags.contains(AprV2Flags::HAS_VOCAB),
+            "HAS_VOCAB flag must survive stamp"
+        );
+        // LAYOUT-002 jidoka still engaged:
+        assert!(
+            out_reader
+                .header()
+                .flags
+                .contains(AprV2Flags::LAYOUT_ROW_MAJOR),
+            "LAYOUT_ROW_MAJOR must always be set"
+        );
+    }
+
+    #[test]
+    fn stamp_rejects_empty_patch() {
+        let input = minimal_apr_with_flags(0);
+        let empty = ProvenancePatch::default();
+        let err = stamp_provenance_bytes(&input, &empty).unwrap_err();
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("patch has no fields"),
+            "empty-patch error must be explicit: {msg}"
+        );
+    }
+
+    #[test]
+    fn stamp_allows_partial_patch_leaving_other_fields_unchanged() {
+        // Input already has a license (pretend) but no data_* fields.
+        let mut md = AprV2Metadata::new("partial-test");
+        md.license = Some("Apache-2.0".into());
+        let mut writer = AprV2Writer::new(md);
+        writer.add_tensor("w", TensorDType::F32, vec![4], vec![0u8; 16]);
+        let input = writer.write().unwrap();
+
+        // Only patch data_source.
+        let patch = ProvenancePatch {
+            data_source: Some("teacher-only".into()),
+            ..Default::default()
+        };
+        let output = stamp_provenance_bytes(&input, &patch).unwrap();
+
+        let out_reader = AprV2Reader::from_bytes(&output).unwrap();
+        assert_eq!(
+            out_reader.metadata().license.as_deref(),
+            Some("Apache-2.0"),
+            "unchanged license must survive"
+        );
+        assert_eq!(
+            out_reader.metadata().data_source.as_deref(),
+            Some("teacher-only"),
+            "patched data_source must land"
+        );
+        assert!(
+            out_reader.metadata().data_license.is_none(),
+            "untouched data_license must remain None"
+        );
+    }
+
+    #[test]
+    fn stamp_is_idempotent_under_identical_patch() {
+        let input = minimal_apr_with_flags(0);
+        let patch = ProvenancePatch {
+            license: Some("Apache-2.0".into()),
+            data_source: Some("teacher-only".into()),
+            data_license: Some("Apache-2.0".into()),
+        };
+
+        let first = stamp_provenance_bytes(&input, &patch).unwrap();
+        let second = stamp_provenance_bytes(&first, &patch).unwrap();
+        assert_eq!(
+            first, second,
+            "applying the same patch twice must be byte-identical (idempotent)"
+        );
+    }
+}

--- a/crates/aprender-core/src/format/v2/writer.rs
+++ b/crates/aprender-core/src/format/v2/writer.rs
@@ -262,6 +262,19 @@ impl AprV2Writer {
         self
     }
 
+    /// Preserve header flags from an existing APR file on round-trip.
+    ///
+    /// Used by `stamp_provenance_bytes` so that QUANTIZED / HAS_VOCAB /
+    /// HAS_MODEL_CARD / etc. set on the input are carried across — without
+    /// this, `AprV2Writer::new()` would emit an output with only
+    /// `LAYOUT_ROW_MAJOR` set and downstream consumers that branch on
+    /// `QUANTIZED` would silently see a different file. `LAYOUT_ROW_MAJOR`
+    /// is always included regardless of the passed-in value so the
+    /// LAYOUT-002 jidoka guard never disengages.
+    pub fn set_header_flags(&mut self, flags: AprV2Flags) {
+        self.header.flags = flags.with(AprV2Flags::LAYOUT_ROW_MAJOR);
+    }
+
     /// Set sharding info
     pub fn with_sharding(&mut self, shard_count: usize, shard_index: usize) -> &mut Self {
         self.header.flags = self.header.flags.with(AprV2Flags::SHARDED);


### PR DESCRIPTION
## Summary (combined: helper + CLI)

This PR now bundles **two commits** that land SHIP-009 full-discharge tooling end-to-end:

1. `aprender::format::v2::stamp_provenance_bytes` — pure Rust helper to patch `license` / `data_source` / `data_license` on an existing APR v2 buffer. Tensor bytes and header flags preserved.
2. `apr stamp <input.apr> --license X --data-source Y --data-license Z --output <out.apr> [--force] [--json]` — CLI subcommand wired over the helper.

(PR #1051 was opened against this branch and squash-merged in, so both commits ride together.)

## Live dogfood on the actual MODEL-1 teacher (RTX 4090 host, noah-Lambda-Vector)

```
$ apr stamp /mnt/nvme-raid0/models/ship-two-001/qwen2.5-coder-7b-instruct-q4k.apr \
    --license "Apache-2.0" \
    --data-source "huggingface.co/Qwen/Qwen2.5-Coder-7B-Instruct" \
    --data-license "Apache-2.0" \
    --output /tmp/stamped.apr \
    --json
{
  "input_bytes":  8035635524,
  "output_bytes": 8035635652,
  "tensor_count": 339,
  "stamped": {
    "license":      "Apache-2.0",
    "data_source":  "huggingface.co/Qwen/Qwen2.5-Coder-7B-Instruct",
    "data_license": "Apache-2.0"
  }
}
```

Verification via `apr inspect`:
- **Input** (shipped teacher): `license: (missing), data_source: (missing), data_license: (missing)`
- **Stamped output**: all three populated, 339/339 tensors preserved, `+128 bytes` overhead (JSON metadata expansion on 7.48 GiB file), LAYOUT_ROW_MAJOR retained, checksum validates.

## Why this matters

Shipped MODEL-1 teacher (`paiml/qwen2.5-coder-7b-apache-q4k-v1`) was built at commit `06a3eae38` (spec v2.11.0) **before** `GATE-APR-PROV-001/002/003` shipped at `8f0607d42` (post-v2.19). `GATE-APR-PROV-004` rejects the `(None, None, None)` triple → SHIP-009 stuck at PARTIAL_ALGORITHM_LEVEL. This PR closes the **tooling gap**.

## Tests

| Suite                                          | Pass |
|------------------------------------------------|------|
| `cargo test -p aprender-core --lib format::v2::stamp` | 6/6 |
| `cargo test -p apr-cli --lib commands::stamp`         | 5/5 |

Plus 1 live dogfood smoke on the 7.48 GiB shipped teacher.

## What this PR does NOT include

- Re-uploading the stamped teacher to HF.
- Refreshing the publish-manifest sha256.
- Retriggering EX-04..EX-07 evidence.

That's the **release-cycle portion** of SHIP-009 full discharge — separate from this tooling PR.

## Spec reference

`docs/specifications/aprender-train/ship-two-models-spec.md` §v2.52.0 atomic next action (2) "Teacher provenance gap".

## Closes

Tasks #141 (helper scaffolding) + #142 (CLI wiring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)