### PR TITLE
feat(apr-cli): apr stamp subcommand — wire stamp_provenance_bytes helper to CLI

### DIFF
--- a/crates/apr-cli/src/commands/mod.rs
+++ b/crates/apr-cli/src/commands/mod.rs
@@ -114,6 +114,7 @@ pub(crate) mod shared_cache;
 pub(crate) mod shared_cache_lint;
 pub(crate) mod showcase;
 pub(crate) mod sign_artifacts;
+pub(crate) mod stamp;
 pub(crate) mod stop_op;
 pub(crate) mod tensors;
 pub(crate) mod token_redactor;

--- a/crates/apr-cli/src/commands/stamp.rs
+++ b/crates/apr-cli/src/commands/stamp.rs
@@ -1,0 +1,254 @@
+//! `apr stamp` — write provenance fields onto an existing APR v2 file.
+//!
+//! Wraps `aprender::format::v2::stamp_provenance_bytes` (PR #1050) so the
+//! shipped MODEL-1 teacher (and any other pre-`GATE-APR-PROV-001..003`
+//! `.apr`) can have its `license` / `data_source` / `data_license`
+//! populated post-hoc, unblocking SHIP-009 full discharge.
+//!
+//! Spec: `docs/specifications/aprender-train/ship-two-models-spec.md`
+//! §v2.52.0 atomic next action (2) "Teacher provenance gap".
+//! Helper: `aprender::format::v2::stamp_provenance_bytes`.
+
+use crate::error::{CliError, Result};
+use aprender::format::v2::{stamp_provenance_bytes, AprV2Reader, ProvenancePatch};
+use std::fs;
+use std::path::Path;
+
+/// Run the stamp command — read input `.apr`, patch the three provenance
+/// fields if any are provided, write to output, then verify by re-reading.
+///
+/// At least one of `license` / `data_source` / `data_license` must be
+/// `Some(...)`; the helper rejects an empty patch on its own, but we
+/// also surface a clear CLI error message to keep the failure mode
+/// human-readable.
+pub(crate) fn run(
+    file: &Path,
+    license: Option<&str>,
+    data_source: Option<&str>,
+    data_license: Option<&str>,
+    output: &Path,
+    force: bool,
+    json_output: bool,
+) -> Result<()> {
+    if license.is_none() && data_source.is_none() && data_license.is_none() {
+        return Err(CliError::ValidationFailed(
+            "apr stamp: at least one of --license, --data-source, --data-license \
+             must be specified — refusing to rewrite without changes"
+                .to_string(),
+        ));
+    }
+
+    if !file.exists() {
+        return Err(CliError::FileNotFound(file.to_path_buf()));
+    }
+    if output.exists() && !force {
+        return Err(CliError::ValidationFailed(format!(
+            "Output file '{}' already exists. Use --force to overwrite.",
+            output.display()
+        )));
+    }
+
+    if !json_output {
+        eprintln!("Reading {}", file.display());
+    }
+    let input = fs::read(file)
+        .map_err(|e| CliError::ValidationFailed(format!("read failed: {e}")))?;
+
+    let patch = ProvenancePatch {
+        license: license.map(str::to_string),
+        data_source: data_source.map(str::to_string),
+        data_license: data_license.map(str::to_string),
+    };
+
+    let stamped = stamp_provenance_bytes(&input, &patch)
+        .map_err(|e| CliError::ValidationFailed(format!("stamp failed: {e:?}")))?;
+
+    fs::write(output, &stamped)
+        .map_err(|e| CliError::ValidationFailed(format!("write failed: {e}")))?;
+
+    // Re-read to confirm round-trip succeeded — a stamp that produces a
+    // file that doesn't parse back is a hard ship-blocker, fail fast.
+    let verify_reader = AprV2Reader::from_bytes(&stamped)
+        .map_err(|e| CliError::ValidationFailed(format!("post-stamp verify failed: {e:?}")))?;
+
+    if json_output {
+        let summary = serde_json::json!({
+            "command":      "stamp",
+            "input":        file.display().to_string(),
+            "output":       output.display().to_string(),
+            "input_bytes":  input.len(),
+            "output_bytes": stamped.len(),
+            "tensor_count": verify_reader.tensor_names().len(),
+            "stamped":      {
+                "license":      verify_reader.metadata().license,
+                "data_source":  verify_reader.metadata().data_source,
+                "data_license": verify_reader.metadata().data_license,
+            },
+            "header_flags_bits": verify_reader.header().flags.bits(),
+        });
+        println!("{}", serde_json::to_string_pretty(&summary).unwrap_or_default());
+    } else {
+        println!(
+            "✓ Stamped {} → {} ({} tensors, {} → {} bytes)",
+            file.display(),
+            output.display(),
+            verify_reader.tensor_names().len(),
+            input.len(),
+            stamped.len(),
+        );
+        println!("  license:      {:?}", verify_reader.metadata().license);
+        println!("  data_source:  {:?}", verify_reader.metadata().data_source);
+        println!("  data_license: {:?}", verify_reader.metadata().data_license);
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aprender::format::v2::{AprV2Metadata, AprV2Writer, TensorDType};
+    use tempfile::TempDir;
+
+    /// Build a minimal valid APR v2 file at `path` with no provenance fields set.
+    fn write_unpopulated_apr(path: &Path) {
+        let metadata = AprV2Metadata::new("stamp-cli-test");
+        let mut writer = AprV2Writer::new(metadata);
+        writer.add_tensor(
+            "weight",
+            TensorDType::F32,
+            vec![2, 3],
+            vec![0u8; 24],
+        );
+        let bytes = writer.write().expect("write test apr");
+        fs::write(path, &bytes).expect("write test apr to disk");
+    }
+
+    #[test]
+    fn stamp_cli_populates_all_three_fields() {
+        let dir = TempDir::new().unwrap();
+        let input = dir.path().join("input.apr");
+        let output = dir.path().join("output.apr");
+        write_unpopulated_apr(&input);
+
+        let result = run(
+            &input,
+            Some("Apache-2.0"),
+            Some("huggingface.co/Qwen/Qwen2.5-Coder-7B-Instruct"),
+            Some("Apache-2.0"),
+            &output,
+            false,
+            true, // json_output to keep stdout structured
+        );
+        assert!(result.is_ok(), "stamp run must succeed: {result:?}");
+
+        let bytes = fs::read(&output).unwrap();
+        let reader = AprV2Reader::from_bytes(&bytes).unwrap();
+        assert_eq!(reader.metadata().license.as_deref(), Some("Apache-2.0"));
+        assert_eq!(
+            reader.metadata().data_source.as_deref(),
+            Some("huggingface.co/Qwen/Qwen2.5-Coder-7B-Instruct")
+        );
+        assert_eq!(
+            reader.metadata().data_license.as_deref(),
+            Some("Apache-2.0")
+        );
+    }
+
+    #[test]
+    fn stamp_cli_rejects_empty_patch() {
+        let dir = TempDir::new().unwrap();
+        let input = dir.path().join("input.apr");
+        let output = dir.path().join("output.apr");
+        write_unpopulated_apr(&input);
+
+        let result = run(&input, None, None, None, &output, false, true);
+        let err = result.unwrap_err();
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("at least one"),
+            "empty-patch CLI error must be explicit: {msg}"
+        );
+        // Output file must NOT have been written.
+        assert!(
+            !output.exists(),
+            "rejected stamp must not create the output file"
+        );
+    }
+
+    #[test]
+    fn stamp_cli_rejects_missing_input() {
+        let dir = TempDir::new().unwrap();
+        let input = dir.path().join("does-not-exist.apr");
+        let output = dir.path().join("output.apr");
+
+        let result = run(
+            &input,
+            Some("Apache-2.0"),
+            None,
+            None,
+            &output,
+            false,
+            true,
+        );
+        let err = result.unwrap_err();
+        // CliError::FileNotFound — exact variant, not just substring match.
+        assert!(
+            matches!(err, CliError::FileNotFound(_)),
+            "missing-input must surface FileNotFound, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn stamp_cli_rejects_existing_output_without_force() {
+        let dir = TempDir::new().unwrap();
+        let input = dir.path().join("input.apr");
+        let output = dir.path().join("output.apr");
+        write_unpopulated_apr(&input);
+        fs::write(&output, b"pre-existing").unwrap();
+
+        let result = run(
+            &input,
+            Some("Apache-2.0"),
+            None,
+            None,
+            &output,
+            false, // force=false
+            true,
+        );
+        let err = result.unwrap_err();
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("already exists") && msg.contains("--force"),
+            "existing-output error must mention --force: {msg}"
+        );
+        // Pre-existing content must be untouched.
+        let still_there = fs::read(&output).unwrap();
+        assert_eq!(still_there, b"pre-existing");
+    }
+
+    #[test]
+    fn stamp_cli_overwrites_existing_output_with_force() {
+        let dir = TempDir::new().unwrap();
+        let input = dir.path().join("input.apr");
+        let output = dir.path().join("output.apr");
+        write_unpopulated_apr(&input);
+        fs::write(&output, b"pre-existing").unwrap();
+
+        let result = run(
+            &input,
+            Some("MIT"),
+            None,
+            None,
+            &output,
+            true, // force=true
+            true,
+        );
+        assert!(result.is_ok(), "stamp with --force must succeed: {result:?}");
+
+        // Output must now be a valid APR file with the patched license.
+        let bytes = fs::read(&output).unwrap();
+        let reader = AprV2Reader::from_bytes(&bytes).expect("force-overwritten file must parse");
+        assert_eq!(reader.metadata().license.as_deref(), Some("MIT"));
+    }
+}

--- a/crates/apr-cli/src/commands_enum.rs
+++ b/crates/apr-cli/src/commands_enum.rs
@@ -407,6 +407,32 @@ pub enum Commands {
         #[arg(short, long)]
         force: bool,
     },
+    /// Stamp provenance fields (license, data_source, data_license) onto an existing .apr file
+    ///
+    /// SHIP-009 full-discharge enabler — patches the three provenance fields on
+    /// a pre-built APR v2 artifact (e.g., the shipped MODEL-1 teacher whose
+    /// fields are all (missing) because it was built before GATE-APR-PROV-001..003
+    /// shipped). Tensor bytes and header flags are preserved verbatim.
+    Stamp {
+        /// Path to input .apr model file
+        #[arg(value_name = "FILE")]
+        file: PathBuf,
+        /// SPDX license identifier (e.g., Apache-2.0)
+        #[arg(long)]
+        license: Option<String>,
+        /// Training-data source (e.g., huggingface.co/Qwen/Qwen2.5-Coder-7B-Instruct)
+        #[arg(long = "data-source")]
+        data_source: Option<String>,
+        /// SPDX license for data_source (e.g., Apache-2.0)
+        #[arg(long = "data-license")]
+        data_license: Option<String>,
+        /// Output file path
+        #[arg(short, long)]
+        output: PathBuf,
+        /// Force overwrite existing files
+        #[arg(short, long)]
+        force: bool,
+    },
     /// Compile model into standalone executable (APR-SPEC §4.16)
     Compile {
         /// Input .apr model file

--- a/crates/apr-cli/src/dispatch.rs
+++ b/crates/apr-cli/src/dispatch.rs
@@ -392,6 +392,24 @@ fn dispatch_format_commands(cli: &Cli) -> Option<Result<(), CliError>> {
                 cli.json,
             )
         }),
+        Commands::Stamp {
+            file,
+            license,
+            data_source,
+            data_license,
+            output,
+            force,
+        } => crate::error::resolve_model_path(file).and_then(|r| {
+            stamp::run(
+                &r,
+                license.as_deref(),
+                data_source.as_deref(),
+                data_license.as_deref(),
+                output,
+                *force,
+                cli.json,
+            )
+        }),
         Commands::Compile {
             file,
             output,

--- a/crates/apr-cli/src/lib.rs
+++ b/crates/apr-cli/src/lib.rs
@@ -48,8 +48,8 @@ use commands::{
     bench, canary, canary::CanaryCommands, cbtop, chat, compare_hf, compile, convert, data, debug,
     diagnose, diff, distill, eval, explain, export, flow, hex, import, inspect, lint, mcp, merge,
     oracle, pipeline, probar, profile, prune, publish, pull, qa, qualify, quantize, rosetta,
-    rosetta::RosettaCommands, run, serve, showcase, tensors, tokenize, trace, tree, tui, validate,
-    validate_manifest,
+    rosetta::RosettaCommands, run, serve, showcase, stamp, tensors, tokenize, trace, tree, tui,
+    validate, validate_manifest,
 };
 #[cfg(feature = "training")]
 use commands::{finetune, gpu, train, tune};


### PR DESCRIPTION
## Summary

Wires `apr stamp <input.apr> --license X --data-source Y --data-license Z --output <out.apr>` over the `aprender::format::v2::stamp_provenance_bytes` helper from PR #1050.

**Stacked on PR #1050.** Auto-merge of #1050 will cascade into this branch's base.

## Live dogfood on the actual MODEL-1 teacher (RTX 4090 host)

```
$ apr stamp /mnt/nvme-raid0/models/ship-two-001/qwen2.5-coder-7b-instruct-q4k.apr \
    --license "Apache-2.0" \
    --data-source "huggingface.co/Qwen/Qwen2.5-Coder-7B-Instruct" \
    --data-license "Apache-2.0" \
    --output /tmp/stamped.apr \
    --json
{
  "command":      "stamp",
  "input_bytes":  8035635524,
  "output_bytes": 8035635652,
  "tensor_count": 339,
  "stamped": {
    "license":      "Apache-2.0",
    "data_source":  "huggingface.co/Qwen/Qwen2.5-Coder-7B-Instruct",
    "data_license": "Apache-2.0"
  }
}
```

Verified via `apr inspect`: shipped teacher had `license/data_source/data_license: (missing)`; stamped output has all three populated. 339/339 tensors preserved, +128 bytes (JSON metadata expansion on 7.48 GiB file), checksum validates.

## Tests (5/5 PASS)

- `stamp_cli_populates_all_three_fields`
- `stamp_cli_rejects_empty_patch` — explicit "at least one" error; output NOT created on failure
- `stamp_cli_rejects_missing_input` — surfaces `CliError::FileNotFound`
- `stamp_cli_rejects_existing_output_without_force` — error mentions `--force`; pre-existing content untouched
- `stamp_cli_overwrites_existing_output_with_force` — `--force` works correctly

## What this PR does NOT include

- Re-stamping the published teacher artifact + re-uploading to HF + refreshing publish-manifest sha256 + retriggering EX-04..EX-07. That is the release-cycle portion of SHIP-009 full discharge — this PR is the tooling.

## Spec reference

`docs/specifications/aprender-train/ship-two-models-spec.md` §v2.52.0 atomic next action (2) "Teacher provenance gap".

## Closes

CLI portion of task #142 / task #141 follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)