### PR TITLE
fix(ship-007): stabilize parity-gate reproducer (APR_SKIP_FP8_WARMUP) + fix flash_decode_seq_lens length-mismatch (Bug 2)

### DIFF
--- a/crates/aprender-serve/src/cuda/executor/flash_decoding_graphed.rs
+++ b/crates/aprender-serve/src/cuda/executor/flash_decoding_graphed.rs
@@ -99,7 +99,19 @@ impl CudaExecutor {
                     "PAR-118: flash_decode_seq_lens_buf not initialized".to_string(),
                 )
             })?;
-            buf.copy_from_host(&[seq_len])?;
+            // SHIP-007 Bug 2 fix: `flash_decode_seq_lens_buf` is sized for
+            // max_batch=32 (per batch.rs:444-445) so it can serve M>1 batched
+            // graph replay. For M=1 decode (like the parity-gate run), only
+            // slot 0 is used by the kernel. The previous `buf.copy_from_host(&[seq_len])`
+            // failed with `Length mismatch: host 1 vs device 32` because
+            // `copy_from_host` requires exact length match. Pad the host slice
+            // to the buffer length and write `seq_len` into slot 0; remaining
+            // slots are zero-initialized at allocation time and the kernel
+            // ignores them in single-batch mode. This unblocks `apr parity` /
+            // SKIP_CUDA_GRAPH=1 debugging on the 7B Q4_K teacher.
+            let mut seq_lens_padded = vec![0u32; buf.len()];
+            seq_lens_padded[0] = seq_len;
+            buf.copy_from_host(&seq_lens_padded)?;
             buf.as_ptr()
         };
 

--- a/crates/aprender-serve/src/cuda/executor/kv_scatter.rs
+++ b/crates/aprender-serve/src/cuda/executor/kv_scatter.rs
@@ -580,7 +580,7 @@ impl CudaExecutor {
             for h in 0..3.min(num_heads) {
                 let start = h * head_dim;
                 eprintln!(
-                    "[CORRECTNESS-013-ATTN] Head {} first 5: {:?}",
+                    "[CORRECTNESS-013-ATTN] Head {} first 16: {:?}",
                     h,
                     &attn_out[start..start + 5]
                 );
@@ -616,7 +616,7 @@ impl CudaExecutor {
         if k_nan > 0 {
             eprintln!("[PAR-058-ATTN] K input has {} NaN out of {}", k_nan, k_input.len());
         } else {
-            eprintln!("[PAR-058-ATTN] K input OK, first 5: {:?}", &k_input[..5.min(k_input.len())]);
+            eprintln!("[PAR-058-ATTN] K input OK, first 16: {:?}", &k_input[..16.min(k_input.len())]);
         }
         let mut q_input = vec![0.0f32; q_gpu.len()];
         q_gpu.copy_to_host(&mut q_input)?;
@@ -624,7 +624,7 @@ impl CudaExecutor {
         if q_nan > 0 {
             eprintln!("[PAR-058-ATTN] Q input has {} NaN out of {}", q_nan, q_input.len());
         } else {
-            eprintln!("[PAR-058-ATTN] Q input OK, first 5: {:?}", &q_input[..5.min(q_input.len())]);
+            eprintln!("[PAR-058-ATTN] Q input OK, first 16: {:?}", &q_input[..16.min(q_input.len())]);
         }
         let k_cache = self.kv_cache_gpu.get(k_key).ok_or_else(|| {
             GpuError::InvalidLaunchConfig(format!("K cache not found for {k_key}"))
@@ -636,9 +636,9 @@ impl CudaExecutor {
         if k_cache_nan > 0 {
             eprintln!("[PAR-058-ATTN] K cache has {} NaN", k_cache_nan);
         } else {
-            eprintln!("[PAR-058-ATTN] K cache head0 pos0 first 5: {:?}", &k_cache_vals[..5.min(k_cache_vals.len())]);
-            if new_len >= 2 && k_cache_vals.len() >= head_dim + 5 {
-                eprintln!("[PAR-058-ATTN] K cache head0 pos1 first 5: {:?}", &k_cache_vals[head_dim..(head_dim + 5).min(k_cache_vals.len())]);
+            eprintln!("[PAR-058-ATTN] K cache head0 pos0 first 16: {:?}", &k_cache_vals[..16.min(k_cache_vals.len())]);
+            if new_len >= 2 && k_cache_vals.len() >= head_dim + 16 {
+                eprintln!("[PAR-058-ATTN] K cache head0 pos1 first 16: {:?}", &k_cache_vals[head_dim..(head_dim + 16).min(k_cache_vals.len())]);
             }
         }
         let v_cache = self.kv_cache_gpu.get(v_key).ok_or_else(|| {
@@ -650,7 +650,7 @@ impl CudaExecutor {
         if v_cache_nan > 0 {
             eprintln!("[PAR-058-ATTN] V cache has {} NaN", v_cache_nan);
         } else {
-            eprintln!("[PAR-058-ATTN] V cache head0 pos0 first 5: {:?}", &v_cache_vals[..5.min(v_cache_vals.len())]);
+            eprintln!("[PAR-058-ATTN] V cache head0 pos0 first 16: {:?}", &v_cache_vals[..16.min(v_cache_vals.len())]);
         }
         Ok(())
     }

--- a/crates/aprender-serve/src/cuda/executor/layers/apply.rs
+++ b/crates/aprender-serve/src/cuda/executor/layers/apply.rs
@@ -48,10 +48,12 @@ impl CudaExecutor {
                     layer_idx, nan_count
                 );
             } else {
+                // SHIP-007 8th-pass: first 3 → first 16 to surface element-3+
+                // divergence within head 0 (head_dim=128).
                 eprintln!(
-                    "[PAR-058-L{}] RMSNorm OK, first 3: {:?}",
+                    "[PAR-058-L{}] RMSNorm OK, first 16: {:?}",
                     layer_idx,
-                    &rmsnorm_out[..3.min(rmsnorm_out.len())]
+                    &rmsnorm_out[..16.min(rmsnorm_out.len())]
                 );
             }
         }
@@ -72,9 +74,10 @@ impl CudaExecutor {
                 "[CORRECTNESS-011-L0] Q4K GEMV params: n={}, k={}",
                 q_dim, hidden_dim
             );
+            // SHIP-007 8th-pass: first 5 → first 16
             eprintln!(
-                "[CORRECTNESS-011-L0] Input (hidden_buf1): first 5 = {:?}",
-                &input_check[..5.min(input_check.len())]
+                "[CORRECTNESS-011-L0] Input (hidden_buf1): first 16 = {:?}",
+                &input_check[..16.min(input_check.len())]
             );
             eprintln!(
                 "[CORRECTNESS-011-L0] Weight ptr = {:#x}, len = {}",

--- a/crates/aprender-serve/src/cuda/executor/layers/cublas_prefill/attention.rs
+++ b/crates/aprender-serve/src/cuda/executor/layers/cublas_prefill/attention.rs
@@ -1399,7 +1399,19 @@ DONE_NORM:
 
         // PMAT-082: cuBLASLt FP8 JIT warmup — eliminate 3ms first-request latency.
         // First cuBLASLt FP8 GEMM triggers JIT compilation; warm it here at model load.
-        if cached > 0 {
+        //
+        // SHIP-007 reproducer-stabilisation hook: this warmup intermittently
+        // produces `CUDA_ERROR_ILLEGAL_ADDRESS (code: 700)` on the
+        // 7B Q4_K teacher (3584-hidden) which poisons the CUDA context and
+        // makes downstream debugging instrumentation unreliable. Setting
+        // `APR_SKIP_FP8_WARMUP=1` skips warmup so `apr parity` /
+        // `GPU_DEBUG_ALL_LAYERS=1` runs can fire deterministically. Default
+        // (env unset) preserves the production warmup behaviour. See
+        // `memory/project_ship_007_attention_parity_investigation.md` —
+        // 5th-pass observation that the FP8 warmup is the context-poison
+        // source, separate from the underlying GQA-7:1 parity divergence.
+        let skip_warmup = std::env::var("APR_SKIP_FP8_WARMUP").is_ok();
+        if cached > 0 && !skip_warmup {
             if self.cublaslt_handle.is_none() {
                 self.cublaslt_handle = Some(trueno_gpu::driver::CublasLtHandle::new()?);
             }
@@ -1450,6 +1462,12 @@ DONE_NORM:
                 self.stream.synchronize()?;
                 eprintln!("[PMAT-082] cuBLASLt FP8 JIT warmed ({n_warmup}×{m_warmup}×{k_warmup})");
             }
+        } else if cached > 0 && skip_warmup {
+            eprintln!(
+                "[PMAT-082] FP8 JIT warmup SKIPPED (APR_SKIP_FP8_WARMUP=1) — \
+                 first FP8 inference will incur ~3ms JIT-compile latency. \
+                 SHIP-007 reproducer-stabilisation hook."
+            );
         }
 
         let elapsed = start.elapsed();

--- a/crates/aprender-serve/src/cuda/executor/layers/gemv_dispatch.rs
+++ b/crates/aprender-serve/src/cuda/executor/layers/gemv_dispatch.rs
@@ -15,9 +15,11 @@ impl CudaExecutor {
         if nan_count > 0 {
             eprintln!("[PAR-058-L{}] {} has {} NaN", layer_idx, label, nan_count);
         } else {
+            // SHIP-007 8th-pass: extended from first 3 → first 16 to surface
+            // element-3+ divergence (CPU element 3 = 0.05, GPU = 0.10 → 110% off).
             eprintln!(
-                "[PAR-058-L{}] {} OK, first 3: {:?}",
-                layer_idx, label, &host[..3.min(host.len())]
+                "[PAR-058-L{}] {} OK, first 16: {:?}",
+                layer_idx, label, &host[..16.min(host.len())]
             );
         }
         Ok(())

--- a/crates/aprender-serve/src/gguf/inference/forward/debug.rs
+++ b/crates/aprender-serve/src/gguf/inference/forward/debug.rs
@@ -254,8 +254,8 @@ impl OwnedQuantizedModel {
             let sq_sum: f32 = hidden.iter().map(|x| x * x).sum();
             let rms = (sq_sum / hidden.len() as f32).sqrt();
             eprintln!(
-                "[GQA-DEBUG-CPU-EMBED] Embedding before L0: first 5 = {:?}, sum={:.4}, rms={:.4}",
-                &hidden[..5.min(hidden.len())],
+                "[GQA-DEBUG-CPU-EMBED] Embedding before L0: first 16 = {:?}, sum={:.4}, rms={:.4}",
+                &hidden[..16.min(hidden.len())],
                 embed_sum,
                 rms
             );
@@ -272,11 +272,11 @@ impl OwnedQuantizedModel {
             let min = hidden.iter().cloned().fold(f32::INFINITY, f32::min);
             let max = hidden.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
             eprintln!(
-                "[PMAT-114-GGUF] After embed: mean={:.6}, min={:.6}, max={:.6}, first5={:?}",
+                "[PMAT-114-GGUF] After embed: mean={:.6}, min={:.6}, max={:.6}, first16={:?}",
                 mean,
                 min,
                 max,
-                &hidden[..5.min(hidden.len())]
+                &hidden[..16.min(hidden.len())]
             );
         }
     }
@@ -327,9 +327,9 @@ impl OwnedQuantizedModel {
             let k_bias = &bias[q_dim..q_dim + kv_dim];
             let k_bias_mean: f32 = k_bias.iter().sum::<f32>() / kv_dim as f32;
             eprintln!(
-                "[PMAT-114-GGUF] L0 K bias mean={:.6}, first5={:?}",
+                "[PMAT-114-GGUF] L0 K bias mean={:.6}, first16={:?}",
                 k_bias_mean,
-                &k_bias[..5.min(kv_dim)]
+                &k_bias[..16.min(kv_dim)]
             );
         }
 
@@ -344,7 +344,7 @@ impl OwnedQuantizedModel {
             q_mean, k_mean, v_mean
         );
         eprintln!(
-            "[PMAT-114-GGUF] L0 Q first5={:?}",
+            "[PMAT-114-GGUF] L0 Q first16={:?}",
             q.get(..5).unwrap_or(&[])
         );
     }
@@ -399,8 +399,8 @@ impl OwnedQuantizedModel {
             let sq_sum: f32 = hidden.iter().map(|x| x * x).sum();
             let rms = (sq_sum / hidden.len() as f32).sqrt();
             eprintln!(
-                "[GQA-DEBUG-CPU-L0] After layer 0: first 5 = {:?}, sum={:.4}, rms={:.4}",
-                &hidden[..5.min(hidden.len())],
+                "[GQA-DEBUG-CPU-L0] After layer 0: first 16 = {:?}, sum={:.4}, rms={:.4}",
+                &hidden[..16.min(hidden.len())],
                 hidden_sum,
                 rms
             );
@@ -414,12 +414,12 @@ impl OwnedQuantizedModel {
             let min = hidden.iter().cloned().fold(f32::INFINITY, f32::min);
             let max = hidden.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
             eprintln!(
-                "[PMAT-114-GGUF] After layer {}: mean={:.6}, min={:.6}, max={:.6}, first5={:?}",
+                "[PMAT-114-GGUF] After layer {}: mean={:.6}, min={:.6}, max={:.6}, first16={:?}",
                 layer_idx,
                 mean,
                 min,
                 max,
-                &hidden[..5.min(hidden.len())]
+                &hidden[..16.min(hidden.len())]
             );
         }
     }

--- a/crates/aprender-serve/src/gguf/inference/forward/ffn_block.rs
+++ b/crates/aprender-serve/src/gguf/inference/forward/ffn_block.rs
@@ -252,7 +252,7 @@ impl OwnedQuantizedModel {
         indexed.sort_by(|(_, a), (_, b)| b.partial_cmp(a).unwrap_or(std::cmp::Ordering::Equal));
         eprintln!(
             "[DEBUG-VERIFY] Top 5 tokens: {:?}",
-            &indexed[..5.min(indexed.len())]
+            &indexed[..16.min(indexed.len())]
         );
     }
 
@@ -278,8 +278,8 @@ impl OwnedQuantizedModel {
             let sq_sum: f32 = hidden.iter().map(|x| x * x).sum();
             let rms = (sq_sum / hidden.len() as f32).sqrt();
             eprintln!(
-                "[GQA-DEBUG-CPU-EMBED] Embedding before L0: first 5 = {:?}, sum={:.4}, rms={:.4}",
-                &hidden[..5.min(hidden.len())],
+                "[GQA-DEBUG-CPU-EMBED] Embedding before L0: first 16 = {:?}, sum={:.4}, rms={:.4}",
+                &hidden[..16.min(hidden.len())],
                 embed_sum,
                 rms
             );
@@ -296,11 +296,11 @@ impl OwnedQuantizedModel {
             let min = hidden.iter().cloned().fold(f32::INFINITY, f32::min);
             let max = hidden.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
             eprintln!(
-                "[PMAT-114-GGUF] After embed: mean={:.6}, min={:.6}, max={:.6}, first5={:?}",
+                "[PMAT-114-GGUF] After embed: mean={:.6}, min={:.6}, max={:.6}, first16={:?}",
                 mean,
                 min,
                 max,
-                &hidden[..5.min(hidden.len())]
+                &hidden[..16.min(hidden.len())]
             );
         }
     }
@@ -351,9 +351,9 @@ impl OwnedQuantizedModel {
             let k_bias = &bias[q_dim..q_dim + kv_dim];
             let k_bias_mean: f32 = k_bias.iter().sum::<f32>() / kv_dim as f32;
             eprintln!(
-                "[PMAT-114-GGUF] L0 K bias mean={:.6}, first5={:?}",
+                "[PMAT-114-GGUF] L0 K bias mean={:.6}, first16={:?}",
                 k_bias_mean,
-                &k_bias[..5.min(kv_dim)]
+                &k_bias[..16.min(kv_dim)]
             );
         }
 
@@ -368,7 +368,7 @@ impl OwnedQuantizedModel {
             q_mean, k_mean, v_mean
         );
         eprintln!(
-            "[PMAT-114-GGUF] L0 Q first5={:?}",
+            "[PMAT-114-GGUF] L0 Q first16={:?}",
             q.get(..5).unwrap_or(&[])
         );
     }
@@ -423,8 +423,8 @@ impl OwnedQuantizedModel {
             let sq_sum: f32 = hidden.iter().map(|x| x * x).sum();
             let rms = (sq_sum / hidden.len() as f32).sqrt();
             eprintln!(
-                "[GQA-DEBUG-CPU-L0] After layer 0: first 5 = {:?}, sum={:.4}, rms={:.4}",
-                &hidden[..5.min(hidden.len())],
+                "[GQA-DEBUG-CPU-L0] After layer 0: first 16 = {:?}, sum={:.4}, rms={:.4}",
+                &hidden[..16.min(hidden.len())],
                 hidden_sum,
                 rms
             );
@@ -438,12 +438,12 @@ impl OwnedQuantizedModel {
             let min = hidden.iter().cloned().fold(f32::INFINITY, f32::min);
             let max = hidden.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
             eprintln!(
-                "[PMAT-114-GGUF] After layer {}: mean={:.6}, min={:.6}, max={:.6}, first5={:?}",
+                "[PMAT-114-GGUF] After layer {}: mean={:.6}, min={:.6}, max={:.6}, first16={:?}",
                 layer_idx,
                 mean,
                 min,
                 max,
-                &hidden[..5.min(hidden.len())]
+                &hidden[..16.min(hidden.len())]
             );
         }
     }
@@ -517,8 +517,8 @@ impl OwnedQuantizedModel {
                 .map(|(x, g)| (x / rms) * g)
                 .collect();
             eprintln!(
-                "[GH-559-CPU] Layer 0 RMSNorm: rms={:.6}, first5={:?}",
-                rms, &normed[..5.min(normed.len())]
+                "[GH-559-CPU] Layer 0 RMSNorm: rms={:.6}, first16={:?}",
+                rms, &normed[..16.min(normed.len())]
             );
         }
 
@@ -677,9 +677,9 @@ impl OwnedQuantizedModel {
                 let sum: f32 = hidden.iter().sum();
                 let rms: f32 = (hidden.iter().map(|x| x * x).sum::<f32>() / hidden.len() as f32).sqrt();
                 eprintln!(
-                    "[GH-559-CPU] Layer {}/{} output: sum={:.6}, rms={:.6}, first5={:?}",
+                    "[GH-559-CPU] Layer {}/{} output: sum={:.6}, rms={:.6}, first16={:?}",
                     layer_idx, self.layers.len(), sum, rms,
-                    &hidden[..5.min(hidden.len())]
+                    &hidden[..16.min(hidden.len())]
                 );
                 // GH-559: For Layer 0, dump elements at Q4K super-block boundaries (every 256)
                 if layer_idx == 0 {


### PR DESCRIPTION
## Summary

Two paired fixes that **unblock the SHIP-007 GPU GQA-7:1 attention parity debugging route**. The actual cosine=-0.005 divergence remains a separate multi-session fix; this PR delivers the deterministic reproducer + clean eager debugging path.

| Fix | File | Effect |
|-----|------|--------|
| 1 | `cublas_prefill/attention.rs:1402` | `APR_SKIP_FP8_WARMUP=1` env var skips the FP8 JIT warmup that intermittently produces `CUDA_ERROR_ILLEGAL_ADDRESS code 700` on 3584-hidden models, poisoning the context |
| 2 | `flash_decoding_graphed.rs:102` | Pad 1-element host slice to `buf.len()` (32) for M=1 decode write into max_batch-sized `flash_decode_seq_lens_buf` — fixes `Length mismatch: host 1 vs device 32` |

## Live verification (RTX 4090, noah-Lambda-Vector)

**Before:** `SKIP_CUDA_GRAPH=1 apr parity .../7b-q4k.gguf` was flaky:
- mode A: `Length mismatch: host 1 vs device 32` (Bug 2)
- mode B: `CUDA_ERROR_ILLEGAL_ADDRESS code 700` (FP8 warmup context poison)

**After:** `APR_SKIP_FP8_WARMUP=1 SKIP_CUDA_GRAPH=1 apr parity ...` deterministically reaches the actual `PARITY-GATE FAILED: cosine=-0.005` diagnostic with **full per-layer instrumentation working** in both directions (CPU `CPU_DEBUG=1`/`APR_TRACE_LAYERS=1`, GPU `GPU_DEBUG=1`/`GPU_DEBUG_ALL_LAYERS=1`).

## Layer-0 divergence pinpointed (now visible)

```
CPU first 5: [-0.49966, -0.23934, 0.11330, 0.04988, -0.01252]
GPU first 5: [-0.49252, -0.26392, 0.12710, 0.10487, -0.02172]
CPU sum=-1.968, GPU sum=-3.215  (~63% divergence)
```

INPUTS match exactly (embedding identical). OUTPUTS diverge after the attention + FFN block. **This narrows the SHIP-007 search space from "GPU forward diverges somehow" to "in layer 0, AFTER attention input prep, BEFORE residual2"** — the next session can isolate the specific kernel.

## What this PR does NOT include

- The actual GQA-7:1 cosine=-0.005 fix. Multi-session work tracked in `memory/project_ship_007_attention_parity_investigation.md`.
- A regression-guard test. Per "no half fixes", an arithmetic-only test that wouldn't catch the actual layout/precision bug class would be a half-fix. The next session should author the test alongside the actual fix.

## Tests

- `cargo check --workspace` → clean
- `cargo clippy --all-targets -- -D warnings -A unused-variables` → 0 errors
- Live RTX 4090 parity-gate run reaches the cosine check (was hard-erroring before)

## Closes

Task #147 (reproducer stabilization). Task #146 (full SHIP-007 fix) remains in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)