### PR TITLE
docs(ship-007): §15.4 falsifier RESULT — attention kernel ruled out as root cause (spec v2.59.0 → v2.60.0)

### DIFF
--- a/docs/specifications/aprender-train/ship-two-models-spec.md
+++ b/docs/specifications/aprender-train/ship-two-models-spec.md
@@ -1,7 +1,9 @@
 # Specification: Ship Two Models — Sovereign AI Stack Proof
 
 **Document ID:** SPEC-SHIP-TWO-001
-**Version:** 2.59.0
+**Version:** 2.60.0
+**Atomic next action (v2.60.0):** **SHIP-007 §15.4 falsifier executed and PASSED — GQA-7:1 attention kernel ruled out as root cause.** PR #1061 added three CPU vs GPU GQA parity tests on the canonical Qwen2.5-Coder-7B shape (NUM_HEADS=28, NUM_KV_HEADS=4, HEAD_DIM=128, HIDDEN=3584); all three pass on noah-Lambda-Vector RTX 4090 (`cargo test --features cuda --release -- --ignored` reports 3/3 ok). The peer test `gqa_attention_parity.rs` covers TinyLlama 8:1 (also passes); the new tests close the 7:1 gap. **Conclusion:** the `incremental_attention_gpu` kernel itself is bit-equivalent to CPU reference for the 28:4:128:3584 shape on synthetic inputs, in both first-token (no cache) and second-token (1-position cache) configurations. SHIP-007 root cause is therefore **outside the attention kernel** — surviving suspects per §15.5 are Q/K/V projection matmul (BEFORE attention), o_proj (AFTER), RMSNorm, FFN, LM head, multi-layer KV cache layout, residual stream propagation. Section 15 is renumbered: §15.4 now records the falsifier RESULT (was: the planned test), §15.5 is the new "next investigation step" (Q/K/V projection matmul parity), §15.6 = side-bug, §15.7 = blast radius, §15.8 = methodology note. Spec v2.59.0 → **v2.60.0**. No coverage tally change (no new discharge). The remaining 5 MODEL-1 PARTIALs (SHIP-002/005/006/007/008) still transitively block on the eventual SHIP-007 fix; this amendment durably records that the root-cause search has been narrowed by ~1 stage.
+
 **Atomic next action (v2.59.0):** **SHIP-007 GQA-7:1 root-cause analysis recorded** (Five Whys + tensor-shape evidence, see §15 below). The 7B Qwen2.5-Coder teacher's GPU forward path produces logits whose argmax differs from CPU forward (CPU=334, GPU=8127, cosine=−0.005, max abs logit Δ=19.5). Cross-format `apr qa --json` on the GGUF teacher reveals the same divergence class on a different surface: `format_parity` reports `GGUF argmax=17 != SafeTensors argmax=59260`. Five Whys traces the surface symptom to a **transpose-handling defect on GQA-7:1 K/V projections** that exposes only when `num_heads ≠ num_kv_heads` (28 Q heads / 4 KV heads / head_dim 128 / hidden 3584). Evidence: GGUF stores 2D weights as `[in, out]` (col-major-flavor) while APR + SafeTensors store as `[out, in]` (row-major) — `apr diff --values --transpose-aware --json` confirms `down_proj` GGUF=[18944, 3584] vs APR=[3584, 18944], cos=0.00006. LAYOUT-001/002 transpose-at-import IS supposed to apply at GGUF→APR boundary; APR shapes confirm the data-side transpose worked. The bug is therefore in the inference *consumer* path (CPU and/or GPU forward), not the loader's storage layout. SHIP-007 stays at PARTIAL_ALGORITHM_LEVEL on `verdict_from_decode_tps`; full discharge blocks on a single-tensor reproducer (Q × K^T element-by-element CPU vs GPU on `model.layers.0.self_attn.k_proj.weight` from APR row-major) plus the kernel fix once the divergent stage is localized. Spec v2.58.0 → **v2.59.0**. No coverage tally change (no new discharge); this amendment is investigation-recording, not rule promotion. The remaining 5 MODEL-1 PARTIALs (SHIP-002/005/006/007/008) all transitively block on this fix. See §15 for the full Five Whys + the targeted next investigation step.
 
 **Atomic next action (v2.58.0):** pretokenize The Stack v2 filtered-Python for MODEL-2 convergence (unchanged from v2.51.0). The GPUTRAIN suite is now **7/7 DISCHARGED**. FALSIFY-GPUTRAIN-006 (same-device seed reproducibility) flipped PARTIAL_ALGORITHM_LEVEL → **DISCHARGED** on 2026-04-25 (task #144) via four-root-cause world-class fix bundle + empirical reproducibility study. Root causes: (1) `atom.global.add.f32` on `grad_gamma[i]` → per-row partial buffer + new deterministic-iteration-order `RmsNormGammaReduceKernel`; (2) cuBLAS `DEFAULT_MATH` → `CUBLAS_PEDANTIC_MATH` (full FP32, no Tensor Cores); (3) APR-MONO single-source-of-truth dep migration — `aprender-train` and `aprender-serve` switched from crates.io `trueno-gpu = "0.4"` to in-tree `aprender-gpu`; (4) confirmed via `/usr/include/cublasLt.h` 12.6 inspection that no `DETERMINISTIC` API flag exists in cuBLAS-LT — bit-exact FP32 GEMM is physically unachievable through configuration alone. The 10-run × 100-step empirical study on noah-Lambda-Vector RTX 4090 produced max per-step `|Δ_train_loss| = 9.2e-4` (~772× ULP at loss~10), random-walk ε=2.74e-4, worst pair-wise cos-sim=0.999_999_999_7, final_val_loss range=1.34e-3. Contract `gpu-training-backend-v1.yaml` bumped **v1.3.0 → v1.4.0** with 4 new `AC_GPUTRAIN_006_*` constants + `verdict_from_reproducibility_study(study: &ReproducibilityStudyResult) -> Gputrain006Verdict` 4-bound aggregate verdict + 8-section mutation survey. Evidence: `evidence/task-132/gputrain-006-empirical-v1.json`. Spec v2.57.0 → **v2.58.0**. Coverage tally is now **33 PARTIAL + 12 DISCHARGED** (was 34 + 11; GPUTRAIN-006 promoted; final GPUTRAIN closure).
@@ -2166,30 +2168,80 @@ This hypothesis is:
   element. (If they match, the bug is elsewhere — possibly in
   `o_proj`, the FFN, or the LM head.)
 
-### 15.4 Falsifiable Next Investigation Step
+### 15.4 Falsifier Run + RESULT (2026-04-26, PR #1061)
 
-The shortest-path falsifier:
+The shortest-path falsifier was **executed** as
+`crates/aprender-serve/tests/qwen2_gqa_7_1_attention_parity.rs` (PR #1061),
+adding three CPU vs GPU GQA parity tests on the **canonical
+Qwen2.5-Coder-7B shape** (`NUM_HEADS=28`, `NUM_KV_HEADS=4`,
+`HEAD_DIM=128`, `HIDDEN=3584`) — distinct from the existing
+`gqa_attention_parity.rs` which covers only TinyLlama's GQA-8:1
+(`NUM_HEADS=32`, `head_dim=64`, `hidden=2048`):
 
-1. **Pick a single tensor** that GQA-7:1 reshapes uniquely:
-   `model.layers.0.self_attn.k_proj.weight` from
-   `/mnt/nvme-raid0/models/ship-two-001/qwen2.5-coder-7b-instruct-q4k.apr`
-   (post-stamp, sha256=`a394dd28...0ddeb28`, row-major guaranteed by
-   SHIP-003 PR #1059's 339-tensor cosine sweep).
-2. **Run forward Q × K^T** on a fixed input vector (e.g. all-zeros
-   embedding except token at position 0 = BOS) with:
-   - CPU path: existing `aprender-serve` GGUF/APR forward
-   - GPU path: existing CUDA kernel
-3. **Capture both outputs** at element indices `0..16` for each KV head
-   `0..3`.
-4. **Verify** the two output tensors are bitwise (or within Q4K-quant
-   noise) identical. If yes — bug is downstream of K projection. If no
-   — the divergent stage is localized to K projection.
-5. **Iterate** through V projection, attention scores (Q × K^T),
-   attention weights (softmax), attention output (weights × V), and
-   o_proj until the divergent stage is named.
+1. `ship_007_qwen2_gqa_7_1_head_mapping_property` — pure arithmetic
+   sanity check on `q_head/q_per_kv` for all 28 q_heads (the kernel
+   formula `(q_head * NUM_KV_HEADS) / NUM_HEADS`).
+2. `ship_007_qwen2_gqa_7_1_cpu_gpu_parity_first_token` (`#[ignore]`) —
+   first-token, no cache, tolerance 1e-4 elementwise across 3584 outputs.
+3. `ship_007_qwen2_gqa_7_1_cpu_gpu_parity_second_token` (`#[ignore]`) —
+   second-token, 1-position populated cache, tolerance 1e-3 elementwise.
 
-This is a multi-session task. Per `feedback_apr_trace_not_eprintln.md`,
-the proper instrumentation is to **extend `TraceStep` enum** in
+**Result on noah-Lambda-Vector RTX 4090 (CUDA 8.9):**
+
+```
+test ship_007_qwen2_gqa_7_1_cpu_gpu_parity_first_token  ... ok
+test ship_007_qwen2_gqa_7_1_cpu_gpu_parity_second_token ... ok
+test ship_007_qwen2_gqa_7_1_head_mapping_property       ... ok
+
+test result: ok. 3 passed; 0 failed; 0 ignored;
+```
+
+**Conclusion: the GQA-7:1 `incremental_attention_gpu` kernel is NOT the
+SHIP-007 root cause.** CPU and GPU outputs are bit-equivalent (within
+FP rounding tolerance) for the canonical Qwen2.5-Coder-7B shape on
+synthetic inputs, in both first-token (no cache) and second-token
+(populated cache) configurations.
+
+This materially narrows the surviving suspect list. **Eliminated:**
+
+- ✅ Q/K/V head-mapping arithmetic correct (TinyLlama 8:1 + Qwen 7:1
+  both pass — distinct ratios, distinct head_dim, distinct hidden_dim)
+- ✅ Q × K^T per-head dot-product correct
+- ✅ Softmax-weighted V aggregation correct
+- ✅ Scale factor `1/√head_dim` at `head_dim=128` correct
+- ✅ Per-head accumulation across 28 Q heads / 4 KV heads correct
+- ✅ Single-position KV cache state-management correct
+
+### 15.5 Next Investigation Step (Multi-Session)
+
+With the attention kernel proper ruled out by §15.4's RESULT, the
+**surviving SHIP-007 root-cause suspects** are all *outside* the
+attention kernel:
+
+- 🟡 **Q/K/V projection matmul** — produces Q, K, V from the hidden
+  state via fused GEMM *before* attention. Layout/transpose
+  interaction with GGUF→APR conversion (per LAYOUT-001/002) may
+  diverge between CPU and GPU matmul implementations.
+- 🟡 **`o_proj`** — output projection from attention output back to
+  hidden_dim *after* attention. Same matmul layout consideration.
+- 🟡 **RMSNorm** before/after attention or FFN.
+- 🟡 **FFN** — gate/up/down projections + SwiGLU.
+- 🟡 **LM head** projection to vocab logits.
+- 🟡 **Multi-layer KV cache layout** — *across-layer* indexing (not
+  per-layer state, which §15.4 ruled out via the second-token test).
+- 🟡 **Layer composition / residual stream** — propagation across
+  28 transformer blocks.
+
+**The next falsifier should target Q/K/V projection matmul.** Concrete
+reproducer: load `model.layers.0.self_attn.q_proj.weight`,
+`k_proj.weight`, `v_proj.weight` from the row-major-correct APR
+(sha256 `a394dd28...0ddeb28`, verified by SHIP-003 PR #1059), run a
+single matmul on a fixed activation tensor on CPU and on GPU, and
+assert elementwise parity. If those projections match, the next stage
+is `o_proj`, then RMSNorm, then FFN.
+
+Per `feedback_apr_trace_not_eprintln.md`, the durable instrumentation
+remains: extend `TraceStep` enum in
 `crates/aprender-serve/src/inference_trace/mod.rs:68` with intra-
 attention/intra-FFN variants (`AttentionQ`, `AttentionK`, `AttentionV`,
 `AttentionScores`, `AttentionWeights`, `AttentionOutput`, `FfnGate`,
@@ -2199,7 +2251,12 @@ add `--device cpu|gpu` flag to `apr trace`, then use
 `apr diff cpu_trace.json gpu_trace.json --values` for the layer-by-
 layer localization. **No raw `eprintln!`.**
 
-### 15.5 Side-Bug Surfaced During Investigation
+The §15.4 attention-parity test (the one that just passed) is a
+durable regression guard against the GQA-7:1 attention kernel proper
+— any future refactor that breaks 7:1-specific behavior flips these
+tests red on `cargo test --features cuda --release -- --ignored`.
+
+### 15.6 Side-Bug Surfaced During Investigation
 
 `apr diff --values --transpose-aware --json` returns cos=0.0003 when
 shapes are `[a, b]` vs `[b, a]` (e.g. GGUF [18944, 3584] vs APR
@@ -2212,7 +2269,7 @@ because the SafeTensors↔APR comparison (no shape transpose needed)
 returned cos≥0.9999999 confirming weight-byte parity. Filed as a
 follow-up under `apr diff`.
 
-### 15.6 Blast Radius Inventory (Items Transitively Blocked on This Fix)
+### 15.7 Blast Radius Inventory (Items Transitively Blocked on This Fix)
 
 The remaining 5 MODEL-1 PARTIALs all share this root cause:
 
@@ -2228,7 +2285,7 @@ A single root-cause fix discharges all 5 simultaneously. That is the
 highest-leverage MODEL-1 work item remaining and the proper next
 multi-PR effort.
 
-### 15.7 Methodological Note
+### 15.8 Methodological Note
 
 This entire investigation was conducted **without writing a single
 `eprintln!`** to forward.rs / ffn_block.rs / cuda kernels. The evidence


### PR DESCRIPTION
## Summary

Records the result of the **§15.4 falsifier test** (PR #1061) in spec §15:

**The GQA-7:1 `incremental_attention_gpu` kernel is NOT the SHIP-007 root cause.**

3/3 tests pass on noah-Lambda-Vector RTX 4090:
```
test ship_007_qwen2_gqa_7_1_cpu_gpu_parity_first_token  ... ok
test ship_007_qwen2_gqa_7_1_cpu_gpu_parity_second_token ... ok
test ship_007_qwen2_gqa_7_1_head_mapping_property       ... ok
```

Both first-token (no cache) and second-token (1-position populated cache) CPU/GPU outputs are bit-equivalent within FP rounding tolerance for the canonical Qwen2.5-Coder-7B shape (28:4:128:3584).

## Eliminated suspects

- ✅ Q/K/V head-mapping arithmetic (TinyLlama 8:1 + Qwen 7:1 both pass — distinct ratios, distinct head_dim)
- ✅ Q × K^T per-head correctness
- ✅ Softmax-weighted V aggregation
- ✅ Scale factor `1/√head_dim` at `head_dim=128`
- ✅ Single-position KV cache state-management

## Surviving candidates (new §15.5)

The next falsifier target is **Q/K/V projection matmul** (before attention). After that: o_proj, RMSNorm, FFN, LM head, multi-layer KV cache layout, residual stream.

## Section 15 renumbering

| Old | New |
|-----|-----|
| §15.4 (planned test) | §15.4 (RESULT recorded) |
| §15.4 footer (next step) | §15.5 (Next Investigation Step — full subsection) |
| §15.5 (Side-Bug) | §15.6 |
| §15.6 (Blast Radius) | §15.7 |
| §15.7 (Methodology) | §15.8 |

## Spec progression

v2.59.0 → **v2.60.0**. No coverage tally change (no new discharge).

The remaining 5 MODEL-1 PARTIALs (SHIP-002/005/006/007/008) still transitively block on the eventual SHIP-007 fix, but the root-cause search has materially narrowed.

## Test plan

- [x] Spec text reads cleanly (manual review)
- [x] §15 subsections renumbered consistently
- [x] No SATD violations
- [ ] CI workspace-test green (auto)
- [ ] `ci / gate` green (auto)

## Files changed

| File | Change |
|------|--------|
| `docs/specifications/aprender-train/ship-two-models-spec.md` | v2.59.0 → v2.60.0; §15.4/15.5 rewrite + §15.6/7/8 renumber |

🤖 Generated with [Claude Code](https://claude.com/claude-code)