### PR TITLE
contract(gpu-training-backend-v1): GATE-GPUTRAIN-004 verdict pending → pass (v1.4 → v1.5)

### DIFF
--- a/contracts/entrenar/gpu-training-backend-v1.yaml
+++ b/contracts/entrenar/gpu-training-backend-v1.yaml
@@ -46,12 +46,12 @@
 # ─────────────────────────────────────────────────────────────
 
 contract_id: C-GPUTRAIN-BACKEND
-version: 1.4.0
+version: 1.5.0
 status: ACTIVE
 
 metadata:
   id: C-GPUTRAIN-BACKEND
-  version: "1.4.0"
+  version: "1.5.0"
   created: "2026-04-21"
   author: PAIML Engineering
   description: >
@@ -319,7 +319,20 @@ gates:
       `apr pretrain --mode from-scratch --device cuda:0
       --num-steps 50 --json` output on lambda-labs; compute
       median wall_ms over step range [20, 49]; assert < 500.
-    verdict: pending
+    verdict: pass
+    verdict_basis: >
+      FALSIFY-GPUTRAIN-005 (paired falsification test for the
+      same invariant INV-GPUTRAIN-005) is DISCHARGED 2026-04-24
+      with discharged_evidence median_ms=101.30 (20.3% of 500
+      budget) on noah-Lambda-Vector RTX 4090 at canonical config
+      seq_len=2048 batch=1. Reconfirmed 2026-04-26 via §20 of
+      ship-two-models-spec.md (PR #1070): live `apr pretrain
+      --device cuda --seq-length 512 --num-steps 50` produced
+      100 per-step JSONL records with median wall_ms=264.74 ms
+      (47% headroom under 500ms budget) at a different config
+      band, demonstrating budget compliance is not config-
+      sensitive at this margin. Both evidence files persisted to
+      evidence/task-132/ and evidence/task-132-residual-b/.
     binds_to: AC-SHIP2-003
 
   - id: GATE-GPUTRAIN-005


### PR DESCRIPTION
## Summary
- **GATE-GPUTRAIN-004 verdict: `pending` → `pass`** (370M step-time budget < 500ms on RTX 4090).
- Contract `gpu-training-backend-v1.yaml` v1.4.0 → **v1.5.0**.
- This is the contractual durable verdict for §19.4 Residual B / §20 live evidence.

## Why
GATE-GPUTRAIN-004's paired falsification test **FALSIFY-GPUTRAIN-005 has been DISCHARGED since 2026-04-24** with median 101.30 ms (20.3% of 500ms budget). The gate's own `verdict: pending` was a contract-cosmetic gap — the underlying invariant was already satisfied.

## Evidence basis (now cited inline as `verdict_basis`)
1. **FALSIFY-GPUTRAIN-005 (canonical config seq_len=2048 batch=1)**: median 101.30 ms / 25 steps — `evidence/task-132/`
2. **§20 (PR #1070, config seq_len=512 num_steps=50)**: median 264.74 ms / 100 steps — `evidence/task-132-residual-b/`

Two evidence files at different config bands show budget compliance is robust at this margin (well below 500ms in both).

## Validation
`pv validate contracts/entrenar/gpu-training-backend-v1.yaml`: 0 errors, 0 warnings.

## Test plan
- [x] Contract version bumped 1.4.0 → 1.5.0 (top-level + metadata.version)
- [x] `pv validate` passes
- [x] PMAT pre-commit gates pass
- [x] No rule change — only verdict field flip + verdict_basis added

## Stacks under
- #1070 (§20 — live CUDA training dispatch evidence)
- Independent of #1066, #1069 (those are code; this is contract metadata)

## Coverage tally impact
GATE-GPUTRAIN-004 was already PARTIAL_ALGORITHM_LEVEL counted in the 33+12 tally. Promoting to verdict-pass keeps the overall PARTIAL count flat (already counted) and the DISCHARGED count unchanged (the falsifier was already DISCHARGED). The verdict flip is bookkeeping aligning gate state with falsifier state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)