### PR TITLE
feat(p3-prb): SHIP-007 GGUF forward_traced sub-FFN populate — 4 sub-FFN ActivationStats slots filled

### DIFF
--- a/crates/aprender-serve/src/gguf/inference/forward/results.rs
+++ b/crates/aprender-serve/src/gguf/inference/forward/results.rs
@@ -361,6 +361,86 @@ impl OwnedQuantizedModel {
         self.scratch_q8k_down_projection(layer_idx, scratch, intermediate_dim, hidden_dim)
     }
 
+    /// SHIP-007 PR B: traced variant of `scratch_swiglu_ffn` that captures
+    /// the 4 sub-FFN `ActivationStats` slots needed for the §26.4 layer-3
+    /// ffn_swigl APR-vs-GGUF bisection.
+    ///
+    /// Numerical path is byte-identical to `scratch_swiglu_ffn`; only stat
+    /// capture is added at the 4 capture points documented in
+    /// `project_ship_007_gguf_forward_traced_plan.md`:
+    ///
+    /// | Stat | Capture point |
+    /// |------|---------------|
+    /// | `ffn_gate_stats` | `scratch.ffn_gate` AFTER bias, BEFORE silu |
+    /// | `ffn_up_stats` | `scratch.ffn_up` AFTER bias |
+    /// | `ffn_silu_gate_stats` | `scratch.ffn_gate` AFTER silu, BEFORE multiply |
+    /// | `ffn_swiglu_inner_stats` | `scratch.ffn_gate` AFTER multiply (silu(g) * u) |
+    ///
+    /// PR A's `forward_traced` calls THIS helper instead of `scratch_swiglu_ffn`
+    /// and writes the captured stats into the in-progress `LayerActivation`.
+    ///
+    /// # Errors
+    ///
+    /// Returns error if the underlying Q8K up+gate or down projection fails.
+    pub(crate) fn scratch_swiglu_ffn_traced(
+        &self,
+        layer_idx: usize,
+        scratch: &mut InferenceScratchBuffer,
+        use_q8k_path: bool,
+        hidden_dim: usize,
+        intermediate_dim: usize,
+        ffn_gate_stats: &mut crate::apr_transformer::ActivationStats,
+        ffn_up_stats: &mut crate::apr_transformer::ActivationStats,
+        ffn_silu_gate_stats: &mut crate::apr_transformer::ActivationStats,
+        ffn_swiglu_inner_stats: &mut crate::apr_transformer::ActivationStats,
+    ) -> Result<()> {
+        let layer = &self.layers[layer_idx];
+
+        // Up + gate projections (Q8K or F32) — identical to non-traced
+        self.scratch_q8k_up_gate(layer_idx, scratch, use_q8k_path, hidden_dim)?;
+
+        // Apply biases — identical to non-traced
+        if let Some(ref bias) = layer.ffn_up_bias {
+            for i in 0..intermediate_dim {
+                scratch.ffn_up[i] += bias[i];
+            }
+        }
+        if let Some(ref bias) = layer.ffn_gate_bias {
+            for i in 0..intermediate_dim {
+                scratch.ffn_gate[i] += bias[i];
+            }
+        }
+
+        // CAPTURE 1 + 2: ffn_gate (post-bias, pre-silu) + ffn_up (post-bias)
+        *ffn_gate_stats = crate::apr_transformer::ActivationStats::from_slice(
+            &scratch.ffn_gate[..intermediate_dim],
+        );
+        *ffn_up_stats = crate::apr_transformer::ActivationStats::from_slice(
+            &scratch.ffn_up[..intermediate_dim],
+        );
+
+        // SiLU on gate
+        ops::silu(&mut scratch.ffn_gate[..intermediate_dim]);
+
+        // CAPTURE 3: ffn_silu_gate (post-silu, pre-multiply)
+        *ffn_silu_gate_stats = crate::apr_transformer::ActivationStats::from_slice(
+            &scratch.ffn_gate[..intermediate_dim],
+        );
+
+        // Multiply with up: silu(gate) * up
+        for i in 0..intermediate_dim {
+            scratch.ffn_gate[i] *= scratch.ffn_up[i];
+        }
+
+        // CAPTURE 4: ffn_swiglu_inner (post-multiply — THE §23 17× anomaly site)
+        *ffn_swiglu_inner_stats = crate::apr_transformer::ActivationStats::from_slice(
+            &scratch.ffn_gate[..intermediate_dim],
+        );
+
+        // Down projection — identical to non-traced
+        self.scratch_q8k_down_projection(layer_idx, scratch, intermediate_dim, hidden_dim)
+    }
+
     /// GELU FFN path with Q8K acceleration for scratch-buffer forward pass
     ///
     /// Computes FFN up projection with optional Q8K VNNI acceleration,

--- a/crates/aprender-serve/src/gguf/inference/forward/traced.rs
+++ b/crates/aprender-serve/src/gguf/inference/forward/traced.rs
@@ -168,18 +168,29 @@ impl OwnedQuantizedModel {
             }
             let ffn_norm_stats = ActivationStats::from_slice(&scratch.normed[..hidden_dim]);
 
-            // 2g. FFN. PR A does NOT instrument the sub-FFN slots — those
-            // 4 fields default-zero per the §26.4 plan; PR B clones
-            // `scratch_swiglu_ffn` into `_traced` to fill them.
+            // 2g. FFN. PR B populates the 4 sub-FFN stat slots via the
+            // `_traced` helper for the SwiGLU path; the GELU path keeps
+            // sub-FFN slots at default-zero (no SwiGLU components).
+            let mut ffn_gate_stats = ActivationStats::default();
+            let mut ffn_up_stats = ActivationStats::default();
+            let mut ffn_silu_gate_stats = ActivationStats::default();
+            let mut ffn_swiglu_inner_stats = ActivationStats::default();
             if self.config.constraints.has_gate_ffn() {
-                self.scratch_swiglu_ffn(
+                self.scratch_swiglu_ffn_traced(
                     layer_idx,
                     &mut scratch,
                     use_q8k_path,
                     hidden_dim,
                     intermediate_dim,
+                    &mut ffn_gate_stats,
+                    &mut ffn_up_stats,
+                    &mut ffn_silu_gate_stats,
+                    &mut ffn_swiglu_inner_stats,
                 )?;
             } else {
+                // GELU path: no SwiGLU sub-FFN components — leave the 4
+                // sub-FFN slots at default-zero. This matches APR's
+                // forward_traced semantics for non-SwiGLU models.
                 self.scratch_gelu_ffn(
                     layer_idx,
                     &mut scratch,
@@ -199,18 +210,18 @@ impl OwnedQuantizedModel {
             let output_stats = ActivationStats::from_slice(&scratch.hidden[..hidden_dim]);
 
             // Construct LayerActivation. Order matches APR's
-            // inference.rs:231-242. PR A: 6 non-FFN populated, 4 sub-FFN
-            // default-zero (PR B fills them).
+            // inference.rs:231-242. PR B: all 10 fields populated for
+            // SwiGLU; GELU path leaves 4 sub-FFN at default-zero.
             layer_activations.push(LayerActivation {
                 layer_idx,
                 attn_norm_stats,
                 qkv_stats,
                 attn_out_stats,
                 ffn_norm_stats,
-                ffn_gate_stats: ActivationStats::default(),
-                ffn_up_stats: ActivationStats::default(),
-                ffn_silu_gate_stats: ActivationStats::default(),
-                ffn_swiglu_inner_stats: ActivationStats::default(),
+                ffn_gate_stats,
+                ffn_up_stats,
+                ffn_silu_gate_stats,
+                ffn_swiglu_inner_stats,
                 ffn_out_stats,
                 output_stats,
             });


### PR DESCRIPTION
## Summary

P3 **PR B** — completes the §26.4 SHIP-007 root-cause-pin chain by populating the 4 sub-FFN slots that PR A (#1081) defaulted to zero.

**Stacked on #1081**. PR base = `feat/p3-pra-gguf-forward-traced`. Once #1081 lands, this PR auto-retargets to main.

## What this PR adds

New helper `scratch_swiglu_ffn_traced` mirrors `scratch_swiglu_ffn` exactly (numerical path is byte-identical) but adds 4 capture points per `project_ship_007_gguf_forward_traced_plan.md`:

| Stat | Capture point | Code site (results.rs) |
|------|---------------|------------------------|
| `ffn_gate_stats` | `scratch.ffn_gate` AFTER bias, BEFORE silu | post-line-352 |
| `ffn_up_stats` | `scratch.ffn_up` AFTER bias | post-line-352 |
| `ffn_silu_gate_stats` | `scratch.ffn_gate` AFTER silu, BEFORE multiply | post-line-355 |
| `ffn_swiglu_inner_stats` | `scratch.ffn_gate` AFTER multiply | post-line-358 |

The 4th capture point is the **§23 17×-anomaly site**. APR-side at layer 3 = 1.222 std (17.2× layer 2's 0.071 baseline). GGUF-side stat now observable via this PR.

## What §26.4 binding criterion will look like (post-merge)

```
$ apr trace --payload /mnt/.../qwen2.5-coder-7b-instruct-q4k.apr  | grep "layer 3.*ffn_swigl"
# APR: layer-3 ffn_swigl std=1.222 (the §23 anomaly)

$ apr trace --payload /mnt/.../qwen2.5-coder-7b-instruct-q4k.gguf | grep "layer 3.*ffn_swigl"
# Outcome A: GGUF layer-3 ffn_swigl std ≈ 0.07 → APR-side bug in apr_transformer/inference.rs:160-164
# Outcome B: GGUF layer-3 ffn_swigl std ≈ 1.22 → 17× spike is normal Qwen2.5 trained behavior; bug elsewhere
```

Either outcome **discharges all 5 transitively-blocked MODEL-1 PARTIALs** at once per §17.5: SHIP-002, SHIP-005, SHIP-006, SHIP-007, SHIP-008.

## Wiring

PR A's `forward_traced` updated to:
- Call `scratch_swiglu_ffn_traced` for SwiGLU path with 4 `&mut ActivationStats` references
- GELU path unchanged (no SwiGLU components — sub-FFN slots stay default-zero, matching APR semantics)

## Validated

```
$ cargo check -p aprender-serve --lib
Finished `dev` profile

$ cargo clippy -p aprender-serve --lib -- -D warnings
Finished `dev` profile
```

## Spec references

- `SPEC-SHIP-TWO-001 §26.4` — P3 plan
- `§17` — layer-3 ffn_out 53× anomaly
- `§23` — layer-3 ffn_swigl is the first 17× anomaly site (APR side)
- `project_ship_007_gguf_forward_traced_plan.md`

## Test plan

- [ ] CI workspace-test passes
- [ ] CI gate passes
- [ ] No regression in existing GGUF inference tests
- [ ] Once #1081 merges, this PR auto-retargets to main and lands cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)