### PR TITLE
feat(p3-prc): wire apr trace --payload &lt;gguf&gt; to call forward_traced — emits per-layer LayerActivation telemetry

### DIFF
--- a/crates/apr-cli/src/commands/trace.rs
+++ b/crates/apr-cli/src/commands/trace.rs
@@ -361,6 +361,36 @@ fn run_traced_inference_gguf(path: &Path) -> Result<(), CliError> {
     println!("{}", format!("Encoded tokens: {:?}", test_tokens).cyan());
     println!();
 
+    // SHIP-007 §26.4 P3: forward_traced emits per-layer LayerActivation
+    // stats for APR-vs-GGUF bisection (the §23 layer-3 ffn_swigl 17×
+    // anomaly comparison). Run BEFORE generation so the trace reflects
+    // a pristine forward pass on the test prompt.
+    println!("{}", "FORWARD PASS (with layer tracing):".green().bold());
+    match model.forward_traced(&test_tokens) {
+        Ok(trace) => {
+            println!();
+            println!("{}", "EMBEDDING:".cyan().bold());
+            print_activation_stats_colored("  ", &trace.embed_stats);
+
+            print_layer_activations(&trace.layer_activations);
+
+            println!();
+            println!("{}", "FINAL LAYER NORM:".cyan().bold());
+            print_activation_stats("  ", &trace.final_norm_stats);
+
+            print_logit_predictions(&trace.logits);
+            print_trace_summary(&trace.layer_activations, &trace.logits);
+        }
+        Err(e) => {
+            eprintln!(
+                "{}",
+                format!("forward_traced unavailable for this GGUF: {e}").yellow()
+            );
+            println!("  Layer-by-layer tracing not available (e.g., encoder-decoder model).");
+        }
+    }
+    println!();
+
     // Run generation with small max_tokens to see what comes out
     println!("{}", "GENERATION (max 8 tokens):".green().bold());
     let gen_config = QuantizedGenerateConfig {

--- a/crates/apr-cli/src/commands/vector_stats.rs
+++ b/crates/apr-cli/src/commands/vector_stats.rs
@@ -89,8 +89,12 @@ fn run_traced_inference_apr(path: &Path) -> Result<(), CliError> {
 }
 
 /// Print layer-by-layer activation stats with anomaly detection.
+///
+/// Made `pub(crate)` for SHIP-007 §26.4 P3: GGUF dispatch in
+/// `commands/trace.rs::run_traced_inference_gguf` reuses this for
+/// the APR-vs-GGUF layer-3 ffn_swigl bisection comparison.
 #[cfg(feature = "inference")]
-fn print_layer_activations(layers: &[realizar::apr_transformer::LayerActivation]) {
+pub(crate) fn print_layer_activations(layers: &[realizar::apr_transformer::LayerActivation]) {
     use colored::Colorize;
 
     println!();
@@ -189,7 +193,7 @@ fn layer_has_inf(layer: &realizar::apr_transformer::LayerActivation) -> bool {
 
 /// Print logit predictions with top-5 tokens.
 #[cfg(feature = "inference")]
-fn print_logit_predictions(logits: &[f32]) {
+pub(crate) fn print_logit_predictions(logits: &[f32]) {
     use colored::Colorize;
 
     let logit_stats = compute_vector_stats(logits);
@@ -209,7 +213,10 @@ fn print_logit_predictions(logits: &[f32]) {
 
 /// Print trace summary analysis (variance, NaN/Inf, logit range).
 #[cfg(feature = "inference")]
-fn print_trace_summary(layers: &[realizar::apr_transformer::LayerActivation], logits: &[f32]) {
+pub(crate) fn print_trace_summary(
+    layers: &[realizar::apr_transformer::LayerActivation],
+    logits: &[f32],
+) {
     use colored::Colorize;
 
     println!();
@@ -361,7 +368,7 @@ fn print_stats(prefix: &str, stats: &VectorStats) {
 
 /// Print activation statistics from realizar's ActivationStats
 #[cfg(feature = "inference")]
-fn print_activation_stats(_prefix: &str, stats: &realizar::apr_transformer::ActivationStats) {
+pub(crate) fn print_activation_stats(_prefix: &str, stats: &realizar::apr_transformer::ActivationStats) {
     use colored::Colorize;
     println!("  Range: [{:.6}, {:.6}]", stats.min, stats.max);
     println!("  Mean: {:.6}, Std: {:.6}", stats.mean, stats.std_dev);
@@ -377,7 +384,7 @@ fn print_activation_stats(_prefix: &str, stats: &realizar::apr_transformer::Acti
 
 /// Print activation statistics with color coding
 #[cfg(feature = "inference")]
-fn print_activation_stats_colored(
+pub(crate) fn print_activation_stats_colored(
     _prefix: &str,
     stats: &realizar::apr_transformer::ActivationStats,
 ) {


### PR DESCRIPTION
## Summary

P3 **PR C** — completes the SHIP-007 §26.4 P3 chain by wiring the new `forward_traced` method (PR A scaffold + PR B sub-FFN populate) into the `apr-cli` trace dispatch.

**Stacked on PR #1082 (PR B), which is stacked on PR #1081 (PR A).** Will retarget to main once both merge.

## What this PR does

Without this, `apr trace --payload <model.gguf>` only does generation+garbage-detection — it does NOT emit per-layer telemetry needed for the §23 layer-3 ffn_swigl APR-vs-GGUF bisection.

After this PR:

```
$ apr trace --payload /mnt/.../qwen2.5-coder-7b-instruct-q4k.gguf
...
FORWARD PASS (with layer tracing):

EMBEDDING:
  ...

LAYER-BY-LAYER ACTIVATIONS:
  Layer  3/28 [OK]
    attn_norm: ...
    qkv      : ...
    ...
    ffn_gate : ...
    ffn_up   : ...
    ffn_silu : ...
    ffn_swigl: ...     ← NEW — the §23 17×-anomaly site, now observable on GGUF
    ffn_out  : ...
    output   : ...
  ...

FINAL LAYER NORM: ...
```

## Files changed

| File | Change |
|------|--------|
| `crates/apr-cli/src/commands/trace.rs::run_traced_inference_gguf` | Calls `model.forward_traced(&test_tokens)` BEFORE generation, prints layer activations + summary |
| `crates/apr-cli/src/commands/vector_stats.rs` | 4 helpers flipped to `pub(crate)` for reuse from trace.rs (already used by APR side) |

The 4 helpers made pub(crate):
- `print_layer_activations`
- `print_logit_predictions`
- `print_trace_summary`
- `print_activation_stats` / `print_activation_stats_colored`

Output format matches APR side exactly — `apr trace --payload <file>.apr` and `<file>.gguf` produce side-by-side comparable per-layer stat blocks.

## §26.4 binding criterion now runnable

Once this PR + #1081 + #1082 all merge:

```
$ apr trace --payload /mnt/.../qwen2.5-coder-7b-instruct-q4k.apr  | grep -A1 "Layer  3"
$ apr trace --payload /mnt/.../qwen2.5-coder-7b-instruct-q4k.gguf | grep -A1 "Layer  3"
```

| Outcome | Verdict |
|---------|---------|
| ratio ≥10× | SHIP-007 bug is APR-side at `apr_transformer/inference.rs:160-164` |
| ratio <2× | 17× spike is normal Qwen2.5 trained behavior; bug elsewhere |

Either discharges 5 MODEL-1 PARTIALs at once per §17.5 (SHIP-002/005/006/007/008).

## Validated

```
$ cargo check -p apr-cli --features inference
Finished `dev` profile

$ cargo clippy -p apr-cli --features inference -- -D warnings
Finished `dev` profile
```

## Spec references

- `SPEC-SHIP-TWO-001 §26.4` — P3 final wiring step
- PR #1081 (P3 PR A: GGUF forward_traced scaffold)
- PR #1082 (P3 PR B: sub-FFN populate)
- §23 (layer-3 ffn_swigl is the first 17× anomaly site, APR side)

## Test plan

- [ ] CI workspace-test passes
- [ ] CI gate passes
- [ ] No regression in existing GGUF generation tests
- [ ] `apr trace --payload <gguf>` smoke-test shows new telemetry block (live test post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)