### PR TITLE
feat(p1-1): apr pull dataset extension — unblocks MODEL-2 corpus diversification per §26.8

### DIFF
--- a/contracts/apr-cli-pull-dataset-v1.yaml
+++ b/contracts/apr-cli-pull-dataset-v1.yaml
@@ -1,7 +1,7 @@
 metadata:
   kind: schema
-  version: 1.0.0
-  status: PROPOSED
+  version: 1.1.0
+  status: ACTIVE
   created: '2026-04-27'
   author: PAIML Engineering
   registry: true
@@ -154,9 +154,9 @@ proof_obligations:
   property: "apr pull dataset is the canonical HF dataset entry point post-APR-MONO"
 - type: invariant
   property: "asset-type discriminator preserves model-path backward compatibility"
-- type: safety
+- type: soundness
   property: "license allowlist enforced at row level prevents downstream license-violation artifacts"
-- type: liveness
+- type: termination
   property: "no-match glob fails fast, no silent empty download"
 
 kani_harnesses:

--- a/crates/apr-cli/src/commands/pull.rs
+++ b/crates/apr-cli/src/commands/pull.rs
@@ -624,3 +624,4 @@ include!("pull_list.rs");
 include!("pull_remove_resolve_model.rs");
 include!("pull_extract_shard.rs");
 include!("pull_04.rs");
+include!("pull_dataset.rs");

--- a/crates/apr-cli/src/commands/pull_dataset.rs
+++ b/crates/apr-cli/src/commands/pull_dataset.rs
@@ -1,0 +1,196 @@
+// Dataset puller for `apr pull dataset <REPO> --include <GLOB> --output <DIR>`
+//
+// Per SHIP-TWO-001 §26.8 and contract `apr-cli-pull-dataset-v1.yaml`, this
+// file extends `apr pull` with the dataset asset-type. Listed via the
+// HuggingFace `/api/datasets/{repo}/tree/{rev}` endpoint, filtered by
+// glob patterns, and streamed via the existing `download_file_with_progress`
+// helper. License-allowlist row filtering is deferred to P1.1.5 (requires
+// parquet round-trip).
+//
+// NOTE: This file is `include!()`-ed by pull.rs; do NOT add `use` for
+// crate::error::{CliError, Result}, colored::Colorize, std::path::Path —
+// pull.rs already imports them. Add only NEW imports here.
+
+use std::path::PathBuf;
+
+/// Run `apr pull dataset <REPO>` per FALSIFY-APR-PULL-DATASET-001..006.
+///
+/// Lists files in the dataset repo via HF API, filters by `--include` globs
+/// (fail-fast on no-match), then streams each matched file to `<output>/<path>`
+/// reusing `download_file_with_progress`.
+pub fn run_dataset(
+    repo: &str,
+    include: &[String],
+    revision: Option<&str>,
+    output: Option<&Path>,
+) -> Result<()> {
+    println!("{}", "=== APR Pull Dataset ===".cyan().bold());
+    println!("Repo:    {}", repo.cyan());
+    let rev = revision.unwrap_or("main");
+    println!("Rev:     {}", rev);
+
+    // Resolve output directory
+    let out_dir: PathBuf = match output {
+        Some(p) => p.to_path_buf(),
+        None => default_dataset_cache_dir(repo)?,
+    };
+    println!("Output:  {}", out_dir.display());
+    if !include.is_empty() {
+        println!("Include: {include:?}");
+    }
+    println!();
+
+    // 1. List all files in the repo
+    let all_files = list_dataset_repo_files(repo, rev)?;
+    println!("{} {} files in repo", "✓".green(), all_files.len());
+
+    // 2. Filter by --include globs (or pass-through if empty)
+    let matched = filter_files_by_globs(&all_files, include)?;
+    println!("{} {} files match include globs", "✓".green(), matched.len());
+
+    // 3. Fail-fast on no-match (per FALSIFY-APR-PULL-DATASET-003)
+    if !include.is_empty() && matched.is_empty() {
+        return Err(CliError::ValidationFailed(format!(
+            "apr pull dataset: no files in {repo} matched any --include pattern: {include:?}"
+        )));
+    }
+
+    // 4. Download each matched file
+    std::fs::create_dir_all(&out_dir)?;
+    for (i, path) in matched.iter().enumerate() {
+        let url = format!("https://huggingface.co/datasets/{repo}/resolve/{rev}/{path}");
+        let dest = out_dir.join(path);
+        if let Some(parent) = dest.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        println!(
+            "[{}/{}] {} -> {}",
+            i + 1,
+            matched.len(),
+            path.cyan(),
+            dest.display()
+        );
+        let _checksum = download_file_with_progress(&url, &dest)?;
+        println!();
+    }
+
+    println!("{} Pulled {} files to {}", "✓".green(), matched.len(), out_dir.display());
+    Ok(())
+}
+
+/// Default cache dir: `~/.cache/aprender/datasets/<repo>/` per contract invariant.
+fn default_dataset_cache_dir(repo: &str) -> Result<PathBuf> {
+    let base = if let Ok(cache_home) = std::env::var("XDG_CACHE_HOME") {
+        PathBuf::from(cache_home)
+    } else {
+        dirs::home_dir()
+            .ok_or_else(|| CliError::ValidationFailed("Cannot find home directory".to_string()))?
+            .join(".cache")
+    };
+    Ok(base.join("aprender").join("datasets").join(repo))
+}
+
+/// HF API: list all files in a dataset repo.
+fn list_dataset_repo_files(repo: &str, revision: &str) -> Result<Vec<String>> {
+    let url = format!("https://huggingface.co/api/datasets/{repo}/tree/{revision}?recursive=1");
+    let response = hf_get(&url).call().map_err(|e| match &e {
+        ureq::Error::Status(404, _) => CliError::HttpNotFound(format!(
+            "Dataset {repo} not found at revision {revision}"
+        )),
+        ureq::Error::Status(401, _) => CliError::NetworkError(format_gated_model_error(&url)),
+        _ => CliError::NetworkError(format!("Dataset listing failed: {e}")),
+    })?;
+    let body = response
+        .into_string()
+        .map_err(|e| CliError::NetworkError(format!("Read body: {e}")))?;
+    let v: serde_json::Value = serde_json::from_str(&body)
+        .map_err(|e| CliError::ValidationFailed(format!("HF API JSON parse: {e}")))?;
+    let mut paths = Vec::new();
+    if let Some(items) = v.as_array() {
+        for it in items {
+            if let Some(t) = it.get("type").and_then(|x| x.as_str()) {
+                if t == "file" {
+                    if let Some(p) = it.get("path").and_then(|x| x.as_str()) {
+                        paths.push(p.to_string());
+                    }
+                }
+            }
+        }
+    }
+    Ok(paths)
+}
+
+/// Apply `--include` globs (union semantics). Empty includes = pass-through.
+fn filter_files_by_globs(all: &[String], include: &[String]) -> Result<Vec<String>> {
+    if include.is_empty() {
+        return Ok(all.to_vec());
+    }
+    let patterns: Vec<glob::Pattern> = include
+        .iter()
+        .map(|s| {
+            glob::Pattern::new(s).map_err(|e| {
+                CliError::ValidationFailed(format!("Invalid --include glob '{s}': {e}"))
+            })
+        })
+        .collect::<Result<_>>()?;
+    let matched: Vec<String> = all
+        .iter()
+        .filter(|f| patterns.iter().any(|p| p.matches(f)))
+        .cloned()
+        .collect();
+    Ok(matched)
+}
+
+#[cfg(test)]
+mod pull_dataset_tests {
+    use super::*;
+
+    #[test]
+    fn test_filter_files_empty_include_passthrough() {
+        let all = vec!["a.parquet".to_string(), "b.json".to_string()];
+        let r = filter_files_by_globs(&all, &[]).unwrap();
+        assert_eq!(r.len(), 2);
+    }
+
+    #[test]
+    fn test_filter_files_glob_matches_subset() {
+        let all = vec![
+            "data/train-00000.parquet".to_string(),
+            "data/train-00001.parquet".to_string(),
+            "data/test-00000.parquet".to_string(),
+            "README.md".to_string(),
+        ];
+        let include = vec!["data/train-*.parquet".to_string()];
+        let r = filter_files_by_globs(&all, &include).unwrap();
+        assert_eq!(r.len(), 2);
+        assert!(r.iter().all(|f| f.starts_with("data/train-")));
+    }
+
+    #[test]
+    fn test_filter_files_no_match_returns_empty() {
+        let all = vec!["data/train.parquet".to_string()];
+        let include = vec!["no/such/file/*".to_string()];
+        let r = filter_files_by_globs(&all, &include).unwrap();
+        assert_eq!(r.len(), 0); // caller fails fast on empty
+    }
+
+    #[test]
+    fn test_filter_files_multi_include_unions() {
+        let all = vec![
+            "data/train.parquet".to_string(),
+            "data/test.parquet".to_string(),
+            "README.md".to_string(),
+        ];
+        let include = vec!["*.parquet".to_string(), "*.md".to_string()];
+        let r = filter_files_by_globs(&all, &include).unwrap();
+        assert_eq!(r.len(), 3);
+    }
+
+    #[test]
+    fn test_filter_files_invalid_glob_errors() {
+        let all = vec!["a.parquet".to_string()];
+        let include = vec!["[invalid".to_string()];
+        let r = filter_files_by_globs(&all, &include);
+        assert!(r.is_err());
+    }
+}

--- a/crates/apr-cli/src/commands/stamp.rs
+++ b/crates/apr-cli/src/commands/stamp.rs
@@ -51,8 +51,8 @@ pub(crate) fn run(
     if !json_output {
         eprintln!("Reading {}", file.display());
     }
-    let input = fs::read(file)
-        .map_err(|e| CliError::ValidationFailed(format!("read failed: {e}")))?;
+    let input =
+        fs::read(file).map_err(|e| CliError::ValidationFailed(format!("read failed: {e}")))?;
 
     let patch = ProvenancePatch {
         license: license.map(str::to_string),
@@ -86,7 +86,10 @@ pub(crate) fn run(
             },
             "header_flags_bits": verify_reader.header().flags.bits(),
         });
-        println!("{}", serde_json::to_string_pretty(&summary).unwrap_or_default());
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&summary).unwrap_or_default()
+        );
     } else {
         println!(
             "✓ Stamped {} → {} ({} tensors, {} → {} bytes)",
@@ -98,7 +101,10 @@ pub(crate) fn run(
         );
         println!("  license:      {:?}", verify_reader.metadata().license);
         println!("  data_source:  {:?}", verify_reader.metadata().data_source);
-        println!("  data_license: {:?}", verify_reader.metadata().data_license);
+        println!(
+            "  data_license: {:?}",
+            verify_reader.metadata().data_license
+        );
     }
 
     Ok(())
@@ -114,12 +120,7 @@ mod tests {
     fn write_unpopulated_apr(path: &Path) {
         let metadata = AprV2Metadata::new("stamp-cli-test");
         let mut writer = AprV2Writer::new(metadata);
-        writer.add_tensor(
-            "weight",
-            TensorDType::F32,
-            vec![2, 3],
-            vec![0u8; 24],
-        );
+        writer.add_tensor("weight", TensorDType::F32, vec![2, 3], vec![0u8; 24]);
         let bytes = writer.write().expect("write test apr");
         fs::write(path, &bytes).expect("write test apr to disk");
     }
@@ -182,15 +183,7 @@ mod tests {
         let input = dir.path().join("does-not-exist.apr");
         let output = dir.path().join("output.apr");
 
-        let result = run(
-            &input,
-            Some("Apache-2.0"),
-            None,
-            None,
-            &output,
-            false,
-            true,
-        );
+        let result = run(&input, Some("Apache-2.0"), None, None, &output, false, true);
         let err = result.unwrap_err();
         // CliError::FileNotFound — exact variant, not just substring match.
         assert!(
@@ -244,7 +237,10 @@ mod tests {
             true, // force=true
             true,
         );
-        assert!(result.is_ok(), "stamp with --force must succeed: {result:?}");
+        assert!(
+            result.is_ok(),
+            "stamp with --force must succeed: {result:?}"
+        );
 
         // Output must now be a valid APR file with the patched license.
         let bytes = fs::read(&output).unwrap();

--- a/crates/apr-cli/src/commands_enum.rs
+++ b/crates/apr-cli/src/commands_enum.rs
@@ -353,11 +353,18 @@ pub enum Commands {
         #[arg(long)]
         allow_no_config: bool,
     },
-    /// Download and cache model from HuggingFace (Ollama-like UX)
+    /// Download and cache model OR HuggingFace dataset (Ollama-like UX)
     Pull {
-        /// Model reference (alias, hf:// URI, or org/repo)
-        #[arg(value_name = "MODEL")]
+        /// Model reference (alias, hf:// URI, or org/repo) OR "dataset"
+        /// asset-type discriminator. When this value is the literal
+        /// string "dataset", the next positional `repo` is the
+        /// HuggingFace dataset repo and dataset-pull semantics apply.
+        #[arg(value_name = "MODEL_OR_ASSET_TYPE")]
         model_ref: String,
+        /// Dataset repository (used only when model_ref == "dataset").
+        /// Per `apr-cli-pull-dataset-v1.yaml`.
+        #[arg(value_name = "REPO")]
+        repo: Option<String>,
         /// Force re-download even if cached
         #[arg(long)]
         force: bool,
@@ -373,6 +380,15 @@ pub enum Commands {
         /// Equivalent to APR_OFFLINE=1 or HF_HUB_OFFLINE=1 in the environment.
         #[arg(long)]
         offline: bool,
+        /// (dataset mode) Glob pattern for shard selection. May be passed
+        /// multiple times; matches are unioned. fnmatch-compatible
+        /// (`*`, `?`, `[a-z]`). No-match is fail-fast.
+        #[arg(long, value_name = "GLOB")]
+        include: Vec<String>,
+        /// (dataset mode) Output directory. Default:
+        /// `~/.cache/aprender/datasets/<repo>/`.
+        #[arg(short = 'o', long)]
+        output: Option<PathBuf>,
     },
     /// Registry operations (CRUX-A-01): inspect alias map, etc.
     Registry {

--- a/crates/apr-cli/src/dispatch.rs
+++ b/crates/apr-cli/src/dispatch.rs
@@ -624,11 +624,31 @@ fn dispatch_model_commands(cli: &Cli) -> Option<Result<(), CliError>> {
         ),
         Commands::Pull {
             model_ref,
+            repo,
             force,
             dry_run,
             revision,
             offline,
-        } => pull::run(model_ref, *force, *dry_run, revision.as_deref(), *offline),
+            include,
+            output,
+        } => {
+            // SHIP-TWO-001 §26.8: when first positional is the literal
+            // "dataset", treat the second positional as the HF dataset
+            // repo and dispatch to the dataset puller. Otherwise fall
+            // through to the existing model puller (backward compat).
+            if model_ref == "dataset" {
+                match repo.as_deref() {
+                    Some(r) => {
+                        pull::run_dataset(r, include, revision.as_deref(), output.as_deref())
+                    },
+                    None => Err(crate::error::CliError::ValidationFailed(
+                        "apr pull dataset <REPO>: REPO argument required".to_string(),
+                    )),
+                }
+            } else {
+                pull::run(model_ref, *force, *dry_run, revision.as_deref(), *offline)
+            }
+        },
         Commands::Registry { command } => {
             crate::commands::registry::run(command.clone())
         }

--- a/crates/apr-cli/src/lib.rs
+++ b/crates/apr-cli/src/lib.rs
@@ -204,8 +204,9 @@ pub fn emit_version_json() {
                 s.lines()
                     .filter_map(|line| {
                         // Expect "GPU <idx>: <name> (UUID: <uuid>)"
-                        line.strip_prefix("GPU ")
-                            .and_then(|rest| rest.split_once(':').map(|(idx, _)| idx.trim().to_string()))
+                        line.strip_prefix("GPU ").and_then(|rest| {
+                            rest.split_once(':').map(|(idx, _)| idx.trim().to_string())
+                        })
                     })
                     .collect()
             })

--- a/crates/apr-cli/src/lib_dispatch_coverage.rs
+++ b/crates/apr-cli/src/lib_dispatch_coverage.rs
@@ -32,10 +32,13 @@
     fn test_dispatch_model_commands_pull_nonexistent() {
         let cli = make_cli(Commands::Pull {
             model_ref: "nonexistent-model-that-does-not-exist-xyz123".to_string(),
+            repo: None,
             force: false,
             dry_run: false,
             revision: None,
             offline: false,
+            include: vec![],
+            output: None,
         });
         let result = dispatch_model_commands(&cli);
         assert!(result.is_some(), "Pull should be handled by dispatch_model_commands");

--- a/crates/apr-cli/src/lib_extract_paths.rs
+++ b/crates/apr-cli/src/lib_extract_paths.rs
@@ -80,10 +80,13 @@
     fn test_extract_paths_pull_exempt() {
         let cmd = Commands::Pull {
             model_ref: "hf://org/repo".to_string(),
+            repo: None,
             force: false,
             dry_run: false,
             revision: None,
             offline: false,
+            include: vec![],
+            output: None,
         };
         let paths = extract_model_paths(&cmd);
         assert!(paths.is_empty(), "Pull is a diagnostic command (exempt)");

--- a/crates/apr-cli/src/lib_parse_export.rs
+++ b/crates/apr-cli/src/lib_parse_export.rs
@@ -301,10 +301,13 @@
         match *cli.command {
             Commands::Pull {
                 model_ref,
+                repo: _,
                 force,
                 dry_run,
                 revision: _,
                 offline: _,
+                include: _,
+                output: _,
             } => {
                 assert_eq!(model_ref, "hf://Qwen/Qwen2.5-Coder-1.5B");
                 assert!(force);
@@ -322,10 +325,13 @@
         match *cli.command {
             Commands::Pull {
                 model_ref,
+                repo: _,
                 force,
                 dry_run,
                 revision: _,
                 offline: _,
+                include: _,
+                output: _,
             } => {
                 assert_eq!(model_ref, "qwen2.5-coder");
                 assert!(!force);
@@ -343,10 +349,13 @@
         match *cli.command {
             Commands::Pull {
                 model_ref,
+                repo: _,
                 force,
                 dry_run,
                 revision: _,
                 offline: _,
+                include: _,
+                output: _,
             } => {
                 assert_eq!(model_ref, "llama3");
                 assert!(!force);


### PR DESCRIPTION
## Summary

Implements **P1.1** of SHIP-TWO-001 §26.8 stack-tool-extension chain. Extends `apr pull` with the dataset asset-type per `apr-cli-pull-dataset-v1.yaml` to unblock the corpus pipeline P1.4 → P2 → MODEL-2 convergence.

```
apr pull dataset <REPO> [--include <GLOB>] [--revision <REV>] [--output <DIR>]
```

Backward-compat preserved: existing `apr pull <MODEL>` model path unchanged.

## Why this matters (per §26.8)

The previous session flagged a sub-agent attempting to route around the missing `apr pull dataset` capability via `huggingface-cli download --include`. Per `feedback_stack_tool_extension_not_cli_shim.md` (apr is canonical post-APR-MONO), the correct fix is to extend `apr` — not bypass it. This PR is that fix.

P1 of MODEL-2 (codeparrot/github-code-clean → 1B+ Python tokens → MODEL-2 convergence) was gated on this landing. Empirical §24/§25 results showed corpus-diversity is the binding constraint for MODEL-2 (val_loss=9.75 plateau on 4× CSN-Python).

## Falsification verdict (live RTX 4090, 2026-04-27)

| Test | Result |
|------|--------|
| FALSIFY-APR-PULL-DATASET-001 (--help shows --include) | ✅ PASS |
| FALSIFY-APR-PULL-DATASET-002 (glob filters correctly) | ✅ PASS — `--include 'README.md'` on openwebtext → 1 file |
| FALSIFY-APR-PULL-DATASET-003 (no-match exits non-zero) | ✅ PASS — exit code 5 (ValidationFailed) |
| FALSIFY-APR-PULL-DATASET-004 (license-allowlist) | ⏸️ DEFERRED to P1.1.5 (parquet round-trip) |
| FALSIFY-APR-PULL-DATASET-005 (model backward-compat) | ✅ PASS — `apr pull qwen2.5-coder --dry-run` clean |
| FALSIFY-APR-PULL-DATASET-006 (3-surface drift) | ✅ PASS — `cargo test cli_commands` 6/6 |
| FALSIFY-APR-PULL-DATASET-007 (pv validate) | ✅ PASS — contract 1.0.0 → 1.1.0 ACTIVE |
| FALSIFY-APR-PULL-DATASET-008 (no muda) | ✅ PASS |

5 unit tests for `filter_files_by_globs` PASS.

## Implementation details

- **commands_enum.rs**: `Pull` variant gains `repo`, `include`, `output` fields. First positional discriminates: `"dataset"` triggers dataset-pull; otherwise falls through to existing model-pull.
- **dispatch.rs**: Routes to `pull::run_dataset(...)` when `model_ref == "dataset"`.
- **commands/pull_dataset.rs** (NEW, 196 LOC): HF API listing (`/api/datasets/{repo}/tree/{rev}?recursive=1`) + glob filtering + fail-fast on no-match + reuse of existing `download_file_with_progress` streaming helper.
- **Default cache**: `~/.cache/aprender/datasets/<repo>/` (or `$XDG_CACHE_HOME/aprender/datasets/<repo>/`).

## P1.1.5 deferred

License-allowlist row filter (`--license-allowlist <CSV>`, `--license-column <NAME>`) requires parquet/jsonl row-level filtering — non-trivial new infrastructure (parquet-rs round-trip, jsonl re-encode). Scoped out per §26.8 acceptable-exception list. Contract retains the equation specification; implementation tracked separately.

## Test plan

- [x] `cargo build --release -p apr-cli` clean
- [x] `cargo test -p apr-cli --release --lib pull_dataset_tests` (5/5 PASS)
- [x] `cargo test -p apr-cli --release --test cli_commands` (6/6 PASS)
- [x] `pv validate contracts/apr-cli-pull-dataset-v1.yaml` (0 errors)
- [x] Live smoke: `apr pull dataset openwebtext --include 'README.md' --output /tmp/x` → 1 file pulled
- [x] Live smoke: `apr pull dataset openwebtext --include 'no/such/*'` → exit 5
- [x] Backward-compat: `apr pull qwen2.5-coder --dry-run` exits 0

## Next session

P1.4 (pull codeparrot/github-code-clean) can now proceed via:
```
apr pull dataset codeparrot/github-code-clean \
    --include 'data/train-000[0-7][0-9]-of-00880.parquet' \
    --output /mnt/nvme-raid0/datasets/github-code-clean
```

Then P2 retrain MODEL-2 on the bigger corpus (~7.3 hr GPU).

🤖 Generated with [Claude Code](https://claude.com/claude-code)