### PR TITLE
fix(ci): add rustup target add for workspace-pinned toolchain in binary-release

### DIFF
--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -81,6 +81,15 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      # The workspace pins a specific channel in `rust-toolchain.toml`
+      # which overrides the dtolnay action for any cargo invocation in
+      # the tree. Add the target explicitly to that pinned toolchain so
+      # native cross-compiles (x86_64-musl) don't fail with `can't find
+      # crate for core` mid-build.
+      - name: Install target on workspace-pinned toolchain
+        if: ${{ !matrix.cross }}
+        run: rustup target add ${{ matrix.target }}
+
       - name: Install musl tools
         if: matrix.target == 'x86_64-unknown-linux-musl'
         run: |


### PR DESCRIPTION
## Summary

- The dtolnay/rust-toolchain action's `targets:` parameter installs targets on the *action-resolved* toolchain, but `rust-toolchain.toml` pins channel 1.93.0 which overrides it for any cargo invocation in the workspace.
- Native cross-compiles (x86_64-musl) consequently fail with `can't find crate for core` — the pinned toolchain has no musl target.
- Add an explicit \`rustup target add \${{ matrix.target }}\` step gated on \`!matrix.cross\` (the cross targets use the cross Docker image which carries its own toolchain, so they don't hit this).

## Why

Same root cause as the fix already merged in [paiml/forjar PR #124](https://github.com/paiml/forjar/pull/124) and [paiml/bashrs PR #200](https://github.com/paiml/bashrs/pull/200). All paiml workspaces with a pinned `rust-toolchain.toml` exhibit the same failure mode for native cross-compiles in `binary-release.yml`.

## Evidence

The v0.31.2 backfill ran the unfixed workflow:
- aarch64-unknown-linux-gnu — succeeded (cross image, unaffected)
- aarch64-unknown-linux-musl — succeeded (cross image, unaffected)
- x86_64-unknown-linux-gnu — succeeded (gnu target ships on rust-toolchain.toml's host triple)
- **x86_64-unknown-linux-musl — failed** with `can't find crate for core`

Once this PR merges I'll re-trigger the v0.31.2 backfill via `gh workflow run "Binary Release" -f tag=v0.31.2` to attach the missing musl tarball.

## Test plan

- [x] `Edit` adds the step in the same place as the bashrs PR (between the dtolnay action and `Install musl tools`)
- [x] Step is gated on `!matrix.cross` so it only runs for native targets
- [ ] CI: `binary-release` workflow on this PR completes (workflow runs on `release: published` and `workflow_dispatch` only, so PR CI doesn't exercise it directly — verification happens at the next backfill)

🤖 Generated with [Claude Code](https://claude.com/claude-code)