### PR TITLE
docs(p1-5): apr-tokenize-parallel-bpe-v1 — contract for parallel BPE (4× speedup at 8 cores)

### DIFF
--- a/contracts/apr-tokenize-parallel-bpe-v1.yaml
+++ b/contracts/apr-tokenize-parallel-bpe-v1.yaml
@@ -1,0 +1,129 @@
+metadata:
+  kind: schema
+  version: 1.0.0
+  status: PROPOSED
+  created: '2026-04-27'
+  author: PAIML Engineering
+  registry: false
+  references:
+  - 'SPEC-SHIP-TWO-001 §26.2 — corpus pipeline'
+  - 'SPEC-SHIP-TWO-001 §26.8 — apr is canonical, extend apr never CLI-shim'
+  - 'feedback_compute_pre_authorized.md — lambda-labs lane is open'
+  description: >
+    Contract for parallelizing `apr tokenize encode-corpus` across multiple
+    CPU cores. Triggering observation 2026-04-27: P1.5 BPE encoding of a
+    760M-char Python+permissive JSONL corpus runs single-threaded at ~13K
+    tokens/sec on RTX 4090 host (48 cores available). Total encode time
+    ~4 hours for 190M tokens. With N-way parallelism, expected speedup
+    ~Nx (BPE is CPU-bound, no shared mutable state across rows).
+
+equations:
+  parallel_correctness:
+    formula: |
+      Splitting the input JSONL into N chunks, encoding each chunk
+      independently with the SAME tokenizer, and concatenating the
+      output token streams MUST produce a token stream IDENTICAL to
+      the single-threaded encoding (modulo final-shard boundary).
+
+      ENC(jsonl_full, tok) ≡ concat(ENC(chunk_0, tok), ..., ENC(chunk_N-1, tok))
+
+      Where ENC encodes per-row independently (BPE has no cross-row state).
+    domain: BPE encoding determinism
+    codomain: bool
+    invariants:
+    - "BPE per-row encoding is independent (no cross-row context window)"
+    - "Same tokenizer + same row → same token sequence (deterministic)"
+    - "Concatenation order preserves input order"
+
+  shard_renumbering:
+    formula: |
+      When N parallel encoders write to N output directories, each
+      producing shard-00000.bin .. shard-MMM.bin, the merged corpus is
+      formed by:
+        merged_shard_idx[i] = sum(N_shards[0..encoder_idx]) + local_shard_idx
+      with renumbered files copied (or hardlinked) into the merged dir.
+      The final shard from encoder_k may be partial (< 10M tokens); this
+      is preserved by the merge.
+    domain: shard numbering
+    codomain: bool
+    invariants:
+    - "No two merged shards have the same shard_idx"
+    - "Order: encoder-0's shards come first, then encoder-1's, etc."
+    - "Total tokens preserved exactly"
+
+  speedup_target:
+    formula: |
+      N-way parallel encoding wall_time ≤ (single_threaded_time / N) +
+      epsilon, where epsilon is fixed I/O+merge overhead bounded by
+      10 seconds independent of N.
+    domain: performance
+    codomain: bool
+    invariants:
+    - "speedup ≥ 0.8 × N for N ≤ min(num_cores, 8)"
+    - "merge step O(num_shards) not O(num_tokens)"
+
+falsification_tests:
+- id: FALSIFY-APR-TOK-PAR-001
+  rule: parallel encode produces identical token stream as serial
+  prediction: "Splitting a 1MB JSONL into 4 chunks and parallel-encoding produces a token stream concat-equal to serial-encoding the full file"
+  test: |
+    apr tokenize encode-corpus --corpus full.jsonl --tokenizer T --output single/
+    split_jsonl full.jsonl --chunks 4
+    for i in 0..3: apr tokenize encode-corpus --corpus chunk-$i.jsonl --tokenizer T --output par-$i/ &
+    wait
+    merge_shards par-0/ par-1/ par-2/ par-3/ --output merged/
+    cmp single/concat.bin merged/concat.bin
+  if_fails: "parallel encoding diverges — bug in chunk split or shard merge"
+
+- id: FALSIFY-APR-TOK-PAR-002
+  rule: speedup ≥ 0.8N for 4-way
+  prediction: "4-way parallel on 4-core machine completes in ≤ 1.25× single-threaded / 4"
+  test: "time_par <= time_serial * 1.25 / 4"
+  if_fails: "parallelism overhead too high — likely due to fork-join cost or I/O contention"
+
+- id: FALSIFY-APR-TOK-PAR-003
+  rule: 8-way doesn't crash
+  prediction: "apr tokenize encode-corpus --workers 8 on 16-core machine succeeds (no OOM, no deadlock)"
+  test: "exit code = 0, output dir has expected shard count"
+  if_fails: "parallelism causes resource exhaustion — workers must respect a memory budget"
+
+- id: FALSIFY-APR-TOK-PAR-004
+  rule: --workers flag is positional discriminator
+  prediction: "`apr tokenize encode-corpus --workers 4` is accepted by clap and visible in --help"
+  test: "apr tokenize encode-corpus --help | grep -q workers"
+  if_fails: "CLI surface drift — flag not registered in clap"
+
+proof_obligations:
+- type: invariant
+  property: "parallel encoding preserves bit-exact tokenization vs serial"
+- type: invariant
+  property: "merged shard byte-stream concat-equals serial output"
+- type: termination
+  property: "no parallel worker hangs; merge step terminates in O(num_shards)"
+- type: completeness
+  property: "every input row appears in exactly one merged shard"
+
+verification_summary:
+  total_obligations: 4
+  proven: 0
+  tested: 0
+  status: pending
+  notes: |
+    Authored 2026-04-27 from observation that P1.5 BPE encoding ran single-
+    threaded at ~13K tokens/sec on a 48-core host. With 760M chars (~190M
+    tokens) to encode, single-threaded ETA was ~4 hours; 8-way parallelism
+    would have brought this to ~30 minutes.
+
+    PROPOSED status until implementation. Implementation steps:
+    1. Add `--workers N` flag to `apr tokenize encode-corpus`.
+    2. Split input JSONL by row count modulo N (preserving order within chunk).
+    3. Spawn N rayon worker threads, each running the existing single-
+       threaded encode logic on its chunk to a per-worker temp dir.
+    4. After all workers complete, merge by renumbering shards in
+       (worker_idx, local_idx) order into the final output dir.
+    5. Write final manifest.json with merged shard list.
+
+    Implementation cost estimate: ~200 LOC + 5 unit tests. P3 priority
+    (after MODEL-2 retrain on codeparrot lands and proves the corpus
+    scales to ~1B+ tokens — at which point single-threaded encoding
+    becomes a 24+ hour operation that's clearly worth paralleling).


### PR DESCRIPTION
## Summary

Contract for parallelizing `apr tokenize encode-corpus` per spec §26.8 stack-tool-extension methodology.

## Triggering observation (2026-04-27)

P1.5 BPE encoding of 760M-char github-code-clean Python+permissive JSONL ran single-threaded at ~13K tokens/sec on a 48-core RTX 4090 host. Wall time ~4 hours for ~190M tokens. **8-way parallelism would have completed in ~30 minutes.**

The encoder is CPU-bound (97.8% CPU on one core) with 47 idle cores — pure waste.

## Contract structure

3 equations:
- `parallel_correctness`: BPE per-row determinism → split + concat ≡ serial
- `shard_renumbering`: merge preserves shard-NNNNN sequencing
- `speedup_target`: ≥0.8N for N ≤ min(num_cores, 8)

4 falsification tests:
- FALSIFY-APR-TOK-PAR-001: parallel == serial token stream
- FALSIFY-APR-TOK-PAR-002: 4-way ≥ 0.8× speedup
- FALSIFY-APR-TOK-PAR-003: 8-way doesn't crash
- FALSIFY-APR-TOK-PAR-004: `--workers` flag visible in --help

## Status

PROPOSED. Implementation deferred to P3 priority.

P1.5 (current run) accepts the 4-hour single-threaded encode. The contract becomes load-bearing once corpus scales to 1B+ tokens (24+ hour single-threaded encode).

Implementation cost estimate: ~200 LOC + 5 unit tests.

## Test plan

- [x] `pv validate contracts/apr-tokenize-parallel-bpe-v1.yaml` exits 0 (verified live)

🤖 Generated with [Claude Code](https://claude.com/claude-code)