### PR TITLE
docs(ship-007): determinism test FALSIFIES parallel-reduction-nondeterminism hypothesis

### DIFF
--- a/crates/aprender-serve/examples/diag_apr_determinism.rs
+++ b/crates/aprender-serve/examples/diag_apr_determinism.rs
@@ -1,0 +1,98 @@
+//! Test the parallel-reduction-nondeterminism hypothesis for SHIP-007.
+//!
+//! Per evidence/ship-007-layer3-bisection-2026-04-28/per-layer-accumulation.md,
+//! the layer-3 sub-FFN divergence APR vs GGUF may stem from non-deterministic
+//! f32 accumulation order in APR's parallel matmul (rayon).
+//!
+//! This diagnostic:
+//! 1. Loads the canonical 7B teacher
+//! 2. Runs forward() twice with the same prompt tokens
+//! 3. Element-wise compares the final logits
+//!
+//! If logits differ across runs:
+//!   → APR forward is non-deterministic
+//!   → parallel reduction is the source
+//!   → fix = deterministic reduction order
+//!
+//! If logits are identical:
+//!   → APR is deterministic
+//!   → the APR vs GGUF gap is structural (different kernel path)
+//!   → next investigation = compare APR vs GGUF kernels on same synthetic input
+
+use realizar::apr_transformer::AprTransformer;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let path = "/mnt/nvme-raid0/models/ship-two-001/qwen2.5-coder-7b-instruct-q4k.apr";
+    println!("Loading {}...", path);
+    let t = AprTransformer::from_apr_file(path)?;
+
+    // "What is 2+2?" prompt tokens (matches the apr trace evidence)
+    let token_ids: Vec<u32> = vec![3838, 374, 220, 17, 10, 17, 30];
+
+    println!("\n=== Run 1 ===");
+    let logits1 = t.forward(&token_ids)?;
+    let n = logits1.len();
+    println!("logits.len() = {}", n);
+    println!("first 5 = {:?}", &logits1[..5]);
+
+    println!("\n=== Run 2 ===");
+    let logits2 = t.forward(&token_ids)?;
+    println!("first 5 = {:?}", &logits2[..5]);
+
+    // Element-wise diff
+    let mut max_diff = 0.0f32;
+    let mut sum_sq_diff = 0.0f32;
+    let mut nonzero_diffs = 0usize;
+    let mut first_diff_idx = None;
+    for i in 0..n {
+        let d = (logits1[i] - logits2[i]).abs();
+        if d > 0.0 {
+            nonzero_diffs += 1;
+            if first_diff_idx.is_none() {
+                first_diff_idx = Some(i);
+            }
+        }
+        if d > max_diff {
+            max_diff = d;
+        }
+        sum_sq_diff += d * d;
+    }
+    let rms = (sum_sq_diff / n as f32).sqrt();
+
+    println!("\n=== VERDICT ===");
+    println!("Total elements: {}", n);
+    println!(
+        "Non-zero diffs: {} ({:.3}%)",
+        nonzero_diffs,
+        100.0 * nonzero_diffs as f64 / n as f64
+    );
+    println!("Max abs diff:   {:.10}", max_diff);
+    println!("RMS diff:       {:.10}", rms);
+    if let Some(i) = first_diff_idx {
+        println!(
+            "First diff at idx {}: {:.10} vs {:.10} (diff = {:.10})",
+            i,
+            logits1[i],
+            logits2[i],
+            (logits1[i] - logits2[i]).abs()
+        );
+    }
+
+    println!("\n=== HYPOTHESIS TEST ===");
+    if max_diff == 0.0 {
+        println!("APR forward is BYTE-IDENTICAL across runs.");
+        println!("→ Parallel-reduction-nondeterminism hypothesis FALSIFIED.");
+        println!("→ APR vs GGUF gap is structural (different kernel path).");
+        println!("→ Next: compare APR vs GGUF kernels on same synthetic input.");
+    } else {
+        println!(
+            "APR forward DIFFERS across runs by max abs diff = {:.6e}",
+            max_diff
+        );
+        println!("→ Parallel-reduction-nondeterminism hypothesis CONFIRMED.");
+        println!("→ Fix: enforce deterministic reduction order in APR matmul kernels.");
+        println!("→ Once fixed, layer-3 ffn_swigl ratio should drop and 5 SHIP-007 PARTIALs flip to DISCHARGED.");
+    }
+
+    Ok(())
+}

--- a/evidence/ship-007-layer3-bisection-2026-04-28/diag_apr_determinism.txt
+++ b/evidence/ship-007-layer3-bisection-2026-04-28/diag_apr_determinism.txt
@@ -1,0 +1,20 @@
+Loading /mnt/nvme-raid0/models/ship-two-001/qwen2.5-coder-7b-instruct-q4k.apr...
+
+=== Run 1 ===
+logits.len() = 152064
+first 5 = [2.3340359, 3.7898252, 6.2179155, 3.7658672, 0.8772266]
+
+=== Run 2 ===
+first 5 = [2.3340359, 3.7898252, 6.2179155, 3.7658672, 0.8772266]
+
+=== VERDICT ===
+Total elements: 152064
+Non-zero diffs: 0 (0.000%)
+Max abs diff:   0.0000000000
+RMS diff:       0.0000000000
+
+=== HYPOTHESIS TEST ===
+APR forward is BYTE-IDENTICAL across runs.
+→ Parallel-reduction-nondeterminism hypothesis FALSIFIED.
+→ APR vs GGUF gap is structural (different kernel path).
+→ Next: compare APR vs GGUF kernels on same synthetic input.


### PR DESCRIPTION
## Summary

Hypothesis from #1099 per-layer analysis: APR's matmul reduction may be parallel (rayon) producing non-deterministic f32 accumulation order. This PR tests it directly.

## Result

Run `apr forward()` twice with identical token input on canonical 7B teacher. Compare logits element-wise:

| Metric | Value |
|--------|------:|
| Total logits | 152,064 |
| Non-zero diffs | **0 (0.000%)** |
| Max abs diff | 0.0000000000 |
| RMS diff | 0.0000000000 |

**APR forward is byte-identical across runs.** Hypothesis FALSIFIED.

## What this means for shipping MODEL-1

The APR vs GGUF gap is **structural**, not stochastic. Both forward paths are deterministic; they produce different per-element results due to different code paths that compound over layers.

## Next investigation step

Compare APR vs GGUF kernel outputs on the SAME synthetic input at layer 0 stage-by-stage. The first stage where APR and GGUF outputs differ at the per-element level (>Q4K tolerance) is the actual bug surface. Likely candidates: RoPE precision, attention softmax order, residual accumulation precision.

Once located, fix at root → SHIP-002/005/006/007/008 (5 PARTIALs) flip to DISCHARGED → MODEL-1 ships cleanly through both APR and GGUF backends → `paiml/qwen2.5-coder-7b-apache-q4k-v1` complete.

## Files

- `crates/aprender-serve/examples/diag_apr_determinism.rs` — re-runnable test
- `evidence/ship-007-layer3-bisection-2026-04-28/diag_apr_determinism.txt` — verified live on RTX 4090

## Test plan

- [x] Built with `--features cuda` from main HEAD
- [x] Ran twice on canonical 7B teacher
- [x] Element-wise diff exactly 0.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)