### PR TITLE
docs(ship-007): §37 — APR vs GGUF forward_traced TRACE-CAPTURE-POINT MISMATCH

### DIFF
--- a/contracts/qwen3-moe-forward-v1.yaml
+++ b/contracts/qwen3-moe-forward-v1.yaml
@@ -1,0 +1,302 @@
+metadata:
+  version: 1.0.0
+  created: '2026-04-28'
+  author: PAIML Engineering
+  description: |
+    Qwen3-MoE forward pass — composes router + per-expert SwiGLU + weighted
+    aggregation into a single, falsifiable forward kernel for any model in
+    the Qwen3MoE family (Qwen3-Coder-30B-A3B-Instruct, Qwen3-235B-A22B,
+    Qwen3.5-MoE).
+
+    Authored under the claude-code-parity-apr POC (companion repo M31)
+    because the measured FALSIFY-CCPA-013 tool-dispatch parity gate is
+    unblocked by `apr run` actually producing tokens against
+    Qwen3-Coder-30B-A3B-Instruct, which is gated on this contract being
+    discharged.
+
+    Status: SCAFFOLD. Three implementation stages (M32b/c/d) named in
+    `proof_obligations.implementation_stages`. Each stage discharges
+    one obligation; final stage (M32d) flips this contract from
+    DRAFT to ACTIVE_RUNTIME.
+  references:
+  - 'Fedus et al. (2022) Switch Transformers: Scaling to Trillion Parameter Models'
+  - 'Shazeer (2020) GLU Variants Improve Transformer'
+  - 'Su et al. (2021) RoFormer: Enhanced Transformer with Rotary Position Embedding'
+  - 'Qwen3 Technical Report — MoE architecture with top-k routing'
+  - 'paiml/aprender contracts/tensor-names-v1.yaml v1.1.0 — qwen3_moe tensor namespace'
+  - 'paiml/aprender contracts/moe-router-v1.yaml — softmax+topk+renorm router'
+  - 'paiml/aprender contracts/moe-expert-dispatch-v1.yaml — per-expert dispatch + weighted aggregation'
+  - 'paiml/aprender contracts/qwen3moe-shapes-v1.yaml — Qwen3MoE shape algebra'
+  - 'paiml/claude-code-parity-apr docs/specifications/claude-code-parity-apr-poc.md M31 — monorepo scope clarification'
+  depends_on:
+  - tensor-names-v1
+  - moe-router-v1
+  - moe-expert-dispatch-v1
+  - qwen3moe-shapes-v1
+  - swiglu-kernel-v1
+  - silu-kernel-v1
+  - rmsnorm-kernel-v1
+  - rope-kernel-v1
+  registry: true
+
+kind: KernelContract
+name: qwen3-moe-forward
+version: "1.0.0"
+status: DRAFT   # SCAFFOLD — flips to ACTIVE_RUNTIME at end of M32d (parity discharge)
+scope: "crates/aprender-serve/src/{gguf,apr}/**, crates/aprender-serve/src/gpu/scheduler/moe_dispatch.rs"
+
+description: |
+  End-to-end forward pass for one MoE decoder layer of a Qwen3MoE model.
+  Inputs: hidden_state[hidden_dim], one MoE layer's weights. Output:
+  hidden_state' = hidden_state + MoE(RMSNorm(hidden_state)).
+
+  The MoE block itself decomposes into:
+
+    1. Router: softmax(W_router @ x) → top-k → renormalize  (moe-router-v1)
+    2. Per-expert SwiGLU: down(SiLU(gate(x)) * up(x))       (swiglu-kernel-v1, per-expert)
+    3. Weighted aggregation: Σ_e w[t,e] * expert_out[t,e]   (moe-expert-dispatch-v1)
+    4. Optional shared expert with sigmoid gate
+
+  Tensor naming for Qwen3MoE comes from tensor-names-v1 v1.1.0:
+
+    blk.{L}.ffn_gate_inp.weight     [num_experts, hidden_dim]            — router
+    blk.{L}.ffn_gate_exps.weight    [num_experts, intermediate, hidden]  — gate per expert
+    blk.{L}.ffn_up_exps.weight      [num_experts, intermediate, hidden]  — up per expert
+    blk.{L}.ffn_down_exps.weight    [num_experts, hidden, intermediate]  — down per expert
+
+  No `blk.{L}.ffn_{gate,up,down}.weight` exists for qwen3_moe — those are
+  dense-FFN tensor names. Loading code that hardcodes those names will
+  fail at the GGUF tensor lookup. (This is precisely the live failure
+  mode reproduced by `apr run <qwen3-coder-30b>.gguf` as of commit
+  15d504cfe — see falsification.F_QW3_MOE_FORWARD_001 below.)
+
+equations:
+  moe_forward_one_layer:
+    formula: |
+      h' = h + MoE(RMSNorm(h))
+      where MoE(x) = Σ_{e ∈ TopK(softmax(W_r @ x), k)} w_e · SwiGLU_e(x)
+                     + (optional) σ(W_s @ x) · SwiGLU_shared(x)
+    domain: |
+      h ∈ R^d, W_r ∈ R^{N_e × d}, W_s ∈ R^{1 × d}, k = num_experts_per_tok,
+      SwiGLU_e ∈ R^d → R^d parameterized by (W_gate^e, W_up^e, W_down^e)
+    invariants:
+    - h.len() == hidden_dim
+    - 'router weights sum: Σ_e selected_w[e] = 1.0  (post-renormalization)'
+    - 'output shape preserved: result.len() == hidden_dim'
+    - 'selected experts ∈ [0, N_e)'
+    - 'finite: result.iter().all(|v| v.is_finite())'
+    preconditions:
+    - hidden_dim > 0
+    - num_experts > 0
+    - num_experts_per_tok > 0 ∧ num_experts_per_tok ≤ num_experts
+    - 'router_weight.shape == [num_experts, hidden_dim]'
+    - 'expert_gate.shape == [num_experts, intermediate, hidden_dim]'
+    - 'expert_up.shape   == [num_experts, intermediate, hidden_dim]'
+    - 'expert_down.shape == [num_experts, hidden_dim, intermediate]'
+    postconditions:
+    - 'result.len() == hidden_dim'
+    - 'result.iter().all(|v| v.is_finite())'
+    assumes:
+      from_contract: moe-router-v1
+      from_equation: softmax_normalization
+      constraints:
+      - 'router probs sum to 1.0 ± 1e-6 prior to top-k'
+    guarantees:
+      shapes:
+        output: { dims: ["hidden_dim"] }
+      constraints:
+      - 'output is finite'
+      - 'output.len() == hidden_dim'
+      - 'differs from h only by additive update (residual preserved)'
+    lean_theorem: Theorems.Qwen3_Moe_Forward_One_Layer
+
+  qwen3_coder_30b_a3b_instantiation:
+    formula: |
+      L = 48, d_model = 2048, d_ff = 6144,
+      N_experts = 128, k = 8 (active per token),
+      n_heads = 32, n_kv = 4 (GQA 8:1),
+      vocab = 151936, max_position = 262144, rope_theta = 1e7
+    domain: 'Qwen3-Coder-30B-A3B-Instruct (config.json + apr inspect)'
+    invariants:
+    - 'Total parameters ≈ 30.5B (matches A3B "30B" suffix)'
+    - 'Active parameters ≈ 3.0B (matches A3B "A3B" suffix; k/N_e × MoE params + non-MoE)'
+    - 'Active/total ratio ≈ 9.8% (8/128 = 6.25% MoE-only; non-MoE adds embedding/attn)'
+    - 'Memory at Q4_K ≈ 17 GB (fits RTX 4090 24GB with KV cache headroom)'
+    preconditions:
+    - 'apr inspect <qwen3-coder>.apr returns family == "qwen3_moe"'
+    - 'GGUF metadata.qwen3moe.expert_count == 128'
+    - 'GGUF metadata.qwen3moe.expert_used_count == 8'
+    lean_theorem: Theorems.Qwen3_Coder_30b_a3b_Shape_Algebra
+
+  ffn_dispatch_branching:
+    formula: |
+      forward_ffn_layer(arch, h, layer) =
+        match arch with
+        | dense    → dense_ffn(h, layer.ffn_gate, layer.ffn_up, layer.ffn_down)
+        | qwen3_moe → moe_forward_token(h, layer.moe_weights, hidden_dim)
+        | other    → UnsupportedOperation
+    domain: 'arch ∈ {dense, qwen3_moe, deepseek_v2_moe, mixtral_moe, ...}'
+    invariants:
+    - 'load-time tensor enumeration MUST be arch-aware (M32b)'
+    - 'forward-time dispatch MUST be arch-aware (M32c)'
+    - 'an arch with no implementation MUST emit a contract-named UnsupportedOperation, not a cryptic "Tensor not found"'
+    preconditions:
+    - 'arch resolved via tensor_names_fallback::normalize_architecture from GGUF general.architecture or HF arch class name'
+
+proof_obligations:
+- type: equivalence
+  property: 'CPU forward result equals reference within Q4_K tolerance (AC_QW3_MOE_001)'
+  formal: '|moe_forward_one_layer(h, W) - llama_cpp_reference(h, W)| / ||ref||_2 < 5e-2'
+  tolerance: 5.0e-2
+  applies_to: all
+
+- type: invariant
+  property: 'Router weights sum to 1.0 after top-k renormalization (AC_QW3_MOE_002)'
+  formal: 'Σ_e route.weights[e] = 1.0 ± 1e-6'
+  applies_to: all
+
+- type: invariant
+  property: 'Output dimensions preserved (AC_QW3_MOE_003)'
+  formal: 'forward.output.len() == hidden_dim'
+  applies_to: all
+
+- type: invariant
+  property: 'Output is finite — no NaN/Inf (AC_QW3_MOE_004)'
+  formal: 'forward.output.iter().all(|v| v.is_finite())'
+  applies_to: all
+
+- type: equivalence
+  property: 'Single-token CPU forward matches HF FP16 reference (AC_QW3_MOE_005)'
+  formal: 'cosine_similarity(apr_logits, hf_fp16_logits) > 0.99'
+  tolerance: 0.01
+  applies_to: all
+
+implementation_stages:
+- id: M32a
+  status: SHIPPED
+  description: 'This contract scaffold (paiml/aprender#TBD).'
+  evidence: 'pv validate contracts/qwen3-moe-forward-v1.yaml exits 0'
+
+- id: M32b
+  status: PENDING
+  description: |
+    Architecture-aware FFN load. Branch transformer_loader.rs and
+    apr/weight.rs at the FFN tensor lookup site on
+    `tensor_names_fallback::normalize_architecture(model_arch)`. For
+    arch == "qwen3_moe", load the 4 MoE tensors per layer
+    (ffn_gate_inp/ffn_gate_exps/ffn_up_exps/ffn_down_exps) into a new
+    `MoeLayerWeights` field on the transformer-layer struct. For
+    forward attempts, emit `RealizarError::UnsupportedOperation` with
+    `operation = "moe_forward_pass"` and
+    `reason` referencing this contract. Falsifier:
+    F_QW3_MOE_FORWARD_002 below.
+  unblocks_obligations: [AC_QW3_MOE_002, AC_QW3_MOE_003]
+
+- id: M32c
+  status: PENDING
+  description: |
+    Wire CPU MoE forward. The pure-Rust `moe_forward_token` in
+    gpu/scheduler/moe_dispatch.rs already implements the full
+    router + per-expert SwiGLU + weighted aggregation kernel. M32c
+    populates `MoeExpertWeights` from the M32b-loaded tensors and
+    calls `moe_forward_token` from the FFN dispatch site for
+    qwen3_moe layers. After M32c, `apr run` produces tokens (any
+    tokens — correctness gate is M32d). Falsifier:
+    F_QW3_MOE_FORWARD_003 below.
+  unblocks_obligations: [AC_QW3_MOE_003, AC_QW3_MOE_004]
+
+- id: M32d
+  status: PENDING
+  description: |
+    Numerical parity vs ground truth. Compare apr CPU forward
+    logits against llama.cpp Q4_K (primary) and HF transformers
+    FP16 (secondary) per CLAUDE.md ground-truth verification
+    workflow. Falsifier: F_QW3_MOE_FORWARD_004. After M32d this
+    contract flips DRAFT → ACTIVE_RUNTIME and unblocks the
+    companion-repo FALSIFY-CCPA-013 measured tool-dispatch parity
+    score.
+  unblocks_obligations: [AC_QW3_MOE_001, AC_QW3_MOE_005]
+
+falsification_tests:
+- id: FALSIFY-QW3-MOE-FORWARD-001
+  rule: 'Baseline failure pinned at M32a-precursor (commit 15d504cfe)'
+  prediction: |
+    `apr run` against a qwen3_moe GGUF emits exactly:
+    "Invalid shape: Tensor 'blk.0.ffn_up.weight' not found"
+    proving that the dense-FFN tensor-name lookup is reached
+    architecture-blind and the M32 implementation gap exists.
+  test: |
+    apr run ~/.cache/pacha/models/<qwen3-coder-gguf-sha>.gguf \
+        --prompt "What is 2+2?" --max-tokens 8
+    Expect stderr matches: /Tensor '.*ffn_up\.weight' not found/
+  if_fails: |
+    The M32 gap was closed by some other route (e.g. tensor-names
+    fallback now resolves the dense names from MoE tensors); this
+    contract is no longer the load-bearing description of the gap
+    and must be retired or renamed.
+
+- id: FALSIFY-QW3-MOE-FORWARD-002
+  rule: 'M32b discharges arch-aware load (no more cryptic dense-FFN error)'
+  prediction: |
+    Loading a qwen3_moe GGUF must NOT emit
+    "Invalid shape: Tensor '*.ffn_{up,gate,down}.weight' not found".
+    If forward is attempted before M32c lands, the error must be
+    `RealizarError::UnsupportedOperation { operation: "moe_forward_pass" }`
+    whose Display contains the literal string "qwen3-moe-forward-v1".
+  test: |
+    cargo test -p aprender-serve --test qwen3_moe_load_path
+    Asserts: load step succeeds, forward step (if attempted)
+    returns UnsupportedOperation containing the contract id.
+  if_fails: |
+    M32b skipped or partial — load path still uses dense FFN
+    names. Add the architecture branch in transformer_loader.rs
+    before declaring M32b discharged.
+
+- id: FALSIFY-QW3-MOE-FORWARD-003
+  rule: 'M32c discharges CPU forward wiring — `apr run` produces tokens'
+  prediction: |
+    `apr run <qwen3-coder>.gguf --prompt "Hi" --max-tokens 8`
+    exits 0 and stdout contains at least one non-whitespace
+    character (any token, correctness not yet asserted).
+  test: |
+    apr run ~/.cache/pacha/models/<qwen3-coder>.gguf \
+        --prompt "Hi" --max-tokens 8
+    Assert: exit 0, stdout matches /\S/.
+  if_fails: |
+    Forward dispatch still on dense path. Verify that the FFN
+    branching at the dispatch site reaches `moe_forward_token`.
+
+- id: FALSIFY-QW3-MOE-FORWARD-004
+  rule: 'M32d discharges numerical parity vs llama.cpp Q4_K reference'
+  prediction: |
+    cosine_similarity(apr_logits[0], llama_cpp_logits[0]) > 0.99
+    on prompt "What is 2+2?" with greedy decode (top_k=1).
+  test: |
+    cargo test -p aprender-serve --test qwen3_moe_parity \
+        -- --include-ignored
+    Compares aprender CPU forward logits at position 0 against
+    llama.cpp's `llama-cli -m <gguf> -p "What is 2+2?" -n 1
+    --verbose --logit-output` parsed reference.
+  if_fails: |
+    Numerical divergence — investigate per CLAUDE.md ground-truth
+    verification checklist (embedding → RMSNorm → attention →
+    FFN → final logits). Quantization tolerance is ±5%
+    element-wise / <1% L2 for Q4_K.
+
+cross_repo_references:
+- repo: paiml/claude-code-parity-apr
+  contract: claude-code-parity-apr-v1
+  current_version: "1.19.0"
+  relation: |
+    The companion-repo POC's measured tool-dispatch parity gate
+    (FALSIFY-CCPA-013) is unblocked by M32d shipping. That POC
+    explicitly named M32 as the next-goal in v1.19.0 (M31 status
+    snapshot: "Outstanding next-goal (in-scope, M32)").
+- repo: paiml/aprender (this repo)
+  contract: tensor-names-v1
+  current_version: "1.1.0"
+  relation: |
+    M29 contract amendment that declared the qwen3_moe tensor
+    namespace + the F-TNV-002 falsifier validating contract
+    templates against the live 17.3 GB Qwen3-Coder GGUF byte
+    inventory. M32 is what the M29 amendment was scaffolding.

--- a/crates/aprender-serve/examples/diag_compare_embedding.rs
+++ b/crates/aprender-serve/examples/diag_compare_embedding.rs
@@ -1,0 +1,189 @@
+//! §37 byte-level comparison: APR vs GGUF token_embedding for SHIP-007 prompt.
+//!
+//! `apr trace --payload` reports embedding stats:
+//!   APR : Range [-0.4160, +0.5273], Mean 0.0000, Std 0.0174
+//!   GGUF: Range [-0.1514, +0.1396], Mean -0.0001, Std 0.0186
+//!
+//! The std is similar (1.07× ratio) but the RANGE is 3.4× wider in APR despite similar std.
+//! This points to outlier embedding values in APR that GGUF doesn't have. This script:
+//!   1. Loads both formats' token embedding tables.
+//!   2. Extracts the 7 token rows for "What is 2+2?" → [3838, 374, 220, 17, 10, 17, 30].
+//!   3. Compares element-wise.
+//!   4. Verdict: bytes-identical → bug downstream of embedding lookup.
+//!                bytes-differ → bug in APR converter or APR loader.
+//!
+//! Per spec §32 methodology — falsifiable bisection via byte-compare.
+
+use realizar::apr_transformer::AprTransformer;
+use realizar::gguf::{MappedGGUFModel, OwnedQuantizedModel};
+
+const PROMPT_TOKENS: &[u32] = &[3838, 374, 220, 17, 10, 17, 30]; // "What is 2+2?"
+
+fn stats(label: &str, data: &[f32]) -> (f32, f32, f32, f32) {
+    let n = data.len() as f32;
+    let mean = data.iter().sum::<f32>() / n;
+    let var = data.iter().map(|x| (x - mean).powi(2)).sum::<f32>() / n;
+    let std = var.sqrt();
+    let min = data.iter().cloned().fold(f32::INFINITY, f32::min);
+    let max = data.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+    println!(
+        "  {:32} n={:7} mean={:>10.6} std={:>10.6} min={:>10.4} max={:>10.4}",
+        label,
+        data.len(),
+        mean,
+        std,
+        min,
+        max
+    );
+    (mean, std, min, max)
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let apr_path = "/mnt/nvme-raid0/models/ship-two-001/qwen2.5-coder-7b-instruct-q4k.apr";
+    let gguf_path = "/mnt/nvme-raid0/models/ship-two-001/qwen2.5-coder-7b-instruct-q4k.gguf";
+
+    println!("=== §37 APR vs GGUF token_embedding byte-compare ===");
+    println!("Prompt tokens: {:?}", PROMPT_TOKENS);
+    println!();
+
+    println!("Loading APR: {}", apr_path);
+    let apr = AprTransformer::from_apr_file(apr_path)?;
+    let cfg = apr.config();
+    let hidden_dim = cfg.hidden_dim;
+    let vocab_size = cfg.vocab_size;
+    println!(
+        "  APR config: vocab={} hidden_dim={} embed_size={}",
+        vocab_size,
+        hidden_dim,
+        apr.token_embedding.len()
+    );
+
+    println!("\nLoading GGUF: {}", gguf_path);
+    let mapped = MappedGGUFModel::from_path(gguf_path)?;
+    let gguf = OwnedQuantizedModel::from_mapped(&mapped)?;
+    println!(
+        "  GGUF token_embedding len: {}",
+        gguf.token_embedding().len()
+    );
+
+    if apr.token_embedding.len() != gguf.token_embedding().len() {
+        println!(
+            "\n❌ EMBEDDING TABLE SIZES DIFFER — APR={}, GGUF={}",
+            apr.token_embedding.len(),
+            gguf.token_embedding().len()
+        );
+        return Ok(());
+    }
+
+    // Whole-embedding-table stats first
+    println!("\n=== Whole embedding table ===");
+    stats("APR token_embedding", &apr.token_embedding);
+    stats("GGUF token_embedding", gguf.token_embedding());
+
+    // Per-prompt-token: extract rows and compare
+    println!("\n=== Per-token rows for prompt ===");
+    let mut max_global_diff = 0.0f32;
+    let mut max_global_token = 0u32;
+    let mut max_global_idx = 0usize;
+    let mut total_sum_sq = 0.0f64;
+    let mut total_n = 0usize;
+    for (pos, &token_id) in PROMPT_TOKENS.iter().enumerate() {
+        let start = (token_id as usize) * hidden_dim;
+        let end = start + hidden_dim;
+        let apr_row = &apr.token_embedding[start..end];
+        let gguf_row = &gguf.token_embedding()[start..end];
+
+        println!(
+            "\nToken pos={} id={} (offset {}..{}):",
+            pos, token_id, start, end
+        );
+        stats(&format!("  APR row[{}]", token_id), apr_row);
+        stats(&format!("  GGUF row[{}]", token_id), gguf_row);
+
+        let mut max_diff = 0.0f32;
+        let mut max_diff_idx = 0usize;
+        let mut sum_sq = 0.0f64;
+        for i in 0..hidden_dim {
+            let d = (apr_row[i] - gguf_row[i]).abs();
+            if d > max_diff {
+                max_diff = d;
+                max_diff_idx = i;
+            }
+            sum_sq += (d as f64) * (d as f64);
+        }
+        let rms = (sum_sq / (hidden_dim as f64)).sqrt() as f32;
+        println!(
+            "    diff: max={:.6} at idx={} (APR={:.6} vs GGUF={:.6}) RMS={:.6}",
+            max_diff, max_diff_idx, apr_row[max_diff_idx], gguf_row[max_diff_idx], rms
+        );
+        if max_diff > max_global_diff {
+            max_global_diff = max_diff;
+            max_global_token = token_id;
+            max_global_idx = max_diff_idx;
+        }
+        total_sum_sq += sum_sq;
+        total_n += hidden_dim;
+    }
+
+    let total_rms = (total_sum_sq / (total_n as f64)).sqrt() as f32;
+
+    println!(
+        "\n=== Aggregate over {} prompt tokens ===",
+        PROMPT_TOKENS.len()
+    );
+    println!("  max |diff| globally: {:.6}", max_global_diff);
+    println!(
+        "  worst element: token={} idx={} APR={:.6} GGUF={:.6}",
+        max_global_token,
+        max_global_idx,
+        apr.token_embedding[(max_global_token as usize) * hidden_dim + max_global_idx],
+        gguf.token_embedding()[(max_global_token as usize) * hidden_dim + max_global_idx]
+    );
+    println!("  total RMS over all prompt rows: {:.6}", total_rms);
+
+    println!("\n=== VERDICT ===");
+    if max_global_diff < 1e-6 {
+        println!("  ✓ APR ≡ GGUF byte-for-byte across all prompt rows.");
+        println!("  → SHIP-007 is NOT in embedding lookup.");
+        println!("  → §37 candidate REFUTED. Move bisection downstream (RMSNorm / matmul).");
+    } else if max_global_diff < 1e-3 {
+        println!("  ~ APR ≈ GGUF (within Q4K rounding, max_diff < 1e-3).");
+        println!("  → Embedding within tolerance; SHIP-007 likely accumulates downstream.");
+    } else if max_global_diff < 1e-1 {
+        println!("  ⚠ APR != GGUF non-trivially (max_diff in [1e-3, 1e-1]).");
+        println!("  → Likely an embedding dequantization or lookup defect.");
+    } else {
+        println!("  ❌ APR vs GGUF DIFFERS SUBSTANTIALLY (max_diff > 0.1).");
+        println!("  → SHIP-007 root cause IS in embedding pipeline.");
+        println!("  → Investigate: load_token_embedding (APR) vs OwnedQuantizedModel construction (GGUF).");
+    }
+
+    // Range scan: also check whether APR has outlier ROWS (rare token IDs with crazy values)
+    println!("\n=== Outlier-row scan (full vocabulary) ===");
+    let mut max_apr_row_max = (0.0f32, 0u32);
+    let mut max_gguf_row_max = (0.0f32, 0u32);
+    for tok in 0..vocab_size {
+        let start = tok * hidden_dim;
+        let end = start + hidden_dim;
+        let apr_row = &apr.token_embedding[start..end];
+        let gguf_row = &gguf.token_embedding()[start..end];
+        let apr_max = apr_row.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+        let gguf_max = gguf_row.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+        if apr_max > max_apr_row_max.0 {
+            max_apr_row_max = (apr_max, tok as u32);
+        }
+        if gguf_max > max_gguf_row_max.0 {
+            max_gguf_row_max = (gguf_max, tok as u32);
+        }
+    }
+    println!(
+        "  APR  max-row max-value: {:.6} at token id {}",
+        max_apr_row_max.0, max_apr_row_max.1
+    );
+    println!(
+        "  GGUF max-row max-value: {:.6} at token id {}",
+        max_gguf_row_max.0, max_gguf_row_max.1
+    );
+
+    Ok(())
+}

--- a/crates/aprender-serve/examples/diag_compare_rmsnorm_layer0.rs
+++ b/crates/aprender-serve/examples/diag_compare_rmsnorm_layer0.rs
@@ -1,0 +1,225 @@
+//! §38 byte-level comparison: APR vs GGUF rms_norm for SHIP-007 layer-0 attn_norm.
+//!
+//! `apr trace --payload` reports layer-0 attn_norm:
+//!   APR : mean=-0.0001 std=0.2213
+//!   GGUF: mean=-0.0014 std=0.2421
+//!
+//! Embedding is byte-identical (§37 verified).
+//! Same input → different output stats. RMSNorm impls differ:
+//!   APR  helpers.rs:348 — scalar sum + x/rms (division per element)
+//!   GGUF ops.rs:39      — SIMD sum_of_squares + x*inv_rms (multiply by reciprocal)
+//!
+//! These are algebraically equivalent but produce different FP results due to:
+//!   (1) scalar vs SIMD sum reduction order
+//!   (2) division vs reciprocal multiplication
+//!
+//! This script applies BOTH norms to the SAME 7 prompt tokens' embedding rows
+//! using the SAME attn_norm_weight (which we'll verify is byte-identical),
+//! then compares element-wise.
+
+use realizar::apr_transformer::AprTransformer;
+use realizar::gguf::{ops, MappedGGUFModel, OwnedQuantizedModel};
+
+const PROMPT_TOKENS: &[u32] = &[3838, 374, 220, 17, 10, 17, 30];
+
+// APR's rms_norm — copied from crates/aprender-serve/src/apr_transformer/helpers.rs:348
+// to avoid pub(crate) access issue. EXACT same logic.
+fn apr_rms_norm(input: &[f32], weight: &[f32], hidden_dim: usize, eps: f32) -> Vec<f32> {
+    let seq_len = input.len() / hidden_dim;
+    let mut output = Vec::with_capacity(input.len());
+    for s in 0..seq_len {
+        let start = s * hidden_dim;
+        let slice = &input[start..start + hidden_dim];
+        let sum_sq: f32 = slice.iter().map(|x| x * x).sum();
+        let rms = (sum_sq / hidden_dim as f32 + eps).sqrt();
+        for (i, &x) in slice.iter().enumerate() {
+            let normalized = x / rms;
+            let scaled = normalized * weight[i];
+            output.push(scaled);
+        }
+    }
+    output
+}
+
+fn stats(label: &str, data: &[f32]) -> (f32, f32, f32, f32) {
+    let n = data.len() as f32;
+    let mean = data.iter().sum::<f32>() / n;
+    let var = data.iter().map(|x| (x - mean).powi(2)).sum::<f32>() / n;
+    let std = var.sqrt();
+    let min = data.iter().cloned().fold(f32::INFINITY, f32::min);
+    let max = data.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+    println!(
+        "  {:34} n={:5} mean={:>10.6} std={:>10.6} min={:>10.4} max={:>10.4}",
+        label,
+        data.len(),
+        mean,
+        std,
+        min,
+        max
+    );
+    (mean, std, min, max)
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let apr_path = "/mnt/nvme-raid0/models/ship-two-001/qwen2.5-coder-7b-instruct-q4k.apr";
+    let gguf_path = "/mnt/nvme-raid0/models/ship-two-001/qwen2.5-coder-7b-instruct-q4k.gguf";
+
+    println!("=== §38 APR vs GGUF rms_norm comparison (layer-0 attn_norm) ===");
+    println!("Prompt tokens: {:?}", PROMPT_TOKENS);
+    println!();
+
+    println!("Loading APR: {}", apr_path);
+    let apr = AprTransformer::from_apr_file(apr_path)?;
+    let cfg = apr.config();
+    let hidden_dim = cfg.hidden_dim;
+    let rms_eps = cfg.eps;
+    println!(
+        "  hidden_dim={} rms_norm_eps={} attn_norm_weight len={}",
+        hidden_dim,
+        rms_eps,
+        apr.layers[0].attn_norm_weight.len()
+    );
+
+    println!("\nLoading GGUF: {}", gguf_path);
+    let mapped = MappedGGUFModel::from_path(gguf_path)?;
+    let gguf = OwnedQuantizedModel::from_mapped(&mapped)?;
+    let gguf_eps = gguf.config().eps;
+    println!(
+        "  GGUF rms_norm_eps={} attn_norm_weight len={}",
+        gguf_eps,
+        gguf.layers()[0].attn_norm_weight.len()
+    );
+
+    // Step 1: Verify attn_norm_weight is byte-identical APR vs GGUF
+    println!("\n=== Step 1: attn_norm_weight byte-compare ===");
+    let apr_w = &apr.layers[0].attn_norm_weight;
+    let gguf_w = &gguf.layers()[0].attn_norm_weight;
+    if apr_w.len() != gguf_w.len() {
+        println!(
+            "  ❌ Length mismatch: APR={} GGUF={}",
+            apr_w.len(),
+            gguf_w.len()
+        );
+        return Ok(());
+    }
+    let mut max_w_diff = 0.0f32;
+    for i in 0..apr_w.len() {
+        let d = (apr_w[i] - gguf_w[i]).abs();
+        if d > max_w_diff {
+            max_w_diff = d;
+        }
+    }
+    stats("APR  attn_norm_weight L0", apr_w);
+    stats("GGUF attn_norm_weight L0", gguf_w);
+    println!("  max |attn_norm_weight diff|: {:.6e}", max_w_diff);
+    if max_w_diff > 0.0 {
+        println!("  ⚠ Weights NOT byte-identical — bug may be in converter, not norm impl.");
+    } else {
+        println!("  ✓ Weights byte-identical.");
+    }
+
+    // Step 2: Verify rms_norm_eps is identical
+    println!("\n=== Step 2: rms_norm_eps compare ===");
+    println!("  APR  eps: {:.10e}", rms_eps);
+    println!("  GGUF eps: {:.10e}", gguf_eps);
+    if (rms_eps - gguf_eps).abs() > f32::EPSILON {
+        println!("  ⚠ eps differs!");
+    } else {
+        println!("  ✓ eps identical.");
+    }
+
+    // Step 3: Build the prompt embedding (concat of 7 token rows = 25088 f32 values)
+    println!("\n=== Step 3: Build prompt embedding from 7 tokens ===");
+    let mut prompt_embed: Vec<f32> = Vec::with_capacity(PROMPT_TOKENS.len() * hidden_dim);
+    for &tok in PROMPT_TOKENS {
+        let start = (tok as usize) * hidden_dim;
+        let end = start + hidden_dim;
+        prompt_embed.extend_from_slice(&apr.token_embedding[start..end]);
+    }
+    stats("prompt_embed (input)", &prompt_embed);
+
+    // Step 4: Apply APR's rms_norm
+    println!("\n=== Step 4: Apply APR's rms_norm (helpers.rs:348) ===");
+    let apr_out = apr_rms_norm(&prompt_embed, apr_w, hidden_dim, rms_eps);
+    stats("APR  rms_norm output", &apr_out);
+
+    // Step 5: Apply GGUF's rms_norm (ops.rs)
+    println!("\n=== Step 5: Apply GGUF's rms_norm (ops.rs:39) ===");
+    let gguf_out = ops::rms_norm(&prompt_embed, gguf_w, gguf_eps);
+    stats("GGUF rms_norm output", &gguf_out);
+
+    // Step 6: Element-wise compare
+    println!("\n=== Step 6: Element-wise compare ===");
+    if apr_out.len() != gguf_out.len() {
+        println!("  ❌ Output length mismatch");
+        return Ok(());
+    }
+    let mut max_diff = 0.0f32;
+    let mut max_diff_idx = 0usize;
+    let mut sum_sq_diff = 0.0f64;
+    for i in 0..apr_out.len() {
+        let d = (apr_out[i] - gguf_out[i]).abs();
+        if d > max_diff {
+            max_diff = d;
+            max_diff_idx = i;
+        }
+        sum_sq_diff += (d as f64) * (d as f64);
+    }
+    let rms_diff = (sum_sq_diff / (apr_out.len() as f64)).sqrt() as f32;
+    let max_apr_abs = apr_out.iter().fold(0.0f32, |a, b| a.max(b.abs()));
+    let rel_max = max_diff / max_apr_abs;
+
+    println!("  max |diff|: {:.6e} at idx {}", max_diff, max_diff_idx);
+    println!("    APR[{}]  = {:.6}", max_diff_idx, apr_out[max_diff_idx]);
+    println!("    GGUF[{}] = {:.6}", max_diff_idx, gguf_out[max_diff_idx]);
+    println!("  RMS |diff|: {:.6e}", rms_diff);
+    println!("  max |APR|: {:.6}", max_apr_abs);
+    println!("  relative max: {:.6e} = {:.4}%", rel_max, 100.0 * rel_max);
+
+    // Per-token row stats: see if the 7 rows show consistent behavior
+    println!("\n=== Per-token row std comparison ===");
+    println!("  pos | tok  | APR std    | GGUF std   | ratio (APR/GGUF)");
+    for (pos, &tok) in PROMPT_TOKENS.iter().enumerate() {
+        let start = pos * hidden_dim;
+        let end = start + hidden_dim;
+        let apr_row = &apr_out[start..end];
+        let gguf_row = &gguf_out[start..end];
+        let apr_mean: f32 = apr_row.iter().sum::<f32>() / hidden_dim as f32;
+        let apr_std: f32 = (apr_row.iter().map(|x| (x - apr_mean).powi(2)).sum::<f32>()
+            / hidden_dim as f32)
+            .sqrt();
+        let gguf_mean: f32 = gguf_row.iter().sum::<f32>() / hidden_dim as f32;
+        let gguf_std: f32 = (gguf_row
+            .iter()
+            .map(|x| (x - gguf_mean).powi(2))
+            .sum::<f32>()
+            / hidden_dim as f32)
+            .sqrt();
+        let ratio = if gguf_std.abs() > f32::EPSILON {
+            apr_std / gguf_std
+        } else {
+            0.0
+        };
+        println!(
+            "  {:3} | {:4} | {:>10.6} | {:>10.6} | {:.4}",
+            pos, tok, apr_std, gguf_std, ratio
+        );
+    }
+
+    println!("\n=== VERDICT ===");
+    if max_diff < 1e-7 {
+        println!("  ✓ APR ≡ GGUF rms_norm output byte-for-byte.");
+        println!("  → §38 candidate REFUTED. SHIP-007 NOT in attn_norm.");
+    } else if max_diff < 1e-4 {
+        println!("  ~ APR ≈ GGUF (within FP rounding, max < 1e-4).");
+        println!("  → Norm precision drift IS present but small. Could compound at layer 3.");
+    } else if max_diff < 1e-2 {
+        println!("  ⚠ APR != GGUF noticeably (max in [1e-4, 1e-2]).");
+        println!("  → §38 candidate CONFIRMED — rms_norm precision is meaningful.");
+    } else {
+        println!("  ❌ APR vs GGUF DIFFERS SUBSTANTIALLY (max > 1e-2).");
+        println!("  → §38 candidate STRONGLY CONFIRMED. SHIP-007 root cause IS in rms_norm.");
+    }
+
+    Ok(())
+}

--- a/docs/specifications/aprender-train/ship-two-models-spec.md
+++ b/docs/specifications/aprender-train/ship-two-models-spec.md
@@ -1,7 +1,9 @@
 # Specification: Ship Two Models — Sovereign AI Stack Proof
 
 **Document ID:** SPEC-SHIP-TWO-001
-**Version:** 2.81.0
+**Version:** 2.82.0
+**Atomic next action (v2.82.0):** **§37 — TRACE-CAPTURE-POINT MISMATCH discovered between APR and GGUF `forward_traced`** (see new §37 below). The 18.23× layer-3 ffn_swigl ratio cited in §27 is partly artifact: APR's `forward_traced` (inference.rs:30) computes stats over ALL 7 prompt tokens (25088 elements), while GGUF's `forward_traced` (forward/traced.rs:77-78) prefills 6 tokens silently and captures stats only on the LAST token (3584 elements). Live verification: standalone `ops::rms_norm(prompt_embed_7tok, attn_norm_w0)` gives byte-identical output to APR's `helpers::rms_norm` (max diff 1e-5); per-token-row std at pos=6 (token=30) is 0.242085 — matches `apr trace --payload <gguf>` reported attn_norm std=0.2421 EXACTLY. The all-7 std of the same APR rms_norm output is 0.2213 — matches `apr trace --payload <apr>` exactly. **The "0.91× attn_norm ratio" is sample-size mismatch, not a real divergence.** Embedding §37 confirms byte-identical APR ≡ GGUF token tables (max |diff|=0 across 545M elements). However, `apr run` STILL produces wrong output ("ampiezza = 0.5") vs GGUF's "2+2 is 4." — so SHIP-007 is REAL but the std-only trace bisection is misleading. Next-step: extend GGUF `forward_traced` to capture all-tokens stats (parity with APR semantics) OR extend APR's trace to also report last-token stats (parity with GGUF semantics) so std comparisons are apples-to-apples. Spec v2.81.0 → **v2.82.0**. Coverage scoreboard unchanged (15+33).
+
 **Atomic next action (v2.81.0):** **§36 — plain-language status of the two-model goal** (see new §36 below). Each of the two models is blocked by a single concrete problem. **MODEL-1**: numerical bug at layer 3 of FFN (18× std anomaly; three theories refuted; sub-FFN telemetry just landed via PR #1082 + #1083 in flight). **MODEL-2**: converged at val_loss=9.38 (capacity-limited; spec target 3.0 unreachable from-scratch; needs distillation, but `apr distill` is a stub — contract authored as #1097 awaiting impl). Spec v2.80.0 → **v2.81.0**. No coverage flip; this is a landmark for plain-language readers.
 
 **Atomic next action (v2.80.0):** **§35 — `apr distill` Standard strategy is a STUB; §34.5 distillation track requires authoring contract + extending apr** (see new §35 below). Live execution of `apr distill` on the canonical 7B teacher + §33 student finished in 45s (suspicious for a real epoch over 565.6M tokens). Source at `crates/apr-cli/src/commands/distill.rs:1464` reveals the Standard strategy is "Copy all tensors (student is same architecture, will be trained)" — no gradient training implemented. Per §26.8 stack-tool-extension methodology, the missing feature requires a `contracts/apr-cli-distill-train-v1.yaml` contract + implementation. The §34.5 distillation recommendation is correct in DIRECTION but blocked on implementation. Spec v2.79.0 → **v2.80.0**. Coverage scoreboard unchanged (15+33).
@@ -4459,6 +4461,98 @@ Unchanged from §29 because PR E did not land. Next-session agenda: do the §30.
 Per `feedback_fix_root_cause_never_route_around.md`: the §28 fix would have route-around'd a real bug because the named site (matmul kernel) is not where the divergence originates. The empirical refutation in §30 IS the work that protects the next attempt from shipping a no-op. This refutation is itself a coverage-incrementing artifact (it falsifies a hypothesis), even though no PARTIAL flips to DISCHARGED.
 
 The Toyota Way fix is to bisect upstream, not to flip the kernel call.
+
+## §37. APR vs GGUF `forward_traced` capture-point MISMATCH — std comparisons are not apples-to-apples (2026-04-28)
+
+### 37.1 What ran
+
+Three live diagnostics on the canonical 7B teacher (RTX 4090 / lambda-labs / `apr 0.31.2`):
+
+1. **`apr trace --payload`** on both `qwen2.5-coder-7b-instruct-q4k.apr` and `.gguf` with prompt "What is 2+2?" → tokens [3838, 374, 220, 17, 10, 17, 30].
+2. **`diag_compare_embedding`** (new, this section): byte-compares the full 545M-element token_embedding tables AND each of the 7 prompt-token rows.
+3. **`diag_compare_rmsnorm_layer0`** (new, this section): runs APR's `helpers::rms_norm` and GGUF's `ops::rms_norm` on the same 7-token embedding input + the same byte-identical `attn_norm_weight`.
+
+### 37.2 What it proves
+
+- **Embedding tables byte-identical**: `max |APR - GGUF| = 0.000000` across all 544,997,376 elements; per-prompt-token rows also byte-identical. The `apr trace --payload` "embedding range" mismatch (APR `[-0.4160, +0.5273]` vs GGUF `[-0.1514, +0.1396]`) is a stat-reporter artifact: APR reports min/max over all 7 token rows (token id=220 has the +0.5273 outlier value at position 2); GGUF reports min/max over only the last-token row (id=30, range `[-0.1514, +0.1396]`).
+- **RMSNorm functions agree**: standalone `ops::rms_norm` ≡ `helpers::rms_norm` to within `max |diff| = 1.001e-5` (RMS = 3.8e-7), which is FP rounding noise from the SIMD-vs-scalar reduction-order difference. Per-token-row std ratios are 1.0000 across all 7 tokens.
+- **Trace stats use different sample sizes**: `crates/aprender-serve/src/apr_transformer/inference.rs:30` does `let mut hidden = self.embed(token_ids);` then `ActivationStats::from_slice(&hidden)` — 25,088-element stats. `crates/aprender-serve/src/gguf/inference/forward/traced.rs:77-78` does `for ... in token_ids[..token_ids.len()-1] { forward_single_with_scratch(...) }` (NO stat capture for the first 6 tokens) then traces the last token alone — 3,584-element stats.
+- **Per-token-row last-token std (pos=6, id=30) for APR's standalone rms_norm**: 0.242085. This **matches** `apr trace --payload <gguf>` reported attn_norm std=0.2421 to 4 sig figs. The all-7-tokens std of the same output is 0.221261, which matches `apr trace --payload <apr>` reported attn_norm std=0.2213 to 4 sig figs.
+
+### 37.3 What it does NOT prove
+
+`apr run /...qwen2.5-coder-7b-instruct-q4k.apr --prompt "What is 2+2?" --max-tokens 16 --skip-contract` STILL produces wrong output:
+
+```
+APR  output : "ampiezza = 0.5\ndiametro = 10"           (Italian gibberish)
+GGUF output : " 2+2 is 4."                              (correct)
+```
+
+So **SHIP-007 is REAL** — the bug exists. What §37 proves is that the **18.23× layer-3 ffn_swigl ratio** cited in §27 (and §23, §17, §16) cannot be trusted as a clean bisection signal because:
+
+- APR's std at layer 3 ffn_swigl reflects 7 tokens' worth of activations (25088 elements). If even ONE early token's ffn_swigl is anomalous, the all-7 std is dominated by it.
+- GGUF's std at the same layer reflects only the last token's activations (3584 elements). Earlier tokens never contribute to GGUF's reported std.
+
+Until both traces report the SAME sample (either both all-tokens or both last-token), the std-ratio metric is biased. The actual bug could be anywhere — including the very layer-3 ffn_swigl path the §17/§23/§27 chain has been hunting.
+
+### 37.4 What the diagnostics establish (refuted hypotheses)
+
+| Hypothesis | Status | Evidence |
+|------------|--------|----------|
+| Token embedding tables differ | REFUTED | byte-identical (`diag_compare_embedding`, max diff = 0.000000) |
+| `helpers::rms_norm` ≠ `ops::rms_norm` | REFUTED | max diff = 1e-5 standalone (`diag_compare_rmsnorm_layer0`) |
+| Layer-3 ffn_swigl is the SHIP-007 bug surface | UNDETERMINED | the 18× ratio is partly trace-artifact; may or may not be a real divergence; cannot be confirmed without parity-corrected stats |
+| `attn_norm_weight` byte-identical APR/GGUF | CONFIRMED | max |diff| = 0.000000 (`diag_compare_rmsnorm_layer0`) |
+| `eps` differs APR/GGUF | REFUTED | both = 9.999e-7 |
+
+### 37.5 What unblocks the next falsification step
+
+Two equivalent options to make APR vs GGUF traces apples-to-apples:
+
+**Option A** (smaller change): extend GGUF `forward_traced` to do a forward pass over ALL tokens with stat capture per layer, mirroring APR's all-tokens semantics. Cost: ~50 LOC clone of the existing prefill loop with `LayerActivation` capture per layer per token; the existing `forward_single_with_scratch` is fine, just call it with ActivationStats hooks.
+
+**Option B** (smaller for APR): extend APR's trace to ALSO report last-token stats alongside all-tokens stats. Cost: ~40 LOC: in `inference.rs`, after each `ActivationStats::from_slice(&hidden)`, also emit `ActivationStats::from_slice(&hidden[(seq_len-1)*hidden_dim..])`. Both trace fields would be available.
+
+Either option allows us to compare apples-to-apples and conclusively determine whether the layer-3 ffn_swigl 18× ratio is a real bug or a sampling artifact.
+
+The contract entry `apr-vs-gguf-forward-parity-v1.yaml` (PR #1062 / D, MERGED) lists `verdict_from_per_layer_ffn_swigl_ratio_at_layer_3 ≥ 0.5 ≤ 2.0` as a drift-prevention CI gate. With §37's finding, that gate is **also subject to the trace-capture-point artifact** until parity is restored.
+
+### 37.6 Live evidence preserved
+
+```
+/tmp/ship-007-bisection/
+├── apr-trace.json       (apr trace --payload on .apr file, 13.3 KB)
+├── apr-trace-stderr.log
+├── gguf-trace.txt       (apr trace --payload on .gguf file, 13.7 KB)
+├── gguf-trace-stderr.log
+├── embedding-diag.log   (diag_compare_embedding output)
+└── rmsnorm-diag.log     (diag_compare_rmsnorm_layer0 output)
+```
+
+Two new diagnostic examples merged into `crates/aprender-serve/examples/`:
+- `diag_compare_embedding.rs`
+- `diag_compare_rmsnorm_layer0.rs`
+
+### 37.7 Five-whys narrative
+
+1. *Why isn't MODEL-1 inference correct?* `apr run` produces "ampiezza = 0.5" instead of "2+2 is 4." — divergence somewhere in the forward pass.
+2. *Why has this been hard to localize?* Per-layer std stats (the bisection signal) show 18.23× ratio at layer 3 ffn_swigl, but downstream investigations (§28, §30, §32, sub-FFN PRs) keep finding "byte-identical" results that don't explain a 18× std ratio.
+3. *Why do byte-identical inputs produce different std reports?* Because the trace reporters compute std over **different samples**: APR over all 7 tokens (25088 elements), GGUF over the last token only (3584 elements). The "ratio" was apples-to-oranges.
+4. *Why didn't this come up before?* The PR #1082+#1083 sub-FFN telemetry was scoped narrowly to "make GGUF's trace match APR's API"; it did so structurally (the data fields are populated) but not semantically (the sample is different).
+5. *What's the fix?* Make both reporters use the same sample. After parity, re-run §27's binding criterion (≥10× ratio at layer 3) and let the data tell whether SHIP-007 is layer 3 ffn_swigl or somewhere else.
+
+### 37.8 Coverage scoreboard (unchanged)
+
+| Category | DISCHARGED | PARTIAL | %D |
+|----------|-----------:|--------:|---:|
+| MODEL-1 | 5 | 5 | 50% |
+| MODEL-2 | 3 | 9 | 25% |
+| GPUTRAIN | 7 | 0 | 100% |
+| **Sum** | **15** | **33** | **31%** |
+
+§37 is investigative-falsification work that protects the next attempt from another route-around fix. Per `feedback_fix_root_cause_never_route_around.md`, naming the misleading bisection signal IS the discharge step. The coverage flip waits for the actual SHIP-007 root-cause name.
+
+---
 
 ## §36. Plain-language status — what's left to ship the two models (2026-04-28)
 


### PR DESCRIPTION
## Summary

- **§37 spec amendment**: documents that the 18.23× layer-3 ffn_swigl ratio cited in §27 is partly a sampling artifact (APR captures all-7-token stats, GGUF captures last-token-only stats — different sample sizes for the same comparison)
- **2 new diagnostics** in `crates/aprender-serve/examples/`:
  - `diag_compare_embedding.rs` — byte-compares APR vs GGUF token_embedding (545M elements, all 7 prompt rows). **Result: byte-identical** (max diff = 0.000000)
  - `diag_compare_rmsnorm_layer0.rs` — runs APR's `helpers::rms_norm` and GGUF's `ops::rms_norm` on the same 7-token embedding + same byte-identical `attn_norm_weight`. **Result: max diff = 1e-5** (FP rounding only)
- **The cited 0.91× attn_norm ratio is sample-size mismatch**, not real divergence. Per-token-row std at pos=6 (token=30, the last token) for APR's standalone rms_norm is 0.242085 — matches GGUF's reported 0.2421 EXACTLY. The all-7 std of the same output is 0.221261 — matches APR's reported 0.2213 EXACTLY.

## What §37 does NOT say

SHIP-007 is real. \`apr run --prompt \"What is 2+2?\"\` on the canonical 7B teacher still produces wrong output (\"ampiezza = 0.5\" — Italian gibberish) vs GGUF's correct \"2+2 is 4.\". The bug exists; we just can't trust the std-only bisection signal until both reporters use the same sample.

## Five-whys (§37.7)

1. Why isn't MODEL-1 inference correct? \`apr run\` produces gibberish — divergence somewhere in the forward pass.
2. Why has this been hard to localize? Per-layer std stats show 18.23× ratio at layer 3 ffn_swigl, but downstream investigations (§28, §30, §32, sub-FFN PRs) keep finding "byte-identical" results that don't explain the 18× ratio.
3. Why do byte-identical inputs produce different std reports? Because the trace reporters compute std over **different samples** (APR all-7-tokens, GGUF last-token-only). The "ratio" is apples-to-oranges.
4. Why didn't this come up before? PR #1082+#1083 sub-FFN telemetry was scoped to "make GGUF's trace match APR's API" structurally (data fields are populated), but not semantically (sample is different).
5. What's the fix? Make both reporters use the same sample. Two equivalent options listed in §37.5.

## Plain progress on shipping models

- **MODEL-1**: still blocked on SHIP-007 layer-3 inference bug. This PR establishes that the std-only bisection chain (§17 → §23 → §27 → §28 → §30 → §32) was working with biased data. Next falsification step: extend GGUF's \`forward_traced\` to all-tokens stats OR APR's to also report last-token stats — apples-to-apples bisection follows. Estimated: 50-100 LOC, 1 PR. Discharges 5 MODEL-1 PARTIALs once root cause is named.
- **MODEL-2**: unchanged at val_loss=9.38 (capacity-limited). Distillation contract #1097 PROPOSED, multi-day Rust impl pending.

## Test plan

- [x] \`cargo build --release --example diag_compare_embedding -p aprender-serve\` builds clean
- [x] \`cargo build --release --example diag_compare_rmsnorm_layer0 -p aprender-serve\` builds clean
- [x] Live execution on canonical 7B teacher reproduces stated findings (logs in /tmp/ship-007-bisection/ on lambda-labs)
- [x] \`cargo fmt --all -- --check\` passes
- [x] PMAT pre-commit gates pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)