### PR TITLE
feat(apr-trace): §37 Option B — last_token stats for APR/GGUF sample-size parity

### DIFF
--- a/crates/aprender-serve/src/apr_transformer/inference.rs
+++ b/crates/aprender-serve/src/apr_transformer/inference.rs
@@ -45,6 +45,11 @@ impl AprTransformer {
                 self.config.eps,
             );
             let attn_norm_stats = ActivationStats::from_slice(&normed);
+            // Last-token-only slice for parity with GGUF (§37 / FALSIFY-APR-GGUF-PARITY-007)
+            let seq_len_for_last = token_ids.len();
+            let last_token_attn_norm_stats = ActivationStats::from_slice(
+                &normed[(seq_len_for_last - 1) * hidden_dim..],
+            );
 
             // 2b. QKV projection
             let qkv_dim = layer.qkv_weight.len() / hidden_dim;
@@ -53,6 +58,8 @@ impl AprTransformer {
                 self.add_bias(&mut qkv, bias);
             }
             let qkv_stats = ActivationStats::from_slice(&qkv);
+            let last_token_qkv_stats =
+                ActivationStats::from_slice(&qkv[(seq_len_for_last - 1) * qkv_dim..]);
 
             // 2c. Attention computation (simplified for trace - same logic as forward)
             let seq_len = token_ids.len();
@@ -127,6 +134,9 @@ impl AprTransformer {
                 self.add_bias(&mut attn_output, bias);
             }
             let attn_out_stats = ActivationStats::from_slice(&attn_output);
+            let last_token_attn_out_stats = ActivationStats::from_slice(
+                &attn_output[(seq_len_for_last - 1) * hidden_dim..],
+            );
 
             // Residual connection
             for i in 0..hidden.len() {
@@ -146,6 +156,9 @@ impl AprTransformer {
                 hidden.clone()
             };
             let ffn_norm_stats = ActivationStats::from_slice(&ffn_input);
+            let last_token_ffn_norm_stats = ActivationStats::from_slice(
+                &ffn_input[(seq_len_for_last - 1) * hidden_dim..],
+            );
 
             // 2g. FFN - check if gated MLP (SwiGLU) by presence of gate weight
             // Per contracts/trace-ffn-sub-block-v1.yaml: capture sub-FFN
@@ -155,6 +168,10 @@ impl AprTransformer {
             let mut ffn_up_stats = ActivationStats::default();
             let mut ffn_silu_gate_stats = ActivationStats::default();
             let mut ffn_swiglu_inner_stats = ActivationStats::default();
+            let mut last_token_ffn_gate_stats = ActivationStats::default();
+            let mut last_token_ffn_up_stats = ActivationStats::default();
+            let mut last_token_ffn_silu_gate_stats = ActivationStats::default();
+            let mut last_token_ffn_swiglu_inner_stats = ActivationStats::default();
 
             let ffn_output = if let Some(ref gate_weight) = layer.ffn_gate_weight {
                 let gate = self.matmul(&ffn_input, gate_weight, hidden_dim, intermediate_dim);
@@ -167,6 +184,12 @@ impl AprTransformer {
 
                 ffn_gate_stats = ActivationStats::from_slice(&gate);
                 ffn_up_stats = ActivationStats::from_slice(&up);
+                last_token_ffn_gate_stats = ActivationStats::from_slice(
+                    &gate[(seq_len_for_last - 1) * intermediate_dim..],
+                );
+                last_token_ffn_up_stats = ActivationStats::from_slice(
+                    &up[(seq_len_for_last - 1) * intermediate_dim..],
+                );
 
                 let mut silu_gate = Vec::with_capacity(gate.len());
                 let mut ffn_hidden = Vec::with_capacity(gate.len());
@@ -178,6 +201,12 @@ impl AprTransformer {
 
                 ffn_silu_gate_stats = ActivationStats::from_slice(&silu_gate);
                 ffn_swiglu_inner_stats = ActivationStats::from_slice(&ffn_hidden);
+                last_token_ffn_silu_gate_stats = ActivationStats::from_slice(
+                    &silu_gate[(seq_len_for_last - 1) * intermediate_dim..],
+                );
+                last_token_ffn_swiglu_inner_stats = ActivationStats::from_slice(
+                    &ffn_hidden[(seq_len_for_last - 1) * intermediate_dim..],
+                );
 
                 let mut out = self.matmul(
                     &ffn_hidden,
@@ -203,6 +232,9 @@ impl AprTransformer {
                     self.add_bias(&mut ffn_hidden, bias);
                 }
                 ffn_up_stats = ActivationStats::from_slice(&ffn_hidden);
+                last_token_ffn_up_stats = ActivationStats::from_slice(
+                    &ffn_hidden[(seq_len_for_last - 1) * intermediate_dim..],
+                );
                 for h in &mut ffn_hidden {
                     let gelu_approx =
                         0.5 * *h * (1.0 + (0.797_884_6 * (*h + 0.044_715 * *h * *h * *h)).tanh());
@@ -220,12 +252,34 @@ impl AprTransformer {
                 out
             };
             let ffn_out_stats = ActivationStats::from_slice(&ffn_output);
+            let last_token_ffn_out_stats = ActivationStats::from_slice(
+                &ffn_output[(seq_len_for_last - 1) * hidden_dim..],
+            );
 
             // Residual connection
             for i in 0..hidden.len() {
                 hidden[i] += ffn_output[i];
             }
             let output_stats = ActivationStats::from_slice(&hidden);
+            let last_token_output_stats = ActivationStats::from_slice(
+                &hidden[(seq_len_for_last - 1) * hidden_dim..],
+            );
+
+            // §37 / FALSIFY-APR-GGUF-PARITY-007: emit last-token-only stats for
+            // sample-size parity with GGUF's forward_traced (which traces only
+            // the last token). When seq_len == 1, last_token == all-tokens.
+            let last_token = Some(crate::apr_transformer::LastTokenStats {
+                attn_norm_stats: last_token_attn_norm_stats,
+                qkv_stats: last_token_qkv_stats,
+                attn_out_stats: last_token_attn_out_stats,
+                ffn_norm_stats: last_token_ffn_norm_stats,
+                ffn_gate_stats: last_token_ffn_gate_stats,
+                ffn_up_stats: last_token_ffn_up_stats,
+                ffn_silu_gate_stats: last_token_ffn_silu_gate_stats,
+                ffn_swiglu_inner_stats: last_token_ffn_swiglu_inner_stats,
+                ffn_out_stats: last_token_ffn_out_stats,
+                output_stats: last_token_output_stats,
+            });
 
             layer_activations.push(LayerActivation {
                 layer_idx,
@@ -239,6 +293,7 @@ impl AprTransformer {
                 ffn_swiglu_inner_stats,
                 ffn_out_stats,
                 output_stats,
+                last_token,
             });
         }
 

--- a/crates/aprender-serve/src/apr_transformer/mod.rs
+++ b/crates/aprender-serve/src/apr_transformer/mod.rs
@@ -262,6 +262,43 @@ impl ActivationStats {
     }
 }
 
+/// Last-token-only activation slice for sample-size parity with GGUF traces.
+///
+/// Per `contracts/apr-vs-gguf-forward-parity-v1.yaml` v1.1.0 +
+/// SPEC-SHIP-TWO-001 §37: APR's `forward_traced` historically emits stats
+/// over ALL prompt tokens (seq_len * dim elements), while GGUF's
+/// `forward_traced` emits stats over only the LAST token (1 * dim
+/// elements). FALSIFY-APR-GGUF-PARITY-007 enforces count parity per layer
+/// per stat slot — a precondition for ratio-gate credibility (-001/-002/-003).
+///
+/// Each field mirrors the corresponding `LayerActivation::*_stats` field but
+/// is computed only over the last token's slice, e.g.
+/// `&hidden[(seq_len - 1) * hidden_dim..]`. When `seq_len == 1`, these stats
+/// are identical to the all-tokens stats (single-element optimization).
+#[derive(Debug, Clone, Default)]
+pub struct LastTokenStats {
+    /// attn_norm output, last-token only
+    pub attn_norm_stats: ActivationStats,
+    /// QKV projection output, last-token only
+    pub qkv_stats: ActivationStats,
+    /// Attention output, last-token only
+    pub attn_out_stats: ActivationStats,
+    /// FFN norm output, last-token only
+    pub ffn_norm_stats: ActivationStats,
+    /// FFN gate matmul output, last-token only
+    pub ffn_gate_stats: ActivationStats,
+    /// FFN up matmul output, last-token only
+    pub ffn_up_stats: ActivationStats,
+    /// silu(gate), last-token only
+    pub ffn_silu_gate_stats: ActivationStats,
+    /// silu(gate) * up, last-token only
+    pub ffn_swiglu_inner_stats: ActivationStats,
+    /// FFN output (post-down-proj), last-token only
+    pub ffn_out_stats: ActivationStats,
+    /// Layer output (post-residual), last-token only
+    pub output_stats: ActivationStats,
+}
+
 /// Per-layer activation trace
 ///
 /// Sub-FFN telemetry fields (`ffn_gate_stats`, `ffn_up_stats`,
@@ -269,6 +306,11 @@ impl ActivationStats {
 /// `contracts/trace-ffn-sub-block-v1.yaml` v1.0.0 to support sub-block
 /// bisection within a transformer block's FFN. Load-bearing for the
 /// SHIP-007 fix per ship-two-models-spec.md §15.5 + §17.4.
+///
+/// `last_token` field added per `contracts/apr-vs-gguf-forward-parity-v1.yaml`
+/// v1.1.0 + SPEC-SHIP-TWO-001 §37: enables apples-to-apples comparison with
+/// GGUF's last-token-only stats, satisfying FALSIFY-APR-GGUF-PARITY-007
+/// count-parity precondition.
 #[derive(Debug, Clone)]
 pub struct LayerActivation {
     /// Layer index (0-indexed)
@@ -297,6 +339,11 @@ pub struct LayerActivation {
     pub ffn_out_stats: ActivationStats,
     /// Statistics after residual connection (layer output)
     pub output_stats: ActivationStats,
+    /// Last-token-only stats for sample-size parity with GGUF
+    /// (FALSIFY-APR-GGUF-PARITY-007). `None` when reporter does not populate
+    /// (e.g., backwards-compat callers). When populated, count == hidden_dim
+    /// or intermediate_dim per stat slot. Mirrors GGUF reporter semantics.
+    pub last_token: Option<LastTokenStats>,
 }
 
 /// Forward pass trace with layer-by-layer activations

--- a/crates/aprender-serve/src/apr_transformer/tests/apr_02.rs
+++ b/crates/aprender-serve/src/apr_transformer/tests/apr_02.rs
@@ -79,6 +79,7 @@ fn test_forward_trace_multiple_layers() {
             ffn_swiglu_inner_stats: ActivationStats::default(),
             ffn_out_stats: stats.clone(),
             output_stats: stats.clone(),
+            last_token: None,
         })
         .collect();
 
@@ -113,9 +114,72 @@ fn test_layer_activation_with_different_stats() {
         ffn_swiglu_inner_stats: ActivationStats::default(),
         ffn_out_stats: ffn_stats.clone(),
         output_stats: ffn_stats,
+        last_token: None,
     };
 
     assert!((layer.attn_norm_stats.mean - 2.0).abs() < 0.01);
     assert!((layer.ffn_norm_stats.mean - 20.0).abs() < 0.01);
     assert!((layer.output_stats.mean - 20.0).abs() < 0.01);
+}
+
+/// FALSIFY-APR-GGUF-PARITY-007: LayerActivation.last_token is Option-typed
+/// and defaults to None for backwards-compat callers (e.g., GPU forward
+/// pass not yet populating). This test pins the schema invariant.
+#[test]
+fn test_layer_activation_last_token_optional_default_none() {
+    let stats = ActivationStats::from_slice(&[1.0, 2.0, 3.0]);
+    let layer = LayerActivation {
+        layer_idx: 0,
+        attn_norm_stats: stats.clone(),
+        qkv_stats: stats.clone(),
+        attn_out_stats: stats.clone(),
+        ffn_norm_stats: stats.clone(),
+        ffn_gate_stats: ActivationStats::default(),
+        ffn_up_stats: ActivationStats::default(),
+        ffn_silu_gate_stats: ActivationStats::default(),
+        ffn_swiglu_inner_stats: ActivationStats::default(),
+        ffn_out_stats: stats.clone(),
+        output_stats: stats,
+        last_token: None,
+    };
+    assert!(layer.last_token.is_none(), "default should be None for backwards-compat");
+}
+
+/// FALSIFY-APR-GGUF-PARITY-007: When last_token IS populated, all 10 stat
+/// slots are present and have count == hidden_dim or intermediate_dim
+/// (matching GGUF's last-token-only sample). This test pins the data shape.
+#[test]
+fn test_layer_activation_last_token_populated_count_parity() {
+    use crate::apr_transformer::LastTokenStats;
+    let hidden_dim = 64;
+    let intermediate_dim = 256;
+    // Simulate last-token slices (single token's worth of values)
+    let last_hidden = vec![0.5f32; hidden_dim];
+    let last_intermediate = vec![0.7f32; intermediate_dim];
+
+    let last_token = LastTokenStats {
+        attn_norm_stats: ActivationStats::from_slice(&last_hidden),
+        qkv_stats: ActivationStats::from_slice(&last_hidden),
+        attn_out_stats: ActivationStats::from_slice(&last_hidden),
+        ffn_norm_stats: ActivationStats::from_slice(&last_hidden),
+        ffn_gate_stats: ActivationStats::from_slice(&last_intermediate),
+        ffn_up_stats: ActivationStats::from_slice(&last_intermediate),
+        ffn_silu_gate_stats: ActivationStats::from_slice(&last_intermediate),
+        ffn_swiglu_inner_stats: ActivationStats::from_slice(&last_intermediate),
+        ffn_out_stats: ActivationStats::from_slice(&last_hidden),
+        output_stats: ActivationStats::from_slice(&last_hidden),
+    };
+
+    // Hidden-dim stat slots: count == hidden_dim
+    assert_eq!(last_token.attn_norm_stats.count, hidden_dim);
+    assert_eq!(last_token.qkv_stats.count, hidden_dim);
+    assert_eq!(last_token.attn_out_stats.count, hidden_dim);
+    assert_eq!(last_token.ffn_norm_stats.count, hidden_dim);
+    assert_eq!(last_token.ffn_out_stats.count, hidden_dim);
+    assert_eq!(last_token.output_stats.count, hidden_dim);
+    // Intermediate-dim sub-FFN stat slots: count == intermediate_dim
+    assert_eq!(last_token.ffn_gate_stats.count, intermediate_dim);
+    assert_eq!(last_token.ffn_up_stats.count, intermediate_dim);
+    assert_eq!(last_token.ffn_silu_gate_stats.count, intermediate_dim);
+    assert_eq!(last_token.ffn_swiglu_inner_stats.count, intermediate_dim);
 }

--- a/crates/aprender-serve/src/apr_transformer/tests/tests_07.rs
+++ b/crates/aprender-serve/src/apr_transformer/tests/tests_07.rs
@@ -337,6 +337,7 @@ fn test_layer_activation_construction() {
         ffn_swiglu_inner_stats: ActivationStats::default(),
         ffn_out_stats: stats.clone(),
         output_stats: stats,
+        last_token: None,
     };
     assert_eq!(layer_act.layer_idx, 0);
     assert_eq!(layer_act.attn_norm_stats.count, 3);
@@ -358,6 +359,7 @@ fn test_layer_activation_debug() {
         ffn_swiglu_inner_stats: ActivationStats::default(),
         ffn_out_stats: stats.clone(),
         output_stats: stats,
+        last_token: None,
     };
     let debug_str = format!("{:?}", layer_act);
     assert!(debug_str.contains("LayerActivation"));
@@ -378,6 +380,7 @@ fn test_layer_activation_clone() {
         ffn_swiglu_inner_stats: ActivationStats::default(),
         ffn_out_stats: stats.clone(),
         output_stats: stats,
+        last_token: None,
     };
     let cloned = layer_act.clone();
     assert_eq!(cloned.layer_idx, 3);
@@ -418,6 +421,7 @@ fn test_forward_trace_with_layers() {
         ffn_swiglu_inner_stats: ActivationStats::default(),
         ffn_out_stats: stats.clone(),
         output_stats: stats.clone(),
+        last_token: None,
     };
     let trace = ForwardTrace {
         input_tokens: vec![1],

--- a/crates/aprender-serve/src/gguf/inference/forward/traced.rs
+++ b/crates/aprender-serve/src/gguf/inference/forward/traced.rs
@@ -212,6 +212,24 @@ impl OwnedQuantizedModel {
             // Construct LayerActivation. Order matches APR's
             // inference.rs:231-242. PR B: all 10 fields populated for
             // SwiGLU; GELU path leaves 4 sub-FFN at default-zero.
+            //
+            // §37 / FALSIFY-APR-GGUF-PARITY-007: GGUF's forward_traced
+            // already captures last-token-only stats (since it traces only
+            // the last token through the inlined orchestrator at line 86+).
+            // Populate `last_token` with a clone so APR.last_token vs GGUF
+            // can be compared apples-to-apples (count parity satisfied).
+            let last_token = Some(crate::apr_transformer::LastTokenStats {
+                attn_norm_stats: attn_norm_stats.clone(),
+                qkv_stats: qkv_stats.clone(),
+                attn_out_stats: attn_out_stats.clone(),
+                ffn_norm_stats: ffn_norm_stats.clone(),
+                ffn_gate_stats: ffn_gate_stats.clone(),
+                ffn_up_stats: ffn_up_stats.clone(),
+                ffn_silu_gate_stats: ffn_silu_gate_stats.clone(),
+                ffn_swiglu_inner_stats: ffn_swiglu_inner_stats.clone(),
+                ffn_out_stats: ffn_out_stats.clone(),
+                output_stats: output_stats.clone(),
+            });
             layer_activations.push(LayerActivation {
                 layer_idx,
                 attn_norm_stats,
@@ -224,6 +242,7 @@ impl OwnedQuantizedModel {
                 ffn_swiglu_inner_stats,
                 ffn_out_stats,
                 output_stats,
+                last_token,
             });
         }
 

--- a/crates/aprender-serve/src/gpu/scheduler/forward_from_model.rs
+++ b/crates/aprender-serve/src/gpu/scheduler/forward_from_model.rs
@@ -365,6 +365,9 @@ impl GpuModel {
                 ffn_swiglu_inner_stats: crate::apr_transformer::ActivationStats::default(),
                 ffn_out_stats,
                 output_stats,
+                // GPU forward_traced does not yet emit last-token-only stats
+                // (FALSIFY-APR-GGUF-PARITY-007 follow-up). None until populated.
+                last_token: None,
             },
         ))
     }

--- a/crates/aprender-serve/src/gpu/scheduler/gpu_forward_pass.rs
+++ b/crates/aprender-serve/src/gpu/scheduler/gpu_forward_pass.rs
@@ -362,6 +362,9 @@ impl GpuModel {
                 ffn_swiglu_inner_stats: crate::apr_transformer::ActivationStats::default(),
                 ffn_out_stats,
                 output_stats,
+                // GPU forward_traced does not yet emit last-token-only stats
+                // (FALSIFY-APR-GGUF-PARITY-007 follow-up). None until populated.
+                last_token: None,
             },
         ))
     }


### PR DESCRIPTION
## Summary

Implements `Option<LastTokenStats>` field on `LayerActivation` per **SPEC-SHIP-TWO-001 §37.5 Option B** + **FALSIFY-APR-GGUF-PARITY-007** (apr-vs-gguf-forward-parity-v1.yaml v1.1.0, PR #1107).

## What changes

- New `LastTokenStats` struct mirroring 10 `ActivationStats` slots, computed only over the last token's slice (`hidden_dim` or `intermediate_dim` elements per slot).
- `LayerActivation.last_token: Option<LastTokenStats>` field, default `None` for backwards-compat.
- `AprTransformer::forward_traced` populates last_token via `&hidden[(seq_len - 1) * dim..]` slicing for all 10 stat slots (attn_norm / qkv / attn_out / ffn_norm / ffn_gate / ffn_up / ffn_silu_gate / ffn_swiglu_inner / ffn_out / output).
- `OwnedQuantizedModel::forward_traced` populates last_token by cloning existing single-token stats (GGUF already traces only the last token).
- 2 new unit tests pin schema invariants (default-None backwards-compat + populated-count parity).
- 6/6 unit tests PASS.

## Live verification (RTX 4090, canonical 7B teacher, prior iteration)

```
✓ FALSIFY-APR-GGUF-PARITY-007 PASS — count parity restored
APR last_token populated: 28/28
GGUF last_token populated: 28/28

Apples-to-apples ffn_swigl ratios:
  Layer 3 ratio: 1.2154× (Pass)  ← NOT 18.23×!
  ALL 28 layers Pass v1.0.0 ratio gate.
```

The §27 binding criterion (layer-3 18.23× ratio) was ALMOST ENTIRELY a sample-size artifact — see §38 in PR #1108 for full analysis.

## What this does NOT solve

SHIP-007 is still REAL. \`apr run\` produces "ampiezza = 0.5" gibberish vs GGUF's "2+2 is 4.". But the bug is NOT in layer-3 ffn_swigl. With the misleading binding criterion deprioritized, next-iteration agenda is to bisect SHIP-007 in the autoregressive generation path / KV cache / sampling.

## Five-whys (codified in §38.6)

1. Why isn't MODEL-1 inference correct? \`apr run\` gibberish.
2. Why hasn't §17/§23/§27 chain produced a fix? 18× signal misleading.
3. Why was it artifact? APR all-7-tokens vs GGUF last-token-only.
4. Why didn't earlier reviews catch this? PRs #1082+#1083 matched API structurally but not semantically.
5. What's the fix? Make both reporters use same sample (this PR).

## Plain progress on shipping models

- **MODEL-1**: this PR makes the FALSIFY-APR-GGUF-PARITY-007 gate satisfiable. With it satisfied, the v1.0.0 ratio gates -001/-002/-003 become CREDIBLE (or, as §38 shows, trivially Pass once measured correctly). Next step: bisect SHIP-007 in autoregressive path.
- **MODEL-2**: unchanged at val_loss=9.38. Awaiting distill-train impl per #1097.

## Methodology adherence

- Live verification on canonical 7B teacher reproduced stated finding ✓
- Five-whys in §38.6 ✓
- Provable contract referenced (FALSIFY-APR-GGUF-PARITY-007 from v1.1.0) ✓
- Authored in **isolated worktree** to avoid git-environment race condition that prevented commit in prior iteration ✓

## Test plan

- [x] 6/6 unit tests PASS in worktree (\`cargo test -p aprender-serve --lib test_layer_activation\`)
- [x] PMAT pre-commit gates pass
- [x] Stacks cleanly on main (no dependency on PR #1105/#1107/#1108)

🤖 Generated with [Claude Code](https://claude.com/claude-code)