### PR TITLE
feat(realizar): M32c.1 — live MoE inventory probe in qwen3_moe load error

### DIFF
--- a/crates/aprender-serve/src/gguf/transformer.rs
+++ b/crates/aprender-serve/src/gguf/transformer.rs
@@ -130,8 +130,29 @@ impl<'a> QuantizedGGUFTransformer<'a> {
         // Replaces the pre-M32 cryptic "Tensor 'blk.0.ffn_up.weight' not
         // found" surface captured by FALSIFY-QW3-MOE-FORWARD-001 in
         // contracts/qwen3-moe-forward-v1.yaml.
+        //
+        // M32c.1: enrich the error with a live-GGUF MoE tensor inventory so
+        // future M32c.2 (forward dispatch) can confirm the contract namespace
+        // resolves against the actual file. Observably proves the loader
+        // CAN see the contract-declared tensors even before it knows how to
+        // dispatch them.
         let canonical_arch = crate::tensor_names::normalize_architecture(&config.architecture);
         if canonical_arch == "qwen3_moe" {
+            // Probe layer 0 for the 4 contract-declared MoE tensor names.
+            // Layer 0 is sufficient (architecture-uniform across layers per
+            // qwen3moe-shapes-v1).
+            let moe_probe_names: [&str; 4] = [
+                "blk.0.ffn_gate_inp.weight",
+                "blk.0.ffn_gate_exps.weight",
+                "blk.0.ffn_up_exps.weight",
+                "blk.0.ffn_down_exps.weight",
+            ];
+            let moe_present: Vec<&str> = moe_probe_names
+                .iter()
+                .filter(|name| model.tensors.iter().any(|t| t.name == **name))
+                .copied()
+                .collect();
+
             return Err(crate::error::RealizarError::UnsupportedOperation {
                 operation: "moe_forward_pass".to_string(),
                 reason: format!(
@@ -141,11 +162,15 @@ impl<'a> QuantizedGGUFTransformer<'a> {
                      arch. The MoE tensor namespace (blk.{{L}}.ffn_gate_inp/\
                      ffn_gate_exps/ffn_up_exps/ffn_down_exps.weight) is declared by \
                      tensor-names-v1 v1.1.0 but forward-pass dispatch is not yet wired. \
+                     Live MoE inventory at layer 0: {}/{} contract tensors present ({:?}). \
                      Tracked under contract qwen3-moe-forward-v1 (M32 staged plan: \
-                     M32a contract scaffold SHIPPED; M32b arch-aware load \
-                     IN PROGRESS; M32c CPU forward + M32d numerical parity PENDING). \
-                     See contracts/qwen3-moe-forward-v1.yaml.",
-                    config.architecture
+                     M32a contract scaffold SHIPPED; M32b arch-aware load SHIPPED; \
+                     M32c.1 inventory probe SHIPPED; M32c.2 CPU forward + M32d numerical \
+                     parity PENDING). See contracts/qwen3-moe-forward-v1.yaml.",
+                    config.architecture,
+                    moe_present.len(),
+                    moe_probe_names.len(),
+                    moe_present,
                 ),
             });
         }

--- a/crates/aprender-serve/src/gguf/transformer_loader.rs
+++ b/crates/aprender-serve/src/gguf/transformer_loader.rs
@@ -19,18 +19,38 @@ impl GGUFTransformer {
         // pre-M32 cryptic "Tensor 'blk.0.ffn_up.weight' not found" surface
         // captured by FALSIFY-QW3-MOE-FORWARD-001 in
         // contracts/qwen3-moe-forward-v1.yaml.
+        //
+        // M32c.1: enrich error with live MoE tensor inventory for layer 0 —
+        // see transformer.rs (QuantizedGGUFTransformer::from_gguf) for the
+        // sister probe.
         let canonical_arch = crate::tensor_names::normalize_architecture(&config.architecture);
         if canonical_arch == "qwen3_moe" {
+            let moe_probe_names: [&str; 4] = [
+                "blk.0.ffn_gate_inp.weight",
+                "blk.0.ffn_gate_exps.weight",
+                "blk.0.ffn_up_exps.weight",
+                "blk.0.ffn_down_exps.weight",
+            ];
+            let moe_present: Vec<&str> = moe_probe_names
+                .iter()
+                .filter(|name| model.tensors.iter().any(|t| t.name == **name))
+                .copied()
+                .collect();
+
             return Err(crate::error::RealizarError::UnsupportedOperation {
                 operation: "moe_forward_pass".to_string(),
                 reason: format!(
                     "Architecture '{}' (canonical 'qwen3_moe') uses Mixture-of-Experts FFN. \
                      Forward pass not yet implemented in the GGUF transformer path. \
+                     Live MoE inventory at layer 0: {}/{} contract tensors present ({:?}). \
                      Tracked under contract qwen3-moe-forward-v1 (M32 staged plan: \
-                     M32a contract scaffold SHIPPED; M32b arch-aware load \
-                     IN PROGRESS; M32c CPU forward + M32d numerical parity PENDING). \
-                     See contracts/qwen3-moe-forward-v1.yaml.",
-                    config.architecture
+                     M32a contract scaffold SHIPPED; M32b arch-aware load SHIPPED; \
+                     M32c.1 inventory probe SHIPPED; M32c.2 CPU forward + M32d numerical \
+                     parity PENDING). See contracts/qwen3-moe-forward-v1.yaml.",
+                    config.architecture,
+                    moe_present.len(),
+                    moe_probe_names.len(),
+                    moe_present,
                 ),
             });
         }

--- a/crates/aprender-serve/tests/qwen3_moe_load_path.rs
+++ b/crates/aprender-serve/tests/qwen3_moe_load_path.rs
@@ -81,7 +81,31 @@ fn f_qw3_moe_load_002b_live_qwen3_coder_returns_unsupported_op() {
                 !reason.contains("blk.0.ffn_up.weight"),
                 "F-QW3-MOE-FORWARD-002b: reason must NOT contain dense-FFN tensor name, got: {reason}"
             );
-            eprintln!("F-QW3-MOE-FORWARD-002b: PASS — structured contract error returned.");
+            // M32c.1: live GGUF inventory probe must report 4/4 MoE
+            // tensors present at layer 0 — discharges the implicit
+            // "M29 contract namespace resolves against the live file"
+            // post-condition that the F-TNV-002d falsifier checks
+            // statically. Tying it into the load-time error path makes
+            // the next M32c.2 forward-dispatch wiring observable as
+            // "this layer 0 inventory becomes the loaded MoeLayerWeights".
+            assert!(
+                reason.contains("4/4 contract tensors present"),
+                "F-QW3-MOE-FORWARD-002b: reason must report 4/4 MoE inventory probe, got: {reason}"
+            );
+            for expected in &[
+                "blk.0.ffn_gate_inp.weight",
+                "blk.0.ffn_gate_exps.weight",
+                "blk.0.ffn_up_exps.weight",
+                "blk.0.ffn_down_exps.weight",
+            ] {
+                assert!(
+                    reason.contains(expected),
+                    "F-QW3-MOE-FORWARD-002b: reason must list {expected}, got: {reason}"
+                );
+            }
+            eprintln!(
+                "F-QW3-MOE-FORWARD-002b: PASS — structured contract error + 4/4 MoE inventory."
+            );
         },
         Err(other) => {
             panic!("F-QW3-MOE-FORWARD-002b: expected UnsupportedOperation, got {other:?}")


### PR DESCRIPTION
## Summary
- Enriches the M32b structured `UnsupportedOperation` returned for `qwen3_moe` GGUF loads with a live layer-0 MoE tensor inventory probe.
- Live evidence: `4/4 contract tensors present (["blk.0.ffn_gate_inp.weight", "blk.0.ffn_gate_exps.weight", "blk.0.ffn_up_exps.weight", "blk.0.ffn_down_exps.weight"])` against the cached 17.3 GB Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf.
- Same probe applied symmetrically to both `QuantizedGGUFTransformer::from_gguf` (used by `apr run`) and `GGUFTransformer::from_gguf` (F32 / convert path).
- Updates `tests/qwen3_moe_load_path.rs::f_qw3_moe_load_002b_live_qwen3_coder_returns_unsupported_op` to assert the enriched error contains `"4/4 contract tensors present"` + each of the 4 contract-named tensor strings.

## Why this is a meaningful slice
Proves *observably* that the M29 contract namespace (tensor-names-v1 v1.1.0) resolves against the live GGUF — without yet implementing the forward-pass wiring. The next slice (M32c.2) replaces the inventory probe with actual `MoeLayerWeights` loading + `moe_forward_token` dispatch.

## Discharges
A sub-step (M32c.1) of the M32 staged plan in `contracts/qwen3-moe-forward-v1.yaml`. Reinforces FALSIFY-QW3-MOE-FORWARD-002 with stronger live-fixture assertions.

## Evidence (lambda-vector RTX 4090, 2026-04-28)

```
$ apr run ~/.cache/pacha/models/2b88b180a790988f.gguf --prompt "Hi" --max-tokens 4
[BOS-FALLBACK] No tokenizer.ggml.bos_token_id in GGUF — using architecture default for 'qwen3moe'
error: Inference failed: Inference failed: Operation 'moe_forward_pass' not supported:
  Architecture 'qwen3moe' (canonical 'qwen3_moe') uses Mixture-of-Experts FFN.
  GGUF transformer load refused: ... Live MoE inventory at layer 0: 4/4 contract
  tensors present (["blk.0.ffn_gate_inp.weight", "blk.0.ffn_gate_exps.weight",
  "blk.0.ffn_up_exps.weight", "blk.0.ffn_down_exps.weight"]). Tracked under
  contract qwen3-moe-forward-v1 (M32 staged plan: M32a contract scaffold
  SHIPPED; M32b arch-aware load SHIPPED; M32c.1 inventory probe SHIPPED;
  M32c.2 CPU forward + M32d numerical parity PENDING).
```

## Test plan
- [x] `cargo test -p aprender-serve --test qwen3_moe_load_path --features cuda --release` PASS (2/2)
- [x] Live `apr run` shows enriched 4/4 inventory output
- [ ] CI green (gate, lint, test, coverage, workspace-test)

## Next stages
- M32c.2: replace the probe with actual `MoeLayerWeights` loading + `moe_forward_token` dispatch from `gpu/scheduler/moe_dispatch.rs`
- M32d: numerical parity vs llama.cpp Q4_K + HF FP16

🤖 Generated with [Claude Code](https://claude.com/claude-code)