### PR TITLE
feat(realizar): M32c.1 — Qwen3MoeQuantizedLayer + load_qwen3_moe_layer

### DIFF
--- a/crates/aprender-serve/src/gguf/mod.rs
+++ b/crates/aprender-serve/src/gguf/mod.rs
@@ -51,6 +51,7 @@ mod owned;
 #[cfg(feature = "cuda")]
 pub mod parity;
 mod quantized;
+pub mod qwen3_moe_load;
 mod runtime;
 mod transformer;
 mod types;

--- a/crates/aprender-serve/src/gguf/qwen3_moe_load.rs
+++ b/crates/aprender-serve/src/gguf/qwen3_moe_load.rs
@@ -1,0 +1,142 @@
+//! M32c.1: Architecture-aware load of Qwen3-MoE expert tensors.
+//!
+//! Per `contracts/qwen3-moe-forward-v1.yaml` (M32a) +
+//! `contracts/tensor-names-v1.yaml` v1.1.0 (M29), the four tensor
+//! names load-bearing for `qwen3_moe` are:
+//!
+//! ```text
+//! blk.{L}.ffn_gate_inp.weight   [num_experts, hidden_dim]            — router
+//! blk.{L}.ffn_gate_exps.weight  [num_experts, intermediate, hidden]  — gate per expert
+//! blk.{L}.ffn_up_exps.weight    [num_experts, intermediate, hidden]  — up   per expert
+//! blk.{L}.ffn_down_exps.weight  [num_experts, hidden, intermediate]  — down per expert
+//! ```
+//!
+//! This module exposes a thin loader that, given a parsed
+//! `GGUFModel` and the file's mmapped bytes, returns four
+//! `QuantizedTensorRef` per layer — the on-disk byte ranges of
+//! each MoE tensor. **No dequantization happens here**: that is
+//! M32c.2's job (forward dispatch). The structs returned here
+//! are read-only descriptors suitable for stashing on a
+//! per-layer struct and consuming via the existing
+//! `fused_q4k_*` / `fused_q6k_*` row-major matvec kernels.
+//!
+//! The forward path remains unchanged in this slice: M32b's
+//! `RealizarError::UnsupportedOperation { operation:
+//! "moe_forward_pass" }` early-return still fires for any
+//! attempted inference. M32c.2 is what replaces that
+//! early-return with an actual MoE forward.
+//!
+//! ## Slice scope
+//! - **In-scope (M32c.1, this module)**: per-layer tensor
+//!   descriptors + a falsifier asserting that the cached
+//!   17.3 GB Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf yields
+//!   non-zero descriptors for every L ∈ [0, 48).
+//! - **Out-of-scope (deferred to M32c.2)**: dequantization,
+//!   forward dispatch, KV cache, attention.
+
+use crate::error::Result;
+use crate::gguf::quantized::QuantizedTensorRef;
+use crate::gguf::GGUFModel;
+use crate::gguf::QuantizedGGUFTransformer;
+
+/// Per-layer MoE tensor descriptors for one Qwen3-MoE decoder block.
+///
+/// All four fields are byte-range descriptors into the GGUF file's
+/// mmapped data — no dequantization or copying happens at load
+/// time. The dequantize-on-demand pattern matches the dense FFN
+/// path's `QuantizedGGUFTransformerLayer` and preserves the
+/// 8× memory-bandwidth advantage of Q4_K (per
+/// `crates/aprender-serve/CLAUDE.md` § "Quantized GGUF Transformer
+/// for fused inference").
+#[derive(Debug, Clone)]
+pub struct Qwen3MoeQuantizedLayer {
+    /// `blk.{L}.ffn_gate_inp.weight` — router projection
+    /// `[num_experts, hidden_dim]` row-major.
+    pub router: QuantizedTensorRef,
+
+    /// `blk.{L}.ffn_gate_exps.weight` — per-expert gate projection
+    /// stacked as `[num_experts, intermediate, hidden_dim]`.
+    pub gate_exps: QuantizedTensorRef,
+
+    /// `blk.{L}.ffn_up_exps.weight` — per-expert up projection
+    /// `[num_experts, intermediate, hidden_dim]`.
+    pub up_exps: QuantizedTensorRef,
+
+    /// `blk.{L}.ffn_down_exps.weight` — per-expert down projection
+    /// `[num_experts, hidden_dim, intermediate]`.
+    pub down_exps: QuantizedTensorRef,
+}
+
+/// Load the four MoE tensor descriptors for `layer_idx` from a
+/// `qwen3_moe`-arch GGUF.
+///
+/// # Errors
+/// Returns the standard `RealizarError::InvalidShape { reason:
+/// "Tensor '...' not found" }` if any of the four contract-named
+/// tensors is missing. For arch-mismatched inputs (e.g. a dense
+/// LLaMA GGUF passed to this function), the caller is expected
+/// to first canonicalize the architecture via
+/// `tensor_names::normalize_architecture` and only invoke this
+/// function for `qwen3_moe`.
+///
+/// # Example
+/// ```ignore
+/// let mapped = MappedGGUFModel::from_path(&path)?;
+/// let layer0 = load_qwen3_moe_layer(&mapped.model, mapped.data(), 0)?;
+/// assert!(layer0.router.num_elements >= 128 * 2048);
+/// ```
+pub fn load_qwen3_moe_layer(
+    model: &GGUFModel,
+    data: &[u8],
+    layer_idx: usize,
+) -> Result<Qwen3MoeQuantizedLayer> {
+    let prefix = format!("blk.{layer_idx}");
+    Ok(Qwen3MoeQuantizedLayer {
+        router: QuantizedGGUFTransformer::get_tensor_ref(
+            model,
+            data,
+            &format!("{prefix}.ffn_gate_inp.weight"),
+        )?,
+        gate_exps: QuantizedGGUFTransformer::get_tensor_ref(
+            model,
+            data,
+            &format!("{prefix}.ffn_gate_exps.weight"),
+        )?,
+        up_exps: QuantizedGGUFTransformer::get_tensor_ref(
+            model,
+            data,
+            &format!("{prefix}.ffn_up_exps.weight"),
+        )?,
+        down_exps: QuantizedGGUFTransformer::get_tensor_ref(
+            model,
+            data,
+            &format!("{prefix}.ffn_down_exps.weight"),
+        )?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Sanity: `Qwen3MoeQuantizedLayer` is a small Clone+Debug
+    /// struct. Catches accidental loss of derive macros.
+    #[test]
+    fn qwen3_moe_quantized_layer_is_clone_and_debug() {
+        let dummy = QuantizedTensorRef {
+            offset: 0,
+            byte_size: 0,
+            num_elements: 0,
+            qtype: 0,
+        };
+        let layer = Qwen3MoeQuantizedLayer {
+            router: dummy.clone(),
+            gate_exps: dummy.clone(),
+            up_exps: dummy.clone(),
+            down_exps: dummy,
+        };
+        let cloned = layer.clone();
+        assert_eq!(cloned.router.offset, layer.router.offset);
+        assert!(format!("{layer:?}").contains("Qwen3MoeQuantizedLayer"));
+    }
+}

--- a/crates/aprender-serve/src/gguf/transformer.rs
+++ b/crates/aprender-serve/src/gguf/transformer.rs
@@ -255,7 +255,11 @@ impl<'a> QuantizedGGUFTransformer<'a> {
     }
 
     /// Get tensor reference (offset + size + qtype) without dequantization
-    fn get_tensor_ref(model: &GGUFModel, data: &[u8], name: &str) -> Result<QuantizedTensorRef> {
+    pub(crate) fn get_tensor_ref(
+        model: &GGUFModel,
+        data: &[u8],
+        name: &str,
+    ) -> Result<QuantizedTensorRef> {
         let tensor = model
             .tensors
             .iter()

--- a/crates/aprender-serve/tests/qwen3_moe_load_layer.rs
+++ b/crates/aprender-serve/tests/qwen3_moe_load_layer.rs
@@ -1,0 +1,188 @@
+//! M32c.1 falsifier — exercises `qwen3_moe_load::load_qwen3_moe_layer`
+//! against the cached 17.3 GB Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf
+//! when present.
+//!
+//! Discharges the load-time half of the M32c plan by proving:
+//!
+//!   1. All four MoE tensor names declared by `tensor-names-v1` v1.1.0
+//!      (M29) resolve to non-empty byte ranges for every L ∈ [0, 48).
+//!   2. The descriptors agree on a consistent shape: gate_exps,
+//!      up_exps, down_exps all have the same `num_elements`
+//!      (`num_experts * intermediate * hidden`) per layer.
+//!
+//! Forward dispatch is **NOT** asserted here — that's M32c.2's
+//! falsifier (`FALSIFY-QW3-MOE-FORWARD-003`, which requires
+//! `apr run` to emit tokens).
+//!
+//! ## Skip behaviour
+//! When the canonical cached GGUF is absent, the test exits 0
+//! with a printed `skipped` line — matching the `f_tnv_002d` and
+//! `f_qw3_moe_load_002b` patterns. Fixture-absent ≠ defect.
+
+use realizar::gguf::qwen3_moe_load::load_qwen3_moe_layer;
+use realizar::gguf::GGUFModel;
+
+use std::path::Path;
+
+const CANONICAL_QWEN3_CODER_GGUF_PATHS: &[&str] = &[
+    "/home/noah/.cache/pacha/models/2b88b180a790988f.gguf",
+    "/mnt/nvme-raid0/models/qwen3-coder-30b-q4k.gguf",
+];
+
+/// Per Qwen3-Coder-30B-A3B-Instruct config (apr inspect):
+/// L=48, hidden=2048, intermediate=6144 (per-expert), N_experts=128.
+const EXPECTED_NUM_LAYERS: usize = 48;
+const EXPECTED_HIDDEN: usize = 2048;
+const EXPECTED_INTERMEDIATE: usize = 768; // ffn_inter for MoE expert (small)
+const EXPECTED_N_EXPERTS: usize = 128;
+
+#[test]
+fn f_qw3_moe_c1_001_load_first_layer_against_live_gguf() {
+    let Some(gguf_path) = CANONICAL_QWEN3_CODER_GGUF_PATHS
+        .iter()
+        .find(|p| Path::new(p).exists())
+    else {
+        eprintln!(
+            "F-QW3-MOE-C1-001: skipped — no Qwen3-Coder GGUF cached at any of {:?}",
+            CANONICAL_QWEN3_CODER_GGUF_PATHS
+        );
+        return;
+    };
+
+    eprintln!("F-QW3-MOE-C1-001: loading layer 0 from {gguf_path}");
+
+    let bytes = std::fs::read(gguf_path).expect("read GGUF bytes");
+    let model = GGUFModel::from_bytes(&bytes).expect("parse GGUF header");
+
+    let layer0 =
+        load_qwen3_moe_layer(&model, &bytes, 0).expect("load layer 0 MoE tensor descriptors");
+
+    assert!(
+        layer0.router.num_elements > 0,
+        "F-QW3-MOE-C1-001: router descriptor must be non-empty, got {:?}",
+        layer0.router
+    );
+    assert!(
+        layer0.gate_exps.num_elements > 0,
+        "F-QW3-MOE-C1-001: gate_exps descriptor must be non-empty, got {:?}",
+        layer0.gate_exps
+    );
+    assert!(
+        layer0.up_exps.num_elements > 0,
+        "F-QW3-MOE-C1-001: up_exps descriptor must be non-empty, got {:?}",
+        layer0.up_exps
+    );
+    assert!(
+        layer0.down_exps.num_elements > 0,
+        "F-QW3-MOE-C1-001: down_exps descriptor must be non-empty, got {:?}",
+        layer0.down_exps
+    );
+
+    assert_eq!(
+        layer0.gate_exps.num_elements, layer0.up_exps.num_elements,
+        "F-QW3-MOE-C1-001: gate_exps + up_exps must share shape \
+         [N_experts, intermediate, hidden]; got gate={}, up={}",
+        layer0.gate_exps.num_elements, layer0.up_exps.num_elements
+    );
+    assert_eq!(
+        layer0.gate_exps.num_elements, layer0.down_exps.num_elements,
+        "F-QW3-MOE-C1-001: gate_exps + down_exps share total element count \
+         (only the dim ordering differs); got gate={}, down={}",
+        layer0.gate_exps.num_elements, layer0.down_exps.num_elements
+    );
+
+    eprintln!(
+        "F-QW3-MOE-C1-001: PASS\n  router.num_elements      = {}\n  \
+         gate/up/down.num_elements = {}\n  qtypes (router/gate/up/down) = ({}, {}, {}, {})",
+        layer0.router.num_elements,
+        layer0.gate_exps.num_elements,
+        layer0.router.qtype,
+        layer0.gate_exps.qtype,
+        layer0.up_exps.qtype,
+        layer0.down_exps.qtype,
+    );
+}
+
+#[test]
+fn f_qw3_moe_c1_002_load_all_48_layers_against_live_gguf() {
+    let Some(gguf_path) = CANONICAL_QWEN3_CODER_GGUF_PATHS
+        .iter()
+        .find(|p| Path::new(p).exists())
+    else {
+        eprintln!("F-QW3-MOE-C1-002: skipped — no cached GGUF.");
+        return;
+    };
+
+    eprintln!("F-QW3-MOE-C1-002: loading all {EXPECTED_NUM_LAYERS} layers from {gguf_path}");
+
+    let bytes = std::fs::read(gguf_path).expect("read GGUF bytes");
+    let model = GGUFModel::from_bytes(&bytes).expect("parse GGUF header");
+
+    let mut consistent_router_size: Option<usize> = None;
+    let mut consistent_expert_size: Option<usize> = None;
+    let mut total_router_bytes: usize = 0;
+    let mut total_expert_bytes: usize = 0;
+
+    for layer_idx in 0..EXPECTED_NUM_LAYERS {
+        let layer = load_qwen3_moe_layer(&model, &bytes, layer_idx)
+            .unwrap_or_else(|e| panic!("F-QW3-MOE-C1-002: layer {layer_idx} load failed: {e:?}"));
+
+        assert!(layer.router.num_elements > 0, "layer {layer_idx} router");
+        assert!(
+            layer.gate_exps.num_elements > 0,
+            "layer {layer_idx} gate_exps"
+        );
+        assert!(layer.up_exps.num_elements > 0, "layer {layer_idx} up_exps");
+        assert!(
+            layer.down_exps.num_elements > 0,
+            "layer {layer_idx} down_exps"
+        );
+
+        if let Some(prev) = consistent_router_size {
+            assert_eq!(
+                prev, layer.router.num_elements,
+                "F-QW3-MOE-C1-002: router shape varies between layer 0 and layer {layer_idx}"
+            );
+        } else {
+            consistent_router_size = Some(layer.router.num_elements);
+        }
+        if let Some(prev) = consistent_expert_size {
+            assert_eq!(
+                prev, layer.gate_exps.num_elements,
+                "F-QW3-MOE-C1-002: expert shape varies between layer 0 and layer {layer_idx}"
+            );
+        } else {
+            consistent_expert_size = Some(layer.gate_exps.num_elements);
+        }
+
+        total_router_bytes += layer.router.byte_size;
+        total_expert_bytes +=
+            layer.gate_exps.byte_size + layer.up_exps.byte_size + layer.down_exps.byte_size;
+    }
+
+    let router_elems = consistent_router_size.expect("at least one layer must be loaded");
+    let expert_elems = consistent_expert_size.expect("at least one layer must be loaded");
+
+    eprintln!(
+        "F-QW3-MOE-C1-002: PASS\n  L={EXPECTED_NUM_LAYERS}\n  \
+         router.num_elements (per layer) = {router_elems}\n  \
+         expert.num_elements (per layer per role) = {expert_elems}\n  \
+         total_router_bytes = {total_router_bytes}\n  \
+         total_expert_bytes (gate+up+down × {EXPECTED_NUM_LAYERS}) = {total_expert_bytes}",
+    );
+
+    let expected_router_elems = EXPECTED_HIDDEN * EXPECTED_N_EXPERTS;
+    assert_eq!(
+        router_elems, expected_router_elems,
+        "F-QW3-MOE-C1-002: router shape must be [N_experts={EXPECTED_N_EXPERTS}, hidden={EXPECTED_HIDDEN}], \
+         expected num_elements = {expected_router_elems}, got {router_elems}"
+    );
+
+    let expected_expert_elems = EXPECTED_N_EXPERTS * EXPECTED_INTERMEDIATE * EXPECTED_HIDDEN;
+    assert_eq!(
+        expert_elems, expected_expert_elems,
+        "F-QW3-MOE-C1-002: expert shape must be \
+         [N_experts={EXPECTED_N_EXPERTS}, intermediate={EXPECTED_INTERMEDIATE}, hidden={EXPECTED_HIDDEN}], \
+         expected num_elements = {expected_expert_elems}, got {expert_elems}"
+    );
+}


### PR DESCRIPTION
## Summary
- New module `crates/aprender-serve/src/gguf/qwen3_moe_load.rs`: `Qwen3MoeQuantizedLayer` struct + `load_qwen3_moe_layer()` loader using the M29 contract namespace
- Exposes `QuantizedGGUFTransformer::get_tensor_ref` as `pub(crate)` for reuse
- New falsifier `tests/qwen3_moe_load_layer.rs` with 2 tests against the live 17.3 GB Qwen3-Coder GGUF

## What this PR does NOT ship
**No forward dispatch.** M32b's structured `UnsupportedOperation` early-return remains in place. M32c.2 (next PR) wires `moe_forward_token` into FFN dispatch, replacing M32b's early-return with actual MoE inference.

## Live evidence (lambda-vector RTX 4090)

```
F-QW3-MOE-C1-001: PASS
  router.num_elements      = 262144              # 128 × 2048 ✓
  gate/up/down.num_elements = 201326592           # 128 × 768 × 2048 ✓
  qtypes (router/gate/up/down) = (0, 12, 12, 14) # F32, Q4_K, Q4_K, Q6_K

F-QW3-MOE-C1-002: PASS
  L=48
  total_expert_bytes (gate+up+down × 48) = 17553162240  # ~17.5 GB matches GGUF size ✓
```

## Test plan
- [x] `cargo test -p aprender-serve --test qwen3_moe_load_layer --features cuda --release` PASS (2/2)
- [x] M32b regression `cargo test -p aprender-serve --test qwen3_moe_load_path --features cuda --release` PASS (2/2)
- [ ] CI green

## Stage map
- M32a: contract scaffold ✅ (#1104 merged)
- M32b: structured-error early-return ✅ (#1106 merged)
- **M32c.1: load layer descriptors (this PR)**
- M32c.2: forward dispatch — `apr run` produces tokens (next PR)
- M32d: numerical parity vs llama.cpp / HF FP16 (DRAFT → ACTIVE_RUNTIME)

🤖 Generated with [Claude Code](https://claude.com/claude-code)