### PR TITLE
feat(realizar): M32c.2.1 — flip from_gguf dispatch + forward-time refusal for qwen3_moe

### DIFF
--- a/crates/aprender-serve/src/gguf/transformer.rs
+++ b/crates/aprender-serve/src/gguf/transformer.rs
@@ -140,24 +140,15 @@ impl<'a> QuantizedGGUFTransformer<'a> {
         // Replaces the pre-M32 cryptic "Tensor 'blk.0.ffn_up.weight' not
         // found" surface captured by FALSIFY-QW3-MOE-FORWARD-001 in
         // contracts/qwen3-moe-forward-v1.yaml.
+        // M32c.2.1: dispatch qwen3_moe arch to the MoE-aware constructor
+        // (M32c.2's `from_gguf_for_moe`). Loading now succeeds end-to-end;
+        // the forward path emits the contract-named UnsupportedOperation
+        // when it encounters the placeholder dense FFN — see M32c.2.2 for
+        // the actual MoE forward wiring. Replaces M32b's load-time refusal.
+        // See contracts/qwen3-moe-forward-v1.yaml.
         let canonical_arch = crate::tensor_names::normalize_architecture(&config.architecture);
         if canonical_arch == "qwen3_moe" {
-            return Err(crate::error::RealizarError::UnsupportedOperation {
-                operation: "moe_forward_pass".to_string(),
-                reason: format!(
-                    "Architecture '{}' (canonical 'qwen3_moe') uses Mixture-of-Experts FFN. \
-                     GGUF transformer load refused: dense FFN tensors \
-                     (blk.{{L}}.ffn_{{gate,up,down}}.weight) do not exist for this \
-                     arch. The MoE tensor namespace (blk.{{L}}.ffn_gate_inp/\
-                     ffn_gate_exps/ffn_up_exps/ffn_down_exps.weight) is declared by \
-                     tensor-names-v1 v1.1.0 but forward-pass dispatch is not yet wired. \
-                     Tracked under contract qwen3-moe-forward-v1 (M32 staged plan: \
-                     M32a contract scaffold SHIPPED; M32b arch-aware load \
-                     IN PROGRESS; M32c CPU forward + M32d numerical parity PENDING). \
-                     See contracts/qwen3-moe-forward-v1.yaml.",
-                    config.architecture
-                ),
-            });
+            return Self::from_gguf_for_moe(model, data);
         }
 
         // Token embedding - keep as f32 for efficient lookup

--- a/crates/aprender-serve/src/infer/gguf_gpu_generate.rs
+++ b/crates/aprender-serve/src/infer/gguf_gpu_generate.rs
@@ -170,6 +170,34 @@ fn run_gguf_generate(
     gen_config: &crate::gguf::QuantizedGenerateConfig,
     config: &InferenceConfig,
 ) -> Result<(Vec<u32>, bool)> {
+    // M32c.2.1: short-circuit MoE forward attempts BEFORE any GPU/CPU
+    // dispatch. M32c.2 made `from_gguf` succeed for qwen3_moe by routing
+    // to `from_gguf_for_moe` (which leaves dense FFN tensor refs as
+    // zero-byte placeholders). Without this guard, the wgpu/CUDA forward
+    // path tries to bind those zero-byte buffers and panics deep in
+    // `wgpu_core::create_bind_group` with `Buffer with 'layer.0.up_proj'
+    // label binding size is zero`. M32c.2.2 will replace this guard with
+    // an actual MoE forward via `moe_forward_token`. See
+    // contracts/qwen3-moe-forward-v1.yaml § FALSIFY-QW3-MOE-FORWARD-003.
+    let canonical_arch =
+        crate::tensor_names::normalize_architecture(&model.config.architecture);
+    if canonical_arch == "qwen3_moe" {
+        return Err(RealizarError::UnsupportedOperation {
+            operation: "moe_forward_dispatch".to_string(),
+            reason: format!(
+                "Architecture '{}' (canonical 'qwen3_moe') uses Mixture-of-Experts FFN. \
+                 Load step succeeded via QuantizedGGUFTransformer::from_gguf_for_moe (M32c.2) \
+                 with all 4 contract-declared MoE tensors per layer present, but the \
+                 forward dispatch is not yet wired to moe_forward_token in \
+                 gpu/scheduler/moe_dispatch.rs. Tracked under contract qwen3-moe-forward-v1 \
+                 (M32 staged plan: M32a/b/c.1/c.2 SHIPPED; M32c.2.1 forward-refusal \
+                 IN PROGRESS; M32c.2.2 forward-wiring + M32d numerical parity PENDING). \
+                 See contracts/qwen3-moe-forward-v1.yaml.",
+                model.config.architecture
+            ),
+        });
+    }
+
     let has_legacy_quant = model_has_legacy_quant(&model);
 
     // GPU path: pass model by value (zero-clone) — model is returned on failure for CPU fallback

--- a/crates/aprender-serve/tests/qwen3_moe_load_path.rs
+++ b/crates/aprender-serve/tests/qwen3_moe_load_path.rs
@@ -36,6 +36,8 @@ use realizar::gguf::{GGUFModel, QuantizedGGUFTransformer};
 
 use std::path::Path;
 
+#[allow(dead_code)] // M32c.2.1: the load-time error path that referenced this id
+                    // is gone; forward-time refusal in apr-cli still uses it.
 const CONTRACT_ID: &str = "qwen3-moe-forward-v1";
 
 /// Canonical lambda-vector cache locations for the M29 reference GGUF
@@ -65,33 +67,43 @@ fn f_qw3_moe_load_002b_live_qwen3_coder_returns_unsupported_op() {
     let bytes = std::fs::read(gguf_path).expect("read GGUF bytes");
     let model = GGUFModel::from_bytes(&bytes).expect("parse GGUF header");
 
-    let result = QuantizedGGUFTransformer::from_gguf(&model, &bytes);
+    // M32c.2.1: load now SUCCEEDS via the dispatch to from_gguf_for_moe.
+    // The contract-named refusal moved to forward time. We assert load
+    // succeeds + every layer has the populated MoE descriptor + dense
+    // FFN fields are placeholders. Forward-time refusal is asserted
+    // separately by the apr-cli `apr run` integration (manual /
+    // FALSIFY-QW3-MOE-FORWARD-003 in M32c.2.2).
+    let transformer = QuantizedGGUFTransformer::from_gguf(&model, &bytes)
+        .expect("F-QW3-MOE-FORWARD-002b: M32c.2.1 load via from_gguf must succeed for qwen3_moe");
 
-    match result {
-        Err(RealizarError::UnsupportedOperation { operation, reason }) => {
-            assert_eq!(
-                operation, "moe_forward_pass",
-                "F-QW3-MOE-FORWARD-002b: operation tag must be 'moe_forward_pass', got {operation:?}"
-            );
-            assert!(
-                reason.contains(CONTRACT_ID),
-                "F-QW3-MOE-FORWARD-002b: reason must reference contract id {CONTRACT_ID:?}, got: {reason}"
-            );
-            assert!(
-                !reason.contains("blk.0.ffn_up.weight"),
-                "F-QW3-MOE-FORWARD-002b: reason must NOT contain dense-FFN tensor name, got: {reason}"
-            );
-            eprintln!("F-QW3-MOE-FORWARD-002b: PASS — structured contract error returned.");
-        },
-        Err(other) => {
-            panic!("F-QW3-MOE-FORWARD-002b: expected UnsupportedOperation, got {other:?}")
-        },
-        Ok(_) => panic!(
-            "F-QW3-MOE-FORWARD-002b: expected M32b to refuse qwen3_moe load, but it succeeded. \
-             Did M32c land without updating this test? If forward dispatch is now wired, \
-             this test should be replaced with FALSIFY-QW3-MOE-FORWARD-003 (token emission)."
-        ),
+    assert!(
+        !transformer.layers.is_empty(),
+        "F-QW3-MOE-FORWARD-002b: layers must be populated"
+    );
+    assert_eq!(
+        transformer.layers.len(),
+        transformer.moe_layers.len(),
+        "F-QW3-MOE-FORWARD-002b: moe_layers parallel to layers"
+    );
+    for (i, moe) in transformer.moe_layers.iter().enumerate() {
+        assert!(
+            moe.is_some(),
+            "F-QW3-MOE-FORWARD-002b: layer {i} moe_layers entry must be Some after from_gguf dispatch"
+        );
     }
+    assert_eq!(
+        transformer.layers[0].ffn_up_weight.num_elements, 0,
+        "F-QW3-MOE-FORWARD-002b: dense ffn_up_weight must be placeholder for MoE layer"
+    );
+
+    // Compile-time silence on the import — RealizarError still in use elsewhere.
+    let _ = std::any::type_name::<RealizarError>();
+
+    eprintln!(
+        "F-QW3-MOE-FORWARD-002b: PASS — load via from_gguf dispatched to from_gguf_for_moe; \
+         {} layers populated; dense FFN placeholders verified.",
+        transformer.layers.len()
+    );
 }
 
 /// Cross-check: the canonical-key normalization must be a fixed point


### PR DESCRIPTION
## Summary
- `QuantizedGGUFTransformer::from_gguf` for `qwen3_moe` arch now returns `Self::from_gguf_for_moe(...)` instead of UnsupportedOperation. Load succeeds end-to-end.
- New forward-time refusal in `run_gguf_generate` returns `RealizarError::UnsupportedOperation { operation: \"moe_forward_dispatch\" }` BEFORE GPU/CPU dispatch — prevents the wgpu panic on zero-byte placeholder buffers.
- Falsifier updated: F-QW3-MOE-FORWARD-002b now asserts load SUCCESS + all 48 layers' `moe_layers[i].is_some()` with populated descriptors.

## Stage map
- M32a: contract scaffold ✅ (#1104)
- M32b: load-time UnsupportedOperation ✅ (#1106)
- M32c.1: Qwen3MoeQuantizedLayer descriptor + loader ✅ (#1116)
- M32c.2: from_gguf_for_moe constructor ✅ (#1117)
- **M32c.2.1: dispatch flip + forward-time refusal (this PR)**
- M32c.2.2: wire `moe_forward_token` into FFN dispatch (apr run produces tokens)
- M32d: numerical parity vs llama.cpp / HF FP16

## Evidence (lambda-vector RTX 4090, 2026-04-28)

**Pre-M32c.2.1 (post-M32c.2)**:
```
thread 'main' panicked: wgpu error: Validation Error
  Buffer with 'layer.0.up_proj' label binding size is zero
```
(placeholder dense-FFN tensor refs reach wgpu bind group)

**Post-M32c.2.1**:
```
Operation 'moe_forward_dispatch' not supported: Architecture 'qwen3moe'
(canonical 'qwen3_moe') uses Mixture-of-Experts FFN. Load step succeeded
via QuantizedGGUFTransformer::from_gguf_for_moe (M32c.2) with all 4
contract-declared MoE tensors per layer present, but the forward dispatch
is not yet wired to moe_forward_token in gpu/scheduler/moe_dispatch.rs.
... See contracts/qwen3-moe-forward-v1.yaml.
```

## Test plan
- [x] `cargo test -p aprender-serve --test qwen3_moe_load_path --features cuda --release` PASS (2/2)
- [x] Live `apr run` shows clean forward-time refusal (no panic)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)