### PR TITLE
feat(realizar): M32c.2.2.0 — expert_byte_slice adapter for per-expert MoE bytes

### DIFF
--- a/crates/aprender-serve/src/gguf/qwen3_moe_load.rs
+++ b/crates/aprender-serve/src/gguf/qwen3_moe_load.rs
@@ -115,6 +115,86 @@ pub fn load_qwen3_moe_layer(
     })
 }
 
+/// Slice the byte range for ONE expert's portion of a stacked
+/// per-expert tensor.
+///
+/// Per the LAZY-FUSED-MATVEC decision recorded in
+/// `contracts/qwen3-moe-forward-v1.yaml` v1.1.0 (M32c.2.2 amendment),
+/// MoE forward dispatch keeps weights quantized and dequantizes
+/// inline through the existing fused Q4_K/Q6_K row-major matvec
+/// kernels. This adapter slices the stacked tensor — laid out
+/// `[num_experts, ...]` row-major — into one expert's contiguous
+/// byte range, ready for `fused_q4k_parallel_matvec` /
+/// `fused_q6k_parallel_matvec`.
+///
+/// # Layout assumption
+/// The stacked tensor's element count is `num_experts *
+/// per_expert_elements`. Both `num_elements` and `byte_size` on
+/// `tensor` divide evenly by `num_experts`. Q4_K and Q6_K K-quants
+/// pad each row of `cols` elements to super-block boundaries
+/// (cols is the LAST dim) — since each expert's slab is itself a
+/// contiguous `[..., cols]` block, the per-expert byte size is
+/// `tensor.byte_size / num_experts`.
+///
+/// # Errors
+/// Returns `RealizarError::InvalidShape` if:
+/// - `num_experts == 0`
+/// - `expert_id >= num_experts`
+/// - `tensor.byte_size % num_experts != 0` (stacking invariant
+///   violation — would indicate an upstream loader bug or an
+///   architecture mismatch)
+/// - the slice runs past `data.len()`
+///
+/// # Returns
+/// `&[u8]` borrowed from `data`, length `tensor.byte_size / num_experts`,
+/// covering exactly expert `expert_id`'s contribution. The caller is
+/// responsible for knowing the per-expert dims and qtype (read off
+/// the sibling `tensor.qtype`).
+pub fn expert_byte_slice<'a>(
+    tensor: &QuantizedTensorRef,
+    data: &'a [u8],
+    expert_id: usize,
+    num_experts: usize,
+) -> crate::error::Result<&'a [u8]> {
+    use crate::error::RealizarError;
+
+    if num_experts == 0 {
+        return Err(RealizarError::InvalidShape {
+            reason: "expert_byte_slice: num_experts must be > 0".to_string(),
+        });
+    }
+    if expert_id >= num_experts {
+        return Err(RealizarError::InvalidShape {
+            reason: format!(
+                "expert_byte_slice: expert_id {expert_id} out of range \
+                 (num_experts = {num_experts})"
+            ),
+        });
+    }
+    if tensor.byte_size % num_experts != 0 {
+        return Err(RealizarError::InvalidShape {
+            reason: format!(
+                "expert_byte_slice: tensor byte_size {} not divisible by num_experts {} \
+                 — stacking invariant violated. Layout mismatch (LAZY-FUSED-MATVEC \
+                 expects [num_experts, ...] outermost dim contiguous)",
+                tensor.byte_size, num_experts
+            ),
+        });
+    }
+    let per_expert_bytes = tensor.byte_size / num_experts;
+    let start = tensor.offset + expert_id * per_expert_bytes;
+    let end = start + per_expert_bytes;
+    if end > data.len() {
+        return Err(RealizarError::InvalidShape {
+            reason: format!(
+                "expert_byte_slice: slice range [{start}, {end}) exceeds file size {}",
+                data.len()
+            ),
+        });
+    }
+    Ok(&data[start..end])
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -138,5 +218,80 @@ mod tests {
         let cloned = layer.clone();
         assert_eq!(cloned.router.offset, layer.router.offset);
         assert!(format!("{layer:?}").contains("Qwen3MoeQuantizedLayer"));
+    }
+
+    /// `expert_byte_slice` returns each expert's contiguous byte
+    /// range in a synthetic 4-expert stacked tensor.
+    #[test]
+    fn expert_byte_slice_partitions_evenly() {
+        // 4 experts × 32 bytes/expert = 128 total bytes.
+        let data: Vec<u8> = (0..128).collect();
+        let tensor = QuantizedTensorRef {
+            offset: 0,
+            byte_size: 128,
+            num_elements: 128 * 2, // arbitrary, not used by slicer
+            qtype: 12,             // Q4_K
+        };
+
+        for e in 0..4 {
+            let slice = expert_byte_slice(&tensor, &data, e, 4).unwrap();
+            assert_eq!(slice.len(), 32, "expert {e} slice length");
+            // Expert e's slice starts at byte e*32; first byte must equal e*32.
+            assert_eq!(slice[0], (e * 32) as u8, "expert {e} first byte");
+        }
+    }
+
+    #[test]
+    fn expert_byte_slice_rejects_out_of_range_expert_id() {
+        let data = vec![0u8; 64];
+        let tensor = QuantizedTensorRef {
+            offset: 0,
+            byte_size: 64,
+            num_elements: 0,
+            qtype: 0,
+        };
+        let err = expert_byte_slice(&tensor, &data, 4, 4).unwrap_err();
+        assert!(format!("{err}").contains("expert_id 4 out of range"));
+    }
+
+    #[test]
+    fn expert_byte_slice_rejects_zero_num_experts() {
+        let data = vec![0u8; 64];
+        let tensor = QuantizedTensorRef {
+            offset: 0,
+            byte_size: 64,
+            num_elements: 0,
+            qtype: 0,
+        };
+        let err = expert_byte_slice(&tensor, &data, 0, 0).unwrap_err();
+        assert!(format!("{err}").contains("num_experts must be > 0"));
+    }
+
+    #[test]
+    fn expert_byte_slice_rejects_uneven_stacking() {
+        let data = vec![0u8; 100];
+        let tensor = QuantizedTensorRef {
+            offset: 0,
+            byte_size: 100,
+            num_elements: 0,
+            qtype: 0,
+        };
+        // 100 not divisible by 3 → stacking invariant violated.
+        let err = expert_byte_slice(&tensor, &data, 0, 3).unwrap_err();
+        assert!(format!("{err}").contains("stacking invariant violated"));
+    }
+
+    #[test]
+    fn expert_byte_slice_rejects_overrun() {
+        let data = vec![0u8; 32];
+        let tensor = QuantizedTensorRef {
+            offset: 0,
+            byte_size: 64, // claims 64 bytes but data only has 32
+            num_elements: 0,
+            qtype: 0,
+        };
+        // Expert 1 starts at byte 32; range [32, 64) overruns the 32-byte buffer.
+        let err = expert_byte_slice(&tensor, &data, 1, 2).unwrap_err();
+        assert!(format!("{err}").contains("exceeds file size"));
     }
 }

--- a/crates/aprender-serve/tests/qwen3_moe_load_layer.rs
+++ b/crates/aprender-serve/tests/qwen3_moe_load_layer.rs
@@ -19,7 +19,7 @@
 //! with a printed `skipped` line — matching the `f_tnv_002d` and
 //! `f_qw3_moe_load_002b` patterns. Fixture-absent ≠ defect.
 
-use realizar::gguf::qwen3_moe_load::load_qwen3_moe_layer;
+use realizar::gguf::qwen3_moe_load::{expert_byte_slice, load_qwen3_moe_layer};
 use realizar::gguf::GGUFModel;
 
 use std::path::Path;
@@ -184,5 +184,77 @@ fn f_qw3_moe_c1_002_load_all_48_layers_against_live_gguf() {
         "F-QW3-MOE-C1-002: expert shape must be \
          [N_experts={EXPECTED_N_EXPERTS}, intermediate={EXPECTED_INTERMEDIATE}, hidden={EXPECTED_HIDDEN}], \
          expected num_elements = {expected_expert_elems}, got {expert_elems}"
+    );
+}
+
+/// M32c.2.2.0 falsifier — exercises `expert_byte_slice` against the live
+/// cached Qwen3-Coder GGUF. Proves that for every layer × every expert,
+/// the per-expert byte range is well-formed (correct length, in-bounds,
+/// distinct from neighbour) — the load-side guarantee that
+/// `fused_q4k_parallel_matvec` (M32c.2.2.1) will rely on.
+#[test]
+fn f_qw3_moe_c220_001_expert_byte_slice_partitions_live_gguf() {
+    let Some(gguf_path) = CANONICAL_QWEN3_CODER_GGUF_PATHS
+        .iter()
+        .find(|p| Path::new(p).exists())
+    else {
+        eprintln!("F-QW3-MOE-C220-001: skipped — no cached GGUF.");
+        return;
+    };
+
+    eprintln!("F-QW3-MOE-C220-001: slicing experts at {gguf_path}");
+
+    let bytes = std::fs::read(gguf_path).expect("read GGUF bytes");
+    let model = GGUFModel::from_bytes(&bytes).expect("parse GGUF header");
+
+    let layer0 = load_qwen3_moe_layer(&model, &bytes, 0).expect("layer 0 descriptors");
+
+    // Slice each of the 4 stacked tensors per-expert and verify:
+    //   - returned slice length is exactly byte_size / num_experts
+    //   - first byte of expert e differs from first byte of expert e+1 in
+    //     at least ONE of the 3 expert tensors (gate/up/down) — proves
+    //     we're slicing into different memory, not aliasing
+    let n = EXPECTED_N_EXPERTS;
+    let stacked = [
+        ("gate_exps", &layer0.gate_exps),
+        ("up_exps", &layer0.up_exps),
+        ("down_exps", &layer0.down_exps),
+    ];
+
+    for (name, tensor) in &stacked {
+        let per_expert = tensor.byte_size / n;
+        for e in 0..n {
+            let slice = expert_byte_slice(tensor, &bytes, e, n).unwrap_or_else(|err| {
+                panic!("F-QW3-MOE-C220-001: {name} expert {e} slice failed: {err}")
+            });
+            assert_eq!(
+                slice.len(),
+                per_expert,
+                "F-QW3-MOE-C220-001: {name} expert {e} length"
+            );
+        }
+    }
+
+    // Different experts have different bytes (sanity vs aliasing).
+    let mut differs = 0usize;
+    for (_, tensor) in &stacked {
+        let s0 = expert_byte_slice(tensor, &bytes, 0, n).unwrap();
+        let s1 = expert_byte_slice(tensor, &bytes, 1, n).unwrap();
+        if s0[..16.min(s0.len())] != s1[..16.min(s1.len())] {
+            differs += 1;
+        }
+    }
+    assert!(
+        differs > 0,
+        "F-QW3-MOE-C220-001: at least one expert tensor must distinguish expert 0 from expert 1"
+    );
+
+    eprintln!(
+        "F-QW3-MOE-C220-001: PASS\n  {} experts × 3 tensors per layer 0 sliced\n  \
+         per-expert sizes: gate={} up={} down={} bytes",
+        n,
+        layer0.gate_exps.byte_size / n,
+        layer0.up_exps.byte_size / n,
+        layer0.down_exps.byte_size / n
     );
 }


### PR DESCRIPTION
## Summary
First implementation slice of the LAZY-FUSED-MATVEC decision pinned in v1.1.0 (PR #1119). Adds `expert_byte_slice()` — slices the byte range for ONE expert from a stacked `[num_experts, ...]` tensor, ready to feed into the existing fused Q4_K / Q6_K matvec kernels.

## Live evidence (lambda-vector RTX 4090)

```
F-QW3-MOE-C220-001: PASS
  128 experts × 3 tensors per layer 0 sliced
  per-expert sizes: gate=884736 up=884736 down=1290240 bytes
```

## Test plan
- [x] 5 new unit tests (partitions + 4 rejection paths)
- [x] Live test against 17.3 GB Qwen3-Coder GGUF (3 stacked tensors × 128 experts each)
- [x] M32c.1 regression checks pass (3/3 in qwen3_moe_load_layer suite)
- [ ] CI green

## Stage map
- M32a/b/c.1/c.2/c.2.1: ✅ merged
- M32c.2.2 dequant-strategy decision (v1.1.0): ✅ merged at 590b8d6aa
- **M32c.2.2.0: per-expert byte slicer (this PR)**
- M32c.2.2.1: per-expert SwiGLU using slicer + fused matvec kernels
- M32c.2.2.2: replace MoE short-circuit with real forward; `apr run` produces tokens
- M32d: numerical parity vs llama.cpp / HF FP16

🤖 Generated with [Claude Code](https://claude.com/claude-code)