### PR TITLE
feat(realizar): M32c.2.2.1 — expert_swiglu_quantized: per-expert SwiGLU via fused Q4_K/Q6_K matvec

### DIFF
--- a/crates/aprender-serve/src/gguf/qwen3_moe_load.rs
+++ b/crates/aprender-serve/src/gguf/qwen3_moe_load.rs
@@ -195,6 +195,91 @@ pub fn expert_byte_slice<'a>(
     Ok(&data[start..end])
 }
 
+/// Per-expert SwiGLU FFN evaluation with on-the-fly Q4_K/Q6_K
+/// dequantization (M32c.2.2.1).
+///
+/// Implements one selected expert's contribution to the MoE layer:
+/// `down(SiLU(gate(x)) ⊙ up(x))` where gate, up are Q4_K and down
+/// is Q6_K. Uses `expert_byte_slice` (M32c.2.2.0) to find the
+/// expert's portion of the stacked tensor + the existing
+/// `fused_q4k_parallel_matvec` / `fused_q6k_parallel_matvec`
+/// row-major kernels to keep weights quantized through the matmul
+/// (LAZY-FUSED-MATVEC, qwen3-moe-forward-v1 v1.1.0).
+///
+/// # Arguments
+/// * `hidden` — input hidden state, length == `hidden_dim`.
+/// * `layer` — the M32c.1 `Qwen3MoeQuantizedLayer` for this decoder block.
+/// * `expert_id` — selected expert index ∈ [0, num_experts).
+/// * `num_experts` — total experts in the stacked tensors (e.g. 128 for Qwen3-Coder-30B).
+/// * `intermediate` — per-expert intermediate dim (e.g. 768 for Qwen3-Coder-30B).
+/// * `hidden_dim` — model hidden dim (e.g. 2048 for Qwen3-Coder-30B).
+/// * `data` — file's mmapped byte slice (zero-copy from `MappedGGUFModel::data()`).
+///
+/// # Returns
+/// A new `Vec<f32>` of length `hidden_dim` — this expert's contribution
+/// to the layer's MoE output. Caller is responsible for the routing
+/// weight scaling and accumulation (see `moe_forward_token` semantics
+/// in `gpu/scheduler/moe_dispatch.rs`).
+///
+/// # Errors
+/// Propagates errors from `expert_byte_slice` (out-of-range expert,
+/// stacking-invariant violation, slice overrun) and the matvec kernels
+/// (length mismatch).
+///
+/// # Layout assumption
+/// Per `tensor-names-v1` v1.1.0:
+///   * `gate_exps`, `up_exps`: stacked `[num_experts, intermediate, hidden]`
+///     row-major Q4_K. Per-expert slab is `[intermediate, hidden]`.
+///   * `down_exps`: stacked `[num_experts, hidden, intermediate]` row-major
+///     Q6_K. Per-expert slab is `[hidden, intermediate]`.
+///
+/// `fused_q4k_parallel_matvec` is documented to take row-major
+/// `[out_dim, in_dim]` weights, so we pass `(hidden_dim, intermediate)` for
+/// gate/up (in=hidden, out=intermediate) and `(intermediate, hidden_dim)`
+/// for down (in=intermediate, out=hidden).
+pub fn expert_swiglu_quantized(
+    hidden: &[f32],
+    layer: &Qwen3MoeQuantizedLayer,
+    expert_id: usize,
+    num_experts: usize,
+    intermediate: usize,
+    hidden_dim: usize,
+    data: &[u8],
+) -> Result<Vec<f32>> {
+    use crate::error::RealizarError;
+    use crate::quantize::{fused_q4k_parallel_matvec, fused_q6k_parallel_matvec};
+
+    if hidden.len() != hidden_dim {
+        return Err(RealizarError::InvalidShape {
+            reason: format!(
+                "expert_swiglu_quantized: hidden.len() = {} but hidden_dim = {}",
+                hidden.len(),
+                hidden_dim
+            ),
+        });
+    }
+
+    let gate_bytes = expert_byte_slice(&layer.gate_exps, data, expert_id, num_experts)?;
+    let up_bytes = expert_byte_slice(&layer.up_exps, data, expert_id, num_experts)?;
+    let down_bytes = expert_byte_slice(&layer.down_exps, data, expert_id, num_experts)?;
+
+    // gate(x) and up(x): each [hidden] → [intermediate], Q4_K weight.
+    let gate_out = fused_q4k_parallel_matvec(gate_bytes, hidden, hidden_dim, intermediate)?;
+    let up_out = fused_q4k_parallel_matvec(up_bytes, hidden, hidden_dim, intermediate)?;
+
+    // SwiGLU: SiLU(gate) ⊙ up. SiLU(x) = x * sigmoid(x) = x / (1 + exp(-x)).
+    let mut ffn_hidden = vec![0.0f32; intermediate];
+    for i in 0..intermediate {
+        let g = gate_out[i];
+        let silu = g / (1.0 + (-g).exp());
+        ffn_hidden[i] = silu * up_out[i];
+    }
+
+    // down(ffn_hidden): [intermediate] → [hidden], Q6_K weight.
+    let result = fused_q6k_parallel_matvec(down_bytes, &ffn_hidden, intermediate, hidden_dim)?;
+    Ok(result)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/aprender-serve/tests/qwen3_moe_load_layer.rs
+++ b/crates/aprender-serve/tests/qwen3_moe_load_layer.rs
@@ -19,7 +19,9 @@
 //! with a printed `skipped` line — matching the `f_tnv_002d` and
 //! `f_qw3_moe_load_002b` patterns. Fixture-absent ≠ defect.
 
-use realizar::gguf::qwen3_moe_load::{expert_byte_slice, load_qwen3_moe_layer};
+use realizar::gguf::qwen3_moe_load::{
+    expert_byte_slice, expert_swiglu_quantized, load_qwen3_moe_layer,
+};
 use realizar::gguf::GGUFModel;
 
 use std::path::Path;
@@ -256,5 +258,97 @@ fn f_qw3_moe_c220_001_expert_byte_slice_partitions_live_gguf() {
         layer0.gate_exps.byte_size / n,
         layer0.up_exps.byte_size / n,
         layer0.down_exps.byte_size / n
+    );
+}
+
+/// M32c.2.2.1 falsifier — exercises `expert_swiglu_quantized` against the
+/// cached Qwen3-Coder GGUF. Proves that ONE expert's SwiGLU FFN evaluation
+/// (gate Q4_K + up Q4_K + SiLU * up + down Q6_K) returns a finite, non-zero
+/// `[hidden_dim]` vector — the per-expert kernel that `moe_forward_token`
+/// will compose in M32c.2.2.2.
+#[test]
+fn f_qw3_moe_c221_001_expert_swiglu_quantized_finite_output() {
+    let Some(gguf_path) = CANONICAL_QWEN3_CODER_GGUF_PATHS
+        .iter()
+        .find(|p| Path::new(p).exists())
+    else {
+        eprintln!("F-QW3-MOE-C221-001: skipped — no cached GGUF.");
+        return;
+    };
+
+    eprintln!("F-QW3-MOE-C221-001: per-expert SwiGLU on {gguf_path}");
+
+    let bytes = std::fs::read(gguf_path).expect("read GGUF bytes");
+    let model = GGUFModel::from_bytes(&bytes).expect("parse GGUF header");
+
+    let layer0 = load_qwen3_moe_layer(&model, &bytes, 0).expect("layer 0");
+
+    // Synthetic hidden state with mild magnitude (post-RMSNorm-shaped).
+    // Real forward feeds the layer's normed input here; for the per-expert
+    // kernel, any finite hidden vector exercises the full kernel chain.
+    let hidden: Vec<f32> = (0..EXPECTED_HIDDEN)
+        .map(|i| 0.01 * ((i as f32).sin()))
+        .collect();
+
+    // Expert 0 — first expert in the stacked tensor.
+    let out = expert_swiglu_quantized(
+        &hidden,
+        &layer0,
+        0,
+        EXPECTED_N_EXPERTS,
+        EXPECTED_INTERMEDIATE,
+        EXPECTED_HIDDEN,
+        &bytes,
+    )
+    .expect("F-QW3-MOE-C221-001: expert 0 SwiGLU should succeed");
+
+    assert_eq!(
+        out.len(),
+        EXPECTED_HIDDEN,
+        "F-QW3-MOE-C221-001: output dim must be hidden_dim"
+    );
+    assert!(
+        out.iter().all(|v| v.is_finite()),
+        "F-QW3-MOE-C221-001: all output elements must be finite (no NaN/Inf)"
+    );
+    let nonzero = out.iter().filter(|v| **v != 0.0).count();
+    assert!(
+        nonzero > EXPECTED_HIDDEN / 2,
+        "F-QW3-MOE-C221-001: at least half the output should be non-zero \
+         (got {nonzero}/{EXPECTED_HIDDEN}); else the kernel is trivially zeroing"
+    );
+
+    // Expert 1 — different selection should produce a measurably different output.
+    let out_e1 = expert_swiglu_quantized(
+        &hidden,
+        &layer0,
+        1,
+        EXPECTED_N_EXPERTS,
+        EXPECTED_INTERMEDIATE,
+        EXPECTED_HIDDEN,
+        &bytes,
+    )
+    .expect("F-QW3-MOE-C221-001: expert 1 SwiGLU should succeed");
+
+    let mut differs = false;
+    for i in 0..EXPECTED_HIDDEN.min(64) {
+        if (out[i] - out_e1[i]).abs() > 1e-6 {
+            differs = true;
+            break;
+        }
+    }
+    assert!(
+        differs,
+        "F-QW3-MOE-C221-001: expert 0 and expert 1 outputs must differ \
+         (else the slicer is aliasing or weights are degenerate)"
+    );
+
+    let out_l2: f32 = out.iter().map(|v| v * v).sum::<f32>().sqrt();
+    eprintln!(
+        "F-QW3-MOE-C221-001: PASS\n  out.len() = {}\n  ||out||_2 = {:.4}\n  \
+         out[0..5] = {:.4?}\n  diff vs expert 1 confirmed",
+        out.len(),
+        out_l2,
+        &out[..5]
     );
 }


### PR DESCRIPTION
## Summary
Per-expert SwiGLU FFN evaluation keeping weights quantized through the matmul (LAZY-FUSED-MATVEC, qwen3-moe-forward-v1 v1.1.0). Composes M32c.2.2.0's `expert_byte_slice` + the existing `fused_q4k_parallel_matvec` / `fused_q6k_parallel_matvec` row-major kernels into one expert's full contribution: `down(SiLU(gate(x)) ⊙ up(x))`.

## Live evidence (lambda-vector RTX 4090)

```
F-QW3-MOE-C221-001: PASS
  out.len() = 2048
  ||out||_2 = 0.0007
  out[0..5] = [-0.0000, -0.0000, 0.0000, -0.0000, 0.0000]
  diff vs expert 1 confirmed
```

The kernel exercises the full per-expert chain on real Qwen3-Coder-30B-A3B Q4_K/Q6_K weights: gate (Q4_K matmul → 768-dim) + up (Q4_K matmul → 768-dim) + SiLU * up + down (Q6_K matmul → 2048-dim). Output is finite, non-zero, and expert-distinguishing.

## Test plan
- [x] F-QW3-MOE-C221-001 falsifier passes (live 17.3 GB GGUF)
- [x] M32c.1 + M32c.2.2.0 regression tests still pass (4/4 in qwen3_moe_load_layer suite)
- [x] `cargo build --lib -p aprender-serve --features cuda` clean
- [ ] CI green

## Stage map
- M32a/b/c.1/c.2/c.2.1: ✅ merged
- M32c.2.2 dequant strategy v1.1.0: ✅ merged
- M32c.2.2.0 byte slicer: ✅ merged
- **M32c.2.2.1 per-expert SwiGLU (this PR)**
- M32c.2.2.2: replace MoE short-circuit with real forward → `apr run` produces tokens
- M32d: numerical parity vs llama.cpp / HF FP16 → flips contract DRAFT → ACTIVE_RUNTIME

🤖 Generated with [Claude Code](https://claude.com/claude-code)