### PR TITLE
feat(realizar): M32c.2.2.2.0 — moe_ffn_forward_layer: full single-layer MoE FFN dispatch

### DIFF
--- a/crates/aprender-serve/src/gguf/qwen3_moe_load.rs
+++ b/crates/aprender-serve/src/gguf/qwen3_moe_load.rs
@@ -280,6 +280,151 @@ pub fn expert_swiglu_quantized(
     Ok(result)
 }
 
+/// Full MoE FFN forward for ONE layer of a Qwen3-MoE model
+/// (M32c.2.2.2.0 — dispatch layer above per-expert SwiGLU).
+///
+/// Implements the full single-token MoE FFN block:
+/// `Σ_{e ∈ TopK(softmax(router@x), k)} renorm(weight_e) · SwiGLU_e(x)`
+/// per `moe-router-v1` + `moe-expert-dispatch-v1` + the LAZY-FUSED-MATVEC
+/// dequant strategy from `qwen3-moe-forward-v1` v1.1.0.
+///
+/// The router weight is read directly as F32 from the mmapped data
+/// (Qwen3-Coder-30B uses qtype=F32 for ffn_gate_inp; quantized routers
+/// would need a small extension here).
+///
+/// # Arguments
+/// * `hidden` — input post-RMSNorm hidden state, length == hidden_dim.
+/// * `layer` — the M32c.1 `Qwen3MoeQuantizedLayer`.
+/// * `num_experts` — total experts in stacked tensors (e.g. 128).
+/// * `num_experts_per_tok` — top-k selection (e.g. 8).
+/// * `intermediate` — per-expert intermediate dim (e.g. 768).
+/// * `hidden_dim` — model hidden dim (e.g. 2048).
+/// * `data` — file's mmapped byte slice.
+///
+/// # Returns
+/// `Vec<f32>` of length hidden_dim — the layer's MoE FFN output
+/// (caller adds to residual).
+///
+/// # Errors
+/// - Router tensor not F32 (extension point for future routers)
+/// - Slice/byte/dim mismatches propagated from sub-calls
+///
+/// # Note on shared expert
+/// Qwen3-Coder-30B-A3B does NOT use a shared expert; `moe_forward_token`
+/// in `gpu/scheduler/moe_dispatch.rs` handles models that do (e.g.
+/// Qwen3.5-MoE) via the `shared_*` tensor groups. This function is
+/// the routed-only variant and is correct for Qwen3-Coder-30B.
+#[allow(clippy::too_many_arguments)]
+pub fn moe_ffn_forward_layer(
+    hidden: &[f32],
+    layer: &Qwen3MoeQuantizedLayer,
+    num_experts: usize,
+    num_experts_per_tok: usize,
+    intermediate: usize,
+    hidden_dim: usize,
+    data: &[u8],
+) -> Result<Vec<f32>> {
+    use crate::error::RealizarError;
+
+    if hidden.len() != hidden_dim {
+        return Err(RealizarError::InvalidShape {
+            reason: format!(
+                "moe_ffn_forward_layer: hidden.len() = {} but hidden_dim = {}",
+                hidden.len(),
+                hidden_dim
+            ),
+        });
+    }
+
+    // ---- Router: read F32 weight, compute logits = router @ hidden ----
+    if layer.router.qtype != crate::gguf::types::GGUF_TYPE_F32 {
+        return Err(RealizarError::UnsupportedOperation {
+            operation: "moe_router_quantized_read".to_string(),
+            reason: format!(
+                "moe_ffn_forward_layer: router qtype = {} (not F32). Quantized router \
+                 not yet wired — Qwen3-Coder-30B uses F32 router so this is fine for it; \
+                 other Qwen3-MoE variants needing quantized router are M32 follow-up.",
+                layer.router.qtype
+            ),
+        });
+    }
+    let router_bytes = &data[layer.router.offset..layer.router.offset + layer.router.byte_size];
+    let expected_bytes = num_experts * hidden_dim * 4;
+    if router_bytes.len() != expected_bytes {
+        return Err(RealizarError::InvalidShape {
+            reason: format!(
+                "moe_ffn_forward_layer: router byte_size {} != expected {} \
+                 (num_experts {} × hidden_dim {} × 4)",
+                router_bytes.len(),
+                expected_bytes,
+                num_experts,
+                hidden_dim
+            ),
+        });
+    }
+    // Reinterpret router_bytes as &[f32]. Layout: [num_experts, hidden_dim] row-major.
+    // logits[e] = Σ_j router[e, j] * hidden[j].
+    let mut logits = vec![0.0f32; num_experts];
+    for e in 0..num_experts {
+        let row_off = e * hidden_dim * 4;
+        let mut sum = 0.0f32;
+        for j in 0..hidden_dim {
+            let b = row_off + j * 4;
+            let w = f32::from_le_bytes([
+                router_bytes[b],
+                router_bytes[b + 1],
+                router_bytes[b + 2],
+                router_bytes[b + 3],
+            ]);
+            sum += w * hidden[j];
+        }
+        logits[e] = sum;
+    }
+
+    // ---- Softmax (numerically stable) ----
+    let max_l = logits.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+    let mut probs: Vec<f32> = logits.iter().map(|&l| (l - max_l).exp()).collect();
+    let psum: f32 = probs.iter().sum();
+    if psum > 0.0 {
+        for p in &mut probs {
+            *p /= psum;
+        }
+    }
+
+    // ---- Top-k selection ----
+    let mut indexed: Vec<(usize, f32)> = probs.iter().copied().enumerate().collect();
+    indexed.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    let topk = &indexed[..num_experts_per_tok.min(num_experts)];
+
+    // ---- Renormalize selected ----
+    let topk_sum: f32 = topk.iter().map(|(_, w)| w).sum();
+    let topk_renorm: Vec<(usize, f32)> = if topk_sum > 0.0 {
+        topk.iter().map(|(i, w)| (*i, w / topk_sum)).collect()
+    } else {
+        let n = topk.len();
+        topk.iter().map(|(i, _)| (*i, 1.0 / n as f32)).collect()
+    };
+
+    // ---- Per-expert SwiGLU + weighted accumulate ----
+    let mut output = vec![0.0f32; hidden_dim];
+    for (expert_id, weight) in topk_renorm {
+        let expert_out = expert_swiglu_quantized(
+            hidden,
+            layer,
+            expert_id,
+            num_experts,
+            intermediate,
+            hidden_dim,
+            data,
+        )?;
+        for i in 0..hidden_dim {
+            output[i] += weight * expert_out[i];
+        }
+    }
+
+    Ok(output)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/aprender-serve/tests/qwen3_moe_load_layer.rs
+++ b/crates/aprender-serve/tests/qwen3_moe_load_layer.rs
@@ -20,7 +20,7 @@
 //! `f_qw3_moe_load_002b` patterns. Fixture-absent ≠ defect.
 
 use realizar::gguf::qwen3_moe_load::{
-    expert_byte_slice, expert_swiglu_quantized, load_qwen3_moe_layer,
+    expert_byte_slice, expert_swiglu_quantized, load_qwen3_moe_layer, moe_ffn_forward_layer,
 };
 use realizar::gguf::GGUFModel;
 
@@ -347,6 +347,65 @@ fn f_qw3_moe_c221_001_expert_swiglu_quantized_finite_output() {
     eprintln!(
         "F-QW3-MOE-C221-001: PASS\n  out.len() = {}\n  ||out||_2 = {:.4}\n  \
          out[0..5] = {:.4?}\n  diff vs expert 1 confirmed",
+        out.len(),
+        out_l2,
+        &out[..5]
+    );
+}
+
+/// M32c.2.2.2.0 falsifier — exercises `moe_ffn_forward_layer` against the
+/// cached Qwen3-Coder GGUF. This is the FULL single-layer MoE FFN dispatch:
+/// router (F32 matmul) + softmax + top-8 + renormalize + per-expert SwiGLU
+/// + weighted sum. The output is the layer's MoE contribution before the
+/// residual addition.
+const EXPECTED_K: usize = 8;
+
+#[test]
+fn f_qw3_moe_c2220_001_full_layer_forward_finite_output() {
+    let Some(gguf_path) = CANONICAL_QWEN3_CODER_GGUF_PATHS
+        .iter()
+        .find(|p| Path::new(p).exists())
+    else {
+        eprintln!("F-QW3-MOE-C2220-001: skipped — no cached GGUF.");
+        return;
+    };
+
+    eprintln!("F-QW3-MOE-C2220-001: full layer 0 MoE FFN forward on {gguf_path}");
+
+    let bytes = std::fs::read(gguf_path).expect("read GGUF bytes");
+    let model = GGUFModel::from_bytes(&bytes).expect("parse GGUF header");
+
+    let layer0 = load_qwen3_moe_layer(&model, &bytes, 0).expect("layer 0");
+
+    let hidden: Vec<f32> = (0..EXPECTED_HIDDEN)
+        .map(|i| 0.1 * ((i as f32 * 0.7).sin()))
+        .collect();
+
+    let out = moe_ffn_forward_layer(
+        &hidden,
+        &layer0,
+        EXPECTED_N_EXPERTS,
+        EXPECTED_K,
+        EXPECTED_INTERMEDIATE,
+        EXPECTED_HIDDEN,
+        &bytes,
+    )
+    .expect("F-QW3-MOE-C2220-001: full layer 0 forward should succeed");
+
+    assert_eq!(out.len(), EXPECTED_HIDDEN);
+    assert!(
+        out.iter().all(|v| v.is_finite()),
+        "F-QW3-MOE-C2220-001: all output elements must be finite"
+    );
+    let nonzero = out.iter().filter(|v| **v != 0.0).count();
+    assert!(
+        nonzero > EXPECTED_HIDDEN / 2,
+        "F-QW3-MOE-C2220-001: at least half the output should be non-zero (got {nonzero}/{EXPECTED_HIDDEN})"
+    );
+
+    let out_l2: f32 = out.iter().map(|v| v * v).sum::<f32>().sqrt();
+    eprintln!(
+        "F-QW3-MOE-C2220-001: PASS\n  out.len() = {}\n  ||out||_2 = {:.6}\n  out[0..5] = {:.6?}",
         out.len(),
         out_l2,
         &out[..5]


### PR DESCRIPTION
## Summary
Composes M32c.2.2.0's `expert_byte_slice` + M32c.2.2.1's `expert_swiglu_quantized` into the FULL single-layer MoE FFN block: F32 router @ hidden → softmax → top-k → renormalize → expert_swiglu × weight (per selected expert) → sum.

## Live evidence (lambda-vector RTX 4090)

```
F-QW3-MOE-C2220-001: PASS
  out.len() = 2048
  ||out||_2 = 0.032122
  out[0..5] = [-0.000310, 0.001133, -0.000075, -0.000454, -0.000459]
```

Real MoE forward output from layer 0 of Qwen3-Coder-30B-A3B Q4_K_M GGUF: 128-expert router, top-8 selection, per-expert SwiGLU through fused Q4_K (gate/up) + Q6_K (down) kernels, weighted sum.

## Stage map
- M32a/b/c.1/c.2/c.2.1: ✅ merged
- M32c.2.2 dequant strategy v1.1.0: ✅ merged
- M32c.2.2.0 byte slicer: ✅ merged
- M32c.2.2.1 per-expert SwiGLU: ✅ merged
- **M32c.2.2.2.0 full-layer dispatch (this PR)**
- M32c.2.2.2.1: replace gguf_gpu_generate.rs short-circuit with real forward → `apr run` produces tokens
- M32d: numerical parity vs llama.cpp / HF FP16 → flips contract DRAFT → ACTIVE_RUNTIME

## Test plan
- [x] F-QW3-MOE-C2220-001 live falsifier (17.3 GB GGUF, full layer 0 forward)
- [x] M32c.1/M32c.2.2.0/M32c.2.2.1 regressions still pass (5/5 in suite)
- [x] `cargo build --lib -p aprender-serve --features cuda` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)