### PR TITLE
feat(realizar): M32c.2.2.2.1.3 — apr run produces tokens on Qwen3-Coder (FALSIFY-QW3-MOE-FORWARD-003 LIVE)

### DIFF
--- a/crates/aprender-serve/src/gguf/qwen3_moe_load.rs
+++ b/crates/aprender-serve/src/gguf/qwen3_moe_load.rs
@@ -247,7 +247,6 @@ pub fn expert_swiglu_quantized(
     data: &[u8],
 ) -> Result<Vec<f32>> {
     use crate::error::RealizarError;
-    use crate::quantize::{fused_q4k_parallel_matvec, fused_q6k_parallel_matvec};
 
     if hidden.len() != hidden_dim {
         return Err(RealizarError::InvalidShape {
@@ -263,9 +262,22 @@ pub fn expert_swiglu_quantized(
     let up_bytes = expert_byte_slice(&layer.up_exps, data, expert_id, num_experts)?;
     let down_bytes = expert_byte_slice(&layer.down_exps, data, expert_id, num_experts)?;
 
-    // gate(x) and up(x): each [hidden] → [intermediate], Q4_K weight.
-    let gate_out = fused_q4k_parallel_matvec(gate_bytes, hidden, hidden_dim, intermediate)?;
-    let up_out = fused_q4k_parallel_matvec(up_bytes, hidden, hidden_dim, intermediate)?;
+    // gate(x) and up(x): qtype-aware dispatch (Q4_K_M GGUFs mix Q4_K/Q6_K
+    // across layers; some layers' gate/up_exps are Q6_K instead of Q4_K).
+    let gate_out = matvec_for_qtype(
+        layer.gate_exps.qtype,
+        gate_bytes,
+        hidden,
+        hidden_dim,
+        intermediate,
+    )?;
+    let up_out = matvec_for_qtype(
+        layer.up_exps.qtype,
+        up_bytes,
+        hidden,
+        hidden_dim,
+        intermediate,
+    )?;
 
     // SwiGLU: SiLU(gate) ⊙ up. SiLU(x) = x * sigmoid(x) = x / (1 + exp(-x)).
     let mut ffn_hidden = vec![0.0f32; intermediate];
@@ -275,9 +287,42 @@ pub fn expert_swiglu_quantized(
         ffn_hidden[i] = silu * up_out[i];
     }
 
-    // down(ffn_hidden): [intermediate] → [hidden], Q6_K weight.
-    let result = fused_q6k_parallel_matvec(down_bytes, &ffn_hidden, intermediate, hidden_dim)?;
+    // down(ffn_hidden): qtype-aware dispatch (Q4_K_M mixes types per layer).
+    let result = matvec_for_qtype(
+        layer.down_exps.qtype,
+        down_bytes,
+        &ffn_hidden,
+        intermediate,
+        hidden_dim,
+    )?;
     Ok(result)
+}
+
+/// Dispatch matvec to the right quantization kernel based on qtype.
+/// Supports Q4_K (12) and Q6_K (14) — the two K-quants used by Qwen3-Coder
+/// Q4_K_M expert tensors. Other quantizations error out.
+fn matvec_for_qtype(
+    qtype: u32,
+    weight_data: &[u8],
+    activations: &[f32],
+    in_dim: usize,
+    out_dim: usize,
+) -> Result<Vec<f32>> {
+    use crate::error::RealizarError;
+    use crate::gguf::types::{GGUF_TYPE_Q4_K, GGUF_TYPE_Q6_K};
+    use crate::quantize::{fused_q4k_parallel_matvec, fused_q6k_parallel_matvec};
+    match qtype {
+        GGUF_TYPE_Q4_K => fused_q4k_parallel_matvec(weight_data, activations, in_dim, out_dim),
+        GGUF_TYPE_Q6_K => fused_q6k_parallel_matvec(weight_data, activations, in_dim, out_dim),
+        other => Err(RealizarError::UnsupportedOperation {
+            operation: "moe_expert_matvec".to_string(),
+            reason: format!(
+                "MoE expert tensor qtype {other} not supported. Qwen3-Coder Q4_K_M uses \
+                 Q4_K (12) and Q6_K (14) — caller must extend matvec_for_qtype for other \
+                 quantizations."
+            ),
+        }),
+    }
 }
 
 /// Full MoE FFN forward for ONE layer of a Qwen3-MoE model

--- a/crates/aprender-serve/src/infer/inference_result.rs
+++ b/crates/aprender-serve/src/infer/inference_result.rs
@@ -216,8 +216,23 @@ fn run_gguf_inference(
             ..Default::default()
     };
 
+    // M32c.2.2.2.1.3: dispatch qwen3_moe to the parallel MoE inference path
+    // (M32c.2.2.2.1.2's run_qwen3_moe_generate). The dense path goes through
+    // run_gguf_generate as before. This replaces M32c.2.1's
+    // gguf_gpu_generate.rs short-circuit with an actual forward pass.
     let infer_start = Instant::now();
-    let (tokens, used_gpu) = run_gguf_generate(model, &input_tokens, &gen_config, config)?;
+    let canonical_arch = crate::tensor_names::normalize_architecture(&model.config.architecture);
+    let (tokens, used_gpu) = if canonical_arch == "qwen3_moe" {
+        let tokens = crate::infer::qwen3_moe_generate::run_qwen3_moe_generate(
+            &mapped,
+            &model,
+            &input_tokens,
+            &gen_config,
+        )?;
+        (tokens, false) // CPU-only path; GPU MoE wiring is M32d follow-up
+    } else {
+        run_gguf_generate(model, &input_tokens, &gen_config, config)?
+    };
     let inference_ms = infer_start.elapsed().as_secs_f64() * 1000.0;
 
     let generated_tokens = &tokens[input_token_count..];


### PR DESCRIPTION
## 🎉 apr run produces tokens on Qwen3-Coder-30B-A3B-Instruct GGUF

This PR closes the M32 chain's main goal. `apr run` on the cached 17.3 GB GGUF now emits a real token via 48 layers of MoE forward inference.

## Live evidence (lambda-vector RTX 4090)

```
$ apr run ~/.cache/pacha/models/2b88b180a790988f.gguf \
    --prompt "fresh-prompt-$(date +%s)" --max-tokens 1
[BOS-FALLBACK] No tokenizer.ggml.bos_token_id in GGUF
[BOS-FALLBACK] No tokenizer.ggml.bos_token_id in GGUF

Output:
aaaaaaaa

Completed in 10.78s
```

## What this PR ships
1. **Dispatch flip** in `run_gguf_inference`: for qwen3_moe arch, routes to `run_qwen3_moe_generate` (M32c.2.2.2.1.2) instead of `run_gguf_generate`. Replaces M32c.2.1's gguf_gpu_generate.rs short-circuit.
2. **Qtype-aware matvec dispatch** in `expert_swiglu_quantized`: Q4_K_M GGUFs mix Q4_K and Q6_K across layers AND within a single layer's gate/up/down trio. Hardcoded Q6_K for down failed live with "Q6_K weight data too small: have 884736" on layer 34 (which uses Q4_K for down). Fix: new `matvec_for_qtype()` helper dispatches based on actual `tensor.qtype`.

## Contract status
qwen3-moe-forward-v1 v1.2.0 falsifications:
- ✅ FALSIFY-QW3-MOE-FORWARD-001: baseline failure pinned (M32a)
- ✅ FALSIFY-QW3-MOE-FORWARD-002: structured load refusal (M32b)
- ✅ **FALSIFY-QW3-MOE-FORWARD-003: apr run produces tokens (THIS PR)**
- ⏳ FALSIFY-QW3-MOE-FORWARD-004: numerical parity (M32d)

Token quality is poor (greedy + no proper BOS + no KV cache) but the forward path WORKS end-to-end. Quality + parity is M32d.

🤖 Generated with [Claude Code](https://claude.com/claude-code)