### PR TITLE
contract(qwen3-moe-forward-v1): v1.2.0 → v1.3.0 — M32d.0 parity strategy decision

### DIFF
--- a/contracts/qwen3-moe-forward-v1.yaml
+++ b/contracts/qwen3-moe-forward-v1.yaml
@@ -1,8 +1,105 @@
 metadata:
-  version: 1.2.0
+  version: 1.3.0
   created: '2026-04-28'
   author: PAIML Engineering
   amendment_history:
+    - version: 1.3.0
+      date: '2026-04-29'
+      kind: amendment
+      title: 'M32d parity strategy decision (replaces aspirational llama-cli --logit-output)'
+      description: |
+        M32a/b/c/c.2.2.* all SHIPPED on aprender main; FALSIFY-QW3-MOE-FORWARD-003
+        is LIVE-DISCHARGED on lambda-vector RTX 4090: `apr run` against the
+        cached 17.3 GB Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf emits real
+        tokens end-to-end (PR #1126 squash a902eea93; live falsifier pinned
+        in CI at PR #1127 squash 0392b1843).
+
+        M32d is the last gate before flipping this contract DRAFT →
+        ACTIVE_RUNTIME. The original test text in
+        FALSIFY-QW3-MOE-FORWARD-004 references
+        `llama-cli ... --verbose --logit-output` as the reference path
+        for full-vector logit dump. **That flag does not exist** in
+        stock llama.cpp v7746 (`llama-cli --help` exposes `--logit-bias`
+        for input bias but no logit-output flag). Three reference paths
+        were considered:
+
+        (P1) HuggingFace transformers FP16 (canonical FP16 ground truth)
+             - Path: uv-run Python script loading the HF Qwen3-Coder
+               weights at FP16 (or BF16 if FP16 unavailable) and
+               dumping `model(input_ids).logits[0, -1, :]` to a npy
+               or json fixture.
+             - Pros: standard, exposed via the transformers public API;
+               full 151936-dim logit vector available; matches CLAUDE.md
+               ground-truth verification checklist (HF as FP32/FP16
+               reference).
+             - Cons: requires network or local HF cache for FP16 weights
+               (~60GB for the un-quantized 30B model — but Qwen3-Coder
+               ships a 30B-A3B-FP16 variant, so disk-feasible). One-time
+               fixture-generation cost (~minutes on RTX 4090).
+             - Cosine-similarity tolerance: > 0.99 (per AC_QW3_MOE_005).
+
+        (P2) llama.cpp Q4_K (same-quantization sanity check)
+             - Path: patch llama.cpp to dump logits at decode step 0,
+               OR use the llama-server REST API's logprobs:N field.
+             - Pros: same quantization as our Q4_K_M dispatch path —
+               isolates "is the kernel correct?" from "is the
+               dequantization correct?".
+             - Cons: stock llama.cpp does not expose full-vector logit
+               dump; needs a patched build OR a stack of top-N logprobs
+               (256 deep; not a full 151936 vector). With top-N only,
+               we can do top-1 argmax-exact match instead of cosine on
+               the full vector.
+             - Sanity tolerance: top-1 argmax must match.
+
+        (P3) Patched llama.cpp full-vector logit dump
+             - Path: fork llama.cpp, add a `--logit-output FILE` flag
+               that writes the full logit tensor to disk at decode 0.
+             - Pros: matches the original FALSIFY-QW3-MOE-FORWARD-004
+               text; cleanest cross-implementation comparison.
+             - Cons: out-of-tree patch on llama.cpp; maintenance
+               burden; not reproducible on user machines without a
+               build dance.
+
+        DECISION: P1 (HF FP16) as PRIMARY reference; P2 (top-1 argmax
+        from llama-cli stdout) as SECONDARY sanity check. P3 rejected
+        as too costly for the discharge value.
+
+        Rationale:
+          * P1 fully discharges AC_QW3_MOE_005 (cosine > 0.99 vs HF
+            FP16) — the original strict gate.
+          * P2 partially discharges AC_QW3_MOE_001 (Q4_K tolerance) at
+            the argmax-exact level — sufficient for CI gate, since
+            cosine vs HF FP16 already covers the full-vector case.
+          * P1+P2 together cover both "is the math right?" (P1) and
+            "is the quantization handled correctly?" (P2) without
+            requiring an out-of-tree llama.cpp patch.
+
+        Staged implementation sub-slices for M32d:
+
+          * M32d.0 — THIS contract amendment (parity strategy).
+          * M32d.1 — Author the HF FP16 fixture-generation script
+            (`scripts/generate_qwen3_moe_fp16_logits.py`) using
+            `uv run --with torch --with transformers`. One-time run
+            on lambda-vector dumps `tests/fixtures/qwen3_moe_fp16_logits_pos0.json`
+            for prompt "What is 2+2?".
+          * M32d.2 — Author `crates/aprender-serve/tests/qwen3_moe_parity.rs`
+            (F-QW3-MOE-PARITY-001) computing cosine similarity between
+            apr-CPU-forward logits[0] and the FP16 fixture; assert
+            > 0.99. Marked `#[ignore]` (heavy; needs cached GGUF +
+            fixture).
+          * M32d.3 — Author secondary sanity test
+            (F-QW3-MOE-PARITY-002): runs `llama-cli` as a subprocess
+            on the same prompt + GGUF, parses stdout to extract the
+            top-1 sampled token, asserts apr's argmax-token equals
+            llama.cpp's top-1.
+          * M32d.4 — Flip contract DRAFT → ACTIVE_RUNTIME; bump
+            qwen3-moe-forward-v1 v1.3.0 → v1.4.0 (or v2.0.0 if status
+            transitions warrant a major bump per pv conventions).
+
+        FALSIFY-QW3-MOE-FORWARD-004 is updated below: `test:` field
+        rewritten to reference the HF FP16 fixture path; `if_fails:`
+        clarifies the HF-vs-Q4K divergence diagnostic order.
+
     - version: 1.2.0
       date: '2026-04-29'
       kind: amendment
@@ -165,8 +262,13 @@ metadata:
 
 kind: KernelContract
 name: qwen3-moe-forward
-version: "1.2.0"
+version: "1.3.0"
 status: DRAFT   # SCAFFOLD — flips to ACTIVE_RUNTIME at end of M32d (parity discharge).
+                # v1.3.0 (M32d.0) records the parity strategy decision:
+                # HF FP16 (primary, cosine > 0.99) + llama.cpp top-1 argmax
+                # (secondary sanity check). Replaces aspirational
+                # `llama-cli --logit-output` reference path which does not
+                # exist in stock llama.cpp v7746.
                 # v1.2.0 (2026-04-29): adds M32c.2.2.2.1 integration strategy decision —
                 # parallel `run_qwen3_moe_generate` function chosen over (A) 99-site
                 # OwnedQuantizedModel field-add and (C) wrapper struct. Implementation
@@ -338,13 +440,40 @@ implementation_stages:
 - id: M32d
   status: PENDING
   description: |
-    Numerical parity vs ground truth. Compare apr CPU forward
-    logits against llama.cpp Q4_K (primary) and HF transformers
-    FP16 (secondary) per CLAUDE.md ground-truth verification
-    workflow. Falsifier: F_QW3_MOE_FORWARD_004. After M32d this
-    contract flips DRAFT → ACTIVE_RUNTIME and unblocks the
-    companion-repo FALSIFY-CCPA-013 measured tool-dispatch parity
-    score.
+    Numerical parity vs ground truth. Reference-path priority
+    revised at v1.3.0 (M32d.0):
+      * PRIMARY:   HF transformers FP16 (cosine > 0.99 on full
+                   151936-dim logit vector)
+      * SECONDARY: llama.cpp top-1 argmax (sanity match against
+                   same Q4_K_M GGUF, greedy decode)
+    Falsifier: FALSIFY-QW3-MOE-FORWARD-004 (rewritten at v1.3.0).
+    After M32d this contract flips DRAFT → ACTIVE_RUNTIME and
+    unblocks the companion-repo FALSIFY-CCPA-013 measured
+    tool-dispatch parity score.
+
+    Sub-slices (each its own PR):
+
+      * M32d.0 — Contract amendment recording the parity strategy
+                 decision (THIS amendment, v1.2.0 → v1.3.0).
+      * M32d.1 — Author `scripts/generate_qwen3_moe_fp16_logits.py`
+                 + run it once on lambda-vector to produce
+                 `crates/aprender-serve/tests/fixtures/qwen3_moe_fp16_logits_pos0.json`
+                 (151936-dim float vector at position 0 for
+                 prompt "What is 2+2?", HF FP16).
+      * M32d.2 — Author primary parity test
+                 `f_qw3_moe_parity_001_cosine_vs_hf_fp16` in
+                 `crates/aprender-serve/tests/qwen3_moe_parity.rs`.
+                 Computes cosine similarity vs the M32d.1 fixture;
+                 asserts > 0.99. `#[ignore]` (heavy).
+      * M32d.3 — Author secondary sanity test
+                 `f_qw3_moe_parity_002_argmax_vs_llama_cpp`. Runs
+                 llama-cli as subprocess on same GGUF + prompt;
+                 asserts apr's argmax == llama.cpp's top-1 token.
+                 `#[ignore]` (heavy; needs llama-cli on PATH).
+      * M32d.4 — Flip contract DRAFT → ACTIVE_RUNTIME; bump
+                 v1.3.0 → v2.0.0 (status transition is a major bump
+                 per pv conventions). Update companion-repo POC
+                 spec snapshot to record FALSIFY-CCPA-013 unblock.
   unblocks_obligations: [AC_QW3_MOE_001, AC_QW3_MOE_005]
 
 falsification_tests:
@@ -397,26 +526,66 @@ falsification_tests:
     branching at the dispatch site reaches `moe_forward_token`.
 
 - id: FALSIFY-QW3-MOE-FORWARD-004
-  rule: 'M32d discharges numerical parity vs llama.cpp Q4_K reference'
+  rule: 'M32d discharges numerical parity vs HF FP16 + llama.cpp argmax'
   prediction: |
-    cosine_similarity(apr_logits[0], llama_cpp_logits[0]) > 0.99
-    on prompt "What is 2+2?" with greedy decode (top_k=1).
+    Two-axis discharge:
+      (a) cosine_similarity(apr_logits[0], hf_fp16_logits[0]) > 0.99
+          on prompt "What is 2+2?" — greedy decode (top_k=1) at
+          position 0 of the prompt's first generation step.
+      (b) argmax(apr_logits[0]) == llama_cpp_top1_token on the same
+          prompt + same GGUF + greedy sampler.
+    Both must hold for the contract to flip DRAFT → ACTIVE_RUNTIME.
   test: |
-    cargo test -p aprender-serve --test qwen3_moe_parity \
-        -- --include-ignored
-    Compares aprender CPU forward logits at position 0 against
-    llama.cpp's `llama-cli -m <gguf> -p "What is 2+2?" -n 1
-    --verbose --logit-output` parsed reference.
+    Pre-step (one-time, M32d.1):
+      uv run --with torch --with transformers \
+          scripts/generate_qwen3_moe_fp16_logits.py \
+          --prompt "What is 2+2?" \
+          --output crates/aprender-serve/tests/fixtures/qwen3_moe_fp16_logits_pos0.json
+      Loads HF Qwen3-Coder-30B-A3B-Instruct (FP16) on RTX 4090, runs
+      one greedy decode step, dumps the 151936-dim logit vector at
+      position 0 to a JSON file.
+
+    Primary gate (M32d.2 — cosine vs HF FP16):
+      cargo test -p aprender-serve --test qwen3_moe_parity \
+          f_qw3_moe_parity_001_cosine_vs_hf_fp16 \
+          -- --ignored --nocapture
+      Loads the cached 17.3 GB Qwen3-Coder GGUF, runs apr-CPU forward
+      via OwnedQuantizedModel::forward_qwen3_moe on the same prompt,
+      loads the FP16 fixture, computes cosine similarity, asserts > 0.99.
+
+    Secondary sanity (M32d.3 — argmax vs llama.cpp):
+      cargo test -p aprender-serve --test qwen3_moe_parity \
+          f_qw3_moe_parity_002_argmax_vs_llama_cpp \
+          -- --ignored --nocapture
+      Runs `llama-cli -m <gguf> -p "What is 2+2?" -n 1 --top-k 1
+      --temp 0.0 --seed 0` as a subprocess, parses stdout to extract
+      the single emitted token, asserts == apr argmax.
   if_fails: |
-    Numerical divergence — investigate per CLAUDE.md ground-truth
-    verification checklist (embedding → RMSNorm → attention →
-    FFN → final logits). Quantization tolerance is ±5%
-    element-wise / <1% L2 for Q4_K.
+    Diagnostic order (per CLAUDE.md ground-truth verification checklist):
+
+    1. If (a) fails (cosine ≤ 0.99 vs HF FP16):
+       - Numerical divergence in the math itself, NOT just quantization.
+       - Investigate layer-by-layer: embedding (Q4_K embed token vs
+         FP16 embed token) → RMSNorm → attention QKV → RoPE → causal
+         attention → FFN router → per-expert SwiGLU → lm_head.
+       - Tolerance budgets per CLAUDE.md: ±5% element-wise / <1% L2
+         for Q4_K layers; ±0.1% for FP16-equivalent layers.
+
+    2. If (a) passes but (b) fails:
+       - Math is correct (cosine > 0.99); divergence is in the
+         sampler or in dropout/seed handling. Check that
+         apr's greedy_argmax matches llama.cpp's --top-k 1
+         --temp 0.0 deterministic path.
+
+    3. If both fail:
+       - Catastrophic divergence; rerun M32c.2.2.2.1.* falsifiers
+         to confirm forward path is still emitting (not a
+         regression in the M32c chain).
 
 cross_repo_references:
 - repo: paiml/claude-code-parity-apr
   contract: claude-code-parity-apr-v1
-  current_version: "1.19.0"
+  current_version: "1.20.0"
   relation: |
     The companion-repo POC's measured tool-dispatch parity gate
     (FALSIFY-CCPA-013) is unblocked by M32d shipping. That POC


### PR DESCRIPTION
## Summary

Records the M32d parity strategy decision in `qwen3-moe-forward-v1`
amendment history. **No code change**; contract amendment only.

The original FALSIFY-QW3-MOE-FORWARD-004 referenced
`llama-cli ... --verbose --logit-output` as the reference path
for full-vector logit dump. That flag does not exist in stock
llama.cpp v7746. M32d cannot proceed without picking an
actually-existing reference path.

## Decision

**PRIMARY** (full-vector cosine > 0.99 per AC_QW3_MOE_005):
HuggingFace transformers FP16 via `uv run --with torch --with transformers`
running `scripts/generate_qwen3_moe_fp16_logits.py`. Dumps the
full 151936-dim logit vector at position 0 for prompt
"What is 2+2?" to a JSON fixture.

**SECONDARY** (top-1 argmax sanity):
`llama-cli -m <gguf> -p "..." -n 1 --top-k 1 --temp 0.0 --seed 0`
as subprocess; asserts apr's argmax == llama.cpp's top-1 token.

**REJECTED**: patched llama.cpp full-vector logit dump
(out-of-tree patch maintenance burden too high).

## M32d sub-slice plan (each its own PR)

| Slice | Deliverable |
|---|---|
| M32d.0 | **THIS PR** — contract amendment |
| M32d.1 | `scripts/generate_qwen3_moe_fp16_logits.py` + one-time fixture generation on lambda-vector |
| M32d.2 | `f_qw3_moe_parity_001_cosine_vs_hf_fp16` test (primary gate) |
| M32d.3 | `f_qw3_moe_parity_002_argmax_vs_llama_cpp` test (secondary sanity) |
| M32d.4 | Flip contract DRAFT → ACTIVE_RUNTIME (v1.3.0 → v2.0.0); update companion-repo POC spec to record FALSIFY-CCPA-013 unblock |

## Test plan

- [x] `pv validate contracts/qwen3-moe-forward-v1.yaml` — 0 errors, 0 warnings
- [ ] CI ci/gate green

🤖 Generated with [Claude Code](https://claude.com/claude-code)