### PR TITLE
feat(aprender-serve): apr-cli-trace-save-tensor-v1 output path helpers

### DIFF
--- a/crates/aprender-serve/src/inference_trace/mod.rs
+++ b/crates/aprender-serve/src/inference_trace/mod.rs
@@ -22,6 +22,7 @@
 //! ```
 
 pub mod save_tensor;
+pub mod save_tensor_paths;
 
 use std::collections::HashSet;
 use std::path::PathBuf;

--- a/crates/aprender-serve/src/inference_trace/save_tensor_paths.rs
+++ b/crates/aprender-serve/src/inference_trace/save_tensor_paths.rs
@@ -1,0 +1,196 @@
+//! Output path helpers for `apr trace --save-tensor`.
+//!
+//! Contract: [`contracts/apr-cli-trace-save-tensor-v1.yaml`] v1.0.0 (PROPOSED).
+//!
+//! ## Layout (per contract `cli_signature` invariants)
+//!
+//! Per-layer stages are written under `<DIR>/layer-<N>/<STAGE>.bin`; whole-
+//! model stages (those marked with the [`super::save_tensor::WHOLE_MODEL_LAYER`]
+//! sentinel — `final_norm`, `lm_head`) are written directly under
+//! `<DIR>/<STAGE>.bin` with no `layer-<N>` segment.
+//!
+//! This module is the layout primitive that the future `apr trace
+//! --save-tensor` CLI implementation calls before invoking the byte writer
+//! in [`super::save_tensor`]. Keeping the path-building rules pure (no I/O,
+//! no model state) lets `apr diff --values` use the same helper to *find*
+//! files, so the writer and reader cannot drift apart.
+
+use std::path::{Path, PathBuf};
+
+use super::save_tensor::WHOLE_MODEL_LAYER;
+
+/// Build the output path for a single save-tensor file.
+///
+/// Pure function — no I/O, does not touch the filesystem.
+///
+/// - `dir`: the `--output` directory passed to `apr trace --save-tensor`.
+/// - `layer`: per-layer stage's decoder layer index, OR
+///   [`WHOLE_MODEL_LAYER`] for whole-model stages.
+/// - `stage_name`: the stage's canonical name from the contract
+///   `cli_signature` enumeration (e.g. `"ffn_gate"`, `"final_norm"`). The
+///   `.bin` extension is appended here.
+///
+/// # Examples
+///
+/// ```
+/// # use realizar::inference_trace::save_tensor_paths::output_path;
+/// # use realizar::inference_trace::save_tensor::WHOLE_MODEL_LAYER;
+/// # use std::path::PathBuf;
+/// // Per-layer stage:
+/// assert_eq!(
+///     output_path(&PathBuf::from("trace_out"), 3, "ffn_gate"),
+///     PathBuf::from("trace_out/layer-3/ffn_gate.bin"),
+/// );
+/// // Whole-model stage:
+/// assert_eq!(
+///     output_path(&PathBuf::from("trace_out"), WHOLE_MODEL_LAYER, "lm_head"),
+///     PathBuf::from("trace_out/lm_head.bin"),
+/// );
+/// ```
+#[must_use]
+pub fn output_path(dir: &Path, layer: u32, stage_name: &str) -> PathBuf {
+    let file_name = format!("{stage_name}.bin");
+    if layer == WHOLE_MODEL_LAYER {
+        dir.join(file_name)
+    } else {
+        dir.join(format!("layer-{layer}")).join(file_name)
+    }
+}
+
+/// Create the output parent directory for a save-tensor file if it does not
+/// already exist.
+///
+/// Per-layer: ensures `<dir>/layer-<N>` exists.
+/// Whole-model: ensures `<dir>` exists.
+///
+/// `--output DIR is created if missing; contents are NOT auto-cleaned`
+/// per the contract. This helper performs only the create step.
+///
+/// # Errors
+///
+/// Forwards any [`std::io::Error`] from [`std::fs::create_dir_all`].
+pub fn ensure_layer_dir(dir: &Path, layer: u32) -> std::io::Result<()> {
+    if layer == WHOLE_MODEL_LAYER {
+        std::fs::create_dir_all(dir)
+    } else {
+        std::fs::create_dir_all(dir.join(format!("layer-{layer}")))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn output_path_per_layer_layer_zero() {
+        let p = output_path(Path::new("trace_out"), 0, "embedding");
+        assert_eq!(p, PathBuf::from("trace_out/layer-0/embedding.bin"));
+    }
+
+    #[test]
+    fn output_path_per_layer_arbitrary() {
+        let p = output_path(Path::new("trace_out"), 3, "ffn_gate");
+        assert_eq!(p, PathBuf::from("trace_out/layer-3/ffn_gate.bin"));
+    }
+
+    #[test]
+    fn output_path_whole_model_no_layer_segment() {
+        let p = output_path(Path::new("trace_out"), WHOLE_MODEL_LAYER, "lm_head");
+        assert_eq!(p, PathBuf::from("trace_out/lm_head.bin"));
+        let p = output_path(Path::new("trace_out"), WHOLE_MODEL_LAYER, "final_norm");
+        assert_eq!(p, PathBuf::from("trace_out/final_norm.bin"));
+    }
+
+    #[test]
+    fn output_path_absolute_dir() {
+        let p = output_path(Path::new("/tmp/trace"), 5, "attention");
+        assert_eq!(p, PathBuf::from("/tmp/trace/layer-5/attention.bin"));
+    }
+
+    #[test]
+    fn output_path_layer_max_minus_one_is_per_layer() {
+        // u32::MAX is the WHOLE_MODEL_LAYER sentinel; the largest valid
+        // per-layer index is u32::MAX - 1.
+        let edge = u32::MAX - 1;
+        let p = output_path(Path::new("d"), edge, "ffn_silu");
+        assert_eq!(p, PathBuf::from(format!("d/layer-{edge}/ffn_silu.bin")));
+    }
+
+    #[test]
+    fn output_path_nested_relative_dir() {
+        let p = output_path(Path::new("./out/run-0042"), 12, "qkv_matmul");
+        assert_eq!(p, PathBuf::from("./out/run-0042/layer-12/qkv_matmul.bin"));
+    }
+
+    #[test]
+    fn output_path_appends_bin_extension() {
+        let p = output_path(Path::new("d"), 0, "ffn_swigl");
+        assert!(
+            p.to_str().expect("utf8").ends_with(".bin"),
+            "all save-tensor files must use .bin extension"
+        );
+    }
+
+    #[test]
+    fn output_path_preserves_stage_name_verbatim() {
+        // No case-folding, no aliasing — `output_path` is a thin formatter.
+        // Caller (CLI layer) is expected to canonicalise via SaveTensorStage.
+        let p = output_path(Path::new("d"), 0, "FFN_GATE");
+        assert_eq!(
+            p,
+            PathBuf::from("d/layer-0/FFN_GATE.bin"),
+            "no implicit case-fold; canonicalisation is caller's responsibility"
+        );
+    }
+
+    #[test]
+    fn ensure_layer_dir_creates_per_layer_dir() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        ensure_layer_dir(tmp.path(), 7).expect("create per-layer");
+        assert!(tmp.path().join("layer-7").is_dir());
+    }
+
+    #[test]
+    fn ensure_layer_dir_creates_whole_model_dir() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let nested = tmp.path().join("nested/output");
+        ensure_layer_dir(&nested, WHOLE_MODEL_LAYER).expect("create whole-model");
+        assert!(nested.is_dir());
+        // No layer-* subdir for whole-model.
+        let dir_entries: Vec<_> = std::fs::read_dir(&nested)
+            .expect("read_dir")
+            .collect::<Result<_, _>>()
+            .expect("entries");
+        assert!(dir_entries.is_empty());
+    }
+
+    #[test]
+    fn ensure_layer_dir_is_idempotent() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        ensure_layer_dir(tmp.path(), 0).expect("first create");
+        ensure_layer_dir(tmp.path(), 0).expect("second create must not fail");
+        assert!(tmp.path().join("layer-0").is_dir());
+    }
+
+    #[test]
+    fn ensure_layer_dir_creates_nested_parents() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let deep = tmp.path().join("a/b/c");
+        ensure_layer_dir(&deep, 4).expect("create nested");
+        assert!(deep.join("layer-4").is_dir());
+    }
+
+    #[test]
+    fn ensure_layer_dir_no_collision_between_per_layer_and_whole_model() {
+        // Whole-model output_path uses `<dir>/<stage>.bin`; per-layer uses
+        // `<dir>/layer-<N>/<stage>.bin`. Verify the layouts cannot collide
+        // by checking that the per-layer `layer-` prefix is never produced
+        // for the whole-model case at any layer value (besides the sentinel
+        // itself, which is handled).
+        let p_whole = output_path(Path::new("d"), WHOLE_MODEL_LAYER, "lm_head");
+        let p_per_layer = output_path(Path::new("d"), 0, "lm_head");
+        assert_ne!(p_whole, p_per_layer);
+        assert!(!p_whole.to_str().unwrap().contains("layer-"));
+        assert!(p_per_layer.to_str().unwrap().contains("layer-0"));
+    }
+}


### PR DESCRIPTION
## Summary

Per [\`apr-cli-trace-save-tensor-v1.yaml\`](contracts/apr-cli-trace-save-tensor-v1.yaml) v1.0.0 PROPOSED \`cli_signature\` invariants: per-layer stages MUST be written under \`<DIR>/layer-<N>/<STAGE>.bin\`; whole-model stages (\`final_norm\`, \`lm_head\`) go directly under \`<DIR>/<STAGE>.bin\` with no \`layer-N\` segment.

This module is the layout primitive that the future \`apr trace --save-tensor\` CLI implementation calls before invoking the byte writer in \`inference_trace::save_tensor\` (#1133). Pure-path / minimal-fs slice keeps the writer and reader (\`apr diff --values\`) from drifting apart on the on-disk layout.

## What's added

New module \`crates/aprender-serve/src/inference_trace/save_tensor_paths.rs\` (~200 LOC):

- \`pub fn output_path(dir: &Path, layer: u32, stage_name: &str) -> PathBuf\`
  - Per-layer: \`<dir>/layer-<N>/<stage>.bin\`
  - Whole-model (\`layer == WHOLE_MODEL_LAYER\`): \`<dir>/<stage>.bin\`
- \`pub fn ensure_layer_dir(dir: &Path, layer: u32) -> io::Result<()>\` — creates the appropriate parent directory; idempotent

## Tests (13 unit + 1 doctest, all green)

**\`output_path\`:**
- \`output_path_per_layer_layer_zero\`, \`_arbitrary\`, \`_absolute_dir\`
- \`output_path_whole_model_no_layer_segment\` (final_norm + lm_head)
- \`output_path_layer_max_minus_one_is_per_layer\` (boundary at WHOLE_MODEL_LAYER)
- \`output_path_nested_relative_dir\`
- \`output_path_appends_bin_extension\`
- \`output_path_preserves_stage_name_verbatim\` (no implicit case-fold; canonicalisation is the caller's responsibility via SaveTensorStage)

**\`ensure_layer_dir\` (using tempfile):**
- \`ensure_layer_dir_creates_per_layer_dir\`
- \`ensure_layer_dir_creates_whole_model_dir\` (verifies no \`layer-*\` subdir for whole-model)
- \`ensure_layer_dir_is_idempotent\`
- \`ensure_layer_dir_creates_nested_parents\`
- \`ensure_layer_dir_no_collision_between_per_layer_and_whole_model\`

## Live verification

\`\`\`
\$ cargo test -p aprender-serve --lib inference_trace::save_tensor_paths
test result: ok. 13 passed; 0 failed; 0 ignored

\$ cargo test -p aprender-serve --doc inference_trace::save_tensor_paths
test result: ok. 1 passed; 0 failed; 0 ignored
\`\`\`

## Why this is small

This PR is tight: 1 new file (~197 LOC including tests + doc), 1 line added to \`mod.rs\`. No CLI surface change, no behavior change to existing binaries. Depends on #1133 (just merged, provides \`WHOLE_MODEL_LAYER\`); independent of #1134 (stage enum still in flight).

## Five-Whys (Toyota Way)

1. SHIP-007 next-session priority is per-stage element-wise diff via \`apr trace --save-tensor\`.
2. Contract \`cli_signature\` mandates a precise filesystem layout.
3. Path building is pure formatter logic — fully testable today.
4. Pinning the layout NOW means writer and reader cannot drift (fewer surprises when \`apr diff --values\` reads these files).
5. §26.8 stack-tool-extension methodology — extend apr in falsifier-sized slices.

## Test plan
- [x] \`cargo test -p aprender-serve --lib inference_trace::save_tensor_paths\` — 13 pass green
- [x] \`cargo test -p aprender-serve --doc inference_trace::save_tensor_paths\` — 1 doctest pass
- [x] \`cargo fmt -p aprender-serve\` — formatted
- [x] Pre-commit quality gates passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)