### PR TITLE
feat(aprender-core): apr-cli-distill-train-v1 TRAIN-005 PARTIAL_ALGORITHM_LEVEL

### DIFF
--- a/crates/aprender-core/src/format/distill_train_005.rs
+++ b/crates/aprender-core/src/format/distill_train_005.rs
@@ -1,0 +1,372 @@
+// SHIP-TWO-001 §35 — `apr-cli-distill-train-v1` algorithm-level
+// PARTIAL discharge for FALSIFY-APR-DISTILL-TRAIN-005.
+//
+// Contract: `contracts/apr-cli-distill-train-v1.yaml` v1.0.0 PROPOSED.
+// Spec: `docs/specifications/aprender-train/ship-two-models-spec.md` §35.
+//
+// ## What FALSIFY-APR-DISTILL-TRAIN-005 says
+//
+//   rule: precompute is byte-deterministic
+//   prediction: Two runs of `apr distill --stage precompute` with same
+//               inputs produce byte-identical `teacher_logits/` output.
+//   test:       diff -r run1/teacher_logits run2/teacher_logits → exit 0
+//   if_fails:   non-determinism in teacher forward pass — likely a
+//               kernel-launch ordering or atomic-add issue.
+//
+// ## What this file proves NOW (`PARTIAL_ALGORITHM_LEVEL`)
+//
+// The decision rule — "every per-file SHA-256 in run A matches the
+// corresponding file's SHA-256 in run B, both directories have the same
+// non-empty file set, and every hash is canonical lowercase 64-char hex"
+// — is pinned. Composes with [`super::ship_010::verdict_from_sha256_match`]
+// (already-merged SHA-256 byte-identity primitive) so the format
+// validation rules (length, lowercase, hex-only) are the SAME ones
+// enforced at MODEL-1 publish time.
+//
+// Future implementations cannot silently weaken determinism by:
+// - dropping a file from one of the two runs (length mismatch → Fail)
+// - emitting different hashes for the same logical file (Fail)
+// - emitting non-canonical hex (uppercase, hyphens) (delegated to ship_010 → Fail)
+
+use super::ship_010::{verdict_from_sha256_match, Ship010Verdict};
+
+/// Binary verdict for `FALSIFY-APR-DISTILL-TRAIN-005`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DistillTrain005Verdict {
+    /// Both runs produced the same set of files in the same order, all
+    /// non-empty, and every per-file SHA-256 matches byte-identically.
+    /// Precompute is deterministic.
+    Pass,
+    /// One or more of:
+    /// - Either run is empty (no files emitted — caller error).
+    /// - Different number of files between run A and run B.
+    /// - At least one per-file SHA-256 mismatch.
+    /// - At least one hash is malformed (length ≠ 64, uppercase, non-hex).
+    Fail,
+}
+
+/// Pure verdict function for FALSIFY-APR-DISTILL-TRAIN-005.
+///
+/// Inputs: per-file SHA-256 hex strings from each run, in the same
+/// canonical order (e.g. sorted by relative path under
+/// `<output_dir>/teacher_logits/`).
+///
+/// Composes with [`super::ship_010::verdict_from_sha256_match`] so the
+/// SHA-256 format validation rules (64 hex chars, lowercase) are the same
+/// ones enforced at MODEL-1 publish time.
+///
+/// # Examples
+///
+/// Identical runs — `Pass`:
+/// ```
+/// use aprender::format::distill_train_005::{
+///     verdict_from_paired_per_file_hashes, DistillTrain005Verdict,
+/// };
+/// let run_a = vec![
+///     "0".repeat(64),
+///     "a".repeat(64),
+///     "b".repeat(64),
+/// ];
+/// let run_b = run_a.clone();
+/// assert_eq!(
+///     verdict_from_paired_per_file_hashes(&run_a, &run_b),
+///     DistillTrain005Verdict::Pass,
+/// );
+/// ```
+///
+/// Mismatched hash — `Fail`:
+/// ```
+/// use aprender::format::distill_train_005::{
+///     verdict_from_paired_per_file_hashes, DistillTrain005Verdict,
+/// };
+/// let run_a = vec!["0".repeat(64)];
+/// let run_b = vec!["1".repeat(64)];
+/// assert_eq!(
+///     verdict_from_paired_per_file_hashes(&run_a, &run_b),
+///     DistillTrain005Verdict::Fail,
+/// );
+/// ```
+#[must_use]
+pub fn verdict_from_paired_per_file_hashes(
+    run_a: &[String],
+    run_b: &[String],
+) -> DistillTrain005Verdict {
+    if run_a.is_empty() || run_b.is_empty() {
+        return DistillTrain005Verdict::Fail;
+    }
+    if run_a.len() != run_b.len() {
+        return DistillTrain005Verdict::Fail;
+    }
+    for (a, b) in run_a.iter().zip(run_b.iter()) {
+        match verdict_from_sha256_match(a, b) {
+            Ship010Verdict::Pass => continue,
+            Ship010Verdict::Fail => return DistillTrain005Verdict::Fail,
+        }
+    }
+    DistillTrain005Verdict::Pass
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn h(c: char) -> String {
+        std::iter::repeat(c).take(64).collect()
+    }
+
+    fn sample_run() -> Vec<String> {
+        vec![h('0'), h('a'), h('b'), h('c'), h('d')]
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 1: Pass band — identical runs.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn pass_identical_runs() {
+        let run = sample_run();
+        assert_eq!(
+            verdict_from_paired_per_file_hashes(&run, &run),
+            DistillTrain005Verdict::Pass
+        );
+    }
+
+    #[test]
+    fn pass_single_file_match() {
+        let run = vec![h('a')];
+        assert_eq!(
+            verdict_from_paired_per_file_hashes(&run, &run),
+            DistillTrain005Verdict::Pass
+        );
+    }
+
+    #[test]
+    fn pass_typical_size_339_files() {
+        // Mirrors a realistic per-shard cache: 339 entries (one per
+        // Qwen2.5-Coder-7B tensor's logits row, illustratively).
+        let run: Vec<String> = (0..339)
+            .map(|i| {
+                let base = format!("{:064x}", i);
+                base
+            })
+            .collect();
+        assert_eq!(
+            verdict_from_paired_per_file_hashes(&run, &run),
+            DistillTrain005Verdict::Pass
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 2: Fail band — single-file hash mismatch.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fail_single_file_mismatch() {
+        let a = vec![h('a')];
+        let b = vec![h('b')];
+        assert_eq!(
+            verdict_from_paired_per_file_hashes(&a, &b),
+            DistillTrain005Verdict::Fail
+        );
+    }
+
+    #[test]
+    fn fail_mismatch_at_each_position() {
+        for bad_idx in [0_usize, 2, 4] {
+            let mut a = sample_run();
+            let b = sample_run();
+            a[bad_idx] = h('f');
+            assert_eq!(
+                verdict_from_paired_per_file_hashes(&a, &b),
+                DistillTrain005Verdict::Fail,
+                "mismatch at index {bad_idx} must Fail"
+            );
+        }
+    }
+
+    #[test]
+    fn fail_one_byte_difference() {
+        // sha256sum changing one bit anywhere in the 256-bit output
+        // changes at least one nybble — pinned via single-char swap here.
+        let a = vec!["0".repeat(63) + "0"];
+        let b = vec!["0".repeat(63) + "1"];
+        assert_eq!(
+            verdict_from_paired_per_file_hashes(&a, &b),
+            DistillTrain005Verdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 3: Length drift — both runs must have the same file count.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fail_run_a_longer() {
+        let a = vec![h('a'), h('b'), h('c')];
+        let b = vec![h('a'), h('b')];
+        assert_eq!(
+            verdict_from_paired_per_file_hashes(&a, &b),
+            DistillTrain005Verdict::Fail
+        );
+    }
+
+    #[test]
+    fn fail_run_b_longer() {
+        let a = vec![h('a'), h('b')];
+        let b = vec![h('a'), h('b'), h('c')];
+        assert_eq!(
+            verdict_from_paired_per_file_hashes(&a, &b),
+            DistillTrain005Verdict::Fail
+        );
+    }
+
+    #[test]
+    fn fail_off_by_one_at_typical_size() {
+        let a: Vec<String> = (0..339).map(|i| format!("{:064x}", i)).collect();
+        let b: Vec<String> = (0..338).map(|i| format!("{:064x}", i)).collect();
+        assert_eq!(
+            verdict_from_paired_per_file_hashes(&a, &b),
+            DistillTrain005Verdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 4: Empty input — caller error → conservative Fail.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fail_both_empty() {
+        let empty: Vec<String> = vec![];
+        assert_eq!(
+            verdict_from_paired_per_file_hashes(&empty, &empty),
+            DistillTrain005Verdict::Fail,
+            "empty cache implies precompute did nothing — caller error"
+        );
+    }
+
+    #[test]
+    fn fail_run_a_empty_but_b_not() {
+        let a: Vec<String> = vec![];
+        let b = vec![h('a')];
+        assert_eq!(
+            verdict_from_paired_per_file_hashes(&a, &b),
+            DistillTrain005Verdict::Fail
+        );
+    }
+
+    #[test]
+    fn fail_run_b_empty_but_a_not() {
+        let a = vec![h('a')];
+        let b: Vec<String> = vec![];
+        assert_eq!(
+            verdict_from_paired_per_file_hashes(&a, &b),
+            DistillTrain005Verdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 5: Format violation — delegated to ship_010 (composition test).
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fail_uppercase_hex_via_ship_010() {
+        // ship_010 enforces canonical lowercase only; uppercase Fails
+        // even when the strings are byte-equal — pinned via composition.
+        let a = vec!["A".repeat(64)];
+        let b = vec!["A".repeat(64)];
+        assert_eq!(
+            verdict_from_paired_per_file_hashes(&a, &b),
+            DistillTrain005Verdict::Fail,
+            "uppercase hex Fails even when byte-equal (ship_010 rule)"
+        );
+    }
+
+    #[test]
+    fn fail_too_short_hash() {
+        let a = vec!["0".repeat(63)];
+        let b = vec!["0".repeat(63)];
+        assert_eq!(
+            verdict_from_paired_per_file_hashes(&a, &b),
+            DistillTrain005Verdict::Fail
+        );
+    }
+
+    #[test]
+    fn fail_too_long_hash() {
+        let a = vec!["0".repeat(65)];
+        let b = vec!["0".repeat(65)];
+        assert_eq!(
+            verdict_from_paired_per_file_hashes(&a, &b),
+            DistillTrain005Verdict::Fail
+        );
+    }
+
+    #[test]
+    fn fail_non_hex_character() {
+        let mut bad = "0".repeat(63);
+        bad.push('z');
+        let a = vec![bad.clone()];
+        let b = vec![bad];
+        assert_eq!(
+            verdict_from_paired_per_file_hashes(&a, &b),
+            DistillTrain005Verdict::Fail,
+            "non-hex character Fails (ship_010 rule)"
+        );
+    }
+
+    #[test]
+    fn fail_empty_string_in_list() {
+        let a = vec![String::new()];
+        let b = vec![String::new()];
+        assert_eq!(
+            verdict_from_paired_per_file_hashes(&a, &b),
+            DistillTrain005Verdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 6: Asymmetry probe — order matters.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fail_same_set_different_order() {
+        // Per contract, both lists are expected in the same canonical
+        // order (e.g., sorted relative paths). A reordered second run
+        // FAILS — the future CLI is responsible for sorting before
+        // comparison; this gate doesn't paper over that bug.
+        let a = vec![h('a'), h('b'), h('c')];
+        let b = vec![h('c'), h('b'), h('a')];
+        assert_eq!(
+            verdict_from_paired_per_file_hashes(&a, &b),
+            DistillTrain005Verdict::Fail,
+            "same hash set in different order must Fail (caller sorts)"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 7: Composition with ship_010 — sanity check that we delegate.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn ship_010_passes_imply_pass() {
+        // Pure composition test: if ship_010 says Pass for every pair,
+        // and the lengths match, this verdict says Pass.
+        let a = vec![h('0'), h('1'), h('2')];
+        let b = a.clone();
+        assert_eq!(
+            verdict_from_paired_per_file_hashes(&a, &b),
+            DistillTrain005Verdict::Pass
+        );
+        // And confirm the underlying ship_010 verdict matches.
+        for (x, y) in a.iter().zip(b.iter()) {
+            assert_eq!(verdict_from_sha256_match(x, y), Ship010Verdict::Pass);
+        }
+    }
+
+    #[test]
+    fn ship_010_fails_imply_fail() {
+        let a = vec![h('0')];
+        let b = vec![h('1')];
+        assert_eq!(
+            verdict_from_paired_per_file_hashes(&a, &b),
+            DistillTrain005Verdict::Fail
+        );
+        assert_eq!(
+            verdict_from_sha256_match(&a[0], &b[0]),
+            Ship010Verdict::Fail
+        );
+    }
+}

--- a/crates/aprender-core/src/format/distill_train_005.rs
+++ b/crates/aprender-core/src/format/distill_train_005.rs
@@ -98,9 +98,8 @@ pub fn verdict_from_paired_per_file_hashes(
         return DistillTrain005Verdict::Fail;
     }
     for (a, b) in run_a.iter().zip(run_b.iter()) {
-        match verdict_from_sha256_match(a, b) {
-            Ship010Verdict::Pass => continue,
-            Ship010Verdict::Fail => return DistillTrain005Verdict::Fail,
+        if matches!(verdict_from_sha256_match(a, b), Ship010Verdict::Fail) {
+            return DistillTrain005Verdict::Fail;
         }
     }
     DistillTrain005Verdict::Pass

--- a/crates/aprender-core/src/format/mod.rs
+++ b/crates/aprender-core/src/format/mod.rs
@@ -415,6 +415,9 @@ pub mod ship_024;
 // FALSIFY-APR-GGUF-PARITY — per-layer ffn_swigl ratio gate for SHIP-007.
 pub mod apr_gguf_forward_parity;
 
+// FALSIFY-APR-DISTILL-TRAIN-005 — precompute byte-determinism gate.
+pub mod distill_train_005;
+
 // FALSIFY-APR-DISTILL-TRAIN-001 — real-training (not stub) tensor-diff gate.
 pub mod distill_train_001;
 


### PR DESCRIPTION
## Summary

Per [\`apr-cli-distill-train-v1.yaml\`](contracts/apr-cli-distill-train-v1.yaml) v1.0.0 PROPOSED. Sibling to \`distill_train_001\` (#1139, stub-detection) + \`distill_train_002\` (#1140, loss-decrease) — completing the algorithm-level binding for the **byte-determinism** axis.

**FALSIFY-APR-DISTILL-TRAIN-005**:
- rule: precompute is byte-deterministic
- prediction: Two runs of \`apr distill --stage precompute\` with same inputs produce byte-identical \`teacher_logits/\` output.
- test: \`diff -r run1/teacher_logits run2/teacher_logits → exit 0\`

This PR pre-commits the *decision rule* — "every per-file SHA-256 in run A matches the corresponding file's SHA-256 in run B, both directories have the same non-empty file count, and every hash is canonical lowercase 64-char hex" — and **composes with \`super::ship_010::verdict_from_sha256_match\`** (already-merged SHA-256 byte-identity primitive) so the format validation rules are the SAME ones enforced at MODEL-1 publish time.

## What's added

New file \`crates/aprender-core/src/format/distill_train_005.rs\` (~375 LOC):

- \`pub enum DistillTrain005Verdict { Pass, Fail }\`
- \`pub fn verdict_from_paired_per_file_hashes(&[String], &[String]) -> DistillTrain005Verdict\`

## Tests (20 unit + 2 doctests, all green) — 7-section mutation survey

1. **Pass band** (3): identical_runs, single_file_match, typical_339_files.
2. **Fail band** (3): single_file_mismatch, mismatch_at_each_position, one_byte_difference.
3. **Length drift** (3): run_a_longer, run_b_longer, off_by_one_at_typical_size.
4. **Empty input** (3): both_empty, a_empty_but_b_not, b_empty_but_a_not.
5. **Format violation via composition** (5): uppercase_hex, too_short, too_long, non_hex, empty_string_in_list.
6. **Asymmetry probe** (1): same_set_different_order → Fail (caller sorts).
7. **Composition with ship_010** (2): Pass-imply-Pass, Fail-imply-Fail sanity.

## Live verification

\`\`\`
\$ cargo test -p aprender-core --lib format::distill_train_005
test result: ok. 20 passed; 0 failed; 0 ignored
\`\`\`

## Distill contract progress

After this PR merges, **5 of 9 falsifiers** are algorithm-bound:

| Falsifier | Discharge | PR |
|-----------|-----------|------|
| TRAIN-001 (stub detection) | PARTIAL_ALGO | #1139 |
| TRAIN-002 (loss decreases) | PARTIAL_ALGO | #1140 |
| TRAIN-003 (T-scaling argmax) | PARTIAL_ALGO | #1132 |
| TRAIN-004 (alpha=1 = pure KD) | PARTIAL_ALGO | #1132 |
| TRAIN-005 (precompute determinism) | PARTIAL_ALGO | **this PR** |

Remaining 4 (006 cache resume, 007 pv-validate already CI-gated, 008 3-surface drift, 009 e2e smoke) all need impl or live wiring.

## Why this is small

This PR is tight: 1 new file (~375 LOC), 1 line added to \`mod.rs\`. No CLI surface change. No behavior change. **Composes with existing \`ship_010\`** for SHA-256 format validation (no duplication).

## Five-Whys (Toyota Way)

1. §35 found \`apr distill --stage train\` is a stub.
2. TRAIN-005 covers byte-determinism (different bug class than TRAIN-001/002).
3. The decision rule (per-file SHA-256 pairwise, same set, same order) is purely algorithmic.
4. Composing with \`ship_010::verdict_from_sha256_match\` means format-validation rules cannot drift between MODEL-1 publish and distill cache layers.
5. §26.8 stack-tool-extension methodology — algorithm-level shape-binding is the established pattern.

## Test plan
- [x] \`cargo test -p aprender-core --lib format::distill_train_005\` — 20 pass green
- [x] \`cargo fmt -p aprender-core\` — formatted
- [x] Pre-commit quality gates passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)