### PR TITLE
feat(aprender-core): apr-cli-distill-train-v1 TRAIN-006 PARTIAL_ALGORITHM_LEVEL

### DIFF
--- a/crates/aprender-core/src/format/distill_train_006.rs
+++ b/crates/aprender-core/src/format/distill_train_006.rs
@@ -1,0 +1,217 @@
+// SHIP-TWO-001 §35 — `apr-cli-distill-train-v1` algorithm-level
+// PARTIAL discharge for FALSIFY-APR-DISTILL-TRAIN-006.
+//
+// Contract: `contracts/apr-cli-distill-train-v1.yaml` v1.0.0 PROPOSED.
+// Spec: `docs/specifications/aprender-train/ship-two-models-spec.md` §35.
+//
+// ## What FALSIFY-APR-DISTILL-TRAIN-006 says
+//
+//   rule: stage train can resume from precompute cache
+//   prediction: If `teacher_logits/` cache exists, stage train SHOULD
+//               skip recomputation and proceed to gradient updates.
+//   test:       rm -rf run/ckpt; apr distill --stage train ... → uses
+//               existing cache, no teacher forward.
+//   if_fails:   missing idempotency — would force re-running expensive
+//               precompute on every train.
+//
+// ## What this file proves NOW (`PARTIAL_ALGORITHM_LEVEL`)
+//
+// Decision rule on the 4-state truth table over
+// `(cache_exists, teacher_forward_invoked)`:
+//
+//   | cache_exists | teacher_forward_invoked | Verdict | Reason                                      |
+//   |--------------|-------------------------|---------|---------------------------------------------|
+//   | true         | true                    | Fail    | idempotency violated — recomputed anyway    |
+//   | true         | false                   | Pass    | cache hit; skipped recomputation            |
+//   | false        | true                    | Pass    | cache miss; honestly recomputed             |
+//   | false        | false                   | Fail    | no cache, no compute — no work done         |
+//
+// Future implementations cannot:
+// - Always recompute (would Fail the cache-hit case)
+// - Skip computation when no cache exists (would Fail the cache-miss case)
+// - Treat "cache exists" implicitly as "skip everything including the
+//   gradient updates" (separate concern; not what this gate checks).
+
+/// Binary verdict for `FALSIFY-APR-DISTILL-TRAIN-006`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DistillTrain006Verdict {
+    /// Cache resume worked correctly:
+    /// - `cache_exists ∧ ¬teacher_forward_invoked` (cache hit), OR
+    /// - `¬cache_exists ∧ teacher_forward_invoked` (cache miss → honest recompute).
+    Pass,
+    /// Cache resume violated idempotency:
+    /// - `cache_exists ∧ teacher_forward_invoked` (recomputed anyway), OR
+    /// - `¬cache_exists ∧ ¬teacher_forward_invoked` (no cache, no compute).
+    Fail,
+}
+
+/// Pure verdict function for FALSIFY-APR-DISTILL-TRAIN-006.
+///
+/// Inputs:
+/// - `cache_exists`: was `<output_dir>/teacher_logits/` populated with a
+///   non-empty SHA-256-hashable set of files when stage `train` started?
+/// - `teacher_forward_invoked`: did the train loop actually run a teacher
+///   forward pass during this run? (Live impl: a counter or a process-level
+///   flag set by the teacher-forward kernel dispatcher.)
+///
+/// Pass iff exactly one of the two booleans is true (XOR semantics).
+///
+/// # Examples
+///
+/// Cache hit — `Pass`:
+/// ```
+/// use aprender::format::distill_train_006::{
+///     verdict_from_cache_resume_observation, DistillTrain006Verdict,
+/// };
+/// let v = verdict_from_cache_resume_observation(true, false);
+/// assert_eq!(v, DistillTrain006Verdict::Pass);
+/// ```
+///
+/// Cache exists but teacher forward ran anyway — `Fail`:
+/// ```
+/// use aprender::format::distill_train_006::{
+///     verdict_from_cache_resume_observation, DistillTrain006Verdict,
+/// };
+/// let v = verdict_from_cache_resume_observation(true, true);
+/// assert_eq!(v, DistillTrain006Verdict::Fail);
+/// ```
+#[must_use]
+pub const fn verdict_from_cache_resume_observation(
+    cache_exists: bool,
+    teacher_forward_invoked: bool,
+) -> DistillTrain006Verdict {
+    // Pass iff exactly one is true (XOR).
+    if cache_exists ^ teacher_forward_invoked {
+        DistillTrain006Verdict::Pass
+    } else {
+        DistillTrain006Verdict::Fail
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -------------------------------------------------------------------------
+    // Section 1: 4-state truth table — exhaustive enumeration of bool inputs.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn truth_table_t_t_fails_idempotency_violated() {
+        assert_eq!(
+            verdict_from_cache_resume_observation(true, true),
+            DistillTrain006Verdict::Fail,
+            "cache exists ∧ recomputed anyway → idempotency violation"
+        );
+    }
+
+    #[test]
+    fn truth_table_t_f_passes_cache_hit() {
+        assert_eq!(
+            verdict_from_cache_resume_observation(true, false),
+            DistillTrain006Verdict::Pass,
+            "cache hit — recomputation skipped → Pass"
+        );
+    }
+
+    #[test]
+    fn truth_table_f_t_passes_cache_miss() {
+        assert_eq!(
+            verdict_from_cache_resume_observation(false, true),
+            DistillTrain006Verdict::Pass,
+            "cache miss → honest recompute → Pass"
+        );
+    }
+
+    #[test]
+    fn truth_table_f_f_fails_no_work_done() {
+        assert_eq!(
+            verdict_from_cache_resume_observation(false, false),
+            DistillTrain006Verdict::Fail,
+            "no cache, no compute → train did no work — Fail"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 2: XOR symmetry — verdict invariant under input swap.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn verdict_symmetric_under_input_swap() {
+        for (a, b) in [(true, true), (true, false), (false, true), (false, false)] {
+            assert_eq!(
+                verdict_from_cache_resume_observation(a, b),
+                verdict_from_cache_resume_observation(b, a),
+                "XOR is symmetric: (a={a}, b={b}) == (a={b}, b={a})"
+            );
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 3: Mutation-resistance — verdict flips under single-bit flip.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn single_bit_flip_changes_verdict_each_axis() {
+        // For every input, flipping exactly one of the two bits must flip
+        // the verdict (Pass ↔ Fail). This is exactly the XOR property — so
+        // the test catches a future drift to AND/OR semantics.
+        for (a, b) in [(true, true), (true, false), (false, true), (false, false)] {
+            let baseline = verdict_from_cache_resume_observation(a, b);
+            let flip_a = verdict_from_cache_resume_observation(!a, b);
+            let flip_b = verdict_from_cache_resume_observation(a, !b);
+            assert_ne!(
+                baseline, flip_a,
+                "flipping cache_exists at ({a},{b}) must flip verdict"
+            );
+            assert_ne!(
+                baseline, flip_b,
+                "flipping teacher_forward at ({a},{b}) must flip verdict"
+            );
+        }
+    }
+
+    #[test]
+    fn double_bit_flip_preserves_verdict() {
+        // Flipping BOTH bits returns to the same equivalence class.
+        for (a, b) in [(true, true), (true, false), (false, true), (false, false)] {
+            let baseline = verdict_from_cache_resume_observation(a, b);
+            let flip_both = verdict_from_cache_resume_observation(!a, !b);
+            assert_eq!(
+                baseline, flip_both,
+                "flipping both bits at ({a},{b}) must preserve verdict"
+            );
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 4: Documentation-rule sanity — verdict matches the truth-table
+    //            comment in the source.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn truth_table_pass_count_is_exactly_two() {
+        let mut pass_count = 0;
+        let mut fail_count = 0;
+        for cache in [true, false] {
+            for forward in [true, false] {
+                match verdict_from_cache_resume_observation(cache, forward) {
+                    DistillTrain006Verdict::Pass => pass_count += 1,
+                    DistillTrain006Verdict::Fail => fail_count += 1,
+                }
+            }
+        }
+        // XOR over two booleans yields true in exactly half the cases.
+        assert_eq!(pass_count, 2);
+        assert_eq!(fail_count, 2);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 5: Const evaluability — verdict can be computed at compile time.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn const_eval_works_in_static_context() {
+        // The verdict fn is `pub const fn` — exercise it at compile time
+        // so a future regression to runtime-only would break this test.
+        const PASS: DistillTrain006Verdict = verdict_from_cache_resume_observation(true, false);
+        const FAIL: DistillTrain006Verdict = verdict_from_cache_resume_observation(true, true);
+        assert_eq!(PASS, DistillTrain006Verdict::Pass);
+        assert_eq!(FAIL, DistillTrain006Verdict::Fail);
+    }
+}

--- a/crates/aprender-core/src/format/mod.rs
+++ b/crates/aprender-core/src/format/mod.rs
@@ -415,6 +415,9 @@ pub mod ship_024;
 // FALSIFY-APR-GGUF-PARITY — per-layer ffn_swigl ratio gate for SHIP-007.
 pub mod apr_gguf_forward_parity;
 
+// FALSIFY-APR-DISTILL-TRAIN-006 — stage train resumes from precompute cache.
+pub mod distill_train_006;
+
 // FALSIFY-APR-DISTILL-TRAIN-001 — real-training (not stub) tensor-diff gate.
 pub mod distill_train_001;
 


### PR DESCRIPTION
## Summary

Per [\`apr-cli-distill-train-v1.yaml\`](contracts/apr-cli-distill-train-v1.yaml) v1.0.0 PROPOSED. Sibling to \`distill_train_001/002/005\` (#1139, #1140, #1141) — completes the algorithm-level binding for the **cache-resume idempotency** axis.

**FALSIFY-APR-DISTILL-TRAIN-006**:
- rule: stage train can resume from precompute cache
- prediction: If \`teacher_logits/\` cache exists, stage train SHOULD skip recomputation
- test: \`rm -rf run/ckpt; apr distill --stage train ... → uses existing cache, no teacher forward\`
- if_fails: missing idempotency — would force re-running expensive precompute on every train

## What's added

New file \`crates/aprender-core/src/format/distill_train_006.rs\` (~190 LOC):

- \`pub enum DistillTrain006Verdict { Pass, Fail }\`
- \`pub const fn verdict_from_cache_resume_observation(cache_exists: bool, teacher_forward_invoked: bool) -> DistillTrain006Verdict\`

XOR semantics — Pass iff exactly one bool is true:

| cache | forward | Verdict | Reason |
| ----- | ------- | ------- | ------ |
| T | T | Fail | idempotency violated — recomputed anyway |
| T | F | Pass | cache hit; skipped recomputation |
| F | T | Pass | cache miss; honestly recomputed |
| F | F | Fail | no cache, no compute — no work done |

## Tests (9 unit + 2 doctests, all green) — 5-section mutation survey

1. **4-state truth table** (4 tests): exhaustive enumeration TT/TF/FT/FF.
2. **XOR symmetry** (1): verdict invariant under (a,b) ↔ (b,a) swap.
3. **Mutation-resistance** (2): single-bit-flip flips verdict; double-bit-flip preserves verdict (catches drift to AND/OR semantics).
4. **Pass-count = 2** (1): XOR yields true in exactly half the 4 cases.
5. **Const evaluability** (1): verdict computable at compile time (catches future regression to runtime-only).

## Live verification

\`\`\`
\$ cargo test -p aprender-core --lib format::distill_train_006
test result: ok. 9 passed; 0 failed; 0 ignored
\`\`\`

## Distill contract progress

After this PR merges, **6 of 9 falsifiers** are algorithm-bound:

| Falsifier | Discharge | PR |
|-----------|-----------|------|
| TRAIN-001 (stub detection) | PARTIAL_ALGO | #1139 |
| TRAIN-002 (loss decreases) | PARTIAL_ALGO | #1140 |
| TRAIN-003 (T-scaling argmax) | PARTIAL_ALGO | #1132 |
| TRAIN-004 (alpha=1 = pure KD) | PARTIAL_ALGO | #1132 |
| TRAIN-005 (precompute determinism) | PARTIAL_ALGO | #1141 |
| TRAIN-006 (cache resume) | PARTIAL_ALGO | **this PR** |

Remaining 3 (007 pv-validate already CI-gated, 008 3-surface drift needs CLI, 009 e2e smoke needs impl).

## Why this is small

This PR is tight: 1 new file (~190 LOC), 1 line added to \`mod.rs\`. No CLI surface change. No behavior change. The verdict is \`pub const fn\` — exercisable at compile time.

## Five-Whys (Toyota Way)

1. §35 found \`apr distill --stage train\` is a stub.
2. TRAIN-006 covers cache-resume idempotency (different bug class than TRAIN-001/002/005).
3. The decision rule is XOR over 2 booleans — purely algorithmic, exhaustively testable in 4 cases.
4. Pinning XOR semantics NOW means a future impl PR cannot silently regress to AND (always recompute) or OR (skip everything).
5. §26.8 stack-tool-extension methodology — algorithm-level shape-binding is the established pattern.

## Test plan
- [x] \`cargo test -p aprender-core --lib format::distill_train_006\` — 9 pass green
- [x] \`cargo fmt -p aprender-core\` — formatted
- [x] Pre-commit quality gates passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)