### PR TITLE
feat(aprender-core): profile-graph-vs-per-op-methodology-v1 PROF10-003 PARTIAL_ALGORITHM_LEVEL

### DIFF
--- a/crates/aprender-core/src/format/mod.rs
+++ b/crates/aprender-core/src/format/mod.rs
@@ -415,6 +415,9 @@ pub mod ship_024;
 // FALSIFY-APR-GGUF-PARITY — per-layer ffn_swigl ratio gate for SHIP-007.
 pub mod apr_gguf_forward_parity;
 
+// FALSIFY-PROF10-003 — apr profile graphed vs ungraphed sanity inequality.
+pub mod prof10_003;
+
 // FALSIFY-SUB-FFN-005 — sub-FFN telemetry per-layer line count.
 pub mod sub_ffn_005;
 

--- a/crates/aprender-core/src/format/prof10_003.rs
+++ b/crates/aprender-core/src/format/prof10_003.rs
@@ -1,0 +1,242 @@
+// SHIP-TWO-001 perf — `profile-graph-vs-per-op-methodology-v1` (F-PROFILE-010)
+// algorithm-level PARTIAL discharge for FALSIFY-PROF10-003.
+//
+// Contract: `contracts/profile-graph-vs-per-op-methodology-v1.yaml` v1.0.0
+// PROPOSED. Spec: docs/specifications/aprender-monorepo-consolidation.md
+// (perf gate). First binding for the F-PROFILE-010 contract surface.
+//
+// ## What FALSIFY-PROF10-003 says
+//
+//   name: Sanity: hotspot sum < graphed decode time in modern models
+//   method: On Qwen2.5-Coder-1.5B Q4_K_M, ungraphed kernel sum per token
+//           should EXCEED graphed decode per token (because ungraphed
+//           includes launch overhead that graph eliminates). Check the
+//           inequality holds.
+//
+// ## What this file proves NOW (`PARTIAL_ALGORITHM_LEVEL`)
+//
+// Decision rule: `ungraphed_us_per_token > graphed_us_per_token` (strict).
+// Both inputs must be non-zero.
+//
+// Future implementations cannot:
+// - Report `ungraphed == graphed` (graph-capture amortization broken).
+// - Report `ungraphed < graphed` (timing measurement broken — graphed
+//   path should always be at most equal, never *better* than per-op
+//   sum which already excludes launch overhead beneficial only for
+//   amortization).
+// - Report zero on either side (caller error / measurement failure).
+
+/// Binary verdict for `FALSIFY-PROF10-003`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Prof10_003Verdict {
+    /// Ungraphed per-token time strictly exceeds graphed per-token time.
+    /// CUDA graph capture is correctly amortizing launch overhead.
+    Pass,
+    /// One or more of:
+    /// - `ungraphed_us_per_token == 0` (measurement failure).
+    /// - `graphed_us_per_token == 0` (measurement failure).
+    /// - `ungraphed_us_per_token <= graphed_us_per_token` (graph capture
+    ///   not amortizing as expected, or per-op timing instrumentation
+    ///   broken — both are regression classes the gate catches).
+    Fail,
+}
+
+/// Pure verdict function for `FALSIFY-PROF10-003`.
+///
+/// Inputs:
+/// - `ungraphed_us_per_token`: sum of per-op kernel compute times, in
+///   microseconds, when running with `SKIP_CUDA_GRAPH=1`.
+/// - `graphed_us_per_token`: end-to-end graphed decode time per token,
+///   in microseconds, when running with default CUDA graph capture.
+///
+/// Pass iff both inputs are non-zero AND
+/// `ungraphed_us_per_token > graphed_us_per_token` (strict).
+///
+/// # Examples
+///
+/// Modern model — graph amortization wins — `Pass`:
+/// ```
+/// use aprender::format::prof10_003::{
+///     verdict_from_decode_time_pair, Prof10_003Verdict,
+/// };
+/// // Qwen2.5-Coder-1.5B representative: ungraphed=2400µs, graphed=1800µs.
+/// let v = verdict_from_decode_time_pair(2400, 1800);
+/// assert_eq!(v, Prof10_003Verdict::Pass);
+/// ```
+///
+/// Equal times — graph capture not amortizing — `Fail`:
+/// ```
+/// use aprender::format::prof10_003::{
+///     verdict_from_decode_time_pair, Prof10_003Verdict,
+/// };
+/// let v = verdict_from_decode_time_pair(1800, 1800);
+/// assert_eq!(v, Prof10_003Verdict::Fail);
+/// ```
+#[must_use]
+pub const fn verdict_from_decode_time_pair(
+    ungraphed_us_per_token: u64,
+    graphed_us_per_token: u64,
+) -> Prof10_003Verdict {
+    if ungraphed_us_per_token == 0 || graphed_us_per_token == 0 {
+        return Prof10_003Verdict::Fail;
+    }
+    if ungraphed_us_per_token > graphed_us_per_token {
+        Prof10_003Verdict::Pass
+    } else {
+        Prof10_003Verdict::Fail
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -------------------------------------------------------------------------
+    // Section 1: Pass band — graph capture amortizing properly.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn pass_qwen_1_5b_representative() {
+        // Qwen2.5-Coder-1.5B at ~440 tok/s graphed, ~300 tok/s ungraphed.
+        // Implies graphed≈2273µs/tok, ungraphed≈3333µs/tok.
+        let v = verdict_from_decode_time_pair(3333, 2273);
+        assert_eq!(v, Prof10_003Verdict::Pass);
+    }
+
+    #[test]
+    fn pass_clear_gap() {
+        let v = verdict_from_decode_time_pair(10_000, 5_000);
+        assert_eq!(v, Prof10_003Verdict::Pass);
+    }
+
+    #[test]
+    fn pass_just_above_equal_one_microsecond() {
+        let v = verdict_from_decode_time_pair(1801, 1800);
+        assert_eq!(v, Prof10_003Verdict::Pass, "1µs gap must Pass (strict >)");
+    }
+
+    #[test]
+    fn pass_realistic_7b_q4k_model() {
+        // Qwen2.5-Coder-7B Q4_K: ~225 tok/s graphed (CUDA), ~140 tok/s ungraphed.
+        // graphed≈4444µs/tok, ungraphed≈7142µs/tok.
+        let v = verdict_from_decode_time_pair(7142, 4444);
+        assert_eq!(v, Prof10_003Verdict::Pass);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 2: Fail band — equal times (no amortization).
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fail_equal_times() {
+        let v = verdict_from_decode_time_pair(1800, 1800);
+        assert_eq!(
+            v,
+            Prof10_003Verdict::Fail,
+            "equal times implies graph capture didn't amortize → Fail"
+        );
+    }
+
+    #[test]
+    fn fail_equal_at_typical_4090_speed() {
+        let v = verdict_from_decode_time_pair(2273, 2273);
+        assert_eq!(v, Prof10_003Verdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 3: Fail band — ungraphed < graphed (impossible/bug).
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fail_graphed_slower_than_ungraphed() {
+        // Mathematically impossible on a working graph capture — graphed
+        // amortizes launch overhead. Catches measurement-instrumentation
+        // bugs.
+        let v = verdict_from_decode_time_pair(1800, 2400);
+        assert_eq!(v, Prof10_003Verdict::Fail);
+    }
+
+    #[test]
+    fn fail_ungraphed_one_microsecond_below() {
+        let v = verdict_from_decode_time_pair(1799, 1800);
+        assert_eq!(v, Prof10_003Verdict::Fail, "1µs below must Fail (strict >)");
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 4: Fail band — measurement failures (zero values).
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fail_ungraphed_zero() {
+        let v = verdict_from_decode_time_pair(0, 1800);
+        assert_eq!(v, Prof10_003Verdict::Fail);
+    }
+
+    #[test]
+    fn fail_graphed_zero() {
+        let v = verdict_from_decode_time_pair(2400, 0);
+        assert_eq!(v, Prof10_003Verdict::Fail);
+    }
+
+    #[test]
+    fn fail_both_zero() {
+        let v = verdict_from_decode_time_pair(0, 0);
+        assert_eq!(v, Prof10_003Verdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 5: Boundary sweep around equality.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn boundary_sweep_around_equality() {
+        let graphed = 1800_u64;
+        let probes: Vec<(u64, Prof10_003Verdict)> = vec![
+            (0, Prof10_003Verdict::Fail),
+            (1, Prof10_003Verdict::Fail), // 1 < 1800
+            (1798, Prof10_003Verdict::Fail),
+            (1799, Prof10_003Verdict::Fail),
+            (1800, Prof10_003Verdict::Fail), // equal
+            (1801, Prof10_003Verdict::Pass),
+            (2000, Prof10_003Verdict::Pass),
+            (3600, Prof10_003Verdict::Pass), // 2× graphed
+            (u64::MAX, Prof10_003Verdict::Pass),
+        ];
+        for (ungraphed, expected) in probes {
+            let v = verdict_from_decode_time_pair(ungraphed, graphed);
+            assert_eq!(
+                v, expected,
+                "ungraphed={ungraphed} graphed={graphed} expected {expected:?}"
+            );
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 6: Realistic gap sweep — typical graph speedup ratios.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn realistic_gap_sweep() {
+        // Modern models typically see 1.1×–2× speedup from graph capture
+        // depending on kernel count and per-launch overhead.
+        let graphed = 1800_u64;
+        for ratio_pct in [105_u64, 110, 115, 125, 150, 200, 300] {
+            let ungraphed = graphed * ratio_pct / 100;
+            let v = verdict_from_decode_time_pair(ungraphed, graphed);
+            assert_eq!(
+                v,
+                Prof10_003Verdict::Pass,
+                "{ratio_pct}% ratio (ungraphed={ungraphed}) must Pass"
+            );
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 7: Const evaluability — verdict is `pub const fn`.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn const_eval_works_in_static_context() {
+        const PASS: Prof10_003Verdict = verdict_from_decode_time_pair(2400, 1800);
+        const FAIL_EQUAL: Prof10_003Verdict = verdict_from_decode_time_pair(1800, 1800);
+        const FAIL_INVERTED: Prof10_003Verdict = verdict_from_decode_time_pair(1000, 2000);
+        const FAIL_ZERO: Prof10_003Verdict = verdict_from_decode_time_pair(0, 1800);
+        assert_eq!(PASS, Prof10_003Verdict::Pass);
+        assert_eq!(FAIL_EQUAL, Prof10_003Verdict::Fail);
+        assert_eq!(FAIL_INVERTED, Prof10_003Verdict::Fail);
+        assert_eq!(FAIL_ZERO, Prof10_003Verdict::Fail);
+    }
+}


### PR DESCRIPTION
## Summary

Per [\`profile-graph-vs-per-op-methodology-v1.yaml\`](contracts/profile-graph-vs-per-op-methodology-v1.yaml) v1.0.0 PROPOSED (F-PROFILE-010). **Fresh contract** — first algorithm-bound PROF10 falsifier (was 0/3). Diversifies to a **7th** PROPOSED contract surface.

**FALSIFY-PROF10-003**: ungraphed kernel sum per token should EXCEED graphed decode per token (because ungraphed includes launch overhead that graph eliminates).

This PR pins the *decision rule* — strict-\`>\` inequality with non-zero inputs — at PARTIAL_ALGORITHM_LEVEL. Future impl cannot mask "amortization not working" as a Pass with equality.

## What's added

New file \`crates/aprender-core/src/format/prof10_003.rs\` (~250 LOC):

- \`pub enum Prof10_003Verdict { Pass, Fail }\`
- \`pub const fn verdict_from_decode_time_pair(ungraphed_us, graphed_us) -> Prof10_003Verdict\`

## Tests (14 unit + 2 doctests, all green) — 7-section mutation survey

1. **Pass band** (4): Qwen-1.5B representative, clear gap, +1µs above equal, realistic 7B Q4K.
2. **Fail band — equal times** (2): graph not amortizing.
3. **Fail band — graphed > ungraphed** (2): bug class (impossible on working graph), -1µs below equal.
4. **Fail band — measurement failures** (3): ungraphed=0, graphed=0, both=0.
5. **Boundary sweep** (1 test, 9 probes 0 → u64::MAX at fixed graphed=1800).
6. **Realistic gap sweep** (1 test, 7 probes 105% → 300% ratio).
7. **Const evaluability** (1 test, 4 cases as \`const\` declarations).

## Live verification

\`\`\`
\$ cargo test -p aprender-core --lib format::prof10_003
test result: ok. 14 passed; 0 failed; 0 ignored
\`\`\`

## Why this is small

Tight: 1 new file (~250 LOC), 1 line added to \`mod.rs\`. **First non-pretokenize-bin, non-distill, non-save-tensor, non-dataset-thestack, non-tokenize-parallel-bpe, non-trace-ffn-sub-block binding** — diversifies to a **7th** PROPOSED contract.

## Five-Whys (Toyota Way)

1. F-PROFILE-010 separates graphed throughput from ungraphed per-op cost — methodology load-bearing for perf decisions.
2. PROF10-003 catches the regression class where graph capture silently stops amortizing launch overhead.
3. The decision rule (strict \`>\`) is a single inequality — purely algorithmic.
4. Pinning strict \`>\` (not \`>=\`) NOW means a future impl cannot mask "amortization not working" as a Pass with equality.
5. §26.8 stack-tool-extension methodology.

## Test plan
- [x] \`cargo test -p aprender-core --lib format::prof10_003\` — 14 pass green
- [x] \`cargo fmt -p aprender-core\` — formatted
- [x] Pre-commit quality gates passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)