### PR TITLE
feat(aprender-core): apr-cli-qa-v1 QA-005 + QA-010 PARTIAL_ALGORITHM_LEVEL — closes 10/10 sweep

### DIFF
--- a/crates/aprender-core/src/format/mod.rs
+++ b/crates/aprender-core/src/format/mod.rs
@@ -424,6 +424,12 @@ pub mod data_inv_006;
 // FALSIFY-APR-DISTILL-TRAIN-002 — KL loss decreases over epochs gate.
 pub mod distill_train_002;
 
+// FALSIFY-QA-005 — apr --version contains git short hash.
+pub mod qa_005;
+
+// FALSIFY-QA-010 — cross-subcommand architecture consistency.
+pub mod qa_010;
+
 // FALSIFY-QA-002 + 006 — apr-cli error-exit honesty (exit != 0 on missing file / error output).
 pub mod qa_002_006;
 

--- a/crates/aprender-core/src/format/qa_005.rs
+++ b/crates/aprender-core/src/format/qa_005.rs
@@ -1,0 +1,284 @@
+// SHIP-TWO-001 — `apr-cli-qa-v1` algorithm-level PARTIAL discharge
+// for FALSIFY-QA-005.
+//
+// Contract: `contracts/apr-cli-qa-v1.yaml`.
+// Spec: `docs/specifications/aprender-train/ship-two-models-spec.md`
+// (apr CLI QA gates).
+//
+// ## What FALSIFY-QA-005 says
+//
+//   rule: version matches HEAD
+//   prediction: "apr --version contains current git hash"
+//   test: "apr --version | grep -q $(git rev-parse --short HEAD)"
+//   if_fails: "stale binary installed"
+//
+// ## What this file proves NOW (`PARTIAL_ALGORITHM_LEVEL`)
+//
+// Decision rule: given (`version_output`, `git_short_hash`), Pass iff:
+//
+//   version_output is non-empty AND
+//   git_short_hash is non-empty AND
+//   git_short_hash length is in canonical 7..=12 byte range AND
+//   git_short_hash is hex-only (lowercase) AND
+//   version_output contains git_short_hash as a substring
+//
+// Composes substring containment with hex-shape and length sanity
+// of the git hash. Catches:
+// - Stale binary: version_output has old hash, doesn't contain
+//   current short hash.
+// - Garbled inputs: hash with non-hex chars (corruption).
+// - Wrong-length hash: a regression that pads/truncates.
+
+/// Minimum length of a git short hash.
+///
+/// `git rev-parse --short HEAD` defaults to 7 chars but auto-grows
+/// for larger repos. 7 is the historical minimum.
+pub const AC_QA_005_MIN_HASH_LEN: usize = 7;
+
+/// Maximum length of a canonical git short hash.
+///
+/// Long-form sha-1 is 40, but `--short` typically caps at 12. We
+/// accept up to 12 for sanity; full 40-char hashes are technically
+/// valid but unusual for `--short`.
+pub const AC_QA_005_MAX_HASH_LEN: usize = 12;
+
+/// Binary verdict for `FALSIFY-QA-005`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Qa005Verdict {
+    /// Both inputs valid AND `version_output` contains `git_short_hash`
+    /// as a substring.
+    Pass,
+    /// One or more of:
+    /// - `version_output.is_empty()` (caller error — apr --version
+    ///   silent).
+    /// - `git_short_hash` is empty / wrong length / non-hex.
+    /// - `version_output` does NOT contain `git_short_hash`
+    ///   (stale binary regression).
+    Fail,
+}
+
+/// Pure verdict function for `FALSIFY-QA-005`.
+///
+/// Inputs:
+/// - `version_output`: stdout from `apr --version`.
+/// - `git_short_hash`: result of `git rev-parse --short HEAD`.
+///
+/// Pass iff:
+/// 1. `!version_output.is_empty()`,
+/// 2. `git_short_hash.len() >= 7 AND <= 12`,
+/// 3. All bytes of `git_short_hash` are lowercase hex (`0-9` or `a-f`),
+/// 4. `version_output` contains `git_short_hash` as a substring.
+///
+/// Otherwise `Fail`.
+#[must_use]
+pub fn verdict_from_version_git_hash(
+    version_output: &[u8],
+    git_short_hash: &[u8],
+) -> Qa005Verdict {
+    if version_output.is_empty() {
+        return Qa005Verdict::Fail;
+    }
+    if git_short_hash.len() < AC_QA_005_MIN_HASH_LEN
+        || git_short_hash.len() > AC_QA_005_MAX_HASH_LEN
+    {
+        return Qa005Verdict::Fail;
+    }
+    if !git_short_hash
+        .iter()
+        .all(|&b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+    {
+        return Qa005Verdict::Fail;
+    }
+    if contains_subsequence(version_output, git_short_hash) {
+        Qa005Verdict::Pass
+    } else {
+        Qa005Verdict::Fail
+    }
+}
+
+/// Returns `true` iff `needle` appears as a contiguous subsequence
+/// of `haystack`. Same primitive used in `pull_dataset_001/005` and
+/// `pub_cli_001`.
+#[must_use]
+fn contains_subsequence(haystack: &[u8], needle: &[u8]) -> bool {
+    if needle.len() > haystack.len() {
+        return false;
+    }
+    haystack.windows(needle.len()).any(|w| w == needle)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -------------------------------------------------------------------------
+    // Section 1: Provenance pin — git short-hash length range.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn provenance_min_hash_len_is_7() {
+        assert_eq!(AC_QA_005_MIN_HASH_LEN, 7);
+    }
+
+    #[test]
+    fn provenance_max_hash_len_is_12() {
+        assert_eq!(AC_QA_005_MAX_HASH_LEN, 12);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 2: Pass band — canonical short hashes embedded in version.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn pass_canonical_7char_hash() {
+        let v = verdict_from_version_git_hash(
+            b"apr 0.31.2 (b7bf4b0)",
+            b"b7bf4b0",
+        );
+        assert_eq!(v, Qa005Verdict::Pass);
+    }
+
+    #[test]
+    fn pass_8char_hash() {
+        let v = verdict_from_version_git_hash(
+            b"apr 0.31.2 (b7bf4b07)",
+            b"b7bf4b07",
+        );
+        assert_eq!(v, Qa005Verdict::Pass);
+    }
+
+    #[test]
+    fn pass_12char_hash_at_max_len() {
+        let v = verdict_from_version_git_hash(
+            b"apr 0.31.2 (b7bf4b07a000)",
+            b"b7bf4b07a000",
+        );
+        assert_eq!(v, Qa005Verdict::Pass);
+    }
+
+    #[test]
+    fn pass_realistic_long_version_output() {
+        let v = verdict_from_version_git_hash(
+            b"apr 0.31.2\nbuild: release\ncommit: b7bf4b07a\nrustc: 1.84.0",
+            b"b7bf4b07a",
+        );
+        assert_eq!(v, Qa005Verdict::Pass);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 3: Fail band — stale binary (hash mismatch).
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fail_old_hash_in_version() {
+        // Binary built from old commit; version shows old hash.
+        let v = verdict_from_version_git_hash(
+            b"apr 0.31.0 (deadbee)",
+            b"b7bf4b0",
+        );
+        assert_eq!(
+            v,
+            Qa005Verdict::Fail,
+            "stale binary must Fail (current hash not in version)"
+        );
+    }
+
+    #[test]
+    fn fail_no_hash_in_version() {
+        let v = verdict_from_version_git_hash(
+            b"apr 0.31.2",
+            b"b7bf4b0",
+        );
+        assert_eq!(v, Qa005Verdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 4: Fail band — empty / wrong-length hash.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fail_empty_hash() {
+        let v = verdict_from_version_git_hash(b"apr 0.31.2 (b7bf4b0)", &[]);
+        assert_eq!(v, Qa005Verdict::Fail);
+    }
+
+    #[test]
+    fn fail_hash_too_short() {
+        // 6 chars is below the 7-char minimum.
+        let v = verdict_from_version_git_hash(
+            b"apr 0.31.2 (b7bf4b)",
+            b"b7bf4b",
+        );
+        assert_eq!(v, Qa005Verdict::Fail);
+    }
+
+    #[test]
+    fn fail_hash_too_long() {
+        // 13 chars exceeds 12-char cap.
+        let v = verdict_from_version_git_hash(
+            b"apr 0.31.2 (b7bf4b07a0000)",
+            b"b7bf4b07a0000",
+        );
+        assert_eq!(v, Qa005Verdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 5: Fail band — non-hex hash (corruption).
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fail_uppercase_hex() {
+        // git --short emits lowercase; uppercase is corruption.
+        let v = verdict_from_version_git_hash(
+            b"apr 0.31.2 (B7BF4B0)",
+            b"B7BF4B0",
+        );
+        assert_eq!(v, Qa005Verdict::Fail);
+    }
+
+    #[test]
+    fn fail_non_hex_chars() {
+        // Has `g` which is invalid hex.
+        let v = verdict_from_version_git_hash(
+            b"apr 0.31.2 (b7g4b0a)",
+            b"b7g4b0a",
+        );
+        assert_eq!(v, Qa005Verdict::Fail);
+    }
+
+    #[test]
+    fn fail_hash_with_dash() {
+        let v = verdict_from_version_git_hash(
+            b"apr 0.31.2 (abc-def)",
+            b"abc-def",
+        );
+        assert_eq!(v, Qa005Verdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 6: Fail band — empty version output.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fail_empty_version_output() {
+        let v = verdict_from_version_git_hash(&[], b"b7bf4b0");
+        assert_eq!(v, Qa005Verdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 7: Realistic — apr release tag scenarios.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn pass_v0_31_release() {
+        let v = verdict_from_version_git_hash(
+            b"apr 0.31.0 (62893da)",
+            b"62893da",
+        );
+        assert_eq!(v, Qa005Verdict::Pass);
+    }
+
+    #[test]
+    fn fail_release_binary_dirty_workspace() {
+        // User has uncommitted changes; current HEAD diverges from
+        // the binary's committed hash.
+        let v = verdict_from_version_git_hash(
+            b"apr 0.31.0 (62893da)",
+            b"a8bb681", // current HEAD differs from binary
+        );
+        assert_eq!(v, Qa005Verdict::Fail);
+    }
+}

--- a/crates/aprender-core/src/format/qa_010.rs
+++ b/crates/aprender-core/src/format/qa_010.rs
@@ -1,0 +1,239 @@
+// SHIP-TWO-001 — `apr-cli-qa-v1` algorithm-level PARTIAL discharge
+// for FALSIFY-QA-010.
+//
+// Contract: `contracts/apr-cli-qa-v1.yaml`.
+// Spec: `docs/specifications/aprender-train/ship-two-models-spec.md`
+// (apr CLI QA gates).
+//
+// ## What FALSIFY-QA-010 says
+//
+//   rule: cross-subcommand architecture consistency
+//   prediction: "inspect and check report same architecture"
+//   test: "diff <(apr inspect --json M | jq .architecture)
+//                <(apr check M 2>&1 | grep -i arch)"
+//   if_fails: "architecture disagrees across subcommands"
+//
+// ## What this file proves NOW (`PARTIAL_ALGORITHM_LEVEL`)
+//
+// Decision rule: given two architecture-string slices extracted
+// from `apr inspect --json` and `apr check`, Pass iff:
+//
+//   inspect_arch is non-empty AND
+//   check_arch is non-empty AND
+//   inspect_arch == check_arch (byte-identical)
+//
+// Positive byte-equality verdict (cf. `bpe_inv_006` encode
+// determinism). Different subcommands MUST agree on the model
+// architecture; disagreement signals a stale parser, a feature-flag
+// drift, or a registry mismatch.
+
+/// Binary verdict for `FALSIFY-QA-010`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Qa010Verdict {
+    /// Both architecture strings are non-empty AND byte-identical.
+    Pass,
+    /// One or more of:
+    /// - Either string is empty (caller error — extraction failed).
+    /// - Strings differ in any byte (architecture disagreement).
+    Fail,
+}
+
+/// Pure verdict function for `FALSIFY-QA-010`.
+///
+/// Inputs:
+/// - `inspect_arch`: architecture string extracted from
+///   `apr inspect --json M | jq .architecture`.
+/// - `check_arch`: architecture string extracted from
+///   `apr check M | grep -i arch`.
+///
+/// Pass iff both non-empty AND `inspect_arch == check_arch`.
+///
+/// Otherwise `Fail`.
+#[must_use]
+pub fn verdict_from_cross_subcmd_arch(
+    inspect_arch: &[u8],
+    check_arch: &[u8],
+) -> Qa010Verdict {
+    if inspect_arch.is_empty() || check_arch.is_empty() {
+        return Qa010Verdict::Fail;
+    }
+    if inspect_arch == check_arch {
+        Qa010Verdict::Pass
+    } else {
+        Qa010Verdict::Fail
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -------------------------------------------------------------------------
+    // Section 1: Pass band — agreement at canonical architectures.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn pass_qwen2_agreement() {
+        let v = verdict_from_cross_subcmd_arch(b"qwen2", b"qwen2");
+        assert_eq!(v, Qa010Verdict::Pass);
+    }
+
+    #[test]
+    fn pass_llama_agreement() {
+        let v = verdict_from_cross_subcmd_arch(b"llama", b"llama");
+        assert_eq!(v, Qa010Verdict::Pass);
+    }
+
+    #[test]
+    fn pass_qwen3_moe_agreement() {
+        let v = verdict_from_cross_subcmd_arch(b"qwen3-moe", b"qwen3-moe");
+        assert_eq!(v, Qa010Verdict::Pass);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 2: Fail band — architecture disagreement.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fail_qwen2_vs_qwen3() {
+        let v = verdict_from_cross_subcmd_arch(b"qwen2", b"qwen3");
+        assert_eq!(
+            v,
+            Qa010Verdict::Fail,
+            "different architectures must Fail"
+        );
+    }
+
+    #[test]
+    fn fail_llama_vs_qwen() {
+        let v = verdict_from_cross_subcmd_arch(b"llama", b"qwen2");
+        assert_eq!(v, Qa010Verdict::Fail);
+    }
+
+    #[test]
+    fn fail_one_byte_difference() {
+        let v = verdict_from_cross_subcmd_arch(b"qwen2", b"qwen3");
+        assert_eq!(v, Qa010Verdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 3: Fail band — case mismatch (case-sensitive).
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fail_case_difference() {
+        let v = verdict_from_cross_subcmd_arch(b"qwen2", b"QWEN2");
+        assert_eq!(
+            v,
+            Qa010Verdict::Fail,
+            "case mismatch must Fail (one subcmd normalized, other didn't)"
+        );
+    }
+
+    #[test]
+    fn fail_inspect_lowercase_check_titlecase() {
+        let v = verdict_from_cross_subcmd_arch(b"llama", b"Llama");
+        assert_eq!(v, Qa010Verdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 4: Fail band — whitespace / formatting differences.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fail_trailing_whitespace() {
+        let v = verdict_from_cross_subcmd_arch(b"qwen2", b"qwen2 ");
+        assert_eq!(v, Qa010Verdict::Fail);
+    }
+
+    #[test]
+    fn fail_leading_whitespace() {
+        let v = verdict_from_cross_subcmd_arch(b"qwen2", b" qwen2");
+        assert_eq!(v, Qa010Verdict::Fail);
+    }
+
+    #[test]
+    fn fail_with_quotes() {
+        // jq sometimes emits values with quotes; `grep` strips them.
+        let v = verdict_from_cross_subcmd_arch(b"\"qwen2\"", b"qwen2");
+        assert_eq!(v, Qa010Verdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 5: Fail band — empty inputs.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fail_inspect_arch_empty() {
+        let v = verdict_from_cross_subcmd_arch(&[], b"qwen2");
+        assert_eq!(v, Qa010Verdict::Fail);
+    }
+
+    #[test]
+    fn fail_check_arch_empty() {
+        let v = verdict_from_cross_subcmd_arch(b"qwen2", &[]);
+        assert_eq!(v, Qa010Verdict::Fail);
+    }
+
+    #[test]
+    fn fail_both_empty() {
+        let v = verdict_from_cross_subcmd_arch(&[], &[]);
+        assert_eq!(
+            v,
+            Qa010Verdict::Fail,
+            "both empty must Fail (vacuous Pass refused)"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 6: Symmetry — verdict is symmetric in (inspect, check).
+    // -------------------------------------------------------------------------
+    #[test]
+    fn verdict_is_symmetric_pass() {
+        let v_ic = verdict_from_cross_subcmd_arch(b"qwen2", b"qwen2");
+        let v_ci = verdict_from_cross_subcmd_arch(b"qwen2", b"qwen2");
+        assert_eq!(v_ic, v_ci);
+        assert_eq!(v_ic, Qa010Verdict::Pass);
+    }
+
+    #[test]
+    fn verdict_is_symmetric_fail() {
+        let v_ic = verdict_from_cross_subcmd_arch(b"qwen2", b"llama");
+        let v_ci = verdict_from_cross_subcmd_arch(b"llama", b"qwen2");
+        assert_eq!(v_ic, v_ci);
+        assert_eq!(v_ic, Qa010Verdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 7: Realistic — full architecture string family.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn pass_realistic_full_architecture_strings() {
+        let v = verdict_from_cross_subcmd_arch(
+            b"qwen2.5-coder-7b",
+            b"qwen2.5-coder-7b",
+        );
+        assert_eq!(v, Qa010Verdict::Pass);
+    }
+
+    #[test]
+    fn fail_realistic_inspect_full_check_short() {
+        // Common drift: inspect emits full name, check emits short.
+        let v = verdict_from_cross_subcmd_arch(
+            b"qwen2.5-coder-7b",
+            b"qwen2",
+        );
+        assert_eq!(v, Qa010Verdict::Fail);
+    }
+
+    #[test]
+    fn fail_inspect_says_qwen3_check_says_qwen2() {
+        // Worst case: stale check parser gives wrong arch.
+        let v = verdict_from_cross_subcmd_arch(b"qwen3-moe", b"qwen2");
+        assert_eq!(v, Qa010Verdict::Fail);
+    }
+
+    #[test]
+    fn pass_albor_llama_370m() {
+        let v = verdict_from_cross_subcmd_arch(
+            b"albor-llama-370m",
+            b"albor-llama-370m",
+        );
+        assert_eq!(v, Qa010Verdict::Pass);
+    }
+}


### PR DESCRIPTION
## Summary
- Algorithm-level PARTIAL discharge for FALSIFY-QA-005 (version contains git hash) AND FALSIFY-QA-010 (cross-subcommand arch consistency) per `contracts/apr-cli-qa-v1.yaml`.
- Two new modules:
  - `qa_005.rs` exporting `verdict_from_version_git_hash(version_output, git_short_hash) -> Qa005Verdict` — substring + hash-shape verdict.
  - `qa_010.rs` exporting `verdict_from_cross_subcmd_arch(inspect_arch, check_arch) -> Qa010Verdict` — byte-equality verdict.
- 37 unit tests total (17 QA-005 + 20 QA-010) across 14 sections.

## ✅ Closes the 10/10 QA sweep on `apr-cli-qa-v1`
All 10 falsifiers now algorithm-level bound: QA-001/002/003/004/005/006/007/008/009/010.

**Four contract families now fully algorithm-bound at PARTIAL:**
- `dataset-thestack-python-v1` (7/7)
- `tokenizer-bpe-v1` (7/7)
- `apr-cli-publish-v1` (4/4)
- `apr-cli-qa-v1` (10/10) ← this PR

## QA-005 highlights
- Pinned `[7, 12]` git short-hash length range.
- Lowercase-hex-only character class (catches uppercase/non-hex corruption).
- Substring containment for the version output (matches contract `grep -q $(git rev-parse --short HEAD)`).

## QA-010 highlights
- Positive byte-equality (cf. `bpe_inv_006` encode determinism).
- Case-sensitive AND whitespace-strict — catches silent normalization between subcommands.
- Symmetry property over (inspect, check).

## Five-Whys (commit-message body has full chain)
1. Bind both → closes 10/10 sweep.
2. Distinct shapes → substring (hash in version) + byte-equality (arch strings).
3. Pin 7..=12 hash length → `--short` truncation guard.
4. Case-sensitive arch → catches normalization drift.
5. 37 tests across 14 sections → mutation-survey breadth.

## Test plan
- [x] `cargo test -p aprender-core --lib qa_005` → 17 passed
- [x] `cargo test -p aprender-core --lib qa_010` → 20 passed
- [x] PMAT pre-commit gates pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)