### PR TITLE
chore(audit): allow RUSTSEC-2026-0114 (wasmtime panic) — unblocks 2026-05-01 CI

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -29,6 +29,11 @@ ignore = [
     "RUSTSEC-2026-0092",
     "RUSTSEC-2026-0094",
     "RUSTSEC-2026-0096",
+    # wasmtime 43 — table allocation panic (severity 5.9 medium). Same
+    # test-only dep + same upgrade path (>=43.0.2 / >=44.0.1) as the
+    # cranelift cluster above. Availability bug, not RCE. Published
+    # 2026-04-30; surfaced first on 2026-05-01 CI runs.
+    "RUSTSEC-2026-0114",
 
     # rustls-webpki 0.101.7 — transitive via aws-smithy-http-client (rustls 0.21).
     # Direct 0.103.x path already bumped to >=0.103.12. The 0.101.7 pin lives

--- a/deny.toml
+++ b/deny.toml
@@ -31,6 +31,7 @@ ignore = [
     { id = "RUSTSEC-2026-0092", reason = "wasmtime: test-only dep (aprender-test-lib)" },
     { id = "RUSTSEC-2026-0094", reason = "wasmtime: test-only dep (aprender-test-lib)" },
     { id = "RUSTSEC-2026-0096", reason = "wasmtime: test-only dep (aprender-test-lib)" },
+    { id = "RUSTSEC-2026-0114", reason = "wasmtime 43 table allocation panic: test-only dep, availability bug not RCE" },
     # rustls-webpki 0.101.7 — transitive via aws-smithy-http-client (rustls 0.21).
     # Direct 0.103.x path already patched to >=0.103.12; 0.101.7 is pinned inside
     # the AWS SDK graph and can only move via a major SDK bump.


### PR DESCRIPTION
## Summary

New RustSec advisory `RUSTSEC-2026-0114` (published 2026-04-30) flags wasmtime 43.0.1 for a table allocation panic. Severity 5.9 (medium). Surfaced as `ci / security: FAILURE` on every PR opened on 2026-05-01 — **blocks the entire current PR queue including the M32d discharge stack (#1222 #1226 #1228 #1232 #1238)**.

## Triage

Same handling as the existing wasmtime advisory cluster (RUSTSEC-2026-0085/0086/0088/0089/0091/0092/0094/0096):
- **test-only dep** (`aprender-test-lib`), not production
- **availability bug** (panic), not RCE / memory safety
- **upgrade path**: >=43.0.2 / >=44.0.1 — same path as the other 8 wasmtime advisories

Adding to ignore list with the same justification keeps consistency with the existing cluster.

## Files

- `.cargo/audit.toml` — adds `RUSTSEC-2026-0114` after the existing wasmtime cluster
- `deny.toml` — adds matching entry per "Mirrors deny.toml ignore list for consistency" comment

## Test plan

- [x] `cargo deny check advisories 2>&1 | grep -c RUSTSEC` produces same count
- [x] FALSIFY-AUDIT-001 invariant maintained (audit.toml IDs == --ignore flags passed)

## Refs

- Unblocks PRs #1222 #1226 #1228 #1232 #1238 (M32d discharge stack)
- RUSTSEC-2026-0114: https://rustsec.org/advisories/RUSTSEC-2026-0114

🤖 Generated with [Claude Code](https://claude.com/claude-code)