### PR TITLE
fix(aprender-serve): M32d Step 7 — sync forward_qwen3_moe_traced with Step 5 Q/K-norm fix

### DIFF
--- a/crates/apr-cli/src/commands/trace.rs
+++ b/crates/apr-cli/src/commands/trace.rs
@@ -365,8 +365,27 @@ fn run_traced_inference_gguf(path: &Path) -> Result<(), CliError> {
     // stats for APR-vs-GGUF bisection (the §23 layer-3 ffn_swigl 17×
     // anomaly comparison). Run BEFORE generation so the trace reflects
     // a pristine forward pass on the test prompt.
+    //
+    // M32d Step 2 (claude-code-parity-apr-poc.md § "M32d FAST PATH"):
+    // qwen3_moe-arch GGUF dispatches to forward_qwen3_moe_traced because
+    // the dense path's forward_traced doesn't exercise the MoE FFN
+    // dispatch — it would silently skip the MoE-specific computation.
     println!("{}", "FORWARD PASS (with layer tracing):".green().bold());
-    match model.forward_traced(&test_tokens) {
+    let canonical_arch = realizar::tensor_names::normalize_architecture(&config.architecture);
+    // Accept both canonical "qwen3_moe" and raw GGUF-reported "qwen3moe"
+    // (no underscore) — the build.rs codegen sometimes lags on the YAML
+    // alias mapping `qwen3moe → qwen3_moe`. Robust string comparison is
+    // cheaper than relying on the generator cache being current.
+    let raw_arch_lower = config.architecture.to_lowercase();
+    let is_qwen3_moe = canonical_arch == "qwen3_moe"
+        || raw_arch_lower == "qwen3moe"
+        || raw_arch_lower == "qwen3_moe";
+    let trace_result = if is_qwen3_moe {
+        run_qwen3_moe_traced_forward(&mapped, &model, &test_tokens)
+    } else {
+        model.forward_traced(&test_tokens)
+    };
+    match trace_result {
         Ok(trace) => {
             println!();
             println!("{}", "EMBEDDING:".cyan().bold());
@@ -391,7 +410,24 @@ fn run_traced_inference_gguf(path: &Path) -> Result<(), CliError> {
     }
     println!();
 
-    // Run generation with small max_tokens to see what comes out
+    // Run generation with small max_tokens to see what comes out.
+    //
+    // M32d Step 2 (claude-code-parity-apr-poc.md § "M32d FAST PATH"):
+    // qwen3_moe-arch GGUF cannot use generate_with_cache because that
+    // method calls the dense FFN path on the placeholder zero weights
+    // (per M32c.2.2 LAZY-FUSED-MATVEC strategy — dense FFN fields are
+    // empty stubs for MoE models). Skip generation for qwen3_moe; the
+    // traced forward output above is the load-bearing diagnostic for
+    // FAST PATH Step 3 (per-layer cosine bisection vs HF FP16).
+    if is_qwen3_moe {
+        println!(
+            "{}",
+            "GENERATION: skipped for qwen3_moe (use `apr run` for text generation)".yellow()
+        );
+        println!();
+        return Ok(());
+    }
+
     println!("{}", "GENERATION (max 8 tokens):".green().bold());
     let gen_config = QuantizedGenerateConfig {
         max_tokens: 8,
@@ -451,6 +487,60 @@ fn run_traced_inference_gguf(path: &Path) -> Result<(), CliError> {
     }
 
     Ok(())
+}
+
+/// M32d Step 2 — qwen3_moe-arch traced forward dispatch helper.
+///
+/// Reads MoE config (num_experts, num_experts_per_tok, moe_intermediate)
+/// from GGUF metadata, loads per-layer Qwen3MoeQuantizedLayer descriptors,
+/// then calls forward_qwen3_moe_traced. Returns ForwardTrace with one
+/// LayerActivation per decoder layer; sub-FFN slots are zero (no globally
+/// meaningful SwiGLU breakdown in MoE).
+///
+/// Companion spec: paiml/claude-code-parity-apr docs/specifications/
+/// claude-code-parity-apr-poc.md § "M32d FAST PATH" Step 2.
+#[cfg(feature = "inference")]
+fn run_qwen3_moe_traced_forward(
+    mapped: &realizar::gguf::MappedGGUFModel,
+    model: &realizar::gguf::OwnedQuantizedModel,
+    test_tokens: &[u32],
+) -> realizar::error::Result<realizar::apr_transformer::ForwardTrace> {
+    let num_experts = mapped.model.expert_count().ok_or_else(|| {
+        realizar::error::RealizarError::InvalidShape {
+            reason: "qwen3_moe trace: missing 'expert_count' in GGUF metadata".to_string(),
+        }
+    })?;
+    let num_experts_per_tok = mapped.model.expert_used_count().ok_or_else(|| {
+        realizar::error::RealizarError::InvalidShape {
+            reason: "qwen3_moe trace: missing 'expert_used_count' in GGUF metadata".to_string(),
+        }
+    })?;
+    let moe_intermediate = mapped.model.expert_feed_forward_length().ok_or_else(|| {
+        realizar::error::RealizarError::InvalidShape {
+            reason: "qwen3_moe trace: missing 'expert_feed_forward_length' in GGUF metadata"
+                .to_string(),
+        }
+    })?;
+
+    let data = mapped.data();
+    let num_layers = model.config().num_layers;
+    let mut moe_layers = Vec::with_capacity(num_layers);
+    for layer_idx in 0..num_layers {
+        moe_layers.push(realizar::gguf::qwen3_moe_load::load_qwen3_moe_layer(
+            &mapped.model,
+            data,
+            layer_idx,
+        )?);
+    }
+
+    model.forward_qwen3_moe_traced(
+        test_tokens,
+        &moe_layers,
+        num_experts,
+        num_experts_per_tok,
+        moe_intermediate,
+        data,
+    )
 }
 
 /// Stub for GGUF inference when inference feature is disabled

--- a/crates/aprender-serve/src/gguf/inference/forward/forward_qwen3_moe_traced.rs
+++ b/crates/aprender-serve/src/gguf/inference/forward/forward_qwen3_moe_traced.rs
@@ -162,7 +162,10 @@ impl OwnedQuantizedModel {
             let qkv_stats =
                 ActivationStats::from_slice(&qkv[qkv_last_start..qkv_last_start + qkv_dim]);
 
-            // 2c. RoPE + extract Q/K/V
+            // 2c. Per-position per-head Q/K RMSNorm (GH-279, Qwen3) + RoPE +
+            // extract Q/K/V. Mirrors forward_qwen3_moe::forward_qwen3_moe
+            // post-Step-5 fix (M32d FAST PATH) so the diagnostic trace shows
+            // the same numerics as the production path.
             let mut q_all = Vec::with_capacity(seq_len * q_dim);
             let mut k_all = Vec::with_capacity(seq_len * k_dim);
             let mut v_all = Vec::with_capacity(seq_len * v_dim);
@@ -171,6 +174,25 @@ impl OwnedQuantizedModel {
                 let mut q = qkv[qkv_start..qkv_start + q_dim].to_vec();
                 let mut k = qkv[qkv_start + q_dim..qkv_start + q_dim + k_dim].to_vec();
                 let v = &qkv[qkv_start + q_dim + k_dim..qkv_start + q_dim + k_dim + v_dim];
+
+                // GH-279: per-head Q/K RMSNorm AFTER bias, BEFORE RoPE.
+                if let Some(ref q_norm) = layer.attn_q_norm_weight {
+                    ops::apply_per_head_rms_norm(
+                        &mut q,
+                        q_norm,
+                        self.config.num_heads,
+                        self.config.eps,
+                    );
+                }
+                if let Some(ref k_norm) = layer.attn_k_norm_weight {
+                    ops::apply_per_head_rms_norm(
+                        &mut k,
+                        k_norm,
+                        self.config.num_kv_heads,
+                        self.config.eps,
+                    );
+                }
+
                 if self.config.constraints.uses_rope() {
                     self.apply_rope(&mut q, s, self.config.num_heads);
                     self.apply_rope(&mut k, s, self.config.num_kv_heads);

--- a/crates/aprender-serve/src/gguf/inference/forward/forward_qwen3_moe_traced.rs
+++ b/crates/aprender-serve/src/gguf/inference/forward/forward_qwen3_moe_traced.rs
@@ -1,0 +1,311 @@
+//! M32d Step 2 (companion `claude-code-parity-apr-poc.md` § "M32d FAST PATH") —
+//! `forward_qwen3_moe_traced` per-layer ActivationStats variant of
+//! `forward_qwen3_moe`.
+//!
+//! ## Purpose
+//!
+//! Step 2 of the M34 five-whys FAST PATH plan converts `apr trace --json
+//! --payload` from "returns null per-layer stats for qwen3_moe" to "returns
+//! finite per-layer L2 + dim-mean/std for every transformer block". Without
+//! this, Step 3 (per-layer cosine bisection vs HF FP16 reference) has no
+//! input.
+//!
+//! ## Method
+//!
+//! Mirrors `OwnedQuantizedModel::forward_qwen3_moe` step-for-step. After each
+//! stat boundary in the layer loop, grab the LAST token's hidden-state slice
+//! and compute `ActivationStats::from_slice`. Sub-FFN slots
+//! (`ffn_gate_stats`, `ffn_up_stats`, `ffn_silu_gate_stats`,
+//! `ffn_swiglu_inner_stats`) default to zero — MoE has no globally meaningful
+//! SwiGLU breakdown because the per-expert SwiGLU is internal to
+//! `moe_ffn_forward_layer` and is weighted+aggregated across top-k experts
+//! before producing `ffn_out`. If component-level breakdown becomes needed
+//! at Step 4, the MoE-specific breakdown is a separate add (router output,
+//! per-expert contribution, etc.).
+//!
+//! ## Hot path safety
+//!
+//! Production `forward_qwen3_moe` is unchanged. This is a parallel slow path
+//! used only by `apr trace`. Allocation cost is acceptable for the diagnostic
+//! CLI use case.
+
+use crate::apr_transformer::{ActivationStats, ForwardTrace, LastTokenStats, LayerActivation};
+use crate::error::Result;
+use crate::gguf::ops;
+use crate::gguf::qwen3_moe_load::{moe_ffn_forward_layer, Qwen3MoeQuantizedLayer};
+use crate::gguf::OwnedQuantizedModel;
+
+impl OwnedQuantizedModel {
+    /// Run a single forward pass for a Qwen3-MoE-arch model and capture
+    /// per-layer activation statistics for the LAST token.
+    ///
+    /// Mirrors `Self::forward_qwen3_moe` numerically; differs only in stat
+    /// capture. Used by `apr trace --json --payload` to drive M34 FAST PATH
+    /// Step 3 (per-layer cosine bisection vs HF FP16 reference).
+    ///
+    /// # Arguments
+    ///
+    /// Identical to `forward_qwen3_moe`.
+    ///
+    /// # Returns
+    ///
+    /// `ForwardTrace` containing per-layer `LayerActivation` for every
+    /// decoder layer plus embedding/final-norm/logit stats. Last-token-only
+    /// stats per FALSIFY-APR-GGUF-PARITY-007 count-parity convention.
+    ///
+    /// # Errors
+    ///
+    /// Same as `forward_qwen3_moe`: invalid shape, MoE config violations,
+    /// or fused-matmul kernel errors.
+    #[allow(clippy::too_many_arguments)]
+    pub fn forward_qwen3_moe_traced(
+        &self,
+        token_ids: &[u32],
+        moe_layers: &[Qwen3MoeQuantizedLayer],
+        num_experts: usize,
+        num_experts_per_tok: usize,
+        moe_intermediate: usize,
+        data: &[u8],
+    ) -> Result<ForwardTrace> {
+        let hidden_dim = self.config.hidden_dim;
+
+        if token_ids.is_empty() {
+            return Err(crate::error::RealizarError::InvalidShape {
+                reason: "forward_qwen3_moe_traced: token_ids must not be empty".to_string(),
+            });
+        }
+        if moe_layers.len() != self.layers.len() {
+            return Err(crate::error::RealizarError::InvalidShape {
+                reason: format!(
+                    "forward_qwen3_moe_traced: moe_layers.len() = {} but model has {} decoder layers",
+                    moe_layers.len(),
+                    self.layers.len()
+                ),
+            });
+        }
+        if num_experts == 0 || num_experts_per_tok == 0 || moe_intermediate == 0 {
+            return Err(crate::error::RealizarError::InvalidShape {
+                reason: format!(
+                    "forward_qwen3_moe_traced: incomplete MoE config — num_experts={num_experts}, \
+                     num_experts_per_tok={num_experts_per_tok}, moe_intermediate={moe_intermediate}."
+                ),
+            });
+        }
+
+        let seq_len = token_ids.len();
+        let last_start = (seq_len - 1) * hidden_dim;
+
+        // 1. Token embedding
+        let mut hidden = self.embed(token_ids);
+        if self.config.constraints.uses_absolute_positions() {
+            if let Some(ref pos_emb) = self.position_embedding {
+                for (s, _) in token_ids.iter().enumerate() {
+                    let pos_start = s * hidden_dim;
+                    let pos_end = pos_start + hidden_dim;
+                    if pos_end <= pos_emb.len() {
+                        let h_start = s * hidden_dim;
+                        for i in 0..hidden_dim {
+                            hidden[h_start + i] += pos_emb[pos_start + i];
+                        }
+                    }
+                }
+            }
+        }
+        let embed_stats = ActivationStats::from_slice(&hidden[last_start..last_start + hidden_dim]);
+
+        let use_rmsnorm = self.config.constraints.uses_rmsnorm();
+        let intermediate = moe_intermediate;
+
+        let mut layer_activations: Vec<LayerActivation> = Vec::with_capacity(self.layers.len());
+
+        // 2. Per-layer
+        for (layer_idx, layer) in self.layers.iter().enumerate() {
+            // 2a. Attention norm
+            let normed = if use_rmsnorm {
+                ops::rms_norm(&hidden, &layer.attn_norm_weight, self.config.eps)
+            } else {
+                ops::layer_norm(
+                    &hidden,
+                    &layer.attn_norm_weight,
+                    layer.attn_norm_bias.as_deref(),
+                    self.config.eps,
+                )
+            };
+            let attn_norm_stats =
+                ActivationStats::from_slice(&normed[last_start..last_start + hidden_dim]);
+
+            // 2b. QKV projection
+            let qkv_dim = layer.qkv_weight.out_dim();
+            let q_dim = layer.qkv_weight.q_dim_for_config(
+                self.config.num_heads,
+                self.config.num_kv_heads,
+                self.config.hidden_dim,
+                self.config.head_dim(),
+            );
+            let k_dim = layer.qkv_weight.k_dim_for_config(
+                self.config.num_heads,
+                self.config.num_kv_heads,
+                self.config.hidden_dim,
+                self.config.head_dim(),
+            );
+            let v_dim = layer.qkv_weight.v_dim_for_config(
+                self.config.num_heads,
+                self.config.num_kv_heads,
+                self.config.hidden_dim,
+                self.config.head_dim(),
+            );
+            let mut qkv = self.qkv_matmul(&normed, &layer.qkv_weight)?;
+            if let Some(ref bias) = layer.qkv_bias {
+                ops::add_bias(&mut qkv, bias);
+            }
+            let qkv_last_start = (seq_len - 1) * qkv_dim;
+            let qkv_stats =
+                ActivationStats::from_slice(&qkv[qkv_last_start..qkv_last_start + qkv_dim]);
+
+            // 2c. RoPE + extract Q/K/V
+            let mut q_all = Vec::with_capacity(seq_len * q_dim);
+            let mut k_all = Vec::with_capacity(seq_len * k_dim);
+            let mut v_all = Vec::with_capacity(seq_len * v_dim);
+            for s in 0..seq_len {
+                let qkv_start = s * qkv_dim;
+                let mut q = qkv[qkv_start..qkv_start + q_dim].to_vec();
+                let mut k = qkv[qkv_start + q_dim..qkv_start + q_dim + k_dim].to_vec();
+                let v = &qkv[qkv_start + q_dim + k_dim..qkv_start + q_dim + k_dim + v_dim];
+                if self.config.constraints.uses_rope() {
+                    self.apply_rope(&mut q, s, self.config.num_heads);
+                    self.apply_rope(&mut k, s, self.config.num_kv_heads);
+                }
+                q_all.extend_from_slice(&q);
+                k_all.extend_from_slice(&k);
+                v_all.extend_from_slice(v);
+            }
+
+            // 2d. Causal attention + output projection
+            let attn_out = self.causal_attention(&q_all, &k_all, &v_all, seq_len);
+            let mut attn_output = self.fused_matmul(&attn_out, &layer.attn_output_weight)?;
+            if let Some(ref bias) = layer.attn_output_bias {
+                ops::add_bias(&mut attn_output, bias);
+            }
+            let attn_out_stats =
+                ActivationStats::from_slice(&attn_output[last_start..last_start + hidden_dim]);
+
+            // 2e. Residual
+            for i in 0..hidden.len() {
+                hidden[i] += attn_output[i];
+            }
+
+            // 2f. Pre-FFN norm
+            let ffn_input = if let Some(ref ffn_norm) = layer.ffn_norm_weight {
+                if use_rmsnorm {
+                    ops::rms_norm(&hidden, ffn_norm, self.config.eps)
+                } else {
+                    ops::layer_norm(
+                        &hidden,
+                        ffn_norm,
+                        layer.ffn_norm_bias.as_deref(),
+                        self.config.eps,
+                    )
+                }
+            } else {
+                hidden.clone()
+            };
+            let ffn_norm_stats =
+                ActivationStats::from_slice(&ffn_input[last_start..last_start + hidden_dim]);
+
+            // 2g. MoE FFN
+            let mut ffn_output = vec![0.0f32; seq_len * hidden_dim];
+            for s in 0..seq_len {
+                let pos_in = &ffn_input[s * hidden_dim..(s + 1) * hidden_dim];
+                let pos_out = moe_ffn_forward_layer(
+                    pos_in,
+                    &moe_layers[layer_idx],
+                    num_experts,
+                    num_experts_per_tok,
+                    intermediate,
+                    hidden_dim,
+                    data,
+                )?;
+                ffn_output[s * hidden_dim..(s + 1) * hidden_dim].copy_from_slice(&pos_out);
+            }
+            let ffn_out_stats =
+                ActivationStats::from_slice(&ffn_output[last_start..last_start + hidden_dim]);
+
+            // 2h. Residual into hidden
+            for i in 0..hidden.len() {
+                hidden[i] += ffn_output[i];
+            }
+            let output_stats =
+                ActivationStats::from_slice(&hidden[last_start..last_start + hidden_dim]);
+
+            // Sub-FFN slots default to zero — MoE has no globally-meaningful
+            // SwiGLU breakdown (per-expert SwiGLU is internal to
+            // moe_ffn_forward_layer and weighted-aggregated before producing
+            // ffn_out_stats). Step 4 of M34 FAST PATH may add MoE-specific
+            // sub-component breakdown (router output, per-expert
+            // contribution).
+            let ffn_gate_stats = ActivationStats::default();
+            let ffn_up_stats = ActivationStats::default();
+            let ffn_silu_gate_stats = ActivationStats::default();
+            let ffn_swiglu_inner_stats = ActivationStats::default();
+
+            let last_token = Some(LastTokenStats {
+                attn_norm_stats: attn_norm_stats.clone(),
+                qkv_stats: qkv_stats.clone(),
+                attn_out_stats: attn_out_stats.clone(),
+                ffn_norm_stats: ffn_norm_stats.clone(),
+                ffn_gate_stats: ffn_gate_stats.clone(),
+                ffn_up_stats: ffn_up_stats.clone(),
+                ffn_silu_gate_stats: ffn_silu_gate_stats.clone(),
+                ffn_swiglu_inner_stats: ffn_swiglu_inner_stats.clone(),
+                ffn_out_stats: ffn_out_stats.clone(),
+                output_stats: output_stats.clone(),
+            });
+
+            layer_activations.push(LayerActivation {
+                layer_idx,
+                attn_norm_stats,
+                qkv_stats,
+                attn_out_stats,
+                ffn_norm_stats,
+                ffn_gate_stats,
+                ffn_up_stats,
+                ffn_silu_gate_stats,
+                ffn_swiglu_inner_stats,
+                ffn_out_stats,
+                output_stats,
+                last_token,
+            });
+        }
+
+        // 3. Final layer norm
+        let normed = if use_rmsnorm {
+            ops::rms_norm(&hidden, &self.output_norm_weight, self.config.eps)
+        } else {
+            ops::layer_norm(
+                &hidden,
+                &self.output_norm_weight,
+                self.output_norm_bias.as_deref(),
+                self.config.eps,
+            )
+        };
+        let final_norm_stats =
+            ActivationStats::from_slice(&normed[last_start..last_start + hidden_dim]);
+
+        // 4. LM head — last token only
+        let last_hidden = &normed[last_start..last_start + hidden_dim];
+        let mut logits = self.fused_matmul(last_hidden, &self.lm_head_weight)?;
+        if let Some(ref bias) = self.lm_head_bias {
+            ops::add_bias(&mut logits, bias);
+        }
+        let logits_stats = ActivationStats::from_slice(&logits);
+
+        Ok(ForwardTrace {
+            input_tokens: token_ids.to_vec(),
+            embed_stats,
+            layer_activations,
+            final_norm_stats,
+            logits_stats,
+            logits,
+        })
+    }
+}

--- a/crates/aprender-serve/src/gguf/inference/forward/mod.rs
+++ b/crates/aprender-serve/src/gguf/inference/forward/mod.rs
@@ -9,6 +9,7 @@ mod batch;
 mod core;
 mod encoder_decoder;
 mod forward_qwen3_moe;
+mod forward_qwen3_moe_traced;
 mod single;
 mod traced;
 

--- a/crates/aprender-serve/tests/qwen3_moe_traced_forward.rs
+++ b/crates/aprender-serve/tests/qwen3_moe_traced_forward.rs
@@ -1,0 +1,216 @@
+//! M32d Step 2 falsifier — `forward_qwen3_moe_traced` per-layer
+//! ActivationStats variant of `forward_qwen3_moe`.
+//!
+//! Companion `claude-code-parity-apr-poc.md` § "M32d FAST PATH" Step 2:
+//!
+//!   "wire `apr trace --json --payload` into qwen3_moe forward (today
+//!    returns null per-layer stats). Add a parallel
+//!    `forward_qwen3_moe_traced` that records each of the 48 layer
+//!    outputs."
+//!
+//! ### Exit criterion (per spec)
+//!
+//!   "`apr trace --json --payload <gguf> --prompt "What is 2+2?"` returns
+//!    non-null `output_stats` for every `transformer_block_N` entry, with
+//!    finite L2 norms."
+//!
+//! This test asserts the in-memory equivalent: `forward_qwen3_moe_traced`
+//! returns a `ForwardTrace` with one `LayerActivation` per decoder layer
+//! whose every populated `ActivationStats` slot is finite. Once this
+//! method is wired into the `apr trace` orchestrator (separate PR), the
+//! CLI exit criterion is mechanically satisfied.
+//!
+//! Skipped when GGUF absent (fixture-absent ≠ defect, per
+//! M32c.2.2.2.1.4 convention).
+
+use realizar::gguf::qwen3_moe_load::load_qwen3_moe_layer;
+use realizar::gguf::{MappedGGUFModel, OwnedQuantizedModel, QuantizedGGUFTransformer};
+
+use std::path::Path;
+
+const CANONICAL_QWEN3_CODER_GGUF_PATHS: &[&str] = &[
+    "/home/noah/.cache/pacha/models/2b88b180a790988f.gguf",
+    "/mnt/nvme-raid0/models/qwen3-coder-30b-q4k.gguf",
+];
+
+const EXPECTED_NUM_LAYERS: usize = 48;
+const EXPECTED_INTERMEDIATE: usize = 768;
+const EXPECTED_N_EXPERTS: usize = 128;
+const EXPECTED_K: usize = 8;
+const EXPECTED_VOCAB: usize = 151936;
+
+#[test]
+fn f_qw3_moe_step2_001_traced_returns_per_layer_finite_stats() {
+    let Some(gguf_path) = CANONICAL_QWEN3_CODER_GGUF_PATHS
+        .iter()
+        .find(|p| Path::new(p).exists())
+    else {
+        eprintln!(
+            "F-QW3-MOE-STEP2-001: skipped — no cached Qwen3-Coder GGUF at any of: {:?}",
+            CANONICAL_QWEN3_CODER_GGUF_PATHS
+        );
+        return;
+    };
+
+    eprintln!("F-QW3-MOE-STEP2-001: traced forward against {gguf_path}");
+
+    let mapped = MappedGGUFModel::from_path(gguf_path).expect("mmap GGUF");
+    let data = mapped.data();
+    let _transformer = QuantizedGGUFTransformer::from_gguf_for_moe(&mapped.model, data)
+        .expect("from_gguf_for_moe must succeed");
+    let model =
+        OwnedQuantizedModel::from_mapped(&mapped).expect("OwnedQuantizedModel::from_mapped");
+
+    let mut moe_layers = Vec::with_capacity(EXPECTED_NUM_LAYERS);
+    for layer_idx in 0..EXPECTED_NUM_LAYERS {
+        moe_layers.push(
+            load_qwen3_moe_layer(&mapped.model, data, layer_idx)
+                .unwrap_or_else(|e| panic!("layer {layer_idx} MoE load failed: {e:?}")),
+        );
+    }
+
+    let token_ids = vec![0u32];
+
+    eprintln!("F-QW3-MOE-STEP2-001: running traced forward (this takes a few minutes)...");
+    let start = std::time::Instant::now();
+    let trace = model
+        .forward_qwen3_moe_traced(
+            &token_ids,
+            &moe_layers,
+            EXPECTED_N_EXPERTS,
+            EXPECTED_K,
+            EXPECTED_INTERMEDIATE,
+            data,
+        )
+        .expect("F-QW3-MOE-STEP2-001: forward_qwen3_moe_traced should succeed");
+    let elapsed = start.elapsed();
+
+    // Per-layer count parity
+    assert_eq!(
+        trace.layer_activations.len(),
+        EXPECTED_NUM_LAYERS,
+        "F-QW3-MOE-STEP2-001: must produce one LayerActivation per decoder layer"
+    );
+
+    // Logits shape parity (matches f_qw3_moe_c22211_001)
+    assert_eq!(
+        trace.logits.len(),
+        EXPECTED_VOCAB,
+        "F-QW3-MOE-STEP2-001: logits len must equal vocab_size"
+    );
+    assert!(
+        trace.logits.iter().all(|v| v.is_finite()),
+        "F-QW3-MOE-STEP2-001: all logits must be finite"
+    );
+
+    // Embed/final-norm/logits stats finite
+    assert_finite_stats(&trace.embed_stats, "embed_stats");
+    assert_finite_stats(&trace.final_norm_stats, "final_norm_stats");
+    assert_finite_stats(&trace.logits_stats, "logits_stats");
+    assert_eq!(
+        trace.embed_stats.count, 2048,
+        "embed_stats count == hidden_dim"
+    );
+
+    // Per-layer: every populated stat slot is finite. Sub-FFN slots
+    // default to zero (no SwiGLU breakdown in MoE) — those are explicitly
+    // allowed.
+    for (i, layer) in trace.layer_activations.iter().enumerate() {
+        assert_eq!(
+            layer.layer_idx, i,
+            "F-QW3-MOE-STEP2-001: layer_idx must match position"
+        );
+        assert_finite_stats(&layer.attn_norm_stats, &format!("layer[{i}].attn_norm"));
+        assert_finite_stats(&layer.qkv_stats, &format!("layer[{i}].qkv"));
+        assert_finite_stats(&layer.attn_out_stats, &format!("layer[{i}].attn_out"));
+        assert_finite_stats(&layer.ffn_norm_stats, &format!("layer[{i}].ffn_norm"));
+        assert_finite_stats(&layer.ffn_out_stats, &format!("layer[{i}].ffn_out"));
+        assert_finite_stats(&layer.output_stats, &format!("layer[{i}].output"));
+
+        // count must equal hidden_dim for the populated slots
+        assert_eq!(
+            layer.attn_norm_stats.count, 2048,
+            "layer[{i}].attn_norm.count must equal hidden_dim"
+        );
+        assert_eq!(
+            layer.output_stats.count, 2048,
+            "layer[{i}].output.count must equal hidden_dim"
+        );
+    }
+
+    let l2: f32 = trace.logits.iter().map(|v| v * v).sum::<f32>().sqrt();
+    eprintln!(
+        "F-QW3-MOE-STEP2-001: PASS\n  elapsed = {:?}\n  layers traced = {}\n  ||logits||_2 = {:.4}\n  layer[0].output_stats.std_dev = {:.4}\n  layer[47].output_stats.std_dev = {:.4}",
+        elapsed,
+        trace.layer_activations.len(),
+        l2,
+        trace.layer_activations[0].output_stats.std_dev,
+        trace.layer_activations[EXPECTED_NUM_LAYERS - 1]
+            .output_stats
+            .std_dev
+    );
+}
+
+#[test]
+fn f_qw3_moe_step2_002_traced_rejects_empty_input() {
+    // Pure error-path test — runs without GGUF.
+    let mapped_path = CANONICAL_QWEN3_CODER_GGUF_PATHS
+        .iter()
+        .find(|p| Path::new(p).exists());
+    let Some(gguf_path) = mapped_path else {
+        eprintln!("F-QW3-MOE-STEP2-002: skipped — no cached GGUF for model construction");
+        return;
+    };
+    let mapped = MappedGGUFModel::from_path(gguf_path).expect("mmap GGUF");
+    let data = mapped.data();
+    let _transformer = QuantizedGGUFTransformer::from_gguf_for_moe(&mapped.model, data)
+        .expect("from_gguf_for_moe");
+    let model = OwnedQuantizedModel::from_mapped(&mapped).expect("from_mapped");
+
+    let result = model.forward_qwen3_moe_traced(
+        &[],
+        &[],
+        EXPECTED_N_EXPERTS,
+        EXPECTED_K,
+        EXPECTED_INTERMEDIATE,
+        data,
+    );
+    assert!(
+        result.is_err(),
+        "F-QW3-MOE-STEP2-002: empty token_ids must error"
+    );
+}
+
+fn assert_finite_stats(stats: &realizar::apr_transformer::ActivationStats, label: &str) {
+    assert_eq!(
+        stats.nan_count, 0,
+        "{label}: nan_count must be 0, got {}",
+        stats.nan_count
+    );
+    assert_eq!(
+        stats.inf_count, 0,
+        "{label}: inf_count must be 0, got {}",
+        stats.inf_count
+    );
+    assert!(
+        stats.min.is_finite(),
+        "{label}: min must be finite, got {}",
+        stats.min
+    );
+    assert!(
+        stats.max.is_finite(),
+        "{label}: max must be finite, got {}",
+        stats.max
+    );
+    assert!(
+        stats.mean.is_finite(),
+        "{label}: mean must be finite, got {}",
+        stats.mean
+    );
+    assert!(
+        stats.std_dev.is_finite(),
+        "{label}: std_dev must be finite, got {}",
+        stats.std_dev
+    );
+    assert!(stats.count > 0, "{label}: count must be > 0");
+}


### PR DESCRIPTION
## TL;DR

**Stacks transitively on #1238 → #1232 → #1228 → #1226 → #1222.**

PR #1222's `forward_qwen3_moe_traced` was authored as a step-for-step mirror of `forward_qwen3_moe` AT THE TIME — when both were missing the per-head Q/K RMSNorm. After #1228 (Step 5) added the norm to the production path, the traced variant kept the bug. This PR syncs them.

## Why this matters

Without this sync, `apr trace --payload` shows DIFFERENT numerics from `apr run` for the same prompt + GGUF — silent diagnostic-vs-production drift. The traced variant becomes USELESS for diagnosing real numerical issues because it's running its own buggy forward.

## The fix

Mirror the same per-head Q/K RMSNorm into `forward_qwen3_moe_traced`'s per-position loop, AFTER bias and BEFORE RoPE — same code as #1228.

## Live verification on lambda-vector RTX 4090

- ✅ `cargo test -p aprender-serve --test qwen3_moe_traced_forward --release` — 2/2 PASS in 7.56s
- ✅ `apr trace --payload <Qwen3-Coder GGUF>` reports healthier per-layer std growth post-sync
- ✅ Sibling F-QW3-MOE-STEP5-001 regression test still passes

## rope_theta auto-applied

`forward_qwen3_moe_traced` reads `self.config.rope_theta` which is set at model load time from `default_rope_theta_for_architecture` (PR #1232). So Step 5b's rope_theta fix is automatically inherited via config — no separate sync needed.

## What this PR does NOT ship

- All other forward stages (norms, MoE FFN dispatch, lm_head, etc.) were already mirrored correctly in the original Step 2 PR — no further sync needed.

## Test plan

- [x] `cargo check -p aprender-serve --lib` — clean
- [x] `cargo clippy -p aprender-serve --lib -- -D warnings` — clean
- [x] `cargo fmt -p aprender-serve --check` — clean
- [x] `cargo test -p aprender-serve --test qwen3_moe_traced_forward --release` — 2/2 PASS
- [x] `cargo test -p aprender-serve --test qwen3_moe_qk_norm_regression --release` — 1/1 PASS

## Refs

- Stacks transitively on #1238 → #1232 → #1228 → #1226 → #1222
- M32d Step 7 sync (M34 FAST PATH plan, `paiml/claude-code-parity-apr` § "M32d FAST PATH")
- GH-279 (Qwen3 per-head Q/K RMSNorm)
- FALSIFY-QW3-MOE-FORWARD-003

🤖 Generated with [Claude Code](https://claude.com/claude-code)