### PR TITLE
feat(apr-cli): SHIP-007 PR-A — `apr trace --save-tensor` clap surface

### DIFF
--- a/crates/apr-cli/src/commands_enum.rs
+++ b/crates/apr-cli/src/commands_enum.rs
@@ -255,6 +255,23 @@ pub enum Commands {
         /// Interactive mode
         #[arg(long)]
         interactive: bool,
+        /// Save per-stage F32 tensors during trace for SHIP-007 layer-0
+        /// element-wise diff. Comma-separated stage names from
+        /// `apr-cli-trace-save-tensor-v1.yaml` (e.g.
+        /// `embedding,qkv_matmul,attention`). Pass `all` to save every
+        /// stage. Output goes to `--save-tensor-dir` if provided,
+        /// else `<file_dir>/trace-tensors/<run_id>/`.
+        #[arg(long, value_name = "STAGES")]
+        save_tensor: Option<String>,
+        /// Output directory for `--save-tensor` (default: sibling
+        /// `trace-tensors/<run_id>/`).
+        #[arg(long, value_name = "DIR")]
+        save_tensor_dir: Option<PathBuf>,
+        /// Layer-id range for `--save-tensor` (default: 0..1, i.e.
+        /// layer 0 only). Format: `START..END` (Rust range syntax,
+        /// END exclusive).
+        #[arg(long, value_name = "RANGE", default_value = "0..1")]
+        save_tensor_layers: String,
     },
     /// Check for best practices and conventions
     Lint {

--- a/crates/apr-cli/src/dispatch.rs
+++ b/crates/apr-cli/src/dispatch.rs
@@ -261,7 +261,20 @@ fn dispatch_diagnostic_commands(cli: &Cli) -> Option<Result<(), CliError>> {
             payload,
             diff,
             interactive,
+            save_tensor,
+            save_tensor_dir,
+            save_tensor_layers,
         } => crate::error::resolve_model_path(file).and_then(|r| {
+            // SHIP-007 layer-0 stage diff: emit a stub message until
+            // the forward_traced wiring lands (PR-B). The clap surface
+            // is shipped here so the contract `apr-cli-trace-save-tensor-v1`
+            // CLI signature is bound at the binary boundary.
+            if let Some(stages) = save_tensor.as_deref() {
+                eprintln!(
+                    "apr trace: --save-tensor={stages} --save-tensor-dir={:?} --save-tensor-layers={save_tensor_layers} (PR-B will plumb to forward_traced)",
+                    save_tensor_dir,
+                );
+            }
             trace::run(
                 &r,
                 layer.as_deref(),

--- a/crates/apr-cli/src/lib_dispatch_coverage.rs
+++ b/crates/apr-cli/src/lib_dispatch_coverage.rs
@@ -558,6 +558,9 @@
             payload: false,
             diff: false,
             interactive: false,
+            save_tensor: None,
+            save_tensor_dir: None,
+            save_tensor_layers: "0..1".to_string(),
         });
         let result = dispatch_diagnostic_commands(&cli);
         assert!(result.is_some(), "Trace should be handled by diagnostic dispatcher");

--- a/crates/apr-cli/src/lib_extract_paths.rs
+++ b/crates/apr-cli/src/lib_extract_paths.rs
@@ -451,6 +451,9 @@
             payload: false,
             diff: false,
             interactive: false,
+            save_tensor: None,
+            save_tensor_dir: None,
+            save_tensor_layers: "0..1".to_string(),
         });
         let result = execute_command(&cli);
         assert!(result.is_err(), "Trace should fail with non-existent file");

--- a/crates/apr-cli/src/lib_parse_rosetta_02.rs
+++ b/crates/apr-cli/src/lib_parse_rosetta_02.rs
@@ -192,6 +192,9 @@
             payload: false,
             diff: false,
             interactive: false,
+            save_tensor: None,
+            save_tensor_dir: None,
+            save_tensor_layers: "0..1".to_string(),
         };
         let paths = extract_model_paths(&cmd);
         assert_eq!(paths, vec![PathBuf::from("model.apr")]);

--- a/crates/apr-cli/src/lib_parse_tensors.rs
+++ b/crates/apr-cli/src/lib_parse_tensors.rs
@@ -107,6 +107,9 @@
                 payload,
                 diff,
                 interactive,
+                save_tensor: _,
+                save_tensor_dir: _,
+                save_tensor_layers: _,
             } => {
                 assert_eq!(file, PathBuf::from("model.apr"));
                 assert_eq!(layer, Some("layer.0".to_string()));


### PR DESCRIPTION
## Summary

- Add `--save-tensor`, `--save-tensor-dir`, `--save-tensor-layers` to `Commands::Trace`
- Bind the CLI signature defined in `contracts/apr-cli-trace-save-tensor-v1.yaml` at the binary boundary
- Stub eprintln in dispatch site; PR-B will plumb to `forward_traced`

This is PR-A of a 4-PR cascade authorized by the operator on 2026-05-02:

> Path forward to ship MODEL-1 is SHIP-007 layer-0 stage diff (extend apr trace --save-tensor, multi-PR work, do both [paths] in parallel)

| PR | Scope |
|----|-------|
| **A (this PR)** | clap surface + dispatch stub |
| B | wire flags through to `forward_traced` in aprender-serve |
| C | integration test on real APR teacher |
| D | `apr diff --stage` extension consuming saved tensors |

The helpers (`save_tensor_stage.rs`, `save_tensor_paths.rs`, `save_tensor_compose.rs`) shipped in PRs #1133–#1137 already exist in `crates/aprender-serve/src/inference_trace/`. PR-A only adds the CLI signature so the contract is bound and `apr trace --help` renders correctly.

## Five Whys

1. **Why ship clap surface alone?** Splits contract-binding from forward-pass wiring; reviewer can verify each layer in isolation, and the binary already prints `--help` exactly as the contract specifies.
2. **Why not stub PR-A and PR-B together?** `forward_traced` lives in `aprender-serve` and threads layer-id through three call sites; bundling makes the diff harder to bisect when MODEL-1 cosine drift later regresses.
3. **Why `0..1` default?** SHIP-007 root cause is pinned at layer-0 qkv matmul (memory: `project_2026_04_27_session2_handoff.md`). Default keeps disk usage bounded; users opt into wider ranges explicitly.
4. **Why eprintln stub instead of returning error?** Contract gate is "CLI accepts the flag" not "feature works"; error would mask the surface from existing test harnesses. Stub message names PR-B as the next step.
5. **Why now in the SHIP-TWO loop?** Path forward to ship MODEL-1 is layer-0 stage diff (per operator directive 2026-05-02); PR-A is step 1/4.

## Ship % update

- **MODEL-1**: ~64% (unchanged — PR-A is surface only; element-wise diff pending PR-B/C/D)
- **MODEL-2**: blocked on Stack v2 corpus access (operator action — visit https://huggingface.co/datasets/bigcode/starcoderdata, accept terms)

## Test plan

- [x] `cargo check -p apr-cli` clean
- [x] `cargo check -p apr-cli --tests` clean
- [x] `cargo test -p apr-cli --lib test_parse_trace_command` pass
- [x] `cargo test -p apr-cli --lib test_dispatch_diagnostic_routes_trace` pass
- [x] `apr trace --help` renders all 3 new flags with full descriptions
- [ ] CI green (gate + workspace-test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)