### PR TITLE
feat(aprender-serve): SHIP-007 PR-B — `SaveTensorPlan` plan-builder

### DIFF
--- a/crates/aprender-serve/src/inference_trace/mod.rs
+++ b/crates/aprender-serve/src/inference_trace/mod.rs
@@ -24,6 +24,7 @@
 pub mod save_tensor;
 pub mod save_tensor_compose;
 pub mod save_tensor_paths;
+pub mod save_tensor_plan;
 pub mod save_tensor_stage;
 
 use std::collections::HashSet;

--- a/crates/aprender-serve/src/inference_trace/save_tensor_plan.rs
+++ b/crates/aprender-serve/src/inference_trace/save_tensor_plan.rs
@@ -1,0 +1,445 @@
+//! Plan-builder for `apr trace --save-tensor` (SHIP-007 PR-B).
+//!
+//! Contract: [`contracts/apr-cli-trace-save-tensor-v1.yaml`] v1.0.0 (PROPOSED).
+//!
+//! ## Role
+//!
+//! [`SaveTensorPlan`] is the bridge between the parsed CLI arguments
+//! (`--save-tensor <STAGES>`, `--save-tensor-dir <DIR>`,
+//! `--save-tensor-layers <RANGE>`) and the future `forward_traced` integration
+//! that will consult the plan at every stage transition.
+//!
+//! PR-B keeps this plan **pure** (no I/O, no model state, no transformer
+//! coupling) so the CLI dispatch site can validate the user's args eagerly
+//! and the forward pass (PR-C) can attach the plan as a side-channel later
+//! without dragging clap-specific types into `aprender-serve`.
+//!
+//! ## Decisions captured here
+//!
+//! - The `all` keyword expands to [`SaveTensorStage::ALL`] (all 18 stages).
+//! - Stage list is comma-delimited (existing [`parse_stage_list`] semantics).
+//! - Layer range is parsed as Rust `START..END` syntax with `END` exclusive.
+//!   `0..1` (the clap default) selects layer 0 only.
+//! - The layer filter applies **only** to per-layer stages
+//!   ([`SaveTensorStage::is_per_layer`] = true). Whole-model stages
+//!   (`final_norm`, `lm_head`) are always saved if selected, regardless of
+//!   the layer range.
+//!
+//! ## What this module does NOT do (deferred)
+//!
+//! - PR-C: thread the plan into [`AprTransformer::forward_traced`] and call
+//!   [`super::save_tensor_compose::write_stage_file`] at each stage boundary.
+//! - PR-D: live integration test on a real APR teacher.
+//!
+//! Keeping the plan-builder isolated from the forward pass means a typo
+//! like `--save-tensor wrng_stage` errors out at CLI dispatch time, not
+//! after a multi-second model load.
+
+use std::ops::Range;
+use std::path::{Path, PathBuf};
+
+use super::save_tensor::WHOLE_MODEL_LAYER;
+use super::save_tensor_paths::output_path;
+use super::save_tensor_stage::{parse_stage_list, SaveTensorStage, StageParseError};
+
+/// The validated, ready-to-execute plan for `apr trace --save-tensor`.
+///
+/// Built from CLI strings via [`SaveTensorPlan::from_cli`]. Once constructed,
+/// the plan is consulted by the forward pass (PR-C) to decide whether each
+/// stage produces a file, and where it goes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SaveTensorPlan {
+    /// The stages selected by the user, in the order they were listed.
+    /// `all` expands to [`SaveTensorStage::ALL`] in canonical order.
+    /// Empty plans are not constructable — `--save-tensor` with no value
+    /// errors out at parse time.
+    pub stages: Vec<SaveTensorStage>,
+    /// Layer range as parsed from `--save-tensor-layers` (`START..END`,
+    /// END-exclusive). Whole-model stages ignore this filter.
+    pub layer_range: Range<u32>,
+    /// Root directory for saved tensors. Per-layer stages go under
+    /// `<output_dir>/layer-<N>/<stage>.bin`; whole-model stages go under
+    /// `<output_dir>/<stage>.bin`.
+    pub output_dir: PathBuf,
+}
+
+/// Errors that can arise building a [`SaveTensorPlan`] from CLI strings.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum PlanParseError {
+    /// A stage name was unrecognised (forwarded from
+    /// [`super::save_tensor_stage::parse_stage_list`]).
+    #[error("save-tensor stage list invalid: {0}")]
+    Stage(StageParseError),
+    /// The `--save-tensor-layers` string did not match `START..END` syntax,
+    /// or the bounds were not parseable as `u32`, or `END <= START`.
+    #[error("save-tensor layer range invalid ({got:?}): {reason}")]
+    LayerRange {
+        /// The original input string.
+        got: String,
+        /// One-line human-readable explanation.
+        reason: String,
+    },
+}
+
+impl SaveTensorPlan {
+    /// Build a [`SaveTensorPlan`] from the raw clap argument strings.
+    ///
+    /// `stages_str` accepts either a comma-separated list of stage names
+    /// (e.g. `"embedding,qkv_matmul,attention"`) or the literal token
+    /// `"all"` (case-insensitive) which expands to every stage in
+    /// [`SaveTensorStage::ALL`].
+    ///
+    /// `layer_range_str` is `START..END` (Rust Range syntax, END exclusive).
+    /// `output_dir` is taken as-is (no auto-creation here; PR-C ensures the
+    /// directory exists before writing the first file).
+    ///
+    /// # Errors
+    ///
+    /// - [`PlanParseError::Stage`] if any token in `stages_str` is not a
+    ///   known canonical stage name (or alias `layer_output`).
+    /// - [`PlanParseError::LayerRange`] if `layer_range_str` is malformed,
+    ///   or if `END <= START`.
+    pub fn from_cli(
+        stages_str: &str,
+        layer_range_str: &str,
+        output_dir: PathBuf,
+    ) -> Result<Self, PlanParseError> {
+        let stages = parse_stages_arg(stages_str).map_err(PlanParseError::Stage)?;
+        let layer_range = parse_layer_range(layer_range_str)?;
+        Ok(Self {
+            stages,
+            layer_range,
+            output_dir,
+        })
+    }
+
+    /// Returns `true` if the plan calls for saving the given (stage, layer)
+    /// pair. Whole-model stages ignore the layer parameter and the layer
+    /// range — they are saved iff selected by the user.
+    #[must_use]
+    pub fn should_save(&self, stage: SaveTensorStage, layer: u32) -> bool {
+        if !self.stages.contains(&stage) {
+            return false;
+        }
+        if !stage.is_per_layer() {
+            return true;
+        }
+        self.layer_range.contains(&layer)
+    }
+
+    /// Build the output path for a single saved tensor file. Mirrors
+    /// [`super::save_tensor_paths::output_path`] but uses the plan's
+    /// `output_dir`.
+    ///
+    /// For whole-model stages, pass [`WHOLE_MODEL_LAYER`] as `layer`.
+    #[must_use]
+    pub fn stage_path(&self, stage: SaveTensorStage, layer: u32) -> PathBuf {
+        let effective_layer = if stage.is_per_layer() {
+            layer
+        } else {
+            WHOLE_MODEL_LAYER
+        };
+        output_path(&self.output_dir, effective_layer, stage.canonical_name())
+    }
+}
+
+/// Parse the `--save-tensor` argument string (either `all` or a
+/// comma-list of stage names).
+fn parse_stages_arg(s: &str) -> Result<Vec<SaveTensorStage>, StageParseError> {
+    let trimmed = s.trim();
+    if trimmed.eq_ignore_ascii_case("all") {
+        return Ok(SaveTensorStage::ALL.to_vec());
+    }
+    parse_stage_list(trimmed)
+}
+
+/// Parse the `--save-tensor-layers` argument string (`START..END`).
+fn parse_layer_range(s: &str) -> Result<Range<u32>, PlanParseError> {
+    let trimmed = s.trim();
+    let (start_str, end_str) =
+        trimmed
+            .split_once("..")
+            .ok_or_else(|| PlanParseError::LayerRange {
+                got: trimmed.to_string(),
+                reason: "expected `START..END`".to_string(),
+            })?;
+    let start: u32 = start_str
+        .trim()
+        .parse()
+        .map_err(|_| PlanParseError::LayerRange {
+            got: trimmed.to_string(),
+            reason: format!("START {start_str:?} is not a valid u32"),
+        })?;
+    let end: u32 = end_str
+        .trim()
+        .parse()
+        .map_err(|_| PlanParseError::LayerRange {
+            got: trimmed.to_string(),
+            reason: format!("END {end_str:?} is not a valid u32"),
+        })?;
+    if end <= start {
+        return Err(PlanParseError::LayerRange {
+            got: trimmed.to_string(),
+            reason: format!("END ({end}) must be > START ({start})"),
+        });
+    }
+    Ok(start..end)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Provenance pin: PR-B is rev 1; if a future PR moves the plan
+    /// constructor, this test should fail to force a memory update.
+    #[test]
+    fn provenance_pin_pr_b_rev1() {
+        // Sentinel: signature shape that downstream PR-C / PR-D rely on.
+        let p = SaveTensorPlan::from_cli("embedding", "0..1", PathBuf::from("/tmp/x")).unwrap();
+        assert_eq!(p.stages.len(), 1);
+        assert_eq!(p.layer_range, 0..1);
+        assert_eq!(p.output_dir, PathBuf::from("/tmp/x"));
+    }
+
+    // ── Pass band ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn realistic_healthy_three_stages_layer_zero() {
+        let plan = SaveTensorPlan::from_cli(
+            "embedding,qkv_matmul,attention",
+            "0..1",
+            PathBuf::from("trace_out"),
+        )
+        .expect("realistic args should parse");
+        assert_eq!(plan.stages.len(), 3);
+        assert_eq!(plan.stages[0], SaveTensorStage::Embedding);
+        assert_eq!(plan.stages[1], SaveTensorStage::QkvMatmul);
+        assert_eq!(plan.stages[2], SaveTensorStage::Attention);
+        assert_eq!(plan.layer_range, 0..1);
+    }
+
+    #[test]
+    fn all_keyword_expands_to_eighteen_stages() {
+        let plan = SaveTensorPlan::from_cli("all", "0..1", PathBuf::from("/tmp")).unwrap();
+        assert_eq!(plan.stages.len(), 18);
+        assert_eq!(plan.stages, SaveTensorStage::ALL.to_vec());
+    }
+
+    #[test]
+    fn all_keyword_case_insensitive() {
+        for variant in ["all", "ALL", "All", "aLL"] {
+            let plan = SaveTensorPlan::from_cli(variant, "0..1", PathBuf::from("/tmp"))
+                .expect("case variant should parse");
+            assert_eq!(plan.stages.len(), 18);
+        }
+    }
+
+    #[test]
+    fn whitespace_in_stage_list_tolerated() {
+        let plan =
+            SaveTensorPlan::from_cli(" embedding , ffn_gate ", "0..1", PathBuf::from("/tmp"))
+                .unwrap();
+        assert_eq!(plan.stages.len(), 2);
+    }
+
+    #[test]
+    fn whitespace_around_layer_range_tolerated() {
+        let plan = SaveTensorPlan::from_cli("embedding", "  3..7 ", PathBuf::from("/tmp")).unwrap();
+        assert_eq!(plan.layer_range, 3..7);
+    }
+
+    #[test]
+    fn wide_layer_range_parses() {
+        let plan = SaveTensorPlan::from_cli("ffn_gate", "0..32", PathBuf::from("/tmp")).unwrap();
+        assert_eq!(plan.layer_range, 0..32);
+    }
+
+    // ── Fail band ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn fail_unknown_stage_name() {
+        let err = SaveTensorPlan::from_cli("not_a_stage", "0..1", PathBuf::from("/tmp"))
+            .expect_err("typo should error");
+        match err {
+            PlanParseError::Stage(StageParseError::Unknown { got, .. }) => {
+                assert_eq!(got, "not_a_stage");
+            },
+            _ => panic!("expected StageParseError::Unknown, got {err:?}"),
+        }
+    }
+
+    #[test]
+    fn fail_empty_token_in_stage_list() {
+        let err = SaveTensorPlan::from_cli("embedding,,ffn_gate", "0..1", PathBuf::from("/tmp"))
+            .expect_err("empty token should error");
+        assert!(matches!(err, PlanParseError::Stage(StageParseError::Empty)));
+    }
+
+    #[test]
+    fn fail_layer_range_missing_dotdot() {
+        let err =
+            SaveTensorPlan::from_cli("embedding", "0-3", PathBuf::from("/tmp")).expect_err("");
+        match err {
+            PlanParseError::LayerRange { got, reason } => {
+                assert_eq!(got, "0-3");
+                assert!(reason.contains("START..END"));
+            },
+            _ => panic!("expected LayerRange, got {err:?}"),
+        }
+    }
+
+    #[test]
+    fn fail_layer_range_negative_start() {
+        // -1 is not a valid u32; we don't accept signed integers.
+        let err =
+            SaveTensorPlan::from_cli("embedding", "-1..3", PathBuf::from("/tmp")).expect_err("");
+        assert!(matches!(err, PlanParseError::LayerRange { .. }));
+    }
+
+    #[test]
+    fn fail_layer_range_end_le_start() {
+        let err =
+            SaveTensorPlan::from_cli("embedding", "5..5", PathBuf::from("/tmp")).expect_err("");
+        match err {
+            PlanParseError::LayerRange { reason, .. } => {
+                assert!(reason.contains("END") && reason.contains("START"));
+            },
+            _ => panic!("expected LayerRange, got {err:?}"),
+        }
+    }
+
+    #[test]
+    fn fail_layer_range_end_lt_start() {
+        let err =
+            SaveTensorPlan::from_cli("embedding", "10..3", PathBuf::from("/tmp")).expect_err("");
+        assert!(matches!(err, PlanParseError::LayerRange { .. }));
+    }
+
+    #[test]
+    fn fail_layer_range_garbage_end() {
+        let err =
+            SaveTensorPlan::from_cli("embedding", "0..abc", PathBuf::from("/tmp")).expect_err("");
+        match err {
+            PlanParseError::LayerRange { reason, .. } => {
+                assert!(reason.contains("END"));
+            },
+            _ => panic!("expected LayerRange, got {err:?}"),
+        }
+    }
+
+    // ── should_save semantics ─────────────────────────────────────────────
+
+    #[test]
+    fn should_save_per_layer_in_range() {
+        let plan = SaveTensorPlan::from_cli("ffn_gate", "0..3", PathBuf::from("/tmp")).unwrap();
+        assert!(plan.should_save(SaveTensorStage::FfnGate, 0));
+        assert!(plan.should_save(SaveTensorStage::FfnGate, 1));
+        assert!(plan.should_save(SaveTensorStage::FfnGate, 2));
+    }
+
+    #[test]
+    fn should_not_save_per_layer_outside_range() {
+        let plan = SaveTensorPlan::from_cli("ffn_gate", "0..3", PathBuf::from("/tmp")).unwrap();
+        assert!(!plan.should_save(SaveTensorStage::FfnGate, 3)); // END exclusive
+        assert!(!plan.should_save(SaveTensorStage::FfnGate, 27));
+    }
+
+    #[test]
+    fn should_not_save_unselected_stage() {
+        let plan = SaveTensorPlan::from_cli("ffn_gate", "0..3", PathBuf::from("/tmp")).unwrap();
+        assert!(!plan.should_save(SaveTensorStage::Attention, 0));
+    }
+
+    #[test]
+    fn should_save_whole_model_stage_ignores_layer_range() {
+        let plan = SaveTensorPlan::from_cli("lm_head", "5..7", PathBuf::from("/tmp")).unwrap();
+        // lm_head is whole-model; layer range is irrelevant.
+        assert!(plan.should_save(SaveTensorStage::LmHead, 0));
+        assert!(plan.should_save(SaveTensorStage::LmHead, 99));
+        assert!(plan.should_save(SaveTensorStage::LmHead, WHOLE_MODEL_LAYER));
+    }
+
+    #[test]
+    fn should_save_default_range_zero_to_one_only_layer_zero() {
+        // Default `0..1` (the clap default) saves layer 0 only.
+        let plan = SaveTensorPlan::from_cli("embedding", "0..1", PathBuf::from("/tmp")).unwrap();
+        assert!(plan.should_save(SaveTensorStage::Embedding, 0));
+        assert!(!plan.should_save(SaveTensorStage::Embedding, 1));
+    }
+
+    // ── stage_path semantics ──────────────────────────────────────────────
+
+    #[test]
+    fn stage_path_per_layer_layer_zero() {
+        let plan =
+            SaveTensorPlan::from_cli("embedding", "0..1", PathBuf::from("trace_out")).unwrap();
+        let p = plan.stage_path(SaveTensorStage::Embedding, 0);
+        assert_eq!(p, PathBuf::from("trace_out/layer-0/embedding.bin"));
+    }
+
+    #[test]
+    fn stage_path_per_layer_layer_three() {
+        let plan =
+            SaveTensorPlan::from_cli("ffn_gate", "0..32", PathBuf::from("trace_out")).unwrap();
+        let p = plan.stage_path(SaveTensorStage::FfnGate, 3);
+        assert_eq!(p, PathBuf::from("trace_out/layer-3/ffn_gate.bin"));
+    }
+
+    #[test]
+    fn stage_path_whole_model_skips_layer_segment() {
+        let plan = SaveTensorPlan::from_cli("lm_head", "0..1", PathBuf::from("trace_out")).unwrap();
+        // Whole-model stage: even if caller passes layer=5, output ignores it.
+        let p = plan.stage_path(SaveTensorStage::LmHead, 5);
+        assert_eq!(p, PathBuf::from("trace_out/lm_head.bin"));
+    }
+
+    #[test]
+    fn stage_path_whole_model_with_sentinel_layer() {
+        let plan =
+            SaveTensorPlan::from_cli("final_norm", "0..1", PathBuf::from("trace_out")).unwrap();
+        let p = plan.stage_path(SaveTensorStage::FinalNorm, WHOLE_MODEL_LAYER);
+        assert_eq!(p, PathBuf::from("trace_out/final_norm.bin"));
+    }
+
+    // ── Edge / mutation survey ────────────────────────────────────────────
+
+    #[test]
+    fn layer_output_alias_resolves_to_post_ffn_residual() {
+        let plan = SaveTensorPlan::from_cli("layer_output", "0..1", PathBuf::from("/tmp")).unwrap();
+        assert_eq!(plan.stages, vec![SaveTensorStage::PostFfnResidual]);
+    }
+
+    #[test]
+    fn duplicate_stages_preserved_for_caller_dedup() {
+        // The plan does NOT auto-dedupe — caller's responsibility if they
+        // want unique writes. (Currently the comma parser preserves order;
+        // this test pins that contract so dedup-on-construction would be a
+        // breaking change.)
+        let plan =
+            SaveTensorPlan::from_cli("embedding,embedding", "0..1", PathBuf::from("/tmp")).unwrap();
+        assert_eq!(plan.stages.len(), 2);
+    }
+
+    #[test]
+    fn min_valid_range_one_layer() {
+        let plan = SaveTensorPlan::from_cli("embedding", "0..1", PathBuf::from("/tmp")).unwrap();
+        assert_eq!(plan.layer_range.end - plan.layer_range.start, 1);
+    }
+
+    #[test]
+    fn high_layer_index_in_range() {
+        // Some models have many layers; sanity-check large u32 values.
+        let plan = SaveTensorPlan::from_cli("ffn_gate", "0..1000", PathBuf::from("/tmp")).unwrap();
+        assert!(plan.should_save(SaveTensorStage::FfnGate, 999));
+        assert!(!plan.should_save(SaveTensorStage::FfnGate, 1000));
+    }
+
+    #[test]
+    fn plan_is_clone_and_eq() {
+        // Plan must be Clone so it can be threaded through forward_traced
+        // by value; PartialEq simplifies test assertions in PR-C/D.
+        let a = SaveTensorPlan::from_cli("embedding", "0..1", PathBuf::from("/tmp")).unwrap();
+        let b = a.clone();
+        assert_eq!(a, b);
+    }
+}

--- a/crates/aprender-serve/tests/save_tensor_plan_integration.rs
+++ b/crates/aprender-serve/tests/save_tensor_plan_integration.rs
@@ -1,0 +1,361 @@
+//! Integration tests for `SaveTensorPlan` end-to-end through the public
+//! `save_tensor*` I/O helpers.
+//!
+//! Contract: [`contracts/apr-cli-trace-save-tensor-v1.yaml`] v1.0.0 (PROPOSED).
+//!
+//! ## Why this complements `save_tensor_integration.rs`
+//!
+//! `save_tensor_integration.rs` exercises the writer (`write_tensor_file`)
+//! and path builder (`output_path`) in isolation. This file exercises the
+//! plan-builder ([`SaveTensorPlan`] from PR-B) driving those helpers as
+//! they will be driven from inside the forward pass once PR-C lands the
+//! `forward_traced` wiring.
+//!
+//! Concretely: we build a plan from CLI argument strings (the same form
+//! the future dispatch site will pass), iterate a fixed sequence of
+//! `(stage, layer, data)` tuples that mimic what the forward pass produces,
+//! and assert:
+//!
+//! 1. Files appear ONLY for `(stage, layer)` pairs where the plan returns
+//!    `should_save == true`.
+//! 2. Each file's path matches `plan.stage_path(stage, layer)` exactly.
+//! 3. Each file's bytes match what `write_tensor_file` would emit for the
+//!    given layer + values.
+//! 4. Byte-for-byte determinism: the same plan + same data → identical
+//!    files across two runs.
+//!
+//! ## Discharge map
+//!
+//! | Falsifier | Discharge level | Test |
+//! |-----------|-----------------|------|
+//! | FALSIFY-APR-TRACE-SAVE-005 (multi-stage in one run) | partial | `plan_three_stages_layer_zero_writes_three_files` |
+//! | FALSIFY-APR-TRACE-SAVE-LAYER-FILTER (range honoured) | partial | `plan_layer_range_filter_excludes_out_of_range` |
+//! | FALSIFY-APR-TRACE-SAVE-WHOLE-MODEL-PATH (no layer-N segment) | partial | `plan_whole_model_stage_writes_to_root_not_layer_dir` |
+//! | FALSIFY-APR-TRACE-SAVE-002 (determinism) | partial | `plan_byte_determinism_across_two_runs` |
+//!
+//! "Partial" because full discharge requires PR-C/D's live CLI integration
+//! invoking the plan from inside `forward_traced`. These tests pin the
+//! plan ↔ writer contract so the wiring PR has a stable target.
+
+use std::path::Path;
+
+use realizar::inference_trace::save_tensor::{self, MAGIC};
+use realizar::inference_trace::save_tensor_paths::ensure_layer_dir;
+use realizar::inference_trace::save_tensor_plan::SaveTensorPlan;
+use realizar::inference_trace::save_tensor_stage::SaveTensorStage;
+
+/// Helper: drive a plan against a fixed `(stage, layer, data)` sequence,
+/// writing only the entries the plan selects. Returns the list of paths
+/// the plan caused to be written.
+///
+/// Mirrors the future dispatch flow:
+///   for (stage, layer, data) in forward_pass_stages:
+///       if plan.should_save(stage, layer):
+///           ensure_layer_dir(plan.output_dir, layer)
+///           write_tensor_file(plan.stage_path(stage, layer), layer, data)
+fn execute_plan_against_sequence(
+    plan: &SaveTensorPlan,
+    sequence: &[(SaveTensorStage, u32, Vec<f32>)],
+) -> Vec<std::path::PathBuf> {
+    use std::io::Write;
+    let mut written = Vec::new();
+    for (stage, layer, data) in sequence {
+        if !plan.should_save(*stage, *layer) {
+            continue;
+        }
+        // Whole-model stages route to plan.output_dir directly; per-layer
+        // stages route to <output_dir>/layer-<N>/. plan.stage_path() encodes
+        // this; ensure_layer_dir mirrors the same fork.
+        let layer_for_dir = if stage.is_per_layer() {
+            *layer
+        } else {
+            save_tensor::WHOLE_MODEL_LAYER
+        };
+        ensure_layer_dir(&plan.output_dir, layer_for_dir).expect("ensure_layer_dir");
+        let path = plan.stage_path(*stage, *layer);
+        let file = std::fs::File::create(&path).expect("create file");
+        let mut writer = std::io::BufWriter::new(file);
+        // For whole-model stages, the layer field stored in the file header
+        // is the WHOLE_MODEL_LAYER sentinel — that's what the writer expects
+        // and what readers will use to round-trip.
+        let layer_for_header = if stage.is_per_layer() {
+            *layer
+        } else {
+            save_tensor::WHOLE_MODEL_LAYER
+        };
+        save_tensor::write_tensor_file(&mut writer, layer_for_header, data).expect("write");
+        writer.flush().expect("flush");
+        written.push(path);
+    }
+    written
+}
+
+#[test]
+fn plan_three_stages_layer_zero_writes_three_files() {
+    // Realistic SHIP-007 layer-0 capture: three stages on layer 0 only.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let plan = SaveTensorPlan::from_cli(
+        "embedding,qkv_matmul,attention",
+        "0..1",
+        tmp.path().to_path_buf(),
+    )
+    .expect("plan parses");
+
+    // Mimic forward pass producing all 3 stages on layer 0, plus an
+    // unrelated stage on layer 0 that the user did NOT select.
+    let sequence = vec![
+        (SaveTensorStage::Embedding, 0u32, vec![1.0_f32, 2.0, 3.0]),
+        (
+            SaveTensorStage::QkvMatmul,
+            0,
+            vec![10.0_f32, 20.0, 30.0, 40.0],
+        ),
+        (SaveTensorStage::Attention, 0, vec![100.0_f32, 200.0, 300.0]),
+        // NOT in plan — must be skipped.
+        (SaveTensorStage::FfnGate, 0, vec![999.0_f32]),
+    ];
+
+    let written = execute_plan_against_sequence(&plan, &sequence);
+    assert_eq!(
+        written.len(),
+        3,
+        "plan should write exactly 3 files (one per selected stage)"
+    );
+
+    // Every written path is what plan.stage_path() predicted:
+    assert_eq!(written[0], plan.stage_path(SaveTensorStage::Embedding, 0));
+    assert_eq!(written[1], plan.stage_path(SaveTensorStage::QkvMatmul, 0));
+    assert_eq!(written[2], plan.stage_path(SaveTensorStage::Attention, 0));
+
+    // Every written file exists and has the expected MAGIC bytes.
+    for path in &written {
+        let bytes = std::fs::read(path).expect("read");
+        assert_eq!(
+            &bytes[..4],
+            MAGIC,
+            "header MAGIC must be APRT for {}",
+            path.display()
+        );
+    }
+
+    // The unselected stage's file MUST NOT exist.
+    let unselected = plan.stage_path(SaveTensorStage::FfnGate, 0);
+    assert!(
+        !unselected.exists(),
+        "FfnGate file must NOT be written when the plan does not select it"
+    );
+}
+
+#[test]
+fn plan_layer_range_filter_excludes_out_of_range() {
+    // Plan saves layer 0..3 only. Stages produced for layers 0,1,2 must
+    // appear; layer 3,4 must not.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let plan = SaveTensorPlan::from_cli("ffn_gate", "0..3", tmp.path().to_path_buf())
+        .expect("plan parses");
+
+    let sequence: Vec<_> = (0..5u32)
+        .map(|l| (SaveTensorStage::FfnGate, l, vec![l as f32, (l * 2) as f32]))
+        .collect();
+
+    let written = execute_plan_against_sequence(&plan, &sequence);
+    assert_eq!(
+        written.len(),
+        3,
+        "layer range 0..3 must write 3 files (layers 0,1,2 — END exclusive)"
+    );
+
+    // Layer 0,1,2 files exist; layer 3,4 files do not.
+    for layer_in in [0, 1, 2] {
+        let p = plan.stage_path(SaveTensorStage::FfnGate, layer_in);
+        assert!(p.exists(), "layer-{layer_in} should be written");
+    }
+    for layer_out in [3, 4] {
+        let p = plan.stage_path(SaveTensorStage::FfnGate, layer_out);
+        assert!(
+            !p.exists(),
+            "layer-{layer_out} must be excluded by range 0..3"
+        );
+    }
+}
+
+#[test]
+fn plan_whole_model_stage_writes_to_root_not_layer_dir() {
+    // Whole-model stages (final_norm, lm_head) bypass the layer-N
+    // directory segment — the plan.stage_path() fork pins this.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let plan =
+        SaveTensorPlan::from_cli("lm_head", "0..1", tmp.path().to_path_buf()).expect("plan parses");
+
+    // Even if the dispatch site passes layer=0, lm_head should ignore it.
+    let sequence = vec![(SaveTensorStage::LmHead, 0u32, vec![0.1_f32, 0.2, 0.3])];
+    let written = execute_plan_against_sequence(&plan, &sequence);
+    assert_eq!(written.len(), 1);
+
+    // Path must be <output_dir>/lm_head.bin (no layer-0/ segment).
+    let expected = tmp.path().join("lm_head.bin");
+    assert_eq!(written[0], expected);
+    assert!(written[0].exists());
+
+    // The "layer-0/lm_head.bin" mistake-path must NOT exist.
+    let mistake = tmp.path().join("layer-0").join("lm_head.bin");
+    assert!(
+        !mistake.exists(),
+        "lm_head must not land in layer-0/ subdirectory"
+    );
+}
+
+#[test]
+fn plan_unselected_stage_produces_no_file() {
+    // Even if forward pass produces a stage's data, the plan acts as a
+    // strict allow-list: should_save == false → zero I/O.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let plan = SaveTensorPlan::from_cli("embedding", "0..1", tmp.path().to_path_buf())
+        .expect("plan parses");
+
+    let sequence = vec![
+        (SaveTensorStage::Embedding, 0u32, vec![1.0_f32]),
+        (SaveTensorStage::Attention, 0, vec![2.0_f32]),
+        (SaveTensorStage::FfnGate, 0, vec![3.0_f32]),
+        (SaveTensorStage::LmHead, 0, vec![4.0_f32]),
+    ];
+    let written = execute_plan_against_sequence(&plan, &sequence);
+    assert_eq!(
+        written.len(),
+        1,
+        "only embedding should be written; 3 unselected stages must produce no I/O"
+    );
+
+    // Confirm by listing the tmp dir.
+    let entries: Vec<_> = walk_files(tmp.path()).collect();
+    assert_eq!(
+        entries.len(),
+        1,
+        "filesystem state: exactly one file under output_dir, got {entries:?}"
+    );
+}
+
+#[test]
+fn plan_byte_determinism_across_two_runs() {
+    // The same plan + same data must produce byte-identical files
+    // (FALSIFY-APR-TRACE-SAVE-002 at the plan integration boundary).
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dir_a = tmp.path().join("run_a");
+    let dir_b = tmp.path().join("run_b");
+
+    let plan_a = SaveTensorPlan::from_cli("embedding,ffn_gate", "0..2", dir_a.clone()).unwrap();
+    let plan_b = SaveTensorPlan::from_cli("embedding,ffn_gate", "0..2", dir_b.clone()).unwrap();
+
+    let sequence: Vec<_> = (0..2u32)
+        .flat_map(|l| {
+            vec![
+                (
+                    SaveTensorStage::Embedding,
+                    l,
+                    (0..32).map(|i| (i + l as i32) as f32 * 0.5).collect(),
+                ),
+                (
+                    SaveTensorStage::FfnGate,
+                    l,
+                    (0..64).map(|i| (i - 32 + l as i32) as f32 * 0.25).collect(),
+                ),
+            ]
+        })
+        .collect();
+
+    let written_a = execute_plan_against_sequence(&plan_a, &sequence);
+    let written_b = execute_plan_against_sequence(&plan_b, &sequence);
+    assert_eq!(
+        written_a.len(),
+        written_b.len(),
+        "same plan → same file count"
+    );
+    for (path_a, path_b) in written_a.iter().zip(written_b.iter()) {
+        let bytes_a = std::fs::read(path_a).expect("read A");
+        let bytes_b = std::fs::read(path_b).expect("read B");
+        assert_eq!(
+            bytes_a,
+            bytes_b,
+            "FALSIFIED determinism: plan {} vs {} produced different bytes",
+            path_a.display(),
+            path_b.display(),
+        );
+    }
+}
+
+#[test]
+fn plan_all_keyword_writes_18_per_layer_files_for_one_layer() {
+    // The `all` keyword expands to 18 stages. With layer range `0..1` and
+    // a single layer, we expect 16 per-layer files + 2 whole-model files.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let plan =
+        SaveTensorPlan::from_cli("all", "0..1", tmp.path().to_path_buf()).expect("plan parses");
+    assert_eq!(plan.stages.len(), 18);
+
+    // Build a sequence with one entry per stage, all on layer 0.
+    let sequence: Vec<_> = SaveTensorStage::ALL
+        .iter()
+        .map(|s| (*s, 0u32, vec![1.0_f32, 2.0, 3.0]))
+        .collect();
+
+    let written = execute_plan_against_sequence(&plan, &sequence);
+    assert_eq!(
+        written.len(),
+        18,
+        "`all` + layer 0..1 should produce all 18 stage files"
+    );
+
+    // Per-layer stages live under layer-0/; whole-model stages live at root.
+    let per_layer_count = SaveTensorStage::ALL
+        .iter()
+        .filter(|s| s.is_per_layer())
+        .count();
+    let whole_model_count = SaveTensorStage::ALL
+        .iter()
+        .filter(|s| !s.is_per_layer())
+        .count();
+    assert_eq!(per_layer_count + whole_model_count, 18);
+
+    // Sanity-check: layer-0/ contains the per-layer files; root contains
+    // the whole-model files.
+    for stage in SaveTensorStage::ALL {
+        let p = plan.stage_path(stage, 0);
+        assert!(
+            p.exists(),
+            "{} file must exist at {}",
+            stage.canonical_name(),
+            p.display()
+        );
+        let in_layer_dir = p
+            .parent()
+            .and_then(|d| d.file_name())
+            .and_then(|n| n.to_str())
+            .map(|s| s == "layer-0")
+            .unwrap_or(false);
+        assert_eq!(
+            in_layer_dir,
+            stage.is_per_layer(),
+            "{}: per-layer expected layer-0/ dir, whole-model expected root",
+            stage.canonical_name()
+        );
+    }
+}
+
+/// Small helper: recursively walk `dir` and yield file paths.
+fn walk_files(dir: &Path) -> impl Iterator<Item = std::path::PathBuf> {
+    fn collect(dir: &Path, out: &mut Vec<std::path::PathBuf>) {
+        if let Ok(entries) = std::fs::read_dir(dir) {
+            for e in entries.flatten() {
+                let p = e.path();
+                if p.is_dir() {
+                    collect(&p, out);
+                } else {
+                    out.push(p);
+                }
+            }
+        }
+    }
+    let mut v = Vec::new();
+    collect(dir, &mut v);
+    v.into_iter()
+}


### PR DESCRIPTION
## Summary

Add `inference_trace::save_tensor_plan` that converts the three `apr trace --save-tensor*` argument strings into a validated, ready-to-execute plan exposing `should_save(stage, layer)` and `stage_path(stage, layer)`.

Pure module — no I/O, no transformer state, no `apr-cli` coupling. PR-C will thread the plan through `AprTransformer::forward_traced` as a side-channel.

## SHIP-007 cascade position

This is PR-B of a 4-PR cascade authorized by the operator on 2026-05-02:

| PR | Status | Scope |
|----|--------|-------|
| A (#1405) | OPEN | clap surface + dispatch stub |
| **B (this PR)** | OPEN | plan-builder (validates strings → struct) |
| C | TBD | wire plan into `forward_traced` + `write_stage_file` |
| D | TBD | `apr diff --stage` consuming saved tensors |

## Independence from PR-A

PR-B does NOT modify `apr-cli`. The branch is off `origin/main` (which does not contain PR-A's clap fields). PR-A and PR-B can land in either order; PR-C will rebase off whichever lands first and add the dispatch wiring.

## Five Whys

1. **Why split plan-builder from forward-pass wiring?** Argument validation must fail BEFORE multi-second model load.
2. **Why pure (no I/O)?** `ensure_layer_dir`/file writes are stateful side effects best owned by PR-C's writer. Tests stay fast: 28 cases in 0.00s.
3. **Why `0..1` default?** Matches PR-A clap default. SHIP-007 root cause pinned at layer-0 qkv matmul.
4. **Why `all` keyword?** Contract §invariants line 63 specifies multiple stages per run; `all` is the obvious shorthand for the 18-stage exhaustive bisection.
5. **Why now?** Operator directive 2026-05-02 — "Path forward to ship MODEL-1 is SHIP-007 layer-0 stage diff (extend apr trace --save-tensor, multi-PR work)".

## Test coverage (28 cases, all pass)

- **Provenance pin** (1)
- **Pass band** (6): realistic 3-stage, `all` expansion, case-insensitive `all`, whitespace tolerance in stages + range, wide range
- **Fail band** (7): unknown stage, empty token, malformed range, negative start, END=START, END<START, garbage END
- **should_save** (5): in-range, out-of-range, unselected, whole-model bypass, default `0..1`
- **stage_path** (4): per-layer 0, per-layer 3, whole-model skips layer segment, sentinel layer
- **Edge** (5): `layer_output` alias, duplicate preservation, min range, high layer index, Clone+Eq

## Ship % update

- **MODEL-1**: ~64% (unchanged — plan-builder is preparatory; element-wise diff still pending PR-C/D)
- **MODEL-2**: blocked on Stack v2 corpus access (operator action — accept terms at https://huggingface.co/datasets/bigcode/starcoderdata)

## Test plan

- [x] `cargo check -p aprender-serve --lib` clean
- [x] `cargo test -p aprender-serve --lib save_tensor_plan` — 28/28 pass
- [x] `cargo clippy -p aprender-serve --lib -- -D warnings` clean (test-target clippy errors are pre-existing in unrelated files)
- [x] `cargo fmt --check` clean
- [ ] CI green (gate + workspace-test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)