### PR TITLE
feat(apr-cli): SHIP-007 PR-D — apr diff --values recognizes APRT stage tensors

### DIFF
--- a/contracts/apr-cli-trace-save-tensor-v1.yaml
+++ b/contracts/apr-cli-trace-save-tensor-v1.yaml
@@ -1,6 +1,6 @@
 metadata:
   kind: schema
-  version: 1.0.0
+  version: 1.1.0
   status: PROPOSED
   created: '2026-04-28'
   author: PAIML Engineering
@@ -165,6 +165,23 @@ falsification_tests:
   prediction: "`pv validate contracts/apr-cli-trace-save-tensor-v1.yaml` exits 0"
   test: "pv validate contracts/apr-cli-trace-save-tensor-v1.yaml"
   if_fails: "contract schema noncompliant"
+
+- id: FALSIFY-APR-TRACE-SAVE-009
+  rule: "`apr diff --values` recognizes APRT magic and runs element-wise stage diff"
+  prediction: |
+    Two APRT stage tensor files with identical contents → max_abs_diff=0,
+    rms_diff=0, cosine_sim≈1. Mismatched dim_product or layer → fail-fast
+    error. Mixed APRT+model file → falls through to existing RosettaStone
+    path (no behavior change for legacy callers).
+  test: "cargo test -p apr-cli --lib commands::diff::aprt_stage_diff_tests (11/11 PASS)"
+  if_fails: "apr diff --values does not honor `apr_diff_values_compat` invariant — stage tensors captured by apr trace --save-tensor cannot be compared without external tooling"
+  binds_to: apr_diff_values_compat
+  status: PARTIAL_ALGORITHM_LEVEL
+  algorithm_evidence:
+    - "is_aprt_stage_file detects b'APRT' magic at offset 0 (4 unit tests covering hit/miss/truncated/missing)"
+    - "compute_aprt_stage_stats element-wise max|diff|, RMS, cosine, top-K (3 unit tests verify identical=0/known-max/top-K-sorted)"
+    - "run_aprt_stage_diff dispatches via include!() in diff.rs after run() detects both inputs are APRT (3 unit tests verify dim_product mismatch / layer mismatch / identical files)"
+    - "Implementation: crates/apr-cli/src/commands/diff_05_aprt_stage.rs"
 
 proof_obligations:
 - type: invariant

--- a/crates/apr-cli/src/commands/diff.rs
+++ b/crates/apr-cli/src/commands/diff.rs
@@ -239,6 +239,14 @@ pub(crate) fn run(
     validate_paths(path1, path2)?;
 
     if compare_values {
+        // SHIP-007 PR-D: APRT stage tensor diff path. When BOTH inputs are
+        // save-tensor files emitted by `apr trace --save-tensor` (12-byte
+        // APRT header + f32 LE body), skip the RosettaStone model walker
+        // and run an element-wise diff per `apr-cli-trace-save-tensor-v1`
+        // `apr_diff_values_compat` invariant.
+        if is_aprt_stage_file(path1) && is_aprt_stage_file(path2) {
+            return run_aprt_stage_diff(path1, path2, limit, json_output);
+        }
         // Run tensor value comparison
         run_tensor_value_diff(path1, path2, filter, limit, transpose_aware, json_output)
     } else {
@@ -465,3 +473,4 @@ fn print_diff_json(
 include!("diff_accumulator.rs");
 include!("diff_output_json_text.rs");
 include!("diff_04.rs");
+include!("diff_05_aprt_stage.rs");

--- a/crates/apr-cli/src/commands/diff_05_aprt_stage.rs
+++ b/crates/apr-cli/src/commands/diff_05_aprt_stage.rs
@@ -1,0 +1,356 @@
+// SHIP-007 PR-D: APRT stage tensor diff for `apr diff --values`.
+//
+// Contract: contracts/apr-cli-trace-save-tensor-v1.yaml
+//   `apr_diff_values_compat` invariant — `apr diff --values` MUST recognize
+//   the 12-byte APRT header and read the f32 LE body so stage tensors
+//   captured by `apr trace --save-tensor` can be compared element-wise
+//   without external metadata.
+//
+// NOTE: this file is `include!()`-ed by diff.rs; do NOT add `use` for
+// crate::error::CliError, std::path::Path, colored::Colorize — diff.rs
+// already imports them. Add only NEW imports here.
+
+/// Detect whether `path` opens to a save-tensor file produced by
+/// `apr trace --save-tensor` (magic bytes `APRT` at offset 0).
+///
+/// Returns `false` on any I/O error or non-matching magic — callers
+/// fall through to the existing RosettaStone path.
+fn is_aprt_stage_file(path: &Path) -> bool {
+    use std::io::Read;
+    let Ok(mut file) = std::fs::File::open(path) else {
+        return false;
+    };
+    let mut magic = [0u8; 4];
+    if file.read_exact(&mut magic).is_err() {
+        return false;
+    }
+    magic == *b"APRT"
+}
+
+/// Element-wise stats for two equally-sized f32 vectors.
+struct AprtStageStats {
+    dim_product: usize,
+    layer: u32,
+    max_abs_diff: f32,
+    max_abs_diff_index: usize,
+    rms_diff: f32,
+    cosine_sim: f64,
+    top_diffs: Vec<(usize, f32, f32, f32)>,
+}
+
+fn compute_aprt_stage_stats(
+    layer: u32,
+    a: &[f32],
+    b: &[f32],
+    top_k: usize,
+) -> AprtStageStats {
+    let n = a.len();
+    let mut max_abs_diff = 0.0f32;
+    let mut max_idx = 0usize;
+    let mut sum_sq_diff = 0.0f64;
+    let mut dot = 0.0f64;
+    let mut na = 0.0f64;
+    let mut nb = 0.0f64;
+    let mut diffs: Vec<(usize, f32, f32, f32)> = Vec::with_capacity(n);
+    for (i, (&x, &y)) in a.iter().zip(b.iter()).enumerate() {
+        let d = (x - y).abs();
+        sum_sq_diff += f64::from(d) * f64::from(d);
+        if d > max_abs_diff {
+            max_abs_diff = d;
+            max_idx = i;
+        }
+        dot += f64::from(x) * f64::from(y);
+        na += f64::from(x) * f64::from(x);
+        nb += f64::from(y) * f64::from(y);
+        diffs.push((i, x, y, d));
+    }
+    let rms = if n == 0 {
+        0.0
+    } else {
+        ((sum_sq_diff / n as f64).sqrt()) as f32
+    };
+    let cosine = if na > 0.0 && nb > 0.0 {
+        dot / (na.sqrt() * nb.sqrt())
+    } else {
+        0.0
+    };
+    diffs.sort_by(|x, y| {
+        y.3.partial_cmp(&x.3).unwrap_or(std::cmp::Ordering::Equal)
+    });
+    diffs.truncate(top_k.max(1));
+    AprtStageStats {
+        dim_product: n,
+        layer,
+        max_abs_diff,
+        max_abs_diff_index: max_idx,
+        rms_diff: rms,
+        cosine_sim: cosine,
+        top_diffs: diffs,
+    }
+}
+
+// serde_json::json!() macro uses infallible unwrap internally
+#[allow(clippy::disallowed_methods)]
+fn run_aprt_stage_diff(
+    path1: &Path,
+    path2: &Path,
+    limit: usize,
+    json_output: bool,
+) -> Result<(), CliError> {
+    use realizar::inference_trace::save_tensor::read_tensor_file;
+
+    let mut f1 = std::fs::File::open(path1).map_err(|e| {
+        CliError::ValidationFailed(format!("Cannot open {}: {e}", path1.display()))
+    })?;
+    let (h1, vals1) = read_tensor_file(&mut f1).map_err(|e| {
+        CliError::ValidationFailed(format!(
+            "Cannot read APRT stage tensor {}: {e}",
+            path1.display()
+        ))
+    })?;
+
+    let mut f2 = std::fs::File::open(path2).map_err(|e| {
+        CliError::ValidationFailed(format!("Cannot open {}: {e}", path2.display()))
+    })?;
+    let (h2, vals2) = read_tensor_file(&mut f2).map_err(|e| {
+        CliError::ValidationFailed(format!(
+            "Cannot read APRT stage tensor {}: {e}",
+            path2.display()
+        ))
+    })?;
+
+    if h1.dim_product != h2.dim_product {
+        return Err(CliError::ValidationFailed(format!(
+            "APRT dim_product mismatch: {} has {} f32s, {} has {} f32s — \
+             cannot compare stage tensors of different sizes",
+            path1.display(),
+            h1.dim_product,
+            path2.display(),
+            h2.dim_product
+        )));
+    }
+    if h1.layer != h2.layer {
+        return Err(CliError::ValidationFailed(format!(
+            "APRT layer mismatch: {} is layer {}, {} is layer {} — \
+             stages from different layers cannot be compared element-wise",
+            path1.display(),
+            h1.layer,
+            path2.display(),
+            h2.layer
+        )));
+    }
+
+    let stats = compute_aprt_stage_stats(h1.layer, &vals1, &vals2, limit);
+
+    if json_output {
+        let top: Vec<serde_json::Value> = stats
+            .top_diffs
+            .iter()
+            .map(|(idx, a, b, d)| {
+                serde_json::json!({
+                    "index": idx,
+                    "a": a,
+                    "b": b,
+                    "abs_diff": d,
+                })
+            })
+            .collect();
+        let layer_label = if stats.layer == 0xFFFF_FFFF {
+            serde_json::Value::String("whole-model".to_string())
+        } else {
+            serde_json::Value::Number(stats.layer.into())
+        };
+        let json = serde_json::json!({
+            "schema": "apr-stage-diff-v1",
+            "path_a": path1.display().to_string(),
+            "path_b": path2.display().to_string(),
+            "layer": layer_label,
+            "dim_product": stats.dim_product,
+            "max_abs_diff": stats.max_abs_diff,
+            "max_abs_diff_index": stats.max_abs_diff_index,
+            "rms_diff": stats.rms_diff,
+            "cosine_sim": stats.cosine_sim,
+            "top_diffs": top,
+        });
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&json).unwrap_or_default()
+        );
+    } else {
+        println!(
+            "{}",
+            "╔══════════════════════════════════════════════════════════════════════════════╗".cyan()
+        );
+        println!(
+            "{}",
+            "║           APR STAGE TENSOR DIFF (APRT, element-wise)                         ║".cyan()
+        );
+        println!(
+            "{}",
+            "╠══════════════════════════════════════════════════════════════════════════════╣".cyan()
+        );
+        let layer_disp = if stats.layer == 0xFFFF_FFFF {
+            "whole-model".to_string()
+        } else {
+            format!("{}", stats.layer)
+        };
+        println!("║ A:           {:<64}║", path1.display().to_string());
+        println!("║ B:           {:<64}║", path2.display().to_string());
+        println!("║ Layer:       {:<64}║", layer_disp);
+        println!("║ Elements:    {:<64}║", stats.dim_product);
+        println!(
+            "║ max|diff|:   {:<64}║",
+            format!("{:.6e} (at index {})", stats.max_abs_diff, stats.max_abs_diff_index)
+        );
+        println!("║ RMS diff:    {:<64.6e}║", stats.rms_diff);
+        println!("║ cosine sim:  {:<64.10}║", stats.cosine_sim);
+        println!(
+            "{}",
+            "╠══════════════════════════════════════════════════════════════════════════════╣".cyan()
+        );
+        println!("║ Top divergences (by |a - b|):                                                ║");
+        for (idx, a, b, d) in &stats.top_diffs {
+            println!(
+                "║   [{:>8}] a={:>+13.6e}  b={:>+13.6e}  |Δ|={:.6e}                ║",
+                idx, a, b, d
+            );
+        }
+        println!(
+            "{}",
+            "╚══════════════════════════════════════════════════════════════════════════════╝".cyan()
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod aprt_stage_diff_tests {
+    use super::*;
+    use std::io::Write;
+
+    fn write_aprt_file(path: &Path, layer: u32, values: &[f32]) {
+        let mut f = std::fs::File::create(path).unwrap();
+        // 12-byte header: magic + layer + dim_product
+        f.write_all(b"APRT").unwrap();
+        f.write_all(&layer.to_le_bytes()).unwrap();
+        let dim = u32::try_from(values.len()).unwrap();
+        f.write_all(&dim.to_le_bytes()).unwrap();
+        for v in values {
+            f.write_all(&v.to_le_bytes()).unwrap();
+        }
+    }
+
+    #[test]
+    fn provenance_pin_pr_d_rev1() {
+        // Drift guard for SHIP-007 PR-D PARTIAL_ALGORITHM_LEVEL discharge.
+        // If anyone moves this file or renames `is_aprt_stage_file` /
+        // `run_aprt_stage_diff`, the include!() in diff.rs and these unit
+        // tests will fail — forcing a contract bump in
+        // `apr-cli-trace-save-tensor-v1.yaml`.
+        let p = std::path::PathBuf::from("/nonexistent/aprt-pin.bin");
+        assert!(!is_aprt_stage_file(&p));
+    }
+
+    #[test]
+    fn is_aprt_stage_file_detects_magic() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = tmp.path().join("ok.bin");
+        write_aprt_file(&p, 0, &[1.0, 2.0, 3.0]);
+        assert!(is_aprt_stage_file(&p));
+    }
+
+    #[test]
+    fn is_aprt_stage_file_rejects_non_aprt() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = tmp.path().join("not.bin");
+        std::fs::write(&p, b"GGUF\x00\x00\x00\x00").unwrap();
+        assert!(!is_aprt_stage_file(&p));
+    }
+
+    #[test]
+    fn is_aprt_stage_file_rejects_truncated() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = tmp.path().join("trunc.bin");
+        std::fs::write(&p, b"AP").unwrap();
+        assert!(!is_aprt_stage_file(&p));
+    }
+
+    #[test]
+    fn is_aprt_stage_file_rejects_missing() {
+        let p = std::path::PathBuf::from("/nonexistent/path/to/aprt-file.bin");
+        assert!(!is_aprt_stage_file(&p));
+    }
+
+    #[test]
+    fn compute_stats_identical_inputs_zero_diff() {
+        let a = vec![1.0_f32, 2.0, 3.0, 4.0];
+        let stats = compute_aprt_stage_stats(0, &a, &a, 3);
+        assert_eq!(stats.dim_product, 4);
+        assert_eq!(stats.max_abs_diff, 0.0);
+        assert_eq!(stats.rms_diff, 0.0);
+        assert!((stats.cosine_sim - 1.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn compute_stats_known_max_and_rms() {
+        let a = vec![1.0_f32, 2.0, 3.0, 4.0];
+        let b = vec![1.0_f32, 2.5, 3.0, 4.0];
+        let stats = compute_aprt_stage_stats(0, &a, &b, 5);
+        // max |diff| = |2.0-2.5| = 0.5 at index 1
+        assert_eq!(stats.max_abs_diff_index, 1);
+        assert!((stats.max_abs_diff - 0.5).abs() < 1e-6);
+        // RMS = sqrt((0 + 0.25 + 0 + 0)/4) = 0.25
+        assert!((stats.rms_diff - 0.25).abs() < 1e-6);
+        // top 1 diff is index 1
+        assert_eq!(stats.top_diffs[0].0, 1);
+    }
+
+    #[test]
+    fn compute_stats_top_k_sorted_descending_by_abs_diff() {
+        let a = vec![0.0_f32, 0.0, 0.0, 0.0, 0.0];
+        let b = vec![0.1_f32, 0.5, -0.3, 0.05, 0.2];
+        let stats = compute_aprt_stage_stats(0, &a, &b, 3);
+        assert_eq!(stats.top_diffs.len(), 3);
+        // expected order by |b|: 0.5, 0.3, 0.2
+        assert_eq!(stats.top_diffs[0].0, 1);
+        assert_eq!(stats.top_diffs[1].0, 2);
+        assert_eq!(stats.top_diffs[2].0, 4);
+    }
+
+    #[test]
+    fn run_diff_dim_product_mismatch_errors() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p1 = tmp.path().join("a.bin");
+        let p2 = tmp.path().join("b.bin");
+        write_aprt_file(&p1, 0, &[1.0, 2.0]);
+        write_aprt_file(&p2, 0, &[1.0, 2.0, 3.0]);
+        let r = run_aprt_stage_diff(&p1, &p2, 5, true);
+        assert!(r.is_err(), "expected dim_product mismatch error");
+        let msg = format!("{}", r.unwrap_err());
+        assert!(msg.contains("dim_product mismatch"), "msg was: {msg}");
+    }
+
+    #[test]
+    fn run_diff_layer_mismatch_errors() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p1 = tmp.path().join("a.bin");
+        let p2 = tmp.path().join("b.bin");
+        write_aprt_file(&p1, 0, &[1.0, 2.0]);
+        write_aprt_file(&p2, 7, &[1.0, 2.0]);
+        let r = run_aprt_stage_diff(&p1, &p2, 5, true);
+        assert!(r.is_err(), "expected layer mismatch error");
+        let msg = format!("{}", r.unwrap_err());
+        assert!(msg.contains("layer mismatch"), "msg was: {msg}");
+    }
+
+    #[test]
+    fn run_diff_identical_files_succeeds() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p1 = tmp.path().join("a.bin");
+        let p2 = tmp.path().join("b.bin");
+        write_aprt_file(&p1, 3, &[1.0, 2.0, 3.0]);
+        write_aprt_file(&p2, 3, &[1.0, 2.0, 3.0]);
+        let r = run_aprt_stage_diff(&p1, &p2, 5, true);
+        assert!(r.is_ok());
+    }
+}


### PR DESCRIPTION
## Summary

- Closes the `apr_diff_values_compat` invariant of `apr-cli-trace-save-tensor-v1` at PARTIAL_ALGORITHM_LEVEL.
- New `diff_05_aprt_stage.rs` include slot: when both inputs to `apr diff --values` start with magic bytes `APRT`, dispatch bypasses the whole-model RosettaStone walker and runs an element-wise stage-tensor diff (max|diff|, RMS, cosine sim, top-K).
- Mismatched dim_product or layer → fail-fast error (no silent compare of incompatible stages).
- Contract `apr-cli-trace-save-tensor-v1` v1.0.0 → v1.1.0 with new FALSIFY-APR-TRACE-SAVE-009.

## Why now

The SHIP-007 PR-A→B→C cascade for MODEL-1 layer-0 stage-by-stage element-wise bisection (per `feedback_model_1_ships_gpu_only.md`) needs PR-D infrastructure ready in parallel with PR #1408 (PR-C-real step 1). PR-D is CLI-only — no dependency on forward_traced threading — so it merges independently.

`apr trace --save-tensor` writes APRT-prefixed per-stage f32 tensors. Without this PR, callers must either parse the 12-byte header by hand or shell out to a Python script — exactly the kind of muda APR-MONO §26.8 forbids.

## What changed

- `crates/apr-cli/src/commands/diff_05_aprt_stage.rs` (new): `is_aprt_stage_file`, `compute_aprt_stage_stats`, `run_aprt_stage_diff` + 11 unit tests (provenance pin, magic detection, stats correctness, error cases).
- `crates/apr-cli/src/commands/diff.rs`: detect APRT magic on both `--values` inputs and dispatch before the RosettaStone path; legacy callers (model-vs-model diff) unchanged.
- `contracts/apr-cli-trace-save-tensor-v1.yaml`: v1.0.0 → v1.1.0; new FALSIFY-APR-TRACE-SAVE-009 with `algorithm_evidence` citing the new unit tests.

## Test plan

- [x] `cargo test -p apr-cli --lib commands::diff::aprt` → 11/11 PASS
- [x] `cargo clippy -p apr-cli --lib --no-deps -- -D warnings` clean
- [x] `pv validate contracts/apr-cli-trace-save-tensor-v1.yaml` → 0 errors
- [ ] CI required checks (`ci / gate`, `workspace-test`)

## Five Whys

1. **Why now?** SHIP-007 cascade needs PR-D ready when PR-C-real step 2 lands.
2. **Why extend `apr diff` instead of new subcommand?** Contract `apr_diff_values_compat` already names `apr diff --values` as the verifier.
3. **Why an include!() file?** diff.rs follows that pattern (diff_accumulator, diff_output_json_text, diff_04).
4. **Why no live integration smoke?** The infrastructure for end-to-end live (`apr trace --save-tensor X.bin`) requires SHIP-007 PR-C-real step 2 (#1408 stacked) to be merged. The unit tests pin the byte-format contract via synthetic APRT fixtures, which is sufficient at PARTIAL_ALGORITHM_LEVEL per the contract's own discharge ladder.
5. **Why dogfood `realizar::inference_trace::save_tensor::read_tensor_file` instead of inline parsing?** Reusing the same parser the writer uses is the canonical way to prevent format drift. apr-cli already imports from realizar via the default `inference` feature.

## Ship % update

- **MODEL-1**: ~64% → ~66% (1 invariant DISCHARGED-at-algorithm; infrastructure clear for SHIP-007 step E live diffing).
- **MODEL-2**: full Stack v1.2 Python corpus tokenization running in background (~33h ETA).

🤖 Generated with [Claude Code](https://claude.com/claude-code)