### PR TITLE
feat(aprender-serve): SHIP-007 PR-C-real step 2 — LmHead capture in forward_traced wrapper

### DIFF
--- a/crates/aprender-serve/src/apr_transformer/traced_save_tensor.rs
+++ b/crates/aprender-serve/src/apr_transformer/traced_save_tensor.rs
@@ -35,7 +35,7 @@ use std::io::{BufWriter, Write};
 
 use crate::apr_transformer::{AprTransformer, ForwardTrace};
 use crate::error::{RealizarError, Result};
-use crate::inference_trace::save_tensor::write_tensor_file;
+use crate::inference_trace::save_tensor::{write_tensor_file, WHOLE_MODEL_LAYER};
 use crate::inference_trace::save_tensor_paths::ensure_layer_dir;
 use crate::inference_trace::save_tensor_plan::SaveTensorPlan;
 use crate::inference_trace::save_tensor_stage::SaveTensorStage;
@@ -57,18 +57,22 @@ pub enum SaveTensorEmitError {
 }
 
 impl AprTransformer {
-    /// SHIP-007 PR-C-real-step1: forward pass with layer-by-layer tracing
-    /// AND optional per-stage F32 tensor capture.
+    /// SHIP-007 PR-C-real (step 1 + step 2): forward pass with layer-by-layer
+    /// tracing AND optional per-stage F32 tensor capture.
     ///
     /// This is a thin wrapper around [`AprTransformer::forward_traced`].
     /// It does the same work, returns the same [`ForwardTrace`], and
-    /// additionally writes the embedding stage to disk if the supplied
-    /// plan selects it (`plan.should_save(SaveTensorStage::Embedding, 0)`).
+    /// additionally writes selected stage tensors to disk:
     ///
-    /// Whole-model stages (`final_norm`, `lm_head`) and per-layer stages
-    /// other than embedding are NOT yet captured by this wrapper — those
-    /// will be added in subsequent PRs that thread the plan through
-    /// `forward_traced` internals.
+    /// - **`Embedding`** (step 1): re-extracted via `self.embed(token_ids)` —
+    ///   cheap (token-table lookup), no internal forward_traced surgery.
+    /// - **`LmHead`** (step 2): pulled from `trace.logits` — already returned
+    ///   by `forward_traced`, no recompute, no surgery.
+    ///
+    /// Per-layer stages other than `Embedding` (qkv_matmul, ffn_gate, etc.)
+    /// and the `FinalNorm` whole-model stage still require threading
+    /// `Option<&SaveTensorPlan>` through `forward_traced` itself; they are
+    /// captured by subsequent steps and silently skipped here.
     ///
     /// Pass an empty plan (e.g.
     /// `SaveTensorPlan::from_cli("embedding", "0..0_does_not_parse", _)`)
@@ -124,6 +128,166 @@ impl AprTransformer {
             })?;
         }
 
+        // Step-2 scope: emit the LmHead (final logits) whole-model stage.
+        // `trace.logits` is already a Vec<f32> returned by forward_traced — no
+        // recompute needed, no internal forward_traced surgery. This is the
+        // same low-risk pattern as Embedding above; the corresponding
+        // forward-pass surgery for per-layer stages (qkv, ffn_*, etc.) is
+        // deferred to subsequent SHIP-007 steps.
+        if plan.should_save(SaveTensorStage::LmHead, WHOLE_MODEL_LAYER) {
+            let path = plan.stage_path(SaveTensorStage::LmHead, WHOLE_MODEL_LAYER);
+            // Whole-model stage: ensure_layer_dir(WHOLE_MODEL_LAYER) creates
+            // `<output_dir>/` (no per-layer subdir).
+            ensure_layer_dir(&plan.output_dir, WHOLE_MODEL_LAYER).map_err(|e| {
+                RealizarError::IoError {
+                    message: format!("save_tensor::ensure_layer_dir(lm_head): {e}"),
+                }
+            })?;
+            let file = std::fs::File::create(&path).map_err(|e| RealizarError::IoError {
+                message: format!("save_tensor::create({}): {e}", path.display()),
+            })?;
+            let mut writer = BufWriter::new(file);
+            // Whole-model stages use WHOLE_MODEL_LAYER as the header layer
+            // field per `save_tensor::write_header` contract.
+            write_tensor_file(&mut writer, WHOLE_MODEL_LAYER, &trace.logits).map_err(|e| {
+                RealizarError::IoError {
+                    message: format!("save_tensor::write({}): {e}", path.display()),
+                }
+            })?;
+            writer.flush().map_err(|e| RealizarError::IoError {
+                message: format!("save_tensor::flush({}): {e}", path.display()),
+            })?;
+        }
+
         Ok(trace)
+    }
+}
+
+#[cfg(test)]
+mod traced_save_tensor_step2_tests {
+    //! SHIP-007 PR-C-real step 2 — `LmHead` branch pin tests.
+    //!
+    //! These tests do NOT instantiate a full `AprTransformer` (loading a
+    //! real APR model is heavyweight). Instead they pin the SHAPE of the
+    //! wrapper's LmHead branch: the same plan API → ensure_dir → File::create
+    //! → write_tensor_file → flush sequence. A drift-prevention pin: if any
+    //! step of the chain breaks (renamed function, changed path layout,
+    //! header byte format change), this test fails before the wrapper does.
+    //!
+    //! Live discharge of the wrapper running on a real model is left to
+    //! SHIP-007 PR-E (`apr trace --save-tensor lm_head` end-to-end).
+    use super::{
+        ensure_layer_dir, write_tensor_file, SaveTensorPlan, SaveTensorStage, WHOLE_MODEL_LAYER,
+    };
+    use std::io::{BufWriter, Write};
+
+    /// Mirror the exact byte-flow the wrapper's step-2 branch performs.
+    fn simulate_step2_lm_head_branch(
+        plan: &SaveTensorPlan,
+        logits: &[f32],
+    ) -> std::io::Result<Option<std::path::PathBuf>> {
+        if !plan.should_save(SaveTensorStage::LmHead, WHOLE_MODEL_LAYER) {
+            return Ok(None);
+        }
+        let path = plan.stage_path(SaveTensorStage::LmHead, WHOLE_MODEL_LAYER);
+        ensure_layer_dir(&plan.output_dir, WHOLE_MODEL_LAYER)?;
+        let file = std::fs::File::create(&path)?;
+        let mut writer = BufWriter::new(file);
+        write_tensor_file(&mut writer, WHOLE_MODEL_LAYER, logits)?;
+        writer.flush()?;
+        Ok(Some(path))
+    }
+
+    #[test]
+    fn step2_lm_head_writes_to_output_root_not_per_layer_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let plan = SaveTensorPlan::from_cli("lm_head", "0..1", tmp.path().to_path_buf()).unwrap();
+        let logits = vec![1.5_f32, 2.5, -3.5, 4.5];
+
+        let written = simulate_step2_lm_head_branch(&plan, &logits)
+            .unwrap()
+            .expect("LmHead is selected — should write");
+
+        // Per `output_path_whole_model_no_layer_segment` test in
+        // save_tensor_paths.rs: whole-model stages land at <root>/lm_head.bin.
+        assert_eq!(written, tmp.path().join("lm_head.bin"));
+        assert!(written.exists());
+        // No layer-N subdirectory should be created for the lm_head stage.
+        assert!(!tmp.path().join("layer-0").join("lm_head.bin").exists());
+    }
+
+    #[test]
+    fn step2_lm_head_header_uses_whole_model_sentinel() {
+        let tmp = tempfile::tempdir().unwrap();
+        let plan = SaveTensorPlan::from_cli("lm_head", "0..1", tmp.path().to_path_buf()).unwrap();
+        let logits = vec![0.1_f32, 0.2, 0.3, 0.4, 0.5];
+
+        let path = simulate_step2_lm_head_branch(&plan, &logits)
+            .unwrap()
+            .unwrap();
+
+        let bytes = std::fs::read(&path).unwrap();
+        assert!(bytes.len() >= 12, "header is 12 bytes minimum");
+        assert_eq!(&bytes[0..4], b"APRT", "magic must be APRT");
+        let layer = u32::from_le_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]);
+        assert_eq!(
+            layer, WHOLE_MODEL_LAYER,
+            "whole-model stages must use WHOLE_MODEL_LAYER sentinel"
+        );
+        let dim = u32::from_le_bytes([bytes[8], bytes[9], bytes[10], bytes[11]]);
+        assert_eq!(dim, logits.len() as u32);
+        assert_eq!(
+            bytes.len(),
+            12 + logits.len() * 4,
+            "total file = 12-byte header + 4 bytes per f32"
+        );
+    }
+
+    #[test]
+    fn step2_lm_head_skipped_when_plan_does_not_select_it() {
+        // Plan selects only Embedding — LmHead branch must NOT fire.
+        let tmp = tempfile::tempdir().unwrap();
+        let plan = SaveTensorPlan::from_cli("embedding", "0..1", tmp.path().to_path_buf()).unwrap();
+        let logits = vec![9.9_f32];
+
+        let written = simulate_step2_lm_head_branch(&plan, &logits).unwrap();
+        assert!(
+            written.is_none(),
+            "LmHead branch must be a no-op when not selected"
+        );
+        assert!(!tmp.path().join("lm_head.bin").exists());
+    }
+
+    #[test]
+    fn step2_lm_head_writes_logits_bytes_verbatim() {
+        // Determinism + bit-identity pin: the bytes after the header are
+        // exactly the f32 LE values from the input slice, no quantization,
+        // no NaN-masking.
+        let tmp = tempfile::tempdir().unwrap();
+        let plan = SaveTensorPlan::from_cli("lm_head", "0..1", tmp.path().to_path_buf()).unwrap();
+        let logits = vec![1.0_f32, f32::NAN, -0.0, f32::INFINITY];
+
+        let path = simulate_step2_lm_head_branch(&plan, &logits)
+            .unwrap()
+            .unwrap();
+
+        let bytes = std::fs::read(&path).unwrap();
+        let body = &bytes[12..];
+        assert_eq!(body.len(), logits.len() * 4);
+        // Verify each f32 round-trips bit-exactly (NaN bits preserved).
+        for (i, expected) in logits.iter().enumerate() {
+            let read = f32::from_le_bytes([
+                body[i * 4],
+                body[i * 4 + 1],
+                body[i * 4 + 2],
+                body[i * 4 + 3],
+            ]);
+            // NaN != NaN, so compare bit patterns instead.
+            assert_eq!(
+                read.to_bits(),
+                expected.to_bits(),
+                "bit-identical round-trip required at index {i}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Extends the SHIP-007 PR-C-real step 1 wrapper (#1408) to capture the **`LmHead`** (final logits) whole-model stage. The logits come straight from `trace.logits` (already returned by `forward_traced`) — no recompute, no surgery on the 360-line function body.

This is the same low-risk pattern as step 1's `Embedding` branch (re-use already-computed data; defer the high-risk per-layer threading into `forward_traced` to future steps).

## What changed

- `crates/aprender-serve/src/apr_transformer/traced_save_tensor.rs`:
  - Added `LmHead` branch using `WHOLE_MODEL_LAYER` sentinel.
  - 4 unit tests in new `traced_save_tensor_step2_tests` module pinning path layout, header sentinel, skip-when-unselected, and bit-identical logits round-trip (NaN-bit preserving).
  - Updated doc-comment to reflect step-1+step-2 capture surface.
- Step 1's `Embedding` branch is byte-identical to before (only added a sibling block).

## Five Whys

1. **Why LmHead next?** Of 18 `SaveTensorStage` variants, only `Embedding` and `LmHead` are externally re-extractable from a `forward_traced` return value without modifying the function body. Step 1 shipped Embedding; LmHead is the obvious second.
2. **Why not jump to per-layer stages?** Those require threading `Option<&SaveTensorPlan>` through the 360-line forward body — high blast radius, deserves its own PR.
3. **Why WHOLE_MODEL_LAYER sentinel?** Per `apr-cli-trace-save-tensor-v1` `byte_format` invariant: whole-model stages carry `0xFFFFFFFF` in the layer field so `apr diff --values` (PR #1413) can recognize them.
4. **Why no live integration test on a real `AprTransformer`?** Loading APR is heavyweight; the wrapper's logic is three plan-API calls + a write. The 4 new pin tests simulate the byte-flow at the contract level. Live discharge is left to SHIP-007 PR-E.
5. **Why now?** PR #1408 (step 1) merged today; PR #1413 (PR-D APRT diff) is in the merge queue. Per `feedback_model_1_ships_gpu_only.md`, the SHIP-007 layer-0 stage-diff path needs the wrapper's capture surface expanded one stage at a time. LmHead is the smallest, safest next step.

## Test plan

- [x] `cargo test -p aprender-serve --lib traced_save_tensor_step2` → 4/4 PASS
  - step2_lm_head_writes_to_output_root_not_per_layer_dir
  - step2_lm_head_header_uses_whole_model_sentinel
  - step2_lm_head_skipped_when_plan_does_not_select_it
  - step2_lm_head_writes_logits_bytes_verbatim (NaN-bit-preserving)
- [x] `cargo check -p aprender-serve --lib` clean
- [ ] CI required checks (`ci / gate`, `workspace-test`)

## Contract

Contract update is intentionally deferred to a follow-up commit to avoid file-conflict with PR #1413 (mid-merge; bumps `apr-cli-trace-save-tensor-v1` v1.0.0 → v1.1.0). Once #1413 lands, a small follow-up will bump v1.1.0 → v1.2.0 with FALSIFY-APR-TRACE-SAVE-010 binding the new LmHead branch at PARTIAL_ALGORITHM_LEVEL. The 4 new pin tests stand in for the algorithm-level discharge until that follow-up.

## Ship % update

- **MODEL-1**: ~66% → ~68% (SHIP-007 capture surface 1/18 → 2/18 stages).
- **MODEL-2**: full Stack v1.2 corpus tokenization in progress in background (~33h ETA, ~14K tok/s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)