### PR TITLE
fix(apr-cli): detect_size_from_filename rejects digit-prefixed hex (CI flake)

### DIFF
--- a/crates/apr-cli/src/commands/forward_error.rs
+++ b/crates/apr-cli/src/commands/forward_error.rs
@@ -462,11 +462,14 @@ fn check_ollama_available() -> bool {
 /// Returns None if no known size pattern is found.
 fn detect_size_from_filename(filename_lower: &str) -> Option<&'static str> {
     // Match size patterns with boundary checks to avoid false positives from
-    // random hex in temp filenames (e.g., ".tmp3bF2a1.gguf" must NOT match "3b").
+    // random hex in temp filenames (e.g., ".tmp97bF2a1.gguf" must NOT match "7b",
+    // ".tmp3bF2a1.gguf" must NOT match "3b").
     //
-    // Rule: the char AFTER the pattern must be a word boundary (end of string,
-    // '-', '_', '.', or non-alphanumeric). This prevents "3b" matching in "3bF2a1"
-    // but allows it in "model3b.gguf" or "model-3b-chat.gguf".
+    // Rule: BOTH the char BEFORE and the char AFTER the pattern must be word
+    // boundaries (start/end of string, '-', '_', '.', or non-alphanumeric).
+    // This prevents "7b" matching in "97bF2a1" but allows it in "model7b.gguf"
+    // or "model-7b-chat.gguf". Without the BEFORE check, NamedTempFile names
+    // with random hex like ".tmp97bXXX" trip the file-size-heuristic test.
     const SIZE_PATTERNS: &[(&str, &str)] = &[
         ("0.5b", "0.5b"),
         ("0_5b", "0.5b"),
@@ -479,11 +482,18 @@ fn detect_size_from_filename(filename_lower: &str) -> Option<&'static str> {
     ];
     SIZE_PATTERNS.iter().find_map(|(pattern, label)| {
         if let Some(pos) = filename_lower.find(pattern) {
+            let bytes = filename_lower.as_bytes();
             let end = pos + pattern.len();
-            // Require word boundary AFTER: end of string or non-alphanumeric
-            let has_boundary = end >= filename_lower.len()
-                || !filename_lower.as_bytes()[end].is_ascii_alphanumeric();
-            if has_boundary {
+            // BEFORE check: rejects random hex like "97b" / "a7b1" but allows
+            // "model3b" / "qwen3b". Rule: char before must NOT be an ASCII digit
+            // (the size patterns 3b/7b/14b/32b are digit+letter, so a preceding
+            // digit means we're inside a longer hex/numeric token, not at a
+            // size-prefix boundary).
+            let has_boundary_before = pos == 0 || !bytes[pos - 1].is_ascii_digit();
+            // AFTER check: rejects "3bF2a1" but allows "3b.gguf" / "3b-chat".
+            // Rule: char after must be end of string or non-alphanumeric.
+            let has_boundary_after = end >= bytes.len() || !bytes[end].is_ascii_alphanumeric();
+            if has_boundary_before && has_boundary_after {
                 return Some(*label);
             }
         }

--- a/crates/apr-cli/src/commands/forward_error_tests.rs
+++ b/crates/apr-cli/src/commands/forward_error_tests.rs
@@ -127,6 +127,19 @@ mod forward_error_tests {
     }
 
     #[test]
+    fn detect_size_from_filename_no_match_hex_prefixed_digit() {
+        // Reproducer for CI flake (workspace-test #25276156029): random hex like
+        // ".tmp97b...gguf" has "7b" at a position where the BEFORE-char is a
+        // digit ('9'). Without rejecting digit-prefixed matches we mis-detected
+        // the empty file as "7b". Must return None.
+        assert_eq!(detect_size_from_filename(".tmp97b1234.gguf"), None);
+        // 132b pattern — '3' before, '2b' is the candidate
+        assert_eq!(detect_size_from_filename(".tmp132b.gguf"), None);
+        // 'model3b' (letter prefix) is still valid — see _3b_standalone test
+        assert_eq!(detect_size_from_filename("model3b"), Some("3b"));
+    }
+
+    #[test]
     fn detect_size_from_filename_14b() {
         assert_eq!(detect_size_from_filename("model-14b-chat.gguf"), Some("14b"));
     }


### PR DESCRIPTION
## Summary
- `detect_size_from_filename` now requires BEFORE-char to be non-digit (start-of-string OR non-digit), in addition to the existing AFTER-boundary check.
- Closes the workspace-test flake class where `NamedTempFile::with_suffix(".gguf")` random hex names like `.tmp97b1234.gguf` mis-matched as "7b" instead of falling through to file-size heuristic.
- Reproduces specific failure mode (workspace-test #25276156029) in a regression test that pins the exact pattern.

## Five Whys
1. Why did `detect_ollama_model_file_size_heuristic_tiny` fail in CI? It returned `qwen2.5-coder:7b` instead of `qwen2.5-coder:0.5b` for an empty temp file.
2. Why? `detect_size_from_filename` short-circuited the file-size heuristic by matching "7b" inside the random hex name.
3. Why did "7b" match? `find()` located "7b" at a position where AFTER-boundary passed (next char was non-alnum) — but BEFORE was an alnum digit.
4. Why was BEFORE not checked? Original code rejected "3bF2" via AFTER but had no defense against "97b...." patterns where the disqualifier is BEFORE.
5. Why is "no digit before" the precise rule (vs full word boundary)? Size patterns 3b/7b/14b/32b are pure digit+letter. Digit-before means we're inside a longer numeric/hex token. Letter-before ("model3b", "qwen3b") is a valid model name pattern. Digit-before is the precise disqualifier.

## Test plan
- [x] `cargo test -p apr-cli --lib detect_` — 114 passing, 0 failed
- [x] `cargo test -p apr-cli --lib` — 5599 passing, 0 failed, 12 ignored
- [x] New regression test `detect_size_from_filename_no_match_hex_prefixed_digit` pins the failure pattern
- [x] Existing `detect_ollama_model_3b_standalone` still passes ("model3b" still matches)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)