### PR TITLE
feat(aprender-serve): SHIP-007 PR-C-real step 3 — per-layer SaveTensorPlan threading through forward_traced

### DIFF
--- a/crates/apr-cli/src/commands/trace_save_tensor.rs
+++ b/crates/apr-cli/src/commands/trace_save_tensor.rs
@@ -111,8 +111,12 @@ pub fn run_save_tensor_apr(
         CliError::InferenceFailed(format!("AprTransformer::from_apr_file failed: {e}"))
     })?;
 
-    // Run the wrapper end-to-end. Currently captures Embedding + LmHead;
-    // SHIP-007 step 3 will widen this to per-layer stages.
+    // SHIP-007 PR-C-real step 3 LIVE: forward_traced_with_save_tensor delegates
+    // to forward_traced_with_plan which threads the SaveTensorPlan through every
+    // capture point in a single forward pass — Embedding, AttnNorm, QkvMatmul,
+    // QkvBias, Attention, AttnOut, PostAttnResidual, FfnNorm, FfnGate, FfnUp,
+    // FfnSilu, FfnSwigl, FfnOut, PostFfnResidual per-layer + FinalNorm + LmHead
+    // whole-model.
     let trace = transformer
         .forward_traced_with_save_tensor(&test_tokens, &plan)
         .map_err(|e| {
@@ -142,8 +146,10 @@ pub fn run_save_tensor_apr(
         trace.logits.len()
     );
     println!(
-        "Note: per-layer stages (qkv, attn_out, ffn_*) are captured in SHIP-007 step 3+; \
-         this run captures Embedding + LmHead only."
+        "Stages captured in single forward pass via SHIP-007 PR-C-real step 3 \
+         (Embedding/AttnNorm/QkvMatmul/QkvBias/Attention/AttnOut/PostAttnResidual/\
+         FfnNorm/FfnGate/FfnUp/FfnSilu/FfnSwigl/FfnOut/PostFfnResidual per-layer \
+         + FinalNorm/LmHead whole-model)."
     );
 
     Ok(())

--- a/crates/aprender-serve/src/apr_transformer/inference.rs
+++ b/crates/aprender-serve/src/apr_transformer/inference.rs
@@ -17,6 +17,45 @@ impl AprTransformer {
     ///
     /// Returns error if inference fails
     pub fn forward_traced(&self, token_ids: &[u32]) -> Result<ForwardTrace> {
+        self.forward_traced_with_plan(token_ids, None)
+    }
+
+    /// SHIP-007 PR-C-real step 3: forward_traced + optional per-stage
+    /// `SaveTensorPlan` emission.
+    ///
+    /// Identical to [`Self::forward_traced`] when `plan == None`. When
+    /// `plan == Some(&plan)`, emits selected stage tensors to disk via
+    /// [`crate::inference_trace::save_tensor_emit::maybe_save_stage`] at
+    /// each natural capture point (Embedding, AttnNorm, QkvMatmul, AttnOut,
+    /// PostAttnResidual, FfnNorm, FfnGate, FfnUp, FfnSilu, FfnSwigl, FfnOut,
+    /// PostFfnResidual per-layer, plus FinalNorm + LmHead whole-model).
+    ///
+    /// Contract: [`contracts/apr-cli-trace-save-tensor-v1.yaml`] step-3
+    /// per-layer threading.
+    ///
+    /// # Errors
+    ///
+    /// - Propagates [`RealizarError`](crate::error::RealizarError) from the
+    ///   underlying forward pass.
+    /// - Returns [`RealizarError::IoError`] if any
+    ///   [`maybe_save_stage`](crate::inference_trace::save_tensor_emit::maybe_save_stage)
+    ///   write fails.
+    pub fn forward_traced_with_plan(
+        &self,
+        token_ids: &[u32],
+        plan: Option<&crate::inference_trace::save_tensor_plan::SaveTensorPlan>,
+    ) -> Result<ForwardTrace> {
+        use crate::inference_trace::save_tensor::WHOLE_MODEL_LAYER;
+        use crate::inference_trace::save_tensor_emit::maybe_save_stage;
+        use crate::inference_trace::save_tensor_stage::SaveTensorStage;
+
+        // Wraps `maybe_save_stage` IO error → `RealizarError::IoError`.
+        let emit = |stage: SaveTensorStage, layer: u32, values: &[f32]| -> Result<()> {
+            maybe_save_stage(plan, stage, layer, values).map_err(|e| RealizarError::IoError {
+                message: format!("save_tensor::{stage:?} L{layer}: {e}"),
+            })
+        };
+
         if token_ids.is_empty() {
             return Err(RealizarError::InvalidShape {
                 reason: "Token sequence cannot be empty".to_string(),
@@ -28,6 +67,7 @@ impl AprTransformer {
 
         // 1. Token embedding lookup
         let mut hidden = self.embed(token_ids);
+        emit(SaveTensorStage::Embedding, 0, &hidden)?;
         let embed_stats = ActivationStats::from_slice(&hidden);
 
         let mut layer_activations = Vec::with_capacity(self.layers.len());
@@ -44,6 +84,7 @@ impl AprTransformer {
                 layer.attn_norm_bias.as_deref(),
                 self.config.eps,
             );
+            emit(SaveTensorStage::AttnNorm, layer_idx as u32, &normed)?;
             let attn_norm_stats = ActivationStats::from_slice(&normed);
             // Last-token-only slice for parity with GGUF (§37 / FALSIFY-APR-GGUF-PARITY-007)
             let seq_len_for_last = token_ids.len();
@@ -54,8 +95,10 @@ impl AprTransformer {
             // 2b. QKV projection
             let qkv_dim = layer.qkv_weight.len() / hidden_dim;
             let mut qkv = self.matmul(&normed, &layer.qkv_weight, hidden_dim, qkv_dim);
+            emit(SaveTensorStage::QkvMatmul, layer_idx as u32, &qkv)?;
             if let Some(ref bias) = layer.qkv_bias {
                 self.add_bias(&mut qkv, bias);
+                emit(SaveTensorStage::QkvBias, layer_idx as u32, &qkv)?;
             }
             let qkv_stats = ActivationStats::from_slice(&qkv);
             let last_token_qkv_stats =
@@ -127,12 +170,16 @@ impl AprTransformer {
                 }
             }
 
+            // Capture pre-O-proj attention output (Q@Kᵀ@V combined).
+            emit(SaveTensorStage::Attention, layer_idx as u32, &attn_out)?;
+
             // Output projection
             let mut attn_output =
                 self.matmul(&attn_out, &layer.attn_output_weight, hidden_dim, hidden_dim);
             if let Some(ref bias) = layer.attn_output_bias {
                 self.add_bias(&mut attn_output, bias);
             }
+            emit(SaveTensorStage::AttnOut, layer_idx as u32, &attn_output)?;
             let attn_out_stats = ActivationStats::from_slice(&attn_output);
             let last_token_attn_out_stats = ActivationStats::from_slice(
                 &attn_output[(seq_len_for_last - 1) * hidden_dim..],
@@ -142,6 +189,7 @@ impl AprTransformer {
             for i in 0..hidden.len() {
                 hidden[i] += attn_output[i];
             }
+            emit(SaveTensorStage::PostAttnResidual, layer_idx as u32, &hidden)?;
 
             // 2f. FFN layer norm (if present)
             let ffn_input = if let Some(ref norm_weight) = layer.ffn_norm_weight {
@@ -155,6 +203,7 @@ impl AprTransformer {
             } else {
                 hidden.clone()
             };
+            emit(SaveTensorStage::FfnNorm, layer_idx as u32, &ffn_input)?;
             let ffn_norm_stats = ActivationStats::from_slice(&ffn_input);
             let last_token_ffn_norm_stats = ActivationStats::from_slice(
                 &ffn_input[(seq_len_for_last - 1) * hidden_dim..],
@@ -175,12 +224,14 @@ impl AprTransformer {
 
             let ffn_output = if let Some(ref gate_weight) = layer.ffn_gate_weight {
                 let gate = self.matmul(&ffn_input, gate_weight, hidden_dim, intermediate_dim);
+                emit(SaveTensorStage::FfnGate, layer_idx as u32, &gate)?;
                 let up = self.matmul(
                     &ffn_input,
                     &layer.ffn_up_weight,
                     hidden_dim,
                     intermediate_dim,
                 );
+                emit(SaveTensorStage::FfnUp, layer_idx as u32, &up)?;
 
                 ffn_gate_stats = ActivationStats::from_slice(&gate);
                 ffn_up_stats = ActivationStats::from_slice(&up);
@@ -198,6 +249,8 @@ impl AprTransformer {
                     silu_gate.push(silu_g);
                     ffn_hidden.push(silu_g * u);
                 }
+                emit(SaveTensorStage::FfnSilu, layer_idx as u32, &silu_gate)?;
+                emit(SaveTensorStage::FfnSwigl, layer_idx as u32, &ffn_hidden)?;
 
                 ffn_silu_gate_stats = ActivationStats::from_slice(&silu_gate);
                 ffn_swiglu_inner_stats = ActivationStats::from_slice(&ffn_hidden);
@@ -251,6 +304,7 @@ impl AprTransformer {
                 }
                 out
             };
+            emit(SaveTensorStage::FfnOut, layer_idx as u32, &ffn_output)?;
             let ffn_out_stats = ActivationStats::from_slice(&ffn_output);
             let last_token_ffn_out_stats = ActivationStats::from_slice(
                 &ffn_output[(seq_len_for_last - 1) * hidden_dim..],
@@ -260,6 +314,7 @@ impl AprTransformer {
             for i in 0..hidden.len() {
                 hidden[i] += ffn_output[i];
             }
+            emit(SaveTensorStage::PostFfnResidual, layer_idx as u32, &hidden)?;
             let output_stats = ActivationStats::from_slice(&hidden);
             let last_token_output_stats = ActivationStats::from_slice(
                 &hidden[(seq_len_for_last - 1) * hidden_dim..],
@@ -304,6 +359,7 @@ impl AprTransformer {
             self.output_norm_bias.as_deref(),
             self.config.eps,
         );
+        emit(SaveTensorStage::FinalNorm, WHOLE_MODEL_LAYER, &normed)?;
         let final_norm_stats = ActivationStats::from_slice(&normed);
 
         // 4. LM head projection (only last token)
@@ -320,6 +376,7 @@ impl AprTransformer {
         if let Some(ref bias) = self.lm_head_bias {
             self.add_bias(&mut logits, bias);
         }
+        emit(SaveTensorStage::LmHead, WHOLE_MODEL_LAYER, &logits)?;
         let logits_stats = ActivationStats::from_slice(&logits);
 
         Ok(ForwardTrace {

--- a/crates/aprender-serve/src/apr_transformer/traced_save_tensor.rs
+++ b/crates/aprender-serve/src/apr_transformer/traced_save_tensor.rs
@@ -90,41 +90,12 @@ impl AprTransformer {
         token_ids: &[u32],
         plan: &SaveTensorPlan,
     ) -> Result<ForwardTrace> {
-        // Run the standard traced forward pass first. If it errors, we
-        // never write a partial save_tensor file (atomic-by-construction).
-        let trace = self.forward_traced(token_ids)?;
-
-        // Step-1 scope: emit ONLY the embedding stage.
-        // Re-extract the embedding F32 buffer if the plan selects it. This
-        // is a cheap second call (token-table lookup, no matmuls).
-        // Subsequent SHIP-007 steps replace this with a direct buffer
-        // pass-through inside forward_traced so we don't compute
-        // embeddings twice.
-        if plan.should_save(SaveTensorStage::Embedding, 0) {
-            let embedding = self.embed(token_ids);
-            maybe_save_stage(Some(plan), SaveTensorStage::Embedding, 0, &embedding).map_err(
-                |e| RealizarError::IoError {
-                    message: format!("save_tensor::Embedding: {e}"),
-                },
-            )?;
-        }
-
-        // Step-2 scope: emit the LmHead (final logits) whole-model stage.
-        // `trace.logits` is already a Vec<f32> returned by forward_traced — no
-        // recompute needed, no internal forward_traced surgery. The
-        // forward-pass surgery for per-layer stages (qkv, ffn_*, etc.) is
-        // deferred to subsequent SHIP-007 steps.
-        maybe_save_stage(
-            Some(plan),
-            SaveTensorStage::LmHead,
-            WHOLE_MODEL_LAYER,
-            &trace.logits,
-        )
-        .map_err(|e| RealizarError::IoError {
-            message: format!("save_tensor::LmHead: {e}"),
-        })?;
-
-        Ok(trace)
+        // SHIP-007 PR-C-real step 3: per-layer threading is now done inside
+        // `forward_traced_with_plan`, so this wrapper is a pure delegator.
+        // Single-pass: no double-embed, no post-loop re-emission of LmHead.
+        // All Embedding/AttnNorm/QkvMatmul/.../LmHead emits happen at their
+        // natural buffer sites in `forward_traced_with_plan`.
+        self.forward_traced_with_plan(token_ids, Some(plan))
     }
 }
 


### PR DESCRIPTION
## Summary

SHIP-007 PR-C-real step 3 — threads `Option<&SaveTensorPlan>` through `forward_traced` itself for **all 16 capture points** (14 per-layer + 2 whole-model) in a **single forward pass**.

Stacked on #1416 (which ships the `maybe_save_stage` helper).

## Live smoke on canonical 7B teacher (RTX 4090 lambda-labs)

```
apr trace <model.apr> --save-tensor "embedding,attn_norm,qkv_matmul,qkv_bias,\
attention,attn_out,post_attn_residual,ffn_norm,ffn_gate,ffn_up,ffn_silu,\
ffn_swigl,ffn_out,post_ffn_residual,final_norm,lm_head" --save-tensor-dir /tmp/...
```

Wrote 16 stage tensor file(s):
- 14 per-layer (layer-0/*): embedding, attn_norm, qkv_matmul, qkv_bias, attention, attn_out, post_attn_residual, ffn_norm, ffn_gate, ffn_up, ffn_silu, ffn_swigl, ffn_out, post_ffn_residual
- 2 whole-model (root/*): final_norm, lm_head

Buffer sizes match Qwen2.5-Coder-7B config:
- 100,364 B = 7 tokens × 3,584 hidden_dim × 4 + 12-byte APRT header
- 530,444 B = 7 tokens × 18,944 intermediate_dim × 4 + 12 (FFN intermediates)
- 129,036 B = 7 tokens × 4,608 qkv_dim × 4 + 12 (qkv_dim = hidden + 2*kv_dim)
- 608,268 B = 152,064 vocab × 4 + 12 (whole-model lm_head)

## What changed

- `AprTransformer::forward_traced_with_plan(tokens, plan: Option<&SaveTensorPlan>)` is the new private impl that threads the plan through every natural capture point.
- `forward_traced(tokens)` becomes a 1-line wrapper that calls it with `None` (zero-overhead — `maybe_save_stage` early-returns on `None`).
- `forward_traced_with_save_tensor` is now a pure delegator: no more double-embed or post-loop re-emission of LmHead.
- All 6 `forward_traced` regression tests pass. All 4 `traced_save_tensor_step2_tests` pass.

## Five Whys

1. **Why thread plan through forward_traced?** Step 3 of SHIP-007 PR-C-real per `apr-cli-trace-save-tensor-v1.yaml`.
2. **Why all 16 stages, not subset?** The bisection target (root cause of MODEL-1 `apr run` divergence) is unknown; capturing every stage lets the operator element-wise diff against a reference at any of 16 points.
3. **Why single-pass via `Option<&SaveTensorPlan>`?** Avoids double-compute of embeddings and the wrapper's double-bookkeeping. DRY.
4. **Why `Option<&SaveTensorPlan>` (optional)?** Existing `forward_traced(tokens)` is called from many test sites and the trait `TracedForward`. Optional preserves the public API.
5. **Why bare `emit(Stage, layer, &buf)?` calls?** Each capture is a one-liner; helpers would mask the natural buffer-name → stage-name pairing and make audit harder.

## Test plan
- [x] `cargo build -p aprender-serve --release --features cuda` — clean
- [x] `cargo test -p aprender-serve --lib forward_traced` — 6 passing
- [x] `cargo test -p aprender-serve --lib traced_save_tensor` — 4 passing
- [x] Live smoke on 7B teacher (16/16 stages captured, byte sizes verified)
- [ ] CI green (workspace-test + ci/gate)
- [ ] Auto-merge on green (after #1416 lands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)