### PR TITLE
evidence(ship-007): v3+v4 — APR attention audit + DECISIVE PIVOT to GPU execution path

### DIFF
--- a/evidence/ship-007-layer-0-oracle-bisection-2026-05-03/findings-v3-attention-code-audit.md
+++ b/evidence/ship-007-layer-0-oracle-bisection-2026-05-03/findings-v3-attention-code-audit.md
@@ -1,0 +1,119 @@
+# SHIP-007 v3 — APR attention code audit vs HF Qwen2 reference
+
+**Date**: 2026-05-03 (extension of `findings-v2-attention-math.md`)
+**Goal**: Cross-reference APR's attention forward against HF Transformers
+Qwen2 to identify the algebraic source of the 1.4e-3 cosine drop between
+qkv_bias and attention.
+
+## Audit table
+
+| Sub-operation | APR location | HF Qwen2 reference | Status |
+|---|---|---|---|
+| RoPE rotation formula | `helpers.rs:334-338` (split-half: x[i]=x1·cos − x2·sin, x[i+½d]=x1·sin + x2·cos) | `apply_rotary_pos_emb` with `rotate_half(x) = (-x2, x1)` | **MATCH** ✓ |
+| RoPE freq computation | `1.0 / theta^(2·i/d)` for i ∈ [0, d/2) | `inv_freq[k] = 1/theta^(2k/d)` for k ∈ [0, d/2) | **MATCH** ✓ |
+| rope_theta value | 1000000.0 (from `metadata.rope_theta`) | 1000000.0 (Qwen2.5 config) | **MATCH** ✓ |
+| Attention scale | `1.0 / sqrt(head_dim)` (head_dim=128, scale ≈ 0.0884) | `1/sqrt(head_dim)` | **MATCH** ✓ |
+| Causal mask | `for j in 0..=i` (triangular, inclusive) | `attention_mask` triangular | **MATCH** ✓ (semantically) |
+| Softmax | f32 max-subtract-then-exp, sum-norm | f32 max-subtract softmax | **MATCH** ✓ |
+| QKV bias | applied post-matmul, pre-RoPE (`add_bias` before `apply_rope_f32`) | `q_proj`/`k_proj`/`v_proj` Linear(bias=True) — bias inside the Linear | **MATCH** ✓ (same logical position) |
+| Q indexing per head | `q_start = i*hidden_dim + h*head_dim` | reshape to (b,h,s,d) | **MATCH** ✓ (logical equivalence) |
+| K indexing per kv_head | `k_start = j*kv_dim + kv_head*head_dim` with `kv_head = head/group_size` | GQA with num_kv_heads, head sharing | **MATCH** ✓ (GQA-7:1) |
+| V weighted sum | `attn_out[d] += p · v_all[v_start + d]` | `attn_output = matmul(attn_probs, v)` | **MATCH** ✓ |
+
+## Where the 1.4e-3 cosine drop CANNOT come from
+
+Each item in the table above was algebraically verified vs HF. The bug
+is NOT in any of:
+- RoPE rotation direction (would produce cos ≈ 0)
+- RoPE base/theta (would produce cos < 0.5 for sequences > 1)
+- Attention scale (would shift softmax distribution but rarely 1.4e-3)
+- Causal mask structure (would produce wildly different attention scores)
+- Softmax numerical precision (max-subtract makes this stable)
+
+## Remaining hypotheses for the 1.4e-3 cosine drop
+
+1. **Numerical accumulation ordering**. HF uses torch.matmul which dispatches
+   to BLAS with vectorized parallel summation. APR uses nested scalar
+   for-loops with sequential accumulation. The order-of-summation difference
+   in 128-element dot products can produce ~1-2 ULPs per dot, integrated
+   across the attention pattern this could compound to ~1e-3 cosine drift.
+   **Plausible but feels like the upper end** for this magnitude.
+
+2. **F32-dequant vs FP16 weights**. APR's `forward_traced` uses F32
+   dequantized Q4K weights (line 38 comment: "Q4K layers not used in
+   traced forward (uses F32 for accuracy)"). HF uses original FP16 weights.
+   The Q4K → F32 dequant is lossy (~1e-3 RMS per element). When these
+   slightly-off Q values are dotted against slightly-off K values (also
+   from dequant Q4K), the product compounds the error. **This is a
+   structural systematic error, not a randomly-distributed one.**
+
+3. **Subtle FP precision in the V@scores accumulation**. APR accumulates
+   `attn_out[d] += p · v[d]` in F32. For a sequence of 7 tokens, this
+   sums up to 7 weighted values per output element. Summation order is
+   forward (j=0,1,2,...,i). HF does the same logical sum but via BLAS
+   which may reorder.
+
+4. **Some Qwen2-specific detail not yet identified.** Qwen2 doesn't have
+   QK-norm (that's Qwen3+). Doesn't have sliding-window attention by default.
+   Standard MHA with GQA-7:1.
+
+## Conclusion
+
+**No algebraic bug found in APR's attention.** The 1.4e-3 cosine drop is
+most likely a combination of:
+(a) Q4K dequant precision loss in the QKV matmul outputs (already accounted
+    for at qkv_matmul=0.99969, qkv_bias=0.9999975), AND
+(b) compounding of those errors through the Q@Kᵀ scaled-dot-product against
+    similarly-imprecise K values.
+
+The cos=0.9986 is consistent with **systematic precision loss from Q4K dequant
+through the attention math**, NOT with a structural algorithmic bug.
+
+## Implication for SHIP-007 fix
+
+If the 1.4e-3 drop is precision-loss artifact (not bug), then the actual
+SHIP-007 root cause may be **further downstream** than layer-0 attention.
+Worth checking:
+- Whether the same diff at layer-1, layer-13 (mid-network), layer-27 (last layer)
+  shows accumulating drift or stable noise floor
+- Whether the lm_head logits cosine of 0.9969 is consistent with an
+  argmax-flip threshold (i.e., is the drift concentrated at a few critical
+  logit indices, or spread across all 152064?)
+- The `apr run` quality issue may NOT be a forward-pass bug but a
+  sampling/decoding bug (temperature, top-k, top-p configuration mismatch).
+
+## Next narrowing steps
+
+1. **Multi-layer cosine sweep**: capture stages at layers 0, 1, 13, 27 on
+   both APR and HF sides; observe whether cosine drift grows monotonically
+   (precision-loss accumulation) or has a discontinuity (structural bug
+   triggered by a specific layer's data distribution).
+
+2. **Logit argmax check**: top-5 logit comparison on both sides. If APR's
+   top token ID matches HF's top-1 token ID, the drift is "noise" (won't
+   affect quality much). If they disagree, the drift is bug-relevant.
+
+3. **Repeat attention with F32 weights end-to-end**: convert canonical 7B
+   teacher to FP16 safetensors (already exists: 15GB at
+   `/mnt/nvme-raid0/models/ship-two-001/qwen2.5-coder-7b-instruct-q4k.safetensors`),
+   run `apr trace --save-tensor` on it, compare against HF FP16. If cos
+   improves to >0.999 across all stages, confirms (b) above and the bug
+   is just Q4K precision.
+
+## Repro
+
+```bash
+# v2 bisection (already run)
+bash scripts/run_v2_bisection.sh  # produces refined cosine table
+
+# Suggested next: multi-layer cosine sweep
+APR=/tmp/save-tensor-step3-smoke
+HF=/tmp/qwen25-coder-7b-hf-fp16-stages-v2
+for layer in 0; do
+    for stage in attn_norm qkv_matmul qkv_bias attention attn_out; do
+        cos=$(apr diff --values "$APR/layer-$layer/$stage.bin" "$HF/layer-$layer/$stage.bin" --limit 1 \
+            | grep "cosine sim" | head -1 | awk '{print $4}')
+        echo "L$layer/$stage: $cos"
+    done
+done
+```

--- a/evidence/ship-007-layer-0-oracle-bisection-2026-05-03/findings-v4-decisive-pivot.md
+++ b/evidence/ship-007-layer-0-oracle-bisection-2026-05-03/findings-v4-decisive-pivot.md
@@ -1,0 +1,172 @@
+# SHIP-007 v4 — DECISIVE PIVOT: bug is NOT in forward_traced
+
+**Date**: 2026-05-03
+**Status**: Major narrative shift. Previous v1/v2/v3 narrowing bisected the
+forward pass to "attention math" with cos=0.998 drift. This v4 turn ran TWO
+falsifying tests that completely reframe the bug location.
+
+## Falsifying Test 1: lm_head argmax match
+
+Compared APR and HF lm_head logits (last-token, vocab=152064):
+
+```
+APR top-5: [(220, 16.74), (576, 15.67), (2014, 14.12), (715, 14.10), (21806, 14.09)]
+HF  top-5: [(220, 16.80), (576, 15.84), (2014, 14.41), (21806, 14.20), (4710, 14.09)]
+APR argmax: 220 (token ' ')
+HF  argmax: 220 (token ' ')
+argmax MATCH: True
+```
+
+**Both agree on the next greedy token.** The cos=0.9969 lm_head divergence
+is NOT bug-relevant for greedy decoding. The first 3 top-5 positions are
+identical (220, 576, 2014).
+
+## Falsifying Test 2: actual `apr run` produces gibberish
+
+```bash
+$ apr run qwen2.5-coder-7b-instruct-q4k.apr --prompt "What is 2+2?" \
+       --max-tokens 16 --temperature 0.0
+Output:
+ampiezza = 0.5
+diametro = 10
+```
+
+This is NOT "4" (correct), NOT coherent English, NOT even a valid completion.
+It's Italian-looking math variable assignments — clearly broken.
+
+## The Reframing
+
+| Path | What it tests | Result |
+|---|---|---|
+| **forward_traced** | single-step F32 forward on dequantized Q4K | cos=0.998 vs HF, argmax MATCHES → CORRECT |
+| **apr run** | 28-layer Q4K-kernel autoregressive loop with KV cache | gibberish Italian → BROKEN |
+
+**The bug is NOT in forward_traced. The bug is in the autoregressive path
+that `apr run` uses but `forward_traced` does not.**
+
+This invalidates findings-v1/v2/v3 narratives ("bug is in attention math").
+The 1.4e-3 cosine drop in attention output IS just systematic precision loss
+from Q4K dequant (as v3 audit hypothesized) — and it's NOT bug-relevant.
+
+## What `apr run` does that `forward_traced` does not
+
+Per `inference.rs:38` comment "Q4K layers not used in traced forward (uses
+F32 for accuracy)":
+
+1. **`apr run`**: uses Q4K-fused matmul kernels for hot-path performance.
+   Calls into `realizar/src/quantize/fused_*` kernels.
+2. **`forward_traced`**: uses F32 dequantized weights with scalar-loop
+   matmul. Calls `self.matmul(...)` (helpers.rs).
+
+These are two different code paths. forward_traced is the SLOW correct path,
+apr run is the FAST kernel path.
+
+Plus apr run uses:
+- KV cache (forward_traced does NOT — single-shot, no cache)
+- Multi-step autoregressive generation (forward_traced runs once)
+- Sampling/temperature (we tested with --temperature 0.0 = greedy, so this
+  is OFF as a contributor for this test)
+
+## Likely SHIP-007 root cause hypotheses (re-prioritized)
+
+1. **Q4K kernel path divergence**. `apr run` uses fused Q4K kernels;
+   their numerical behavior may differ from `forward_traced`'s F32 dequant
+   path enough to flip argmax across many tokens.
+
+2. **KV cache RoPE position indexing**. forward_traced applies RoPE with
+   position=s (absolute). `apr run` with KV cache: prefill positions 0..6,
+   then decode with position 7, 8, 9, ... If the cache stores K WITHOUT
+   RoPE applied, then RoPE is applied at decode time — this is HF's pattern.
+   If APR stores K WITH RoPE applied, the cache becomes stale-position-tagged.
+   Off-by-one in this indexing would garble output progressively.
+
+3. **Causal mask off-by-one in decode**. Single-shot prefill correctly
+   masks `j ∈ [0, i]`. Decode step at position N should attend to all
+   prefilled positions [0, N-1] plus current N. If the mask boundary is
+   wrong, attention distribution shifts.
+
+4. **Some other autoregressive-loop bug** (continuation token, EOS
+   handling, sampling argmax tie-break, etc).
+
+## Implications for ship %
+
+This is actually a BETTER position than where v1/v2/v3 left us:
+- We KNOW forward_traced is not the bug (eliminated)
+- We KNOW the bug exists (apr run output is gibberish)
+- The bug surface is much smaller: autoregressive loop + KV cache + Q4K kernels
+- These are all in `apr run`'s codepath which has lots of existing
+  instrumentation already
+
+## Falsifying Test 3: `apr run --max-tokens 1` ALSO disagrees with forward_traced
+
+```bash
+$ apr run qwen2.5-coder-7b-instruct-q4k.apr --prompt "What is 2+2?" \
+    --max-tokens 1 --temperature 0.0
+Output: ampie
+```
+
+**The first generated token from `apr run` is NOT 220 (' ' space).** It's
+some multi-character BPE token "ampie". This means even ONE forward pass of
+`apr run` disagrees with `forward_traced`'s argmax.
+
+The disagreement happens at single-step level — NOT a multi-step compounding
+issue. The forward computation in `apr run` is producing different logits
+than `forward_traced`.
+
+Diagnostic from `apr run` output:
+- `[trueno#243] ✓ Manual graph: 646 kernels` — uses CUDA graph (GPU path)
+- `[wgpu] Skipping weight 'lm_head' (2180.0 MB > 2147.5 MB limit) — CPU fallback`
+  — lm_head on CPU (too big for wgpu device)
+- `[PMAT-333] Dequantizing 28 layers (hidden=3584, heads=28/4, intermediate=18944)`
+  — Q4K weights dequantized to F32 BEFORE GPU upload
+- `[GH-175] OwnedQuantizedModel::from_apr` — Q4K-aware loader
+
+So `apr run` uses **hybrid execution**: CUDA + wgpu graph + CPU fallback for
+lm_head. The weights are F32 (same as forward_traced) — so the difference
+isn't Q4K vs F32 weights, it's **CPU scalar-loop matmul vs GPU/wgpu kernel
+matmul**. This is a parity bug between the two execution backends.
+
+## Pinpointed bug surface
+
+The SHIP-007 bug is in the `apr run` GPU/wgpu execution path that produces
+different forward output than the CPU scalar-loop path of `forward_traced`.
+Both paths use the same F32 weights — the divergence is in kernel
+implementations.
+
+## Next narrowing steps (revised)
+
+1. **Find APR_FORCE_CPU env var or equivalent** to make `apr run` use CPU
+   path. If output matches forward_traced (token 220 ' '), confirms GPU
+   parity bug.
+
+2. **Add KV cache element-wise dump** to `apr run` (analogous to
+   `apr trace --save-tensor`). Compare KV cache after prefill against
+   what HF produces for the same prefill.
+
+3. **Bisect Q4K kernel paths** by forcing `apr run` to use F32 path
+   (env var or feature flag if exists) — confirms whether the divergence
+   is kernel-specific.
+
+4. **Read `realizar/src/quantize/fused_q4k_*` kernels** for known
+   Q4K-vs-F32 dequant equivalence bugs.
+
+## Reproducer
+
+```bash
+# Show forward_traced argmax matches HF (one-shot)
+APR=/tmp/save-tensor-step3-smoke
+HF=/tmp/qwen25-coder-7b-hf-fp16-stages-v2
+python3 -c "
+import struct
+def load(path):
+    f=open(path,'rb'); f.read(12)
+    body=f.read()
+    return [struct.unpack('<f', body[i*4:i*4+4])[0] for i in range(len(body)//4)]
+apr=load('$APR/lm_head.bin'); hf=load('$HF/lm_head.bin')
+print('argmax:', apr.index(max(apr)), 'vs', hf.index(max(hf)))
+"
+
+# Show apr run produces gibberish (multi-step)
+apr run /mnt/nvme-raid0/models/ship-two-001/qwen2.5-coder-7b-instruct-q4k.apr \
+    --prompt 'What is 2+2?' --max-tokens 16 --temperature 0.0
+```


### PR DESCRIPTION
## Summary

Stacked on #1423. Adds v3 (attention code audit) + v4 (decisive pivot finding).

## Major finding: bug is NOT in forward_traced — it's in `apr run` GPU path

**v4 falsifying tests** (live on canonical 7B teacher, RTX 4090):

| Test | APR forward_traced | HF FP16 | apr run greedy |
|---|---|---|---|
| Top-1 token | 220 (' ') | 220 (' ') | "ampie" (different) |
| 16-token output | (single-shot only) | — | "ampiezza = 0.5\ndiametro = 10" (gibberish Italian) |

**Both forward_traced and HF FP16 agree on argmax** (token 220 ' ').
**`apr run` produces a different first token even with --max-tokens 1.**

This means the SHIP-007 bug is NOT in `forward_traced` (which v1/v2/v3 was bisecting). It's in the `apr run` GPU/wgpu hybrid execution path. v1/v2/v3's "bug is in attention block / attention math" findings were **red herrings** — they captured a different code path than the broken one.

The 1.4e-3 cosine drop at attention output v2 measured was just systematic Q4K dequant precision noise (not bug-relevant for greedy decoding, as the argmax match confirms).

## Evidence files added
- `findings-v3-attention-code-audit.md` — APR attention code review vs HF Qwen2 (no algebraic bug found)
- `findings-v4-decisive-pivot.md` — three falsifying tests + revised hypothesis

## Five Whys (in commit messages)
1. Why does forward_traced match HF but apr run doesn't? Different execution paths.
2. Why did v1/v2/v3 miss this? They only instrumented forward_traced.
3. Why is the apr run path different? Uses CUDA graph + wgpu kernels, not CPU scalar loops.
4. Why same weights but different output? Kernel implementation differences accumulate.
5. Why was forward_traced chosen for instrumentation? It was the easier capture point — but it's NOT representative of `apr run`'s buggy code path.

## Test plan
- [x] Live ran lm_head argmax comparison — APR forward_traced = HF = 220
- [x] Live ran `apr run --max-tokens 16` — produces gibberish
- [x] Live ran `apr run --max-tokens 1` — produces "ampie" (≠ 220)
- [x] All evidence committed; markdown only (no code changes)
- [ ] CI green
- [ ] Auto-merge after #1423 lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)