### PR TITLE
contract(apr-cpu-vs-gpu-output-parity-v1): v1.2.0 — FALSIFY-CPU-GPU-005 wgpu visibility + parity-gate entry

### DIFF
--- a/contracts/apr-cpu-vs-gpu-output-parity-v1.yaml
+++ b/contracts/apr-cpu-vs-gpu-output-parity-v1.yaml
@@ -1,6 +1,6 @@
 metadata:
   kind: schema
-  version: 1.1.0
+  version: 1.2.0
   status: ACTIVE
   created: '2026-05-03'
   author: PAIML Engineering
@@ -13,6 +13,7 @@ metadata:
   - 'crates/aprender-serve/src/gguf/cuda/mod.rs:268-279 (gate enforcement, with SKIP_PARITY_GATE=1 bypass)'
   - 'crates/aprender-serve/src/infer/gguf_gpu_generate.rs:487-494 (load_apr_cuda_model — visible-fallback log added 2026-05-03)'
   changelog:
+  - '1.2.0 — 2026-05-03 — added FALSIFY-CPU-GPU-005 (wgpu visibility + parity-gate symmetry). Closes the second half of the silent-fallback loophole: even after #1428 made CUDA rejection visible, the wgpu fallback path still ships gibberish silently for the same canonical 7B teacher because (a) its init/abort logs are verbose-gated and (b) it has no parity_gate analog. Visibility-log fix lands in this revision; the cosine-similarity gate is bound at PARTIAL_ALGORITHM_LEVEL pending a follow-up implementation PR (~100-150 LOC).'
   - '1.1.0 — 2026-05-03 — corrected FALSIFY-CPU-GPU-003 algorithm_evidence: parity_gate IS already wired into the .apr → OwnedQuantizedModelCuda path via with_max_seq_len:268-279 (called from load_apr_cuda_model:487). The user-visible gap was that CUDA failure (e.g. ILLEGAL_ADDRESS during gate forward, or cosine < 0.99) was logged only in --verbose mode — fallback then hits wgpu which itself produces gibberish, so the user saw silent gibberish. PR converts the fallback log to unconditional one-line eprintln so the GPU rejection is always visible. Promoted contract from PROPOSED → ACTIVE.'
   description: >
     CPU-vs-GPU output parity contract. Codifies that for any model and prompt,
@@ -167,18 +168,52 @@ falsification_tests:
   functional_evidence:
   - "Live smoke 2026-05-03 on canonical 7B teacher: --no-gpu produces correct '2 + 2 equals 4.' in 9.81s with no GPU log lines"
 
+- id: FALSIFY-CPU-GPU-005
+  rule: wgpu fallback path must (a) log its lifecycle visibly without --verbose AND (b) run a parity gate at init analogous to CUDA's parity_gate
+  prediction: |
+    When the CUDA path is rejected (FALSIFY-CPU-GPU-003), `apr run`
+    transparently falls through to wgpu (`try_apr_wgpu_inference`,
+    gguf_gpu_generate.rs:297). The wgpu path ALSO produces gibberish on
+    the canonical 7B teacher (v6 evidence). User-visible behaviour MUST
+    be:
+      (a) wgpu init/error logs are non-verbose-gated — user sees
+          "Backend: wgpu (Vulkan)" or "[GH-559] wgpu init failed: ..."
+          without --verbose, just like CUDA.
+      (b) wgpu init runs a one-token CPU-vs-wgpu cosine check on the
+          BOS token. If cosine < 0.99 OR argmax mismatch, return None
+          → fall through to CPU. Tagged stderr line:
+          `[apr-cpu-vs-gpu-output-parity-v1] wgpu path rejected, attempting fallback: <reason>`
+  test: |
+    apr run <broken-gpu-model.apr> --prompt 'What is 2+2?' --max-tokens 1
+      --temperature 0.0 2>&1 | tee /tmp/run.log
+    SHOULD show:
+      [apr-cpu-vs-gpu-output-parity-v1] CUDA path rejected, ...   (existing FALSIFY-CPU-GPU-003)
+      Backend: wgpu (Vulkan)                                       (NEW: visible without -v)
+      [apr-cpu-vs-gpu-output-parity-v1] wgpu path rejected, ...   (NEW: parity gate)
+      Backend: CPU (correct output follows)
+    AND the final stdout output should be the CPU-produced "2 + 2 equals 4." (or equivalent), NOT wgpu's gibberish.
+  if_fails: "Even after the CUDA jidoka log, wgpu can still ship silent gibberish — the loophole is not closed"
+  binds_to: greedy_argmax_parity
+  status: PARTIAL_ALGORITHM_LEVEL
+  algorithm_evidence:
+  - "Symptom replicated 2026-05-03: with apr 0.31.2 and PR #1428 landed, default-mode `apr run` on canonical 7B teacher: CUDA logs `[apr-cpu-vs-gpu-output-parity-v1] CUDA path rejected` (good — #1428's contribution), then wgpu silently runs and ships 'ampiezza = 10\\nampie'"
+  - "Visibility (a) implementation in this revision: gguf_gpu_generate.rs:305-323 — drop `if config.verbose` from the [GH-559] wgpu init failed and Backend: wgpu (Vulkan) eprintlns"
+  - "Parity gate (b) deferred to follow-up PR. Implementation sketch: at gguf_gpu_generate.rs:388 (after weights uploaded, before autoregressive loop), run one CPU forward via OwnedQuantizedModel.forward_single_with_cache(bos, &mut tmp_cache, 0), run one wgpu single-step decode (extracted from the existing autoregressive loop body), cosine-compare logits. <0.99 → return None (fall to CPU)."
+  - "Implementation gap on follow-up: the wgpu single-step decode is not currently exposed as a callable function — needs a small refactor to extract the per-token loop body."
+  - "Drift-prevention: regression test should grep stderr for both `[apr-cpu-vs-gpu-output-parity-v1] CUDA path rejected` AND `Backend: wgpu (Vulkan)` (or the future wgpu rejection tag) on a deliberately broken or non-CUDA host"
+
 proof_obligations:
 - type: invariant
   property: "apr run greedy first-token argmax is identical between GPU and --no-gpu paths"
 - type: invariant
   property: "apr run with .apr file MUST run parity gate (currently only .gguf path has one)"
 - type: completeness
-  property: "all 4 falsifiers (greedy argmax, cosine, gate enforced, no-gpu honored) cover the parity surface"
+  property: "all 5 falsifiers (greedy argmax, cosine, CUDA gate enforced, no-gpu honored, wgpu gate enforced) cover the parity surface"
 - type: liveness
-  property: "if GPU parity gate fails, user gets either an explicit error OR a CPU fallback — never silent gibberish"
+  property: "if GPU parity gate fails on ANY backend (CUDA or wgpu), user gets either an explicit error OR a CPU fallback — never silent gibberish"
 
 verification_summary:
-  total_obligations: 4
+  total_obligations: 5
   proven: 0
   tested: 0
   status: pending

--- a/crates/aprender-serve/src/infer/gguf_gpu_generate.rs
+++ b/crates/aprender-serve/src/infer/gguf_gpu_generate.rs
@@ -27,9 +27,10 @@ fn try_wgpu_generate(
     let gpu = trueno::backends::gpu::GpuDevice::new()
         .map_err(|e| RealizarError::InferenceError(format!("wgpu init: {e}")))?;
 
-    if verbose {
-        eprintln!("Backend: wgpu (Vulkan)");
-    }
+    // FALSIFY-CPU-GPU-005: wgpu lifecycle visible without --verbose so users
+    // see which backend actually serves their tokens after CUDA fallback.
+    let _ = verbose;
+    eprintln!("Backend: wgpu (Vulkan)");
 
     let config = model.config();
     let hidden_dim = config.hidden_dim;
@@ -311,16 +312,17 @@ fn try_apr_wgpu_inference(
     let gpu = match GpuDevice::new() {
         Ok(g) => g,
         Err(e) => {
-            if config.verbose {
-                eprintln!("[GH-559] wgpu init failed: {}", e);
-            }
+            // FALSIFY-CPU-GPU-005: wgpu init failure is a backend-fallback decision —
+            // user must see why this backend was rejected without --verbose.
+            eprintln!("[GH-559] wgpu init failed: {}", e);
             return None;
         }
     };
 
-    if config.verbose {
-        eprintln!("Backend: wgpu (Vulkan)");
-    }
+    // FALSIFY-CPU-GPU-005: wgpu lifecycle visible without --verbose. Symmetric to
+    // FALSIFY-CPU-GPU-003's CUDA-fallback log so users always know which backend
+    // actually serves their tokens.
+    eprintln!("Backend: wgpu (Vulkan)");
 
     // Load model
     let mapped = match MappedAprModel::from_path(&config.model_path) {


### PR DESCRIPTION
## Summary
- Adds **FALSIFY-CPU-GPU-005** to `apr-cpu-vs-gpu-output-parity-v1` at PARTIAL_ALGORITHM_LEVEL: wgpu fallback must (a) log lifecycle visibly without `--verbose` AND (b) run a parity gate analogous to CUDA's.
- Lands (a) **wgpu visibility fix** immediately — symmetric to #1428's CUDA fix. Users will now see `Backend: wgpu (Vulkan)` and `[GH-559] wgpu init failed: ...` on stderr without `--verbose`.
- Defers (b) wgpu cosine-similarity gate to follow-up PR (~100-150 LOC, needs a small refactor to expose wgpu single-step decode).
- Bumps contract v1.1.0 → v1.2.0 (additive; no existing falsifier semantics changed).

## Why this PR
Per Toyota Way + the v1.1.0 contract follow-up I flagged: when the CUDA path is rejected, fall-through hits wgpu, which today produces independent gibberish on the canonical 7B teacher. PR #1428 made CUDA's rejection visible but wgpu still serves silent garbage. This PR closes the visibility half of the loophole + binds the parity-gate half so it doesn't get lost.

## Test plan
- [x] `pv validate contracts/apr-cpu-vs-gpu-output-parity-v1.yaml` — 0 errors
- [x] `cargo build -p aprender-serve --features cuda --release` — clean
- [x] `cargo test -p aprender-serve --features cuda --lib cuda_fallback_log_prefix_is_contract_tagged` — 1 passed (drift-prevention from #1429 still green)
- [ ] Live smoke after release rebuild on lambda-labs canonical 7B teacher: stderr should now include `[apr-cpu-vs-gpu-output-parity-v1] CUDA path rejected, ...` AND `Backend: wgpu (Vulkan)` without `-v`

## Out of scope (follow-up tracked in v1.2.0 algorithm_evidence)
- Implement the wgpu cosine gate at `try_apr_wgpu_inference`'s init point — extract per-token decode body into a callable, run one CPU+wgpu BOS forward, cosine-compare logits, return None on < 0.99.

🤖 Generated with [Claude Code](https://claude.com/claude-code)