### PR TITLE
fix(aprender-train): bind quantize_to_gguf_bytes match result so --features hub builds

### DIFF
--- a/crates/aprender-train/src/hf_pipeline/export/gguf_writer.rs
+++ b/crates/aprender-train/src/hf_pipeline/export/gguf_writer.rs
@@ -25,7 +25,7 @@ pub enum GgufQuantization {
 /// For Q4_0/Q8_0, quantizes via entrenar's quant module and encodes to GGUF block format.
 pub fn quantize_to_gguf_bytes(data: &[f32], quant: GgufQuantization) -> (Vec<u8>, GgmlType) {
     contract_pre_quantize!(data);
-    match quant {
+    let result = match quant {
         GgufQuantization::None => {
             let bytes: Vec<u8> = bytemuck::cast_slice(data).to_vec();
             (bytes, GgmlType::F32)


### PR DESCRIPTION
## Summary
- One-character fix: `let result = match quant { ... };` so the function body actually binds the tuple it computes instead of discarding it via a trailing `;`.
- Without this, `--features hub` fails to compile with two `error[E0425]: cannot find value 'result' in this scope` errors at `gguf_writer.rs:42-43`.
- `--features hub` is not exercised by any workflow in `.github/workflows/`, which is why main CI is green despite this latent defect.

## Why this PR
Discovered while attempting to add FALSIFY-APR-DISTILL-TRAIN-003/004 falsifier coverage to `hf_pipeline::distillation::DistillationLoss` in the previous /loop iteration. The hub-feature build is the only path that exercises the parallel hf_pipeline distillation implementation, so this defect was blocking falsifier-parity work between the canonical `distill::loss` and the hf_pipeline copy.

## Surfaces 11 pre-existing test failures (jidoka, not regressions)
With the build fixed, `cargo test --features hub` now reports 145 passed / 11 failed. None of the 11 failures are caused by this fix — they're pre-existing bugs that were silently masked by the build error. Two distinct classes:

1. **`test_falsify_quantize_empty_data_*` (3 tests)** — `contract_pre_quantize!` macro asserts `input.len() > 0` while the tests assert empty input → empty output. Contract / test drift; needs the contract precondition relaxed or the tests updated to `#[should_panic]`.

2. **`test_falsify_*_roundtrip` (8 tests)** — F32 byte-encoding bug in the GGUF roundtrip path: `expected [5.0, 6.0, 7.0, 8.0]` vs `got [0.0, 5.93e-39, ...]`. Looks like a header-alignment / padding miscalculation. Real bug, not a test issue.

Both classes are explicitly out of scope for this PR (separate root causes get separate fixes per Toyota Way).

## Test plan
- [x] `cargo build -p aprender-train --lib --features hub` → clean
- [x] `cargo test -p aprender-train --lib --features hub` → 145/156 passes (pre-existing 11 failures documented above)
- [x] `cargo fmt --all -- --check` → no diff in touched file

## Out of scope (follow-ups)
- Fix the empty-data contract drift (3 tests)
- Fix the F32 GGUF roundtrip byte-encoding bug (8 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)