### PR TITLE
fix(aprender-train): early-return on empty input in quantize_to_gguf_bytes

### DIFF
--- a/crates/aprender-train/src/hf_pipeline/export/gguf_writer.rs
+++ b/crates/aprender-train/src/hf_pipeline/export/gguf_writer.rs
@@ -24,6 +24,23 @@ pub enum GgufQuantization {
 /// For `GgufQuantization::None`, returns the f32 data as little-endian bytes with `GgmlType::F32`.
 /// For Q4_0/Q8_0, quantizes via entrenar's quant module and encodes to GGUF block format.
 pub fn quantize_to_gguf_bytes(data: &[f32], quant: GgufQuantization) -> (Vec<u8>, GgmlType) {
+    // Edge case: empty input is a valid no-op for all three quantization
+    // modes (empty tensor → empty bytes, dtype preserved). Return early so
+    // we don't trip `contract_pre_quantize!`'s `input.len() > 0` debug
+    // assertion — the contract's domain is non-empty inputs (where the
+    // precision bound is meaningful), but the function must still handle
+    // empty cleanly because callers may pass zero-length slices for
+    // skipped tensors. See `test_falsify_quantize_empty_data_*` for the
+    // documented invariant: empty input → empty output, dtype matches the
+    // requested quantization mode.
+    if data.is_empty() {
+        let dtype = match quant {
+            GgufQuantization::None => GgmlType::F32,
+            GgufQuantization::Q4_0 => GgmlType::Q4_0,
+            GgufQuantization::Q8_0 => GgmlType::Q8_0,
+        };
+        return (Vec::new(), dtype);
+    }
     contract_pre_quantize!(data);
     let result = match quant {
         GgufQuantization::None => {


### PR DESCRIPTION
## Summary
- Closes the empty-data contract drift surfaced as 3 failures by PR #1432.
- Adds an early-return for `data.is_empty()` so `contract_pre_quantize!`'s `input.len() > 0` debug assertion doesn't panic on a documented edge case (`test_falsify_quantize_empty_data_*`: empty input → empty output, dtype preserved).
- Net result on `--features hub`: 11 → 9 pre-existing test failures (the remaining 9 are F32 GGUF roundtrip byte-encoding bugs — separate root cause, separate PR).

## Five Whys
1. Why was the contract precondition tripping? Generated from a YAML contract declaring `input.len() > 0`.
2. Why are tests asserting empty → empty? Real callers pass zero-length slices for skipped tensors.
3. Why not loosen the contract? Domain restrictions are intentional — the precision postcondition is undefined on empty input.
4. Why early-return rather than restructure the match? Less indentation; the empty case only computes the dtype tag.
5. Why ship now? Per Toyota Way each defect gets a focused fix; this closes the empty-data class cleanly without entangling the unrelated roundtrip bug.

## Test plan
- [x] `cargo test -p aprender-train --lib --features hub gguf_writer` → 23/23 pass (was 20/23)
- [x] `cargo test -p aprender-train --lib --features hub` → 9 failures (was 11; net 2 closed)
- [x] `cargo fmt --all -- --check` → no diff in touched file

## Out of scope (follow-up: F32 GGUF roundtrip bug)
8 remaining failures of the form `expected [5.0, 6.0, 7.0, 8.0]` vs `got [0.0, 5.93e-39, ...]` — looks like a header-alignment / padding miscalculation in the GGUF writer pipeline. Real serialization defect, separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)