### PR TITLE
fix(aprender-train): account for GGUF tensor-data alignment padding in test helpers

### DIFF
--- a/crates/aprender-train/src/hf_pipeline/export/gguf_verify/tests/mod.rs
+++ b/crates/aprender-train/src/hf_pipeline/export/gguf_verify/tests/mod.rs
@@ -7,7 +7,10 @@ use super::parsing::{read_gguf_string, skip_gguf_value};
 use super::types::GgufTensorInfo;
 use super::*;
 use crate::hf_pipeline::export::gguf_writer::{quantize_to_gguf_bytes, GgufQuantization};
-use aprender::format::gguf::{export_tensors_to_gguf, GgmlType, GgufTensor, GgufValue};
+use aprender::format::gguf::{
+    export_tensors_to_gguf, padding_for_alignment, GgmlType, GgufTensor, GgufValue,
+    GGUF_DEFAULT_ALIGNMENT,
+};
 
 /// Helper: serialize GGUF to a Vec<u8> via aprender
 pub(super) fn write_gguf(tensors: &[GgufTensor], metadata: &[(String, GgufValue)]) -> Vec<u8> {
@@ -38,9 +41,14 @@ pub(super) fn extract_f32_tensor_data(
 
 /// Find the start of the tensor data section by scanning past header + metadata + tensor info.
 ///
-/// Note: aprender's `export_tensors_to_gguf` places tensor data immediately after
-/// tensor info with NO alignment padding. Tensor offsets in the info entries are
-/// relative to this position.
+/// `aprender::format::gguf::export_tensors_to_gguf` writes alignment padding
+/// (default 32 bytes) AFTER the tensor-info section so the tensor data starts
+/// at a `GGUF_DEFAULT_ALIGNMENT`-aligned offset. The previous version of this
+/// helper claimed "NO alignment padding" — that's incorrect; tensor data is
+/// preceded by `padding_for_alignment(pos, GGUF_DEFAULT_ALIGNMENT)` zero bytes.
+/// All `test_falsify_*_roundtrip` and friends were reading f32 bytes at the
+/// padding offset (zeros) instead of the actual tensor offset, surfaced as
+/// `expected [5.0, 6.0, 7.0, 8.0]` vs `got [0.0, 5.93e-39, ...]`.
 pub(super) fn find_data_section_start(gguf_bytes: &[u8], summary: &GgufSummary) -> usize {
     let mut pos = 24; // skip header
                       // Skip metadata
@@ -62,5 +70,7 @@ pub(super) fn find_data_section_start(gguf_bytes: &[u8], summary: &GgufSummary) 
         ) as usize;
         pos += 4 + n_dims * 8 + 4 + 8; // dims + dtype + offset
     }
+    // Skip alignment padding before tensor data (matches writer at types.rs:445).
+    pos += padding_for_alignment(pos, GGUF_DEFAULT_ALIGNMENT);
     pos
 }

--- a/crates/aprender-train/src/hf_pipeline/export/gguf_writer.rs
+++ b/crates/aprender-train/src/hf_pipeline/export/gguf_writer.rs
@@ -24,6 +24,23 @@ pub enum GgufQuantization {
 /// For `GgufQuantization::None`, returns the f32 data as little-endian bytes with `GgmlType::F32`.
 /// For Q4_0/Q8_0, quantizes via entrenar's quant module and encodes to GGUF block format.
 pub fn quantize_to_gguf_bytes(data: &[f32], quant: GgufQuantization) -> (Vec<u8>, GgmlType) {
+    // Edge case: empty input is a valid no-op for all three quantization
+    // modes (empty tensor → empty bytes, dtype preserved). Return early so
+    // we don't trip `contract_pre_quantize!`'s `input.len() > 0` debug
+    // assertion — the contract's domain is non-empty inputs (where the
+    // precision bound is meaningful), but the function must still handle
+    // empty cleanly because callers may pass zero-length slices for
+    // skipped tensors. See `test_falsify_quantize_empty_data_*` for the
+    // documented invariant: empty input → empty output, dtype matches the
+    // requested quantization mode.
+    if data.is_empty() {
+        let dtype = match quant {
+            GgufQuantization::None => GgmlType::F32,
+            GgufQuantization::Q4_0 => GgmlType::Q4_0,
+            GgufQuantization::Q8_0 => GgmlType::Q8_0,
+        };
+        return (Vec::new(), dtype);
+    }
     contract_pre_quantize!(data);
     let result = match quant {
         GgufQuantization::None => {

--- a/crates/aprender-train/src/hf_pipeline/export/pipeline.rs
+++ b/crates/aprender-train/src/hf_pipeline/export/pipeline.rs
@@ -377,6 +377,14 @@ mod tests {
         ) as usize;
         pos += 4 + n_dims * 8 + 4 + 8; // dims + dtype + offset
 
+        // Skip alignment padding before tensor data — `aprender::format::gguf::
+        // export_tensors_to_gguf` writes `padding_for_alignment(header_size,
+        // GGUF_DEFAULT_ALIGNMENT)` zero bytes after the tensor-info section so
+        // tensor data begins at a 32-byte-aligned offset (types.rs:445). Without
+        // this skip we'd read padding zeros instead of the actual f32 bytes.
+        use aprender::format::gguf::{padding_for_alignment, GGUF_DEFAULT_ALIGNMENT};
+        pos += padding_for_alignment(pos, GGUF_DEFAULT_ALIGNMENT);
+
         // Now pos is at the start of tensor data
         let data_start = pos;
         let recovered: Vec<f32> = (0..64)


### PR DESCRIPTION
## Summary
- Closes the last 9 of 11 pre-existing test failures surfaced by PR #1432: 8 in `gguf_verify/tests/falsify.rs`, 1 inline in `pipeline.rs`. Single root cause: test helpers skipped header + metadata + tensor-info but NOT the trailing 32-byte alignment padding the writer emits at `aprender::format::gguf::types.rs:445`.
- After this PR, `--features hub` is **fully green**: 7986 pass / 0 fail / 16 ignored.

## Five Whys
1. Why was the data section misaligned? Test helpers had a comment claiming "NO alignment padding" — incorrect; the writer DOES pad.
2. Why didn't anyone notice before? `--features hub` was unbuildable on main until PR #1432 fixed `quantize_to_gguf_bytes`.
3. Why two near-identical helpers? Refactor extracted `find_data_section_start` but missed an inline clone in `pipeline.rs`. This PR fixes both; follow-up: collapse the inline copy to call the shared helper.
4. Why use a hardcoded `pos += padding_for_alignment(pos, ALIGN)` instead of a higher-level abstraction? Bounded scope — single-line fix in each location. Refactor is separate work.
5. Why ship now? One root cause closes all 9 surfaced failures cleanly. `--features hub` jumps from 7977/7986 → 7986/7986 (full green).

## Net `--features hub` health across today's session
- Pre-#1432: build error (no tests could run)
- Post-#1432: 7975/7986 (11 pre-existing failures surfaced, jidoka)
- Post-#1433: 7977/7986 (3 empty-data fixed)
- Post-this: **7986/7986 ✅** (alignment-padding fix closes the rest)

## Test plan
- [x] `cargo test -p aprender-train --lib --features hub` → 7986 pass / 0 fail
- [x] `cargo test -p aprender-train --lib --features hub gguf_verify` → 72/72 pass
- [x] `cargo fmt --all -- --check` → no diff in touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)