### PR TITLE
feat(apr-cpu-vs-gpu-output-parity-v1): cpu_vs_gpu_cosine_similarity helper for FALSIFY-CPU-GPU-005 part b

### DIFF
--- a/crates/aprender-serve/src/infer/gguf_gpu_generate.rs
+++ b/crates/aprender-serve/src/infer/gguf_gpu_generate.rs
@@ -19,6 +19,41 @@ pub(crate) const CUDA_FALLBACK_LOG_PREFIX: &str =
 pub(crate) const WGPU_FALLBACK_LOG_PREFIX: &str =
     "[apr-cpu-vs-gpu-output-parity-v1] wgpu path rejected";
 
+/// f64-accumulated cosine similarity for FALSIFY-CPU-GPU-005 part b.
+///
+/// Numerically-stable companion to `cuda::mod_parity_gate::cosine_similarity` (which
+/// lives behind `cfg(feature = "cuda")`). Lifted to this module so the future wgpu
+/// cosine gate (predicted by contract `apr-cpu-vs-gpu-output-parity-v1` v1.2.0
+/// FALSIFY-CPU-GPU-005 part b) can compare a wgpu single-step decode against a
+/// CPU reference forward at init without taking a `--features cuda` build dependency.
+///
+/// Returns 0.0 when either input is zero-norm or the inputs differ in length —
+/// this is the conservative "fail-closed" default that triggers fallback to CPU.
+///
+/// See `contracts/apr-cpu-vs-gpu-output-parity-v1.yaml` § FALSIFY-CPU-GPU-005
+/// implementation_evidence line 201 for the gate algorithm.
+pub(crate) fn cpu_vs_gpu_cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
+    if a.len() != b.len() || a.is_empty() {
+        return 0.0;
+    }
+    let mut dot: f64 = 0.0;
+    let mut norm_a: f64 = 0.0;
+    let mut norm_b: f64 = 0.0;
+    for (x, y) in a.iter().zip(b.iter()) {
+        let x = f64::from(*x);
+        let y = f64::from(*y);
+        dot += x * y;
+        norm_a += x * x;
+        norm_b += y * y;
+    }
+    let denom = norm_a.sqrt() * norm_b.sqrt();
+    if denom < 1e-12 {
+        0.0
+    } else {
+        (dot / denom) as f32
+    }
+}
+
 /// GH-559: Try wgpu (Vulkan) generation as fallback when CUDA JIT fails.
 /// Uses trueno's WgslForwardPass with dequantized F32 weights.
 /// Proven: cosine=0.999863 on Blackwell sm_121.
@@ -949,5 +984,68 @@ mod tests {
         assert!(WGPU_FALLBACK_LOG_PREFIX.starts_with(contract_tag));
         assert!(CUDA_FALLBACK_LOG_PREFIX.ends_with("path rejected"));
         assert!(WGPU_FALLBACK_LOG_PREFIX.ends_with("path rejected"));
+    }
+
+    /// FALSIFY-CPU-GPU-005 part b cosine helper — parallel vectors return 1.
+    ///
+    /// Locks in the gate's positive case: when wgpu produces logits identical
+    /// to CPU, the gate must NOT trigger fallback (cosine = 1.0 ≥ 0.99 floor).
+    #[test]
+    fn cpu_vs_gpu_cosine_similarity_parallel_returns_one() {
+        let a = vec![1.0_f32, 2.0, 3.0, 4.0];
+        let b = a.clone();
+        let cos = super::cpu_vs_gpu_cosine_similarity(&a, &b);
+        assert!(
+            (cos - 1.0).abs() < 1e-6,
+            "parallel vectors must yield cosine 1.0, got {cos}"
+        );
+    }
+
+    /// FALSIFY-CPU-GPU-005 part b cosine helper — orthogonal returns 0.
+    ///
+    /// Negative case: orthogonal vectors must yield cosine 0.0 which is well
+    /// below the 0.99 gate floor → fallback triggers.
+    #[test]
+    fn cpu_vs_gpu_cosine_similarity_orthogonal_returns_zero() {
+        let a = vec![1.0_f32, 0.0, 0.0, 0.0];
+        let b = vec![0.0_f32, 1.0, 0.0, 0.0];
+        let cos = super::cpu_vs_gpu_cosine_similarity(&a, &b);
+        assert!(
+            cos.abs() < 1e-6,
+            "orthogonal vectors must yield cosine 0.0, got {cos}"
+        );
+    }
+
+    /// FALSIFY-CPU-GPU-005 part b cosine helper — fail-closed on bad input.
+    ///
+    /// Zero-norm or mismatched-length inputs MUST return 0.0 so the future gate
+    /// triggers fallback rather than dividing by zero or panicking. This is the
+    /// "conservative default" that closes the silent-gibberish loophole even
+    /// when the probe forward itself emits NaN/zeros.
+    #[test]
+    fn cpu_vs_gpu_cosine_similarity_fails_closed() {
+        // Zero-norm input
+        let zero = vec![0.0_f32; 4];
+        let nonzero = vec![1.0_f32, 2.0, 3.0, 4.0];
+        assert_eq!(
+            super::cpu_vs_gpu_cosine_similarity(&zero, &nonzero),
+            0.0,
+            "zero-norm input must fail closed"
+        );
+        // Length mismatch
+        let short = vec![1.0_f32, 2.0];
+        let long = vec![1.0_f32, 2.0, 3.0, 4.0];
+        assert_eq!(
+            super::cpu_vs_gpu_cosine_similarity(&short, &long),
+            0.0,
+            "length mismatch must fail closed"
+        );
+        // Empty input
+        let empty: Vec<f32> = Vec::new();
+        assert_eq!(
+            super::cpu_vs_gpu_cosine_similarity(&empty, &empty),
+            0.0,
+            "empty input must fail closed"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Lifts the cosine-similarity primitive from \`cuda::mod_parity_gate\` (which lives behind \`cfg(feature = \"cuda\")\`) into \`infer/gguf_gpu_generate.rs\` at module scope. The future wgpu cosine gate (FALSIFY-CPU-GPU-005 part b, contract v1.2.0 implementation_evidence line 201) can now call this helper without a \`--features cuda\` build dependency.

## Helper

\`\`\`rust
pub(crate) fn cpu_vs_gpu_cosine_similarity(a: &[f32], b: &[f32]) -> f32
\`\`\`

- f64-accumulated for numerical stability
- **Fail-closed**: returns 0.0 on length-mismatch / zero-norm / empty input → triggers fallback below 0.99 floor

## Tests (3 pass)

- \`cpu_vs_gpu_cosine_similarity_parallel_returns_one\` — positive case (no fallback)
- \`cpu_vs_gpu_cosine_similarity_orthogonal_returns_zero\` — negative case (fallback triggers)
- \`cpu_vs_gpu_cosine_similarity_fails_closed\` — conservative-default for bad input

## Five Whys

1. **Why lift now?** Part b is the single piece of work that closes FALSIFY-CPU-GPU-005 from PARTIAL_ALGORITHM_LEVEL → FUNCTIONAL. The helper is the smallest independently-landable piece.
2. **Why not import from cuda?** That module is \`cfg(feature = \"cuda\")\`-gated; the wgpu path is gated \`cfg(feature = \"gpu\")\` (not cuda) — importing would force both features for cosine math.
3. **Why fail-closed?** Per \`feedback_fix_root_cause_never_route_around\` and §40/§41 jidoka: the gate must NEVER ship silent gibberish. NaN/zero/wrong-length input → return 0.0 → user sees the fallback log.
4. **Why 3 tests?** Cosine surface has 3 failure modes (positive, negative, conservative). Each must be independently locked in.
5. **Why bounded?** ~80 LOC total. No behavior change (helper currently unused). Builds without \`--features cuda\`. Lays groundwork for part b PR (~100-150 LOC).

## Net effect

- FALSIFY-CPU-GPU-005 status unchanged (still PARTIAL_ALGORITHM_LEVEL)
- MODEL-1 ship % unchanged at 88%
- Discharge happens when part b's wgpu single-step decode lands and uses this helper

## Test plan

- [ ] \`cargo test -p aprender-serve --lib cpu_vs_gpu_cosine\` (3 pass)
- [ ] CI green on required gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)