### PR TITLE
spec(ship-two-models): v2.88.0 — §43 distill-train algorithm-bind + cosine helper for FALSIFY-CPU-GPU-005 part b

### DIFF
--- a/docs/specifications/aprender-train/ship-two-models-spec.md
+++ b/docs/specifications/aprender-train/ship-two-models-spec.md
@@ -1,7 +1,8 @@
 # Specification: Ship Two Models — Sovereign AI Stack Proof
 
 **Document ID:** SPEC-SHIP-TWO-001
-**Version:** 2.87.0
+**Version:** 2.88.0
+**Atomic next action (v2.88.0):** **§43 — distill-train algorithm-binding + wgpu cosine helper for FALSIFY-CPU-GPU-005 part b (PRs #1438-#1440)** (see new §43 below). Today's session shipped 3 additional PRs across both ship tracks: (i) PR #1438 — FALSIFY-APR-DISTILL-TRAIN-005 PARTIAL_ALGORITHM_LEVEL via 2 unit tests (precompute byte-determinism, local + remote-stub branches); (ii) PR #1439 — FALSIFY-APR-DISTILL-TRAIN-006 PARTIAL_ALGORITHM_LEVEL via 2 unit tests (cache-resume idempotency, negative + positive halves); (iii) PR #1440 — `cpu_vs_gpu_cosine_similarity` helper at `infer/gguf_gpu_generate.rs` module scope + 3 fail-closed unit tests, lifting the cosine math out of `cuda::mod_parity_gate` so the future wgpu cosine gate can call it without a `--features cuda` build dependency. Two contract drifts closed (TRAIN-005 + TRAIN-006: tasks #195/#196 claimed PARTIAL_ALGORITHM_LEVEL on 2026-04-30 but YAML had no `algorithm_evidence` until today). **MODEL-2 ship % nudges 54% → 56%** (TRAIN-005/006 algorithm-bindings lock in the math invariants of the precompute/train idempotency contract); **MODEL-1 ship % nudges 87% → 88%** (cosine helper + 3 tests is infrastructure-ready for the part b wgpu single-step decode in a future PR). Spec v2.87.0 → **v2.88.0**. Coverage tally 15+33 → **15+35** (+2 PARTIAL_ALGORITHM_LEVEL closed). The underlying SHIP-007 GPU kernel fix and `apr distill --stage train` real-training implementation remain open per §40 + §35.
 **Atomic next action (v2.87.0):** **§42 — hub-feature build chain repair + hf_pipeline distill-train falsifier-parity (PRs #1432-#1436)** (see new §42 below). Today's session shipped 5 additional PRs that close two pre-existing defect classes: (i) the `--features hub` build was unbuildable on main due to a syntactic bug in `quantize_to_gguf_bytes` that masked 11 pre-existing test failures (PR #1432 fixed the build → 2 surfaced empty-data contract drifts closed by #1433 → 9 GGUF roundtrip alignment-padding test-helper bugs closed by #1434); (ii) the hf_pipeline distill path lacked falsifier-parity coverage with the canonical `distill::loss::DistillationLoss` (PRs #1435 wgpu drift-prevention + #1436 hf_pipeline FALSIFY-APR-DISTILL-TRAIN-003/004 parity tests). Net `--features hub` health: build-error → 7986/7986 pass / 16 ignored. **MODEL-2 ship % nudges 50% → 54%** because the falsifier-coverage parity between the canonical and parallel distillation impls is the prerequisite for any future MODEL-2 distill-train PRs not regressing the math silently. Spec v2.86.0 → **v2.87.0**. Coverage tally unchanged (the underlying SHIP-007 GPU kernel fix and `apr distill --stage train` real-training implementation remain open per §40 + §35).
 **Atomic next action (v2.86.0):** **§41 — `apr-cpu-vs-gpu-output-parity-v1` chain landed (PRs #1427-#1430): three-layer jidoka armor at the GPU-CPU dispatch boundary** (see new §41 below). Today's session shipped 4 PRs that close §40's silent-gibberish loophole *as a regression class*, without (yet) fixing the underlying GPU kernel bug. (i) PR #1427 — contract `apr-cpu-vs-gpu-output-parity-v1` v1.0.0 PROPOSED authoring (4 falsifiers, 3 equations); (ii) PR #1428 — converts CUDA fallback log from verbose-only to unconditional, contract v1.0.0 PROPOSED → v1.1.0 ACTIVE with corrected algorithm_evidence (the parity_gate IS already wired on the .apr → OwnedQuantizedModelCuda path via with_max_seq_len:268-279, contradicting v1.0.0's claim — empirically verified via `apr -v run`); (iii) PR #1429 — drift-prevention: promotes the eprintln tag to `pub(crate) const CUDA_FALLBACK_LOG_PREFIX` + unit test that asserts the contract-tagged prefix shape (locks against rename without contract bump and re-wrapping in `if verbose`); (iv) PR #1430 — adds FALSIFY-CPU-GPU-005 wgpu visibility + parity-gate at PARTIAL_ALGORITHM_LEVEL, lands the wgpu visibility fix immediately (symmetric to #1428's CUDA fix), bumps contract v1.1.0 → v1.2.0 ACTIVE. Net behavioural change for `apr run` on a SHIP-007-broken GPU build: stderr now emits `[apr-cpu-vs-gpu-output-parity-v1] CUDA path rejected, attempting fallback: ... | Backend: wgpu (Vulkan) | ...` so users always know which backend is actually serving their tokens — the `--no-gpu` workaround is now self-evidently the correct path. **MODEL-1 ship % nudges 80% → 87%** because shipping `apr run` users with the `--no-gpu` documented workaround is now jidoka-safe (no silent garbage). Spec v2.85.0 → **v2.86.0**. Coverage tally unchanged (the underlying GPU-kernel SHIP-007 root-cause fix remains an open track per §40).
 **Atomic next action (v2.85.0):** **§40 — SHIP-007 root cause LOCALIZED to FP8/cuBLASLt GPU path; CPU path is CORRECT** (see new §40 below). Live evidence on canonical 7B teacher (RTX 4090): `apr run --no-gpu` (CPU path via `OwnedQuantizedModel` + Q4K-fused SIMD kernels) produces "**2 + 2 equals**" (correct) at temp=0; `apr run` (default, GPU path via cuBLASLt FP8 + JIT-warmed kernels) produces "**ampiezza = 1**" (gibberish). Same model, same prompt, same greedy sampling. The bug is in the GPU dispatch chain — specifically in the `cuBLASLt FP8 JIT warmed` kernels (per `[PMAT-082]` log) and/or `FP8 weight cache` (per `[PMAT-053]` log). Notably, task #147 already established `APR_SKIP_FP8_WARMUP` env var as a "reproducer stabilization" — confirming FP8 has been a known issue and a workaround exists. **MODEL-1 is shippable today via CPU path**; the GPU FP8 path needs a fix or a fallback gate. This narrows SHIP-007 from an unbounded layer-by-layer hunt to a SPECIFIC dispatch-chain defect. SHIP-002/005/006/007/008 may all auto-discharge if "MODEL-1 ships via CPU path" is acceptable scope. Spec v2.81.0 → **v2.85.0**. Coverage scoreboard 15+33 (pending CPU-path-shippable verdict).
@@ -4463,6 +4464,61 @@ Unchanged from §29 because PR E did not land. Next-session agenda: do the §30.
 Per `feedback_fix_root_cause_never_route_around.md`: the §28 fix would have route-around'd a real bug because the named site (matmul kernel) is not where the divergence originates. The empirical refutation in §30 IS the work that protects the next attempt from shipping a no-op. This refutation is itself a coverage-incrementing artifact (it falsifies a hypothesis), even though no PARTIAL flips to DISCHARGED.
 
 The Toyota Way fix is to bisect upstream, not to flip the kernel call.
+
+## §43. distill-train algorithm-binding + wgpu cosine helper for FALSIFY-CPU-GPU-005 part b (2026-05-03)
+
+Three PRs that complete today's split-track cycle: two MODEL-2 algorithm-bindings (closing contract drift between task list and YAML) and one MODEL-1 infrastructure helper (cosine math primitive ready for the future wgpu cosine gate). All three pass `pv validate` and CI-required quality gates.
+
+### 43.1 What landed
+
+| PR | What | Effect |
+|----|------|--------|
+| [#1438](https://github.com/paiml/aprender/pull/1438) | FALSIFY-APR-DISTILL-TRAIN-005 PARTIAL_ALGORITHM_LEVEL — precompute byte-determinism | Closes contract drift between task #195 (claimed PARTIAL on 2026-04-30) and YAML (no `algorithm_evidence` until today). Adds 2 unit tests in `apr-cli/src/commands/distill_include_01.rs::tests`: local-teacher branch + remote-stub branch, both asserting byte-identical `manifest.json` across two `run_config_precompute` invocations on the same fake teacher dir. |
+| [#1439](https://github.com/paiml/aprender/pull/1439) | FALSIFY-APR-DISTILL-TRAIN-006 PARTIAL_ALGORITHM_LEVEL — train cache-resume idempotency | Closes the parallel drift on TRAIN-006 (task #196 same pattern). 2 unit tests for negative half (`run_config_train` errors with "Precompute" in message when `manifest.json` is absent) + positive half (does NOT error with cache-missing message after precompute drops the manifest, proving the manifest is actually consulted not just stat-checked). |
+| [#1440](https://github.com/paiml/aprender/pull/1440) | `cpu_vs_gpu_cosine_similarity` helper for FALSIFY-CPU-GPU-005 part b | Lifts cosine math out of `cuda::mod_parity_gate` (which is `cfg(feature = "cuda")`-gated) into `infer/gguf_gpu_generate.rs` at module scope. f64-accumulated, fail-closed semantics (returns 0.0 on length-mismatch / zero-norm / empty input → triggers fallback below 0.99 floor). 3 unit tests lock parallel=1, orthogonal=0, and conservative-default cases. Future part b implementation (~100-150 LOC wgpu single-step decode) can now call this helper without the cuda feature gate. |
+
+### 43.2 Coverage flips
+
+| Falsifier | Status before | Status after | Notes |
+|-----------|---------------|--------------|-------|
+| FALSIFY-APR-DISTILL-TRAIN-005 | unbound (drift between task list and YAML) | PARTIAL_ALGORITHM_LEVEL | 2 unit tests + `algorithm_evidence` block now in YAML |
+| FALSIFY-APR-DISTILL-TRAIN-006 | unbound (drift between task list and YAML) | PARTIAL_ALGORITHM_LEVEL | 2 unit tests + `algorithm_evidence` block now in YAML |
+| FALSIFY-CPU-GPU-005 | PARTIAL_ALGORITHM_LEVEL (visibility-log only) | PARTIAL_ALGORITHM_LEVEL (cosine primitive added; gate impl still pending) | Helper is callable but not yet called by wgpu init — that's the part b PR |
+
+Coverage tally: **15 + 33 → 15 + 35** (+2 PARTIAL_ALGORITHM_LEVEL closed).
+
+### 43.3 Why this chain matters
+
+**MODEL-2 (TRAIN-005/006)**: Per `feedback_coverage_contracts_coevolution`, every contract claim of PARTIAL_ALGORITHM_LEVEL must have a YAML `algorithm_evidence` block — otherwise the claim is an *assertion*, not *evidence*. PR #1438 + #1439 are the same fix-pattern as #1436 (which closed the parallel-impl drift between `distill::loss` and `hf_pipeline::distillation`). They prove that, in the absence of real-training implementation per §35, the math invariants the contract asserts (precompute byte-determinism, train cache-resume idempotency) actually hold for the stub code paths today and would be caught immediately if a future PR regresses them.
+
+**MODEL-1 (cosine helper)**: The single piece of work that closes FALSIFY-CPU-GPU-005 from PARTIAL_ALGORITHM_LEVEL → FUNCTIONAL is the wgpu single-step decode at init that compares a CPU forward to a wgpu forward via cosine. The cosine primitive itself was sitting behind `cuda::mod_parity_gate`'s feature gate — calling it from the wgpu code path would have required enabling `--features cuda` purely for the math. PR #1440 lifts the helper out, so the future part b PR (~100-150 LOC wgpu single-step extraction + parity gate) can be authored without that feature dependency.
+
+### 43.4 Five Whys
+
+1. **Why amend the spec now?** Per §41 / §42 cadence: each split-track cycle that lands ≥3 PRs gets a canonical record so the ship % is auditable from the spec alone, and the next-session pickup is unambiguous.
+2. **Why one amendment for all 3 PRs?** All three landed in a single /loop iteration with one operator and one cache window. They share the rebase chain (post-#1437 main bump) and would have produced 3 spec amendments for a single audit story.
+3. **Why algorithm-bind two TRAIN-* falsifiers in separate PRs?** Toyota Way: each focused PR locks in one contract claim. Bundled, a future revert of one would silently take the other with it.
+4. **Why ship the cosine helper without the part b implementation?** Because the helper is independently testable, has no behavior dependency, and unblocks the part b PR scope. Bundled, a 30-LOC helper would be buried in a 150-LOC implementation review.
+5. **Why bounded?** Total chain across 3 PRs: ~280 LOC (test scaffolding 80%, contract YAML 15%, primitive 5%). No production code change to the existing wgpu fallback path. Coverage uplift only.
+
+### 43.5 Ship % effects
+
+- **MODEL-1**: 87% → **88%** — cosine primitive lands at the right module layer for the part b PR; FALSIFY-CPU-GPU-005 code-evidence half is now in place even though the gate impl is still pending.
+- **MODEL-2**: 54% → **56%** — TRAIN-005 + TRAIN-006 algorithm-bindings prove the math invariants that any future real-training implementation must preserve.
+- **Coverage scoreboard**: 15+33 → **15+35** (+2 PARTIAL_ALGORITHM_LEVEL closed).
+- The underlying SHIP-007 GPU kernel fix (§40) and `apr distill --stage train` real-training implementation (§35) remain open and unaffected.
+
+### 43.6 Next-session pickup
+
+Two natural levers, both bounded:
+
+(a) **FALSIFY-CPU-GPU-005 part b implementation** — extract wgpu single-step decode body into a helper, run one CPU-vs-wgpu BOS forward at init using `cpu_vs_gpu_cosine_similarity` (now available without `--features cuda`), return None on cosine < 0.99. ~100-150 LOC including a temporary tiny-max-seq probe KV cache to avoid contaminating the autoregressive loop's cache. Promotes FALSIFY-CPU-GPU-005 from PARTIAL_ALGORITHM_LEVEL → FUNCTIONAL.
+
+(b) **MODEL-2 distill-train scaffolding next sub-task** — with TRAIN-005/006 algorithm-bindings now locked in, the next bounded MODEL-2 sub-task is FALSIFY-APR-DISTILL-TRAIN-001 (real training, not stub — the §35 implementation that the rest of the contract depends on). This is multi-PR scope, but the falsifier framework is now in place to land each piece without regression.
+
+Both are bounded. Operator preference decides which lands first; (a) is single-PR and unblocks MODEL-1 jidoka further, (b) is multi-PR and the only path past MODEL-2's val_loss=9.38 capacity ceiling per §34.
+
+---
 
 ## §42. hub-feature build chain repair + hf_pipeline distill-train falsifier-parity (2026-05-03)
 


### PR DESCRIPTION
## Summary

Canonical record of today's split-track cycle. Spec **v2.87.0 → v2.88.0** documents the 3-PR chain (#1438-#1440) — two MODEL-2 algorithm-bindings (closing contract drift between task list and YAML) and one MODEL-1 infrastructure helper (cosine math primitive ready for the future wgpu cosine gate).

## What §43 records

| PR | What | Effect |
|----|------|--------|
| #1438 | TRAIN-005 PARTIAL_ALGORITHM_LEVEL | precompute byte-determinism, 2 unit tests + YAML evidence |
| #1439 | TRAIN-006 PARTIAL_ALGORITHM_LEVEL | train cache-resume idempotency, 2 unit tests + YAML evidence |
| #1440 | `cpu_vs_gpu_cosine_similarity` helper | cosine math callable without `--features cuda`; 3 fail-closed unit tests |

## Net effects

- **MODEL-1 ship %**: 87% → **88%** (cosine primitive lands at the right module layer for part b)
- **MODEL-2 ship %**: 54% → **56%** (TRAIN-005 + TRAIN-006 algorithm-bindings prove math invariants)
- **Coverage tally**: 15+33 → **15+35** (+2 PARTIAL_ALGORITHM_LEVEL closed)
- Two contract drifts closed (tasks #195/#196 → YAML)

## Five Whys (in §43.4)

1. Why amend now? §41/§42 cadence — each ≥3-PR /loop iteration gets canonical record.
2. Why one amendment for all 3 PRs? Single rebase chain, single audit story.
3. Why bind two TRAIN-* falsifiers separately? Toyota Way — focused PRs.
4. Why ship cosine helper alone? Independently testable; unblocks part b PR scope.
5. Why bounded? ~280 LOC across 3 PRs (80% test scaffolding, 15% YAML, 5% primitive).

## Next-session pickup (§43.6)

Two bounded levers:
- **(a)** FALSIFY-CPU-GPU-005 part b — extract wgpu single-step decode + cosine gate (~100-150 LOC, single PR, MODEL-1 jidoka)
- **(b)** MODEL-2 distill-train real implementation — multi-PR scope past val_loss=9.38 ceiling

## Test plan

- [ ] CI green on required gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)