### PR TITLE
spec(ship-two-models): v2.92.0 — §47 SHIP-007 layer-0 attention bisection cascade STARTED

### DIFF
--- a/contracts/qwen3-moe-forward-gpu-v1.yaml
+++ b/contracts/qwen3-moe-forward-gpu-v1.yaml
@@ -1,0 +1,442 @@
+metadata:
+  version: 1.0.0
+  kind: kernel
+  created: '2026-05-04'
+  author: PAIML Engineering
+  amendment_history:
+    - version: 1.0.0
+      date: '2026-05-04'
+      kind: created
+      title: 'Initial contract scaffold for GPU MoE forward path (P0 / HIGHEST PRIORITY per claude-code-parity-apr M49)'
+      description: |
+        Companion to `qwen3-moe-forward-v1` (CPU LAZY-FUSED-MATVEC,
+        ACTIVE_ALGORITHM_LEVEL since M32d functional discharge
+        2026-05-02). This contract specifies the GPU sibling.
+
+        Why P0 / HIGHEST PRIORITY (per claude-code-parity-apr POC spec
+        M49 elevation, 2026-05-04):
+
+          - CPU-only LAZY-FUSED-MATVEC produces correct output but at
+            ~30 tok/s on Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.
+          - The dense GPU path on this stack runs at 225-440 tok/s
+            (cuBLAS Q4_K on RTX 4090).
+          - MoE inference is ~10x slower than dense — makes the
+            spec-prescribed default Qwen3-Coder model production-
+            infeasible at ~30 tok/s.
+          - The action-stream parity machinery in the companion
+            (CCPA-001..013, all DISCHARGED) is correct but cannot be
+            exercised at production cadence — every `apr code`
+            invocation hits the 30 tok/s wall.
+
+        Until this contract discharges, the companion's dogfood loops
+        and the production `apr code` path are throughput-bounded by
+        the CPU MoE baseline. Hence P0.
+
+        Scaffold-only at v1.0.0; status DRAFT until at least M-stage
+        M-GPU-MOE-1 (CUDA kernel + cosine parity gate) lands on
+        aprender main. Stages outlined in implementation_stages below.
+
+  description: |
+    GPU companion to `qwen3-moe-forward-v1` (CPU LAZY-FUSED-MATVEC,
+    ACTIVE_ALGORITHM_LEVEL since M32d functional discharge 2026-05-02).
+    Specifies the CUDA/wgpu sibling with identical numerical semantics
+    + cosine ≥0.99 parity gate vs the CPU reference + ≥150 tok/s
+    throughput target on RTX 4090. P0/HIGHEST PRIORITY per
+    claude-code-parity-apr POC M49 elevation 2026-05-04 — current CPU
+    baseline of ~30 tok/s is the rate-limit on production-cadence
+    consumption of the M32d discharge.
+
+  references:
+    - 'aprender contracts/qwen3-moe-forward-v1.yaml — CPU LAZY-FUSED-MATVEC sibling'
+    - 'aprender contracts/moe-router-v1.yaml — softmax + top-k + renormalize'
+    - 'aprender contracts/moe-expert-dispatch-v1.yaml — per-expert dispatch + weighted aggregation'
+    - 'aprender contracts/swiglu-kernel-v1.yaml — per-expert FFN'
+    - 'aprender contracts/apr-cpu-vs-gpu-output-parity-v1.yaml — CPU↔GPU parity discipline (FALSIFY-CPU-GPU-001..005)'
+    - 'paiml/claude-code-parity-apr docs/specifications/claude-code-parity-apr-poc.md § "Scope extensions" sub-extension 2 (P0)'
+    - 'paiml/claude-code-parity-apr docs/specifications/claude-code-parity-apr-poc.md § "Risks & open questions" R10'
+    - 'arXiv:2305.18398 Dao FlashAttention-2 (fused-kernel parity discipline)'
+    - 'arXiv:2305.05176 Aminabadi et al. DeepSpeed-MoE (sparse-MoE GPU dispatch / expert-parallel scheduling)'
+    - 'arXiv:2101.03961 Fedus et al. Switch Transformers (modern MoE forward conventions)'
+
+  depends_on:
+    - qwen3-moe-forward-v1
+    - moe-router-v1
+    - moe-expert-dispatch-v1
+    - swiglu-kernel-v1
+    - apr-cpu-vs-gpu-output-parity-v1
+    - tensor-layout-v1
+    - tensor-names-v1
+
+kind: KernelContract
+name: qwen3-moe-forward-gpu
+version: "1.0.0"
+status: DRAFT   # Scaffold only; flips to ACTIVE_ALGORITHM_LEVEL when
+                # CUDA kernel + cosine parity gate (FALSIFY-QW3-MOE-GPU-
+                # PARITY-001) lands on aprender main. Flips to
+                # ACTIVE_RUNTIME when wgpu fallback + throughput target
+                # (≥150 tok/s on RTX 4090) also discharge.
+                #
+                # v1.0.0 (2026-05-04): Initial scaffold per
+                # claude-code-parity-apr POC M49 priority elevation.
+                # No code yet — this contract IS the deliverable for
+                # M-stage M-GPU-MOE-0.
+scope: "crates/aprender-serve/src/gpu/{forward_qwen3_moe_gpu,scheduler/moe_dispatch}.rs, crates/aprender-compute/src/gpu/moe_kernels.rs (TBD)"
+
+description: |
+  GPU sibling of the CPU `forward_qwen3_moe` path. Same end-to-end
+  semantics as `qwen3-moe-forward-v1`: hidden_state[hidden_dim] in,
+  hidden_state'[hidden_dim] out, with hidden_state' = hidden_state +
+  MoE(RMSNorm(hidden_state)).
+
+  The numerical decomposition is identical:
+
+    1. Router: softmax(W_router @ x) → top-k → renormalize
+    2. Per-expert SwiGLU: down(SiLU(gate(x)) * up(x))
+    3. Weighted aggregation: Σ_e w[t,e] * expert_out[t,e]
+    4. Optional shared expert with sigmoid gate
+
+  What changes is the dispatch substrate: CUDA kernel (primary) +
+  wgpu fallback (per CLAUDE.md backend-agnostic mandate). The CPU
+  LAZY-FUSED-MATVEC path remains the reference; the GPU path must
+  produce cosine ≥ 0.99 against it (FALSIFY-QW3-MOE-GPU-PARITY-001).
+
+  Dispatch architecture (DeepSpeed-MoE precedent, arXiv:2305.05176):
+
+    - Sparse expert dispatch: only the top-k experts per token are
+      visited; experts not selected do NOT trigger GPU memory
+      transfers or kernel launches.
+    - Fused dequant+matmul: Q4_K/Q6_K tiles dequantized into shared
+      memory inline with the matmul, mirroring the CPU
+      `fused_q4k_parallel_matvec` / `fused_q6k_parallel_matvec`
+      semantics.
+    - Expert-parallel scheduling: tokens routed to the same expert
+      are batched within a single kernel launch; cross-expert
+      synchronization at the weighted-aggregation step.
+
+  Memory budget on RTX 4090 (24 GB VRAM):
+
+    - 17.5 GB Q4_K/Q6_K expert tensors stay on GPU (mmap'd at load
+      time). EAGER FP32 expansion would expand to 70 GB and OOM —
+      this is the same constraint that drove the CPU
+      LAZY-FUSED-MATVEC choice in qwen3-moe-forward-v1 v1.1.0.
+    - ~2 GB attention KV cache.
+    - ~1-2 GB activations + workspace.
+    - ~3 GB headroom.
+
+  Tensor naming follows tensor-names-v1 v1.1.0 (qwen3_moe arch key,
+  same as the CPU path): blk.{L}.ffn_gate_inp / ffn_gate_exps /
+  ffn_up_exps / ffn_down_exps.
+
+equations:
+  moe_forward_one_layer_gpu:
+    formula: |
+      h' = h + MoE_gpu(RMSNorm(h))
+      where MoE_gpu(x) = Σ_{e ∈ TopK(softmax(W_r @ x), k)} w_e · SwiGLU_gpu_e(x)
+                         + (optional) σ(W_s @ x) · SwiGLU_gpu_shared(x)
+    domain: |
+      h ∈ R^d, W_r ∈ R^{N_e × d}, W_s ∈ R^{1 × d}, k = num_experts_per_tok,
+      SwiGLU_gpu_e ∈ R^d → R^d parameterized by (W_gate^e, W_up^e, W_down^e),
+      all weights resident on GPU global memory in their on-disk Q4_K/Q6_K
+      quantized form (no FP32 expansion).
+    invariants:
+    - h.len() == hidden_dim
+    - 'router weights sum: Σ_e selected_w[e] = 1.0  (post-renormalization)'
+    - 'output shape preserved: result.len() == hidden_dim'
+    - 'selected experts ∈ [0, N_e)'
+    - 'cosine_similarity(MoE_gpu(x), MoE_cpu_lazy_fused_matvec(x)) ≥ 0.99'
+    preconditions:
+    - hidden_dim > 0
+    - num_experts > 0
+    - num_experts_per_tok > 0 ∧ num_experts_per_tok ≤ num_experts
+    - 'router_weight.shape == [num_experts, hidden_dim]'
+    - 'expert_gate.shape == [num_experts, intermediate, hidden_dim]'
+    - 'expert_up.shape   == [num_experts, intermediate, hidden_dim]'
+    - 'expert_down.shape == [num_experts, hidden, intermediate]'
+    - 'CudaExecutor::new(0).is_ok() — GPU device 0 available'
+    postconditions:
+    - 'h_prime.len() == hidden_dim'
+    - 'h_prime.iter().all(|v| v.is_finite())'
+    - 'cosine_similarity(h_prime, cpu_reference) ≥ 0.99'
+
+  gpu_throughput_target:
+    formula: |
+      tokens_per_second(qwen3_coder_30b_a3b_instruct_q4_k_m, RTX_4090) ≥ 150
+    domain: |
+      Single-prompt single-stream generate loop, no batching, KV cache
+      enabled. Model: Qwen3-Coder-30B-A3B-Instruct-Q4_K_M (17.3 GB GGUF).
+      Hardware: NVIDIA RTX 4090 (24 GB VRAM, 16384 CUDA cores).
+      Measurement window: ≥128 tokens generated (per CLAUDE.md "128-tok
+      median" perf-parity convention).
+    invariants:
+    - 'tps ≥ 150 over ≥128-token measurement window'
+    - 'tps ≥ 5x CPU baseline of ~30 tok/s'
+    rationale: |
+      CPU LAZY-FUSED-MATVEC measured at ~30 tok/s on the same model.
+      Dense GPU Q4_K (Qwen2.5-Coder-7B Q4_K_M) measured at 225-440 tok/s
+      on RTX 4090 cuBLAS. MoE has expert-dispatch overhead; allow
+      headroom: target ≥150 tok/s = ≥5x CPU baseline, ~3x slower than
+      dense GPU (the dispatch overhead).
+
+proof_obligations:
+- type: equivalence
+  property: 'GPU forward result matches CPU LAZY-FUSED-MATVEC reference within ≥0.99 cosine (AC_GPU_MOE_001)'
+  formal: 'cosine_similarity(forward_qwen3_moe_gpu(x), forward_qwen3_moe_cpu(x)) ≥ 0.99'
+  tolerance: 0.01
+  applies_to: all
+
+- type: invariant
+  property: 'Router weights sum to 1.0 after top-k renormalization (AC_GPU_MOE_002)'
+  formal: 'Σ_e route.weights[e] = 1.0 ± 1e-6'
+  applies_to: all
+
+- type: invariant
+  property: 'Output dimensions preserved (AC_GPU_MOE_003)'
+  formal: 'forward_gpu.output.len() == hidden_dim'
+  applies_to: all
+
+- type: invariant
+  property: 'Output is finite — no NaN/Inf (AC_GPU_MOE_004)'
+  formal: 'forward_gpu.output.iter().all(|v| v.is_finite())'
+  applies_to: all
+
+- type: equivalence
+  property: 'GPU forward result matches HF FP16 reference (AC_GPU_MOE_005)'
+  formal: 'cosine_similarity(apr_gpu_logits, hf_fp16_logits) > 0.99'
+  tolerance: 0.01
+  applies_to: all
+  note: |
+    Inherits from qwen3-moe-forward-v1 AC_QW3_MOE_005. Operator-confirm
+    pending the same ~60 GB Qwen3-Coder-30B-A3B-FP16 download.
+
+- type: bound
+  property: 'GPU throughput ≥ 150 tok/s on RTX 4090 (AC_GPU_MOE_006)'
+  formal: 'tps_128_tok_median(qwen3_coder_30b_a3b_q4_k_m, RTX_4090) ≥ 150'
+  applies_to: all
+
+- type: invariant
+  property: 'GPU memory budget under 24 GB VRAM (AC_GPU_MOE_007)'
+  formal: 'cuda_mem_get_info().used / cuda_mem_get_info().total ≤ 0.95'
+  applies_to: all
+  note: |
+    Hard cap: 95% VRAM utilization to leave headroom for activations,
+    KV cache, and OS/driver overhead. Model alone (17.5 GB Q4_K/Q6_K
+    expert tensors) is ~73% of 24 GB; remaining 22% covers
+    activations + KV cache + workspace + headroom per the description's
+    memory-budget breakdown.
+
+implementation_stages:
+- id: M-GPU-MOE-0
+  status: SHIPPED
+  description: |
+    This contract scaffold (v1.0.0). No code; just the kernel-contract
+    YAML defining what GPU MoE means and the gates it has to discharge.
+  evidence:
+    - 'aprender contracts/qwen3-moe-forward-gpu-v1.yaml at v1.0.0'
+    - 'pv validate contracts/qwen3-moe-forward-gpu-v1.yaml exits 0'
+
+- id: M-GPU-MOE-1
+  status: PENDING
+  description: |
+    CUDA kernel `forward_qwen3_moe_gpu` in
+    `crates/aprender-serve/src/gpu/forward_qwen3_moe_gpu.rs` (or similar).
+    Sparse expert dispatch + fused dequant+matmul. Discharges
+    AC_GPU_MOE_001..005 against the CPU LAZY-FUSED-MATVEC reference and
+    the HF FP16 reference (the latter inherited from the v1 contract).
+    Flips this contract DRAFT → ACTIVE_ALGORITHM_LEVEL.
+  expected_acceptance:
+    - AC_GPU_MOE_001
+    - AC_GPU_MOE_002
+    - AC_GPU_MOE_003
+    - AC_GPU_MOE_004
+    - AC_GPU_MOE_005
+  blockers:
+    - 'aprender does not yet have a fused-quantized-dequant-matmul GPU kernel for sparse MoE dispatch'
+    - 'DeepSpeed-MoE-style expert-parallel scheduling needs design work for the Q4_K_M / Q6_K row-major layouts'
+
+- id: M-GPU-MOE-2
+  status: PENDING
+  description: |
+    wgpu fallback path (per CLAUDE.md backend-agnostic mandate).
+    Same numerical equivalence gate as M-GPU-MOE-1 but for non-CUDA
+    hardware. Discharges AC_GPU_MOE_001..005 on a wgpu device.
+  expected_acceptance:
+    - AC_GPU_MOE_001
+    - AC_GPU_MOE_002
+    - AC_GPU_MOE_003
+    - AC_GPU_MOE_004
+    - AC_GPU_MOE_005
+
+- id: M-GPU-MOE-3
+  status: PENDING
+  description: |
+    Throughput target. ≥150 tok/s on Qwen3-Coder-30B-A3B-Instruct-Q4_K_M
+    on RTX 4090. Discharges AC_GPU_MOE_006. Memory-budget compliance
+    discharges AC_GPU_MOE_007.
+    With this stage SHIPPED, this contract flips ACTIVE_ALGORITHM_LEVEL
+    → ACTIVE_RUNTIME — the same convention as qwen3-moe-forward-v1.
+  expected_acceptance:
+    - AC_GPU_MOE_006
+    - AC_GPU_MOE_007
+
+falsification_tests:
+- id: FALSIFY-QW3-MOE-GPU-001
+  rule: 'Baseline failure: GPU MoE forward path does not exist'
+  prediction: |
+    `apr run <qwen3-moe>.gguf --gpu` (with explicit GPU dispatch) for
+    a qwen3_moe model falls back to CPU LAZY-FUSED-MATVEC (the v1
+    contract path) — there is no `forward_qwen3_moe_gpu` symbol.
+  test: |
+    grep -rn "forward_qwen3_moe_gpu" crates/aprender-serve/src/
+    Expect: 0 matches (function does not exist).
+  if_fails: |
+    Someone shipped GPU MoE without bumping this contract — please
+    update v1.0.0 → v1.1.0 with the discharge and flip status.
+
+- id: FALSIFY-QW3-MOE-GPU-PARITY-001
+  rule: 'M-GPU-MOE-1 discharges CPU↔GPU cosine ≥0.99 parity gate'
+  prediction: |
+    A GPU forward pass on Qwen3-Coder-30B-A3B-Instruct-Q4_K_M produces
+    logits with cosine ≥0.99 vs the CPU LAZY-FUSED-MATVEC reference on
+    the same input.
+  test: |
+    cargo test -p aprender-serve --test qwen3_moe_gpu_parity --features cuda -- --include-ignored
+    Asserts: cosine_similarity(apr_gpu_logits, apr_cpu_logits) ≥ 0.99
+    on a fixed prompt vs the cached 17.3 GB Qwen3-Coder GGUF.
+  if_fails: |
+    GPU kernel diverges from CPU reference. Bisect via
+    `apr trace --json --payload` (M32d Step 2 surface) on both paths,
+    diff per-layer ActivationStats. Common failure modes:
+      - per-head Q/K RMSNorm not applied on GPU (rank-3 prior, see
+        qwen3-moe-forward-v1 v1.4.0 § M32d Step 5)
+      - rope_theta default 10K instead of 1M for qwen3_moe (rank-4
+        prior, see § M32d Step 5b)
+      - Q4_K dequant scale/zero-point mismatch
+      - sparse expert dispatch picking different top-k vs CPU (router
+        floating-point reordering)
+
+- id: FALSIFY-QW3-MOE-GPU-PARITY-002
+  rule: 'M-GPU-MOE-1 inherits HF FP16 cosine ≥0.99 from v1 contract'
+  prediction: |
+    GPU forward pass logits, compared against
+    qwen3_moe_fp16_logits_pos0.json (M32d.1 fixture, operator-confirm),
+    produce cosine_similarity ≥ 0.99.
+  test: |
+    cargo test -p aprender-serve --test qwen3_moe_gpu_hf_parity --features cuda -- --include-ignored
+    Asserts: cosine_similarity(apr_gpu_logits, hf_fp16_logits) ≥ 0.99
+  if_fails: |
+    Same as v1 contract's FALSIFY-QW3-MOE-FORWARD-004 if-fails:
+    HF FP16 fixture missing (M32d.1 not run yet) → run
+    `scripts/generate_qwen3_moe_fp16_logits.py` first, then re-run.
+    Otherwise, GPU kernel has a numerical bug — see PARITY-001 if_fails.
+
+- id: FALSIFY-QW3-MOE-GPU-THROUGHPUT-001
+  rule: 'M-GPU-MOE-3 discharges throughput target ≥150 tok/s'
+  prediction: |
+    `apr bench --model qwen3-coder-30b-a3b-instruct-q4_k_m --gpu --backend cuda`
+    over a 128-token median measurement window reports ≥150 tok/s on
+    RTX 4090.
+  test: |
+    apr bench /path/to/qwen3-coder-30b-a3b-instruct-q4_k_m.gguf \
+        --backend cuda --tokens 128 --runs 5 --json | jq '.median_tps'
+    Assert: ≥ 150
+  if_fails: |
+    GPU kernel correct but slow. Profile via `apr profile` (roofline)
+    and `apr trace`. Common failure modes:
+      - sparse expert dispatch not actually sparse (visiting all 128
+        experts per token, not just top-8)
+      - dequant happening per-element instead of per-tile
+      - kernel launch overhead per expert (should batch)
+      - DRAM bandwidth bottleneck (Q4_K bytes streaming inefficiently)
+
+- id: FALSIFY-QW3-MOE-GPU-INVARIANTS-001
+  rule: 'M-GPU-MOE-1 discharges output-shape + finiteness invariants (AC_GPU_MOE_002/003/004)'
+  prediction: |
+    A GPU forward pass on Qwen3-Coder-30B-A3B-Instruct-Q4_K_M produces
+    output that satisfies: router weights sum to 1.0 ± 1e-6 after
+    top-k renormalization (AC_GPU_MOE_002), output length equals
+    hidden_dim (AC_GPU_MOE_003), every output element is finite
+    (no NaN, no Inf — AC_GPU_MOE_004).
+  test: |
+    cargo test -p aprender-serve --test qwen3_moe_gpu_invariants --features cuda -- --include-ignored
+    Asserts:
+      (Σ router_weights[selected]) ∈ [1.0 - 1e-6, 1.0 + 1e-6]
+      output.len() == config.hidden_dim
+      output.iter().all(|v| v.is_finite())
+  if_fails: |
+    Different failure modes per assertion:
+      - router weight sum != 1.0 → top-k softmax + renormalization
+        bug; check that the scatter+normalize step picks ALL top-k
+        weights and divides by their pre-normalize sum.
+      - output.len() != hidden_dim → kernel writes wrong slice or
+        the workspace tensor shape is wrong.
+      - output contains NaN/Inf → numerical overflow, likely in
+        Q4_K dequantization (scale x quant + zero-point) or in the
+        SwiGLU SiLU activation.
+
+- id: FALSIFY-QW3-MOE-GPU-DETERMINISM-001
+  rule: 'GPU forward is deterministic across runs on same input + seed (mirrors apr-cpu-vs-gpu-output-parity-v1 FALSIFY-CPU-GPU-003 discharge)'
+  prediction: |
+    Two consecutive `apr run --backend cuda` invocations on the same
+    GGUF + same prompt + same seed produce byte-identical token streams
+    AND cosine ≥0.9999999 logit equivalence (per CLAUDE.md PMAT-216
+    GPU-parity mandate).
+  test: |
+    apr run <gguf> --backend cuda --prompt "Hi" --max-tokens 32 --seed 42 > out1.txt
+    apr run <gguf> --backend cuda --prompt "Hi" --max-tokens 32 --seed 42 > out2.txt
+    diff out1.txt out2.txt
+    Assert: empty diff, exit 0
+  if_fails: |
+    Non-deterministic GPU dispatch. Common causes: cuBLAS DEFAULT_MATH
+    instead of PEDANTIC_MATH (see GPUTRAIN-006 discharge precedent on
+    aprender main: cuBLAS DEFAULT_MATH → PEDANTIC_MATH in PR #1052),
+    atomic adds in reduction kernels (use deterministic warp-shuffle
+    reductions instead, per RmsNormGammaReduceKernel precedent), or
+    unsynchronized stream operations.
+
+- id: FALSIFY-QW3-MOE-GPU-MEMORY-001
+  rule: 'M-GPU-MOE-3 discharges memory-budget gate (AC_GPU_MOE_007)'
+  prediction: |
+    Live `apr run` against Qwen3-Coder-30B-A3B-Instruct-Q4_K_M on
+    RTX 4090 stays under 95% VRAM utilization.
+  test: |
+    apr run <gguf> --backend cuda --prompt "Hi" --max-tokens 128 &
+    sleep 5
+    nvidia-smi --query-gpu=memory.used,memory.total --format=csv,noheader,nounits | head -1
+    Assert: used / total ≤ 0.95
+  if_fails: |
+    Either (a) experts being EAGER-expanded instead of LAZY-FUSED, OR
+    (b) workspace/scratch buffers oversized, OR (c) KV cache larger
+    than expected. Check that expert tensors stay in their on-disk
+    Q4_K/Q6_K form on GPU (no FP32 expansion). The 17.5 GB → 70 GB
+    expansion is the documented OOM mode (qwen3-moe-forward-v1
+    v1.1.0 LAZY-FUSED-MATVEC decision).
+
+qa_gate:
+  id: F-QW3-MOE-GPU-001
+  name: Qwen3-MoE GPU Forward Contract
+  checks:
+  - cpu_gpu_cosine_parity_at_least_0.99
+  - hf_fp16_cosine_parity_at_least_0.99
+  - throughput_at_least_150_tokens_per_second
+  - vram_under_95_percent
+  - bytewise_determinism
+  pass_criteria: All 7 falsification tests pass — FALSIFY-QW3-MOE-GPU-001 + PARITY-001/002 + INVARIANTS-001 + DETERMINISM-001 + THROUGHPUT-001 + MEMORY-001
+  falsification: Swap quantized expert dispatch with EAGER FP32 expansion (will OOM on 24 GB VRAM, fail FALSIFY-QW3-MOE-GPU-MEMORY-001)
+
+
+kani_harnesses:
+- id: KANI-QW3-MOE-GPU-001
+  obligation: "Router weights sum to 1.0 +/- 1e-6 after top-k renormalization (AC_GPU_MOE_002)"
+  property: "For all input hidden_state h, router output satisfies sum(selected_w) in [1.0 - 1e-6, 1.0 + 1e-6] post-renormalization"
+  bound: 8
+  strategy: bounded_int
+  solver: cadical
+  harness: verify_gpu_router_weights_sum_to_one
+- id: KANI-QW3-MOE-GPU-002
+  obligation: "Output shape preserved: forward_gpu.output.len() == hidden_dim (AC_GPU_MOE_003)"
+  property: "For all input h with h.len() == hidden_dim, forward_qwen3_moe_gpu(h).len() == hidden_dim"
+  bound: 8
+  strategy: bounded_int
+  solver: cadical
+  harness: verify_gpu_output_shape_preserved
+

--- a/docs/specifications/aprender-train/ship-two-models-spec.md
+++ b/docs/specifications/aprender-train/ship-two-models-spec.md
@@ -1,7 +1,8 @@
 # Specification: Ship Two Models — Sovereign AI Stack Proof
 
 **Document ID:** SPEC-SHIP-TWO-001
-**Version:** 2.91.0
+**Version:** 2.92.0
+**Atomic next action (v2.92.0):** **§47 — SHIP-007 layer-0 attention bisection cascade STARTED (PRs #1450 + #1451 + #1452)** (see new §47 below). Three more PRs ship the §46.7(a) follow-up scaffold: (i) PR #1450 — new contract `trace-attn-sub-stages-v1.yaml` v1.0.0 PROPOSED → v1.1.0 PROPOSED (Toyota Way correction within the same branch). v1.0.0 originally claimed 5 new `SaveTensorStage` variants; live inspection of `inference_trace::save_tensor_stage` showed 3 already exist (`QPostRope`, `KPostRope`, `Attention`) — only **2 are truly new** (`AttnScores`, `AttnSoftmax`). v1.1.0 corrected scope to those 2 + documented the 9-stage `bisection_chain_layer_0` equation across parent + new stages. (ii) PR #1451 — `SaveTensorStage` enum gains the 2 new variants in canonical computation order (`KPostRope → AttnScores → AttnSoftmax → Attention`); 5 new tests for FALSIFY-ATTN-SUB-001 (round-trip, ordering, parser-list); 167/167 inference_trace tests PASS; `cargo check --workspace --lib` clean. (iii) PR #1452 — research evidence note documenting a **pre-existing capture gap discovered while authoring the wire-plan**: `QPostRope` + `KPostRope` are in the parent enum but have NO `emit()` calls in `forward_traced_with_plan`. The parent contract `apr-cli-trace-save-tensor-v1.yaml` v1.4.0 (FUNCTIONAL) silently overstates coverage for those 2 stages. The next-cycle FALSIFY-ATTN-SUB-002 PR will wire **4 stages, not 2**, closing this drift as a side effect. **MODEL-1 ship % unchanged at 91%** (cascade is scaffold; ship % moves when a falsifier flips DISCHARGED, expected at FALSIFY-ATTN-SUB-004 LIVE bisection in a future cycle). **MODEL-2 ship % unchanged at 57%**. Spec v2.91.0 → **v2.92.0**. Coverage tally unchanged this cycle (5 falsifier slots PARTIAL_ALGORITHM_LEVEL added to a NEW contract — these increment coverage when the contract YAML lands on main, which gates on PR #1450 merge).
 **Atomic next action (v2.91.0):** **§46 — v0.32.0 release-cut decision: HOLD, gated on SHIP-007 layer-0 attention bisection (PR #1448 in flight)** (see new §46 below). After landing the v2.90.0 §45 milestone (PR #1447 merged), the next decision was whether the 238-commit body of work since v0.31.2 warrants a `cargo publish` cut. **Verdict: HOLD.** The release-readiness audit found exactly one load-bearing blocker — SHIP-007 layer-0 attention divergence is empirically pinpointed (cos=0.99999995 attn_norm → 0.9966 attn_out per memory `2026-05-03 SHIP-007 finding`) but **not yet fixed**, so cutting v0.32.0 today would crates.io-ship a binary where `apr run` on a 7B GPU teacher still emits gibberish unless the user passes `--no-gpu`. The §41-§45 jidoka armor makes the failure visible + fail-closed (which is shippable behaviour), but a user-facing `## [0.32.0]` headline that reads "5/5 DISCHARGE on apr-cpu-vs-gpu-output-parity-v1" implies the GPU correctness hole is closed when in truth it is only contained. Two pre-flight artifacts shipped along with this decision: (i) PR #1448 fills the empty `[Unreleased]` CHANGELOG section with the full session body of work; (ii) PR #1448 also repairs the `bash scripts/check_readme_claims.sh` drift gate which was FAILING on `main` (1096→1105 contracts, 79→80 CLI commands). Per `feedback_post_publish_qa_required.md`, the next cut also requires `cargo install aprender --force` + `/dogfood` GO verdict — v0.31.1 was yanked for skipping that gate. Spec v2.90.0 → **v2.91.0**. Coverage tally unchanged (no falsifiers flipped this cycle; this amendment is a release-decision audit record).
 **Atomic next action (v2.90.0):** **§45 — `apr-cpu-vs-gpu-output-parity-v1` 5/5 LIVE DISCHARGE milestone (PRs #1445 + #1446)** (see new §45 below). Two live smokes on canonical Qwen2.5-Coder-7B teacher (RTX 4090, binary built from main @ 817ec0553) closed every falsifier in the parity contract: (i) PR #1445 — default-mode `apr run` smoke fired all three jidoka tags in stderr (CUDA cos=-0.005 + argmax 8127≠334; `Backend: wgpu (Vulkan)`; wgpu cos=0.766 < 0.99) and produced correct CPU output "2 + 2 equals 4." → FALSIFY-CPU-GPU-005 PARTIAL_ALGORITHM_LEVEL → DISCHARGED. (ii) PR #1446 — `--no-gpu` smoke produced 9.02s CPU-only run with zero GPU log lines + correct output → joined #1445 evidence to flip FALSIFY-CPU-GPU-001/002/003 PARTIAL → DISCHARGED + FALSIFY-CPU-GPU-004 FUNCTIONAL → DISCHARGED. **All 5/5 falsifiers in apr-cpu-vs-gpu-output-parity-v1 are now DISCHARGED**; the contract is COMPLETE. Coverage tally: 15+37 → **20+32** (+5 in this 2-PR cycle, the largest single-cycle coverage flip of the SHIP-TWO program). MODEL-1 ship % nudges 89% → **91%** (the silent-gibberish loophole that v5/§40 originated is now both implemented closed AND end-to-end live-verified on the canonical broken-GPU model). The §41 → §43 → §44 → §45 jidoka chain is contract-complete; only the underlying SHIP-007 GPU kernel root-cause fix per §40 remains for full GPU-shipability of MODEL-1. Spec v2.89.0 → **v2.90.0**. Contract apr-cpu-vs-gpu-output-parity-v1 v1.3.0 → v1.5.0 ACTIVE.
 **Atomic next action (v2.89.0):** **§44 — FALSIFY-CPU-GPU-005 part b implementation + distill-train 9/9 sweep close (PRs #1442 + #1443)** (see new §44 below). Today's continuation cycle landed two more PRs across both ship tracks: (i) PR #1442 — FALSIFY-CPU-GPU-005 part b live implementation: ~70 LOC inline at `try_apr_wgpu_inference` running a CPU-vs-wgpu cosine probe on the BOS token before the autoregressive loop, with a separate tiny probe_kv_caches (max_seq=2) so the real cache stays uncontaminated; emits `WGPU_FALLBACK_LOG_PREFIX` and returns None on cosine < 0.99 OR any probe error (fail-closed). Contract `apr-cpu-vs-gpu-output-parity-v1` v1.2.0 → v1.3.0 ACTIVE. (ii) PR #1443 — closes the last three falsifiers in `apr-cli-distill-train-v1`: TRAIN-007 + TRAIN-008 PARTIAL_ALGORITHM_LEVEL via existing tests (`pv validate` + `cli_commands::test_no_unregistered_commands`), and TRAIN-009 explicitly marked BLOCKER_FIXTURE_ABSENT pending the §35 real-training implementation. **All 9 TRAIN-* falsifiers now have explicit `algorithm_evidence` blocks** (8× PARTIAL + 1× BLOCKER); the distill contract has reached terminal-binding state — no further drift gaps remain. **MODEL-1 ship % nudges 88% → 89%** (wgpu silent-gibberish loophole now closed at the init boundary, symmetric to the CUDA `parity_gate` from §41); **MODEL-2 ship % nudges 56% → 57%** (last falsifier-binding gap closed for the distill contract; only remaining lever is §35 real-training implementation, multi-PR scope). Spec v2.88.0 → **v2.89.0**. Coverage tally 15+35 → **15+37** (+2 PARTIAL_ALGORITHM_LEVEL closed; TRAIN-009 explicitly blocked, not counted).
@@ -4467,6 +4468,120 @@ Unchanged from §29 because PR E did not land. Next-session agenda: do the §30.
 Per `feedback_fix_root_cause_never_route_around.md`: the §28 fix would have route-around'd a real bug because the named site (matmul kernel) is not where the divergence originates. The empirical refutation in §30 IS the work that protects the next attempt from shipping a no-op. This refutation is itself a coverage-incrementing artifact (it falsifies a hypothesis), even though no PARTIAL flips to DISCHARGED.
 
 The Toyota Way fix is to bisect upstream, not to flip the kernel call.
+
+## §47. SHIP-007 layer-0 attention bisection cascade STARTED (2026-05-04)
+
+After §46 declared the v0.32.0 cut HOLD-gated on SHIP-007 layer-0 attention, the §46.7(a) follow-up cascade kicked off the same day with three PRs (#1450 + #1451 + #1452). This section records what landed, the Toyota Way correction caught mid-cascade, and the wire-plan for the next cycle's implementation PR.
+
+### 47.1 Cascade roadmap
+
+The full SHIP-007 layer-0 attention bisection requires this PR sequence:
+
+| # | PR | What | Discharge status |
+|---|----|------|-------|
+| 1 | #1450 | Contract `trace-attn-sub-stages-v1.yaml` v1.1.0 PROPOSED | 5 falsifiers algorithm-bound (4× PARTIAL + 1× BLOCKER) |
+| 2 | #1451 | Enum extension: 2 new `SaveTensorStage` variants | FALSIFY-ATTN-SUB-001 PARTIAL_ALGORITHM_LEVEL |
+| 3 | #1452 | Research evidence note (pre-existing capture gap) | No falsifier flip; documentation only |
+| 4 | (next) | `forward_traced_with_plan` wires 4 sub-stages | FALSIFY-ATTN-SUB-002 algorithm-bind + drift fix |
+| 5 | (next) | `apr diff --values` recognizes new stages | FALSIFY-ATTN-SUB-003 |
+| 6 | (next) | HF FP16 oracle script extension | unblocks FALSIFY-ATTN-SUB-004 |
+| 7 | (next) | Live RTX 4090 bisection on canonical 7B teacher | FALSIFY-ATTN-SUB-004 → DISCHARGED |
+| 8 | (next) | SHIP-007 root-cause fix at the bisected sub-stage | unblocks MODEL-1 GPU shipability |
+
+§47 captures the first 3 (scaffold). §48+ will capture later steps as they land.
+
+### 47.2 What landed
+
+**PR #1450** — Contract authoring:
+
+- Initial v1.0.0 claimed 5 new variants needed: `QPostRope`, `KPostRope`, `AttnScores`, `AttnSoftmax`, `AttnVOut`.
+- Mid-cascade live source inspection (per `feedback_no_guessing.md`) showed `QPostRope`, `KPostRope`, and `Attention` (the latter semantically equivalent to my proposed "AttnVOut") **already exist** in the parent `SaveTensorStage` enum.
+- Toyota Way correction within same branch: v1.0.0 → v1.1.0, scope reduced to 2 truly-new variants (`AttnScores` between Q·Kᵀ and softmax; `AttnSoftmax` between softmax-mask and ·V).
+- v1.1.0 also added the `bisection_chain_layer_0` equation pinning the **9-element cosine sequence** that FALSIFY-ATTN-SUB-004 will measure on RTX 4090.
+
+**PR #1451** — Enum extension:
+
+- Adds `AttnScores` + `AttnSoftmax` to `SaveTensorStage` in canonical computation order (`KPostRope → AttnScores → AttnSoftmax → Attention`).
+- Updates `ALL` (18 → 20), `canonical_name`, `FromStr`, plus `is_per_layer_count` test (16+2 per-layer + 2 whole-model = 20).
+- 5 new tests for FALSIFY-ATTN-SUB-001: round-trip for each new name, full 7-stage attention block ordering, 2-stage parser-list, 9-stage full layer-0 chain parser-list.
+- `cargo test -p aprender-serve --lib inference_trace` 167/167 PASS; `cargo check --workspace --lib` clean.
+
+**PR #1452** — Research evidence:
+
+- Authored while inspecting `forward_traced_with_plan` to scope FALSIFY-ATTN-SUB-002.
+- Discovered: `QPostRope` + `KPostRope` are in the enum but have **no `emit()` call**. Their tensors `q_all` + `k_all` are computed at lines 130-131 of `apr_transformer/inference.rs` but never captured.
+- The parent contract `apr-cli-trace-save-tensor-v1.yaml` v1.4.0 (FUNCTIONAL) silently overstates coverage for those 2 stages.
+- Records the wire-plan that the next-cycle FALSIFY-ATTN-SUB-002 PR will close: 4 stages (the 2 new + 2 pre-existing gaps), not 2.
+
+### 47.3 The Toyota Way correction in detail
+
+v1.0.0 of `trace-attn-sub-stages-v1.yaml` was the day's first defect. Caught on the next iteration, mid-cascade, before any implementation PR depended on the wrong scope.
+
+| Aspect | v1.0.0 (defective) | v1.1.0 (corrected) |
+|---|---|---|
+| New variants claimed | 5 | 2 |
+| Implementation PR LOC estimate | ~150 | ~60 (40% reduction) |
+| Pre-existing gap acknowledged | No | Yes (`QPostRope`/`KPostRope` are in enum but unwired) |
+| `bisection_chain_layer_0` equation | Vague | 9-element cosine sequence pinned |
+
+The cost-of-defect was paid at the contract layer (cheapest place). Correction was a YAML-only re-author, no code rolled back.
+
+Per `feedback_no_guessing.md`: "use pmat query / apr trace / contracts, not speculation". The v1.0.0 defect was authored from the parent contract's prose description without checking the live enum. v1.1.0 fixed that.
+
+### 47.4 Pre-existing parent contract drift
+
+`apr-cli-trace-save-tensor-v1.yaml` v1.4.0 is FUNCTIONAL. Its `cli_signature` enumerates 18 stages including `QPostRope` + `KPostRope`. Its `forward_traced_with_plan` claim is that all 18 stages emit at the documented capture points.
+
+**Empirically false.** `forward_traced_with_plan` has no `emit(QPostRope, ...)` or `emit(KPostRope, ...)` call. A user passing `--save-tensor q_post_rope` gets a clean exit with no file written — silent failure.
+
+This is a parent-contract drift, not a regression introduced by the SHIP-007 cascade. The cascade discovered it; the next-cycle FALSIFY-ATTN-SUB-002 PR will close it as a free side-effect by wiring the 2 missing stages alongside the 2 new ones. Per `feedback_toyota_way_all_defects.md`: all defects are mine. The parent contract bump (v1.4.0 → v1.5.0) will be done in the same PR that closes the wires.
+
+### 47.5 Net effects
+
+- Spec v2.91.0 → **v2.92.0** (cascade-started record).
+- Contract `trace-attn-sub-stages-v1.yaml` v1.0.0 → v1.1.0 PROPOSED (PR #1450 — pending merge).
+- `SaveTensorStage` enum: 18 → 20 variants (PR #1451 — pending merge).
+- 5 new falsifiers algorithm-bound (4× PARTIAL_ALGORITHM_LEVEL + 1× BLOCKER_FIXTURE_ABSENT) once #1450 merges.
+- **MODEL-1 ship %**: unchanged at 91% (scaffold; ship % moves at FALSIFY-ATTN-SUB-004 LIVE DISCHARGE in a future cycle).
+- **MODEL-2 ship %**: unchanged at 57%.
+- Coverage tally: unchanged this cycle (the 5 new PARTIAL_ALGORITHM_LEVEL increments will land when PR #1450 lands the YAML).
+
+### 47.6 Open follow-ups (next-cycle priorities)
+
+In ranked-leverage order:
+
+1. **FALSIFY-ATTN-SUB-002 implementation PR** — wires 4 stages (`QPostRope`, `KPostRope`, `AttnScores`, `AttnSoftmax`) into `forward_traced_with_plan`. Closes the parent-contract drift as a side-effect. Per the wire-plan in `evidence/ship-007-layer0-attn-bisection-2026-05-04/forward-traced-research.md`: insertion points are post line 133 for Q/K post-rope; inside head loop lines 152/160 for scores/softmax with a per-head accumulator. Expected ~60 LOC + 4-5 unit tests + 1 backward-compat test.
+
+2. **FALSIFY-ATTN-SUB-003 — `apr diff --values` recognition** — generic APRT path already exists; verify the 2 new stage suffixes load + diff cleanly. Likely 1 test + 0 LOC change if the loader is per-stage-agnostic.
+
+3. **HF FP16 oracle extension** — extend `scripts/ship-007-layer0-oracle/` (PR #1423) to capture `attn_scores` + `attn_softmax` reference tensors. Pre-condition for FALSIFY-ATTN-SUB-004 LIVE discharge.
+
+4. **FALSIFY-ATTN-SUB-004 LIVE bisection** — `apr diff` on the 9-stage cosine sequence on RTX 4090. Identifies the SHIP-007 sub-stage. **This is the load-bearing predicate** that converts pinpoint-to-bisected-sub-stage. Expected to flip 1 sub-stage from "correct" to "wrong" — likely the QkvMatmul→QPostRope transition (since memory `2026-05-03 SHIP-007 finding` already pins divergence inside attention block).
+
+5. **SHIP-007 root-cause fix** — once SUB-004 names the bug-bearing sub-stage, the fix PR scopes to that one sub-stage's algorithm. Expected 100-300 LOC.
+
+After step 5, MODEL-1 ship % moves 91% → 95%+ pending live `apr run` correctness on default (GPU) path.
+
+### 47.7 Five Whys — why amend after only 3 PRs
+
+1. **Why amend now (3 PRs) and not after 5?**
+   The §41-§46 cadence rule was "one amendment per ≥3-PR cycle". Today's 3 PRs hit the threshold exactly. Holding for more would muddy the audit story (the 5-step bisection cascade is a single conceptual unit and should be split into start-state and discharge-state amendments).
+
+2. **Why split into §47 (cascade started) and a future §48 (cascade discharged)?**
+   The Toyota Way correction (v1.0.0 → v1.1.0) is a fact worth pinning. If §47 waited for cascade discharge, the audit would lose the mid-cascade course-correction event.
+
+3. **Why pin the parent contract drift in §47 rather than amend `apr-cli-trace-save-tensor-v1.yaml` directly?**
+   The parent contract is on FUNCTIONAL; bumping it is a minor revision. §47 records the drift for posterity; the actual bump happens in the next-cycle implementation PR that closes the drift as a side-effect.
+
+4. **Why not include FALSIFY-ATTN-SUB-002 implementation in this cycle?**
+   Single-piece flow (Toyota Way). Adding a 5th PR to a 4-PR train slows merge throughput. The implementation requires a small refactor of the score/softmax accumulator loop in `inference.rs` — better landed cleanly off main once #1451 merges.
+
+5. **Why not also amend `apr-cli-trace-save-tensor-v1.yaml` to add `q_post_rope`/`k_post_rope` evidence?**
+   The drift is already pinned in §47 + the research evidence file. Bumping the parent contract requires either (a) the wire fix landing first (FUNCTIONAL evidence), or (b) PROPOSED→ACTIVE downgrade (which loses the FUNCTIONAL claim entirely). Cleaner to bump in the next-cycle PR that ships the wire.
+
+### 47.8 Spec amendment cadence preserved
+
+Seven §-amendments since 2026-05-03 (§41 → §42 → §43 → §44 → §45 → §46 → §47). Each ≥1-PR cycle, each preserving the audit story for a future maintainer. The cadence rule of "one amendment per ≥3-PR cycle OR per landmark milestone" continues to hold: §47 records a 3-PR cycle scaffold milestone.
 
 ## §46. v0.32.0 release-cut decision — HOLD, gated on SHIP-007 layer-0 attention bisection (2026-05-04)
 


### PR DESCRIPTION
## Summary

Spec **v2.91.0 → v2.92.0** records that the §46.7(a) follow-up cascade kicked off the same day with three PRs (#1450 + #1451 + #1452).

## What §47 records

| Subsection | Content |
|---|---|
| 47.1 | 8-step cascade roadmap (this amendment captures steps 1-3) |
| 47.2 | What landed in PRs #1450 + #1451 + #1452 |
| 47.3 | **Toyota Way correction in detail** — v1.0.0 → v1.1.0 mid-cascade |
| 47.4 | Pre-existing parent contract drift (QPostRope/KPostRope unwired) |
| 47.5 | Net effects |
| 47.6 | Open follow-ups (5-step ranked priority list) |
| 47.7 | Five Whys |
| 47.8 | Spec amendment cadence preserved |

## Net effects

- Spec v2.91.0 → **v2.92.0**
- MODEL-1 ship %: unchanged at 91% (cascade is scaffold)
- MODEL-2 ship %: unchanged at 57%
- Coverage tally: unchanged this cycle (increments when PR #1450 YAML lands)

## Cascade roadmap captured

| # | PR | Discharge status |
|---|----|------|
| 1 | #1450 | 5 falsifiers algorithm-bound |
| 2 | #1451 | FALSIFY-ATTN-SUB-001 PARTIAL_ALGORITHM_LEVEL |
| 3 | #1452 | Research evidence (no falsifier flip) |
| 4-8 | (next) | FALSIFY-ATTN-SUB-002..004 + SHIP-007 root-cause fix |

## Pre-existing drift discovered + recorded

Researching the wire-plan surfaced that \`QPostRope\` + \`KPostRope\` are in the parent enum but have NO \`emit()\` calls in \`forward_traced_with_plan\`. The parent contract \`apr-cli-trace-save-tensor-v1.yaml\` v1.4.0 (FUNCTIONAL) silently overstates coverage. Next-cycle FALSIFY-ATTN-SUB-002 PR closes the drift as a free side-effect.

## Test plan

- [ ] CI green on required gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)