### PR TITLE
fix(apr-qa): strengthen Golden Output gate with statistical gibberish detection

### DIFF
--- a/crates/apr-cli/src/commands/fields.rs
+++ b/crates/apr-cli/src/commands/fields.rs
@@ -81,6 +81,46 @@
     }
 
     #[test]
+    fn verify_output_rejects_qwen2_05b_observed_gibberish() {
+        // Captured from `apr run qwen2.5-coder-0.5b-instruct-imported.apr --prompt "Hello"`
+        // (2026-05-04). Pre-fix this gibberish was passing the Golden Output gate because the
+        // hardcoded garbage list missed CJK/Polish/diacritic byte fragments.
+        let observed =
+            "ìłľê°Ģ udaÅĤo udaÅĤoá¿Ĩëĸ» Ãĥå udaÅĤo ÃĥÂłÂłÂłÂł zwiÄħzku";
+        let result = verify_output(observed, "FALSIFY-QA-GIBBERISH-001", &["Hello", "!"]);
+        assert!(
+            matches!(result, OutputVerification::Fail { .. }),
+            "Qwen2-0.5B observed gibberish must be rejected"
+        );
+    }
+
+    #[test]
+    fn verify_output_rejects_repeated_fragment() {
+        let result = verify_output(
+            "udaÅĤo udaÅĤo udaÅĤo udaÅĤo end",
+            "FALSIFY-QA-GIBBERISH-002",
+            &["end"],
+        );
+        assert!(
+            matches!(result, OutputVerification::Fail { .. }),
+            "4x-repeated fragment must trip the loop-pathology signal"
+        );
+    }
+
+    #[test]
+    fn verify_output_accepts_normal_english() {
+        let result = verify_output(
+            "The answer is 4. Hello world!",
+            "FALSIFY-QA-GIBBERISH-003",
+            &["4"],
+        );
+        assert!(
+            matches!(result, OutputVerification::Pass),
+            "Normal ASCII English must pass"
+        );
+    }
+
+    #[test]
     fn verify_output_rejects_null_bytes() {
         let result = verify_output("Hello\0World", "test-005", &["Hello"]);
         assert!(matches!(result, OutputVerification::Fail { .. }));

--- a/crates/apr-cli/src/commands/output_verification.rs
+++ b/crates/apr-cli/src/commands/output_verification.rs
@@ -291,6 +291,64 @@ pub enum OutputVerification {
     },
 }
 
+/// Statistical gibberish detection — returns Some(reason) if output is junk.
+///
+/// Three signals; any one triggers rejection:
+/// 1. **Non-ASCII saturation**: For ASCII-prompt completions, > 60% non-ASCII
+///    bytes is a strong gibberish indicator. English+code answers are ASCII-heavy.
+/// 2. **Repeated-fragment detection**: A 4+ byte substring appearing 3+ times
+///    consecutively (e.g. "udaÅĤo udaÅĤo udaÅĤo") flags BPE/loop pathologies.
+/// 3. **Replacement-character density**: > 1 U+FFFD per 32 chars indicates
+///    repeated UTF-8 decode failures.
+///
+/// All thresholds are conservative — coherent English/code outputs pass cleanly,
+/// while the Qwen2-0.5B observed gibberish ("ëĸ» Ãĥ pÃ³Åº zwiÄħzku") is rejected.
+fn detect_gibberish(output: &str, test_id: &str) -> Option<String> {
+    // Signal 1: non-ASCII saturation
+    let total = output.chars().count();
+    if total >= 16 {
+        let non_ascii = output.chars().filter(|c| !c.is_ascii()).count();
+        let ratio = non_ascii as f64 / total as f64;
+        if ratio > 0.6 {
+            return Some(format!(
+                "{test_id}: gibberish (non-ASCII ratio {:.1}% > 60%)",
+                ratio * 100.0
+            ));
+        }
+    }
+
+    // Signal 2: 4+ byte fragment repeated 3+ times in a row
+    let bytes = output.as_bytes();
+    if bytes.len() >= 12 {
+        let max_frag = 16.min(bytes.len() / 3);
+        for frag_len in 4..=max_frag {
+            let mut i = 0;
+            while i + frag_len * 3 <= bytes.len() {
+                let frag = &bytes[i..i + frag_len];
+                if &bytes[i + frag_len..i + 2 * frag_len] == frag
+                    && &bytes[i + 2 * frag_len..i + 3 * frag_len] == frag
+                {
+                    let preview = String::from_utf8_lossy(frag).into_owned();
+                    return Some(format!(
+                        "{test_id}: gibberish (fragment {preview:?} repeats 3+ times)"
+                    ));
+                }
+                i += 1;
+            }
+        }
+    }
+
+    // Signal 3: replacement-character density
+    let fffd_count = output.matches('\u{FFFD}').count();
+    if fffd_count > 0 && total >= 32 && fffd_count * 32 > total {
+        return Some(format!(
+            "{test_id}: gibberish (U+FFFD density {fffd_count}/{total} > 1/32)"
+        ));
+    }
+
+    None
+}
+
 /// Verify output is correct: not empty, no garbage, contains expected answer
 /// (PMAT-QA-PROTOCOL-001 §7.4)
 ///
@@ -319,6 +377,15 @@ pub fn verify_output(
                 reason: format!("{test_id}: Garbage detected: '{pattern}'"),
             };
         }
+    }
+
+    // Check 2.5: Statistical gibberish detection (Toyota Way root-cause fix).
+    // The fixed garbage-pattern list above misses new defect classes — e.g.
+    // Qwen2-0.5B-Instruct emits CJK/Polish/diacritic byte-fragments like
+    // "udaÅĤo", "ëĸ»", "zwiÄħzku" that no prior pattern catches. We add three
+    // statistical signals; ANY positive trip rejects the output.
+    if let Some(reason) = detect_gibberish(output, test_id) {
+        return OutputVerification::Fail { reason };
     }
 
     // Check 3: BPE artifacts (null bytes, excessive control chars)


### PR DESCRIPTION
## Summary

- `apr qa` Golden Output gate had a hardcoded 4-string garbage list (`["\u{FFFD}", "[UNK]", "akunji", "olumbia"]`) that missed every new gibberish class
- Added `detect_gibberish` with 3 statistical signals (non-ASCII ratio > 60%, 4+ byte fragment repeated 3+ times, U+FFFD density)
- Captured Qwen2-0.5B observed gibberish (\"udaÅĤo\", \"ëĸ»\", \"zwiÄħzku\") as drift-prevention test cases

## Five Whys (in commit msg ddb6a1a42)

1. Why did defective Qwen2-0.5B-Instruct inference ship undetected? `apr qa` Golden Output PASSED.
2. Why did Golden Output PASS gibberish? `verify_output` garbage check used 4 hardcoded strings.
3. Why hardcoded? Patterns came from one-off past incidents (LAYOUT-002 \"olumbia\") and were never generalized.
4. Why never generalized? No statistical sanity signal (non-ASCII ratio, repeated-fragment, FFFD density).
5. Why dangerous? New gibberish classes sail through — the gate became a falsifying liar.

## Honest scope

- ✅ Strengthens the GATE so future regressions of this class FAIL
- ✅ 14/14 unit tests pass, including 3 new ones using real captured gibberish
- ⚠️ Does NOT yet flip the existing 0.5B `apr qa` run because the gate's internal 512-token generation produces different (apparently sufficiently-ASCII) output than the manual 16-token test that captured the gibberish
- ⚠️ Underlying Qwen2-0.5B short-prompt inference defect still exists; downstream bisection PR follows now that the gate can no longer hide it

## Test plan

- [x] \`cargo test -p apr-cli --lib --features inference verify_output\` — 14/14 pass
- [x] \`cargo build --release -p apr-cli --features cuda --bin apr\` — clean
- [x] Pre-commit quality gates green (per local hook)
- [ ] CI \`ci / gate\` and \`workspace-test\` (pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)