### PR TITLE
feat(aprender-serve): moe_ffn_forward_layer_cuda — M-GPU-MOE-1.1.1

### DIFF
--- a/crates/aprender-serve/src/gguf/cuda/expert_swiglu_cuda.rs
+++ b/crates/aprender-serve/src/gguf/cuda/expert_swiglu_cuda.rs
@@ -1,0 +1,198 @@
+// crates/aprender-serve/src/gguf/cuda/expert_swiglu_cuda.rs
+//
+// M-GPU-MOE-1.1.0 — per-expert SwiGLU GPU helper for forward_qwen3_moe_cuda.
+//
+// Per qwen3-moe-forward-gpu-v1 v1.1.0 option D (PR #1462 squash 449540714):
+// the GPU MoE forward path lives on OwnedQuantizedModelCuda. This file
+// provides the inner-most building block — the per-expert SwiGLU FFN
+// computed on GPU via the existing CudaExecutor primitives.
+//
+// Why a separate helper
+// =====================
+//
+// Mirrors the CPU staging of qwen3-moe-forward-v1 M32c.2.2.* — the
+// per-expert byte slicer (M32c.2.2.0) and per-expert SwiGLU
+// (M32c.2.2.1) landed in separate sub-milestones BEFORE the full
+// `moe_ffn_forward_layer` integration (M32c.2.2.2.0). Same shape on
+// the GPU side: helper first (M-GPU-MOE-1.1.0), full integration in
+// the wrapper method (M-GPU-MOE-1.1.1+).
+//
+// Numerical equivalence
+// =====================
+//
+// The CPU sibling `moe_ffn_forward_layer` (qwen3_moe_load.rs:363)
+// computes per expert:
+//
+//   gate_out      = q4k_matmul_row_major(gate_W,  hidden)
+//   up_out        = q4k_matmul_row_major(up_W,    hidden)
+//   ffn_inner[i]  = silu(gate_out[i]) * up_out[i]   for i in [0, intermediate)
+//   expert_out    = q6k_matmul_row_major(down_W,   ffn_inner)
+//
+// where silu(x) = x · sigmoid(x) = x / (1 + e^(-x)).
+//
+// This helper performs the same sequence on GPU using
+// CudaExecutor::q4k_matvec for gate_proj/up_proj and
+// CudaExecutor::q6k_gemv for down_proj. The CPU↔GPU equivalence
+// gate (FALSIFY-QW3-MOE-GPU-PARITY-001 cosine ≥0.99) is asserted at
+// the integration layer (M-GPU-MOE-1.2), not here — but this helper
+// is the load-bearing kernel-call site that gate validates.
+
+// Imports inherited from parent forward.rs (RealizarError, Result).
+// CudaExecutor is reachable via `crate::cuda::CudaExecutor` at use sites.
+// This file is included via uses.rs include!() chain.
+
+/// Per-expert SwiGLU FFN on GPU — single-expert, single-token.
+///
+/// Mirrors the CPU per-expert SwiGLU body in
+/// `gguf/qwen3_moe_load.rs::moe_ffn_forward_layer` (the inner loop
+/// over selected experts) but routes the matmuls through the
+/// CudaExecutor.
+///
+/// # Arguments
+///
+/// * `executor` — owned mutable reference to the CudaExecutor (cache-
+///   aware kernel dispatch + cuBLAS handle).
+/// * `gate_bytes` — raw Q4_K bytes for this expert's gate_proj weight,
+///   shape `[intermediate, hidden_dim]` row-major. Obtain via
+///   `expert_byte_slice(layer.gate_exps, data, expert_id, num_experts)`.
+/// * `up_bytes` — raw Q4_K bytes for this expert's up_proj weight,
+///   same shape as gate.
+/// * `down_bytes` — raw Q6_K bytes for this expert's down_proj weight,
+///   shape `[hidden_dim, intermediate]` row-major.
+/// * `hidden` — input activation, length `hidden_dim`.
+/// * `hidden_dim` — model hidden dimension.
+/// * `intermediate` — MoE FFN intermediate dimension (Qwen3-Coder-30B
+///   uses 768).
+///
+/// # Returns
+///
+/// `Vec<f32>` of length `hidden_dim` — this expert's contribution
+/// before weighted aggregation across selected experts.
+///
+/// # Errors
+///
+/// Propagates errors from `CudaExecutor::q4k_matvec` and
+/// `CudaExecutor::q6k_gemv`. Returns `RealizarError::InvalidShape`
+/// on dimensional mismatches.
+///
+/// # Numerical
+///
+/// silu(x) = x * sigmoid(x) computed in f32 elementwise on CPU
+/// between the two GPU dispatches. The element-wise multiplication
+/// `silu(gate) * up` is also CPU. Only the matmuls go to GPU.
+/// This is the "naive per-expert dispatch" baseline of the contract's
+/// Sub-extension 2 implementation_stages.M-GPU-MOE-1.1.0; the fused
+/// dequant+matmul + sparse expert batching path is M-GPU-MOE-3.
+#[cfg(feature = "cuda")]
+pub(crate) fn expert_swiglu_cuda(
+    executor: &mut crate::cuda::CudaExecutor,
+    gate_bytes: &[u8],
+    up_bytes: &[u8],
+    down_bytes: &[u8],
+    hidden: &[f32],
+    hidden_dim: usize,
+    intermediate: usize,
+) -> Result<Vec<f32>> {
+    if hidden.len() != hidden_dim {
+        return Err(RealizarError::InvalidShape {
+            reason: format!(
+                "expert_swiglu_cuda: hidden.len() = {} but hidden_dim = {}",
+                hidden.len(),
+                hidden_dim
+            ),
+        });
+    }
+    if hidden_dim == 0 || intermediate == 0 {
+        return Err(RealizarError::InvalidShape {
+            reason: format!(
+                "expert_swiglu_cuda: hidden_dim ({hidden_dim}) and intermediate \
+                 ({intermediate}) must both be > 0"
+            ),
+        });
+    }
+
+    // 1. gate_out = q4k_matmul(gate_W, hidden)   [intermediate]
+    let mut gate_out = vec![0.0f32; intermediate];
+    executor
+        .q4k_matvec(
+            gate_bytes,
+            hidden,
+            &mut gate_out,
+            intermediate as u32,
+            hidden_dim as u32,
+        )
+        .map_err(|e| RealizarError::UnsupportedOperation {
+            operation: "expert_swiglu_cuda::gate_q4k_matvec".to_string(),
+            reason: format!("{e}"),
+        })?;
+
+    // 2. up_out = q4k_matmul(up_W, hidden)   [intermediate]
+    let mut up_out = vec![0.0f32; intermediate];
+    executor
+        .q4k_matvec(
+            up_bytes,
+            hidden,
+            &mut up_out,
+            intermediate as u32,
+            hidden_dim as u32,
+        )
+        .map_err(|e| RealizarError::UnsupportedOperation {
+            operation: "expert_swiglu_cuda::up_q4k_matvec".to_string(),
+            reason: format!("{e}"),
+        })?;
+
+    // 3. ffn_inner[i] = silu(gate[i]) * up[i]   element-wise CPU
+    //    silu(x) = x * sigmoid(x) = x / (1 + e^(-x))
+    let mut ffn_inner = vec![0.0f32; intermediate];
+    for i in 0..intermediate {
+        let g = gate_out[i];
+        let silu_g = g / (1.0 + (-g).exp());
+        ffn_inner[i] = silu_g * up_out[i];
+    }
+
+    // 4. expert_out = q6k_matmul(down_W, ffn_inner)   [hidden_dim]
+    let mut expert_out = vec![0.0f32; hidden_dim];
+    executor
+        .q6k_gemv(
+            down_bytes,
+            &ffn_inner,
+            &mut expert_out,
+            hidden_dim as u32,
+            intermediate as u32,
+        )
+        .map_err(|e| RealizarError::UnsupportedOperation {
+            operation: "expert_swiglu_cuda::down_q6k_gemv".to_string(),
+            reason: format!("{e}"),
+        })?;
+
+    Ok(expert_out)
+}
+
+#[cfg(test)]
+mod expert_swiglu_cuda_tests {
+    use super::*;
+
+    /// Compilation gate for signature drift.
+    #[test]
+    fn expert_swiglu_cuda_signature_drift_gate() {}
+
+    /// Validate input shape rejection — InvalidShape on len mismatch.
+    #[cfg(feature = "cuda")]
+    #[test]
+    fn expert_swiglu_cuda_rejects_mismatched_hidden_len() {
+        if let Ok(mut executor) = crate::cuda::CudaExecutor::new(0) {
+            let dummy_bytes = vec![0u8; 144];
+            let hidden = vec![1.0f32; 5];
+            let result = expert_swiglu_cuda(
+                &mut executor,
+                &dummy_bytes,
+                &dummy_bytes,
+                &dummy_bytes,
+                &hidden,
+                10,
+                4,
+            );
+            assert!(matches!(result, Err(RealizarError::InvalidShape { .. })));
+        }
+    }
+}

--- a/crates/aprender-serve/src/gguf/cuda/moe_ffn_forward_layer_cuda.rs
+++ b/crates/aprender-serve/src/gguf/cuda/moe_ffn_forward_layer_cuda.rs
@@ -1,0 +1,163 @@
+// crates/aprender-serve/src/gguf/cuda/moe_ffn_forward_layer_cuda.rs
+//
+// M-GPU-MOE-1.1.1 — single-layer MoE FFN forward on GPU. Mirrors the
+// CPU sibling `gguf/qwen3_moe_load.rs::moe_ffn_forward_layer` step-
+// for-step, replacing only the per-expert SwiGLU body with a call
+// into `expert_swiglu_cuda` (M-GPU-MOE-1.1.0).
+//
+// Per qwen3-moe-forward-gpu-v1 v1.1.0 option D (PR #1462 squash
+// 449540714): GPU MoE forward path lives on OwnedQuantizedModelCuda
+// and reuses existing CudaExecutor primitives, with router/softmax/
+// top-k/aggregation on CPU (small per-token operations) and per-
+// expert matmuls on GPU.
+//
+// Imports inherited from parent forward.rs (RealizarError, Result).
+// Use fully-qualified paths for qwen3_moe_load items to avoid the
+// "must be defined only once" namespace conflict from the include!() chain.
+
+/// GPU sibling of `moe_ffn_forward_layer` — single-layer MoE FFN
+/// forward for one token.
+///
+/// # Architecture (option D, naive per-expert dispatch)
+///
+/// 1. **Router (CPU)**: `logits = router_F32 @ hidden`, softmax + top-k
+///    + renormalize. Router is small (~1 MB for Qwen3-Coder-30B's
+///    128×2048 router); CPU is fast enough.
+/// 2. **Per-expert SwiGLU (GPU via `expert_swiglu_cuda`)**: for each
+///    of the top-k selected experts, slice the per-expert Q4_K/Q6_K
+///    bytes from the on-disk GGUF and dispatch the gate/up/down
+///    matmuls via existing CudaExecutor primitives.
+/// 3. **Weighted aggregation (CPU)**: `out = Σ_e w_e · expert_out_e`.
+///    Top-k is small (Qwen3-Coder uses k=8); CPU sum is fast.
+///
+/// # Numerical equivalence vs CPU sibling
+///
+/// CPU `moe_ffn_forward_layer` uses fused_q4k/q6k_parallel_matvec
+/// (Rust SIMD); this routes through CudaExecutor::q4k_matvec /
+/// q6k_gemv. Both dequantize the same Q4_K/Q6_K bytes. Cosine ≥0.99
+/// equivalence is asserted at M-GPU-MOE-1.2 (FALSIFY-QW3-MOE-GPU-PARITY-001).
+///
+/// # Errors
+///
+/// - `InvalidShape` on dimensional mismatch.
+/// - `UnsupportedOperation` on quantized router (only F32 router supported
+///   in v1.1; quantized router is M32 follow-up).
+/// - Propagates errors from `expert_byte_slice` and `expert_swiglu_cuda`.
+#[cfg(feature = "cuda")]
+pub(crate) fn moe_ffn_forward_layer_cuda(
+    executor: &mut crate::cuda::CudaExecutor,
+    hidden: &[f32],
+    layer: &crate::gguf::qwen3_moe_load::Qwen3MoeQuantizedLayer,
+    num_experts: usize,
+    num_experts_per_tok: usize,
+    intermediate: usize,
+    hidden_dim: usize,
+    data: &[u8],
+) -> Result<Vec<f32>> {
+    if hidden.len() != hidden_dim {
+        return Err(RealizarError::InvalidShape {
+            reason: format!(
+                "moe_ffn_forward_layer_cuda: hidden.len() = {} but hidden_dim = {}",
+                hidden.len(),
+                hidden_dim
+            ),
+        });
+    }
+
+    // Router: F32 weight, logits = router @ hidden
+    if layer.router.qtype != crate::gguf::types::GGUF_TYPE_F32 {
+        return Err(RealizarError::UnsupportedOperation {
+            operation: "moe_router_quantized_read_cuda".to_string(),
+            reason: format!(
+                "moe_ffn_forward_layer_cuda: router qtype = {} (not F32). \
+                 Quantized router not yet wired.",
+                layer.router.qtype
+            ),
+        });
+    }
+    let router_bytes = &data[layer.router.offset..layer.router.offset + layer.router.byte_size];
+    let expected_bytes = num_experts * hidden_dim * 4;
+    if router_bytes.len() != expected_bytes {
+        return Err(RealizarError::InvalidShape {
+            reason: format!(
+                "moe_ffn_forward_layer_cuda: router byte_size {} != expected {}",
+                router_bytes.len(),
+                expected_bytes
+            ),
+        });
+    }
+    let mut logits = vec![0.0f32; num_experts];
+    for e in 0..num_experts {
+        let row_off = e * hidden_dim * 4;
+        let mut sum = 0.0f32;
+        for j in 0..hidden_dim {
+            let b = row_off + j * 4;
+            let w = f32::from_le_bytes([
+                router_bytes[b],
+                router_bytes[b + 1],
+                router_bytes[b + 2],
+                router_bytes[b + 3],
+            ]);
+            sum += w * hidden[j];
+        }
+        logits[e] = sum;
+    }
+
+    // Softmax (numerically stable)
+    let max_l = logits.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+    let mut probs: Vec<f32> = logits.iter().map(|&l| (l - max_l).exp()).collect();
+    let psum: f32 = probs.iter().sum();
+    if psum > 0.0 {
+        for p in &mut probs {
+            *p /= psum;
+        }
+    }
+
+    // Top-k selection
+    let mut indexed: Vec<(usize, f32)> = probs.iter().copied().enumerate().collect();
+    indexed.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    let topk = &indexed[..num_experts_per_tok.min(num_experts)];
+
+    // Renormalize selected
+    let topk_sum: f32 = topk.iter().map(|(_, w)| w).sum();
+    let topk_renorm: Vec<(usize, f32)> = if topk_sum > 0.0 {
+        topk.iter().map(|(i, w)| (*i, w / topk_sum)).collect()
+    } else {
+        let n = topk.len();
+        topk.iter().map(|(i, _)| (*i, 1.0 / n as f32)).collect()
+    };
+
+    // Per-expert SwiGLU on GPU + weighted aggregation on CPU
+    let mut out = vec![0.0f32; hidden_dim];
+    for &(expert_id, weight) in &topk_renorm {
+        let gate_bytes = crate::gguf::qwen3_moe_load::expert_byte_slice(
+            &layer.gate_exps, data, expert_id, num_experts)?;
+        let up_bytes = crate::gguf::qwen3_moe_load::expert_byte_slice(
+            &layer.up_exps, data, expert_id, num_experts)?;
+        let down_bytes = crate::gguf::qwen3_moe_load::expert_byte_slice(
+            &layer.down_exps, data, expert_id, num_experts)?;
+
+        let expert_out = expert_swiglu_cuda(
+            executor,
+            gate_bytes,
+            up_bytes,
+            down_bytes,
+            hidden,
+            hidden_dim,
+            intermediate,
+        )?;
+
+        for i in 0..hidden_dim {
+            out[i] += weight * expert_out[i];
+        }
+    }
+
+    Ok(out)
+}
+
+#[cfg(test)]
+mod moe_ffn_forward_layer_cuda_tests {
+    /// Compilation gate.
+    #[test]
+    fn moe_ffn_forward_layer_cuda_signature_drift_gate() {}
+}

--- a/crates/aprender-serve/src/gguf/cuda/uses.rs
+++ b/crates/aprender-serve/src/gguf/cuda/uses.rs
@@ -310,3 +310,4 @@ include!("matmul.rs");
 include!("clone_layer_weights.rs");
 include!("forward_qwen3_moe_cuda.rs");
 include!("expert_swiglu_cuda.rs");
+include!("moe_ffn_forward_layer_cuda.rs");

--- a/crates/aprender-serve/src/gguf/cuda/uses.rs
+++ b/crates/aprender-serve/src/gguf/cuda/uses.rs
@@ -309,3 +309,4 @@ include!("cuda.rs");
 include!("matmul.rs");
 include!("clone_layer_weights.rs");
 include!("forward_qwen3_moe_cuda.rs");
+include!("expert_swiglu_cuda.rs");


### PR DESCRIPTION
## Summary

- New \`moe_ffn_forward_layer_cuda\` — single-layer MoE FFN on GPU
- Mirrors CPU sibling \`moe_ffn_forward_layer\` (qwen3_moe_load.rs:363) line-for-line
- Composes \`expert_swiglu_cuda\` (#1465 M-GPU-MOE-1.1.0) per top-k expert
- Router/softmax/top-k/aggregation CPU; per-expert matmuls GPU

## Architecture (option D, naive per-expert dispatch)

\`\`\`
1. router @ hidden → softmax → top-k → renormalize    (CPU)
2. for expert in top-k:
     gate_bytes/up_bytes/down_bytes = expert_byte_slice(...)
     expert_out = expert_swiglu_cuda(executor, ..., hidden, ...)  (GPU)
3. out = Σ weight[e] * expert_out[e]                  (CPU)
\`\`\`

## Test plan

- [x] \`cargo check -p aprender-serve --features cuda\` — compiles
- [ ] Stack: M-GPU-MOE-1.1.2 PR — replace forward_qwen3_moe_cuda stub body with full forward calling this helper

## Stacked on

PR #1465 (M-GPU-MOE-1.1.0 expert_swiglu_cuda helper)

🤖 Generated with [Claude Code](https://claude.com/claude-code)