### PR TITLE
contract(apr-pretrain-from-init-v1): v1.0.0 PROPOSED — §49 step 3 of MODEL-2 pivot

### DIFF
--- a/contracts/apr-pretrain-from-init-v1.yaml
+++ b/contracts/apr-pretrain-from-init-v1.yaml
@@ -1,0 +1,255 @@
+metadata:
+  kind: schema
+  version: 1.0.0
+  status: PROPOSED
+  created: '2026-05-04'
+  author: PAIML Engineering
+  registry: true
+  references:
+  - 'SPEC-SHIP-TWO-001 §49 — MODEL-2 strategy pivot from-scratch → pretrained-init (2026-05-04)'
+  - 'SPEC-SHIP-TWO-001 §49.6 step 3 — author apr-pretrain-from-init-v1 contract'
+  - 'SPEC-SHIP-TWO-001 §49.6 step 4 — wire --init <model.apr> flag (this contract drives that PR)'
+  - 'contracts/training-loop-pretrain-v1.yaml — parent contract (C-TRAIN-PRETRAIN v1.5.0 ACTIVE)'
+  - 'feedback_cli_subcommand_three_surface_drift.md — clap+yaml+test 3-surface rule'
+  - 'feedback_fix_root_cause_never_route_around.md'
+  - 'feedback_no_guessing.md'
+  description: >
+    Contract pinning the semantics of `apr pretrain --init <model.apr>` for §49's
+    MODEL-2 pretrained-init strategy. The previous from-scratch strategy
+    asymptoted at val_loss=9.75 on a 565M-token corpus (§24, §25, §49.1) — a
+    data-budget ceiling, not a capacity ceiling. §49 retires from-scratch in
+    favor of fine-tuning a Qwen2.5-class pretrained checkpoint on the same
+    corpus, where the pretrained init has already paid the 1T-token data tax.
+    This contract pins what the new flag MUST do: load weights from an APR
+    file as initial weights for the pretrain optimizer, fail-fast on missing
+    or shape-mismatched files, and surface a measurable init_loss <
+    from_scratch_loss signal at step 0 that proves the load-bearing claim
+    "the init weights arrived intact and are evaluating on the new corpus."
+    Note: this contract is orthogonal to the parallel SHIP-007 / Qwen2-0.5B
+    `apr run` gibberish investigation (memory entry
+    project_qwen2_0_5b_is_ship_007_manifestation.md, 2026-05-04). Training
+    forward passes use a different code path than `apr run` inference; the
+    init flag's correctness is provable independently.
+
+equations:
+  init_flag_signature:
+    formula: |
+      `apr pretrain` MUST accept an optional `--init <PATH>` flag whose value
+      is a path to an existing APR-format model file. Semantics:
+        absent → existing behavior (random init for from-scratch, or whatever
+                 the existing `--mode finetune` path uses today)
+        present → load weights from <PATH>.apr as the initial weights for the
+                  pretrain optimizer, then run the existing pretrain loop.
+      The flag composes with `--mode {finetune,from-scratch}`:
+        --mode finetune --init <PATH>     → load <PATH>, fine-tune defaults
+        --mode from-scratch --init <PATH> → load <PATH>, from-scratch defaults
+                                            (allowed but non-canonical — emits
+                                            a warning since cosine-decay window
+                                            is sized for cold start)
+        --mode finetune (no --init)       → existing finetune path (no regression)
+        --mode from-scratch (no --init)   → existing from-scratch path (no regression)
+    domain: crates/apr-cli/src/commands/pretrain.rs CLI surface
+    codomain: bool
+    invariants:
+    - "Flag is OPTIONAL — its absence MUST NOT regress existing pretrain behavior"
+    - "Flag value is a filesystem path to an APR-format file"
+    - "Flag composes with --mode without restriction at parse time"
+    - "Flag value defaults to None (not empty string)"
+    - "Help text mentions the §49 pretrained-init strategy"
+
+  init_load_semantics:
+    formula: |
+      When `--init <PATH>` is present, the pretrain driver MUST:
+        1. Open <PATH> via the existing APR loader (not duplicate logic)
+        2. Verify magic bytes APR\\0 (v2) or APRN (v1)
+        3. Verify the loaded model's architecture matches the pretrain target
+           (vocab_size, hidden_size, num_layers, num_heads, num_kv_heads,
+           ffn_intermediate, max_position_embeddings) — exact equality
+        4. Materialize all tensor weights as the optimizer's initial state
+        5. Begin training with these weights instead of random init
+      Loading order: weights load BEFORE optimizer state (Adam moments, LR
+      scheduler step counter). Optimizer state begins fresh at step 0 (the
+      pretrained checkpoint's optimizer state is NOT carried over — only the
+      model weights).
+    domain: weight loading boundary
+    codomain: WeightTensor[*]
+    invariants:
+    - "APR magic bytes verified before any tensor read"
+    - "Architecture mismatch is FAIL-FAST, not silent-truncate"
+    - "Optimizer state starts fresh — only weights inherit from <PATH>"
+    - "Loader is reused, not reimplemented (no duplicate APR parser)"
+    - "All tensor shapes match exactly; no silent reshape/transpose"
+
+  init_error_semantics:
+    formula: |
+      When `--init <PATH>` is present and any of these conditions hold, the
+      pretrain driver MUST exit non-zero BEFORE step 1:
+        - <PATH> does not exist
+        - <PATH> exists but is not a valid APR file (wrong magic bytes)
+        - <PATH> is a valid APR file but architecture does not match
+          (vocab_size mismatch, hidden_size mismatch, etc.)
+        - <PATH> is a valid APR file with matching architecture but a
+          tensor's shape does not match the target architecture's expectation
+      No silent fallback to random init. No silent truncate. No silent
+      partial-load. The training run does not begin until weight loading
+      succeeds end-to-end.
+    domain: error-exit boundary
+    codomain: ExitCode
+    invariants:
+    - "Missing file → exit non-zero before step 1"
+    - "Invalid magic bytes → exit non-zero before step 1"
+    - "Architecture mismatch → exit non-zero before step 1"
+    - "Shape mismatch → exit non-zero before step 1"
+    - "No silent random-init fallback when --init was specified"
+    - "Error messages name the specific mismatch (vocab, hidden, layer count, etc.)"
+
+  init_loss_signal:
+    formula: |
+      The load-bearing empirical claim of §49: a pretrained checkpoint
+      evaluated on the new corpus has init_loss STRICTLY less than the
+      from-scratch random-init loss on the same corpus. Concretely:
+        init_loss(step=0) < from_scratch_loss(step=0)
+      where both are evaluated on the same val split of the same corpus,
+      same seed, same batch size, same seq length. For Qwen2.5-Coder-0.5B
+      class init on csn-python+codeparrot corpus, expected:
+        init_loss(step=0) ∈ [2.5, 6.0]    (pretrained on similar code)
+        from_scratch_loss(step=0) ∈ [9.5, 11.0]  (uniform over vocab=50257,
+                                                  ln(50257)≈10.82)
+      The contract pins ONLY the strict-inequality + ceiling claim:
+        init_loss(step=0) ≤ 6.0 < from_scratch_loss(step=0)
+      Tighter bounds belong in evidence, not in the contract.
+    domain: validation loss at step 0
+    codomain: float (cross-entropy nats)
+    invariants:
+    - "init_loss(step=0) is finite (not NaN, not Inf)"
+    - "init_loss(step=0) ≤ 6.0"
+    - "from_scratch_loss(step=0) ≥ ln(vocab_size) − 1.5 ≈ 9.32 (Q in [9.5, 11.0])"
+    - "init_loss(step=0) < from_scratch_loss(step=0) by ≥ 3.0 (load-bearing gap)"
+
+  three_surface_drift_prevention:
+    formula: |
+      Adding `--init <PATH>` to `apr pretrain` MUST update three surfaces
+      atomically per `feedback_cli_subcommand_three_surface_drift.md`:
+        1. crates/apr-cli/src/commands/pretrain.rs (clap field)
+        2. crates/apr-cli/src/commands/pretrain.rs::tests (clap-parse tests)
+        3. crates/apr-cli/tests/cli_commands.rs (cli_commands flag-parse test)
+      All three MUST be updated in the same PR; CI gate must catch missing
+      cases. Note: unlike `apr pull dataset`, --init is a FLAG on an EXISTING
+      subcommand, so contracts/apr-cli-commands-v1.yaml does NOT need a new
+      registry entry (registry is per-subcommand, not per-flag).
+    domain: 3-surface coherence for new clap flags
+    codomain: bool
+    invariants:
+    - "Clap field present in PretrainArgs / PretrainOptions struct"
+    - "At least one unit test parses --init <path> via clap"
+    - "At least one integration test exercises --init <missing-file> error path"
+    - "cargo test -p apr-cli passes (pretrain.rs and cli_commands.rs tests)"
+
+falsification_tests:
+- id: FALSIFY-APR-PRETRAIN-INIT-001
+  rule: --init flag exists and is documented
+  prediction: "`apr pretrain --help 2>&1 | grep -qE 'init.*<.*PATH'` exits 0"
+  test: "apr pretrain --help 2>&1 | grep -qE 'init'"
+  if_fails: "flag missing — §49 strategy unimplemented"
+
+- id: FALSIFY-APR-PRETRAIN-INIT-002
+  rule: --init absent regression-free
+  prediction: "`apr pretrain --mode from-scratch --synthetic --dataset <tmp> --tokenizer <tmp> --run-dir <tmp> --num-steps 10 --vocab-size 50257` (no --init) exits 0 and writes a synthetic ckpt"
+  test: "cargo test -p apr-cli --lib pretrain::tests::pretrain_no_init_synthetic_ok"
+  if_fails: "regression in existing pretrain behavior — §49 must not break §24/§25"
+
+- id: FALSIFY-APR-PRETRAIN-INIT-003
+  rule: --init missing-file fails fast
+  prediction: "`apr pretrain --init /tmp/nonexistent.apr ...` exits non-zero BEFORE step 1; stderr names the missing path"
+  test: "cargo test -p apr-cli --lib pretrain::tests::pretrain_init_missing_file_errors"
+  if_fails: "silent fallback to random-init when --init was specified — operator gets a from-scratch run mislabeled as init-finetune"
+
+- id: FALSIFY-APR-PRETRAIN-INIT-004
+  rule: --init invalid magic fails fast
+  prediction: "`apr pretrain --init <file-with-wrong-magic.apr> ...` exits non-zero BEFORE step 1; stderr names the magic-mismatch"
+  test: "cargo test -p apr-cli --lib pretrain::tests::pretrain_init_bad_magic_errors"
+  if_fails: "silent random-init fallback on corrupted APR — same defect class as -003"
+
+- id: FALSIFY-APR-PRETRAIN-INIT-005
+  rule: --init architecture mismatch fails fast
+  prediction: "`apr pretrain --init <vocab=32000.apr> --vocab-size 50257 ...` exits non-zero BEFORE step 1; stderr names vocab_size mismatch"
+  test: "cargo test -p apr-cli --lib pretrain::tests::pretrain_init_arch_mismatch_errors"
+  if_fails: "silent shape-truncate or shape-pad — produces a model whose embedding rows are uninitialized garbage"
+
+- id: FALSIFY-APR-PRETRAIN-INIT-006
+  rule: --init load-bearing init_loss signal
+  prediction: "step-0 val_loss with --init <Qwen2.5-Coder-0.5B-Instruct.apr> is ≤ 6.0; step-0 val_loss without --init (--mode from-scratch) is ≥ 9.5; gap ≥ 3.0"
+  test: "cargo test -p apr-cli --lib pretrain::tests::pretrain_init_step0_loss_below_from_scratch"
+  if_fails: "init weights are loaded but produce identical loss to random init — either weights are corrupted on load, or the loaded model is silently re-initialized somewhere downstream (this is the §49 load-bearing test)"
+
+- id: FALSIFY-APR-PRETRAIN-INIT-007
+  rule: 3-surface drift prevention
+  prediction: "clap field, unit test, and integration test all reference --init"
+  test: "cargo test -p apr-cli --test cli_commands pretrain_init_flag_registered"
+  if_fails: "3-surface drift; flag exists in clap but not in tests, or vice versa"
+
+- id: FALSIFY-APR-PRETRAIN-INIT-008
+  rule: contract validates via pv
+  prediction: "`pv validate contracts/apr-pretrain-from-init-v1.yaml` exits 0"
+  test: "pv validate contracts/apr-pretrain-from-init-v1.yaml"
+  if_fails: "contract schema noncompliant; will not pass CI gate"
+
+- id: FALSIFY-APR-PRETRAIN-INIT-009
+  rule: optimizer state begins fresh
+  prediction: "with --init <PATH>, Adam first-moment and second-moment buffers are zero-initialized at step 0; LR scheduler step counter is 0"
+  test: "cargo test -p apr-cli --lib pretrain::tests::pretrain_init_optimizer_state_fresh"
+  if_fails: "stale optimizer state from the source checkpoint contaminates new training trajectory; LR schedule misaligned with corpus"
+
+- id: FALSIFY-APR-PRETRAIN-INIT-010
+  rule: weight load is idempotent
+  prediction: "two consecutive `apr pretrain --init <PATH> --num-steps 0 --seed 42` invocations produce byte-identical post-init checkpoints"
+  test: "cargo test -p apr-cli --lib pretrain::tests::pretrain_init_loadback_idempotent"
+  if_fails: "non-deterministic weight load — debugging future divergence becomes impossible"
+
+proof_obligations:
+- type: invariant
+  property: "init_flag_signature: --init is OPTIONAL and composes with --mode without restriction"
+- type: invariant
+  property: "init_load_semantics: APR loader is REUSED, not duplicated; magic-byte check happens before tensor read"
+- type: soundness
+  property: "init_error_semantics: every load failure exits non-zero BEFORE step 1; no silent random-init fallback when --init was specified"
+- type: termination
+  property: "init_load_semantics terminates on a finite-size APR file"
+- type: liveness
+  property: "init_loss_signal: step-0 val_loss(init) < step-0 val_loss(from-scratch); gap ≥ 3.0 nats"
+- type: invariant
+  property: "three_surface_drift_prevention: clap field + unit test + integration test all present in same PR"
+
+kani_harnesses:
+- id: KH-APR-PRETRAIN-INIT-001
+  obligation: init_flag_signature
+  property: flag_absent_implies_existing_behavior
+  bound: 4  # 2 modes × 2 init-presence states = 4-cell decision table
+- id: KH-APR-PRETRAIN-INIT-002
+  obligation: init_error_semantics
+  property: load_failure_implies_nonzero_exit
+  bound: 8  # 4 failure modes × 2 mode values
+
+verification_summary:
+  total_obligations: 6
+  proven: 0
+  tested: 0
+  status: pending
+  notes: |
+    Authored 2026-05-04 as §49 step 3 of SHIP-TWO-001 MODEL-2 pretrained-init
+    pivot. PROPOSED status until §49 step 4 (wire-up PR) lands. Promotion to
+    PARTIAL_ALGORITHM_LEVEL requires the 10 FALSIFY-APR-PRETRAIN-INIT-* tests
+    to be at least authored (compile-bound, may xfail until impl). Promotion
+    to FUNCTIONAL requires all 10 to PASS. Promotion to DISCHARGED requires a
+    LIVE 500-step fine-tune run on the canonical Qwen2.5-Coder-0.5B-Instruct
+    APR file producing val_loss < 9.38 (the previous corpus-bottleneck floor)
+    per §49.6 step 5.
+
+    Cross-reference: this contract is INDEPENDENT of the SHIP-007 / Qwen2-0.5B
+    `apr run` gibberish defect (memory:project_qwen2_0_5b_is_ship_007_manifestation.md,
+    2026-05-04). The training forward path uses a different loader and dispatch
+    surface than `apr run` inference; the init flag's correctness is provable
+    independently. If the gibberish defect turns out to also infect the
+    training forward path, this contract's FALSIFY-APR-PRETRAIN-INIT-006
+    will catch it — init_loss will not be ≤ 6.0 if the loaded weights are
+    being silently corrupted.


### PR DESCRIPTION
## Summary

Authors `contracts/apr-pretrain-from-init-v1.yaml` v1.0.0 PROPOSED — the contract layer for §49's MODEL-2 pretrained-init pivot.

§49 (spec v2.94.0, 2026-05-04, PR #1461) retired the from-scratch MODEL-2 strategy after §24.8's 80K-step LR-budget falsification confirmed val_loss=9.75 as a corpus-bottleneck floor on the 565M-token corpus. This contract pins the semantics of the new `apr pretrain --init <model.apr>` flag that loads weights from a Qwen2.5-class APR file as the initial weights for fine-tuning.

**This is the contract; the wire-up PR is §49 step 4 (next cycle, ~50 LOC).**

## What this PR adds

`contracts/apr-pretrain-from-init-v1.yaml`:
- 5 equations: `init_flag_signature`, `init_load_semantics`, `init_error_semantics`, `init_loss_signal`, `three_surface_drift_prevention`
- 10 falsifiers (`FALSIFY-APR-PRETRAIN-INIT-001..010`)
- 6 proof obligations (invariant, soundness, termination, liveness)
- 2 kani harnesses
- Cross-references to spec §49, parent contract `training-loop-pretrain-v1.yaml`, and the orthogonal SHIP-007/0.5B gibberish defect

## Validation

```
$ pv validate contracts/apr-pretrain-from-init-v1.yaml
0 error(s), 0 warning(s)
Contract is valid.
```

## Load-bearing claim

The contract pins as `FALSIFY-APR-PRETRAIN-INIT-006`:

> step-0 val_loss with --init <Qwen2.5-Coder-0.5B-Instruct.apr> is ≤ 6.0; step-0 val_loss without --init (--mode from-scratch) is ≥ 9.5; gap ≥ 3.0

If the wire-up PR (§49 step 4) ships and this falsifier doesn't pass, it means either (a) the init weights are not actually loaded, or (b) they're loaded but silently corrupted. Both are catchable by this contract.

## Plain ship-% update

- **MODEL-1**: unchanged at **91%** (SHIP-007 cascade infrastructure track)
- **MODEL-2**: unchanged at **57%** — first ship-% movement gated on §49 step 5 (LIVE 500-step fine-tune producing val_loss < 9.38)

## Five Whys

1. **Why a contract before the impl?** `pv validate` rejects schema drift; the falsifier list pins what the wire-up PR must satisfy. Contract-first prevents the wire-up shipping with silent gaps.
2. **Why now?** Spec §49 was authored 2026-05-04 (#1461) and roadmap step 3 is "author this contract". Step 4 (wire-up) blocks on it.
3. **Why scope to PROPOSED?** No impl exists yet. Promotion to ACTIVE/FUNCTIONAL/DISCHARGED is gated on the wire-up PR landing and falsifiers compile-binding.
4. **Why 10 falsifiers, not 5?** Each error class is a distinct silent-failure mode. The §24 retrospective showed `--synthetic` defaulted silently to `true` for months — a contract pinning "no silent fallback" must enumerate ALL silent paths so CI catches each.
5. **Why not block on SHIP-007 / 0.5B gibberish?** Orthogonal. SHIP-007 is `apr run` inference; this contract is `apr pretrain` training-forward. Separating keeps the wire-up PR small and lets §49 progress while SHIP-007 stays under operator-gated investigation.

## Test plan

- [x] `pv validate contracts/apr-pretrain-from-init-v1.yaml` exits 0
- [ ] `cargo test -p aprender-contracts --lib` passes (CI)
- [ ] `cargo deny check advisories` passes (CI)
- [ ] Workspace lint passes (CI)
- [ ] `pmat quality-gates` passes (pre-commit)

## Refs

- SPEC-SHIP-TWO-001 §49 — MODEL-2 strategy pivot (#1461)
- `contracts/training-loop-pretrain-v1.yaml` v1.5.0 ACTIVE (parent)
- `feedback_cli_subcommand_three_surface_drift.md`
- `feedback_no_guessing.md`
- `memory:project_qwen2_0_5b_is_ship_007_manifestation.md` (orthogonal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)