### PR TITLE
fix(aprender-train): qwen2_0_5b tie_word_embeddings true — §50.4 step 5b + DEFECT FIX

### DIFF
--- a/crates/aprender-train/src/transformer/config.rs
+++ b/crates/aprender-train/src/transformer/config.rs
@@ -152,7 +152,20 @@ impl TransformerConfig {
         }
     }
 
-    /// Qwen2 0.5B configuration (good for testing)
+    /// Qwen2 0.5B configuration (good for testing).
+    ///
+    /// Empirically verified against
+    /// `~/.cache/huggingface/hub/models--Qwen--Qwen2.5-Coder-0.5B-Instruct/.../config.json`
+    /// 2026-05-04. Pinned by
+    /// `contracts/apr-pretrain-arch-polymorphic-v1.yaml` FALSIFY-001.
+    ///
+    /// Note: `tie_word_embeddings: true` is the Qwen2.5 0.5B/1.5B convention
+    /// (the 7B variant turns this OFF; see `qwen2_7b()`). This is a Qwen
+    /// scaling-law quirk — small Qwen models reuse embedding+lm_head weights
+    /// to save params, but the larger variants pay the param cost for
+    /// untied weights. Drift-prevention: keeping this `true` is required
+    /// for SHIP-TWO-001 §49 MODEL-2 fine-tune from a Qwen2.5-Coder-0.5B
+    /// checkpoint.
     pub fn qwen2_0_5b() -> Self {
         Self {
             hidden_size: QWEN2_0_5B_HIDDEN_SIZE,
@@ -169,7 +182,7 @@ impl TransformerConfig {
             architecture: ModelArchitecture::Decoder,
             hf_architecture: None,
             hf_model_type: None,
-            tie_word_embeddings: false,
+            tie_word_embeddings: true,
         }
     }
 
@@ -653,6 +666,74 @@ mod tests {
         assert_eq!(config.num_kv_heads, 8); // Grouped-query attention
         assert_eq!(config.num_attention_heads, 32);
         // 32 / 8 = 4 query heads per KV head
+    }
+
+    /// FALSIFY-APR-PRETRAIN-ARCH-001 — `qwen2_0_5b()` constructor matches
+    /// HF config byte-for-byte.
+    ///
+    /// Empirically verified against
+    /// `~/.cache/huggingface/hub/models--Qwen--Qwen2.5-Coder-0.5B-Instruct/.../config.json`
+    /// on 2026-05-04 for SHIP-TWO-001 §50.4 step 5b. If any of these 11
+    /// fields drift from HF, the §49 fine-tune path's init weights will
+    /// load into the wrong-shape optimizer and produce silent gibberish.
+    #[test]
+    fn qwen2_0_5b_matches_hf_config_2026_05_04() {
+        let config = TransformerConfig::qwen2_0_5b();
+        assert_eq!(config.hidden_size, 896, "hidden_size");
+        assert_eq!(config.num_attention_heads, 14, "num_attention_heads");
+        assert_eq!(config.num_kv_heads, 2, "num_kv_heads (GQA-7:1)");
+        assert_eq!(config.intermediate_size, 4864, "intermediate_size");
+        assert_eq!(config.num_hidden_layers, 24, "num_hidden_layers");
+        assert_eq!(config.vocab_size, 151_936, "vocab_size");
+        assert_eq!(config.max_position_embeddings, 32_768, "max_position_embeddings");
+        assert!(
+            (config.rms_norm_eps - 1e-6).abs() < f32::EPSILON,
+            "rms_norm_eps={}, want 1e-6",
+            config.rms_norm_eps
+        );
+        assert!(
+            (config.rope_theta - 1_000_000.0).abs() < f32::EPSILON,
+            "rope_theta={}, want 1_000_000.0",
+            config.rope_theta
+        );
+        assert!(config.use_bias, "use_bias must be true (Qwen2 quirk)");
+        assert!(
+            config.tie_word_embeddings,
+            "tie_word_embeddings must be true for Qwen2.5 0.5B (HF config 2026-05-04)"
+        );
+        assert_eq!(config.architecture, ModelArchitecture::Decoder);
+        // GQA ratio = 14/2 = 7, the canonical Qwen2.5-0.5B GQA-7:1.
+        assert_eq!(config.num_attention_heads / config.num_kv_heads, 7);
+    }
+
+    /// Drift-prevention: `qwen2_1_5b()` inherits `tie_word_embeddings` from
+    /// `qwen2_0_5b()` via `..Self::qwen2_0_5b()` spread. If someone splits
+    /// the inheritance, this test catches the silent flip.
+    #[test]
+    fn qwen2_1_5b_inherits_tie_word_embeddings_from_0_5b() {
+        let parent = TransformerConfig::qwen2_0_5b();
+        let child = TransformerConfig::qwen2_1_5b();
+        assert_eq!(
+            child.tie_word_embeddings, parent.tie_word_embeddings,
+            "qwen2_1_5b must inherit tie_word_embeddings from qwen2_0_5b — both are HF tie=true"
+        );
+        assert!(
+            child.tie_word_embeddings,
+            "qwen2_1_5b tie_word_embeddings must be true (HF config 2026-05-04)"
+        );
+    }
+
+    /// Pin the Qwen scaling-law quirk: 0.5B + 1.5B tie embeddings, 7B does not.
+    /// If the 7B is ever changed to inherit from 0.5B, this test catches it
+    /// before an operator silently fine-tunes a 7B with the wrong head shape.
+    #[test]
+    fn qwen2_7b_does_not_tie_embeddings() {
+        let config = TransformerConfig::qwen2_7b();
+        assert!(
+            !config.tie_word_embeddings,
+            "qwen2_7b tie_word_embeddings MUST be false per HF config 2026-05-04 — \
+             larger Qwen variants pay param cost for untied weights"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

§50.4 step 5b authored a contract assuming `qwen2_0_5b()` did not exist. **Live source inspection during impl revealed the constructor ALREADY EXISTS** at `transformer/config.rs:156`. Reading the HF config byte-for-byte (per `feedback_no_guessing.md`) revealed a real defect:

| Source | tie_word_embeddings |
|--------|---------------------|
| HF config (Qwen2.5-Coder-0.5B-Instruct) | **`true`** |
| Existing `qwen2_0_5b()` code | `false` ❌ |

Fix: 1 LOC change `false → true`. Per Qwen scaling-law convention verified against the HF cache:

| Variant | tie | Source |
|---------|-----|--------|
| Qwen2.5-Coder-0.5B | `true` ✓ | HF cache 2026-05-04 |
| Qwen2.5-Coder-1.5B | `true` ✓ | inherits via `..Self::qwen2_0_5b()` |
| Qwen2.5-Coder-7B | `false` ✓ | explicit in `qwen2_7b()` |

## Why the defect matters

Tied vs untied embeddings is a **load-bearing architectural property**. With `tie=false` (current bug), if an operator fine-tunes from a Qwen2.5-0.5B init checkpoint, the lm_head will be allocated as a separate tensor that doesn't get loaded (because the APR file only contains the embed_tokens tensor — they share weights). The result: lm_head random-initialized and untrained, producing **silent gibberish at val time**. This is exactly the §49 / §50 failure class the contract was authored to prevent.

## What this PR adds

1. Fix `tie_word_embeddings: false → true` at `transformer/config.rs:156-174`
2. Docstring noting empirical verification + HF cache path + Qwen scaling-law quirk
3. **3 new drift-prevention tests** in `transformer::config::tests`:
   - `qwen2_0_5b_matches_hf_config_2026_05_04` (FALSIFY-001 byte-identity, 11 fields)
   - `qwen2_1_5b_inherits_tie_word_embeddings_from_0_5b` (catches spread-split refactors)
   - `qwen2_7b_does_not_tie_embeddings` (pins the 7B scaling-law quirk)

## Test results

```
$ cargo test -p aprender-train --lib transformer::config::tests::qwen2
running 3 tests
test transformer::config::tests::qwen2_1_5b_inherits_tie_word_embeddings_from_0_5b ... ok
test transformer::config::tests::qwen2_0_5b_matches_hf_config_2026_05_04 ... ok
test transformer::config::tests::qwen2_7b_does_not_tie_embeddings ... ok

test result: ok. 3 passed; 0 failed; 0 ignored
```

## Discharges

`FALSIFY-APR-PRETRAIN-ARCH-001` (constructor exists + matches HF config byte-for-byte) — pinned in `apr-pretrain-arch-polymorphic-v1.yaml` (PR #1473, in flight).

## Plain ship-% update

- **MODEL-1**: unchanged at **91%** (SHIP-007 cascade infrastructure track)
- **MODEL-2**: unchanged at **57%** — first ship-% movement gated on §50.4 step 5g (LIVE 500-step fine-tune producing val_loss < 9.38)

## Five Whys

1. **Why was the constructor already there but with wrong tie setting?** Likely authored before the spec-§49 use case became the load-bearing target. The constants for `qwen2_0_5b` were correct for inference, but `tie_word_embeddings` is mostly a training-pipeline concern — it determines whether lm_head is a separate trainable parameter or shares with embed_tokens.
2. **Why didn't existing tests catch this earlier?** They pinned shape (hidden, layers, heads, etc.) but no test verified `tie_word_embeddings`. This PR adds the missing drift-prevention.
3. **Why fix this in the same PR as the test (not separate)?** Toyota Way: the test IS the discharge mechanism for FALSIFY-001. A test that passed against the (defective) status quo would be a liar. Fixing first + testing second guarantees the test pins correct behavior.
4. **Why also pin 1.5B inheritance and 7B anti-spread?** Drift-prevention. The `..Self::qwen2_0_5b()` spread is fragile — a future refactor could split the inheritance and silently flip 1.5B's `tie` back to `false`. Similarly, an over-enthusiastic refactor could homogenize 7B with 0.5B (incorrectly setting 7B's `tie=true`). Tests catch both.
5. **Why §50.4 step 5b was overscoped at 40 LOC:** §50 was authored under the assumption that the constructor didn't exist. Live source inspection revealed the foundation was already there, just with one defect. Same lesson as §50 itself — read source before authoring scope.

## Test plan

- [x] `cargo test -p aprender-train --lib transformer::config::tests::qwen2` — 3/3 pass
- [x] `cargo check -p aprender-train --lib` — clean
- [x] Pre-commit quality gates pass
- [ ] CI checks (gate, test, lint, coverage, security)

## Refs

- **Contract**: PR #1473 `apr-pretrain-arch-polymorphic-v1` (in flight) — pins FALSIFY-001 that this PR discharges
- **Spec**: PR #1472 §50 (in flight) — re-scoped roadmap that this PR's defect-fix slots into
- **Builds on**: PR #1470 (`apr-pretrain-from-init-v1` contract, merged), PR #1471 (clap field wire-up, merged)
- HF config: `~/.cache/huggingface/hub/models--Qwen--Qwen2.5-Coder-{0.5B,1.5B,7B}-Instruct/.../config.json`
- `feedback_no_guessing.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)