### PR TITLE
test(aprender-train): GQA-7:1 forward-pass smoke test — §50.4 step 5e

### DIFF
--- a/crates/aprender-train/src/transformer/model.rs
+++ b/crates/aprender-train/src/transformer/model.rs
@@ -559,6 +559,78 @@ mod tests {
         assert_eq!(logits.len(), 3 * config.vocab_size);
     }
 
+    /// FALSIFY-APR-PRETRAIN-ARCH-004 (smoke level) — GQA-7:1 forward pass
+    /// runs without panic and produces finite output of correct shape.
+    ///
+    /// Per `apr-pretrain-arch-polymorphic-v1` (PR #1473), the §49 fine-tune
+    /// path uses Qwen2.5-Coder-0.5B's GQA-7:1 ratio (kv_heads=2,
+    /// query_heads=14). The Llama370M codepath only exercised GQA-4:1.
+    /// This test pins that the existing attention kernel handles the new
+    /// ratio without per-ratio specialization.
+    ///
+    /// Tiny shape (hidden=112=14*8, head_dim=8) keeps the test under 1ms.
+    /// Full numerical-parity vs GQA-1:1 reference (cosine ≥ 0.9999) is a
+    /// FUNCTIONAL-level discharge, not algorithm-level. PARTIAL_ALGORITHM_LEVEL
+    /// only requires that the kernel COMPILES and PRODUCES finite output for
+    /// the new ratio — both proven here.
+    ///
+    /// Spec: SPEC-SHIP-TWO-001 §50.4 step 5e.
+    #[test]
+    fn falsify_apr_pretrain_arch_004_gqa_7_1_forward_pass_smoke() {
+        // Tiny GQA-7:1 config: kv_heads=2, num_attention_heads=14, head_dim=8.
+        // hidden = num_attention_heads * head_dim = 14 * 8 = 112.
+        let config = TransformerConfig {
+            hidden_size: 112,
+            num_attention_heads: 14,
+            num_kv_heads: 2,
+            intermediate_size: 64,
+            num_hidden_layers: 1,
+            vocab_size: 256,
+            max_position_embeddings: 512,
+            rms_norm_eps: 1e-6,
+            rope_theta: 1_000_000.0, // Qwen2 ROPE convention
+            use_bias: true,          // Qwen2 quirk
+            head_dim_override: None, // 112 / 14 = 8, no override needed
+            architecture: crate::transformer::config::ModelArchitecture::Decoder,
+            hf_architecture: None,
+            hf_model_type: None,
+            tie_word_embeddings: true, // Qwen2.5-0.5B convention
+        };
+
+        // Drift-prevention: verify GQA-7:1 ratio holds at construction time.
+        // If a future refactor flips num_attention_heads or num_kv_heads such
+        // that the ratio is no longer 7, this test catches it before the
+        // forward pass even runs.
+        assert_eq!(
+            config.num_attention_heads / config.num_kv_heads,
+            7,
+            "GQA-7:1 ratio must be 14/2=7 (Qwen2.5-0.5B canonical)"
+        );
+
+        let transformer = Transformer::new(&config);
+        let tokens = vec![1u32, 2, 3, 4]; // seq_len=4 short prefix
+        let logits = transformer.forward(&tokens);
+
+        // Shape invariant: forward returns seq_len * vocab_size logits.
+        assert_eq!(
+            logits.len(),
+            4 * config.vocab_size,
+            "GQA-7:1 forward must return seq_len * vocab_size logits"
+        );
+
+        // Numerical invariant: all logits finite (no NaN, no Inf).
+        // The §24 retrospective showed silent NaN propagation through GQA can
+        // produce loss=NaN that the divergence guard catches LATE (after
+        // multiple steps). FALSIFY-004's smoke level catches it at the
+        // first forward pass, before any optimizer state corrupts.
+        assert!(
+            logits.data().iter().all(|&v| v.is_finite()),
+            "GQA-7:1 forward must produce all-finite logits — silent NaN \
+             would corrupt the §49 fine-tune trajectory before FALSIFY-006 \
+             (init_loss < 6.0) could measure it"
+        );
+    }
+
     #[test]
     fn test_transformer_tiny_forward_last() {
         let config = TransformerConfig::tiny();


### PR DESCRIPTION
Adds GQA-7:1 forward-pass smoke test discharging FALSIFY-APR-PRETRAIN-ARCH-004 at smoke level. Tiny shape (hidden=112, vocab=256, layers=1). Test verifies: runs without panic, correct shape, all-finite logits. The existing Llama370M codepath only exercised GQA-4:1; this pins that the kernel handles 7:1 (Qwen2.5-Coder-0.5B canonical) without per-ratio specialization. PR #1473 contract obligation. Plain ship-%: MODEL-1=91%, MODEL-2=57% (unchanged; gated on step 5g LIVE fine-tune). Builds on PRs #1472 (merged) + #1473/#1474/#1475/#1476 (in flight).