### PR TITLE
contract(apr-pretrain-arch-polymorphic-v1): v1.0.0 → v1.1.0 PARTIAL_ALGORITHM_LEVEL

### DIFF
--- a/contracts/apr-pretrain-arch-polymorphic-v1.yaml
+++ b/contracts/apr-pretrain-arch-polymorphic-v1.yaml
@@ -1,20 +1,59 @@
 metadata:
   kind: schema
-  version: 1.0.0
-  status: PROPOSED
+  version: 1.1.0
+  status: PARTIAL_ALGORITHM_LEVEL
   created: '2026-05-04'
+  updated: '2026-05-04'
   author: PAIML Engineering
   registry: true
+  changelog:
+  - version: 1.1.0
+    date: '2026-05-04'
+    change: |
+      v1.0.0 PROPOSED → v1.1.0 PARTIAL_ALGORITHM_LEVEL.
+      All 8 FALSIFY-APR-PRETRAIN-ARCH-* falsifiers are now bound to
+      executable tests:
+        FALSIFY-001 (qwen2_0_5b matches HF config) — PR #1474 merged
+          (config.rs::tests::qwen2_0_5b_matches_hf_config)
+        FALSIFY-002 (build_transformer_config(None) preserves Llama370M)
+          — PR #1475 merged
+          (pretrain_real.rs::tests::build_transformer_config_no_init_matches_llama370m)
+        FALSIFY-003 (build_transformer_config(Some) extracts 10 fields)
+          — PR #1475 merged
+          (pretrain_real.rs::tests::build_transformer_config_qwen_init_matches_constructor)
+        FALSIFY-004 (GQA-7:1 forward-pass smoke) — PR #1478 merged
+          (transformer/model.rs::tests::falsify_apr_pretrain_arch_004_gqa_7_1_forward_pass_smoke)
+        FALSIFY-005 (Qwen tokenizer passes with Qwen --init) — PR #1476 merged
+          (commands/pretrain.rs::tests::preflight_qwen_vocab_passes_with_qwen_init)
+        FALSIFY-006 (Qwen tokenizer fails without --init) — PR #1476 merged
+          (commands/pretrain.rs::tests::preflight_qwen_vocab_fails_without_init)
+        FALSIFY-007 (encoder-arch APR rejected fail-fast) — PR #1479 open,
+          auto-merge armed (pretrain_real.rs::tests::validate_pretrain_init_arch_compatible_*)
+        FALSIFY-008 (contract self-validates via pv) — bound by this YAML
+          passing `pv validate`
+      Promotion to FUNCTIONAL requires all 8 tests to PASS on main
+      (FALSIFY-007 lands when #1479 merges). Promotion to DISCHARGED
+      requires §50.4 step 5g LIVE empirical 500-step fine-tune on
+      Qwen2.5-Coder-0.5B-Instruct.apr.
+  - version: 1.0.0
+    date: '2026-05-04'
+    change: |
+      Authored as §50.4 step 5a of SHIP-TWO-001 MODEL-2 polymorphic
+      pivot (PR #1473 merged). PROPOSED status — pinning the
+      arch-extraction algorithm before any §50.4 step 5b-5h
+      implementation lands.
   references:
   - 'SPEC-SHIP-TWO-001 §50 — MODEL-2 architecture-coupling finding (2026-05-04)'
   - 'SPEC-SHIP-TWO-001 §50.4 step 5a — author this contract'
   - 'SPEC-SHIP-TWO-001 §50.4 steps 5b-5f — implementation roadmap this contract drives'
+  - 'SPEC-SHIP-TWO-001 §51 — cascade snapshot recording 7/8 falsifiers PARTIAL_ALGORITHM_LEVEL bound (PR #1480 merged)'
   - 'contracts/apr-pretrain-from-init-v1.yaml v1.1.0 PARTIAL_ALGORITHM_LEVEL — sibling (FALSIFY-005 arch-mismatch is consumed here)'
   - 'contracts/training-loop-pretrain-v1.yaml v1.5.0 ACTIVE — parent (PretrainConfig is what the polymorphic builder emits)'
   - 'contracts/architecture-requirements-v1.yaml — sibling (TransformerConfig family invariants)'
   - 'contracts/gqa-kernel-v1.yaml — sibling (GQA ratio invariants)'
   - 'feedback_no_guessing.md — read source before forming hypothesis'
   - 'feedback_fix_root_cause_never_route_around.md'
+  - 'feedback_falsifier_first_cascade_pattern.md — 1 PR ≈ 1 falsifier discharge cascade (this contract is the canonical example)'
   description: >
     Contract pinning the architecture-extraction algorithm for the
     pretrained-init MODEL-2 path. Per §50, the existing pretrain trainer
@@ -207,20 +246,22 @@ kani_harnesses:
 verification_summary:
   total_obligations: 6
   proven: 0
-  tested: 0
-  status: pending
+  tested: 7
+  status: partial
   notes: |
     Authored 2026-05-04 as §50.4 step 5a of SHIP-TWO-001 MODEL-2
-    architecture-polymorphic pivot. PROPOSED status until §50.4 steps
-    5b-5e land (constructor + extractor + Qwen tokenizer surface +
-    GQA-7:1 verification). Promotion to PARTIAL_ALGORITHM_LEVEL
-    requires the 8 FALSIFY-APR-PRETRAIN-ARCH-* tests to be at least
-    authored (compile-bound, may xfail until impl). Promotion to
-    FUNCTIONAL requires all 8 to PASS. Promotion to DISCHARGED requires
-    a LIVE 500-step fine-tune run on the canonical Qwen2.5-Coder-0.5B-
-    Instruct APR file producing val_loss < 9.38 (the §24/§25 corpus
-    floor) — empirical proof that the architecture-polymorphic path
-    actually works end-to-end.
+    architecture-polymorphic pivot. v1.1.0 PARTIAL_ALGORITHM_LEVEL
+    (2026-05-04): 7/8 falsifiers bound on main, 8th (FALSIFY-007)
+    bound on PR #1479 with auto-merge armed. Tests authored:
+      FALSIFY-001..006 — merged (PRs #1474, #1475, #1476, #1478)
+      FALSIFY-007 — PR #1479 (encoder-family fail-fast)
+      FALSIFY-008 — contract self-validation via `pv validate`
+    Promotion to FUNCTIONAL requires #1479 land (FALSIFY-007 PASS on
+    main) AND every FALSIFY-001..006 PASS in CI. Promotion to
+    DISCHARGED requires §50.4 step 5g LIVE empirical run: 500-step
+    fine-tune on canonical Qwen2.5-Coder-0.5B-Instruct.apr producing
+    val_loss < 9.38 (the §24/§25 corpus floor) — empirical proof that
+    the architecture-polymorphic path actually works end-to-end.
 
     Cross-references:
     - This contract DOES NOT replace apr-pretrain-from-init-v1; the two


### PR DESCRIPTION
## Summary

Bump `apr-pretrain-arch-polymorphic-v1` contract status from PROPOSED to
PARTIAL_ALGORITHM_LEVEL. All 8 FALSIFY-APR-PRETRAIN-ARCH-* falsifiers
are now bound to executable tests across the §50.4 cascade.

## Falsifier scoreboard

| ID  | Rule                                          | PR                            | Status                  |
|-----|-----------------------------------------------|-------------------------------|-------------------------|
| 001 | qwen2_0_5b matches HF config                  | #1474 merged                  | PARTIAL_ALGORITHM_LEVEL |
| 002 | build_transformer_config(None) → Llama370M    | #1475 merged                  | PARTIAL_ALGORITHM_LEVEL |
| 003 | build_transformer_config(Some) extracts 10    | #1475 merged                  | PARTIAL_ALGORITHM_LEVEL |
| 004 | GQA-7:1 forward-pass smoke                    | #1478 merged                  | PARTIAL_ALGORITHM_LEVEL |
| 005 | Qwen tokenizer passes with --init Qwen        | #1476 merged                  | PARTIAL_ALGORITHM_LEVEL |
| 006 | Qwen tokenizer fails without --init           | #1476 merged                  | PARTIAL_ALGORITHM_LEVEL |
| 007 | encoder-arch APR fail-fast                    | #1479 open (auto-merge armed) | PARTIAL_ALGORITHM_LEVEL |
| 008 | contract self-validates via pv                | THIS PR (pv exits 0)          | PARTIAL_ALGORITHM_LEVEL |

## Test plan

- [x] `pv validate contracts/apr-pretrain-arch-polymorphic-v1.yaml` exits 0
- [x] All 8 falsifiers cite a concrete test path or PR
- [x] Changelog entry under `metadata.changelog` with version/date/change

## Why now

Per `feedback_falsifier_first_cascade_pattern.md`: when a saturated
auto-merge queue blocks more impl PRs, switch to non-conflict work.
This contract bump touches only one YAML file (no Rust/test source)
and cannot conflict with #1479 / #1481 (impl PRs in queue).

## Five Whys

1. Why bump status now? — 7/8 falsifiers bound on main + 8th bound on
   open PR; PROPOSED is stale per §51 snapshot.
2. Why not wait for #1479 land first? — §51 already recorded "7/8
   PARTIAL bound"; the 8th is contract-self validation, which is met
   by THIS PR's `pv validate` output.
3. Why not bundle with #1479? — Different file, different review scope.
4. Why not skip the bump? — Operator-facing scoreboard is in the YAML;
   stale PROPOSED implies "not yet started" which contradicts §51.
5. Why YAML changelog? — Records THIS bump's reasoning so future
   operators don't re-derive it from git log.

## Promotion gates (next)

- FUNCTIONAL: requires #1479 land (FALSIFY-007 PASS on main) AND every
  FALSIFY-001..006 PASS in CI.
- DISCHARGED: requires §50.4 step 5g LIVE empirical 500-step fine-tune
  on Qwen2.5-Coder-0.5B-Instruct.apr producing val_loss < 9.38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)