### PR TITLE
feat(aprender-serve): M-GPU-MOE-1.3 — preload_weights_gpu MoE-aware (partial discharge)

### DIFF
--- a/crates/aprender-serve/src/cuda/executor/weights.rs
+++ b/crates/aprender-serve/src/cuda/executor/weights.rs
@@ -368,9 +368,32 @@ impl CudaExecutor {
             let (attn_k_ptr, attn_k_len) = get_qweight(&k_name)?;
             let (attn_v_ptr, attn_v_len) = get_qweight(&v_name)?;
             let (attn_output_ptr, attn_output_len) = get_qweight(&o_name)?;
-            let (ffn_gate_ptr, ffn_gate_len) = get_qweight(&gate_name)?;
-            let (ffn_up_ptr, ffn_up_len) = get_qweight(&up_name)?;
-            let (ffn_down_ptr, ffn_down_len) = get_qweight(&down_name)?;
+
+            // M-GPU-MOE-1.3 (qwen3-moe-forward-gpu-v1 v1.3.0): for MoE
+            // architectures, the per-layer dense FFN tensor names
+            // (`ffn_gate.weight`, `ffn_up.weight`, `ffn_down.weight`)
+            // do NOT exist in the GGUF — MoE has 128 expert tensors per
+            // layer (`ffn_gate_exps.weight` etc.) loaded into the
+            // `moe_layers` parameter at forward-time. Skip the lookup
+            // and use (0, 0) sentinels; consumers MUST gate FFN access
+            // on `arch.is_moe` and route to `moe_ffn_forward_layer_cuda`.
+            // See: evidence/m-gpu-moe-1-2-blocked-by-preload-bug-2026-05-04/findings.md
+            let (ffn_gate_ptr, ffn_gate_len) = if arch.is_moe {
+                (0u64, 0usize)
+            } else {
+                get_qweight(&gate_name)?
+            };
+            let (ffn_up_ptr, ffn_up_len) = if arch.is_moe {
+                (0u64, 0usize)
+            } else {
+                get_qweight(&up_name)?
+            };
+            let (ffn_down_ptr, ffn_down_len) = if arch.is_moe {
+                (0u64, 0usize)
+            } else {
+                get_qweight(&down_name)?
+            };
+
             let (attn_norm_ptr, attn_norm_len) = get_rmsnorm(&attn_norm_name)?;
             let (ffn_norm_ptr, ffn_norm_len) = get_rmsnorm(&ffn_norm_name)?;
 
@@ -379,9 +402,10 @@ impl CudaExecutor {
             let attn_k_qtype = self.resolve_qtype(&k_name);
             let attn_v_qtype = self.resolve_qtype(&v_name);
             let attn_output_qtype = self.resolve_qtype(&o_name);
-            let ffn_gate_qtype = self.resolve_qtype(&gate_name);
-            let ffn_up_qtype = self.resolve_qtype(&up_name);
-            let ffn_down_qtype = self.resolve_qtype(&down_name);
+            // M-GPU-MOE-1.3: qtype sentinels for MoE (FFN qtypes unused)
+            let ffn_gate_qtype = if arch.is_moe { WeightQuantType::Q4K } else { self.resolve_qtype(&gate_name) };
+            let ffn_up_qtype = if arch.is_moe { WeightQuantType::Q4K } else { self.resolve_qtype(&up_name) };
+            let ffn_down_qtype = if arch.is_moe { WeightQuantType::Q4K } else { self.resolve_qtype(&down_name) };
 
             // Log if non-Q4K types detected (for debugging mixed-quant models)
             self.log_mixed_quant_types(

--- a/crates/aprender-serve/src/cuda/types.rs
+++ b/crates/aprender-serve/src/cuda/types.rs
@@ -540,6 +540,23 @@ impl ValidatedLayerWeights {
         let roles = required_roles(arch);
 
         for &role in roles {
+            // M-GPU-MOE-1.3 (qwen3-moe-forward-gpu-v1 v1.3.0): for MoE
+            // architectures, the per-layer dense FFN tensor names
+            // (FfnGate, FfnUp, FfnDown) DO NOT EXIST — MoE has 128
+            // expert tensors per layer loaded into the `moe_layers`
+            // parameter at forward-time. Skip these role checks; the
+            // MoE forward path uses moe_layers directly and never
+            // reads FfnGate/FfnUp/FfnDown from the indexed weights.
+            // See: evidence/m-gpu-moe-1-2-blocked-by-preload-bug-2026-05-04/findings.md
+            if arch.is_moe
+                && matches!(
+                    role,
+                    WeightRole::FfnGate | WeightRole::FfnUp | WeightRole::FfnDown
+                )
+            {
+                continue;
+            }
+
             let (ptr, len) = Self::get_field(&raw, role);
             if ptr == 0 && len == 0 {
                 return Err(WeightValidationError {

--- a/crates/aprender-serve/src/gguf/arch_constraints_fallback.rs
+++ b/crates/aprender-serve/src/gguf/arch_constraints_fallback.rs
@@ -24,6 +24,7 @@ fn from_architecture_generated(arch: &str) -> ArchConstraints {
             tied_embeddings: true,
             has_qk_norm: false,
             default_eps: 1e-5,
+            is_moe: false,
         },
         // llama.yaml
         "llama" | "llama3" => ArchConstraints {
@@ -36,6 +37,7 @@ fn from_architecture_generated(arch: &str) -> ArchConstraints {
             tied_embeddings: false,
             has_qk_norm: false,
             default_eps: 1e-5,
+            is_moe: false,
         },
         // qwen2.yaml
         "qwen2" | "qwen2.5" | "qwen" => ArchConstraints {
@@ -48,6 +50,7 @@ fn from_architecture_generated(arch: &str) -> ArchConstraints {
             tied_embeddings: false,
             has_qk_norm: false,
             default_eps: 1e-6,
+            is_moe: false,
         },
         // qwen3.yaml
         "qwen3" => ArchConstraints {
@@ -60,6 +63,7 @@ fn from_architecture_generated(arch: &str) -> ArchConstraints {
             tied_embeddings: false,
             has_qk_norm: true,
             default_eps: 1e-6,
+            is_moe: false,
         },
         // mistral.yaml
         "mistral" => ArchConstraints {
@@ -72,6 +76,7 @@ fn from_architecture_generated(arch: &str) -> ArchConstraints {
             tied_embeddings: false,
             has_qk_norm: false,
             default_eps: 1e-5,
+            is_moe: false,
         },
         // phi2 (Phi-1.5/Phi-2)
         "phi2" => ArchConstraints {
@@ -84,6 +89,7 @@ fn from_architecture_generated(arch: &str) -> ArchConstraints {
             tied_embeddings: false,
             has_qk_norm: false,
             default_eps: 1e-5,
+            is_moe: false,
         },
         // phi.yaml (Phi-3/Phi-3.5)
         "phi" | "phi3" => ArchConstraints {
@@ -96,6 +102,7 @@ fn from_architecture_generated(arch: &str) -> ArchConstraints {
             tied_embeddings: false,
             has_qk_norm: false,
             default_eps: 1e-5,
+            is_moe: false,
         },
         // gemma.yaml
         "gemma" | "gemma2" => ArchConstraints {
@@ -108,6 +115,7 @@ fn from_architecture_generated(arch: &str) -> ArchConstraints {
             tied_embeddings: true,
             has_qk_norm: false,
             default_eps: 1e-6,
+            is_moe: false,
         },
         // deepseek.yaml — GH-323: fixed eps from 1e-5 to 1e-6 (matches YAML)
         "deepseek" | "deepseek2" => ArchConstraints {
@@ -120,6 +128,7 @@ fn from_architecture_generated(arch: &str) -> ArchConstraints {
             tied_embeddings: false,
             has_qk_norm: false,
             default_eps: 1e-6,
+            is_moe: false,
         },
         // bert.yaml
         "bert" => ArchConstraints {
@@ -132,6 +141,7 @@ fn from_architecture_generated(arch: &str) -> ArchConstraints {
             tied_embeddings: true,
             has_qk_norm: false,
             default_eps: 1e-12,
+            is_moe: false,
         },
         // whisper.yaml
         "whisper" => ArchConstraints {
@@ -144,6 +154,7 @@ fn from_architecture_generated(arch: &str) -> ArchConstraints {
             tied_embeddings: false,
             has_qk_norm: false,
             default_eps: 1e-5,
+            is_moe: false,
         },
         // t5.yaml — PMAT-395: T5 encoder-decoder (realizr#177)
         // T5 uses LayerNorm (not RMSNorm), GELU (DenseReluDense),
@@ -158,6 +169,7 @@ fn from_architecture_generated(arch: &str) -> ArchConstraints {
             tied_embeddings: true,
             has_qk_norm: false,
             default_eps: 1e-6,
+            is_moe: false,
         },
         // mamba.yaml
         "mamba" => ArchConstraints {
@@ -170,6 +182,7 @@ fn from_architecture_generated(arch: &str) -> ArchConstraints {
             tied_embeddings: true,
             has_qk_norm: false,
             default_eps: 1e-5,
+            is_moe: false,
         },
         // qwen3_5.yaml
         "qwen3_5" | "qwen3.5" | "qwen35" => ArchConstraints {
@@ -182,11 +195,21 @@ fn from_architecture_generated(arch: &str) -> ArchConstraints {
             tied_embeddings: false,
             has_qk_norm: false,
             default_eps: 1e-6,
+            is_moe: false,
         },
         // ALB-010: Qwen3 MoE (Qwen3-Coder-30B-A3B: 128 experts, per-head QK norm)
         // and Qwen3.5 MoE (Qwen3.5-35B-A3B: 256 experts, DeltaNet+GQA)
         // Both have per-head Q/K RMSNorm: q_norm.weight/k_norm.weight [head_dim]
-        "qwen3_moe" | "qwen3_5_moe" => ArchConstraints {
+        // M-GPU-MOE-1.3 (qwen3-moe-forward-gpu-v1 v1.3.0): is_moe=true
+        // gates `CudaExecutor::build_indexed_weights` from demanding the
+        // dense FFN tensor names that don't exist in MoE GGUF.
+        //
+        // Both `qwen3_moe` (canonical, post-normalization) and `qwen3moe`
+        // (raw GGUF general.architecture string) are matched. The raw
+        // form is what reaches `ArchConstraints::from_architecture` from
+        // `ValidatedModelConfig::from_apr` (config.rs:404) without going
+        // through `normalize_architecture`.
+        "qwen3_moe" | "qwen3_5_moe" | "qwen3moe" | "qwen3_5moe" => ArchConstraints {
             norm_type: NormType::RmsNorm,
             activation: Activation::Silu,
             positional_encoding: PositionalEncoding::Rope,
@@ -196,6 +219,7 @@ fn from_architecture_generated(arch: &str) -> ArchConstraints {
             tied_embeddings: false,
             has_qk_norm: true,
             default_eps: 1e-6,
+            is_moe: true,
         },
         // falcon_h1.yaml
         "falcon_h1" | "falcon-h1" => ArchConstraints {
@@ -208,6 +232,7 @@ fn from_architecture_generated(arch: &str) -> ArchConstraints {
             tied_embeddings: false,
             has_qk_norm: false,
             default_eps: 1e-6,
+            is_moe: false,
         },
         // openelm.yaml
         "openelm" => ArchConstraints {
@@ -220,6 +245,7 @@ fn from_architecture_generated(arch: &str) -> ArchConstraints {
             tied_embeddings: false,
             has_qk_norm: false,
             default_eps: 1e-6,
+            is_moe: false,
         },
         // moonshine.yaml
         "moonshine" => ArchConstraints {
@@ -232,6 +258,7 @@ fn from_architecture_generated(arch: &str) -> ArchConstraints {
             tied_embeddings: true,
             has_qk_norm: false,
             default_eps: 1e-5,
+            is_moe: false,
         },
         // rwkv7.yaml
         "rwkv7" | "rwkv" => ArchConstraints {
@@ -244,6 +271,7 @@ fn from_architecture_generated(arch: &str) -> ArchConstraints {
             tied_embeddings: false,
             has_qk_norm: false,
             default_eps: 1e-5,
+            is_moe: false,
         },
         // Default: LLaMA-like (most common pattern in modern LLMs)
         _ => ArchConstraints {
@@ -256,6 +284,7 @@ fn from_architecture_generated(arch: &str) -> ArchConstraints {
             tied_embeddings: false,
             has_qk_norm: false,
             default_eps: 1e-5,
+            is_moe: false,
         },
     }
 }

--- a/crates/aprender-serve/src/gguf/config.rs
+++ b/crates/aprender-serve/src/gguf/config.rs
@@ -112,6 +112,17 @@ pub struct ArchConstraints {
     pub has_qk_norm: bool,
     /// Default norm epsilon when GGUF metadata is missing
     pub default_eps: f32,
+    /// Whether this architecture is a Mixture-of-Experts (MoE) variant
+    /// (qwen3_moe, qwen3_5_moe, ...). MoE architectures have per-layer
+    /// expert tensors `blk.{i}.ffn_gate_exps.weight` etc. instead of
+    /// the dense single-tensor names `blk.{i}.ffn_gate.weight` used by
+    /// dense architectures (llama, qwen3, etc.).
+    ///
+    /// Consumers MUST gate dense-FFN-name lookups on `!is_moe`:
+    /// `CudaExecutor::build_indexed_weights` skips ffn_gate/up/down
+    /// weight lookups when this is true (M-GPU-MOE-1.3 per
+    /// `qwen3-moe-forward-gpu-v1` v1.3.0).
+    pub is_moe: bool,
 }
 
 // GH-323: Generated from arch-constraints-v1.yaml by build.rs.

--- a/crates/aprender-serve/src/gguf/cuda/mod.rs
+++ b/crates/aprender-serve/src/gguf/cuda/mod.rs
@@ -265,11 +265,26 @@ impl OwnedQuantizedModelCuda {
         // Run ONE token through both backends and compare logits.
         // If cosine similarity < 0.99, refuse to construct.
         // Skip gate if SKIP_PARITY_GATE=1 (for debugging the gate itself)
+        //
+        // M-GPU-MOE-1.3 (qwen3-moe-forward-gpu-v1 v1.3.0): Skip the
+        // parity gate for MoE architectures. The gate calls
+        // `forward_single_with_cache` (CPU dense) and
+        // `forward_gpu_resident` (GPU dense) — both dense forward
+        // paths that index `layer.ffn_up_weight` directly. For MoE
+        // those weights are `dense_ffn_placeholder` (byte_size=0)
+        // because the real expert tensors live in `moe_layers`, so
+        // the dense forward panics in `fused_matmul_f32` at the
+        // empty data slice.
+        //
+        // The MoE-specific parity gate (FALSIFY-QW3-MOE-GPU-PARITY-001)
+        // is exercised by `qwen3_moe_gpu_parity.rs` which uses the
+        // MoE forward methods directly, bypassing the dense path
+        // this gate runs.
         let skip_gate = std::env::var("SKIP_PARITY_GATE")
             .map(|v| v == "1")
             .unwrap_or(false);
 
-        if !skip_gate {
+        if !skip_gate && !self.model.config.constraints.is_moe {
             if let Err(e) = parity_gate(&mut self) {
                 return Err(CudaInitError {
                     error: e,


### PR DESCRIPTION
## Summary

Implements **M-GPU-MOE-1.3** per `qwen3-moe-forward-gpu-v1` v1.3.0 (PR #1490). Two-commit fix.

## What this PR fixes

| File | Change |
|---|---|
| `gguf/config.rs` | Add `is_moe: bool` field to `ArchConstraints` |
| `gguf/arch_constraints_fallback.rs` | Set `is_moe: true` for qwen3_moe arm; add raw `qwen3moe`/`qwen3_5moe` aliases |
| `cuda/executor/weights.rs` | `build_indexed_weights` skips ffn_gate/up/down lookups when `arch.is_moe` |
| `cuda/types.rs` | `ValidatedLayerWeights::validate` skips FfnGate/FfnUp/FfnDown role checks when `arch.is_moe` |
| `gguf/cuda/mod.rs` | Skip `parity_gate` (Jidoka load-time gate) for MoE — runs dense forward against placeholders |

## Test progression on lambda-vector RTX 4090

```
BEFORE this PR:
  panic at OwnedQuantizedModelCuda::new
  → build_indexed_weights demands `blk.0.ffn_gate.weight` (doesn't exist for MoE)

AFTER commit 1 (build_indexed_weights + ValidatedLayerWeights gates):
  panic at parity_gate (matmul_fused.rs:211)
  → dense forward indexes `layer.ffn_up_weight.data` (placeholder, byte_size=0)

AFTER commit 2 (parity_gate MoE guard):
  ✅ CPU forward succeeds (forward_qwen3_moe LAZY-FUSED-MATVEC)
  ✅ OwnedQuantizedModelCuda construction succeeds  
  ✅ GPU forward executes (forward_qwen3_moe_cuda)
  ❌ Asserts at gpu_logits.iter().all(|v| v.is_finite())
     → GPU produces NaN/Inf (separate downstream numerical bug)
```

## What this PR partially discharges

- **FALSIFY-QW3-MOE-GPU-PRELOAD-001** ✅ — wrapper construction succeeds (was the original bug)
- **FALSIFY-QW3-MOE-GPU-INVARIANTS-001** ⚠️ — partial (output length OK; finiteness FAILS due to NaN/Inf)
- **FALSIFY-QW3-MOE-GPU-PARITY-001** ❌ — blocked by downstream NaN/Inf bug

## New downstream bug (next iteration)

GPU forward produces NaN/Inf logits. Likely M-GPU-MOE-1.5 candidates:
- Q4K matmul accumulator overflow in `expert_swiglu_cuda`
- SwiGLU silu producing Inf for large inputs
- Top-k router weight renormalization div-by-zero
- Missing per-head Q/K RMSNorm in MoE GPU path

Bisection via `apr trace --json --payload` per M32d Step 2 methodology.

## Stacking

This PR depends on PR #1490 (contract v1.2.0 → v1.3.0 amendment + evidence).

## Test plan
- [x] All compile combos clean
- [x] 3 cosine-helper unit tests pass
- [x] Heavy test progresses to GPU forward execution (was: failed at construction)
- [ ] CI ci/gate green
- [ ] PR #1490 lands first

🤖 Generated with [Claude Code](https://claude.com/claude-code)