### PR TITLE
feat(apr-cli + aprender-train + spec): §55 polymorphic preflight relaxation v1.2 → v1.3 FUNCTIONAL

### DIFF
--- a/contracts/apr-pretrain-arch-polymorphic-v1.yaml
+++ b/contracts/apr-pretrain-arch-polymorphic-v1.yaml
@@ -1,12 +1,60 @@
 metadata:
   kind: schema
-  version: 1.2.0
+  version: 1.3.0
   status: FUNCTIONAL
   created: '2026-05-04'
   updated: '2026-05-05'
   author: PAIML Engineering
   registry: true
   changelog:
+  - version: 1.3.0
+    date: '2026-05-05'
+    change: |
+      v1.2.0 → v1.3.0 — refines `qwen_tokenizer_vocab_compatibility`
+      semantic from strict equality to relaxed bound when --init is
+      set (SPEC-SHIP-TWO-001 §55).
+
+      Trigger: §54's LIVE smoke (`evidence/section-54-5g-prereqs-2026-05-05/`)
+      surfaced that public Qwen2.5-Coder-0.5B-Instruct/tokenizer.json
+      materializes 151643 BPE entries + 22 added tokens = 151665
+      effective strings, but config.json declares vocab_size=151936
+      (271 reserved/special slots not in the BPE state machine).
+      Strict equality was correct for §24/§25 from-scratch but too
+      strict for HF-distributed pretrained checkpoints with reserved
+      slots (the standard pattern across Qwen2.5/Llama2/Mistral).
+
+      Relaxed semantic:
+        init=Some  → tokenizer_vocab ≤ model_vocab (HF reserved-slot
+                     tolerance; preserves OOB safety because every
+                     tokenizer-emitted id is in [0, tokenizer_vocab)
+                     ⊆ [0, model_vocab))
+        init=None  → tokenizer_vocab == model_vocab (UNCHANGED;
+                     §24/§25 from-scratch baseline regression-free)
+
+      Implementation: new helper `assert_tokenizer_vocab_within_model_bound`
+      in `aprender-train/src/models/llama_370m.rs` symmetric to
+      `assert_tokenizer_vocab_matches_model`; `preflight_tokenizer_vocab_matches_target`
+      in apr-cli takes a 3rd `init_is_some: bool` parameter and routes
+      to the appropriate assertion.
+
+      Two new falsifiers added at PARTIAL_ALGORITHM_LEVEL:
+        FALSIFY-APR-PRETRAIN-ARCH-009 — relaxed bound accepts
+          tokenizer_vocab ≤ model_vocab under polymorphic init
+          (Qwen reserved-slot pattern: 151665 ≤ 151936 PASSES)
+        FALSIFY-APR-PRETRAIN-ARCH-010 — relaxed bound REJECTS
+          tokenizer_vocab > model_vocab even under polymorphic init
+          (OOB safety: bound is ≤ not <)
+
+      LIVE smoke 2026-05-05T05:48Z: rebuilt apr from this branch +
+      §54-extracted Qwen tokenizer dir at /tmp/qwen-0.5b-tokenizer-extracted
+      + Qwen2.5-Coder-0.5B-Instruct-fp16.apr (declared vocab=151936) →
+      preflight PASSED (no GATE-ARCH / FALSIFY errors). Process
+      proceeded past preflight to weight load (timeout-killed at 30s
+      mid-load; the load itself takes >30s for 942MB FP16 single-thread).
+
+      Status remains FUNCTIONAL: 8 original falsifiers PASS + 2 new
+      relaxed-bound falsifiers PASS = 10/10. Promotion to DISCHARGED
+      still requires §50.4 step 5g.3 LIVE val_loss < 9.38 measurement.
   - version: 1.2.0
     date: '2026-05-05'
     change: |
@@ -180,25 +228,42 @@ equations:
       `preflight_tokenizer_vocab_matches_model()` (the GATE-ARCH-370M-011
       pre-flight in `crates/apr-cli/src/commands/pretrain.rs`) MUST gate
       by the EXTRACTED arch's vocab_size, NOT by the hardcoded
-      `Llama370MConfig::VOCAB_SIZE` (50_257).
-      Specifically:
+      `Llama370MConfig::VOCAB_SIZE` (50_257). The bound semantic is
+      polymorphic per §55:
         With --init present:
           target_vocab = extracted_config.vocab_size
-          (e.g., 151_936 for Qwen2.5-0.5B; 32_000 for LLaMA2;
-                 50_257 for 370M-from-scratch)
+          INVARIANT: tokenizer_vocab ≤ target_vocab  (RELAXED bound)
+          Rationale: HF-distributed checkpoints (Qwen2.5/Llama2/Mistral)
+          materialize fewer string-token entries in tokenizer.json than
+          their config.json declares as `vocab_size` — the gap is
+          reserved/special slots that lm_head + embedding layers have
+          weights for but no tokenizer string maps to. Strict equality
+          would fail-fast on every HF model.
+          Safety: tokenizer-emitted ids ∈ [0, tokenizer_vocab) ⊆
+          [0, model_vocab); reserved high-id slots are never indexed
+          at training time; bound preserves N-09 OOB safety.
         With --init absent:
-          target_vocab = Llama370MConfig::VOCAB_SIZE  (existing behavior)
-      The Qwen tokenizer's vocab.json (151_936 entries) MUST pass
-      pre-flight when --init points at a Qwen2.5 APR file. Same
-      tokenizer with --init absent MUST still fail pre-flight (correct
-      regression on the from-scratch path).
+          target_vocab = Llama370MConfig::VOCAB_SIZE  (50_257)
+          INVARIANT: tokenizer_vocab == target_vocab  (STRICT bound,
+          the §24/§25 from-scratch baseline; preserves
+          INV-ARCH-370M-006 regression-free)
+      The Qwen tokenizer's effective vocab.json (151_643 BPE-only or
+      151_665 BPE+added_tokens) MUST pass pre-flight when --init points
+      at a Qwen2.5 APR file (declared vocab 151_936). Same tokenizer
+      with --init absent MUST still fail pre-flight (correct regression
+      on the from-scratch path).
+      OVERSIZE GUARD: tokenizer_vocab > target_vocab MUST FAIL even
+      under polymorphic init (FALSIFY-APR-PRETRAIN-ARCH-010); bound is
+      ≤, not <. A tokenizer with more strings than the model declares
+      could emit ids ≥ model_vocab → silent embedding-lookup garbage.
     domain: tokenizer-model vocab match boundary
     codomain: bool
     invariants:
-    - "init present → vocab match against extracted config"
-    - "init absent → vocab match against Llama370MConfig::VOCAB_SIZE (regression-free)"
-    - "false-pass (e.g., 50_257 tokenizer with Qwen init) is FAIL-FAST"
-    - "false-fail (e.g., 151_936 tokenizer with Qwen init) is FORBIDDEN"
+    - "init present → tokenizer_vocab ≤ extracted_config.vocab_size (RELAXED, admits HF reserved slots)"
+    - "init absent → tokenizer_vocab == Llama370MConfig::VOCAB_SIZE (STRICT, regression-free)"
+    - "false-pass (e.g., 50_257 tokenizer with Qwen 151_936 init) is FAIL-FAST"
+    - "false-fail (e.g., 151_665 HF Qwen tokenizer with Qwen 151_936 init) is FORBIDDEN"
+    - "OOB-class (tokenizer > model) is FAIL-FAST under both modes"
 
 falsification_tests:
 - id: FALSIFY-APR-PRETRAIN-ARCH-001
@@ -249,6 +314,18 @@ falsification_tests:
   test: "pv validate contracts/apr-pretrain-arch-polymorphic-v1.yaml"
   if_fails: "contract schema noncompliant; will not pass CI gate"
 
+- id: FALSIFY-APR-PRETRAIN-ARCH-009
+  rule: relaxed bound accepts HF reserved-slot tokenizer under polymorphic init
+  prediction: "`assert_tokenizer_vocab_within_model_bound(151_665, 151_936)` returns Ok; `preflight_tokenizer_vocab_matches_target(<dir with 151_665 entries>, 151_936, init_is_some=true)` returns Ok. The §54 LIVE smoke shape (Qwen2.5-Coder-0.5B materialized 151_665 ≤ declared 151_936) MUST PASS preflight under the polymorphic init path."
+  test: "cargo test -p aprender-train --lib -- falsify_apr_pretrain_arch_009_relaxed_bound_accepts_qwen_reserved_slots && cargo test -p apr-cli --lib commands::pretrain::tests::preflight_qwen_reserved_slots_pass_under_polymorphic_init"
+  if_fails: "polymorphic preflight is too strict; HF-distributed tokenizers (Qwen/Llama2/Mistral) cannot be fine-tuned without padding their vocab.json with synthetic reserved tokens — defeats the §50.4 cascade's purpose"
+
+- id: FALSIFY-APR-PRETRAIN-ARCH-010
+  rule: relaxed bound rejects oversized tokenizer even under polymorphic init
+  prediction: "`assert_tokenizer_vocab_within_model_bound(<model_vocab + 1>, model_vocab)` returns Err citing RELAXED + OOB; `preflight_tokenizer_vocab_matches_target(<dir with > target entries>, target, init_is_some=true)` returns Err. Bound is ≤, not <; OOB safety is preserved."
+  test: "cargo test -p aprender-train --lib -- falsify_apr_pretrain_arch_010_relaxed_bound_rejects_oversized_tokenizer && cargo test -p apr-cli --lib commands::pretrain::tests::preflight_oversized_tokenizer_rejected_even_under_polymorphic_init"
+  if_fails: "relaxed bound is too permissive; a tokenizer with more strings than the model expects emits OOB ids → N-09 escape → silent embedding-lookup garbage during training"
+
 proof_obligations:
 - type: invariant
   property: "arch_extraction_signature: init=None preserves Llama370M baseline byte-for-byte"
@@ -276,11 +353,18 @@ kani_harnesses:
 verification_summary:
   total_obligations: 6
   proven: 0
-  tested: 8
+  tested: 10
   status: functional
   notes: |
     Authored 2026-05-04 as §50.4 step 5a of SHIP-TWO-001 MODEL-2
-    architecture-polymorphic pivot. v1.2.0 FUNCTIONAL (2026-05-05):
+    architecture-polymorphic pivot. v1.3.0 FUNCTIONAL (2026-05-05):
+    §55 amendment refines the polymorphic-path bound from strict
+    equality to ≤ (with strict-equality preserved for from-scratch).
+    Two new falsifiers (FALSIFY-009/010) bind the relaxed bound +
+    OOB safety. LIVE smoke confirms preflight passes on §54-extracted
+    Qwen tokenizer.
+
+    v1.2.0 FUNCTIONAL (2026-05-05):
     PR #1494 (5f.4 CLI wireup) merged at 2026-05-05T01:48:14Z, which
     composes the previously-merged helpers via
     `build_shared_trainer_with_init` and routes the live `apr pretrain

--- a/crates/apr-cli/src/commands/pretrain.rs
+++ b/crates/apr-cli/src/commands/pretrain.rs
@@ -16,7 +16,10 @@ use crate::error::{CliError, Result};
 use crate::output;
 use clap::ValueEnum;
 use colored::Colorize;
-use entrenar::models::llama_370m::{assert_tokenizer_vocab_matches_model, Llama370MConfig};
+use entrenar::models::llama_370m::{
+    assert_tokenizer_vocab_matches_model, assert_tokenizer_vocab_within_model_bound,
+    Llama370MConfig,
+};
 use entrenar::train::device::{resolve_device, Device};
 use entrenar::train::pretrain::{
     CheckpointFn, LinearDecaySynthetic, PretrainAbort, PretrainConfig, PretrainLoop, RunStatus,
@@ -322,6 +325,7 @@ fn validate_init_apr_path(path: &Path) -> Result<()> {
 fn preflight_tokenizer_vocab_matches_target(
     tokenizer_dir: &Path,
     target_vocab_size: usize,
+    init_is_some: bool,
 ) -> Result<()> {
     let vocab_path = tokenizer_dir.join("vocab.json");
     let vocab_json = std::fs::read_to_string(&vocab_path).map_err(|e| {
@@ -337,8 +341,17 @@ fn preflight_tokenizer_vocab_matches_target(
                 vocab_path.display()
             ))
         })?;
-    assert_tokenizer_vocab_matches_model(vocab.len(), target_vocab_size)
-        .map_err(CliError::ValidationFailed)
+    // §55: when --init is set (polymorphic path with HF-distributed
+    // checkpoint), allow tokenizer_vocab ≤ model_vocab to admit Qwen-style
+    // reserved-slot vocabularies. When --init is absent (§24/§25 from-scratch
+    // baseline), enforce strict equality to preserve INV-ARCH-370M-006.
+    if init_is_some {
+        assert_tokenizer_vocab_within_model_bound(vocab.len(), target_vocab_size)
+            .map_err(CliError::ValidationFailed)
+    } else {
+        assert_tokenizer_vocab_matches_model(vocab.len(), target_vocab_size)
+            .map_err(CliError::ValidationFailed)
+    }
 }
 
 /// Real-corpus drive: build a shared 370M trainer (CPU or CUDA), split
@@ -373,7 +386,11 @@ fn drive_real(
     let target_vocab = init_arch
         .map(|cfg| cfg.vocab_size)
         .unwrap_or(Llama370MConfig::VOCAB_SIZE);
-    preflight_tokenizer_vocab_matches_target(&config.tokenizer_dir, target_vocab)?;
+    preflight_tokenizer_vocab_matches_target(
+        &config.tokenizer_dir,
+        target_vocab,
+        init_arch.is_some(),
+    )?;
 
     // MVP: pad_id/eos_id both 0. All sequences are uniform length
     // (seq_length + 1) so LMBatch::from_sequences takes the shared
@@ -739,7 +756,7 @@ mod tests {
         // exactly Llama370MConfig::VOCAB_SIZE entries must pass pre-flight.
         let tmp = TempDir::new().expect("tempdir");
         stage_vocab_json(tmp.path(), Llama370MConfig::VOCAB_SIZE);
-        preflight_tokenizer_vocab_matches_target(tmp.path(), Llama370MConfig::VOCAB_SIZE)
+        preflight_tokenizer_vocab_matches_target(tmp.path(), Llama370MConfig::VOCAB_SIZE, false)
             .expect("matching vocab must pass GATE-ARCH-370M-011");
     }
 
@@ -754,8 +771,9 @@ mod tests {
         let tmp = TempDir::new().expect("tempdir");
         let mismatch = Llama370MConfig::VOCAB_SIZE - 1;
         stage_vocab_json(tmp.path(), mismatch);
-        let err = preflight_tokenizer_vocab_matches_target(tmp.path(), Llama370MConfig::VOCAB_SIZE)
-            .expect_err("tokenizer/model vocab mismatch must be rejected");
+        let err =
+            preflight_tokenizer_vocab_matches_target(tmp.path(), Llama370MConfig::VOCAB_SIZE, false)
+                .expect_err("tokenizer/model vocab mismatch must be rejected");
         match err {
             CliError::ValidationFailed(msg) => {
                 assert!(
@@ -781,8 +799,9 @@ mod tests {
         // error) — the operator should know the tokenizer layout is
         // wrong, not that the dataset is empty.
         let tmp = TempDir::new().expect("tempdir");
-        let err = preflight_tokenizer_vocab_matches_target(tmp.path(), Llama370MConfig::VOCAB_SIZE)
-            .expect_err("missing vocab.json must be rejected");
+        let err =
+            preflight_tokenizer_vocab_matches_target(tmp.path(), Llama370MConfig::VOCAB_SIZE, false)
+                .expect_err("missing vocab.json must be rejected");
         match err {
             CliError::ValidationFailed(msg) => {
                 assert!(
@@ -809,7 +828,10 @@ mod tests {
         const QWEN2_VOCAB_SIZE: usize = 151_936;
         let tmp = TempDir::new().expect("tempdir");
         stage_vocab_json(tmp.path(), QWEN2_VOCAB_SIZE);
-        preflight_tokenizer_vocab_matches_target(tmp.path(), QWEN2_VOCAB_SIZE).expect(
+        // §50.4 step 5d called this with init=Some semantic (the polymorphic path). Use
+        // init_is_some=true here per §55 relaxed-bound semantics; vocab.len() == target
+        // is still acceptable under <=.
+        preflight_tokenizer_vocab_matches_target(tmp.path(), QWEN2_VOCAB_SIZE, true).expect(
             "Qwen tokenizer (151_936) MUST pass preflight when target is Qwen-shaped — \
              this is the load-bearing claim of §49 fine-tune from a Qwen2.5 init checkpoint",
         );
@@ -826,11 +848,17 @@ mod tests {
         const QWEN2_VOCAB_SIZE: usize = 151_936;
         let tmp = TempDir::new().expect("tempdir");
         stage_vocab_json(tmp.path(), QWEN2_VOCAB_SIZE);
-        let err = preflight_tokenizer_vocab_matches_target(tmp.path(), Llama370MConfig::VOCAB_SIZE)
-            .expect_err(
-                "Qwen tokenizer (151_936) MUST FAIL preflight when target is Llama370M (50_257) — \
-                 silent-pass would corrupt training",
-            );
+        // §55: this is the from-scratch path (init absent), so init_is_some=false.
+        // Strict equality applies; tokenizer (151_936) ≠ target (50_257) MUST fail.
+        let err = preflight_tokenizer_vocab_matches_target(
+            tmp.path(),
+            Llama370MConfig::VOCAB_SIZE,
+            false,
+        )
+        .expect_err(
+            "Qwen tokenizer (151_936) MUST FAIL preflight when target is Llama370M (50_257) — \
+             silent-pass would corrupt training",
+        );
         match err {
             CliError::ValidationFailed(msg) => {
                 assert!(
@@ -840,6 +868,73 @@ mod tests {
                 assert!(
                     msg.contains(&Llama370MConfig::VOCAB_SIZE.to_string()),
                     "msg must name target Llama vocab size 50_257: {msg}"
+                );
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    /// FALSIFY-APR-PRETRAIN-ARCH-009 (§55) — at preflight level, an HF
+    /// tokenizer with vocab.json count = 151665 (BPE+added, the §54 LIVE
+    /// smoke shape) MUST PASS preflight when target is Qwen 151936 AND
+    /// init_is_some=true (the polymorphic path).
+    #[test]
+    fn preflight_qwen_reserved_slots_pass_under_polymorphic_init() {
+        const QWEN_TOKENIZER_EFFECTIVE: usize = 151_665;
+        const QWEN_DECLARED_VOCAB: usize = 151_936;
+        let tmp = TempDir::new().expect("tempdir");
+        stage_vocab_json(tmp.path(), QWEN_TOKENIZER_EFFECTIVE);
+
+        // init_is_some=true: relaxed bound applies; 151665 ≤ 151936 PASSES.
+        preflight_tokenizer_vocab_matches_target(tmp.path(), QWEN_DECLARED_VOCAB, true).expect(
+            "FALSIFY-APR-PRETRAIN-ARCH-009: HF reserved-slot tokenizer (151_665 ≤ 151_936) \
+             MUST pass preflight under polymorphic init path (§55 relaxed bound)",
+        );
+
+        // init_is_some=false: strict equality applies; 151665 ≠ 151936 FAILS.
+        let err =
+            preflight_tokenizer_vocab_matches_target(tmp.path(), QWEN_DECLARED_VOCAB, false)
+                .expect_err(
+                    "FALSIFY-APR-PRETRAIN-ARCH-009 dual: from-scratch path MUST keep strict ==",
+                );
+        match err {
+            CliError::ValidationFailed(msg) => {
+                assert!(
+                    msg.contains("GATE-ARCH-370M-011")
+                        && msg.contains(&QWEN_TOKENIZER_EFFECTIVE.to_string())
+                        && msg.contains(&QWEN_DECLARED_VOCAB.to_string()),
+                    "strict-mode error must name gate + both sizes: {msg}"
+                );
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    /// FALSIFY-APR-PRETRAIN-ARCH-010 (§55) — at preflight level, a tokenizer
+    /// with MORE entries than the model declares MUST FAIL even under the
+    /// polymorphic init path. This is the OOB-safety guard: such a tokenizer
+    /// could emit ids ≥ model_vocab → silent embedding-lookup garbage.
+    #[test]
+    fn preflight_oversized_tokenizer_rejected_even_under_polymorphic_init() {
+        const QWEN_DECLARED_VOCAB: usize = 151_936;
+        let oversized = QWEN_DECLARED_VOCAB + 100;
+        let tmp = TempDir::new().expect("tempdir");
+        stage_vocab_json(tmp.path(), oversized);
+
+        let err = preflight_tokenizer_vocab_matches_target(
+            tmp.path(),
+            QWEN_DECLARED_VOCAB,
+            true, // polymorphic path
+        )
+        .expect_err(
+            "FALSIFY-APR-PRETRAIN-ARCH-010: oversized tokenizer MUST fail-fast even under \
+             polymorphic init (OOB safety; relaxed bound is ≤ not <)",
+        );
+        match err {
+            CliError::ValidationFailed(msg) => {
+                assert!(
+                    msg.contains("RELAXED") && msg.contains("OOB"),
+                    "polymorphic-mode error must cite RELAXED + OOB: {msg}"
                 );
             }
             other => panic!("unexpected error: {other:?}"),

--- a/crates/aprender-train/src/models/llama_370m.rs
+++ b/crates/aprender-train/src/models/llama_370m.rs
@@ -383,6 +383,45 @@ pub fn assert_tokenizer_vocab_matches_model(
     ))
 }
 
+/// Polymorphic-path variant of [`assert_tokenizer_vocab_matches_model`] that
+/// allows `tokenizer_vocab_size <= model_vocab_size` (per
+/// `apr-pretrain-arch-polymorphic-v1` v1.3.0 §qwen_tokenizer_vocab_compatibility,
+/// SPEC-SHIP-TWO-001 §55). When fine-tuning from an HF-distributed
+/// pretrained checkpoint (Qwen2.5 / Llama2 / Mistral), `tokenizer.json`
+/// commonly materializes fewer string-token entries than the model's
+/// declared `vocab_size` declares. The gap is reserved/special slots
+/// (e.g., `<|reserved_271|>`...) that the lm_head + embedding layers
+/// have weights for but no tokenizer string maps to. Strict equality
+/// (the §24/§25 from-scratch baseline invariant) is too strict for
+/// these models; the relaxed bound preserves the OOB-safety property:
+///
+/// **Safety argument**: tokenizer.encode(text) → ids ∈ [0, tokenizer_vocab).
+/// Embedding/lm_head layers are sized for [0, model_vocab). When
+/// tokenizer_vocab ≤ model_vocab, every encoded id is in-bounds; the
+/// reserved high-id slots are never indexed at training time. When
+/// tokenizer_vocab > model_vocab, the encoder could emit ids ≥ model_vocab
+/// → N-09 OOB → silent garbage gradients → fail-fast.
+///
+/// Returns `Ok(())` when bound holds, `Err(String)` with a machine-diffable
+/// message when violated.
+pub fn assert_tokenizer_vocab_within_model_bound(
+    tokenizer_vocab_size: usize,
+    model_vocab_size: usize,
+) -> Result<(), String> {
+    if tokenizer_vocab_size <= model_vocab_size {
+        return Ok(());
+    }
+    Err(format!(
+        "GATE-ARCH-370M-011 (INV-ARCH-370M-006-RELAXED) violated: \
+         tokenizer vocab_size ({tokenizer_vocab_size}) > model vocab_size \
+         ({model_vocab_size}). See contracts/apr-pretrain-arch-polymorphic-v1.yaml \
+         §qwen_tokenizer_vocab_compatibility — for HF-distributed pretrained \
+         checkpoints, tokenizer_vocab MUST be <= model_vocab (reserved-slot \
+         tolerance); a tokenizer with MORE strings than the model expects \
+         would emit OOB ids → N-09 escape → silent garbage gradients."
+    ))
+}
+
 // ─────────────────────────────────────────────────────────────
 // FALSIFY-SHIP-017 / AC-SHIP2-007 / GATE-ARCH-370M-005
 // ─────────────────────────────────────────────────────────────
@@ -804,6 +843,64 @@ mod tests {
             Llama370MConfig::VOCAB_SIZE
         )
         .is_err());
+    }
+
+    /// FALSIFY-APR-PRETRAIN-ARCH-009 (§55) — relaxed-bound helper accepts
+    /// `tokenizer_vocab <= model_vocab` for the polymorphic init path.
+    /// Discharges the §55 finding: HF-distributed Qwen2.5-Coder-0.5B
+    /// materializes 151643 BPE entries + 22 added = 151665 effective
+    /// strings, but config.json declares `vocab_size = 151936` (271
+    /// reserved slots). The relaxed bound preserves OOB safety while
+    /// admitting the standard HF reserved-slot pattern.
+    #[test]
+    fn falsify_apr_pretrain_arch_009_relaxed_bound_accepts_qwen_reserved_slots() {
+        // The exact §55 LIVE smoke shape: 151665 ≤ 151936 must pass.
+        const QWEN_BPE_PLUS_ADDED: usize = 151_665;
+        const QWEN_DECLARED_VOCAB: usize = 151_936;
+        assert!(
+            assert_tokenizer_vocab_within_model_bound(
+                QWEN_BPE_PLUS_ADDED,
+                QWEN_DECLARED_VOCAB
+            )
+            .is_ok(),
+            "FALSIFY-APR-PRETRAIN-ARCH-009: tokenizer 151665 ≤ model 151936 MUST pass relaxed bound \
+             (HF reserved-slot tolerance)"
+        );
+
+        // BPE-only count (without --include-added-tokens): 151643 ≤ 151936 must also pass.
+        const QWEN_BPE_ONLY: usize = 151_643;
+        assert!(
+            assert_tokenizer_vocab_within_model_bound(QWEN_BPE_ONLY, QWEN_DECLARED_VOCAB).is_ok()
+        );
+
+        // Equality remains acceptable (Llama370M-from-scratch case).
+        assert!(assert_tokenizer_vocab_within_model_bound(
+            Llama370MConfig::VOCAB_SIZE,
+            Llama370MConfig::VOCAB_SIZE
+        )
+        .is_ok());
+    }
+
+    /// FALSIFY-APR-PRETRAIN-ARCH-010 (§55) — relaxed-bound helper REJECTS
+    /// `tokenizer_vocab > model_vocab`. This is the OOB-safety guard:
+    /// a tokenizer producing ids ≥ model_vocab would silently corrupt
+    /// embedding lookup. Strict-greater MUST fail-fast.
+    #[test]
+    fn falsify_apr_pretrain_arch_010_relaxed_bound_rejects_oversized_tokenizer() {
+        const QWEN_DECLARED_VOCAB: usize = 151_936;
+        let oversized = QWEN_DECLARED_VOCAB + 1;
+        let err =
+            assert_tokenizer_vocab_within_model_bound(oversized, QWEN_DECLARED_VOCAB)
+                .expect_err("FALSIFY-APR-PRETRAIN-ARCH-010: tokenizer > model MUST fail-fast");
+        assert!(
+            err.contains("RELAXED") && err.contains("OOB"),
+            "error must cite the relaxed-mode invariant + OOB risk: {err}"
+        );
+        assert!(
+            err.contains(&oversized.to_string())
+                && err.contains(&QWEN_DECLARED_VOCAB.to_string()),
+            "error must name both sizes for forensics: {err}"
+        );
     }
 
     /// INV-ARCH-370M-001 — estimated param count within [366M, 374M].

--- a/docs/specifications/aprender-train/ship-two-models-spec.md
+++ b/docs/specifications/aprender-train/ship-two-models-spec.md
@@ -1,7 +1,8 @@
 # Specification: Ship Two Models — Sovereign AI Stack Proof
 
 **Document ID:** SPEC-SHIP-TWO-001
-**Version:** 2.99.0
+**Version:** 3.00.0
+**Atomic next action (v3.00.0):** **§55 — Polymorphic preflight relaxation: tokenizer_vocab ≤ model_vocab when init=Some; LIVE smoke confirms Qwen extracted tokenizer passes preflight (2026-05-05)** (see new §55 below). §54's LIVE smoke surfaced that public Qwen2.5-Coder-0.5B-Instruct/tokenizer.json materializes 151643 BPE entries + 22 added = 151665 effective strings, but config.json declares vocab_size=151936 (271 reserved/special slots not in tokenizer.json). Strict equality preflight was correct for §24/§25 from-scratch but too strict for HF-distributed pretrained checkpoints with reserved slots. §55 introduces the relaxed bound `tokenizer_vocab ≤ model_vocab` for the polymorphic path (init=Some); strict equality is preserved for the from-scratch path (init=None, regression-free). New helper `assert_tokenizer_vocab_within_model_bound` + extended preflight signature + 4 new tests (2 helper + 2 integration). Contract `apr-pretrain-arch-polymorphic-v1` v1.2.0 → **v1.3.0 FUNCTIONAL** with FALSIFY-009 (relaxed accept) + FALSIFY-010 (oversize reject — OOB safety). LIVE smoke 2026-05-05T05:48Z: rebuilt apr binary + §54-extracted Qwen tokenizer + Qwen 0.5B init APR → preflight PASSED (no GATE-ARCH errors); process proceeded past preflight to weight load (timeout-killed at 30s mid-load). Spec v2.99.0 → **v3.00.0**. **MODEL-1 ship %**: unchanged at **91%**. **MODEL-2 ship %**: unchanged at **57%** until step 5g.3 produces val_loss < 9.38. Coverage tally: 8 → 10 falsifiers in apr-pretrain-arch-polymorphic-v1 (+2 new, all PASS). 5g.1 (corpus retokenize) now technically dispatchable.
 **Atomic next action (v2.99.0):** **§54 — Step 5g has multi-step prerequisites; live preflight smoke proves polymorphic gate fires on Qwen --init + legacy 50257-vocab tokenizer (2026-05-05)** (see new §54 below). Live empirical smoke on canonical 0.5B init APR + canonical 565M-token codeparrot corpus + canonical 50257-vocab tokenizer + freshly-built apr binary (commit 92c7e237b post-#1494) FIRED CORRECTLY: `GATE-ARCH-370M-011 (INV-ARCH-370M-006) violated: tokenizer vocab_size (50257) != model vocab_size (151936)`. This is the FIRST end-to-end runtime evidence that the §50.4 cascade's polymorphic preflight (PR #1476) works in the user-facing CLI (FALSIFY-APR-PRETRAIN-ARCH-005/006 reach LIVE-INTEGRATION level beyond unit-test PARTIAL). But the smoke also surfaces 5g's true scope: a Qwen-vocab tokenizer dir + Qwen-tokenized corpus must exist BEFORE the preflight passes — neither exists on this host today. Step 5g is re-scoped from "1 dispatch, 0 LOC" to **5g.0 (Qwen tokenizer extraction, ~50 LOC) → 5g.1 (Qwen-tokenized corpus, multi-hour wall) → 5g.2 (LIVE 500-step fine-tune, 0 LOC operator-dispatch) → 5g.3 (val_loss < 9.38 verdict)**. Spec v2.98.0 → **v2.99.0**. **MODEL-1 ship %**: unchanged at **91%**. **MODEL-2 ship %**: unchanged at **57%** until step 5g.3 produces val_loss < 9.38 evidence. Coverage tally: snapshot + roadmap re-scoping (no contract status flip — the polymorphic preflight evidence reinforces v1.2.0 FUNCTIONAL but doesn't yet promote to DISCHARGED).
 **Atomic next action (v2.98.0):** **§53 — §50.4 cascade INTEGRATION-COMPLETE on main; `apr pretrain --init` end-to-end runnable; only 5g LIVE remains (2026-05-05)** (see new §53 below). PR #1494 (§50.4 step 5f.4 CLI wireup) MERGED at 01:48:14Z. The `apr pretrain --init <PATH>` flow is now end-to-end functional on CPU: magic-byte validation → arch extraction via `model_config::read_apr_architecture` → polymorphic preflight with EXTRACTED vocab → `build_shared_trainer_with_init` composing 5f.1 (encoder rejection) + 5f.2 (load) + 5f.3 (populate). The legacy "not yet wired" Err from §49 step 4 is RETIRED. CUDA path fail-fasts with FALSIFY-APR-PRETRAIN-INIT-CUDA-001 (5f.5 follow-up). Contract `apr-pretrain-arch-polymorphic-v1` ready for v1.1.0 PARTIAL_ALGORITHM_LEVEL → v1.2.0 FUNCTIONAL bump (8/8 falsifiers PASS on main, integration verified). **§50.4 cascade ships 11 PRs over 2 days** (#1471/#1472/#1473/#1474/#1475/#1476/#1478/#1479/#1481/#1482/#1483/#1486/#1494). Spec v2.97.0 → **v2.98.0**. **MODEL-1 ship %**: unchanged at **91%**. **MODEL-2 ship %**: unchanged at **57%** until step 5g produces val_loss < 9.38 — but step 5g is now operator-dispatchable (the only blocker resolved). Coverage tally: snapshot, contract status flip pending v1.2.0 bump.
 **Atomic next action (v2.97.0):** **§52 — §50.4 cascade ALGORITHM-COMPLETE on main; new step 5f.4 CLI wireup gap identified before 5g LIVE (2026-05-04)** (see new §52 below). Same-day continuation of §51 cascade landed PR #1479 (FALSIFY-APR-PRETRAIN-ARCH-007 encoder/decoder family validator) and PR #1481 (`load_init_tensors_from_apr` in `aprender-train`). #1483 (`populate_trainer_from_init_tensors`, §50.4 step 5f.3) and #1482 (contract `apr-pretrain-arch-polymorphic-v1` v1.0.0 → v1.1.0 PARTIAL_ALGORITHM_LEVEL bump) are MERGEABLE in queue. **All 8 falsifiers in `apr-pretrain-arch-polymorphic-v1` are now bound on main or about to land**: 6 already MERGED (#1474/#1475/#1476/#1478/#1479/#1473), #1483 + #1482 cover the remaining 2 (5f.3 populate + the v1.1.0 contract status bump). **NEW finding from live source inspection of `apr-cli/src/commands/pretrain.rs:259-297`**: even with all helper functions merged (`load_init_tensors_from_apr` + `validate_pretrain_init_arch_compatible` + `populate_trainer_from_init_tensors` + `build_transformer_config` + polymorphic preflight), the CLI dispatch `validate_init_apr_path` HARDCODES an `Err(...not yet wired...)` return — so an operator running `apr pretrain --init <Qwen>.apr` STILL gets a "not yet wired" runtime error. **Step 5f.4 (CLI wireup, ~150 LOC) is the missing connecting step that makes 5g LIVE actually runnable.** Roadmap re-scoped: 5a-5f.3 (algorithm machinery, COMPLETE) → **5f.4 (CLI wireup, NOT YET STARTED)** → 5g (LIVE 500-step fine-tune, gates ship-%) → 5h (stamp + publish). Spec v2.96.0 → **v2.97.0**. **MODEL-1 ship %**: unchanged at **91%**. **MODEL-2 ship %**: unchanged at **57%** until step 5g produces val_loss < 9.38 evidence — but step 5g now requires step 5f.4 to land first. Coverage tally unchanged this cycle (snapshot + roadmap re-scoping, not falsifier flips).
@@ -4475,6 +4476,121 @@ Unchanged from §29 because PR E did not land. Next-session agenda: do the §30.
 Per `feedback_fix_root_cause_never_route_around.md`: the §28 fix would have route-around'd a real bug because the named site (matmul kernel) is not where the divergence originates. The empirical refutation in §30 IS the work that protects the next attempt from shipping a no-op. This refutation is itself a coverage-incrementing artifact (it falsifies a hypothesis), even though no PARTIAL flips to DISCHARGED.
 
 The Toyota Way fix is to bisect upstream, not to flip the kernel call.
+
+## §55. Polymorphic preflight relaxation: tokenizer_vocab ≤ model_vocab when init=Some (2026-05-05)
+
+§54 closed with the §55 follow-up identified: the polymorphic preflight's strict equality semantic is too strict for HF-distributed pretrained checkpoints with reserved slots. This section records the relaxation, the contract amendment, and the LIVE smoke that confirms the fix.
+
+### 55.1 The strictness gap §54 surfaced
+
+§54's evidence `evidence/section-54-5g-prereqs-2026-05-05/preflight-fail-fast-smoke.md` showed the polymorphic preflight firing correctly on a tokenizer-vs-model-vocab mismatch (50257 vs 151936). After PR #1497 landed `apr tokenize import-hf` and §54's chain extended to:
+
+```bash
+apr tokenize import-hf --input <Qwen-tokenizer.json> --output /tmp/qwen-tok-extracted
+# → bpe_vocab=151643, merges=151387, added_tokens=22
+apr pretrain --init <Qwen.apr> --tokenizer /tmp/qwen-tok-extracted ...
+# → ERROR: tokenizer vocab_size (151643/151665) != model vocab_size (151936)
+```
+
+This is **the canonical HF reserved-slot pattern**:
+- Qwen2.5-Coder-0.5B-Instruct's `tokenizer.json` contains 151643 BPE state-machine entries + 22 added tokens (e.g., `<|im_start|>`).
+- Qwen2.5-Coder-0.5B-Instruct's `config.json` declares `vocab_size = 151936`.
+- Gap (271 entries) is reserved/special slots: the lm_head + embedding layers have weights for IDs 151665..151935, but no tokenizer string maps to those IDs.
+- This pattern repeats across Qwen2.5/Llama2/Mistral/Phi families.
+
+Strict equality preflight (`tokenizer_vocab == model_vocab`) was correct for §24/§25 from-scratch training (where the operator trains a tokenizer to exactly match the model). It is **wrong** for HF-distributed pretrained checkpoints.
+
+### 55.2 The relaxation
+
+| Path | Bound | Rationale |
+|---|---|---|
+| `init=None` (from-scratch) | `tokenizer_vocab == model_vocab` | UNCHANGED. §24/§25 baseline regression-free. INV-ARCH-370M-006 preserved. |
+| `init=Some` (polymorphic) | `tokenizer_vocab ≤ model_vocab` | NEW per §55. Admits HF reserved slots. OOB-safe because tokenizer-emitted ids ∈ [0, tokenizer_vocab) ⊆ [0, model_vocab). |
+
+**OOB safety argument**: A tokenizer with `tokenizer_vocab` entries can only emit ids in [0, tokenizer_vocab). When `tokenizer_vocab ≤ model_vocab`, every id is in the model's embedding/lm_head domain. Reserved high-id slots (in the model but not the tokenizer) are never indexed at training time. The N-09 OOB escape in `Embedding::forward` cannot fire.
+
+**Symmetric guard**: `tokenizer_vocab > model_vocab` MUST FAIL even under `init=Some` — bound is `≤`, not `<`. A tokenizer with MORE strings than the model declares could emit ids ≥ model_vocab → silent embedding-lookup garbage. FALSIFY-APR-PRETRAIN-ARCH-010 pins this.
+
+### 55.3 What this PR ships
+
+| Artifact | Change | Falsifier |
+|---|---|---|
+| `aprender-train/src/models/llama_370m.rs` | New helper `assert_tokenizer_vocab_within_model_bound` symmetric to `assert_tokenizer_vocab_matches_model` | (helper for FALSIFY-009/010) |
+| `apr-cli/src/commands/pretrain.rs::preflight_tokenizer_vocab_matches_target` | 3rd `init_is_some: bool` param; routes to relaxed/strict assertion | (integration call site) |
+| `apr-cli/src/commands/pretrain.rs::drive_real` | Passes `init_arch.is_some()` to preflight | (integration call site) |
+| `contracts/apr-pretrain-arch-polymorphic-v1.yaml` | v1.2.0 → v1.3.0 FUNCTIONAL; refined `qwen_tokenizer_vocab_compatibility` invariant; added FALSIFY-009 + FALSIFY-010 | FALSIFY-APR-PRETRAIN-ARCH-009/010 PASS |
+| `falsify_apr_pretrain_arch_009_relaxed_bound_accepts_qwen_reserved_slots` | aprender-train unit test | FALSIFY-009 PASS |
+| `falsify_apr_pretrain_arch_010_relaxed_bound_rejects_oversized_tokenizer` | aprender-train unit test | FALSIFY-010 PASS |
+| `preflight_qwen_reserved_slots_pass_under_polymorphic_init` | apr-cli integration test | FALSIFY-009 INTEGRATION PASS |
+| `preflight_oversized_tokenizer_rejected_even_under_polymorphic_init` | apr-cli integration test | FALSIFY-010 INTEGRATION PASS |
+| `evidence/section-55-relaxed-preflight-2026-05-05/relaxed-preflight-passes-smoke.md` | LIVE smoke evidence | FALSIFY-009 LIVE-INTEGRATION |
+
+### 55.4 LIVE smoke
+
+```bash
+# Rebuilt apr binary from this branch + §54-extracted Qwen tokenizer:
+timeout 30 apr pretrain \
+  --tokenizer /tmp/qwen-0.5b-tokenizer-extracted \
+  --init /mnt/nvme-raid0/models/qwen2.5-coder-0.5b-instruct-fp16.apr \
+  --mode finetune --num-steps 1 --device cpu \
+  --vocab-size 151936 --batch-size 1 --seq-length 32
+
+# Result: exit=124 (timeout), AFTER preflight passed.
+# Output: Configuration printed + Device: cpu + (proceeded to weight load)
+# No GATE-ARCH-370M-011 violations.
+```
+
+Evidence: `evidence/section-55-relaxed-preflight-2026-05-05/relaxed-preflight-passes-smoke.md`.
+
+### 55.5 Falsifier scoreboard for `apr-pretrain-arch-polymorphic-v1`
+
+| # | Falsifier | What it pins | Status |
+|---|---|---|---|
+| 001 | qwen2_0_5b matches HF | INTEGRATION (§53) |
+| 002 | init=None preserves Llama370M | INTEGRATION (§53) |
+| 003 | init=Some pass-through | INTEGRATION (§53) |
+| 004 | GQA-7:1 forward smoke | PARTIAL_ALGORITHM_LEVEL |
+| 005 | Qwen tokenizer + Qwen --init pass | INTEGRATION (§53) + LIVE (§55) |
+| 006 | Qwen tokenizer + no --init fail | INTEGRATION (§53) |
+| 007 | Encoder/decoder family validator | INTEGRATION (§53) |
+| 008 | pv validate exits 0 | PARTIAL_ALGORITHM_LEVEL |
+| **009** | **Relaxed bound accepts HF reserved slots** | **PARTIAL_ALGORITHM_LEVEL + LIVE smoke (§55)** |
+| **010** | **Relaxed bound rejects oversized (OOB safety)** | **PARTIAL_ALGORITHM_LEVEL (§55)** |
+
+10/10 falsifiers PASS. Contract status remains FUNCTIONAL (no regression; the v1.3.0 bump adds 2 falsifiers + LIVE smoke evidence for FALSIFY-009).
+
+### 55.6 5g roadmap status update
+
+| # | Step | LOC / wall | Status |
+|---|------|------------|--------|
+| 5g.0 | `apr tokenize import-hf` | ~700 LOC | ✅ MERGED PR #1497 |
+| **5g.0.1** | **Polymorphic preflight relaxation (§55)** | **~140 LOC** | **THIS PR** |
+| 5g.1 | Re-tokenize codeparrot corpus with Qwen vocab | 0 LOC + ~10 hr operator-dispatch | now technically dispatchable |
+| 5g.2 | LIVE 500-step fine-tune dispatch | 0 LOC + ~20-60 min | gated on 5g.1 |
+| 5g.3 | val_loss < 9.38 verdict; flip MODEL-2 ship % 57% → ≥58% | 0 LOC | gated on 5g.2 |
+
+5g.1 has unblocked. The 10-hour wall is the operator's call (per `feedback_compute_pre_authorized.md`, named training/tokenization runs are pre-authorized below 48h).
+
+### 55.7 Five Whys
+
+1. **Why did §54 not catch the strictness gap?** §54 was authored from the legacy-tokenizer perspective (50257 vs 151936 — a vastly larger mismatch). It didn't probe the within-Qwen case (151643/151665 vs 151936) because the §54 smoke used the legacy 50257-vocab tokenizer dir (which §50.4 shipped before §54's tokenizer extraction tooling existed). The within-Qwen case only surfaces AFTER 5g.0 lands.
+2. **Why is the bound `≤` and not `==` even for the polymorphic path?** Because HF-distributed checkpoints standardly declare a vocab_size that exceeds tokenizer.json's materialized count. Strict equality would fail on every Qwen/Llama2/Mistral checkpoint without manual padding — defeats the entire §50.4 cascade purpose.
+3. **Why preserve strict equality on the from-scratch path?** Because §24/§25's evidence was gathered under strict equality; weakening the gate retroactively could mask future from-scratch tokenizer drift bugs (the original incident at commit 29607ed33 that motivated INV-ARCH-370M-006). The from-scratch path doesn't need the relaxation; it would only erode the safety bound.
+4. **Why a new helper `assert_tokenizer_vocab_within_model_bound` instead of a mode parameter on the existing helper?** Because the existing `assert_tokenizer_vocab_matches_model` is referenced by 1+ external callers (training-loop-pretrain-v1 contract, llama-370m-sovereign-v1) that explicitly want strict equality. A mode parameter would be backward-incompatible. Two helpers + a routing call site at the preflight level is the smallest delta.
+5. **Why pin both FALSIFY-009 (accept) and FALSIFY-010 (reject) rather than just one?** Because the bound is `≤`, not `<`. Without FALSIFY-010, a regression that loosens to `tokenizer_vocab > model_vocab` would silently restore N-09 OOB risk; that regression is exactly the class FALSIFY-010 catches.
+
+### 55.8 Net effects
+
+- Spec v2.99.0 → **v3.00.0** (rolling over to 3.x as the §50.4 cascade pivots from polymorphic infrastructure to live training prerequisites).
+- Contract `apr-pretrain-arch-polymorphic-v1` v1.2.0 → **v1.3.0 FUNCTIONAL** (10 falsifiers, all PASS).
+- 5g.0.1 lands as a single PR; 5g.1 unblocked.
+- **MODEL-1 ship %**: unchanged at **91%**.
+- **MODEL-2 ship %**: unchanged at **57%** until 5g.3 produces val_loss < 9.38 evidence.
+- Coverage tally: +2 PARTIAL_ALGORITHM_LEVEL falsifiers (FALSIFY-009/010) added to the v1.3.0 contract; LIVE-INTEGRATION reinforces FALSIFY-005/009.
+
+### 55.9 Spec amendment cadence preserved
+
+§41 → §42 → §43 → §44 → §45 → §46 → §47 → §48 → §49 → §50 → §51 → §52 → §53 → §54 → §55. Fifteen amendments since 2026-05-03. §55 closes the same-day continuation chain that §54 opened — the four-section pattern (52 gap → 53 fill → 54 next gap → 55 fill) is the canonical falsifier-first cadence.
 
 ## §54. Step 5g has multi-step prerequisites; live preflight smoke proves polymorphic gate fires on Qwen --init + legacy 50257-vocab tokenizer (2026-05-05)
 

--- a/evidence/section-55-relaxed-preflight-2026-05-05/relaxed-preflight-passes-smoke.md
+++ b/evidence/section-55-relaxed-preflight-2026-05-05/relaxed-preflight-passes-smoke.md
@@ -1,0 +1,77 @@
+# LIVE smoke: §55 relaxed preflight passes on §54-extracted Qwen tokenizer
+
+**Date:** 2026-05-05T05:48Z
+**Branch:** feat/section-55-polymorphic-preflight-relaxation (this PR).
+**Spec ref:** SPEC-SHIP-TWO-001 §55.
+**Contract:** apr-pretrain-arch-polymorphic-v1 v1.3.0 FUNCTIONAL.
+**Falsifiers exercised:** FALSIFY-APR-PRETRAIN-ARCH-009 (LIVE) + 010 (unit-test only).
+
+## Inputs
+
+- **Init APR:** `qwen2.5-coder-0.5b-instruct-fp16.apr` (declared vocab=151936).
+- **Tokenizer dir:** `/tmp/qwen-0.5b-tokenizer-extracted` (vocab.json with 151643 BPE entries — produced by §54's PR #1497 `apr tokenize import-hf` LIVE smoke).
+- **Corpus shards:** `/mnt/nvme-raid0/data/codeparrot-python-permissive-shards`.
+- **Binary:** `apr` rebuilt from this branch at `/mnt/nvme-raid0/targets/aprender/release/apr`.
+
+## Command
+
+```bash
+timeout 30 apr pretrain \
+  --dataset /mnt/nvme-raid0/data/codeparrot-python-permissive-shards \
+  --tokenizer /tmp/qwen-0.5b-tokenizer-extracted \
+  --run-dir /tmp/apr-55-smoke/run-1 \
+  --init /mnt/nvme-raid0/models/qwen2.5-coder-0.5b-instruct-fp16.apr \
+  --mode finetune --num-steps 1 --device cpu --seed 42 \
+  --vocab-size 151936 --batch-size 1 --seq-length 32
+```
+
+## Result
+
+Process timeout-killed at 30s (exit=124) AFTER the preflight passed:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  apr pretrain — SHIP-TWO-001 MODEL-2 training loop
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+=== Configuration ===
+    Dataset: /mnt/nvme-raid0/data/codeparrot-python-permissive-shards
+    Tokenizer: /tmp/qwen-0.5b-tokenizer-extracted
+    Run dir: /tmp/apr-55-smoke/run-1
+    LR max: 5.00e-5
+    Total steps: 1
+    Warmup steps: 100
+    Batch × seq: 1 × 32
+    Steps / epoch: 100
+    Seed: 42
+    Target val_loss: 2.20
+
+    Device: cpu
+```
+
+**No GATE-ARCH-370M-011 errors. No FALSIFY violations. No `violated:` lines.**
+
+The process proceeded past preflight to weight load + forward-pass attempt; timeout fired at 30s (the 942MB FP16 weight load alone takes longer than 30s single-threaded on CPU; this smoke confirms preflight pass, not full training).
+
+## What this proves
+
+- **FALSIFY-APR-PRETRAIN-ARCH-009 LIVE-DISCHARGE-INTEGRATION**: the relaxed bound `tokenizer_vocab (151643) ≤ model_vocab (151936)` accepts an HF-distributed Qwen2.5 tokenizer dir under the polymorphic init path. Step 5g.1 (corpus retokenize) is now technically dispatchable.
+- §55 amendment is **internally consistent**: code change + contract bump + helper test + integration test + LIVE smoke all align.
+- §54's "5g.0 unblocks 5g.1 modulo §55" assertion is **resolved**: 5g.1 is now actually dispatchable (modulo the multi-hour wall the operator must accept).
+
+## What this does NOT yet prove
+
+- Full forward-pass numerical correctness on the loaded Qwen weights (the timeout cut the run before the first step completed).
+- Convergence behavior — `val_loss < 9.38` is still 5g.3.
+- Correctness of `populate_trainer_from_init_tensors` on a 0.5B FP16 source vs the trainer's 290-tensor expected shape (the load might still error on shape mismatch when the timeout-killed process eventually got there).
+
+These are tracked as 5g.2 / 5g.3 follow-up work.
+
+## Files referenced
+
+- `crates/aprender-train/src/models/llama_370m.rs::assert_tokenizer_vocab_within_model_bound` (this PR).
+- `crates/apr-cli/src/commands/pretrain.rs::preflight_tokenizer_vocab_matches_target` (this PR — extended signature).
+- `contracts/apr-pretrain-arch-polymorphic-v1.yaml` v1.3.0 FUNCTIONAL (this PR).
+- `evidence/section-54-5g-prereqs-2026-05-05/preflight-fail-fast-smoke.md` — §54's complementary fail-fast smoke that triggered §55.
+- `evidence/section-50-4-step-5g-0-import-hf-2026-05-05/live-extraction-smoke.md` — §54's tokenizer extraction (PR #1497).


### PR DESCRIPTION
## Summary

Implements §55 per spec §54 (PR #1496) finding. Refines the polymorphic-path preflight semantic from strict equality to relaxed bound (\`tokenizer_vocab ≤ model_vocab\`) when \`--init\` is set, while preserving strict equality for the from-scratch path. Bumps contract v1.2.0 → **v1.3.0 FUNCTIONAL**. Unblocks 5g.1 (corpus retokenize with Qwen vocab).

## Why

§54 LIVE smoke + 5g.0 (PR #1497) chain surfaced that public Qwen2.5-Coder-0.5B-Instruct's \`tokenizer.json\` materializes 151643 BPE entries + 22 added = **151665 effective**, but \`config.json\` declares **vocab_size = 151936**. The 271-slot gap is reserved/special slots — the lm_head + embedding layers have weights for IDs 151665..151935, but no tokenizer string maps to them. This is the canonical HF reserved-slot pattern across Qwen2.5/Llama2/Mistral.

Strict equality preflight was correct for §24/§25 from-scratch (where tokenizer is trained to exactly match) but **wrong** for HF-distributed pretrained checkpoints.

## What ships

| Artifact | Change |
|---|---|
| \`aprender-train/src/models/llama_370m.rs\` | New helper \`assert_tokenizer_vocab_within_model_bound\` |
| \`apr-cli/src/commands/pretrain.rs\` | \`preflight_tokenizer_vocab_matches_target\` takes \`init_is_some: bool\`; \`drive_real\` routes through it |
| Contract v1.2.0 → v1.3.0 FUNCTIONAL | refined \`qwen_tokenizer_vocab_compatibility\` formula + invariants |
| FALSIFY-APR-PRETRAIN-ARCH-009 | NEW: relaxed bound accepts HF reserved slots |
| FALSIFY-APR-PRETRAIN-ARCH-010 | NEW: relaxed bound rejects oversized (OOB safety) |
| 4 new tests (2 helper + 2 integration) | All PASS |
| \`evidence/section-55-relaxed-preflight-2026-05-05/\` | LIVE smoke evidence |
| \`docs/specifications/aprender-train/ship-two-models-spec.md\` | §55 amendment |

## LIVE smoke

\`\`\`
$ timeout 30 apr pretrain \\
    --init <Qwen2.5-Coder-0.5B-Instruct-fp16.apr> \\
    --tokenizer /tmp/qwen-0.5b-tokenizer-extracted \\
    --mode finetune --num-steps 1 --device cpu --vocab-size 151936
exit=124  # timeout, AFTER preflight passed
# No GATE-ARCH-370M-011 violations in output
\`\`\`

Process proceeded past preflight to weight load (timeout fired at 30s mid-load). FALSIFY-APR-PRETRAIN-ARCH-009 LIVE-INTEGRATION DISCHARGE.

## Five Whys

1. **Why did §54 not catch this?** §54 used legacy 50257-vocab tokenizer (not §54's own extracted Qwen tokenizer); within-Qwen mismatch only surfaces after 5g.0 lands.
2. **Why bound is ≤ not ==?** HF checkpoints standardly declare vocab > tokenizer materialized; strict-equality would fail every Qwen/Llama2/Mistral.
3. **Why preserve strict equality on from-scratch?** §24/§25 evidence was under strict; weakening retroactively could mask future from-scratch tokenizer-drift bugs.
4. **Why new helper rather than mode param on existing?** External callers (\`training-loop-pretrain-v1\` contract, \`llama-370m-sovereign-v1\`) explicitly want strict; mode param would be backward-incompatible.
5. **Why pin both FALSIFY-009 (accept) and FALSIFY-010 (reject)?** Bound is ≤, not <. Without FALSIFY-010, a regression to \`tokenizer_vocab > model_vocab\` would silently restore N-09 OOB risk.

## Test plan
- [x] \`pv validate contracts/apr-pretrain-arch-polymorphic-v1.yaml\` exits 0
- [x] PMAT pre-commit quality gates pass
- [x] 3/3 aprender-train llama_370m helper tests pass (existing strict + 2 new relaxed)
- [x] 7/7 apr-cli preflight tests pass (5 existing + 2 new integration)
- [x] LIVE smoke: relaxed preflight passes on §54-extracted Qwen tokenizer
- [ ] CI gate green (workspace-test, ci/gate)
- [ ] Auto-merge fires on green CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)