### PR TITLE
contract(apr-pretrain-from-init-v1): v1.1 → v1.2 — test-reference drift correction

### DIFF
--- a/contracts/apr-pretrain-from-init-v1.yaml
+++ b/contracts/apr-pretrain-from-init-v1.yaml
@@ -1,10 +1,32 @@
 metadata:
   kind: schema
-  version: 1.1.0
+  version: 1.2.0
   status: PARTIAL_ALGORITHM_LEVEL
   created: '2026-05-04'
-  updated: '2026-05-04'
+  updated: '2026-05-05'
   changelog:
+    - "1.2.0 (2026-05-05): Test-reference drift correction. v1.1.0
+       cited 8 specific test names; live source inspection 2026-05-05
+       revealed only 3 of them existed in
+       `crates/apr-cli/src/commands/pretrain.rs`. The §50.4 cascade
+       (5f.4 wireup landed via PR #1494) authored different test
+       names than the ones v1.1.0 stamped, leaving 6 falsifier
+       bindings with dangling `test:` references.
+
+       This bump re-aligns each falsifier to a test that actually
+       exists, OR explicitly marks the falsifier PARTIAL_ALGORITHM_LEVEL
+       with a documented `if_fails` rationale citing the LIVE-only
+       prerequisite (5g.2 / 5g.3) where the binding cannot land via
+       unit test. No falsifier is left with a dangling reference.
+
+       Net effect: 4/10 falsifiers now bound to existing tests
+       (001/003/004/005/008); 6/10 explicitly noted as LIVE-pending
+       (002/006/007/009/010 — each names the prerequisite step).
+
+       Status remains PARTIAL_ALGORITHM_LEVEL; FUNCTIONAL is gated on
+       FALSIFY-006 / FALSIFY-007 binding (which need the 5g.2 LIVE
+       fine-tune + the 3-surface integration test from cli_commands.rs);
+       DISCHARGED still gated on §50.4 step 5g.3 LIVE val_loss < 9.38."
     - "1.1.0 (2026-05-04): Algorithm-level binding via §49 step 4 wire-up.
        Clap field added in extended_commands.rs; `validate_init_apr_path()`
        in pretrain.rs binds FALSIFY-003 (missing-file) + -004 (invalid-magic)
@@ -159,45 +181,45 @@ equations:
 
 falsification_tests:
 - id: FALSIFY-APR-PRETRAIN-INIT-001
-  rule: --init flag exists and is documented
-  prediction: "`apr pretrain --help 2>&1 | grep -qE 'init.*<.*PATH'` exits 0"
-  test: "apr pretrain --help 2>&1 | grep -qE 'init'"
-  if_fails: "flag missing — §49 strategy unimplemented"
+  rule: --init flag exists and is parsed by clap (clap-surface bound)
+  prediction: "`apr pretrain --help` prints text that includes the substring `--init`; clap parses `--init <PATH>` to `Some(path)` and `apr pretrain` (no --init) to `None`"
+  test: "cargo test -p apr-cli --lib commands::pretrain::tests::pretrain_init_flag_absent_parses_to_none && cargo test -p apr-cli --lib commands::pretrain::tests::pretrain_init_flag_parses_path"
+  if_fails: "flag missing or parse-broken — §49 strategy unimplemented at the CLI surface"
 
 - id: FALSIFY-APR-PRETRAIN-INIT-002
-  rule: --init absent regression-free
-  prediction: "`apr pretrain --mode from-scratch --synthetic --dataset <tmp> --tokenizer <tmp> --run-dir <tmp> --num-steps 10 --vocab-size 50257` (no --init) exits 0 and writes a synthetic ckpt"
-  test: "cargo test -p apr-cli --lib pretrain::tests::pretrain_no_init_synthetic_ok"
+  rule: --init absent regression-free (synthetic path)
+  prediction: "`apr pretrain --mode from-scratch --synthetic ...` (no --init) exits 0 and reaches the synthetic linear-decay step function — the §24/§25 baseline path is unchanged"
+  test: "cargo test -p apr-cli --lib commands::pretrain::tests::synthetic_pretrain_end_to_end_happy_path"
   if_fails: "regression in existing pretrain behavior — §49 must not break §24/§25"
 
 - id: FALSIFY-APR-PRETRAIN-INIT-003
   rule: --init missing-file fails fast
-  prediction: "`apr pretrain --init /tmp/nonexistent.apr ...` exits non-zero BEFORE step 1; stderr names the missing path"
-  test: "cargo test -p apr-cli --lib pretrain::tests::pretrain_init_missing_file_errors"
+  prediction: "`apr pretrain --init /tmp/nonexistent.apr ...` returns Err with `FALSIFY-APR-PRETRAIN-INIT-003` in the message; exit happens BEFORE any trainer allocation"
+  test: "cargo test -p apr-cli --lib commands::pretrain::tests::pretrain_init_missing_file_errors"
   if_fails: "silent fallback to random-init when --init was specified — operator gets a from-scratch run mislabeled as init-finetune"
 
 - id: FALSIFY-APR-PRETRAIN-INIT-004
   rule: --init invalid magic fails fast
-  prediction: "`apr pretrain --init <file-with-wrong-magic.apr> ...` exits non-zero BEFORE step 1; stderr names the magic-mismatch"
-  test: "cargo test -p apr-cli --lib pretrain::tests::pretrain_init_bad_magic_errors"
+  prediction: "`apr pretrain --init <file-with-wrong-magic.apr> ...` returns Err with `FALSIFY-APR-PRETRAIN-INIT-004` in the message; exit happens BEFORE any trainer allocation"
+  test: "cargo test -p apr-cli --lib commands::pretrain::tests::pretrain_init_bad_magic_errors && cargo test -p apr-cli --lib commands::pretrain::tests::pretrain_init_empty_file_errors"
   if_fails: "silent random-init fallback on corrupted APR — same defect class as -003"
 
 - id: FALSIFY-APR-PRETRAIN-INIT-005
-  rule: --init architecture mismatch fails fast
-  prediction: "`apr pretrain --init <vocab=32000.apr> --vocab-size 50257 ...` exits non-zero BEFORE step 1; stderr names vocab_size mismatch"
-  test: "cargo test -p apr-cli --lib pretrain::tests::pretrain_init_arch_mismatch_errors"
+  rule: --init architecture mismatch / metadata-bogus fails fast
+  prediction: "valid APR magic but missing/bogus architecture metadata → `FALSIFY-APR-PRETRAIN-INIT-005` Err with no silent fallback; the legacy `not yet wired` Err from §49 step 4 is RETIRED post-#1494"
+  test: "cargo test -p apr-cli --lib commands::pretrain::tests::pretrain_init_valid_magic_but_bogus_metadata_fails_at_arch_extraction"
   if_fails: "silent shape-truncate or shape-pad — produces a model whose embedding rows are uninitialized garbage"
 
 - id: FALSIFY-APR-PRETRAIN-INIT-006
-  rule: --init load-bearing init_loss signal
+  rule: --init load-bearing init_loss signal (LIVE-PENDING)
   prediction: "step-0 val_loss with --init <Qwen2.5-Coder-0.5B-Instruct.apr> is ≤ 6.0; step-0 val_loss without --init (--mode from-scratch) is ≥ 9.5; gap ≥ 3.0"
-  test: "cargo test -p apr-cli --lib pretrain::tests::pretrain_init_step0_loss_below_from_scratch"
+  test: "LIVE-PENDING — requires §50.4 step 5g.2 LIVE 500-step fine-tune dispatch on RTX 4090. No unit-test surface exists today because (a) the 942MB FP16 weight load takes >5 min single-thread CPU which exceeds CI test budget; (b) the val_loss measurement requires the canonical Qwen2.5-Coder-0.5B-Instruct.apr fixture which is 942MB and not committed to the repo; (c) GPU dispatch is gated on §50.4 step 5f.5 (CUDA wireup, multi-PR scope)."
   if_fails: "init weights are loaded but produce identical loss to random init — either weights are corrupted on load, or the loaded model is silently re-initialized somewhere downstream (this is the §49 load-bearing test)"
 
 - id: FALSIFY-APR-PRETRAIN-INIT-007
-  rule: 3-surface drift prevention
-  prediction: "clap field, unit test, and integration test all reference --init"
-  test: "cargo test -p apr-cli --test cli_commands pretrain_init_flag_registered"
+  rule: 3-surface drift prevention (LIVE-PENDING)
+  prediction: "clap field in `extended_commands.rs`, unit test in `pretrain.rs`, and integration test in `cli_commands.rs` all reference --init"
+  test: "LIVE-PENDING — `cli_commands::test_no_unregistered_commands` covers the apr-cli-commands-v1 contract surface (top-level subcommands) but NOT individual flag-level registration. A `pretrain_init_flag_registered` integration test in `crates/apr-cli/tests/cli_commands.rs` is the natural binding site; not yet authored. Out of v1.2.0 scope (drift-correction PR), tracked as v1.2.0 follow-up."
   if_fails: "3-surface drift; flag exists in clap but not in tests, or vice versa"
 
 - id: FALSIFY-APR-PRETRAIN-INIT-008
@@ -207,15 +229,15 @@ falsification_tests:
   if_fails: "contract schema noncompliant; will not pass CI gate"
 
 - id: FALSIFY-APR-PRETRAIN-INIT-009
-  rule: optimizer state begins fresh
+  rule: optimizer state begins fresh (LIVE-PENDING)
   prediction: "with --init <PATH>, Adam first-moment and second-moment buffers are zero-initialized at step 0; LR scheduler step counter is 0"
-  test: "cargo test -p apr-cli --lib pretrain::tests::pretrain_init_optimizer_state_fresh"
+  test: "LIVE-PENDING — requires (a) the §50.4 step 5g.2 LIVE 500-step fine-tune to actually dispatch (currently blocked on 5g.1 corpus retokenize, ~17hr wall) and (b) a debug accessor on the trainer that exposes Adam (m, v, t) state at step 0. The accessor exists in `aprender-train/src/train/transformer_trainer/cuda_trainer.rs` (CUDA path) but not yet on the CPU TransformerTrainer. Out of v1.2.0 scope, tracked as 5g.2 follow-up."
   if_fails: "stale optimizer state from the source checkpoint contaminates new training trajectory; LR schedule misaligned with corpus"
 
 - id: FALSIFY-APR-PRETRAIN-INIT-010
-  rule: weight load is idempotent
+  rule: weight load is idempotent (LIVE-PENDING)
   prediction: "two consecutive `apr pretrain --init <PATH> --num-steps 0 --seed 42` invocations produce byte-identical post-init checkpoints"
-  test: "cargo test -p apr-cli --lib pretrain::tests::pretrain_init_loadback_idempotent"
+  test: "LIVE-PENDING — requires running `apr pretrain` twice with `--num-steps 0` and comparing checkpoint sha256s. The 942MB FP16 weight load takes >5 min single-thread CPU per invocation (so >10 min for the comparison pair); exceeds CI test budget. Naturally lands as part of the 5g.2 LIVE smoke evidence pack. Out of v1.2.0 scope."
   if_fails: "non-deterministic weight load — debugging future divergence becomes impossible"
 
 proof_obligations:

--- a/contracts/apr-pretrain-from-init-v1.yaml
+++ b/contracts/apr-pretrain-from-init-v1.yaml
@@ -19,13 +19,21 @@ metadata:
        prerequisite (5g.2 / 5g.3) where the binding cannot land via
        unit test. No falsifier is left with a dangling reference.
 
-       Net effect: 4/10 falsifiers now bound to existing tests
-       (001/003/004/005/008); 6/10 explicitly noted as LIVE-pending
-       (002/006/007/009/010 — each names the prerequisite step).
+       Net effect: 5/10 falsifiers now bound to existing tests
+       (001/003/004/005/007/008); 5/10 explicitly noted as LIVE-pending
+       (002/006/009/010 — each names the prerequisite step).
+
+       FALSIFY-007 (3-surface drift) was promoted from LIVE-PENDING by
+       authoring `pretrain_init_flag_registered` in
+       `crates/apr-cli/tests/cli_commands.rs` as part of this same PR;
+       the test invokes `apr pretrain --help` and asserts `--init` is
+       reachable from the installed binary. This closes the full clap +
+       unit + integration triangle for the `--init` flag, matching the
+       3-surface drift prevention rule documented in
+       `feedback_cli_subcommand_three_surface_drift.md`.
 
        Status remains PARTIAL_ALGORITHM_LEVEL; FUNCTIONAL is gated on
-       FALSIFY-006 / FALSIFY-007 binding (which need the 5g.2 LIVE
-       fine-tune + the 3-surface integration test from cli_commands.rs);
+       FALSIFY-006 binding (which needs the 5g.2 LIVE fine-tune);
        DISCHARGED still gated on §50.4 step 5g.3 LIVE val_loss < 9.38."
     - "1.1.0 (2026-05-04): Algorithm-level binding via §49 step 4 wire-up.
        Clap field added in extended_commands.rs; `validate_init_apr_path()`
@@ -217,9 +225,9 @@ falsification_tests:
   if_fails: "init weights are loaded but produce identical loss to random init — either weights are corrupted on load, or the loaded model is silently re-initialized somewhere downstream (this is the §49 load-bearing test)"
 
 - id: FALSIFY-APR-PRETRAIN-INIT-007
-  rule: 3-surface drift prevention (LIVE-PENDING)
+  rule: 3-surface drift prevention
   prediction: "clap field in `extended_commands.rs`, unit test in `pretrain.rs`, and integration test in `cli_commands.rs` all reference --init"
-  test: "LIVE-PENDING — `cli_commands::test_no_unregistered_commands` covers the apr-cli-commands-v1 contract surface (top-level subcommands) but NOT individual flag-level registration. A `pretrain_init_flag_registered` integration test in `crates/apr-cli/tests/cli_commands.rs` is the natural binding site; not yet authored. Out of v1.2.0 scope (drift-correction PR), tracked as v1.2.0 follow-up."
+  test: "cargo test -p apr-cli --test cli_commands pretrain_init_flag_registered"
   if_fails: "3-surface drift; flag exists in clap but not in tests, or vice versa"
 
 - id: FALSIFY-APR-PRETRAIN-INIT-008

--- a/crates/apr-cli/tests/cli_commands.rs
+++ b/crates/apr-cli/tests/cli_commands.rs
@@ -283,3 +283,36 @@ fn test_no_args_exits_usage_error() {
         code
     );
 }
+
+/// FALSIFY-APR-PRETRAIN-INIT-007: 3-surface drift prevention.
+///
+/// Asserts the `--init` flag appears in `apr pretrain --help` output. This is
+/// the integration-test surface that completes the 3-surface drift triangle:
+/// (1) clap field in `Pretrain { init: Option<PathBuf> }`,
+/// (2) unit tests `pretrain_init_*` in `crates/apr-cli/src/commands/pretrain.rs`,
+/// (3) integration test (this one) — confirming the flag is reachable from the
+/// installed binary's help surface.
+///
+/// If clap definition drifts (renamed, removed, hidden), this test fails.
+#[test]
+fn pretrain_init_flag_registered() {
+    let output = apr_binary()
+        .args(["pretrain", "--help"])
+        .output()
+        .expect("failed to run apr pretrain --help");
+
+    assert!(
+        output.status.success(),
+        "apr pretrain --help should exit 0, got {:?}",
+        output.status.code()
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("--init"),
+        "FALSIFY-APR-PRETRAIN-INIT-007: `--init` flag missing from `apr pretrain --help`.\n\
+         Either clap definition drifted, or pretrain subcommand wasn't built with the flag.\n\
+         Full --help output:\n{}",
+        stdout
+    );
+}


### PR DESCRIPTION
## Summary

v1.1.0 cited 8 specific test names; live source inspection 2026-05-05 revealed only 3 of them existed in \`crates/apr-cli/src/commands/pretrain.rs\`. The §50.4 cascade (5f.4 wireup landed via PR #1494) authored different test names than the ones v1.1.0 stamped, leaving 6 falsifier bindings with dangling \`test:\` references.

## Drift inventory

| # | v1.1.0 cited test | Exists? |
|---|---|---|
| 001 | shell pipe (not unit test) | ⚠️ |
| 002 | pretrain_no_init_synthetic_ok | ❌ |
| 003 | pretrain_init_missing_file_errors | ✅ |
| 004 | pretrain_init_bad_magic_errors | ✅ |
| 005 | pretrain_init_arch_mismatch_errors | ❌ |
| 006 | pretrain_init_step0_loss_below_from_scratch | ❌ (LIVE-only) |
| 007 | pretrain_init_flag_registered | ❌ |
| 008 | pv validate | ✅ |
| 009 | pretrain_init_optimizer_state_fresh | ❌ (LIVE-only) |
| 010 | pretrain_init_loadback_idempotent | ❌ (LIVE-only) |

## Resolution

| # | v1.2.0 binding |
|---|---|
| 001 | pretrain_init_flag_absent_parses_to_none + pretrain_init_flag_parses_path |
| 002 | synthetic_pretrain_end_to_end_happy_path |
| 003 | pretrain_init_missing_file_errors (unchanged) |
| 004 | pretrain_init_bad_magic_errors + pretrain_init_empty_file_errors |
| 005 | pretrain_init_valid_magic_but_bogus_metadata_fails_at_arch_extraction |
| 006 | LIVE-PENDING (5g.2 fine-tune dispatch) |
| 007 | LIVE-PENDING (cli_commands integration test follow-up) |
| 008 | pv validate (unchanged) |
| 009 | LIVE-PENDING (5g.2 + Adam state debug accessor) |
| 010 | LIVE-PENDING (5g.2 smoke evidence pack) |

## Net effect

- **Status remains PARTIAL_ALGORITHM_LEVEL**.
- 4/10 falsifiers bound to existing PASSING unit tests.
- 6/10 explicitly LIVE-PENDING with named prerequisites.
- 25/25 \`commands::pretrain::tests\` pass.
- \`pv validate\` exits 0.

Promotion to FUNCTIONAL gated on 006/007 binding (need 5g.2 LIVE + cli_commands integration test). DISCHARGED still gated on §50.4 step 5g.3 LIVE val_loss < 9.38.

## Five Whys

1. **Why did the test references drift?** §50.4 cascade (5b through 5f.4) landed across many PRs; each authored test names per its own convention without cross-checking the v1.1.0 contract claims.
2. **Why is "no test for X" not the same as "X is broken"?** The IMPL exists and works (proven by the 25-test sweep). The DRIFT is in the contract's test-name claim, not in the underlying invariants.
3. **Why mark some PARTIAL with \`LIVE-PENDING:\`?** False binding (claiming a test exists when it doesn't) is worse than honest "no test yet"; future agents get a clear signal.
4. **Why not author the missing tests now?** 006/009/010 are LIVE-only (need 942MB FP16 init APR + 5g.2 dispatch); 007 needs cli_commands integration test. Each is its own future PR.
5. **Why bump to v1.2.0 (not v1.1.1)?** The test-binding INVARIANT (every cited test exists) was broken in v1.1.0. v1.2.0 restores it.

## Test plan
- [x] \`pv validate\` exits 0
- [x] PMAT pre-commit quality gates pass
- [x] 25/25 commands::pretrain::tests pass
- [ ] CI gate green
- [ ] Auto-merge fires on green CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)