### PR TITLE
contract(apr-pretrain-arch-polymorphic-v1): v1.4 → v1.5 — fix FALSIFY-005/006 test-reference drift

### DIFF
--- a/contracts/apr-pretrain-arch-polymorphic-v1.yaml
+++ b/contracts/apr-pretrain-arch-polymorphic-v1.yaml
@@ -1,12 +1,45 @@
 metadata:
   kind: schema
-  version: 1.4.0
+  version: 1.5.0
   status: FUNCTIONAL
   created: '2026-05-04'
   updated: '2026-05-05'
   author: PAIML Engineering
   registry: true
   changelog:
+  - version: 1.5.0
+    date: '2026-05-05'
+    change: |
+      v1.4.0 → v1.5.0 — test-reference drift correction for
+      FALSIFY-APR-PRETRAIN-ARCH-005 and FALSIFY-APR-PRETRAIN-ARCH-006.
+
+      Drift inventory (PV-VER-001 class — same defect class as PR #1504
+      caught in apr-pretrain-from-init-v1):
+        FALSIFY-005 cited `preflight_qwen_vocab_passes_with_qwen_init`
+          → does NOT exist in `crates/apr-cli/src/commands/pretrain.rs`.
+          Actual test name authored by PR #1476: `preflight_qwen_vocab_passes_with_qwen_target`.
+        FALSIFY-006 cited `preflight_qwen_vocab_fails_without_init`
+          → does NOT exist. Actual: `preflight_qwen_vocab_fails_with_llama_target`.
+
+      The v1.1.0 changelog entry stamped these names BEFORE PR #1476
+      authored the actual tests; the merge picked semantically-equivalent
+      but textually-different names. The contract's `test:` field stayed
+      stale. v1.4.0 (this contract's most recent bump) didn't catch the
+      drift because CUDA-001 was the focus.
+
+      Same drift class as the apr-pretrain-from-init-v1 v1.2.0 fix
+      (PR #1504, merged 2026-05-05T07:21Z). Per `feedback_no_guessing.md`,
+      contract test references must point to tests that exist; otherwise
+      the falsifier is unfalsifiable.
+
+      No falsifier semantics change. No new tests added. Contract status
+      remains FUNCTIONAL: 11 falsifiers all PASS, including FALSIFY-005
+      and FALSIFY-006 which now reference the existing tests.
+
+      Verified locally:
+        - `cargo test -p apr-cli --lib commands::pretrain::tests::preflight_qwen_vocab_passes_with_qwen_target` PASS
+        - `cargo test -p apr-cli --lib commands::pretrain::tests::preflight_qwen_vocab_fails_with_llama_target` PASS
+        - `pv validate contracts/apr-pretrain-arch-polymorphic-v1.yaml` exits 0.
   - version: 1.4.0
     date: '2026-05-05'
     change: |
@@ -323,13 +356,13 @@ falsification_tests:
 - id: FALSIFY-APR-PRETRAIN-ARCH-005
   rule: Qwen tokenizer (vocab=151_936) passes pre-flight with --init Qwen
   prediction: "preflight_tokenizer_vocab_matches_model() returns Ok with vocab.json containing 151_936 entries when --init points at a Qwen2.5 APR file"
-  test: "cargo test -p apr-cli --lib commands::pretrain::tests::preflight_qwen_vocab_passes_with_qwen_init"
+  test: "cargo test -p apr-cli --lib commands::pretrain::tests::preflight_qwen_vocab_passes_with_qwen_target"
   if_fails: "preflight false-fails on Qwen tokenizer — operator cannot fine-tune Qwen2.5 even with arch-polymorphic builder"
 
 - id: FALSIFY-APR-PRETRAIN-ARCH-006
   rule: Qwen tokenizer with --init absent fails pre-flight
   prediction: "preflight_tokenizer_vocab_matches_model() returns Err with vocab.json containing 151_936 entries when --init is absent (target=Llama370MConfig::VOCAB_SIZE=50_257)"
-  test: "cargo test -p apr-cli --lib commands::pretrain::tests::preflight_qwen_vocab_fails_without_init"
+  test: "cargo test -p apr-cli --lib commands::pretrain::tests::preflight_qwen_vocab_fails_with_llama_target"
   if_fails: "preflight false-passes — from-scratch path silently accepts wrong-vocab tokenizer"
 
 - id: FALSIFY-APR-PRETRAIN-ARCH-007


### PR DESCRIPTION
## Summary

Same drift class as PR #1504 caught in apr-pretrain-from-init-v1. Test names cited in v1.1.0 changelog never matched the actual tests PR #1476 authored. Drift survived three intervening bumps (v1.1→v1.2→v1.3→v1.4) because each focused on adding new falsifiers, not auditing existing bindings.

## Drift inventory

| Falsifier | v1.4.0 cited test | Exists? | Actual test |
|---|---|---|---|
| FALSIFY-005 | \`preflight_qwen_vocab_passes_with_qwen_init\` | ❌ | \`preflight_qwen_vocab_passes_with_qwen_target\` |
| FALSIFY-006 | \`preflight_qwen_vocab_fails_without_init\` | ❌ | \`preflight_qwen_vocab_fails_with_llama_target\` |

## Resolution

Update the \`test:\` field for FALSIFY-005 and FALSIFY-006 to reference the actual tests authored by PR #1476. No falsifier semantics change. No new tests added.

## Verification
- \`cargo test -p apr-cli --lib -- commands::pretrain::tests::preflight_qwen_vocab_passes_with_qwen_target\` PASS
- \`cargo test -p apr-cli --lib -- commands::pretrain::tests::preflight_qwen_vocab_fails_with_llama_target\` PASS
- \`pv validate contracts/apr-pretrain-arch-polymorphic-v1.yaml\` exits 0

## Five Whys

1. **Why did the drift survive 3 bumps?** Each bump (v1.2/v1.3/v1.4) focused on ADDING new content (CUDA-001, relaxed bound, etc.); none audited existing bindings.
2. **Why didn't the §50.4 cascade catch this?** The cascade authored tests; the contract was authored separately. Names diverged at the boundary; no cross-check landed.
3. **Why is this a contract-only fix?** The tests exist and pass — only the contract's text reference needed correction.
4. **Why bump to v1.5.0?** Same logic as PR #1504: the test-binding INVARIANT was broken; v1.5.0 restores it.
5. **Why important if the impl is correct?** Per \`feedback_no_guessing.md\`, contracts citing non-existent tests are unfalsifiable. Better to fix than wait for PV-VER-001 lint to flag.

## Net effects

- Contract v1.4.0 → v1.5.0 FUNCTIONAL.
- 11 falsifiers, all PASS — same count, but FALSIFY-005/006 now reference real tests.
- MODEL-1 ship % unchanged at 91%; MODEL-2 ship % unchanged at 57% until 5g.3.

Hygiene work while 5g.1 (~12hr) corpus retokenize runs. Same defect class as PR #1504; together they close test-reference drift across both pretrain contracts.

## Test plan
- [x] \`pv validate\` exits 0
- [x] PMAT pre-commit quality gates pass
- [x] Both cited tests pass
- [ ] CI gate green
- [ ] Auto-merge fires on green CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)