### PR TITLE
contract+test(apr-cli-tokenize-import-hf-v1): v1.0 → v1.1 — bind FALSIFY-001 with real integration test

### DIFF
--- a/contracts/apr-cli-tokenize-import-hf-v1.yaml
+++ b/contracts/apr-cli-tokenize-import-hf-v1.yaml
@@ -1,12 +1,45 @@
 metadata:
   kind: schema
-  version: 1.0.0
+  version: 1.1.0
   status: PARTIAL_ALGORITHM_LEVEL
   created: '2026-05-05'
   updated: '2026-05-05'
   author: PAIML Engineering
   registry: true
   changelog:
+  - version: 1.1.0
+    date: '2026-05-05'
+    change: |
+      v1.0.0 → v1.1.0 — bind FALSIFY-TOK-IMPORT-HF-001 to a real
+      integration test.
+
+      v1.0.0 stamped a vague test reference for FALSIFY-001:
+        "cargo test -p apr-cli --test cli_commands -- --nocapture
+         (or equivalent) reports import-hf as a registered tokenize
+         subcommand"
+      This was not a runnable invocation — same drift class as PR
+      #1504 + PR #1505 caught for sibling pretrain contracts.
+
+      This bump:
+        - Adds `tokenize_import_hf_subcommand_registered` integration
+          test in `crates/apr-cli/tests/cli_commands.rs` that runs
+          `apr tokenize import-hf --help` and asserts (a) exit 0,
+          (b) `--input`, `--output`, `--include-added-tokens` flags
+          appear in stdout. Pins the 3-surface drift triangle:
+            (1) clap variant TokenizeCommands::ImportHf
+            (2) unit tests commands::tokenize::tests::import_hf_*
+            (3) integration test (this new one)
+        - Updates FALSIFY-001 `test:` field to cite the new test by name.
+
+      No falsifier semantics change. Status remains
+      PARTIAL_ALGORITHM_LEVEL: 5/5 falsifiers PASS, but the contract
+      hasn't yet seen the LIVE evidence that promotes to FUNCTIONAL
+      (per v1.0.0 changelog: "Promotion to FUNCTIONAL requires 5g.1
+      LIVE: extract Qwen2.5-Coder-0.5B-Instruct tokenizer.json on
+      canonical host AND have downstream `apr tokenize encode-corpus`
+      succeed without modification" — this happened in §56 LIVE smoke
+      but the contract status flip waits for full-corpus completion
+      via the in-flight 5g.1 dispatch).
   - version: 1.0.0
     date: '2026-05-05'
     change: |
@@ -98,9 +131,9 @@ equations:
 falsification_tests:
 - id: FALSIFY-TOK-IMPORT-HF-001
   rule: command is registered in apr tokenize subcommand surface
-  prediction: "`apr tokenize import-hf --help` prints help text and exits 0; the subcommand is recognized in the dispatch path"
-  test: "cargo test -p apr-cli --test cli_commands -- --nocapture (or equivalent) reports import-hf as a registered tokenize subcommand"
-  if_fails: "subcommand was added to TokenizeCommands enum but dispatch surface did not pick it up — three-surface drift per feedback_cli_subcommand_three_surface_drift.md"
+  prediction: "`apr tokenize import-hf --help` exits 0 and prints help text containing `--input`, `--output`, and `--include-added-tokens` flags. Pins the 3-surface drift triangle: (1) clap variant `TokenizeCommands::ImportHf`, (2) unit tests `commands::tokenize::tests::import_hf_*`, (3) this integration test."
+  test: "cargo test -p apr-cli --test cli_commands -- tokenize_import_hf_subcommand_registered"
+  if_fails: "subcommand was added to TokenizeCommands enum but dispatch surface did not pick it up, OR a flag rename drifted from clap definition — three-surface drift per feedback_cli_subcommand_three_surface_drift.md"
 
 - id: FALSIFY-TOK-IMPORT-HF-002
   rule: BPE input produces non-empty vocab.json + merges.txt

--- a/crates/apr-cli/tests/cli_commands.rs
+++ b/crates/apr-cli/tests/cli_commands.rs
@@ -316,3 +316,46 @@ fn pretrain_init_flag_registered() {
         stdout
     );
 }
+
+/// FALSIFY-TOK-IMPORT-HF-001: `apr tokenize import-hf` subcommand is
+/// registered in the dispatch surface.
+///
+/// Asserts `apr tokenize import-hf --help` exits 0 and prints help text
+/// mentioning the `--input`, `--output`, and `--include-added-tokens` flags
+/// that `apr-cli-tokenize-import-hf-v1` v1.0.0 §extraction_signature pins.
+///
+/// 3-surface drift prevention triangle for `import-hf`:
+///   (1) clap variant `TokenizeCommands::ImportHf { ... }` in
+///       `crates/apr-cli/src/tokenize_commands.rs`
+///   (2) unit tests `commands::tokenize::tests::import_hf_*` in
+///       `crates/apr-cli/src/commands/tokenize.rs`
+///   (3) integration test (this one) — confirming the subcommand is
+///       reachable from the installed binary's help surface.
+///
+/// If `tokenize_commands.rs` drops the `ImportHf` variant, or
+/// `dispatch_analysis.rs` fails to wire it through, or the binary is built
+/// without the subcommand registered, this test fails.
+#[test]
+fn tokenize_import_hf_subcommand_registered() {
+    let output = apr_binary()
+        .args(["tokenize", "import-hf", "--help"])
+        .output()
+        .expect("failed to run apr tokenize import-hf --help");
+
+    assert!(
+        output.status.success(),
+        "FALSIFY-TOK-IMPORT-HF-001: `apr tokenize import-hf --help` should exit 0, got {:?}\nstderr:\n{}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for flag in ["--input", "--output", "--include-added-tokens"] {
+        assert!(
+            stdout.contains(flag),
+            "FALSIFY-TOK-IMPORT-HF-001: `{flag}` flag missing from `apr tokenize import-hf --help`.\n\
+             Either clap definition drifted, dispatch isn't wired, or the binary was built without the subcommand.\n\
+             Full --help output:\n{stdout}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

v1.0.0 stamped a vague test reference for FALSIFY-TOK-IMPORT-HF-001 (\"or equivalent\" — not a runnable invocation). Same drift class as PR #1504 + PR #1505 caught for sibling pretrain contracts.

## What ships

**Test**: \`tokenize_import_hf_subcommand_registered\` in \`crates/apr-cli/tests/cli_commands.rs\` runs \`apr tokenize import-hf --help\` and asserts (a) exit 0, (b) \`--input\`, \`--output\`, \`--include-added-tokens\` flags appear. Mirrors the \`pretrain_init_flag_registered\` pattern.

**Contract** apr-cli-tokenize-import-hf-v1 v1.0.0 → **v1.1.0** PARTIAL_ALGORITHM_LEVEL:
- FALSIFY-TOK-IMPORT-HF-001 \`test:\` updated to cite the new test.
- 5/5 falsifiers PASS, all bound to real tests.

## Verification
- \`cargo test -p apr-cli --test cli_commands -- tokenize_import_hf_subcommand_registered\` PASS
- \`pv validate contracts/apr-cli-tokenize-import-hf-v1.yaml\` exits 0

## Five Whys

1. **Why was the v1.0.0 reference vague?** Authored alongside the subcommand impl; integration test deferred under assumption \`test_no_unregistered_commands\` would cover it. But that only covers top-level subcommands.
2. **Why is sub-subcommand not covered by test_no_unregistered_commands?** It walks \`apr-cli-commands-v1.yaml\` which only enumerates top-level.
3. **Why bump to v1.1.0?** Test-binding INVARIANT was broken; v1.1.0 restores it.
4. **Why mirror the \`pretrain_init_flag_registered\` pattern?** Codebase consistency; the pattern is a clean drift guard.
5. **Why pin specific flags?** Flag-level drift (e.g., \`--input\` → \`--source\`) breaks UX without breaking exit-0 check.

## Net effects

- Contract v1.0.0 → v1.1.0 PARTIAL_ALGORITHM_LEVEL.
- 1 new integration test (33 LOC).
- MODEL-1 ship % unchanged at 91%; MODEL-2 ship % unchanged at 57%.

Third drift-fix PR in the same session (after PR #1504 + PR #1505), closing the test-reference drift class across the §50.4 cascade contracts.

## Test plan
- [x] \`pv validate\` exits 0
- [x] PMAT pre-commit quality gates pass
- [x] New integration test passes
- [ ] CI gate green
- [ ] Auto-merge fires on green CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)