### PR TITLE
feat(aprender-rag): v0.31.2 → v0.32.0 — rename lib trueno_rag → aprender_rag (BREAKING)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,7 +284,7 @@ dependencies = [
 
 [[package]]
 name = "apr-cli"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "alimentar",
  "anyhow",
@@ -397,7 +397,7 @@ dependencies = [
 
 [[package]]
 name = "aprender"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "apr-cli",
  "aprender-core",
@@ -405,7 +405,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-bench-compute"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "aprender-core",
  "criterion 0.7.0",
@@ -414,7 +414,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-bench-tokenizer"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "aprender-core",
  "criterion 0.7.0",
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cbtop"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "anyhow",
  "aprender-compute",
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cgp"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "anyhow",
  "aprender-gpu",
@@ -468,7 +468,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-common"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "lz4_flex 0.11.6",
  "zstd",
@@ -476,7 +476,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-compute"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "anyhow",
  "aprender-core",
@@ -525,7 +525,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-compute-xtask"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "anyhow",
  "bashrs",
@@ -538,7 +538,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-contracts"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "aprender-contracts-macros",
  "criterion 0.5.1",
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-contracts-cli"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "aprender-contracts",
  "clap",
@@ -564,7 +564,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-contracts-macros"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -574,7 +574,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-core"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "aes-gcm",
  "alimentar",
@@ -626,7 +626,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cuda-edge"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "aprender-gpu",
  "proptest",
@@ -637,7 +637,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cupti"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "bindgen 0.71.1",
  "bitflags 2.11.0",
@@ -647,7 +647,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-data"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -699,7 +699,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-db"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "anyhow",
  "arrow 57.3.0",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-distribute"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "arrow 57.3.0",
  "bincode",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-explain"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "aprender-gpu",
  "clap",
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-fft"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -802,7 +802,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-gemm-codegen"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -811,7 +811,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-gpu"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "aprender-profile",
  "batuta-common",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-graph"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "anyhow",
  "aprender-core",
@@ -856,7 +856,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-image"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-mcp"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -879,9 +879,9 @@ dependencies = [
 
 [[package]]
 name = "aprender-monte-carlo"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
- "aprender 0.31.2",
+ "aprender 0.32.0",
  "assert_cmd",
  "chrono",
  "clap",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-orchestrate"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "alimentar",
  "anyhow",
@@ -971,7 +971,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-cli"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "aprender-present-yaml",
  "clap",
@@ -984,7 +984,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-core"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "aprender-compute",
  "criterion 0.7.0",
@@ -997,7 +997,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-layout"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "aprender-present-core",
  "criterion 0.7.0",
@@ -1008,7 +1008,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-lib"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "aprender-present-core",
  "aprender-present-layout",
@@ -1037,7 +1037,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-terminal"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "aprender-present-core",
  "bitvec",
@@ -1059,7 +1059,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-test"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "aprender-present-core",
  "aprender-present-test-macros",
@@ -1070,7 +1070,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-test-macros"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1079,7 +1079,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-widgets"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "aprender-present-core",
  "aprender-present-yaml",
@@ -1091,7 +1091,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-yaml"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "aprender-present-core",
  "proptest",
@@ -1101,7 +1101,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-profile"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "addr2line 0.25.1",
  "anyhow",
@@ -1154,7 +1154,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-profile-core"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "hex",
  "serde",
@@ -1164,7 +1164,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-ptx-debug"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "proptest",
  "thiserror 2.0.18",
@@ -1172,7 +1172,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-certify"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "chrono",
  "proptest",
@@ -1182,7 +1182,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-cli"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "aprender-qa-certify",
  "aprender-qa-gen",
@@ -1201,7 +1201,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-gen"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1218,7 +1218,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-report"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "anyhow",
  "aprender-qa-gen",
@@ -1236,7 +1236,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-runner"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "anyhow",
  "aprender-qa-gen",
@@ -1261,14 +1261,14 @@ dependencies = [
 
 [[package]]
 name = "aprender-quant"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "half",
 ]
 
 [[package]]
 name = "aprender-rag"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "async-trait",
  "batuta-common",
@@ -1297,7 +1297,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-rand"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1306,7 +1306,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-registry"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "alimentar",
  "anyhow",
@@ -1336,7 +1336,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-serve"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "alimentar",
  "anyhow",
@@ -1403,7 +1403,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-shell"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "aprender-core",
  "assert_cmd",
@@ -1420,7 +1420,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-simulate"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "bincode",
  "bitflags 2.11.0",
@@ -1459,7 +1459,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-solve"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1468,7 +1468,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-sparse"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1477,7 +1477,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-tensor"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1486,7 +1486,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-cli"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "aprender-test-lib",
  "assert_cmd",
@@ -1514,7 +1514,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-derive"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1524,7 +1524,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-js-gen"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -1540,7 +1540,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-lib"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "aprender-compute",
  "aprender-present-core",
@@ -1584,7 +1584,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-showcase"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "aprender-present-terminal",
  "console_error_panic_hook",
@@ -1601,7 +1601,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "alimentar",
  "approx",
@@ -1668,7 +1668,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-bench"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1685,7 +1685,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-common"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "clap",
  "proptest",
@@ -1697,7 +1697,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-distill"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1718,7 +1718,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-inspect"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1734,7 +1734,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-lora"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1750,7 +1750,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-shell"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1766,7 +1766,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-wasm"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "proptest",
  "serde",
@@ -1777,9 +1777,9 @@ dependencies = [
 
 [[package]]
 name = "aprender-tsp"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
- "aprender 0.31.2",
+ "aprender 0.32.0",
  "assert_cmd",
  "clap",
  "crc32fast",
@@ -1792,7 +1792,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-verify"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "chrono",
  "criterion 0.5.1",
@@ -1804,7 +1804,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-verify-ml"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "aprender-core",
  "aprender-profile",
@@ -1848,7 +1848,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-viz"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "approx",
  "aprender-core",
@@ -1883,7 +1883,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "aprender-zram-adaptive",
  "aprender-zram-core",
@@ -1893,7 +1893,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-adaptive"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "aprender-zram-core",
  "proptest",
@@ -1902,7 +1902,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-cli"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "aprender-zram-adaptive",
  "aprender-zram-core",
@@ -1916,7 +1916,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-core"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "aprender-gpu",
  "criterion 0.7.0",
@@ -1928,7 +1928,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-generator"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "aprender-zram-core",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.31.2"
+version = "0.32.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/paiml/aprender"
@@ -171,7 +171,7 @@ minijinja = { version = "2.14", features = ["loader", "serde"] }
 # Contracts
 provable-contracts = "0.3"
 provable-contracts-macros = "0.3"
-aprender-contracts-macros = { path = "crates/aprender-contracts-macros", version = "0.31.2" }
+aprender-contracts-macros = { path = "crates/aprender-contracts-macros", version = "0.32.0" }
 
 # YAML
 serde_yaml = "0.9"
@@ -183,30 +183,30 @@ hf-hub = { version = "0.4", default-features = false, features = ["ureq"] }
 hf-xet = "1.5.1"
 
 # Workspace-internal crates (paths within the monorepo)
-aprender-compute = { path = "crates/aprender-compute", version = "0.31.2" }
-aprender-gpu = { path = "crates/aprender-gpu", version = "0.31.2" }
-aprender-quant = { path = "crates/aprender-quant", version = "0.31.2" }
-aprender-serve = { path = "crates/aprender-serve", version = "0.31.2" }
-realizar = { path = "crates/aprender-serve", version = "0.31.2", package = "aprender-serve" }
-aprender-train = { path = "crates/aprender-train", version = "0.31.2" }
-entrenar = { path = "crates/aprender-train", version = "0.31.2", package = "aprender-train" }
-aprender-train-common = { path = "crates/aprender-train-common", version = "0.31.2" }
-aprender-orchestrate = { path = "crates/aprender-orchestrate", version = "0.31.2" }
-aprender-contracts = { path = "crates/aprender-contracts", version = "0.31.2" }
-aprender-profile = { path = "crates/aprender-profile", version = "0.31.2" }
-aprender-profile-core = { path = "crates/aprender-profile-core", version = "0.31.2" }
-aprender-zram-core = { path = "crates/aprender-zram-core", version = "0.31.2" }
-aprender-zram-adaptive = { path = "crates/aprender-zram-adaptive", version = "0.31.2" }
-aprender-present-core = { path = "crates/aprender-present-core", version = "0.31.2" }
-aprender-present-terminal = { path = "crates/aprender-present-terminal", version = "0.31.2" }
-aprender-present-widgets = { path = "crates/aprender-present-widgets", version = "0.31.2" }
-aprender-present-layout = { path = "crates/aprender-present-layout", version = "0.31.2" }
-aprender-present-yaml = { path = "crates/aprender-present-yaml", version = "0.31.2" }
-aprender-present-test = { path = "crates/aprender-present-test", version = "0.31.2" }
-aprender-db = { path = "crates/aprender-db", version = "0.31.2" }
-aprender-graph = { path = "crates/aprender-graph", version = "0.31.2" }
-aprender-rag = { path = "crates/aprender-rag", version = "0.31.2" }
-aprender-data = { path = "crates/aprender-data", version = "0.31.2" }
+aprender-compute = { path = "crates/aprender-compute", version = "0.32.0" }
+aprender-gpu = { path = "crates/aprender-gpu", version = "0.32.0" }
+aprender-quant = { path = "crates/aprender-quant", version = "0.32.0" }
+aprender-serve = { path = "crates/aprender-serve", version = "0.32.0" }
+realizar = { path = "crates/aprender-serve", version = "0.32.0", package = "aprender-serve" }
+aprender-train = { path = "crates/aprender-train", version = "0.32.0" }
+entrenar = { path = "crates/aprender-train", version = "0.32.0", package = "aprender-train" }
+aprender-train-common = { path = "crates/aprender-train-common", version = "0.32.0" }
+aprender-orchestrate = { path = "crates/aprender-orchestrate", version = "0.32.0" }
+aprender-contracts = { path = "crates/aprender-contracts", version = "0.32.0" }
+aprender-profile = { path = "crates/aprender-profile", version = "0.32.0" }
+aprender-profile-core = { path = "crates/aprender-profile-core", version = "0.32.0" }
+aprender-zram-core = { path = "crates/aprender-zram-core", version = "0.32.0" }
+aprender-zram-adaptive = { path = "crates/aprender-zram-adaptive", version = "0.32.0" }
+aprender-present-core = { path = "crates/aprender-present-core", version = "0.32.0" }
+aprender-present-terminal = { path = "crates/aprender-present-terminal", version = "0.32.0" }
+aprender-present-widgets = { path = "crates/aprender-present-widgets", version = "0.32.0" }
+aprender-present-layout = { path = "crates/aprender-present-layout", version = "0.32.0" }
+aprender-present-yaml = { path = "crates/aprender-present-yaml", version = "0.32.0" }
+aprender-present-test = { path = "crates/aprender-present-test", version = "0.32.0" }
+aprender-db = { path = "crates/aprender-db", version = "0.32.0" }
+aprender-graph = { path = "crates/aprender-graph", version = "0.32.0" }
+aprender-rag = { path = "crates/aprender-rag", version = "0.32.0" }
+aprender-data = { path = "crates/aprender-data", version = "0.32.0" }
 
 # Additional external deps needed by sub-crates
 serde_yaml_ng = "0.10"
@@ -251,25 +251,25 @@ wasmtime = "43"
 bollard = "0.17"
 
 # Old crate name aliases (workspace = true refs in migrated sub-crates)
-trueno-zram-core = { path = "crates/aprender-zram-core", version = "0.31.2", package = "aprender-zram-core" }
-trueno-zram-adaptive = { path = "crates/aprender-zram-adaptive", version = "0.31.2", package = "aprender-zram-adaptive" }
-trueno = { path = "crates/aprender-compute", version = "0.31.2", package = "aprender-compute" }
-presentar-core = { path = "crates/aprender-present-core", version = "0.31.2", package = "aprender-present-core" }
-presentar-terminal = { path = "crates/aprender-present-terminal", version = "0.31.2", package = "aprender-present-terminal" }
-presentar-widgets = { path = "crates/aprender-present-widgets", version = "0.31.2", package = "aprender-present-widgets" }
-presentar-layout = { path = "crates/aprender-present-layout", version = "0.31.2", package = "aprender-present-layout" }
-presentar-yaml = { path = "crates/aprender-present-yaml", version = "0.31.2", package = "aprender-present-yaml" }
-presentar-test = { path = "crates/aprender-present-test", version = "0.31.2", package = "aprender-present-test" }
-presentar-test-macros = { path = "crates/aprender-present-test-macros", version = "0.31.2", package = "aprender-present-test-macros" }
-jugar-probar-derive = { path = "crates/aprender-test-derive", version = "0.31.2", package = "aprender-test-derive" }
-batuta-common = { path = "crates/aprender-common", version = "0.31.2", package = "aprender-common" }
+trueno-zram-core = { path = "crates/aprender-zram-core", version = "0.32.0", package = "aprender-zram-core" }
+trueno-zram-adaptive = { path = "crates/aprender-zram-adaptive", version = "0.32.0", package = "aprender-zram-adaptive" }
+trueno = { path = "crates/aprender-compute", version = "0.32.0", package = "aprender-compute" }
+presentar-core = { path = "crates/aprender-present-core", version = "0.32.0", package = "aprender-present-core" }
+presentar-terminal = { path = "crates/aprender-present-terminal", version = "0.32.0", package = "aprender-present-terminal" }
+presentar-widgets = { path = "crates/aprender-present-widgets", version = "0.32.0", package = "aprender-present-widgets" }
+presentar-layout = { path = "crates/aprender-present-layout", version = "0.32.0", package = "aprender-present-layout" }
+presentar-yaml = { path = "crates/aprender-present-yaml", version = "0.32.0", package = "aprender-present-yaml" }
+presentar-test = { path = "crates/aprender-present-test", version = "0.32.0", package = "aprender-present-test" }
+presentar-test-macros = { path = "crates/aprender-present-test-macros", version = "0.32.0", package = "aprender-present-test-macros" }
+jugar-probar-derive = { path = "crates/aprender-test-derive", version = "0.32.0", package = "aprender-test-derive" }
+batuta-common = { path = "crates/aprender-common", version = "0.32.0", package = "aprender-common" }
 # APR-MONO sibling aliases — MUST use workspace refs, NEVER crates.io versions.
 # Hard-pinning these to crates.io creates a diamond: sub-crates pull older
 # aprender versions → multiple `aprender` crates in Cargo.lock = MUDA.
-renacer = { path = "crates/aprender-profile", version = "0.31.2", package = "aprender-profile" }
-entrenar-lora = { path = "crates/aprender-train-lora", version = "0.31.2", package = "aprender-train-lora" }
-batuta = { path = "crates/aprender-orchestrate", version = "0.31.2", package = "aprender-orchestrate" }
-trueno-graph = { path = "crates/aprender-graph", version = "0.31.2", package = "aprender-graph" }
+renacer = { path = "crates/aprender-profile", version = "0.32.0", package = "aprender-profile" }
+entrenar-lora = { path = "crates/aprender-train-lora", version = "0.32.0", package = "aprender-train-lora" }
+batuta = { path = "crates/aprender-orchestrate", version = "0.32.0", package = "aprender-orchestrate" }
+trueno-graph = { path = "crates/aprender-graph", version = "0.32.0", package = "aprender-graph" }
 
 [workspace.lints.rust]
 # Safety
@@ -398,7 +398,7 @@ semicolon_if_nothing_returned = "allow"  # Style preference
 
 [package]
 name = "aprender"
-version = "0.31.2"
+version = "0.32.0"
 edition = "2021"
 rust-version = "1.89"
 authors = ["Noah Gift <noah@paiml.com>"]
@@ -423,7 +423,7 @@ name = "apr"
 path = "src/bin/apr.rs"
 
 [dependencies]
-apr-cli = { path = "crates/apr-cli", version = "0.31.2", default-features = true }
+apr-cli = { path = "crates/apr-cli", version = "0.32.0", default-features = true }
 # Core ML library (lib name = "aprender")
 aprender_ml = { path = "crates/aprender-core", version = ">=0.29", package = "aprender-core" }
 

--- a/crates/apr-cli/Cargo.toml
+++ b/crates/apr-cli/Cargo.toml
@@ -99,10 +99,10 @@ libc = "0.2"
 
 [dependencies]
 # Core aprender library
-aprender = { path = "../aprender-core", version = "0.31.2", package = "aprender-core", default-features = true, features = ["format-compression"] }
+aprender = { path = "../aprender-core", version = "0.32.0", package = "aprender-core", default-features = true, features = ["format-compression"] }
 
 # MCP (Model Context Protocol) server — `apr mcp` subcommand
-aprender-mcp = { path = "../aprender-mcp", version = "0.31.2" }
+aprender-mcp = { path = "../aprender-mcp", version = "0.32.0" }
 async-stream = "0.3"
 provable-contracts-macros = "0.3"
 

--- a/crates/apr-cli/src/commands/mono.rs
+++ b/crates/apr-cli/src/commands/mono.rs
@@ -181,7 +181,7 @@ const SHIM_MAP: &[(&str, &str, &str, &str)] = &[
     ),
     ("trueno-db", "aprender-db", "trueno_db", "0.4.0"),
     ("trueno-graph", "aprender-graph", "trueno_graph", "0.2.0"),
-    ("trueno-rag", "aprender-rag", "trueno_rag", "0.3.0"),
+    ("trueno-rag", "aprender-rag", "aprender_rag", "0.3.0"),
     ("trueno-viz", "aprender-viz", "trueno_viz", "0.3.0"),
     (
         "trueno-zram-core",

--- a/crates/aprender-bench-compute/Cargo.toml
+++ b/crates/aprender-bench-compute/Cargo.toml
@@ -11,7 +11,7 @@ disallowed_methods = "allow"
 
 [dependencies]
 # The implementation under test
-aprender = { path = "../aprender-core", version = "0.31.2", package = "aprender-core", features = ["format-quantize"] }
+aprender = { path = "../aprender-core", version = "0.32.0", package = "aprender-core", features = ["format-quantize"] }
 
 # Reference implementation for A/B comparison
 # Pure Rust (no BLAS) to keep comparison fair — both are pure Rust SIMD

--- a/crates/aprender-bench-tokenizer/Cargo.toml
+++ b/crates/aprender-bench-tokenizer/Cargo.toml
@@ -11,7 +11,7 @@ disallowed_methods = "allow"
 
 [dependencies]
 # The implementation under test
-aprender = { path = "../aprender-core", version = "0.31.2", package = "aprender-core" }
+aprender = { path = "../aprender-core", version = "0.32.0", package = "aprender-core" }
 
 # HuggingFace reference for A/B comparison
 # Regular dep (not dev-dep) because [[bench]] harness=false binaries can't see dev-deps

--- a/crates/aprender-cbtop/Cargo.toml
+++ b/crates/aprender-cbtop/Cargo.toml
@@ -23,8 +23,8 @@ presentar-core = "0.3"
 presentar-terminal = "0.3"
 
 # Compute backends
-trueno = { version = "0.31.2", path = "../aprender-compute", package = "aprender-compute" }
-trueno-gpu = { version = "0.31.2", path = "../aprender-gpu", package = "aprender-gpu", optional = true }
+trueno = { version = "0.32.0", path = "../aprender-compute", package = "aprender-compute" }
+trueno-gpu = { version = "0.32.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true }
 
 # Terminal handling
 crossterm = "0.28"

--- a/crates/aprender-cgp/Cargo.toml
+++ b/crates/aprender-cgp/Cargo.toml
@@ -36,7 +36,7 @@ num_cpus = "1.17"
 comfy-table = "7"
 colored = "3"
 # GPU profiling: direct cuBLAS measurement (OWN THE STACK)
-trueno-gpu = { path = "../aprender-gpu", version = "0.31.2", features = ["cuda"], optional = true, package = "aprender-gpu" }
+trueno-gpu = { path = "../aprender-gpu", version = "0.32.0", features = ["cuda"], optional = true, package = "aprender-gpu" }
 
 [features]
 default = []

--- a/crates/aprender-compute/Cargo.toml
+++ b/crates/aprender-compute/Cargo.toml
@@ -38,11 +38,11 @@ futures-intrusive = { version = "0.5", optional = true }
 wasm-bindgen-futures = { version = "0.4", optional = true }
 wasm-bindgen = { version = "0.2", optional = true }
 # Native CUDA monitoring via trueno-gpu (TRUENO-SPEC-010)
-trueno-gpu = { version = "0.31.2", path = "../aprender-gpu", optional = true, package = "aprender-gpu" }
+trueno-gpu = { version = "0.32.0", path = "../aprender-gpu", optional = true, package = "aprender-gpu" }
 # PMAT-336: Provable contracts compile-time enforcement
 provable-contracts-macros = "0.3"
 # P1a: Sovereign GEMM microkernel codegen (compile-time shape specialization)
-trueno-gemm-codegen = { version = "0.31.2", path = "../aprender-gemm-codegen", package = "aprender-gemm-codegen" }
+trueno-gemm-codegen = { version = "0.32.0", path = "../aprender-gemm-codegen", package = "aprender-gemm-codegen" }
 # Tracing/profiling support (renacer integration)
 tracing = { version = "0.1", optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"], optional = true }
@@ -54,7 +54,7 @@ presentar-core = { version = "0.3", optional = true }
 # Stress test reporting types compatible with renacer (TRUENO-SPEC-025)
 # Note: renacer 0.9.1 has compilation issue; using compatible local types instead
 dhat = { version = "0.3", optional = true }
-trueno-quant = { version = "0.31.2", path = "../aprender-quant", package = "aprender-quant" }
+trueno-quant = { version = "0.32.0", path = "../aprender-quant", package = "aprender-quant" }
 num_cpus = "1.17.0"
 anyhow = "1.0.100"
 # Hardware capability detection (PMAT-447)
@@ -62,7 +62,7 @@ chrono = "0.4"
 toml = "0.8"
 # ML tuner integration (SHOWCASE-BRICK-001, Section 12)
 # Uses aprender 0.24.0 RandomForest for learned optimization
-aprender = { path = "../aprender-core", version = "0.31.2", package = "aprender-core", optional = true, default-features = false }
+aprender = { path = "../aprender-core", version = "0.32.0", package = "aprender-core", optional = true, default-features = false }
 # Execution path graph (PAR-201, Section E.7)
 trueno-graph = { workspace = true, optional = true }
 # TUI visualization for execution graphs (PAR-201)
@@ -90,10 +90,10 @@ nalgebra = "0.34"  # For eigendecomposition benchmark comparison
 simular = "0.2.0"
 regex = "1.11"  # For PTX/WGSL pattern validation in falsification tests
 # GPU edge-case test framework (TCE-001)
-trueno-cuda-edge = { version = "0.31.2", path = "../aprender-cuda-edge", package = "aprender-cuda-edge" }
+trueno-cuda-edge = { version = "0.32.0", path = "../aprender-cuda-edge", package = "aprender-cuda-edge" }
 # Sparse and solver crates for contract tests
-trueno-sparse = { version = "0.31.2", path = "../aprender-sparse", package = "aprender-sparse" }
-trueno-solve = { version = "0.31.2", path = "../aprender-solve", package = "aprender-solve" }
+trueno-sparse = { version = "0.32.0", path = "../aprender-sparse", package = "aprender-sparse" }
+trueno-solve = { version = "0.32.0", path = "../aprender-solve", package = "aprender-solve" }
 ndarray = "0.17.2"
 faer = "0.24"  # For GEMM benchmark comparison (fastest pure-Rust BLAS)
 matrixmultiply = "0.3"  # Direct matrixmultiply crate benchmark (engine behind ndarray)

--- a/crates/aprender-contracts-cli/Cargo.toml
+++ b/crates/aprender-contracts-cli/Cargo.toml
@@ -13,7 +13,7 @@ name = "pv"
 path = "src/main.rs"
 
 [dependencies]
-aprender-contracts = { path = "../aprender-contracts", version = "0.31.2" }
+aprender-contracts = { path = "../aprender-contracts", version = "0.32.0" }
 clap = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }

--- a/crates/aprender-contracts/Cargo.toml
+++ b/crates/aprender-contracts/Cargo.toml
@@ -19,7 +19,7 @@ kani = []
 name = "provable_contracts"
 
 [dependencies]
-provable-contracts-macros = { path = "../aprender-contracts-macros", version = "0.31.2", package = "aprender-contracts-macros" }
+provable-contracts-macros = { path = "../aprender-contracts-macros", version = "0.32.0", package = "aprender-contracts-macros" }
 regex = "1"
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/aprender-cuda-edge/Cargo.toml
+++ b/crates/aprender-cuda-edge/Cargo.toml
@@ -15,7 +15,7 @@ name = "trueno_cuda_edge"
 [dependencies]
 thiserror = "2.0"
 serde = { version = "1.0", features = ["derive"] }
-trueno-gpu = { version = "0.31.2", path = "../aprender-gpu", package = "aprender-gpu", optional = true }
+trueno-gpu = { version = "0.32.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true }
 
 [dev-dependencies]
 proptest = "1.6"

--- a/crates/aprender-explain/Cargo.toml
+++ b/crates/aprender-explain/Cargo.toml
@@ -25,7 +25,7 @@ presentar-terminal = "0.3"
 crossterm = "0.28"
 
 # Internal dependency for PTX generation
-trueno-gpu = { version = "0.31.2", path = "../aprender-gpu", package = "aprender-gpu", features = ["cuda"] }
+trueno-gpu = { version = "0.32.0", path = "../aprender-gpu", package = "aprender-gpu", features = ["cuda"] }
 
 [dev-dependencies]
 proptest = "1.4"

--- a/crates/aprender-graph/Cargo.toml
+++ b/crates/aprender-graph/Cargo.toml
@@ -28,7 +28,7 @@ anyhow = "1"
 thiserror = "2"
 
 # Phase 2+ dependencies
-aprender = { path = "../aprender-core", version = "0.31.2", package = "aprender-core" }                                        # Sparse matrix ops, PageRank
+aprender = { path = "../aprender-core", version = "0.32.0", package = "aprender-core" }                                        # Sparse matrix ops, PageRank
 trueno = "0.17"                                          # SIMD primitives
 trueno-db = "0.3.17"                                     # Columnar storage
 

--- a/crates/aprender-monte-carlo/Cargo.toml
+++ b/crates/aprender-monte-carlo/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 name = "aprender-monte-carlo"
 
 [dependencies]
-aprender = { path = "../../", version = "0.31.2" }
+aprender = { path = "../../", version = "0.32.0" }
 clap = { version = "4", features = ["derive"] }
 rand = "0.9"
 rand_chacha = "0.9"

--- a/crates/aprender-orchestrate/Cargo.toml
+++ b/crates/aprender-orchestrate/Cargo.toml
@@ -113,7 +113,7 @@ pacha = { version = "0.2", optional = true }
 realizar = { version = "0.8", optional = true, features = ["cuda"] }
 
 # ML algorithms and training (native-only)
-aprender = { path = "../aprender-core", version = "0.31.2", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.32.0", package = "aprender-core", optional = true }
 entrenar = { workspace = true, optional = true }
 alimentar = { version = "0.2", optional = true }
 

--- a/crates/aprender-profile/Cargo.toml
+++ b/crates/aprender-profile/Cargo.toml
@@ -74,7 +74,7 @@ trueno = { version = "0.17" }
 
 # Machine learning for anomaly detection (Sprint 23)
 # GH-581: Use path dep to avoid trueno version skew with local workspace
-aprender = { path = "../aprender-core", version = "0.31.2", package = "aprender-core" }
+aprender = { path = "../aprender-core", version = "0.32.0", package = "aprender-core" }
 
 # Lock-free data structures for ring buffer (Sprint 40)
 crossbeam = { version = "0.8", default-features = false, features = ["crossbeam-channel", "crossbeam-queue", "std"] }

--- a/crates/aprender-qa-runner/Cargo.toml
+++ b/crates/aprender-qa-runner/Cargo.toml
@@ -29,7 +29,7 @@ sha2 = "0.10"
 regex = { workspace = true }
 num_cpus = "1.16"
 safetensors = { workspace = true }
-jugar-probar = { version = "0.31.0", path = "../aprender-test-lib", package = "aprender-test-lib", features = ["llm-types"] }
+jugar-probar = { version = "0.32.0", path = "../aprender-test-lib", package = "aprender-test-lib", features = ["llm-types"] }
 # Test fixtures dependencies (optional)
 tempfile = { version = "3", optional = true }
 half = { version = "2.4", optional = true }

--- a/crates/aprender-rag/Cargo.toml
+++ b/crates/aprender-rag/Cargo.toml
@@ -28,7 +28,7 @@ exclude = [
 ]
 
 [lib]
-name = "trueno_rag"
+name = "aprender_rag"
 
 [dependencies]
 # Core compute

--- a/crates/aprender-rag/benches/retrieval.rs
+++ b/crates/aprender-rag/benches/retrieval.rs
@@ -3,7 +3,7 @@
 
 use criterion::{criterion_group, criterion_main, Criterion};
 use std::hint::black_box;
-use trueno_rag::{
+use aprender_rag::{
     chunk::{Chunk, Chunker, RecursiveChunker},
     embed::MockEmbedder,
     index::{BM25Index, SparseIndex, VectorStore},

--- a/crates/aprender-rag/crates/trueno-rag-cli/Cargo.toml
+++ b/crates/aprender-rag/crates/trueno-rag-cli/Cargo.toml
@@ -13,7 +13,7 @@ name = "trueno-rag"
 path = "src/main.rs"
 
 [dependencies]
-trueno-rag = { version = "0.2.0", path = "../.." }
+aprender-rag = { version = "0.32.0", path = "../.." }
 clap = { version = "4.5", features = ["derive"] }
 tokio = { version = "1.49", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/aprender-rag/crates/trueno-rag-cli/src/discover.rs
+++ b/crates/aprender-rag/crates/trueno-rag-cli/src/discover.rs
@@ -8,7 +8,7 @@ use globset::{Glob, GlobSet, GlobSetBuilder};
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
-use trueno_rag::loader::LoaderRegistry;
+use aprender_rag::loader::LoaderRegistry;
 
 /// Media file extensions that can be transcribed.
 pub(crate) const MEDIA_EXTENSIONS: &[&str] = &[

--- a/crates/aprender-rag/crates/trueno-rag-cli/src/eval_cmd.rs
+++ b/crates/aprender-rag/crates/trueno-rag-cli/src/eval_cmd.rs
@@ -7,7 +7,7 @@ use anyhow::{Context, Result};
 use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
-use trueno_rag::{embed::Embedder, Chunk};
+use aprender_rag::{embed::Embedder, Chunk};
 
 use crate::query::{
     cosine_similarity, create_query_embedder, expand_query_hyde, parse_fusion_strategy,
@@ -79,8 +79,8 @@ fn run_eval_sample(
     sample_size: usize,
     seed: u64,
 ) -> Result<()> {
-    use trueno_rag::eval::generate::IndexChunk;
-    use trueno_rag::eval::{AnthropicClient, GroundTruthGenerator};
+    use aprender_rag::eval::generate::IndexChunk;
+    use aprender_rag::eval::{AnthropicClient, GroundTruthGenerator};
 
     let index_file = Path::new(index_path).join("index.json");
     if !index_file.exists() {
@@ -151,7 +151,7 @@ fn run_eval_generate(
     model: &str,
     dry_run: bool,
 ) -> Result<()> {
-    use trueno_rag::eval::{generate::IndexChunk, AnthropicClient, GroundTruthGenerator};
+    use aprender_rag::eval::{generate::IndexChunk, AnthropicClient, GroundTruthGenerator};
 
     let index_file = Path::new(index_path).join("index.json");
     if !index_file.exists() {
@@ -218,8 +218,8 @@ fn run_eval_retrieve(
     rerank: &str,
     hyde: bool,
 ) -> Result<()> {
-    use trueno_rag::eval::types::GroundTruthEntry;
-    use trueno_rag::DocumentId;
+    use aprender_rag::eval::types::GroundTruthEntry;
+    use aprender_rag::DocumentId;
 
     // Validate mode
     if !["dense", "sparse", "hybrid"].contains(&mode) {
@@ -335,7 +335,7 @@ fn run_eval_retrieve(
 
 /// Expand all ground-truth queries via HyDE (Hypothetical Document Embeddings).
 fn expand_all_queries_hyde(
-    queries: &[trueno_rag::eval::types::GroundTruthEntry],
+    queries: &[aprender_rag::eval::types::GroundTruthEntry],
 ) -> Result<Vec<String>> {
     println!("HyDE enabled — expanding {} queries via Claude API...", queries.len());
     let mut expanded = Vec::with_capacity(queries.len());
@@ -349,7 +349,7 @@ fn expand_all_queries_hyde(
 
 /// Dense eval retrieval: cosine similarity over embeddings.
 fn eval_retrieve_dense(
-    queries: &[trueno_rag::eval::types::GroundTruthEntry],
+    queries: &[aprender_rag::eval::types::GroundTruthEntry],
     persisted: &PersistedIndex,
     embedder: &dyn Embedder,
     effective_query: &dyn Fn(usize, &str) -> String,
@@ -358,7 +358,7 @@ fn eval_retrieve_dense(
     rerank: &str,
     output: &mut impl std::io::Write,
 ) -> Result<()> {
-    use trueno_rag::eval::types::{RetrievalResultEntry, RetrievedChunk};
+    use aprender_rag::eval::types::{RetrievalResultEntry, RetrievedChunk};
 
     for (i, entry) in queries.iter().enumerate() {
         print!("[{}/{}] {}...", i + 1, queries.len(), &entry.query[..entry.query.len().min(60)]);
@@ -411,7 +411,7 @@ fn eval_retrieve_dense(
 
 /// Sparse eval retrieval: BM25 keyword matching.
 fn eval_retrieve_sparse(
-    queries: &[trueno_rag::eval::types::GroundTruthEntry],
+    queries: &[aprender_rag::eval::types::GroundTruthEntry],
     persisted: &PersistedIndex,
     build_chunks: &dyn Fn(bool) -> Vec<Chunk>,
     effective_query: &dyn Fn(usize, &str) -> String,
@@ -420,15 +420,15 @@ fn eval_retrieve_sparse(
     rerank: &str,
     output: &mut impl std::io::Write,
 ) -> Result<()> {
-    use trueno_rag::eval::types::{RetrievalResultEntry, RetrievedChunk};
-    use trueno_rag::index::SparseIndex;
-    use trueno_rag::BM25Index;
+    use aprender_rag::eval::types::{RetrievalResultEntry, RetrievedChunk};
+    use aprender_rag::index::SparseIndex;
+    use aprender_rag::BM25Index;
 
     println!("Building BM25 index from {} chunks...", persisted.chunks.len());
     let start_build = std::time::Instant::now();
     let mut bm25 = BM25Index::new();
     let chunks = build_chunks(false);
-    let mut chunk_map: HashMap<trueno_rag::ChunkId, usize> = HashMap::new();
+    let mut chunk_map: HashMap<aprender_rag::ChunkId, usize> = HashMap::new();
     for (i, chunk) in chunks.iter().enumerate() {
         chunk_map.insert(chunk.id, i);
         bm25.add(chunk);
@@ -479,7 +479,7 @@ fn eval_retrieve_sparse(
 /// Hybrid eval retrieval: BM25 + dense with RRF fusion.
 #[allow(clippy::too_many_arguments)]
 fn eval_retrieve_hybrid(
-    queries: &[trueno_rag::eval::types::GroundTruthEntry],
+    queries: &[aprender_rag::eval::types::GroundTruthEntry],
     persisted: &PersistedIndex,
     embedder: Box<dyn Embedder>,
     build_chunks: &dyn Fn(bool) -> Vec<Chunk>,
@@ -492,10 +492,10 @@ fn eval_retrieve_hybrid(
     candidates: usize,
     output: &mut impl std::io::Write,
 ) -> Result<()> {
-    use trueno_rag::eval::types::{RetrievalResultEntry, RetrievedChunk};
-    use trueno_rag::index::VectorStoreConfig;
-    use trueno_rag::retrieve::HybridRetrieverConfig;
-    use trueno_rag::{BM25Index, HybridRetriever, VectorStore};
+    use aprender_rag::eval::types::{RetrievalResultEntry, RetrievedChunk};
+    use aprender_rag::index::VectorStoreConfig;
+    use aprender_rag::retrieve::HybridRetrieverConfig;
+    use aprender_rag::{BM25Index, HybridRetriever, VectorStore};
 
     let fusion_strategy = parse_fusion_strategy(fusion, fusion_k)?;
     let dim = embedder.dimension();
@@ -514,7 +514,7 @@ fn eval_retrieve_hybrid(
 
     let chunks = build_chunks(true);
     let n_chunks = chunks.len();
-    let mut chunk_meta: HashMap<trueno_rag::ChunkId, usize> = HashMap::new();
+    let mut chunk_meta: HashMap<aprender_rag::ChunkId, usize> = HashMap::new();
     for (i, chunk) in chunks.into_iter().enumerate() {
         chunk_meta.insert(chunk.id, i);
         retriever.index(chunk)?;
@@ -584,7 +584,7 @@ async fn run_eval_judge(
     top_k: usize,
     model: &str,
 ) -> Result<()> {
-    use trueno_rag::eval::{
+    use aprender_rag::eval::{
         types::{JudgeCache, RetrievalResultEntry},
         AnthropicClient, RelevanceJudge,
     };
@@ -627,8 +627,8 @@ fn run_eval_metrics(
     judgments_path: &str,
     output_path: &str,
 ) -> Result<()> {
-    use trueno_rag::eval::metrics::{compute_metrics_from_judgments, format_metrics_summary};
-    use trueno_rag::eval::types::{JudgmentEntry, RetrievalResultEntry};
+    use aprender_rag::eval::metrics::{compute_metrics_from_judgments, format_metrics_summary};
+    use aprender_rag::eval::types::{JudgmentEntry, RetrievalResultEntry};
 
     // Load retrieval results
     let text = fs::read_to_string(retrieval_results_path)
@@ -664,7 +664,7 @@ fn run_eval_metrics(
 }
 
 fn run_eval_compare(baseline_path: &str, candidate_path: &str) -> Result<()> {
-    use trueno_rag::eval::{judge::compare_results, types::EvalOutput};
+    use aprender_rag::eval::{judge::compare_results, types::EvalOutput};
 
     let baseline: EvalOutput = serde_json::from_str(
         &fs::read_to_string(baseline_path)
@@ -680,7 +680,7 @@ fn run_eval_compare(baseline_path: &str, candidate_path: &str) -> Result<()> {
 }
 
 fn run_eval_gate(results_path: &str, min_mrr: f64, min_hit5: f64) -> Result<()> {
-    use trueno_rag::eval::{judge::check_gate, types::EvalOutput};
+    use aprender_rag::eval::{judge::check_gate, types::EvalOutput};
 
     let output: EvalOutput = serde_json::from_str(
         &fs::read_to_string(results_path)

--- a/crates/aprender-rag/crates/trueno-rag-cli/src/incremental.rs
+++ b/crates/aprender-rag/crates/trueno-rag-cli/src/incremental.rs
@@ -17,7 +17,7 @@ use {
     crate::ingest::{chunk_and_embed, create_embedder, finish_load_report, load_documents},
     crate::PersistedChunk,
     std::path::Path,
-    trueno_rag::{
+    aprender_rag::{
         chunk::{RecursiveChunker, TimestampChunker},
         loader::LoaderRegistry,
     },
@@ -189,7 +189,7 @@ fn run_index_incremental_inner(
 
 /// Open an existing SQLite index, failing if it does not exist.
 #[cfg(feature = "sqlite")]
-fn open_existing_index(output: &str) -> Result<trueno_rag::SqliteIndex> {
+fn open_existing_index(output: &str) -> Result<aprender_rag::SqliteIndex> {
     let db_path = Path::new(output).join("index.sqlite");
     if !db_path.exists() {
         anyhow::bail!(
@@ -197,14 +197,14 @@ fn open_existing_index(output: &str) -> Result<trueno_rag::SqliteIndex> {
             db_path.display()
         );
     }
-    trueno_rag::SqliteIndex::open(&db_path)
+    aprender_rag::SqliteIndex::open(&db_path)
         .map_err(|e| anyhow::anyhow!("Failed to open SQLite index: {e}"))
 }
 
 /// Compare file hashes against stored fingerprints in the SQLite index.
 #[cfg(feature = "sqlite")]
 fn diff_against_stored(
-    sqlite_index: &trueno_rag::SqliteIndex,
+    sqlite_index: &aprender_rag::SqliteIndex,
     file_hashes: &[(PathBuf, [u8; 32])],
 ) -> Result<(Vec<(PathBuf, [u8; 32])>, Vec<String>)> {
     let stored_fps = sqlite_index
@@ -217,7 +217,7 @@ fn diff_against_stored(
 /// Remove deleted sources from the SQLite index, printing each removal.
 #[cfg(feature = "sqlite")]
 fn remove_deleted_sources(
-    sqlite_index: &trueno_rag::SqliteIndex,
+    sqlite_index: &aprender_rag::SqliteIndex,
     deleted: &[String],
 ) -> Result<()> {
     for del_path in deleted {
@@ -233,7 +233,7 @@ fn remove_deleted_sources(
 
 /// Optimize the SQLite index and print final document/chunk counts.
 #[cfg(feature = "sqlite")]
-fn optimize_and_report(sqlite_index: &trueno_rag::SqliteIndex) -> Result<()> {
+fn optimize_and_report(sqlite_index: &aprender_rag::SqliteIndex) -> Result<()> {
     sqlite_index.optimize().map_err(|e| anyhow::anyhow!("Failed to optimize: {e}"))?;
     let stats =
         sqlite_index.document_count().map_err(|e| anyhow::anyhow!("Failed to count docs: {e}"))?;
@@ -246,7 +246,7 @@ fn optimize_and_report(sqlite_index: &trueno_rag::SqliteIndex) -> Result<()> {
 /// Insert changed documents into SQLite with fingerprints.
 #[cfg(feature = "sqlite")]
 fn incremental_insert(
-    sqlite_index: &trueno_rag::SqliteIndex,
+    sqlite_index: &aprender_rag::SqliteIndex,
     chunks: &[PersistedChunk],
     changed: &[(PathBuf, [u8; 32])],
 ) -> Result<()> {

--- a/crates/aprender-rag/crates/trueno-rag-cli/src/ingest.rs
+++ b/crates/aprender-rag/crates/trueno-rag-cli/src/ingest.rs
@@ -12,7 +12,7 @@ use std::fs;
 use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
-use trueno_rag::{
+use aprender_rag::{
     chunk::{RecursiveChunker, TimestampChunker},
     embed::{Embedder, TfIdfEmbedder},
     loader::LoaderRegistry,
@@ -20,7 +20,7 @@ use trueno_rag::{
 };
 
 #[cfg(feature = "embeddings")]
-use trueno_rag::{EmbeddingModelType, FastEmbedder};
+use aprender_rag::{EmbeddingModelType, FastEmbedder};
 
 use crate::discover::{build_exclude_set, classify_files, discover_files};
 use crate::{ChunkStrategy, EmbedderType, PersistedChunk, PersistedIndex, SemanticModel};
@@ -340,7 +340,7 @@ pub(crate) fn export_sqlite(persisted: &PersistedIndex, output_path: &Path) -> R
     if db_path.exists() {
         fs::remove_file(&db_path)?;
     }
-    let sqlite_index = trueno_rag::SqliteIndex::open(&db_path)
+    let sqlite_index = aprender_rag::SqliteIndex::open(&db_path)
         .map_err(|e| anyhow::anyhow!("Failed to create SQLite index: {e}"))?;
 
     // Group chunks by source document

--- a/crates/aprender-rag/crates/trueno-rag-cli/src/main.rs
+++ b/crates/aprender-rag/crates/trueno-rag-cli/src/main.rs
@@ -33,7 +33,7 @@ mod transcribe;
 use anyhow::Result;
 use clap::{Parser, Subcommand, ValueEnum};
 use serde::{Deserialize, Serialize};
-use trueno_rag::loader::LoaderRegistry;
+use aprender_rag::loader::LoaderRegistry;
 
 /// Embedder type selection
 #[derive(Debug, Clone, Copy, Default, ValueEnum)]
@@ -652,8 +652,8 @@ mod tests {
     use std::collections::HashMap;
     use std::fs;
     use std::path::{Path, PathBuf};
-    use trueno_rag::fusion::FusionStrategy;
-    use trueno_rag::Document;
+    use aprender_rag::fusion::FusionStrategy;
+    use aprender_rag::Document;
 
     // Re-import functions from submodules for testing
     use crate::discover::*;
@@ -881,7 +881,7 @@ mod tests {
         assert!(db_path.exists(), "index.sqlite should be created");
 
         // Verify doc and chunk counts via SqliteIndex API
-        let idx = trueno_rag::SqliteIndex::open(&db_path).unwrap();
+        let idx = aprender_rag::SqliteIndex::open(&db_path).unwrap();
         assert_eq!(idx.document_count().unwrap(), 2, "2 unique source docs");
         assert_eq!(idx.chunk_count().unwrap(), 3, "3 chunks total");
 
@@ -943,7 +943,7 @@ mod tests {
 
         export_sqlite(&persisted, &dir).unwrap();
 
-        let idx = trueno_rag::SqliteIndex::open(dir.join("index.sqlite")).unwrap();
+        let idx = aprender_rag::SqliteIndex::open(dir.join("index.sqlite")).unwrap();
         assert_eq!(idx.document_count().unwrap(), 2);
         assert_eq!(idx.chunk_count().unwrap(), 4);
 
@@ -973,7 +973,7 @@ mod tests {
 
         export_sqlite(&persisted, &dir).unwrap();
 
-        let idx = trueno_rag::SqliteIndex::open(dir.join("index.sqlite")).unwrap();
+        let idx = aprender_rag::SqliteIndex::open(dir.join("index.sqlite")).unwrap();
         assert_eq!(idx.document_count().unwrap(), 1, "unknown doc grouped");
         assert_eq!(idx.chunk_count().unwrap(), 1);
 
@@ -1006,7 +1006,7 @@ mod tests {
 
         export_sqlite(&persisted, &dir).unwrap();
 
-        let idx = trueno_rag::SqliteIndex::open(dir.join("index.sqlite")).unwrap();
+        let idx = aprender_rag::SqliteIndex::open(dir.join("index.sqlite")).unwrap();
         assert_eq!(idx.document_count().unwrap(), 1);
         assert_eq!(idx.chunk_count().unwrap(), 1);
 
@@ -1055,7 +1055,7 @@ mod tests {
 
         export_sqlite(&persisted, &dir).unwrap();
 
-        let idx = trueno_rag::SqliteIndex::open(dir.join("index.sqlite")).unwrap();
+        let idx = aprender_rag::SqliteIndex::open(dir.join("index.sqlite")).unwrap();
         assert_eq!(idx.document_count().unwrap(), 0);
         assert_eq!(idx.chunk_count().unwrap(), 0);
 
@@ -1341,9 +1341,9 @@ mod tests {
 
     #[test]
     fn test_chunk_and_embed_timestamp_strategy() {
-        use trueno_rag::chunk::RecursiveChunker;
-        use trueno_rag::chunk::TimestampChunker;
-        use trueno_rag::embed::MockEmbedder;
+        use aprender_rag::chunk::RecursiveChunker;
+        use aprender_rag::chunk::TimestampChunker;
+        use aprender_rag::embed::MockEmbedder;
 
         let embedder = MockEmbedder::new(4);
         let recursive = RecursiveChunker::new(512, 64);
@@ -1438,9 +1438,9 @@ mod tests {
 
     #[test]
     fn test_chunk_and_embed_empty_document() {
-        use trueno_rag::chunk::RecursiveChunker;
-        use trueno_rag::chunk::TimestampChunker;
-        use trueno_rag::embed::MockEmbedder;
+        use aprender_rag::chunk::RecursiveChunker;
+        use aprender_rag::chunk::TimestampChunker;
+        use aprender_rag::embed::MockEmbedder;
 
         let embedder = MockEmbedder::new(4);
         let recursive = RecursiveChunker::new(512, 64);
@@ -1468,9 +1468,9 @@ mod tests {
 
     #[test]
     fn test_chunk_and_embed_with_dedup() {
-        use trueno_rag::chunk::RecursiveChunker;
-        use trueno_rag::chunk::TimestampChunker;
-        use trueno_rag::embed::MockEmbedder;
+        use aprender_rag::chunk::RecursiveChunker;
+        use aprender_rag::chunk::TimestampChunker;
+        use aprender_rag::embed::MockEmbedder;
 
         let embedder = MockEmbedder::new(4);
         let recursive = RecursiveChunker::new(512, 64);

--- a/crates/aprender-rag/crates/trueno-rag-cli/src/query.rs
+++ b/crates/aprender-rag/crates/trueno-rag-cli/src/query.rs
@@ -6,7 +6,7 @@ use anyhow::Result;
 use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
-use trueno_rag::{
+use aprender_rag::{
     chunk::RecursiveChunker,
     embed::{Embedder, TfIdfEmbedder},
     fusion::FusionStrategy,
@@ -16,7 +16,7 @@ use trueno_rag::{
 };
 
 #[cfg(feature = "embeddings")]
-use trueno_rag::{EmbeddingModelType, FastEmbedder};
+use aprender_rag::{EmbeddingModelType, FastEmbedder};
 
 use crate::{PersistedChunk, PersistedIndex};
 
@@ -175,7 +175,7 @@ pub(crate) fn create_query_embedder(persisted: &PersistedIndex) -> Result<Box<dy
 /// similarity for vocabulary-mismatched queries.
 #[cfg(feature = "eval")]
 pub(crate) fn expand_query_hyde(query: &str) -> Result<String> {
-    use trueno_rag::preprocess::{AnthropicHypotheticalGenerator, HypotheticalGenerator};
+    use aprender_rag::preprocess::{AnthropicHypotheticalGenerator, HypotheticalGenerator};
 
     let generator = AnthropicHypotheticalGenerator::from_env()
         .map_err(|e| anyhow::anyhow!("HyDE requires ANTHROPIC_API_KEY: {e}"))?;
@@ -207,9 +207,9 @@ pub(crate) fn apply_rerank(
     chunks: &[PersistedChunk],
     top_k: usize,
 ) -> Result<Vec<(usize, f32)>> {
-    use trueno_rag::rerank::Reranker;
-    use trueno_rag::retrieve::RetrievalResult;
-    use trueno_rag::DocumentId;
+    use aprender_rag::rerank::Reranker;
+    use aprender_rag::retrieve::RetrievalResult;
+    use aprender_rag::DocumentId;
 
     match rerank {
         "none" => Ok(scores.iter().take(top_k).copied().collect()),
@@ -259,12 +259,12 @@ pub(crate) fn apply_rerank(
 pub(crate) fn rerank_retrieved_chunks(
     rerank: &str,
     query: &str,
-    mut results: Vec<trueno_rag::eval::types::RetrievedChunk>,
+    mut results: Vec<aprender_rag::eval::types::RetrievedChunk>,
     top_k: usize,
-) -> Result<Vec<trueno_rag::eval::types::RetrievedChunk>> {
-    use trueno_rag::rerank::Reranker;
-    use trueno_rag::retrieve::RetrievalResult;
-    use trueno_rag::DocumentId;
+) -> Result<Vec<aprender_rag::eval::types::RetrievedChunk>> {
+    use aprender_rag::rerank::Reranker;
+    use aprender_rag::retrieve::RetrievalResult;
+    use aprender_rag::DocumentId;
 
     match rerank {
         "none" => {
@@ -337,11 +337,11 @@ pub(crate) fn query_sparse(
     persisted: &PersistedIndex,
     top_k: usize,
 ) -> Vec<(usize, f32)> {
-    use trueno_rag::index::SparseIndex;
-    use trueno_rag::{BM25Index, DocumentId};
+    use aprender_rag::index::SparseIndex;
+    use aprender_rag::{BM25Index, DocumentId};
 
     let mut bm25 = BM25Index::new();
-    let mut chunk_map: HashMap<trueno_rag::ChunkId, usize> = HashMap::new();
+    let mut chunk_map: HashMap<aprender_rag::ChunkId, usize> = HashMap::new();
     for (i, pc) in persisted.chunks.iter().enumerate() {
         let chunk = Chunk::new(DocumentId::new(), pc.content.clone(), 0, pc.content.len());
         chunk_map.insert(chunk.id, i);
@@ -361,9 +361,9 @@ pub(crate) fn query_hybrid(
     fusion_k: Option<f32>,
     candidates: usize,
 ) -> Result<Vec<(usize, f32)>> {
-    use trueno_rag::index::VectorStoreConfig;
-    use trueno_rag::retrieve::HybridRetrieverConfig;
-    use trueno_rag::{BM25Index, DocumentId, HybridRetriever, VectorStore};
+    use aprender_rag::index::VectorStoreConfig;
+    use aprender_rag::retrieve::HybridRetrieverConfig;
+    use aprender_rag::{BM25Index, DocumentId, HybridRetriever, VectorStore};
 
     let fusion_strategy = parse_fusion_strategy(fusion, fusion_k)?;
 
@@ -382,7 +382,7 @@ pub(crate) fn query_hybrid(
 
     let mut retriever = HybridRetriever::new(dense_store, bm25, embedder).with_config(config);
 
-    let mut chunk_meta: HashMap<trueno_rag::ChunkId, usize> = HashMap::new();
+    let mut chunk_meta: HashMap<aprender_rag::ChunkId, usize> = HashMap::new();
     for (i, pc) in persisted.chunks.iter().enumerate() {
         let mut chunk = Chunk::new(DocumentId::new(), pc.content.clone(), 0, pc.content.len());
         chunk.metadata.title = pc.title.clone();
@@ -443,8 +443,8 @@ pub(crate) fn format_query_results(
             let time_info = match (chunk.start_secs, chunk.end_secs) {
                 (Some(start), Some(end)) => format!(
                     " [{}–{}]",
-                    trueno_rag::media::format_display_time(start),
-                    trueno_rag::media::format_display_time(end),
+                    aprender_rag::media::format_display_time(start),
+                    aprender_rag::media::format_display_time(end),
                 ),
                 _ => String::new(),
             };

--- a/crates/aprender-rag/crates/trueno-rag-cli/src/transcribe.rs
+++ b/crates/aprender-rag/crates/trueno-rag-cli/src/transcribe.rs
@@ -182,7 +182,7 @@ fn run_transcription_batch(
 ) -> Result<()> {
     use rayon::prelude::*;
     use std::sync::Mutex;
-    use trueno_rag::{
+    use aprender_rag::{
         DocumentLoader, TranscriptionBackend, TranscriptionConfig, TranscriptionLoader,
     };
 

--- a/crates/aprender-rag/examples/basic_rag.rs
+++ b/crates/aprender-rag/examples/basic_rag.rs
@@ -2,12 +2,12 @@
 //!
 //! Run with: cargo run --example basic_rag
 
-use trueno_rag::{
+use aprender_rag::{
     chunk::RecursiveChunker, embed::MockEmbedder, fusion::FusionStrategy,
     pipeline::RagPipelineBuilder, rerank::LexicalReranker, Document,
 };
 
-fn main() -> trueno_rag::Result<()> {
+fn main() -> aprender_rag::Result<()> {
     println!("=== Basic RAG Pipeline Example ===\n");
 
     // 1. Build the pipeline

--- a/crates/aprender-rag/examples/chunking_strategies.rs
+++ b/crates/aprender-rag/examples/chunking_strategies.rs
@@ -2,7 +2,7 @@
 //!
 //! Run with: cargo run --example chunking_strategies
 
-use trueno_rag::{
+use aprender_rag::{
     chunk::{
         Chunker, FixedSizeChunker, ParagraphChunker, RecursiveChunker, SentenceChunker,
         StructuralChunker,
@@ -10,7 +10,7 @@ use trueno_rag::{
     Document,
 };
 
-fn main() -> trueno_rag::Result<()> {
+fn main() -> aprender_rag::Result<()> {
     println!("=== Chunking Strategies Comparison ===\n");
 
     // Sample document

--- a/crates/aprender-rag/examples/compressed_index.rs
+++ b/crates/aprender-rag/examples/compressed_index.rs
@@ -6,10 +6,10 @@
 //! reducing storage footprint by 5-10x for typical RAG indices.
 
 #[cfg(feature = "compression")]
-use trueno_rag::{compressed::Compression, index::SparseIndex, BM25Index, Chunk, DocumentId};
+use aprender_rag::{compressed::Compression, index::SparseIndex, BM25Index, Chunk, DocumentId};
 
 #[cfg(feature = "compression")]
-fn main() -> trueno_rag::Result<()> {
+fn main() -> aprender_rag::Result<()> {
     println!("=== Trueno-RAG Compressed Index Demo ===\n");
 
     // Demo basic compression
@@ -29,7 +29,7 @@ fn main() -> trueno_rag::Result<()> {
 }
 
 #[cfg(feature = "compression")]
-fn demo_basic_compression() -> trueno_rag::Result<()> {
+fn demo_basic_compression() -> aprender_rag::Result<()> {
     println!("1. Basic BM25 Index Compression");
     println!("   -----------------------------");
 
@@ -68,7 +68,7 @@ fn demo_basic_compression() -> trueno_rag::Result<()> {
 }
 
 #[cfg(feature = "compression")]
-fn demo_compression_comparison() -> trueno_rag::Result<()> {
+fn demo_compression_comparison() -> aprender_rag::Result<()> {
     println!("2. Compression Ratio Comparison");
     println!("   -----------------------------");
 
@@ -112,7 +112,7 @@ fn demo_compression_comparison() -> trueno_rag::Result<()> {
 }
 
 #[cfg(feature = "compression")]
-fn demo_search_after_restore() -> trueno_rag::Result<()> {
+fn demo_search_after_restore() -> aprender_rag::Result<()> {
     println!("3. Search Behavior After Restore");
     println!("   ------------------------------");
 
@@ -158,7 +158,7 @@ fn demo_search_after_restore() -> trueno_rag::Result<()> {
 }
 
 #[cfg(feature = "compression")]
-fn demo_persistence_workflow() -> trueno_rag::Result<()> {
+fn demo_persistence_workflow() -> aprender_rag::Result<()> {
     println!("4. Persistence Workflow (Simulated)");
     println!("   ---------------------------------");
 

--- a/crates/aprender-rag/examples/eval_hybrid.rs
+++ b/crates/aprender-rag/examples/eval_hybrid.rs
@@ -8,7 +8,7 @@
 //! Run with: cargo run --example eval_hybrid
 
 use std::collections::HashSet;
-use trueno_rag::{
+use aprender_rag::{
     embed::{Embedder, MockEmbedder},
     fusion::FusionStrategy,
     metrics::RetrievalMetrics,
@@ -16,7 +16,7 @@ use trueno_rag::{
     BM25Index, Chunk, ChunkId, DocumentId, HybridRetriever, VectorStore,
 };
 
-fn main() -> trueno_rag::Result<()> {
+fn main() -> aprender_rag::Result<()> {
     println!("=== Hybrid vs Dense vs Sparse Retrieval Comparison ===\n");
 
     // Create sample documents about programming and cloud computing

--- a/crates/aprender-rag/examples/hybrid_search.rs
+++ b/crates/aprender-rag/examples/hybrid_search.rs
@@ -2,12 +2,12 @@
 //!
 //! Run with: cargo run --example hybrid_search
 
-use trueno_rag::{
+use aprender_rag::{
     embed::MockEmbedder, fusion::FusionStrategy, pipeline::RagPipelineBuilder,
     rerank::NoOpReranker, Document,
 };
 
-fn main() -> trueno_rag::Result<()> {
+fn main() -> aprender_rag::Result<()> {
     println!("=== Hybrid Search with Different Fusion Strategies ===\n");
 
     let documents = vec![

--- a/crates/aprender-rag/examples/metrics_evaluation.rs
+++ b/crates/aprender-rag/examples/metrics_evaluation.rs
@@ -3,7 +3,7 @@
 //! Run with: cargo run --example metrics_evaluation
 
 use std::collections::HashSet;
-use trueno_rag::{metrics::RetrievalMetrics, ChunkId};
+use aprender_rag::{metrics::RetrievalMetrics, ChunkId};
 
 fn main() {
     println!("=== Retrieval Metrics Evaluation ===\n");

--- a/crates/aprender-rag/examples/nemotron_embeddings.rs
+++ b/crates/aprender-rag/examples/nemotron_embeddings.rs
@@ -15,10 +15,10 @@
 //! ```
 
 #[cfg(feature = "nemotron")]
-use trueno_rag::embed::{cosine_similarity, Embedder, NemotronConfig, NemotronEmbedder};
+use aprender_rag::embed::{cosine_similarity, Embedder, NemotronConfig, NemotronEmbedder};
 
 #[cfg(feature = "nemotron")]
-fn main() -> trueno_rag::Result<()> {
+fn main() -> aprender_rag::Result<()> {
     // Configure the embedder
     // Replace with your actual model path
     let model_path = std::env::var("NEMOTRON_MODEL_PATH")

--- a/crates/aprender-rag/examples/semantic_embeddings.rs
+++ b/crates/aprender-rag/examples/semantic_embeddings.rs
@@ -8,7 +8,7 @@
 //! The first run will download the model (~90MB for MiniLM).
 
 #[cfg(feature = "embeddings")]
-use trueno_rag::{
+use aprender_rag::{
     chunk::RecursiveChunker, embed::Embedder, fusion::FusionStrategy, pipeline::RagPipelineBuilder,
     rerank::LexicalReranker, Document, EmbeddingModelType, FastEmbedder,
 };
@@ -53,7 +53,7 @@ fn sample_documents() -> Vec<Document> {
 }
 
 #[cfg(feature = "embeddings")]
-fn demo_similarity() -> trueno_rag::Result<()> {
+fn demo_similarity() -> aprender_rag::Result<()> {
     println!("=== Embedding Similarity Demo ===\n");
     let embedder = FastEmbedder::new(EmbeddingModelType::AllMiniLmL6V2)?;
 
@@ -84,7 +84,7 @@ fn demo_similarity() -> trueno_rag::Result<()> {
 }
 
 #[cfg(feature = "embeddings")]
-fn demo_retrieval() -> trueno_rag::Result<()> {
+fn demo_retrieval() -> aprender_rag::Result<()> {
     println!("Loading embedding model (first run downloads ~90MB)...");
     let embedder = FastEmbedder::new(EmbeddingModelType::AllMiniLmL6V2)?;
     println!("Model: {} (dimension: {})\n", embedder.model_id(), embedder.dimension());
@@ -116,7 +116,7 @@ fn demo_retrieval() -> trueno_rag::Result<()> {
 }
 
 #[cfg(feature = "embeddings")]
-fn main() -> trueno_rag::Result<()> {
+fn main() -> aprender_rag::Result<()> {
     println!("=== Semantic Embeddings Example ===\n");
     demo_retrieval()?;
     demo_similarity()
@@ -124,9 +124,9 @@ fn main() -> trueno_rag::Result<()> {
 
 #[cfg(feature = "embeddings")]
 fn run_query(
-    pipeline: &mut trueno_rag::pipeline::RagPipeline<FastEmbedder, LexicalReranker>,
+    pipeline: &mut aprender_rag::pipeline::RagPipeline<FastEmbedder, LexicalReranker>,
     query: &str,
-) -> trueno_rag::Result<()> {
+) -> aprender_rag::Result<()> {
     println!("Query: \"{}\"\n", query);
     let results = pipeline.query(query, 2)?;
     if results.is_empty() {

--- a/crates/aprender-rag/examples/sqlite_export.rs
+++ b/crates/aprender-rag/examples/sqlite_export.rs
@@ -7,9 +7,9 @@
 //!
 //! (The `sqlite` feature is enabled by default.)
 
-use trueno_rag::sqlite::SqliteIndex;
+use aprender_rag::sqlite::SqliteIndex;
 
-fn main() -> trueno_rag::Result<()> {
+fn main() -> aprender_rag::Result<()> {
     println!("=== SQLite+FTS5 Export Example ===\n");
 
     // 1. Create an in-memory SQLite index

--- a/crates/aprender-rag/src/chunk/timestamp.rs
+++ b/crates/aprender-rag/src/chunk/timestamp.rs
@@ -15,9 +15,9 @@ use crate::{Document, Error, Result};
 /// # Example
 ///
 /// ```rust
-/// use trueno_rag::chunk::{TimestampChunker, Chunker};
-/// use trueno_rag::Document;
-/// use trueno_rag::media::SubtitleCue;
+/// use aprender_rag::chunk::{TimestampChunker, Chunker};
+/// use aprender_rag::Document;
+/// use aprender_rag::media::SubtitleCue;
 ///
 /// let cues = vec![
 ///     SubtitleCue { index: 0, start_secs: 0.0, end_secs: 30.0, text: "First segment.".into() },

--- a/crates/aprender-rag/src/embed/mod.rs
+++ b/crates/aprender-rag/src/embed/mod.rs
@@ -441,7 +441,7 @@ impl EmbeddingModelType {
 /// # Example
 ///
 /// ```rust,ignore
-/// use trueno_rag::embed::{FastEmbedder, EmbeddingModelType, Embedder};
+/// use aprender_rag::embed::{FastEmbedder, EmbeddingModelType, Embedder};
 ///
 /// let embedder = FastEmbedder::new(EmbeddingModelType::AllMiniLmL6V2)?;
 /// let embedding = embedder.embed("Hello, world!")?;

--- a/crates/aprender-rag/src/embed/nemotron.rs
+++ b/crates/aprender-rag/src/embed/nemotron.rs
@@ -111,7 +111,7 @@ impl NemotronConfig {
 /// # Example
 ///
 /// ```rust,ignore
-/// use trueno_rag::embed::{NemotronEmbedder, NemotronConfig, Embedder};
+/// use aprender_rag::embed::{NemotronEmbedder, NemotronConfig, Embedder};
 ///
 /// let config = NemotronConfig::new("models/NV-Embed-v2-Q4_K.gguf")
 ///     .with_gpu(true);

--- a/crates/aprender-rag/src/lib.rs
+++ b/crates/aprender-rag/src/lib.rs
@@ -6,7 +6,7 @@
 //! # Quick Start
 //!
 //! ```rust
-//! use trueno_rag::{
+//! use aprender_rag::{
 //!     pipeline::RagPipelineBuilder,
 //!     chunk::RecursiveChunker,
 //!     embed::MockEmbedder,
@@ -57,7 +57,7 @@
 //! # Example: Custom Chunking
 //!
 //! ```rust
-//! use trueno_rag::{chunk::{ParagraphChunker, Chunker}, Document};
+//! use aprender_rag::{chunk::{ParagraphChunker, Chunker}, Document};
 //!
 //! let chunker = ParagraphChunker::new(2); // 2 paragraphs per chunk
 //! let doc = Document::new("Para 1.\n\nPara 2.\n\nPara 3.");

--- a/crates/aprender-rag/src/loader/mod.rs
+++ b/crates/aprender-rag/src/loader/mod.rs
@@ -12,7 +12,7 @@
 //! # Example
 //!
 //! ```rust
-//! use trueno_rag::loader::LoaderRegistry;
+//! use aprender_rag::loader::LoaderRegistry;
 //! use std::path::Path;
 //!
 //! let registry = LoaderRegistry::new();

--- a/crates/aprender-rag/src/loader/transcription.rs
+++ b/crates/aprender-rag/src/loader/transcription.rs
@@ -82,8 +82,8 @@ impl Default for TranscriptionConfig {
 /// # Example
 ///
 /// ```rust,no_run
-/// use trueno_rag::loader::transcription::{TranscriptionLoader, TranscriptionConfig};
-/// use trueno_rag::loader::LoaderRegistry;
+/// use aprender_rag::loader::transcription::{TranscriptionLoader, TranscriptionConfig};
+/// use aprender_rag::loader::LoaderRegistry;
 ///
 /// let mut registry = LoaderRegistry::new();
 /// registry.register(Box::new(TranscriptionLoader::with_defaults()));

--- a/crates/aprender-rag/src/media.rs
+++ b/crates/aprender-rag/src/media.rs
@@ -6,7 +6,7 @@
 //! # Example
 //!
 //! ```rust
-//! use trueno_rag::media::{parse_subtitles, SubtitleFormat};
+//! use aprender_rag::media::{parse_subtitles, SubtitleFormat};
 //!
 //! let srt = "1\n00:00:01,000 --> 00:00:04,500\nHello world.\n";
 //! let track = parse_subtitles(srt).unwrap();

--- a/crates/aprender-rag/src/multivector/embedder.rs
+++ b/crates/aprender-rag/src/multivector/embedder.rs
@@ -15,7 +15,7 @@ use crate::Result;
 /// # Example
 ///
 /// ```ignore
-/// use trueno_rag::multivector::{MultiVectorEmbedder, MockMultiVectorEmbedder};
+/// use aprender_rag::multivector::{MultiVectorEmbedder, MockMultiVectorEmbedder};
 ///
 /// let embedder = MockMultiVectorEmbedder::new(128, 512);
 /// let embedding = embedder.embed_tokens("hello world").unwrap();
@@ -61,8 +61,8 @@ pub trait MultiVectorEmbedder: Send + Sync {
 /// # Example
 ///
 /// ```
-/// use trueno_rag::multivector::MockMultiVectorEmbedder;
-/// use trueno_rag::multivector::MultiVectorEmbedder;
+/// use aprender_rag::multivector::MockMultiVectorEmbedder;
+/// use aprender_rag::multivector::MultiVectorEmbedder;
 ///
 /// let embedder = MockMultiVectorEmbedder::new(128, 512);
 ///

--- a/crates/aprender-rag/src/multivector/mod.rs
+++ b/crates/aprender-rag/src/multivector/mod.rs
@@ -27,7 +27,7 @@
 //! # Quick Start
 //!
 //! ```ignore
-//! use trueno_rag::multivector::{
+//! use aprender_rag::multivector::{
 //!     WarpIndex, WarpIndexConfig, WarpSearchConfig,
 //!     MockMultiVectorEmbedder, MultiVectorEmbedder,
 //!     MultiVectorRetriever,

--- a/crates/aprender-rag/src/multivector/types.rs
+++ b/crates/aprender-rag/src/multivector/types.rs
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
 /// # Example
 ///
 /// ```
-/// use trueno_rag::multivector::MultiVectorEmbedding;
+/// use aprender_rag::multivector::MultiVectorEmbedding;
 ///
 /// // Create a 3-token embedding with 128 dimensions per token
 /// let embeddings = vec![0.0f32; 3 * 128];

--- a/crates/aprender-rag/src/retrieve.rs
+++ b/crates/aprender-rag/src/retrieve.rs
@@ -371,7 +371,7 @@ impl Default for SparseRetriever {
 /// # Example
 ///
 /// ```ignore
-/// use trueno_rag::multivector::{
+/// use aprender_rag::multivector::{
 ///     WarpIndexConfig, WarpSearchConfig,
 ///     MockMultiVectorEmbedder, MultiVectorRetriever,
 /// };

--- a/crates/aprender-rag/tests/integration.rs
+++ b/crates/aprender-rag/tests/integration.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::disallowed_methods)]
 //! Integration tests for trueno-rag
 
-use trueno_rag::{
+use aprender_rag::{
     chunk::{
         Chunker, ParagraphChunker, RecursiveChunker, SentenceChunker, StructuralChunker,
         TimestampChunker,

--- a/crates/aprender-rag/tests/nemotron_integration.rs
+++ b/crates/aprender-rag/tests/nemotron_integration.rs
@@ -7,7 +7,7 @@
 
 #![cfg(feature = "nemotron")]
 
-use trueno_rag::embed::{cosine_similarity, Embedder, NemotronConfig, NemotronEmbedder};
+use aprender_rag::embed::{cosine_similarity, Embedder, NemotronConfig, NemotronEmbedder};
 
 /// Test model path - set via environment variable or use default
 fn test_model_path() -> Option<String> {
@@ -178,7 +178,7 @@ fn test_nemotron_empty_document_error() {
 #[test]
 #[ignore = "Requires GGUF model file (set NEMOTRON_MODEL_PATH env var)"]
 fn test_nemotron_embed_chunks() {
-    use trueno_rag::{Chunk, DocumentId};
+    use aprender_rag::{Chunk, DocumentId};
 
     let Some(embedder) = create_test_embedder() else {
         eprintln!("Skipping: NEMOTRON_MODEL_PATH not set");

--- a/crates/aprender-rag/tests/property_tests.rs
+++ b/crates/aprender-rag/tests/property_tests.rs
@@ -2,7 +2,7 @@
 //! Property-based tests for trueno-rag
 
 use proptest::prelude::*;
-use trueno_rag::{
+use aprender_rag::{
     chunk::{Chunker, FixedSizeChunker, ParagraphChunker, RecursiveChunker, TimestampChunker},
     embed::{cosine_similarity, Embedder, MockEmbedder},
     media::{parse_subtitles, SubtitleCue, SubtitleFormat, SubtitleTrack},

--- a/crates/aprender-registry/Cargo.toml
+++ b/crates/aprender-registry/Cargo.toml
@@ -42,7 +42,7 @@ zstd = { version = "0.13", optional = true }
 clap = { version = "4", features = ["derive"], optional = true }
 
 # Ecosystem integration
-aprender = { path = "../aprender-core", version = "0.31.2", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.32.0", package = "aprender-core", optional = true }
 alimentar = { version = "0.2.3", optional = true }
 
 # HTTP client (optional)

--- a/crates/aprender-serve/Cargo.toml
+++ b/crates/aprender-serve/Cargo.toml
@@ -39,7 +39,7 @@ name = "realizar"
 trueno = { version = "0.17", features = ["gpu"] }
 # CUDA PTX generation and runtime for NVIDIA GPUs (optional, pure Rust, no LLVM/nvcc)
 # v0.4.12: BatchedQ6K, MultiWarp, RopeNeox, FlashDecoding kernels
-trueno-gpu = { version = "0.31.2", path = "../aprender-gpu", package = "aprender-gpu", optional = true, features = ["cuda"] }  # APR-MONO single-source-of-truth
+trueno-gpu = { version = "0.32.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true, features = ["cuda"] }  # APR-MONO single-source-of-truth
 # KV cache storage (for attention caching)
 trueno-db = { version = "0.3.16", optional = true }
 # K-quantization formats (Q4_K, Q5_K, Q6_K) - Toyota Way: ONE source of truth
@@ -53,7 +53,7 @@ renacer-core = { version = "0.1" }
 
 # ML algorithms and .apr model format (optional for aprender model serving)
 # v0.24.1: chat templates, GGUF tokenizer preservation (local may be newer)
-aprender = { path = "../aprender-core", version = "0.31.2", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.32.0", package = "aprender-core", optional = true }
 
 # Data loading library (optional for data pipeline examples)
 alimentar = { version = "0.2", optional = true, default-features = false, features = ["local", "shuffle"] }

--- a/crates/aprender-shell/Cargo.toml
+++ b/crates/aprender-shell/Cargo.toml
@@ -24,7 +24,7 @@ harness = false
 
 [dependencies]
 # Use path for local dev, crates.io for release
-aprender = { path = "../aprender-core", version = "0.31.2", package = "aprender-core", features = ["format-encryption", "format-compression", "format-homomorphic"] }
+aprender = { path = "../aprender-core", version = "0.32.0", package = "aprender-core", features = ["format-encryption", "format-compression", "format-homomorphic"] }
 clap = { version = "4", features = ["derive"] }
 dirs = "5"
 serde = { version = "1", features = ["derive"] }

--- a/crates/aprender-test-cli/Cargo.toml
+++ b/crates/aprender-test-cli/Cargo.toml
@@ -24,7 +24,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Core library (was: jugar-probar) — dep key preserves Rust identifier
-jugar-probar = { path = "../aprender-test-lib", version = "0.31.2", package = "aprender-test-lib" }
+jugar-probar = { path = "../aprender-test-lib", version = "0.32.0", package = "aprender-test-lib" }
 
 # CLI framework
 clap = { workspace = true }

--- a/crates/aprender-train-bench/Cargo.toml
+++ b/crates/aprender-train-bench/Cargo.toml
@@ -19,8 +19,8 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-entrenar = { version = "0.31.2", path = "../aprender-train", package = "aprender-train" }
-entrenar-common = { version = "0.31.2", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar = { version = "0.32.0", path = "../aprender-train", package = "aprender-train" }
+entrenar-common = { version = "0.32.0", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/aprender-train-distill/Cargo.toml
+++ b/crates/aprender-train-distill/Cargo.toml
@@ -23,8 +23,8 @@ default = []
 hub = ["entrenar/hub"]
 
 [dependencies]
-entrenar = { version = "0.31.2", path = "../aprender-train", package = "aprender-train" }
-entrenar-common = { version = "0.31.2", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar = { version = "0.32.0", path = "../aprender-train", package = "aprender-train" }
+entrenar-common = { version = "0.32.0", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/aprender-train-inspect/Cargo.toml
+++ b/crates/aprender-train-inspect/Cargo.toml
@@ -19,8 +19,8 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-entrenar = { version = "0.31.2", path = "../aprender-train", package = "aprender-train" }
-entrenar-common = { version = "0.31.2", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar = { version = "0.32.0", path = "../aprender-train", package = "aprender-train" }
+entrenar-common = { version = "0.32.0", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/aprender-train-lora/Cargo.toml
+++ b/crates/aprender-train-lora/Cargo.toml
@@ -19,8 +19,8 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-entrenar = { version = "0.31.2", path = "../aprender-train", package = "aprender-train" }
-entrenar-common = { version = "0.31.2", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar = { version = "0.32.0", path = "../aprender-train", package = "aprender-train" }
+entrenar-common = { version = "0.32.0", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/aprender-train-shell/Cargo.toml
+++ b/crates/aprender-train-shell/Cargo.toml
@@ -19,8 +19,8 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-entrenar = { version = "0.31.2", path = "../aprender-train", package = "aprender-train" }
-entrenar-common = { version = "0.31.2", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar = { version = "0.32.0", path = "../aprender-train", package = "aprender-train" }
+entrenar-common = { version = "0.32.0", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 rustyline = "14"
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/aprender-train/Cargo.toml
+++ b/crates/aprender-train/Cargo.toml
@@ -75,9 +75,9 @@ provable-contracts-macros = { version = "0.2" }
 # Core PAIML stack
 ndarray = "0.16"
 trueno = { version = "0.17", features = ["parallel"] }  # SIMD-accelerated compute
-trueno-gpu = { version = "0.31.2", path = "../aprender-gpu", package = "aprender-gpu", optional = true }  # CUDA compute (APR-MONO single-source-of-truth)
+trueno-gpu = { version = "0.32.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true }  # CUDA compute (APR-MONO single-source-of-truth)
 realizar = { version = "0.8", optional = true }  # CUDA inference engine
-aprender = { path = "../aprender-core", version = "0.31.2", package = "aprender-core" }  # ML interpret module + .apr format + tokenizers
+aprender = { path = "../aprender-core", version = "0.32.0", package = "aprender-core" }  # ML interpret module + .apr format + tokenizers
 trueno-viz = { version = "0.2", features = ["terminal"] }  # Terminal visualization
 presentar-terminal = { version = "0.3.5", optional = true }  # Sovereign TUI framework (gated by "tui" feature)
 presentar-core = "0.3.4"  # Presentar core traits (crates.io — path removed, presentar restructured)

--- a/crates/aprender-tsp/Cargo.toml
+++ b/crates/aprender-tsp/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 name = "aprender-tsp"
 
 [dependencies]
-aprender = { path = "../../", version = "0.31.2" }
+aprender = { path = "../../", version = "0.32.0" }
 clap = { version = "4", features = ["derive"] }
 rand = "0.9"
 crc32fast = "1.4"

--- a/crates/aprender-verify-ml/Cargo.toml
+++ b/crates/aprender-verify-ml/Cargo.toml
@@ -50,7 +50,7 @@ uuid = { version = "1.11", features = ["v4", "serde"] }
 trueno = "0.7.3"
 
 # Machine learning for bug prediction (optional)
-aprender = { path = "../aprender-core", version = "0.31.2", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.32.0", package = "aprender-core", optional = true }
 
 # LLM fine-tuning integration (optional)
 entrenar = { workspace = true, optional = true }

--- a/crates/aprender-viz/Cargo.toml
+++ b/crates/aprender-viz/Cargo.toml
@@ -29,7 +29,7 @@ base64 = "0.22"
 thiserror = "2.0"
 
 # Optional: ML integration
-aprender = { path = "../aprender-core", version = "0.31.2", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.32.0", package = "aprender-core", optional = true }
 
 # Optional: Graph integration
 trueno-graph = { workspace = true, optional = true, default-features = false }


### PR DESCRIPTION
## Summary

Published \`aprender-rag = \"0.31.2\"\` had \`[lib] name = \"trueno_rag\"\`, making \`use aprender_rag::*\` not compile against external consumers. This renames the lib to match the package name + bumps to **v0.32.0** (breaking import-path change → minor bump per SemVer).

User report:
> the published aprender-rag = "0.31.2" still has [lib] name = "trueno_rag" in its Cargo.toml, so use aprender_rag::* won't actually compile against the current crate.

## What ships

- \`crates/aprender-rag/Cargo.toml\`: \`[lib] name = \"trueno_rag\"\` → \`\"aprender_rag\"\`.
- \`crates/aprender-rag/src/**/*.rs\`: doctests use \`aprender_rag::*\`.
- \`crates/aprender-rag/crates/trueno-rag-cli/\`: sub-cli updated to consume the renamed lib (Cargo.toml + 7 source files).
- Workspace \`version\` 0.31.2 → 0.32.0 across **64 files**.

## What is NOT changed

- \`aprender-core\`, \`aprender-train\`, \`aprender-orchestrate\` continue to depend on the **external** \`trueno-rag = \"0.2\"\` crate from crates.io (NOT the local path dep). Their \`use trueno_rag::*\` imports remain — they consume a separate, older published crate. Migrating those is a separate refactor.
- \`apr-cli/src/commands/mono.rs\` line 184 already declared the intended lib name \`aprender_rag\` for the \`apr mono\` rename registry — this PR makes Cargo.toml match the registry.

## Verification

\`\`\`
cargo check -p aprender-rag             # ✓ clean
cargo test -p aprender-rag --lib        # 442/442 pass
cargo test -p aprender-rag --doc        # 5/5 pass
\`\`\`

\`cargo check --workspace\` has 1 pre-existing error in \`aprender-orchestrate\` bin (\`batuta::cmd_code\` arg drift) — unrelated to this PR (verified by reproducing on main pre-this-branch via \`git stash\`).

## Five Whys

1. **Why did lib name drift from package name?** Pre-monorepo crate was published as \`trueno-rag\` with lib \`trueno_rag\`; APR-MONO renamed the package but not the lib.
2. **Why did internal tests pass but external compile fail?** Internal doctests use \`use trueno_rag::*\` (matching lib name); external consumers expect \`use aprender_rag::*\` (matching package name they typed).
3. **Why minor bump (0.32.0)?** Renaming the lib changes public import path → breaking → SemVer minor (this is pre-1.0).
4. **Why not migrate workspace crates off external \`trueno-rag\`?** Out of scope; needs API-diff investigation between published 0.2.x and local 0.32.0.
5. **Why ship despite pre-existing orchestrate error?** Unrelated defect (verified pre-existing on main); blocking conflates concerns.

## Operator follow-up

\`cargo publish\` requires crates.io credentials (operator-only):
\`\`\`
cargo publish -p aprender-rag           # publishes 0.32.0
cargo install aprender --force          # post-publish QA per
                                          feedback_post_publish_qa_required.md
\`\`\`

## Test plan
- [x] Lib rename in \`crates/aprender-rag/Cargo.toml\`
- [x] All workspace 0.31.2 pins → 0.32.0
- [x] aprender-rag doctests + unit tests pass
- [x] PMAT pre-commit gates pass
- [ ] CI gate green
- [ ] Auto-merge fires on green CI
- [ ] Operator runs \`cargo publish -p aprender-rag\` post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)