### PR TITLE
fix(aprender-orchestrate): cmd_code arg-count drift — pass None for emit_trace

### DIFF
--- a/crates/aprender-orchestrate/src/cli/code.rs
+++ b/crates/aprender-orchestrate/src/cli/code.rs
@@ -11,6 +11,12 @@ use std::path::PathBuf;
 /// Entry point for `batuta code` (binary-side thin wrapper).
 ///
 /// Delegates entirely to the library-level `agent::code::cmd_code`.
+///
+/// Note: the upstream `cmd_code` gained an 8th `emit_trace: Option<PathBuf>`
+/// parameter; the bin-side clap surface (`Commands::Code` in
+/// `main_dispatch.rs`) does not yet expose it, so this wrapper passes
+/// `None`. Threading `--emit-trace` through the clap surface is a
+/// future enhancement.
 pub fn cmd_code(
     model: Option<PathBuf>,
     project: PathBuf,
@@ -20,7 +26,16 @@ pub fn cmd_code(
     max_turns: u32,
     manifest_path: Option<PathBuf>,
 ) -> anyhow::Result<()> {
-    batuta::agent::code::cmd_code(model, project, resume, prompt, print, max_turns, manifest_path)
+    batuta::agent::code::cmd_code(
+        model,
+        project,
+        resume,
+        prompt,
+        print,
+        max_turns,
+        manifest_path,
+        None, // emit_trace: not yet plumbed through the binary's clap surface.
+    )
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Upstream \`batuta::agent::code::cmd_code\` gained an 8th \`emit_trace: Option<PathBuf>\` param; the bin-side thin wrapper in \`cli/code.rs\` was not updated, producing E0061 that blocks \`cargo check --workspace\` and the clean-room gate.

## Fix

Pass \`None\` for \`emit_trace\` at the bin wrapper. The bin's clap surface (\`Commands::Code\`) doesn't yet expose \`--emit-trace\`; threading it through is a future enhancement. This minimal fix un-blocks the v0.32.0 cascade publish.

## Verification
- \`cargo check -p aprender-orchestrate --bin aprender-orchestrate\` → 0 errors
- \`cargo check --workspace\` → 0 errors, 91 pre-existing warnings

## Why now

Pre-cascade-publish gate (per \`crates/aprender-orchestrate/CLAUDE.md\` release policy). Without this, clean-room fails and cascade is blocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)