### PR TITLE
fix(aprender-core): path-only dev-deps — break publish-time cycle (Refs #1514)

### DIFF
--- a/crates/aprender-core/Cargo.toml
+++ b/crates/aprender-core/Cargo.toml
@@ -159,12 +159,19 @@ serde_yaml_ng = "0.10"
 [dev-dependencies]
 proptest = "1.6"
 criterion = { workspace = true }
-renacer = { workspace = true }
+# Path-only dev-deps (no version key): cargo strips these from the published
+# manifest, breaking the publish-time cycle (renacer + entrenar both depend
+# on aprender-core at runtime, so requiring their 0.32.0 to exist on
+# crates.io BEFORE aprender-core publishes is impossible without this strip).
+# Local test runs still resolve via the path; consumers of the published
+# crate don't see these deps at all.
+renacer = { path = "../aprender-profile", package = "aprender-profile" }
 tempfile = "3.14"  # For format module tests
 jugar-probar = "0.5"  # TUI/GUI testing framework with coverage tracking (spec §8)
 ctrlc = "3.4"  # Signal handling for SIGINT/SIGTERM (PMAT-098-PF: zombie process mitigation)
 provable-contracts = "0.3"  # Contract enforcement (dev-only)
-entrenar = { workspace = true }  # Integration tests for InferenceMonitor (GH-305: was runtime dep, now dev-only)
+# Integration tests for InferenceMonitor (GH-305: was runtime dep, now dev-only).
+entrenar = { path = "../aprender-train", package = "aprender-train" }
 serde_yaml = "0.9"  # YAML contract binding in tests (FALSIFY-SHIP-009 GATE-APR-PROV-004)
 
 [features]


### PR DESCRIPTION
## Summary

aprender-core's dev-deps create a publish-time cycle:
- \`renacer\` (= aprender-profile) workspace-pinned at 0.32.0
- \`entrenar\` (= aprender-train) workspace-pinned at 0.32.0

Both depend on aprender-core at runtime → publishing aprender-core requires their 0.32.0 to exist on crates.io, which they can't because they require aprender-core 0.32.0 first. Cycle.

## Fix

Override dev-dep entries to path-only (no version key). cargo strips path-only-no-version dev-deps from the published manifest.

\`\`\`toml
renacer = { path = "../aprender-profile", package = "aprender-profile" }
entrenar = { path = "../aprender-train", package = "aprender-train" }
\`\`\`

Local tests still resolve via the path; downstream consumers of the published crate don't see these deps at all.

## Verification

- \`cargo publish -p aprender-core --dry-run --allow-dirty\` ✓ clean (was failing)
- \`cargo test -p aprender-core --lib --no-run\` ✓ compiles

## Why this is the canonical fix

Per Cargo's published-manifest semantics, path-only-no-version dev-deps are stripped at publish time. Same pattern used by wasmtime, swc, and other monorepo projects.

The alternative (separate quantization crate per \`qwen2.5-coder-showcase-demo.md §E.7\`) is multi-PR architectural work; this 2-line change unblocks v0.32.0 cascade publish today.

## Refs #1514

This is step 1 of the v0.32.0 cascade publish project. Subsequent steps:
- Clean-room green on intel
- Topological cargo publish (~13-19 user-facing crates)
- Post-publish QA per \`feedback_post_publish_qa_required.md\`
- CHANGELOG entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)