### PR TITLE
feat(M-FFN-GGUF-3): heavy APR-vs-GGUF layer-3 ffn_swigl diff harness — SHIP-007 H1/H2 bisection

### DIFF
--- a/contracts/trace-ffn-sub-block-gguf-v1.yaml
+++ b/contracts/trace-ffn-sub-block-gguf-v1.yaml
@@ -285,23 +285,34 @@ implementation_stages:
     - FALSIFY-FFN-GGUF-002 (byte-identity vs production)
 
 - id: M-FFN-GGUF-3
-  status: PENDING  # heavy comparison harness OPEN
+  status: ALGORITHM_LEVEL_DISCHARGED  # harness exists; full discharge pending operator-dispatched LIVE run with canonical 7B .apr + .gguf
   description: |
-    Heavy comparison harness — runs `apr trace --payload` on both
-    APR `.apr` and GGUF `.gguf` versions of the canonical 7B
-    teacher (paiml/qwen2.5-coder-7b-apache-q4k-v1) on the same
-    prompt, captures per-layer ffn_swigl std for each, computes
-    ratio at layer 3 specifically. Reports H1 (≈1.0 ratio) or
-    H2 (>>1.0 ratio).
+    Heavy comparison harness — runs APR `forward_traced` and GGUF
+    `forward_traced` on the same canonical 7B teacher prompt,
+    extracts per-layer `ffn_swiglu_inner_stats.std_dev`, computes
+    layer-3 ratio. Reports H1 (ratio in [0.5, 2.0]) or H2 (ratio
+    outside that band).
 
-    Operationally unblocked by M-FFN-GGUF-2: the GGUF-side
-    forward_traced now emits the 4 sub-FFN fields. The heavy
-    harness just needs to compare APR vs GGUF on the same prompt.
+    Status promoted PENDING → ALGORITHM_LEVEL_DISCHARGED at this
+    contract amendment: the harness EXISTS at
+    `crates/aprender-serve/tests/ffn_gguf_apr_layer_3_swigl_diff.rs`
+    as `falsify_ffn_gguf_003_layer_3_swigl_h1_h2_bisection`.
+    `#[ignore]`-gated; skips cleanly if neither canonical .apr
+    nor .gguf is present on the host (mirrors the M80
+    `qwen3_moe_gpu_per_stage_diff` skip-if-not-present pattern).
 
-    Implementation hint: mirror the
-    `falsify_moe_sub_002_cpu_gpu_traced_per_stage_diff` heavy
-    harness pattern (M80 PR #1524) but for APR-vs-GGUF instead
-    of CPU-vs-GPU.
+    Full DISCHARGED status pending operator-dispatched LIVE run
+    that produces the actual H1 vs H2 verdict. Required files:
+    - canonical 7B APR teacher (`paiml/qwen2.5-coder-7b-apache-q4k-v1`)
+    - canonical 7B GGUF (`qwen2.5-coder-7b-instruct-q4k.gguf`)
+      — already cached at
+        `/mnt/nvme-raid0/models/ship-two-001/qwen2.5-coder-7b-instruct-q4k.gguf`
+
+    Operator workflow:
+        cargo test -p aprender-serve \
+            --test ffn_gguf_apr_layer_3_swigl_diff \
+            -- --include-ignored --nocapture
+    Output: per-layer table + final H1/H2 verdict.
   expected_acceptance:
     - FALSIFY-FFN-GGUF-003 (bisection distinguishes H1/H2)
 

--- a/crates/aprender-serve/tests/ffn_gguf_apr_layer_3_swigl_diff.rs
+++ b/crates/aprender-serve/tests/ffn_gguf_apr_layer_3_swigl_diff.rs
@@ -1,0 +1,213 @@
+//! M-FFN-GGUF-3 — heavy APR-vs-GGUF layer-3 ffn_swigl std comparison harness.
+//!
+//! Per `contracts/trace-ffn-sub-block-gguf-v1.yaml` step M-FFN-GGUF-3, this
+//! harness compares APR-side and GGUF-side `ffn_swiglu_inner_stats.std_dev` at
+//! layer 3 on the same canonical 7B teacher prompt to distinguish two
+//! competing hypotheses for the SHIP-007 §21 layer-3 ffn_swigl anomaly:
+//!
+//! - **H1**: Token-position-dependent correlation — NORMAL model behavior;
+//!   SHIP-007 root cause is ELSEWHERE. Predicts: GGUF layer-3 ffn_swigl std
+//!   ≈ APR layer-3 ffn_swigl std (ratio within `[1/RATIO_TOL, RATIO_TOL]`).
+//! - **H2**: APR-side bug — APR forward path produces different VALUES than
+//!   GGUF (despite SHIP-003 PR #1059 proving weights are byte-equivalent at
+//!   cos≥0.9999999). Predicts: ratio outside `[1/RATIO_TOL, RATIO_TOL]`.
+//!
+//! Discharges FALSIFY-FFN-GGUF-003. The H1/H2 outcome dictates the next
+//! cascade step (M-FFN-GGUF-4 — SHIP-007 root-cause fix PR cites the
+//! bisected hypothesis).
+//!
+//! ## How to run
+//!
+//! Skip-if-not-present pattern (mirrors M80
+//! `qwen3_moe_gpu_per_stage_diff::falsify_moe_sub_002_*`):
+//!
+//! ```bash
+//! cargo test -p aprender-serve --test ffn_gguf_apr_layer_3_swigl_diff \
+//!     -- --include-ignored --nocapture
+//! ```
+//!
+//! `#[ignore]`-gated so normal CI doesn't run the heavy load. Cleanly
+//! skips with a clear message if either the canonical 7B APR teacher
+//! file or the canonical 7B GGUF file is missing on the host.
+//!
+//! ## Required files (any one of each list)
+//!
+//! Canonical 7B APR teacher (paiml/qwen2.5-coder-7b-apache-q4k-v1):
+//!   - `/mnt/nvme-raid0/models/ship-two-001/qwen2.5-coder-7b-apache-q4k-v1.apr`
+//!   - `/home/noah/.apr/models/qwen2.5-coder-7b-apache-q4k-v1.apr`
+//!   - `/mnt/nvme-raid0/cache/apr-home/models/qwen2.5-coder-7b-apache-q4k-v1.apr`
+//!
+//! Canonical 7B GGUF (qwen2.5-coder-7b-instruct-q4k.gguf):
+//!   - `/mnt/nvme-raid0/models/ship-two-001/qwen2.5-coder-7b-instruct-q4k.gguf`
+//!   - `/home/noah/.cache/huggingface/hub/.../qwen2.5-coder-7b-instruct-q4k.gguf`
+//!
+//! ## Reference
+//!
+//! - `contracts/trace-ffn-sub-block-gguf-v1.yaml` (this contract)
+//! - SHIP-007 §21 (aprender PR #1072 squash 211edeafc) — the layer-3
+//!   anomaly site narrowing
+//! - `crates/aprender-serve/tests/qwen3_moe_gpu_per_stage_diff.rs`
+//!   (M80 — sibling pattern for CPU-vs-GPU MoE diff harness)
+//!
+//! ## Ratio interpretation
+//!
+//! At PR-author time (2026-05-06), known APR layer-3 ffn_swigl std
+//! ≈ 1.222 from the §21 evidence. The harness reports the ratio
+//! `apr_std / gguf_std`. Outcome interpretation:
+//!
+//! - ratio in [0.5, 2.0] → **H1 confirmed** (normal model behavior);
+//!   SHIP-007 root cause is ELSEWHERE (lm_head, post-FFN residual,
+//!   token-position correlation, ...).
+//! - ratio > 2.0 (or < 0.5) → **H2 confirmed** (APR-side bug);
+//!   fix at `inference.rs:160-164` swigl elementwise multiply.
+
+use realizar::apr_transformer::AprTransformer;
+use realizar::gguf::{MappedGGUFModel, OwnedQuantizedModel};
+
+use std::path::Path;
+
+const CANONICAL_QWEN25_CODER_7B_APR_PATHS: &[&str] = &[
+    "/mnt/nvme-raid0/models/ship-two-001/qwen2.5-coder-7b-apache-q4k-v1.apr",
+    "/home/noah/.apr/models/qwen2.5-coder-7b-apache-q4k-v1.apr",
+    "/mnt/nvme-raid0/cache/apr-home/models/qwen2.5-coder-7b-apache-q4k-v1.apr",
+];
+
+const CANONICAL_QWEN25_CODER_7B_GGUF_PATHS: &[&str] = &[
+    "/mnt/nvme-raid0/models/ship-two-001/qwen2.5-coder-7b-instruct-q4k.gguf",
+];
+
+/// Layer 3 is the §21 narrowed anomaly site (ffn_swigl std = 1.222 vs
+/// layer-2 baseline 0.071 — 17.2× spike).
+const ANOMALY_LAYER: usize = 3;
+
+/// Ratio outside this band → H2 confirmed (APR-side bug). Within band → H1
+/// confirmed (normal model behavior). 2.0× tolerance is generous —
+/// quantization difference between APR and GGUF Q4_K is typically < 5%
+/// per element-level cosine of weights (SHIP-003 PR #1059 cos≥0.9999999).
+const RATIO_TOL: f32 = 2.0;
+
+/// Canonical SHIP-007 prompt. Same as the §21 evidence file
+/// `evidence/ship-007-layer-3-anomaly/sub-ffn-bisection-2026-04-26.txt`.
+const CANONICAL_PROMPT: &str = "What is 2+2?";
+
+#[test]
+#[ignore]
+fn falsify_ffn_gguf_003_layer_3_swigl_h1_h2_bisection() {
+    let Some(apr_path) = CANONICAL_QWEN25_CODER_7B_APR_PATHS
+        .iter()
+        .find(|p| Path::new(p).exists())
+    else {
+        eprintln!(
+            "M-FFN-GGUF-3 layer-3 swigl diff: skipped — no canonical 7B APR teacher \
+             in {CANONICAL_QWEN25_CODER_7B_APR_PATHS:?}"
+        );
+        return;
+    };
+    let Some(gguf_path) = CANONICAL_QWEN25_CODER_7B_GGUF_PATHS
+        .iter()
+        .find(|p| Path::new(p).exists())
+    else {
+        eprintln!(
+            "M-FFN-GGUF-3 layer-3 swigl diff: skipped — no canonical 7B GGUF \
+             in {CANONICAL_QWEN25_CODER_7B_GGUF_PATHS:?}"
+        );
+        return;
+    };
+
+    eprintln!("M-FFN-GGUF-3: APR vs GGUF layer-3 ffn_swigl std H1/H2 bisection");
+    eprintln!("  apr_path:    {apr_path}");
+    eprintln!("  gguf_path:   {gguf_path}");
+    eprintln!("  prompt:      {CANONICAL_PROMPT:?}");
+    eprintln!("  layer:       {ANOMALY_LAYER}");
+    eprintln!("  ratio_tol:   {RATIO_TOL}");
+    eprintln!();
+
+    // ---- APR side ----
+    eprintln!("Loading APR teacher...");
+    let apr_transformer =
+        AprTransformer::from_apr_file(apr_path).expect("AprTransformer::from_apr_file failed");
+
+    // GGUF tokenizer is consistent with APR for this teacher pair —
+    // re-tokenize once and use the same tokens for both forwards.
+    let mapped = MappedGGUFModel::from_path(gguf_path).expect("MappedGGUFModel::from_path failed");
+    let tokens = mapped
+        .model
+        .encode(CANONICAL_PROMPT)
+        .unwrap_or_else(|| vec![1u32]);
+    eprintln!("  tokens:    {tokens:?} ({} tokens)", tokens.len());
+    eprintln!();
+
+    eprintln!("APR forward_traced...");
+    let apr_trace = apr_transformer
+        .forward_traced(&tokens)
+        .expect("APR forward_traced failed");
+
+    // ---- GGUF side ----
+    eprintln!("GGUF forward_traced...");
+    let gguf_model = OwnedQuantizedModel::from_mapped(&mapped).expect("from_mapped failed");
+    let gguf_trace = gguf_model
+        .forward_traced(&tokens)
+        .expect("GGUF forward_traced failed");
+
+    // ---- Per-layer comparison ----
+    let apr_layers = &apr_trace.layer_activations;
+    let gguf_layers = &gguf_trace.layer_activations;
+    let n_layers = apr_layers.len().min(gguf_layers.len());
+    assert!(
+        n_layers > ANOMALY_LAYER,
+        "model has fewer layers than ANOMALY_LAYER ({ANOMALY_LAYER}); got {n_layers}"
+    );
+
+    eprintln!();
+    eprintln!("layer | apr.ffn_swigl.std    | gguf.ffn_swigl.std   | ratio (apr/gguf)");
+    eprintln!("------|----------------------|----------------------|------------------");
+    let mut anomaly_ratio: Option<f32> = None;
+    for layer_idx in 0..n_layers {
+        let apr_std = apr_layers[layer_idx].ffn_swiglu_inner_stats.std_dev;
+        let gguf_std = gguf_layers[layer_idx].ffn_swiglu_inner_stats.std_dev;
+        let ratio = if gguf_std.abs() > 1e-9 {
+            apr_std / gguf_std
+        } else {
+            f32::NAN
+        };
+        eprintln!(
+            "L{layer_idx:02}   | {apr_std:>20.6} | {gguf_std:>20.6} | {ratio:>16.4}"
+        );
+        if layer_idx == ANOMALY_LAYER {
+            anomaly_ratio = Some(ratio);
+        }
+    }
+
+    // ---- H1/H2 verdict ----
+    eprintln!();
+    let ratio = anomaly_ratio.expect("ANOMALY_LAYER index always set in the loop");
+    let in_h1_band = ratio.abs() >= 1.0 / RATIO_TOL && ratio.abs() <= RATIO_TOL;
+    if in_h1_band {
+        eprintln!(
+            "M-FFN-GGUF-3 verdict: **H1 CONFIRMED** at layer {ANOMALY_LAYER} (ratio {ratio:.4} in [{:.4}, {RATIO_TOL:.4}])",
+            1.0 / RATIO_TOL
+        );
+        eprintln!("  → APR layer-3 ffn_swigl is normal model behavior (matches GGUF).");
+        eprintln!("  → SHIP-007 root cause is ELSEWHERE — pivot to lm_head /");
+        eprintln!("    post-FFN residual / token-position correlation surface.");
+    } else {
+        eprintln!(
+            "M-FFN-GGUF-3 verdict: **H2 CONFIRMED** at layer {ANOMALY_LAYER} (ratio {ratio:.4} outside [{:.4}, {RATIO_TOL:.4}])",
+            1.0 / RATIO_TOL
+        );
+        eprintln!("  → APR-side bug confirmed — fix at `inference.rs:160-164`");
+        eprintln!("    swigl elementwise multiply.");
+    }
+    eprintln!();
+    eprintln!("Per FALSIFY-FFN-GGUF-003: this harness DISCHARGES the rule (it");
+    eprintln!("reports a single H1 or H2 verdict). Per FALSIFY-FFN-GGUF-004:");
+    eprintln!("the SHIP-007 root-cause fix PR title/body MUST cite either H1");
+    eprintln!("or H2 and one of:");
+    eprintln!("  {{ffn_swigl, swigl_elementwise_multiply, lm_head,");
+    eprintln!("    post_ffn_residual, token_position_correlation}}");
+
+    // The harness's job is to PRODUCE the H1/H2 verdict, not to assert.
+    // Both verdicts are valid outcomes — only fix-PR-cites-stage
+    // (FALSIFY-FFN-GGUF-004) requires the operator to do something with
+    // the result.
+}


### PR DESCRIPTION
## Summary

Authors the heavy comparison harness pinned in **contract `trace-ffn-sub-block-gguf-v1` v1.0.0 step M-FFN-GGUF-3** (M88 PR #1532). The harness produces the H1 vs H2 verdict for SHIP-007 layer-3 ffn_swigl bisection on operator dispatch.

Mirrors the proven M80 skip-if-not-present pattern from `qwen3_moe_gpu_per_stage_diff::falsify_moe_sub_002_*`.

## What it does

```rust
let apr = AprTransformer::from_apr_file(apr_path)?;
let mapped = MappedGGUFModel::from_path(gguf_path)?;
let tokens = mapped.model.encode("What is 2+2?")?;
let apr_trace = apr.forward_traced(&tokens)?;
let gguf_model = OwnedQuantizedModel::from_mapped(&mapped)?;
let gguf_trace = gguf_model.forward_traced(&tokens)?;

// Per-layer table + ratio at layer 3
ratio = apr_layer_3.ffn_swiglu_inner_stats.std_dev / gguf_layer_3.ffn_swiglu_inner_stats.std_dev
```

## H1 vs H2 verdict logic

| Ratio | Verdict | Implication |
|-------|---------|-------------|
| `[0.5, 2.0]` | **H1 confirmed** | NORMAL model behavior; SHIP-007 root cause is ELSEWHERE (lm_head / post-FFN residual / token-position correlation) |
| outside band | **H2 confirmed** | APR-side bug; fix at `inference.rs:160-164` swigl elementwise multiply |

Either verdict is a valid outcome — only **FALSIFY-FFN-GGUF-004** requires the operator to take action with the result (write the SHIP-007 root-cause fix PR citing H1 or H2).

## Skip-if-not-present

`#[ignore]`-gated; skips cleanly if either canonical 7B `.apr` or `.gguf` is missing on the host:

```
$ cargo test -p aprender-serve --test ffn_gguf_apr_layer_3_swigl_diff -- --include-ignored --nocapture
M-FFN-GGUF-3 layer-3 swigl diff: skipped — no canonical 7B APR teacher in [...]
test result: ok. 1 passed; 0 failed; 0 ignored
```

Verified locally — this host has the `.gguf` at `/mnt/nvme-raid0/models/ship-two-001/qwen2.5-coder-7b-instruct-q4k.gguf` but no canonical `.apr`; test ran clean and skipped.

## Contract amendment

**M-FFN-GGUF-3**: PENDING → **ALGORITHM_LEVEL_DISCHARGED**

The harness EXISTS and produces a verdict on operator dispatch. Full DISCHARGED requires operator to run with canonical files present and capture the verdict in `evidence/ship-007-layer-3-h1-h2-bisection-{date}/`.

## Cascade state after this PR

| Stage | Status |
|-------|--------|
| M-FFN-GGUF-0 | SHIPPED (M88 — contract scaffold) |
| M-FFN-GGUF-1 | SHIPPED (LayerActivation re-export) |
| M-FFN-GGUF-2 | SHIPPED (PRs #1081 + #1082) |
| M-FFN-GGUF-3 | **ALGORITHM_LEVEL_DISCHARGED** (this PR — harness exists, full DISCHARGED awaits operator dispatch) |
| M-FFN-GGUF-4 | PENDING (SHIP-007 fix PR cites H1 or H2) |

## Operator workflow (next deliberate-session)

```bash
# Ensure canonical 7B .apr is on host (apr pull or copy from teacher source)
ls /mnt/nvme-raid0/models/ship-two-001/qwen2.5-coder-7b-apache-q4k-v1.apr

# Run the harness
cargo test -p aprender-serve --test ffn_gguf_apr_layer_3_swigl_diff \
    -- --include-ignored --nocapture

# Capture verdict in evidence/ship-007-layer-3-h1-h2-bisection-2026-MM-DD/findings.md
# Author M-FFN-GGUF-4 SHIP-007 fix PR citing H1 or H2 by name
```

## Test plan

- [x] Compiles + lists 1 test
- [x] Skips cleanly when files missing (host: 1/2 files present)
- [x] No production code touched (additive test-only file)
- [x] Contract amendment validates `pv validate` 0/0
- [x] Mirrors M80 skip-if-not-present pattern verbatim

🤖 Generated with [Claude Code](https://claude.com/claude-code)