### PR TITLE
feat(M-FFN-GGUF-4 step a): determinism falsifier — §28 parallel-reduction hypothesis FALSIFIED

### DIFF
--- a/contracts/trace-ffn-sub-block-gguf-v1.yaml
+++ b/contracts/trace-ffn-sub-block-gguf-v1.yaml
@@ -1,6 +1,6 @@
 metadata:
   id: C-TRACE-FFN-SUB-BLOCK-GGUF
-  version: 1.1.0
+  version: 1.2.0
   created: '2026-05-06'
   author: PAIML Engineering
   kind: pattern
@@ -84,6 +84,71 @@ metadata:
     harness + fix) have a clear discharge path, and it cross-
     references the prior-work PRs for anyone reading the contract
     surface for the first time.
+
+    v1.2.0 AMENDMENT (2026-05-06): §28 PARALLEL-REDUCTION HYPOTHESIS FALSIFIED.
+
+    Authored 2 lib-only determinism falsifiers in
+    `crates/aprender-serve/src/apr_transformer/helpers.rs::
+     determinism_tests`:
+
+      falsify_ffn_gguf_005_f32_matmul_byte_deterministic_above_parallel_threshold
+      falsify_ffn_gguf_005b_f32_matmul_byte_deterministic_below_parallel_threshold
+
+    Both tests run `f32_matmul` TWICE with identical synthetic
+    inputs (out_dim above + below F32_PARALLEL_THRESHOLD=256) and
+    assert byte-identical output via `f32::to_bits()` comparison.
+
+    BOTH TESTS PASS. APR's `f32_matmul` (and the underlying
+    `f32_matvec_parallel` rayon-parallel kernel) is **byte-
+    deterministic** across repeated calls.
+
+    This FALSIFIES the §28 parallel-reduction hypothesis at the
+    kernel level. The §27 layer-3 18.23× drift is NOT caused by
+    APR being non-deterministic with itself.
+
+    REFINED HYPOTHESIS (post-falsification):
+
+    The cumulative APR↔GGUF drift must be a DIFFERENCE between
+    APR's and GGUF's reduction order, not non-determinism within
+    APR. Candidates:
+
+    H2a' (refined): APR uses `simd_dot_f32_avx2` (4-wide FMA, 8-
+         element AVX2 chunks) while GGUF uses
+         `fused_q4k_q8k_parallel_matvec_into` (different unroll +
+         block boundaries). F32 sum-of-products is non-associative;
+         different unroll → different bit-level results, even with
+         IDENTICAL byte-equivalent weights (per SHIP-003 PR #1059
+         cos≥0.9999999 weight invariance).
+
+    H2b: Layer-3-specific upstream divergence — gate or up at L3
+         only (despite §22 showing them individually normal at
+         std-level; per-element divergence may be hidden by std
+         aggregation).
+
+    H2c: Quantization dequant alignment differs at certain layer
+         configs.
+
+    NEXT M-FFN-GGUF-4 INVESTIGATION STEP (post-§28 falsification):
+
+    Cross-implementation deterministic-difference test — author a
+    SECOND lib-only test that runs APR's `f32_matmul` AND GGUF's
+    `fused_q4k_q8k_parallel_matvec_into` (or its f32 equivalent)
+    on byte-identical synthetic inputs and asserts whether the
+    outputs match. If they differ at the bit level, the candidate
+    fix is to align APR's reduction order to GGUF's (or vice
+    versa). This would transitively fix SHIP-007.
+
+    STATUS PROMOTIONS (v1.2.0):
+
+    - FALSIFY-FFN-GGUF-005 (NEW): falsifier added in
+      determinism_tests module; status DISCHARGED (both tests
+      pass on first run; §28 hypothesis empirically falsified).
+    - M-FFN-GGUF-4 step (a): SHIPPED (this amendment + the 2
+      lib-only falsifier tests). Step (b) cross-impl difference
+      test + step (c) fix remain PENDING.
+
+    Production hot paths byte-unchanged. Tests additive in
+    `helpers.rs` `#[cfg(test)] mod determinism_tests`.
 
     v1.1.0 AMENDMENT (2026-05-06): §27 EVIDENCE INTEGRATED.
 

--- a/crates/aprender-serve/src/apr_transformer/helpers.rs
+++ b/crates/aprender-serve/src/apr_transformer/helpers.rs
@@ -378,3 +378,103 @@ pub(crate) fn rms_norm(
 }
 
 include!("helpers_simd_dot.rs");
+
+#[cfg(test)]
+mod determinism_tests {
+    use super::*;
+
+    /// FALSIFY-FFN-GGUF-005 / M-FFN-GGUF-4 step (a):
+    /// `f32_matmul` is byte-deterministic across repeated calls.
+    ///
+    /// SHIP-007 §28 hypothesis: APR's `f32_matvec_parallel` uses rayon
+    /// `par_chunks_mut` which COULD produce non-deterministic ordering of
+    /// per-output-element computations across runs. F32 accumulation is
+    /// non-associative; different orders → different results at the
+    /// per-element level. Over 3 layers, per-element differences could
+    /// compound to the layer-3 ffn_swigl 18.23× ratio observed in §27.
+    ///
+    /// This test FALSIFIES the §28 hypothesis at the kernel level.
+    /// `par_chunks_mut` parallelizes ACROSS output elements; each output
+    /// element is computed by exactly one thread; the per-element dot
+    /// product (`simd_dot_f32`) is serial. So the kernel SHOULD be
+    /// byte-deterministic across runs.
+    ///
+    /// If this test PASSES: §28 parallel-reduction hypothesis is
+    /// FALSIFIED. SHIP-007 root cause is elsewhere (likely f32 reduction
+    /// order DIFFERENCE between APR and GGUF — APR uses
+    /// `simd_dot_f32_avx2` 4-wide unrolled FMA; GGUF
+    /// `fused_q4k_q8k_parallel_matvec_into` may use different unroll
+    /// or block boundaries).
+    ///
+    /// If this test FAILS: §28 hypothesis CONFIRMED. Fix = ensure
+    /// deterministic reduction order in `f32_matvec_parallel`.
+    ///
+    /// Per `contracts/trace-ffn-sub-block-gguf-v1.yaml` v1.1.0 amendment
+    /// (§28 hypothesis test).
+    #[test]
+    fn falsify_ffn_gguf_005_f32_matmul_byte_deterministic_above_parallel_threshold() {
+        // out_dim above F32_PARALLEL_THRESHOLD (256) so f32_matvec_parallel fires
+        let in_dim = 128;
+        let out_dim = 512;
+        let seq_len = 4;
+
+        // Synthetic but reproducible inputs (no random — same byte pattern across runs)
+        let input: Vec<f32> = (0..seq_len * in_dim)
+            .map(|i| ((i % 17) as f32 - 8.0) * 0.1)
+            .collect();
+        let weight: Vec<f32> = (0..in_dim * out_dim)
+            .map(|i| (((i * 31) % 23) as f32 - 11.0) * 0.05)
+            .collect();
+
+        // Run twice with identical inputs
+        let result_a = f32_matmul(&input, &weight, in_dim, out_dim);
+        let result_b = f32_matmul(&input, &weight, in_dim, out_dim);
+
+        // Byte-identity assertion (not just "close" — the §28 hypothesis is
+        // about NON-DETERMINISM, which would manifest as differing bits).
+        assert_eq!(
+            result_a.len(),
+            result_b.len(),
+            "matmul output length differs across runs (sanity check failed)"
+        );
+        for (i, (&a, &b)) in result_a.iter().zip(result_b.iter()).enumerate() {
+            assert_eq!(
+                a.to_bits(),
+                b.to_bits(),
+                "f32_matmul non-deterministic at element {i}: {a} ({:#x}) vs {b} ({:#x}) — \
+                 §28 parallel-reduction hypothesis CONFIRMED. Fix scope = make \
+                 f32_matvec_parallel deterministic.",
+                a.to_bits(),
+                b.to_bits()
+            );
+        }
+    }
+
+    /// Same test but for the `f32_matmul_scalar` fallback path (out_dim
+    /// below threshold). Should also be deterministic — no rayon, fully
+    /// sequential.
+    #[test]
+    fn falsify_ffn_gguf_005b_f32_matmul_byte_deterministic_below_parallel_threshold() {
+        let in_dim = 128;
+        let out_dim = 64; // Below F32_PARALLEL_THRESHOLD = 256
+        let seq_len = 1;
+
+        let input: Vec<f32> = (0..seq_len * in_dim)
+            .map(|i| ((i % 13) as f32 - 6.0) * 0.1)
+            .collect();
+        let weight: Vec<f32> = (0..in_dim * out_dim)
+            .map(|i| (((i * 23) % 19) as f32 - 9.0) * 0.05)
+            .collect();
+
+        let result_a = f32_matmul(&input, &weight, in_dim, out_dim);
+        let result_b = f32_matmul(&input, &weight, in_dim, out_dim);
+
+        for (i, (&a, &b)) in result_a.iter().zip(result_b.iter()).enumerate() {
+            assert_eq!(
+                a.to_bits(),
+                b.to_bits(),
+                "f32_matmul (sequential path) non-deterministic at element {i}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Authors 2 lib-only determinism falsifiers (FALSIFY-FFN-GGUF-005) in `apr_transformer::helpers::determinism_tests`. Both tests run `f32_matmul` TWICE with identical synthetic inputs and assert byte-identical output via `f32::to_bits()` comparison.

**Both tests PASS on first run.** APR's `f32_matmul` is byte-deterministic across repeated calls.

This **FALSIFIES the §28 parallel-reduction hypothesis** at the kernel level. The §27 layer-3 18.23× drift is NOT caused by APR being non-deterministic with itself.

## Test code

```rust
#[test]
fn falsify_ffn_gguf_005_f32_matmul_byte_deterministic_above_parallel_threshold() {
    // out_dim above F32_PARALLEL_THRESHOLD (256) so f32_matvec_parallel fires
    let result_a = f32_matmul(&input, &weight, in_dim, out_dim);
    let result_b = f32_matmul(&input, &weight, in_dim, out_dim);
    for (i, (&a, &b)) in result_a.iter().zip(result_b.iter()).enumerate() {
        assert_eq!(a.to_bits(), b.to_bits(), ...);
    }
}
```

## Refined hypothesis (post-§28 falsification)

The cumulative APR↔GGUF drift must be a **DIFFERENCE between APR's and GGUF's reduction order**, not non-determinism within APR.

- APR uses `simd_dot_f32_avx2` (4-wide FMA, 8-element AVX2 chunks)
- GGUF uses `fused_q4k_q8k_parallel_matvec_into` (different unroll + block boundaries)
- F32 sum-of-products is non-associative; different unroll → different bit-level results

## Next M-FFN-GGUF-4 investigation step

**Cross-implementation deterministic-difference test** — author a SECOND lib-only test that runs APR's `f32_matmul` AND GGUF's `fused_q4k_q8k_parallel_matvec_into` (or its f32 equivalent) on byte-identical synthetic inputs and asserts whether outputs match. If they differ at the bit level, fix scope = align reduction order.

## Contract amendment (v1.1.0 → v1.2.0)

| Field | Before | After |
|-------|--------|-------|
| version | 1.1.0 | **1.2.0** |
| FALSIFY-FFN-GGUF-005 | NEW | **DISCHARGED** |
| M-FFN-GGUF-4 step (a) | PENDING | **SHIPPED** |

## Methodology lesson applied

Lesson #3 (cascade ordering): branched off main AFTER #1534 (v1.1.0) merged to avoid cascade-ordering rebase conflict. Verified by `git rebase origin/main` succeeding cleanly with the v1.1.0 amendment intact.

## Test plan

- [x] `pv validate` 0/0
- [x] 2 lib tests pass on first run
- [x] No production hot path touched (additive `#[cfg(test)] mod`)
- [x] §28 hypothesis empirically falsified

🤖 Generated with [Claude Code](https://claude.com/claude-code)