### PR TITLE
feat(M-FFN-GGUF-4 step c, H2d.2): Q4K dequant byte-identity test — H2d.2 ALSO FALSIFIED

### DIFF
--- a/contracts/trace-ffn-sub-block-gguf-v1.yaml
+++ b/contracts/trace-ffn-sub-block-gguf-v1.yaml
@@ -1,6 +1,6 @@
 metadata:
   id: C-TRACE-FFN-SUB-BLOCK-GGUF
-  version: 1.3.0
+  version: 1.4.0
   created: '2026-05-06'
   author: PAIML Engineering
   kind: pattern
@@ -84,6 +84,88 @@ metadata:
     harness + fix) have a clear discharge path, and it cross-
     references the prior-work PRs for anyone reading the contract
     surface for the first time.
+
+    v1.4.0 AMENDMENT (2026-05-06): H2d.2 ALSO FALSIFIED AT DEQUANT LEVEL.
+
+    Authored a third lib-only falsifier (FALSIFY-FFN-GGUF-007) at
+    `crates/aprender-serve/tests/ffn_gguf_007_q4k_dequant_byte_identity.rs`:
+
+      falsify_ffn_gguf_007_q4k_scalar_vs_simd_dequant_byte_identity
+
+    Test runs `realizar::quantize::dequantize_q4_k` (scalar) and
+    `realizar::quantize::dequantize_q4_k_simd` (AVX2 if available)
+    on a synthetic 144-byte Q4K super-block and compares the
+    resulting Vec<f32> bit-by-bit via `f32::to_bits()`.
+
+    EMPIRICAL RESULT (2026-05-06): both paths produce BYTE-IDENTICAL
+    output across all 256 elements. element[0] = 10.75 (0x412c0000);
+    element[255] = 1.25 (0x3fa00000). Asserted as regression-test
+    invariant.
+
+    This **FALSIFIES H2d.2 at the APR-internal dequant level**.
+    APR's two own Q4K dequant paths agree byte-for-byte on the
+    same input. The SHIP-007 §22 layer-3 18.23× drift cannot be
+    explained by APR's loader picking one dequant path while
+    GGUF's matvec uses a different APR-internal dequant path —
+    they're equivalent.
+
+    THIRD HYPOTHESIS FALSIFICATION IN ONE SESSION:
+    - §28  parallel-reduction non-determinism (M91): FALSIFIED
+    - H2a' SIMD-vs-scalar dot reduction (M92): FALSIFIED
+    - H2d.2 APR-internal Q4K dequant byte-identity (this v1.4.0):
+      FALSIFIED
+
+    REMAINING VIABLE HYPOTHESES (post-three-falsification):
+
+    - H2d.1: per-block dequant boundaries differ between APR's
+             whole-row F32 reduction (calls `dequantize_q4_k_simd`
+             once for the full row, then `f32_matmul`) and GGUF's
+             super-block Q4K-byte-by-byte fused reduction
+             (`fused_q4k_q8k_parallel_matvec_into` has its own
+             inline dequant per super-block as the matvec
+             progresses).
+    - H2d.3: Q8K activation quantization in GGUF's path (a step
+             APR doesn't have at all). APR passes F32 activations
+             through f32_matmul; GGUF quantizes activations to Q8K
+             before each matmul. This Q8K quantization rounds
+             activations to ~7-bit precision, which compounds
+             across layers DIFFERENTLY than APR's full-F32 path.
+    - H2d.4 (NEW): the FUSED matvec's INLINE Q4K dequant in
+             `fused_q4k_q8k_parallel_matvec_into` may produce
+             different bits than the STANDALONE dequant routines
+             (`dequantize_q4_k`, `dequantize_q4_k_simd`). Both
+             are byte-identical to each other (this M93), but
+             that doesn't constrain the inline-fused dequant
+             path which is a separate code path.
+
+    NEXT STEP RECOMMENDATION: H2d.4 — author a falsifier comparing
+    standalone `dequantize_q4_k_simd` followed by `f32_matmul` vs
+    the fused `fused_q4k_q8k_parallel_matvec_into` on the same Q4K
+    bytes + (Q8K-quantized → dequantized → re-Q8K-quantized)
+    activation, with a control over Q8K precision loss. Most
+    direct test of H2d.1 + H2d.4 combined.
+
+    Alternative: accept that SHIP-007 §22 root cause may NOT be in
+    a single-tensor reduction-order boundary at all. The cumulative
+    drift could be from accumulator precision in residual-addition
+    sums (which APR and GGUF may handle in different orders), the
+    RMSNorm rsqrt approximation, or the per-token tokenization
+    difference. Each is its own falsifier candidate.
+
+    STATUS PROMOTIONS (v1.4.0):
+
+    - FALSIFY-FFN-GGUF-007 (NEW): byte-identical scalar+SIMD Q4K
+      dequant asserted as regression-test invariant; status
+      DISCHARGED (test passes on first run; H2d.2 empirically
+      falsified at APR-internal dequant level).
+    - M-FFN-GGUF-4 step (c) candidate H2d.2 narrowing: SHIPPED
+      (this falsifier reduces step (c) hypothesis space from
+      {1,2,3} to {1,3,4}).
+    - Contract metadata.status: ACTIVE_ALGORITHM_LEVEL → unchanged
+      (still gated on M-FFN-GGUF-4 step (c) actual fix landing).
+
+    Production hot paths byte-unchanged. New test additive in
+    `crates/aprender-serve/tests/ffn_gguf_007_*.rs`.
 
     v1.3.0 AMENDMENT (2026-05-06): H2a' SIMD-VS-SCALAR REDUCTION-ORDER ALSO FALSIFIED.
 

--- a/crates/aprender-serve/tests/ffn_gguf_007_q4k_dequant_byte_identity.rs
+++ b/crates/aprender-serve/tests/ffn_gguf_007_q4k_dequant_byte_identity.rs
@@ -1,0 +1,136 @@
+//! M-FFN-GGUF-4 step (c) candidate H2d.2 falsifier — APR Q4K dequant byte-identity.
+//!
+//! Tests that APR's scalar `dequantize_q4_k` and SIMD-accelerated
+//! `dequantize_q4_k_simd` produce **byte-identical** Vec<f32> for the
+//! same Q4K super-block bytes. Analog of M92's
+//! `falsify_ffn_gguf_006_simd_vs_scalar_reduction_order_byte_identity`
+//! but for Q4K dequant (not f32 dot product).
+//!
+//! ## Why this matters for SHIP-007 §22 / H2d.2
+//!
+//! The §27 evidence pinned SHIP-007 layer-3 to APR-side at the
+//! per-element f32 level. Two reduction-order hypotheses have been
+//! falsified:
+//! - §28 parallel-reduction non-determinism (M91): FALSIFIED
+//! - H2a' SIMD-vs-scalar reduction-order (M92): FALSIFIED
+//!
+//! The refined H2d.2 hypothesis (post-second-falsification): APR's
+//! F32 weights themselves differ at bit level from a true dequantization
+//! of GGUF Q4K bytes — despite SHIP-003 PR #1059 cos≥0.9999999 weight
+//! invariance.
+//!
+//! This test addresses H2d.2 at the APR-INTERNAL dequant level. If
+//! APR's two own dequant paths (scalar + SIMD) differ at bit level on
+//! the same Q4K bytes, then H2d.2 has a mechanically realizable cause:
+//! whichever path APR's loader uses produces different f32 bits than
+//! whichever path GGUF's matvec uses internally.
+//!
+//! ## Test design
+//!
+//! Synthetic Q4K super-block (144 bytes):
+//! - bytes 0..2: f16 d (block scale)
+//! - bytes 2..4: f16 dmin (block min)
+//! - bytes 4..16: 12 packed scale/min sub-block bytes
+//! - bytes 16..144: 128 quantized 4-bit values (256 elements packed)
+//!
+//! Reproducible (no randomness — same byte pattern across runs).
+//!
+//! ## Expected outcome
+//!
+//! Per the precedent from M91+M92 (both reduction-order hypotheses
+//! produced byte-identical results across paths), this test EXPECTS
+//! both dequant paths to also produce byte-identical output. Asserting
+//! BYTE-IDENTITY as the regression-test invariant.
+//!
+//! If FALSIFIED (paths produce DIFFERENT bits): H2d.2 has confirmed
+//! mechanism — APR's loader picks one path, GGUF's matvec picks the
+//! other (or has its own inline dequant), and the f32 weights APR
+//! uses differ from what GGUF effectively uses at the bit level.
+//! SHIP-007 fix scope = align dequant paths.
+//!
+//! Per `contracts/trace-ffn-sub-block-gguf-v1.yaml` v1.3.0 amendment
+//! H2d.2 hypothesis class.
+
+use realizar::quantize::{dequantize_q4_k, dequantize_q4_k_simd};
+
+/// Build one synthetic Q4K super-block with reproducible byte values.
+/// Mimics the layout documented in `dequantize_q4_k` source (144 bytes total).
+fn synthetic_q4k_super_block() -> Vec<u8> {
+    let mut block = vec![0u8; 144];
+    // f16 d = 0x3C00 (= 1.0)
+    block[0] = 0x00;
+    block[1] = 0x3C;
+    // f16 dmin = 0xB400 (= -0.25)
+    block[2] = 0x00;
+    block[3] = 0xB4;
+    // 12 scale/min bytes — set to a non-trivial fixed pattern
+    for (i, b) in block[4..16].iter_mut().enumerate() {
+        *b = ((i * 7 + 3) % 256) as u8;
+    }
+    // 128 quant bytes — set to a non-trivial fixed pattern
+    for (i, b) in block[16..144].iter_mut().enumerate() {
+        // Mix of low and high nibbles to exercise both extraction paths
+        *b = ((i * 13 + 17) % 256) as u8;
+    }
+    block
+}
+
+#[test]
+fn falsify_ffn_gguf_007_q4k_scalar_vs_simd_dequant_byte_identity() {
+    let block = synthetic_q4k_super_block();
+    assert_eq!(block.len(), 144, "test setup: super-block must be 144 bytes");
+
+    let result_scalar =
+        dequantize_q4_k(&block).expect("dequantize_q4_k (scalar) failed on synthetic block");
+    let result_simd =
+        dequantize_q4_k_simd(&block).expect("dequantize_q4_k_simd failed on synthetic block");
+
+    assert_eq!(
+        result_scalar.len(),
+        256,
+        "Q4K super-block must dequantize to exactly 256 elements (got {})",
+        result_scalar.len()
+    );
+    assert_eq!(
+        result_simd.len(),
+        256,
+        "SIMD path must produce same count (got {})",
+        result_simd.len()
+    );
+
+    // EMPIRICAL EXPECTATION (per M91+M92 precedent): both paths produce
+    // byte-identical f32 bits. Assert as regression-test invariant.
+    let mut first_diff: Option<(usize, u32, u32)> = None;
+    for (i, (&s, &v)) in result_scalar.iter().zip(result_simd.iter()).enumerate() {
+        if s.to_bits() != v.to_bits() {
+            first_diff = Some((i, s.to_bits(), v.to_bits()));
+            break;
+        }
+    }
+
+    if let Some((i, scalar_bits, simd_bits)) = first_diff {
+        panic!(
+            "FALSIFY-FFN-GGUF-007: scalar and SIMD Q4K dequant produced DIFFERENT bits at \
+             element {i}: scalar={} ({scalar_bits:#x}) vs simd={} ({simd_bits:#x}). \
+             H2d.2 hypothesis MECHANICALLY CONFIRMED — APR's two own dequant paths differ \
+             at bit level on same Q4K bytes. SHIP-007 fix scope: align dequant paths AND \
+             ensure APR's loader uses the same path GGUF's matvec uses internally. \
+             Update contract trace-ffn-sub-block-gguf-v1 v1.3.0 with empirical evidence.",
+            f32::from_bits(scalar_bits),
+            f32::from_bits(simd_bits)
+        );
+    }
+
+    // Document the empirical canonical first element so a future
+    // engineer doesn't have to re-derive it.
+    eprintln!(
+        "FALSIFY-FFN-GGUF-007: scalar+SIMD Q4K dequant byte-identical across all 256 elements. \
+         element[0]={} ({:#x}); element[255]={} ({:#x}). \
+         H2d.2 hypothesis FALSIFIED at APR-internal dequant level — both APR dequant paths \
+         agree byte-for-byte.",
+        result_scalar[0],
+        result_scalar[0].to_bits(),
+        result_scalar[255],
+        result_scalar[255].to_bits()
+    );
+}


### PR DESCRIPTION
## Summary

**THIRD hypothesis falsification in one session.** Authors `falsify_ffn_gguf_007_q4k_scalar_vs_simd_dequant_byte_identity` testing that APR's scalar `dequantize_q4_k` and SIMD `dequantize_q4_k_simd` produce byte-identical Vec<f32> for the same Q4K super-block bytes.

**Empirical result**: both paths produce byte-identical output across all 256 elements (`element[0]=10.75=0x412c0000`, `element[255]=1.25=0x3fa00000`). H2d.2 hypothesis FALSIFIED at the APR-internal dequant level.

## Three hypothesis falsifications this session

| Hypothesis | Status | Test |
|------------|--------|------|
| §28 parallel-reduction non-determinism | **FALSIFIED** | FALSIFY-FFN-GGUF-005 (M91) |
| H2a' SIMD-vs-scalar dot reduction | **FALSIFIED** | FALSIFY-FFN-GGUF-006 (M92) |
| **H2d.2 APR-internal Q4K dequant byte-identity** | **FALSIFIED** | **FALSIFY-FFN-GGUF-007 (this PR)** |

## Remaining viable hypotheses (post-three-falsification)

- **H2d.1**: per-block dequant boundaries differ between APR whole-row reduction and GGUF super-block Q4K-byte-by-byte fused reduction
- **H2d.3**: Q8K activation quantization in GGUF's path (a step APR doesn't have at all)
- **H2d.4** (NEW): the FUSED matvec's INLINE Q4K dequant may produce different bits than the STANDALONE dequant routines

## Contract amendment (v1.3.0 → v1.4.0)

| Field | Before | After |
|-------|--------|-------|
| version | 1.3.0 | **1.4.0** |
| FALSIFY-FFN-GGUF-007 | NEW | **DISCHARGED** |
| Step (c) hypothesis space | {H2d.1, H2d.2, H2d.3} | **{H2d.1, H2d.3, H2d.4}** |

## Test plan

- [x] `pv validate` 0/0
- [x] Test passes on first run
- [x] No production code touched (additive test-only file)
- [x] H2d.2 empirically falsified

🤖 Generated with [Claude Code](https://claude.com/claude-code)