### PR TITLE
feat(apr-cli): #1547 `apr tokenize encode-corpus --num-workers` parallelism

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,6 +323,7 @@ dependencies = [
  "predicates",
  "proptest",
  "provable-contracts-macros 0.3.1",
+ "rayon",
  "regex",
  "rmp-serde",
  "serde",

--- a/contracts/apr-tokenize-parallel-bpe-v1.yaml
+++ b/contracts/apr-tokenize-parallel-bpe-v1.yaml
@@ -1,14 +1,16 @@
 metadata:
   kind: schema
-  version: 1.0.0
-  status: PROPOSED
+  version: 1.1.0
+  status: ACTIVE
   created: '2026-04-27'
+  updated: '2026-05-05'
   author: PAIML Engineering
   registry: false
   references:
   - 'SPEC-SHIP-TWO-001 §26.2 — corpus pipeline'
   - 'SPEC-SHIP-TWO-001 §26.8 — apr is canonical, extend apr never CLI-shim'
   - 'feedback_compute_pre_authorized.md — lambda-labs lane is open'
+  - 'GH-1547 — SHIP-TWO-001 5g.1: live encode at hour 47, single-thread'
   description: >
     Contract for parallelizing `apr tokenize encode-corpus` across multiple
     CPU cores. Triggering observation 2026-04-27: P1.5 BPE encoding of a
@@ -16,6 +18,13 @@ metadata:
     tokens/sec on RTX 4090 host (48 cores available). Total encode time
     ~4 hours for 190M tokens. With N-way parallelism, expected speedup
     ~Nx (BPE is CPU-bound, no shared mutable state across rows).
+
+    v1.1.0 (2026-05-05): Implementation landed via GH-1547. Strategy
+    REVISED from "split input + N child encoders + post-hoc merge" to
+    "single-process chunked rayon": pull a CHUNK of docs, par_iter encode,
+    sequential write. Strictly safer (no shard renumbering, no merge step)
+    and just as fast for CPU-bound BPE. Flag is `--num-workers N` (operator
+    request, not `--workers`). Default is `available_parallelism`.
 
 equations:
   parallel_correctness:
@@ -35,20 +44,30 @@ equations:
     - "Same tokenizer + same row → same token sequence (deterministic)"
     - "Concatenation order preserves input order"
 
-  shard_renumbering:
+  in_process_chunked_rayon:
     formula: |
-      When N parallel encoders write to N output directories, each
-      producing shard-00000.bin .. shard-MMM.bin, the merged corpus is
-      formed by:
-        merged_shard_idx[i] = sum(N_shards[0..encoder_idx]) + local_shard_idx
-      with renumbered files copied (or hardlinked) into the merged dir.
-      The final shard from encoder_k may be partial (< 10M tokens); this
-      is preserved by the merge.
-    domain: shard numbering
+      v1.1.0 implementation — single-process chunked rayon (no shard
+      renumbering or merge needed):
+
+      1. Pull a CHUNK of K docs from the canonical input iterator
+         (preserves on-disk JSONL/parquet order).
+      2. Encode the chunk via rayon par_iter into a Vec<Result<...>>
+         indexed by chunk-local position (par_iter on Vec<T> preserves
+         output index order).
+      3. Drain the encoded vec into the open shard writer in chunk-local
+         order, applying eos_policy and rotating shards exactly as the
+         legacy single-threaded path does.
+      4. Repeat until the source iterator is exhausted.
+
+      This collapses v1.0.0's three-stage "split → fan-out encoders →
+      merge" pipeline into a single-pass loop. Memory is bounded by
+      `K * avg_doc_token_count * 4 bytes`. Chunk size K = 10_000 docs.
+    domain: in-process chunked parallelism
     codomain: bool
     invariants:
-    - "No two merged shards have the same shard_idx"
-    - "Order: encoder-0's shards come first, then encoder-1's, etc."
+    - "Output bytes are independent of worker count (byte-identical across N)"
+    - "Output shard naming is shard-{idx:05}.bin (same as legacy path)"
+    - "No temporary directories — one output dir, written incrementally"
     - "Total tokens preserved exactly"
 
   speedup_target:
@@ -64,34 +83,47 @@ equations:
 
 falsification_tests:
 - id: FALSIFY-APR-TOK-PAR-001
-  rule: parallel encode produces identical token stream as serial
-  prediction: "Splitting a 1MB JSONL into 4 chunks and parallel-encoding produces a token stream concat-equal to serial-encoding the full file"
-  test: |
-    apr tokenize encode-corpus --corpus full.jsonl --tokenizer T --output single/
-    split_jsonl full.jsonl --chunks 4
-    for i in 0..3: apr tokenize encode-corpus --corpus chunk-$i.jsonl --tokenizer T --output par-$i/ &
-    wait
-    merge_shards par-0/ par-1/ par-2/ par-3/ --output merged/
-    cmp single/concat.bin merged/concat.bin
-  if_fails: "parallel encoding diverges — bug in chunk split or shard merge"
+  rule: parallel encode produces byte-identical shards vs serial
+  prediction: "`--num-workers 4` and `--num-workers 1` produce shard-NNNNN.bin files that are byte-identical for the same JSONL input"
+  test: "crates/apr-cli/src/commands/tokenize.rs::tests::encode_corpus_num_workers_1_matches_num_workers_n_byte_for_byte"
+  status: DISCHARGED
+  if_fails: "parallel encoding diverges — chunk-internal ordering or shard rotation broke determinism"
 
 - id: FALSIFY-APR-TOK-PAR-002
   rule: speedup ≥ 0.8N for 4-way
   prediction: "4-way parallel on 4-core machine completes in ≤ 1.25× single-threaded / 4"
-  test: "time_par <= time_serial * 1.25 / 4"
+  test: "operational measurement (issue #1547 retrain target: 17h → ~6h on 8-core)"
+  status: PARTIAL_OPERATIONAL_PENDING
   if_fails: "parallelism overhead too high — likely due to fork-join cost or I/O contention"
 
 - id: FALSIFY-APR-TOK-PAR-003
-  rule: 8-way doesn't crash
-  prediction: "apr tokenize encode-corpus --workers 8 on 16-core machine succeeds (no OOM, no deadlock)"
+  rule: high worker counts don't crash or starve
+  prediction: "apr tokenize encode-corpus --num-workers 8 on 16-core machine succeeds (no OOM, no deadlock)"
   test: "exit code = 0, output dir has expected shard count"
+  status: DISCHARGED_BY_CONSTRUCTION
   if_fails: "parallelism causes resource exhaustion — workers must respect a memory budget"
+  notes: "Memory is bounded by CHUNK_SIZE × avg_doc_tokens × 4. Chunk drains before next pull."
 
 - id: FALSIFY-APR-TOK-PAR-004
-  rule: --workers flag is positional discriminator
-  prediction: "`apr tokenize encode-corpus --workers 4` is accepted by clap and visible in --help"
-  test: "apr tokenize encode-corpus --help | grep -q workers"
+  rule: --num-workers flag is registered in clap surface
+  prediction: "`apr tokenize encode-corpus --help` output includes the literal string `--num-workers`"
+  test: "crates/apr-cli/tests/falsification_apr_tok_par_004.rs::falsify_apr_tok_par_004_help_advertises_num_workers_flag"
+  status: DISCHARGED
   if_fails: "CLI surface drift — flag not registered in clap"
+
+- id: FALSIFY-APR-TOK-PAR-005
+  rule: --num-workers default equals available_parallelism
+  prediction: "resolve_num_workers(None) == std::thread::available_parallelism().get() (or 1 on cgroup-restricted hosts)"
+  test: "crates/apr-cli/src/commands/tokenize.rs::tests::encode_corpus_resolve_workers_default_is_available_parallelism"
+  status: DISCHARGED
+  if_fails: "default is hardcoded — operator gets surprising thread count on smaller machines"
+
+- id: FALSIFY-APR-TOK-PAR-006
+  rule: --num-workers 0 is a config error not a silent fallback
+  prediction: "resolve_num_workers(Some(0)) returns CliError::ValidationFailed naming the flag and the >= 1 bound"
+  test: "crates/apr-cli/src/commands/tokenize.rs::tests::encode_corpus_resolve_workers_rejects_zero"
+  status: DISCHARGED
+  if_fails: "operator typo silently coerced — typo class hidden"
 
 proof_obligations:
 - type: invariant
@@ -106,24 +138,35 @@ proof_obligations:
 verification_summary:
   total_obligations: 4
   proven: 0
-  tested: 0
-  status: pending
+  tested: 4
+  status: discharged_unit
   notes: |
     Authored 2026-04-27 from observation that P1.5 BPE encoding ran single-
     threaded at ~13K tokens/sec on a 48-core host. With 760M chars (~190M
     tokens) to encode, single-threaded ETA was ~4 hours; 8-way parallelism
     would have brought this to ~30 minutes.
 
-    PROPOSED status until implementation. Implementation steps:
-    1. Add `--workers N` flag to `apr tokenize encode-corpus`.
-    2. Split input JSONL by row count modulo N (preserving order within chunk).
-    3. Spawn N rayon worker threads, each running the existing single-
-       threaded encode logic on its chunk to a per-worker temp dir.
-    4. After all workers complete, merge by renumbering shards in
-       (worker_idx, local_idx) order into the final output dir.
-    5. Write final manifest.json with merged shard list.
+    v1.1.0 (2026-05-05, GH-1547): ACTIVE. Implementation landed in
+    `crates/apr-cli/src/commands/tokenize.rs::run_encode_corpus`. Strategy
+    revised from v1.0.0's "split + N-encoder + merge" to a strictly safer
+    single-pass chunked rayon loop:
 
-    Implementation cost estimate: ~200 LOC + 5 unit tests. P3 priority
-    (after MODEL-2 retrain on codeparrot lands and proves the corpus
-    scales to ~1B+ tokens — at which point single-threaded encoding
-    becomes a 24+ hour operation that's clearly worth paralleling).
+    1. `--num-workers N` clap flag on `apr tokenize encode-corpus`.
+       Default = `std::thread::available_parallelism()` (logical CPU count).
+       Some(0) is rejected as a config error.
+    2. Pull CHUNK_SIZE (10_000) docs from the canonical input iterator.
+    3. par_iter the chunk through tokenizer.encode → Vec<Result<...>>
+       indexed by chunk-local position.
+    4. Drain in chunk-local order into the open shard writer, applying
+       eos_policy and rotating shards exactly as the legacy single-thread
+       path does.
+    5. Repeat until iterator exhausted.
+
+    Live trigger: SHIP-TWO-001 5g.1 retrain encode running 47h on PID
+    2767124, projected 17h. Issue #1547. Falsifiers
+    FALSIFY-APR-TOK-PAR-001/004/005/006 DISCHARGED via unit tests in
+    `tokenize.rs::tests::encode_corpus_*`. -PAR-002 (operational speedup)
+    is PARTIAL_OPERATIONAL_PENDING — discharged once the next encode run
+    posts wall-clock evidence ≤ 6h on the same corpus. -PAR-003
+    (no-crash at high worker count) is DISCHARGED_BY_CONSTRUCTION via the
+    bounded-memory chunk loop.

--- a/crates/apr-cli/Cargo.toml
+++ b/crates/apr-cli/Cargo.toml
@@ -215,6 +215,11 @@ serde_yaml = { package = "serde_yaml_ng", version = "0.10" }
 # Unicode normalization (NFC) for BPE corpus preprocessing (MODEL-2).
 unicode-normalization = "0.1"
 
+# Parallelism — used by `apr tokenize encode-corpus --num-workers` (issue #1547).
+# Per-doc BPE encoding is independent across rows; rayon's chunked par_iter
+# preserves input order via Vec<Result<...>> indexed by chunk position.
+rayon = { workspace = true }
+
 [[example]]
 name = "serve_with_tracing"
 required-features = ["inference"]

--- a/crates/apr-cli/src/commands/tokenize.rs
+++ b/crates/apr-cli/src/commands/tokenize.rs
@@ -590,12 +590,45 @@ fn validate_normalization(norm: &str) -> Result<()> {
     }
 }
 
+/// Per-doc-chunk batch size for the parallel encode path. Chosen so each
+/// rayon spawn amortizes thread setup against ~10K BPE encodes (~13K tok/s
+/// per worker → ~1s of work per chunk on the SHIP-TWO-001 760M-char Python
+/// corpus). Smaller chunks waste rayon overhead; larger chunks delay shard
+/// flush feedback (issue #1547).
+#[cfg(feature = "training")]
+const ENCODE_CHUNK_SIZE: usize = 10_000;
+
+/// Resolve the effective rayon worker count for `apr tokenize encode-corpus`.
+///
+/// `None` (default) → `std::thread::available_parallelism()`, falling back
+/// to 1 if the OS cannot answer (e.g. cgroup-restricted CI). Explicit `Some(0)`
+/// is rejected as a config error rather than silently coerced. `Some(1)`
+/// triggers the legacy single-threaded byte-identical path.
+#[cfg(feature = "training")]
+fn resolve_num_workers(num_workers: Option<usize>) -> Result<usize> {
+    match num_workers {
+        Some(0) => Err(CliError::ValidationFailed(
+            "--num-workers must be >= 1 (got 0)".to_string(),
+        )),
+        Some(n) => Ok(n),
+        None => Ok(std::thread::available_parallelism()
+            .map(std::num::NonZeroUsize::get)
+            .unwrap_or(1)),
+    }
+}
+
 /// Run `apr tokenize encode-corpus` — pretokenize a JSONL corpus into `.bin`
 /// shards per contracts/pretokenize-bin-v1.yaml. Emits flat little-endian u32
 /// streams (the exact format ShardBatchIter expects at MODEL-2 pretrain time).
 ///
 /// Requires the `training` feature so `entrenar::tokenizer::BPETokenizer`
 /// is linked; without it, encode-corpus is unavailable (matching `run_train`).
+///
+/// `num_workers` controls per-document BPE encoding parallelism (issue #1547).
+/// `Some(1)` runs the byte-identical single-threaded legacy path; `None` uses
+/// `available_parallelism`; `Some(N)` for N > 1 uses chunked rayon while
+/// preserving original document order per `parallel_correctness` invariant
+/// in `contracts/apr-tokenize-parallel-bpe-v1.yaml`.
 #[cfg(feature = "training")]
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn run_encode_corpus(
@@ -606,6 +639,7 @@ pub(crate) fn run_encode_corpus(
     content_field: &str,
     normalization: &str,
     eos_policy: &str,
+    num_workers: Option<usize>,
     json_output: bool,
 ) -> Result<()> {
     use entrenar::tokenizer::{BPETokenizer, Normalization, Tokenizer, TokenizerConfig};
@@ -625,6 +659,7 @@ pub(crate) fn run_encode_corpus(
             "shard_tokens must be > 0".to_string(),
         ));
     }
+    let workers = resolve_num_workers(num_workers)?;
     if !corpus.exists() {
         return Err(CliError::FileNotFound(corpus.to_path_buf()));
     }
@@ -676,24 +711,39 @@ pub(crate) fn run_encode_corpus(
     let mut writer = open_shard(output_dir, shard_idx)?;
     let mut doc_iter_count: u64 = 0;
 
-    for triple in iter_corpus_texts(&files, corpus_format, content_field) {
-        let (file_display, locator, text) = triple?;
-        let ids = tokenizer.encode(&text).map_err(|e| {
-            CliError::ValidationFailed(format!("Encoding failed at {file_display} {locator}: {e}"))
-        })?;
+    // Source iterator: yields (file_display, locator, text) triples in
+    // canonical input order. Both the single-threaded and chunked-parallel
+    // paths consume from this same iterator — the only difference is whether
+    // chunks are encoded in lock-step or via rayon.
+    let mut source = iter_corpus_texts(&files, corpus_format, content_field);
 
-        if eos_policy == "between" && doc_iter_count > 0 {
+    // Closure: emit a single doc's encoded ids into `writer`, applying the
+    // EOS policy and shard rotation. Identical bookkeeping for both paths
+    // — the only invariant difference is when (and on what thread) the
+    // `tokenizer.encode()` call happened. Output bytes per doc are
+    // independent of worker count.
+    let emit = |writer: &mut std::io::BufWriter<std::fs::File>,
+                shard_idx: &mut usize,
+                tokens_in_shard: &mut usize,
+                total_tokens: &mut u64,
+                eos_count: &mut u64,
+                doc_iter_count: &mut u64,
+                file_display: &str,
+                locator: &str,
+                ids: &[u32]|
+     -> Result<()> {
+        if eos_policy == "between" && *doc_iter_count > 0 {
             if let Some(eos) = eos_id {
                 writer
                     .write_all(&eos.to_le_bytes())
                     .map_err(|e| CliError::ValidationFailed(format!("Shard write failed: {e}")))?;
-                tokens_in_shard += 1;
-                total_tokens += 1;
-                eos_count += 1;
+                *tokens_in_shard += 1;
+                *total_tokens += 1;
+                *eos_count += 1;
             }
         }
 
-        for id in &ids {
+        for id in ids {
             if (*id as usize) >= vocab_size {
                 return Err(CliError::ValidationFailed(format!(
                     "Token id {id} >= vocab_size {vocab_size} at {file_display} {locator} \
@@ -703,8 +753,8 @@ pub(crate) fn run_encode_corpus(
             writer
                 .write_all(&id.to_le_bytes())
                 .map_err(|e| CliError::ValidationFailed(format!("Shard write failed: {e}")))?;
-            tokens_in_shard += 1;
-            total_tokens += 1;
+            *tokens_in_shard += 1;
+            *total_tokens += 1;
         }
 
         if eos_policy == "after" {
@@ -712,24 +762,126 @@ pub(crate) fn run_encode_corpus(
                 writer
                     .write_all(&eos.to_le_bytes())
                     .map_err(|e| CliError::ValidationFailed(format!("Shard write failed: {e}")))?;
-                tokens_in_shard += 1;
-                total_tokens += 1;
-                eos_count += 1;
+                *tokens_in_shard += 1;
+                *total_tokens += 1;
+                *eos_count += 1;
             }
         }
 
-        doc_iter_count += 1;
-        total_docs += 1;
+        *doc_iter_count += 1;
+        Ok(())
+    };
 
-        if tokens_in_shard >= shard_tokens {
-            writer
-                .flush()
-                .map_err(|e| CliError::ValidationFailed(format!("Shard flush failed: {e}")))?;
-            shard_idx += 1;
-            tokens_in_shard = 0;
-            writer = open_shard(output_dir, shard_idx)?;
+    if workers <= 1 {
+        // Legacy single-threaded path. MUST stay byte-identical to pre-#1547
+        // output for any operator job that pinned `--num-workers 1`.
+        for triple in source.by_ref() {
+            let (file_display, locator, text) = triple?;
+            let ids = tokenizer.encode(&text).map_err(|e| {
+                CliError::ValidationFailed(format!(
+                    "Encoding failed at {file_display} {locator}: {e}"
+                ))
+            })?;
+            emit(
+                &mut writer,
+                &mut shard_idx,
+                &mut tokens_in_shard,
+                &mut total_tokens,
+                &mut eos_count,
+                &mut doc_iter_count,
+                &file_display,
+                &locator,
+                &ids,
+            )?;
+            total_docs += 1;
+            if tokens_in_shard >= shard_tokens {
+                writer
+                    .flush()
+                    .map_err(|e| CliError::ValidationFailed(format!("Shard flush failed: {e}")))?;
+                shard_idx += 1;
+                tokens_in_shard = 0;
+                writer = open_shard(output_dir, shard_idx)?;
+            }
+        }
+    } else {
+        // Chunked parallel path. Read CHUNK docs sequentially, encode in
+        // parallel via rayon (preserving chunk-local order via index), then
+        // drain into `writer` sequentially. This bounds memory at roughly
+        // `CHUNK * avg_doc_token_count * 4` bytes and bounds rayon spawn
+        // overhead at `total_docs / CHUNK` dispatches.
+        use rayon::prelude::*;
+        let pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(workers)
+            .build()
+            .map_err(|e| {
+                CliError::ValidationFailed(format!("Cannot build rayon pool ({workers}): {e}"))
+            })?;
+
+        loop {
+            // 1. Pull next chunk from the canonical source iterator. Errors
+            //    here are JSON-parse / IO errors — surface them before
+            //    dispatching the chunk so the failing locator is precise.
+            let mut chunk: Vec<(String, String, String)> = Vec::with_capacity(ENCODE_CHUNK_SIZE);
+            for _ in 0..ENCODE_CHUNK_SIZE {
+                match source.next() {
+                    Some(Ok(triple)) => chunk.push(triple),
+                    Some(Err(e)) => return Err(e),
+                    None => break,
+                }
+            }
+            if chunk.is_empty() {
+                break;
+            }
+
+            // 2. Parallel encode within this rayon pool. `par_iter` over a
+            //    Vec<T> preserves index order in the output Vec, so the
+            //    write phase below sees docs in original input order.
+            let encoded: Vec<Result<(String, String, Vec<u32>)>> = pool.install(|| {
+                chunk
+                    .par_iter()
+                    .map(|(file_display, locator, text)| {
+                        tokenizer
+                            .encode(text)
+                            .map(|ids| (file_display.clone(), locator.clone(), ids))
+                            .map_err(|e| {
+                                CliError::ValidationFailed(format!(
+                                    "Encoding failed at {file_display} {locator}: {e}"
+                                ))
+                            })
+                    })
+                    .collect()
+            });
+
+            // 3. Sequential write phase — same emit closure as the
+            //    single-threaded path, so output bytes are determined
+            //    purely by (doc_index, tokenizer, eos_policy) and not by
+            //    worker count.
+            for result in encoded {
+                let (file_display, locator, ids) = result?;
+                emit(
+                    &mut writer,
+                    &mut shard_idx,
+                    &mut tokens_in_shard,
+                    &mut total_tokens,
+                    &mut eos_count,
+                    &mut doc_iter_count,
+                    &file_display,
+                    &locator,
+                    &ids,
+                )?;
+                total_docs += 1;
+                if tokens_in_shard >= shard_tokens {
+                    writer.flush().map_err(|e| {
+                        CliError::ValidationFailed(format!("Shard flush failed: {e}"))
+                    })?;
+                    shard_idx += 1;
+                    tokens_in_shard = 0;
+                    writer = open_shard(output_dir, shard_idx)?;
+                }
+            }
         }
     }
+
     writer
         .flush()
         .map_err(|e| CliError::ValidationFailed(format!("Shard flush failed: {e}")))?;
@@ -753,6 +905,7 @@ pub(crate) fn run_encode_corpus(
             CorpusFormat::Parquet => "parquet",
         },
         "input_files": files.iter().map(|p| p.display().to_string()).collect::<Vec<_>>(),
+        "num_workers": workers,
         "elapsed_seconds": elapsed.as_secs_f64(),
     });
     let manifest_path = output_dir.join("manifest.json");
@@ -775,6 +928,7 @@ pub(crate) fn run_encode_corpus(
         output::kv("  Total tokens", format_number(total_tokens as usize));
         output::kv("  Total documents", format_number(total_docs as usize));
         output::kv("  Vocab size", format_number(vocab_size));
+        output::kv("  Workers", workers.to_string());
         output::kv("  Elapsed", format!("{:.1}s", elapsed.as_secs_f64()));
         output::kv("  Manifest", manifest_path.display().to_string());
     }
@@ -1208,10 +1362,7 @@ pub(crate) fn run_import_hf(
         output::kv("  BPE vocab", format_number(bpe_vocab_count));
         output::kv("  Merges", format_number(merges_count));
         output::kv("  Added tokens", format_number(added_tokens_count));
-        output::kv(
-            "  Effective vocab",
-            format_number(effective_vocab.len()),
-        );
+        output::kv("  Effective vocab", format_number(effective_vocab.len()));
         output::kv("  Output dir", output.display().to_string());
         println!();
         println!("{}", "Wrote:".green().bold());
@@ -1518,10 +1669,9 @@ mod tests {
         // Default: no added tokens in vocab.json.
         let out_default = tmp.path().join("default");
         run_import_hf(&input, &out_default, false, true).expect("default import");
-        let v_default: serde_json::Map<String, serde_json::Value> = serde_json::from_str(
-            &std::fs::read_to_string(out_default.join("vocab.json")).unwrap(),
-        )
-        .unwrap();
+        let v_default: serde_json::Map<String, serde_json::Value> =
+            serde_json::from_str(&std::fs::read_to_string(out_default.join("vocab.json")).unwrap())
+                .unwrap();
         assert_eq!(v_default.len(), 100);
         assert!(
             !v_default.contains_key("<|endoftext|>"),
@@ -1531,14 +1681,191 @@ mod tests {
         // With flag: added tokens included.
         let out_full = tmp.path().join("full");
         run_import_hf(&input, &out_full, true, true).expect("full import");
-        let v_full: serde_json::Map<String, serde_json::Value> = serde_json::from_str(
-            &std::fs::read_to_string(out_full.join("vocab.json")).unwrap(),
-        )
-        .unwrap();
+        let v_full: serde_json::Map<String, serde_json::Value> =
+            serde_json::from_str(&std::fs::read_to_string(out_full.join("vocab.json")).unwrap())
+                .unwrap();
         assert_eq!(v_full.len(), 101);
         assert!(
             v_full.contains_key("<|endoftext|>"),
             "include-added-tokens mode must include the special"
         );
+    }
+
+    // ─── apr tokenize encode-corpus --num-workers (issue #1547) ─────────
+    // SHIP-TWO-001 5g.1 unblock: per-document BPE encoding is independent
+    // across rows, so chunked rayon with sequential write-phase preserves
+    // both byte-identity (for `--num-workers 1`) and shard order (for any N).
+    // These tests pin those properties.
+    //
+    // Note: FALSIFY-APR-TOK-PAR-004 (`--num-workers` advertised in
+    // `apr tokenize encode-corpus --help`) is verified by the integration
+    // test at `tests/falsification_apr_tok_par_004.rs` — running clap's
+    // CommandFactory in-process recurses through the full Cli tree, which
+    // overflows the default test stack on this binary's command surface.
+    // The integration test invokes the compiled `apr` binary instead, which
+    // matches the operator-facing surface 1:1 and avoids the stack issue.
+
+    #[cfg(feature = "training")]
+    #[test]
+    fn encode_corpus_resolve_workers_default_is_available_parallelism() {
+        // FALSIFY-#1547-DEFAULT: `None` → std::thread::available_parallelism().
+        // Allow the OS-cgroup edge case where parallelism is reported as 1
+        // (covered by the unwrap_or(1) fallback). The contract is "not zero
+        // and matches the platform reading", not a hardcoded core count.
+        let resolved = resolve_num_workers(None).expect("default must resolve");
+        let expected = std::thread::available_parallelism()
+            .map(std::num::NonZeroUsize::get)
+            .unwrap_or(1);
+        assert_eq!(
+            resolved, expected,
+            "default must equal available_parallelism (or 1 fallback)"
+        );
+        assert!(resolved >= 1, "resolved worker count must be >= 1");
+    }
+
+    #[cfg(feature = "training")]
+    #[test]
+    fn encode_corpus_resolve_workers_explicit_value_passes_through() {
+        // Explicit Some(N) for N >= 1 returns N verbatim — operators can
+        // pin worker count for memory/sharing reasons without surprise.
+        assert_eq!(resolve_num_workers(Some(1)).expect("Some(1)"), 1);
+        assert_eq!(resolve_num_workers(Some(4)).expect("Some(4)"), 4);
+        assert_eq!(resolve_num_workers(Some(64)).expect("Some(64)"), 64);
+    }
+
+    #[cfg(feature = "training")]
+    #[test]
+    fn encode_corpus_resolve_workers_rejects_zero() {
+        // Some(0) is a config error, not a silent fallback. Keeps the
+        // failure-mode loud — a user who typed `--num-workers 0` almost
+        // certainly meant something else, and silently coercing to 1 (or
+        // available_parallelism) hides the typo.
+        let err = resolve_num_workers(Some(0)).expect_err("zero must error");
+        match err {
+            CliError::ValidationFailed(msg) => {
+                assert!(msg.contains("--num-workers"), "error must name flag: {msg}");
+                assert!(msg.contains(">= 1"), "error must state bound: {msg}");
+            }
+            other => panic!("unexpected error variant: {other:?}"),
+        }
+    }
+
+    /// Issue #1547 byte-identity AC: `--num-workers 1` MUST produce the
+    /// same shard bytes as the pre-PR single-threaded path on a small
+    /// fixture, AND `--num-workers N` (N > 1) MUST produce the same shard
+    /// bytes as `--num-workers 1`. The latter is the operative invariant
+    /// for the SHIP-TWO-001 5g.1 retraining: parallelism MUST NOT alter
+    /// the token stream the trainer ingests.
+    ///
+    /// Per `contracts/apr-tokenize-parallel-bpe-v1.yaml` §parallel_correctness:
+    ///   ENC(jsonl_full, tok) ≡ concat(ENC(chunk_0), ..., ENC(chunk_N-1))
+    /// when chunks preserve input order and BPE has no cross-row state.
+    ///
+    /// 10 distinct documents (avoids any "chunk-of-1 happens to be ordered"
+    /// degenerate case) and a non-trivial vocab to exercise real merges.
+    #[cfg(feature = "training")]
+    #[test]
+    fn encode_corpus_num_workers_1_matches_num_workers_n_byte_for_byte() {
+        let tmp = TempDir::new().expect("tempdir");
+
+        // Build a tokenizer in-tree so the test stays hermetic.
+        let train_corpus = write_corpus_file(
+            tmp.path(),
+            "train.jsonl",
+            &[
+                r#"{"content": "hello world the quick brown fox"}"#,
+                r#"{"content": "the lazy dog jumped over the fence"}"#,
+                r#"{"content": "rust is a systems programming language"}"#,
+            ],
+        );
+        let tok_dir = tmp.path().join("tok");
+        run_train(&train_corpus, 400, 1, &tok_dir, "nfc", true).expect("train tokenizer");
+
+        // 10-doc encode corpus — diverse content so chunk-internal order
+        // matters (any reordering shows up as token-stream divergence).
+        let encode_lines: Vec<String> = (0..10)
+            .map(|i| {
+                format!(
+                    r#"{{"content": "doc {i} alpha beta gamma the quick brown fox jumps {i}"}}"#
+                )
+            })
+            .collect();
+        let encode_refs: Vec<&str> = encode_lines.iter().map(String::as_str).collect();
+        let corpus = write_corpus_file(tmp.path(), "encode.jsonl", &encode_refs);
+
+        // Single-threaded reference output.
+        let out_1 = tmp.path().join("out_1");
+        run_encode_corpus(
+            &corpus,
+            &tok_dir,
+            &out_1,
+            10_000_000,
+            "content",
+            "nfc",
+            "between",
+            Some(1),
+            true,
+        )
+        .expect("encode --num-workers 1");
+
+        // Parallel output (4 workers — > 1 forces the rayon path).
+        let out_n = tmp.path().join("out_n");
+        run_encode_corpus(
+            &corpus,
+            &tok_dir,
+            &out_n,
+            10_000_000,
+            "content",
+            "nfc",
+            "between",
+            Some(4),
+            true,
+        )
+        .expect("encode --num-workers 4");
+
+        // Compare every shard byte-for-byte. The manifest gains a
+        // `num_workers` field (additive metadata) so we deliberately only
+        // diff the .bin shards — they encode the load-bearing invariant.
+        let shards_1: Vec<_> = std::fs::read_dir(&out_1)
+            .expect("read out_1")
+            .filter_map(std::result::Result::ok)
+            .filter(|e| e.path().extension().and_then(std::ffi::OsStr::to_str) == Some("bin"))
+            .collect();
+        let shards_n: Vec<_> = std::fs::read_dir(&out_n)
+            .expect("read out_n")
+            .filter_map(std::result::Result::ok)
+            .filter(|e| e.path().extension().and_then(std::ffi::OsStr::to_str) == Some("bin"))
+            .collect();
+        assert_eq!(
+            shards_1.len(),
+            shards_n.len(),
+            "shard count must match across worker counts"
+        );
+        assert!(!shards_1.is_empty(), "test must produce at least one shard");
+
+        let mut names_1: Vec<String> = shards_1
+            .iter()
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .collect();
+        let mut names_n: Vec<String> = shards_n
+            .iter()
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .collect();
+        names_1.sort();
+        names_n.sort();
+        assert_eq!(
+            names_1, names_n,
+            "shard filenames must match (deterministic naming)"
+        );
+
+        for name in &names_1 {
+            let bytes_1 = std::fs::read(out_1.join(name)).expect("read single-threaded shard");
+            let bytes_n = std::fs::read(out_n.join(name)).expect("read parallel shard");
+            assert_eq!(
+                bytes_1, bytes_n,
+                "FALSIFY-#1547-PARITY: shard {name} must be byte-identical \
+                 between --num-workers 1 and --num-workers 4"
+            );
+        }
     }
 }

--- a/crates/apr-cli/src/dispatch_analysis.rs
+++ b/crates/apr-cli/src/dispatch_analysis.rs
@@ -701,6 +701,7 @@ fn dispatch_tokenize_command(
             content_field,
             normalization,
             eos_policy,
+            num_workers,
         } => tokenize::run_encode_corpus(
             corpus,
             tokenizer,
@@ -709,6 +710,7 @@ fn dispatch_tokenize_command(
             content_field,
             normalization,
             eos_policy,
+            *num_workers,
             cli.json,
         ),
     }

--- a/crates/apr-cli/src/tokenize_commands.rs
+++ b/crates/apr-cli/src/tokenize_commands.rs
@@ -150,5 +150,16 @@ pub enum TokenizeCommands {
         /// EOS insertion policy: none|between|after.
         #[arg(long, default_value = "between")]
         eos_policy: String,
+        /// Number of rayon workers for per-document BPE encoding.
+        ///
+        /// Defaults to `std::thread::available_parallelism()` (logical CPU count).
+        /// Set to `1` to force the single-threaded byte-identical legacy path.
+        /// Set to a fixed N to bound memory or share the host with other jobs.
+        ///
+        /// Output shard order is preserved: chunked encoding keeps original
+        /// document order regardless of worker count (issue #1547,
+        /// contracts/apr-tokenize-parallel-bpe-v1.yaml `parallel_correctness`).
+        #[arg(long, value_name = "N")]
+        num_workers: Option<usize>,
     },
 }

--- a/crates/apr-cli/tests/falsification_apr_tok_par_004.rs
+++ b/crates/apr-cli/tests/falsification_apr_tok_par_004.rs
@@ -1,0 +1,60 @@
+//! FALSIFY-APR-TOK-PAR-004 — `apr tokenize encode-corpus --help` MUST
+//! advertise the `--num-workers` flag introduced in issue #1547.
+//!
+//! In-process clap rendering via `Cli::command()` overflows the default
+//! test-thread stack on this binary's command surface (a known clap-derive
+//! cost; see `commands/tokenize.rs::tests` comment). This integration test
+//! invokes the compiled `apr` binary directly — the same surface the
+//! operator hits — and greps `--help` output for the flag.
+//!
+//! Pinning this test means a future refactor that drops the flag (e.g.
+//! when migrating subcommand definitions) tripwires loudly instead of
+//! silently re-introducing the 47-hour single-thread regression.
+//!
+//! Contract: contracts/apr-tokenize-parallel-bpe-v1.yaml v1.1.0.
+
+#![cfg(feature = "training")]
+
+use std::process::Command;
+
+fn apr_binary() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_apr"));
+    cmd.env("NO_COLOR", "1");
+    cmd
+}
+
+#[test]
+fn falsify_apr_tok_par_004_help_advertises_num_workers_flag() {
+    let out = apr_binary()
+        .args(["tokenize", "encode-corpus", "--help"])
+        .output()
+        .expect("run apr tokenize encode-corpus --help");
+    assert!(
+        out.status.success(),
+        "apr tokenize encode-corpus --help must exit 0; stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("--num-workers"),
+        "FALSIFY-APR-TOK-PAR-004: --help must advertise --num-workers \
+         (issue #1547); got:\n{stdout}"
+    );
+}
+
+#[test]
+fn falsify_apr_tok_par_004_help_documents_default_resolution() {
+    // Anti-regression: the flag's help text should mention the default
+    // resolution mechanism so an operator skimming `--help` sees that
+    // omitting the flag yields full-CPU parallelism (not single-thread).
+    let out = apr_binary()
+        .args(["tokenize", "encode-corpus", "--help"])
+        .output()
+        .expect("run apr tokenize encode-corpus --help");
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("available_parallelism") || stdout.contains("logical CPU"),
+        "--help should explain the default num_workers value; got:\n{stdout}"
+    );
+}


### PR DESCRIPTION
## Summary

- Adds `--num-workers <N>` to `apr tokenize encode-corpus`. SHIP-TWO-001 5g.1 unblock: the live encode job has been single-threaded for 47+ hours; chunked rayon brings the projected ~17h re-encode under ~6h on an 8-core box.
- Strategy: pull CHUNK (10_000) docs from the canonical input iterator, `par_iter` encode them in a sized rayon pool, drain into the open shard writer in original input order. Single-threaded path stays byte-identical to pre-#1547 output. Output bytes are independent of worker count.
- Default = `std::thread::available_parallelism()`. `--num-workers 0` is a config error (not a silent fallback). Manifest gains a `num_workers` field; CLI output gains a `Workers` row.

## Falsifiers (contracts/apr-tokenize-parallel-bpe-v1.yaml v1.0.0 -> v1.1.0)

Status: PROPOSED -> ACTIVE.

| Falsifier | Property | Status |
|---|---|---|
| FALSIFY-APR-TOK-PAR-001 | byte-identity (1 worker vs N workers) | DISCHARGED (unit) |
| FALSIFY-APR-TOK-PAR-002 | 4-way speedup >= 0.8N | PARTIAL_OPERATIONAL_PENDING |
| FALSIFY-APR-TOK-PAR-003 | 8-way no-crash | DISCHARGED_BY_CONSTRUCTION |
| FALSIFY-APR-TOK-PAR-004 | `--help` advertises flag | DISCHARGED (integration) |
| FALSIFY-APR-TOK-PAR-005 | default = available_parallelism | DISCHARGED (unit) |
| FALSIFY-APR-TOK-PAR-006 | `--num-workers 0` errors | DISCHARGED (unit) |

## Test plan

- [x] `cargo test -p apr-cli --features training --lib commands::tokenize::tests::encode_corpus` — 4 inline tests pass (resolve_num_workers + 1-vs-4 byte-for-byte shard parity on a 10-doc fixture)
- [x] `cargo test -p apr-cli --features training --test falsification_apr_tok_par_004` — 2 integration tests pass (`--help` advertises `--num-workers`, docs default resolution)
- [x] `cargo test -p apr-cli --features training --test cli_commands` — 8 CLI registration tests pass
- [x] `cargo clippy -p apr-cli --features training --lib -- -D warnings` clean
- [x] `cargo fmt -p apr-cli -- --check` clean
- [x] `pv validate contracts/apr-tokenize-parallel-bpe-v1.yaml` — 0 errors, 0 warnings
- [ ] Operational: next live encode run discharges FALSIFY-APR-TOK-PAR-002 once wall-clock evidence <= 6h posts

## Files

- `crates/apr-cli/src/tokenize_commands.rs` — clap surface (`#[arg(long, value_name = "N")] num_workers: Option<usize>`)
- `crates/apr-cli/src/commands/tokenize.rs` — `resolve_num_workers` + chunked-rayon path; legacy single-thread path unchanged for `--num-workers 1`
- `crates/apr-cli/src/dispatch_analysis.rs` — wire the new field through the dispatch
- `crates/apr-cli/Cargo.toml` — `rayon = { workspace = true }`
- `crates/apr-cli/tests/falsification_apr_tok_par_004.rs` — new integration tests for the help surface
- `contracts/apr-tokenize-parallel-bpe-v1.yaml` — v1.0.0 -> v1.1.0 (PROPOSED -> ACTIVE), strategy revised to chunked rayon, falsifier statuses updated

Closes #1547.

🤖 Generated with [Claude Code](https://claude.com/claude-code)