### PR TITLE
docs(contracts): SHIP-007 §22 upstream RESOLVED — evidence pins on 5 MODEL-1 PARTIAL discharges

### DIFF
--- a/contracts/apr-model-qa-v1.yaml
+++ b/contracts/apr-model-qa-v1.yaml
@@ -1,5 +1,5 @@
 metadata:
-  version: 1.2.0
+  version: 1.3.0
   created: '2026-04-04'
   updated: '2026-04-22'
   author: PAIML Engineering
@@ -325,6 +325,9 @@ falsification_tests:
     RTX 4090 host producing 8 "pass": true entries. Algorithm-level
     rule is dischargeable offline; compute-heavy harness awaits
     SHIP-TWO-001 MODEL-1 post-ship evidence lane.
+    **Upstream blocker SHIP-007 §22 RESOLVED 2026-05-07** (aprender PR
+    #1550 squash `e856eb91f`; M-FFN-GGUF-5 fix); live discharge is now
+    dispatch-ready — no further upstream blockers.
 - id: FALSIFY-EX-001
   rule: Golden Output is a hard ship-blocker under --require-golden-output
   prediction: |

--- a/contracts/chat-template-v1.yaml
+++ b/contracts/chat-template-v1.yaml
@@ -1,5 +1,5 @@
 metadata:
-  version: "1.1.0"
+  version: "1.2.0"
   created: "2026-04-13"
   updated: "2026-04-22"
   author: PAIML Engineering
@@ -19,7 +19,7 @@ metadata:
 
 kind: AlgorithmContract
 name: chat-template
-version: "1.1.0"
+version: "1.2.0"
 scope: "crates/aprender-core/src/text/chat_template/ + crates/aprender-serve/src/chat/"
 
 description: |
@@ -83,6 +83,9 @@ falsification:
       spec-defined golden output. Algorithm-level rule is dischargeable
       offline; compute-heavy harness awaits SHIP-TWO-001 evidence
       collection lane.
+      **Upstream blocker SHIP-007 §22 RESOLVED 2026-05-07** (aprender PR
+      #1550 squash `e856eb91f`; M-FFN-GGUF-5 fix); live discharge is now
+      dispatch-ready — no further upstream blockers.
     counter_example_classes:
       - "empty render (engine crash / returned empty string)"
       - "missing trailing <|im_start|>assistant\\n generation prompt"

--- a/contracts/qwen2-e2e-verification-v1.yaml
+++ b/contracts/qwen2-e2e-verification-v1.yaml
@@ -1,5 +1,5 @@
 metadata:
-  version: 1.10.0
+  version: 1.11.0
   created: '2026-02-20'
   author: PAIML Engineering
   description: |
@@ -372,7 +372,12 @@ falsification_tests:
   full_discharge_blocks_on: |
     Live `apr run paiml/qwen2.5-coder-7b-apache-q4k-v1.safetensors --prompt
     "def fib(n):"` on RTX 4090 + `rustpython`/`ruff` AST parse of the emitted
-    completion; any parse error count > 0 is a ship-blocker.
+    completion; any parse error count > 0 is a ship-blocker. **Upstream
+    blocker SHIP-007 §22 RESOLVED 2026-05-07** (aprender PR #1550 squash
+    `e856eb91f`; M-FFN-GGUF-5 fix); per-tensor APR↔GGUF divergence at the
+    matvec kernel boundary closed via Q4K+Q8K dispatch in `forward_traced`;
+    layer-3 ratio = 1.245× → H1 CONFIRMED on canonical 7B teacher. Live
+    discharge is now dispatch-ready — no further upstream blockers.
   counter_example_classes:
   - regressed_sampling
   - widened_tolerance
@@ -421,6 +426,9 @@ falsification_tests:
     paiml/qwen2.5-coder-7b-apache-q4k-v1 --json` on RTX 4090 with
     --features cuda; median pass@1 across 3 seed=0 runs must be ≥
     86.00 (or ≥ 84.80 under spec's 1.2 pp noise allowance).
+    **Upstream blocker SHIP-007 §22 RESOLVED 2026-05-07** (aprender
+    PR #1550 squash `e856eb91f`; M-FFN-GGUF-5 fix); live discharge is
+    now dispatch-ready — no further upstream blockers.
   counter_example_classes:
   - "regressed_teacher: distilled checkpoint lost a quantization
     round-trip and HumanEval pass@1 fell from 87% to 82%"
@@ -461,6 +469,9 @@ falsification_tests:
     Live `apr bench --iterations 5 --max-tokens 128
     paiml/qwen2.5-coder-7b-apache-q4k-v1` on RTX 4090 with --features
     cuda; median of 5 iterations must be ≥ 30.0 tok/s.
+    **Upstream blocker SHIP-007 §22 RESOLVED 2026-05-07** (aprender
+    PR #1550 squash `e856eb91f`; M-FFN-GGUF-5 fix); live discharge is
+    now dispatch-ready — no further upstream blockers.
   counter_example_classes:
   - regressed_kernel
   - drifted_constant


### PR DESCRIPTION
## Summary

After M-FFN-GGUF-5 fix MERGED on aprender main 2026-05-07 ([PR #1550](https://github.com/paiml/aprender/pull/1550) squash `e856eb91f`), the §27 layer-3 ffn_swigl APR-vs-GGUF divergence is closed: live H1 CONFIRMED at layer-3 ratio 1.245× (was 18.23× pre-methodology-fix).

5 MODEL-1 PARTIAL discharges become **live-dispatch-ready**: SHIP-002, SHIP-005, SHIP-006, SHIP-007, SHIP-008.

## Pure additive YAML — no behavioral or test changes

| Contract | Version | ACs covered |
|---|---|---|
| `contracts/qwen2-e2e-verification-v1.yaml` | 1.10.0 → **1.11.0** | FALSIFY-QW2E-SHIP-002, FALSIFY-QW2E-SHIP-005, FALSIFY-QW2E-SHIP-007 |
| `contracts/apr-model-qa-v1.yaml` | 1.2.0 → **1.3.0** | FALSIFY-QA-SHIP-006 |
| `contracts/chat-template-v1.yaml` | 1.1.0 → **1.2.0** | GATE-CHAT-SHIP-008 |

Each contract's `full_discharge_blocks_on` clause now includes:

> **Upstream blocker SHIP-007 §22 RESOLVED 2026-05-07** (aprender PR #1550 squash `e856eb91f`; M-FFN-GGUF-5 fix); live discharge is now dispatch-ready — no further upstream blockers.

## What this does NOT do

This PR does NOT promote `PARTIAL_ALGORITHM_LEVEL → DISCHARGED` — that needs LIVE evidence files. Each individual discharge still requires its own LIVE run on RTX 4090 per the canonical command in `full_discharge_blocks_on` (`apr run` / `apr eval` / `apr bench` / `apr qa`).

## Companion work in parallel

Sub-agent is authoring `scripts/ship-discharges/ship-XXX-discharge.sh` dispatch scripts that an operator can run to do each LIVE discharge. Separate PR.

## Test plan

- [x] `pv validate contracts/qwen2-e2e-verification-v1.yaml` → 0 errors
- [x] `pv validate contracts/apr-model-qa-v1.yaml` → 0 errors
- [x] `pv validate contracts/chat-template-v1.yaml` → 0 errors
- [x] No code changes; production hot paths byte-unchanged
- [ ] CI ci/gate green
- [ ] Auto-merge once required checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)