### PR TITLE
fix(M-FFN-GGUF-5b): SHIP-007 §22 closure — QKV split-Q4K dispatch in forward_traced + production forward()

### DIFF
--- a/crates/aprender-serve/src/apr_transformer/inference.rs
+++ b/crates/aprender-serve/src/apr_transformer/inference.rs
@@ -96,8 +96,23 @@ impl AprTransformer {
             );
 
             // 2b. QKV projection
+            // M-FFN-GGUF-5b / SHIP-007 §22 closure: split-Q4K QKV when the
+            // q4k_layer has separate attn_q/k/v Q4K bytes (matches GGUF
+            // Q4K+Q8K matvec semantics like the rest of `forward_traced` and
+            // mirrors `project_qkv_fused`). F32 fallback otherwise.
             let qkv_dim = layer.qkv_weight.len() / hidden_dim;
-            let mut qkv = self.matmul(&normed, &layer.qkv_weight, hidden_dim, qkv_dim);
+            let head_dim_pre = hidden_dim / self.config.num_heads;
+            let kv_size_pre = self.config.num_kv_heads * head_dim_pre;
+            let seq_len_pre = token_ids.len();
+            let mut qkv = self.qkv_split_q4k_traced(
+                &normed,
+                q4k_layer,
+                &layer.qkv_weight,
+                seq_len_pre,
+                hidden_dim,
+                kv_size_pre,
+                qkv_dim,
+            );
             emit(SaveTensorStage::QkvMatmul, layer_idx as u32, &qkv)?;
             if let Some(ref bias) = layer.qkv_bias {
                 self.add_bias(&mut qkv, bias);

--- a/crates/aprender-serve/src/apr_transformer/mod_apr_transformer.rs
+++ b/crates/aprender-serve/src/apr_transformer/mod_apr_transformer.rs
@@ -172,6 +172,77 @@ impl AprTransformer {
         helpers::f32_matmul(input, f32_weight, in_dim, out_dim)
     }
 
+    /// M-FFN-GGUF-5b / SHIP-007 §22 closure: split-Q4K QKV projection for the
+    /// multi-token traced/forward paths.
+    ///
+    /// When `q4k_layer` exposes separate `attn_q_weight` / `attn_k_weight` /
+    /// `attn_v_weight{,_q6k}` Q4K bytes (matching the production decode
+    /// `forward_with_cache` storage layout), this helper computes Q, K, V
+    /// independently across all sequence positions via `seq_matmul_q4k` /
+    /// `seq_matmul_q6k`, then re-interleaves per-token to produce the fused
+    /// `[Q_pos | K_pos | V_pos]` layout that the downstream RoPE +
+    /// attention code expects (mirrors the F32 fused QKV matmul output of
+    /// `f32_matmul(normed, qkv_weight, hidden_dim, qkv_dim)`).
+    ///
+    /// Mirrors `project_qkv_fused`'s semantics (single-token decode) at
+    /// sequence granularity. Falls back to fused F32 matmul when any Q
+    /// or K bytes are missing (V can be Q6K).
+    ///
+    /// Closes the 8th `forward_traced` / `forward()` matmul site that M-FFN-GGUF-5
+    /// (PR #1550) left as F32 fallback because Q4K storage splits Q/K/V into
+    /// separate arrays while APR uses a fused F32 `qkv_weight` array.
+    #[allow(clippy::unused_self)]
+    #[allow(clippy::too_many_arguments)]
+    fn qkv_split_q4k_traced(
+        &self,
+        normed: &[f32],
+        q4k_layer: Option<&Q4KLayerWeights>,
+        fused_f32_weight: &[f32],
+        seq_len: usize,
+        hidden_dim: usize,
+        kv_size: usize,
+        qkv_dim: usize,
+    ) -> Vec<f32> {
+        // Try Q4K-split path: requires separate attn_q + attn_k bytes;
+        // V may be Q4K or Q6K (Q6K used for high-precision V on some 7B
+        // qwen2.5 quantizations — mirrors `select_q4k_q6k` cascade).
+        if let Some(q4k) = q4k_layer {
+            let q_b = q4k.attn_q_weight.as_deref();
+            let k_b = q4k.attn_k_weight.as_deref();
+            let v_q4k = q4k.attn_v_weight.as_deref();
+            let v_q6k = q4k.attn_v_weight_q6k.as_deref();
+
+            if let (Some(qb), Some(kb)) = (q_b, k_b) {
+                let q_out = Self::seq_matmul_q4k(qb, normed, seq_len, hidden_dim, hidden_dim).ok();
+                let k_out = Self::seq_matmul_q4k(kb, normed, seq_len, kv_size, hidden_dim).ok();
+                // V: prefer Q4K, fall back to Q6K.
+                let v_out = if let Some(vb) = v_q4k {
+                    Self::seq_matmul_q4k(vb, normed, seq_len, kv_size, hidden_dim).ok()
+                } else if let Some(vb) = v_q6k {
+                    Self::seq_matmul_q6k(vb, normed, seq_len, kv_size, hidden_dim).ok()
+                } else {
+                    None
+                };
+                if let (Some(q), Some(k), Some(v)) = (q_out, k_out, v_out) {
+                    let mut qkv = vec![0.0f32; seq_len * qkv_dim];
+                    for s in 0..seq_len {
+                        let qkv_off = s * qkv_dim;
+                        qkv[qkv_off..qkv_off + hidden_dim]
+                            .copy_from_slice(&q[s * hidden_dim..(s + 1) * hidden_dim]);
+                        qkv[qkv_off + hidden_dim..qkv_off + hidden_dim + kv_size]
+                            .copy_from_slice(&k[s * kv_size..(s + 1) * kv_size]);
+                        qkv[qkv_off + hidden_dim + kv_size
+                            ..qkv_off + hidden_dim + 2 * kv_size]
+                            .copy_from_slice(&v[s * kv_size..(s + 1) * kv_size]);
+                    }
+                    return qkv;
+                }
+            }
+        }
+        // F32 fused fallback: matches existing legacy semantics byte-for-byte.
+        helpers::f32_matmul(normed, fused_f32_weight, hidden_dim, qkv_dim)
+    }
+
     /// Add bias in-place (delegates to helpers module)
     #[allow(clippy::unused_self)]
     fn add_bias(&self, data: &mut [f32], bias: &[f32]) {

--- a/crates/aprender-serve/src/apr_transformer/pmat-260.rs
+++ b/crates/aprender-serve/src/apr_transformer/pmat-260.rs
@@ -326,9 +326,24 @@ impl AprTransformer {
             );
 
             // 2b. QKV projection
+            // M-FFN-GGUF-5b / SHIP-007 §22 closure: split-Q4K QKV when the
+            // q4k_layer has separate attn_q/k/v Q4K bytes (matches GGUF
+            // Q4K+Q8K matvec semantics; mirrors `forward_with_cache` ↔
+            // `project_qkv_fused`). F32 fallback otherwise.
             // Calculate qkv_dim from actual weight size (handles GQA models)
             let qkv_dim = layer.qkv_weight.len() / hidden_dim;
-            let mut qkv = self.matmul(&normed, &layer.qkv_weight, hidden_dim, qkv_dim);
+            let head_dim_pre = hidden_dim / self.config.num_heads;
+            let kv_size_pre = self.config.num_kv_heads * head_dim_pre;
+            let seq_len_pre = token_ids.len();
+            let mut qkv = self.qkv_split_q4k_traced(
+                &normed,
+                q4k_layer,
+                &layer.qkv_weight,
+                seq_len_pre,
+                hidden_dim,
+                kv_size_pre,
+                qkv_dim,
+            );
             if let Some(ref bias) = layer.qkv_bias {
                 self.add_bias(&mut qkv, bias);
             }


### PR DESCRIPTION
## Summary

Closes the 8th (final) F32-fallback matmul site that M-FFN-GGUF-5 (PR #1550) left as a fused F32 matmul because Q4K storage splits Q/K/V into separate `attn_q_weight` / `attn_k_weight` / `attn_v_weight{,_q6k}` arrays while APR uses a fused F32 `qkv_weight` array.

After this PR, **BOTH** `forward_traced` (inference.rs) **AND** production `forward()` (pmat-260.rs) use the Q4K-split QKV path when `q4k_layer` is available, mirroring the production decode `forward_with_cache` ↔ `project_qkv_fused` semantics at sequence (multi-token) granularity.

## What changes

### New helper: `qkv_split_q4k_traced` (mod_apr_transformer.rs)

Computes Q, K, V independently across all sequence positions via `seq_matmul_q4k` / `seq_matmul_q6k`, then re-interleaves per-token to produce the fused `[Q_pos | K_pos | V_pos]` layout that the downstream RoPE + attention code expects.

V supports the Q4K → Q6K cascade (mirrors `select_q4k_q6k`).

Falls back to fused F32 matmul when any required Q or K bytes are missing.

### Two call-site swaps

1. `forward_traced` in `inference.rs:99-100` — swap fused F32 matmul → `qkv_split_q4k_traced`
2. Production `forward()` in `pmat-260.rs:330-331` — same swap on the production hot path used by `apr run` for prompt processing

## Empirical verification

### Build + lib tests

```
cargo build -p aprender-serve → clean compile
cargo test -p aprender-serve --lib → 15233 passed; 0 failed
cargo test -p aprender-serve --lib determinism_tests → 10 passed (M91-M101)
```

### LIVE on canonical 7B (lambda-vector RTX 4090, 180s)

```
cargo test -p aprender-serve --test ffn_gguf_apr_layer_3_swigl_diff \
    -- --include-ignored --nocapture
```

**Layer-3 ratio = 1.2059** (in [0.5, 2.0] H1 band; tighter than M-FFN-GGUF-5's prior 1.245× reading).

```
layer | apr.ffn_swigl.std | gguf.ffn_swigl.std | ratio (apr/gguf)
------|-------------------|--------------------|-----------------
L00   | 0.077376          | 0.079255           | 0.9763
L01   | 0.050151          | 0.044786           | 1.1198
L02   | 0.044975          | 0.063019           | 0.7137
L03   | 0.080802          | 0.067006           | 1.2059  ← H1 BAND
...
L27   | 1.187084          | 1.532710           | 0.7745

verdict: H1 CONFIRMED — APR layer-3 ffn_swigl matches GGUF apples-to-apples
```

All 28 layers' last-token-only `ffn_swigl` std now lands within the H1 band [0.5, 2.0].

## Test plan

- [x] `cargo build -p aprender-serve` → clean
- [x] `cargo test -p aprender-serve --lib` → 15233 passed
- [x] `cargo test -p aprender-serve --lib determinism_tests` → 10 passed (M91-M101)
- [x] LIVE 7B teacher layer-3 ffn_swigl diff → **H1 CONFIRMED** (ratio 1.2059)
- [x] Production hot path coverage: `pmat-260.rs forward()` uses `qkv_split_q4k_traced` when q4k_layer is present (`apr run` prompt processing)
- [x] F32-only fallback unchanged when q4k_layer is None or Q/K bytes are absent

Refs SHIP-007 §22, M-FFN-GGUF-5 (#1550), M91-M101 + M-FFN-GGUF-7 cascade, FALSIFY-FFN-GGUF-003 H1 verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)