### PR TITLE
chore(contracts): add kani_harnesses.bound: 4 to 11 policy-style contracts (PV-VAL-001 SCHEMA-012)

### DIFF
--- a/contracts/apr-cli-dep-migration-v1.yaml
+++ b/contracts/apr-cli-dep-migration-v1.yaml
@@ -54,6 +54,7 @@ kani_harnesses:
 - id: KH-DEPMIG-001
   obligation: no_old_dep_names
   property: all_deps_use_new_names
+  bound: 4
 
 verification_summary:
   total_obligations: 2

--- a/contracts/apr-cli-publish-v1.yaml
+++ b/contracts/apr-cli-publish-v1.yaml
@@ -78,6 +78,7 @@ kani_harnesses:
 - id: KH-PUB-CLI-001
   obligation: no_cyclic_resolution
   property: acyclic_dep_graph
+  bound: 4
 
 verification_summary:
   total_obligations: 4

--- a/contracts/apr-cli-qa-v1.yaml
+++ b/contracts/apr-cli-qa-v1.yaml
@@ -184,6 +184,7 @@ kani_harnesses:
 - id: KH-QA-001
   obligation: help_universality
   property: all_commands_respond_to_help
+  bound: 4
 
 verification_summary:
   total_obligations: 10

--- a/contracts/apr-cli-safety-v1.yaml
+++ b/contracts/apr-cli-safety-v1.yaml
@@ -67,6 +67,7 @@ kani_harnesses:
 - id: KH-CLI-001
   obligation: validate_exit_code
   property: exit_code_nonzero_on_failure
+  bound: 4
 verification_summary:
   total_obligations: 4
   l2_property_tested: 4

--- a/contracts/apr-docs-v1.yaml
+++ b/contracts/apr-docs-v1.yaml
@@ -91,6 +91,7 @@ kani_harnesses:
 - id: KH-DOCS-001
   obligation: readme_install_command
   property: install_produces_apr_binary
+  bound: 4
 
 verification_summary:
   total_obligations: 5

--- a/contracts/crate-hygiene-v1.yaml
+++ b/contracts/crate-hygiene-v1.yaml
@@ -120,6 +120,7 @@ kani_harnesses:
 - id: KH-HYGIENE-001
   obligation: workspace_version_inheritance
   property: all_crates_inherit_workspace_version
+  bound: 4
 
 verification_summary:
   total_obligations: 5

--- a/contracts/crate-readme-v1.yaml
+++ b/contracts/crate-readme-v1.yaml
@@ -54,6 +54,7 @@ kani_harnesses:
 - id: KH-README-001
   obligation: readme_exists
   property: all_crates_have_readme
+  bound: 4
 
 verification_summary:
   total_obligations: 2

--- a/contracts/hero-svg-v1.yaml
+++ b/contracts/hero-svg-v1.yaml
@@ -61,6 +61,7 @@ kani_harnesses:
 - id: KH-SVG-001
   obligation: text_within_bounds
   property: no_text_overflow
+  bound: 4
 
 verification_summary:
   total_obligations: 3

--- a/contracts/ratatui-migration-v1.yaml
+++ b/contracts/ratatui-migration-v1.yaml
@@ -81,6 +81,7 @@ kani_harnesses:
 - id: KH-RATATUI-001
   obligation: zero_ratatui_deps
   property: no_ratatui_anywhere
+  bound: 4
 
 verification_summary:
   total_obligations: 4

--- a/contracts/repo-filesystem-v1.yaml
+++ b/contracts/repo-filesystem-v1.yaml
@@ -98,6 +98,7 @@ kani_harnesses:
 - id: KH-FS-001
   obligation: allowed_root_files
   property: no_cruft_at_root
+  bound: 4
 
 verification_summary:
   total_obligations: 6

--- a/contracts/unified-specs-v1.yaml
+++ b/contracts/unified-specs-v1.yaml
@@ -76,6 +76,7 @@ kani_harnesses:
 - id: KH-SPECS-001
   obligation: single_toc
   property: toc_covers_all_specs
+  bound: 4
 
 verification_summary:
   total_obligations: 3


### PR DESCRIPTION
## Summary

After reinstalling `pv` from in-tree source (v0.3.1 → v0.32.0), `pv lint contracts/` reported 0 errors / 870 warnings. 11 of those warnings (SCHEMA-012) were `kani_harnesses` entries missing the required `bound:` field.

## Fix

Add `bound: 4` to each of 11 policy-style kani_harnesses (no loops to unwind).

| Contract | Harness | Property |
|---|---|---|
| `apr-cli-dep-migration-v1.yaml` | KH-DEPMIG-001 | dep-name renames |
| `apr-cli-publish-v1.yaml` | KH-PUB-CLI-001 | acyclic dep graph |
| `apr-cli-qa-v1.yaml` | KH-QA-001 | help universality |
| `apr-cli-safety-v1.yaml` | KH-CLI-001 | exit-code-nonzero |
| `apr-docs-v1.yaml` | KH-DOCS-001 | install produces apr |
| `crate-hygiene-v1.yaml` | KH-HYGIENE-001 | workspace version inheritance |
| `crate-readme-v1.yaml` | KH-README-001 | all crates have README |
| `hero-svg-v1.yaml` | KH-SVG-001 | text within bounds |
| `ratatui-migration-v1.yaml` | KH-RATATUI-001 | no ratatui anywhere |
| `repo-filesystem-v1.yaml` | KH-FS-001 | no cruft at root |
| `unified-specs-v1.yaml` | KH-SPECS-001 | single TOC |

`bound: 4` is the conventional kani default for predicate-only checks (matches existing entries in `apr-cli-operations-v1.yaml`, `apr-chat-session-v1.yaml`). Higher bounds (8/16/32) are reserved for contracts with explicit loops.

## Result

```
pv lint contracts/
before: 0 errors, 870 warnings (11 SCHEMA-012)
after:  0 errors, 859 warnings (0 SCHEMA-012)
```

Pure additive YAML; no behavioral or test changes; no `metadata.version` bumps (hygiene patch).

## Test plan

- [x] `pv lint contracts/` after fix → 0 SCHEMA-012 warnings
- [x] No code or test changes
- [ ] CI ci/gate green
- [ ] Auto-merge once required checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)