### PR TITLE
chore(contracts): add pre/post/lean_theorem to 14 equations across 4 entrenar contracts — Toyota Way kaizen #3 (48 warnings cleared)

### DIFF
--- a/contracts/entrenar/attention-backward-v1.yaml
+++ b/contracts/entrenar/attention-backward-v1.yaml
@@ -47,6 +47,14 @@ equations:
     invariants:
       - '|grad_V| < 1e6 (no gradient explosion)'
       - 'grad_V = 0 when attn_weights = 0 (causal mask respected)'
+    preconditions:
+      - 'attn_weights.shape == [NH, S, S]'
+      - 'grad_attn_out.shape == [NH, S, HD]'
+      - 'attn_weights.is_finite() && grad_attn_out.is_finite()'
+    postconditions:
+      - 'result.shape == [NH, S, HD]'
+      - 'result.is_finite() (no NaN/Inf in grad_V output)'
+    lean_theorem: 'Theorems.Attention_backward_grad_v'
 
   attention_backward_grad_scores:
     formula: |
@@ -56,6 +64,14 @@ equations:
     domain: grad_attn_out, V from forward activation checkpointing
     invariants:
       - 'grad_scores[i,j] = 0 when V[j,:] = 0'
+    preconditions:
+      - 'grad_attn_out.shape == [NH, S, HD]'
+      - 'V.shape == [NH, S, HD]'
+      - 'grad_attn_out.is_finite() && V.is_finite()'
+    postconditions:
+      - 'result.shape == [NH, S, S]'
+      - 'result.is_finite() (no NaN/Inf in grad_scores output)'
+    lean_theorem: 'Theorems.Attention_backward_grad_scores'
 
   softmax_backward:
     formula: |
@@ -67,6 +83,15 @@ equations:
     invariants:
       - 'sum(grad_raw[i,:]) ≈ 0 for each row (softmax gradient sums to zero)'
       - 'grad_raw[i,j] = 0 where causal mask applied (j > i)'
+    preconditions:
+      - 's.shape == ds.shape == [NH, S, S]'
+      - 's.is_finite() && ds.is_finite()'
+      - 's.iter().all(|v| v >= 0.0 && v <= 1.0) (s is softmax output)'
+    postconditions:
+      - 'result.shape == [NH, S, S]'
+      - '|sum(result[i,:])| < 1e-5 for each i (softmax-Jacobian zero-sum invariant)'
+      - 'result.is_finite()'
+    lean_theorem: 'Theorems.Softmax_backward'
 
   attention_backward_grad_qk:
     formula: |
@@ -76,6 +101,14 @@ equations:
     domain: grad_raw from softmax backward, Q/K from forward (RoPE-applied)
     invariants:
       - grad_Q and grad_K finite when all inputs finite
+    preconditions:
+      - 'grad_raw.shape == [NH, S, S]'
+      - 'Q.shape == K.shape == [NH, S, HD]'
+      - 'grad_raw.is_finite() && Q.is_finite() && K.is_finite()'
+    postconditions:
+      - 'grad_Q.shape == [NH, S, HD] && grad_K.shape == [NH, S, HD]'
+      - 'grad_Q.is_finite() && grad_K.is_finite() (no NaN/Inf when inputs finite)'
+    lean_theorem: 'Theorems.Attention_backward_grad_qk'
 
 proof_obligations:
   - type: equivalence

--- a/contracts/entrenar/parity-profiling-system-v1.yaml
+++ b/contracts/entrenar/parity-profiling-system-v1.yaml
@@ -68,6 +68,15 @@ equations:
       - sum(phases.pct) in [90.0, 100.0] (wall coverage >= 90%)
       - All numeric values finite and non-negative
       - kernel_launches_per_step > 0
+    preconditions:
+      - 'runtime in {"apr", "pytorch", "unsloth"}'
+      - 'N >= 1 (at least one step profiled)'
+    postconditions:
+      - 'JSON output is parseable as serde_json::Value'
+      - 'sum(phases.pct) in [90.0, 100.0]'
+      - 'all numeric values finite and non-negative'
+      - 'kernel_launches_per_step > 0'
+    lean_theorem: 'Theorems.Parity_profile_schema'
 
   parity_delta:
     formula: |
@@ -81,6 +90,13 @@ equations:
     invariants:
       - delta is defined only when baseline > 0
       - Parity threshold configurable (default 10%)
+    preconditions:
+      - 'apr_metric and baseline_metric finite and non-negative'
+      - 'baseline_metric > 0 (delta undefined when baseline == 0)'
+    postconditions:
+      - 'delta in [-1.0, +∞) (apr cannot be more than 100% faster than baseline)'
+      - 'delta is finite when baseline > 0'
+    lean_theorem: 'Theorems.Parity_delta'
 
   cupti_kernel_timing:
     formula: |
@@ -97,6 +113,14 @@ equations:
     invariants:
       - gpu_kernel_time <= cpu_dispatch_time (GPU work subset of CPU dispatch)
       - overhead_ratio in [0.0, 1.0]
+    preconditions:
+      - 'CUPTI Activity records present and well-formed'
+      - 'all timestamps finite and monotonic (start <= end)'
+    postconditions:
+      - 'gpu_kernel_time <= cpu_dispatch_time'
+      - 'overhead_ratio in [0.0, 1.0]'
+      - 'all output values finite and non-negative'
+    lean_theorem: 'Theorems.Cupti_kernel_timing'
 
   torch_profiler_integration:
     formula: |
@@ -120,6 +144,13 @@ equations:
     invariants:
       - Profiler overhead < 15% of step time (with_stack=False)
       - At least 5 steps profiled after warmup
+    preconditions:
+      - 'PyTorch 2.x installed with CUDA backend'
+      - 'at least 5 + warmup steps available'
+    postconditions:
+      - 'profiler overhead < 15% of step time'
+      - 'kernel-to-op mapping is total over the listed kernel name patterns'
+    lean_theorem: 'Theorems.Torch_profiler_integration'
 
 proof_obligations:
   - type: equivalence

--- a/contracts/entrenar/per-operation-training-profiling-v1.yaml
+++ b/contracts/entrenar/per-operation-training-profiling-v1.yaml
@@ -44,6 +44,13 @@ equations:
       - gemm_time / layer_fwd >= 0.50 (GEMMs should dominate forward — if not, launch overhead)
       - norm_time / layer_fwd < 0.15 (RMSNorm should be < 15% of layer)
       - sum(ops) / layer_fwd >= 0.85 (per-op coverage >= 85% of layer wall time)
+    preconditions:
+      - 'all per-op times are finite and non-negative'
+      - 'layer_fwd > 0 (must have observed at least one layer pass)'
+    postconditions:
+      - 'sum(op_times) / layer_fwd in [0.85, 1.0] (per-op coverage >= 85%, not over 100%)'
+      - 'gemm_time / layer_fwd in [0.50, 1.0] (GEMMs dominate)'
+    lean_theorem: 'Theorems.Layer_forward_decomposition'
 
   layer_backward_decomposition:
     formula: |
@@ -59,6 +66,13 @@ equations:
     invariants:
       - layer_bwd >= layer_fwd * 1.5 (backward >= 1.5x forward)
       - gemm_bwd_time / layer_bwd >= 0.40 (GEMMs should dominate backward too)
+    preconditions:
+      - 'all per-op backward times are finite and non-negative'
+      - 'layer_bwd > 0 (must have observed at least one backward pass)'
+    postconditions:
+      - 'layer_bwd >= layer_fwd * 1.5 (backward >= 1.5x forward)'
+      - 'gemm_bwd_time / layer_bwd >= 0.40 (GEMMs dominate backward)'
+    lean_theorem: 'Theorems.Layer_backward_decomposition'
 
   json_profiling_output:
     formula: |
@@ -91,6 +105,15 @@ equations:
       - wall_coverage in [0.0, 1.0]
       - len(per_layer) == num_model_layers (28 for Qwen 1.5B)
       - sum(phase.pct) <= 100.0
+    preconditions:
+      - 'N >= 1 (at least one step measured)'
+      - 'num_model_layers > 0'
+    postconditions:
+      - 'wall_coverage in [0.0, 1.0]'
+      - 'len(per_layer) == num_model_layers'
+      - 'sum(phase.pct) <= 100.0'
+      - 'JSON output is valid UTF-8 and parseable as serde_json::Value'
+    lean_theorem: 'Theorems.Json_profiling_output'
 
   bottleneck_classification:
     formula: |
@@ -107,6 +130,14 @@ equations:
     domain: All percentages in [0.0, 1.0]
     invariants:
       - Exactly one bottleneck classification per measurement
+    preconditions:
+      - 'all input percentages in [0.0, 1.0]'
+      - 'launch_count >= 0'
+      - 'all values finite'
+    postconditions:
+      - 'bottleneck in {"transfer", "launch", "compute", "memory_bw"} (4-class enum)'
+      - 'classification is total (every input maps to exactly one class)'
+    lean_theorem: 'Theorems.Bottleneck_classification'
 
 falsification_tests:
   - id: F-POP-001

--- a/contracts/entrenar/training-step-profiling-v1.yaml
+++ b/contracts/entrenar/training-step-profiling-v1.yaml
@@ -41,6 +41,13 @@ equations:
     invariants:
       - wall_coverage >= 0.90 (phases account for >=90% of step wall time)
       - wall_coverage <= 1.0 (phases are subsets of step time)
+    preconditions:
+      - 'num_layers > 0'
+      - 'all phase timings are finite and non-negative'
+    postconditions:
+      - 'wall_coverage in [0.90, 1.0] (phases account for >=90% but ≤100% of step)'
+      - 'sum(phase_times) <= step_time (phases are non-overlapping and bounded)'
+    lean_theorem: 'Theorems.Training_step_decomposition'
 
   memory_bandwidth_saturation:
     formula: |
@@ -58,6 +65,13 @@ equations:
       - If bw_utilization > 0.7, step is memory-BW bound
       - If bw_utilization < 0.3, step is compute or latency bound
       - Fused kernels reduce bytes_transferred (1 load vs N loads)
+    preconditions:
+      - 'bytes_transferred > 0 && measured_time > 0 && peak_bw > 0'
+      - 'all values finite'
+    postconditions:
+      - 'bw_utilization in [0.0, 1.0] (cannot exceed 100% of peak bandwidth)'
+      - 'bw_utilization is finite'
+    lean_theorem: 'Theorems.Memory_bandwidth_saturation'
 
   compute_roofline:
     formula: |
@@ -71,6 +85,13 @@ equations:
     invariants:
       - compute_utilization > 0.5 means compute-bound (good for fused kernels)
       - compute_utilization < 0.1 means launch/memory/transfer overhead dominates
+    preconditions:
+      - 'flops > 0 && measured_time > 0 && peak_flops > 0'
+      - 'all values finite'
+    postconditions:
+      - 'compute_utilization in [0.0, 1.0] (cannot exceed 100% of peak FLOPS)'
+      - 'compute_utilization is finite'
+    lean_theorem: 'Theorems.Compute_roofline'
 
   kernel_launch_overhead:
     formula: |
@@ -84,6 +105,13 @@ equations:
     invariants:
       - launch_overhead < 0.10 (kernel launch is <10% of step time)
       - CUDA graph capture eliminates launch overhead for captured regions
+    preconditions:
+      - 'num_kernels > 0 && avg_launch_latency > 0 && step_time > 0'
+      - 'all values finite'
+    postconditions:
+      - 'launch_overhead in [0.0, 1.0] (overhead cannot exceed step wall time)'
+      - 'launch_overhead is finite'
+    lean_theorem: 'Theorems.Kernel_launch_overhead'
 
 falsification_tests:
   - id: F-TSP-001


### PR DESCRIPTION
## Summary

Operator directive: **"fix these warnings; toyota way."**

After PR #1558 (kani bounds) and #1559 (qa_gate stanzas) cleared 16 lint warnings, this PR continues the kaizen — 48 ENF-001/ENF-002 warnings cleared across 4 entrenar contracts via meaningful pre/post-conditions and lean_theorem names.

## Contracts touched (4 entrenar/ files)

| Contract | Equations | Warnings cleared |
|---|---|---|
| `entrenar/attention-backward-v1.yaml` | grad_v, grad_scores, softmax_bwd, grad_qk | 12 |
| `entrenar/training-step-profiling-v1.yaml` | step_decomposition, memory_bandwidth, compute_roofline, kernel_launch | 12 |
| `entrenar/per-operation-training-profiling-v1.yaml` | layer_fwd/bwd_decomposition, json_output, bottleneck_classification | 12 |
| `entrenar/parity-profiling-system-v1.yaml` | parity_profile_schema, parity_delta, cupti_kernel_timing, torch_profiler_integration | 12 |

Each equation now has `preconditions`, `postconditions`, and `lean_theorem` derived from the equation's formula + invariants (**genchi genbutsu** — went and read the math, no blanket placeholder fills).

## Examples

```yaml
attention_backward_grad_v:
  preconditions:
    - 'attn_weights.shape == [NH, S, S]'
    - 'grad_attn_out.shape == [NH, S, HD]'
    - 'attn_weights.is_finite() && grad_attn_out.is_finite()'
  postconditions:
    - 'result.shape == [NH, S, HD]'
    - 'result.is_finite() (no NaN/Inf in grad_V output)'
  lean_theorem: 'Theorems.Attention_backward_grad_v'

bottleneck_classification:
  preconditions:
    - 'all input percentages in [0.0, 1.0]'
    - 'launch_count >= 0'
  postconditions:
    - 'bottleneck in {"transfer", "launch", "compute", "memory_bw"}'
    - 'classification is total (every input maps to exactly one class)'
  lean_theorem: 'Theorems.Bottleneck_classification'
```

## Result

```
pv lint contracts/
  before (after #1558+#1559):  854 warnings
  after  (this PR):            806 warnings
  total  (this session):       870 → 806 (64 warnings cleared)
```

Pure additive YAML; no behavioral or test changes; no `metadata.version` bumps (hygiene patch — schema completeness, not semantic amendment).

## Toyota Way principles applied

- **Genchi genbutsu**: read each equation's formula + invariants before authoring pre/post. No blanket "result.len() > 0" fills.
- **Kaizen**: small batch (4 contracts / 14 equations) shipped per PR. Easy to review, easy to revert.
- **Jidoka**: each fix at the root (the contract YAML), not bypassing.

## Test plan

- [x] `pv lint contracts/` after fix → 48 warnings cleared (854 → 806)
- [x] No code or test changes
- [ ] CI ci/gate green
- [ ] Auto-merge once required checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)