### PR TITLE
chore(contracts): pre/post/lean_theorem on 3 more contracts — Toyota Way kaizen #4 (29 warnings cleared)

### DIFF
--- a/contracts/nf4-fused-gate-up-swiglu-v1.yaml
+++ b/contracts/nf4-fused-gate-up-swiglu-v1.yaml
@@ -28,6 +28,14 @@ equations:
     codomain: out ∈ ℝ^{intermediate}
     constants:
       epsilon: 1.0e-5
+    preconditions:
+      - 'x.shape == [hidden]; gamma.shape == [hidden]'
+      - 'W_gate.shape == W_up.shape == [intermediate, hidden]'
+      - 'x finite; gamma finite; epsilon > 0'
+    postconditions:
+      - 'out.shape == [intermediate]; out is finite'
+      - '4 kernel launches; 3 intermediate DRAM roundtrips'
+    lean_theorem: 'Theorems.Separate_ffn'
 
   fused_rmsnorm_gate_up_swiglu_nf4:
     formula: |
@@ -55,8 +63,13 @@ equations:
     preconditions:
     - hidden divisible by 64 (NF4 block alignment)
     - intermediate divisible by warp_size
+    - 'x finite; gamma finite; epsilon > 0'
     postconditions:
     - out element-wise matches separate_ffn within tolerance
+    - 'out.shape == [intermediate]; out is finite'
+    - 'DRAM reads of x == 1 (vs 3 in separate path)'
+    - '1 kernel launch (vs 4 in separate path)'
+    lean_theorem: 'Theorems.Fused_rmsnorm_gate_up_swiglu_nf4'
 
   bandwidth_savings:
     formula: |
@@ -78,6 +91,12 @@ equations:
         Per layer = 119 KB saved
         Per forward (28 layers) = 3.3 MB saved
     domain: bytes
+    preconditions:
+      - 'hidden > 0 && intermediate > 0'
+    postconditions:
+      - 'savings == hidden * 8 + intermediate * 12 (bytes)'
+      - 'savings > 0 (fused path always saves bandwidth vs separate)'
+    lean_theorem: 'Theorems.Bandwidth_savings'
     constants:
       qwen_hidden: 1536
       qwen_intermediate: 8960

--- a/contracts/nf4-fused-qkv-gemm-v1.yaml
+++ b/contracts/nf4-fused-qkv-gemm-v1.yaml
@@ -27,6 +27,15 @@ equations:
       qwen_hidden: 1536
       qwen_q_dim: 1536
       qwen_kv_dim: 256
+    preconditions:
+      - 'A.shape == [M, K]; M > 0 && K > 0'
+      - 'W_q_nf4.shape == [K, q_dim]; W_k_nf4.shape == [K, kv_dim]; W_v_nf4.shape == [K, kv_dim]'
+      - 'A is finite'
+    postconditions:
+      - 'q.shape == [M, q_dim]; k.shape == [M, kv_dim]; v.shape == [M, kv_dim]'
+      - 'q, k, v all finite when A is finite'
+      - 'DRAM reads of A == 3 (one per projection)'
+    lean_theorem: 'Theorems.Separate_qkv'
 
   fused_qkv:
     formula: |
@@ -42,8 +51,13 @@ equations:
     preconditions:
     - K dim == V dim (required for fused K+V)
     - hidden_size divisible by 64 (NF4 block alignment)
+    - 'A.shape == [M, K]; M > 0 && K > 0; A is finite'
     postconditions:
     - q, k, v element-wise match separate within tolerance
+    - 'q.shape == [M, q_dim]; k.shape == v.shape == [M, kv_dim]'
+    - 'DRAM reads of A == 2 (Q path + KV path; bandwidth saved vs separate path)'
+    - 'fused_kv element-wise matches [separate_k, separate_v] within ε=1e-4'
+    lean_theorem: 'Theorems.Fused_qkv'
 
   bandwidth_savings:
     formula: |
@@ -55,6 +69,12 @@ equations:
         savings = 2048 × 1536 × 4 = 12.6 MB per layer
         Per forward (28 layers) = 352 MB saved
     domain: bytes
+    preconditions:
+      - 'M > 0 && K > 0'
+    postconditions:
+      - 'savings == M × K × 4 bytes (33% reduction in input reads)'
+      - 'savings > 0'
+    lean_theorem: 'Theorems.Bandwidth_savings'
 
 proof_obligations:
 - type: equivalence

--- a/contracts/probar/training-step-scorecard-v1.yaml
+++ b/contracts/probar/training-step-scorecard-v1.yaml
@@ -57,6 +57,15 @@ equations:
       - 'efficiency in [0.0, 1.0]'
       - 'grade is monotonically non-decreasing with efficiency'
       - 'grade boundary thresholds are configurable'
+    preconditions:
+      - 'StepProfiler JSON is valid serde_json::Value'
+      - 'avg_step_ms > 0 && tokens_per_step > 0 && hardware_peak_bw > 0'
+      - 'all numeric inputs finite'
+    postconditions:
+      - 'efficiency in [0.0, 1.0]'
+      - 'grade in {"A", "B", "C", "D", "F"}'
+      - 'efficiency_a >= efficiency_b implies grade(a) >= grade(b)'
+    lean_theorem: 'Theorems.Training_efficiency_grade'
 
   bottleneck_classification:
     formula: |
@@ -76,6 +85,14 @@ equations:
     invariants:
       - 'Exactly one classification per measurement'
       - 'Classification thresholds are configurable'
+    preconditions:
+      - 'all per-op timings finite and non-negative'
+      - 'step_time > 0'
+      - 'compute_util in [0.0, 1.0]'
+    postconditions:
+      - 'bottleneck in {"transfer", "launch", "compute", "memory_bw"}'
+      - 'classification is total (every input maps to exactly one class)'
+    lean_theorem: 'Theorems.Bottleneck_classification'
 
   forward_backward_ratio:
     formula: |
@@ -94,6 +111,15 @@ equations:
     invariants:
       - 'ratio >= 0.0'
       - 'Layers with NaN backward skip should be flagged, not averaged'
+    preconditions:
+      - 'fwd_ms[i] > 0 for all valid layers (denominator)'
+      - 'bwd_ms[i] >= 0 for all valid layers'
+      - 'NaN-skip layers excluded from aggregate (flagged separately)'
+    postconditions:
+      - 'ratio[i] >= 0.0 for all valid layers'
+      - 'avg_ratio is finite when any valid layers exist'
+      - 'ratio_cv is finite when avg_ratio > 0'
+    lean_theorem: 'Theorems.Forward_backward_ratio'
 
   regression_detection:
     formula: |
@@ -113,6 +139,15 @@ equations:
     invariants:
       - 'Regression thresholds are configurable per metric'
       - 'At least throughput and step_time must be checked'
+    preconditions:
+      - 'both baseline and current StepProfiler JSON are well-formed'
+      - 'B[m] != 0 for all checked metrics m (delta undefined when baseline is zero)'
+      - 'all metric values finite'
+    postconditions:
+      - 'delta[m] is finite when B[m] != 0'
+      - 'regressed[m] is total over the configured threshold map'
+      - 'output list contains all m where regressed[m] is true (no silent drops)'
+    lean_theorem: 'Theorems.Regression_detection'
 
   scorecard_output:
     formula: |
@@ -141,6 +176,16 @@ equations:
       - 'per_layer_summary has exactly num_model_layers entries'
       - 'hotspot_ops sorted by total_ms descending'
       - 'recommendations non-empty when grade <= C'
+    preconditions:
+      - 'StepProfiler JSON input is well-formed and complete'
+      - 'num_model_layers > 0'
+    postconditions:
+      - 'JSON output is parseable as TrainingScorecard'
+      - 'all numeric fields finite and non-negative'
+      - 'len(per_layer_summary) == num_model_layers'
+      - 'hotspot_ops sorted by total_ms descending'
+      - 'len(recommendations) > 0 when grade in {"C", "D", "F"}'
+    lean_theorem: 'Theorems.Scorecard_output'
 
 proof_obligations:
   - type: invariant


### PR DESCRIPTION
## Summary

Continues post-SHIP-007 §22 lint cleanup. Adds load-bearing schema fields to 3 contracts.

## Contracts touched

| Contract | Equations | Warnings cleared |
|---|---|---|
| `probar/training-step-scorecard-v1.yaml` | training_efficiency_grade, bottleneck_classification, forward_backward_ratio, regression_detection, scorecard_output | 15 |
| `nf4-fused-qkv-gemm-v1.yaml` | separate_qkv, fused_qkv, bandwidth_savings | 7 |
| `nf4-fused-gate-up-swiglu-v1.yaml` | separate_ffn, fused_rmsnorm_gate_up_swiglu_nf4, bandwidth_savings | 7 |

Each pre/post empirically reasoned from formula + invariants.

## Result

```
pv lint contracts/
  before this PR:  806 warnings (after #1560 kaizen #3)
  after this PR:   777 warnings (29 cleared)
  total session:   870 → 777 (93 warnings cleared across 4 PRs)
```

Pure additive YAML; no behavioral or test changes.

## Toyota Way

- **Genchi genbutsu**: read each equation's formula+invariants before authoring.
- **Kaizen**: small batch (3 contracts / 11 equations).
- **Jidoka**: fix at the root.

## Test plan

- [x] `pv lint contracts/` after fix → 29 warnings cleared
- [x] No code or test changes
- [ ] CI ci/gate green
- [ ] Auto-merge once required checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)