### PR TITLE
feat(apr-code): --output-format/--input-format flags (Claude-Code parity flip)

### DIFF
--- a/contracts/apr-code-parity-v1.yaml
+++ b/contracts/apr-code-parity-v1.yaml
@@ -15,13 +15,19 @@
 #
 # Headline invariant: before epic PMAT-CODE-PARITY-MATRIX-001 closes,
 # aggregate counts must reach ≥9 SHIPPED / 7 PARTIAL / ≤4 MISSING.
-# Current counts (2026-04-18 v5.1): 14 SHIPPED / 3 PARTIAL / 4 MISSING. **EPIC CLOSURE CONDITIONS MET** — SHIPPED ≥9 AND MISSING ≤4. Epic PMAT-CODE-PARITY-MATRIX-001 is CLOSEABLE. Remaining 4 MISSING rows (notebook, monitor, plugins, IDE) are all P2 deferred with no epic dependency.
+# Current counts (2026-04-18 v5.1): 14 SHIPPED / 3 PARTIAL / 4 MISSING.
+# 2026-05-07 v5.2 update: non-interactive-mode flipped PARTIAL → SHIPPED via
+# PMAT-CODE-OUTPUT-FORMAT-001 / PMAT-CODE-INPUT-FORMAT-001 (--output-format /
+# --input-format wired on `apr code` with 8 unit tests). New counts: 15 SHIPPED
+# / 2 PARTIAL / 4 MISSING. **EPIC CLOSURE CONDITIONS REMAIN MET** — SHIPPED ≥9
+# AND MISSING ≤4. Epic PMAT-CODE-PARITY-MATRIX-001 is CLOSEABLE. Remaining 4
+# MISSING rows (notebook, monitor, plugins, IDE) are all P2 deferred.
 # ─────────────────────────────────────────────────────────────────────────────
 
 metadata:
-  version: 1.0.0
+  version: 5.2.0
   created: '2026-04-18'
-  last_modified: '2026-04-18'
+  last_modified: '2026-05-07'
   author: PAIML Engineering
   kind: pattern   # cross-cutting verification pattern (parity audit), not a mathematical kernel
   description: >
@@ -363,15 +369,25 @@ categories:
     priority: P2
 
   - id: non-interactive-mode
-    name: Non-interactive mode (-p + --output-format)
-    status: PARTIAL
-    detail: -p works with iteration cap 10; --output-format/--input-format absent
+    name: Non-interactive mode (-p + --output-format/--input-format)
+    status: SHIPPED
+    detail: |
+      -p with --output-format <text|json> AND --input-format <text|json> shipped
+      via PMAT-CODE-OUTPUT-FORMAT-001 / PMAT-CODE-INPUT-FORMAT-001.
+      `--output-format json` emits the Claude-Code `claude -p --output-format
+      json` envelope (`{type:"result",subtype:"success",result,session_id,
+      duration_ms,num_turns,tokens_in,tokens_out,total_cost_usd:0}`).
+      `--input-format json` accepts `{"role":"user","content":"..."}` from
+      stdin. Both flags are clap ValueEnum so unknown values fail loudly
+      (exit 2) instead of running on garbage. 8 unit tests cover envelope
+      shape, error subtype, content extraction, missing fields, and
+      malformed-JSON rejection.
     evidence_path: crates/apr-cli/src/commands_enum.rs
-    evidence_line_range: [509, 515]
+    evidence_line_range: [1, 30]
     cross_check_command: |
-      pmat query --literal "run_single_prompt" --limit 3 --include-source \
-        | grep -c "max_iterations"
-    expected_min_hits: 1
+      /mnt/nvme-raid0/targets/aprender/release/apr code --help 2>&1 \
+        | grep -E -- "--output-format|--input-format" | wc -l
+    expected_min_hits: 2
     ticket: PMAT-CODE-NON-INTERACTIVE-PARITY-001
     priority: P1
 

--- a/crates/apr-cli/src/commands_enum.rs
+++ b/crates/apr-cli/src/commands_enum.rs
@@ -1,4 +1,27 @@
 
+/// Output format for `apr code` non-interactive mode (PMAT-CODE-OUTPUT-FORMAT-001).
+/// Mirrors Claude Code's `claude -p --output-format <fmt>` parity row.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum, Default)]
+pub enum CodeOutputFormat {
+    /// Plain assistant text on stdout (default; existing behavior).
+    #[default]
+    Text,
+    /// Structured JSON envelope: `{type:"result", subtype:"success", result, session_id, duration_ms}`.
+    Json,
+}
+
+/// Input format for `apr code` non-interactive mode (PMAT-CODE-INPUT-FORMAT-001).
+/// `--input-format json` reads `{"role":"user","content":"..."}` from stdin instead
+/// of treating stdin as raw prompt text.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum, Default)]
+pub enum CodeInputFormat {
+    /// Raw prompt text from positional args or stdin (default; existing behavior).
+    #[default]
+    Text,
+    /// JSON message envelope on stdin: `{"role":"user","content":"..."}`.
+    Json,
+}
+
 #[derive(Subcommand, Debug)]
 pub enum Commands {
     /// Run model directly (auto-download, cache, execute)
@@ -618,6 +641,20 @@ pub enum Commands {
         /// against canonical Claude Code reference fixtures.
         #[arg(long)]
         emit_trace: Option<PathBuf>,
+
+        /// Output format for non-interactive (`-p`) mode (PMAT-CODE-OUTPUT-FORMAT-001).
+        /// `text` (default): plain assistant text.
+        /// `json`: structured `{type:"result", subtype:"success", result, session_id, duration_ms}`
+        /// envelope matching Claude Code's `claude -p --output-format json` shape.
+        #[arg(long, value_enum, default_value_t = CodeOutputFormat::Text)]
+        output_format: CodeOutputFormat,
+
+        /// Input format for non-interactive stdin (PMAT-CODE-INPUT-FORMAT-001).
+        /// `text` (default): treat stdin as raw prompt text.
+        /// `json`: parse `{"role":"user","content":"..."}` from stdin and use `content`
+        /// as the prompt. Matches Claude Code's `claude -p --input-format json` shape.
+        #[arg(long, value_enum, default_value_t = CodeInputFormat::Text)]
+        input_format: CodeInputFormat,
     },
     /// Extended analysis, profiling, QA, and visualization commands
     #[command(flatten)]

--- a/crates/apr-cli/src/dispatch.rs
+++ b/crates/apr-cli/src/dispatch.rs
@@ -158,6 +158,8 @@ fn dispatch_runtime_commands(cli: &Cli) -> Option<Result<(), CliError>> {
             max_turns,
             manifest,
             emit_trace,
+            output_format,
+            input_format,
         } => batuta::agent::code::cmd_code(
             model.clone(),
             project.clone(),
@@ -167,6 +169,17 @@ fn dispatch_runtime_commands(cli: &Cli) -> Option<Result<(), CliError>> {
             *max_turns,
             manifest.clone(),
             emit_trace.clone(),
+            // PMAT-CODE-OUTPUT-FORMAT-001 / PMAT-CODE-INPUT-FORMAT-001:
+            // forward as `&str` so the orchestrate crate need not depend on
+            // the apr-cli ValueEnum types.
+            match output_format {
+                crate::CodeOutputFormat::Text => "text",
+                crate::CodeOutputFormat::Json => "json",
+            },
+            match input_format {
+                crate::CodeInputFormat::Text => "text",
+                crate::CodeInputFormat::Json => "json",
+            },
         )
         .map_err(|e| CliError::Aprender(e.to_string())),
 

--- a/crates/aprender-orchestrate/src/agent/code.rs
+++ b/crates/aprender-orchestrate/src/agent/code.rs
@@ -24,6 +24,7 @@ use crate::serve::backends::PrivacyTier;
 /// This is the public library API — callable from both the batuta binary
 /// and apr-cli (PMAT-162). Handles model discovery, driver selection,
 /// tool registration, and REPL launch.
+#[allow(clippy::too_many_arguments)]
 pub fn cmd_code(
     model: Option<PathBuf>,
     project: PathBuf,
@@ -33,6 +34,12 @@ pub fn cmd_code(
     max_turns: u32,
     manifest_path: Option<PathBuf>,
     emit_trace: Option<PathBuf>,
+    // PMAT-CODE-OUTPUT-FORMAT-001 / PMAT-CODE-INPUT-FORMAT-001:
+    // accepted as &str ("text" | "json") to keep this crate's public API
+    // independent of apr-cli's ValueEnum types. Unknown values fall back
+    // to "text" — the legacy behavior — under Poka-Yoke.
+    output_format: &str,
+    input_format: &str,
 ) -> anyhow::Result<()> {
     // --project: change working directory for project instructions
     if project.as_os_str() != "." && project.is_dir() {
@@ -139,7 +146,15 @@ pub fn cmd_code(
         let prompt_text = if prompt.is_empty() {
             let mut buf = String::new();
             std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)?;
-            buf
+            // PMAT-CODE-INPUT-FORMAT-001: when --input-format=json, parse
+            // a `{"role":"user","content":"..."}` envelope and use `content`
+            // as the prompt. Empty/missing content is a hard error so the
+            // operator notices the malformed envelope.
+            if input_format.eq_ignore_ascii_case("json") {
+                parse_json_input_envelope(&buf)?
+            } else {
+                buf
+            }
         } else {
             prompt.join(" ")
         };
@@ -150,6 +165,7 @@ pub fn cmd_code(
             &memory,
             &prompt_text,
             emit_trace.as_deref(),
+            output_format,
         );
         drop(driver); // Kill apr serve subprocess before exit
         std::process::exit(code);
@@ -500,6 +516,8 @@ fn run_single_prompt(
     memory: &dyn crate::agent::memory::MemorySubstrate,
     prompt: &str,
     emit_trace: Option<&std::path::Path>,
+    // PMAT-CODE-OUTPUT-FORMAT-001: "text" (default) or "json".
+    output_format: &str,
 ) -> i32 {
     let mut single_manifest = manifest.clone();
     single_manifest.resources.max_iterations = single_manifest.resources.max_iterations.min(10);
@@ -535,6 +553,7 @@ fn run_single_prompt(
 
     match result {
         Ok(r) => {
+            let elapsed = started.elapsed();
             if r.text.is_empty() {
                 // PMAT-190: Empty response — model may be emitting only thinking tokens
                 // that get stripped by strip_thinking_blocks(). Common with Qwen3 when
@@ -544,6 +563,13 @@ fn run_single_prompt(
                      Model may be in thinking mode — rebuild apr from source for Qwen3NoThinkTemplate fix.",
                     r.iterations, r.tool_calls
                 );
+                if output_format.eq_ignore_ascii_case("json") {
+                    println!("{}", build_json_result_envelope(&r, elapsed, /*is_error*/ true));
+                }
+            } else if output_format.eq_ignore_ascii_case("json") {
+                // PMAT-CODE-OUTPUT-FORMAT-001: structured envelope mirroring
+                // Claude Code's `claude -p --output-format json` shape.
+                println!("{}", build_json_result_envelope(&r, elapsed, /*is_error*/ false));
             } else {
                 println!("{}", r.text);
             }
@@ -647,6 +673,78 @@ fn emit_ccpa_trace(
 
     let body = format!("{}\n{}\n{}\n{}\n", session_start, user_prompt, assistant_turn, session_end);
     std::fs::write(path, body)
+}
+
+/// PMAT-CODE-INPUT-FORMAT-001 (M-NON-INT-002): parse a `{"role":"user","content":"..."}`
+/// JSON envelope from stdin and return the prompt text. Mirrors the shape Claude
+/// Code accepts on `claude -p --input-format json`.
+///
+/// Errors are surfaced (not silently downgraded) so a malformed envelope fails
+/// loudly instead of running the agent on garbage. `role` other than `"user"`
+/// is also rejected — the non-interactive surface is single-user-turn only.
+fn parse_json_input_envelope(buf: &str) -> anyhow::Result<String> {
+    let trimmed = buf.trim();
+    if trimmed.is_empty() {
+        anyhow::bail!("--input-format=json: stdin is empty (expected JSON envelope)");
+    }
+    let v: serde_json::Value = serde_json::from_str(trimmed)
+        .map_err(|e| anyhow::anyhow!("--input-format=json: invalid JSON on stdin: {e}"))?;
+    let role = v.get("role").and_then(|r| r.as_str()).unwrap_or("user");
+    if role != "user" {
+        anyhow::bail!("--input-format=json: only role=\"user\" supported, got \"{role}\"");
+    }
+    let content = v
+        .get("content")
+        .and_then(|c| c.as_str())
+        .ok_or_else(|| anyhow::anyhow!("--input-format=json: missing string field `content`"))?;
+    Ok(content.to_owned())
+}
+
+/// PMAT-CODE-OUTPUT-FORMAT-001 (M-NON-INT-001): build a structured JSON
+/// envelope mirroring Claude Code's `claude -p --output-format json` shape:
+///
+/// ```json
+/// {
+///   "type": "result",
+///   "subtype": "success",
+///   "is_error": false,
+///   "duration_ms": 1234,
+///   "result": "the assistant text",
+///   "session_id": "<uuidv7-shaped>",
+///   "num_turns": 1,
+///   "total_cost_usd": 0
+/// }
+/// ```
+fn build_json_result_envelope(
+    result: &super::result::AgentLoopResult,
+    elapsed: std::time::Duration,
+    is_error: bool,
+) -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let ts_micros =
+        SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_micros()).unwrap_or(0);
+    // Same UUIDv7-shaped stable-per-run session id used by emit_ccpa_trace.
+    let session_id = format!(
+        "{:08x}-{:04x}-7000-{:04x}-{:012x}",
+        (ts_micros >> 64) as u32 & 0xFFFF_FFFF,
+        ((ts_micros >> 48) & 0xFFFF) as u16,
+        ((ts_micros >> 32) & 0xFFFF) as u16,
+        (ts_micros & 0xFFFF_FFFF_FFFF) as u64
+    );
+    let envelope = serde_json::json!({
+        "type": "result",
+        "subtype": if is_error { "error" } else { "success" },
+        "is_error": is_error,
+        "duration_ms": elapsed.as_millis() as u64,
+        "result": result.text,
+        "session_id": session_id,
+        "num_turns": result.iterations,
+        "tokens_in": result.usage.input_tokens,
+        "tokens_out": result.usage.output_tokens,
+        // Local sovereign inference: cost is always zero by construction.
+        "total_cost_usd": 0,
+    });
+    envelope.to_string()
 }
 
 // Prompts and exit codes extracted to code_prompts.rs

--- a/crates/aprender-orchestrate/src/agent/code_tests.rs
+++ b/crates/aprender-orchestrate/src/agent/code_tests.rs
@@ -210,7 +210,7 @@ fn test_cmd_code_signature_matches_spec() {
     // Verify the public API signature exists and is callable
     // This catches regressions where the function is made private or renamed
     // Verify cmd_code exists and is callable
-    let _ = cmd_code as fn(_, _, _, _, _, _, _, _) -> _;
+    let _ = cmd_code as fn(_, _, _, _, _, _, _, _, _, _) -> _;
 }
 
 #[test]
@@ -568,5 +568,100 @@ mod emit_trace_tests {
         for line in body.lines() {
             assert!(line.contains("\"v\":1"), "every JSONL record must carry v:1, got: {line}");
         }
+    }
+}
+
+// ── PMAT-CODE-OUTPUT-FORMAT-001 / PMAT-CODE-INPUT-FORMAT-001 ─────────
+// Non-interactive mode parity with `claude -p --output-format <fmt>`
+// and `claude -p --input-format json`.
+
+#[cfg(test)]
+mod non_interactive_format_tests {
+    use super::super::{build_json_result_envelope, parse_json_input_envelope};
+    use crate::agent::{AgentLoopResult, TokenUsage};
+
+    fn synth_result(text: &str) -> AgentLoopResult {
+        AgentLoopResult {
+            text: text.to_owned(),
+            usage: TokenUsage { input_tokens: 42, output_tokens: 7 },
+            iterations: 3,
+            tool_calls: 1,
+        }
+    }
+
+    #[test]
+    fn json_output_envelope_carries_required_fields() {
+        // Mirrors `claude -p "x" --output-format json` shape — the operator
+        // contract for any tool downstream (e.g. CCPA differ) that parses
+        // this envelope.
+        let r = synth_result("the answer is 4");
+        let s = build_json_result_envelope(&r, std::time::Duration::from_millis(123), false);
+        let v: serde_json::Value = serde_json::from_str(&s).expect("envelope is valid JSON");
+        assert_eq!(v["type"], "result");
+        assert_eq!(v["subtype"], "success");
+        assert_eq!(v["is_error"], false);
+        assert_eq!(v["duration_ms"], 123);
+        assert_eq!(v["result"], "the answer is 4");
+        assert_eq!(v["num_turns"], 3);
+        assert_eq!(v["tokens_in"], 42);
+        assert_eq!(v["tokens_out"], 7);
+        assert_eq!(v["total_cost_usd"], 0);
+        assert!(v["session_id"].as_str().is_some_and(|s| !s.is_empty()));
+    }
+
+    #[test]
+    fn json_output_envelope_marks_error_subtype_on_empty_response() {
+        let r = synth_result("");
+        let s = build_json_result_envelope(&r, std::time::Duration::from_millis(1), true);
+        let v: serde_json::Value = serde_json::from_str(&s).expect("valid JSON");
+        assert_eq!(v["subtype"], "error");
+        assert_eq!(v["is_error"], true);
+        assert_eq!(v["result"], "");
+    }
+
+    #[test]
+    fn json_input_envelope_extracts_user_content() {
+        let buf = r#"{"role":"user","content":"What is 2+2?"}"#;
+        let prompt = parse_json_input_envelope(buf).expect("valid envelope");
+        assert_eq!(prompt, "What is 2+2?");
+    }
+
+    #[test]
+    fn json_input_envelope_defaults_role_to_user_when_omitted() {
+        // Lenient: omitted role implies "user" since non-interactive surface
+        // is single-turn user-only by construction.
+        let buf = r#"{"content":"hello"}"#;
+        let prompt = parse_json_input_envelope(buf).expect("valid envelope");
+        assert_eq!(prompt, "hello");
+    }
+
+    #[test]
+    fn json_input_envelope_rejects_non_user_role() {
+        let buf = r#"{"role":"assistant","content":"x"}"#;
+        let err = parse_json_input_envelope(buf).expect_err("must reject non-user role");
+        let msg = format!("{err}");
+        assert!(msg.contains("role"), "error must mention role: {msg}");
+    }
+
+    #[test]
+    fn json_input_envelope_rejects_missing_content() {
+        let buf = r#"{"role":"user"}"#;
+        let err = parse_json_input_envelope(buf).expect_err("must reject missing content");
+        let msg = format!("{err}");
+        assert!(msg.contains("content"), "error must mention content field: {msg}");
+    }
+
+    #[test]
+    fn json_input_envelope_rejects_empty_stdin() {
+        let err = parse_json_input_envelope("   \n").expect_err("must reject empty stdin");
+        let msg = format!("{err}");
+        assert!(msg.contains("empty"), "error must mention empty: {msg}");
+    }
+
+    #[test]
+    fn json_input_envelope_rejects_malformed_json() {
+        let err = parse_json_input_envelope("{not json").expect_err("must reject bad JSON");
+        let msg = format!("{err}");
+        assert!(msg.contains("invalid JSON"), "error must mention JSON: {msg}");
     }
 }

--- a/crates/aprender-orchestrate/src/cli/code.rs
+++ b/crates/aprender-orchestrate/src/cli/code.rs
@@ -12,11 +12,15 @@ use std::path::PathBuf;
 ///
 /// Delegates entirely to the library-level `agent::code::cmd_code`.
 ///
-/// Note: the upstream `cmd_code` gained an 8th `emit_trace: Option<PathBuf>`
-/// parameter; the bin-side clap surface (`Commands::Code` in
-/// `main_dispatch.rs`) does not yet expose it, so this wrapper passes
-/// `None`. Threading `--emit-trace` through the clap surface is a
-/// future enhancement.
+/// Note: the upstream `cmd_code` has gained additional parameters over time:
+/// - 8th: `emit_trace: Option<PathBuf>` (M28 — ccpa-trace.jsonl)
+/// - 9th: `output_format: &str` (PMAT-CODE-OUTPUT-FORMAT-001 — Claude-Code parity)
+/// - 10th: `input_format: &str` (PMAT-CODE-INPUT-FORMAT-001 — Claude-Code parity)
+///
+/// The bin-side clap surface (`Commands::Code` in `main_dispatch.rs`) does
+/// not yet expose them; this wrapper passes legacy defaults so behavior is
+/// unchanged. Threading the new flags through the binary's clap is a future
+/// enhancement (the apr-cli surface already exposes them via `apr code`).
 pub fn cmd_code(
     model: Option<PathBuf>,
     project: PathBuf,
@@ -34,7 +38,9 @@ pub fn cmd_code(
         print,
         max_turns,
         manifest_path,
-        None, // emit_trace: not yet plumbed through the binary's clap surface.
+        None,   // emit_trace: not yet plumbed through the binary's clap surface.
+        "text", // output_format: legacy default
+        "text", // input_format: legacy default
     )
 }
 

--- a/crates/aprender-orchestrate/src/cli/code_tests.rs
+++ b/crates/aprender-orchestrate/src/cli/code_tests.rs
@@ -10,7 +10,7 @@ fn test_cmd_code_is_accessible() {
     // Verify the public API entry point exists and is callable.
     // We can't run cmd_code without a model, but we can verify it compiles.
     // Verify cmd_code exists and is callable (signature tested in agent/code_tests.rs)
-    let _ = cmd_code as fn(_, _, _, _, _, _, _) -> _;
+    let _ = cmd_code as fn(_, _, _, _, _, _, _, _, _, _) -> _;
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Wires `--output-format <text|json>` and `--input-format <text|json>` flags onto `apr code -p` for Claude Code parity (PMAT-CODE-OUTPUT-FORMAT-001 / PMAT-CODE-INPUT-FORMAT-001).
- Flips the non-interactive-mode row in `contracts/apr-code-parity-v1.yaml` from PARTIAL → SHIPPED. New aggregate counts: 15 SHIPPED / 2 PARTIAL / 4 MISSING.
- 8 new unit tests + LIVE end-to-end smoke on `qwen2.5-coder-1.5b-q4k.apr` (`What is 2+2?` → `result:"4"` in 777ms; `{"role":"user","content":"What is 5+5?"}` → `result:"10"` in 812ms).

## Output envelope (mirrors Claude Code)
```json
{"type":"result","subtype":"success","is_error":false,
 "duration_ms":777,"result":"4","session_id":"...",
 "num_turns":1,"tokens_in":33,"tokens_out":1,
 "total_cost_usd":0}
```
Empty assistant text → `subtype:"error"`. Local sovereign inference → `total_cost_usd:0` by construction.

## Input envelope
`{"role":"user","content":"..."}` from stdin under `--input-format json`. Non-user role, missing `content`, empty stdin, and malformed JSON all fail loudly with `error: Aprender error: --input-format=json: ...` (Poka-Yoke; no garbage runs).

## Test plan
- [x] `cargo test -p aprender-orchestrate --lib --features inference,agents non_interactive_format_tests` — 8/8 pass
- [x] `cargo test -p aprender-orchestrate --lib --features inference,agents` — 6397/6397 pass (no regression)
- [x] `cargo test -p apr-cli --lib --features code` — 5635/5635 pass
- [x] `cargo test -p apr-cli --test cli_commands --features code` — 8/8 pass
- [x] `cargo build --release -p apr-cli --features code` — clean
- [x] `pv validate contracts/apr-code-parity-v1.yaml` — 0 errors / 0 warnings
- [x] LIVE smoke: `apr code --output-format json -p "What is 2+2?"` returns Claude-Code envelope
- [x] LIVE smoke: `--input-format json` from stdin extracts `content` and passes through to model
- [x] LIVE smoke: `apr code --output-format invalid` exits 2 with clap-rendered error
- [x] LIVE smoke: malformed JSON on stdin fails with `--input-format=json: invalid JSON on stdin: ...`
- [x] Cross-check: `apr code --help | grep -E -- "--output-format|--input-format" | wc -l` → 4 (≥2 required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)