### PR TITLE
feat(apr-code): settings.json permissionMode + allowedHosts (PMAT-CODE-CONFIG-LADDER-FIELDS-001)

### DIFF
--- a/crates/aprender-orchestrate/src/agent/code.rs
+++ b/crates/aprender-orchestrate/src/agent/code.rs
@@ -68,7 +68,7 @@ pub fn cmd_code(
             // is reported rather than silently ignored.
             let project_root = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
             let settings = crate::agent::settings::AprSettings::load_layered(&project_root)?;
-            apply_settings_to_manifest(&mut m, &settings);
+            apply_settings_to_manifest(&mut m, &settings)?;
             m
         }
     };
@@ -237,10 +237,16 @@ pub fn cmd_code(
 /// CLI flags apply. Each `Some(_)` field on settings overrides the manifest
 /// default; `None` fields leave the manifest alone. The CLI surface is wired
 /// AFTER this so `--model` / `--max-turns` always win over settings.
+///
+/// PMAT-CODE-CONFIG-LADDER-FIELDS-001 (2026-05-07): also honors
+/// `permissionMode` (validated via [`PermissionMode::parse`]; unknown
+/// strings produce a hard error so a typo doesn't run the agent under the
+/// wrong policy) and `allowedHosts` (mapped to [`AgentManifest::allowed_hosts`];
+/// Sovereign privacy tier still wins as a Poka-Yoke).
 fn apply_settings_to_manifest(
     manifest: &mut AgentManifest,
     settings: &crate::agent::settings::AprSettings,
-) {
+) -> anyhow::Result<()> {
     if let Some(ref model) = settings.model {
         // Heuristic: a slash or starts with `hf://` / `./` / `/` → repo or
         // path. We keep this loose because the same field accepts both
@@ -266,6 +272,26 @@ fn apply_settings_to_manifest(
     if let Some(mt) = settings.max_turns {
         manifest.resources.max_iterations = mt;
     }
+    if let Some(ref pm) = settings.permission_mode {
+        // Parse once at apply time so the operator sees a clear error with
+        // the bad value rather than a generic serde error. Currently only
+        // the parse + validate is enforced — the runtime per-tool verdict
+        // gate is tracked by PMAT-CODE-PERMISSIONS-RUNTIME-001.
+        if crate::agent::permission::PermissionMode::parse(pm).is_none() {
+            anyhow::bail!(
+                "settings.json permissionMode: unknown mode {pm:?} \
+                 (expected default | plan | acceptEdits | bypassPermissions)"
+            );
+        }
+    }
+    if let Some(ref hosts) = settings.allowed_hosts {
+        // Only apply if the operator hasn't already declared an explicit
+        // list via TOML manifest. Keeps manifest > settings precedence.
+        if manifest.allowed_hosts.is_empty() {
+            manifest.allowed_hosts = hosts.clone();
+        }
+    }
+    Ok(())
 }
 
 /// Build fallback driver (embedded RealizarDriver) when AprServeDriver unavailable.

--- a/crates/aprender-orchestrate/src/agent/code_tests.rs
+++ b/crates/aprender-orchestrate/src/agent/code_tests.rs
@@ -503,7 +503,7 @@ mod settings_apply_tests {
     fn apply_model_repo_preserves_alias_form() {
         let mut m = build_default_manifest();
         let s = AprSettings { model: Some("qwen3:1.7b-q4k".into()), ..Default::default() };
-        apply_settings_to_manifest(&mut m, &s);
+        apply_settings_to_manifest(&mut m, &s).expect("apply ok");
         assert_eq!(m.model.model_repo.as_deref(), Some("qwen3:1.7b-q4k"));
         assert!(m.model.model_path.is_none());
     }
@@ -512,7 +512,7 @@ mod settings_apply_tests {
     fn apply_model_path_treats_absolute_as_path() {
         let mut m = build_default_manifest();
         let s = AprSettings { model: Some("/abs/model.gguf".into()), ..Default::default() };
-        apply_settings_to_manifest(&mut m, &s);
+        apply_settings_to_manifest(&mut m, &s).expect("apply ok");
         assert_eq!(
             m.model.model_path.as_ref().map(|p| p.to_string_lossy().into_owned()),
             Some("/abs/model.gguf".to_string())
@@ -524,7 +524,7 @@ mod settings_apply_tests {
     fn apply_model_path_treats_relative_dot_as_path() {
         let mut m = build_default_manifest();
         let s = AprSettings { model: Some("./local.apr".into()), ..Default::default() };
-        apply_settings_to_manifest(&mut m, &s);
+        apply_settings_to_manifest(&mut m, &s).expect("apply ok");
         assert!(m.model.model_path.is_some());
         assert!(m.model.model_repo.is_none());
     }
@@ -534,7 +534,7 @@ mod settings_apply_tests {
         let mut m = build_default_manifest();
         let original = m.resources.max_iterations;
         let s = AprSettings { max_turns: Some(7), ..Default::default() };
-        apply_settings_to_manifest(&mut m, &s);
+        apply_settings_to_manifest(&mut m, &s).expect("apply ok");
         assert_eq!(m.resources.max_iterations, 7);
         assert_ne!(7, original, "test invalid: settings.max_turns matches default");
     }
@@ -544,7 +544,7 @@ mod settings_apply_tests {
         let mut m = build_default_manifest();
         let base_len = m.model.system_prompt.len();
         let s = AprSettings { extra_system_prompt: Some("BE TERSE.".into()), ..Default::default() };
-        apply_settings_to_manifest(&mut m, &s);
+        apply_settings_to_manifest(&mut m, &s).expect("apply ok");
         assert!(m.model.system_prompt.len() > base_len, "must append, not replace");
         assert!(m.model.system_prompt.ends_with("BE TERSE."));
     }
@@ -554,7 +554,7 @@ mod settings_apply_tests {
         let mut m = build_default_manifest();
         let base = m.model.system_prompt.clone();
         let s = AprSettings { extra_system_prompt: Some("   \n  ".into()), ..Default::default() };
-        apply_settings_to_manifest(&mut m, &s);
+        apply_settings_to_manifest(&mut m, &s).expect("apply ok");
         assert_eq!(m.model.system_prompt, base, "whitespace-only extra is no-op");
     }
 
@@ -567,11 +567,70 @@ mod settings_apply_tests {
             m.model.system_prompt.clone(),
             m.resources.max_iterations,
         );
-        apply_settings_to_manifest(&mut m, &AprSettings::default());
+        apply_settings_to_manifest(&mut m, &AprSettings::default()).expect("apply ok");
         assert_eq!(m.model.model_path, snapshot.0);
         assert_eq!(m.model.model_repo, snapshot.1);
         assert_eq!(m.model.system_prompt, snapshot.2);
         assert_eq!(m.resources.max_iterations, snapshot.3);
+    }
+
+    // ── PMAT-CODE-CONFIG-LADDER-FIELDS-001: permission_mode + allowed_hosts
+
+    #[test]
+    fn apply_valid_permission_mode_succeeds() {
+        let mut m = build_default_manifest();
+        for mode in &["default", "plan", "acceptEdits", "bypassPermissions"] {
+            let s = AprSettings { permission_mode: Some((*mode).into()), ..Default::default() };
+            apply_settings_to_manifest(&mut m, &s)
+                .unwrap_or_else(|e| panic!("expected {mode} to parse: {e}"));
+        }
+    }
+
+    #[test]
+    fn apply_unknown_permission_mode_errs_loudly() {
+        let mut m = build_default_manifest();
+        let s = AprSettings { permission_mode: Some("totally-fake".into()), ..Default::default() };
+        let err = apply_settings_to_manifest(&mut m, &s).expect_err("must reject unknown");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("permissionMode"),
+            "error must mention permissionMode field name: {msg}"
+        );
+        assert!(msg.contains("totally-fake"), "error must echo the bad value: {msg}");
+    }
+
+    #[test]
+    fn apply_allowed_hosts_populates_manifest() {
+        let mut m = build_default_manifest();
+        // Default manifest's allowed_hosts is empty (Sovereign by default).
+        assert!(m.allowed_hosts.is_empty());
+        let s = AprSettings {
+            allowed_hosts: Some(vec!["docs.anthropic.com".into(), "crates.io".into()]),
+            ..Default::default()
+        };
+        apply_settings_to_manifest(&mut m, &s).expect("apply ok");
+        assert_eq!(
+            m.allowed_hosts,
+            vec!["docs.anthropic.com".to_string(), "crates.io".to_string()]
+        );
+    }
+
+    #[test]
+    fn apply_allowed_hosts_does_not_override_explicit_manifest() {
+        // Operator-declared TOML manifest wins over settings.json — same
+        // policy as model/max_turns/etc.
+        let mut m = build_default_manifest();
+        m.allowed_hosts = vec!["explicit.example.com".into()];
+        let s = AprSettings {
+            allowed_hosts: Some(vec!["from-settings.example.com".into()]),
+            ..Default::default()
+        };
+        apply_settings_to_manifest(&mut m, &s).expect("apply ok");
+        assert_eq!(
+            m.allowed_hosts,
+            vec!["explicit.example.com".to_string()],
+            "manifest-declared list must NOT be replaced by settings"
+        );
     }
 }
 

--- a/crates/aprender-orchestrate/src/agent/settings.rs
+++ b/crates/aprender-orchestrate/src/agent/settings.rs
@@ -58,6 +58,29 @@ pub struct AprSettings {
     /// Default working-directory project root override. Resolved relative
     /// to the settings file's directory; absolute paths pass through.
     pub project: Option<PathBuf>,
+
+    /// Permission mode for the agent's tool dispatch (PMAT-CODE-CONFIG-LADDER-FIELDS-001).
+    /// Mirrors Claude Code's `permissionMode` field. Accepts the camelCase /
+    /// kebab-case / snake_case aliases that
+    /// [`crate::agent::permission::PermissionMode::parse`] honors:
+    /// `"default" | "plan" | "acceptEdits" | "bypassPermissions"` (and
+    /// case-insensitive equivalents). Unknown strings produce a settings-load
+    /// error from `apply_settings_to_manifest` (Poka-Yoke).
+    ///
+    /// Stored as `Option<String>` rather than `Option<PermissionMode>` so the
+    /// settings type stays JSON-trivial and so unknown values surface a
+    /// clear `apr code` error message at apply time rather than a generic
+    /// serde error at parse time.
+    #[serde(rename = "permissionMode", alias = "permission_mode")]
+    pub permission_mode: Option<String>,
+
+    /// Hostnames the agent's `NetworkTool` / `BrowserTool` may reach
+    /// (PMAT-CODE-CONFIG-LADDER-FIELDS-001). Mirrors `AgentManifest.allowed_hosts`.
+    /// Sovereign privacy tier always blocks network tools regardless of this
+    /// list (Poka-Yoke; tier wins over config). Empty list = no network
+    /// tools registered.
+    #[serde(rename = "allowedHosts", alias = "allowed_hosts")]
+    pub allowed_hosts: Option<Vec<String>>,
 }
 
 impl AprSettings {
@@ -75,6 +98,12 @@ impl AprSettings {
         }
         if other.project.is_some() {
             self.project = other.project.clone();
+        }
+        if other.permission_mode.is_some() {
+            self.permission_mode = other.permission_mode.clone();
+        }
+        if other.allowed_hosts.is_some() {
+            self.allowed_hosts = other.allowed_hosts.clone();
         }
     }
 
@@ -193,6 +222,62 @@ mod tests {
         // Poka-Yoke: typo in field name shouldn't silently no-op.
         let err = AprSettings::from_json_str(r#"{"modle":"foo"}"#).expect_err("must reject typo");
         assert!(format!("{err}").contains("invalid settings JSON"));
+    }
+
+    // PMAT-CODE-CONFIG-LADDER-FIELDS-001 — permission_mode + allowed_hosts
+
+    #[test]
+    fn from_json_parses_permission_mode_camel() {
+        // Claude Code's `permissionMode` shape (camelCase wire form).
+        let s = AprSettings::from_json_str(r#"{"permissionMode":"acceptEdits"}"#).expect("parse");
+        assert_eq!(s.permission_mode.as_deref(), Some("acceptEdits"));
+    }
+
+    #[test]
+    fn from_json_parses_permission_mode_snake_alias() {
+        // Operator-friendly snake_case alias also accepted.
+        let s = AprSettings::from_json_str(r#"{"permission_mode":"plan"}"#).expect("parse");
+        assert_eq!(s.permission_mode.as_deref(), Some("plan"));
+    }
+
+    #[test]
+    fn from_json_parses_allowed_hosts_camel() {
+        let s =
+            AprSettings::from_json_str(r#"{"allowedHosts":["docs.anthropic.com","crates.io"]}"#)
+                .expect("parse");
+        assert_eq!(
+            s.allowed_hosts.as_deref(),
+            Some(&["docs.anthropic.com".to_string(), "crates.io".to_string()][..])
+        );
+    }
+
+    #[test]
+    fn from_json_parses_allowed_hosts_snake_alias() {
+        let s = AprSettings::from_json_str(r#"{"allowed_hosts":["github.com"]}"#).expect("parse");
+        assert_eq!(s.allowed_hosts.as_deref(), Some(&["github.com".to_string()][..]));
+    }
+
+    #[test]
+    fn merge_permission_mode_other_wins() {
+        let mut base =
+            AprSettings { permission_mode: Some("default".into()), ..Default::default() };
+        let over = AprSettings { permission_mode: Some("plan".into()), ..Default::default() };
+        base.merge(&over);
+        assert_eq!(base.permission_mode.as_deref(), Some("plan"));
+    }
+
+    #[test]
+    fn merge_allowed_hosts_other_wins_replaces_not_unions() {
+        // Settings ladder semantics: project-local fully replaces user-global
+        // for any field with `Some(_)`. We do NOT do list-union — operator
+        // who wants both must list both in the project file.
+        let mut base = AprSettings {
+            allowed_hosts: Some(vec!["a.com".into(), "b.com".into()]),
+            ..Default::default()
+        };
+        let over = AprSettings { allowed_hosts: Some(vec!["c.com".into()]), ..Default::default() };
+        base.merge(&over);
+        assert_eq!(base.allowed_hosts.as_deref(), Some(&["c.com".to_string()][..]));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Closes PMAT-CODE-CONFIG-LADDER-FIELDS-001 — the P2 follow-up from PMAT-CODE-CONFIG-LADDER-001 that called out missing fields. Adds `permissionMode` and `allowedHosts` to the `settings.json` ladder, mirroring Claude Code's wire shape with snake_case aliases.

## Wire shape
```json
{
  "model": "qwen3:1.7b-q4k",
  "permissionMode": "acceptEdits",
  "allowedHosts": ["docs.anthropic.com", "crates.io"]
}
```

## Behavior
- **`permissionMode`** validated at apply time via `PermissionMode::parse`. Unknown strings produce a hard error with the bad value echoed (Poka-Yoke). Future-proofs the file: operator can populate it now, runtime per-tool verdict gate tracked by PMAT-CODE-PERMISSIONS-RUNTIME-001 (P2).
- **`allowedHosts`** mapped to `AgentManifest.allowed_hosts`. Manifest-declared TOML lists win on collision. Sovereign privacy tier still wins via the existing `register_web_tools` gate.

## Signature change
`apply_settings_to_manifest` now returns `anyhow::Result<()>` so the unknown-permissionMode failure surfaces; existing test sites updated to use `.expect("apply ok")`.

## Test plan
- [x] `cargo test -p aprender-orchestrate --lib agent::settings` — 20/20 pass (incl. 6 new for parse+merge)
- [x] `cargo test -p aprender-orchestrate --lib settings_apply_tests` — 11/11 pass (incl. 4 new)
- [x] `cargo fmt -p aprender-orchestrate -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)