### PR TITLE
feat(apr-code): /debug /rename /upgrade slash commands (PMAT-CODE-SLASH-EXTENDED-001)

### DIFF
--- a/crates/aprender-orchestrate/src/agent/repl.rs
+++ b/crates/aprender-orchestrate/src/agent/repl.rs
@@ -52,6 +52,12 @@ enum SlashCommand {
     Resume,
     AddDir,
     Agents,
+    // PMAT-CODE-SLASH-EXTENDED-001: final 3 variants from Claude Code's
+    // built-in surface. Stubs that print a deliberate placeholder so
+    // operators see "not yet wired" rather than `Unknown`.
+    Debug,
+    Rename,
+    Upgrade,
     Unknown(String),
 }
 
@@ -85,6 +91,10 @@ impl SlashCommand {
             "/resume" => Self::Resume,
             "/add-dir" | "/adddir" => Self::AddDir,
             "/agents" => Self::Agents,
+            // PMAT-CODE-SLASH-EXTENDED-001
+            "/debug" | "/dbg" => Self::Debug,
+            "/rename" => Self::Rename,
+            "/upgrade" => Self::Upgrade,
             other => Self::Unknown(other.to_string()),
         })
     }
@@ -543,6 +553,32 @@ fn handle_slash_command(
         SlashCommand::Agents => {
             println!(
                 "  Custom agents not yet implemented — tracked by PMAT-CODE-CUSTOM-AGENTS-001."
+            );
+        }
+        // PMAT-CODE-SLASH-EXTENDED-001: stub handlers for the final 3
+        // Claude-Code-parity variants. Each prints a deliberate placeholder
+        // so the operator sees "recognized, not yet wired" instead of
+        // "Unknown command" — same pattern the 2026-04-18 batch used.
+        SlashCommand::Debug => {
+            println!(
+                "  /debug not yet implemented — interactive trace inspection \
+                 tracked by PMAT-CODE-SLASH-DEBUG-001 (P2). \
+                 Use `apr trace --json --payload` for non-interactive tracing."
+            );
+        }
+        SlashCommand::Rename => {
+            println!(
+                "  /rename not yet implemented — session rename \
+                 tracked by PMAT-CODE-SLASH-RENAME-001 (P2). \
+                 Sessions are currently identified by their UUIDv7 id under \
+                 ~/.apr/sessions/<id>/."
+            );
+        }
+        SlashCommand::Upgrade => {
+            println!(
+                "  /upgrade not yet implemented — version-check + self-upgrade \
+                 tracked by PMAT-CODE-SLASH-UPGRADE-001 (P2). \
+                 Run `cargo install aprender --force` for now."
             );
         }
         SlashCommand::Unknown(name) => {

--- a/crates/aprender-orchestrate/src/agent/repl_tests.rs
+++ b/crates/aprender-orchestrate/src/agent/repl_tests.rs
@@ -58,6 +58,27 @@ fn test_slash_command_parse_claude_code_parity() {
     assert_eq!(SlashCommand::parse("/config edit"), Some(SlashCommand::Config));
 }
 
+/// PMAT-CODE-SLASH-EXTENDED-001: final 3 Claude-Code variants. Stub
+/// handlers print a deliberate placeholder so the operator sees
+/// "recognized, not yet wired" — same falsifier pattern as the v4.2
+/// parity batch.
+#[test]
+fn test_slash_command_parse_extended() {
+    assert_eq!(SlashCommand::parse("/debug"), Some(SlashCommand::Debug));
+    assert_eq!(SlashCommand::parse("/dbg"), Some(SlashCommand::Debug));
+    assert_eq!(SlashCommand::parse("/rename"), Some(SlashCommand::Rename));
+    assert_eq!(SlashCommand::parse("/upgrade"), Some(SlashCommand::Upgrade));
+    // Trailing args route correctly.
+    assert_eq!(SlashCommand::parse("/rename my-session"), Some(SlashCommand::Rename));
+    assert_eq!(SlashCommand::parse("/debug verbose"), Some(SlashCommand::Debug));
+    // Anything that doesn't match the canonical 24 variants still routes
+    // to Unknown — this is the falsification gate.
+    assert_eq!(
+        SlashCommand::parse("/totally-fake"),
+        Some(SlashCommand::Unknown("/totally-fake".to_string()))
+    );
+}
+
 #[test]
 fn test_repl_session_new() {
     let session = ReplSession::new("test", 4096);


### PR DESCRIPTION
## Summary
Closes PMAT-CODE-SLASH-EXTENDED-001 — the P2 follow-up from PMAT-CODE-SLASH-PARITY-001 that listed `/debug`, `/rename`, `/upgrade` as the final 3 still-absent slash commands.

After this PR, `SlashCommand` covers **24 variants** matching Claude Code's full surface, plus `Unknown` as the falsification gate.

## Variants added
| Variant | Alias | Stub points to |
|---------|-------|---------------|
| `/debug` | `/dbg` | `apr trace --json --payload` for non-interactive tracing; real wiring → `PMAT-CODE-SLASH-DEBUG-001` (P2) |
| `/rename` | — | sessions currently identified by UUIDv7 id; rename → `PMAT-CODE-SLASH-RENAME-001` (P2) |
| `/upgrade` | — | `cargo install aprender --force` for now; self-upgrade → `PMAT-CODE-SLASH-UPGRADE-001` (P2) |

Same stub-handler pattern as the v4.2 parity batch: parser recognizes the variant so the operator sees a deliberate placeholder ("recognized, not yet wired") instead of "Unknown command".

## Test plan
- [x] `cargo test -p aprender-orchestrate --lib test_slash_command_parse` — 5/5 pass (incl. new `test_slash_command_parse_extended`)
- [x] `cargo fmt -p aprender-orchestrate -- --check` clean
- [x] Falsification gate: anything outside the canonical 24 still routes to `Unknown(name)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)