### PR TITLE
fix(apr-cli): route HumanEval through ChatML for instruct models — H4 SHIP-005 fix

### DIFF
--- a/crates/apr-cli/src/commands/eval/inference.rs
+++ b/crates/apr-cli/src/commands/eval/inference.rs
@@ -275,18 +275,24 @@ fn load_humaneval_tokenizer(
 
 /// ALB-084: Run HumanEval with actual model inference + Python test execution.
 ///
-/// PMAT-CODE-SHIP-005-FIX (2026-05-11): routed through `realizar::run_inference`
-/// + `OwnedQuantizedModel::from_apr` (the same working path that SHIP-002 +
-/// SHIP-006 + SHIP-008 LIVE-discharged) instead of the legacy
-/// `AprTransformer::forward_with_cache + AprKVCache` path. The legacy path
-/// produced 0/3 pass@1 on canonical 7B teacher smoke test (every problem
-/// FAIL); the run_inference path produces the canonical pairwise-comparison
-/// solution for HumanEval/0 (verified manually 2026-05-11 via `apr run`).
+/// PMAT-CODE-SHIP-005-H4-FIX (2026-05-11): for instruct-family models, route
+/// the prompt through ChatML auto-wrap (`InferenceConfig::with_prompt` →
+/// `prepare_tokens_apr` → ChatMLTemplate). Parse the assistant's
+/// `\`\`\`python ... \`\`\`` code block out of the response and use that as the
+/// completion. Falls back to raw-continuation when no code block is found
+/// (preserving the older PMAT-CODE-SHIP-005-FIX behaviour).
 ///
-/// HumanEval prompts are raw Python code (with docstrings); we tokenize via
-/// embedded BPE and pass via `InferenceConfig::with_input_tokens` to bypass
-/// `prepare_tokens_apr`'s ChatML auto-wrap (which would wrap raw Python in
-/// `<|im_start|>user...` causing degenerate output).
+/// Why: §65 + §66 evidence. Raw-continuation produces 34.15% pass@1 on
+/// canonical 7B Qwen2.5-Coder-Instruct. Same model + same prompt via `apr run`
+/// (ChatML auto-wrap) produces correct solutions. The Qwen-Instruct teacher
+/// is trained for chat format; published pass@1 = 88.4% uses chat template.
+///
+/// Detection: a model is considered "instruct" when its file extension is
+/// `.apr` and either the architecture metadata is qwen2/qwen/llama/mistral/
+/// phi/phi3, the vocabulary contains `<|im_start|>`, or the filename
+/// contains `instruct`/`-chat`. This matches `prepare_tokens_apr`'s
+/// detection logic; we don't replicate it — `with_prompt` triggers the same
+/// auto-wrap inside `prepare_tokens`.
 #[cfg(feature = "inference")]
 fn run_humaneval_inference(
     model_path: &Path,
@@ -321,16 +327,19 @@ fn run_humaneval_inference(
             continue;
         }
 
-        // Generate completion via run_inference (greedy, max 256 tokens).
-        // `with_input_tokens` bypasses `prepare_tokens_apr`'s ChatML auto-wrap
-        // — HumanEval prompts are raw Python and must NOT be wrapped.
-        let config = InferenceConfig::new(model_path)
-            .with_input_tokens(prompt_tokens.clone())
-            .with_max_tokens(256)
+        // H4 fix: route through ChatML auto-wrap via `with_prompt`. The
+        // `prepare_tokens_apr` in realizar/aprender-serve detects the
+        // instruct architecture from APR metadata and wraps the user prompt
+        // in `<|im_start|>user\n...<|im_end|>\n<|im_start|>assistant\n` for
+        // chat-tuned models. The assistant emits a markdown-wrapped Python
+        // code block.
+        let config_chatml = InferenceConfig::new(model_path)
+            .with_prompt(problem.prompt.clone())
+            .with_max_tokens(512)
             .with_temperature(0.0)
             .with_top_k(1);
 
-        let result = match run_inference(&config) {
+        let result = match run_inference(&config_chatml) {
             Ok(r) => r,
             Err(e) => {
                 if !json_output {
@@ -341,35 +350,48 @@ fn run_humaneval_inference(
             },
         };
 
-        // run_inference's `result.text` is the FULL decoded sequence
-        // (prompt + completion). Slicing by the prompt string preserves
-        // exact byte boundaries — slicing by tokens introduces a leading-
-        // whitespace artifact when the prompt ends with `\n` and the
-        // first generated token decodes as a leading-space-prefixed run.
-        let completion = if let Some(stripped) = result.text.strip_prefix(&problem.prompt) {
-            stripped.to_string()
+        // Try to extract a Python code block from the assistant response.
+        // On instruct-family models the response is wrapped in markdown;
+        // on base models the response is raw continuation — both are handled.
+        let completion = if let Some(code) = extract_python_code_block(&result.text) {
+            // ChatML/markdown path: assistant emitted `\`\`\`python\n…\n\`\`\``.
+            // The extracted code contains the full function (signature +
+            // body); concatenating with prompt would duplicate the signature,
+            // so we use the code block AS the program (after the prompt's
+            // imports — the canonical solution-checking format expects
+            // `prompt + completion` to be a valid program).
+            //
+            // The simplest robust approach is to use the extracted block
+            // directly as the COMPLETE function, drop the prompt's empty
+            // function shell, and append the test harness.
+            code
         } else {
-            // Fallback: token-level slicing if text doesn't begin with the
-            // prompt verbatim (e.g., tokenizer-specific whitespace handling).
-            let completion_tokens = if result.tokens.len() > result.input_token_count {
-                &result.tokens[result.input_token_count..]
+            // Raw-continuation fallback (pre-H4 path). Slice off the prompt
+            // prefix when it's verbatim in result.text; otherwise decode
+            // tokens past `input_token_count`. Apply dedent residual fix.
+            let raw = if let Some(stripped) = result.text.strip_prefix(&problem.prompt) {
+                stripped.to_string()
             } else {
-                &result.tokens[..]
+                let completion_tokens = if result.tokens.len() > result.input_token_count {
+                    &result.tokens[result.input_token_count..]
+                } else {
+                    &result.tokens[..]
+                };
+                tokenizer.decode(completion_tokens)
             };
-            tokenizer.decode(completion_tokens)
+            let truncated = truncate_at_function_boundary(&raw);
+            // The aligned form goes APPENDED to the prompt; encode that as
+            // the full continuation. We then split the prompt back off in
+            // the program-build step below.
+            format!("{}{}", problem.prompt, align_continuation_indent(&problem.prompt, truncated))
         };
-        let completion = truncate_at_function_boundary(&completion);
 
-        // PMAT-CODE-SHIP-005-WHITESPACE-RESIDUAL: BPE raw-continuation
-        // can emit a 1-space over-indent at the prompt-completion boundary.
-        // Align to the prompt's last non-empty line's indent before
-        // concatenation — invalid-Python IndentationError otherwise.
-        let aligned = align_continuation_indent(&problem.prompt, completion);
-
-        let full_program = format!(
-            "{}{}\n\n{}\n\ncheck({})\n",
-            problem.prompt, aligned, problem.test, entry
-        );
+        // Build the test program. Two cases:
+        //   - ChatML path: `completion` is a complete function from the
+        //     code block (signature + body). Use it directly.
+        //   - Raw-continuation path: `completion` already includes the
+        //     prompt prefix (concatenated above).
+        let full_program = format!("{completion}\n\n{}\n\ncheck({})\n", problem.test, entry);
 
         let ok = execute_python_test(&full_program, 10);
         if ok {
@@ -562,6 +584,45 @@ fn run_humaneval_inference_cuda(
     Err("CUDA not available (compile with --features cuda)".to_string())
 }
 
+/// PMAT-CODE-SHIP-005-H4-FIX: extract the first Python code block from a
+/// ChatML assistant response.
+///
+/// Instruct-family models (Qwen-Coder-Instruct, etc.) respond to a coding
+/// prompt with a markdown-wrapped solution like:
+///
+/// ```text
+/// Certainly! Here's a solution:
+/// ```python
+/// def truncate_number(number: float) -> float:
+///     import math
+///     fractional_part, _ = math.modf(number)
+///     return fractional_part
+/// ```
+/// ```
+///
+/// This helper extracts the inner code between the first ```python fence
+/// and the next ``` fence. Returns `None` when no fenced Python block is
+/// found (caller falls back to raw-continuation slicing).
+///
+/// Tolerant of variants:
+/// - ```python … ``` (preferred)
+/// - ```py … ```
+/// - ``` … ``` (untagged — still treated as Python on a code-eval path)
+pub(super) fn extract_python_code_block(text: &str) -> Option<String> {
+    for fence in ["```python\n", "```py\n", "```\n"] {
+        if let Some(start) = text.find(fence) {
+            let after_open = start + fence.len();
+            if let Some(rel_end) = text[after_open..].find("\n```") {
+                let code = &text[after_open..after_open + rel_end];
+                if !code.trim().is_empty() {
+                    return Some(code.to_string());
+                }
+            }
+        }
+    }
+    None
+}
+
 /// Truncate completion at the next top-level function/class definition.
 pub(super) fn truncate_at_function_boundary(completion: &str) -> &str {
     // Find the first '\ndef ' or '\nclass ' that indicates a new top-level definition
@@ -638,6 +699,59 @@ pub(super) fn align_continuation_indent(prompt: &str, completion: &str) -> Strin
             }
         })
         .collect()
+}
+
+#[cfg(test)]
+mod extract_python_code_block_tests {
+    use super::extract_python_code_block;
+
+    /// SHIP-005 H4 canonical case: assistant emits a Python fenced block.
+    #[test]
+    fn extracts_python_fenced_block() {
+        let text = "Certainly!\n```python\ndef f(x):\n    return x + 1\n```\nLet me know if you need more.";
+        let got = extract_python_code_block(text);
+        assert_eq!(got.as_deref(), Some("def f(x):\n    return x + 1"));
+    }
+
+    /// Tolerates `py` shortform fence.
+    #[test]
+    fn extracts_py_short_fence() {
+        let text = "```py\ndef g():\n    pass\n```";
+        let got = extract_python_code_block(text);
+        assert_eq!(got.as_deref(), Some("def g():\n    pass"));
+    }
+
+    /// Untagged fence — accept for code-eval path.
+    #[test]
+    fn extracts_untagged_fence() {
+        let text = "```\nimport os\n```";
+        let got = extract_python_code_block(text);
+        assert_eq!(got.as_deref(), Some("import os"));
+    }
+
+    /// No fence → None (caller falls back to raw-continuation).
+    #[test]
+    fn returns_none_on_no_fence() {
+        let text = "Just plain text with no code block.";
+        let got = extract_python_code_block(text);
+        assert!(got.is_none());
+    }
+
+    /// Empty fenced block → None (not an actionable code completion).
+    #[test]
+    fn returns_none_on_empty_fence() {
+        let text = "```python\n\n```";
+        let got = extract_python_code_block(text);
+        assert!(got.is_none());
+    }
+
+    /// Multiple fenced blocks → first one wins.
+    #[test]
+    fn extracts_first_of_multiple_blocks() {
+        let text = "```python\nfirst = 1\n```\nthen:\n```python\nsecond = 2\n```";
+        let got = extract_python_code_block(text);
+        assert_eq!(got.as_deref(), Some("first = 1"));
+    }
 }
 
 #[cfg(test)]

--- a/crates/aprender-core/src/format/bpe_inv_004.rs
+++ b/crates/aprender-core/src/format/bpe_inv_004.rs
@@ -135,11 +135,7 @@ pub fn verdict_from_merge_rule_count(
         Some(v) if v > 0 => v,
         _ => return BpeInv004Verdict::Fail,
     };
-    let abs_diff = if merge_count >= expected {
-        merge_count - expected
-    } else {
-        expected - merge_count
-    };
+    let abs_diff = merge_count.abs_diff(expected);
     if abs_diff <= AC_BPE_INV_004_SLACK {
         BpeInv004Verdict::Pass
     } else {

--- a/crates/aprender-core/src/format/bpe_inv_004.rs
+++ b/crates/aprender-core/src/format/bpe_inv_004.rs
@@ -1,0 +1,355 @@
+// SHIP-TWO-001 MODEL-2 — `tokenizer-bpe-v1` (C-TOK-BPE-001)
+// algorithm-level PARTIAL discharge for INV-BPE-004.
+//
+// Contract: `contracts/tokenizer-bpe-v1.yaml`.
+// Spec: `docs/specifications/aprender-train/ship-two-models-spec.md`
+// MODEL-2 tokenizer pipeline (§26.3), AC-SHIP2-003.
+//
+// ## What INV-BPE-004 says
+//
+//   description: Merge rules count equals
+//                (vocab_size − |special_tokens| − 256 byte-level
+//                fallback) ± 4. The ±4 slack covers byte-level
+//                fallback edge cases where a byte ID is added
+//                directly without a merge.
+//   falsifier:   Load merges.txt (or equivalent from
+//                tokenizer.json), count lines. Assert
+//                |merges| ∈ [49993, 50001] (for the canonical 50_257
+//                / 4 / 256 / ±4 example). Outside range fails.
+//
+// ## What this file proves NOW (`PARTIAL_ALGORITHM_LEVEL`)
+//
+// Decision rule: given (`merge_count`, `vocab_size`,
+// `special_token_count`, `byte_fallback_count`), compute the
+// expected merge count
+//
+//   expected = vocab_size − special_token_count − byte_fallback_count
+//
+// and Pass iff:
+//
+//   |merge_count − expected| <= AC_BPE_INV_004_SLACK (4)
+//
+// AND the inputs are well-formed:
+// - vocab_size > special_token_count + byte_fallback_count (no
+//   negative expected; the sum mustn't exhaust the vocab)
+// - byte_fallback_count <= 256 (a u9 invariant — there are exactly
+//   256 byte values; a count above 256 indicates corruption)
+// - the underlying subtraction is `checked_sub` to prevent silent
+//   wrapping at degenerate inputs
+
+/// Slack tolerance band on either side of the merge-count
+/// expectation.
+///
+/// Per contract `INV-BPE-004`: ±4 covers byte-level fallback edge
+/// cases (e.g., a byte id that is added directly without a merge,
+/// or 1-2 reserved bytes that the trainer skips). Drift to ±0 would
+/// over-tighten and reject valid byte-fallback variants; drift to
+/// ±10 would let a 6-merge regression slip through unnoticed.
+pub const AC_BPE_INV_004_SLACK: u64 = 4;
+
+/// Maximum number of byte-level fallback IDs.
+///
+/// There are exactly 256 byte values (0..256). The fallback set
+/// cannot exceed this; a value above 256 indicates corruption in
+/// the tokenizer config.
+pub const AC_BPE_INV_004_MAX_BYTE_FALLBACK: u64 = 256;
+
+/// Binary verdict for `INV-BPE-004`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BpeInv004Verdict {
+    /// Merge count is within ±4 of `vocab_size − specials − bytes`,
+    /// and all inputs are well-formed.
+    Pass,
+    /// One or more of:
+    /// - `byte_fallback_count > 256` (corruption — there are only 256 bytes).
+    /// - `vocab_size <= special_token_count + byte_fallback_count`
+    ///   (caller error — no room for any merges).
+    /// - `merge_count` differs from the expected value by more than ±4.
+    /// - Subtraction underflow (degenerate caller input).
+    Fail,
+}
+
+/// Pure verdict function for `INV-BPE-004`.
+///
+/// Inputs:
+/// - `merge_count`: actual merge-rule line count from `merges.txt`.
+/// - `vocab_size`: declared total vocabulary size.
+/// - `special_token_count`: number of special tokens (e.g., 4 for
+///   BOS/EOS/PAD/UNK; can be larger for chat-template tokens).
+/// - `byte_fallback_count`: number of byte-level fallback IDs
+///   (typically 256).
+///
+/// Pass iff:
+/// 1. `byte_fallback_count <= 256`,
+/// 2. `vocab_size > special_token_count + byte_fallback_count`
+///    (computed via `checked_add` + `checked_sub`),
+/// 3. `|merge_count − expected| <= 4`
+///    where `expected = vocab_size − special_token_count − byte_fallback_count`.
+///
+/// Otherwise `Fail`.
+///
+/// # Examples
+///
+/// GPT-2 canonical: 50_257 vocab − 1 special − 256 bytes = 50_000
+/// expected merges. Actual 50_000 → `Pass`:
+/// ```
+/// use aprender::format::bpe_inv_004::{
+///     verdict_from_merge_rule_count, BpeInv004Verdict,
+/// };
+/// let v = verdict_from_merge_rule_count(50_000, 50_257, 1, 256);
+/// assert_eq!(v, BpeInv004Verdict::Pass);
+/// ```
+///
+/// Same expectation, actual 50_004 (within ±4 slack) → `Pass`:
+/// ```
+/// use aprender::format::bpe_inv_004::{
+///     verdict_from_merge_rule_count, BpeInv004Verdict,
+/// };
+/// let v = verdict_from_merge_rule_count(50_004, 50_257, 1, 256);
+/// assert_eq!(v, BpeInv004Verdict::Pass);
+/// ```
+///
+/// Drift of 5 merges → `Fail`:
+/// ```
+/// use aprender::format::bpe_inv_004::{
+///     verdict_from_merge_rule_count, BpeInv004Verdict,
+/// };
+/// let v = verdict_from_merge_rule_count(50_005, 50_257, 1, 256);
+/// assert_eq!(v, BpeInv004Verdict::Fail);
+/// ```
+#[must_use]
+pub fn verdict_from_merge_rule_count(
+    merge_count: u64,
+    vocab_size: u64,
+    special_token_count: u64,
+    byte_fallback_count: u64,
+) -> BpeInv004Verdict {
+    if byte_fallback_count > AC_BPE_INV_004_MAX_BYTE_FALLBACK {
+        return BpeInv004Verdict::Fail;
+    }
+    let reserved = match special_token_count.checked_add(byte_fallback_count) {
+        Some(v) => v,
+        None => return BpeInv004Verdict::Fail,
+    };
+    let expected = match vocab_size.checked_sub(reserved) {
+        Some(v) if v > 0 => v,
+        _ => return BpeInv004Verdict::Fail,
+    };
+    let abs_diff = if merge_count >= expected {
+        merge_count - expected
+    } else {
+        expected - merge_count
+    };
+    if abs_diff <= AC_BPE_INV_004_SLACK {
+        BpeInv004Verdict::Pass
+    } else {
+        BpeInv004Verdict::Fail
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -------------------------------------------------------------------------
+    // Section 1: Provenance pin — slack and byte cap.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn provenance_slack_is_four() {
+        assert_eq!(AC_BPE_INV_004_SLACK, 4);
+    }
+
+    #[test]
+    fn provenance_max_byte_fallback_is_256() {
+        assert_eq!(AC_BPE_INV_004_MAX_BYTE_FALLBACK, 256);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 2: Pass band — exact and within-slack matches.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn pass_gpt2_canonical_exact() {
+        // 50_257 − 1 − 256 = 50_000 expected.
+        let v = verdict_from_merge_rule_count(50_000, 50_257, 1, 256);
+        assert_eq!(v, BpeInv004Verdict::Pass);
+    }
+
+    #[test]
+    fn pass_gpt2_at_plus_4_slack() {
+        let v = verdict_from_merge_rule_count(50_004, 50_257, 1, 256);
+        assert_eq!(v, BpeInv004Verdict::Pass);
+    }
+
+    #[test]
+    fn pass_gpt2_at_minus_4_slack() {
+        // 50_257 − 1 − 256 = 50_000; merge=49_996 is at -4 slack.
+        let v = verdict_from_merge_rule_count(49_996, 50_257, 1, 256);
+        assert_eq!(v, BpeInv004Verdict::Pass);
+    }
+
+    #[test]
+    fn pass_qwen_4_specials() {
+        // Qwen-style: 152_064 vocab − 22 specials − 256 bytes = 151_786 expected.
+        let v = verdict_from_merge_rule_count(151_786, 152_064, 22, 256);
+        assert_eq!(v, BpeInv004Verdict::Pass);
+    }
+
+    #[test]
+    fn pass_albor_llama_370m_4_specials() {
+        // MODEL-2 albor-llama: 32_000 − 4 − 256 = 31_740 expected.
+        let v = verdict_from_merge_rule_count(31_740, 32_000, 4, 256);
+        assert_eq!(v, BpeInv004Verdict::Pass);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 3: Fail band — outside ±4 slack.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fail_gpt2_at_plus_5() {
+        let v = verdict_from_merge_rule_count(50_005, 50_257, 1, 256);
+        assert_eq!(
+            v,
+            BpeInv004Verdict::Fail,
+            "+5 merges exceeds ±4 slack"
+        );
+    }
+
+    #[test]
+    fn fail_gpt2_at_minus_5() {
+        let v = verdict_from_merge_rule_count(49_995, 50_257, 1, 256);
+        assert_eq!(v, BpeInv004Verdict::Fail);
+    }
+
+    #[test]
+    fn fail_gpt2_at_plus_100() {
+        let v = verdict_from_merge_rule_count(50_100, 50_257, 1, 256);
+        assert_eq!(v, BpeInv004Verdict::Fail);
+    }
+
+    #[test]
+    fn fail_zero_merges_when_thousands_expected() {
+        // Catastrophic: merges.txt empty.
+        let v = verdict_from_merge_rule_count(0, 50_257, 1, 256);
+        assert_eq!(v, BpeInv004Verdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 4: Fail band — input domain violations.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fail_byte_fallback_above_256() {
+        // Only 256 byte values exist; 257 is corruption.
+        let v = verdict_from_merge_rule_count(50_000, 50_257, 1, 257);
+        assert_eq!(
+            v,
+            BpeInv004Verdict::Fail,
+            "byte_fallback > 256 must Fail (impossible by definition)"
+        );
+    }
+
+    #[test]
+    fn fail_byte_fallback_far_above_256() {
+        let v = verdict_from_merge_rule_count(50_000, 50_257, 1, 1_000_000);
+        assert_eq!(v, BpeInv004Verdict::Fail);
+    }
+
+    #[test]
+    fn fail_vocab_too_small_for_reserved() {
+        // vocab=200, specials=4, bytes=256 → reserved=260 > 200 → Fail.
+        let v = verdict_from_merge_rule_count(0, 200, 4, 256);
+        assert_eq!(
+            v,
+            BpeInv004Verdict::Fail,
+            "vocab < specials + bytes must Fail (no room for merges)"
+        );
+    }
+
+    #[test]
+    fn fail_vocab_exactly_equals_reserved() {
+        // vocab=260, specials=4, bytes=256 → expected=0 (no merges
+        // at all). The verdict refuses this as caller error: a BPE
+        // tokenizer with zero merges is degenerate.
+        let v = verdict_from_merge_rule_count(0, 260, 4, 256);
+        assert_eq!(v, BpeInv004Verdict::Fail);
+    }
+
+    #[test]
+    fn fail_specials_plus_bytes_overflow() {
+        // u64 overflow on (specials + bytes).
+        let huge = u64::MAX / 2 + 1;
+        let v = verdict_from_merge_rule_count(50_000, u64::MAX, huge, 256);
+        // huge + 256 < huge + huge; still a single overflow path
+        // exists if specials = u64::MAX. Test the unambiguous case:
+        let v2 = verdict_from_merge_rule_count(50_000, u64::MAX, u64::MAX, 256);
+        assert_eq!(
+            v,
+            BpeInv004Verdict::Fail,
+            "any caller-error condition must Fail"
+        );
+        assert_eq!(v2, BpeInv004Verdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 5: Boundary sweep — ±4 at fixed expectation.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn merge_count_sweep_around_50_000() {
+        let probes: Vec<(u64, BpeInv004Verdict)> = vec![
+            (49_990, BpeInv004Verdict::Fail),
+            (49_995, BpeInv004Verdict::Fail), // -5
+            (49_996, BpeInv004Verdict::Pass), // -4 (inclusive)
+            (49_997, BpeInv004Verdict::Pass),
+            (49_999, BpeInv004Verdict::Pass),
+            (50_000, BpeInv004Verdict::Pass), // exact
+            (50_001, BpeInv004Verdict::Pass),
+            (50_003, BpeInv004Verdict::Pass),
+            (50_004, BpeInv004Verdict::Pass), // +4 (inclusive)
+            (50_005, BpeInv004Verdict::Fail), // +5
+            (50_010, BpeInv004Verdict::Fail),
+        ];
+        for (merge, expected) in probes {
+            let v = verdict_from_merge_rule_count(merge, 50_257, 1, 256);
+            assert_eq!(v, expected, "merge={merge} expected {expected:?}");
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 6: Symmetry — ±k symmetric around exact.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn slack_is_symmetric() {
+        // For any k in 0..=4, both expected+k and expected-k must Pass.
+        let expected = 50_000_u64;
+        for k in 0..=4_u64 {
+            let v_high = verdict_from_merge_rule_count(expected + k, 50_257, 1, 256);
+            let v_low = verdict_from_merge_rule_count(expected - k, 50_257, 1, 256);
+            assert_eq!(v_high, BpeInv004Verdict::Pass, "+{k} slack");
+            assert_eq!(v_low, BpeInv004Verdict::Pass, "-{k} slack");
+        }
+        // ±5 must Fail on both sides.
+        for k in 5..=8_u64 {
+            let v_high = verdict_from_merge_rule_count(expected + k, 50_257, 1, 256);
+            let v_low = verdict_from_merge_rule_count(expected - k, 50_257, 1, 256);
+            assert_eq!(v_high, BpeInv004Verdict::Fail, "+{k} drift");
+            assert_eq!(v_low, BpeInv004Verdict::Fail, "-{k} drift");
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 7: Realistic — multiple model families with non-256-byte fallbacks.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn pass_with_zero_byte_fallback() {
+        // Pure word-piece tokenizer: no byte-level fallback (0).
+        // 1000 vocab − 4 specials − 0 bytes = 996 expected.
+        let v = verdict_from_merge_rule_count(996, 1_000, 4, 0);
+        assert_eq!(v, BpeInv004Verdict::Pass);
+    }
+
+    #[test]
+    fn pass_at_exactly_256_byte_fallback_boundary() {
+        // byte_fallback = 256 is the inclusive cap.
+        let v = verdict_from_merge_rule_count(31_740, 32_000, 4, 256);
+        assert_eq!(v, BpeInv004Verdict::Pass);
+    }
+}

--- a/crates/aprender-core/src/format/mod.rs
+++ b/crates/aprender-core/src/format/mod.rs
@@ -472,6 +472,9 @@ pub mod bpe_inv_003;
 // INV-BPE-002 — tokenizer-bpe four required special tokens distinct + in range.
 pub mod bpe_inv_002;
 
+// INV-BPE-004 — tokenizer-bpe merge-rule count algebra (vocab − specials − bytes ± 4).
+pub mod bpe_inv_004;
+
 // FALSIFY-PROF10-003 — apr profile graphed vs ungraphed sanity inequality.
 pub mod prof10_003;
 


### PR DESCRIPTION
## Summary

§66 confirmed (via 5-min cross-CLI test on gx10) that the 34.15% pass@1 in §65 is **harness methodology mismatch**, not model knowledge. This PR ships the H4 fix.

## Fix

`crates/apr-cli/src/commands/eval/inference.rs::run_humaneval_inference`:
- Switch from `InferenceConfig::with_input_tokens` (raw-continuation) to `InferenceConfig::with_prompt` (triggers ChatML auto-wrap inside `prepare_tokens_apr` for instruct-family models)
- NEW helper `extract_python_code_block(text)` — extracts code from `\`\`\`python ... \`\`\`` fenced blocks (also handles `\`\`\`py\`\`\`` and untagged `\`\`\``)
- Raw-continuation fallback when no fenced code block is found (preserves pre-H4 behaviour for base models)

## LIVE Smoke (2026-05-11, gx10-a5b5 Blackwell GB10)

5-problem mixed smoke (HumanEval/0, 2, 6, 15, 100):
- **4/5 PASS = 80% pass@1**
- HumanEval/0: PASS (was passing)
- **HumanEval/2: PASS** (was FAILING — H4 fixes it)
- HumanEval/6: FAIL (still failing — harder problem)
- **HumanEval/15: PASS** (was FAILING — H4 fixes it)
- **HumanEval/100: PASS** (was FAILING — H4 fixes it)

Full 164-run dispatched on gx10 (~5h wall). lambda-vector remains free per user direction.

## Unit Tests (6 passing)

- `extracts_python_fenced_block` (canonical case)
- `extracts_py_short_fence`
- `extracts_untagged_fence`
- `returns_none_on_no_fence` (raw-continuation fallback trigger)
- `returns_none_on_empty_fence`
- `extracts_first_of_multiple_blocks`

## Validation

- [x] `cargo test -p apr-cli --release --features cuda extract_python_code_block_tests` — 6/6 pass
- [x] `cargo build -p apr-cli --release --features cuda` (gx10 aarch64): clean
- [x] LIVE 4/5 pass@1 on canonical 7B APR teacher
- [ ] Full 164-run completion (~5h, dispatched in background on gx10)

## Ship-% Movement

- **MODEL-1 ship %**: stays at **94%** pending full 164-run completion
- **Expected post-164-run pass@1**: 80-88% (matches Qwen team's published 88.4%)
- **If pass@1 ≥ 84.80% on 164-run** → SHIP-005 LIVE-discharges → MODEL-1 ship % **94% → 95%**

## Why this is the right fix

- **Falsified raw-continuation** (§65): 34% pass@1 → far below 84.80% floor
- **Confirmed ChatML works** (§66 cross-CLI test): apr run with auto-wrap produces correct solutions
- **Aligned with Qwen team methodology** (published 88.4% uses chat template)
- **Backwards-compatible**: base models without ChatML detection still get raw-continuation via the fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)