### PR TITLE
chore(format): squash 20 more PARTIAL-discharge feat commits (batch 2)

### DIFF
--- a/crates/aprender-core/src/format/mod.rs
+++ b/crates/aprender-core/src/format/mod.rs
@@ -439,10 +439,10 @@ pub mod pub_cli_001;
 // FALSIFY-PUB-CLI-003 — apr --help line count > 50 (all 58 commands listed).
 pub mod pub_cli_003;
 
-// FALSIFY-SGD-001..003 — apr-stochastic-lr-v1 3-gate algorithm-level
-// PARTIAL discharge (backward compat default Batch, stochastic MCC > 0.3
-// on imbalanced, mini-batch(n) == full-batch unbiased).
-pub mod sgd_001_003;
+// F-SILENT-001..005 — apr-qa-silent-fallback-v1 5-gate algorithm-level
+// PARTIAL discharge (truncation detection, zero-tps rejection,
+// unknown-arch handling, missing-tokenizer detection, loud failure).
+pub mod qasilent_001_005;
 
 // FALSIFY-APR-PULL-DATASET-001 — apr pull dataset --help shows both flags + exits 0.
 pub mod pull_dataset_001;

--- a/crates/aprender-core/src/format/mod.rs
+++ b/crates/aprender-core/src/format/mod.rs
@@ -439,8 +439,8 @@ pub mod pub_cli_001;
 // FALSIFY-PUB-CLI-003 — apr --help line count > 50 (all 58 commands listed).
 pub mod pub_cli_003;
 
-// FALSIFY-RF-001..004 — random-forest-v1 PARTIAL_ALGORITHM_LEVEL discharge.
-pub mod rf_001_004;
+// FALSIFY-SE-001..004 — shannon-entropy-v1 PARTIAL_ALGORITHM_LEVEL discharge.
+pub mod se_001_004;
 
 // FALSIFY-APR-PULL-DATASET-001 — apr pull dataset --help shows both flags + exits 0.
 pub mod pull_dataset_001;

--- a/crates/aprender-core/src/format/mod.rs
+++ b/crates/aprender-core/src/format/mod.rs
@@ -439,12 +439,11 @@ pub mod pub_cli_001;
 // FALSIFY-PUB-CLI-003 — apr --help line count > 50 (all 58 commands listed).
 pub mod pub_cli_003;
 
-// FALSIFY-MONO-001..013 — cgp-monorepo-consolidation-v1 13-gate
-// algorithm-level PARTIAL discharge (incremental compile, CI time,
-// merge conflicts, publish time, broken-publish incidents, clone time,
-// history preservation, shim re-exports, version bump compat, registry
-// compliance, single binary, flat layout, contract per subcommand).
-pub mod mono_001_013;
+// FALSIFY-BUILD-001..007 — cgp-monorepo-build-v1 7-gate algorithm-level
+// PARTIAL discharge (no duplicate workspace members, version
+// consistency, ≥60 members, no [patch.crates-io], all dirs have
+// Cargo.toml, aprender-* naming, flat layout).
+pub mod monorepo_001_007;
 
 // FALSIFY-APR-PULL-DATASET-001 — apr pull dataset --help shows both flags + exits 0.
 pub mod pull_dataset_001;

--- a/crates/aprender-core/src/format/mod.rs
+++ b/crates/aprender-core/src/format/mod.rs
@@ -439,8 +439,12 @@ pub mod pub_cli_001;
 // FALSIFY-PUB-CLI-003 — apr --help line count > 50 (all 58 commands listed).
 pub mod pub_cli_003;
 
-// FALSIFY-CHAT-001..003 — chat template render decision rules.
-pub mod chat_template_001_003;
+// FALSIFY-MONO-001..013 — cgp-monorepo-consolidation-v1 13-gate
+// algorithm-level PARTIAL discharge (incremental compile, CI time,
+// merge conflicts, publish time, broken-publish incidents, clone time,
+// history preservation, shim re-exports, version bump compat, registry
+// compliance, single binary, flat layout, contract per subcommand).
+pub mod mono_001_013;
 
 // FALSIFY-APR-PULL-DATASET-001 — apr pull dataset --help shows both flags + exits 0.
 pub mod pull_dataset_001;

--- a/crates/aprender-core/src/format/mod.rs
+++ b/crates/aprender-core/src/format/mod.rs
@@ -439,11 +439,10 @@ pub mod pub_cli_001;
 // FALSIFY-PUB-CLI-003 — apr --help line count > 50 (all 58 commands listed).
 pub mod pub_cli_003;
 
-// FALSIFY-ZEROGATEV-001..004 — apr-zero-feature-gate-v1 4-gate
-// algorithm-level PARTIAL discharge (every subcommand --help exits 0,
-// no feature-gate phrases, GPU fallback graceful, default features
-// complete with cuda/code excluded).
-pub mod zerogate_001_004;
+// FALSIFY-SGD-001..003 — apr-stochastic-lr-v1 3-gate algorithm-level
+// PARTIAL discharge (backward compat default Batch, stochastic MCC > 0.3
+// on imbalanced, mini-batch(n) == full-batch unbiased).
+pub mod sgd_001_003;
 
 // FALSIFY-APR-PULL-DATASET-001 — apr pull dataset --help shows both flags + exits 0.
 pub mod pull_dataset_001;

--- a/crates/aprender-core/src/format/mod.rs
+++ b/crates/aprender-core/src/format/mod.rs
@@ -439,10 +439,10 @@ pub mod pub_cli_001;
 // FALSIFY-PUB-CLI-003 — apr --help line count > 50 (all 58 commands listed).
 pub mod pub_cli_003;
 
-// F-COV-001..005 — apr-qa-coverage-v1 5-gate algorithm-level PARTIAL
-// discharge (per-category command coverage, untested-surface tracking,
-// complexity gate, SATD zero, dogfood exercise map).
-pub mod qacov_001_005;
+// FALSIFY-ORGTAX-001..005 — apr-org-taxonomy-v1 5-condition algorithm-level
+// PARTIAL discharge (orphan classification, archive deadline, stale archive,
+// legacy redirect, category sum).
+pub mod orgtax_001_005;
 
 // FALSIFY-APR-PULL-DATASET-001 — apr pull dataset --help shows both flags + exits 0.
 pub mod pull_dataset_001;

--- a/crates/aprender-core/src/format/mod.rs
+++ b/crates/aprender-core/src/format/mod.rs
@@ -439,10 +439,10 @@ pub mod pub_cli_001;
 // FALSIFY-PUB-CLI-003 — apr --help line count > 50 (all 58 commands listed).
 pub mod pub_cli_003;
 
-// F-DIFF-001..005 — apr-qa-differential-v1 5-gate algorithm-level
-// PARTIAL discharge (ollama parity, tokenizer roundtrip, concurrent
-// serve parity, perplexity budget per quantization, cross-format L2).
-pub mod qadiff_001_005;
+// F-COV-001..005 — apr-qa-coverage-v1 5-gate algorithm-level PARTIAL
+// discharge (per-category command coverage, untested-surface tracking,
+// complexity gate, SATD zero, dogfood exercise map).
+pub mod qacov_001_005;
 
 // FALSIFY-APR-PULL-DATASET-001 — apr pull dataset --help shows both flags + exits 0.
 pub mod pull_dataset_001;

--- a/crates/aprender-core/src/format/mod.rs
+++ b/crates/aprender-core/src/format/mod.rs
@@ -439,8 +439,8 @@ pub mod pub_cli_001;
 // FALSIFY-PUB-CLI-003 — apr --help line count > 50 (all 58 commands listed).
 pub mod pub_cli_003;
 
-// FALSIFY-MOE_ROUTER_V1_001..003 — moe-router-v1 PARTIAL_ALGORITHM_LEVEL discharge.
-pub mod moer_001_003;
+// FALSIFY-SD-001..005 — speculative-decoding-v1 PARTIAL_ALGORITHM_LEVEL discharge.
+pub mod sd_001_005;
 
 // FALSIFY-APR-PULL-DATASET-001 — apr pull dataset --help shows both flags + exits 0.
 pub mod pull_dataset_001;

--- a/crates/aprender-core/src/format/mod.rs
+++ b/crates/aprender-core/src/format/mod.rs
@@ -439,8 +439,8 @@ pub mod pub_cli_001;
 // FALSIFY-PUB-CLI-003 — apr --help line count > 50 (all 58 commands listed).
 pub mod pub_cli_003;
 
-// FALSIFY-MOE_EXPERT_DISPATCH_V1_001..002 — moe-expert-dispatch-v1 PARTIAL_ALGORITHM_LEVEL discharge.
-pub mod moed_001_002;
+// FALSIFY-MOE_ROUTER_V1_001..003 — moe-router-v1 PARTIAL_ALGORITHM_LEVEL discharge.
+pub mod moer_001_003;
 
 // FALSIFY-APR-PULL-DATASET-001 — apr pull dataset --help shows both flags + exits 0.
 pub mod pull_dataset_001;

--- a/crates/aprender-core/src/format/mod.rs
+++ b/crates/aprender-core/src/format/mod.rs
@@ -439,8 +439,8 @@ pub mod pub_cli_001;
 // FALSIFY-PUB-CLI-003 — apr --help line count > 50 (all 58 commands listed).
 pub mod pub_cli_003;
 
-// FALSIFY-RANK-001..004 — metrics-ranking-v1 PARTIAL_ALGORITHM_LEVEL discharge.
-pub mod rank_001_004;
+// FALSIFY-SVM-001..004 — svm-v1 PARTIAL_ALGORITHM_LEVEL discharge.
+pub mod svm_001_004;
 
 // FALSIFY-APR-PULL-DATASET-001 — apr pull dataset --help shows both flags + exits 0.
 pub mod pull_dataset_001;

--- a/crates/aprender-core/src/format/mod.rs
+++ b/crates/aprender-core/src/format/mod.rs
@@ -439,8 +439,8 @@ pub mod pub_cli_001;
 // FALSIFY-PUB-CLI-003 — apr --help line count > 50 (all 58 commands listed).
 pub mod pub_cli_003;
 
-// FALSIFY-SD-001..005 — speculative-decoding-v1 PARTIAL_ALGORITHM_LEVEL discharge.
-pub mod sd_001_005;
+// FALSIFY-RF-001..004 — random-forest-v1 PARTIAL_ALGORITHM_LEVEL discharge.
+pub mod rf_001_004;
 
 // FALSIFY-APR-PULL-DATASET-001 — apr pull dataset --help shows both flags + exits 0.
 pub mod pull_dataset_001;

--- a/crates/aprender-core/src/format/mod.rs
+++ b/crates/aprender-core/src/format/mod.rs
@@ -439,8 +439,8 @@ pub mod pub_cli_001;
 // FALSIFY-PUB-CLI-003 — apr --help line count > 50 (all 58 commands listed).
 pub mod pub_cli_003;
 
-// FALSIFY-SVM-001..004 — svm-v1 PARTIAL_ALGORITHM_LEVEL discharge.
-pub mod svm_001_004;
+// FALSIFY-PCA-001..004 — pca-v1 PARTIAL_ALGORITHM_LEVEL discharge.
+pub mod pca_001_004;
 
 // FALSIFY-APR-PULL-DATASET-001 — apr pull dataset --help shows both flags + exits 0.
 pub mod pull_dataset_001;

--- a/crates/aprender-core/src/format/mod.rs
+++ b/crates/aprender-core/src/format/mod.rs
@@ -439,11 +439,10 @@ pub mod pub_cli_001;
 // FALSIFY-PUB-CLI-003 — apr --help line count > 50 (all 58 commands listed).
 pub mod pub_cli_003;
 
-// FALSIFY-BUILD-001..007 — cgp-monorepo-build-v1 7-gate algorithm-level
-// PARTIAL discharge (no duplicate workspace members, version
-// consistency, ≥60 members, no [patch.crates-io], all dirs have
-// Cargo.toml, aprender-* naming, flat layout).
-pub mod monorepo_001_007;
+// FALSIFY-VERSION-001..003 — apr-version-traceability-v1 3-gate
+// algorithm-level PARTIAL discharge (no `(unknown)` sentinel, no
+// alternative sentinels, version string present).
+pub mod version_001_003;
 
 // FALSIFY-APR-PULL-DATASET-001 — apr pull dataset --help shows both flags + exits 0.
 pub mod pull_dataset_001;

--- a/crates/aprender-core/src/format/mod.rs
+++ b/crates/aprender-core/src/format/mod.rs
@@ -439,8 +439,8 @@ pub mod pub_cli_001;
 // FALSIFY-PUB-CLI-003 — apr --help line count > 50 (all 58 commands listed).
 pub mod pub_cli_003;
 
-// FALSIFY-PCA-001..004 — pca-v1 PARTIAL_ALGORITHM_LEVEL discharge.
-pub mod pca_001_004;
+// FALSIFY-OPT-001..003 — optimization-v1 PARTIAL_ALGORITHM_LEVEL discharge.
+pub mod opt_001_003;
 
 // FALSIFY-APR-PULL-DATASET-001 — apr pull dataset --help shows both flags + exits 0.
 pub mod pull_dataset_001;

--- a/crates/aprender-core/src/format/mod.rs
+++ b/crates/aprender-core/src/format/mod.rs
@@ -439,8 +439,8 @@ pub mod pub_cli_001;
 // FALSIFY-PUB-CLI-003 — apr --help line count > 50 (all 58 commands listed).
 pub mod pub_cli_003;
 
-// FALSIFY-OPT-001..003 — optimization-v1 PARTIAL_ALGORITHM_LEVEL discharge.
-pub mod opt_001_003;
+// FALSIFY-MOE_EXPERT_DISPATCH_V1_001..002 — moe-expert-dispatch-v1 PARTIAL_ALGORITHM_LEVEL discharge.
+pub mod moed_001_002;
 
 // FALSIFY-APR-PULL-DATASET-001 — apr pull dataset --help shows both flags + exits 0.
 pub mod pull_dataset_001;

--- a/crates/aprender-core/src/format/mod.rs
+++ b/crates/aprender-core/src/format/mod.rs
@@ -439,10 +439,8 @@ pub mod pub_cli_001;
 // FALSIFY-PUB-CLI-003 — apr --help line count > 50 (all 58 commands listed).
 pub mod pub_cli_003;
 
-// FALSIFY-ORGTAX-001..005 — apr-org-taxonomy-v1 5-condition algorithm-level
-// PARTIAL discharge (orphan classification, archive deadline, stale archive,
-// legacy redirect, category sum).
-pub mod orgtax_001_005;
+// FALSIFY-RANK-001..004 — metrics-ranking-v1 PARTIAL_ALGORITHM_LEVEL discharge.
+pub mod rank_001_004;
 
 // FALSIFY-APR-PULL-DATASET-001 — apr pull dataset --help shows both flags + exits 0.
 pub mod pull_dataset_001;

--- a/crates/aprender-core/src/format/mod.rs
+++ b/crates/aprender-core/src/format/mod.rs
@@ -439,10 +439,11 @@ pub mod pub_cli_001;
 // FALSIFY-PUB-CLI-003 — apr --help line count > 50 (all 58 commands listed).
 pub mod pub_cli_003;
 
-// FALSIFY-VERSION-001..003 — apr-version-traceability-v1 3-gate
-// algorithm-level PARTIAL discharge (no `(unknown)` sentinel, no
-// alternative sentinels, version string present).
-pub mod version_001_003;
+// FALSIFY-ZEROGATEV-001..004 — apr-zero-feature-gate-v1 4-gate
+// algorithm-level PARTIAL discharge (every subcommand --help exits 0,
+// no feature-gate phrases, GPU fallback graceful, default features
+// complete with cuda/code excluded).
+pub mod zerogate_001_004;
 
 // FALSIFY-APR-PULL-DATASET-001 — apr pull dataset --help shows both flags + exits 0.
 pub mod pull_dataset_001;

--- a/crates/aprender-core/src/format/mod.rs
+++ b/crates/aprender-core/src/format/mod.rs
@@ -439,10 +439,10 @@ pub mod pub_cli_001;
 // FALSIFY-PUB-CLI-003 — apr --help line count > 50 (all 58 commands listed).
 pub mod pub_cli_003;
 
-// F-SILENT-001..005 — apr-qa-silent-fallback-v1 5-gate algorithm-level
-// PARTIAL discharge (truncation detection, zero-tps rejection,
-// unknown-arch handling, missing-tokenizer detection, loud failure).
-pub mod qasilent_001_005;
+// F-META-001..005 — apr-qa-metamorphic-v1 5-gate algorithm-level PARTIAL
+// discharge (quant equivalence, roundtrip fidelity, multi-arch smoke,
+// prompt invariance, temperature=0 determinism).
+pub mod qameta_001_005;
 
 // FALSIFY-APR-PULL-DATASET-001 — apr pull dataset --help shows both flags + exits 0.
 pub mod pull_dataset_001;

--- a/crates/aprender-core/src/format/mod.rs
+++ b/crates/aprender-core/src/format/mod.rs
@@ -439,10 +439,10 @@ pub mod pub_cli_001;
 // FALSIFY-PUB-CLI-003 — apr --help line count > 50 (all 58 commands listed).
 pub mod pub_cli_003;
 
-// F-META-001..005 — apr-qa-metamorphic-v1 5-gate algorithm-level PARTIAL
-// discharge (quant equivalence, roundtrip fidelity, multi-arch smoke,
-// prompt invariance, temperature=0 determinism).
-pub mod qameta_001_005;
+// F-DIFF-001..005 — apr-qa-differential-v1 5-gate algorithm-level
+// PARTIAL discharge (ollama parity, tokenizer roundtrip, concurrent
+// serve parity, perplexity budget per quantization, cross-format L2).
+pub mod qadiff_001_005;
 
 // FALSIFY-APR-PULL-DATASET-001 — apr pull dataset --help shows both flags + exits 0.
 pub mod pull_dataset_001;

--- a/crates/aprender-core/src/format/mod.rs
+++ b/crates/aprender-core/src/format/mod.rs
@@ -439,8 +439,8 @@ pub mod pub_cli_001;
 // FALSIFY-PUB-CLI-003 — apr --help line count > 50 (all 58 commands listed).
 pub mod pub_cli_003;
 
-// FALSIFY-SE-001..004 — shannon-entropy-v1 PARTIAL_ALGORITHM_LEVEL discharge.
-pub mod se_001_004;
+// FALSIFY-NB-001..005 — naive-bayes-v1 PARTIAL_ALGORITHM_LEVEL discharge.
+pub mod nb_001_005;
 
 // FALSIFY-APR-PULL-DATASET-001 — apr pull dataset --help shows both flags + exits 0.
 pub mod pull_dataset_001;

--- a/crates/aprender-core/src/format/moed_001_002.rs
+++ b/crates/aprender-core/src/format/moed_001_002.rs
@@ -1,0 +1,501 @@
+// SHIP-TWO-001 — `moe-expert-dispatch-v1` algorithm-level PARTIAL
+// discharge for FALSIFY-MOE_EXPERT_DISPATCH_V1_001..002.
+//
+// Contract: `contracts/moe-expert-dispatch-v1.yaml`.
+// Spec: `docs/specifications/aprender-train/ship-two-models-spec.md`.
+//
+// ## What this file proves NOW (PARTIAL_ALGORITHM_LEVEL)
+//
+// Two dispatch gates from Fedus et al. (2022) Switch Transformers:
+//
+// - MOE-DISPATCH-001 (expert isolation): every expert e only processes
+//   tokens routed to e. Concretely: `dispatched[e]` is a subset of
+//   `selected[t]` ⇒ {t : e ∈ selected[t]}.
+// - MOE-DISPATCH-002 (weighted aggregation):
+//   output[t] = Σ_{e ∈ selected[t]} weight[t,e] * expert_output[t,e]
+//   matches a reference scalar implementation within tolerance.
+//
+// In-module reference: `expert_dispatch` returns per-expert token
+// lists; `weighted_aggregate` does the post-FFN combine.
+
+/// ULP tolerance for weighted aggregation parity.
+pub const AC_MOE_DISPATCH_002_AGG_TOLERANCE: f32 = 1e-5;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MoeDispatchVerdict {
+    Pass,
+    Fail,
+}
+
+// -----------------------------------------------------------------------------
+// In-module reference dispatch.
+// -----------------------------------------------------------------------------
+
+/// Dispatch tokens to experts. Given `selected[t]` = the list of expert
+/// indices selected for token t, returns `dispatched[e]` = list of
+/// (token_idx, weight_idx) tuples for expert e, where weight_idx is
+/// the position of e within selected[t] (so the caller can find the
+/// weight in selected_weights[t][weight_idx]).
+#[must_use]
+pub fn expert_dispatch(
+    selected: &[Vec<usize>],
+    n_experts: usize,
+) -> Vec<Vec<(usize, usize)>> {
+    let mut dispatched: Vec<Vec<(usize, usize)>> = vec![Vec::new(); n_experts];
+    for (t, sel) in selected.iter().enumerate() {
+        for (k_idx, &e) in sel.iter().enumerate() {
+            if e < n_experts {
+                dispatched[e].push((t, k_idx));
+            }
+        }
+    }
+    dispatched
+}
+
+/// Reference weighted aggregation:
+/// output[t][d] = Σ_{e ∈ selected[t]} weight[t][e] * expert_output[t][e][d]
+///
+/// `expert_outputs[t][k][d]` is the d-th hidden dim of the FFN output
+/// of the k-th expert chosen for token t. `selected_weights[t][k]` is
+/// the renormalized weight for that expert.
+///
+/// Returns flat row-major `[n_tokens, hidden_dim]`.
+#[must_use]
+pub fn weighted_aggregate(
+    expert_outputs: &[Vec<Vec<f32>>],
+    selected_weights: &[Vec<f32>],
+    hidden_dim: usize,
+) -> Vec<f32> {
+    let n_tokens = expert_outputs.len();
+    let mut out = vec![0.0_f32; n_tokens * hidden_dim];
+    for t in 0..n_tokens {
+        let k = expert_outputs[t].len();
+        for k_idx in 0..k {
+            let w = selected_weights[t][k_idx];
+            for d in 0..hidden_dim {
+                out[t * hidden_dim + d] += w * expert_outputs[t][k_idx][d];
+            }
+        }
+    }
+    out
+}
+
+// -----------------------------------------------------------------------------
+// Verdict 1: MOE-DISPATCH-001 — expert isolation.
+// -----------------------------------------------------------------------------
+
+/// Pass iff every (token, k_idx) in `dispatched[e]` corresponds to
+/// `selected[token][k_idx] == e`.
+///
+/// In other words: each expert sees exactly the tokens routed to it,
+/// nothing more, nothing less.
+#[must_use]
+pub fn verdict_from_expert_isolation(
+    dispatched: &[Vec<(usize, usize)>],
+    selected: &[Vec<usize>],
+) -> MoeDispatchVerdict {
+    let n_experts = dispatched.len();
+    if n_experts == 0 {
+        return MoeDispatchVerdict::Fail;
+    }
+
+    // Build the "expected" multiset from `selected`.
+    let mut expected: Vec<Vec<(usize, usize)>> = vec![Vec::new(); n_experts];
+    for (t, sel) in selected.iter().enumerate() {
+        for (k_idx, &e) in sel.iter().enumerate() {
+            if e >= n_experts {
+                return MoeDispatchVerdict::Fail;
+            }
+            expected[e].push((t, k_idx));
+        }
+    }
+
+    // Compare per-expert sorted lists for set-equality (allowing
+    // any internal order in dispatched).
+    for e in 0..n_experts {
+        let mut a = dispatched[e].clone();
+        let mut b = expected[e].clone();
+        a.sort_unstable();
+        b.sort_unstable();
+        if a != b {
+            return MoeDispatchVerdict::Fail;
+        }
+    }
+    MoeDispatchVerdict::Pass
+}
+
+// -----------------------------------------------------------------------------
+// Verdict 2: MOE-DISPATCH-002 — weighted aggregation.
+// -----------------------------------------------------------------------------
+
+/// Pass iff `actual` and `expected` agree elementwise within
+/// `AC_MOE_DISPATCH_002_AGG_TOLERANCE`.
+#[must_use]
+pub fn verdict_from_weighted_aggregation(actual: &[f32], expected: &[f32]) -> MoeDispatchVerdict {
+    if actual.len() != expected.len() {
+        return MoeDispatchVerdict::Fail;
+    }
+    if actual.is_empty() {
+        return MoeDispatchVerdict::Fail;
+    }
+    for (a, e) in actual.iter().zip(expected.iter()) {
+        if !a.is_finite() || !e.is_finite() {
+            return MoeDispatchVerdict::Fail;
+        }
+        if (a - e).abs() >= AC_MOE_DISPATCH_002_AGG_TOLERANCE {
+            return MoeDispatchVerdict::Fail;
+        }
+    }
+    MoeDispatchVerdict::Pass
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -------------------------------------------------------------------------
+    // Section 1: Provenance pin.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn provenance_agg_tolerance_1e_5() {
+        assert_eq!(AC_MOE_DISPATCH_002_AGG_TOLERANCE, 1e-5);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 2: MOE-DISPATCH-001 Pass band.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn moed001_pass_simple_dispatch() {
+        // 3 tokens, 4 experts, top-2.
+        // token 0 → experts {1, 0}
+        // token 1 → experts {2, 3}
+        // token 2 → experts {1, 3}
+        let selected = vec![vec![1_usize, 0], vec![2, 3], vec![1, 3]];
+        let dispatched = expert_dispatch(&selected, 4);
+        assert_eq!(
+            verdict_from_expert_isolation(&dispatched, &selected),
+            MoeDispatchVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn moed001_pass_single_token_single_expert() {
+        let selected = vec![vec![0_usize]];
+        let dispatched = expert_dispatch(&selected, 4);
+        assert_eq!(
+            verdict_from_expert_isolation(&dispatched, &selected),
+            MoeDispatchVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn moed001_pass_unused_expert() {
+        // Expert 3 never selected; its dispatched list must be empty.
+        let selected = vec![vec![0_usize, 1], vec![0, 2]];
+        let dispatched = expert_dispatch(&selected, 4);
+        assert!(dispatched[3].is_empty());
+        assert_eq!(
+            verdict_from_expert_isolation(&dispatched, &selected),
+            MoeDispatchVerdict::Pass
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 3: MOE-DISPATCH-001 Fail band.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn moed001_fail_extra_token_routed_to_expert() {
+        let selected = vec![vec![1_usize, 0]];
+        let mut dispatched = expert_dispatch(&selected, 4);
+        // Inject an extra (token=99, k_idx=0) into expert 2 — token 99
+        // never selected expert 2.
+        dispatched[2].push((99, 0));
+        assert_eq!(
+            verdict_from_expert_isolation(&dispatched, &selected),
+            MoeDispatchVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn moed001_fail_missing_token_from_expert() {
+        let selected = vec![vec![1_usize, 0], vec![1, 2]];
+        let mut dispatched = expert_dispatch(&selected, 4);
+        // Drop one token from expert 1 — it should have 2 entries.
+        dispatched[1].pop();
+        assert_eq!(
+            verdict_from_expert_isolation(&dispatched, &selected),
+            MoeDispatchVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn moed001_fail_expert_index_out_of_range() {
+        // Selected has expert id 99 but we declared n_experts=4.
+        let selected = vec![vec![99_usize, 0]];
+        let dispatched = expert_dispatch(&selected, 4);
+        // expert_dispatch silently drops e >= n_experts; isolation
+        // verdict catches this via the comparison loop.
+        assert_eq!(
+            verdict_from_expert_isolation(&dispatched, &selected),
+            MoeDispatchVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn moed001_fail_empty_dispatched() {
+        // n_experts=0 is illegal.
+        let selected: Vec<Vec<usize>> = vec![vec![0_usize]];
+        let dispatched: Vec<Vec<(usize, usize)>> = vec![];
+        assert_eq!(
+            verdict_from_expert_isolation(&dispatched, &selected),
+            MoeDispatchVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn moed001_fail_wrong_token_index() {
+        let selected = vec![vec![0_usize], vec![0]];
+        let mut dispatched = expert_dispatch(&selected, 2);
+        // expert 0 should have entries [(0, 0), (1, 0)]; corrupt one:
+        dispatched[0][0].0 = 5; // wrong token id
+        assert_eq!(
+            verdict_from_expert_isolation(&dispatched, &selected),
+            MoeDispatchVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 4: MOE-DISPATCH-002 Pass band.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn moed002_pass_identical() {
+        let actual = vec![1.0_f32, 2.0, 3.0];
+        let expected = vec![1.0_f32, 2.0, 3.0];
+        assert_eq!(
+            verdict_from_weighted_aggregation(&actual, &expected),
+            MoeDispatchVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn moed002_pass_within_tolerance() {
+        let actual = vec![1.0_f32, 2.000005];
+        let expected = vec![1.0_f32, 2.0];
+        assert_eq!(
+            verdict_from_weighted_aggregation(&actual, &expected),
+            MoeDispatchVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn moed002_pass_realistic_aggregation() {
+        // 1 token, 2 experts, hidden_dim=3.
+        // selected[0] = [0, 1], weights = [0.6, 0.4]
+        // expert_outputs[0][0] = [1, 2, 3], [0][1] = [4, 5, 6]
+        // expected output[0] = 0.6*[1,2,3] + 0.4*[4,5,6] = [2.2, 3.2, 4.2]
+        let expert_outputs = vec![vec![vec![1.0_f32, 2.0, 3.0], vec![4.0, 5.0, 6.0]]];
+        let selected_weights = vec![vec![0.6_f32, 0.4]];
+        let actual = weighted_aggregate(&expert_outputs, &selected_weights, 3);
+
+        let expected = vec![2.2_f32, 3.2, 4.2];
+        assert_eq!(
+            verdict_from_weighted_aggregation(&actual, &expected),
+            MoeDispatchVerdict::Pass
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 5: MOE-DISPATCH-002 Fail band.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn moed002_fail_above_tolerance() {
+        let actual = vec![1.0_f32, 2.001];
+        let expected = vec![1.0_f32, 2.0];
+        assert_eq!(
+            verdict_from_weighted_aggregation(&actual, &expected),
+            MoeDispatchVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn moed002_fail_length_mismatch() {
+        let actual = vec![1.0_f32, 2.0];
+        let expected = vec![1.0_f32, 2.0, 3.0];
+        assert_eq!(
+            verdict_from_weighted_aggregation(&actual, &expected),
+            MoeDispatchVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn moed002_fail_empty_both() {
+        let v: Vec<f32> = vec![];
+        assert_eq!(
+            verdict_from_weighted_aggregation(&v, &v),
+            MoeDispatchVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn moed002_fail_nan_actual() {
+        let actual = vec![f32::NAN];
+        let expected = vec![1.0_f32];
+        assert_eq!(
+            verdict_from_weighted_aggregation(&actual, &expected),
+            MoeDispatchVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn moed002_fail_inf_expected() {
+        let actual = vec![1.0_f32];
+        let expected = vec![f32::INFINITY];
+        assert_eq!(
+            verdict_from_weighted_aggregation(&actual, &expected),
+            MoeDispatchVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 6: Domain — reference functions.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn domain_expert_dispatch_correct_tuples() {
+        let selected = vec![vec![1_usize, 0], vec![1, 2]];
+        let dispatched = expert_dispatch(&selected, 3);
+        // Expert 0: token 0 picked it at k_idx=1.
+        assert_eq!(dispatched[0], vec![(0, 1)]);
+        // Expert 1: tokens 0, 1 each picked it at k_idx=0.
+        assert_eq!(dispatched[1], vec![(0, 0), (1, 0)]);
+        // Expert 2: token 1 picked it at k_idx=1.
+        assert_eq!(dispatched[2], vec![(1, 1)]);
+    }
+
+    #[test]
+    fn domain_weighted_aggregate_zero_weights_zero_output() {
+        let expert_outputs = vec![vec![vec![1.0_f32], vec![2.0]]];
+        let selected_weights = vec![vec![0.0_f32, 0.0]];
+        let out = weighted_aggregate(&expert_outputs, &selected_weights, 1);
+        assert_eq!(out, vec![0.0_f32]);
+    }
+
+    #[test]
+    fn domain_weighted_aggregate_single_expert_unweighted() {
+        // weight=1.0 selects single expert ⇒ output = expert_output.
+        let expert_outputs = vec![vec![vec![5.0_f32, 6.0]]];
+        let selected_weights = vec![vec![1.0_f32]];
+        let out = weighted_aggregate(&expert_outputs, &selected_weights, 2);
+        assert_eq!(out, vec![5.0_f32, 6.0]);
+    }
+
+    #[test]
+    fn domain_dispatch_then_aggregate_round_trip() {
+        // 2 tokens, 3 experts, top-2; verify dispatch + aggregate
+        // commute cleanly.
+        let selected = vec![vec![0_usize, 1], vec![1, 2]];
+        let n_experts = 3;
+        let dispatched = expert_dispatch(&selected, n_experts);
+        assert_eq!(
+            verdict_from_expert_isolation(&dispatched, &selected),
+            MoeDispatchVerdict::Pass
+        );
+
+        // Build expert_outputs/selected_weights from the dispatch:
+        // (synthetic — each expert outputs constant-ish vectors)
+        let weights = vec![vec![0.5_f32, 0.5], vec![0.6, 0.4]];
+        let outputs = vec![
+            vec![vec![1.0_f32, 0.0], vec![0.0, 1.0]],
+            vec![vec![1.0_f32, 1.0], vec![2.0, 2.0]],
+        ];
+        let actual = weighted_aggregate(&outputs, &weights, 2);
+
+        // Manually compute expected:
+        // token 0: 0.5*[1,0] + 0.5*[0,1] = [0.5, 0.5]
+        // token 1: 0.6*[1,1] + 0.4*[2,2] = [1.4, 1.4]
+        let expected = vec![0.5_f32, 0.5, 1.4, 1.4];
+        assert_eq!(
+            verdict_from_weighted_aggregation(&actual, &expected),
+            MoeDispatchVerdict::Pass
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 7: Sweep — n_experts and top-k combinations.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn sweep_isolation_passes_for_various_topologies() {
+        // Try (n_tokens, n_experts, k) combinations.
+        let test_cases = [(3_usize, 4, 1), (3, 4, 2), (5, 8, 2), (10, 16, 4)];
+        for (nt, ne, k) in test_cases {
+            let mut selected = Vec::new();
+            for t in 0..nt {
+                let row: Vec<usize> = (0..k).map(|i| (t + i) % ne).collect();
+                selected.push(row);
+            }
+            let dispatched = expert_dispatch(&selected, ne);
+            assert_eq!(
+                verdict_from_expert_isolation(&dispatched, &selected),
+                MoeDispatchVerdict::Pass,
+                "nt={nt} ne={ne} k={k}"
+            );
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 8: Realistic — contract regression scenarios.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn realistic_isolation_violation_caught() {
+        // Bug regression: an expert receives a token that wasn't routed
+        // to it. Catch via verdict.
+        let selected = vec![vec![0_usize, 1]];
+        let mut dispatched = expert_dispatch(&selected, 4);
+        dispatched[2].push((0, 0)); // Bug: token 0 wasn't routed to expert 2.
+        assert_eq!(
+            verdict_from_expert_isolation(&dispatched, &selected),
+            MoeDispatchVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn realistic_aggregation_off_by_factor() {
+        // Bug regression: weights applied incorrectly (e.g., sum uses
+        // unrenormalized weights instead of renormalized).
+        let actual = vec![1.5_f32]; // bug: 1.5x correct
+        let expected = vec![1.0_f32];
+        assert_eq!(
+            verdict_from_weighted_aggregation(&actual, &expected),
+            MoeDispatchVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn realistic_full_dispatch_pipeline() {
+        // 2 tokens, 4 experts, top-2 — full pipeline.
+        let selected = vec![vec![1_usize, 0], vec![2, 3]];
+        let weights = vec![vec![0.7_f32, 0.3], vec![0.5, 0.5]];
+
+        // Synthetic expert outputs per chosen-expert per token, dim=2.
+        let expert_outputs = vec![
+            // token 0: expert 1 output, then expert 0 output
+            vec![vec![10.0_f32, 0.0], vec![0.0, 10.0]],
+            // token 1: expert 2 output, then expert 3 output
+            vec![vec![1.0_f32, 1.0], vec![2.0, 2.0]],
+        ];
+
+        let dispatched = expert_dispatch(&selected, 4);
+        assert_eq!(
+            verdict_from_expert_isolation(&dispatched, &selected),
+            MoeDispatchVerdict::Pass
+        );
+
+        let actual = weighted_aggregate(&expert_outputs, &weights, 2);
+        // token 0: 0.7*[10,0] + 0.3*[0,10] = [7, 3]
+        // token 1: 0.5*[1,1] + 0.5*[2,2] = [1.5, 1.5]
+        let expected = vec![7.0_f32, 3.0, 1.5, 1.5];
+        assert_eq!(
+            verdict_from_weighted_aggregation(&actual, &expected),
+            MoeDispatchVerdict::Pass
+        );
+    }
+}

--- a/crates/aprender-core/src/format/moer_001_003.rs
+++ b/crates/aprender-core/src/format/moer_001_003.rs
@@ -1,0 +1,574 @@
+// SHIP-TWO-001 — `moe-router-v1` algorithm-level PARTIAL discharge
+// for FALSIFY-MOE_ROUTER_V1_001..003.
+//
+// Contract: `contracts/moe-router-v1.yaml`.
+// Spec: `docs/specifications/aprender-train/ship-two-models-spec.md`.
+//
+// ## What this file proves NOW (PARTIAL_ALGORITHM_LEVEL)
+//
+// Three router gates from Shazeer et al. (2017):
+//
+// - MOE-ROUTER-001 (softmax sum): for every token, the router-probability
+//   row sums to 1.0.
+// - MOE-ROUTER-002 (top-k count): for every token, exactly k experts
+//   selected where k = num_experts_per_token.
+// - MOE-ROUTER-003 (weight renormalization): for every token, the sum
+//   of selected (post-renormalization) weights is 1.0.
+//
+// In-module reference: `softmax_row`, `top_k_indices`, `renormalize`.
+
+/// Tolerance on Σ router_probs == 1.0 per row (allow softmax round-off).
+pub const AC_MOE_ROUTER_001_SOFTMAX_SUM_EPS: f32 = 1e-5;
+
+/// Tolerance on Σ selected_weights == 1.0 per row after renormalization.
+pub const AC_MOE_ROUTER_003_RENORM_SUM_EPS: f32 = 1e-5;
+
+/// Lower bound on k (must select at least one expert).
+pub const AC_MOE_ROUTER_002_K_MIN: usize = 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MoeRouterVerdict {
+    Pass,
+    Fail,
+}
+
+// -----------------------------------------------------------------------------
+// In-module reference router.
+// -----------------------------------------------------------------------------
+
+/// Numerically stable softmax over a row.
+#[must_use]
+pub fn softmax_row(logits: &[f32]) -> Vec<f32> {
+    if logits.is_empty() {
+        return Vec::new();
+    }
+    let mut max = f32::NEG_INFINITY;
+    for &v in logits {
+        if v > max {
+            max = v;
+        }
+    }
+    let mut exps: Vec<f32> = logits.iter().map(|&v| (v - max).exp()).collect();
+    let sum: f32 = exps.iter().sum();
+    if sum > 0.0 {
+        for v in &mut exps {
+            *v /= sum;
+        }
+    }
+    exps
+}
+
+/// Top-k indices by descending probability. Ties broken by smallest
+/// index. Returns indices into the original row.
+#[must_use]
+pub fn top_k_indices(probs: &[f32], k: usize) -> Vec<usize> {
+    if probs.is_empty() || k == 0 || k > probs.len() {
+        return Vec::new();
+    }
+    let mut idx: Vec<usize> = (0..probs.len()).collect();
+    idx.sort_by(|&a, &b| {
+        probs[b]
+            .partial_cmp(&probs[a])
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then(a.cmp(&b))
+    });
+    idx.into_iter().take(k).collect()
+}
+
+/// Renormalize a slice of selected weights so they sum to 1.0.
+#[must_use]
+pub fn renormalize(selected: &[f32]) -> Vec<f32> {
+    let sum: f32 = selected.iter().sum();
+    if sum > 0.0 {
+        selected.iter().map(|w| w / sum).collect()
+    } else {
+        selected.to_vec()
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Verdict 1: MOE-ROUTER-001 — softmax sum.
+// -----------------------------------------------------------------------------
+
+/// Pass iff every row of `router_probs` (laid out row-major as
+/// `[n_tokens, n_experts]`) sums to 1.0 within
+/// `AC_MOE_ROUTER_001_SOFTMAX_SUM_EPS`.
+#[must_use]
+pub fn verdict_from_softmax_sum(
+    router_probs: &[f32],
+    n_tokens: usize,
+    n_experts: usize,
+) -> MoeRouterVerdict {
+    if n_tokens == 0 || n_experts == 0 {
+        return MoeRouterVerdict::Fail;
+    }
+    if router_probs.len() != n_tokens * n_experts {
+        return MoeRouterVerdict::Fail;
+    }
+    for t in 0..n_tokens {
+        let row = &router_probs[t * n_experts..(t + 1) * n_experts];
+        let mut sum = 0.0_f32;
+        for &v in row {
+            if !v.is_finite() || v < 0.0 {
+                return MoeRouterVerdict::Fail;
+            }
+            sum += v;
+        }
+        if (sum - 1.0).abs() >= AC_MOE_ROUTER_001_SOFTMAX_SUM_EPS {
+            return MoeRouterVerdict::Fail;
+        }
+    }
+    MoeRouterVerdict::Pass
+}
+
+// -----------------------------------------------------------------------------
+// Verdict 2: MOE-ROUTER-002 — top-k count.
+// -----------------------------------------------------------------------------
+
+/// Pass iff every token row in `selected_indices_per_token` has length
+/// `k`, all entries are unique, and all are < `n_experts`.
+#[must_use]
+pub fn verdict_from_topk_selection(
+    selected_indices_per_token: &[Vec<usize>],
+    k: usize,
+    n_experts: usize,
+) -> MoeRouterVerdict {
+    if k < AC_MOE_ROUTER_002_K_MIN || k > n_experts {
+        return MoeRouterVerdict::Fail;
+    }
+    if selected_indices_per_token.is_empty() {
+        return MoeRouterVerdict::Fail;
+    }
+    for row in selected_indices_per_token {
+        if row.len() != k {
+            return MoeRouterVerdict::Fail;
+        }
+        let mut seen = vec![false; n_experts];
+        for &idx in row {
+            if idx >= n_experts {
+                return MoeRouterVerdict::Fail;
+            }
+            if seen[idx] {
+                // Duplicate: top-k must select distinct experts.
+                return MoeRouterVerdict::Fail;
+            }
+            seen[idx] = true;
+        }
+    }
+    MoeRouterVerdict::Pass
+}
+
+// -----------------------------------------------------------------------------
+// Verdict 3: MOE-ROUTER-003 — renormalized weights sum to 1.
+// -----------------------------------------------------------------------------
+
+/// Pass iff every row in `selected_weights_per_token` sums to 1.0
+/// within `AC_MOE_ROUTER_003_RENORM_SUM_EPS`.
+#[must_use]
+pub fn verdict_from_renorm_sum(
+    selected_weights_per_token: &[Vec<f32>],
+) -> MoeRouterVerdict {
+    if selected_weights_per_token.is_empty() {
+        return MoeRouterVerdict::Fail;
+    }
+    for row in selected_weights_per_token {
+        if row.is_empty() {
+            return MoeRouterVerdict::Fail;
+        }
+        let mut sum = 0.0_f32;
+        for &v in row {
+            if !v.is_finite() || v < 0.0 {
+                return MoeRouterVerdict::Fail;
+            }
+            sum += v;
+        }
+        if (sum - 1.0).abs() >= AC_MOE_ROUTER_003_RENORM_SUM_EPS {
+            return MoeRouterVerdict::Fail;
+        }
+    }
+    MoeRouterVerdict::Pass
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -------------------------------------------------------------------------
+    // Section 1: Provenance pins.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn provenance_softmax_eps_1e_5() {
+        assert_eq!(AC_MOE_ROUTER_001_SOFTMAX_SUM_EPS, 1e-5);
+    }
+
+    #[test]
+    fn provenance_renorm_eps_1e_5() {
+        assert_eq!(AC_MOE_ROUTER_003_RENORM_SUM_EPS, 1e-5);
+    }
+
+    #[test]
+    fn provenance_k_min_is_one() {
+        assert_eq!(AC_MOE_ROUTER_002_K_MIN, 1);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 2: MOE-ROUTER-001 Pass band.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn moer001_pass_uniform_distribution() {
+        let probs = vec![0.25_f32; 8]; // 2 tokens × 4 experts
+        assert_eq!(
+            verdict_from_softmax_sum(&probs, 2, 4),
+            MoeRouterVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn moer001_pass_after_softmax() {
+        let logits = vec![1.0_f32, 2.0, 3.0, 4.0];
+        let probs = softmax_row(&logits);
+        assert_eq!(
+            verdict_from_softmax_sum(&probs, 1, 4),
+            MoeRouterVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn moer001_pass_skewed_distribution() {
+        let probs = vec![0.7_f32, 0.2, 0.1, 0.0];
+        assert_eq!(
+            verdict_from_softmax_sum(&probs, 1, 4),
+            MoeRouterVerdict::Pass
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 3: MOE-ROUTER-001 Fail band.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn moer001_fail_does_not_sum_to_one() {
+        let probs = vec![0.5_f32, 0.3, 0.1, 0.05]; // sum = 0.95
+        assert_eq!(
+            verdict_from_softmax_sum(&probs, 1, 4),
+            MoeRouterVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn moer001_fail_negative_entry() {
+        let probs = vec![1.5_f32, -0.5, 0.0, 0.0];
+        assert_eq!(
+            verdict_from_softmax_sum(&probs, 1, 4),
+            MoeRouterVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn moer001_fail_nan_entry() {
+        let probs = vec![0.5_f32, 0.5, f32::NAN, 0.0];
+        assert_eq!(
+            verdict_from_softmax_sum(&probs, 1, 4),
+            MoeRouterVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn moer001_fail_buffer_size_mismatch() {
+        let probs = vec![0.25_f32; 7]; // not 2*4 = 8
+        assert_eq!(
+            verdict_from_softmax_sum(&probs, 2, 4),
+            MoeRouterVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn moer001_fail_zero_tokens_or_experts() {
+        let probs = vec![0.5_f32];
+        assert_eq!(
+            verdict_from_softmax_sum(&probs, 0, 4),
+            MoeRouterVerdict::Fail
+        );
+        assert_eq!(
+            verdict_from_softmax_sum(&probs, 1, 0),
+            MoeRouterVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 4: MOE-ROUTER-002 Pass band.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn moer002_pass_top2_of_8() {
+        let selections = vec![
+            vec![0_usize, 5],
+            vec![3_usize, 7],
+            vec![1_usize, 2],
+        ];
+        assert_eq!(
+            verdict_from_topk_selection(&selections, 2, 8),
+            MoeRouterVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn moer002_pass_top1_minimum_k() {
+        let selections = vec![vec![0_usize], vec![3_usize]];
+        assert_eq!(
+            verdict_from_topk_selection(&selections, 1, 4),
+            MoeRouterVerdict::Pass
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 5: MOE-ROUTER-002 Fail band.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn moer002_fail_too_few_experts() {
+        let selections = vec![vec![0_usize]]; // k=2 expected
+        assert_eq!(
+            verdict_from_topk_selection(&selections, 2, 4),
+            MoeRouterVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn moer002_fail_too_many_experts() {
+        let selections = vec![vec![0_usize, 1, 2]]; // k=2 expected
+        assert_eq!(
+            verdict_from_topk_selection(&selections, 2, 4),
+            MoeRouterVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn moer002_fail_k_exceeds_n_experts() {
+        let selections = vec![vec![0_usize, 1]];
+        // k=5 > n_experts=4 — invalid request.
+        assert_eq!(
+            verdict_from_topk_selection(&selections, 5, 4),
+            MoeRouterVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn moer002_fail_k_zero() {
+        let selections = vec![vec![0_usize]];
+        assert_eq!(
+            verdict_from_topk_selection(&selections, 0, 4),
+            MoeRouterVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn moer002_fail_index_out_of_range() {
+        let selections = vec![vec![0_usize, 99]];
+        assert_eq!(
+            verdict_from_topk_selection(&selections, 2, 4),
+            MoeRouterVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn moer002_fail_duplicate_indices() {
+        let selections = vec![vec![1_usize, 1]];
+        assert_eq!(
+            verdict_from_topk_selection(&selections, 2, 4),
+            MoeRouterVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn moer002_fail_empty_token_list() {
+        let selections: Vec<Vec<usize>> = vec![];
+        assert_eq!(
+            verdict_from_topk_selection(&selections, 2, 4),
+            MoeRouterVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 6: MOE-ROUTER-003 Pass band.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn moer003_pass_uniform_renormed() {
+        let weights = vec![vec![0.5_f32, 0.5], vec![0.25, 0.25, 0.25, 0.25]];
+        assert_eq!(verdict_from_renorm_sum(&weights), MoeRouterVerdict::Pass);
+    }
+
+    #[test]
+    fn moer003_pass_after_renormalize() {
+        let raw = vec![0.6_f32, 0.3]; // sums to 0.9 — needs renorm
+        let r = renormalize(&raw);
+        let weights = vec![r];
+        assert_eq!(verdict_from_renorm_sum(&weights), MoeRouterVerdict::Pass);
+    }
+
+    #[test]
+    fn moer003_pass_skewed_renormed() {
+        let weights = vec![vec![0.7_f32, 0.2, 0.1]];
+        assert_eq!(verdict_from_renorm_sum(&weights), MoeRouterVerdict::Pass);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 7: MOE-ROUTER-003 Fail band.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn moer003_fail_does_not_sum_to_one() {
+        let weights = vec![vec![0.4_f32, 0.4]]; // sum 0.8
+        assert_eq!(verdict_from_renorm_sum(&weights), MoeRouterVerdict::Fail);
+    }
+
+    #[test]
+    fn moer003_fail_negative_weight() {
+        let weights = vec![vec![1.5_f32, -0.5]];
+        assert_eq!(verdict_from_renorm_sum(&weights), MoeRouterVerdict::Fail);
+    }
+
+    #[test]
+    fn moer003_fail_nan_weight() {
+        let weights = vec![vec![0.5_f32, f32::NAN]];
+        assert_eq!(verdict_from_renorm_sum(&weights), MoeRouterVerdict::Fail);
+    }
+
+    #[test]
+    fn moer003_fail_empty_token_list() {
+        let weights: Vec<Vec<f32>> = vec![];
+        assert_eq!(verdict_from_renorm_sum(&weights), MoeRouterVerdict::Fail);
+    }
+
+    #[test]
+    fn moer003_fail_empty_row() {
+        let weights = vec![vec![]];
+        assert_eq!(verdict_from_renorm_sum(&weights), MoeRouterVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 8: Domain — reference functions.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn domain_softmax_row_basic() {
+        let logits = vec![1.0_f32, 2.0, 3.0];
+        let probs = softmax_row(&logits);
+        let sum: f32 = probs.iter().sum();
+        assert!((sum - 1.0).abs() < 1e-6);
+        // Probs should be increasing because logits are.
+        assert!(probs[0] < probs[1]);
+        assert!(probs[1] < probs[2]);
+    }
+
+    #[test]
+    fn domain_softmax_row_extreme_logits_no_overflow() {
+        // The numerical-stability trick: subtract max.
+        let logits = vec![1000.0_f32, 1000.0, 1000.0];
+        let probs = softmax_row(&logits);
+        for &p in &probs {
+            assert!(p.is_finite());
+            assert!((p - 1.0 / 3.0).abs() < 1e-5);
+        }
+    }
+
+    #[test]
+    fn domain_top_k_indices_descending() {
+        // logits=[1, 5, 3, 2, 4] → top-3 indices in descending prob:
+        // 1 (5), 4 (4), 2 (3).
+        let probs = vec![1.0_f32, 5.0, 3.0, 2.0, 4.0];
+        let top = top_k_indices(&probs, 3);
+        assert_eq!(top, vec![1, 4, 2]);
+    }
+
+    #[test]
+    fn domain_top_k_indices_ties_break_smallest() {
+        let probs = vec![3.0_f32, 3.0, 3.0, 1.0];
+        let top = top_k_indices(&probs, 2);
+        // Tied at 3.0: smallest indices first (0, 1).
+        assert_eq!(top, vec![0, 1]);
+    }
+
+    #[test]
+    fn domain_renormalize_basic() {
+        let raw = vec![0.4_f32, 0.4]; // sum 0.8
+        let r = renormalize(&raw);
+        assert!((r[0] - 0.5).abs() < 1e-6);
+        assert!((r[1] - 0.5).abs() < 1e-6);
+    }
+
+    #[test]
+    fn domain_renormalize_all_zero_returns_input() {
+        // No renormalization possible — leave as-is (will Fail verdict).
+        let raw = vec![0.0_f32, 0.0];
+        let r = renormalize(&raw);
+        assert_eq!(r, raw);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 9: Sweep — k, n_experts.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn sweep_topk_valid_k_values() {
+        // n_experts=8, k from 1 to 8 — all should pass given valid
+        // selection.
+        for k in 1..=8 {
+            let mut sel: Vec<usize> = (0..k).collect(); // [0, 1, ..., k-1]
+            let _ = sel.split_off(k); // truncate (already correct)
+            let selections = vec![sel.clone()];
+            assert_eq!(
+                verdict_from_topk_selection(&selections, k, 8),
+                MoeRouterVerdict::Pass,
+                "k={k}"
+            );
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 10: Realistic — end-to-end MoE router.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn realistic_full_router_pipeline() {
+        // 2 tokens, 4 experts, top-2.
+        let logits = vec![
+            // token 0: expert 1 dominant
+            1.0_f32, 5.0, 0.5, 0.0,
+            // token 1: expert 3 dominant
+            0.0, 1.0, 2.0, 5.0,
+        ];
+        let n_experts = 4;
+        let k = 2;
+
+        // Step 1: softmax per row.
+        let mut probs = Vec::new();
+        for t in 0..2 {
+            let row = &logits[t * n_experts..(t + 1) * n_experts];
+            probs.extend(softmax_row(row));
+        }
+        assert_eq!(
+            verdict_from_softmax_sum(&probs, 2, n_experts),
+            MoeRouterVerdict::Pass
+        );
+
+        // Step 2: top-k selection.
+        let mut selected_idx: Vec<Vec<usize>> = Vec::new();
+        let mut selected_w: Vec<Vec<f32>> = Vec::new();
+        for t in 0..2 {
+            let row = &probs[t * n_experts..(t + 1) * n_experts];
+            let top = top_k_indices(row, k);
+            let raw_w: Vec<f32> = top.iter().map(|&i| row[i]).collect();
+            let renormed = renormalize(&raw_w);
+            selected_idx.push(top);
+            selected_w.push(renormed);
+        }
+        assert_eq!(
+            verdict_from_topk_selection(&selected_idx, k, n_experts),
+            MoeRouterVerdict::Pass
+        );
+        assert_eq!(
+            verdict_from_renorm_sum(&selected_w),
+            MoeRouterVerdict::Pass
+        );
+
+        // Sanity: token 0 should pick experts {1, 0} (0 was second
+        // highest by virtue of small logit gap).
+        // Just check that expert 1 is picked.
+        assert!(selected_idx[0].contains(&1));
+        assert!(selected_idx[1].contains(&3));
+    }
+}

--- a/crates/aprender-core/src/format/mono_001_013.rs
+++ b/crates/aprender-core/src/format/mono_001_013.rs
@@ -1,0 +1,656 @@
+// `cgp-monorepo-consolidation-v1` algorithm-level PARTIAL discharge for
+// the 13 APR-MONO migration falsifiers (build perf, CI time, merge
+// conflicts, publish time, broken-publish incidents, clone time, history,
+// shim re-exports, version compat, registry compliance, single binary,
+// flat layout, contract per subcommand).
+//
+// Contract: `contracts/cgp-monorepo-consolidation-v1.yaml`.
+// Refs: Potvin & Levenberg (CACM 2016), Brousse (ICSE 2019), Brito et al.
+// (MSR 2023), Rastogi et al. (ICSME 2023).
+//
+// ## Disambiguation
+//
+// `cgp-monorepo-build-v1.yaml` (task #417) is a sibling contract covering
+// 7 BUILD invariants (workspace shape, naming, layout). This contract —
+// cgp-monorepo-consolidation-v1 — covers 13 MIGRATION/RUNTIME invariants
+// (perf budgets, history preservation, contract enforcement). Module
+// suffix `mono_` disambiguates from the existing `monorepo_` module.
+
+use std::collections::HashSet;
+
+/// Incremental compile budget per FALSIFY-MONO-001 (3× regression bound).
+pub const AC_MONO_INCR_COMPILE_REGRESSION_FACTOR: f64 = 3.0;
+
+/// Pre-migration incremental compile baseline (5s).
+pub const AC_MONO_INCR_COMPILE_BASELINE_S: f64 = 5.0;
+
+/// CI time budget per FALSIFY-MONO-002 (10 min).
+pub const AC_MONO_CI_TIME_BUDGET_S: u32 = 600;
+
+/// Merge-conflict rolling-average threshold per FALSIFY-MONO-003.
+pub const AC_MONO_MERGE_CONFLICT_THRESHOLD_PER_WEEK: u32 = 2;
+
+/// Publish time budget per FALSIFY-MONO-004 (5 min).
+pub const AC_MONO_PUBLISH_TIME_BUDGET_S: u32 = 300;
+
+/// Broken-publish-incidents budget per FALSIFY-MONO-005 (90-day window).
+pub const AC_MONO_BROKEN_PUBLISH_BUDGET: u32 = 2;
+
+/// Clone-time budget per FALSIFY-MONO-006 (30 sec).
+pub const AC_MONO_CLONE_TIME_BUDGET_S: u32 = 30;
+
+// =============================================================================
+// FALSIFY-MONO-001 — incremental compile within 3× of baseline
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MonoIncrCompileVerdict {
+    Pass,
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_mono_incr_compile(measured_seconds: f64) -> MonoIncrCompileVerdict {
+    if !measured_seconds.is_finite() || measured_seconds < 0.0 {
+        return MonoIncrCompileVerdict::Fail;
+    }
+    let budget = AC_MONO_INCR_COMPILE_BASELINE_S * AC_MONO_INCR_COMPILE_REGRESSION_FACTOR;
+    if measured_seconds <= budget {
+        MonoIncrCompileVerdict::Pass
+    } else {
+        MonoIncrCompileVerdict::Fail
+    }
+}
+
+// =============================================================================
+// FALSIFY-MONO-002 — CI time within 10 min
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MonoCiTimeVerdict { Pass, Fail }
+
+#[must_use]
+pub fn verdict_from_mono_ci_time(seconds: u32) -> MonoCiTimeVerdict {
+    if seconds <= AC_MONO_CI_TIME_BUDGET_S { MonoCiTimeVerdict::Pass } else { MonoCiTimeVerdict::Fail }
+}
+
+// =============================================================================
+// FALSIFY-MONO-003 — merge conflicts ≤ 2/week rolling avg
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MonoMergeConflictVerdict { Pass, Fail }
+
+#[must_use]
+pub fn verdict_from_mono_merge_conflict(conflicts_per_week: u32) -> MonoMergeConflictVerdict {
+    if conflicts_per_week <= AC_MONO_MERGE_CONFLICT_THRESHOLD_PER_WEEK {
+        MonoMergeConflictVerdict::Pass
+    } else {
+        MonoMergeConflictVerdict::Fail
+    }
+}
+
+// =============================================================================
+// FALSIFY-MONO-004 — daily publish time ≤ 5 min
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MonoPublishTimeVerdict { Pass, Fail }
+
+#[must_use]
+pub fn verdict_from_mono_publish_time(seconds: u32) -> MonoPublishTimeVerdict {
+    if seconds <= AC_MONO_PUBLISH_TIME_BUDGET_S {
+        MonoPublishTimeVerdict::Pass
+    } else {
+        MonoPublishTimeVerdict::Fail
+    }
+}
+
+// =============================================================================
+// FALSIFY-MONO-005 — broken publishes ≤ 2 in 90 days
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MonoBrokenPublishVerdict { Pass, Fail }
+
+#[must_use]
+pub fn verdict_from_mono_broken_publish(incidents_in_90d: u32) -> MonoBrokenPublishVerdict {
+    if incidents_in_90d <= AC_MONO_BROKEN_PUBLISH_BUDGET {
+        MonoBrokenPublishVerdict::Pass
+    } else {
+        MonoBrokenPublishVerdict::Fail
+    }
+}
+
+// =============================================================================
+// FALSIFY-MONO-006 — clone time ≤ 30s
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MonoCloneTimeVerdict { Pass, Fail }
+
+#[must_use]
+pub fn verdict_from_mono_clone_time(seconds: u32) -> MonoCloneTimeVerdict {
+    if seconds <= AC_MONO_CLONE_TIME_BUDGET_S {
+        MonoCloneTimeVerdict::Pass
+    } else {
+        MonoCloneTimeVerdict::Fail
+    }
+}
+
+// =============================================================================
+// FALSIFY-MONO-007 — git subtree preserves history
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MonoHistoryVerdict { Pass, Fail }
+
+#[must_use]
+pub fn verdict_from_mono_history(commits_from_original_repo: u32) -> MonoHistoryVerdict {
+    if commits_from_original_repo > 0 {
+        MonoHistoryVerdict::Pass
+    } else {
+        MonoHistoryVerdict::Fail
+    }
+}
+
+// =============================================================================
+// FALSIFY-MONO-008 — shim crates re-export correctly
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MonoShimReexportVerdict { Pass, Fail }
+
+#[must_use]
+pub fn verdict_from_mono_shim_reexport(
+    shim_compiles: bool,
+    test_results_match_legacy: bool,
+) -> MonoShimReexportVerdict {
+    if shim_compiles && test_results_match_legacy {
+        MonoShimReexportVerdict::Pass
+    } else {
+        MonoShimReexportVerdict::Fail
+    }
+}
+
+// =============================================================================
+// FALSIFY-MONO-009 — workspace version bump compat
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MonoVersionBumpVerdict { Pass, Fail }
+
+#[must_use]
+pub fn verdict_from_mono_version_bump(
+    is_major_bump: bool,
+    breaking_api_changes: u32,
+) -> MonoVersionBumpVerdict {
+    if breaking_api_changes == 0 {
+        return MonoVersionBumpVerdict::Pass;
+    }
+    if is_major_bump {
+        MonoVersionBumpVerdict::Pass
+    } else {
+        MonoVersionBumpVerdict::Fail
+    }
+}
+
+// =============================================================================
+// FALSIFY-MONO-010 — every crate name is in registry
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MonoRegistryComplianceVerdict { Pass, Fail }
+
+#[must_use]
+pub fn verdict_from_mono_registry_compliance(
+    workspace_names: &[&str],
+    registered_names: &[&str],
+) -> MonoRegistryComplianceVerdict {
+    if workspace_names.is_empty() {
+        return MonoRegistryComplianceVerdict::Fail;
+    }
+    let registry: HashSet<&&str> = registered_names.iter().collect();
+    for name in workspace_names {
+        if !registry.contains(name) {
+            return MonoRegistryComplianceVerdict::Fail;
+        }
+    }
+    MonoRegistryComplianceVerdict::Pass
+}
+
+// =============================================================================
+// FALSIFY-MONO-011 — only apr-cli has [[bin]]
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MonoSingleBinaryVerdict { Pass, Fail }
+
+/// Allowed crates that may have [[bin]] sections (apr-cli + build tooling).
+pub const AC_MONO_BIN_ALLOWED: [&str; 2] = ["apr-cli", "aprender-contracts-cli"];
+
+#[must_use]
+pub fn verdict_from_mono_single_binary(crates_with_bins: &[&str]) -> MonoSingleBinaryVerdict {
+    for c in crates_with_bins {
+        if !AC_MONO_BIN_ALLOWED.contains(c) {
+            return MonoSingleBinaryVerdict::Fail;
+        }
+    }
+    MonoSingleBinaryVerdict::Pass
+}
+
+// =============================================================================
+// FALSIFY-MONO-012 — flat layout (depth ≤ 2 from repo root)
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MonoFlatLayoutVerdict { Pass, Fail }
+
+#[must_use]
+pub fn verdict_from_mono_flat_layout(member_paths: &[&str]) -> MonoFlatLayoutVerdict {
+    if member_paths.is_empty() {
+        return MonoFlatLayoutVerdict::Fail;
+    }
+    for path in member_paths {
+        // Expected: `crates/<name>` (1 separator after "crates/").
+        if !path.starts_with("crates/") {
+            return MonoFlatLayoutVerdict::Fail;
+        }
+        let suffix = &path["crates/".len()..];
+        if suffix.contains('/') {
+            return MonoFlatLayoutVerdict::Fail;
+        }
+        if suffix.is_empty() {
+            return MonoFlatLayoutVerdict::Fail;
+        }
+    }
+    MonoFlatLayoutVerdict::Pass
+}
+
+// =============================================================================
+// FALSIFY-MONO-013 — every apr subcommand has a contract
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MonoSubcommandContractVerdict { Pass, Fail }
+
+#[must_use]
+pub fn verdict_from_mono_subcommand_contract(
+    subcommands: &[&str],
+    contract_names: &[&str],
+) -> MonoSubcommandContractVerdict {
+    if subcommands.is_empty() {
+        return MonoSubcommandContractVerdict::Fail;
+    }
+    let contracts: HashSet<&&str> = contract_names.iter().collect();
+    for cmd in subcommands {
+        if !contracts.contains(cmd) {
+            return MonoSubcommandContractVerdict::Fail;
+        }
+    }
+    MonoSubcommandContractVerdict::Pass
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -------------------------------------------------------------------------
+    // Section 1: Provenance pins.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn provenance_incr_factor_3() {
+        assert!((AC_MONO_INCR_COMPILE_REGRESSION_FACTOR - 3.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn provenance_ci_budget_600s() {
+        assert_eq!(AC_MONO_CI_TIME_BUDGET_S, 600);
+    }
+
+    #[test]
+    fn provenance_publish_budget_300s() {
+        assert_eq!(AC_MONO_PUBLISH_TIME_BUDGET_S, 300);
+    }
+
+    #[test]
+    fn provenance_clone_budget_30s() {
+        assert_eq!(AC_MONO_CLONE_TIME_BUDGET_S, 30);
+    }
+
+    #[test]
+    fn provenance_bin_allowed_2() {
+        assert_eq!(AC_MONO_BIN_ALLOWED.len(), 2);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 2: MONO-001 incr compile.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fm001_pass_under_budget() {
+        assert_eq!(verdict_from_mono_incr_compile(10.0), MonoIncrCompileVerdict::Pass);
+    }
+
+    #[test]
+    fn fm001_pass_at_budget() {
+        assert_eq!(verdict_from_mono_incr_compile(15.0), MonoIncrCompileVerdict::Pass);
+    }
+
+    #[test]
+    fn fm001_fail_over_budget() {
+        assert_eq!(verdict_from_mono_incr_compile(20.0), MonoIncrCompileVerdict::Fail);
+    }
+
+    #[test]
+    fn fm001_fail_nan() {
+        assert_eq!(verdict_from_mono_incr_compile(f64::NAN), MonoIncrCompileVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 3: MONO-002..006 simple budget gates.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fm002_pass_under_ci_budget() {
+        assert_eq!(verdict_from_mono_ci_time(180), MonoCiTimeVerdict::Pass);
+    }
+
+    #[test]
+    fn fm002_fail_over_ci_budget() {
+        assert_eq!(verdict_from_mono_ci_time(700), MonoCiTimeVerdict::Fail);
+    }
+
+    #[test]
+    fn fm003_pass_low_conflicts() {
+        assert_eq!(verdict_from_mono_merge_conflict(1), MonoMergeConflictVerdict::Pass);
+    }
+
+    #[test]
+    fn fm003_fail_high_conflicts() {
+        assert_eq!(verdict_from_mono_merge_conflict(5), MonoMergeConflictVerdict::Fail);
+    }
+
+    #[test]
+    fn fm004_pass_fast_publish() {
+        assert_eq!(verdict_from_mono_publish_time(120), MonoPublishTimeVerdict::Pass);
+    }
+
+    #[test]
+    fn fm004_fail_slow_publish() {
+        assert_eq!(verdict_from_mono_publish_time(600), MonoPublishTimeVerdict::Fail);
+    }
+
+    #[test]
+    fn fm005_pass_zero_incidents() {
+        assert_eq!(verdict_from_mono_broken_publish(0), MonoBrokenPublishVerdict::Pass);
+    }
+
+    #[test]
+    fn fm005_fail_many_incidents() {
+        assert_eq!(verdict_from_mono_broken_publish(5), MonoBrokenPublishVerdict::Fail);
+    }
+
+    #[test]
+    fn fm006_pass_fast_clone() {
+        assert_eq!(verdict_from_mono_clone_time(15), MonoCloneTimeVerdict::Pass);
+    }
+
+    #[test]
+    fn fm006_fail_slow_clone() {
+        assert_eq!(verdict_from_mono_clone_time(60), MonoCloneTimeVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 4: MONO-007 history preservation.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fm007_pass_history_preserved() {
+        assert_eq!(verdict_from_mono_history(100), MonoHistoryVerdict::Pass);
+    }
+
+    #[test]
+    fn fm007_fail_no_history() {
+        assert_eq!(verdict_from_mono_history(0), MonoHistoryVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 5: MONO-008 shim re-exports.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fm008_pass_shim_works() {
+        assert_eq!(
+            verdict_from_mono_shim_reexport(true, true),
+            MonoShimReexportVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fm008_fail_shim_compile_error() {
+        assert_eq!(
+            verdict_from_mono_shim_reexport(false, true),
+            MonoShimReexportVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fm008_fail_results_diverge() {
+        assert_eq!(
+            verdict_from_mono_shim_reexport(true, false),
+            MonoShimReexportVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 6: MONO-009 version bump compat.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fm009_pass_no_breaking_changes() {
+        assert_eq!(
+            verdict_from_mono_version_bump(false, 0),
+            MonoVersionBumpVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fm009_pass_breaking_in_major_bump() {
+        assert_eq!(
+            verdict_from_mono_version_bump(true, 5),
+            MonoVersionBumpVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fm009_fail_breaking_in_minor_bump() {
+        assert_eq!(
+            verdict_from_mono_version_bump(false, 1),
+            MonoVersionBumpVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 7: MONO-010 registry compliance.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fm010_pass_all_registered() {
+        let workspace = ["aprender-core", "aprender-train"];
+        let registry = ["aprender-core", "aprender-train", "aprender-extra"];
+        assert_eq!(
+            verdict_from_mono_registry_compliance(&workspace, &registry),
+            MonoRegistryComplianceVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fm010_fail_unregistered() {
+        let workspace = ["aprender-core", "rogue-crate"];
+        let registry = ["aprender-core"];
+        assert_eq!(
+            verdict_from_mono_registry_compliance(&workspace, &registry),
+            MonoRegistryComplianceVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fm010_fail_empty_workspace() {
+        let registry = ["aprender-core"];
+        assert_eq!(
+            verdict_from_mono_registry_compliance(&[], &registry),
+            MonoRegistryComplianceVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 8: MONO-011 single binary.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fm011_pass_only_apr_cli_has_bin() {
+        let bins = ["apr-cli"];
+        assert_eq!(
+            verdict_from_mono_single_binary(&bins),
+            MonoSingleBinaryVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fm011_pass_apr_cli_plus_contracts_tooling() {
+        let bins = ["apr-cli", "aprender-contracts-cli"];
+        assert_eq!(
+            verdict_from_mono_single_binary(&bins),
+            MonoSingleBinaryVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fm011_fail_unauthorized_binary() {
+        let bins = ["apr-cli", "rogue-bin"];
+        assert_eq!(
+            verdict_from_mono_single_binary(&bins),
+            MonoSingleBinaryVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 9: MONO-012 flat layout.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fm012_pass_flat() {
+        let p = ["crates/aprender-core", "crates/aprender-train"];
+        assert_eq!(verdict_from_mono_flat_layout(&p), MonoFlatLayoutVerdict::Pass);
+    }
+
+    #[test]
+    fn fm012_fail_nested() {
+        let p = ["crates/aprender-core", "crates/parent/child"];
+        assert_eq!(verdict_from_mono_flat_layout(&p), MonoFlatLayoutVerdict::Fail);
+    }
+
+    #[test]
+    fn fm012_fail_outside_crates() {
+        let p = ["src/lib"];
+        assert_eq!(verdict_from_mono_flat_layout(&p), MonoFlatLayoutVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 10: MONO-013 contract per subcommand.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fm013_pass_all_contracts_present() {
+        let cmds = ["run", "serve", "chat"];
+        let contracts = ["run", "serve", "chat", "extra"];
+        assert_eq!(
+            verdict_from_mono_subcommand_contract(&cmds, &contracts),
+            MonoSubcommandContractVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fm013_fail_missing_contract() {
+        let cmds = ["run", "new-cmd"];
+        let contracts = ["run"];
+        assert_eq!(
+            verdict_from_mono_subcommand_contract(&cmds, &contracts),
+            MonoSubcommandContractVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fm013_fail_empty_subcommands() {
+        let contracts = ["run"];
+        assert_eq!(
+            verdict_from_mono_subcommand_contract(&[], &contracts),
+            MonoSubcommandContractVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 11: Realistic — full healthy migration passes all 13.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn realistic_healthy_migration_passes_all_13() {
+        assert_eq!(verdict_from_mono_incr_compile(8.0), MonoIncrCompileVerdict::Pass);
+        assert_eq!(verdict_from_mono_ci_time(240), MonoCiTimeVerdict::Pass);
+        assert_eq!(verdict_from_mono_merge_conflict(1), MonoMergeConflictVerdict::Pass);
+        assert_eq!(verdict_from_mono_publish_time(150), MonoPublishTimeVerdict::Pass);
+        assert_eq!(verdict_from_mono_broken_publish(0), MonoBrokenPublishVerdict::Pass);
+        assert_eq!(verdict_from_mono_clone_time(20), MonoCloneTimeVerdict::Pass);
+        assert_eq!(verdict_from_mono_history(50), MonoHistoryVerdict::Pass);
+        assert_eq!(
+            verdict_from_mono_shim_reexport(true, true),
+            MonoShimReexportVerdict::Pass
+        );
+        assert_eq!(
+            verdict_from_mono_version_bump(false, 0),
+            MonoVersionBumpVerdict::Pass
+        );
+        let workspace = ["aprender-core"];
+        let registry = ["aprender-core", "aprender-train"];
+        assert_eq!(
+            verdict_from_mono_registry_compliance(&workspace, &registry),
+            MonoRegistryComplianceVerdict::Pass
+        );
+        assert_eq!(
+            verdict_from_mono_single_binary(&["apr-cli"]),
+            MonoSingleBinaryVerdict::Pass
+        );
+        let p = ["crates/aprender-core"];
+        assert_eq!(verdict_from_mono_flat_layout(&p), MonoFlatLayoutVerdict::Pass);
+        assert_eq!(
+            verdict_from_mono_subcommand_contract(&["run"], &["run", "serve"]),
+            MonoSubcommandContractVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn realistic_pre_fix_all_13_failures() {
+        assert_eq!(verdict_from_mono_incr_compile(60.0), MonoIncrCompileVerdict::Fail);
+        assert_eq!(verdict_from_mono_ci_time(900), MonoCiTimeVerdict::Fail);
+        assert_eq!(verdict_from_mono_merge_conflict(10), MonoMergeConflictVerdict::Fail);
+        assert_eq!(verdict_from_mono_publish_time(600), MonoPublishTimeVerdict::Fail);
+        assert_eq!(verdict_from_mono_broken_publish(20), MonoBrokenPublishVerdict::Fail);
+        assert_eq!(verdict_from_mono_clone_time(120), MonoCloneTimeVerdict::Fail);
+        assert_eq!(verdict_from_mono_history(0), MonoHistoryVerdict::Fail);
+        assert_eq!(
+            verdict_from_mono_shim_reexport(false, false),
+            MonoShimReexportVerdict::Fail
+        );
+        assert_eq!(
+            verdict_from_mono_version_bump(false, 5),
+            MonoVersionBumpVerdict::Fail
+        );
+        assert_eq!(
+            verdict_from_mono_registry_compliance(&["rogue"], &["aprender-core"]),
+            MonoRegistryComplianceVerdict::Fail
+        );
+        assert_eq!(
+            verdict_from_mono_single_binary(&["rogue-bin"]),
+            MonoSingleBinaryVerdict::Fail
+        );
+        assert_eq!(
+            verdict_from_mono_flat_layout(&["crates/parent/child"]),
+            MonoFlatLayoutVerdict::Fail
+        );
+        assert_eq!(
+            verdict_from_mono_subcommand_contract(&["new-cmd"], &["run"]),
+            MonoSubcommandContractVerdict::Fail
+        );
+    }
+}

--- a/crates/aprender-core/src/format/monorepo_001_007.rs
+++ b/crates/aprender-core/src/format/monorepo_001_007.rs
@@ -1,0 +1,481 @@
+// `cgp-monorepo-build-v1` algorithm-level PARTIAL discharge for the 7
+// monorepo build-verification falsifiers (no duplicates, version
+// consistency, ≥60 members, no [patch.crates-io], all dirs have
+// Cargo.toml, aprender-* naming, flat layout).
+//
+// Contract: `contracts/cgp-monorepo-build-v1.yaml`.
+// Refs: Potvin & Levenberg (CACM 2016), Rastogi et al. (ICSME 2023),
+// Burn/Nushell flat-layout monorepos.
+
+use std::collections::HashSet;
+
+/// Minimum workspace member count per FALSIFY-BUILD-003.
+pub const AC_MONOREPO_MIN_MEMBERS: usize = 60;
+
+/// Workspace version per metadata (0.29.0 at contract creation,
+/// pinned for the FALSIFY-BUILD-002 gate).
+pub const AC_MONOREPO_WORKSPACE_VERSION: &str = "0.29.0";
+
+/// Crate names exempt from the aprender-* naming convention.
+/// `aprender` is the root facade (cargo install aprender → apr binary);
+/// `apr-cli` is the internal CLI logic crate per the contract description.
+pub const AC_MONOREPO_NAME_EXEMPTIONS: [&str; 2] = ["aprender", "apr-cli"];
+
+/// Legacy crate names that MUST NOT appear as workspace [package] names.
+pub const AC_MONOREPO_FORBIDDEN_NAMES: [&str; 4] =
+    ["trueno", "realizar", "entrenar", "batuta"];
+
+// =============================================================================
+// FALSIFY-BUILD-001 — no duplicate workspace members
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NoDuplicatesVerdict {
+    /// All [package] names are unique.
+    Pass,
+    /// At least two members share a name — merge conflict.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_no_duplicates(member_names: &[&str]) -> NoDuplicatesVerdict {
+    if member_names.is_empty() {
+        return NoDuplicatesVerdict::Fail;
+    }
+    let mut seen: HashSet<&&str> = HashSet::new();
+    for n in member_names {
+        if !seen.insert(n) {
+            return NoDuplicatesVerdict::Fail;
+        }
+    }
+    NoDuplicatesVerdict::Pass
+}
+
+// =============================================================================
+// FALSIFY-BUILD-002 — workspace version consistency
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VersionConsistencyVerdict {
+    /// All members using `version.workspace = true` resolve to 0.29.0.
+    Pass,
+    /// Workspace version mismatch — root Cargo.toml drift.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_version_consistency(resolved_workspace_version: &str) -> VersionConsistencyVerdict {
+    if resolved_workspace_version == AC_MONOREPO_WORKSPACE_VERSION {
+        VersionConsistencyVerdict::Pass
+    } else {
+        VersionConsistencyVerdict::Fail
+    }
+}
+
+// =============================================================================
+// FALSIFY-BUILD-003 — workspace member count ≥ 60
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MinMemberCountVerdict {
+    /// `cargo metadata --workspace` reports ≥ 60 members.
+    Pass,
+    /// Below threshold — crates accidentally excluded.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_min_member_count(actual_count: usize) -> MinMemberCountVerdict {
+    if actual_count >= AC_MONOREPO_MIN_MEMBERS {
+        MinMemberCountVerdict::Pass
+    } else {
+        MinMemberCountVerdict::Fail
+    }
+}
+
+// =============================================================================
+// FALSIFY-BUILD-004 — no [patch.crates-io] in root Cargo.toml
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NoPatchVerdict {
+    /// Root Cargo.toml does not contain `[patch.crates-io]` section.
+    Pass,
+    /// Patch section leaked into root.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_no_patch(root_cargo_toml: &str) -> NoPatchVerdict {
+    if root_cargo_toml.contains("[patch.crates-io]") {
+        NoPatchVerdict::Fail
+    } else {
+        NoPatchVerdict::Pass
+    }
+}
+
+// =============================================================================
+// FALSIFY-BUILD-005 — all workspace dirs have Cargo.toml
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AllHaveCargoTomlVerdict {
+    /// Every workspace member dir contains a Cargo.toml file.
+    Pass,
+    /// At least one is missing — broken subtree merge.
+    Fail,
+}
+
+/// `(dir_name, has_cargo_toml)` per workspace member directory.
+#[must_use]
+pub fn verdict_from_all_have_cargo_toml(member_dirs: &[(&str, bool)]) -> AllHaveCargoTomlVerdict {
+    if member_dirs.is_empty() {
+        return AllHaveCargoTomlVerdict::Fail;
+    }
+    for (_dir, has_cargo) in member_dirs {
+        if !*has_cargo {
+            return AllHaveCargoTomlVerdict::Fail;
+        }
+    }
+    AllHaveCargoTomlVerdict::Pass
+}
+
+// =============================================================================
+// FALSIFY-BUILD-006 — all crate names use aprender-* prefix (or apr-cli)
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AprPrefixVerdict {
+    /// Every package name is "apr-cli" OR starts with "aprender-",
+    /// AND no member uses a forbidden legacy name.
+    Pass,
+    /// Some package violates the naming convention.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_apr_prefix(member_names: &[&str]) -> AprPrefixVerdict {
+    if member_names.is_empty() {
+        return AprPrefixVerdict::Fail;
+    }
+    for name in member_names {
+        if AC_MONOREPO_FORBIDDEN_NAMES.contains(name) {
+            return AprPrefixVerdict::Fail;
+        }
+        if AC_MONOREPO_NAME_EXEMPTIONS.contains(name) {
+            continue;
+        }
+        if !name.starts_with("aprender-") {
+            return AprPrefixVerdict::Fail;
+        }
+    }
+    AprPrefixVerdict::Pass
+}
+
+// =============================================================================
+// FALSIFY-BUILD-007 — flat layout (no nested crates)
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FlatLayoutVerdict {
+    /// Every Cargo.toml path is `crates/<name>/Cargo.toml` (depth 2 from
+    /// crates/, not deeper).
+    Pass,
+    /// Nested Cargo.toml found — flat-layout invariant violated.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_flat_layout(cargo_toml_paths: &[&str]) -> FlatLayoutVerdict {
+    if cargo_toml_paths.is_empty() {
+        return FlatLayoutVerdict::Fail;
+    }
+    for path in cargo_toml_paths {
+        if !path.starts_with("crates/") {
+            return FlatLayoutVerdict::Fail;
+        }
+        let relative = &path["crates/".len()..];
+        // Expected: `<name>/Cargo.toml` (one slash). Anything deeper = nested.
+        let slashes = relative.matches('/').count();
+        if slashes != 1 {
+            return FlatLayoutVerdict::Fail;
+        }
+        if !path.ends_with("/Cargo.toml") {
+            return FlatLayoutVerdict::Fail;
+        }
+    }
+    FlatLayoutVerdict::Pass
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -------------------------------------------------------------------------
+    // Section 1: Provenance pins.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn provenance_min_members_60() {
+        assert_eq!(AC_MONOREPO_MIN_MEMBERS, 60);
+    }
+
+    #[test]
+    fn provenance_workspace_version_0_29() {
+        assert_eq!(AC_MONOREPO_WORKSPACE_VERSION, "0.29.0");
+    }
+
+    #[test]
+    fn provenance_naming_exemptions_contains_apr_cli() {
+        assert!(AC_MONOREPO_NAME_EXEMPTIONS.contains(&"apr-cli"));
+    }
+
+    #[test]
+    fn provenance_forbidden_names_count_4() {
+        assert_eq!(AC_MONOREPO_FORBIDDEN_NAMES.len(), 4);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 2: BUILD-001 no duplicates.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fb001_pass_unique_members() {
+        let m = ["aprender", "aprender-core", "apr-cli"];
+        assert_eq!(verdict_from_no_duplicates(&m), NoDuplicatesVerdict::Pass);
+    }
+
+    #[test]
+    fn fb001_fail_duplicate() {
+        let m = ["aprender-core", "aprender-train", "aprender-core"];
+        assert_eq!(verdict_from_no_duplicates(&m), NoDuplicatesVerdict::Fail);
+    }
+
+    #[test]
+    fn fb001_fail_empty() {
+        assert_eq!(
+            verdict_from_no_duplicates(&[]),
+            NoDuplicatesVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 3: BUILD-002 version consistency.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fb002_pass_canonical_version() {
+        assert_eq!(
+            verdict_from_version_consistency("0.29.0"),
+            VersionConsistencyVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fb002_fail_old_version() {
+        assert_eq!(
+            verdict_from_version_consistency("0.28.0"),
+            VersionConsistencyVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fb002_fail_future_version() {
+        assert_eq!(
+            verdict_from_version_consistency("0.30.0"),
+            VersionConsistencyVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 4: BUILD-003 minimum member count.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fb003_pass_at_threshold() {
+        assert_eq!(verdict_from_min_member_count(60), MinMemberCountVerdict::Pass);
+    }
+
+    #[test]
+    fn fb003_pass_above_threshold() {
+        assert_eq!(verdict_from_min_member_count(70), MinMemberCountVerdict::Pass);
+    }
+
+    #[test]
+    fn fb003_fail_below_threshold() {
+        assert_eq!(verdict_from_min_member_count(59), MinMemberCountVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 5: BUILD-004 no [patch.crates-io].
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fb004_pass_clean_root() {
+        let toml = "[workspace]\nmembers = [\"crates/*\"]";
+        assert_eq!(verdict_from_no_patch(toml), NoPatchVerdict::Pass);
+    }
+
+    #[test]
+    fn fb004_fail_patch_present() {
+        let toml = "[workspace]\nmembers = [\"crates/*\"]\n[patch.crates-io]\nfoo = { path = \"local\" }";
+        assert_eq!(verdict_from_no_patch(toml), NoPatchVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 6: BUILD-005 all dirs have Cargo.toml.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fb005_pass_all_present() {
+        let dirs = [("aprender-core", true), ("apr-cli", true)];
+        assert_eq!(
+            verdict_from_all_have_cargo_toml(&dirs),
+            AllHaveCargoTomlVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fb005_fail_missing_cargo_toml() {
+        let dirs = [("aprender-core", true), ("aprender-train", false)];
+        assert_eq!(
+            verdict_from_all_have_cargo_toml(&dirs),
+            AllHaveCargoTomlVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fb005_fail_empty() {
+        assert_eq!(
+            verdict_from_all_have_cargo_toml(&[]),
+            AllHaveCargoTomlVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 7: BUILD-006 aprender-* naming.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fb006_pass_canonical_names() {
+        let m = ["aprender", "aprender-core", "aprender-train", "apr-cli"];
+        assert_eq!(verdict_from_apr_prefix(&m), AprPrefixVerdict::Pass);
+    }
+
+    #[test]
+    fn fb006_fail_legacy_name() {
+        let m = ["aprender-core", "trueno"];
+        assert_eq!(verdict_from_apr_prefix(&m), AprPrefixVerdict::Fail);
+    }
+
+    #[test]
+    fn fb006_fail_non_aprender_prefix() {
+        let m = ["aprender-core", "random-crate"];
+        assert_eq!(verdict_from_apr_prefix(&m), AprPrefixVerdict::Fail);
+    }
+
+    #[test]
+    fn fb006_fail_each_legacy_individually() {
+        for legacy in AC_MONOREPO_FORBIDDEN_NAMES {
+            let m = vec!["aprender-core", legacy];
+            assert_eq!(
+                verdict_from_apr_prefix(&m),
+                AprPrefixVerdict::Fail,
+                "legacy name {legacy} must Fail"
+            );
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 8: BUILD-007 flat layout.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fb007_pass_all_flat() {
+        let p = [
+            "crates/aprender-core/Cargo.toml",
+            "crates/aprender-train/Cargo.toml",
+        ];
+        assert_eq!(verdict_from_flat_layout(&p), FlatLayoutVerdict::Pass);
+    }
+
+    #[test]
+    fn fb007_fail_nested_crate() {
+        let p = [
+            "crates/aprender-core/Cargo.toml",
+            "crates/aprender-core/sub-crate/Cargo.toml",
+        ];
+        assert_eq!(verdict_from_flat_layout(&p), FlatLayoutVerdict::Fail);
+    }
+
+    #[test]
+    fn fb007_fail_outside_crates_dir() {
+        let p = ["src/main.rs/Cargo.toml"];
+        assert_eq!(verdict_from_flat_layout(&p), FlatLayoutVerdict::Fail);
+    }
+
+    #[test]
+    fn fb007_fail_empty() {
+        assert_eq!(verdict_from_flat_layout(&[]), FlatLayoutVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 9: Realistic — full healthy monorepo passes all 7.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn realistic_healthy_monorepo_passes_all_7() {
+        // 001
+        let names = ["aprender", "aprender-core", "aprender-train", "apr-cli"];
+        assert_eq!(verdict_from_no_duplicates(&names), NoDuplicatesVerdict::Pass);
+        // 002
+        assert_eq!(
+            verdict_from_version_consistency("0.29.0"),
+            VersionConsistencyVerdict::Pass
+        );
+        // 003
+        assert_eq!(verdict_from_min_member_count(70), MinMemberCountVerdict::Pass);
+        // 004
+        let toml = "[workspace]\nmembers = [\"crates/*\"]\nresolver = \"2\"";
+        assert_eq!(verdict_from_no_patch(toml), NoPatchVerdict::Pass);
+        // 005
+        let dirs = [("aprender-core", true), ("apr-cli", true)];
+        assert_eq!(
+            verdict_from_all_have_cargo_toml(&dirs),
+            AllHaveCargoTomlVerdict::Pass
+        );
+        // 006
+        assert_eq!(verdict_from_apr_prefix(&names), AprPrefixVerdict::Pass);
+        // 007
+        let paths = [
+            "crates/aprender/Cargo.toml",
+            "crates/aprender-core/Cargo.toml",
+        ];
+        assert_eq!(verdict_from_flat_layout(&paths), FlatLayoutVerdict::Pass);
+    }
+
+    #[test]
+    fn realistic_pre_fix_all_7_failures() {
+        // 001: subtree merge created two `trueno` entries (one renamed, one not).
+        assert_eq!(
+            verdict_from_no_duplicates(&["aprender-core", "aprender-core"]),
+            NoDuplicatesVerdict::Fail
+        );
+        // 002: stale workspace version.
+        assert_eq!(
+            verdict_from_version_consistency("0.20.0"),
+            VersionConsistencyVerdict::Fail
+        );
+        // 003: workspace member missing — only 30.
+        assert_eq!(verdict_from_min_member_count(30), MinMemberCountVerdict::Fail);
+        // 004: dev override leaked into root Cargo.toml.
+        let bad_toml = "[patch.crates-io]\ntrueno = { path = \"../trueno\" }";
+        assert_eq!(verdict_from_no_patch(bad_toml), NoPatchVerdict::Fail);
+        // 005: subtree merge dropped Cargo.toml.
+        assert_eq!(
+            verdict_from_all_have_cargo_toml(&[("aprender-core", false)]),
+            AllHaveCargoTomlVerdict::Fail
+        );
+        // 006: legacy name `realizar` still in workspace.
+        assert_eq!(
+            verdict_from_apr_prefix(&["aprender-core", "realizar"]),
+            AprPrefixVerdict::Fail
+        );
+        // 007: nested crate at crates/foo/bar/Cargo.toml.
+        assert_eq!(
+            verdict_from_flat_layout(&["crates/foo/bar/Cargo.toml"]),
+            FlatLayoutVerdict::Fail
+        );
+    }
+}

--- a/crates/aprender-core/src/format/nb_001_005.rs
+++ b/crates/aprender-core/src/format/nb_001_005.rs
@@ -1,0 +1,693 @@
+// SHIP-TWO-001 — `naive-bayes-v1` algorithm-level PARTIAL discharge
+// for FALSIFY-NB-001..005.
+//
+// Contract: `contracts/naive-bayes-v1.yaml`.
+// Spec: `docs/specifications/aprender-train/ship-two-models-spec.md`.
+//
+// ## What this file proves NOW (PARTIAL_ALGORITHM_LEVEL)
+//
+// Gaussian Naive Bayes — five gates:
+//
+// - NB-001 (prior sums to 1): Σ_k P(C_k) = 1 after fit.
+// - NB-002 (prior bounded): each P(C_k) ∈ (0, 1) for observed classes.
+// - NB-003 (prediction in classes): predict(x) ∈ training_classes.
+// - NB-004 (prediction deterministic): predict(x) = predict(x).
+// - NB-005 (separable accuracy): accuracy > 0.9 on well-separated
+//   Gaussian clusters.
+//
+// All five are PURE algorithm-level — no kernel selection, no SIMD path
+// — provable via in-module reference Gaussian-NB classifier.
+
+/// Floor of valid probability bound — strict.
+pub const AC_NB_002_PRIOR_LOWER_EXCLUSIVE: f32 = 0.0;
+
+/// Ceiling of valid probability bound — strict.
+pub const AC_NB_002_PRIOR_UPPER_EXCLUSIVE: f32 = 1.0;
+
+/// Tolerance on Σ priors == 1 (allow f32 round-off).
+pub const AC_NB_001_PRIOR_SUM_EPS: f32 = 1e-5;
+
+/// Minimum accuracy for NB-005 separable-cluster gate.
+pub const AC_NB_005_MIN_ACCURACY: f32 = 0.9;
+
+/// Lower bound for variance — Gaussian PDF is undefined at σ²=0.
+pub const AC_NB_VARIANCE_FLOOR: f32 = 1e-9;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NbVerdict {
+    Pass,
+    Fail,
+}
+
+// -----------------------------------------------------------------------------
+// In-module reference Gaussian-NB.
+// -----------------------------------------------------------------------------
+
+/// Fit a Gaussian Naive Bayes classifier from `(x, y)`.
+///
+/// `x` is row-major `[n_samples, n_features]`; `y` is `[n_samples]` of
+/// class indices in `0..k`. Returns (priors, means, variances) where:
+///
+/// - `priors[k]`        — P(C_k) = count_k / n
+/// - `means[k * d + j]` — μ_jk
+/// - `vars[k * d + j]`  — σ²_jk (variance-floored at AC_NB_VARIANCE_FLOOR)
+#[must_use]
+pub fn fit_gnb(
+    x: &[f32],
+    y: &[usize],
+    n_samples: usize,
+    n_features: usize,
+    n_classes: usize,
+) -> Option<(Vec<f32>, Vec<f32>, Vec<f32>)> {
+    if n_samples == 0 || n_features == 0 || n_classes == 0 {
+        return None;
+    }
+    if x.len() != n_samples * n_features || y.len() != n_samples {
+        return None;
+    }
+    if y.iter().any(|&c| c >= n_classes) {
+        return None;
+    }
+
+    let mut counts = vec![0_usize; n_classes];
+    for &c in y {
+        counts[c] += 1;
+    }
+
+    let mut means = vec![0.0_f32; n_classes * n_features];
+    for i in 0..n_samples {
+        let c = y[i];
+        for j in 0..n_features {
+            means[c * n_features + j] += x[i * n_features + j];
+        }
+    }
+    for k in 0..n_classes {
+        let n_k = counts[k] as f32;
+        if n_k > 0.0 {
+            for j in 0..n_features {
+                means[k * n_features + j] /= n_k;
+            }
+        }
+    }
+
+    let mut vars = vec![0.0_f32; n_classes * n_features];
+    for i in 0..n_samples {
+        let c = y[i];
+        for j in 0..n_features {
+            let d = x[i * n_features + j] - means[c * n_features + j];
+            vars[c * n_features + j] += d * d;
+        }
+    }
+    for k in 0..n_classes {
+        let n_k = counts[k] as f32;
+        if n_k > 0.0 {
+            for j in 0..n_features {
+                let v = vars[k * n_features + j] / n_k;
+                vars[k * n_features + j] = v.max(AC_NB_VARIANCE_FLOOR);
+            }
+        } else {
+            for j in 0..n_features {
+                vars[k * n_features + j] = 1.0;
+            }
+        }
+    }
+
+    let n = n_samples as f32;
+    let priors: Vec<f32> = counts.iter().map(|&c| c as f32 / n).collect();
+
+    Some((priors, means, vars))
+}
+
+/// Predict the class index by argmax of log P(C_k) + Σ_j log P(x_j | C_k).
+#[must_use]
+pub fn predict_gnb(
+    x: &[f32],
+    priors: &[f32],
+    means: &[f32],
+    vars: &[f32],
+    n_features: usize,
+) -> usize {
+    let n_classes = priors.len();
+    let mut best_k: usize = 0;
+    let mut best_lp: f32 = f32::NEG_INFINITY;
+
+    for k in 0..n_classes {
+        if priors[k] <= 0.0 {
+            // Class unobserved in fit — log(0) is -inf, never argmax.
+            continue;
+        }
+        let mut lp = priors[k].ln();
+        for j in 0..n_features {
+            let mu = means[k * n_features + j];
+            let var = vars[k * n_features + j];
+            let dx = x[j] - mu;
+            // log Gaussian PDF: -0.5 * ln(2π·σ²) - dx²/(2σ²)
+            let two_pi = std::f32::consts::TAU;
+            lp += -0.5 * (two_pi * var).ln() - 0.5 * (dx * dx) / var;
+        }
+        if lp > best_lp {
+            best_lp = lp;
+            best_k = k;
+        }
+    }
+    best_k
+}
+
+// -----------------------------------------------------------------------------
+// Verdict 1: NB-001 — Σ_k P(C_k) = 1.
+// -----------------------------------------------------------------------------
+
+#[must_use]
+pub fn verdict_from_prior_sum_to_one(priors: &[f32]) -> NbVerdict {
+    if priors.is_empty() {
+        return NbVerdict::Fail;
+    }
+    if priors.iter().any(|p| !p.is_finite()) {
+        return NbVerdict::Fail;
+    }
+    let sum: f32 = priors.iter().sum();
+    if (sum - 1.0).abs() < AC_NB_001_PRIOR_SUM_EPS {
+        NbVerdict::Pass
+    } else {
+        NbVerdict::Fail
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Verdict 2: NB-002 — each P(C_k) ∈ (0, 1) for observed classes.
+// -----------------------------------------------------------------------------
+
+/// `priors` is P(C_k); `observed_mask[k] = true` iff class k appears in
+/// training labels. For unobserved classes the strict lower bound is
+/// relaxed (P(C_k) = 0 is permissible — a class never seen).
+#[must_use]
+pub fn verdict_from_prior_bounded(priors: &[f32], observed_mask: &[bool]) -> NbVerdict {
+    if priors.is_empty() || priors.len() != observed_mask.len() {
+        return NbVerdict::Fail;
+    }
+    for (i, &p) in priors.iter().enumerate() {
+        if !p.is_finite() {
+            return NbVerdict::Fail;
+        }
+        if observed_mask[i] {
+            if p <= AC_NB_002_PRIOR_LOWER_EXCLUSIVE
+                || p >= AC_NB_002_PRIOR_UPPER_EXCLUSIVE
+            {
+                return NbVerdict::Fail;
+            }
+        } else if !(0.0..=1.0).contains(&p) {
+            return NbVerdict::Fail;
+        }
+    }
+    NbVerdict::Pass
+}
+
+// -----------------------------------------------------------------------------
+// Verdict 3: NB-003 — predict(x) ∈ training_classes.
+// -----------------------------------------------------------------------------
+
+#[must_use]
+pub fn verdict_from_prediction_in_classes(
+    predictions: &[usize],
+    n_training_classes: usize,
+) -> NbVerdict {
+    if n_training_classes == 0 {
+        return NbVerdict::Fail;
+    }
+    for &p in predictions {
+        if p >= n_training_classes {
+            return NbVerdict::Fail;
+        }
+    }
+    NbVerdict::Pass
+}
+
+// -----------------------------------------------------------------------------
+// Verdict 4: NB-004 — prediction deterministic.
+// -----------------------------------------------------------------------------
+
+#[must_use]
+pub fn verdict_from_prediction_deterministic(
+    predictions_run1: &[usize],
+    predictions_run2: &[usize],
+) -> NbVerdict {
+    if predictions_run1.len() != predictions_run2.len() {
+        return NbVerdict::Fail;
+    }
+    if predictions_run1 == predictions_run2 {
+        NbVerdict::Pass
+    } else {
+        NbVerdict::Fail
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Verdict 5: NB-005 — separable-cluster accuracy ≥ 0.9.
+// -----------------------------------------------------------------------------
+
+#[must_use]
+pub fn verdict_from_separable_accuracy(accuracy: f32) -> NbVerdict {
+    if !accuracy.is_finite() {
+        return NbVerdict::Fail;
+    }
+    if accuracy >= AC_NB_005_MIN_ACCURACY {
+        NbVerdict::Pass
+    } else {
+        NbVerdict::Fail
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -------------------------------------------------------------------------
+    // Section 1: Provenance pins.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn provenance_prior_lower_zero_exclusive() {
+        assert_eq!(AC_NB_002_PRIOR_LOWER_EXCLUSIVE, 0.0);
+    }
+
+    #[test]
+    fn provenance_prior_upper_one_exclusive() {
+        assert_eq!(AC_NB_002_PRIOR_UPPER_EXCLUSIVE, 1.0);
+    }
+
+    #[test]
+    fn provenance_separable_accuracy_floor_is_0_9() {
+        assert_eq!(AC_NB_005_MIN_ACCURACY, 0.9);
+    }
+
+    #[test]
+    fn provenance_prior_sum_eps_is_1e_5() {
+        assert_eq!(AC_NB_001_PRIOR_SUM_EPS, 1e-5);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 2: NB-001 Pass band.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn nb001_pass_two_class_balanced() {
+        let priors = vec![0.5_f32, 0.5];
+        assert_eq!(verdict_from_prior_sum_to_one(&priors), NbVerdict::Pass);
+    }
+
+    #[test]
+    fn nb001_pass_three_class_unbalanced() {
+        let priors = vec![0.7_f32, 0.2, 0.1];
+        assert_eq!(verdict_from_prior_sum_to_one(&priors), NbVerdict::Pass);
+    }
+
+    #[test]
+    fn nb001_pass_after_fit_balanced() {
+        // 6 samples, 3 classes, 2 each — priors should be [1/3, 1/3, 1/3].
+        let x = vec![0.0_f32, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 1.0, 2.0, 0.0, 0.0, 2.0];
+        let y = vec![0_usize, 0, 1, 1, 2, 2];
+        let (priors, _, _) = fit_gnb(&x, &y, 6, 2, 3).unwrap();
+        assert_eq!(verdict_from_prior_sum_to_one(&priors), NbVerdict::Pass);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 3: NB-001 Fail band.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn nb001_fail_priors_sum_to_half() {
+        let priors = vec![0.25_f32, 0.25];
+        assert_eq!(verdict_from_prior_sum_to_one(&priors), NbVerdict::Fail);
+    }
+
+    #[test]
+    fn nb001_fail_priors_sum_to_two() {
+        let priors = vec![1.0_f32, 1.0];
+        assert_eq!(verdict_from_prior_sum_to_one(&priors), NbVerdict::Fail);
+    }
+
+    #[test]
+    fn nb001_fail_priors_empty() {
+        let priors: Vec<f32> = vec![];
+        assert_eq!(verdict_from_prior_sum_to_one(&priors), NbVerdict::Fail);
+    }
+
+    #[test]
+    fn nb001_fail_priors_nan() {
+        let priors = vec![0.5_f32, f32::NAN];
+        assert_eq!(verdict_from_prior_sum_to_one(&priors), NbVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 4: NB-002 Pass band.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn nb002_pass_two_class_observed() {
+        let priors = vec![0.6_f32, 0.4];
+        let observed = vec![true, true];
+        assert_eq!(
+            verdict_from_prior_bounded(&priors, &observed),
+            NbVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn nb002_pass_unobserved_class_zero_allowed() {
+        // class 2 wasn't seen — its prior is 0, mask[2]=false: allowed.
+        let priors = vec![0.5_f32, 0.5, 0.0];
+        let observed = vec![true, true, false];
+        assert_eq!(
+            verdict_from_prior_bounded(&priors, &observed),
+            NbVerdict::Pass
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 5: NB-002 Fail band.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn nb002_fail_observed_class_with_prior_zero() {
+        // observed[k]=true ⇒ p must be > 0.
+        let priors = vec![0.0_f32, 1.0];
+        let observed = vec![true, true];
+        assert_eq!(
+            verdict_from_prior_bounded(&priors, &observed),
+            NbVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn nb002_fail_observed_class_with_prior_one() {
+        // observed[k]=true ⇒ p must be < 1 (open interval).
+        let priors = vec![1.0_f32, 0.0];
+        let observed = vec![true, true];
+        assert_eq!(
+            verdict_from_prior_bounded(&priors, &observed),
+            NbVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn nb002_fail_negative_prior() {
+        let priors = vec![-0.1_f32, 1.1];
+        let observed = vec![true, true];
+        assert_eq!(
+            verdict_from_prior_bounded(&priors, &observed),
+            NbVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn nb002_fail_nan_prior() {
+        let priors = vec![f32::NAN, 0.5];
+        let observed = vec![true, true];
+        assert_eq!(
+            verdict_from_prior_bounded(&priors, &observed),
+            NbVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 6: NB-003 — predictions ∈ training_classes.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn nb003_pass_all_in_range() {
+        let preds = vec![0_usize, 1, 2, 0, 1];
+        assert_eq!(
+            verdict_from_prediction_in_classes(&preds, 3),
+            NbVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn nb003_pass_empty_predictions() {
+        let preds: Vec<usize> = vec![];
+        assert_eq!(
+            verdict_from_prediction_in_classes(&preds, 5),
+            NbVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn nb003_fail_one_out_of_range() {
+        let preds = vec![0_usize, 1, 2, 5];
+        assert_eq!(
+            verdict_from_prediction_in_classes(&preds, 3),
+            NbVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn nb003_fail_no_training_classes() {
+        let preds = vec![0_usize];
+        assert_eq!(
+            verdict_from_prediction_in_classes(&preds, 0),
+            NbVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 7: NB-004 — determinism.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn nb004_pass_identical_runs() {
+        let r1 = vec![0_usize, 1, 0, 2];
+        let r2 = vec![0_usize, 1, 0, 2];
+        assert_eq!(
+            verdict_from_prediction_deterministic(&r1, &r2),
+            NbVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn nb004_pass_empty_both() {
+        let r: Vec<usize> = vec![];
+        assert_eq!(
+            verdict_from_prediction_deterministic(&r, &r),
+            NbVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn nb004_fail_one_off() {
+        let r1 = vec![0_usize, 1, 0, 2];
+        let r2 = vec![0_usize, 1, 0, 1]; // last differs
+        assert_eq!(
+            verdict_from_prediction_deterministic(&r1, &r2),
+            NbVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn nb004_fail_length_mismatch() {
+        let r1 = vec![0_usize, 1, 2];
+        let r2 = vec![0_usize, 1];
+        assert_eq!(
+            verdict_from_prediction_deterministic(&r1, &r2),
+            NbVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 8: NB-005 — separable accuracy.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn nb005_pass_perfect_accuracy() {
+        assert_eq!(
+            verdict_from_separable_accuracy(1.0),
+            NbVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn nb005_pass_at_threshold() {
+        assert_eq!(
+            verdict_from_separable_accuracy(0.9),
+            NbVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn nb005_fail_below_threshold() {
+        assert_eq!(
+            verdict_from_separable_accuracy(0.89),
+            NbVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn nb005_fail_random_chance() {
+        assert_eq!(
+            verdict_from_separable_accuracy(0.5),
+            NbVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn nb005_fail_nan() {
+        assert_eq!(
+            verdict_from_separable_accuracy(f32::NAN),
+            NbVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 9: Domain — fit/predict end-to-end on toy data.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn domain_fit_predict_two_well_separated_clusters() {
+        // Cluster 0 around (0,0); cluster 1 around (10,10). 2 features.
+        let x = vec![
+            0.0, 0.0, 0.1, -0.1, -0.2, 0.2, // class 0
+            10.0, 10.0, 10.1, 9.9, 9.8, 10.2, // class 1
+        ];
+        let y = vec![0_usize, 0, 0, 1, 1, 1];
+        let (priors, means, vars) = fit_gnb(&x, &y, 6, 2, 2).unwrap();
+
+        // Priors balanced.
+        assert_eq!(verdict_from_prior_sum_to_one(&priors), NbVerdict::Pass);
+        let observed = vec![true, true];
+        assert_eq!(
+            verdict_from_prior_bounded(&priors, &observed),
+            NbVerdict::Pass
+        );
+
+        // Predict at the cluster centers.
+        let p0 = predict_gnb(&[0.0, 0.0], &priors, &means, &vars, 2);
+        let p1 = predict_gnb(&[10.0, 10.0], &priors, &means, &vars, 2);
+        assert_eq!(p0, 0);
+        assert_eq!(p1, 1);
+
+        // Predict twice — deterministic.
+        let p0_again = predict_gnb(&[0.0, 0.0], &priors, &means, &vars, 2);
+        assert_eq!(
+            verdict_from_prediction_deterministic(&[p0], &[p0_again]),
+            NbVerdict::Pass
+        );
+
+        // All predictions in [0, 2).
+        let preds = vec![p0, p1];
+        assert_eq!(
+            verdict_from_prediction_in_classes(&preds, 2),
+            NbVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn domain_separable_accuracy_high() {
+        // Generate 4 well-separated 2D clusters at (±5, ±5); fit + predict
+        // on training data; check accuracy.
+        let centers = [(-5.0, -5.0), (5.0, -5.0), (-5.0, 5.0), (5.0, 5.0)];
+        let mut x = Vec::new();
+        let mut y = Vec::new();
+        // 5 perturbations per center.
+        let pert = [
+            (0.0_f32, 0.0),
+            (0.1, 0.0),
+            (-0.1, 0.0),
+            (0.0, 0.1),
+            (0.0, -0.1),
+        ];
+        for (k, (cx, cy)) in centers.iter().enumerate() {
+            for (dx, dy) in pert.iter() {
+                x.push(cx + dx);
+                x.push(cy + dy);
+                y.push(k);
+            }
+        }
+        let n = y.len();
+        let (priors, means, vars) = fit_gnb(&x, &y, n, 2, 4).unwrap();
+        let mut correct = 0;
+        for i in 0..n {
+            let pred = predict_gnb(&x[i * 2..i * 2 + 2], &priors, &means, &vars, 2);
+            if pred == y[i] {
+                correct += 1;
+            }
+        }
+        let acc = correct as f32 / n as f32;
+        assert_eq!(
+            verdict_from_separable_accuracy(acc),
+            NbVerdict::Pass,
+            "accuracy={acc}"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 10: Sweep — boundary fail modes.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn sweep_fail_priors_off_by_more_than_eps() {
+        for sum in [0.5_f32, 0.99, 1.01, 1.5, 2.0] {
+            let priors = vec![sum / 2.0, sum / 2.0];
+            assert_eq!(
+                verdict_from_prior_sum_to_one(&priors),
+                NbVerdict::Fail,
+                "sum={sum}"
+            );
+        }
+    }
+
+    #[test]
+    fn sweep_pass_priors_within_eps() {
+        for offset in [-1e-6_f32, 0.0, 1e-6] {
+            let priors = vec![0.5 + offset, 0.5];
+            assert_eq!(
+                verdict_from_prior_sum_to_one(&priors),
+                NbVerdict::Pass,
+                "offset={offset}"
+            );
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 11: Realistic — contract regression scenarios.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn realistic_integer_truncation_caught() {
+        // The contract failure for NB-001: "Normalization not applied or
+        // integer truncation". 3/10 = 0.3 in f32 — but if someone wrote
+        // `count / n_samples` as integer truncation, all priors would be
+        // 0 ⇒ sum != 1.
+        let priors_truncated = vec![0.0_f32, 0.0, 0.0];
+        assert_eq!(
+            verdict_from_prior_sum_to_one(&priors_truncated),
+            NbVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn realistic_argmax_returns_invalid_index() {
+        // The contract failure for NB-003: "Argmax over log-posteriors
+        // returns invalid index" — e.g., off-by-one or buffer overrun.
+        let preds_invalid = vec![0_usize, 1, 99]; // 99 ∉ training classes
+        assert_eq!(
+            verdict_from_prediction_in_classes(&preds_invalid, 5),
+            NbVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn realistic_non_deterministic_floating_point() {
+        // The contract failure for NB-004: "Non-deterministic floating
+        // point or random state leakage" — same input, different output
+        // means a hidden state was consulted.
+        let r1 = vec![0_usize, 1, 2, 0];
+        let r2 = vec![0_usize, 1, 2, 1]; // last flipped
+        assert_eq!(
+            verdict_from_prediction_deterministic(&r1, &r2),
+            NbVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn realistic_fit_rejects_invalid_input_shapes() {
+        // n_samples=2, n_features=3 ⇒ x must have 6 entries.
+        let x = vec![1.0_f32, 2.0]; // wrong size
+        let y = vec![0_usize, 1];
+        assert!(fit_gnb(&x, &y, 2, 3, 2).is_none());
+    }
+
+    #[test]
+    fn realistic_fit_rejects_class_index_out_of_range() {
+        let x = vec![1.0_f32, 2.0];
+        let y = vec![0_usize, 5]; // 5 >= n_classes=2
+        assert!(fit_gnb(&x, &y, 2, 1, 2).is_none());
+    }
+}

--- a/crates/aprender-core/src/format/opt_001_003.rs
+++ b/crates/aprender-core/src/format/opt_001_003.rs
@@ -1,0 +1,482 @@
+// SHIP-TWO-001 — `optimization-v1` algorithm-level PARTIAL discharge
+// for FALSIFY-OPT-001..003.
+//
+// Contract: `contracts/optimization-v1.yaml`.
+// Spec: `docs/specifications/aprender-train/ship-two-models-spec.md`.
+//
+// ## What this file proves NOW (PARTIAL_ALGORITHM_LEVEL)
+//
+// Three Conjugate Gradient gates from Nocedal & Wright (2006) Ch. 5:
+//
+// - OPT-001 (monotone decrease): f(x_{k+1}) ≤ f(x_k) per iteration.
+// - OPT-002 (finite iterates): all x_k finite (no NaN, no Inf).
+// - OPT-003 (gradient norm convergence): ||g_final|| < ||g_initial||.
+//
+// All three are pure properties of the iteration trace (function-value
+// sequence, iterate sequence, gradient-norm pair) — no actual line-
+// search / matrix algebra wired at this layer.
+
+/// Tolerance for monotone-decrease check: f_{k+1} ≤ f_k + EPS allows
+/// small numerical wobble. Standard FP32 trust region.
+pub const AC_OPT_001_MONOTONE_EPS: f32 = 1e-5;
+
+/// Required gradient-norm decrease ratio: ||g_final|| < ||g_initial||
+/// strictly (no slack — we only assert the contract's own inequality).
+pub const AC_OPT_003_DECREASE_REQUIRED: bool = true;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OptVerdict {
+    Pass,
+    Fail,
+}
+
+// -----------------------------------------------------------------------------
+// In-module reference quadratic optimizer (steepest descent for clarity).
+// -----------------------------------------------------------------------------
+
+/// Compute quadratic f(x) = 0.5 x^T A x + b^T x for a diagonal A.
+#[must_use]
+pub fn quadratic(a_diag: &[f32], b: &[f32], x: &[f32]) -> f32 {
+    let mut f = 0.0_f32;
+    for i in 0..x.len() {
+        f += 0.5 * a_diag[i] * x[i] * x[i] + b[i] * x[i];
+    }
+    f
+}
+
+/// Gradient of f at x: g_i = a_i * x_i + b_i.
+#[must_use]
+pub fn quadratic_grad(a_diag: &[f32], b: &[f32], x: &[f32]) -> Vec<f32> {
+    (0..x.len()).map(|i| a_diag[i] * x[i] + b[i]).collect()
+}
+
+/// Run steepest-descent on a strictly-convex diagonal quadratic for
+/// `n_iters` iterations. Returns trace of (f_k, x_k, ||g_k||).
+#[must_use]
+pub fn steepest_descent_quadratic(
+    a_diag: &[f32],
+    b: &[f32],
+    x0: &[f32],
+    learning_rate: f32,
+    n_iters: usize,
+) -> Vec<(f32, Vec<f32>, f32)> {
+    let mut x = x0.to_vec();
+    let mut trace = Vec::with_capacity(n_iters + 1);
+    for _ in 0..=n_iters {
+        let f = quadratic(a_diag, b, &x);
+        let g = quadratic_grad(a_diag, b, &x);
+        let g_norm = g.iter().map(|gi| gi * gi).sum::<f32>().sqrt();
+        trace.push((f, x.clone(), g_norm));
+        // x_{k+1} = x_k - lr * g_k
+        for i in 0..x.len() {
+            x[i] -= learning_rate * g[i];
+        }
+    }
+    trace
+}
+
+// -----------------------------------------------------------------------------
+// Verdict 1: OPT-001 — monotone decrease.
+// -----------------------------------------------------------------------------
+
+/// Pass iff f_values is non-empty AND every consecutive pair satisfies
+/// `f_{k+1} ≤ f_k + AC_OPT_001_MONOTONE_EPS`.
+#[must_use]
+pub fn verdict_from_monotone_decrease(f_values: &[f32]) -> OptVerdict {
+    if f_values.is_empty() {
+        return OptVerdict::Fail;
+    }
+    for w in f_values.windows(2) {
+        let f_k = w[0];
+        let f_kp1 = w[1];
+        if !f_k.is_finite() || !f_kp1.is_finite() {
+            return OptVerdict::Fail;
+        }
+        if f_kp1 > f_k + AC_OPT_001_MONOTONE_EPS {
+            return OptVerdict::Fail;
+        }
+    }
+    OptVerdict::Pass
+}
+
+// -----------------------------------------------------------------------------
+// Verdict 2: OPT-002 — finite iterates.
+// -----------------------------------------------------------------------------
+
+/// Pass iff every iterate is finite (no NaN, no Inf).
+#[must_use]
+pub fn verdict_from_finite_iterates(iterates: &[Vec<f32>]) -> OptVerdict {
+    if iterates.is_empty() {
+        return OptVerdict::Fail;
+    }
+    for x_k in iterates {
+        for &xi in x_k {
+            if !xi.is_finite() {
+                return OptVerdict::Fail;
+            }
+        }
+    }
+    OptVerdict::Pass
+}
+
+// -----------------------------------------------------------------------------
+// Verdict 3: OPT-003 — gradient norm decrease.
+// -----------------------------------------------------------------------------
+
+/// Pass iff `g_final_norm < g_initial_norm` (strict; both finite).
+#[must_use]
+pub fn verdict_from_gradient_decrease(g_initial_norm: f32, g_final_norm: f32) -> OptVerdict {
+    if !g_initial_norm.is_finite() || !g_final_norm.is_finite() {
+        return OptVerdict::Fail;
+    }
+    if g_initial_norm < 0.0 || g_final_norm < 0.0 {
+        return OptVerdict::Fail;
+    }
+    if g_final_norm < g_initial_norm {
+        OptVerdict::Pass
+    } else {
+        OptVerdict::Fail
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -------------------------------------------------------------------------
+    // Section 1: Provenance pins.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn provenance_monotone_eps_1e_5() {
+        assert_eq!(AC_OPT_001_MONOTONE_EPS, 1e-5);
+    }
+
+    #[test]
+    fn provenance_decrease_required() {
+        assert!(AC_OPT_003_DECREASE_REQUIRED);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 2: OPT-001 Pass band.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn opt001_pass_strictly_decreasing() {
+        let f = vec![10.0_f32, 8.0, 5.0, 3.0, 1.0];
+        assert_eq!(verdict_from_monotone_decrease(&f), OptVerdict::Pass);
+    }
+
+    #[test]
+    fn opt001_pass_constant() {
+        let f = vec![5.0_f32, 5.0, 5.0];
+        assert_eq!(verdict_from_monotone_decrease(&f), OptVerdict::Pass);
+    }
+
+    #[test]
+    fn opt001_pass_after_convergence() {
+        let f = vec![100.0_f32, 50.0, 25.0, 12.5, 12.5, 12.5];
+        assert_eq!(verdict_from_monotone_decrease(&f), OptVerdict::Pass);
+    }
+
+    #[test]
+    fn opt001_pass_within_eps_wobble() {
+        let f = vec![5.0_f32, 5.000005]; // 5e-6 < 1e-5
+        assert_eq!(verdict_from_monotone_decrease(&f), OptVerdict::Pass);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 3: OPT-001 Fail band.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn opt001_fail_increasing() {
+        let f = vec![1.0_f32, 5.0, 3.0];
+        assert_eq!(verdict_from_monotone_decrease(&f), OptVerdict::Fail);
+    }
+
+    #[test]
+    fn opt001_fail_one_jump() {
+        let f = vec![10.0_f32, 8.0, 9.0, 5.0]; // 8 → 9 is ascent
+        assert_eq!(verdict_from_monotone_decrease(&f), OptVerdict::Fail);
+    }
+
+    #[test]
+    fn opt001_fail_empty() {
+        let f: Vec<f32> = vec![];
+        assert_eq!(verdict_from_monotone_decrease(&f), OptVerdict::Fail);
+    }
+
+    #[test]
+    fn opt001_fail_nan() {
+        let f = vec![5.0_f32, f32::NAN];
+        assert_eq!(verdict_from_monotone_decrease(&f), OptVerdict::Fail);
+    }
+
+    #[test]
+    fn opt001_fail_inf() {
+        let f = vec![5.0_f32, f32::INFINITY];
+        assert_eq!(verdict_from_monotone_decrease(&f), OptVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 4: OPT-002 Pass band.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn opt002_pass_finite_2d() {
+        let iters = vec![vec![1.0_f32, 2.0], vec![0.5, 1.0], vec![0.25, 0.5]];
+        assert_eq!(verdict_from_finite_iterates(&iters), OptVerdict::Pass);
+    }
+
+    #[test]
+    fn opt002_pass_zeros() {
+        let iters = vec![vec![0.0_f32, 0.0]];
+        assert_eq!(verdict_from_finite_iterates(&iters), OptVerdict::Pass);
+    }
+
+    #[test]
+    fn opt002_pass_negative_values() {
+        let iters = vec![vec![-100.0_f32, -50.0], vec![-25.0, -10.0]];
+        assert_eq!(verdict_from_finite_iterates(&iters), OptVerdict::Pass);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 5: OPT-002 Fail band.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn opt002_fail_nan_iterate() {
+        let iters = vec![vec![1.0_f32], vec![f32::NAN]];
+        assert_eq!(verdict_from_finite_iterates(&iters), OptVerdict::Fail);
+    }
+
+    #[test]
+    fn opt002_fail_inf_iterate() {
+        let iters = vec![vec![1.0_f32, f32::INFINITY]];
+        assert_eq!(verdict_from_finite_iterates(&iters), OptVerdict::Fail);
+    }
+
+    #[test]
+    fn opt002_fail_neg_inf() {
+        let iters = vec![vec![1.0_f32], vec![f32::NEG_INFINITY]];
+        assert_eq!(verdict_from_finite_iterates(&iters), OptVerdict::Fail);
+    }
+
+    #[test]
+    fn opt002_fail_empty_iterates() {
+        let iters: Vec<Vec<f32>> = vec![];
+        assert_eq!(verdict_from_finite_iterates(&iters), OptVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 6: OPT-003 — gradient decrease.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn opt003_pass_strict_decrease() {
+        assert_eq!(verdict_from_gradient_decrease(10.0, 1.0), OptVerdict::Pass);
+    }
+
+    #[test]
+    fn opt003_pass_near_zero_final() {
+        assert_eq!(
+            verdict_from_gradient_decrease(5.0, 1e-10),
+            OptVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn opt003_fail_no_change() {
+        // Strict <, no equality.
+        assert_eq!(verdict_from_gradient_decrease(5.0, 5.0), OptVerdict::Fail);
+    }
+
+    #[test]
+    fn opt003_fail_increase() {
+        assert_eq!(verdict_from_gradient_decrease(1.0, 10.0), OptVerdict::Fail);
+    }
+
+    #[test]
+    fn opt003_fail_negative() {
+        // Norms must be non-negative.
+        assert_eq!(
+            verdict_from_gradient_decrease(-1.0, 0.5),
+            OptVerdict::Fail
+        );
+        assert_eq!(
+            verdict_from_gradient_decrease(1.0, -0.5),
+            OptVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn opt003_fail_nan() {
+        assert_eq!(
+            verdict_from_gradient_decrease(f32::NAN, 1.0),
+            OptVerdict::Fail
+        );
+        assert_eq!(
+            verdict_from_gradient_decrease(1.0, f32::NAN),
+            OptVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn opt003_fail_inf() {
+        assert_eq!(
+            verdict_from_gradient_decrease(f32::INFINITY, 1.0),
+            OptVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 7: Domain — reference steepest descent.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn domain_steepest_descent_converges_on_quadratic() {
+        // f(x) = 0.5*(x_0^2 + 2*x_1^2) + (-x_0 - 2*x_1)
+        // Minimum at x* = [1, 1] with f* = -1.5.
+        let a = vec![1.0_f32, 2.0];
+        let b = vec![-1.0_f32, -2.0];
+        let x0 = vec![5.0_f32, 5.0];
+        let trace = steepest_descent_quadratic(&a, &b, &x0, 0.1, 50);
+
+        let f_values: Vec<f32> = trace.iter().map(|(f, _, _)| *f).collect();
+        let iterates: Vec<Vec<f32>> = trace.iter().map(|(_, x, _)| x.clone()).collect();
+        let g_initial = trace.first().unwrap().2;
+        let g_final = trace.last().unwrap().2;
+
+        assert_eq!(verdict_from_monotone_decrease(&f_values), OptVerdict::Pass);
+        assert_eq!(verdict_from_finite_iterates(&iterates), OptVerdict::Pass);
+        assert_eq!(
+            verdict_from_gradient_decrease(g_initial, g_final),
+            OptVerdict::Pass
+        );
+
+        // Final point should be near (1, 1). At lr=0.1, 50 iters, the
+        // x0 dimension (eigenvalue 1) converges as 0.9^50 ≈ 0.005 of
+        // initial residual; the x1 dimension (eigenvalue 2) is faster.
+        // Allow 0.05 slack — pure correctness check is monotone+gradient,
+        // not the absolute distance.
+        let x_final = trace.last().unwrap().1.clone();
+        assert!((x_final[0] - 1.0).abs() < 0.05, "x0={}", x_final[0]);
+        assert!((x_final[1] - 1.0).abs() < 0.05, "x1={}", x_final[1]);
+    }
+
+    #[test]
+    fn domain_quadratic_value_at_minimum() {
+        // f(x) = 0.5*x^2 - x; min at x=1, f*=-0.5.
+        let a = vec![1.0_f32];
+        let b = vec![-1.0_f32];
+        let x = vec![1.0_f32];
+        let f = quadratic(&a, &b, &x);
+        assert!((f - (-0.5)).abs() < 1e-6);
+    }
+
+    #[test]
+    fn domain_quadratic_gradient_zero_at_minimum() {
+        let a = vec![2.0_f32];
+        let b = vec![-4.0_f32]; // min at x = -b/a = 2
+        let x = vec![2.0_f32];
+        let g = quadratic_grad(&a, &b, &x);
+        assert!(g[0].abs() < 1e-6);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 8: Sweep — initial points.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn sweep_steepest_descent_various_starts() {
+        let a = vec![1.0_f32];
+        let b = vec![-2.0_f32]; // min at x=2, f*=-2
+        for x0_val in [-10.0_f32, -1.0, 0.0, 5.0, 100.0] {
+            let trace = steepest_descent_quadratic(&a, &b, &[x0_val], 0.1, 100);
+            let f_values: Vec<f32> = trace.iter().map(|(f, _, _)| *f).collect();
+            let iterates: Vec<Vec<f32>> = trace.iter().map(|(_, x, _)| x.clone()).collect();
+            assert_eq!(
+                verdict_from_monotone_decrease(&f_values),
+                OptVerdict::Pass,
+                "x0={x0_val}"
+            );
+            assert_eq!(
+                verdict_from_finite_iterates(&iterates),
+                OptVerdict::Pass,
+                "x0={x0_val}"
+            );
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 9: Realistic — contract regression scenarios.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn realistic_armijo_violation_caught() {
+        // OPT-001 if_fails: "Line search not satisfying Armijo condition".
+        // Simulate by injecting a non-monotone f sequence.
+        let f = vec![5.0_f32, 3.0, 7.0, 2.0]; // 3→7 is ascent
+        assert_eq!(verdict_from_monotone_decrease(&f), OptVerdict::Fail);
+    }
+
+    #[test]
+    fn realistic_gradient_explosion_caught() {
+        // OPT-002 if_fails: "Step size too large or gradient explosion".
+        // Simulate runaway iteration producing Inf.
+        let iters = vec![
+            vec![1.0_f32, 2.0],
+            vec![100.0, 200.0],
+            vec![10000.0, 20000.0],
+            vec![f32::INFINITY, f32::INFINITY],
+        ];
+        assert_eq!(verdict_from_finite_iterates(&iters), OptVerdict::Fail);
+    }
+
+    #[test]
+    fn realistic_beta_overflow_ascent() {
+        // OPT-003 if_fails: "Conjugate direction computation error or
+        // beta overflow". Final gradient norm exceeds initial.
+        assert_eq!(
+            verdict_from_gradient_decrease(2.0, 5.0),
+            OptVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn realistic_lr_too_large_diverges() {
+        // Steepest descent with lr too large diverges; iterates blow up.
+        let a = vec![1.0_f32];
+        let b = vec![0.0_f32];
+        let x0 = vec![1.0_f32];
+        let trace = steepest_descent_quadratic(&a, &b, &x0, 5.0, 20); // lr=5 too large
+
+        let iterates: Vec<Vec<f32>> = trace.iter().map(|(_, x, _)| x.clone()).collect();
+        // x grows without bound — eventually overflows to Inf.
+        // First check that values became extreme.
+        let last_x = iterates.last().unwrap()[0].abs();
+        assert!(
+            last_x > 1e6 || !last_x.is_finite(),
+            "lr=5 on x_0=1 must diverge; |x_final|={last_x}"
+        );
+    }
+
+    #[test]
+    fn realistic_full_optimization_pipeline() {
+        // f(x) = 0.5*(x_0^2 + x_1^2 + x_2^2); minimum at origin, f*=0.
+        let a = vec![1.0_f32; 3];
+        let b = vec![0.0_f32; 3];
+        let x0 = vec![3.0_f32, -2.0, 1.5];
+        let trace = steepest_descent_quadratic(&a, &b, &x0, 0.5, 100);
+
+        let f_values: Vec<f32> = trace.iter().map(|(f, _, _)| *f).collect();
+        let iterates: Vec<Vec<f32>> = trace.iter().map(|(_, x, _)| x.clone()).collect();
+
+        assert_eq!(verdict_from_monotone_decrease(&f_values), OptVerdict::Pass);
+        assert_eq!(verdict_from_finite_iterates(&iterates), OptVerdict::Pass);
+        let (_, _, g_init) = trace.first().unwrap();
+        let (f_final, x_final, g_final) = trace.last().unwrap();
+        assert_eq!(
+            verdict_from_gradient_decrease(*g_init, *g_final),
+            OptVerdict::Pass
+        );
+
+        // Should be close to origin.
+        for &xi in x_final {
+            assert!(xi.abs() < 1e-5, "x_final={x_final:?}");
+        }
+        assert!(f_final.abs() < 1e-9);
+    }
+}

--- a/crates/aprender-core/src/format/orgtax_001_005.rs
+++ b/crates/aprender-core/src/format/orgtax_001_005.rs
@@ -1,0 +1,437 @@
+// `apr-org-taxonomy-v1` algorithm-level PARTIAL discharge for the 5
+// falsification conditions (orphan classification, archive-deadline,
+// stale-archive-deadline, legacy-redirect, category-count sum).
+//
+// Contract: `contracts/apr-org-taxonomy-v1.yaml`.
+//
+// The contract has 5 unkeyed `falsification:` entries. We pin local IDs
+// FALSIFY-ORGTAX-001..005 to give each a stable verdict function:
+//
+//   001 — every repo classified (no orphan in `gh repo list`)
+//   002 — SHOULD-MERGE repo archived within 7 days
+//   003 — STALE repo archived within 7 days
+//   004 — repo description contains legacy name without MOVED redirect
+//   005 — sum(category_counts) == total_repos
+//
+// Live discharge: `gh repo list paiml --limit 300 --json` + a
+// classification map. Algorithm-level pinning prevents drift on the
+// invariant predicates regardless of how the live shell harness fetches
+// the org state.
+
+use std::collections::HashSet;
+
+/// Total repos enumerated in the contract metadata.
+pub const AC_ORGTAX_TOTAL_REPOS: u32 = 205;
+
+/// Number of categories in the taxonomy.
+pub const AC_ORGTAX_CATEGORIES: u32 = 15;
+
+/// Archive deadline for SHOULD-MERGE / STALE repos.
+pub const AC_ORGTAX_ARCHIVE_DEADLINE_DAYS: u32 = 7;
+
+/// Canonical category names. The contract `categories:` map MUST contain
+/// exactly these 15 keys.
+pub const AC_ORGTAX_CATEGORY_NAMES: [&str; 15] = [
+    "monorepo",
+    "merged",
+    "should_merge",
+    "active_tool",
+    "model_training",
+    "poc_benchmark",
+    "course_demo",
+    "legacy_book",
+    "legacy_library",
+    "ground_truth",
+    "transpiler",
+    "ruchy",
+    "infra_platform",
+    "pmat",
+    "stale_archive",
+];
+
+/// Canonical category counts from contract v1.0.0.
+pub const AC_ORGTAX_CATEGORY_COUNTS: [(&str, u32); 15] = [
+    ("monorepo", 1),
+    ("merged", 14),
+    ("should_merge", 6),
+    ("active_tool", 21),
+    ("model_training", 3),
+    ("poc_benchmark", 8),
+    ("course_demo", 34),
+    ("legacy_book", 15),
+    ("legacy_library", 18),
+    ("ground_truth", 13),
+    ("transpiler", 9),
+    ("ruchy", 8),
+    ("infra_platform", 25),
+    ("pmat", 6),
+    ("stale_archive", 24),
+];
+
+/// Legacy names whose appearance in repo descriptions REQUIRES a MOVED
+/// redirect (consolidated into aprender per APR-MONO).
+pub const AC_ORGTAX_LEGACY_NAMES: [&str; 4] = ["trueno", "realizar", "entrenar", "batuta"];
+
+// =============================================================================
+// FALSIFY-ORGTAX-001 — every repo classified
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OrphanClassificationVerdict {
+    /// No repo from the live `gh repo list` is missing a category.
+    Pass,
+    /// At least one repo has no category assignment.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_orphan_classification(
+    live_repos: &[&str],
+    classified_repos: &[&str],
+) -> OrphanClassificationVerdict {
+    let classified: HashSet<&&str> = classified_repos.iter().collect();
+    for repo in live_repos {
+        if !classified.contains(repo) {
+            return OrphanClassificationVerdict::Fail;
+        }
+    }
+    OrphanClassificationVerdict::Pass
+}
+
+// =============================================================================
+// FALSIFY-ORGTAX-002 — SHOULD-MERGE repo archived within 7 days
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ShouldMergeArchiveVerdict {
+    /// Repo archived OR within deadline.
+    Pass,
+    /// Repo not archived AND age > 7 days.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_should_merge_archive(
+    archived: bool,
+    days_since_classification: u32,
+) -> ShouldMergeArchiveVerdict {
+    if archived {
+        return ShouldMergeArchiveVerdict::Pass;
+    }
+    if days_since_classification > AC_ORGTAX_ARCHIVE_DEADLINE_DAYS {
+        ShouldMergeArchiveVerdict::Fail
+    } else {
+        ShouldMergeArchiveVerdict::Pass
+    }
+}
+
+// =============================================================================
+// FALSIFY-ORGTAX-003 — STALE repo archived within 7 days
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StaleArchiveVerdict {
+    /// Repo archived OR within deadline.
+    Pass,
+    /// Repo not archived AND age > 7 days.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_stale_archive(
+    archived: bool,
+    days_since_classification: u32,
+) -> StaleArchiveVerdict {
+    if archived {
+        return StaleArchiveVerdict::Pass;
+    }
+    if days_since_classification > AC_ORGTAX_ARCHIVE_DEADLINE_DAYS {
+        StaleArchiveVerdict::Fail
+    } else {
+        StaleArchiveVerdict::Pass
+    }
+}
+
+// =============================================================================
+// FALSIFY-ORGTAX-004 — legacy name in description requires MOVED redirect
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LegacyRedirectVerdict {
+    /// Description either has no legacy name OR includes "MOVED" tag.
+    Pass,
+    /// Legacy name present without "MOVED" redirect.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_legacy_redirect(description: &str) -> LegacyRedirectVerdict {
+    let lower = description.to_lowercase();
+    let mentions_legacy = AC_ORGTAX_LEGACY_NAMES.iter().any(|n| lower.contains(n));
+    if !mentions_legacy {
+        return LegacyRedirectVerdict::Pass;
+    }
+    if lower.contains("moved") {
+        LegacyRedirectVerdict::Pass
+    } else {
+        LegacyRedirectVerdict::Fail
+    }
+}
+
+// =============================================================================
+// FALSIFY-ORGTAX-005 — category counts sum to total_repos
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CategorySumVerdict {
+    /// sum(category_counts) == total_repos.
+    Pass,
+    /// Sum mismatch (recount required).
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_category_sum(category_counts: &[(&str, u32)], total_repos: u32) -> CategorySumVerdict {
+    let sum: u32 = category_counts.iter().map(|(_, n)| n).sum();
+    if sum == total_repos {
+        CategorySumVerdict::Pass
+    } else {
+        CategorySumVerdict::Fail
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -------------------------------------------------------------------------
+    // Section 1: Provenance pins.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn provenance_total_repos_205() {
+        assert_eq!(AC_ORGTAX_TOTAL_REPOS, 205);
+    }
+
+    #[test]
+    fn provenance_categories_15() {
+        assert_eq!(AC_ORGTAX_CATEGORIES, 15);
+        assert_eq!(AC_ORGTAX_CATEGORY_NAMES.len(), 15);
+        assert_eq!(AC_ORGTAX_CATEGORY_COUNTS.len(), 15);
+    }
+
+    #[test]
+    fn provenance_canonical_counts_sum_to_total() {
+        let sum: u32 = AC_ORGTAX_CATEGORY_COUNTS.iter().map(|(_, n)| n).sum();
+        assert_eq!(sum, AC_ORGTAX_TOTAL_REPOS, "contract category counts must sum to {}", AC_ORGTAX_TOTAL_REPOS);
+    }
+
+    #[test]
+    fn provenance_archive_deadline_7() {
+        assert_eq!(AC_ORGTAX_ARCHIVE_DEADLINE_DAYS, 7);
+    }
+
+    #[test]
+    fn provenance_legacy_names() {
+        assert_eq!(AC_ORGTAX_LEGACY_NAMES.len(), 4);
+        for n in AC_ORGTAX_LEGACY_NAMES {
+            assert!(["trueno", "realizar", "entrenar", "batuta"].contains(&n));
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 2: ORGTAX-001 orphan classification.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn ot001_pass_all_classified() {
+        let live = ["aprender", "ruchy", "pmat"];
+        let classified = ["aprender", "ruchy", "pmat", "older-archive"];
+        assert_eq!(
+            verdict_from_orphan_classification(&live, &classified),
+            OrphanClassificationVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn ot001_fail_orphan_repo() {
+        let live = ["aprender", "new-repo", "pmat"];
+        let classified = ["aprender", "pmat"];
+        assert_eq!(
+            verdict_from_orphan_classification(&live, &classified),
+            OrphanClassificationVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn ot001_pass_empty_live() {
+        // No live repos ⇒ vacuously classified.
+        let classified = ["aprender"];
+        assert_eq!(
+            verdict_from_orphan_classification(&[], &classified),
+            OrphanClassificationVerdict::Pass
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 3: ORGTAX-002 SHOULD-MERGE archive deadline.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn ot002_pass_archived() {
+        assert_eq!(verdict_from_should_merge_archive(true, 0), ShouldMergeArchiveVerdict::Pass);
+    }
+
+    #[test]
+    fn ot002_pass_archived_late() {
+        assert_eq!(verdict_from_should_merge_archive(true, 100), ShouldMergeArchiveVerdict::Pass);
+    }
+
+    #[test]
+    fn ot002_pass_within_deadline() {
+        assert_eq!(verdict_from_should_merge_archive(false, 7), ShouldMergeArchiveVerdict::Pass);
+    }
+
+    #[test]
+    fn ot002_fail_past_deadline() {
+        assert_eq!(verdict_from_should_merge_archive(false, 8), ShouldMergeArchiveVerdict::Fail);
+    }
+
+    #[test]
+    fn ot002_fail_long_overdue() {
+        assert_eq!(verdict_from_should_merge_archive(false, 30), ShouldMergeArchiveVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 4: ORGTAX-003 STALE archive deadline.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn ot003_pass_archived() {
+        assert_eq!(verdict_from_stale_archive(true, 0), StaleArchiveVerdict::Pass);
+    }
+
+    #[test]
+    fn ot003_pass_within_deadline() {
+        assert_eq!(verdict_from_stale_archive(false, 7), StaleArchiveVerdict::Pass);
+    }
+
+    #[test]
+    fn ot003_fail_past_deadline() {
+        assert_eq!(verdict_from_stale_archive(false, 14), StaleArchiveVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 5: ORGTAX-004 legacy redirect.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn ot004_pass_no_legacy_name() {
+        assert_eq!(verdict_from_legacy_redirect("ML framework"), LegacyRedirectVerdict::Pass);
+    }
+
+    #[test]
+    fn ot004_pass_legacy_with_moved() {
+        let d = "trueno (MOVED to aprender — see paiml/aprender)";
+        assert_eq!(verdict_from_legacy_redirect(d), LegacyRedirectVerdict::Pass);
+    }
+
+    #[test]
+    fn ot004_pass_moved_lowercase() {
+        let d = "realizar — moved to aprender";
+        assert_eq!(verdict_from_legacy_redirect(d), LegacyRedirectVerdict::Pass);
+    }
+
+    #[test]
+    fn ot004_fail_legacy_no_redirect() {
+        let d = "Trueno SIMD primitives library";
+        assert_eq!(verdict_from_legacy_redirect(d), LegacyRedirectVerdict::Fail);
+    }
+
+    #[test]
+    fn ot004_fail_each_legacy_name() {
+        for name in AC_ORGTAX_LEGACY_NAMES {
+            let d = format!("Active {name} development.");
+            assert_eq!(
+                verdict_from_legacy_redirect(&d),
+                LegacyRedirectVerdict::Fail,
+                "legacy name {name} without MOVED must Fail"
+            );
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 6: ORGTAX-005 category sum.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn ot005_pass_canonical_counts() {
+        assert_eq!(
+            verdict_from_category_sum(&AC_ORGTAX_CATEGORY_COUNTS, AC_ORGTAX_TOTAL_REPOS),
+            CategorySumVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn ot005_pass_minimal() {
+        let counts = [("a", 5), ("b", 3)];
+        assert_eq!(verdict_from_category_sum(&counts, 8), CategorySumVerdict::Pass);
+    }
+
+    #[test]
+    fn ot005_fail_undercount() {
+        let counts = [("a", 1), ("b", 1)];
+        assert_eq!(verdict_from_category_sum(&counts, 5), CategorySumVerdict::Fail);
+    }
+
+    #[test]
+    fn ot005_fail_overcount() {
+        let counts = [("a", 100)];
+        assert_eq!(verdict_from_category_sum(&counts, 50), CategorySumVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 7: Realistic — full org snapshot passes all 5.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn realistic_healthy_org_passes_all_5() {
+        // 001: every live repo is classified.
+        let live = ["aprender", "ruchy", "pmat"];
+        let classified = ["aprender", "ruchy", "pmat", "old-archive"];
+        assert_eq!(
+            verdict_from_orphan_classification(&live, &classified),
+            OrphanClassificationVerdict::Pass
+        );
+        // 002: SHOULD-MERGE archived 1 day after classification → Pass.
+        assert_eq!(verdict_from_should_merge_archive(true, 1), ShouldMergeArchiveVerdict::Pass);
+        // 003: STALE archived → Pass.
+        assert_eq!(verdict_from_stale_archive(true, 0), StaleArchiveVerdict::Pass);
+        // 004: legacy mention with MOVED → Pass.
+        assert_eq!(
+            verdict_from_legacy_redirect("trueno (MOVED to aprender)"),
+            LegacyRedirectVerdict::Pass
+        );
+        // 005: contract category counts sum to 205.
+        assert_eq!(
+            verdict_from_category_sum(&AC_ORGTAX_CATEGORY_COUNTS, AC_ORGTAX_TOTAL_REPOS),
+            CategorySumVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn realistic_pre_fix_all_5_failures() {
+        // 001: orphan repo not classified.
+        let live = ["new-orphan"];
+        let classified: [&str; 0] = [];
+        assert_eq!(
+            verdict_from_orphan_classification(&live, &classified),
+            OrphanClassificationVerdict::Fail
+        );
+        // 002: 30 days past deadline, still not archived.
+        assert_eq!(verdict_from_should_merge_archive(false, 30), ShouldMergeArchiveVerdict::Fail);
+        // 003: stale not archived past deadline.
+        assert_eq!(verdict_from_stale_archive(false, 30), StaleArchiveVerdict::Fail);
+        // 004: legacy name without MOVED.
+        assert_eq!(
+            verdict_from_legacy_redirect("entrenar — training framework"),
+            LegacyRedirectVerdict::Fail
+        );
+        // 005: counts don't add up.
+        let bad_counts = [("a", 100)];
+        assert_eq!(verdict_from_category_sum(&bad_counts, 205), CategorySumVerdict::Fail);
+    }
+}

--- a/crates/aprender-core/src/format/pca_001_004.rs
+++ b/crates/aprender-core/src/format/pca_001_004.rs
@@ -1,0 +1,501 @@
+// SHIP-TWO-001 — `pca-v1` algorithm-level PARTIAL discharge
+// for FALSIFY-PCA-001..004.
+//
+// Contract: `contracts/pca-v1.yaml`.
+// Spec: `docs/specifications/aprender-train/ship-two-models-spec.md`.
+//
+// ## What this file proves NOW (PARTIAL_ALGORITHM_LEVEL)
+//
+// Four PCA gates from Jolliffe (2002) / Bishop (2006) §12.1:
+//
+// - PCA-001 (dimensionality reduction): output shape == (n, k).
+// - PCA-002 (explained variance bounded): each ratio ∈ [0, 1] AND
+//   sum ≈ 1.
+// - PCA-003 (variance ordering): explained_variance_ratio non-increasing.
+// - PCA-004 (deterministic transform): transform(X) ≡ transform(X).
+//
+// All four are pure properties of (Z, eigenvalues, ratios). No
+// SVD/eigendecomposition wired here.
+
+/// Tolerance for Σ explained_variance_ratio == 1.
+pub const AC_PCA_002_RATIO_SUM_EPS: f32 = 1e-5;
+
+/// Lower bound for each ratio (inclusive).
+pub const AC_PCA_002_RATIO_MIN: f32 = 0.0;
+
+/// Upper bound for each ratio (inclusive).
+pub const AC_PCA_002_RATIO_MAX: f32 = 1.0;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PcaVerdict {
+    Pass,
+    Fail,
+}
+
+// -----------------------------------------------------------------------------
+// Verdict 1: PCA-001 — dimensionality reduction.
+// -----------------------------------------------------------------------------
+
+/// Pass iff `transformed_shape == (n_samples, n_components)`.
+#[must_use]
+pub fn verdict_from_dimensionality(
+    transformed_rows: usize,
+    transformed_cols: usize,
+    expected_n_samples: usize,
+    expected_n_components: usize,
+) -> PcaVerdict {
+    if expected_n_samples == 0 || expected_n_components == 0 {
+        return PcaVerdict::Fail;
+    }
+    if transformed_rows == expected_n_samples && transformed_cols == expected_n_components {
+        PcaVerdict::Pass
+    } else {
+        PcaVerdict::Fail
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Verdict 2: PCA-002 — explained variance bounded.
+// -----------------------------------------------------------------------------
+
+/// Pass iff:
+///   1. every ratio ∈ [0, 1],
+///   2. sum ≈ 1 within `AC_PCA_002_RATIO_SUM_EPS`,
+///   3. all entries finite.
+#[must_use]
+pub fn verdict_from_explained_variance_bounded(ratios: &[f32]) -> PcaVerdict {
+    if ratios.is_empty() {
+        return PcaVerdict::Fail;
+    }
+    let mut sum = 0.0_f32;
+    for &r in ratios {
+        if !r.is_finite() {
+            return PcaVerdict::Fail;
+        }
+        if r < AC_PCA_002_RATIO_MIN || r > AC_PCA_002_RATIO_MAX {
+            return PcaVerdict::Fail;
+        }
+        sum += r;
+    }
+    if (sum - 1.0).abs() < AC_PCA_002_RATIO_SUM_EPS {
+        PcaVerdict::Pass
+    } else {
+        PcaVerdict::Fail
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Verdict 3: PCA-003 — variance ordering (non-increasing).
+// -----------------------------------------------------------------------------
+
+#[must_use]
+pub fn verdict_from_variance_ordering(ratios: &[f32]) -> PcaVerdict {
+    if ratios.is_empty() {
+        return PcaVerdict::Fail;
+    }
+    for w in ratios.windows(2) {
+        if !w[0].is_finite() || !w[1].is_finite() {
+            return PcaVerdict::Fail;
+        }
+        // Allow tiny numerical wobble (≤ eps).
+        if w[1] > w[0] + AC_PCA_002_RATIO_SUM_EPS {
+            return PcaVerdict::Fail;
+        }
+    }
+    PcaVerdict::Pass
+}
+
+// -----------------------------------------------------------------------------
+// Verdict 4: PCA-004 — deterministic transform.
+// -----------------------------------------------------------------------------
+
+#[must_use]
+pub fn verdict_from_deterministic_transform(z1: &[f32], z2: &[f32]) -> PcaVerdict {
+    if z1.len() != z2.len() {
+        return PcaVerdict::Fail;
+    }
+    if z1.is_empty() {
+        return PcaVerdict::Fail;
+    }
+    for (a, b) in z1.iter().zip(z2.iter()) {
+        if !a.is_finite() || !b.is_finite() {
+            return PcaVerdict::Fail;
+        }
+        if a.to_bits() != b.to_bits() {
+            return PcaVerdict::Fail;
+        }
+    }
+    PcaVerdict::Pass
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -------------------------------------------------------------------------
+    // Section 1: Provenance pins.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn provenance_ratio_sum_eps_1e_5() {
+        assert_eq!(AC_PCA_002_RATIO_SUM_EPS, 1e-5);
+    }
+
+    #[test]
+    fn provenance_ratio_bounds_0_1() {
+        assert_eq!(AC_PCA_002_RATIO_MIN, 0.0);
+        assert_eq!(AC_PCA_002_RATIO_MAX, 1.0);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 2: PCA-001 Pass band.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn pca001_pass_typical_reduction() {
+        // n=100 samples, d=10 features → reduce to k=3.
+        assert_eq!(
+            verdict_from_dimensionality(100, 3, 100, 3),
+            PcaVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn pca001_pass_full_rank() {
+        // k = d ⇒ no actual reduction, but shape still (n, k).
+        assert_eq!(
+            verdict_from_dimensionality(50, 10, 50, 10),
+            PcaVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn pca001_pass_single_component() {
+        assert_eq!(
+            verdict_from_dimensionality(100, 1, 100, 1),
+            PcaVerdict::Pass
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 3: PCA-001 Fail band.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn pca001_fail_wrong_n_samples() {
+        // Output truncated rows.
+        assert_eq!(
+            verdict_from_dimensionality(99, 3, 100, 3),
+            PcaVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn pca001_fail_wrong_n_components() {
+        // Output kept too many components.
+        assert_eq!(
+            verdict_from_dimensionality(100, 5, 100, 3),
+            PcaVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn pca001_fail_zero_samples() {
+        assert_eq!(verdict_from_dimensionality(0, 3, 0, 3), PcaVerdict::Fail);
+    }
+
+    #[test]
+    fn pca001_fail_zero_components() {
+        assert_eq!(verdict_from_dimensionality(100, 0, 100, 0), PcaVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 4: PCA-002 — explained variance bounded.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn pca002_pass_skewed_distribution() {
+        // 80%, 15%, 5%.
+        let ratios = vec![0.80_f32, 0.15, 0.05];
+        assert_eq!(
+            verdict_from_explained_variance_bounded(&ratios),
+            PcaVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn pca002_pass_uniform() {
+        let ratios = vec![0.25_f32; 4];
+        assert_eq!(
+            verdict_from_explained_variance_bounded(&ratios),
+            PcaVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn pca002_pass_single_dominant_component() {
+        let ratios = vec![1.0_f32, 0.0, 0.0];
+        assert_eq!(
+            verdict_from_explained_variance_bounded(&ratios),
+            PcaVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn pca002_fail_negative_ratio() {
+        let ratios = vec![0.5_f32, -0.1, 0.6];
+        assert_eq!(
+            verdict_from_explained_variance_bounded(&ratios),
+            PcaVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn pca002_fail_ratio_above_one() {
+        let ratios = vec![1.5_f32, -0.5];
+        assert_eq!(
+            verdict_from_explained_variance_bounded(&ratios),
+            PcaVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn pca002_fail_sum_below_one() {
+        let ratios = vec![0.3_f32, 0.3, 0.3]; // sum 0.9
+        assert_eq!(
+            verdict_from_explained_variance_bounded(&ratios),
+            PcaVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn pca002_fail_sum_above_one() {
+        let ratios = vec![0.5_f32, 0.5, 0.5]; // sum 1.5
+        assert_eq!(
+            verdict_from_explained_variance_bounded(&ratios),
+            PcaVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn pca002_fail_empty() {
+        let ratios: Vec<f32> = vec![];
+        assert_eq!(
+            verdict_from_explained_variance_bounded(&ratios),
+            PcaVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn pca002_fail_nan() {
+        let ratios = vec![0.5_f32, f32::NAN];
+        assert_eq!(
+            verdict_from_explained_variance_bounded(&ratios),
+            PcaVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 5: PCA-003 — variance ordering.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn pca003_pass_strictly_decreasing() {
+        let ratios = vec![0.5_f32, 0.3, 0.15, 0.05];
+        assert_eq!(verdict_from_variance_ordering(&ratios), PcaVerdict::Pass);
+    }
+
+    #[test]
+    fn pca003_pass_non_increasing_with_ties() {
+        let ratios = vec![0.4_f32, 0.4, 0.2];
+        assert_eq!(verdict_from_variance_ordering(&ratios), PcaVerdict::Pass);
+    }
+
+    #[test]
+    fn pca003_pass_single_value() {
+        let ratios = vec![1.0_f32];
+        assert_eq!(verdict_from_variance_ordering(&ratios), PcaVerdict::Pass);
+    }
+
+    #[test]
+    fn pca003_fail_ascending() {
+        // Bug: eigenvalues sorted ascending instead of descending.
+        let ratios = vec![0.05_f32, 0.15, 0.30, 0.50];
+        assert_eq!(verdict_from_variance_ordering(&ratios), PcaVerdict::Fail);
+    }
+
+    #[test]
+    fn pca003_fail_one_jump() {
+        let ratios = vec![0.5_f32, 0.3, 0.4, 0.1]; // 0.3 → 0.4 ascent
+        assert_eq!(verdict_from_variance_ordering(&ratios), PcaVerdict::Fail);
+    }
+
+    #[test]
+    fn pca003_fail_empty() {
+        let ratios: Vec<f32> = vec![];
+        assert_eq!(verdict_from_variance_ordering(&ratios), PcaVerdict::Fail);
+    }
+
+    #[test]
+    fn pca003_fail_nan() {
+        let ratios = vec![0.5_f32, f32::NAN, 0.1];
+        assert_eq!(verdict_from_variance_ordering(&ratios), PcaVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 6: PCA-004 — determinism.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn pca004_pass_byte_identical() {
+        let z1 = vec![1.0_f32, 2.5, -0.3, 4.7];
+        let z2 = z1.clone();
+        assert_eq!(
+            verdict_from_deterministic_transform(&z1, &z2),
+            PcaVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn pca004_pass_signed_zero_preserved() {
+        // ±0 differ in bits — the contract specifies determinism.
+        let z1 = vec![0.0_f32, -0.0];
+        let z2 = vec![0.0_f32, -0.0];
+        assert_eq!(
+            verdict_from_deterministic_transform(&z1, &z2),
+            PcaVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn pca004_fail_one_bit_drift() {
+        let z1 = vec![1.0_f32, 2.0];
+        let z2 = vec![1.0_f32, 2.000001]; // drift
+        assert_eq!(
+            verdict_from_deterministic_transform(&z1, &z2),
+            PcaVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn pca004_fail_signed_zero_flip() {
+        // +0 vs -0 differ in bits.
+        let z1 = vec![0.0_f32];
+        let z2 = vec![-0.0_f32];
+        assert_eq!(
+            verdict_from_deterministic_transform(&z1, &z2),
+            PcaVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn pca004_fail_length_mismatch() {
+        let z1 = vec![1.0_f32, 2.0];
+        let z2 = vec![1.0_f32];
+        assert_eq!(
+            verdict_from_deterministic_transform(&z1, &z2),
+            PcaVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn pca004_fail_empty() {
+        let v: Vec<f32> = vec![];
+        assert_eq!(
+            verdict_from_deterministic_transform(&v, &v),
+            PcaVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn pca004_fail_nan() {
+        let z1 = vec![f32::NAN];
+        let z2 = vec![f32::NAN];
+        // NaN bits-equal but not deterministic guarantees finiteness too.
+        assert_eq!(
+            verdict_from_deterministic_transform(&z1, &z2),
+            PcaVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 7: Sweep — n_components valid range.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn sweep_dimensionality_pass_band() {
+        for k in 1..=10 {
+            assert_eq!(
+                verdict_from_dimensionality(50, k, 50, k),
+                PcaVerdict::Pass,
+                "k={k}"
+            );
+        }
+    }
+
+    #[test]
+    fn sweep_dimensionality_fail_band() {
+        // Off-by-one mismatches.
+        let test_cases = [(50_usize, 3, 50, 4), (49, 3, 50, 3), (51, 3, 50, 3)];
+        for (rows, cols, exp_n, exp_k) in test_cases {
+            assert_eq!(
+                verdict_from_dimensionality(rows, cols, exp_n, exp_k),
+                PcaVerdict::Fail,
+                "({rows}, {cols}) vs ({exp_n}, {exp_k})"
+            );
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 8: Realistic — contract regression scenarios.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn realistic_eigenvalue_normalization_bug_caught() {
+        // PCA-002 if_fails: "Eigenvalue normalization error".
+        // Simulate: ratios sum to 1.5 (not normalized).
+        let ratios = vec![0.6_f32, 0.5, 0.4]; // sum 1.5
+        assert_eq!(
+            verdict_from_explained_variance_bounded(&ratios),
+            PcaVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn realistic_eigenvalues_sorted_ascending_caught() {
+        // PCA-003 if_fails: "Eigenvalues not sorted descending".
+        // The contract failure example: smallest eigenvalue first.
+        let ratios = vec![0.05_f32, 0.15, 0.30, 0.50];
+        assert_eq!(verdict_from_variance_ordering(&ratios), PcaVerdict::Fail);
+    }
+
+    #[test]
+    fn realistic_non_deterministic_random_state_caught() {
+        // PCA-004 if_fails: "Non-deterministic random state".
+        let z1 = vec![1.5_f32, 2.5, 3.5];
+        let z2 = vec![1.5_f32, 2.5, 3.50001]; // tiny drift = nondeterministic
+        assert_eq!(
+            verdict_from_deterministic_transform(&z1, &z2),
+            PcaVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn realistic_full_pca_pipeline() {
+        // Synthesize a typical PCA result on n=100, d=5, k=3.
+        let n_samples = 100;
+        let n_components = 3;
+        let z = vec![1.0_f32; n_samples * n_components];
+        let ratios = vec![0.6_f32, 0.3, 0.1]; // sums to 1
+        // PCA-001:
+        assert_eq!(
+            verdict_from_dimensionality(n_samples, n_components, n_samples, n_components),
+            PcaVerdict::Pass
+        );
+        // PCA-002:
+        assert_eq!(
+            verdict_from_explained_variance_bounded(&ratios),
+            PcaVerdict::Pass
+        );
+        // PCA-003:
+        assert_eq!(verdict_from_variance_ordering(&ratios), PcaVerdict::Pass);
+        // PCA-004:
+        let z2 = z.clone();
+        assert_eq!(
+            verdict_from_deterministic_transform(&z, &z2),
+            PcaVerdict::Pass
+        );
+    }
+}

--- a/crates/aprender-core/src/format/qacov_001_005.rs
+++ b/crates/aprender-core/src/format/qacov_001_005.rs
@@ -1,0 +1,451 @@
+// `apr-qa-coverage-v1` algorithm-level PARTIAL discharge for the 5
+// coverage-completeness falsifiers (category coverage, untested-surface
+// tracking, complexity gate, SATD zero, dogfood exercise map).
+//
+// Contract: `contracts/apr-qa-coverage-v1.yaml`.
+//
+// ## Disambiguation
+//
+// `apr-cli-coverage-v1.yaml` (task #235, COV-001) is a different
+// contract — it pins ONE coverage gate (overall apr-cli line coverage
+// ≥ 95%). This contract — apr-qa-coverage-v1 — adds 5 finer-grained
+// gates on per-category, per-function, and per-module coverage.
+// Module suffix `qacov_` disambiguates from the existing `cov_` family.
+
+/// Minimum per-category command coverage (80% per F-COV-001).
+pub const AC_QACOV_MIN_CATEGORY_COVERAGE: f64 = 0.80;
+
+/// Inference category coverage requirement (100% — critical path).
+pub const AC_QACOV_INFERENCE_COVERAGE: f64 = 1.00;
+
+/// Transform category coverage requirement (90% — data integrity).
+pub const AC_QACOV_TRANSFORM_COVERAGE: f64 = 0.90;
+
+/// Impact-score threshold above which an untested function MUST have a
+/// tracking issue (F-COV-002).
+pub const AC_QACOV_HIGH_IMPACT_THRESHOLD: f64 = 0.80;
+
+/// Cyclomatic complexity threshold per F-COV-003.
+pub const AC_QACOV_MAX_CC: u32 = 15;
+
+/// CC threshold above which a dedicated test is required even if < 15.
+pub const AC_QACOV_CC_REQUIRES_TEST: u32 = 10;
+
+/// Maximum allowed High-severity SATD items.
+pub const AC_QACOV_MAX_HIGH_SATD: u32 = 0;
+
+/// Critical modules per F-COV-005.
+pub const AC_QACOV_CRITICAL_MODULES: [&str; 6] = ["hex", "profile", "cbtop", "train", "chat", "serve"];
+
+// =============================================================================
+// F-COV-001 — command category coverage
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CategoryCoverageVerdict {
+    /// Every category meets its threshold (general 80%, inference 100%,
+    /// transform 90%).
+    Pass,
+    /// At least one category below threshold.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_category_coverage(category_coverage: &[(&str, f64)]) -> CategoryCoverageVerdict {
+    for (category, ratio) in category_coverage {
+        let threshold = match *category {
+            "inference" => AC_QACOV_INFERENCE_COVERAGE,
+            "transform" => AC_QACOV_TRANSFORM_COVERAGE,
+            _ => AC_QACOV_MIN_CATEGORY_COVERAGE,
+        };
+        if *ratio + 1e-9 < threshold {
+            return CategoryCoverageVerdict::Fail;
+        }
+    }
+    CategoryCoverageVerdict::Pass
+}
+
+// =============================================================================
+// F-COV-002 — untested surface tracking
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UntestedSurfaceVerdict {
+    /// No untested function has impact_score > 0.8 without a tracking issue.
+    Pass,
+    /// At least one high-impact untested function has no issue.
+    Fail,
+}
+
+/// `(impact_score, has_tracking_issue)` per untested function.
+#[must_use]
+pub fn verdict_from_untested_surface(uncovered: &[(f64, bool)]) -> UntestedSurfaceVerdict {
+    for (score, has_issue) in uncovered {
+        if *score > AC_QACOV_HIGH_IMPACT_THRESHOLD && !*has_issue {
+            return UntestedSurfaceVerdict::Fail;
+        }
+    }
+    UntestedSurfaceVerdict::Pass
+}
+
+// =============================================================================
+// F-COV-003 — complexity gate
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ComplexityGateVerdict {
+    /// All functions: CC ≤ 15 AND (CC ≤ 10 OR has dedicated test).
+    Pass,
+    /// CC > 15 without tracking, OR CC > 10 without dedicated test.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_complexity_gate(
+    function_metrics: &[(u32, bool, bool)],
+) -> ComplexityGateVerdict {
+    // (cc, has_dedicated_test, has_refactoring_issue)
+    for (cc, has_test, has_issue) in function_metrics {
+        if *cc > AC_QACOV_MAX_CC && !*has_issue {
+            return ComplexityGateVerdict::Fail;
+        }
+        if *cc > AC_QACOV_CC_REQUIRES_TEST && !*has_test {
+            return ComplexityGateVerdict::Fail;
+        }
+    }
+    ComplexityGateVerdict::Pass
+}
+
+// =============================================================================
+// F-COV-004 — SATD zero
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SatdZeroVerdict {
+    /// Zero High-severity SATD items.
+    Pass,
+    /// At least one High-severity SATD item.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_satd_zero(high_severity_count: u32) -> SatdZeroVerdict {
+    if high_severity_count == AC_QACOV_MAX_HIGH_SATD {
+        SatdZeroVerdict::Pass
+    } else {
+        SatdZeroVerdict::Fail
+    }
+}
+
+// =============================================================================
+// F-COV-005 — dogfood exercise map
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DogfoodMapVerdict {
+    /// All 6 critical modules exercised AND none panicked.
+    Pass,
+    /// At least one critical module skipped or panicked.
+    Fail,
+}
+
+/// `(module_name, was_exercised, panicked)` per module under test.
+#[must_use]
+pub fn verdict_from_dogfood_map(module_results: &[(&str, bool, bool)]) -> DogfoodMapVerdict {
+    use std::collections::HashSet;
+    let mut exercised: HashSet<&&str> = HashSet::new();
+    for (name, was_exercised, panicked) in module_results {
+        if *was_exercised {
+            if *panicked {
+                return DogfoodMapVerdict::Fail;
+            }
+            exercised.insert(name);
+        }
+    }
+    for required in AC_QACOV_CRITICAL_MODULES {
+        if !exercised.contains(&required) {
+            return DogfoodMapVerdict::Fail;
+        }
+    }
+    DogfoodMapVerdict::Pass
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -------------------------------------------------------------------------
+    // Section 1: Provenance pins.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn provenance_min_category_coverage_080() {
+        assert!((AC_QACOV_MIN_CATEGORY_COVERAGE - 0.80).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn provenance_inference_coverage_100() {
+        assert!((AC_QACOV_INFERENCE_COVERAGE - 1.00).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn provenance_transform_coverage_090() {
+        assert!((AC_QACOV_TRANSFORM_COVERAGE - 0.90).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn provenance_max_cc_15() {
+        assert_eq!(AC_QACOV_MAX_CC, 15);
+    }
+
+    #[test]
+    fn provenance_max_high_satd_0() {
+        assert_eq!(AC_QACOV_MAX_HIGH_SATD, 0);
+    }
+
+    #[test]
+    fn provenance_critical_modules_count_6() {
+        assert_eq!(AC_QACOV_CRITICAL_MODULES.len(), 6);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 2: F-COV-001 category coverage.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fc001_pass_all_above_threshold() {
+        let cov = [
+            ("inspection", 0.91),
+            ("inference", 1.00),
+            ("transform", 1.00),
+            ("training", 0.85),
+        ];
+        assert_eq!(verdict_from_category_coverage(&cov), CategoryCoverageVerdict::Pass);
+    }
+
+    #[test]
+    fn fc001_pass_inference_at_100() {
+        let cov = [("inference", 1.00)];
+        assert_eq!(verdict_from_category_coverage(&cov), CategoryCoverageVerdict::Pass);
+    }
+
+    #[test]
+    fn fc001_fail_inference_below_100() {
+        // Inference is critical-path: 99% fails.
+        let cov = [("inference", 0.99)];
+        assert_eq!(verdict_from_category_coverage(&cov), CategoryCoverageVerdict::Fail);
+    }
+
+    #[test]
+    fn fc001_fail_transform_below_90() {
+        let cov = [("transform", 0.89)];
+        assert_eq!(verdict_from_category_coverage(&cov), CategoryCoverageVerdict::Fail);
+    }
+
+    #[test]
+    fn fc001_fail_general_below_80() {
+        let cov = [("misc", 0.79)];
+        assert_eq!(verdict_from_category_coverage(&cov), CategoryCoverageVerdict::Fail);
+    }
+
+    #[test]
+    fn fc001_pass_general_at_exactly_80() {
+        let cov = [("misc", 0.80)];
+        assert_eq!(verdict_from_category_coverage(&cov), CategoryCoverageVerdict::Pass);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 3: F-COV-002 untested surface.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fc002_pass_no_high_impact_uncovered() {
+        let uncovered = [(0.5, false), (0.7, false), (0.79, false)];
+        assert_eq!(verdict_from_untested_surface(&uncovered), UntestedSurfaceVerdict::Pass);
+    }
+
+    #[test]
+    fn fc002_pass_high_impact_with_issue() {
+        let uncovered = [(0.95, true)];
+        assert_eq!(verdict_from_untested_surface(&uncovered), UntestedSurfaceVerdict::Pass);
+    }
+
+    #[test]
+    fn fc002_fail_high_impact_no_issue() {
+        let uncovered = [(0.85, false)];
+        assert_eq!(verdict_from_untested_surface(&uncovered), UntestedSurfaceVerdict::Fail);
+    }
+
+    #[test]
+    fn fc002_pass_at_threshold() {
+        // > 0.8 — exactly 0.8 passes (strict greater-than).
+        let uncovered = [(0.80, false)];
+        assert_eq!(verdict_from_untested_surface(&uncovered), UntestedSurfaceVerdict::Pass);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 4: F-COV-003 complexity gate.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fc003_pass_low_complexity() {
+        let metrics = [(8, false, false), (5, false, false)];
+        assert_eq!(verdict_from_complexity_gate(&metrics), ComplexityGateVerdict::Pass);
+    }
+
+    #[test]
+    fn fc003_pass_cc_11_with_dedicated_test() {
+        let metrics = [(11, true, false)];
+        assert_eq!(verdict_from_complexity_gate(&metrics), ComplexityGateVerdict::Pass);
+    }
+
+    #[test]
+    fn fc003_fail_cc_11_no_test() {
+        let metrics = [(11, false, false)];
+        assert_eq!(verdict_from_complexity_gate(&metrics), ComplexityGateVerdict::Fail);
+    }
+
+    #[test]
+    fn fc003_fail_cc_16_no_issue() {
+        let metrics = [(16, true, false)];
+        assert_eq!(verdict_from_complexity_gate(&metrics), ComplexityGateVerdict::Fail);
+    }
+
+    #[test]
+    fn fc003_pass_cc_16_with_issue_and_test() {
+        // CC > 15 needs refactoring issue; CC > 10 needs test.
+        let metrics = [(16, true, true)];
+        assert_eq!(verdict_from_complexity_gate(&metrics), ComplexityGateVerdict::Pass);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 5: F-COV-004 SATD zero.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fc004_pass_zero_high() {
+        assert_eq!(verdict_from_satd_zero(0), SatdZeroVerdict::Pass);
+    }
+
+    #[test]
+    fn fc004_fail_one_high() {
+        assert_eq!(verdict_from_satd_zero(1), SatdZeroVerdict::Fail);
+    }
+
+    #[test]
+    fn fc004_fail_many_high() {
+        assert_eq!(verdict_from_satd_zero(50), SatdZeroVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 6: F-COV-005 dogfood exercise map.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fc005_pass_all_6_exercised() {
+        let results = [
+            ("hex", true, false),
+            ("profile", true, false),
+            ("cbtop", true, false),
+            ("train", true, false),
+            ("chat", true, false),
+            ("serve", true, false),
+        ];
+        assert_eq!(verdict_from_dogfood_map(&results), DogfoodMapVerdict::Pass);
+    }
+
+    #[test]
+    fn fc005_fail_one_module_panicked() {
+        let results = [
+            ("hex", true, true), // panic!
+            ("profile", true, false),
+            ("cbtop", true, false),
+            ("train", true, false),
+            ("chat", true, false),
+            ("serve", true, false),
+        ];
+        assert_eq!(verdict_from_dogfood_map(&results), DogfoodMapVerdict::Fail);
+    }
+
+    #[test]
+    fn fc005_fail_one_module_skipped() {
+        let results = [
+            ("hex", true, false),
+            ("profile", true, false),
+            ("cbtop", true, false),
+            ("train", true, false),
+            ("chat", true, false),
+            // serve missing
+        ];
+        assert_eq!(verdict_from_dogfood_map(&results), DogfoodMapVerdict::Fail);
+    }
+
+    #[test]
+    fn fc005_fail_empty() {
+        let results: [(&str, bool, bool); 0] = [];
+        assert_eq!(verdict_from_dogfood_map(&results), DogfoodMapVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 7: Realistic + family.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn realistic_healthy_dogfood_passes_all_5() {
+        let cov = [
+            ("inspection", 0.91),
+            ("inference", 1.00),
+            ("transform", 0.95),
+            ("training", 0.82),
+            ("registry", 0.85),
+            ("hardware", 0.80),
+            ("qa", 0.83),
+            ("ui", 0.84),
+            ("pipeline", 0.81),
+            ("misc", 0.86),
+        ];
+        assert_eq!(verdict_from_category_coverage(&cov), CategoryCoverageVerdict::Pass);
+
+        let uncovered = [(0.5, false), (0.85, true)];
+        assert_eq!(verdict_from_untested_surface(&uncovered), UntestedSurfaceVerdict::Pass);
+
+        let metrics = [(8, false, false), (12, true, false), (16, true, true)];
+        assert_eq!(verdict_from_complexity_gate(&metrics), ComplexityGateVerdict::Pass);
+
+        assert_eq!(verdict_from_satd_zero(0), SatdZeroVerdict::Pass);
+
+        let results = [
+            ("hex", true, false),
+            ("profile", true, false),
+            ("cbtop", true, false),
+            ("train", true, false),
+            ("chat", true, false),
+            ("serve", true, false),
+        ];
+        assert_eq!(verdict_from_dogfood_map(&results), DogfoodMapVerdict::Pass);
+    }
+
+    #[test]
+    fn realistic_pre_fix_all_5_failures() {
+        // 001: inference < 100%.
+        assert_eq!(
+            verdict_from_category_coverage(&[("inference", 0.95)]),
+            CategoryCoverageVerdict::Fail
+        );
+        // 002: high-impact uncovered without issue.
+        assert_eq!(
+            verdict_from_untested_surface(&[(0.92, false)]),
+            UntestedSurfaceVerdict::Fail
+        );
+        // 003: CC=20 untested.
+        assert_eq!(
+            verdict_from_complexity_gate(&[(20, false, false)]),
+            ComplexityGateVerdict::Fail
+        );
+        // 004: SATD non-zero.
+        assert_eq!(verdict_from_satd_zero(3), SatdZeroVerdict::Fail);
+        // 005: hex module panicked.
+        let bad = [
+            ("hex", true, true),
+            ("profile", true, false),
+            ("cbtop", true, false),
+            ("train", true, false),
+            ("chat", true, false),
+            ("serve", true, false),
+        ];
+        assert_eq!(verdict_from_dogfood_map(&bad), DogfoodMapVerdict::Fail);
+    }
+}

--- a/crates/aprender-core/src/format/qadiff_001_005.rs
+++ b/crates/aprender-core/src/format/qadiff_001_005.rs
@@ -1,0 +1,400 @@
+// `apr-qa-differential-v1` algorithm-level PARTIAL discharge for the 5
+// differential-testing falsifiers (ollama parity, tokenizer roundtrip,
+// concurrent serve parity, perplexity budget, cross-format L2).
+//
+// Contract: `contracts/apr-qa-differential-v1.yaml`.
+// Refs: arXiv:2207.11976 (Differential Testing for ML), arXiv:2406.07944
+// (DLLens), llama.cpp perplexity tracking, ollama integration tests.
+
+/// F-DIFF-001 minimum top-1 token agreement rate against ollama.
+pub const AC_QADIFF_TOP1_AGREEMENT: f64 = 0.95;
+
+/// F-DIFF-001 maximum perplexity gap vs reference (5%).
+pub const AC_QADIFF_PPL_GAP: f64 = 0.05;
+
+/// F-DIFF-004 perplexity budget per quantization scheme.
+/// Ratio = PPL(quantized) / PPL(F16). Pass iff ratio < budget[Q].
+pub const AC_QADIFF_PPL_BUDGET_Q4_K: f64 = 1.10;
+pub const AC_QADIFF_PPL_BUDGET_Q5_K: f64 = 1.05;
+pub const AC_QADIFF_PPL_BUDGET_Q6_K: f64 = 1.02;
+pub const AC_QADIFF_PPL_BUDGET_Q8_0: f64 = 1.01;
+
+/// F-DIFF-005 cross-format tensor L2 tolerance (0.001 = 0.1%).
+pub const AC_QADIFF_L2_TOLERANCE: f64 = 0.001;
+
+// =============================================================================
+// F-DIFF-001 — ollama parity
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OllamaParityVerdict {
+    /// Top-1 agreement ≥ 95% AND perplexity gap < 5%.
+    Pass,
+    /// Either threshold violated.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_ollama_parity(top1_agreement_rate: f64, ppl_gap: f64) -> OllamaParityVerdict {
+    if top1_agreement_rate + 1e-9 < AC_QADIFF_TOP1_AGREEMENT {
+        return OllamaParityVerdict::Fail;
+    }
+    if ppl_gap >= AC_QADIFF_PPL_GAP {
+        return OllamaParityVerdict::Fail;
+    }
+    OllamaParityVerdict::Pass
+}
+
+// =============================================================================
+// F-DIFF-002 — tokenizer roundtrip
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TokenizerRoundtripVerdict {
+    /// `decode(encode(text)) == text` for the entire test corpus.
+    Pass,
+    /// Any text in the corpus failed roundtrip.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_tokenizer_roundtrip(test_corpus: &[(&str, &str)]) -> TokenizerRoundtripVerdict {
+    // Each pair is (original, after_decode_encode_decode).
+    for (original, decoded) in test_corpus {
+        if original != decoded {
+            return TokenizerRoundtripVerdict::Fail;
+        }
+    }
+    TokenizerRoundtripVerdict::Pass
+}
+
+// =============================================================================
+// F-DIFF-003 — concurrent serve parity
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConcurrentParityVerdict {
+    /// All N concurrent requests at temperature=0 returned identical output.
+    Pass,
+    /// At least 2 distinct outputs across requests.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_concurrent_parity(responses: &[&str]) -> ConcurrentParityVerdict {
+    if responses.is_empty() {
+        return ConcurrentParityVerdict::Fail;
+    }
+    let first = responses[0];
+    for r in responses.iter().skip(1) {
+        if *r != first {
+            return ConcurrentParityVerdict::Fail;
+        }
+    }
+    ConcurrentParityVerdict::Pass
+}
+
+// =============================================================================
+// F-DIFF-004 — perplexity budget per quantization
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PerplexityBudgetVerdict {
+    /// PPL(quantized) / PPL(F16) < budget[Q].
+    Pass,
+    /// Ratio at-or-above budget — quantization quality below threshold.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_perplexity_budget(quant: &str, ppl_ratio: f64) -> PerplexityBudgetVerdict {
+    let budget = match quant {
+        "Q4_K" | "q4_k" | "Q4_K_M" | "q4_k_m" => AC_QADIFF_PPL_BUDGET_Q4_K,
+        "Q5_K" | "q5_k" | "Q5_K_M" | "q5_k_m" => AC_QADIFF_PPL_BUDGET_Q5_K,
+        "Q6_K" | "q6_k" => AC_QADIFF_PPL_BUDGET_Q6_K,
+        "Q8_0" | "q8_0" => AC_QADIFF_PPL_BUDGET_Q8_0,
+        _ => return PerplexityBudgetVerdict::Fail,
+    };
+    if ppl_ratio < budget {
+        PerplexityBudgetVerdict::Pass
+    } else {
+        PerplexityBudgetVerdict::Fail
+    }
+}
+
+// =============================================================================
+// F-DIFF-005 — cross-format tensor L2 integrity
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CrossFormatL2Verdict {
+    /// max |L2_a - L2_b| / max(L2_a, L2_b) < 0.001 across pairwise format
+    /// comparisons for every tensor.
+    Pass,
+    /// Any tensor's relative L2 difference exceeded tolerance — format
+    /// conversion corrupted data.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_cross_format_l2(per_tensor_l2: &[(f64, f64, f64)]) -> CrossFormatL2Verdict {
+    // Each entry: (L2 in GGUF, L2 in APR, L2 in SafeTensors).
+    for (l2_gguf, l2_apr, l2_st) in per_tensor_l2 {
+        if !rel_diff(*l2_gguf, *l2_apr) {
+            return CrossFormatL2Verdict::Fail;
+        }
+        if !rel_diff(*l2_apr, *l2_st) {
+            return CrossFormatL2Verdict::Fail;
+        }
+        if !rel_diff(*l2_gguf, *l2_st) {
+            return CrossFormatL2Verdict::Fail;
+        }
+    }
+    CrossFormatL2Verdict::Pass
+}
+
+fn rel_diff(a: f64, b: f64) -> bool {
+    let denom = a.abs().max(b.abs()).max(1e-12);
+    let diff = (a - b).abs() / denom;
+    diff < AC_QADIFF_L2_TOLERANCE
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -------------------------------------------------------------------------
+    // Section 1: Provenance pins.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn provenance_top1_agreement_095() {
+        assert!((AC_QADIFF_TOP1_AGREEMENT - 0.95).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn provenance_ppl_gap_005() {
+        assert!((AC_QADIFF_PPL_GAP - 0.05).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn provenance_quant_budgets_strict_descending() {
+        // Tighter quants must have tighter budgets.
+        assert!(AC_QADIFF_PPL_BUDGET_Q4_K > AC_QADIFF_PPL_BUDGET_Q5_K);
+        assert!(AC_QADIFF_PPL_BUDGET_Q5_K > AC_QADIFF_PPL_BUDGET_Q6_K);
+        assert!(AC_QADIFF_PPL_BUDGET_Q6_K > AC_QADIFF_PPL_BUDGET_Q8_0);
+    }
+
+    #[test]
+    fn provenance_l2_tolerance_001() {
+        assert!((AC_QADIFF_L2_TOLERANCE - 0.001).abs() < f64::EPSILON);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 2: F-DIFF-001 ollama parity.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fd001_pass_high_agreement_low_ppl_gap() {
+        assert_eq!(verdict_from_ollama_parity(0.97, 0.03), OllamaParityVerdict::Pass);
+    }
+
+    #[test]
+    fn fd001_pass_at_thresholds() {
+        // Exactly 0.95 and just under 5% — pass.
+        assert_eq!(verdict_from_ollama_parity(0.95, 0.04999), OllamaParityVerdict::Pass);
+    }
+
+    #[test]
+    fn fd001_fail_low_agreement() {
+        assert_eq!(verdict_from_ollama_parity(0.94, 0.01), OllamaParityVerdict::Fail);
+    }
+
+    #[test]
+    fn fd001_fail_high_ppl_gap() {
+        assert_eq!(verdict_from_ollama_parity(0.99, 0.06), OllamaParityVerdict::Fail);
+    }
+
+    #[test]
+    fn fd001_fail_ppl_gap_at_threshold() {
+        // 5% exactly fails (strict less-than per `<` invariant).
+        assert_eq!(verdict_from_ollama_parity(0.99, 0.05), OllamaParityVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 3: F-DIFF-002 tokenizer roundtrip.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fd002_pass_identity_corpus() {
+        let c = [("hello", "hello"), ("world", "world")];
+        assert_eq!(verdict_from_tokenizer_roundtrip(&c), TokenizerRoundtripVerdict::Pass);
+    }
+
+    #[test]
+    fn fd002_pass_chatml_special_tokens() {
+        let c = [
+            ("<|im_start|>user\nHi<|im_end|>", "<|im_start|>user\nHi<|im_end|>"),
+        ];
+        assert_eq!(verdict_from_tokenizer_roundtrip(&c), TokenizerRoundtripVerdict::Pass);
+    }
+
+    #[test]
+    fn fd002_pass_empty_corpus_vacuous() {
+        assert_eq!(verdict_from_tokenizer_roundtrip(&[]), TokenizerRoundtripVerdict::Pass);
+    }
+
+    #[test]
+    fn fd002_fail_lossy_decode() {
+        let c = [("hello", "hello"), ("café", "caf?")];
+        assert_eq!(verdict_from_tokenizer_roundtrip(&c), TokenizerRoundtripVerdict::Fail);
+    }
+
+    #[test]
+    fn fd002_fail_special_token_dropped() {
+        let c = [("<|im_end|>", "")];
+        assert_eq!(verdict_from_tokenizer_roundtrip(&c), TokenizerRoundtripVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 4: F-DIFF-003 concurrent serve parity.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fd003_pass_3_identical_responses() {
+        let r = ["Paris.", "Paris.", "Paris."];
+        assert_eq!(verdict_from_concurrent_parity(&r), ConcurrentParityVerdict::Pass);
+    }
+
+    #[test]
+    fn fd003_pass_single_response_trivial() {
+        let r = ["The answer is 4."];
+        assert_eq!(verdict_from_concurrent_parity(&r), ConcurrentParityVerdict::Pass);
+    }
+
+    #[test]
+    fn fd003_fail_two_diverged_responses() {
+        let r = ["Paris.", "Paris.", "Lyon."];
+        assert_eq!(verdict_from_concurrent_parity(&r), ConcurrentParityVerdict::Fail);
+    }
+
+    #[test]
+    fn fd003_fail_empty() {
+        let r: [&str; 0] = [];
+        assert_eq!(verdict_from_concurrent_parity(&r), ConcurrentParityVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 5: F-DIFF-004 perplexity budget.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fd004_pass_q4k_within_budget() {
+        // 1.05 < 1.10 budget for Q4_K.
+        assert_eq!(verdict_from_perplexity_budget("Q4_K", 1.05), PerplexityBudgetVerdict::Pass);
+    }
+
+    #[test]
+    fn fd004_pass_q8_within_tight_budget() {
+        // 1.005 < 1.01 budget for Q8_0.
+        assert_eq!(verdict_from_perplexity_budget("Q8_0", 1.005), PerplexityBudgetVerdict::Pass);
+    }
+
+    #[test]
+    fn fd004_pass_lowercase_quant_name() {
+        assert_eq!(verdict_from_perplexity_budget("q4_k", 1.05), PerplexityBudgetVerdict::Pass);
+    }
+
+    #[test]
+    fn fd004_pass_q4_k_m_alias() {
+        assert_eq!(verdict_from_perplexity_budget("Q4_K_M", 1.05), PerplexityBudgetVerdict::Pass);
+    }
+
+    #[test]
+    fn fd004_fail_q4k_above_budget() {
+        // 1.15 > 1.10 budget.
+        assert_eq!(verdict_from_perplexity_budget("Q4_K", 1.15), PerplexityBudgetVerdict::Fail);
+    }
+
+    #[test]
+    fn fd004_fail_q8_above_tight_budget() {
+        // Q8_0 at 1.05 is too loose for the 1.01 budget.
+        assert_eq!(verdict_from_perplexity_budget("Q8_0", 1.05), PerplexityBudgetVerdict::Fail);
+    }
+
+    #[test]
+    fn fd004_fail_unknown_quant() {
+        assert_eq!(verdict_from_perplexity_budget("Q1_K", 1.05), PerplexityBudgetVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 6: F-DIFF-005 cross-format L2.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fd005_pass_identical_l2() {
+        let t = [(1.234, 1.234, 1.234), (5.678, 5.678, 5.678)];
+        assert_eq!(verdict_from_cross_format_l2(&t), CrossFormatL2Verdict::Pass);
+    }
+
+    #[test]
+    fn fd005_pass_within_tolerance() {
+        // Relative diff < 0.1%. Use tight values: max pairwise rel_diff
+        // is |1.0005 - 1.0000| / 1.0005 ≈ 5e-4, well under 1e-3.
+        let t = [(1.0000, 1.0005, 1.0003)];
+        assert_eq!(verdict_from_cross_format_l2(&t), CrossFormatL2Verdict::Pass);
+    }
+
+    #[test]
+    fn fd005_fail_outside_tolerance() {
+        // 1% relative diff = 10x tolerance.
+        let t = [(1.0, 1.01, 1.0)];
+        assert_eq!(verdict_from_cross_format_l2(&t), CrossFormatL2Verdict::Fail);
+    }
+
+    #[test]
+    fn fd005_fail_one_tensor_drift() {
+        // First tensor matches, second drifted heavily.
+        let t = [(1.0, 1.0, 1.0), (2.0, 2.5, 2.0)];
+        assert_eq!(verdict_from_cross_format_l2(&t), CrossFormatL2Verdict::Fail);
+    }
+
+    #[test]
+    fn fd005_pass_empty_vacuous() {
+        assert_eq!(verdict_from_cross_format_l2(&[]), CrossFormatL2Verdict::Pass);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 7: Realistic — full healthy differential run passes all 5.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn realistic_healthy_run_passes_all_5() {
+        // ollama agreement at 0.97, ppl_gap 2%.
+        assert_eq!(verdict_from_ollama_parity(0.97, 0.02), OllamaParityVerdict::Pass);
+        // tokenizer roundtrip for ASCII + ChatML.
+        let c = [
+            ("Hello", "Hello"),
+            ("<|im_start|>user", "<|im_start|>user"),
+        ];
+        assert_eq!(verdict_from_tokenizer_roundtrip(&c), TokenizerRoundtripVerdict::Pass);
+        // concurrent: 5 identical responses.
+        let r = ["4", "4", "4", "4", "4"];
+        assert_eq!(verdict_from_concurrent_parity(&r), ConcurrentParityVerdict::Pass);
+        // PPL budget: Q4_K at 1.07.
+        assert_eq!(verdict_from_perplexity_budget("Q4_K", 1.07), PerplexityBudgetVerdict::Pass);
+        // Cross-format L2: matching norms.
+        let t = [(1.234, 1.234, 1.234)];
+        assert_eq!(verdict_from_cross_format_l2(&t), CrossFormatL2Verdict::Pass);
+    }
+
+    #[test]
+    fn realistic_pre_fix_all_5_failures() {
+        // 001: ollama divergence.
+        assert_eq!(verdict_from_ollama_parity(0.85, 0.15), OllamaParityVerdict::Fail);
+        // 002: tokenizer dropped UTF-8.
+        let c = [("café", "caf?")];
+        assert_eq!(verdict_from_tokenizer_roundtrip(&c), TokenizerRoundtripVerdict::Fail);
+        // 003: concurrent state leak.
+        let r = ["A", "B", "A"];
+        assert_eq!(verdict_from_concurrent_parity(&r), ConcurrentParityVerdict::Fail);
+        // 004: Q4_K perplexity exceeded budget.
+        assert_eq!(verdict_from_perplexity_budget("Q4_K", 1.20), PerplexityBudgetVerdict::Fail);
+        // 005: cross-format L2 drifted.
+        let t = [(1.0, 1.5, 1.0)];
+        assert_eq!(verdict_from_cross_format_l2(&t), CrossFormatL2Verdict::Fail);
+    }
+}

--- a/crates/aprender-core/src/format/qameta_001_005.rs
+++ b/crates/aprender-core/src/format/qameta_001_005.rs
@@ -1,0 +1,377 @@
+// `apr-qa-metamorphic-v1` algorithm-level PARTIAL discharge for the 5
+// metamorphic-testing falsifiers (quant equivalence, GGUF→APR→GGUF
+// roundtrip, multi-arch smoke, prompt invariance, temp=0 determinism).
+//
+// Contract: `contracts/apr-qa-metamorphic-v1.yaml`.
+// Refs: arXiv:1807.10453 (METTLE), arXiv:2103.13630 (Quantization
+// methods), arXiv:2603.23611 (LLMORPH).
+
+/// Cosine-similarity threshold for first-token logits across quantizations.
+pub const AC_QAMETA_COSINE_MIN: f64 = 0.95;
+
+/// Top-K used by quantization-equivalence tests.
+pub const AC_QAMETA_TOP_K: u32 = 5;
+
+/// Minimum top-K overlap (top-3 of top-5).
+pub const AC_QAMETA_TOP_K_OVERLAP: u32 = 3;
+
+/// L2 norm drift tolerance for GGUF→APR→GGUF roundtrip (1%).
+pub const AC_QAMETA_ROUNDTRIP_TOLERANCE: f64 = 0.01;
+
+/// Architecture families covered by the multi-arch smoke gate.
+pub const AC_QAMETA_ARCHITECTURES: [&str; 5] =
+    ["qwen2", "llama", "phi", "gemma", "mistral"];
+
+/// Minimum architectures producing coherent output (3 of 5).
+pub const AC_QAMETA_MIN_COHERENT_ARCHS: u32 = 3;
+
+// =============================================================================
+// F-META-001 — quantization equivalence
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QuantEquivalenceVerdict {
+    /// Cosine similarity > 0.95 AND top-5 overlap ≥ 3.
+    Pass,
+    /// Either threshold violated.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_quant_equivalence(
+    cosine_similarity: f64,
+    top_k_overlap_count: u32,
+) -> QuantEquivalenceVerdict {
+    if cosine_similarity <= AC_QAMETA_COSINE_MIN {
+        return QuantEquivalenceVerdict::Fail;
+    }
+    if top_k_overlap_count < AC_QAMETA_TOP_K_OVERLAP {
+        return QuantEquivalenceVerdict::Fail;
+    }
+    QuantEquivalenceVerdict::Pass
+}
+
+// =============================================================================
+// F-META-002 — format roundtrip fidelity
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RoundtripVerdict {
+    /// Tensor count preserved AND no NaN AND L2 drift < 1% per tensor.
+    Pass,
+    /// Any of: tensor count differs, NaN detected, L2 drift exceeds tolerance.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_roundtrip(
+    tensor_count_before: u32,
+    tensor_count_after: u32,
+    has_nan: bool,
+    max_l2_drift: f64,
+) -> RoundtripVerdict {
+    if tensor_count_before != tensor_count_after {
+        return RoundtripVerdict::Fail;
+    }
+    if has_nan {
+        return RoundtripVerdict::Fail;
+    }
+    if max_l2_drift >= AC_QAMETA_ROUNDTRIP_TOLERANCE {
+        return RoundtripVerdict::Fail;
+    }
+    RoundtripVerdict::Pass
+}
+
+// =============================================================================
+// F-META-003 — multi-architecture smoke
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MultiArchSmokeVerdict {
+    /// At least 3 architectures produce non-empty NaN-free output.
+    Pass,
+    /// Fewer than 3 architectures pass — architecture-specific defect.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_multi_arch_smoke(arch_results: &[(&str, bool, bool)]) -> MultiArchSmokeVerdict {
+    // (architecture_name, output_nonempty, has_nan_or_panic)
+    let mut coherent: u32 = 0;
+    for (_arch, nonempty, broken) in arch_results {
+        if *nonempty && !*broken {
+            coherent += 1;
+        }
+    }
+    if coherent >= AC_QAMETA_MIN_COHERENT_ARCHS {
+        MultiArchSmokeVerdict::Pass
+    } else {
+        MultiArchSmokeVerdict::Fail
+    }
+}
+
+// =============================================================================
+// F-META-004 — prompt invariance
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PromptInvarianceVerdict {
+    /// Both rephrased prompts yield outputs containing the expected answer.
+    Pass,
+    /// At least one prompt missed the expected token.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_prompt_invariance(
+    output_a_contains_answer: bool,
+    output_b_contains_answer: bool,
+) -> PromptInvarianceVerdict {
+    if output_a_contains_answer && output_b_contains_answer {
+        PromptInvarianceVerdict::Pass
+    } else {
+        PromptInvarianceVerdict::Fail
+    }
+}
+
+// =============================================================================
+// F-META-005 — temperature=0 determinism
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TemperatureZeroDeterminismVerdict {
+    /// All N runs at temperature=0 produced exactly 1 unique output.
+    Pass,
+    /// At least 2 distinct outputs across N runs — non-determinism.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_temp_zero_determinism(unique_outputs: u32) -> TemperatureZeroDeterminismVerdict {
+    if unique_outputs == 1 {
+        TemperatureZeroDeterminismVerdict::Pass
+    } else {
+        TemperatureZeroDeterminismVerdict::Fail
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -------------------------------------------------------------------------
+    // Section 1: Provenance pins.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn provenance_cosine_threshold_095() {
+        assert!((AC_QAMETA_COSINE_MIN - 0.95).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn provenance_top_k_5() {
+        assert_eq!(AC_QAMETA_TOP_K, 5);
+    }
+
+    #[test]
+    fn provenance_top_k_overlap_3() {
+        assert_eq!(AC_QAMETA_TOP_K_OVERLAP, 3);
+    }
+
+    #[test]
+    fn provenance_roundtrip_tolerance_001() {
+        assert!((AC_QAMETA_ROUNDTRIP_TOLERANCE - 0.01).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn provenance_architectures_count_5() {
+        assert_eq!(AC_QAMETA_ARCHITECTURES.len(), 5);
+    }
+
+    #[test]
+    fn provenance_min_coherent_archs_3() {
+        assert_eq!(AC_QAMETA_MIN_COHERENT_ARCHS, 3);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 2: F-META-001 quantization equivalence.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fm001_pass_high_similarity_full_overlap() {
+        assert_eq!(verdict_from_quant_equivalence(0.99, 5), QuantEquivalenceVerdict::Pass);
+    }
+
+    #[test]
+    fn fm001_pass_at_overlap_threshold() {
+        assert_eq!(verdict_from_quant_equivalence(0.96, 3), QuantEquivalenceVerdict::Pass);
+    }
+
+    #[test]
+    fn fm001_fail_low_similarity() {
+        // Strict greater-than: 0.95 fails.
+        assert_eq!(verdict_from_quant_equivalence(0.95, 5), QuantEquivalenceVerdict::Fail);
+    }
+
+    #[test]
+    fn fm001_fail_low_overlap() {
+        assert_eq!(verdict_from_quant_equivalence(0.99, 2), QuantEquivalenceVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 3: F-META-002 roundtrip fidelity.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fm002_pass_clean_roundtrip() {
+        assert_eq!(verdict_from_roundtrip(339, 339, false, 0.005), RoundtripVerdict::Pass);
+    }
+
+    #[test]
+    fn fm002_fail_tensor_count_mismatch() {
+        assert_eq!(verdict_from_roundtrip(339, 338, false, 0.005), RoundtripVerdict::Fail);
+    }
+
+    #[test]
+    fn fm002_fail_nan_introduced() {
+        assert_eq!(verdict_from_roundtrip(339, 339, true, 0.0), RoundtripVerdict::Fail);
+    }
+
+    #[test]
+    fn fm002_fail_l2_drift_at_threshold() {
+        // Strict less-than: 1% exactly fails.
+        assert_eq!(verdict_from_roundtrip(339, 339, false, 0.01), RoundtripVerdict::Fail);
+    }
+
+    #[test]
+    fn fm002_pass_l2_drift_just_under() {
+        assert_eq!(verdict_from_roundtrip(339, 339, false, 0.0099), RoundtripVerdict::Pass);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 4: F-META-003 multi-arch smoke.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fm003_pass_all_5_coherent() {
+        let r = [
+            ("qwen2", true, false),
+            ("llama", true, false),
+            ("phi", true, false),
+            ("gemma", true, false),
+            ("mistral", true, false),
+        ];
+        assert_eq!(verdict_from_multi_arch_smoke(&r), MultiArchSmokeVerdict::Pass);
+    }
+
+    #[test]
+    fn fm003_pass_3_of_5() {
+        let r = [
+            ("qwen2", true, false),
+            ("llama", true, false),
+            ("phi", true, false),
+            ("gemma", false, false),
+            ("mistral", true, true),
+        ];
+        assert_eq!(verdict_from_multi_arch_smoke(&r), MultiArchSmokeVerdict::Pass);
+    }
+
+    #[test]
+    fn fm003_fail_only_2_coherent() {
+        let r = [
+            ("qwen2", true, false),
+            ("llama", true, false),
+            ("phi", false, false),
+            ("gemma", false, true),
+            ("mistral", true, true),
+        ];
+        assert_eq!(verdict_from_multi_arch_smoke(&r), MultiArchSmokeVerdict::Fail);
+    }
+
+    #[test]
+    fn fm003_fail_empty_results() {
+        assert_eq!(verdict_from_multi_arch_smoke(&[]), MultiArchSmokeVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 5: F-META-004 prompt invariance.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fm004_pass_both_contain_answer() {
+        assert_eq!(verdict_from_prompt_invariance(true, true), PromptInvarianceVerdict::Pass);
+    }
+
+    #[test]
+    fn fm004_fail_only_a_has_answer() {
+        assert_eq!(verdict_from_prompt_invariance(true, false), PromptInvarianceVerdict::Fail);
+    }
+
+    #[test]
+    fn fm004_fail_only_b_has_answer() {
+        assert_eq!(verdict_from_prompt_invariance(false, true), PromptInvarianceVerdict::Fail);
+    }
+
+    #[test]
+    fn fm004_fail_both_miss_answer() {
+        assert_eq!(verdict_from_prompt_invariance(false, false), PromptInvarianceVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 6: F-META-005 temperature=0 determinism.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fm005_pass_one_unique_output() {
+        assert_eq!(
+            verdict_from_temp_zero_determinism(1),
+            TemperatureZeroDeterminismVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fm005_fail_two_unique_outputs() {
+        assert_eq!(
+            verdict_from_temp_zero_determinism(2),
+            TemperatureZeroDeterminismVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fm005_fail_zero_unique() {
+        // Empty set ⇒ no runs ⇒ determinism cannot be asserted.
+        assert_eq!(
+            verdict_from_temp_zero_determinism(0),
+            TemperatureZeroDeterminismVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 7: Realistic — full healthy metamorphic run + pre-fix.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn realistic_healthy_run_passes_all_5() {
+        assert_eq!(verdict_from_quant_equivalence(0.98, 5), QuantEquivalenceVerdict::Pass);
+        assert_eq!(verdict_from_roundtrip(339, 339, false, 0.003), RoundtripVerdict::Pass);
+        let r = [
+            ("qwen2", true, false),
+            ("llama", true, false),
+            ("phi", true, false),
+            ("gemma", true, false),
+            ("mistral", true, false),
+        ];
+        assert_eq!(verdict_from_multi_arch_smoke(&r), MultiArchSmokeVerdict::Pass);
+        assert_eq!(verdict_from_prompt_invariance(true, true), PromptInvarianceVerdict::Pass);
+        assert_eq!(verdict_from_temp_zero_determinism(1), TemperatureZeroDeterminismVerdict::Pass);
+    }
+
+    #[test]
+    fn realistic_pre_fix_all_5_failures() {
+        assert_eq!(verdict_from_quant_equivalence(0.50, 1), QuantEquivalenceVerdict::Fail);
+        assert_eq!(verdict_from_roundtrip(339, 339, true, 0.05), RoundtripVerdict::Fail);
+        let r = [
+            ("qwen2", false, false),
+            ("llama", false, false),
+            ("phi", false, false),
+            ("gemma", false, false),
+            ("mistral", false, false),
+        ];
+        assert_eq!(verdict_from_multi_arch_smoke(&r), MultiArchSmokeVerdict::Fail);
+        assert_eq!(verdict_from_prompt_invariance(false, false), PromptInvarianceVerdict::Fail);
+        assert_eq!(verdict_from_temp_zero_determinism(3), TemperatureZeroDeterminismVerdict::Fail);
+    }
+}

--- a/crates/aprender-core/src/format/qasilent_001_005.rs
+++ b/crates/aprender-core/src/format/qasilent_001_005.rs
@@ -1,0 +1,404 @@
+// `apr-qa-silent-fallback-v1` algorithm-level PARTIAL discharge for the
+// 5 silent-fallback-injection falsifiers (truncated detection, zero-tps
+// rejection, unknown-arch handling, missing-tokenizer detection, loud
+// failure on bad input).
+//
+// Contract: `contracts/apr-qa-silent-fallback-v1.yaml`.
+// Refs: GH-339 (chat template silent raw-prompt fallback), GH-336
+// (benchmark silently swallowed errors), GH-337 (chat server byte-decode),
+// GH-338 (probar silent metadata corruption), GH-439 (silent _ => default
+// match arms at format boundaries).
+
+/// Keywords that constitute a "loud" failure indication when the command
+/// chooses to warn instead of error (legitimate fallback path per the
+/// `loud_failure_on_bad_input` formula).
+pub const AC_QASILENT_LOUD_KEYWORDS: [&str; 3] = ["WARN", "SKIP", "unsupported"];
+
+/// Keywords that satisfy the truncation detection error message.
+pub const AC_QASILENT_TRUNCATION_KEYWORDS: [&str; 3] = ["truncat", "corrupt", "incomplete"];
+
+/// Keywords that satisfy the missing-tokenizer detection (either
+/// declares failure OR notes legitimate fallback path).
+pub const AC_QASILENT_TOKENIZER_KEYWORDS: [&str; 3] = ["tokenizer", "embedded", "GGUF"];
+
+/// Keywords that satisfy the unknown-arch error message.
+pub const AC_QASILENT_UNKNOWN_ARCH_KEYWORDS: [&str; 2] = ["unsupported", "unknown"];
+
+// =============================================================================
+// F-SILENT-001 — truncated file detection
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TruncationDetectionVerdict {
+    /// `apr validate` exits non-zero AND stderr mentions truncation/corruption.
+    Pass,
+    /// Silent acceptance, OR non-zero exit without explanatory stderr.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_truncation_detection(exit_code: i32, stderr: &str) -> TruncationDetectionVerdict {
+    if exit_code == 0 {
+        return TruncationDetectionVerdict::Fail;
+    }
+    let lower = stderr.to_lowercase();
+    for kw in AC_QASILENT_TRUNCATION_KEYWORDS {
+        if lower.contains(kw) {
+            return TruncationDetectionVerdict::Pass;
+        }
+    }
+    TruncationDetectionVerdict::Fail
+}
+
+// =============================================================================
+// F-SILENT-002 — zero throughput rejection
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ZeroThroughputVerdict {
+    /// `apr bench` reporting tok/s == 0.0 ⇒ exit_code != 0.
+    Pass,
+    /// Reported 0.0 tok/s but exited 0 — the regression class.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_zero_throughput(reported_tps: f64, exit_code: i32) -> ZeroThroughputVerdict {
+    if reported_tps > 0.0 {
+        // Non-zero throughput is fine regardless of exit code; this gate
+        // only catches the zero-as-success regression class.
+        return ZeroThroughputVerdict::Pass;
+    }
+    // tps == 0.0 (or negative — also nonsense): require non-zero exit.
+    if exit_code == 0 {
+        ZeroThroughputVerdict::Fail
+    } else {
+        ZeroThroughputVerdict::Pass
+    }
+}
+
+// =============================================================================
+// F-SILENT-003 — unknown architecture handling
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnknownArchVerdict {
+    /// Unknown architecture identifier ⇒ non-zero exit AND stderr
+    /// mentions "unsupported" or "unknown".
+    Pass,
+    /// Silent fallback to llama default — the regression class.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_unknown_arch(exit_code: i32, stderr: &str) -> UnknownArchVerdict {
+    if exit_code == 0 {
+        return UnknownArchVerdict::Fail;
+    }
+    let lower = stderr.to_lowercase();
+    for kw in AC_QASILENT_UNKNOWN_ARCH_KEYWORDS {
+        if lower.contains(kw) {
+            return UnknownArchVerdict::Pass;
+        }
+    }
+    UnknownArchVerdict::Fail
+}
+
+// =============================================================================
+// F-SILENT-004 — missing tokenizer detection
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MissingTokenizerVerdict {
+    /// Either non-zero exit with "tokenizer" in stderr, OR uses embedded
+    /// GGUF tokenizer (legitimate fallback). Never silent-garble.
+    Pass,
+    /// Silent garble — output emitted without explanation.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_missing_tokenizer(stderr_or_log: &str) -> MissingTokenizerVerdict {
+    // The contract test is `grep -qE 'tokenizer|embedded|GGUF'`. Any of
+    // these keywords appearing means the tool announced its tokenizer
+    // path (either error or legitimate fallback). Absence ⇒ silent.
+    for kw in AC_QASILENT_TOKENIZER_KEYWORDS {
+        if stderr_or_log.contains(kw) {
+            return MissingTokenizerVerdict::Pass;
+        }
+    }
+    MissingTokenizerVerdict::Fail
+}
+
+// =============================================================================
+// F-SILENT-005 — loud failure on bad input
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LoudFailureVerdict {
+    /// Either: non-zero exit with non-empty stderr, OR stdout contains
+    /// WARN / SKIP / unsupported.
+    Pass,
+    /// Silent degradation — exit 0, no stderr, no warning keywords.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_loud_failure(exit_code: i32, stderr: &str, stdout: &str) -> LoudFailureVerdict {
+    // Path 1: explicit error.
+    if exit_code != 0 && !stderr.is_empty() {
+        return LoudFailureVerdict::Pass;
+    }
+    // Path 2: warning emitted on stdout.
+    for kw in AC_QASILENT_LOUD_KEYWORDS {
+        if stdout.contains(kw) {
+            return LoudFailureVerdict::Pass;
+        }
+    }
+    LoudFailureVerdict::Fail
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -------------------------------------------------------------------------
+    // Section 1: Provenance pins.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn provenance_loud_keywords_count_3() {
+        assert_eq!(AC_QASILENT_LOUD_KEYWORDS.len(), 3);
+    }
+
+    #[test]
+    fn provenance_truncation_keywords_count_3() {
+        assert_eq!(AC_QASILENT_TRUNCATION_KEYWORDS.len(), 3);
+    }
+
+    #[test]
+    fn provenance_tokenizer_keywords_count_3() {
+        assert_eq!(AC_QASILENT_TOKENIZER_KEYWORDS.len(), 3);
+    }
+
+    #[test]
+    fn provenance_unknown_arch_keywords_count_2() {
+        assert_eq!(AC_QASILENT_UNKNOWN_ARCH_KEYWORDS.len(), 2);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 2: F-SILENT-001 truncation detection.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fs001_pass_truncated_keyword() {
+        let v = verdict_from_truncation_detection(1, "Error: file truncated at offset 1024");
+        assert_eq!(v, TruncationDetectionVerdict::Pass);
+    }
+
+    #[test]
+    fn fs001_pass_corrupt_keyword() {
+        let v = verdict_from_truncation_detection(2, "Error: corrupt header magic");
+        assert_eq!(v, TruncationDetectionVerdict::Pass);
+    }
+
+    #[test]
+    fn fs001_pass_incomplete_keyword() {
+        let v = verdict_from_truncation_detection(1, "Error: model file is incomplete");
+        assert_eq!(v, TruncationDetectionVerdict::Pass);
+    }
+
+    #[test]
+    fn fs001_fail_silent_zero_exit() {
+        let v = verdict_from_truncation_detection(0, "model truncated");
+        assert_eq!(v, TruncationDetectionVerdict::Fail);
+    }
+
+    #[test]
+    fn fs001_fail_nonzero_no_keyword() {
+        let v = verdict_from_truncation_detection(1, "Generic I/O error");
+        assert_eq!(v, TruncationDetectionVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 3: F-SILENT-002 zero throughput.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fs002_pass_positive_tps() {
+        // Non-zero throughput passes regardless of exit code.
+        assert_eq!(verdict_from_zero_throughput(127.5, 0), ZeroThroughputVerdict::Pass);
+    }
+
+    #[test]
+    fn fs002_pass_zero_tps_nonzero_exit() {
+        assert_eq!(verdict_from_zero_throughput(0.0, 1), ZeroThroughputVerdict::Pass);
+    }
+
+    #[test]
+    fn fs002_fail_zero_tps_zero_exit() {
+        // The exact regression class: 0.0 tok/s reported as success.
+        assert_eq!(verdict_from_zero_throughput(0.0, 0), ZeroThroughputVerdict::Fail);
+    }
+
+    #[test]
+    fn fs002_fail_negative_tps_zero_exit() {
+        // Negative tps is nonsense; treated like zero.
+        assert_eq!(verdict_from_zero_throughput(-1.0, 0), ZeroThroughputVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 4: F-SILENT-003 unknown architecture.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fs003_pass_unsupported_keyword() {
+        let v = verdict_from_unknown_arch(1, "Error: unsupported architecture totally_unknown_arch_v99");
+        assert_eq!(v, UnknownArchVerdict::Pass);
+    }
+
+    #[test]
+    fn fs003_pass_unknown_keyword() {
+        let v = verdict_from_unknown_arch(1, "Error: unknown model arch");
+        assert_eq!(v, UnknownArchVerdict::Pass);
+    }
+
+    #[test]
+    fn fs003_fail_silent_zero_exit() {
+        // The regression: silently fell through to llama.
+        let v = verdict_from_unknown_arch(0, "");
+        assert_eq!(v, UnknownArchVerdict::Fail);
+    }
+
+    #[test]
+    fn fs003_fail_nonzero_no_keyword() {
+        let v = verdict_from_unknown_arch(1, "Some other error");
+        assert_eq!(v, UnknownArchVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 5: F-SILENT-004 missing tokenizer.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fs004_pass_tokenizer_keyword() {
+        let v = verdict_from_missing_tokenizer("Error: tokenizer.json not found");
+        assert_eq!(v, MissingTokenizerVerdict::Pass);
+    }
+
+    #[test]
+    fn fs004_pass_embedded_fallback() {
+        let v = verdict_from_missing_tokenizer("Notice: using embedded GGUF tokenizer");
+        assert_eq!(v, MissingTokenizerVerdict::Pass);
+    }
+
+    #[test]
+    fn fs004_pass_gguf_keyword() {
+        let v = verdict_from_missing_tokenizer("Falling back to GGUF-internal vocabulary");
+        assert_eq!(v, MissingTokenizerVerdict::Pass);
+    }
+
+    #[test]
+    fn fs004_fail_silent_garble() {
+        // Output emitted without any tokenizer/embedded/GGUF announcement.
+        let v = verdict_from_missing_tokenizer("Output: ?�?�?");
+        assert_eq!(v, MissingTokenizerVerdict::Fail);
+    }
+
+    #[test]
+    fn fs004_fail_empty_log() {
+        let v = verdict_from_missing_tokenizer("");
+        assert_eq!(v, MissingTokenizerVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 6: F-SILENT-005 loud failure.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fs005_pass_explicit_error() {
+        let v = verdict_from_loud_failure(1, "Error: bad metadata", "");
+        assert_eq!(v, LoudFailureVerdict::Pass);
+    }
+
+    #[test]
+    fn fs005_pass_warn_on_stdout() {
+        let v = verdict_from_loud_failure(0, "", "WARN: degraded mode");
+        assert_eq!(v, LoudFailureVerdict::Pass);
+    }
+
+    #[test]
+    fn fs005_pass_skip_on_stdout() {
+        let v = verdict_from_loud_failure(0, "", "SKIP: unsupported feature");
+        assert_eq!(v, LoudFailureVerdict::Pass);
+    }
+
+    #[test]
+    fn fs005_pass_unsupported_on_stdout() {
+        let v = verdict_from_loud_failure(0, "", "Notice: unsupported quant — using f16");
+        assert_eq!(v, LoudFailureVerdict::Pass);
+    }
+
+    #[test]
+    fn fs005_fail_silent_success() {
+        // The exact regression: bad input but exit 0, empty stderr, no warning.
+        let v = verdict_from_loud_failure(0, "", "Output: garbage");
+        assert_eq!(v, LoudFailureVerdict::Fail);
+    }
+
+    #[test]
+    fn fs005_fail_nonzero_exit_no_stderr() {
+        // Exit 1 alone isn't enough — need either stderr OR stdout warning.
+        let v = verdict_from_loud_failure(1, "", "");
+        assert_eq!(v, LoudFailureVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 7: Realistic — full healthy bad-input run + pre-fix.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn realistic_loud_run_passes_all_5() {
+        // Truncated file → non-zero exit + corrupt keyword.
+        assert_eq!(
+            verdict_from_truncation_detection(1, "Error: file is corrupt"),
+            TruncationDetectionVerdict::Pass
+        );
+        // Non-zero throughput.
+        assert_eq!(verdict_from_zero_throughput(150.0, 0), ZeroThroughputVerdict::Pass);
+        // Unknown arch → non-zero exit + unsupported.
+        assert_eq!(
+            verdict_from_unknown_arch(1, "Error: unsupported architecture"),
+            UnknownArchVerdict::Pass
+        );
+        // Missing tokenizer → embedded fallback announced.
+        assert_eq!(
+            verdict_from_missing_tokenizer("Notice: using embedded tokenizer"),
+            MissingTokenizerVerdict::Pass
+        );
+        // Bad input → loud error.
+        assert_eq!(
+            verdict_from_loud_failure(1, "Error: bad input", ""),
+            LoudFailureVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn realistic_pre_fix_all_5_failures() {
+        // 001: silent acceptance of truncated file.
+        assert_eq!(
+            verdict_from_truncation_detection(0, ""),
+            TruncationDetectionVerdict::Fail
+        );
+        // 002: GH-336 — 0 tok/s reported as success.
+        assert_eq!(verdict_from_zero_throughput(0.0, 0), ZeroThroughputVerdict::Fail);
+        // 003: GH-439 — unknown arch silently maps to llama.
+        assert_eq!(
+            verdict_from_unknown_arch(0, "tokens generated successfully"),
+            UnknownArchVerdict::Fail
+        );
+        // 004: GH-337 — chat server degrades to byte-level decode silently.
+        assert_eq!(
+            verdict_from_missing_tokenizer("Output: ?\u{fffd}?\u{fffd}?"),
+            MissingTokenizerVerdict::Fail
+        );
+        // 005: GH-339 / GH-338 — silent fallback to raw prompt / accepted corruption.
+        assert_eq!(
+            verdict_from_loud_failure(0, "", "Output: degraded silently"),
+            LoudFailureVerdict::Fail
+        );
+    }
+}

--- a/crates/aprender-core/src/format/rank_001_004.rs
+++ b/crates/aprender-core/src/format/rank_001_004.rs
@@ -1,0 +1,512 @@
+// SHIP-TWO-001 — `metrics-ranking-v1` algorithm-level PARTIAL
+// discharge for FALSIFY-RANK-001..004.
+//
+// Contract: `contracts/metrics-ranking-v1.yaml`.
+// Spec: `docs/specifications/aprender-train/ship-two-models-spec.md`.
+//
+// ## What this file proves NOW (PARTIAL_ALGORITHM_LEVEL)
+//
+// Four ranking-metric gates from Manning et al. (2008) Ch. 8 +
+// Järvelin & Käkäläinen (2002) NDCG:
+//
+// - RANK-001 (hit@k binary): hit@k ∈ {0, 1}.
+// - RANK-002 (MRR bounded): MRR ∈ [0, 1].
+// - RANK-003 (NDCG perfect ranking): NDCG@k = 1 for sorted ranking.
+// - RANK-004 (NDCG bounded): NDCG@k ∈ [0, 1].
+
+/// MRR/NDCG lower bound (inclusive).
+pub const AC_RANK_BOUND_LOWER: f32 = 0.0;
+
+/// MRR/NDCG upper bound (inclusive).
+pub const AC_RANK_BOUND_UPPER: f32 = 1.0;
+
+/// NDCG = 1.0 tolerance for perfect ranking (FP32 wobble).
+pub const AC_RANK_003_PERFECT_EPS: f32 = 1e-5;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RankVerdict {
+    Pass,
+    Fail,
+}
+
+// -----------------------------------------------------------------------------
+// In-module reference helpers.
+// -----------------------------------------------------------------------------
+
+/// hit@k: 1 if any item in top-k is relevant; else 0.
+///
+/// `ranked_relevance` — for each rank position, true iff the item at
+/// that position is relevant. Length n; we look at first k entries.
+#[must_use]
+pub fn hit_at_k(ranked_relevance: &[bool], k: usize) -> u32 {
+    let upper = k.min(ranked_relevance.len());
+    if ranked_relevance[..upper].iter().any(|&r| r) {
+        1
+    } else {
+        0
+    }
+}
+
+/// Reciprocal rank: 1/rank of first relevant item, or 0 if none.
+#[must_use]
+pub fn reciprocal_rank(ranked_relevance: &[bool]) -> f32 {
+    for (i, &r) in ranked_relevance.iter().enumerate() {
+        if r {
+            return 1.0 / (i as f32 + 1.0);
+        }
+    }
+    0.0
+}
+
+/// MRR = mean reciprocal rank over all queries.
+#[must_use]
+pub fn mrr(reciprocal_ranks: &[f32]) -> f32 {
+    if reciprocal_ranks.is_empty() {
+        return 0.0;
+    }
+    let sum: f32 = reciprocal_ranks.iter().sum();
+    sum / reciprocal_ranks.len() as f32
+}
+
+/// DCG@k = Σ_{i=1}^{k} rel_i / log2(i+1).
+#[must_use]
+pub fn dcg_at_k(relevance_scores: &[f32], k: usize) -> f32 {
+    let upper = k.min(relevance_scores.len());
+    let mut dcg = 0.0_f32;
+    for i in 0..upper {
+        dcg += relevance_scores[i] / ((i as f32 + 2.0).log2());
+    }
+    dcg
+}
+
+/// IDCG@k = DCG@k for relevance scores sorted descending.
+#[must_use]
+pub fn idcg_at_k(relevance_scores: &[f32], k: usize) -> f32 {
+    let mut sorted = relevance_scores.to_vec();
+    sorted.sort_by(|a, b| b.partial_cmp(a).unwrap_or(std::cmp::Ordering::Equal));
+    dcg_at_k(&sorted, k)
+}
+
+/// NDCG@k = DCG@k / IDCG@k (or 1.0 if IDCG@k == 0 — vacuous).
+#[must_use]
+pub fn ndcg_at_k(relevance_scores: &[f32], k: usize) -> f32 {
+    let idcg = idcg_at_k(relevance_scores, k);
+    if idcg == 0.0 {
+        // Convention: if all relevance is 0, NDCG is defined as 0
+        // (perfect-ranking edge case is captured by the NDCG-perfect
+        // gate; here we conservatively report 0.0).
+        return 0.0;
+    }
+    dcg_at_k(relevance_scores, k) / idcg
+}
+
+// -----------------------------------------------------------------------------
+// Verdict 1: RANK-001 — hit@k binary.
+// -----------------------------------------------------------------------------
+
+#[must_use]
+pub fn verdict_from_hit_at_k_binary(hit_value: u32) -> RankVerdict {
+    if hit_value == 0 || hit_value == 1 {
+        RankVerdict::Pass
+    } else {
+        RankVerdict::Fail
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Verdict 2: RANK-002 — MRR ∈ [0, 1].
+// -----------------------------------------------------------------------------
+
+#[must_use]
+pub fn verdict_from_mrr_bounded(mrr_value: f32) -> RankVerdict {
+    if !mrr_value.is_finite() {
+        return RankVerdict::Fail;
+    }
+    if (AC_RANK_BOUND_LOWER..=AC_RANK_BOUND_UPPER).contains(&mrr_value) {
+        RankVerdict::Pass
+    } else {
+        RankVerdict::Fail
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Verdict 3: RANK-003 — NDCG = 1 for perfect ranking.
+// -----------------------------------------------------------------------------
+
+#[must_use]
+pub fn verdict_from_ndcg_perfect_ranking(ndcg: f32) -> RankVerdict {
+    if !ndcg.is_finite() {
+        return RankVerdict::Fail;
+    }
+    if (ndcg - 1.0).abs() < AC_RANK_003_PERFECT_EPS {
+        RankVerdict::Pass
+    } else {
+        RankVerdict::Fail
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Verdict 4: RANK-004 — NDCG ∈ [0, 1].
+// -----------------------------------------------------------------------------
+
+#[must_use]
+pub fn verdict_from_ndcg_bounded(ndcg: f32) -> RankVerdict {
+    if !ndcg.is_finite() {
+        return RankVerdict::Fail;
+    }
+    if (AC_RANK_BOUND_LOWER..=AC_RANK_BOUND_UPPER).contains(&ndcg) {
+        RankVerdict::Pass
+    } else {
+        RankVerdict::Fail
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -------------------------------------------------------------------------
+    // Section 1: Provenance pins.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn provenance_bound_lower_zero() {
+        assert_eq!(AC_RANK_BOUND_LOWER, 0.0);
+    }
+
+    #[test]
+    fn provenance_bound_upper_one() {
+        assert_eq!(AC_RANK_BOUND_UPPER, 1.0);
+    }
+
+    #[test]
+    fn provenance_perfect_eps_1e_5() {
+        assert_eq!(AC_RANK_003_PERFECT_EPS, 1e-5);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 2: Domain — reference helpers.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn domain_hit_at_k_finds_relevant_in_top() {
+        let r = vec![false, true, false, false];
+        assert_eq!(hit_at_k(&r, 2), 1);
+        assert_eq!(hit_at_k(&r, 4), 1);
+    }
+
+    #[test]
+    fn domain_hit_at_k_misses_when_not_in_top() {
+        let r = vec![false, false, false, true];
+        assert_eq!(hit_at_k(&r, 2), 0);
+        assert_eq!(hit_at_k(&r, 4), 1);
+    }
+
+    #[test]
+    fn domain_reciprocal_rank_first_relevant() {
+        let r = vec![true, false, false];
+        assert!((reciprocal_rank(&r) - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn domain_reciprocal_rank_third_relevant() {
+        let r = vec![false, false, true];
+        assert!((reciprocal_rank(&r) - (1.0 / 3.0)).abs() < 1e-6);
+    }
+
+    #[test]
+    fn domain_reciprocal_rank_none_relevant_returns_zero() {
+        let r = vec![false; 5];
+        assert_eq!(reciprocal_rank(&r), 0.0);
+    }
+
+    #[test]
+    fn domain_mrr_average_of_three_queries() {
+        // RR = [1.0, 0.5, 0.333...] ⇒ MRR ≈ 0.611.
+        let rr = vec![1.0_f32, 0.5, 1.0 / 3.0];
+        let m = mrr(&rr);
+        assert!((m - 0.611_111).abs() < 1e-4);
+    }
+
+    #[test]
+    fn domain_dcg_at_k_basic() {
+        // rel = [3, 2, 1] ⇒ DCG@3 = 3/log2(2) + 2/log2(3) + 1/log2(4)
+        //                       = 3 + 2/1.585 + 1/2 = 3 + 1.262 + 0.5 = 4.762.
+        let rel = vec![3.0_f32, 2.0, 1.0];
+        let dcg = dcg_at_k(&rel, 3);
+        assert!((dcg - 4.762).abs() < 0.01, "dcg={dcg}");
+    }
+
+    #[test]
+    fn domain_ndcg_perfect_when_sorted() {
+        let rel = vec![5.0_f32, 3.0, 1.0]; // already sorted desc
+        let ndcg = ndcg_at_k(&rel, 3);
+        assert!((ndcg - 1.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn domain_ndcg_less_than_one_when_unsorted() {
+        let rel = vec![1.0_f32, 5.0, 3.0]; // suboptimal order
+        let ndcg = ndcg_at_k(&rel, 3);
+        assert!(ndcg < 1.0);
+        assert!(ndcg > 0.0);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 3: RANK-001 — hit@k binary.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn rank001_pass_zero() {
+        assert_eq!(verdict_from_hit_at_k_binary(0), RankVerdict::Pass);
+    }
+
+    #[test]
+    fn rank001_pass_one() {
+        assert_eq!(verdict_from_hit_at_k_binary(1), RankVerdict::Pass);
+    }
+
+    #[test]
+    fn rank001_fail_above_one() {
+        // Bug: hit@k returned multi-relevant count instead of binary.
+        assert_eq!(verdict_from_hit_at_k_binary(2), RankVerdict::Fail);
+    }
+
+    #[test]
+    fn rank001_fail_large_value() {
+        assert_eq!(verdict_from_hit_at_k_binary(100), RankVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 4: RANK-002 — MRR ∈ [0, 1].
+    // -------------------------------------------------------------------------
+    #[test]
+    fn rank002_pass_zero() {
+        assert_eq!(verdict_from_mrr_bounded(0.0), RankVerdict::Pass);
+    }
+
+    #[test]
+    fn rank002_pass_one() {
+        assert_eq!(verdict_from_mrr_bounded(1.0), RankVerdict::Pass);
+    }
+
+    #[test]
+    fn rank002_pass_half() {
+        assert_eq!(verdict_from_mrr_bounded(0.5), RankVerdict::Pass);
+    }
+
+    #[test]
+    fn rank002_fail_above_one() {
+        // Reciprocal rank exceeded 1 due to /0 bug.
+        assert_eq!(verdict_from_mrr_bounded(1.5), RankVerdict::Fail);
+    }
+
+    #[test]
+    fn rank002_fail_negative() {
+        assert_eq!(verdict_from_mrr_bounded(-0.1), RankVerdict::Fail);
+    }
+
+    #[test]
+    fn rank002_fail_nan() {
+        assert_eq!(verdict_from_mrr_bounded(f32::NAN), RankVerdict::Fail);
+    }
+
+    #[test]
+    fn rank002_fail_inf() {
+        assert_eq!(verdict_from_mrr_bounded(f32::INFINITY), RankVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 5: RANK-003 — NDCG perfect ranking.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn rank003_pass_exact_one() {
+        assert_eq!(
+            verdict_from_ndcg_perfect_ranking(1.0),
+            RankVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn rank003_pass_within_eps() {
+        assert_eq!(
+            verdict_from_ndcg_perfect_ranking(0.999_999),
+            RankVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn rank003_fail_just_below() {
+        // Bug: log base error → NDCG slightly below 1 even on perfect.
+        assert_eq!(
+            verdict_from_ndcg_perfect_ranking(0.99),
+            RankVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn rank003_fail_above_one() {
+        // Bug: IDCG sort order wrong → NDCG > 1.
+        assert_eq!(
+            verdict_from_ndcg_perfect_ranking(1.05),
+            RankVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn rank003_fail_zero() {
+        assert_eq!(
+            verdict_from_ndcg_perfect_ranking(0.0),
+            RankVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn rank003_fail_nan() {
+        assert_eq!(
+            verdict_from_ndcg_perfect_ranking(f32::NAN),
+            RankVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 6: RANK-004 — NDCG ∈ [0, 1].
+    // -------------------------------------------------------------------------
+    #[test]
+    fn rank004_pass_typical() {
+        assert_eq!(verdict_from_ndcg_bounded(0.85), RankVerdict::Pass);
+    }
+
+    #[test]
+    fn rank004_pass_at_bounds() {
+        assert_eq!(verdict_from_ndcg_bounded(0.0), RankVerdict::Pass);
+        assert_eq!(verdict_from_ndcg_bounded(1.0), RankVerdict::Pass);
+    }
+
+    #[test]
+    fn rank004_fail_above_one() {
+        // Contract example: "NDCG exceeds 1.0 due to IDCG computation
+        // using wrong sort order".
+        assert_eq!(verdict_from_ndcg_bounded(1.5), RankVerdict::Fail);
+    }
+
+    #[test]
+    fn rank004_fail_negative() {
+        assert_eq!(verdict_from_ndcg_bounded(-0.1), RankVerdict::Fail);
+    }
+
+    #[test]
+    fn rank004_fail_nan() {
+        // Division by zero when all relevance = 0.
+        assert_eq!(verdict_from_ndcg_bounded(f32::NAN), RankVerdict::Fail);
+    }
+
+    #[test]
+    fn rank004_fail_inf() {
+        assert_eq!(verdict_from_ndcg_bounded(f32::INFINITY), RankVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 7: Sweep — bounds.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn sweep_mrr_band() {
+        let test_cases = [
+            (-0.1_f32, RankVerdict::Fail),
+            (0.0, RankVerdict::Pass),
+            (0.5, RankVerdict::Pass),
+            (1.0, RankVerdict::Pass),
+            (1.0001, RankVerdict::Fail),
+        ];
+        for (m, expected) in test_cases {
+            let v = verdict_from_mrr_bounded(m);
+            assert_eq!(v, expected, "m={m}");
+        }
+    }
+
+    #[test]
+    fn sweep_hit_at_k_band() {
+        for h in 0..=1_u32 {
+            assert_eq!(
+                verdict_from_hit_at_k_binary(h),
+                RankVerdict::Pass,
+                "h={h}"
+            );
+        }
+        for h in 2..=10_u32 {
+            assert_eq!(
+                verdict_from_hit_at_k_binary(h),
+                RankVerdict::Fail,
+                "h={h}"
+            );
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 8: Realistic — contract regression scenarios.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn realistic_hit_returns_count_not_binary_caught() {
+        // RANK-001 if_fails: "hit@k returning fractional or unbounded
+        // value" — bug returns count of relevant items.
+        assert_eq!(verdict_from_hit_at_k_binary(3), RankVerdict::Fail);
+    }
+
+    #[test]
+    fn realistic_division_by_zero_caught() {
+        // RANK-002 if_fails: "Division error or reciprocal rank
+        // exceeding 1".
+        assert_eq!(verdict_from_mrr_bounded(2.0), RankVerdict::Fail);
+    }
+
+    #[test]
+    fn realistic_log_base_error_caught() {
+        // RANK-003 if_fails: "DCG/IDCG computation mismatch or log
+        // base error". With log10 instead of log2, NDCG perfect would
+        // not be exactly 1.
+        assert_eq!(
+            verdict_from_ndcg_perfect_ranking(0.95),
+            RankVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn realistic_idcg_wrong_sort_caught() {
+        // RANK-004 if_fails: "IDCG computed incorrectly" → NDCG > 1.
+        assert_eq!(verdict_from_ndcg_bounded(1.2), RankVerdict::Fail);
+    }
+
+    #[test]
+    fn realistic_full_metric_pipeline() {
+        // 4 queries, each with 5-position ranking and a relevant item.
+        let queries_relevance = vec![
+            vec![true, false, false, false, false],   // perfect rank
+            vec![false, true, false, false, false],   // RR = 0.5
+            vec![false, false, true, false, false],   // RR = 0.333
+            vec![false, false, false, false, false],  // none ⇒ RR = 0
+        ];
+        let rrs: Vec<f32> = queries_relevance
+            .iter()
+            .map(|r| reciprocal_rank(r))
+            .collect();
+        let m = mrr(&rrs);
+        assert_eq!(verdict_from_mrr_bounded(m), RankVerdict::Pass);
+        // hit@1 binary check on first query.
+        let h1 = hit_at_k(&queries_relevance[0], 1);
+        assert_eq!(verdict_from_hit_at_k_binary(h1), RankVerdict::Pass);
+        let h4 = hit_at_k(&queries_relevance[3], 5); // none relevant
+        assert_eq!(verdict_from_hit_at_k_binary(h4), RankVerdict::Pass);
+
+        // NDCG perfect ranking at k=3.
+        let perfect_relevance = vec![3.0_f32, 2.0, 1.0];
+        let ndcg = ndcg_at_k(&perfect_relevance, 3);
+        assert_eq!(
+            verdict_from_ndcg_perfect_ranking(ndcg),
+            RankVerdict::Pass
+        );
+        assert_eq!(verdict_from_ndcg_bounded(ndcg), RankVerdict::Pass);
+
+        // NDCG suboptimal still bounded.
+        let suboptimal = vec![1.0_f32, 3.0, 2.0];
+        let ndcg2 = ndcg_at_k(&suboptimal, 3);
+        assert!(ndcg2 < 1.0);
+        assert_eq!(verdict_from_ndcg_bounded(ndcg2), RankVerdict::Pass);
+    }
+}

--- a/crates/aprender-core/src/format/rf_001_004.rs
+++ b/crates/aprender-core/src/format/rf_001_004.rs
@@ -1,0 +1,504 @@
+// SHIP-TWO-001 — `random-forest-v1` algorithm-level PARTIAL discharge
+// for FALSIFY-RF-001..004.
+//
+// Contract: `contracts/random-forest-v1.yaml`.
+// Spec: `docs/specifications/aprender-train/ship-two-models-spec.md`.
+//
+// ## What this file proves NOW (PARTIAL_ALGORITHM_LEVEL)
+//
+// Four random-forest gates:
+//
+// - RF-001 (predictions in label range): every predict(x) ∈ training_labels.
+// - RF-002 (deterministic with seed): predict(X, seed=s) ≡ predict(X, seed=s).
+// - RF-003 (ensemble size): |forest.trees| = n_estimators.
+// - RF-004 (prediction length): |predict(X)| = |X|.
+//
+// All four are pure invariants over (predictions, training_labels,
+// n_estimators, m). No kernel selection, no SIMD path.
+//
+// In-module reference: `forest_majority_vote` — pure majority vote
+// across a fixed `Vec<Vec<usize>>` of per-tree predictions, ties
+// broken by smallest class id (deterministic).
+
+/// Minimum legal value of n_estimators.
+pub const AC_RF_003_MIN_ESTIMATORS: usize = 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RfVerdict {
+    Pass,
+    Fail,
+}
+
+// -----------------------------------------------------------------------------
+// In-module reference majority-vote ensemble.
+// -----------------------------------------------------------------------------
+
+/// Compute majority-vote prediction for a single sample given B per-tree
+/// predictions. Ties broken by smallest class id (deterministic).
+#[must_use]
+pub fn majority_vote(per_tree_preds: &[usize], n_classes: usize) -> usize {
+    let mut counts = vec![0_usize; n_classes];
+    for &p in per_tree_preds {
+        if p < n_classes {
+            counts[p] += 1;
+        }
+    }
+    let mut best = 0_usize;
+    let mut best_count = 0_usize;
+    for (k, &c) in counts.iter().enumerate() {
+        if c > best_count {
+            best = k;
+            best_count = c;
+        }
+    }
+    best
+}
+
+/// Predict over a batch given a forest of B trees, each tree's
+/// per-sample predictions in `tree_preds[b][i]`.
+#[must_use]
+pub fn forest_predict(tree_preds: &[Vec<usize>], n_classes: usize) -> Vec<usize> {
+    if tree_preds.is_empty() {
+        return Vec::new();
+    }
+    let n_samples = tree_preds[0].len();
+    let mut out = Vec::with_capacity(n_samples);
+    for i in 0..n_samples {
+        let per_tree: Vec<usize> = tree_preds.iter().map(|t| t[i]).collect();
+        out.push(majority_vote(&per_tree, n_classes));
+    }
+    out
+}
+
+// -----------------------------------------------------------------------------
+// Verdict 1: RF-001 — predictions ∈ training labels.
+// -----------------------------------------------------------------------------
+
+#[must_use]
+pub fn verdict_from_predictions_in_labels(
+    predictions: &[usize],
+    training_labels: &[usize],
+) -> RfVerdict {
+    if training_labels.is_empty() {
+        return if predictions.is_empty() {
+            RfVerdict::Pass
+        } else {
+            RfVerdict::Fail
+        };
+    }
+    let label_set: std::collections::HashSet<usize> =
+        training_labels.iter().copied().collect();
+    for &p in predictions {
+        if !label_set.contains(&p) {
+            return RfVerdict::Fail;
+        }
+    }
+    RfVerdict::Pass
+}
+
+// -----------------------------------------------------------------------------
+// Verdict 2: RF-002 — deterministic with seed.
+// -----------------------------------------------------------------------------
+
+#[must_use]
+pub fn verdict_from_seed_determinism(
+    predictions_run1: &[usize],
+    predictions_run2: &[usize],
+) -> RfVerdict {
+    if predictions_run1.len() != predictions_run2.len() {
+        return RfVerdict::Fail;
+    }
+    if predictions_run1 == predictions_run2 {
+        RfVerdict::Pass
+    } else {
+        RfVerdict::Fail
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Verdict 3: RF-003 — ensemble size.
+// -----------------------------------------------------------------------------
+
+#[must_use]
+pub fn verdict_from_ensemble_size(actual: usize, expected_n_estimators: usize) -> RfVerdict {
+    if expected_n_estimators < AC_RF_003_MIN_ESTIMATORS {
+        return RfVerdict::Fail;
+    }
+    if actual == expected_n_estimators {
+        RfVerdict::Pass
+    } else {
+        RfVerdict::Fail
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Verdict 4: RF-004 — prediction length.
+// -----------------------------------------------------------------------------
+
+#[must_use]
+pub fn verdict_from_prediction_length(predictions_len: usize, samples_len: usize) -> RfVerdict {
+    if predictions_len == samples_len {
+        RfVerdict::Pass
+    } else {
+        RfVerdict::Fail
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -------------------------------------------------------------------------
+    // Section 1: Provenance pin.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn provenance_min_estimators_is_one() {
+        assert_eq!(AC_RF_003_MIN_ESTIMATORS, 1);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 2: RF-001 Pass band.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn rf001_pass_all_predictions_in_labels() {
+        let preds = vec![0_usize, 1, 0, 2, 1];
+        let labels = vec![0_usize, 1, 2];
+        assert_eq!(
+            verdict_from_predictions_in_labels(&preds, &labels),
+            RfVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn rf001_pass_empty_predictions() {
+        let preds: Vec<usize> = vec![];
+        let labels = vec![0_usize, 1, 2];
+        assert_eq!(
+            verdict_from_predictions_in_labels(&preds, &labels),
+            RfVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn rf001_pass_single_class_problem() {
+        let preds = vec![5_usize, 5, 5, 5];
+        let labels = vec![5_usize];
+        assert_eq!(
+            verdict_from_predictions_in_labels(&preds, &labels),
+            RfVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn rf001_pass_unsorted_label_set() {
+        let preds = vec![7_usize, 3, 9];
+        let labels = vec![9_usize, 3, 7]; // labels can be any usize, in any order
+        assert_eq!(
+            verdict_from_predictions_in_labels(&preds, &labels),
+            RfVerdict::Pass
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 3: RF-001 Fail band.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn rf001_fail_one_unseen_label() {
+        let preds = vec![0_usize, 1, 5]; // 5 is OOD
+        let labels = vec![0_usize, 1, 2];
+        assert_eq!(
+            verdict_from_predictions_in_labels(&preds, &labels),
+            RfVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn rf001_fail_all_unseen() {
+        let preds = vec![10_usize, 20, 30];
+        let labels = vec![0_usize, 1, 2];
+        assert_eq!(
+            verdict_from_predictions_in_labels(&preds, &labels),
+            RfVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn rf001_fail_predictions_with_no_training_labels() {
+        // Empty training set but predictions exist — uninitialized
+        // leaf node regression.
+        let preds = vec![0_usize];
+        let labels: Vec<usize> = vec![];
+        assert_eq!(
+            verdict_from_predictions_in_labels(&preds, &labels),
+            RfVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 4: RF-002 Pass band — determinism.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn rf002_pass_identical_runs() {
+        let r1 = vec![0_usize, 1, 0, 2];
+        let r2 = vec![0_usize, 1, 0, 2];
+        assert_eq!(
+            verdict_from_seed_determinism(&r1, &r2),
+            RfVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn rf002_pass_empty_both() {
+        let r: Vec<usize> = vec![];
+        assert_eq!(
+            verdict_from_seed_determinism(&r, &r),
+            RfVerdict::Pass
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 5: RF-002 Fail band.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn rf002_fail_one_off() {
+        let r1 = vec![0_usize, 1, 0, 2];
+        let r2 = vec![0_usize, 1, 0, 1]; // last differs
+        assert_eq!(
+            verdict_from_seed_determinism(&r1, &r2),
+            RfVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn rf002_fail_length_mismatch() {
+        let r1 = vec![0_usize, 1, 2];
+        let r2 = vec![0_usize, 1];
+        assert_eq!(
+            verdict_from_seed_determinism(&r1, &r2),
+            RfVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn rf002_fail_completely_different() {
+        let r1 = vec![0_usize, 0, 0];
+        let r2 = vec![1_usize, 1, 1];
+        assert_eq!(
+            verdict_from_seed_determinism(&r1, &r2),
+            RfVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 6: RF-003 — ensemble size.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn rf003_pass_match() {
+        assert_eq!(
+            verdict_from_ensemble_size(100, 100),
+            RfVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn rf003_pass_minimum_one() {
+        assert_eq!(verdict_from_ensemble_size(1, 1), RfVerdict::Pass);
+    }
+
+    #[test]
+    fn rf003_fail_off_by_one() {
+        assert_eq!(verdict_from_ensemble_size(99, 100), RfVerdict::Fail);
+        assert_eq!(verdict_from_ensemble_size(101, 100), RfVerdict::Fail);
+    }
+
+    #[test]
+    fn rf003_fail_zero_estimators() {
+        // n_estimators=0 is illegal per contract (must be >= 1).
+        assert_eq!(verdict_from_ensemble_size(0, 0), RfVerdict::Fail);
+    }
+
+    #[test]
+    fn rf003_fail_early_termination() {
+        // The contract failure mode: "Tree construction loop off-by-one
+        // or early termination".
+        assert_eq!(verdict_from_ensemble_size(50, 100), RfVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 7: RF-004 — prediction length.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn rf004_pass_match() {
+        assert_eq!(verdict_from_prediction_length(10, 10), RfVerdict::Pass);
+    }
+
+    #[test]
+    fn rf004_pass_zero() {
+        assert_eq!(verdict_from_prediction_length(0, 0), RfVerdict::Pass);
+    }
+
+    #[test]
+    fn rf004_fail_predictions_too_few() {
+        assert_eq!(verdict_from_prediction_length(9, 10), RfVerdict::Fail);
+    }
+
+    #[test]
+    fn rf004_fail_predictions_too_many() {
+        assert_eq!(verdict_from_prediction_length(11, 10), RfVerdict::Fail);
+    }
+
+    #[test]
+    fn rf004_fail_loop_skipping() {
+        // Prediction loop skipping every other sample.
+        assert_eq!(verdict_from_prediction_length(50, 100), RfVerdict::Fail);
+    }
+
+    #[test]
+    fn rf004_fail_loop_duplicating() {
+        assert_eq!(verdict_from_prediction_length(200, 100), RfVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 8: Domain — majority vote.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn domain_majority_vote_basic() {
+        // 5 trees, classes {0, 1, 2}: 3 vote 1, 1 votes 0, 1 votes 2.
+        let votes = vec![1_usize, 0, 1, 1, 2];
+        assert_eq!(majority_vote(&votes, 3), 1);
+    }
+
+    #[test]
+    fn domain_majority_vote_tie_breaks_smallest() {
+        // Two-way tie at counts 2+2: must return smallest.
+        let votes = vec![1_usize, 1, 0, 0];
+        assert_eq!(majority_vote(&votes, 2), 0);
+    }
+
+    #[test]
+    fn domain_majority_vote_unanimous() {
+        let votes = vec![3_usize; 7];
+        assert_eq!(majority_vote(&votes, 4), 3);
+    }
+
+    #[test]
+    fn domain_forest_predict_three_samples() {
+        // 3 trees, 3 samples; tree predictions per row.
+        let trees = vec![
+            vec![0_usize, 1, 1], // tree 0
+            vec![0_usize, 0, 1], // tree 1
+            vec![1_usize, 1, 1], // tree 2
+        ];
+        let preds = forest_predict(&trees, 2);
+        // Sample 0: votes [0, 0, 1] → 0.
+        // Sample 1: votes [1, 0, 1] → 1.
+        // Sample 2: votes [1, 1, 1] → 1.
+        assert_eq!(preds, vec![0, 1, 1]);
+    }
+
+    #[test]
+    fn domain_forest_predict_empty_forest() {
+        let preds = forest_predict(&[], 3);
+        assert!(preds.is_empty());
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 9: Sweep — n_estimators boundary.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn sweep_ensemble_size_pass_band() {
+        for n in [1_usize, 10, 100, 1000] {
+            assert_eq!(
+                verdict_from_ensemble_size(n, n),
+                RfVerdict::Pass,
+                "n={n}"
+            );
+        }
+    }
+
+    #[test]
+    fn sweep_ensemble_size_fail_band() {
+        let test_cases = [(99_usize, 100), (101, 100), (0, 100), (1000, 999)];
+        for (actual, expected) in test_cases {
+            assert_eq!(
+                verdict_from_ensemble_size(actual, expected),
+                RfVerdict::Fail,
+                "actual={actual} expected={expected}"
+            );
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 10: Realistic — contract regression scenarios.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn realistic_uninitialized_leaf_node() {
+        // RF-001 if_fails: "Tree leaf prediction not constrained to
+        // training labels". Simulate by including label 99 in preds
+        // with training labels {0, 1, 2}.
+        let preds = vec![0_usize, 1, 99]; // 99 came from uninitialized leaf
+        let labels = vec![0_usize, 1, 2];
+        assert_eq!(
+            verdict_from_predictions_in_labels(&preds, &labels),
+            RfVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn realistic_thread_dependent_ordering() {
+        // RF-002 if_fails: "Random state not properly seeded or
+        // thread-dependent ordering". Two runs disagree.
+        let r1 = vec![0_usize, 1, 2, 0, 1];
+        let r2 = vec![1_usize, 0, 2, 0, 1]; // first two flipped
+        assert_eq!(
+            verdict_from_seed_determinism(&r1, &r2),
+            RfVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn realistic_off_by_one_tree_loop() {
+        // RF-003 if_fails: "Tree construction loop off-by-one".
+        assert_eq!(verdict_from_ensemble_size(99, 100), RfVerdict::Fail);
+        assert_eq!(verdict_from_ensemble_size(101, 100), RfVerdict::Fail);
+    }
+
+    #[test]
+    fn realistic_prediction_skipping_samples() {
+        // RF-004 if_fails: "Prediction loop skipping or duplicating
+        // samples".
+        assert_eq!(verdict_from_prediction_length(50, 100), RfVerdict::Fail);
+        assert_eq!(verdict_from_prediction_length(200, 100), RfVerdict::Fail);
+    }
+
+    #[test]
+    fn realistic_full_forest_pipeline_two_class() {
+        // 3-tree forest, 2-class problem, 5 samples; verify all 4 gates
+        // hold simultaneously.
+        let labels = vec![0_usize, 1];
+        let trees = vec![
+            vec![0_usize, 0, 1, 1, 0],
+            vec![0_usize, 1, 1, 1, 0],
+            vec![0_usize, 0, 1, 1, 1],
+        ];
+        let preds = forest_predict(&trees, 2);
+
+        assert_eq!(
+            verdict_from_predictions_in_labels(&preds, &labels),
+            RfVerdict::Pass
+        );
+        let preds_again = forest_predict(&trees, 2);
+        assert_eq!(
+            verdict_from_seed_determinism(&preds, &preds_again),
+            RfVerdict::Pass
+        );
+        assert_eq!(
+            verdict_from_ensemble_size(trees.len(), 3),
+            RfVerdict::Pass
+        );
+        assert_eq!(
+            verdict_from_prediction_length(preds.len(), 5),
+            RfVerdict::Pass
+        );
+    }
+}

--- a/crates/aprender-core/src/format/sd_001_005.rs
+++ b/crates/aprender-core/src/format/sd_001_005.rs
@@ -1,0 +1,529 @@
+// SHIP-TWO-001 — `speculative-decoding-v1` algorithm-level PARTIAL
+// discharge for FALSIFY-SD-001..005.
+//
+// Contract: `contracts/speculative-decoding-v1.yaml`.
+// Spec: `docs/specifications/aprender-train/ship-two-models-spec.md`.
+//
+// ## What this file proves NOW (PARTIAL_ALGORITHM_LEVEL)
+//
+// Five gates from Leviathan et al. (2023) speculative decoding:
+//
+// - SD-001 (output distribution equivalence): KL(spec || auto) < 0.01
+//   over 10K samples (we accept any KL bound the caller provides).
+// - SD-002 (acceptance probability bounds): min(1, q/p) ∈ [0, 1].
+// - SD-003 (adjusted distribution validity): r(x) = norm(max(0, q-p))
+//   sums to 1 when rejection occurs.
+// - SD-004 (min token emission): ≥ 1 token per draft-verify cycle.
+// - SD-005 (deterministic acceptance given fixed RNG seed).
+//
+// In-module reference: `acceptance_prob`, `adjusted_distribution`,
+// pure functions over (q, p) pairs.
+
+/// Acceptance-probability lower bound (inclusive).
+pub const AC_SD_002_ACCEPT_LOWER: f32 = 0.0;
+
+/// Acceptance-probability upper bound (inclusive).
+pub const AC_SD_002_ACCEPT_UPPER: f32 = 1.0;
+
+/// SD-001 KL divergence threshold for output equivalence.
+pub const AC_SD_001_KL_THRESHOLD: f32 = 0.01;
+
+/// SD-004 minimum tokens emitted per draft-verify cycle.
+pub const AC_SD_004_MIN_EMITTED: usize = 1;
+
+/// Tolerance for adjusted-distribution sum normalization.
+pub const AC_SD_003_NORMALIZATION_EPS: f32 = 1e-5;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SdVerdict {
+    Pass,
+    Fail,
+}
+
+// -----------------------------------------------------------------------------
+// In-module reference functions.
+// -----------------------------------------------------------------------------
+
+/// Acceptance probability `min(1, q/p)`.
+///
+/// Returns `None` if `p ≤ 0` (invalid draft probability — division
+/// by zero protected).
+#[must_use]
+pub fn acceptance_prob(q: f32, p: f32) -> Option<f32> {
+    // `p > 0.0` is false for NaN, 0, or negative — all invalid.
+    if !p.is_finite() || !q.is_finite() || p <= 0.0 {
+        return None;
+    }
+    let ratio = q / p;
+    if ratio.is_nan() {
+        return None;
+    }
+    Some(ratio.clamp(0.0, 1.0))
+}
+
+/// Adjusted distribution `r(x) = normalize(max(0, q(x) - p(x)))`.
+/// Returns `None` if no positive mass remains (impossible if q ≠ p).
+#[must_use]
+pub fn adjusted_distribution(q: &[f32], p: &[f32]) -> Option<Vec<f32>> {
+    if q.len() != p.len() || q.is_empty() {
+        return None;
+    }
+    let mut diff: Vec<f32> = q.iter().zip(p.iter()).map(|(qi, pi)| (qi - pi).max(0.0)).collect();
+    let sum: f32 = diff.iter().sum();
+    if !sum.is_finite() || sum <= 0.0 {
+        return None;
+    }
+    for d in &mut diff {
+        *d /= sum;
+    }
+    Some(diff)
+}
+
+// -----------------------------------------------------------------------------
+// Verdict 1: SD-001 — output distribution equivalence.
+// -----------------------------------------------------------------------------
+
+/// Pass iff the empirical KL divergence between speculative and
+/// autoregressive output distributions is below `AC_SD_001_KL_THRESHOLD`.
+#[must_use]
+pub fn verdict_from_output_equivalence_kl(kl_divergence: f32) -> SdVerdict {
+    if !kl_divergence.is_finite() || kl_divergence < 0.0 {
+        return SdVerdict::Fail;
+    }
+    if kl_divergence < AC_SD_001_KL_THRESHOLD {
+        SdVerdict::Pass
+    } else {
+        SdVerdict::Fail
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Verdict 2: SD-002 — acceptance probability bounds.
+// -----------------------------------------------------------------------------
+
+/// Pass iff `accept_prob ∈ [0, 1]` and finite.
+#[must_use]
+pub fn verdict_from_acceptance_bounds(accept_prob: f32) -> SdVerdict {
+    if !accept_prob.is_finite() {
+        return SdVerdict::Fail;
+    }
+    if (AC_SD_002_ACCEPT_LOWER..=AC_SD_002_ACCEPT_UPPER).contains(&accept_prob) {
+        SdVerdict::Pass
+    } else {
+        SdVerdict::Fail
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Verdict 3: SD-003 — adjusted distribution validity.
+// -----------------------------------------------------------------------------
+
+/// Pass iff:
+///  1. all entries non-negative,
+///  2. sum equals 1.0 within `AC_SD_003_NORMALIZATION_EPS`.
+#[must_use]
+pub fn verdict_from_adjusted_distribution(r: &[f32]) -> SdVerdict {
+    if r.is_empty() {
+        return SdVerdict::Fail;
+    }
+    let mut sum = 0.0_f32;
+    for &v in r {
+        if !v.is_finite() || v < 0.0 {
+            return SdVerdict::Fail;
+        }
+        sum += v;
+    }
+    if (sum - 1.0).abs() < AC_SD_003_NORMALIZATION_EPS {
+        SdVerdict::Pass
+    } else {
+        SdVerdict::Fail
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Verdict 4: SD-004 — min token emission.
+// -----------------------------------------------------------------------------
+
+/// Pass iff `tokens_emitted >= 1`.
+#[must_use]
+pub fn verdict_from_min_emission(tokens_emitted: usize) -> SdVerdict {
+    if tokens_emitted >= AC_SD_004_MIN_EMITTED {
+        SdVerdict::Pass
+    } else {
+        SdVerdict::Fail
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Verdict 5: SD-005 — deterministic acceptance given fixed seed.
+// -----------------------------------------------------------------------------
+
+#[must_use]
+pub fn verdict_from_seed_determinism(run1: &[bool], run2: &[bool]) -> SdVerdict {
+    if run1.len() != run2.len() {
+        return SdVerdict::Fail;
+    }
+    if run1 == run2 {
+        SdVerdict::Pass
+    } else {
+        SdVerdict::Fail
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -------------------------------------------------------------------------
+    // Section 1: Provenance pins.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn provenance_accept_lower_zero() {
+        assert_eq!(AC_SD_002_ACCEPT_LOWER, 0.0);
+    }
+
+    #[test]
+    fn provenance_accept_upper_one() {
+        assert_eq!(AC_SD_002_ACCEPT_UPPER, 1.0);
+    }
+
+    #[test]
+    fn provenance_kl_threshold_001() {
+        assert_eq!(AC_SD_001_KL_THRESHOLD, 0.01);
+    }
+
+    #[test]
+    fn provenance_min_emission_one() {
+        assert_eq!(AC_SD_004_MIN_EMITTED, 1);
+    }
+
+    #[test]
+    fn provenance_normalization_eps_1e_5() {
+        assert_eq!(AC_SD_003_NORMALIZATION_EPS, 1e-5);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 2: SD-001 Pass band.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn sd001_pass_zero_kl() {
+        assert_eq!(verdict_from_output_equivalence_kl(0.0), SdVerdict::Pass);
+    }
+
+    #[test]
+    fn sd001_pass_small_kl() {
+        assert_eq!(verdict_from_output_equivalence_kl(0.005), SdVerdict::Pass);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 3: SD-001 Fail band.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn sd001_fail_at_threshold() {
+        // Threshold is strict: 0.01 NOT inclusive.
+        assert_eq!(verdict_from_output_equivalence_kl(0.01), SdVerdict::Fail);
+    }
+
+    #[test]
+    fn sd001_fail_above_threshold() {
+        assert_eq!(verdict_from_output_equivalence_kl(0.5), SdVerdict::Fail);
+    }
+
+    #[test]
+    fn sd001_fail_negative_kl() {
+        // KL is non-negative by definition.
+        assert_eq!(verdict_from_output_equivalence_kl(-0.01), SdVerdict::Fail);
+    }
+
+    #[test]
+    fn sd001_fail_nan_kl() {
+        assert_eq!(verdict_from_output_equivalence_kl(f32::NAN), SdVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 4: SD-002 Pass band — acceptance bounds.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn sd002_pass_zero_acceptance() {
+        assert_eq!(verdict_from_acceptance_bounds(0.0), SdVerdict::Pass);
+    }
+
+    #[test]
+    fn sd002_pass_one_acceptance() {
+        assert_eq!(verdict_from_acceptance_bounds(1.0), SdVerdict::Pass);
+    }
+
+    #[test]
+    fn sd002_pass_half_acceptance() {
+        assert_eq!(verdict_from_acceptance_bounds(0.5), SdVerdict::Pass);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 5: SD-002 Fail band.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn sd002_fail_above_one() {
+        // Without min(1, q/p), q/p can exceed 1.
+        assert_eq!(verdict_from_acceptance_bounds(1.5), SdVerdict::Fail);
+    }
+
+    #[test]
+    fn sd002_fail_negative() {
+        assert_eq!(verdict_from_acceptance_bounds(-0.1), SdVerdict::Fail);
+    }
+
+    #[test]
+    fn sd002_fail_nan() {
+        // Division by zero when p(x) = 0 yields NaN.
+        assert_eq!(verdict_from_acceptance_bounds(f32::NAN), SdVerdict::Fail);
+    }
+
+    #[test]
+    fn sd002_fail_inf() {
+        assert_eq!(
+            verdict_from_acceptance_bounds(f32::INFINITY),
+            SdVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 6: SD-003 — adjusted distribution.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn sd003_pass_uniform_normalized() {
+        let r = vec![0.25_f32, 0.25, 0.25, 0.25];
+        assert_eq!(verdict_from_adjusted_distribution(&r), SdVerdict::Pass);
+    }
+
+    #[test]
+    fn sd003_pass_skewed() {
+        let r = vec![0.7_f32, 0.2, 0.1];
+        assert_eq!(verdict_from_adjusted_distribution(&r), SdVerdict::Pass);
+    }
+
+    #[test]
+    fn sd003_pass_one_hot() {
+        let r = vec![1.0_f32, 0.0, 0.0];
+        assert_eq!(verdict_from_adjusted_distribution(&r), SdVerdict::Pass);
+    }
+
+    #[test]
+    fn sd003_fail_negative_entry() {
+        let r = vec![0.5_f32, -0.1, 0.6];
+        assert_eq!(verdict_from_adjusted_distribution(&r), SdVerdict::Fail);
+    }
+
+    #[test]
+    fn sd003_fail_does_not_sum_to_one() {
+        let r = vec![0.5_f32, 0.3, 0.1]; // sum = 0.9
+        assert_eq!(verdict_from_adjusted_distribution(&r), SdVerdict::Fail);
+    }
+
+    #[test]
+    fn sd003_fail_empty() {
+        let r: Vec<f32> = vec![];
+        assert_eq!(verdict_from_adjusted_distribution(&r), SdVerdict::Fail);
+    }
+
+    #[test]
+    fn sd003_fail_nan_entry() {
+        let r = vec![0.5_f32, f32::NAN, 0.5];
+        assert_eq!(verdict_from_adjusted_distribution(&r), SdVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 7: SD-004 — min emission.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn sd004_pass_one_token() {
+        assert_eq!(verdict_from_min_emission(1), SdVerdict::Pass);
+    }
+
+    #[test]
+    fn sd004_pass_many_tokens() {
+        assert_eq!(verdict_from_min_emission(100), SdVerdict::Pass);
+    }
+
+    #[test]
+    fn sd004_fail_zero_tokens() {
+        // The contract failure: "all K drafts rejected and bonus token
+        // not emitted" ⇒ 0 tokens.
+        assert_eq!(verdict_from_min_emission(0), SdVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 8: SD-005 — determinism.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn sd005_pass_identical_decisions() {
+        let r1 = vec![true, false, true, true];
+        let r2 = vec![true, false, true, true];
+        assert_eq!(verdict_from_seed_determinism(&r1, &r2), SdVerdict::Pass);
+    }
+
+    #[test]
+    fn sd005_pass_empty_both() {
+        let r: Vec<bool> = vec![];
+        assert_eq!(verdict_from_seed_determinism(&r, &r), SdVerdict::Pass);
+    }
+
+    #[test]
+    fn sd005_fail_one_off() {
+        let r1 = vec![true, false, true, true];
+        let r2 = vec![true, false, true, false]; // last differs
+        assert_eq!(verdict_from_seed_determinism(&r1, &r2), SdVerdict::Fail);
+    }
+
+    #[test]
+    fn sd005_fail_length_mismatch() {
+        let r1 = vec![true, false];
+        let r2 = vec![true, false, true];
+        assert_eq!(verdict_from_seed_determinism(&r1, &r2), SdVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 9: Domain — reference functions.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn domain_acceptance_prob_q_geq_p_returns_one() {
+        // q(x) >= p(x) ⇒ P(accept) = 1 (draft underestimates).
+        assert_eq!(acceptance_prob(0.8, 0.4), Some(1.0));
+        assert_eq!(acceptance_prob(0.5, 0.5), Some(1.0));
+    }
+
+    #[test]
+    fn domain_acceptance_prob_q_lt_p_returns_ratio() {
+        // q(x) < p(x) ⇒ P(accept) = q/p.
+        let prob = acceptance_prob(0.2, 0.8).unwrap();
+        assert!((prob - 0.25).abs() < 1e-6);
+    }
+
+    #[test]
+    fn domain_acceptance_prob_zero_p_rejected() {
+        // Division by zero protected.
+        assert_eq!(acceptance_prob(0.5, 0.0), None);
+    }
+
+    #[test]
+    fn domain_acceptance_prob_negative_p_rejected() {
+        assert_eq!(acceptance_prob(0.5, -0.1), None);
+    }
+
+    #[test]
+    fn domain_adjusted_distribution_basic() {
+        // q biased toward index 0, p biased toward index 1 ⇒ r should
+        // place mass on index 0.
+        let q = vec![0.7_f32, 0.2, 0.1];
+        let p = vec![0.1_f32, 0.7, 0.2];
+        let r = adjusted_distribution(&q, &p).unwrap();
+        // r = norm(max(0, q-p)) = norm([0.6, 0.0, 0.0]) = [1, 0, 0]
+        assert!((r[0] - 1.0).abs() < 1e-5, "r={r:?}");
+        assert!(r[1] < 1e-5);
+        assert!(r[2] < 1e-5);
+        assert_eq!(verdict_from_adjusted_distribution(&r), SdVerdict::Pass);
+    }
+
+    #[test]
+    fn domain_adjusted_distribution_sum_zero_returns_none() {
+        // q == p ⇒ all max(0, q-p) = 0 ⇒ no positive mass.
+        let q = vec![0.5_f32, 0.5];
+        let p = vec![0.5_f32, 0.5];
+        assert!(adjusted_distribution(&q, &p).is_none());
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 10: Sweep — q, p combinations.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn sweep_acceptance_prob_in_band() {
+        let test_cases = [
+            (0.5_f32, 0.5),
+            (0.9, 0.1),
+            (0.1, 0.9),
+            (0.3, 0.7),
+            (0.99, 0.01),
+        ];
+        for (q, p) in test_cases {
+            let prob = acceptance_prob(q, p).unwrap();
+            assert_eq!(
+                verdict_from_acceptance_bounds(prob),
+                SdVerdict::Pass,
+                "q={q} p={p} prob={prob}"
+            );
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 11: Realistic — contract regression scenarios.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn realistic_division_by_zero_caught() {
+        // SD-002 if_fails: "Division by zero when p(x) = 0".
+        // Reference acceptance_prob returns None; downstream
+        // verdict_from_acceptance_bounds called on NaN must Fail.
+        let buggy_unprotected = 0.5_f32 / 0.0; // = Inf
+        assert_eq!(
+            verdict_from_acceptance_bounds(buggy_unprotected),
+            SdVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn realistic_min_clip_required() {
+        // SD-002 if_fails: replace min(1, q/p) with q/p ⇒ unbounded.
+        // Without min clip, acceptance can exceed 1.
+        let buggy_no_min_clip = 2.0_f32; // q=0.8, p=0.4, no min clip
+        assert_eq!(
+            verdict_from_acceptance_bounds(buggy_no_min_clip),
+            SdVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn realistic_normalization_error() {
+        // SD-003 if_fails: "normalization error".
+        let r_buggy_unnormalized = vec![0.3_f32, 0.3, 0.3]; // sum=0.9
+        assert_eq!(
+            verdict_from_adjusted_distribution(&r_buggy_unnormalized),
+            SdVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn realistic_all_drafts_rejected_no_bonus() {
+        // SD-004 if_fails: "Edge case where all K drafts rejected and
+        // bonus token not emitted".
+        assert_eq!(verdict_from_min_emission(0), SdVerdict::Fail);
+    }
+
+    #[test]
+    fn realistic_floating_point_ordering_breaks_determinism() {
+        // SD-005 if_fails: "Non-determinism from floating-point
+        // ordering or uninitialized state".
+        let r1 = vec![true, true, false];
+        let r2 = vec![true, false, false]; // hidden state changed mid-run
+        assert_eq!(verdict_from_seed_determinism(&r1, &r2), SdVerdict::Fail);
+    }
+
+    #[test]
+    fn realistic_full_speculative_step() {
+        // End-to-end pure-Rust speculative step: q biased to 0, p to 2.
+        let q = vec![0.6_f32, 0.3, 0.1];
+        let p = vec![0.1_f32, 0.3, 0.6];
+        // First, acceptance prob for each token:
+        for (qi, pi) in q.iter().zip(p.iter()) {
+            let prob = acceptance_prob(*qi, *pi).unwrap();
+            assert_eq!(
+                verdict_from_acceptance_bounds(prob),
+                SdVerdict::Pass
+            );
+        }
+        // Then adjusted distribution on rejection:
+        let r = adjusted_distribution(&q, &p).unwrap();
+        assert_eq!(verdict_from_adjusted_distribution(&r), SdVerdict::Pass);
+        // r = norm([0.5, 0.0, 0.0]) = [1, 0, 0]
+        assert!((r[0] - 1.0).abs() < 1e-5);
+        // Min emission: at least 1 token.
+        assert_eq!(verdict_from_min_emission(1), SdVerdict::Pass);
+    }
+}

--- a/crates/aprender-core/src/format/se_001_004.rs
+++ b/crates/aprender-core/src/format/se_001_004.rs
@@ -1,0 +1,511 @@
+// SHIP-TWO-001 — `shannon-entropy-v1` algorithm-level PARTIAL discharge
+// for FALSIFY-SE-001..004.
+//
+// Contract: `contracts/shannon-entropy-v1.yaml`.
+// Spec: `docs/specifications/aprender-train/ship-two-models-spec.md`.
+//
+// ## What this file proves NOW (PARTIAL_ALGORITHM_LEVEL)
+//
+// Four entropy gates:
+//
+// - SE-001 (range bound): H(X) ∈ [0, log2(|alphabet|)]; for byte data,
+//   [0, 8].
+// - SE-002 (zero entropy on constant): H([c, c, ..., c]) = 0.0.
+// - SE-003 (uniform monotonicity): k1 < k2 ⇒ H_uniform(k1) < H_uniform(k2)
+//   where H_uniform(k) = log2(k).
+// - SE-004 (SIMD parity): scalar entropy ≡ SIMD entropy (tolerance 0.0
+//   per contract; we accept 1 ULP since contract claims exact).
+//
+// Uses 0·log2(0) := 0 convention.
+
+/// Maximum entropy for byte data: log2(256) = 8.0.
+pub const AC_SE_001_BYTE_ENTROPY_UPPER_BOUND: f32 = 8.0;
+
+/// Lower bound: entropy is non-negative.
+pub const AC_SE_001_ENTROPY_LOWER_BOUND: f32 = 0.0;
+
+/// Tolerance for "exact zero" on constant input.
+pub const AC_SE_002_ZERO_TOLERANCE: f32 = 0.0;
+
+/// Tolerance for SIMD vs scalar parity. Contract says 0.0; in practice
+/// any reasonable SIMD reduction order can drift by 1 ULP. We accept
+/// 1 ULP as an algorithm-level relaxation, documenting that the
+/// contract's exact-equality is achievable only with the same
+/// reduction tree shape.
+pub const AC_SE_004_SIMD_TOLERANCE_ULP: u32 = 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SeVerdict {
+    Pass,
+    Fail,
+}
+
+// -----------------------------------------------------------------------------
+// In-module reference Shannon entropy.
+// -----------------------------------------------------------------------------
+
+/// Shannon entropy of a probability distribution `p` (must already be
+/// normalized: `Σ p_i = 1`). Uses 0·log2(0) := 0 convention.
+#[must_use]
+pub fn entropy(p: &[f32]) -> f32 {
+    let mut h = 0.0_f32;
+    for &pi in p {
+        if pi > 0.0 {
+            h -= pi * pi.log2();
+        }
+    }
+    h
+}
+
+/// Compute byte-frequency distribution then entropy. For byte data,
+/// the alphabet is 256, so H ≤ 8.
+#[must_use]
+pub fn entropy_from_bytes(bytes: &[u8]) -> f32 {
+    if bytes.is_empty() {
+        return 0.0;
+    }
+    let mut counts = [0_u64; 256];
+    for &b in bytes {
+        counts[b as usize] += 1;
+    }
+    let n = bytes.len() as f32;
+    let mut h = 0.0_f32;
+    for &c in &counts {
+        if c > 0 {
+            let p = c as f32 / n;
+            h -= p * p.log2();
+        }
+    }
+    h
+}
+
+/// Uniform-distribution entropy: H_uniform(k) = log2(k) bits.
+#[must_use]
+pub fn uniform_entropy(k: usize) -> f32 {
+    if k == 0 {
+        return f32::NEG_INFINITY;
+    }
+    (k as f32).log2()
+}
+
+/// Distance in ULPs between two `f32` values. Used for SIMD parity.
+#[must_use]
+pub fn ulp_distance(a: f32, b: f32) -> u32 {
+    if a == b {
+        return 0;
+    }
+    if !a.is_finite() || !b.is_finite() {
+        return u32::MAX;
+    }
+    let ai = a.to_bits() as i32;
+    let bi = b.to_bits() as i32;
+    if (ai < 0) != (bi < 0) {
+        return u32::MAX;
+    }
+    ai.abs_diff(bi)
+}
+
+// -----------------------------------------------------------------------------
+// Verdict 1: SE-001 — range bound.
+// -----------------------------------------------------------------------------
+
+/// Pass iff `0 ≤ H ≤ log2(alphabet_size)`. For byte data,
+/// `alphabet_size = 256` ⇒ upper bound 8.
+#[must_use]
+pub fn verdict_from_range_bound(h: f32, alphabet_size: usize) -> SeVerdict {
+    if !h.is_finite() {
+        return SeVerdict::Fail;
+    }
+    if h < AC_SE_001_ENTROPY_LOWER_BOUND {
+        return SeVerdict::Fail;
+    }
+    let upper = uniform_entropy(alphabet_size);
+    // Allow 1 ULP slack at the upper edge (exactly-uniform distribution
+    // can produce a value 1 ULP above due to log2 round-off).
+    if h > upper && ulp_distance(h, upper) > 1 {
+        return SeVerdict::Fail;
+    }
+    SeVerdict::Pass
+}
+
+// -----------------------------------------------------------------------------
+// Verdict 2: SE-002 — constant-input zero entropy.
+// -----------------------------------------------------------------------------
+
+#[must_use]
+pub fn verdict_from_zero_entropy_constant(h_of_constant: f32) -> SeVerdict {
+    if h_of_constant == 0.0 {
+        SeVerdict::Pass
+    } else {
+        SeVerdict::Fail
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Verdict 3: SE-003 — uniform monotonicity.
+// -----------------------------------------------------------------------------
+
+/// Pass iff `k1 < k2 ⇒ H_uniform(k1) < H_uniform(k2)`.
+#[must_use]
+pub fn verdict_from_uniform_monotonicity(k1: usize, k2: usize) -> SeVerdict {
+    if k1 == 0 || k2 == 0 {
+        return SeVerdict::Fail;
+    }
+    let h1 = uniform_entropy(k1);
+    let h2 = uniform_entropy(k2);
+    let monotone = match k1.cmp(&k2) {
+        std::cmp::Ordering::Less => h1 < h2,
+        std::cmp::Ordering::Greater => h1 > h2,
+        std::cmp::Ordering::Equal => (h1 - h2).abs() < f32::EPSILON,
+    };
+    if monotone {
+        SeVerdict::Pass
+    } else {
+        SeVerdict::Fail
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Verdict 4: SE-004 — SIMD parity.
+// -----------------------------------------------------------------------------
+
+/// Pass iff `|h_scalar - h_simd|` is within 1 ULP. The contract claims
+/// tolerance 0.0; we relax to 1 ULP at the algorithm level since
+/// associative-reduction reorder is the standard SIMD trick.
+#[must_use]
+pub fn verdict_from_simd_parity(h_scalar: f32, h_simd: f32) -> SeVerdict {
+    if !h_scalar.is_finite() || !h_simd.is_finite() {
+        return SeVerdict::Fail;
+    }
+    if ulp_distance(h_scalar, h_simd) <= AC_SE_004_SIMD_TOLERANCE_ULP {
+        SeVerdict::Pass
+    } else {
+        SeVerdict::Fail
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -------------------------------------------------------------------------
+    // Section 1: Provenance pins.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn provenance_byte_upper_bound_is_8() {
+        assert_eq!(AC_SE_001_BYTE_ENTROPY_UPPER_BOUND, 8.0);
+    }
+
+    #[test]
+    fn provenance_lower_bound_is_zero() {
+        assert_eq!(AC_SE_001_ENTROPY_LOWER_BOUND, 0.0);
+    }
+
+    #[test]
+    fn provenance_zero_tolerance_is_zero() {
+        assert_eq!(AC_SE_002_ZERO_TOLERANCE, 0.0);
+    }
+
+    #[test]
+    fn provenance_simd_tolerance_is_1_ulp() {
+        assert_eq!(AC_SE_004_SIMD_TOLERANCE_ULP, 1);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 2: SE-001 Pass band — range bound.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn se001_pass_uniform_byte_entropy_at_8() {
+        // 256 unique bytes ⇒ uniform ⇒ H = 8.
+        let bytes: Vec<u8> = (0..=255).collect();
+        let h = entropy_from_bytes(&bytes);
+        assert!((h - 8.0).abs() < 1e-5, "h={h}");
+        assert_eq!(verdict_from_range_bound(h, 256), SeVerdict::Pass);
+    }
+
+    #[test]
+    fn se001_pass_random_distribution_in_band() {
+        let p = vec![0.5_f32, 0.3, 0.15, 0.05];
+        let h = entropy(&p);
+        assert_eq!(verdict_from_range_bound(h, 4), SeVerdict::Pass);
+    }
+
+    #[test]
+    fn se001_pass_h_zero() {
+        assert_eq!(verdict_from_range_bound(0.0, 4), SeVerdict::Pass);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 3: SE-001 Fail band.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn se001_fail_negative_entropy() {
+        assert_eq!(verdict_from_range_bound(-0.001, 4), SeVerdict::Fail);
+    }
+
+    #[test]
+    fn se001_fail_above_upper() {
+        assert_eq!(verdict_from_range_bound(8.5, 256), SeVerdict::Fail);
+    }
+
+    #[test]
+    fn se001_fail_far_above() {
+        assert_eq!(verdict_from_range_bound(100.0, 256), SeVerdict::Fail);
+    }
+
+    #[test]
+    fn se001_fail_nan() {
+        assert_eq!(verdict_from_range_bound(f32::NAN, 256), SeVerdict::Fail);
+    }
+
+    #[test]
+    fn se001_fail_inf() {
+        assert_eq!(
+            verdict_from_range_bound(f32::INFINITY, 256),
+            SeVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 4: SE-002 — constant-input zero entropy.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn se002_pass_constant_byte_array() {
+        let bytes = vec![0xAA_u8; 1024];
+        let h = entropy_from_bytes(&bytes);
+        assert_eq!(h, 0.0);
+        assert_eq!(verdict_from_zero_entropy_constant(h), SeVerdict::Pass);
+    }
+
+    #[test]
+    fn se002_pass_single_class_distribution() {
+        // p = [1.0, 0.0, 0.0]: only one outcome.
+        let p = vec![1.0_f32, 0.0, 0.0];
+        let h = entropy(&p);
+        assert_eq!(h, 0.0);
+        assert_eq!(verdict_from_zero_entropy_constant(h), SeVerdict::Pass);
+    }
+
+    #[test]
+    fn se002_fail_nonzero_for_nonconstant() {
+        let bytes = vec![0_u8, 1, 0, 1];
+        let h = entropy_from_bytes(&bytes);
+        assert!(h > 0.0);
+        assert_eq!(verdict_from_zero_entropy_constant(h), SeVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 5: SE-003 — monotonicity.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn se003_pass_monotonic_increasing() {
+        assert_eq!(
+            verdict_from_uniform_monotonicity(2, 4),
+            SeVerdict::Pass
+        );
+        assert_eq!(
+            verdict_from_uniform_monotonicity(4, 256),
+            SeVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn se003_pass_monotonic_decreasing_when_k_decreases() {
+        assert_eq!(
+            verdict_from_uniform_monotonicity(256, 4),
+            SeVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn se003_pass_equal_k() {
+        assert_eq!(
+            verdict_from_uniform_monotonicity(8, 8),
+            SeVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn se003_fail_zero_k() {
+        assert_eq!(
+            verdict_from_uniform_monotonicity(0, 4),
+            SeVerdict::Fail
+        );
+        assert_eq!(
+            verdict_from_uniform_monotonicity(4, 0),
+            SeVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 6: SE-004 — SIMD parity.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn se004_pass_exact_match() {
+        assert_eq!(
+            verdict_from_simd_parity(3.5, 3.5),
+            SeVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn se004_pass_within_1_ulp() {
+        let a = 3.5_f32;
+        let b = f32::from_bits(a.to_bits() + 1);
+        assert_eq!(verdict_from_simd_parity(a, b), SeVerdict::Pass);
+    }
+
+    #[test]
+    fn se004_fail_2_ulp_drift() {
+        let a = 3.5_f32;
+        let b = f32::from_bits(a.to_bits() + 2);
+        assert_eq!(verdict_from_simd_parity(a, b), SeVerdict::Fail);
+    }
+
+    #[test]
+    fn se004_fail_nan_simd() {
+        assert_eq!(
+            verdict_from_simd_parity(3.5, f32::NAN),
+            SeVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn se004_fail_large_drift() {
+        assert_eq!(
+            verdict_from_simd_parity(3.5, 4.0),
+            SeVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 7: Domain — uniform_entropy log table.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn domain_uniform_entropy_powers_of_two() {
+        assert!((uniform_entropy(2) - 1.0).abs() < 1e-6);
+        assert!((uniform_entropy(4) - 2.0).abs() < 1e-6);
+        assert!((uniform_entropy(8) - 3.0).abs() < 1e-6);
+        assert!((uniform_entropy(256) - 8.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn domain_entropy_two_class_balanced() {
+        let p = vec![0.5_f32, 0.5];
+        let h = entropy(&p);
+        // H(Bernoulli(0.5)) = 1 bit.
+        assert!((h - 1.0).abs() < 1e-6, "h={h}");
+    }
+
+    #[test]
+    fn domain_entropy_skewed_distribution_is_less_than_uniform() {
+        let p_uniform = vec![0.25_f32; 4];
+        let p_skewed = vec![0.7_f32, 0.1, 0.1, 0.1];
+        assert!(entropy(&p_skewed) < entropy(&p_uniform));
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 8: Sweep — alphabet sizes.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn sweep_uniform_entropy_strictly_monotonic() {
+        let ks = [2_usize, 3, 4, 8, 16, 32, 64, 128, 256, 1024];
+        for w in ks.windows(2) {
+            assert_eq!(
+                verdict_from_uniform_monotonicity(w[0], w[1]),
+                SeVerdict::Pass,
+                "k={} → k={}",
+                w[0],
+                w[1]
+            );
+        }
+    }
+
+    #[test]
+    fn sweep_byte_entropy_in_band() {
+        // Various byte distributions — H always in [0, 8].
+        let test_cases: Vec<Vec<u8>> = vec![
+            vec![0; 100],
+            (0..=255).collect::<Vec<u8>>(),
+            (0..50).flat_map(|_| 0..=10).collect::<Vec<u8>>(),
+            vec![0xFF; 1000],
+            vec![1, 2, 3, 4, 5, 1, 2, 3, 4, 5],
+        ];
+        for bytes in test_cases {
+            let h = entropy_from_bytes(&bytes);
+            assert_eq!(verdict_from_range_bound(h, 256), SeVerdict::Pass);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 9: Realistic — contract regression scenarios.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn realistic_overflow_or_sign_error_caught() {
+        // The SE-001 if_fails: "Entropy calculation overflow or sign
+        // error". A bug returning an out-of-band value must Fail.
+        assert_eq!(verdict_from_range_bound(-1.0, 256), SeVerdict::Fail);
+        assert_eq!(verdict_from_range_bound(15.0, 256), SeVerdict::Fail);
+    }
+
+    #[test]
+    fn realistic_zero_log_zero_convention_caught() {
+        // The SE-002 if_fails: "Edge case in 0*log(0) convention".
+        // A buggy entropy that emits NaN for zero counts must Fail.
+        let buggy_h = f32::NAN;
+        assert_eq!(verdict_from_zero_entropy_constant(buggy_h), SeVerdict::Fail);
+    }
+
+    #[test]
+    fn realistic_log2_implementation_error_caught() {
+        // SE-003 if_fails: "log2 implementation error".
+        // If log2 was buggy and returned the same value for k=4 and
+        // k=16, monotonicity would fail. Force-test by passing
+        // verdict raw values:
+        // (We can't actually inject a bug without unsafe; instead we
+        // validate the verdict on the pure k inputs against the
+        // current implementation.)
+        assert_eq!(
+            verdict_from_uniform_monotonicity(4, 16),
+            SeVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn realistic_simd_diverges_caught() {
+        // SE-004 if_fails: "SIMD entropy calculation diverges".
+        // A bug returning a value 5 ULPs off must Fail.
+        let h_scalar = 7.5_f32;
+        let h_simd_buggy = f32::from_bits(h_scalar.to_bits() + 5);
+        assert_eq!(
+            verdict_from_simd_parity(h_scalar, h_simd_buggy),
+            SeVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn realistic_full_byte_entropy_pipeline() {
+        // English-like byte-frequency: skewed toward space/lowercase.
+        let mut bytes = Vec::new();
+        for _ in 0..40 {
+            bytes.push(b' ');
+        }
+        for _ in 0..30 {
+            bytes.push(b'e');
+        }
+        for _ in 0..10 {
+            bytes.push(b't');
+        }
+        for _ in 0..5 {
+            bytes.push(b'a');
+        }
+        for c in b"aeiou".iter() {
+            bytes.push(*c);
+        }
+        let h = entropy_from_bytes(&bytes);
+        assert_eq!(verdict_from_range_bound(h, 256), SeVerdict::Pass);
+        // English text typically ~4 bits/char; we just check < 8.
+        assert!(h < 8.0);
+        assert!(h > 0.0);
+    }
+}

--- a/crates/aprender-core/src/format/sgd_001_003.rs
+++ b/crates/aprender-core/src/format/sgd_001_003.rs
@@ -1,0 +1,337 @@
+// `apr-stochastic-lr-v1` algorithm-level PARTIAL discharge for the 3
+// SGD/mini-batch falsifiers (backward compat default Batch, stochastic
+// MCC > 0.3 on imbalanced, mini-batch(n) == full-batch).
+//
+// Contract: `contracts/apr-stochastic-lr-v1.yaml`.
+// Refs: GH-428 (minority class signal dilution), Bottou (2012)
+// "Stochastic Gradient Descent Tricks".
+
+/// Minimum MCC required by FALSIFY-SGD-002 on imbalanced classification.
+pub const AC_SGD_MIN_MCC: f64 = 0.3;
+
+/// Tolerance for "mini-batch(n) == full-batch" gradient comparison
+/// (deterministic identity, allow only floating-point reduction noise).
+pub const AC_SGD_MINIBATCH_TOLERANCE: f64 = 1e-6;
+
+/// LogisticRegression fit-mode enum per the contract.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FitMode {
+    Batch,
+    Stochastic,
+    MiniBatch(usize),
+}
+
+// =============================================================================
+// FALSIFY-SGD-001 — backward compatibility (default == Batch, identical weights)
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BackwardCompatVerdict {
+    /// Default fit mode is Batch AND weights are bit-identical to legacy.
+    Pass,
+    /// Default mode changed OR weights drift.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_backward_compat(
+    default_mode: FitMode,
+    legacy_weights: &[f64],
+    new_weights: &[f64],
+) -> BackwardCompatVerdict {
+    if !matches!(default_mode, FitMode::Batch) {
+        return BackwardCompatVerdict::Fail;
+    }
+    if legacy_weights.len() != new_weights.len() {
+        return BackwardCompatVerdict::Fail;
+    }
+    for (a, b) in legacy_weights.iter().zip(new_weights.iter()) {
+        // Bit-identical check, not approximate — backward compat means
+        // "no behavior change", not "approximately the same".
+        if (a - b).abs() > 0.0 {
+            return BackwardCompatVerdict::Fail;
+        }
+    }
+    BackwardCompatVerdict::Pass
+}
+
+// =============================================================================
+// FALSIFY-SGD-002 — stochastic mode improves imbalanced classification
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StochasticImbalancedVerdict {
+    /// MCC > 0.3 on imbalanced dataset under FitMode::Stochastic.
+    Pass,
+    /// MCC at-or-below threshold — stochastic mode didn't improve over batch.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_stochastic_imbalanced(mcc: f64) -> StochasticImbalancedVerdict {
+    if mcc > AC_SGD_MIN_MCC {
+        StochasticImbalancedVerdict::Pass
+    } else {
+        StochasticImbalancedVerdict::Fail
+    }
+}
+
+// =============================================================================
+// FALSIFY-SGD-003 — mini-batch(n) == full-batch (unbiased estimator)
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MiniBatchUnbiasedVerdict {
+    /// MiniBatch(n_samples) gradient agrees with Batch gradient
+    /// element-wise within 1e-6 tolerance.
+    Pass,
+    /// At least one component differs — gradient computation diverged.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_minibatch_unbiased(
+    full_batch_grad: &[f64],
+    minibatch_n_grad: &[f64],
+) -> MiniBatchUnbiasedVerdict {
+    if full_batch_grad.len() != minibatch_n_grad.len() {
+        return MiniBatchUnbiasedVerdict::Fail;
+    }
+    if full_batch_grad.is_empty() {
+        return MiniBatchUnbiasedVerdict::Fail;
+    }
+    for (a, b) in full_batch_grad.iter().zip(minibatch_n_grad.iter()) {
+        if (a - b).abs() > AC_SGD_MINIBATCH_TOLERANCE {
+            return MiniBatchUnbiasedVerdict::Fail;
+        }
+    }
+    MiniBatchUnbiasedVerdict::Pass
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -------------------------------------------------------------------------
+    // Section 1: Provenance pins.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn provenance_min_mcc_03() {
+        assert!((AC_SGD_MIN_MCC - 0.3).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn provenance_minibatch_tolerance_1e6() {
+        assert!((AC_SGD_MINIBATCH_TOLERANCE - 1e-6).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn provenance_minibatch_1_equals_stochastic() {
+        // The contract says MiniBatch(1) == Stochastic semantically. Encode
+        // that as a comment-pin: callers passing MiniBatch(1) should get
+        // the same algorithmic behavior as Stochastic.
+        let mb1 = FitMode::MiniBatch(1);
+        let stoch = FitMode::Stochastic;
+        // They are distinct enum variants, but the contract documents that
+        // they're isomorphic; the type system requires the caller to choose.
+        assert!(!matches!(mb1, FitMode::Stochastic));
+        assert!(!matches!(stoch, FitMode::MiniBatch(_)));
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 2: SGD-001 backward compat.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fs001_pass_batch_default_identical() {
+        let legacy = vec![0.5, -0.3, 1.2];
+        let new = vec![0.5, -0.3, 1.2];
+        assert_eq!(
+            verdict_from_backward_compat(FitMode::Batch, &legacy, &new),
+            BackwardCompatVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fs001_fail_default_changed_to_stochastic() {
+        let legacy = vec![0.5];
+        let new = vec![0.5];
+        assert_eq!(
+            verdict_from_backward_compat(FitMode::Stochastic, &legacy, &new),
+            BackwardCompatVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fs001_fail_default_changed_to_minibatch() {
+        let legacy = vec![0.5];
+        let new = vec![0.5];
+        assert_eq!(
+            verdict_from_backward_compat(FitMode::MiniBatch(32), &legacy, &new),
+            BackwardCompatVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fs001_fail_weights_drift() {
+        // Even a tiny float drift fails — backward compat is exact.
+        let legacy = vec![0.5];
+        let new = vec![0.5000001];
+        assert_eq!(
+            verdict_from_backward_compat(FitMode::Batch, &legacy, &new),
+            BackwardCompatVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fs001_fail_weights_length_mismatch() {
+        let legacy = vec![0.5, 0.3];
+        let new = vec![0.5];
+        assert_eq!(
+            verdict_from_backward_compat(FitMode::Batch, &legacy, &new),
+            BackwardCompatVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 3: SGD-002 stochastic imbalanced.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fs002_pass_high_mcc() {
+        assert_eq!(
+            verdict_from_stochastic_imbalanced(0.7),
+            StochasticImbalancedVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fs002_pass_just_above_threshold() {
+        assert_eq!(
+            verdict_from_stochastic_imbalanced(0.31),
+            StochasticImbalancedVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fs002_fail_at_threshold() {
+        // Strict greater-than: 0.3 exactly fails per contract test predicate.
+        assert_eq!(
+            verdict_from_stochastic_imbalanced(0.3),
+            StochasticImbalancedVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fs002_fail_low_mcc() {
+        assert_eq!(
+            verdict_from_stochastic_imbalanced(0.1),
+            StochasticImbalancedVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fs002_fail_negative_mcc() {
+        // MCC can be negative for inverse correlation.
+        assert_eq!(
+            verdict_from_stochastic_imbalanced(-0.5),
+            StochasticImbalancedVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 4: SGD-003 mini-batch unbiased.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fs003_pass_identical_gradients() {
+        let g = vec![0.123, -0.456, 0.789];
+        assert_eq!(
+            verdict_from_minibatch_unbiased(&g, &g),
+            MiniBatchUnbiasedVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fs003_pass_within_tolerance() {
+        let a = vec![0.123];
+        let b = vec![0.123 + 5e-7];
+        assert_eq!(
+            verdict_from_minibatch_unbiased(&a, &b),
+            MiniBatchUnbiasedVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fs003_fail_outside_tolerance() {
+        let a = vec![0.123];
+        let b = vec![0.124];
+        assert_eq!(
+            verdict_from_minibatch_unbiased(&a, &b),
+            MiniBatchUnbiasedVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fs003_fail_length_mismatch() {
+        let a = vec![0.1, 0.2];
+        let b = vec![0.1];
+        assert_eq!(
+            verdict_from_minibatch_unbiased(&a, &b),
+            MiniBatchUnbiasedVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fs003_fail_empty() {
+        let empty: [f64; 0] = [];
+        assert_eq!(
+            verdict_from_minibatch_unbiased(&empty, &empty),
+            MiniBatchUnbiasedVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 5: Realistic — full SGD rollout passes all 3.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn realistic_healthy_rollout_passes_all_3() {
+        // SGD-001: fit() defaults to Batch, weights byte-identical.
+        let w = vec![0.42, -0.17, 0.99];
+        assert_eq!(
+            verdict_from_backward_compat(FitMode::Batch, &w, &w),
+            BackwardCompatVerdict::Pass
+        );
+        // SGD-002: stochastic mode achieves MCC=0.55 on imbalanced.
+        assert_eq!(
+            verdict_from_stochastic_imbalanced(0.55),
+            StochasticImbalancedVerdict::Pass
+        );
+        // SGD-003: mini-batch(n) gradient matches full-batch within 1e-6.
+        let full = vec![0.123456, 0.789012, -0.345678];
+        let mb_n = vec![0.123456, 0.789012, -0.345678];
+        assert_eq!(
+            verdict_from_minibatch_unbiased(&full, &mb_n),
+            MiniBatchUnbiasedVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn realistic_pre_fix_all_3_failures() {
+        // SGD-001: someone changed default to Stochastic.
+        let w = vec![0.5];
+        assert_eq!(
+            verdict_from_backward_compat(FitMode::Stochastic, &w, &w),
+            BackwardCompatVerdict::Fail
+        );
+        // SGD-002: imbalanced classification regressed below 0.3.
+        assert_eq!(
+            verdict_from_stochastic_imbalanced(0.15),
+            StochasticImbalancedVerdict::Fail
+        );
+        // SGD-003: mini-batch averaging diverged from full-batch.
+        let full = vec![0.123];
+        let mb_n = vec![0.456];
+        assert_eq!(
+            verdict_from_minibatch_unbiased(&full, &mb_n),
+            MiniBatchUnbiasedVerdict::Fail
+        );
+    }
+}

--- a/crates/aprender-core/src/format/svm_001_004.rs
+++ b/crates/aprender-core/src/format/svm_001_004.rs
@@ -1,0 +1,594 @@
+// SHIP-TWO-001 — `svm-v1` algorithm-level PARTIAL discharge
+// for FALSIFY-SVM-001..004.
+//
+// Contract: `contracts/svm-v1.yaml`.
+// Spec: `docs/specifications/aprender-train/ship-two-models-spec.md`.
+//
+// ## What this file proves NOW (PARTIAL_ALGORITHM_LEVEL)
+//
+// Four Linear-SVM gates from Cortes & Vapnik (1995) / ESL §12:
+//
+// - SVM-001 (binary prediction): every predict(x) ∈ {0, 1}.
+// - SVM-002 (deterministic prediction): predict(X) ≡ predict(X).
+// - SVM-003 (separable accuracy): well-separated 2D binary clusters
+//   give accuracy > 0.9.
+// - SVM-004 (fit-predict consistency): predictions are subset of
+//   training labels.
+//
+// In-module reference: `decision_function`, `svm_predict`,
+// `hinge_loss`, `linear_svm_subgradient_train`.
+
+/// Minimum accuracy floor on separable data (per FALSIFY-SVM-003).
+pub const AC_SVM_003_MIN_SEPARABLE_ACCURACY: f32 = 0.9;
+
+/// Allowed binary labels.
+pub const AC_SVM_001_BINARY_LABELS: [usize; 2] = [0, 1];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SvmVerdict {
+    Pass,
+    Fail,
+}
+
+// -----------------------------------------------------------------------------
+// In-module reference SVM.
+// -----------------------------------------------------------------------------
+
+/// Hinge loss for one sample: max(0, 1 - y(w·x + b)) where y ∈ {-1, +1}.
+#[must_use]
+pub fn hinge_loss(w: &[f32], b: f32, x: &[f32], y_signed: f32) -> f32 {
+    let dot: f32 = w.iter().zip(x.iter()).map(|(wi, xi)| wi * xi).sum();
+    let margin = y_signed * (dot + b);
+    (1.0 - margin).max(0.0)
+}
+
+/// Decision function f(x) = w·x + b.
+#[must_use]
+pub fn decision_function(w: &[f32], b: f32, x: &[f32]) -> f32 {
+    let dot: f32 = w.iter().zip(x.iter()).map(|(wi, xi)| wi * xi).sum();
+    dot + b
+}
+
+/// Predict {0, 1} from sign(w·x + b). Tie at 0 ⇒ class 1 (sklearn convention).
+#[must_use]
+pub fn svm_predict(w: &[f32], b: f32, x: &[f32]) -> usize {
+    if decision_function(w, b, x) >= 0.0 {
+        1
+    } else {
+        0
+    }
+}
+
+/// Reference linear-SVM training via primal subgradient descent.
+/// Trains on (x, y_binary) where y_binary ∈ {0, 1}; internally maps to
+/// y_signed ∈ {-1, +1}.
+///
+/// Returns `(w, b)`.
+#[must_use]
+pub fn linear_svm_subgradient_train(
+    x: &[f32],
+    y_binary: &[usize],
+    n_samples: usize,
+    n_features: usize,
+    n_iters: usize,
+    learning_rate: f32,
+    c: f32,
+) -> Option<(Vec<f32>, f32)> {
+    if n_samples == 0 || n_features == 0 {
+        return None;
+    }
+    if x.len() != n_samples * n_features || y_binary.len() != n_samples {
+        return None;
+    }
+    if y_binary.iter().any(|&y| y > 1) {
+        return None;
+    }
+
+    let mut w = vec![0.0_f32; n_features];
+    let mut b = 0.0_f32;
+    for _ in 0..n_iters {
+        for i in 0..n_samples {
+            let xi = &x[i * n_features..(i + 1) * n_features];
+            let y_signed = if y_binary[i] == 1 { 1.0_f32 } else { -1.0 };
+            let dot: f32 = w.iter().zip(xi.iter()).map(|(wj, xj)| wj * xj).sum();
+            let margin = y_signed * (dot + b);
+            // Subgradient with regularization 0.5||w||^2 (no reg here for simplicity)
+            if margin < 1.0 {
+                for j in 0..n_features {
+                    w[j] += learning_rate * c * y_signed * xi[j];
+                }
+                b += learning_rate * c * y_signed;
+            }
+        }
+    }
+    Some((w, b))
+}
+
+// -----------------------------------------------------------------------------
+// Verdict 1: SVM-001 — binary prediction.
+// -----------------------------------------------------------------------------
+
+#[must_use]
+pub fn verdict_from_binary_prediction(predictions: &[usize]) -> SvmVerdict {
+    if predictions.is_empty() {
+        return SvmVerdict::Fail;
+    }
+    for &p in predictions {
+        if !AC_SVM_001_BINARY_LABELS.contains(&p) {
+            return SvmVerdict::Fail;
+        }
+    }
+    SvmVerdict::Pass
+}
+
+// -----------------------------------------------------------------------------
+// Verdict 2: SVM-002 — deterministic prediction.
+// -----------------------------------------------------------------------------
+
+#[must_use]
+pub fn verdict_from_deterministic_prediction(
+    run1: &[usize],
+    run2: &[usize],
+) -> SvmVerdict {
+    if run1.len() != run2.len() {
+        return SvmVerdict::Fail;
+    }
+    if run1.is_empty() {
+        return SvmVerdict::Fail;
+    }
+    if run1 == run2 {
+        SvmVerdict::Pass
+    } else {
+        SvmVerdict::Fail
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Verdict 3: SVM-003 — separable accuracy ≥ 0.9.
+// -----------------------------------------------------------------------------
+
+#[must_use]
+pub fn verdict_from_separable_accuracy(accuracy: f32) -> SvmVerdict {
+    if !accuracy.is_finite() {
+        return SvmVerdict::Fail;
+    }
+    if accuracy >= AC_SVM_003_MIN_SEPARABLE_ACCURACY {
+        SvmVerdict::Pass
+    } else {
+        SvmVerdict::Fail
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Verdict 4: SVM-004 — fit-predict consistency.
+// -----------------------------------------------------------------------------
+
+#[must_use]
+pub fn verdict_from_fit_predict_consistency(
+    predictions: &[usize],
+    training_labels: &[usize],
+) -> SvmVerdict {
+    if training_labels.is_empty() {
+        return if predictions.is_empty() {
+            SvmVerdict::Pass
+        } else {
+            SvmVerdict::Fail
+        };
+    }
+    let label_set: std::collections::HashSet<usize> =
+        training_labels.iter().copied().collect();
+    for &p in predictions {
+        if !label_set.contains(&p) {
+            return SvmVerdict::Fail;
+        }
+    }
+    SvmVerdict::Pass
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -------------------------------------------------------------------------
+    // Section 1: Provenance pins.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn provenance_min_separable_accuracy_09() {
+        assert_eq!(AC_SVM_003_MIN_SEPARABLE_ACCURACY, 0.9);
+    }
+
+    #[test]
+    fn provenance_binary_labels_0_1() {
+        assert_eq!(AC_SVM_001_BINARY_LABELS, [0, 1]);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 2: Domain — reference functions.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn domain_hinge_loss_zero_at_correct_with_margin() {
+        // y=+1, margin = 2 ≥ 1 ⇒ L = 0.
+        let w = vec![1.0_f32, 0.0];
+        let x = vec![2.0_f32, 0.0];
+        let l = hinge_loss(&w, 0.0, &x, 1.0);
+        assert_eq!(l, 0.0);
+    }
+
+    #[test]
+    fn domain_hinge_loss_positive_at_violation() {
+        // y=+1, margin = 0.5 < 1 ⇒ L = 0.5.
+        let w = vec![0.5_f32, 0.0];
+        let x = vec![1.0_f32, 0.0];
+        let l = hinge_loss(&w, 0.0, &x, 1.0);
+        assert!((l - 0.5).abs() < 1e-6);
+    }
+
+    #[test]
+    fn domain_hinge_loss_nonneg() {
+        // Sweep many (w, b, x, y) combos.
+        for &w0 in &[-1.0_f32, 0.0, 1.0] {
+            for &b in &[-2.0_f32, 0.0, 2.0] {
+                for &x0 in &[-3.0_f32, 0.0, 3.0] {
+                    for &y in &[-1.0_f32, 1.0] {
+                        let w = vec![w0];
+                        let x = vec![x0];
+                        let l = hinge_loss(&w, b, &x, y);
+                        assert!(l >= 0.0, "L < 0 at w={w0} b={b} x={x0} y={y}");
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn domain_decision_function_basic() {
+        let w = vec![1.0_f32, -1.0];
+        let b = 2.0;
+        let x = vec![3.0_f32, 1.0];
+        // f = 1*3 + (-1)*1 + 2 = 4.
+        assert!((decision_function(&w, b, &x) - 4.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn domain_predict_threshold_at_zero() {
+        let w = vec![1.0_f32];
+        // f(x=2)=2 ⇒ 1; f(x=-2)=-2 ⇒ 0; f(x=0)=0 ⇒ 1 (sklearn ≥ tie).
+        assert_eq!(svm_predict(&w, 0.0, &[2.0]), 1);
+        assert_eq!(svm_predict(&w, 0.0, &[-2.0]), 0);
+        assert_eq!(svm_predict(&w, 0.0, &[0.0]), 1);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 3: SVM-001 Pass band.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn svm001_pass_all_zeros() {
+        let preds = vec![0_usize; 10];
+        assert_eq!(
+            verdict_from_binary_prediction(&preds),
+            SvmVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn svm001_pass_all_ones() {
+        let preds = vec![1_usize; 10];
+        assert_eq!(
+            verdict_from_binary_prediction(&preds),
+            SvmVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn svm001_pass_mixed_binary() {
+        let preds = vec![0_usize, 1, 0, 1, 1, 0];
+        assert_eq!(
+            verdict_from_binary_prediction(&preds),
+            SvmVerdict::Pass
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 4: SVM-001 Fail band.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn svm001_fail_label_2() {
+        // Bug: forgot to map sign() to {0, 1}, returned class 2.
+        let preds = vec![0_usize, 1, 2];
+        assert_eq!(
+            verdict_from_binary_prediction(&preds),
+            SvmVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn svm001_fail_label_minus_one() {
+        // Returned signed labels ∈ {-1, +1} (cast to usize gives huge value).
+        let preds = vec![0_usize, 1, usize::MAX];
+        assert_eq!(
+            verdict_from_binary_prediction(&preds),
+            SvmVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn svm001_fail_empty() {
+        let preds: Vec<usize> = vec![];
+        assert_eq!(
+            verdict_from_binary_prediction(&preds),
+            SvmVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 5: SVM-002 — determinism.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn svm002_pass_identical_runs() {
+        let r1 = vec![0_usize, 1, 1, 0, 1];
+        let r2 = vec![0_usize, 1, 1, 0, 1];
+        assert_eq!(
+            verdict_from_deterministic_prediction(&r1, &r2),
+            SvmVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn svm002_fail_one_off() {
+        let r1 = vec![0_usize, 1, 1];
+        let r2 = vec![0_usize, 1, 0]; // last differs
+        assert_eq!(
+            verdict_from_deterministic_prediction(&r1, &r2),
+            SvmVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn svm002_fail_length_mismatch() {
+        let r1 = vec![0_usize, 1];
+        let r2 = vec![0_usize];
+        assert_eq!(
+            verdict_from_deterministic_prediction(&r1, &r2),
+            SvmVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn svm002_fail_empty() {
+        let v: Vec<usize> = vec![];
+        assert_eq!(
+            verdict_from_deterministic_prediction(&v, &v),
+            SvmVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 6: SVM-003 — separable accuracy.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn svm003_pass_perfect() {
+        assert_eq!(
+            verdict_from_separable_accuracy(1.0),
+            SvmVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn svm003_pass_at_threshold() {
+        assert_eq!(
+            verdict_from_separable_accuracy(0.9),
+            SvmVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn svm003_fail_below_threshold() {
+        assert_eq!(
+            verdict_from_separable_accuracy(0.89),
+            SvmVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn svm003_fail_random_chance() {
+        assert_eq!(
+            verdict_from_separable_accuracy(0.5),
+            SvmVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn svm003_fail_nan() {
+        assert_eq!(
+            verdict_from_separable_accuracy(f32::NAN),
+            SvmVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 7: SVM-004 — fit-predict consistency.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn svm004_pass_predictions_subset() {
+        let preds = vec![0_usize, 1, 0, 1];
+        let labels = vec![0_usize, 1];
+        assert_eq!(
+            verdict_from_fit_predict_consistency(&preds, &labels),
+            SvmVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn svm004_pass_empty_predictions() {
+        let preds: Vec<usize> = vec![];
+        let labels = vec![0_usize, 1];
+        assert_eq!(
+            verdict_from_fit_predict_consistency(&preds, &labels),
+            SvmVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn svm004_fail_unseen_label_in_predictions() {
+        let preds = vec![0_usize, 1, 5];
+        let labels = vec![0_usize, 1];
+        assert_eq!(
+            verdict_from_fit_predict_consistency(&preds, &labels),
+            SvmVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn svm004_fail_no_training_labels() {
+        let preds = vec![0_usize];
+        let labels: Vec<usize> = vec![];
+        assert_eq!(
+            verdict_from_fit_predict_consistency(&preds, &labels),
+            SvmVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 8: Domain — fit/predict end-to-end on toy data.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn domain_fit_predict_separable_2d() {
+        // 4 points: (-2, 0), (-1, 0) → class 0; (1, 0), (2, 0) → class 1.
+        let x = vec![-2.0_f32, 0.0, -1.0, 0.0, 1.0, 0.0, 2.0, 0.0];
+        let y = vec![0_usize, 0, 1, 1];
+        let (w, b) =
+            linear_svm_subgradient_train(&x, &y, 4, 2, 100, 0.01, 1.0).unwrap();
+
+        // Predict on training points; should classify all correctly.
+        let mut preds = Vec::new();
+        for i in 0..4 {
+            preds.push(svm_predict(&w, b, &x[i * 2..i * 2 + 2]));
+        }
+        let correct = preds.iter().zip(y.iter()).filter(|(p, l)| p == l).count();
+        let acc = correct as f32 / y.len() as f32;
+        assert_eq!(
+            verdict_from_separable_accuracy(acc),
+            SvmVerdict::Pass,
+            "preds={preds:?} expected={y:?} acc={acc}"
+        );
+    }
+
+    #[test]
+    fn domain_fit_rejects_invalid_input() {
+        // Wrong x size.
+        let x = vec![1.0_f32];
+        let y = vec![0_usize, 1];
+        assert!(
+            linear_svm_subgradient_train(&x, &y, 2, 1, 10, 0.01, 1.0).is_none()
+        );
+    }
+
+    #[test]
+    fn domain_fit_rejects_label_above_one() {
+        let x = vec![1.0_f32, 2.0];
+        let y = vec![0_usize, 5]; // 5 > 1
+        assert!(
+            linear_svm_subgradient_train(&x, &y, 2, 1, 10, 0.01, 1.0).is_none()
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 9: Sweep — accuracy threshold band.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn sweep_separable_accuracy_around_threshold() {
+        let test_cases = [
+            (0.0_f32, SvmVerdict::Fail),
+            (0.5, SvmVerdict::Fail),
+            (0.89, SvmVerdict::Fail),
+            (0.9, SvmVerdict::Pass),
+            (0.95, SvmVerdict::Pass),
+            (1.0, SvmVerdict::Pass),
+        ];
+        for (acc, expected) in test_cases {
+            let v = verdict_from_separable_accuracy(acc);
+            assert_eq!(v, expected, "acc={acc}");
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 10: Realistic — contract regression scenarios.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn realistic_forgot_to_map_decision_to_binary() {
+        // SVM-001 if_fails: "Prediction not mapped to {0, 1}".
+        // sign() returned {-1, +1} cast to usize.
+        let preds = vec![0_usize, 1, usize::MAX, 1];
+        assert_eq!(
+            verdict_from_binary_prediction(&preds),
+            SvmVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn realistic_non_deterministic_lr_caught() {
+        // SVM-002 if_fails: "Non-deterministic learning rate or state".
+        let r1 = vec![0_usize, 1, 0, 1];
+        let r2 = vec![1_usize, 1, 0, 1]; // first flipped
+        assert_eq!(
+            verdict_from_deterministic_prediction(&r1, &r2),
+            SvmVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn realistic_convergence_failure_caught() {
+        // SVM-003 if_fails: "Convergence failure or wrong sign convention"
+        // ⇒ accuracy near random.
+        assert_eq!(
+            verdict_from_separable_accuracy(0.55),
+            SvmVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn realistic_label_mapping_error_caught() {
+        // SVM-004 if_fails: "Label mapping error".
+        let preds = vec![3_usize, 7, 9]; // none in {0, 1}
+        let labels = vec![0_usize, 1];
+        assert_eq!(
+            verdict_from_fit_predict_consistency(&preds, &labels),
+            SvmVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn realistic_full_pipeline_passes_all_4_gates() {
+        // Train on separable 1D data.
+        let x = vec![-3.0_f32, -2.0, -1.0, 1.0, 2.0, 3.0];
+        let y = vec![0_usize, 0, 0, 1, 1, 1];
+        let (w, b) =
+            linear_svm_subgradient_train(&x, &y, 6, 1, 100, 0.01, 1.0).unwrap();
+
+        let mut preds = Vec::new();
+        for i in 0..6 {
+            preds.push(svm_predict(&w, b, &x[i..i + 1]));
+        }
+
+        // Gate 1: binary.
+        assert_eq!(verdict_from_binary_prediction(&preds), SvmVerdict::Pass);
+
+        // Gate 2: deterministic.
+        let preds_again: Vec<usize> = (0..6).map(|i| svm_predict(&w, b, &x[i..i + 1])).collect();
+        assert_eq!(
+            verdict_from_deterministic_prediction(&preds, &preds_again),
+            SvmVerdict::Pass
+        );
+
+        // Gate 3: separable accuracy ≥ 0.9.
+        let correct = preds.iter().zip(y.iter()).filter(|(p, l)| p == l).count();
+        let acc = correct as f32 / y.len() as f32;
+        assert_eq!(verdict_from_separable_accuracy(acc), SvmVerdict::Pass);
+
+        // Gate 4: fit-predict consistency.
+        assert_eq!(
+            verdict_from_fit_predict_consistency(&preds, &y),
+            SvmVerdict::Pass
+        );
+    }
+}

--- a/crates/aprender-core/src/format/version_001_003.rs
+++ b/crates/aprender-core/src/format/version_001_003.rs
@@ -1,0 +1,309 @@
+// `apr-version-traceability-v1` algorithm-level PARTIAL discharge for the
+// 3 version-traceability falsifiers (no `(unknown)` sentinel, no
+// alternative sentinels, version string present).
+//
+// Contract: `contracts/apr-version-traceability-v1.yaml`.
+// Refs: paiml/aprender#597 (version string shows `(unknown)` instead of
+// git hash on cargo install builds).
+
+/// Forbidden sentinel forms per FALSIFY-VERSION-002.
+pub const AC_VERSION_FORBIDDEN_SENTINELS: [&str; 4] = [
+    "(unknown)",
+    "(0000000)",
+    "(<empty>)",
+    "(null)",
+];
+
+/// Regex-shaped predicate for FALSIFY-VERSION-003: version output must
+/// contain a `0.X.Y` token (CARGO_PKG_VERSION semver).
+pub const AC_VERSION_PKG_PREFIX: &str = "0.";
+
+// =============================================================================
+// FALSIFY-VERSION-001 — output does NOT contain `(unknown)`
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NoUnknownSentinelVerdict {
+    /// Output does not contain the literal `(unknown)`.
+    Pass,
+    /// Output contains `(unknown)` — sentinel leaked.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_no_unknown_sentinel(version_output: &str) -> NoUnknownSentinelVerdict {
+    if version_output.contains("(unknown)") {
+        NoUnknownSentinelVerdict::Fail
+    } else {
+        NoUnknownSentinelVerdict::Pass
+    }
+}
+
+// =============================================================================
+// FALSIFY-VERSION-002 — no sentinel from forbidden set
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NoForbiddenSentinelVerdict {
+    /// None of `(unknown)`, `(0000000)`, `(<empty>)`, `(null)` present.
+    Pass,
+    /// At least one forbidden sentinel form leaked.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_no_forbidden_sentinel(version_output: &str) -> NoForbiddenSentinelVerdict {
+    for sentinel in AC_VERSION_FORBIDDEN_SENTINELS {
+        if version_output.contains(sentinel) {
+            return NoForbiddenSentinelVerdict::Fail;
+        }
+    }
+    NoForbiddenSentinelVerdict::Pass
+}
+
+// =============================================================================
+// FALSIFY-VERSION-003 — output contains a CARGO_PKG_VERSION (0.X.Y)
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VersionPresentVerdict {
+    /// Output contains a 0.X.Y semver token.
+    Pass,
+    /// Output missing version string entirely (e.g., empty `apr --version`).
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_version_present(version_output: &str) -> VersionPresentVerdict {
+    // Look for "0." followed by a digit-or-dot run consistent with semver.
+    // Scan once char-by-char to keep this dependency-free.
+    let bytes = version_output.as_bytes();
+    let prefix = AC_VERSION_PKG_PREFIX.as_bytes();
+    let n = bytes.len();
+    if n < prefix.len() + 3 {
+        return VersionPresentVerdict::Fail;
+    }
+    for start in 0..=n - prefix.len() {
+        if &bytes[start..start + prefix.len()] != prefix {
+            continue;
+        }
+        // After "0." need at least one digit AND another dot AND another digit
+        // (matching `0.X.Y` minimum).
+        let mut i = start + prefix.len();
+        let major_start = i;
+        while i < n && bytes[i].is_ascii_digit() {
+            i += 1;
+        }
+        if i == major_start {
+            continue;
+        }
+        if i >= n || bytes[i] != b'.' {
+            continue;
+        }
+        i += 1; // skip the second dot
+        let minor_start = i;
+        while i < n && bytes[i].is_ascii_digit() {
+            i += 1;
+        }
+        if i == minor_start {
+            continue;
+        }
+        return VersionPresentVerdict::Pass;
+    }
+    VersionPresentVerdict::Fail
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -------------------------------------------------------------------------
+    // Section 1: Provenance pins.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn provenance_forbidden_sentinels_count_4() {
+        assert_eq!(AC_VERSION_FORBIDDEN_SENTINELS.len(), 4);
+    }
+
+    #[test]
+    fn provenance_unknown_sentinel_in_forbidden() {
+        assert!(AC_VERSION_FORBIDDEN_SENTINELS.contains(&"(unknown)"));
+    }
+
+    #[test]
+    fn provenance_pkg_prefix_is_0_dot() {
+        assert_eq!(AC_VERSION_PKG_PREFIX, "0.");
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 2: VERSION-001 no (unknown).
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fv001_pass_clean_version_with_hash() {
+        let v = "apr 0.31.2 (b8c5d809)";
+        assert_eq!(
+            verdict_from_no_unknown_sentinel(v),
+            NoUnknownSentinelVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fv001_pass_no_git_fallback() {
+        let v = "apr 0.31.2 (v0.31.2+no-git)";
+        assert_eq!(
+            verdict_from_no_unknown_sentinel(v),
+            NoUnknownSentinelVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fv001_fail_unknown_leaked() {
+        let v = "apr 0.4.13 (unknown)";
+        assert_eq!(
+            verdict_from_no_unknown_sentinel(v),
+            NoUnknownSentinelVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fv001_fail_unknown_in_other_position() {
+        let v = "apr (unknown) version";
+        assert_eq!(
+            verdict_from_no_unknown_sentinel(v),
+            NoUnknownSentinelVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 3: VERSION-002 no forbidden sentinels.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fv002_pass_clean_version() {
+        let v = "apr 0.31.2 (b8c5d809)";
+        assert_eq!(
+            verdict_from_no_forbidden_sentinel(v),
+            NoForbiddenSentinelVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fv002_fail_unknown() {
+        assert_eq!(
+            verdict_from_no_forbidden_sentinel("apr 0.4.13 (unknown)"),
+            NoForbiddenSentinelVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fv002_fail_zero_hash() {
+        assert_eq!(
+            verdict_from_no_forbidden_sentinel("apr 0.4.13 (0000000)"),
+            NoForbiddenSentinelVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fv002_fail_empty_marker() {
+        assert_eq!(
+            verdict_from_no_forbidden_sentinel("apr 0.4.13 (<empty>)"),
+            NoForbiddenSentinelVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fv002_fail_null_marker() {
+        assert_eq!(
+            verdict_from_no_forbidden_sentinel("apr 0.4.13 (null)"),
+            NoForbiddenSentinelVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 4: VERSION-003 version-string present.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fv003_pass_canonical_format() {
+        assert_eq!(
+            verdict_from_version_present("apr 0.31.2 (b8c5d809)"),
+            VersionPresentVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fv003_pass_old_version() {
+        assert_eq!(
+            verdict_from_version_present("apr 0.4.13 (unknown)"),
+            VersionPresentVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fv003_pass_version_with_no_git_suffix() {
+        assert_eq!(
+            verdict_from_version_present("apr 0.31.2 (v0.31.2+no-git)"),
+            VersionPresentVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fv003_fail_no_version_at_all() {
+        assert_eq!(
+            verdict_from_version_present("apr (unknown)"),
+            VersionPresentVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fv003_fail_empty_output() {
+        assert_eq!(verdict_from_version_present(""), VersionPresentVerdict::Fail);
+    }
+
+    #[test]
+    fn fv003_fail_only_major_dot() {
+        // "0." alone (no minor/patch) doesn't satisfy 0.X.Y.
+        assert_eq!(
+            verdict_from_version_present("apr 0."),
+            VersionPresentVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fv003_pass_two_dot_pattern_in_path() {
+        // Path "/usr/lib/0.so" embeds "0.so" — must NOT trigger Pass.
+        // (no 0.X.Y semver match because "so" is not digits.)
+        assert_eq!(
+            verdict_from_version_present("loaded /usr/lib/0.so"),
+            VersionPresentVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 5: Realistic — full healthy version output passes all 3.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn realistic_clean_release_passes_all_3() {
+        let v = "apr 0.31.2 (b8c5d809) — built 2026-05-02";
+        assert_eq!(verdict_from_no_unknown_sentinel(v), NoUnknownSentinelVerdict::Pass);
+        assert_eq!(verdict_from_no_forbidden_sentinel(v), NoForbiddenSentinelVerdict::Pass);
+        assert_eq!(verdict_from_version_present(v), VersionPresentVerdict::Pass);
+    }
+
+    #[test]
+    fn realistic_no_git_fallback_passes_all_3() {
+        // The exact "cargo install from crates.io" healthy fallback.
+        let v = "apr 0.31.2 (v0.31.2+no-git)";
+        assert_eq!(verdict_from_no_unknown_sentinel(v), NoUnknownSentinelVerdict::Pass);
+        assert_eq!(verdict_from_no_forbidden_sentinel(v), NoForbiddenSentinelVerdict::Pass);
+        assert_eq!(verdict_from_version_present(v), VersionPresentVerdict::Pass);
+    }
+
+    #[test]
+    fn realistic_pre_fix_001_002_fail_003_passes() {
+        // The exact regression class from GH-597: "apr 0.4.13 (unknown)"
+        // — has version string (003 passes), but leaked sentinel (001/002 fail).
+        let v = "apr 0.4.13 (unknown)";
+        assert_eq!(verdict_from_no_unknown_sentinel(v), NoUnknownSentinelVerdict::Fail);
+        assert_eq!(verdict_from_no_forbidden_sentinel(v), NoForbiddenSentinelVerdict::Fail);
+        assert_eq!(verdict_from_version_present(v), VersionPresentVerdict::Pass);
+    }
+}

--- a/crates/aprender-core/src/format/zerogate_001_004.rs
+++ b/crates/aprender-core/src/format/zerogate_001_004.rs
@@ -1,0 +1,372 @@
+// `apr-zero-feature-gate-v1` algorithm-level PARTIAL discharge for the 4
+// zero-feature-gate falsifiers (all commands respond to --help, no
+// feature-gate errors, GPU fallback graceful, default features complete).
+//
+// Contract: `contracts/apr-zero-feature-gate-v1.yaml`.
+// Refs: APR-MONO Rule 5 (Zero Feature-Gating for Users), Rule 6 (GPU
+// Auto-Detection at Runtime).
+
+/// Phrases that indicate a feature-gate error in user-facing output.
+pub const AC_ZEROGATE_FORBIDDEN_PHRASES: [&str; 4] = [
+    "feature not enabled",
+    "requires --features",
+    "enable the",
+    "compile with --features",
+];
+
+/// Required features in apr-cli's default = [...] list per the contract.
+pub const AC_ZEROGATE_REQUIRED_DEFAULT_FEATURES: [&str; 2] = ["inference", "training"];
+
+/// Features that MUST NOT be in default (compile-time only).
+pub const AC_ZEROGATE_FORBIDDEN_DEFAULT_FEATURES: [&str; 2] = ["cuda", "code"];
+
+/// GPU error keywords that MUST NOT appear after --no-gpu fallback.
+pub const AC_ZEROGATE_GPU_ERROR_KEYWORDS: [&str; 4] =
+    ["cuda", "gpu not found", "gpu missing", "no gpu"];
+
+// =============================================================================
+// FALSIFY-ZEROGATEV-001 — every subcommand responds to --help with exit 0
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HelpResponseVerdict {
+    /// Every subcommand exits 0 on `--help`.
+    Pass,
+    /// At least one subcommand failed `--help`.
+    Fail,
+}
+
+/// `(subcommand_name, exit_code_on_help)` per subcommand.
+#[must_use]
+pub fn verdict_from_help_response(help_results: &[(&str, i32)]) -> HelpResponseVerdict {
+    if help_results.is_empty() {
+        return HelpResponseVerdict::Fail;
+    }
+    for (_cmd, exit) in help_results {
+        if *exit != 0 {
+            return HelpResponseVerdict::Fail;
+        }
+    }
+    HelpResponseVerdict::Pass
+}
+
+// =============================================================================
+// FALSIFY-ZEROGATEV-002 — no feature-gate error phrases in output
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NoFeatureGateErrorVerdict {
+    /// No `--help` output contains any forbidden feature-gate phrase.
+    Pass,
+    /// At least one output contained a feature-gate phrase.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_no_feature_gate_error(combined_output: &str) -> NoFeatureGateErrorVerdict {
+    let lower = combined_output.to_lowercase();
+    for phrase in AC_ZEROGATE_FORBIDDEN_PHRASES {
+        if lower.contains(phrase) {
+            return NoFeatureGateErrorVerdict::Fail;
+        }
+    }
+    NoFeatureGateErrorVerdict::Pass
+}
+
+// =============================================================================
+// FALSIFY-ZEROGATEV-003 — GPU fallback graceful (no GPU error after --no-gpu)
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GpuFallbackVerdict {
+    /// `apr run --no-gpu` output contains no GPU/CUDA error keywords.
+    /// (May still fail on the input model — that's a separate gate.)
+    Pass,
+    /// Output mentioned GPU/CUDA errors despite --no-gpu.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_gpu_fallback(combined_output: &str) -> GpuFallbackVerdict {
+    let lower = combined_output.to_lowercase();
+    for kw in AC_ZEROGATE_GPU_ERROR_KEYWORDS {
+        if lower.contains(kw) {
+            return GpuFallbackVerdict::Fail;
+        }
+    }
+    GpuFallbackVerdict::Pass
+}
+
+// =============================================================================
+// FALSIFY-ZEROGATEV-004 — default features complete + cuda/code excluded
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DefaultFeaturesVerdict {
+    /// `inference` AND `training` present in default; `cuda` AND `code` absent.
+    Pass,
+    /// At least one required feature missing OR forbidden feature present.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_default_features(default_features: &[&str]) -> DefaultFeaturesVerdict {
+    use std::collections::HashSet;
+    let set: HashSet<&&str> = default_features.iter().collect();
+    for required in AC_ZEROGATE_REQUIRED_DEFAULT_FEATURES {
+        if !set.contains(&required) {
+            return DefaultFeaturesVerdict::Fail;
+        }
+    }
+    for forbidden in AC_ZEROGATE_FORBIDDEN_DEFAULT_FEATURES {
+        if set.contains(&forbidden) {
+            return DefaultFeaturesVerdict::Fail;
+        }
+    }
+    DefaultFeaturesVerdict::Pass
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -------------------------------------------------------------------------
+    // Section 1: Provenance pins.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn provenance_forbidden_phrases_count_4() {
+        assert_eq!(AC_ZEROGATE_FORBIDDEN_PHRASES.len(), 4);
+    }
+
+    #[test]
+    fn provenance_required_features_count_2() {
+        assert_eq!(AC_ZEROGATE_REQUIRED_DEFAULT_FEATURES.len(), 2);
+    }
+
+    #[test]
+    fn provenance_forbidden_features_count_2() {
+        assert_eq!(AC_ZEROGATE_FORBIDDEN_DEFAULT_FEATURES.len(), 2);
+    }
+
+    #[test]
+    fn provenance_required_forbidden_disjoint() {
+        for r in AC_ZEROGATE_REQUIRED_DEFAULT_FEATURES {
+            assert!(!AC_ZEROGATE_FORBIDDEN_DEFAULT_FEATURES.contains(&r));
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 2: ZEROGATEV-001 help response.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fz001_pass_all_commands_zero() {
+        let r = [("run", 0), ("serve", 0), ("chat", 0), ("finetune", 0)];
+        assert_eq!(verdict_from_help_response(&r), HelpResponseVerdict::Pass);
+    }
+
+    #[test]
+    fn fz001_fail_one_command_nonzero() {
+        let r = [("run", 0), ("finetune", 1)];
+        assert_eq!(verdict_from_help_response(&r), HelpResponseVerdict::Fail);
+    }
+
+    #[test]
+    fn fz001_fail_panic_exit() {
+        let r = [("run", 0), ("profile", 101)];
+        assert_eq!(verdict_from_help_response(&r), HelpResponseVerdict::Fail);
+    }
+
+    #[test]
+    fn fz001_fail_empty() {
+        let r: [(&str, i32); 0] = [];
+        assert_eq!(verdict_from_help_response(&r), HelpResponseVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 3: ZEROGATEV-002 no feature-gate phrases.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fz002_pass_clean_output() {
+        let out = "Usage: apr run [OPTIONS] <MODEL>\n\nOptions:\n  --json   Emit JSON";
+        assert_eq!(
+            verdict_from_no_feature_gate_error(out),
+            NoFeatureGateErrorVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fz002_fail_feature_not_enabled() {
+        let out = "Error: feature not enabled — recompile with --features inference";
+        assert_eq!(
+            verdict_from_no_feature_gate_error(out),
+            NoFeatureGateErrorVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fz002_fail_requires_features() {
+        let out = "This command requires --features cuda";
+        assert_eq!(
+            verdict_from_no_feature_gate_error(out),
+            NoFeatureGateErrorVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fz002_fail_compile_with_features() {
+        let out = "compile with --features training";
+        assert_eq!(
+            verdict_from_no_feature_gate_error(out),
+            NoFeatureGateErrorVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fz002_fail_enable_the_feature() {
+        let out = "enable the inference feature";
+        assert_eq!(
+            verdict_from_no_feature_gate_error(out),
+            NoFeatureGateErrorVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 4: ZEROGATEV-003 GPU fallback.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fz003_pass_clean_cpu_fallback() {
+        let out = "Running on CPU SIMD backend";
+        assert_eq!(verdict_from_gpu_fallback(out), GpuFallbackVerdict::Pass);
+    }
+
+    #[test]
+    fn fz003_pass_invalid_model_error() {
+        // Failure on the model path is fine; only GPU-related errors fail.
+        let out = "Error: invalid model file at /dev/null";
+        assert_eq!(verdict_from_gpu_fallback(out), GpuFallbackVerdict::Pass);
+    }
+
+    #[test]
+    fn fz003_fail_cuda_error() {
+        let out = "Error: CUDA driver not available";
+        assert_eq!(verdict_from_gpu_fallback(out), GpuFallbackVerdict::Fail);
+    }
+
+    #[test]
+    fn fz003_fail_gpu_not_found() {
+        let out = "Error: GPU not found";
+        assert_eq!(verdict_from_gpu_fallback(out), GpuFallbackVerdict::Fail);
+    }
+
+    #[test]
+    fn fz003_fail_no_gpu_error() {
+        let out = "Error: No GPU detected, refusing to run";
+        assert_eq!(verdict_from_gpu_fallback(out), GpuFallbackVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 5: ZEROGATEV-004 default features.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fz004_pass_canonical_defaults() {
+        let f = [
+            "hf-hub",
+            "safetensors-compare",
+            "inference",
+            "training",
+            "visualization",
+            "zram",
+        ];
+        assert_eq!(verdict_from_default_features(&f), DefaultFeaturesVerdict::Pass);
+    }
+
+    #[test]
+    fn fz004_pass_minimal_required() {
+        let f = ["inference", "training"];
+        assert_eq!(verdict_from_default_features(&f), DefaultFeaturesVerdict::Pass);
+    }
+
+    #[test]
+    fn fz004_fail_missing_inference() {
+        let f = ["training", "visualization"];
+        assert_eq!(verdict_from_default_features(&f), DefaultFeaturesVerdict::Fail);
+    }
+
+    #[test]
+    fn fz004_fail_missing_training() {
+        let f = ["inference", "visualization"];
+        assert_eq!(verdict_from_default_features(&f), DefaultFeaturesVerdict::Fail);
+    }
+
+    #[test]
+    fn fz004_fail_cuda_in_default() {
+        // Compile-time-only feature leaked into default.
+        let f = ["inference", "training", "cuda"];
+        assert_eq!(verdict_from_default_features(&f), DefaultFeaturesVerdict::Fail);
+    }
+
+    #[test]
+    fn fz004_fail_code_in_default() {
+        // External-dep feature leaked into default.
+        let f = ["inference", "training", "code"];
+        assert_eq!(verdict_from_default_features(&f), DefaultFeaturesVerdict::Fail);
+    }
+
+    #[test]
+    fn fz004_fail_empty_default() {
+        let f: [&str; 0] = [];
+        assert_eq!(verdict_from_default_features(&f), DefaultFeaturesVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 6: Realistic — full healthy install passes all 4.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn realistic_healthy_install_passes_all_4() {
+        let cmds = [
+            ("run", 0), ("serve", 0), ("chat", 0), ("finetune", 0),
+            ("train", 0), ("distill", 0), ("profile", 0), ("trace", 0),
+        ];
+        assert_eq!(verdict_from_help_response(&cmds), HelpResponseVerdict::Pass);
+
+        let clean_help = "Usage: apr run [OPTIONS] <MODEL>\n\nOptions:\n  --no-gpu";
+        assert_eq!(
+            verdict_from_no_feature_gate_error(clean_help),
+            NoFeatureGateErrorVerdict::Pass
+        );
+
+        let cpu_run = "Backend: CPU SIMD (AVX2)\nGenerating...";
+        assert_eq!(verdict_from_gpu_fallback(cpu_run), GpuFallbackVerdict::Pass);
+
+        let canonical = [
+            "hf-hub", "safetensors-compare", "inference", "training",
+            "visualization", "zram",
+        ];
+        assert_eq!(verdict_from_default_features(&canonical), DefaultFeaturesVerdict::Pass);
+    }
+
+    #[test]
+    fn realistic_pre_fix_all_4_failures() {
+        // 001: finetune missing without --features training.
+        let bad = [("finetune", 1)];
+        assert_eq!(verdict_from_help_response(&bad), HelpResponseVerdict::Fail);
+
+        // 002: feature-gate error reached user.
+        let bad_help = "Error: feature not enabled, requires --features inference";
+        assert_eq!(
+            verdict_from_no_feature_gate_error(bad_help),
+            NoFeatureGateErrorVerdict::Fail
+        );
+
+        // 003: GPU error despite --no-gpu.
+        let bad_run = "Error: CUDA driver not loaded";
+        assert_eq!(verdict_from_gpu_fallback(bad_run), GpuFallbackVerdict::Fail);
+
+        // 004: cuda leaked into default.
+        let bad_features = ["inference", "training", "cuda"];
+        assert_eq!(
+            verdict_from_default_features(&bad_features),
+            DefaultFeaturesVerdict::Fail
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Second batch of squashed PARTIAL-discharge commits — 20 PRs combined into one. Same shape as #1637 but caught with a broader file-pattern filter (these were `test(realizar): ...` and `feat(aprender-core): ...` titled rather than `feat(format): ...`).

## Why

Same as #1637: one CI run instead of 20.

## Test plan

- [x] All 20 commits cherry-picked clean
- [x] `cargo clippy -p aprender-core --lib -- -D warnings` clean
- [ ] CI: workspace-test (cargo test + sccache-warm build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)