### PR TITLE
chore(format): squash 26 realizar PARTIAL-discharge feat commits (batch 4)

### DIFF
--- a/crates/aprender-core/src/format/aprbook_001_005.rs
+++ b/crates/aprender-core/src/format/aprbook_001_005.rs
@@ -1,0 +1,361 @@
+// `apr-book-ch*` family algorithm-level PARTIAL discharge for the 5
+// falsification conditions shared by every `apr-book-ch*-v1.yaml` contract.
+//
+// Contracts: `contracts/apr-book-ch01-v1.yaml` ..
+// `contracts/apr-book-ch27-v1.yaml` (27 contracts × 5 conditions = 135
+// falsifier instantiations).
+//
+// All apr-book-ch* contracts (Chapter 1 .. Chapter 27 of the APR-BOOK
+// reference book) share an identical falsification schema. Each declares
+// 5 P0-severity conditions:
+//
+//   1. "cargo run -p aprender-core --example chXX_<...> exits non-zero"
+//   2. "Section without arXiv citation"
+//   3. "Legacy name appears in chapter text"
+//   4. "Oracle --explain output contradicts chapter claim"
+//   5. "assert!() failure in example"
+//
+// One verdict module satisfies the algorithm-level pin for all 27
+// chapter contracts. Live discharge is `cargo run --example` per chapter
+// + `apr oracle --explain` queries; this module pins the predicates so
+// future bulk chapter edits cannot drift on the shape of any of the 5
+// invariants.
+//
+// Local IDs FALSIFY-APRBOOK-001..005 are synthesized to give each
+// unkeyed YAML entry a stable handle.
+
+/// Legacy names whose appearance in chapter text REQUIRES removal
+/// post-APR-MONO consolidation (matches apr-page-* family policy).
+pub const AC_APRBOOK_LEGACY_NAMES: [&str; 4] = ["trueno", "realizar", "entrenar", "batuta"];
+
+/// Total chapters in the APR-BOOK family (ch01..ch27).
+pub const AC_APRBOOK_TOTAL_CHAPTERS: u32 = 27;
+
+// =============================================================================
+// FALSIFY-APRBOOK-001 — example exit code is 0
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BookExampleExitVerdict {
+    /// `cargo run --example chXX_<...>` exited 0.
+    Pass,
+    /// Non-zero exit (P0 reject_chapter).
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_book_example_exit(exit_code: i32) -> BookExampleExitVerdict {
+    if exit_code == 0 {
+        BookExampleExitVerdict::Pass
+    } else {
+        BookExampleExitVerdict::Fail
+    }
+}
+
+// =============================================================================
+// FALSIFY-APRBOOK-002 — every section has an arXiv citation
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SectionCitationVerdict {
+    /// Every section in the chapter cites at least one arXiv ID.
+    Pass,
+    /// At least one section without arXiv citation (P0 reject_chapter).
+    Fail,
+}
+
+/// Pure verdict for FALSIFY-APRBOOK-002.
+///
+/// `section_citation_counts` is a slice of (section_heading, citation_count)
+/// pairs. Pass iff all counts are ≥ 1.
+#[must_use]
+pub fn verdict_from_section_citations(section_citation_counts: &[(&str, u32)]) -> SectionCitationVerdict {
+    if section_citation_counts.is_empty() {
+        // No sections at all — vacuous pass; FALSIFY-APRPAGE-001/-005 catch
+        // missing-content separately at the file-existence layer.
+        return SectionCitationVerdict::Pass;
+    }
+    for (_section, count) in section_citation_counts {
+        if *count == 0 {
+            return SectionCitationVerdict::Fail;
+        }
+    }
+    SectionCitationVerdict::Pass
+}
+
+// =============================================================================
+// FALSIFY-APRBOOK-003 — no legacy names in chapter text
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NoLegacyInBookVerdict {
+    /// Chapter text contains zero of {trueno, realizar, entrenar, batuta},
+    /// OR every occurrence is in a "MOVED"/migration/history context.
+    Pass,
+    /// Active legacy reference (P0 reject_chapter).
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_no_legacy_in_book(chapter_text: &str) -> NoLegacyInBookVerdict {
+    let lower = chapter_text.to_lowercase();
+    let mentions_legacy = AC_APRBOOK_LEGACY_NAMES.iter().any(|n| lower.contains(n));
+    if !mentions_legacy {
+        return NoLegacyInBookVerdict::Pass;
+    }
+    if lower.contains("moved") || lower.contains("migration") || lower.contains("history") {
+        NoLegacyInBookVerdict::Pass
+    } else {
+        NoLegacyInBookVerdict::Fail
+    }
+}
+
+// =============================================================================
+// FALSIFY-APRBOOK-004 — oracle --explain doesn't contradict chapter claim
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OracleConsistencyVerdict {
+    /// `apr oracle --explain` output is consistent with chapter claims.
+    Pass,
+    /// Contradiction detected (P0 reject_chapter).
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_oracle_consistency(contradiction_count: u32) -> OracleConsistencyVerdict {
+    if contradiction_count == 0 {
+        OracleConsistencyVerdict::Pass
+    } else {
+        OracleConsistencyVerdict::Fail
+    }
+}
+
+// =============================================================================
+// FALSIFY-APRBOOK-005 — all assert!() in example pass
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AssertPassVerdict {
+    /// Every `assert!()` in the chapter example evaluates to true.
+    Pass,
+    /// At least one assert!() failed (P0 reject_chapter).
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_assert_pass(failed_assert_count: u32) -> AssertPassVerdict {
+    if failed_assert_count == 0 {
+        AssertPassVerdict::Pass
+    } else {
+        AssertPassVerdict::Fail
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -------------------------------------------------------------------------
+    // Section 1: Provenance pins.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn provenance_legacy_names_count_4() {
+        assert_eq!(AC_APRBOOK_LEGACY_NAMES.len(), 4);
+    }
+
+    #[test]
+    fn provenance_total_chapters_27() {
+        assert_eq!(AC_APRBOOK_TOTAL_CHAPTERS, 27);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 2: APRBOOK-001 example exit.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn ab001_pass_exit_zero() {
+        assert_eq!(verdict_from_book_example_exit(0), BookExampleExitVerdict::Pass);
+    }
+
+    #[test]
+    fn ab001_fail_exit_one() {
+        assert_eq!(verdict_from_book_example_exit(1), BookExampleExitVerdict::Fail);
+    }
+
+    #[test]
+    fn ab001_fail_panic() {
+        // Rust panic exit code 101.
+        assert_eq!(verdict_from_book_example_exit(101), BookExampleExitVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 3: APRBOOK-002 section citations.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn ab002_pass_all_sections_cited() {
+        let sections = [("Why Rust", 1), ("Memory Safety", 2), ("Performance", 3)];
+        assert_eq!(
+            verdict_from_section_citations(&sections),
+            SectionCitationVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn ab002_pass_no_sections_vacuous() {
+        assert_eq!(verdict_from_section_citations(&[]), SectionCitationVerdict::Pass);
+    }
+
+    #[test]
+    fn ab002_fail_uncited_section() {
+        let sections = [("Why Rust", 1), ("Drift Section", 0)];
+        assert_eq!(
+            verdict_from_section_citations(&sections),
+            SectionCitationVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn ab002_fail_all_uncited() {
+        let sections = [("Section A", 0), ("Section B", 0)];
+        assert_eq!(
+            verdict_from_section_citations(&sections),
+            SectionCitationVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 4: APRBOOK-003 no legacy names in chapter.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn ab003_pass_clean_chapter() {
+        let t = "Chapter 1: Why Rust for ML — aprender uses safe Rust types.";
+        assert_eq!(verdict_from_no_legacy_in_book(t), NoLegacyInBookVerdict::Pass);
+    }
+
+    #[test]
+    fn ab003_pass_history_section() {
+        let t = "## History\nPre-APR-MONO, trueno was a separate crate.";
+        assert_eq!(verdict_from_no_legacy_in_book(t), NoLegacyInBookVerdict::Pass);
+    }
+
+    #[test]
+    fn ab003_pass_with_moved_tag() {
+        let t = "See trueno (MOVED to crates/aprender-compute/) for SIMD.";
+        assert_eq!(verdict_from_no_legacy_in_book(t), NoLegacyInBookVerdict::Pass);
+    }
+
+    #[test]
+    fn ab003_fail_active_legacy() {
+        let t = "Use realizar to serve models.";
+        assert_eq!(verdict_from_no_legacy_in_book(t), NoLegacyInBookVerdict::Fail);
+    }
+
+    #[test]
+    fn ab003_fail_each_legacy_name_active() {
+        for name in AC_APRBOOK_LEGACY_NAMES {
+            let t = format!("Use {name} for foo.");
+            assert_eq!(
+                verdict_from_no_legacy_in_book(&t),
+                NoLegacyInBookVerdict::Fail,
+                "active legacy name {name} must Fail"
+            );
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 5: APRBOOK-004 oracle consistency.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn ab004_pass_no_contradictions() {
+        assert_eq!(verdict_from_oracle_consistency(0), OracleConsistencyVerdict::Pass);
+    }
+
+    #[test]
+    fn ab004_fail_one_contradiction() {
+        assert_eq!(verdict_from_oracle_consistency(1), OracleConsistencyVerdict::Fail);
+    }
+
+    #[test]
+    fn ab004_fail_many_contradictions() {
+        assert_eq!(verdict_from_oracle_consistency(10), OracleConsistencyVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 6: APRBOOK-005 assert!() pass.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn ab005_pass_zero_failures() {
+        assert_eq!(verdict_from_assert_pass(0), AssertPassVerdict::Pass);
+    }
+
+    #[test]
+    fn ab005_fail_one_failure() {
+        assert_eq!(verdict_from_assert_pass(1), AssertPassVerdict::Fail);
+    }
+
+    #[test]
+    fn ab005_fail_many_failures() {
+        assert_eq!(verdict_from_assert_pass(20), AssertPassVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 7: Realistic — a healthy chapter passes all 5.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn realistic_full_healthy_chapter_passes_all_5() {
+        // A typical apr-book-ch08-v1 (Transformers) chapter:
+        // example exits 0, every section cites arXiv, no legacy names,
+        // oracle agrees, all assert!() pass.
+        assert_eq!(verdict_from_book_example_exit(0), BookExampleExitVerdict::Pass);
+
+        let sections = [
+            ("Multi-Head Attention", 2),
+            ("Positional Encoding", 1),
+            ("Layer Norm", 1),
+        ];
+        assert_eq!(
+            verdict_from_section_citations(&sections),
+            SectionCitationVerdict::Pass
+        );
+
+        let chapter = "Transformer block: Attention(Q,K,V) — see arXiv:1706.03762.";
+        assert_eq!(verdict_from_no_legacy_in_book(chapter), NoLegacyInBookVerdict::Pass);
+        assert_eq!(verdict_from_oracle_consistency(0), OracleConsistencyVerdict::Pass);
+        assert_eq!(verdict_from_assert_pass(0), AssertPassVerdict::Pass);
+    }
+
+    #[test]
+    fn realistic_pre_fix_all_5_failures() {
+        // The exact regression class for each gate.
+        assert_eq!(verdict_from_book_example_exit(101), BookExampleExitVerdict::Fail);
+
+        let bad_sections = [("Section", 0)];
+        assert_eq!(
+            verdict_from_section_citations(&bad_sections),
+            SectionCitationVerdict::Fail
+        );
+
+        let bad_text = "Use entrenar for training.";
+        assert_eq!(verdict_from_no_legacy_in_book(bad_text), NoLegacyInBookVerdict::Fail);
+
+        assert_eq!(verdict_from_oracle_consistency(2), OracleConsistencyVerdict::Fail);
+        assert_eq!(verdict_from_assert_pass(3), AssertPassVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 8: Family coverage — verdicts are chapter-identity-agnostic.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn family_coverage_uniform_schema() {
+        // All 27 chapters share the same falsification schema. The verdict
+        // logic doesn't depend on which chapter is being checked.
+        for ch in 1..=AC_APRBOOK_TOTAL_CHAPTERS {
+            let chapter_id = format!("apr-book-ch{ch:02}");
+            assert_eq!(
+                verdict_from_book_example_exit(0),
+                BookExampleExitVerdict::Pass,
+                "{chapter_id} healthy example"
+            );
+        }
+    }
+}

--- a/crates/aprender-core/src/format/aprcorpus_001_005.rs
+++ b/crates/aprender-core/src/format/aprcorpus_001_005.rs
@@ -1,0 +1,311 @@
+// `apr-corpus-*` family algorithm-level PARTIAL discharge for the 5
+// falsification conditions shared by every `apr-corpus-*-v1.yaml` contract.
+//
+// Contracts: `contracts/apr-corpus-*.yaml` (13 contracts × 5 conditions =
+// 65 falsifier instantiations).
+//
+// All apr-corpus-* contracts (vllm, jax, hugging-face, lean, ludwig, tgi,
+// databricks, etc.) share an identical schema. Each declares 5
+// falsification conditions:
+//
+//   1. "Repository contains zero test files" (P0 — add_tests)
+//   2. "No Rust equivalent mapping documented" (P1 — add_mapping)
+//   3. "Corpus not indexed in oracle RAG" (P1 — reindex)
+//   4. "Last commit older than 180 days (staleness)" (P1 — refresh_or_archive)
+//   5. "Ground-truth pattern contradicts current aprender API" (P0 — update_pattern)
+//
+// One verdict module satisfies the algorithm-level pin for all 13
+// apr-corpus contracts. Live discharge is `apr oracle --rag-index` +
+// `gh repo` queries; this module pins the predicates so future bulk
+// corpus operations cannot drift on the shape of any of the 5
+// invariants.
+//
+// Local IDs FALSIFY-APRCORPUS-001..005 are synthesized to give each
+// unkeyed YAML entry a stable handle.
+
+/// Staleness threshold per FALSIFY-APRCORPUS-004.
+pub const AC_APRCORPUS_STALENESS_DAYS: u32 = 180;
+
+/// Minimum test file count per FALSIFY-APRCORPUS-001 (the contract test
+/// is "Repository contains zero test files" — exactly 0 fails).
+pub const AC_APRCORPUS_MIN_TEST_FILES: u32 = 1;
+
+// =============================================================================
+// FALSIFY-APRCORPUS-001 — repository has at least 1 test file
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CorpusTestFilesVerdict {
+    /// At least 1 test file present.
+    Pass,
+    /// Zero test files (P0 regression).
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_corpus_test_files(test_file_count: u32) -> CorpusTestFilesVerdict {
+    if test_file_count >= AC_APRCORPUS_MIN_TEST_FILES {
+        CorpusTestFilesVerdict::Pass
+    } else {
+        CorpusTestFilesVerdict::Fail
+    }
+}
+
+// =============================================================================
+// FALSIFY-APRCORPUS-002 — Rust equivalent mapping documented
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RustMappingVerdict {
+    /// Mapping documented (e.g., README has a "Rust equivalent" / "aprender
+    /// mapping" section, or every pattern file declares its Rust analogue).
+    Pass,
+    /// No mapping documented (P1).
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_rust_mapping(mapping_documented: bool) -> RustMappingVerdict {
+    if mapping_documented {
+        RustMappingVerdict::Pass
+    } else {
+        RustMappingVerdict::Fail
+    }
+}
+
+// =============================================================================
+// FALSIFY-APRCORPUS-003 — corpus indexed in oracle RAG
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RagIndexedVerdict {
+    /// `apr oracle --rag` finds at least 1 pattern in the corpus's domain.
+    Pass,
+    /// Domain query returns zero matches (P1).
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_rag_indexed(rag_match_count: u32) -> RagIndexedVerdict {
+    if rag_match_count >= 1 {
+        RagIndexedVerdict::Pass
+    } else {
+        RagIndexedVerdict::Fail
+    }
+}
+
+// =============================================================================
+// FALSIFY-APRCORPUS-004 — last commit within 180 days
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CorpusFreshnessVerdict {
+    /// Last commit ≤ 180 days ago.
+    Pass,
+    /// Last commit > 180 days ago (P1 — refresh_or_archive).
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_corpus_freshness(days_since_last_commit: u32) -> CorpusFreshnessVerdict {
+    if days_since_last_commit <= AC_APRCORPUS_STALENESS_DAYS {
+        CorpusFreshnessVerdict::Pass
+    } else {
+        CorpusFreshnessVerdict::Fail
+    }
+}
+
+// =============================================================================
+// FALSIFY-APRCORPUS-005 — ground-truth pattern doesn't contradict aprender API
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ApiConsistencyVerdict {
+    /// All ground-truth patterns reference current aprender API surface.
+    Pass,
+    /// At least one pattern references removed/renamed API (P0 — update_pattern).
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_api_consistency(contradicting_pattern_count: u32) -> ApiConsistencyVerdict {
+    if contradicting_pattern_count == 0 {
+        ApiConsistencyVerdict::Pass
+    } else {
+        ApiConsistencyVerdict::Fail
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -------------------------------------------------------------------------
+    // Section 1: Provenance pins.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn provenance_staleness_180_days() {
+        assert_eq!(AC_APRCORPUS_STALENESS_DAYS, 180);
+    }
+
+    #[test]
+    fn provenance_min_test_files_is_1() {
+        // Contract gate is "Repository contains ZERO test files" → fail.
+        // Pass requires ≥ 1.
+        assert_eq!(AC_APRCORPUS_MIN_TEST_FILES, 1);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 2: APRCORPUS-001 test files.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn ac001_pass_one_test_file() {
+        assert_eq!(verdict_from_corpus_test_files(1), CorpusTestFilesVerdict::Pass);
+    }
+
+    #[test]
+    fn ac001_pass_many_test_files() {
+        assert_eq!(verdict_from_corpus_test_files(100), CorpusTestFilesVerdict::Pass);
+    }
+
+    #[test]
+    fn ac001_fail_zero_test_files() {
+        assert_eq!(verdict_from_corpus_test_files(0), CorpusTestFilesVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 3: APRCORPUS-002 Rust mapping.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn ac002_pass_mapping_documented() {
+        assert_eq!(verdict_from_rust_mapping(true), RustMappingVerdict::Pass);
+    }
+
+    #[test]
+    fn ac002_fail_no_mapping() {
+        assert_eq!(verdict_from_rust_mapping(false), RustMappingVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 4: APRCORPUS-003 RAG indexed.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn ac003_pass_one_match() {
+        assert_eq!(verdict_from_rag_indexed(1), RagIndexedVerdict::Pass);
+    }
+
+    #[test]
+    fn ac003_pass_many_matches() {
+        assert_eq!(verdict_from_rag_indexed(50), RagIndexedVerdict::Pass);
+    }
+
+    #[test]
+    fn ac003_fail_zero_matches() {
+        assert_eq!(verdict_from_rag_indexed(0), RagIndexedVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 5: APRCORPUS-004 freshness.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn ac004_pass_recent_commit() {
+        assert_eq!(verdict_from_corpus_freshness(7), CorpusFreshnessVerdict::Pass);
+    }
+
+    #[test]
+    fn ac004_pass_at_threshold() {
+        // The contract says "older than 180 days" — exactly 180 still passes.
+        assert_eq!(verdict_from_corpus_freshness(180), CorpusFreshnessVerdict::Pass);
+    }
+
+    #[test]
+    fn ac004_fail_one_day_past() {
+        assert_eq!(verdict_from_corpus_freshness(181), CorpusFreshnessVerdict::Fail);
+    }
+
+    #[test]
+    fn ac004_fail_long_stale() {
+        assert_eq!(verdict_from_corpus_freshness(365), CorpusFreshnessVerdict::Fail);
+    }
+
+    #[test]
+    fn ac004_pass_zero_days() {
+        // Just-pushed corpus.
+        assert_eq!(verdict_from_corpus_freshness(0), CorpusFreshnessVerdict::Pass);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 6: APRCORPUS-005 API consistency.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn ac005_pass_no_contradictions() {
+        assert_eq!(verdict_from_api_consistency(0), ApiConsistencyVerdict::Pass);
+    }
+
+    #[test]
+    fn ac005_fail_one_contradiction() {
+        assert_eq!(verdict_from_api_consistency(1), ApiConsistencyVerdict::Fail);
+    }
+
+    #[test]
+    fn ac005_fail_many_contradictions() {
+        assert_eq!(verdict_from_api_consistency(20), ApiConsistencyVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 7: Realistic — full healthy corpus passes all 5.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn realistic_full_healthy_corpus_passes_all_5() {
+        // Maps to a typical paiml/<lang>-ground-truth-corpus repo state:
+        // 35 test files, mapping documented, RAG returns 12 matches,
+        // last commit 14 days ago, no API contradictions.
+        assert_eq!(verdict_from_corpus_test_files(35), CorpusTestFilesVerdict::Pass);
+        assert_eq!(verdict_from_rust_mapping(true), RustMappingVerdict::Pass);
+        assert_eq!(verdict_from_rag_indexed(12), RagIndexedVerdict::Pass);
+        assert_eq!(verdict_from_corpus_freshness(14), CorpusFreshnessVerdict::Pass);
+        assert_eq!(verdict_from_api_consistency(0), ApiConsistencyVerdict::Pass);
+    }
+
+    #[test]
+    fn realistic_pre_fix_all_5_failures() {
+        // The exact regression class for each gate.
+        assert_eq!(verdict_from_corpus_test_files(0), CorpusTestFilesVerdict::Fail);
+        assert_eq!(verdict_from_rust_mapping(false), RustMappingVerdict::Fail);
+        assert_eq!(verdict_from_rag_indexed(0), RagIndexedVerdict::Fail);
+        assert_eq!(verdict_from_corpus_freshness(365), CorpusFreshnessVerdict::Fail);
+        assert_eq!(verdict_from_api_consistency(3), ApiConsistencyVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 8: Family coverage — verdicts are corpus-identity-agnostic.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn family_coverage_uniform_schema() {
+        // The 13 apr-corpus-* contracts share this falsification schema.
+        // Verdict logic doesn't depend on which corpus is being checked.
+        let corpora = [
+            "vllm-ground-truth",
+            "jax-ground-truth",
+            "hugging-face-ground-truth",
+            "lean-ground-truth",
+            "ludwig-ground-truth",
+            "tgi-ground-truth",
+            "databricks-ground-truth",
+            "databricks-scala-ground-truth",
+            "mixed-python-rust-ground-truth",
+            "mixed-rust-lean-ground-truth",
+            "safe-lua-groundtruth",
+            "tiny-model-ground-truth",
+            "algorithm-competition-corpus",
+        ];
+        assert_eq!(corpora.len(), 13);
+        for c in corpora {
+            assert_eq!(
+                verdict_from_corpus_test_files(10),
+                CorpusTestFilesVerdict::Pass,
+                "corpus {c} healthy"
+            );
+        }
+    }
+}

--- a/crates/aprender-core/src/format/aprdocs_001_005.rs
+++ b/crates/aprender-core/src/format/aprdocs_001_005.rs
@@ -1,0 +1,363 @@
+// `apr-docs-v1` algorithm-level PARTIAL discharge for the 5
+// FALSIFY-README gates (install command, apr run example, no apr-cli
+// reference, no stale repos, mdbook build).
+//
+// Contract: `contracts/apr-docs-v1.yaml`.
+//
+// ## Disambiguation
+//
+// `readme-claims-v1.yaml` (task #256) is a sibling contract that pins
+// quantitative claims (crate count, contract count, CLI command count,
+// cookbook link). Despite both contracts sharing the FALSIFY-README-*
+// prefix in some descriptions, the two contracts cover different
+// invariants. This file binds `apr-docs-v1` only.
+//
+// ## What this file proves NOW (`PARTIAL_ALGORITHM_LEVEL`)
+//
+// Five pure decision predicates over the README text and an mdbook exit
+// code. Live discharge is `make tier3` running the falsification tests
+// directly (`grep -q "cargo install aprender" README.md`, `mdbook build
+// book/`). Algorithm-level pinning prevents drift on the install-command
+// brand and the no-stale-repos invariant.
+
+/// Required install command per FALSIFY-README-001.
+pub const AC_DOCS_REQUIRED_INSTALL: &str = "cargo install aprender";
+
+/// Required CLI usage example per FALSIFY-README-002.
+pub const AC_DOCS_REQUIRED_USAGE: &str = "apr run";
+
+/// Forbidden install command per FALSIFY-README-003.
+pub const AC_DOCS_FORBIDDEN_INSTALL: &str = "cargo install apr-cli";
+
+/// Repo names that MUST NOT appear as `cargo install <name>` per
+/// FALSIFY-README-004 (post-APR-MONO-consolidation).
+pub const AC_DOCS_FORBIDDEN_REPOS: [&str; 4] = ["trueno", "realizar", "entrenar", "batuta"];
+
+// =============================================================================
+// FALSIFY-README-001 — `cargo install aprender` present
+// =============================================================================
+
+/// Verdict for FALSIFY-README-001.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InstallCommandVerdict {
+    /// README contains `cargo install aprender`.
+    Pass,
+    /// String absent.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_install_command(readme: &str) -> InstallCommandVerdict {
+    if readme.contains(AC_DOCS_REQUIRED_INSTALL) {
+        InstallCommandVerdict::Pass
+    } else {
+        InstallCommandVerdict::Fail
+    }
+}
+
+// =============================================================================
+// FALSIFY-README-002 — `apr run` example present
+// =============================================================================
+
+/// Verdict for FALSIFY-README-002.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AprRunExampleVerdict {
+    /// README contains `apr run`.
+    Pass,
+    /// String absent.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_apr_run_example(readme: &str) -> AprRunExampleVerdict {
+    if readme.contains(AC_DOCS_REQUIRED_USAGE) {
+        AprRunExampleVerdict::Pass
+    } else {
+        AprRunExampleVerdict::Fail
+    }
+}
+
+// =============================================================================
+// FALSIFY-README-003 — `cargo install apr-cli` ABSENT
+// =============================================================================
+
+/// Verdict for FALSIFY-README-003.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NoAprCliInstallVerdict {
+    /// README does NOT contain `cargo install apr-cli`.
+    Pass,
+    /// Forbidden string is present.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_no_apr_cli_install(readme: &str) -> NoAprCliInstallVerdict {
+    if readme.contains(AC_DOCS_FORBIDDEN_INSTALL) {
+        NoAprCliInstallVerdict::Fail
+    } else {
+        NoAprCliInstallVerdict::Pass
+    }
+}
+
+// =============================================================================
+// FALSIFY-README-004 — no stale repo install commands
+// =============================================================================
+
+/// Verdict for FALSIFY-README-004.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NoStaleReposVerdict {
+    /// README does not contain `cargo install <stale_repo>` for any of
+    /// {trueno, realizar, entrenar, batuta}.
+    Pass,
+    /// At least one stale repo `cargo install` reference present.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_no_stale_repos(readme: &str) -> NoStaleReposVerdict {
+    for repo in AC_DOCS_FORBIDDEN_REPOS {
+        let needle = format!("cargo install {repo}");
+        // Match the gate's `\b` boundary: `cargo install batuta-something` MUST
+        // not trigger; only `cargo install batuta` (followed by whitespace,
+        // newline, or end-of-text) does.
+        if let Some(pos) = readme.find(&needle) {
+            let after = &readme[pos + needle.len()..];
+            // Word boundary: next char is not alphanumeric, underscore, or hyphen.
+            let boundary_ok = after
+                .chars()
+                .next()
+                .is_none_or(|c| !c.is_ascii_alphanumeric() && c != '_' && c != '-');
+            if boundary_ok {
+                return NoStaleReposVerdict::Fail;
+            }
+        }
+    }
+    NoStaleReposVerdict::Pass
+}
+
+// =============================================================================
+// FALSIFY-README-005 — `mdbook build book/` exits 0
+// =============================================================================
+
+/// Verdict for FALSIFY-README-005.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MdbookBuildVerdict {
+    /// `mdbook build book/` exited 0.
+    Pass,
+    /// Non-zero exit.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_mdbook_build(exit_code: i32) -> MdbookBuildVerdict {
+    if exit_code == 0 {
+        MdbookBuildVerdict::Pass
+    } else {
+        MdbookBuildVerdict::Fail
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -------------------------------------------------------------------------
+    // Section 1: Provenance pins.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn provenance_install_command_string() {
+        assert_eq!(AC_DOCS_REQUIRED_INSTALL, "cargo install aprender");
+    }
+
+    #[test]
+    fn provenance_required_usage_string() {
+        assert_eq!(AC_DOCS_REQUIRED_USAGE, "apr run");
+    }
+
+    #[test]
+    fn provenance_forbidden_install_string() {
+        assert_eq!(AC_DOCS_FORBIDDEN_INSTALL, "cargo install apr-cli");
+    }
+
+    #[test]
+    fn provenance_forbidden_repos_count_4() {
+        assert_eq!(AC_DOCS_FORBIDDEN_REPOS.len(), 4);
+        assert!(AC_DOCS_FORBIDDEN_REPOS.contains(&"trueno"));
+        assert!(AC_DOCS_FORBIDDEN_REPOS.contains(&"realizar"));
+        assert!(AC_DOCS_FORBIDDEN_REPOS.contains(&"entrenar"));
+        assert!(AC_DOCS_FORBIDDEN_REPOS.contains(&"batuta"));
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 2: README-001 install command.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn r001_pass_install_present() {
+        let r = "## Install\n```bash\ncargo install aprender\n```\n";
+        assert_eq!(verdict_from_install_command(r), InstallCommandVerdict::Pass);
+    }
+
+    #[test]
+    fn r001_fail_install_absent() {
+        let r = "## Install\nDownload the binary from releases.\n";
+        assert_eq!(verdict_from_install_command(r), InstallCommandVerdict::Fail);
+    }
+
+    #[test]
+    fn r001_fail_empty_readme() {
+        assert_eq!(verdict_from_install_command(""), InstallCommandVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 3: README-002 apr run example.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn r002_pass_apr_run_present() {
+        let r = "## Quickstart\n```bash\napr run hf://Qwen/Qwen3-Coder-30B-A3B\n```";
+        assert_eq!(verdict_from_apr_run_example(r), AprRunExampleVerdict::Pass);
+    }
+
+    #[test]
+    fn r002_fail_apr_run_absent() {
+        let r = "## Quickstart\nSee the docs site for usage.";
+        assert_eq!(verdict_from_apr_run_example(r), AprRunExampleVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 4: README-003 no apr-cli install.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn r003_pass_no_apr_cli_install() {
+        let r = "## Install\n`cargo install aprender`\n";
+        assert_eq!(verdict_from_no_apr_cli_install(r), NoAprCliInstallVerdict::Pass);
+    }
+
+    #[test]
+    fn r003_fail_apr_cli_install_present() {
+        let r = "## Install\n`cargo install apr-cli`\n";
+        assert_eq!(verdict_from_no_apr_cli_install(r), NoAprCliInstallVerdict::Fail);
+    }
+
+    #[test]
+    fn r003_pass_apr_cli_mentioned_but_not_installed() {
+        // The crate name appears in module paths but not as a cargo install.
+        let r = "The internal `apr-cli` crate provides command logic.";
+        assert_eq!(verdict_from_no_apr_cli_install(r), NoAprCliInstallVerdict::Pass);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 5: README-004 no stale repos.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn r004_pass_only_aprender() {
+        let r = "## Install\n`cargo install aprender`";
+        assert_eq!(verdict_from_no_stale_repos(r), NoStaleReposVerdict::Pass);
+    }
+
+    #[test]
+    fn r004_fail_install_trueno() {
+        let r = "## Install\n`cargo install trueno`";
+        assert_eq!(verdict_from_no_stale_repos(r), NoStaleReposVerdict::Fail);
+    }
+
+    #[test]
+    fn r004_fail_install_realizar() {
+        let r = "Install: cargo install realizar";
+        assert_eq!(verdict_from_no_stale_repos(r), NoStaleReposVerdict::Fail);
+    }
+
+    #[test]
+    fn r004_fail_install_entrenar() {
+        let r = "$ cargo install entrenar\n";
+        assert_eq!(verdict_from_no_stale_repos(r), NoStaleReposVerdict::Fail);
+    }
+
+    #[test]
+    fn r004_fail_install_batuta() {
+        let r = "## Install\n```bash\ncargo install batuta\n```";
+        assert_eq!(verdict_from_no_stale_repos(r), NoStaleReposVerdict::Fail);
+    }
+
+    #[test]
+    fn r004_pass_stale_name_in_history_context() {
+        // Migration/history context — the gate explicitly allows stale names
+        // to appear; only `cargo install <name>\b` is forbidden.
+        let r = "Pre-APR-MONO, separate crates trueno, realizar, entrenar, batuta were installed individually.";
+        assert_eq!(verdict_from_no_stale_repos(r), NoStaleReposVerdict::Pass);
+    }
+
+    #[test]
+    fn r004_pass_stale_name_with_suffix() {
+        // Word boundary: `cargo install trueno-foo` MUST pass.
+        let r = "cargo install trueno-extras";
+        assert_eq!(verdict_from_no_stale_repos(r), NoStaleReposVerdict::Pass);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 6: README-005 mdbook build.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn r005_pass_exit_zero() {
+        assert_eq!(verdict_from_mdbook_build(0), MdbookBuildVerdict::Pass);
+    }
+
+    #[test]
+    fn r005_fail_exit_nonzero() {
+        assert_eq!(verdict_from_mdbook_build(1), MdbookBuildVerdict::Fail);
+    }
+
+    #[test]
+    fn r005_fail_exit_signal() {
+        assert_eq!(verdict_from_mdbook_build(137), MdbookBuildVerdict::Fail);
+    }
+
+    #[test]
+    fn r005_fail_exit_negative() {
+        assert_eq!(verdict_from_mdbook_build(-1), MdbookBuildVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 7: Realistic — a healthy README + clean book build passes all 5.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn realistic_full_healthy_readme_passes_all_5() {
+        let readme = "\
+# aprender
+
+Next-generation ML framework in pure Rust.
+
+## Install
+
+```bash
+cargo install aprender
+```
+
+## Quickstart
+
+```bash
+apr run hf://Qwen/Qwen3-Coder-30B-A3B
+```
+
+## History
+
+Pre-APR-MONO, the framework was split across trueno, realizar, entrenar,
+and batuta. These are now subsumed by aprender.
+";
+        assert_eq!(verdict_from_install_command(readme), InstallCommandVerdict::Pass);
+        assert_eq!(verdict_from_apr_run_example(readme), AprRunExampleVerdict::Pass);
+        assert_eq!(verdict_from_no_apr_cli_install(readme), NoAprCliInstallVerdict::Pass);
+        assert_eq!(verdict_from_no_stale_repos(readme), NoStaleReposVerdict::Pass);
+        assert_eq!(verdict_from_mdbook_build(0), MdbookBuildVerdict::Pass);
+    }
+
+    #[test]
+    fn realistic_pre_fix_all_5_failures() {
+        // The exact regression class: bad README + book builds broken.
+        let bad = "## Install\n`cargo install apr-cli`\n## Train\n`cargo install trueno`";
+        assert_eq!(verdict_from_install_command(bad), InstallCommandVerdict::Fail);
+        assert_eq!(verdict_from_apr_run_example(bad), AprRunExampleVerdict::Fail);
+        assert_eq!(verdict_from_no_apr_cli_install(bad), NoAprCliInstallVerdict::Fail);
+        assert_eq!(verdict_from_no_stale_repos(bad), NoStaleReposVerdict::Fail);
+        assert_eq!(verdict_from_mdbook_build(1), MdbookBuildVerdict::Fail);
+    }
+}

--- a/crates/aprender-core/src/format/aprpage_001_005.rs
+++ b/crates/aprender-core/src/format/aprpage_001_005.rs
@@ -1,0 +1,373 @@
+// `apr-page-*` family algorithm-level PARTIAL discharge for the 5
+// falsification conditions shared by every `apr-page-*-v1.yaml` contract.
+//
+// Contracts: `contracts/apr-page-*.yaml` (257 contracts × 5 conditions =
+// 1,285 falsifier instantiations).
+//
+// All apr-page-* contracts (book pages, best-practices pages, chapter
+// pages, etc.) share an identical schema. Each declares 5 falsification
+// conditions:
+//
+//   1. "Page .md file does not exist at declared path"
+//   2. "Example does not compile"
+//   3. "Example exits non-zero"
+//   4. "Section in .md not listed in contract"
+//   5. "Legacy name in page text"
+//
+// One verdict module satisfies the algorithm-level pin for all 257
+// contracts. Live discharge is `pv validate` per-page; this module
+// pins the predicates so future bulk page edits cannot drift on the
+// shape of any of the 5 invariants.
+//
+// Local IDs FALSIFY-APRPAGE-001..005 are synthesized to give each
+// unkeyed YAML entry a stable handle.
+
+use std::collections::HashSet;
+
+/// Legacy names whose appearance in apr-page-* page text REQUIRES
+/// removal post-APR-MONO consolidation (matches the same set as
+/// apr-org-taxonomy-v1 and apr-docs-v1).
+pub const AC_APRPAGE_LEGACY_NAMES: [&str; 4] = ["trueno", "realizar", "entrenar", "batuta"];
+
+// =============================================================================
+// FALSIFY-APRPAGE-001 — page .md file exists at declared path
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PageExistsVerdict {
+    /// Path declared in contract.page.path resolves to a real file.
+    Pass,
+    /// Path missing on disk.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_page_exists(path_exists_on_disk: bool) -> PageExistsVerdict {
+    if path_exists_on_disk {
+        PageExistsVerdict::Pass
+    } else {
+        PageExistsVerdict::Fail
+    }
+}
+
+// =============================================================================
+// FALSIFY-APRPAGE-002 — example compiles
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExampleCompileVerdict {
+    /// `cargo build` (or rustc) on the page's example exits 0.
+    /// If the contract declares no example (`page.example == ""`),
+    /// the gate is vacuously satisfied.
+    Pass,
+    /// Compile failure (non-zero rustc exit).
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_example_compiles(
+    has_example: bool,
+    compile_exit_code: i32,
+) -> ExampleCompileVerdict {
+    if !has_example {
+        return ExampleCompileVerdict::Pass;
+    }
+    if compile_exit_code == 0 {
+        ExampleCompileVerdict::Pass
+    } else {
+        ExampleCompileVerdict::Fail
+    }
+}
+
+// =============================================================================
+// FALSIFY-APRPAGE-003 — example exits 0 at runtime
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExampleRunVerdict {
+    /// Compiled example, when run, exits 0. Vacuous if no example.
+    Pass,
+    /// Non-zero exit.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_example_run(has_example: bool, run_exit_code: i32) -> ExampleRunVerdict {
+    if !has_example {
+        return ExampleRunVerdict::Pass;
+    }
+    if run_exit_code == 0 {
+        ExampleRunVerdict::Pass
+    } else {
+        ExampleRunVerdict::Fail
+    }
+}
+
+// =============================================================================
+// FALSIFY-APRPAGE-004 — every section in .md is listed in contract
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SectionListedVerdict {
+    /// Every heading found in the rendered .md is also present in the
+    /// contract's `sections[*].heading` list.
+    Pass,
+    /// At least one heading in the file is missing from the contract.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_section_listed(
+    md_headings: &[&str],
+    contract_headings: &[&str],
+) -> SectionListedVerdict {
+    let allowed: HashSet<&&str> = contract_headings.iter().collect();
+    for h in md_headings {
+        if !allowed.contains(h) {
+            return SectionListedVerdict::Fail;
+        }
+    }
+    SectionListedVerdict::Pass
+}
+
+// =============================================================================
+// FALSIFY-APRPAGE-005 — no legacy names in page text
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NoLegacyNameVerdict {
+    /// Page text contains none of {trueno, realizar, entrenar, batuta},
+    /// OR every occurrence is in a "MOVED"/migration context (matches
+    /// the same MOVED-redirect tag used by apr-org-taxonomy-v1).
+    Pass,
+    /// Legacy name appears without a MOVED/migration tag.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_no_legacy_name(page_text: &str) -> NoLegacyNameVerdict {
+    let lower = page_text.to_lowercase();
+    let mentions_legacy = AC_APRPAGE_LEGACY_NAMES.iter().any(|n| lower.contains(n));
+    if !mentions_legacy {
+        return NoLegacyNameVerdict::Pass;
+    }
+    if lower.contains("moved") || lower.contains("migration") || lower.contains("history") {
+        NoLegacyNameVerdict::Pass
+    } else {
+        NoLegacyNameVerdict::Fail
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -------------------------------------------------------------------------
+    // Section 1: Provenance pins.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn provenance_legacy_names_count_4() {
+        assert_eq!(AC_APRPAGE_LEGACY_NAMES.len(), 4);
+        assert!(AC_APRPAGE_LEGACY_NAMES.contains(&"trueno"));
+        assert!(AC_APRPAGE_LEGACY_NAMES.contains(&"realizar"));
+        assert!(AC_APRPAGE_LEGACY_NAMES.contains(&"entrenar"));
+        assert!(AC_APRPAGE_LEGACY_NAMES.contains(&"batuta"));
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 2: APRPAGE-001 page exists.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn ap001_pass_path_resolves() {
+        assert_eq!(verdict_from_page_exists(true), PageExistsVerdict::Pass);
+    }
+
+    #[test]
+    fn ap001_fail_path_missing() {
+        assert_eq!(verdict_from_page_exists(false), PageExistsVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 3: APRPAGE-002 example compiles.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn ap002_pass_no_example_vacuous() {
+        // Contract declares example: "" → no example → vacuous Pass.
+        assert_eq!(verdict_from_example_compiles(false, 1), ExampleCompileVerdict::Pass);
+    }
+
+    #[test]
+    fn ap002_pass_example_compiles_clean() {
+        assert_eq!(verdict_from_example_compiles(true, 0), ExampleCompileVerdict::Pass);
+    }
+
+    #[test]
+    fn ap002_fail_example_compile_error() {
+        assert_eq!(verdict_from_example_compiles(true, 1), ExampleCompileVerdict::Fail);
+    }
+
+    #[test]
+    fn ap002_fail_example_compile_panic() {
+        // rustc panic exit code = 101.
+        assert_eq!(verdict_from_example_compiles(true, 101), ExampleCompileVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 4: APRPAGE-003 example runs clean.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn ap003_pass_no_example_vacuous() {
+        assert_eq!(verdict_from_example_run(false, 1), ExampleRunVerdict::Pass);
+    }
+
+    #[test]
+    fn ap003_pass_example_exits_zero() {
+        assert_eq!(verdict_from_example_run(true, 0), ExampleRunVerdict::Pass);
+    }
+
+    #[test]
+    fn ap003_fail_example_panic() {
+        assert_eq!(verdict_from_example_run(true, 101), ExampleRunVerdict::Fail);
+    }
+
+    #[test]
+    fn ap003_fail_example_signal_terminated() {
+        assert_eq!(verdict_from_example_run(true, 137), ExampleRunVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 5: APRPAGE-004 section listed.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn ap004_pass_md_subset_of_contract() {
+        let md = ["Dependency Graph", "By Category"];
+        let contract = ["Dependency Graph", "By Category", "Future Work"];
+        assert_eq!(verdict_from_section_listed(&md, &contract), SectionListedVerdict::Pass);
+    }
+
+    #[test]
+    fn ap004_pass_empty_md() {
+        // No headings in the file ⇒ vacuously listed.
+        let contract = ["A", "B"];
+        assert_eq!(verdict_from_section_listed(&[], &contract), SectionListedVerdict::Pass);
+    }
+
+    #[test]
+    fn ap004_fail_undeclared_section() {
+        let md = ["Dependency Graph", "Unauthorized New Section"];
+        let contract = ["Dependency Graph"];
+        assert_eq!(verdict_from_section_listed(&md, &contract), SectionListedVerdict::Fail);
+    }
+
+    #[test]
+    fn ap004_fail_empty_contract_with_md_headings() {
+        let md = ["A"];
+        let contract: [&str; 0] = [];
+        assert_eq!(verdict_from_section_listed(&md, &contract), SectionListedVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 6: APRPAGE-005 no legacy names.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn ap005_pass_no_legacy_mentions() {
+        assert_eq!(
+            verdict_from_no_legacy_name("aprender ML framework — apr CLI."),
+            NoLegacyNameVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn ap005_pass_legacy_in_history_context() {
+        let p = "Pre-APR-MONO history: trueno, realizar, entrenar, batuta were separate crates.";
+        assert_eq!(verdict_from_no_legacy_name(p), NoLegacyNameVerdict::Pass);
+    }
+
+    #[test]
+    fn ap005_pass_legacy_with_moved_tag() {
+        let p = "trueno (MOVED to crates/aprender-compute/)";
+        assert_eq!(verdict_from_no_legacy_name(p), NoLegacyNameVerdict::Pass);
+    }
+
+    #[test]
+    fn ap005_pass_legacy_with_migration_tag() {
+        let p = "Migration note: realizar → crates/aprender-serve/";
+        assert_eq!(verdict_from_no_legacy_name(p), NoLegacyNameVerdict::Pass);
+    }
+
+    #[test]
+    fn ap005_fail_active_legacy_install() {
+        let p = "Install batuta from crates.io and run `batuta serve`.";
+        assert_eq!(verdict_from_no_legacy_name(p), NoLegacyNameVerdict::Fail);
+    }
+
+    #[test]
+    fn ap005_fail_each_legacy_name_active() {
+        for name in AC_APRPAGE_LEGACY_NAMES {
+            let p = format!("Use {name} for SIMD operations.");
+            assert_eq!(
+                verdict_from_no_legacy_name(&p),
+                NoLegacyNameVerdict::Fail,
+                "active legacy name {name} must Fail"
+            );
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 7: Realistic — full healthy page passes all 5.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn realistic_full_healthy_page_passes_all_5() {
+        // 001: page exists.
+        assert_eq!(verdict_from_page_exists(true), PageExistsVerdict::Pass);
+        // 002: no example in contract → vacuous.
+        assert_eq!(verdict_from_example_compiles(false, 1), ExampleCompileVerdict::Pass);
+        // 003: vacuous run.
+        assert_eq!(verdict_from_example_run(false, 1), ExampleRunVerdict::Pass);
+        // 004: every md heading is in contract.
+        let md = ["Dependency Graph", "By Category"];
+        let contract = ["Dependency Graph", "By Category"];
+        assert_eq!(verdict_from_section_listed(&md, &contract), SectionListedVerdict::Pass);
+        // 005: page text with MOVED tag for legacy mentions.
+        let page = "Architecture: aprender-compute (MOVED from trueno).";
+        assert_eq!(verdict_from_no_legacy_name(page), NoLegacyNameVerdict::Pass);
+    }
+
+    #[test]
+    fn realistic_pre_fix_all_5_failures() {
+        // 001: missing path.
+        assert_eq!(verdict_from_page_exists(false), PageExistsVerdict::Fail);
+        // 002: example compile error.
+        assert_eq!(verdict_from_example_compiles(true, 1), ExampleCompileVerdict::Fail);
+        // 003: example panicked.
+        assert_eq!(verdict_from_example_run(true, 101), ExampleRunVerdict::Fail);
+        // 004: undeclared section in md.
+        let md = ["Dependency Graph", "Drift Section"];
+        let contract = ["Dependency Graph"];
+        assert_eq!(verdict_from_section_listed(&md, &contract), SectionListedVerdict::Fail);
+        // 005: active legacy install instructions.
+        let bad = "Install: cargo install batuta";
+        assert_eq!(verdict_from_no_legacy_name(bad), NoLegacyNameVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 8: Family coverage — these verdicts work for ALL 257 apr-page-*.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn family_coverage_uniform_schema() {
+        // Smoke: the verdicts treat page identity as opaque. The same
+        // verdict_from_* set covers architecture-crate-map, chapters-ch01,
+        // best-practices-api-design, etc. The contract path matters
+        // only at the live harness layer.
+        let pages = [
+            "architecture-crate-map",
+            "chapters-ch01-why-rust",
+            "best-practices-api-design",
+            "advanced-testing-mutation-testing",
+        ];
+        for p in pages {
+            // Each page passes 001 if its declared .md exists.
+            assert_eq!(verdict_from_page_exists(true), PageExistsVerdict::Pass, "{p}");
+        }
+    }
+}

--- a/crates/aprender-core/src/format/aprserve_001_004.rs
+++ b/crates/aprender-core/src/format/aprserve_001_004.rs
@@ -1,0 +1,388 @@
+// `apr-serve-v1` algorithm-level PARTIAL discharge for the 4
+// inference-server falsifiers (health-readiness, graceful shutdown,
+// 404 routing, concurrent inference isolation).
+//
+// Contract: `contracts/apr-serve-v1.yaml`.
+
+/// Default graceful-shutdown timeout (30 seconds) per server_lifecycle
+/// invariant.
+pub const AC_APRSERVE_SHUTDOWN_TIMEOUT_S: u32 = 30;
+
+/// Server lifecycle states per the contract's state machine.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ServerState {
+    Init,
+    Binding,
+    Loading,
+    Ready,
+    Draining,
+    Stopped,
+}
+
+// =============================================================================
+// FALSIFY-SRV-001 — health returns 200 only when ready
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HealthReadinessVerdict {
+    /// /health returns 200 only in Ready state; 503 in all others.
+    Pass,
+    /// /health returned 200 in non-Ready state — health-lying regression.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_health_readiness(state: ServerState, http_status: u16) -> HealthReadinessVerdict {
+    match (state, http_status) {
+        (ServerState::Ready, 200) => HealthReadinessVerdict::Pass,
+        // 200 in any non-Ready state is the regression class.
+        (_, 200) => HealthReadinessVerdict::Fail,
+        // Any non-200 in Ready is also wrong (probably 503 by the test).
+        (ServerState::Ready, _) => HealthReadinessVerdict::Fail,
+        // Non-Ready state returning 503 (or any non-200) is correct.
+        _ => HealthReadinessVerdict::Pass,
+    }
+}
+
+// =============================================================================
+// FALSIFY-SRV-002 — graceful shutdown completes in-flight
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GracefulShutdownVerdict {
+    /// In-flight count == 0 before exit AND exit_code == 0 AND shutdown
+    /// duration ≤ timeout.
+    Pass,
+    /// In-flight requests dropped (connection reset), or timeout exceeded.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_graceful_shutdown(
+    in_flight_at_exit: u32,
+    exit_code: i32,
+    shutdown_duration_s: u32,
+) -> GracefulShutdownVerdict {
+    if in_flight_at_exit > 0 {
+        return GracefulShutdownVerdict::Fail;
+    }
+    if exit_code != 0 {
+        return GracefulShutdownVerdict::Fail;
+    }
+    if shutdown_duration_s > AC_APRSERVE_SHUTDOWN_TIMEOUT_S {
+        return GracefulShutdownVerdict::Fail;
+    }
+    GracefulShutdownVerdict::Pass
+}
+
+// =============================================================================
+// FALSIFY-SRV-003 — unknown path returns 404 (not 500 / HTML)
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnknownPathVerdict {
+    /// Status 404 AND Content-Type: application/json.
+    Pass,
+    /// 500, 200, or HTML response — fell through to default Actix handler.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_unknown_path(http_status: u16, content_type: &str) -> UnknownPathVerdict {
+    if http_status != 404 {
+        return UnknownPathVerdict::Fail;
+    }
+    let lower = content_type.to_lowercase();
+    if !lower.contains("application/json") {
+        return UnknownPathVerdict::Fail;
+    }
+    UnknownPathVerdict::Pass
+}
+
+// =============================================================================
+// FALSIFY-SRV-004 — concurrent inference isolation
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConcurrentIsolationVerdict {
+    /// All N concurrent identical requests at temperature=0 return
+    /// identical output (no KV-cache contamination).
+    Pass,
+    /// At least 2 distinct outputs across requests.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_concurrent_isolation(responses: &[&str]) -> ConcurrentIsolationVerdict {
+    if responses.is_empty() {
+        return ConcurrentIsolationVerdict::Fail;
+    }
+    let first = responses[0];
+    for r in responses.iter().skip(1) {
+        if *r != first {
+            return ConcurrentIsolationVerdict::Fail;
+        }
+    }
+    ConcurrentIsolationVerdict::Pass
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -------------------------------------------------------------------------
+    // Section 1: Provenance pins.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn provenance_shutdown_timeout_30s() {
+        assert_eq!(AC_APRSERVE_SHUTDOWN_TIMEOUT_S, 30);
+    }
+
+    #[test]
+    fn provenance_state_machine_six_states() {
+        // Smoke: count of valid lifecycle states matches contract enumeration.
+        let all = [
+            ServerState::Init,
+            ServerState::Binding,
+            ServerState::Loading,
+            ServerState::Ready,
+            ServerState::Draining,
+            ServerState::Stopped,
+        ];
+        assert_eq!(all.len(), 6);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 2: SRV-001 health readiness.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fs001_pass_ready_returns_200() {
+        assert_eq!(
+            verdict_from_health_readiness(ServerState::Ready, 200),
+            HealthReadinessVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fs001_pass_loading_returns_503() {
+        assert_eq!(
+            verdict_from_health_readiness(ServerState::Loading, 503),
+            HealthReadinessVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fs001_pass_init_returns_503() {
+        assert_eq!(
+            verdict_from_health_readiness(ServerState::Init, 503),
+            HealthReadinessVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fs001_pass_draining_returns_503() {
+        assert_eq!(
+            verdict_from_health_readiness(ServerState::Draining, 503),
+            HealthReadinessVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fs001_fail_loading_returns_200() {
+        // The exact regression: health-lying during model load.
+        assert_eq!(
+            verdict_from_health_readiness(ServerState::Loading, 200),
+            HealthReadinessVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fs001_fail_ready_returns_503() {
+        // Ready state must return 200, not 503.
+        assert_eq!(
+            verdict_from_health_readiness(ServerState::Ready, 503),
+            HealthReadinessVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 3: SRV-002 graceful shutdown.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fs002_pass_clean_shutdown() {
+        assert_eq!(
+            verdict_from_graceful_shutdown(0, 0, 5),
+            GracefulShutdownVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fs002_pass_at_timeout() {
+        assert_eq!(
+            verdict_from_graceful_shutdown(0, 0, 30),
+            GracefulShutdownVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fs002_fail_in_flight_dropped() {
+        assert_eq!(
+            verdict_from_graceful_shutdown(3, 0, 5),
+            GracefulShutdownVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fs002_fail_nonzero_exit() {
+        assert_eq!(
+            verdict_from_graceful_shutdown(0, 1, 5),
+            GracefulShutdownVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fs002_fail_timeout_exceeded() {
+        assert_eq!(
+            verdict_from_graceful_shutdown(0, 0, 31),
+            GracefulShutdownVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 4: SRV-003 unknown path 404 routing.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fs003_pass_404_json() {
+        assert_eq!(
+            verdict_from_unknown_path(404, "application/json"),
+            UnknownPathVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fs003_pass_404_json_charset() {
+        assert_eq!(
+            verdict_from_unknown_path(404, "application/json; charset=utf-8"),
+            UnknownPathVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fs003_fail_500_internal_error() {
+        // The regression: routing failure surfaced as 500.
+        assert_eq!(
+            verdict_from_unknown_path(500, "application/json"),
+            UnknownPathVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fs003_fail_404_html() {
+        // Actix default — HTML 404 is the regression class.
+        assert_eq!(
+            verdict_from_unknown_path(404, "text/html"),
+            UnknownPathVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fs003_fail_200_returned() {
+        assert_eq!(
+            verdict_from_unknown_path(200, "application/json"),
+            UnknownPathVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 5: SRV-004 concurrent inference isolation.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fs004_pass_10_identical() {
+        let r = ["The capital of France is Paris."; 10];
+        assert_eq!(
+            verdict_from_concurrent_isolation(&r),
+            ConcurrentIsolationVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fs004_pass_single_request() {
+        let r = ["A response"];
+        assert_eq!(
+            verdict_from_concurrent_isolation(&r),
+            ConcurrentIsolationVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fs004_fail_kv_cache_contamination() {
+        // The regression: req 7 leaked content from req 6.
+        let r = [
+            "Paris.", "Paris.", "Paris.", "Paris.", "Paris.",
+            "Paris.", "Paris.", "Lyon.", "Paris.", "Paris.",
+        ];
+        assert_eq!(
+            verdict_from_concurrent_isolation(&r),
+            ConcurrentIsolationVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fs004_fail_empty() {
+        let r: [&str; 0] = [];
+        assert_eq!(
+            verdict_from_concurrent_isolation(&r),
+            ConcurrentIsolationVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 6: Realistic — full healthy server passes all 4.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn realistic_healthy_server_passes_all_4() {
+        // Ready + 200, in-flight==0 + exit 0, 404 JSON, 5 identical responses.
+        assert_eq!(
+            verdict_from_health_readiness(ServerState::Ready, 200),
+            HealthReadinessVerdict::Pass
+        );
+        assert_eq!(
+            verdict_from_graceful_shutdown(0, 0, 8),
+            GracefulShutdownVerdict::Pass
+        );
+        assert_eq!(
+            verdict_from_unknown_path(404, "application/json"),
+            UnknownPathVerdict::Pass
+        );
+        let r = ["4", "4", "4", "4", "4"];
+        assert_eq!(
+            verdict_from_concurrent_isolation(&r),
+            ConcurrentIsolationVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn realistic_pre_fix_all_4_failures() {
+        // 001: health lies during loading.
+        assert_eq!(
+            verdict_from_health_readiness(ServerState::Loading, 200),
+            HealthReadinessVerdict::Fail
+        );
+        // 002: SIGTERM dropped 5 in-flight requests.
+        assert_eq!(
+            verdict_from_graceful_shutdown(5, 0, 1),
+            GracefulShutdownVerdict::Fail
+        );
+        // 003: HTML 404 from Actix default handler.
+        assert_eq!(
+            verdict_from_unknown_path(404, "text/html"),
+            UnknownPathVerdict::Fail
+        );
+        // 004: KV-cache contaminated request 8.
+        let r = ["A", "A", "B"];
+        assert_eq!(
+            verdict_from_concurrent_isolation(&r),
+            ConcurrentIsolationVerdict::Fail
+        );
+    }
+}

--- a/crates/aprender-core/src/format/aprtool_001_005.rs
+++ b/crates/aprender-core/src/format/aprtool_001_005.rs
@@ -1,0 +1,293 @@
+// `apr-tool-*` family algorithm-level PARTIAL discharge for the 5
+// falsification conditions shared by every `apr-tool-*-v1.yaml` contract.
+//
+// Contracts: `contracts/apr-tool-*.yaml` (21 contracts × 5 conditions =
+// 105 falsifier instantiations).
+//
+// All apr-tool-* contracts (bashrs, ccpo, cohete, copia, decy, depyler,
+// etc.) share an identical falsification schema. Each declares 5
+// conditions describing a "healthy active-tool repo":
+//
+//   1. "gh repo view paiml/<tool> returns archived=true" (P0 — reclassify)
+//   2. "README.md missing or empty" (P0 — create_readme)
+//   3. "No CI workflow in .github/workflows/" (P1 — add_ci)
+//   4. "cargo build fails (Rust) or equivalent build fails" (P0 — fix_build)
+//   5. "Zero tests in repository" (P1 — add_tests)
+//
+// One verdict module satisfies the algorithm-level pin for all 21
+// apr-tool contracts. Live discharge is `gh repo view` + filesystem
+// inspection + per-language build. This module pins the predicates so
+// future tool consolidations cannot drift on the shape of any of the 5
+// invariants.
+//
+// Local IDs FALSIFY-APRTOOL-001..005 are synthesized to give each
+// unkeyed YAML entry a stable handle.
+
+/// Minimum CI-workflow files in `.github/workflows/`.
+pub const AC_APRTOOL_MIN_CI_WORKFLOWS: u32 = 1;
+
+/// Minimum test count per FALSIFY-APRTOOL-005.
+pub const AC_APRTOOL_MIN_TESTS: u32 = 1;
+
+// =============================================================================
+// FALSIFY-APRTOOL-001 — repo is NOT archived
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NotArchivedVerdict {
+    /// Repo is live (archived == false).
+    Pass,
+    /// Repo is archived but still classified as active-tool (P0 reclassify).
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_not_archived(archived: bool) -> NotArchivedVerdict {
+    if archived {
+        NotArchivedVerdict::Fail
+    } else {
+        NotArchivedVerdict::Pass
+    }
+}
+
+// =============================================================================
+// FALSIFY-APRTOOL-002 — README.md present and non-empty
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReadmeVerdict {
+    /// README.md exists AND has content.
+    Pass,
+    /// Missing OR empty (P0 create_readme).
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_readme(readme_exists: bool, readme_size_bytes: u64) -> ReadmeVerdict {
+    if !readme_exists {
+        return ReadmeVerdict::Fail;
+    }
+    if readme_size_bytes == 0 {
+        return ReadmeVerdict::Fail;
+    }
+    ReadmeVerdict::Pass
+}
+
+// =============================================================================
+// FALSIFY-APRTOOL-003 — at least 1 CI workflow file
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CiWorkflowVerdict {
+    /// .github/workflows/ contains ≥ 1 .yml/.yaml workflow.
+    Pass,
+    /// Empty or missing (P1 add_ci).
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_ci_workflow(workflow_count: u32) -> CiWorkflowVerdict {
+    if workflow_count >= AC_APRTOOL_MIN_CI_WORKFLOWS {
+        CiWorkflowVerdict::Pass
+    } else {
+        CiWorkflowVerdict::Fail
+    }
+}
+
+// =============================================================================
+// FALSIFY-APRTOOL-004 — build passes
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BuildPassesVerdict {
+    /// `cargo build` (or per-language equivalent) exits 0.
+    Pass,
+    /// Build failed (P0 fix_build).
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_build_passes(build_exit_code: i32) -> BuildPassesVerdict {
+    if build_exit_code == 0 {
+        BuildPassesVerdict::Pass
+    } else {
+        BuildPassesVerdict::Fail
+    }
+}
+
+// =============================================================================
+// FALSIFY-APRTOOL-005 — at least 1 test
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HasTestsVerdict {
+    /// Repository has ≥ 1 test (anywhere — `tests/`, `src/**/*::tests`, etc.).
+    Pass,
+    /// Zero tests (P1 add_tests).
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_has_tests(test_count: u32) -> HasTestsVerdict {
+    if test_count >= AC_APRTOOL_MIN_TESTS {
+        HasTestsVerdict::Pass
+    } else {
+        HasTestsVerdict::Fail
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -------------------------------------------------------------------------
+    // Section 1: Provenance pins.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn provenance_min_ci_workflows_is_1() {
+        assert_eq!(AC_APRTOOL_MIN_CI_WORKFLOWS, 1);
+    }
+
+    #[test]
+    fn provenance_min_tests_is_1() {
+        assert_eq!(AC_APRTOOL_MIN_TESTS, 1);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 2: APRTOOL-001 not archived.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn at001_pass_repo_live() {
+        assert_eq!(verdict_from_not_archived(false), NotArchivedVerdict::Pass);
+    }
+
+    #[test]
+    fn at001_fail_repo_archived() {
+        assert_eq!(verdict_from_not_archived(true), NotArchivedVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 3: APRTOOL-002 README.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn at002_pass_readme_present() {
+        assert_eq!(verdict_from_readme(true, 1024), ReadmeVerdict::Pass);
+    }
+
+    #[test]
+    fn at002_pass_readme_minimal() {
+        // 1 byte still counts.
+        assert_eq!(verdict_from_readme(true, 1), ReadmeVerdict::Pass);
+    }
+
+    #[test]
+    fn at002_fail_no_readme() {
+        assert_eq!(verdict_from_readme(false, 0), ReadmeVerdict::Fail);
+    }
+
+    #[test]
+    fn at002_fail_empty_readme() {
+        assert_eq!(verdict_from_readme(true, 0), ReadmeVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 4: APRTOOL-003 CI workflow.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn at003_pass_one_workflow() {
+        assert_eq!(verdict_from_ci_workflow(1), CiWorkflowVerdict::Pass);
+    }
+
+    #[test]
+    fn at003_pass_many_workflows() {
+        assert_eq!(verdict_from_ci_workflow(10), CiWorkflowVerdict::Pass);
+    }
+
+    #[test]
+    fn at003_fail_zero_workflows() {
+        assert_eq!(verdict_from_ci_workflow(0), CiWorkflowVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 5: APRTOOL-004 build passes.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn at004_pass_build_clean() {
+        assert_eq!(verdict_from_build_passes(0), BuildPassesVerdict::Pass);
+    }
+
+    #[test]
+    fn at004_fail_build_compile_error() {
+        assert_eq!(verdict_from_build_passes(1), BuildPassesVerdict::Fail);
+    }
+
+    #[test]
+    fn at004_fail_build_panic() {
+        assert_eq!(verdict_from_build_passes(101), BuildPassesVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 6: APRTOOL-005 has tests.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn at005_pass_one_test() {
+        assert_eq!(verdict_from_has_tests(1), HasTestsVerdict::Pass);
+    }
+
+    #[test]
+    fn at005_pass_many_tests() {
+        assert_eq!(verdict_from_has_tests(500), HasTestsVerdict::Pass);
+    }
+
+    #[test]
+    fn at005_fail_zero_tests() {
+        assert_eq!(verdict_from_has_tests(0), HasTestsVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 7: Realistic — full healthy active-tool repo passes all 5.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn realistic_healthy_tool_passes_all_5() {
+        // bashrs / cohete / copia state: live, has README, CI present, builds
+        // clean, has tests.
+        assert_eq!(verdict_from_not_archived(false), NotArchivedVerdict::Pass);
+        assert_eq!(verdict_from_readme(true, 4096), ReadmeVerdict::Pass);
+        assert_eq!(verdict_from_ci_workflow(3), CiWorkflowVerdict::Pass);
+        assert_eq!(verdict_from_build_passes(0), BuildPassesVerdict::Pass);
+        assert_eq!(verdict_from_has_tests(125), HasTestsVerdict::Pass);
+    }
+
+    #[test]
+    fn realistic_pre_fix_all_5_failures() {
+        // Each gate's regression class.
+        assert_eq!(verdict_from_not_archived(true), NotArchivedVerdict::Fail);
+        assert_eq!(verdict_from_readme(false, 0), ReadmeVerdict::Fail);
+        assert_eq!(verdict_from_ci_workflow(0), CiWorkflowVerdict::Fail);
+        assert_eq!(verdict_from_build_passes(1), BuildPassesVerdict::Fail);
+        assert_eq!(verdict_from_has_tests(0), HasTestsVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 8: Family coverage — all 21 apr-tool-* contracts.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn family_coverage_uniform_schema() {
+        // The 21 apr-tool-* contracts share this falsification schema.
+        // Verdicts work regardless of the tool's identity or implementation language.
+        let tools = [
+            "bashrs", "ccpo", "cohete", "copia", "decy", "depyler",
+            "forjar", "fueguia", "ggsa", "kit", "labrador", "letrar",
+            "linguamatic", "lupa", "manodura", "molino", "pmat",
+            "ramificar", "ruchy", "sembrar", "tomb",
+        ];
+        assert_eq!(tools.len(), 21);
+        for t in tools {
+            assert_eq!(
+                verdict_from_not_archived(false),
+                NotArchivedVerdict::Pass,
+                "tool {t} live"
+            );
+        }
+    }
+}

--- a/crates/aprender-core/src/format/archschema_001_008.rs
+++ b/crates/aprender-core/src/format/archschema_001_008.rs
@@ -1,0 +1,536 @@
+// `apr-architecture-schema-v1` algorithm-level PARTIAL discharge for the
+// 8 transformer-architecture-schema falsifiers (head divisibility, GQA
+// group size, attn shapes, FFN transpose, norm count, embedding shape,
+// rope_type, total tensor count tolerance).
+//
+// Contract: `contracts/apr-architecture-schema-v1.yaml`.
+// Refs: Vaswani et al. (2017), Shazeer (2020) GLU Variants, Su et al.
+// (2021) RoFormer, Ainslie et al. (2023) GQA.
+//
+// ## Disambiguation
+//
+// `architecture-requirements-v1.yaml` (task #260) is a sibling contract
+// covering 12 different ARCH-* gates (build/install requirements, not
+// transformer architecture). Despite both using the FALSIFY-ARCH-* gate
+// prefix, the two contracts cover orthogonal invariants. Module suffix
+// `archschema_` disambiguates from any `arch_` module bound to
+// architecture-requirements-v1.
+
+/// Tolerance bound on `abs(actual - expected_tensor_count)` per
+/// FALSIFY-ARCH-008.
+pub const AC_ARCHSCHEMA_TENSOR_COUNT_TOLERANCE: i32 = 5;
+
+/// Valid RoPE type values per FALSIFY-ARCH-007 (spec CORRECTNESS-011).
+pub const AC_ARCHSCHEMA_VALID_ROPE_TYPES: [u32; 2] = [0, 2];
+
+// =============================================================================
+// FALSIFY-ARCH-001 — head_dim divides hidden_size evenly
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HeadDimVerdict {
+    /// hidden_size.is_multiple_of(num_heads).
+    Pass,
+    /// Hidden-size not divisible by num_heads — head_dim would be non-integer.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_head_dim(hidden_size: u32, num_heads: u32) -> HeadDimVerdict {
+    if num_heads == 0 {
+        return HeadDimVerdict::Fail;
+    }
+    if hidden_size.is_multiple_of(num_heads) {
+        HeadDimVerdict::Pass
+    } else {
+        HeadDimVerdict::Fail
+    }
+}
+
+// =============================================================================
+// FALSIFY-ARCH-002 — GQA group size divides num_heads evenly
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GqaGroupVerdict {
+    /// num_heads.is_multiple_of(num_kv_heads).
+    Pass,
+    /// num_heads not divisible by num_kv_heads — GQA group size non-integer.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_gqa_group(num_heads: u32, num_kv_heads: u32) -> GqaGroupVerdict {
+    if num_kv_heads == 0 {
+        return GqaGroupVerdict::Fail;
+    }
+    if num_heads.is_multiple_of(num_kv_heads) {
+        GqaGroupVerdict::Pass
+    } else {
+        GqaGroupVerdict::Fail
+    }
+}
+
+// =============================================================================
+// FALSIFY-ARCH-003 — attention Q/K/V/O shapes match config
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AttnShapeVerdict {
+    /// Q=[h, n_h*d], K=V=[h, n_kv*d], O=[n_h*d, h] all match config.
+    Pass,
+    /// Any projection's shape mismatches.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_attn_shape(
+    hidden_size: u32,
+    num_heads: u32,
+    num_kv_heads: u32,
+    head_dim: u32,
+    q_shape: (u32, u32),
+    k_shape: (u32, u32),
+    v_shape: (u32, u32),
+    o_shape: (u32, u32),
+) -> AttnShapeVerdict {
+    let q_inner = num_heads * head_dim;
+    let kv_inner = num_kv_heads * head_dim;
+    if q_shape != (hidden_size, q_inner) {
+        return AttnShapeVerdict::Fail;
+    }
+    if k_shape != (hidden_size, kv_inner) {
+        return AttnShapeVerdict::Fail;
+    }
+    if v_shape != (hidden_size, kv_inner) {
+        return AttnShapeVerdict::Fail;
+    }
+    if o_shape != (q_inner, hidden_size) {
+        return AttnShapeVerdict::Fail;
+    }
+    AttnShapeVerdict::Pass
+}
+
+// =============================================================================
+// FALSIFY-ARCH-004 — FFN gate/up/down transpose consistency
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FfnShapeVerdict {
+    /// gate.shape == up.shape AND down.shape == transpose(gate.shape).
+    Pass,
+    /// Any inconsistency.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_ffn_shape(
+    gate_shape: (u32, u32),
+    up_shape: (u32, u32),
+    down_shape: (u32, u32),
+) -> FfnShapeVerdict {
+    if gate_shape != up_shape {
+        return FfnShapeVerdict::Fail;
+    }
+    let (a, b) = gate_shape;
+    if down_shape != (b, a) {
+        return FfnShapeVerdict::Fail;
+    }
+    FfnShapeVerdict::Pass
+}
+
+// =============================================================================
+// FALSIFY-ARCH-005 — exactly 2 norm tensors per layer + 1 final norm
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NormCountVerdict {
+    /// total_norms == 2 * num_layers + 1 (attn_norm + ffn_norm per layer + final).
+    Pass,
+    /// Norm count off — missing or extra norm tensor.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_norm_count(num_layers: u32, total_norms: u32) -> NormCountVerdict {
+    let expected = 2 * num_layers + 1;
+    if total_norms == expected {
+        NormCountVerdict::Pass
+    } else {
+        NormCountVerdict::Fail
+    }
+}
+
+// =============================================================================
+// FALSIFY-ARCH-006 — embedding shape matches vocab/hidden
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EmbeddingShapeVerdict {
+    /// Embedding shape == [vocab_size, hidden_size].
+    Pass,
+    /// Off-by-one or other mismatch.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_embedding_shape(
+    vocab_size: u32,
+    hidden_size: u32,
+    embedding_shape: (u32, u32),
+) -> EmbeddingShapeVerdict {
+    if embedding_shape == (vocab_size, hidden_size) {
+        EmbeddingShapeVerdict::Pass
+    } else {
+        EmbeddingShapeVerdict::Fail
+    }
+}
+
+// =============================================================================
+// FALSIFY-ARCH-007 — RoPE type ∈ {0, 2}
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RopeTypeVerdict {
+    /// rope_type ∈ {0 = NORM, 2 = NEOX}.
+    Pass,
+    /// Unknown rope_type — silent default to 0 is the regression class.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_rope_type(rope_type: u32) -> RopeTypeVerdict {
+    if AC_ARCHSCHEMA_VALID_ROPE_TYPES.contains(&rope_type) {
+        RopeTypeVerdict::Pass
+    } else {
+        RopeTypeVerdict::Fail
+    }
+}
+
+// =============================================================================
+// FALSIFY-ARCH-008 — total tensor count within ±5 tolerance
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TensorCountVerdict {
+    /// abs(actual - expected) <= 5.
+    Pass,
+    /// Out of tolerance — model has too many or too few tensors.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_tensor_count(actual: u32, expected: u32) -> TensorCountVerdict {
+    let diff = (actual as i64 - expected as i64).abs();
+    if diff <= AC_ARCHSCHEMA_TENSOR_COUNT_TOLERANCE as i64 {
+        TensorCountVerdict::Pass
+    } else {
+        TensorCountVerdict::Fail
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -------------------------------------------------------------------------
+    // Section 1: Provenance pins.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn provenance_tensor_count_tolerance_5() {
+        assert_eq!(AC_ARCHSCHEMA_TENSOR_COUNT_TOLERANCE, 5);
+    }
+
+    #[test]
+    fn provenance_valid_rope_types_count_2() {
+        assert_eq!(AC_ARCHSCHEMA_VALID_ROPE_TYPES.len(), 2);
+        assert!(AC_ARCHSCHEMA_VALID_ROPE_TYPES.contains(&0));
+        assert!(AC_ARCHSCHEMA_VALID_ROPE_TYPES.contains(&2));
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 2: ARCH-001 head dim.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fa001_pass_qwen2_7b() {
+        // Qwen2.5-Coder-7B: hidden=3584, heads=28 → head_dim=128.
+        assert_eq!(verdict_from_head_dim(3584, 28), HeadDimVerdict::Pass);
+    }
+
+    #[test]
+    fn fa001_pass_llama_70b() {
+        assert_eq!(verdict_from_head_dim(8192, 64), HeadDimVerdict::Pass);
+    }
+
+    #[test]
+    fn fa001_fail_prime_hidden() {
+        // 769 / 12 not integer.
+        assert_eq!(verdict_from_head_dim(769, 12), HeadDimVerdict::Fail);
+    }
+
+    #[test]
+    fn fa001_fail_zero_heads() {
+        assert_eq!(verdict_from_head_dim(512, 0), HeadDimVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 3: ARCH-002 GQA group size.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fa002_pass_qwen2_7b_4_kv() {
+        // 28 heads, 4 kv heads → 7:1 GQA.
+        assert_eq!(verdict_from_gqa_group(28, 4), GqaGroupVerdict::Pass);
+    }
+
+    #[test]
+    fn fa002_pass_mha_no_gqa() {
+        // num_heads == num_kv_heads (full MHA).
+        assert_eq!(verdict_from_gqa_group(12, 12), GqaGroupVerdict::Pass);
+    }
+
+    #[test]
+    fn fa002_fail_non_divisible() {
+        assert_eq!(verdict_from_gqa_group(12, 5), GqaGroupVerdict::Fail);
+    }
+
+    #[test]
+    fn fa002_fail_zero_kv_heads() {
+        assert_eq!(verdict_from_gqa_group(12, 0), GqaGroupVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 4: ARCH-003 attention shape.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fa003_pass_qwen2_5_coder_7b_layer_shapes() {
+        // hidden=3584, n_h=28, n_kv=4, d=128.
+        let q = (3584, 28 * 128);
+        let k = (3584, 4 * 128);
+        let v = (3584, 4 * 128);
+        let o = (28 * 128, 3584);
+        assert_eq!(
+            verdict_from_attn_shape(3584, 28, 4, 128, q, k, v, o),
+            AttnShapeVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fa003_fail_q_off_by_one() {
+        let q = (3584, 28 * 128 + 1); // bad
+        let k = (3584, 4 * 128);
+        let v = (3584, 4 * 128);
+        let o = (28 * 128, 3584);
+        assert_eq!(
+            verdict_from_attn_shape(3584, 28, 4, 128, q, k, v, o),
+            AttnShapeVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fa003_fail_o_wrong_shape() {
+        // Note: for Qwen2 hidden_size == num_heads * head_dim, so Q is
+        // square and transposing Q gives the same shape. Use a different
+        // wrong O shape to expose the regression.
+        let q = (3584, 28 * 128);
+        let k = (3584, 4 * 128);
+        let v = (3584, 4 * 128);
+        let o = (1, 1); // obviously wrong
+        assert_eq!(
+            verdict_from_attn_shape(3584, 28, 4, 128, q, k, v, o),
+            AttnShapeVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fa003_fail_kv_uses_q_inner_not_kv() {
+        let q = (3584, 28 * 128);
+        let k = (3584, 28 * 128); // wrong: used q dim instead of kv
+        let v = (3584, 4 * 128);
+        let o = (28 * 128, 3584);
+        assert_eq!(
+            verdict_from_attn_shape(3584, 28, 4, 128, q, k, v, o),
+            AttnShapeVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 5: ARCH-004 FFN transpose.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fa004_pass_qwen2_7b_ffn() {
+        // hidden=3584, intermediate=18944.
+        let gate = (3584, 18944);
+        let up = (3584, 18944);
+        let down = (18944, 3584);
+        assert_eq!(verdict_from_ffn_shape(gate, up, down), FfnShapeVerdict::Pass);
+    }
+
+    #[test]
+    fn fa004_fail_gate_up_mismatch() {
+        let gate = (3584, 18944);
+        let up = (3584, 18943); // off by one
+        let down = (18944, 3584);
+        assert_eq!(verdict_from_ffn_shape(gate, up, down), FfnShapeVerdict::Fail);
+    }
+
+    #[test]
+    fn fa004_fail_down_not_transposed() {
+        let gate = (3584, 18944);
+        let up = (3584, 18944);
+        let down = (3584, 18944); // not transposed
+        assert_eq!(verdict_from_ffn_shape(gate, up, down), FfnShapeVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 6: ARCH-005 norm count.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fa005_pass_qwen2_7b_28_layers() {
+        // 28 layers * 2 norms + 1 final = 57.
+        assert_eq!(verdict_from_norm_count(28, 57), NormCountVerdict::Pass);
+    }
+
+    #[test]
+    fn fa005_pass_minimal_1_layer() {
+        // 1 layer * 2 + 1 final = 3.
+        assert_eq!(verdict_from_norm_count(1, 3), NormCountVerdict::Pass);
+    }
+
+    #[test]
+    fn fa005_fail_missing_one_norm() {
+        // 28 layers expects 57; 56 = missing one ffn_norm.
+        assert_eq!(verdict_from_norm_count(28, 56), NormCountVerdict::Fail);
+    }
+
+    #[test]
+    fn fa005_fail_extra_norm() {
+        assert_eq!(verdict_from_norm_count(28, 58), NormCountVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 7: ARCH-006 embedding shape.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fa006_pass_qwen2_7b_embedding() {
+        let e = (152064, 3584);
+        assert_eq!(verdict_from_embedding_shape(152064, 3584, e), EmbeddingShapeVerdict::Pass);
+    }
+
+    #[test]
+    fn fa006_fail_off_by_one_vocab() {
+        let e = (152063, 3584);
+        assert_eq!(verdict_from_embedding_shape(152064, 3584, e), EmbeddingShapeVerdict::Fail);
+    }
+
+    #[test]
+    fn fa006_fail_swapped_axes() {
+        let e = (3584, 152064);
+        assert_eq!(verdict_from_embedding_shape(152064, 3584, e), EmbeddingShapeVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 8: ARCH-007 rope type.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fa007_pass_norm_type_0() {
+        assert_eq!(verdict_from_rope_type(0), RopeTypeVerdict::Pass);
+    }
+
+    #[test]
+    fn fa007_pass_neox_type_2() {
+        assert_eq!(verdict_from_rope_type(2), RopeTypeVerdict::Pass);
+    }
+
+    #[test]
+    fn fa007_fail_invalid_type_1() {
+        assert_eq!(verdict_from_rope_type(1), RopeTypeVerdict::Fail);
+    }
+
+    #[test]
+    fn fa007_fail_invalid_type_3() {
+        assert_eq!(verdict_from_rope_type(3), RopeTypeVerdict::Fail);
+    }
+
+    #[test]
+    fn fa007_fail_invalid_large() {
+        assert_eq!(verdict_from_rope_type(99), RopeTypeVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 9: ARCH-008 total tensor count.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fa008_pass_exact_match() {
+        assert_eq!(verdict_from_tensor_count(339, 339), TensorCountVerdict::Pass);
+    }
+
+    #[test]
+    fn fa008_pass_within_tolerance_plus5() {
+        assert_eq!(verdict_from_tensor_count(344, 339), TensorCountVerdict::Pass);
+    }
+
+    #[test]
+    fn fa008_pass_within_tolerance_minus5() {
+        assert_eq!(verdict_from_tensor_count(334, 339), TensorCountVerdict::Pass);
+    }
+
+    #[test]
+    fn fa008_fail_minus_10() {
+        assert_eq!(verdict_from_tensor_count(329, 339), TensorCountVerdict::Fail);
+    }
+
+    #[test]
+    fn fa008_fail_plus_50() {
+        assert_eq!(verdict_from_tensor_count(389, 339), TensorCountVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 10: Realistic — full Qwen2.5-Coder-7B passes all 8.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn realistic_qwen2_7b_passes_all_8() {
+        // Qwen2.5-Coder-7B: hidden=3584, layers=28, heads=28, kv_heads=4,
+        // head_dim=128, intermediate=18944, vocab=152064, rope_type=0, 339 tensors.
+        assert_eq!(verdict_from_head_dim(3584, 28), HeadDimVerdict::Pass);
+        assert_eq!(verdict_from_gqa_group(28, 4), GqaGroupVerdict::Pass);
+        assert_eq!(
+            verdict_from_attn_shape(3584, 28, 4, 128,
+                (3584, 3584), (3584, 512), (3584, 512), (3584, 3584)),
+            AttnShapeVerdict::Pass
+        );
+        assert_eq!(
+            verdict_from_ffn_shape((3584, 18944), (3584, 18944), (18944, 3584)),
+            FfnShapeVerdict::Pass
+        );
+        assert_eq!(verdict_from_norm_count(28, 57), NormCountVerdict::Pass);
+        assert_eq!(
+            verdict_from_embedding_shape(152064, 3584, (152064, 3584)),
+            EmbeddingShapeVerdict::Pass
+        );
+        assert_eq!(verdict_from_rope_type(0), RopeTypeVerdict::Pass);
+        assert_eq!(verdict_from_tensor_count(339, 339), TensorCountVerdict::Pass);
+    }
+
+    #[test]
+    fn realistic_pre_fix_all_8_failures() {
+        // Each gate's regression class.
+        assert_eq!(verdict_from_head_dim(769, 12), HeadDimVerdict::Fail);
+        assert_eq!(verdict_from_gqa_group(12, 5), GqaGroupVerdict::Fail);
+        assert_eq!(
+            verdict_from_attn_shape(3584, 28, 4, 128,
+                (3584, 3585), (3584, 512), (3584, 512), (3584, 3584)),
+            AttnShapeVerdict::Fail
+        );
+        assert_eq!(
+            verdict_from_ffn_shape((3584, 18944), (3584, 18944), (3584, 18944)),
+            FfnShapeVerdict::Fail
+        );
+        assert_eq!(verdict_from_norm_count(28, 56), NormCountVerdict::Fail);
+        assert_eq!(
+            verdict_from_embedding_shape(152064, 3584, (152063, 3584)),
+            EmbeddingShapeVerdict::Fail
+        );
+        assert_eq!(verdict_from_rope_type(3), RopeTypeVerdict::Fail);
+        assert_eq!(verdict_from_tensor_count(329, 339), TensorCountVerdict::Fail);
+    }
+}

--- a/crates/aprender-core/src/format/attnbwd_001_002.rs
+++ b/crates/aprender-core/src/format/attnbwd_001_002.rs
@@ -1,0 +1,277 @@
+// `attention-backward-v1` algorithm-level PARTIAL discharge for the 2
+// FlashAttention-style backward-pass falsifiers (gradient correctness,
+// causal mask preservation in backward).
+//
+// Contract: `contracts/attention-backward-v1.yaml`.
+// Refs: Dao et al. (2022). FlashAttention: Fast and Memory-Efficient
+// Exact Attention.
+//
+// ## Disambiguation
+//
+// `attention-kernel-v1.yaml` (task #308) covers FORWARD attention
+// (5/5 ATT-* gates). This contract covers BACKWARD only. Module suffix
+// `attnbwd_` disambiguates from any `att_*` forward modules.
+
+/// Tolerance for tiled-vs-naive backward gradient comparison
+/// (FlashAttention reordering FMA introduces FP roundoff).
+pub const AC_ATTNBWD_GRAD_TOLERANCE: f32 = 1.0e-3;
+
+// =============================================================================
+// FALSIFY-ATTENTION_BACKWARD_V1_001 — gradient correctness
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AttnBwdGradVerdict {
+    /// max |tiled_dQ[i] - naive_dQ[i]| < ε across all heads.
+    Pass,
+    /// At least one element exceeds tolerance.
+    Fail,
+}
+
+/// Pure verdict for FALSIFY-ATTENTION_BACKWARD_V1_001.
+///
+/// Inputs are (head, element)-flattened gradient tensors from the
+/// tiled and naive backward implementations.
+#[must_use]
+pub fn verdict_from_attn_bwd_grad(tiled_dq: &[f32], naive_dq: &[f32]) -> AttnBwdGradVerdict {
+    if tiled_dq.len() != naive_dq.len() {
+        return AttnBwdGradVerdict::Fail;
+    }
+    if tiled_dq.is_empty() {
+        return AttnBwdGradVerdict::Fail;
+    }
+    for (a, b) in tiled_dq.iter().zip(naive_dq.iter()) {
+        if (a - b).abs() >= AC_ATTNBWD_GRAD_TOLERANCE {
+            return AttnBwdGradVerdict::Fail;
+        }
+    }
+    AttnBwdGradVerdict::Pass
+}
+
+// =============================================================================
+// FALSIFY-ATTENTION_BACKWARD_V1_002 — causal mask preservation
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CausalMaskVerdict {
+    /// ∀ i < j: attention_weight[i, j] == 0.0 (lower-triangular pass-through).
+    Pass,
+    /// At least one upper-triangular position has non-zero weight —
+    /// causal mask leaked information across the time barrier.
+    Fail,
+}
+
+/// Pure verdict for FALSIFY-ATTENTION_BACKWARD_V1_002.
+///
+/// `attention_weights` is a row-major (seq_len × seq_len) matrix.
+#[must_use]
+pub fn verdict_from_causal_mask(seq_len: usize, attention_weights: &[f32]) -> CausalMaskVerdict {
+    if seq_len == 0 {
+        return CausalMaskVerdict::Fail;
+    }
+    if attention_weights.len() != seq_len * seq_len {
+        return CausalMaskVerdict::Fail;
+    }
+    for i in 0..seq_len {
+        for j in 0..seq_len {
+            if i < j {
+                let w = attention_weights[i * seq_len + j];
+                if w != 0.0 {
+                    return CausalMaskVerdict::Fail;
+                }
+            }
+        }
+    }
+    CausalMaskVerdict::Pass
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -------------------------------------------------------------------------
+    // Section 1: Provenance pins.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn provenance_grad_tolerance_1e_neg3() {
+        assert!((AC_ATTNBWD_GRAD_TOLERANCE - 1.0e-3).abs() < f32::EPSILON);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 2: ABV1-001 gradient correctness.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fa001_pass_exact_match() {
+        let dq = vec![1.0; 64];
+        assert_eq!(
+            verdict_from_attn_bwd_grad(&dq, &dq),
+            AttnBwdGradVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fa001_pass_within_tolerance() {
+        let tiled = vec![1.0001, 2.0001, 3.0001];
+        let naive = vec![1.0, 2.0, 3.0];
+        assert_eq!(
+            verdict_from_attn_bwd_grad(&tiled, &naive),
+            AttnBwdGradVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fa001_fail_above_tolerance() {
+        let tiled = vec![1.5];
+        let naive = vec![1.0];
+        assert_eq!(
+            verdict_from_attn_bwd_grad(&tiled, &naive),
+            AttnBwdGradVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fa001_fail_at_threshold() {
+        // Strict less-than: 1e-3 exactly fails.
+        let tiled = vec![1.001];
+        let naive = vec![1.0];
+        assert_eq!(
+            verdict_from_attn_bwd_grad(&tiled, &naive),
+            AttnBwdGradVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fa001_fail_length_mismatch() {
+        let tiled = vec![1.0, 2.0];
+        let naive = vec![1.0];
+        assert_eq!(
+            verdict_from_attn_bwd_grad(&tiled, &naive),
+            AttnBwdGradVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fa001_fail_empty() {
+        assert_eq!(
+            verdict_from_attn_bwd_grad(&[], &[]),
+            AttnBwdGradVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fa001_pass_multi_head_4x16() {
+        // 4 heads * 16 elements = 64 grad entries.
+        let dq: Vec<f32> = (0..64).map(|i| i as f32 * 0.01).collect();
+        assert_eq!(
+            verdict_from_attn_bwd_grad(&dq, &dq),
+            AttnBwdGradVerdict::Pass
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 3: ABV1-002 causal mask.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fa002_pass_lower_triangular_only() {
+        // 3x3 lower-triangular: rows 0,1,2 have non-zero only at j ≤ i.
+        let w = vec![
+            0.5, 0.0, 0.0, // i=0
+            0.3, 0.7, 0.0, // i=1
+            0.1, 0.4, 0.5, // i=2
+        ];
+        assert_eq!(verdict_from_causal_mask(3, &w), CausalMaskVerdict::Pass);
+    }
+
+    #[test]
+    fn fa002_pass_diagonal_only() {
+        let w = vec![
+            1.0, 0.0, 0.0,
+            0.0, 1.0, 0.0,
+            0.0, 0.0, 1.0,
+        ];
+        assert_eq!(verdict_from_causal_mask(3, &w), CausalMaskVerdict::Pass);
+    }
+
+    #[test]
+    fn fa002_pass_seq_len_1() {
+        let w = vec![1.0];
+        assert_eq!(verdict_from_causal_mask(1, &w), CausalMaskVerdict::Pass);
+    }
+
+    #[test]
+    fn fa002_fail_upper_triangular_leak() {
+        // i=0, j=1 has weight 0.5 — future attended in past position.
+        let w = vec![
+            0.5, 0.5, 0.0,
+            0.3, 0.7, 0.0,
+            0.1, 0.4, 0.5,
+        ];
+        assert_eq!(verdict_from_causal_mask(3, &w), CausalMaskVerdict::Fail);
+    }
+
+    #[test]
+    fn fa002_fail_corner_leak() {
+        // i=0, j=2 (top-right corner).
+        let w = vec![
+            1.0, 0.0, 0.0001,
+            0.0, 1.0, 0.0,
+            0.0, 0.0, 1.0,
+        ];
+        assert_eq!(verdict_from_causal_mask(3, &w), CausalMaskVerdict::Fail);
+    }
+
+    #[test]
+    fn fa002_fail_zero_seq_len() {
+        assert_eq!(verdict_from_causal_mask(0, &[]), CausalMaskVerdict::Fail);
+    }
+
+    #[test]
+    fn fa002_fail_size_mismatch() {
+        let w = vec![1.0, 2.0]; // 2 elements but seq_len=3 → expect 9
+        assert_eq!(verdict_from_causal_mask(3, &w), CausalMaskVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 4: Realistic — full healthy backward pass.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn realistic_healthy_backward_passes_both() {
+        // 4 heads × 8 elements gradient, tiled matches naive within 5e-4.
+        let naive: Vec<f32> = (0..32).map(|i| (i as f32) * 0.1).collect();
+        let tiled: Vec<f32> = naive.iter().map(|&x| x + 5e-4).collect();
+        assert_eq!(
+            verdict_from_attn_bwd_grad(&tiled, &naive),
+            AttnBwdGradVerdict::Pass
+        );
+
+        // 4x4 strict lower-triangular attention weights.
+        let w = vec![
+            0.2, 0.0, 0.0, 0.0,
+            0.1, 0.3, 0.0, 0.0,
+            0.05, 0.1, 0.4, 0.0,
+            0.05, 0.1, 0.2, 0.5,
+        ];
+        assert_eq!(verdict_from_causal_mask(4, &w), CausalMaskVerdict::Pass);
+    }
+
+    #[test]
+    fn realistic_pre_fix_both_failures() {
+        // 001: tile-boundary FMA reordering bug — gradient diverges by 0.5.
+        let naive = vec![1.0; 32];
+        let mut tiled = naive.clone();
+        tiled[16] += 0.5;
+        assert_eq!(
+            verdict_from_attn_bwd_grad(&tiled, &naive),
+            AttnBwdGradVerdict::Fail
+        );
+
+        // 002: backward pass forgot to apply causal mask, all weights non-zero.
+        let w = vec![
+            0.25, 0.25, 0.25, 0.25,
+            0.25, 0.25, 0.25, 0.25,
+            0.25, 0.25, 0.25, 0.25,
+            0.25, 0.25, 0.25, 0.25,
+        ];
+        assert_eq!(verdict_from_causal_mask(4, &w), CausalMaskVerdict::Fail);
+    }
+}

--- a/crates/aprender-core/src/format/avx512q4k_001_002.rs
+++ b/crates/aprender-core/src/format/avx512q4k_001_002.rs
@@ -1,0 +1,302 @@
+// `avx512-q4k-v1` algorithm-level PARTIAL discharge for the 2 AVX-512
+// Q4_K GEMV falsifiers (scalar equivalence within 1e-3, ≥1.5x AVX2
+// throughput).
+//
+// Contract: `contracts/avx512-q4k-v1.yaml`.
+// Refs: GPTQ (Frantar et al., 2023), QuIP# (Chee et al., 2023).
+//
+// ## Disambiguation
+//
+// `avx2-fma-dot-v1.yaml` (task #402) covers the AVX2 8-wide f32 dot
+// product. This contract — avx512-q4k-v1 — covers the AVX-512 16-wide
+// Q4_K-quantized GEMV (different SIMD width, different operand format).
+// Module suffix `avx512q4k_` disambiguates from `dot_*`.
+
+/// Tolerance budget for AVX-512 vs scalar reference per
+/// `equations.C-AVX512-Q4K-001`.
+pub const AC_AVX512_Q4K_TOLERANCE: f32 = 1.0e-3;
+
+/// Minimum throughput speedup over AVX2 per `equations.C-AVX512-Q4K-002`.
+pub const AC_AVX512_Q4K_MIN_SPEEDUP: f64 = 1.5;
+
+/// Minimum input dimension for the speedup gate to apply.
+pub const AC_AVX512_Q4K_SPEEDUP_MIN_DIM: usize = 1024;
+
+/// Q4_K super-block layout per the contract description.
+pub const AC_AVX512_Q4K_BLOCK_ELEMENTS: usize = 256;
+pub const AC_AVX512_Q4K_BLOCK_BYTES: usize = 144;
+
+// =============================================================================
+// FALSIFY-AVX512-Q4K-001 — AVX-512 output matches scalar within 1e-3
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Avx512Q4kEquivalenceVerdict {
+    /// max_i |avx512[i] - scalar[i]| < 1e-3.
+    Pass,
+    /// At least one element exceeds tolerance.
+    Fail,
+}
+
+/// `avx512_output` and `scalar_output` are the SIMD and scalar reference
+/// dequant+matmul outputs for the same Q4_K weight + f32 input.
+#[must_use]
+pub fn verdict_from_avx512_q4k_equivalence(
+    avx512_output: &[f32],
+    scalar_output: &[f32],
+) -> Avx512Q4kEquivalenceVerdict {
+    if avx512_output.len() != scalar_output.len() {
+        return Avx512Q4kEquivalenceVerdict::Fail;
+    }
+    if avx512_output.is_empty() {
+        return Avx512Q4kEquivalenceVerdict::Fail;
+    }
+    for (a, b) in avx512_output.iter().zip(scalar_output.iter()) {
+        if (a - b).abs() >= AC_AVX512_Q4K_TOLERANCE {
+            return Avx512Q4kEquivalenceVerdict::Fail;
+        }
+    }
+    Avx512Q4kEquivalenceVerdict::Pass
+}
+
+// =============================================================================
+// FALSIFY-AVX512-Q4K-002 — ≥1.5x AVX2 throughput at in_dim ≥ 1024
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Avx512Q4kSpeedupVerdict {
+    /// in_dim ≥ 1024 ⇒ throughput(avx512) ≥ 1.5 * throughput(avx2).
+    /// in_dim < 1024 ⇒ vacuous Pass (gate doesn't apply).
+    Pass,
+    /// At in_dim ≥ 1024 the speedup is below 1.5x — overhead regression.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_avx512_q4k_speedup(
+    in_dim: usize,
+    avx2_throughput: f64,
+    avx512_throughput: f64,
+) -> Avx512Q4kSpeedupVerdict {
+    if in_dim < AC_AVX512_Q4K_SPEEDUP_MIN_DIM {
+        return Avx512Q4kSpeedupVerdict::Pass;
+    }
+    if avx2_throughput <= 0.0 {
+        // Can't compute speedup; treat as harness defect (Fail).
+        return Avx512Q4kSpeedupVerdict::Fail;
+    }
+    let speedup = avx512_throughput / avx2_throughput;
+    if speedup >= AC_AVX512_Q4K_MIN_SPEEDUP {
+        Avx512Q4kSpeedupVerdict::Pass
+    } else {
+        Avx512Q4kSpeedupVerdict::Fail
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -------------------------------------------------------------------------
+    // Section 1: Provenance pins.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn provenance_tolerance_1e_neg3() {
+        assert!((AC_AVX512_Q4K_TOLERANCE - 1.0e-3).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn provenance_min_speedup_1_5() {
+        assert!((AC_AVX512_Q4K_MIN_SPEEDUP - 1.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn provenance_speedup_min_dim_1024() {
+        assert_eq!(AC_AVX512_Q4K_SPEEDUP_MIN_DIM, 1024);
+    }
+
+    #[test]
+    fn provenance_super_block_256_elements() {
+        assert_eq!(AC_AVX512_Q4K_BLOCK_ELEMENTS, 256);
+    }
+
+    #[test]
+    fn provenance_super_block_144_bytes() {
+        assert_eq!(AC_AVX512_Q4K_BLOCK_BYTES, 144);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 2: AVX512-Q4K-001 equivalence.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fa001_pass_exact_match() {
+        let a = vec![1.0, 2.0, 3.0];
+        let s = vec![1.0, 2.0, 3.0];
+        assert_eq!(
+            verdict_from_avx512_q4k_equivalence(&a, &s),
+            Avx512Q4kEquivalenceVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fa001_pass_within_tolerance() {
+        let a = vec![1.0001, 2.0002, 3.0003];
+        let s = vec![1.0, 2.0, 3.0];
+        assert_eq!(
+            verdict_from_avx512_q4k_equivalence(&a, &s),
+            Avx512Q4kEquivalenceVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fa001_fail_above_tolerance() {
+        let a = vec![1.0, 2.0, 3.5]; // 0.5 > 1e-3
+        let s = vec![1.0, 2.0, 3.0];
+        assert_eq!(
+            verdict_from_avx512_q4k_equivalence(&a, &s),
+            Avx512Q4kEquivalenceVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fa001_fail_at_threshold() {
+        // Strict less-than.
+        let a = vec![1.001];
+        let s = vec![1.0];
+        assert_eq!(
+            verdict_from_avx512_q4k_equivalence(&a, &s),
+            Avx512Q4kEquivalenceVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fa001_fail_length_mismatch() {
+        let a = vec![1.0, 2.0];
+        let s = vec![1.0];
+        assert_eq!(
+            verdict_from_avx512_q4k_equivalence(&a, &s),
+            Avx512Q4kEquivalenceVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fa001_fail_empty() {
+        let a: Vec<f32> = vec![];
+        let s: Vec<f32> = vec![];
+        assert_eq!(
+            verdict_from_avx512_q4k_equivalence(&a, &s),
+            Avx512Q4kEquivalenceVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fa001_pass_super_block_256() {
+        // 256-element super-block: all match within tolerance.
+        let a: Vec<f32> = (0..256).map(|i| i as f32 + 1e-5).collect();
+        let s: Vec<f32> = (0..256).map(|i| i as f32).collect();
+        assert_eq!(
+            verdict_from_avx512_q4k_equivalence(&a, &s),
+            Avx512Q4kEquivalenceVerdict::Pass
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 3: AVX512-Q4K-002 throughput.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fa002_pass_speedup_2x() {
+        // AVX2 = 100, AVX-512 = 200 ⇒ 2x.
+        assert_eq!(
+            verdict_from_avx512_q4k_speedup(2048, 100.0, 200.0),
+            Avx512Q4kSpeedupVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fa002_pass_speedup_at_1_5x() {
+        assert_eq!(
+            verdict_from_avx512_q4k_speedup(2048, 100.0, 150.0),
+            Avx512Q4kSpeedupVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fa002_fail_speedup_below_1_5x() {
+        // 1.4x — below threshold.
+        assert_eq!(
+            verdict_from_avx512_q4k_speedup(2048, 100.0, 140.0),
+            Avx512Q4kSpeedupVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fa002_fail_no_speedup() {
+        // Same throughput.
+        assert_eq!(
+            verdict_from_avx512_q4k_speedup(2048, 100.0, 100.0),
+            Avx512Q4kSpeedupVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fa002_pass_small_dim_vacuous() {
+        // in_dim < 1024 ⇒ gate doesn't apply.
+        assert_eq!(
+            verdict_from_avx512_q4k_speedup(512, 100.0, 100.0),
+            Avx512Q4kSpeedupVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fa002_pass_at_min_dim() {
+        // in_dim == 1024 with 1.5x.
+        assert_eq!(
+            verdict_from_avx512_q4k_speedup(1024, 100.0, 150.0),
+            Avx512Q4kSpeedupVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fa002_fail_zero_avx2_throughput() {
+        // Harness defect: AVX2 reported 0 tps.
+        assert_eq!(
+            verdict_from_avx512_q4k_speedup(2048, 0.0, 200.0),
+            Avx512Q4kSpeedupVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 4: Realistic — full healthy AVX-512 Q4K kernel.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn realistic_healthy_kernel_passes_both() {
+        // 256-element output, all within 1e-4 of scalar; speedup 1.7x at 2048.
+        let a: Vec<f32> = (0..256).map(|i| i as f32 + 1e-4).collect();
+        let s: Vec<f32> = (0..256).map(|i| i as f32).collect();
+        assert_eq!(
+            verdict_from_avx512_q4k_equivalence(&a, &s),
+            Avx512Q4kEquivalenceVerdict::Pass
+        );
+        assert_eq!(
+            verdict_from_avx512_q4k_speedup(2048, 100.0, 170.0),
+            Avx512Q4kSpeedupVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn realistic_pre_fix_both_failures() {
+        // Equivalence: lane-mishandled element at index 64.
+        let mut a: Vec<f32> = (0..256).map(|i| i as f32).collect();
+        a[64] += 5.0; // wrong by 5.0
+        let s: Vec<f32> = (0..256).map(|i| i as f32).collect();
+        assert_eq!(
+            verdict_from_avx512_q4k_equivalence(&a, &s),
+            Avx512Q4kEquivalenceVerdict::Fail
+        );
+        // Speedup: zmm overhead regression — only 1.2x.
+        assert_eq!(
+            verdict_from_avx512_q4k_speedup(2048, 100.0, 120.0),
+            Avx512Q4kSpeedupVerdict::Fail
+        );
+    }
+}

--- a/crates/aprender-core/src/format/bayes_001_004.rs
+++ b/crates/aprender-core/src/format/bayes_001_004.rs
@@ -1,243 +1,381 @@
-// SHIP-TWO-001 — `bias-add-v1` algorithm-level PARTIAL discharge for
-// FALSIFY-BA-001..004 (closes 4/4 sweep).
+// `bayesian-v1` algorithm-level PARTIAL discharge for the 4 Bayesian-
+// inference falsifiers (posterior positivity, prediction finiteness,
+// prediction determinism, posterior concentration with more data).
 //
-// Contract: `contracts/bias-add-v1.yaml`.
-// Spec: Bias addition kernel — broadcast bias vector over batch.
+// Contract: `contracts/bayesian-v1.yaml`.
+// Refs: Gelman et al. (2013) Bayesian Data Analysis, Murphy (2012)
+// Machine Learning: A Probabilistic Perspective.
 
-// ===========================================================================
-// Helper — bias_add reference (in-module)
-// ===========================================================================
+// =============================================================================
+// FALSIFY-BAYES-001 — posterior parameters remain positive
+// =============================================================================
 
-/// y[b, i] = x[b, i] + bias[i] for x ∈ R^{B × D}, bias ∈ R^D.
-/// Row-major flattened input: x.len() == B * D, bias.len() == D.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BayesPosteriorPositivityVerdict {
+    /// alpha' > 0 AND beta' > 0 after conjugate update.
+    Pass,
+    /// Either parameter went non-positive (zero or negative) — arithmetic
+    /// error or underflow.
+    Fail,
+}
+
 #[must_use]
-pub fn bias_add(x: &[f32], bias: &[f32], batch: usize, d: usize) -> Option<Vec<f32>> {
-    if x.len() != batch * d { return None; }
-    if bias.len() != d { return None; }
-    if !x.iter().all(|v| v.is_finite()) { return None; }
-    if !bias.iter().all(|v| v.is_finite()) { return None; }
-    let mut y = vec![0.0_f32; batch * d];
-    for b in 0..batch {
-        for i in 0..d {
-            y[b * d + i] = x[b * d + i] + bias[i];
+pub fn verdict_from_bayes_posterior_positivity(alpha_prime: f64, beta_prime: f64) -> BayesPosteriorPositivityVerdict {
+    if !alpha_prime.is_finite() || !beta_prime.is_finite() {
+        return BayesPosteriorPositivityVerdict::Fail;
+    }
+    if alpha_prime > 0.0 && beta_prime > 0.0 {
+        BayesPosteriorPositivityVerdict::Pass
+    } else {
+        BayesPosteriorPositivityVerdict::Fail
+    }
+}
+
+// =============================================================================
+// FALSIFY-BAYES-002 — BLR predictions finite
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BayesPredictionFinitenessVerdict {
+    /// All BLR predictions y_hat[i] are finite (no NaN/Inf).
+    Pass,
+    /// At least one prediction is NaN or Inf — covariance inversion instability.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_bayes_prediction_finiteness(predictions: &[f64]) -> BayesPredictionFinitenessVerdict {
+    if predictions.is_empty() {
+        return BayesPredictionFinitenessVerdict::Fail;
+    }
+    for &p in predictions {
+        if !p.is_finite() {
+            return BayesPredictionFinitenessVerdict::Fail;
         }
     }
-    Some(y)
+    BayesPredictionFinitenessVerdict::Pass
 }
 
-// ===========================================================================
-// BA-001 — Shape preservation: shape(y) == shape(x)
-// ===========================================================================
+// =============================================================================
+// FALSIFY-BAYES-003 — prediction is deterministic
+// =============================================================================
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Ba001Verdict { Pass, Fail }
-
-#[must_use]
-pub fn verdict_from_shape_preservation(
-    x: &[f32],
-    bias: &[f32],
-    batch: usize,
-    d: usize,
-) -> Ba001Verdict {
-    match bias_add(x, bias, batch, d) {
-        Some(y) if y.len() == x.len() => Ba001Verdict::Pass,
-        _ => Ba001Verdict::Fail,
-    }
+pub enum BayesDeterminismVerdict {
+    /// predict(X) == predict(X) bit-identical across two calls.
+    Pass,
+    /// Predictions diverge between calls — random state leaked.
+    Fail,
 }
 
-// ===========================================================================
-// BA-002 — Zero-bias identity: bias_add(x, 0) == x byte-exactly
-// ===========================================================================
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Ba002Verdict { Pass, Fail }
-
 #[must_use]
-pub fn verdict_from_zero_bias_identity(x: &[f32], batch: usize, d: usize) -> Ba002Verdict {
-    if x.is_empty() { return Ba002Verdict::Fail; }
-    let zero_bias = vec![0.0_f32; d];
-    let y = match bias_add(x, &zero_bias, batch, d) {
-        Some(v) => v,
-        None => return Ba002Verdict::Fail,
-    };
-    if y.len() != x.len() { return Ba002Verdict::Fail; }
-    for (a, b) in x.iter().zip(y.iter()) {
-        if a.to_bits() != b.to_bits() { return Ba002Verdict::Fail; }
+pub fn verdict_from_bayes_determinism(call_a: &[f64], call_b: &[f64]) -> BayesDeterminismVerdict {
+    if call_a.len() != call_b.len() {
+        return BayesDeterminismVerdict::Fail;
     }
-    Ba002Verdict::Pass
+    if call_a.is_empty() {
+        return BayesDeterminismVerdict::Fail;
+    }
+    for (a, b) in call_a.iter().zip(call_b.iter()) {
+        if a.is_nan() && b.is_nan() {
+            // NaN != NaN by IEEE; treat as "both NaN" → divergent prediction
+            // Fail (separately from determinism, but the contract treats
+            // any NaN output as a Fail per BAYES-002).
+            return BayesDeterminismVerdict::Fail;
+        }
+        if a != b {
+            return BayesDeterminismVerdict::Fail;
+        }
+    }
+    BayesDeterminismVerdict::Pass
 }
 
-// ===========================================================================
-// BA-003 — Additivity: bias_add(bias_add(x, b1), b2) ≈ bias_add(x, b1 + b2)
-// ===========================================================================
-
-pub const AC_BA_003_TOLERANCE: f32 = 1.0e-6;
+// =============================================================================
+// FALSIFY-BAYES-004 — posterior concentration with more data
+// =============================================================================
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Ba003Verdict { Pass, Fail }
-
-#[must_use]
-pub fn verdict_from_additivity(
-    x: &[f32],
-    b1: &[f32],
-    b2: &[f32],
-    batch: usize,
-    d: usize,
-) -> Ba003Verdict {
-    if b1.len() != d || b2.len() != d { return Ba003Verdict::Fail; }
-    // Path 1: x → +b1 → +b2.
-    let after_b1 = match bias_add(x, b1, batch, d) {
-        Some(v) => v,
-        None => return Ba003Verdict::Fail,
-    };
-    let path1 = match bias_add(&after_b1, b2, batch, d) {
-        Some(v) => v,
-        None => return Ba003Verdict::Fail,
-    };
-    // Path 2: x → +(b1 + b2).
-    let combined: Vec<f32> = b1.iter().zip(b2.iter()).map(|(&a, &c)| a + c).collect();
-    let path2 = match bias_add(x, &combined, batch, d) {
-        Some(v) => v,
-        None => return Ba003Verdict::Fail,
-    };
-    if path1.len() != path2.len() { return Ba003Verdict::Fail; }
-    for (a, b) in path1.iter().zip(path2.iter()) {
-        if !a.is_finite() || !b.is_finite() { return Ba003Verdict::Fail; }
-        if (a - b).abs() > AC_BA_003_TOLERANCE { return Ba003Verdict::Fail; }
-    }
-    Ba003Verdict::Pass
+pub enum BayesConcentrationVerdict {
+    /// More data ⇒ posterior variance strictly decreases (or stays equal
+    /// in degenerate cases).
+    Pass,
+    /// 2n-sample variance ≥ n-sample variance — evidence not accumulating.
+    Fail,
 }
 
-// ===========================================================================
-// BA-004 — SIMD parity: scalar == SIMD byte-exactly (contract tolerance=0.0)
-// ===========================================================================
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Ba004Verdict { Pass, Fail }
-
 #[must_use]
-pub fn verdict_from_simd_parity(scalar: &[f32], simd: &[f32]) -> Ba004Verdict {
-    if scalar.is_empty() || simd.is_empty() { return Ba004Verdict::Fail; }
-    if scalar.len() != simd.len() { return Ba004Verdict::Fail; }
-    for (&s, &v) in scalar.iter().zip(simd.iter()) {
-        if !s.is_finite() || !v.is_finite() { return Ba004Verdict::Fail; }
-        if s.to_bits() != v.to_bits() { return Ba004Verdict::Fail; }
+pub fn verdict_from_bayes_concentration(variance_n: f64, variance_2n: f64) -> BayesConcentrationVerdict {
+    if !variance_n.is_finite() || !variance_2n.is_finite() {
+        return BayesConcentrationVerdict::Fail;
     }
-    Ba004Verdict::Pass
+    if variance_n < 0.0 || variance_2n < 0.0 {
+        return BayesConcentrationVerdict::Fail;
+    }
+    if variance_2n < variance_n {
+        BayesConcentrationVerdict::Pass
+    } else {
+        BayesConcentrationVerdict::Fail
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    // BA-001 (shape preservation)
-    #[test] fn ba001_pass_canonical() {
-        // batch=2, d=3.
-        let x = vec![1.0_f32, 2.0, 3.0, 4.0, 5.0, 6.0];
-        let bias = vec![0.1_f32, 0.2, 0.3];
-        assert_eq!(verdict_from_shape_preservation(&x, &bias, 2, 3), Ba001Verdict::Pass);
-    }
-    #[test] fn ba001_fail_dim_mismatch() {
-        let x = vec![1.0_f32, 2.0, 3.0]; // batch * d = 6 ≠ 3
-        let bias = vec![0.1_f32, 0.2, 0.3];
-        assert_eq!(verdict_from_shape_preservation(&x, &bias, 2, 3), Ba001Verdict::Fail);
-    }
-    #[test] fn ba001_fail_bias_dim_mismatch() {
-        let x = vec![1.0_f32; 6];
-        let bias = vec![0.1_f32, 0.2]; // wrong size
-        assert_eq!(verdict_from_shape_preservation(&x, &bias, 2, 3), Ba001Verdict::Fail);
-    }
-    #[test] fn ba001_fail_nan() {
-        let x = vec![1.0_f32, f32::NAN, 3.0];
-        let bias = vec![0.1_f32, 0.2, 0.3];
-        assert_eq!(verdict_from_shape_preservation(&x, &bias, 1, 3), Ba001Verdict::Fail);
+    // -------------------------------------------------------------------------
+    // Section 1: BAYES-001 posterior positivity.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fb001_pass_canonical_beta_binomial() {
+        // α' = 5+10, β' = 2+3.
+        assert_eq!(
+            verdict_from_bayes_posterior_positivity(15.0, 5.0),
+            BayesPosteriorPositivityVerdict::Pass
+        );
     }
 
-    // BA-002 (zero-bias identity)
-    #[test] fn ba002_pass_canonical() {
-        let x = vec![1.0_f32, 2.0, 3.0, 4.0, 5.0, 6.0];
-        assert_eq!(verdict_from_zero_bias_identity(&x, 2, 3), Ba002Verdict::Pass);
-    }
-    #[test] fn ba002_pass_random_x() {
-        let x: Vec<f32> = (0..256).map(|i| (i as f32 * 0.01) - 1.0).collect();
-        // batch=4, d=64.
-        assert_eq!(verdict_from_zero_bias_identity(&x, 4, 64), Ba002Verdict::Pass);
-    }
-    #[test] fn ba002_fail_dim_mismatch() {
-        let x = vec![1.0_f32, 2.0]; // batch * d = 6 ≠ 2
-        assert_eq!(verdict_from_zero_bias_identity(&x, 2, 3), Ba002Verdict::Fail);
-    }
-    #[test] fn ba002_fail_empty() {
-        assert_eq!(verdict_from_zero_bias_identity(&[], 0, 0), Ba002Verdict::Fail);
+    #[test]
+    fn fb001_pass_just_above_zero() {
+        assert_eq!(
+            verdict_from_bayes_posterior_positivity(1e-10, 1e-10),
+            BayesPosteriorPositivityVerdict::Pass
+        );
     }
 
-    // BA-003 (additivity)
-    #[test] fn ba003_pass_canonical() {
-        let x = vec![1.0_f32, 2.0, 3.0, 4.0];
-        let b1 = vec![0.1_f32, 0.2];
-        let b2 = vec![0.3_f32, 0.4];
-        assert_eq!(verdict_from_additivity(&x, &b1, &b2, 2, 2), Ba003Verdict::Pass);
-    }
-    #[test] fn ba003_pass_zero_biases() {
-        let x = vec![1.0_f32, 2.0];
-        let b1 = vec![0.0_f32, 0.0];
-        let b2 = vec![0.0_f32, 0.0];
-        assert_eq!(verdict_from_additivity(&x, &b1, &b2, 1, 2), Ba003Verdict::Pass);
-    }
-    #[test] fn ba003_fail_b1_wrong_size() {
-        let x = vec![1.0_f32, 2.0];
-        let b1 = vec![0.1_f32]; // d=2 but b1 has 1
-        let b2 = vec![0.3_f32, 0.4];
-        assert_eq!(verdict_from_additivity(&x, &b1, &b2, 1, 2), Ba003Verdict::Fail);
-    }
-    #[test] fn ba003_fail_b2_wrong_size() {
-        let x = vec![1.0_f32, 2.0];
-        let b1 = vec![0.1_f32, 0.2];
-        let b2 = vec![0.3_f32]; // d=2 but b2 has 1
-        assert_eq!(verdict_from_additivity(&x, &b1, &b2, 1, 2), Ba003Verdict::Fail);
+    #[test]
+    fn fb001_fail_alpha_zero() {
+        assert_eq!(
+            verdict_from_bayes_posterior_positivity(0.0, 5.0),
+            BayesPosteriorPositivityVerdict::Fail
+        );
     }
 
-    // BA-004 (SIMD parity)
-    #[test] fn ba004_pass_identical() {
-        let v = vec![1.0_f32, 2.0, 3.0];
-        assert_eq!(verdict_from_simd_parity(&v, &v), Ba004Verdict::Pass);
-    }
-    #[test] fn ba004_fail_one_ulp() {
-        // Contract tolerance=0.0 — even 1 ULP fails.
-        let a = vec![1.0_f32];
-        let b = vec![f32::from_bits(1.0_f32.to_bits() + 1)];
-        assert_eq!(verdict_from_simd_parity(&a, &b), Ba004Verdict::Fail);
-    }
-    #[test] fn ba004_fail_length() {
-        let a = vec![1.0_f32];
-        let b = vec![1.0_f32, 2.0];
-        assert_eq!(verdict_from_simd_parity(&a, &b), Ba004Verdict::Fail);
-    }
-    #[test] fn ba004_fail_nan() {
-        let a = vec![f32::NAN];
-        let b = vec![f32::NAN];
-        assert_eq!(verdict_from_simd_parity(&a, &b), Ba004Verdict::Fail);
+    #[test]
+    fn fb001_fail_beta_negative() {
+        assert_eq!(
+            verdict_from_bayes_posterior_positivity(5.0, -0.001),
+            BayesPosteriorPositivityVerdict::Fail
+        );
     }
 
-    // Helper sanity
-    #[test] fn bias_add_canonical() {
-        // [[1, 2], [3, 4]] + [10, 20] = [[11, 22], [13, 24]]
-        let x = vec![1.0_f32, 2.0, 3.0, 4.0];
-        let bias = vec![10.0_f32, 20.0];
-        let y = bias_add(&x, &bias, 2, 2).unwrap();
-        assert_eq!(y, vec![11.0_f32, 22.0, 13.0, 24.0]);
-    }
-    #[test] fn bias_add_broadcasts() {
-        // Bias [b0, b1] applied to ALL rows.
-        let x = vec![1.0_f32; 6];
-        let bias = vec![10.0_f32, 20.0, 30.0];
-        let y = bias_add(&x, &bias, 2, 3).unwrap();
-        // Row 0: [11, 21, 31]; row 1: [11, 21, 31].
-        assert_eq!(y, vec![11.0_f32, 21.0, 31.0, 11.0, 21.0, 31.0]);
+    #[test]
+    fn fb001_fail_nan_alpha() {
+        assert_eq!(
+            verdict_from_bayes_posterior_positivity(f64::NAN, 5.0),
+            BayesPosteriorPositivityVerdict::Fail
+        );
     }
 
-    // Provenance
-    #[test] fn provenance_constants() {
-        assert!((AC_BA_003_TOLERANCE - 1e-6).abs() < 1e-12);
+    #[test]
+    fn fb001_fail_inf_beta() {
+        assert_eq!(
+            verdict_from_bayes_posterior_positivity(5.0, f64::INFINITY),
+            BayesPosteriorPositivityVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 2: BAYES-002 prediction finiteness.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fb002_pass_all_finite() {
+        let p = vec![1.0, -2.5, 3.1415, 0.0];
+        assert_eq!(
+            verdict_from_bayes_prediction_finiteness(&p),
+            BayesPredictionFinitenessVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fb002_fail_nan_in_predictions() {
+        let p = vec![1.0, f64::NAN];
+        assert_eq!(
+            verdict_from_bayes_prediction_finiteness(&p),
+            BayesPredictionFinitenessVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fb002_fail_inf_in_predictions() {
+        let p = vec![f64::INFINITY];
+        assert_eq!(
+            verdict_from_bayes_prediction_finiteness(&p),
+            BayesPredictionFinitenessVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fb002_fail_neg_inf() {
+        let p = vec![1.0, f64::NEG_INFINITY];
+        assert_eq!(
+            verdict_from_bayes_prediction_finiteness(&p),
+            BayesPredictionFinitenessVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fb002_fail_empty() {
+        assert_eq!(
+            verdict_from_bayes_prediction_finiteness(&[]),
+            BayesPredictionFinitenessVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 3: BAYES-003 determinism.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fb003_pass_bit_identical() {
+        let p = vec![1.5, 2.5, 3.5];
+        assert_eq!(
+            verdict_from_bayes_determinism(&p, &p),
+            BayesDeterminismVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fb003_fail_one_element_differs() {
+        let a = vec![1.5, 2.5, 3.5];
+        let b = vec![1.5, 2.5, 3.50000001];
+        assert_eq!(
+            verdict_from_bayes_determinism(&a, &b),
+            BayesDeterminismVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fb003_fail_length_mismatch() {
+        let a = vec![1.0];
+        let b = vec![1.0, 2.0];
+        assert_eq!(
+            verdict_from_bayes_determinism(&a, &b),
+            BayesDeterminismVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fb003_fail_both_nan() {
+        let a = vec![f64::NAN];
+        let b = vec![f64::NAN];
+        assert_eq!(
+            verdict_from_bayes_determinism(&a, &b),
+            BayesDeterminismVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fb003_fail_empty() {
+        assert_eq!(
+            verdict_from_bayes_determinism(&[], &[]),
+            BayesDeterminismVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 4: BAYES-004 posterior concentration.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fb004_pass_2n_smaller() {
+        // Doubling data halves variance approximately.
+        assert_eq!(
+            verdict_from_bayes_concentration(1.0, 0.5),
+            BayesConcentrationVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fb004_pass_marginal_decrease() {
+        assert_eq!(
+            verdict_from_bayes_concentration(1.0, 0.999999),
+            BayesConcentrationVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fb004_fail_variance_unchanged() {
+        // Strict decrease required.
+        assert_eq!(
+            verdict_from_bayes_concentration(1.0, 1.0),
+            BayesConcentrationVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fb004_fail_variance_increased() {
+        assert_eq!(
+            verdict_from_bayes_concentration(1.0, 1.5),
+            BayesConcentrationVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fb004_fail_negative_variance() {
+        // Variance should never go negative.
+        assert_eq!(
+            verdict_from_bayes_concentration(1.0, -0.1),
+            BayesConcentrationVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fb004_fail_nan_variance() {
+        assert_eq!(
+            verdict_from_bayes_concentration(1.0, f64::NAN),
+            BayesConcentrationVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 5: Realistic — full healthy Bayesian inference passes all 4.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn realistic_healthy_bayes_passes_all_4() {
+        // Beta-Binomial conjugate update: α'=15, β'=5.
+        assert_eq!(
+            verdict_from_bayes_posterior_positivity(15.0, 5.0),
+            BayesPosteriorPositivityVerdict::Pass
+        );
+        // BLR predictions all finite.
+        assert_eq!(
+            verdict_from_bayes_prediction_finiteness(&[1.5, -2.0, 3.7]),
+            BayesPredictionFinitenessVerdict::Pass
+        );
+        // Deterministic predictions.
+        let p = vec![1.5, -2.0, 3.7];
+        assert_eq!(
+            verdict_from_bayes_determinism(&p, &p),
+            BayesDeterminismVerdict::Pass
+        );
+        // Posterior concentrated with more data.
+        assert_eq!(
+            verdict_from_bayes_concentration(2.0, 1.0),
+            BayesConcentrationVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn realistic_pre_fix_all_4_failures() {
+        // 001: arithmetic underflow → α' = 0.
+        assert_eq!(
+            verdict_from_bayes_posterior_positivity(0.0, 5.0),
+            BayesPosteriorPositivityVerdict::Fail
+        );
+        // 002: covariance inversion produced NaN.
+        assert_eq!(
+            verdict_from_bayes_prediction_finiteness(&[1.0, f64::NAN]),
+            BayesPredictionFinitenessVerdict::Fail
+        );
+        // 003: random state leaked → predictions differ.
+        let a = vec![1.0];
+        let b = vec![1.5];
+        assert_eq!(
+            verdict_from_bayes_determinism(&a, &b),
+            BayesDeterminismVerdict::Fail
+        );
+        // 004: evidence not accumulating → variance grew.
+        assert_eq!(
+            verdict_from_bayes_concentration(1.0, 1.5),
+            BayesConcentrationVerdict::Fail
+        );
     }
 }

--- a/crates/aprender-core/src/format/bd_001_005.rs
+++ b/crates/aprender-core/src/format/bd_001_005.rs
@@ -1,0 +1,479 @@
+// `backend-dispatch-v1` algorithm-level PARTIAL discharge for the 5
+// backend-dispatch falsifiers (GPU threshold monotonicity, garbage
+// oracle, QK norm score bound, BPE roundtrip, SIMD dispatch
+// equivalence).
+//
+// Contract: `contracts/backend-dispatch-v1.yaml`.
+
+/// GPU dispatch threshold per `equations.gpu_threshold`.
+pub const AC_BD_GPU_THRESHOLD: u32 = 100_000;
+
+/// SIMD-only threshold (no threading) per `equations.simd_only_threshold`.
+pub const AC_BD_SIMD_ONLY_THRESHOLD: u32 = 1_000;
+
+/// Garbage-oracle repetition ratio threshold (>0.3 = garbage).
+pub const AC_BD_GARBAGE_REPETITION_THRESHOLD: f32 = 0.3;
+
+/// Garbage-oracle minimum unique character count.
+pub const AC_BD_GARBAGE_UNIQUE_CHARS_MIN: usize = 10;
+
+/// SIMD vs scalar tolerance (contract: 0.0 — exact equality).
+pub const AC_BD_SIMD_TOLERANCE: f32 = 0.0;
+
+// =============================================================================
+// FALSIFY-BD-001 — GPU dispatch monotonic
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GpuDispatchVerdict {
+    /// dispatch_chooses_gpu(n) ⇔ n >= 100_000.
+    /// Monotonic: if n1 >= threshold AND n2 > n1 then n2 >= threshold.
+    Pass,
+    /// Non-monotonic dispatch decision.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_gpu_dispatch(n: u32, chose_gpu: bool) -> GpuDispatchVerdict {
+    let should_be_gpu = n >= AC_BD_GPU_THRESHOLD;
+    if chose_gpu == should_be_gpu {
+        GpuDispatchVerdict::Pass
+    } else {
+        GpuDispatchVerdict::Fail
+    }
+}
+
+// =============================================================================
+// FALSIFY-BD-002 — garbage oracle
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GarbageOracleVerdict {
+    /// `is_garbage` matches predicate (rep_ratio > 0.3 OR unique_chars < 10).
+    Pass,
+    /// Oracle missed a degenerate string OR false-flagged a healthy one.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_garbage_oracle(
+    repetition_ratio: f32,
+    unique_chars: usize,
+    classified_as_garbage: bool,
+) -> GarbageOracleVerdict {
+    if !repetition_ratio.is_finite() {
+        return GarbageOracleVerdict::Fail;
+    }
+    let should_be_garbage = repetition_ratio > AC_BD_GARBAGE_REPETITION_THRESHOLD
+        || unique_chars < AC_BD_GARBAGE_UNIQUE_CHARS_MIN;
+    if classified_as_garbage == should_be_garbage {
+        GarbageOracleVerdict::Pass
+    } else {
+        GarbageOracleVerdict::Fail
+    }
+}
+
+// =============================================================================
+// FALSIFY-BD-003 — QK norm score bound
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QkNormBoundVerdict {
+    /// |pre_softmax_score| ≤ sqrt(head_dim).
+    Pass,
+    /// L2 normalization not applied — score exploded.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_qk_norm_bound(score: f32, head_dim: u32) -> QkNormBoundVerdict {
+    if head_dim == 0 {
+        return QkNormBoundVerdict::Fail;
+    }
+    if !score.is_finite() {
+        return QkNormBoundVerdict::Fail;
+    }
+    let bound = (head_dim as f32).sqrt();
+    if score.abs() <= bound + 1e-5 {
+        QkNormBoundVerdict::Pass
+    } else {
+        QkNormBoundVerdict::Fail
+    }
+}
+
+// =============================================================================
+// FALSIFY-BD-004 — BPE roundtrip
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BpeRoundtripVerdict {
+    /// encode(decode(tokens)) == tokens (lossless).
+    Pass,
+    /// Tokens diverge — lossy tokenization.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_bpe_roundtrip(original_tokens: &[u32], reencoded_tokens: &[u32]) -> BpeRoundtripVerdict {
+    if original_tokens.is_empty() {
+        return BpeRoundtripVerdict::Fail;
+    }
+    if original_tokens != reencoded_tokens {
+        return BpeRoundtripVerdict::Fail;
+    }
+    BpeRoundtripVerdict::Pass
+}
+
+// =============================================================================
+// FALSIFY-BD-005 — SIMD dispatch equivalence (exact)
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SimdEquivalenceVerdict {
+    /// SIMD output bit-identical to scalar output (tolerance 0.0).
+    Pass,
+    /// Diverged — SIMD dispatch produced different result.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_simd_equivalence(simd: &[f32], scalar: &[f32]) -> SimdEquivalenceVerdict {
+    if simd.len() != scalar.len() {
+        return SimdEquivalenceVerdict::Fail;
+    }
+    if simd.is_empty() {
+        return SimdEquivalenceVerdict::Fail;
+    }
+    for (a, b) in simd.iter().zip(scalar.iter()) {
+        if a.is_nan() != b.is_nan() {
+            return SimdEquivalenceVerdict::Fail;
+        }
+        if !a.is_nan() && a != b {
+            return SimdEquivalenceVerdict::Fail;
+        }
+    }
+    SimdEquivalenceVerdict::Pass
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -------------------------------------------------------------------------
+    // Section 1: Provenance pins.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn provenance_gpu_threshold_100k() {
+        assert_eq!(AC_BD_GPU_THRESHOLD, 100_000);
+    }
+
+    #[test]
+    fn provenance_simd_only_threshold_1k() {
+        assert_eq!(AC_BD_SIMD_ONLY_THRESHOLD, 1_000);
+    }
+
+    #[test]
+    fn provenance_garbage_threshold_03() {
+        assert!((AC_BD_GARBAGE_REPETITION_THRESHOLD - 0.3).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn provenance_garbage_unique_min_10() {
+        assert_eq!(AC_BD_GARBAGE_UNIQUE_CHARS_MIN, 10);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 2: BD-001 GPU threshold.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fbd001_pass_above_threshold_gpu() {
+        assert_eq!(
+            verdict_from_gpu_dispatch(150_000, true),
+            GpuDispatchVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fbd001_pass_at_threshold_gpu() {
+        assert_eq!(
+            verdict_from_gpu_dispatch(100_000, true),
+            GpuDispatchVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fbd001_pass_below_threshold_cpu() {
+        assert_eq!(
+            verdict_from_gpu_dispatch(50_000, false),
+            GpuDispatchVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fbd001_fail_below_threshold_chose_gpu() {
+        assert_eq!(
+            verdict_from_gpu_dispatch(50_000, true),
+            GpuDispatchVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fbd001_fail_above_threshold_chose_cpu() {
+        assert_eq!(
+            verdict_from_gpu_dispatch(200_000, false),
+            GpuDispatchVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 3: BD-002 garbage oracle.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fbd002_pass_clean_text_classified_clean() {
+        // 0.1 rep ratio + 26 chars = healthy.
+        assert_eq!(
+            verdict_from_garbage_oracle(0.1, 26, false),
+            GarbageOracleVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fbd002_pass_high_rep_classified_garbage() {
+        assert_eq!(
+            verdict_from_garbage_oracle(0.5, 30, true),
+            GarbageOracleVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fbd002_pass_low_diversity_classified_garbage() {
+        assert_eq!(
+            verdict_from_garbage_oracle(0.1, 5, true),
+            GarbageOracleVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fbd002_fail_high_rep_classified_clean() {
+        // Oracle missed degenerate text.
+        assert_eq!(
+            verdict_from_garbage_oracle(0.5, 30, false),
+            GarbageOracleVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fbd002_fail_clean_classified_garbage() {
+        assert_eq!(
+            verdict_from_garbage_oracle(0.05, 50, true),
+            GarbageOracleVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fbd002_fail_nan_repetition() {
+        assert_eq!(
+            verdict_from_garbage_oracle(f32::NAN, 30, false),
+            GarbageOracleVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 4: BD-003 QK norm bound.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fbd003_pass_at_bound() {
+        // head_dim=64 → bound = 8.
+        assert_eq!(
+            verdict_from_qk_norm_bound(8.0, 64),
+            QkNormBoundVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fbd003_pass_within_bound() {
+        assert_eq!(
+            verdict_from_qk_norm_bound(5.0, 64),
+            QkNormBoundVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fbd003_pass_negative_within_bound() {
+        assert_eq!(
+            verdict_from_qk_norm_bound(-7.5, 64),
+            QkNormBoundVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fbd003_fail_above_bound() {
+        // 100 > sqrt(64)=8.
+        assert_eq!(
+            verdict_from_qk_norm_bound(100.0, 64),
+            QkNormBoundVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fbd003_fail_zero_head_dim() {
+        assert_eq!(
+            verdict_from_qk_norm_bound(0.0, 0),
+            QkNormBoundVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fbd003_fail_nan_score() {
+        assert_eq!(
+            verdict_from_qk_norm_bound(f32::NAN, 64),
+            QkNormBoundVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 5: BD-004 BPE roundtrip.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fbd004_pass_lossless_roundtrip() {
+        let t = vec![1u32, 2, 3, 4, 5];
+        assert_eq!(
+            verdict_from_bpe_roundtrip(&t, &t),
+            BpeRoundtripVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fbd004_fail_token_drift() {
+        let original = vec![1u32, 2, 3];
+        let reencoded = vec![1u32, 2, 4];
+        assert_eq!(
+            verdict_from_bpe_roundtrip(&original, &reencoded),
+            BpeRoundtripVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fbd004_fail_length_change() {
+        let original = vec![1u32, 2];
+        let reencoded = vec![1u32, 2, 3];
+        assert_eq!(
+            verdict_from_bpe_roundtrip(&original, &reencoded),
+            BpeRoundtripVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fbd004_fail_empty() {
+        assert_eq!(
+            verdict_from_bpe_roundtrip(&[], &[]),
+            BpeRoundtripVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 6: BD-005 SIMD dispatch equivalence (exact).
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fbd005_pass_bit_identical() {
+        let v = vec![1.5_f32, 2.5];
+        assert_eq!(
+            verdict_from_simd_equivalence(&v, &v),
+            SimdEquivalenceVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fbd005_fail_tiny_drift() {
+        // Contract: tolerance == 0.0 — even 1 ULP fails.
+        let simd = vec![1.5_f32 + f32::EPSILON];
+        let scalar = vec![1.5_f32];
+        assert_eq!(
+            verdict_from_simd_equivalence(&simd, &scalar),
+            SimdEquivalenceVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fbd005_fail_length_mismatch() {
+        assert_eq!(
+            verdict_from_simd_equivalence(&[1.0], &[1.0, 2.0]),
+            SimdEquivalenceVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fbd005_fail_empty() {
+        assert_eq!(
+            verdict_from_simd_equivalence(&[], &[]),
+            SimdEquivalenceVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 7: Realistic — full healthy backend dispatch passes all 5.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn realistic_healthy_dispatch_passes_all_5() {
+        // 7B model GEMM ≈ 1M elements → GPU.
+        assert_eq!(
+            verdict_from_gpu_dispatch(1_000_000, true),
+            GpuDispatchVerdict::Pass
+        );
+        // Healthy English text.
+        assert_eq!(
+            verdict_from_garbage_oracle(0.05, 35, false),
+            GarbageOracleVerdict::Pass
+        );
+        // Qwen2 head_dim=128 → bound = sqrt(128) ≈ 11.3.
+        assert_eq!(
+            verdict_from_qk_norm_bound(11.0, 128),
+            QkNormBoundVerdict::Pass
+        );
+        // Lossless BPE roundtrip.
+        let tokens = vec![100u32, 200, 300];
+        assert_eq!(
+            verdict_from_bpe_roundtrip(&tokens, &tokens),
+            BpeRoundtripVerdict::Pass
+        );
+        // SIMD bit-identical.
+        let v = vec![1.0_f32, 2.0, 3.0];
+        assert_eq!(
+            verdict_from_simd_equivalence(&v, &v),
+            SimdEquivalenceVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn realistic_pre_fix_all_5_failures() {
+        // 001: chose CPU on 1M elements.
+        assert_eq!(
+            verdict_from_gpu_dispatch(1_000_000, false),
+            GpuDispatchVerdict::Fail
+        );
+        // 002: oracle missed "aaaaaaa".
+        assert_eq!(
+            verdict_from_garbage_oracle(0.95, 1, false),
+            GarbageOracleVerdict::Fail
+        );
+        // 003: L2 normalization missing — score 200 on head_dim=64.
+        assert_eq!(
+            verdict_from_qk_norm_bound(200.0, 64),
+            QkNormBoundVerdict::Fail
+        );
+        // 004: tokenizer dropped a token.
+        let original = vec![1u32, 2, 3];
+        let reencoded = vec![1u32, 3];
+        assert_eq!(
+            verdict_from_bpe_roundtrip(&original, &reencoded),
+            BpeRoundtripVerdict::Fail
+        );
+        // 005: SIMD reduction order leaked an FMA.
+        let simd = vec![1.5_f32];
+        let scalar = vec![1.5_f32 + f32::EPSILON];
+        assert_eq!(
+            verdict_from_simd_equivalence(&simd, &scalar),
+            SimdEquivalenceVerdict::Fail
+        );
+    }
+}

--- a/crates/aprender-core/src/format/beam_001_005.rs
+++ b/crates/aprender-core/src/format/beam_001_005.rs
@@ -1,0 +1,472 @@
+// `batched-beam-search-v1` algorithm-level PARTIAL discharge for the 5
+// batched-beam-search falsifiers (output equivalence with sequential,
+// top-K consistency, beam=1 == greedy, termination, edge-case property).
+//
+// Contract: `contracts/batched-beam-search-v1.yaml`.
+// Refs: Freitag & Al-Onaizan (2017) Beam Search Strategies, Graves
+// (2012) Sequence Transduction §3.1, Radford et al. (2023) Whisper.
+
+/// Tolerance for batched-vs-sequential matmul output comparison.
+pub const AC_BEAM_OUTPUT_TOLERANCE: f32 = 1.0e-5;
+
+/// Whisper vocab size (used in canonical N×V test layouts).
+pub const AC_BEAM_WHISPER_VOCAB: usize = 51_864;
+
+// =============================================================================
+// FALSIFY-BATCH-001 — output equivalence with sequential beam projection
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BeamOutputEquivalenceVerdict {
+    /// max_b max_i |batched[b][i] - sequential[b][i]| < 1e-5.
+    Pass,
+    /// At least one element exceeds tolerance — FP non-associativity bug.
+    Fail,
+}
+
+/// Inputs are flattened (n_beams * d_out) row-major output tensors.
+#[must_use]
+pub fn verdict_from_beam_output_equivalence(
+    batched: &[f32],
+    sequential: &[f32],
+) -> BeamOutputEquivalenceVerdict {
+    if batched.len() != sequential.len() {
+        return BeamOutputEquivalenceVerdict::Fail;
+    }
+    if batched.is_empty() {
+        return BeamOutputEquivalenceVerdict::Fail;
+    }
+    for (a, b) in batched.iter().zip(sequential.iter()) {
+        if (a - b).abs() >= AC_BEAM_OUTPUT_TOLERANCE {
+            return BeamOutputEquivalenceVerdict::Fail;
+        }
+    }
+    BeamOutputEquivalenceVerdict::Pass
+}
+
+// =============================================================================
+// FALSIFY-BATCH-002 — top-K beam selection matches sequential
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BeamTopKConsistencyVerdict {
+    /// Set of (parent, token) pairs from batched == set from sequential.
+    Pass,
+    /// At least one pair differs — flattened-index decomposition bug.
+    Fail,
+}
+
+/// `(parent_beam, token_id)` tuples from each implementation, in any order.
+#[must_use]
+pub fn verdict_from_beam_topk_consistency(
+    batched: &[(u32, u32)],
+    sequential: &[(u32, u32)],
+) -> BeamTopKConsistencyVerdict {
+    use std::collections::HashSet;
+    if batched.len() != sequential.len() {
+        return BeamTopKConsistencyVerdict::Fail;
+    }
+    if batched.is_empty() {
+        return BeamTopKConsistencyVerdict::Fail;
+    }
+    let set_a: HashSet<&(u32, u32)> = batched.iter().collect();
+    let set_b: HashSet<&(u32, u32)> = sequential.iter().collect();
+    if set_a == set_b {
+        BeamTopKConsistencyVerdict::Pass
+    } else {
+        BeamTopKConsistencyVerdict::Fail
+    }
+}
+
+// =============================================================================
+// FALSIFY-BATCH-003 — beam=1 produces same sequence as greedy decode
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BeamGreedyParityVerdict {
+    /// beam_search(input, K=1) token sequence == greedy_decode(input).
+    Pass,
+    /// Sequences differ — beam-bookkeeping corrupts K=1 degenerate case.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_beam_greedy_parity(
+    beam_tokens: &[u32],
+    greedy_tokens: &[u32],
+) -> BeamGreedyParityVerdict {
+    if beam_tokens == greedy_tokens {
+        BeamGreedyParityVerdict::Pass
+    } else {
+        BeamGreedyParityVerdict::Fail
+    }
+}
+
+// =============================================================================
+// FALSIFY-BATCH-004 — termination within max_len
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BeamTerminationVerdict {
+    /// All returned beams have length ≤ max_len AND step counter ≤ max_len.
+    Pass,
+    /// At least one beam exceeded max_len — termination check broken.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_beam_termination(
+    final_step_count: usize,
+    max_len: usize,
+    returned_beam_lengths: &[usize],
+) -> BeamTerminationVerdict {
+    if max_len == 0 {
+        return BeamTerminationVerdict::Fail;
+    }
+    if final_step_count > max_len {
+        return BeamTerminationVerdict::Fail;
+    }
+    if returned_beam_lengths.is_empty() {
+        // Fallback guarantees at least one beam.
+        return BeamTerminationVerdict::Fail;
+    }
+    for &len in returned_beam_lengths {
+        if len > max_len {
+            return BeamTerminationVerdict::Fail;
+        }
+    }
+    BeamTerminationVerdict::Pass
+}
+
+// =============================================================================
+// FALSIFY-BATCH-005 — boundary-condition termination property
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BeamBoundaryVerdict {
+    /// Adversarial boundary inputs (max_len ∈ {1, 10, 100, 448}) all
+    /// terminate cleanly with ≥1 returned beam.
+    Pass,
+    /// Boundary case violated termination invariant.
+    Fail,
+}
+
+/// Each entry: (max_len_used, did_terminate_cleanly, returned_beams_count).
+#[must_use]
+pub fn verdict_from_beam_boundary(boundary_runs: &[(usize, bool, usize)]) -> BeamBoundaryVerdict {
+    if boundary_runs.is_empty() {
+        return BeamBoundaryVerdict::Fail;
+    }
+    for (_max_len, terminated_clean, beams_returned) in boundary_runs {
+        if !*terminated_clean {
+            return BeamBoundaryVerdict::Fail;
+        }
+        if *beams_returned == 0 {
+            return BeamBoundaryVerdict::Fail;
+        }
+    }
+    BeamBoundaryVerdict::Pass
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -------------------------------------------------------------------------
+    // Section 1: Provenance pins.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn provenance_output_tolerance_1e_neg5() {
+        assert!((AC_BEAM_OUTPUT_TOLERANCE - 1.0e-5).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn provenance_whisper_vocab_51864() {
+        assert_eq!(AC_BEAM_WHISPER_VOCAB, 51_864);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 2: BATCH-001 output equivalence.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fb001_pass_exact_match() {
+        let a = vec![1.0; 32];
+        assert_eq!(
+            verdict_from_beam_output_equivalence(&a, &a),
+            BeamOutputEquivalenceVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fb001_pass_within_tolerance() {
+        let batched = vec![1.0 + 5e-6, 2.0 + 5e-6];
+        let sequential = vec![1.0, 2.0];
+        assert_eq!(
+            verdict_from_beam_output_equivalence(&batched, &sequential),
+            BeamOutputEquivalenceVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fb001_fail_above_tolerance() {
+        let batched = vec![1.5];
+        let sequential = vec![1.0];
+        assert_eq!(
+            verdict_from_beam_output_equivalence(&batched, &sequential),
+            BeamOutputEquivalenceVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fb001_fail_length_mismatch() {
+        assert_eq!(
+            verdict_from_beam_output_equivalence(&[1.0], &[1.0, 2.0]),
+            BeamOutputEquivalenceVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fb001_fail_empty() {
+        assert_eq!(
+            verdict_from_beam_output_equivalence(&[], &[]),
+            BeamOutputEquivalenceVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 3: BATCH-002 top-K consistency.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fb002_pass_same_set_same_order() {
+        let a = [(0u32, 100u32), (1, 200), (2, 300)];
+        assert_eq!(
+            verdict_from_beam_topk_consistency(&a, &a),
+            BeamTopKConsistencyVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fb002_pass_same_set_different_order() {
+        // Set semantics: order doesn't matter.
+        let a = [(0u32, 100), (1, 200)];
+        let b = [(1u32, 200), (0, 100)];
+        assert_eq!(
+            verdict_from_beam_topk_consistency(&a, &b),
+            BeamTopKConsistencyVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fb002_fail_different_pairs() {
+        let a = [(0u32, 100)];
+        let b = [(0u32, 101)]; // off-by-one in token_id
+        assert_eq!(
+            verdict_from_beam_topk_consistency(&a, &b),
+            BeamTopKConsistencyVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fb002_fail_length_mismatch() {
+        let a = [(0u32, 100), (1, 200)];
+        let b = [(0u32, 100)];
+        assert_eq!(
+            verdict_from_beam_topk_consistency(&a, &b),
+            BeamTopKConsistencyVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fb002_fail_empty() {
+        let empty: [(u32, u32); 0] = [];
+        assert_eq!(
+            verdict_from_beam_topk_consistency(&empty, &empty),
+            BeamTopKConsistencyVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 4: BATCH-003 beam=1 == greedy.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fb003_pass_identical_sequences() {
+        let beam = [1u32, 2, 3, 4];
+        let greedy = [1u32, 2, 3, 4];
+        assert_eq!(
+            verdict_from_beam_greedy_parity(&beam, &greedy),
+            BeamGreedyParityVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fb003_fail_different_first_token() {
+        let beam = [2u32, 3, 4];
+        let greedy = [1u32, 3, 4];
+        assert_eq!(
+            verdict_from_beam_greedy_parity(&beam, &greedy),
+            BeamGreedyParityVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fb003_fail_different_length() {
+        let beam = [1u32, 2, 3];
+        let greedy = [1u32, 2, 3, 4];
+        assert_eq!(
+            verdict_from_beam_greedy_parity(&beam, &greedy),
+            BeamGreedyParityVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 5: BATCH-004 termination.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fb004_pass_terminated_in_time() {
+        assert_eq!(
+            verdict_from_beam_termination(50, 100, &[40, 50, 30]),
+            BeamTerminationVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fb004_pass_at_max_len() {
+        assert_eq!(
+            verdict_from_beam_termination(100, 100, &[100]),
+            BeamTerminationVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fb004_fail_step_count_overrun() {
+        assert_eq!(
+            verdict_from_beam_termination(101, 100, &[100]),
+            BeamTerminationVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fb004_fail_beam_overrun() {
+        assert_eq!(
+            verdict_from_beam_termination(100, 100, &[100, 101]),
+            BeamTerminationVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fb004_fail_no_beams_returned() {
+        // Fallback should guarantee ≥1 beam.
+        assert_eq!(
+            verdict_from_beam_termination(50, 100, &[]),
+            BeamTerminationVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fb004_fail_zero_max_len() {
+        assert_eq!(
+            verdict_from_beam_termination(0, 0, &[0]),
+            BeamTerminationVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 6: BATCH-005 boundary conditions.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fb005_pass_canonical_boundaries() {
+        // max_len ∈ {1, 10, 100, 448} per contract test.
+        let runs = [
+            (1usize, true, 1usize),
+            (10, true, 4),
+            (100, true, 4),
+            (448, true, 4),
+        ];
+        assert_eq!(
+            verdict_from_beam_boundary(&runs),
+            BeamBoundaryVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fb005_fail_one_boundary_no_terminate() {
+        let runs = [(1usize, true, 1usize), (448, false, 0)];
+        assert_eq!(verdict_from_beam_boundary(&runs), BeamBoundaryVerdict::Fail);
+    }
+
+    #[test]
+    fn fb005_fail_one_boundary_no_beams() {
+        let runs = [(10usize, true, 0usize)];
+        assert_eq!(verdict_from_beam_boundary(&runs), BeamBoundaryVerdict::Fail);
+    }
+
+    #[test]
+    fn fb005_fail_empty_run_list() {
+        let runs: [(usize, bool, usize); 0] = [];
+        assert_eq!(verdict_from_beam_boundary(&runs), BeamBoundaryVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 7: Realistic — full healthy beam search passes all 5.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn realistic_healthy_beam_search_passes_all_5() {
+        let batched = vec![1.0; 64];
+        assert_eq!(
+            verdict_from_beam_output_equivalence(&batched, &batched),
+            BeamOutputEquivalenceVerdict::Pass
+        );
+        let topk = [(0u32, 100), (1, 200), (2, 300), (3, 400)];
+        assert_eq!(
+            verdict_from_beam_topk_consistency(&topk, &topk),
+            BeamTopKConsistencyVerdict::Pass
+        );
+        let seq = [1u32, 2, 3];
+        assert_eq!(
+            verdict_from_beam_greedy_parity(&seq, &seq),
+            BeamGreedyParityVerdict::Pass
+        );
+        assert_eq!(
+            verdict_from_beam_termination(50, 100, &[40, 50, 30, 35]),
+            BeamTerminationVerdict::Pass
+        );
+        let runs = [(1usize, true, 1), (10, true, 4), (100, true, 4), (448, true, 4)];
+        assert_eq!(
+            verdict_from_beam_boundary(&runs),
+            BeamBoundaryVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn realistic_pre_fix_all_5_failures() {
+        // 001: GEMM accumulation order diverged.
+        let batched = vec![1.5];
+        let sequential = vec![1.0];
+        assert_eq!(
+            verdict_from_beam_output_equivalence(&batched, &sequential),
+            BeamOutputEquivalenceVerdict::Fail
+        );
+        // 002: index decomposition off-by-one.
+        let a = [(0u32, 100)];
+        let b = [(0u32, 101)];
+        assert_eq!(
+            verdict_from_beam_topk_consistency(&a, &b),
+            BeamTopKConsistencyVerdict::Fail
+        );
+        // 003: K=1 bookkeeping corrupted output.
+        let beam = [99u32];
+        let greedy = [100u32];
+        assert_eq!(
+            verdict_from_beam_greedy_parity(&beam, &greedy),
+            BeamGreedyParityVerdict::Fail
+        );
+        // 004: step counter overshot.
+        assert_eq!(
+            verdict_from_beam_termination(150, 100, &[150]),
+            BeamTerminationVerdict::Fail
+        );
+        // 005: max_len=1 boundary failed to terminate.
+        let runs = [(1usize, false, 0)];
+        assert_eq!(verdict_from_beam_boundary(&runs), BeamBoundaryVerdict::Fail);
+    }
+}

--- a/crates/aprender-core/src/format/biattn_001_004.rs
+++ b/crates/aprender-core/src/format/biattn_001_004.rs
@@ -1,0 +1,424 @@
+// `bidirectional-attention-v1` algorithm-level PARTIAL discharge for the
+// 4 BERT-style bidirectional-attention falsifiers (no causal mask, n=1
+// causal parity, weight normalization, full density).
+//
+// Contract: `contracts/bidirectional-attention-v1.yaml`.
+// Refs: Devlin et al. (2019) BERT.
+
+/// Tolerance for "weights sum to 1" check (1e-5).
+pub const AC_BIATTN_NORM_TOLERANCE: f32 = 1.0e-5;
+
+/// Tolerance for n=1 causal-parity check (1e-6).
+pub const AC_BIATTN_CAUSAL_PARITY_TOLERANCE: f32 = 1.0e-6;
+
+// =============================================================================
+// FALSIFY-BIATT-001 — no causal mask (upper triangle non-zero)
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BiattnNoCausalMaskVerdict {
+    /// All entries attn_weights[i, j] > 0 (no zero from masking).
+    Pass,
+    /// Some upper-triangle entry is zero — causal mask leaked.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_biattn_no_causal_mask(
+    n: usize,
+    attn_weights: &[f32],
+) -> BiattnNoCausalMaskVerdict {
+    if n == 0 {
+        return BiattnNoCausalMaskVerdict::Fail;
+    }
+    if attn_weights.len() != n * n {
+        return BiattnNoCausalMaskVerdict::Fail;
+    }
+    for i in 0..n {
+        for j in 0..n {
+            if i < j {
+                let w = attn_weights[i * n + j];
+                if !w.is_finite() {
+                    return BiattnNoCausalMaskVerdict::Fail;
+                }
+                if w <= 0.0 {
+                    return BiattnNoCausalMaskVerdict::Fail;
+                }
+            }
+        }
+    }
+    BiattnNoCausalMaskVerdict::Pass
+}
+
+// =============================================================================
+// FALSIFY-BIATT-002 — n=1 causal parity
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BiattnCausalParityVerdict {
+    /// At n=1: |BiAttn(q,k,v) - CausalAttn(q,k,v)| < 1e-6.
+    Pass,
+    /// Mask application differs even when mask is trivial.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_biattn_causal_parity(
+    bi_output: &[f32],
+    causal_output: &[f32],
+) -> BiattnCausalParityVerdict {
+    if bi_output.len() != causal_output.len() {
+        return BiattnCausalParityVerdict::Fail;
+    }
+    if bi_output.is_empty() {
+        return BiattnCausalParityVerdict::Fail;
+    }
+    for (a, b) in bi_output.iter().zip(causal_output.iter()) {
+        if !a.is_finite() || !b.is_finite() {
+            return BiattnCausalParityVerdict::Fail;
+        }
+        if (a - b).abs() >= AC_BIATTN_CAUSAL_PARITY_TOLERANCE {
+            return BiattnCausalParityVerdict::Fail;
+        }
+    }
+    BiattnCausalParityVerdict::Pass
+}
+
+// =============================================================================
+// FALSIFY-BIATT-003 — weight normalization (each row sums to 1.0)
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BiattnWeightNormalizationVerdict {
+    /// |sum(attn_weights[i, :]) - 1.0| < 1e-5 ∀ i.
+    Pass,
+    /// At least one row doesn't sum to 1 — softmax bug.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_biattn_weight_normalization(
+    n: usize,
+    attn_weights: &[f32],
+) -> BiattnWeightNormalizationVerdict {
+    if n == 0 {
+        return BiattnWeightNormalizationVerdict::Fail;
+    }
+    if attn_weights.len() != n * n {
+        return BiattnWeightNormalizationVerdict::Fail;
+    }
+    for i in 0..n {
+        let row_sum: f32 = (0..n).map(|j| attn_weights[i * n + j]).sum();
+        if !row_sum.is_finite() {
+            return BiattnWeightNormalizationVerdict::Fail;
+        }
+        if (row_sum - 1.0).abs() >= AC_BIATTN_NORM_TOLERANCE {
+            return BiattnWeightNormalizationVerdict::Fail;
+        }
+    }
+    BiattnWeightNormalizationVerdict::Pass
+}
+
+// =============================================================================
+// FALSIFY-BIATT-004 — full attention density (all entries > 0)
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BiattnFullDensityVerdict {
+    /// All n×n attention weights are strictly positive.
+    Pass,
+    /// At least one entry is zero or non-positive — sparse attention bug.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_biattn_full_density(
+    n: usize,
+    attn_weights: &[f32],
+) -> BiattnFullDensityVerdict {
+    if n == 0 {
+        return BiattnFullDensityVerdict::Fail;
+    }
+    if attn_weights.len() != n * n {
+        return BiattnFullDensityVerdict::Fail;
+    }
+    for &w in attn_weights {
+        if !w.is_finite() {
+            return BiattnFullDensityVerdict::Fail;
+        }
+        if w <= 0.0 {
+            return BiattnFullDensityVerdict::Fail;
+        }
+    }
+    BiattnFullDensityVerdict::Pass
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -------------------------------------------------------------------------
+    // Section 1: Provenance pins.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn provenance_norm_tolerance_1e_neg5() {
+        assert!((AC_BIATTN_NORM_TOLERANCE - 1.0e-5).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn provenance_causal_parity_tolerance_1e_neg6() {
+        assert!((AC_BIATTN_CAUSAL_PARITY_TOLERANCE - 1.0e-6).abs() < f32::EPSILON);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 2: BIATT-001 no causal mask.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fbi001_pass_dense_3x3() {
+        // All entries 1/3 (uniform attention).
+        let w = vec![0.333_f32; 9];
+        assert_eq!(
+            verdict_from_biattn_no_causal_mask(3, &w),
+            BiattnNoCausalMaskVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fbi001_fail_upper_triangle_zero() {
+        // i=0, j=1 (upper) is zero — causal mask leaked.
+        let w = vec![
+            0.5_f32, 0.0, 0.0,
+            0.3, 0.7, 0.0,
+            0.1, 0.4, 0.5,
+        ];
+        assert_eq!(
+            verdict_from_biattn_no_causal_mask(3, &w),
+            BiattnNoCausalMaskVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fbi001_fail_zero_n() {
+        assert_eq!(
+            verdict_from_biattn_no_causal_mask(0, &[]),
+            BiattnNoCausalMaskVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fbi001_fail_size_mismatch() {
+        let w = vec![1.0_f32, 2.0]; // expect 9
+        assert_eq!(
+            verdict_from_biattn_no_causal_mask(3, &w),
+            BiattnNoCausalMaskVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 3: BIATT-002 n=1 causal parity.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fbi002_pass_n1_identical() {
+        let bi = vec![1.5_f32, 2.5];
+        let causal = vec![1.5_f32, 2.5];
+        assert_eq!(
+            verdict_from_biattn_causal_parity(&bi, &causal),
+            BiattnCausalParityVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fbi002_pass_within_tolerance() {
+        let bi = vec![1.5_f32 + 1e-7];
+        let causal = vec![1.5_f32];
+        assert_eq!(
+            verdict_from_biattn_causal_parity(&bi, &causal),
+            BiattnCausalParityVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fbi002_fail_outside_tolerance() {
+        let bi = vec![2.0_f32];
+        let causal = vec![1.0_f32];
+        assert_eq!(
+            verdict_from_biattn_causal_parity(&bi, &causal),
+            BiattnCausalParityVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fbi002_fail_length_mismatch() {
+        assert_eq!(
+            verdict_from_biattn_causal_parity(&[1.0], &[1.0, 2.0]),
+            BiattnCausalParityVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fbi002_fail_empty() {
+        assert_eq!(
+            verdict_from_biattn_causal_parity(&[], &[]),
+            BiattnCausalParityVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 4: BIATT-003 weight normalization.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fbi003_pass_uniform_3x3() {
+        // 1/3 each, sum = 1.
+        let w = vec![1.0_f32 / 3.0; 9];
+        assert_eq!(
+            verdict_from_biattn_weight_normalization(3, &w),
+            BiattnWeightNormalizationVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fbi003_pass_softmax_distribution_2x2() {
+        let w = vec![
+            0.3_f32, 0.7,
+            0.6, 0.4,
+        ];
+        assert_eq!(
+            verdict_from_biattn_weight_normalization(2, &w),
+            BiattnWeightNormalizationVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fbi003_fail_undersum() {
+        let w = vec![
+            0.3_f32, 0.3, // sum = 0.6
+            0.5, 0.5,
+        ];
+        assert_eq!(
+            verdict_from_biattn_weight_normalization(2, &w),
+            BiattnWeightNormalizationVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fbi003_fail_oversum() {
+        let w = vec![
+            0.5_f32, 0.6, // sum = 1.1
+            0.5, 0.5,
+        ];
+        assert_eq!(
+            verdict_from_biattn_weight_normalization(2, &w),
+            BiattnWeightNormalizationVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 5: BIATT-004 full density.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fbi004_pass_all_positive() {
+        let w = vec![0.25_f32; 16];
+        assert_eq!(
+            verdict_from_biattn_full_density(4, &w),
+            BiattnFullDensityVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fbi004_fail_zero_entry() {
+        let w = vec![
+            0.5_f32, 0.5,
+            0.0, 1.0, // top-left zero
+        ];
+        assert_eq!(
+            verdict_from_biattn_full_density(2, &w),
+            BiattnFullDensityVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fbi004_fail_negative_entry() {
+        let w = vec![0.5_f32, 0.5, -0.1, 1.1];
+        assert_eq!(
+            verdict_from_biattn_full_density(2, &w),
+            BiattnFullDensityVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fbi004_fail_nan_entry() {
+        let w = vec![0.5_f32, f32::NAN, 0.5, 0.5];
+        assert_eq!(
+            verdict_from_biattn_full_density(2, &w),
+            BiattnFullDensityVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 6: Realistic — full healthy bidirectional attention.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn realistic_healthy_biattn_passes_all_4() {
+        // 4×4 nearly-uniform attention (typical BERT-style layer 0).
+        let w = vec![0.25_f32; 16];
+        assert_eq!(
+            verdict_from_biattn_no_causal_mask(4, &w),
+            BiattnNoCausalMaskVerdict::Pass
+        );
+        // n=1 causal parity (single token, mask trivial).
+        let bi = vec![1.0_f32, 2.0];
+        let causal = vec![1.0_f32, 2.0];
+        assert_eq!(
+            verdict_from_biattn_causal_parity(&bi, &causal),
+            BiattnCausalParityVerdict::Pass
+        );
+        // Each row sums to 1.
+        assert_eq!(
+            verdict_from_biattn_weight_normalization(4, &w),
+            BiattnWeightNormalizationVerdict::Pass
+        );
+        // All entries > 0.
+        assert_eq!(
+            verdict_from_biattn_full_density(4, &w),
+            BiattnFullDensityVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn realistic_pre_fix_all_4_failures() {
+        // 001: causal mask leaked into BERT path.
+        let masked = vec![
+            0.5_f32, 0.0, 0.0, 0.0,
+            0.3, 0.7, 0.0, 0.0,
+            0.1, 0.3, 0.6, 0.0,
+            0.1, 0.2, 0.3, 0.4,
+        ];
+        assert_eq!(
+            verdict_from_biattn_no_causal_mask(4, &masked),
+            BiattnNoCausalMaskVerdict::Fail
+        );
+        // 002: BiAttn diverged from CausalAttn at n=1.
+        assert_eq!(
+            verdict_from_biattn_causal_parity(&[2.0], &[1.0]),
+            BiattnCausalParityVerdict::Fail
+        );
+        // 003: rows don't sum to 1 (softmax skipped).
+        let bad = vec![
+            2.0_f32, 3.0,
+            1.0, 1.0,
+        ];
+        assert_eq!(
+            verdict_from_biattn_weight_normalization(2, &bad),
+            BiattnWeightNormalizationVerdict::Fail
+        );
+        // 004: zero entries from sparse-attention bug.
+        let sparse = vec![
+            0.5_f32, 0.0,
+            0.5, 0.5,
+        ];
+        assert_eq!(
+            verdict_from_biattn_full_density(2, &sparse),
+            BiattnFullDensityVerdict::Fail
+        );
+    }
+}

--- a/crates/aprender-core/src/format/bn_001_006.rs
+++ b/crates/aprender-core/src/format/bn_001_006.rs
@@ -1,0 +1,511 @@
+// `batchnorm-kernel-v1` algorithm-level PARTIAL discharge for the 6
+// BatchNorm falsifiers (training standardization, denominator safety,
+// running stats non-negativity, eval-mode determinism, SIMD equivalence,
+// batch=1 boundary).
+//
+// Contract: `contracts/batchnorm-kernel-v1.yaml`.
+// Refs: Ioffe & Szegedy (2015) Batch Normalization.
+
+/// Tolerance for "post-BN mean ≈ 0" check when gamma=1, beta=0.
+pub const AC_BN_MEAN_TOLERANCE: f32 = 1.0e-5;
+
+/// SIMD-vs-scalar tolerance (8 ULP per contract proof_obligations).
+/// At |x| ~ 1.0, 8 ULP ≈ 8 * 2^-23 ≈ 9.5e-7.
+pub const AC_BN_SIMD_TOLERANCE: f32 = 1.0e-5;
+
+// =============================================================================
+// FALSIFY-BN-001 — training standardization
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BnTrainStandardizeVerdict {
+    /// |mean(BN(x)[:,c])| < 1e-5 per channel c when gamma=1, beta=0.
+    Pass,
+    /// Some channel's post-BN mean exceeds tolerance.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_bn_train_standardize(per_channel_means: &[f32]) -> BnTrainStandardizeVerdict {
+    if per_channel_means.is_empty() {
+        return BnTrainStandardizeVerdict::Fail;
+    }
+    for &m in per_channel_means {
+        if m.abs() >= AC_BN_MEAN_TOLERANCE {
+            return BnTrainStandardizeVerdict::Fail;
+        }
+    }
+    BnTrainStandardizeVerdict::Pass
+}
+
+// =============================================================================
+// FALSIFY-BN-002 — denominator safety (no NaN/Inf with eps>0)
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BnDenomSafetyVerdict {
+    /// All output elements finite (no NaN/Inf) even on zero-variance input.
+    Pass,
+    /// Output contains NaN or Inf — eps not added before sqrt.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_bn_denom_safety(output: &[f32]) -> BnDenomSafetyVerdict {
+    if output.is_empty() {
+        return BnDenomSafetyVerdict::Fail;
+    }
+    for &v in output {
+        if !v.is_finite() {
+            return BnDenomSafetyVerdict::Fail;
+        }
+    }
+    BnDenomSafetyVerdict::Pass
+}
+
+// =============================================================================
+// FALSIFY-BN-003 — running stats non-negativity
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BnRunningNonnegVerdict {
+    /// sigma_run >= 0 across all channels.
+    Pass,
+    /// Some channel's running variance went negative — EMA accumulation bug.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_bn_running_nonneg(sigma_run_per_channel: &[f32]) -> BnRunningNonnegVerdict {
+    if sigma_run_per_channel.is_empty() {
+        return BnRunningNonnegVerdict::Fail;
+    }
+    for &s in sigma_run_per_channel {
+        if s < 0.0 || !s.is_finite() {
+            return BnRunningNonnegVerdict::Fail;
+        }
+    }
+    BnRunningNonnegVerdict::Pass
+}
+
+// =============================================================================
+// FALSIFY-BN-004 — eval mode uses running stats, not batch stats
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BnEvalModeVerdict {
+    /// When running ≠ batch stats, BN_eval(x) ≠ BN_train(x).
+    Pass,
+    /// Eval and train modes produced same output despite divergent stats —
+    /// mode flag ignored.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_bn_eval_mode(
+    eval_output: &[f32],
+    train_output: &[f32],
+    stats_diverged: bool,
+) -> BnEvalModeVerdict {
+    if !stats_diverged {
+        // Stats are equal: eval and train should produce equal output —
+        // out of scope for this gate.
+        return BnEvalModeVerdict::Pass;
+    }
+    if eval_output.len() != train_output.len() {
+        return BnEvalModeVerdict::Fail;
+    }
+    if eval_output.is_empty() {
+        return BnEvalModeVerdict::Fail;
+    }
+    for (a, b) in eval_output.iter().zip(train_output.iter()) {
+        if (a - b).abs() > 1e-9 {
+            return BnEvalModeVerdict::Pass;
+        }
+    }
+    BnEvalModeVerdict::Fail
+}
+
+// =============================================================================
+// FALSIFY-BN-005 — SIMD matches scalar within 8 ULP
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BnSimdEquivalenceVerdict {
+    /// max_i |simd[i] - scalar[i]| < tolerance.
+    Pass,
+    /// SIMD reduction order differs.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_bn_simd_equivalence(simd: &[f32], scalar: &[f32]) -> BnSimdEquivalenceVerdict {
+    if simd.len() != scalar.len() {
+        return BnSimdEquivalenceVerdict::Fail;
+    }
+    if simd.is_empty() {
+        return BnSimdEquivalenceVerdict::Fail;
+    }
+    for (a, b) in simd.iter().zip(scalar.iter()) {
+        if (a - b).abs() >= AC_BN_SIMD_TOLERANCE {
+            return BnSimdEquivalenceVerdict::Fail;
+        }
+    }
+    BnSimdEquivalenceVerdict::Pass
+}
+
+// =============================================================================
+// FALSIFY-BN-006 — batch=1 boundary (zero variance ⇒ output = beta when gamma=1)
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BnBatchOneBoundaryVerdict {
+    /// At N=1: output[c] == beta[c] within tolerance (gamma=1).
+    Pass,
+    /// Edge-case in variance computation for N=1.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_bn_batch_one_boundary(
+    output: &[f32],
+    beta: &[f32],
+) -> BnBatchOneBoundaryVerdict {
+    if output.len() != beta.len() {
+        return BnBatchOneBoundaryVerdict::Fail;
+    }
+    if output.is_empty() {
+        return BnBatchOneBoundaryVerdict::Fail;
+    }
+    for (o, b) in output.iter().zip(beta.iter()) {
+        if (o - b).abs() >= AC_BN_MEAN_TOLERANCE {
+            return BnBatchOneBoundaryVerdict::Fail;
+        }
+    }
+    BnBatchOneBoundaryVerdict::Pass
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -------------------------------------------------------------------------
+    // Section 1: Provenance pins.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn provenance_mean_tolerance_1e_neg5() {
+        assert!((AC_BN_MEAN_TOLERANCE - 1.0e-5).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn provenance_simd_tolerance_1e_neg5() {
+        assert!((AC_BN_SIMD_TOLERANCE - 1.0e-5).abs() < f32::EPSILON);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 2: BN-001 training standardization.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fbn001_pass_zero_mean_per_channel() {
+        let m = vec![0.0_f32, 1e-7, -2e-7, 5e-6];
+        assert_eq!(
+            verdict_from_bn_train_standardize(&m),
+            BnTrainStandardizeVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fbn001_fail_channel_mean_drift() {
+        let m = vec![0.0_f32, 0.5];
+        assert_eq!(
+            verdict_from_bn_train_standardize(&m),
+            BnTrainStandardizeVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fbn001_fail_at_threshold() {
+        let m = vec![1.0e-5_f32];
+        assert_eq!(
+            verdict_from_bn_train_standardize(&m),
+            BnTrainStandardizeVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fbn001_fail_empty() {
+        assert_eq!(
+            verdict_from_bn_train_standardize(&[]),
+            BnTrainStandardizeVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 3: BN-002 denominator safety.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fbn002_pass_finite_zero_variance() {
+        let o = vec![0.0_f32, 0.0, 0.0];
+        assert_eq!(
+            verdict_from_bn_denom_safety(&o),
+            BnDenomSafetyVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fbn002_fail_nan_in_output() {
+        let o = vec![0.0_f32, f32::NAN, 0.0];
+        assert_eq!(
+            verdict_from_bn_denom_safety(&o),
+            BnDenomSafetyVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fbn002_fail_inf_in_output() {
+        let o = vec![0.0_f32, f32::INFINITY];
+        assert_eq!(
+            verdict_from_bn_denom_safety(&o),
+            BnDenomSafetyVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fbn002_fail_empty() {
+        assert_eq!(verdict_from_bn_denom_safety(&[]), BnDenomSafetyVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 4: BN-003 running stats non-negativity.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fbn003_pass_all_nonneg() {
+        let s = vec![0.0_f32, 1.0, 5.5, 100.0];
+        assert_eq!(
+            verdict_from_bn_running_nonneg(&s),
+            BnRunningNonnegVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fbn003_fail_negative_variance() {
+        let s = vec![1.0_f32, -0.001];
+        assert_eq!(
+            verdict_from_bn_running_nonneg(&s),
+            BnRunningNonnegVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fbn003_fail_nan_variance() {
+        let s = vec![1.0_f32, f32::NAN];
+        assert_eq!(
+            verdict_from_bn_running_nonneg(&s),
+            BnRunningNonnegVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 5: BN-004 eval mode.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fbn004_pass_eval_diverges_from_train() {
+        let eval = vec![1.0_f32, 2.0];
+        let train = vec![0.5_f32, 1.5];
+        assert_eq!(
+            verdict_from_bn_eval_mode(&eval, &train, true),
+            BnEvalModeVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fbn004_pass_stats_match_then_outputs_should_match() {
+        // stats_diverged=false → vacuous pass.
+        let eval = vec![1.0_f32];
+        let train = vec![1.0_f32];
+        assert_eq!(
+            verdict_from_bn_eval_mode(&eval, &train, false),
+            BnEvalModeVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fbn004_fail_eval_equal_train_when_stats_diverged() {
+        // The regression: mode flag ignored.
+        let eval = vec![1.0_f32, 2.0];
+        let train = vec![1.0_f32, 2.0];
+        assert_eq!(
+            verdict_from_bn_eval_mode(&eval, &train, true),
+            BnEvalModeVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fbn004_fail_length_mismatch() {
+        let eval = vec![1.0_f32];
+        let train = vec![1.0_f32, 2.0];
+        assert_eq!(
+            verdict_from_bn_eval_mode(&eval, &train, true),
+            BnEvalModeVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 6: BN-005 SIMD equivalence.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fbn005_pass_exact_match() {
+        let v = vec![1.0_f32, 2.0, 3.0];
+        assert_eq!(
+            verdict_from_bn_simd_equivalence(&v, &v),
+            BnSimdEquivalenceVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fbn005_pass_within_tolerance() {
+        let s = vec![1.0_f32, 2.0];
+        let scalar = vec![1.0_f32 + 1e-7, 2.0 + 1e-7];
+        assert_eq!(
+            verdict_from_bn_simd_equivalence(&s, &scalar),
+            BnSimdEquivalenceVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fbn005_fail_outside_tolerance() {
+        let s = vec![1.5_f32];
+        let scalar = vec![1.0_f32];
+        assert_eq!(
+            verdict_from_bn_simd_equivalence(&s, &scalar),
+            BnSimdEquivalenceVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fbn005_fail_length_mismatch() {
+        assert_eq!(
+            verdict_from_bn_simd_equivalence(&[1.0], &[1.0, 2.0]),
+            BnSimdEquivalenceVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 7: BN-006 batch=1 boundary.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fbn006_pass_output_equals_beta() {
+        let o = vec![0.5_f32, 1.5, -0.3];
+        let b = vec![0.5_f32, 1.5, -0.3];
+        assert_eq!(
+            verdict_from_bn_batch_one_boundary(&o, &b),
+            BnBatchOneBoundaryVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fbn006_pass_within_tolerance() {
+        let o = vec![0.5_f32 + 1e-7];
+        let b = vec![0.5_f32];
+        assert_eq!(
+            verdict_from_bn_batch_one_boundary(&o, &b),
+            BnBatchOneBoundaryVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fbn006_fail_output_diverges_from_beta() {
+        let o = vec![1.0_f32];
+        let b = vec![0.5_f32];
+        assert_eq!(
+            verdict_from_bn_batch_one_boundary(&o, &b),
+            BnBatchOneBoundaryVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fbn006_fail_length_mismatch() {
+        assert_eq!(
+            verdict_from_bn_batch_one_boundary(&[1.0], &[1.0, 2.0]),
+            BnBatchOneBoundaryVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 8: Realistic — full healthy BatchNorm passes all 6.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn realistic_healthy_batchnorm_passes_all_6() {
+        // 001
+        let means = vec![0.0_f32, 1e-8, -1e-8];
+        assert_eq!(
+            verdict_from_bn_train_standardize(&means),
+            BnTrainStandardizeVerdict::Pass
+        );
+        // 002
+        let out = vec![0.5_f32, 1.5];
+        assert_eq!(verdict_from_bn_denom_safety(&out), BnDenomSafetyVerdict::Pass);
+        // 003
+        let s = vec![0.5_f32, 1.0];
+        assert_eq!(
+            verdict_from_bn_running_nonneg(&s),
+            BnRunningNonnegVerdict::Pass
+        );
+        // 004
+        let eval = vec![1.0_f32, 2.0];
+        let train = vec![0.7_f32, 1.7];
+        assert_eq!(
+            verdict_from_bn_eval_mode(&eval, &train, true),
+            BnEvalModeVerdict::Pass
+        );
+        // 005
+        let v = vec![0.5_f32, 1.5];
+        assert_eq!(
+            verdict_from_bn_simd_equivalence(&v, &v),
+            BnSimdEquivalenceVerdict::Pass
+        );
+        // 006
+        let o = vec![0.5_f32];
+        let b = vec![0.5_f32];
+        assert_eq!(
+            verdict_from_bn_batch_one_boundary(&o, &b),
+            BnBatchOneBoundaryVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn realistic_pre_fix_all_6_failures() {
+        // 001: forgot to subtract batch mean.
+        assert_eq!(
+            verdict_from_bn_train_standardize(&[0.5]),
+            BnTrainStandardizeVerdict::Fail
+        );
+        // 002: zero-variance + no eps → NaN.
+        assert_eq!(
+            verdict_from_bn_denom_safety(&[f32::NAN]),
+            BnDenomSafetyVerdict::Fail
+        );
+        // 003: EMA accumulator went negative.
+        assert_eq!(
+            verdict_from_bn_running_nonneg(&[-1e-3]),
+            BnRunningNonnegVerdict::Fail
+        );
+        // 004: mode flag ignored — eval == train despite divergent stats.
+        let eval = vec![1.0_f32];
+        let train = vec![1.0_f32];
+        assert_eq!(
+            verdict_from_bn_eval_mode(&eval, &train, true),
+            BnEvalModeVerdict::Fail
+        );
+        // 005: SIMD reduction off.
+        assert_eq!(
+            verdict_from_bn_simd_equivalence(&[1.5], &[1.0]),
+            BnSimdEquivalenceVerdict::Fail
+        );
+        // 006: N=1 case bug.
+        assert_eq!(
+            verdict_from_bn_batch_one_boundary(&[10.0], &[0.0]),
+            BnBatchOneBoundaryVerdict::Fail
+        );
+    }
+}

--- a/crates/aprender-core/src/format/btrain_001_006.rs
+++ b/crates/aprender-core/src/format/btrain_001_006.rs
@@ -1,0 +1,493 @@
+// `batch-training-v1` algorithm-level PARTIAL discharge for the 6
+// mini-batch + gradient accumulation falsifiers.
+//
+// Contract: `contracts/batch-training-v1.yaml`.
+// Refs: Goyal et al. (2017) "Accurate, Large Minibatch SGD"
+// (arXiv:1706.02677).
+
+/// Tolerance for "single-batch vs accumulated micro-batch" gradient
+/// equivalence (1e-5 per contract F-BATCH-001).
+pub const AC_BTRAIN_GRAD_TOLERANCE: f32 = 1.0e-5;
+
+/// Tolerance for clipped-norm bound check (1e-6 per FALSIFY-BATCH-003).
+pub const AC_BTRAIN_CLIP_TOLERANCE: f32 = 1.0e-6;
+
+/// Tolerance for "params changed" check (1e-10 — strict per contract).
+pub const AC_BTRAIN_PARAM_CHANGE_TOLERANCE: f32 = 1.0e-10;
+
+// =============================================================================
+// FALSIFY-BATCH-001 — gradient equivalence (single batch == accumulated)
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BtrainGradEquivalenceVerdict {
+    /// |single_batch_grad[i] - accumulated_grad[i]| < 1e-5 ∀ i.
+    Pass,
+    /// Some gradient component diverges — normalization error.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_btrain_grad_equivalence(
+    single_batch: &[f32],
+    accumulated: &[f32],
+) -> BtrainGradEquivalenceVerdict {
+    if single_batch.len() != accumulated.len() {
+        return BtrainGradEquivalenceVerdict::Fail;
+    }
+    if single_batch.is_empty() {
+        return BtrainGradEquivalenceVerdict::Fail;
+    }
+    for (a, b) in single_batch.iter().zip(accumulated.iter()) {
+        if !a.is_finite() || !b.is_finite() {
+            return BtrainGradEquivalenceVerdict::Fail;
+        }
+        if (a - b).abs() >= AC_BTRAIN_GRAD_TOLERANCE {
+            return BtrainGradEquivalenceVerdict::Fail;
+        }
+    }
+    BtrainGradEquivalenceVerdict::Pass
+}
+
+// =============================================================================
+// FALSIFY-BATCH-002 — loss is finite AND non-negative
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BtrainLossFiniteVerdict {
+    /// Batch loss is finite (no NaN, no Inf) AND >= 0.
+    Pass,
+    /// NaN/Inf or negative loss.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_btrain_loss_finite(loss: f32) -> BtrainLossFiniteVerdict {
+    if !loss.is_finite() {
+        return BtrainLossFiniteVerdict::Fail;
+    }
+    if loss < 0.0 {
+        return BtrainLossFiniteVerdict::Fail;
+    }
+    BtrainLossFiniteVerdict::Pass
+}
+
+// =============================================================================
+// FALSIFY-BATCH-003 — gradient norm bounded by clip_norm
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BtrainGradClipVerdict {
+    /// post_clip_grad_norm <= clip_norm + 1e-6 (with rounding tolerance).
+    Pass,
+    /// Norm exceeds clip threshold — clipping not applied.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_btrain_grad_clip(post_clip_norm: f32, clip_norm: f32) -> BtrainGradClipVerdict {
+    if !post_clip_norm.is_finite() || !clip_norm.is_finite() {
+        return BtrainGradClipVerdict::Fail;
+    }
+    if clip_norm <= 0.0 {
+        return BtrainGradClipVerdict::Fail;
+    }
+    if post_clip_norm <= clip_norm + AC_BTRAIN_CLIP_TOLERANCE {
+        BtrainGradClipVerdict::Pass
+    } else {
+        BtrainGradClipVerdict::Fail
+    }
+}
+
+// =============================================================================
+// FALSIFY-BATCH-004 — single optimizer step changed parameters
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BtrainOptimizerStepVerdict {
+    /// At least one parameter changed AFTER train_batch (optimizer fired).
+    Pass,
+    /// Parameters identical — optimizer not called.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_btrain_optimizer_step(
+    params_before: &[f32],
+    params_after: &[f32],
+) -> BtrainOptimizerStepVerdict {
+    if params_before.len() != params_after.len() {
+        return BtrainOptimizerStepVerdict::Fail;
+    }
+    if params_before.is_empty() {
+        return BtrainOptimizerStepVerdict::Fail;
+    }
+    for (a, b) in params_before.iter().zip(params_after.iter()) {
+        if (a - b).abs() > AC_BTRAIN_PARAM_CHANGE_TOLERANCE {
+            return BtrainOptimizerStepVerdict::Pass;
+        }
+    }
+    BtrainOptimizerStepVerdict::Fail
+}
+
+// =============================================================================
+// FALSIFY-BATCH-005 — no stale gradients between batches
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BtrainNoStaleGradVerdict {
+    /// Gradients differ between back-to-back batches (zeroing happened).
+    Pass,
+    /// Gradients identical — stale from previous batch.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_btrain_no_stale_grad(
+    grads_after_a: &[f32],
+    grads_after_b: &[f32],
+) -> BtrainNoStaleGradVerdict {
+    if grads_after_a.len() != grads_after_b.len() {
+        return BtrainNoStaleGradVerdict::Fail;
+    }
+    if grads_after_a.is_empty() {
+        return BtrainNoStaleGradVerdict::Fail;
+    }
+    for (a, b) in grads_after_a.iter().zip(grads_after_b.iter()) {
+        if (a - b).abs() > AC_BTRAIN_PARAM_CHANGE_TOLERANCE {
+            return BtrainNoStaleGradVerdict::Pass;
+        }
+    }
+    BtrainNoStaleGradVerdict::Fail
+}
+
+// =============================================================================
+// FALSIFY-BATCH-006 — gradient scaling (all post-scaling values finite)
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BtrainGradScalingVerdict {
+    /// All accumulated gradients are finite after divide-by-K.
+    Pass,
+    /// Any non-finite element.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_btrain_grad_scaling(
+    accumulated_grads: &[f32],
+    accumulation_steps: u32,
+) -> BtrainGradScalingVerdict {
+    if accumulation_steps == 0 {
+        return BtrainGradScalingVerdict::Fail;
+    }
+    if accumulated_grads.is_empty() {
+        return BtrainGradScalingVerdict::Fail;
+    }
+    for &g in accumulated_grads {
+        if !g.is_finite() {
+            return BtrainGradScalingVerdict::Fail;
+        }
+    }
+    BtrainGradScalingVerdict::Pass
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -------------------------------------------------------------------------
+    // Section 1: Provenance pins.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn provenance_grad_tolerance_1e_neg5() {
+        assert!((AC_BTRAIN_GRAD_TOLERANCE - 1.0e-5).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn provenance_clip_tolerance_1e_neg6() {
+        assert!((AC_BTRAIN_CLIP_TOLERANCE - 1.0e-6).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn provenance_param_tolerance_1e_neg10() {
+        assert!((AC_BTRAIN_PARAM_CHANGE_TOLERANCE - 1.0e-10).abs() < f32::EPSILON);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 2: BATCH-001 gradient equivalence.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fbt001_pass_exact_match() {
+        let g = vec![0.5_f32, -0.3, 0.1];
+        assert_eq!(
+            verdict_from_btrain_grad_equivalence(&g, &g),
+            BtrainGradEquivalenceVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fbt001_pass_within_tolerance() {
+        let single = vec![0.5_f32];
+        let acc = vec![0.5_f32 + 5e-6];
+        assert_eq!(
+            verdict_from_btrain_grad_equivalence(&single, &acc),
+            BtrainGradEquivalenceVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fbt001_fail_outside_tolerance() {
+        assert_eq!(
+            verdict_from_btrain_grad_equivalence(&[0.5], &[0.6]),
+            BtrainGradEquivalenceVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fbt001_fail_length_mismatch() {
+        assert_eq!(
+            verdict_from_btrain_grad_equivalence(&[0.1], &[0.1, 0.2]),
+            BtrainGradEquivalenceVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fbt001_fail_nan() {
+        assert_eq!(
+            verdict_from_btrain_grad_equivalence(&[f32::NAN], &[0.0]),
+            BtrainGradEquivalenceVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 3: BATCH-002 loss finite.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fbt002_pass_positive_loss() {
+        assert_eq!(verdict_from_btrain_loss_finite(0.5), BtrainLossFiniteVerdict::Pass);
+    }
+
+    #[test]
+    fn fbt002_pass_zero_loss() {
+        assert_eq!(verdict_from_btrain_loss_finite(0.0), BtrainLossFiniteVerdict::Pass);
+    }
+
+    #[test]
+    fn fbt002_fail_nan() {
+        assert_eq!(verdict_from_btrain_loss_finite(f32::NAN), BtrainLossFiniteVerdict::Fail);
+    }
+
+    #[test]
+    fn fbt002_fail_inf() {
+        assert_eq!(verdict_from_btrain_loss_finite(f32::INFINITY), BtrainLossFiniteVerdict::Fail);
+    }
+
+    #[test]
+    fn fbt002_fail_negative() {
+        assert_eq!(verdict_from_btrain_loss_finite(-0.001), BtrainLossFiniteVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 4: BATCH-003 gradient clipping.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fbt003_pass_under_clip() {
+        assert_eq!(verdict_from_btrain_grad_clip(0.8, 1.0), BtrainGradClipVerdict::Pass);
+    }
+
+    #[test]
+    fn fbt003_pass_at_clip() {
+        assert_eq!(verdict_from_btrain_grad_clip(1.0, 1.0), BtrainGradClipVerdict::Pass);
+    }
+
+    #[test]
+    fn fbt003_fail_over_clip() {
+        assert_eq!(verdict_from_btrain_grad_clip(2.0, 1.0), BtrainGradClipVerdict::Fail);
+    }
+
+    #[test]
+    fn fbt003_fail_clip_zero() {
+        assert_eq!(verdict_from_btrain_grad_clip(0.5, 0.0), BtrainGradClipVerdict::Fail);
+    }
+
+    #[test]
+    fn fbt003_fail_nan_norm() {
+        assert_eq!(
+            verdict_from_btrain_grad_clip(f32::NAN, 1.0),
+            BtrainGradClipVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 5: BATCH-004 single optimizer step.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fbt004_pass_params_changed() {
+        let before = vec![1.0_f32, 2.0];
+        let after = vec![1.001_f32, 2.001];
+        assert_eq!(
+            verdict_from_btrain_optimizer_step(&before, &after),
+            BtrainOptimizerStepVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fbt004_fail_params_unchanged() {
+        let v = vec![1.0_f32, 2.0];
+        assert_eq!(
+            verdict_from_btrain_optimizer_step(&v, &v),
+            BtrainOptimizerStepVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fbt004_fail_length_mismatch() {
+        assert_eq!(
+            verdict_from_btrain_optimizer_step(&[1.0], &[1.0, 2.0]),
+            BtrainOptimizerStepVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 6: BATCH-005 no stale gradients.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fbt005_pass_grads_differ() {
+        let a = vec![0.5_f32, -0.3];
+        let b = vec![0.4_f32, 0.1];
+        assert_eq!(
+            verdict_from_btrain_no_stale_grad(&a, &b),
+            BtrainNoStaleGradVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fbt005_fail_grads_identical() {
+        let g = vec![0.5_f32, -0.3];
+        assert_eq!(
+            verdict_from_btrain_no_stale_grad(&g, &g),
+            BtrainNoStaleGradVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fbt005_fail_empty() {
+        assert_eq!(
+            verdict_from_btrain_no_stale_grad(&[], &[]),
+            BtrainNoStaleGradVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 7: BATCH-006 gradient scaling.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fbt006_pass_finite_scaled_grads() {
+        let g = vec![0.125_f32, -0.0625, 0.03125];
+        assert_eq!(
+            verdict_from_btrain_grad_scaling(&g, 4),
+            BtrainGradScalingVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fbt006_fail_nan_after_scaling() {
+        let g = vec![f32::NAN];
+        assert_eq!(
+            verdict_from_btrain_grad_scaling(&g, 4),
+            BtrainGradScalingVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fbt006_fail_zero_steps() {
+        assert_eq!(
+            verdict_from_btrain_grad_scaling(&[0.5], 0),
+            BtrainGradScalingVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fbt006_fail_empty() {
+        assert_eq!(
+            verdict_from_btrain_grad_scaling(&[], 4),
+            BtrainGradScalingVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 8: Realistic — full healthy batch training.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn realistic_healthy_batch_training_passes_all_6() {
+        // 001: gradient equivalence within tolerance.
+        let single = vec![0.1_f32, -0.2, 0.3];
+        let acc = vec![0.1_f32 + 1e-7, -0.2 + 1e-7, 0.3 - 1e-7];
+        assert_eq!(
+            verdict_from_btrain_grad_equivalence(&single, &acc),
+            BtrainGradEquivalenceVerdict::Pass
+        );
+        // 002: positive finite loss.
+        assert_eq!(
+            verdict_from_btrain_loss_finite(2.5),
+            BtrainLossFiniteVerdict::Pass
+        );
+        // 003: clipped norm under threshold.
+        assert_eq!(
+            verdict_from_btrain_grad_clip(0.95, 1.0),
+            BtrainGradClipVerdict::Pass
+        );
+        // 004: params changed.
+        assert_eq!(
+            verdict_from_btrain_optimizer_step(&[1.0_f32], &[1.001_f32]),
+            BtrainOptimizerStepVerdict::Pass
+        );
+        // 005: grads differ between batches.
+        assert_eq!(
+            verdict_from_btrain_no_stale_grad(&[0.5_f32], &[0.4_f32]),
+            BtrainNoStaleGradVerdict::Pass
+        );
+        // 006: scaled grads finite.
+        assert_eq!(
+            verdict_from_btrain_grad_scaling(&[0.125_f32, -0.0625], 8),
+            BtrainGradScalingVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn realistic_pre_fix_all_6_failures() {
+        // 001: forgot to divide by K.
+        assert_eq!(
+            verdict_from_btrain_grad_equivalence(&[0.1], &[0.4]),
+            BtrainGradEquivalenceVerdict::Fail
+        );
+        // 002: loss is NaN.
+        assert_eq!(
+            verdict_from_btrain_loss_finite(f32::NAN),
+            BtrainLossFiniteVerdict::Fail
+        );
+        // 003: clipping skipped, norm = 100.
+        assert_eq!(
+            verdict_from_btrain_grad_clip(100.0, 1.0),
+            BtrainGradClipVerdict::Fail
+        );
+        // 004: optimizer not wired.
+        let v = vec![1.0_f32, 2.0];
+        assert_eq!(
+            verdict_from_btrain_optimizer_step(&v, &v),
+            BtrainOptimizerStepVerdict::Fail
+        );
+        // 005: stale gradients.
+        let g = vec![0.5_f32];
+        assert_eq!(
+            verdict_from_btrain_no_stale_grad(&g, &g),
+            BtrainNoStaleGradVerdict::Fail
+        );
+        // 006: scaled grads have NaN.
+        assert_eq!(
+            verdict_from_btrain_grad_scaling(&[f32::NAN], 4),
+            BtrainGradScalingVerdict::Fail
+        );
+    }
+}

--- a/crates/aprender-core/src/format/chaos_001_005.rs
+++ b/crates/aprender-core/src/format/chaos_001_005.rs
@@ -1,0 +1,466 @@
+// `apr-qa-chaos-v1` algorithm-level PARTIAL discharge for the 5
+// chaos-engineering falsifiers (memory budget, graceful OOM, signal
+// handling, batch-overwrite protection, disk exhaustion).
+//
+// Contract: `contracts/apr-qa-chaos-v1.yaml`.
+// Refs: GH-434 (OOM on 57 GB models), GH-352 (apr pull RAM), GH-471
+// (GPU hangs on MoE), GH-478 (per-layer dequant OOM 32B).
+//
+// ## What this file proves NOW (`PARTIAL_ALGORITHM_LEVEL`)
+//
+// Five pure decision predicates over inputs derived from a chaos run
+// (peak RSS, exit code under ulimit, exit code under SIGINT, disk-full
+// behavior). Live discharge is `/usr/bin/time -v` + `ulimit` + `kill
+// -INT` shell harnesses; this module pins the predicates so future
+// emergency-path rewrites cannot drift on the resource-bound semantics.
+
+/// Memory budget multiplier per F-CHAOS-001:
+/// `peak_rss_bytes < 3 * model_size_bytes + 512 MB overhead`.
+pub const AC_CHAOS_RSS_MULTIPLIER: f64 = 3.0;
+
+/// Memory overhead constant (512 MB).
+pub const AC_CHAOS_RSS_OVERHEAD_BYTES: u64 = 512 * 1024 * 1024;
+
+/// SIGINT exit code per Unix convention (128 + 2).
+pub const AC_CHAOS_SIGINT_EXIT_CODE: i32 = 130;
+
+/// SIGSEGV exit code (128 + 11) — the regression class for F-CHAOS-002.
+pub const AC_CHAOS_SIGSEGV_EXIT_CODE: i32 = 139;
+
+/// Maximum acceptable SIGINT response time per F-CHAOS-003.
+pub const AC_CHAOS_SIGINT_MAX_RESPONSE_MS: u64 = 2_000;
+
+/// Keywords that satisfy F-CHAOS-002's stderr requirement.
+pub const AC_CHAOS_OOM_KEYWORDS: [&str; 3] = ["memory", "oom", "allocation"];
+
+/// Keywords that satisfy F-CHAOS-005's stderr requirement.
+pub const AC_CHAOS_DISK_KEYWORDS: [&str; 3] = ["disk", "space", "write"];
+
+// =============================================================================
+// F-CHAOS-001 — memory budget
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MemoryBudgetVerdict {
+    /// `peak_rss < 3 * model_size + 512 MB`.
+    Pass,
+    /// Peak RSS exceeds budget — unbounded allocation regression.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_memory_budget(peak_rss_bytes: u64, model_size_bytes: u64) -> MemoryBudgetVerdict {
+    let budget = (model_size_bytes as f64 * AC_CHAOS_RSS_MULTIPLIER) as u64
+        + AC_CHAOS_RSS_OVERHEAD_BYTES;
+    if peak_rss_bytes < budget {
+        MemoryBudgetVerdict::Pass
+    } else {
+        MemoryBudgetVerdict::Fail
+    }
+}
+
+// =============================================================================
+// F-CHAOS-002 — graceful OOM
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GracefulOomVerdict {
+    /// Exit code is non-zero AND not SIGSEGV (139), AND stderr mentions
+    /// memory/OOM/allocation.
+    Pass,
+    /// SIGSEGV crash, exit 0 (silent failure), or stderr without OOM signal.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_graceful_oom(exit_code: i32, stderr: &str) -> GracefulOomVerdict {
+    if exit_code == AC_CHAOS_SIGSEGV_EXIT_CODE {
+        return GracefulOomVerdict::Fail;
+    }
+    if exit_code == 0 {
+        // Silent success on memory-limited run is a worse regression than
+        // a segfault — partial output emitted as valid.
+        return GracefulOomVerdict::Fail;
+    }
+    let lower = stderr.to_lowercase();
+    for kw in AC_CHAOS_OOM_KEYWORDS {
+        if lower.contains(kw) {
+            return GracefulOomVerdict::Pass;
+        }
+    }
+    GracefulOomVerdict::Fail
+}
+
+// =============================================================================
+// F-CHAOS-003 — signal handling
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SignalHandlingVerdict {
+    /// Exit 130 (SIGINT) AND response time < 2s AND no corrupt cache.
+    Pass,
+    /// Wrong exit code, slow response, or corrupt cache state.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_signal_handling(
+    exit_code: i32,
+    response_time_ms: u64,
+    cache_corrupt: bool,
+) -> SignalHandlingVerdict {
+    if exit_code != AC_CHAOS_SIGINT_EXIT_CODE {
+        return SignalHandlingVerdict::Fail;
+    }
+    if response_time_ms >= AC_CHAOS_SIGINT_MAX_RESPONSE_MS {
+        return SignalHandlingVerdict::Fail;
+    }
+    if cache_corrupt {
+        return SignalHandlingVerdict::Fail;
+    }
+    SignalHandlingVerdict::Pass
+}
+
+// =============================================================================
+// F-CHAOS-004 — batch overwrite protection
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OverwriteProtectionVerdict {
+    /// `apr <cmd> -o <existing_file>` without `--force` exits non-zero.
+    Pass,
+    /// Silently overwrote (exit 0) — the regression class.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_overwrite_protection(
+    output_file_existed: bool,
+    force_flag: bool,
+    exit_code: i32,
+) -> OverwriteProtectionVerdict {
+    if !output_file_existed {
+        // No conflict possible.
+        return OverwriteProtectionVerdict::Pass;
+    }
+    if force_flag {
+        // User explicitly authorized overwrite.
+        return OverwriteProtectionVerdict::Pass;
+    }
+    if exit_code == 0 {
+        OverwriteProtectionVerdict::Fail
+    } else {
+        OverwriteProtectionVerdict::Pass
+    }
+}
+
+// =============================================================================
+// F-CHAOS-005 — disk exhaustion
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiskExhaustionVerdict {
+    /// Full-disk write produces non-zero exit AND mentions disk/space/write
+    /// in stderr.
+    Pass,
+    /// Silent success or exit without disk-related stderr.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_disk_exhaustion(exit_code: i32, stderr: &str) -> DiskExhaustionVerdict {
+    if exit_code == 0 {
+        return DiskExhaustionVerdict::Fail;
+    }
+    let lower = stderr.to_lowercase();
+    for kw in AC_CHAOS_DISK_KEYWORDS {
+        if lower.contains(kw) {
+            return DiskExhaustionVerdict::Pass;
+        }
+    }
+    DiskExhaustionVerdict::Fail
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ONE_GB: u64 = 1024 * 1024 * 1024;
+    const ONE_MB: u64 = 1024 * 1024;
+
+    // -------------------------------------------------------------------------
+    // Section 1: Provenance pins.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn provenance_rss_multiplier_3() {
+        assert!((AC_CHAOS_RSS_MULTIPLIER - 3.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn provenance_overhead_512_mb() {
+        assert_eq!(AC_CHAOS_RSS_OVERHEAD_BYTES, 512 * 1024 * 1024);
+    }
+
+    #[test]
+    fn provenance_sigint_exit_130() {
+        assert_eq!(AC_CHAOS_SIGINT_EXIT_CODE, 130);
+    }
+
+    #[test]
+    fn provenance_sigsegv_exit_139() {
+        assert_eq!(AC_CHAOS_SIGSEGV_EXIT_CODE, 139);
+    }
+
+    #[test]
+    fn provenance_sigint_response_ms_2000() {
+        assert_eq!(AC_CHAOS_SIGINT_MAX_RESPONSE_MS, 2_000);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 2: F-CHAOS-001 memory budget.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fc001_pass_well_under_budget() {
+        // 1 GB model, used 2 GB peak (under 3 GB + 512 MB).
+        assert_eq!(
+            verdict_from_memory_budget(2 * ONE_GB, ONE_GB),
+            MemoryBudgetVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fc001_pass_at_budget_minus_one() {
+        // 1 GB model: budget = 3 GB + 512 MB. Just under.
+        let budget = 3 * ONE_GB + 512 * ONE_MB;
+        assert_eq!(
+            verdict_from_memory_budget(budget - 1, ONE_GB),
+            MemoryBudgetVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fc001_fail_at_budget() {
+        // Strict less-than: equality fails.
+        let budget = 3 * ONE_GB + 512 * ONE_MB;
+        assert_eq!(
+            verdict_from_memory_budget(budget, ONE_GB),
+            MemoryBudgetVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fc001_fail_unbounded() {
+        // 100x over budget — clearly leak.
+        assert_eq!(
+            verdict_from_memory_budget(50 * ONE_GB, ONE_GB),
+            MemoryBudgetVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fc001_pass_7b_under_15gb() {
+        // Contract example: `apr run 7B.gguf` uses < 15 GB RSS.
+        let model_7b = 5 * ONE_GB; // q4_k_m roughly 5 GB
+        let peak_15gb = 15 * ONE_GB - 1;
+        assert_eq!(
+            verdict_from_memory_budget(peak_15gb, model_7b),
+            MemoryBudgetVerdict::Pass
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 3: F-CHAOS-002 graceful OOM.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fc002_pass_oom_with_memory_word() {
+        let v = verdict_from_graceful_oom(1, "Error: out of memory");
+        assert_eq!(v, GracefulOomVerdict::Pass);
+    }
+
+    #[test]
+    fn fc002_pass_oom_with_allocation_word() {
+        let v = verdict_from_graceful_oom(1, "Error: failed allocation");
+        assert_eq!(v, GracefulOomVerdict::Pass);
+    }
+
+    #[test]
+    fn fc002_pass_oom_uppercase() {
+        let v = verdict_from_graceful_oom(2, "OOM detected");
+        assert_eq!(v, GracefulOomVerdict::Pass);
+    }
+
+    #[test]
+    fn fc002_fail_sigsegv() {
+        let v = verdict_from_graceful_oom(139, "any stderr");
+        assert_eq!(v, GracefulOomVerdict::Fail);
+    }
+
+    #[test]
+    fn fc002_fail_silent_zero_exit() {
+        let v = verdict_from_graceful_oom(0, "memory exhausted");
+        assert_eq!(v, GracefulOomVerdict::Fail);
+    }
+
+    #[test]
+    fn fc002_fail_nonzero_no_oom_word() {
+        let v = verdict_from_graceful_oom(1, "Error: file not found");
+        assert_eq!(v, GracefulOomVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 4: F-CHAOS-003 signal handling.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fc003_pass_clean_sigint() {
+        let v = verdict_from_signal_handling(130, 500, false);
+        assert_eq!(v, SignalHandlingVerdict::Pass);
+    }
+
+    #[test]
+    fn fc003_pass_sigint_at_limit() {
+        // Just under 2s.
+        let v = verdict_from_signal_handling(130, 1_999, false);
+        assert_eq!(v, SignalHandlingVerdict::Pass);
+    }
+
+    #[test]
+    fn fc003_fail_wrong_exit_code() {
+        let v = verdict_from_signal_handling(0, 500, false);
+        assert_eq!(v, SignalHandlingVerdict::Fail);
+    }
+
+    #[test]
+    fn fc003_fail_slow_response() {
+        let v = verdict_from_signal_handling(130, 2_000, false);
+        assert_eq!(v, SignalHandlingVerdict::Fail);
+    }
+
+    #[test]
+    fn fc003_fail_corrupt_cache() {
+        let v = verdict_from_signal_handling(130, 500, true);
+        assert_eq!(v, SignalHandlingVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 5: F-CHAOS-004 batch overwrite protection.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fc004_pass_no_existing_file() {
+        let v = verdict_from_overwrite_protection(false, false, 0);
+        assert_eq!(v, OverwriteProtectionVerdict::Pass);
+    }
+
+    #[test]
+    fn fc004_pass_force_flag_set() {
+        // User explicitly opted in.
+        let v = verdict_from_overwrite_protection(true, true, 0);
+        assert_eq!(v, OverwriteProtectionVerdict::Pass);
+    }
+
+    #[test]
+    fn fc004_pass_existing_file_command_refused() {
+        let v = verdict_from_overwrite_protection(true, false, 1);
+        assert_eq!(v, OverwriteProtectionVerdict::Pass);
+    }
+
+    #[test]
+    fn fc004_fail_silent_overwrite() {
+        // The regression: file existed, no --force, but exit 0 = overwrite.
+        let v = verdict_from_overwrite_protection(true, false, 0);
+        assert_eq!(v, OverwriteProtectionVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 6: F-CHAOS-005 disk exhaustion.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fc005_pass_disk_word() {
+        let v = verdict_from_disk_exhaustion(1, "Error: no disk space");
+        assert_eq!(v, DiskExhaustionVerdict::Pass);
+    }
+
+    #[test]
+    fn fc005_pass_space_word() {
+        let v = verdict_from_disk_exhaustion(1, "Error: no space left on device");
+        assert_eq!(v, DiskExhaustionVerdict::Pass);
+    }
+
+    #[test]
+    fn fc005_pass_write_word() {
+        let v = verdict_from_disk_exhaustion(28, "Error: write failed");
+        assert_eq!(v, DiskExhaustionVerdict::Pass);
+    }
+
+    #[test]
+    fn fc005_fail_silent_zero_exit() {
+        // The regression: partial file written silently.
+        let v = verdict_from_disk_exhaustion(0, "Error: no space left");
+        assert_eq!(v, DiskExhaustionVerdict::Fail);
+    }
+
+    #[test]
+    fn fc005_fail_nonzero_no_disk_word() {
+        let v = verdict_from_disk_exhaustion(1, "Error: tensor mismatch");
+        assert_eq!(v, DiskExhaustionVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 7: Realistic — full chaos run passes all 5.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn realistic_healthy_chaos_run_passes_all_5() {
+        // 5 GB model under 16 GB RSS budget; OOM mentions memory; SIGINT
+        // exit 130 in 100ms; no overwrite without --force; full-disk
+        // produces "no space" error.
+        assert_eq!(
+            verdict_from_memory_budget(13 * ONE_GB, 5 * ONE_GB),
+            MemoryBudgetVerdict::Pass
+        );
+        assert_eq!(
+            verdict_from_graceful_oom(1, "out of memory"),
+            GracefulOomVerdict::Pass
+        );
+        assert_eq!(
+            verdict_from_signal_handling(130, 100, false),
+            SignalHandlingVerdict::Pass
+        );
+        assert_eq!(
+            verdict_from_overwrite_protection(true, false, 1),
+            OverwriteProtectionVerdict::Pass
+        );
+        assert_eq!(
+            verdict_from_disk_exhaustion(1, "no space left on device"),
+            DiskExhaustionVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn realistic_pre_fix_all_5_failures() {
+        // Each gate's regression class.
+        // 001: 100x over budget (memory leak).
+        assert_eq!(
+            verdict_from_memory_budget(500 * ONE_GB, 5 * ONE_GB),
+            MemoryBudgetVerdict::Fail
+        );
+        // 002: SIGSEGV under ulimit (the contract test's failure mode).
+        assert_eq!(
+            verdict_from_graceful_oom(139, "ulimit reached"),
+            GracefulOomVerdict::Fail
+        );
+        // 003: wrong exit (e.g., 0 — process kept running through SIGINT).
+        assert_eq!(
+            verdict_from_signal_handling(0, 500, false),
+            SignalHandlingVerdict::Fail
+        );
+        // 004: silent overwrite.
+        assert_eq!(
+            verdict_from_overwrite_protection(true, false, 0),
+            OverwriteProtectionVerdict::Fail
+        );
+        // 005: silent partial file on full disk.
+        assert_eq!(
+            verdict_from_disk_exhaustion(0, "wrote 0 bytes"),
+            DiskExhaustionVerdict::Fail
+        );
+    }
+}

--- a/crates/aprender-core/src/format/ciinfra_001_006.rs
+++ b/crates/aprender-core/src/format/ciinfra_001_006.rs
@@ -1,0 +1,328 @@
+// `ci-infra-v1` algorithm-level PARTIAL discharge for the 6 CI-
+// infrastructure falsifiers (RC1-RC6 root-cause prevention).
+//
+// Contract: `contracts/ci-infra-v1.yaml`.
+// Refs: docs/specifications/components/ci-infrastructure.md, RC1-RC6
+// root-cause analyses.
+
+/// Maximum acceptable test --exclude flags in ci.yml (per F-INFRA-005).
+pub const AC_CIINFRA_MAX_EXCLUSIONS: u32 = 2;
+
+// =============================================================================
+// F-INFRA-001 — workflow_trigger_explicit
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CiTriggerExplicitVerdict {
+    /// All push-triggered workflows include `branches:` filter.
+    Pass,
+    /// At least one bare `on: push:` (no filter) — RC1 phantom failures.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_ci_trigger_explicit(bare_push_workflow_count: u32) -> CiTriggerExplicitVerdict {
+    if bare_push_workflow_count == 0 {
+        CiTriggerExplicitVerdict::Pass
+    } else {
+        CiTriggerExplicitVerdict::Fail
+    }
+}
+
+// =============================================================================
+// F-INFRA-002 — platform_deps_gated
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CiPlatformDepsVerdict {
+    /// All platform-specific deps under `[target.'cfg(...)'.dependencies]`.
+    Pass,
+    /// At least one platform dep in unconditional `[dependencies]` —
+    /// RC2 nightly Windows failure.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_ci_platform_deps(unguarded_platform_dep_count: u32) -> CiPlatformDepsVerdict {
+    if unguarded_platform_dep_count == 0 {
+        CiPlatformDepsVerdict::Pass
+    } else {
+        CiPlatformDepsVerdict::Fail
+    }
+}
+
+// =============================================================================
+// F-INFRA-003 — external_repos_pinned
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CiExternalRepoPinVerdict {
+    /// All external-repo checkouts pinned to tag (v*) or 40-char SHA.
+    Pass,
+    /// At least one floating reference (main/master/HEAD) — RC3
+    /// cross-repo breakage.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_ci_external_repo_pin(floating_external_count: u32) -> CiExternalRepoPinVerdict {
+    if floating_external_count == 0 {
+        CiExternalRepoPinVerdict::Pass
+    } else {
+        CiExternalRepoPinVerdict::Fail
+    }
+}
+
+// =============================================================================
+// F-INFRA-004 — patches_tracked
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CiPatchesTrackedVerdict {
+    /// Every `[patch.crates-io]` entry has GH-/issue/expiration comment.
+    Pass,
+    /// At least one untracked patch — RC4 floating cc dependency.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_ci_patches_tracked(untracked_patch_count: u32) -> CiPatchesTrackedVerdict {
+    if untracked_patch_count == 0 {
+        CiPatchesTrackedVerdict::Pass
+    } else {
+        CiPatchesTrackedVerdict::Fail
+    }
+}
+
+// =============================================================================
+// F-INFRA-005 — no_untested_exclusions
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CiNoExclusionsVerdict {
+    /// `--exclude` flag count in ci.yml ≤ 2 (GPU-only acceptable).
+    Pass,
+    /// > 2 exclusions — RC5 untested code paths.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_ci_no_exclusions(exclude_flag_count: u32) -> CiNoExclusionsVerdict {
+    if exclude_flag_count <= AC_CIINFRA_MAX_EXCLUSIONS {
+        CiNoExclusionsVerdict::Pass
+    } else {
+        CiNoExclusionsVerdict::Fail
+    }
+}
+
+// =============================================================================
+// F-INFRA-006 — rustflags_consistent
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CiRustflagsConsistentVerdict {
+    /// All workflows that set RUSTFLAGS use the same value (or only 0/1
+    /// workflows set it).
+    Pass,
+    /// Multiple distinct RUSTFLAGS values — RC6 cascading fix cycles.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_ci_rustflags_consistent(distinct_rustflags_value_count: u32) -> CiRustflagsConsistentVerdict {
+    if distinct_rustflags_value_count <= 1 {
+        CiRustflagsConsistentVerdict::Pass
+    } else {
+        CiRustflagsConsistentVerdict::Fail
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -------------------------------------------------------------------------
+    // Section 1: Provenance pin.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn provenance_max_exclusions_2() {
+        assert_eq!(AC_CIINFRA_MAX_EXCLUSIONS, 2);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 2: F-INFRA-001 trigger explicit.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fci001_pass_no_bare_push() {
+        assert_eq!(
+            verdict_from_ci_trigger_explicit(0),
+            CiTriggerExplicitVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fci001_fail_one_bare_push() {
+        assert_eq!(
+            verdict_from_ci_trigger_explicit(1),
+            CiTriggerExplicitVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fci001_fail_many_bare_push() {
+        assert_eq!(
+            verdict_from_ci_trigger_explicit(5),
+            CiTriggerExplicitVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 3: F-INFRA-002 platform deps.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fci002_pass_all_gated() {
+        assert_eq!(
+            verdict_from_ci_platform_deps(0),
+            CiPlatformDepsVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fci002_fail_one_unguarded() {
+        assert_eq!(
+            verdict_from_ci_platform_deps(1),
+            CiPlatformDepsVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 4: F-INFRA-003 external repos.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fci003_pass_all_pinned() {
+        assert_eq!(
+            verdict_from_ci_external_repo_pin(0),
+            CiExternalRepoPinVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fci003_fail_floating_main() {
+        assert_eq!(
+            verdict_from_ci_external_repo_pin(1),
+            CiExternalRepoPinVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 5: F-INFRA-004 patches tracked.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fci004_pass_no_untracked() {
+        assert_eq!(
+            verdict_from_ci_patches_tracked(0),
+            CiPatchesTrackedVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fci004_fail_one_untracked() {
+        assert_eq!(
+            verdict_from_ci_patches_tracked(1),
+            CiPatchesTrackedVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 6: F-INFRA-005 no untested exclusions.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fci005_pass_zero_exclusions() {
+        assert_eq!(
+            verdict_from_ci_no_exclusions(0),
+            CiNoExclusionsVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fci005_pass_at_threshold() {
+        assert_eq!(
+            verdict_from_ci_no_exclusions(2),
+            CiNoExclusionsVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fci005_fail_three_exclusions() {
+        assert_eq!(
+            verdict_from_ci_no_exclusions(3),
+            CiNoExclusionsVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 7: F-INFRA-006 RUSTFLAGS consistent.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fci006_pass_zero_workflows_set_rustflags() {
+        assert_eq!(
+            verdict_from_ci_rustflags_consistent(0),
+            CiRustflagsConsistentVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fci006_pass_one_consistent_value() {
+        assert_eq!(
+            verdict_from_ci_rustflags_consistent(1),
+            CiRustflagsConsistentVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fci006_fail_two_distinct_values() {
+        assert_eq!(
+            verdict_from_ci_rustflags_consistent(2),
+            CiRustflagsConsistentVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 8: Realistic — full healthy CI passes all 6.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn realistic_healthy_ci_passes_all_6() {
+        // All RC1-RC6 root causes eliminated.
+        assert_eq!(verdict_from_ci_trigger_explicit(0), CiTriggerExplicitVerdict::Pass);
+        assert_eq!(verdict_from_ci_platform_deps(0), CiPlatformDepsVerdict::Pass);
+        assert_eq!(verdict_from_ci_external_repo_pin(0), CiExternalRepoPinVerdict::Pass);
+        assert_eq!(verdict_from_ci_patches_tracked(0), CiPatchesTrackedVerdict::Pass);
+        assert_eq!(verdict_from_ci_no_exclusions(2), CiNoExclusionsVerdict::Pass);
+        assert_eq!(
+            verdict_from_ci_rustflags_consistent(1),
+            CiRustflagsConsistentVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn realistic_pre_fix_all_6_failures() {
+        // RC1: bare push trigger.
+        assert_eq!(verdict_from_ci_trigger_explicit(3), CiTriggerExplicitVerdict::Fail);
+        // RC2: nix in unconditional [dependencies].
+        assert_eq!(verdict_from_ci_platform_deps(1), CiPlatformDepsVerdict::Fail);
+        // RC3: paiml/sibling pinned to main.
+        assert_eq!(
+            verdict_from_ci_external_repo_pin(2),
+            CiExternalRepoPinVerdict::Fail
+        );
+        // RC4: untracked cc patch.
+        assert_eq!(verdict_from_ci_patches_tracked(1), CiPatchesTrackedVerdict::Fail);
+        // RC5: 5 crates excluded from CI.
+        assert_eq!(verdict_from_ci_no_exclusions(5), CiNoExclusionsVerdict::Fail);
+        // RC6: 3 distinct RUSTFLAGS across workflows.
+        assert_eq!(
+            verdict_from_ci_rustflags_consistent(3),
+            CiRustflagsConsistentVerdict::Fail
+        );
+    }
+}

--- a/crates/aprender-core/src/format/clf_001_005.rs
+++ b/crates/aprender-core/src/format/clf_001_005.rs
@@ -1,0 +1,496 @@
+// `classifier-pipeline-v1` algorithm-level PARTIAL discharge for the 5
+// CLF-RUN classifier-pipeline falsifiers (sigmoid correctness, split
+// determinism, linear probe learning, probe roundtrip, embedding
+// roundtrip).
+//
+// Contract: `contracts/classifier-pipeline-v1.yaml`.
+// Refs: SSC v11 §4.3 Classifier Infrastructure, Alain & Bengio (2016)
+// "Understanding intermediate layers using linear classifier probes".
+//
+// ## Disambiguation
+//
+// `classification-finetune-v1.yaml` (FALSIFY-CLASS-001..006, already
+// bound via `classification_contract_falsify`) covers fine-tuning. This
+// contract — classifier-pipeline-v1 — covers the linear-probe-on-frozen-
+// embeddings pipeline. Module suffix `clf_` (CLF-RUN identifier from the
+// SSC spec) disambiguates from any `class_*` finetune modules.
+
+/// Sigmoid value at zero per FALSIFY-CLF-001.
+pub const AC_CLF_SIGMOID_ZERO: f32 = 0.5;
+
+/// Tolerance for sigmoid(0) == 0.5 check.
+pub const AC_CLF_SIGMOID_ZERO_TOLERANCE: f32 = 1e-6;
+
+/// Saturation thresholds: sigmoid(±large) ≈ 0/1 within this tolerance.
+pub const AC_CLF_SIGMOID_SAT_TOLERANCE: f32 = 1e-3;
+
+/// Linear-probe synthetic-data accuracy threshold per FALSIFY-CLF-003.
+pub const AC_CLF_PROBE_ACCURACY_THRESHOLD: f32 = 0.70;
+
+// =============================================================================
+// FALSIFY-CLF-001 — sigmoid correctness at boundary values
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SigmoidCorrectnessVerdict {
+    /// sigmoid(0) ≈ 0.5, sigmoid(large) ≈ 1, sigmoid(-large) ≈ 0.
+    Pass,
+    /// Numerical implementation error in activation.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_sigmoid_correctness(
+    sigmoid_at_zero: f32,
+    sigmoid_at_large_pos: f32,
+    sigmoid_at_large_neg: f32,
+) -> SigmoidCorrectnessVerdict {
+    // sigmoid(0) == 0.5 within 1e-6.
+    if (sigmoid_at_zero - AC_CLF_SIGMOID_ZERO).abs() >= AC_CLF_SIGMOID_ZERO_TOLERANCE {
+        return SigmoidCorrectnessVerdict::Fail;
+    }
+    // sigmoid(large_pos) ≈ 1.
+    if (sigmoid_at_large_pos - 1.0).abs() >= AC_CLF_SIGMOID_SAT_TOLERANCE {
+        return SigmoidCorrectnessVerdict::Fail;
+    }
+    // sigmoid(large_neg) ≈ 0.
+    if sigmoid_at_large_neg.abs() >= AC_CLF_SIGMOID_SAT_TOLERANCE {
+        return SigmoidCorrectnessVerdict::Fail;
+    }
+    SigmoidCorrectnessVerdict::Pass
+}
+
+// =============================================================================
+// FALSIFY-CLF-002 — split determinism with same seed
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SplitDeterminismVerdict {
+    /// split_a == split_b (bit-identical) when seed is the same.
+    Pass,
+    /// Sets diverged — non-deterministic hash or random element.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_split_determinism(
+    train_a: &[u32],
+    test_a: &[u32],
+    train_b: &[u32],
+    test_b: &[u32],
+) -> SplitDeterminismVerdict {
+    if train_a.is_empty() && test_a.is_empty() {
+        return SplitDeterminismVerdict::Fail;
+    }
+    if train_a != train_b {
+        return SplitDeterminismVerdict::Fail;
+    }
+    if test_a != test_b {
+        return SplitDeterminismVerdict::Fail;
+    }
+    SplitDeterminismVerdict::Pass
+}
+
+// =============================================================================
+// FALSIFY-CLF-003 — linear probe learns linearly separable data
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProbeLearnsVerdict {
+    /// Training accuracy on linearly-separable synthetic data > 70%.
+    Pass,
+    /// Below threshold — SGD bug or LR misconfiguration.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_probe_learns(train_accuracy: f32) -> ProbeLearnsVerdict {
+    if !train_accuracy.is_finite() {
+        return ProbeLearnsVerdict::Fail;
+    }
+    if !(0.0..=1.0).contains(&train_accuracy) {
+        return ProbeLearnsVerdict::Fail;
+    }
+    if train_accuracy > AC_CLF_PROBE_ACCURACY_THRESHOLD {
+        ProbeLearnsVerdict::Pass
+    } else {
+        ProbeLearnsVerdict::Fail
+    }
+}
+
+// =============================================================================
+// FALSIFY-CLF-004 — probe save/load roundtrip
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProbeRoundtripVerdict {
+    /// Loaded probe weights, bias, all metadata bit-identical to saved.
+    Pass,
+    /// Any field differs — JSON precision loss or dropped field.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_probe_roundtrip(
+    saved_weights: &[f32],
+    loaded_weights: &[f32],
+    saved_bias: f32,
+    loaded_bias: f32,
+) -> ProbeRoundtripVerdict {
+    if saved_weights.len() != loaded_weights.len() {
+        return ProbeRoundtripVerdict::Fail;
+    }
+    if saved_weights.is_empty() {
+        return ProbeRoundtripVerdict::Fail;
+    }
+    for (a, b) in saved_weights.iter().zip(loaded_weights.iter()) {
+        if a.is_nan() != b.is_nan() {
+            return ProbeRoundtripVerdict::Fail;
+        }
+        if !a.is_nan() && a != b {
+            return ProbeRoundtripVerdict::Fail;
+        }
+    }
+    if saved_bias.is_nan() != loaded_bias.is_nan() {
+        return ProbeRoundtripVerdict::Fail;
+    }
+    if !saved_bias.is_nan() && saved_bias != loaded_bias {
+        return ProbeRoundtripVerdict::Fail;
+    }
+    ProbeRoundtripVerdict::Pass
+}
+
+// =============================================================================
+// FALSIFY-CLF-005 — embedding save/load roundtrip
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EmbeddingRoundtripVerdict {
+    /// JSONL roundtrip preserves entry count AND every embedding value.
+    Pass,
+    /// Count mismatch or float precision loss.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_embedding_roundtrip(
+    saved: &[Vec<f32>],
+    loaded: &[Vec<f32>],
+) -> EmbeddingRoundtripVerdict {
+    if saved.len() != loaded.len() {
+        return EmbeddingRoundtripVerdict::Fail;
+    }
+    if saved.is_empty() {
+        return EmbeddingRoundtripVerdict::Fail;
+    }
+    for (sv, lv) in saved.iter().zip(loaded.iter()) {
+        if sv.len() != lv.len() {
+            return EmbeddingRoundtripVerdict::Fail;
+        }
+        for (a, b) in sv.iter().zip(lv.iter()) {
+            if a != b {
+                return EmbeddingRoundtripVerdict::Fail;
+            }
+        }
+    }
+    EmbeddingRoundtripVerdict::Pass
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -------------------------------------------------------------------------
+    // Section 1: Provenance pins.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn provenance_sigmoid_zero_05() {
+        assert!((AC_CLF_SIGMOID_ZERO - 0.5).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn provenance_probe_accuracy_threshold_70() {
+        assert!((AC_CLF_PROBE_ACCURACY_THRESHOLD - 0.70).abs() < f32::EPSILON);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 2: CLF-001 sigmoid correctness.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fclf001_pass_canonical_sigmoid() {
+        // sigmoid(0)=0.5, sigmoid(20)≈1, sigmoid(-20)≈0
+        let s_zero = 0.5_f32;
+        let s_pos = 1.0 - 1e-9;
+        let s_neg = 1e-9_f32;
+        assert_eq!(
+            verdict_from_sigmoid_correctness(s_zero, s_pos, s_neg),
+            SigmoidCorrectnessVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fclf001_fail_zero_off() {
+        assert_eq!(
+            verdict_from_sigmoid_correctness(0.6, 1.0, 0.0),
+            SigmoidCorrectnessVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fclf001_fail_pos_saturation_off() {
+        assert_eq!(
+            verdict_from_sigmoid_correctness(0.5, 0.5, 0.0),
+            SigmoidCorrectnessVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fclf001_fail_neg_saturation_off() {
+        assert_eq!(
+            verdict_from_sigmoid_correctness(0.5, 1.0, 0.5),
+            SigmoidCorrectnessVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 3: CLF-002 split determinism.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fclf002_pass_identical_splits() {
+        let train = [1u32, 2, 3, 4];
+        let test = [5u32, 6];
+        assert_eq!(
+            verdict_from_split_determinism(&train, &test, &train, &test),
+            SplitDeterminismVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fclf002_fail_train_diverges() {
+        let train_a = [1u32, 2, 3];
+        let test = [4u32, 5];
+        let train_b = [1u32, 3, 2];
+        assert_eq!(
+            verdict_from_split_determinism(&train_a, &test, &train_b, &test),
+            SplitDeterminismVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fclf002_fail_test_diverges() {
+        let train = [1u32];
+        let test_a = [2u32];
+        let test_b = [3u32];
+        assert_eq!(
+            verdict_from_split_determinism(&train, &test_a, &train, &test_b),
+            SplitDeterminismVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fclf002_fail_empty() {
+        assert_eq!(
+            verdict_from_split_determinism(&[], &[], &[], &[]),
+            SplitDeterminismVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 4: CLF-003 probe learns.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fclf003_pass_high_accuracy() {
+        assert_eq!(verdict_from_probe_learns(0.95), ProbeLearnsVerdict::Pass);
+    }
+
+    #[test]
+    fn fclf003_pass_just_above_threshold() {
+        assert_eq!(verdict_from_probe_learns(0.71), ProbeLearnsVerdict::Pass);
+    }
+
+    #[test]
+    fn fclf003_fail_at_threshold() {
+        // Strict greater-than.
+        assert_eq!(verdict_from_probe_learns(0.70), ProbeLearnsVerdict::Fail);
+    }
+
+    #[test]
+    fn fclf003_fail_below_threshold() {
+        assert_eq!(verdict_from_probe_learns(0.55), ProbeLearnsVerdict::Fail);
+    }
+
+    #[test]
+    fn fclf003_fail_nan_accuracy() {
+        assert_eq!(verdict_from_probe_learns(f32::NAN), ProbeLearnsVerdict::Fail);
+    }
+
+    #[test]
+    fn fclf003_fail_out_of_range() {
+        assert_eq!(verdict_from_probe_learns(1.5), ProbeLearnsVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 5: CLF-004 probe roundtrip.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fclf004_pass_exact_roundtrip() {
+        let w = vec![0.1_f32, 0.2, 0.3];
+        assert_eq!(
+            verdict_from_probe_roundtrip(&w, &w, 0.5, 0.5),
+            ProbeRoundtripVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fclf004_fail_weight_drift() {
+        let saved = vec![0.1_f32];
+        let loaded = vec![0.10000001_f32];
+        assert_eq!(
+            verdict_from_probe_roundtrip(&saved, &loaded, 0.5, 0.5),
+            ProbeRoundtripVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fclf004_fail_bias_drift() {
+        let w = vec![0.1_f32];
+        assert_eq!(
+            verdict_from_probe_roundtrip(&w, &w, 0.5, 0.5000001),
+            ProbeRoundtripVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fclf004_fail_length_mismatch() {
+        let saved = vec![0.1_f32, 0.2];
+        let loaded = vec![0.1_f32];
+        assert_eq!(
+            verdict_from_probe_roundtrip(&saved, &loaded, 0.5, 0.5),
+            ProbeRoundtripVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fclf004_fail_empty() {
+        assert_eq!(
+            verdict_from_probe_roundtrip(&[], &[], 0.0, 0.0),
+            ProbeRoundtripVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 6: CLF-005 embedding roundtrip.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fclf005_pass_exact_roundtrip() {
+        let saved = vec![vec![0.1_f32, 0.2], vec![0.3_f32, 0.4]];
+        assert_eq!(
+            verdict_from_embedding_roundtrip(&saved, &saved),
+            EmbeddingRoundtripVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fclf005_fail_count_mismatch() {
+        let saved = vec![vec![0.1_f32]];
+        let loaded = vec![vec![0.1_f32], vec![0.2_f32]];
+        assert_eq!(
+            verdict_from_embedding_roundtrip(&saved, &loaded),
+            EmbeddingRoundtripVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fclf005_fail_dimension_mismatch() {
+        let saved = vec![vec![0.1_f32, 0.2]];
+        let loaded = vec![vec![0.1_f32]];
+        assert_eq!(
+            verdict_from_embedding_roundtrip(&saved, &loaded),
+            EmbeddingRoundtripVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fclf005_fail_value_drift() {
+        let saved = vec![vec![0.1_f32]];
+        let loaded = vec![vec![0.10000001_f32]];
+        assert_eq!(
+            verdict_from_embedding_roundtrip(&saved, &loaded),
+            EmbeddingRoundtripVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fclf005_fail_empty() {
+        let empty: Vec<Vec<f32>> = vec![];
+        assert_eq!(
+            verdict_from_embedding_roundtrip(&empty, &empty),
+            EmbeddingRoundtripVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 7: Realistic — full healthy classifier-pipeline passes all 5.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn realistic_healthy_pipeline_passes_all_5() {
+        // 001
+        assert_eq!(
+            verdict_from_sigmoid_correctness(0.5, 1.0 - 1e-9, 1e-9),
+            SigmoidCorrectnessVerdict::Pass
+        );
+        // 002
+        let train = [1u32, 2, 3];
+        let test = [4u32];
+        assert_eq!(
+            verdict_from_split_determinism(&train, &test, &train, &test),
+            SplitDeterminismVerdict::Pass
+        );
+        // 003 (validated_results: linear probe at 95.2% on 500-entry BPE).
+        assert_eq!(verdict_from_probe_learns(0.952), ProbeLearnsVerdict::Pass);
+        // 004
+        let w = vec![0.1_f32, 0.2];
+        assert_eq!(
+            verdict_from_probe_roundtrip(&w, &w, 0.5, 0.5),
+            ProbeRoundtripVerdict::Pass
+        );
+        // 005
+        let e = vec![vec![0.1_f32; 768]];
+        assert_eq!(
+            verdict_from_embedding_roundtrip(&e, &e),
+            EmbeddingRoundtripVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn realistic_pre_fix_all_5_failures() {
+        // 001: sigmoid(0) returned 0.6.
+        assert_eq!(
+            verdict_from_sigmoid_correctness(0.6, 1.0, 0.0),
+            SigmoidCorrectnessVerdict::Fail
+        );
+        // 002: hash leaked → split diverges.
+        let a = [1u32, 2];
+        let b = [2u32, 1];
+        assert_eq!(
+            verdict_from_split_determinism(&a, &[3u32], &b, &[3u32]),
+            SplitDeterminismVerdict::Fail
+        );
+        // 003: SGD lr too large → 50% accuracy.
+        assert_eq!(verdict_from_probe_learns(0.5), ProbeLearnsVerdict::Fail);
+        // 004: f64→f32 precision loss in JSON.
+        let saved = vec![0.1_f32];
+        let loaded = vec![0.10000001_f32];
+        assert_eq!(
+            verdict_from_probe_roundtrip(&saved, &loaded, 0.5, 0.5),
+            ProbeRoundtripVerdict::Fail
+        );
+        // 005: JSONL line skipped on parse error.
+        let saved = vec![vec![0.1_f32], vec![0.2_f32]];
+        let loaded = vec![vec![0.1_f32]];
+        assert_eq!(
+            verdict_from_embedding_roundtrip(&saved, &loaded),
+            EmbeddingRoundtripVerdict::Fail
+        );
+    }
+}

--- a/crates/aprender-core/src/format/clidispatch_001_004.rs
+++ b/crates/aprender-core/src/format/clidispatch_001_004.rs
@@ -1,0 +1,435 @@
+// `cli-dispatch-v1` algorithm-level PARTIAL discharge for the 4 CLI-
+// dispatch falsifiers (dispatch completeness, exit-code injectivity,
+// JSON output parseability, inspection idempotency).
+//
+// Contract: `contracts/cli-dispatch-v1.yaml`.
+// Refs: POSIX.1-2017 Utility Conventions, GNU Coding Standards (Exit
+// Status), apr-cli/src/error.rs::CliError.
+//
+// ## Disambiguation
+//
+// `apr-cli-commands-v1.yaml` (task #278) is a sibling contract covering
+// 4 different FALSIFY-CLI-001..004 gates on command registration. This
+// contract — cli-dispatch-v1 — covers dispatch correctness, exit codes,
+// and output format. Module suffix `clidispatch_` disambiguates from
+// any `cli_*` registration modules.
+
+use std::collections::HashSet;
+
+/// Canonical exit codes per `cli_config.exit_codes`.
+pub const AC_CLIDISPATCH_EXIT_CODES: [(&str, u8); 11] = [
+    ("success", 0),
+    ("general_error", 1),
+    ("file_not_found", 3),
+    ("invalid_format", 4),
+    ("validation_failed", 5),
+    ("model_load_failed", 6),
+    ("io_error", 7),
+    ("inference_failed", 8),
+    ("feature_disabled", 9),
+    ("network_error", 10),
+    ("http_not_found", 11),
+];
+
+/// Output format identifiers per `cli_config.output_formats`.
+pub const AC_CLIDISPATCH_OUTPUT_FORMATS: [&str; 6] =
+    ["text", "json", "yaml", "csv", "srt", "vtt"];
+
+/// Read-only inspection commands per equation `idempotent_inspection`.
+pub const AC_CLIDISPATCH_INSPECTION_CMDS: [&str; 7] =
+    ["check", "inspect", "debug", "validate", "lint", "explain", "list"];
+
+// =============================================================================
+// FALSIFY-CLI-001 — every Commands variant has a dispatch handler
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DispatchCompletenessVerdict {
+    /// Every subcommand in the registry has a dispatch handler that
+    /// returned exit 0 on `--help` (clap-recognized).
+    Pass,
+    /// At least one subcommand failed `--help` (no handler).
+    Fail,
+}
+
+/// `(subcommand_name, --help_exit_code)` per registered subcommand.
+#[must_use]
+pub fn verdict_from_dispatch_completeness(help_results: &[(&str, i32)]) -> DispatchCompletenessVerdict {
+    if help_results.is_empty() {
+        return DispatchCompletenessVerdict::Fail;
+    }
+    for (_cmd, exit) in help_results {
+        if *exit != 0 {
+            return DispatchCompletenessVerdict::Fail;
+        }
+    }
+    DispatchCompletenessVerdict::Pass
+}
+
+// =============================================================================
+// FALSIFY-CLI-002 — exit codes are injective (no collisions)
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExitCodeInjectivityVerdict {
+    /// Distinct CliError variants map to distinct exit codes.
+    Pass,
+    /// Two error variants share the same code.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_exit_code_injectivity(error_code_pairs: &[(&str, u8)]) -> ExitCodeInjectivityVerdict {
+    if error_code_pairs.is_empty() {
+        return ExitCodeInjectivityVerdict::Fail;
+    }
+    let mut seen: HashSet<u8> = HashSet::new();
+    for (_name, code) in error_code_pairs {
+        if !seen.insert(*code) {
+            return ExitCodeInjectivityVerdict::Fail;
+        }
+    }
+    ExitCodeInjectivityVerdict::Pass
+}
+
+// =============================================================================
+// FALSIFY-CLI-003 — JSON output is always parseable
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum JsonParseableVerdict {
+    /// `--json` output starts with valid JSON sentinel ('{' or '['),
+    /// has balanced braces/brackets, and contains no obvious malformed
+    /// markers.
+    Pass,
+    /// Output not JSON-shaped — unescaped string, trailing comma, etc.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_json_parseable(output: &str) -> JsonParseableVerdict {
+    let trimmed = output.trim();
+    if trimmed.is_empty() {
+        return JsonParseableVerdict::Fail;
+    }
+    // Safety: `trimmed.is_empty()` was checked above, so both .next() and .last() yield Some.
+    let first = trimmed.chars().next().expect("non-empty trimmed");
+    let last = trimmed.chars().last().expect("non-empty trimmed");
+    let valid_start = first == '{' || first == '[';
+    let valid_end = last == '}' || last == ']';
+    if !valid_start || !valid_end {
+        return JsonParseableVerdict::Fail;
+    }
+    // Match braces and brackets pairwise — outer wrapper only.
+    if first == '{' && last != '}' {
+        return JsonParseableVerdict::Fail;
+    }
+    if first == '[' && last != ']' {
+        return JsonParseableVerdict::Fail;
+    }
+    // Catch obvious trailing-comma regression: ",}" or ",]" sequence.
+    if trimmed.contains(",}") || trimmed.contains(",]") {
+        return JsonParseableVerdict::Fail;
+    }
+    JsonParseableVerdict::Pass
+}
+
+// =============================================================================
+// FALSIFY-CLI-004 — inspection commands are idempotent
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InspectionIdempotencyVerdict {
+    /// Two runs of an inspection command produce identical stdout AND exit code.
+    Pass,
+    /// Diverged — hidden state mutation or non-determinism.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_inspection_idempotency(
+    stdout_a: &[u8],
+    stdout_b: &[u8],
+    exit_code_a: i32,
+    exit_code_b: i32,
+) -> InspectionIdempotencyVerdict {
+    if stdout_a.is_empty() && stdout_b.is_empty() {
+        return InspectionIdempotencyVerdict::Fail;
+    }
+    if stdout_a != stdout_b {
+        return InspectionIdempotencyVerdict::Fail;
+    }
+    if exit_code_a != exit_code_b {
+        return InspectionIdempotencyVerdict::Fail;
+    }
+    InspectionIdempotencyVerdict::Pass
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -------------------------------------------------------------------------
+    // Section 1: Provenance pins.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn provenance_exit_codes_are_injective_in_constants() {
+        let mut seen: HashSet<u8> = HashSet::new();
+        for (_, code) in AC_CLIDISPATCH_EXIT_CODES {
+            assert!(seen.insert(code), "exit code {code} duplicated in constants");
+        }
+    }
+
+    #[test]
+    fn provenance_success_is_zero() {
+        assert_eq!(AC_CLIDISPATCH_EXIT_CODES[0].1, 0);
+    }
+
+    #[test]
+    fn provenance_file_not_found_is_3() {
+        let entry = AC_CLIDISPATCH_EXIT_CODES.iter().find(|(n, _)| *n == "file_not_found").unwrap();
+        assert_eq!(entry.1, 3);
+    }
+
+    #[test]
+    fn provenance_output_formats_count_6() {
+        assert_eq!(AC_CLIDISPATCH_OUTPUT_FORMATS.len(), 6);
+    }
+
+    #[test]
+    fn provenance_inspection_cmds_count_7() {
+        assert_eq!(AC_CLIDISPATCH_INSPECTION_CMDS.len(), 7);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 2: CLI-001 dispatch completeness.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fcli001_pass_all_dispatched() {
+        let r = [
+            ("check", 0), ("run", 0), ("inspect", 0), ("debug", 0),
+            ("validate", 0), ("lint", 0), ("explain", 0),
+        ];
+        assert_eq!(
+            verdict_from_dispatch_completeness(&r),
+            DispatchCompletenessVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fcli001_fail_one_command_failed() {
+        let r = [("check", 0), ("run", 1)];
+        assert_eq!(
+            verdict_from_dispatch_completeness(&r),
+            DispatchCompletenessVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fcli001_fail_empty() {
+        let r: [(&str, i32); 0] = [];
+        assert_eq!(
+            verdict_from_dispatch_completeness(&r),
+            DispatchCompletenessVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 3: CLI-002 exit-code injectivity.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fcli002_pass_all_distinct() {
+        let pairs = [("Ok", 0u8), ("Generic", 1), ("FileNotFound", 3)];
+        assert_eq!(
+            verdict_from_exit_code_injectivity(&pairs),
+            ExitCodeInjectivityVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fcli002_pass_canonical_constants() {
+        let v: Vec<(&str, u8)> = AC_CLIDISPATCH_EXIT_CODES.to_vec();
+        assert_eq!(
+            verdict_from_exit_code_injectivity(&v),
+            ExitCodeInjectivityVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fcli002_fail_collision() {
+        let pairs = [("FileNotFound", 3u8), ("InvalidFormat", 3)];
+        assert_eq!(
+            verdict_from_exit_code_injectivity(&pairs),
+            ExitCodeInjectivityVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fcli002_fail_empty() {
+        let pairs: [(&str, u8); 0] = [];
+        assert_eq!(
+            verdict_from_exit_code_injectivity(&pairs),
+            ExitCodeInjectivityVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 4: CLI-003 JSON parseability.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fcli003_pass_object() {
+        assert_eq!(
+            verdict_from_json_parseable(r#"{"key": "value"}"#),
+            JsonParseableVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fcli003_pass_array() {
+        assert_eq!(
+            verdict_from_json_parseable("[1, 2, 3]"),
+            JsonParseableVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fcli003_pass_object_with_whitespace() {
+        assert_eq!(
+            verdict_from_json_parseable("\n  {\"k\": 1}  \n"),
+            JsonParseableVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fcli003_fail_empty() {
+        assert_eq!(verdict_from_json_parseable(""), JsonParseableVerdict::Fail);
+    }
+
+    #[test]
+    fn fcli003_fail_plain_text() {
+        assert_eq!(
+            verdict_from_json_parseable("not json"),
+            JsonParseableVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fcli003_fail_unmatched_brace() {
+        assert_eq!(
+            verdict_from_json_parseable("{not closed"),
+            JsonParseableVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fcli003_fail_trailing_comma_object() {
+        assert_eq!(
+            verdict_from_json_parseable(r#"{"k": 1,}"#),
+            JsonParseableVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fcli003_fail_trailing_comma_array() {
+        assert_eq!(
+            verdict_from_json_parseable("[1, 2, 3,]"),
+            JsonParseableVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 5: CLI-004 inspection idempotency.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fcli004_pass_identical_runs() {
+        let stdout = b"model OK\n";
+        assert_eq!(
+            verdict_from_inspection_idempotency(stdout, stdout, 0, 0),
+            InspectionIdempotencyVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fcli004_fail_stdout_diverges() {
+        let a = b"version 1\n";
+        let b = b"version 2\n";
+        assert_eq!(
+            verdict_from_inspection_idempotency(a, b, 0, 0),
+            InspectionIdempotencyVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fcli004_fail_exit_diverges() {
+        let stdout = b"output\n";
+        assert_eq!(
+            verdict_from_inspection_idempotency(stdout, stdout, 0, 1),
+            InspectionIdempotencyVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fcli004_fail_both_empty() {
+        // No output captured = harness defect.
+        assert_eq!(
+            verdict_from_inspection_idempotency(b"", b"", 0, 0),
+            InspectionIdempotencyVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 6: Realistic — full healthy CLI passes all 4.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn realistic_healthy_cli_passes_all_4() {
+        // 001
+        let cmds = [
+            ("check", 0), ("run", 0), ("serve", 0), ("inspect", 0),
+        ];
+        assert_eq!(
+            verdict_from_dispatch_completeness(&cmds),
+            DispatchCompletenessVerdict::Pass
+        );
+        // 002 (canonical exit-code table).
+        let pairs: Vec<(&str, u8)> = AC_CLIDISPATCH_EXIT_CODES.to_vec();
+        assert_eq!(
+            verdict_from_exit_code_injectivity(&pairs),
+            ExitCodeInjectivityVerdict::Pass
+        );
+        // 003
+        let json = r#"{"model": "qwen2.5", "tensors": 339}"#;
+        assert_eq!(verdict_from_json_parseable(json), JsonParseableVerdict::Pass);
+        // 004
+        let stdout = b"validation OK\n";
+        assert_eq!(
+            verdict_from_inspection_idempotency(stdout, stdout, 0, 0),
+            InspectionIdempotencyVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn realistic_pre_fix_all_4_failures() {
+        // 001: subcommand not wired.
+        let bad_cmds = [("rm", 127)];
+        assert_eq!(
+            verdict_from_dispatch_completeness(&bad_cmds),
+            DispatchCompletenessVerdict::Fail
+        );
+        // 002: typo gave two errors the same code.
+        let bad_pairs = [("FileNotFound", 3u8), ("InvalidFormat", 3)];
+        assert_eq!(
+            verdict_from_exit_code_injectivity(&bad_pairs),
+            ExitCodeInjectivityVerdict::Fail
+        );
+        // 003: JSON serializer dropped close-brace.
+        assert_eq!(
+            verdict_from_json_parseable(r#"{"key": "value""#),
+            JsonParseableVerdict::Fail
+        );
+        // 004: inspection mutated state.
+        assert_eq!(
+            verdict_from_inspection_idempotency(b"a\n", b"b\n", 0, 0),
+            InspectionIdempotencyVerdict::Fail
+        );
+    }
+}

--- a/crates/aprender-core/src/format/cma_001_006.rs
+++ b/crates/aprender-core/src/format/cma_001_006.rs
@@ -1,0 +1,556 @@
+// `cma-es-kernel-v1` algorithm-level PARTIAL discharge for the 6
+// CMA-ES (Covariance Matrix Adaptation Evolution Strategy) falsifiers
+// (sigma positivity, C positive-definite, weights normalized,
+// C symmetric, SIMD equivalence, d=1 boundary).
+//
+// Contract: `contracts/cma-es-kernel-v1.yaml`.
+// Refs: Hansen (2016) The CMA Evolution Strategy: A Tutorial, Hansen &
+// Ostermeier (2001) Completely Derandomized Self-Adaptation in
+// Evolution Strategies.
+
+/// Tolerance for "weights sum to 1" check (1e-10 per contract).
+pub const AC_CMA_WEIGHT_NORM_TOLERANCE: f64 = 1.0e-10;
+
+/// Tolerance for "C is symmetric" check (1e-10 per contract).
+pub const AC_CMA_SYMMETRY_TOLERANCE: f64 = 1.0e-10;
+
+/// Tolerance for SIMD-vs-scalar sample equivalence (8 ULP).
+pub const AC_CMA_SIMD_TOLERANCE: f64 = 1.0e-7;
+
+// =============================================================================
+// FALSIFY-CMA-001 — sigma > 0 at every generation
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CmaSigmaPositivityVerdict {
+    /// All sigma values across generations are strictly positive AND finite.
+    Pass,
+    /// Sigma went non-positive (zero or negative) or non-finite.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_cma_sigma_positivity(sigma_per_generation: &[f64]) -> CmaSigmaPositivityVerdict {
+    if sigma_per_generation.is_empty() {
+        return CmaSigmaPositivityVerdict::Fail;
+    }
+    for &s in sigma_per_generation {
+        if !s.is_finite() {
+            return CmaSigmaPositivityVerdict::Fail;
+        }
+        if s <= 0.0 {
+            return CmaSigmaPositivityVerdict::Fail;
+        }
+    }
+    CmaSigmaPositivityVerdict::Pass
+}
+
+// =============================================================================
+// FALSIFY-CMA-002 — C eigenvalues > 0 at every generation
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CmaCovariancePosDefVerdict {
+    /// min eigenvalue > 0 across all generations.
+    Pass,
+    /// Some generation produced a C with non-positive eigenvalue —
+    /// rank update introduced negative eigenvalue.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_cma_covariance_posdef(min_eigenvalues: &[f64]) -> CmaCovariancePosDefVerdict {
+    if min_eigenvalues.is_empty() {
+        return CmaCovariancePosDefVerdict::Fail;
+    }
+    for &lambda_min in min_eigenvalues {
+        if !lambda_min.is_finite() {
+            return CmaCovariancePosDefVerdict::Fail;
+        }
+        if lambda_min <= 0.0 {
+            return CmaCovariancePosDefVerdict::Fail;
+        }
+    }
+    CmaCovariancePosDefVerdict::Pass
+}
+
+// =============================================================================
+// FALSIFY-CMA-003 — recombination weights sum to 1 within 1e-10
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CmaWeightNormalizationVerdict {
+    /// |sum(w_i) - 1.0| < 1e-10.
+    Pass,
+    /// Weights don't sum to 1 — formula error.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_cma_weight_normalization(weights: &[f64]) -> CmaWeightNormalizationVerdict {
+    if weights.is_empty() {
+        return CmaWeightNormalizationVerdict::Fail;
+    }
+    let sum: f64 = weights.iter().sum();
+    if !sum.is_finite() {
+        return CmaWeightNormalizationVerdict::Fail;
+    }
+    if (sum - 1.0).abs() < AC_CMA_WEIGHT_NORM_TOLERANCE {
+        CmaWeightNormalizationVerdict::Pass
+    } else {
+        CmaWeightNormalizationVerdict::Fail
+    }
+}
+
+// =============================================================================
+// FALSIFY-CMA-004 — C symmetric within 1e-10
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CmaCovarianceSymmetryVerdict {
+    /// max_ij |C[i,j] - C[j,i]| < 1e-10 across all generations.
+    Pass,
+    /// Asymmetric update in rank-one or rank-mu.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_cma_covariance_symmetry(
+    dim: usize,
+    covariance_matrix: &[f64],
+) -> CmaCovarianceSymmetryVerdict {
+    if dim == 0 {
+        return CmaCovarianceSymmetryVerdict::Fail;
+    }
+    if covariance_matrix.len() != dim * dim {
+        return CmaCovarianceSymmetryVerdict::Fail;
+    }
+    for i in 0..dim {
+        for j in 0..i {
+            let c_ij = covariance_matrix[i * dim + j];
+            let c_ji = covariance_matrix[j * dim + i];
+            if !c_ij.is_finite() || !c_ji.is_finite() {
+                return CmaCovarianceSymmetryVerdict::Fail;
+            }
+            if (c_ij - c_ji).abs() >= AC_CMA_SYMMETRY_TOLERANCE {
+                return CmaCovarianceSymmetryVerdict::Fail;
+            }
+        }
+    }
+    CmaCovarianceSymmetryVerdict::Pass
+}
+
+// =============================================================================
+// FALSIFY-CMA-005 — SIMD vs scalar within 8 ULP
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CmaSimdEquivalenceVerdict {
+    /// max_i |simd_sample[i] - scalar_sample[i]| < 1e-7.
+    Pass,
+    /// SIMD Cholesky or matmul differs.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_cma_simd_equivalence(simd: &[f64], scalar: &[f64]) -> CmaSimdEquivalenceVerdict {
+    if simd.len() != scalar.len() {
+        return CmaSimdEquivalenceVerdict::Fail;
+    }
+    if simd.is_empty() {
+        return CmaSimdEquivalenceVerdict::Fail;
+    }
+    for (a, b) in simd.iter().zip(scalar.iter()) {
+        if (a - b).abs() >= AC_CMA_SIMD_TOLERANCE {
+            return CmaSimdEquivalenceVerdict::Fail;
+        }
+    }
+    CmaSimdEquivalenceVerdict::Pass
+}
+
+// =============================================================================
+// FALSIFY-CMA-006 — d=1 reduces to (1+1)-ES
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CmaDimOneBoundaryVerdict {
+    /// At d=1, CMA-ES with sphere/quadratic function converges to optimum
+    /// (final sigma very small, final mean ≈ optimum).
+    Pass,
+    /// Edge case in covariance for scalar — failed to converge.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_cma_dim_one_boundary(
+    final_mean: f64,
+    target_optimum: f64,
+    final_sigma: f64,
+) -> CmaDimOneBoundaryVerdict {
+    if !final_mean.is_finite() || !final_sigma.is_finite() {
+        return CmaDimOneBoundaryVerdict::Fail;
+    }
+    // Final sigma should have decayed (CMA-ES contracts to near optimum).
+    if final_sigma >= 1.0 {
+        return CmaDimOneBoundaryVerdict::Fail;
+    }
+    // Mean should be near target.
+    if (final_mean - target_optimum).abs() >= 0.1 {
+        return CmaDimOneBoundaryVerdict::Fail;
+    }
+    CmaDimOneBoundaryVerdict::Pass
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -------------------------------------------------------------------------
+    // Section 1: Provenance pins.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn provenance_weight_norm_tol_1e_neg10() {
+        assert!((AC_CMA_WEIGHT_NORM_TOLERANCE - 1.0e-10).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn provenance_symmetry_tol_1e_neg10() {
+        assert!((AC_CMA_SYMMETRY_TOLERANCE - 1.0e-10).abs() < f64::EPSILON);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 2: CMA-001 sigma positivity.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fcma001_pass_all_positive() {
+        let s = vec![1.0_f64, 0.5, 0.25, 0.1, 0.01];
+        assert_eq!(
+            verdict_from_cma_sigma_positivity(&s),
+            CmaSigmaPositivityVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fcma001_fail_zero() {
+        let s = vec![1.0_f64, 0.0];
+        assert_eq!(
+            verdict_from_cma_sigma_positivity(&s),
+            CmaSigmaPositivityVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fcma001_fail_negative() {
+        let s = vec![1.0_f64, -1e-10];
+        assert_eq!(
+            verdict_from_cma_sigma_positivity(&s),
+            CmaSigmaPositivityVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fcma001_fail_nan() {
+        let s = vec![1.0_f64, f64::NAN];
+        assert_eq!(
+            verdict_from_cma_sigma_positivity(&s),
+            CmaSigmaPositivityVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fcma001_fail_empty() {
+        assert_eq!(
+            verdict_from_cma_sigma_positivity(&[]),
+            CmaSigmaPositivityVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 3: CMA-002 covariance positive definiteness.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fcma002_pass_all_positive_eigenvalues() {
+        let l = vec![1.0_f64, 0.5, 0.1, 1e-6];
+        assert_eq!(
+            verdict_from_cma_covariance_posdef(&l),
+            CmaCovariancePosDefVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fcma002_fail_zero_eigenvalue() {
+        let l = vec![1.0_f64, 0.0];
+        assert_eq!(
+            verdict_from_cma_covariance_posdef(&l),
+            CmaCovariancePosDefVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fcma002_fail_negative_eigenvalue() {
+        let l = vec![1.0_f64, -1e-10];
+        assert_eq!(
+            verdict_from_cma_covariance_posdef(&l),
+            CmaCovariancePosDefVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 4: CMA-003 weight normalization.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fcma003_pass_uniform_4() {
+        let w = vec![0.25_f64, 0.25, 0.25, 0.25];
+        assert_eq!(
+            verdict_from_cma_weight_normalization(&w),
+            CmaWeightNormalizationVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fcma003_pass_canonical_decreasing() {
+        // Sum carefully: must be exactly within 1e-10 of 1.0.
+        let w = vec![0.5_f64, 0.3, 0.15, 0.05];
+        assert_eq!(
+            verdict_from_cma_weight_normalization(&w),
+            CmaWeightNormalizationVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fcma003_fail_undersum() {
+        let w = vec![0.5_f64, 0.3];
+        assert_eq!(
+            verdict_from_cma_weight_normalization(&w),
+            CmaWeightNormalizationVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fcma003_fail_oversum() {
+        let w = vec![0.5_f64, 0.6];
+        assert_eq!(
+            verdict_from_cma_weight_normalization(&w),
+            CmaWeightNormalizationVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fcma003_fail_empty() {
+        assert_eq!(
+            verdict_from_cma_weight_normalization(&[]),
+            CmaWeightNormalizationVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 5: CMA-004 covariance symmetry.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fcma004_pass_2x2_symmetric() {
+        // [[1, 0.3], [0.3, 2]]
+        let c = vec![1.0_f64, 0.3, 0.3, 2.0];
+        assert_eq!(
+            verdict_from_cma_covariance_symmetry(2, &c),
+            CmaCovarianceSymmetryVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fcma004_pass_3x3_diagonal() {
+        let c = vec![1.0_f64, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 3.0];
+        assert_eq!(
+            verdict_from_cma_covariance_symmetry(3, &c),
+            CmaCovarianceSymmetryVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fcma004_fail_2x2_asymmetric() {
+        // [[1, 0.3], [0.5, 2]] — c01=0.3, c10=0.5 (not equal).
+        let c = vec![1.0_f64, 0.3, 0.5, 2.0];
+        assert_eq!(
+            verdict_from_cma_covariance_symmetry(2, &c),
+            CmaCovarianceSymmetryVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fcma004_fail_zero_dim() {
+        assert_eq!(
+            verdict_from_cma_covariance_symmetry(0, &[]),
+            CmaCovarianceSymmetryVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fcma004_fail_size_mismatch() {
+        let c = vec![1.0_f64, 0.0, 0.0]; // expect dim*dim = 4
+        assert_eq!(
+            verdict_from_cma_covariance_symmetry(2, &c),
+            CmaCovarianceSymmetryVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 6: CMA-005 SIMD equivalence.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fcma005_pass_exact_match() {
+        let s = vec![1.5_f64, 2.5, 3.5];
+        assert_eq!(
+            verdict_from_cma_simd_equivalence(&s, &s),
+            CmaSimdEquivalenceVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fcma005_pass_within_tolerance() {
+        let simd = vec![1.5_f64];
+        let scalar = vec![1.5_f64 + 1e-9];
+        assert_eq!(
+            verdict_from_cma_simd_equivalence(&simd, &scalar),
+            CmaSimdEquivalenceVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fcma005_fail_outside_tolerance() {
+        let simd = vec![1.5_f64];
+        let scalar = vec![1.4_f64];
+        assert_eq!(
+            verdict_from_cma_simd_equivalence(&simd, &scalar),
+            CmaSimdEquivalenceVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fcma005_fail_length_mismatch() {
+        assert_eq!(
+            verdict_from_cma_simd_equivalence(&[1.0], &[1.0, 2.0]),
+            CmaSimdEquivalenceVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 7: CMA-006 d=1 boundary.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fcma006_pass_converged_to_optimum() {
+        // Final mean ≈ 0 (target), sigma decayed.
+        assert_eq!(
+            verdict_from_cma_dim_one_boundary(0.0, 0.0, 1e-6),
+            CmaDimOneBoundaryVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fcma006_pass_near_optimum() {
+        assert_eq!(
+            verdict_from_cma_dim_one_boundary(0.05, 0.0, 0.01),
+            CmaDimOneBoundaryVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fcma006_fail_sigma_too_large() {
+        // Didn't converge — sigma stayed at 1.0.
+        assert_eq!(
+            verdict_from_cma_dim_one_boundary(0.0, 0.0, 1.0),
+            CmaDimOneBoundaryVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fcma006_fail_far_from_optimum() {
+        assert_eq!(
+            verdict_from_cma_dim_one_boundary(5.0, 0.0, 0.01),
+            CmaDimOneBoundaryVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fcma006_fail_nan_mean() {
+        assert_eq!(
+            verdict_from_cma_dim_one_boundary(f64::NAN, 0.0, 0.1),
+            CmaDimOneBoundaryVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 8: Realistic — full healthy CMA-ES run passes all 6.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn realistic_healthy_cma_passes_all_6() {
+        // 1000 generations with monotonically decreasing sigma.
+        let s: Vec<f64> = (0..1000).map(|t| 1.0 / (t as f64 + 1.0)).collect();
+        assert_eq!(
+            verdict_from_cma_sigma_positivity(&s),
+            CmaSigmaPositivityVerdict::Pass
+        );
+        // 100 generations, all eigenvalues > 0.
+        let l = vec![0.5_f64; 100];
+        assert_eq!(
+            verdict_from_cma_covariance_posdef(&l),
+            CmaCovariancePosDefVerdict::Pass
+        );
+        // 4 weights uniform.
+        let w = vec![0.25_f64; 4];
+        assert_eq!(
+            verdict_from_cma_weight_normalization(&w),
+            CmaWeightNormalizationVerdict::Pass
+        );
+        // 2x2 identity covariance.
+        let c = vec![1.0_f64, 0.0, 0.0, 1.0];
+        assert_eq!(
+            verdict_from_cma_covariance_symmetry(2, &c),
+            CmaCovarianceSymmetryVerdict::Pass
+        );
+        // SIMD bit-identical to scalar.
+        let v = vec![1.5_f64, 2.5];
+        assert_eq!(
+            verdict_from_cma_simd_equivalence(&v, &v),
+            CmaSimdEquivalenceVerdict::Pass
+        );
+        // d=1 converged.
+        assert_eq!(
+            verdict_from_cma_dim_one_boundary(0.0, 0.0, 1e-6),
+            CmaDimOneBoundaryVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn realistic_pre_fix_all_6_failures() {
+        // 001: sigma went negative.
+        assert_eq!(
+            verdict_from_cma_sigma_positivity(&[1.0, -0.001]),
+            CmaSigmaPositivityVerdict::Fail
+        );
+        // 002: rank update introduced negative eigenvalue.
+        assert_eq!(
+            verdict_from_cma_covariance_posdef(&[0.5, -0.01]),
+            CmaCovariancePosDefVerdict::Fail
+        );
+        // 003: weights formula bug.
+        assert_eq!(
+            verdict_from_cma_weight_normalization(&[0.5, 0.6]),
+            CmaWeightNormalizationVerdict::Fail
+        );
+        // 004: asymmetric C.
+        let bad = vec![1.0_f64, 0.3, 0.5, 2.0];
+        assert_eq!(
+            verdict_from_cma_covariance_symmetry(2, &bad),
+            CmaCovarianceSymmetryVerdict::Fail
+        );
+        // 005: SIMD Cholesky differs.
+        assert_eq!(
+            verdict_from_cma_simd_equivalence(&[1.5], &[1.0]),
+            CmaSimdEquivalenceVerdict::Fail
+        );
+        // 006: d=1 didn't converge.
+        assert_eq!(
+            verdict_from_cma_dim_one_boundary(10.0, 0.0, 5.0),
+            CmaDimOneBoundaryVerdict::Fail
+        );
+    }
+}

--- a/crates/aprender-core/src/format/codegen_001_002.rs
+++ b/crates/aprender-core/src/format/codegen_001_002.rs
@@ -1,0 +1,225 @@
+// `codegen-dispatch-v1` algorithm-level PARTIAL discharge for the 2
+// runtime-SIMD-dispatch falsifiers (scalar fallback safety, dispatch
+// determinism).
+//
+// Contract: `contracts/codegen-dispatch-v1.yaml`.
+
+/// Tolerance for "scalar matches reference" check (8 ULP — same as
+/// avx2-fma-dot-v1).
+pub const AC_CODEGEN_FALLBACK_TOLERANCE: f32 = 1.0e-5;
+
+// =============================================================================
+// FALSIFY-CODEGEN_DISPATCH_V1_001 — scalar fallback safety
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CodegenFallbackVerdict {
+    /// Scalar fallback output matches reference within tolerance for
+    /// every input in the test corpus.
+    Pass,
+    /// Scalar diverges from reference on at least one input.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_codegen_fallback(scalar_outputs: &[f32], reference_outputs: &[f32]) -> CodegenFallbackVerdict {
+    if scalar_outputs.len() != reference_outputs.len() {
+        return CodegenFallbackVerdict::Fail;
+    }
+    if scalar_outputs.is_empty() {
+        return CodegenFallbackVerdict::Fail;
+    }
+    for (a, b) in scalar_outputs.iter().zip(reference_outputs.iter()) {
+        if !a.is_finite() || !b.is_finite() {
+            return CodegenFallbackVerdict::Fail;
+        }
+        if (a - b).abs() >= AC_CODEGEN_FALLBACK_TOLERANCE {
+            return CodegenFallbackVerdict::Fail;
+        }
+    }
+    CodegenFallbackVerdict::Pass
+}
+
+// =============================================================================
+// FALSIFY-CODEGEN_DISPATCH_V1_002 — dispatch determinism
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CodegenDispatchDeterminismVerdict {
+    /// Same hardware fingerprint ⇒ same kernel selected across N calls.
+    Pass,
+    /// Two calls on identical hardware selected different kernels.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_codegen_dispatch_determinism(selected_kernels: &[&str]) -> CodegenDispatchDeterminismVerdict {
+    if selected_kernels.is_empty() {
+        return CodegenDispatchDeterminismVerdict::Fail;
+    }
+    let first = selected_kernels[0];
+    for k in selected_kernels.iter().skip(1) {
+        if *k != first {
+            return CodegenDispatchDeterminismVerdict::Fail;
+        }
+    }
+    CodegenDispatchDeterminismVerdict::Pass
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -------------------------------------------------------------------------
+    // Section 1: Provenance pin.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn provenance_fallback_tolerance_1e_neg5() {
+        assert!((AC_CODEGEN_FALLBACK_TOLERANCE - 1.0e-5).abs() < f32::EPSILON);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 2: CODEGEN-001 scalar fallback safety.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fcg001_pass_exact_match() {
+        let v = vec![1.0_f32, 2.0, 3.0];
+        assert_eq!(
+            verdict_from_codegen_fallback(&v, &v),
+            CodegenFallbackVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fcg001_pass_within_tolerance() {
+        let scalar = vec![1.000001_f32];
+        let reference = vec![1.0_f32];
+        assert_eq!(
+            verdict_from_codegen_fallback(&scalar, &reference),
+            CodegenFallbackVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fcg001_fail_outside_tolerance() {
+        let scalar = vec![1.5_f32];
+        let reference = vec![1.0_f32];
+        assert_eq!(
+            verdict_from_codegen_fallback(&scalar, &reference),
+            CodegenFallbackVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fcg001_fail_length_mismatch() {
+        assert_eq!(
+            verdict_from_codegen_fallback(&[1.0], &[1.0, 2.0]),
+            CodegenFallbackVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fcg001_fail_nan() {
+        assert_eq!(
+            verdict_from_codegen_fallback(&[f32::NAN], &[1.0]),
+            CodegenFallbackVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fcg001_fail_empty() {
+        assert_eq!(
+            verdict_from_codegen_fallback(&[], &[]),
+            CodegenFallbackVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 3: CODEGEN-002 dispatch determinism.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fcg002_pass_all_same_kernel() {
+        let k = ["avx512", "avx512", "avx512", "avx512"];
+        assert_eq!(
+            verdict_from_codegen_dispatch_determinism(&k),
+            CodegenDispatchDeterminismVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fcg002_pass_single_call() {
+        let k = ["scalar"];
+        assert_eq!(
+            verdict_from_codegen_dispatch_determinism(&k),
+            CodegenDispatchDeterminismVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fcg002_fail_kernel_changed() {
+        let k = ["avx512", "avx2"];
+        assert_eq!(
+            verdict_from_codegen_dispatch_determinism(&k),
+            CodegenDispatchDeterminismVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fcg002_fail_third_call_diverged() {
+        let k = ["avx512", "avx512", "scalar"];
+        assert_eq!(
+            verdict_from_codegen_dispatch_determinism(&k),
+            CodegenDispatchDeterminismVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fcg002_fail_empty() {
+        let empty: [&str; 0] = [];
+        assert_eq!(
+            verdict_from_codegen_dispatch_determinism(&empty),
+            CodegenDispatchDeterminismVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 4: Realistic — full healthy SIMD dispatch passes both.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn realistic_healthy_dispatch_passes_both() {
+        // 1024-element output, scalar matches AVX-512 reference.
+        let v: Vec<f32> = (0..1024).map(|i| i as f32 + 1e-7).collect();
+        let r: Vec<f32> = (0..1024).map(|i| i as f32).collect();
+        assert_eq!(
+            verdict_from_codegen_fallback(&v, &r),
+            CodegenFallbackVerdict::Pass
+        );
+
+        // 100 calls all selected avx2 (uniform hardware).
+        let calls = vec!["avx2"; 100];
+        assert_eq!(
+            verdict_from_codegen_dispatch_determinism(&calls),
+            CodegenDispatchDeterminismVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn realistic_pre_fix_both_failures() {
+        // Bug class 001: scalar produced different result for one element.
+        let mut scalar: Vec<f32> = (0..1024).map(|i| i as f32).collect();
+        scalar[512] += 0.5;
+        let reference: Vec<f32> = (0..1024).map(|i| i as f32).collect();
+        assert_eq!(
+            verdict_from_codegen_fallback(&scalar, &reference),
+            CodegenFallbackVerdict::Fail
+        );
+
+        // Bug class 002: kernel selection raced — call 50 picked scalar.
+        let mut calls = vec!["avx2"; 100];
+        calls[50] = "scalar";
+        assert_eq!(
+            verdict_from_codegen_dispatch_determinism(&calls),
+            CodegenDispatchDeterminismVerdict::Fail
+        );
+    }
+}

--- a/crates/aprender-core/src/format/comp_001_002.rs
+++ b/crates/aprender-core/src/format/comp_001_002.rs
@@ -1,0 +1,241 @@
+// `compression-roundtrip-v1` algorithm-level PARTIAL discharge for the
+// 2 LZ4/Zstd lossless-roundtrip falsifiers.
+//
+// Contract: `contracts/compression-roundtrip-v1.yaml`.
+// Refs: LZ4 Frame format spec, Zstd compression format spec.
+//
+// ## What this file proves NOW (`PARTIAL_ALGORITHM_LEVEL`)
+//
+// Two pure decision predicates over (original_bytes, decompressed_bytes)
+// pairs. Live discharge wraps these around the actual lz4/zstd
+// implementations. Algorithm-level pinning prevents drift on the
+// "byte-level equality, not floating-point tolerance" invariant.
+
+/// LZ4 frame overhead estimate (~16 bytes per spec).
+pub const AC_COMP_LZ4_OVERHEAD_BYTES: u32 = 16;
+
+/// Zstd frame overhead estimate (~18 bytes per spec).
+pub const AC_COMP_ZSTD_OVERHEAD_BYTES: u32 = 18;
+
+// =============================================================================
+// FALSIFY-COMP-001 — LZ4 lossless roundtrip
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Lz4LosslessVerdict {
+    /// decompress(compress(data)) == data byte-for-byte AND
+    /// compressed_size <= original_size + LZ4_OVERHEAD.
+    Pass,
+    /// Either roundtrip diverges OR compressed size exceeds budget.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_lz4_lossless(
+    original: &[u8],
+    decompressed: &[u8],
+    compressed_size: u32,
+) -> Lz4LosslessVerdict {
+    if original != decompressed {
+        return Lz4LosslessVerdict::Fail;
+    }
+    let budget = original.len() as u64 + AC_COMP_LZ4_OVERHEAD_BYTES as u64;
+    if compressed_size as u64 > budget {
+        return Lz4LosslessVerdict::Fail;
+    }
+    Lz4LosslessVerdict::Pass
+}
+
+// =============================================================================
+// FALSIFY-COMP-002 — Zstd lossless roundtrip
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ZstdLosslessVerdict {
+    /// decompress(compress(data)) == data byte-for-byte AND
+    /// compressed_size <= original_size + ZSTD_OVERHEAD.
+    Pass,
+    /// Roundtrip diverges or size exceeds budget.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_zstd_lossless(
+    original: &[u8],
+    decompressed: &[u8],
+    compressed_size: u32,
+) -> ZstdLosslessVerdict {
+    if original != decompressed {
+        return ZstdLosslessVerdict::Fail;
+    }
+    let budget = original.len() as u64 + AC_COMP_ZSTD_OVERHEAD_BYTES as u64;
+    if compressed_size as u64 > budget {
+        return ZstdLosslessVerdict::Fail;
+    }
+    ZstdLosslessVerdict::Pass
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -------------------------------------------------------------------------
+    // Section 1: Provenance pins.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn provenance_lz4_overhead_16() {
+        assert_eq!(AC_COMP_LZ4_OVERHEAD_BYTES, 16);
+    }
+
+    #[test]
+    fn provenance_zstd_overhead_18() {
+        assert_eq!(AC_COMP_ZSTD_OVERHEAD_BYTES, 18);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 2: COMP-001 LZ4 lossless.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fc001_pass_identity_compressible() {
+        // 1024-byte zeros → highly compressible.
+        let data = vec![0u8; 1024];
+        assert_eq!(
+            verdict_from_lz4_lossless(&data, &data, 50),
+            Lz4LosslessVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fc001_pass_incompressible() {
+        // Random data: compressed_size ≈ original + 16 overhead.
+        let data: Vec<u8> = (0..1024).map(|i| (i % 256) as u8).collect();
+        assert_eq!(
+            verdict_from_lz4_lossless(&data, &data, 1024 + 16),
+            Lz4LosslessVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fc001_pass_empty() {
+        let data: Vec<u8> = vec![];
+        // Empty: compressed = overhead (16).
+        assert_eq!(
+            verdict_from_lz4_lossless(&data, &data, 16),
+            Lz4LosslessVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fc001_fail_byte_drift() {
+        let original = vec![0u8, 1, 2, 3];
+        let decompressed = vec![0u8, 1, 2, 99]; // last byte wrong
+        assert_eq!(
+            verdict_from_lz4_lossless(&original, &decompressed, 100),
+            Lz4LosslessVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fc001_fail_length_drift() {
+        let original = vec![0u8; 10];
+        let decompressed = vec![0u8; 9]; // truncated by 1
+        assert_eq!(
+            verdict_from_lz4_lossless(&original, &decompressed, 50),
+            Lz4LosslessVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fc001_fail_compressed_exceeds_budget() {
+        // 1024 + 16 = 1040 budget; 2000 exceeds.
+        let data = vec![0u8; 1024];
+        assert_eq!(
+            verdict_from_lz4_lossless(&data, &data, 2000),
+            Lz4LosslessVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 3: COMP-002 Zstd lossless.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fz002_pass_identity_compressible() {
+        let data = vec![0u8; 1024];
+        assert_eq!(
+            verdict_from_zstd_lossless(&data, &data, 30),
+            ZstdLosslessVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fz002_pass_incompressible() {
+        let data: Vec<u8> = (0..1024).map(|i| (i % 256) as u8).collect();
+        assert_eq!(
+            verdict_from_zstd_lossless(&data, &data, 1024 + 18),
+            ZstdLosslessVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fz002_pass_empty() {
+        let data: Vec<u8> = vec![];
+        assert_eq!(
+            verdict_from_zstd_lossless(&data, &data, 18),
+            ZstdLosslessVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fz002_fail_byte_drift() {
+        let original = vec![1u8, 2, 3];
+        let decompressed = vec![1u8, 2, 4];
+        assert_eq!(
+            verdict_from_zstd_lossless(&original, &decompressed, 100),
+            ZstdLosslessVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fz002_fail_compressed_exceeds_budget() {
+        let data = vec![0u8; 100];
+        // Budget = 100 + 18 = 118; 200 exceeds.
+        assert_eq!(
+            verdict_from_zstd_lossless(&data, &data, 200),
+            ZstdLosslessVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 4: Realistic — full healthy compression passes both.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn realistic_healthy_roundtrip_passes_both() {
+        // 100 MB tensor data, compressible 50:1 with LZ4, 100:1 with Zstd.
+        let data = vec![0u8; 100_000_000];
+        assert_eq!(
+            verdict_from_lz4_lossless(&data, &data, 2_000_000),
+            Lz4LosslessVerdict::Pass
+        );
+        assert_eq!(
+            verdict_from_zstd_lossless(&data, &data, 1_000_000),
+            ZstdLosslessVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn realistic_pre_fix_both_failures() {
+        // LZ4 dropped a byte at end of stream.
+        let original = vec![1u8, 2, 3, 4, 5];
+        let lz4_decompressed = vec![1u8, 2, 3, 4]; // truncated
+        assert_eq!(
+            verdict_from_lz4_lossless(&original, &lz4_decompressed, 50),
+            Lz4LosslessVerdict::Fail
+        );
+        // Zstd corrupted middle byte.
+        let zstd_decompressed = vec![1u8, 2, 99, 4, 5];
+        assert_eq!(
+            verdict_from_zstd_lossless(&original, &zstd_decompressed, 50),
+            ZstdLosslessVerdict::Fail
+        );
+    }
+}

--- a/crates/aprender-core/src/format/comparehf_001_003.rs
+++ b/crates/aprender-core/src/format/comparehf_001_003.rs
@@ -1,0 +1,328 @@
+// `apr-compare-hf-nonvacuous-v1` algorithm-level PARTIAL discharge for
+// the 3 vacuous-truth-prevention falsifiers (0-tensor exit non-zero,
+// no PASS phrase on 0 tensors, mapping diagnostic on 0 tensors).
+//
+// Contract: `contracts/apr-compare-hf-nonvacuous-v1.yaml`.
+// Refs: paiml/aprender#621 (`compare-hf reports '✓ All tensors match'
+// when it compared 0 tensors`).
+//
+// ## What this file proves NOW (`PARTIAL_ALGORITHM_LEVEL`)
+//
+// Three pure decision predicates that pin the contract's invariants:
+// vacuous truth at the library level (∀ ∅ = true) MUST be guarded at
+// the CLI boundary. A user running `apr compare-hf` wants to VERIFY,
+// and "verified nothing" is not a successful verification.
+
+/// PASS-phrase tokens that MUST NOT appear on 0-tensor output.
+pub const AC_COMPAREHF_FORBIDDEN_PASS_PHRASES: [&str; 2] =
+    ["all tensors match", "✓"];
+
+/// Diagnostic-keyword set that MUST appear on 0-tensor output.
+pub const AC_COMPAREHF_REQUIRED_DIAGNOSTIC_KEYWORDS: [&str; 4] =
+    ["mapping", "no tensors matched", "0 tensors", "name-mapping"];
+
+// =============================================================================
+// FALSIFY-COMPARE-HF-001 — 0-tensor comparison exits non-zero
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NonzeroExitOnVacuousVerdict {
+    /// total_compared == 0 ⇒ exit_code != 0.
+    /// total_compared >= 1 ⇒ exit_code reflects pass/fail (any value).
+    Pass,
+    /// total_compared == 0 AND exit_code == 0 — vacuous PASS.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_nonzero_exit_on_vacuous(
+    total_compared: u32,
+    exit_code: i32,
+) -> NonzeroExitOnVacuousVerdict {
+    if total_compared == 0 && exit_code == 0 {
+        NonzeroExitOnVacuousVerdict::Fail
+    } else {
+        NonzeroExitOnVacuousVerdict::Pass
+    }
+}
+
+// =============================================================================
+// FALSIFY-COMPARE-HF-002 — no PASS phrase on 0-tensor output
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NoPassPhraseOnVacuousVerdict {
+    /// 0-tensor case: output does NOT contain "all tensors match" / "✓".
+    /// Non-zero compared: any text is acceptable.
+    Pass,
+    /// 0-tensor case but PASS phrase leaked.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_no_pass_phrase_on_vacuous(
+    total_compared: u32,
+    output: &str,
+) -> NoPassPhraseOnVacuousVerdict {
+    if total_compared > 0 {
+        return NoPassPhraseOnVacuousVerdict::Pass;
+    }
+    let lower = output.to_lowercase();
+    for phrase in AC_COMPAREHF_FORBIDDEN_PASS_PHRASES {
+        if lower.contains(phrase) {
+            return NoPassPhraseOnVacuousVerdict::Fail;
+        }
+    }
+    NoPassPhraseOnVacuousVerdict::Pass
+}
+
+// =============================================================================
+// FALSIFY-COMPARE-HF-003 — mapping diagnostic on 0-tensor output
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MappingDiagnosticVerdict {
+    /// 0-tensor case: output contains a mapping/zero-tensors hint.
+    /// Non-zero compared: any text is acceptable.
+    Pass,
+    /// 0-tensor case but no diagnostic keyword found.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_mapping_diagnostic(
+    total_compared: u32,
+    output: &str,
+) -> MappingDiagnosticVerdict {
+    if total_compared > 0 {
+        return MappingDiagnosticVerdict::Pass;
+    }
+    let lower = output.to_lowercase();
+    for kw in AC_COMPAREHF_REQUIRED_DIAGNOSTIC_KEYWORDS {
+        if lower.contains(kw) {
+            return MappingDiagnosticVerdict::Pass;
+        }
+    }
+    MappingDiagnosticVerdict::Fail
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -------------------------------------------------------------------------
+    // Section 1: Provenance pins.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn provenance_forbidden_pass_phrases_count_2() {
+        assert_eq!(AC_COMPAREHF_FORBIDDEN_PASS_PHRASES.len(), 2);
+    }
+
+    #[test]
+    fn provenance_required_diagnostics_count_4() {
+        assert_eq!(AC_COMPAREHF_REQUIRED_DIAGNOSTIC_KEYWORDS.len(), 4);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 2: COMPARE-HF-001 non-zero exit on vacuous.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fc001_pass_zero_compared_nonzero_exit() {
+        assert_eq!(
+            verdict_from_nonzero_exit_on_vacuous(0, 1),
+            NonzeroExitOnVacuousVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fc001_pass_one_compared_zero_exit() {
+        // Non-vacuous comparison; exit 0 is fine if all passed.
+        assert_eq!(
+            verdict_from_nonzero_exit_on_vacuous(1, 0),
+            NonzeroExitOnVacuousVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fc001_pass_many_compared_failed_exit() {
+        // Non-vacuous comparison with some failures: non-zero exit OK.
+        assert_eq!(
+            verdict_from_nonzero_exit_on_vacuous(339, 1),
+            NonzeroExitOnVacuousVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fc001_fail_zero_compared_zero_exit() {
+        // The exact GH-621 regression class.
+        assert_eq!(
+            verdict_from_nonzero_exit_on_vacuous(0, 0),
+            NonzeroExitOnVacuousVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 3: COMPARE-HF-002 no PASS phrase on vacuous.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fc002_pass_nonvacuous_with_pass_phrase() {
+        // Non-vacuous + "all tensors match" is correct.
+        let out = "Total tensors compared: 339\n✓ All tensors match within threshold!";
+        assert_eq!(
+            verdict_from_no_pass_phrase_on_vacuous(339, out),
+            NoPassPhraseOnVacuousVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fc002_pass_vacuous_with_error_text() {
+        // Vacuous with error text (no PASS phrase).
+        let out = "Total tensors compared: 0\nError: tensor name mapping failed";
+        assert_eq!(
+            verdict_from_no_pass_phrase_on_vacuous(0, out),
+            NoPassPhraseOnVacuousVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fc002_fail_vacuous_with_pass_phrase() {
+        // The exact regression: 0 compared but "All tensors match" emitted.
+        let out = "Total tensors compared: 0\n✓ All tensors match within threshold!";
+        assert_eq!(
+            verdict_from_no_pass_phrase_on_vacuous(0, out),
+            NoPassPhraseOnVacuousVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fc002_fail_vacuous_with_only_checkmark() {
+        let out = "Total: 0\n✓";
+        assert_eq!(
+            verdict_from_no_pass_phrase_on_vacuous(0, out),
+            NoPassPhraseOnVacuousVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fc002_fail_case_insensitive_pass_phrase() {
+        let out = "Total: 0\nALL TENSORS MATCH";
+        assert_eq!(
+            verdict_from_no_pass_phrase_on_vacuous(0, out),
+            NoPassPhraseOnVacuousVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 4: COMPARE-HF-003 mapping diagnostic on vacuous.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fc003_pass_nonvacuous_no_diagnostic_required() {
+        let out = "Total: 339\n✓ All match";
+        assert_eq!(
+            verdict_from_mapping_diagnostic(339, out),
+            MappingDiagnosticVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fc003_pass_vacuous_with_mapping_keyword() {
+        let out = "Total: 0\nError: name mapping issue between GGUF and HF";
+        assert_eq!(
+            verdict_from_mapping_diagnostic(0, out),
+            MappingDiagnosticVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fc003_pass_vacuous_with_zero_tensors_keyword() {
+        let out = "Total: 0\nError: 0 tensors matched any name pattern";
+        assert_eq!(
+            verdict_from_mapping_diagnostic(0, out),
+            MappingDiagnosticVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fc003_pass_vacuous_with_no_tensors_matched_keyword() {
+        let out = "Total: 0\nNo tensors matched between local and HF.";
+        assert_eq!(
+            verdict_from_mapping_diagnostic(0, out),
+            MappingDiagnosticVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fc003_fail_vacuous_no_diagnostic() {
+        // The regression: 0 compared but no hint why.
+        let out = "Total: 0\nDone.";
+        assert_eq!(
+            verdict_from_mapping_diagnostic(0, out),
+            MappingDiagnosticVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fc003_fail_vacuous_empty_output() {
+        assert_eq!(
+            verdict_from_mapping_diagnostic(0, ""),
+            MappingDiagnosticVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 5: Realistic — full healthy run + GH-621 regression.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn realistic_healthy_compare_passes_all_3() {
+        // Successful 339-tensor comparison.
+        let out = "Total tensors compared: 339\n✓ All tensors match within threshold!";
+        assert_eq!(
+            verdict_from_nonzero_exit_on_vacuous(339, 0),
+            NonzeroExitOnVacuousVerdict::Pass
+        );
+        assert_eq!(
+            verdict_from_no_pass_phrase_on_vacuous(339, out),
+            NoPassPhraseOnVacuousVerdict::Pass
+        );
+        assert_eq!(
+            verdict_from_mapping_diagnostic(339, out),
+            MappingDiagnosticVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn realistic_healthy_zero_tensor_with_diagnostic_passes_all_3() {
+        // Post-fix: 0 tensors with non-zero exit + diagnostic + no PASS phrase.
+        let out = "Total tensors compared: 0\nError: tensor name mapping returned 0 matches between local GGUF and HF.";
+        assert_eq!(
+            verdict_from_nonzero_exit_on_vacuous(0, 1),
+            NonzeroExitOnVacuousVerdict::Pass
+        );
+        assert_eq!(
+            verdict_from_no_pass_phrase_on_vacuous(0, out),
+            NoPassPhraseOnVacuousVerdict::Pass
+        );
+        assert_eq!(
+            verdict_from_mapping_diagnostic(0, out),
+            MappingDiagnosticVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn realistic_pre_fix_gh_621_all_3_fail() {
+        // The exact GH-621 symptom string.
+        let out = "Total tensors compared: 0\n✓ All tensors match within threshold!";
+        assert_eq!(
+            verdict_from_nonzero_exit_on_vacuous(0, 0),
+            NonzeroExitOnVacuousVerdict::Fail
+        );
+        assert_eq!(
+            verdict_from_no_pass_phrase_on_vacuous(0, out),
+            NoPassPhraseOnVacuousVerdict::Fail
+        );
+        assert_eq!(
+            verdict_from_mapping_diagnostic(0, out),
+            MappingDiagnosticVerdict::Fail
+        );
+    }
+}

--- a/crates/aprender-core/src/format/ctxgen_001_002.rs
+++ b/crates/aprender-core/src/format/ctxgen_001_002.rs
@@ -1,0 +1,198 @@
+// `context-generation-v1` algorithm-level PARTIAL discharge for the 2
+// RAG context-generation falsifiers (relevance ordering, context budget).
+//
+// Contract: `contracts/context-generation-v1.yaml`.
+
+// =============================================================================
+// FALSIFY-CONTEXT_GENERATION_V1_001 — relevance descending order
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CtxRelevanceOrderingVerdict {
+    /// retrieved_docs.scores sorted in descending order.
+    Pass,
+    /// At least one adjacent pair is out of order.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_ctx_relevance_ordering(scores: &[f32]) -> CtxRelevanceOrderingVerdict {
+    if scores.is_empty() {
+        return CtxRelevanceOrderingVerdict::Fail;
+    }
+    for window in scores.windows(2) {
+        let (a, b) = (window[0], window[1]);
+        if !a.is_finite() || !b.is_finite() {
+            return CtxRelevanceOrderingVerdict::Fail;
+        }
+        if a < b {
+            return CtxRelevanceOrderingVerdict::Fail;
+        }
+    }
+    CtxRelevanceOrderingVerdict::Pass
+}
+
+// =============================================================================
+// FALSIFY-CONTEXT_GENERATION_V1_002 — context budget
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CtxBudgetVerdict {
+    /// Σ tokens(doc_i) ≤ max_context_length.
+    Pass,
+    /// Tokens exceed budget — context window overflow.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_ctx_budget(per_doc_tokens: &[u32], max_context_length: u32) -> CtxBudgetVerdict {
+    if max_context_length == 0 {
+        return CtxBudgetVerdict::Fail;
+    }
+    let total: u64 = per_doc_tokens.iter().map(|&t| t as u64).sum();
+    if total <= max_context_length as u64 {
+        CtxBudgetVerdict::Pass
+    } else {
+        CtxBudgetVerdict::Fail
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -------------------------------------------------------------------------
+    // Section 1: CTX-001 relevance ordering.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fctx001_pass_descending() {
+        let s = vec![0.99_f32, 0.85, 0.42, 0.10];
+        assert_eq!(
+            verdict_from_ctx_relevance_ordering(&s),
+            CtxRelevanceOrderingVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fctx001_pass_equal_adjacent() {
+        // Ties are descending-or-equal; PASS per "sorted by descending".
+        let s = vec![0.5_f32, 0.5, 0.3];
+        assert_eq!(
+            verdict_from_ctx_relevance_ordering(&s),
+            CtxRelevanceOrderingVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fctx001_pass_single() {
+        let s = vec![0.7_f32];
+        assert_eq!(
+            verdict_from_ctx_relevance_ordering(&s),
+            CtxRelevanceOrderingVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fctx001_fail_ascending_pair() {
+        let s = vec![0.5_f32, 0.7];
+        assert_eq!(
+            verdict_from_ctx_relevance_ordering(&s),
+            CtxRelevanceOrderingVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fctx001_fail_one_inversion() {
+        let s = vec![0.9_f32, 0.8, 0.85, 0.5];
+        assert_eq!(
+            verdict_from_ctx_relevance_ordering(&s),
+            CtxRelevanceOrderingVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fctx001_fail_nan() {
+        let s = vec![0.9_f32, f32::NAN];
+        assert_eq!(
+            verdict_from_ctx_relevance_ordering(&s),
+            CtxRelevanceOrderingVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fctx001_fail_empty() {
+        assert_eq!(
+            verdict_from_ctx_relevance_ordering(&[]),
+            CtxRelevanceOrderingVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 2: CTX-002 context budget.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fctx002_pass_under_budget() {
+        let t = vec![100u32, 200, 300, 400];
+        assert_eq!(verdict_from_ctx_budget(&t, 4096), CtxBudgetVerdict::Pass);
+    }
+
+    #[test]
+    fn fctx002_pass_at_budget() {
+        let t = vec![1024u32, 1024, 1024, 1024];
+        assert_eq!(verdict_from_ctx_budget(&t, 4096), CtxBudgetVerdict::Pass);
+    }
+
+    #[test]
+    fn fctx002_pass_empty_zero_total() {
+        let t: Vec<u32> = vec![];
+        assert_eq!(verdict_from_ctx_budget(&t, 4096), CtxBudgetVerdict::Pass);
+    }
+
+    #[test]
+    fn fctx002_fail_over_budget() {
+        let t = vec![2048u32, 2048, 1];
+        assert_eq!(verdict_from_ctx_budget(&t, 4096), CtxBudgetVerdict::Fail);
+    }
+
+    #[test]
+    fn fctx002_fail_zero_max() {
+        let t = vec![1u32];
+        assert_eq!(verdict_from_ctx_budget(&t, 0), CtxBudgetVerdict::Fail);
+    }
+
+    #[test]
+    fn fctx002_pass_large_budget_qwen3_30b() {
+        // Qwen3-Coder-30B max_context = 256k, single 100k doc.
+        let t = vec![100_000u32];
+        assert_eq!(verdict_from_ctx_budget(&t, 262_144), CtxBudgetVerdict::Pass);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 3: Realistic — full healthy RAG passes both.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn realistic_healthy_rag_passes_both() {
+        // 5 docs, monotonically descending relevance, total 4000 tokens.
+        let scores = vec![0.95_f32, 0.87, 0.62, 0.41, 0.18];
+        assert_eq!(
+            verdict_from_ctx_relevance_ordering(&scores),
+            CtxRelevanceOrderingVerdict::Pass
+        );
+        let tokens = vec![800u32, 1000, 800, 600, 800];
+        assert_eq!(verdict_from_ctx_budget(&tokens, 4096), CtxBudgetVerdict::Pass);
+    }
+
+    #[test]
+    fn realistic_pre_fix_both_failures() {
+        // Bug class 001: ranking pipeline emitted in ascending order.
+        let bad_order = vec![0.1_f32, 0.5, 0.95];
+        assert_eq!(
+            verdict_from_ctx_relevance_ordering(&bad_order),
+            CtxRelevanceOrderingVerdict::Fail
+        );
+        // Bug class 002: token-budget guard skipped → 8192 tokens emitted into
+        // a 4096-token context window.
+        let bad_budget = vec![4096u32, 4096];
+        assert_eq!(verdict_from_ctx_budget(&bad_budget, 4096), CtxBudgetVerdict::Fail);
+    }
+}

--- a/crates/aprender-core/src/format/dot_001_005.rs
+++ b/crates/aprender-core/src/format/dot_001_005.rs
@@ -1,0 +1,399 @@
+// `avx2-fma-dot-v1` algorithm-level PARTIAL discharge for the 5
+// AVX2+FMA dot-product falsifiers (scalar equivalence, empty/unit base
+// case, decoder dimension match, commutativity, NaN propagation).
+//
+// Contract: `contracts/avx2-fma-dot-v1.yaml`.
+// Refs: Intel 64 Optimization Manual §11.6 FMA, Agner Fog (2024)
+// Instruction Tables (vfmadd231ps: 4-5c latency, 0.5c throughput).
+
+/// Tolerance budget for SIMD-vs-scalar equivalence (4 ULP per contract).
+/// At f32 with values ~1.0, 4 ULP ≈ 4 * 2^-23 ≈ 4.77e-7. We use a
+/// conservative 4.0 absolute tolerance for the `proof_obligations`
+/// `tolerance: 4.0` line.
+pub const AC_DOT_SIMD_TOLERANCE_ABS: f32 = 4.0;
+
+/// Commutativity tolerance per `proof_obligations`.
+pub const AC_DOT_COMMUT_TOLERANCE: f32 = 1.0e-6;
+
+/// Whisper-tiny canonical decoder dimensions per FALSIFY-DOT-003.
+pub const AC_DOT_WHISPER_D_MODEL: usize = 384;
+pub const AC_DOT_WHISPER_D_FF: usize = 1536;
+
+// =============================================================================
+// FALSIFY-DOT-001 — SIMD matches scalar (within 4 ULP)
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DotScalarEquivalenceVerdict {
+    /// |dot_simd - dot_scalar| < 4 absolute.
+    Pass,
+    /// Above tolerance.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_dot_scalar_equivalence(simd: f32, scalar: f32) -> DotScalarEquivalenceVerdict {
+    if !simd.is_finite() && !scalar.is_finite() {
+        // NaN/inf comparison handled by gate 005; treat divergent NaN
+        // signals as out-of-scope here.
+        return DotScalarEquivalenceVerdict::Pass;
+    }
+    if (simd - scalar).abs() < AC_DOT_SIMD_TOLERANCE_ABS {
+        DotScalarEquivalenceVerdict::Pass
+    } else {
+        DotScalarEquivalenceVerdict::Fail
+    }
+}
+
+// =============================================================================
+// FALSIFY-DOT-002 — empty and unit base cases
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DotBaseCaseVerdict {
+    /// dot([], []) == 0.0 AND dot([x], [y]) == x*y exactly.
+    Pass,
+    /// Either case wrong.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_dot_base_case(empty_result: f32, unit_x: f32, unit_y: f32, unit_result: f32) -> DotBaseCaseVerdict {
+    if empty_result != 0.0 {
+        return DotBaseCaseVerdict::Fail;
+    }
+    let expected = unit_x * unit_y;
+    // Exact equality (the contract test is "exact equality tests").
+    if expected.is_nan() {
+        if !unit_result.is_nan() {
+            return DotBaseCaseVerdict::Fail;
+        }
+    } else if unit_result != expected {
+        return DotBaseCaseVerdict::Fail;
+    }
+    DotBaseCaseVerdict::Pass
+}
+
+// =============================================================================
+// FALSIFY-DOT-003 — decoder dimensions match scalar
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DotDecoderDimVerdict {
+    /// SIMD matches scalar at d_model=384 AND d_ff=1536 within tolerance.
+    Pass,
+    /// Mismatch at either alignment boundary.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_dot_decoder_dim(
+    simd_at_dmodel: f32,
+    scalar_at_dmodel: f32,
+    simd_at_dff: f32,
+    scalar_at_dff: f32,
+) -> DotDecoderDimVerdict {
+    if (simd_at_dmodel - scalar_at_dmodel).abs() >= AC_DOT_SIMD_TOLERANCE_ABS {
+        return DotDecoderDimVerdict::Fail;
+    }
+    if (simd_at_dff - scalar_at_dff).abs() >= AC_DOT_SIMD_TOLERANCE_ABS {
+        return DotDecoderDimVerdict::Fail;
+    }
+    DotDecoderDimVerdict::Pass
+}
+
+// =============================================================================
+// FALSIFY-DOT-004 — commutativity
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DotCommutativityVerdict {
+    /// |dot(a,b) - dot(b,a)| < 1e-6.
+    Pass,
+    /// Asymmetric — accumulation order leaked.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_dot_commutativity(dot_ab: f32, dot_ba: f32) -> DotCommutativityVerdict {
+    if (dot_ab - dot_ba).abs() < AC_DOT_COMMUT_TOLERANCE {
+        DotCommutativityVerdict::Pass
+    } else {
+        DotCommutativityVerdict::Fail
+    }
+}
+
+// =============================================================================
+// FALSIFY-DOT-005 — NaN propagation
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DotNanPropagationVerdict {
+    /// dot input contains NaN ⇒ dot output is NaN.
+    Pass,
+    /// NaN silently dropped in SIMD lane.
+    Fail,
+}
+
+#[must_use]
+pub fn verdict_from_dot_nan_propagation(input_has_nan: bool, output_is_nan: bool) -> DotNanPropagationVerdict {
+    match (input_has_nan, output_is_nan) {
+        (true, true) => DotNanPropagationVerdict::Pass,
+        (true, false) => DotNanPropagationVerdict::Fail,
+        // No NaN in input → output should NOT be NaN. (NaN-from-nowhere is
+        // a different bug; this gate only catches NaN-loss.)
+        (false, _) => DotNanPropagationVerdict::Pass,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -------------------------------------------------------------------------
+    // Section 1: Provenance pins.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn provenance_simd_tolerance_4_0() {
+        assert!((AC_DOT_SIMD_TOLERANCE_ABS - 4.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn provenance_commut_tolerance_1e_neg6() {
+        assert!((AC_DOT_COMMUT_TOLERANCE - 1.0e-6).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn provenance_whisper_d_model_384() {
+        assert_eq!(AC_DOT_WHISPER_D_MODEL, 384);
+    }
+
+    #[test]
+    fn provenance_whisper_d_ff_1536() {
+        assert_eq!(AC_DOT_WHISPER_D_FF, 1536);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 2: DOT-001 SIMD-vs-scalar equivalence.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fd001_pass_exact_match() {
+        assert_eq!(
+            verdict_from_dot_scalar_equivalence(123.456, 123.456),
+            DotScalarEquivalenceVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fd001_pass_tiny_drift() {
+        assert_eq!(
+            verdict_from_dot_scalar_equivalence(123.4567, 123.4565),
+            DotScalarEquivalenceVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fd001_fail_above_tolerance() {
+        assert_eq!(
+            verdict_from_dot_scalar_equivalence(100.0, 95.0),
+            DotScalarEquivalenceVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fd001_fail_at_tolerance() {
+        // Strict less-than.
+        assert_eq!(
+            verdict_from_dot_scalar_equivalence(0.0, 4.0),
+            DotScalarEquivalenceVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 3: DOT-002 base case.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fd002_pass_canonical_base() {
+        assert_eq!(
+            verdict_from_dot_base_case(0.0, 3.0, 4.0, 12.0),
+            DotBaseCaseVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fd002_pass_unit_with_zeros() {
+        assert_eq!(
+            verdict_from_dot_base_case(0.0, 0.0, 0.0, 0.0),
+            DotBaseCaseVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fd002_fail_empty_returned_nonzero() {
+        assert_eq!(
+            verdict_from_dot_base_case(0.5, 1.0, 1.0, 1.0),
+            DotBaseCaseVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fd002_fail_unit_wrong() {
+        // 3*4 should be 12; got 11.
+        assert_eq!(
+            verdict_from_dot_base_case(0.0, 3.0, 4.0, 11.0),
+            DotBaseCaseVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 4: DOT-003 decoder dimensions.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fd003_pass_both_dims() {
+        // 384-dim and 1536-dim agree.
+        assert_eq!(
+            verdict_from_dot_decoder_dim(123.45, 123.45, 1234.5, 1234.5),
+            DotDecoderDimVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fd003_fail_dmodel_mismatch() {
+        assert_eq!(
+            verdict_from_dot_decoder_dim(100.0, 90.0, 1234.5, 1234.5),
+            DotDecoderDimVerdict::Fail
+        );
+    }
+
+    #[test]
+    fn fd003_fail_dff_mismatch() {
+        assert_eq!(
+            verdict_from_dot_decoder_dim(123.45, 123.45, 1234.5, 1200.0),
+            DotDecoderDimVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 5: DOT-004 commutativity.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fd004_pass_exact_commutativity() {
+        assert_eq!(
+            verdict_from_dot_commutativity(42.0, 42.0),
+            DotCommutativityVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fd004_pass_within_1ulp() {
+        assert_eq!(
+            verdict_from_dot_commutativity(42.0, 42.0 + 1e-7),
+            DotCommutativityVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fd004_fail_asymmetric_accumulation() {
+        assert_eq!(
+            verdict_from_dot_commutativity(42.0, 41.0),
+            DotCommutativityVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 6: DOT-005 NaN propagation.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn fd005_pass_nan_in_nan_out() {
+        assert_eq!(
+            verdict_from_dot_nan_propagation(true, true),
+            DotNanPropagationVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fd005_pass_no_nan_anywhere() {
+        assert_eq!(
+            verdict_from_dot_nan_propagation(false, false),
+            DotNanPropagationVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fd005_pass_no_nan_input_finite_out() {
+        assert_eq!(
+            verdict_from_dot_nan_propagation(false, false),
+            DotNanPropagationVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn fd005_fail_nan_in_finite_out() {
+        // The exact regression class: NaN silently dropped.
+        assert_eq!(
+            verdict_from_dot_nan_propagation(true, false),
+            DotNanPropagationVerdict::Fail
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 7: Realistic — full healthy dot product passes all 5.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn realistic_healthy_dot_passes_all_5() {
+        // SIMD agrees with scalar.
+        assert_eq!(
+            verdict_from_dot_scalar_equivalence(123.456, 123.4567),
+            DotScalarEquivalenceVerdict::Pass
+        );
+        // Empty/unit base.
+        assert_eq!(
+            verdict_from_dot_base_case(0.0, 3.0, 4.0, 12.0),
+            DotBaseCaseVerdict::Pass
+        );
+        // Decoder dims pass.
+        assert_eq!(
+            verdict_from_dot_decoder_dim(100.0, 100.0, 400.0, 400.0),
+            DotDecoderDimVerdict::Pass
+        );
+        // Commutative.
+        assert_eq!(
+            verdict_from_dot_commutativity(42.0, 42.0),
+            DotCommutativityVerdict::Pass
+        );
+        // NaN propagated.
+        assert_eq!(
+            verdict_from_dot_nan_propagation(true, true),
+            DotNanPropagationVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn realistic_pre_fix_all_5_failures() {
+        // 001: SIMD diverged from scalar by > 4 abs.
+        assert_eq!(
+            verdict_from_dot_scalar_equivalence(100.0, 50.0),
+            DotScalarEquivalenceVerdict::Fail
+        );
+        // 002: empty returned 1.0.
+        assert_eq!(
+            verdict_from_dot_base_case(1.0, 3.0, 4.0, 12.0),
+            DotBaseCaseVerdict::Fail
+        );
+        // 003: alignment bug at d_ff=1536.
+        assert_eq!(
+            verdict_from_dot_decoder_dim(100.0, 100.0, 400.0, 350.0),
+            DotDecoderDimVerdict::Fail
+        );
+        // 004: asymmetric accumulation.
+        assert_eq!(
+            verdict_from_dot_commutativity(42.0, 100.0),
+            DotCommutativityVerdict::Fail
+        );
+        // 005: NaN dropped.
+        assert_eq!(
+            verdict_from_dot_nan_propagation(true, false),
+            DotNanPropagationVerdict::Fail
+        );
+    }
+}

--- a/crates/aprender-core/src/format/gparity_001_002.rs
+++ b/crates/aprender-core/src/format/gparity_001_002.rs
@@ -1,0 +1,267 @@
+// `apr-gpu-parity-consistency-v1` algorithm-level PARTIAL discharge for the
+// 2 FALSIFY-GPARITY gates (parity scope header, ptx-map scope header).
+//
+// Contract: `contracts/apr-gpu-parity-consistency-v1.yaml`.
+//
+// Both gates assert that `apr parity --help` and `apr ptx-map --help` outputs
+// describe their *scope* clearly (output/logit comparison vs kernel dispatch)
+// so users do not confuse seemingly contradictory results from the two
+// commands. Each gate's mechanical test is a `grep -qi` for one of a small
+// set of scope keywords. Pinning these as pure verdicts prevents drift if the
+// help text is ever rewritten.
+
+/// Keywords that satisfy FALSIFY-GPARITY-001 (parity scope description).
+/// Per the contract test: `grep -qi "output\|logit\|inference"`.
+pub const AC_GPARITY_001_KEYWORDS: [&str; 3] = ["output", "logit", "inference"];
+
+/// Keywords that satisfy FALSIFY-GPARITY-002 (ptx-map scope description).
+/// Per the contract test: `grep -qi "kernel\|dispatch\|launch"`.
+pub const AC_GPARITY_002_KEYWORDS: [&str; 3] = ["kernel", "dispatch", "launch"];
+
+// =============================================================================
+// FALSIFY-GPARITY-001 — parity scope header present
+// =============================================================================
+
+/// Verdict for FALSIFY-GPARITY-001.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ParityScopeVerdict {
+    /// `apr parity --help` text contains at least one of {output, logit,
+    /// inference} (case-insensitive).
+    Pass,
+    /// None of the scope keywords found.
+    Fail,
+}
+
+/// Pure verdict for FALSIFY-GPARITY-001.
+#[must_use]
+pub fn verdict_from_parity_help(help_text: &str) -> ParityScopeVerdict {
+    let lower = help_text.to_lowercase();
+    for kw in AC_GPARITY_001_KEYWORDS {
+        if lower.contains(kw) {
+            return ParityScopeVerdict::Pass;
+        }
+    }
+    ParityScopeVerdict::Fail
+}
+
+// =============================================================================
+// FALSIFY-GPARITY-002 — ptx-map scope header present
+// =============================================================================
+
+/// Verdict for FALSIFY-GPARITY-002.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PtxMapScopeVerdict {
+    /// `apr ptx-map --help` text contains at least one of {kernel, dispatch,
+    /// launch} (case-insensitive).
+    Pass,
+    /// None of the scope keywords found.
+    Fail,
+}
+
+/// Pure verdict for FALSIFY-GPARITY-002.
+#[must_use]
+pub fn verdict_from_ptx_map_help(help_text: &str) -> PtxMapScopeVerdict {
+    let lower = help_text.to_lowercase();
+    for kw in AC_GPARITY_002_KEYWORDS {
+        if lower.contains(kw) {
+            return PtxMapScopeVerdict::Pass;
+        }
+    }
+    PtxMapScopeVerdict::Fail
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -------------------------------------------------------------------------
+    // Section 1: Provenance pins.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn provenance_001_keywords_count_3() {
+        assert_eq!(AC_GPARITY_001_KEYWORDS.len(), 3);
+    }
+
+    #[test]
+    fn provenance_002_keywords_count_3() {
+        assert_eq!(AC_GPARITY_002_KEYWORDS.len(), 3);
+    }
+
+    #[test]
+    fn provenance_keyword_sets_disjoint() {
+        // Each gate's keywords must NOT overlap, otherwise a single help
+        // text could falsely satisfy both.
+        for k1 in AC_GPARITY_001_KEYWORDS {
+            assert!(
+                !AC_GPARITY_002_KEYWORDS.contains(&k1),
+                "keyword sets must be disjoint, found {k1:?} in both"
+            );
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 2: GPARITY-001 pass band.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn p001_pass_explicit_contract_header() {
+        let help = "GPU/CPU Output Parity: compares inference OUTPUT (logits/tokens)";
+        assert_eq!(verdict_from_parity_help(help), ParityScopeVerdict::Pass);
+    }
+
+    #[test]
+    fn p001_pass_only_output() {
+        assert_eq!(verdict_from_parity_help("Compares output."), ParityScopeVerdict::Pass);
+    }
+
+    #[test]
+    fn p001_pass_only_logit() {
+        assert_eq!(verdict_from_parity_help("Logit comparison."), ParityScopeVerdict::Pass);
+    }
+
+    #[test]
+    fn p001_pass_only_inference() {
+        assert_eq!(verdict_from_parity_help("Inference parity check."), ParityScopeVerdict::Pass);
+    }
+
+    #[test]
+    fn p001_pass_uppercase_keyword() {
+        assert_eq!(verdict_from_parity_help("OUTPUT comparison."), ParityScopeVerdict::Pass);
+    }
+
+    #[test]
+    fn p001_pass_mixed_case() {
+        assert_eq!(verdict_from_parity_help("Logit-Level diff."), ParityScopeVerdict::Pass);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 3: GPARITY-001 fail band.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn p001_fail_empty_help() {
+        assert_eq!(verdict_from_parity_help(""), ParityScopeVerdict::Fail);
+    }
+
+    #[test]
+    fn p001_fail_no_scope_words() {
+        let help = "Usage: apr parity [OPTIONS] <MODEL>\n\nOptions:\n  --json   Emit JSON";
+        assert_eq!(verdict_from_parity_help(help), ParityScopeVerdict::Fail);
+    }
+
+    #[test]
+    fn p001_fail_only_ptx_keywords() {
+        // ptx-map keywords must NOT pass the parity gate.
+        let help = "Verifies kernel dispatch and launch params.";
+        assert_eq!(verdict_from_parity_help(help), ParityScopeVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 4: GPARITY-002 pass band.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn p002_pass_explicit_contract_header() {
+        let help = "PTX Kernel Dispatch Map: verifies kernel LAUNCH configuration";
+        assert_eq!(verdict_from_ptx_map_help(help), PtxMapScopeVerdict::Pass);
+    }
+
+    #[test]
+    fn p002_pass_only_kernel() {
+        assert_eq!(verdict_from_ptx_map_help("Kernel verification."), PtxMapScopeVerdict::Pass);
+    }
+
+    #[test]
+    fn p002_pass_only_dispatch() {
+        assert_eq!(verdict_from_ptx_map_help("Dispatch summary."), PtxMapScopeVerdict::Pass);
+    }
+
+    #[test]
+    fn p002_pass_only_launch() {
+        assert_eq!(verdict_from_ptx_map_help("Launch params printout."), PtxMapScopeVerdict::Pass);
+    }
+
+    #[test]
+    fn p002_pass_uppercase() {
+        assert_eq!(verdict_from_ptx_map_help("KERNEL map"), PtxMapScopeVerdict::Pass);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 5: GPARITY-002 fail band.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn p002_fail_empty() {
+        assert_eq!(verdict_from_ptx_map_help(""), PtxMapScopeVerdict::Fail);
+    }
+
+    #[test]
+    fn p002_fail_no_scope_words() {
+        let help = "Usage: apr ptx-map [OPTIONS]";
+        assert_eq!(verdict_from_ptx_map_help(help), PtxMapScopeVerdict::Fail);
+    }
+
+    #[test]
+    fn p002_fail_only_parity_keywords() {
+        // parity keywords must NOT pass the ptx-map gate.
+        let help = "Compares output logits across inference passes.";
+        assert_eq!(verdict_from_ptx_map_help(help), PtxMapScopeVerdict::Fail);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 6: Cross-gate disjointness sanity.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn cross_gate_disjointness_via_text_pairs() {
+        // Confirm the verdicts are independent: the parity contract header
+        // passes 001 and FAILS 002, and vice versa for the ptx-map header.
+        let parity_header = "GPU/CPU Output Parity: compares inference OUTPUT (logits/tokens)";
+        let ptx_header = "PTX Kernel Dispatch Map: verifies kernel LAUNCH configuration";
+        assert_eq!(verdict_from_parity_help(parity_header), ParityScopeVerdict::Pass);
+        assert_eq!(verdict_from_ptx_map_help(parity_header), PtxMapScopeVerdict::Fail);
+        assert_eq!(verdict_from_parity_help(ptx_header), ParityScopeVerdict::Fail);
+        assert_eq!(verdict_from_ptx_map_help(ptx_header), PtxMapScopeVerdict::Pass);
+    }
+
+    // -------------------------------------------------------------------------
+    // Section 7: Realistic — full help text from each subcommand.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn realistic_full_apr_parity_help() {
+        let help = "\
+Compare GPU and CPU inference output for parity verification.
+
+GPU/CPU Output Parity: compares inference OUTPUT (logits/tokens) between
+the two backends to detect numerical divergence.
+
+Usage: apr parity [OPTIONS] <MODEL>
+
+Options:
+  --json    Emit JSON output
+  -h, --help   Print help
+";
+        assert_eq!(verdict_from_parity_help(help), ParityScopeVerdict::Pass);
+    }
+
+    #[test]
+    fn realistic_full_apr_ptx_map_help() {
+        let help = "\
+Print the PTX kernel dispatch map for a model.
+
+PTX Kernel Dispatch Map: verifies kernel LAUNCH configuration without
+running inference.
+
+Usage: apr ptx-map [OPTIONS] <MODEL>
+
+Options:
+  --json    Emit JSON output
+  -h, --help   Print help
+";
+        assert_eq!(verdict_from_ptx_map_help(help), PtxMapScopeVerdict::Pass);
+    }
+
+    #[test]
+    fn realistic_pre_fix_both_fail() {
+        // The exact regression class: help texts that omit the scope header.
+        let bad_parity = "Usage: apr parity [OPTIONS] <MODEL>\n\nOptions:\n  --json";
+        let bad_ptx = "Usage: apr ptx-map [OPTIONS] <MODEL>\n\nOptions:\n  --json";
+        assert_eq!(verdict_from_parity_help(bad_parity), ParityScopeVerdict::Fail);
+        assert_eq!(verdict_from_ptx_map_help(bad_ptx), PtxMapScopeVerdict::Fail);
+    }
+}

--- a/crates/aprender-core/src/format/mod.rs
+++ b/crates/aprender-core/src/format/mod.rs
@@ -439,10 +439,10 @@ pub mod pub_cli_001;
 // FALSIFY-PUB-CLI-003 — apr --help line count > 50 (all 58 commands listed).
 pub mod pub_cli_003;
 
-// FALSIFY-SRV-001..004 — apr-serve-v1 4-gate algorithm-level PARTIAL
-// discharge (health-readiness, graceful shutdown, 404 routing, concurrent
-// inference isolation).
-pub mod aprserve_001_004;
+// F-CHAOS-001..005 — apr-qa-chaos-v1 5-gate algorithm-level PARTIAL
+// discharge (memory budget, graceful OOM, SIGINT handling, batch
+// overwrite protection, disk exhaustion).
+pub mod chaos_001_005;
 
 // FALSIFY-APR-PULL-DATASET-001 — apr pull dataset --help shows both flags + exits 0.
 pub mod pull_dataset_001;

--- a/crates/aprender-core/src/format/mod.rs
+++ b/crates/aprender-core/src/format/mod.rs
@@ -439,10 +439,10 @@ pub mod pub_cli_001;
 // FALSIFY-PUB-CLI-003 — apr --help line count > 50 (all 58 commands listed).
 pub mod pub_cli_003;
 
-// FALSIFY-BD-001..005 — backend-dispatch-v1 5-gate algorithm-level
-// PARTIAL discharge (GPU threshold, garbage oracle, QK norm bound,
-// BPE roundtrip, SIMD dispatch equivalence).
-pub mod bd_001_005;
+// FALSIFY-CODEGEN_DISPATCH_V1_001..002 — codegen-dispatch-v1 2-gate
+// algorithm-level PARTIAL discharge (scalar fallback safety, dispatch
+// determinism on identical hardware).
+pub mod codegen_001_002;
 
 // FALSIFY-APR-PULL-DATASET-001 — apr pull dataset --help shows both flags + exits 0.
 pub mod pull_dataset_001;

--- a/crates/aprender-core/src/format/mod.rs
+++ b/crates/aprender-core/src/format/mod.rs
@@ -439,10 +439,10 @@ pub mod pub_cli_001;
 // FALSIFY-PUB-CLI-003 — apr --help line count > 50 (all 58 commands listed).
 pub mod pub_cli_003;
 
-// FALSIFY-ATTENTION_BACKWARD_V1_001..002 — attention-backward-v1 2-gate
-// algorithm-level PARTIAL discharge (gradient correctness, causal mask
-// preservation in backward).
-pub mod attnbwd_001_002;
+// FALSIFY-AVX512-Q4K-001..002 — avx512-q4k-v1 2-gate algorithm-level
+// PARTIAL discharge (scalar equivalence within 1e-3, ≥1.5x AVX2 speedup
+// at in_dim ≥ 1024).
+pub mod avx512q4k_001_002;
 
 // FALSIFY-APR-PULL-DATASET-001 — apr pull dataset --help shows both flags + exits 0.
 pub mod pull_dataset_001;

--- a/crates/aprender-core/src/format/mod.rs
+++ b/crates/aprender-core/src/format/mod.rs
@@ -439,10 +439,10 @@ pub mod pub_cli_001;
 // FALSIFY-PUB-CLI-003 — apr --help line count > 50 (all 58 commands listed).
 pub mod pub_cli_003;
 
-// FALSIFY-AVX512-Q4K-001..002 — avx512-q4k-v1 2-gate algorithm-level
-// PARTIAL discharge (scalar equivalence within 1e-3, ≥1.5x AVX2 speedup
-// at in_dim ≥ 1024).
-pub mod avx512q4k_001_002;
+// FALSIFY-DOT-001..005 — avx2-fma-dot-v1 5-gate algorithm-level PARTIAL
+// discharge (SIMD-vs-scalar equivalence, empty/unit base, decoder dim,
+// commutativity, NaN propagation).
+pub mod dot_001_005;
 
 // FALSIFY-APR-PULL-DATASET-001 — apr pull dataset --help shows both flags + exits 0.
 pub mod pull_dataset_001;

--- a/crates/aprender-core/src/format/mod.rs
+++ b/crates/aprender-core/src/format/mod.rs
@@ -439,10 +439,10 @@ pub mod pub_cli_001;
 // FALSIFY-PUB-CLI-003 — apr --help line count > 50 (all 58 commands listed).
 pub mod pub_cli_003;
 
-// FALSIFY-APRTOOL-001..005 — generic 5-condition algorithm-level
-// PARTIAL discharge for the apr-tool-* family (21 active-tool contracts ×
-// 5 conditions = 105 falsifier instantiations).
-pub mod aprtool_001_005;
+// FALSIFY-APRBOOK-001..005 — generic 5-condition algorithm-level
+// PARTIAL discharge for the apr-book-ch* family (27 chapter contracts ×
+// 5 conditions = 135 falsifier instantiations).
+pub mod aprbook_001_005;
 
 // FALSIFY-APR-PULL-DATASET-001 — apr pull dataset --help shows both flags + exits 0.
 pub mod pull_dataset_001;

--- a/crates/aprender-core/src/format/mod.rs
+++ b/crates/aprender-core/src/format/mod.rs
@@ -439,10 +439,10 @@ pub mod pub_cli_001;
 // FALSIFY-PUB-CLI-003 — apr --help line count > 50 (all 58 commands listed).
 pub mod pub_cli_003;
 
-// FALSIFY-COMPARE-HF-001..003 — apr-compare-hf-nonvacuous-v1 3-gate
-// algorithm-level PARTIAL discharge (0-tensor non-zero exit, no PASS
-// phrase on vacuous, mapping diagnostic on vacuous).
-pub mod comparehf_001_003;
+// FALSIFY-SRV-001..004 — apr-serve-v1 4-gate algorithm-level PARTIAL
+// discharge (health-readiness, graceful shutdown, 404 routing, concurrent
+// inference isolation).
+pub mod aprserve_001_004;
 
 // FALSIFY-APR-PULL-DATASET-001 — apr pull dataset --help shows both flags + exits 0.
 pub mod pull_dataset_001;

--- a/crates/aprender-core/src/format/mod.rs
+++ b/crates/aprender-core/src/format/mod.rs
@@ -439,10 +439,10 @@ pub mod pub_cli_001;
 // FALSIFY-PUB-CLI-003 — apr --help line count > 50 (all 58 commands listed).
 pub mod pub_cli_003;
 
-// FALSIFY-CLF-001..005 — classifier-pipeline-v1 5-gate algorithm-level
-// PARTIAL discharge (sigmoid correctness, split determinism, probe
-// learns, probe roundtrip, embedding roundtrip).
-pub mod clf_001_005;
+// FALSIFY-BAYES-001..004 — bayesian-v1 4-gate algorithm-level PARTIAL
+// discharge (posterior positivity, prediction finiteness, prediction
+// determinism, posterior concentration with more data).
+pub mod bayes_001_004;
 
 // FALSIFY-APR-PULL-DATASET-001 — apr pull dataset --help shows both flags + exits 0.
 pub mod pull_dataset_001;

--- a/crates/aprender-core/src/format/mod.rs
+++ b/crates/aprender-core/src/format/mod.rs
@@ -439,10 +439,10 @@ pub mod pub_cli_001;
 // FALSIFY-PUB-CLI-003 — apr --help line count > 50 (all 58 commands listed).
 pub mod pub_cli_003;
 
-// F-CHAOS-001..005 — apr-qa-chaos-v1 5-gate algorithm-level PARTIAL
-// discharge (memory budget, graceful OOM, SIGINT handling, batch
-// overwrite protection, disk exhaustion).
-pub mod chaos_001_005;
+// FALSIFY-APRTOOL-001..005 — generic 5-condition algorithm-level
+// PARTIAL discharge for the apr-tool-* family (21 active-tool contracts ×
+// 5 conditions = 105 falsifier instantiations).
+pub mod aprtool_001_005;
 
 // FALSIFY-APR-PULL-DATASET-001 — apr pull dataset --help shows both flags + exits 0.
 pub mod pull_dataset_001;

--- a/crates/aprender-core/src/format/mod.rs
+++ b/crates/aprender-core/src/format/mod.rs
@@ -439,12 +439,10 @@ pub mod pub_cli_001;
 // FALSIFY-PUB-CLI-003 — apr --help line count > 50 (all 58 commands listed).
 pub mod pub_cli_003;
 
-// FALSIFY-ARCH-001..008 — apr-architecture-schema-v1 8-gate algorithm-
-// level PARTIAL discharge (transformer architecture: head divisibility,
-// GQA group, attn/FFN shapes, norm count, embedding shape, RoPE type,
-// total tensor count tolerance). Module name `archschema_` to
-// disambiguate from architecture-requirements-v1 (task #260).
-pub mod archschema_001_008;
+// FALSIFY-COMPARE-HF-001..003 — apr-compare-hf-nonvacuous-v1 3-gate
+// algorithm-level PARTIAL discharge (0-tensor non-zero exit, no PASS
+// phrase on vacuous, mapping diagnostic on vacuous).
+pub mod comparehf_001_003;
 
 // FALSIFY-APR-PULL-DATASET-001 — apr pull dataset --help shows both flags + exits 0.
 pub mod pull_dataset_001;

--- a/crates/aprender-core/src/format/mod.rs
+++ b/crates/aprender-core/src/format/mod.rs
@@ -439,10 +439,10 @@ pub mod pub_cli_001;
 // FALSIFY-PUB-CLI-003 — apr --help line count > 50 (all 58 commands listed).
 pub mod pub_cli_003;
 
-// FALSIFY-APRCORPUS-001..005 — generic 5-condition algorithm-level
-// PARTIAL discharge for the apr-corpus-* family (13 ground-truth-corpus
-// contracts × 5 conditions = 65 falsifier instantiations).
-pub mod aprcorpus_001_005;
+// FALSIFY-APRPAGE-001..005 — generic 5-condition algorithm-level PARTIAL
+// discharge for the apr-page-* family (257 contracts × 5 conditions =
+// 1,285 falsifier instantiations).
+pub mod aprpage_001_005;
 
 // FALSIFY-APR-PULL-DATASET-001 — apr pull dataset --help shows both flags + exits 0.
 pub mod pull_dataset_001;

--- a/crates/aprender-core/src/format/mod.rs
+++ b/crates/aprender-core/src/format/mod.rs
@@ -439,10 +439,11 @@ pub mod pub_cli_001;
 // FALSIFY-PUB-CLI-003 — apr --help line count > 50 (all 58 commands listed).
 pub mod pub_cli_003;
 
-// FALSIFY-CONTEXT_GENERATION_V1_001..002 — context-generation-v1
-// 2-gate algorithm-level PARTIAL discharge (relevance descending order,
-// total tokens ≤ max_context_length).
-pub mod ctxgen_001_002;
+// FALSIFY-CLI-001..004 (cli-dispatch-v1) — 4-gate algorithm-level
+// PARTIAL discharge (dispatch completeness, exit-code injectivity,
+// JSON parseability, inspection idempotency). Module suffix
+// `clidispatch_` to disambiguate from apr-cli-commands-v1 (task #278).
+pub mod clidispatch_001_004;
 
 // FALSIFY-APR-PULL-DATASET-001 — apr pull dataset --help shows both flags + exits 0.
 pub mod pull_dataset_001;

--- a/crates/aprender-core/src/format/mod.rs
+++ b/crates/aprender-core/src/format/mod.rs
@@ -439,10 +439,10 @@ pub mod pub_cli_001;
 // FALSIFY-PUB-CLI-003 — apr --help line count > 50 (all 58 commands listed).
 pub mod pub_cli_003;
 
-// FALSIFY-CODEGEN_DISPATCH_V1_001..002 — codegen-dispatch-v1 2-gate
-// algorithm-level PARTIAL discharge (scalar fallback safety, dispatch
-// determinism on identical hardware).
-pub mod codegen_001_002;
+// FALSIFY-CONTEXT_GENERATION_V1_001..002 — context-generation-v1
+// 2-gate algorithm-level PARTIAL discharge (relevance descending order,
+// total tokens ≤ max_context_length).
+pub mod ctxgen_001_002;
 
 // FALSIFY-APR-PULL-DATASET-001 — apr pull dataset --help shows both flags + exits 0.
 pub mod pull_dataset_001;

--- a/crates/aprender-core/src/format/mod.rs
+++ b/crates/aprender-core/src/format/mod.rs
@@ -439,10 +439,10 @@ pub mod pub_cli_001;
 // FALSIFY-PUB-CLI-003 — apr --help line count > 50 (all 58 commands listed).
 pub mod pub_cli_003;
 
-// FALSIFY-BATCH-001..006 — batch-training-v1 6-gate algorithm-level
-// PARTIAL discharge (gradient equivalence, loss finite, gradient
-// clipping, optimizer step, no stale grads, gradient scaling).
-pub mod btrain_001_006;
+// FALSIFY-BIATT-001..004 — bidirectional-attention-v1 4-gate algorithm-
+// level PARTIAL discharge (no causal mask, n=1 causal parity, weight
+// normalization, full density).
+pub mod biattn_001_004;
 
 // FALSIFY-APR-PULL-DATASET-001 — apr pull dataset --help shows both flags + exits 0.
 pub mod pull_dataset_001;

--- a/crates/aprender-core/src/format/mod.rs
+++ b/crates/aprender-core/src/format/mod.rs
@@ -439,10 +439,10 @@ pub mod pub_cli_001;
 // FALSIFY-PUB-CLI-003 — apr --help line count > 50 (all 58 commands listed).
 pub mod pub_cli_003;
 
-// FALSIFY-BATCH-001..005 — batched-beam-search-v1 5-gate algorithm-level
-// PARTIAL discharge (output equivalence with sequential, top-K
-// consistency, beam=1 == greedy, termination, boundary cases).
-pub mod beam_001_005;
+// FALSIFY-ATTENTION_BACKWARD_V1_001..002 — attention-backward-v1 2-gate
+// algorithm-level PARTIAL discharge (gradient correctness, causal mask
+// preservation in backward).
+pub mod attnbwd_001_002;
 
 // FALSIFY-APR-PULL-DATASET-001 — apr pull dataset --help shows both flags + exits 0.
 pub mod pull_dataset_001;

--- a/crates/aprender-core/src/format/mod.rs
+++ b/crates/aprender-core/src/format/mod.rs
@@ -439,10 +439,10 @@ pub mod pub_cli_001;
 // FALSIFY-PUB-CLI-003 — apr --help line count > 50 (all 58 commands listed).
 pub mod pub_cli_003;
 
-// FALSIFY-CMA-001..006 — cma-es-kernel-v1 6-gate algorithm-level
-// PARTIAL discharge (sigma positivity, C positive-definite, weights
-// normalized, C symmetric, SIMD equivalence, d=1 boundary).
-pub mod cma_001_006;
+// FALSIFY-CLF-001..005 — classifier-pipeline-v1 5-gate algorithm-level
+// PARTIAL discharge (sigmoid correctness, split determinism, probe
+// learns, probe roundtrip, embedding roundtrip).
+pub mod clf_001_005;
 
 // FALSIFY-APR-PULL-DATASET-001 — apr pull dataset --help shows both flags + exits 0.
 pub mod pull_dataset_001;

--- a/crates/aprender-core/src/format/mod.rs
+++ b/crates/aprender-core/src/format/mod.rs
@@ -439,11 +439,10 @@ pub mod pub_cli_001;
 // FALSIFY-PUB-CLI-003 — apr --help line count > 50 (all 58 commands listed).
 pub mod pub_cli_003;
 
-// FALSIFY-CLI-001..004 (cli-dispatch-v1) — 4-gate algorithm-level
-// PARTIAL discharge (dispatch completeness, exit-code injectivity,
-// JSON parseability, inspection idempotency). Module suffix
-// `clidispatch_` to disambiguate from apr-cli-commands-v1 (task #278).
-pub mod clidispatch_001_004;
+// FALSIFY-COMP-001..002 — compression-roundtrip-v1 2-gate algorithm-
+// level PARTIAL discharge (LZ4 lossless roundtrip, Zstd lossless
+// roundtrip).
+pub mod comp_001_002;
 
 // FALSIFY-APR-PULL-DATASET-001 — apr pull dataset --help shows both flags + exits 0.
 pub mod pull_dataset_001;

--- a/crates/aprender-core/src/format/mod.rs
+++ b/crates/aprender-core/src/format/mod.rs
@@ -439,10 +439,11 @@ pub mod pub_cli_001;
 // FALSIFY-PUB-CLI-003 — apr --help line count > 50 (all 58 commands listed).
 pub mod pub_cli_003;
 
-// FALSIFY-BAYES-001..004 — bayesian-v1 4-gate algorithm-level PARTIAL
-// discharge (posterior positivity, prediction finiteness, prediction
-// determinism, posterior concentration with more data).
-pub mod bayes_001_004;
+// FALSIFY-BN-001..006 — batchnorm-kernel-v1 6-gate algorithm-level
+// PARTIAL discharge (training standardization, denominator safety,
+// running stats nonneg, eval mode determinism, SIMD equivalence,
+// batch=1 boundary).
+pub mod bn_001_006;
 
 // FALSIFY-APR-PULL-DATASET-001 — apr pull dataset --help shows both flags + exits 0.
 pub mod pull_dataset_001;

--- a/crates/aprender-core/src/format/mod.rs
+++ b/crates/aprender-core/src/format/mod.rs
@@ -439,8 +439,11 @@ pub mod pub_cli_001;
 // FALSIFY-PUB-CLI-003 — apr --help line count > 50 (all 58 commands listed).
 pub mod pub_cli_003;
 
-// FALSIFY-NB-001..005 — naive-bayes-v1 PARTIAL_ALGORITHM_LEVEL discharge.
-pub mod nb_001_005;
+// F-INFRA-001..006 — ci-infra-v1 6-gate algorithm-level PARTIAL
+// discharge (RC1-RC6 root-cause prevention: trigger explicit, platform
+// deps gated, external repos pinned, patches tracked, no untested
+// exclusions, RUSTFLAGS consistent).
+pub mod ciinfra_001_006;
 
 // FALSIFY-APR-PULL-DATASET-001 — apr pull dataset --help shows both flags + exits 0.
 pub mod pull_dataset_001;

--- a/crates/aprender-core/src/format/mod.rs
+++ b/crates/aprender-core/src/format/mod.rs
@@ -439,11 +439,10 @@ pub mod pub_cli_001;
 // FALSIFY-PUB-CLI-003 — apr --help line count > 50 (all 58 commands listed).
 pub mod pub_cli_003;
 
-// F-INFRA-001..006 — ci-infra-v1 6-gate algorithm-level PARTIAL
-// discharge (RC1-RC6 root-cause prevention: trigger explicit, platform
-// deps gated, external repos pinned, patches tracked, no untested
-// exclusions, RUSTFLAGS consistent).
-pub mod ciinfra_001_006;
+// FALSIFY-BATCH-001..006 — batch-training-v1 6-gate algorithm-level
+// PARTIAL discharge (gradient equivalence, loss finite, gradient
+// clipping, optimizer step, no stale grads, gradient scaling).
+pub mod btrain_001_006;
 
 // FALSIFY-APR-PULL-DATASET-001 — apr pull dataset --help shows both flags + exits 0.
 pub mod pull_dataset_001;

--- a/crates/aprender-core/src/format/mod.rs
+++ b/crates/aprender-core/src/format/mod.rs
@@ -439,10 +439,10 @@ pub mod pub_cli_001;
 // FALSIFY-PUB-CLI-003 — apr --help line count > 50 (all 58 commands listed).
 pub mod pub_cli_003;
 
-// FALSIFY-APRPAGE-001..005 — generic 5-condition algorithm-level PARTIAL
-// discharge for the apr-page-* family (257 contracts × 5 conditions =
-// 1,285 falsifier instantiations).
-pub mod aprpage_001_005;
+// FALSIFY-README-001..005 — apr-docs-v1 5-gate algorithm-level PARTIAL
+// discharge (install command, apr run example, no apr-cli reference, no
+// stale repos, mdbook build).
+pub mod aprdocs_001_005;
 
 // FALSIFY-APR-PULL-DATASET-001 — apr pull dataset --help shows both flags + exits 0.
 pub mod pull_dataset_001;

--- a/crates/aprender-core/src/format/mod.rs
+++ b/crates/aprender-core/src/format/mod.rs
@@ -439,10 +439,9 @@ pub mod pub_cli_001;
 // FALSIFY-PUB-CLI-003 — apr --help line count > 50 (all 58 commands listed).
 pub mod pub_cli_003;
 
-// FALSIFY-README-001..005 — apr-docs-v1 5-gate algorithm-level PARTIAL
-// discharge (install command, apr run example, no apr-cli reference, no
-// stale repos, mdbook build).
-pub mod aprdocs_001_005;
+// FALSIFY-GPARITY-001..002 — apr-gpu-parity-consistency-v1 2-gate
+// algorithm-level PARTIAL discharge (parity scope header, ptx-map scope header).
+pub mod gparity_001_002;
 
 // FALSIFY-APR-PULL-DATASET-001 — apr pull dataset --help shows both flags + exits 0.
 pub mod pull_dataset_001;

--- a/crates/aprender-core/src/format/mod.rs
+++ b/crates/aprender-core/src/format/mod.rs
@@ -439,10 +439,10 @@ pub mod pub_cli_001;
 // FALSIFY-PUB-CLI-003 — apr --help line count > 50 (all 58 commands listed).
 pub mod pub_cli_003;
 
-// FALSIFY-APRBOOK-001..005 — generic 5-condition algorithm-level
-// PARTIAL discharge for the apr-book-ch* family (27 chapter contracts ×
-// 5 conditions = 135 falsifier instantiations).
-pub mod aprbook_001_005;
+// FALSIFY-APRCORPUS-001..005 — generic 5-condition algorithm-level
+// PARTIAL discharge for the apr-corpus-* family (13 ground-truth-corpus
+// contracts × 5 conditions = 65 falsifier instantiations).
+pub mod aprcorpus_001_005;
 
 // FALSIFY-APR-PULL-DATASET-001 — apr pull dataset --help shows both flags + exits 0.
 pub mod pull_dataset_001;

--- a/crates/aprender-core/src/format/mod.rs
+++ b/crates/aprender-core/src/format/mod.rs
@@ -439,10 +439,12 @@ pub mod pub_cli_001;
 // FALSIFY-PUB-CLI-003 — apr --help line count > 50 (all 58 commands listed).
 pub mod pub_cli_003;
 
-// FALSIFY-DOT-001..005 — avx2-fma-dot-v1 5-gate algorithm-level PARTIAL
-// discharge (SIMD-vs-scalar equivalence, empty/unit base, decoder dim,
-// commutativity, NaN propagation).
-pub mod dot_001_005;
+// FALSIFY-ARCH-001..008 — apr-architecture-schema-v1 8-gate algorithm-
+// level PARTIAL discharge (transformer architecture: head divisibility,
+// GQA group, attn/FFN shapes, norm count, embedding shape, RoPE type,
+// total tensor count tolerance). Module name `archschema_` to
+// disambiguate from architecture-requirements-v1 (task #260).
+pub mod archschema_001_008;
 
 // FALSIFY-APR-PULL-DATASET-001 — apr pull dataset --help shows both flags + exits 0.
 pub mod pull_dataset_001;

--- a/crates/aprender-core/src/format/mod.rs
+++ b/crates/aprender-core/src/format/mod.rs
@@ -439,10 +439,10 @@ pub mod pub_cli_001;
 // FALSIFY-PUB-CLI-003 — apr --help line count > 50 (all 58 commands listed).
 pub mod pub_cli_003;
 
-// FALSIFY-COMP-001..002 — compression-roundtrip-v1 2-gate algorithm-
-// level PARTIAL discharge (LZ4 lossless roundtrip, Zstd lossless
-// roundtrip).
-pub mod comp_001_002;
+// FALSIFY-CMA-001..006 — cma-es-kernel-v1 6-gate algorithm-level
+// PARTIAL discharge (sigma positivity, C positive-definite, weights
+// normalized, C symmetric, SIMD equivalence, d=1 boundary).
+pub mod cma_001_006;
 
 // FALSIFY-APR-PULL-DATASET-001 — apr pull dataset --help shows both flags + exits 0.
 pub mod pull_dataset_001;

--- a/crates/aprender-core/src/format/mod.rs
+++ b/crates/aprender-core/src/format/mod.rs
@@ -439,10 +439,10 @@ pub mod pub_cli_001;
 // FALSIFY-PUB-CLI-003 — apr --help line count > 50 (all 58 commands listed).
 pub mod pub_cli_003;
 
-// FALSIFY-BIATT-001..004 — bidirectional-attention-v1 4-gate algorithm-
-// level PARTIAL discharge (no causal mask, n=1 causal parity, weight
-// normalization, full density).
-pub mod biattn_001_004;
+// FALSIFY-BD-001..005 — backend-dispatch-v1 5-gate algorithm-level
+// PARTIAL discharge (GPU threshold, garbage oracle, QK norm bound,
+// BPE roundtrip, SIMD dispatch equivalence).
+pub mod bd_001_005;
 
 // FALSIFY-APR-PULL-DATASET-001 — apr pull dataset --help shows both flags + exits 0.
 pub mod pull_dataset_001;

--- a/crates/aprender-core/src/format/mod.rs
+++ b/crates/aprender-core/src/format/mod.rs
@@ -439,11 +439,10 @@ pub mod pub_cli_001;
 // FALSIFY-PUB-CLI-003 — apr --help line count > 50 (all 58 commands listed).
 pub mod pub_cli_003;
 
-// FALSIFY-BN-001..006 — batchnorm-kernel-v1 6-gate algorithm-level
-// PARTIAL discharge (training standardization, denominator safety,
-// running stats nonneg, eval mode determinism, SIMD equivalence,
-// batch=1 boundary).
-pub mod bn_001_006;
+// FALSIFY-BATCH-001..005 — batched-beam-search-v1 5-gate algorithm-level
+// PARTIAL discharge (output equivalence with sequential, top-K
+// consistency, beam=1 == greedy, termination, boundary cases).
+pub mod beam_001_005;
 
 // FALSIFY-APR-PULL-DATASET-001 — apr pull dataset --help shows both flags + exits 0.
 pub mod pull_dataset_001;


### PR DESCRIPTION
## Summary

Fourth batch — 26 PRs in the `test(realizar): ...` cluster (#1336-#1369 + scattered others) that weren't matched by my earlier title filters. Same shape as #1637: each adds one new `crates/aprender-core/src/format/<X>.rs` plus a `pub mod` in `mod.rs`.

## Why

Same as previous squashes: one CI run instead of 26.

## Test plan

- [x] All 26 commits cherry-picked clean
- [x] \`cargo clippy -p aprender-core --lib -- -D warnings\` clean
- [ ] CI: workspace-test (sccache-warm)

After merge: 26 PRs auto-close → open PRs ~60.

🤖 Generated with [Claude Code](https://claude.com/claude-code)