### PR TITLE
🎉 chore: v0.33.0 release prep — CHANGELOG + workspace version bump (MODEL-1 100%)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,90 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.33.0] - 2026-05-13
+
+### 🎉 MODEL-1 SHIP % = 100% — all 10 AC-SHIP1-* LIVE-DISCHARGED
+
+This release completes SHIP-TWO-001 MODEL-1: every acceptance criterion (SHIP-001 through SHIP-010) is LIVE-discharged on the canonical 7B Qwen2.5-Coder-Instruct Q4_K_M teacher on RTX 4090 with `--features cuda`.
+
+| AC | What | Discharge §  |
+|----|------|-------------|
+| SHIP-001 | `apr run <safetensors>` loads via realizar | §72 |
+| SHIP-002 | `apr run "def fib(n):"` valid Python | §61 |
+| SHIP-003 | q4_k_m round-trip cos ≥ 0.999 | §72 |
+| SHIP-004 | GGUF exports + loads in llama.cpp | §72 |
+| SHIP-005 | HumanEval pass@1 = 86.59% on gx10 164-run | §71 |
+| SHIP-006 | `apr qa` 12-gate aggregate PASS | §61.8 |
+| **SHIP-007** | **PARITY-GATE PASS + 124.6 tok/s @ 128-tok decode** | **§75** |
+| SHIP-008 | Chat template render | §61 |
+| SHIP-009 | License + provenance in `model.apr` metadata | §72 |
+| SHIP-010 | Published HF URL + sha256 match | §72 |
+
+### Fixed
+
+#### SHIP-007 — F32 GEMV PTX kernel layout (PR #1651, §75)
+
+`crates/aprender-gpu/src/kernels/gemv/mod.rs::GemvKernel::build_ptx` assumed weight matrix `A` is `[K rows × N cols]` row-major (`A[i,j]` at `i*N + j`). The standard ML weight convention is `[output_dim=N, input_dim=K]` row-major (`A[i,j]` at `i*K + j` per PyTorch/SafeTensors/GGUF/dequantized lm_head). The kernel was reading TRANSPOSED weights → `y = A^T @ x` instead of `y = A @ x` → systematically anti-correlated logits (cos = -0.005190 vs CPU, sign-flipped top-K divergences).
+
+Fix: rewrite inner loop to iterate K within row `block_id` (row_base = a_ptr + block_id * K * 4; thread `t` reads A[block_id, t]).
+
+Empirical discharge on canonical 7B teacher, lambda-vector RTX 4090:
+- PARITY-GATE PASS (no error from `forward_gpu_resident`)
+- `apr bench` 5-iter 128-tok decode = **124.6 tok/s** (4.15× over AC-SHIP1-007 30 tok/s floor)
+- Default path (CUDA graphed), no `SKIP_PARITY_GATE`, no `APR_SKIP_FP8_WARMUP`
+
+#### SHIP-005 — HumanEval harness RC3 fix (PR #1635, §70/§71)
+
+`run_humaneval_inference`'s ChatML branch built `full_program = "{completion}\n\n{test}\n\ncheck({entry})\n"` — dropping `problem.prompt`'s preamble (e.g., `from typing import List`). Function signatures using typing aliases failed with NameError at line 1, affecting ~70% of the HumanEval canonical set.
+
+Fix: new `extract_prompt_preamble(prompt, entry_point)` helper. ChatML branch now prepends preamble: `full_program = "{preamble}\n{completion}\n\n{test}\n\ncheck({entry})\n"`.
+
+Empirical discharge on canonical 7B teacher, gx10 164-run:
+- Pre-fix (§67, H4 only): pass@1 = 80.49%
+- Post-fix (§71, +RC3): **pass@1 = 86.59%** (+6.10pp; clears 84.80% floor by +1.79pp)
+
+### Added
+
+#### Diagnostic surfaces
+
+- `APR_EVAL_DEBUG=1` (PR #1634): per-problem JSON dump in `apr eval`. Captures task_id, prompt, response, full_program, exit_code, stderr, success — diagnoses harness false-negatives (RC1-RC4). Used to localize §70 RC3 in 5 minutes on gx10.
+- `APR_GPU_STAGE_DUMP=<dir>` (PR #1649): GPU-side per-stage F32 tensor dump in APRT format. Captures Embedding, PostFfnResidual @ last layer, FinalNorm, LmHead on the GPU forward path. Used to localize §74/§75 SHIP-007 bug to F32 GEMV via stage-by-stage stats analysis (no per-element diff needed).
+- `APR_LM_HEAD_FORCE_QTYPE=<q4k|q5k|q6k|f32>` (PR #1651): env-gated override for LM head quantization-type detection. Used as bisection probe during §74 investigation; kept as diagnostic.
+
+#### Falsifiable contracts
+
+- `contracts/apr-eval-humaneval-harness-invariant-v1.yaml` v1.1.0 (PR #1634/#1635): 2 equations + 3 proof obligations + 5 falsifiers (FALSIFY-HEH-001..005) covering the §69 harness-invariant class. `pv validate` PASS.
+- `contracts/apr-ship-007-gpu-stage-bisection-v1.yaml` v1.0.0 (PR #1648): 2 equations + 3 proof obligations + 4 falsifiers (FALSIFY-SHIP-007-GPU-001..004) scaffolding the SHIP-007 cascade.
+
+#### MBPP harness fix
+
+- `run_mbpp_inference` routed through `realizar::run_inference` + ChatML auto-wrap + code-block extraction + canonical MBPP prompt format (test-list hint). 1-problem smoke flips MBPP/11 from FAIL→PASS; 5-problem smoke at 4/5 pass@1 (PRs #1641, #1645).
+
+### Methodology lessons captured
+
+Lessons #16-#22 in `MEMORY.md`:
+- #16 Compose falsifiers via manual end-to-end replication (§69)
+- #17 Pre-fix RED smoke can mask the bug class (§70)
+- #18 Predict-then-verify closes a cascade (§70 → §71)
+- #19 Algorithm-level falsifiers + small evidence runs collapse PARTIAL→LIVE in batches (§72)
+- #20 Re-measure cascade layers before continuing (§73)
+- #21 Stage-by-stage numerical analysis localizes bug class without per-element diffing (§74)
+- #22 Symptom analysis → bug class localization in O(1); methodology lessons compose (§75)
+
+### Spec versions
+
+`docs/specifications/aprender-train/ship-two-models-spec.md`: 3.13.0 → **3.21.0** across §67, §68, §69, §70, §71, §72, §73, §74, §75 (9 amendments over 2 days).
+
+### Cascade arc summary
+
+| Date | § | What |
+|------|---|------|
+| 2026-05-12 | 67-72 | SHIP-005 cascade: H4 → RC3 → LIVE-DISCHARGED at 86.59% pass@1; 5-AC LIVE evidence cascade (SHIP-001/003/004/009/010 PARTIAL→LIVE) |
+| 2026-05-12 | 73 | SHIP-007 cascade scope reduced from 3 layers to 1 (FP8 + throughput already fixed; only parity blocks) |
+| 2026-05-13 | 74-75 | SHIP-007 bug LOCALIZED to F32 GEMV via PR-B stage bisection → 1-PR layout fix → MODEL-1 100% |
+
+13 PRs shipped over 2 calendar days. PR-E (#1651) was the single-file layout fix.
+
 ## [0.32.0] - 2026-05-05
 
 ### Breaking

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.32.0"
+version = "0.33.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/paiml/aprender"
@@ -171,7 +171,7 @@ minijinja = { version = "2.14", features = ["loader", "serde"] }
 # Contracts
 provable-contracts = "0.3"
 provable-contracts-macros = "0.3"
-aprender-contracts-macros = { path = "crates/aprender-contracts-macros", version = "0.32.0" }
+aprender-contracts-macros = { path = "crates/aprender-contracts-macros", version = "0.33.0" }
 
 # YAML
 serde_yaml = "0.9"
@@ -183,30 +183,30 @@ hf-hub = { version = "0.4", default-features = false, features = ["ureq"] }
 hf-xet = "1.5.1"
 
 # Workspace-internal crates (paths within the monorepo)
-aprender-compute = { path = "crates/aprender-compute", version = "0.32.0" }
-aprender-gpu = { path = "crates/aprender-gpu", version = "0.32.0" }
-aprender-quant = { path = "crates/aprender-quant", version = "0.32.0" }
-aprender-serve = { path = "crates/aprender-serve", version = "0.32.0" }
-realizar = { path = "crates/aprender-serve", version = "0.32.0", package = "aprender-serve" }
-aprender-train = { path = "crates/aprender-train", version = "0.32.0" }
-entrenar = { path = "crates/aprender-train", version = "0.32.0", package = "aprender-train" }
-aprender-train-common = { path = "crates/aprender-train-common", version = "0.32.0" }
-aprender-orchestrate = { path = "crates/aprender-orchestrate", version = "0.32.0" }
-aprender-contracts = { path = "crates/aprender-contracts", version = "0.32.0" }
-aprender-profile = { path = "crates/aprender-profile", version = "0.32.0" }
-aprender-profile-core = { path = "crates/aprender-profile-core", version = "0.32.0" }
-aprender-zram-core = { path = "crates/aprender-zram-core", version = "0.32.0" }
-aprender-zram-adaptive = { path = "crates/aprender-zram-adaptive", version = "0.32.0" }
-aprender-present-core = { path = "crates/aprender-present-core", version = "0.32.0" }
-aprender-present-terminal = { path = "crates/aprender-present-terminal", version = "0.32.0" }
-aprender-present-widgets = { path = "crates/aprender-present-widgets", version = "0.32.0" }
-aprender-present-layout = { path = "crates/aprender-present-layout", version = "0.32.0" }
-aprender-present-yaml = { path = "crates/aprender-present-yaml", version = "0.32.0" }
-aprender-present-test = { path = "crates/aprender-present-test", version = "0.32.0" }
-aprender-db = { path = "crates/aprender-db", version = "0.32.0" }
-aprender-graph = { path = "crates/aprender-graph", version = "0.32.0" }
-aprender-rag = { path = "crates/aprender-rag", version = "0.32.0" }
-aprender-data = { path = "crates/aprender-data", version = "0.32.0" }
+aprender-compute = { path = "crates/aprender-compute", version = "0.33.0" }
+aprender-gpu = { path = "crates/aprender-gpu", version = "0.33.0" }
+aprender-quant = { path = "crates/aprender-quant", version = "0.33.0" }
+aprender-serve = { path = "crates/aprender-serve", version = "0.33.0" }
+realizar = { path = "crates/aprender-serve", version = "0.33.0", package = "aprender-serve" }
+aprender-train = { path = "crates/aprender-train", version = "0.33.0" }
+entrenar = { path = "crates/aprender-train", version = "0.33.0", package = "aprender-train" }
+aprender-train-common = { path = "crates/aprender-train-common", version = "0.33.0" }
+aprender-orchestrate = { path = "crates/aprender-orchestrate", version = "0.33.0" }
+aprender-contracts = { path = "crates/aprender-contracts", version = "0.33.0" }
+aprender-profile = { path = "crates/aprender-profile", version = "0.33.0" }
+aprender-profile-core = { path = "crates/aprender-profile-core", version = "0.33.0" }
+aprender-zram-core = { path = "crates/aprender-zram-core", version = "0.33.0" }
+aprender-zram-adaptive = { path = "crates/aprender-zram-adaptive", version = "0.33.0" }
+aprender-present-core = { path = "crates/aprender-present-core", version = "0.33.0" }
+aprender-present-terminal = { path = "crates/aprender-present-terminal", version = "0.33.0" }
+aprender-present-widgets = { path = "crates/aprender-present-widgets", version = "0.33.0" }
+aprender-present-layout = { path = "crates/aprender-present-layout", version = "0.33.0" }
+aprender-present-yaml = { path = "crates/aprender-present-yaml", version = "0.33.0" }
+aprender-present-test = { path = "crates/aprender-present-test", version = "0.33.0" }
+aprender-db = { path = "crates/aprender-db", version = "0.33.0" }
+aprender-graph = { path = "crates/aprender-graph", version = "0.33.0" }
+aprender-rag = { path = "crates/aprender-rag", version = "0.33.0" }
+aprender-data = { path = "crates/aprender-data", version = "0.33.0" }
 
 # Additional external deps needed by sub-crates
 serde_yaml_ng = "0.10"
@@ -251,25 +251,25 @@ wasmtime = "43"
 bollard = "0.17"
 
 # Old crate name aliases (workspace = true refs in migrated sub-crates)
-trueno-zram-core = { path = "crates/aprender-zram-core", version = "0.32.0", package = "aprender-zram-core" }
-trueno-zram-adaptive = { path = "crates/aprender-zram-adaptive", version = "0.32.0", package = "aprender-zram-adaptive" }
-trueno = { path = "crates/aprender-compute", version = "0.32.0", package = "aprender-compute" }
-presentar-core = { path = "crates/aprender-present-core", version = "0.32.0", package = "aprender-present-core" }
-presentar-terminal = { path = "crates/aprender-present-terminal", version = "0.32.0", package = "aprender-present-terminal" }
-presentar-widgets = { path = "crates/aprender-present-widgets", version = "0.32.0", package = "aprender-present-widgets" }
-presentar-layout = { path = "crates/aprender-present-layout", version = "0.32.0", package = "aprender-present-layout" }
-presentar-yaml = { path = "crates/aprender-present-yaml", version = "0.32.0", package = "aprender-present-yaml" }
-presentar-test = { path = "crates/aprender-present-test", version = "0.32.0", package = "aprender-present-test" }
-presentar-test-macros = { path = "crates/aprender-present-test-macros", version = "0.32.0", package = "aprender-present-test-macros" }
-jugar-probar-derive = { path = "crates/aprender-test-derive", version = "0.32.0", package = "aprender-test-derive" }
-batuta-common = { path = "crates/aprender-common", version = "0.32.0", package = "aprender-common" }
+trueno-zram-core = { path = "crates/aprender-zram-core", version = "0.33.0", package = "aprender-zram-core" }
+trueno-zram-adaptive = { path = "crates/aprender-zram-adaptive", version = "0.33.0", package = "aprender-zram-adaptive" }
+trueno = { path = "crates/aprender-compute", version = "0.33.0", package = "aprender-compute" }
+presentar-core = { path = "crates/aprender-present-core", version = "0.33.0", package = "aprender-present-core" }
+presentar-terminal = { path = "crates/aprender-present-terminal", version = "0.33.0", package = "aprender-present-terminal" }
+presentar-widgets = { path = "crates/aprender-present-widgets", version = "0.33.0", package = "aprender-present-widgets" }
+presentar-layout = { path = "crates/aprender-present-layout", version = "0.33.0", package = "aprender-present-layout" }
+presentar-yaml = { path = "crates/aprender-present-yaml", version = "0.33.0", package = "aprender-present-yaml" }
+presentar-test = { path = "crates/aprender-present-test", version = "0.33.0", package = "aprender-present-test" }
+presentar-test-macros = { path = "crates/aprender-present-test-macros", version = "0.33.0", package = "aprender-present-test-macros" }
+jugar-probar-derive = { path = "crates/aprender-test-derive", version = "0.33.0", package = "aprender-test-derive" }
+batuta-common = { path = "crates/aprender-common", version = "0.33.0", package = "aprender-common" }
 # APR-MONO sibling aliases — MUST use workspace refs, NEVER crates.io versions.
 # Hard-pinning these to crates.io creates a diamond: sub-crates pull older
 # aprender versions → multiple `aprender` crates in Cargo.lock = MUDA.
-renacer = { path = "crates/aprender-profile", version = "0.32.0", package = "aprender-profile" }
-entrenar-lora = { path = "crates/aprender-train-lora", version = "0.32.0", package = "aprender-train-lora" }
-batuta = { path = "crates/aprender-orchestrate", version = "0.32.0", package = "aprender-orchestrate" }
-trueno-graph = { path = "crates/aprender-graph", version = "0.32.0", package = "aprender-graph" }
+renacer = { path = "crates/aprender-profile", version = "0.33.0", package = "aprender-profile" }
+entrenar-lora = { path = "crates/aprender-train-lora", version = "0.33.0", package = "aprender-train-lora" }
+batuta = { path = "crates/aprender-orchestrate", version = "0.33.0", package = "aprender-orchestrate" }
+trueno-graph = { path = "crates/aprender-graph", version = "0.33.0", package = "aprender-graph" }
 
 [workspace.lints.rust]
 # Safety
@@ -398,7 +398,7 @@ semicolon_if_nothing_returned = "allow"  # Style preference
 
 [package]
 name = "aprender"
-version = "0.32.0"
+version = "0.33.0"
 edition = "2021"
 rust-version = "1.89"
 authors = ["Noah Gift <noah@paiml.com>"]
@@ -428,7 +428,7 @@ required-features = ["cli"]
 # (e.g. apr-cookbook, downstream apps) don't pull apr-cli's heavy transitive
 # dep graph (renacer/profile/inference/zram/visualization). `cargo install
 # aprender` still works because `cli` is in default features. See GH-1599.
-apr-cli = { path = "crates/apr-cli", version = "0.32.0", default-features = true, optional = true }
+apr-cli = { path = "crates/apr-cli", version = "0.33.0", default-features = true, optional = true }
 # Core ML library (lib name = "aprender")
 aprender_ml = { path = "crates/aprender-core", version = ">=0.29", package = "aprender-core" }
 

--- a/crates/apr-cli/Cargo.toml
+++ b/crates/apr-cli/Cargo.toml
@@ -99,10 +99,10 @@ libc = "0.2"
 
 [dependencies]
 # Core aprender library
-aprender = { path = "../aprender-core", version = "0.32.0", package = "aprender-core", default-features = true, features = ["format-compression"] }
+aprender = { path = "../aprender-core", version = "0.33.0", package = "aprender-core", default-features = true, features = ["format-compression"] }
 
 # MCP (Model Context Protocol) server — `apr mcp` subcommand
-aprender-mcp = { path = "../aprender-mcp", version = "0.32.0" }
+aprender-mcp = { path = "../aprender-mcp", version = "0.33.0" }
 async-stream = "0.3"
 provable-contracts-macros = "0.3"
 

--- a/crates/aprender-bench-compute/Cargo.toml
+++ b/crates/aprender-bench-compute/Cargo.toml
@@ -11,7 +11,7 @@ disallowed_methods = "allow"
 
 [dependencies]
 # The implementation under test
-aprender = { path = "../aprender-core", version = "0.32.0", package = "aprender-core", features = ["format-quantize"] }
+aprender = { path = "../aprender-core", version = "0.33.0", package = "aprender-core", features = ["format-quantize"] }
 
 # Reference implementation for A/B comparison
 # Pure Rust (no BLAS) to keep comparison fair — both are pure Rust SIMD

--- a/crates/aprender-bench-tokenizer/Cargo.toml
+++ b/crates/aprender-bench-tokenizer/Cargo.toml
@@ -11,7 +11,7 @@ disallowed_methods = "allow"
 
 [dependencies]
 # The implementation under test
-aprender = { path = "../aprender-core", version = "0.32.0", package = "aprender-core" }
+aprender = { path = "../aprender-core", version = "0.33.0", package = "aprender-core" }
 
 # HuggingFace reference for A/B comparison
 # Regular dep (not dev-dep) because [[bench]] harness=false binaries can't see dev-deps

--- a/crates/aprender-cbtop/Cargo.toml
+++ b/crates/aprender-cbtop/Cargo.toml
@@ -23,8 +23,8 @@ presentar-core = "0.3"
 presentar-terminal = "0.3"
 
 # Compute backends
-trueno = { version = "0.32.0", path = "../aprender-compute", package = "aprender-compute" }
-trueno-gpu = { version = "0.32.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true }
+trueno = { version = "0.33.0", path = "../aprender-compute", package = "aprender-compute" }
+trueno-gpu = { version = "0.33.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true }
 
 # Terminal handling
 crossterm = "0.28"

--- a/crates/aprender-cgp/Cargo.toml
+++ b/crates/aprender-cgp/Cargo.toml
@@ -36,7 +36,7 @@ num_cpus = "1.17"
 comfy-table = "7"
 colored = "3"
 # GPU profiling: direct cuBLAS measurement (OWN THE STACK)
-trueno-gpu = { path = "../aprender-gpu", version = "0.32.0", features = ["cuda"], optional = true, package = "aprender-gpu" }
+trueno-gpu = { path = "../aprender-gpu", version = "0.33.0", features = ["cuda"], optional = true, package = "aprender-gpu" }
 
 [features]
 default = []

--- a/crates/aprender-compute/Cargo.toml
+++ b/crates/aprender-compute/Cargo.toml
@@ -38,11 +38,11 @@ futures-intrusive = { version = "0.5", optional = true }
 wasm-bindgen-futures = { version = "0.4", optional = true }
 wasm-bindgen = { version = "0.2", optional = true }
 # Native CUDA monitoring via trueno-gpu (TRUENO-SPEC-010)
-trueno-gpu = { version = "0.32.0", path = "../aprender-gpu", optional = true, package = "aprender-gpu" }
+trueno-gpu = { version = "0.33.0", path = "../aprender-gpu", optional = true, package = "aprender-gpu" }
 # PMAT-336: Provable contracts compile-time enforcement
 provable-contracts-macros = "0.3"
 # P1a: Sovereign GEMM microkernel codegen (compile-time shape specialization)
-trueno-gemm-codegen = { version = "0.32.0", path = "../aprender-gemm-codegen", package = "aprender-gemm-codegen" }
+trueno-gemm-codegen = { version = "0.33.0", path = "../aprender-gemm-codegen", package = "aprender-gemm-codegen" }
 # Tracing/profiling support (renacer integration)
 tracing = { version = "0.1", optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"], optional = true }
@@ -54,7 +54,7 @@ presentar-core = { version = "0.3", optional = true }
 # Stress test reporting types compatible with renacer (TRUENO-SPEC-025)
 # Note: renacer 0.9.1 has compilation issue; using compatible local types instead
 dhat = { version = "0.3", optional = true }
-trueno-quant = { version = "0.32.0", path = "../aprender-quant", package = "aprender-quant" }
+trueno-quant = { version = "0.33.0", path = "../aprender-quant", package = "aprender-quant" }
 num_cpus = "1.17.0"
 anyhow = "1.0.100"
 # Hardware capability detection (PMAT-447)
@@ -62,7 +62,7 @@ chrono = "0.4"
 toml = "0.8"
 # ML tuner integration (SHOWCASE-BRICK-001, Section 12)
 # Uses aprender 0.24.0 RandomForest for learned optimization
-aprender = { path = "../aprender-core", version = "0.32.0", package = "aprender-core", optional = true, default-features = false }
+aprender = { path = "../aprender-core", version = "0.33.0", package = "aprender-core", optional = true, default-features = false }
 # Execution path graph (PAR-201, Section E.7)
 trueno-graph = { workspace = true, optional = true }
 # TUI visualization for execution graphs (PAR-201)
@@ -90,10 +90,10 @@ nalgebra = "0.34"  # For eigendecomposition benchmark comparison
 simular = "0.2.0"
 regex = "1.11"  # For PTX/WGSL pattern validation in falsification tests
 # GPU edge-case test framework (TCE-001)
-trueno-cuda-edge = { version = "0.32.0", path = "../aprender-cuda-edge", package = "aprender-cuda-edge" }
+trueno-cuda-edge = { version = "0.33.0", path = "../aprender-cuda-edge", package = "aprender-cuda-edge" }
 # Sparse and solver crates for contract tests
-trueno-sparse = { version = "0.32.0", path = "../aprender-sparse", package = "aprender-sparse" }
-trueno-solve = { version = "0.32.0", path = "../aprender-solve", package = "aprender-solve" }
+trueno-sparse = { version = "0.33.0", path = "../aprender-sparse", package = "aprender-sparse" }
+trueno-solve = { version = "0.33.0", path = "../aprender-solve", package = "aprender-solve" }
 ndarray = "0.17.2"
 faer = "0.24"  # For GEMM benchmark comparison (fastest pure-Rust BLAS)
 matrixmultiply = "0.3"  # Direct matrixmultiply crate benchmark (engine behind ndarray)

--- a/crates/aprender-contracts-cli/Cargo.toml
+++ b/crates/aprender-contracts-cli/Cargo.toml
@@ -13,7 +13,7 @@ name = "pv"
 path = "src/main.rs"
 
 [dependencies]
-aprender-contracts = { path = "../aprender-contracts", version = "0.32.0" }
+aprender-contracts = { path = "../aprender-contracts", version = "0.33.0" }
 clap = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }

--- a/crates/aprender-contracts/Cargo.toml
+++ b/crates/aprender-contracts/Cargo.toml
@@ -19,7 +19,7 @@ kani = []
 name = "provable_contracts"
 
 [dependencies]
-provable-contracts-macros = { path = "../aprender-contracts-macros", version = "0.32.0", package = "aprender-contracts-macros" }
+provable-contracts-macros = { path = "../aprender-contracts-macros", version = "0.33.0", package = "aprender-contracts-macros" }
 regex = "1"
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/aprender-cuda-edge/Cargo.toml
+++ b/crates/aprender-cuda-edge/Cargo.toml
@@ -15,7 +15,7 @@ name = "trueno_cuda_edge"
 [dependencies]
 thiserror = "2.0"
 serde = { version = "1.0", features = ["derive"] }
-trueno-gpu = { version = "0.32.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true }
+trueno-gpu = { version = "0.33.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true }
 
 [dev-dependencies]
 proptest = "1.6"

--- a/crates/aprender-explain/Cargo.toml
+++ b/crates/aprender-explain/Cargo.toml
@@ -25,7 +25,7 @@ presentar-terminal = "0.3"
 crossterm = "0.28"
 
 # Internal dependency for PTX generation
-trueno-gpu = { version = "0.32.0", path = "../aprender-gpu", package = "aprender-gpu", features = ["cuda"] }
+trueno-gpu = { version = "0.33.0", path = "../aprender-gpu", package = "aprender-gpu", features = ["cuda"] }
 
 [dev-dependencies]
 proptest = "1.4"

--- a/crates/aprender-graph/Cargo.toml
+++ b/crates/aprender-graph/Cargo.toml
@@ -28,7 +28,7 @@ anyhow = "1"
 thiserror = "2"
 
 # Phase 2+ dependencies
-aprender = { path = "../aprender-core", version = "0.32.0", package = "aprender-core" }                                        # Sparse matrix ops, PageRank
+aprender = { path = "../aprender-core", version = "0.33.0", package = "aprender-core" }                                        # Sparse matrix ops, PageRank
 trueno = "0.17"                                          # SIMD primitives
 trueno-db = "0.3.17"                                     # Columnar storage
 

--- a/crates/aprender-monte-carlo/Cargo.toml
+++ b/crates/aprender-monte-carlo/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 name = "aprender-monte-carlo"
 
 [dependencies]
-aprender = { path = "../../", version = "0.32.0" }
+aprender = { path = "../../", version = "0.33.0" }
 clap = { version = "4", features = ["derive"] }
 rand = "0.9"
 rand_chacha = "0.9"

--- a/crates/aprender-orchestrate/Cargo.toml
+++ b/crates/aprender-orchestrate/Cargo.toml
@@ -113,7 +113,7 @@ pacha = { version = "0.2", optional = true }
 realizar = { version = "0.8", optional = true, features = ["cuda"] }
 
 # ML algorithms and training (native-only)
-aprender = { path = "../aprender-core", version = "0.32.0", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.33.0", package = "aprender-core", optional = true }
 entrenar = { workspace = true, optional = true }
 alimentar = { version = "0.2", optional = true }
 

--- a/crates/aprender-profile/Cargo.toml
+++ b/crates/aprender-profile/Cargo.toml
@@ -74,7 +74,7 @@ trueno = { version = "0.17" }
 
 # Machine learning for anomaly detection (Sprint 23)
 # GH-581: Use path dep to avoid trueno version skew with local workspace
-aprender = { path = "../aprender-core", version = "0.32.0", package = "aprender-core" }
+aprender = { path = "../aprender-core", version = "0.33.0", package = "aprender-core" }
 
 # Lock-free data structures for ring buffer (Sprint 40)
 crossbeam = { version = "0.8", default-features = false, features = ["crossbeam-channel", "crossbeam-queue", "std"] }

--- a/crates/aprender-qa-runner/Cargo.toml
+++ b/crates/aprender-qa-runner/Cargo.toml
@@ -29,7 +29,7 @@ sha2 = "0.10"
 regex = { workspace = true }
 num_cpus = "1.16"
 safetensors = { workspace = true }
-jugar-probar = { version = "0.32.0", path = "../aprender-test-lib", package = "aprender-test-lib", features = ["llm-types"] }
+jugar-probar = { version = "0.33.0", path = "../aprender-test-lib", package = "aprender-test-lib", features = ["llm-types"] }
 # Test fixtures dependencies (optional)
 tempfile = { version = "3", optional = true }
 half = { version = "2.4", optional = true }

--- a/crates/aprender-registry/Cargo.toml
+++ b/crates/aprender-registry/Cargo.toml
@@ -42,7 +42,7 @@ zstd = { version = "0.13", optional = true }
 clap = { version = "4", features = ["derive"], optional = true }
 
 # Ecosystem integration
-aprender = { path = "../aprender-core", version = "0.32.0", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.33.0", package = "aprender-core", optional = true }
 alimentar = { version = "0.2.3", optional = true }
 
 # HTTP client (optional)

--- a/crates/aprender-serve/Cargo.toml
+++ b/crates/aprender-serve/Cargo.toml
@@ -39,7 +39,7 @@ name = "realizar"
 trueno = { version = "0.17", features = ["gpu"] }
 # CUDA PTX generation and runtime for NVIDIA GPUs (optional, pure Rust, no LLVM/nvcc)
 # v0.4.12: BatchedQ6K, MultiWarp, RopeNeox, FlashDecoding kernels
-trueno-gpu = { version = "0.32.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true, features = ["cuda"] }  # APR-MONO single-source-of-truth
+trueno-gpu = { version = "0.33.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true, features = ["cuda"] }  # APR-MONO single-source-of-truth
 # KV cache storage (for attention caching)
 trueno-db = { version = "0.3.16", optional = true }
 # K-quantization formats (Q4_K, Q5_K, Q6_K) - Toyota Way: ONE source of truth
@@ -53,7 +53,7 @@ renacer-core = { version = "0.1" }
 
 # ML algorithms and .apr model format (optional for aprender model serving)
 # v0.24.1: chat templates, GGUF tokenizer preservation (local may be newer)
-aprender = { path = "../aprender-core", version = "0.32.0", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.33.0", package = "aprender-core", optional = true }
 
 # Data loading library (optional for data pipeline examples)
 alimentar = { version = "0.2", optional = true, default-features = false, features = ["local", "shuffle"] }

--- a/crates/aprender-shell/Cargo.toml
+++ b/crates/aprender-shell/Cargo.toml
@@ -24,7 +24,7 @@ harness = false
 
 [dependencies]
 # Use path for local dev, crates.io for release
-aprender = { path = "../aprender-core", version = "0.32.0", package = "aprender-core", features = ["format-encryption", "format-compression", "format-homomorphic"] }
+aprender = { path = "../aprender-core", version = "0.33.0", package = "aprender-core", features = ["format-encryption", "format-compression", "format-homomorphic"] }
 clap = { version = "4", features = ["derive"] }
 dirs = "5"
 serde = { version = "1", features = ["derive"] }

--- a/crates/aprender-test-cli/Cargo.toml
+++ b/crates/aprender-test-cli/Cargo.toml
@@ -24,7 +24,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Core library (was: jugar-probar) — dep key preserves Rust identifier
-jugar-probar = { path = "../aprender-test-lib", version = "0.32.0", package = "aprender-test-lib" }
+jugar-probar = { path = "../aprender-test-lib", version = "0.33.0", package = "aprender-test-lib" }
 
 # CLI framework
 clap = { workspace = true }

--- a/crates/aprender-train-bench/Cargo.toml
+++ b/crates/aprender-train-bench/Cargo.toml
@@ -19,8 +19,8 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-entrenar = { version = "0.32.0", path = "../aprender-train", package = "aprender-train" }
-entrenar-common = { version = "0.32.0", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar = { version = "0.33.0", path = "../aprender-train", package = "aprender-train" }
+entrenar-common = { version = "0.33.0", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/aprender-train-distill/Cargo.toml
+++ b/crates/aprender-train-distill/Cargo.toml
@@ -23,8 +23,8 @@ default = []
 hub = ["entrenar/hub"]
 
 [dependencies]
-entrenar = { version = "0.32.0", path = "../aprender-train", package = "aprender-train" }
-entrenar-common = { version = "0.32.0", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar = { version = "0.33.0", path = "../aprender-train", package = "aprender-train" }
+entrenar-common = { version = "0.33.0", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/aprender-train-inspect/Cargo.toml
+++ b/crates/aprender-train-inspect/Cargo.toml
@@ -19,8 +19,8 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-entrenar = { version = "0.32.0", path = "../aprender-train", package = "aprender-train" }
-entrenar-common = { version = "0.32.0", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar = { version = "0.33.0", path = "../aprender-train", package = "aprender-train" }
+entrenar-common = { version = "0.33.0", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/aprender-train-lora/Cargo.toml
+++ b/crates/aprender-train-lora/Cargo.toml
@@ -19,8 +19,8 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-entrenar = { version = "0.32.0", path = "../aprender-train", package = "aprender-train" }
-entrenar-common = { version = "0.32.0", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar = { version = "0.33.0", path = "../aprender-train", package = "aprender-train" }
+entrenar-common = { version = "0.33.0", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/aprender-train-shell/Cargo.toml
+++ b/crates/aprender-train-shell/Cargo.toml
@@ -19,8 +19,8 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-entrenar = { version = "0.32.0", path = "../aprender-train", package = "aprender-train" }
-entrenar-common = { version = "0.32.0", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar = { version = "0.33.0", path = "../aprender-train", package = "aprender-train" }
+entrenar-common = { version = "0.33.0", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 rustyline = "14"
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/aprender-train/Cargo.toml
+++ b/crates/aprender-train/Cargo.toml
@@ -75,9 +75,9 @@ provable-contracts-macros = { version = "0.2" }
 # Core PAIML stack
 ndarray = "0.16"
 trueno = { version = "0.17", features = ["parallel"] }  # SIMD-accelerated compute
-trueno-gpu = { version = "0.32.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true }  # CUDA compute (APR-MONO single-source-of-truth)
+trueno-gpu = { version = "0.33.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true }  # CUDA compute (APR-MONO single-source-of-truth)
 realizar = { version = "0.8", optional = true }  # CUDA inference engine
-aprender = { path = "../aprender-core", version = "0.32.0", package = "aprender-core" }  # ML interpret module + .apr format + tokenizers
+aprender = { path = "../aprender-core", version = "0.33.0", package = "aprender-core" }  # ML interpret module + .apr format + tokenizers
 trueno-viz = { version = "0.2", features = ["terminal"] }  # Terminal visualization
 presentar-terminal = { version = "0.3.5", optional = true }  # Sovereign TUI framework (gated by "tui" feature)
 presentar-core = "0.3.4"  # Presentar core traits (crates.io — path removed, presentar restructured)

--- a/crates/aprender-tsp/Cargo.toml
+++ b/crates/aprender-tsp/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 name = "aprender-tsp"
 
 [dependencies]
-aprender = { path = "../../", version = "0.32.0" }
+aprender = { path = "../../", version = "0.33.0" }
 clap = { version = "4", features = ["derive"] }
 rand = "0.9"
 crc32fast = "1.4"

--- a/crates/aprender-verify-ml/Cargo.toml
+++ b/crates/aprender-verify-ml/Cargo.toml
@@ -50,7 +50,7 @@ uuid = { version = "1.11", features = ["v4", "serde"] }
 trueno = "0.7.3"
 
 # Machine learning for bug prediction (optional)
-aprender = { path = "../aprender-core", version = "0.32.0", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.33.0", package = "aprender-core", optional = true }
 
 # LLM fine-tuning integration (optional)
 entrenar = { workspace = true, optional = true }

--- a/crates/aprender-viz/Cargo.toml
+++ b/crates/aprender-viz/Cargo.toml
@@ -29,7 +29,7 @@ base64 = "0.22"
 thiserror = "2.0"
 
 # Optional: ML integration
-aprender = { path = "../aprender-core", version = "0.32.0", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.33.0", package = "aprender-core", optional = true }
 
 # Optional: Graph integration
 trueno-graph = { workspace = true, optional = true, default-features = false }


### PR DESCRIPTION
## 🎉 v0.33.0 marks MODEL-1 SHIP % = 100%

This is the release prep PR. Ships the version bump + CHANGELOG narrative for the SHIP-TWO-001 MODEL-1 100% milestone. Actual crates.io publish + GitHub release happen after merge + post-publish QA.

## What ships

1. **CHANGELOG.md [0.33.0]** entry:
   - 🎉 MODEL-1 SHIP % = 100% — all 10 AC-SHIP1-* LIVE-discharged table
   - **Fixed**: SHIP-007 F32 GEMV PTX layout (PR #1651) → 124.6 tok/s
   - **Fixed**: SHIP-005 HumanEval RC3 (PR #1635) → pass@1 86.59%
   - **Added**: `APR_EVAL_DEBUG=1` + `APR_GPU_STAGE_DUMP=<dir>` diagnostic surfaces
   - **Added**: MBPP harness H4 fix (PR #1645)
   - **Added**: 2 falsifiable contracts (`apr-eval-humaneval-harness-invariant-v1` v1.1.0, `apr-ship-007-gpu-stage-bisection-v1` v1.0.0)
   - Methodology lessons #16-22
   - Spec: v3.13.0 → v3.21.0 (§67-§75)

2. **Workspace version**: 0.32.0 → 0.33.0
   - `[workspace.package].version`
   - Root `[package].version` (aprender facade crate)
   - 28 sub-crate version literals batch-updated

3. `cargo check -p aprender` → clean

## Out of scope (post-merge steps)

After this PR lands + #1651/1652 land:
- Tag `v0.33.0` on main
- Cascade publish to crates.io in topological dependency order (per `project_ship_two_001_v0_32_0_release.md`)
- Post-publish QA: `cargo install aprender --force` + `/dogfood` GO verdict (memory: `feedback_post_publish_qa_required.md` — v0.31.1 yanked for skipping)
- GitHub Release with §75 narrative

## Test plan

- [x] `cargo check -p aprender` → clean at v0.33.0
- [x] All version refs in workspace updated (0 remaining literals)
- [x] CHANGELOG entry mirrors the §69-§75 cascade
- [ ] CI runs (workspace-test container)

## Refs

- §75 (PR #1652) MODEL-1 100% spec
- §74 (PR #1650) SHIP-007 localized
- PRs #1633/1634/1635/1636/1642/1646/1647/1648/1649/1650/1651/1652 (the §69-§75 cascade)
- `feedback_post_publish_qa_required.md` (post-publish QA rule)

🤖 Generated with [Claude Code](https://claude.com/claude-code)