### PR TITLE
fix(apr-cli serve): try Q4K pool-allocator path before generic GPU dispatch (closes #471)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,7 +284,7 @@ dependencies = [
 
 [[package]]
 name = "apr-cli"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "alimentar",
  "anyhow",
@@ -399,7 +399,7 @@ dependencies = [
 
 [[package]]
 name = "aprender"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "apr-cli",
  "aprender-core",
@@ -407,7 +407,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-bench-compute"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-core",
  "criterion 0.7.0",
@@ -416,7 +416,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-bench-tokenizer"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-core",
  "criterion 0.7.0",
@@ -425,7 +425,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cbtop"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "aprender-compute",
@@ -450,7 +450,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cgp"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "aprender-gpu",
@@ -470,7 +470,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-common"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "lz4_flex 0.11.6",
  "zstd",
@@ -478,7 +478,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-compute"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "aprender-core",
@@ -527,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-compute-xtask"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "bashrs",
@@ -540,7 +540,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-contracts"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-contracts-macros",
  "criterion 0.5.1",
@@ -555,7 +555,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-contracts-cli"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-contracts",
  "clap",
@@ -566,7 +566,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-contracts-macros"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -576,7 +576,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-core"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aes-gcm",
  "alimentar",
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cuda-edge"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-gpu",
  "proptest",
@@ -639,7 +639,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cupti"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "bindgen 0.71.1",
  "bitflags 2.11.0",
@@ -649,7 +649,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-data"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-db"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "arrow 57.3.0",
@@ -746,7 +746,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-distribute"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "arrow 57.3.0",
  "bincode",
@@ -777,7 +777,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-explain"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-gpu",
  "clap",
@@ -795,7 +795,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-fft"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -804,7 +804,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-gemm-codegen"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-gpu"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-profile",
  "batuta-common",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-graph"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "aprender-core",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-image"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-mcp"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -882,9 +882,9 @@ dependencies = [
 
 [[package]]
 name = "aprender-monte-carlo"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
- "aprender 0.32.0",
+ "aprender 0.33.0",
  "assert_cmd",
  "chrono",
  "clap",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-orchestrate"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "alimentar",
  "anyhow",
@@ -974,7 +974,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-cli"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-present-yaml",
  "clap",
@@ -987,7 +987,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-core"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-compute",
  "criterion 0.7.0",
@@ -1000,7 +1000,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-layout"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-present-core",
  "criterion 0.7.0",
@@ -1011,7 +1011,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-lib"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-present-core",
  "aprender-present-layout",
@@ -1040,7 +1040,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-terminal"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-present-core",
  "bitvec",
@@ -1062,7 +1062,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-test"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-present-core",
  "aprender-present-test-macros",
@@ -1073,7 +1073,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-test-macros"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1082,7 +1082,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-widgets"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-present-core",
  "aprender-present-yaml",
@@ -1094,7 +1094,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-yaml"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-present-core",
  "proptest",
@@ -1104,7 +1104,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-profile"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "addr2line 0.25.1",
  "anyhow",
@@ -1157,7 +1157,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-profile-core"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "hex",
  "serde",
@@ -1167,7 +1167,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-ptx-debug"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "proptest",
  "thiserror 2.0.18",
@@ -1175,7 +1175,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-certify"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "chrono",
  "proptest",
@@ -1185,7 +1185,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-cli"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-qa-certify",
  "aprender-qa-gen",
@@ -1204,7 +1204,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-gen"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1221,7 +1221,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-report"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "aprender-qa-gen",
@@ -1239,7 +1239,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-runner"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "aprender-qa-gen",
@@ -1264,14 +1264,14 @@ dependencies = [
 
 [[package]]
 name = "aprender-quant"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "half",
 ]
 
 [[package]]
 name = "aprender-rag"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "async-trait",
  "batuta-common",
@@ -1302,7 +1302,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-rand"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1311,7 +1311,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-registry"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "alimentar",
  "anyhow",
@@ -1341,7 +1341,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-serve"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "alimentar",
  "anyhow",
@@ -1408,7 +1408,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-shell"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-core",
  "assert_cmd",
@@ -1425,7 +1425,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-simulate"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "bincode",
  "bitflags 2.11.0",
@@ -1464,7 +1464,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-solve"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1473,7 +1473,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-sparse"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1482,7 +1482,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-tensor"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1491,7 +1491,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-cli"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-test-lib",
  "assert_cmd",
@@ -1519,7 +1519,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-derive"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1529,7 +1529,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-js-gen"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -1545,7 +1545,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-lib"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-compute",
  "aprender-present-core",
@@ -1589,7 +1589,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-showcase"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-present-terminal",
  "console_error_panic_hook",
@@ -1606,7 +1606,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "alimentar",
  "approx",
@@ -1673,7 +1673,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-bench"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1690,7 +1690,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-common"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "clap",
  "proptest",
@@ -1702,7 +1702,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-distill"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1723,7 +1723,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-inspect"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1739,7 +1739,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-lora"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1755,7 +1755,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-shell"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1771,7 +1771,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-wasm"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "proptest",
  "serde",
@@ -1782,9 +1782,9 @@ dependencies = [
 
 [[package]]
 name = "aprender-tsp"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
- "aprender 0.32.0",
+ "aprender 0.33.0",
  "assert_cmd",
  "clap",
  "crc32fast",
@@ -1797,7 +1797,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-verify"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "chrono",
  "criterion 0.5.1",
@@ -1809,7 +1809,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-verify-ml"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-core",
  "aprender-profile",
@@ -1853,7 +1853,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-viz"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "approx",
  "aprender-core",
@@ -1888,7 +1888,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-zram-adaptive",
  "aprender-zram-core",
@@ -1898,7 +1898,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-adaptive"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-zram-core",
  "proptest",
@@ -1907,7 +1907,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-cli"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-zram-adaptive",
  "aprender-zram-core",
@@ -1921,7 +1921,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-core"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-gpu",
  "criterion 0.7.0",
@@ -1933,7 +1933,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-generator"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-zram-core",
  "serde",

--- a/crates/apr-cli/src/commands/serve/handlers.rs
+++ b/crates/apr-cli/src/commands/serve/handlers.rs
@@ -1008,11 +1008,35 @@ struct AprCompletionResponse {
 }
 
 fn start_apr_server(model_path: &Path, config: &ServerConfig) -> Result<()> {
-    // GH-87: Try fused Q4K GPU path first (same kernels as GGUF, 190+ tok/s)
+    // GH-471: For Q4K APR models, try the pool-allocator path first. The
+    // generic OwnedQuantizedModel::from_apr() path hangs on large (17GB+ /
+    // 18k tensor) MoE models because it does per-tensor cuMemAlloc; the
+    // ALB-095/098 Q4K scheduler does a single pool cuMemAlloc and loads
+    // the same 30B Q4K MoE in ~12s vs hanging indefinitely.
+    //
+    // The Q4K path's spawn_apr_q4k_inference_thread does its own metadata
+    // validation (`parse_apr_q4k_config`) and weight-format check
+    // (`upload_apr_q4k_weights` rejects non-Q4K tensors), so passing a
+    // non-Q4K APR errors cleanly and falls through to the generic GPU path.
+    //
+    // Without `cuda-batch` feature this function is a stub that errors
+    // immediately, so the fallback chain stays identical for non-batch builds.
     #[cfg(feature = "cuda")]
     {
         let use_gpu = config.gpu && !config.no_gpu;
         if use_gpu {
+            match start_apr_q4k_server_gpu(model_path, config) {
+                Ok(()) => return Ok(()),
+                Err(e) => {
+                    // Common case for non-Q4K APR — fall through quietly to
+                    // the generic GPU path (which handles dequant + small models).
+                    eprintln!(
+                        "[GH-471] Q4K pool-allocator path declined ({e}), trying generic GPU path"
+                    );
+                }
+            }
+            // GH-87: fused Q4K GPU path (same kernels as GGUF, 190+ tok/s).
+            // Handles dequantized + non-Q4K APR via OwnedQuantizedModel::from_apr.
             match start_apr_server_gpu(model_path, config) {
                 Ok(()) => return Ok(()),
                 Err(e) => {


### PR DESCRIPTION
## Summary

Closes #471. \`apr serve run <model.apr> --gpu\` hung indefinitely on 17 GB / 18k-tensor Q4K MoE models (qwen3-coder-30b). \`realizar serve --gpu\` loaded the same file in ~12 s using \`spawn_apr_q4k_inference_thread\`'s pool allocator.

Root cause: \`start_apr_q4k_server_gpu\` (already implemented in \`handlers_include_01.rs:96\`) was compiled in but NEVER called from \`start_apr_server\`.

## Fix

Dispatch \`start_apr_q4k_server_gpu\` before \`start_apr_server_gpu\` when \`--gpu\` is requested:

\`\`\`rust
match start_apr_q4k_server_gpu(model_path, config) {
    Ok(()) => return Ok(()),
    Err(e) => { eprintln!(\"[GH-471] declined: {e}\"); }
}
match start_apr_server_gpu(model_path, config) { /* existing fallback */ }
\`\`\`

The Q4K path's \`parse_apr_q4k_config\` + \`upload_apr_q4k_weights\` already validate the model shape, so passing non-Q4K APRs through it fails cleanly. The \`cuda\`-only stub (no \`cuda-batch\`) errors immediately, preserving existing behavior for non-batch builds.

## Test plan

- [x] \`cargo check -p apr-cli --features cuda\` clean
- [x] \`cargo check -p apr-cli --features cuda-batch\` clean
- [ ] CI: workspace-test
- [ ] Optional: \`apr serve run qwen3-coder-30b-q4k.apr --gpu --features cuda-batch\` exits load phase in <20s

🤖 Generated with [Claude Code](https://claude.com/claude-code)