### PR TITLE
perf(quantize): pre-allocated slice writes for Q8_0/Q4_0 dequant (refs #386)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,7 +284,7 @@ dependencies = [
 
 [[package]]
 name = "apr-cli"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "alimentar",
  "anyhow",
@@ -399,7 +399,7 @@ dependencies = [
 
 [[package]]
 name = "aprender"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "apr-cli",
  "aprender-core",
@@ -407,7 +407,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-bench-compute"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-core",
  "criterion 0.7.0",
@@ -416,7 +416,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-bench-tokenizer"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-core",
  "criterion 0.7.0",
@@ -425,7 +425,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cbtop"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "aprender-compute",
@@ -450,7 +450,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cgp"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "aprender-gpu",
@@ -470,7 +470,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-common"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "lz4_flex 0.11.6",
  "zstd",
@@ -478,7 +478,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-compute"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "aprender-core",
@@ -527,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-compute-xtask"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "bashrs",
@@ -540,7 +540,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-contracts"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-contracts-macros",
  "criterion 0.5.1",
@@ -555,7 +555,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-contracts-cli"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-contracts",
  "clap",
@@ -566,7 +566,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-contracts-macros"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -576,7 +576,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-core"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aes-gcm",
  "alimentar",
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cuda-edge"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-gpu",
  "proptest",
@@ -639,7 +639,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cupti"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "bindgen 0.71.1",
  "bitflags 2.11.0",
@@ -649,7 +649,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-data"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-db"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "arrow 57.3.0",
@@ -746,7 +746,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-distribute"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "arrow 57.3.0",
  "bincode",
@@ -777,7 +777,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-explain"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-gpu",
  "clap",
@@ -795,7 +795,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-fft"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -804,7 +804,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-gemm-codegen"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-gpu"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-profile",
  "batuta-common",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-graph"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "aprender-core",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-image"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-mcp"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -882,9 +882,9 @@ dependencies = [
 
 [[package]]
 name = "aprender-monte-carlo"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
- "aprender 0.32.0",
+ "aprender 0.33.0",
  "assert_cmd",
  "chrono",
  "clap",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-orchestrate"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "alimentar",
  "anyhow",
@@ -974,7 +974,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-cli"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-present-yaml",
  "clap",
@@ -987,7 +987,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-core"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-compute",
  "criterion 0.7.0",
@@ -1000,7 +1000,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-layout"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-present-core",
  "criterion 0.7.0",
@@ -1011,7 +1011,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-lib"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-present-core",
  "aprender-present-layout",
@@ -1040,7 +1040,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-terminal"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-present-core",
  "bitvec",
@@ -1062,7 +1062,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-test"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-present-core",
  "aprender-present-test-macros",
@@ -1073,7 +1073,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-test-macros"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1082,7 +1082,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-widgets"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-present-core",
  "aprender-present-yaml",
@@ -1094,7 +1094,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-yaml"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-present-core",
  "proptest",
@@ -1104,7 +1104,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-profile"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "addr2line 0.25.1",
  "anyhow",
@@ -1157,7 +1157,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-profile-core"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "hex",
  "serde",
@@ -1167,7 +1167,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-ptx-debug"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "proptest",
  "thiserror 2.0.18",
@@ -1175,7 +1175,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-certify"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "chrono",
  "proptest",
@@ -1185,7 +1185,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-cli"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-qa-certify",
  "aprender-qa-gen",
@@ -1204,7 +1204,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-gen"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1221,7 +1221,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-report"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "aprender-qa-gen",
@@ -1239,7 +1239,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-runner"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "aprender-qa-gen",
@@ -1264,14 +1264,14 @@ dependencies = [
 
 [[package]]
 name = "aprender-quant"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "half",
 ]
 
 [[package]]
 name = "aprender-rag"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "async-trait",
  "batuta-common",
@@ -1302,7 +1302,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-rand"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1311,7 +1311,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-registry"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "alimentar",
  "anyhow",
@@ -1341,7 +1341,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-serve"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "alimentar",
  "anyhow",
@@ -1408,7 +1408,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-shell"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-core",
  "assert_cmd",
@@ -1425,7 +1425,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-simulate"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "bincode",
  "bitflags 2.11.0",
@@ -1464,7 +1464,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-solve"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1473,7 +1473,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-sparse"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1482,7 +1482,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-tensor"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1491,7 +1491,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-cli"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-test-lib",
  "assert_cmd",
@@ -1519,7 +1519,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-derive"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1529,7 +1529,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-js-gen"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -1545,7 +1545,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-lib"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-compute",
  "aprender-present-core",
@@ -1589,7 +1589,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-showcase"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-present-terminal",
  "console_error_panic_hook",
@@ -1606,7 +1606,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "alimentar",
  "approx",
@@ -1673,7 +1673,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-bench"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1690,7 +1690,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-common"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "clap",
  "proptest",
@@ -1702,7 +1702,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-distill"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1723,7 +1723,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-inspect"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1739,7 +1739,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-lora"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1755,7 +1755,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-shell"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1771,7 +1771,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-wasm"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "proptest",
  "serde",
@@ -1782,9 +1782,9 @@ dependencies = [
 
 [[package]]
 name = "aprender-tsp"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
- "aprender 0.32.0",
+ "aprender 0.33.0",
  "assert_cmd",
  "clap",
  "crc32fast",
@@ -1797,7 +1797,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-verify"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "chrono",
  "criterion 0.5.1",
@@ -1809,7 +1809,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-verify-ml"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-core",
  "aprender-profile",
@@ -1853,7 +1853,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-viz"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "approx",
  "aprender-core",
@@ -1888,7 +1888,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-zram-adaptive",
  "aprender-zram-core",
@@ -1898,7 +1898,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-adaptive"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-zram-core",
  "proptest",
@@ -1907,7 +1907,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-cli"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-zram-adaptive",
  "aprender-zram-core",
@@ -1921,7 +1921,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-core"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-gpu",
  "criterion 0.7.0",
@@ -1933,7 +1933,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-generator"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aprender-zram-core",
  "serde",

--- a/crates/aprender-core/src/format/quantize.rs
+++ b/crates/aprender-core/src/format/quantize.rs
@@ -263,7 +263,12 @@ impl Quantizer for Q8_0Quantizer {
             });
         }
 
-        let mut result = Vec::with_capacity(total_elements);
+        // GH-386: pre-allocate output and write directly to slice ranges so
+        // the inner loop is a tight `i8 → f32 * scale` over a fixed-size local
+        // [i8; 32]. LLVM auto-vectorizes this pattern into AVX2/NEON SIMD,
+        // replacing the previous `Vec::push` loop that bottlenecked on
+        // per-element capacity-growth checks.
+        let mut result = vec![0.0f32; total_elements];
 
         for block_idx in 0..num_blocks {
             let block_start = block_idx * Q8_0_BLOCK_BYTES;
@@ -272,8 +277,8 @@ impl Quantizer for Q8_0Quantizer {
             let scale_bytes = [block.blocks[block_start], block.blocks[block_start + 1]];
             let scale = f16::from_le_bytes(scale_bytes).to_f32();
 
-            // Read and dequantize values
             let quants_start = block_start + 2;
+            let out_start = block_idx * BLOCK_SIZE;
             let elements_in_block = if block_idx == num_blocks - 1 {
                 let remaining = total_elements % BLOCK_SIZE;
                 if remaining == 0 {
@@ -285,10 +290,10 @@ impl Quantizer for Q8_0Quantizer {
                 BLOCK_SIZE
             };
 
-            for i in 0..elements_in_block {
-                let q = block.blocks[quants_start + i] as i8;
-                let val = f32::from(q) * scale;
-                result.push(val);
+            let qs_src = &block.blocks[quants_start..quants_start + elements_in_block];
+            let out = &mut result[out_start..out_start + elements_in_block];
+            for (o, &b) in out.iter_mut().zip(qs_src) {
+                *o = f32::from(b as i8) * scale;
             }
         }
 
@@ -385,7 +390,13 @@ impl Quantizer for Q4_0Quantizer {
             });
         }
 
-        let mut result = Vec::with_capacity(total_elements);
+        // GH-386: pre-allocate output + write to slice ranges. Layout matches
+        // the interleaved pack used by `quantize` above (byte_i carries data
+        // positions 2i and 2i+1) — NOT the GGML half-half layout used in
+        // format::gguf::dequant.rs. Kept identical to the previous code's
+        // observable behavior; only the dispatch is tightened so LLVM can
+        // auto-vectorize the per-byte unpack + multiply.
+        let mut result = vec![0.0f32; total_elements];
 
         for block_idx in 0..num_blocks {
             let block_start = block_idx * Q4_0_BLOCK_BYTES;
@@ -394,8 +405,8 @@ impl Quantizer for Q4_0Quantizer {
             let scale_bytes = [block.blocks[block_start], block.blocks[block_start + 1]];
             let scale = f16::from_le_bytes(scale_bytes).to_f32();
 
-            // Read and dequantize packed nibbles
             let quants_start = block_start + 2;
+            let out_start = block_idx * BLOCK_SIZE;
             let elements_in_block = if block_idx == num_blocks - 1 {
                 let remaining = total_elements % BLOCK_SIZE;
                 if remaining == 0 {
@@ -407,20 +418,19 @@ impl Quantizer for Q4_0Quantizer {
                 BLOCK_SIZE
             };
 
-            for i in 0..(elements_in_block + 1) / 2 {
-                let packed = block.blocks[quants_start + i];
-                let q0 = (packed & 0x0F) as i8 - 8;
-                let q1 = ((packed >> 4) & 0x0F) as i8 - 8;
-
-                result.push(f32::from(q0) * scale);
-                if result.len() < total_elements && (i * 2 + 1) < elements_in_block {
-                    result.push(f32::from(q1) * scale);
+            let nibble_bytes = (elements_in_block + 1) / 2;
+            let packed = &block.blocks[quants_start..quants_start + nibble_bytes];
+            for (i, &p) in packed.iter().enumerate() {
+                let q0 = (p & 0x0F) as i8 - 8;
+                let q1 = ((p >> 4) & 0x0F) as i8 - 8;
+                let idx0 = out_start + i * 2;
+                result[idx0] = f32::from(q0) * scale;
+                let idx1 = idx0 + 1;
+                if idx1 < out_start + elements_in_block {
+                    result[idx1] = f32::from(q1) * scale;
                 }
             }
         }
-
-        // Ensure we have exactly the right number of elements
-        result.truncate(total_elements);
 
         Ok(result)
     }


### PR DESCRIPTION
## Summary

Refs #386. Rewrites \`Q8_0Quantizer::dequantize\` and \`Q4_0Quantizer::dequantize\` in \`crates/aprender-core/src/format/quantize.rs\` to use pre-allocated output + slice writes instead of \`Vec::with_capacity\` + per-element \`push\`.

## Why

\`Vec::push\` pays a per-element capacity-growth check that prevents LLVM from auto-vectorizing the tight \`i8 → f32 * scale\` body. The pattern in this PR is identical to \`aprender-compute::dequantize_q8_0_to_f32\` (model.rs:854) and matches the autovectorizer-friendly form documented in #386.

Math is unchanged — same i8→f32 cast, same scale multiply, same interleaved nibble layout for Q4_0 (kept distinct from GGML half-half in \`format::gguf::dequant.rs\`).

## Test plan

- [x] \`cargo check -p aprender-core\` clean
- [x] \`cargo test -p aprender-core --lib --no-default-features\` — 13764 / 13764 pass
- [ ] CI: workspace-test
- [ ] Bench (future PR): re-measure \`bench_dequantize_q8_0\` / \`bench_dequantize_q4_0\` to quantify gain. Expected: LLVM emits \`vpmovsxbd\` + \`vmulps\` on 32-element chunks, moving Q8_0 dequant closer to the memcpy ceiling.

## Note

This is the structural prerequisite for #386. Explicit AVX2/AVX-512 intrinsics (the issue's full "5× speedup") would build on this same shape but require trueno backend integration — out of scope for this single-file refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)