### PR TITLE
fix(Cargo.lock): bump cc 1.2.59 to 1.2.62 for rustc 1.93.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4150,9 +4150,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.59"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -15576,7 +15576,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if 0.1.10",
  "static_assertions",
 ]
 


### PR DESCRIPTION
Bump cc 1.2.59 to 1.2.62 in Cargo.lock to fix cargo publish verify failure on rustc 1.93.0. cc 1.2.59 calls apple_sdk_name method that no longer exists. Discovered during v0.33.0 cascade publish (24 crates). Verified: cargo install aprender --force --locked from crates.io succeeds with apr 0.33.0 reported. Generated with Claude Code.