### PR TITLE
feat(rosetta): Architecture::FalconClassic variant + falcon family (closes #1587)

### DIFF
--- a/contracts/model-families/falcon.yaml
+++ b/contracts/model-families/falcon.yaml
@@ -1,0 +1,147 @@
+metadata:
+  version: "1.0"
+  created: "2026-05-14"
+  description: "Model family descriptor: falcon classic (closes GH-1587)"
+  kind: model-family
+  references:
+    - "https://huggingface.co/tiiuae/falcon-7b/blob/main/config.json"
+    - "https://huggingface.co/tiiuae/falcon-40b/blob/main/config.json"
+    - "https://huggingface.co/tiiuae/falcon-rw-7b/blob/main/config.json"
+
+family: falcon
+display_name: "TII Falcon (classic)"
+vendor: TII (Technology Innovation Institute)
+architectures:
+  - FalconForCausalLM
+hf_pattern: "tiiuae/falcon-*"
+
+# Falcon classic uses RoPE position encoding, fused QKV
+# (`self_attention.query_key_value`), GELU MLP, LayerNorm with bias.
+# Three structural variants:
+#   - Falcon-7B: MQA (single shared K/V head), single per-block layernorm
+#   - Falcon-40B: MGQA (8 K/V groups), separate ln_attn + ln_mlp
+#   - Falcon-11B (RefinedWeb): MGQA, similar to 40B
+# All share `transformer.h.N.*` HF naming (distinct from FalconH1's
+# hybrid SSM, which uses `Architecture::FalconH1`).
+#
+# Falcon does NOT use ALiBi (unlike BLOOM) — RoPE θ=10000 in 7B/40B,
+# θ=500000 in 11B.
+size_variants:
+  7b:
+    parameters: "7B"
+    hidden_dim: 4544
+    num_layers: 32
+    num_heads: 71
+    num_kv_heads: 1
+    intermediate_dim: 18176
+    vocab_size: 65024
+    max_position_embeddings: 2048
+    head_dim: 64
+    rope_theta: 10000.0
+    norm_eps: 0.00001
+  11b:
+    parameters: "11B"
+    hidden_dim: 4096
+    num_layers: 60
+    num_heads: 32
+    num_kv_heads: 8
+    intermediate_dim: 16384
+    vocab_size: 65024
+    max_position_embeddings: 8192
+    head_dim: 128
+    rope_theta: 500000.0
+    norm_eps: 0.00001
+  40b:
+    parameters: "40B"
+    hidden_dim: 8192
+    num_layers: 60
+    num_heads: 128
+    num_kv_heads: 8
+    intermediate_dim: 32768
+    vocab_size: 65024
+    max_position_embeddings: 2048
+    head_dim: 64
+    rope_theta: 10000.0
+    norm_eps: 0.00001
+
+constraints:
+  attention_type: gqa
+  activation: gelu
+  norm_type: layernorm
+  has_bias: true
+  tied_embeddings: false
+  positional_encoding: rope
+  mlp_type: gelu_mlp
+
+tensor_template:
+  embedding: "model.embed_tokens.weight"
+  lm_head: "lm_head.weight"
+  final_norm: "model.norm.weight"
+  per_layer:
+    # Fused QKV — Q/K/V interleaved per head in MQA variants.
+    qkv_proj_weight: "model.layers.{n}.self_attn.qkv_proj.weight"
+    qkv_proj_bias: "model.layers.{n}.self_attn.qkv_proj.bias"
+    o_proj_weight: "model.layers.{n}.self_attn.o_proj.weight"
+    o_proj_bias: "model.layers.{n}.self_attn.o_proj.bias"
+    up_proj_weight: "model.layers.{n}.mlp.up_proj.weight"
+    up_proj_bias: "model.layers.{n}.mlp.up_proj.bias"
+    down_proj_weight: "model.layers.{n}.mlp.down_proj.weight"
+    down_proj_bias: "model.layers.{n}.mlp.down_proj.bias"
+    input_layernorm_weight: "model.layers.{n}.input_layernorm.weight"
+    input_layernorm_bias: "model.layers.{n}.input_layernorm.bias"
+    post_attention_layernorm_weight: "model.layers.{n}.post_attention_layernorm.weight"
+    post_attention_layernorm_bias: "model.layers.{n}.post_attention_layernorm.bias"
+    gate_proj_weight: null
+    gate_proj_bias: null
+
+shape_template:
+  embedding: "[vocab_size, hidden_dim]"
+  lm_head: "[vocab_size, hidden_dim]"
+  final_norm: "[hidden_dim]"
+  # Fused QKV: [num_heads*head_dim + 2*num_kv_heads*head_dim, hidden_dim]
+  qkv_proj_weight: "[(num_heads + 2 * num_kv_heads) * head_dim, hidden_dim]"
+  qkv_proj_bias: "[(num_heads + 2 * num_kv_heads) * head_dim]"
+  o_proj: "[hidden_dim, num_heads * head_dim]"
+  up_proj: "[intermediate_dim, hidden_dim]"
+  down_proj: "[hidden_dim, intermediate_dim]"
+  input_layernorm: "[hidden_dim]"
+  post_attention_layernorm: "[hidden_dim]"
+  bias: "[hidden_dim]"
+
+gguf_tensor_template:
+  embedding: "token_embd.weight"
+  position_embedding: null
+  lm_head: "output.weight"
+  final_norm_weight: "output_norm.weight"
+  final_norm_bias: "output_norm.bias"
+  transpose_weights: false
+  per_layer:
+    qkv_proj_weight: "attn_qkv.weight"
+    qkv_proj_bias: "attn_qkv.bias"
+    o_proj_weight: "attn_output.weight"
+    o_proj_bias: "attn_output.bias"
+    up_proj_weight: "ffn_up.weight"
+    up_proj_bias: "ffn_up.bias"
+    down_proj_weight: "ffn_down.weight"
+    down_proj_bias: "ffn_down.bias"
+    input_layernorm_weight: "attn_norm.weight"
+    input_layernorm_bias: "attn_norm.bias"
+    post_attention_layernorm_weight: "ffn_norm.weight"
+    post_attention_layernorm_bias: "ffn_norm.bias"
+    gate_proj_weight: null
+    gate_proj_bias: null
+
+quantizations:
+  - q4_k_m
+  - q5_k_m
+  - q8_0
+  - f16
+  - f32
+
+certification:
+  playbook_path: "../apr-model-qa-playbook/playbooks/models/falcon-{size}.playbook.yaml"
+  csv_family_key: "falcon"
+  size_categories:
+    7b: medium
+    11b: medium
+    40b: xlarge

--- a/crates/aprender-core/src/format/converter/tests/coverage_types_arch_functions.rs
+++ b/crates/aprender-core/src/format/converter/tests/coverage_types_arch_functions.rs
@@ -94,7 +94,11 @@ fn test_from_model_type_case_insensitive_gh219() {
 fn test_from_model_type_unknown_gh219() {
     assert_eq!(Architecture::from_model_type("unknown_arch"), None);
     assert_eq!(Architecture::from_model_type(""), None);
-    assert_eq!(Architecture::from_model_type("falcon"), None);
+    // GH-1587: "falcon" now maps to FalconClassic (was None pre-#1587).
+    assert_eq!(
+        Architecture::from_model_type("falcon"),
+        Some(Architecture::FalconClassic)
+    );
 }
 
 // -------------------------------------------------------------------------

--- a/crates/aprender-core/src/format/converter_types.rs
+++ b/crates/aprender-core/src/format/converter_types.rs
@@ -150,6 +150,11 @@ pub enum Architecture {
     OpenElm,
     /// RWKV-7 (linear attention / recurrence)
     Rwkv7,
+    /// TII Falcon classic (`FalconForCausalLM`) — MQA/MGQA, RoPE,
+    /// parallel attn+mlp residuals, `transformer.h.N.*` HF naming.
+    /// GH-1587: tensor name mapping only — parallel-residual runtime
+    /// inference is a separate concern.
+    FalconClassic,
 }
 
 include!("tensor_expectation.rs");

--- a/crates/aprender-core/src/format/tensor_expectation.rs
+++ b/crates/aprender-core/src/format/tensor_expectation.rs
@@ -25,6 +25,9 @@ impl Architecture {
             Self::Moonshine => Self::whisper_map_name(source_name), // Audio model, strip model. prefix
             Self::Mamba => Self::auto_map_name(source_name),     // SSM: mixer.* naming, passthrough
             Self::Rwkv7 => Self::auto_map_name(source_name),     // Recurrence: rwkv.blocks.* naming, passthrough
+            // GH-1587: Falcon classic uses `transformer.h.N.*` naming with
+            // fused QKV (single MQ head in 7B, MGQA in 40B+).
+            Self::FalconClassic => Self::falcon_classic_map_name(source_name),
         }
     }
 
@@ -59,6 +62,7 @@ impl Architecture {
                 | Self::Mamba
                 | Self::OpenElm
                 | Self::Rwkv7
+                | Self::FalconClassic
         )
     }
 
@@ -104,6 +108,7 @@ impl Architecture {
             Self::Moonshine => "Moonshine",
             Self::OpenElm => "OpenELM",
             Self::Rwkv7 => "RWKV-7",
+            Self::FalconClassic => "Falcon",
         }
     }
 
@@ -144,6 +149,10 @@ impl Architecture {
             // GH-1591 OLMo / GH-1592 StableLM added here as Llama-family
             "smollm" | "smollm2" | "granite" | "granite3" | "nemotron" | "olmo" | "olmo2"
             | "stablelm" | "stablelm_epoch" | "stablelm_alpha" => Some(Self::Llama),
+            // GH-1587: Falcon classic — distinct from FalconH1 (hybrid SSM).
+            "falcon" | "falcon7b" | "falcon40b" | "falcon11b" | "refinedweb" => {
+                Some(Self::FalconClassic)
+            },
             _ => None,
         }
     }
@@ -311,6 +320,73 @@ impl Architecture {
             "model.decoder.embed_positions.weight" => "model.position_embedding.weight".to_string(),
             "model.decoder.final_layer_norm.weight" => "model.norm.weight".to_string(),
             "model.decoder.final_layer_norm.bias" => "model.norm.bias".to_string(),
+            "lm_head.weight" => "lm_head.weight".to_string(),
+            _ => name.to_string(),
+        }
+    }
+
+    /// GH-1587: Map Falcon classic tensor names to APR canonical format.
+    ///
+    /// Falcon (`FalconForCausalLM`, both 7B/40B/11B and RefinedWeb variants)
+    /// uses HuggingFace `transformer.h.N.*` naming with:
+    /// - Fused QKV (`self_attention.query_key_value`), either MQA (single
+    ///   K/V head, 7B) or MGQA (8 K/V groups, 40B)
+    /// - RoPE position encoding (no positional-embedding tensor)
+    /// - Parallel attn+mlp residuals (40B+ has separate norms; 7B uses one)
+    /// - LayerNorm (Falcon-7B has a single `input_layernorm` per block; 40B+
+    ///   has both `ln_attn` and `ln_mlp`)
+    ///
+    /// HuggingFace → APR mapping:
+    /// - `transformer.word_embeddings.weight`           → `model.embed_tokens.weight`
+    /// - `transformer.h.N.input_layernorm.{w,b}`        → `model.layers.N.input_layernorm.{w,b}`
+    /// - `transformer.h.N.ln_attn.{w,b}` (40B)          → `model.layers.N.input_layernorm.{w,b}`
+    /// - `transformer.h.N.ln_mlp.{w,b}` (40B)           → `model.layers.N.post_attention_layernorm.{w,b}`
+    /// - `transformer.h.N.self_attention.query_key_value.{w,b}` → `model.layers.N.self_attn.qkv_proj.{w,b}` (fused)
+    /// - `transformer.h.N.self_attention.dense.{w,b}`   → `model.layers.N.self_attn.o_proj.{w,b}`
+    /// - `transformer.h.N.mlp.dense_h_to_4h.{w,b}`      → `model.layers.N.mlp.up_proj.{w,b}`
+    /// - `transformer.h.N.mlp.dense_4h_to_h.{w,b}`      → `model.layers.N.mlp.down_proj.{w,b}`
+    /// - `transformer.ln_f.{w,b}`                       → `model.norm.{w,b}`
+    /// - `lm_head.weight`                               → `lm_head.weight`
+    fn falcon_classic_map_name(name: &str) -> String {
+        if let Some(rest) = name.strip_prefix("transformer.h.") {
+            if let Some(dot_pos) = rest.find('.') {
+                let layer_num = &rest[..dot_pos];
+                let suffix = &rest[dot_pos + 1..];
+
+                let apr_suffix = match suffix {
+                    // Falcon-7B: single layernorm per block
+                    "input_layernorm.weight" => "input_layernorm.weight",
+                    "input_layernorm.bias" => "input_layernorm.bias",
+                    // Falcon-40B: separate attn + mlp layernorms
+                    "ln_attn.weight" => "input_layernorm.weight",
+                    "ln_attn.bias" => "input_layernorm.bias",
+                    "ln_mlp.weight" => "post_attention_layernorm.weight",
+                    "ln_mlp.bias" => "post_attention_layernorm.bias",
+                    // Older single post_attention_layernorm (some variants)
+                    "post_attention_layernorm.weight" => "post_attention_layernorm.weight",
+                    "post_attention_layernorm.bias" => "post_attention_layernorm.bias",
+                    // Fused QKV — kept fused; splitter at conversion layer handles
+                    // the MQA/MGQA-specific Q/K/V layout.
+                    "self_attention.query_key_value.weight" => "self_attn.qkv_proj.weight",
+                    "self_attention.query_key_value.bias" => "self_attn.qkv_proj.bias",
+                    "self_attention.dense.weight" => "self_attn.o_proj.weight",
+                    "self_attention.dense.bias" => "self_attn.o_proj.bias",
+                    "mlp.dense_h_to_4h.weight" => "mlp.up_proj.weight",
+                    "mlp.dense_h_to_4h.bias" => "mlp.up_proj.bias",
+                    "mlp.dense_4h_to_h.weight" => "mlp.down_proj.weight",
+                    "mlp.dense_4h_to_h.bias" => "mlp.down_proj.bias",
+                    other => other,
+                };
+
+                return format!("model.layers.{layer_num}.{apr_suffix}");
+            }
+        }
+
+        // Non-layer tensors
+        match name {
+            "transformer.word_embeddings.weight" => "model.embed_tokens.weight".to_string(),
+            "transformer.ln_f.weight" => "model.norm.weight".to_string(),
+            "transformer.ln_f.bias" => "model.norm.bias".to_string(),
             "lm_head.weight" => "lm_head.weight".to_string(),
             _ => name.to_string(),
         }


### PR DESCRIPTION
## Summary

Closes #1587. Adds \`Architecture::FalconClassic\` variant + Falcon-specific tensor mapper + \`contracts/model-families/falcon.yaml\`.

## Why FalconClassic needs its own variant

Falcon (TII; \`FalconForCausalLM\`) is distinct from both:
- **FalconH1** (hybrid Transformer+SSM, uses \`Architecture::FalconH1\` mapper)
- **BLOOM** (different prefix, different position encoding)

Falcon-specific traits:
- HF prefix \`transformer.h.N.*\` (BLOOM: \`h.N.*\`; LLaMA: \`model.layers.N.*\`)
- RoPE position encoding (BLOOM uses ALiBi)
- Fused QKV with MQA (7B: 1 K/V head) or MGQA (40B/11B: 8 K/V groups)
- **Two layernorm layouts**: 7B has single per-block; 40B has separate \`ln_attn\` + \`ln_mlp\` (parallel residual design)

## Engine changes

- \`converter_types.rs::Architecture\` + \`FalconClassic\` variant
- \`tensor_expectation.rs::map_name\` + dispatch
- \`tensor_expectation.rs::is_llm\`, \`display_name\`, \`from_model_type\` updates
- \`tensor_expectation.rs::falcon_classic_map_name\` NEW (95 LOC) — handles both 7B (single \`input_layernorm\`) and 40B (\`ln_attn\` + \`ln_mlp\`) variants
- Coverage test \`test_from_model_type_unknown_gh219\` updated: \`from_model_type(\"falcon\")\` now returns \`Some(FalconClassic)\`

## YAML

\`contracts/model-families/falcon.yaml\` covers 7B (MQA, RoPE θ=10000), 11B (MGQA, RoPE θ=500000), 40B (MGQA, RoPE θ=10000). All share 65024-token vocab.

## Test plan

- [x] \`pv validate\` clean
- [x] FALSIFY-PARITY-002 \`test_every_model_family_yaml_has_architecture\` passes
- [x] FALSIFY-MF-006 \`no_duplicate_architecture_classes\` passes
- [x] FALSIFY-MF-011 \`vocab_consistency\` passes
- [x] All 13764 aprender-core --lib tests pass
- [ ] CI: workspace-test

## Out of scope

- Parallel attn+mlp residual runtime — \`is_inference_verified()\` returns false for FalconClassic; engine has no parallel-residual code path
- MQA/MGQA-aware QKV splitter at conversion layer

🤖 Generated with [Claude Code](https://claude.com/claude-code)