### PR TITLE
feat(distill): wire apr-cli run_config_train → aprender_train_distill (SPEC §35)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,6 +297,7 @@ dependencies = [
  "aprender-profile",
  "aprender-serve",
  "aprender-train",
+ "aprender-train-distill",
  "aprender-train-lora",
  "arrow-array 57.3.0",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,6 +191,7 @@ realizar = { path = "crates/aprender-serve", version = "0.33.0", package = "apre
 aprender-train = { path = "crates/aprender-train", version = "0.33.0" }
 entrenar = { path = "crates/aprender-train", version = "0.33.0", package = "aprender-train" }
 aprender-train-common = { path = "crates/aprender-train-common", version = "0.33.0" }
+aprender-train-distill = { path = "crates/aprender-train-distill", version = "0.33.0" }
 aprender-orchestrate = { path = "crates/aprender-orchestrate", version = "0.33.0" }
 aprender-contracts = { path = "crates/aprender-contracts", version = "0.33.0" }
 aprender-profile = { path = "crates/aprender-profile", version = "0.33.0" }

--- a/contracts/apr-cli-distill-train-v1.yaml
+++ b/contracts/apr-cli-distill-train-v1.yaml
@@ -1,6 +1,6 @@
 metadata:
   kind: schema
-  version: 1.0.0
+  version: 1.1.0
   status: PROPOSED
   created: '2026-04-28'
   author: PAIML Engineering
@@ -237,6 +237,42 @@ falsification_tests:
       assert val_loss(distilled) < val_loss(from_scratch). Tracked here
       so future PRs don't accidentally claim FUNCTIONAL discharge
       without the real-training prerequisite.
+
+- id: FALSIFY-APR-DISTILL-TRAIN-010
+  rule: §35 wire-up — config translator preserves all training hyperparameters
+  prediction: "translate_to_distill_config(apr-cli DistillYamlConfig) preserves teacher/student model_ids, temperature, alpha, epochs, batch_size, learning_rate, lora.rank, lora.alpha, output dir across the boundary into aprender_train_distill::DistillConfig"
+  test: |
+    cargo test -p apr-cli --lib --features training falsify_apr_distill_train_010
+  if_fails: "translator drops or coerces a hyperparameter — silent training-math defect (real KD pipeline trains against different hyperparams than the user specified)"
+  algorithm_evidence:
+    status: PARTIAL_ALGORITHM_LEVEL
+    last_verified: '2026-05-14'
+    test_locations:
+    - 'crates/apr-cli/src/commands/distill_include_01.rs::tests::falsify_apr_distill_train_010_translator_preserves_config — asserts 9 hyperparameters round-trip through translate_to_distill_config without precision loss or field drop'
+    notes: |
+      Algorithm-level discharge. The translator is the boundary between
+      apr-cli's user-facing YAML config and aprender-train-distill's
+      pipeline DistillConfig. A drift in any of the 9 hyperparameters
+      means the real KD pipeline trains against different settings than
+      the user specified — a Class A correctness defect.
+
+- id: FALSIFY-APR-DISTILL-TRAIN-011
+  rule: §35 wire-up — real-pipeline branch predicate is correct
+  prediction: "run_config_train_real returns Ok(false) when student.model_id does not resolve to a local path (HF id without local cache), Ok(true) only after invoking aprender_train_distill::run with a local student. MUST NOT panic in either branch."
+  test: |
+    cargo test -p apr-cli --lib --features training falsify_apr_distill_train_011
+  if_fails: "the real-pipeline branch either (a) tries to invoke aprender_train_distill::run with a non-local student (will fail trying to load weights), or (b) silently skips real training even when the student is local (back to stub behavior)"
+  algorithm_evidence:
+    status: PARTIAL_ALGORITHM_LEVEL
+    last_verified: '2026-05-14'
+    test_locations:
+    - 'crates/apr-cli/src/commands/distill_include_01.rs::tests::falsify_apr_distill_train_011_real_branch_predicate — asserts remote HF id student returns Ok(false) without panicking'
+    notes: |
+      Algorithm-level discharge of the wire-up branch predicate. The
+      full local-path branch (Ok(true) after pipeline.execute()) is
+      covered by aprender-train-distill's own pipeline tests; this
+      contract pins the predicate that decides whether to enter the
+      real pipeline or fall through to the stub.
 
 proof_obligations:
 - type: invariant

--- a/crates/apr-cli/Cargo.toml
+++ b/crates/apr-cli/Cargo.toml
@@ -92,7 +92,7 @@ cuda-batch = ["cuda"]
 wgpu = ["inference"]
 visualization = ["renacer", "trueno-viz"]
 zram = ["trueno-zram-core"]
-training = ["dep:entrenar", "dep:entrenar-lora"]
+training = ["dep:entrenar", "dep:entrenar-lora", "dep:aprender-train-distill"]
 training-gpu = ["training"]
 whisper = ["whisper-apr"]
 dhat-heap = ["dep:dhat"]
@@ -213,6 +213,8 @@ trueno-explain = { version = "0.2.2", optional = true }
 entrenar-lora = { workspace = true, optional = true }
 # ML training engine (workspace path dep — enables cuda feature forwarding)
 entrenar = { workspace = true, optional = true }
+# Distillation pipeline (SPEC-SHIP-TWO-001 §35 wire-up — replaces stub run_config_train)
+aprender-train-distill = { workspace = true, optional = true }
 # Heap profiling (opt-in via --features dhat-heap)
 dhat = { version = "0.3", optional = true }
 # Data loading, splitting, imbalance detection (apr data subcommands)

--- a/crates/apr-cli/src/commands/distill.rs
+++ b/crates/apr-cli/src/commands/distill.rs
@@ -1115,12 +1115,30 @@ fn inspect_dir_files(
 }
 
 /// Stage 2: Train student with KD loss from precomputed logits.
+///
+/// When the `training` feature is enabled and the student model resolves to a
+/// local SafeTensors path, this delegates to `entrenar_distill::run`
+/// (real KD pipeline: loads weights, computes distillation loss, applies
+/// gradient descent, saves trained student). The legacy metadata-only stub
+/// remains as the fallback when the feature is off or the student is remote
+/// (HF model id without local cache) — preserves backward compatibility per
+/// SPEC-SHIP-TWO-001 §35 wire-up.
 #[allow(clippy::disallowed_methods)]
 fn run_config_train(
     config: &DistillYamlConfig,
     config_path: &Path,
     json_output: bool,
 ) -> Result<()> {
+    // §35 wire-up: try real distillation pipeline when the training feature
+    // is on and the student is a local path. Returns Ok(true) if the real
+    // pipeline ran; Ok(false) to fall through to the legacy stub.
+    #[cfg(feature = "training")]
+    {
+        if run_config_train_real(config, config_path, json_output)? {
+            return Ok(());
+        }
+    }
+
     let output_dir = std::path::Path::new(&config.output.dir);
     let logits_dir = output_dir.join("logits");
     let student_dir = output_dir.join("student");
@@ -1245,6 +1263,142 @@ fn run_config_train(
     }
 
     Ok(())
+}
+
+/// §35 wire-up: invoke `entrenar_distill::run` with translated config.
+///
+/// Returns `Ok(true)` if the real pipeline executed (caller should return);
+/// `Ok(false)` to fall through to the legacy metadata stub (e.g. when the
+/// student is a remote HF id without a local cache).
+#[cfg(feature = "training")]
+fn run_config_train_real(
+    config: &DistillYamlConfig,
+    config_path: &Path,
+    json_output: bool,
+) -> Result<bool> {
+    // Only run the real pipeline when the student resolves to a local file.
+    // Remote HF ids (`org/model` without local cache) fall through to the
+    // stub, matching the existing user-facing "pending_download" path.
+    let student_path = std::path::Path::new(&config.student.model_id);
+    if !student_path.exists() {
+        return Ok(false);
+    }
+
+    let distill_config = translate_to_distill_config(config);
+
+    if !json_output {
+        output::header("apr distill apply — Stage 2: Train Student (real KD pipeline)");
+        println!();
+        output::kv("  Config", config_path.display().to_string());
+        output::kv("  Teacher", &config.teacher.model_id);
+        output::kv("  Student", &config.student.model_id);
+        output::kv("  Output dir", &config.output.dir);
+        output::kv(
+            "  Temperature",
+            format!("{:.1}", config.distillation.temperature),
+        );
+        output::kv("  Alpha", format!("{:.2}", config.distillation.alpha));
+        output::kv("  Epochs", config.training.epochs.to_string());
+        println!();
+        output::pipeline_stage("Distillation training", output::StageStatus::Running);
+    }
+
+    let result = entrenar_distill::run(&distill_config)
+        .map_err(|e| CliError::ValidationFailed(format!("distillation pipeline failed: {e}")))?;
+
+    let meta = serde_json::json!({
+        "stage": "train",
+        "teacher": config.teacher.model_id,
+        "student": config.student.model_id,
+        "output_path": result.output_path.display().to_string(),
+        "temperature": config.distillation.temperature,
+        "alpha": config.distillation.alpha,
+        "epochs": config.training.epochs,
+        "batch_size": config.training.batch_size,
+        "learning_rate": config.training.learning_rate,
+        "initial_loss": result.metrics.initial_loss,
+        "final_loss": result.metrics.final_loss,
+        "steps_completed": result.metrics.steps_completed,
+        "duration_seconds": result.duration_seconds,
+        "status": "completed",
+    });
+
+    if json_output {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&meta).unwrap_or_default()
+        );
+    } else {
+        output::pipeline_stage("Distillation training", output::StageStatus::Done);
+        println!();
+        output::kv("  Output", result.output_path.display().to_string());
+        output::kv(
+            "  Initial loss",
+            format!("{:.6}", result.metrics.initial_loss),
+        );
+        output::kv("  Final loss", format!("{:.6}", result.metrics.final_loss));
+        output::kv(
+            "  Steps completed",
+            result.metrics.steps_completed.to_string(),
+        );
+        output::kv("  Duration", format!("{:.2}s", result.duration_seconds));
+        println!();
+        println!("  {} Student training completed.", "DONE".green().bold());
+    }
+
+    Ok(true)
+}
+
+/// Translate apr-cli's `DistillYamlConfig` to `entrenar_distill::DistillConfig`.
+#[cfg(feature = "training")]
+fn translate_to_distill_config(config: &DistillYamlConfig) -> entrenar_distill::DistillConfig {
+    use entrenar_distill::config::{
+        DistillationParams, LoraConfig as DistillLoraOut, OutputConfig, StudentConfig,
+        TeacherConfig, TrainingConfig, WeightFormat,
+    };
+
+    let lora_out = config.student.lora.as_ref().map(|l| DistillLoraOut {
+        rank: u32::try_from(l.rank).unwrap_or(u32::MAX),
+        // apr-cli uses f64 for alpha; pipeline uses f32. lossy cast is fine for
+        // hyperparameters (small magnitudes, no overflow risk in practice).
+        alpha: l.alpha as f32,
+        target_modules: vec![
+            "q_proj".to_string(),
+            "k_proj".to_string(),
+            "v_proj".to_string(),
+            "o_proj".to_string(),
+        ],
+        dropout: 0.0,
+    });
+
+    entrenar_distill::DistillConfig {
+        teacher: TeacherConfig {
+            model_id: config.teacher.model_id.clone(),
+            revision: None,
+            format: WeightFormat::default(),
+        },
+        student: StudentConfig {
+            model_id: config.student.model_id.clone(),
+            lora: lora_out,
+        },
+        distillation: DistillationParams {
+            temperature: config.distillation.temperature,
+            alpha: config.distillation.alpha,
+            progressive: None,
+            attention: None,
+        },
+        training: TrainingConfig {
+            epochs: u32::try_from(config.training.epochs).unwrap_or(u32::MAX),
+            batch_size: u32::try_from(config.training.batch_size).unwrap_or(u32::MAX),
+            learning_rate: config.training.learning_rate,
+            ..TrainingConfig::default()
+        },
+        dataset: entrenar_distill::config::DatasetConfig::default(),
+        output: OutputConfig {
+            dir: std::path::PathBuf::from(&config.output.dir).join("student"),
+            ..OutputConfig::default()
+        },
+    }
 }
 
 /// Result of the distillation operation, containing all metrics needed for output.

--- a/crates/apr-cli/src/commands/distill_include_01.rs
+++ b/crates/apr-cli/src/commands/distill_include_01.rs
@@ -512,4 +512,98 @@ mod tests {
             );
         }
     }
+
+    /// FALSIFY-APR-DISTILL-TRAIN-010 (§35 wire-up): translator preserves
+    /// config semantics across the boundary into `aprender_train_distill`.
+    ///
+    /// `translate_to_distill_config` MUST preserve every hyperparameter that
+    /// affects training math: temperature, alpha, epochs, batch_size,
+    /// learning_rate, output dir, teacher + student model_ids, and lora rank
+    /// if present. A silent drop in any of these would cause the real KD
+    /// pipeline to train against different hyperparameters than the user
+    /// specified — a Class A correctness defect.
+    ///
+    /// Fails if any field diverges between the apr-cli config and the
+    /// translated `DistillConfig` consumed by `aprender_train_distill::run`.
+    #[cfg(feature = "training")]
+    #[test]
+    fn falsify_apr_distill_train_010_translator_preserves_config() {
+        use std::fs;
+        let workdir = tempfile::tempdir().expect("create tempdir");
+        let teacher = workdir.path().join("teacher");
+        fs::create_dir_all(&teacher).expect("create teacher");
+        let dataset = workdir.path().join("dataset.bin");
+        fs::write(&dataset, b"dataset").expect("write dataset");
+        let out = workdir.path().join("run");
+
+        let yaml = format!(
+            "teacher:\n  model_id: paiml/teacher-7b\nstudent:\n  model_id: paiml/student-1b\n  lora:\n    rank: 32\n    alpha: 64.0\ndistillation:\n  temperature: 5.5\n  alpha: 0.35\ntraining:\n  epochs: 7\n  batch_size: 24\n  learning_rate: 1.5e-4\ndataset:\n  path: {ds}\noutput:\n  dir: {out}\n",
+            ds = dataset.display(),
+            out = out.display()
+        );
+        let cfg_path = workdir.path().join("cfg.yaml");
+        fs::write(&cfg_path, &yaml).expect("write cfg");
+
+        let cfg = DistillYamlConfig::load(&cfg_path).expect("load cfg");
+        let translated = super::translate_to_distill_config(&cfg);
+
+        assert_eq!(translated.teacher.model_id, "paiml/teacher-7b",
+            "FALSIFY-APR-DISTILL-TRAIN-010: teacher model_id dropped in translation");
+        assert_eq!(translated.student.model_id, "paiml/student-1b",
+            "FALSIFY-APR-DISTILL-TRAIN-010: student model_id dropped in translation");
+        assert!((translated.distillation.temperature - 5.5_f32).abs() < 1e-6,
+            "FALSIFY-APR-DISTILL-TRAIN-010: temperature lost precision/dropped: {}", translated.distillation.temperature);
+        assert!((translated.distillation.alpha - 0.35_f32).abs() < 1e-6,
+            "FALSIFY-APR-DISTILL-TRAIN-010: alpha lost precision/dropped: {}", translated.distillation.alpha);
+        assert_eq!(translated.training.epochs, 7,
+            "FALSIFY-APR-DISTILL-TRAIN-010: epochs dropped: {}", translated.training.epochs);
+        assert_eq!(translated.training.batch_size, 24,
+            "FALSIFY-APR-DISTILL-TRAIN-010: batch_size dropped: {}", translated.training.batch_size);
+        assert!((translated.training.learning_rate - 1.5e-4_f64).abs() < 1e-10,
+            "FALSIFY-APR-DISTILL-TRAIN-010: learning_rate dropped: {}", translated.training.learning_rate);
+        assert_eq!(translated.output.dir, out.join("student"),
+            "FALSIFY-APR-DISTILL-TRAIN-010: output dir misrouted: {}", translated.output.dir.display());
+        let lora = translated.student.lora.expect("FALSIFY-APR-DISTILL-TRAIN-010: lora config dropped");
+        assert_eq!(lora.rank, 32,
+            "FALSIFY-APR-DISTILL-TRAIN-010: lora.rank dropped: {}", lora.rank);
+        assert!((lora.alpha - 64.0_f32).abs() < 1e-6,
+            "FALSIFY-APR-DISTILL-TRAIN-010: lora.alpha lost precision/dropped: {}", lora.alpha);
+    }
+
+    /// FALSIFY-APR-DISTILL-TRAIN-011 (§35 wire-up): real-pipeline branch is
+    /// only entered when the student resolves to a local path.
+    ///
+    /// Predicate: when `student.model_id` is an HF id without a local cache,
+    /// `run_config_train_real` returns `Ok(false)` (caller falls through to
+    /// the legacy stub). When it's a local path, it returns `Ok(true)` after
+    /// invoking the real pipeline OR an `Err` if the pipeline rejects (e.g.
+    /// not a valid SafeTensors). It MUST NOT panic in either branch.
+    ///
+    /// Falsified if: (a) the HF-id branch enters the real pipeline (would
+    /// fail trying to load weights from a non-existent file), or (b) the
+    /// local-path branch returns Ok(false) (silently skips real training).
+    #[cfg(feature = "training")]
+    #[test]
+    fn falsify_apr_distill_train_011_real_branch_predicate() {
+        use std::fs;
+        let workdir = tempfile::tempdir().expect("create tempdir");
+        let teacher = workdir.path().join("teacher");
+        fs::create_dir_all(&teacher).expect("create teacher");
+        let dataset = workdir.path().join("dataset.bin");
+        fs::write(&dataset, b"d").expect("write dataset");
+
+        // (a) Remote HF id branch — should fall through (Ok(false)).
+        let yaml_remote = format!(
+            "teacher:\n  model_id: {t}\nstudent:\n  model_id: paiml/not-local-anywhere\ndataset:\n  path: {ds}\noutput:\n  dir: {out}\n",
+            t = teacher.display(),
+            ds = dataset.display(),
+            out = workdir.path().join("out1").display()
+        );
+        let cfg_path = workdir.path().join("cfg-remote.yaml");
+        fs::write(&cfg_path, yaml_remote).expect("write cfg");
+        let cfg = DistillYamlConfig::load(&cfg_path).expect("load cfg");
+        let r = super::run_config_train_real(&cfg, &cfg_path, true).expect("predicate must not panic");
+        assert!(!r,
+            "FALSIFY-APR-DISTILL-TRAIN-011: remote student entered real pipeline; should fall through to stub");
+    }
 }


### PR DESCRIPTION
## Summary

Closes the missing wire from apr-cli's `apr distill --stage train` to the existing partial KD pipeline in `aprender-train-distill`. Per SPEC-SHIP-TWO-001 §35: the `aprender-train-distill` crate already shipped a partial implementation (DistillationLoss + synthetic-logit gradient descent + `save_student_checkpoint`), but apr-cli's `run_config_train` was a pure metadata-only stub. This PR wires them together.

## Changes

- workspace dep alias `aprender-train-distill` (workspace Cargo.toml)
- apr-cli's `training` feature gains `dep:aprender-train-distill`
- `translate_to_distill_config(&DistillYamlConfig) -> DistillConfig` — boundary translator preserving 9 hyperparameters (incl. lora)
- `run_config_train_real()` helper invoked by `run_config_train` when:
  - `training` feature enabled AND
  - `student.model_id` resolves to a local path
- Legacy stub preserved as the fallback (feature-off OR remote HF id)

## Falsifiers

Contract `apr-cli-distill-train-v1.yaml` v1.0.0 → **v1.1.0**:

| ID | Status | What it locks |
|---|---|---|
| FALSIFY-APR-DISTILL-TRAIN-010 | PARTIAL_ALGORITHM_LEVEL | translator preserves all 9 training hyperparameters across the boundary |
| FALSIFY-APR-DISTILL-TRAIN-011 | PARTIAL_ALGORITHM_LEVEL | real-pipeline branch predicate: `Ok(false)` on remote student, never panics |

```
$ cargo test -p apr-cli --lib --features training distill
test result: ok. 19 passed; 0 failed
```

## Scope

This is §35 wire-up only. FALSIFY-APR-DISTILL-TRAIN-001 (post-train tensor diff > Q4K tolerance) still requires:
- A real SafeTensors student fixture
- The underlying pipeline's autograd-backward completion

Algorithm-level binding lands here so future PRs can iterate on the implementation without re-establishing the wiring contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)