### PR TITLE
feat(apr-cli): CRUX-B-05 safetensors shard/unshard (apr shard + apr unshard)

### DIFF
--- a/contracts/apr-cli-commands-v1.yaml
+++ b/contracts/apr-cli-commands-v1.yaml
@@ -532,6 +532,18 @@ commands:
     requires_model: false
     side_effects: []
 
+  - name: shard
+    category: model_ops
+    description: "Split safetensors file into shards + weight-map index (CRUX-B-05)"
+    requires_model: true
+    side_effects: [filesystem]
+
+  - name: unshard
+    category: model_ops
+    description: "Reconstruct single safetensors file from sharded directory (CRUX-B-05)"
+    requires_model: false
+    side_effects: [filesystem]
+
   - name: oracle
     category: misc
     description: "RAG oracle — search Sovereign AI Stack documentation"

--- a/contracts/crux-B-05-v1.yaml
+++ b/contracts/crux-B-05-v1.yaml
@@ -1,33 +1,40 @@
 # CRUX-B-05 — Safetensors shard/merge weight-map
-# Auto-scaffolded from crux-competitive-research-ux-v1.yaml (DRAFT).
-# DO NOT promote to ACTIVE until: (1) evidence collected, (2) falsification
-# body reflects competitor's canonical CLI, (3) apr surface mapped or gap
-# tracked in pmat work (see master §12).
+# Promoted to partial_algorithm_level by CRUX-B-05 implementation PR
+# (apr shard + apr unshard). Live FALSIFY-CRUX-B-05-001/002/003 ship as
+# integration tests under `cargo test -p apr-cli --lib commands::shard`.
 
 metadata:
   id: CRUX-B-05
-  version: "1.0.0-draft"
+  version: "1.1.0"
   created: "2026-04-18"
+  updated: "2026-05-15"
   author: PAIML Engineering
   registry: true
-  status: draft
+  status: partial_algorithm_level
+  kind: kernel
   parent_contracts:
   - crux-competitive-research-ux-v1
   category: "B — Inspection & Debugging"
   competitor: huggingface
   demand_score: 4  # 1..5, high priority in pmat work
-  intake_status: partial
+  intake_status: supported
   description: >
-    Safetensors shard/merge via weight-map. Parity target is
+    Safetensors shard/unshard via weight-map. Parity target is
     HuggingFace's weight-map format defined in
     `model.safetensors.index.json` (HF Transformers big-models docs)
     and the conventions used by `transformers.PreTrainedModel.save_pretrained`
     /`from_pretrained` when loading sharded safetensors. Aprender parity:
     `apr shard model.safetensors --max-shard-size SZ -o OUT/` MUST split
-    into shards + emit a valid index.json; `apr merge OUT/ -o merged.safetensors`
-    MUST reconstruct a single safetensors file byte-equivalent to the
-    input. Round-trip (split→merge) MUST be the identity on tensor
-    values. See
+    into shards + emit a valid index.json;
+    `apr unshard OUT/ -o merged.safetensors` MUST reconstruct a single
+    safetensors file whose tensor values are byte-equivalent to the
+    input (header insertion order is deterministic but not required to
+    match the original byte-for-byte — see
+    `split_then_merge_identity.invariants`). Round-trip (split → unshard)
+    MUST be the identity on tensor values. v1.1.0 (2026-05-15): renamed
+    the reconstruct verb from `apr merge` → `apr unshard` to avoid
+    collision with the existing `apr merge` model-parameter-averaging
+    command. See
     https://huggingface.co/docs/transformers/big_models#sharded-checkpoints
     and
     https://github.com/huggingface/transformers/blob/main/src/transformers/modeling_utils.py
@@ -114,8 +121,8 @@ falsification_tests:
   if_fails: "apr shard weight-map does not cover all tensors or references missing shards"
 
 - id: FALSIFY-CRUX-B-05-002
-  rule: split-then-merge is the identity on tensor values
-  prediction: "apr shard + apr merge restores byte-identical tensors"
+  rule: split-then-unshard is the identity on tensor values
+  prediction: "apr shard + apr unshard restores byte-identical tensors"
   test: |
     TMP=$(mktemp -d)
     python3 - "$TMP" <<'PY'
@@ -126,7 +133,7 @@ falsification_tests:
     save_file(sd, os.path.join(d, "model.safetensors"))
     PY
     apr shard "$TMP/model.safetensors" --max-shard-size 1MB -o "$TMP/sharded/" >/dev/null
-    apr merge "$TMP/sharded/" -o "$TMP/rebuilt.safetensors" >/dev/null
+    apr unshard "$TMP/sharded/" -o "$TMP/rebuilt.safetensors" >/dev/null
     python3 - "$TMP" <<'PY'
     import sys, os, torch
     from safetensors.torch import load_file
@@ -135,9 +142,9 @@ falsification_tests:
     reb  = load_file(os.path.join(d,"rebuilt.safetensors"))
     assert set(orig) == set(reb)
     for k in orig:
-        assert torch.equal(orig[k], reb[k]), f"tensor {k} diverged after split/merge"
+        assert torch.equal(orig[k], reb[k]), f"tensor {k} diverged after split/unshard"
     PY
-  if_fails: "split then merge did not round-trip to byte-identical tensors"
+  if_fails: "split then unshard did not round-trip to byte-identical tensors"
 
 - id: FALSIFY-CRUX-B-05-003
   rule: index.json metadata.total_size equals sum of tensor bytes
@@ -188,21 +195,27 @@ falsification_tests:
 
 proof_obligations:
 - type: equivalence
-  property: "apr shard/merge produces index.json and layout compatible with HF transformers sharded loader on evidence/crux/huggingface/shard-merge-goldens.json"
+  property: "apr shard/unshard produces index.json and layout compatible with HF transformers sharded loader on evidence/crux/huggingface/shard-merge-goldens.json"
 - type: invariant
   property: "Every tensor appears in exactly one shard (no duplication, no omission)"
 - type: invariant
   property: "index.json total_size equals Σ(element_size × numel) across all tensors"
 - type: invariant
-  property: "merge(split(S, SZ)) == S (identity on tensor values for any valid max_shard_size)"
+  property: "unshard(shard(S, SZ)) == S (identity on tensor values for any valid max_shard_size)"
 - type: invariant
   property: "weight_map shard filenames are relative (no absolute paths, no ..)"
 
 verification_summary:
   total_obligations: 5
   proven: 0
-  tested: 0
-  status: spec-complete
+  tested: 4
+  status: partial_algorithm_level
+  notes: |
+    FALSIFY-CRUX-B-05-001/002/003 ship as in-tree integration tests under
+    `cargo test -p apr-cli --lib commands::shard` (3 falsifier suites +
+    22 supporting tests = 25 total green). FALSIFY-CRUX-B-05-004 (parity
+    against transformers golden sha256) remains pending golden-set
+    population in evidence/crux/huggingface/shard-merge-goldens.json.
 
 pmat_work_tracking:
   # Managed by master contract §12. If intake_status == "missing", a ticket

--- a/crates/apr-cli/Cargo.toml
+++ b/crates/apr-cli/Cargo.toml
@@ -227,7 +227,7 @@ serde_yaml = { package = "serde_yaml_ng", version = "0.10" }
 # Unicode normalization (NFC) for BPE corpus preprocessing (MODEL-2).
 unicode-normalization = "0.1"
 
-# CRUX-B-20 — `apr diff --quant-roundtrip` per-tensor error report.
+# CRUX-B-05 + CRUX-B-20 — shard/unshard + diff --quant-roundtrip both use safetensors.
 safetensors = { workspace = true }
 
 # Parallelism — used by `apr tokenize encode-corpus --num-workers` (issue #1547).

--- a/crates/apr-cli/src/commands/mod.rs
+++ b/crates/apr-cli/src/commands/mod.rs
@@ -114,6 +114,7 @@ pub(crate) mod search_merge;
 pub(crate) mod serve;
 pub(crate) mod serve_plan;
 pub(crate) mod serve_plan_output;
+pub(crate) mod shard;
 pub(crate) mod shared_cache;
 pub(crate) mod shared_cache_lint;
 pub(crate) mod showcase;

--- a/crates/apr-cli/src/commands/shard/mod.rs
+++ b/crates/apr-cli/src/commands/shard/mod.rs
@@ -1,0 +1,137 @@
+//! CRUX-B-05 — Safetensors shard/unshard via weight-map.
+//!
+//! Parity target: HuggingFace `model.safetensors.index.json` layout used by
+//! `transformers.PreTrainedModel.save_pretrained` for big models.
+//!
+//! Surface:
+//! - `apr shard FILE --max-shard-size SZ -o OUT/`   (split)
+//! - `apr unshard DIR -o merged.safetensors`        (merge)
+//!
+//! See `contracts/crux-B-05-v1.yaml`.
+
+use std::path::Path;
+
+pub mod sharder;
+pub mod unsharder;
+
+#[cfg(test)]
+mod tests;
+
+/// Entry point for `apr shard`.
+pub fn run_shard(
+    file: &Path,
+    max_shard_size: &str,
+    output: &Path,
+) -> Result<sharder::ShardReport, sharder::ShardError> {
+    let limit = parse_size(max_shard_size).map_err(sharder::ShardError::ParseSize)?;
+    sharder::shard_safetensors_file(file, limit, output)
+}
+
+/// Entry point for `apr unshard`.
+pub fn run_unshard(
+    input_dir: &Path,
+    output: &Path,
+) -> Result<unsharder::UnshardReport, unsharder::UnshardError> {
+    unsharder::unshard_safetensors_dir(input_dir, output)
+}
+
+/// Parse a human-readable size string into bytes.
+///
+/// Supports `B`, `KB`, `MB`, `GB`, `TB` (decimal) and `KiB`, `MiB`, `GiB`, `TiB` (binary).
+/// Numbers may be fractional (e.g. `1.5GB`). Unitless input is interpreted as bytes.
+///
+/// # Errors
+///
+/// Returns a descriptive string on malformed input.
+pub fn parse_size(s: &str) -> Result<u64, String> {
+    let s = s.trim();
+    if s.is_empty() {
+        return Err("empty size".to_string());
+    }
+
+    let split_at = s
+        .find(|c: char| c.is_ascii_alphabetic())
+        .unwrap_or(s.len());
+    let (num_part, unit_part) = s.split_at(split_at);
+    let num_part = num_part.trim();
+    let unit_part = unit_part.trim();
+
+    let num: f64 = num_part
+        .parse()
+        .map_err(|e| format!("invalid number '{num_part}': {e}"))?;
+    if num < 0.0 || !num.is_finite() {
+        return Err(format!("size must be a finite non-negative number: {num}"));
+    }
+
+    let multiplier: f64 = match unit_part.to_ascii_uppercase().as_str() {
+        "" | "B" => 1.0,
+        "K" | "KB" => 1_000.0,
+        "M" | "MB" => 1_000_000.0,
+        "G" | "GB" => 1_000_000_000.0,
+        "T" | "TB" => 1_000_000_000_000.0,
+        "KIB" => 1024.0,
+        "MIB" => 1024.0 * 1024.0,
+        "GIB" => 1024.0 * 1024.0 * 1024.0,
+        "TIB" => 1024.0 * 1024.0 * 1024.0 * 1024.0,
+        other => return Err(format!("unknown size unit '{other}'")),
+    };
+
+    let total = num * multiplier;
+    if total > u64::MAX as f64 {
+        return Err(format!("size overflow: {s}"));
+    }
+    Ok(total as u64)
+}
+
+#[cfg(test)]
+mod size_tests {
+    use super::parse_size;
+
+    #[test]
+    fn bytes_no_unit() {
+        assert_eq!(parse_size("1024").unwrap(), 1024);
+    }
+
+    #[test]
+    fn decimal_units() {
+        assert_eq!(parse_size("1MB").unwrap(), 1_000_000);
+        assert_eq!(parse_size("2GB").unwrap(), 2_000_000_000);
+    }
+
+    #[test]
+    fn binary_units() {
+        assert_eq!(parse_size("1MiB").unwrap(), 1_048_576);
+        assert_eq!(parse_size("1GiB").unwrap(), 1_073_741_824);
+    }
+
+    #[test]
+    fn case_insensitive() {
+        assert_eq!(parse_size("5mb").unwrap(), 5_000_000);
+        assert_eq!(parse_size("5Mb").unwrap(), 5_000_000);
+    }
+
+    #[test]
+    fn fractional() {
+        assert_eq!(parse_size("1.5GB").unwrap(), 1_500_000_000);
+    }
+
+    #[test]
+    fn whitespace_tolerated() {
+        assert_eq!(parse_size("  10 MB ").unwrap(), 10_000_000);
+    }
+
+    #[test]
+    fn rejects_negative() {
+        assert!(parse_size("-1MB").is_err());
+    }
+
+    #[test]
+    fn rejects_unknown_unit() {
+        assert!(parse_size("1XB").is_err());
+    }
+
+    #[test]
+    fn rejects_empty() {
+        assert!(parse_size("").is_err());
+    }
+}

--- a/crates/apr-cli/src/commands/shard/sharder.rs
+++ b/crates/apr-cli/src/commands/shard/sharder.rs
@@ -1,0 +1,269 @@
+//! Split a single safetensors file into shards + weight-map index.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use safetensors::tensor::{Dtype, SafeTensors, TensorView};
+
+#[derive(Debug)]
+pub enum ShardError {
+    ParseSize(String),
+    Io(std::io::Error),
+    SafeTensors(safetensors::SafeTensorError),
+    Invalid(String),
+}
+
+impl std::fmt::Display for ShardError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ShardError::ParseSize(m) => write!(f, "invalid --max-shard-size: {m}"),
+            ShardError::Io(e) => write!(f, "i/o error: {e}"),
+            ShardError::SafeTensors(e) => write!(f, "safetensors error: {e}"),
+            ShardError::Invalid(m) => write!(f, "{m}"),
+        }
+    }
+}
+
+impl std::error::Error for ShardError {}
+
+impl From<std::io::Error> for ShardError {
+    fn from(e: std::io::Error) -> Self {
+        ShardError::Io(e)
+    }
+}
+
+impl From<safetensors::SafeTensorError> for ShardError {
+    fn from(e: safetensors::SafeTensorError) -> Self {
+        ShardError::SafeTensors(e)
+    }
+}
+
+/// Result of a shard operation.
+#[derive(Debug, Clone)]
+pub struct ShardReport {
+    pub shard_files: Vec<PathBuf>,
+    pub index_path: PathBuf,
+    pub total_size: u64,
+    pub tensor_count: usize,
+}
+
+/// Element-size in bytes for every safetensors dtype.
+fn dtype_size(dt: Dtype) -> usize {
+    match dt {
+        Dtype::BOOL | Dtype::U8 | Dtype::I8 | Dtype::F8_E4M3 | Dtype::F8_E5M2 => 1,
+        Dtype::U16 | Dtype::I16 | Dtype::F16 | Dtype::BF16 => 2,
+        Dtype::U32 | Dtype::I32 | Dtype::F32 => 4,
+        Dtype::U64 | Dtype::I64 | Dtype::F64 => 8,
+        _ => 1, // future-proof fallback; safetensors crate adds new dtypes occasionally
+    }
+}
+
+fn tensor_byte_size(view: &TensorView<'_>) -> u64 {
+    let elems: u64 = view.shape().iter().map(|d| *d as u64).product();
+    elems.saturating_mul(dtype_size(view.dtype()) as u64)
+}
+
+/// Group tensors into shards via single-pass greedy bin packing.
+///
+/// Walks tensors in the original on-disk order. A new shard starts when the
+/// current one is non-empty and adding the next tensor would exceed
+/// `max_shard_size`. Tensors larger than `max_shard_size` are placed in their
+/// own shard alone (HF transformers behaviour — single tensors never split).
+fn plan_shards<'a>(
+    names: &'a [&'a str],
+    sizes: &[u64],
+    max_shard_size: u64,
+) -> Vec<Vec<usize>> {
+    debug_assert_eq!(names.len(), sizes.len());
+    let mut shards: Vec<Vec<usize>> = Vec::new();
+    let mut current: Vec<usize> = Vec::new();
+    let mut current_size: u64 = 0;
+
+    for (i, &sz) in sizes.iter().enumerate() {
+        let would_overflow = current_size.saturating_add(sz) > max_shard_size;
+        if !current.is_empty() && would_overflow {
+            shards.push(std::mem::take(&mut current));
+            current_size = 0;
+        }
+        current.push(i);
+        current_size = current_size.saturating_add(sz);
+    }
+    if !current.is_empty() {
+        shards.push(current);
+    }
+    shards
+}
+
+/// Build a `model-NNNNN-of-MMMMM.safetensors` filename per HF convention.
+fn shard_filename(index: usize, total: usize) -> String {
+    format!("model-{index:05}-of-{total:05}.safetensors")
+}
+
+/// Produce a sorted, deterministic `model.safetensors.index.json` payload.
+fn build_index_json(
+    weight_map: &BTreeMap<String, String>,
+    total_size: u64,
+) -> String {
+    let mut out = String::with_capacity(weight_map.len() * 80 + 64);
+    out.push_str("{\n");
+    out.push_str("  \"metadata\": {\n");
+    out.push_str(&format!("    \"total_size\": {total_size}\n"));
+    out.push_str("  },\n");
+    out.push_str("  \"weight_map\": {\n");
+
+    let mut first = true;
+    for (name, shard) in weight_map {
+        if !first {
+            out.push_str(",\n");
+        }
+        first = false;
+        out.push_str("    ");
+        out.push_str(&json_string(name));
+        out.push_str(": ");
+        out.push_str(&json_string(shard));
+    }
+    if !first {
+        out.push('\n');
+    }
+    out.push_str("  }\n");
+    out.push_str("}\n");
+    out
+}
+
+/// Minimal JSON string encoder for shard names and tensor keys.
+fn json_string(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
+/// Split `input` into shards + emit `model.safetensors.index.json`.
+pub fn shard_safetensors_file(
+    input: &Path,
+    max_shard_size: u64,
+    output_dir: &Path,
+) -> Result<ShardReport, ShardError> {
+    if max_shard_size == 0 {
+        return Err(ShardError::Invalid(
+            "--max-shard-size must be positive".to_string(),
+        ));
+    }
+    if !input.is_file() {
+        return Err(ShardError::Invalid(format!(
+            "input is not a file: {}",
+            input.display()
+        )));
+    }
+
+    let bytes = fs::read(input)?;
+    let st = SafeTensors::deserialize(&bytes)?;
+    let names: Vec<&str> = st.names().into_iter().map(String::as_str).collect();
+    if names.is_empty() {
+        return Err(ShardError::Invalid("input has no tensors".to_string()));
+    }
+
+    let views: Vec<TensorView<'_>> = names
+        .iter()
+        .map(|n| st.tensor(n))
+        .collect::<Result<Vec<_>, _>>()?;
+    let sizes: Vec<u64> = views.iter().map(tensor_byte_size).collect();
+    let total_size: u64 = sizes.iter().sum();
+
+    let plan = plan_shards(&names, &sizes, max_shard_size);
+    let total_shards = plan.len();
+
+    fs::create_dir_all(output_dir)?;
+
+    let mut weight_map = BTreeMap::new();
+    let mut shard_files = Vec::with_capacity(total_shards);
+
+    for (idx, group) in plan.iter().enumerate() {
+        let file_name = shard_filename(idx + 1, total_shards);
+        let shard_path = output_dir.join(&file_name);
+
+        let shard_tensors: Vec<(&str, TensorView<'_>)> = group
+            .iter()
+            .map(|&i| (names[i], views[i].clone()))
+            .collect();
+
+        let serialized = safetensors::serialize(shard_tensors, &None)
+            .map_err(ShardError::SafeTensors)?;
+        fs::write(&shard_path, &serialized)?;
+
+        for &i in group {
+            weight_map.insert(names[i].to_string(), file_name.clone());
+        }
+        shard_files.push(shard_path);
+    }
+
+    let index_path = output_dir.join("model.safetensors.index.json");
+    let index_json = build_index_json(&weight_map, total_size);
+    fs::write(&index_path, index_json)?;
+
+    Ok(ShardReport {
+        shard_files,
+        index_path,
+        total_size,
+        tensor_count: names.len(),
+    })
+}
+
+#[cfg(test)]
+mod plan_tests {
+    use super::{plan_shards, shard_filename};
+
+    #[test]
+    fn single_shard_when_under_limit() {
+        let names = vec!["a", "b", "c"];
+        let sizes = vec![10u64, 20, 30];
+        let plan = plan_shards(&names, &sizes, 1000);
+        assert_eq!(plan.len(), 1);
+        assert_eq!(plan[0], vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn splits_when_over_limit() {
+        let names = vec!["a", "b", "c", "d"];
+        let sizes = vec![60u64, 60, 60, 60];
+        let plan = plan_shards(&names, &sizes, 100);
+        assert_eq!(plan.len(), 4);
+    }
+
+    #[test]
+    fn oversized_tensor_alone() {
+        let names = vec!["a", "big", "c"];
+        let sizes = vec![10u64, 5000, 10];
+        let plan = plan_shards(&names, &sizes, 100);
+        // a => shard 0; big => shard 1 (over-limit, alone); c => shard 2
+        assert_eq!(plan.len(), 3);
+        assert_eq!(plan[1], vec![1]);
+    }
+
+    #[test]
+    fn preserves_insertion_order() {
+        let names = vec!["x", "y", "z"];
+        let sizes = vec![50u64, 50, 50];
+        let plan = plan_shards(&names, &sizes, 100);
+        let flat: Vec<usize> = plan.into_iter().flatten().collect();
+        assert_eq!(flat, vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn shard_filename_format() {
+        assert_eq!(shard_filename(1, 3), "model-00001-of-00003.safetensors");
+        assert_eq!(shard_filename(42, 100), "model-00042-of-00100.safetensors");
+    }
+}

--- a/crates/apr-cli/src/commands/shard/tests.rs
+++ b/crates/apr-cli/src/commands/shard/tests.rs
@@ -1,0 +1,247 @@
+//! End-to-end tests for `apr shard` / `apr unshard`.
+//!
+//! Covers CRUX-B-05 falsifiers — split→merge round-trip identity, weight-map
+//! coverage, total_size invariant — plus parser unit tests.
+
+use std::fs;
+use std::path::Path;
+
+use safetensors::tensor::{Dtype, SafeTensors, TensorView};
+use tempfile::TempDir;
+
+use super::sharder::{shard_safetensors_file, ShardReport};
+use super::unsharder::{unshard_safetensors_dir, UnshardReport};
+
+fn write_safetensors(
+    dir: &Path,
+    name: &str,
+    tensors: &[(&str, Dtype, Vec<usize>, Vec<u8>)],
+) -> std::path::PathBuf {
+    let views: Vec<(&str, TensorView<'_>)> = tensors
+        .iter()
+        .map(|(n, dt, shape, bytes)| {
+            (
+                *n,
+                TensorView::new(*dt, shape.clone(), bytes).expect("TensorView"),
+            )
+        })
+        .collect();
+    let bytes = safetensors::serialize(views, &None).expect("serialize");
+    let path = dir.join(name);
+    fs::write(&path, bytes).expect("write");
+    path
+}
+
+fn fake_f32_bytes(seed: u32, n: usize) -> Vec<u8> {
+    let mut out: Vec<u8> = Vec::with_capacity(n * 4);
+    for i in 0..n {
+        let v = ((i as u32).wrapping_mul(2_654_435_761).wrapping_add(seed)) as f32 * 1e-9;
+        out.extend_from_slice(&v.to_le_bytes());
+    }
+    out
+}
+
+/// FALSIFY-CRUX-B-05-001 — weight_map covers exactly the input tensors,
+/// every referenced shard file is present, total_size > 0.
+#[test]
+fn falsify_crux_b_05_001_weight_map_covers_all_tensors() {
+    let tmp = TempDir::new().expect("tempdir");
+    let mut spec = Vec::new();
+    for i in 0..20 {
+        spec.push((
+            // SafeTensors crate refuses tensor names with '.' followed by digits
+            // alone, but `t_0`, `t_1`, ... are valid. Match the contract intent.
+            Box::leak(format!("t_{i}").into_boxed_str()) as &str,
+            Dtype::F32,
+            vec![32usize, 32],
+            fake_f32_bytes(i as u32, 32 * 32),
+        ));
+    }
+    let input = write_safetensors(tmp.path(), "model.safetensors", &spec);
+
+    let out_dir = tmp.path().join("out");
+    let ShardReport {
+        index_path,
+        shard_files,
+        tensor_count,
+        total_size,
+    } = shard_safetensors_file(&input, 8 * 1024, &out_dir).expect("shard");
+
+    assert!(index_path.is_file(), "index.json must exist");
+    assert_eq!(tensor_count, 20);
+    assert!(total_size > 0);
+    assert!(shard_files.len() >= 2, "small limit should produce multiple shards");
+
+    let idx_text = fs::read_to_string(&index_path).expect("read index");
+    // Spot-check the JSON shape — every tensor name appears as a key.
+    for (name, _, _, _) in &spec {
+        assert!(
+            idx_text.contains(&format!("\"{name}\"")),
+            "tensor {name} missing from weight_map"
+        );
+    }
+    for shard in &shard_files {
+        assert!(shard.is_file(), "shard file {} must exist", shard.display());
+        let fname = shard.file_name().unwrap().to_string_lossy().into_owned();
+        assert!(
+            idx_text.contains(&format!("\"{fname}\"")),
+            "weight_map references {fname} which is on disk"
+        );
+    }
+}
+
+/// FALSIFY-CRUX-B-05-002 — split(M) then merge produces tensors that are
+/// byte-identical to the originals, including dtype and shape.
+#[test]
+fn falsify_crux_b_05_002_split_then_merge_identity() {
+    let tmp = TempDir::new().expect("tempdir");
+    let mut spec: Vec<(&str, Dtype, Vec<usize>, Vec<u8>)> = Vec::new();
+    for i in 0..30 {
+        spec.push((
+            Box::leak(format!("layer_{i}").into_boxed_str()) as &str,
+            Dtype::F32,
+            vec![16usize, 16],
+            fake_f32_bytes(i as u32 + 100, 16 * 16),
+        ));
+    }
+    let input = write_safetensors(tmp.path(), "model.safetensors", &spec);
+
+    let sharded = tmp.path().join("sharded");
+    shard_safetensors_file(&input, 2 * 1024, &sharded).expect("shard");
+
+    let rebuilt = tmp.path().join("rebuilt.safetensors");
+    let UnshardReport { tensor_count, .. } =
+        unshard_safetensors_dir(&sharded, &rebuilt).expect("unshard");
+    assert_eq!(tensor_count, 30);
+
+    // Compare tensor-by-tensor.
+    let orig_bytes = fs::read(&input).expect("read orig");
+    let reb_bytes = fs::read(&rebuilt).expect("read rebuilt");
+    let orig = SafeTensors::deserialize(&orig_bytes).expect("deserialize orig");
+    let reb = SafeTensors::deserialize(&reb_bytes).expect("deserialize reb");
+
+    let orig_names: std::collections::HashSet<&str> =
+        orig.names().into_iter().map(String::as_str).collect();
+    let reb_names: std::collections::HashSet<&str> =
+        reb.names().into_iter().map(String::as_str).collect();
+    assert_eq!(orig_names, reb_names, "tensor set must match");
+
+    for name in orig.names() {
+        let a = orig.tensor(name).expect("orig tensor");
+        let b = reb.tensor(name).expect("reb tensor");
+        assert_eq!(a.dtype(), b.dtype(), "dtype mismatch for {name}");
+        assert_eq!(a.shape(), b.shape(), "shape mismatch for {name}");
+        assert_eq!(a.data(), b.data(), "bytes mismatch for {name}");
+    }
+}
+
+/// FALSIFY-CRUX-B-05-003 — `metadata.total_size` equals the sum of
+/// `element_size × numel` across all tensors.
+#[test]
+fn falsify_crux_b_05_003_total_size_equals_sum_of_bytes() {
+    let tmp = TempDir::new().expect("tempdir");
+
+    // Mix of f32 (4B/elem) and f16 (2B/elem) to exercise dtype_size.
+    let f32_bytes = fake_f32_bytes(7, 100 * 100); // 40_000 bytes
+    let f16_bytes: Vec<u8> = (0..(50 * 50)).flat_map(|i| (i as u16).to_le_bytes()).collect(); // 5_000 bytes
+    let spec = vec![
+        ("a", Dtype::F32, vec![100usize, 100], f32_bytes),
+        ("b", Dtype::F16, vec![50usize, 50], f16_bytes),
+    ];
+    let expected_total: u64 = 100 * 100 * 4 + 50 * 50 * 2;
+    let input = write_safetensors(tmp.path(), "model.safetensors", &spec);
+
+    let out_dir = tmp.path().join("out");
+    let report = shard_safetensors_file(&input, 1024, &out_dir).expect("shard");
+    assert_eq!(report.total_size, expected_total);
+
+    let idx_text = fs::read_to_string(&out_dir.join("model.safetensors.index.json"))
+        .expect("read index");
+    assert!(
+        idx_text.contains(&format!("\"total_size\": {expected_total}")),
+        "index.json must declare total_size = {expected_total}"
+    );
+}
+
+/// Edge case — single tensor larger than the shard limit lands in its own shard.
+#[test]
+fn oversized_single_tensor_alone() {
+    let tmp = TempDir::new().expect("tempdir");
+    let spec = vec![
+        ("small1", Dtype::F32, vec![16usize, 16], fake_f32_bytes(0, 256)),
+        ("big", Dtype::F32, vec![512usize, 512], fake_f32_bytes(1, 512 * 512)),
+        ("small2", Dtype::F32, vec![16usize, 16], fake_f32_bytes(2, 256)),
+    ];
+    let input = write_safetensors(tmp.path(), "model.safetensors", &spec);
+
+    let out_dir = tmp.path().join("out");
+    let report = shard_safetensors_file(&input, 4 * 1024, &out_dir).expect("shard");
+    assert!(report.shard_files.len() >= 2);
+
+    let rebuilt = tmp.path().join("rebuilt.safetensors");
+    unshard_safetensors_dir(&out_dir, &rebuilt).expect("unshard");
+
+    let orig = fs::read(&input).unwrap();
+    let reb = fs::read(&rebuilt).unwrap();
+    let o = SafeTensors::deserialize(&orig).unwrap();
+    let r = SafeTensors::deserialize(&reb).unwrap();
+    for name in o.names() {
+        assert_eq!(
+            o.tensor(name).unwrap().data(),
+            r.tensor(name).unwrap().data(),
+            "tensor {name} corrupted on round-trip"
+        );
+    }
+}
+
+/// Round-trip identity holds for a small input with a huge shard size limit
+/// (everything in one shard).
+#[test]
+fn single_shard_roundtrip() {
+    let tmp = TempDir::new().expect("tempdir");
+    let spec = vec![
+        ("alpha", Dtype::F32, vec![10usize, 10], fake_f32_bytes(3, 100)),
+        ("beta", Dtype::F32, vec![10usize, 10], fake_f32_bytes(4, 100)),
+    ];
+    let input = write_safetensors(tmp.path(), "model.safetensors", &spec);
+
+    let out_dir = tmp.path().join("out");
+    let report = shard_safetensors_file(&input, 100 * 1024 * 1024, &out_dir).expect("shard");
+    assert_eq!(report.shard_files.len(), 1);
+
+    let rebuilt = tmp.path().join("rebuilt.safetensors");
+    unshard_safetensors_dir(&out_dir, &rebuilt).expect("unshard");
+
+    let o = fs::read(&input).unwrap();
+    let r = fs::read(&rebuilt).unwrap();
+    let ost = SafeTensors::deserialize(&o).unwrap();
+    let rst = SafeTensors::deserialize(&r).unwrap();
+    for name in ost.names() {
+        assert_eq!(
+            ost.tensor(name).unwrap().data(),
+            rst.tensor(name).unwrap().data()
+        );
+    }
+}
+
+/// Missing index.json → unshard returns a descriptive error.
+#[test]
+fn unshard_rejects_missing_index() {
+    let tmp = TempDir::new().expect("tempdir");
+    let err = unshard_safetensors_dir(tmp.path(), &tmp.path().join("out.safetensors"))
+        .expect_err("must fail without index.json");
+    let msg = format!("{err}");
+    assert!(msg.contains("model.safetensors.index.json"), "error: {msg}");
+}
+
+/// Empty input → shard returns a descriptive error rather than producing
+/// a 0-shard index.json that an unsharder cannot reconstruct.
+#[test]
+fn shard_rejects_empty_input() {
+    let tmp = TempDir::new().expect("tempdir");
+    let path = write_safetensors(tmp.path(), "empty.safetensors", &[]);
+    let out_dir = tmp.path().join("out");
+    let err = shard_safetensors_file(&path, 1024, &out_dir)
+        .expect_err("empty input should be rejected");
+    assert!(format!("{err}").contains("no tensors"));
+}

--- a/crates/apr-cli/src/commands/shard/unsharder.rs
+++ b/crates/apr-cli/src/commands/shard/unsharder.rs
@@ -1,0 +1,303 @@
+//! Reconstruct a single safetensors file from a sharded directory.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use safetensors::tensor::{SafeTensors, TensorView};
+
+#[derive(Debug)]
+pub enum UnshardError {
+    Io(std::io::Error),
+    SafeTensors(safetensors::SafeTensorError),
+    Invalid(String),
+}
+
+impl std::fmt::Display for UnshardError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            UnshardError::Io(e) => write!(f, "i/o error: {e}"),
+            UnshardError::SafeTensors(e) => write!(f, "safetensors error: {e}"),
+            UnshardError::Invalid(m) => write!(f, "{m}"),
+        }
+    }
+}
+
+impl std::error::Error for UnshardError {}
+
+impl From<std::io::Error> for UnshardError {
+    fn from(e: std::io::Error) -> Self {
+        UnshardError::Io(e)
+    }
+}
+
+impl From<safetensors::SafeTensorError> for UnshardError {
+    fn from(e: safetensors::SafeTensorError) -> Self {
+        UnshardError::SafeTensors(e)
+    }
+}
+
+/// Result of an unshard operation.
+#[derive(Debug, Clone)]
+pub struct UnshardReport {
+    pub output: PathBuf,
+    pub tensor_count: usize,
+    pub shard_count: usize,
+    pub total_size: u64,
+}
+
+/// Parsed `model.safetensors.index.json` (key → shard filename).
+struct Index {
+    weight_map: Vec<(String, String)>, // preserves insertion order from index.json
+    total_size: Option<u64>,
+}
+
+fn parse_index_json(json: &str) -> Result<Index, UnshardError> {
+    let json = json.trim();
+    if !json.starts_with('{') || !json.ends_with('}') {
+        return Err(UnshardError::Invalid(
+            "index.json is not a JSON object".to_string(),
+        ));
+    }
+
+    let total_size = json.find("\"total_size\"").and_then(|pos| {
+        let after = &json[pos + 12..];
+        let colon = after.find(':')?;
+        let after_colon = after[colon + 1..].trim_start();
+        let end = after_colon
+            .find(|c: char| !c.is_ascii_digit())
+            .unwrap_or(after_colon.len());
+        after_colon[..end].parse::<u64>().ok()
+    });
+
+    let wm_start = json.find("\"weight_map\"").ok_or_else(|| {
+        UnshardError::Invalid("missing 'weight_map' key in index.json".to_string())
+    })?;
+    let after_key = &json[wm_start + 12..];
+    let obj_start = after_key.find('{').ok_or_else(|| {
+        UnshardError::Invalid("malformed weight_map: missing opening brace".to_string())
+    })?;
+    let obj = &after_key[obj_start..];
+
+    let mut depth = 0i32;
+    let mut obj_end = 0usize;
+    for (i, c) in obj.char_indices() {
+        match c {
+            '{' => depth += 1,
+            '}' => {
+                depth -= 1;
+                if depth == 0 {
+                    obj_end = i;
+                    break;
+                }
+            }
+            _ => {}
+        }
+    }
+    if obj_end == 0 {
+        return Err(UnshardError::Invalid(
+            "malformed weight_map: missing closing brace".to_string(),
+        ));
+    }
+    let inner = &obj[1..obj_end];
+
+    let mut entries = Vec::new();
+    for pair in inner.split(',') {
+        let pair = pair.trim();
+        if pair.is_empty() {
+            continue;
+        }
+        let parts: Vec<&str> = pair.splitn(2, ':').collect();
+        if parts.len() != 2 {
+            continue;
+        }
+        let key = unquote(parts[0].trim());
+        let val = unquote(parts[1].trim());
+        if !key.is_empty() && !val.is_empty() {
+            entries.push((key, val));
+        }
+    }
+
+    Ok(Index {
+        weight_map: entries,
+        total_size,
+    })
+}
+
+fn unquote(s: &str) -> String {
+    let s = s.trim();
+    if s.len() >= 2 && s.starts_with('"') && s.ends_with('"') {
+        s[1..s.len() - 1].to_string()
+    } else {
+        s.to_string()
+    }
+}
+
+/// Validate that a shard filename is a plain relative path with no parent
+/// traversal — enforcement of B-05 invariant
+/// "weight_map shard filenames are relative (no absolute paths, no ..)".
+fn validate_shard_path(name: &str) -> Result<(), UnshardError> {
+    let p = Path::new(name);
+    if p.is_absolute() {
+        return Err(UnshardError::Invalid(format!(
+            "shard filename must be relative: {name}"
+        )));
+    }
+    for comp in p.components() {
+        use std::path::Component;
+        match comp {
+            Component::Normal(_) => {}
+            Component::ParentDir => {
+                return Err(UnshardError::Invalid(format!(
+                    "shard filename contains '..': {name}"
+                )));
+            }
+            Component::RootDir | Component::Prefix(_) => {
+                return Err(UnshardError::Invalid(format!(
+                    "shard filename has root component: {name}"
+                )));
+            }
+            Component::CurDir => {}
+        }
+    }
+    Ok(())
+}
+
+/// Reconstruct a single safetensors file from a sharded directory.
+pub fn unshard_safetensors_dir(
+    input_dir: &Path,
+    output: &Path,
+) -> Result<UnshardReport, UnshardError> {
+    if !input_dir.is_dir() {
+        return Err(UnshardError::Invalid(format!(
+            "input is not a directory: {}",
+            input_dir.display()
+        )));
+    }
+    let index_path = input_dir.join("model.safetensors.index.json");
+    if !index_path.is_file() {
+        return Err(UnshardError::Invalid(format!(
+            "missing model.safetensors.index.json in {}",
+            input_dir.display()
+        )));
+    }
+
+    let index_text = fs::read_to_string(&index_path)?;
+    let index = parse_index_json(&index_text)?;
+    if index.weight_map.is_empty() {
+        return Err(UnshardError::Invalid(
+            "weight_map is empty in index.json".to_string(),
+        ));
+    }
+
+    // Load each unique shard exactly once, preserving the first-seen order so
+    // that within a shard tensors land in the order safetensors stores them.
+    let mut shard_order: Vec<String> = Vec::new();
+    let mut seen: HashMap<String, ()> = HashMap::new();
+    for (_tensor, shard) in &index.weight_map {
+        validate_shard_path(shard)?;
+        if seen.insert(shard.clone(), ()).is_none() {
+            shard_order.push(shard.clone());
+        }
+    }
+
+    let mut shard_bytes: HashMap<String, Vec<u8>> = HashMap::new();
+    for shard in &shard_order {
+        let shard_path = input_dir.join(shard);
+        if !shard_path.is_file() {
+            return Err(UnshardError::Invalid(format!(
+                "shard file missing on disk: {}",
+                shard_path.display()
+            )));
+        }
+        shard_bytes.insert(shard.clone(), fs::read(&shard_path)?);
+    }
+
+    // Verify every tensor named in the weight_map actually exists in its shard.
+    let mut all_views: Vec<(String, TensorView<'_>)> = Vec::new();
+    let mut total_bytes: u64 = 0;
+    let mut by_shard: HashMap<&str, SafeTensors<'_>> = HashMap::new();
+    for shard in &shard_order {
+        let bytes = shard_bytes.get(shard).unwrap();
+        let st = SafeTensors::deserialize(bytes)?;
+        by_shard.insert(shard.as_str(), st);
+    }
+
+    // Visit tensors in weight_map insertion order. We preserve insertion order
+    // because that is what the contract spec requires for the round-trip.
+    for (tensor_name, shard_name) in &index.weight_map {
+        let st = by_shard.get(shard_name.as_str()).ok_or_else(|| {
+            UnshardError::Invalid(format!("shard not loaded: {shard_name}"))
+        })?;
+        let view = st.tensor(tensor_name).map_err(|e| {
+            UnshardError::Invalid(format!(
+                "tensor '{tensor_name}' declared in weight_map but not present in shard {shard_name}: {e}"
+            ))
+        })?;
+        total_bytes = total_bytes.saturating_add(view.data().len() as u64);
+        all_views.push((tensor_name.clone(), view));
+    }
+
+    if let Some(declared) = index.total_size {
+        if declared != total_bytes {
+            return Err(UnshardError::Invalid(format!(
+                "index.json total_size {declared} disagrees with shard contents {total_bytes}"
+            )));
+        }
+    }
+
+    let view_refs: Vec<(&str, TensorView<'_>)> =
+        all_views.iter().map(|(n, v)| (n.as_str(), v.clone())).collect();
+
+    let serialized = safetensors::serialize(view_refs, &None)
+        .map_err(UnshardError::SafeTensors)?;
+
+    if let Some(parent) = output.parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent)?;
+        }
+    }
+    fs::write(output, &serialized)?;
+
+    Ok(UnshardReport {
+        output: output.to_path_buf(),
+        tensor_count: index.weight_map.len(),
+        shard_count: shard_order.len(),
+        total_size: total_bytes,
+    })
+}
+
+#[cfg(test)]
+mod parser_tests {
+    use super::{parse_index_json, validate_shard_path};
+
+    #[test]
+    fn parses_minimal_index() {
+        let json = r#"{
+            "metadata": {"total_size": 1024},
+            "weight_map": {
+                "a.weight": "model-00001-of-00002.safetensors",
+                "b.weight": "model-00002-of-00002.safetensors"
+            }
+        }"#;
+        let idx = parse_index_json(json).expect("parse");
+        assert_eq!(idx.total_size, Some(1024));
+        assert_eq!(idx.weight_map.len(), 2);
+        assert_eq!(idx.weight_map[0].0, "a.weight");
+    }
+
+    #[test]
+    fn rejects_traversal() {
+        assert!(validate_shard_path("../escape.safetensors").is_err());
+    }
+
+    #[test]
+    fn rejects_absolute() {
+        assert!(validate_shard_path("/etc/passwd").is_err());
+    }
+
+    #[test]
+    fn accepts_relative_filename() {
+        assert!(validate_shard_path("model-00001-of-00002.safetensors").is_ok());
+    }
+}

--- a/crates/apr-cli/src/dispatch_analysis.rs
+++ b/crates/apr-cli/src/dispatch_analysis.rs
@@ -397,6 +397,16 @@ fn dispatch_analysis_commands(cli: &Cli) -> Option<Result<(), CliError>> {
             commands::ppl::run(log_probs_file, cli.json)
         }
 
+        ExtendedCommands::Shard {
+            file,
+            max_shard_size,
+            output,
+        } => dispatch_shard(file, max_shard_size, output, cli.json),
+
+        ExtendedCommands::Unshard { input, output } => {
+            dispatch_unshard(input, output, cli.json)
+        }
+
         ExtendedCommands::Diagnose {
             checkpoint_dir,
             data,
@@ -413,6 +423,84 @@ fn dispatch_analysis_commands(cli: &Cli) -> Option<Result<(), CliError>> {
         _ => return None,
     };
     Some(result)
+}
+
+/// CRUX-B-05 — split a safetensors file into shards + weight-map index.
+fn dispatch_shard(
+    file: &std::path::Path,
+    max_shard_size: &str,
+    output: &std::path::Path,
+    json: bool,
+) -> Result<(), CliError> {
+    match commands::shard::run_shard(file, max_shard_size, output) {
+        Ok(report) => {
+            if json {
+                let shard_names: Vec<String> = report
+                    .shard_files
+                    .iter()
+                    .map(|p| p.file_name().map_or_else(
+                        || p.display().to_string(),
+                        |n| n.to_string_lossy().into_owned(),
+                    ))
+                    .collect();
+                let shards_json: Vec<String> = shard_names
+                    .iter()
+                    .map(|n| format!("\"{n}\""))
+                    .collect();
+                println!(
+                    "{{\"status\":\"ok\",\"command\":\"shard\",\"input\":\"{}\",\"output_dir\":\"{}\",\"index\":\"{}\",\"shard_count\":{},\"tensor_count\":{},\"total_size\":{},\"shards\":[{}]}}",
+                    file.display(),
+                    output.display(),
+                    report.index_path.display(),
+                    report.shard_files.len(),
+                    report.tensor_count,
+                    report.total_size,
+                    shards_json.join(",")
+                );
+            } else {
+                println!("APR Shard");
+                println!("  input:        {}", file.display());
+                println!("  output dir:   {}", output.display());
+                println!("  index:        {}", report.index_path.display());
+                println!("  tensor count: {}", report.tensor_count);
+                println!("  shard count:  {}", report.shard_files.len());
+                println!("  total size:   {} bytes", report.total_size);
+            }
+            Ok(())
+        }
+        Err(e) => Err(CliError::ValidationFailed(format!("apr shard failed: {e}"))),
+    }
+}
+
+/// CRUX-B-05 — reconstruct a single safetensors file from a sharded directory.
+fn dispatch_unshard(
+    input: &std::path::Path,
+    output: &std::path::Path,
+    json: bool,
+) -> Result<(), CliError> {
+    match commands::shard::run_unshard(input, output) {
+        Ok(report) => {
+            if json {
+                println!(
+                    "{{\"status\":\"ok\",\"command\":\"unshard\",\"input_dir\":\"{}\",\"output\":\"{}\",\"shard_count\":{},\"tensor_count\":{},\"total_size\":{}}}",
+                    input.display(),
+                    report.output.display(),
+                    report.shard_count,
+                    report.tensor_count,
+                    report.total_size,
+                );
+            } else {
+                println!("APR Unshard");
+                println!("  input dir:    {}", input.display());
+                println!("  output:       {}", report.output.display());
+                println!("  shard count:  {}", report.shard_count);
+                println!("  tensor count: {}", report.tensor_count);
+                println!("  total size:   {} bytes", report.total_size);
+            }
+            Ok(())
+        }
+        Err(e) => Err(CliError::ValidationFailed(format!("apr unshard failed: {e}"))),
+    }
 }
 
 #[cfg(feature = "training")]

--- a/crates/apr-cli/src/extended_commands.rs
+++ b/crates/apr-cli/src/extended_commands.rs
@@ -858,6 +858,27 @@ pub enum ExtendedCommands {
         #[arg(long, value_name = "FILE")]
         log_probs_file: PathBuf,
     },
+    /// Split a safetensors file into shards + weight-map index (CRUX-B-05)
+    Shard {
+        /// Single-file safetensors model to split
+        #[arg(value_name = "FILE")]
+        file: PathBuf,
+        /// Maximum size of each shard (e.g. 5GB, 500MB, 1.5GiB)
+        #[arg(long, value_name = "SIZE", default_value = "5GB")]
+        max_shard_size: String,
+        /// Output directory for shards + model.safetensors.index.json
+        #[arg(short, long, value_name = "DIR")]
+        output: PathBuf,
+    },
+    /// Reconstruct a single safetensors file from a sharded directory (CRUX-B-05)
+    Unshard {
+        /// Sharded directory containing model.safetensors.index.json
+        #[arg(value_name = "DIR")]
+        input: PathBuf,
+        /// Output single-file safetensors path
+        #[arg(short, long, value_name = "FILE")]
+        output: PathBuf,
+    },
     /// Publishing, conversion, and analysis tools
     #[command(flatten)]
     Tools(ToolCommands),

--- a/crates/apr-cli/tests/cli_commands.rs
+++ b/crates/apr-cli/tests/cli_commands.rs
@@ -111,6 +111,8 @@ fn registered_commands() -> Vec<&'static str> {
         "rm-gc-lint",
         "shared-cache-lint",
         "ppl",
+        "shard",
+        "unshard",
         "oracle",
         "grad-norm",
         "encrypt",


### PR DESCRIPTION
## Summary

CRUX-B-05 safetensors shard/unshard via weight-map — HuggingFace
`model.safetensors.index.json` parity:

- **`apr shard FILE --max-shard-size SZ -o OUT/`** — split a single
  safetensors file into N shards named `model-NNNNN-of-MMMMM.safetensors`,
  plus a deterministic alphabetically-sorted `model.safetensors.index.json`
  with `weight_map` + `metadata.total_size`.
- **`apr unshard DIR -o merged.safetensors`** — reconstruct a single
  safetensors file from the sharded directory, with shard-path validation
  (no absolute paths, no `..`) and total_size cross-check.

Round-trip identity, weight-map coverage, and total_size invariant ship
as in-tree falsifiers — 25 tests green under
`cargo test -p apr-cli --lib commands::shard` (3 FALSIFY-CRUX-B-05-001/002/003
+ 22 supporting).

**Naming choice:** kept verbs orthogonal from existing
`apr merge` (model parameter averaging: average | weighted | slerp | ties | dare)
by introducing `apr unshard` instead of overloading the verb. Contract
description and FALSIFY tests updated accordingly.

## Contract promotion

`contracts/crux-B-05-v1.yaml`:
- v1.0.0-draft → v1.1.0
- status: draft → **partial_algorithm_level**
- intake_status: partial → **supported**
- FALSIFY-001/002/003 in-tree; FALSIFY-004 (transformers golden parity)
  remains pending golden-set population.

## 3-surface drift compliance

- `crates/apr-cli/src/extended_commands.rs` — `Shard` + `Unshard` clap variants
- `crates/apr-cli/src/dispatch_analysis.rs` — `dispatch_shard` / `dispatch_unshard`
- `contracts/apr-cli-commands-v1.yaml` — `shard` + `unshard` entries
- `crates/apr-cli/tests/cli_commands.rs` — `registered_commands` mirrored
- `apr <cmd> --help` exit 0 verified (cli_commands.rs 8/8 green)

## CRUX M1 epic (#918) progress

| Story | Status |
|---|---|
| K-11 modelfile DSL | shipped (PR #1680) |
| **B-05 shard/unshard** | **this PR** |
| C-04, C-11, C-13, I-04 | partial — blocked on live aprender-serve endpoint |
| K-02 | draft — blocked on live aprender-serve endpoint |

## Test plan

- [x] `cargo test -p apr-cli --lib commands::shard` — 25/25 green (3 falsifiers + 22 supporting)
- [x] `cargo test -p apr-cli --test cli_commands` — 8/8 green
- [x] `cargo test -p apr-cli --lib` — 5708/5708 green
- [x] `pv validate contracts/crux-B-05-v1.yaml` — 0 errors, 0 warnings
- [x] Live e2e binary round-trip: `apr shard model.safetensors --max-shard-size 8KB -o out/ && apr unshard out/ -o rebuilt.safetensors` → tensors byte-identical
- [x] `cargo fmt --all -- --check` (apr-cli unchanged)
- [x] `cargo clippy -p apr-cli --lib --no-deps -- -D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)