### PR TITLE
feat(rosetta): Architecture::Bloom variant + BLOOM model-family contract (closes #1586)

### DIFF
--- a/contracts/model-families/bloom.yaml
+++ b/contracts/model-families/bloom.yaml
@@ -1,0 +1,129 @@
+metadata:
+  version: "1.0"
+  created: "2026-05-14"
+  description: "Model family descriptor: bloom (closes GH-1586)"
+  kind: model-family
+  references:
+    - "https://huggingface.co/bigscience/bloom-560m/blob/main/config.json"
+    - "https://huggingface.co/bigscience/bloom-7b1/blob/main/config.json"
+
+family: bloom
+display_name: "BigScience BLOOM"
+vendor: BigScience
+architectures:
+  - BloomForCausalLM
+hf_pattern: "bigscience/bloom*"
+
+# BLOOM uses ALiBi position bias (no positional-embedding tensor),
+# fused QKV (query_key_value), GELU MLP, LayerNorm, and `tie_word_embeddings: true`.
+# All checkpoints share the 250880-token SentencePiece vocab.
+#
+# This YAML covers the 560M and 7B1 checkpoints — the two most commonly
+# benchmarked sizes. Larger variants (1B1, 1B7, 3B, 176B) share the same
+# architecture but vary in dims; add additional size_variants as needed.
+size_variants:
+  560m:
+    parameters: "560M"
+    hidden_dim: 1024
+    num_layers: 24
+    num_heads: 16
+    num_kv_heads: 16
+    intermediate_dim: 4096
+    vocab_size: 250880
+    max_position_embeddings: 2048
+    head_dim: 64
+    norm_eps: 0.00001
+  7b1:
+    parameters: "7.1B"
+    hidden_dim: 4096
+    num_layers: 30
+    num_heads: 32
+    num_kv_heads: 32
+    intermediate_dim: 16384
+    vocab_size: 250880
+    max_position_embeddings: 2048
+    head_dim: 128
+    norm_eps: 0.00001
+
+constraints:
+  attention_type: mha
+  activation: gelu
+  norm_type: layernorm
+  has_bias: true
+  tied_embeddings: true
+  positional_encoding: alibi
+  mlp_type: gelu_mlp
+
+# BLOOM tensor names after `bloom_map_name` (see tensor_expectation.rs).
+# Fused QKV is kept fused at this layer; the splitter runs at conversion.
+tensor_template:
+  embedding: "model.embed_tokens.weight"
+  lm_head: "lm_head.weight"
+  final_norm: "model.norm.weight"
+  per_layer:
+    # Fused QKV (BLOOM packs Q/K/V interleaved per head, not concatenated).
+    qkv_proj_weight: "model.layers.{n}.self_attn.qkv_proj.weight"
+    qkv_proj_bias: "model.layers.{n}.self_attn.qkv_proj.bias"
+    o_proj_weight: "model.layers.{n}.self_attn.o_proj.weight"
+    o_proj_bias: "model.layers.{n}.self_attn.o_proj.bias"
+    up_proj_weight: "model.layers.{n}.mlp.up_proj.weight"
+    up_proj_bias: "model.layers.{n}.mlp.up_proj.bias"
+    down_proj_weight: "model.layers.{n}.mlp.down_proj.weight"
+    down_proj_bias: "model.layers.{n}.mlp.down_proj.bias"
+    input_layernorm_weight: "model.layers.{n}.input_layernorm.weight"
+    input_layernorm_bias: "model.layers.{n}.input_layernorm.bias"
+    post_attention_layernorm_weight: "model.layers.{n}.post_attention_layernorm.weight"
+    post_attention_layernorm_bias: "model.layers.{n}.post_attention_layernorm.bias"
+    gate_proj_weight: null
+    gate_proj_bias: null
+
+shape_template:
+  embedding: "[vocab_size, hidden_dim]"
+  lm_head: "[vocab_size, hidden_dim]"
+  final_norm: "[hidden_dim]"
+  # Fused QKV: [3*hidden_dim, hidden_dim] for weights, [3*hidden_dim] for bias.
+  qkv_proj_weight: "[3 * hidden_dim, hidden_dim]"
+  qkv_proj_bias: "[3 * hidden_dim]"
+  o_proj: "[hidden_dim, hidden_dim]"
+  up_proj: "[intermediate_dim, hidden_dim]"
+  down_proj: "[hidden_dim, intermediate_dim]"
+  input_layernorm: "[hidden_dim]"
+  post_attention_layernorm: "[hidden_dim]"
+  bias: "[hidden_dim]"
+
+# llama.cpp BLOOM GGUF uses the standard fused attn_qkv tensor naming.
+gguf_tensor_template:
+  embedding: "token_embd.weight"
+  position_embedding: null
+  lm_head: "output.weight"
+  final_norm_weight: "output_norm.weight"
+  final_norm_bias: "output_norm.bias"
+  transpose_weights: false
+  per_layer:
+    qkv_proj_weight: "attn_qkv.weight"
+    qkv_proj_bias: "attn_qkv.bias"
+    o_proj_weight: "attn_output.weight"
+    o_proj_bias: "attn_output.bias"
+    up_proj_weight: "ffn_up.weight"
+    up_proj_bias: "ffn_up.bias"
+    down_proj_weight: "ffn_down.weight"
+    down_proj_bias: "ffn_down.bias"
+    input_layernorm_weight: "attn_norm.weight"
+    input_layernorm_bias: "attn_norm.bias"
+    post_attention_layernorm_weight: "ffn_norm.weight"
+    post_attention_layernorm_bias: "ffn_norm.bias"
+    gate_proj_weight: null
+    gate_proj_bias: null
+
+quantizations:
+  - q4_k_m
+  - q8_0
+  - f16
+  - f32
+
+certification:
+  playbook_path: "../apr-model-qa-playbook/playbooks/models/bloom-{size}.playbook.yaml"
+  csv_family_key: "bloom"
+  size_categories:
+    560m: small
+    7b1: medium

--- a/crates/aprender-core/src/format/converter_types.rs
+++ b/crates/aprender-core/src/format/converter_types.rs
@@ -155,6 +155,10 @@ pub enum Architecture {
     /// GH-1587: tensor name mapping only — parallel-residual runtime
     /// inference is a separate concern.
     FalconClassic,
+    /// `BigScience` BLOOM (ALiBi position bias, fused QKV).
+    /// GH-1586: tensor name mapping only — full ALiBi runtime inference is
+    /// a separate concern (`is_inference_verified()` returns false).
+    Bloom,
 }
 
 include!("tensor_expectation.rs");

--- a/crates/aprender-core/src/format/tensor_expectation.rs
+++ b/crates/aprender-core/src/format/tensor_expectation.rs
@@ -28,6 +28,9 @@ impl Architecture {
             // GH-1587: Falcon classic uses `transformer.h.N.*` naming with
             // fused QKV (single MQ head in 7B, MGQA in 40B+).
             Self::FalconClassic => Self::falcon_classic_map_name(source_name),
+            // GH-1586: BLOOM's HuggingFace names diverge from the LLaMA pattern
+            // (word_embeddings vs embed_tokens; h.N.* vs model.layers.N.*).
+            Self::Bloom => Self::bloom_map_name(source_name),
         }
     }
 
@@ -63,6 +66,7 @@ impl Architecture {
                 | Self::OpenElm
                 | Self::Rwkv7
                 | Self::FalconClassic
+                | Self::Bloom
         )
     }
 
@@ -109,6 +113,7 @@ impl Architecture {
             Self::OpenElm => "OpenELM",
             Self::Rwkv7 => "RWKV-7",
             Self::FalconClassic => "Falcon",
+            Self::Bloom => "BLOOM",
         }
     }
 
@@ -153,6 +158,8 @@ impl Architecture {
             "falcon" | "falcon7b" | "falcon40b" | "falcon11b" | "refinedweb" => {
                 Some(Self::FalconClassic)
             },
+            // GH-1586: BLOOM — distinct from LLaMA (ALiBi position bias, fused QKV).
+            "bloom" | "bloomz" => Some(Self::Bloom),
             _ => None,
         }
     }
@@ -387,6 +394,64 @@ impl Architecture {
             "transformer.word_embeddings.weight" => "model.embed_tokens.weight".to_string(),
             "transformer.ln_f.weight" => "model.norm.weight".to_string(),
             "transformer.ln_f.bias" => "model.norm.bias".to_string(),
+            "lm_head.weight" => "lm_head.weight".to_string(),
+            _ => name.to_string(),
+        }
+    }
+
+    /// GH-1586: Map BLOOM tensor names to APR canonical format.
+    ///
+    /// BLOOM (`BloomForCausalLM`) uses HuggingFace `h.N.*` naming with fused
+    /// QKV in `self_attention.query_key_value` and ALiBi position bias (no
+    /// positional-embedding tensor). The fused QKV is RENAMED here but not
+    /// split — the splitter must run at the conversion layer because BLOOM
+    /// packs Q/K/V interleaved per head, not concatenated.
+    ///
+    /// HuggingFace → APR mapping:
+    /// - `word_embeddings.weight`                       → `model.embed_tokens.weight`
+    /// - `word_embeddings_layernorm.weight/bias`        → `model.embed_norm.{w,b}`
+    /// - `h.N.input_layernorm.{w,b}`                    → `model.layers.N.input_layernorm.{w,b}`
+    /// - `h.N.self_attention.query_key_value.{w,b}`     → `model.layers.N.self_attn.qkv_proj.{w,b}` (fused)
+    /// - `h.N.self_attention.dense.{w,b}`               → `model.layers.N.self_attn.o_proj.{w,b}`
+    /// - `h.N.post_attention_layernorm.{w,b}`           → `model.layers.N.post_attention_layernorm.{w,b}`
+    /// - `h.N.mlp.dense_h_to_4h.{w,b}`                  → `model.layers.N.mlp.up_proj.{w,b}`
+    /// - `h.N.mlp.dense_4h_to_h.{w,b}`                  → `model.layers.N.mlp.down_proj.{w,b}`
+    /// - `ln_f.{w,b}`                                   → `model.norm.{w,b}`
+    fn bloom_map_name(name: &str) -> String {
+        if let Some(rest) = name.strip_prefix("h.") {
+            if let Some(dot_pos) = rest.find('.') {
+                let layer_num = &rest[..dot_pos];
+                let suffix = &rest[dot_pos + 1..];
+
+                let apr_suffix = match suffix {
+                    "input_layernorm.weight" => "input_layernorm.weight",
+                    "input_layernorm.bias" => "input_layernorm.bias",
+                    "post_attention_layernorm.weight" => "post_attention_layernorm.weight",
+                    "post_attention_layernorm.bias" => "post_attention_layernorm.bias",
+                    // Fused QKV — kept fused here; splitter runs at conversion layer.
+                    "self_attention.query_key_value.weight" => "self_attn.qkv_proj.weight",
+                    "self_attention.query_key_value.bias" => "self_attn.qkv_proj.bias",
+                    "self_attention.dense.weight" => "self_attn.o_proj.weight",
+                    "self_attention.dense.bias" => "self_attn.o_proj.bias",
+                    "mlp.dense_h_to_4h.weight" => "mlp.up_proj.weight",
+                    "mlp.dense_h_to_4h.bias" => "mlp.up_proj.bias",
+                    "mlp.dense_4h_to_h.weight" => "mlp.down_proj.weight",
+                    "mlp.dense_4h_to_h.bias" => "mlp.down_proj.bias",
+                    other => other,
+                };
+
+                return format!("model.layers.{layer_num}.{apr_suffix}");
+            }
+        }
+
+        // Non-layer tensors
+        match name {
+            "word_embeddings.weight" => "model.embed_tokens.weight".to_string(),
+            "word_embeddings_layernorm.weight" => "model.embed_norm.weight".to_string(),
+            "word_embeddings_layernorm.bias" => "model.embed_norm.bias".to_string(),
+            "ln_f.weight" => "model.norm.weight".to_string(),
+            "ln_f.bias" => "model.norm.bias".to_string(),
+            // BLOOM ties embeddings → lm_head; if a separate lm_head exists, preserve.
             "lm_head.weight" => "lm_head.weight".to_string(),
             _ => name.to_string(),
         }


### PR DESCRIPTION
## Summary

Re-authors PR #1671 (BLOOM rosetta variant) on a clean cherry-pick onto
current `main` — the original branch developed unresolvable interleaving
conflicts with the FalconClassic variant once both were merged in
parallel.

Adds:
- `Architecture::Bloom` enum variant in `converter_types.rs`
- `bloom_map_name` function mapping HuggingFace `h.N.*` tensor names to
  the APR canonical `model.layers.N.*` layout
- `from_model_type("bloom")` / `"bloomz"` → `Some(Architecture::Bloom)`
- `is_llm()` includes Bloom; `display_name()` returns "BLOOM"
- `contracts/model-families/bloom.yaml` (129-line family contract,
  BLOOM-560M + BLOOM-7B1 size variants, shared 250880-token vocab)

Out of scope (separate tickets):
- ALiBi runtime inference support — `is_inference_verified()` returns
  false for BLOOM; the engine has no ALiBi position-bias code path
- Fused QKV splitter at conversion layer (BLOOM packs Q/K/V interleaved
  per head, not concatenated, so needs a Bloom-specific splitter)

## Verified

- `pv validate contracts/model-families/bloom.yaml` → 0 errors, 0 warnings
- All 13764 `aprender-core --lib` tests pass
- 3 falsifiers green: FALSIFY-PARITY-002 (every YAML mapped),
  FALSIFY-MF-006 (no duplicate arch classes), FALSIFY-MF-011 (vocab
  consistency)
- Compiles cleanly under `cargo check`

Closes #1586. Supersedes #1671.

🤖 Generated with [Claude Code](https://claude.com/claude-code)