### PR TITLE
feat(rosetta): Architecture::InternLm2 variant + internlm2 family (closes #1589)

### DIFF
--- a/contracts/model-families/internlm2.yaml
+++ b/contracts/model-families/internlm2.yaml
@@ -1,0 +1,123 @@
+metadata:
+  version: "1.0"
+  created: "2026-05-14"
+  description: "Model family descriptor: internlm2 (closes GH-1589)"
+  kind: model-family
+  references:
+    - "https://huggingface.co/internlm/internlm2_5-7b-chat/blob/main/config.json"
+    - "https://huggingface.co/internlm/internlm2-20b/blob/main/config.json"
+
+family: internlm2
+display_name: "Shanghai AI Lab InternLM2"
+vendor: Shanghai AI Lab
+architectures:
+  - InternLM2ForCausalLM
+hf_pattern: "internlm/internlm2*"
+
+# InternLM2 / InternLM2.5 are LLaMA-derivative architectures with renamed
+# tensor subtrees:
+#   model.tok_embeddings        (vs model.embed_tokens)
+#   attention.wqkv (fused QKV)  (vs self_attn.q/k/v_proj)
+#   attention.wo                (vs self_attn.o_proj)
+#   feed_forward.w1/w2/w3       (vs mlp.gate/down/up_proj — note w1=gate, w2=down, w3=up)
+#   attention_norm              (vs input_layernorm)
+#   ffn_norm                    (vs post_attention_layernorm)
+#   output                      (vs lm_head; tied_embeddings: false)
+#
+# All InternLM2 sizes share the 92544-token vocab and use GQA + RoPE +
+# SwiGLU + RMSNorm. RoPE θ=1000000 for both 2.0 and 2.5 generations.
+size_variants:
+  7b:
+    parameters: "7B"
+    hidden_dim: 4096
+    num_layers: 32
+    num_heads: 32
+    num_kv_heads: 8
+    intermediate_dim: 14336
+    vocab_size: 92544
+    max_position_embeddings: 32768
+    head_dim: 128
+    rope_theta: 1000000.0
+    rms_norm_eps: 0.00001
+  20b:
+    parameters: "20B"
+    hidden_dim: 6144
+    num_layers: 48
+    num_heads: 48
+    num_kv_heads: 8
+    intermediate_dim: 16384
+    vocab_size: 92544
+    max_position_embeddings: 32768
+    head_dim: 128
+    rope_theta: 1000000.0
+    rms_norm_eps: 0.00001
+
+constraints:
+  attention_type: gqa
+  activation: silu
+  norm_type: rmsnorm
+  has_bias: false
+  tied_embeddings: false
+  positional_encoding: rope
+  mlp_type: swiglu
+
+tensor_template:
+  embedding: "model.embed_tokens.weight"
+  lm_head: "lm_head.weight"
+  final_norm: "model.norm.weight"
+  per_layer:
+    # Fused QKV — Q/K/V interleaved per GQA group; splitter at conversion.
+    qkv_proj_weight: "model.layers.{n}.self_attn.qkv_proj.weight"
+    qkv_proj_bias: null
+    o_proj_weight: "model.layers.{n}.self_attn.o_proj.weight"
+    o_proj_bias: null
+    gate_proj_weight: "model.layers.{n}.mlp.gate_proj.weight"
+    up_proj_weight: "model.layers.{n}.mlp.up_proj.weight"
+    down_proj_weight: "model.layers.{n}.mlp.down_proj.weight"
+    input_layernorm: "model.layers.{n}.input_layernorm.weight"
+    post_attention_layernorm: "model.layers.{n}.post_attention_layernorm.weight"
+
+shape_template:
+  embedding: "[vocab_size, hidden_dim]"
+  lm_head: "[vocab_size, hidden_dim]"
+  final_norm: "[hidden_dim]"
+  # Fused QKV: [(num_heads + 2*num_kv_heads) * head_dim, hidden_dim]
+  qkv_proj_weight: "[(num_heads + 2 * num_kv_heads) * head_dim, hidden_dim]"
+  o_proj_weight: "[hidden_dim, num_heads * head_dim]"
+  gate_proj_weight: "[intermediate_dim, hidden_dim]"
+  up_proj_weight: "[intermediate_dim, hidden_dim]"
+  down_proj_weight: "[hidden_dim, intermediate_dim]"
+  input_layernorm: "[hidden_dim]"
+  post_attention_layernorm: "[hidden_dim]"
+
+gguf_tensor_template:
+  embedding: "token_embd.weight"
+  position_embedding: null
+  lm_head: "output.weight"
+  final_norm_weight: "output_norm.weight"
+  final_norm_bias: null
+  per_layer:
+    qkv_proj_weight: "attn_qkv.weight"
+    qkv_proj_bias: null
+    o_proj_weight: "attn_output.weight"
+    o_proj_bias: null
+    gate_proj_weight: "ffn_gate.weight"
+    up_proj_weight: "ffn_up.weight"
+    down_proj_weight: "ffn_down.weight"
+    input_layernorm: "attn_norm.weight"
+    post_attention_layernorm: "ffn_norm.weight"
+
+quantizations:
+  - q4_k_m
+  - q5_k_m
+  - q6_k
+  - q8_0
+  - f16
+  - f32
+
+certification:
+  playbook_path: "../apr-model-qa-playbook/playbooks/models/internlm2-{size}.playbook.yaml"
+  csv_family_key: "internlm2"
+  size_categories:
+    7b: medium
+    20b: large

--- a/crates/aprender-core/src/format/converter_types.rs
+++ b/crates/aprender-core/src/format/converter_types.rs
@@ -155,6 +155,13 @@ pub enum Architecture {
     /// GH-1587: tensor name mapping only — parallel-residual runtime
     /// inference is a separate concern.
     FalconClassic,
+    /// Shanghai AI Lab `InternLM2` / `InternLM2.5` (`InternLM2ForCausalLM`).
+    /// LLaMA-derivative with renamed tensors (`wqkv`/`wo`/`w1`/`w2`/`w3`)
+    /// and `tok_embeddings`/`attention_norm`/`ffn_norm`/`output` instead
+    /// of `embed_tokens`/`input_layernorm`/`post_attention_layernorm`/`lm_head`.
+    /// GH-1589: tensor name mapping only — fused wqkv splitter is a
+    /// separate concern.
+    InternLm2,
 }
 
 include!("tensor_expectation.rs");

--- a/crates/aprender-core/src/format/tensor_expectation.rs
+++ b/crates/aprender-core/src/format/tensor_expectation.rs
@@ -28,6 +28,10 @@ impl Architecture {
             // GH-1587: Falcon classic uses `transformer.h.N.*` naming with
             // fused QKV (single MQ head in 7B, MGQA in 40B+).
             Self::FalconClassic => Self::falcon_classic_map_name(source_name),
+            // GH-1589: InternLM2 uses LLaMA-style `model.layers.N.*` but with
+            // distinct subtree names (attention.wqkv / wo / feed_forward.w1/w2/w3 /
+            // attention_norm / ffn_norm / tok_embeddings / output).
+            Self::InternLm2 => Self::internlm2_map_name(source_name),
         }
     }
 
@@ -63,6 +67,7 @@ impl Architecture {
                 | Self::OpenElm
                 | Self::Rwkv7
                 | Self::FalconClassic
+                | Self::InternLm2
         )
     }
 
@@ -109,6 +114,7 @@ impl Architecture {
             Self::OpenElm => "OpenELM",
             Self::Rwkv7 => "RWKV-7",
             Self::FalconClassic => "Falcon",
+            Self::InternLm2 => "InternLM2",
         }
     }
 
@@ -153,6 +159,9 @@ impl Architecture {
             "falcon" | "falcon7b" | "falcon40b" | "falcon11b" | "refinedweb" => {
                 Some(Self::FalconClassic)
             },
+            // GH-1589: InternLM2 / InternLM2.5 — distinct from LLaMA (renamed
+            // subtrees: wqkv/wo/w1/w2/w3 vs q/k/v/o + gate/up/down).
+            "internlm2" | "internlm2_5" | "internlm2.5" => Some(Self::InternLm2),
             _ => None,
         }
     }
@@ -388,6 +397,57 @@ impl Architecture {
             "transformer.ln_f.weight" => "model.norm.weight".to_string(),
             "transformer.ln_f.bias" => "model.norm.bias".to_string(),
             "lm_head.weight" => "lm_head.weight".to_string(),
+            _ => name.to_string(),
+        }
+    }
+
+    /// GH-1589: Map InternLM2 / InternLM2.5 tensor names to APR canonical format.
+    ///
+    /// InternLM2 (`InternLM2ForCausalLM`) is LLaMA-derivative but with renamed
+    /// subtrees:
+    /// - `model.tok_embeddings.weight`                  → `model.embed_tokens.weight`
+    /// - `model.layers.N.attention.wqkv.weight`         → `model.layers.N.self_attn.qkv_proj.weight` (fused)
+    /// - `model.layers.N.attention.wo.weight`           → `model.layers.N.self_attn.o_proj.weight`
+    /// - `model.layers.N.feed_forward.w1.weight`        → `model.layers.N.mlp.gate_proj.weight`
+    /// - `model.layers.N.feed_forward.w2.weight`        → `model.layers.N.mlp.down_proj.weight`
+    /// - `model.layers.N.feed_forward.w3.weight`        → `model.layers.N.mlp.up_proj.weight`
+    /// - `model.layers.N.attention_norm.weight`         → `model.layers.N.input_layernorm.weight`
+    /// - `model.layers.N.ffn_norm.weight`               → `model.layers.N.post_attention_layernorm.weight`
+    /// - `model.norm.weight`                            → `model.norm.weight` (passthrough)
+    /// - `output.weight`                                → `lm_head.weight`
+    ///
+    /// Fused QKV is kept fused here; splitter must run at conversion layer
+    /// since InternLM2 packs Q/K/V interleaved per GQA group (8 K/V groups
+    /// in 7B/2.5-7B, 8 K/V groups in 20B).
+    fn internlm2_map_name(name: &str) -> String {
+        if let Some(rest) = name.strip_prefix("model.layers.") {
+            if let Some(dot_pos) = rest.find('.') {
+                let layer_num = &rest[..dot_pos];
+                let suffix = &rest[dot_pos + 1..];
+
+                let apr_suffix = match suffix {
+                    "attention.wqkv.weight" => "self_attn.qkv_proj.weight",
+                    "attention.wqkv.bias" => "self_attn.qkv_proj.bias",
+                    "attention.wo.weight" => "self_attn.o_proj.weight",
+                    "attention.wo.bias" => "self_attn.o_proj.bias",
+                    // InternLM2 MLP: w1=gate, w2=down, w3=up (SwiGLU)
+                    "feed_forward.w1.weight" => "mlp.gate_proj.weight",
+                    "feed_forward.w2.weight" => "mlp.down_proj.weight",
+                    "feed_forward.w3.weight" => "mlp.up_proj.weight",
+                    "attention_norm.weight" => "input_layernorm.weight",
+                    "ffn_norm.weight" => "post_attention_layernorm.weight",
+                    other => other,
+                };
+
+                return format!("model.layers.{layer_num}.{apr_suffix}");
+            }
+        }
+
+        // Non-layer tensors
+        match name {
+            "model.tok_embeddings.weight" => "model.embed_tokens.weight".to_string(),
+            "model.norm.weight" => "model.norm.weight".to_string(),
+            "output.weight" => "lm_head.weight".to_string(),
             _ => name.to_string(),
         }
     }


### PR DESCRIPTION
## Summary

Re-authors PR #1674 (InternLM2 rosetta variant) on a clean cherry-pick
onto current `main` — the original branch developed unresolvable
interleaving conflicts with the FalconClassic + BLOOM variants once
those landed in parallel.

Adds:
- `Architecture::InternLm2` enum variant in `converter_types.rs`
- `internlm2_map_name` function mapping HuggingFace
  `model.tok_embeddings`/`wqkv`/`wo`/`w1`/`w2`/`w3`/`attention_norm`/
  `ffn_norm`/`output` to the APR canonical
  `model.embed_tokens`/`self_attn.qkv_proj`/`o_proj`/`mlp.gate_proj`/
  `down_proj`/`up_proj`/`input_layernorm`/`post_attention_layernorm`/
  `lm_head` layout
- `from_model_type("internlm2" | "internlm2_5" | "internlm2.5")`
  → `Some(Architecture::InternLm2)`
- `is_llm()` includes InternLm2; `display_name()` returns "InternLM2"
- `contracts/model-families/internlm2.yaml` (123-line family contract,
  InternLM2-7B / 2.5-7B / 20B; shared 92544 vocab, RoPE θ=1000000,
  8 K/V groups)

Out of scope (separate tickets):
- Fused wqkv splitter at conversion layer (InternLM2 packs Q/K/V
  interleaved per GQA group — distinct from GPT-NeoX concat layout)
- `is_inference_verified()` returns false until splitter is wired

## Verified

- `pv validate contracts/model-families/internlm2.yaml` → 0 errors
- All 13766 `aprender-core --lib` tests pass
- 3 falsifiers green: FALSIFY-PARITY-002, FALSIFY-MF-006, FALSIFY-MF-011
- Compiles cleanly under `cargo check`

Closes #1589. Supersedes #1674.

🤖 Generated with [Claude Code](https://claude.com/claude-code)