### PR TITLE
feat(apr-cli): probar subcommand restructure — milestone 1 (refs #876)

### DIFF
--- a/contracts/apr-cli-commands-v1.yaml
+++ b/contracts/apr-cli-commands-v1.yaml
@@ -398,9 +398,19 @@ commands:
 
   - name: probar
     category: misc
-    description: "Export for probar visual regression testing"
-    requires_model: true
+    description: |
+      Probar testing framework — visual regression, replay, compliance, audio/video, more.
+      GH-876 Milestone 1: `apr probar tensor` (PMAT-481 tensor visual regression).
+      Follow-up milestones add the remaining probador subcommands (test, record,
+      report, coverage, init, config, serve, build, watch, playbook, comply,
+      av-sync, audio, video, animation, stress, llm).
+    requires_model: false
     side_effects: [filesystem]
+    subcommands:
+      - name: tensor
+        description: "Export tensor activations for visual regression testing (PMAT-481)"
+        requires_model: true
+        side_effects: [filesystem]
 
   - name: diagnose
     category: misc

--- a/crates/apr-cli/src/dispatch_analysis.rs
+++ b/crates/apr-cli/src/dispatch_analysis.rs
@@ -58,25 +58,29 @@ fn dispatch_analysis_commands(cli: &Cli) -> Option<Result<(), CliError>> {
             *simulated,
         ),
 
-        ExtendedCommands::Probar {
-            file,
-            output,
-            format,
-            golden,
-            layer,
-            assert,
-            tolerance,
-        } => crate::error::resolve_model_path(file).and_then(|r| {
-            probar::run(
-                &r,
+        // GH-876 Milestone 1: Probar is now a subcommand container.
+        // The existing flat-args behavior moved under `apr probar tensor <FILE>`.
+        ExtendedCommands::Probar { command } => match command {
+            ProbarSubcommand::Tensor {
+                file,
                 output,
-                format.parse().unwrap_or(probar::ExportFormat::Both),
-                golden.as_deref(),
-                layer.as_deref(),
-                *assert,
-                *tolerance,
-            )
-        }),
+                format,
+                golden,
+                layer,
+                assert,
+                tolerance,
+            } => crate::error::resolve_model_path(file).and_then(|r| {
+                probar::run(
+                    &r,
+                    output,
+                    format.parse().unwrap_or(probar::ExportFormat::Both),
+                    golden.as_deref(),
+                    layer.as_deref(),
+                    *assert,
+                    *tolerance,
+                )
+            }),
+        },
 
         ExtendedCommands::CompareHf {
             file,

--- a/crates/apr-cli/src/extended_commands.rs
+++ b/crates/apr-cli/src/extended_commands.rs
@@ -470,29 +470,16 @@ pub enum ExtendedCommands {
         #[arg(long)]
         simulated: bool,
     },
-    /// Export for probar visual regression testing (PMAT-481)
+    /// Probar testing framework (GH-876 — visual regression, replay, more).
+    ///
+    /// GH-876 Milestone 1: `apr probar tensor` migrates the existing flat
+    /// `apr probar <FILE>` behavior (PMAT-481 tensor visual regression).
+    /// The remaining probador subcommands (test, record, coverage, playbook,
+    /// comply, av-sync, audio, video, animation, stress, llm) land in
+    /// follow-up PRs that delegate to the probador library.
     Probar {
-        /// Path to .apr model file
-        #[arg(value_name = "FILE")]
-        file: PathBuf,
-        /// Output directory for test artifacts
-        #[arg(short, long, default_value = "./probar-export")]
-        output: PathBuf,
-        /// Export format: json, png, or both
-        #[arg(long, default_value = "both")]
-        format: String,
-        /// Golden reference directory for comparison
-        #[arg(long)]
-        golden: Option<PathBuf>,
-        /// Filter layers by name pattern
-        #[arg(long)]
-        layer: Option<String>,
-        /// Exit non-zero on golden divergence (CI mode, PMAT-481)
-        #[arg(long)]
-        assert: bool,
-        /// Cosine similarity threshold for golden comparison (default: 0.98)
-        #[arg(long, default_value = "0.98")]
-        tolerance: f32,
+        #[command(subcommand)]
+        command: ProbarSubcommand,
     },
     /// Compare APR model against HuggingFace source
     #[command(name = "compare-hf")]
@@ -967,5 +954,41 @@ pub enum ModelfileSubcommand {
         /// Output format: `json` or `human`
         #[arg(long, default_value = "json")]
         format: String,
+    },
+}
+
+/// GH-876: Subcommands for `apr probar` — consolidates the probador testing
+/// framework under `apr`. Milestone 1 ships only `tensor` (the migrated
+/// existing behavior). Subsequent milestones add the remaining 14 probador
+/// subcommands as separate PRs that delegate to the probador library.
+#[derive(Subcommand, Debug)]
+pub enum ProbarSubcommand {
+    /// Export tensor activations for visual regression testing (PMAT-481).
+    ///
+    /// Generates JSON/PNG per-layer test artifacts that can be compared
+    /// against a golden reference directory to detect regressions in
+    /// model behavior after weight updates, quantization, or refactors.
+    Tensor {
+        /// Path to .apr model file
+        #[arg(value_name = "FILE")]
+        file: PathBuf,
+        /// Output directory for test artifacts
+        #[arg(short, long, default_value = "./probar-export")]
+        output: PathBuf,
+        /// Export format: json, png, or both
+        #[arg(long, default_value = "both")]
+        format: String,
+        /// Golden reference directory for comparison
+        #[arg(long)]
+        golden: Option<PathBuf>,
+        /// Filter layers by name pattern
+        #[arg(long)]
+        layer: Option<String>,
+        /// Exit non-zero on golden divergence (CI mode, PMAT-481)
+        #[arg(long)]
+        assert: bool,
+        /// Cosine similarity threshold for golden comparison (default: 0.98)
+        #[arg(long, default_value = "0.98")]
+        tolerance: f32,
     },
 }

--- a/crates/apr-cli/src/lib_execute_export_convert.rs
+++ b/crates/apr-cli/src/lib_execute_export_convert.rs
@@ -86,16 +86,20 @@
     }
 
     /// Test execute_command: Probar with non-existent file returns error
+    /// (via the GH-876 tensor subcommand)
     #[test]
     fn test_execute_probar_file_not_found() {
+        use ProbarSubcommand;
         let cli = make_cli(Commands::Extended(ExtendedCommands::Probar {
-            file: PathBuf::from("/tmp/nonexistent_model_probar_test.apr"),
-            output: PathBuf::from("/tmp/probar-out"),
-            format: "both".to_string(),
-            golden: None,
-            layer: None,
-            assert: false,
-            tolerance: 0.98,
+            command: ProbarSubcommand::Tensor {
+                file: PathBuf::from("/tmp/nonexistent_model_probar_test.apr"),
+                output: PathBuf::from("/tmp/probar-out"),
+                format: "both".to_string(),
+                golden: None,
+                layer: None,
+                assert: false,
+                tolerance: 0.98,
+            },
         }));
         let result = execute_command(&cli);
         assert!(result.is_err(), "Probar should fail with non-existent file");

--- a/crates/apr-cli/src/lib_parse_eval.rs
+++ b/crates/apr-cli/src/lib_parse_eval.rs
@@ -235,12 +235,19 @@
         }
     }
 
-    /// Test parsing 'apr probar' command with options
+    /// Test parsing 'apr probar tensor' command with options.
+    ///
+    /// GH-876 Milestone 1: the existing flat `apr probar <FILE>` became
+    /// `apr probar tensor <FILE>`. The tensor subcommand preserves all
+    /// the original flags (--output / --format / --golden / --layer /
+    /// --assert / --tolerance).
     #[test]
     fn test_parse_probar_command() {
+        use ProbarSubcommand;
         let args = vec![
             "apr",
             "probar",
+            "tensor",
             "model.apr",
             "--output",
             "/tmp/probar",
@@ -253,45 +260,50 @@
         ];
         let cli = parse_cli(args).expect("Failed to parse");
         match *cli.command {
-            Commands::Extended(ExtendedCommands::Probar {
-                file,
-                output,
-                format,
-                golden,
-                layer,
-                assert,
-                tolerance,
-            }) => {
-                assert_eq!(file, PathBuf::from("model.apr"));
-                assert_eq!(output, PathBuf::from("/tmp/probar"));
-                assert_eq!(format, "json");
-                assert_eq!(golden, Some(PathBuf::from("/refs/golden")));
-                assert_eq!(layer, Some("layer.0".to_string()));
-                assert!(!assert);
-                assert!((tolerance - 0.98).abs() < 0.01);
-            }
+            Commands::Extended(ExtendedCommands::Probar { command }) => match command {
+                ProbarSubcommand::Tensor {
+                    file,
+                    output,
+                    format,
+                    golden,
+                    layer,
+                    assert,
+                    tolerance,
+                } => {
+                    assert_eq!(file, PathBuf::from("model.apr"));
+                    assert_eq!(output, PathBuf::from("/tmp/probar"));
+                    assert_eq!(format, "json");
+                    assert_eq!(golden, Some(PathBuf::from("/refs/golden")));
+                    assert_eq!(layer, Some("layer.0".to_string()));
+                    assert!(!assert);
+                    assert!((tolerance - 0.98).abs() < 0.01);
+                },
+            },
             _ => panic!("Expected Probar command"),
         }
     }
 
-    /// Test parsing 'apr probar' with defaults
+    /// Test parsing 'apr probar tensor' with defaults
     #[test]
     fn test_parse_probar_defaults() {
-        let args = vec!["apr", "probar", "model.apr"];
+        use ProbarSubcommand;
+        let args = vec!["apr", "probar", "tensor", "model.apr"];
         let cli = parse_cli(args).expect("Failed to parse");
         match *cli.command {
-            Commands::Extended(ExtendedCommands::Probar {
-                output,
-                format,
-                golden,
-                layer,
-                ..
-            }) => {
-                assert_eq!(output, PathBuf::from("./probar-export"));
-                assert_eq!(format, "both");
-                assert!(golden.is_none());
-                assert!(layer.is_none());
-            }
+            Commands::Extended(ExtendedCommands::Probar { command }) => match command {
+                ProbarSubcommand::Tensor {
+                    output,
+                    format,
+                    golden,
+                    layer,
+                    ..
+                } => {
+                    assert_eq!(output, PathBuf::from("./probar-export"));
+                    assert_eq!(format, "both");
+                    assert!(golden.is_none());
+                    assert!(layer.is_none());
+                },
+            },
             _ => panic!("Expected Probar command"),
         }
     }

--- a/crates/apr-cli/src/lib_parse_rosetta_02.rs
+++ b/crates/apr-cli/src/lib_parse_rosetta_02.rs
@@ -200,17 +200,20 @@
         assert_eq!(paths, vec![PathBuf::from("model.apr")]);
     }
 
-    /// Test extract_model_paths: Probar returns file path
+    /// Test extract_model_paths: Probar returns file path (via tensor subcommand)
     #[test]
     fn test_extract_paths_probar() {
+        use ProbarSubcommand;
         let cmd = Commands::Extended(ExtendedCommands::Probar {
-            file: PathBuf::from("model.apr"),
-            output: PathBuf::from("./probar-export"),
-            format: "both".to_string(),
-            golden: None,
-            layer: None,
-            assert: false,
-            tolerance: 0.98,
+            command: ProbarSubcommand::Tensor {
+                file: PathBuf::from("model.apr"),
+                output: PathBuf::from("./probar-export"),
+                format: "both".to_string(),
+                golden: None,
+                layer: None,
+                assert: false,
+                tolerance: 0.98,
+            },
         });
         let paths = extract_model_paths(&cmd);
         assert_eq!(paths, vec![PathBuf::from("model.apr")]);

--- a/crates/apr-cli/src/validate.rs
+++ b/crates/apr-cli/src/validate.rs
@@ -7,8 +7,14 @@
 fn extract_extended_model_paths(command: &ExtendedCommands) -> Vec<PathBuf> {
     match command {
         // === ACTION COMMANDS (gated) ===
-        ExtendedCommands::Probar { file, .. }
-        | ExtendedCommands::CompareHf { file, .. }
+        // GH-876: Probar is a subcommand container; extract file from the
+        // active subcommand variant.
+        ExtendedCommands::Probar { command: probar_sub } => match probar_sub {
+            ProbarSubcommand::Tensor { file, .. } => {
+                vec![file.clone()]
+            },
+        },
+        ExtendedCommands::CompareHf { file, .. }
         | ExtendedCommands::Chat { file, .. }
         | ExtendedCommands::Bench { file, .. }
         | ExtendedCommands::Eval { file, .. }


### PR DESCRIPTION
## Summary

Re-authors PR #1679 (probar restructure milestone 1) on a clean
cherry-pick onto current `main` — the original branch developed
unresolvable interleaving conflicts with the K-11 modelfile DSL PR
(#1680) once that landed in parallel.

GH-876 Milestone 1: consolidates the existing flat `apr probar <FILE>`
into a nested `apr probar tensor <FILE>` subcommand structure under a
new `ProbarSubcommand` enum, in preparation for the remaining 14
probador subcommands (test, record, coverage, playbook, comply,
av-sync, audio, video, animation, stress, llm, ...) to land in
follow-up PRs.

## Changes

- `Probar { file, output, format, ... }` → `Probar { command: ProbarSubcommand }`
- New `ProbarSubcommand::Tensor { ... }` carries all the prior PMAT-481 flags
  unchanged (file, output, format, golden, layer, assert, tolerance)
- Dispatch sites in `dispatch_analysis.rs` / `lib_parse_eval.rs` /
  `lib_execute_export_convert.rs` / `lib_parse_rosetta_02.rs` /
  `validate.rs` updated to match new shape
- `contracts/apr-cli-commands-v1.yaml`: `probar` entry now declares
  `subcommands: [tensor]`

## Verified

- `cargo check -p apr-cli` clean
- `cargo test -p apr-cli --test cli_commands` → 8/8 green
- `apr probar tensor --help` exit 0; help text preserves all PMAT-481 flags

Closes #876 (milestone 1). Supersedes #1679.

🤖 Generated with [Claude Code](https://claude.com/claude-code)