### PR TITLE
fix(brick-test): bump rmsnorm_brick_runs budget 1ms → 100ms — clears CI noise floor

### DIFF
--- a/crates/aprender-serve/src/brick/tests_f001_brick_f002.rs
+++ b/crates/aprender-serve/src/brick/tests_f001_brick_f002.rs
@@ -129,12 +129,20 @@
         assert!(assertion.check_f32(&[1.0, f32::NAN, 3.0], true).is_err());
     }
 
-    // Verify RmsNormBrick runs correctly
+    // Verify RmsNormBrick runs correctly.
+    //
+    // The 1ms budget from the earlier "more lenient" bump is still tight on
+    // contended self-hosted runners — observed `budget exceeded` failures on
+    // PR #1688 (run 25911250791) and multiple sibling PRs the same day.
+    // RmsNorm on a 4-element vector is microseconds of real compute; under
+    // CI load (concurrent cargo builds sharing target dirs + L3) wall time
+    // can spike by 50-100×. Bumping to 100ms preserves the budget guardrail
+    // (catches genuine perf regressions in the 100s-of-ms range) while
+    // eliminating the noise floor crossing.
     #[test]
     fn rmsnorm_brick_runs() {
-        // Use a more lenient budget to avoid flaky failures on slow CI
-        let brick =
-            RmsNormBrick::new(vec![1.0; 4], 1e-5).with_budget(TokenBudget::from_latency(1000.0)); // 1ms budget
+        let brick = RmsNormBrick::new(vec![1.0; 4], 1e-5)
+            .with_budget(TokenBudget::from_latency(100_000.0)); // 100ms budget
         let input = vec![1.0, 2.0, 3.0, 4.0];
         let result = brick.run(&input).expect("should run");
 


### PR DESCRIPTION
## Summary

\`brick::brick_tests::tests::rmsnorm_brick_runs\` started failing with
\`budget exceeded\` on contended self-hosted runners — observed across at
least 5 concurrent PRs (#1688, #1689, #1685, #1683, #1675) on
2026-05-15, including the ETXTBSY retry-window fix PR which has
zero relation to brick code.

A 4-element RmsNorm is microseconds of real compute. The previous 1ms
budget (already labelled "more lenient" by a prior bump) sits inside
the noise floor when the runner is concurrently building 10+ cargo
workspaces sharing target dirs + L3 — wall time spikes 50–100×.

100ms preserves the guardrail (catches genuine 100s-of-ms perf
regressions) without crossing the contention noise floor.

Per Toyota Way memory rule: flakes are real defects, not items to mark
\`#[ignore]\` or rerun-until-green.

## Verified

- \`cargo test -p aprender-serve --lib rmsnorm_brick_runs\` → ok
- Diff is 1-line value change + expanded comment; no behavioural impact

## Impact

Once this lands, the 5 PRs currently failing on the same defect should
auto-rebase and pass next CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)