### PR TITLE
fix(ci)!: per-run target-dir — P0 STOP THE LINE on cancel-corrupt-state race

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,20 @@ jobs:
       # Phase 3 pilot (heavy workload) — build-performance.md §7 Phase 3.
       # APR-MONO monorepo: 879+ compile units, largest dep graph in the fleet.
       # Highest expected sccache hit-rate lift; without it each PR cold-compiles
-      # in its per-PR target dir (`/mnt/nvme-raid0/targets/aprender-ci/<PR>`)
+      # in its per-PR-per-run target dir
+      # (`/mnt/nvme-raid0/targets/aprender-ci/<PR>/run-<RUN_ID>`)
       # for ~34min, leaving only ~4min for tests inside the 40min timeout —
       # the entire merge queue saturates.
+      #
+      # 2026-05-15: target-dir path bumped from `aprender-ci/<PR>` to
+      # `aprender-ci/<PR>/run-<RUN_ID>` to break the cancel-corrupt-state
+      # race introduced by the prior per-PR fix (paiml/.github#31,
+      # 2026-04-23). `concurrency.cancel-in-progress: true` + persistent
+      # per-PR mount = the SIGTERM→SIGKILL window of a dying old cargo
+      # corrupted `/workspace/target/debug/deps/` for the new run that
+      # mounted the same host path. sccache stays on its own mount, so
+      # cross-run cache effectiveness is preserved; only cargo-incremental
+      # state (small fraction of total compile) is lost per new run.
       #
       # 2026-04-19: temporarily disabled — sovereign-ci:stable container image
       # was missing the `rustc-sccache` wrapper script. Fixed upstream in
@@ -111,7 +122,7 @@ jobs:
           -e CI -e GITHUB_ACTIONS -e GITHUB_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_RUN_ID -e GITHUB_EVENT_NAME -e GITHUB_WORKFLOW \
             -v "${GITHUB_WORKSPACE}:/workspace" \
             -v "/mnt/nvme-raid0/cargo-ci/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
-            -v "/mnt/nvme-raid0/targets/aprender-ci/${PR_OR_REF}:/workspace/target" \
+            -v "/mnt/nvme-raid0/targets/aprender-ci/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
             -v "/home/noah/data/sccache:/sccache" \
             -w /workspace \
             -e CARGO_TARGET_DIR=/workspace/target \
@@ -129,7 +140,7 @@ jobs:
           -e CI -e GITHUB_ACTIONS -e GITHUB_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_RUN_ID -e GITHUB_EVENT_NAME -e GITHUB_WORKFLOW \
             -v "${GITHUB_WORKSPACE}:/workspace" \
             -v "/mnt/nvme-raid0/cargo-ci/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
-            -v "/mnt/nvme-raid0/targets/aprender-ci/${PR_OR_REF}:/workspace/target" \
+            -v "/mnt/nvme-raid0/targets/aprender-ci/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
             -v "/home/noah/data/sccache:/sccache" \
             -w /workspace \
             -e CARGO_TARGET_DIR=/workspace/target \
@@ -145,7 +156,7 @@ jobs:
           -e CI -e GITHUB_ACTIONS -e GITHUB_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_RUN_ID -e GITHUB_EVENT_NAME -e GITHUB_WORKFLOW \
             -v "${GITHUB_WORKSPACE}:/workspace" \
             -v "/mnt/nvme-raid0/cargo-ci/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
-            -v "/mnt/nvme-raid0/targets/aprender-ci/${PR_OR_REF}:/workspace/target" \
+            -v "/mnt/nvme-raid0/targets/aprender-ci/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
             -v "/home/noah/data/sccache:/sccache" \
             -w /workspace \
             -e CARGO_TARGET_DIR=/workspace/target \
@@ -177,7 +188,7 @@ jobs:
           -e CI -e GITHUB_ACTIONS -e GITHUB_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_RUN_ID -e GITHUB_EVENT_NAME -e GITHUB_WORKFLOW \
             -v "${GITHUB_WORKSPACE}:/workspace" \
             -v "/mnt/nvme-raid0/cargo-ci/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
-            -v "/mnt/nvme-raid0/targets/aprender-ci/${PR_OR_REF}:/workspace/target" \
+            -v "/mnt/nvme-raid0/targets/aprender-ci/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
             "$IMAGE" \
             bash -c 'chown -R 1000:1000 /workspace || true; chown -R 1000:1000 /usr/local/cargo/registry || true; chown -R 1000:1000 /workspace/target || true'
 


### PR DESCRIPTION
## Andon

**STOP THE LINE.** Recurring \`couldn't create a temp dir: /workspace/target/debug/deps/...\`
flakes hitting 4-5 PRs simultaneously, blocking the entire merge queue.

## Root cause (five-whys)

1. CI fails with \`couldn't create a temp dir: /workspace/target/debug/deps/...\`
2. \`deps/\` was unlinked mid-build, then cargo tried to create a tempfile inside it
3. A concurrent process on the same host path is racing this run's cargo
4. \`concurrency.cancel-in-progress: true\` (\`.github/workflows/ci.yml:22\`)
   cancels the old run when \`update-branch\` pushes a new commit — but cancellation
   is signal-based with a 30s SIGTERM→SIGKILL window. During those 30s the old
   cargo is still writing/cleaning files in \`/workspace/target/...\`
5. The mount was per-PR (\`aprender-ci/\${PR_OR_REF}\`), so the new run mounted
   THE SAME host directory as the dying old run — they shared
   \`/workspace/target/debug/deps/\` on the host

## What the prior fix solved vs. what it introduced

The 2026-04-23 fleet fix (paiml/.github#31) moved sovereign-ci from a shared
runner-wide target dir to per-PR isolation, solving CROSS-PR same-runner
collisions. That worked. But the per-PR isolation INTRODUCED this
cancel-corrupt-state collision for SAME-PR sequential runs — every
\`update-branch\` or new push triggers a new run that mounts the SAME host path.

## Fix

Bump the mount path one level deeper:

\`\`\`
aprender-ci/\${PR_OR_REF}  →  aprender-ci/\${PR_OR_REF}/run-\${GITHUB_RUN_ID}
\`\`\`

Now every CI run gets its own isolated target dir; no two cargo invocations
ever share a host directory.

## Trade-offs

- **sccache**: unchanged. Lives on its own mount (\`/home/noah/data/sccache\`)
  and continues to dedupe across ALL runs of ALL PRs. This is the heavy
  lifter — typical 80%+ hit rate on warm cache.
- **cargo-incremental**: lost per new run. Cost is small because sccache
  already covers most of the rebuild surface; cargo-incremental is just
  per-crate metadata, not codegen.
- **Disk**: per-run dirs accumulate under \`aprender-ci/<PR>/\`. Existing
  disk-guard hook deletes old PR dirs after merge (incl. all run subdirs).
  No new cleanup logic needed.

## Verified

- \`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"\` → OK
- 4 mount lines updated (workspace-test: 3 docker steps + ownership-fix step)
- Inline comment block documents the race for future maintainers

## Impact

Once this lands, the recurring "No such file or directory (os error 2)"
flakes hitting the queue should stop. Currently blocking PR queue cascade.

Refs Toyota Way andon: this is the **second iteration** of the per-PR-target
fix. The 2026-04-23 fix was correct in direction (isolate from runner shared
state) but didn't account for the cancel-in-progress race. Both fixes are
needed: per-PR isolates across-PRs; per-RUN isolates within-PR rebuilds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)