### PR TITLE
feat(export): SPEC §81 P0-F — HF arch → GGUF lowercase case mapping

### DIFF
--- a/crates/aprender-core/src/format/converter/export_tests_arch_case_mapping.rs
+++ b/crates/aprender-core/src/format/converter/export_tests_arch_case_mapping.rs
@@ -1,0 +1,108 @@
+//! SPEC-SHIP-TWO-001 §81 P0-F — HF arch → GGUF lowercase case mapping.
+//!
+//! APR metadata uses HuggingFace transformers convention
+//! (e.g. `"LlamaForCausalLM"`, `"Qwen2ForCausalLM"`).
+//! GGUF / llama.cpp expects lowercase family names
+//! (`"llama"`, `"qwen2"`).
+//!
+//! Empirical surfacing on §78's MODEL-2 checkpoint:
+//! - `apr export --format gguf epoch-004.apr -o /tmp/e4.gguf` succeeded
+//! - `llama-cli -m /tmp/e4.gguf` refused with
+//!   `unknown model architecture: 'LlamaForCausalLM'`
+//!
+//! Fix surface: `gguf_export_config::normalize_arch_for_gguf` maps
+//! HF-style → GGUF-style at the export boundary.
+
+// `normalize_arch_for_gguf` lives in `gguf_export_config.rs` which is
+// `include!()`'d via `apr_export_fn.rs` → `export.rs` → `converter/mod.rs`,
+// so it is reachable as a sibling under `super` (the `converter` module).
+use super::super::normalize_arch_for_gguf;
+
+/// FALSIFY-EXPORT-GGUF-ARCH-001: LlamaForCausalLM must map to lowercase llama.
+///
+/// The load-bearing case from §81 P0-C — MODEL-2 epoch-004.apr embeds
+/// `architecture="LlamaForCausalLM"` (PyTorch/HF style); GGUF readers
+/// (llama.cpp, llm-cpp) require lowercase `"llama"`.
+#[test]
+fn falsify_export_gguf_arch_001_llama_hf_to_gguf_case() {
+    assert_eq!(normalize_arch_for_gguf("LlamaForCausalLM"), "llama");
+}
+
+#[test]
+fn falsify_export_gguf_arch_002_qwen2_hf_to_gguf_case() {
+    assert_eq!(normalize_arch_for_gguf("Qwen2ForCausalLM"), "qwen2");
+}
+
+#[test]
+fn falsify_export_gguf_arch_003_qwen3_hf_to_gguf_case() {
+    assert_eq!(normalize_arch_for_gguf("Qwen3ForCausalLM"), "qwen3");
+}
+
+#[test]
+fn falsify_export_gguf_arch_004_qwen_moe_variants() {
+    assert_eq!(normalize_arch_for_gguf("Qwen2MoeForCausalLM"), "qwen2moe");
+    assert_eq!(normalize_arch_for_gguf("Qwen3MoeForCausalLM"), "qwen3moe");
+}
+
+#[test]
+fn falsify_export_gguf_arch_005_mistral_maps_to_llama() {
+    // Mistral architectures use the llama family in GGUF — no separate "mistral".
+    assert_eq!(normalize_arch_for_gguf("MistralForCausalLM"), "llama");
+}
+
+#[test]
+fn falsify_export_gguf_arch_006_phi3_gpt2_bert() {
+    assert_eq!(normalize_arch_for_gguf("Phi3ForCausalLM"), "phi3");
+    assert_eq!(normalize_arch_for_gguf("GPT2LMHeadModel"), "gpt2");
+    assert_eq!(normalize_arch_for_gguf("BertForMaskedLM"), "bert");
+}
+
+#[test]
+fn falsify_export_gguf_arch_007_already_lowercase_passes_through() {
+    // Idempotent: feeding in already-normalized GGUF names must not change them.
+    assert_eq!(normalize_arch_for_gguf("llama"), "llama");
+    assert_eq!(normalize_arch_for_gguf("qwen2"), "qwen2");
+    assert_eq!(normalize_arch_for_gguf("phi3"), "phi3");
+    assert_eq!(normalize_arch_for_gguf("unknown"), "unknown");
+}
+
+#[test]
+fn falsify_export_gguf_arch_008_unknown_lowercase_fallback() {
+    // Defensive: an unknown HF-style name lowercases to maintain debuggability
+    // rather than crashing or silently producing wrong output.
+    let result = normalize_arch_for_gguf("SomeNovelArchForCausalLM");
+    assert_eq!(result, "somenovelarchforcausallm");
+    // The result MUST be lowercase (GGUF convention) even for unknowns.
+    assert_eq!(result, result.to_lowercase());
+}
+
+#[test]
+fn falsify_export_gguf_arch_009_never_emits_hf_uppercase() {
+    // Property: for the 6 known HF mappings, the output MUST NOT equal the input
+    // (it must have been normalized).
+    let hf_names = [
+        "LlamaForCausalLM",
+        "Qwen2ForCausalLM",
+        "Qwen3ForCausalLM",
+        "Qwen2MoeForCausalLM",
+        "Qwen3MoeForCausalLM",
+        "MistralForCausalLM",
+        "Phi3ForCausalLM",
+        "GPT2LMHeadModel",
+        "BertForMaskedLM",
+    ];
+    for hf in &hf_names {
+        let normalized = normalize_arch_for_gguf(hf);
+        assert_ne!(
+            normalized, *hf,
+            "HF name {} was not normalized (still upper-cased)",
+            hf
+        );
+        assert!(
+            normalized.chars().all(|c: char| !c.is_uppercase()),
+            "normalize_arch_for_gguf({}) → {} contains uppercase chars",
+            hf,
+            normalized
+        );
+    }
+}

--- a/crates/aprender-core/src/format/converter/export_tests_include_01.rs
+++ b/crates/aprender-core/src/format/converter/export_tests_include_01.rs
@@ -188,3 +188,5 @@ mod export_tests_e2e_gguf;
 mod export_tests_arch_metadata;
 #[path = "export_tests_unfuse_with_metadata.rs"]
 mod export_tests_unfuse_with_metadata;
+#[path = "export_tests_arch_case_mapping.rs"]
+mod export_tests_arch_case_mapping;

--- a/crates/aprender-core/src/format/converter/gguf_export_config.rs
+++ b/crates/aprender-core/src/format/converter/gguf_export_config.rs
@@ -93,6 +93,40 @@ struct GgufExportConfig {
     model_name: String,
 }
 
+/// Normalize an APR-side architecture string into the GGUF / llama.cpp
+/// convention (lowercase family name).
+///
+/// APR metadata uses HuggingFace transformers convention (e.g.
+/// `"LlamaForCausalLM"`, `"Qwen2ForCausalLM"`). GGUF / llama.cpp
+/// expects lowercase family names (`"llama"`, `"qwen2"`).
+///
+/// SPEC-SHIP-TWO-001 §81 P0-F. Empirical surfacing on §78's MODEL-2
+/// checkpoint: `apr export --format gguf` succeeded but `llama-cli`
+/// refused to load with "unknown model architecture: 'LlamaForCausalLM'".
+///
+/// Strategy: explicit mapping table for known HF names; lowercase fallback
+/// for anything else (preserves backward compatibility with already-correct
+/// inputs).
+pub(crate) fn normalize_arch_for_gguf(arch: &str) -> String {
+    match arch {
+        // HF "*ForCausalLM" suffixed family names → GGUF lowercase
+        "LlamaForCausalLM" => "llama".to_string(),
+        "Qwen2ForCausalLM" => "qwen2".to_string(),
+        "Qwen2MoeForCausalLM" => "qwen2moe".to_string(),
+        "Qwen3ForCausalLM" => "qwen3".to_string(),
+        "Qwen3MoeForCausalLM" => "qwen3moe".to_string(),
+        "MistralForCausalLM" => "llama".to_string(), // Mistral uses llama arch in GGUF
+        "Phi3ForCausalLM" => "phi3".to_string(),
+        "GPT2LMHeadModel" => "gpt2".to_string(),
+        "BertForMaskedLM" => "bert".to_string(),
+        // Already in GGUF convention → pass through unchanged
+        "llama" | "qwen2" | "qwen2moe" | "qwen3" | "qwen3moe" | "phi3" | "gpt2" | "bert"
+        | "unknown" => arch.to_string(),
+        // Unknown HF name → lowercase fallback (preserves debuggability)
+        other => other.to_lowercase(),
+    }
+}
+
 /// Resolve GGUF export config from APR metadata + inferred fallbacks.
 fn resolve_gguf_config(
     apr_metadata: Option<&crate::format::v2::AprV2Metadata>,
@@ -122,10 +156,14 @@ fn resolve_gguf_config(
     );
 
     // N-01 (Meyer DbC): Resolve architecture, then use it for rope_theta default.
-    let arch = apr_metadata
+    let arch_raw = apr_metadata
         .and_then(|m| m.architecture.clone())
         .or_else(|| inferred.and_then(|c| c.architecture.clone()))
         .unwrap_or_else(|| "unknown".to_string());
+    // §81 P0-F: APR metadata uses HuggingFace transformers convention
+    // (e.g. "LlamaForCausalLM"); GGUF / llama.cpp expects lowercase
+    // family names (e.g. "llama"). Map at the export boundary.
+    let arch = normalize_arch_for_gguf(&arch_raw);
 
     GgufExportConfig {
         arch,


### PR DESCRIPTION
Maps HF `LlamaForCausalLM` → GGUF `llama` at `apr export --format gguf` boundary. Empirically verified end-to-end: llama-cli now passes arch check (advances to P0-D next blocker, missing tokenizer merges — separate fix). 9 unit tests cover all known HF mappings + idempotent + lowercase fallback. **MODEL-2 ship %**: unchanged (P0-D still blocks llama-cli load). Closes one of three §81 blockers.