### PR TITLE
feat(train): SPEC §82 P2-B — warn on corpus wrap-around to expose data starvation

### DIFF
--- a/crates/apr-cli/src/commands/pretrain.rs
+++ b/crates/apr-cli/src/commands/pretrain.rs
@@ -435,7 +435,13 @@ fn drive_real(
                 dataset.display()
             ))
         })?
-        .with_wrap_around(true);
+        .with_wrap_around(true)
+        // SPEC §82 P2-B: surface data starvation. When the corpus cycles
+        // mid-run, emit a stderr line so operators can detect that the
+        // step budget exceeds the corpus capacity (per Chinchilla, train
+        // tokens D ≈ 20·N — if D is small, the corpus wraps repeatedly
+        // and the model memorizes instead of generalizing).
+        .with_warn_on_wrap_around(true);
 
     // Reserve the first `HELD_OUT_BATCHES` batches as the held-out val
     // set; the remainder feeds RealStepFn.

--- a/crates/aprender-train/src/train/shard_reader.rs
+++ b/crates/aprender-train/src/train/shard_reader.rs
@@ -32,6 +32,9 @@ pub struct ShardBatchIter {
     eos_id: u32,
     wrap_around: bool,
     epochs_completed: u64,
+    /// SPEC §82 P2-B: emit `eprintln!` when wrap-around fires.
+    /// Helps operators detect data starvation (corpus too small for step budget).
+    warn_on_wrap_around: bool,
 }
 
 impl ShardBatchIter {
@@ -68,6 +71,7 @@ impl ShardBatchIter {
             eos_id,
             wrap_around: false,
             epochs_completed: 0,
+            warn_on_wrap_around: false,
         })
     }
 
@@ -92,6 +96,15 @@ impl ShardBatchIter {
     #[must_use]
     pub fn epochs_completed(&self) -> u64 {
         self.epochs_completed
+    }
+
+    /// SPEC §82 P2-B: when wrap-around fires, emit a stderr line so operators
+    /// can detect data starvation (corpus too small for the requested step
+    /// budget). Default off for backward compatibility with tests.
+    #[must_use]
+    pub fn with_warn_on_wrap_around(mut self, warn: bool) -> Self {
+        self.warn_on_wrap_around = warn;
+        self
     }
 
     fn ensure_reader(&mut self) -> io::Result<bool> {
@@ -121,6 +134,16 @@ impl ShardBatchIter {
                 // and start over; else return None as before.
                 if self.wrap_around {
                     self.epochs_completed += 1;
+                    if self.warn_on_wrap_around {
+                        eprintln!(
+                            "[P2-B] corpus wrap-around #{}: dataset_dir of {} shards exhausted; \
+                             cycling. If observed early in run, corpus is too small for the \
+                             requested step budget — extend corpus per Chinchilla D ≈ 20·N or \
+                             reduce --num-steps.",
+                            self.epochs_completed,
+                            self.shards.len(),
+                        );
+                    }
                     self.cursor_shard = 0;
                     self.cursor_reader = None;
                     if !self.ensure_reader()? {
@@ -211,6 +234,45 @@ mod tests {
             "epochs_completed = {} should reflect at least 2 wrap resets",
             iter.epochs_completed()
         );
+    }
+
+    /// SPEC §82 P2-B: --warn-on-wrap-around exposes data starvation by
+    /// emitting a stderr line whenever the corpus cycles. This test verifies
+    /// the wrap counter still advances and the iterator stays well-behaved;
+    /// stderr capture is brittle across test harnesses, so we don't assert
+    /// on the literal text — that's a behavioural integration concern.
+    #[test]
+    fn warn_on_wrap_around_does_not_break_iteration() {
+        let tmp = TempDir::new().expect("tempdir");
+        let tokens: Vec<u32> = (0u32..40).collect();
+        write_shard(tmp.path(), "shard-0.bin", &tokens);
+        let mut iter = ShardBatchIter::new(tmp.path(), 2, 4, 0, 0)
+            .expect("iter")
+            .with_wrap_around(true)
+            .with_warn_on_wrap_around(true);
+        let mut batches = Vec::new();
+        for _ in 0..8 {
+            batches.push(iter.next().expect("must keep yielding with wrap"));
+        }
+        assert_eq!(batches.len(), 8);
+        assert!(
+            iter.epochs_completed() >= 1,
+            "at least one wrap should have fired with 4-batches/epoch × 8 pulls",
+        );
+    }
+
+    /// SPEC §82 P2-B: with_warn_on_wrap_around defaults off, and turning it on
+    /// without wrap_around is a no-op (no warning, no wrap, exhaustion is final).
+    #[test]
+    fn warn_without_wrap_is_inert() {
+        let tmp = TempDir::new().expect("tempdir");
+        let tokens: Vec<u32> = (0u32..40).collect();
+        write_shard(tmp.path(), "shard-0.bin", &tokens);
+        let iter = ShardBatchIter::new(tmp.path(), 2, 4, 0, 0)
+            .expect("iter")
+            .with_warn_on_wrap_around(true);
+        let batches: Vec<_> = iter.collect();
+        assert_eq!(batches.len(), 4, "still terminates after one pass without wrap");
     }
 
     /// Default behaviour (wrap_around=false) preserved: returns None


### PR DESCRIPTION
## Summary

- New `ShardBatchIter::with_warn_on_wrap_around(true)` opt-in flag that prints a stderr line each time the corpus cycles past its last shard.
- `apr pretrain` enables it by default so operators can detect when `--num-steps` exceeds corpus capacity (per Chinchilla `D ≈ 20·N`).
- Discharges §82's P2-B item (Δship +1, prevention, ~30 LOC + 2 tests).

## Motivation

Methodology lesson #29 (Class 3 packaging defects come in waves) and lesson #18 (predict-then-verify) both surface data starvation as a recurring class of MODEL-2 convergence failure. The 9.75 val_loss floor in §49 was eventually traced to 4× corpus memorization (`project_2026_04_27_4x_corpus_memorization_disproof.md`) — silent wrap-around masked the cause for weeks.

Now: 18M-token corpus + 5K steps × batch=16 × seq=512 = 41M tokens needed → wrap-around fires 2.3× during the run, with an explicit stderr line each time.

## Test plan

- [x] `cargo test -p aprender-train --lib shard_reader` → 7/7 PASS
- [x] 2 new tests: `warn_on_wrap_around_does_not_break_iteration` + `warn_without_wrap_is_inert`
- [x] 5 prior tests unaffected (backward compatible)
- [x] `cargo build -p apr-cli --bin apr` succeeds

## Backward compatibility

Default OFF. Tests and library users see no change unless they opt in via `.with_warn_on_wrap_around(true)`. Only `apr pretrain` enables it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)