### PR TITLE
feat(apr-cli): CRUX-K-08 `apr otlp-lint` OpenTelemetry trace classifier

### DIFF
--- a/contracts/apr-cli-commands-v1.yaml
+++ b/contracts/apr-cli-commands-v1.yaml
@@ -544,6 +544,12 @@ commands:
     requires_model: false
     side_effects: []
 
+  - name: otlp-lint
+    category: inspection
+    description: "Validate captured OTLP/JSON ExportTraceServiceRequest (CRUX-K-08): apr.inference span present + gen_ai.*/apr.tokens.* attributes + W3C trace-context propagation"
+    requires_model: false
+    side_effects: []
+
   - name: shard
     category: model_ops
     description: "Split safetensors file into shards + weight-map index (CRUX-B-05)"

--- a/contracts/crux-K-08-v1.yaml
+++ b/contracts/crux-K-08-v1.yaml
@@ -1,16 +1,22 @@
 # CRUX-K-08 — OpenTelemetry traces
-# Auto-scaffolded from crux-competitive-research-ux-v1.yaml (DRAFT).
-# DO NOT promote to ACTIVE until: (1) evidence collected, (2) falsification
-# body reflects competitor's canonical CLI, (3) apr surface mapped or gap
-# tracked in pmat work (see master §12).
+# Promoted to PARTIAL_ALGORITHM_LEVEL at v1.1.0 under CRUX-SHIP-001 (2026-05-16):
+# - classifier: crates/apr-cli/src/commands/otlp_classifier.rs (11 unit tests)
+# - CLI surface: `apr otlp-lint --otlp-file FILE [--require-apr-span] [--require-genai-attrs] [--expect-trace-id HEX32]`
+# - e2e: crates/apr-cli/tests/falsification_crux_k_08.rs (11 tests)
+# Full discharge blocks on a live `apr serve` OTLP exporter wired to
+# `OTEL_EXPORTER_OTLP_ENDPOINT` emitting `apr.inference` spans with
+# gen_ai.* attributes and W3C trace-context propagation — tracked as
+# BLOCKER-UPSTREAM-MISSING.
 
 metadata:
   id: CRUX-K-08
-  version: "1.0.0-draft"
+  version: "1.1.0"
   created: "2026-04-18"
+  updated: "2026-05-16"
   author: PAIML Engineering
   registry: true
-  status: draft
+  status: partial
+  kind: kernel
   parent_contracts:
   - crux-competitive-research-ux-v1
   category: "K — Ecosystem & Integration"
@@ -102,6 +108,25 @@ falsification_tests:
     sleep 1
     grep -q 'apr.inference' /tmp/otlp.log
   if_fails: "apr serve does not export OTLP span named 'apr.inference' to configured endpoint"
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/otlp_classifier.rs
+    cli_path: crates/apr-cli/src/commands/otlp_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_k_08.rs
+    e2e_tests:
+    - falsify_crux_k_08_001_span_present_ok_on_apr_inference
+    - falsify_crux_k_08_001_span_present_reports_missing_apr_inference
+    sub_claim: |
+      Algorithm-level necessary conditions on an already-captured OTLP/JSON
+      `ExportTraceServiceRequest`: `classify_span_present` walks
+      `resourceSpans[].scopeSpans[].spans[]` and returns `Ok { count }` only
+      when at least one span has the requested name (`apr.inference`),
+      and reports `SpanNameNotFound { names_seen }` listing the names that
+      were emitted so divergence is debuggable. Reject conditions
+      `NotAnObject` and `MissingResourceSpans` surface malformed bodies
+      before they reach the live exporter.
+    scope: "(body, span_name) -> OtlpSpanPresentOutcome (pure)"
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: "live aprender-serve OTLP exporter emitting `apr.inference` spans"
 
 - id: FALSIFY-CRUX-K-08-002
   rule: "GenAI semantic conventions present on inference span"
@@ -114,6 +139,22 @@ falsification_tests:
       grep -q "$KEY" /tmp/otlp.log || { echo "missing attribute: $KEY"; exit 1; }
     done
   if_fails: "OTLP span missing one of the required gen_ai.* or apr.tokens.* attributes"
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/otlp_classifier.rs
+    cli_path: crates/apr-cli/src/commands/otlp_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_k_08.rs
+    e2e_tests:
+    - falsify_crux_k_08_002_genai_attributes_ok_on_full_body
+    - falsify_crux_k_08_002_genai_attributes_reports_partial_set
+    sub_claim: |
+      Algorithm-level necessary conditions: `classify_genai_attributes`
+      collects every `attributes[].key` across all spans in the OTLP body
+      (the OTLP/JSON encoding uses a key-value array, not a map), then
+      verifies the K08_REQUIRED_ATTRIBUTES set is a subset. Missing keys
+      are reported lexicographically so diffs are stable across runs.
+    scope: "(body, required_keys) -> OtlpAttributesOutcome (pure)"
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: "live aprender-serve OTLP exporter populating gen_ai.* + apr.tokens.* attributes"
 
 - id: FALSIFY-CRUX-K-08-003
   rule: "W3C trace-context propagation: incoming traceparent reused in exported span"
@@ -131,6 +172,25 @@ falsification_tests:
     sleep 1
     grep -q "$TRACE_ID" /tmp/otlp.log
   if_fails: "apr serve does not honor W3C traceparent (trace-id not propagated to exported span)"
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/otlp_classifier.rs
+    cli_path: crates/apr-cli/src/commands/otlp_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_k_08.rs
+    e2e_tests:
+    - falsify_crux_k_08_003_trace_propagation_ok_on_canonical_traceparent
+    - falsify_crux_k_08_003_trace_propagation_rejects_short_id
+    - falsify_crux_k_08_003_trace_propagation_reports_mismatch
+    sub_claim: |
+      Algorithm-level necessary conditions: `classify_trace_propagation`
+      first validates the expected trace-id is 32 lowercase hex characters
+      (W3C trace-context format) — rejects anything else with
+      `InvalidExpectedTraceId` so caller bugs surface before the body is
+      walked. Then it scans every `traceId` in the OTLP body for byte-equal
+      match; on miss it reports `TraceIdNotFound { ids_seen }` listing the
+      actual trace-ids so divergence is debuggable.
+    scope: "(body, expected_trace_id) -> OtlpTracePropagationOutcome (pure)"
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: "live aprender-serve OTLP exporter wiring W3C traceparent into emitted spans"
 
 proof_obligations:
 - type: invariant

--- a/crates/apr-cli/src/commands/mod.rs
+++ b/crates/apr-cli/src/commands/mod.rs
@@ -79,6 +79,8 @@ pub(crate) mod ollama_tools_lint;
 pub(crate) mod oom_classifier;
 pub(crate) mod oom_lint;
 pub(crate) mod oracle;
+pub(crate) mod otlp_classifier;
+pub(crate) mod otlp_lint;
 pub(crate) mod parity;
 pub(crate) mod pipeline;
 pub(crate) mod ppl;

--- a/crates/apr-cli/src/commands/otlp_classifier.rs
+++ b/crates/apr-cli/src/commands/otlp_classifier.rs
@@ -1,0 +1,371 @@
+//! OpenTelemetry OTLP trace classifier (CRUX-K-08).
+//!
+//! Pure, deterministic classifiers that discharge FALSIFY-CRUX-K-08-{001,002,003}
+//! at the PARTIAL_ALGORITHM_LEVEL — algorithm-level necessary conditions on
+//! an already-captured OTLP/JSON `ExportTraceServiceRequest` body:
+//!
+//!   * `classify_span_present` — at least one span with the given name exists
+//!     anywhere in `resourceSpans[].scopeSpans[].spans[]`.
+//!   * `classify_genai_attributes` — at least one span carries every required
+//!     attribute key (e.g. `gen_ai.system`, `gen_ai.request.model`,
+//!     `apr.tokens.prompt`, `apr.tokens.output`).
+//!   * `classify_trace_propagation` — at least one span's `traceId` matches an
+//!     expected 32-hex-char trace-id (the W3C `traceparent` upstream).
+//!
+//! All three operate on the **OTLP/JSON** encoding documented at
+//! <https://opentelemetry.io/docs/specs/otlp/#json-protobuf-encoding>. Body
+//! shape:
+//!
+//! ```json
+//! {
+//!   "resourceSpans": [{
+//!     "resource": {"attributes": [{"key":..., "value":{"stringValue":...}}]},
+//!     "scopeSpans": [{
+//!       "spans": [{
+//!         "traceId": "<32-hex>",
+//!         "spanId": "<16-hex>",
+//!         "parentSpanId": "<16-hex>",
+//!         "name": "apr.inference",
+//!         "attributes": [{"key":"gen_ai.system","value":{"stringValue":"apr"}}, ...]
+//!       }]
+//!     }]
+//!   }]
+//! }
+//! ```
+//!
+//! Full discharge blocks on a live `apr serve` OTLP exporter wired to
+//! `OTEL_EXPORTER_OTLP_ENDPOINT` — tracked as BLOCKER-UPSTREAM-MISSING.
+
+use serde_json::Value;
+
+/// Canonical OpenTelemetry GenAI + apr-specific attribute keys that an
+/// `apr.inference` span must carry (CRUX-K-08 `gen_ai_semconv_attributes`).
+pub const K08_REQUIRED_ATTRIBUTES: &[&str] = &[
+    "gen_ai.system",
+    "gen_ai.request.model",
+    "apr.tokens.prompt",
+    "apr.tokens.output",
+];
+
+/// Canonical span name emitted by `apr serve` on every inference request.
+pub const K08_ROOT_SPAN_NAME: &str = "apr.inference";
+
+/// Outcome of `classify_span_present`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OtlpSpanPresentOutcome {
+    /// At least one span with the requested name exists.
+    Ok { count: usize },
+    /// OTLP body root is not a JSON object.
+    NotAnObject,
+    /// `resourceSpans` is absent or not an array.
+    MissingResourceSpans,
+    /// Body parsed but no span matches the requested name.
+    SpanNameNotFound {
+        requested: String,
+        names_seen: Vec<String>,
+    },
+}
+
+/// Outcome of `classify_genai_attributes`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OtlpAttributesOutcome {
+    /// Every required attribute key appeared on at least one span.
+    Ok,
+    /// At least one required attribute key is absent from every span.
+    Missing { missing: Vec<String> },
+}
+
+/// Outcome of `classify_trace_propagation`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OtlpTracePropagationOutcome {
+    /// At least one span's `traceId` matches the expected trace-id (lowercase hex).
+    Ok,
+    /// Expected trace-id is not 32 lowercase hex characters.
+    InvalidExpectedTraceId { got: String },
+    /// No span in the body carries the expected `traceId`.
+    TraceIdNotFound {
+        expected: String,
+        ids_seen: Vec<String>,
+    },
+}
+
+/// Return true if a span anywhere in `body` has `name == span_name`.
+pub fn classify_span_present(body: &Value, span_name: &str) -> OtlpSpanPresentOutcome {
+    let Some(obj) = body.as_object() else {
+        return OtlpSpanPresentOutcome::NotAnObject;
+    };
+    let Some(resource_spans) = obj.get("resourceSpans").and_then(Value::as_array) else {
+        return OtlpSpanPresentOutcome::MissingResourceSpans;
+    };
+    let mut count = 0;
+    let mut names = Vec::new();
+    for rs in resource_spans {
+        for ss in rs
+            .get("scopeSpans")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+        {
+            for span in ss
+                .get("spans")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+            {
+                if let Some(n) = span.get("name").and_then(Value::as_str) {
+                    if n == span_name {
+                        count += 1;
+                    } else {
+                        names.push(n.to_string());
+                    }
+                }
+            }
+        }
+    }
+    if count > 0 {
+        OtlpSpanPresentOutcome::Ok { count }
+    } else {
+        OtlpSpanPresentOutcome::SpanNameNotFound {
+            requested: span_name.to_string(),
+            names_seen: names,
+        }
+    }
+}
+
+/// Verify that every key in `required` appears on at least one span's
+/// `attributes[]` list anywhere in the body. (OTLP attributes are a
+/// key-value array, not a map.)
+pub fn classify_genai_attributes(body: &Value, required: &[&str]) -> OtlpAttributesOutcome {
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    if let Some(resource_spans) = body.get("resourceSpans").and_then(Value::as_array) {
+        for rs in resource_spans {
+            for ss in rs
+                .get("scopeSpans")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+            {
+                for span in ss
+                    .get("spans")
+                    .and_then(Value::as_array)
+                    .into_iter()
+                    .flatten()
+                {
+                    if let Some(attrs) = span.get("attributes").and_then(Value::as_array) {
+                        for kv in attrs {
+                            if let Some(k) = kv.get("key").and_then(Value::as_str) {
+                                seen.insert(k.to_string());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    let mut missing: Vec<String> = required
+        .iter()
+        .filter(|r| !seen.contains(**r))
+        .map(|s| (*s).to_string())
+        .collect();
+    if missing.is_empty() {
+        OtlpAttributesOutcome::Ok
+    } else {
+        missing.sort();
+        OtlpAttributesOutcome::Missing { missing }
+    }
+}
+
+/// Verify that at least one span in `body` has `traceId == expected_trace_id`.
+///
+/// `expected_trace_id` must be 32 lowercase hex characters (W3C trace-context
+/// trace-id encoding). The comparison is byte-equal — OTLP/JSON traceId is
+/// always lowercase hex per the spec.
+pub fn classify_trace_propagation(
+    body: &Value,
+    expected_trace_id: &str,
+) -> OtlpTracePropagationOutcome {
+    if expected_trace_id.len() != 32
+        || !expected_trace_id
+            .bytes()
+            .all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'f'))
+    {
+        return OtlpTracePropagationOutcome::InvalidExpectedTraceId {
+            got: expected_trace_id.to_string(),
+        };
+    }
+    let mut ids = Vec::new();
+    if let Some(resource_spans) = body.get("resourceSpans").and_then(Value::as_array) {
+        for rs in resource_spans {
+            for ss in rs
+                .get("scopeSpans")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+            {
+                for span in ss
+                    .get("spans")
+                    .and_then(Value::as_array)
+                    .into_iter()
+                    .flatten()
+                {
+                    if let Some(tid) = span.get("traceId").and_then(Value::as_str) {
+                        if tid == expected_trace_id {
+                            return OtlpTracePropagationOutcome::Ok;
+                        }
+                        ids.push(tid.to_string());
+                    }
+                }
+            }
+        }
+    }
+    OtlpTracePropagationOutcome::TraceIdNotFound {
+        expected: expected_trace_id.to_string(),
+        ids_seen: ids,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn good_body() -> Value {
+        json!({
+            "resourceSpans": [{
+                "resource": {"attributes": []},
+                "scopeSpans": [{
+                    "scope": {"name": "apr"},
+                    "spans": [{
+                        "traceId": "0af7651916cd43dd8448eb211c80319c",
+                        "spanId": "1234567890abcdef",
+                        "parentSpanId": "00f067aa0ba902b7",
+                        "name": "apr.inference",
+                        "attributes": [
+                            {"key": "gen_ai.system", "value": {"stringValue": "apr"}},
+                            {"key": "gen_ai.request.model", "value": {"stringValue": "qwen3-1.7b"}},
+                            {"key": "apr.tokens.prompt", "value": {"intValue": "42"}},
+                            {"key": "apr.tokens.output", "value": {"intValue": "10"}},
+                        ]
+                    }]
+                }]
+            }]
+        })
+    }
+
+    #[test]
+    fn span_present_ok_on_apr_inference() {
+        let out = classify_span_present(&good_body(), K08_ROOT_SPAN_NAME);
+        assert_eq!(out, OtlpSpanPresentOutcome::Ok { count: 1 });
+    }
+
+    #[test]
+    fn span_present_rejects_not_an_object() {
+        let body = json!([1, 2, 3]);
+        assert_eq!(
+            classify_span_present(&body, K08_ROOT_SPAN_NAME),
+            OtlpSpanPresentOutcome::NotAnObject
+        );
+    }
+
+    #[test]
+    fn span_present_rejects_missing_resource_spans() {
+        let body = json!({"otherTopLevel": []});
+        assert_eq!(
+            classify_span_present(&body, K08_ROOT_SPAN_NAME),
+            OtlpSpanPresentOutcome::MissingResourceSpans
+        );
+    }
+
+    #[test]
+    fn span_present_reports_unrecognized_name() {
+        let body =
+            json!({"resourceSpans":[{"scopeSpans":[{"spans":[{"name":"http.server.request"}]}]}]});
+        match classify_span_present(&body, K08_ROOT_SPAN_NAME) {
+            OtlpSpanPresentOutcome::SpanNameNotFound { names_seen, .. } => {
+                assert!(names_seen.contains(&"http.server.request".to_string()));
+            }
+            other => panic!("expected SpanNameNotFound, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn genai_attributes_ok_on_full_body() {
+        assert_eq!(
+            classify_genai_attributes(&good_body(), K08_REQUIRED_ATTRIBUTES),
+            OtlpAttributesOutcome::Ok
+        );
+    }
+
+    #[test]
+    fn genai_attributes_reports_missing_subset() {
+        let body = json!({
+            "resourceSpans":[{"scopeSpans":[{"spans":[{
+                "name": "apr.inference",
+                "attributes":[
+                    {"key":"gen_ai.system","value":{"stringValue":"apr"}}
+                ]
+            }]}]}]
+        });
+        match classify_genai_attributes(&body, K08_REQUIRED_ATTRIBUTES) {
+            OtlpAttributesOutcome::Missing { missing } => {
+                assert!(missing.contains(&"gen_ai.request.model".to_string()));
+                assert!(missing.contains(&"apr.tokens.prompt".to_string()));
+                assert!(missing.contains(&"apr.tokens.output".to_string()));
+                assert!(!missing.contains(&"gen_ai.system".to_string()));
+            }
+            other => panic!("expected Missing, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn trace_propagation_ok_on_canonical_traceparent() {
+        let out = classify_trace_propagation(&good_body(), "0af7651916cd43dd8448eb211c80319c");
+        assert_eq!(out, OtlpTracePropagationOutcome::Ok);
+    }
+
+    #[test]
+    fn trace_propagation_rejects_short_expected_id() {
+        let out = classify_trace_propagation(&good_body(), "short");
+        assert!(matches!(
+            out,
+            OtlpTracePropagationOutcome::InvalidExpectedTraceId { .. }
+        ));
+    }
+
+    #[test]
+    fn trace_propagation_rejects_uppercase_expected_id() {
+        // OTLP/JSON encodes traceId as lowercase hex; an uppercase request is invalid input.
+        let out = classify_trace_propagation(&good_body(), "0AF7651916CD43DD8448EB211C80319C");
+        assert!(matches!(
+            out,
+            OtlpTracePropagationOutcome::InvalidExpectedTraceId { .. }
+        ));
+    }
+
+    #[test]
+    fn trace_propagation_reports_mismatch() {
+        let out = classify_trace_propagation(&good_body(), "ffffffffffffffffffffffffffffffff");
+        match out {
+            OtlpTracePropagationOutcome::TraceIdNotFound { ids_seen, .. } => {
+                assert!(ids_seen.contains(&"0af7651916cd43dd8448eb211c80319c".to_string()));
+            }
+            other => panic!("expected TraceIdNotFound, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn span_present_counts_multiple_spans_in_multiple_scopes() {
+        let body = json!({
+            "resourceSpans":[
+                {"scopeSpans":[
+                    {"spans":[{"name":"apr.inference"},{"name":"apr.inference"}]},
+                    {"spans":[{"name":"apr.inference"}]}
+                ]}
+            ]
+        });
+        assert_eq!(
+            classify_span_present(&body, "apr.inference"),
+            OtlpSpanPresentOutcome::Ok { count: 3 }
+        );
+    }
+}

--- a/crates/apr-cli/src/commands/otlp_lint.rs
+++ b/crates/apr-cli/src/commands/otlp_lint.rs
@@ -1,0 +1,109 @@
+//! `apr otlp-lint` — CRUX-K-08 OpenTelemetry OTLP trace gate.
+//!
+//! Reads an already-captured OTLP/JSON `ExportTraceServiceRequest` body and
+//! dispatches the pure classifiers in `otlp_classifier`. Exits non-zero on
+//! any failure.
+//!
+//! Spec: `contracts/crux-K-08-v1.yaml`. CRUX-SHIP-001 g2/g3 surface.
+
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+
+use super::otlp_classifier::{
+    classify_genai_attributes, classify_span_present, classify_trace_propagation,
+    OtlpAttributesOutcome, OtlpSpanPresentOutcome, OtlpTracePropagationOutcome,
+    K08_REQUIRED_ATTRIBUTES, K08_ROOT_SPAN_NAME,
+};
+use crate::error::{CliError, Result};
+
+pub(crate) fn run(
+    otlp_file: &Path,
+    require_apr_span: bool,
+    require_genai_attrs: bool,
+    expect_trace_id: Option<&str>,
+    json: bool,
+) -> Result<()> {
+    if !otlp_file.exists() {
+        return Err(CliError::FileNotFound(PathBuf::from(otlp_file)));
+    }
+    let body_text = std::fs::read_to_string(otlp_file)?;
+    let body: Value = serde_json::from_str(&body_text).map_err(|e| {
+        CliError::InvalidFormat(format!(
+            "apr otlp-lint: failed to parse JSON from {}: {e}",
+            otlp_file.display()
+        ))
+    })?;
+
+    let span = if require_apr_span {
+        Some(classify_span_present(&body, K08_ROOT_SPAN_NAME))
+    } else {
+        None
+    };
+    let attrs = if require_genai_attrs {
+        Some(classify_genai_attributes(&body, K08_REQUIRED_ATTRIBUTES))
+    } else {
+        None
+    };
+    let trace = expect_trace_id.map(|tid| classify_trace_propagation(&body, tid));
+
+    print_report(
+        otlp_file,
+        span.as_ref(),
+        attrs.as_ref(),
+        trace.as_ref(),
+        json,
+    );
+
+    if let Some(outcome) = &span {
+        if !matches!(outcome, OtlpSpanPresentOutcome::Ok { .. }) {
+            return Err(CliError::ValidationFailed(format!(
+                "otlp-lint span-present gate rejected body: {outcome:?}"
+            )));
+        }
+    }
+    if let Some(outcome) = &attrs {
+        if !matches!(outcome, OtlpAttributesOutcome::Ok) {
+            return Err(CliError::ValidationFailed(format!(
+                "otlp-lint genai-attributes gate rejected body: {outcome:?}"
+            )));
+        }
+    }
+    if let Some(outcome) = &trace {
+        if !matches!(outcome, OtlpTracePropagationOutcome::Ok) {
+            return Err(CliError::ValidationFailed(format!(
+                "otlp-lint trace-propagation gate rejected body: {outcome:?}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn print_report(
+    path: &Path,
+    span: Option<&OtlpSpanPresentOutcome>,
+    attrs: Option<&OtlpAttributesOutcome>,
+    trace: Option<&OtlpTracePropagationOutcome>,
+    json: bool,
+) {
+    if json {
+        let obj = serde_json::json!({
+            "file": path.display().to_string(),
+            "span_present": span.map(|s| format!("{s:?}")),
+            "genai_attributes": attrs.map(|a| format!("{a:?}")),
+            "trace_propagation": trace.map(|t| format!("{t:?}")),
+        });
+        println!("{}", serde_json::to_string_pretty(&obj).unwrap_or_default());
+        return;
+    }
+    println!("otlp-lint report for {}", path.display());
+    if let Some(s) = span {
+        println!("  span_present     : {s:?}");
+    }
+    if let Some(a) = attrs {
+        println!("  genai_attributes : {a:?}");
+    }
+    if let Some(t) = trace {
+        println!("  trace_propagation: {t:?}");
+    }
+}

--- a/crates/apr-cli/src/dispatch_analysis.rs
+++ b/crates/apr-cli/src/dispatch_analysis.rs
@@ -157,6 +157,19 @@ fn dispatch_analysis_commands(cli: &Cli) -> Option<Result<(), CliError>> {
             stderr_file,
         } => commands::oom_lint::run(report_file, stderr_file.as_deref(), cli.json),
 
+        ExtendedCommands::OtlpLint {
+            otlp_file,
+            require_apr_span,
+            require_genai_attrs,
+            expect_trace_id,
+        } => commands::otlp_lint::run(
+            otlp_file,
+            *require_apr_span,
+            *require_genai_attrs,
+            expect_trace_id.as_deref(),
+            cli.json,
+        ),
+
         ExtendedCommands::PrometheusLint {
             metrics_file,
             content_type,

--- a/crates/apr-cli/src/extended_commands.rs
+++ b/crates/apr-cli/src/extended_commands.rs
@@ -784,6 +784,21 @@ pub enum ExtendedCommands {
         #[arg(long, value_name = "FILE")]
         stderr_file: Option<PathBuf>,
     },
+    /// Lint a captured OTLP/JSON ExportTraceServiceRequest body (CRUX-K-08)
+    OtlpLint {
+        /// Path to captured OTLP/JSON export body
+        #[arg(long, value_name = "FILE")]
+        otlp_file: PathBuf,
+        /// Require at least one `apr.inference` span to be present
+        #[arg(long)]
+        require_apr_span: bool,
+        /// Require gen_ai.* and apr.tokens.* attribute keys on some span
+        #[arg(long)]
+        require_genai_attrs: bool,
+        /// Verify W3C trace-context propagation: expect this 32-hex traceId
+        #[arg(long, value_name = "HEX32")]
+        expect_trace_id: Option<String>,
+    },
     /// Lint a captured Prometheus /metrics response (CRUX-K-07)
     PrometheusLint {
         /// Path to captured /metrics response body (text/plain; version=0.0.4)

--- a/crates/apr-cli/tests/cli_commands.rs
+++ b/crates/apr-cli/tests/cli_commands.rs
@@ -113,6 +113,7 @@ fn registered_commands() -> Vec<&'static str> {
         "ppl",
         "quant-preservation-lint",
         "prometheus-lint",
+        "otlp-lint",
         "shard",
         "unshard",
         "oracle",

--- a/crates/apr-cli/tests/falsification_crux_k_08.rs
+++ b/crates/apr-cli/tests/falsification_crux_k_08.rs
@@ -1,0 +1,275 @@
+//! CRUX-K-08 — end-to-end falsification harness for `apr otlp-lint`.
+//!
+//! CRUX-SHIP-001 gate g3 evidence: every FALSIFY-CRUX-K-08-{001,002,003}
+//! gate the classifier discharges has a matching captured OTLP/JSON body
+//! that the binary must classify exactly as the harness expects.
+
+use serde_json::json;
+use std::io::Write;
+use std::process::Command;
+
+fn apr_binary() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_apr"));
+    cmd.env("NO_COLOR", "1");
+    cmd
+}
+
+fn write_otlp(body: &serde_json::Value) -> tempfile::NamedTempFile {
+    let mut f = tempfile::Builder::new()
+        .prefix("crux-k-08-otlp-")
+        .suffix(".json")
+        .tempfile()
+        .expect("tempfile");
+    f.write_all(
+        serde_json::to_vec_pretty(body)
+            .expect("serialize")
+            .as_slice(),
+    )
+    .expect("write");
+    f.flush().expect("flush");
+    f
+}
+
+fn good_otlp_body() -> serde_json::Value {
+    json!({
+        "resourceSpans": [{
+            "resource": {"attributes": [
+                {"key": "service.name", "value": {"stringValue": "apr-serve"}}
+            ]},
+            "scopeSpans": [{
+                "scope": {"name": "apr"},
+                "spans": [{
+                    "traceId": "0af7651916cd43dd8448eb211c80319c",
+                    "spanId": "1234567890abcdef",
+                    "parentSpanId": "00f067aa0ba902b7",
+                    "name": "apr.inference",
+                    "attributes": [
+                        {"key": "gen_ai.system", "value": {"stringValue": "apr"}},
+                        {"key": "gen_ai.request.model", "value": {"stringValue": "qwen3-1.7b"}},
+                        {"key": "apr.tokens.prompt", "value": {"intValue": "42"}},
+                        {"key": "apr.tokens.output", "value": {"intValue": "10"}}
+                    ]
+                }]
+            }]
+        }]
+    })
+}
+
+// ===== g2: CLI shape =====
+
+#[test]
+fn falsify_crux_k_08_cli_help_advertises_flags() {
+    let out = apr_binary()
+        .args(["otlp-lint", "--help"])
+        .output()
+        .expect("run");
+    assert!(out.status.success(), "--help must exit 0");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("--otlp-file"),
+        "--help must advertise --otlp-file; got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("--require-apr-span"),
+        "--help must advertise --require-apr-span; got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("--require-genai-attrs"),
+        "--help must advertise --require-genai-attrs; got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("--expect-trace-id"),
+        "--help must advertise --expect-trace-id; got:\n{stdout}"
+    );
+}
+
+#[test]
+fn falsify_crux_k_08_cli_missing_file_fails() {
+    let out = apr_binary()
+        .args([
+            "otlp-lint",
+            "--otlp-file",
+            "/nonexistent/crux-k-08-missing.json",
+        ])
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "missing file must not exit 0");
+}
+
+#[test]
+fn falsify_crux_k_08_cli_malformed_json_fails() {
+    let mut f = tempfile::Builder::new()
+        .prefix("crux-k-08-bad-")
+        .suffix(".json")
+        .tempfile()
+        .expect("tempfile");
+    f.write_all(b"{ not json").expect("write");
+    f.flush().expect("flush");
+    let out = apr_binary()
+        .args(["otlp-lint", "--otlp-file"])
+        .arg(f.path())
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "malformed JSON must not exit 0");
+}
+
+// ===== g3: classifier discharges =====
+
+#[test]
+fn falsify_crux_k_08_001_span_present_ok_on_apr_inference() {
+    let f = write_otlp(&good_otlp_body());
+    let out = apr_binary()
+        .args(["otlp-lint", "--otlp-file"])
+        .arg(f.path())
+        .arg("--require-apr-span")
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "good OTLP body must pass span-present gate; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn falsify_crux_k_08_001_span_present_reports_missing_apr_inference() {
+    let body =
+        json!({"resourceSpans":[{"scopeSpans":[{"spans":[{"name":"http.server.request"}]}]}]});
+    let f = write_otlp(&body);
+    let out = apr_binary()
+        .args(["otlp-lint", "--otlp-file"])
+        .arg(f.path())
+        .arg("--require-apr-span")
+        .output()
+        .expect("run");
+    assert!(
+        !out.status.success(),
+        "missing apr.inference span must fail"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("SpanNameNotFound"),
+        "stderr must name SpanNameNotFound outcome; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn falsify_crux_k_08_002_genai_attributes_ok_on_full_body() {
+    let f = write_otlp(&good_otlp_body());
+    let out = apr_binary()
+        .args(["otlp-lint", "--otlp-file"])
+        .arg(f.path())
+        .arg("--require-genai-attrs")
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "full body must pass genai-attributes gate; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn falsify_crux_k_08_002_genai_attributes_reports_partial_set() {
+    let body = json!({
+        "resourceSpans":[{"scopeSpans":[{"spans":[{
+            "name":"apr.inference",
+            "attributes":[
+                {"key":"gen_ai.system","value":{"stringValue":"apr"}}
+            ]
+        }]}]}]
+    });
+    let f = write_otlp(&body);
+    let out = apr_binary()
+        .args(["otlp-lint", "--otlp-file"])
+        .arg(f.path())
+        .arg("--require-genai-attrs")
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "partial attribute set must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("Missing") && stderr.contains("apr.tokens.prompt"),
+        "stderr must list missing keys; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn falsify_crux_k_08_003_trace_propagation_ok_on_canonical_traceparent() {
+    let f = write_otlp(&good_otlp_body());
+    let out = apr_binary()
+        .args(["otlp-lint", "--otlp-file"])
+        .arg(f.path())
+        .args(["--expect-trace-id", "0af7651916cd43dd8448eb211c80319c"])
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "canonical traceparent must pass; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn falsify_crux_k_08_003_trace_propagation_rejects_short_id() {
+    let f = write_otlp(&good_otlp_body());
+    let out = apr_binary()
+        .args(["otlp-lint", "--otlp-file"])
+        .arg(f.path())
+        .args(["--expect-trace-id", "shortid"])
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "short trace-id must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("InvalidExpectedTraceId"),
+        "stderr must name InvalidExpectedTraceId outcome; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn falsify_crux_k_08_003_trace_propagation_reports_mismatch() {
+    let f = write_otlp(&good_otlp_body());
+    let out = apr_binary()
+        .args(["otlp-lint", "--otlp-file"])
+        .arg(f.path())
+        .args(["--expect-trace-id", "ffffffffffffffffffffffffffffffff"])
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "unmatched trace-id must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("TraceIdNotFound"),
+        "stderr must name TraceIdNotFound outcome; got:\n{stderr}"
+    );
+}
+
+// ===== JSON output shape =====
+
+#[test]
+fn falsify_crux_k_08_json_output_contains_outcomes() {
+    let f = write_otlp(&good_otlp_body());
+    let out = apr_binary()
+        .args(["--json", "otlp-lint", "--otlp-file"])
+        .arg(f.path())
+        .arg("--require-apr-span")
+        .arg("--require-genai-attrs")
+        .args(["--expect-trace-id", "0af7651916cd43dd8448eb211c80319c"])
+        .output()
+        .expect("run");
+    assert!(out.status.success(), "json + good body must exit 0");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("json output must parse");
+    assert!(parsed["span_present"]
+        .as_str()
+        .expect("span_present")
+        .contains("Ok"));
+    assert!(parsed["genai_attributes"]
+        .as_str()
+        .expect("genai_attributes")
+        .contains("Ok"));
+    assert!(parsed["trace_propagation"]
+        .as_str()
+        .expect("trace_propagation")
+        .contains("Ok"));
+}


### PR DESCRIPTION
## Summary

- Promotes `contracts/crux-K-08-v1.yaml` from `draft` → PARTIAL_ALGORITHM_LEVEL.
- Adds `apr otlp-lint --otlp-file FILE [--require-apr-span] [--require-genai-attrs] [--expect-trace-id HEX32]` — pure-function classifier over captured OTLP/JSON ExportTraceServiceRequest bodies validating: `apr.inference` span presence, GenAI semconv + `apr.tokens.*` attributes, and W3C trace-context propagation.
- 11 classifier unit tests + 11 e2e falsification tests + 8 cli_commands surface tests all pass.

Discharges FALSIFY-CRUX-K-08-001 (span present), -002 (attribute set), and -003 (trace-id propagation) at PARTIAL_ALGORITHM_LEVEL. Full discharge blocks on a live \`apr serve\` OTLP exporter wired to \`OTEL_EXPORTER_OTLP_ENDPOINT\`.

## Test plan

- [x] \`cargo test -p apr-cli --lib otlp_classifier\` — 11/11 pass.
- [x] \`cargo test -p apr-cli --test falsification_crux_k_08\` — 11/11 pass.
- [x] \`cargo test -p apr-cli --test cli_commands\` — 8/8 pass (3-surface drift policy).
- [x] \`pv validate contracts/crux-K-08-v1.yaml\` — clean.
- [ ] CI green on \`ci / gate\` + \`workspace-test\`.

Refs #921 (CRUX M4 observability epic), #917 (CRUX Phase 3 umbrella).

🤖 Generated with [Claude Code](https://claude.com/claude-code)