### PR TITLE
feat(apr-cli): CRUX-F-06 `apr kv-timeline-lint` KV-cache utilization classifier

### DIFF
--- a/contracts/apr-cli-commands-v1.yaml
+++ b/contracts/apr-cli-commands-v1.yaml
@@ -550,6 +550,12 @@ commands:
     requires_model: false
     side_effects: []
 
+  - name: kv-timeline-lint
+    category: inspection
+    description: "Validate captured KV-cache utilization timeline (CRUX-F-06): schema + block conservation + used_pct arithmetic + peak consistency + preemption-threshold trigger"
+    requires_model: false
+    side_effects: []
+
   - name: shard
     category: model_ops
     description: "Split safetensors file into shards + weight-map index (CRUX-B-05)"

--- a/contracts/crux-F-06-v1.yaml
+++ b/contracts/crux-F-06-v1.yaml
@@ -1,14 +1,20 @@
 # CRUX-F-06 — KV-cache utilization timeline
-# Auto-scaffolded from crux-competitive-research-ux-v1.yaml (spec-complete).
-# Evidence must land before ACTIVE promotion — see master §12.
+# Promoted to PARTIAL_ALGORITHM_LEVEL at v1.1.0 under CRUX-SHIP-001 (2026-05-16):
+# - classifier: crates/apr-cli/src/commands/kv_timeline_classifier.rs (14 unit tests)
+# - CLI surface: `apr kv-timeline-lint --timeline-file FILE [--preempt-threshold F]`
+# - e2e: crates/apr-cli/tests/falsification_crux_f_06.rs (11 tests)
+# Full discharge blocks on a live `apr profile --kv-timeline` emitter writing
+# the F-06 timeline JSON — tracked as BLOCKER-UPSTREAM-MISSING.
 
 metadata:
   id: CRUX-F-06
-  version: "1.0.0-draft"
+  version: "1.1.0"
   created: "2026-04-18"
+  updated: "2026-05-16"
   author: PAIML Engineering
   registry: true
-  status: draft
+  status: partial
+  kind: kernel
   parent_contracts:
   - crux-competitive-research-ux-v1
   category: "F — Tensor Ops & Low-level"
@@ -75,6 +81,26 @@ falsification_tests:
     jq '.timeline | map(has("used_blocks") and has("free_blocks") and has("used_pct")) | all' /tmp/kv.json \
       | grep -q true
   if_fails: "timeline entries missing block accounting fields"
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/kv_timeline_classifier.rs
+    cli_path: crates/apr-cli/src/commands/kv_timeline_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_f_06.rs
+    e2e_tests:
+    - falsify_crux_f_06_001_schema_ok_on_good_body
+    - falsify_crux_f_06_001_schema_reports_missing_top_key
+    sub_claim: |
+      Algorithm-level necessary conditions on an already-captured KV-timeline
+      JSON: `classify_schema` verifies the root is an object with all 5
+      required top-level keys (`timeline`, `block_size_tokens`,
+      `total_blocks`, `peak_used_pct`, `preemption_count`), `block_size_tokens`
+      and `total_blocks` are strictly positive, and every entry in `timeline`
+      is an object with all 7 required step-level keys (`step`, `t_ms`,
+      `used_blocks`, `free_blocks`, `used_pct`, `active_seqs`,
+      `preempted_seqs`). Outcome variants name the first missing key so
+      bugs surface deterministically.
+    scope: "(body) -> KvSchemaOutcome (pure)"
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: "live `apr profile --kv-timeline` emitting the F-06 timeline JSON"
 
 - id: FALSIFY-CRUX-F-06-002
   rule: block conservation
@@ -89,6 +115,23 @@ falsification_tests:
         assert s['used_blocks'] + s['free_blocks'] == T, f'{s}'
     "
   if_fails: "block conservation broken — used + free != total"
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/kv_timeline_classifier.rs
+    cli_path: crates/apr-cli/src/commands/kv_timeline_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_f_06.rs
+    e2e_tests:
+    - falsify_crux_f_06_002_block_conservation_rejects_violation
+    - falsify_crux_f_06_002_used_pct_arithmetic_rejects_mismatch
+    sub_claim: |
+      Algorithm-level necessary conditions: `classify_block_conservation`
+      verifies `used_blocks + free_blocks == total_blocks` for every step;
+      `classify_used_pct_arithmetic` verifies `used_pct == used_blocks /
+      total_blocks` within 1e-9 for every step. Both classifiers report
+      the violating step index and concrete values so allocator bugs can
+      be triaged directly from the lint output.
+    scope: "(body) -> (KvBlockConservationOutcome, KvUsedPctOutcome) (pure)"
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: "live `apr profile --kv-timeline` emitting consistent block accounting"
 
 - id: FALSIFY-CRUX-F-06-003
   rule: preemption occurs only near saturation
@@ -104,6 +147,24 @@ falsification_tests:
             assert s['used_pct'] >= 0.95, f'preempt without saturation: {s}'
     "
   if_fails: "preemption triggered below 95% cache utilization"
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/kv_timeline_classifier.rs
+    cli_path: crates/apr-cli/src/commands/kv_timeline_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_f_06.rs
+    e2e_tests:
+    - falsify_crux_f_06_003_preemption_trigger_rejects_below_threshold
+    - falsify_crux_f_06_003_preemption_trigger_respects_custom_threshold
+    sub_claim: |
+      Algorithm-level necessary conditions: `classify_preemption_trigger`
+      walks the timeline once and rejects with
+      `PreemptionBelowThreshold { index, used_pct, threshold,
+      preempted_seqs }` for any step where `preempted_seqs > 0` and
+      `used_pct < threshold` (default 0.95 from vLLM). Threshold is
+      configurable via `--preempt-threshold` so the same classifier
+      catches both canonical and tuned scheduler configurations.
+    scope: "(body, threshold) -> KvPreemptionOutcome (pure)"
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: "live scheduler emitting preemption events through the timeline"
 
 - id: FALSIFY-CRUX-F-06-004
   rule: peak_used_pct == max(timeline.used_pct)
@@ -117,6 +178,22 @@ falsification_tests:
     assert abs(d['peak_used_pct'] - peak) < 1e-9
     "
   if_fails: "peak_used_pct does not equal timeline max"
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/kv_timeline_classifier.rs
+    cli_path: crates/apr-cli/src/commands/kv_timeline_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_f_06.rs
+    e2e_tests:
+    - falsify_crux_f_06_004_peak_consistency_rejects_peak_mismatch
+    - falsify_crux_f_06_004_peak_consistency_rejects_preempt_count_mismatch
+    sub_claim: |
+      Algorithm-level necessary conditions: `classify_peak_consistency`
+      verifies (a) `peak_used_pct == max(timeline.used_pct)` within 1e-9
+      and (b) `preemption_count == sum(timeline.preempted_seqs)`. Both
+      mismatches name the expected and actual values so emitter bugs are
+      diagnosable from the lint output alone.
+    scope: "(body) -> KvPeakOutcome (pure)"
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: "live `apr profile --kv-timeline` emitting consistent aggregates"
 
 proof_obligations:
 - type: invariant

--- a/crates/apr-cli/src/commands/kv_timeline_classifier.rs
+++ b/crates/apr-cli/src/commands/kv_timeline_classifier.rs
@@ -1,0 +1,447 @@
+//! KV-cache utilization timeline classifier (CRUX-F-06).
+//!
+//! Pure, deterministic classifiers that discharge FALSIFY-CRUX-F-06-{001..004}
+//! at the PARTIAL_ALGORITHM_LEVEL — algorithm-level necessary conditions on
+//! an already-captured KV-timeline JSON emitted by
+//! `apr profile --kv-timeline --json`:
+//!
+//!   * `classify_schema` — top-level keys (`timeline`, `block_size_tokens`,
+//!     `total_blocks`, `peak_used_pct`, `preemption_count`) present and of
+//!     correct types; each step entry has all 7 required fields.
+//!   * `classify_block_conservation` — for every step
+//!     `used_blocks + free_blocks == total_blocks`.
+//!   * `classify_used_pct_arithmetic` — for every step
+//!     `used_pct == used_blocks / total_blocks` within 1e-9.
+//!   * `classify_peak_consistency` — `peak_used_pct == max(timeline[*].used_pct)`
+//!     within 1e-9 and `preemption_count == sum(timeline[*].preempted_seqs)`.
+//!   * `classify_preemption_trigger` — every step with `preempted_seqs > 0`
+//!     has `used_pct >= threshold` (vllm default 0.95).
+//!
+//! Full discharge blocks on a live `apr profile --kv-timeline` emitter —
+//! tracked as BLOCKER-UPSTREAM-MISSING.
+
+use serde_json::Value;
+
+/// Default vLLM preemption threshold; preemptions fired below this used_pct
+/// indicate a scheduler bug.
+pub const F06_DEFAULT_PREEMPT_THRESHOLD: f64 = 0.95;
+
+/// The 5 required top-level keys on a CRUX-F-06 KV-timeline JSON
+/// (see `contracts/crux-F-06-v1.yaml` equation `kv_timeline_schema`).
+pub const KV_TIMELINE_TOP_KEYS: &[&str] = &[
+    "timeline",
+    "block_size_tokens",
+    "total_blocks",
+    "peak_used_pct",
+    "preemption_count",
+];
+
+/// The 7 required per-step keys on each `timeline[i]` entry.
+pub const KV_TIMELINE_STEP_KEYS: &[&str] = &[
+    "step",
+    "t_ms",
+    "used_blocks",
+    "free_blocks",
+    "used_pct",
+    "active_seqs",
+    "preempted_seqs",
+];
+
+/// Outcome of `classify_schema`.
+#[derive(Debug, Clone, PartialEq)]
+pub enum KvSchemaOutcome {
+    Ok,
+    NotAnObject,
+    MissingTopKey { key: &'static str },
+    TimelineNotArray,
+    StepNotAnObject { index: usize },
+    StepMissingKey { index: usize, key: &'static str },
+    BlockSizeNotPositive { got: i64 },
+    TotalBlocksNotPositive { got: i64 },
+}
+
+/// Outcome of `classify_block_conservation`.
+#[derive(Debug, Clone, PartialEq)]
+pub enum KvBlockConservationOutcome {
+    Ok,
+    Violation {
+        index: usize,
+        used_blocks: u64,
+        free_blocks: u64,
+        total_blocks: u64,
+    },
+}
+
+/// Outcome of `classify_used_pct_arithmetic`.
+#[derive(Debug, Clone, PartialEq)]
+pub enum KvUsedPctOutcome {
+    Ok,
+    Mismatch {
+        index: usize,
+        expected: f64,
+        got: f64,
+    },
+}
+
+/// Outcome of `classify_peak_consistency`.
+#[derive(Debug, Clone, PartialEq)]
+pub enum KvPeakOutcome {
+    Ok,
+    PeakMismatch { expected: f64, got: f64 },
+    PreemptionCountMismatch { expected: u64, got: u64 },
+}
+
+/// Outcome of `classify_preemption_trigger`.
+#[derive(Debug, Clone, PartialEq)]
+pub enum KvPreemptionOutcome {
+    Ok,
+    PreemptionBelowThreshold {
+        index: usize,
+        used_pct: f64,
+        threshold: f64,
+        preempted_seqs: u64,
+    },
+}
+
+/// Validate that the JSON body matches the F-06 timeline schema.
+pub fn classify_schema(body: &Value) -> KvSchemaOutcome {
+    let Some(obj) = body.as_object() else {
+        return KvSchemaOutcome::NotAnObject;
+    };
+    for k in KV_TIMELINE_TOP_KEYS {
+        if !obj.contains_key(*k) {
+            return KvSchemaOutcome::MissingTopKey { key: k };
+        }
+    }
+    let Some(timeline) = obj.get("timeline").and_then(Value::as_array) else {
+        return KvSchemaOutcome::TimelineNotArray;
+    };
+    let block_size = obj
+        .get("block_size_tokens")
+        .and_then(Value::as_i64)
+        .unwrap_or(0);
+    if block_size <= 0 {
+        return KvSchemaOutcome::BlockSizeNotPositive { got: block_size };
+    }
+    let total = obj.get("total_blocks").and_then(Value::as_i64).unwrap_or(0);
+    if total <= 0 {
+        return KvSchemaOutcome::TotalBlocksNotPositive { got: total };
+    }
+    for (i, step) in timeline.iter().enumerate() {
+        let Some(step_obj) = step.as_object() else {
+            return KvSchemaOutcome::StepNotAnObject { index: i };
+        };
+        for k in KV_TIMELINE_STEP_KEYS {
+            if !step_obj.contains_key(*k) {
+                return KvSchemaOutcome::StepMissingKey { index: i, key: k };
+            }
+        }
+    }
+    KvSchemaOutcome::Ok
+}
+
+/// Verify `used_blocks + free_blocks == total_blocks` for every step.
+pub fn classify_block_conservation(body: &Value) -> KvBlockConservationOutcome {
+    let total = body
+        .get("total_blocks")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let Some(timeline) = body.get("timeline").and_then(Value::as_array) else {
+        return KvBlockConservationOutcome::Ok;
+    };
+    for (i, step) in timeline.iter().enumerate() {
+        let used = step.get("used_blocks").and_then(Value::as_u64).unwrap_or(0);
+        let free = step.get("free_blocks").and_then(Value::as_u64).unwrap_or(0);
+        if used.saturating_add(free) != total {
+            return KvBlockConservationOutcome::Violation {
+                index: i,
+                used_blocks: used,
+                free_blocks: free,
+                total_blocks: total,
+            };
+        }
+    }
+    KvBlockConservationOutcome::Ok
+}
+
+/// Verify `used_pct == used_blocks / total_blocks` for every step (within 1e-9).
+pub fn classify_used_pct_arithmetic(body: &Value) -> KvUsedPctOutcome {
+    let total = body
+        .get("total_blocks")
+        .and_then(Value::as_u64)
+        .unwrap_or(0) as f64;
+    let Some(timeline) = body.get("timeline").and_then(Value::as_array) else {
+        return KvUsedPctOutcome::Ok;
+    };
+    for (i, step) in timeline.iter().enumerate() {
+        let used = step.get("used_blocks").and_then(Value::as_u64).unwrap_or(0) as f64;
+        let got = step.get("used_pct").and_then(Value::as_f64).unwrap_or(0.0);
+        let expected = if total > 0.0 { used / total } else { 0.0 };
+        if (got - expected).abs() > 1e-9 {
+            return KvUsedPctOutcome::Mismatch {
+                index: i,
+                expected,
+                got,
+            };
+        }
+    }
+    KvUsedPctOutcome::Ok
+}
+
+/// Verify `peak_used_pct == max(timeline.used_pct)` and
+/// `preemption_count == sum(timeline.preempted_seqs)`.
+pub fn classify_peak_consistency(body: &Value) -> KvPeakOutcome {
+    let peak_got = body
+        .get("peak_used_pct")
+        .and_then(Value::as_f64)
+        .unwrap_or(0.0);
+    let pc_got = body
+        .get("preemption_count")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let timeline = body.get("timeline").and_then(Value::as_array);
+
+    let (peak_expected, pc_expected) = match timeline {
+        Some(t) => {
+            let mut peak = f64::NEG_INFINITY;
+            let mut total_preempt: u64 = 0;
+            for step in t {
+                let up = step.get("used_pct").and_then(Value::as_f64).unwrap_or(0.0);
+                if up > peak {
+                    peak = up;
+                }
+                total_preempt = total_preempt.saturating_add(
+                    step.get("preempted_seqs")
+                        .and_then(Value::as_u64)
+                        .unwrap_or(0),
+                );
+            }
+            if peak == f64::NEG_INFINITY {
+                peak = 0.0;
+            }
+            (peak, total_preempt)
+        }
+        None => (0.0, 0),
+    };
+
+    if (peak_got - peak_expected).abs() > 1e-9 {
+        return KvPeakOutcome::PeakMismatch {
+            expected: peak_expected,
+            got: peak_got,
+        };
+    }
+    if pc_got != pc_expected {
+        return KvPeakOutcome::PreemptionCountMismatch {
+            expected: pc_expected,
+            got: pc_got,
+        };
+    }
+    KvPeakOutcome::Ok
+}
+
+/// Verify `preempted_seqs > 0 IMPLIES used_pct >= threshold` for every step.
+pub fn classify_preemption_trigger(body: &Value, threshold: f64) -> KvPreemptionOutcome {
+    let Some(timeline) = body.get("timeline").and_then(Value::as_array) else {
+        return KvPreemptionOutcome::Ok;
+    };
+    for (i, step) in timeline.iter().enumerate() {
+        let preempted = step
+            .get("preempted_seqs")
+            .and_then(Value::as_u64)
+            .unwrap_or(0);
+        if preempted == 0 {
+            continue;
+        }
+        let up = step.get("used_pct").and_then(Value::as_f64).unwrap_or(0.0);
+        if up < threshold {
+            return KvPreemptionOutcome::PreemptionBelowThreshold {
+                index: i,
+                used_pct: up,
+                threshold,
+                preempted_seqs: preempted,
+            };
+        }
+    }
+    KvPreemptionOutcome::Ok
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn good_body() -> Value {
+        json!({
+            "timeline": [
+                {"step": 0, "t_ms": 0.0,  "used_blocks":  10, "free_blocks":  90, "used_pct": 0.10, "active_seqs": 1, "preempted_seqs": 0},
+                {"step": 1, "t_ms": 8.0,  "used_blocks":  50, "free_blocks":  50, "used_pct": 0.50, "active_seqs": 1, "preempted_seqs": 0},
+                {"step": 2, "t_ms": 16.0, "used_blocks":  96, "free_blocks":   4, "used_pct": 0.96, "active_seqs": 2, "preempted_seqs": 1},
+            ],
+            "block_size_tokens": 16,
+            "total_blocks": 100,
+            "peak_used_pct": 0.96,
+            "preemption_count": 1,
+        })
+    }
+
+    #[test]
+    fn schema_ok_on_well_formed_body() {
+        assert_eq!(classify_schema(&good_body()), KvSchemaOutcome::Ok);
+    }
+
+    #[test]
+    fn schema_rejects_not_an_object() {
+        assert_eq!(
+            classify_schema(&json!([1, 2])),
+            KvSchemaOutcome::NotAnObject
+        );
+    }
+
+    #[test]
+    fn schema_reports_missing_top_key() {
+        let body = json!({"timeline": [], "block_size_tokens": 16, "total_blocks": 100, "peak_used_pct": 0.0});
+        assert_eq!(
+            classify_schema(&body),
+            KvSchemaOutcome::MissingTopKey {
+                key: "preemption_count"
+            }
+        );
+    }
+
+    #[test]
+    fn schema_reports_missing_step_key() {
+        let body = json!({
+            "timeline": [{"step": 0, "t_ms": 0.0}],
+            "block_size_tokens": 16,
+            "total_blocks": 100,
+            "peak_used_pct": 0.0,
+            "preemption_count": 0,
+        });
+        match classify_schema(&body) {
+            KvSchemaOutcome::StepMissingKey { index, .. } => assert_eq!(index, 0),
+            other => panic!("expected StepMissingKey, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn schema_rejects_nonpositive_block_size() {
+        let body = json!({
+            "timeline": [],
+            "block_size_tokens": 0,
+            "total_blocks": 100,
+            "peak_used_pct": 0.0,
+            "preemption_count": 0,
+        });
+        assert!(matches!(
+            classify_schema(&body),
+            KvSchemaOutcome::BlockSizeNotPositive { got: 0 }
+        ));
+    }
+
+    #[test]
+    fn block_conservation_ok_on_good_body() {
+        assert_eq!(
+            classify_block_conservation(&good_body()),
+            KvBlockConservationOutcome::Ok
+        );
+    }
+
+    #[test]
+    fn block_conservation_reports_violation() {
+        let body = json!({
+            "timeline": [{"step": 0, "t_ms": 0.0, "used_blocks": 30, "free_blocks": 30, "used_pct": 0.30, "active_seqs": 1, "preempted_seqs": 0}],
+            "block_size_tokens": 16,
+            "total_blocks": 100,
+            "peak_used_pct": 0.30,
+            "preemption_count": 0,
+        });
+        match classify_block_conservation(&body) {
+            KvBlockConservationOutcome::Violation {
+                index,
+                used_blocks,
+                free_blocks,
+                total_blocks,
+            } => {
+                assert_eq!(index, 0);
+                assert_eq!(used_blocks, 30);
+                assert_eq!(free_blocks, 30);
+                assert_eq!(total_blocks, 100);
+            }
+            other => panic!("expected Violation, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn used_pct_arithmetic_ok_on_good_body() {
+        assert_eq!(
+            classify_used_pct_arithmetic(&good_body()),
+            KvUsedPctOutcome::Ok
+        );
+    }
+
+    #[test]
+    fn used_pct_arithmetic_reports_mismatch() {
+        let body = json!({
+            "timeline": [{"step": 0, "t_ms": 0.0, "used_blocks": 50, "free_blocks": 50, "used_pct": 0.10, "active_seqs": 1, "preempted_seqs": 0}],
+            "block_size_tokens": 16,
+            "total_blocks": 100,
+            "peak_used_pct": 0.10,
+            "preemption_count": 0,
+        });
+        assert!(matches!(
+            classify_used_pct_arithmetic(&body),
+            KvUsedPctOutcome::Mismatch { index: 0, .. }
+        ));
+    }
+
+    #[test]
+    fn peak_consistency_ok_on_good_body() {
+        assert_eq!(classify_peak_consistency(&good_body()), KvPeakOutcome::Ok);
+    }
+
+    #[test]
+    fn peak_consistency_reports_peak_mismatch() {
+        let mut body = good_body();
+        body["peak_used_pct"] = json!(0.50);
+        assert!(matches!(
+            classify_peak_consistency(&body),
+            KvPeakOutcome::PeakMismatch { .. }
+        ));
+    }
+
+    #[test]
+    fn peak_consistency_reports_preemption_count_mismatch() {
+        let mut body = good_body();
+        body["preemption_count"] = json!(99);
+        assert!(matches!(
+            classify_peak_consistency(&body),
+            KvPeakOutcome::PreemptionCountMismatch {
+                expected: 1,
+                got: 99
+            }
+        ));
+    }
+
+    #[test]
+    fn preemption_trigger_ok_on_good_body() {
+        assert_eq!(
+            classify_preemption_trigger(&good_body(), F06_DEFAULT_PREEMPT_THRESHOLD),
+            KvPreemptionOutcome::Ok
+        );
+    }
+
+    #[test]
+    fn preemption_trigger_reports_below_threshold() {
+        let body = json!({
+            "timeline": [{"step": 0, "t_ms": 0.0, "used_blocks": 50, "free_blocks": 50, "used_pct": 0.50, "active_seqs": 1, "preempted_seqs": 1}],
+            "block_size_tokens": 16,
+            "total_blocks": 100,
+            "peak_used_pct": 0.50,
+            "preemption_count": 1,
+        });
+        assert!(matches!(
+            classify_preemption_trigger(&body, F06_DEFAULT_PREEMPT_THRESHOLD),
+            KvPreemptionOutcome::PreemptionBelowThreshold { index: 0, .. }
+        ));
+    }
+}

--- a/crates/apr-cli/src/commands/kv_timeline_lint.rs
+++ b/crates/apr-cli/src/commands/kv_timeline_lint.rs
@@ -1,0 +1,120 @@
+//! `apr kv-timeline-lint` — CRUX-F-06 KV-cache utilization timeline gate.
+//!
+//! Reads an already-captured `apr profile --kv-timeline --json` body and
+//! dispatches the pure classifiers in `kv_timeline_classifier`. Exits
+//! non-zero on any failure.
+//!
+//! Spec: `contracts/crux-F-06-v1.yaml`. CRUX-SHIP-001 g2/g3 surface.
+
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+
+use super::kv_timeline_classifier::{
+    classify_block_conservation, classify_peak_consistency, classify_preemption_trigger,
+    classify_schema, classify_used_pct_arithmetic, KvBlockConservationOutcome, KvPeakOutcome,
+    KvPreemptionOutcome, KvSchemaOutcome, KvUsedPctOutcome, F06_DEFAULT_PREEMPT_THRESHOLD,
+};
+use crate::error::{CliError, Result};
+
+pub(crate) fn run(timeline_file: &Path, preempt_threshold: f64, json: bool) -> Result<()> {
+    if !timeline_file.exists() {
+        return Err(CliError::FileNotFound(PathBuf::from(timeline_file)));
+    }
+    let body_text = std::fs::read_to_string(timeline_file)?;
+    let body: Value = serde_json::from_str(&body_text).map_err(|e| {
+        CliError::InvalidFormat(format!(
+            "apr kv-timeline-lint: failed to parse JSON from {}: {e}",
+            timeline_file.display()
+        ))
+    })?;
+
+    let schema = classify_schema(&body);
+    // Downstream classifiers assume the schema gate passed; if it failed, we
+    // still surface the schema outcome but skip the dependent gates.
+    let (block, used_pct, peak, preempt) = if matches!(schema, KvSchemaOutcome::Ok) {
+        (
+            classify_block_conservation(&body),
+            classify_used_pct_arithmetic(&body),
+            classify_peak_consistency(&body),
+            classify_preemption_trigger(&body, preempt_threshold),
+        )
+    } else {
+        (
+            KvBlockConservationOutcome::Ok,
+            KvUsedPctOutcome::Ok,
+            KvPeakOutcome::Ok,
+            KvPreemptionOutcome::Ok,
+        )
+    };
+
+    print_report(
+        timeline_file,
+        &schema,
+        &block,
+        &used_pct,
+        &peak,
+        &preempt,
+        json,
+    );
+
+    if !matches!(schema, KvSchemaOutcome::Ok) {
+        return Err(CliError::ValidationFailed(format!(
+            "kv-timeline-lint schema gate rejected body: {schema:?}"
+        )));
+    }
+    if !matches!(block, KvBlockConservationOutcome::Ok) {
+        return Err(CliError::ValidationFailed(format!(
+            "kv-timeline-lint block-conservation gate rejected body: {block:?}"
+        )));
+    }
+    if !matches!(used_pct, KvUsedPctOutcome::Ok) {
+        return Err(CliError::ValidationFailed(format!(
+            "kv-timeline-lint used-pct gate rejected body: {used_pct:?}"
+        )));
+    }
+    if !matches!(peak, KvPeakOutcome::Ok) {
+        return Err(CliError::ValidationFailed(format!(
+            "kv-timeline-lint peak-consistency gate rejected body: {peak:?}"
+        )));
+    }
+    if !matches!(preempt, KvPreemptionOutcome::Ok) {
+        return Err(CliError::ValidationFailed(format!(
+            "kv-timeline-lint preemption-trigger gate rejected body: {preempt:?}"
+        )));
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn print_report(
+    path: &Path,
+    schema: &KvSchemaOutcome,
+    block: &KvBlockConservationOutcome,
+    used_pct: &KvUsedPctOutcome,
+    peak: &KvPeakOutcome,
+    preempt: &KvPreemptionOutcome,
+    json: bool,
+) {
+    if json {
+        let obj = serde_json::json!({
+            "file": path.display().to_string(),
+            "schema": format!("{schema:?}"),
+            "block_conservation": format!("{block:?}"),
+            "used_pct_arithmetic": format!("{used_pct:?}"),
+            "peak_consistency": format!("{peak:?}"),
+            "preemption_trigger": format!("{preempt:?}"),
+        });
+        println!("{}", serde_json::to_string_pretty(&obj).unwrap_or_default());
+        return;
+    }
+    println!("kv-timeline-lint report for {}", path.display());
+    println!("  schema             : {schema:?}");
+    println!("  block_conservation : {block:?}");
+    println!("  used_pct_arithmetic: {used_pct:?}");
+    println!("  peak_consistency   : {peak:?}");
+    println!("  preemption_trigger : {preempt:?}");
+}
+
+/// Expose the default for tests that want the canonical vLLM threshold.
+pub const KV_TIMELINE_DEFAULT_THRESHOLD: f64 = F06_DEFAULT_PREEMPT_THRESHOLD;

--- a/crates/apr-cli/src/commands/mod.rs
+++ b/crates/apr-cli/src/commands/mod.rs
@@ -58,6 +58,8 @@ pub(crate) mod imatrix_lint;
 pub(crate) mod import;
 pub(crate) mod inspect;
 pub(crate) mod kernel_explain;
+pub(crate) mod kv_timeline_classifier;
+pub(crate) mod kv_timeline_lint;
 pub(crate) mod lint;
 pub(crate) mod manifest;
 pub(crate) mod mcp;

--- a/crates/apr-cli/src/dispatch_analysis.rs
+++ b/crates/apr-cli/src/dispatch_analysis.rs
@@ -157,6 +157,11 @@ fn dispatch_analysis_commands(cli: &Cli) -> Option<Result<(), CliError>> {
             stderr_file,
         } => commands::oom_lint::run(report_file, stderr_file.as_deref(), cli.json),
 
+        ExtendedCommands::KvTimelineLint {
+            timeline_file,
+            preempt_threshold,
+        } => commands::kv_timeline_lint::run(timeline_file, *preempt_threshold, cli.json),
+
         ExtendedCommands::OtlpLint {
             otlp_file,
             require_apr_span,

--- a/crates/apr-cli/src/extended_commands.rs
+++ b/crates/apr-cli/src/extended_commands.rs
@@ -784,6 +784,15 @@ pub enum ExtendedCommands {
         #[arg(long, value_name = "FILE")]
         stderr_file: Option<PathBuf>,
     },
+    /// Lint a captured KV-cache utilization timeline (CRUX-F-06)
+    KvTimelineLint {
+        /// Path to captured `apr profile --kv-timeline --json` body
+        #[arg(long, value_name = "FILE")]
+        timeline_file: PathBuf,
+        /// Preemption threshold (default 0.95, vLLM canonical)
+        #[arg(long, value_name = "FRACTION", default_value_t = 0.95)]
+        preempt_threshold: f64,
+    },
     /// Lint a captured OTLP/JSON ExportTraceServiceRequest body (CRUX-K-08)
     OtlpLint {
         /// Path to captured OTLP/JSON export body

--- a/crates/apr-cli/tests/cli_commands.rs
+++ b/crates/apr-cli/tests/cli_commands.rs
@@ -114,6 +114,7 @@ fn registered_commands() -> Vec<&'static str> {
         "quant-preservation-lint",
         "prometheus-lint",
         "otlp-lint",
+        "kv-timeline-lint",
         "shard",
         "unshard",
         "oracle",

--- a/crates/apr-cli/tests/falsification_crux_f_06.rs
+++ b/crates/apr-cli/tests/falsification_crux_f_06.rs
@@ -1,0 +1,278 @@
+//! CRUX-F-06 — end-to-end falsification harness for `apr kv-timeline-lint`.
+//!
+//! CRUX-SHIP-001 gate g3 evidence: every FALSIFY-CRUX-F-06-{001..004}
+//! gate the classifier discharges has a matching captured KV-timeline JSON
+//! that the binary must classify exactly as the harness expects.
+
+use serde_json::json;
+use std::io::Write;
+use std::process::Command;
+
+fn apr_binary() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_apr"));
+    cmd.env("NO_COLOR", "1");
+    cmd
+}
+
+fn write_body(body: &serde_json::Value) -> tempfile::NamedTempFile {
+    let mut f = tempfile::Builder::new()
+        .prefix("crux-f-06-")
+        .suffix(".json")
+        .tempfile()
+        .expect("tempfile");
+    f.write_all(
+        serde_json::to_vec_pretty(body)
+            .expect("serialize")
+            .as_slice(),
+    )
+    .expect("write");
+    f.flush().expect("flush");
+    f
+}
+
+fn good_timeline() -> serde_json::Value {
+    json!({
+        "timeline": [
+            {"step": 0, "t_ms": 0.0,  "used_blocks":  10, "free_blocks":  90, "used_pct": 0.10, "active_seqs": 1, "preempted_seqs": 0},
+            {"step": 1, "t_ms": 8.0,  "used_blocks":  50, "free_blocks":  50, "used_pct": 0.50, "active_seqs": 1, "preempted_seqs": 0},
+            {"step": 2, "t_ms": 16.0, "used_blocks":  96, "free_blocks":   4, "used_pct": 0.96, "active_seqs": 2, "preempted_seqs": 1},
+        ],
+        "block_size_tokens": 16,
+        "total_blocks": 100,
+        "peak_used_pct": 0.96,
+        "preemption_count": 1,
+    })
+}
+
+// ===== g2: CLI shape =====
+
+#[test]
+fn falsify_crux_f_06_cli_help_advertises_flags() {
+    let out = apr_binary()
+        .args(["kv-timeline-lint", "--help"])
+        .output()
+        .expect("run");
+    assert!(out.status.success(), "--help must exit 0");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("--timeline-file"),
+        "--help must advertise --timeline-file; got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("--preempt-threshold"),
+        "--help must advertise --preempt-threshold; got:\n{stdout}"
+    );
+}
+
+#[test]
+fn falsify_crux_f_06_cli_missing_file_fails() {
+    let out = apr_binary()
+        .args([
+            "kv-timeline-lint",
+            "--timeline-file",
+            "/nonexistent/crux-f-06-missing.json",
+        ])
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "missing file must not exit 0");
+}
+
+// ===== g3: classifier discharges =====
+
+#[test]
+fn falsify_crux_f_06_001_schema_ok_on_good_body() {
+    let f = write_body(&good_timeline());
+    let out = apr_binary()
+        .args(["kv-timeline-lint", "--timeline-file"])
+        .arg(f.path())
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "good timeline must pass; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn falsify_crux_f_06_001_schema_reports_missing_top_key() {
+    let body =
+        json!({"timeline": [], "block_size_tokens": 16, "total_blocks": 100, "peak_used_pct": 0.0});
+    let f = write_body(&body);
+    let out = apr_binary()
+        .args(["kv-timeline-lint", "--timeline-file"])
+        .arg(f.path())
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "missing preemption_count must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("MissingTopKey"),
+        "stderr must name MissingTopKey; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn falsify_crux_f_06_002_block_conservation_rejects_violation() {
+    let body = json!({
+        "timeline": [{"step": 0, "t_ms": 0.0, "used_blocks": 30, "free_blocks": 30, "used_pct": 0.30, "active_seqs": 1, "preempted_seqs": 0}],
+        "block_size_tokens": 16,
+        "total_blocks": 100,
+        "peak_used_pct": 0.30,
+        "preemption_count": 0,
+    });
+    let f = write_body(&body);
+    let out = apr_binary()
+        .args(["kv-timeline-lint", "--timeline-file"])
+        .arg(f.path())
+        .output()
+        .expect("run");
+    assert!(
+        !out.status.success(),
+        "block conservation violation must fail"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("Violation"),
+        "stderr must name Violation; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn falsify_crux_f_06_002_used_pct_arithmetic_rejects_mismatch() {
+    let body = json!({
+        "timeline": [{"step": 0, "t_ms": 0.0, "used_blocks": 50, "free_blocks": 50, "used_pct": 0.10, "active_seqs": 1, "preempted_seqs": 0}],
+        "block_size_tokens": 16,
+        "total_blocks": 100,
+        "peak_used_pct": 0.10,
+        "preemption_count": 0,
+    });
+    let f = write_body(&body);
+    let out = apr_binary()
+        .args(["kv-timeline-lint", "--timeline-file"])
+        .arg(f.path())
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "used_pct mismatch must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("Mismatch"),
+        "stderr must name Mismatch; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn falsify_crux_f_06_004_peak_consistency_rejects_peak_mismatch() {
+    let mut body = good_timeline();
+    body["peak_used_pct"] = json!(0.50);
+    let f = write_body(&body);
+    let out = apr_binary()
+        .args(["kv-timeline-lint", "--timeline-file"])
+        .arg(f.path())
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "peak mismatch must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("PeakMismatch"),
+        "stderr must name PeakMismatch; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn falsify_crux_f_06_004_peak_consistency_rejects_preempt_count_mismatch() {
+    let mut body = good_timeline();
+    body["preemption_count"] = json!(99);
+    let f = write_body(&body);
+    let out = apr_binary()
+        .args(["kv-timeline-lint", "--timeline-file"])
+        .arg(f.path())
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "preempt count mismatch must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("PreemptionCountMismatch"),
+        "stderr must name PreemptionCountMismatch; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn falsify_crux_f_06_003_preemption_trigger_rejects_below_threshold() {
+    let body = json!({
+        "timeline": [{"step": 0, "t_ms": 0.0, "used_blocks": 50, "free_blocks": 50, "used_pct": 0.50, "active_seqs": 1, "preempted_seqs": 1}],
+        "block_size_tokens": 16,
+        "total_blocks": 100,
+        "peak_used_pct": 0.50,
+        "preemption_count": 1,
+    });
+    let f = write_body(&body);
+    let out = apr_binary()
+        .args(["kv-timeline-lint", "--timeline-file"])
+        .arg(f.path())
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "preempt below 0.95 must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("PreemptionBelowThreshold"),
+        "stderr must name PreemptionBelowThreshold; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn falsify_crux_f_06_003_preemption_trigger_respects_custom_threshold() {
+    // A trace that preempts at 0.80; default threshold (0.95) rejects, but
+    // --preempt-threshold 0.80 accepts.
+    let body = json!({
+        "timeline": [{"step": 0, "t_ms": 0.0, "used_blocks": 80, "free_blocks": 20, "used_pct": 0.80, "active_seqs": 1, "preempted_seqs": 1}],
+        "block_size_tokens": 16,
+        "total_blocks": 100,
+        "peak_used_pct": 0.80,
+        "preemption_count": 1,
+    });
+    let f = write_body(&body);
+    let out = apr_binary()
+        .args(["kv-timeline-lint", "--timeline-file"])
+        .arg(f.path())
+        .args(["--preempt-threshold", "0.80"])
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "preempt at exactly threshold must pass; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+// ===== JSON output shape =====
+
+#[test]
+fn falsify_crux_f_06_json_output_contains_outcomes() {
+    let f = write_body(&good_timeline());
+    let out = apr_binary()
+        .args(["--json", "kv-timeline-lint", "--timeline-file"])
+        .arg(f.path())
+        .output()
+        .expect("run");
+    assert!(out.status.success(), "json + good body must exit 0");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("json output must parse");
+    assert!(parsed["schema"].as_str().expect("schema").contains("Ok"));
+    assert!(parsed["block_conservation"]
+        .as_str()
+        .expect("block")
+        .contains("Ok"));
+    assert!(parsed["used_pct_arithmetic"]
+        .as_str()
+        .expect("used_pct")
+        .contains("Ok"));
+    assert!(parsed["peak_consistency"]
+        .as_str()
+        .expect("peak")
+        .contains("Ok"));
+    assert!(parsed["preemption_trigger"]
+        .as_str()
+        .expect("preempt")
+        .contains("Ok"));
+}


### PR DESCRIPTION
## Summary

- Promotes \`contracts/crux-F-06-v1.yaml\` from \`draft\` → PARTIAL_ALGORITHM_LEVEL.
- Adds \`apr kv-timeline-lint --timeline-file FILE [--preempt-threshold F]\` — pure-function classifier over captured \`apr profile --kv-timeline --json\` bodies validating: schema (5 top-level + 7 per-step keys), block conservation, used_pct arithmetic, peak/preempt-count consistency, and preemption-threshold trigger.
- 14 classifier unit tests + 11 e2e falsification tests + 8 cli_commands surface tests all pass.

Discharges FALSIFY-CRUX-F-06-{001..004} at PARTIAL_ALGORITHM_LEVEL. Full discharge blocks on a live \`apr profile --kv-timeline\` emitter.

## Test plan

- [x] \`cargo test -p apr-cli --lib kv_timeline_classifier\` — 14/14 pass.
- [x] \`cargo test -p apr-cli --test falsification_crux_f_06\` — 11/11 pass.
- [x] \`cargo test -p apr-cli --test cli_commands\` — 8/8 pass (3-surface drift policy).
- [x] \`pv validate contracts/crux-F-06-v1.yaml\` — clean.
- [ ] CI green on \`ci / gate\` + \`workspace-test\`.

Refs #921 (CRUX M4 observability epic), #917 (CRUX Phase 3 umbrella).

🤖 Generated with [Claude Code](https://claude.com/claude-code)