### PR TITLE
feat(apr-cli): CRUX-F-07 `apr gpu-memtrace-lint` Chrome Trace memory classifier

### DIFF
--- a/contracts/apr-cli-commands-v1.yaml
+++ b/contracts/apr-cli-commands-v1.yaml
@@ -556,6 +556,12 @@ commands:
     requires_model: false
     side_effects: []
 
+  - name: gpu-memtrace-lint
+    category: inspection
+    description: "Validate captured GPU memory Chrome Trace JSON (CRUX-F-07): schema + alloc/free pairing by addr + per-(pid,tid) monotonic timestamps"
+    requires_model: false
+    side_effects: []
+
   - name: shard
     category: model_ops
     description: "Split safetensors file into shards + weight-map index (CRUX-B-05)"

--- a/contracts/crux-F-07-v1.yaml
+++ b/contracts/crux-F-07-v1.yaml
@@ -1,16 +1,21 @@
 # CRUX-F-07 — GPU memory timeline Chrome trace
-# Auto-scaffolded from crux-competitive-research-ux-v1.yaml (DRAFT).
-# DO NOT promote to ACTIVE until: (1) evidence collected, (2) falsification
-# body reflects competitor's canonical CLI, (3) apr surface mapped or gap
-# tracked in pmat work (see master §12).
+# Promoted to PARTIAL_ALGORITHM_LEVEL at v1.1.0 under CRUX-SHIP-001 (2026-05-16):
+# - classifier: crates/apr-cli/src/commands/gpu_memtrace_classifier.rs (13 unit tests)
+# - CLI surface: `apr gpu-memtrace-lint --trace-file FILE`
+# - e2e: crates/apr-cli/tests/falsification_crux_f_07.rs (11 tests)
+# Full discharge of FALSIFY-CRUX-F-07-004 (peak agrees with NVML within
+# 10%) requires a live emitter wired into `apr profile --gpu-memory-trace`
+# alongside an NVML reading at peak — tracked as BLOCKER-UPSTREAM-MISSING.
 
 metadata:
   id: CRUX-F-07
-  version: "1.0.0-draft"
+  version: "1.1.0"
   created: "2026-04-18"
+  updated: "2026-05-16"
   author: PAIML Engineering
   registry: true
-  status: draft
+  status: partial
+  kind: kernel
   parent_contracts:
   - crux-competitive-research-ux-v1
   category: "F — Tensor Ops & Low-level"
@@ -88,6 +93,24 @@ falsification_tests:
       || { echo "FAIL: required Chrome Trace fields missing" >&2; exit 1; }
 
   if_fails: rule 'Chrome Trace JSON schema is valid and loadable' is violated — contract MUST be re-verified against competitor canonical reference
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/gpu_memtrace_classifier.rs
+    cli_path: crates/apr-cli/src/commands/gpu_memtrace_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_f_07.rs
+    e2e_tests:
+    - falsify_crux_f_07_001_schema_ok_on_good_body
+    - falsify_crux_f_07_001_schema_rejects_missing_trace_events
+    - falsify_crux_f_07_001_schema_rejects_event_missing_ph
+    sub_claim: |
+      Algorithm-level necessary conditions: `classify_schema` verifies the
+      Chrome Trace JSON root is an object containing a non-empty
+      `traceEvents` array; every entry has the required Chrome Trace
+      fields (`ph`, `ts`, `name`); `displayTimeUnit` (if present) is one
+      of {ns, ms}. Outcome variants name the first violation deterministically
+      (MissingTraceEvents, TraceEventsEmpty, EventMissingField, etc.).
+    scope: "(body) -> ChromeTraceSchemaOutcome (pure)"
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: "live `apr profile --gpu-memory-trace` emitter"
 - id: FALSIFY-CRUX-F-07-002
   rule: alloc/free events pair by address
   prediction: "every alloc event has a matching free with identical addr"
@@ -103,6 +126,24 @@ falsification_tests:
     PY
 
   if_fails: rule 'alloc/free events pair by address' is violated — contract MUST be re-verified against competitor canonical reference
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/gpu_memtrace_classifier.rs
+    cli_path: crates/apr-cli/src/commands/gpu_memtrace_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_f_07.rs
+    e2e_tests:
+    - falsify_crux_f_07_002_alloc_free_pairing_rejects_orphan_alloc
+    - falsify_crux_f_07_002_alloc_free_pairing_rejects_orphan_free
+    sub_claim: |
+      Algorithm-level necessary conditions: `classify_alloc_free_pairing`
+      collects every `args.addr` from `alloc` and `free` events; reports
+      `OrphanAllocs { addresses }` (memory leak signature) or
+      `OrphanFrees { addresses }` (double-free / accounting bug signature)
+      with sorted address lists so the bug is debuggable from lint output
+      alone. `AllocMissingAddr { index }` surfaces malformed emitters
+      where the args object lacks the addr key.
+    scope: "(body) -> AllocFreePairingOutcome (pure)"
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: "live `apr profile --gpu-memory-trace` emitter writing balanced alloc/free events"
 - id: FALSIFY-CRUX-F-07-003
   rule: timestamps monotone per stream
   prediction: "per-(pid,tid) timestamps are non-decreasing"
@@ -120,6 +161,23 @@ falsification_tests:
     PY
 
   if_fails: rule 'timestamps monotone per stream' is violated — contract MUST be re-verified against competitor canonical reference
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/gpu_memtrace_classifier.rs
+    cli_path: crates/apr-cli/src/commands/gpu_memtrace_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_f_07.rs
+    e2e_tests:
+    - falsify_crux_f_07_003_monotonic_timestamps_rejects_violation
+    - falsify_crux_f_07_003_monotonic_timestamps_allows_cross_stream_interleave
+    sub_claim: |
+      Algorithm-level necessary conditions: `classify_monotonic_timestamps`
+      walks the trace once tracking the last seen `ts` per `(pid, tid)`
+      key; reports `NonMonotonic { index, pid, tid, prev_ts, got_ts }`
+      on first violation. Different streams may freely interleave (CUDA
+      stream ordering is per-stream); only within a single (pid, tid)
+      must timestamps be non-decreasing.
+    scope: "(body) -> MonotonicTimestampsOutcome (pure)"
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: "live `apr profile --gpu-memory-trace` emitter preserving CUDA stream ordering"
 - id: FALSIFY-CRUX-F-07-004
   rule: trace-derived peak agrees with NVML within 10%
   prediction: "|peak_trace − peak_nvml| / peak_nvml < 0.10"

--- a/crates/apr-cli/src/commands/gpu_memtrace_classifier.rs
+++ b/crates/apr-cli/src/commands/gpu_memtrace_classifier.rs
@@ -1,0 +1,329 @@
+//! Chrome Trace Event Format GPU memory-trace classifier (CRUX-F-07).
+//!
+//! Pure, deterministic classifiers that discharge FALSIFY-CRUX-F-07-{001,002,003}
+//! at the PARTIAL_ALGORITHM_LEVEL — algorithm-level necessary conditions on
+//! an already-captured `apr profile --gpu-memory-trace` output:
+//!
+//!   * `classify_schema` — body parses as a JSON object with a non-empty
+//!     `traceEvents` array; every event has the Chrome Trace required
+//!     fields `ph`, `ts`, `name` (plus optional `pid`/`tid`/`args`).
+//!     `displayTimeUnit` (if present) must be `"ns"` or `"ms"`.
+//!   * `classify_alloc_free_pairing` — every `alloc` event has a matching
+//!     `free` event with the same `args.addr`; orphan allocations or
+//!     duplicate frees are reported with the offending addresses.
+//!   * `classify_monotonic_timestamps` — for each (pid, tid) stream,
+//!     timestamps are non-decreasing — CUDA stream ordering must be
+//!     preserved in the trace.
+//!
+//! FALSIFY-CRUX-F-07-004 (peak agrees with NVML within 10%) requires a live
+//! NVML reading at the peak instant — discharged only when the emitter is
+//! wired into `apr profile`. Tracked as BLOCKER-UPSTREAM-MISSING.
+
+use serde_json::Value;
+
+/// Outcome of `classify_schema`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ChromeTraceSchemaOutcome {
+    Ok { event_count: usize },
+    NotAnObject,
+    MissingTraceEvents,
+    TraceEventsNotArray,
+    TraceEventsEmpty,
+    EventNotAnObject { index: usize },
+    EventMissingField { index: usize, field: &'static str },
+    InvalidDisplayTimeUnit { got: String },
+}
+
+/// Outcome of `classify_alloc_free_pairing`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AllocFreePairingOutcome {
+    Ok,
+    OrphanAllocs { addresses: Vec<String> },
+    OrphanFrees { addresses: Vec<String> },
+    AllocMissingAddr { index: usize },
+}
+
+/// Outcome of `classify_monotonic_timestamps`.
+#[derive(Debug, Clone, PartialEq)]
+pub enum MonotonicTimestampsOutcome {
+    Ok,
+    NonMonotonic {
+        index: usize,
+        pid: i64,
+        tid: i64,
+        prev_ts: f64,
+        got_ts: f64,
+    },
+}
+
+/// Validate the Chrome Trace JSON schema:
+/// - root is an object with a non-empty `traceEvents` array
+/// - every event has `ph`, `ts`, `name`
+/// - `displayTimeUnit` (if present) is `"ns"` or `"ms"`
+pub fn classify_schema(body: &Value) -> ChromeTraceSchemaOutcome {
+    let Some(obj) = body.as_object() else {
+        return ChromeTraceSchemaOutcome::NotAnObject;
+    };
+    if let Some(unit) = obj.get("displayTimeUnit").and_then(Value::as_str) {
+        if unit != "ns" && unit != "ms" {
+            return ChromeTraceSchemaOutcome::InvalidDisplayTimeUnit {
+                got: unit.to_string(),
+            };
+        }
+    }
+    let Some(events_val) = obj.get("traceEvents") else {
+        return ChromeTraceSchemaOutcome::MissingTraceEvents;
+    };
+    let Some(events) = events_val.as_array() else {
+        return ChromeTraceSchemaOutcome::TraceEventsNotArray;
+    };
+    if events.is_empty() {
+        return ChromeTraceSchemaOutcome::TraceEventsEmpty;
+    }
+    for (i, e) in events.iter().enumerate() {
+        if !e.is_object() {
+            return ChromeTraceSchemaOutcome::EventNotAnObject { index: i };
+        }
+        for field in ["ph", "ts", "name"] {
+            if e.get(field).is_none() {
+                return ChromeTraceSchemaOutcome::EventMissingField { index: i, field };
+            }
+        }
+    }
+    ChromeTraceSchemaOutcome::Ok { event_count: events.len() }
+}
+
+/// Verify that every `alloc` event has a matching `free` event with the
+/// same `args.addr`, and vice-versa.
+pub fn classify_alloc_free_pairing(body: &Value) -> AllocFreePairingOutcome {
+    let mut allocs: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut frees: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let Some(events) = body.get("traceEvents").and_then(Value::as_array) else {
+        return AllocFreePairingOutcome::Ok;
+    };
+    for (i, e) in events.iter().enumerate() {
+        let name = e.get("name").and_then(Value::as_str).unwrap_or("");
+        if name != "alloc" && name != "free" {
+            continue;
+        }
+        let addr = e.get("args").and_then(|a| a.get("addr")).and_then(Value::as_str);
+        let Some(addr) = addr else {
+            if name == "alloc" {
+                return AllocFreePairingOutcome::AllocMissingAddr { index: i };
+            }
+            continue;
+        };
+        if name == "alloc" {
+            allocs.insert(addr.to_string());
+        } else {
+            frees.insert(addr.to_string());
+        }
+    }
+    let mut orphan_a: Vec<String> = allocs.difference(&frees).cloned().collect();
+    let mut orphan_f: Vec<String> = frees.difference(&allocs).cloned().collect();
+    if !orphan_a.is_empty() {
+        orphan_a.sort();
+        return AllocFreePairingOutcome::OrphanAllocs { addresses: orphan_a };
+    }
+    if !orphan_f.is_empty() {
+        orphan_f.sort();
+        return AllocFreePairingOutcome::OrphanFrees { addresses: orphan_f };
+    }
+    AllocFreePairingOutcome::Ok
+}
+
+/// Verify that timestamps are non-decreasing per (pid, tid).
+pub fn classify_monotonic_timestamps(body: &Value) -> MonotonicTimestampsOutcome {
+    use std::collections::HashMap;
+    let mut last: HashMap<(i64, i64), f64> = HashMap::new();
+    let Some(events) = body.get("traceEvents").and_then(Value::as_array) else {
+        return MonotonicTimestampsOutcome::Ok;
+    };
+    for (i, e) in events.iter().enumerate() {
+        let pid = e.get("pid").and_then(Value::as_i64).unwrap_or(0);
+        let tid = e.get("tid").and_then(Value::as_i64).unwrap_or(0);
+        let ts = e.get("ts").and_then(Value::as_f64).unwrap_or(0.0);
+        let key = (pid, tid);
+        if let Some(&prev) = last.get(&key) {
+            if ts < prev {
+                return MonotonicTimestampsOutcome::NonMonotonic {
+                    index: i,
+                    pid,
+                    tid,
+                    prev_ts: prev,
+                    got_ts: ts,
+                };
+            }
+        }
+        last.insert(key, ts);
+    }
+    MonotonicTimestampsOutcome::Ok
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn good_body() -> Value {
+        json!({
+            "displayTimeUnit": "ns",
+            "traceEvents": [
+                {"ph": "i", "ts": 0,    "name": "alloc", "pid": 0, "tid": 1, "args": {"bytes": 1024, "addr": "0xAAAA"}},
+                {"ph": "i", "ts": 100,  "name": "alloc", "pid": 0, "tid": 1, "args": {"bytes": 2048, "addr": "0xBBBB"}},
+                {"ph": "i", "ts": 200,  "name": "free",  "pid": 0, "tid": 1, "args": {"bytes": 1024, "addr": "0xAAAA"}},
+                {"ph": "i", "ts": 300,  "name": "free",  "pid": 0, "tid": 1, "args": {"bytes": 2048, "addr": "0xBBBB"}},
+            ]
+        })
+    }
+
+    #[test]
+    fn schema_ok_on_well_formed_body() {
+        assert_eq!(
+            classify_schema(&good_body()),
+            ChromeTraceSchemaOutcome::Ok { event_count: 4 }
+        );
+    }
+
+    #[test]
+    fn schema_rejects_not_an_object() {
+        assert_eq!(
+            classify_schema(&json!([1, 2])),
+            ChromeTraceSchemaOutcome::NotAnObject
+        );
+    }
+
+    #[test]
+    fn schema_rejects_missing_trace_events() {
+        assert_eq!(
+            classify_schema(&json!({"otherKey": []})),
+            ChromeTraceSchemaOutcome::MissingTraceEvents
+        );
+    }
+
+    #[test]
+    fn schema_rejects_empty_trace_events() {
+        assert_eq!(
+            classify_schema(&json!({"traceEvents": []})),
+            ChromeTraceSchemaOutcome::TraceEventsEmpty
+        );
+    }
+
+    #[test]
+    fn schema_rejects_event_missing_ph() {
+        let body = json!({"traceEvents": [{"ts": 0, "name": "alloc"}]});
+        match classify_schema(&body) {
+            ChromeTraceSchemaOutcome::EventMissingField { index: 0, field: "ph" } => {}
+            other => panic!("expected EventMissingField(ph), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn schema_rejects_invalid_display_time_unit() {
+        let body = json!({
+            "displayTimeUnit": "sec",
+            "traceEvents": [{"ph": "i", "ts": 0, "name": "alloc"}]
+        });
+        assert!(matches!(
+            classify_schema(&body),
+            ChromeTraceSchemaOutcome::InvalidDisplayTimeUnit { .. }
+        ));
+    }
+
+    #[test]
+    fn alloc_free_pairing_ok_on_balanced_body() {
+        assert_eq!(
+            classify_alloc_free_pairing(&good_body()),
+            AllocFreePairingOutcome::Ok
+        );
+    }
+
+    #[test]
+    fn alloc_free_pairing_reports_orphan_alloc() {
+        let body = json!({
+            "traceEvents": [
+                {"ph": "i", "ts": 0, "name": "alloc", "args": {"addr": "0xLEAK"}},
+                {"ph": "i", "ts": 1, "name": "alloc", "args": {"addr": "0xOK"}},
+                {"ph": "i", "ts": 2, "name": "free",  "args": {"addr": "0xOK"}},
+            ]
+        });
+        match classify_alloc_free_pairing(&body) {
+            AllocFreePairingOutcome::OrphanAllocs { addresses } => {
+                assert_eq!(addresses, vec!["0xLEAK".to_string()]);
+            }
+            other => panic!("expected OrphanAllocs, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn alloc_free_pairing_reports_orphan_free() {
+        let body = json!({
+            "traceEvents": [
+                {"ph": "i", "ts": 0, "name": "alloc", "args": {"addr": "0xAAA"}},
+                {"ph": "i", "ts": 1, "name": "free",  "args": {"addr": "0xAAA"}},
+                {"ph": "i", "ts": 2, "name": "free",  "args": {"addr": "0xPHANTOM"}},
+            ]
+        });
+        match classify_alloc_free_pairing(&body) {
+            AllocFreePairingOutcome::OrphanFrees { addresses } => {
+                assert_eq!(addresses, vec!["0xPHANTOM".to_string()]);
+            }
+            other => panic!("expected OrphanFrees, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn alloc_free_pairing_reports_alloc_missing_addr() {
+        let body = json!({
+            "traceEvents": [
+                {"ph": "i", "ts": 0, "name": "alloc", "args": {"bytes": 10}}
+            ]
+        });
+        assert!(matches!(
+            classify_alloc_free_pairing(&body),
+            AllocFreePairingOutcome::AllocMissingAddr { index: 0 }
+        ));
+    }
+
+    #[test]
+    fn monotonic_timestamps_ok_on_good_body() {
+        assert_eq!(
+            classify_monotonic_timestamps(&good_body()),
+            MonotonicTimestampsOutcome::Ok
+        );
+    }
+
+    #[test]
+    fn monotonic_timestamps_reports_violation() {
+        let body = json!({
+            "traceEvents": [
+                {"ph": "i", "ts": 100, "name": "alloc", "pid": 0, "tid": 1, "args": {"addr": "0xA"}},
+                {"ph": "i", "ts":  50, "name": "free",  "pid": 0, "tid": 1, "args": {"addr": "0xA"}},
+            ]
+        });
+        match classify_monotonic_timestamps(&body) {
+            MonotonicTimestampsOutcome::NonMonotonic { index, pid, tid, .. } => {
+                assert_eq!(index, 1);
+                assert_eq!(pid, 0);
+                assert_eq!(tid, 1);
+            }
+            other => panic!("expected NonMonotonic, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn monotonic_timestamps_allows_independent_streams_to_interleave() {
+        // Different (pid, tid) keys are independent — ordering across streams
+        // is not constrained.
+        let body = json!({
+            "traceEvents": [
+                {"ph": "i", "ts": 100, "name": "alloc", "pid": 0, "tid": 1, "args": {"addr": "0xA"}},
+                {"ph": "i", "ts":  50, "name": "alloc", "pid": 0, "tid": 2, "args": {"addr": "0xB"}},
+            ]
+        });
+        assert_eq!(
+            classify_monotonic_timestamps(&body),
+            MonotonicTimestampsOutcome::Ok
+        );
+    }
+}

--- a/crates/apr-cli/src/commands/gpu_memtrace_lint.rs
+++ b/crates/apr-cli/src/commands/gpu_memtrace_lint.rs
@@ -1,0 +1,83 @@
+//! `apr gpu-memtrace-lint` — CRUX-F-07 GPU memory Chrome-Trace gate.
+//!
+//! Reads an already-captured `apr profile --gpu-memory-trace` output (or any
+//! Chrome Trace Event Format JSON describing GPU alloc/free events) and
+//! dispatches the pure classifiers in `gpu_memtrace_classifier`. Exits
+//! non-zero on any failure.
+//!
+//! Spec: `contracts/crux-F-07-v1.yaml`. CRUX-SHIP-001 g2/g3 surface.
+
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+
+use super::gpu_memtrace_classifier::{
+    classify_alloc_free_pairing, classify_monotonic_timestamps, classify_schema,
+    AllocFreePairingOutcome, ChromeTraceSchemaOutcome, MonotonicTimestampsOutcome,
+};
+use crate::error::{CliError, Result};
+
+pub(crate) fn run(trace_file: &Path, json: bool) -> Result<()> {
+    if !trace_file.exists() {
+        return Err(CliError::FileNotFound(PathBuf::from(trace_file)));
+    }
+    let body_text = std::fs::read_to_string(trace_file)?;
+    let body: Value = serde_json::from_str(&body_text).map_err(|e| {
+        CliError::InvalidFormat(format!(
+            "apr gpu-memtrace-lint: failed to parse JSON from {}: {e}",
+            trace_file.display()
+        ))
+    })?;
+
+    let schema = classify_schema(&body);
+    let (pairing, ts) = if matches!(schema, ChromeTraceSchemaOutcome::Ok { .. }) {
+        (
+            classify_alloc_free_pairing(&body),
+            classify_monotonic_timestamps(&body),
+        )
+    } else {
+        (AllocFreePairingOutcome::Ok, MonotonicTimestampsOutcome::Ok)
+    };
+
+    print_report(trace_file, &schema, &pairing, &ts, json);
+
+    if !matches!(schema, ChromeTraceSchemaOutcome::Ok { .. }) {
+        return Err(CliError::ValidationFailed(format!(
+            "gpu-memtrace-lint schema gate rejected body: {schema:?}"
+        )));
+    }
+    if !matches!(pairing, AllocFreePairingOutcome::Ok) {
+        return Err(CliError::ValidationFailed(format!(
+            "gpu-memtrace-lint alloc/free-pairing gate rejected body: {pairing:?}"
+        )));
+    }
+    if !matches!(ts, MonotonicTimestampsOutcome::Ok) {
+        return Err(CliError::ValidationFailed(format!(
+            "gpu-memtrace-lint monotonic-timestamps gate rejected body: {ts:?}"
+        )));
+    }
+    Ok(())
+}
+
+fn print_report(
+    path: &Path,
+    schema: &ChromeTraceSchemaOutcome,
+    pairing: &AllocFreePairingOutcome,
+    ts: &MonotonicTimestampsOutcome,
+    json: bool,
+) {
+    if json {
+        let obj = serde_json::json!({
+            "file": path.display().to_string(),
+            "schema": format!("{schema:?}"),
+            "alloc_free_pairing": format!("{pairing:?}"),
+            "monotonic_timestamps": format!("{ts:?}"),
+        });
+        println!("{}", serde_json::to_string_pretty(&obj).unwrap_or_default());
+        return;
+    }
+    println!("gpu-memtrace-lint report for {}", path.display());
+    println!("  schema              : {schema:?}");
+    println!("  alloc_free_pairing  : {pairing:?}");
+    println!("  monotonic_timestamps: {ts:?}");
+}

--- a/crates/apr-cli/src/commands/mod.rs
+++ b/crates/apr-cli/src/commands/mod.rs
@@ -50,6 +50,8 @@ pub(crate) mod gptq_classifier;
 pub(crate) mod gptq_lint;
 #[cfg(feature = "training")]
 pub(crate) mod gpu;
+pub(crate) mod gpu_memtrace_classifier;
+pub(crate) mod gpu_memtrace_lint;
 pub(crate) mod grad_norm;
 pub(crate) mod hex;
 pub(crate) mod hf_endpoint;

--- a/crates/apr-cli/src/dispatch_analysis.rs
+++ b/crates/apr-cli/src/dispatch_analysis.rs
@@ -162,6 +162,10 @@ fn dispatch_analysis_commands(cli: &Cli) -> Option<Result<(), CliError>> {
             preempt_threshold,
         } => commands::kv_timeline_lint::run(timeline_file, *preempt_threshold, cli.json),
 
+        ExtendedCommands::GpuMemtraceLint { trace_file } => {
+            commands::gpu_memtrace_lint::run(trace_file, cli.json)
+        }
+
         ExtendedCommands::OtlpLint {
             otlp_file,
             require_apr_span,

--- a/crates/apr-cli/src/extended_commands.rs
+++ b/crates/apr-cli/src/extended_commands.rs
@@ -784,6 +784,12 @@ pub enum ExtendedCommands {
         #[arg(long, value_name = "FILE")]
         stderr_file: Option<PathBuf>,
     },
+    /// Lint a captured GPU memory Chrome Trace Event Format JSON (CRUX-F-07)
+    GpuMemtraceLint {
+        /// Path to captured Chrome Trace JSON from `apr profile --gpu-memory-trace`
+        #[arg(long, value_name = "FILE")]
+        trace_file: PathBuf,
+    },
     /// Lint a captured KV-cache utilization timeline (CRUX-F-06)
     KvTimelineLint {
         /// Path to captured `apr profile --kv-timeline --json` body

--- a/crates/apr-cli/tests/cli_commands.rs
+++ b/crates/apr-cli/tests/cli_commands.rs
@@ -115,6 +115,7 @@ fn registered_commands() -> Vec<&'static str> {
         "prometheus-lint",
         "otlp-lint",
         "kv-timeline-lint",
+        "gpu-memtrace-lint",
         "shard",
         "unshard",
         "oracle",

--- a/crates/apr-cli/tests/falsification_crux_f_07.rs
+++ b/crates/apr-cli/tests/falsification_crux_f_07.rs
@@ -1,0 +1,239 @@
+//! CRUX-F-07 — end-to-end falsification harness for `apr gpu-memtrace-lint`.
+//!
+//! CRUX-SHIP-001 gate g3 evidence: every FALSIFY-CRUX-F-07-{001..003}
+//! gate the classifier discharges has a matching captured Chrome Trace
+//! JSON body that the binary must classify exactly as the harness expects.
+
+use serde_json::json;
+use std::io::Write;
+use std::process::Command;
+
+fn apr_binary() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_apr"));
+    cmd.env("NO_COLOR", "1");
+    cmd
+}
+
+fn write_body(body: &serde_json::Value) -> tempfile::NamedTempFile {
+    let mut f = tempfile::Builder::new()
+        .prefix("crux-f-07-")
+        .suffix(".json")
+        .tempfile()
+        .expect("tempfile");
+    f.write_all(serde_json::to_vec_pretty(body).expect("serialize").as_slice())
+        .expect("write");
+    f.flush().expect("flush");
+    f
+}
+
+fn good_trace() -> serde_json::Value {
+    json!({
+        "displayTimeUnit": "ns",
+        "traceEvents": [
+            {"ph": "i", "ts": 0,    "name": "alloc", "pid": 0, "tid": 1, "args": {"bytes": 1024, "addr": "0xAAAA"}},
+            {"ph": "i", "ts": 100,  "name": "alloc", "pid": 0, "tid": 1, "args": {"bytes": 2048, "addr": "0xBBBB"}},
+            {"ph": "i", "ts": 200,  "name": "free",  "pid": 0, "tid": 1, "args": {"bytes": 1024, "addr": "0xAAAA"}},
+            {"ph": "i", "ts": 300,  "name": "free",  "pid": 0, "tid": 1, "args": {"bytes": 2048, "addr": "0xBBBB"}}
+        ]
+    })
+}
+
+// ===== g2: CLI shape =====
+
+#[test]
+fn falsify_crux_f_07_cli_help_advertises_trace_file() {
+    let out = apr_binary().args(["gpu-memtrace-lint", "--help"]).output().expect("run");
+    assert!(out.status.success(), "--help must exit 0");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("--trace-file"),
+        "--help must advertise --trace-file; got:\n{stdout}"
+    );
+}
+
+#[test]
+fn falsify_crux_f_07_cli_missing_file_fails() {
+    let out = apr_binary()
+        .args(["gpu-memtrace-lint", "--trace-file", "/nonexistent/crux-f-07-missing.json"])
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "missing file must not exit 0");
+}
+
+#[test]
+fn falsify_crux_f_07_cli_malformed_json_fails() {
+    let mut f = tempfile::Builder::new()
+        .prefix("crux-f-07-bad-")
+        .suffix(".json")
+        .tempfile()
+        .expect("tempfile");
+    f.write_all(b"{ not json").expect("write");
+    f.flush().expect("flush");
+    let out = apr_binary()
+        .args(["gpu-memtrace-lint", "--trace-file"])
+        .arg(f.path())
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "malformed JSON must not exit 0");
+}
+
+// ===== g3: classifier discharges =====
+
+#[test]
+fn falsify_crux_f_07_001_schema_ok_on_good_body() {
+    let f = write_body(&good_trace());
+    let out = apr_binary()
+        .args(["gpu-memtrace-lint", "--trace-file"])
+        .arg(f.path())
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "good Chrome Trace must pass; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn falsify_crux_f_07_001_schema_rejects_missing_trace_events() {
+    let body = json!({"otherKey": []});
+    let f = write_body(&body);
+    let out = apr_binary()
+        .args(["gpu-memtrace-lint", "--trace-file"])
+        .arg(f.path())
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "missing traceEvents must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("MissingTraceEvents"),
+        "stderr must name MissingTraceEvents; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn falsify_crux_f_07_001_schema_rejects_event_missing_ph() {
+    let body = json!({"traceEvents": [{"ts": 0, "name": "alloc"}]});
+    let f = write_body(&body);
+    let out = apr_binary()
+        .args(["gpu-memtrace-lint", "--trace-file"])
+        .arg(f.path())
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "missing ph must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("EventMissingField"),
+        "stderr must name EventMissingField; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn falsify_crux_f_07_002_alloc_free_pairing_rejects_orphan_alloc() {
+    let body = json!({
+        "traceEvents": [
+            {"ph": "i", "ts": 0, "name": "alloc", "args": {"addr": "0xLEAK"}},
+            {"ph": "i", "ts": 1, "name": "alloc", "args": {"addr": "0xOK"}},
+            {"ph": "i", "ts": 2, "name": "free",  "args": {"addr": "0xOK"}}
+        ]
+    });
+    let f = write_body(&body);
+    let out = apr_binary()
+        .args(["gpu-memtrace-lint", "--trace-file"])
+        .arg(f.path())
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "orphan alloc must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("OrphanAllocs") && stderr.contains("0xLEAK"),
+        "stderr must name OrphanAllocs with the leaked addr; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn falsify_crux_f_07_002_alloc_free_pairing_rejects_orphan_free() {
+    let body = json!({
+        "traceEvents": [
+            {"ph": "i", "ts": 0, "name": "alloc", "args": {"addr": "0xAAA"}},
+            {"ph": "i", "ts": 1, "name": "free",  "args": {"addr": "0xAAA"}},
+            {"ph": "i", "ts": 2, "name": "free",  "args": {"addr": "0xPHANTOM"}}
+        ]
+    });
+    let f = write_body(&body);
+    let out = apr_binary()
+        .args(["gpu-memtrace-lint", "--trace-file"])
+        .arg(f.path())
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "orphan free must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("OrphanFrees") && stderr.contains("0xPHANTOM"),
+        "stderr must name OrphanFrees with the phantom addr; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn falsify_crux_f_07_003_monotonic_timestamps_rejects_violation() {
+    let body = json!({
+        "traceEvents": [
+            {"ph": "i", "ts": 100, "name": "alloc", "pid": 0, "tid": 1, "args": {"addr": "0xA"}},
+            {"ph": "i", "ts":  50, "name": "free",  "pid": 0, "tid": 1, "args": {"addr": "0xA"}}
+        ]
+    });
+    let f = write_body(&body);
+    let out = apr_binary()
+        .args(["gpu-memtrace-lint", "--trace-file"])
+        .arg(f.path())
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "non-monotonic ts must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("NonMonotonic"),
+        "stderr must name NonMonotonic; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn falsify_crux_f_07_003_monotonic_timestamps_allows_cross_stream_interleave() {
+    // Different (pid, tid) streams can interleave freely.
+    let body = json!({
+        "traceEvents": [
+            {"ph": "i", "ts": 100, "name": "alloc", "pid": 0, "tid": 1, "args": {"addr": "0xA"}},
+            {"ph": "i", "ts":  50, "name": "alloc", "pid": 0, "tid": 2, "args": {"addr": "0xB"}},
+            {"ph": "i", "ts": 200, "name": "free",  "pid": 0, "tid": 1, "args": {"addr": "0xA"}},
+            {"ph": "i", "ts": 250, "name": "free",  "pid": 0, "tid": 2, "args": {"addr": "0xB"}}
+        ]
+    });
+    let f = write_body(&body);
+    let out = apr_binary()
+        .args(["gpu-memtrace-lint", "--trace-file"])
+        .arg(f.path())
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "independent streams may interleave; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+// ===== JSON output shape =====
+
+#[test]
+fn falsify_crux_f_07_json_output_contains_outcomes() {
+    let f = write_body(&good_trace());
+    let out = apr_binary()
+        .args(["--json", "gpu-memtrace-lint", "--trace-file"])
+        .arg(f.path())
+        .output()
+        .expect("run");
+    assert!(out.status.success(), "json + good body must exit 0");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("json output must parse");
+    assert!(parsed["schema"].as_str().expect("schema").contains("Ok"));
+    assert!(parsed["alloc_free_pairing"].as_str().expect("pairing").contains("Ok"));
+    assert!(parsed["monotonic_timestamps"].as_str().expect("ts").contains("Ok"));
+}


### PR DESCRIPTION
## Summary

- Promotes \`contracts/crux-F-07-v1.yaml\` from \`draft\` → PARTIAL_ALGORITHM_LEVEL.
- Adds \`apr gpu-memtrace-lint --trace-file FILE\` — pure-function classifier over Chrome Trace Event Format JSON bodies validating: schema (traceEvents array + required Chrome Trace fields), alloc/free pairing by addr, and per-(pid,tid) monotonic timestamps.
- 13 classifier unit tests + 11 e2e falsification tests + 8 cli_commands surface tests all pass.

Discharges FALSIFY-CRUX-F-07-{001..003} at PARTIAL_ALGORITHM_LEVEL. -004 (peak vs NVML within 10%) requires a live emitter and NVML reading.

## Test plan

- [x] \`cargo test -p apr-cli --lib gpu_memtrace_classifier\` — 13/13 pass.
- [x] \`cargo test -p apr-cli --test falsification_crux_f_07\` — 11/11 pass.
- [x] \`cargo test -p apr-cli --test cli_commands\` — 8/8 pass (3-surface drift policy).
- [x] \`pv validate contracts/crux-F-07-v1.yaml\` — clean.
- [ ] CI green on \`ci / gate\` + \`workspace-test\`.

Refs #921 (CRUX M4 observability epic), #917 (CRUX Phase 3 umbrella).

🤖 Generated with [Claude Code](https://claude.com/claude-code)