### PR TITLE
feat(apr-cli): CRUX-F-19 `apr explain-token-lint` sampler-chain classifier

### DIFF
--- a/contracts/apr-cli-commands-v1.yaml
+++ b/contracts/apr-cli-commands-v1.yaml
@@ -562,6 +562,12 @@ commands:
     requires_model: false
     side_effects: []
 
+  - name: explain-token-lint
+    category: inspection
+    description: "Validate captured `apr explain --format jsonl` sampler-chain trace (CRUX-F-19): schema + Σ post_prob ≈ 1 + sampled_id present in candidates + optional greedy=argmax assertion"
+    requires_model: false
+    side_effects: []
+
   - name: shard
     category: model_ops
     description: "Split safetensors file into shards + weight-map index (CRUX-B-05)"

--- a/contracts/crux-F-19-v1.yaml
+++ b/contracts/crux-F-19-v1.yaml
@@ -1,12 +1,21 @@
 # CRUX-F-19 — apr explain token selection
+# Promoted to PARTIAL_ALGORITHM_LEVEL at v1.2.0 under CRUX-SHIP-001 (2026-05-16):
+# - classifier: crates/apr-cli/src/commands/explain_token_classifier.rs (13 unit tests)
+# - CLI surface: `apr explain-token-lint --jsonl-file FILE [--tolerance F] [--require-greedy]`
+# - e2e: crates/apr-cli/tests/falsification_crux_f_19.rs (11 tests)
+# Full discharge of F-19-001/002/003 requires a live `apr explain` emitter
+# writing the JSONL records under a real sampler — tracked as
+# BLOCKER-UPSTREAM-MISSING.
 
 metadata:
   id: CRUX-F-19
-  version: "1.1.0"
+  version: "1.2.0"
   created: "2026-04-18"
+  updated: "2026-05-16"
   author: PAIML Engineering
   registry: true
-  status: draft
+  status: partial
+  kind: kernel
   parent_contracts:
   - crux-competitive-research-ux-v1
   category: "F — Tensor Ops & Low-level"
@@ -57,6 +66,28 @@ falsification_tests:
       assert abs(total - 1.0) < 1e-5, (r["step"], total)
     PY
   if_fails: rule 'post-sampler probs normalize' is violated — contract MUST be re-verified against competitor canonical reference
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/explain_token_classifier.rs
+    cli_path: crates/apr-cli/src/commands/explain_token_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_f_19.rs
+    e2e_tests:
+    - falsify_crux_f_19_001_probs_normalize_ok_on_good_body
+    - falsify_crux_f_19_001_probs_normalize_rejects_unnormalized
+    - falsify_crux_f_19_001_schema_rejects_empty_body
+    - falsify_crux_f_19_001_schema_rejects_malformed_line
+    - falsify_crux_f_19_tolerance_relaxes_normalize_gate
+    sub_claim: |
+      Algorithm-level necessary conditions on an already-captured JSONL
+      `apr explain` body: `classify_schema` verifies every line is a JSON
+      object with `step`, `sampled_id`, and a non-empty `candidates` array
+      whose entries carry `{token_id, pre_prob, post_prob, rank}`.
+      `classify_probs_normalize` then verifies `Σ post_prob ≈ 1.0` within
+      `tolerance` (default 1e-5, configurable). Outcome variants name
+      the offending line, step, and concrete sum so emitter bugs are
+      debuggable from lint output.
+    scope: "(body, tolerance) -> ExplainProbsOutcome (pure)"
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: "live `apr explain` emitter writing normalized post-sampler probabilities"
 - id: FALSIFY-CRUX-F-19-002
   rule: sampled token always present in candidate list
   prediction: "for each step, sampled_token in {c.token for c in candidates}"
@@ -70,6 +101,23 @@ falsification_tests:
       assert r["sampled_id"] in ids, r
     PY
   if_fails: rule 'sampled token always present in candidate list' is violated — contract MUST be re-verified against competitor canonical reference
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/explain_token_classifier.rs
+    cli_path: crates/apr-cli/src/commands/explain_token_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_f_19.rs
+    e2e_tests:
+    - falsify_crux_f_19_002_sampled_in_candidates_rejects_missing
+    sub_claim: |
+      Algorithm-level necessary condition: `classify_sampled_in_candidates`
+      verifies `sampled_id` appears in `candidates[*].token_id` for every
+      step. The sampler cannot return a token that was not in the
+      considered set; a violation is either a hallucinated sample id or
+      a truncated candidate list. Reports
+      `SampledNotInCandidates { line_no, step, sampled_id }` so the
+      offending step is pinpointed.
+    scope: "(body) -> ExplainSampledOutcome (pure)"
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: "live `apr explain` emitter writing the full candidate list"
 - id: FALSIFY-CRUX-F-19-003
   rule: temp=0 always picks rank-0 candidate
   prediction: "--temp 0 --top-k 1 → sampled == argmax(logits)"
@@ -86,6 +134,24 @@ falsification_tests:
     PY
 
   if_fails: rule 'temp=0 always picks rank-0 candidate' is violated — contract MUST be re-verified against competitor canonical reference
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/explain_token_classifier.rs
+    cli_path: crates/apr-cli/src/commands/explain_token_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_f_19.rs
+    e2e_tests:
+    - falsify_crux_f_19_003_greedy_argmax_ok_on_good_body
+    - falsify_crux_f_19_003_greedy_argmax_rejects_non_argmax
+    sub_claim: |
+      Algorithm-level necessary condition: when the caller asserts the
+      trace was produced under greedy decoding (`--temp 0 --top-k 1` —
+      `apr explain-token-lint --require-greedy`), `classify_greedy_picks_argmax`
+      verifies `sampled_id == argmax_id(pre_prob)` for every step.
+      `NotArgmax` outcome reports both the sampled and argmax token
+      ids with their pre-sampler probabilities so divergences are
+      pinpointed.
+    scope: "(body) -> ExplainGreedyOutcome (pure)"
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: "live `apr explain` emitter under greedy decoding"
 proof_obligations:
 - type: equivalence
   property: "apr explain output matches HF `generate(output_scores=True)` token probabilities within 1e-5"

--- a/crates/apr-cli/src/commands/explain_token_classifier.rs
+++ b/crates/apr-cli/src/commands/explain_token_classifier.rs
@@ -1,0 +1,385 @@
+//! Token-selection explanation classifier (CRUX-F-19).
+//!
+//! Pure, deterministic classifiers that discharge FALSIFY-CRUX-F-19-{001,002,003}
+//! at the PARTIAL_ALGORITHM_LEVEL — algorithm-level necessary conditions on
+//! an already-captured `apr explain --format jsonl` body (one JSON object per
+//! line, each describing a sampled token plus its candidate list):
+//!
+//!   * `classify_schema` — every line parses as a JSON object with the
+//!     5 required keys (`step`, `sampled_id`, `candidates`, optional
+//!     `token_id`, optional `token_str`); each candidate has
+//!     `token_id`, `pre_prob`, `post_prob`, `rank`.
+//!   * `classify_probs_normalize` — Σ post_prob across each step's
+//!     candidates ≈ 1.0 within 1e-5.
+//!   * `classify_sampled_in_candidates` — `sampled_id` appears in the
+//!     candidates list for every step (the sampler cannot return a
+//!     token that wasn't in the considered set).
+//!   * `classify_greedy_picks_argmax` — when the caller asserts the
+//!     trace was produced under `--temp 0 --top-k 1`, every step's
+//!     `sampled_id` equals the argmax of `pre_prob` across candidates.
+//!
+//! Full discharge blocks on a live `apr explain` emitter wired to the
+//! sampler — tracked as BLOCKER-UPSTREAM-MISSING.
+
+use serde_json::Value;
+
+/// Outcome of `classify_schema`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ExplainSchemaOutcome {
+    Ok { line_count: usize },
+    Empty,
+    LineNotJson { line_no: usize, message: String },
+    LineNotAnObject { line_no: usize },
+    LineMissingField { line_no: usize, field: &'static str },
+    CandidatesNotArray { line_no: usize },
+    CandidatesEmpty { line_no: usize },
+    CandidateNotAnObject { line_no: usize, index: usize },
+    CandidateMissingField { line_no: usize, index: usize, field: &'static str },
+}
+
+/// Outcome of `classify_probs_normalize`.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ExplainProbsOutcome {
+    Ok,
+    NotNormalized { line_no: usize, step: i64, sum: f64, tolerance: f64 },
+}
+
+/// Outcome of `classify_sampled_in_candidates`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ExplainSampledOutcome {
+    Ok,
+    SampledNotInCandidates { line_no: usize, step: i64, sampled_id: i64 },
+}
+
+/// Outcome of `classify_greedy_picks_argmax`.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ExplainGreedyOutcome {
+    Ok,
+    NotArgmax {
+        line_no: usize,
+        step: i64,
+        sampled_id: i64,
+        sampled_pre_prob: f64,
+        argmax_id: i64,
+        argmax_pre_prob: f64,
+    },
+}
+
+/// Parse a JSONL body into a list of (line_no, line, parsed) tuples.
+/// Returns the schema outcome on the first error encountered.
+fn parse_jsonl(body: &str) -> Result<Vec<(usize, Value)>, ExplainSchemaOutcome> {
+    let mut out = Vec::new();
+    let mut nonblank = 0usize;
+    for (idx, raw) in body.lines().enumerate() {
+        let line_no = idx + 1;
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        nonblank += 1;
+        let v: Value = serde_json::from_str(trimmed).map_err(|e| {
+            ExplainSchemaOutcome::LineNotJson { line_no, message: e.to_string() }
+        })?;
+        if !v.is_object() {
+            return Err(ExplainSchemaOutcome::LineNotAnObject { line_no });
+        }
+        out.push((line_no, v));
+    }
+    if nonblank == 0 {
+        return Err(ExplainSchemaOutcome::Empty);
+    }
+    Ok(out)
+}
+
+/// Schema gate: every JSONL line is an object with `step`, `sampled_id`, and
+/// a non-empty `candidates` array of `{token_id, pre_prob, post_prob, rank}`.
+pub fn classify_schema(body: &str) -> ExplainSchemaOutcome {
+    let parsed = match parse_jsonl(body) {
+        Ok(p) => p,
+        Err(e) => return e,
+    };
+    for (line_no, v) in &parsed {
+        for f in ["step", "sampled_id", "candidates"] {
+            if v.get(f).is_none() {
+                return ExplainSchemaOutcome::LineMissingField {
+                    line_no: *line_no,
+                    field: match f {
+                        "step" => "step",
+                        "sampled_id" => "sampled_id",
+                        _ => "candidates",
+                    },
+                };
+            }
+        }
+        let Some(cands) = v.get("candidates").and_then(Value::as_array) else {
+            return ExplainSchemaOutcome::CandidatesNotArray { line_no: *line_no };
+        };
+        if cands.is_empty() {
+            return ExplainSchemaOutcome::CandidatesEmpty { line_no: *line_no };
+        }
+        for (i, c) in cands.iter().enumerate() {
+            if !c.is_object() {
+                return ExplainSchemaOutcome::CandidateNotAnObject {
+                    line_no: *line_no,
+                    index: i,
+                };
+            }
+            for f in ["token_id", "pre_prob", "post_prob", "rank"] {
+                if c.get(f).is_none() {
+                    return ExplainSchemaOutcome::CandidateMissingField {
+                        line_no: *line_no,
+                        index: i,
+                        field: match f {
+                            "token_id" => "token_id",
+                            "pre_prob" => "pre_prob",
+                            "post_prob" => "post_prob",
+                            _ => "rank",
+                        },
+                    };
+                }
+            }
+        }
+    }
+    ExplainSchemaOutcome::Ok { line_count: parsed.len() }
+}
+
+/// Verify Σ post_prob ≈ 1.0 (within `tolerance`) per step.
+pub fn classify_probs_normalize(body: &str, tolerance: f64) -> ExplainProbsOutcome {
+    let parsed = match parse_jsonl(body) {
+        Ok(p) => p,
+        Err(_) => return ExplainProbsOutcome::Ok, // schema gate handles malformed input
+    };
+    for (line_no, v) in parsed {
+        let step = v.get("step").and_then(Value::as_i64).unwrap_or(0);
+        let Some(cands) = v.get("candidates").and_then(Value::as_array) else {
+            continue;
+        };
+        let sum: f64 = cands
+            .iter()
+            .filter_map(|c| c.get("post_prob").and_then(Value::as_f64))
+            .sum();
+        if (sum - 1.0).abs() > tolerance {
+            return ExplainProbsOutcome::NotNormalized { line_no, step, sum, tolerance };
+        }
+    }
+    ExplainProbsOutcome::Ok
+}
+
+/// Verify `sampled_id` is in `candidates[*].token_id` for every step.
+pub fn classify_sampled_in_candidates(body: &str) -> ExplainSampledOutcome {
+    let parsed = match parse_jsonl(body) {
+        Ok(p) => p,
+        Err(_) => return ExplainSampledOutcome::Ok,
+    };
+    for (line_no, v) in parsed {
+        let step = v.get("step").and_then(Value::as_i64).unwrap_or(0);
+        let sampled = v.get("sampled_id").and_then(Value::as_i64).unwrap_or(-1);
+        let Some(cands) = v.get("candidates").and_then(Value::as_array) else {
+            continue;
+        };
+        let found = cands
+            .iter()
+            .filter_map(|c| c.get("token_id").and_then(Value::as_i64))
+            .any(|id| id == sampled);
+        if !found {
+            return ExplainSampledOutcome::SampledNotInCandidates {
+                line_no,
+                step,
+                sampled_id: sampled,
+            };
+        }
+    }
+    ExplainSampledOutcome::Ok
+}
+
+/// Verify that under greedy decoding (`temp == 0`, `top_k == 1`) the
+/// sampled token is the argmax of `pre_prob`.
+pub fn classify_greedy_picks_argmax(body: &str) -> ExplainGreedyOutcome {
+    let parsed = match parse_jsonl(body) {
+        Ok(p) => p,
+        Err(_) => return ExplainGreedyOutcome::Ok,
+    };
+    for (line_no, v) in parsed {
+        let step = v.get("step").and_then(Value::as_i64).unwrap_or(0);
+        let sampled = v.get("sampled_id").and_then(Value::as_i64).unwrap_or(-1);
+        let Some(cands) = v.get("candidates").and_then(Value::as_array) else {
+            continue;
+        };
+        let mut best: Option<(i64, f64)> = None;
+        let mut sampled_pre: f64 = f64::NAN;
+        for c in cands {
+            let id = c.get("token_id").and_then(Value::as_i64).unwrap_or(-1);
+            let pre = c.get("pre_prob").and_then(Value::as_f64).unwrap_or(0.0);
+            if id == sampled {
+                sampled_pre = pre;
+            }
+            match best {
+                None => best = Some((id, pre)),
+                Some((_, b)) if pre > b => best = Some((id, pre)),
+                _ => {}
+            }
+        }
+        let Some((argmax_id, argmax_pre)) = best else {
+            continue;
+        };
+        if argmax_id != sampled {
+            return ExplainGreedyOutcome::NotArgmax {
+                line_no,
+                step,
+                sampled_id: sampled,
+                sampled_pre_prob: sampled_pre,
+                argmax_id,
+                argmax_pre_prob: argmax_pre,
+            };
+        }
+    }
+    ExplainGreedyOutcome::Ok
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn good_body() -> String {
+        // Two steps with normalized probs and the sampled id present.
+        let l0 = r#"{"step":0,"sampled_id":7,"candidates":[
+            {"token_id":7,"pre_prob":0.6,"post_prob":0.7,"rank":0},
+            {"token_id":3,"pre_prob":0.3,"post_prob":0.2,"rank":1},
+            {"token_id":5,"pre_prob":0.1,"post_prob":0.1,"rank":2}
+        ]}"#;
+        let l1 = r#"{"step":1,"sampled_id":3,"candidates":[
+            {"token_id":3,"pre_prob":0.5,"post_prob":0.5,"rank":0},
+            {"token_id":7,"pre_prob":0.4,"post_prob":0.5,"rank":1}
+        ]}"#;
+        // Strip the embedded newlines/indentation so each line is one record.
+        let mut out = String::new();
+        out.push_str(&l0.split_whitespace().collect::<String>());
+        out.push('\n');
+        out.push_str(&l1.split_whitespace().collect::<String>());
+        out.push('\n');
+        out
+    }
+
+    #[test]
+    fn schema_ok_on_good_body() {
+        let out = classify_schema(&good_body());
+        assert_eq!(out, ExplainSchemaOutcome::Ok { line_count: 2 });
+    }
+
+    #[test]
+    fn schema_rejects_empty_body() {
+        assert_eq!(classify_schema(""), ExplainSchemaOutcome::Empty);
+    }
+
+    #[test]
+    fn schema_rejects_non_json_line() {
+        let body = "not json\n";
+        assert!(matches!(
+            classify_schema(body),
+            ExplainSchemaOutcome::LineNotJson { line_no: 1, .. }
+        ));
+    }
+
+    #[test]
+    fn schema_rejects_non_object_line() {
+        let body = "[1,2,3]\n";
+        assert_eq!(
+            classify_schema(body),
+            ExplainSchemaOutcome::LineNotAnObject { line_no: 1 }
+        );
+    }
+
+    #[test]
+    fn schema_rejects_missing_field() {
+        let body = r#"{"step":0,"candidates":[{"token_id":1,"pre_prob":1.0,"post_prob":1.0,"rank":0}]}"#;
+        assert!(matches!(
+            classify_schema(body),
+            ExplainSchemaOutcome::LineMissingField { line_no: 1, field: "sampled_id" }
+        ));
+    }
+
+    #[test]
+    fn schema_rejects_candidate_missing_field() {
+        let body = r#"{"step":0,"sampled_id":1,"candidates":[{"token_id":1,"pre_prob":1.0,"rank":0}]}"#;
+        assert!(matches!(
+            classify_schema(body),
+            ExplainSchemaOutcome::CandidateMissingField { line_no: 1, index: 0, field: "post_prob" }
+        ));
+    }
+
+    #[test]
+    fn schema_rejects_empty_candidates() {
+        let body = r#"{"step":0,"sampled_id":1,"candidates":[]}"#;
+        assert!(matches!(
+            classify_schema(body),
+            ExplainSchemaOutcome::CandidatesEmpty { line_no: 1 }
+        ));
+    }
+
+    #[test]
+    fn probs_normalize_ok_on_good_body() {
+        assert_eq!(
+            classify_probs_normalize(&good_body(), 1e-5),
+            ExplainProbsOutcome::Ok
+        );
+    }
+
+    #[test]
+    fn probs_normalize_reports_violation() {
+        let body = r#"{"step":0,"sampled_id":1,"candidates":[
+            {"token_id":1,"pre_prob":0.5,"post_prob":0.6,"rank":0},
+            {"token_id":2,"pre_prob":0.5,"post_prob":0.6,"rank":1}
+        ]}"#;
+        // Strip whitespace so it's one JSONL line.
+        let body = body.split_whitespace().collect::<String>();
+        assert!(matches!(
+            classify_probs_normalize(&body, 1e-5),
+            ExplainProbsOutcome::NotNormalized { .. }
+        ));
+    }
+
+    #[test]
+    fn sampled_in_candidates_ok_on_good_body() {
+        assert_eq!(
+            classify_sampled_in_candidates(&good_body()),
+            ExplainSampledOutcome::Ok
+        );
+    }
+
+    #[test]
+    fn sampled_in_candidates_reports_missing() {
+        let body = r#"{"step":0,"sampled_id":99,"candidates":[
+            {"token_id":1,"pre_prob":1.0,"post_prob":1.0,"rank":0}
+        ]}"#;
+        let body = body.split_whitespace().collect::<String>();
+        assert!(matches!(
+            classify_sampled_in_candidates(&body),
+            ExplainSampledOutcome::SampledNotInCandidates { sampled_id: 99, .. }
+        ));
+    }
+
+    #[test]
+    fn greedy_picks_argmax_ok_on_good_body() {
+        assert_eq!(
+            classify_greedy_picks_argmax(&good_body()),
+            ExplainGreedyOutcome::Ok
+        );
+    }
+
+    #[test]
+    fn greedy_picks_argmax_reports_non_argmax() {
+        // sampled_id=3 but argmax pre_prob is token 7
+        let body = r#"{"step":0,"sampled_id":3,"candidates":[
+            {"token_id":7,"pre_prob":0.9,"post_prob":1.0,"rank":0},
+            {"token_id":3,"pre_prob":0.1,"post_prob":0.0,"rank":1}
+        ]}"#;
+        let body = body.split_whitespace().collect::<String>();
+        match classify_greedy_picks_argmax(&body) {
+            ExplainGreedyOutcome::NotArgmax { sampled_id, argmax_id, .. } => {
+                assert_eq!(sampled_id, 3);
+                assert_eq!(argmax_id, 7);
+            }
+            other => panic!("expected NotArgmax, got {other:?}"),
+        }
+    }
+}

--- a/crates/apr-cli/src/commands/explain_token_lint.rs
+++ b/crates/apr-cli/src/commands/explain_token_lint.rs
@@ -1,0 +1,97 @@
+//! `apr explain-token-lint` — CRUX-F-19 sampler-chain JSONL gate.
+//!
+//! Reads an already-captured `apr explain --format jsonl` body and dispatches
+//! the pure classifiers in `explain_token_classifier`. Exits non-zero on any
+//! failure.
+//!
+//! Spec: `contracts/crux-F-19-v1.yaml`. CRUX-SHIP-001 g2/g3 surface.
+
+use std::path::{Path, PathBuf};
+
+use super::explain_token_classifier::{
+    classify_greedy_picks_argmax, classify_probs_normalize, classify_sampled_in_candidates,
+    classify_schema, ExplainGreedyOutcome, ExplainProbsOutcome, ExplainSampledOutcome,
+    ExplainSchemaOutcome,
+};
+use crate::error::{CliError, Result};
+
+pub(crate) fn run(
+    jsonl_file: &Path,
+    tolerance: f64,
+    require_greedy: bool,
+    json: bool,
+) -> Result<()> {
+    if !jsonl_file.exists() {
+        return Err(CliError::FileNotFound(PathBuf::from(jsonl_file)));
+    }
+    let body = std::fs::read_to_string(jsonl_file)?;
+
+    let schema = classify_schema(&body);
+    let (probs, sampled, greedy) = if matches!(schema, ExplainSchemaOutcome::Ok { .. }) {
+        (
+            classify_probs_normalize(&body, tolerance),
+            classify_sampled_in_candidates(&body),
+            if require_greedy {
+                Some(classify_greedy_picks_argmax(&body))
+            } else {
+                None
+            },
+        )
+    } else {
+        (ExplainProbsOutcome::Ok, ExplainSampledOutcome::Ok, None)
+    };
+
+    print_report(jsonl_file, &schema, &probs, &sampled, greedy.as_ref(), json);
+
+    if !matches!(schema, ExplainSchemaOutcome::Ok { .. }) {
+        return Err(CliError::ValidationFailed(format!(
+            "explain-token-lint schema gate rejected body: {schema:?}"
+        )));
+    }
+    if !matches!(probs, ExplainProbsOutcome::Ok) {
+        return Err(CliError::ValidationFailed(format!(
+            "explain-token-lint probs-normalize gate rejected body: {probs:?}"
+        )));
+    }
+    if !matches!(sampled, ExplainSampledOutcome::Ok) {
+        return Err(CliError::ValidationFailed(format!(
+            "explain-token-lint sampled-in-candidates gate rejected body: {sampled:?}"
+        )));
+    }
+    if let Some(g) = &greedy {
+        if !matches!(g, ExplainGreedyOutcome::Ok) {
+            return Err(CliError::ValidationFailed(format!(
+                "explain-token-lint greedy-argmax gate rejected body: {g:?}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn print_report(
+    path: &Path,
+    schema: &ExplainSchemaOutcome,
+    probs: &ExplainProbsOutcome,
+    sampled: &ExplainSampledOutcome,
+    greedy: Option<&ExplainGreedyOutcome>,
+    json: bool,
+) {
+    if json {
+        let obj = serde_json::json!({
+            "file": path.display().to_string(),
+            "schema": format!("{schema:?}"),
+            "probs_normalize": format!("{probs:?}"),
+            "sampled_in_candidates": format!("{sampled:?}"),
+            "greedy_picks_argmax": greedy.map(|g| format!("{g:?}")),
+        });
+        println!("{}", serde_json::to_string_pretty(&obj).unwrap_or_default());
+        return;
+    }
+    println!("explain-token-lint report for {}", path.display());
+    println!("  schema                : {schema:?}");
+    println!("  probs_normalize       : {probs:?}");
+    println!("  sampled_in_candidates : {sampled:?}");
+    if let Some(g) = greedy {
+        println!("  greedy_picks_argmax   : {g:?}");
+    }
+}

--- a/crates/apr-cli/src/commands/mod.rs
+++ b/crates/apr-cli/src/commands/mod.rs
@@ -37,6 +37,8 @@ pub(crate) mod eval;
 #[cfg(feature = "training")]
 pub(crate) mod experiment;
 pub(crate) mod explain;
+pub(crate) mod explain_token_classifier;
+pub(crate) mod explain_token_lint;
 pub(crate) mod export;
 #[cfg(feature = "training")]
 pub(crate) mod finetune;

--- a/crates/apr-cli/src/dispatch_analysis.rs
+++ b/crates/apr-cli/src/dispatch_analysis.rs
@@ -166,6 +166,12 @@ fn dispatch_analysis_commands(cli: &Cli) -> Option<Result<(), CliError>> {
             commands::gpu_memtrace_lint::run(trace_file, cli.json)
         }
 
+        ExtendedCommands::ExplainTokenLint {
+            jsonl_file,
+            tolerance,
+            require_greedy,
+        } => commands::explain_token_lint::run(jsonl_file, *tolerance, *require_greedy, cli.json),
+
         ExtendedCommands::OtlpLint {
             otlp_file,
             require_apr_span,

--- a/crates/apr-cli/src/extended_commands.rs
+++ b/crates/apr-cli/src/extended_commands.rs
@@ -784,6 +784,18 @@ pub enum ExtendedCommands {
         #[arg(long, value_name = "FILE")]
         stderr_file: Option<PathBuf>,
     },
+    /// Lint a captured `apr explain --format jsonl` token-selection trace (CRUX-F-19)
+    ExplainTokenLint {
+        /// Path to captured JSONL body (one sampled-token record per line)
+        #[arg(long, value_name = "FILE")]
+        jsonl_file: PathBuf,
+        /// Tolerance for `Σ post_prob ≈ 1.0` (default 1e-5)
+        #[arg(long, value_name = "F64", default_value_t = 1e-5)]
+        tolerance: f64,
+        /// Assert greedy decoding: sampled_id must equal argmax(pre_prob)
+        #[arg(long)]
+        require_greedy: bool,
+    },
     /// Lint a captured GPU memory Chrome Trace Event Format JSON (CRUX-F-07)
     GpuMemtraceLint {
         /// Path to captured Chrome Trace JSON from `apr profile --gpu-memory-trace`

--- a/crates/apr-cli/tests/cli_commands.rs
+++ b/crates/apr-cli/tests/cli_commands.rs
@@ -116,6 +116,7 @@ fn registered_commands() -> Vec<&'static str> {
         "otlp-lint",
         "kv-timeline-lint",
         "gpu-memtrace-lint",
+        "explain-token-lint",
         "shard",
         "unshard",
         "oracle",

--- a/crates/apr-cli/tests/falsification_crux_f_19.rs
+++ b/crates/apr-cli/tests/falsification_crux_f_19.rs
@@ -1,0 +1,219 @@
+//! CRUX-F-19 — end-to-end falsification harness for `apr explain-token-lint`.
+//!
+//! CRUX-SHIP-001 gate g3 evidence: every FALSIFY-CRUX-F-19-{001,002,003}
+//! gate the classifier discharges has a matching captured JSONL body that
+//! the binary must classify exactly as the harness expects.
+
+use std::io::Write;
+use std::process::Command;
+
+fn apr_binary() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_apr"));
+    cmd.env("NO_COLOR", "1");
+    cmd
+}
+
+fn write_body(body: &str) -> tempfile::NamedTempFile {
+    let mut f = tempfile::Builder::new()
+        .prefix("crux-f-19-")
+        .suffix(".jsonl")
+        .tempfile()
+        .expect("tempfile");
+    f.write_all(body.as_bytes()).expect("write");
+    f.flush().expect("flush");
+    f
+}
+
+fn good_body() -> String {
+    // Two normalized steps with sampled token present in candidates.
+    let l0 = r#"{"step":0,"sampled_id":7,"candidates":[{"token_id":7,"pre_prob":0.6,"post_prob":0.7,"rank":0},{"token_id":3,"pre_prob":0.3,"post_prob":0.2,"rank":1},{"token_id":5,"pre_prob":0.1,"post_prob":0.1,"rank":2}]}"#;
+    let l1 = r#"{"step":1,"sampled_id":3,"candidates":[{"token_id":3,"pre_prob":0.5,"post_prob":0.5,"rank":0},{"token_id":7,"pre_prob":0.4,"post_prob":0.5,"rank":1}]}"#;
+    format!("{l0}\n{l1}\n")
+}
+
+// ===== g2: CLI shape =====
+
+#[test]
+fn falsify_crux_f_19_cli_help_advertises_flags() {
+    let out = apr_binary().args(["explain-token-lint", "--help"]).output().expect("run");
+    assert!(out.status.success(), "--help must exit 0");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("--jsonl-file"),
+        "--help must advertise --jsonl-file; got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("--tolerance"),
+        "--help must advertise --tolerance; got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("--require-greedy"),
+        "--help must advertise --require-greedy; got:\n{stdout}"
+    );
+}
+
+#[test]
+fn falsify_crux_f_19_cli_missing_file_fails() {
+    let out = apr_binary()
+        .args(["explain-token-lint", "--jsonl-file", "/nonexistent/crux-f-19-missing.jsonl"])
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "missing file must not exit 0");
+}
+
+// ===== g3: classifier discharges =====
+
+#[test]
+fn falsify_crux_f_19_001_probs_normalize_ok_on_good_body() {
+    let f = write_body(&good_body());
+    let out = apr_binary()
+        .args(["explain-token-lint", "--jsonl-file"])
+        .arg(f.path())
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "good body must pass; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn falsify_crux_f_19_001_probs_normalize_rejects_unnormalized() {
+    let body = r#"{"step":0,"sampled_id":1,"candidates":[{"token_id":1,"pre_prob":0.5,"post_prob":0.6,"rank":0},{"token_id":2,"pre_prob":0.5,"post_prob":0.6,"rank":1}]}
+"#;
+    let f = write_body(body);
+    let out = apr_binary()
+        .args(["explain-token-lint", "--jsonl-file"])
+        .arg(f.path())
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "unnormalized probs must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("NotNormalized"),
+        "stderr must name NotNormalized; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn falsify_crux_f_19_002_sampled_in_candidates_rejects_missing() {
+    let body = r#"{"step":0,"sampled_id":99,"candidates":[{"token_id":1,"pre_prob":1.0,"post_prob":1.0,"rank":0}]}
+"#;
+    let f = write_body(body);
+    let out = apr_binary()
+        .args(["explain-token-lint", "--jsonl-file"])
+        .arg(f.path())
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "sampled_id not in candidates must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("SampledNotInCandidates"),
+        "stderr must name SampledNotInCandidates; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn falsify_crux_f_19_003_greedy_argmax_ok_on_good_body() {
+    let f = write_body(&good_body());
+    let out = apr_binary()
+        .args(["explain-token-lint", "--jsonl-file"])
+        .arg(f.path())
+        .arg("--require-greedy")
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "greedy=argmax in good body; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn falsify_crux_f_19_003_greedy_argmax_rejects_non_argmax() {
+    // sampled_id is rank=1, not the argmax of pre_prob
+    let body = r#"{"step":0,"sampled_id":3,"candidates":[{"token_id":7,"pre_prob":0.9,"post_prob":1.0,"rank":0},{"token_id":3,"pre_prob":0.1,"post_prob":0.0,"rank":1}]}
+"#;
+    let f = write_body(body);
+    let out = apr_binary()
+        .args(["explain-token-lint", "--jsonl-file"])
+        .arg(f.path())
+        .arg("--require-greedy")
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "non-argmax under greedy must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("NotArgmax"),
+        "stderr must name NotArgmax; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn falsify_crux_f_19_001_schema_rejects_empty_body() {
+    let f = write_body("");
+    let out = apr_binary()
+        .args(["explain-token-lint", "--jsonl-file"])
+        .arg(f.path())
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "empty body must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("Empty"), "stderr must name Empty; got:\n{stderr}");
+}
+
+#[test]
+fn falsify_crux_f_19_001_schema_rejects_malformed_line() {
+    let f = write_body("not json\n");
+    let out = apr_binary()
+        .args(["explain-token-lint", "--jsonl-file"])
+        .arg(f.path())
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "non-json line must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("LineNotJson"),
+        "stderr must name LineNotJson; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn falsify_crux_f_19_tolerance_relaxes_normalize_gate() {
+    // Probs sum to 1.01 — strict tolerance fails, relaxed passes.
+    let body = r#"{"step":0,"sampled_id":1,"candidates":[{"token_id":1,"pre_prob":0.5,"post_prob":0.51,"rank":0},{"token_id":2,"pre_prob":0.5,"post_prob":0.50,"rank":1}]}
+"#;
+    let f = write_body(body);
+    let out = apr_binary()
+        .args(["explain-token-lint", "--jsonl-file"])
+        .arg(f.path())
+        .args(["--tolerance", "0.05"])
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "0.01 deviation within 0.05 tolerance must pass; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+// ===== JSON output shape =====
+
+#[test]
+fn falsify_crux_f_19_json_output_contains_outcomes() {
+    let f = write_body(&good_body());
+    let out = apr_binary()
+        .args(["--json", "explain-token-lint", "--jsonl-file"])
+        .arg(f.path())
+        .arg("--require-greedy")
+        .output()
+        .expect("run");
+    assert!(out.status.success(), "json + good body must exit 0");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("json output must parse");
+    assert!(parsed["schema"].as_str().expect("schema").contains("Ok"));
+    assert!(parsed["probs_normalize"].as_str().expect("probs").contains("Ok"));
+    assert!(parsed["sampled_in_candidates"].as_str().expect("sampled").contains("Ok"));
+    assert!(parsed["greedy_picks_argmax"].as_str().expect("greedy").contains("Ok"));
+}


### PR DESCRIPTION
## Summary

- Promotes \`contracts/crux-F-19-v1.yaml\` from \`draft\` → PARTIAL_ALGORITHM_LEVEL.
- Adds \`apr explain-token-lint --jsonl-file FILE [--tolerance F] [--require-greedy]\` — pure-function classifier over \`apr explain --format jsonl\` bodies validating: schema (line is object with required step/sampled_id/candidates fields), Σ post_prob ≈ 1.0, sampled_id ∈ candidates, and (opt-in) greedy=argmax.
- 13 classifier unit tests + 11 e2e falsification tests + 8 cli_commands surface tests all pass.

Discharges FALSIFY-CRUX-F-19-{001,002,003} at PARTIAL_ALGORITHM_LEVEL. Full discharge blocks on a live \`apr explain\` emitter.

## Test plan

- [x] \`cargo test -p apr-cli --lib explain_token_classifier\` — 13/13 pass.
- [x] \`cargo test -p apr-cli --test falsification_crux_f_19\` — 11/11 pass.
- [x] \`cargo test -p apr-cli --test cli_commands\` — 8/8 pass (3-surface drift policy).
- [x] \`pv validate contracts/crux-F-19-v1.yaml\` — clean.
- [ ] CI green on \`ci / gate\` + \`workspace-test\`.

Refs #921 (CRUX M4 observability epic), #917 (CRUX Phase 3 umbrella).

🤖 Generated with [Claude Code](https://claude.com/claude-code)