### PR TITLE
feat(apr-cli): CRUX-F-11 `apr check-finite-lint` NaN/Inf detector classifier

### DIFF
--- a/contracts/apr-cli-commands-v1.yaml
+++ b/contracts/apr-cli-commands-v1.yaml
@@ -568,6 +568,12 @@ commands:
     requires_model: false
     side_effects: []
 
+  - name: check-finite-lint
+    category: inspection
+    description: "Validate captured `apr trace --check-finite` outputs (CRUX-F-11): error JSON shape (6 keys + value ∈ {nan,+inf,-inf}) + layer-coverage list (min_layers + transformer-op prefixes)"
+    requires_model: false
+    side_effects: []
+
   - name: shard
     category: model_ops
     description: "Split safetensors file into shards + weight-map index (CRUX-B-05)"

--- a/contracts/crux-F-11-v1.yaml
+++ b/contracts/crux-F-11-v1.yaml
@@ -1,16 +1,21 @@
 # CRUX-F-11 — NaN/Inf detector in activations
-# Auto-scaffolded from crux-competitive-research-ux-v1.yaml (DRAFT).
-# DO NOT promote to ACTIVE until: (1) evidence collected, (2) falsification
-# body reflects competitor's canonical CLI, (3) apr surface mapped or gap
-# tracked in pmat work (see master §12).
+# Promoted to PARTIAL_ALGORITHM_LEVEL at v1.1.0 under CRUX-SHIP-001 (2026-05-16):
+# - classifier: crates/apr-cli/src/commands/check_finite_classifier.rs (12 unit tests)
+# - CLI surface: `apr check-finite-lint [--error-file F] [--list-file F] [--min-layers N]`
+# - e2e: crates/apr-cli/tests/falsification_crux_f_11.rs (12 tests)
+# FALSIFY-CRUX-F-11-001 (clean exit 0) and -004 (parity with torch
+# anomaly mode) require a live `apr trace --check-finite` emitter and a
+# poisoned-weight harness — tracked as BLOCKER-UPSTREAM-MISSING.
 
 metadata:
   id: CRUX-F-11
-  version: "1.0.0-draft"
+  version: "1.1.0"
   created: "2026-04-18"
+  updated: "2026-05-16"
   author: PAIML Engineering
   registry: true
-  status: draft
+  status: partial
+  kind: kernel
   parent_contracts:
   - crux-competitive-research-ux-v1
   category: "F — Tensor Ops & Low-level"
@@ -102,6 +107,27 @@ falsification_tests:
       || { echo "FAIL: missing or wrong layer in error JSON: $OUT" >&2; exit 1; }
 
   if_fails: rule 'poisoned weight triggers exit 2 with layer name' is violated — contract MUST be re-verified against competitor canonical reference
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/check_finite_classifier.rs
+    cli_path: crates/apr-cli/src/commands/check_finite_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_f_11.rs
+    e2e_tests:
+    - falsify_crux_f_11_002_error_json_ok_on_well_formed
+    - falsify_crux_f_11_002_error_json_rejects_missing_layer
+    - falsify_crux_f_11_002_error_json_rejects_wrong_error_tag
+    - falsify_crux_f_11_002_error_json_rejects_value_out_of_set
+    sub_claim: |
+      Algorithm-level necessary conditions on an already-captured stderr
+      JSON from `apr trace --check-finite` on a poisoned model:
+      `classify_error_json` verifies the body is an object with the 6
+      required keys (`error`, `layer`, `shape`, `first_bad_index`,
+      `value`, `op`), `error == "non_finite"`, `value ∈ {nan, +inf, -inf}`,
+      `shape` is an integer array, and `first_bad_index >= 0`. Each
+      outcome names the offending field so emitter bugs are debuggable
+      from the lint output alone.
+    scope: "(body) -> CheckFiniteErrorOutcome (pure)"
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: "live `apr trace --check-finite` writing the F-11 error JSON on a poisoned model"
 - id: FALSIFY-CRUX-F-11-003
   rule: layer coverage is complete
   prediction: "--check-finite --list enumerates every tensor-producing op"
@@ -112,6 +138,27 @@ falsification_tests:
     [ "$N" -ge 100 ] || { echo "FAIL: only $N layers listed, expected >= 100" >&2; exit 1; }
 
   if_fails: rule 'layer coverage is complete' is violated — contract MUST be re-verified against competitor canonical reference
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/check_finite_classifier.rs
+    cli_path: crates/apr-cli/src/commands/check_finite_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_f_11.rs
+    e2e_tests:
+    - falsify_crux_f_11_003_layer_coverage_ok_on_well_formed
+    - falsify_crux_f_11_003_layer_coverage_rejects_too_few
+    - falsify_crux_f_11_003_layer_coverage_rejects_missing_op_prefixes
+    - falsify_crux_f_11_min_layers_threshold_is_configurable
+    sub_claim: |
+      Algorithm-level necessary conditions on an already-captured stdout
+      JSON from `apr trace --check-finite --list`:
+      `classify_layer_coverage` verifies the body has a `layers` array
+      with at least `min_layers` entries (default 100, configurable)
+      and every transformer-op prefix in `F11_REQUIRED_OP_PREFIXES`
+      (attention_q/k/v/out, ffn_gate/up/down, layernorm) appears in at
+      least one layer name. Missing prefixes are listed sorted so the
+      coverage gap is debuggable from lint output.
+    scope: "(body, min_layers, required_op_prefixes) -> CheckFiniteCoverageOutcome (pure)"
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: "live `apr trace --check-finite --list` enumerating every forward-pass tensor op"
 - id: FALSIFY-CRUX-F-11-004
   rule: parity with torch anomaly detection
   prediction: "apr and torch identify the same first-fault layer"

--- a/crates/apr-cli/src/commands/check_finite_classifier.rs
+++ b/crates/apr-cli/src/commands/check_finite_classifier.rs
@@ -1,0 +1,298 @@
+//! NaN/Inf activation-check classifier (CRUX-F-11).
+//!
+//! Pure, deterministic classifiers that discharge FALSIFY-CRUX-F-11-{002,003}
+//! at the PARTIAL_ALGORITHM_LEVEL — algorithm-level necessary conditions on:
+//!
+//!   * a captured `apr trace --check-finite` stderr JSON describing the
+//!     first non-finite activation; and
+//!   * a captured `apr trace --check-finite --list` JSON enumerating every
+//!     tensor-producing op in the forward pass.
+//!
+//! Classifiers:
+//!   * `classify_error_json` — error body has the 6 required keys
+//!     (`error`, `layer`, `shape`, `first_bad_index`, `value`, `op`),
+//!     `error == "non_finite"`, and `value ∈ {"nan", "+inf", "-inf"}`.
+//!   * `classify_layer_coverage` — list body's `layers` array contains
+//!     at least `min_layers` entries and includes every transformer
+//!     op prefix in `required_op_prefixes` (default: attention_q,
+//!     attention_k, attention_v, attention_out, ffn_gate, ffn_up,
+//!     ffn_down, layernorm).
+//!
+//! FALSIFY-CRUX-F-11-001 (clean exit 0) and -004 (parity with torch
+//! anomaly mode) require live runs and are tracked as
+//! BLOCKER-UPSTREAM-MISSING.
+
+use serde_json::Value;
+
+/// Default transformer-op name prefixes that every layer-list emission
+/// must cover (CRUX-F-11 `layer_coverage_complete`).
+pub const F11_REQUIRED_OP_PREFIXES: &[&str] = &[
+    "attention_q",
+    "attention_k",
+    "attention_v",
+    "attention_out",
+    "ffn_gate",
+    "ffn_up",
+    "ffn_down",
+    "layernorm",
+];
+
+/// Required top-level keys on a CRUX-F-11 error JSON
+/// (`apr trace --check-finite` stderr on a poisoned model).
+pub const F11_ERROR_JSON_KEYS: &[&str] =
+    &["error", "layer", "shape", "first_bad_index", "value", "op"];
+
+/// Allowed values for the `value` field of an error JSON.
+pub const F11_ALLOWED_VALUES: &[&str] = &["nan", "+inf", "-inf"];
+
+/// Outcome of `classify_error_json`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CheckFiniteErrorOutcome {
+    Ok,
+    NotAnObject,
+    MissingKey { key: &'static str },
+    ErrorTagWrong { got: String },
+    ValueOutOfSet { got: String },
+    ShapeNotIntArray,
+    FirstBadIndexNotNonNegative { got: i64 },
+}
+
+/// Outcome of `classify_layer_coverage`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CheckFiniteCoverageOutcome {
+    Ok { count: usize },
+    NotAnObject,
+    LayersNotArray,
+    TooFewLayers { got: usize, min: usize },
+    MissingOpPrefixes { missing: Vec<String> },
+}
+
+/// Validate the error JSON body emitted on stderr when a non-finite
+/// activation is detected (FALSIFY-CRUX-F-11-002).
+pub fn classify_error_json(body: &Value) -> CheckFiniteErrorOutcome {
+    let Some(obj) = body.as_object() else {
+        return CheckFiniteErrorOutcome::NotAnObject;
+    };
+    for k in F11_ERROR_JSON_KEYS {
+        if !obj.contains_key(*k) {
+            return CheckFiniteErrorOutcome::MissingKey { key: k };
+        }
+    }
+    let err = obj.get("error").and_then(Value::as_str).unwrap_or("");
+    if err != "non_finite" {
+        return CheckFiniteErrorOutcome::ErrorTagWrong { got: err.to_string() };
+    }
+    let value = obj.get("value").and_then(Value::as_str).unwrap_or("");
+    if !F11_ALLOWED_VALUES.contains(&value) {
+        return CheckFiniteErrorOutcome::ValueOutOfSet { got: value.to_string() };
+    }
+    let Some(shape) = obj.get("shape").and_then(Value::as_array) else {
+        return CheckFiniteErrorOutcome::ShapeNotIntArray;
+    };
+    for dim in shape {
+        if dim.as_i64().is_none() {
+            return CheckFiniteErrorOutcome::ShapeNotIntArray;
+        }
+    }
+    let idx = obj.get("first_bad_index").and_then(Value::as_i64).unwrap_or(-1);
+    if idx < 0 {
+        return CheckFiniteErrorOutcome::FirstBadIndexNotNonNegative { got: idx };
+    }
+    CheckFiniteErrorOutcome::Ok
+}
+
+/// Validate the layer-coverage JSON emitted on stdout when
+/// `--check-finite --list` is requested (FALSIFY-CRUX-F-11-003).
+pub fn classify_layer_coverage(
+    body: &Value,
+    min_layers: usize,
+    required_op_prefixes: &[&str],
+) -> CheckFiniteCoverageOutcome {
+    let Some(obj) = body.as_object() else {
+        return CheckFiniteCoverageOutcome::NotAnObject;
+    };
+    let Some(layers) = obj.get("layers").and_then(Value::as_array) else {
+        return CheckFiniteCoverageOutcome::LayersNotArray;
+    };
+    let count = layers.len();
+    if count < min_layers {
+        return CheckFiniteCoverageOutcome::TooFewLayers { got: count, min: min_layers };
+    }
+    // Collect every layer name (`name` field, otherwise the layer entry
+    // itself if it is a bare string).
+    let mut names: Vec<String> = Vec::new();
+    for l in layers {
+        if let Some(n) = l.get("name").and_then(Value::as_str) {
+            names.push(n.to_string());
+        } else if let Some(n) = l.as_str() {
+            names.push(n.to_string());
+        }
+    }
+    let mut missing: Vec<String> = required_op_prefixes
+        .iter()
+        .filter(|p| !names.iter().any(|n| n.contains(**p)))
+        .map(|s| (*s).to_string())
+        .collect();
+    if !missing.is_empty() {
+        missing.sort();
+        return CheckFiniteCoverageOutcome::MissingOpPrefixes { missing };
+    }
+    CheckFiniteCoverageOutcome::Ok { count }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn good_error_json() -> Value {
+        json!({
+            "error": "non_finite",
+            "layer": "blk.0.ffn_up",
+            "shape": [1, 4096],
+            "first_bad_index": 0,
+            "value": "nan",
+            "op": "ffn_up"
+        })
+    }
+
+    fn good_layer_list(n_blocks: usize) -> Value {
+        let mut layers: Vec<Value> = Vec::new();
+        for b in 0..n_blocks {
+            for op in &[
+                "attention_q",
+                "attention_k",
+                "attention_v",
+                "attention_out",
+                "ffn_gate",
+                "ffn_up",
+                "ffn_down",
+                "layernorm_in",
+                "layernorm_post",
+            ] {
+                layers.push(json!({"name": format!("blk.{b}.{op}"), "shape": [1, 4096]}));
+            }
+        }
+        layers.push(json!({"name": "embed_tokens", "shape": [1, 4096]}));
+        layers.push(json!({"name": "output_norm", "shape": [1, 4096]}));
+        layers.push(json!({"name": "lm_head", "shape": [1, 32000]}));
+        json!({"layers": layers})
+    }
+
+    #[test]
+    fn error_json_ok_on_well_formed() {
+        assert_eq!(classify_error_json(&good_error_json()), CheckFiniteErrorOutcome::Ok);
+    }
+
+    #[test]
+    fn error_json_rejects_not_an_object() {
+        assert_eq!(
+            classify_error_json(&json!([1, 2])),
+            CheckFiniteErrorOutcome::NotAnObject
+        );
+    }
+
+    #[test]
+    fn error_json_reports_missing_key() {
+        let body = json!({"error": "non_finite", "shape": [1], "first_bad_index": 0, "value": "nan", "op": "x"});
+        assert_eq!(
+            classify_error_json(&body),
+            CheckFiniteErrorOutcome::MissingKey { key: "layer" }
+        );
+    }
+
+    #[test]
+    fn error_json_rejects_wrong_error_tag() {
+        let body = json!({"error": "weird_other", "layer": "L", "shape": [1], "first_bad_index": 0, "value": "nan", "op": "x"});
+        assert!(matches!(
+            classify_error_json(&body),
+            CheckFiniteErrorOutcome::ErrorTagWrong { .. }
+        ));
+    }
+
+    #[test]
+    fn error_json_rejects_value_outside_allowed_set() {
+        let body = json!({"error": "non_finite", "layer": "L", "shape": [1], "first_bad_index": 0, "value": "banana", "op": "x"});
+        assert!(matches!(
+            classify_error_json(&body),
+            CheckFiniteErrorOutcome::ValueOutOfSet { .. }
+        ));
+    }
+
+    #[test]
+    fn error_json_rejects_non_int_shape() {
+        let body = json!({"error": "non_finite", "layer": "L", "shape": ["wide"], "first_bad_index": 0, "value": "nan", "op": "x"});
+        assert_eq!(
+            classify_error_json(&body),
+            CheckFiniteErrorOutcome::ShapeNotIntArray
+        );
+    }
+
+    #[test]
+    fn error_json_rejects_negative_first_bad_index() {
+        let body = json!({"error": "non_finite", "layer": "L", "shape": [1], "first_bad_index": -1, "value": "nan", "op": "x"});
+        assert!(matches!(
+            classify_error_json(&body),
+            CheckFiniteErrorOutcome::FirstBadIndexNotNonNegative { got: -1 }
+        ));
+    }
+
+    #[test]
+    fn layer_coverage_ok_on_well_formed_list() {
+        // 28 blocks × 9 ops + 3 extras = 255 — easily clears 100.
+        let body = good_layer_list(28);
+        match classify_layer_coverage(&body, 100, F11_REQUIRED_OP_PREFIXES) {
+            CheckFiniteCoverageOutcome::Ok { count } => assert_eq!(count, 28 * 9 + 3),
+            other => panic!("expected Ok, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn layer_coverage_rejects_not_an_object() {
+        assert_eq!(
+            classify_layer_coverage(&json!([1, 2]), 100, F11_REQUIRED_OP_PREFIXES),
+            CheckFiniteCoverageOutcome::NotAnObject
+        );
+    }
+
+    #[test]
+    fn layer_coverage_rejects_missing_layers_array() {
+        assert_eq!(
+            classify_layer_coverage(&json!({"otherKey": []}), 100, F11_REQUIRED_OP_PREFIXES),
+            CheckFiniteCoverageOutcome::LayersNotArray
+        );
+    }
+
+    #[test]
+    fn layer_coverage_reports_too_few_layers() {
+        let body = good_layer_list(2); // 21 layers
+        assert!(matches!(
+            classify_layer_coverage(&body, 100, F11_REQUIRED_OP_PREFIXES),
+            CheckFiniteCoverageOutcome::TooFewLayers { got: 21, min: 100 }
+        ));
+    }
+
+    #[test]
+    fn layer_coverage_reports_missing_op_prefixes() {
+        // Only attention layers; FFN/LN missing.
+        let mut layers: Vec<Value> = Vec::new();
+        for b in 0..20 {
+            for op in &["attention_q", "attention_k", "attention_v", "attention_out"] {
+                layers.push(json!({"name": format!("blk.{b}.{op}")}));
+            }
+            // Pad so we hit the 100-layer floor without exercising FFN/LN.
+            for k in 0..5 {
+                layers.push(json!({"name": format!("blk.{b}.extra_{k}")}));
+            }
+        }
+        let body = json!({"layers": layers});
+        match classify_layer_coverage(&body, 100, F11_REQUIRED_OP_PREFIXES) {
+            CheckFiniteCoverageOutcome::MissingOpPrefixes { missing } => {
+                assert!(missing.contains(&"ffn_gate".to_string()));
+                assert!(missing.contains(&"layernorm".to_string()));
+                assert!(!missing.contains(&"attention_q".to_string()));
+            }
+            other => panic!("expected MissingOpPrefixes, got {other:?}"),
+        }
+    }
+}

--- a/crates/apr-cli/src/commands/check_finite_lint.rs
+++ b/crates/apr-cli/src/commands/check_finite_lint.rs
@@ -1,0 +1,116 @@
+//! `apr check-finite-lint` — CRUX-F-11 NaN/Inf activation-check gate.
+//!
+//! Reads an already-captured `apr trace --check-finite` (error JSON on
+//! stderr from a poisoned model) and/or `apr trace --check-finite --list`
+//! (layer coverage on stdout) body and dispatches the pure classifiers in
+//! `check_finite_classifier`. Exits non-zero on any failure.
+//!
+//! Spec: `contracts/crux-F-11-v1.yaml`. CRUX-SHIP-001 g2/g3 surface.
+
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+
+use super::check_finite_classifier::{
+    classify_error_json, classify_layer_coverage, CheckFiniteCoverageOutcome,
+    CheckFiniteErrorOutcome, F11_REQUIRED_OP_PREFIXES,
+};
+use crate::error::{CliError, Result};
+
+pub(crate) fn run(
+    error_file: Option<&Path>,
+    list_file: Option<&Path>,
+    min_layers: usize,
+    json: bool,
+) -> Result<()> {
+    if error_file.is_none() && list_file.is_none() {
+        return Err(CliError::ValidationFailed(
+            "apr check-finite-lint: at least one of --error-file or --list-file is required"
+                .to_string(),
+        ));
+    }
+
+    let err_outcome = match error_file {
+        Some(p) => {
+            if !p.exists() {
+                return Err(CliError::FileNotFound(PathBuf::from(p)));
+            }
+            let body_text = std::fs::read_to_string(p)?;
+            let body: Value = serde_json::from_str(&body_text).map_err(|e| {
+                CliError::InvalidFormat(format!(
+                    "apr check-finite-lint: failed to parse error JSON from {}: {e}",
+                    p.display()
+                ))
+            })?;
+            Some(classify_error_json(&body))
+        }
+        None => None,
+    };
+
+    let cov_outcome = match list_file {
+        Some(p) => {
+            if !p.exists() {
+                return Err(CliError::FileNotFound(PathBuf::from(p)));
+            }
+            let body_text = std::fs::read_to_string(p)?;
+            let body: Value = serde_json::from_str(&body_text).map_err(|e| {
+                CliError::InvalidFormat(format!(
+                    "apr check-finite-lint: failed to parse list JSON from {}: {e}",
+                    p.display()
+                ))
+            })?;
+            Some(classify_layer_coverage(&body, min_layers, F11_REQUIRED_OP_PREFIXES))
+        }
+        None => None,
+    };
+
+    print_report(error_file, list_file, err_outcome.as_ref(), cov_outcome.as_ref(), json);
+
+    if let Some(o) = &err_outcome {
+        if !matches!(o, CheckFiniteErrorOutcome::Ok) {
+            return Err(CliError::ValidationFailed(format!(
+                "check-finite-lint error-json gate rejected body: {o:?}"
+            )));
+        }
+    }
+    if let Some(o) = &cov_outcome {
+        if !matches!(o, CheckFiniteCoverageOutcome::Ok { .. }) {
+            return Err(CliError::ValidationFailed(format!(
+                "check-finite-lint layer-coverage gate rejected body: {o:?}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn print_report(
+    error_file: Option<&Path>,
+    list_file: Option<&Path>,
+    err: Option<&CheckFiniteErrorOutcome>,
+    cov: Option<&CheckFiniteCoverageOutcome>,
+    json: bool,
+) {
+    if json {
+        let obj = serde_json::json!({
+            "error_file": error_file.map(|p| p.display().to_string()),
+            "list_file": list_file.map(|p| p.display().to_string()),
+            "error_json": err.map(|o| format!("{o:?}")),
+            "layer_coverage": cov.map(|o| format!("{o:?}")),
+        });
+        println!("{}", serde_json::to_string_pretty(&obj).unwrap_or_default());
+        return;
+    }
+    println!("check-finite-lint report");
+    if let Some(p) = error_file {
+        println!("  error_file    : {}", p.display());
+    }
+    if let Some(p) = list_file {
+        println!("  list_file     : {}", p.display());
+    }
+    if let Some(o) = err {
+        println!("  error_json    : {o:?}");
+    }
+    if let Some(o) = cov {
+        println!("  layer_coverage: {o:?}");
+    }
+}

--- a/crates/apr-cli/src/commands/mod.rs
+++ b/crates/apr-cli/src/commands/mod.rs
@@ -15,6 +15,8 @@ pub mod canary;
 pub mod cbtop;
 pub mod chat;
 pub mod check;
+pub(crate) mod check_finite_classifier;
+pub(crate) mod check_finite_lint;
 pub mod compare_hf;
 pub(crate) mod compile;
 pub(crate) mod convert;

--- a/crates/apr-cli/src/dispatch_analysis.rs
+++ b/crates/apr-cli/src/dispatch_analysis.rs
@@ -172,6 +172,17 @@ fn dispatch_analysis_commands(cli: &Cli) -> Option<Result<(), CliError>> {
             require_greedy,
         } => commands::explain_token_lint::run(jsonl_file, *tolerance, *require_greedy, cli.json),
 
+        ExtendedCommands::CheckFiniteLint {
+            error_file,
+            list_file,
+            min_layers,
+        } => commands::check_finite_lint::run(
+            error_file.as_deref(),
+            list_file.as_deref(),
+            *min_layers,
+            cli.json,
+        ),
+
         ExtendedCommands::OtlpLint {
             otlp_file,
             require_apr_span,

--- a/crates/apr-cli/src/extended_commands.rs
+++ b/crates/apr-cli/src/extended_commands.rs
@@ -784,6 +784,18 @@ pub enum ExtendedCommands {
         #[arg(long, value_name = "FILE")]
         stderr_file: Option<PathBuf>,
     },
+    /// Lint a captured `apr trace --check-finite` error JSON and/or `--list` coverage JSON (CRUX-F-11)
+    CheckFiniteLint {
+        /// Captured stderr JSON from `apr trace --check-finite` on a poisoned model
+        #[arg(long, value_name = "FILE")]
+        error_file: Option<PathBuf>,
+        /// Captured stdout JSON from `apr trace --check-finite --list`
+        #[arg(long, value_name = "FILE")]
+        list_file: Option<PathBuf>,
+        /// Minimum layer-coverage count when `--list-file` is supplied (default 100)
+        #[arg(long, value_name = "N", default_value_t = 100)]
+        min_layers: usize,
+    },
     /// Lint a captured `apr explain --format jsonl` token-selection trace (CRUX-F-19)
     ExplainTokenLint {
         /// Path to captured JSONL body (one sampled-token record per line)

--- a/crates/apr-cli/tests/cli_commands.rs
+++ b/crates/apr-cli/tests/cli_commands.rs
@@ -117,6 +117,7 @@ fn registered_commands() -> Vec<&'static str> {
         "kv-timeline-lint",
         "gpu-memtrace-lint",
         "explain-token-lint",
+        "check-finite-lint",
         "shard",
         "unshard",
         "oracle",

--- a/crates/apr-cli/tests/falsification_crux_f_11.rs
+++ b/crates/apr-cli/tests/falsification_crux_f_11.rs
@@ -1,0 +1,249 @@
+//! CRUX-F-11 — end-to-end falsification harness for `apr check-finite-lint`.
+//!
+//! CRUX-SHIP-001 gate g3 evidence: every FALSIFY-CRUX-F-11-{002,003} gate the
+//! classifier discharges has a matching captured JSON body that the binary
+//! must classify exactly as the harness expects.
+
+use serde_json::json;
+use std::io::Write;
+use std::process::Command;
+
+fn apr_binary() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_apr"));
+    cmd.env("NO_COLOR", "1");
+    cmd
+}
+
+fn write_json(body: &serde_json::Value) -> tempfile::NamedTempFile {
+    let mut f = tempfile::Builder::new()
+        .prefix("crux-f-11-")
+        .suffix(".json")
+        .tempfile()
+        .expect("tempfile");
+    f.write_all(serde_json::to_vec_pretty(body).expect("serialize").as_slice())
+        .expect("write");
+    f.flush().expect("flush");
+    f
+}
+
+fn good_error_json() -> serde_json::Value {
+    json!({
+        "error": "non_finite",
+        "layer": "blk.0.ffn_up",
+        "shape": [1, 4096],
+        "first_bad_index": 0,
+        "value": "nan",
+        "op": "ffn_up"
+    })
+}
+
+fn good_layer_list(n_blocks: usize) -> serde_json::Value {
+    let mut layers: Vec<serde_json::Value> = Vec::new();
+    for b in 0..n_blocks {
+        for op in &[
+            "attention_q",
+            "attention_k",
+            "attention_v",
+            "attention_out",
+            "ffn_gate",
+            "ffn_up",
+            "ffn_down",
+            "layernorm_in",
+            "layernorm_post",
+        ] {
+            layers.push(json!({"name": format!("blk.{b}.{op}"), "shape": [1, 4096]}));
+        }
+    }
+    layers.push(json!({"name": "embed_tokens"}));
+    layers.push(json!({"name": "output_norm"}));
+    layers.push(json!({"name": "lm_head"}));
+    json!({"layers": layers})
+}
+
+// ===== g2: CLI shape =====
+
+#[test]
+fn falsify_crux_f_11_cli_help_advertises_flags() {
+    let out = apr_binary().args(["check-finite-lint", "--help"]).output().expect("run");
+    assert!(out.status.success(), "--help must exit 0");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("--error-file"), "--help must advertise --error-file; got:\n{stdout}");
+    assert!(stdout.contains("--list-file"), "--help must advertise --list-file; got:\n{stdout}");
+    assert!(stdout.contains("--min-layers"), "--help must advertise --min-layers; got:\n{stdout}");
+}
+
+#[test]
+fn falsify_crux_f_11_cli_requires_at_least_one_file() {
+    let out = apr_binary().args(["check-finite-lint"]).output().expect("run");
+    assert!(!out.status.success(), "bare invocation must not exit 0");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("at least one of --error-file or --list-file"),
+        "stderr must explain the requirement; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn falsify_crux_f_11_cli_missing_error_file_fails() {
+    let out = apr_binary()
+        .args(["check-finite-lint", "--error-file", "/nonexistent/crux-f-11-missing.json"])
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "missing error-file must not exit 0");
+}
+
+// ===== g3: classifier discharges =====
+
+#[test]
+fn falsify_crux_f_11_002_error_json_ok_on_well_formed() {
+    let f = write_json(&good_error_json());
+    let out = apr_binary()
+        .args(["check-finite-lint", "--error-file"])
+        .arg(f.path())
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "good error JSON must pass; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn falsify_crux_f_11_002_error_json_rejects_missing_layer() {
+    let mut body = good_error_json();
+    body.as_object_mut().expect("obj").remove("layer");
+    let f = write_json(&body);
+    let out = apr_binary()
+        .args(["check-finite-lint", "--error-file"])
+        .arg(f.path())
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "missing layer key must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("MissingKey") && stderr.contains("layer"),
+        "stderr must name MissingKey(layer); got:\n{stderr}"
+    );
+}
+
+#[test]
+fn falsify_crux_f_11_002_error_json_rejects_wrong_error_tag() {
+    let mut body = good_error_json();
+    body["error"] = json!("weird_other");
+    let f = write_json(&body);
+    let out = apr_binary()
+        .args(["check-finite-lint", "--error-file"])
+        .arg(f.path())
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "wrong error tag must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("ErrorTagWrong"), "stderr must name ErrorTagWrong; got:\n{stderr}");
+}
+
+#[test]
+fn falsify_crux_f_11_002_error_json_rejects_value_out_of_set() {
+    let mut body = good_error_json();
+    body["value"] = json!("banana");
+    let f = write_json(&body);
+    let out = apr_binary()
+        .args(["check-finite-lint", "--error-file"])
+        .arg(f.path())
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "value outside set must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("ValueOutOfSet"), "stderr must name ValueOutOfSet; got:\n{stderr}");
+}
+
+#[test]
+fn falsify_crux_f_11_003_layer_coverage_ok_on_well_formed() {
+    let f = write_json(&good_layer_list(28));
+    let out = apr_binary()
+        .args(["check-finite-lint", "--list-file"])
+        .arg(f.path())
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "good layer list must pass; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn falsify_crux_f_11_003_layer_coverage_rejects_too_few() {
+    let f = write_json(&good_layer_list(2));
+    let out = apr_binary()
+        .args(["check-finite-lint", "--list-file"])
+        .arg(f.path())
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "too-few-layers must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("TooFewLayers"), "stderr must name TooFewLayers; got:\n{stderr}");
+}
+
+#[test]
+fn falsify_crux_f_11_003_layer_coverage_rejects_missing_op_prefixes() {
+    // 100 attention-only layers; FFN/LN absent.
+    let mut layers: Vec<serde_json::Value> = Vec::new();
+    for b in 0..20 {
+        for op in &["attention_q", "attention_k", "attention_v", "attention_out"] {
+            layers.push(json!({"name": format!("blk.{b}.{op}")}));
+        }
+        for k in 0..5 {
+            layers.push(json!({"name": format!("blk.{b}.extra_{k}")}));
+        }
+    }
+    let f = write_json(&json!({"layers": layers}));
+    let out = apr_binary()
+        .args(["check-finite-lint", "--list-file"])
+        .arg(f.path())
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "missing op prefixes must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("MissingOpPrefixes") && stderr.contains("ffn_gate"),
+        "stderr must name MissingOpPrefixes with ffn_gate; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn falsify_crux_f_11_min_layers_threshold_is_configurable() {
+    // Set --min-layers 10; the 2-block list (21 layers) should now pass on count.
+    let f = write_json(&good_layer_list(2));
+    let out = apr_binary()
+        .args(["check-finite-lint", "--list-file"])
+        .arg(f.path())
+        .args(["--min-layers", "10"])
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "10-layer floor must accept 21-layer list; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+// ===== JSON output shape =====
+
+#[test]
+fn falsify_crux_f_11_json_output_contains_outcomes() {
+    let ef = write_json(&good_error_json());
+    let lf = write_json(&good_layer_list(28));
+    let out = apr_binary()
+        .args(["--json", "check-finite-lint", "--error-file"])
+        .arg(ef.path())
+        .arg("--list-file")
+        .arg(lf.path())
+        .output()
+        .expect("run");
+    assert!(out.status.success(), "json + good bodies must exit 0");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("json output must parse");
+    assert!(parsed["error_json"].as_str().expect("error_json").contains("Ok"));
+    assert!(parsed["layer_coverage"].as_str().expect("layer_coverage").contains("Ok"));
+}


### PR DESCRIPTION
## Summary

- Promotes \`contracts/crux-F-11-v1.yaml\` from \`draft\` → PARTIAL_ALGORITHM_LEVEL.
- Adds \`apr check-finite-lint [--error-file F] [--list-file F] [--min-layers N]\` — pure-function classifier validating: error JSON shape from \`apr trace --check-finite\` on a poisoned model (6 required keys, error tag, value ∈ {nan,+inf,-inf}, shape, first_bad_index) AND/OR layer coverage list from \`--list\` (min_layers + transformer-op prefixes).
- 12 classifier unit tests + 12 e2e falsification tests + 8 cli_commands surface tests all pass.

Discharges FALSIFY-CRUX-F-11-{002,003} at PARTIAL_ALGORITHM_LEVEL. -001 (clean exit 0) and -004 (parity with torch anomaly) require a live emitter + poisoned-weight harness.

## Test plan

- [x] \`cargo test -p apr-cli --lib check_finite_classifier\` — 12/12 pass.
- [x] \`cargo test -p apr-cli --test falsification_crux_f_11\` — 12/12 pass.
- [x] \`cargo test -p apr-cli --test cli_commands\` — 8/8 pass (3-surface drift policy).
- [x] \`pv validate contracts/crux-F-11-v1.yaml\` — clean.
- [ ] CI green on \`ci / gate\` + \`workspace-test\`.

Refs #921 (CRUX M4 observability epic), #917 (CRUX Phase 3 umbrella).

🤖 Generated with [Claude Code](https://claude.com/claude-code)