### PR TITLE
feat(contracts): extend ContractKind for training-precondition-gate + corpus-assembly (unblocks #1722 #1723)

### DIFF
--- a/crates/aprender-contracts/src/schema/kind.rs
+++ b/crates/aprender-contracts/src/schema/kind.rs
@@ -25,6 +25,13 @@ use serde::{Deserialize, Serialize};
 ///   provability; validated for `metadata` + schedule fields.
 /// - `PretrainingCorpus`: a pretraining-corpus contract — dataset source,
 ///   license, total-bytes bound, shard layout. Exempt from provability.
+/// - `TrainingPreconditionGate`: a hard precondition gate that must be
+///   satisfied before training starts (e.g. Chinchilla compute-optimal
+///   token/parameter ratio, GPU memory floor, dataset checksum). Exempt
+///   from provability; validated for `metadata` + gate-formula fields.
+/// - `CorpusAssembly`: a multi-source corpus assembly pipeline contract —
+///   declares input shards, dedup strategy, license-merge policy, and
+///   output manifest. Exempt from provability.
 /// - `Pattern`: a cross-cutting verification pattern (threading safety,
 ///   async safety, compute parity) that applies across multiple kernels.
 ///   Exempt from the kernel provability invariant but still validated for
@@ -45,6 +52,8 @@ pub enum ContractKind {
     Tokenizer,
     TrainingLoop,
     PretrainingCorpus,
+    TrainingPreconditionGate,
+    CorpusAssembly,
     Pattern,
     Schema,
 }
@@ -59,6 +68,8 @@ impl std::fmt::Display for ContractKind {
             Self::Tokenizer => "tokenizer",
             Self::TrainingLoop => "training-loop",
             Self::PretrainingCorpus => "pretraining-corpus",
+            Self::TrainingPreconditionGate => "training-precondition-gate",
+            Self::CorpusAssembly => "corpus-assembly",
             Self::Pattern => "pattern",
             Self::Schema => "schema",
         };

--- a/crates/aprender-contracts/src/schema/types_tests.rs
+++ b/crates/aprender-contracts/src/schema/types_tests.rs
@@ -67,6 +67,11 @@ fn contract_kind_display() {
         ContractKind::PretrainingCorpus.to_string(),
         "pretraining-corpus",
     );
+    assert_eq!(
+        ContractKind::TrainingPreconditionGate.to_string(),
+        "training-precondition-gate",
+    );
+    assert_eq!(ContractKind::CorpusAssembly.to_string(), "corpus-assembly");
     assert_eq!(ContractKind::Pattern.to_string(), "pattern");
     assert_eq!(ContractKind::Schema.to_string(), "schema");
 }
@@ -97,6 +102,8 @@ fn non_kernel_kinds_exempt_from_provability() {
         ContractKind::Tokenizer,
         ContractKind::TrainingLoop,
         ContractKind::PretrainingCorpus,
+        ContractKind::TrainingPreconditionGate,
+        ContractKind::CorpusAssembly,
         ContractKind::Pattern,
         ContractKind::Schema,
     ] {


### PR DESCRIPTION
## Summary

- Adds \`TrainingPreconditionGate\` and \`CorpusAssembly\` variants to \`ContractKind\` so PR #1722 (chinchilla-gate-v1.yaml) and #1723 (corpus-merge-v3-v1.yaml) workspace-test failures unblock simultaneously.
- Both new kinds are exempt-from-provability shells (same pattern as \`TrainingLoop\` / \`PretrainingCorpus\`).
- Non-breaking: no exhaustive \`match\` on \`ContractKind\` in the codebase.

Root cause: both PRs introduce contracts whose \`metadata.kind\` value is not in the schema:

\`\`\`
thread panicked: 'No parse errors expected:
  [("chinchilla-gate-v1", "Failed to parse YAML: metadata.kind:
    unknown variant \`training-precondition-gate\`, ...")]'
\`\`\`

Per memory rule: \"If pv validate rejects a contract... extend aprender-contracts/src/schema/ to add the new kind.\"

## Test plan

- [x] \`cargo test -p aprender-contracts --lib\` — 1392 pass, 0 fail (includes contract_kind_display + non_kernel_kinds_exempt_from_provability extended for the 2 new variants).
- [ ] CI green on \`ci / gate\` + \`workspace-test\`.
- [ ] Re-test #1722 + #1723 against this main after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)