### PR TITLE
feat(apr-cli): CRUX-F-17 `apr attn-viz-lint` attention visualization classifier

### DIFF
--- a/contracts/apr-cli-commands-v1.yaml
+++ b/contracts/apr-cli-commands-v1.yaml
@@ -574,6 +574,12 @@ commands:
     requires_model: false
     side_effects: []
 
+  - name: attn-viz-lint
+    category: inspection
+    description: "Validate captured `apr attn-viz` outputs (CRUX-F-17): 4-D attention dump row-softmax normalization + causal-mask zero + HTML heatmap count"
+    requires_model: false
+    side_effects: []
+
   - name: shard
     category: model_ops
     description: "Split safetensors file into shards + weight-map index (CRUX-B-05)"

--- a/contracts/crux-F-17-v1.yaml
+++ b/contracts/crux-F-17-v1.yaml
@@ -1,12 +1,20 @@
 # CRUX-F-17 — Attention pattern visualization
+# Promoted to PARTIAL_ALGORITHM_LEVEL at v1.2.0 under CRUX-SHIP-001 (2026-05-17):
+# - classifier: crates/apr-cli/src/commands/attn_viz_classifier.rs (9 unit tests)
+# - CLI surface: `apr attn-viz-lint [--attn-file F] [--html-file F] [--expected-heatmaps N] [--tolerance F] [--epsilon F]`
+# - e2e: crates/apr-cli/tests/falsification_crux_f_17.rs (9 tests)
+# Full discharge requires a live `apr attn-viz` emitter writing the
+# attention dump (JSON form) + HTML — tracked as BLOCKER-UPSTREAM-MISSING.
 
 metadata:
   id: CRUX-F-17
-  version: "1.1.0"
+  version: "1.2.0"
   created: "2026-04-18"
+  updated: "2026-05-17"
   author: PAIML Engineering
   registry: true
-  status: draft
+  status: partial
+  kind: kernel
   parent_contracts:
   - crux-competitive-research-ux-v1
   category: "F — Tensor Ops & Low-level"
@@ -52,6 +60,25 @@ falsification_tests:
     assert np.allclose(sums, 1.0, atol=1e-5), (sums.min(), sums.max())
     PY
   if_fails: rule 'attention rows are proper distributions' is violated — contract MUST be re-verified against competitor canonical reference
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/attn_viz_classifier.rs
+    cli_path: crates/apr-cli/src/commands/attn_viz_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_f_17.rs
+    e2e_tests:
+    - falsify_crux_f_17_001_row_softmax_ok_on_good_dump
+    - falsify_crux_f_17_001_row_softmax_rejects_unnormalized
+    - falsify_crux_f_17_tolerance_relaxes_row_softmax_gate
+    sub_claim: |
+      Algorithm-level necessary condition on the captured attention dump
+      (JSON form, 4-D `[layers][heads][rows][cols]` floats):
+      `classify_row_softmax_normalization` verifies `Σ_j attn[l,h,i,j] ≈ 1.0`
+      within `tolerance` (default 1e-5, configurable). The outcome
+      `RowOutOfNormalization { layer, head, row, sum, tolerance }`
+      pinpoints the offending slice so emitter bugs are debuggable
+      from the lint output alone.
+    scope: "(body, tolerance) -> AttnRowsOutcome (pure)"
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: "live `apr attn-viz` emitter writing the attention dump"
 - id: FALSIFY-CRUX-F-17-002
   rule: causal mask zeroes future positions
   prediction: "upper-triangular positions (j > i) are ≤ 1e-9"
@@ -65,6 +92,22 @@ falsification_tests:
     assert (a[..., mask] <= 1e-9).all(), a[..., mask].max()
     PY
   if_fails: rule 'causal mask zeroes future positions' is violated — contract MUST be re-verified against competitor canonical reference
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/attn_viz_classifier.rs
+    cli_path: crates/apr-cli/src/commands/attn_viz_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_f_17.rs
+    e2e_tests:
+    - falsify_crux_f_17_002_causal_mask_rejects_nonzero_future
+    sub_claim: |
+      Algorithm-level necessary condition: `classify_causal_mask` walks
+      the 4-D dump and rejects with `NonZeroFuturePosition { layer,
+      head, row, col, value, epsilon }` on the first `(i, j)` with
+      `j > i` and `|attn[l,h,i,j]| > epsilon` (default 1e-9,
+      configurable). Mask leaks indicate either a missing pre-softmax
+      `-inf` mask injection or an off-by-one in the triangular mask.
+    scope: "(body, epsilon) -> AttnCausalMaskOutcome (pure)"
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: "live `apr attn-viz` emitter writing causal-masked attention"
 - id: FALSIFY-CRUX-F-17-003
   rule: HTML output contains one heatmap per requested head
   prediction: "html contains |layers|*|heads| canvas/svg elements"
@@ -74,6 +117,23 @@ falsification_tests:
     python3 -c "assert $n >= 4, $n"
 
   if_fails: rule 'HTML output contains one heatmap per requested head' is violated — contract MUST be re-verified against competitor canonical reference
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/attn_viz_classifier.rs
+    cli_path: crates/apr-cli/src/commands/attn_viz_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_f_17.rs
+    e2e_tests:
+    - falsify_crux_f_17_003_html_heatmap_count_ok_when_threshold_met
+    - falsify_crux_f_17_003_html_heatmap_count_rejects_too_few
+    sub_claim: |
+      Algorithm-level necessary condition: `classify_html_heatmap_count`
+      counts `<svg` and `<canvas` open-tags in the HTML body (tolerant
+      of attributes between the tag name and `>`) and rejects when
+      total < `|layers| * |heads|` (default 1, caller-configured).
+      The outcome reports the actual count so the emitter's coverage
+      gap is debuggable from lint output.
+    scope: "(html, expected) -> AttnHtmlOutcome (pure)"
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: "live `apr attn-viz` emitter writing the per-head heatmap HTML"
 proof_obligations:
 - type: equivalence
   property: "apr attn-viz attention values match HF `output_attentions=True` to 1e-5 on same model+prompt"

--- a/crates/apr-cli/src/commands/attn_viz_classifier.rs
+++ b/crates/apr-cli/src/commands/attn_viz_classifier.rs
@@ -1,0 +1,292 @@
+//! Attention pattern visualization classifier (CRUX-F-17).
+//!
+//! Pure, deterministic classifiers that discharge FALSIFY-CRUX-F-17-{001,002,003}
+//! at the PARTIAL_ALGORITHM_LEVEL — algorithm-level necessary conditions on:
+//!
+//!   * a captured attention dump in JSON form (4-D array
+//!     `[layers][heads][rows][cols]` of floats) — converted from the
+//!     spec's binary `attn.npy` via
+//!     `python3 -c "import numpy as np, json; json.dump(np.load('attn.npy').tolist(), open('attn.json','w'))"`
+//!   * the HTML heatmap output from `apr attn-viz --out DIR`.
+//!
+//! Classifiers:
+//!   * `classify_row_softmax_normalization` — every row in every
+//!     `(layer, head)` slice sums to 1.0 ± tolerance (default 1e-5).
+//!   * `classify_causal_mask` — for every `(layer, head, i, j)` with
+//!     `j > i`, the value is ≤ epsilon (default 1e-9) — the causal
+//!     mask must zero future positions before softmax.
+//!   * `classify_html_heatmap_count` — the HTML body contains at
+//!     least `expected` `<svg` or `<canvas` open-tags (one per
+//!     `(layer, head)` cell).
+//!
+//! Full discharge requires `apr attn-viz` actually emitting the
+//! attention dump + HTML — tracked as BLOCKER-UPSTREAM-MISSING.
+
+use serde_json::Value;
+
+/// Outcome of `classify_row_softmax_normalization`.
+#[derive(Debug, Clone, PartialEq)]
+pub enum AttnRowsOutcome {
+    Ok { shape: (usize, usize, usize, usize) },
+    NotA4DArray { message: String },
+    RowOutOfNormalization {
+        layer: usize,
+        head: usize,
+        row: usize,
+        sum: f64,
+        tolerance: f64,
+    },
+}
+
+/// Outcome of `classify_causal_mask`.
+#[derive(Debug, Clone, PartialEq)]
+pub enum AttnCausalMaskOutcome {
+    Ok,
+    NonZeroFuturePosition {
+        layer: usize,
+        head: usize,
+        row: usize,
+        col: usize,
+        value: f64,
+        epsilon: f64,
+    },
+}
+
+/// Outcome of `classify_html_heatmap_count`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AttnHtmlOutcome {
+    Ok { count: usize },
+    TooFewHeatmaps { got: usize, expected: usize },
+}
+
+/// Parse a 4-D `Vec<Vec<Vec<Vec<f64>>>>` from `body` (typically `attn.json`).
+/// Returns the array and its shape as `(L, H, R, C)`.
+fn parse_4d_array(body: &Value) -> Result<(Vec<Vec<Vec<Vec<f64>>>>, (usize, usize, usize, usize)), String> {
+    let layers = body.as_array().ok_or_else(|| "root is not an array".to_string())?;
+    if layers.is_empty() {
+        return Err("layers dimension is empty".to_string());
+    }
+    let mut out: Vec<Vec<Vec<Vec<f64>>>> = Vec::with_capacity(layers.len());
+    let mut shape = (layers.len(), 0usize, 0usize, 0usize);
+    for (li, layer) in layers.iter().enumerate() {
+        let heads = layer.as_array().ok_or_else(|| format!("layer[{li}] not an array"))?;
+        let mut layer_vec: Vec<Vec<Vec<f64>>> = Vec::with_capacity(heads.len());
+        for (hi, head) in heads.iter().enumerate() {
+            let rows = head.as_array().ok_or_else(|| format!("layer[{li}].head[{hi}] not an array"))?;
+            let mut head_vec: Vec<Vec<f64>> = Vec::with_capacity(rows.len());
+            for (ri, row) in rows.iter().enumerate() {
+                let cols = row.as_array().ok_or_else(|| format!("layer[{li}].head[{hi}].row[{ri}] not an array"))?;
+                let mut row_vec: Vec<f64> = Vec::with_capacity(cols.len());
+                for (ci, c) in cols.iter().enumerate() {
+                    let v = c.as_f64().ok_or_else(|| {
+                        format!("layer[{li}].head[{hi}].row[{ri}].col[{ci}] not a number")
+                    })?;
+                    row_vec.push(v);
+                }
+                head_vec.push(row_vec);
+            }
+            layer_vec.push(head_vec);
+        }
+        if li == 0 {
+            shape.1 = layer_vec.len();
+            shape.2 = layer_vec.first().map(Vec::len).unwrap_or(0);
+            shape.3 = layer_vec.first().and_then(|h| h.first()).map(Vec::len).unwrap_or(0);
+        }
+        out.push(layer_vec);
+    }
+    Ok((out, shape))
+}
+
+/// Verify that every row in every (layer, head) slice sums to 1.0
+/// within `tolerance`.
+pub fn classify_row_softmax_normalization(body: &Value, tolerance: f64) -> AttnRowsOutcome {
+    let (arr, shape) = match parse_4d_array(body) {
+        Ok(v) => v,
+        Err(e) => return AttnRowsOutcome::NotA4DArray { message: e },
+    };
+    for (li, layer) in arr.iter().enumerate() {
+        for (hi, head) in layer.iter().enumerate() {
+            for (ri, row) in head.iter().enumerate() {
+                let s: f64 = row.iter().sum();
+                if (s - 1.0).abs() > tolerance {
+                    return AttnRowsOutcome::RowOutOfNormalization {
+                        layer: li,
+                        head: hi,
+                        row: ri,
+                        sum: s,
+                        tolerance,
+                    };
+                }
+            }
+        }
+    }
+    AttnRowsOutcome::Ok { shape }
+}
+
+/// Verify that the upper-triangular positions (j > i) are ≤ `epsilon`
+/// — causal mask must zero future positions before softmax.
+pub fn classify_causal_mask(body: &Value, epsilon: f64) -> AttnCausalMaskOutcome {
+    let arr = match parse_4d_array(body) {
+        Ok((v, _)) => v,
+        Err(_) => return AttnCausalMaskOutcome::Ok,
+    };
+    for (li, layer) in arr.iter().enumerate() {
+        for (hi, head) in layer.iter().enumerate() {
+            for (ri, row) in head.iter().enumerate() {
+                for (ci, &v) in row.iter().enumerate() {
+                    if ci > ri && v.abs() > epsilon {
+                        return AttnCausalMaskOutcome::NonZeroFuturePosition {
+                            layer: li,
+                            head: hi,
+                            row: ri,
+                            col: ci,
+                            value: v,
+                            epsilon,
+                        };
+                    }
+                }
+            }
+        }
+    }
+    AttnCausalMaskOutcome::Ok
+}
+
+/// Count the number of `<svg` or `<canvas` open-tags in the HTML body;
+/// require at least `expected` (typically `|layers| * |heads|`).
+pub fn classify_html_heatmap_count(html: &str, expected: usize) -> AttnHtmlOutcome {
+    let count = count_tag_opens(html, "<svg") + count_tag_opens(html, "<canvas");
+    if count >= expected {
+        AttnHtmlOutcome::Ok { count }
+    } else {
+        AttnHtmlOutcome::TooFewHeatmaps { got: count, expected }
+    }
+}
+
+fn count_tag_opens(haystack: &str, needle: &str) -> usize {
+    let mut n = 0usize;
+    let mut start = 0usize;
+    while let Some(idx) = haystack[start..].find(needle) {
+        n += 1;
+        start += idx + needle.len();
+    }
+    n
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    /// Build a (2,2,3,3) attention array with row-softmax normalized
+    /// and causal mask honored.
+    fn good_array() -> Value {
+        // (L=2, H=2, S=3, S=3); each row sums to 1, j > i is zero.
+        let row0 = json!([1.0, 0.0, 0.0]); // step 0 attends only to itself
+        let row1 = json!([0.4, 0.6, 0.0]); // step 1 attends to {0,1}
+        let row2 = json!([0.2, 0.3, 0.5]); // step 2 attends to {0,1,2}
+        let head = json!([row0.clone(), row1.clone(), row2.clone()]);
+        let layer = json!([head.clone(), head.clone()]);
+        json!([layer.clone(), layer.clone()])
+    }
+
+    #[test]
+    fn rows_softmax_ok_on_good_array() {
+        let out = classify_row_softmax_normalization(&good_array(), 1e-5);
+        assert!(matches!(out, AttnRowsOutcome::Ok { .. }), "{out:?}");
+    }
+
+    #[test]
+    fn rows_softmax_rejects_non_4d_input() {
+        let out = classify_row_softmax_normalization(&json!([1, 2, 3]), 1e-5);
+        assert!(matches!(out, AttnRowsOutcome::NotA4DArray { .. }), "{out:?}");
+    }
+
+    #[test]
+    fn rows_softmax_reports_unnormalized_row() {
+        // Sum to 1.2 on row 0 of layer 0 head 0.
+        let bad = json!([[[
+            [0.6, 0.6, 0.0],
+            [0.4, 0.6, 0.0],
+            [0.2, 0.3, 0.5]
+        ]]]);
+        match classify_row_softmax_normalization(&bad, 1e-5) {
+            AttnRowsOutcome::RowOutOfNormalization { layer: 0, head: 0, row: 0, sum, .. } => {
+                assert!((sum - 1.2).abs() < 1e-9, "got sum {sum}");
+            }
+            other => panic!("expected RowOutOfNormalization, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rows_softmax_tolerance_can_be_relaxed() {
+        // Sum to 1.01 — strict 1e-5 fails, relaxed 0.05 passes.
+        let body = json!([[[[0.51, 0.50, 0.0], [0.4, 0.6, 0.0], [0.2, 0.3, 0.5]]]]);
+        assert!(matches!(
+            classify_row_softmax_normalization(&body, 1e-5),
+            AttnRowsOutcome::RowOutOfNormalization { .. }
+        ));
+        assert!(matches!(
+            classify_row_softmax_normalization(&body, 0.05),
+            AttnRowsOutcome::Ok { .. }
+        ));
+    }
+
+    #[test]
+    fn causal_mask_ok_on_good_array() {
+        assert_eq!(
+            classify_causal_mask(&good_array(), 1e-9),
+            AttnCausalMaskOutcome::Ok
+        );
+    }
+
+    #[test]
+    fn causal_mask_reports_nonzero_future() {
+        // Row 0 has weight 0.5 on column 1 — future position leaks.
+        let body = json!([[[
+            [0.5, 0.5, 0.0],
+            [0.4, 0.6, 0.0],
+            [0.2, 0.3, 0.5]
+        ]]]);
+        match classify_causal_mask(&body, 1e-9) {
+            AttnCausalMaskOutcome::NonZeroFuturePosition {
+                layer: 0,
+                head: 0,
+                row: 0,
+                col: 1,
+                value,
+                ..
+            } => {
+                assert!((value - 0.5).abs() < 1e-9, "got value {value}");
+            }
+            other => panic!("expected NonZeroFuturePosition, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn html_heatmap_count_ok_when_threshold_met() {
+        let html = "<html><svg></svg><svg></svg><canvas></canvas><svg></svg></html>";
+        assert_eq!(
+            classify_html_heatmap_count(html, 4),
+            AttnHtmlOutcome::Ok { count: 4 }
+        );
+    }
+
+    #[test]
+    fn html_heatmap_count_reports_too_few() {
+        let html = "<html><svg></svg></html>";
+        assert_eq!(
+            classify_html_heatmap_count(html, 4),
+            AttnHtmlOutcome::TooFewHeatmaps { got: 1, expected: 4 }
+        );
+    }
+
+    #[test]
+    fn html_heatmap_count_handles_attributes_in_open_tag() {
+        // Real HTML has attributes between `<svg` and `>`.
+        let html = r#"<svg class="heatmap" width="200"></svg><svg id="b"></svg>"#;
+        assert_eq!(
+            classify_html_heatmap_count(html, 2),
+            AttnHtmlOutcome::Ok { count: 2 }
+        );
+    }
+}

--- a/crates/apr-cli/src/commands/attn_viz_lint.rs
+++ b/crates/apr-cli/src/commands/attn_viz_lint.rs
@@ -1,0 +1,134 @@
+//! `apr attn-viz-lint` — CRUX-F-17 attention-visualization gate.
+//!
+//! Reads a captured attention dump (JSON form of the 4-D
+//! `[layers][heads][rows][cols]` array) and/or an HTML heatmap output
+//! and dispatches the pure classifiers in `attn_viz_classifier`. Exits
+//! non-zero on any failure.
+//!
+//! Spec: `contracts/crux-F-17-v1.yaml`. CRUX-SHIP-001 g2/g3 surface.
+
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+
+use super::attn_viz_classifier::{
+    classify_causal_mask, classify_html_heatmap_count, classify_row_softmax_normalization,
+    AttnCausalMaskOutcome, AttnHtmlOutcome, AttnRowsOutcome,
+};
+use crate::error::{CliError, Result};
+
+pub(crate) fn run(
+    attn_file: Option<&Path>,
+    html_file: Option<&Path>,
+    expected_heatmaps: usize,
+    tolerance: f64,
+    epsilon: f64,
+    json: bool,
+) -> Result<()> {
+    if attn_file.is_none() && html_file.is_none() {
+        return Err(CliError::ValidationFailed(
+            "apr attn-viz-lint: at least one of --attn-file or --html-file is required"
+                .to_string(),
+        ));
+    }
+
+    let (rows_outcome, mask_outcome) = match attn_file {
+        Some(p) => {
+            if !p.exists() {
+                return Err(CliError::FileNotFound(PathBuf::from(p)));
+            }
+            let body_text = std::fs::read_to_string(p)?;
+            let body: Value = serde_json::from_str(&body_text).map_err(|e| {
+                CliError::InvalidFormat(format!(
+                    "apr attn-viz-lint: failed to parse JSON from {}: {e}",
+                    p.display()
+                ))
+            })?;
+            (
+                Some(classify_row_softmax_normalization(&body, tolerance)),
+                Some(classify_causal_mask(&body, epsilon)),
+            )
+        }
+        None => (None, None),
+    };
+
+    let html_outcome = match html_file {
+        Some(p) => {
+            if !p.exists() {
+                return Err(CliError::FileNotFound(PathBuf::from(p)));
+            }
+            let html = std::fs::read_to_string(p)?;
+            Some(classify_html_heatmap_count(&html, expected_heatmaps))
+        }
+        None => None,
+    };
+
+    print_report(
+        attn_file,
+        html_file,
+        rows_outcome.as_ref(),
+        mask_outcome.as_ref(),
+        html_outcome.as_ref(),
+        json,
+    );
+
+    if let Some(o) = &rows_outcome {
+        if !matches!(o, AttnRowsOutcome::Ok { .. }) {
+            return Err(CliError::ValidationFailed(format!(
+                "attn-viz-lint row-softmax gate rejected body: {o:?}"
+            )));
+        }
+    }
+    if let Some(o) = &mask_outcome {
+        if !matches!(o, AttnCausalMaskOutcome::Ok) {
+            return Err(CliError::ValidationFailed(format!(
+                "attn-viz-lint causal-mask gate rejected body: {o:?}"
+            )));
+        }
+    }
+    if let Some(o) = &html_outcome {
+        if !matches!(o, AttnHtmlOutcome::Ok { .. }) {
+            return Err(CliError::ValidationFailed(format!(
+                "attn-viz-lint html-heatmap-count gate rejected body: {o:?}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn print_report(
+    attn_file: Option<&Path>,
+    html_file: Option<&Path>,
+    rows: Option<&AttnRowsOutcome>,
+    mask: Option<&AttnCausalMaskOutcome>,
+    html: Option<&AttnHtmlOutcome>,
+    json: bool,
+) {
+    if json {
+        let obj = serde_json::json!({
+            "attn_file": attn_file.map(|p| p.display().to_string()),
+            "html_file": html_file.map(|p| p.display().to_string()),
+            "row_softmax": rows.map(|o| format!("{o:?}")),
+            "causal_mask": mask.map(|o| format!("{o:?}")),
+            "html_heatmaps": html.map(|o| format!("{o:?}")),
+        });
+        println!("{}", serde_json::to_string_pretty(&obj).unwrap_or_default());
+        return;
+    }
+    println!("attn-viz-lint report");
+    if let Some(p) = attn_file {
+        println!("  attn_file     : {}", p.display());
+    }
+    if let Some(p) = html_file {
+        println!("  html_file     : {}", p.display());
+    }
+    if let Some(o) = rows {
+        println!("  row_softmax   : {o:?}");
+    }
+    if let Some(o) = mask {
+        println!("  causal_mask   : {o:?}");
+    }
+    if let Some(o) = html {
+        println!("  html_heatmaps : {o:?}");
+    }
+}

--- a/crates/apr-cli/src/commands/mod.rs
+++ b/crates/apr-cli/src/commands/mod.rs
@@ -6,6 +6,8 @@
 //! - Visualization: Make problems visible
 
 pub(crate) mod aliases;
+pub(crate) mod attn_viz_classifier;
+pub(crate) mod attn_viz_lint;
 pub(crate) mod auto_quant;
 pub(crate) mod awq_classifier;
 pub(crate) mod awq_lint;

--- a/crates/apr-cli/src/dispatch_analysis.rs
+++ b/crates/apr-cli/src/dispatch_analysis.rs
@@ -183,6 +183,21 @@ fn dispatch_analysis_commands(cli: &Cli) -> Option<Result<(), CliError>> {
             cli.json,
         ),
 
+        ExtendedCommands::AttnVizLint {
+            attn_file,
+            html_file,
+            expected_heatmaps,
+            tolerance,
+            epsilon,
+        } => commands::attn_viz_lint::run(
+            attn_file.as_deref(),
+            html_file.as_deref(),
+            *expected_heatmaps,
+            *tolerance,
+            *epsilon,
+            cli.json,
+        ),
+
         ExtendedCommands::OtlpLint {
             otlp_file,
             require_apr_span,

--- a/crates/apr-cli/src/extended_commands.rs
+++ b/crates/apr-cli/src/extended_commands.rs
@@ -784,6 +784,24 @@ pub enum ExtendedCommands {
         #[arg(long, value_name = "FILE")]
         stderr_file: Option<PathBuf>,
     },
+    /// Lint a captured `apr attn-viz` attention dump (CRUX-F-17)
+    AttnVizLint {
+        /// Path to attention dump in JSON form (4-D [layers][heads][rows][cols] floats)
+        #[arg(long, value_name = "FILE")]
+        attn_file: Option<PathBuf>,
+        /// Path to HTML heatmap output
+        #[arg(long, value_name = "FILE")]
+        html_file: Option<PathBuf>,
+        /// Minimum <svg|<canvas open-tag count expected in HTML (|layers|*|heads|)
+        #[arg(long, value_name = "N", default_value_t = 1)]
+        expected_heatmaps: usize,
+        /// Row-softmax normalization tolerance (default 1e-5)
+        #[arg(long, value_name = "F64", default_value_t = 1e-5)]
+        tolerance: f64,
+        /// Causal-mask zero epsilon (default 1e-9)
+        #[arg(long, value_name = "F64", default_value_t = 1e-9)]
+        epsilon: f64,
+    },
     /// Lint a captured `apr trace --check-finite` error JSON and/or `--list` coverage JSON (CRUX-F-11)
     CheckFiniteLint {
         /// Captured stderr JSON from `apr trace --check-finite` on a poisoned model

--- a/crates/apr-cli/tests/cli_commands.rs
+++ b/crates/apr-cli/tests/cli_commands.rs
@@ -118,6 +118,7 @@ fn registered_commands() -> Vec<&'static str> {
         "gpu-memtrace-lint",
         "explain-token-lint",
         "check-finite-lint",
+        "attn-viz-lint",
         "shard",
         "unshard",
         "oracle",

--- a/crates/apr-cli/tests/falsification_crux_f_17.rs
+++ b/crates/apr-cli/tests/falsification_crux_f_17.rs
@@ -1,0 +1,198 @@
+//! CRUX-F-17 — end-to-end falsification harness for `apr attn-viz-lint`.
+//!
+//! CRUX-SHIP-001 gate g3 evidence: every FALSIFY-CRUX-F-17-{001,002,003} gate
+//! the classifier discharges has a matching captured JSON/HTML body that the
+//! binary must classify exactly as the harness expects.
+
+use serde_json::json;
+use std::io::Write;
+use std::process::Command;
+
+fn apr_binary() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_apr"));
+    cmd.env("NO_COLOR", "1");
+    cmd
+}
+
+fn write_json(body: &serde_json::Value) -> tempfile::NamedTempFile {
+    let mut f = tempfile::Builder::new()
+        .prefix("crux-f-17-")
+        .suffix(".json")
+        .tempfile()
+        .expect("tempfile");
+    f.write_all(serde_json::to_vec_pretty(body).expect("serialize").as_slice())
+        .expect("write");
+    f.flush().expect("flush");
+    f
+}
+
+fn write_html(body: &str) -> tempfile::NamedTempFile {
+    let mut f = tempfile::Builder::new()
+        .prefix("crux-f-17-")
+        .suffix(".html")
+        .tempfile()
+        .expect("tempfile");
+    f.write_all(body.as_bytes()).expect("write");
+    f.flush().expect("flush");
+    f
+}
+
+fn good_attn() -> serde_json::Value {
+    // (L=2, H=2, S=3, S=3); rows sum to 1, j > i is zero.
+    let row0 = json!([1.0, 0.0, 0.0]);
+    let row1 = json!([0.4, 0.6, 0.0]);
+    let row2 = json!([0.2, 0.3, 0.5]);
+    let head = json!([row0.clone(), row1.clone(), row2.clone()]);
+    let layer = json!([head.clone(), head.clone()]);
+    json!([layer.clone(), layer.clone()])
+}
+
+// ===== g2: CLI shape =====
+
+#[test]
+fn falsify_crux_f_17_cli_help_advertises_flags() {
+    let out = apr_binary().args(["attn-viz-lint", "--help"]).output().expect("run");
+    assert!(out.status.success(), "--help must exit 0");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    for flag in ["--attn-file", "--html-file", "--expected-heatmaps", "--tolerance", "--epsilon"] {
+        assert!(stdout.contains(flag), "--help must advertise {flag}; got:\n{stdout}");
+    }
+}
+
+#[test]
+fn falsify_crux_f_17_cli_requires_at_least_one_file() {
+    let out = apr_binary().args(["attn-viz-lint"]).output().expect("run");
+    assert!(!out.status.success(), "bare invocation must not exit 0");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("at least one of --attn-file or --html-file"),
+        "stderr must explain requirement; got:\n{stderr}"
+    );
+}
+
+// ===== g3: classifier discharges =====
+
+#[test]
+fn falsify_crux_f_17_001_row_softmax_ok_on_good_dump() {
+    let f = write_json(&good_attn());
+    let out = apr_binary()
+        .args(["attn-viz-lint", "--attn-file"])
+        .arg(f.path())
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "good attn must pass; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn falsify_crux_f_17_001_row_softmax_rejects_unnormalized() {
+    let bad = json!([[[[0.6, 0.6, 0.0], [0.4, 0.6, 0.0], [0.2, 0.3, 0.5]]]]);
+    let f = write_json(&bad);
+    let out = apr_binary()
+        .args(["attn-viz-lint", "--attn-file"])
+        .arg(f.path())
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "unnormalized row must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("RowOutOfNormalization"),
+        "stderr must name RowOutOfNormalization; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn falsify_crux_f_17_002_causal_mask_rejects_nonzero_future() {
+    // Row 0 has weight on column 1 (a future position).
+    let bad = json!([[[[0.5, 0.5, 0.0], [0.4, 0.6, 0.0], [0.2, 0.3, 0.5]]]]);
+    let f = write_json(&bad);
+    let out = apr_binary()
+        .args(["attn-viz-lint", "--attn-file"])
+        .arg(f.path())
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "causal-mask leak must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("NonZeroFuturePosition") || stderr.contains("RowOutOfNormalization"),
+        "stderr must name NonZeroFuturePosition (or RowOutOfNormalization first); got:\n{stderr}"
+    );
+}
+
+#[test]
+fn falsify_crux_f_17_003_html_heatmap_count_ok_when_threshold_met() {
+    let html = "<html><svg></svg><svg></svg><canvas></canvas><svg></svg></html>";
+    let f = write_html(html);
+    let out = apr_binary()
+        .args(["attn-viz-lint", "--html-file"])
+        .arg(f.path())
+        .args(["--expected-heatmaps", "4"])
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "4 heatmaps with threshold 4 must pass; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn falsify_crux_f_17_003_html_heatmap_count_rejects_too_few() {
+    let html = "<html><svg></svg></html>";
+    let f = write_html(html);
+    let out = apr_binary()
+        .args(["attn-viz-lint", "--html-file"])
+        .arg(f.path())
+        .args(["--expected-heatmaps", "4"])
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "1 heatmap with threshold 4 must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("TooFewHeatmaps"),
+        "stderr must name TooFewHeatmaps; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn falsify_crux_f_17_tolerance_relaxes_row_softmax_gate() {
+    // Causal-mask honored; row 2 sums to 1.01 — strict 1e-5 fails, relaxed 0.05 passes.
+    let body = json!([[[[1.0, 0.0, 0.0], [0.4, 0.6, 0.0], [0.21, 0.30, 0.50]]]]);
+    let f = write_json(&body);
+    let out = apr_binary()
+        .args(["attn-viz-lint", "--attn-file"])
+        .arg(f.path())
+        .args(["--tolerance", "0.05"])
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "0.01 deviation within 0.05 tolerance must pass; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+// ===== JSON output shape =====
+
+#[test]
+fn falsify_crux_f_17_json_output_contains_outcomes() {
+    let af = write_json(&good_attn());
+    let hf = write_html("<svg></svg><svg></svg><svg></svg><svg></svg>");
+    let out = apr_binary()
+        .args(["--json", "attn-viz-lint", "--attn-file"])
+        .arg(af.path())
+        .arg("--html-file")
+        .arg(hf.path())
+        .args(["--expected-heatmaps", "4"])
+        .output()
+        .expect("run");
+    assert!(out.status.success(), "json + good bodies must exit 0");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("json output must parse");
+    assert!(parsed["row_softmax"].as_str().expect("row_softmax").contains("Ok"));
+    assert!(parsed["causal_mask"].as_str().expect("causal_mask").contains("Ok"));
+    assert!(parsed["html_heatmaps"].as_str().expect("html_heatmaps").contains("Ok"));
+}


### PR DESCRIPTION
## Summary

- Promotes \`contracts/crux-F-17-v1.yaml\` from \`draft\` → PARTIAL_ALGORITHM_LEVEL.
- Adds \`apr attn-viz-lint [--attn-file F] [--html-file F] [--expected-heatmaps N] [--tolerance F] [--epsilon F]\` — pure-function classifier validating: row-softmax normalization (Σ_j ≈ 1.0), causal mask (j > i → 0), HTML heatmap count.
- 9 classifier unit tests + 9 e2e falsification tests + 8 cli_commands surface tests all pass.

Discharges FALSIFY-CRUX-F-17-{001,002,003} at PARTIAL_ALGORITHM_LEVEL. Full discharge requires a live \`apr attn-viz\` emitter.

## Test plan

- [x] \`cargo test -p apr-cli --lib attn_viz_classifier\` — 9/9 pass.
- [x] \`cargo test -p apr-cli --test falsification_crux_f_17\` — 9/9 pass.
- [x] \`cargo test -p apr-cli --test cli_commands\` — 8/8 pass (3-surface drift policy).
- [x] \`pv validate contracts/crux-F-17-v1.yaml\` — clean.
- [ ] CI green on \`ci / gate\` + \`workspace-test\`.

Refs #921 (CRUX M4 observability epic), #917 (CRUX Phase 3 umbrella).

🤖 Generated with [Claude Code](https://claude.com/claude-code)