### PR TITLE
feat(apr-cli): CRUX-F-18 `apr embed-viz-lint` UMAP embedding CSV classifier

### DIFF
--- a/contracts/apr-cli-commands-v1.yaml
+++ b/contracts/apr-cli-commands-v1.yaml
@@ -580,6 +580,12 @@ commands:
     requires_model: false
     side_effects: []
 
+  - name: embed-viz-lint
+    category: inspection
+    description: "Validate captured `apr debug embed-viz` CSV (CRUX-F-18): schema (4 columns + finite coords + non-negative token_id) + optional row-count=vocab_size + optional byte-identical determinism check"
+    requires_model: false
+    side_effects: []
+
   - name: shard
     category: model_ops
     description: "Split safetensors file into shards + weight-map index (CRUX-B-05)"

--- a/contracts/crux-F-18-v1.yaml
+++ b/contracts/crux-F-18-v1.yaml
@@ -1,12 +1,21 @@
 # CRUX-F-18 — Token embedding UMAP 2D
+# Promoted to PARTIAL_ALGORITHM_LEVEL at v1.2.0 under CRUX-SHIP-001 (2026-05-17):
+# - classifier: crates/apr-cli/src/commands/embed_viz_classifier.rs (12 unit tests)
+# - CLI surface: `apr embed-viz-lint --csv-file F [--expected-vocab-size N] [--csv-file-b F]`
+# - e2e: crates/apr-cli/tests/falsification_crux_f_18.rs (10 tests)
+# FALSIFY-CRUX-F-18-002 (token_str round-trips via the tokenizer)
+# requires a live tokenizer decoder and is tracked as
+# BLOCKER-UPSTREAM-MISSING.
 
 metadata:
   id: CRUX-F-18
-  version: "1.1.0"
+  version: "1.2.0"
   created: "2026-04-18"
+  updated: "2026-05-17"
   author: PAIML Engineering
   registry: true
-  status: draft
+  status: partial
+  kind: kernel
   parent_contracts:
   - crux-competitive-research-ux-v1
   category: "F — Profiling & Debugging"
@@ -48,6 +57,27 @@ falsification_tests:
     rows=$(tail -n +2 /tmp/emb.csv | wc -l)
     python3 -c "assert $vs == $rows, ($vs, $rows)"
   if_fails: rule 'one row per vocab entry' is violated — contract MUST be re-verified against competitor canonical reference
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/embed_viz_classifier.rs
+    cli_path: crates/apr-cli/src/commands/embed_viz_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_f_18.rs
+    e2e_tests:
+    - falsify_crux_f_18_001_schema_ok_on_good_body
+    - falsify_crux_f_18_001_schema_rejects_missing_column
+    - falsify_crux_f_18_001_schema_rejects_nonfinite_coord
+    - falsify_crux_f_18_001_row_count_ok_when_matches_vocab
+    - falsify_crux_f_18_001_row_count_rejects_mismatch
+    sub_claim: |
+      Algorithm-level necessary conditions on a captured `apr debug
+      embed-viz` CSV: `classify_schema` verifies the header carries
+      `token_id`, `token_str`, `x`, `y` (order-independent), every row
+      has the same column count as the header, `token_id` parses as a
+      non-negative integer, and `x`/`y` parse as finite floats (no
+      NaN/Inf). `classify_row_count` verifies row count equals the
+      caller-supplied `expected_vocab_size`.
+    scope: "(body, expected_vocab_size) -> (EmbedSchemaOutcome, EmbedRowCountOutcome) (pure)"
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: "live `apr debug embed-viz` emitter writing one row per vocab entry"
 - id: FALSIFY-CRUX-F-18-002
   rule: token_str round-trips through tokenizer
   prediction: "row i token_str decodes to tokenizer.decode([i])"
@@ -73,6 +103,23 @@ falsification_tests:
     diff /tmp/emb1.csv /tmp/emb2.csv
 
   if_fails: rule 'determinism under fixed seed' is violated — contract MUST be re-verified against competitor canonical reference
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/embed_viz_classifier.rs
+    cli_path: crates/apr-cli/src/commands/embed_viz_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_f_18.rs
+    e2e_tests:
+    - falsify_crux_f_18_003_determinism_ok_on_byte_identical
+    - falsify_crux_f_18_003_determinism_rejects_diverging_csvs
+    sub_claim: |
+      Algorithm-level necessary condition: `classify_determinism` does
+      a byte-exact comparison of two CSV bodies produced under the same
+      seed. Variants `LengthDiffers { left_bytes, right_bytes }` and
+      `FirstDiffAtByte { offset, left, right }` pinpoint the exact
+      drift so seed-leak / nondeterminism bugs are debuggable from the
+      lint output alone.
+    scope: "(left_bytes, right_bytes) -> EmbedDeterminismOutcome (pure)"
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: "live `apr debug embed-viz` emitter writing seed-deterministic CSV"
 proof_obligations:
 - type: equivalence
   property: "apr debug embed-viz matches umap-learn n_components=2 cosine fit_transform"

--- a/crates/apr-cli/src/commands/embed_viz_classifier.rs
+++ b/crates/apr-cli/src/commands/embed_viz_classifier.rs
@@ -1,0 +1,283 @@
+//! Token embedding UMAP 2D classifier (CRUX-F-18).
+//!
+//! Pure, deterministic classifiers that discharge FALSIFY-CRUX-F-18-{001,003}
+//! at the PARTIAL_ALGORITHM_LEVEL — algorithm-level necessary conditions on
+//! a captured `apr debug embed-viz --seed N -o emb.csv` output:
+//!
+//!   * `classify_schema` — header is `token_id,token_str,x,y` (in some
+//!     order); every row has the same 4 columns; `token_id` parses as
+//!     non-negative int; `x` and `y` parse as finite floats.
+//!   * `classify_row_count` — number of data rows equals
+//!     `expected_vocab_size`.
+//!   * `classify_determinism` — two captured CSVs produced under the
+//!     same seed are byte-identical (no trailing-newline / whitespace
+//!     drift either).
+//!
+//! FALSIFY-CRUX-F-18-002 (token_str round-trips via the tokenizer)
+//! requires a live tokenizer decoder — tracked as
+//! BLOCKER-UPSTREAM-MISSING.
+
+/// Required CSV column headers (order-independent).
+pub const F18_REQUIRED_COLUMNS: &[&str] = &["token_id", "token_str", "x", "y"];
+
+/// Outcome of `classify_schema`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EmbedSchemaOutcome {
+    Ok { rows: usize },
+    Empty,
+    MissingHeader,
+    MissingColumn { col: &'static str },
+    WrongColumnCount { line_no: usize, got: usize, expected: usize },
+    TokenIdNotNonNegativeInt { line_no: usize, got: String },
+    CoordNotFiniteFloat { line_no: usize, col: &'static str, got: String },
+}
+
+/// Outcome of `classify_row_count`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EmbedRowCountOutcome {
+    Ok,
+    Mismatch { got: usize, expected: usize },
+}
+
+/// Outcome of `classify_determinism`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EmbedDeterminismOutcome {
+    Ok { bytes: usize },
+    LengthDiffers { left_bytes: usize, right_bytes: usize },
+    FirstDiffAtByte { offset: usize, left: u8, right: u8 },
+}
+
+/// Validate CSV schema (header + per-row types).
+pub fn classify_schema(body: &str) -> EmbedSchemaOutcome {
+    let mut lines = body.lines();
+    let Some(header) = lines.next() else {
+        return EmbedSchemaOutcome::Empty;
+    };
+    let cols: Vec<&str> = header.split(',').map(str::trim).collect();
+    if cols.len() < F18_REQUIRED_COLUMNS.len() {
+        return EmbedSchemaOutcome::MissingHeader;
+    }
+    let mut idx_token_id: Option<usize> = None;
+    let mut idx_token_str: Option<usize> = None;
+    let mut idx_x: Option<usize> = None;
+    let mut idx_y: Option<usize> = None;
+    for (i, c) in cols.iter().enumerate() {
+        match *c {
+            "token_id" => idx_token_id = Some(i),
+            "token_str" => idx_token_str = Some(i),
+            "x" => idx_x = Some(i),
+            "y" => idx_y = Some(i),
+            _ => {}
+        }
+    }
+    for (val, col) in [
+        (idx_token_id, "token_id"),
+        (idx_token_str, "token_str"),
+        (idx_x, "x"),
+        (idx_y, "y"),
+    ] {
+        if val.is_none() {
+            return EmbedSchemaOutcome::MissingColumn { col };
+        }
+    }
+    let idx_token_id = idx_token_id.unwrap_or(0);
+    let idx_x = idx_x.unwrap_or(0);
+    let idx_y = idx_y.unwrap_or(0);
+    let expected = cols.len();
+
+    let mut rows = 0usize;
+    for (i, line) in lines.enumerate() {
+        let line_no = i + 2; // header is line 1
+        if line.trim().is_empty() {
+            continue;
+        }
+        // Split on commas; we tolerate quoted token_str strings if they don't
+        // contain commas. For commas inside quoted strings, the contract spec
+        // says the emitter is responsible for proper CSV quoting — the
+        // classifier verifies the column count matches the header.
+        let parts: Vec<&str> = line.split(',').collect();
+        if parts.len() != expected {
+            return EmbedSchemaOutcome::WrongColumnCount {
+                line_no,
+                got: parts.len(),
+                expected,
+            };
+        }
+        match parts[idx_token_id].trim().parse::<i64>() {
+            Ok(v) if v >= 0 => {}
+            _ => {
+                return EmbedSchemaOutcome::TokenIdNotNonNegativeInt {
+                    line_no,
+                    got: parts[idx_token_id].to_string(),
+                }
+            }
+        }
+        for (idx, name) in [(idx_x, "x"), (idx_y, "y")] {
+            let raw = parts[idx].trim();
+            match raw.parse::<f64>() {
+                Ok(v) if v.is_finite() => {}
+                _ => {
+                    return EmbedSchemaOutcome::CoordNotFiniteFloat {
+                        line_no,
+                        col: name,
+                        got: raw.to_string(),
+                    }
+                }
+            }
+        }
+        rows += 1;
+    }
+    EmbedSchemaOutcome::Ok { rows }
+}
+
+/// Verify the row count equals `expected_vocab_size`.
+pub fn classify_row_count(body: &str, expected: usize) -> EmbedRowCountOutcome {
+    let count = body
+        .lines()
+        .skip(1) // header
+        .filter(|l| !l.trim().is_empty())
+        .count();
+    if count == expected {
+        EmbedRowCountOutcome::Ok
+    } else {
+        EmbedRowCountOutcome::Mismatch { got: count, expected }
+    }
+}
+
+/// Verify two CSVs are byte-identical.
+pub fn classify_determinism(left: &[u8], right: &[u8]) -> EmbedDeterminismOutcome {
+    if left.len() != right.len() {
+        return EmbedDeterminismOutcome::LengthDiffers {
+            left_bytes: left.len(),
+            right_bytes: right.len(),
+        };
+    }
+    for (i, (l, r)) in left.iter().zip(right.iter()).enumerate() {
+        if l != r {
+            return EmbedDeterminismOutcome::FirstDiffAtByte {
+                offset: i,
+                left: *l,
+                right: *r,
+            };
+        }
+    }
+    EmbedDeterminismOutcome::Ok { bytes: left.len() }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn good_body() -> String {
+        "token_id,token_str,x,y\n0,<pad>,0.1,0.2\n1,<unk>,-0.5,1.5\n2,hello,3.14,-2.71\n".to_string()
+    }
+
+    #[test]
+    fn schema_ok_on_good_body() {
+        let out = classify_schema(&good_body());
+        assert_eq!(out, EmbedSchemaOutcome::Ok { rows: 3 });
+    }
+
+    #[test]
+    fn schema_rejects_empty_body() {
+        assert_eq!(classify_schema(""), EmbedSchemaOutcome::Empty);
+    }
+
+    #[test]
+    fn schema_rejects_missing_column() {
+        // Header missing `y`.
+        let body = "token_id,token_str,x\n0,<pad>,0.1\n";
+        assert!(matches!(
+            classify_schema(body),
+            EmbedSchemaOutcome::MissingHeader | EmbedSchemaOutcome::MissingColumn { .. }
+        ));
+    }
+
+    #[test]
+    fn schema_rejects_negative_token_id() {
+        let body = "token_id,token_str,x,y\n-1,<pad>,0.1,0.2\n";
+        assert!(matches!(
+            classify_schema(body),
+            EmbedSchemaOutcome::TokenIdNotNonNegativeInt { line_no: 2, .. }
+        ));
+    }
+
+    #[test]
+    fn schema_rejects_nonfinite_x() {
+        let body = "token_id,token_str,x,y\n0,<pad>,nan,0.2\n";
+        match classify_schema(body) {
+            EmbedSchemaOutcome::CoordNotFiniteFloat { line_no: 2, col: "x", .. } => {}
+            other => panic!("expected CoordNotFiniteFloat(x), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn schema_rejects_inf_y() {
+        let body = "token_id,token_str,x,y\n0,<pad>,0.0,inf\n";
+        match classify_schema(body) {
+            EmbedSchemaOutcome::CoordNotFiniteFloat { line_no: 2, col: "y", .. } => {}
+            other => panic!("expected CoordNotFiniteFloat(y), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn schema_accepts_reordered_columns() {
+        let body = "x,y,token_id,token_str\n0.1,0.2,0,<pad>\n";
+        assert_eq!(
+            classify_schema(body),
+            EmbedSchemaOutcome::Ok { rows: 1 }
+        );
+    }
+
+    #[test]
+    fn row_count_ok_on_match() {
+        assert_eq!(
+            classify_row_count(&good_body(), 3),
+            EmbedRowCountOutcome::Ok
+        );
+    }
+
+    #[test]
+    fn row_count_reports_mismatch() {
+        assert_eq!(
+            classify_row_count(&good_body(), 100),
+            EmbedRowCountOutcome::Mismatch { got: 3, expected: 100 }
+        );
+    }
+
+    #[test]
+    fn determinism_ok_on_byte_identical() {
+        let b1 = b"abc\n123\n";
+        let b2 = b"abc\n123\n";
+        assert_eq!(
+            classify_determinism(b1, b2),
+            EmbedDeterminismOutcome::Ok { bytes: 8 }
+        );
+    }
+
+    #[test]
+    fn determinism_reports_length_diff() {
+        let b1 = b"abc\n";
+        let b2 = b"abc\n\n";
+        assert_eq!(
+            classify_determinism(b1, b2),
+            EmbedDeterminismOutcome::LengthDiffers {
+                left_bytes: 4,
+                right_bytes: 5,
+            }
+        );
+    }
+
+    #[test]
+    fn determinism_reports_first_diff_byte() {
+        let b1 = b"abc\n123\n";
+        let b2 = b"abc\n124\n";
+        match classify_determinism(b1, b2) {
+            EmbedDeterminismOutcome::FirstDiffAtByte { offset: 6, left, right } => {
+                assert_eq!(left, b'3');
+                assert_eq!(right, b'4');
+            }
+            other => panic!("expected FirstDiffAtByte, got {other:?}"),
+        }
+    }
+}

--- a/crates/apr-cli/src/commands/embed_viz_lint.rs
+++ b/crates/apr-cli/src/commands/embed_viz_lint.rs
@@ -1,0 +1,92 @@
+//! `apr embed-viz-lint` — CRUX-F-18 UMAP token-embedding CSV gate.
+//!
+//! Reads a captured `apr debug embed-viz -o emb.csv` body and dispatches
+//! the pure classifiers in `embed_viz_classifier`. Exits non-zero on
+//! any failure.
+//!
+//! Spec: `contracts/crux-F-18-v1.yaml`. CRUX-SHIP-001 g2/g3 surface.
+
+use std::path::{Path, PathBuf};
+
+use super::embed_viz_classifier::{
+    classify_determinism, classify_row_count, classify_schema, EmbedDeterminismOutcome,
+    EmbedRowCountOutcome, EmbedSchemaOutcome,
+};
+use crate::error::{CliError, Result};
+
+pub(crate) fn run(
+    csv_file: &Path,
+    expected_vocab_size: Option<usize>,
+    csv_file_b: Option<&Path>,
+    json: bool,
+) -> Result<()> {
+    if !csv_file.exists() {
+        return Err(CliError::FileNotFound(PathBuf::from(csv_file)));
+    }
+    let body = std::fs::read_to_string(csv_file)?;
+
+    let schema = classify_schema(&body);
+    let row_count = expected_vocab_size.map(|n| classify_row_count(&body, n));
+    let determinism = match csv_file_b {
+        Some(p) => {
+            if !p.exists() {
+                return Err(CliError::FileNotFound(PathBuf::from(p)));
+            }
+            let b = std::fs::read(p)?;
+            Some(classify_determinism(body.as_bytes(), &b))
+        }
+        None => None,
+    };
+
+    print_report(csv_file, csv_file_b, &schema, row_count.as_ref(), determinism.as_ref(), json);
+
+    if !matches!(schema, EmbedSchemaOutcome::Ok { .. }) {
+        return Err(CliError::ValidationFailed(format!(
+            "embed-viz-lint schema gate rejected body: {schema:?}"
+        )));
+    }
+    if let Some(o) = &row_count {
+        if !matches!(o, EmbedRowCountOutcome::Ok) {
+            return Err(CliError::ValidationFailed(format!(
+                "embed-viz-lint row-count gate rejected body: {o:?}"
+            )));
+        }
+    }
+    if let Some(o) = &determinism {
+        if !matches!(o, EmbedDeterminismOutcome::Ok { .. }) {
+            return Err(CliError::ValidationFailed(format!(
+                "embed-viz-lint determinism gate rejected bodies: {o:?}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn print_report(
+    csv_file: &Path,
+    csv_file_b: Option<&Path>,
+    schema: &EmbedSchemaOutcome,
+    row_count: Option<&EmbedRowCountOutcome>,
+    determinism: Option<&EmbedDeterminismOutcome>,
+    json: bool,
+) {
+    if json {
+        let obj = serde_json::json!({
+            "csv_file": csv_file.display().to_string(),
+            "csv_file_b": csv_file_b.map(|p| p.display().to_string()),
+            "schema": format!("{schema:?}"),
+            "row_count": row_count.map(|o| format!("{o:?}")),
+            "determinism": determinism.map(|o| format!("{o:?}")),
+        });
+        println!("{}", serde_json::to_string_pretty(&obj).unwrap_or_default());
+        return;
+    }
+    println!("embed-viz-lint report for {}", csv_file.display());
+    println!("  schema     : {schema:?}");
+    if let Some(o) = row_count {
+        println!("  row_count  : {o:?}");
+    }
+    if let Some(o) = determinism {
+        println!("  determinism: {o:?}");
+    }
+}

--- a/crates/apr-cli/src/commands/mod.rs
+++ b/crates/apr-cli/src/commands/mod.rs
@@ -35,6 +35,8 @@ pub(crate) mod diagnose;
 
 pub(crate) mod dry_sampling_classifier;
 pub(crate) mod dry_sampling_lint;
+pub(crate) mod embed_viz_classifier;
+pub(crate) mod embed_viz_lint;
 pub(crate) mod embeddings_classifier;
 pub(crate) mod embeddings_lint;
 pub(crate) mod eval;

--- a/crates/apr-cli/src/dispatch_analysis.rs
+++ b/crates/apr-cli/src/dispatch_analysis.rs
@@ -198,6 +198,17 @@ fn dispatch_analysis_commands(cli: &Cli) -> Option<Result<(), CliError>> {
             cli.json,
         ),
 
+        ExtendedCommands::EmbedVizLint {
+            csv_file,
+            expected_vocab_size,
+            csv_file_b,
+        } => commands::embed_viz_lint::run(
+            csv_file,
+            *expected_vocab_size,
+            csv_file_b.as_deref(),
+            cli.json,
+        ),
+
         ExtendedCommands::OtlpLint {
             otlp_file,
             require_apr_span,

--- a/crates/apr-cli/src/extended_commands.rs
+++ b/crates/apr-cli/src/extended_commands.rs
@@ -814,6 +814,18 @@ pub enum ExtendedCommands {
         #[arg(long, value_name = "N", default_value_t = 100)]
         min_layers: usize,
     },
+    /// Lint a captured `apr debug embed-viz` CSV (CRUX-F-18)
+    EmbedVizLint {
+        /// Path to captured embed-viz CSV (token_id,token_str,x,y)
+        #[arg(long, value_name = "FILE")]
+        csv_file: PathBuf,
+        /// Expected row count == vocab_size (optional)
+        #[arg(long, value_name = "N")]
+        expected_vocab_size: Option<usize>,
+        /// Second CSV captured under the same seed for determinism check (optional)
+        #[arg(long, value_name = "FILE")]
+        csv_file_b: Option<PathBuf>,
+    },
     /// Lint a captured `apr explain --format jsonl` token-selection trace (CRUX-F-19)
     ExplainTokenLint {
         /// Path to captured JSONL body (one sampled-token record per line)

--- a/crates/apr-cli/tests/cli_commands.rs
+++ b/crates/apr-cli/tests/cli_commands.rs
@@ -119,6 +119,7 @@ fn registered_commands() -> Vec<&'static str> {
         "explain-token-lint",
         "check-finite-lint",
         "attn-viz-lint",
+        "embed-viz-lint",
         "shard",
         "unshard",
         "oracle",

--- a/crates/apr-cli/tests/falsification_crux_f_18.rs
+++ b/crates/apr-cli/tests/falsification_crux_f_18.rs
@@ -1,0 +1,194 @@
+//! CRUX-F-18 — end-to-end falsification harness for `apr embed-viz-lint`.
+//!
+//! CRUX-SHIP-001 gate g3 evidence: every FALSIFY-CRUX-F-18-{001,003} gate
+//! the classifier discharges has a matching captured CSV body that the
+//! binary must classify exactly as the harness expects.
+
+use std::io::Write;
+use std::process::Command;
+
+fn apr_binary() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_apr"));
+    cmd.env("NO_COLOR", "1");
+    cmd
+}
+
+fn write_csv(body: &str) -> tempfile::NamedTempFile {
+    let mut f = tempfile::Builder::new()
+        .prefix("crux-f-18-")
+        .suffix(".csv")
+        .tempfile()
+        .expect("tempfile");
+    f.write_all(body.as_bytes()).expect("write");
+    f.flush().expect("flush");
+    f
+}
+
+fn good_body() -> &'static str {
+    "token_id,token_str,x,y\n0,<pad>,0.1,0.2\n1,<unk>,-0.5,1.5\n2,hello,3.14,-2.71\n"
+}
+
+// ===== g2: CLI shape =====
+
+#[test]
+fn falsify_crux_f_18_cli_help_advertises_flags() {
+    let out = apr_binary().args(["embed-viz-lint", "--help"]).output().expect("run");
+    assert!(out.status.success(), "--help must exit 0");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    for flag in ["--csv-file", "--expected-vocab-size", "--csv-file-b"] {
+        assert!(stdout.contains(flag), "--help must advertise {flag}; got:\n{stdout}");
+    }
+}
+
+#[test]
+fn falsify_crux_f_18_cli_missing_file_fails() {
+    let out = apr_binary()
+        .args(["embed-viz-lint", "--csv-file", "/nonexistent/crux-f-18-missing.csv"])
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "missing file must not exit 0");
+}
+
+// ===== g3: classifier discharges =====
+
+#[test]
+fn falsify_crux_f_18_001_schema_ok_on_good_body() {
+    let f = write_csv(good_body());
+    let out = apr_binary()
+        .args(["embed-viz-lint", "--csv-file"])
+        .arg(f.path())
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "good body must pass; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn falsify_crux_f_18_001_schema_rejects_missing_column() {
+    let body = "token_id,token_str,x\n0,<pad>,0.1\n";
+    let f = write_csv(body);
+    let out = apr_binary()
+        .args(["embed-viz-lint", "--csv-file"])
+        .arg(f.path())
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "missing y column must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("MissingColumn") || stderr.contains("MissingHeader"),
+        "stderr must name MissingColumn/Header; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn falsify_crux_f_18_001_schema_rejects_nonfinite_coord() {
+    let body = "token_id,token_str,x,y\n0,<pad>,nan,0.2\n";
+    let f = write_csv(body);
+    let out = apr_binary()
+        .args(["embed-viz-lint", "--csv-file"])
+        .arg(f.path())
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "nan coord must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("CoordNotFiniteFloat"),
+        "stderr must name CoordNotFiniteFloat; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn falsify_crux_f_18_001_row_count_ok_when_matches_vocab() {
+    let f = write_csv(good_body());
+    let out = apr_binary()
+        .args(["embed-viz-lint", "--csv-file"])
+        .arg(f.path())
+        .args(["--expected-vocab-size", "3"])
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "row-count match must pass; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn falsify_crux_f_18_001_row_count_rejects_mismatch() {
+    let f = write_csv(good_body());
+    let out = apr_binary()
+        .args(["embed-viz-lint", "--csv-file"])
+        .arg(f.path())
+        .args(["--expected-vocab-size", "100"])
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "row-count mismatch must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("Mismatch"),
+        "stderr must name Mismatch; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn falsify_crux_f_18_003_determinism_ok_on_byte_identical() {
+    let f1 = write_csv(good_body());
+    let f2 = write_csv(good_body());
+    let out = apr_binary()
+        .args(["embed-viz-lint", "--csv-file"])
+        .arg(f1.path())
+        .arg("--csv-file-b")
+        .arg(f2.path())
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "byte-identical CSVs must pass; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn falsify_crux_f_18_003_determinism_rejects_diverging_csvs() {
+    let f1 = write_csv(good_body());
+    let body2 = "token_id,token_str,x,y\n0,<pad>,0.1,0.2\n1,<unk>,-0.5,1.5\n2,hello,3.99,-2.71\n";
+    let f2 = write_csv(body2);
+    let out = apr_binary()
+        .args(["embed-viz-lint", "--csv-file"])
+        .arg(f1.path())
+        .arg("--csv-file-b")
+        .arg(f2.path())
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "diverging CSVs must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("FirstDiffAtByte") || stderr.contains("LengthDiffers"),
+        "stderr must name FirstDiffAtByte or LengthDiffers; got:\n{stderr}"
+    );
+}
+
+// ===== JSON output shape =====
+
+#[test]
+fn falsify_crux_f_18_json_output_contains_outcomes() {
+    let f1 = write_csv(good_body());
+    let f2 = write_csv(good_body());
+    let out = apr_binary()
+        .args(["--json", "embed-viz-lint", "--csv-file"])
+        .arg(f1.path())
+        .args(["--expected-vocab-size", "3"])
+        .arg("--csv-file-b")
+        .arg(f2.path())
+        .output()
+        .expect("run");
+    assert!(out.status.success(), "json + good bodies must exit 0");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("json output must parse");
+    assert!(parsed["schema"].as_str().expect("schema").contains("Ok"));
+    assert!(parsed["row_count"].as_str().expect("row_count").contains("Ok"));
+    assert!(parsed["determinism"].as_str().expect("determinism").contains("Ok"));
+}


### PR DESCRIPTION
## Summary

- Promotes \`contracts/crux-F-18-v1.yaml\` from \`draft\` → PARTIAL_ALGORITHM_LEVEL.
- Adds \`apr embed-viz-lint --csv-file F [--expected-vocab-size N] [--csv-file-b F]\` — pure-function classifier validating: CSV schema (4 required columns, finite x/y, non-negative token_id), row count = vocab_size, byte-identical determinism across two seeded runs.
- 12 classifier unit tests + 10 e2e falsification tests + 8 cli_commands surface tests all pass.

Discharges FALSIFY-CRUX-F-18-{001,003} at PARTIAL_ALGORITHM_LEVEL. FALSIFY-CRUX-F-18-002 (token_str round-trips via tokenizer) requires a live tokenizer decoder.

## Test plan

- [x] \`cargo test -p apr-cli --lib embed_viz_classifier\` — 12/12 pass.
- [x] \`cargo test -p apr-cli --test falsification_crux_f_18\` — 10/10 pass.
- [x] \`cargo test -p apr-cli --test cli_commands\` — 8/8 pass (3-surface drift policy).
- [x] \`pv validate contracts/crux-F-18-v1.yaml\` — clean.
- [ ] CI green on \`ci / gate\` + \`workspace-test\`.

Refs #921 (CRUX M4 observability epic), #917 (CRUX Phase 3 umbrella).

🤖 Generated with [Claude Code](https://claude.com/claude-code)