### PR TITLE
feat(apr-cli): CRUX-F-14 `apr hang-trace-lint` deadlock/hang stack-dump classifier

### DIFF
--- a/contracts/apr-cli-commands-v1.yaml
+++ b/contracts/apr-cli-commands-v1.yaml
@@ -598,6 +598,12 @@ commands:
     requires_model: false
     side_effects: []
 
+  - name: hang-trace-lint
+    category: inspection
+    description: "Validate captured `$APR_TRACE_DIR` after a hang/timeout (CRUX-F-14): per-rank rank{N}.py.txt files (world_size + non-empty) OR empty-on-success + exit-code 124/1/0 distinction"
+    requires_model: false
+    side_effects: []
+
   - name: shard
     category: model_ops
     description: "Split safetensors file into shards + weight-map index (CRUX-B-05)"

--- a/contracts/crux-F-14-v1.yaml
+++ b/contracts/crux-F-14-v1.yaml
@@ -1,12 +1,21 @@
 # CRUX-F-14 — Deadlock/hang detector stack dump
+# Promoted to PARTIAL_ALGORITHM_LEVEL at v1.2.0 under CRUX-SHIP-001 (2026-05-17):
+# - classifier: crates/apr-cli/src/commands/hang_trace_classifier.rs (12 unit tests)
+# - CLI surface: `apr hang-trace-lint --trace-dir DIR [--mode timeout|success] [--world-size N] [--exit-code I] [--expected-exit-code I]`
+# - e2e: crates/apr-cli/tests/falsification_crux_f_14.rs (11 tests)
+# Full discharge of F-14-{001,002,003} requires a live `apr train`
+# watchdog actually emitting per-rank stack dumps on hang — tracked as
+# BLOCKER-UPSTREAM-MISSING.
 
 metadata:
   id: CRUX-F-14
-  version: "1.1.0"
+  version: "1.2.0"
   created: "2026-04-18"
+  updated: "2026-05-17"
   author: PAIML Engineering
   registry: true
-  status: draft
+  status: partial
+  kind: kernel
   parent_contracts:
   - crux-competitive-research-ux-v1
   category: "F — Tensor Ops & Low-level"
@@ -52,6 +61,25 @@ falsification_tests:
     [ "$ec" = "124" ]
     [ -f /tmp/dd/rank0.py.txt ] && [ -f /tmp/dd/rank1.py.txt ]
   if_fails: rule 'timeout produces per-rank stack files' is violated — contract MUST be re-verified against competitor canonical reference
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/hang_trace_classifier.rs
+    cli_path: crates/apr-cli/src/commands/hang_trace_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_f_14.rs
+    e2e_tests:
+    - falsify_crux_f_14_001_timeout_ok_on_complete_dump
+    - falsify_crux_f_14_001_timeout_rejects_missing_rank
+    - falsify_crux_f_14_001_timeout_rejects_empty_file
+    sub_claim: |
+      Algorithm-level necessary conditions on a captured `$APR_TRACE_DIR`
+      after a timeout: `classify_timeout_dump` verifies the directory
+      contains a non-empty `rank{N}.py.txt` file for every rank in
+      `0..world_size` and rejects unrecognized filenames. Outcome
+      variants `MissingRank { rank }` and `EmptyFile { rank }` pinpoint
+      the offending rank so watchdog bugs are debuggable from the lint
+      output alone.
+    scope: "(listing, world_size) -> HangTimeoutOutcome (pure)"
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: "live `apr train` watchdog emitting per-rank stack dumps on hang"
 - id: FALSIFY-CRUX-F-14-002
   rule: normal completion produces NO stack dumps
   prediction: "healthy training leaves trace_dir empty (no false triggers)"
@@ -62,6 +90,21 @@ falsification_tests:
       apr train tests/fixtures/tiny-sft.jsonl --model tests/fixtures/tinyllama-hf --steps 1
     [ -z "$(ls /tmp/dd2)" ]
   if_fails: rule 'normal completion produces NO stack dumps' is violated — contract MUST be re-verified against competitor canonical reference
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/hang_trace_classifier.rs
+    cli_path: crates/apr-cli/src/commands/hang_trace_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_f_14.rs
+    e2e_tests:
+    - falsify_crux_f_14_002_success_ok_when_dir_is_empty
+    - falsify_crux_f_14_002_success_rejects_unexpected_file
+    sub_claim: |
+      Algorithm-level necessary condition: `classify_empty_on_success`
+      verifies the captured trace-dir is empty after a successful run.
+      Any file present produces `UnexpectedFile { name }`, surfacing
+      the false-trigger emit (watchdog firing without an actual hang).
+    scope: "(listing) -> HangEmptyOnSuccessOutcome (pure)"
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: "live `apr train` watchdog leaving the dir empty on clean exit"
 - id: FALSIFY-CRUX-F-14-003
   rule: exit code 124 signals timeout vs 1 for other errors
   prediction: "non-hang errors return exit=1, not 124"
@@ -72,6 +115,22 @@ falsification_tests:
     [ "$ec" != "124" ]
 
   if_fails: rule 'exit code 124 signals timeout vs 1 for other errors' is violated — contract MUST be re-verified against competitor canonical reference
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/hang_trace_classifier.rs
+    cli_path: crates/apr-cli/src/commands/hang_trace_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_f_14.rs
+    e2e_tests:
+    - falsify_crux_f_14_003_exit_code_124_passes_timeout_expectation
+    - falsify_crux_f_14_003_exit_code_1_fails_timeout_expectation
+    sub_claim: |
+      Algorithm-level necessary condition: `classify_exit_code` matches
+      observed exit code against an expected value (typically 124 for
+      timeout per POSIX coreutils convention, 1 for other failures, 0
+      for success) and produces `OkTimeout`/`OkOtherError`/`OkSuccess`
+      on match, or `ExitCodeMismatch { got, expected }` on divergence.
+    scope: "(got, expected) -> HangExitOutcome (pure)"
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: "live `apr train` exiting 124 only on watchdog timeout"
 proof_obligations:
 - type: equivalence
   property: "apr hang detector dump format compatible with PyTorch flight-recorder + NCCL trace ring"

--- a/crates/apr-cli/src/commands/hang_trace_classifier.rs
+++ b/crates/apr-cli/src/commands/hang_trace_classifier.rs
@@ -1,0 +1,270 @@
+//! Deadlock/hang detector stack dump classifier (CRUX-F-14).
+//!
+//! Pure, deterministic classifiers that discharge FALSIFY-CRUX-F-14-{001,002,003}
+//! at the PARTIAL_ALGORITHM_LEVEL — algorithm-level necessary conditions on
+//! a captured `$APR_TRACE_DIR` after a hang/timeout (or a successful run):
+//!
+//!   * `classify_timeout_dump` — directory contains exactly `world_size`
+//!     `rank{N}.py.txt` files (for N in 0..world_size), each non-empty;
+//!     optional `.native.txt` and `.nccl.json` files are accepted.
+//!   * `classify_empty_on_success` — directory is empty (no rank files)
+//!     when the run completed normally.
+//!   * `classify_exit_code` — exit code distinguishes timeout (124) vs
+//!     other failures (any other non-zero) vs success (0).
+//!
+//! Full discharge of -001/-002/-003 requires a live `apr train` watchdog
+//! actually emitting these files on hang — tracked as
+//! BLOCKER-UPSTREAM-MISSING.
+
+/// Canonical timeout exit code (POSIX `coreutils timeout` convention).
+pub const F14_TIMEOUT_EXIT_CODE: i32 = 124;
+
+/// Outcome of `classify_timeout_dump`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HangTimeoutOutcome {
+    Ok { ranks_seen: usize },
+    DirEmpty,
+    MissingRank { rank: usize },
+    EmptyFile { rank: usize },
+    UnexpectedFilename { name: String },
+}
+
+/// Outcome of `classify_empty_on_success`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HangEmptyOnSuccessOutcome {
+    Ok,
+    UnexpectedFile { name: String },
+}
+
+/// Outcome of `classify_exit_code`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HangExitOutcome {
+    OkTimeout,
+    OkOtherError { code: i32 },
+    OkSuccess,
+    ExitCodeMismatch { got: i32, expected: i32 },
+}
+
+/// Listing of a captured trace-dir as parallel arrays so the classifier
+/// is testable without touching the filesystem.
+#[derive(Debug, Clone)]
+pub struct TraceDirListing<'a> {
+    /// File names (basename only, e.g. `rank0.py.txt`).
+    pub names: Vec<&'a str>,
+    /// Byte sizes for each file (parallel to `names`).
+    pub sizes: Vec<u64>,
+}
+
+impl<'a> TraceDirListing<'a> {
+    pub fn from_pairs(pairs: &'a [(&'a str, u64)]) -> Self {
+        Self {
+            names: pairs.iter().map(|p| p.0).collect(),
+            sizes: pairs.iter().map(|p| p.1).collect(),
+        }
+    }
+}
+
+/// FALSIFY-CRUX-F-14-001: verify timeout dumped exactly `world_size`
+/// non-empty `rank{N}.py.txt` files (with N in `0..world_size`).
+pub fn classify_timeout_dump(
+    listing: &TraceDirListing<'_>,
+    world_size: usize,
+) -> HangTimeoutOutcome {
+    if world_size == 0 {
+        // Degenerate: zero ranks expected => any contents is fine,
+        // but a missing dir would be a different problem; treat as Ok.
+        return HangTimeoutOutcome::Ok { ranks_seen: 0 };
+    }
+    if listing.names.is_empty() {
+        return HangTimeoutOutcome::DirEmpty;
+    }
+    // Validate every observed file is a recognized rank file.
+    for name in &listing.names {
+        if !is_recognized_rank_file(name) {
+            return HangTimeoutOutcome::UnexpectedFilename {
+                name: (*name).to_string(),
+            };
+        }
+    }
+    // Each rank must have at least a .py.txt file, non-empty.
+    for r in 0..world_size {
+        let needle = format!("rank{r}.py.txt");
+        let Some(idx) = listing.names.iter().position(|n| *n == needle) else {
+            return HangTimeoutOutcome::MissingRank { rank: r };
+        };
+        if listing.sizes.get(idx).copied().unwrap_or(0) == 0 {
+            return HangTimeoutOutcome::EmptyFile { rank: r };
+        }
+    }
+    HangTimeoutOutcome::Ok { ranks_seen: world_size }
+}
+
+/// FALSIFY-CRUX-F-14-002: verify the trace-dir is empty after a successful
+/// run (no false-trigger dumps).
+pub fn classify_empty_on_success(listing: &TraceDirListing<'_>) -> HangEmptyOnSuccessOutcome {
+    if let Some(name) = listing.names.first() {
+        return HangEmptyOnSuccessOutcome::UnexpectedFile {
+            name: (*name).to_string(),
+        };
+    }
+    HangEmptyOnSuccessOutcome::Ok
+}
+
+/// FALSIFY-CRUX-F-14-003: verify exit code matches expectation
+/// (124 = timeout, any other non-zero = other error, 0 = success).
+pub fn classify_exit_code(got: i32, expected: i32) -> HangExitOutcome {
+    if got == expected {
+        return match got {
+            F14_TIMEOUT_EXIT_CODE => HangExitOutcome::OkTimeout,
+            0 => HangExitOutcome::OkSuccess,
+            other => HangExitOutcome::OkOtherError { code: other },
+        };
+    }
+    HangExitOutcome::ExitCodeMismatch { got, expected }
+}
+
+fn is_recognized_rank_file(name: &str) -> bool {
+    // Accepted shapes: rank{N}.py.txt, rank{N}.native.txt, rank{N}.nccl.json
+    let Some(rest) = name.strip_prefix("rank") else {
+        return false;
+    };
+    let Some(dot) = rest.find('.') else {
+        return false;
+    };
+    let (num, suffix) = rest.split_at(dot);
+    if num.is_empty() || !num.bytes().all(|b| b.is_ascii_digit()) {
+        return false;
+    }
+    matches!(suffix, ".py.txt" | ".native.txt" | ".nccl.json")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ok_listing_for(world_size: usize) -> Vec<(String, u64)> {
+        (0..world_size).map(|r| (format!("rank{r}.py.txt"), 256u64)).collect()
+    }
+
+    fn listing_view(pairs: &[(String, u64)]) -> TraceDirListing<'_> {
+        let names: Vec<&str> = pairs.iter().map(|p| p.0.as_str()).collect();
+        let sizes: Vec<u64> = pairs.iter().map(|p| p.1).collect();
+        TraceDirListing { names, sizes }
+    }
+
+    #[test]
+    fn timeout_dump_ok_when_all_ranks_present() {
+        let pairs = ok_listing_for(2);
+        let listing = listing_view(&pairs);
+        assert_eq!(
+            classify_timeout_dump(&listing, 2),
+            HangTimeoutOutcome::Ok { ranks_seen: 2 }
+        );
+    }
+
+    #[test]
+    fn timeout_dump_rejects_empty_dir() {
+        let listing = TraceDirListing { names: vec![], sizes: vec![] };
+        assert_eq!(
+            classify_timeout_dump(&listing, 2),
+            HangTimeoutOutcome::DirEmpty
+        );
+    }
+
+    #[test]
+    fn timeout_dump_reports_missing_rank() {
+        let pairs = vec![("rank0.py.txt".to_string(), 256u64)];
+        let listing = listing_view(&pairs);
+        assert_eq!(
+            classify_timeout_dump(&listing, 2),
+            HangTimeoutOutcome::MissingRank { rank: 1 }
+        );
+    }
+
+    #[test]
+    fn timeout_dump_reports_empty_file() {
+        let pairs = vec![
+            ("rank0.py.txt".to_string(), 256u64),
+            ("rank1.py.txt".to_string(), 0u64),
+        ];
+        let listing = listing_view(&pairs);
+        assert_eq!(
+            classify_timeout_dump(&listing, 2),
+            HangTimeoutOutcome::EmptyFile { rank: 1 }
+        );
+    }
+
+    #[test]
+    fn timeout_dump_reports_unexpected_filename() {
+        let pairs = vec![("scratchpad.txt".to_string(), 10u64)];
+        let listing = listing_view(&pairs);
+        match classify_timeout_dump(&listing, 1) {
+            HangTimeoutOutcome::UnexpectedFilename { name } => assert_eq!(name, "scratchpad.txt"),
+            other => panic!("expected UnexpectedFilename, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn timeout_dump_accepts_extra_native_and_nccl_files() {
+        let pairs = vec![
+            ("rank0.py.txt".to_string(), 256u64),
+            ("rank0.native.txt".to_string(), 512u64),
+            ("rank0.nccl.json".to_string(), 1024u64),
+        ];
+        let listing = listing_view(&pairs);
+        assert_eq!(
+            classify_timeout_dump(&listing, 1),
+            HangTimeoutOutcome::Ok { ranks_seen: 1 }
+        );
+    }
+
+    #[test]
+    fn empty_on_success_ok_when_dir_is_empty() {
+        let listing = TraceDirListing { names: vec![], sizes: vec![] };
+        assert_eq!(
+            classify_empty_on_success(&listing),
+            HangEmptyOnSuccessOutcome::Ok
+        );
+    }
+
+    #[test]
+    fn empty_on_success_reports_unexpected_file() {
+        let pairs = vec![("rank0.py.txt".to_string(), 256u64)];
+        let listing = listing_view(&pairs);
+        match classify_empty_on_success(&listing) {
+            HangEmptyOnSuccessOutcome::UnexpectedFile { name } => {
+                assert_eq!(name, "rank0.py.txt");
+            }
+            other => panic!("expected UnexpectedFile, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn exit_code_124_matches_timeout() {
+        assert_eq!(
+            classify_exit_code(F14_TIMEOUT_EXIT_CODE, F14_TIMEOUT_EXIT_CODE),
+            HangExitOutcome::OkTimeout
+        );
+    }
+
+    #[test]
+    fn exit_code_1_is_other_error() {
+        assert_eq!(
+            classify_exit_code(1, 1),
+            HangExitOutcome::OkOtherError { code: 1 }
+        );
+    }
+
+    #[test]
+    fn exit_code_0_is_success() {
+        assert_eq!(classify_exit_code(0, 0), HangExitOutcome::OkSuccess);
+    }
+
+    #[test]
+    fn exit_code_mismatch_reports_both_values() {
+        assert_eq!(
+            classify_exit_code(1, F14_TIMEOUT_EXIT_CODE),
+            HangExitOutcome::ExitCodeMismatch { got: 1, expected: 124 }
+        );
+    }
+}

--- a/crates/apr-cli/src/commands/hang_trace_lint.rs
+++ b/crates/apr-cli/src/commands/hang_trace_lint.rs
@@ -1,0 +1,115 @@
+//! `apr hang-trace-lint` — CRUX-F-14 deadlock/hang-trace dir gate.
+//!
+//! Reads a captured `$APR_TRACE_DIR` after an `apr train` watchdog timeout
+//! (or a successful run) and dispatches the pure classifiers in
+//! `hang_trace_classifier`. Exits non-zero on any failure.
+//!
+//! Spec: `contracts/crux-F-14-v1.yaml`. CRUX-SHIP-001 g2/g3 surface.
+
+use std::path::{Path, PathBuf};
+
+use super::hang_trace_classifier::{
+    classify_empty_on_success, classify_exit_code, classify_timeout_dump,
+    HangEmptyOnSuccessOutcome, HangExitOutcome, HangTimeoutOutcome, TraceDirListing,
+};
+use crate::error::{CliError, Result};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum HangMode {
+    Timeout,
+    Success,
+}
+
+pub(crate) fn run(
+    trace_dir: &Path,
+    mode: HangMode,
+    world_size: usize,
+    exit_code: Option<i32>,
+    expected_exit_code: Option<i32>,
+    json: bool,
+) -> Result<()> {
+    if !trace_dir.exists() {
+        return Err(CliError::FileNotFound(PathBuf::from(trace_dir)));
+    }
+    let entries = std::fs::read_dir(trace_dir)?
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().map(|t| t.is_file()).unwrap_or(false))
+        .map(|e| {
+            let name = e.file_name().to_string_lossy().to_string();
+            let size = e.metadata().map(|m| m.len()).unwrap_or(0);
+            (name, size)
+        })
+        .collect::<Vec<_>>();
+    let names: Vec<&str> = entries.iter().map(|e| e.0.as_str()).collect();
+    let sizes: Vec<u64> = entries.iter().map(|e| e.1).collect();
+    let listing = TraceDirListing { names, sizes };
+
+    let dir_outcome_t = if mode == HangMode::Timeout {
+        Some(classify_timeout_dump(&listing, world_size))
+    } else {
+        None
+    };
+    let dir_outcome_s = if mode == HangMode::Success {
+        Some(classify_empty_on_success(&listing))
+    } else {
+        None
+    };
+    let exit_outcome = match (exit_code, expected_exit_code) {
+        (Some(got), Some(expected)) => Some(classify_exit_code(got, expected)),
+        _ => None,
+    };
+
+    print_report(trace_dir, dir_outcome_t.as_ref(), dir_outcome_s.as_ref(), exit_outcome.as_ref(), json);
+
+    if let Some(o) = &dir_outcome_t {
+        if !matches!(o, HangTimeoutOutcome::Ok { .. }) {
+            return Err(CliError::ValidationFailed(format!(
+                "hang-trace-lint timeout-dump gate rejected dir: {o:?}"
+            )));
+        }
+    }
+    if let Some(o) = &dir_outcome_s {
+        if !matches!(o, HangEmptyOnSuccessOutcome::Ok) {
+            return Err(CliError::ValidationFailed(format!(
+                "hang-trace-lint empty-on-success gate rejected dir: {o:?}"
+            )));
+        }
+    }
+    if let Some(o) = &exit_outcome {
+        if matches!(o, HangExitOutcome::ExitCodeMismatch { .. }) {
+            return Err(CliError::ValidationFailed(format!(
+                "hang-trace-lint exit-code gate rejected: {o:?}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn print_report(
+    trace_dir: &Path,
+    timeout_outcome: Option<&HangTimeoutOutcome>,
+    success_outcome: Option<&HangEmptyOnSuccessOutcome>,
+    exit_outcome: Option<&HangExitOutcome>,
+    json: bool,
+) {
+    if json {
+        let obj = serde_json::json!({
+            "trace_dir": trace_dir.display().to_string(),
+            "timeout_dump": timeout_outcome.map(|o| format!("{o:?}")),
+            "empty_on_success": success_outcome.map(|o| format!("{o:?}")),
+            "exit_code": exit_outcome.map(|o| format!("{o:?}")),
+        });
+        println!("{}", serde_json::to_string_pretty(&obj).unwrap_or_default());
+        return;
+    }
+    println!("hang-trace-lint report for {}", trace_dir.display());
+    if let Some(o) = timeout_outcome {
+        println!("  timeout_dump    : {o:?}");
+    }
+    if let Some(o) = success_outcome {
+        println!("  empty_on_success: {o:?}");
+    }
+    if let Some(o) = exit_outcome {
+        println!("  exit_code       : {o:?}");
+    }
+}

--- a/crates/apr-cli/src/commands/mod.rs
+++ b/crates/apr-cli/src/commands/mod.rs
@@ -61,6 +61,8 @@ pub(crate) mod gpu;
 pub(crate) mod gpu_memtrace_classifier;
 pub(crate) mod gpu_memtrace_lint;
 pub(crate) mod grad_norm;
+pub(crate) mod hang_trace_classifier;
+pub(crate) mod hang_trace_lint;
 pub(crate) mod hex;
 pub(crate) mod hf_endpoint;
 pub(crate) mod imatrix_classifier;

--- a/crates/apr-cli/src/dispatch_analysis.rs
+++ b/crates/apr-cli/src/dispatch_analysis.rs
@@ -226,6 +226,33 @@ fn dispatch_analysis_commands(cli: &Cli) -> Option<Result<(), CliError>> {
             cli.json,
         ),
 
+        ExtendedCommands::HangTraceLint {
+            trace_dir,
+            mode,
+            world_size,
+            exit_code,
+            expected_exit_code,
+        } => match mode.as_str() {
+            "timeout" | "success" => {
+                let m = if mode == "timeout" {
+                    commands::hang_trace_lint::HangMode::Timeout
+                } else {
+                    commands::hang_trace_lint::HangMode::Success
+                };
+                commands::hang_trace_lint::run(
+                    trace_dir,
+                    m,
+                    *world_size,
+                    *exit_code,
+                    *expected_exit_code,
+                    cli.json,
+                )
+            }
+            other => Err(crate::error::CliError::ValidationFailed(format!(
+                "apr hang-trace-lint --mode must be `timeout` or `success` (got `{other}`)"
+            ))),
+        },
+
         ExtendedCommands::OtlpLint {
             otlp_file,
             require_apr_span,

--- a/crates/apr-cli/src/extended_commands.rs
+++ b/crates/apr-cli/src/extended_commands.rs
@@ -808,6 +808,24 @@ pub enum ExtendedCommands {
         #[arg(long)]
         require_grammar: bool,
     },
+    /// Lint a captured `$APR_TRACE_DIR` hang stack-dump directory (CRUX-F-14)
+    HangTraceLint {
+        /// Path to the captured trace directory
+        #[arg(long, value_name = "DIR")]
+        trace_dir: PathBuf,
+        /// Inspection mode: `timeout` (expects per-rank dumps) or `success` (expects empty dir)
+        #[arg(long, value_name = "MODE", default_value = "timeout")]
+        mode: String,
+        /// Expected world_size when mode=timeout (number of rank{N}.py.txt files)
+        #[arg(long, value_name = "N", default_value_t = 2)]
+        world_size: usize,
+        /// Actual exit code from the run under inspection (for exit-code gate)
+        #[arg(long, value_name = "I32")]
+        exit_code: Option<i32>,
+        /// Expected exit code (typically 124 for timeout, 1 for other error, 0 for success)
+        #[arg(long, value_name = "I32")]
+        expected_exit_code: Option<i32>,
+    },
     /// Lint a captured `apr attn-viz` attention dump (CRUX-F-17)
     AttnVizLint {
         /// Path to attention dump in JSON form (4-D [layers][heads][rows][cols] floats)

--- a/crates/apr-cli/tests/cli_commands.rs
+++ b/crates/apr-cli/tests/cli_commands.rs
@@ -122,6 +122,7 @@ fn registered_commands() -> Vec<&'static str> {
         "embed-viz-lint",
         "nccl-diag-lint",
         "react-trace-lint",
+        "hang-trace-lint",
         "shard",
         "unshard",
         "oracle",

--- a/crates/apr-cli/tests/falsification_crux_f_14.rs
+++ b/crates/apr-cli/tests/falsification_crux_f_14.rs
@@ -1,0 +1,217 @@
+//! CRUX-F-14 — end-to-end falsification harness for `apr hang-trace-lint`.
+//!
+//! CRUX-SHIP-001 gate g3 evidence: every FALSIFY-CRUX-F-14-{001,002,003} gate
+//! the classifier discharges has a matching captured trace directory that the
+//! binary must classify exactly as the harness expects.
+
+use std::fs;
+use std::io::Write;
+use std::process::Command;
+
+fn apr_binary() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_apr"));
+    cmd.env("NO_COLOR", "1");
+    cmd
+}
+
+/// Build a temp directory with the given (filename, body) pairs.
+fn make_trace_dir(pairs: &[(&str, &[u8])]) -> tempfile::TempDir {
+    let dir = tempfile::Builder::new()
+        .prefix("crux-f-14-")
+        .tempdir()
+        .expect("tempdir");
+    for (name, body) in pairs {
+        let mut f = fs::File::create(dir.path().join(name)).expect("create file");
+        f.write_all(body).expect("write");
+        f.flush().expect("flush");
+    }
+    dir
+}
+
+fn good_world_size_2() -> Vec<(&'static str, &'static [u8])> {
+    vec![
+        ("rank0.py.txt", b"Traceback...\nFile \"x.py\", line 1\n"),
+        ("rank1.py.txt", b"Traceback...\nFile \"x.py\", line 1\n"),
+    ]
+}
+
+// ===== g2: CLI shape =====
+
+#[test]
+fn falsify_crux_f_14_cli_help_advertises_flags() {
+    let out = apr_binary().args(["hang-trace-lint", "--help"]).output().expect("run");
+    assert!(out.status.success(), "--help must exit 0");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    for flag in ["--trace-dir", "--mode", "--world-size", "--exit-code", "--expected-exit-code"] {
+        assert!(stdout.contains(flag), "--help must advertise {flag}; got:\n{stdout}");
+    }
+}
+
+#[test]
+fn falsify_crux_f_14_cli_missing_dir_fails() {
+    let out = apr_binary()
+        .args(["hang-trace-lint", "--trace-dir", "/nonexistent/crux-f-14-missing"])
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "missing dir must not exit 0");
+}
+
+#[test]
+fn falsify_crux_f_14_cli_rejects_invalid_mode() {
+    let dir = make_trace_dir(&good_world_size_2());
+    let out = apr_binary()
+        .args(["hang-trace-lint", "--trace-dir"])
+        .arg(dir.path())
+        .args(["--mode", "ambiguous"])
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "invalid mode must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("--mode must be"),
+        "stderr must explain mode requirement; got:\n{stderr}"
+    );
+}
+
+// ===== g3: classifier discharges =====
+
+#[test]
+fn falsify_crux_f_14_001_timeout_ok_on_complete_dump() {
+    let dir = make_trace_dir(&good_world_size_2());
+    let out = apr_binary()
+        .args(["hang-trace-lint", "--trace-dir"])
+        .arg(dir.path())
+        .args(["--world-size", "2"])
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "complete dump must pass; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn falsify_crux_f_14_001_timeout_rejects_missing_rank() {
+    let pairs: Vec<(&str, &[u8])> = vec![("rank0.py.txt", b"traceback\n")];
+    let dir = make_trace_dir(&pairs);
+    let out = apr_binary()
+        .args(["hang-trace-lint", "--trace-dir"])
+        .arg(dir.path())
+        .args(["--world-size", "2"])
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "missing rank must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("MissingRank"),
+        "stderr must name MissingRank; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn falsify_crux_f_14_001_timeout_rejects_empty_file() {
+    let pairs: Vec<(&str, &[u8])> = vec![
+        ("rank0.py.txt", b"traceback\n"),
+        ("rank1.py.txt", b""),
+    ];
+    let dir = make_trace_dir(&pairs);
+    let out = apr_binary()
+        .args(["hang-trace-lint", "--trace-dir"])
+        .arg(dir.path())
+        .args(["--world-size", "2"])
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "empty rank file must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("EmptyFile"),
+        "stderr must name EmptyFile; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn falsify_crux_f_14_002_success_ok_when_dir_is_empty() {
+    let pairs: Vec<(&str, &[u8])> = vec![];
+    let dir = make_trace_dir(&pairs);
+    let out = apr_binary()
+        .args(["hang-trace-lint", "--trace-dir"])
+        .arg(dir.path())
+        .args(["--mode", "success"])
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "empty dir under success mode must pass; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn falsify_crux_f_14_002_success_rejects_unexpected_file() {
+    let pairs: Vec<(&str, &[u8])> = vec![("rank0.py.txt", b"oops\n")];
+    let dir = make_trace_dir(&pairs);
+    let out = apr_binary()
+        .args(["hang-trace-lint", "--trace-dir"])
+        .arg(dir.path())
+        .args(["--mode", "success"])
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "false-trigger dump must fail success mode");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("UnexpectedFile"),
+        "stderr must name UnexpectedFile; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn falsify_crux_f_14_003_exit_code_124_passes_timeout_expectation() {
+    let dir = make_trace_dir(&good_world_size_2());
+    let out = apr_binary()
+        .args(["hang-trace-lint", "--trace-dir"])
+        .arg(dir.path())
+        .args(["--world-size", "2", "--exit-code", "124", "--expected-exit-code", "124"])
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "exit 124 matching 124 must pass; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn falsify_crux_f_14_003_exit_code_1_fails_timeout_expectation() {
+    let dir = make_trace_dir(&good_world_size_2());
+    let out = apr_binary()
+        .args(["hang-trace-lint", "--trace-dir"])
+        .arg(dir.path())
+        .args(["--world-size", "2", "--exit-code", "1", "--expected-exit-code", "124"])
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "exit 1 != 124 must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("ExitCodeMismatch"),
+        "stderr must name ExitCodeMismatch; got:\n{stderr}"
+    );
+}
+
+// ===== JSON output shape =====
+
+#[test]
+fn falsify_crux_f_14_json_output_contains_outcomes() {
+    let dir = make_trace_dir(&good_world_size_2());
+    let out = apr_binary()
+        .args(["--json", "hang-trace-lint", "--trace-dir"])
+        .arg(dir.path())
+        .args(["--world-size", "2", "--exit-code", "124", "--expected-exit-code", "124"])
+        .output()
+        .expect("run");
+    assert!(out.status.success(), "json + good dir must exit 0");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("json output must parse");
+    assert!(parsed["timeout_dump"].as_str().expect("timeout_dump").contains("Ok"));
+    assert!(parsed["exit_code"].as_str().expect("exit_code").contains("OkTimeout"));
+}


### PR DESCRIPTION
## Summary

- Promotes \`contracts/crux-F-14-v1.yaml\` from \`draft\` → PARTIAL_ALGORITHM_LEVEL.
- Adds \`apr hang-trace-lint --trace-dir DIR [--mode timeout|success] [--world-size N] [--exit-code I] [--expected-exit-code I]\` — pure-function classifier validating: per-rank stack-dump files (\`rank{N}.py.txt\`) on timeout, empty trace-dir on success, exit-code 124/1/0 distinction (PyTorch 2.x \`torch.distributed.*\` parity).
- 12 classifier unit tests + 11 e2e falsification tests + 8 cli_commands surface tests all pass.

Discharges FALSIFY-CRUX-F-14-{001,002,003} at PARTIAL_ALGORITHM_LEVEL.

## Test plan

- [x] \`cargo test -p apr-cli --lib hang_trace_classifier\` — 12/12 pass.
- [x] \`cargo test -p apr-cli --test falsification_crux_f_14\` — 11/11 pass.
- [x] \`cargo test -p apr-cli --test cli_commands\` — 8/8 pass (3-surface drift policy).
- [x] \`pv validate contracts/crux-F-14-v1.yaml\` — clean.
- [ ] CI green on \`ci / gate\` + \`workspace-test\`.

Refs #921 (CRUX M4 observability epic), #917 (CRUX Phase 3 umbrella).

🤖 Generated with [Claude Code](https://claude.com/claude-code)