### PR TITLE
feat(apr-cli): CRUX-F-15 `apr nccl-diag-lint` NCCL failure-diagnostics classifier

### DIFF
--- a/contracts/apr-cli-commands-v1.yaml
+++ b/contracts/apr-cli-commands-v1.yaml
@@ -586,6 +586,12 @@ commands:
     requires_model: false
     side_effects: []
 
+  - name: nccl-diag-lint
+    category: inspection
+    description: "Validate captured NCCL failure-diagnostics JSON (CRUX-F-15): 6 required keys (host, rank, nccl_version, last_op, code, suggest) + optional exit-code >= 128 + optional nvidia.com doc-link in suggest"
+    requires_model: false
+    side_effects: []
+
   - name: shard
     category: model_ops
     description: "Split safetensors file into shards + weight-map index (CRUX-B-05)"

--- a/contracts/crux-F-15-v1.yaml
+++ b/contracts/crux-F-15-v1.yaml
@@ -1,12 +1,21 @@
 # CRUX-F-15 — NCCL failure diagnostics
+# Promoted to PARTIAL_ALGORITHM_LEVEL at v1.2.0 under CRUX-SHIP-001 (2026-05-17):
+# - classifier: crates/apr-cli/src/commands/nccl_diag_classifier.rs (12 unit tests)
+# - CLI surface: `apr nccl-diag-lint --diag-file F [--exit-code I] [--require-doc-link]`
+# - e2e: crates/apr-cli/tests/falsification_crux_f_15.rs (11 tests)
+# Full discharge of F-15-{001,002,003} requires a live `apr train`
+# actually emitting the diagnostic on NCCL error — tracked as
+# BLOCKER-UPSTREAM-MISSING.
 
 metadata:
   id: CRUX-F-15
-  version: "1.1.0"
+  version: "1.2.0"
   created: "2026-04-18"
+  updated: "2026-05-17"
   author: PAIML Engineering
   registry: true
-  status: draft
+  status: partial
+  kind: kernel
   parent_contracts:
   - crux-competitive-research-ux-v1
   category: "F — Tensor Ops & Low-level"
@@ -57,6 +66,25 @@ falsification_tests:
       assert k in d, f"missing key {k}"
     PY
   if_fails: rule 'nccl error produces parseable JSON diag' is violated — contract MUST be re-verified against competitor canonical reference
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/nccl_diag_classifier.rs
+    cli_path: crates/apr-cli/src/commands/nccl_diag_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_f_15.rs
+    e2e_tests:
+    - falsify_crux_f_15_001_schema_ok_on_well_formed
+    - falsify_crux_f_15_001_schema_rejects_missing_key
+    - falsify_crux_f_15_001_schema_rejects_negative_rank
+    sub_claim: |
+      Algorithm-level necessary conditions on the captured stderr
+      JSON: `classify_schema` verifies the body is an object with the
+      6 required keys (`host`, `rank`, `nccl_version`, `last_op`,
+      `code`, `suggest`), `host`/`nccl_version`/`last_op`/`suggest`
+      are strings, `rank` is a non-negative integer, and `code` is
+      an integer. Outcomes name the offending field so emitter bugs
+      are debuggable from lint output alone.
+    scope: "(body) -> NcclSchemaOutcome (pure)"
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: "live `apr train` emitting the F-15 JSON diagnostic on NCCL error"
 - id: FALSIFY-CRUX-F-15-002
   rule: exit code encodes err code (not generic 1)
   prediction: "exit code != 1 (non-generic); maps to 128+code range"
@@ -66,6 +94,23 @@ falsification_tests:
       --world-size 2 --steps 1 --model tests/fixtures/tinyllama-hf 2>/dev/null; ec=$?
     [ "$ec" -ge 128 ]
   if_fails: rule 'exit code encodes err code (not generic 1)' is violated — contract MUST be re-verified against competitor canonical reference
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/nccl_diag_classifier.rs
+    cli_path: crates/apr-cli/src/commands/nccl_diag_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_f_15.rs
+    e2e_tests:
+    - falsify_crux_f_15_002_exit_code_ge_128_passes
+    - falsify_crux_f_15_002_exit_code_1_fails
+    sub_claim: |
+      Algorithm-level necessary condition: `classify_exit_code`
+      verifies observed exit code is >= 128 (POSIX `128 +
+      signal_or_code` convention used by NCCL error classes).
+      Generic exit 1 fails, signaling that the scheduler cannot
+      dispatch on the NCCL error class. Reports
+      `BelowThreshold { got, threshold }`.
+    scope: "(got, threshold) -> NcclExitOutcome (pure)"
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: "live `apr train` returning 128+code on NCCL error"
 - id: FALSIFY-CRUX-F-15-003
   rule: suggest field cites NCCL doc link
   prediction: "suggest field contains an nvidia.com or nccl URL"
@@ -74,6 +119,24 @@ falsification_tests:
     grep -Eo 'https?://(docs\.nvidia\.com|developer\.nvidia\.com|github\.com/NVIDIA/nccl)' /tmp/nccl-err
 
   if_fails: rule 'suggest field cites NCCL doc link' is violated — contract MUST be re-verified against competitor canonical reference
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/nccl_diag_classifier.rs
+    cli_path: crates/apr-cli/src/commands/nccl_diag_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_f_15.rs
+    e2e_tests:
+    - falsify_crux_f_15_003_doc_link_ok_on_nvidia_url
+    - falsify_crux_f_15_003_doc_link_rejects_free_text
+    sub_claim: |
+      Algorithm-level necessary condition: `classify_doc_link`
+      verifies the `suggest` field contains at least one canonical
+      NCCL documentation URL substring (docs.nvidia.com,
+      developer.nvidia.com, github.com/NVIDIA/nccl). Free-text
+      suggestions fail with `NoDocLink { suggest }`, surfacing
+      the actual emitted text so the operator can patch the
+      suggest table.
+    scope: "(body) -> NcclDocLinkOutcome (pure)"
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: "live `apr train` emitting actionable doc-link suggestions"
 proof_obligations:
 - type: equivalence
   property: "apr NCCL diagnosis surface matches TORCH_NCCL_ASYNC_ERROR_HANDLING behavior"

--- a/crates/apr-cli/src/commands/mod.rs
+++ b/crates/apr-cli/src/commands/mod.rs
@@ -81,6 +81,8 @@ pub(crate) mod monitor;
 #[cfg(feature = "dev")]
 pub mod mono;
 pub(crate) mod multi_lora_classifier;
+pub(crate) mod nccl_diag_classifier;
+pub(crate) mod nccl_diag_lint;
 pub(crate) mod nf4_classifier;
 pub(crate) mod nf4_lint;
 pub(crate) mod offline;

--- a/crates/apr-cli/src/commands/nccl_diag_classifier.rs
+++ b/crates/apr-cli/src/commands/nccl_diag_classifier.rs
@@ -1,0 +1,237 @@
+//! NCCL failure-diagnostics JSON classifier (CRUX-F-15).
+//!
+//! Pure, deterministic classifiers that discharge FALSIFY-CRUX-F-15-{001,002,003}
+//! at the PARTIAL_ALGORITHM_LEVEL — algorithm-level necessary conditions on
+//! the actionable JSON diagnostic emitted on stderr when an NCCL collective
+//! fails (e.g. `apr train` under `TORCH_NCCL_ASYNC_ERROR_HANDLING` parity):
+//!
+//!   * `classify_schema` — JSON object carries all 6 required keys
+//!     (`host`, `rank`, `nccl_version`, `last_op`, `code`, `suggest`)
+//!     with the expected types.
+//!   * `classify_exit_code` — observed exit code is >= 128 (encodes
+//!     NCCL error class so schedulers can dispatch).
+//!   * `classify_doc_link` — `suggest` field contains an
+//!     `nvidia.com` / `github.com/NVIDIA/nccl` URL (actionable
+//!     redirect into the canonical NCCL troubleshooting docs).
+//!
+//! Full discharge of F-15-{001,002,003} requires a live `apr train`
+//! actually emitting the diagnostic on NCCL error — tracked as
+//! BLOCKER-UPSTREAM-MISSING.
+
+use serde_json::Value;
+
+/// Required top-level keys on the CRUX-F-15 diagnostic JSON.
+pub const F15_REQUIRED_KEYS: &[&str] =
+    &["host", "rank", "nccl_version", "last_op", "code", "suggest"];
+
+/// Minimum exit code that signals an NCCL-class failure (POSIX:
+/// `128 + signal_or_code`). Below this and the scheduler cannot
+/// distinguish NCCL faults from generic process failure.
+pub const F15_MIN_EXIT_CODE: i32 = 128;
+
+/// Substrings any one of which is sufficient to satisfy the
+/// "suggest field cites NCCL doc link" gate.
+pub const F15_DOC_LINK_SUBSTRINGS: &[&str] = &[
+    "docs.nvidia.com",
+    "developer.nvidia.com",
+    "github.com/NVIDIA/nccl",
+];
+
+/// Outcome of `classify_schema`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NcclSchemaOutcome {
+    Ok,
+    NotAnObject,
+    MissingKey { key: &'static str },
+    HostNotString,
+    RankNotNonNegativeInt { got: i64 },
+    NcclVersionNotString,
+    LastOpNotString,
+    CodeNotInt,
+    SuggestNotString,
+}
+
+/// Outcome of `classify_exit_code`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NcclExitOutcome {
+    Ok { code: i32 },
+    BelowThreshold { got: i32, threshold: i32 },
+}
+
+/// Outcome of `classify_doc_link`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NcclDocLinkOutcome {
+    Ok,
+    NoDocLink { suggest: String },
+}
+
+/// Validate the JSON has all required keys with expected types.
+pub fn classify_schema(body: &Value) -> NcclSchemaOutcome {
+    let Some(obj) = body.as_object() else {
+        return NcclSchemaOutcome::NotAnObject;
+    };
+    for k in F15_REQUIRED_KEYS {
+        if !obj.contains_key(*k) {
+            return NcclSchemaOutcome::MissingKey { key: k };
+        }
+    }
+    if obj.get("host").and_then(Value::as_str).is_none() {
+        return NcclSchemaOutcome::HostNotString;
+    }
+    let rank = obj.get("rank").and_then(Value::as_i64).unwrap_or(-1);
+    if rank < 0 {
+        return NcclSchemaOutcome::RankNotNonNegativeInt { got: rank };
+    }
+    if obj.get("nccl_version").and_then(Value::as_str).is_none() {
+        return NcclSchemaOutcome::NcclVersionNotString;
+    }
+    if obj.get("last_op").and_then(Value::as_str).is_none() {
+        return NcclSchemaOutcome::LastOpNotString;
+    }
+    if obj.get("code").and_then(Value::as_i64).is_none() {
+        return NcclSchemaOutcome::CodeNotInt;
+    }
+    if obj.get("suggest").and_then(Value::as_str).is_none() {
+        return NcclSchemaOutcome::SuggestNotString;
+    }
+    NcclSchemaOutcome::Ok
+}
+
+/// Verify exit code >= `threshold` (default `F15_MIN_EXIT_CODE`).
+pub fn classify_exit_code(got: i32, threshold: i32) -> NcclExitOutcome {
+    if got >= threshold {
+        NcclExitOutcome::Ok { code: got }
+    } else {
+        NcclExitOutcome::BelowThreshold { got, threshold }
+    }
+}
+
+/// Verify the `suggest` field contains at least one canonical NCCL doc URL.
+pub fn classify_doc_link(body: &Value) -> NcclDocLinkOutcome {
+    let suggest = body
+        .get("suggest")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string();
+    for needle in F15_DOC_LINK_SUBSTRINGS {
+        if suggest.contains(*needle) {
+            return NcclDocLinkOutcome::Ok;
+        }
+    }
+    NcclDocLinkOutcome::NoDocLink { suggest }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn good_body() -> Value {
+        json!({
+            "host": "node-0",
+            "rank": 0,
+            "peer_rank": 1,
+            "nccl_version": "2.20.5",
+            "cuda_devices": "0,1",
+            "fabric": "ib",
+            "last_op": "AllReduce",
+            "code": 6,
+            "suggest": "See https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/troubleshooting.html"
+        })
+    }
+
+    #[test]
+    fn schema_ok_on_good_body() {
+        assert_eq!(classify_schema(&good_body()), NcclSchemaOutcome::Ok);
+    }
+
+    #[test]
+    fn schema_rejects_not_an_object() {
+        assert_eq!(
+            classify_schema(&json!([1, 2])),
+            NcclSchemaOutcome::NotAnObject
+        );
+    }
+
+    #[test]
+    fn schema_reports_missing_key() {
+        let mut body = good_body();
+        body.as_object_mut().expect("obj").remove("suggest");
+        assert_eq!(
+            classify_schema(&body),
+            NcclSchemaOutcome::MissingKey { key: "suggest" }
+        );
+    }
+
+    #[test]
+    fn schema_rejects_negative_rank() {
+        let mut body = good_body();
+        body["rank"] = json!(-1);
+        assert!(matches!(
+            classify_schema(&body),
+            NcclSchemaOutcome::RankNotNonNegativeInt { got: -1 }
+        ));
+    }
+
+    #[test]
+    fn schema_rejects_non_string_host() {
+        let mut body = good_body();
+        body["host"] = json!(123);
+        assert_eq!(classify_schema(&body), NcclSchemaOutcome::HostNotString);
+    }
+
+    #[test]
+    fn schema_rejects_non_int_code() {
+        let mut body = good_body();
+        body["code"] = json!("six");
+        assert_eq!(classify_schema(&body), NcclSchemaOutcome::CodeNotInt);
+    }
+
+    #[test]
+    fn exit_code_ok_at_threshold() {
+        assert_eq!(
+            classify_exit_code(F15_MIN_EXIT_CODE, F15_MIN_EXIT_CODE),
+            NcclExitOutcome::Ok { code: 128 }
+        );
+    }
+
+    #[test]
+    fn exit_code_ok_above_threshold() {
+        assert_eq!(
+            classify_exit_code(134, F15_MIN_EXIT_CODE),
+            NcclExitOutcome::Ok { code: 134 }
+        );
+    }
+
+    #[test]
+    fn exit_code_rejects_generic_one() {
+        assert_eq!(
+            classify_exit_code(1, F15_MIN_EXIT_CODE),
+            NcclExitOutcome::BelowThreshold { got: 1, threshold: 128 }
+        );
+    }
+
+    #[test]
+    fn doc_link_ok_on_nvidia_url() {
+        assert_eq!(classify_doc_link(&good_body()), NcclDocLinkOutcome::Ok);
+    }
+
+    #[test]
+    fn doc_link_ok_on_nccl_github() {
+        let mut body = good_body();
+        body["suggest"] = json!("Check github.com/NVIDIA/nccl/issues/123");
+        assert_eq!(classify_doc_link(&body), NcclDocLinkOutcome::Ok);
+    }
+
+    #[test]
+    fn doc_link_rejects_free_text() {
+        let mut body = good_body();
+        body["suggest"] = json!("Try restarting your training run");
+        match classify_doc_link(&body) {
+            NcclDocLinkOutcome::NoDocLink { suggest } => {
+                assert!(suggest.contains("restarting"));
+            }
+            other => panic!("expected NoDocLink, got {other:?}"),
+        }
+    }
+}

--- a/crates/apr-cli/src/commands/nccl_diag_lint.rs
+++ b/crates/apr-cli/src/commands/nccl_diag_lint.rs
@@ -1,0 +1,93 @@
+//! `apr nccl-diag-lint` — CRUX-F-15 NCCL failure-diagnostics gate.
+//!
+//! Reads a captured stderr JSON diagnostic emitted by `apr train` on NCCL
+//! error and dispatches the pure classifiers in `nccl_diag_classifier`.
+//! Exits non-zero on any failure.
+//!
+//! Spec: `contracts/crux-F-15-v1.yaml`. CRUX-SHIP-001 g2/g3 surface.
+
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+
+use super::nccl_diag_classifier::{
+    classify_doc_link, classify_exit_code, classify_schema, NcclDocLinkOutcome, NcclExitOutcome,
+    NcclSchemaOutcome, F15_MIN_EXIT_CODE,
+};
+use crate::error::{CliError, Result};
+
+pub(crate) fn run(
+    diag_file: &Path,
+    exit_code: Option<i32>,
+    require_doc_link: bool,
+    json: bool,
+) -> Result<()> {
+    if !diag_file.exists() {
+        return Err(CliError::FileNotFound(PathBuf::from(diag_file)));
+    }
+    let body_text = std::fs::read_to_string(diag_file)?;
+    let body: Value = serde_json::from_str(&body_text).map_err(|e| {
+        CliError::InvalidFormat(format!(
+            "apr nccl-diag-lint: failed to parse JSON from {}: {e}",
+            diag_file.display()
+        ))
+    })?;
+
+    let schema = classify_schema(&body);
+    let doc_link = if require_doc_link && matches!(schema, NcclSchemaOutcome::Ok) {
+        Some(classify_doc_link(&body))
+    } else {
+        None
+    };
+    let exit = exit_code.map(|c| classify_exit_code(c, F15_MIN_EXIT_CODE));
+
+    print_report(diag_file, &schema, doc_link.as_ref(), exit.as_ref(), json);
+
+    if !matches!(schema, NcclSchemaOutcome::Ok) {
+        return Err(CliError::ValidationFailed(format!(
+            "nccl-diag-lint schema gate rejected body: {schema:?}"
+        )));
+    }
+    if let Some(o) = &doc_link {
+        if !matches!(o, NcclDocLinkOutcome::Ok) {
+            return Err(CliError::ValidationFailed(format!(
+                "nccl-diag-lint doc-link gate rejected body: {o:?}"
+            )));
+        }
+    }
+    if let Some(o) = &exit {
+        if !matches!(o, NcclExitOutcome::Ok { .. }) {
+            return Err(CliError::ValidationFailed(format!(
+                "nccl-diag-lint exit-code gate rejected: {o:?}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn print_report(
+    path: &Path,
+    schema: &NcclSchemaOutcome,
+    doc_link: Option<&NcclDocLinkOutcome>,
+    exit: Option<&NcclExitOutcome>,
+    json: bool,
+) {
+    if json {
+        let obj = serde_json::json!({
+            "file": path.display().to_string(),
+            "schema": format!("{schema:?}"),
+            "doc_link": doc_link.map(|o| format!("{o:?}")),
+            "exit_code": exit.map(|o| format!("{o:?}")),
+        });
+        println!("{}", serde_json::to_string_pretty(&obj).unwrap_or_default());
+        return;
+    }
+    println!("nccl-diag-lint report for {}", path.display());
+    println!("  schema    : {schema:?}");
+    if let Some(o) = doc_link {
+        println!("  doc_link  : {o:?}");
+    }
+    if let Some(o) = exit {
+        println!("  exit_code : {o:?}");
+    }
+}

--- a/crates/apr-cli/src/dispatch_analysis.rs
+++ b/crates/apr-cli/src/dispatch_analysis.rs
@@ -183,6 +183,12 @@ fn dispatch_analysis_commands(cli: &Cli) -> Option<Result<(), CliError>> {
             cli.json,
         ),
 
+        ExtendedCommands::NcclDiagLint {
+            diag_file,
+            exit_code,
+            require_doc_link,
+        } => commands::nccl_diag_lint::run(diag_file, *exit_code, *require_doc_link, cli.json),
+
         ExtendedCommands::AttnVizLint {
             attn_file,
             html_file,

--- a/crates/apr-cli/src/extended_commands.rs
+++ b/crates/apr-cli/src/extended_commands.rs
@@ -784,6 +784,18 @@ pub enum ExtendedCommands {
         #[arg(long, value_name = "FILE")]
         stderr_file: Option<PathBuf>,
     },
+    /// Lint a captured NCCL failure-diagnostics JSON from stderr (CRUX-F-15)
+    NcclDiagLint {
+        /// Path to captured stderr JSON diagnostic
+        #[arg(long, value_name = "FILE")]
+        diag_file: PathBuf,
+        /// Optional observed exit code (gate: >= 128 = NCCL class)
+        #[arg(long, value_name = "I32")]
+        exit_code: Option<i32>,
+        /// Require the `suggest` field to cite an nvidia.com / NVIDIA/nccl URL
+        #[arg(long)]
+        require_doc_link: bool,
+    },
     /// Lint a captured `apr attn-viz` attention dump (CRUX-F-17)
     AttnVizLint {
         /// Path to attention dump in JSON form (4-D [layers][heads][rows][cols] floats)

--- a/crates/apr-cli/tests/cli_commands.rs
+++ b/crates/apr-cli/tests/cli_commands.rs
@@ -120,6 +120,7 @@ fn registered_commands() -> Vec<&'static str> {
         "check-finite-lint",
         "attn-viz-lint",
         "embed-viz-lint",
+        "nccl-diag-lint",
         "shard",
         "unshard",
         "oracle",

--- a/crates/apr-cli/tests/falsification_crux_f_15.rs
+++ b/crates/apr-cli/tests/falsification_crux_f_15.rs
@@ -1,0 +1,220 @@
+//! CRUX-F-15 — end-to-end falsification harness for `apr nccl-diag-lint`.
+//!
+//! CRUX-SHIP-001 gate g3 evidence: every FALSIFY-CRUX-F-15-{001,002,003}
+//! gate the classifier discharges has a matching captured JSON body that
+//! the binary must classify exactly as the harness expects.
+
+use serde_json::json;
+use std::io::Write;
+use std::process::Command;
+
+fn apr_binary() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_apr"));
+    cmd.env("NO_COLOR", "1");
+    cmd
+}
+
+fn write_json(body: &serde_json::Value) -> tempfile::NamedTempFile {
+    let mut f = tempfile::Builder::new()
+        .prefix("crux-f-15-")
+        .suffix(".json")
+        .tempfile()
+        .expect("tempfile");
+    f.write_all(serde_json::to_vec_pretty(body).expect("serialize").as_slice())
+        .expect("write");
+    f.flush().expect("flush");
+    f
+}
+
+fn good_body() -> serde_json::Value {
+    json!({
+        "host": "node-0",
+        "rank": 0,
+        "peer_rank": 1,
+        "nccl_version": "2.20.5",
+        "cuda_devices": "0,1",
+        "fabric": "ib",
+        "last_op": "AllReduce",
+        "code": 6,
+        "suggest": "See https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/troubleshooting.html"
+    })
+}
+
+// ===== g2: CLI shape =====
+
+#[test]
+fn falsify_crux_f_15_cli_help_advertises_flags() {
+    let out = apr_binary().args(["nccl-diag-lint", "--help"]).output().expect("run");
+    assert!(out.status.success(), "--help must exit 0");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    for flag in ["--diag-file", "--exit-code", "--require-doc-link"] {
+        assert!(stdout.contains(flag), "--help must advertise {flag}; got:\n{stdout}");
+    }
+}
+
+#[test]
+fn falsify_crux_f_15_cli_missing_file_fails() {
+    let out = apr_binary()
+        .args(["nccl-diag-lint", "--diag-file", "/nonexistent/crux-f-15-missing.json"])
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "missing file must not exit 0");
+}
+
+#[test]
+fn falsify_crux_f_15_cli_malformed_json_fails() {
+    let mut f = tempfile::Builder::new()
+        .prefix("crux-f-15-bad-")
+        .suffix(".json")
+        .tempfile()
+        .expect("tempfile");
+    f.write_all(b"{ not json").expect("write");
+    f.flush().expect("flush");
+    let out = apr_binary()
+        .args(["nccl-diag-lint", "--diag-file"])
+        .arg(f.path())
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "malformed JSON must not exit 0");
+}
+
+// ===== g3: classifier discharges =====
+
+#[test]
+fn falsify_crux_f_15_001_schema_ok_on_well_formed() {
+    let f = write_json(&good_body());
+    let out = apr_binary()
+        .args(["nccl-diag-lint", "--diag-file"])
+        .arg(f.path())
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "good diag must pass; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn falsify_crux_f_15_001_schema_rejects_missing_key() {
+    let mut body = good_body();
+    body.as_object_mut().expect("obj").remove("suggest");
+    let f = write_json(&body);
+    let out = apr_binary()
+        .args(["nccl-diag-lint", "--diag-file"])
+        .arg(f.path())
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "missing suggest must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("MissingKey") && stderr.contains("suggest"),
+        "stderr must name MissingKey(suggest); got:\n{stderr}"
+    );
+}
+
+#[test]
+fn falsify_crux_f_15_001_schema_rejects_negative_rank() {
+    let mut body = good_body();
+    body["rank"] = json!(-5);
+    let f = write_json(&body);
+    let out = apr_binary()
+        .args(["nccl-diag-lint", "--diag-file"])
+        .arg(f.path())
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "negative rank must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("RankNotNonNegativeInt"),
+        "stderr must name RankNotNonNegativeInt; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn falsify_crux_f_15_002_exit_code_ge_128_passes() {
+    let f = write_json(&good_body());
+    let out = apr_binary()
+        .args(["nccl-diag-lint", "--diag-file"])
+        .arg(f.path())
+        .args(["--exit-code", "134"])
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "exit 134 must pass (>= 128); stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn falsify_crux_f_15_002_exit_code_1_fails() {
+    let f = write_json(&good_body());
+    let out = apr_binary()
+        .args(["nccl-diag-lint", "--diag-file"])
+        .arg(f.path())
+        .args(["--exit-code", "1"])
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "exit 1 must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("BelowThreshold"),
+        "stderr must name BelowThreshold; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn falsify_crux_f_15_003_doc_link_ok_on_nvidia_url() {
+    let f = write_json(&good_body());
+    let out = apr_binary()
+        .args(["nccl-diag-lint", "--diag-file"])
+        .arg(f.path())
+        .arg("--require-doc-link")
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "nvidia.com URL in suggest must pass; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn falsify_crux_f_15_003_doc_link_rejects_free_text() {
+    let mut body = good_body();
+    body["suggest"] = json!("Try restarting and check logs");
+    let f = write_json(&body);
+    let out = apr_binary()
+        .args(["nccl-diag-lint", "--diag-file"])
+        .arg(f.path())
+        .arg("--require-doc-link")
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "free-text suggest must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("NoDocLink"),
+        "stderr must name NoDocLink; got:\n{stderr}"
+    );
+}
+
+// ===== JSON output shape =====
+
+#[test]
+fn falsify_crux_f_15_json_output_contains_outcomes() {
+    let f = write_json(&good_body());
+    let out = apr_binary()
+        .args(["--json", "nccl-diag-lint", "--diag-file"])
+        .arg(f.path())
+        .args(["--exit-code", "134"])
+        .arg("--require-doc-link")
+        .output()
+        .expect("run");
+    assert!(out.status.success(), "json + good body must exit 0");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("json output must parse");
+    assert!(parsed["schema"].as_str().expect("schema").contains("Ok"));
+    assert!(parsed["doc_link"].as_str().expect("doc_link").contains("Ok"));
+    assert!(parsed["exit_code"].as_str().expect("exit_code").contains("Ok"));
+}


### PR DESCRIPTION
## Summary

- Promotes \`contracts/crux-F-15-v1.yaml\` from \`draft\` → PARTIAL_ALGORITHM_LEVEL.
- Adds \`apr nccl-diag-lint --diag-file F [--exit-code I] [--require-doc-link]\` — pure-function classifier validating: 6-key JSON schema (host, rank, nccl_version, last_op, code, suggest), exit code ≥ 128, suggest contains nvidia.com / NVIDIA/nccl URL (PyTorch \`TORCH_NCCL_ASYNC_ERROR_HANDLING\` parity).
- 12 classifier unit tests + 11 e2e falsification tests + 8 cli_commands surface tests all pass.

Discharges FALSIFY-CRUX-F-15-{001,002,003} at PARTIAL_ALGORITHM_LEVEL.

## Test plan

- [x] \`cargo test -p apr-cli --lib nccl_diag_classifier\` — 12/12 pass.
- [x] \`cargo test -p apr-cli --test falsification_crux_f_15\` — 11/11 pass.
- [x] \`cargo test -p apr-cli --test cli_commands\` — 8/8 pass (3-surface drift policy).
- [x] \`pv validate contracts/crux-F-15-v1.yaml\` — clean.
- [ ] CI green on \`ci / gate\` + \`workspace-test\`.

Refs #921 (CRUX M4 observability epic), #917 (CRUX Phase 3 umbrella).

🤖 Generated with [Claude Code](https://claude.com/claude-code)