### PR TITLE
feat(apr-cli): CRUX-I-06 `apr react-trace-lint` ReAct agent trace classifier

### DIFF
--- a/contracts/apr-cli-commands-v1.yaml
+++ b/contracts/apr-cli-commands-v1.yaml
@@ -592,6 +592,12 @@ commands:
     requires_model: false
     side_effects: []
 
+  - name: react-trace-lint
+    category: inspection
+    description: "Validate captured `apr agent --trace` ReAct loop trace (CRUX-I-06): termination reason matches exit-code (final_answer=0, max_iterations|timeout=2, tool_error=3, parse_fail=4) + iteration bound + scratchpad grammar (Thought/Action/Observation/Final Answer)"
+    requires_model: false
+    side_effects: []
+
   - name: shard
     category: model_ops
     description: "Split safetensors file into shards + weight-map index (CRUX-B-05)"

--- a/contracts/crux-I-06-v1.yaml
+++ b/contracts/crux-I-06-v1.yaml
@@ -1,16 +1,21 @@
 # CRUX-I-06 — ReAct agent loop + stop conditions
-# Auto-scaffolded from crux-competitive-research-ux-v1.yaml (DRAFT).
-# DO NOT promote to ACTIVE until: (1) evidence collected, (2) falsification
-# body reflects competitor's canonical CLI, (3) apr surface mapped or gap
-# tracked in pmat work (see master §12).
+# Promoted to PARTIAL_ALGORITHM_LEVEL at v1.1.0 under CRUX-SHIP-001 (2026-05-17):
+# - classifier: crates/apr-cli/src/commands/react_trace_classifier.rs (14 unit tests)
+# - CLI surface: `apr react-trace-lint --trace-file F [--max-iterations N] [--require-grammar]`
+# - e2e: crates/apr-cli/tests/falsification_crux_i_06.rs (10 tests)
+# Full discharge of -001/-002/-003 requires a live `apr agent` actually
+# running the ReAct loop and writing the trace JSON — tracked as
+# BLOCKER-UPSTREAM-MISSING.
 
 metadata:
   id: CRUX-I-06
-  version: "1.0.0-draft"
+  version: "1.1.0"
   created: "2026-04-18"
+  updated: "2026-05-17"
   author: PAIML Engineering
   registry: true
-  status: draft
+  status: partial
+  kind: kernel
   parent_contracts:
   - crux-competitive-research-ux-v1
   category: "I — Observability & Metrics"
@@ -98,6 +103,27 @@ falsification_tests:
       || { echo "FAIL: answer not extracted from Final Answer: line" >&2; exit 1; }
 
   if_fails: rule 'ReAct loop halts on 'Final Answer:' before next Action' is violated — contract MUST be re-verified against competitor canonical reference
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/react_trace_classifier.rs
+    cli_path: crates/apr-cli/src/commands/react_trace_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_i_06.rs
+    e2e_tests:
+    - falsify_crux_i_06_001_termination_ok_on_final_answer
+    - falsify_crux_i_06_001_termination_rejects_exit_code_mismatch
+    - falsify_crux_i_06_001_termination_rejects_unknown_reason
+    - falsify_crux_i_06_001_grammar_rejects_action_after_final_answer
+    sub_claim: |
+      Algorithm-level necessary conditions: `classify_termination`
+      verifies the canonical reason→exit-code mapping
+      (final_answer=0, max_iterations|timeout=2, tool_error=3,
+      parse_fail=4) and that `final_answer` exits carry an `answer`
+      field. `classify_scratchpad_grammar` parses the captured
+      scratchpad and rejects an `Action:` block emitted after a
+      `Final Answer:` line — that's the live halt violation surfaced
+      offline.
+    scope: "(body) -> (ReactTerminationOutcome, ReactGrammarOutcome) (pure)"
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: "live `apr agent` halting on Final Answer:"
 - id: FALSIFY-CRUX-I-06-002
   rule: max-iterations fires with structured reason
   prediction: "loop without Final Answer halts at max_iterations with reason JSON"
@@ -113,6 +139,23 @@ falsification_tests:
       || { echo "FAIL: expected structured max_iterations reason: $OUT" >&2; exit 1; }
 
   if_fails: rule 'max-iterations fires with structured reason' is violated — contract MUST be re-verified against competitor canonical reference
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/react_trace_classifier.rs
+    cli_path: crates/apr-cli/src/commands/react_trace_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_i_06.rs
+    e2e_tests:
+    - falsify_crux_i_06_002_termination_ok_on_max_iterations
+    - falsify_crux_i_06_002_iteration_bound_ok_within_budget
+    - falsify_crux_i_06_002_iteration_bound_rejects_over_budget
+    sub_claim: |
+      Algorithm-level necessary conditions: `classify_termination`
+      maps `reason: "max_iterations"` to exit_code=2 and
+      `classify_iteration_bound` verifies the trace's `iterations`
+      field is within `[0, max_iterations]`. `IterationsExceedBudget`
+      surfaces the canonical bug (loop ignored the budget).
+    scope: "(body, max_iterations) -> (ReactTerminationOutcome, ReactBoundOutcome) (pure)"
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: "live `apr agent` respecting --max-iterations"
 - id: FALSIFY-CRUX-I-06-003
   rule: deterministic replay at temperature=0
   prediction: "two runs with same seed and temp=0 produce identical traces"

--- a/crates/apr-cli/src/commands/mod.rs
+++ b/crates/apr-cli/src/commands/mod.rs
@@ -118,6 +118,8 @@ pub(crate) mod qa_capability;
 pub(crate) mod qualify;
 pub(crate) mod quant_preservation;
 pub(crate) mod quantize;
+pub(crate) mod react_trace_classifier;
+pub(crate) mod react_trace_lint;
 pub(crate) mod recipe;
 pub(crate) mod registry;
 pub(crate) mod registry_quota;

--- a/crates/apr-cli/src/commands/react_trace_classifier.rs
+++ b/crates/apr-cli/src/commands/react_trace_classifier.rs
@@ -1,0 +1,348 @@
+//! ReAct agent loop trace classifier (CRUX-I-06).
+//!
+//! Pure, deterministic classifiers that discharge FALSIFY-CRUX-I-06-{001,002,003}
+//! at the PARTIAL_ALGORITHM_LEVEL — algorithm-level necessary conditions on
+//! a captured `apr agent --trace OUT.json` body.
+//!
+//! Trace shape (per spec):
+//! ```json
+//! {
+//!   "iterations": 3,
+//!   "answer": "4",                        // present iff Final Answer fired
+//!   "reason": "max_iterations" | "timeout" | "tool_error" | "parse_fail",
+//!   "scratchpad": "Thought: ...\nAction: ...\nObservation: ...\nFinal Answer: 4",
+//!   "exit_code": 0 | 2 | 3 | 4
+//! }
+//! ```
+//!
+//! Classifiers:
+//!   * `classify_termination` — exactly one stop condition fires, exit_code
+//!     matches the canonical mapping (0=final_answer, 2=max_iterations|timeout,
+//!     3=tool_error, 4=parse_fail).
+//!   * `classify_scratchpad_grammar` — the scratchpad parses as a sequence
+//!     of `Thought: ... Action: ... Action Input: ... Observation: ...`
+//!     blocks optionally terminated by `Final Answer: ...`; rejects
+//!     truncated or rewritten content.
+//!   * `classify_iteration_bound` — `iterations <= max_iterations`; if
+//!     `Final Answer:` is present, no extra Action block follows it.
+
+use serde_json::Value;
+
+/// Canonical termination-reason → exit-code mapping (CRUX-I-06 `stop_conditions`).
+pub const I06_REASON_EXIT: &[(&str, i32)] = &[
+    ("final_answer", 0),
+    ("max_iterations", 2),
+    ("timeout", 2),
+    ("tool_error", 3),
+    ("parse_fail", 4),
+];
+
+/// Outcome of `classify_termination`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReactTerminationOutcome {
+    Ok { reason: String, exit_code: i32 },
+    NotAnObject,
+    MissingExitCode,
+    UnknownReason { got: String },
+    ExitCodeMismatch { reason: String, got: i32, expected: i32 },
+    FinalAnswerWithoutAnswerField,
+}
+
+/// Outcome of `classify_scratchpad_grammar`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReactGrammarOutcome {
+    Ok { blocks: usize },
+    Empty,
+    MissingThought { block: usize },
+    MissingAction { block: usize },
+    ActionAfterFinalAnswer { block: usize },
+}
+
+/// Outcome of `classify_iteration_bound`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReactBoundOutcome {
+    Ok,
+    IterationsExceedBudget { iterations: i64, max: i64 },
+    IterationsNegative { got: i64 },
+}
+
+/// FALSIFY-CRUX-I-06-001 / -002 / live-only -003: termination contract.
+pub fn classify_termination(body: &Value) -> ReactTerminationOutcome {
+    let Some(obj) = body.as_object() else {
+        return ReactTerminationOutcome::NotAnObject;
+    };
+    let exit_code = match obj.get("exit_code").and_then(Value::as_i64) {
+        Some(c) => c as i32,
+        None => return ReactTerminationOutcome::MissingExitCode,
+    };
+    // `reason` is required for non-zero exits; on exit 0 the spec wants `answer`
+    // to be present so the field can be omitted.
+    let reason: String = match obj.get("reason").and_then(Value::as_str) {
+        Some(s) => s.to_string(),
+        None if exit_code == 0 => "final_answer".to_string(),
+        None => return ReactTerminationOutcome::UnknownReason { got: "<missing>".to_string() },
+    };
+    let Some((_, expected)) = I06_REASON_EXIT.iter().find(|(r, _)| *r == reason.as_str()) else {
+        return ReactTerminationOutcome::UnknownReason { got: reason };
+    };
+    if exit_code != *expected {
+        return ReactTerminationOutcome::ExitCodeMismatch {
+            reason,
+            got: exit_code,
+            expected: *expected,
+        };
+    }
+    if reason == "final_answer" && obj.get("answer").and_then(Value::as_str).is_none() {
+        return ReactTerminationOutcome::FinalAnswerWithoutAnswerField;
+    }
+    ReactTerminationOutcome::Ok { reason, exit_code }
+}
+
+/// FALSIFY-CRUX-I-06-001 scratchpad grammar parser.
+pub fn classify_scratchpad_grammar(scratchpad: &str) -> ReactGrammarOutcome {
+    let trimmed = scratchpad.trim();
+    if trimmed.is_empty() {
+        return ReactGrammarOutcome::Empty;
+    }
+    // Find "Final Answer:" position; once present no Action may follow.
+    let final_pos = trimmed.find("Final Answer:");
+
+    let mut blocks = 0usize;
+    let mut cursor = 0usize;
+    while cursor < trimmed.len() {
+        let body = &trimmed[cursor..];
+        let Some(thought_start) = body.find("Thought:") else {
+            break;
+        };
+        // No more Thought blocks ⇒ tail is the (optional) Final Answer.
+        blocks += 1;
+        let block_idx = blocks - 1;
+        // Each block must have an Action: header before the next Thought / Final Answer / end.
+        let after_thought = thought_start + "Thought:".len();
+        let rest = &body[after_thought..];
+        let action_pos = rest.find("Action:");
+        let next_thought_pos = rest.find("Thought:");
+        let final_inblock_pos = rest.find("Final Answer:");
+        // Determine block end (whichever delimiter comes first after Action).
+        let end_of_block = [next_thought_pos, final_inblock_pos]
+            .iter()
+            .filter_map(|p| *p)
+            .min()
+            .unwrap_or(rest.len());
+
+        match action_pos {
+            Some(p) if p < end_of_block => {
+                // Action exists inside this block — block is well-formed.
+            }
+            _ => {
+                // Allow the very last block to be a pure Final Answer (no Action).
+                if final_inblock_pos.is_some() && next_thought_pos.is_none() {
+                    // Block has a Thought leading directly to a Final Answer
+                    // (e.g. one-shot reasoning). Spec permits this.
+                } else {
+                    return ReactGrammarOutcome::MissingAction { block: block_idx };
+                }
+            }
+        }
+        cursor += thought_start + "Thought:".len() + end_of_block;
+    }
+
+    // Validate no Action follows Final Answer.
+    if let Some(fp) = final_pos {
+        let tail = &trimmed[fp + "Final Answer:".len()..];
+        if tail.contains("Action:") {
+            return ReactGrammarOutcome::ActionAfterFinalAnswer {
+                block: blocks.saturating_sub(1),
+            };
+        }
+    }
+
+    if blocks == 0 {
+        // Pure Final Answer with no Thought is degenerate but acceptable
+        // (spec doesn't forbid an LLM emitting just `Final Answer: X`).
+        if final_pos.is_some() {
+            return ReactGrammarOutcome::Ok { blocks: 0 };
+        }
+        return ReactGrammarOutcome::MissingThought { block: 0 };
+    }
+    ReactGrammarOutcome::Ok { blocks }
+}
+
+/// FALSIFY-CRUX-I-06-001 / -002 iteration-budget guard.
+pub fn classify_iteration_bound(body: &Value, max_iterations: i64) -> ReactBoundOutcome {
+    let iters = body.get("iterations").and_then(Value::as_i64).unwrap_or(0);
+    if iters < 0 {
+        return ReactBoundOutcome::IterationsNegative { got: iters };
+    }
+    if iters > max_iterations {
+        return ReactBoundOutcome::IterationsExceedBudget {
+            iterations: iters,
+            max: max_iterations,
+        };
+    }
+    ReactBoundOutcome::Ok
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn good_final_answer_body() -> Value {
+        json!({
+            "iterations": 1,
+            "answer": "4",
+            "scratchpad": "Thought: I should compute 2+2.\nFinal Answer: 4",
+            "exit_code": 0
+        })
+    }
+
+    fn good_max_iterations_body() -> Value {
+        json!({
+            "iterations": 3,
+            "reason": "max_iterations",
+            "scratchpad": "Thought: try\nAction: echo\nAction Input: hi\nObservation: hi\nThought: try\nAction: echo\nAction Input: hi\nObservation: hi\nThought: still trying\nAction: echo\nAction Input: x\nObservation: x",
+            "exit_code": 2
+        })
+    }
+
+    #[test]
+    fn termination_ok_on_final_answer() {
+        match classify_termination(&good_final_answer_body()) {
+            ReactTerminationOutcome::Ok { reason, exit_code } => {
+                assert_eq!(reason, "final_answer");
+                assert_eq!(exit_code, 0);
+            }
+            other => panic!("expected Ok(final_answer, 0), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn termination_ok_on_max_iterations() {
+        match classify_termination(&good_max_iterations_body()) {
+            ReactTerminationOutcome::Ok { reason, exit_code } => {
+                assert_eq!(reason, "max_iterations");
+                assert_eq!(exit_code, 2);
+            }
+            other => panic!("expected Ok(max_iterations, 2), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn termination_rejects_unknown_reason() {
+        let body = json!({"iterations": 1, "reason": "whoops", "scratchpad": "", "exit_code": 5});
+        assert!(matches!(
+            classify_termination(&body),
+            ReactTerminationOutcome::UnknownReason { .. }
+        ));
+    }
+
+    #[test]
+    fn termination_rejects_exit_code_mismatch() {
+        let body = json!({"iterations": 3, "reason": "max_iterations", "scratchpad": "", "exit_code": 1});
+        match classify_termination(&body) {
+            ReactTerminationOutcome::ExitCodeMismatch { reason, got, expected } => {
+                assert_eq!(reason, "max_iterations");
+                assert_eq!(got, 1);
+                assert_eq!(expected, 2);
+            }
+            other => panic!("expected ExitCodeMismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn termination_rejects_final_answer_without_answer_field() {
+        let body = json!({"iterations": 1, "exit_code": 0, "scratchpad": "Final Answer: 4"});
+        // No `answer` key with reason=final_answer (default-inferred).
+        assert_eq!(
+            classify_termination(&body),
+            ReactTerminationOutcome::FinalAnswerWithoutAnswerField
+        );
+    }
+
+    #[test]
+    fn termination_rejects_not_an_object() {
+        assert_eq!(
+            classify_termination(&json!([1, 2])),
+            ReactTerminationOutcome::NotAnObject
+        );
+    }
+
+    #[test]
+    fn scratchpad_ok_on_three_block_trace() {
+        let sp = "Thought: t1\nAction: a1\nAction Input: i1\nObservation: o1\n\
+                  Thought: t2\nAction: a2\nAction Input: i2\nObservation: o2\n\
+                  Thought: t3\nAction: a3\nAction Input: i3\nObservation: o3";
+        assert_eq!(
+            classify_scratchpad_grammar(sp),
+            ReactGrammarOutcome::Ok { blocks: 3 }
+        );
+    }
+
+    #[test]
+    fn scratchpad_ok_on_thought_then_final_answer() {
+        let sp = "Thought: I should compute 2+2.\nFinal Answer: 4";
+        // Block has Thought leading to Final Answer (no Action) — accepted.
+        match classify_scratchpad_grammar(sp) {
+            ReactGrammarOutcome::Ok { .. } => {}
+            other => panic!("expected Ok, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn scratchpad_rejects_empty() {
+        assert_eq!(
+            classify_scratchpad_grammar(""),
+            ReactGrammarOutcome::Empty
+        );
+    }
+
+    #[test]
+    fn scratchpad_rejects_action_after_final_answer() {
+        let sp = "Thought: done.\nFinal Answer: 4\nAction: rogue\nAction Input: x";
+        match classify_scratchpad_grammar(sp) {
+            ReactGrammarOutcome::ActionAfterFinalAnswer { .. } => {}
+            other => panic!("expected ActionAfterFinalAnswer, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn scratchpad_rejects_missing_action_in_middle_block() {
+        // Two blocks: first has Action, second is Thought-only (no Action, no Final Answer).
+        let sp = "Thought: t1\nAction: a1\nAction Input: i1\nObservation: o1\nThought: t2";
+        match classify_scratchpad_grammar(sp) {
+            ReactGrammarOutcome::MissingAction { block } => assert_eq!(block, 1),
+            other => panic!("expected MissingAction(1), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn iteration_bound_ok_within_budget() {
+        let body = json!({"iterations": 3});
+        assert_eq!(
+            classify_iteration_bound(&body, 5),
+            ReactBoundOutcome::Ok
+        );
+    }
+
+    #[test]
+    fn iteration_bound_rejects_over_budget() {
+        let body = json!({"iterations": 10});
+        match classify_iteration_bound(&body, 5) {
+            ReactBoundOutcome::IterationsExceedBudget { iterations, max } => {
+                assert_eq!(iterations, 10);
+                assert_eq!(max, 5);
+            }
+            other => panic!("expected IterationsExceedBudget, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn iteration_bound_rejects_negative() {
+        let body = json!({"iterations": -1});
+        assert!(matches!(
+            classify_iteration_bound(&body, 5),
+            ReactBoundOutcome::IterationsNegative { got: -1 }
+        ));
+    }
+}

--- a/crates/apr-cli/src/commands/react_trace_lint.rs
+++ b/crates/apr-cli/src/commands/react_trace_lint.rs
@@ -1,0 +1,94 @@
+//! `apr react-trace-lint` — CRUX-I-06 ReAct agent trace gate.
+//!
+//! Reads a captured `apr agent --trace OUT.json` body and dispatches the
+//! pure classifiers in `react_trace_classifier`. Exits non-zero on any
+//! failure.
+//!
+//! Spec: `contracts/crux-I-06-v1.yaml`. CRUX-SHIP-001 g2/g3 surface.
+
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+
+use super::react_trace_classifier::{
+    classify_iteration_bound, classify_scratchpad_grammar, classify_termination,
+    ReactBoundOutcome, ReactGrammarOutcome, ReactTerminationOutcome,
+};
+use crate::error::{CliError, Result};
+
+pub(crate) fn run(
+    trace_file: &Path,
+    max_iterations: Option<i64>,
+    require_grammar: bool,
+    json: bool,
+) -> Result<()> {
+    if !trace_file.exists() {
+        return Err(CliError::FileNotFound(PathBuf::from(trace_file)));
+    }
+    let body_text = std::fs::read_to_string(trace_file)?;
+    let body: Value = serde_json::from_str(&body_text).map_err(|e| {
+        CliError::InvalidFormat(format!(
+            "apr react-trace-lint: failed to parse JSON from {}: {e}",
+            trace_file.display()
+        ))
+    })?;
+
+    let term = classify_termination(&body);
+    let bound = max_iterations.map(|n| classify_iteration_bound(&body, n));
+    let grammar = if require_grammar {
+        let sp = body.get("scratchpad").and_then(Value::as_str).unwrap_or("");
+        Some(classify_scratchpad_grammar(sp))
+    } else {
+        None
+    };
+
+    print_report(trace_file, &term, bound.as_ref(), grammar.as_ref(), json);
+
+    if !matches!(term, ReactTerminationOutcome::Ok { .. }) {
+        return Err(CliError::ValidationFailed(format!(
+            "react-trace-lint termination gate rejected body: {term:?}"
+        )));
+    }
+    if let Some(o) = &bound {
+        if !matches!(o, ReactBoundOutcome::Ok) {
+            return Err(CliError::ValidationFailed(format!(
+                "react-trace-lint iteration-bound gate rejected body: {o:?}"
+            )));
+        }
+    }
+    if let Some(o) = &grammar {
+        if !matches!(o, ReactGrammarOutcome::Ok { .. }) {
+            return Err(CliError::ValidationFailed(format!(
+                "react-trace-lint scratchpad-grammar gate rejected body: {o:?}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn print_report(
+    path: &Path,
+    term: &ReactTerminationOutcome,
+    bound: Option<&ReactBoundOutcome>,
+    grammar: Option<&ReactGrammarOutcome>,
+    json: bool,
+) {
+    if json {
+        let obj = serde_json::json!({
+            "file": path.display().to_string(),
+            "termination": format!("{term:?}"),
+            "iteration_bound": bound.map(|o| format!("{o:?}")),
+            "scratchpad_grammar": grammar.map(|o| format!("{o:?}")),
+        });
+        println!("{}", serde_json::to_string_pretty(&obj).unwrap_or_default());
+        return;
+    }
+    println!("react-trace-lint report for {}", path.display());
+    println!("  termination       : {term:?}");
+    if let Some(o) = bound {
+        println!("  iteration_bound   : {o:?}");
+    }
+    if let Some(o) = grammar {
+        println!("  scratchpad_grammar: {o:?}");
+    }
+}

--- a/crates/apr-cli/src/dispatch_analysis.rs
+++ b/crates/apr-cli/src/dispatch_analysis.rs
@@ -189,6 +189,17 @@ fn dispatch_analysis_commands(cli: &Cli) -> Option<Result<(), CliError>> {
             require_doc_link,
         } => commands::nccl_diag_lint::run(diag_file, *exit_code, *require_doc_link, cli.json),
 
+        ExtendedCommands::ReactTraceLint {
+            trace_file,
+            max_iterations,
+            require_grammar,
+        } => commands::react_trace_lint::run(
+            trace_file,
+            *max_iterations,
+            *require_grammar,
+            cli.json,
+        ),
+
         ExtendedCommands::AttnVizLint {
             attn_file,
             html_file,

--- a/crates/apr-cli/src/extended_commands.rs
+++ b/crates/apr-cli/src/extended_commands.rs
@@ -796,6 +796,18 @@ pub enum ExtendedCommands {
         #[arg(long)]
         require_doc_link: bool,
     },
+    /// Lint a captured `apr agent --trace` ReAct loop trace (CRUX-I-06)
+    ReactTraceLint {
+        /// Path to captured trace JSON
+        #[arg(long, value_name = "FILE")]
+        trace_file: PathBuf,
+        /// Optional max_iterations budget the trace was produced under
+        #[arg(long, value_name = "N")]
+        max_iterations: Option<i64>,
+        /// Require the scratchpad to parse cleanly as Thought/Action/Observation blocks
+        #[arg(long)]
+        require_grammar: bool,
+    },
     /// Lint a captured `apr attn-viz` attention dump (CRUX-F-17)
     AttnVizLint {
         /// Path to attention dump in JSON form (4-D [layers][heads][rows][cols] floats)

--- a/crates/apr-cli/tests/cli_commands.rs
+++ b/crates/apr-cli/tests/cli_commands.rs
@@ -121,6 +121,7 @@ fn registered_commands() -> Vec<&'static str> {
         "attn-viz-lint",
         "embed-viz-lint",
         "nccl-diag-lint",
+        "react-trace-lint",
         "shard",
         "unshard",
         "oracle",

--- a/crates/apr-cli/tests/falsification_crux_i_06.rs
+++ b/crates/apr-cli/tests/falsification_crux_i_06.rs
@@ -1,0 +1,224 @@
+//! CRUX-I-06 — end-to-end falsification harness for `apr react-trace-lint`.
+//!
+//! CRUX-SHIP-001 gate g3 evidence: every FALSIFY-CRUX-I-06-{001,002} gate
+//! the classifier discharges has a matching captured trace JSON that the
+//! binary must classify exactly as the harness expects.
+
+use serde_json::json;
+use std::io::Write;
+use std::process::Command;
+
+fn apr_binary() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_apr"));
+    cmd.env("NO_COLOR", "1");
+    cmd
+}
+
+fn write_json(body: &serde_json::Value) -> tempfile::NamedTempFile {
+    let mut f = tempfile::Builder::new()
+        .prefix("crux-i-06-")
+        .suffix(".json")
+        .tempfile()
+        .expect("tempfile");
+    f.write_all(serde_json::to_vec_pretty(body).expect("serialize").as_slice())
+        .expect("write");
+    f.flush().expect("flush");
+    f
+}
+
+fn good_final_answer() -> serde_json::Value {
+    json!({
+        "iterations": 1,
+        "answer": "4",
+        "scratchpad": "Thought: I should compute 2+2.\nFinal Answer: 4",
+        "exit_code": 0
+    })
+}
+
+fn good_max_iterations() -> serde_json::Value {
+    json!({
+        "iterations": 3,
+        "reason": "max_iterations",
+        "scratchpad": "Thought: try\nAction: echo\nAction Input: hi\nObservation: hi\nThought: try\nAction: echo\nAction Input: hi\nObservation: hi\nThought: still trying\nAction: echo\nAction Input: x\nObservation: x",
+        "exit_code": 2
+    })
+}
+
+// ===== g2: CLI shape =====
+
+#[test]
+fn falsify_crux_i_06_cli_help_advertises_flags() {
+    let out = apr_binary().args(["react-trace-lint", "--help"]).output().expect("run");
+    assert!(out.status.success(), "--help must exit 0");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    for flag in ["--trace-file", "--max-iterations", "--require-grammar"] {
+        assert!(stdout.contains(flag), "--help must advertise {flag}; got:\n{stdout}");
+    }
+}
+
+#[test]
+fn falsify_crux_i_06_cli_missing_file_fails() {
+    let out = apr_binary()
+        .args(["react-trace-lint", "--trace-file", "/nonexistent/crux-i-06-missing.json"])
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "missing file must not exit 0");
+}
+
+// ===== g3: classifier discharges =====
+
+#[test]
+fn falsify_crux_i_06_001_termination_ok_on_final_answer() {
+    let f = write_json(&good_final_answer());
+    let out = apr_binary()
+        .args(["react-trace-lint", "--trace-file"])
+        .arg(f.path())
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "final-answer trace must pass; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn falsify_crux_i_06_002_termination_ok_on_max_iterations() {
+    let f = write_json(&good_max_iterations());
+    let out = apr_binary()
+        .args(["react-trace-lint", "--trace-file"])
+        .arg(f.path())
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "max-iterations trace must pass; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn falsify_crux_i_06_001_termination_rejects_exit_code_mismatch() {
+    let body = json!({
+        "iterations": 3,
+        "reason": "max_iterations",
+        "scratchpad": "Thought: x\nAction: y\nAction Input: z\nObservation: o",
+        "exit_code": 1
+    });
+    let f = write_json(&body);
+    let out = apr_binary()
+        .args(["react-trace-lint", "--trace-file"])
+        .arg(f.path())
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "exit-code mismatch must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("ExitCodeMismatch"),
+        "stderr must name ExitCodeMismatch; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn falsify_crux_i_06_001_termination_rejects_unknown_reason() {
+    let body = json!({
+        "iterations": 1,
+        "reason": "weird_other",
+        "scratchpad": "Thought: x\nFinal Answer: 4",
+        "exit_code": 7
+    });
+    let f = write_json(&body);
+    let out = apr_binary()
+        .args(["react-trace-lint", "--trace-file"])
+        .arg(f.path())
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "unknown reason must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("UnknownReason"),
+        "stderr must name UnknownReason; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn falsify_crux_i_06_001_grammar_rejects_action_after_final_answer() {
+    let body = json!({
+        "iterations": 1,
+        "answer": "4",
+        "scratchpad": "Thought: done\nFinal Answer: 4\nAction: rogue\nAction Input: x",
+        "exit_code": 0
+    });
+    let f = write_json(&body);
+    let out = apr_binary()
+        .args(["react-trace-lint", "--trace-file"])
+        .arg(f.path())
+        .arg("--require-grammar")
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "action-after-Final-Answer must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("ActionAfterFinalAnswer"),
+        "stderr must name ActionAfterFinalAnswer; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn falsify_crux_i_06_002_iteration_bound_ok_within_budget() {
+    let f = write_json(&good_max_iterations());
+    let out = apr_binary()
+        .args(["react-trace-lint", "--trace-file"])
+        .arg(f.path())
+        .args(["--max-iterations", "5"])
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "iterations=3 within budget=5 must pass; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn falsify_crux_i_06_002_iteration_bound_rejects_over_budget() {
+    let body = json!({
+        "iterations": 100,
+        "reason": "max_iterations",
+        "scratchpad": "Thought: x\nAction: y\nAction Input: z\nObservation: o",
+        "exit_code": 2
+    });
+    let f = write_json(&body);
+    let out = apr_binary()
+        .args(["react-trace-lint", "--trace-file"])
+        .arg(f.path())
+        .args(["--max-iterations", "5"])
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "iterations > budget must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("IterationsExceedBudget"),
+        "stderr must name IterationsExceedBudget; got:\n{stderr}"
+    );
+}
+
+// ===== JSON output shape =====
+
+#[test]
+fn falsify_crux_i_06_json_output_contains_outcomes() {
+    let f = write_json(&good_max_iterations());
+    let out = apr_binary()
+        .args(["--json", "react-trace-lint", "--trace-file"])
+        .arg(f.path())
+        .args(["--max-iterations", "5"])
+        .arg("--require-grammar")
+        .output()
+        .expect("run");
+    assert!(out.status.success(), "json + good body must exit 0");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("json output must parse");
+    assert!(parsed["termination"].as_str().expect("termination").contains("Ok"));
+    assert!(parsed["iteration_bound"].as_str().expect("iteration_bound").contains("Ok"));
+    assert!(parsed["scratchpad_grammar"].as_str().expect("scratchpad_grammar").contains("Ok"));
+}


### PR DESCRIPTION
## Summary

- Promotes \`contracts/crux-I-06-v1.yaml\` from \`draft\` → PARTIAL_ALGORITHM_LEVEL.
- Adds \`apr react-trace-lint --trace-file F [--max-iterations N] [--require-grammar]\` — pure-function classifier validating: termination reason→exit-code mapping (final_answer=0, max_iterations=2, etc.), iteration bound, scratchpad grammar (Thought/Action/Observation blocks, no Action-after-Final-Answer).
- 14 classifier unit tests + 10 e2e falsification tests + 8 cli_commands surface tests all pass.

Discharges FALSIFY-CRUX-I-06-{001,002} at PARTIAL_ALGORITHM_LEVEL.

## Test plan

- [x] \`cargo test -p apr-cli --lib react_trace_classifier\` — 14/14 pass.
- [x] \`cargo test -p apr-cli --test falsification_crux_i_06\` — 10/10 pass.
- [x] \`cargo test -p apr-cli --test cli_commands\` — 8/8 pass (3-surface drift policy).
- [x] \`pv validate contracts/crux-I-06-v1.yaml\` — clean.
- [ ] CI green on \`ci / gate\` + \`workspace-test\`.

Refs #921 (CRUX M4 observability epic), #917 (CRUX Phase 3 umbrella).

🤖 Generated with [Claude Code](https://claude.com/claude-code)