### PR TITLE
feat(apr-cli): CRUX-D-11 `apr ddp-metrics-lint` DDP multi-GPU metrics classifier

### DIFF
--- a/contracts/apr-cli-commands-v1.yaml
+++ b/contracts/apr-cli-commands-v1.yaml
@@ -604,6 +604,12 @@ commands:
     requires_model: false
     side_effects: []
 
+  - name: ddp-metrics-lint
+    category: inspection
+    description: "Validate two captured `apr finetune --parallel ddp --json` outputs (CRUX-D-11): scaling efficiency T_N/(N*T_1) >= 0.85 + loss parity |L_N - L_1|/L_1 <= 0.01 + per-step allreduce bandwidth > 0"
+    requires_model: false
+    side_effects: []
+
   - name: shard
     category: model_ops
     description: "Split safetensors file into shards + weight-map index (CRUX-B-05)"

--- a/contracts/crux-D-11-v1.yaml
+++ b/contracts/crux-D-11-v1.yaml
@@ -1,16 +1,21 @@
 # CRUX-D-11 — DDP multi-GPU single node
-# Auto-scaffolded from crux-competitive-research-ux-v1.yaml (DRAFT).
-# DO NOT promote to ACTIVE until: (1) evidence collected, (2) falsification
-# body reflects competitor's canonical CLI, (3) apr surface mapped or gap
-# tracked in pmat work (see master §12).
+# Promoted to PARTIAL_ALGORITHM_LEVEL at v1.1.0 under CRUX-SHIP-001 (2026-05-17):
+# - classifier: crates/apr-cli/src/commands/ddp_metrics_classifier.rs (12 unit tests)
+# - CLI surface: `apr ddp-metrics-lint --metrics-1gpu-file F --metrics-ngpu-file F --world-size N [--scaling-floor F] [--loss-tolerance F]`
+# - e2e: crates/apr-cli/tests/falsification_crux_d_11.rs (10 tests)
+# Full discharge requires a live multi-GPU `apr finetune` actually
+# emitting the JSON metrics on both world_size=1 and world_size=N runs
+# — tracked as BLOCKER-UPSTREAM-MISSING.
 
 metadata:
   id: CRUX-D-11
-  version: "1.0.0-draft"
+  version: "1.1.0"
   created: "2026-04-18"
+  updated: "2026-05-17"
   author: PAIML Engineering
   registry: true
-  status: draft
+  status: partial
+  kind: kernel
   parent_contracts:
   - crux-competitive-research-ux-v1
   category: "D — Inference & Generation"
@@ -89,6 +94,24 @@ falsification_tests:
     assert eff >= 0.85, f'DDP scaling efficiency {eff:.3f} < 0.85 (T1={t1}, T4={t4})'
     "
   if_fails: "DDP scaling below 0.85× — bucket size, overlap, or PCIe fallback issue"
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/ddp_metrics_classifier.rs
+    cli_path: crates/apr-cli/src/commands/ddp_metrics_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_d_11.rs
+    e2e_tests:
+    - falsify_crux_d_11_001_scaling_ok_at_0_875
+    - falsify_crux_d_11_001_scaling_rejects_below_floor
+    - falsify_crux_d_11_scaling_floor_configurable
+    sub_claim: |
+      Algorithm-level necessary condition: `classify_scaling_efficiency`
+      computes `T_N / (N * T_1)` from the two captured `tokens_per_sec`
+      values and rejects when the ratio is below the floor
+      (default 0.85, configurable). Reports
+      `BelowThreshold { world_size, t1, tn, efficiency, threshold }`
+      so the offending run is pinpointed.
+    scope: "(metrics_1gpu, metrics_ngpu, world_size, threshold) -> DdpScalingOutcome (pure)"
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: "live multi-GPU `apr finetune` emitting tokens_per_sec at N=1 and N=k"
 
 - id: FALSIFY-CRUX-D-11-002
   rule: DDP final loss matches single-GPU within ±1%
@@ -105,6 +128,22 @@ falsification_tests:
     assert rel <= 0.01, f'DDP loss parity failed: rel_diff={rel:.4f} (L1={l1}, LN={ln})'
     "
   if_fails: "DDP final loss diverges from single-GPU — reduction, sampler, or seeding bug"
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/ddp_metrics_classifier.rs
+    cli_path: crates/apr-cli/src/commands/ddp_metrics_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_d_11.rs
+    e2e_tests:
+    - falsify_crux_d_11_002_loss_parity_ok_within_tolerance
+    - falsify_crux_d_11_002_loss_parity_rejects_divergence
+    sub_claim: |
+      Algorithm-level necessary condition: `classify_loss_parity`
+      computes `|L_N - L_1| / L_1` and rejects when it exceeds the
+      tolerance (default 0.01, configurable). Reports
+      `Divergence { l1, ln, rel_diff, tolerance }` so reduction /
+      sampler bugs are debuggable from the lint output alone.
+    scope: "(metrics_1gpu, metrics_ngpu, tolerance) -> DdpLossParityOutcome (pure)"
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: "live multi-GPU `apr finetune` emitting matching final_loss at N=1 and N=k"
 
 - id: FALSIFY-CRUX-D-11-003
   rule: gradient all-reduce bandwidth logged and non-zero
@@ -115,6 +154,22 @@ falsification_tests:
       --epochs 1 --json 2>/dev/null)
     echo "$OUT" | jq -e '.ddp_metrics.allreduce_bandwidth_gbps | length > 0 and all(. > 0)'
   if_fails: "All-reduce bandwidth not logged or reports zero — collective backend misconfigured"
+  evidence_discharged_by:
+    classifier_path: crates/apr-cli/src/commands/ddp_metrics_classifier.rs
+    cli_path: crates/apr-cli/src/commands/ddp_metrics_lint.rs
+    e2e_path: crates/apr-cli/tests/falsification_crux_d_11.rs
+    e2e_tests:
+    - falsify_crux_d_11_003_allreduce_rejects_missing_array
+    - falsify_crux_d_11_003_allreduce_rejects_zero_step
+    sub_claim: |
+      Algorithm-level necessary condition: `classify_allreduce_bandwidth`
+      walks `ddp_metrics.allreduce_bandwidth_gbps[]` and rejects when
+      the array is absent, empty, or contains any non-positive entry.
+      Reports `MissingDdpMetrics`, `MissingBandwidthArray`,
+      `EmptyBandwidthArray`, or `NonPositiveBandwidth { step_index }`.
+    scope: "(metrics) -> DdpAllreduceOutcome (pure)"
+    discharge_status: PARTIAL_ALGORITHM_LEVEL
+    full_discharge_blocked_on: "live multi-GPU `apr finetune` emitting per-step allreduce bandwidth"
 
 - id: FALSIFY-CRUX-D-11-004
   rule: --num-gpus rejects values exceeding detected GPUs

--- a/crates/apr-cli/src/commands/ddp_metrics_classifier.rs
+++ b/crates/apr-cli/src/commands/ddp_metrics_classifier.rs
@@ -1,0 +1,284 @@
+//! DDP multi-GPU metrics classifier (CRUX-D-11).
+//!
+//! Pure, deterministic classifiers that discharge FALSIFY-CRUX-D-11-{001,002,003}
+//! at the PARTIAL_ALGORITHM_LEVEL — algorithm-level necessary conditions on
+//! captured `apr finetune --parallel ddp --json` outputs at N=1 and N>=2 GPUs:
+//!
+//!   * `classify_scaling_efficiency` — `T_N / (N * T_1) >= threshold`
+//!     (default 0.85, vLLM/PyTorch DDP convention). T_X = `tokens_per_sec`.
+//!   * `classify_loss_parity` — `|L_N - L_1| / L_1 <= tolerance` (default
+//!     0.01). Verifies the all-reduce reduction + deterministic sampler
+//!     preserve loss invariance at identical seed/total-samples.
+//!   * `classify_allreduce_bandwidth` — every per-step bandwidth entry in
+//!     `ddp_metrics.allreduce_bandwidth_gbps[]` is strictly positive.
+//!
+//! Full discharge of -001/-002/-003 requires a live multi-GPU `apr finetune`
+//! actually emitting the JSON metrics — tracked as BLOCKER-UPSTREAM-MISSING.
+
+use serde_json::Value;
+
+/// Default DDP scaling-efficiency floor (PyTorch DDP convention).
+pub const D11_DEFAULT_SCALING_FLOOR: f64 = 0.85;
+
+/// Default DDP loss-parity tolerance (1%).
+pub const D11_DEFAULT_LOSS_TOLERANCE: f64 = 0.01;
+
+/// Outcome of `classify_scaling_efficiency`.
+#[derive(Debug, Clone, PartialEq)]
+pub enum DdpScalingOutcome {
+    Ok { efficiency: f64 },
+    MissingTokensPerSec { which: &'static str },
+    NonPositiveTokensPerSec { which: &'static str, got: f64 },
+    InvalidWorldSize { got: i64 },
+    BelowThreshold {
+        world_size: i64,
+        t1: f64,
+        tn: f64,
+        efficiency: f64,
+        threshold: f64,
+    },
+}
+
+/// Outcome of `classify_loss_parity`.
+#[derive(Debug, Clone, PartialEq)]
+pub enum DdpLossParityOutcome {
+    Ok { rel_diff: f64 },
+    MissingFinalLoss { which: &'static str },
+    NonPositiveBaselineLoss { got: f64 },
+    Divergence {
+        l1: f64,
+        ln: f64,
+        rel_diff: f64,
+        tolerance: f64,
+    },
+}
+
+/// Outcome of `classify_allreduce_bandwidth`.
+#[derive(Debug, Clone, PartialEq)]
+pub enum DdpAllreduceOutcome {
+    Ok { steps: usize },
+    MissingDdpMetrics,
+    MissingBandwidthArray,
+    EmptyBandwidthArray,
+    NonPositiveBandwidth { step_index: usize, got: f64 },
+}
+
+/// Verify `T_N / (N * T_1) >= threshold` (default 0.85).
+pub fn classify_scaling_efficiency(
+    metrics_1gpu: &Value,
+    metrics_ngpu: &Value,
+    world_size: i64,
+    threshold: f64,
+) -> DdpScalingOutcome {
+    if world_size <= 1 {
+        return DdpScalingOutcome::InvalidWorldSize { got: world_size };
+    }
+    let Some(t1) = metrics_1gpu.get("tokens_per_sec").and_then(Value::as_f64) else {
+        return DdpScalingOutcome::MissingTokensPerSec { which: "metrics_1gpu" };
+    };
+    let Some(tn) = metrics_ngpu.get("tokens_per_sec").and_then(Value::as_f64) else {
+        return DdpScalingOutcome::MissingTokensPerSec { which: "metrics_ngpu" };
+    };
+    if t1 <= 0.0 {
+        return DdpScalingOutcome::NonPositiveTokensPerSec { which: "metrics_1gpu", got: t1 };
+    }
+    if tn <= 0.0 {
+        return DdpScalingOutcome::NonPositiveTokensPerSec { which: "metrics_ngpu", got: tn };
+    }
+    let efficiency = tn / (world_size as f64 * t1);
+    if efficiency < threshold {
+        return DdpScalingOutcome::BelowThreshold {
+            world_size,
+            t1,
+            tn,
+            efficiency,
+            threshold,
+        };
+    }
+    DdpScalingOutcome::Ok { efficiency }
+}
+
+/// Verify `|L_N - L_1| / L_1 <= tolerance` (default 0.01).
+pub fn classify_loss_parity(
+    metrics_1gpu: &Value,
+    metrics_ngpu: &Value,
+    tolerance: f64,
+) -> DdpLossParityOutcome {
+    let Some(l1) = metrics_1gpu.get("final_loss").and_then(Value::as_f64) else {
+        return DdpLossParityOutcome::MissingFinalLoss { which: "metrics_1gpu" };
+    };
+    let Some(ln) = metrics_ngpu.get("final_loss").and_then(Value::as_f64) else {
+        return DdpLossParityOutcome::MissingFinalLoss { which: "metrics_ngpu" };
+    };
+    if l1 <= 0.0 {
+        return DdpLossParityOutcome::NonPositiveBaselineLoss { got: l1 };
+    }
+    let rel_diff = (ln - l1).abs() / l1;
+    if rel_diff > tolerance {
+        return DdpLossParityOutcome::Divergence { l1, ln, rel_diff, tolerance };
+    }
+    DdpLossParityOutcome::Ok { rel_diff }
+}
+
+/// Verify every per-step entry in `ddp_metrics.allreduce_bandwidth_gbps`
+/// is strictly positive.
+pub fn classify_allreduce_bandwidth(metrics: &Value) -> DdpAllreduceOutcome {
+    let Some(ddp) = metrics.get("ddp_metrics") else {
+        return DdpAllreduceOutcome::MissingDdpMetrics;
+    };
+    let Some(arr) = ddp.get("allreduce_bandwidth_gbps").and_then(Value::as_array) else {
+        return DdpAllreduceOutcome::MissingBandwidthArray;
+    };
+    if arr.is_empty() {
+        return DdpAllreduceOutcome::EmptyBandwidthArray;
+    }
+    for (i, v) in arr.iter().enumerate() {
+        let bw = v.as_f64().unwrap_or(0.0);
+        if bw <= 0.0 {
+            return DdpAllreduceOutcome::NonPositiveBandwidth { step_index: i, got: bw };
+        }
+    }
+    DdpAllreduceOutcome::Ok { steps: arr.len() }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn t1_body() -> Value {
+        json!({
+            "tokens_per_sec": 1000.0,
+            "final_loss": 2.5,
+            "ddp_metrics": {"allreduce_bandwidth_gbps": [120.0, 118.0, 121.0]}
+        })
+    }
+
+    fn tn_body_efficient() -> Value {
+        // N=4: T4 = 3500 → eff = 3500 / 4000 = 0.875 (≥0.85)
+        json!({
+            "tokens_per_sec": 3500.0,
+            "final_loss": 2.51,
+            "ddp_metrics": {"allreduce_bandwidth_gbps": [80.0, 82.0, 79.0]}
+        })
+    }
+
+    fn tn_body_inefficient() -> Value {
+        // N=4: T4 = 2000 → eff = 2000 / 4000 = 0.5
+        json!({
+            "tokens_per_sec": 2000.0,
+            "final_loss": 2.51,
+            "ddp_metrics": {"allreduce_bandwidth_gbps": [40.0]}
+        })
+    }
+
+    #[test]
+    fn scaling_ok_at_0_875() {
+        match classify_scaling_efficiency(&t1_body(), &tn_body_efficient(), 4, 0.85) {
+            DdpScalingOutcome::Ok { efficiency } => {
+                assert!((efficiency - 0.875).abs() < 1e-6, "got {efficiency}");
+            }
+            other => panic!("expected Ok, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn scaling_rejects_below_threshold() {
+        match classify_scaling_efficiency(&t1_body(), &tn_body_inefficient(), 4, 0.85) {
+            DdpScalingOutcome::BelowThreshold { efficiency, .. } => {
+                assert!((efficiency - 0.5).abs() < 1e-6, "got {efficiency}");
+            }
+            other => panic!("expected BelowThreshold, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn scaling_rejects_invalid_world_size() {
+        let out = classify_scaling_efficiency(&t1_body(), &tn_body_efficient(), 1, 0.85);
+        assert!(matches!(out, DdpScalingOutcome::InvalidWorldSize { got: 1 }));
+    }
+
+    #[test]
+    fn scaling_rejects_missing_tokens_per_sec() {
+        let empty = json!({});
+        assert!(matches!(
+            classify_scaling_efficiency(&empty, &tn_body_efficient(), 4, 0.85),
+            DdpScalingOutcome::MissingTokensPerSec { which: "metrics_1gpu" }
+        ));
+    }
+
+    #[test]
+    fn scaling_rejects_zero_tokens_per_sec() {
+        let zero = json!({"tokens_per_sec": 0.0});
+        assert!(matches!(
+            classify_scaling_efficiency(&t1_body(), &zero, 4, 0.85),
+            DdpScalingOutcome::NonPositiveTokensPerSec { which: "metrics_ngpu", .. }
+        ));
+    }
+
+    #[test]
+    fn loss_parity_ok_within_tolerance() {
+        let out = classify_loss_parity(&t1_body(), &tn_body_efficient(), 0.01);
+        match out {
+            DdpLossParityOutcome::Ok { rel_diff } => {
+                // |2.51 - 2.5| / 2.5 = 0.004
+                assert!((rel_diff - 0.004).abs() < 1e-6, "got {rel_diff}");
+            }
+            other => panic!("expected Ok, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn loss_parity_rejects_divergence() {
+        let diverged = json!({"final_loss": 5.0, "tokens_per_sec": 1.0});
+        // |5.0 - 2.5| / 2.5 = 1.0 > 0.01
+        assert!(matches!(
+            classify_loss_parity(&t1_body(), &diverged, 0.01),
+            DdpLossParityOutcome::Divergence { .. }
+        ));
+    }
+
+    #[test]
+    fn loss_parity_rejects_missing_final_loss() {
+        let empty = json!({});
+        assert!(matches!(
+            classify_loss_parity(&empty, &tn_body_efficient(), 0.01),
+            DdpLossParityOutcome::MissingFinalLoss { which: "metrics_1gpu" }
+        ));
+    }
+
+    #[test]
+    fn allreduce_ok_on_positive_array() {
+        match classify_allreduce_bandwidth(&tn_body_efficient()) {
+            DdpAllreduceOutcome::Ok { steps } => assert_eq!(steps, 3),
+            other => panic!("expected Ok(3), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn allreduce_rejects_missing_ddp_metrics() {
+        let empty = json!({});
+        assert_eq!(
+            classify_allreduce_bandwidth(&empty),
+            DdpAllreduceOutcome::MissingDdpMetrics
+        );
+    }
+
+    #[test]
+    fn allreduce_rejects_empty_array() {
+        let body = json!({"ddp_metrics": {"allreduce_bandwidth_gbps": []}});
+        assert_eq!(
+            classify_allreduce_bandwidth(&body),
+            DdpAllreduceOutcome::EmptyBandwidthArray
+        );
+    }
+
+    #[test]
+    fn allreduce_rejects_zero_bandwidth() {
+        let body = json!({"ddp_metrics": {"allreduce_bandwidth_gbps": [120.0, 0.0, 121.0]}});
+        match classify_allreduce_bandwidth(&body) {
+            DdpAllreduceOutcome::NonPositiveBandwidth { step_index: 1, .. } => {}
+            other => panic!("expected NonPositiveBandwidth(step 1), got {other:?}"),
+        }
+    }
+}

--- a/crates/apr-cli/src/commands/ddp_metrics_lint.rs
+++ b/crates/apr-cli/src/commands/ddp_metrics_lint.rs
@@ -1,0 +1,106 @@
+//! `apr ddp-metrics-lint` — CRUX-D-11 DDP multi-GPU metrics gate.
+//!
+//! Reads two captured `apr finetune --parallel ddp --json` outputs (N=1 and
+//! N=k) and dispatches the pure classifiers in `ddp_metrics_classifier`.
+//! Exits non-zero on any failure.
+//!
+//! Spec: `contracts/crux-D-11-v1.yaml`. CRUX-SHIP-001 g2/g3 surface.
+
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+
+use super::ddp_metrics_classifier::{
+    classify_allreduce_bandwidth, classify_loss_parity, classify_scaling_efficiency,
+    DdpAllreduceOutcome, DdpLossParityOutcome, DdpScalingOutcome, D11_DEFAULT_LOSS_TOLERANCE,
+    D11_DEFAULT_SCALING_FLOOR,
+};
+use crate::error::{CliError, Result};
+
+pub(crate) fn run(
+    metrics_1gpu_file: &Path,
+    metrics_ngpu_file: &Path,
+    world_size: i64,
+    scaling_floor: f64,
+    loss_tolerance: f64,
+    json: bool,
+) -> Result<()> {
+    let body_1 = load_json(metrics_1gpu_file)?;
+    let body_n = load_json(metrics_ngpu_file)?;
+
+    let scaling = classify_scaling_efficiency(&body_1, &body_n, world_size, scaling_floor);
+    let parity = classify_loss_parity(&body_1, &body_n, loss_tolerance);
+    let allreduce = classify_allreduce_bandwidth(&body_n);
+
+    print_report(
+        metrics_1gpu_file,
+        metrics_ngpu_file,
+        &scaling,
+        &parity,
+        &allreduce,
+        json,
+    );
+
+    if !matches!(scaling, DdpScalingOutcome::Ok { .. }) {
+        return Err(CliError::ValidationFailed(format!(
+            "ddp-metrics-lint scaling-efficiency gate rejected: {scaling:?}"
+        )));
+    }
+    if !matches!(parity, DdpLossParityOutcome::Ok { .. }) {
+        return Err(CliError::ValidationFailed(format!(
+            "ddp-metrics-lint loss-parity gate rejected: {parity:?}"
+        )));
+    }
+    if !matches!(allreduce, DdpAllreduceOutcome::Ok { .. }) {
+        return Err(CliError::ValidationFailed(format!(
+            "ddp-metrics-lint allreduce-bandwidth gate rejected: {allreduce:?}"
+        )));
+    }
+    Ok(())
+}
+
+fn load_json(path: &Path) -> Result<Value> {
+    if !path.exists() {
+        return Err(CliError::FileNotFound(PathBuf::from(path)));
+    }
+    let body_text = std::fs::read_to_string(path)?;
+    serde_json::from_str(&body_text).map_err(|e| {
+        CliError::InvalidFormat(format!(
+            "apr ddp-metrics-lint: failed to parse JSON from {}: {e}",
+            path.display()
+        ))
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn print_report(
+    file1: &Path,
+    file_n: &Path,
+    scaling: &DdpScalingOutcome,
+    parity: &DdpLossParityOutcome,
+    allreduce: &DdpAllreduceOutcome,
+    json: bool,
+) {
+    if json {
+        let obj = serde_json::json!({
+            "metrics_1gpu_file": file1.display().to_string(),
+            "metrics_ngpu_file": file_n.display().to_string(),
+            "scaling_efficiency": format!("{scaling:?}"),
+            "loss_parity": format!("{parity:?}"),
+            "allreduce_bandwidth": format!("{allreduce:?}"),
+        });
+        println!("{}", serde_json::to_string_pretty(&obj).unwrap_or_default());
+        return;
+    }
+    println!("ddp-metrics-lint report");
+    println!("  metrics_1gpu_file   : {}", file1.display());
+    println!("  metrics_ngpu_file   : {}", file_n.display());
+    println!("  scaling_efficiency  : {scaling:?}");
+    println!("  loss_parity         : {parity:?}");
+    println!("  allreduce_bandwidth : {allreduce:?}");
+}
+
+/// Default constants re-exported so CLI defaults stay in sync with the
+/// classifier module.
+pub const DDP_METRICS_DEFAULT_SCALING_FLOOR: f64 = D11_DEFAULT_SCALING_FLOOR;
+pub const DDP_METRICS_DEFAULT_LOSS_TOLERANCE: f64 = D11_DEFAULT_LOSS_TOLERANCE;

--- a/crates/apr-cli/src/commands/mod.rs
+++ b/crates/apr-cli/src/commands/mod.rs
@@ -23,6 +23,8 @@ pub mod compare_hf;
 pub(crate) mod compile;
 pub(crate) mod convert;
 pub(crate) mod copy_tag;
+pub(crate) mod ddp_metrics_classifier;
+pub(crate) mod ddp_metrics_lint;
 pub(crate) mod debug;
 pub(crate) mod diff;
 pub(crate) mod diff_quant_roundtrip;

--- a/crates/apr-cli/src/dispatch_analysis.rs
+++ b/crates/apr-cli/src/dispatch_analysis.rs
@@ -200,6 +200,21 @@ fn dispatch_analysis_commands(cli: &Cli) -> Option<Result<(), CliError>> {
             cli.json,
         ),
 
+        ExtendedCommands::DdpMetricsLint {
+            metrics_1gpu_file,
+            metrics_ngpu_file,
+            world_size,
+            scaling_floor,
+            loss_tolerance,
+        } => commands::ddp_metrics_lint::run(
+            metrics_1gpu_file,
+            metrics_ngpu_file,
+            *world_size,
+            *scaling_floor,
+            *loss_tolerance,
+            cli.json,
+        ),
+
         ExtendedCommands::AttnVizLint {
             attn_file,
             html_file,

--- a/crates/apr-cli/src/extended_commands.rs
+++ b/crates/apr-cli/src/extended_commands.rs
@@ -834,6 +834,24 @@ pub enum ExtendedCommands {
         #[arg(long, value_name = "I32")]
         expected_exit_code: Option<i32>,
     },
+    /// Lint two captured `apr finetune --parallel ddp --json` outputs (N=1, N=k) (CRUX-D-11)
+    DdpMetricsLint {
+        /// Path to N=1 metrics JSON
+        #[arg(long, value_name = "FILE")]
+        metrics_1gpu_file: PathBuf,
+        /// Path to N=world_size metrics JSON
+        #[arg(long, value_name = "FILE")]
+        metrics_ngpu_file: PathBuf,
+        /// World size used for --metrics-ngpu-file run (>= 2)
+        #[arg(long, value_name = "N")]
+        world_size: i64,
+        /// Scaling-efficiency floor (default 0.85, PyTorch DDP convention)
+        #[arg(long, value_name = "F", default_value_t = 0.85)]
+        scaling_floor: f64,
+        /// Loss-parity relative tolerance (default 0.01)
+        #[arg(long, value_name = "F", default_value_t = 0.01)]
+        loss_tolerance: f64,
+    },
     /// Lint a captured `apr attn-viz` attention dump (CRUX-F-17)
     AttnVizLint {
         /// Path to attention dump in JSON form (4-D [layers][heads][rows][cols] floats)

--- a/crates/apr-cli/tests/cli_commands.rs
+++ b/crates/apr-cli/tests/cli_commands.rs
@@ -123,6 +123,7 @@ fn registered_commands() -> Vec<&'static str> {
         "nccl-diag-lint",
         "react-trace-lint",
         "hang-trace-lint",
+        "ddp-metrics-lint",
         "shard",
         "unshard",
         "oracle",

--- a/crates/apr-cli/tests/falsification_crux_d_11.rs
+++ b/crates/apr-cli/tests/falsification_crux_d_11.rs
@@ -1,0 +1,262 @@
+//! CRUX-D-11 — end-to-end falsification harness for `apr ddp-metrics-lint`.
+//!
+//! CRUX-SHIP-001 gate g3 evidence: every FALSIFY-CRUX-D-11-{001,002,003}
+//! gate the classifier discharges has a matching captured JSON pair that
+//! the binary must classify exactly as the harness expects.
+
+use serde_json::json;
+use std::io::Write;
+use std::process::Command;
+
+fn apr_binary() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_apr"));
+    cmd.env("NO_COLOR", "1");
+    cmd
+}
+
+fn write_json(body: &serde_json::Value) -> tempfile::NamedTempFile {
+    let mut f = tempfile::Builder::new()
+        .prefix("crux-d-11-")
+        .suffix(".json")
+        .tempfile()
+        .expect("tempfile");
+    f.write_all(serde_json::to_vec_pretty(body).expect("serialize").as_slice())
+        .expect("write");
+    f.flush().expect("flush");
+    f
+}
+
+fn good_t1() -> serde_json::Value {
+    json!({
+        "tokens_per_sec": 1000.0,
+        "final_loss": 2.5,
+        "ddp_metrics": {"allreduce_bandwidth_gbps": [120.0, 118.0, 121.0]}
+    })
+}
+
+fn good_t4() -> serde_json::Value {
+    // T_4 = 3500 → eff = 3500/4000 = 0.875 ≥ 0.85; loss within 0.4%.
+    json!({
+        "tokens_per_sec": 3500.0,
+        "final_loss": 2.51,
+        "ddp_metrics": {"allreduce_bandwidth_gbps": [80.0, 82.0, 79.0]}
+    })
+}
+
+// ===== g2: CLI shape =====
+
+#[test]
+fn falsify_crux_d_11_cli_help_advertises_flags() {
+    let out = apr_binary().args(["ddp-metrics-lint", "--help"]).output().expect("run");
+    assert!(out.status.success(), "--help must exit 0");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    for flag in [
+        "--metrics-1gpu-file",
+        "--metrics-ngpu-file",
+        "--world-size",
+        "--scaling-floor",
+        "--loss-tolerance",
+    ] {
+        assert!(stdout.contains(flag), "--help must advertise {flag}; got:\n{stdout}");
+    }
+}
+
+#[test]
+fn falsify_crux_d_11_cli_missing_file_fails() {
+    let out = apr_binary()
+        .args([
+            "ddp-metrics-lint",
+            "--metrics-1gpu-file",
+            "/nonexistent/crux-d-11-missing.json",
+            "--metrics-ngpu-file",
+            "/nonexistent/other.json",
+            "--world-size",
+            "4",
+        ])
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "missing file must not exit 0");
+}
+
+// ===== g3: classifier discharges =====
+
+#[test]
+fn falsify_crux_d_11_001_scaling_ok_at_0_875() {
+    let f1 = write_json(&good_t1());
+    let fn_ = write_json(&good_t4());
+    let out = apr_binary()
+        .args(["ddp-metrics-lint", "--metrics-1gpu-file"])
+        .arg(f1.path())
+        .arg("--metrics-ngpu-file")
+        .arg(fn_.path())
+        .args(["--world-size", "4"])
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "0.875 efficiency must pass; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn falsify_crux_d_11_001_scaling_rejects_below_floor() {
+    let f1 = write_json(&good_t1());
+    let bad = json!({
+        "tokens_per_sec": 2000.0,
+        "final_loss": 2.51,
+        "ddp_metrics": {"allreduce_bandwidth_gbps": [40.0]}
+    });
+    let fn_ = write_json(&bad);
+    let out = apr_binary()
+        .args(["ddp-metrics-lint", "--metrics-1gpu-file"])
+        .arg(f1.path())
+        .arg("--metrics-ngpu-file")
+        .arg(fn_.path())
+        .args(["--world-size", "4"])
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "0.5 efficiency must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("BelowThreshold"),
+        "stderr must name BelowThreshold; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn falsify_crux_d_11_002_loss_parity_ok_within_tolerance() {
+    let f1 = write_json(&good_t1());
+    let fn_ = write_json(&good_t4());
+    let out = apr_binary()
+        .args(["ddp-metrics-lint", "--metrics-1gpu-file"])
+        .arg(f1.path())
+        .arg("--metrics-ngpu-file")
+        .arg(fn_.path())
+        .args(["--world-size", "4"])
+        .output()
+        .expect("run");
+    assert!(out.status.success(), "loss within 1% must pass");
+}
+
+#[test]
+fn falsify_crux_d_11_002_loss_parity_rejects_divergence() {
+    let f1 = write_json(&good_t1());
+    let bad = json!({
+        "tokens_per_sec": 3500.0,
+        "final_loss": 5.0,
+        "ddp_metrics": {"allreduce_bandwidth_gbps": [80.0]}
+    });
+    let fn_ = write_json(&bad);
+    let out = apr_binary()
+        .args(["ddp-metrics-lint", "--metrics-1gpu-file"])
+        .arg(f1.path())
+        .arg("--metrics-ngpu-file")
+        .arg(fn_.path())
+        .args(["--world-size", "4"])
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "loss divergence must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("Divergence"),
+        "stderr must name Divergence; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn falsify_crux_d_11_003_allreduce_rejects_missing_array() {
+    let f1 = write_json(&good_t1());
+    let bad = json!({
+        "tokens_per_sec": 3500.0,
+        "final_loss": 2.51
+        // no ddp_metrics
+    });
+    let fn_ = write_json(&bad);
+    let out = apr_binary()
+        .args(["ddp-metrics-lint", "--metrics-1gpu-file"])
+        .arg(f1.path())
+        .arg("--metrics-ngpu-file")
+        .arg(fn_.path())
+        .args(["--world-size", "4"])
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "missing ddp_metrics must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("MissingDdpMetrics"),
+        "stderr must name MissingDdpMetrics; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn falsify_crux_d_11_003_allreduce_rejects_zero_step() {
+    let f1 = write_json(&good_t1());
+    let bad = json!({
+        "tokens_per_sec": 3500.0,
+        "final_loss": 2.51,
+        "ddp_metrics": {"allreduce_bandwidth_gbps": [120.0, 0.0, 121.0]}
+    });
+    let fn_ = write_json(&bad);
+    let out = apr_binary()
+        .args(["ddp-metrics-lint", "--metrics-1gpu-file"])
+        .arg(f1.path())
+        .arg("--metrics-ngpu-file")
+        .arg(fn_.path())
+        .args(["--world-size", "4"])
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "zero bandwidth must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("NonPositiveBandwidth"),
+        "stderr must name NonPositiveBandwidth; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn falsify_crux_d_11_scaling_floor_configurable() {
+    // T_4/4*T_1 = 0.6; default floor 0.85 fails, --scaling-floor 0.5 passes.
+    let f1 = write_json(&good_t1());
+    let body = json!({
+        "tokens_per_sec": 2400.0,
+        "final_loss": 2.51,
+        "ddp_metrics": {"allreduce_bandwidth_gbps": [50.0]}
+    });
+    let fn_ = write_json(&body);
+    let out = apr_binary()
+        .args(["ddp-metrics-lint", "--metrics-1gpu-file"])
+        .arg(f1.path())
+        .arg("--metrics-ngpu-file")
+        .arg(fn_.path())
+        .args(["--world-size", "4", "--scaling-floor", "0.5"])
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "0.6 efficiency with floor=0.5 must pass; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+// ===== JSON output shape =====
+
+#[test]
+fn falsify_crux_d_11_json_output_contains_outcomes() {
+    let f1 = write_json(&good_t1());
+    let fn_ = write_json(&good_t4());
+    let out = apr_binary()
+        .args(["--json", "ddp-metrics-lint", "--metrics-1gpu-file"])
+        .arg(f1.path())
+        .arg("--metrics-ngpu-file")
+        .arg(fn_.path())
+        .args(["--world-size", "4"])
+        .output()
+        .expect("run");
+    assert!(out.status.success(), "json + good bodies must exit 0");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("json output must parse");
+    assert!(parsed["scaling_efficiency"].as_str().expect("scaling").contains("Ok"));
+    assert!(parsed["loss_parity"].as_str().expect("loss_parity").contains("Ok"));
+    assert!(parsed["allreduce_bandwidth"].as_str().expect("allreduce").contains("Ok"));
+}


### PR DESCRIPTION
## Summary

- Promotes \`contracts/crux-D-11-v1.yaml\` from \`draft\` → PARTIAL_ALGORITHM_LEVEL.
- Adds \`apr ddp-metrics-lint --metrics-1gpu-file F --metrics-ngpu-file F --world-size N [--scaling-floor F] [--loss-tolerance F]\` — pure-function classifier validating: T_N/(N*T_1) ≥ 0.85, |L_N - L_1|/L_1 ≤ 0.01, per-step allreduce bandwidth > 0 (PyTorch DDP parity).
- 12 classifier unit tests + 10 e2e falsification tests + 8 cli_commands surface tests all pass.

Discharges FALSIFY-CRUX-D-11-{001,002,003} at PARTIAL_ALGORITHM_LEVEL.

## Test plan

- [x] \`cargo test -p apr-cli --lib ddp_metrics_classifier\` — 12/12 pass.
- [x] \`cargo test -p apr-cli --test falsification_crux_d_11\` — 10/10 pass.
- [x] \`cargo test -p apr-cli --test cli_commands\` — 8/8 pass (3-surface drift policy).
- [ ] CI green on \`ci / gate\` + \`workspace-test\`.

Refs #919 (CRUX M2 distributed training epic), #917 (CRUX Phase 3 umbrella).

🤖 Generated with [Claude Code](https://claude.com/claude-code)