### PR TITLE
feat(apr-cli): CRUX-L-02 `apr attn-parity-lint` FlashAttention-2 parity classifier

### DIFF
--- a/contracts/apr-cli-commands-v1.yaml
+++ b/contracts/apr-cli-commands-v1.yaml
@@ -616,6 +616,12 @@ commands:
     requires_model: false
     side_effects: []
 
+  - name: attn-parity-lint
+    category: inspection
+    description: "Validate captured flash-attn2 parity + provenance JSON outputs (CRUX-L-02): max_abs_diff <= 5e-3, cosine_sim >= 0.9999, kernel_source matches hf-kernels-community:flash-attn2@<40-hex>, fallback reason present when not flash2, head_dim error names the rejection"
+    requires_model: false
+    side_effects: []
+
   - name: shard
     category: model_ops
     description: "Split safetensors file into shards + weight-map index (CRUX-B-05)"

--- a/contracts/crux-L-02-v1.yaml
+++ b/contracts/crux-L-02-v1.yaml
@@ -1,13 +1,22 @@
 # CRUX-L-02 — Drop-in flash-attn2 dispatch via HF kernels-community
 # Authored under PMAT-656. See docs/specifications/crux-competitive-research-ux-workflows.md §5.L.
+# Promoted to PARTIAL_ALGORITHM_LEVEL at v1.1.0 under CRUX-SHIP-001 (2026-05-17):
+# - classifier: crates/apr-cli/src/commands/attn_parity_classifier.rs (13 unit tests)
+# - CLI surface: `apr attn-parity-lint [--parity-file F] [--provenance-file F] [--head-dim-error-file F] [--tol-abs F] [--tol-cos F]`
+# - e2e: crates/apr-cli/tests/falsification_crux_l_02.rs (11 tests)
+# Full discharge requires live `apr kernel parity` + `apr run --attn flash2`
+# emitters wired to the hf-kernels-community FA2 SO. Tracked as
+# BLOCKER-UPSTREAM-MISSING.
 
 metadata:
   id: CRUX-L-02
-  version: "1.0.0-draft"
+  version: "1.1.0"
   created: "2026-04-21"
+  updated: "2026-05-17"
   author: PAIML Engineering
   registry: true
-  status: draft
+  status: partial
+  kind: kernel
   parent_contracts:
   - crux-competitive-research-ux-v1
   - crux-L-01-v1

--- a/crates/apr-cli/src/commands/attn_parity_classifier.rs
+++ b/crates/apr-cli/src/commands/attn_parity_classifier.rs
@@ -1,0 +1,286 @@
+//! Flash-attention parity classifier (CRUX-L-02).
+//!
+//! Pure, deterministic classifiers that discharge FALSIFY-CRUX-L-02-{002,003,004}
+//! at the PARTIAL_ALGORITHM_LEVEL — algorithm-level necessary conditions on:
+//!
+//!   * a captured `apr kernel parity --impl flash2 --ref naive --json` body
+//!     (numerical parity gate); and
+//!   * a captured `apr run --attn flash2 --json` body (kernel-source
+//!     provenance + fallback metadata); and
+//!   * a captured error JSON from a head_dim-rejection path.
+//!
+//! Classifiers:
+//!   * `classify_parity_numerics` — `max_abs_diff <= tol_abs` (default 5e-3)
+//!     AND `cosine_sim >= tol_cos` (default 0.9999). Bounds from the
+//!     FlashAttention-2 paper (Dao 2023, arXiv:2307.08691).
+//!   * `classify_provenance` — `attn_impl == "flash2"` ⇒
+//!     `kernel_source` matches
+//!     `^hf-kernels-community:flash-attn2@[0-9a-f]{40}$`;
+//!     `attn_impl != "flash2"` ⇒ `fallback` is a non-empty string.
+//!   * `classify_head_dim_error` — error JSON has `error` containing
+//!     `unsupported-head-dim` or `head_dim` (caller asserts exit_code=1).
+//!
+//! Full discharge requires a live `apr kernel parity` + `apr run --attn flash2`
+//! pipeline — tracked as BLOCKER-UPSTREAM-MISSING.
+
+use serde_json::Value;
+
+/// Default FlashAttention-2 numerical-parity tolerances (Dao 2023 bound).
+pub const L02_DEFAULT_MAX_ABS_DIFF: f64 = 5e-3;
+pub const L02_DEFAULT_MIN_COSINE_SIM: f64 = 0.9999;
+
+/// Canonical kernel-source prefix (hf-kernels-community FA2 release).
+pub const L02_KERNEL_SOURCE_PREFIX: &str = "hf-kernels-community:flash-attn2@";
+
+/// Outcome of `classify_parity_numerics`.
+#[derive(Debug, Clone, PartialEq)]
+pub enum AttnParityNumericsOutcome {
+    Ok { max_abs_diff: f64, cosine_sim: f64 },
+    NotAnObject,
+    MissingMaxAbsDiff,
+    MissingCosineSim,
+    NonFiniteMaxAbsDiff { got: f64 },
+    NonFiniteCosineSim { got: f64 },
+    MaxAbsDiffExceedsTolerance { got: f64, tolerance: f64 },
+    CosineSimBelowFloor { got: f64, floor: f64 },
+}
+
+/// Outcome of `classify_provenance`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AttnProvenanceOutcome {
+    OkFlash2 { sha: String },
+    OkFallback { reason: String },
+    NotAnObject,
+    MissingAttnImpl,
+    UnknownAttnImpl { got: String },
+    KernelSourceMissing,
+    KernelSourceMalformed { got: String },
+    FallbackMissingWhenNotFlash2 { attn_impl: String },
+}
+
+/// Outcome of `classify_head_dim_error`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AttnHeadDimErrorOutcome {
+    Ok { error: String },
+    NotAnObject,
+    MissingErrorField,
+    ErrorDoesNotMentionHeadDim { got: String },
+}
+
+/// FALSIFY-CRUX-L-02-002: numerical parity vs the naive reference.
+pub fn classify_parity_numerics(
+    body: &Value,
+    tol_abs: f64,
+    tol_cos: f64,
+) -> AttnParityNumericsOutcome {
+    let Some(obj) = body.as_object() else {
+        return AttnParityNumericsOutcome::NotAnObject;
+    };
+    let Some(mad) = obj.get("max_abs_diff").and_then(Value::as_f64) else {
+        return AttnParityNumericsOutcome::MissingMaxAbsDiff;
+    };
+    let Some(cos) = obj.get("cosine_sim").and_then(Value::as_f64) else {
+        return AttnParityNumericsOutcome::MissingCosineSim;
+    };
+    if !mad.is_finite() {
+        return AttnParityNumericsOutcome::NonFiniteMaxAbsDiff { got: mad };
+    }
+    if !cos.is_finite() {
+        return AttnParityNumericsOutcome::NonFiniteCosineSim { got: cos };
+    }
+    if mad > tol_abs {
+        return AttnParityNumericsOutcome::MaxAbsDiffExceedsTolerance {
+            got: mad,
+            tolerance: tol_abs,
+        };
+    }
+    if cos < tol_cos {
+        return AttnParityNumericsOutcome::CosineSimBelowFloor { got: cos, floor: tol_cos };
+    }
+    AttnParityNumericsOutcome::Ok { max_abs_diff: mad, cosine_sim: cos }
+}
+
+/// FALSIFY-CRUX-L-02-003: provenance & fallback metadata.
+pub fn classify_provenance(body: &Value) -> AttnProvenanceOutcome {
+    let Some(obj) = body.as_object() else {
+        return AttnProvenanceOutcome::NotAnObject;
+    };
+    let Some(impl_) = obj.get("attn_impl").and_then(Value::as_str) else {
+        return AttnProvenanceOutcome::MissingAttnImpl;
+    };
+    match impl_ {
+        "flash2" => {
+            let src = obj.get("kernel_source").and_then(Value::as_str);
+            match src {
+                None => AttnProvenanceOutcome::KernelSourceMissing,
+                Some(s) => {
+                    if !s.starts_with(L02_KERNEL_SOURCE_PREFIX) {
+                        return AttnProvenanceOutcome::KernelSourceMalformed { got: s.to_string() };
+                    }
+                    let sha = &s[L02_KERNEL_SOURCE_PREFIX.len()..];
+                    if sha.len() != 40 || !sha.bytes().all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'f'))
+                    {
+                        return AttnProvenanceOutcome::KernelSourceMalformed { got: s.to_string() };
+                    }
+                    AttnProvenanceOutcome::OkFlash2 { sha: sha.to_string() }
+                }
+            }
+        }
+        "naive" | "fallback" => {
+            let fb = obj.get("fallback").and_then(Value::as_str);
+            match fb {
+                Some(s) if !s.is_empty() => {
+                    AttnProvenanceOutcome::OkFallback { reason: s.to_string() }
+                }
+                _ => AttnProvenanceOutcome::FallbackMissingWhenNotFlash2 {
+                    attn_impl: impl_.to_string(),
+                },
+            }
+        }
+        other => AttnProvenanceOutcome::UnknownAttnImpl { got: other.to_string() },
+    }
+}
+
+/// FALSIFY-CRUX-L-02-004: unsupported head_dim error JSON shape.
+pub fn classify_head_dim_error(body: &Value) -> AttnHeadDimErrorOutcome {
+    let Some(obj) = body.as_object() else {
+        return AttnHeadDimErrorOutcome::NotAnObject;
+    };
+    let Some(err) = obj.get("error").and_then(Value::as_str) else {
+        return AttnHeadDimErrorOutcome::MissingErrorField;
+    };
+    if err.contains("unsupported-head-dim") || err.contains("head_dim") || err.contains("head-dim") {
+        return AttnHeadDimErrorOutcome::Ok { error: err.to_string() };
+    }
+    AttnHeadDimErrorOutcome::ErrorDoesNotMentionHeadDim { got: err.to_string() }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parity_ok_inside_tolerance() {
+        let body = json!({"max_abs_diff": 0.002, "cosine_sim": 0.99999});
+        match classify_parity_numerics(&body, 5e-3, 0.9999) {
+            AttnParityNumericsOutcome::Ok { .. } => {}
+            other => panic!("expected Ok, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parity_rejects_max_abs_diff_above_tolerance() {
+        let body = json!({"max_abs_diff": 0.01, "cosine_sim": 0.99999});
+        assert!(matches!(
+            classify_parity_numerics(&body, 5e-3, 0.9999),
+            AttnParityNumericsOutcome::MaxAbsDiffExceedsTolerance { .. }
+        ));
+    }
+
+    #[test]
+    fn parity_rejects_cosine_below_floor() {
+        let body = json!({"max_abs_diff": 0.001, "cosine_sim": 0.99});
+        assert!(matches!(
+            classify_parity_numerics(&body, 5e-3, 0.9999),
+            AttnParityNumericsOutcome::CosineSimBelowFloor { .. }
+        ));
+    }
+
+    #[test]
+    fn parity_rejects_missing_keys() {
+        assert_eq!(
+            classify_parity_numerics(&json!({"cosine_sim": 1.0}), 5e-3, 0.9999),
+            AttnParityNumericsOutcome::MissingMaxAbsDiff
+        );
+        assert_eq!(
+            classify_parity_numerics(&json!({"max_abs_diff": 0.0}), 5e-3, 0.9999),
+            AttnParityNumericsOutcome::MissingCosineSim
+        );
+    }
+
+    #[test]
+    fn provenance_ok_on_pinned_flash2() {
+        let sha = "abcdef0123456789abcdef0123456789abcdef01";
+        let src = format!("hf-kernels-community:flash-attn2@{sha}");
+        let body = json!({"attn_impl": "flash2", "kernel_source": src});
+        match classify_provenance(&body) {
+            AttnProvenanceOutcome::OkFlash2 { sha: got } => assert_eq!(got, sha),
+            other => panic!("expected OkFlash2, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn provenance_rejects_malformed_sha() {
+        let body = json!({"attn_impl": "flash2", "kernel_source": "hf-kernels-community:flash-attn2@short"});
+        assert!(matches!(
+            classify_provenance(&body),
+            AttnProvenanceOutcome::KernelSourceMalformed { .. }
+        ));
+    }
+
+    #[test]
+    fn provenance_rejects_missing_kernel_source_when_flash2() {
+        let body = json!({"attn_impl": "flash2"});
+        assert_eq!(
+            classify_provenance(&body),
+            AttnProvenanceOutcome::KernelSourceMissing
+        );
+    }
+
+    #[test]
+    fn provenance_ok_on_naive_with_fallback_reason() {
+        let body = json!({"attn_impl": "naive", "fallback": "no-gpu"});
+        match classify_provenance(&body) {
+            AttnProvenanceOutcome::OkFallback { reason } => assert_eq!(reason, "no-gpu"),
+            other => panic!("expected OkFallback, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn provenance_rejects_naive_without_fallback() {
+        let body = json!({"attn_impl": "naive"});
+        assert!(matches!(
+            classify_provenance(&body),
+            AttnProvenanceOutcome::FallbackMissingWhenNotFlash2 { .. }
+        ));
+    }
+
+    #[test]
+    fn provenance_rejects_unknown_attn_impl() {
+        let body = json!({"attn_impl": "unobtanium"});
+        assert!(matches!(
+            classify_provenance(&body),
+            AttnProvenanceOutcome::UnknownAttnImpl { .. }
+        ));
+    }
+
+    #[test]
+    fn head_dim_error_ok_on_unsupported_message() {
+        let body = json!({"error": "unsupported-head-dim: got 96, expected 64 or 128"});
+        match classify_head_dim_error(&body) {
+            AttnHeadDimErrorOutcome::Ok { error } => {
+                assert!(error.contains("unsupported-head-dim"));
+            }
+            other => panic!("expected Ok, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn head_dim_error_rejects_irrelevant_error() {
+        let body = json!({"error": "out of memory"});
+        assert!(matches!(
+            classify_head_dim_error(&body),
+            AttnHeadDimErrorOutcome::ErrorDoesNotMentionHeadDim { .. }
+        ));
+    }
+
+    #[test]
+    fn head_dim_error_rejects_missing_error_field() {
+        let body = json!({});
+        assert_eq!(
+            classify_head_dim_error(&body),
+            AttnHeadDimErrorOutcome::MissingErrorField
+        );
+    }
+}

--- a/crates/apr-cli/src/commands/attn_parity_lint.rs
+++ b/crates/apr-cli/src/commands/attn_parity_lint.rs
@@ -1,0 +1,143 @@
+//! `apr attn-parity-lint` — CRUX-L-02 flash-attn2 parity gate.
+//!
+//! Reads a captured `apr kernel parity --impl flash2 --ref naive --json`
+//! body and/or `apr run --attn flash2 --json` body and/or a head_dim
+//! error JSON, then dispatches the pure classifiers in
+//! `attn_parity_classifier`. Exits non-zero on any failure.
+//!
+//! Spec: `contracts/crux-L-02-v1.yaml`. CRUX-SHIP-001 g2/g3 surface.
+
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+
+use super::attn_parity_classifier::{
+    classify_head_dim_error, classify_parity_numerics, classify_provenance,
+    AttnHeadDimErrorOutcome, AttnParityNumericsOutcome, AttnProvenanceOutcome,
+    L02_DEFAULT_MAX_ABS_DIFF, L02_DEFAULT_MIN_COSINE_SIM,
+};
+use crate::error::{CliError, Result};
+
+pub(crate) fn run(
+    parity_file: Option<&Path>,
+    provenance_file: Option<&Path>,
+    head_dim_error_file: Option<&Path>,
+    tol_abs: f64,
+    tol_cos: f64,
+    json: bool,
+) -> Result<()> {
+    if parity_file.is_none() && provenance_file.is_none() && head_dim_error_file.is_none() {
+        return Err(CliError::ValidationFailed(
+            "apr attn-parity-lint: at least one of --parity-file, --provenance-file, or --head-dim-error-file is required"
+                .to_string(),
+        ));
+    }
+
+    let parity = match parity_file {
+        Some(p) => Some(classify_parity_numerics(&load_json(p)?, tol_abs, tol_cos)),
+        None => None,
+    };
+    let provenance = match provenance_file {
+        Some(p) => Some(classify_provenance(&load_json(p)?)),
+        None => None,
+    };
+    let head_dim = match head_dim_error_file {
+        Some(p) => Some(classify_head_dim_error(&load_json(p)?)),
+        None => None,
+    };
+
+    print_report(
+        parity_file,
+        provenance_file,
+        head_dim_error_file,
+        parity.as_ref(),
+        provenance.as_ref(),
+        head_dim.as_ref(),
+        json,
+    );
+
+    if let Some(o) = &parity {
+        if !matches!(o, AttnParityNumericsOutcome::Ok { .. }) {
+            return Err(CliError::ValidationFailed(format!(
+                "attn-parity-lint parity-numerics gate rejected body: {o:?}"
+            )));
+        }
+    }
+    if let Some(o) = &provenance {
+        if !matches!(
+            o,
+            AttnProvenanceOutcome::OkFlash2 { .. } | AttnProvenanceOutcome::OkFallback { .. }
+        ) {
+            return Err(CliError::ValidationFailed(format!(
+                "attn-parity-lint provenance gate rejected body: {o:?}"
+            )));
+        }
+    }
+    if let Some(o) = &head_dim {
+        if !matches!(o, AttnHeadDimErrorOutcome::Ok { .. }) {
+            return Err(CliError::ValidationFailed(format!(
+                "attn-parity-lint head-dim-error gate rejected body: {o:?}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn load_json(path: &Path) -> Result<Value> {
+    if !path.exists() {
+        return Err(CliError::FileNotFound(PathBuf::from(path)));
+    }
+    let body_text = std::fs::read_to_string(path)?;
+    serde_json::from_str(&body_text).map_err(|e| {
+        CliError::InvalidFormat(format!(
+            "apr attn-parity-lint: failed to parse JSON from {}: {e}",
+            path.display()
+        ))
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn print_report(
+    parity_file: Option<&Path>,
+    provenance_file: Option<&Path>,
+    head_dim_error_file: Option<&Path>,
+    parity: Option<&AttnParityNumericsOutcome>,
+    provenance: Option<&AttnProvenanceOutcome>,
+    head_dim: Option<&AttnHeadDimErrorOutcome>,
+    json: bool,
+) {
+    if json {
+        let obj = serde_json::json!({
+            "parity_file": parity_file.map(|p| p.display().to_string()),
+            "provenance_file": provenance_file.map(|p| p.display().to_string()),
+            "head_dim_error_file": head_dim_error_file.map(|p| p.display().to_string()),
+            "parity_numerics": parity.map(|o| format!("{o:?}")),
+            "provenance": provenance.map(|o| format!("{o:?}")),
+            "head_dim_error": head_dim.map(|o| format!("{o:?}")),
+        });
+        println!("{}", serde_json::to_string_pretty(&obj).unwrap_or_default());
+        return;
+    }
+    println!("attn-parity-lint report");
+    if let Some(p) = parity_file {
+        println!("  parity_file        : {}", p.display());
+    }
+    if let Some(p) = provenance_file {
+        println!("  provenance_file    : {}", p.display());
+    }
+    if let Some(p) = head_dim_error_file {
+        println!("  head_dim_error_file: {}", p.display());
+    }
+    if let Some(o) = parity {
+        println!("  parity_numerics    : {o:?}");
+    }
+    if let Some(o) = provenance {
+        println!("  provenance         : {o:?}");
+    }
+    if let Some(o) = head_dim {
+        println!("  head_dim_error     : {o:?}");
+    }
+}
+
+pub const ATTN_PARITY_DEFAULT_MAX_ABS_DIFF: f64 = L02_DEFAULT_MAX_ABS_DIFF;
+pub const ATTN_PARITY_DEFAULT_MIN_COSINE_SIM: f64 = L02_DEFAULT_MIN_COSINE_SIM;

--- a/crates/apr-cli/src/commands/mod.rs
+++ b/crates/apr-cli/src/commands/mod.rs
@@ -6,6 +6,8 @@
 //! - Visualization: Make problems visible
 
 pub(crate) mod aliases;
+pub(crate) mod attn_parity_classifier;
+pub(crate) mod attn_parity_lint;
 pub(crate) mod attn_viz_classifier;
 pub(crate) mod attn_viz_lint;
 pub(crate) mod audio_inspect_classifier;

--- a/crates/apr-cli/src/dispatch_analysis.rs
+++ b/crates/apr-cli/src/dispatch_analysis.rs
@@ -226,6 +226,21 @@ fn dispatch_analysis_commands(cli: &Cli) -> Option<Result<(), CliError>> {
             cli.json,
         ),
 
+        ExtendedCommands::AttnParityLint {
+            parity_file,
+            provenance_file,
+            head_dim_error_file,
+            tol_abs,
+            tol_cos,
+        } => commands::attn_parity_lint::run(
+            parity_file.as_deref(),
+            provenance_file.as_deref(),
+            head_dim_error_file.as_deref(),
+            *tol_abs,
+            *tol_cos,
+            cli.json,
+        ),
+
         ExtendedCommands::AttnVizLint {
             attn_file,
             html_file,

--- a/crates/apr-cli/src/extended_commands.rs
+++ b/crates/apr-cli/src/extended_commands.rs
@@ -864,6 +864,24 @@ pub enum ExtendedCommands {
         #[arg(long, value_name = "U32")]
         expected_channels: Option<u32>,
     },
+    /// Lint captured flash-attn2 parity + provenance JSON outputs (CRUX-L-02)
+    AttnParityLint {
+        /// Path to captured `apr kernel parity --impl flash2 --ref naive --json` body
+        #[arg(long, value_name = "FILE")]
+        parity_file: Option<PathBuf>,
+        /// Path to captured `apr run --attn flash2 --json` body for provenance check
+        #[arg(long, value_name = "FILE")]
+        provenance_file: Option<PathBuf>,
+        /// Path to captured head_dim error JSON
+        #[arg(long, value_name = "FILE")]
+        head_dim_error_file: Option<PathBuf>,
+        /// Max absolute diff tolerance (default 5e-3, FlashAttention-2 bound)
+        #[arg(long, value_name = "F", default_value_t = 5e-3)]
+        tol_abs: f64,
+        /// Min cosine similarity floor (default 0.9999)
+        #[arg(long, value_name = "F", default_value_t = 0.9999)]
+        tol_cos: f64,
+    },
     /// Lint a captured `apr attn-viz` attention dump (CRUX-F-17)
     AttnVizLint {
         /// Path to attention dump in JSON form (4-D [layers][heads][rows][cols] floats)

--- a/crates/apr-cli/tests/cli_commands.rs
+++ b/crates/apr-cli/tests/cli_commands.rs
@@ -125,6 +125,7 @@ fn registered_commands() -> Vec<&'static str> {
         "hang-trace-lint",
         "ddp-metrics-lint",
         "audio-inspect-lint",
+        "attn-parity-lint",
         "shard",
         "unshard",
         "oracle",

--- a/crates/apr-cli/tests/falsification_crux_l_02.rs
+++ b/crates/apr-cli/tests/falsification_crux_l_02.rs
@@ -1,0 +1,223 @@
+//! CRUX-L-02 — end-to-end falsification harness for `apr attn-parity-lint`.
+//!
+//! CRUX-SHIP-001 gate g3 evidence: every FALSIFY-CRUX-L-02-{002,003,004} gate
+//! the classifier discharges has a matching captured JSON body that the
+//! binary must classify exactly as the harness expects.
+
+use serde_json::json;
+use std::io::Write;
+use std::process::Command;
+
+fn apr_binary() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_apr"));
+    cmd.env("NO_COLOR", "1");
+    cmd
+}
+
+fn write_json(body: &serde_json::Value) -> tempfile::NamedTempFile {
+    let mut f = tempfile::Builder::new()
+        .prefix("crux-l-02-")
+        .suffix(".json")
+        .tempfile()
+        .expect("tempfile");
+    f.write_all(serde_json::to_vec_pretty(body).expect("serialize").as_slice())
+        .expect("write");
+    f.flush().expect("flush");
+    f
+}
+
+fn good_parity() -> serde_json::Value {
+    json!({"max_abs_diff": 0.002, "cosine_sim": 0.99999})
+}
+
+fn good_provenance() -> serde_json::Value {
+    json!({
+        "attn_impl": "flash2",
+        "kernel_source": "hf-kernels-community:flash-attn2@abcdef0123456789abcdef0123456789abcdef01",
+        "fallback": null
+    })
+}
+
+// ===== g2: CLI shape =====
+
+#[test]
+fn falsify_crux_l_02_cli_help_advertises_flags() {
+    let out = apr_binary().args(["attn-parity-lint", "--help"]).output().expect("run");
+    assert!(out.status.success(), "--help must exit 0");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    for flag in [
+        "--parity-file",
+        "--provenance-file",
+        "--head-dim-error-file",
+        "--tol-abs",
+        "--tol-cos",
+    ] {
+        assert!(stdout.contains(flag), "--help must advertise {flag}; got:\n{stdout}");
+    }
+}
+
+#[test]
+fn falsify_crux_l_02_cli_requires_at_least_one_file() {
+    let out = apr_binary().args(["attn-parity-lint"]).output().expect("run");
+    assert!(!out.status.success(), "bare invocation must not exit 0");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("at least one of"),
+        "stderr must explain requirement; got:\n{stderr}"
+    );
+}
+
+// ===== g3: classifier discharges =====
+
+#[test]
+fn falsify_crux_l_02_002_parity_ok_within_bounds() {
+    let f = write_json(&good_parity());
+    let out = apr_binary()
+        .args(["attn-parity-lint", "--parity-file"])
+        .arg(f.path())
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "in-tolerance parity must pass; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn falsify_crux_l_02_002_parity_rejects_max_abs_diff_above() {
+    let body = json!({"max_abs_diff": 0.01, "cosine_sim": 0.99999});
+    let f = write_json(&body);
+    let out = apr_binary()
+        .args(["attn-parity-lint", "--parity-file"])
+        .arg(f.path())
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "max_abs_diff > 5e-3 must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("MaxAbsDiffExceedsTolerance"),
+        "stderr must name MaxAbsDiffExceedsTolerance; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn falsify_crux_l_02_002_parity_rejects_cosine_below_floor() {
+    let body = json!({"max_abs_diff": 0.001, "cosine_sim": 0.99});
+    let f = write_json(&body);
+    let out = apr_binary()
+        .args(["attn-parity-lint", "--parity-file"])
+        .arg(f.path())
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "cosine < 0.9999 must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("CosineSimBelowFloor"),
+        "stderr must name CosineSimBelowFloor; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn falsify_crux_l_02_003_provenance_ok_on_pinned_flash2() {
+    let f = write_json(&good_provenance());
+    let out = apr_binary()
+        .args(["attn-parity-lint", "--provenance-file"])
+        .arg(f.path())
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "pinned flash2 source must pass; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn falsify_crux_l_02_003_provenance_rejects_malformed_sha() {
+    let body = json!({
+        "attn_impl": "flash2",
+        "kernel_source": "hf-kernels-community:flash-attn2@short"
+    });
+    let f = write_json(&body);
+    let out = apr_binary()
+        .args(["attn-parity-lint", "--provenance-file"])
+        .arg(f.path())
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "malformed sha must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("KernelSourceMalformed"),
+        "stderr must name KernelSourceMalformed; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn falsify_crux_l_02_003_provenance_ok_on_naive_with_reason() {
+    let body = json!({"attn_impl": "naive", "fallback": "no-gpu"});
+    let f = write_json(&body);
+    let out = apr_binary()
+        .args(["attn-parity-lint", "--provenance-file"])
+        .arg(f.path())
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "naive with fallback reason must pass; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn falsify_crux_l_02_004_head_dim_error_ok_on_unsupported() {
+    let body = json!({"error": "unsupported-head-dim: got 96, expected 64 or 128"});
+    let f = write_json(&body);
+    let out = apr_binary()
+        .args(["attn-parity-lint", "--head-dim-error-file"])
+        .arg(f.path())
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "unsupported-head-dim error must pass; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn falsify_crux_l_02_004_head_dim_error_rejects_irrelevant_error() {
+    let body = json!({"error": "out of memory"});
+    let f = write_json(&body);
+    let out = apr_binary()
+        .args(["attn-parity-lint", "--head-dim-error-file"])
+        .arg(f.path())
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "irrelevant error must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("ErrorDoesNotMentionHeadDim"),
+        "stderr must name ErrorDoesNotMentionHeadDim; got:\n{stderr}"
+    );
+}
+
+// ===== JSON output shape =====
+
+#[test]
+fn falsify_crux_l_02_json_output_contains_outcomes() {
+    let fp = write_json(&good_parity());
+    let fv = write_json(&good_provenance());
+    let out = apr_binary()
+        .args(["--json", "attn-parity-lint", "--parity-file"])
+        .arg(fp.path())
+        .arg("--provenance-file")
+        .arg(fv.path())
+        .output()
+        .expect("run");
+    assert!(out.status.success(), "json + good bodies must exit 0");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("json output must parse");
+    assert!(parsed["parity_numerics"].as_str().expect("parity").contains("Ok"));
+    assert!(parsed["provenance"].as_str().expect("provenance").contains("OkFlash2"));
+}


### PR DESCRIPTION
## Summary

- Promotes \`contracts/crux-L-02-v1.yaml\` from \`draft\` → PARTIAL_ALGORITHM_LEVEL.
- Adds \`apr attn-parity-lint [--parity-file F] [--provenance-file F] [--head-dim-error-file F] [--tol-abs F] [--tol-cos F]\` — pure-function classifier validating: FA2 parity bounds (max_abs_diff ≤ 5e-3, cosine_sim ≥ 0.9999), kernel-source provenance pinned to \`hf-kernels-community:flash-attn2@<40-hex>\`, head_dim error JSON shape.
- 13 classifier unit tests + 11 e2e falsification tests + 8 cli_commands surface tests all pass.

Discharges FALSIFY-CRUX-L-02-{002,003,004} at PARTIAL_ALGORITHM_LEVEL.

## Test plan

- [x] \`cargo test -p apr-cli --lib attn_parity_classifier\` — 13/13 pass.
- [x] \`cargo test -p apr-cli --test falsification_crux_l_02\` — 11/11 pass.
- [x] \`cargo test -p apr-cli --test cli_commands\` — 8/8 pass (3-surface drift policy).
- [ ] CI green on \`ci / gate\` + \`workspace-test\`.

Refs #917 (CRUX Phase 3 umbrella).

🤖 Generated with [Claude Code](https://claude.com/claude-code)