### PR TITLE
test(m-gpu-moe-3): PR-3g multi-prompt argmax agreement — L47 NOT BENIGN (#1583)

### DIFF
--- a/crates/aprender-serve/tests/qwen3_moe_gpu_parity.rs
+++ b/crates/aprender-serve/tests/qwen3_moe_gpu_parity.rs
@@ -232,6 +232,197 @@ fn falsify_qw3_moe_gpu_parity_001_cosine_vs_cpu() {
     );
 }
 
+/// FALSIFY-QW3-MOE-GPU-ARGMAX-AGREEMENT — M-GPU-MOE-3 PR-3g (#1583).
+///
+/// **Hypothesis**: the L47 expert-set routing divergence confirmed by
+/// PR-3e2 #1743 (CPU picks experts `{2,20,36,57,60,73,111,120}`, GPU
+/// picks `{2,12,36,57,60,103,111,120}` at L47) is COSMETICALLY a cosine
+/// miss (cos=0.964 on the final logits) but is BENIGN for actual
+/// inference — the **argmax token** still agrees between CPU and GPU,
+/// because the L47 divergence is concentrated on 2 of 8 experts whose
+/// weights are small relative to the top-1 token's vote.
+///
+/// Empirical evidence (lambda-vector RTX 4090, prompt `[785, 9217, 308]`,
+/// post-PR-2 #1737 fp64 q6k_gemv acc):
+///
+/// ```text
+/// cos_sim    = 0.963667 (FAILS 0.99 threshold)
+/// cpu_argmax = 944 (val = 13.7270)
+/// gpu_argmax = 944 (val = 14.4133)  ← SAME PREDICTED TOKEN
+/// ```
+///
+/// If this hypothesis holds across multiple canonical prompts, the L47
+/// expert-set divergence can be marked **KNOWN_LIMITATION_BENIGN** in
+/// `qwen3-moe-forward-gpu-v1` (next contract amendment v1.7.1 → v1.7.2)
+/// and the M-GPU-MOE-3 cascade can park L47, ship the 47/48-PASS state,
+/// and move to PR-4 throughput.
+///
+/// ## What this test asserts
+///
+/// For each of N canonical prompts:
+/// - Both CPU `forward_qwen3_moe` and GPU `forward_qwen3_moe_cuda`
+///   produce a `[vocab_size]` logit vector.
+/// - `argmax(cpu_logits) == argmax(gpu_logits)`.
+///
+/// If argmax agreement holds on all N prompts, prints the verdict
+/// "L47 cliff BENIGN — CPU and GPU agree on top-1 predicted token on
+/// all canonical prompts" and the cascade can park L47.
+///
+/// If argmax DISAGREES on any prompt, prints which prompt and the
+/// divergent tokens. That would force re-opening Option C (fp64 in
+/// per-expert SwiGLU intermediates) as the L47 cliff would NOT be
+/// benign.
+///
+/// ## Probe semantics
+///
+/// This is a PROBE — it prints the verdict, does not hard-assert. The
+/// existing `falsify_qw3_moe_gpu_parity_001_cosine_vs_cpu` test still
+/// hard-asserts cos ≥ 0.99 (which will continue to fail until L47 is
+/// closed). The probe runs in parallel to give the actual user-impact
+/// answer.
+///
+/// ## How to run
+///
+/// ```
+/// cargo test --release --features cuda \
+///   -p aprender-serve --test qwen3_moe_gpu_parity \
+///   falsify_qw3_moe_gpu_argmax_agreement \
+///   -- --ignored --nocapture
+/// ```
+///
+/// Hardware: RTX 4090, sm_89. ~30s per prompt.
+#[test]
+#[ignore = "requires cached Qwen3-Coder-30B-A3B-Instruct-Q4_K_M GGUF + CUDA RTX 4090; ~30s per prompt × N prompts"]
+fn falsify_qw3_moe_gpu_argmax_agreement() {
+    let Some(gguf_path) = CANONICAL_QWEN3_CODER_GGUF_PATHS
+        .iter()
+        .find(|p| Path::new(p).exists())
+    else {
+        eprintln!(
+            "FALSIFY-QW3-MOE-GPU-ARGMAX-AGREEMENT: skipped — no cached Qwen3-Coder GGUF in {CANONICAL_QWEN3_CODER_GGUF_PATHS:?}"
+        );
+        return;
+    };
+
+    // Canonical prompts span code/text/multilingual to surface any
+    // prompt-dependent L47-divergence-→-argmax-flip cases. If argmax
+    // agrees on all of these, L47 is benign with high confidence.
+    let canonical_prompts: &[(&str, &[u32])] = &[
+        ("canonical_3tok", &[785, 9217, 308]),       // existing test prompt
+        ("single_tok_785", &[785]),                  // PR-3 per-layer prompt
+        ("multi_tok_short", &[785, 374, 264, 6716]), // 4-token English
+        ("multi_tok_code", &[750, 220, 17, 220, 488, 220, 17, 30]), // "def 2 + 2?"
+    ];
+
+    eprintln!("FALSIFY-QW3-MOE-GPU-ARGMAX-AGREEMENT: testing argmax agreement across {} prompts", canonical_prompts.len());
+    eprintln!("  gguf: {gguf_path}");
+
+    let mapped = MappedGGUFModel::from_path(gguf_path).expect("mmap GGUF");
+    let data = mapped.data();
+
+    let mut moe_layers = Vec::with_capacity(EXPECTED_NUM_LAYERS);
+    for layer_idx in 0..EXPECTED_NUM_LAYERS {
+        moe_layers.push(
+            load_qwen3_moe_layer(&mapped.model, data, layer_idx)
+                .unwrap_or_else(|e| panic!("layer {layer_idx} MoE load failed: {e:?}")),
+        );
+    }
+
+    // Build models once; reuse across prompts.
+    let cpu_model =
+        OwnedQuantizedModel::from_mapped(&mapped).expect("OwnedQuantizedModel::from_mapped #1");
+    let gpu_inner =
+        OwnedQuantizedModel::from_mapped(&mapped).expect("OwnedQuantizedModel::from_mapped #2");
+    let mut gpu_model = OwnedQuantizedModelCuda::new(gpu_inner, 0)
+        .expect("OwnedQuantizedModelCuda::new(model, 0) must succeed on RTX 4090");
+
+    let mut results: Vec<(String, u32, u32, f32, f32)> = Vec::new();
+    let mut disagreements: Vec<(String, u32, u32)> = Vec::new();
+
+    for (name, tokens) in canonical_prompts {
+        eprintln!("FALSIFY-QW3-MOE-GPU-ARGMAX-AGREEMENT: {name} (len={})", tokens.len());
+        let cpu_logits = cpu_model
+            .forward_qwen3_moe(
+                tokens,
+                &moe_layers,
+                EXPECTED_N_EXPERTS,
+                EXPECTED_K,
+                EXPECTED_INTERMEDIATE,
+                data,
+            )
+            .expect("CPU forward must succeed");
+        let gpu_logits = gpu_model
+            .forward_qwen3_moe_cuda(
+                tokens,
+                &moe_layers,
+                EXPECTED_N_EXPERTS,
+                EXPECTED_K,
+                EXPECTED_INTERMEDIATE,
+                data,
+            )
+            .expect("GPU forward must succeed");
+
+        let (cpu_argmax_idx, &cpu_max_val) = cpu_logits
+            .iter()
+            .enumerate()
+            .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
+            .expect("CPU logits non-empty");
+        let (gpu_argmax_idx, &gpu_max_val) = gpu_logits
+            .iter()
+            .enumerate()
+            .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
+            .expect("GPU logits non-empty");
+        let cpu_argmax = cpu_argmax_idx as u32;
+        let gpu_argmax = gpu_argmax_idx as u32;
+
+        results.push((
+            (*name).to_string(),
+            cpu_argmax,
+            gpu_argmax,
+            cpu_max_val,
+            gpu_max_val,
+        ));
+        if cpu_argmax != gpu_argmax {
+            disagreements.push(((*name).to_string(), cpu_argmax, gpu_argmax));
+        }
+    }
+
+    eprintln!("FALSIFY-QW3-MOE-GPU-ARGMAX-AGREEMENT: per-prompt argmax:");
+    eprintln!("  PROMPT             | CPU argmax (val)     | GPU argmax (val)");
+    for (name, cpu_arg, gpu_arg, cpu_val, gpu_val) in &results {
+        let mark = if cpu_arg == gpu_arg { "✓" } else { "✗ MISMATCH" };
+        eprintln!(
+            "  {name:18} | {cpu_arg:6} ({cpu_val:8.4})  | {gpu_arg:6} ({gpu_val:8.4})  {mark}"
+        );
+    }
+
+    if disagreements.is_empty() {
+        eprintln!(
+            "FALSIFY-QW3-MOE-GPU-ARGMAX-AGREEMENT: VERDICT — L47 cliff is BENIGN on {} canonical prompts. CPU and GPU predict the SAME top-1 token despite the L47 expert-set divergence.",
+            canonical_prompts.len()
+        );
+        eprintln!(
+            "  → safe to mark L47 KNOWN_LIMITATION_BENIGN in qwen3-moe-forward-gpu-v1 (next contract amendment v1.7.1 → v1.7.2)."
+        );
+    } else {
+        eprintln!(
+            "FALSIFY-QW3-MOE-GPU-ARGMAX-AGREEMENT: VERDICT — L47 cliff is NOT BENIGN. argmax disagrees on {} of {} prompts:",
+            disagreements.len(),
+            canonical_prompts.len()
+        );
+        for (name, cpu_arg, gpu_arg) in &disagreements {
+            eprintln!("    {name}: cpu={cpu_arg} gpu={gpu_arg}");
+        }
+        eprintln!(
+            "  → Option C (fp64 in per-expert SwiGLU) must be authored as PR-3h."
+        );
+    }
+
+    // This is a PROBE — print the verdict but do not assert. The
+    // verdict drives the next contract amendment (KNOWN_LIMITATION_BENIGN
+    // marking) or the next code PR (PR-3h Option C).
+}
+
 #[test]
 fn cosine_similarity_unit_vectors() {
     let a = vec![1.0_f32, 0.0, 0.0];


### PR DESCRIPTION
## Summary

PR-3g of the **#1583 M-GPU-MOE-3** cascade. Adds the canonical \"is L47 actually user-visible\" falsifier — runs 4 canonical prompts through both CPU and GPU full forwards, prints the argmax agreement table + verdict.

## Hardware result (lambda-vector RTX 4090, 2026-05-17)

```
PROMPT             | CPU argmax (val)     | GPU argmax (val)
canonical_3tok     |    944 ( 13.7270)  |    944 ( 14.4133)  ✓
single_tok_785     |    220 ( 15.5523)  |     25 ( 18.5098)  ✗ MISMATCH
multi_tok_short    |    315 ( 26.2279)  |    315 ( 25.5230)  ✓
multi_tok_code     |    198 ( 17.7453)  |    198 ( 17.8433)  ✓
```

**3/4 prompts agree, 1 disagrees.** L47 cliff is **NOT benign** — the expert-set divergence DOES flip the top-1 predicted token for some prompts (~25% in this small sample). Option E (Accept) is off the table; must pursue Option C (fp64 in per-expert SwiGLU intermediates).

## Cascade falsifier sequence

The full cascade is now:

| PR | Result | Why this fix didn't close L47 |
|---|---|---|
| PR-2 #1737 | ✅ closed 47/48 layers | fp64 q6k_gemv acc was necessary but not sufficient |
| PR-3d | H(i) FALSIFIED | qtypes are identical L0/L46/L47 |
| PR-3e2 #1743 | H(ii) CONFIRMED | 2 of 8 experts swap at L47 |
| PR-3f1 | FALSIFIED | drift is upstream of softmax |
| PR-3f2 | FALSIFIED | drift is upstream of weighted-sum |
| **PR-3g (this)** | **L47 NOT BENIGN** | argmax flips on 1/4 prompts |
| PR-3h (next) | pending | Option C: fp64 in per-expert SwiGLU |

By elimination, the drift source must be **inside each per-expert SwiGLU's intermediate chain**: `silu(gate) × up` at f32 + the hidden-dim×4 intermediate state at f32 (the down-proj q6k_gemv acc is already fp64 thanks to PR-2).

## What this PR adds

`crates/aprender-serve/tests/qwen3_moe_gpu_parity.rs`:
- new test `falsify_qw3_moe_gpu_argmax_agreement` — multi-prompt PROBE that builds CPU + GPU models once, runs 4 canonical prompts, prints agreement table + verdict (BENIGN / NOT BENIGN + diff). Same `#[ignore]` + `#[cfg(feature = \"cuda\")]` gates as siblings.

## Test plan

- [x] Compiles with `--features cuda`
- [x] Runs on RTX 4090 in 24.45s
- [x] Verdict line classifies BENIGN / NOT BENIGN
- [x] Prints disagreement details so PR-3h knows which prompts to test against
- [x] PROBE not hard-fail (no assertion)

## Reproduction

```bash
cargo test --release --features cuda \
  -p aprender-serve --test qwen3_moe_gpu_parity \
  falsify_qw3_moe_gpu_argmax_agreement \
  -- --ignored --nocapture
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)