### PR TITLE
feat(apr-inspect): surface hf_architecture + hf_model_type (PMAT-690 P0-K follow-up)

### DIFF
--- a/crates/apr-cli/src/commands/construction.rs
+++ b/crates/apr-cli/src/commands/construction.rs
@@ -412,6 +412,8 @@
             original_format: Some("safetensors".to_string()),
             created_at: Some("2024-01-01".to_string()),
             architecture: Some("qwen2".to_string()),
+            hf_architecture: Some("Qwen2ForCausalLM".to_string()),
+            hf_model_type: Some("qwen2".to_string()),
             param_count: Some(494_000_000),
             hidden_size: Some(896),
             num_layers: Some(24),

--- a/crates/apr-cli/src/commands/inspect.rs
+++ b/crates/apr-cli/src/commands/inspect.rs
@@ -78,6 +78,17 @@ struct MetadataInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     created_at: Option<String>,
     architecture: Option<String>,
+    // PMAT-690 P0-K: surface the HF identity fields stamped at import
+    // time so operators can verify upstream propagation (apr convert
+    // → apr pretrain --init → apr export). Distinct from `architecture`
+    // (lowercase family) — `hf_architecture` is the canonical class
+    // name like "Qwen2ForCausalLM"; `hf_model_type` mirrors
+    // `config.json::model_type`. Per C-APR-INSPECT-METADATA-PROPAGATION
+    // and C-APR-CONVERT-HF-ARCH the two fields render as null when
+    // absent (NOT silently skipped via skip_serializing_if) so the
+    // auditor can grep for them in any apr inspect --json output.
+    hf_architecture: Option<String>,
+    hf_model_type: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     param_count: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -524,6 +535,12 @@ fn read_metadata(reader: &mut BufReader<File>, header: &HeaderData) -> MetadataI
                     .architecture
                     .filter(|a| !a.is_empty())
                     .or_else(|| Some("unknown".to_string())),
+                // PMAT-690 P0-K: copy unconditionally (even if None) so
+                // operators can grep `apr inspect --json | jq .hf_architecture`
+                // and distinguish "stamped" from "missing" rather than
+                // having the key silently skipped.
+                hf_architecture: meta.hf_architecture.filter(|a| !a.is_empty()),
+                hf_model_type: meta.hf_model_type.filter(|a| !a.is_empty()),
                 param_count: if meta.param_count > 0 {
                     Some(meta.param_count)
                 } else {

--- a/crates/apr-cli/src/commands/inspect_output_json.rs
+++ b/crates/apr-cli/src/commands/inspect_output_json.rs
@@ -142,6 +142,20 @@ fn output_architecture(metadata: &MetadataInfo) {
     if let Some(arch) = &metadata.architecture {
         println!("    Family: {arch}");
     }
+    // PMAT-690 P0-K: surface the HF identity fields so operators can
+    // verify upstream `apr convert` stamping without `--json | jq`.
+    // Distinct from `Family`: `HF Class` is the canonical class name
+    // (e.g. "Qwen2ForCausalLM"); `HF model_type` mirrors
+    // `config.json::model_type`. Per C-APR-CONVERT-HF-ARCH and the
+    // §84 P0-K root-cause analysis, missing fields here mean the
+    // import skipped stamping — operators can route the failure
+    // back to `apr convert` rather than chasing downstream symptoms.
+    if let Some(hf) = &metadata.hf_architecture {
+        println!("    HF Class: {hf}");
+    }
+    if let Some(mt) = &metadata.hf_model_type {
+        println!("    HF model_type: {mt}");
+    }
     if let Some(p) = metadata.param_count {
         println!("    Parameters: {}", format_param_count(p));
     }

--- a/crates/apr-cli/src/commands/inspect_tests.rs
+++ b/crates/apr-cli/src/commands/inspect_tests.rs
@@ -201,4 +201,72 @@ mod inspect_tests {
             "populated provenance must not render `(missing)`; got:\n{rendered}"
         );
     }
+
+    // ========================================================================
+    // PMAT-690 P0-K — apr inspect surfaces hf_architecture + hf_model_type
+    // ========================================================================
+
+    /// PMAT-690 P0-K: `apr inspect --json` MUST emit `hf_architecture` and
+    /// `hf_model_type` keys (null when None). Operators query
+    /// `apr inspect --json | jq .metadata.hf_architecture` to verify that
+    /// the upstream `apr convert` stamping worked. Silently skipping the
+    /// keys hides the upstream-producer defect that this contract was
+    /// authored to prevent (see memory/feedback_upstream_metadata_masquerade.md).
+    #[test]
+    fn pmat_690_p0k_inspect_emits_hf_arch_keys_when_none() {
+        let meta = MetadataInfo::default();
+        let json = serde_json::to_string(&meta).expect("serialize MetadataInfo");
+        let parsed: serde_json::Value = serde_json::from_str(&json).expect("parse JSON");
+        let obj = parsed.as_object().expect("JSON object at top level");
+
+        // Both keys MUST be present and null (not skipped via
+        // skip_serializing_if). The contract on apr inspect is that an
+        // operator can grep for `"hf_architecture"` in any output and
+        // distinguish "stamped" from "missing".
+        for key in ["hf_architecture", "hf_model_type"] {
+            assert!(
+                obj.contains_key(key),
+                "MetadataInfo JSON must emit key `{key}` even when None \
+                 (no skip_serializing_if). Auditing the import→pretrain→export \
+                 chain requires both keys to be grep-checkable."
+            );
+            assert!(
+                obj[key].is_null(),
+                "key `{key}` must serialize as null when None, got {:?}",
+                obj[key]
+            );
+        }
+    }
+
+    /// PMAT-690 P0-K: when hf_architecture / hf_model_type are populated,
+    /// `apr inspect --json` renders the actual values (not null, not the
+    /// architecture-family-lowercase string).
+    #[test]
+    fn pmat_690_p0k_inspect_emits_hf_arch_values_when_populated() {
+        let meta = MetadataInfo {
+            architecture: Some("qwen2".to_string()),
+            hf_architecture: Some("Qwen2ForCausalLM".to_string()),
+            hf_model_type: Some("qwen2".to_string()),
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&meta).expect("serialize MetadataInfo");
+        let parsed: serde_json::Value = serde_json::from_str(&json).expect("parse JSON");
+        let obj = parsed.as_object().expect("JSON object");
+
+        assert_eq!(
+            obj.get("architecture").and_then(|v| v.as_str()),
+            Some("qwen2"),
+            "architecture (family) must render unchanged"
+        );
+        assert_eq!(
+            obj.get("hf_architecture").and_then(|v| v.as_str()),
+            Some("Qwen2ForCausalLM"),
+            "hf_architecture (HF class name) must render the canonical string"
+        );
+        assert_eq!(
+            obj.get("hf_model_type").and_then(|v| v.as_str()),
+            Some("qwen2"),
+            "hf_model_type must render the config.json::model_type value"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

`apr inspect` now renders the HF identity fields that PMAT-690 P0-K stamps into `AprV2Metadata`. Operators can verify upstream `apr convert` stamping via `apr inspect --json | jq .metadata.hf_architecture` and `.metadata.hf_model_type` instead of grepping source code.

This closes the operator-visibility gap left by [#1742](https://github.com/paiml/aprender/pull/1742): the stamping happens, but until this PR there was no CLI surface to verify it.

## Stacked on #1742

This branch is based on `feat/pmat-690-p0k-apr-convert-hf-arch-v2` (the P0-K branch) because it depends on the `AprV2Metadata.hf_architecture` / `.hf_model_type` fields that #1742 adds. Will rebase to `main` after #1742 lands (or you can merge them in order — this PR is small and isolated).

## What changes

- **`MetadataInfo`** (`crates/apr-cli/src/commands/inspect.rs`): adds `hf_architecture` + `hf_model_type` fields. Both serialize as null when None (NOT skipped via `skip_serializing_if`), mirroring the C-APR-PROVENANCE pattern so auditors can grep-check every output.
- **`read_metadata`**: copies the two fields from `AprV2Metadata` into `MetadataInfo`.
- **`output_architecture`** (text path): renders new "HF Class" and "HF model_type" rows beneath the existing "Family" row when populated.

## Test plan

- [x] `cargo test -p apr-cli --features training --lib pmat_690_p0k` — 2/2 pass:
  - `pmat_690_p0k_inspect_emits_hf_arch_keys_when_none` — both keys serialize as null (not skipped) when absent. Required for the grep-check audit recipe.
  - `pmat_690_p0k_inspect_emits_hf_arch_values_when_populated` — when populated, keys render `Qwen2ForCausalLM` / `qwen2`.
- [x] `cargo test -p apr-cli --features training --lib` — 5,938 tests pass, 0 regressions.
- [x] `cargo check -p apr-cli --features training` — clean.

## Refs

- PR [#1742](https://github.com/paiml/aprender/pull/1742) (PMAT-690 P0-K — the upstream stamping)
- `contracts/apr-convert-hf-arch-v1.yaml` (round-trip invariant)
- `docs/specifications/aprender-train/ship-model-2-spec.md §84`
- `memory/feedback_upstream_metadata_masquerade.md` (methodology #33)

🤖 Generated with [Claude Code](https://claude.com/claude-code)