### PR TITLE
feat(apr-cli): bench MoE dispatch — routes Qwen3-MoE GGUFs through forward_qwen3_moe (#1749)

### DIFF
--- a/crates/apr-cli/src/commands/bench.rs
+++ b/crates/apr-cli/src/commands/bench.rs
@@ -696,4 +696,5 @@ fn print_header(path: &Path, config: &BenchConfig) {
 
 include!("benchmark.rs");
 include!("bench_safetensors.rs");
+include!("bench_moe.rs");
 include!("bench_04.rs");

--- a/crates/apr-cli/src/commands/bench_moe.rs
+++ b/crates/apr-cli/src/commands/bench_moe.rs
@@ -1,0 +1,282 @@
+/// MoE GGUF benchmark — bridges `apr bench` to the Qwen3-MoE forward path.
+///
+/// Closes #1749. Pre-fix, `apr bench` against any MoE GGUF (Qwen3-Coder-30B-
+/// A3B-Instruct, etc.) routes through the dense `forward_single_with_cache`
+/// path which calls `matmul_fused.rs:211` on tensor names that don't exist on
+/// MoE models, panicking with `index out of bounds: len=0 but index ≈ 91M`.
+///
+/// This module detects MoE via `gguf.expert_count().is_some()` and routes to
+/// `forward_qwen3_moe` (CPU) or `forward_qwen3_moe_cuda` (GPU), running them
+/// autoregressively (re-running prefill each step) to get a tok/s number.
+///
+/// # Why autoregressive re-prefill
+///
+/// The existing `forward_qwen3_moe[_cuda]` helpers don't take a KV cache —
+/// they run a full forward over `token_ids` each call. For an N-token bench
+/// run, the i-th iteration runs forward over `prompt + first (i-1)
+/// generated tokens`. This is O(N²) in N but for `--max-tokens 32` that's
+/// 32 forwards over a ≤ (prompt_len + 32) sequence — bounded.
+///
+/// True KV-cache MoE decoding is a separate concern (M-GPU-MOE-3 PR-4
+/// throughput cascade); this bench produces a usable upper-bound tok/s
+/// number without requiring that work.
+
+#[cfg(feature = "inference")]
+fn is_moe_gguf(gguf: &realizar::gguf::GGUFModel) -> bool {
+    gguf.expert_count().unwrap_or(0) > 0
+}
+
+/// MoE GGUF benchmark entry point. Called from `run_gguf_benchmark` after
+/// MoE detection. Loads the model + per-layer MoE tensor descriptors once,
+/// then runs warmup + iterations through the appropriate forward path.
+#[cfg(feature = "inference")]
+fn run_gguf_moe_benchmark(
+    path: &Path,
+    config: &BenchConfig,
+    use_cuda: bool,
+    prompt_tokens: &[u32],
+    _tracer: &TracerImpl,
+) -> Result<BenchResult> {
+    use realizar::gguf::qwen3_moe_load::load_qwen3_moe_layer;
+    use realizar::gguf::{MappedGGUFModel, OwnedQuantizedModel};
+
+    if !config.quiet {
+        eprintln!("{}", "Loading MoE GGUF model...".yellow());
+    }
+    let start = Instant::now();
+
+    let mapped = MappedGGUFModel::from_path(path)
+        .map_err(|e| CliError::ValidationFailed(format!("Failed to mmap MoE model: {e}")))?;
+
+    let model = OwnedQuantizedModel::from_mapped(&mapped)
+        .map_err(|e| CliError::ValidationFailed(format!("Failed to create MoE model: {e}")))?;
+
+    // Read MoE config from GGUF metadata. expert_count() must be Some
+    // (caller already gated on is_moe_gguf), but use unwrap_or with a panic-
+    // safe default to satisfy clippy::disallowed_methods.
+    let num_experts = mapped.model.expert_count().ok_or_else(|| {
+        CliError::ValidationFailed("MoE bench routed but expert_count() returned None".to_string())
+    })?;
+    let num_experts_per_tok = mapped.model.expert_used_count().ok_or_else(|| {
+        CliError::ValidationFailed(
+            "MoE bench: expert_used_count() returned None on a MoE GGUF".to_string(),
+        )
+    })?;
+    let moe_intermediate = mapped.model.expert_feed_forward_length().ok_or_else(|| {
+        CliError::ValidationFailed(
+            "MoE bench: expert_feed_forward_length() returned None on a MoE GGUF".to_string(),
+        )
+    })?;
+
+    let num_layers = model.layers().len();
+    let mut moe_layers = Vec::with_capacity(num_layers);
+    let data = mapped.data();
+    for layer_idx in 0..num_layers {
+        let layer = load_qwen3_moe_layer(&mapped.model, data, layer_idx).map_err(|e| {
+            CliError::ValidationFailed(format!("Failed to load MoE layer {layer_idx}: {e}"))
+        })?;
+        moe_layers.push(layer);
+    }
+
+    let load_time = start.elapsed();
+    if !config.quiet {
+        eprintln!(
+            "{} in {:.2}s ({} layers, {} experts × top-{})",
+            "MoE model ready".green(),
+            load_time.as_secs_f32(),
+            num_layers,
+            num_experts,
+            num_experts_per_tok
+        );
+        eprintln!();
+    }
+
+    #[cfg(feature = "cuda")]
+    if use_cuda {
+        return run_cuda_moe_benchmark(
+            model,
+            moe_layers,
+            num_experts,
+            num_experts_per_tok,
+            moe_intermediate,
+            prompt_tokens,
+            config,
+            mapped.data().to_vec(),
+        );
+    }
+    #[cfg(not(feature = "cuda"))]
+    let _ = use_cuda;
+
+    run_cpu_moe_benchmark(
+        model,
+        moe_layers,
+        num_experts,
+        num_experts_per_tok,
+        moe_intermediate,
+        prompt_tokens,
+        config,
+        mapped.data().to_vec(),
+    )
+}
+
+/// CUDA MoE benchmark path. Runs `forward_qwen3_moe_cuda` autoregressively.
+#[cfg(all(feature = "inference", feature = "cuda"))]
+#[allow(clippy::too_many_arguments)]
+fn run_cuda_moe_benchmark(
+    model: realizar::gguf::OwnedQuantizedModel,
+    moe_layers: Vec<realizar::gguf::qwen3_moe_load::Qwen3MoeQuantizedLayer>,
+    num_experts: usize,
+    num_experts_per_tok: usize,
+    moe_intermediate: usize,
+    prompt_tokens: &[u32],
+    config: &BenchConfig,
+    data: Vec<u8>,
+) -> Result<BenchResult> {
+    use realizar::gguf::OwnedQuantizedModelCuda;
+
+    let mut cuda_model = OwnedQuantizedModelCuda::new(model, 0)
+        .map_err(|e| CliError::ValidationFailed(format!("MoE CUDA init failed: {e}")))?;
+
+    bench_log(config, &"Running warmup (CUDA MoE)...".yellow().to_string());
+    for i in 0..config.warmup {
+        let warmup_start = Instant::now();
+        let _ = cuda_model
+            .forward_qwen3_moe_cuda(
+                prompt_tokens,
+                &moe_layers,
+                num_experts,
+                num_experts_per_tok,
+                moe_intermediate,
+                &data,
+            )
+            .map_err(|e| CliError::ValidationFailed(format!("MoE warmup forward failed: {e}")))?;
+        bench_log_iter(config, i, warmup_start.elapsed(), Some(1));
+    }
+    bench_log_done(config);
+
+    bench_log(
+        config,
+        &"Running measurement (CUDA MoE, autoregressive)..."
+            .yellow()
+            .to_string(),
+    );
+    let mut iteration_times = Vec::with_capacity(config.iterations);
+    let mut total_tokens = 0usize;
+    let mut first_token_time = Duration::ZERO;
+    let mut tokens = prompt_tokens.to_vec();
+
+    for i in 0..config.iterations {
+        let iter_start = Instant::now();
+        let logits = cuda_model
+            .forward_qwen3_moe_cuda(
+                &tokens,
+                &moe_layers,
+                num_experts,
+                num_experts_per_tok,
+                moe_intermediate,
+                &data,
+            )
+            .map_err(|e| CliError::ValidationFailed(format!("MoE measure forward failed: {e}")))?;
+        let elapsed = iter_start.elapsed();
+        if i == 0 {
+            first_token_time = elapsed;
+        }
+        iteration_times.push(elapsed);
+        total_tokens += 1;
+
+        // Greedy decode: append argmax(logits) to drive autoregressive step
+        if let Some((argmax_idx, _)) = logits
+            .iter()
+            .enumerate()
+            .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
+        {
+            tokens.push(argmax_idx as u32);
+        }
+        bench_log_iter(config, i, elapsed, Some(1));
+
+        if total_tokens >= config.max_tokens {
+            break;
+        }
+    }
+    bench_log_done(config);
+
+    calculate_benchmark_stats(iteration_times, total_tokens, first_token_time, config)
+}
+
+/// CPU MoE benchmark path. Runs `forward_qwen3_moe` autoregressively.
+#[cfg(feature = "inference")]
+#[allow(clippy::too_many_arguments)]
+fn run_cpu_moe_benchmark(
+    model: realizar::gguf::OwnedQuantizedModel,
+    moe_layers: Vec<realizar::gguf::qwen3_moe_load::Qwen3MoeQuantizedLayer>,
+    num_experts: usize,
+    num_experts_per_tok: usize,
+    moe_intermediate: usize,
+    prompt_tokens: &[u32],
+    config: &BenchConfig,
+    data: Vec<u8>,
+) -> Result<BenchResult> {
+    bench_log(config, &"Running warmup (CPU MoE)...".yellow().to_string());
+    for i in 0..config.warmup {
+        let warmup_start = Instant::now();
+        let _ = model
+            .forward_qwen3_moe(
+                prompt_tokens,
+                &moe_layers,
+                num_experts,
+                num_experts_per_tok,
+                moe_intermediate,
+                &data,
+            )
+            .map_err(|e| CliError::ValidationFailed(format!("MoE CPU warmup failed: {e}")))?;
+        bench_log_iter(config, i, warmup_start.elapsed(), Some(1));
+    }
+    bench_log_done(config);
+
+    bench_log(
+        config,
+        &"Running measurement (CPU MoE, autoregressive)..."
+            .yellow()
+            .to_string(),
+    );
+    let mut iteration_times = Vec::with_capacity(config.iterations);
+    let mut total_tokens = 0usize;
+    let mut first_token_time = Duration::ZERO;
+    let mut tokens = prompt_tokens.to_vec();
+
+    for i in 0..config.iterations {
+        let iter_start = Instant::now();
+        let logits = model
+            .forward_qwen3_moe(
+                &tokens,
+                &moe_layers,
+                num_experts,
+                num_experts_per_tok,
+                moe_intermediate,
+                &data,
+            )
+            .map_err(|e| CliError::ValidationFailed(format!("MoE CPU measure failed: {e}")))?;
+        let elapsed = iter_start.elapsed();
+        if i == 0 {
+            first_token_time = elapsed;
+        }
+        iteration_times.push(elapsed);
+        total_tokens += 1;
+
+        if let Some((argmax_idx, _)) = logits
+            .iter()
+            .enumerate()
+            .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
+        {
+            tokens.push(argmax_idx as u32);
+        }
+        bench_log_iter(config, i, elapsed, Some(1));
+
+        if total_tokens >= config.max_tokens {
+            break;
+        }
+    }
+    bench_log_done(config);
+
+    calculate_benchmark_stats(iteration_times, total_tokens, first_token_time, config)
+}

--- a/crates/apr-cli/src/commands/benchmark.rs
+++ b/crates/apr-cli/src/commands/benchmark.rs
@@ -1,4 +1,3 @@
-
 /// Run warmup iterations with progress display.
 fn run_bench_warmup<F: FnMut()>(config: &BenchConfig, count: usize, mut f: F) {
     if !config.quiet {
@@ -176,6 +175,24 @@ fn run_gguf_benchmark(
         .encode(&config.prompt)
         .unwrap_or_else(|| vec![bos, 9707, 11, 358, 1079, 264, 11761, 18328, 13, 9842]);
 
+    // #1749: MoE dispatch — Qwen3-Coder-30B-A3B + other MoE GGUFs have
+    // 3D `*_exps` tensors and no 2D dense FFN tensors. The dense
+    // `forward_single_with_cache` path used by `generate_with_cache`
+    // panics in `matmul_fused.rs:211` on these. Route MoE models to the
+    // MoE-aware bench helpers in `bench_moe.rs` which call
+    // `forward_qwen3_moe[_cuda]` autoregressively.
+    if is_moe_gguf(&gguf) {
+        if !config.quiet {
+            eprintln!(
+                "{} MoE detected (expert_count={}, top-k={}) — routing through forward_qwen3_moe",
+                "Bench mode:".cyan().bold(),
+                gguf.expert_count().unwrap_or(0),
+                gguf.expert_used_count().unwrap_or(0)
+            );
+        }
+        return run_gguf_moe_benchmark(path, config, use_cuda, &prompt_tokens, tracer);
+    }
+
     let gen_config = QuantizedGenerateConfig {
         max_tokens: config.max_tokens.min(128),
         temperature: 0.0,
@@ -205,7 +222,14 @@ fn run_gguf_benchmark(
                     );
                 }
                 let cpu_start = Instant::now();
-                return run_cpu_benchmark(&prompt_tokens, &gen_config, config, cpu_start, path, tracer);
+                return run_cpu_benchmark(
+                    &prompt_tokens,
+                    &gen_config,
+                    config,
+                    cpu_start,
+                    path,
+                    tracer,
+                );
             }
         }
     }
@@ -324,7 +348,7 @@ fn run_apr_benchmark(
         top_k: 0,
         repetition_penalty: 1.0,
         trace: false,
-    stop_tokens: vec![],
+        stop_tokens: vec![],
     };
 
     // Warmup (untraced)
@@ -367,7 +391,8 @@ fn run_apr_measurement(
                 if generate_errors == 0 {
                     eprintln!(
                         "{}",
-                        format!("Warning: generate_with_cache() failed on iteration {i}: {e}").yellow()
+                        format!("Warning: generate_with_cache() failed on iteration {i}: {e}")
+                            .yellow()
                     );
                 }
                 generate_errors += 1;
@@ -393,7 +418,11 @@ fn run_apr_measurement(
     }
 
     total_tokens = handle_zero_generation_fallback(
-        generation_failed, total_tokens, config.iterations, prompt_tokens.len(), config.quiet,
+        generation_failed,
+        total_tokens,
+        config.iterations,
+        prompt_tokens.len(),
+        config.quiet,
     );
     if !config.quiet {
         eprintln!();
@@ -418,7 +447,10 @@ fn run_apr_cuda_benchmark(
     use realizar::gguf::{OwnedQuantizedModel, OwnedQuantizedModelCuda, QuantizedGenerateConfig};
 
     if !config.quiet {
-        eprintln!("{}", "Loading APR model (GPU, fused Q4K kernels)...".yellow());
+        eprintln!(
+            "{}",
+            "Loading APR model (GPU, fused Q4K kernels)...".yellow()
+        );
     }
     let start = Instant::now();
 
@@ -430,8 +462,9 @@ fn run_apr_cuda_benchmark(
 
     // Use embedded tokenizer if available, else fall back to sibling/default
     let prompt_tokens: Vec<u32> = {
-        let cpu_model = AprV2Model::load(path)
-            .map_err(|e| CliError::ValidationFailed(format!("Failed to load APR for tokenizer: {e}")))?;
+        let cpu_model = AprV2Model::load(path).map_err(|e| {
+            CliError::ValidationFailed(format!("Failed to load APR for tokenizer: {e}"))
+        })?;
         if let Some(tokenizer) = cpu_model.load_embedded_bpe_tokenizer() {
             tokenizer.encode(&config.prompt)
         } else {
@@ -439,8 +472,9 @@ fn run_apr_cuda_benchmark(
         }
     };
 
-    let model = OwnedQuantizedModel::from_apr(&mapped)
-        .map_err(|e| CliError::ValidationFailed(format!("Failed to create quantized model from APR: {e}")))?;
+    let model = OwnedQuantizedModel::from_apr(&mapped).map_err(|e| {
+        CliError::ValidationFailed(format!("Failed to create quantized model from APR: {e}"))
+    })?;
 
     let mut cuda_model = OwnedQuantizedModelCuda::new(model, 0)
         .map_err(|e| CliError::ValidationFailed(format!("Failed to init CUDA: {e}")))?;


### PR DESCRIPTION
## Summary

Closes #1749. `apr bench` against any MoE GGUF (Qwen3-Coder-30B-A3B-Instruct etc.) used to panic in `matmul_fused.rs:211` (`index out of bounds: len=0 but index ≈ 91M`) because the dense `forward_single_with_cache` path looks up 2D `ffn_{gate,up,down}.weight` tensors that don't exist on MoE models (which have 3D `*_exps` instead).

This PR detects MoE via `gguf.expert_count().is_some()` and routes to `forward_qwen3_moe` (CPU) / `forward_qwen3_moe_cuda` (GPU), running them autoregressively. Unblocks M-GPU-MOE-3 PR-4 throughput measurement.

## Empirical (lambda-vector RTX 4090, 2026-05-17)

```bash
apr bench /home/noah/models/Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf \
  --max-tokens 8 --warmup 1 --iterations 4 --json
```

```json
{
  "total_tokens": 4,
  "total_time_ms": 87085,
  "mean_time_ms": 21771,
  "time_to_first_token_ms": 22839,
  "latency_p50_ms": 22216,
  "latency_p99_ms": 32470
}
```

**0.046 tok/s effective** — autoregressive re-prefill cost (no KV cache yet). PR-4's job is to push this to ≥150 tok/s by adding the cache.

## What's in this PR

- `crates/apr-cli/src/commands/bench_moe.rs` (new): `is_moe_gguf` predicate + `run_gguf_moe_benchmark` + CUDA/CPU autoregressive bench helpers using greedy argmax decode.
- `crates/apr-cli/src/commands/bench.rs`: new `include!(\"bench_moe.rs\")` (same pattern as the existing bench sub-files).
- `crates/apr-cli/src/commands/benchmark.rs`: MoE detection in `run_gguf_benchmark` + tail-call to `run_gguf_moe_benchmark`.

## What's NOT in this PR

- True KV-cache MoE decoding (= M-GPU-MOE-3 PR-4 throughput target proper)
- MoE bench for SafeTensors / APR formats (only GGUF MoE today)

## Test plan

- [x] `cargo build -p apr-cli --features 'inference cuda'` clean
- [x] `apr bench Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf --json` exits cleanly with valid JSON (instead of panicking)
- [x] Dense GGUF bench path unchanged (route only flips on `expert_count > 0`)

## Cross-refs

- #1583 M-GPU-MOE-3 — PR-4 throughput unblocks on this
- #1747 contract v1.7.2 — L47 known-divergence + cascade pause

🤖 Generated with [Claude Code](https://claude.com/claude-code)