### PR TITLE
fix(orchestrate): #1781 apr serve startup-ready timeout — configurable + size-aware

### DIFF
--- a/crates/aprender-orchestrate/src/agent/driver/apr_serve.rs
+++ b/crates/aprender-orchestrate/src/agent/driver/apr_serve.rs
@@ -30,6 +30,9 @@ pub struct AprServeDriver {
     _child: Child,
     /// Context window size
     context_window_size: usize,
+    /// Model file size in bytes (used to scale the startup-ready timeout
+    /// for large MoE GGUFs). `None` if stat failed at launch time.
+    model_size_bytes: Option<u64>,
 }
 
 impl Drop for AprServeDriver {
@@ -117,11 +120,14 @@ impl AprServeDriver {
 
         eprintln!("Launched apr serve on port {port} (pid {})", child.id());
 
+        let model_size_bytes = std::fs::metadata(&model_path).ok().map(|m| m.len());
+
         let mut driver = Self {
             base_url,
             model_name,
             _child: child,
             context_window_size: context_window.unwrap_or(4096),
+            model_size_bytes,
         };
 
         // Wait for server to be ready
@@ -130,22 +136,35 @@ impl AprServeDriver {
         Ok(driver)
     }
 
-    /// Poll health endpoint until server is ready (max 30s).
+    /// Poll health endpoint until server is ready.
+    ///
+    /// Default budget is 30 seconds — fine for small models that mmap and
+    /// validate in <5s. Large MoE GGUFs (e.g., Qwen3-Coder-30B at 18.5 GB)
+    /// can exceed 30s on cold-cache loads, so the budget is overridable
+    /// via `APR_SERVE_READY_TIMEOUT_S` (an integer count of seconds).
+    /// The default also auto-scales by model file size when the model
+    /// is known: +1 second per 500 MB above 2 GB (e.g., an 18 GB model
+    /// gets ~62s budget; a 1 GB model gets the 30s baseline).
     ///
     /// PMAT-171: Detects subprocess death during startup. On timeout or crash,
     /// reads stderr from the child process for actionable debug output.
+    ///
+    /// PR #1781: Configurable timeout + size-aware default.
     fn wait_for_ready(&mut self) -> Result<(), AgentError> {
         let addr = self.base_url.trim_start_matches("http://").to_string();
         let sock_addr: std::net::SocketAddr =
             addr.parse().unwrap_or_else(|_| std::net::SocketAddr::from(([127, 0, 0, 1], 19384)));
 
+        let timeout_secs = self.resolve_ready_timeout_secs();
         let start = std::time::Instant::now();
-        let timeout = std::time::Duration::from_secs(30);
+        let timeout = std::time::Duration::from_secs(timeout_secs);
 
         loop {
             if start.elapsed() > timeout {
                 let stderr = self.drain_stderr();
-                let mut msg = "apr serve did not become ready within 30s".to_string();
+                let mut msg = format!(
+                    "apr serve did not become ready within {timeout_secs}s (override via APR_SERVE_READY_TIMEOUT_S)"
+                );
                 if !stderr.is_empty() {
                     msg.push_str(&format!("\nsubprocess stderr:\n{stderr}"));
                 }
@@ -178,6 +197,16 @@ impl AprServeDriver {
 
             std::thread::sleep(std::time::Duration::from_millis(500));
         }
+    }
+
+    /// Resolve the startup-ready timeout in seconds.
+    ///
+    /// Reads `APR_SERVE_READY_TIMEOUT_S` from the env (operator override)
+    /// and falls back to a size-aware default. See
+    /// [`compute_ready_timeout_secs`] for the resolution rules + unit tests.
+    fn resolve_ready_timeout_secs(&self) -> u64 {
+        let env_override = std::env::var("APR_SERVE_READY_TIMEOUT_S").ok();
+        compute_ready_timeout_secs(self.model_size_bytes, env_override.as_deref())
     }
 
     /// Read available stderr from the child process (non-blocking, last 2KB).
@@ -262,6 +291,46 @@ impl AprServeDriver {
             "stream": false
         })
     }
+}
+
+/// Compute the startup-ready timeout in seconds for `apr serve`.
+///
+/// Resolution order:
+/// 1. If `env_override` parses as a `u64`, use it verbatim (operator
+///    override; minimum 1s clamp via `.max(1)`).
+/// 2. Otherwise compute a size-aware default: 30s baseline + 1s per
+///    500 MB above 2 GB. A 1 GB model gets 30s; a 4 GB model gets ~34s;
+///    an 18 GB model gets ~62s; a 30 GB model gets ~86s.
+/// 3. If model size is unknown (stat failed at launch), fall back to
+///    30s baseline.
+///
+/// Always returns at least `MIN_TIMEOUT_S = 1` to avoid the pathological
+/// 0-second budget case.
+///
+/// Extracted as a free function so the resolution logic is unit-testable
+/// without spawning a subprocess. Called from
+/// [`AprServeDriver::resolve_ready_timeout_secs`] with the live env.
+#[must_use]
+pub fn compute_ready_timeout_secs(
+    model_size_bytes: Option<u64>,
+    env_override: Option<&str>,
+) -> u64 {
+    const MIN_TIMEOUT_S: u64 = 1;
+    const BASELINE_S: u64 = 30;
+    const SIZE_FREE_BYTES: u64 = 2 * 1024 * 1024 * 1024; // 2 GB
+    const BYTES_PER_EXTRA_SECOND: u64 = 500 * 1024 * 1024; // 500 MB
+
+    if let Some(raw) = env_override {
+        if let Ok(n) = raw.parse::<u64>() {
+            return n.max(MIN_TIMEOUT_S);
+        }
+    }
+    let Some(bytes) = model_size_bytes else {
+        return BASELINE_S;
+    };
+    let extra_bytes = bytes.saturating_sub(SIZE_FREE_BYTES);
+    let extra_secs = extra_bytes / BYTES_PER_EXTRA_SECOND;
+    BASELINE_S.saturating_add(extra_secs)
 }
 
 #[async_trait]

--- a/crates/aprender-orchestrate/src/agent/driver/apr_serve_tests.rs
+++ b/crates/aprender-orchestrate/src/agent/driver/apr_serve_tests.rs
@@ -253,3 +253,79 @@ fn falsify_http_001_strips_verbose_keeps_compact() {
     assert!(c.contains("## Tools"), "compact table preserved (PMAT-176)");
     assert!(!c.contains("## Available Tools"), "verbose section stripped");
 }
+
+// PR #1781 — `compute_ready_timeout_secs` tests.
+//
+// Fixes the hardcoded 30s startup-readiness timeout that blocked
+// large MoE GGUFs (e.g. Qwen3-Coder-30B at 18.5 GB) from ever
+// becoming ready in the SubprocessDriver. Resolver supports
+// `APR_SERVE_READY_TIMEOUT_S` env override + size-aware default
+// (30s baseline + 1s per 500 MB above 2 GB).
+
+use super::compute_ready_timeout_secs;
+
+#[test]
+fn ready_timeout_env_override_takes_precedence() {
+    // Env override beats size-aware default.
+    assert_eq!(compute_ready_timeout_secs(Some(50_000_000_000), Some("5")), 5);
+    assert_eq!(compute_ready_timeout_secs(None, Some("120")), 120);
+}
+
+#[test]
+fn ready_timeout_env_override_clamped_to_minimum() {
+    // 0 → clamped to 1 (avoid pathological zero-budget case).
+    assert_eq!(compute_ready_timeout_secs(None, Some("0")), 1);
+}
+
+#[test]
+fn ready_timeout_env_override_invalid_falls_through_to_default() {
+    // Non-integer → fall back to size-aware default.
+    assert_eq!(compute_ready_timeout_secs(None, Some("abc")), 30);
+    assert_eq!(compute_ready_timeout_secs(None, Some("")), 30);
+}
+
+#[test]
+fn ready_timeout_small_model_keeps_baseline() {
+    // 1 GB ≤ 2 GB free band → baseline 30s.
+    assert_eq!(compute_ready_timeout_secs(Some(1 * 1024 * 1024 * 1024), None), 30);
+    // 2 GB exactly → baseline.
+    assert_eq!(compute_ready_timeout_secs(Some(2 * 1024 * 1024 * 1024), None), 30);
+}
+
+#[test]
+fn ready_timeout_scales_with_model_size() {
+    // 4 GB: 2 GB above free band → 4 extra seconds (4 × 500 MB) → 34s.
+    assert_eq!(compute_ready_timeout_secs(Some(4 * 1024 * 1024 * 1024), None), 34);
+    // 18 GB (Qwen3-Coder-30B Q4_K_M): 16 GB above free band → 32 extra → 62s.
+    let qwen3_size = 18_u64 * 1024 * 1024 * 1024;
+    assert_eq!(compute_ready_timeout_secs(Some(qwen3_size), None), 62);
+    // 30 GB hypothetical: 28 GB above free band ÷ 500 MB per extra second
+    // = 57 extra (integer division of 28*1024 MB / 500 MB), → 87s total.
+    assert_eq!(compute_ready_timeout_secs(Some(30 * 1024 * 1024 * 1024), None), 87);
+}
+
+#[test]
+fn ready_timeout_unknown_size_falls_back_to_baseline() {
+    // model_size_bytes = None (stat failed) → 30s baseline.
+    assert_eq!(compute_ready_timeout_secs(None, None), 30);
+}
+
+#[test]
+fn ready_timeout_env_override_works_when_size_unknown() {
+    // Env override always wins, regardless of size knowledge.
+    assert_eq!(compute_ready_timeout_secs(None, Some("60")), 60);
+}
+
+#[test]
+fn ready_timeout_qwen3_coder_30b_real_size() {
+    // Real M260 measurement: Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf
+    // is 18,556,689,568 bytes. Size-aware default must exceed the 30s
+    // baseline that originally blocked the CCPA calibration bench.
+    let actual_bytes = 18_556_689_568_u64;
+    let secs = compute_ready_timeout_secs(Some(actual_bytes), None);
+    assert!(
+        secs >= 50,
+        "Qwen3-Coder-30B (18.5 GB) must get >= 50s budget; got {secs}s — fix paiml/claude-code-parity-apr M260"
+    );
+    assert!(secs <= 90, "Default scaling must not exceed reasonable max; got {secs}s");
+}


### PR DESCRIPTION
## Summary
Closes #1781. The hardcoded `Duration::from_secs(30)` in `AprServeDriver::wait_for_ready` blocked large MoE GGUFs (Qwen3-Coder-30B, 18.5 GB) from ever becoming ready — cold-cache load exceeds 30s; warm-cache is ~1s.

## Root cause (5-whys)
1. Why did large MoE startups fail? → `apr serve did not become ready within 30s`
2. Why? → Cold-cache load of 18.5 GB Qwen3-MoE GGUF exceeds 30s
3. Why the 30s? → Hardcoded `Duration::from_secs(30)` at `apr_serve.rs:143`
4. Why hardcoded? → No env-var or model-size scaling
5. Why? → Designed for sub-2GB models that load in <5s

## Fix
Two-axis: env override + size-aware default.

```rust
pub fn compute_ready_timeout_secs(
    model_size_bytes: Option<u64>,
    env_override: Option<&str>,
) -> u64 { ... }
```

**Resolution order**:
1. `APR_SERVE_READY_TIMEOUT_S=N` env var (operator escape hatch; clamped ≥1s)
2. Size-aware default: 30s baseline + 1s per 500 MB above 2 GB
3. Unknown size → 30s baseline

**Per-model budgets** under the size-aware default:
| Model size | Budget |
|---|---|
| 1 GB | 30s (unchanged) |
| 4 GB | 34s |
| 18 GB (Qwen3-Coder-30B) | 62s |
| 30 GB | 87s |

Error message updated:
> `apr serve did not become ready within Ns (override via APR_SERVE_READY_TIMEOUT_S)`

## Test plan
- [x] 8 new unit tests in `apr_serve_tests.rs` (env precedence, clamping, invalid fallback, baseline, scaling, unknown size, env-when-size-unknown, real Qwen3-Coder-30B 18.5 GB)
- [x] apr_serve module: 17 → 25 tests GREEN
- [x] `cargo check -p aprender-orchestrate` clean
- [x] `cargo clippy -p aprender-orchestrate --tests -- -D warnings` clean
- [x] `cargo fmt --check` clean

## Empirical evidence
- paiml/claude-code-parity-apr M260 dispatch produced 15/15 student-side `driver_error` with this timeout
- `time apr serve run Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf` against already-warm-cache model → ready in ~1s
- Companion-side pre-warm workaround at paiml/claude-code-parity-apr M262 (PR #239) — this PR obsoletes the workaround for hosts that set `APR_SERVE_READY_TIMEOUT_S`

## Doctrine
Toyota Way: fixed at root cause instead of accepting the 30s budget as a hard constraint.