### PR TITLE
docs(audit): AUDIT-Q4K-SHAPE-001 — shape-swap is benign on 256-divisible artifacts (PMAT-690 defect 4)

### DIFF
--- a/crates/aprender-core/src/format/converter/gguf_export_config.rs
+++ b/crates/aprender-core/src/format/converter/gguf_export_config.rs
@@ -738,6 +738,81 @@ mod q4k_divisibility_tests {
         );
         assert_eq!(bytes.len(), 2_451_456, "exact byte count for ffn_down");
     }
+
+    /// AUDIT-Q4K-SHAPE-001 — in-tree falsification of the pre-v0.34.0
+    /// shape-swap bug for the 256-divisible-on-both-dims case. See
+    /// `docs/specifications/audits/q4k-shape-swap-impact.md`.
+    ///
+    /// **Empirical finding**: when both `shape[0]` and `shape[1]` are
+    /// 256-divisible, `quantize_q4_k_matrix(data, [a, b])` and
+    /// `quantize_q4_k_matrix(data, [b, a])` produce **byte-identical**
+    /// output. Therefore Qwen2 1.5B (hidden=1536, intermediate=8960) and
+    /// Qwen2 7B (hidden=3584, intermediate=18944) Q4_K exports produced
+    /// before the v0.34.0 fix are **bit-equivalent to a post-fix re-export**
+    /// for the in-tree path — no re-export needed for correctness.
+    ///
+    /// **Why**: the function iterates `rows` times grabbing `cols`
+    /// contiguous elements per iteration, then quantizes that 1D slice as
+    /// fixed-size 256-element super-blocks via `quantize_q4_k`. When both
+    /// dims are 256-multiples, the data is consumed in the same linear
+    /// order with the same 256-aligned chunking either way — the "row"
+    /// boundary is invisible to the quantizer because it sits on a
+    /// super-block boundary.
+    ///
+    /// **The shape-swap bug bites only when `cols % 256 != 0`** because
+    /// the function then pads `cols` up to the next 256-multiple,
+    /// shifting subsequent super-blocks off-stride. That's Qwen2 0.5B
+    /// territory (hidden=896 → cols=896 when swapped wrong) — handled
+    /// by the defect-2 K-divisibility fallback (forces F32 instead of
+    /// quantizing).
+    ///
+    /// This test pins the byte-equivalence finding. If it ever fails,
+    /// trueno-quant changed its layout and the audit doc needs a revisit.
+    #[test]
+    #[allow(clippy::cast_precision_loss)]
+    fn audit_q4k_shape_swap_byte_identical_when_both_dims_divisible() {
+        use super::super::quantize_q4_k_matrix;
+
+        // 256 × 512: both 256-divisible, shape[0] != shape[1] so the swap
+        // meaningfully differs. Small enough for a fast unit test.
+        let rows = 256_usize;
+        let cols = 512_usize;
+        let n = rows * cols;
+
+        // Heterogeneous per-row distribution: row r centered at r*0.01,
+        // std 0.1. Adjacent rows differ enough that — IF the swap shifted
+        // super-block boundaries — the resulting bytes would diverge.
+        let mut data = vec![0.0_f32; n];
+        for r in 0..rows {
+            let row_mean = (r as f32) * 0.01;
+            for c in 0..cols {
+                let perturbation = ((r * 31 + c * 17) as f32).sin() * 0.1;
+                data[r * cols + c] = row_mean + perturbation;
+            }
+        }
+
+        // CORRECT (post-v0.34.0): APR-native shape.
+        let correct_bytes = quantize_q4_k_matrix(&data, &[rows, cols]);
+        // BUGGY (pre-v0.34.0): swap before passing.
+        let buggy_bytes = quantize_q4_k_matrix(&data, &[cols, rows]);
+
+        assert_eq!(
+            correct_bytes.len(),
+            buggy_bytes.len(),
+            "shape-swap audit precondition: byte counts equal"
+        );
+
+        // **Central finding**: for the 256-divisible-on-both-dims case,
+        // the bytes are IDENTICAL. The bug doesn't manifest here at all.
+        assert_eq!(
+            correct_bytes, buggy_bytes,
+            "AUDIT-Q4K-SHAPE-001: when both dims are 256-divisible, the \
+             pre-v0.34.0 shape-swap produces byte-identical output to the \
+             post-v0.34.0 correct call. Falsification of any future divergence \
+             would mean trueno-quant's layout changed — revisit the audit doc \
+             and the v0.33.0 / earlier shipped Q4_K artifacts."
+        );
+    }
 }
 
 include!("export_include_01.rs");

--- a/docs/specifications/audits/q4k-shape-swap-impact.md
+++ b/docs/specifications/audits/q4k-shape-swap-impact.md
@@ -1,0 +1,105 @@
+# Audit: Q4_K shape-swap impact on v0.33.0-and-earlier Q4_K artifacts
+
+**Document ID:** AUDIT-Q4K-SHAPE-001
+**Version:** 1.1.0 (empirically falsified the original concern; benign for 256-divisible-both-dims case)
+**Status:** Live — closes PMAT-690 P3-C-prep defect 4 (task #110)
+**Parent:** [SPEC-HF-PUBLISH-001](../aprender-train/model-hf-publish-pipeline-spec.md), [ship-model-2-spec.md §84](../aprender-train/ship-model-2-spec.md)
+**Trigger:** PR #1771 (v0.34.0, 2026-05-18) fixed `quantize_q4_k_matrix` to receive APR-native shape `[rows=out, cols=in=K]` instead of the swapped `[K, out]`. The swap had been in production since the function was first called; we need to know whether shipped artifacts produced under the pre-fix path are usable.
+
+## TL;DR
+
+**Already-shipped Q4_K artifacts produced before v0.34.0 are BIT-EQUIVALENT to a hypothetical post-v0.34.0 re-export** whenever both weight-tensor dims are 256-divisible. No re-export needed for correctness. Confirmed by the in-tree falsification test `audit_q4k_shape_swap_byte_identical_when_both_dims_divisible` (passes 2026-05-18) which proves the pre-fix `quantize_q4_k_matrix(data, [a, b])` and post-fix `quantize_q4_k_matrix(data, [b, a])` produce **byte-identical** output on the 256-divisible-both-dims case.
+
+The defect-3 fix only matters when the inner dim K is NOT 256-divisible (e.g., Qwen2 0.5B `hidden=896`) — and that case is independently caught by the defect-2 K-divisibility fallback which forces F32 instead of quantizing. So:
+- **Qwen2 0.5B** (hidden=896, NOT divisible): defect-2 F32 fallback → no Q4_K applied → defect-3 irrelevant.
+- **Qwen2 1.5B** (hidden=1536, divisible): defect-3 byte-identical → pre-fix artifact = post-fix artifact.
+- **Qwen2 7B** (hidden=3584, divisible): defect-3 byte-identical → pre-fix artifact = post-fix artifact.
+
+This audit was triggered by an a-priori concern that the pre-fix swap might silently degrade inference quality on 1.5B/7B shipped artifacts. The empirical evidence falsified that concern.
+
+## Mechanism
+
+`quantize_q4_k_matrix(data, shape)` interprets `shape[0]` as `rows` and `shape[1]` as `cols`, then iterates:
+
+```rust
+for row_idx in 0..rows {
+    let mut padded_row = vec![0.0f32; padded_cols];  // padded_cols = ceil(cols/256) * 256
+    if row_end <= data.len() {
+        padded_row[..cols].copy_from_slice(&data[row_idx * cols .. (row_idx+1) * cols]);
+    }
+    let row_q4k = quantize_q4_k(&padded_row);        // splits into 256-element super-blocks
+    result.extend_from_slice(&row_q4k);
+}
+```
+
+Each iteration:
+1. Reads `cols` contiguous elements from `data` (offset `row_idx * cols`).
+2. Pads to next 256-multiple if needed.
+3. Quantizes via `quantize_q4_k` which produces one super-block per 256 elements of the padded slice.
+
+### Case A: both dims 256-divisible (Qwen2 1.5B/7B)
+
+`cols % 256 == 0` → no padding. The function consumes data in linear order, chunking into `cols / 256` super-blocks per iteration. **The data is consumed in the same linear order with the same 256-aligned chunking regardless of how rows/cols are partitioned.** Specifically:
+
+- Call A: `[rows=256, cols=512]`, 256 iterations each producing 2 super-blocks → 512 super-blocks total, in offset order `0, 256, 512, 768, …, 130816`.
+- Call B: `[rows=512, cols=256]` (the swap), 512 iterations each producing 1 super-block → 512 super-blocks total, in offset order `0, 256, 512, 768, …, 130816`.
+
+The super-block at offset `i*256` reads the same 256 elements in both calls. The output bytes are byte-identical.
+
+**Verified empirically** by the in-tree test `audit_q4k_shape_swap_byte_identical_when_both_dims_divisible` with a heterogeneous-per-row matrix (so any layout-sensitive divergence would be amplified). `assert_eq!(correct_bytes, buggy_bytes)` passes.
+
+### Case B: K (inner dim) NOT 256-divisible (Qwen2 0.5B)
+
+For Qwen2 0.5B `ffn_down.weight` with APR shape `[hidden=896, intermediate=4864]`:
+
+- Pre-fix call: shape swapped to `[4864, 896]`. The function iterates rows=4864, cols=896. `cols % 256 = 128 ≠ 0` → pads to 1024. Each iteration produces 4 super-blocks (the 4th being half-padding). Total output: `4864 × 4 × 144 = 2,801,664 bytes`.
+- llama.cpp expectation: `ne[0]=4864, ne[1]=896` → super-blocks = `(4864 × 896) / 256 = 17,024`. Bytes = `17,024 × 144 = 2,451,456`.
+- **Excess: 350,208 bytes**, causing the offset drift that PR #1771 surfaced.
+
+This is the case PR #1771's defect 2 fix forecloses by falling back to F32 when `shape[1] % 256 != 0`. With that fallback in place, the swap is moot — no Q4_K bytes are produced for the affected tensor.
+
+## Why MODEL-1's 4.4pp HumanEval gap vs upstream is NOT this bug
+
+Pre-finding hypothesis: `paiml/qwen2.5-coder-7b-apache-q4k-v1` at AC-SHIP1-005 = 86.59% vs upstream `Qwen/Qwen2.5-Coder-7B-Instruct` Q4_K_M ≈ 91% could mean the shape-swap was degrading our quantization.
+
+Post-finding: the audit proves the bytes are identical to a hypothetical post-fix re-export, so the gap CANNOT be attributable to defect 3. The actual contributors are:
+- **Q4_K vs Q4_K_M (mixed precision)**: llama.cpp's `_M` variant leaves attention output projections + the FFN down projection at Q6_K for sensitivity. Aprender's Q4_K is pure Q4_K throughout. This is the largest plausible contributor.
+- **Different cumulative rounding paths** from different f32 → Q4_K implementations (aprender's `trueno_quant` vs llama.cpp's native quantizer). Small but non-zero.
+
+If MODEL-1 quality matters more than v1 immutability, the path is to:
+1. Add Q4_K_M (mixed precision) support to `apr export` — leave sensitive tensors at Q6_K.
+2. Re-export `paiml/qwen2.5-coder-7b-apache-q4k-v1` as v1.1.0 with Q4_K_M.
+3. Re-run HumanEval; expect to recover most of the 4.4pp gap.
+
+This is a feature-add, not a bug fix. Out of scope for this audit.
+
+## Action items (closed)
+
+| ID | Task | Status |
+|----|------|--------|
+| Q4K-AUDIT-001 | Run the in-tree falsification test and pin the numerical result | **DONE** — `audit_q4k_shape_swap_byte_identical_when_both_dims_divisible` passes |
+| Q4K-AUDIT-002 | Re-export `paiml/qwen2.5-coder-7b-apache-q4k-v1` post-v0.34.0 | **WITHDRAWN** — empirically unnecessary; bytes are identical |
+| Q4K-AUDIT-003 | CHANGELOG entry warning external users of pre-v0.34.0 Q4_K artifacts | **REVISED** — v0.34.0 CHANGELOG should clarify the bug only affected `K % 256 != 0` tensors; 256-divisible artifacts are unaffected |
+
+## Action items (open)
+
+| ID | Task | Owner | Status |
+|----|------|-------|--------|
+| Q4K-AUDIT-004 | (Optional) Add Q4_K_M (mixed precision) export support to recover the ~4.4pp HumanEval gap on MODEL-1 | apr-export team | proposed (not blocking) |
+
+## v0.34.0 CHANGELOG correction
+
+The v0.34.0 CHANGELOG implies the shape-swap fix changed published byte layouts for all Qwen2 variants. This audit refutes that: the byte layouts only differ when `K % 256 != 0` (which the defect-2 fix forces to F32 fallback anyway). A small clarification PR is warranted but is non-urgent.
+
+## References
+
+- In-tree falsifier: `crates/aprender-core/src/format/converter/gguf_export_config.rs::q4k_divisibility_tests::audit_q4k_shape_swap_byte_identical_when_both_dims_divisible`
+- PR #1771 (v0.34.0) — the original fix
+- `trueno_quant::quantize_q4_k_matrix` — the function under audit
+- [SPEC-HF-PUBLISH-001 §"HF API gotchas" rule 6](../aprender-train/model-hf-publish-pipeline-spec.md) — captures "Q4_K shape must be APR-native" as a load-bearing rule for future publishes; this audit clarifies that the rule prevents a future regression rather than fixing existing artifacts.
+- `feedback_predict_then_verify_closes_cascade.md` (2026-05-12) — memory rule for falsification-first audits; this doc follows that pattern.
+
+## Changelog
+
+- **1.1.0 (2026-05-18)** — Empirically falsified the v1.0.0 concern. The shape-swap bug is benign on 256-divisible-both-dims tensors (Qwen2 1.5B/7B). The defect-2 K-divisibility fallback already handles the non-divisible case (Qwen2 0.5B). No re-export needed for any already-shipped Q4_K artifact. Closes task #110.
+- **1.0.0 (2026-05-18)** — Initial publish with a-priori concern that pre-v0.34.0 Q4_K artifacts might be silently degraded. Math established but not yet empirically verified; turned out to be wrong.


### PR DESCRIPTION
## Summary

Closes task #110 (P3-C-prep defect 4) by **empirically falsifying** the a-priori concern that pre-v0.34.0 Q4_K artifacts might have been silently degraded by the `quantize_q4_k_matrix` shape-swap.

## Finding

When BOTH weight-tensor dims are 256-divisible (Qwen2 1.5B `hidden=1536, intermediate=8960`; Qwen2 7B `hidden=3584, intermediate=18944`), the pre-fix `quantize_q4_k_matrix(data, [in, out])` and post-fix `quantize_q4_k_matrix(data, [out, in])` produce **byte-identical** output.

Mechanism: the function consumes data linearly, chunking into fixed-size 256-element super-blocks. When both dims are 256-multiples, the per-iteration row boundary lands on a super-block boundary anyway — the swap is a no-op for the output bytes.

The shape-swap bug only manifests when `cols % 256 != 0` (e.g., Qwen2 0.5B `hidden=896`). That case is already caught by the defect-2 K-divisibility fallback (forces F32 instead of quantizing). So no shipped artifact is degraded by defect 3.

## Falsifier

New unit test `audit_q4k_shape_swap_byte_identical_when_both_dims_divisible` in `gguf_export_config.rs::q4k_divisibility_tests`. Generates a 256×512 matrix with heterogeneous-per-row statistics (so any layout-sensitive divergence would be amplified) and asserts byte-identity of the two quantization calls. Passes 2026-05-18.

## Impact

- **`paiml/qwen2.5-coder-7b-apache-q4k-v1`** — pre-v0.34.0 artifact is bit-equivalent to a hypothetical post-fix re-export. **No re-export needed.**
- **`paiml/albor-370m-v1`** — uses the post-fix path AND defect-2 F32 fallback (hidden=896). **Already correct.**
- **Any other Qwen2 1.5B / 7B Q4_K GGUF previously exported with `apr export`** — unaffected.

## Why MODEL-1's ~4.4pp HumanEval gap vs upstream is NOT this bug

`paiml/qwen2.5-coder-7b-apache-q4k-v1` at AC-SHIP1-005 = 86.59% vs upstream `Qwen/Qwen2.5-Coder-7B-Instruct` Q4_K_M ≈ 91%. Post-finding, the gap is attributable to:
1. **Q4_K vs Q4_K_M (mixed precision)** — llama.cpp's `_M` variant keeps sensitive tensors (attn output, ffn down) at Q6_K. Aprender's Q4_K is pure throughout.
2. **Different cumulative rounding paths** from different f32→Q4_K implementations.

Recovery path is to add Q4_K_M export support to `apr export` (filed as Q4K-AUDIT-004, non-blocking, separate ticket).

## Test plan

- [x] `cargo test -p aprender-core --lib audit_q4k_shape_swap` passes
- [x] All 8 q4k_divisibility_tests pass (1 new + 7 pre-existing)
- [x] Audit doc explains math + cites empirical falsifier + closes action items

🤖 Generated with [Claude Code](https://claude.com/claude-code)