### PR TITLE
ci: pre-build chown of per-RUN target dir to fix root-owned bind mount

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,36 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ github.token }}
+      - name: Pre-build chown — fix per-RUN root ownership
+        # Root cause (five-whys):
+        #   1. Why do fresh runs sometimes fail with "failed to create
+        #      /workspace/target/debug" / "No such file or directory"?
+        #      Cargo (running as user 1000 inside the container) can't
+        #      write to /workspace/target/debug.
+        #   2. Why can't it write? The bind-mount source dir on the host
+        #      (/mnt/nvme-raid0/targets/aprender-ci/<PR>/run-<RUN_ID>) is
+        #      owned by root:root.
+        #   3. Why is it root-owned? Docker's bind-mount creates missing
+        #      host directories with the daemon's uid (root). Per-RUN
+        #      paths are always fresh, so this fires every run.
+        #   4. Why didn't this happen before? Pre-#1693 the per-PR (not
+        #      per-RUN) path persisted across runs, and the downstream
+        #      "post-job cleanup" docker chown step fixed ownership for
+        #      the NEXT run's git-clean. Per-RUN paths invalidate that —
+        #      each run gets a brand-new root-owned dir.
+        #   5. Root cause: the chown step runs AFTER cargo, not BEFORE.
+        #      First-runs always fail; reruns appear to work only when
+        #      the previous run's belated chown fixed the now-stale dir.
+        # Fix (this step): docker run as root, chown the per-RUN target
+        # dir + cargo registry to noah:1000 BEFORE the cargo step.
+        # Idempotent — `|| true` tolerates dirs that are already
+        # noah-owned (e.g. a rerun of the same run-id).
+        run: |
+          docker run --rm \
+            -v "/mnt/nvme-raid0/targets/aprender-ci/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
+            -v "/mnt/nvme-raid0/cargo-ci/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
+            "$IMAGE" \
+            bash -c 'chown -R 1000:1000 /workspace/target /usr/local/cargo/registry 2>/dev/null || true'
       - name: Workspace lib tests (25,300+)
         # Excluded: aprender-gpu (cuBLAS), aprender-cuda-edge (CUDA), aprender-compute (SIMD SIGSEGV at exit)
         # Timeout: 75min (was 55, was 40).


### PR DESCRIPTION
## Summary

Adds a chown step BEFORE the cargo step in \`workspace-test\` that runs the sovereign-ci image as root and chowns the per-RUN target dir (\`/mnt/nvme-raid0/targets/aprender-ci/<PR>/run-<RUN_ID>\`) and cargo registry to noah:1000.

## Why — five-whys

1. **Why do fresh runs fail with \`failed to create /workspace/target/debug\`?** Cargo runs as uid 1000 inside the container and can't write to root-owned dirs.
2. **Why root-owned?** Docker's bind-mount creates missing host directories with the daemon's uid (root).
3. **Why does this fire every run?** Per-RUN paths (#1693 in \`aprender-ci/<PR>/run-<RUN_ID>\`) are always fresh — Docker creates them root-owned every time.
4. **Why didn't this happen before #1693?** Pre-#1693 the per-PR (not per-RUN) path persisted across runs, and the existing post-job chown step at line 245 fixed perms for the next run's git-clean. Per-RUN invalidates that.
5. **Root cause**: the chown step runs AFTER cargo, not BEFORE. First-runs always fail; reruns appear to work only when a sibling run's belated chown happened to fix the (now-stale) dir.

## Empirical (2026-05-18 lambda-vector ssh intel)

Inspection showed 6 in-flight runs hit the same error simultaneously across unrelated PRs:

\`\`\`
ROOT-OWNED: /mnt/nvme-raid0/targets/aprender-ci/1792/run-26040118649 (root:root)
ROOT-OWNED: /mnt/nvme-raid0/targets/aprender-ci/1793/run-26040120976 (root:root)
ROOT-OWNED: /mnt/nvme-raid0/targets/aprender-ci/1794/run-26040155236 (root:root)
ROOT-OWNED: /mnt/nvme-raid0/targets/aprender-ci/1796/run-26040126733 (root:root)
ROOT-OWNED: /mnt/nvme-raid0/targets/aprender-ci/1797/run-26040155057 (root:root)
ROOT-OWNED: /mnt/nvme-raid0/targets/aprender-ci/main/run-26040057475 (root:root)
\`\`\`

All resolved immediately after manual \`sudo chown -R 1000:1000\` on the runner host. Disk space and inode counts were fine (67% used / 22% inodes); this was pure ownership.

This was misdiagnosed as a transient infra flake across the day's session — every \"workspace-test failure\" turned out to be the same root cause at different cargo entry points (lint, test, coverage, gate all error in the same way).

## Fix

A new step BEFORE \`Workspace lib tests\`:

\`\`\`yaml
- name: Pre-build chown — fix per-RUN root ownership
  run: |
    docker run --rm \\
      -v \"/mnt/nvme-raid0/targets/aprender-ci/\${PR_OR_REF}/run-\${GITHUB_RUN_ID}:/workspace/target\" \\
      -v \"/mnt/nvme-raid0/cargo-ci/registry/\${PR_OR_REF}:/usr/local/cargo/registry\" \\
      \"\$IMAGE\" \\
      bash -c 'chown -R 1000:1000 /workspace/target /usr/local/cargo/registry 2>/dev/null || true'
\`\`\`

Idempotent (\`|| true\` covers reruns where the dir is already noah-owned). Adds ~2s per run since chown of an empty fresh dir is fast.

## Test plan

- [x] YAML lint: \`python3 -c \"import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))\"\` PASS
- [x] Manual one-shot \`sudo chown\` of stuck dirs unblocked 6 in-flight PRs
- [ ] First CI run on this branch verifies the new step works (this PR is self-testing — if the chown step is buggy, this PR's own CI will fail)
- [ ] Subsequent runs on other PRs confirm the fix is stable

## Cross-refs

- #1693 / #1704 — per-RUN target dir migration that surfaced this latent bug
- \`feedback_ci_per_run_target_dir_tradeoff.md\` memory — captured the per-RUN vs per-PR tradeoff but didn't anticipate the chown-timing fallout

🤖 Generated with [Claude Code](https://claude.com/claude-code)