### PR TITLE
fix(distill): Phase 3 dispatch script CLI-flag alignment (PMAT-698b)

### DIFF
--- a/evidence/distill-phase-3-readiness/findings.md
+++ b/evidence/distill-phase-3-readiness/findings.md
@@ -1,0 +1,121 @@
+# Phase 3 Dispatch Readiness Audit — Pre-cascade-land snapshot
+
+**Date:** 2026-05-18
+**Branch tip:** `feat/distill-cuda-backend-construction` @ ca6cc8223
+**Cascade in flight:** PRs #1787 / #1788 / #1791 / #1792 / #1793 / #1795 / #1796 / #1797 — all OPEN/BLOCKED, auto-merge SQUASH armed, 0 failures
+**Trigger:** dry-run of `scripts/dispatch-distill-phase-3-gx10.sh` validated, but a deeper read of the `apr distill` invocation reveals a flag-surface gap.
+
+## Defect summary
+
+The Phase 3 dispatch script (`scripts/dispatch-distill-phase-3-gx10.sh`, shipped in PR #1795) invokes `apr distill` with **six flags that do not exist** on the current CLI surface:
+
+| Script flag           | Current CLI flag (Phase 3-prep) | Status                          |
+|-----------------------|---------------------------------|---------------------------------|
+| `--num-steps 500`     | (none)                          | ❌ no CLI surface                |
+| `--batch-size 4`      | (none — uses default 32)        | ❌ no CLI surface                |
+| `--learning-rate 1.5e-5` | (none — uses default 1e-4)   | ❌ no CLI surface                |
+| `--student-init <ID>` | `--student <PATH>` (PathBuf)    | ⚠ name mismatch + type mismatch |
+| `--output-dir <DIR>`  | `--output <PATH>` (file path)   | ⚠ name + semantics mismatch     |
+| `--device cuda`       | `--backend cuda`                | ⚠ name mismatch                 |
+
+When the cascade lands and the script is invoked, `apr distill` will reject the unknown flags and exit non-zero before any training begins. The smoke run cannot fire as-shipped.
+
+## Root cause
+
+PRs #1796 + #1797 (Phase 3-prep) added `--backend` and wired `run_cuda_backend()` but stopped at the minimum CLI surface needed for a fixture-vs-cuda backend switch. The dispatch script (#1795) was authored ASPIRATIONALLY against the full Phase 3 surface, on the assumption that the same PR cascade would add the missing flags. It didn't — the missing flags fell into the gap between #1797 and a future Phase 3 ticket.
+
+## Local proofs
+
+```
+$ /mnt/nvme-raid0/targets/aprender/debug/apr distill --help
+…
+  --epochs <EPOCHS>            Training epochs [default: 3]
+  --backend <BACKEND>          SPEC-DISTILL-001 Phase 3-prep …
+```
+
+No `--num-steps`, no `--batch-size`, no `--learning-rate`. Confirmed at branch tip `ca6cc8223` after a forced rebuild (cargo feature-cache staleness rule applied — `target/debug/apr` was hard-linked to a stale binary in `/mnt/nvme-raid0/targets/aprender/`; fresh binary at `/mnt/nvme-raid0/targets/aprender/debug/apr` has the Phase 3-prep `--backend` flag but nothing further).
+
+## Recommended fix scope (Phase 3 CLI surface, new ticket — call it PMAT-698b)
+
+Add three flags to `apr-cli` `Distill` enum variant:
+
+1. `--num-steps <N>` (Option<u32>): if set, caps total training step count; pipeline ignores `--epochs` when this is set
+2. `--batch-size <N>` (Option<u32>): override `DistillConfig::training.batch_size` (currently hardcoded to 32 via default)
+3. `--learning-rate <F>` (Option<f64>): override `DistillConfig::training.learning_rate` (currently hardcoded to 1e-4)
+
+Thread through `distill::run(...)` → `run_cuda_backend(...)` → `DistillConfig::training` overrides. Add `--device` as an alias for `--backend` (same enum). Accept `--student` with either a path OR an HF repo ID (auto-resolve via cache lookup).
+
+Also: pipeline `train()` loop currently has `steps_this_epoch = (1000 / batch_size).max(1)` hardcoded — needs to honor `max_steps: Option<u32>` if set.
+
+## Falsifier (F-DISTILL-CLI-PHASE-3-FLAGS, proposed)
+
+A unit test in `crates/apr-cli/src/commands/distill.rs::tests`:
+
+```rust
+#[test]
+fn falsify_phase_3_dispatch_script_flag_surface_aligned() {
+    // Read the dispatch script, extract the `apr distill ...` invocation,
+    // tokenize it, and assert that every `--flag` token appears in the clap
+    // matches of `apr distill --help`.
+    let script = include_str!("../../../../scripts/dispatch-distill-phase-3-gx10.sh");
+    let flags_used: Vec<_> = extract_apr_distill_flags(script);
+    let cli_flags: Vec<_> = extract_distill_clap_flags();
+    for f in &flags_used {
+        assert!(cli_flags.contains(f), "dispatch script uses {} which is not on apr distill CLI", f);
+    }
+}
+```
+
+This contract pins script↔CLI alignment forever.
+
+## Resolution (post-cascade)
+
+Cascade drained 2026-05-18 18:24 UTC:
+- #1788 squash-merged Phase 2 (`11a0ba77f`)
+- #1797 squash-merged the rest of the cascade (`aee8716d6`) per chain-PR squash leapfrog
+- #1787 / #1791 / #1792 / #1793 / #1795 / #1796 closed as subsumed
+
+This findings.md ships with PR PMAT-698b (`fix/distill-phase-3-dispatch-flags-pmat-698b`), which fixes the dispatch script to use the EXISTING CLI surface rather than the aspirational one. The CLI additions (`--max-steps`, `--batch-size`, `--learning-rate`) are deferred to a future PMAT-698c after the smoke run validates the pipeline end-to-end with default hyperparameters.
+
+### Script fix (this PR)
+
+| Aspirational flag         | Fixed to                              |
+|---------------------------|---------------------------------------|
+| `--teacher REPO`          | positional `<TEACHER_DIR>` (resolved) |
+| `--student-init REPO`     | `--student <STUDENT_DIR>` (resolved)  |
+| `--num-steps 500`         | `--epochs 17` (round-up of 500/31)    |
+| `--batch-size 4`          | dropped — uses default 32             |
+| `--learning-rate 1.5e-5`  | dropped — uses default 1e-4           |
+| `--output-dir DIR`        | `--output DIR/student.apr`            |
+| `--device cuda`           | `--backend cuda`                      |
+
+HF repo IDs are resolved to local cache dirs via shell function `hf_repo_to_dir` inside the SSH heredoc — `~/.cache/huggingface/hub/models--<sanitized>/snapshots/<sha>/` is what `apr distill` expects (per `for_inference()` signature).
+
+### Deferred to PMAT-698c (future PR)
+
+Adding `--max-steps`, `--batch-size`, `--learning-rate` CLI flags lets the dispatch use the user's preferred hyperparameters (batch=4, lr=1.5e-5) instead of defaults. The pipeline.rs training loop also needs `max_steps: Option<u32>` to cap the loop. Scope: ~150 LOC + falsifier.
+
+## Cascade state at audit time
+
+```
+#1787: OPEN/BLOCKED  S=3 P=3 F=0   (Phase 1b — CudaTrainerTeacher)
+#1788: OPEN/BLOCKED  S=6 P=1 F=0   (Phase 2 — KD step) ← closest to merge
+#1791: OPEN/BLOCKED  S=5 P=2 F=0   (Phase 2b — StudentLogitsProvider)
+#1792: OPEN/BLOCKED  S=5 P=2 F=0   (Phase 2c — pipeline integration)
+#1793: OPEN/BLOCKED  S=4 P=2 F=0   (Phase 2d — CudaStudentProvider)
+#1795: OPEN/BLOCKED  S=2 P=4 F=0   (Phase 3 dispatch + watch scripts) ← contains the defect this audit identifies
+#1796: OPEN/BLOCKED  S=5 P=2 F=0   (Phase 3-prep — --backend flag)
+#1797: OPEN/BLOCKED  S=5 P=2 F=0   (Phase 3-prep — cuda backend construction)
+```
+
+All 8 PRs target `main` as siblings (not a daisy chain). Per the `feedback_chain_pr_squash_leapfrog.md` memory rule, when one squash-merges with the cascade content, GitHub will mark subsumed siblings as MERGED automatically.
+
+## Lesson #N+1 candidate (NEW)
+
+**Dispatch scripts authored mid-cascade must be flag-aligned with the CLI on the same branch as the script.** PR #1795 added a script that depended on a CLI surface PR #1796/#1797 didn't provide. The aspirational script + minimal-surface CLI shipped in different PRs, leaving the dispatch broken until a follow-up PMAT-698b lands.
+
+Mitigation: every PR that ships an executable script under `scripts/` must include either:
+- a smoke test that runs the script's invocation against the binary built from the same branch (DRY_RUN=1 + `--help` shape check), OR
+- a `pv lint` contract assertion that the script's `apr <subcommand>` flags ⊆ the binary's clap matches
+
+Without one of these, scripts drift silently.

--- a/scripts/dispatch-distill-phase-3-gx10.sh
+++ b/scripts/dispatch-distill-phase-3-gx10.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-# SPEC-DISTILL-001 Phase 3 — 500-step E2E smoke run on gx10 (Blackwell GB10).
+# SPEC-DISTILL-001 Phase 3 - 500-step E2E smoke run on gx10 (Blackwell GB10).
 #
-# Falsifier: F-DISTILL-SMOKE-001 — val_loss at step 500 < step 0.
+# Falsifier: F-DISTILL-SMOKE-001 - val_loss at step 500 < step 0.
 #
 # Prerequisites
 # =============
@@ -11,7 +11,7 @@
 # 3. MODEL-1 teacher is cached on gx10 at
 #    ~/.cache/huggingface/hub/models--paiml--qwen2.5-coder-7b-apache-q4k-v1/
 #    (apr pull will fetch it if missing).
-# 4. HF_TOKEN exported in the local shell — propagated via ssh -A or
+# 4. HF_TOKEN exported in the local shell - propagated via ssh -A or
 #    explicit `ssh gx10 "export HF_TOKEN=...; ./run.sh"` patterns.
 #
 # Constraints
@@ -19,7 +19,7 @@
 # - gx10 is aarch64 + Blackwell (sm_121). The trueno backward path on
 #   Blackwell may hit the JIT pre-warming bug per memory rule
 #   `feedback_blackwell_jit_blocked_training.md`. Phase 3 specifically
-#   tolerates this — if the fused-NF4 path crashes, we fall back to the
+#   tolerates this - if the fused-NF4 path crashes, we fall back to the
 #   in-tree forward-only smoke (proves teacher + kd_step orchestration
 #   without weight updates) and document Phase 3a as partial.
 # - Real Phase 3 discharge of F-DISTILL-SMOKE-001 needs a working
@@ -119,30 +119,68 @@ echo "=== dispatching smoke run on gx10 ==="
 RUN_DIR_REMOTE="/mnt/nvme-raid0/runs/${RUN_NAME}"
 LOG_REMOTE="${RUN_DIR_REMOTE}/launch.log"
 
+# SPEC-DISTILL-001 Phase 3 dispatch - CLI-flag-aligned invocation (PMAT-698b).
+# The post-#1797 `apr distill` surface is:
+#   - positional <TEACHER>           (PathBuf - directory containing model.apr or model.safetensors)
+#   - --student <STUDENT>            (PathBuf - same shape)
+#   - --epochs <N>                   (no --num-steps; pipeline runs ~31 steps/epoch at default batch=32)
+#   - --temperature, --alpha, --backend cuda, --output <FILE>
+# Per evidence/distill-phase-3-readiness/findings.md, the earlier script used
+# aspirational flags (--num-steps/--batch-size/--learning-rate/--student-init/
+# --output-dir/--device) that do not exist on the post-Phase-3-prep CLI.
+#
+# Map the user-facing knobs to the real CLI:
+#   - STEPS=500 (default) → --epochs 17 (~527 steps at default batch=32)
+#   - BATCH_SIZE / LR are NOT yet exposed on the CLI; documented but unused
+#     here. A follow-up PMAT-698c adds --batch-size / --learning-rate / --max-steps.
+#   - TEACHER_REPO / STUDENT_INIT → resolved to ~/.cache/huggingface/hub snapshot
+#     dirs via shell expansion (apr pull populates the cache).
+
+EPOCHS_FROM_STEPS=$(( (STEPS + 30) / 31 ))  # round up: 500 → 17 epochs
+
 ssh "${GX10_USER}@${GX10_HOST}" "
     set -e
     mkdir -p '${RUN_DIR_REMOTE}'
     cd '${GX10_REPO_PATH}'
-    nohup ./target/release/apr distill \\
-        --teacher ${TEACHER_REPO} \\
-        --student-init ${STUDENT_INIT} \\
-        --num-steps ${STEPS} \\
-        --batch-size ${BATCH_SIZE} \\
-        --learning-rate ${LR} \\
+
+    # Resolve HF repo → local cache snapshot dir. The hub layout is
+    # models--<org>--<name>/snapshots/<sha>/, with one snapshot per pull.
+    hf_repo_to_dir() {
+        local repo=\"\$1\"
+        local sanitized=\"\${repo//\\//--}\"
+        local cache_root=\"\$HOME/.cache/huggingface/hub/models--\${sanitized}\"
+        ls -td \"\${cache_root}/snapshots/\"*/ 2>/dev/null | head -1 | sed 's:/\$::'
+    }
+    TEACHER_DIR=\$(hf_repo_to_dir '${TEACHER_REPO}')
+    STUDENT_DIR=\$(hf_repo_to_dir '${STUDENT_INIT}')
+    if [ -z \"\$TEACHER_DIR\" ] || [ ! -d \"\$TEACHER_DIR\" ]; then
+        echo \"teacher cache dir not found for '${TEACHER_REPO}' - apr pull failed?\" >&2
+        exit 1
+    fi
+    if [ -z \"\$STUDENT_DIR\" ] || [ ! -d \"\$STUDENT_DIR\" ]; then
+        echo \"student cache dir not found for '${STUDENT_INIT}' - apr pull failed?\" >&2
+        exit 1
+    fi
+    echo \"teacher dir: \$TEACHER_DIR\"
+    echo \"student dir: \$STUDENT_DIR\"
+
+    nohup ./target/release/apr distill \"\$TEACHER_DIR\" \\
+        --student \"\$STUDENT_DIR\" \\
+        --epochs ${EPOCHS_FROM_STEPS} \\
         --temperature ${T} \\
         --alpha ${ALPHA} \\
-        --output-dir '${RUN_DIR_REMOTE}' \\
-        --device cuda \\
+        --backend cuda \\
+        --output '${RUN_DIR_REMOTE}/student.apr' \\
         > '${LOG_REMOTE}' 2>&1 &
     DISPATCH_PID=\$!
     echo \"dispatched PID \${DISPATCH_PID}\"
     sleep 5
     if ! kill -0 \${DISPATCH_PID} 2>/dev/null; then
-        echo 'EARLY EXIT — capturing tail of log:' >&2
+        echo 'EARLY EXIT - capturing tail of log:' >&2
         tail -40 '${LOG_REMOTE}' >&2 || true
         exit 1
     fi
-    echo \"PID alive after 5s — training underway\"
+    echo \"PID alive after 5s - training underway\"
 "
 
 # --------------------------------------------------------------------------
@@ -152,7 +190,7 @@ mkdir -p "${EVIDENCE_DIR}"
 cat > "${EVIDENCE_DIR}/dispatch.json" <<JSON
 {
   "ticket": "PMAT-697",
-  "phase": "SPEC-DISTILL-001 Phase 3 — E2E smoke",
+  "phase": "SPEC-DISTILL-001 Phase 3 - E2E smoke",
   "falsifier": "F-DISTILL-SMOKE-001",
   "run_name": "${RUN_NAME}",
   "host": "${GX10_HOST}",


### PR DESCRIPTION
## Summary

- Dispatch script (squash-landed via #1797) used six aspirational `apr distill` flags that don't exist on the current CLI: `--num-steps`, `--batch-size`, `--learning-rate`, `--student-init`, `--output-dir`, `--device`
- Realign to existing flags (`--epochs`, `--student`, `--backend`, `--output`) and drop the two without CLI surface (deferred to PMAT-698c)
- HF repo IDs resolved to local cache snapshot dirs via shell function inside the SSH heredoc — matches `CudaTrainerTeacher::for_inference`'s directory expectation

Unblocks task #124: Phase 3 real smoke dispatch on gx10.

## Defect surfaced

PR #1795 shipped `scripts/dispatch-distill-phase-3-gx10.sh` with flags PR #1796/#1797 didn't add. The smoke run cannot fire as-shipped — `apr distill` rejects unknown flags. Detailed audit in `evidence/distill-phase-3-readiness/findings.md`.

## Mapping

| Aspirational flag         | Fixed to                              |
|---------------------------|---------------------------------------|
| `--teacher REPO`          | positional `<TEACHER_DIR>` (resolved) |
| `--student-init REPO`     | `--student <STUDENT_DIR>` (resolved)  |
| `--num-steps 500`         | `--epochs 17` (round-up of 500/31)    |
| `--batch-size 4`          | dropped — uses default 32             |
| `--learning-rate 1.5e-5`  | dropped — uses default 1e-4           |
| `--output-dir DIR`        | `--output DIR/student.apr`            |
| `--device cuda`           | `--backend cuda`                      |

## Test plan

- [x] `DRY_RUN=1 bash scripts/dispatch-distill-phase-3-gx10.sh` exits cleanly
- [x] `bashrs lint` error count drops from 14 → 11 (script-local improvement; remaining 11 are pre-existing heredoc/string mis-parses on the SSH block)
- [ ] After merge, gx10 dispatch validates F-DISTILL-SMOKE-001 (val_loss at end < val_loss at start)

## Deferred to PMAT-698c

Adding `--max-steps`, `--batch-size`, `--learning-rate` CLI flags so the dispatch can use user-preferred hyperparameters (batch=4, lr=1.5e-5) instead of defaults. Scope: ~150 LOC + falsifier in pipeline.rs to honor `max_steps: Option<u32>` cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)