### PR TITLE
fix(distill): accept APR magic bytes in load_safetensors_weights (PMAT-698f)

### DIFF
--- a/crates/aprender-train-distill/src/weights.rs
+++ b/crates/aprender-train-distill/src/weights.rs
@@ -21,6 +21,25 @@ pub fn load_safetensors_weights(
         source: e,
     })?;
 
+    // PMAT-698f: when the cuda distillation backend is active, teacher/student
+    // are staged as APR v2 files (via `apr import` in the dispatch script,
+    // because CudaTrainerTeacher::for_inference reads APR metadata, not
+    // SafeTensors). The pipeline.train() helper used to assert the file
+    // parses as SafeTensors as a sanity check on the fixture path — for APR
+    // inputs the SafeTensors parser fails with "header too large" because
+    // it reads the APR v2 binary header bytes as a u64 SafeTensors header
+    // length.
+    //
+    // Detect the APR magic bytes ("APR\0" v2, "APRN" v1) and return empty
+    // maps. The cuda path's pipeline.train() uses providers (not these
+    // maps) for forward/backward; the empty maps just become no-op
+    // placeholders for the post-train logit projection. The FALSIFY-APR-
+    // DISTILL-TRAIN-001 contract is a fixture-path-only assertion and
+    // remains intact for that path.
+    if data.len() >= 4 && (&data[..4] == b"APR\0" || &data[..4] == b"APRN") {
+        return Ok((HashMap::new(), HashMap::new()));
+    }
+
     let tensors =
         safetensors::SafeTensors::deserialize(&data).map_err(|e| EntrenarError::Serialization {
             message: format!("invalid SafeTensors file {}: {e}", path.display()),


### PR DESCRIPTION
## Summary

Phase 3 dispatch on gx10 reaches the training loop after PMAT-698e (workspace cap) but then fails at:

```
Validation failed: cuda pipeline.execute failed: Serialization error:
invalid SafeTensors file /home/noah/runs/.../teacher/model.apr: header too large
```

`pipeline.train()` calls `load_safetensors_weights` on both teacher and student paths. The cuda backend (PMAT-697 wiring) stages files as APR v2 (via `apr import`) because `CudaTrainerTeacher::for_inference` reads APR metadata, not SafeTensors. SafeTensors's deserializer reads the APR v2 binary header bytes as a u64 header length and rejects the file.

## Fix

Detect APR v1/v2 magic bytes (`APR\0` / `APRN`) in `load_safetensors_weights` and return empty maps. The cuda path's `pipeline.train()` uses providers (not these maps) for forward/backward; the empty maps are no-op placeholders for the post-train logit projection.

## Test plan

- [x] 58 distill lib tests pass (fixture path FALSIFY-APR-DISTILL-TRAIN-001/002 unchanged)
- [x] Existing `test_load_safetensors_weights_invalid_data` test passes (non-APR invalid data still errors)
- [ ] Live gx10 dispatch (post-merge) reaches training loop steps (or surfaces NEXT defect)

## Relationship to ongoing Phase 3 fixes

This is the THIRD live-dispatch-discovered defect in the cuda path:
1. PMAT-700-B — skip PTX GEMM pre-warm when cuBLAS active (JIT cache pressure)
2. PMAT-698e — cap max_position_embeddings at 2048 (workspace sizing)
3. PMAT-698f — accept APR magic in weight loader (format compatibility)

Each is independent, each was surfaced by the previous fix unblocking further progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)