### PR TITLE
fix(distill): pre-warm non-LoRA backward kernels (PMAT-698g)

### DIFF
--- a/crates/aprender-train/src/autograd/cuda_backward/cache.rs
+++ b/crates/aprender-train/src/autograd/cuda_backward/cache.rs
@@ -167,10 +167,22 @@ pub fn pre_warm_lora_backward_kernels(
     use trueno_gpu::kernels::Kernel;
 
     eprintln!("[BWD-PREWARM] Called with lora_rank={lora_rank}, hidden={hidden_size}, inter={intermediate_size}");
-    if lora_rank == 0 {
-        eprintln!("[BWD-PREWARM] Skipping (lora_rank=0)");
-        return Ok(());
-    }
+
+    // PMAT-698g: non-LoRA backward pre-warm. The original gate at
+    // `lora_rank == 0` short-circuited the entire function — leaving
+    // silu_backward, batched_softmax_backward, batched_rms_norm_backward,
+    // and rms_norm_gamma_reduce to JIT on demand mid-training. On Blackwell
+    // sm_121, on-demand JIT during the first backward step corrupts the
+    // CUDA stream (trueno#200), surfacing as
+    //   forward_backward_with_grad returned None
+    // mid-step (Phase 3 dispatch v8 confirmed this: kernels compiled
+    // successfully but stream state was poisoned afterwards).
+    //
+    // Now: only the LoRA-specific gemm_backward warmups are skipped when
+    // lora_rank == 0; the activation/norm kernels and the standard FP32
+    // GEMM backward shapes are always pre-warmed (they're needed by
+    // non-LoRA distillation training too).
+    let is_lora = lora_rank > 0;
 
     let cache = KERNEL_CACHE.get().ok_or(CudaTensorError::DeviceNotInitialized)?;
     let mut cache = cache.lock().map_err(|_err| {
@@ -200,38 +212,40 @@ pub fn pre_warm_lora_backward_kernels(
     // Tile size must match BACKWARD_TILE_SIZE in gemm.rs (C-TILE-BWD-007)
     let tile: u32 = 16;
 
-    // ── LoRA backward shapes (always needed) ──
-    // gemm_backward_b: weight gradients
-    warm!(
-        format!("gemm_backward_b_{s}_{r}_{qd}"),
-        GemmBackwardBKernel::tiled_unrolled(s, r, qd, tile)
-    );
-    if kv != qd {
+    // ── LoRA backward shapes (LoRA training only) ──
+    if is_lora {
+        // gemm_backward_b: weight gradients
         warm!(
-            format!("gemm_backward_b_{s}_{r}_{kv}"),
-            GemmBackwardBKernel::tiled_unrolled(s, r, kv, tile)
+            format!("gemm_backward_b_{s}_{r}_{qd}"),
+            GemmBackwardBKernel::tiled_unrolled(s, r, qd, tile)
         );
-    }
-    warm!(
-        format!("gemm_backward_b_{s}_{h}_{r}"),
-        GemmBackwardBKernel::tiled_unrolled(s, h, r, tile)
-    );
+        if kv != qd {
+            warm!(
+                format!("gemm_backward_b_{s}_{r}_{kv}"),
+                GemmBackwardBKernel::tiled_unrolled(s, r, kv, tile)
+            );
+        }
+        warm!(
+            format!("gemm_backward_b_{s}_{h}_{r}"),
+            GemmBackwardBKernel::tiled_unrolled(s, h, r, tile)
+        );
 
-    // gemm_backward_a: input gradients
-    warm!(
-        format!("gemm_backward_a_{s}_{qd}_{r}"),
-        GemmBackwardAKernel::tiled_unrolled(s, qd, r, tile)
-    );
-    if kv != qd {
+        // gemm_backward_a: input gradients
         warm!(
-            format!("gemm_backward_a_{s}_{kv}_{r}"),
-            GemmBackwardAKernel::tiled_unrolled(s, kv, r, tile)
+            format!("gemm_backward_a_{s}_{qd}_{r}"),
+            GemmBackwardAKernel::tiled_unrolled(s, qd, r, tile)
+        );
+        if kv != qd {
+            warm!(
+                format!("gemm_backward_a_{s}_{kv}_{r}"),
+                GemmBackwardAKernel::tiled_unrolled(s, kv, r, tile)
+            );
+        }
+        warm!(
+            format!("gemm_backward_a_{s}_{r}_{h}"),
+            GemmBackwardAKernel::tiled_unrolled(s, r, h, tile)
         );
     }
-    warm!(
-        format!("gemm_backward_a_{s}_{r}_{h}"),
-        GemmBackwardAKernel::tiled_unrolled(s, r, h, tile)
-    );
 
     // ── Full fp32 backward shapes (non-NF4 mode) ──
     if !quantize_nf4 {


### PR DESCRIPTION
## Summary

Phase 3 dispatch v8 on gx10 reached the training loop and the first backward step started **JIT-compiling backward kernels on demand mid-training**, then failed with:

```
forward_backward_with_grad returned None (CUDA stream poisoned or gradient shape mismatch)
```

This is the documented Blackwell sm_121 bug (trueno#200, CLAUDE.md "Backward kernels: Crash because they compile on-demand when GPU is already active").

## Root cause

`pre_warm_lora_backward_kernels` had a short-circuit:

```rust
if lora_rank == 0 {
    eprintln!("[BWD-PREWARM] Skipping (lora_rank=0)");
    return Ok(());
}
```

The function name implies LoRA-only, but its BODY contains pre-warms for `silu_backward`, `batched_softmax_backward`, and `batched_rms_norm_backward` — which distillation training also needs. The early-out left those to JIT during training, exactly when Blackwell can't.

## Fix

Restructure — only LoRA-specific GEMM-backward warm-ups are gated on `lora_rank > 0`. Activation/norm/standard-FP32-GEMM backward kernels always pre-warm.

## Test plan

- [x] `cargo check --features cuda` clean build
- [x] 18 cuda_backward lib tests pass
- [ ] Live gx10 dispatch reaches stepping (post-merge)

## Defect cascade so far

Stage 4 of the Phase 3 cuda dispatch cascade:

| Stage | PR | What |
|-------|----|----|
| 1 | #1804 PMAT-700-B | Skip PTX GEMM pre-warm when cuBLAS active (JIT cache pressure) |
| 2 | #1808 PMAT-698e | Cap max_seq_len at 2048 (workspace sizing) |
| 3 | #1809 PMAT-698f | Accept APR magic in load_safetensors_weights (format compat) |
| **4** | **THIS** PMAT-698g | Pre-warm non-LoRA backward kernels (stream poisoning) |

Each surfaced the next defect once unblocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)