### PR TITLE
fix(distill): pre-warm rms_norm_gamma_reduce too (PMAT-698h)

### DIFF
--- a/crates/aprender-train/src/autograd/cuda_backward/cache.rs
+++ b/crates/aprender-train/src/autograd/cuda_backward/cache.rs
@@ -162,7 +162,7 @@ pub fn pre_warm_lora_backward_kernels(
 ) -> Result<()> {
     use trueno_gpu::kernels::backward::{
         BatchedRmsNormBackwardKernel, BatchedSoftmaxBackwardKernel, GemmBackwardAKernel,
-        GemmBackwardBKernel, SiluBackwardKernel,
+        GemmBackwardBKernel, RmsNormGammaReduceKernel, SiluBackwardKernel,
     };
     use trueno_gpu::kernels::Kernel;
 
@@ -303,6 +303,21 @@ pub fn pre_warm_lora_backward_kernels(
     // RMSNorm backward (dimension-independent)
     let eps = 1e-5_f32;
     warm!("batched_rms_norm_backward".to_string(), BatchedRmsNormBackwardKernel::new(s, h, eps));
+
+    // PMAT-698h: RMSNorm backward is TWO stages — `batched_rms_norm_backward`
+    // produces a [batch_size, hidden] gamma-partial buffer, then
+    // `rms_norm_gamma_reduce` (in structured.rs:247) sums it row-by-row in
+    // deterministic fixed order to produce the final [hidden] gamma
+    // gradient. The reduce kernel was previously JIT'd on first call —
+    // discovered in Phase 3 dispatch v9 where every other backward kernel
+    // was pre-warmed but gamma_reduce still hit on-demand JIT and the
+    // sm_121 stream poisoned during it. Now: always pre-warm with the
+    // same (batch_size=max_seq_len, hidden_size) dims that structured.rs
+    // constructs at call time.
+    warm!(
+        "rms_norm_gamma_reduce".to_string(),
+        RmsNormGammaReduceKernel::new(s, h)
+    );
 
     let _ = count;
     Ok(())


### PR DESCRIPTION
## Summary

Phase 3 dispatch v9 (with PMAT-698g landed) still failed with the same `forward_backward_with_grad returned None` error. Cause: **RMSNorm backward is two kernels**, only one was pre-warmed.

| Stage | Kernel | PMAT-698g | PMAT-698h |
|-------|--------|-----------|-----------|
| 1 | `batched_rms_norm_backward` (compute per-row gamma partials) | ✓ pre-warmed | ✓ pre-warmed |
| 2 | `rms_norm_gamma_reduce` (deterministic fixed-order sum of partials) | ✗ JIT'd | ✓ pre-warmed |

`structured.rs:247` calls `rms_norm_gamma_reduce` immediately after Stage 1 to fold the per-row gamma partials into a single `[hidden]` gradient. The reduce was missing from my PMAT-698g pre-warm list, so it JIT'd during the first backward step → sm_121 stream poisoning.

## Fix

Add `RmsNormGammaReduceKernel::new(max_seq_len, hidden)` to the backward pre-warm. Matches the `(batch_size, hidden_size)` dims that structured.rs constructs at call time.

## Test plan

- [x] `cargo check --features cuda` — clean build
- [x] 18 cuda_backward lib tests pass
- [ ] Live gx10 dispatch reaches stepping (post-merge)

## Defect cascade — stage 5

| # | PR | What |
|---|----|----|
| 1 | #1804 PMAT-700-B | Skip PTX GEMM pre-warm (JIT cache pressure) |
| 2 | #1808 PMAT-698e | Cap max_seq_len at 2048 (workspace sizing) |
| 3 | #1809 PMAT-698f | Accept APR magic in weights loader |
| 4 | #1810 PMAT-698g | Pre-warm non-LoRA backward kernels |
| **5** | **THIS** PMAT-698h | Pre-warm rms_norm_gamma_reduce |

Each surfaced the next defect once unblocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)