### PR TITLE
fix(#1789): make AprServeDriver max_tokens cap env-configurable

### DIFF
--- a/crates/aprender-orchestrate/src/agent/driver/apr_serve.rs
+++ b/crates/aprender-orchestrate/src/agent/driver/apr_serve.rs
@@ -281,7 +281,16 @@ impl AprServeDriver {
         // - File edit content (multi-line diffs)
         // - Explanation text alongside tool calls
         // Previous 512 cap truncated complex edits mid-output.
-        let max_tokens = request.max_tokens.min(1024);
+        //
+        // aprender#1789 follow-up: env-var override for large MoE models
+        // without KV cache. At ~0.5 tok/s (30B-MoE-no-KV), 1024 tokens
+        // takes ~34 min — exceeds reasonable per-turn budgets. Allow the
+        // operator (or bench harness) to dial down for slow models.
+        let max_tokens_cap = std::env::var("APR_AGENT_MAX_TOKENS_CAP")
+            .ok()
+            .and_then(|v| v.parse::<u32>().ok())
+            .unwrap_or(1024);
+        let max_tokens = request.max_tokens.min(max_tokens_cap);
 
         serde_json::json!({
             "model": self.model_name,


### PR DESCRIPTION
## Summary

Third in the aprender#1789 follow-up series. PMAT-170's hardcoded 1024-token cap in `AprServeDriver::build_openai_body` is reasonable for small/fast models but excessive for large MoE models without KV cache.

## Empirical context

Phase 6 bench against Qwen3-Coder-30B-A3B-Instruct-Q4_K_M (post-#1812):
- Smoke test: ~0.5 tok/s sustained
- 1024 tokens at 0.5 tok/s = ~34 min wall per turn
- Bench's per-turn-timeout budget is 900s default, 2000s configured
- Result: every fixture hits driver_error (exit 124, timeout SIGTERM)

The HTTP timeout knob from #1812 isn't enough — the bottleneck is generation length, not HTTP wait.

## Fix

Same env-var pattern as `APR_AGENT_HTTP_TIMEOUT_S` (#1812). New `APR_AGENT_MAX_TOKENS_CAP` env var; default unchanged at 1024 (no regression for existing flows). Phase 6 bench uses `APR_AGENT_MAX_TOKENS_CAP=128` to fit per-turn budget.

## Test plan

- [x] `cargo check -p aprender-orchestrate` — clean
- [ ] CI (sovereign-ci full workflow)
- [ ] Phase 6 30B-MoE bench: non-driver_error student outcomes (oracle_passed, oracle_failed_after_max_turns, or oracle_failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)