### PR TITLE
diag(distill): per-kernel JIT logging in forward cache (PMAT-698i)

### DIFF
--- a/crates/aprender-train/src/autograd/cuda_forward/cache.rs
+++ b/crates/aprender-train/src/autograd/cuda_forward/cache.rs
@@ -123,6 +123,10 @@ impl ForwardKernelCache {
         match self.modules.entry(name.to_string()) {
             Entry::Occupied(e) => Ok(e.into_mut()),
             Entry::Vacant(e) => {
+                // PMAT-698i: diagnostic logging. Surfaces every forward-cache
+                // JIT event with its kernel name so missing pre-warm entries
+                // are identifiable in O(1) instead of O(N) iterations.
+                eprintln!("[FWD-CACHE] Compiling '{name}' (ptx_len={})", ptx.len());
                 // trueno#200: Use from_ptx_direct on Blackwell
                 let (major, _) = self.ctx.compute_capability().map_err(|e| {
                     CudaTensorError::KernelError(format!("compute_capability: {e:?}"))
@@ -135,6 +139,7 @@ impl ForwardKernelCache {
                 .map_err(|err| {
                     CudaTensorError::KernelError(format!("Failed to compile {name}: {err:?}"))
                 })?;
+                eprintln!("[FWD-CACHE] OK '{name}'");
                 Ok(e.insert(module))
             }
         }


### PR DESCRIPTION
## Summary

The Phase 3 cuda dispatch defect cascade (PMAT-698e..h) has been chasing missing pre-warm entries **ONE KERNEL AT A TIME** by inferring kernel names from CUDA error messages. After 5 iterations:

| Iter | PR | Kernel discovered | Result |
|------|----|-------------------|--------|
| 1 | #1808 PMAT-698e | (workspace cap, not a kernel) | unblocks load |
| 2 | #1809 PMAT-698f | (format compat, not a kernel) | unblocks pipeline |
| 3 | #1810 PMAT-698g | silu_backward, softmax_backward, rms_norm_backward | unblocks 3 backwards |
| 4 | #1813 PMAT-698h | rms_norm_gamma_reduce | unblocks 1 more |
| 5 | ❓ | Still 4 GH-480 patches post-pre-warm with NO kernel name in log | unknown |

This diagnostic PR adds `eprintln` to `ForwardKernelCache::get_or_compile` so every forward JIT event prints its kernel key. After one dispatch we get the full list in one pass.

Mirrors the existing `[BWD-CACHE]` log on the backward path.

## Sample expected output (post-merge dispatch)

```
[CUDA] Pre-warmed 23 forward kernels (JIT compiled before block upload)
...
✓ 24 transformer blocks uploaded to GPU
[FWD-CACHE] Compiling 'batched_rope_neox_forward_896' (ptx_len=4231)
[FWD-CACHE] OK 'batched_rope_neox_forward_896'
[FWD-CACHE] Compiling 'bf16_to_f32_cast' (ptx_len=1108)
...
```

Then PMAT-698j adds those kernel names to `pre_warm_for_model`.

## Test plan

- [x] `cargo check --features cuda` clean build
- [ ] Live gx10 dispatch logs every forward JIT event (post-merge)
- [ ] Each kernel name becomes a one-line addition to `pre_warm_for_model`

## Defect cascade — stage 6 (DIAGNOSTIC)

| # | PR | What |
|---|----|----|
| 1 | #1804 PMAT-700-B | Skip PTX GEMM pre-warm (JIT cache pressure) |
| 2 | #1808 PMAT-698e | Cap max_seq_len at 2048 |
| 3 | #1809 PMAT-698f | Accept APR magic in weights loader |
| 4 | #1810 PMAT-698g | Pre-warm non-LoRA backward kernels |
| 5 | #1813 PMAT-698h | Pre-warm rms_norm_gamma_reduce |
| **6** | **THIS** PMAT-698i | **Diagnostic: log every forward JIT** |
| 7 | (next) PMAT-698j | Consolidated pre-warm sweep from diagnostic output |

🤖 Generated with [Claude Code](https://claude.com/claude-code)