### PR TITLE
fix(distill): pre-warm rmsnorm at both 1e-6 (Qwen2) and 1e-5 (Llama) eps (PMAT-698n)

### DIFF
--- a/crates/aprender-train/src/autograd/cuda_forward/cache.rs
+++ b/crates/aprender-train/src/autograd/cuda_forward/cache.rs
@@ -212,16 +212,27 @@ impl ForwardKernelCache {
         // suffix (normalization.rs:139:
         //   let key = format!("batched_rmsnorm_fwd_{hidden_size}_eps{eps_bits:08x}"))
         // Pre-warm key used to omit the eps suffix → cache miss at runtime →
-        // JIT mid-forward → Blackwell sm_121 stream poisoning. Default eps
-        // for Qwen2 is 1e-6 (RMSNorm default) but the active config may vary
-        // per model. Use the standard 1e-5 default; runtime models with
-        // different eps will still cache-miss for their specific suffix but
-        // the dominant case is covered.
-        let default_eps_bits = 1.0e-5_f32.to_bits();
+        // JIT mid-forward → Blackwell sm_121 stream poisoning.
+        //
+        // PMAT-698n: PMAT-698k pre-warmed at eps=1e-5 (0x3727c5ac) but the
+        // dominant model (Qwen2 / Qwen2.5) uses rms_norm_eps=1e-6
+        // (0x358637bd). Live diagnostic confirmed the runtime key on the
+        // Phase 3 dispatch was `batched_rmsnorm_fwd_896_eps358637bd`. Switch
+        // the pre-warm default to 1e-6 (Qwen2 standard) AND additionally
+        // pre-warm 1e-5 (Llama/Mistral standard) for cross-family coverage.
+        // The cost of pre-warming both is ~30 KB of cache headroom.
+        let qwen2_eps_bits = 1.0e-6_f32.to_bits(); // 0x358637bd
+        let llama_eps_bits = 1.0e-5_f32.to_bits(); // 0x3727c5ac
         warm!(
-            format!("batched_rmsnorm_fwd_{h}_eps{default_eps_bits:08x}"),
+            format!("batched_rmsnorm_fwd_{h}_eps{qwen2_eps_bits:08x}"),
             BatchedVectorizedRmsNormKernel::new(h, 1)
         );
+        if qwen2_eps_bits != llama_eps_bits {
+            warm!(
+                format!("batched_rmsnorm_fwd_{h}_eps{llama_eps_bits:08x}"),
+                BatchedVectorizedRmsNormKernel::new(h, 1)
+            );
+        }
 
         // PMAT-700 (SPEC-BLACKWELL-FIX-001 Fix #2): when cuBLAS is available
         // and the runtime takes its fast path for the standard 2D GEMMs


### PR DESCRIPTION
## Summary

PMAT-698k added the `_eps{:08x}` suffix to the rmsnorm pre-warm key but used the wrong default value:

- Pre-warm: `1.0e-5_f32.to_bits() = 0x3727c5ac` (Llama/Mistral default)
- Runtime (Qwen2.5-Coder-0.5B): `rms_norm_eps = 1e-6 = 0x358637bd`

Different bits → different cache key → still cache-misses on Qwen2 family. Live Phase 3 dispatch v11 confirmed `batched_rmsnorm_fwd_896_eps358637bd` still JIT'd.

## Fix

Pre-warm BOTH eps values. Cost: ~30 KB extra cache. Benefit: zero rmsnorm cache misses for either Qwen2 family OR Llama family without per-model dispatch logic.

## Test plan

- [x] `cargo check --features cuda` clean
- [ ] Live gx10 dispatch: zero `[FWD-CACHE] Compiling` events for `batched_rmsnorm_fwd_*`

## Cascade stage 10

Final forward-cache JIT hygiene fix. Phase 3 pipeline already works end-to-end (#1817 PMAT-698j unblocked it); this just eliminates the last cache miss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)