### PR TITLE
fix(distill): scale smoke batch to seq_len=256 (PMAT-698o, Phase 4-prep stage A)

### DIFF
--- a/crates/aprender-train-distill/src/pipeline.rs
+++ b/crates/aprender-train-distill/src/pipeline.rs
@@ -233,8 +233,28 @@ impl<'a> Pipeline<'a> {
         // For real distillation with a real dataset, the caller would
         // override the pipeline's batch construction entirely; this default
         // exists for the smoke + fixture-path tests.
+        //
+        // PMAT-698o: scale the synthetic batch from seq_len=1 (Phase 3
+        // smoke) to seq_len=APR_DISTILL_SMOKE_SEQ_LEN (default 256) so the
+        // smoke exercises the same memory/kernel paths that Phase 4 real
+        // training will use. The student observes a row of `seq_len` copies
+        // of the same token and is asked to predict that token — still
+        // trivially learnable (identity from a constant signal), but now
+        // touches the attention scores tensor, batched 4D GEMMs, and rope
+        // forward at non-singleton sequence dimensions. Catches latent
+        // bugs that only surface at seq > 1 before we commit Phase 4
+        // compute.
+        //
+        // Override via env: APR_DISTILL_SMOKE_SEQ_LEN=N.
+        // Fixture tests are unaffected by the longer sequence — the
+        // FixtureStudent ignores input shape and emits argmax-on-label
+        // logits regardless of seq_len.
+        let smoke_seq_len: usize = std::env::var("APR_DISTILL_SMOKE_SEQ_LEN")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(256);
         let dummy_batch: Vec<Vec<u32>> = (0..batch_size)
-            .map(|i| vec![(i % num_classes) as u32])
+            .map(|i| vec![(i % num_classes) as u32; smoke_seq_len])
             .collect();
         let labels: Vec<usize> = (0..batch_size).map(|i| i % num_classes).collect();
 


### PR DESCRIPTION
## Stage A of Phase 4 ladder

Phase 3 smoke ran at seq_len=1 (single-token rows). Phase 4 will run at seq_len 256-512 with real corpus. Scaling the synthetic smoke now catches seq-dependent latent bugs **cheaply** (~5 min compute) before Phase 4 commits 28h of GB10 time.

## What seq_len > 1 exercises

| Code path | seq_len=1 hits? | seq_len=256 hits? |
|-----------|------------------|---------------------|
| Attention scores tensor | trivial (1×1) | full (256×256 per head) |
| Batched 4D GEMM at non-singleton k | no | yes |
| RoPE forward at non-singleton seq | no | yes |
| Softmax over multi-element row | no | yes |
| Backward kernels at non-singleton seq | no | yes |

## Implementation

Env-overridable (`APR_DISTILL_SMOKE_SEQ_LEN`, default 256). Each row carries `seq_len` copies of the same token — task remains trivially learnable (identity from constant input), but touches the full forward kernel surface.

## Test plan

- [x] 58 distill lib tests pass (fixture path unchanged — FixtureStudent ignores input shape)
- [ ] Live gx10 dispatch: F-DISTILL-SMOKE-001 still passes at seq_len=256 with 1.5B → 0.5B

## What this catches

If the dispatch fails post-merge, the failure mode tells us which Phase 4 risk is real:
- OOM at workspace allocation → real memory budget issue
- New JIT events → seq-dependent kernels not pre-warmed
- Numerical divergence → kernel correctness bug at seq > 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)