### PR TITLE
fix(clean_chat_output): strip leading turn-marker prefix at start-of-string

### DIFF
--- a/crates/aprender-serve/src/api/realize_handlers.rs
+++ b/crates/aprender-serve/src/api/realize_handlers.rs
@@ -236,7 +236,20 @@ pub fn clean_chat_output(text: &str) -> String {
         "<|im_start|>",  // Start of new turn in ChatML
     ];
 
-    let mut result = text.to_string();
+    // V1_004 follow-up (paiml/claude-code-parity-apr M291): "\nHuman:" /
+    // "\n\nHuman:" require a preceding newline to match. When a response
+    // starts with "Human:" / "User:" / "Assistant:" with no newline before
+    // it, the truncate-at-earliest loop below misses the marker and the
+    // prefix bleeds into the captured chat reply. Strip leading turn-markers
+    // explicitly first.
+    let trimmed = text.trim_start();
+    const LEADING_PREFIXES: &[&str] = &["Human:", "User:", "Assistant:"];
+    let stripped: &str = LEADING_PREFIXES
+        .iter()
+        .find_map(|p| trimmed.strip_prefix(p))
+        .unwrap_or(trimmed);
+
+    let mut result = stripped.to_string();
 
     // Find the earliest stop sequence and truncate there
     let mut earliest_pos = result.len();

--- a/crates/aprender-serve/src/api/tests/format_chat_02.rs
+++ b/crates/aprender-serve/src/api/tests/format_chat_02.rs
@@ -88,6 +88,63 @@ fn test_clean_chat_output_partial_markers() {
     assert!(!result.contains("extra stuff"));
 }
 
+// V1_004 follow-up (paiml/claude-code-parity-apr M291): the start-of-string
+// "Human:" / "User:" / "Assistant:" prefix gap. Previously, the existing
+// "\nHuman:" stop-sequence required a preceding newline; a response that
+// literally began with "Human: ..." slipped through verbatim. These cases
+// pin the new explicit leading-prefix strip.
+
+#[test]
+fn test_clean_chat_output_leading_human_prefix() {
+    use crate::api::realize_handlers::clean_chat_output;
+    let result = clean_chat_output("Human: Here's what I have so far:\n\nhello");
+    assert!(!result.starts_with("Human:"), "result was: {result:?}");
+    assert!(result.contains("Here's what I have so far"));
+}
+
+#[test]
+fn test_clean_chat_output_leading_user_prefix() {
+    use crate::api::realize_handlers::clean_chat_output;
+    let result = clean_chat_output("User: please explain this code");
+    assert!(!result.starts_with("User:"), "result was: {result:?}");
+    assert!(result.contains("please explain this code"));
+}
+
+#[test]
+fn test_clean_chat_output_leading_assistant_prefix() {
+    use crate::api::realize_handlers::clean_chat_output;
+    let result = clean_chat_output("Assistant: here is my answer");
+    assert!(!result.starts_with("Assistant:"), "result was: {result:?}");
+    assert!(result.contains("here is my answer"));
+}
+
+#[test]
+fn test_clean_chat_output_leading_prefix_with_whitespace() {
+    use crate::api::realize_handlers::clean_chat_output;
+    // Whitespace before the leading prefix should not block the strip.
+    let result = clean_chat_output("  \n\tHuman: body");
+    assert!(!result.starts_with("Human:"), "result was: {result:?}");
+    assert!(result.contains("body"));
+}
+
+#[test]
+fn test_clean_chat_output_inline_human_after_leading_strip() {
+    use crate::api::realize_handlers::clean_chat_output;
+    // Leading "Human:" is stripped; later "\nHuman:" still truncates remainder.
+    let result = clean_chat_output("Human: turn body\nHuman: leak");
+    assert!(!result.contains("leak"), "result was: {result:?}");
+    assert!(result.contains("turn body"));
+}
+
+#[test]
+fn test_clean_chat_output_no_false_positive_on_human_in_middle() {
+    use crate::api::realize_handlers::clean_chat_output;
+    // "Human:" mid-sentence (no leading position, no preceding newline) must
+    // NOT be stripped — the strip is only at start-of-string.
+    let result = clean_chat_output("The word Human: is left alone.");
+    assert!(result.contains("Human:"), "result was: {result:?}");
+}
+
 // ============================================================================
 // B3: HTTP Handler Integration - Realize Endpoints
 // ============================================================================


### PR DESCRIPTION
## Summary

- Strip leading "Human:" / "User:" / "Assistant:" prefix at start-of-string before the existing stop-sequence pass in `clean_chat_output`.
- Closes the start-of-string corner case where existing `\nHuman:` / `\n\nHuman:` stop sequences require a preceding newline.
- 6 new pin tests in `api::tests::format_chat_02` covering: leading Human / User / Assistant, leading whitespace, inline post-leading-strip stop, no-false-positive on mid-sentence "Human:".

## Why

Empirically observed at paiml/claude-code-parity-apr Phase 6 sub-bench B (M291) on Qwen3-Coder-30B-A3B: model began turns 1-20 with "Human: ..." which slipped through the cleaner verbatim. The new stop_token + EOS plumbing in #1852 stops generation at `<|im_end|>`, but if the model emitted "Human:" *before* the EOS, the prefix stayed.

Fix preserves mid-sentence "Human:" (only stripped at start-of-string) and still fires existing `\nHuman:` truncation for embedded turn-boundary leaks.

## Test plan

- [x] `cargo test -p aprender-serve --lib clean_chat_output_leading` — 4 new leading-prefix tests pass
- [x] `cargo test -p aprender-serve --lib test_clean_chat_output_inline_human_after_leading_strip` — combined leading-strip + inline-stop case
- [x] `cargo test -p aprender-serve --lib test_clean_chat_output_no_false_positive_on_human_in_middle` — mid-sentence "Human:" preserved
- [x] No regression in 95+ existing `clean_chat_output*` tests

## Cross-references

- paiml/claude-code-parity-apr M291 V1_004 follow-up snapshot
- aprender#1852 (EOS stop_token + clean_chat_output wire-up in MoE chat path)
- aprender#1849 (few-shot prompt examples)

Refs: CCPA M291.

🤖 Generated with [Claude Code](https://claude.com/claude-code)