### PR TITLE
feat: qwen3-moe streaming SSE impl (qwen3-moe-streaming-sse-v1 V1_001+V1_003)

### DIFF
--- a/crates/aprender-serve/src/api/cuda_chat_backend.rs
+++ b/crates/aprender-serve/src/api/cuda_chat_backend.rs
@@ -750,6 +750,40 @@ fn try_qwen3_moe_backend(
         ..defaults
     };
 
+    // qwen3-moe-streaming-sse-v1: per-token SSE when stream=true.
+    // Dispatches to the callback variant + builds an SSE response from
+    // a tokio mpsc channel. Non-streaming path falls through below.
+    if request.stream {
+        let (tx, rx) = tokio::sync::mpsc::channel::<Result<u32, String>>(64);
+        let mapped_clone = mapped.clone();
+        let quantized_clone = quantized.clone();
+        let input_ids_clone = input_ids.clone();
+        let gen_config_clone = gen_config.clone();
+
+        tokio::task::spawn_blocking(move || {
+            let result = crate::infer::qwen3_moe_generate::run_qwen3_moe_generate_streaming(
+                &mapped_clone,
+                &quantized_clone,
+                &input_ids_clone,
+                &gen_config_clone,
+                |token_id| tx.blocking_send(Ok(token_id)).is_ok(),
+            );
+            if let Err(e) = result {
+                let _ = tx.blocking_send(Err(e.to_string()));
+            }
+        });
+
+        return Some(crate::api::openai_handlers::true_streaming_sse_response(
+            rx,
+            tokenizer,
+            request_id.to_string(),
+            request.model.clone(),
+            state.metrics.clone(),
+            start,
+            true,
+        ));
+    }
+
     let tokens = match crate::infer::qwen3_moe_generate::run_qwen3_moe_generate(
         &mapped,
         &quantized,

--- a/crates/aprender-serve/src/api/openai_handlers.rs
+++ b/crates/aprender-serve/src/api/openai_handlers.rs
@@ -208,7 +208,7 @@ fn pregenerated_sse_response(
 /// Build a true-streaming SSE response with keep-alive (tokens arrive via channel).
 // serde_json::json!() uses infallible unwrap
 #[allow(clippy::disallowed_methods)]
-fn true_streaming_sse_response(
+pub(crate) fn true_streaming_sse_response(
     rx: tokio::sync::mpsc::Receiver<Result<u32, String>>,
     tokenizer: Arc<BPETokenizer>,
     request_id: String,

--- a/crates/aprender-serve/src/infer/qwen3_moe_generate.rs
+++ b/crates/aprender-serve/src/infer/qwen3_moe_generate.rs
@@ -297,6 +297,141 @@ pub fn run_qwen3_moe_generate(
     Ok(tokens)
 }
 
+/// Streaming variant of `run_qwen3_moe_generate` — discharges
+/// `qwen3-moe-streaming-sse-v1.yaml` per-token emit requirement.
+///
+/// Mirrors `run_qwen3_moe_generate` step-for-step, but invokes
+/// `on_token(next_token)` after each decode step. The callback returns
+/// `bool` — `false` short-circuits the loop (e.g. client disconnect).
+///
+/// Stop tokens and max-context guards are honored identically to the
+/// non-streaming variant. The callback fires for every appended token
+/// (including the one that triggered the stop, if any) before the loop
+/// exits — matching the dense path's streaming semantics.
+pub fn run_qwen3_moe_generate_streaming(
+    mapped: &MappedGGUFModel,
+    model: &OwnedQuantizedModel,
+    input_tokens: &[u32],
+    gen_config: &QuantizedGenerateConfig,
+    mut on_token: impl FnMut(u32) -> bool,
+) -> Result<()> {
+    if input_tokens.is_empty() {
+        return Err(RealizarError::InvalidShape {
+            reason: "run_qwen3_moe_generate_streaming: prompt cannot be empty".to_string(),
+        });
+    }
+
+    let canonical_arch = crate::tensor_names::normalize_architecture(&model.config().architecture);
+    if canonical_arch != "qwen3_moe" {
+        return Err(RealizarError::InvalidShape {
+            reason: format!(
+                "run_qwen3_moe_generate_streaming: arch '{}' (canonical '{}') is not qwen3_moe",
+                model.config().architecture,
+                canonical_arch
+            ),
+        });
+    }
+
+    let num_experts = mapped
+        .model
+        .expert_count()
+        .ok_or_else(|| RealizarError::InvalidShape {
+            reason: format!(
+                "run_qwen3_moe_generate_streaming: missing '{}.expert_count'",
+                model.config().architecture
+            ),
+        })?;
+    let num_experts_per_tok =
+        mapped
+            .model
+            .expert_used_count()
+            .ok_or_else(|| RealizarError::InvalidShape {
+                reason: format!(
+                    "run_qwen3_moe_generate_streaming: missing '{}.expert_used_count'",
+                    model.config().architecture
+                ),
+            })?;
+    let moe_intermediate =
+        mapped
+            .model
+            .expert_feed_forward_length()
+            .ok_or_else(|| RealizarError::InvalidShape {
+                reason: format!(
+                    "run_qwen3_moe_generate_streaming: missing '{}.expert_feed_forward_length'",
+                    model.config().architecture
+                ),
+            })?;
+
+    let data = mapped.data();
+    let num_layers = model.config().num_layers;
+    let mut moe_layers = Vec::with_capacity(num_layers);
+    for layer_idx in 0..num_layers {
+        moe_layers.push(load_qwen3_moe_layer(&mapped.model, data, layer_idx)?);
+    }
+
+    let env_ctx = std::env::var("REALIZR_CONTEXT_LENGTH")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(4096);
+    let needed = input_tokens.len() + gen_config.max_tokens + 8;
+    let max_seq_len = env_ctx.max(needed);
+    let mut cache = OwnedQuantizedKVCache::from_config(model.config(), max_seq_len);
+    let mut rng = StdRng::seed_from_u64(gen_config.seed);
+
+    let mut tokens = input_tokens.to_vec();
+    let mut last_logits = Vec::new();
+    for (pos, &tok) in input_tokens.iter().enumerate() {
+        last_logits = model.forward_single_qwen3_moe_with_cache(
+            tok,
+            &mut cache,
+            pos,
+            &moe_layers,
+            num_experts,
+            num_experts_per_tok,
+            moe_intermediate,
+            data,
+        )?;
+    }
+    if last_logits.is_empty() {
+        return Err(RealizarError::InvalidShape {
+            reason: "run_qwen3_moe_generate_streaming: prefill produced no logits".to_string(),
+        });
+    }
+
+    for _step in 0..gen_config.max_tokens {
+        let next_token = sample_from_logits(&last_logits, gen_config, &mut rng, &tokens)?;
+        tokens.push(next_token);
+
+        // Emit BEFORE checking stop conditions so the client sees every
+        // sampled token (matches dense path streaming semantics).
+        if !on_token(next_token) {
+            // Callback signaled stop (e.g. client disconnect).
+            return Ok(());
+        }
+
+        if gen_config.stop_tokens.contains(&next_token) {
+            break;
+        }
+        if tokens.len() >= max_seq_len {
+            break;
+        }
+
+        let pos = tokens.len() - 1;
+        last_logits = model.forward_single_qwen3_moe_with_cache(
+            next_token,
+            &mut cache,
+            pos,
+            &moe_layers,
+            num_experts,
+            num_experts_per_tok,
+            moe_intermediate,
+            data,
+        )?;
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod sample_from_logits_tests {
     //! Unit tests for the `qwen3-moe-sampling-v1.yaml` falsifiers

--- a/crates/aprender-serve/tests/qwen3_moe_streaming_sse_v1.rs
+++ b/crates/aprender-serve/tests/qwen3_moe_streaming_sse_v1.rs
@@ -1,0 +1,175 @@
+//! V1_001 + V1_003 falsification tests for qwen3-moe-streaming-sse-v1.yaml.
+//!
+//! Validates the per-token callback contract that backs the HTTP SSE
+//! streaming path. The HTTP envelope is exercised through the dense
+//! path's `true_streaming_sse_response` (proven by the existing dense
+//! streaming tests); this file asserts the qwen3_moe-specific callback
+//! invariants.
+//!
+//! ## Discharges
+//! - **FALSIFY-V1_001**: callback fires per-token (one call per
+//!   generated token, in emission order, BEFORE the loop body returns).
+//! - **FALSIFY-V1_003**: streaming throughput bounded below by M32d
+//!   per-token cost (median inter-callback latency < 500ms).
+//!
+//! FALSIFY-V1_002 (`stream=false` regression) is already covered by
+//! `qwen3_moe_serve_dispatch_v1.rs`.
+//!
+//! ## Gating
+//!
+//! `#[ignore]` by default. Activated by:
+//!
+//! ```text
+//! QWEN3_MOE_GGUF_PATH=/path/to/qwen3-moe.gguf \
+//!   cargo test --test qwen3_moe_streaming_sse_v1 \
+//!   -p aprender-serve --features cuda --release -- --ignored --nocapture
+//! ```
+
+use realizar::gguf::{MappedGGUFModel, OwnedQuantizedModel, QuantizedGenerateConfig};
+use realizar::infer::qwen3_moe_generate::{
+    run_qwen3_moe_generate, run_qwen3_moe_generate_streaming,
+};
+use std::time::Instant;
+
+fn gguf_path() -> Option<String> {
+    std::env::var("QWEN3_MOE_GGUF_PATH").ok()
+}
+
+fn fixture_setup() -> Option<(MappedGGUFModel, OwnedQuantizedModel)> {
+    let path = gguf_path()?;
+    let mapped = MappedGGUFModel::from_path(&path)
+        .unwrap_or_else(|e| panic!("Failed to mmap GGUF at {path}: {e}"));
+    let model =
+        OwnedQuantizedModel::from_mapped(&mapped).expect("OwnedQuantizedModel::from_mapped");
+    Some((mapped, model))
+}
+
+const PROMPT: &[u32] = &[9707, 198]; // "Hello\n"
+const MAX_TOKENS: usize = 8;
+
+fn greedy_config() -> QuantizedGenerateConfig {
+    QuantizedGenerateConfig {
+        max_tokens: MAX_TOKENS,
+        temperature: 0.0, // greedy for parity check
+        top_k: 1,
+        seed: 42,
+        stop_tokens: Vec::new(),
+        ..QuantizedGenerateConfig::default()
+    }
+}
+
+/// V1_001: streaming callback fires once per generated token, in
+/// emission order, and the captured tokens equal the non-streaming
+/// output. Discharges "per_token_emit" equation.
+#[test]
+#[ignore]
+fn v1_001_callback_fires_per_token() {
+    let Some((mapped, model)) = fixture_setup() else {
+        eprintln!("SKIP: QWEN3_MOE_GGUF_PATH not set");
+        return;
+    };
+
+    // Run non-streaming once to establish the expected token sequence.
+    let cfg = greedy_config();
+    let expected = run_qwen3_moe_generate(&mapped, &model, PROMPT, &cfg)
+        .expect("run_qwen3_moe_generate (baseline)");
+    let expected_generated: Vec<u32> = expected[PROMPT.len()..].to_vec();
+    assert!(
+        !expected_generated.is_empty(),
+        "baseline produced no tokens — fixture broken"
+    );
+
+    // Run streaming and collect tokens via callback.
+    let mut streamed: Vec<u32> = Vec::new();
+    run_qwen3_moe_generate_streaming(&mapped, &model, PROMPT, &cfg, |t| {
+        streamed.push(t);
+        true
+    })
+    .expect("run_qwen3_moe_generate_streaming");
+
+    assert_eq!(
+        streamed, expected_generated,
+        "streaming tokens diverged from non-streaming baseline (greedy, same seed)"
+    );
+}
+
+/// V1_003: median inter-callback latency < 500ms (corresponds to ≥
+/// 2 tok/s streamed; conservative floor below M32d's ~5 tok/s).
+/// Discharges "Streaming throughput is bounded below by M32d's
+/// per-token cost".
+#[test]
+#[ignore]
+fn v1_003_inter_token_latency_floor() {
+    let Some((mapped, model)) = fixture_setup() else {
+        eprintln!("SKIP: QWEN3_MOE_GGUF_PATH not set");
+        return;
+    };
+
+    let cfg = QuantizedGenerateConfig {
+        max_tokens: 32,
+        temperature: 0.0,
+        top_k: 1,
+        seed: 0,
+        stop_tokens: Vec::new(),
+        ..QuantizedGenerateConfig::default()
+    };
+
+    let mut timestamps: Vec<Instant> = Vec::new();
+    run_qwen3_moe_generate_streaming(&mapped, &model, PROMPT, &cfg, |_t| {
+        timestamps.push(Instant::now());
+        true
+    })
+    .expect("run_qwen3_moe_generate_streaming");
+
+    assert!(
+        timestamps.len() >= 4,
+        "expected ≥4 callback invocations for inter-token measurement, got {}",
+        timestamps.len()
+    );
+
+    // Compute inter-callback gaps (skip first — includes prefill).
+    let mut gaps_ms: Vec<u64> = timestamps
+        .windows(2)
+        .map(|w| (w[1] - w[0]).as_millis() as u64)
+        .collect();
+    gaps_ms.sort_unstable();
+    let median = gaps_ms[gaps_ms.len() / 2];
+
+    eprintln!(
+        "V1_003: {} callbacks, median inter-token gap = {} ms, gaps = {:?}",
+        timestamps.len(),
+        median,
+        gaps_ms
+    );
+
+    assert!(
+        median < 500,
+        "median inter-token gap {} ms exceeds 500ms floor — streaming throughput regression",
+        median
+    );
+}
+
+/// Negative path: callback returning `false` short-circuits the decode
+/// loop. Asserts the disconnect-handling contract documented in the
+/// streaming function's doc-comment.
+#[test]
+#[ignore]
+fn callback_stop_short_circuits() {
+    let Some((mapped, model)) = fixture_setup() else {
+        eprintln!("SKIP: QWEN3_MOE_GGUF_PATH not set");
+        return;
+    };
+
+    let cfg = greedy_config();
+    let mut count = 0usize;
+    run_qwen3_moe_generate_streaming(&mapped, &model, PROMPT, &cfg, |_t| {
+        count += 1;
+        count < 3 // stop after 3 tokens
+    })
+    .expect("run_qwen3_moe_generate_streaming");
+
+    assert_eq!(
+        count, 3,
+        "callback should have been invoked exactly 3 times before short-circuit"
+    );
+}


### PR DESCRIPTION
## Summary

Discharges [`contracts/qwen3-moe-streaming-sse-v1.yaml`](https://github.com/paiml/aprender/blob/main/contracts/qwen3-moe-streaming-sse-v1.yaml) v1.0.0 (spec landed in #1835).

Post-M32d (#1832), MoE per-token generation amortizes to ~100ms; this PR codifies that \`stream=true\` on a qwen3_moe model emits SSE events per-token instead of buffering the full completion.

## Falsifiers discharged

- **V1_001**: per-token callback fires, captured tokens equal non-streaming greedy baseline
- **V1_003**: median inter-token gap < 500ms (≥2 tok/s floor, well below M32d's ~5 tok/s)
- **V1_002** (\`stream=false\` regression): already covered by \`qwen3_moe_serve_dispatch_v1.rs\`

## Changes

- \`infer/qwen3_moe_generate.rs\`: new \`run_qwen3_moe_generate_streaming\` (callback variant of \`run_qwen3_moe_generate\`). Mirrors the non-streaming function step-for-step but invokes \`on_token(u32) -> bool\` per decoded token. Callback returning \`false\` short-circuits for client disconnect.
- \`api/cuda_chat_backend.rs\`: in \`try_qwen3_moe_backend\`, branch on \`request.stream\` — if true, spin up mpsc channel, run streaming variant on \`spawn_blocking\`, route through dense path's \`true_streaming_sse_response\`.
- \`api/openai_handlers.rs\`: promote \`true_streaming_sse_response\` from \`fn\` → \`pub(crate) fn\` so MoE backend can reuse the same SSE framing.
- \`tests/qwen3_moe_streaming_sse_v1.rs\`: env-gated integration tests (\`QWEN3_MOE_GGUF_PATH\`, \`#[ignore]\`).

## Test plan

- [x] \`cargo check -p aprender-serve --lib\` — clean
- [x] \`cargo test -p aprender-serve --lib qwen3_moe_generate\` — 12/12 pass
- [ ] Operator-dispatched: \`QWEN3_MOE_GGUF_PATH=… cargo test --test qwen3_moe_streaming_sse_v1 -- --ignored --nocapture\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)