### PR TITLE
fix(distill): save trained GPU weights + periodic checkpoints (PMAT-699 P0)

### DIFF
--- a/crates/aprender-train-distill/src/pipeline.rs
+++ b/crates/aprender-train-distill/src/pipeline.rs
@@ -310,6 +310,17 @@ impl<'a> Pipeline<'a> {
         let mut last_batch = initial_batch;
         let mut last_labels = initial_labels;
 
+        // PMAT-699 P0 durability fix: periodic intermediate checkpointing.
+        // Stage D 2026-05-20 ran 25h with ZERO checkpoints — if it had
+        // crashed at step 49999, the full run would be lost. Default 5000
+        // steps; env-overridable via APR_DISTILL_CHECKPOINT_EVERY=N.
+        // Set N=0 to disable (smoke tests).
+        let checkpoint_every: u64 = std::env::var("APR_DISTILL_CHECKPOINT_EVERY")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(5000);
+        let checkpoint_dir = self.config.output.dir.clone();
+
         for _epoch in 0..self.config.training.epochs {
             let steps_this_epoch = (1000 / u64::from(self.config.training.batch_size)).max(1);
 
@@ -344,6 +355,26 @@ impl<'a> Pipeline<'a> {
                 step += 1;
                 last_batch = dummy_batch;
                 last_labels = labels;
+
+                // PMAT-699 P0 durability: periodic checkpoint save.
+                if checkpoint_every > 0 && step % checkpoint_every == 0 {
+                    let ckpt_path =
+                        checkpoint_dir.join(format!("ckpt-step-{step:06}.apr"));
+                    if let Err(e) = self.student.save_checkpoint(&ckpt_path) {
+                        // Don't fail training on checkpoint write error; just
+                        // log loudly. Loss progress is more valuable than
+                        // pristine intermediate snapshots.
+                        eprintln!(
+                            "[PMAT-699] checkpoint save at step {step} failed: \
+                             {e} (training continues)"
+                        );
+                    } else {
+                        eprintln!(
+                            "[PMAT-699] checkpoint saved at step {step}: {}",
+                            ckpt_path.display()
+                        );
+                    }
+                }
             }
         }
 
@@ -403,8 +434,19 @@ impl<'a> Pipeline<'a> {
     }
 
     /// Export trained student model using `save_student_checkpoint`.
+    ///
+    /// PMAT-699 P0: now ALSO calls `self.student.save_checkpoint(...)` after
+    /// the metadata-only safetensors write, so the CudaStudentProvider can
+    /// pull its trained GPU weights back to disk as an APR v2 file in the
+    /// same directory. Without this, the cuda path's 25h of training
+    /// silently produces a 200-byte empty model.safetensors (Stage D
+    /// 2026-05-20 incident).
+    ///
+    /// The fixture path's no-op default `save_checkpoint` preserves the
+    /// existing FixtureStudent behavior — only the safetensors metadata
+    /// sidecar is written, matching pre-PMAT-699 semantics.
     fn export(
-        &self,
+        &mut self,
         weights: &HashMap<String, Vec<f32>>,
         shapes: &HashMap<String, Vec<usize>>,
         metrics: &TrainingMetrics,
@@ -458,6 +500,22 @@ impl<'a> Pipeline<'a> {
                     message: format!("GGUF export failed: {e}"),
                 })?;
         }
+
+        // PMAT-699 P0: ask the student provider to persist its real
+        // weights. FixtureStudent: no-op (default trait impl). CudaStudent:
+        // delegates to trainer.save_apr() and writes an APR file alongside
+        // the metadata sidecar. Without this, the cuda path's trained GPU
+        // weights are never serialized — Stage D 2026-05-20 ran 25h and
+        // produced a 200-byte empty model.safetensors.
+        let apr_target = self.config.output.dir.join("model.apr");
+        self.student.save_checkpoint(&apr_target).map_err(|e| {
+            EntrenarError::Internal {
+                message: format!(
+                    "student.save_checkpoint({}) failed: {e}",
+                    apr_target.display()
+                ),
+            }
+        })?;
 
         Ok(output_path)
     }

--- a/crates/aprender-train-distill/src/student_provider.rs
+++ b/crates/aprender-train-distill/src/student_provider.rs
@@ -75,6 +75,24 @@ pub trait StudentLogitsProvider {
     /// Returns an error if the gradient shape doesn't match or the
     /// optimizer step fails.
     fn apply_kd_gradient(&mut self, gradient: &[Vec<f32>]) -> Result<()>;
+
+    /// PMAT-699 (Phase 4 P0): persist the student's current trained weights
+    /// to disk.
+    ///
+    /// Default implementation is a no-op — appropriate for FixtureStudent
+    /// where the pipeline's export step writes the placeholder
+    /// `student_weights` map directly. CudaStudentProvider MUST override
+    /// to delegate to its trainer's `save_apr` — otherwise 25h of GPU
+    /// training silently produces a 200-byte empty checkpoint
+    /// (Stage D 2026-05-20 incident).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the backend cannot serialize (e.g., GPU
+    /// download fails, disk write fails).
+    fn save_checkpoint(&mut self, _path: &std::path::Path) -> Result<()> {
+        Ok(())
+    }
 }
 
 /// Fixture student for unit testing the orchestration layer.
@@ -289,6 +307,42 @@ mod cuda_backend {
                               returned None (CUDA stream poisoned or gradient \
                               shape mismatch)"
                         .to_string(),
+                })?;
+            Ok(())
+        }
+
+        /// PMAT-699 P0 fix: pull trained weights from GPU and write them
+        /// to the destination directory as an APR v2 checkpoint.
+        ///
+        /// Without this override, pipeline.export() serialized the empty
+        /// student_weights HashMap (PMAT-698f's APR short-circuit returns
+        /// empty), producing a 200-byte placeholder model.safetensors.
+        /// Stage D 2026-05-20 ran 25h of GB10 training and lost all
+        /// weights because of this gap.
+        ///
+        /// Delegates to the trainer's existing save_apr method.
+        fn save_checkpoint(&mut self, path: &std::path::Path) -> Result<()> {
+            // Ensure parent dir exists (trainer.save_apr writes into it).
+            if let Some(parent) = path.parent() {
+                if !parent.as_os_str().is_empty() {
+                    std::fs::create_dir_all(parent).map_err(|e| {
+                        entrenar_common::EntrenarError::Io {
+                            context: format!(
+                                "save_checkpoint mkdir parent {}",
+                                parent.display()
+                            ),
+                            source: e,
+                        }
+                    })?;
+                }
+            }
+            self.trainer
+                .save_apr(path, "albor-distilled-v2", "Qwen2ForCausalLM")
+                .map_err(|e| entrenar_common::EntrenarError::Internal {
+                    message: format!(
+                        "CudaStudentProvider.save_checkpoint: trainer.save_apr({}) failed: {e:?}",
+                        path.display()
+                    ),
                 })?;
             Ok(())
         }


### PR DESCRIPTION
## P0 — Stage D 2026-05-20 produced 200-byte empty checkpoint despite 25h compute

Two P0 defects surfaced by Stage D Phase 4 dispatch: training ran for 25h on Blackwell GB10, final_loss=3.58 (real convergence), but `student-trained.apr/model.safetensors` was a **200-byte empty placeholder**. The trained weights lived only in `CudaStudentProvider`'s GPU memory and are gone now that the process exited.

## Root cause — defect pair

**Defect 1 — empty export:**
`pipeline.export()` serializes the `student_weights` HashMap. PMAT-698f's APR short-circuit (correct on the read side) returns empty maps. The write side then ships nothing.

**Defect 2 — zero intermediate checkpoints:**
A 25h run with no periodic saves. A crash at step 49999 would have had identical outcome to what we observed.

## Fix

1. **New trait method** `StudentLogitsProvider::save_checkpoint(&mut self, path: &Path) -> Result<()>` with no-op default (preserves `FixtureStudent` behavior).

2. **`CudaStudentProvider::save_checkpoint(path)`** delegates to `trainer.save_apr(path, "albor-distilled-v2", "Qwen2ForCausalLM")`. GPU weights → APR v2 file with full metadata.

3. **`pipeline.export()`** calls `self.student.save_checkpoint(<output_dir>/model.apr)` after the metadata sidecar write. CUDA path produces a real APR; fixture path still writes only the metadata-only safetensors.

4. **Periodic checkpointing** in `pipeline.train()`:
   - Every `APR_DISTILL_CHECKPOINT_EVERY` steps (default 5000)
   - Files: `<output_dir>/ckpt-step-{N:06}.apr`
   - Write failures logged but don't fail training
   - Set to 0 to disable (smoke tests)

## Test plan

- [x] `cargo check` (both with/without cuda feature) clean
- [x] 61 distill lib tests pass (fixture path semantics preserved)
- [ ] Live re-dispatch (Phase 4 short re-train per user direction): verify `model.apr` non-empty AND `ckpt-step-NNNNNN.apr` every 5000 steps

## What this unblocks

Phase 5 (HumanEval) + Phase 6 (publish) — both require a model with real weights. Per user direction (2026-05-21): land this P0 fix, then dispatch a 5-10K-step re-train (~5h) to produce a usable Phase 5/6 checkpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)