### PR TITLE
fix(tests): repair stale include_str! paths after monorepo consolidation

### DIFF
--- a/crates/aprender-serve/tests/fusion_gate_contract_falsify.rs
+++ b/crates/aprender-serve/tests/fusion_gate_contract_falsify.rs
@@ -17,7 +17,7 @@ use proptest::prelude::*;
 
 /// The kernel-fusion-v1.yaml contract, included at compile time.
 /// Path: from `realizar/tests/` up two levels to `aprender/contracts/`.
-const CONTRACT_YAML: &str = include_str!("../../aprender/contracts/kernel-fusion-v1.yaml");
+const CONTRACT_YAML: &str = include_str!("../../../contracts/kernel-fusion-v1.yaml");
 
 /// All known fused kernel names that MUST appear in the contract.
 /// Sourced from the `kernels.fused` fields in kernel-fusion-v1.yaml.

--- a/crates/aprender-serve/tests/parity_contract_falsify.rs
+++ b/crates/aprender-serve/tests/parity_contract_falsify.rs
@@ -12,7 +12,7 @@
 use proptest::prelude::*;
 
 /// The contract YAML — source of truth for GPU/CPU parity thresholds.
-const CONTRACT_YAML: &str = include_str!("../../aprender/contracts/layer-parity-v1.yaml");
+const CONTRACT_YAML: &str = include_str!("../../../contracts/layer-parity-v1.yaml");
 
 /// Mirror of the PARITY_GATE_COSINE_MIN constant from realizar/src/gguf/cuda/mod.rs.
 /// Test 8 verifies this matches the contract YAML.


### PR DESCRIPTION
## Summary

\`fusion_gate_contract_falsify.rs\` and \`parity_contract_falsify.rs\` both reference \`../../aprender/contracts/*.yaml\` from when contracts lived in the standalone aprender repo. Post-consolidation, \`contracts/\` moved to the workspace root — the correct relative path is \`../../../contracts/\`.

## Symptom (latent on main since the monorepo collapse)

\`\`\`
error: couldn't read \`crates/aprender-serve/tests/../../aprender/contracts/layer-parity-v1.yaml\`:
  No such file or directory (os error 2)
\`\`\`

CI's main test command (\`cargo test --workspace --lib\`) skips integration tests in \`tests/\`, so this hasn't been a gating failure — but \`cargo clippy --all-targets\` does build them, and any future PR that expands \`--tests\` coverage hits these errors. Discovered while running clippy during #1846's E0063 triage.

## Verification

\`\`\`
$ cargo test -p aprender-serve --test parity_contract_falsify --release
test result: ok. 11 passed; 0 failed
\`\`\`

\`\`\`
$ cargo test -p aprender-serve --test fusion_gate_contract_falsify --release
test result: FAILED. 4 passed; 1 failed   ← QA-002 falsifier doing its job
\`\`\`

The QA-002 failure is **the falsifier working as intended** — 5 fused kernels exist in the codebase but lack entries in \`contracts/kernel-fusion-v1.yaml\` (FusedQKVKernel, FusedGateUpKernel, FusedGemmBiasGeluKernel, FusedRmsNormQ4KGemvKernel, FusedGateUpQ4KGemvKernel). Filed as a separate follow-up issue — out of scope for the path fix.

## Test plan
- [x] \`cargo test --test parity_contract_falsify\` — 11/11 PASS
- [x] \`cargo test --test fusion_gate_contract_falsify -- falsify_fusion_qa_001 falsify_fusion_qa_003\` — 4/4 PASS (QA-002 separate)
- [x] No new lint regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)