### PR TITLE
fix(tests): repair third stale CARGO_MANIFEST_DIR path missed by #1857

### DIFF
--- a/crates/aprender-gpu/src/kernels/tests/fusion_contract_falsify.rs
+++ b/crates/aprender-gpu/src/kernels/tests/fusion_contract_falsify.rs
@@ -11,12 +11,13 @@ use super::*;
 use proptest::prelude::*;
 use std::path::Path;
 
-/// Path to the kernel-fusion-v1.yaml contract in the aprender crate.
-/// CARGO_MANIFEST_DIR for trueno-gpu is trueno/trueno-gpu, so ../../aprender/
-/// reaches the aprender crate root.
+/// Path to the kernel-fusion-v1.yaml contract at the workspace root.
+/// Post-monorepo-consolidation: CARGO_MANIFEST_DIR for aprender-gpu is
+/// `crates/aprender-gpu/`, so `/../../contracts/` reaches the workspace
+/// root `contracts/` directory.
 const CONTRACT_PATH: &str = concat!(
     env!("CARGO_MANIFEST_DIR"),
-    "/../../aprender/contracts/kernel-fusion-v1.yaml"
+    "/../../contracts/kernel-fusion-v1.yaml"
 );
 
 /// Helper: read the contract YAML as a string, panicking with a clear message if missing.


### PR DESCRIPTION
## Summary

Third stale \`../../aprender/contracts/\` path that #1857 missed.

\`crates/aprender-gpu/src/kernels/tests/fusion_contract_falsify.rs\` builds CONTRACT_PATH via:

\`\`\`rust
concat!(env!(\"CARGO_MANIFEST_DIR\"), \"/../../aprender/contracts/kernel-fusion-v1.yaml\")
\`\`\`

Post-monorepo, \`CARGO_MANIFEST_DIR\` for \`aprender-gpu\` is \`crates/aprender-gpu/\`, so the old suffix resolves to \`crates/aprender/contracts/\` (doesn't exist). Correct suffix is \`/../../contracts/\`.

Comment updated to reflect post-consolidation reality too.

## Verification

\`\`\`bash
$ cargo test -p aprender-gpu --features cuda --lib --release falsify_fusion_001
\`\`\`

The test now finds the contract and runs. It still surfaces the SAME \`FusedQKVKernel\`-class contract drift covered by #1858 — that's the falsifier working as intended, not a regression here.

## Test plan
- [x] \`cargo check -p aprender-gpu --lib --tests\` clean
- [x] Test now compiles and reaches the assertion (used to fail at \`include_str!\` resolution)
- [x] Audit complete — no other stale \`../../aprender/contracts/\` paths remain anywhere in \`crates/\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)