### PR TITLE
fix(contracts): register 5 missing fused kernels in kernel-fusion-v1.yaml (closes #1858)

### DIFF
--- a/contracts/kernel-fusion-v1.yaml
+++ b/contracts/kernel-fusion-v1.yaml
@@ -120,6 +120,77 @@ fusion_decisions:
       '
     blocking_reason: Requires weight interleaving at GGUF load + new kernel
     priority: P1 — moderate impact, complex implementation
+  fused_qkv:
+    id: FUSION-006
+    status: ACTIVE
+    description: Q/K/V projection in single kernel (3x kernel-launch reduction)
+    kernels:
+      fused: FusedQKVKernel (crates/aprender-gpu/src/kernels/fused/mod.rs:50)
+      replaces:
+      - Q projection GEMV
+      - K projection GEMV
+      - V projection GEMV
+    call_site: crates/aprender-serve/src/cuda/generate.rs:267
+    saves_per_layer: 2
+    falsification: Splitting fused Q/K/V into three separate GEMV launches must increase per-token wall.
+  fused_gate_up:
+    id: FUSION-007
+    status: ACTIVE
+    description: Gate+Up FFN projections with SwiGLU activation in single kernel (2x launch reduction; FP32-input path)
+    kernels:
+      fused: FusedGateUpKernel (crates/aprender-gpu/src/kernels/fused/mod.rs:227)
+      replaces:
+      - Gate projection GEMV
+      - Up projection GEMV
+      - SwiGLU activation
+    call_site: crates/aprender-serve/src/cuda/generate.rs:270
+    saves_per_layer: 2
+    falsification: Splitting fused Gate+Up+SwiGLU into separate launches must increase per-token wall.
+  fused_gemm_bias_gelu:
+    id: FUSION-008
+    status: ACTIVE
+    description: GEMM + bias + GELU activation in single kernel (3x launch reduction; WAPR-PERF-007)
+    kernels:
+      fused: FusedGemmBiasGeluKernel (crates/aprender-gpu/src/kernels/fused/gemm_bias_gelu.rs:25)
+      replaces:
+      - GEMM kernel
+      - Bias add
+      - GELU activation
+    call_site: crates/aprender-gpu/src/memory/resident/ops/composite/linear_bias.rs:232
+    saves_per_layer: 2
+    notes: |
+      Originally landed for Whisper encoder FFN. General-purpose: any
+      Linear(bias=true) + GELU sequence dispatches through this kernel.
+    falsification: Splitting GEMM + Bias + GELU into three separate launches must increase wall time.
+  fused_rmsnorm_q4k_gemv:
+    id: FUSION-009
+    status: ACTIVE
+    description: RMSNorm + Q4K GEMV in single pass (input normalization fused with quantized matmul)
+    kernels:
+      fused: FusedRmsNormQ4KGemvKernel (crates/aprender-gpu/src/kernels/quantize/fused/rmsnorm_gemv.rs:26)
+      replaces:
+      - RmsNormKernel
+      - Q4K GEMV (separate normalization read)
+    call_site: crates/aprender-serve/src/cuda/generate.rs:202
+    saves_per_layer: 1
+    falsification: Splitting RMSNorm and Q4K GEMV into two kernels must increase per-token wall.
+  fused_gate_up_q4k_gemv:
+    id: FUSION-010
+    status: ACTIVE
+    description: Gate + Up Q4K-quantized GEMV sharing input vector load (Q4K-input variant of FUSION-007)
+    kernels:
+      fused: FusedGateUpQ4KGemvKernel (crates/aprender-gpu/src/kernels/quantize/fused/gate_up_gemv.rs:29)
+      replaces:
+      - Gate Q4K GEMV (separate input load)
+      - Up Q4K GEMV (separate input load)
+    call_site: crates/aprender-serve/src/cuda/generate.rs:273
+    saves_per_layer: 1
+    notes: |
+      Distinct from FUSION-007 (FusedGateUpKernel = FP32 input) — this
+      one fuses the Q4K-quantized projections where the activation
+      vector load is shared between gate and up. SwiGLU is applied
+      separately downstream.
+    falsification: Splitting Gate Q4K GEMV and Up Q4K GEMV into two kernels (each reloading input) must increase wall time.
 enforcement:
   kernel_registry_complete:
     description: No orphaned fused kernels (kernel exists but decision undocumented)


### PR DESCRIPTION
## Summary

Closes #1858 by adding entries for the 5 fused kernels that the \`enforcement.kernel_registry_complete\` falsifier detected as drift.

The drift was masked until #1857 / #1860 repaired the broken \`include_str!\` paths — once the QA-002 falsifier could actually compile, it correctly flagged registry incompleteness.

## Five entries added

| ID | Kernel | Replaces | Call site |
|---|---|---|---|
| FUSION-006 | \`FusedQKVKernel\` | Q/K/V GEMVs | \`crates/aprender-serve/src/cuda/generate.rs:267\` |
| FUSION-007 | \`FusedGateUpKernel\` | Gate+Up GEMV + SwiGLU (FP32 path) | \`crates/aprender-serve/src/cuda/generate.rs:270\` |
| FUSION-008 | \`FusedGemmBiasGeluKernel\` | GEMM + Bias + GELU | \`crates/aprender-gpu/src/memory/resident/ops/composite/linear_bias.rs:232\` |
| FUSION-009 | \`FusedRmsNormQ4KGemvKernel\` | RMSNorm + Q4K GEMV | \`crates/aprender-serve/src/cuda/generate.rs:202\` |
| FUSION-010 | \`FusedGateUpQ4KGemvKernel\` | Gate+Up Q4K GEMVs (shared input load) | \`crates/aprender-serve/src/cuda/generate.rs:273\` |

All 5 status ACTIVE. FUSION-007 vs FUSION-010 distinction documented inline (FP32-input path vs Q4K-input path).

## Verification

\`\`\`
$ pv validate contracts/kernel-fusion-v1.yaml
Contract is valid.

$ cargo test -p aprender-serve --test fusion_gate_contract_falsify --release
test result: ok. 5 passed; 0 failed     ← was 4/5 with QA-002 failing

$ cargo test -p aprender-gpu --features cuda --lib --release falsify_fusion_001_every_fused_kernel_has_yaml_entry
test result: ok. 1 passed; 0 failed     ← was failing on FusedQKVKernel
\`\`\`

Both falsifier tests flip FAILED → PASS.

## Test plan
- [x] \`pv validate\` clean
- [x] aprender-serve fusion_gate_contract_falsify: 5/5 PASS
- [x] aprender-gpu falsify_fusion_001: 1/1 PASS

Closes #1858.

🤖 Generated with [Claude Code](https://claude.com/claude-code)