### PR TITLE
fix(export): apr export no longer panics on missing num_layers (closes #1865)

### DIFF
--- a/contracts/apr-export-num-layers-v1.yaml
+++ b/contracts/apr-export-num-layers-v1.yaml
@@ -1,0 +1,88 @@
+metadata:
+  version: 1.0.0
+  created: '2026-05-22'
+  author: PAIML Engineering
+  description: "`apr export <model>.apr --format gguf` must produce a clean error (or succeed via inference) when `num_layers` is absent from APR metadata. Panicking with `.expect()` on an Option<usize> is forbidden for any user-reachable code path."
+  kind: pattern
+  references:
+    - "paiml/aprender#1865 (apr export <model>.apr --format gguf panics: 'C-07: num_layers required for GGUF export')"
+    - "crates/aprender-core/src/format/converter/metadata.rs:export_apr_to_gguf_raw"
+    - "crates/aprender-core/src/format/converter/metadata.rs:build_gguf_arch_metadata"
+  registry: true
+  tags:
+    - cli
+    - export
+    - converter
+    - panic
+    - poka-yoke
+
+five_whys:
+  symptom: "`apr export /path/to/qwen2.5-coder-1.5b-instruct-q4k.apr --format gguf -o /tmp/rt.gguf` panics with `thread 'main' panicked at metadata.rs:384: C-07: num_layers required for GGUF export`, exit 101"
+  why_1: "`build_gguf_arch_metadata` and `export_apr_to_gguf_raw` call `.expect()` on `apr_metadata.num_layers`, which is `Option<usize>`"
+  why_2: "The APR file in question was produced without a `num_layers` stamp — likely an older `apr convert` or `apr stamp` invocation that left the field as `None`"
+  why_3: "The exporter assumed the `apr stamp` step always populates `num_layers`, but had no fallback for files produced before that requirement"
+  why_4: "There is no inference path: `num_layers` is recoverable from the tensor layout (every `blk.N.*` index ≤ N), but the exporter only consults metadata"
+  why_5: "No provable contract forbids `.expect()` on Option<usize> in user-reachable code paths; CLAUDE.md bans `.unwrap()` but allows `.expect()` as a sentinel for 'genuinely impossible' invariants — and this site was misclassified as such"
+  root_cause: "Missing inference fallback + `.expect()` used as a soft error-path instead of a true never-violated invariant. Together: any APR file without a stamped `num_layers` aborts `apr export` with exit 101 instead of producing a clean failure or succeeding via inference."
+
+equations:
+  num_layers_inference:
+    formula: "infer_num_layers(tensors) = max{N : exists name like 'blk.N.*' or 'model.layers.N.*'} + 1"
+    domain: "set of tensor names in an APR file"
+    codomain: "Option<usize>"
+    invariants:
+      - "Returns Some(K) when at least one tensor matches blk.<N>.* or model.layers.<N>.*"
+      - "K equals max(N) + 1 (block_count uses 0-indexed layers)"
+      - "Returns None when no tensor matches either prefix family"
+
+  export_no_panic:
+    formula: "apr export <any-valid-apr> --format gguf returns Result, never panics"
+    domain: "Any APR file that AprV2Reader can parse"
+    codomain: "Result<ExportReport, AprenderError>"
+    invariants:
+      - "All `.expect()` calls on `apr_metadata.<dim>` are replaced with `.ok_or_else(|| FormatError)`"
+      - "`build_gguf_arch_metadata` returns `Result<Vec<(String, GgufValue)>, AprenderError>`"
+      - "Missing num_layers triggers tensor-name inference before raising an error"
+      - "Exit code on missing dim is 5 (CliError::ValidationFailed::FormatError), not 101 (panic)"
+
+proof_obligations:
+  - type: invariant
+    property: "Tensor-name inference returns max-index + 1"
+    formal: "infer_num_layers([blk.0.x, blk.1.x, blk.2.x]) = Some(3)"
+    applies_to: num_layers_inference
+  - type: invariant
+    property: "Inference returns None on non-block tensors"
+    formal: "infer_num_layers([token_embd.weight, output_norm.weight]) = None"
+    applies_to: num_layers_inference
+  - type: invariant
+    property: "Export does not panic on missing dim"
+    formal: "export_apr_to_gguf_raw(apr_with_no_num_layers) = Err | Ok (never panic)"
+    applies_to: export_no_panic
+
+falsification_tests:
+  - id: FALSIFY-EXPORT-NUM-LAYERS-001
+    rule: "infer_num_layers_from_tensor_names matches max(blk.N) + 1"
+    prediction: "Calling infer_num_layers_from_tensor_names on ['blk.0.attn_q', 'blk.5.attn_q', 'blk.27.ffn_down'] returns Some(28)"
+    test: "cargo test -p aprender-core --lib infer_num_layers_from_tensor_names"
+    if_fails: "Inference logic does not correctly find max layer index"
+
+  - id: FALSIFY-EXPORT-NUM-LAYERS-002
+    rule: "No `.expect()` on Option<usize> in user-reachable export paths"
+    prediction: "grep -n `.expect.*required for GGUF export` in metadata.rs returns no matches"
+    test: "! grep -nE '\\.expect\\(\"C-07: [a-z_]+ required for GGUF export' crates/aprender-core/src/format/converter/metadata.rs"
+    if_fails: "An `.expect()` panic site still leaks through `apr export`"
+
+  - id: FALSIFY-EXPORT-NUM-LAYERS-003
+    rule: "build_gguf_arch_metadata returns Result"
+    prediction: "build_gguf_arch_metadata signature returns `Result<Vec<...>>`, not bare `Vec<...>`"
+    test: "grep -A3 'fn build_gguf_arch_metadata' crates/aprender-core/src/format/converter/metadata.rs | grep -qE -- '-> Result<'"
+    if_fails: "Function still returns Vec — missing dims will continue to panic via downstream .expect()"
+
+qa_gate:
+  id: F-EXPORT-NUM-LAYERS-001
+  name: "apr export panic-free for missing num_layers"
+  description: "apr export must not panic when num_layers is absent from APR metadata — either infer from tensor names or return clean error"
+  checks:
+    - "num_layers_inference"
+    - "export_no_panic"
+  pass_criteria: "FALSIFY-EXPORT-NUM-LAYERS-{001,002,003} all PASS"

--- a/crates/aprender-core/src/format/converter/export_tests_arch_metadata.rs
+++ b/crates/aprender-core/src/format/converter/export_tests_arch_metadata.rs
@@ -1,9 +1,9 @@
 use super::*;
 
-/// C-07 (Meyer DbC): Missing required dimensions must panic, not silently default.
+/// #1865: Missing required dimensions return a clean error, not a panic.
+/// (Pre-#1865 these used `.expect()` and were tested with `#[should_panic]`.)
 #[test]
-#[should_panic(expected = "C-07: hidden_size required")]
-fn test_build_gguf_arch_metadata_panics_on_missing_hidden_size() {
+fn test_build_gguf_arch_metadata_errors_on_missing_hidden_size() {
     use crate::format::v2::AprV2Metadata;
 
     let mut apr = AprV2Metadata::new("test");
@@ -13,13 +13,12 @@ fn test_build_gguf_arch_metadata_panics_on_missing_hidden_size() {
     apr.vocab_size = Some(32000);
     apr.intermediate_size = Some(11008);
 
-    let _ = build_gguf_arch_metadata(&apr);
+    let err = build_gguf_arch_metadata(&apr).expect_err("missing hidden_size must error");
+    assert!(err.to_string().contains("hidden_size"), "got: {err}");
 }
 
-/// C-07 (Meyer DbC): Missing required dimensions must panic, not silently default.
 #[test]
-#[should_panic(expected = "C-07: num_layers required")]
-fn test_build_gguf_arch_metadata_panics_on_missing_num_layers() {
+fn test_build_gguf_arch_metadata_errors_on_missing_num_layers() {
     use crate::format::v2::AprV2Metadata;
 
     let mut apr = AprV2Metadata::new("test");
@@ -29,13 +28,12 @@ fn test_build_gguf_arch_metadata_panics_on_missing_num_layers() {
     apr.vocab_size = Some(32000);
     apr.intermediate_size = Some(11008);
 
-    let _ = build_gguf_arch_metadata(&apr);
+    let err = build_gguf_arch_metadata(&apr).expect_err("missing num_layers must error");
+    assert!(err.to_string().contains("num_layers"), "got: {err}");
 }
 
-/// C-07 (Meyer DbC): Missing required dimensions must panic, not silently default.
 #[test]
-#[should_panic(expected = "C-07: vocab_size required")]
-fn test_build_gguf_arch_metadata_panics_on_missing_vocab_size() {
+fn test_build_gguf_arch_metadata_errors_on_missing_vocab_size() {
     use crate::format::v2::AprV2Metadata;
 
     let mut apr = AprV2Metadata::new("test");
@@ -45,7 +43,8 @@ fn test_build_gguf_arch_metadata_panics_on_missing_vocab_size() {
     apr.vocab_size = None;
     apr.intermediate_size = Some(11008);
 
-    let _ = build_gguf_arch_metadata(&apr);
+    let err = build_gguf_arch_metadata(&apr).expect_err("missing vocab_size must error");
+    assert!(err.to_string().contains("vocab_size"), "got: {err}");
 }
 
 /// C-07: With all required fields populated, export succeeds.
@@ -63,7 +62,7 @@ fn test_build_gguf_arch_metadata_succeeds_with_required_fields() {
     apr.intermediate_size = Some(11008);
     apr.name = Some("model".to_string());
 
-    let entries = build_gguf_arch_metadata(&apr);
+    let entries = build_gguf_arch_metadata(&apr).expect("required fields populated");
     let find = |key: &str| entries.iter().find(|(k, _)| k == key).map(|(_, v)| v);
 
     match find("qwen2.embedding_length") {
@@ -89,7 +88,7 @@ fn test_build_gguf_arch_metadata_zero_heads_uses_default_head_dim() {
     apr.vocab_size = Some(100);
     apr.intermediate_size = Some(256);
 
-    let entries = build_gguf_arch_metadata(&apr);
+    let entries = build_gguf_arch_metadata(&apr).expect("required fields populated");
     let find = |key: &str| entries.iter().find(|(k, _)| k == key).map(|(_, v)| v);
 
     // N-02: When num_heads=0, head_dim defaults to 0 (no hidden assumption)
@@ -114,7 +113,7 @@ fn test_build_gguf_arch_metadata_llama_architecture() {
     apr.intermediate_size = Some(11008);
     apr.name = Some("LLaMA-7B".to_string());
 
-    let entries = build_gguf_arch_metadata(&apr);
+    let entries = build_gguf_arch_metadata(&apr).expect("required fields populated");
     let find = |key: &str| entries.iter().find(|(k, _)| k == key).map(|(_, v)| v);
 
     // All arch-prefixed keys should use "llama" prefix
@@ -400,4 +399,89 @@ fn test_unfuse_qkv_tensors_no_apr_metadata_returns_original() {
     // No metadata available (file doesn't exist) -> returns original
     assert_eq!(result.len(), 1);
     assert!(result.contains_key("model.layers.0.self_attn.qkv_proj.weight"));
+}
+
+// ========================================================================
+// #1865: infer_num_layers_from_tensor_names — apr-export-num-layers-v1
+// ========================================================================
+
+#[test]
+fn test_infer_num_layers_from_blk_n_names() {
+    let names = [
+        "token_embd.weight",
+        "blk.0.attn_q.weight",
+        "blk.5.ffn_down.weight",
+        "blk.27.attn_norm.weight",
+        "output_norm.weight",
+    ];
+    assert_eq!(infer_num_layers_from_tensor_names(&names), Some(28));
+}
+
+#[test]
+fn test_infer_num_layers_from_hf_model_layers_n() {
+    let names = [
+        "model.embed_tokens.weight",
+        "model.layers.0.self_attn.q_proj.weight",
+        "model.layers.31.mlp.up_proj.weight",
+        "model.norm.weight",
+    ];
+    assert_eq!(infer_num_layers_from_tensor_names(&names), Some(32));
+}
+
+#[test]
+fn test_infer_num_layers_returns_none_when_no_block_tensors() {
+    let names = ["token_embd.weight", "output_norm.weight", "output.weight"];
+    assert_eq!(infer_num_layers_from_tensor_names(&names), None);
+}
+
+#[test]
+fn test_infer_num_layers_ignores_malformed_indices() {
+    // blk.foo.x has a non-numeric index and must be skipped without panicking.
+    let names = ["blk.0.attn_q", "blk.foo.weird", "blk.7.ffn_down"];
+    assert_eq!(infer_num_layers_from_tensor_names(&names), Some(8));
+}
+
+/// FALSIFY-EXPORT-NUM-LAYERS-001: integration smoke for the inference path.
+/// Builds an APR file with no `num_layers` metadata but well-formed `blk.N.*`
+/// tensor names; `apr export` must succeed (or fail cleanly), never panic.
+#[test]
+fn test_export_apr_to_gguf_raw_infers_num_layers_when_missing() {
+    use crate::format::v2::{AprV2Metadata, AprV2Writer};
+    use tempfile::tempdir;
+
+    let dir = tempdir().expect("create temp dir");
+    let apr_path = dir.path().join("model.apr");
+    let gguf_path = dir.path().join("model.gguf");
+
+    let mut metadata = AprV2Metadata::new("qwen2");
+    metadata.architecture = Some("qwen2".to_string());
+    metadata.hidden_size = Some(4);
+    metadata.num_layers = None; // <-- intentionally missing; must be inferred
+    metadata.num_heads = Some(2);
+    metadata.vocab_size = Some(8);
+    metadata.intermediate_size = Some(16);
+    metadata.name = Some("test".to_string());
+    metadata
+        .custom
+        .insert("tokenizer.model".to_string(), serde_json::json!("gpt2"));
+    metadata.custom.insert(
+        "tokenizer.vocabulary".to_string(),
+        serde_json::json!(["a", "b", "c", "d", "e", "f", "g", "h"]),
+    );
+
+    let mut writer = AprV2Writer::new(metadata);
+    writer.add_f32_tensor("token_embd.weight", vec![8, 4], &vec![0.1f32; 8 * 4]);
+    writer.add_f32_tensor("blk.0.attn_norm.weight", vec![4], &[1.0f32; 4]);
+    writer.add_f32_tensor("blk.1.attn_norm.weight", vec![4], &[1.0f32; 4]);
+    writer.add_f32_tensor("output_norm.weight", vec![4], &[1.0f32; 4]);
+
+    let apr_bytes = writer.write().expect("write APR");
+    std::fs::write(&apr_path, &apr_bytes).expect("write APR file");
+
+    // Critical: this must NOT panic. Pre-#1865 this aborted with exit 101.
+    let result = export_apr_to_gguf_raw(&apr_path, &gguf_path);
+    assert!(
+        result.is_ok(),
+        "export must succeed via num_layers inference; got: {result:?}"
+    );
 }

--- a/crates/aprender-core/src/format/converter/export_tests_detect_quant.rs
+++ b/crates/aprender-core/src/format/converter/export_tests_detect_quant.rs
@@ -332,7 +332,7 @@ fn test_build_gguf_arch_metadata_gpt2_keys() {
     apr.intermediate_size = Some(3072);
     apr.rms_norm_eps = Some(1e-5);
 
-    let metadata = build_gguf_arch_metadata(&apr);
+    let metadata = build_gguf_arch_metadata(&apr).expect("required fields populated");
     let keys: Vec<&str> = metadata.iter().map(|(k, _)| k.as_str()).collect();
 
     assert!(keys.contains(&"gpt2.attention.layer_norm_epsilon"));
@@ -353,7 +353,7 @@ fn test_build_gguf_arch_metadata_qwen2_keys() {
     apr.vocab_size = Some(151936);
     apr.intermediate_size = Some(8960);
 
-    let metadata = build_gguf_arch_metadata(&apr);
+    let metadata = build_gguf_arch_metadata(&apr).expect("required fields populated");
     let keys: Vec<&str> = metadata.iter().map(|(k, _)| k.as_str()).collect();
 
     assert!(keys.contains(&"qwen2.attention.layer_norm_rms_epsilon"));

--- a/crates/aprender-core/src/format/converter/export_tests_e2e_gguf.rs
+++ b/crates/aprender-core/src/format/converter/export_tests_e2e_gguf.rs
@@ -332,7 +332,7 @@ fn test_build_gguf_arch_metadata_with_all_fields_populated() {
     apr.rms_norm_eps = Some(1e-6);
     apr.name = Some("Qwen2.5-0.5B".to_string());
 
-    let entries = build_gguf_arch_metadata(&apr);
+    let entries = build_gguf_arch_metadata(&apr).expect("required fields populated");
 
     // Verify all expected keys are present
     let find = |key: &str| entries.iter().find(|(k, _)| k == key).map(|(_, v)| v);

--- a/crates/aprender-core/src/format/converter/metadata.rs
+++ b/crates/aprender-core/src/format/converter/metadata.rs
@@ -1,30 +1,55 @@
 
-/// Build GGUF architecture metadata from APR model metadata
+/// Infer `num_layers` from APR tensor names by counting unique `blk.N.*` prefixes.
+/// Returns `None` if the file uses a different naming convention (e.g. pre-mapping
+/// HF names like `model.layers.N.*`).
+///
+/// Contract: apr-export-num-layers-v1 (#1865).
+pub(crate) fn infer_num_layers_from_tensor_names(names: &[&str]) -> Option<usize> {
+    let mut max_idx: Option<usize> = None;
+    for name in names {
+        // Match both `blk.N.*` (GGUF) and `model.layers.N.*` (HF) conventions.
+        let stripped = name
+            .strip_prefix("blk.")
+            .or_else(|| name.strip_prefix("model.layers."));
+        if let Some(rest) = stripped {
+            if let Some(dot) = rest.find('.') {
+                if let Ok(idx) = rest[..dot].parse::<usize>() {
+                    max_idx = Some(max_idx.map_or(idx, |m| m.max(idx)));
+                }
+            }
+        }
+    }
+    max_idx.map(|i| i + 1)
+}
+
+fn missing_dim_err(field: &str) -> AprenderError {
+    AprenderError::FormatError {
+        message: format!(
+            "C-07: {field} required for GGUF export (missing in APR metadata). \
+             Re-stamp the APR file with `apr stamp` populating model dimensions, \
+             or convert from the original GGUF/SafeTensors source."
+        ),
+    }
+}
+
+/// Build GGUF architecture metadata from APR model metadata.
+///
+/// Returns `Err(AprenderError::FormatError)` instead of panicking when required
+/// dimensions are missing, so `apr export` produces a clean exit-5 instead of
+/// a panic-101 (#1865).
 fn build_gguf_arch_metadata(
     apr_metadata: &crate::format::v2::AprV2Metadata,
-) -> Vec<(String, crate::format::gguf::GgufValue)> {
+) -> Result<Vec<(String, crate::format::gguf::GgufValue)>> {
     use crate::format::gguf::GgufValue;
 
     let arch = resolve_architecture(apr_metadata);
-    // C-07 (Meyer DbC): Require dimensions from model metadata — no silent LLaMA-7B defaults.
-    // These fields are always populated during import/conversion. If missing, the APR file
-    // is malformed and exporting with wrong dimensions would produce a corrupt GGUF.
-    let hidden_size = apr_metadata
-        .hidden_size
-        .expect("C-07: hidden_size required for GGUF export (missing in APR metadata)");
-    let num_layers = apr_metadata
-        .num_layers
-        .expect("C-07: num_layers required for GGUF export (missing in APR metadata)");
-    let num_heads = apr_metadata
-        .num_heads
-        .expect("C-07: num_heads required for GGUF export (missing in APR metadata)");
+    let hidden_size = apr_metadata.hidden_size.ok_or_else(|| missing_dim_err("hidden_size"))?;
+    let num_layers = apr_metadata.num_layers.ok_or_else(|| missing_dim_err("num_layers"))?;
+    let num_heads = apr_metadata.num_heads.ok_or_else(|| missing_dim_err("num_heads"))?;
     let num_kv_heads = apr_metadata.num_kv_heads.unwrap_or(num_heads);
-    let vocab_size = apr_metadata
-        .vocab_size
-        .expect("C-07: vocab_size required for GGUF export (missing in APR metadata)");
-    let intermediate_size = apr_metadata
-        .intermediate_size
-        .expect("C-07: intermediate_size required for GGUF export (missing in APR metadata)");
+    let vocab_size = apr_metadata.vocab_size.ok_or_else(|| missing_dim_err("vocab_size"))?;
+    let intermediate_size =
+        apr_metadata.intermediate_size.ok_or_else(|| missing_dim_err("intermediate_size"))?;
     let max_pos = apr_metadata.max_position_embeddings.unwrap_or(0);
     // N-01 (Meyer DbC): rope_theta from metadata, or architecture-specific default.
     let rope_theta = apr_metadata.rope_theta.unwrap_or_else(||
@@ -107,7 +132,7 @@ fn build_gguf_arch_metadata(
         GgufValue::Uint32(vocab_size as u32),
     ));
 
-    metadata
+    Ok(metadata)
 }
 
 /// Push a string array from APR custom fields to GGUF entries.
@@ -375,23 +400,31 @@ fn export_apr_to_gguf_raw(input: &Path, output: &Path) -> Result<ExportReport> {
         message: format!("Failed to parse APR file: {e:?}"),
     })?;
 
-    let apr_metadata = reader.metadata().clone();
+    let mut apr_metadata = reader.metadata().clone();
+
+    // #1865: infer `num_layers` from tensor names when metadata is silent. Older
+    // APR files (and any produced without `apr stamp --num-layers`) leave this
+    // field unset; the tensor layout always carries the layer count, so derive
+    // it before raising a missing-dimension error.
+    if apr_metadata.num_layers.is_none() {
+        let names = reader.tensor_names();
+        if let Some(inferred) = infer_num_layers_from_tensor_names(&names) {
+            eprintln!(
+                "[#1865] num_layers missing from APR metadata — inferred {} from blk.N.* tensor names",
+                inferred
+            );
+            apr_metadata.num_layers = Some(inferred);
+        }
+    }
 
     let arch = resolve_architecture(&apr_metadata);
-    // C-07 (Meyer DbC): Required dimensions — no silent LLaMA-7B defaults.
-    let num_layers = apr_metadata
-        .num_layers
-        .expect("C-07: num_layers required for GGUF export");
-    let num_heads = apr_metadata
-        .num_heads
-        .expect("C-07: num_heads required for GGUF export");
+    let num_layers = apr_metadata.num_layers.ok_or_else(|| missing_dim_err("num_layers"))?;
+    let num_heads = apr_metadata.num_heads.ok_or_else(|| missing_dim_err("num_heads"))?;
     let num_kv_heads = apr_metadata.num_kv_heads.unwrap_or(num_heads);
-    let hidden_size = apr_metadata
-        .hidden_size
-        .expect("C-07: hidden_size required for GGUF export");
+    let hidden_size = apr_metadata.hidden_size.ok_or_else(|| missing_dim_err("hidden_size"))?;
 
     // Build metadata from architecture config + tokenizer custom fields
-    let mut metadata = build_gguf_arch_metadata(&apr_metadata);
+    let mut metadata = build_gguf_arch_metadata(&apr_metadata)?;
     let vocab_size = apr_metadata.vocab_size.unwrap_or(0);
     metadata.extend(extract_apr_tokenizer_for_gguf(&apr_metadata, vocab_size));
 


### PR DESCRIPTION
## Summary

Fixes [#1865](https://github.com/paiml/aprender/issues/1865) — `apr export <model>.apr --format gguf` panicked with `C-07: num_layers required for GGUF export` (exit 101) on any APR file that did not carry `num_layers` in metadata. Older APR files (and any produced without `apr stamp --num-layers`) leave the field as `None`.

## Fix

### 1. Inference fallback (`metadata.rs`)

`infer_num_layers_from_tensor_names()` derives the layer count from `blk.N.*` (GGUF convention) or `model.layers.N.*` (HF convention) tensor names. Every APR file carries this information in its tensor layout; the exporter just wasn't consulting it. `export_apr_to_gguf_raw` patches the metadata with the inferred value before the dim-required check fires.

### 2. No-panic guarantee (`metadata.rs`)

`build_gguf_arch_metadata` returns `Result<Vec<...>, AprenderError>` instead of panicking via `.expect()`. Both call sites use `?`. Missing dims produce a clean `CliError::ValidationFailed::FormatError`:

```
error: Validation failed: Invalid model format: C-07: hidden_size required
for GGUF export (missing in APR metadata). Re-stamp the APR file with
`apr stamp` populating model dimensions, or convert from the original
GGUF/SafeTensors source.
```

Exit code **5** (ValidationFailed), not **101** (panic).

## Contract

New `contracts/apr-export-num-layers-v1.yaml`:
- equation `num_layers_inference`: `max(blk.N) + 1`
- equation `export_no_panic`: all dim lookups go through `ok_or_else`
- **FALSIFY-EXPORT-NUM-LAYERS-001**: inference correctness (PASS)
- **FALSIFY-EXPORT-NUM-LAYERS-002**: no `.expect()` leakage in metadata.rs (PASS)
- **FALSIFY-EXPORT-NUM-LAYERS-003**: `build_gguf_arch_metadata -> Result<...>` (PASS)

## Tests

- 4 unit tests for `infer_num_layers_from_tensor_names` (blk.N, model.layers.N, no-block, malformed)
- 1 integration test `test_export_apr_to_gguf_raw_infers_num_layers_when_missing`
- 3 `#[should_panic]` tests converted to `expect_err` assertions
- 6 happy-path tests updated for `Result` return type

All 14 affected tests pass.

## End-to-end verification

```
$ apr export /home/noah/models/qwen2.5-coder-1.5b-instruct-q4k.apr \
    --format gguf -o /tmp/rt.gguf
[PMAT-252] Raw passthrough: detected Q4K in APR source.
[#1865] num_layers missing from APR metadata — inferred 28 from blk.N.* tensor names
error: Validation failed: Invalid model format: C-07: num_heads required ...
$ echo $?
5
```

Exit 5 (clean error), not 101 (panic). The 1.5B file also lacks `num_heads` and `hidden_size`, which now error cleanly with recovery advice instead of aborting.

## Test plan

- [x] 4 inference unit tests pass
- [x] Integration test (inference path) passes
- [x] Converted `#[should_panic]` tests pass as `expect_err`
- [x] FALSIFY-EXPORT-NUM-LAYERS-{001,002,003} all PASS
- [x] Contract YAML parses
- [x] Real reproducer no longer panics (exit 5, not 101)
- [ ] CI: workspace-test, fmt, contracts, deny

🤖 Generated with [Claude Code](https://claude.com/claude-code)