### PR TITLE
chore(deny): ignore RUSTSEC-2026-0105 (core2 yanked, transitive via bitstream-io)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -38,6 +38,9 @@ ignore = [
     { id = "RUSTSEC-2026-0098", reason = "rustls-webpki 0.101.7: transitive via aws-smithy-http-client (rustls 0.21), no drop-in fix" },
     { id = "RUSTSEC-2026-0099", reason = "rustls-webpki 0.101.7: transitive via aws-smithy-http-client (rustls 0.21), no drop-in fix" },
     { id = "RUSTSEC-2026-0104", reason = "rustls-webpki 0.101.7: transitive via aws-smithy-http-client (rustls 0.21), no drop-in fix. Direct 0.103.x path bumped to 0.103.13." },
+    # core2 0.4.0 — unmaintained, all versions yanked. Transitive via bitstream-io
+    # (image/media decoding stack). Surfaced 2026-05-22 blocking ALL in-flight PRs.
+    { id = "RUSTSEC-2026-0105", reason = "core2: yanked + unmaintained, transitive via bitstream-io; waiting for upstream migration off core2" },
 ]
 
 [licenses]


### PR DESCRIPTION
## Summary

`cargo deny check advisories` started failing on every PR (and on main) 2026-05-22 with a new advisory:

```
error[unmaintained]: core2 is unmaintained, all versions yanked
├ ID: RUSTSEC-2026-0105
├ Advisory: https://rustsec.org/advisories/RUSTSEC-2026-0105
```

The dep is pulled in transitively via `bitstream-io` (image/media decoding stack — `cargo tree` shows `bitstream-io v4.9.0 → core2 v0.4.0`). No first-party use; no drop-in replacement until upstream `bitstream-io` migrates off core2.

## Why this PR is urgent

This commit unblocks the in-flight PR cascade:
- #1867 fix(version) build.rs worktree HEAD
- #1868 fix(export) num_layers panic
- #1870 fix(validate) quality threshold
- #1873 chore(readme) drift fix
- #1875 feat(qwen-story)
- #1876 fix(wgpu-parity) multi-step gate

All 6 failed CI's `ci / lint` step on this single advisory.

## Verification

```
$ cargo deny check advisories
... (warnings about previously-ignored advisories that no longer match — pre-existing) ...
advisories ok
```

## Test plan

- [x] `cargo deny check advisories` exits 0 locally
- [x] Diff is a single 3-line addition; no other config changed
- [ ] CI: ci / lint, workspace-test

🤖 Generated with [Claude Code](https://claude.com/claude-code)