### PR TITLE
fix(qa): add EOS stop_tokens to Golden Output gate — closes phantom #1864 cuBLAS

### DIFF
--- a/crates/apr-cli/src/commands/golden_output.rs
+++ b/crates/apr-cli/src/commands/golden_output.rs
@@ -47,12 +47,20 @@ fn golden_output_gguf_cpu(
 ) -> Result<(Vec<u32>, String)> {
     use realizar::gguf::{OwnedQuantizedModel, QuantizedGenerateConfig};
 
-    let bos = aprender::demo::SpecialTokens::qwen2().bos_id;
-    let prompt_tokens = gguf.encode(prompt).unwrap_or_else(|| vec![bos, 9707]);
+    let specials = aprender::demo::SpecialTokens::qwen2();
+    let prompt_tokens = gguf.encode(prompt).unwrap_or_else(|| vec![specials.bos_id, 9707]);
+    // #1864: without stop_tokens, the model runs for the full max_tokens
+    // budget and starts emitting in-distribution chat-template tokens like
+    // `<|im_start|>` from accumulated drift — which `verify_output` then
+    // (correctly) flags as gibberish. The actual underlying inference path
+    // (`apr serve` /v1/chat/completions) sets stop_tokens to EOS — so user
+    // traffic was never affected. This aligns the gate's gen_config with the
+    // production path. See `cuda_chat_backend.rs:113` for the symmetric setup.
     let gen_config = QuantizedGenerateConfig {
         max_tokens,
         temperature: 0.0,
         top_k: 1,
+        stop_tokens: vec![specials.eos_id],
         ..Default::default()
     };
     let model = OwnedQuantizedModel::from_mapped(mapped)
@@ -150,14 +158,18 @@ fn validate_golden_test_case(
         // Safe: format==Gguf guarantees these are Some
         let gguf_ref = gguf_model.expect("GGUF model required for GPU golden output");
         let mapped_ref = mapped.expect("GGUF mapped model required for GPU golden output");
-        let bos = aprender::demo::SpecialTokens::qwen2().bos_id;
+        let specials = aprender::demo::SpecialTokens::qwen2();
         let prompt_tokens = gguf_ref
             .encode(prompt)
-            .unwrap_or_else(|| vec![bos, 9707]);
+            .unwrap_or_else(|| vec![specials.bos_id, 9707]);
+        // #1864: GPU path mirrors the CPU gate's fix above — set stop_tokens
+        // to EOS so generation terminates at end-of-turn rather than running
+        // the full 512-token budget and drifting into `<|im_start|>` repeats.
         let gen_config = QuantizedGenerateConfig {
             max_tokens: golden_max_tokens, // GH-279-4: match CPU budget
             temperature: 0.0,
             top_k: 1,
+            stop_tokens: vec![specials.eos_id],
             ..Default::default()
         };
         if let Some(failure) = validate_gpu_golden_output(


### PR DESCRIPTION
## TL;DR

**Closes [#1864](https://github.com/paiml/aprender/issues/1864).** The "cuBLAS FP8 7B Q4K gibberish" was a missing-`stop_tokens` config in the QA gate, not a numerical bug. User instinct ("could this be a chat template or something simple?") was correct.

## Falsification path

| Hypothesis | Falsifier | Result |
|---|---|---|
| Deep cuBLAS FP8 numerical bug | Run my Stage A reproducer | Yes, single-step argmax mismatches by 1057 vs 75311, correlation 0.987 |
| Bug surfaces in user-visible HTTP | `apr serve run <7B GGUF>` + curl `/v1/chat/completions` | **❌ User-visible path returns `'2+2 equals 4.'` CORRECTLY** |
| Then why does Golden Output FAIL? | Inspect gate's `gen_config` | **`..Default::default()` → `stop_tokens: Vec::new()`** |
| What does `apr serve` set? | Read `cuda_chat_backend.rs:113` | `stop_tokens: vec![eos_token_id]` |

**Five-whys**:
1. Golden Output FAILs with `<|im_start|>` repeats — why?
2. Generation runs the full 512 max_tokens — why?
3. No EOS in `stop_tokens`, defaults to empty — why?
4. The gate's gen_config uses `..Default::default()` without overriding it — why?
5. The author of the gate didn't realize `Default::stop_tokens = Vec::new()`. **Root cause = config drift between gate and production path.**

## Live discharge (RTX 4090, this host)

Pre-fix:
```
$ apr qa qwen2.5-coder-7b-instruct-q4_k_m.gguf
✗ FAIL Golden Output GPU output failed (CPU passed): gibberish (fragment "<|im_start|>" repeats 3+ times)
```

Post-fix:
```
$ apr qa qwen2.5-coder-7b-instruct-q4_k_m.gguf
✓ PASS Golden Output 2 golden test cases passed
```

## Diff

Two 4-line changes in `crates/apr-cli/src/commands/golden_output.rs`:
- CPU path (line 50-57): rename `bos` → `specials`, add `stop_tokens: vec![specials.eos_id]`
- GPU path (line 153-170): same pattern

Total: **16 insertions, 4 deletions** in 1 file. The "multi-day cuBLAS expert work" estimate was wrong — this was 5 lines.

## What this revokes

- **v0.35.0 release HELD** justification → **UNBLOCKED**
- **SPEC-CUBLAS-FP8-7B-FIX-001** Stages C-F → no longer needed; Stage A reproducer + Stage B per-layer instrumentation remain useful but not blocking. Spec status → **SUPERSEDED**.

## What still holds

- The reproducer in PR #1884 (Stage A) correctly observes ~3e-3 abs-diff per element between CPU vs cuBLAS FP8 single-step forward. This is **expected FP8 precision**, not a defect. Stage B (PR #1887) documented it correctly as "FP8 precision floor".
- PR #1876 wgpu multi-step parity gate remains a real improvement: catches autoregressive drift that would otherwise produce silent gibberish on wgpu-only paths.

## Methodology lesson

Worth saving to `memory/feedback_falsify_simple_before_deep.md`:

> When a test gate FAILs with a complex-looking symptom (e.g. "FP8 numerical drift"), the **first falsifier should be**: does the user-visible code path that the test purports to verify ALSO fail, or just the test gate? If only the test fails, the bug is in the test config, not the implementation. ~2 minutes of `apr serve` + curl would have saved days of bisection.

## Test plan

- [x] `apr qa <7B Q4K GGUF>` now PASSes Golden Output (live verified)
- [x] `apr qa <1.5B Q4K APR>` continues to PASS (no regression)
- [x] `apr serve run <7B> + curl` produces correct output (verified pre and post)
- [x] `cargo test -p aprender-contracts --lib lint_passes_on_real_contracts`
- [ ] CI: workspace-test, fmt, contracts-lib

🤖 Generated with [Claude Code](https://claude.com/claude-code)