### PR TITLE
fix(0.35.1): root facade feature passthroughs (cargo install aprender --features cuda)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -428,7 +428,7 @@ semicolon_if_nothing_returned = "allow"  # Style preference
 
 [package]
 name = "aprender"
-version = "0.35.0"
+version = "0.35.1"
 edition = "2021"
 rust-version = "1.89"
 authors = ["Noah Gift <noah@paiml.com>"]
@@ -467,6 +467,21 @@ default = ["cli"]
 # Pulls in apr-cli (binary CLI implementation). Required to build the `apr`
 # binary. Library-only consumers should set `default-features = false`.
 cli = ["dep:apr-cli"]
+
+# Feature passthroughs — let end users do
+#   cargo install aprender --features cuda
+# without knowing about the apr-cli intermediate crate.
+cuda = ["cli", "apr-cli/cuda"]
+cuda-batch = ["cli", "apr-cli/cuda-batch"]
+wgpu = ["cli", "apr-cli/wgpu"]
+inference = ["cli", "apr-cli/inference"]
+training = ["cli", "apr-cli/training"]
+training-gpu = ["cli", "apr-cli/training-gpu"]
+visualization = ["cli", "apr-cli/visualization"]
+zram = ["cli", "apr-cli/zram"]
+xet = ["cli", "apr-cli/xet"]
+whisper = ["cli", "apr-cli/whisper"]
+full = ["cli", "apr-cli/full"]
 
 [lib]
 name = "aprender"

--- a/README.md
+++ b/README.md
@@ -20,10 +20,28 @@
 ## Quick Start
 
 ```bash
-cargo install aprender
+cargo install aprender                    # CPU + wgpu (default features)
+cargo install aprender --features cuda    # GPU acceleration (NVIDIA, ~20× faster)
+cargo install aprender --features full    # everything (training, visualization, zram)
+
 apr pull qwen2.5-coder-1.5b
 apr run qwen2.5-coder-1.5b "What is 2+2?"
 ```
+
+> **⏸ 3-month hiatus: v0.35.0/v0.35.1 is the last release until 2026-08-22.**
+> Bug-fix PRs continue to merge to `main` during the hiatus; the next versioned
+> release will batch them as v0.36.0. Use `cargo install --git
+> https://github.com/paiml/aprender` to track `main` HEAD in the meantime.
+
+> **v0.35.1 — Root facade feature passthroughs.** `cargo install aprender
+> --features cuda` (and `wgpu`, `inference`, `training`, `full`, etc.) now work
+> directly. See [v0.35.1 release notes](https://github.com/paiml/aprender/releases/tag/v0.35.1).
+
+> **v0.35.0 — Dogfood-driven release.** 8-beat Qwen end-to-end story added to
+> the test contract surface; multi-step wgpu parity gate catches 7B Q4K
+> autoregressive drift; `apr qa` Golden Output gate now sets `stop_tokens`
+> (closes #1864 — was a 5-line config gap, not a deep cuBLAS bug). See
+> [v0.35.0 release notes](https://github.com/paiml/aprender/releases/tag/v0.35.0).
 
 > **v0.34.0 — MODEL-2 §88 stack-existence-proof shipped end-to-end.**
 > [`paiml/albor-370m-v1`](https://huggingface.co/paiml/albor-370m-v1) is the
@@ -53,7 +71,7 @@ publishing — all backed by YAML provable contracts that fail CI on drift.
 | Metric | Count | Source of truth |
 |-------:|------:|---|
 | Workspace crates | **80** workspace crates | `ls crates/` |
-| Provable contracts | **1151** provable contracts | `find contracts/ -name '*.yaml'` |
+| Provable contracts | **1153** provable contracts | `find contracts/ -name '*.yaml'` |
 | CLI commands | **103** CLI commands | `apr --help` |
 
 These numbers are enforced by [`contracts/readme-claims-v1.yaml`](contracts/readme-claims-v1.yaml).
@@ -242,7 +260,7 @@ paiml/aprender/
 │   ├── aprender-profile/           # Profiling
 │   ├── aprender-db/ aprender-graph/ aprender-rag/
 │   └── ... (80 crates total)
-├── contracts/                      # 1151 provable YAML contracts
+├── contracts/                      # 1153 provable YAML contracts
 └── book/                           # mdBook documentation
 ```
 


### PR DESCRIPTION
## Summary

Post-publish dogfood of v0.35.0 surfaced a packaging gap: `cargo install aprender --features cuda` fails because the root facade only exposes `cli` + `default`. Per memory/feedback_cuda_feature_footgun, `--features cuda` is the documented install command for GPU users (20 vs 400 tok/s on RTX 4090).

## Fix

Add 11 passthrough features to root Cargo.toml that forward to apr-cli/*:

```
cuda = ["cli", "apr-cli/cuda"]
cuda-batch = ["cli", "apr-cli/cuda-batch"]
wgpu = ["cli", "apr-cli/wgpu"]
inference = ["cli", "apr-cli/inference"]
training = ["cli", "apr-cli/training"]
training-gpu = ["cli", "apr-cli/training-gpu"]
visualization = ["cli", "apr-cli/visualization"]
zram = ["cli", "apr-cli/zram"]
xet = ["cli", "apr-cli/xet"]
whisper = ["cli", "apr-cli/whisper"]
full = ["cli", "apr-cli/full"]
```

## Versioning

- Root facade: `0.35.0 → 0.35.1`
- Sub-crates: stay at `0.35.0`
- `aprender@0.35.1` depends on `apr-cli@0.35.0` (no transitive churn)
- Only `aprender` needs republishing to crates.io

## End-user impact

After v0.35.1 lands on crates.io, both of these will work:

```bash
cargo install aprender                    # CPU only (already worked)
cargo install aprender --features cuda    # GPU (newly enabled)
cargo install aprender --features full    # everything
```

## Verification

- `cargo metadata` registers all 11 new features ✓
- `cargo check` parses correctly ✓
- Dogfood post-publish will rerun on v0.35.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)