### PR TITLE
chore: sync Cargo.lock to aprender@0.35.1 (post-publish)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "aprender"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "apr-cli",
  "aprender-core",
@@ -888,7 +888,7 @@ dependencies = [
 name = "aprender-monte-carlo"
 version = "0.35.0"
 dependencies = [
- "aprender 0.35.0",
+ "aprender 0.35.1",
  "assert_cmd",
  "chrono",
  "clap",
@@ -1789,7 +1789,7 @@ dependencies = [
 name = "aprender-tsp"
 version = "0.35.0"
 dependencies = [
- "aprender 0.35.0",
+ "aprender 0.35.1",
  "assert_cmd",
  "clap",
  "crc32fast",


### PR DESCRIPTION
## Summary

Post-publish housekeeping: bump `aprender` entry in `Cargo.lock` to `0.35.1` to match the [`aprender@0.35.1`](https://crates.io/crates/aprender/0.35.1) that shipped to crates.io after PR #1895.

## Why

Workspace Cargo.toml says `version = "0.35.1"` (since #1895 merged), but `Cargo.lock` still listed `aprender 0.35.0`. Downstream `cargo install --git` users would see the right code but the wrong manifest version. This 3-line lockfile delta closes the drift.

## Diff

```
[[package]]
 name = "aprender"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "apr-cli",
  "aprender-core",
]
```

Plus two transitive `aprender 0.35.0 → 0.35.1` references in the deps of `aprender-monte-carlo` and `aprender-tsp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)