### PR TITLE
fix(readme): apr cookbook subcommand does not exist (post-publish dogfood)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,10 +68,10 @@ End-to-end recipes (data prep → train → quantize → publish → serve) live
 examples with local `book/src/` walkthroughs.
 
 ```bash
-git clone https://github.com/paiml/apr-cookbook  # ../apr-cookbook
-cd ../apr-cookbook
-apr cookbook list                              # 341 recipes
-apr cookbook run train-tiny-from-scratch       # runs end-to-end
+git clone https://github.com/paiml/apr-cookbook
+cd apr-cookbook
+cargo run --example bundle_static_model         # any example
+mdbook serve book                               # walkthrough docs
 ```
 
 ## Install


### PR DESCRIPTION
## Summary

Post-publish v0.35.2 dogfood found `apr cookbook list` returns "unrecognized subcommand". The README documented a CLI interface that doesn't exist — the cookbook is a library + examples crate, used via `cargo run --example` + `mdbook serve book`.

## Fix

Replace 4 lines in the Cookbook section:

```diff
- git clone https://github.com/paiml/apr-cookbook  # ../apr-cookbook
- cd ../apr-cookbook
- apr cookbook list                              # 341 recipes
- apr cookbook run train-tiny-from-scratch       # runs end-to-end
+ git clone https://github.com/paiml/apr-cookbook
+ cd apr-cookbook
+ cargo run --example bundle_static_model         # any example by name
+ mdbook serve book                               # walkthrough docs
```

## Why the contract gate didn't catch it

`FALSIFY-README-004` only checks for the presence of the cookbook link, not the runnability of the example commands. Adding a runnability check would require either (a) running each command in CI (heavy) or (b) parsing the README for `apr <subcommand>` and validating against `apr --help`. Out of scope for hiatus close-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)