### PR TITLE
docs(roadmap): correct ROADMAP.md staleness — v0.2.0 "(Current)" → v0.35.2

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,21 +2,39 @@
 
 Next Generation Machine Learning in Pure Rust
 
-## Version Status
+## Current status
 
-| Version | Status | Description |
-|---------|--------|-------------|
-| v0.1.0  | ✅ **Released** | Foundation - Linear Regression + K-Means |
-| v0.2.0  | ✅ **Released** | Decision Trees, Random Forests, Cross-Validation, Serialization |
-| v0.3.0  | ✅ **Released** | Regularization & Optimization |
-| v0.4.0  | ✅ **Released** | TOP 10 ML Algorithms Complete |
-| v0.4.1  | ✅ **Released** | Graph Algorithms, Advanced Clustering, Anomaly Detection, Stats |
-| v0.5.0  | Planned | Neural Networks |
-| v1.0.0  | Planned | Production Hardening |
+> **v0.35.2** (2026-05-22) — published to crates.io: `cargo install aprender` → `apr`.
+
+Aprender is now an **80-crate monorepo** spanning model **training**, **inference**
+(realizar), **SIMD/GPU compute** (trueno), and a **103-subcommand `apr` CLI** — well
+beyond the single-algorithm releases this file originally tracked. 25,300+ tests,
+1148+ provable contracts.
+
+**This file is a high-level version overview, not the working backlog.** The
+canonical, issue-linked roadmap is
+[`docs/roadmaps/roadmap.yaml`](docs/roadmaps/roadmap.yaml); per-release detail is in
+[`CHANGELOG.md`](CHANGELOG.md) and active design specs in
+[`docs/specifications/`](docs/specifications/).
+
+| Version | Status | Headline |
+|---------|--------|----------|
+| v0.1.0 | ✅ Released | Foundation — Linear Regression + K-Means |
+| v0.2.0–v0.4.1 | ✅ Released | TOP 10 ML algorithms, trees/ensembles, cross-validation, graph algorithms, stats |
+| v0.7.x | ✅ Released | ARIMA, text processing, Bayesian inference, GLMs, ICA |
+| v0.11–v0.30 | ✅ Released | Monorepo consolidation, `apr` CLI, APR/GGUF/SafeTensors formats, quantization, inference server |
+| v0.31–v0.34 | ✅ Released | MoE serving, distillation pipeline, MODEL-1 code model, provable-contract expansion |
+| **v0.35.2** | ✅ **Current** | Hiatus close-out (eval/distill fixes, book completeness, DX) — last release before the 2026-08-22 hiatus |
+| _next_ | 📋 Planned | tracked in [`docs/roadmaps/roadmap.yaml`](docs/roadmaps/roadmap.yaml) |
 
 ---
 
-## v0.2.0: Tree Models & Cross-Validation (Current)
+**Early-version history (detail).** The per-version sections below are the
+original v0.1–v0.8 development notes, retained for historical context. They
+**predate the monorepo consolidation** and do not reflect the current
+architecture — see the canonical roadmap linked above.
+
+## v0.2.0: Tree Models & Cross-Validation
 
 **Target**: Decision Trees, Random Forests, Model Selection, Model Persistence
 


### PR DESCRIPTION
## Problem

\`ROADMAP.md:19\` declared:

\`\`\`
## v0.2.0: Tree Models & Cross-Validation (Current)
\`\`\`

…while HEAD ships **v0.35.2** — the repo-root, crates.io-facing roadmap was **33 minor versions stale**. The "Version Status" table stopped at v0.4.1 with "v0.5.0 Neural Networks (Planned)", and the detailed sections were abandoned around v0.8.x — all predating the 80-crate monorepo consolidation, the \`apr\` CLI, inference, quantization, MoE, and the distillation pipeline.

(Surfaced by a repo-wide roadmap analysis as the cross-cutting first action.)

## Fix

- Replace the stale table with an accurate **Current status** callout (v0.35.2 + what aprender is now) and a condensed, truthful version history through v0.35.2.
- Point readers to the canonical, issue-linked roadmap [\`docs/roadmaps/roadmap.yaml\`](docs/roadmaps/roadmap.yaml), [\`CHANGELOG.md\`](CHANGELOG.md), and [\`docs/specifications/\`](docs/specifications/) — this file is now explicitly a high-level overview, not the working backlog.
- Drop the false **(Current)** label; frame the v0.1–v0.8 sections as historical early-version notes that predate the monorepo.

**No forward commitments are invented** — the corrected file states current reality and defers the working plan to the canonical roadmap. Docs-only; `## Current status` + the v0.1–v0.8 detail sections now sit at consistent heading levels, no `(Current)` remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)