### PR TITLE
perf(ci): mold linker for workspace-test compile (cut the link phase sccache can't cache)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,6 +198,14 @@ jobs:
         # saturation (7+ concurrent CI runs) we observed 55min hits
         # exactly at the timeout — runs 25919246467 / 25919258460 /
         # sibling PRs failed simultaneously at 55:00.0.
+        #
+        # 2026-06-10: RUSTFLAGS=-Clink-arg=-fuse-ld=mold (mold 1.10.1 ships in
+        # the sovereign-ci image) attacks the *linking* cost above — the one
+        # phase sccache cannot cache. Set IDENTICALLY on the compute +
+        # integration steps below so all three share one sccache key + target
+        # fingerprint (a differing RUSTFLAGS would force a full recompile per
+        # step). NOT applied to the `coverage` job: mold breaks LLVM coverage
+        # instrumentation (see Makefile, two-phase coverage workaround).
         timeout-minutes: 75
         run: |
           docker run --rm \
@@ -214,6 +222,7 @@ jobs:
             -e CARGO_BUILD_JOBS=8 \
             -e CARGO_PROFILE_TEST_DEBUG=line-tables-only \
             -e CARGO_PROFILE_DEV_DEBUG=line-tables-only \
+            -e RUSTFLAGS="-C link-arg=-fuse-ld=mold" \
             "$IMAGE" \
             cargo test --workspace --lib --exclude aprender-gpu --exclude aprender-cuda-edge --exclude aprender-compute
       - name: Compute tests (tolerate SIGSEGV at exit — all tests pass but harness crashes on cleanup)
@@ -230,6 +239,7 @@ jobs:
             -e SCCACHE_DIR=/sccache \
             -e CARGO_INCREMENTAL=0 \
             -e CARGO_BUILD_JOBS=8 \
+            -e RUSTFLAGS="-C link-arg=-fuse-ld=mold" \
             "$IMAGE" \
             bash -c 'cargo test -p aprender-compute --lib 2>&1 | tee /tmp/compute-test.log; grep -q "test result.*0 failed" /tmp/compute-test.log'
       - name: Integration tests
@@ -246,6 +256,7 @@ jobs:
             -e SCCACHE_DIR=/sccache \
             -e CARGO_INCREMENTAL=0 \
             -e CARGO_BUILD_JOBS=8 \
+            -e RUSTFLAGS="-C link-arg=-fuse-ld=mold" \
             "$IMAGE" \
             bash -c 'cargo test -p aprender-core --test monorepo_invariants && cargo test -p aprender-core --test readme_contract && cargo test -p apr-cli --test cli_commands'
       - name: Build.rs crate-root escape check (v0.31.1 yank guard)


### PR DESCRIPTION
## Problem

`workspace-test` is the long pole in CI. Its own comment is the diagnosis:

> sccache covers codegen (~80% hit rate on warm cache) **but cargo's metadata + linking + test binaries still cost ~40-50min cold**.

Steady-state (warm) the job is **~20 min**; the **~40-50 min** figure is the **cold** case (fresh target dir + cold/stale sccache) — which is exactly what's happening on the current post-hiatus runs. **Linking is the one phase sccache cannot cache**, and we link ~77 test binaries (the big ones — `apr-cli`, `aprender-core` — link a lot).

## Investigation → why mold is the best *implementable* fix

| Candidate | Verdict |
|---|---|
| **mold linker** | ✅ **mold 1.10.1 is already in the `sovereign-ci` image** (verified: links a working binary). Attacks the uncached link phase. Implementable here, zero image change. |
| `cargo-nextest` | ❌ **not in the image** — would need a paiml/infra image rebuild, or a fragile per-run binary download (external network dep in CI). Out of scope. |
| shard tests across the 15 runners | ❌ **all 15 `intel-clean-room` runners share ONE 32-core host (`mac-server`)** — sharding splits the same CPU pool, so it gives **no single-PR latency win**, only throughput. |
| bump `CARGO_BUILD_JOBS` | ❌ host is shared across intra-PR jobs *and* concurrent PRs → bumping risks oversubscription. Left at 8. |

## Change

`RUSTFLAGS=-Clink-arg=-fuse-ld=mold` on the three compiling steps (workspace lib / compute / integration), set **identically** so they share one sccache key + target fingerprint (a differing value would force a full recompile per step).

**Coverage is deliberately untouched** — mold breaks LLVM coverage instrumentation (Makefile two-phase workaround); the `coverage` job lives in the reusable workflow and gets no mold.

## Validation

- mold smoke-tested in the container ✅; `ci.yml` parses ✅; mold scoped to the 3 steps only, never near `llvm-cov` ✅.
- ⚠️ **The first run after merge is cold** (new RUSTFLAGS → new sccache key → one rebuild). Compare a **warm** mold run vs the **~20 min warm no-mold** baseline, not the immediate post-merge run.

Follow-ups for bigger gains (need paiml/infra): bake `cargo-nextest` into the image (2-3× on the test-execution phase + unlocks partitioning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)