### PR TITLE
feat(distill): per-position knowledge distillation — release v0.36.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.0] - 2026-06-10
+
+### Added
+
+- **Per-position knowledge distillation** (full-sequence KD) for the
+  `aprender-train-distill` pipeline. The existing per-row path trains on ONE
+  target per window (the next token after the window); per-position KD trains
+  on EVERY position (position `p` predicts token `p+1`), giving up to
+  `seq_len`× more distillation signal per forward pass. New
+  `kd_step_per_position`, and additive trait methods `logits_per_position` /
+  `apply_kd_gradient_per_position` (teacher + student) /
+  `next_batch_per_position` (BatchSource) whose **defaults wrap the per-row
+  methods** — so existing providers, including the CUDA backend, compile and
+  behave unchanged. Opt-in via `APR_DISTILL_PER_POSITION` (default off → the
+  production loop is byte-identical). Contract:
+  `contracts/distill-per-position-kd-v1.yaml` (5 falsifiers + 2 kani
+  harnesses, all passing on the CPU/fixture path).
+  - **Scope:** the CPU/fixture path is fully verified. The real throughput
+    benefit needs the CUDA teacher/student to emit all-position logits (a GPU
+    forward change) — until then CUDA falls back to one position via the
+    defaults. That GPU per-position forward is a documented follow-up.
+  - While implementing, corrected a **misleading comment** in
+    `ShardBatchSource` that claimed "identity-mapping semantics": the per-row
+    labels were always genuine next-token (`LMBatch` causal-shifted target),
+    not identity. Pinned by a falsifier so it can't mislead again.
+
 ### Fixed
 
 - **PMAT-706 re-land**: the `APR_DISTILL_MAX_STEPS=N` smoke-validation mode

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,7 +284,7 @@ dependencies = [
 
 [[package]]
 name = "apr-cli"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "alimentar",
  "anyhow",
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "aprender"
-version = "0.35.2"
+version = "0.36.0"
 dependencies = [
  "apr-cli",
  "aprender-core",
@@ -411,7 +411,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-bench-compute"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "aprender-core",
  "criterion 0.7.0",
@@ -420,7 +420,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-bench-tokenizer"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "aprender-core",
  "criterion 0.7.0",
@@ -429,7 +429,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cbtop"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "aprender-compute",
@@ -454,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cgp"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "aprender-gpu",
@@ -474,7 +474,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-common"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "lz4_flex 0.11.6",
  "zstd",
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-compute"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "aprender-core",
@@ -531,7 +531,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-compute-xtask"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "bashrs",
@@ -544,7 +544,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-contracts"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "aprender-contracts-macros",
  "criterion 0.5.1",
@@ -559,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-contracts-cli"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "aprender-contracts",
  "clap",
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-contracts-macros"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-core"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "aes-gcm",
  "alimentar",
@@ -632,7 +632,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cuda-edge"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "aprender-gpu",
  "proptest",
@@ -643,7 +643,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cupti"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "bindgen 0.71.1",
  "bitflags 2.11.0",
@@ -653,7 +653,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-data"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-db"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "arrow 57.3.0",
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-distribute"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "arrow 57.3.0",
  "bincode",
@@ -781,7 +781,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-explain"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "aprender-gpu",
  "clap",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-fft"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -808,7 +808,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-gemm-codegen"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-gpu"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "aprender-profile",
  "batuta-common",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-graph"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "aprender-core",
@@ -862,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-image"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-mcp"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -886,9 +886,9 @@ dependencies = [
 
 [[package]]
 name = "aprender-monte-carlo"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
- "aprender 0.35.2",
+ "aprender 0.36.0",
  "assert_cmd",
  "chrono",
  "clap",
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-orchestrate"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "alimentar",
  "anyhow",
@@ -979,7 +979,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-cli"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "aprender-present-yaml",
  "clap",
@@ -992,7 +992,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-core"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "aprender-compute",
  "criterion 0.7.0",
@@ -1005,7 +1005,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-layout"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "aprender-present-core",
  "criterion 0.7.0",
@@ -1016,7 +1016,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-lib"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "aprender-present-core",
  "aprender-present-layout",
@@ -1045,7 +1045,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-terminal"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "aprender-present-core",
  "bitvec",
@@ -1067,7 +1067,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-test"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "aprender-present-core",
  "aprender-present-test-macros",
@@ -1078,7 +1078,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-test-macros"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1087,7 +1087,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-widgets"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "aprender-present-core",
  "aprender-present-yaml",
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-yaml"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "aprender-present-core",
  "proptest",
@@ -1109,7 +1109,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-profile"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "addr2line 0.25.1",
  "anyhow",
@@ -1162,7 +1162,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-profile-core"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "hex",
  "serde",
@@ -1172,7 +1172,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-ptx-debug"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "proptest",
  "thiserror 2.0.18",
@@ -1180,7 +1180,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-certify"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "chrono",
  "proptest",
@@ -1190,7 +1190,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-cli"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "aprender-qa-certify",
  "aprender-qa-gen",
@@ -1209,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-gen"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1226,7 +1226,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-report"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "aprender-qa-gen",
@@ -1244,7 +1244,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-runner"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "aprender-qa-gen",
@@ -1269,14 +1269,14 @@ dependencies = [
 
 [[package]]
 name = "aprender-quant"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "half",
 ]
 
 [[package]]
 name = "aprender-rag"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "batuta-common",
@@ -1307,7 +1307,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-rand"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1316,7 +1316,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-registry"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "alimentar",
  "anyhow",
@@ -1346,7 +1346,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-serve"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "alimentar",
  "anyhow",
@@ -1413,7 +1413,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-shell"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "aprender-core",
  "assert_cmd",
@@ -1430,7 +1430,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-simulate"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "bincode",
  "bitflags 2.11.0",
@@ -1469,7 +1469,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-solve"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1478,7 +1478,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-sparse"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1487,7 +1487,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-tensor"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1496,7 +1496,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-cli"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "aprender-test-lib",
  "assert_cmd",
@@ -1524,7 +1524,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-derive"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1534,7 +1534,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-js-gen"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -1550,7 +1550,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-lib"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "aprender-compute",
  "aprender-present-core",
@@ -1594,7 +1594,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-showcase"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "aprender-present-terminal",
  "console_error_panic_hook",
@@ -1611,7 +1611,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "alimentar",
  "approx",
@@ -1678,7 +1678,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-bench"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1695,7 +1695,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-common"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "clap",
  "proptest",
@@ -1707,7 +1707,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-distill"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1728,7 +1728,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-inspect"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1744,7 +1744,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-lora"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-shell"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1776,7 +1776,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-wasm"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "proptest",
  "serde",
@@ -1787,9 +1787,9 @@ dependencies = [
 
 [[package]]
 name = "aprender-tsp"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
- "aprender 0.35.2",
+ "aprender 0.36.0",
  "assert_cmd",
  "clap",
  "crc32fast",
@@ -1802,7 +1802,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-verify"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "chrono",
  "criterion 0.5.1",
@@ -1814,7 +1814,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-verify-ml"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "aprender-core",
  "aprender-profile",
@@ -1858,7 +1858,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-viz"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "approx",
  "aprender-core",
@@ -1893,7 +1893,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "aprender-zram-adaptive",
  "aprender-zram-core",
@@ -1903,7 +1903,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-adaptive"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "aprender-zram-core",
  "proptest",
@@ -1912,7 +1912,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-cli"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "aprender-zram-adaptive",
  "aprender-zram-core",
@@ -1926,7 +1926,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-core"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "aprender-gpu",
  "criterion 0.7.0",
@@ -1938,7 +1938,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-generator"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "aprender-zram-core",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.35.0"
+version = "0.36.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/paiml/aprender"
@@ -171,7 +171,7 @@ minijinja = { version = "2.14", features = ["loader", "serde"] }
 # Contracts
 provable-contracts = "0.3"
 provable-contracts-macros = "0.3"
-aprender-contracts-macros = { path = "crates/aprender-contracts-macros", version = "0.35.0" }
+aprender-contracts-macros = { path = "crates/aprender-contracts-macros", version = "0.36.0" }
 
 # YAML
 serde_yaml = "0.9"
@@ -183,31 +183,31 @@ hf-hub = { version = "0.4", default-features = false, features = ["ureq"] }
 hf-xet = "1.5.1"
 
 # Workspace-internal crates (paths within the monorepo)
-aprender-compute = { path = "crates/aprender-compute", version = "0.35.0" }
-aprender-gpu = { path = "crates/aprender-gpu", version = "0.35.0" }
-aprender-quant = { path = "crates/aprender-quant", version = "0.35.0" }
-aprender-serve = { path = "crates/aprender-serve", version = "0.35.0" }
-realizar = { path = "crates/aprender-serve", version = "0.35.0", package = "aprender-serve" }
-aprender-train = { path = "crates/aprender-train", version = "0.35.0" }
-entrenar = { path = "crates/aprender-train", version = "0.35.0", package = "aprender-train" }
-aprender-train-common = { path = "crates/aprender-train-common", version = "0.35.0" }
-aprender-train-distill = { path = "crates/aprender-train-distill", version = "0.35.0" }
-aprender-orchestrate = { path = "crates/aprender-orchestrate", version = "0.35.0" }
-aprender-contracts = { path = "crates/aprender-contracts", version = "0.35.0" }
-aprender-profile = { path = "crates/aprender-profile", version = "0.35.0" }
-aprender-profile-core = { path = "crates/aprender-profile-core", version = "0.35.0" }
-aprender-zram-core = { path = "crates/aprender-zram-core", version = "0.35.0" }
-aprender-zram-adaptive = { path = "crates/aprender-zram-adaptive", version = "0.35.0" }
-aprender-present-core = { path = "crates/aprender-present-core", version = "0.35.0" }
-aprender-present-terminal = { path = "crates/aprender-present-terminal", version = "0.35.0" }
-aprender-present-widgets = { path = "crates/aprender-present-widgets", version = "0.35.0" }
-aprender-present-layout = { path = "crates/aprender-present-layout", version = "0.35.0" }
-aprender-present-yaml = { path = "crates/aprender-present-yaml", version = "0.35.0" }
-aprender-present-test = { path = "crates/aprender-present-test", version = "0.35.0" }
-aprender-db = { path = "crates/aprender-db", version = "0.35.0" }
-aprender-graph = { path = "crates/aprender-graph", version = "0.35.0" }
-aprender-rag = { path = "crates/aprender-rag", version = "0.35.0" }
-aprender-data = { path = "crates/aprender-data", version = "0.35.0" }
+aprender-compute = { path = "crates/aprender-compute", version = "0.36.0" }
+aprender-gpu = { path = "crates/aprender-gpu", version = "0.36.0" }
+aprender-quant = { path = "crates/aprender-quant", version = "0.36.0" }
+aprender-serve = { path = "crates/aprender-serve", version = "0.36.0" }
+realizar = { path = "crates/aprender-serve", version = "0.36.0", package = "aprender-serve" }
+aprender-train = { path = "crates/aprender-train", version = "0.36.0" }
+entrenar = { path = "crates/aprender-train", version = "0.36.0", package = "aprender-train" }
+aprender-train-common = { path = "crates/aprender-train-common", version = "0.36.0" }
+aprender-train-distill = { path = "crates/aprender-train-distill", version = "0.36.0" }
+aprender-orchestrate = { path = "crates/aprender-orchestrate", version = "0.36.0" }
+aprender-contracts = { path = "crates/aprender-contracts", version = "0.36.0" }
+aprender-profile = { path = "crates/aprender-profile", version = "0.36.0" }
+aprender-profile-core = { path = "crates/aprender-profile-core", version = "0.36.0" }
+aprender-zram-core = { path = "crates/aprender-zram-core", version = "0.36.0" }
+aprender-zram-adaptive = { path = "crates/aprender-zram-adaptive", version = "0.36.0" }
+aprender-present-core = { path = "crates/aprender-present-core", version = "0.36.0" }
+aprender-present-terminal = { path = "crates/aprender-present-terminal", version = "0.36.0" }
+aprender-present-widgets = { path = "crates/aprender-present-widgets", version = "0.36.0" }
+aprender-present-layout = { path = "crates/aprender-present-layout", version = "0.36.0" }
+aprender-present-yaml = { path = "crates/aprender-present-yaml", version = "0.36.0" }
+aprender-present-test = { path = "crates/aprender-present-test", version = "0.36.0" }
+aprender-db = { path = "crates/aprender-db", version = "0.36.0" }
+aprender-graph = { path = "crates/aprender-graph", version = "0.36.0" }
+aprender-rag = { path = "crates/aprender-rag", version = "0.36.0" }
+aprender-data = { path = "crates/aprender-data", version = "0.36.0" }
 
 # Additional external deps needed by sub-crates
 serde_yaml_ng = "0.10"
@@ -252,25 +252,25 @@ wasmtime = "43"
 bollard = "0.17"
 
 # Old crate name aliases (workspace = true refs in migrated sub-crates)
-trueno-zram-core = { path = "crates/aprender-zram-core", version = "0.35.0", package = "aprender-zram-core" }
-trueno-zram-adaptive = { path = "crates/aprender-zram-adaptive", version = "0.35.0", package = "aprender-zram-adaptive" }
-trueno = { path = "crates/aprender-compute", version = "0.35.0", package = "aprender-compute" }
-presentar-core = { path = "crates/aprender-present-core", version = "0.35.0", package = "aprender-present-core" }
-presentar-terminal = { path = "crates/aprender-present-terminal", version = "0.35.0", package = "aprender-present-terminal" }
-presentar-widgets = { path = "crates/aprender-present-widgets", version = "0.35.0", package = "aprender-present-widgets" }
-presentar-layout = { path = "crates/aprender-present-layout", version = "0.35.0", package = "aprender-present-layout" }
-presentar-yaml = { path = "crates/aprender-present-yaml", version = "0.35.0", package = "aprender-present-yaml" }
-presentar-test = { path = "crates/aprender-present-test", version = "0.35.0", package = "aprender-present-test" }
-presentar-test-macros = { path = "crates/aprender-present-test-macros", version = "0.35.0", package = "aprender-present-test-macros" }
-jugar-probar-derive = { path = "crates/aprender-test-derive", version = "0.35.0", package = "aprender-test-derive" }
-batuta-common = { path = "crates/aprender-common", version = "0.35.0", package = "aprender-common" }
+trueno-zram-core = { path = "crates/aprender-zram-core", version = "0.36.0", package = "aprender-zram-core" }
+trueno-zram-adaptive = { path = "crates/aprender-zram-adaptive", version = "0.36.0", package = "aprender-zram-adaptive" }
+trueno = { path = "crates/aprender-compute", version = "0.36.0", package = "aprender-compute" }
+presentar-core = { path = "crates/aprender-present-core", version = "0.36.0", package = "aprender-present-core" }
+presentar-terminal = { path = "crates/aprender-present-terminal", version = "0.36.0", package = "aprender-present-terminal" }
+presentar-widgets = { path = "crates/aprender-present-widgets", version = "0.36.0", package = "aprender-present-widgets" }
+presentar-layout = { path = "crates/aprender-present-layout", version = "0.36.0", package = "aprender-present-layout" }
+presentar-yaml = { path = "crates/aprender-present-yaml", version = "0.36.0", package = "aprender-present-yaml" }
+presentar-test = { path = "crates/aprender-present-test", version = "0.36.0", package = "aprender-present-test" }
+presentar-test-macros = { path = "crates/aprender-present-test-macros", version = "0.36.0", package = "aprender-present-test-macros" }
+jugar-probar-derive = { path = "crates/aprender-test-derive", version = "0.36.0", package = "aprender-test-derive" }
+batuta-common = { path = "crates/aprender-common", version = "0.36.0", package = "aprender-common" }
 # APR-MONO sibling aliases — MUST use workspace refs, NEVER crates.io versions.
 # Hard-pinning these to crates.io creates a diamond: sub-crates pull older
 # aprender versions → multiple `aprender` crates in Cargo.lock = MUDA.
-renacer = { path = "crates/aprender-profile", version = "0.35.0", package = "aprender-profile" }
-entrenar-lora = { path = "crates/aprender-train-lora", version = "0.35.0", package = "aprender-train-lora" }
-batuta = { path = "crates/aprender-orchestrate", version = "0.35.0", package = "aprender-orchestrate" }
-trueno-graph = { path = "crates/aprender-graph", version = "0.35.0", package = "aprender-graph" }
+renacer = { path = "crates/aprender-profile", version = "0.36.0", package = "aprender-profile" }
+entrenar-lora = { path = "crates/aprender-train-lora", version = "0.36.0", package = "aprender-train-lora" }
+batuta = { path = "crates/aprender-orchestrate", version = "0.36.0", package = "aprender-orchestrate" }
+trueno-graph = { path = "crates/aprender-graph", version = "0.36.0", package = "aprender-graph" }
 
 [workspace.lints.rust]
 # Safety
@@ -428,7 +428,7 @@ semicolon_if_nothing_returned = "allow"  # Style preference
 
 [package]
 name = "aprender"
-version = "0.35.2"
+version = "0.36.0"
 edition = "2021"
 rust-version = "1.89"
 authors = ["Noah Gift <noah@paiml.com>"]
@@ -458,7 +458,7 @@ required-features = ["cli"]
 # (e.g. apr-cookbook, downstream apps) don't pull apr-cli's heavy transitive
 # dep graph (renacer/profile/inference/zram/visualization). `cargo install
 # aprender` still works because `cli` is in default features. See GH-1599.
-apr-cli = { path = "crates/apr-cli", version = "0.35.0", default-features = true, optional = true }
+apr-cli = { path = "crates/apr-cli", version = "0.36.0", default-features = true, optional = true }
 # Core ML library (lib name = "aprender")
 aprender_ml = { path = "crates/aprender-core", version = ">=0.29", package = "aprender-core" }
 

--- a/contracts/distill-per-position-kd-v1.yaml
+++ b/contracts/distill-per-position-kd-v1.yaml
@@ -1,0 +1,162 @@
+metadata:
+  version: 1.0.0
+  created: '2026-06-10'
+  author: PAIML Engineering
+  description: |
+    Full-sequence (per-position) knowledge distillation for the
+    aprender-train-distill pipeline. The per-row KD path trains on ONE target
+    per window (the next token after the window); per-position KD trains on
+    EVERY position (position p predicts token p+1), giving up to seq_len× more
+    distillation signal per forward pass.
+
+    This is an ADDITIVE capability: new trait methods (`logits_per_position`,
+    `apply_kd_gradient_per_position`, `next_batch_per_position`) default to
+    wrapping the existing per-row methods, so existing providers — including
+    the CUDA backend — compile and behave UNCHANGED. The pipeline branch is
+    opt-in via `APR_DISTILL_PER_POSITION` (default off → the production loop is
+    byte-identical). Fixture providers override the new methods so the path is
+    CPU-falsifiable end-to-end.
+
+    Scope note: the CPU/fixture path is fully verified here. The real benefit
+    requires the CUDA teacher/student to emit all-position logits (a GPU
+    forward change) — until then CUDA falls back to one position via the
+    defaults. That GPU per-position forward is a documented follow-up, NOT
+    covered by these CPU falsifiers.
+  references:
+  - 'SPEC-DISTILL-001 — distillation pipeline'
+  - 'crates/aprender-train/.../transformer_trainer/batch.rs — LMBatch causal-shift layout (target[p]=input[p+1])'
+  - 'contracts/apr-distill-smoke-validation-v1.yaml — sibling distill contract'
+  - 'kd_step.rs kd_loss / kd_logit_gradient — the per-triple primitives reused per (row, position)'
+
+kind: KernelContract
+name: distill-per-position-kd
+version: 1.0.0
+scope: aprender-train-distill kd_step_per_position + BatchSource/Provider per-position methods + Pipeline opt-in branch
+
+equations:
+  per_position_signal:
+    formula: |
+      For a batch of B rows each length L, per-position KD makes B*L
+      next-token predictions (position p predicts token p+1), vs B for the
+      per-row path. avg_loss = (1/(B*L)) * sum over (row, position) of
+      kd_loss(student[row][p], teacher[row][p], label[row][p], T, alpha).
+    domain: B >= 0, L >= 0; labels[row][p] in [0, vocab)
+    codomain: scalar avg_loss; grads shape [B][L][vocab]
+    invariants:
+    - 'per-position prediction count = sum over rows of min(teacher_pos, student_pos, label_pos)'
+    - 'grads[row] has one [vocab] vector per trained position of that row'
+    - 'when student logits == teacher logits at every position and alpha=0, loss and all grads are ~0'
+    - 'ragged rows (unequal teacher/student/label position counts) train on the min-prefix without panic'
+    lean_theorem: Theorems.Per_Position_Signal
+
+  additive_safety:
+    formula: |
+      The per-position trait methods default to wrapping the per-row methods
+      as a single position; the Pipeline per-position branch is gated on
+      `APR_DISTILL_PER_POSITION` (default false).
+    domain: any provider / batch source / pipeline config
+    codomain: behavior of the per-row path
+    invariants:
+    - 'with APR_DISTILL_PER_POSITION unset/false, train() is byte-identical to the per-row path'
+    - 'providers that do not override logits_per_position expose exactly one position (== per-row last position)'
+    - 'CUDA teacher/student compile unchanged (default methods supply the per-position shape)'
+    lean_theorem: Theorems.Additive_Safety
+
+proof_obligations:
+- type: invariant
+  property: per-position trains on all positions
+  formal: |
+    For B rows of length L with matching teacher/student/labels:
+    kd_step_per_position returns grads with sum(|grads[r]|) == B*L (not B).
+- type: invariant
+  property: math correct — zero loss/grad at perfect per-position agreement
+  formal: |
+    If student[r][p] == teacher[r][p] for all (r,p) and alpha=0, then
+    avg_loss < 1e-4 and every grad component has |.| < 1e-4.
+- type: invariant
+  property: ragged rows are safe
+  formal: |
+    For any (teacher_pos, student_pos, label_pos), the trained position count
+    per row is exactly min of the three; no panic, no out-of-bounds.
+- type: classification
+  property: opt-in additive — per-row path unchanged
+  formal: |
+    With APR_DISTILL_PER_POSITION off, Pipeline::train produces the same
+    metrics path as before this contract (per-row); with it on, the pipeline
+    reduces loss end-to-end on the fixture path.
+
+falsification_tests:
+- id: FT-PERPOS-001
+  rule: per-position KD trains on EVERY position (B*L predictions, grads [B][L])
+  prediction: |
+    kd_step_per_position on 2 rows × length 4 returns grads[0].len()==4,
+    grads[1].len()==4, total predictions==8 (not 2).
+  if_fails: |
+    The position loop is off (e.g. only last position used), or grads aren't
+    per-position. Check kd_step_per_position's inner `for p in 0..n_pos`.
+  evidence: cargo test -p aprender-train-distill --lib kd_step::tests::pmat_perpos_001_trains_on_all_positions
+- id: FT-PERPOS-002
+  rule: per-position yields strictly more signal than per-row
+  prediction: |
+    On the same single 4-token row, per-row makes 1 prediction; per-position
+    makes 4. per_pos > per_row.
+  if_fails: |
+    Per-position collapsed to per-row (e.g. only one position emitted). Check
+    the provider override + next_batch_per_position labels length.
+  evidence: cargo test -p aprender-train-distill --lib kd_step::tests::pmat_perpos_002_more_signal_than_per_row
+- id: FT-PERPOS-003
+  rule: zero loss/grad when student==teacher per position (alpha=0)
+  prediction: |
+    With student logits == teacher logits at every position and alpha=0,
+    avg_loss < 1e-4 and all grad components < 1e-4.
+  if_fails: |
+    The per-position KL/grad math diverges from kd_loss/kd_logit_gradient.
+    Verify the primitives are applied per (row, position) unchanged.
+  evidence: cargo test -p aprender-train-distill --lib kd_step::tests::pmat_perpos_003_zero_loss_when_student_equals_teacher
+- id: FT-PERPOS-004
+  rule: ragged rows train on the min-prefix without panic
+  prediction: |
+    teacher 4 positions, student 3, labels 2 → grads[0].len()==2; no panic.
+  if_fails: |
+    n_pos uses max/teacher-only instead of min → index out of bounds. Check
+    `t_rows.len().min(s_rows.len()).min(row_labels.len())`.
+  evidence: cargo test -p aprender-train-distill --lib kd_step::tests::pmat_perpos_004_ragged_rows_use_min_positions
+- id: FT-PERPOS-005
+  rule: pipeline per-position mode reduces loss end-to-end; per-row unchanged
+  prediction: |
+    Pipeline::new(..).with_per_position(true).execute() yields
+    final_loss < initial_loss; with_per_position(false) also reduces loss
+    (per-row path healthy).
+  if_fails: |
+    The opt-in branch is broken (wrong apply_kd_gradient_per_position wiring)
+    or the per-row path regressed. Check the pipeline train() branch.
+  evidence: cargo test -p aprender-train-distill --lib pipeline::tests::falsify_perpos_005_pipeline_per_position_reduces_loss
+
+kani_harnesses:
+- id: KANI-PERPOS-001
+  obligation: trained position count is the min of the three sources (no OOB)
+  property: |
+    For all (tp in [0..16], sp in [0..16], lp in [0..16]): the per-position
+    loop trains exactly min(tp, sp, lp) positions and never indexes beyond any
+    of the three vectors.
+  bound: 16
+  strategy: bounded_int
+  solver: cadical
+  harness: verify_per_position_min_count
+- id: KANI-PERPOS-002
+  obligation: empty / zero-position batch is a no-op, not a panic
+  property: |
+    For B=0 or L=0: kd_step_per_position returns avg_loss=0.0 and empty grads;
+    apply_kd_gradient_per_position on empty input is a no-op.
+  bound: 1
+  strategy: compositional
+  solver: cadical
+  harness: verify_per_position_empty_safe
+
+qa_gate:
+  id: F-PERPOS-001
+  name: distill-per-position-kd-v1 Contract
+  description: Full-sequence per-position KD must train on every position with correct math, be additive/opt-in (per-row path unchanged), and reduce loss end-to-end on the fixture path.
+  checks:
+  - validation
+  - falsification

--- a/crates/apr-cli/Cargo.toml
+++ b/crates/apr-cli/Cargo.toml
@@ -103,10 +103,10 @@ libc = "0.2"
 
 [dependencies]
 # Core aprender library
-aprender = { path = "../aprender-core", version = "0.35.0", package = "aprender-core", default-features = true, features = ["format-compression"] }
+aprender = { path = "../aprender-core", version = "0.36.0", package = "aprender-core", default-features = true, features = ["format-compression"] }
 
 # MCP (Model Context Protocol) server — `apr mcp` subcommand
-aprender-mcp = { path = "../aprender-mcp", version = "0.35.0" }
+aprender-mcp = { path = "../aprender-mcp", version = "0.36.0" }
 async-stream = "0.3"
 provable-contracts-macros = "0.3"
 

--- a/crates/aprender-bench-compute/Cargo.toml
+++ b/crates/aprender-bench-compute/Cargo.toml
@@ -11,7 +11,7 @@ disallowed_methods = "allow"
 
 [dependencies]
 # The implementation under test
-aprender = { path = "../aprender-core", version = "0.35.0", package = "aprender-core", features = ["format-quantize"] }
+aprender = { path = "../aprender-core", version = "0.36.0", package = "aprender-core", features = ["format-quantize"] }
 
 # Reference implementation for A/B comparison
 # Pure Rust (no BLAS) to keep comparison fair — both are pure Rust SIMD

--- a/crates/aprender-bench-tokenizer/Cargo.toml
+++ b/crates/aprender-bench-tokenizer/Cargo.toml
@@ -11,7 +11,7 @@ disallowed_methods = "allow"
 
 [dependencies]
 # The implementation under test
-aprender = { path = "../aprender-core", version = "0.35.0", package = "aprender-core" }
+aprender = { path = "../aprender-core", version = "0.36.0", package = "aprender-core" }
 
 # HuggingFace reference for A/B comparison
 # Regular dep (not dev-dep) because [[bench]] harness=false binaries can't see dev-deps

--- a/crates/aprender-cbtop/Cargo.toml
+++ b/crates/aprender-cbtop/Cargo.toml
@@ -23,8 +23,8 @@ presentar-core = "0.3"
 presentar-terminal = "0.3"
 
 # Compute backends
-trueno = { version = "0.35.0", path = "../aprender-compute", package = "aprender-compute" }
-trueno-gpu = { version = "0.35.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true }
+trueno = { version = "0.36.0", path = "../aprender-compute", package = "aprender-compute" }
+trueno-gpu = { version = "0.36.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true }
 
 # Terminal handling
 crossterm = "0.28"

--- a/crates/aprender-cgp/Cargo.toml
+++ b/crates/aprender-cgp/Cargo.toml
@@ -36,7 +36,7 @@ num_cpus = "1.17"
 comfy-table = "7"
 colored = "3"
 # GPU profiling: direct cuBLAS measurement (OWN THE STACK)
-trueno-gpu = { path = "../aprender-gpu", version = "0.35.0", features = ["cuda"], optional = true, package = "aprender-gpu" }
+trueno-gpu = { path = "../aprender-gpu", version = "0.36.0", features = ["cuda"], optional = true, package = "aprender-gpu" }
 
 [features]
 default = []

--- a/crates/aprender-compute/Cargo.toml
+++ b/crates/aprender-compute/Cargo.toml
@@ -38,11 +38,11 @@ futures-intrusive = { version = "0.5", optional = true }
 wasm-bindgen-futures = { version = "0.4", optional = true }
 wasm-bindgen = { version = "0.2", optional = true }
 # Native CUDA monitoring via trueno-gpu (TRUENO-SPEC-010)
-trueno-gpu = { version = "0.35.0", path = "../aprender-gpu", optional = true, package = "aprender-gpu" }
+trueno-gpu = { version = "0.36.0", path = "../aprender-gpu", optional = true, package = "aprender-gpu" }
 # PMAT-336: Provable contracts compile-time enforcement
 provable-contracts-macros = "0.3"
 # P1a: Sovereign GEMM microkernel codegen (compile-time shape specialization)
-trueno-gemm-codegen = { version = "0.35.0", path = "../aprender-gemm-codegen", package = "aprender-gemm-codegen" }
+trueno-gemm-codegen = { version = "0.36.0", path = "../aprender-gemm-codegen", package = "aprender-gemm-codegen" }
 # Tracing/profiling support (renacer integration)
 tracing = { version = "0.1", optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"], optional = true }
@@ -54,7 +54,7 @@ presentar-core = { version = "0.3", optional = true }
 # Stress test reporting types compatible with renacer (TRUENO-SPEC-025)
 # Note: renacer 0.9.1 has compilation issue; using compatible local types instead
 dhat = { version = "0.3", optional = true }
-trueno-quant = { version = "0.35.0", path = "../aprender-quant", package = "aprender-quant" }
+trueno-quant = { version = "0.36.0", path = "../aprender-quant", package = "aprender-quant" }
 num_cpus = "1.17.0"
 anyhow = "1.0.100"
 # Hardware capability detection (PMAT-447)
@@ -62,7 +62,7 @@ chrono = "0.4"
 toml = "0.8"
 # ML tuner integration (SHOWCASE-BRICK-001, Section 12)
 # Uses aprender 0.24.0 RandomForest for learned optimization
-aprender = { path = "../aprender-core", version = "0.35.0", package = "aprender-core", optional = true, default-features = false }
+aprender = { path = "../aprender-core", version = "0.36.0", package = "aprender-core", optional = true, default-features = false }
 # Execution path graph (PAR-201, Section E.7)
 trueno-graph = { workspace = true, optional = true }
 # TUI visualization for execution graphs (PAR-201)
@@ -90,10 +90,10 @@ nalgebra = "0.34"  # For eigendecomposition benchmark comparison
 simular = "0.2.0"
 regex = "1.11"  # For PTX/WGSL pattern validation in falsification tests
 # GPU edge-case test framework (TCE-001)
-trueno-cuda-edge = { version = "0.35.0", path = "../aprender-cuda-edge", package = "aprender-cuda-edge" }
+trueno-cuda-edge = { version = "0.36.0", path = "../aprender-cuda-edge", package = "aprender-cuda-edge" }
 # Sparse and solver crates for contract tests
-trueno-sparse = { version = "0.35.0", path = "../aprender-sparse", package = "aprender-sparse" }
-trueno-solve = { version = "0.35.0", path = "../aprender-solve", package = "aprender-solve" }
+trueno-sparse = { version = "0.36.0", path = "../aprender-sparse", package = "aprender-sparse" }
+trueno-solve = { version = "0.36.0", path = "../aprender-solve", package = "aprender-solve" }
 ndarray = "0.17.2"
 faer = "0.24"  # For GEMM benchmark comparison (fastest pure-Rust BLAS)
 matrixmultiply = "0.3"  # Direct matrixmultiply crate benchmark (engine behind ndarray)

--- a/crates/aprender-contracts-cli/Cargo.toml
+++ b/crates/aprender-contracts-cli/Cargo.toml
@@ -13,7 +13,7 @@ name = "pv"
 path = "src/main.rs"
 
 [dependencies]
-aprender-contracts = { path = "../aprender-contracts", version = "0.35.0" }
+aprender-contracts = { path = "../aprender-contracts", version = "0.36.0" }
 clap = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }

--- a/crates/aprender-contracts/Cargo.toml
+++ b/crates/aprender-contracts/Cargo.toml
@@ -19,7 +19,7 @@ kani = []
 name = "provable_contracts"
 
 [dependencies]
-provable-contracts-macros = { path = "../aprender-contracts-macros", version = "0.35.0", package = "aprender-contracts-macros" }
+provable-contracts-macros = { path = "../aprender-contracts-macros", version = "0.36.0", package = "aprender-contracts-macros" }
 regex = "1"
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/aprender-cuda-edge/Cargo.toml
+++ b/crates/aprender-cuda-edge/Cargo.toml
@@ -15,7 +15,7 @@ name = "trueno_cuda_edge"
 [dependencies]
 thiserror = "2.0"
 serde = { version = "1.0", features = ["derive"] }
-trueno-gpu = { version = "0.35.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true }
+trueno-gpu = { version = "0.36.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true }
 
 [dev-dependencies]
 proptest = "1.6"

--- a/crates/aprender-explain/Cargo.toml
+++ b/crates/aprender-explain/Cargo.toml
@@ -25,7 +25,7 @@ presentar-terminal = "0.3"
 crossterm = "0.28"
 
 # Internal dependency for PTX generation
-trueno-gpu = { version = "0.35.0", path = "../aprender-gpu", package = "aprender-gpu", features = ["cuda"] }
+trueno-gpu = { version = "0.36.0", path = "../aprender-gpu", package = "aprender-gpu", features = ["cuda"] }
 
 [dev-dependencies]
 proptest = "1.4"

--- a/crates/aprender-graph/Cargo.toml
+++ b/crates/aprender-graph/Cargo.toml
@@ -28,7 +28,7 @@ anyhow = "1"
 thiserror = "2"
 
 # Phase 2+ dependencies
-aprender = { path = "../aprender-core", version = "0.35.0", package = "aprender-core" }                                        # Sparse matrix ops, PageRank
+aprender = { path = "../aprender-core", version = "0.36.0", package = "aprender-core" }                                        # Sparse matrix ops, PageRank
 trueno = "0.17"                                          # SIMD primitives
 trueno-db = "0.3.17"                                     # Columnar storage
 

--- a/crates/aprender-monte-carlo/Cargo.toml
+++ b/crates/aprender-monte-carlo/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 name = "aprender-monte-carlo"
 
 [dependencies]
-aprender = { path = "../../", version = "0.35.0" }
+aprender = { path = "../../", version = "0.36.0" }
 clap = { version = "4", features = ["derive"] }
 rand = "0.9"
 rand_chacha = "0.9"

--- a/crates/aprender-orchestrate/Cargo.toml
+++ b/crates/aprender-orchestrate/Cargo.toml
@@ -117,7 +117,7 @@ pacha = { version = "0.2", optional = true }
 realizar = { version = "0.8", optional = true, features = ["cuda"] }
 
 # ML algorithms and training (native-only)
-aprender = { path = "../aprender-core", version = "0.35.0", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.36.0", package = "aprender-core", optional = true }
 entrenar = { workspace = true, optional = true }
 alimentar = { version = "0.2", optional = true }
 

--- a/crates/aprender-profile/Cargo.toml
+++ b/crates/aprender-profile/Cargo.toml
@@ -74,7 +74,7 @@ trueno = { version = "0.17" }
 
 # Machine learning for anomaly detection (Sprint 23)
 # GH-581: Use path dep to avoid trueno version skew with local workspace
-aprender = { path = "../aprender-core", version = "0.35.0", package = "aprender-core" }
+aprender = { path = "../aprender-core", version = "0.36.0", package = "aprender-core" }
 
 # Lock-free data structures for ring buffer (Sprint 40)
 crossbeam = { version = "0.8", default-features = false, features = ["crossbeam-channel", "crossbeam-queue", "std"] }

--- a/crates/aprender-qa-runner/Cargo.toml
+++ b/crates/aprender-qa-runner/Cargo.toml
@@ -29,7 +29,7 @@ sha2 = "0.10"
 regex = { workspace = true }
 num_cpus = "1.16"
 safetensors = { workspace = true }
-jugar-probar = { version = "0.35.0", path = "../aprender-test-lib", package = "aprender-test-lib", features = ["llm-types"] }
+jugar-probar = { version = "0.36.0", path = "../aprender-test-lib", package = "aprender-test-lib", features = ["llm-types"] }
 # Test fixtures dependencies (optional)
 tempfile = { version = "3", optional = true }
 half = { version = "2.4", optional = true }

--- a/crates/aprender-registry/Cargo.toml
+++ b/crates/aprender-registry/Cargo.toml
@@ -42,7 +42,7 @@ zstd = { version = "0.13", optional = true }
 clap = { version = "4", features = ["derive"], optional = true }
 
 # Ecosystem integration
-aprender = { path = "../aprender-core", version = "0.35.0", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.36.0", package = "aprender-core", optional = true }
 alimentar = { version = "0.2.3", optional = true }
 
 # HTTP client (optional)

--- a/crates/aprender-serve/Cargo.toml
+++ b/crates/aprender-serve/Cargo.toml
@@ -39,7 +39,7 @@ name = "realizar"
 trueno = { version = "0.17", features = ["gpu"] }
 # CUDA PTX generation and runtime for NVIDIA GPUs (optional, pure Rust, no LLVM/nvcc)
 # v0.4.12: BatchedQ6K, MultiWarp, RopeNeox, FlashDecoding kernels
-trueno-gpu = { version = "0.35.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true, features = ["cuda"] }  # APR-MONO single-source-of-truth
+trueno-gpu = { version = "0.36.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true, features = ["cuda"] }  # APR-MONO single-source-of-truth
 # KV cache storage (for attention caching)
 trueno-db = { version = "0.3.16", optional = true }
 # K-quantization formats (Q4_K, Q5_K, Q6_K) - Toyota Way: ONE source of truth
@@ -53,7 +53,7 @@ renacer-core = { version = "0.1" }
 
 # ML algorithms and .apr model format (optional for aprender model serving)
 # v0.24.1: chat templates, GGUF tokenizer preservation (local may be newer)
-aprender = { path = "../aprender-core", version = "0.35.0", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.36.0", package = "aprender-core", optional = true }
 
 # Data loading library (optional for data pipeline examples)
 alimentar = { version = "0.2", optional = true, default-features = false, features = ["local", "shuffle"] }

--- a/crates/aprender-shell/Cargo.toml
+++ b/crates/aprender-shell/Cargo.toml
@@ -24,7 +24,7 @@ harness = false
 
 [dependencies]
 # Use path for local dev, crates.io for release
-aprender = { path = "../aprender-core", version = "0.35.0", package = "aprender-core", features = ["format-encryption", "format-compression", "format-homomorphic"] }
+aprender = { path = "../aprender-core", version = "0.36.0", package = "aprender-core", features = ["format-encryption", "format-compression", "format-homomorphic"] }
 clap = { version = "4", features = ["derive"] }
 dirs = "5"
 serde = { version = "1", features = ["derive"] }

--- a/crates/aprender-test-cli/Cargo.toml
+++ b/crates/aprender-test-cli/Cargo.toml
@@ -24,7 +24,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Core library (was: jugar-probar) — dep key preserves Rust identifier
-jugar-probar = { path = "../aprender-test-lib", version = "0.35.0", package = "aprender-test-lib" }
+jugar-probar = { path = "../aprender-test-lib", version = "0.36.0", package = "aprender-test-lib" }
 
 # CLI framework
 clap = { workspace = true }

--- a/crates/aprender-train-bench/Cargo.toml
+++ b/crates/aprender-train-bench/Cargo.toml
@@ -19,8 +19,8 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-entrenar = { version = "0.35.0", path = "../aprender-train", package = "aprender-train" }
-entrenar-common = { version = "0.35.0", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar = { version = "0.36.0", path = "../aprender-train", package = "aprender-train" }
+entrenar-common = { version = "0.36.0", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/aprender-train-distill/Cargo.toml
+++ b/crates/aprender-train-distill/Cargo.toml
@@ -32,8 +32,8 @@ cuda = ["entrenar/cuda"]
 shard-batch-source = []
 
 [dependencies]
-entrenar = { version = "0.35.0", path = "../aprender-train", package = "aprender-train" }
-entrenar-common = { version = "0.35.0", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar = { version = "0.36.0", path = "../aprender-train", package = "aprender-train" }
+entrenar-common = { version = "0.36.0", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/aprender-train-distill/src/batch_source.rs
+++ b/crates/aprender-train-distill/src/batch_source.rs
@@ -46,6 +46,31 @@ pub trait BatchSource {
         seq_len: usize,
     ) -> Result<(Vec<Vec<u32>>, Vec<usize>)>;
 
+    /// Produce the next training batch with PER-POSITION labels.
+    ///
+    /// Returns `(inputs, labels)` where `labels` is `[batch][position]` — the
+    /// full shifted target sequence for every input window (position `p`'s
+    /// target is the token at `p+1`). This drives full-sequence KD
+    /// ([`crate::kd_step::kd_step_per_position`]), which trains on every
+    /// position instead of only the next token after the window.
+    ///
+    /// The default wraps [`Self::next_batch`] as a single trailing-position
+    /// label, so existing sources keep working; sources backed by real
+    /// shifted targets (`ShardBatchSource`) override it to expose all
+    /// positions.
+    ///
+    /// # Errors
+    ///
+    /// Same as [`Self::next_batch`].
+    fn next_batch_per_position(
+        &mut self,
+        batch_size: usize,
+        seq_len: usize,
+    ) -> Result<(Vec<Vec<u32>>, Vec<Vec<usize>>)> {
+        let (inputs, labels) = self.next_batch(batch_size, seq_len)?;
+        Ok((inputs, labels.into_iter().map(|l| vec![l]).collect()))
+    }
+
     /// Optional: reset the source's internal cursor (e.g., for re-runs
     /// against a finite corpus). Default no-op for stateless sources.
     fn reset(&mut self) {}
@@ -79,6 +104,21 @@ impl BatchSource for SyntheticBatchSource {
             .map(|i| vec![(i % nc) as u32; seq_len])
             .collect();
         let labels: Vec<usize> = (0..batch_size).map(|i| i % nc).collect();
+        Ok((inputs, labels))
+    }
+
+    fn next_batch_per_position(
+        &mut self,
+        batch_size: usize,
+        seq_len: usize,
+    ) -> Result<(Vec<Vec<u32>>, Vec<Vec<usize>>)> {
+        // Synthetic identity rows: each position predicts the same row token,
+        // so the per-position labels are that token repeated `seq_len` times.
+        let nc = self.num_classes;
+        let inputs: Vec<Vec<u32>> = (0..batch_size)
+            .map(|i| vec![(i % nc) as u32; seq_len])
+            .collect();
+        let labels: Vec<Vec<usize>> = (0..batch_size).map(|i| vec![i % nc; seq_len]).collect();
         Ok((inputs, labels))
     }
 }
@@ -138,20 +178,22 @@ impl BatchSource for ShardBatchSource {
             .ok_or_else(|| entrenar_common::EntrenarError::Internal {
                 message: "ShardBatchSource exhausted without wrap-around".to_string(),
             })?;
-        // LMBatch packs tokens with overlap (stride > 0) or split layout.
-        // Convert to (inputs, labels) where label is the next token after
-        // each row's input window. For Phase 4-prep this Stage B PR keeps
-        // the conversion conservative: per-row predict-the-last-input-token
-        // (same identity-mapping semantics as SyntheticBatchSource so the
-        // pipeline doesn't immediately diverge on real data — Phase 4
-        // proper switches to true next-token prediction).
+        // LMBatch uses causal layout: get_target(i) is the input shifted by
+        // one (`target[p] = input[p+1]`). So `get_target(i).last()` is the
+        // GENUINE next token immediately AFTER the input window — real
+        // next-token prediction, NOT identity mapping. (An earlier comment
+        // here mislabelled this as "identity-mapping"; it never was — see
+        // crates/aprender-train/.../batch.rs causal-shift layout and the
+        // `shard_batch_source_label_is_genuine_next_token` falsifier below.)
+        // This per-row path trains on one target per window; the per-position
+        // path (next_batch_per_position) trains on every position.
         let inputs: Vec<Vec<u32>> = (0..batch_size)
             .map(|i| batch.get_input(i).map(<[u32]>::to_vec).unwrap_or_default())
             .collect();
         let labels: Vec<usize> = (0..batch_size)
             .map(|i| {
-                // Use the target's last token as the label (next-token
-                // prediction at the end of the input window).
+                // The next token after the window = last token of the
+                // causal-shifted target sequence.
                 batch
                     .get_target(i)
                     .and_then(|t| t.last())
@@ -160,6 +202,37 @@ impl BatchSource for ShardBatchSource {
             })
             .collect();
         let _ = seq_len; // shapes asserted via ShardBatchIter contract
+        Ok((inputs, labels))
+    }
+
+    fn next_batch_per_position(
+        &mut self,
+        batch_size: usize,
+        seq_len: usize,
+    ) -> Result<(Vec<Vec<u32>>, Vec<Vec<usize>>)> {
+        use std::iter::Iterator;
+        let batch = self
+            .inner
+            .next()
+            .ok_or_else(|| entrenar_common::EntrenarError::Internal {
+                message: "ShardBatchSource exhausted without wrap-around".to_string(),
+            })?;
+        // Full-sequence KD: per-position labels are the ENTIRE causal-shifted
+        // target sequence (`target[p] = input[p+1]`), so every position
+        // predicts its successor — up to `seq_len`× more KD signal per window
+        // than the per-row path.
+        let inputs: Vec<Vec<u32>> = (0..batch_size)
+            .map(|i| batch.get_input(i).map(<[u32]>::to_vec).unwrap_or_default())
+            .collect();
+        let labels: Vec<Vec<usize>> = (0..batch_size)
+            .map(|i| {
+                batch
+                    .get_target(i)
+                    .map(|t| t.iter().map(|&x| x as usize).collect())
+                    .unwrap_or_default()
+            })
+            .collect();
+        let _ = seq_len;
         Ok((inputs, labels))
     }
 }

--- a/crates/aprender-train-distill/src/kd_step.rs
+++ b/crates/aprender-train-distill/src/kd_step.rs
@@ -244,6 +244,89 @@ where
     Ok((avg_loss, grads))
 }
 
+/// Run a per-position KD orchestration step (full-sequence distillation).
+///
+/// Where [`kd_step`] trains on ONE target per window (the next token after
+/// the window), this trains on EVERY position: position `p` of each row
+/// predicts the token at `p+1`. That is up to `seq_len`× more KD signal per
+/// forward pass.
+///
+/// - `labels` is `[batch][position]` — the shifted target sequence per row
+///   (from `BatchSource::next_batch_per_position`).
+/// - `teacher` supplies `[batch][position][vocab]` via
+///   [`TeacherLogitsProvider::logits_per_position`].
+/// - `compute_student_logits_per_position(row)` returns `[position][vocab]`
+///   for one input row (typically the student provider's per-position
+///   forward applied to that row).
+///
+/// Returns `(avg_loss, grads)` where `avg_loss` is averaged over ALL
+/// (batch × position) predictions and `grads` is `[batch][position][vocab]`
+/// (feed to [`crate::student_provider::StudentLogitsProvider::apply_kd_gradient_per_position`]).
+///
+/// Per-row position counts are reconciled as `min(teacher, student, labels)`
+/// so a row with fewer student/label positions simply trains on the prefix
+/// it has — no panic on ragged batches.
+///
+/// # Errors
+///
+/// Propagates teacher errors; returns `EntrenarError::Internal` if any
+/// student/teacher logit row length doesn't match the teacher's vocab size.
+pub fn kd_step_per_position<F>(
+    teacher: &mut dyn TeacherLogitsProvider,
+    input_ids: &[Vec<u32>],
+    labels: &[Vec<usize>],
+    temperature: f32,
+    alpha: f32,
+    mut compute_student_logits_per_position: F,
+) -> Result<(f32, Vec<Vec<Vec<f32>>>)>
+where
+    F: FnMut(&[u32]) -> Vec<Vec<f32>>,
+{
+    assert_eq!(
+        input_ids.len(),
+        labels.len(),
+        "kd_step_per_position: input_ids and labels must have the same batch size"
+    );
+    let teacher_pp = teacher.logits_per_position(input_ids)?;
+    let vocab = teacher.vocab_size();
+
+    let mut total_loss = 0.0_f32;
+    let mut prediction_count = 0usize;
+    let mut grads: Vec<Vec<Vec<f32>>> = Vec::with_capacity(input_ids.len());
+
+    for ((ids, t_rows), row_labels) in input_ids.iter().zip(teacher_pp.iter()).zip(labels.iter()) {
+        let s_rows = compute_student_logits_per_position(ids);
+        let n_pos = t_rows.len().min(s_rows.len()).min(row_labels.len());
+        let mut row_grads = Vec::with_capacity(n_pos);
+        for p in 0..n_pos {
+            let s = &s_rows[p];
+            let t = &t_rows[p];
+            if s.len() != vocab || t.len() != vocab {
+                return Err(entrenar_common::EntrenarError::Internal {
+                    message: format!(
+                        "kd_step_per_position: logit len mismatch at position {p} \
+                         (student {}, teacher {}, vocab {vocab})",
+                        s.len(),
+                        t.len()
+                    ),
+                });
+            }
+            let label = row_labels[p];
+            total_loss += kd_loss(s, t, label, temperature, alpha);
+            prediction_count += 1;
+            row_grads.push(kd_logit_gradient(s, t, label, temperature, alpha));
+        }
+        grads.push(row_grads);
+    }
+
+    let avg_loss = if prediction_count == 0 {
+        0.0
+    } else {
+        total_loss / prediction_count as f32
+    };
+    Ok((avg_loss, grads))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -376,5 +459,104 @@ mod tests {
             result.is_err(),
             "vocab size mismatch must error, not silently corrupt"
         );
+    }
+
+    // ===== Per-position (full-sequence) KD — contract distill-per-position-kd-v1 =====
+
+    /// FT-PERPOS-001: per-position KD trains on EVERY position. For a batch of
+    /// B rows each of length L, it makes B×L predictions and returns grads
+    /// shaped [B][L] — strictly more signal than the per-row path's B.
+    #[test]
+    fn pmat_perpos_001_trains_on_all_positions() {
+        let vocab = 16;
+        let mut teacher = FixtureTeacher::new(vocab);
+        // 2 rows, length 4 → 8 predictions (vs 2 for per-row).
+        let inputs = vec![vec![1u32, 2, 3, 4], vec![5u32, 6, 7, 8]];
+        let labels = vec![vec![2usize, 3, 4, 4], vec![6usize, 7, 8, 8]];
+        let student = |ids: &[u32]| vec![vec![0.0_f32; vocab]; ids.len()];
+        let (_loss, grads) =
+            kd_step_per_position(&mut teacher, &inputs, &labels, 4.0, 0.5, student)
+                .expect("per-position step");
+        assert_eq!(grads.len(), 2, "one grad-block per row");
+        assert_eq!(grads[0].len(), 4, "FT-PERPOS-001: grads at ALL 4 positions");
+        assert_eq!(grads[1].len(), 4);
+        let predictions: usize = grads.iter().map(Vec::len).sum();
+        assert_eq!(predictions, 8, "B×L = 2×4 predictions, not B=2");
+    }
+
+    /// FT-PERPOS-002: per-position yields strictly more predictions than the
+    /// per-row path on the same data (the whole point of full-sequence KD).
+    #[test]
+    fn pmat_perpos_002_more_signal_than_per_row() {
+        let vocab = 16;
+        let inputs = vec![vec![1u32, 2, 3, 4]];
+        // per-row
+        let mut t1 = FixtureTeacher::new(vocab);
+        let (_l, per_row_grads) =
+            kd_step(&mut t1, &inputs, &[4], 4.0, 0.5, |_| vec![0.0_f32; vocab]).expect("per-row");
+        // per-position
+        let mut t2 = FixtureTeacher::new(vocab);
+        let (_l2, pp_grads) = kd_step_per_position(
+            &mut t2,
+            &inputs,
+            &[vec![2usize, 3, 4, 4]],
+            4.0,
+            0.5,
+            |ids| vec![vec![0.0_f32; vocab]; ids.len()],
+        )
+        .expect("per-position");
+        let per_row: usize = per_row_grads.len();
+        let per_pos: usize = pp_grads.iter().map(Vec::len).sum();
+        assert_eq!(per_row, 1);
+        assert_eq!(per_pos, 4);
+        assert!(per_pos > per_row, "per-position must produce more signal");
+    }
+
+    /// FT-PERPOS-003: when the student equals the teacher at every position
+    /// (and alpha=0, pure KD), the loss and all gradients are ~zero — the math
+    /// is correct per-position (mirror of F-DISTILL-KDSTEP-002).
+    #[test]
+    fn pmat_perpos_003_zero_loss_when_student_equals_teacher() {
+        let vocab = 8;
+        let mut teacher = FixtureTeacher::new(vocab);
+        let inputs = vec![vec![1u32, 2, 3]];
+        let labels = vec![vec![2usize, 3, 3]];
+        // Student returns exactly the teacher's per-position logits.
+        let teacher_pp = teacher.logits_per_position(&inputs).expect("teacher pp");
+        let tp = teacher_pp.clone();
+        let (loss, grads) = kd_step_per_position(
+            &mut teacher,
+            &inputs,
+            &labels,
+            4.0,
+            0.0, // pure KD → no CE term
+            move |_ids| tp[0].clone(),
+        )
+        .expect("per-position step");
+        assert!(
+            loss.abs() < 1e-4,
+            "alpha=0 + student==teacher → ~0 loss (got {loss})"
+        );
+        for row in &grads {
+            for g in row {
+                let max = g.iter().fold(0.0_f32, |m, &x| m.max(x.abs()));
+                assert!(max < 1e-4, "KD grad ~0 when student==teacher (got {max})");
+            }
+        }
+    }
+
+    /// FT-PERPOS-004: ragged rows (fewer student/label positions) train on the
+    /// common prefix without panicking — robustness on uneven batches.
+    #[test]
+    fn pmat_perpos_004_ragged_rows_use_min_positions() {
+        let vocab = 16;
+        let mut teacher = FixtureTeacher::new(vocab);
+        let inputs = vec![vec![1u32, 2, 3, 4]]; // teacher gives 4 positions
+        let labels = vec![vec![2usize, 3]]; // only 2 labels
+        let student = |_ids: &[u32]| vec![vec![0.0_f32; vocab]; 3]; // only 3 positions
+        let (_loss, grads) =
+            kd_step_per_position(&mut teacher, &inputs, &labels, 4.0, 0.5, student)
+                .expect("ragged step must not panic");
+        assert_eq!(grads[0].len(), 2, "min(4 teacher, 3 student, 2 labels) = 2");
     }
 }

--- a/crates/aprender-train-distill/src/pipeline.rs
+++ b/crates/aprender-train-distill/src/pipeline.rs
@@ -82,6 +82,13 @@ pub struct Pipeline<'a> {
     /// tests via [`Self::with_max_steps`] so they never touch process env.
     /// Contract: `contracts/apr-distill-smoke-validation-v1.yaml`.
     smoke_max_steps: Option<u64>,
+    /// PMAT-PERPOS: full-sequence (per-position) KD mode. When `true`, each
+    /// step trains on EVERY position of the window (`kd_step_per_position`)
+    /// rather than one target per window — up to `seq_len`× more KD signal.
+    /// Defaults from `APR_DISTILL_PER_POSITION` at construction; override in
+    /// tests via [`Self::with_per_position`]. Default `false` keeps the
+    /// production loop byte-identical. Contract: `contracts/distill-per-position-kd-v1.yaml`.
+    per_position: bool,
 }
 
 impl<'a> Pipeline<'a> {
@@ -106,7 +113,20 @@ impl<'a> Pipeline<'a> {
             callbacks: Vec::new(),
             // PMAT-706: pick up the operator's smoke budget from the env once.
             smoke_max_steps: parse_max_steps(),
+            // PMAT-PERPOS: full-sequence KD opt-in from the env once.
+            per_position: parse_per_position(),
         }
+    }
+
+    /// PMAT-PERPOS: enable/disable full-sequence (per-position) KD.
+    ///
+    /// `true` trains on every position of each window; `false` (default) is
+    /// the per-row path. Primarily a test seam — operators set
+    /// `APR_DISTILL_PER_POSITION=1`, which `new()` reads automatically.
+    #[must_use]
+    pub fn with_per_position(mut self, per_position: bool) -> Self {
+        self.per_position = per_position;
+        self
     }
 
     /// PMAT-706: override the smoke-validation early-break budget.
@@ -455,33 +475,65 @@ impl<'a> Pipeline<'a> {
             }
 
             for _s in 0..steps_this_epoch {
-                let (dummy_batch, labels) =
-                    self.batch_source.next_batch(batch_size, smoke_seq_len)?;
-                let (loss, grads) = crate::kd_step::kd_step(
-                    self.teacher.as_mut(),
-                    &dummy_batch,
-                    &labels,
-                    temperature,
-                    alpha,
-                    |ids| {
-                        // Compute student logits inline. The closure runs
-                        // once per batch element inside kd_step.
-                        // For Phase 2c we ask the provider for the whole
-                        // batch upfront (cheaper than per-element when the
-                        // provider has shared state) and index into it.
-                        // FixtureStudent and any non-trivial provider both
-                        // satisfy the contract that adjacent calls with the
-                        // same input_ids return the same logits, so this
-                        // simple pattern is safe.
-                        let logits_vv = self
-                            .student
-                            .logits_for_batch(std::slice::from_ref(&ids.to_vec()))
-                            .expect("student provider failed mid-step");
-                        logits_vv.into_iter().next().unwrap_or_default()
-                    },
-                )?;
+                // PMAT-PERPOS: per-position (full-sequence) KD trains on EVERY
+                // position of each window; the default per-row path trains on
+                // one target per window. Opt-in via APR_DISTILL_PER_POSITION
+                // (default off → the production loop is byte-identical). CUDA
+                // providers fall back to one position via the trait defaults
+                // until they implement a true all-positions forward.
+                let (loss, dummy_batch, labels) = if self.per_position {
+                    let (inputs, pp_labels) = self
+                        .batch_source
+                        .next_batch_per_position(batch_size, smoke_seq_len)?;
+                    let (loss, grads) = crate::kd_step::kd_step_per_position(
+                        self.teacher.as_mut(),
+                        &inputs,
+                        &pp_labels,
+                        temperature,
+                        alpha,
+                        |ids| {
+                            self.student
+                                .logits_per_position(std::slice::from_ref(&ids.to_vec()))
+                                .expect("student per-position forward failed mid-step")
+                                .into_iter()
+                                .next()
+                                .unwrap_or_default()
+                        },
+                    )?;
+                    self.student.apply_kd_gradient_per_position(&grads)?;
+                    // Per-row labels for the final-loss telemetry: the last
+                    // target of each row (the next token after the window).
+                    let row_labels: Vec<usize> = pp_labels
+                        .iter()
+                        .map(|l| l.last().copied().unwrap_or(0))
+                        .collect();
+                    (loss, inputs, row_labels)
+                } else {
+                    let (dummy_batch, labels) =
+                        self.batch_source.next_batch(batch_size, smoke_seq_len)?;
+                    let (loss, grads) = crate::kd_step::kd_step(
+                        self.teacher.as_mut(),
+                        &dummy_batch,
+                        &labels,
+                        temperature,
+                        alpha,
+                        |ids| {
+                            // Compute student logits inline. The closure runs
+                            // once per batch element inside kd_step. Whole-batch
+                            // upfront is cheaper when the provider has shared
+                            // state; adjacent same-input calls are deterministic
+                            // so indexing is safe.
+                            let logits_vv = self
+                                .student
+                                .logits_for_batch(std::slice::from_ref(&ids.to_vec()))
+                                .expect("student provider failed mid-step");
+                            logits_vv.into_iter().next().unwrap_or_default()
+                        },
+                    )?;
+                    self.student.apply_kd_gradient(&grads)?;
+                    (loss, dummy_batch, labels)
+                };
                 best_loss = best_loss.min(loss);
-                self.student.apply_kd_gradient(&grads)?;
                 step += 1;
                 last_batch = dummy_batch;
                 last_labels = labels;
@@ -802,6 +854,19 @@ fn parse_max_steps_value(raw: Option<&str>) -> Option<u64> {
 /// PMAT-706: read `APR_DISTILL_MAX_STEPS` from the environment once.
 fn parse_max_steps() -> Option<u64> {
     parse_max_steps_value(std::env::var("APR_DISTILL_MAX_STEPS").ok().as_deref())
+}
+
+/// PMAT-PERPOS: read the `APR_DISTILL_PER_POSITION` opt-in once. Truthy
+/// values: `1`, `true`, `yes`, `on` (case-insensitive). Anything else
+/// (unset, empty, `0`, `false`) → per-row mode (no behavior change).
+fn parse_per_position() -> bool {
+    std::env::var("APR_DISTILL_PER_POSITION")
+        .ok()
+        .map(|v| {
+            let v = v.trim().to_ascii_lowercase();
+            matches!(v.as_str(), "1" | "true" | "yes" | "on")
+        })
+        .unwrap_or(false)
 }
 
 /// PMAT-706: projected-wall-time target for the smoke summary. Defaults to
@@ -1319,6 +1384,64 @@ mod tests {
              broken somewhere.",
             result.metrics.initial_loss,
             result.metrics.final_loss
+        );
+    }
+
+    /// FT-PERPOS-005 (contract distill-per-position-kd-v1): the pipeline in
+    /// per-position mode trains end-to-end on every position and reduces loss,
+    /// AND `with_per_position(false)` is byte-identical to the default path
+    /// (the production loop is untouched unless explicitly opted in).
+    #[test]
+    fn falsify_perpos_005_pipeline_per_position_reduces_loss() {
+        use safetensors::tensor::{Dtype, TensorView};
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let dummy: Vec<f32> = (0..32).map(|i| i as f32 * 0.01).collect();
+        let dummy_bytes: Vec<u8> = bytemuck::cast_slice(&dummy).to_vec();
+        for name in ["teacher", "student"] {
+            let p = tmp.path().join(format!("{name}.safetensors"));
+            let views = vec![(
+                "layer.weight",
+                TensorView::new(Dtype::F32, vec![8, 4], &dummy_bytes).expect("view"),
+            )];
+            std::fs::write(&p, safetensors::serialize(views, None).expect("ser")).expect("write");
+        }
+        let mk_config = |out: std::path::PathBuf| {
+            let mut c = DistillConfig::minimal(
+                tmp.path().join("teacher.safetensors").to_str().unwrap(),
+                tmp.path().join("student.safetensors").to_str().unwrap(),
+            );
+            c.output.dir = out;
+            c.training.epochs = 3;
+            c.training.batch_size = 4;
+            c.distillation.temperature = 4.0;
+            c.distillation.alpha = 0.5;
+            c
+        };
+
+        // Per-position mode: trains on every position, loss must decrease.
+        let cfg_pp = mk_config(tmp.path().join("out_pp"));
+        let mut pp = Pipeline::new(&cfg_pp).with_per_position(true);
+        let r_pp = pp.execute().expect("per-position pipeline must run");
+        eprintln!(
+            "[FT-PERPOS-005] per-position initial={} final={} steps={}",
+            r_pp.metrics.initial_loss, r_pp.metrics.final_loss, r_pp.metrics.steps_completed
+        );
+        assert!(
+            r_pp.metrics.final_loss < r_pp.metrics.initial_loss,
+            "per-position KD must reduce loss (initial={}, final={})",
+            r_pp.metrics.initial_loss,
+            r_pp.metrics.final_loss
+        );
+
+        // Default (per-row) still works and is the unchanged path.
+        let cfg_row = mk_config(tmp.path().join("out_row"));
+        let mut row = Pipeline::new(&cfg_row).with_per_position(false);
+        let r_row = row.execute().expect("per-row pipeline must run");
+        assert!(
+            r_row.metrics.final_loss < r_row.metrics.initial_loss,
+            "per-row path must remain healthy (initial={}, final={})",
+            r_row.metrics.initial_loss,
+            r_row.metrics.final_loss
         );
     }
 

--- a/crates/aprender-train-distill/src/student_provider.rs
+++ b/crates/aprender-train-distill/src/student_provider.rs
@@ -76,6 +76,46 @@ pub trait StudentLogitsProvider {
     /// optimizer step fails.
     fn apply_kd_gradient(&mut self, gradient: &[Vec<f32>]) -> Result<()>;
 
+    /// Per-position forward pass: logits at EVERY position of each input
+    /// window, shape `[batch][position][vocab]`. Pairs with
+    /// [`TeacherLogitsProvider::logits_per_position`] for full-sequence KD.
+    ///
+    /// Default wraps `logits_for_batch` as a single trailing position so
+    /// existing students (incl. CUDA) keep working unchanged.
+    ///
+    /// # Errors
+    ///
+    /// Same as [`Self::logits_for_batch`].
+    fn logits_per_position(&mut self, input_ids: &[Vec<u32>]) -> Result<Vec<Vec<Vec<f32>>>> {
+        Ok(self
+            .logits_for_batch(input_ids)?
+            .into_iter()
+            .map(|row| vec![row])
+            .collect())
+    }
+
+    /// Backward + optimizer step seeded by per-position KD gradients,
+    /// shape `[batch][position][vocab]`.
+    ///
+    /// Default flattens positions into independent token-level samples
+    /// (`[batch*position][vocab]`) and delegates to [`Self::apply_kd_gradient`],
+    /// which averages them — the canonical token-level batch averaging. A
+    /// student with a true per-position backward may override this.
+    ///
+    /// # Errors
+    ///
+    /// Same as [`Self::apply_kd_gradient`].
+    fn apply_kd_gradient_per_position(&mut self, gradient: &[Vec<Vec<f32>>]) -> Result<()> {
+        let flat: Vec<Vec<f32>> = gradient
+            .iter()
+            .flat_map(|rows| rows.iter().cloned())
+            .collect();
+        if flat.is_empty() {
+            return Ok(());
+        }
+        self.apply_kd_gradient(&flat)
+    }
+
     /// PMAT-699 (Phase 4 P0): persist the student's current trained weights
     /// to disk.
     ///
@@ -139,6 +179,16 @@ impl StudentLogitsProvider for FixtureStudent {
     fn logits_for_batch(&mut self, input_ids: &[Vec<u32>]) -> Result<Vec<Vec<f32>>> {
         // The fixture is input-independent — broadcast the same logits.
         Ok(input_ids.iter().map(|_| self.logits.clone()).collect())
+    }
+
+    fn logits_per_position(&mut self, input_ids: &[Vec<u32>]) -> Result<Vec<Vec<Vec<f32>>>> {
+        // Input-independent fixture: broadcast the same logits to every
+        // position of every row, so the per-position shape matches the
+        // teacher's `[batch][position][vocab]`.
+        Ok(input_ids
+            .iter()
+            .map(|ids| (0..ids.len().max(1)).map(|_| self.logits.clone()).collect())
+            .collect())
     }
 
     fn apply_kd_gradient(&mut self, gradient: &[Vec<f32>]) -> Result<()> {

--- a/crates/aprender-train-distill/src/teacher_provider.rs
+++ b/crates/aprender-train-distill/src/teacher_provider.rs
@@ -49,6 +49,29 @@ pub trait TeacherLogitsProvider {
     /// missing weights). The pipeline aborts on error rather than
     /// silently fall back to non-distillation training.
     fn logits_for_batch(&mut self, input_ids: &[Vec<u32>]) -> Result<Vec<Vec<f32>>>;
+
+    /// Run the teacher and return logits at EVERY position of each input
+    /// window: shape `[batch][position][vocab]`. This is the per-position
+    /// next-token signal used by full-sequence KD — every position predicts
+    /// its successor, giving up to `seq_len`× more distillation signal per
+    /// forward pass than the last-position-only [`Self::logits_for_batch`].
+    ///
+    /// The default impl wraps `logits_for_batch` as a single trailing
+    /// position, so existing providers (including the CUDA backend) keep
+    /// working unchanged — they expose one position until they override this
+    /// with a true all-positions forward. Per-position-capable providers
+    /// (e.g. `FixtureTeacher`) override it.
+    ///
+    /// # Errors
+    ///
+    /// Propagates backend errors, same as [`Self::logits_for_batch`].
+    fn logits_per_position(&mut self, input_ids: &[Vec<u32>]) -> Result<Vec<Vec<Vec<f32>>>> {
+        Ok(self
+            .logits_for_batch(input_ids)?
+            .into_iter()
+            .map(|row| vec![row])
+            .collect())
+    }
 }
 
 /// A frozen-fixture teacher used in unit tests. Returns logits whose
@@ -92,6 +115,36 @@ impl TeacherLogitsProvider for FixtureTeacher {
             };
             logits[idx] = 10.0;
             out.push(logits);
+        }
+        Ok(out)
+    }
+
+    fn logits_per_position(&mut self, input_ids: &[Vec<u32>]) -> Result<Vec<Vec<Vec<f32>>>> {
+        // Per-position fixture: position p predicts the genuine next token
+        // within the window (ids[p+1]); the final position (no successor in
+        // the window) falls back to its own token. Each position's argmax is
+        // therefore its target, giving the student a distinct, learnable
+        // per-position signal.
+        let mut out = Vec::with_capacity(input_ids.len());
+        for ids in input_ids {
+            let mut rows = Vec::with_capacity(ids.len());
+            for p in 0..ids.len() {
+                let mut logits = vec![0.0_f32; self.vocab_size];
+                #[allow(clippy::cast_possible_truncation)]
+                let predicted = if p + 1 < ids.len() {
+                    ids[p + 1] as usize
+                } else {
+                    ids[p] as usize
+                };
+                let idx = if predicted < self.vocab_size {
+                    predicted
+                } else {
+                    0
+                };
+                logits[idx] = 10.0;
+                rows.push(logits);
+            }
+            out.push(rows);
         }
         Ok(out)
     }

--- a/crates/aprender-train-inspect/Cargo.toml
+++ b/crates/aprender-train-inspect/Cargo.toml
@@ -19,8 +19,8 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-entrenar = { version = "0.35.0", path = "../aprender-train", package = "aprender-train" }
-entrenar-common = { version = "0.35.0", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar = { version = "0.36.0", path = "../aprender-train", package = "aprender-train" }
+entrenar-common = { version = "0.36.0", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/aprender-train-lora/Cargo.toml
+++ b/crates/aprender-train-lora/Cargo.toml
@@ -19,8 +19,8 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-entrenar = { version = "0.35.0", path = "../aprender-train", package = "aprender-train" }
-entrenar-common = { version = "0.35.0", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar = { version = "0.36.0", path = "../aprender-train", package = "aprender-train" }
+entrenar-common = { version = "0.36.0", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/aprender-train-shell/Cargo.toml
+++ b/crates/aprender-train-shell/Cargo.toml
@@ -19,8 +19,8 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-entrenar = { version = "0.35.0", path = "../aprender-train", package = "aprender-train" }
-entrenar-common = { version = "0.35.0", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar = { version = "0.36.0", path = "../aprender-train", package = "aprender-train" }
+entrenar-common = { version = "0.36.0", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 rustyline = "14"
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/aprender-train/Cargo.toml
+++ b/crates/aprender-train/Cargo.toml
@@ -75,9 +75,9 @@ provable-contracts-macros = { version = "0.2" }
 # Core PAIML stack
 ndarray = "0.16"
 trueno = { version = "0.17", features = ["parallel"] }  # SIMD-accelerated compute
-trueno-gpu = { version = "0.35.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true }  # CUDA compute (APR-MONO single-source-of-truth)
+trueno-gpu = { version = "0.36.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true }  # CUDA compute (APR-MONO single-source-of-truth)
 realizar = { version = "0.8", optional = true }  # CUDA inference engine
-aprender = { path = "../aprender-core", version = "0.35.0", package = "aprender-core" }  # ML interpret module + .apr format + tokenizers
+aprender = { path = "../aprender-core", version = "0.36.0", package = "aprender-core" }  # ML interpret module + .apr format + tokenizers
 trueno-viz = { version = "0.2", features = ["terminal"] }  # Terminal visualization
 presentar-terminal = { version = "0.3.5", optional = true }  # Sovereign TUI framework (gated by "tui" feature)
 presentar-core = "0.3.4"  # Presentar core traits (crates.io — path removed, presentar restructured)

--- a/crates/aprender-tsp/Cargo.toml
+++ b/crates/aprender-tsp/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 name = "aprender-tsp"
 
 [dependencies]
-aprender = { path = "../../", version = "0.35.0" }
+aprender = { path = "../../", version = "0.36.0" }
 clap = { version = "4", features = ["derive"] }
 rand = "0.9"
 crc32fast = "1.4"

--- a/crates/aprender-verify-ml/Cargo.toml
+++ b/crates/aprender-verify-ml/Cargo.toml
@@ -50,7 +50,7 @@ uuid = { version = "1.11", features = ["v4", "serde"] }
 trueno = "0.7.3"
 
 # Machine learning for bug prediction (optional)
-aprender = { path = "../aprender-core", version = "0.35.0", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.36.0", package = "aprender-core", optional = true }
 
 # LLM fine-tuning integration (optional)
 entrenar = { workspace = true, optional = true }

--- a/crates/aprender-viz/Cargo.toml
+++ b/crates/aprender-viz/Cargo.toml
@@ -29,7 +29,7 @@ base64 = "0.22"
 thiserror = "2.0"
 
 # Optional: ML integration
-aprender = { path = "../aprender-core", version = "0.35.0", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.36.0", package = "aprender-core", optional = true }
 
 # Optional: Graph integration
 trueno-graph = { workspace = true, optional = true, default-features = false }


### PR DESCRIPTION
## The single biggest change for v0.36.0

Per a 6-lens goals analysis + adversarial scoring, the biggest change is **full-sequence (per-position) knowledge distillation**. The per-row path trains on **one** target per window (next token after the window); per-position KD trains on **every** position (position `p` predicts `p+1`) — up to **`seq_len`× more distillation signal per forward pass**.

> **Why not the originally-recommended "real-KD wiring" change?** Verification proved that a phantom — `ShardBatchSource` *already* emits genuine next-token labels (`LMBatch` causal-shifted target; confirmed empirically: `input=[10,11,12,13] → label=14`, not identity). That misleading comment is corrected + falsifier-pinned here.

## Additive + safe by construction

- **`kd_step_per_position`** — reuses the existing per-triple `kd_loss`/`kd_logit_gradient` primitives per `(row, position)`, averages over all predictions, trains `min(teacher,student,labels)` positions per row (no panic on ragged batches).
- **New trait methods** `logits_per_position` / `apply_kd_gradient_per_position` (teacher + student) + `next_batch_per_position` (BatchSource) whose **defaults wrap the per-row methods** → every existing provider, **including the CUDA backend, compiles and behaves unchanged**.
- Fixture/Synthetic/Shard sources override them with genuine per-position logits/labels.
- **Pipeline opt-in** via `APR_DISTILL_PER_POSITION` (default off → the production Stage-D loop is **byte-identical**).

## Verification — `contracts/distill-per-position-kd-v1.yaml` (Rule 7)

5 falsifiers + 2 kani harnesses, `pv validate` clean:

| FT | Checks |
|----|--------|
| PERPOS-001 | trains on ALL positions (B×L preds, grads `[B][L]`) |
| PERPOS-002 | strictly more signal than per-row |
| PERPOS-003 | zero loss/grad at perfect per-position agreement (math correct) |
| PERPOS-004 | ragged rows train the min-prefix, no panic |
| PERPOS-005 | pipeline per-position **reduces loss end-to-end**; per-row path unchanged |

✅ 75/77 distill tests pass · lib clippy-clean · `cargo fmt --all --check` clean · `cargo check --workspace` clean · apr-cli compiles.

## Honest scope
The **CPU/fixture path is fully verified.** The real throughput benefit needs the CUDA teacher/student to emit all-position logits (a GPU forward change) — until then CUDA falls back to one position via the defaults. That GPU per-position forward is a documented follow-up; deliberately **not** wired into the dispatch script (would be a misleading no-benefit knob today).

## Release
Workspace `0.35.0 → 0.36.0`, facade `aprender 0.35.2 → 0.36.0` (unified at 0.36.0); CHANGELOG `[0.36.0]`; all internal version pins bumped; `Cargo.lock` regenerated. After merge: tag `v0.36.0` + crates.io publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)