### PR TITLE
feat(gguf): sharded GGUF auto-merge — v0.38.0 (#1893 criterion 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.38.0] - 2026-06-11
+
+### Added
+
+- **Sharded GGUF auto-merge (#1893 criterion 2)**: `apr pull` now merges a
+  downloaded split-GGUF set (`model-NNNNN-of-MMMMM.gguf`) into a single
+  `model.gguf` so the existing single-file loader runs the model unchanged —
+  no inference-hot-path refactor (which would risk *all* GGUF inference). Pulled
+  sharded models are now runnable end-to-end. `merge_gguf_shards` is
+  **type-agnostic** (copies tensor data by raw byte range → every ggml quant
+  type works), **lossless on metadata** (preserves arbitrary `<arch>.*` config
+  keys via the new `GgufReader::from_file_full` keep-all mode), **bounded in
+  memory** (streams to disk, holds ≤ one part at a time), and rejects duplicate
+  tensors across parts. Parts are deleted after a successful merge.
+
+### Verified
+
+- This release was hardened against a **multi-agent adversarial verification**
+  that found 5 release-blockers before publish — most critically that sourcing
+  metadata from the architecture-whitelisted reader silently dropped
+  `gemma.*`/`phi3.*`/`deepseek2.*`/`falcon.*`/etc. config keys, making merged
+  models of those (mainstream) architectures unloadable. Contract
+  `contracts/sharded-gguf-merge-v1.yaml` (FT-MERGE-001/004/005/006 + 2 kani
+  harnesses), including a cross-parser interop test that loads the merged file
+  with realizar's real `GGUFModel::from_bytes`.
+
 ## [0.37.0] - 2026-06-10
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,7 +284,7 @@ dependencies = [
 
 [[package]]
 name = "apr-cli"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "alimentar",
  "anyhow",
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "aprender"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "apr-cli",
  "aprender-core",
@@ -411,7 +411,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-bench-compute"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "aprender-core",
  "criterion 0.7.0",
@@ -420,7 +420,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-bench-tokenizer"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "aprender-core",
  "criterion 0.7.0",
@@ -429,7 +429,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cbtop"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "aprender-compute",
@@ -454,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cgp"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "aprender-gpu",
@@ -474,7 +474,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-common"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "lz4_flex 0.11.6",
  "zstd",
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-compute"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "aprender-core",
@@ -531,7 +531,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-compute-xtask"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "bashrs",
@@ -544,7 +544,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-contracts"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "aprender-contracts-macros",
  "criterion 0.5.1",
@@ -559,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-contracts-cli"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "aprender-contracts",
  "clap",
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-contracts-macros"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-core"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "aes-gcm",
  "alimentar",
@@ -632,7 +632,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cuda-edge"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "aprender-gpu",
  "proptest",
@@ -643,7 +643,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cupti"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "bindgen 0.71.1",
  "bitflags 2.11.0",
@@ -653,7 +653,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-data"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-db"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "arrow 57.3.0",
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-distribute"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "arrow 57.3.0",
  "bincode",
@@ -781,7 +781,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-explain"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "aprender-gpu",
  "clap",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-fft"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -808,7 +808,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-gemm-codegen"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-gpu"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "aprender-profile",
  "batuta-common",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-graph"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "aprender-core",
@@ -862,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-image"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-mcp"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -886,9 +886,9 @@ dependencies = [
 
 [[package]]
 name = "aprender-monte-carlo"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
- "aprender 0.37.0",
+ "aprender 0.38.0",
  "assert_cmd",
  "chrono",
  "clap",
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-orchestrate"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "alimentar",
  "anyhow",
@@ -979,7 +979,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-cli"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "aprender-present-yaml",
  "clap",
@@ -992,7 +992,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-core"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "aprender-compute",
  "criterion 0.7.0",
@@ -1005,7 +1005,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-layout"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "aprender-present-core",
  "criterion 0.7.0",
@@ -1016,7 +1016,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-lib"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "aprender-present-core",
  "aprender-present-layout",
@@ -1045,7 +1045,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-terminal"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "aprender-present-core",
  "bitvec",
@@ -1067,7 +1067,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-test"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "aprender-present-core",
  "aprender-present-test-macros",
@@ -1078,7 +1078,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-test-macros"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1087,7 +1087,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-widgets"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "aprender-present-core",
  "aprender-present-yaml",
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-yaml"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "aprender-present-core",
  "proptest",
@@ -1109,7 +1109,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-profile"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "addr2line 0.25.1",
  "anyhow",
@@ -1162,7 +1162,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-profile-core"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "hex",
  "serde",
@@ -1172,7 +1172,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-ptx-debug"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "proptest",
  "thiserror 2.0.18",
@@ -1180,7 +1180,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-certify"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "chrono",
  "proptest",
@@ -1190,7 +1190,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-cli"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "aprender-qa-certify",
  "aprender-qa-gen",
@@ -1209,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-gen"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1226,7 +1226,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-report"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "aprender-qa-gen",
@@ -1244,7 +1244,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-runner"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "aprender-qa-gen",
@@ -1269,14 +1269,14 @@ dependencies = [
 
 [[package]]
 name = "aprender-quant"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "half",
 ]
 
 [[package]]
 name = "aprender-rag"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "batuta-common",
@@ -1307,7 +1307,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-rand"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1316,7 +1316,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-registry"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "alimentar",
  "anyhow",
@@ -1346,7 +1346,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-serve"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "alimentar",
  "anyhow",
@@ -1413,7 +1413,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-shell"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "aprender-core",
  "assert_cmd",
@@ -1430,7 +1430,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-simulate"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "bincode",
  "bitflags 2.11.0",
@@ -1469,7 +1469,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-solve"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1478,7 +1478,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-sparse"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1487,7 +1487,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-tensor"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1496,7 +1496,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-cli"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "aprender-test-lib",
  "assert_cmd",
@@ -1524,7 +1524,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-derive"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1534,7 +1534,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-js-gen"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -1550,7 +1550,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-lib"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "aprender-compute",
  "aprender-present-core",
@@ -1594,7 +1594,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-showcase"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "aprender-present-terminal",
  "console_error_panic_hook",
@@ -1611,7 +1611,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "alimentar",
  "approx",
@@ -1678,7 +1678,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-bench"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1695,7 +1695,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-common"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "clap",
  "proptest",
@@ -1707,7 +1707,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-distill"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1728,7 +1728,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-inspect"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1744,7 +1744,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-lora"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-shell"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1776,7 +1776,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-wasm"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "proptest",
  "serde",
@@ -1787,9 +1787,9 @@ dependencies = [
 
 [[package]]
 name = "aprender-tsp"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
- "aprender 0.37.0",
+ "aprender 0.38.0",
  "assert_cmd",
  "clap",
  "crc32fast",
@@ -1802,7 +1802,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-verify"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "chrono",
  "criterion 0.5.1",
@@ -1814,7 +1814,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-verify-ml"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "aprender-core",
  "aprender-profile",
@@ -1858,7 +1858,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-viz"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "approx",
  "aprender-core",
@@ -1893,7 +1893,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "aprender-zram-adaptive",
  "aprender-zram-core",
@@ -1903,7 +1903,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-adaptive"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "aprender-zram-core",
  "proptest",
@@ -1912,7 +1912,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-cli"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "aprender-zram-adaptive",
  "aprender-zram-core",
@@ -1926,7 +1926,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-core"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "aprender-gpu",
  "criterion 0.7.0",
@@ -1938,7 +1938,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-generator"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "aprender-zram-core",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.37.0"
+version = "0.38.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/paiml/aprender"
@@ -171,7 +171,7 @@ minijinja = { version = "2.14", features = ["loader", "serde"] }
 # Contracts
 provable-contracts = "0.3"
 provable-contracts-macros = "0.3"
-aprender-contracts-macros = { path = "crates/aprender-contracts-macros", version = "0.37.0" }
+aprender-contracts-macros = { path = "crates/aprender-contracts-macros", version = "0.38.0" }
 
 # YAML
 serde_yaml = "0.9"
@@ -183,31 +183,31 @@ hf-hub = { version = "0.4", default-features = false, features = ["ureq"] }
 hf-xet = "1.5.1"
 
 # Workspace-internal crates (paths within the monorepo)
-aprender-compute = { path = "crates/aprender-compute", version = "0.37.0" }
-aprender-gpu = { path = "crates/aprender-gpu", version = "0.37.0" }
-aprender-quant = { path = "crates/aprender-quant", version = "0.37.0" }
-aprender-serve = { path = "crates/aprender-serve", version = "0.37.0" }
-realizar = { path = "crates/aprender-serve", version = "0.37.0", package = "aprender-serve" }
-aprender-train = { path = "crates/aprender-train", version = "0.37.0" }
-entrenar = { path = "crates/aprender-train", version = "0.37.0", package = "aprender-train" }
-aprender-train-common = { path = "crates/aprender-train-common", version = "0.37.0" }
-aprender-train-distill = { path = "crates/aprender-train-distill", version = "0.37.0" }
-aprender-orchestrate = { path = "crates/aprender-orchestrate", version = "0.37.0" }
-aprender-contracts = { path = "crates/aprender-contracts", version = "0.37.0" }
-aprender-profile = { path = "crates/aprender-profile", version = "0.37.0" }
-aprender-profile-core = { path = "crates/aprender-profile-core", version = "0.37.0" }
-aprender-zram-core = { path = "crates/aprender-zram-core", version = "0.37.0" }
-aprender-zram-adaptive = { path = "crates/aprender-zram-adaptive", version = "0.37.0" }
-aprender-present-core = { path = "crates/aprender-present-core", version = "0.37.0" }
-aprender-present-terminal = { path = "crates/aprender-present-terminal", version = "0.37.0" }
-aprender-present-widgets = { path = "crates/aprender-present-widgets", version = "0.37.0" }
-aprender-present-layout = { path = "crates/aprender-present-layout", version = "0.37.0" }
-aprender-present-yaml = { path = "crates/aprender-present-yaml", version = "0.37.0" }
-aprender-present-test = { path = "crates/aprender-present-test", version = "0.37.0" }
-aprender-db = { path = "crates/aprender-db", version = "0.37.0" }
-aprender-graph = { path = "crates/aprender-graph", version = "0.37.0" }
-aprender-rag = { path = "crates/aprender-rag", version = "0.37.0" }
-aprender-data = { path = "crates/aprender-data", version = "0.37.0" }
+aprender-compute = { path = "crates/aprender-compute", version = "0.38.0" }
+aprender-gpu = { path = "crates/aprender-gpu", version = "0.38.0" }
+aprender-quant = { path = "crates/aprender-quant", version = "0.38.0" }
+aprender-serve = { path = "crates/aprender-serve", version = "0.38.0" }
+realizar = { path = "crates/aprender-serve", version = "0.38.0", package = "aprender-serve" }
+aprender-train = { path = "crates/aprender-train", version = "0.38.0" }
+entrenar = { path = "crates/aprender-train", version = "0.38.0", package = "aprender-train" }
+aprender-train-common = { path = "crates/aprender-train-common", version = "0.38.0" }
+aprender-train-distill = { path = "crates/aprender-train-distill", version = "0.38.0" }
+aprender-orchestrate = { path = "crates/aprender-orchestrate", version = "0.38.0" }
+aprender-contracts = { path = "crates/aprender-contracts", version = "0.38.0" }
+aprender-profile = { path = "crates/aprender-profile", version = "0.38.0" }
+aprender-profile-core = { path = "crates/aprender-profile-core", version = "0.38.0" }
+aprender-zram-core = { path = "crates/aprender-zram-core", version = "0.38.0" }
+aprender-zram-adaptive = { path = "crates/aprender-zram-adaptive", version = "0.38.0" }
+aprender-present-core = { path = "crates/aprender-present-core", version = "0.38.0" }
+aprender-present-terminal = { path = "crates/aprender-present-terminal", version = "0.38.0" }
+aprender-present-widgets = { path = "crates/aprender-present-widgets", version = "0.38.0" }
+aprender-present-layout = { path = "crates/aprender-present-layout", version = "0.38.0" }
+aprender-present-yaml = { path = "crates/aprender-present-yaml", version = "0.38.0" }
+aprender-present-test = { path = "crates/aprender-present-test", version = "0.38.0" }
+aprender-db = { path = "crates/aprender-db", version = "0.38.0" }
+aprender-graph = { path = "crates/aprender-graph", version = "0.38.0" }
+aprender-rag = { path = "crates/aprender-rag", version = "0.38.0" }
+aprender-data = { path = "crates/aprender-data", version = "0.38.0" }
 
 # Additional external deps needed by sub-crates
 serde_yaml_ng = "0.10"
@@ -252,25 +252,25 @@ wasmtime = "43"
 bollard = "0.17"
 
 # Old crate name aliases (workspace = true refs in migrated sub-crates)
-trueno-zram-core = { path = "crates/aprender-zram-core", version = "0.37.0", package = "aprender-zram-core" }
-trueno-zram-adaptive = { path = "crates/aprender-zram-adaptive", version = "0.37.0", package = "aprender-zram-adaptive" }
-trueno = { path = "crates/aprender-compute", version = "0.37.0", package = "aprender-compute" }
-presentar-core = { path = "crates/aprender-present-core", version = "0.37.0", package = "aprender-present-core" }
-presentar-terminal = { path = "crates/aprender-present-terminal", version = "0.37.0", package = "aprender-present-terminal" }
-presentar-widgets = { path = "crates/aprender-present-widgets", version = "0.37.0", package = "aprender-present-widgets" }
-presentar-layout = { path = "crates/aprender-present-layout", version = "0.37.0", package = "aprender-present-layout" }
-presentar-yaml = { path = "crates/aprender-present-yaml", version = "0.37.0", package = "aprender-present-yaml" }
-presentar-test = { path = "crates/aprender-present-test", version = "0.37.0", package = "aprender-present-test" }
-presentar-test-macros = { path = "crates/aprender-present-test-macros", version = "0.37.0", package = "aprender-present-test-macros" }
-jugar-probar-derive = { path = "crates/aprender-test-derive", version = "0.37.0", package = "aprender-test-derive" }
-batuta-common = { path = "crates/aprender-common", version = "0.37.0", package = "aprender-common" }
+trueno-zram-core = { path = "crates/aprender-zram-core", version = "0.38.0", package = "aprender-zram-core" }
+trueno-zram-adaptive = { path = "crates/aprender-zram-adaptive", version = "0.38.0", package = "aprender-zram-adaptive" }
+trueno = { path = "crates/aprender-compute", version = "0.38.0", package = "aprender-compute" }
+presentar-core = { path = "crates/aprender-present-core", version = "0.38.0", package = "aprender-present-core" }
+presentar-terminal = { path = "crates/aprender-present-terminal", version = "0.38.0", package = "aprender-present-terminal" }
+presentar-widgets = { path = "crates/aprender-present-widgets", version = "0.38.0", package = "aprender-present-widgets" }
+presentar-layout = { path = "crates/aprender-present-layout", version = "0.38.0", package = "aprender-present-layout" }
+presentar-yaml = { path = "crates/aprender-present-yaml", version = "0.38.0", package = "aprender-present-yaml" }
+presentar-test = { path = "crates/aprender-present-test", version = "0.38.0", package = "aprender-present-test" }
+presentar-test-macros = { path = "crates/aprender-present-test-macros", version = "0.38.0", package = "aprender-present-test-macros" }
+jugar-probar-derive = { path = "crates/aprender-test-derive", version = "0.38.0", package = "aprender-test-derive" }
+batuta-common = { path = "crates/aprender-common", version = "0.38.0", package = "aprender-common" }
 # APR-MONO sibling aliases — MUST use workspace refs, NEVER crates.io versions.
 # Hard-pinning these to crates.io creates a diamond: sub-crates pull older
 # aprender versions → multiple `aprender` crates in Cargo.lock = MUDA.
-renacer = { path = "crates/aprender-profile", version = "0.37.0", package = "aprender-profile" }
-entrenar-lora = { path = "crates/aprender-train-lora", version = "0.37.0", package = "aprender-train-lora" }
-batuta = { path = "crates/aprender-orchestrate", version = "0.37.0", package = "aprender-orchestrate" }
-trueno-graph = { path = "crates/aprender-graph", version = "0.37.0", package = "aprender-graph" }
+renacer = { path = "crates/aprender-profile", version = "0.38.0", package = "aprender-profile" }
+entrenar-lora = { path = "crates/aprender-train-lora", version = "0.38.0", package = "aprender-train-lora" }
+batuta = { path = "crates/aprender-orchestrate", version = "0.38.0", package = "aprender-orchestrate" }
+trueno-graph = { path = "crates/aprender-graph", version = "0.38.0", package = "aprender-graph" }
 
 [workspace.lints.rust]
 # Safety
@@ -428,7 +428,7 @@ semicolon_if_nothing_returned = "allow"  # Style preference
 
 [package]
 name = "aprender"
-version = "0.37.0"
+version = "0.38.0"
 edition = "2021"
 rust-version = "1.89"
 authors = ["Noah Gift <noah@paiml.com>"]
@@ -458,7 +458,7 @@ required-features = ["cli"]
 # (e.g. apr-cookbook, downstream apps) don't pull apr-cli's heavy transitive
 # dep graph (renacer/profile/inference/zram/visualization). `cargo install
 # aprender` still works because `cli` is in default features. See GH-1599.
-apr-cli = { path = "crates/apr-cli", version = "0.37.0", default-features = true, optional = true }
+apr-cli = { path = "crates/apr-cli", version = "0.38.0", default-features = true, optional = true }
 # Core ML library (lib name = "aprender")
 aprender_ml = { path = "crates/aprender-core", version = ">=0.29", package = "aprender-core" }
 

--- a/contracts/sharded-gguf-merge-v1.yaml
+++ b/contracts/sharded-gguf-merge-v1.yaml
@@ -1,0 +1,127 @@
+metadata:
+  version: 1.0.0
+  created: '2026-06-11'
+  author: PAIML Engineering
+  description: |
+    `merge_gguf_shards` combines a complete sharded-GGUF set
+    (`<prefix>-NNNNN-of-MMMMM.gguf`) into a SINGLE GGUF so the existing
+    single-file loader (`realizar GGUFModel::from_path`) runs the model unchanged
+    — no inference-hot-path refactor. This is #1893 criterion 2 ("infer across a
+    split GGUF without manual pre-stitching"), delivered as auto-merge at pull
+    time.
+
+    Hardened against a multi-agent adversarial review (5 release-blockers):
+    - METADATA must be LOSSLESS. Sourcing metadata from the architecture-
+      whitelisted reader silently dropped <arch>.* config keys (gemma.*, phi3.*,
+      deepseek2.*, …) -> merged file unloadable. The merge reads part-0 metadata
+      with the keep-all reader and re-emits every key except split.* /
+      general.alignment.
+    - MEMORY must be BOUNDED. A 7B sharded model must not need ~2x its size in
+      RAM; the merge streams output to disk and holds at most one part at a time.
+    - Tensors must be a DISJOINT union; duplicate names across parts are rejected.
+    - The merged file must be accepted by the REAL inference loader, not just the
+      writer's sibling reader.
+  references:
+  - 'issue #1893 criterion 2 — run sharded GGUF without manual pre-stitching'
+  - 'crates/aprender-core/src/format/gguf/merge.rs — merge_gguf_shards (streaming, type-agnostic)'
+  - 'crates/aprender-core/src/format/gguf/reader_parsing.rs — from_file_full / from_bytes_keep(keep_all)'
+  - 'crates/apr-cli/src/commands/pull.rs — run_sharded_gguf wiring + parts cleanup'
+  - 'contracts/sharded-gguf-pull-v1.yaml — the v0.37.0 pull-side this completes'
+
+kind: KernelContract
+name: sharded-gguf-merge
+version: 1.0.0
+scope: aprender-core merge_gguf_shards + GgufReader keep-all mode + apr-cli pull wiring
+
+equations:
+  lossless_merge:
+    formula: |
+      merge(parts) produces a single GGUF whose tensor set is the disjoint union
+      of all parts' tensors (bytes preserved), whose metadata equals part-0's
+      metadata minus {split.*, general.alignment}, and which the real loader
+      (realizar GGUFModel::from_bytes) parses successfully.
+    domain: parts = complete shard set, len >= 2, disjoint tensor names
+    codomain: one GGUF file
+    invariants:
+    - 'every tensor from every part appears exactly once, bytes identical'
+    - 'every part-0 metadata key survives except split.* and general.alignment (NO architecture whitelist)'
+    - 'duplicate tensor name across parts -> Err (never silently merged)'
+    - 'the merged file is accepted by realizar GGUFModel::from_bytes'
+    lean_theorem: Theorems.Lossless_Merge
+  bounded_memory:
+    formula: |
+      Peak heap during merge is O(largest single part), not O(total model size):
+      output is streamed to disk and parts are re-read one at a time.
+    domain: any shard set
+    codomain: peak resident heap
+    invariants:
+    - 'the whole merged model is never materialized in a single in-RAM buffer'
+    - 'at most one part''s bytes are resident at once'
+    lean_theorem: Theorems.Bounded_Memory
+
+proof_obligations:
+- type: invariant
+  property: tensors unioned with bytes preserved
+  formal: |
+    For a 2-part split, the merged file contains every source tensor with
+    byte-identical data and stripped split.* metadata.
+- type: invariant
+  property: lossless metadata for non-whitelisted architectures
+  formal: |
+    For a gemma-arch split, the merged file retains gemma.embedding_length /
+    gemma.block_count / gemma.attention.head_count.
+- type: invariant
+  property: duplicate tensor names rejected
+  formal: 'A tensor name present in two parts makes merge return Err.'
+- type: classification
+  property: real-loader acceptance
+  formal: 'realizar::gguf::GGUFModel::from_bytes(merged) is Ok.'
+
+falsification_tests:
+- id: FT-MERGE-001
+  rule: tensors unioned, split.* stripped, bytes preserved
+  prediction: 'a 2-part split round-trips with both tensors and no split.* keys.'
+  if_fails: 'offset/alignment or union logic wrong. Check the pass-1/pass-2 offset math.'
+  evidence: cargo test -p aprender-core --lib format::gguf::merge::tests::merge_two_part_roundtrip
+- id: FT-MERGE-004
+  rule: non-whitelisted arch (gemma) config metadata survives the merge
+  prediction: 'merged gemma file still has gemma.embedding_length / block_count / head_count.'
+  if_fails: 'merge is sourcing metadata from the whitelisted reader again. Use from_file_full.'
+  evidence: cargo test -p aprender-core --lib format::gguf::merge::tests::merge_preserves_nonwhitelisted_arch_metadata
+- id: FT-MERGE-005
+  rule: duplicate tensor names across parts are rejected
+  prediction: 'two parts sharing a tensor name -> merge returns Err.'
+  if_fails: 'the cross-part dedup HashSet check is missing or wrong.'
+  evidence: cargo test -p aprender-core --lib format::gguf::merge::tests::merge_rejects_duplicate_tensor_names
+- id: FT-MERGE-006
+  rule: the merged file loads in realizar's real GGUF parser
+  prediction: 'realizar::gguf::GGUFModel::from_bytes(merged gemma split) is Ok.'
+  if_fails: 'the merged byte layout diverges from what the inference loader accepts.'
+  evidence: cargo test -p apr-cli --lib sharded_gguf_interop_tests::merged_sharded_gguf_loads_in_realizar
+
+kani_harnesses:
+- id: KANI-MERGE-001
+  obligation: offsets are monotonic and alignment-correct
+  property: |
+    For any sequence of tensor block lengths, the cumulative offset written in
+    the tensor-info section equals the byte position where that tensor's data is
+    streamed (both pad each block to 32-byte alignment). No divergence.
+  bound: 16
+  strategy: bounded_int
+  solver: cadical
+  harness: verify_merge_offsets_match
+- id: KANI-MERGE-002
+  obligation: fewer than 2 parts is a clean error
+  property: 'merge_gguf_shards with 0 or 1 parts returns Err, never panics.'
+  bound: 2
+  strategy: compositional
+  solver: cadical
+  harness: verify_merge_min_parts
+
+qa_gate:
+  id: F-MERGE-001
+  name: sharded-gguf-merge-v1 Contract
+  description: Merge must be lossless (tensors + all-arch metadata), bounded-memory, dedup-checked, and accepted by the real loader.
+  checks:
+  - validation
+  - falsification

--- a/crates/apr-cli/Cargo.toml
+++ b/crates/apr-cli/Cargo.toml
@@ -103,10 +103,10 @@ libc = "0.2"
 
 [dependencies]
 # Core aprender library
-aprender = { path = "../aprender-core", version = "0.37.0", package = "aprender-core", default-features = true, features = ["format-compression"] }
+aprender = { path = "../aprender-core", version = "0.38.0", package = "aprender-core", default-features = true, features = ["format-compression"] }
 
 # MCP (Model Context Protocol) server — `apr mcp` subcommand
-aprender-mcp = { path = "../aprender-mcp", version = "0.37.0" }
+aprender-mcp = { path = "../aprender-mcp", version = "0.38.0" }
 async-stream = "0.3"
 provable-contracts-macros = "0.3"
 

--- a/crates/apr-cli/src/commands/pull.rs
+++ b/crates/apr-cli/src/commands/pull.rs
@@ -371,18 +371,43 @@ fn run_sharded_gguf(
     download_companion_files(cache_dir, base_url, force)?;
     write_shard_manifest(&manifest_path, org, repo, file_checksums)?;
 
-    let first_part = cache_dir.join(shard_files.first().map_or("", String::as_str));
     println!();
     println!(
         "{} Downloaded {} GGUF shards",
         "✓".green(),
         shard_files.len().to_string().yellow()
     );
-    println!("  Path: {}", first_part.display().to_string().green());
+
+    // #1893 criterion 2: merge the parts into one loadable GGUF so the existing
+    // single-file loader runs the model unchanged ("without manual
+    // pre-stitching"). On failure, fall back to the first part — a completed
+    // download is never wasted.
+    let part_paths: Vec<std::path::PathBuf> =
+        shard_files.iter().map(|f| cache_dir.join(f)).collect();
+    let merged_path = cache_dir.join("model.gguf");
+    let usage_path = match aprender::format::gguf::merge_gguf_shards(&part_paths, &merged_path) {
+        Ok(()) => {
+            println!(
+                "  {} merged {} parts → model.gguf",
+                "✓".green(),
+                shard_files.len().to_string().yellow()
+            );
+            merged_path
+        }
+        Err(e) => {
+            eprintln!(
+                "  {} shard merge failed ({e}); leaving parts in place",
+                "!".yellow()
+            );
+            cache_dir.join(shard_files.first().map_or("", String::as_str))
+        }
+    };
+
+    println!("  Path: {}", usage_path.display().to_string().green());
     println!();
     println!("{}", "Usage:".cyan().bold());
-    println!("  apr run {}", first_part.display());
-    println!("  apr serve {}", first_part.display());
+    println!("  apr run {}", usage_path.display());
+    println!("  apr serve {}", usage_path.display());
     Ok(())
 }
 

--- a/crates/apr-cli/src/commands/pull.rs
+++ b/crates/apr-cli/src/commands/pull.rs
@@ -380,34 +380,49 @@ fn run_sharded_gguf(
 
     // #1893 criterion 2: merge the parts into one loadable GGUF so the existing
     // single-file loader runs the model unchanged ("without manual
-    // pre-stitching"). On failure, fall back to the first part — a completed
-    // download is never wasted.
+    // pre-stitching").
     let part_paths: Vec<std::path::PathBuf> =
         shard_files.iter().map(|f| cache_dir.join(f)).collect();
     let merged_path = cache_dir.join("model.gguf");
-    let usage_path = match aprender::format::gguf::merge_gguf_shards(&part_paths, &merged_path) {
+    match aprender::format::gguf::merge_gguf_shards(&part_paths, &merged_path) {
         Ok(()) => {
+            // The merged model supersedes the parts — delete them so the model
+            // doesn't occupy ~2× its size on disk indefinitely.
+            for part in &part_paths {
+                if let Err(e) = std::fs::remove_file(part) {
+                    eprintln!(
+                        "  {} could not remove shard {} ({e})",
+                        "!".yellow(),
+                        part.display()
+                    );
+                }
+            }
             println!(
                 "  {} merged {} parts → model.gguf",
                 "✓".green(),
                 shard_files.len().to_string().yellow()
             );
-            merged_path
+            println!("  Path: {}", merged_path.display().to_string().green());
+            println!();
+            println!("{}", "Usage:".cyan().bold());
+            println!("  apr run {}", merged_path.display());
+            println!("  apr serve {}", merged_path.display());
         }
         Err(e) => {
+            // Honest failure: the individual parts are NOT independently
+            // runnable, so do not point `apr run` at one of them.
+            eprintln!("  {} could not assemble the sharded model: {e}", "✗".red());
             eprintln!(
-                "  {} shard merge failed ({e}); leaving parts in place",
-                "!".yellow()
+                "  The {} parts were downloaded to {} but cannot be run \
+                 individually. Please file an issue (#1893) with the model name.",
+                shard_files.len(),
+                cache_dir.display()
             );
-            cache_dir.join(shard_files.first().map_or("", String::as_str))
+            return Err(CliError::ValidationFailed(format!(
+                "sharded GGUF merge failed: {e}"
+            )));
         }
-    };
-
-    println!("  Path: {}", usage_path.display().to_string().green());
-    println!();
-    println!("{}", "Usage:".cyan().bold());
-    println!("  apr run {}", usage_path.display());
-    println!("  apr serve {}", usage_path.display());
+    }
     Ok(())
 }
 
@@ -702,3 +717,69 @@ include!("pull_remove_resolve_model.rs");
 include!("pull_extract_shard.rs");
 include!("pull_04.rs");
 include!("pull_dataset.rs");
+
+#[cfg(all(test, feature = "inference"))]
+mod sharded_gguf_interop_tests {
+    use aprender::format::gguf::{
+        export_tensors_to_gguf, merge_gguf_shards, GgmlType, GgufTensor, GgufValue,
+    };
+    use std::path::Path;
+
+    fn write_part(path: &Path, tensors: &[GgufTensor], meta: &[(String, GgufValue)]) {
+        let mut buf = Vec::new();
+        export_tensors_to_gguf(&mut buf, tensors, meta).expect("export part");
+        std::fs::write(path, &buf).expect("write part");
+    }
+
+    /// FT-MERGE-006: the merged sharded GGUF is accepted by realizar's OWN GGUF
+    /// parser (`GGUFModel::from_bytes`) — the actual inference loader, not just
+    /// aprender-core's reader. Closes the cross-parser verification gap: a merge
+    /// validated only by the writer's sibling reader could still be rejected by
+    /// the loader it exists to feed.
+    #[test]
+    fn merged_sharded_gguf_loads_in_realizar() {
+        let dir = std::env::temp_dir().join(format!("apr-merge-interop-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        let p0 = dir.join("model-00001-of-00002.gguf");
+        let p1 = dir.join("model-00002-of-00002.gguf");
+        let merged = dir.join("model.gguf");
+
+        let tensor = |name: &str, fill: u8| GgufTensor {
+            name: name.into(),
+            shape: vec![4],
+            dtype: GgmlType::F32,
+            data: vec![fill; 16],
+        };
+        write_part(
+            &p0,
+            &[tensor("blk.0.weight", 1)],
+            &[
+                (
+                    "general.architecture".into(),
+                    GgufValue::String("gemma".into()),
+                ),
+                ("gemma.embedding_length".into(), GgufValue::Uint32(2048)),
+                ("gemma.block_count".into(), GgufValue::Uint32(18)),
+                ("split.no".into(), GgufValue::Uint16(0)),
+                ("split.count".into(), GgufValue::Uint16(2)),
+            ],
+        );
+        write_part(
+            &p1,
+            &[tensor("blk.1.weight", 2)],
+            &[("split.no".into(), GgufValue::Uint16(1))],
+        );
+
+        merge_gguf_shards(&[p0, p1], &merged).expect("merge");
+        let bytes = std::fs::read(&merged).expect("read merged");
+
+        let parsed = realizar::gguf::GGUFModel::from_bytes(&bytes);
+        assert!(
+            parsed.is_ok(),
+            "realizar's GGUF loader must accept the merged sharded file: {:?}",
+            parsed.err()
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/crates/aprender-bench-compute/Cargo.toml
+++ b/crates/aprender-bench-compute/Cargo.toml
@@ -11,7 +11,7 @@ disallowed_methods = "allow"
 
 [dependencies]
 # The implementation under test
-aprender = { path = "../aprender-core", version = "0.37.0", package = "aprender-core", features = ["format-quantize"] }
+aprender = { path = "../aprender-core", version = "0.38.0", package = "aprender-core", features = ["format-quantize"] }
 
 # Reference implementation for A/B comparison
 # Pure Rust (no BLAS) to keep comparison fair — both are pure Rust SIMD

--- a/crates/aprender-bench-tokenizer/Cargo.toml
+++ b/crates/aprender-bench-tokenizer/Cargo.toml
@@ -11,7 +11,7 @@ disallowed_methods = "allow"
 
 [dependencies]
 # The implementation under test
-aprender = { path = "../aprender-core", version = "0.37.0", package = "aprender-core" }
+aprender = { path = "../aprender-core", version = "0.38.0", package = "aprender-core" }
 
 # HuggingFace reference for A/B comparison
 # Regular dep (not dev-dep) because [[bench]] harness=false binaries can't see dev-deps

--- a/crates/aprender-cbtop/Cargo.toml
+++ b/crates/aprender-cbtop/Cargo.toml
@@ -23,8 +23,8 @@ presentar-core = "0.3"
 presentar-terminal = "0.3"
 
 # Compute backends
-trueno = { version = "0.37.0", path = "../aprender-compute", package = "aprender-compute" }
-trueno-gpu = { version = "0.37.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true }
+trueno = { version = "0.38.0", path = "../aprender-compute", package = "aprender-compute" }
+trueno-gpu = { version = "0.38.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true }
 
 # Terminal handling
 crossterm = "0.28"

--- a/crates/aprender-cgp/Cargo.toml
+++ b/crates/aprender-cgp/Cargo.toml
@@ -36,7 +36,7 @@ num_cpus = "1.17"
 comfy-table = "7"
 colored = "3"
 # GPU profiling: direct cuBLAS measurement (OWN THE STACK)
-trueno-gpu = { path = "../aprender-gpu", version = "0.37.0", features = ["cuda"], optional = true, package = "aprender-gpu" }
+trueno-gpu = { path = "../aprender-gpu", version = "0.38.0", features = ["cuda"], optional = true, package = "aprender-gpu" }
 
 [features]
 default = []

--- a/crates/aprender-compute/Cargo.toml
+++ b/crates/aprender-compute/Cargo.toml
@@ -38,11 +38,11 @@ futures-intrusive = { version = "0.5", optional = true }
 wasm-bindgen-futures = { version = "0.4", optional = true }
 wasm-bindgen = { version = "0.2", optional = true }
 # Native CUDA monitoring via trueno-gpu (TRUENO-SPEC-010)
-trueno-gpu = { version = "0.37.0", path = "../aprender-gpu", optional = true, package = "aprender-gpu" }
+trueno-gpu = { version = "0.38.0", path = "../aprender-gpu", optional = true, package = "aprender-gpu" }
 # PMAT-336: Provable contracts compile-time enforcement
 provable-contracts-macros = "0.3"
 # P1a: Sovereign GEMM microkernel codegen (compile-time shape specialization)
-trueno-gemm-codegen = { version = "0.37.0", path = "../aprender-gemm-codegen", package = "aprender-gemm-codegen" }
+trueno-gemm-codegen = { version = "0.38.0", path = "../aprender-gemm-codegen", package = "aprender-gemm-codegen" }
 # Tracing/profiling support (renacer integration)
 tracing = { version = "0.1", optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"], optional = true }
@@ -54,7 +54,7 @@ presentar-core = { version = "0.3", optional = true }
 # Stress test reporting types compatible with renacer (TRUENO-SPEC-025)
 # Note: renacer 0.9.1 has compilation issue; using compatible local types instead
 dhat = { version = "0.3", optional = true }
-trueno-quant = { version = "0.37.0", path = "../aprender-quant", package = "aprender-quant" }
+trueno-quant = { version = "0.38.0", path = "../aprender-quant", package = "aprender-quant" }
 num_cpus = "1.17.0"
 anyhow = "1.0.100"
 # Hardware capability detection (PMAT-447)
@@ -62,7 +62,7 @@ chrono = "0.4"
 toml = "0.8"
 # ML tuner integration (SHOWCASE-BRICK-001, Section 12)
 # Uses aprender 0.24.0 RandomForest for learned optimization
-aprender = { path = "../aprender-core", version = "0.37.0", package = "aprender-core", optional = true, default-features = false }
+aprender = { path = "../aprender-core", version = "0.38.0", package = "aprender-core", optional = true, default-features = false }
 # Execution path graph (PAR-201, Section E.7)
 trueno-graph = { workspace = true, optional = true }
 # TUI visualization for execution graphs (PAR-201)
@@ -90,10 +90,10 @@ nalgebra = "0.34"  # For eigendecomposition benchmark comparison
 simular = "0.2.0"
 regex = "1.11"  # For PTX/WGSL pattern validation in falsification tests
 # GPU edge-case test framework (TCE-001)
-trueno-cuda-edge = { version = "0.37.0", path = "../aprender-cuda-edge", package = "aprender-cuda-edge" }
+trueno-cuda-edge = { version = "0.38.0", path = "../aprender-cuda-edge", package = "aprender-cuda-edge" }
 # Sparse and solver crates for contract tests
-trueno-sparse = { version = "0.37.0", path = "../aprender-sparse", package = "aprender-sparse" }
-trueno-solve = { version = "0.37.0", path = "../aprender-solve", package = "aprender-solve" }
+trueno-sparse = { version = "0.38.0", path = "../aprender-sparse", package = "aprender-sparse" }
+trueno-solve = { version = "0.38.0", path = "../aprender-solve", package = "aprender-solve" }
 ndarray = "0.17.2"
 faer = "0.24"  # For GEMM benchmark comparison (fastest pure-Rust BLAS)
 matrixmultiply = "0.3"  # Direct matrixmultiply crate benchmark (engine behind ndarray)

--- a/crates/aprender-contracts-cli/Cargo.toml
+++ b/crates/aprender-contracts-cli/Cargo.toml
@@ -13,7 +13,7 @@ name = "pv"
 path = "src/main.rs"
 
 [dependencies]
-aprender-contracts = { path = "../aprender-contracts", version = "0.37.0" }
+aprender-contracts = { path = "../aprender-contracts", version = "0.38.0" }
 clap = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }

--- a/crates/aprender-contracts/Cargo.toml
+++ b/crates/aprender-contracts/Cargo.toml
@@ -19,7 +19,7 @@ kani = []
 name = "provable_contracts"
 
 [dependencies]
-provable-contracts-macros = { path = "../aprender-contracts-macros", version = "0.37.0", package = "aprender-contracts-macros" }
+provable-contracts-macros = { path = "../aprender-contracts-macros", version = "0.38.0", package = "aprender-contracts-macros" }
 regex = "1"
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/aprender-core/src/format/gguf/merge.rs
+++ b/crates/aprender-core/src/format/gguf/merge.rs
@@ -1,0 +1,248 @@
+//! #1893: Merge sharded GGUF parts (`-NNNNN-of-MMMMM.gguf`) into one GGUF file.
+//!
+//! Sharded GGUFs carry no `index.json`; each part is a complete GGUF holding a
+//! SUBSET of tensors plus `split.*` metadata. Merging the parts into a single
+//! file lets the existing single-file loader (`GGUFModel::from_path`) run them
+//! unchanged — no inference-hot-path refactor (the codebase's #1 garbage-output
+//! risk class).
+//!
+//! **Type-agnostic.** Tensor data is copied as raw byte ranges sized from the
+//! source part's own offset table (the gap to the next tensor's offset), then
+//! re-padded to GGUF alignment in the merged file. So EVERY ggml quant type
+//! works (Q5_K / Q3_K / IQ\* included) regardless of the `GgmlType` enum — we
+//! never interpret tensor contents. `split.*` and `general.alignment` keys are
+//! stripped so the merged file is self-consistent at the default 32-byte
+//! alignment.
+
+use super::reader::{GgufReader, GgufTensorMeta};
+use super::types::{
+    padding_for_alignment, write_metadata_kv, GgufHeader, GgufValue, GGUF_DEFAULT_ALIGNMENT,
+    GGUF_VERSION,
+};
+use crate::error::{AprenderError, Result};
+use std::io;
+use std::path::{Path, PathBuf};
+
+fn invalid(msg: String) -> AprenderError {
+    AprenderError::Io(io::Error::new(io::ErrorKind::InvalidData, msg))
+}
+
+/// Write a length-prefixed UTF-8 string (GGUF spec §7).
+fn write_string(buf: &mut Vec<u8>, s: &str) {
+    buf.extend_from_slice(&(s.len() as u64).to_le_bytes());
+    buf.extend_from_slice(s.as_bytes());
+}
+
+/// One tensor pulled from a shard: name, dims, raw ggml type, and raw bytes.
+struct MergedTensor {
+    name: String,
+    dims: Vec<u64>,
+    dtype: u32,
+    data: Vec<u8>,
+}
+
+/// Merge ordered sharded-GGUF `parts` (the complete set, in part order 1..=N)
+/// into a single GGUF written to `output`.
+///
+/// Metadata is taken from the first part with `split.*` / `general.alignment`
+/// stripped; tensors are the union across all parts in file order.
+///
+/// # Errors
+/// Returns an error if fewer than 2 parts are given, a part fails to parse, a
+/// part has corrupt tensor offsets, or the output cannot be written.
+pub fn merge_gguf_shards(parts: &[PathBuf], output: &Path) -> Result<()> {
+    if parts.len() < 2 {
+        return Err(invalid(format!(
+            "merge_gguf_shards needs >= 2 parts, got {}",
+            parts.len()
+        )));
+    }
+
+    let mut tensors: Vec<MergedTensor> = Vec::new();
+    let mut metadata: Vec<(String, GgufValue)> = Vec::new();
+
+    for (i, path) in parts.iter().enumerate() {
+        let reader = GgufReader::from_file(path)?;
+
+        // Metadata comes from the first part only (the others duplicate it),
+        // minus the split bookkeeping and any alignment override.
+        if i == 0 {
+            for (k, v) in &reader.metadata {
+                if !k.starts_with("split.") && k != "general.alignment" {
+                    metadata.push((k.clone(), v.clone()));
+                }
+            }
+        }
+
+        // Size each tensor by the gap to the next offset (type-agnostic).
+        let mut metas: Vec<&GgufTensorMeta> = reader.tensors.iter().collect();
+        metas.sort_by_key(|t| t.offset);
+        let section_len = reader.data.len().saturating_sub(reader.data_offset);
+
+        for (j, meta) in metas.iter().enumerate() {
+            let start = meta.offset as usize;
+            let end = if j + 1 < metas.len() {
+                metas[j + 1].offset as usize
+            } else {
+                section_len
+            };
+            let abs_start = reader.data_offset.saturating_add(start);
+            let abs_end = reader.data_offset.saturating_add(end);
+            if end < start || abs_end > reader.data.len() {
+                return Err(invalid(format!(
+                    "corrupt tensor offsets in shard {}",
+                    path.display()
+                )));
+            }
+            tensors.push(MergedTensor {
+                name: meta.name.clone(),
+                dims: meta.dims.clone(),
+                dtype: meta.dtype,
+                data: reader.data[abs_start..abs_end].to_vec(),
+            });
+        }
+    }
+
+    // --- Serialize the merged GGUF ---
+    // Header + metadata + tensor infos go into a buffer first so the data
+    // section can be aligned against the real header size (DEFECT-002 pattern).
+    let mut head: Vec<u8> = Vec::new();
+    GgufHeader {
+        version: GGUF_VERSION,
+        tensor_count: tensors.len() as u64,
+        metadata_kv_count: metadata.len() as u64,
+    }
+    .write_to(&mut head)?;
+    for (k, v) in &metadata {
+        write_metadata_kv(&mut head, k, v)?;
+    }
+
+    // Tensor infos with cumulative, alignment-padded offsets.
+    let mut running: u64 = 0;
+    for t in &tensors {
+        write_string(&mut head, &t.name);
+        head.extend_from_slice(&(t.dims.len() as u32).to_le_bytes());
+        for d in &t.dims {
+            head.extend_from_slice(&d.to_le_bytes());
+        }
+        head.extend_from_slice(&t.dtype.to_le_bytes());
+        head.extend_from_slice(&running.to_le_bytes());
+        running = running.saturating_add(t.data.len() as u64);
+        running = running
+            .saturating_add(padding_for_alignment(running as usize, GGUF_DEFAULT_ALIGNMENT) as u64);
+    }
+
+    let mut out = head;
+    // Pad the header section to alignment, then write each tensor's bytes
+    // followed by its own alignment padding (mirrors the offset math above).
+    let header_pad = padding_for_alignment(out.len(), GGUF_DEFAULT_ALIGNMENT);
+    out.extend(std::iter::repeat(0u8).take(header_pad));
+    for t in &tensors {
+        out.extend_from_slice(&t.data);
+        let data_pad = padding_for_alignment(t.data.len(), GGUF_DEFAULT_ALIGNMENT);
+        out.extend(std::iter::repeat(0u8).take(data_pad));
+    }
+
+    std::fs::write(output, &out)
+        .map_err(|e| AprenderError::Io(io::Error::new(e.kind(), e.to_string())))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::format::gguf::types::{export_tensors_to_gguf, GgmlType, GgufTensor};
+
+    fn write_part(path: &Path, tensors: &[GgufTensor], meta: &[(String, GgufValue)]) {
+        let mut buf = Vec::new();
+        export_tensors_to_gguf(&mut buf, tensors, meta).expect("export part");
+        std::fs::write(path, &buf).expect("write part");
+    }
+
+    /// FT-MERGE-001..003: a 2-part split round-trips — tensors unioned with bytes
+    /// preserved, split.* stripped, general.* kept.
+    #[test]
+    fn merge_two_part_roundtrip() {
+        let dir = std::env::temp_dir().join(format!("apr-merge-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        let p0 = dir.join("model-00001-of-00002.gguf");
+        let p1 = dir.join("model-00002-of-00002.gguf");
+        let merged = dir.join("model.gguf");
+
+        // F32 tensor (16B) in part 0; Q4_0 tensor (36B) in part 1.
+        let a_data = vec![1u8; 16];
+        let b_data = vec![2u8; 36];
+        let a = GgufTensor {
+            name: "blk.0.weight".into(),
+            shape: vec![4],
+            dtype: GgmlType::F32,
+            data: a_data.clone(),
+        };
+        let b = GgufTensor {
+            name: "blk.1.weight".into(),
+            shape: vec![64],
+            dtype: GgmlType::Q4_0,
+            data: b_data.clone(),
+        };
+
+        write_part(
+            &p0,
+            &[a],
+            &[
+                (
+                    "general.architecture".into(),
+                    GgufValue::String("llama".into()),
+                ),
+                ("split.no".into(), GgufValue::Uint16(0)),
+                ("split.count".into(), GgufValue::Uint16(2)),
+            ],
+        );
+        write_part(
+            &p1,
+            &[b],
+            &[
+                ("split.no".into(), GgufValue::Uint16(1)),
+                ("split.count".into(), GgufValue::Uint16(2)),
+            ],
+        );
+
+        merge_gguf_shards(&[p0, p1], &merged).expect("merge");
+
+        let r = GgufReader::from_file(&merged).expect("re-read merged");
+
+        // FT-MERGE-001: union of tensors across parts.
+        let names: Vec<&str> = r.tensors.iter().map(|t| t.name.as_str()).collect();
+        assert!(
+            names.contains(&"blk.0.weight") && names.contains(&"blk.1.weight"),
+            "merged file must contain tensors from BOTH parts, got {names:?}"
+        );
+
+        // FT-MERGE-002: split.* stripped, general.* preserved.
+        assert!(
+            !r.metadata.keys().any(|k| k.starts_with("split.")),
+            "split.* metadata must be stripped from the merged file"
+        );
+        assert!(
+            r.metadata.contains_key("general.architecture"),
+            "general.* metadata must be preserved"
+        );
+
+        // FT-MERGE-003: tensor bytes preserved (read the real prefix of each).
+        for (name, want) in [("blk.0.weight", &a_data), ("blk.1.weight", &b_data)] {
+            let m = r
+                .tensors
+                .iter()
+                .find(|t| t.name == name)
+                .unwrap_or_else(|| panic!("tensor {name} missing"));
+            let start = r.data_offset + m.offset as usize;
+            let got = &r.data[start..start + want.len()];
+            assert_eq!(
+                got,
+                want.as_slice(),
+                "tensor {name} bytes must survive merge"
+            );
+        }
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/crates/aprender-core/src/format/gguf/merge.rs
+++ b/crates/aprender-core/src/format/gguf/merge.rs
@@ -6,13 +6,21 @@
 //! unchanged — no inference-hot-path refactor (the codebase's #1 garbage-output
 //! risk class).
 //!
-//! **Type-agnostic.** Tensor data is copied as raw byte ranges sized from the
-//! source part's own offset table (the gap to the next tensor's offset), then
-//! re-padded to GGUF alignment in the merged file. So EVERY ggml quant type
-//! works (Q5_K / Q3_K / IQ\* included) regardless of the `GgmlType` enum — we
-//! never interpret tensor contents. `split.*` and `general.alignment` keys are
-//! stripped so the merged file is self-consistent at the default 32-byte
-//! alignment.
+//! **Type-agnostic data.** Tensor data is copied as raw byte ranges sized from
+//! the source part's own offset table (the gap to the next tensor's offset),
+//! then re-padded to GGUF alignment in the merged file. So EVERY ggml quant type
+//! works (Q5_K / Q3_K / IQ\* included) regardless of the `GgmlType` enum.
+//!
+//! **Lossless metadata.** Part-0 metadata is read with [`GgufReader::from_file_full`]
+//! (no architecture whitelist) so arbitrary `<arch>.*` config keys (gemma.*,
+//! phi3.*, deepseek2.*, …) survive — without this the merged file would be
+//! unloadable for any architecture outside the reader's parse whitelist.
+//! `split.*` and `general.alignment` keys are stripped so the merged file is
+//! self-consistent at the default 32-byte alignment.
+//!
+//! **Bounded memory.** The output is streamed to disk and each part is held in
+//! RAM only while its tensors are copied (peak ≈ the largest single part, not
+//! the whole model) — required for the 7B+ sharded models this targets.
 
 use super::reader::{GgufReader, GgufTensorMeta};
 use super::types::{
@@ -20,11 +28,17 @@ use super::types::{
     GGUF_VERSION,
 };
 use crate::error::{AprenderError, Result};
-use std::io;
+use std::collections::HashSet;
+use std::fs::File;
+use std::io::{self, BufWriter, Write};
 use std::path::{Path, PathBuf};
 
 fn invalid(msg: String) -> AprenderError {
     AprenderError::Io(io::Error::new(io::ErrorKind::InvalidData, msg))
+}
+
+fn io_err(e: io::Error) -> AprenderError {
+    AprenderError::Io(io::Error::new(e.kind(), e.to_string()))
 }
 
 /// Write a length-prefixed UTF-8 string (GGUF spec §7).
@@ -33,23 +47,29 @@ fn write_string(buf: &mut Vec<u8>, s: &str) {
     buf.extend_from_slice(s.as_bytes());
 }
 
-/// One tensor pulled from a shard: name, dims, raw ggml type, and raw bytes.
-struct MergedTensor {
+/// Where a merged tensor's data lives: the source part and its absolute byte
+/// range within that part's file (so pass 2 can re-read and stream it).
+struct TensorPlan {
     name: String,
     dims: Vec<u64>,
     dtype: u32,
-    data: Vec<u8>,
+    part: usize,
+    abs_start: usize,
+    abs_end: usize,
 }
 
 /// Merge ordered sharded-GGUF `parts` (the complete set, in part order 1..=N)
 /// into a single GGUF written to `output`.
 ///
-/// Metadata is taken from the first part with `split.*` / `general.alignment`
-/// stripped; tensors are the union across all parts in file order.
+/// Metadata is taken verbatim from the first part (ALL keys) with `split.*` /
+/// `general.alignment` stripped; tensors are the union across all parts in file
+/// order. Duplicate tensor names across parts are rejected (a split must be
+/// disjoint).
 ///
 /// # Errors
 /// Returns an error if fewer than 2 parts are given, a part fails to parse, a
-/// part has corrupt tensor offsets, or the output cannot be written.
+/// part has corrupt tensor offsets, a tensor name appears in more than one
+/// part, or the output cannot be written.
 pub fn merge_gguf_shards(parts: &[PathBuf], output: &Path) -> Result<()> {
     if parts.len() < 2 {
         return Err(invalid(format!(
@@ -58,15 +78,22 @@ pub fn merge_gguf_shards(parts: &[PathBuf], output: &Path) -> Result<()> {
         )));
     }
 
-    let mut tensors: Vec<MergedTensor> = Vec::new();
+    let mut plans: Vec<TensorPlan> = Vec::new();
     let mut metadata: Vec<(String, GgufValue)> = Vec::new();
+    let mut seen: HashSet<String> = HashSet::new();
 
-    for (i, path) in parts.iter().enumerate() {
-        let reader = GgufReader::from_file(path)?;
+    // Pass 1: gather metadata (part 0, ALL keys) and tensor plans (all parts).
+    // Each part's whole-file buffer is freed at the end of its iteration.
+    for (pi, path) in parts.iter().enumerate() {
+        let reader = if pi == 0 {
+            // keep every <arch>.* config key — the merged model is otherwise
+            // unloadable for non-whitelisted architectures.
+            GgufReader::from_file_full(path)?
+        } else {
+            GgufReader::from_file(path)?
+        };
 
-        // Metadata comes from the first part only (the others duplicate it),
-        // minus the split bookkeeping and any alignment override.
-        if i == 0 {
+        if pi == 0 {
             for (k, v) in &reader.metadata {
                 if !k.starts_with("split.") && k != "general.alignment" {
                     metadata.push((k.clone(), v.clone()));
@@ -79,8 +106,8 @@ pub fn merge_gguf_shards(parts: &[PathBuf], output: &Path) -> Result<()> {
         metas.sort_by_key(|t| t.offset);
         let section_len = reader.data.len().saturating_sub(reader.data_offset);
 
-        for (j, meta) in metas.iter().enumerate() {
-            let start = meta.offset as usize;
+        for (j, m) in metas.iter().enumerate() {
+            let start = m.offset as usize;
             let end = if j + 1 < metas.len() {
                 metas[j + 1].offset as usize
             } else {
@@ -94,32 +121,37 @@ pub fn merge_gguf_shards(parts: &[PathBuf], output: &Path) -> Result<()> {
                     path.display()
                 )));
             }
-            tensors.push(MergedTensor {
-                name: meta.name.clone(),
-                dims: meta.dims.clone(),
-                dtype: meta.dtype,
-                data: reader.data[abs_start..abs_end].to_vec(),
+            if !seen.insert(m.name.clone()) {
+                return Err(invalid(format!(
+                    "duplicate tensor '{}' across shards (corrupt or non-disjoint split)",
+                    m.name
+                )));
+            }
+            plans.push(TensorPlan {
+                name: m.name.clone(),
+                dims: m.dims.clone(),
+                dtype: m.dtype,
+                part: pi,
+                abs_start,
+                abs_end,
             });
         }
     }
 
-    // --- Serialize the merged GGUF ---
-    // Header + metadata + tensor infos go into a buffer first so the data
-    // section can be aligned against the real header size (DEFECT-002 pattern).
+    // Build the header section (header + metadata + tensor infos) in RAM — it is
+    // small (no tensor data) and lets the data section align to its exact size.
     let mut head: Vec<u8> = Vec::new();
     GgufHeader {
         version: GGUF_VERSION,
-        tensor_count: tensors.len() as u64,
+        tensor_count: plans.len() as u64,
         metadata_kv_count: metadata.len() as u64,
     }
     .write_to(&mut head)?;
     for (k, v) in &metadata {
         write_metadata_kv(&mut head, k, v)?;
     }
-
-    // Tensor infos with cumulative, alignment-padded offsets.
     let mut running: u64 = 0;
-    for t in &tensors {
+    for t in &plans {
         write_string(&mut head, &t.name);
         head.extend_from_slice(&(t.dims.len() as u32).to_le_bytes());
         for d in &t.dims {
@@ -127,24 +159,43 @@ pub fn merge_gguf_shards(parts: &[PathBuf], output: &Path) -> Result<()> {
         }
         head.extend_from_slice(&t.dtype.to_le_bytes());
         head.extend_from_slice(&running.to_le_bytes());
-        running = running.saturating_add(t.data.len() as u64);
+        let len = (t.abs_end - t.abs_start) as u64;
+        running = running.saturating_add(len);
         running = running
             .saturating_add(padding_for_alignment(running as usize, GGUF_DEFAULT_ALIGNMENT) as u64);
     }
 
-    let mut out = head;
-    // Pad the header section to alignment, then write each tensor's bytes
-    // followed by its own alignment padding (mirrors the offset math above).
-    let header_pad = padding_for_alignment(out.len(), GGUF_DEFAULT_ALIGNMENT);
-    out.extend(std::iter::repeat(0u8).take(header_pad));
-    for t in &tensors {
-        out.extend_from_slice(&t.data);
-        let data_pad = padding_for_alignment(t.data.len(), GGUF_DEFAULT_ALIGNMENT);
-        out.extend(std::iter::repeat(0u8).take(data_pad));
+    // Pass 2: stream to the output file — header, then each tensor's bytes,
+    // re-reading one part at a time so peak RAM ≈ the largest single part.
+    let file = File::create(output).map_err(io_err)?;
+    let mut w = BufWriter::new(file);
+    w.write_all(&head).map_err(io_err)?;
+    let header_pad = padding_for_alignment(head.len(), GGUF_DEFAULT_ALIGNMENT);
+    if header_pad > 0 {
+        w.write_all(&vec![0u8; header_pad]).map_err(io_err)?;
     }
 
-    std::fs::write(output, &out)
-        .map_err(|e| AprenderError::Io(io::Error::new(e.kind(), e.to_string())))?;
+    let mut loaded: Option<(usize, GgufReader)> = None;
+    for t in &plans {
+        let reload = loaded.as_ref().map_or(true, |(pi, _)| *pi != t.part);
+        if reload {
+            loaded = Some((t.part, GgufReader::from_file(&parts[t.part])?));
+        }
+        let reader = &loaded.as_ref().expect("part just loaded").1;
+        if t.abs_end > reader.data.len() {
+            return Err(invalid(format!(
+                "shard {} shorter than expected on re-read",
+                parts[t.part].display()
+            )));
+        }
+        let block = &reader.data[t.abs_start..t.abs_end];
+        w.write_all(block).map_err(io_err)?;
+        let pad = padding_for_alignment(block.len(), GGUF_DEFAULT_ALIGNMENT);
+        if pad > 0 {
+            w.write_all(&vec![0u8; pad]).map_err(io_err)?;
+        }
+    }
+    w.flush().map_err(io_err)?;
     Ok(())
 }
 
@@ -159,17 +210,21 @@ mod tests {
         std::fs::write(path, &buf).expect("write part");
     }
 
+    fn tmpdir(tag: &str) -> PathBuf {
+        let d = std::env::temp_dir().join(format!("apr-merge-{}-{}", tag, std::process::id()));
+        std::fs::create_dir_all(&d).expect("mkdir");
+        d
+    }
+
     /// FT-MERGE-001..003: a 2-part split round-trips — tensors unioned with bytes
     /// preserved, split.* stripped, general.* kept.
     #[test]
     fn merge_two_part_roundtrip() {
-        let dir = std::env::temp_dir().join(format!("apr-merge-{}", std::process::id()));
-        std::fs::create_dir_all(&dir).expect("mkdir");
+        let dir = tmpdir("rt");
         let p0 = dir.join("model-00001-of-00002.gguf");
         let p1 = dir.join("model-00002-of-00002.gguf");
         let merged = dir.join("model.gguf");
 
-        // F32 tensor (16B) in part 0; Q4_0 tensor (36B) in part 1.
         let a_data = vec![1u8; 16];
         let b_data = vec![2u8; 36];
         let a = GgufTensor {
@@ -208,26 +263,20 @@ mod tests {
 
         merge_gguf_shards(&[p0, p1], &merged).expect("merge");
 
-        let r = GgufReader::from_file(&merged).expect("re-read merged");
-
-        // FT-MERGE-001: union of tensors across parts.
+        let r = GgufReader::from_file_full(&merged).expect("re-read merged");
         let names: Vec<&str> = r.tensors.iter().map(|t| t.name.as_str()).collect();
         assert!(
             names.contains(&"blk.0.weight") && names.contains(&"blk.1.weight"),
             "merged file must contain tensors from BOTH parts, got {names:?}"
         );
-
-        // FT-MERGE-002: split.* stripped, general.* preserved.
         assert!(
             !r.metadata.keys().any(|k| k.starts_with("split.")),
-            "split.* metadata must be stripped from the merged file"
+            "split.* metadata must be stripped"
         );
         assert!(
             r.metadata.contains_key("general.architecture"),
             "general.* metadata must be preserved"
         );
-
-        // FT-MERGE-003: tensor bytes preserved (read the real prefix of each).
         for (name, want) in [("blk.0.weight", &a_data), ("blk.1.weight", &b_data)] {
             let m = r
                 .tensors
@@ -235,14 +284,105 @@ mod tests {
                 .find(|t| t.name == name)
                 .unwrap_or_else(|| panic!("tensor {name} missing"));
             let start = r.data_offset + m.offset as usize;
-            let got = &r.data[start..start + want.len()];
             assert_eq!(
-                got,
+                &r.data[start..start + want.len()],
                 want.as_slice(),
                 "tensor {name} bytes must survive merge"
             );
         }
+        std::fs::remove_dir_all(&dir).ok();
+    }
 
+    /// FT-MERGE-004 (release-blocker regression): config metadata for a
+    /// NON-whitelisted architecture (gemma) must survive the merge — otherwise
+    /// the merged model is unloadable ("Missing embedding_length"). The earlier
+    /// llama-only test masked this because llama is in the reader whitelist.
+    #[test]
+    fn merge_preserves_nonwhitelisted_arch_metadata() {
+        let dir = tmpdir("gemma");
+        let p0 = dir.join("model-00001-of-00002.gguf");
+        let p1 = dir.join("model-00002-of-00002.gguf");
+        let merged = dir.join("model.gguf");
+
+        let t0 = GgufTensor {
+            name: "blk.0.weight".into(),
+            shape: vec![4],
+            dtype: GgmlType::F32,
+            data: vec![7u8; 16],
+        };
+        let t1 = GgufTensor {
+            name: "blk.1.weight".into(),
+            shape: vec![4],
+            dtype: GgmlType::F32,
+            data: vec![9u8; 16],
+        };
+        write_part(
+            &p0,
+            &[t0],
+            &[
+                (
+                    "general.architecture".into(),
+                    GgufValue::String("gemma".into()),
+                ),
+                ("gemma.embedding_length".into(), GgufValue::Uint32(2048)),
+                ("gemma.block_count".into(), GgufValue::Uint32(18)),
+                ("gemma.attention.head_count".into(), GgufValue::Uint32(8)),
+                ("split.no".into(), GgufValue::Uint16(0)),
+                ("split.count".into(), GgufValue::Uint16(2)),
+            ],
+        );
+        write_part(&p1, &[t1], &[("split.no".into(), GgufValue::Uint16(1))]);
+
+        merge_gguf_shards(&[p0, p1], &merged).expect("merge");
+
+        // Must read back with from_file_full (the merged file carries gemma.*).
+        let r = GgufReader::from_file_full(&merged).expect("re-read merged");
+        for key in [
+            "gemma.embedding_length",
+            "gemma.block_count",
+            "gemma.attention.head_count",
+        ] {
+            assert!(
+                r.metadata.contains_key(key),
+                "merged gemma model must retain {key}; got {:?}",
+                r.metadata.keys().collect::<Vec<_>>()
+            );
+        }
+        assert!(!r.metadata.keys().any(|k| k.starts_with("split.")));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// FT-MERGE-005: a tensor name appearing in two parts is rejected (a split
+    /// must be disjoint — duplicates would silently inflate tensor_count and
+    /// ship wrong weights).
+    #[test]
+    fn merge_rejects_duplicate_tensor_names() {
+        let dir = tmpdir("dup");
+        let p0 = dir.join("model-00001-of-00002.gguf");
+        let p1 = dir.join("model-00002-of-00002.gguf");
+        let merged = dir.join("model.gguf");
+
+        let dup = |fill: u8| GgufTensor {
+            name: "blk.0.weight".into(),
+            shape: vec![4],
+            dtype: GgmlType::F32,
+            data: vec![fill; 16],
+        };
+        write_part(
+            &p0,
+            &[dup(1)],
+            &[(
+                "general.architecture".into(),
+                GgufValue::String("llama".into()),
+            )],
+        );
+        write_part(&p1, &[dup(2)], &[]);
+
+        let res = merge_gguf_shards(&[p0, p1], &merged);
+        assert!(
+            res.is_err(),
+            "duplicate tensor name across shards must be rejected"
+        );
         std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/crates/aprender-core/src/format/gguf/mod.rs
+++ b/crates/aprender-core/src/format/gguf/mod.rs
@@ -25,12 +25,14 @@
 // Submodules (PMAT-199: split from monolithic gguf.rs)
 pub mod api;
 pub mod dequant;
+pub mod merge;
 pub mod reader;
 pub mod types;
 
 // Re-exports for backward compatibility
 pub use api::*;
 pub use dequant::*;
+pub use merge::*;
 pub use reader::*;
 pub use types::*;
 

--- a/crates/aprender-core/src/format/gguf/reader_parsing.rs
+++ b/crates/aprender-core/src/format/gguf/reader_parsing.rs
@@ -7,8 +7,29 @@ impl GgufReader {
         Self::from_bytes(data)
     }
 
-    /// Parse GGUF from bytes
+    /// Load a GGUF file preserving ALL metadata keys (no architecture
+    /// whitelist).
+    ///
+    /// Used by the sharded-GGUF merge ([`super::merge::merge_gguf_shards`]) so
+    /// arbitrary `<arch>.*` config keys (gemma.*, phi3.*, deepseek2.*, …)
+    /// survive into the merged file — otherwise the merged model is unloadable
+    /// for any architecture outside the parse whitelist.
+    pub fn from_file_full<P: AsRef<Path>>(path: P) -> Result<Self> {
+        let mut file = File::open(path.as_ref()).map_err(AprenderError::Io)?;
+        let mut data = Vec::new();
+        file.read_to_end(&mut data).map_err(AprenderError::Io)?;
+        Self::from_bytes_keep(data, true)
+    }
+
+    /// Parse GGUF from bytes (whitelist metadata — back-compat default).
     pub fn from_bytes(data: Vec<u8>) -> Result<Self> {
+        Self::from_bytes_keep(data, false)
+    }
+
+    /// Parse GGUF from bytes. When `keep_all` is true EVERY metadata key is
+    /// retained; otherwise only `tokenizer.` / `general.` / known-arch keys are
+    /// parsed (the rest skipped for efficiency).
+    pub fn from_bytes_keep(data: Vec<u8>, keep_all: bool) -> Result<Self> {
         if data.len() < 24 {
             return Err(AprenderError::FormatError {
                 message: "GGUF file too small (< 24 bytes)".to_string(),
@@ -68,7 +89,8 @@ impl GgufReader {
 
             // Parse value for tokenizer, general, and model architecture keys
             // We parse: tokenizer.*, general.*, and per-arch keys for full model config
-            if key.starts_with("tokenizer.")
+            if keep_all
+                || key.starts_with("tokenizer.")
                 || key.starts_with("general.")
                 || key.starts_with("llama.")
                 || key.starts_with("qwen2.")

--- a/crates/aprender-cuda-edge/Cargo.toml
+++ b/crates/aprender-cuda-edge/Cargo.toml
@@ -15,7 +15,7 @@ name = "trueno_cuda_edge"
 [dependencies]
 thiserror = "2.0"
 serde = { version = "1.0", features = ["derive"] }
-trueno-gpu = { version = "0.37.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true }
+trueno-gpu = { version = "0.38.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true }
 
 [dev-dependencies]
 proptest = "1.6"

--- a/crates/aprender-explain/Cargo.toml
+++ b/crates/aprender-explain/Cargo.toml
@@ -25,7 +25,7 @@ presentar-terminal = "0.3"
 crossterm = "0.28"
 
 # Internal dependency for PTX generation
-trueno-gpu = { version = "0.37.0", path = "../aprender-gpu", package = "aprender-gpu", features = ["cuda"] }
+trueno-gpu = { version = "0.38.0", path = "../aprender-gpu", package = "aprender-gpu", features = ["cuda"] }
 
 [dev-dependencies]
 proptest = "1.4"

--- a/crates/aprender-graph/Cargo.toml
+++ b/crates/aprender-graph/Cargo.toml
@@ -28,7 +28,7 @@ anyhow = "1"
 thiserror = "2"
 
 # Phase 2+ dependencies
-aprender = { path = "../aprender-core", version = "0.37.0", package = "aprender-core" }                                        # Sparse matrix ops, PageRank
+aprender = { path = "../aprender-core", version = "0.38.0", package = "aprender-core" }                                        # Sparse matrix ops, PageRank
 trueno = "0.17"                                          # SIMD primitives
 trueno-db = "0.3.17"                                     # Columnar storage
 

--- a/crates/aprender-monte-carlo/Cargo.toml
+++ b/crates/aprender-monte-carlo/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 name = "aprender-monte-carlo"
 
 [dependencies]
-aprender = { path = "../../", version = "0.37.0" }
+aprender = { path = "../../", version = "0.38.0" }
 clap = { version = "4", features = ["derive"] }
 rand = "0.9"
 rand_chacha = "0.9"

--- a/crates/aprender-orchestrate/Cargo.toml
+++ b/crates/aprender-orchestrate/Cargo.toml
@@ -117,7 +117,7 @@ pacha = { version = "0.2", optional = true }
 realizar = { version = "0.8", optional = true, features = ["cuda"] }
 
 # ML algorithms and training (native-only)
-aprender = { path = "../aprender-core", version = "0.37.0", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.38.0", package = "aprender-core", optional = true }
 entrenar = { workspace = true, optional = true }
 alimentar = { version = "0.2", optional = true }
 

--- a/crates/aprender-profile/Cargo.toml
+++ b/crates/aprender-profile/Cargo.toml
@@ -74,7 +74,7 @@ trueno = { version = "0.17" }
 
 # Machine learning for anomaly detection (Sprint 23)
 # GH-581: Use path dep to avoid trueno version skew with local workspace
-aprender = { path = "../aprender-core", version = "0.37.0", package = "aprender-core" }
+aprender = { path = "../aprender-core", version = "0.38.0", package = "aprender-core" }
 
 # Lock-free data structures for ring buffer (Sprint 40)
 crossbeam = { version = "0.8", default-features = false, features = ["crossbeam-channel", "crossbeam-queue", "std"] }

--- a/crates/aprender-qa-runner/Cargo.toml
+++ b/crates/aprender-qa-runner/Cargo.toml
@@ -29,7 +29,7 @@ sha2 = "0.10"
 regex = { workspace = true }
 num_cpus = "1.16"
 safetensors = { workspace = true }
-jugar-probar = { version = "0.37.0", path = "../aprender-test-lib", package = "aprender-test-lib", features = ["llm-types"] }
+jugar-probar = { version = "0.38.0", path = "../aprender-test-lib", package = "aprender-test-lib", features = ["llm-types"] }
 # Test fixtures dependencies (optional)
 tempfile = { version = "3", optional = true }
 half = { version = "2.4", optional = true }

--- a/crates/aprender-registry/Cargo.toml
+++ b/crates/aprender-registry/Cargo.toml
@@ -42,7 +42,7 @@ zstd = { version = "0.13", optional = true }
 clap = { version = "4", features = ["derive"], optional = true }
 
 # Ecosystem integration
-aprender = { path = "../aprender-core", version = "0.37.0", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.38.0", package = "aprender-core", optional = true }
 alimentar = { version = "0.2.3", optional = true }
 
 # HTTP client (optional)

--- a/crates/aprender-serve/Cargo.toml
+++ b/crates/aprender-serve/Cargo.toml
@@ -39,7 +39,7 @@ name = "realizar"
 trueno = { version = "0.17", features = ["gpu"] }
 # CUDA PTX generation and runtime for NVIDIA GPUs (optional, pure Rust, no LLVM/nvcc)
 # v0.4.12: BatchedQ6K, MultiWarp, RopeNeox, FlashDecoding kernels
-trueno-gpu = { version = "0.37.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true, features = ["cuda"] }  # APR-MONO single-source-of-truth
+trueno-gpu = { version = "0.38.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true, features = ["cuda"] }  # APR-MONO single-source-of-truth
 # KV cache storage (for attention caching)
 trueno-db = { version = "0.3.16", optional = true }
 # K-quantization formats (Q4_K, Q5_K, Q6_K) - Toyota Way: ONE source of truth
@@ -53,7 +53,7 @@ renacer-core = { version = "0.1" }
 
 # ML algorithms and .apr model format (optional for aprender model serving)
 # v0.24.1: chat templates, GGUF tokenizer preservation (local may be newer)
-aprender = { path = "../aprender-core", version = "0.37.0", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.38.0", package = "aprender-core", optional = true }
 
 # Data loading library (optional for data pipeline examples)
 alimentar = { version = "0.2", optional = true, default-features = false, features = ["local", "shuffle"] }

--- a/crates/aprender-shell/Cargo.toml
+++ b/crates/aprender-shell/Cargo.toml
@@ -24,7 +24,7 @@ harness = false
 
 [dependencies]
 # Use path for local dev, crates.io for release
-aprender = { path = "../aprender-core", version = "0.37.0", package = "aprender-core", features = ["format-encryption", "format-compression", "format-homomorphic"] }
+aprender = { path = "../aprender-core", version = "0.38.0", package = "aprender-core", features = ["format-encryption", "format-compression", "format-homomorphic"] }
 clap = { version = "4", features = ["derive"] }
 dirs = "5"
 serde = { version = "1", features = ["derive"] }

--- a/crates/aprender-test-cli/Cargo.toml
+++ b/crates/aprender-test-cli/Cargo.toml
@@ -24,7 +24,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Core library (was: jugar-probar) — dep key preserves Rust identifier
-jugar-probar = { path = "../aprender-test-lib", version = "0.37.0", package = "aprender-test-lib" }
+jugar-probar = { path = "../aprender-test-lib", version = "0.38.0", package = "aprender-test-lib" }
 
 # CLI framework
 clap = { workspace = true }

--- a/crates/aprender-train-bench/Cargo.toml
+++ b/crates/aprender-train-bench/Cargo.toml
@@ -19,8 +19,8 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-entrenar = { version = "0.37.0", path = "../aprender-train", package = "aprender-train" }
-entrenar-common = { version = "0.37.0", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar = { version = "0.38.0", path = "../aprender-train", package = "aprender-train" }
+entrenar-common = { version = "0.38.0", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/aprender-train-distill/Cargo.toml
+++ b/crates/aprender-train-distill/Cargo.toml
@@ -32,8 +32,8 @@ cuda = ["entrenar/cuda"]
 shard-batch-source = []
 
 [dependencies]
-entrenar = { version = "0.37.0", path = "../aprender-train", package = "aprender-train" }
-entrenar-common = { version = "0.37.0", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar = { version = "0.38.0", path = "../aprender-train", package = "aprender-train" }
+entrenar-common = { version = "0.38.0", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/aprender-train-inspect/Cargo.toml
+++ b/crates/aprender-train-inspect/Cargo.toml
@@ -19,8 +19,8 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-entrenar = { version = "0.37.0", path = "../aprender-train", package = "aprender-train" }
-entrenar-common = { version = "0.37.0", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar = { version = "0.38.0", path = "../aprender-train", package = "aprender-train" }
+entrenar-common = { version = "0.38.0", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/aprender-train-lora/Cargo.toml
+++ b/crates/aprender-train-lora/Cargo.toml
@@ -19,8 +19,8 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-entrenar = { version = "0.37.0", path = "../aprender-train", package = "aprender-train" }
-entrenar-common = { version = "0.37.0", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar = { version = "0.38.0", path = "../aprender-train", package = "aprender-train" }
+entrenar-common = { version = "0.38.0", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/aprender-train-shell/Cargo.toml
+++ b/crates/aprender-train-shell/Cargo.toml
@@ -19,8 +19,8 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-entrenar = { version = "0.37.0", path = "../aprender-train", package = "aprender-train" }
-entrenar-common = { version = "0.37.0", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar = { version = "0.38.0", path = "../aprender-train", package = "aprender-train" }
+entrenar-common = { version = "0.38.0", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 rustyline = "14"
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/aprender-train/Cargo.toml
+++ b/crates/aprender-train/Cargo.toml
@@ -75,9 +75,9 @@ provable-contracts-macros = { version = "0.2" }
 # Core PAIML stack
 ndarray = "0.16"
 trueno = { version = "0.17", features = ["parallel"] }  # SIMD-accelerated compute
-trueno-gpu = { version = "0.37.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true }  # CUDA compute (APR-MONO single-source-of-truth)
+trueno-gpu = { version = "0.38.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true }  # CUDA compute (APR-MONO single-source-of-truth)
 realizar = { version = "0.8", optional = true }  # CUDA inference engine
-aprender = { path = "../aprender-core", version = "0.37.0", package = "aprender-core" }  # ML interpret module + .apr format + tokenizers
+aprender = { path = "../aprender-core", version = "0.38.0", package = "aprender-core" }  # ML interpret module + .apr format + tokenizers
 trueno-viz = { version = "0.2", features = ["terminal"] }  # Terminal visualization
 presentar-terminal = { version = "0.3.5", optional = true }  # Sovereign TUI framework (gated by "tui" feature)
 presentar-core = "0.3.4"  # Presentar core traits (crates.io — path removed, presentar restructured)

--- a/crates/aprender-tsp/Cargo.toml
+++ b/crates/aprender-tsp/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 name = "aprender-tsp"
 
 [dependencies]
-aprender = { path = "../../", version = "0.37.0" }
+aprender = { path = "../../", version = "0.38.0" }
 clap = { version = "4", features = ["derive"] }
 rand = "0.9"
 crc32fast = "1.4"

--- a/crates/aprender-verify-ml/Cargo.toml
+++ b/crates/aprender-verify-ml/Cargo.toml
@@ -50,7 +50,7 @@ uuid = { version = "1.11", features = ["v4", "serde"] }
 trueno = "0.7.3"
 
 # Machine learning for bug prediction (optional)
-aprender = { path = "../aprender-core", version = "0.37.0", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.38.0", package = "aprender-core", optional = true }
 
 # LLM fine-tuning integration (optional)
 entrenar = { workspace = true, optional = true }

--- a/crates/aprender-viz/Cargo.toml
+++ b/crates/aprender-viz/Cargo.toml
@@ -29,7 +29,7 @@ base64 = "0.22"
 thiserror = "2.0"
 
 # Optional: ML integration
-aprender = { path = "../aprender-core", version = "0.37.0", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.38.0", package = "aprender-core", optional = true }
 
 # Optional: Graph integration
 trueno-graph = { workspace = true, optional = true, default-features = false }


### PR DESCRIPTION
## v0.38.0 — sharded GGUF auto-merge (#1893 criterion 2)

Pulled split GGUFs are now **runnable end-to-end**. `apr pull` merges the `-of-` parts into one `model.gguf`, so the existing single-file loader runs the model unchanged — **no inference-hot-path refactor** (a single→multi-mmap change would risk *all* GGUF inference, the repo's #1 garbage-output class).

`merge_gguf_shards`:
- **Type-agnostic** — tensor data copied by raw byte range (sized via offset-differencing, re-padded to alignment) → every ggml quant type (Q5_K/Q3_K/IQ\*) works.
- **Lossless metadata** — part-0 metadata via new `GgufReader::from_file_full` (keep-all) preserves arbitrary `<arch>.*` config keys.
- **Bounded memory** — streams to disk, holds ≤ one part at a time (peak ≈ largest part, not whole model).
- **Disjoint-union** — rejects duplicate tensor names; deletes parts after a successful merge.

## Hardened by adversarial verification ⚠️
Before publish, a **multi-agent adversarial workflow** reviewed the merge and found **5 release-blockers** — all fixed + regression-tested:

| # | Blocker | Fix |
|---|---------|-----|
| 1 | Metadata sourced from the arch-**whitelisted** reader → `gemma.*`/`phi3.*`/`deepseek2.*`/`falcon.*`/`starcoder2.*` silently dropped → merged file **unloadable** ("Missing embedding_length") | `from_file_full` keep-all; `merge_preserves_nonwhitelisted_arch_metadata` (gemma) |
| 2 | ~2× model RAM → **OOM on 7B** | two-pass **streaming** merge |
| 3 | Duplicate tensors silently merged | rejected; `merge_rejects_duplicate_tensor_names` |
| 4 | (same root as #1, all non-whitelisted arches) | — |
| 5 | Round-trip validated with the **wrong parser** | interop test loads merged file via realizar `GGUFModel::from_bytes` |

The offset/alignment math was independently **proven correct** by the review (unchanged).

## Verification
- ✅ `contracts/sharded-gguf-merge-v1.yaml` — FT-MERGE-001/004/005/006 + 2 kani harnesses, `pv validate` clean.
- ✅ 377 gguf tests + 3 merge tests + realizar interop test green; `cargo check --workspace` + fmt clean.

Release: workspace + facade → 0.38.0; CHANGELOG `[0.38.0]`. Closes #1893.

🤖 Generated with [Claude Code](https://claude.com/claude-code)