### PR TITLE
feat(gguf): BF16 loader support — v0.39.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.39.0] - 2026-06-11
+
+### Added
+
+- **BF16 (bfloat16) GGUF loader support**: BF16 GGUFs (ggml type 30) now load.
+  Previously any BF16 GGUF hard-failed with *"Unsupported quantization type: 30"*
+  because `get_tensor_f32` (embeddings/norms/lm_head) and `tensor_byte_size`
+  (per-layer weights) lacked a BF16 dispatch arm — even though the matmul weight
+  path already consumed BF16. The fix adds the two arms (reusing the existing
+  `simd_bf16_to_f32` converter; BF16 is 2 bytes/elem, value `from_bits(b << 16)`)
+  and `GGUFBuilder::add_bf16_tensor` for fixtures. Contract
+  `contracts/bf16-dequant-v1.yaml` (FT-BF16-001 golden converter + FT-BF16-002
+  end-to-end dispatch). Dense BF16 load path complete (get_tensor_f32 +
+  tensor_byte_size + matmul); MoE/CUDA BF16 remain follow-ups.
+
 ## [0.38.0] - 2026-06-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,7 +284,7 @@ dependencies = [
 
 [[package]]
 name = "apr-cli"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "alimentar",
  "anyhow",
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "aprender"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "apr-cli",
  "aprender-core",
@@ -411,7 +411,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-bench-compute"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "aprender-core",
  "criterion 0.7.0",
@@ -420,7 +420,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-bench-tokenizer"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "aprender-core",
  "criterion 0.7.0",
@@ -429,7 +429,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cbtop"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "aprender-compute",
@@ -454,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cgp"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "aprender-gpu",
@@ -474,7 +474,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-common"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "lz4_flex 0.11.6",
  "zstd",
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-compute"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "aprender-core",
@@ -531,7 +531,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-compute-xtask"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "bashrs",
@@ -544,7 +544,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-contracts"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "aprender-contracts-macros",
  "criterion 0.5.1",
@@ -559,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-contracts-cli"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "aprender-contracts",
  "clap",
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-contracts-macros"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-core"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "aes-gcm",
  "alimentar",
@@ -632,7 +632,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cuda-edge"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "aprender-gpu",
  "proptest",
@@ -643,7 +643,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cupti"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "bindgen 0.71.1",
  "bitflags 2.11.0",
@@ -653,7 +653,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-data"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-db"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "arrow 57.3.0",
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-distribute"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "arrow 57.3.0",
  "bincode",
@@ -781,7 +781,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-explain"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "aprender-gpu",
  "clap",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-fft"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -808,7 +808,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-gemm-codegen"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-gpu"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "aprender-profile",
  "batuta-common",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-graph"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "aprender-core",
@@ -862,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-image"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-mcp"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -886,9 +886,9 @@ dependencies = [
 
 [[package]]
 name = "aprender-monte-carlo"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
- "aprender 0.38.0",
+ "aprender 0.39.0",
  "assert_cmd",
  "chrono",
  "clap",
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-orchestrate"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "alimentar",
  "anyhow",
@@ -979,7 +979,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-cli"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "aprender-present-yaml",
  "clap",
@@ -992,7 +992,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-core"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "aprender-compute",
  "criterion 0.7.0",
@@ -1005,7 +1005,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-layout"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "aprender-present-core",
  "criterion 0.7.0",
@@ -1016,7 +1016,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-lib"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "aprender-present-core",
  "aprender-present-layout",
@@ -1045,7 +1045,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-terminal"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "aprender-present-core",
  "bitvec",
@@ -1067,7 +1067,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-test"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "aprender-present-core",
  "aprender-present-test-macros",
@@ -1078,7 +1078,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-test-macros"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1087,7 +1087,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-widgets"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "aprender-present-core",
  "aprender-present-yaml",
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-yaml"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "aprender-present-core",
  "proptest",
@@ -1109,7 +1109,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-profile"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "addr2line 0.25.1",
  "anyhow",
@@ -1162,7 +1162,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-profile-core"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "hex",
  "serde",
@@ -1172,7 +1172,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-ptx-debug"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "proptest",
  "thiserror 2.0.18",
@@ -1180,7 +1180,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-certify"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "chrono",
  "proptest",
@@ -1190,7 +1190,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-cli"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "aprender-qa-certify",
  "aprender-qa-gen",
@@ -1209,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-gen"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1226,7 +1226,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-report"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "aprender-qa-gen",
@@ -1244,7 +1244,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-runner"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "aprender-qa-gen",
@@ -1269,14 +1269,14 @@ dependencies = [
 
 [[package]]
 name = "aprender-quant"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "half",
 ]
 
 [[package]]
 name = "aprender-rag"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "batuta-common",
@@ -1307,7 +1307,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-rand"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1316,7 +1316,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-registry"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "alimentar",
  "anyhow",
@@ -1346,7 +1346,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-serve"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "alimentar",
  "anyhow",
@@ -1413,7 +1413,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-shell"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "aprender-core",
  "assert_cmd",
@@ -1430,7 +1430,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-simulate"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "bincode",
  "bitflags 2.11.0",
@@ -1469,7 +1469,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-solve"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1478,7 +1478,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-sparse"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1487,7 +1487,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-tensor"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1496,7 +1496,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-cli"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "aprender-test-lib",
  "assert_cmd",
@@ -1524,7 +1524,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-derive"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1534,7 +1534,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-js-gen"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -1550,7 +1550,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-lib"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "aprender-compute",
  "aprender-present-core",
@@ -1594,7 +1594,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-showcase"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "aprender-present-terminal",
  "console_error_panic_hook",
@@ -1611,7 +1611,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "alimentar",
  "approx",
@@ -1678,7 +1678,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-bench"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1695,7 +1695,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-common"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "clap",
  "proptest",
@@ -1707,7 +1707,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-distill"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1728,7 +1728,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-inspect"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1744,7 +1744,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-lora"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-shell"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1776,7 +1776,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-wasm"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "proptest",
  "serde",
@@ -1787,9 +1787,9 @@ dependencies = [
 
 [[package]]
 name = "aprender-tsp"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
- "aprender 0.38.0",
+ "aprender 0.39.0",
  "assert_cmd",
  "clap",
  "crc32fast",
@@ -1802,7 +1802,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-verify"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "chrono",
  "criterion 0.5.1",
@@ -1814,7 +1814,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-verify-ml"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "aprender-core",
  "aprender-profile",
@@ -1858,7 +1858,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-viz"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "approx",
  "aprender-core",
@@ -1893,7 +1893,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "aprender-zram-adaptive",
  "aprender-zram-core",
@@ -1903,7 +1903,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-adaptive"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "aprender-zram-core",
  "proptest",
@@ -1912,7 +1912,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-cli"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "aprender-zram-adaptive",
  "aprender-zram-core",
@@ -1926,7 +1926,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-core"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "aprender-gpu",
  "criterion 0.7.0",
@@ -1938,7 +1938,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-generator"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "aprender-zram-core",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.38.0"
+version = "0.39.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/paiml/aprender"
@@ -171,7 +171,7 @@ minijinja = { version = "2.14", features = ["loader", "serde"] }
 # Contracts
 provable-contracts = "0.3"
 provable-contracts-macros = "0.3"
-aprender-contracts-macros = { path = "crates/aprender-contracts-macros", version = "0.38.0" }
+aprender-contracts-macros = { path = "crates/aprender-contracts-macros", version = "0.39.0" }
 
 # YAML
 serde_yaml = "0.9"
@@ -183,31 +183,31 @@ hf-hub = { version = "0.4", default-features = false, features = ["ureq"] }
 hf-xet = "1.5.1"
 
 # Workspace-internal crates (paths within the monorepo)
-aprender-compute = { path = "crates/aprender-compute", version = "0.38.0" }
-aprender-gpu = { path = "crates/aprender-gpu", version = "0.38.0" }
-aprender-quant = { path = "crates/aprender-quant", version = "0.38.0" }
-aprender-serve = { path = "crates/aprender-serve", version = "0.38.0" }
-realizar = { path = "crates/aprender-serve", version = "0.38.0", package = "aprender-serve" }
-aprender-train = { path = "crates/aprender-train", version = "0.38.0" }
-entrenar = { path = "crates/aprender-train", version = "0.38.0", package = "aprender-train" }
-aprender-train-common = { path = "crates/aprender-train-common", version = "0.38.0" }
-aprender-train-distill = { path = "crates/aprender-train-distill", version = "0.38.0" }
-aprender-orchestrate = { path = "crates/aprender-orchestrate", version = "0.38.0" }
-aprender-contracts = { path = "crates/aprender-contracts", version = "0.38.0" }
-aprender-profile = { path = "crates/aprender-profile", version = "0.38.0" }
-aprender-profile-core = { path = "crates/aprender-profile-core", version = "0.38.0" }
-aprender-zram-core = { path = "crates/aprender-zram-core", version = "0.38.0" }
-aprender-zram-adaptive = { path = "crates/aprender-zram-adaptive", version = "0.38.0" }
-aprender-present-core = { path = "crates/aprender-present-core", version = "0.38.0" }
-aprender-present-terminal = { path = "crates/aprender-present-terminal", version = "0.38.0" }
-aprender-present-widgets = { path = "crates/aprender-present-widgets", version = "0.38.0" }
-aprender-present-layout = { path = "crates/aprender-present-layout", version = "0.38.0" }
-aprender-present-yaml = { path = "crates/aprender-present-yaml", version = "0.38.0" }
-aprender-present-test = { path = "crates/aprender-present-test", version = "0.38.0" }
-aprender-db = { path = "crates/aprender-db", version = "0.38.0" }
-aprender-graph = { path = "crates/aprender-graph", version = "0.38.0" }
-aprender-rag = { path = "crates/aprender-rag", version = "0.38.0" }
-aprender-data = { path = "crates/aprender-data", version = "0.38.0" }
+aprender-compute = { path = "crates/aprender-compute", version = "0.39.0" }
+aprender-gpu = { path = "crates/aprender-gpu", version = "0.39.0" }
+aprender-quant = { path = "crates/aprender-quant", version = "0.39.0" }
+aprender-serve = { path = "crates/aprender-serve", version = "0.39.0" }
+realizar = { path = "crates/aprender-serve", version = "0.39.0", package = "aprender-serve" }
+aprender-train = { path = "crates/aprender-train", version = "0.39.0" }
+entrenar = { path = "crates/aprender-train", version = "0.39.0", package = "aprender-train" }
+aprender-train-common = { path = "crates/aprender-train-common", version = "0.39.0" }
+aprender-train-distill = { path = "crates/aprender-train-distill", version = "0.39.0" }
+aprender-orchestrate = { path = "crates/aprender-orchestrate", version = "0.39.0" }
+aprender-contracts = { path = "crates/aprender-contracts", version = "0.39.0" }
+aprender-profile = { path = "crates/aprender-profile", version = "0.39.0" }
+aprender-profile-core = { path = "crates/aprender-profile-core", version = "0.39.0" }
+aprender-zram-core = { path = "crates/aprender-zram-core", version = "0.39.0" }
+aprender-zram-adaptive = { path = "crates/aprender-zram-adaptive", version = "0.39.0" }
+aprender-present-core = { path = "crates/aprender-present-core", version = "0.39.0" }
+aprender-present-terminal = { path = "crates/aprender-present-terminal", version = "0.39.0" }
+aprender-present-widgets = { path = "crates/aprender-present-widgets", version = "0.39.0" }
+aprender-present-layout = { path = "crates/aprender-present-layout", version = "0.39.0" }
+aprender-present-yaml = { path = "crates/aprender-present-yaml", version = "0.39.0" }
+aprender-present-test = { path = "crates/aprender-present-test", version = "0.39.0" }
+aprender-db = { path = "crates/aprender-db", version = "0.39.0" }
+aprender-graph = { path = "crates/aprender-graph", version = "0.39.0" }
+aprender-rag = { path = "crates/aprender-rag", version = "0.39.0" }
+aprender-data = { path = "crates/aprender-data", version = "0.39.0" }
 
 # Additional external deps needed by sub-crates
 serde_yaml_ng = "0.10"
@@ -252,25 +252,25 @@ wasmtime = "43"
 bollard = "0.17"
 
 # Old crate name aliases (workspace = true refs in migrated sub-crates)
-trueno-zram-core = { path = "crates/aprender-zram-core", version = "0.38.0", package = "aprender-zram-core" }
-trueno-zram-adaptive = { path = "crates/aprender-zram-adaptive", version = "0.38.0", package = "aprender-zram-adaptive" }
-trueno = { path = "crates/aprender-compute", version = "0.38.0", package = "aprender-compute" }
-presentar-core = { path = "crates/aprender-present-core", version = "0.38.0", package = "aprender-present-core" }
-presentar-terminal = { path = "crates/aprender-present-terminal", version = "0.38.0", package = "aprender-present-terminal" }
-presentar-widgets = { path = "crates/aprender-present-widgets", version = "0.38.0", package = "aprender-present-widgets" }
-presentar-layout = { path = "crates/aprender-present-layout", version = "0.38.0", package = "aprender-present-layout" }
-presentar-yaml = { path = "crates/aprender-present-yaml", version = "0.38.0", package = "aprender-present-yaml" }
-presentar-test = { path = "crates/aprender-present-test", version = "0.38.0", package = "aprender-present-test" }
-presentar-test-macros = { path = "crates/aprender-present-test-macros", version = "0.38.0", package = "aprender-present-test-macros" }
-jugar-probar-derive = { path = "crates/aprender-test-derive", version = "0.38.0", package = "aprender-test-derive" }
-batuta-common = { path = "crates/aprender-common", version = "0.38.0", package = "aprender-common" }
+trueno-zram-core = { path = "crates/aprender-zram-core", version = "0.39.0", package = "aprender-zram-core" }
+trueno-zram-adaptive = { path = "crates/aprender-zram-adaptive", version = "0.39.0", package = "aprender-zram-adaptive" }
+trueno = { path = "crates/aprender-compute", version = "0.39.0", package = "aprender-compute" }
+presentar-core = { path = "crates/aprender-present-core", version = "0.39.0", package = "aprender-present-core" }
+presentar-terminal = { path = "crates/aprender-present-terminal", version = "0.39.0", package = "aprender-present-terminal" }
+presentar-widgets = { path = "crates/aprender-present-widgets", version = "0.39.0", package = "aprender-present-widgets" }
+presentar-layout = { path = "crates/aprender-present-layout", version = "0.39.0", package = "aprender-present-layout" }
+presentar-yaml = { path = "crates/aprender-present-yaml", version = "0.39.0", package = "aprender-present-yaml" }
+presentar-test = { path = "crates/aprender-present-test", version = "0.39.0", package = "aprender-present-test" }
+presentar-test-macros = { path = "crates/aprender-present-test-macros", version = "0.39.0", package = "aprender-present-test-macros" }
+jugar-probar-derive = { path = "crates/aprender-test-derive", version = "0.39.0", package = "aprender-test-derive" }
+batuta-common = { path = "crates/aprender-common", version = "0.39.0", package = "aprender-common" }
 # APR-MONO sibling aliases — MUST use workspace refs, NEVER crates.io versions.
 # Hard-pinning these to crates.io creates a diamond: sub-crates pull older
 # aprender versions → multiple `aprender` crates in Cargo.lock = MUDA.
-renacer = { path = "crates/aprender-profile", version = "0.38.0", package = "aprender-profile" }
-entrenar-lora = { path = "crates/aprender-train-lora", version = "0.38.0", package = "aprender-train-lora" }
-batuta = { path = "crates/aprender-orchestrate", version = "0.38.0", package = "aprender-orchestrate" }
-trueno-graph = { path = "crates/aprender-graph", version = "0.38.0", package = "aprender-graph" }
+renacer = { path = "crates/aprender-profile", version = "0.39.0", package = "aprender-profile" }
+entrenar-lora = { path = "crates/aprender-train-lora", version = "0.39.0", package = "aprender-train-lora" }
+batuta = { path = "crates/aprender-orchestrate", version = "0.39.0", package = "aprender-orchestrate" }
+trueno-graph = { path = "crates/aprender-graph", version = "0.39.0", package = "aprender-graph" }
 
 [workspace.lints.rust]
 # Safety
@@ -428,7 +428,7 @@ semicolon_if_nothing_returned = "allow"  # Style preference
 
 [package]
 name = "aprender"
-version = "0.38.0"
+version = "0.39.0"
 edition = "2021"
 rust-version = "1.89"
 authors = ["Noah Gift <noah@paiml.com>"]
@@ -458,7 +458,7 @@ required-features = ["cli"]
 # (e.g. apr-cookbook, downstream apps) don't pull apr-cli's heavy transitive
 # dep graph (renacer/profile/inference/zram/visualization). `cargo install
 # aprender` still works because `cli` is in default features. See GH-1599.
-apr-cli = { path = "crates/apr-cli", version = "0.38.0", default-features = true, optional = true }
+apr-cli = { path = "crates/apr-cli", version = "0.39.0", default-features = true, optional = true }
 # Core ML library (lib name = "aprender")
 aprender_ml = { path = "crates/aprender-core", version = ">=0.29", package = "aprender-core" }
 

--- a/contracts/bf16-dequant-v1.yaml
+++ b/contracts/bf16-dequant-v1.yaml
@@ -1,0 +1,102 @@
+metadata:
+  version: 1.0.0
+  created: '2026-06-11'
+  author: PAIML Engineering
+  description: |
+    BF16 (bfloat16, GGML type 30) support in the GGUF loader. Before this, any
+    BF16 GGUF hard-failed at load: get_tensor_f32 (embeddings/norms/lm_head) and
+    tensor_byte_size (per-layer weights) both lacked a BF16 dispatch arm and hit
+    the catch-all "Unsupported quantization type: 30". The matmul weight path
+    already consumed BF16, so the framework half-supported it — only the central
+    loader rejected it.
+
+    The fix is a dispatch-arm add (Q3_K/#1913 pattern) reusing the existing,
+    battle-tested converter simd_bf16_to_f32 (already used by the safetensors
+    loaders + gguf/embedding.rs). BF16 has no super-block structure: 2 bytes per
+    element, value = from_bits((bits as u32) << 16).
+  references:
+  - 'crates/aprender-serve/src/gguf/metadata.rs — get_tensor_f32 BF16 arm'
+  - 'crates/aprender-serve/src/gguf/transformer.rs — tensor_byte_size BF16 arm'
+  - 'crates/aprender-serve/src/inference/simd.rs:264 — simd_bf16_to_f32 (reused converter)'
+  - 'contracts/q3k-dequant-v1.yaml — the sibling missing-dispatch fix this mirrors'
+
+kind: KernelContract
+name: bf16-dequant
+version: 1.0.0
+scope: aprender-serve GGUF loader BF16 (type 30) dispatch — get_tensor_f32 + tensor_byte_size
+
+equations:
+  bf16_block_layout:
+    formula: |
+      BF16 has NO super-block: byte_size(n elements) = n * 2. tensor_byte_size
+      returns num_elements * 2 for GGUF_TYPE_BF16.
+    domain: num_elements >= 0
+    codomain: byte size
+    invariants:
+    - 'no QK_K / block rounding — exactly 2 bytes per element'
+    lean_theorem: Theorems.BF16_Block_Layout
+  bf16_dequant_formula:
+    formula: |
+      Each little-endian u16 b dequantizes to f32 via from_bits((b as u32) << 16):
+      BF16 is the high 16 bits of an IEEE-754 f32. get_tensor_f32 dispatches
+      GGUF_TYPE_BF16 to simd_bf16_to_f32 over the tensor's 2*n byte range.
+    domain: a 2*n byte slice of BF16 data
+    codomain: Vec<f32> of length n
+    invariants:
+    - 'output length == byte_len / 2'
+    - 'get_tensor_f32 no longer returns "Unsupported quantization type: 30" for BF16'
+    - 'out-of-range offset returns Err (bounds-checked), never panics'
+    lean_theorem: Theorems.BF16_Dequant_Formula
+
+proof_obligations:
+- type: invariant
+  property: dequant length and value
+  formal: |
+    For BF16 bytes built from f32 vals via half::bf16::from_f32, simd_bf16_to_f32
+    returns those f32s within bf16 rounding tolerance; length == bytes/2.
+- type: classification
+  property: BF16 dispatches, not rejected
+  formal: |
+    A GGUFModel with a GGUF_TYPE_BF16 tensor: get_tensor_f32 returns Ok with the
+    correct values, NOT Err "Unsupported quantization type: 30". (Byte sizing
+    n*2 is covered by the bf16_block_layout equation + tensor_byte_size arm.)
+
+falsification_tests:
+- id: FT-BF16-001
+  rule: simd BF16->F32 converter round-trips known values
+  prediction: |
+    simd_bf16_to_f32(bf16_bytes([1.5,-2.0,0.0,3.25,256.0])) == those f32s within
+    1% + 1e-3.
+  if_fails: 'the >>16 / from_bits semantics or endianness is wrong.'
+  evidence: cargo test -p aprender-serve --lib ft_bf16_001_simd_bf16_to_f32_golden
+- id: FT-BF16-002
+  rule: a BF16 GGUF tensor dispatches through get_tensor_f32 with correct values
+  prediction: |
+    A GGUFModel with one GGUF_TYPE_BF16 tensor: get_tensor_f32 is Ok, length 4,
+    values match — NOT "Unsupported quantization type: 30".
+  if_fails: 'the BF16 arm is missing from get_tensor_f32 or the byte range is wrong.'
+  evidence: cargo test -p aprender-serve --lib ft_bf16_002_get_tensor_f32_dispatches_bf16
+
+kani_harnesses:
+- id: KANI-BF16-001
+  obligation: byte-size is exactly 2n and overflow-safe
+  property: 'for all n in [0..4096]: tensor_byte_size(BF16, n) == n*2; no overflow/panic.'
+  bound: 4096
+  strategy: bounded_int
+  solver: cadical
+  harness: verify_bf16_byte_size
+- id: KANI-BF16-002
+  obligation: out-of-range BF16 offset is a clean error
+  property: 'get_tensor_f32 with offset+2n > file_len returns Err, never OOB/panic.'
+  bound: 1
+  strategy: compositional
+  solver: cadical
+  harness: verify_bf16_bounds_safe
+
+qa_gate:
+  id: F-BF16-001
+  name: bf16-dequant-v1 Contract
+  description: BF16 GGUFs must load — get_tensor_f32 + tensor_byte_size dispatch type 30 to the SIMD converter, never the "Unsupported quantization type" catch-all.
+  checks:
+  - validation
+  - falsification

--- a/crates/apr-cli/Cargo.toml
+++ b/crates/apr-cli/Cargo.toml
@@ -103,10 +103,10 @@ libc = "0.2"
 
 [dependencies]
 # Core aprender library
-aprender = { path = "../aprender-core", version = "0.38.0", package = "aprender-core", default-features = true, features = ["format-compression"] }
+aprender = { path = "../aprender-core", version = "0.39.0", package = "aprender-core", default-features = true, features = ["format-compression"] }
 
 # MCP (Model Context Protocol) server — `apr mcp` subcommand
-aprender-mcp = { path = "../aprender-mcp", version = "0.38.0" }
+aprender-mcp = { path = "../aprender-mcp", version = "0.39.0" }
 async-stream = "0.3"
 provable-contracts-macros = "0.3"
 

--- a/crates/aprender-bench-compute/Cargo.toml
+++ b/crates/aprender-bench-compute/Cargo.toml
@@ -11,7 +11,7 @@ disallowed_methods = "allow"
 
 [dependencies]
 # The implementation under test
-aprender = { path = "../aprender-core", version = "0.38.0", package = "aprender-core", features = ["format-quantize"] }
+aprender = { path = "../aprender-core", version = "0.39.0", package = "aprender-core", features = ["format-quantize"] }
 
 # Reference implementation for A/B comparison
 # Pure Rust (no BLAS) to keep comparison fair — both are pure Rust SIMD

--- a/crates/aprender-bench-tokenizer/Cargo.toml
+++ b/crates/aprender-bench-tokenizer/Cargo.toml
@@ -11,7 +11,7 @@ disallowed_methods = "allow"
 
 [dependencies]
 # The implementation under test
-aprender = { path = "../aprender-core", version = "0.38.0", package = "aprender-core" }
+aprender = { path = "../aprender-core", version = "0.39.0", package = "aprender-core" }
 
 # HuggingFace reference for A/B comparison
 # Regular dep (not dev-dep) because [[bench]] harness=false binaries can't see dev-deps

--- a/crates/aprender-cbtop/Cargo.toml
+++ b/crates/aprender-cbtop/Cargo.toml
@@ -23,8 +23,8 @@ presentar-core = "0.3"
 presentar-terminal = "0.3"
 
 # Compute backends
-trueno = { version = "0.38.0", path = "../aprender-compute", package = "aprender-compute" }
-trueno-gpu = { version = "0.38.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true }
+trueno = { version = "0.39.0", path = "../aprender-compute", package = "aprender-compute" }
+trueno-gpu = { version = "0.39.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true }
 
 # Terminal handling
 crossterm = "0.28"

--- a/crates/aprender-cgp/Cargo.toml
+++ b/crates/aprender-cgp/Cargo.toml
@@ -36,7 +36,7 @@ num_cpus = "1.17"
 comfy-table = "7"
 colored = "3"
 # GPU profiling: direct cuBLAS measurement (OWN THE STACK)
-trueno-gpu = { path = "../aprender-gpu", version = "0.38.0", features = ["cuda"], optional = true, package = "aprender-gpu" }
+trueno-gpu = { path = "../aprender-gpu", version = "0.39.0", features = ["cuda"], optional = true, package = "aprender-gpu" }
 
 [features]
 default = []

--- a/crates/aprender-compute/Cargo.toml
+++ b/crates/aprender-compute/Cargo.toml
@@ -38,11 +38,11 @@ futures-intrusive = { version = "0.5", optional = true }
 wasm-bindgen-futures = { version = "0.4", optional = true }
 wasm-bindgen = { version = "0.2", optional = true }
 # Native CUDA monitoring via trueno-gpu (TRUENO-SPEC-010)
-trueno-gpu = { version = "0.38.0", path = "../aprender-gpu", optional = true, package = "aprender-gpu" }
+trueno-gpu = { version = "0.39.0", path = "../aprender-gpu", optional = true, package = "aprender-gpu" }
 # PMAT-336: Provable contracts compile-time enforcement
 provable-contracts-macros = "0.3"
 # P1a: Sovereign GEMM microkernel codegen (compile-time shape specialization)
-trueno-gemm-codegen = { version = "0.38.0", path = "../aprender-gemm-codegen", package = "aprender-gemm-codegen" }
+trueno-gemm-codegen = { version = "0.39.0", path = "../aprender-gemm-codegen", package = "aprender-gemm-codegen" }
 # Tracing/profiling support (renacer integration)
 tracing = { version = "0.1", optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"], optional = true }
@@ -54,7 +54,7 @@ presentar-core = { version = "0.3", optional = true }
 # Stress test reporting types compatible with renacer (TRUENO-SPEC-025)
 # Note: renacer 0.9.1 has compilation issue; using compatible local types instead
 dhat = { version = "0.3", optional = true }
-trueno-quant = { version = "0.38.0", path = "../aprender-quant", package = "aprender-quant" }
+trueno-quant = { version = "0.39.0", path = "../aprender-quant", package = "aprender-quant" }
 num_cpus = "1.17.0"
 anyhow = "1.0.100"
 # Hardware capability detection (PMAT-447)
@@ -62,7 +62,7 @@ chrono = "0.4"
 toml = "0.8"
 # ML tuner integration (SHOWCASE-BRICK-001, Section 12)
 # Uses aprender 0.24.0 RandomForest for learned optimization
-aprender = { path = "../aprender-core", version = "0.38.0", package = "aprender-core", optional = true, default-features = false }
+aprender = { path = "../aprender-core", version = "0.39.0", package = "aprender-core", optional = true, default-features = false }
 # Execution path graph (PAR-201, Section E.7)
 trueno-graph = { workspace = true, optional = true }
 # TUI visualization for execution graphs (PAR-201)
@@ -90,10 +90,10 @@ nalgebra = "0.34"  # For eigendecomposition benchmark comparison
 simular = "0.2.0"
 regex = "1.11"  # For PTX/WGSL pattern validation in falsification tests
 # GPU edge-case test framework (TCE-001)
-trueno-cuda-edge = { version = "0.38.0", path = "../aprender-cuda-edge", package = "aprender-cuda-edge" }
+trueno-cuda-edge = { version = "0.39.0", path = "../aprender-cuda-edge", package = "aprender-cuda-edge" }
 # Sparse and solver crates for contract tests
-trueno-sparse = { version = "0.38.0", path = "../aprender-sparse", package = "aprender-sparse" }
-trueno-solve = { version = "0.38.0", path = "../aprender-solve", package = "aprender-solve" }
+trueno-sparse = { version = "0.39.0", path = "../aprender-sparse", package = "aprender-sparse" }
+trueno-solve = { version = "0.39.0", path = "../aprender-solve", package = "aprender-solve" }
 ndarray = "0.17.2"
 faer = "0.24"  # For GEMM benchmark comparison (fastest pure-Rust BLAS)
 matrixmultiply = "0.3"  # Direct matrixmultiply crate benchmark (engine behind ndarray)

--- a/crates/aprender-contracts-cli/Cargo.toml
+++ b/crates/aprender-contracts-cli/Cargo.toml
@@ -13,7 +13,7 @@ name = "pv"
 path = "src/main.rs"
 
 [dependencies]
-aprender-contracts = { path = "../aprender-contracts", version = "0.38.0" }
+aprender-contracts = { path = "../aprender-contracts", version = "0.39.0" }
 clap = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }

--- a/crates/aprender-contracts/Cargo.toml
+++ b/crates/aprender-contracts/Cargo.toml
@@ -19,7 +19,7 @@ kani = []
 name = "provable_contracts"
 
 [dependencies]
-provable-contracts-macros = { path = "../aprender-contracts-macros", version = "0.38.0", package = "aprender-contracts-macros" }
+provable-contracts-macros = { path = "../aprender-contracts-macros", version = "0.39.0", package = "aprender-contracts-macros" }
 regex = "1"
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/aprender-cuda-edge/Cargo.toml
+++ b/crates/aprender-cuda-edge/Cargo.toml
@@ -15,7 +15,7 @@ name = "trueno_cuda_edge"
 [dependencies]
 thiserror = "2.0"
 serde = { version = "1.0", features = ["derive"] }
-trueno-gpu = { version = "0.38.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true }
+trueno-gpu = { version = "0.39.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true }
 
 [dev-dependencies]
 proptest = "1.6"

--- a/crates/aprender-explain/Cargo.toml
+++ b/crates/aprender-explain/Cargo.toml
@@ -25,7 +25,7 @@ presentar-terminal = "0.3"
 crossterm = "0.28"
 
 # Internal dependency for PTX generation
-trueno-gpu = { version = "0.38.0", path = "../aprender-gpu", package = "aprender-gpu", features = ["cuda"] }
+trueno-gpu = { version = "0.39.0", path = "../aprender-gpu", package = "aprender-gpu", features = ["cuda"] }
 
 [dev-dependencies]
 proptest = "1.4"

--- a/crates/aprender-graph/Cargo.toml
+++ b/crates/aprender-graph/Cargo.toml
@@ -28,7 +28,7 @@ anyhow = "1"
 thiserror = "2"
 
 # Phase 2+ dependencies
-aprender = { path = "../aprender-core", version = "0.38.0", package = "aprender-core" }                                        # Sparse matrix ops, PageRank
+aprender = { path = "../aprender-core", version = "0.39.0", package = "aprender-core" }                                        # Sparse matrix ops, PageRank
 trueno = "0.17"                                          # SIMD primitives
 trueno-db = "0.3.17"                                     # Columnar storage
 

--- a/crates/aprender-monte-carlo/Cargo.toml
+++ b/crates/aprender-monte-carlo/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 name = "aprender-monte-carlo"
 
 [dependencies]
-aprender = { path = "../../", version = "0.38.0" }
+aprender = { path = "../../", version = "0.39.0" }
 clap = { version = "4", features = ["derive"] }
 rand = "0.9"
 rand_chacha = "0.9"

--- a/crates/aprender-orchestrate/Cargo.toml
+++ b/crates/aprender-orchestrate/Cargo.toml
@@ -117,7 +117,7 @@ pacha = { version = "0.2", optional = true }
 realizar = { version = "0.8", optional = true, features = ["cuda"] }
 
 # ML algorithms and training (native-only)
-aprender = { path = "../aprender-core", version = "0.38.0", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.39.0", package = "aprender-core", optional = true }
 entrenar = { workspace = true, optional = true }
 alimentar = { version = "0.2", optional = true }
 

--- a/crates/aprender-profile/Cargo.toml
+++ b/crates/aprender-profile/Cargo.toml
@@ -74,7 +74,7 @@ trueno = { version = "0.17" }
 
 # Machine learning for anomaly detection (Sprint 23)
 # GH-581: Use path dep to avoid trueno version skew with local workspace
-aprender = { path = "../aprender-core", version = "0.38.0", package = "aprender-core" }
+aprender = { path = "../aprender-core", version = "0.39.0", package = "aprender-core" }
 
 # Lock-free data structures for ring buffer (Sprint 40)
 crossbeam = { version = "0.8", default-features = false, features = ["crossbeam-channel", "crossbeam-queue", "std"] }

--- a/crates/aprender-qa-runner/Cargo.toml
+++ b/crates/aprender-qa-runner/Cargo.toml
@@ -29,7 +29,7 @@ sha2 = "0.10"
 regex = { workspace = true }
 num_cpus = "1.16"
 safetensors = { workspace = true }
-jugar-probar = { version = "0.38.0", path = "../aprender-test-lib", package = "aprender-test-lib", features = ["llm-types"] }
+jugar-probar = { version = "0.39.0", path = "../aprender-test-lib", package = "aprender-test-lib", features = ["llm-types"] }
 # Test fixtures dependencies (optional)
 tempfile = { version = "3", optional = true }
 half = { version = "2.4", optional = true }

--- a/crates/aprender-registry/Cargo.toml
+++ b/crates/aprender-registry/Cargo.toml
@@ -42,7 +42,7 @@ zstd = { version = "0.13", optional = true }
 clap = { version = "4", features = ["derive"], optional = true }
 
 # Ecosystem integration
-aprender = { path = "../aprender-core", version = "0.38.0", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.39.0", package = "aprender-core", optional = true }
 alimentar = { version = "0.2.3", optional = true }
 
 # HTTP client (optional)

--- a/crates/aprender-serve/Cargo.toml
+++ b/crates/aprender-serve/Cargo.toml
@@ -39,7 +39,7 @@ name = "realizar"
 trueno = { version = "0.17", features = ["gpu"] }
 # CUDA PTX generation and runtime for NVIDIA GPUs (optional, pure Rust, no LLVM/nvcc)
 # v0.4.12: BatchedQ6K, MultiWarp, RopeNeox, FlashDecoding kernels
-trueno-gpu = { version = "0.38.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true, features = ["cuda"] }  # APR-MONO single-source-of-truth
+trueno-gpu = { version = "0.39.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true, features = ["cuda"] }  # APR-MONO single-source-of-truth
 # KV cache storage (for attention caching)
 trueno-db = { version = "0.3.16", optional = true }
 # K-quantization formats (Q4_K, Q5_K, Q6_K) - Toyota Way: ONE source of truth
@@ -53,7 +53,7 @@ renacer-core = { version = "0.1" }
 
 # ML algorithms and .apr model format (optional for aprender model serving)
 # v0.24.1: chat templates, GGUF tokenizer preservation (local may be newer)
-aprender = { path = "../aprender-core", version = "0.38.0", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.39.0", package = "aprender-core", optional = true }
 
 # Data loading library (optional for data pipeline examples)
 alimentar = { version = "0.2", optional = true, default-features = false, features = ["local", "shuffle"] }

--- a/crates/aprender-serve/src/gguf/loader.rs
+++ b/crates/aprender-serve/src/gguf/loader.rs
@@ -7,10 +7,10 @@ use crate::error::{RealizarError, Result};
 use crate::gguf::utils::gpt2_unicode_to_byte;
 use crate::gguf::{
     GGUFConfig, GGUFHeader, GGUFModel, GGUFTransformer, GGUFTransformerLayer, GGUFValue,
-    TensorInfo, ValidatedModelConfig, GGUF_ALIGNMENT, GGUF_MAGIC, GGUF_TYPE_F16, GGUF_TYPE_F32,
-    GGUF_TYPE_Q2_K, GGUF_TYPE_Q3_K, GGUF_TYPE_Q4_0, GGUF_TYPE_Q4_1, GGUF_TYPE_Q4_K, GGUF_TYPE_Q5_0,
-    GGUF_TYPE_Q5_1, GGUF_TYPE_Q5_K, GGUF_TYPE_Q6_K, GGUF_TYPE_Q8_0, GGUF_VERSION_V2,
-    GGUF_VERSION_V3,
+    TensorInfo, ValidatedModelConfig, GGUF_ALIGNMENT, GGUF_MAGIC, GGUF_TYPE_BF16, GGUF_TYPE_F16,
+    GGUF_TYPE_F32, GGUF_TYPE_Q2_K, GGUF_TYPE_Q3_K, GGUF_TYPE_Q4_0, GGUF_TYPE_Q4_1, GGUF_TYPE_Q4_K,
+    GGUF_TYPE_Q5_0, GGUF_TYPE_Q5_1, GGUF_TYPE_Q5_K, GGUF_TYPE_Q6_K, GGUF_TYPE_Q8_0,
+    GGUF_VERSION_V2, GGUF_VERSION_V3,
 };
 use std::collections::HashMap;
 use std::io::{Cursor, Read};

--- a/crates/aprender-serve/src/gguf/metadata.rs
+++ b/crates/aprender-serve/src/gguf/metadata.rs
@@ -306,6 +306,29 @@ impl GGUFModel {
                 let values = dequantize_f16(bytes)?;
                 Ok(values)
             },
+            GGUF_TYPE_BF16 => {
+                // BF16 (bfloat16): 2 bytes/elem, no block structure. Reuses the
+                // existing SIMD converter (y = from_bits((bits as u32) << 16))
+                // already used by the safetensors loaders + gguf/embedding.rs.
+                // #1893-class fix: without this arm a BF16 GGUF's
+                // embeddings/norms/lm_head hit the catch-all "Unsupported
+                // quantization type: 30".
+                let byte_size = size * 2;
+                if offset + byte_size > file_data.len() {
+                    return Err(RealizarError::UnsupportedOperation {
+                        operation: "get_tensor_f32".to_string(),
+                        reason: format!(
+                            "Data range [{}, {}) exceeds file size {}",
+                            offset,
+                            offset + byte_size,
+                            file_data.len()
+                        ),
+                    });
+                }
+                Ok(crate::inference::simd_bf16_to_f32(
+                    &file_data[offset..offset + byte_size],
+                ))
+            },
             GGUF_TYPE_Q4_1 => {
                 // Q4_1 quantized data
                 use crate::quantize::dequantize_q4_1;

--- a/crates/aprender-serve/src/gguf/test_factory.rs
+++ b/crates/aprender-serve/src/gguf/test_factory.rs
@@ -19,9 +19,9 @@
 //! ```
 
 use super::types::{
-    GGUF_ALIGNMENT, GGUF_MAGIC, GGUF_TYPE_F16, GGUF_TYPE_F32, GGUF_TYPE_Q2_K, GGUF_TYPE_Q3_K,
-    GGUF_TYPE_Q4_0, GGUF_TYPE_Q4_1, GGUF_TYPE_Q4_K, GGUF_TYPE_Q5_0, GGUF_TYPE_Q5_1, GGUF_TYPE_Q5_K,
-    GGUF_TYPE_Q6_K, GGUF_TYPE_Q8_0, GGUF_VERSION_V3,
+    GGUF_ALIGNMENT, GGUF_MAGIC, GGUF_TYPE_BF16, GGUF_TYPE_F16, GGUF_TYPE_F32, GGUF_TYPE_Q2_K,
+    GGUF_TYPE_Q3_K, GGUF_TYPE_Q4_0, GGUF_TYPE_Q4_1, GGUF_TYPE_Q4_K, GGUF_TYPE_Q5_0, GGUF_TYPE_Q5_1,
+    GGUF_TYPE_Q5_K, GGUF_TYPE_Q6_K, GGUF_TYPE_Q8_0, GGUF_VERSION_V3,
 };
 
 /// Builder for creating valid GGUF v3 files in memory
@@ -269,6 +269,18 @@ impl GGUFBuilder {
             name.to_string(),
             dims.to_vec(),
             GGUF_TYPE_F16,
+            data.to_vec(),
+        ));
+        self
+    }
+
+    /// Add a BF16 tensor (2 bytes per element, no block structure).
+    #[must_use]
+    pub fn add_bf16_tensor(mut self, name: &str, dims: &[u64], data: &[u8]) -> Self {
+        self.tensors.push((
+            name.to_string(),
+            dims.to_vec(),
+            GGUF_TYPE_BF16,
             data.to_vec(),
         ));
         self

--- a/crates/aprender-serve/src/gguf/test_factory_gguf_builder.rs
+++ b/crates/aprender-serve/src/gguf/test_factory_gguf_builder.rs
@@ -173,6 +173,53 @@ mod tests {
         assert_eq!(model.tensors[0].qtype, GGUF_TYPE_Q4_0);
     }
 
+    fn bf16_bytes(vals: &[f32]) -> Vec<u8> {
+        let mut b = Vec::with_capacity(vals.len() * 2);
+        for &v in vals {
+            b.extend_from_slice(&half::bf16::from_f32(v).to_le_bytes());
+        }
+        b
+    }
+
+    /// FT-BF16-001: the SIMD BF16→F32 converter round-trips known values
+    /// (y = from_bits((bits as u32) << 16)). Pins the byte-level semantics.
+    #[test]
+    fn ft_bf16_001_simd_bf16_to_f32_golden() {
+        let vals = [1.5f32, -2.0, 0.0, 3.25, 256.0];
+        let out = crate::inference::simd_bf16_to_f32(&bf16_bytes(&vals));
+        assert_eq!(out.len(), vals.len());
+        for (got, want) in out.iter().zip(vals.iter()) {
+            assert!(
+                (got - want).abs() <= want.abs() * 0.01 + 1e-3,
+                "bf16 dequant: got {got}, want {want}"
+            );
+        }
+    }
+
+    /// FT-BF16-002 (release-blocker fix): a BF16 GGUF tensor DISPATCHES through
+    /// get_tensor_f32 with correct values — it must NOT hit the catch-all
+    /// "Unsupported quantization type: 30" that broke every BF16 GGUF load.
+    #[test]
+    fn ft_bf16_002_get_tensor_f32_dispatches_bf16() {
+        let vals = [1.5f32, -2.0, 0.0, 3.25];
+        let data = GGUFBuilder::new()
+            .add_bf16_tensor("test.bf16", &[4], &bf16_bytes(&vals))
+            .build();
+        let model = GGUFModel::from_bytes(&data).expect("parse BF16 GGUF");
+        assert_eq!(model.tensors[0].qtype, GGUF_TYPE_BF16);
+
+        let out = model
+            .get_tensor_f32("test.bf16", &data)
+            .expect("BF16 must dequantize, not error with 'Unsupported quantization type: 30'");
+        assert_eq!(out.len(), 4);
+        for (got, want) in out.iter().zip(vals.iter()) {
+            assert!(
+                (got - want).abs() < 1e-2,
+                "bf16 tensor dequant: got {got}, want {want}"
+            );
+        }
+    }
+
     #[test]
     fn test_gguf_builder_q8_0_tensor() {
         let q8_data = create_q8_0_data(64);

--- a/crates/aprender-serve/src/gguf/transformer.rs
+++ b/crates/aprender-serve/src/gguf/transformer.rs
@@ -9,8 +9,8 @@ use crate::quantize::QK_K;
 use super::config::{GGUFConfig, ValidatedModelConfig};
 use super::quantized::{QKVWeights, QuantizedTensorRef};
 use super::types::{
-    GGUFModel, GGUF_TYPE_F32, GGUF_TYPE_Q2_K, GGUF_TYPE_Q4_0, GGUF_TYPE_Q4_1, GGUF_TYPE_Q4_K,
-    GGUF_TYPE_Q5_0, GGUF_TYPE_Q5_K, GGUF_TYPE_Q6_K, GGUF_TYPE_Q8_0,
+    GGUFModel, GGUF_TYPE_BF16, GGUF_TYPE_F32, GGUF_TYPE_Q2_K, GGUF_TYPE_Q4_0, GGUF_TYPE_Q4_1,
+    GGUF_TYPE_Q4_K, GGUF_TYPE_Q5_0, GGUF_TYPE_Q5_K, GGUF_TYPE_Q6_K, GGUF_TYPE_Q8_0,
 };
 
 /// Quantized transformer layer weights (stored as byte references)
@@ -405,6 +405,8 @@ impl<'a> QuantizedGGUFTransformer<'a> {
 
         match qtype {
             GGUF_TYPE_F32 => Ok(num_elements * 4),
+            // BF16: 2 bytes/elem, no block structure (#1893-class loader gap).
+            GGUF_TYPE_BF16 => Ok(num_elements * 2),
             GGUF_TYPE_Q4_0 => Ok(num_elements.div_ceil(32) * 18),
             GGUF_TYPE_Q8_0 => Ok(num_elements.div_ceil(32) * 34),
             GGUF_TYPE_Q2_K => Ok(num_elements.div_ceil(QK_K) * 84),

--- a/crates/aprender-shell/Cargo.toml
+++ b/crates/aprender-shell/Cargo.toml
@@ -24,7 +24,7 @@ harness = false
 
 [dependencies]
 # Use path for local dev, crates.io for release
-aprender = { path = "../aprender-core", version = "0.38.0", package = "aprender-core", features = ["format-encryption", "format-compression", "format-homomorphic"] }
+aprender = { path = "../aprender-core", version = "0.39.0", package = "aprender-core", features = ["format-encryption", "format-compression", "format-homomorphic"] }
 clap = { version = "4", features = ["derive"] }
 dirs = "5"
 serde = { version = "1", features = ["derive"] }

--- a/crates/aprender-test-cli/Cargo.toml
+++ b/crates/aprender-test-cli/Cargo.toml
@@ -24,7 +24,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Core library (was: jugar-probar) — dep key preserves Rust identifier
-jugar-probar = { path = "../aprender-test-lib", version = "0.38.0", package = "aprender-test-lib" }
+jugar-probar = { path = "../aprender-test-lib", version = "0.39.0", package = "aprender-test-lib" }
 
 # CLI framework
 clap = { workspace = true }

--- a/crates/aprender-train-bench/Cargo.toml
+++ b/crates/aprender-train-bench/Cargo.toml
@@ -19,8 +19,8 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-entrenar = { version = "0.38.0", path = "../aprender-train", package = "aprender-train" }
-entrenar-common = { version = "0.38.0", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar = { version = "0.39.0", path = "../aprender-train", package = "aprender-train" }
+entrenar-common = { version = "0.39.0", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/aprender-train-distill/Cargo.toml
+++ b/crates/aprender-train-distill/Cargo.toml
@@ -32,8 +32,8 @@ cuda = ["entrenar/cuda"]
 shard-batch-source = []
 
 [dependencies]
-entrenar = { version = "0.38.0", path = "../aprender-train", package = "aprender-train" }
-entrenar-common = { version = "0.38.0", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar = { version = "0.39.0", path = "../aprender-train", package = "aprender-train" }
+entrenar-common = { version = "0.39.0", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/aprender-train-inspect/Cargo.toml
+++ b/crates/aprender-train-inspect/Cargo.toml
@@ -19,8 +19,8 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-entrenar = { version = "0.38.0", path = "../aprender-train", package = "aprender-train" }
-entrenar-common = { version = "0.38.0", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar = { version = "0.39.0", path = "../aprender-train", package = "aprender-train" }
+entrenar-common = { version = "0.39.0", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/aprender-train-lora/Cargo.toml
+++ b/crates/aprender-train-lora/Cargo.toml
@@ -19,8 +19,8 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-entrenar = { version = "0.38.0", path = "../aprender-train", package = "aprender-train" }
-entrenar-common = { version = "0.38.0", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar = { version = "0.39.0", path = "../aprender-train", package = "aprender-train" }
+entrenar-common = { version = "0.39.0", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/aprender-train-shell/Cargo.toml
+++ b/crates/aprender-train-shell/Cargo.toml
@@ -19,8 +19,8 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-entrenar = { version = "0.38.0", path = "../aprender-train", package = "aprender-train" }
-entrenar-common = { version = "0.38.0", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar = { version = "0.39.0", path = "../aprender-train", package = "aprender-train" }
+entrenar-common = { version = "0.39.0", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 rustyline = "14"
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/aprender-train/Cargo.toml
+++ b/crates/aprender-train/Cargo.toml
@@ -75,9 +75,9 @@ provable-contracts-macros = { version = "0.2" }
 # Core PAIML stack
 ndarray = "0.16"
 trueno = { version = "0.17", features = ["parallel"] }  # SIMD-accelerated compute
-trueno-gpu = { version = "0.38.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true }  # CUDA compute (APR-MONO single-source-of-truth)
+trueno-gpu = { version = "0.39.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true }  # CUDA compute (APR-MONO single-source-of-truth)
 realizar = { version = "0.8", optional = true }  # CUDA inference engine
-aprender = { path = "../aprender-core", version = "0.38.0", package = "aprender-core" }  # ML interpret module + .apr format + tokenizers
+aprender = { path = "../aprender-core", version = "0.39.0", package = "aprender-core" }  # ML interpret module + .apr format + tokenizers
 trueno-viz = { version = "0.2", features = ["terminal"] }  # Terminal visualization
 presentar-terminal = { version = "0.3.5", optional = true }  # Sovereign TUI framework (gated by "tui" feature)
 presentar-core = "0.3.4"  # Presentar core traits (crates.io — path removed, presentar restructured)

--- a/crates/aprender-tsp/Cargo.toml
+++ b/crates/aprender-tsp/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 name = "aprender-tsp"
 
 [dependencies]
-aprender = { path = "../../", version = "0.38.0" }
+aprender = { path = "../../", version = "0.39.0" }
 clap = { version = "4", features = ["derive"] }
 rand = "0.9"
 crc32fast = "1.4"

--- a/crates/aprender-verify-ml/Cargo.toml
+++ b/crates/aprender-verify-ml/Cargo.toml
@@ -50,7 +50,7 @@ uuid = { version = "1.11", features = ["v4", "serde"] }
 trueno = "0.7.3"
 
 # Machine learning for bug prediction (optional)
-aprender = { path = "../aprender-core", version = "0.38.0", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.39.0", package = "aprender-core", optional = true }
 
 # LLM fine-tuning integration (optional)
 entrenar = { workspace = true, optional = true }

--- a/crates/aprender-viz/Cargo.toml
+++ b/crates/aprender-viz/Cargo.toml
@@ -29,7 +29,7 @@ base64 = "0.22"
 thiserror = "2.0"
 
 # Optional: ML integration
-aprender = { path = "../aprender-core", version = "0.38.0", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.39.0", package = "aprender-core", optional = true }
 
 # Optional: Graph integration
 trueno-graph = { workspace = true, optional = true, default-features = false }


### PR DESCRIPTION
## v0.39.0 — BF16 (bfloat16) GGUF loader support

Any BF16 GGUF (ggml type 30) previously **hard-failed at load** with *"Unsupported quantization type: 30"* — `get_tensor_f32` (embeddings/norms/lm_head) and `tensor_byte_size` (per-layer weights) both lacked a BF16 dispatch arm, even though the matmul weight path already consumed BF16 (`fused_matmul_into.rs:526`). The framework half-supported BF16; only the central loader rejected it.

**Fix** (Q3_K/#1913 dispatch-arm pattern, reusing the battle-tested `simd_bf16_to_f32` already used by the safetensors loaders + `gguf/embedding.rs`):
- `metadata.rs` `get_tensor_f32`: BF16 arm (2 bytes/elem, bounds-checked) → `simd_bf16_to_f32`.
- `transformer.rs` `tensor_byte_size`: `GGUF_TYPE_BF16 => n*2`.
- `GGUFBuilder::add_bf16_tensor` for fixtures; `GGUF_TYPE_BF16` imports.

**Found via** an ultracode EV-ranking workflow over the codebase (highest EV: high user-value × S effort, CPU-verifiable, no GPU/auth).

## Verification
- ✅ FT-BF16-001 (golden converter round-trip) + FT-BF16-002 (a BF16 GGUFModel dispatches through `get_tensor_f32` with correct values, **not** the catch-all).
- ✅ Self-checked all qtype-rejection sites: dense BF16 path (`get_tensor_f32` + `tensor_byte_size` + matmul) is complete; MoE/CUDA BF16 are noted follow-ups.
- ✅ `contracts/bf16-dequant-v1.yaml` `pv validate` clean; `cargo check --workspace` + fmt clean.

Release: workspace + facade → 0.39.0; CHANGELOG `[0.39.0]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)