### PR TITLE
fix(export): reject AprQ8 in APR→GGUF export (corrupt-GGUF) — v0.40.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.40.0] - 2026-06-11
+
+### Fixed
+
+- **APR→GGUF export no longer produces corrupt GGUF for AprQ8 tensors**: export
+  silently mapped APR-native `AprQ8` (single-whole-tensor-scale 8-bit,
+  `[f32 scale] + [i8×N]` = 4+N bytes) to GGML `Q8_0` (per-32-block,
+  `ceil(N/32)·34` bytes) and emitted the raw APR bytes **unconverted** under the
+  `Q8_0` label — a corrupt GGUF that any llama.cpp loader misreads (reachable via
+  `apr import x.gguf && apr export --format gguf` on Q4_K_M models). Export now
+  **rejects** AprQ8 with a clear error (pointing to `apr convert` → F32/F16),
+  restoring import/export symmetry (the import side already refuses GGUF `Q8_0`,
+  and AprQ4 export was already rejected). Layout-identical dtypes
+  (F32/F16/Q4K/Q6K) export unchanged. Contract
+  `contracts/apr-gguf-export-symmetry-v1.yaml` (FT-APRQ8-001/002).
+
 ## [0.39.0] - 2026-06-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,7 +284,7 @@ dependencies = [
 
 [[package]]
 name = "apr-cli"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "alimentar",
  "anyhow",
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "aprender"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "apr-cli",
  "aprender-core",
@@ -411,7 +411,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-bench-compute"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "aprender-core",
  "criterion 0.7.0",
@@ -420,7 +420,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-bench-tokenizer"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "aprender-core",
  "criterion 0.7.0",
@@ -429,7 +429,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cbtop"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "aprender-compute",
@@ -454,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cgp"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "aprender-gpu",
@@ -474,7 +474,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-common"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "lz4_flex 0.11.6",
  "zstd",
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-compute"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "aprender-core",
@@ -531,7 +531,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-compute-xtask"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "bashrs",
@@ -544,7 +544,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-contracts"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "aprender-contracts-macros",
  "criterion 0.5.1",
@@ -559,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-contracts-cli"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "aprender-contracts",
  "clap",
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-contracts-macros"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-core"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "aes-gcm",
  "alimentar",
@@ -632,7 +632,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cuda-edge"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "aprender-gpu",
  "proptest",
@@ -643,7 +643,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cupti"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "bindgen 0.71.1",
  "bitflags 2.11.0",
@@ -653,7 +653,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-data"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-db"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "arrow 57.3.0",
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-distribute"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "arrow 57.3.0",
  "bincode",
@@ -781,7 +781,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-explain"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "aprender-gpu",
  "clap",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-fft"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -808,7 +808,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-gemm-codegen"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-gpu"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "aprender-profile",
  "batuta-common",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-graph"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "aprender-core",
@@ -862,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-image"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-mcp"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -886,9 +886,9 @@ dependencies = [
 
 [[package]]
 name = "aprender-monte-carlo"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
- "aprender 0.39.0",
+ "aprender 0.40.0",
  "assert_cmd",
  "chrono",
  "clap",
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-orchestrate"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "alimentar",
  "anyhow",
@@ -979,7 +979,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-cli"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "aprender-present-yaml",
  "clap",
@@ -992,7 +992,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-core"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "aprender-compute",
  "criterion 0.7.0",
@@ -1005,7 +1005,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-layout"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "aprender-present-core",
  "criterion 0.7.0",
@@ -1016,7 +1016,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-lib"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "aprender-present-core",
  "aprender-present-layout",
@@ -1045,7 +1045,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-terminal"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "aprender-present-core",
  "bitvec",
@@ -1067,7 +1067,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-test"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "aprender-present-core",
  "aprender-present-test-macros",
@@ -1078,7 +1078,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-test-macros"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1087,7 +1087,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-widgets"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "aprender-present-core",
  "aprender-present-yaml",
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-yaml"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "aprender-present-core",
  "proptest",
@@ -1109,7 +1109,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-profile"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "addr2line 0.25.1",
  "anyhow",
@@ -1162,7 +1162,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-profile-core"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "hex",
  "serde",
@@ -1172,7 +1172,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-ptx-debug"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "proptest",
  "thiserror 2.0.18",
@@ -1180,7 +1180,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-certify"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "chrono",
  "proptest",
@@ -1190,7 +1190,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-cli"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "aprender-qa-certify",
  "aprender-qa-gen",
@@ -1209,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-gen"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1226,7 +1226,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-report"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "aprender-qa-gen",
@@ -1244,7 +1244,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-runner"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "aprender-qa-gen",
@@ -1269,14 +1269,14 @@ dependencies = [
 
 [[package]]
 name = "aprender-quant"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "half",
 ]
 
 [[package]]
 name = "aprender-rag"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "batuta-common",
@@ -1307,7 +1307,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-rand"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1316,7 +1316,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-registry"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "alimentar",
  "anyhow",
@@ -1346,7 +1346,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-serve"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "alimentar",
  "anyhow",
@@ -1413,7 +1413,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-shell"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "aprender-core",
  "assert_cmd",
@@ -1430,7 +1430,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-simulate"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "bincode",
  "bitflags 2.11.0",
@@ -1469,7 +1469,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-solve"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1478,7 +1478,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-sparse"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1487,7 +1487,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-tensor"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1496,7 +1496,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-cli"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "aprender-test-lib",
  "assert_cmd",
@@ -1524,7 +1524,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-derive"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1534,7 +1534,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-js-gen"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -1550,7 +1550,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-lib"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "aprender-compute",
  "aprender-present-core",
@@ -1594,7 +1594,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-showcase"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "aprender-present-terminal",
  "console_error_panic_hook",
@@ -1611,7 +1611,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "alimentar",
  "approx",
@@ -1678,7 +1678,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-bench"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1695,7 +1695,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-common"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "clap",
  "proptest",
@@ -1707,7 +1707,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-distill"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1728,7 +1728,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-inspect"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1744,7 +1744,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-lora"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-shell"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1776,7 +1776,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-wasm"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "proptest",
  "serde",
@@ -1787,9 +1787,9 @@ dependencies = [
 
 [[package]]
 name = "aprender-tsp"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
- "aprender 0.39.0",
+ "aprender 0.40.0",
  "assert_cmd",
  "clap",
  "crc32fast",
@@ -1802,7 +1802,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-verify"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "chrono",
  "criterion 0.5.1",
@@ -1814,7 +1814,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-verify-ml"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "aprender-core",
  "aprender-profile",
@@ -1858,7 +1858,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-viz"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "approx",
  "aprender-core",
@@ -1893,7 +1893,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "aprender-zram-adaptive",
  "aprender-zram-core",
@@ -1903,7 +1903,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-adaptive"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "aprender-zram-core",
  "proptest",
@@ -1912,7 +1912,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-cli"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "aprender-zram-adaptive",
  "aprender-zram-core",
@@ -1926,7 +1926,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-core"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "aprender-gpu",
  "criterion 0.7.0",
@@ -1938,7 +1938,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-generator"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "aprender-zram-core",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.39.0"
+version = "0.40.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/paiml/aprender"
@@ -171,7 +171,7 @@ minijinja = { version = "2.14", features = ["loader", "serde"] }
 # Contracts
 provable-contracts = "0.3"
 provable-contracts-macros = "0.3"
-aprender-contracts-macros = { path = "crates/aprender-contracts-macros", version = "0.39.0" }
+aprender-contracts-macros = { path = "crates/aprender-contracts-macros", version = "0.40.0" }
 
 # YAML
 serde_yaml = "0.9"
@@ -183,31 +183,31 @@ hf-hub = { version = "0.4", default-features = false, features = ["ureq"] }
 hf-xet = "1.5.1"
 
 # Workspace-internal crates (paths within the monorepo)
-aprender-compute = { path = "crates/aprender-compute", version = "0.39.0" }
-aprender-gpu = { path = "crates/aprender-gpu", version = "0.39.0" }
-aprender-quant = { path = "crates/aprender-quant", version = "0.39.0" }
-aprender-serve = { path = "crates/aprender-serve", version = "0.39.0" }
-realizar = { path = "crates/aprender-serve", version = "0.39.0", package = "aprender-serve" }
-aprender-train = { path = "crates/aprender-train", version = "0.39.0" }
-entrenar = { path = "crates/aprender-train", version = "0.39.0", package = "aprender-train" }
-aprender-train-common = { path = "crates/aprender-train-common", version = "0.39.0" }
-aprender-train-distill = { path = "crates/aprender-train-distill", version = "0.39.0" }
-aprender-orchestrate = { path = "crates/aprender-orchestrate", version = "0.39.0" }
-aprender-contracts = { path = "crates/aprender-contracts", version = "0.39.0" }
-aprender-profile = { path = "crates/aprender-profile", version = "0.39.0" }
-aprender-profile-core = { path = "crates/aprender-profile-core", version = "0.39.0" }
-aprender-zram-core = { path = "crates/aprender-zram-core", version = "0.39.0" }
-aprender-zram-adaptive = { path = "crates/aprender-zram-adaptive", version = "0.39.0" }
-aprender-present-core = { path = "crates/aprender-present-core", version = "0.39.0" }
-aprender-present-terminal = { path = "crates/aprender-present-terminal", version = "0.39.0" }
-aprender-present-widgets = { path = "crates/aprender-present-widgets", version = "0.39.0" }
-aprender-present-layout = { path = "crates/aprender-present-layout", version = "0.39.0" }
-aprender-present-yaml = { path = "crates/aprender-present-yaml", version = "0.39.0" }
-aprender-present-test = { path = "crates/aprender-present-test", version = "0.39.0" }
-aprender-db = { path = "crates/aprender-db", version = "0.39.0" }
-aprender-graph = { path = "crates/aprender-graph", version = "0.39.0" }
-aprender-rag = { path = "crates/aprender-rag", version = "0.39.0" }
-aprender-data = { path = "crates/aprender-data", version = "0.39.0" }
+aprender-compute = { path = "crates/aprender-compute", version = "0.40.0" }
+aprender-gpu = { path = "crates/aprender-gpu", version = "0.40.0" }
+aprender-quant = { path = "crates/aprender-quant", version = "0.40.0" }
+aprender-serve = { path = "crates/aprender-serve", version = "0.40.0" }
+realizar = { path = "crates/aprender-serve", version = "0.40.0", package = "aprender-serve" }
+aprender-train = { path = "crates/aprender-train", version = "0.40.0" }
+entrenar = { path = "crates/aprender-train", version = "0.40.0", package = "aprender-train" }
+aprender-train-common = { path = "crates/aprender-train-common", version = "0.40.0" }
+aprender-train-distill = { path = "crates/aprender-train-distill", version = "0.40.0" }
+aprender-orchestrate = { path = "crates/aprender-orchestrate", version = "0.40.0" }
+aprender-contracts = { path = "crates/aprender-contracts", version = "0.40.0" }
+aprender-profile = { path = "crates/aprender-profile", version = "0.40.0" }
+aprender-profile-core = { path = "crates/aprender-profile-core", version = "0.40.0" }
+aprender-zram-core = { path = "crates/aprender-zram-core", version = "0.40.0" }
+aprender-zram-adaptive = { path = "crates/aprender-zram-adaptive", version = "0.40.0" }
+aprender-present-core = { path = "crates/aprender-present-core", version = "0.40.0" }
+aprender-present-terminal = { path = "crates/aprender-present-terminal", version = "0.40.0" }
+aprender-present-widgets = { path = "crates/aprender-present-widgets", version = "0.40.0" }
+aprender-present-layout = { path = "crates/aprender-present-layout", version = "0.40.0" }
+aprender-present-yaml = { path = "crates/aprender-present-yaml", version = "0.40.0" }
+aprender-present-test = { path = "crates/aprender-present-test", version = "0.40.0" }
+aprender-db = { path = "crates/aprender-db", version = "0.40.0" }
+aprender-graph = { path = "crates/aprender-graph", version = "0.40.0" }
+aprender-rag = { path = "crates/aprender-rag", version = "0.40.0" }
+aprender-data = { path = "crates/aprender-data", version = "0.40.0" }
 
 # Additional external deps needed by sub-crates
 serde_yaml_ng = "0.10"
@@ -252,25 +252,25 @@ wasmtime = "43"
 bollard = "0.17"
 
 # Old crate name aliases (workspace = true refs in migrated sub-crates)
-trueno-zram-core = { path = "crates/aprender-zram-core", version = "0.39.0", package = "aprender-zram-core" }
-trueno-zram-adaptive = { path = "crates/aprender-zram-adaptive", version = "0.39.0", package = "aprender-zram-adaptive" }
-trueno = { path = "crates/aprender-compute", version = "0.39.0", package = "aprender-compute" }
-presentar-core = { path = "crates/aprender-present-core", version = "0.39.0", package = "aprender-present-core" }
-presentar-terminal = { path = "crates/aprender-present-terminal", version = "0.39.0", package = "aprender-present-terminal" }
-presentar-widgets = { path = "crates/aprender-present-widgets", version = "0.39.0", package = "aprender-present-widgets" }
-presentar-layout = { path = "crates/aprender-present-layout", version = "0.39.0", package = "aprender-present-layout" }
-presentar-yaml = { path = "crates/aprender-present-yaml", version = "0.39.0", package = "aprender-present-yaml" }
-presentar-test = { path = "crates/aprender-present-test", version = "0.39.0", package = "aprender-present-test" }
-presentar-test-macros = { path = "crates/aprender-present-test-macros", version = "0.39.0", package = "aprender-present-test-macros" }
-jugar-probar-derive = { path = "crates/aprender-test-derive", version = "0.39.0", package = "aprender-test-derive" }
-batuta-common = { path = "crates/aprender-common", version = "0.39.0", package = "aprender-common" }
+trueno-zram-core = { path = "crates/aprender-zram-core", version = "0.40.0", package = "aprender-zram-core" }
+trueno-zram-adaptive = { path = "crates/aprender-zram-adaptive", version = "0.40.0", package = "aprender-zram-adaptive" }
+trueno = { path = "crates/aprender-compute", version = "0.40.0", package = "aprender-compute" }
+presentar-core = { path = "crates/aprender-present-core", version = "0.40.0", package = "aprender-present-core" }
+presentar-terminal = { path = "crates/aprender-present-terminal", version = "0.40.0", package = "aprender-present-terminal" }
+presentar-widgets = { path = "crates/aprender-present-widgets", version = "0.40.0", package = "aprender-present-widgets" }
+presentar-layout = { path = "crates/aprender-present-layout", version = "0.40.0", package = "aprender-present-layout" }
+presentar-yaml = { path = "crates/aprender-present-yaml", version = "0.40.0", package = "aprender-present-yaml" }
+presentar-test = { path = "crates/aprender-present-test", version = "0.40.0", package = "aprender-present-test" }
+presentar-test-macros = { path = "crates/aprender-present-test-macros", version = "0.40.0", package = "aprender-present-test-macros" }
+jugar-probar-derive = { path = "crates/aprender-test-derive", version = "0.40.0", package = "aprender-test-derive" }
+batuta-common = { path = "crates/aprender-common", version = "0.40.0", package = "aprender-common" }
 # APR-MONO sibling aliases — MUST use workspace refs, NEVER crates.io versions.
 # Hard-pinning these to crates.io creates a diamond: sub-crates pull older
 # aprender versions → multiple `aprender` crates in Cargo.lock = MUDA.
-renacer = { path = "crates/aprender-profile", version = "0.39.0", package = "aprender-profile" }
-entrenar-lora = { path = "crates/aprender-train-lora", version = "0.39.0", package = "aprender-train-lora" }
-batuta = { path = "crates/aprender-orchestrate", version = "0.39.0", package = "aprender-orchestrate" }
-trueno-graph = { path = "crates/aprender-graph", version = "0.39.0", package = "aprender-graph" }
+renacer = { path = "crates/aprender-profile", version = "0.40.0", package = "aprender-profile" }
+entrenar-lora = { path = "crates/aprender-train-lora", version = "0.40.0", package = "aprender-train-lora" }
+batuta = { path = "crates/aprender-orchestrate", version = "0.40.0", package = "aprender-orchestrate" }
+trueno-graph = { path = "crates/aprender-graph", version = "0.40.0", package = "aprender-graph" }
 
 [workspace.lints.rust]
 # Safety
@@ -428,7 +428,7 @@ semicolon_if_nothing_returned = "allow"  # Style preference
 
 [package]
 name = "aprender"
-version = "0.39.0"
+version = "0.40.0"
 edition = "2021"
 rust-version = "1.89"
 authors = ["Noah Gift <noah@paiml.com>"]
@@ -458,7 +458,7 @@ required-features = ["cli"]
 # (e.g. apr-cookbook, downstream apps) don't pull apr-cli's heavy transitive
 # dep graph (renacer/profile/inference/zram/visualization). `cargo install
 # aprender` still works because `cli` is in default features. See GH-1599.
-apr-cli = { path = "crates/apr-cli", version = "0.39.0", default-features = true, optional = true }
+apr-cli = { path = "crates/apr-cli", version = "0.40.0", default-features = true, optional = true }
 # Core ML library (lib name = "aprender")
 aprender_ml = { path = "crates/aprender-core", version = ">=0.29", package = "aprender-core" }
 

--- a/contracts/apr-gguf-export-symmetry-v1.yaml
+++ b/contracts/apr-gguf-export-symmetry-v1.yaml
@@ -1,0 +1,90 @@
+metadata:
+  version: 1.0.0
+  created: '2026-06-11'
+  author: PAIML Engineering
+  description: |
+    APR→GGUF export must NEVER relabel an APR-native quant dtype as a GGML type
+    whose byte layout differs — doing so produces a silently CORRUPT GGUF.
+
+    AprQ8 (TensorDType::AprQ8, id 129) is APR-native single-whole-tensor-scale
+    8-bit: [scale: f32 (4B)] + [i8 × N] = 4+N bytes. GGML Q8_0 (id 8) is a
+    totally different per-32-block layout: [f16 scale (2B) + 32×i8] =
+    ceil(N/32)*34 bytes. The export path mapped AprQ8 → Q8_0 and emitted the raw
+    APR bytes under the Q8_0 label, so a 256-element tensor was 260 bytes labeled
+    as a 272-byte Q8_0 block layout — any llama.cpp loader misreads it.
+
+    The fix restores import/export symmetry: AprQ8 (like AprQ4 already) has NO
+    GGUF equivalent and is REJECTED with a clear error, mirroring the import-side
+    refusal of GGUF Q8_0 (which APR cannot represent exactly). A real
+    AprQ8→Q8_0 requantize is a separate feature, not a silent relabel.
+  references:
+  - 'crates/aprender-core/src/format/converter/metadata.rs — export_apr_to_gguf_raw dtype match (AprQ8 reject arm)'
+  - 'crates/aprender-core/src/format/converter/fusion.rs — apr_dtype_to_ggml (AprQ8 None arm)'
+  - 'crates/aprender-core/src/format/v2/tensor_index_impl.rs:173 — AprQ8 layout (scale f32 + i8 x N)'
+  - 'crates/aprender-core/src/format/converter/write_model_config.rs:148 — symmetric import-side Q8_0 rejection'
+
+kind: KernelContract
+name: apr-gguf-export-symmetry
+version: 1.0.0
+scope: aprender-core APR→GGUF export dtype mapping (metadata.rs + fusion.rs)
+
+equations:
+  layout_compatible_export:
+    formula: |
+      APR→GGUF export emits a tensor under a GGML type T ONLY IF the APR dtype's
+      byte layout is byte-identical to T's. APR-native quant dtypes (AprQ8 4+N
+      bytes single-scale; AprQ4) have NO byte-compatible GGML type and MUST be
+      rejected, never relabeled.
+    domain: an APR tensor's TensorDType
+    codomain: a GgmlType or a FormatError
+    invariants:
+    - 'AprQ8 export -> Err (NOT silently mapped to Q8_0)'
+    - 'AprQ4 export -> Err (unchanged)'
+    - 'layout-identical dtypes (F32/F16/Q4K/Q6K) still export successfully'
+    - 'symmetric with the import-side rejection of GGUF Q8_0'
+    lean_theorem: Theorems.Layout_Compatible_Export
+
+proof_obligations:
+- type: classification
+  property: APR-native quant export rejected
+  formal: |
+    export_apr_to_gguf_raw on an APR file containing an AprQ8 tensor returns
+    Err whose message names "AprQ8".
+- type: invariant
+  property: layout-identical dtypes still export
+  formal: |
+    An APR file of F32 (and Q4K/Q6K) tensors still exports to a valid GGUF the
+    GgufReader can parse.
+
+falsification_tests:
+- id: FT-APRQ8-001
+  rule: AprQ8 export is rejected, not silently relabeled as Q8_0
+  prediction: |
+    export_apr_to_gguf_raw on an APR with an AprQ8 tensor returns Err containing
+    "AprQ8" (before the fix it returned Ok with a corrupt GGUF).
+  if_fails: 'the AprQ8 arm is back in the success match mapping to Q8_0.'
+  evidence: cargo test -p aprender-core --lib ft_aprq8_001_export_rejects_aprq8_not_silent_corruption
+- id: FT-APRQ8-002
+  rule: layout-identical dtypes still export successfully
+  prediction: 'an all-F32 APR exports to a GGUF that GgufReader parses (3 tensors).'
+  if_fails: 'the reject arm is over-broad and now blocks valid F32/Q4K/Q6K export.'
+  evidence: cargo test -p aprender-core --lib test_export_apr_to_gguf_raw_round_trip
+
+kani_harnesses:
+- id: KANI-APRQ8-001
+  obligation: only layout-identical dtypes map to a GgmlType
+  property: |
+    For all TensorDType d: apr_dtype_to_ggml(d) is Some(T) ONLY for d in
+    {F32,F16,Q4K,Q6K}; AprQ8/AprQ4/BF16/F64/I*/U8 -> None. No panic.
+  bound: 1
+  strategy: compositional
+  solver: cadical
+  harness: verify_export_dtype_rejects_apr_native
+
+qa_gate:
+  id: F-APRQ8-001
+  name: apr-gguf-export-symmetry-v1 Contract
+  description: APR→GGUF export must reject APR-native quant dtypes (AprQ8/AprQ4) rather than relabel them as a byte-incompatible GGML type and emit a corrupt GGUF.
+  checks:
+  - validation
+  - falsification

--- a/crates/apr-cli/Cargo.toml
+++ b/crates/apr-cli/Cargo.toml
@@ -103,10 +103,10 @@ libc = "0.2"
 
 [dependencies]
 # Core aprender library
-aprender = { path = "../aprender-core", version = "0.39.0", package = "aprender-core", default-features = true, features = ["format-compression"] }
+aprender = { path = "../aprender-core", version = "0.40.0", package = "aprender-core", default-features = true, features = ["format-compression"] }
 
 # MCP (Model Context Protocol) server — `apr mcp` subcommand
-aprender-mcp = { path = "../aprender-mcp", version = "0.39.0" }
+aprender-mcp = { path = "../aprender-mcp", version = "0.40.0" }
 async-stream = "0.3"
 provable-contracts-macros = "0.3"
 

--- a/crates/aprender-bench-compute/Cargo.toml
+++ b/crates/aprender-bench-compute/Cargo.toml
@@ -11,7 +11,7 @@ disallowed_methods = "allow"
 
 [dependencies]
 # The implementation under test
-aprender = { path = "../aprender-core", version = "0.39.0", package = "aprender-core", features = ["format-quantize"] }
+aprender = { path = "../aprender-core", version = "0.40.0", package = "aprender-core", features = ["format-quantize"] }
 
 # Reference implementation for A/B comparison
 # Pure Rust (no BLAS) to keep comparison fair — both are pure Rust SIMD

--- a/crates/aprender-bench-tokenizer/Cargo.toml
+++ b/crates/aprender-bench-tokenizer/Cargo.toml
@@ -11,7 +11,7 @@ disallowed_methods = "allow"
 
 [dependencies]
 # The implementation under test
-aprender = { path = "../aprender-core", version = "0.39.0", package = "aprender-core" }
+aprender = { path = "../aprender-core", version = "0.40.0", package = "aprender-core" }
 
 # HuggingFace reference for A/B comparison
 # Regular dep (not dev-dep) because [[bench]] harness=false binaries can't see dev-deps

--- a/crates/aprender-cbtop/Cargo.toml
+++ b/crates/aprender-cbtop/Cargo.toml
@@ -23,8 +23,8 @@ presentar-core = "0.3"
 presentar-terminal = "0.3"
 
 # Compute backends
-trueno = { version = "0.39.0", path = "../aprender-compute", package = "aprender-compute" }
-trueno-gpu = { version = "0.39.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true }
+trueno = { version = "0.40.0", path = "../aprender-compute", package = "aprender-compute" }
+trueno-gpu = { version = "0.40.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true }
 
 # Terminal handling
 crossterm = "0.28"

--- a/crates/aprender-cgp/Cargo.toml
+++ b/crates/aprender-cgp/Cargo.toml
@@ -36,7 +36,7 @@ num_cpus = "1.17"
 comfy-table = "7"
 colored = "3"
 # GPU profiling: direct cuBLAS measurement (OWN THE STACK)
-trueno-gpu = { path = "../aprender-gpu", version = "0.39.0", features = ["cuda"], optional = true, package = "aprender-gpu" }
+trueno-gpu = { path = "../aprender-gpu", version = "0.40.0", features = ["cuda"], optional = true, package = "aprender-gpu" }
 
 [features]
 default = []

--- a/crates/aprender-compute/Cargo.toml
+++ b/crates/aprender-compute/Cargo.toml
@@ -38,11 +38,11 @@ futures-intrusive = { version = "0.5", optional = true }
 wasm-bindgen-futures = { version = "0.4", optional = true }
 wasm-bindgen = { version = "0.2", optional = true }
 # Native CUDA monitoring via trueno-gpu (TRUENO-SPEC-010)
-trueno-gpu = { version = "0.39.0", path = "../aprender-gpu", optional = true, package = "aprender-gpu" }
+trueno-gpu = { version = "0.40.0", path = "../aprender-gpu", optional = true, package = "aprender-gpu" }
 # PMAT-336: Provable contracts compile-time enforcement
 provable-contracts-macros = "0.3"
 # P1a: Sovereign GEMM microkernel codegen (compile-time shape specialization)
-trueno-gemm-codegen = { version = "0.39.0", path = "../aprender-gemm-codegen", package = "aprender-gemm-codegen" }
+trueno-gemm-codegen = { version = "0.40.0", path = "../aprender-gemm-codegen", package = "aprender-gemm-codegen" }
 # Tracing/profiling support (renacer integration)
 tracing = { version = "0.1", optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"], optional = true }
@@ -54,7 +54,7 @@ presentar-core = { version = "0.3", optional = true }
 # Stress test reporting types compatible with renacer (TRUENO-SPEC-025)
 # Note: renacer 0.9.1 has compilation issue; using compatible local types instead
 dhat = { version = "0.3", optional = true }
-trueno-quant = { version = "0.39.0", path = "../aprender-quant", package = "aprender-quant" }
+trueno-quant = { version = "0.40.0", path = "../aprender-quant", package = "aprender-quant" }
 num_cpus = "1.17.0"
 anyhow = "1.0.100"
 # Hardware capability detection (PMAT-447)
@@ -62,7 +62,7 @@ chrono = "0.4"
 toml = "0.8"
 # ML tuner integration (SHOWCASE-BRICK-001, Section 12)
 # Uses aprender 0.24.0 RandomForest for learned optimization
-aprender = { path = "../aprender-core", version = "0.39.0", package = "aprender-core", optional = true, default-features = false }
+aprender = { path = "../aprender-core", version = "0.40.0", package = "aprender-core", optional = true, default-features = false }
 # Execution path graph (PAR-201, Section E.7)
 trueno-graph = { workspace = true, optional = true }
 # TUI visualization for execution graphs (PAR-201)
@@ -90,10 +90,10 @@ nalgebra = "0.34"  # For eigendecomposition benchmark comparison
 simular = "0.2.0"
 regex = "1.11"  # For PTX/WGSL pattern validation in falsification tests
 # GPU edge-case test framework (TCE-001)
-trueno-cuda-edge = { version = "0.39.0", path = "../aprender-cuda-edge", package = "aprender-cuda-edge" }
+trueno-cuda-edge = { version = "0.40.0", path = "../aprender-cuda-edge", package = "aprender-cuda-edge" }
 # Sparse and solver crates for contract tests
-trueno-sparse = { version = "0.39.0", path = "../aprender-sparse", package = "aprender-sparse" }
-trueno-solve = { version = "0.39.0", path = "../aprender-solve", package = "aprender-solve" }
+trueno-sparse = { version = "0.40.0", path = "../aprender-sparse", package = "aprender-sparse" }
+trueno-solve = { version = "0.40.0", path = "../aprender-solve", package = "aprender-solve" }
 ndarray = "0.17.2"
 faer = "0.24"  # For GEMM benchmark comparison (fastest pure-Rust BLAS)
 matrixmultiply = "0.3"  # Direct matrixmultiply crate benchmark (engine behind ndarray)

--- a/crates/aprender-contracts-cli/Cargo.toml
+++ b/crates/aprender-contracts-cli/Cargo.toml
@@ -13,7 +13,7 @@ name = "pv"
 path = "src/main.rs"
 
 [dependencies]
-aprender-contracts = { path = "../aprender-contracts", version = "0.39.0" }
+aprender-contracts = { path = "../aprender-contracts", version = "0.40.0" }
 clap = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }

--- a/crates/aprender-contracts/Cargo.toml
+++ b/crates/aprender-contracts/Cargo.toml
@@ -19,7 +19,7 @@ kani = []
 name = "provable_contracts"
 
 [dependencies]
-provable-contracts-macros = { path = "../aprender-contracts-macros", version = "0.39.0", package = "aprender-contracts-macros" }
+provable-contracts-macros = { path = "../aprender-contracts-macros", version = "0.40.0", package = "aprender-contracts-macros" }
 regex = "1"
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/aprender-core/src/format/converter/export_tests_arch_metadata.rs
+++ b/crates/aprender-core/src/format/converter/export_tests_arch_metadata.rs
@@ -485,3 +485,61 @@ fn test_export_apr_to_gguf_raw_infers_num_layers_when_missing() {
         "export must succeed via num_layers inference; got: {result:?}"
     );
 }
+
+/// FT-APRQ8-001: APR→GGUF export must REJECT an AprQ8 tensor (APR-native
+/// single-whole-tensor-scale 8-bit, 4+N bytes) instead of silently relabeling
+/// it as GGML Q8_0 (per-32-block, ceil(N/32)*34 bytes) — which produced a
+/// CORRUPT GGUF that any llama.cpp loader misreads. Symmetric with the existing
+/// AprQ4 rejection and the import-side Q8_0 refusal.
+#[test]
+fn ft_aprq8_001_export_rejects_aprq8_not_silent_corruption() {
+    use crate::format::v2::{AprV2Metadata, AprV2Writer};
+    use tempfile::tempdir;
+
+    let dir = tempdir().expect("temp dir");
+    let apr_path = dir.path().join("model.apr");
+    let gguf_path = dir.path().join("model.gguf");
+
+    let mut metadata = AprV2Metadata::new("qwen2");
+    metadata.architecture = Some("qwen2".to_string());
+    metadata.hidden_size = Some(4);
+    metadata.num_layers = Some(1);
+    metadata.num_heads = Some(2);
+    metadata.num_kv_heads = Some(2);
+    metadata.vocab_size = Some(8);
+    metadata.intermediate_size = Some(16);
+    metadata.max_position_embeddings = Some(2048);
+    metadata.rope_theta = Some(10000.0);
+    metadata.rms_norm_eps = Some(1e-5);
+    metadata.name = Some("test-model".to_string());
+    metadata
+        .custom
+        .insert("tokenizer.model".to_string(), serde_json::json!("gpt2"));
+    metadata.custom.insert(
+        "tokenizer.vocabulary".to_string(),
+        serde_json::json!(["<|endoftext|>", "hello", "world", "the", "a", "is", ".", " "]),
+    );
+    metadata
+        .custom
+        .insert("tokenizer.vocab_size".to_string(), serde_json::json!(8));
+
+    let mut writer = AprV2Writer::new(metadata);
+    writer.add_f32_tensor("model.embed_tokens.weight", vec![8, 4], &vec![0.1f32; 32]);
+    writer.add_f32_tensor("model.norm.weight", vec![4], &vec![1.0f32; 4]);
+    // The offending tensor: an APR-native AprQ8 weight (NOT GGML Q8_0).
+    writer.add_q8_tensor("lm_head.weight", vec![8, 4], &vec![0.05f32; 32]);
+
+    let apr_bytes = writer.write().expect("write APR");
+    std::fs::write(&apr_path, &apr_bytes).expect("write APR file");
+
+    let result = export_apr_to_gguf_raw(&apr_path, &gguf_path);
+    assert!(
+        result.is_err(),
+        "AprQ8 export must be REJECTED, not silently relabeled as Q8_0 (corrupt GGUF)"
+    );
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("AprQ8"),
+        "rejection must name AprQ8 to disambiguate from Q8_0; got: {msg}"
+    );
+}

--- a/crates/aprender-core/src/format/converter/fusion.rs
+++ b/crates/aprender-core/src/format/converter/fusion.rs
@@ -123,9 +123,16 @@ fn apr_dtype_to_ggml(dtype: crate::format::v2::TensorDType) -> Option<crate::for
         TensorDType::F16 => Some(GgmlType::F16),
         TensorDType::Q4K => Some(GgmlType::Q4K),
         TensorDType::Q6K => Some(GgmlType::Q6K),
-        TensorDType::AprQ8 => Some(GgmlType::Q8_0),
-        TensorDType::BF16 | TensorDType::F64 | TensorDType::I32
-        | TensorDType::I64 | TensorDType::I8 | TensorDType::U8
+        // AprQ8 (APR-native single-scale 8-bit, 4+N bytes) is NOT GGML Q8_0
+        // (per-32-block, ceil(N/32)*34 bytes) — relabeling produces corrupt
+        // GGUF. Reject alongside AprQ4 (symmetric with metadata.rs export arm).
+        TensorDType::AprQ8
+        | TensorDType::BF16
+        | TensorDType::F64
+        | TensorDType::I32
+        | TensorDType::I64
+        | TensorDType::I8
+        | TensorDType::U8
         | TensorDType::AprQ4 => {
             eprintln!(
                 "[GH-439] apr_dtype_to_ggml: unsupported dtype {:?} — \

--- a/crates/aprender-core/src/format/converter/metadata.rs
+++ b/crates/aprender-core/src/format/converter/metadata.rs
@@ -466,7 +466,9 @@ fn export_apr_to_gguf_raw(input: &Path, output: &Path) -> Result<ExportReport> {
                 message: format!("Tensor '{}' data not found", name),
             })?;
 
-        // Map APR dtype → GGUF dtype (same discriminant values)
+        // Map APR dtype → GGUF dtype. NOTE: the discriminants are NOT shared —
+        // APR-native quant types (AprQ8=129, AprQ4=128) have NO GGML equivalent
+        // despite the similar names.
         // GH-439 (poka-yoke): Exhaustive match — no silent fallbacks.
         // Adding a new TensorDType variant forces a compile error here.
         let gguf_dtype = match entry.dtype {
@@ -474,7 +476,24 @@ fn export_apr_to_gguf_raw(input: &Path, output: &Path) -> Result<ExportReport> {
             TensorDType::F16 => GgmlType::F16,
             TensorDType::Q4K => GgmlType::Q4K,
             TensorDType::Q6K => GgmlType::Q6K,
-            TensorDType::AprQ8 => GgmlType::Q8_0,
+            // AprQ8 is APR-native single-whole-tensor-scale 8-bit
+            // ([scale: f32 (4B)] + [i8; N] = 4+N bytes). GGML Q8_0 is a totally
+            // different per-32-block layout ([f16 scale (2B) + 32×i8] =
+            // ceil(N/32)*34 bytes). Emitting the raw APR bytes under a Q8_0
+            // label produces a CORRUPT GGUF, so reject — symmetric with the
+            // AprQ4 arm below and the import-side Q8_0 rejection
+            // (write_model_config.rs). A real AprQ8→Q8_0 requantize is a
+            // separate feature, not a silent relabel.
+            TensorDType::AprQ8 => {
+                return Err(AprenderError::FormatError {
+                    message: format!(
+                        "Tensor '{}' has dtype AprQ8 (APR-native single-scale 8-bit, \
+                         NOT GGML Q8_0) which has no GGUF equivalent. \
+                         Convert to F32/F16 first with `apr convert`.",
+                        name
+                    ),
+                });
+            }
             TensorDType::BF16 | TensorDType::F64 | TensorDType::I32
             | TensorDType::I64 | TensorDType::I8 | TensorDType::U8
             | TensorDType::AprQ4 => {

--- a/crates/aprender-cuda-edge/Cargo.toml
+++ b/crates/aprender-cuda-edge/Cargo.toml
@@ -15,7 +15,7 @@ name = "trueno_cuda_edge"
 [dependencies]
 thiserror = "2.0"
 serde = { version = "1.0", features = ["derive"] }
-trueno-gpu = { version = "0.39.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true }
+trueno-gpu = { version = "0.40.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true }
 
 [dev-dependencies]
 proptest = "1.6"

--- a/crates/aprender-explain/Cargo.toml
+++ b/crates/aprender-explain/Cargo.toml
@@ -25,7 +25,7 @@ presentar-terminal = "0.3"
 crossterm = "0.28"
 
 # Internal dependency for PTX generation
-trueno-gpu = { version = "0.39.0", path = "../aprender-gpu", package = "aprender-gpu", features = ["cuda"] }
+trueno-gpu = { version = "0.40.0", path = "../aprender-gpu", package = "aprender-gpu", features = ["cuda"] }
 
 [dev-dependencies]
 proptest = "1.4"

--- a/crates/aprender-graph/Cargo.toml
+++ b/crates/aprender-graph/Cargo.toml
@@ -28,7 +28,7 @@ anyhow = "1"
 thiserror = "2"
 
 # Phase 2+ dependencies
-aprender = { path = "../aprender-core", version = "0.39.0", package = "aprender-core" }                                        # Sparse matrix ops, PageRank
+aprender = { path = "../aprender-core", version = "0.40.0", package = "aprender-core" }                                        # Sparse matrix ops, PageRank
 trueno = "0.17"                                          # SIMD primitives
 trueno-db = "0.3.17"                                     # Columnar storage
 

--- a/crates/aprender-monte-carlo/Cargo.toml
+++ b/crates/aprender-monte-carlo/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 name = "aprender-monte-carlo"
 
 [dependencies]
-aprender = { path = "../../", version = "0.39.0" }
+aprender = { path = "../../", version = "0.40.0" }
 clap = { version = "4", features = ["derive"] }
 rand = "0.9"
 rand_chacha = "0.9"

--- a/crates/aprender-orchestrate/Cargo.toml
+++ b/crates/aprender-orchestrate/Cargo.toml
@@ -117,7 +117,7 @@ pacha = { version = "0.2", optional = true }
 realizar = { version = "0.8", optional = true, features = ["cuda"] }
 
 # ML algorithms and training (native-only)
-aprender = { path = "../aprender-core", version = "0.39.0", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.40.0", package = "aprender-core", optional = true }
 entrenar = { workspace = true, optional = true }
 alimentar = { version = "0.2", optional = true }
 

--- a/crates/aprender-profile/Cargo.toml
+++ b/crates/aprender-profile/Cargo.toml
@@ -74,7 +74,7 @@ trueno = { version = "0.17" }
 
 # Machine learning for anomaly detection (Sprint 23)
 # GH-581: Use path dep to avoid trueno version skew with local workspace
-aprender = { path = "../aprender-core", version = "0.39.0", package = "aprender-core" }
+aprender = { path = "../aprender-core", version = "0.40.0", package = "aprender-core" }
 
 # Lock-free data structures for ring buffer (Sprint 40)
 crossbeam = { version = "0.8", default-features = false, features = ["crossbeam-channel", "crossbeam-queue", "std"] }

--- a/crates/aprender-qa-runner/Cargo.toml
+++ b/crates/aprender-qa-runner/Cargo.toml
@@ -29,7 +29,7 @@ sha2 = "0.10"
 regex = { workspace = true }
 num_cpus = "1.16"
 safetensors = { workspace = true }
-jugar-probar = { version = "0.39.0", path = "../aprender-test-lib", package = "aprender-test-lib", features = ["llm-types"] }
+jugar-probar = { version = "0.40.0", path = "../aprender-test-lib", package = "aprender-test-lib", features = ["llm-types"] }
 # Test fixtures dependencies (optional)
 tempfile = { version = "3", optional = true }
 half = { version = "2.4", optional = true }

--- a/crates/aprender-registry/Cargo.toml
+++ b/crates/aprender-registry/Cargo.toml
@@ -42,7 +42,7 @@ zstd = { version = "0.13", optional = true }
 clap = { version = "4", features = ["derive"], optional = true }
 
 # Ecosystem integration
-aprender = { path = "../aprender-core", version = "0.39.0", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.40.0", package = "aprender-core", optional = true }
 alimentar = { version = "0.2.3", optional = true }
 
 # HTTP client (optional)

--- a/crates/aprender-serve/Cargo.toml
+++ b/crates/aprender-serve/Cargo.toml
@@ -39,7 +39,7 @@ name = "realizar"
 trueno = { version = "0.17", features = ["gpu"] }
 # CUDA PTX generation and runtime for NVIDIA GPUs (optional, pure Rust, no LLVM/nvcc)
 # v0.4.12: BatchedQ6K, MultiWarp, RopeNeox, FlashDecoding kernels
-trueno-gpu = { version = "0.39.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true, features = ["cuda"] }  # APR-MONO single-source-of-truth
+trueno-gpu = { version = "0.40.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true, features = ["cuda"] }  # APR-MONO single-source-of-truth
 # KV cache storage (for attention caching)
 trueno-db = { version = "0.3.16", optional = true }
 # K-quantization formats (Q4_K, Q5_K, Q6_K) - Toyota Way: ONE source of truth
@@ -53,7 +53,7 @@ renacer-core = { version = "0.1" }
 
 # ML algorithms and .apr model format (optional for aprender model serving)
 # v0.24.1: chat templates, GGUF tokenizer preservation (local may be newer)
-aprender = { path = "../aprender-core", version = "0.39.0", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.40.0", package = "aprender-core", optional = true }
 
 # Data loading library (optional for data pipeline examples)
 alimentar = { version = "0.2", optional = true, default-features = false, features = ["local", "shuffle"] }

--- a/crates/aprender-shell/Cargo.toml
+++ b/crates/aprender-shell/Cargo.toml
@@ -24,7 +24,7 @@ harness = false
 
 [dependencies]
 # Use path for local dev, crates.io for release
-aprender = { path = "../aprender-core", version = "0.39.0", package = "aprender-core", features = ["format-encryption", "format-compression", "format-homomorphic"] }
+aprender = { path = "../aprender-core", version = "0.40.0", package = "aprender-core", features = ["format-encryption", "format-compression", "format-homomorphic"] }
 clap = { version = "4", features = ["derive"] }
 dirs = "5"
 serde = { version = "1", features = ["derive"] }

--- a/crates/aprender-test-cli/Cargo.toml
+++ b/crates/aprender-test-cli/Cargo.toml
@@ -24,7 +24,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Core library (was: jugar-probar) — dep key preserves Rust identifier
-jugar-probar = { path = "../aprender-test-lib", version = "0.39.0", package = "aprender-test-lib" }
+jugar-probar = { path = "../aprender-test-lib", version = "0.40.0", package = "aprender-test-lib" }
 
 # CLI framework
 clap = { workspace = true }

--- a/crates/aprender-train-bench/Cargo.toml
+++ b/crates/aprender-train-bench/Cargo.toml
@@ -19,8 +19,8 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-entrenar = { version = "0.39.0", path = "../aprender-train", package = "aprender-train" }
-entrenar-common = { version = "0.39.0", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar = { version = "0.40.0", path = "../aprender-train", package = "aprender-train" }
+entrenar-common = { version = "0.40.0", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/aprender-train-distill/Cargo.toml
+++ b/crates/aprender-train-distill/Cargo.toml
@@ -32,8 +32,8 @@ cuda = ["entrenar/cuda"]
 shard-batch-source = []
 
 [dependencies]
-entrenar = { version = "0.39.0", path = "../aprender-train", package = "aprender-train" }
-entrenar-common = { version = "0.39.0", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar = { version = "0.40.0", path = "../aprender-train", package = "aprender-train" }
+entrenar-common = { version = "0.40.0", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/aprender-train-inspect/Cargo.toml
+++ b/crates/aprender-train-inspect/Cargo.toml
@@ -19,8 +19,8 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-entrenar = { version = "0.39.0", path = "../aprender-train", package = "aprender-train" }
-entrenar-common = { version = "0.39.0", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar = { version = "0.40.0", path = "../aprender-train", package = "aprender-train" }
+entrenar-common = { version = "0.40.0", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/aprender-train-lora/Cargo.toml
+++ b/crates/aprender-train-lora/Cargo.toml
@@ -19,8 +19,8 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-entrenar = { version = "0.39.0", path = "../aprender-train", package = "aprender-train" }
-entrenar-common = { version = "0.39.0", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar = { version = "0.40.0", path = "../aprender-train", package = "aprender-train" }
+entrenar-common = { version = "0.40.0", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/aprender-train-shell/Cargo.toml
+++ b/crates/aprender-train-shell/Cargo.toml
@@ -19,8 +19,8 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-entrenar = { version = "0.39.0", path = "../aprender-train", package = "aprender-train" }
-entrenar-common = { version = "0.39.0", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar = { version = "0.40.0", path = "../aprender-train", package = "aprender-train" }
+entrenar-common = { version = "0.40.0", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 rustyline = "14"
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/aprender-train/Cargo.toml
+++ b/crates/aprender-train/Cargo.toml
@@ -75,9 +75,9 @@ provable-contracts-macros = { version = "0.2" }
 # Core PAIML stack
 ndarray = "0.16"
 trueno = { version = "0.17", features = ["parallel"] }  # SIMD-accelerated compute
-trueno-gpu = { version = "0.39.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true }  # CUDA compute (APR-MONO single-source-of-truth)
+trueno-gpu = { version = "0.40.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true }  # CUDA compute (APR-MONO single-source-of-truth)
 realizar = { version = "0.8", optional = true }  # CUDA inference engine
-aprender = { path = "../aprender-core", version = "0.39.0", package = "aprender-core" }  # ML interpret module + .apr format + tokenizers
+aprender = { path = "../aprender-core", version = "0.40.0", package = "aprender-core" }  # ML interpret module + .apr format + tokenizers
 trueno-viz = { version = "0.2", features = ["terminal"] }  # Terminal visualization
 presentar-terminal = { version = "0.3.5", optional = true }  # Sovereign TUI framework (gated by "tui" feature)
 presentar-core = "0.3.4"  # Presentar core traits (crates.io — path removed, presentar restructured)

--- a/crates/aprender-tsp/Cargo.toml
+++ b/crates/aprender-tsp/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 name = "aprender-tsp"
 
 [dependencies]
-aprender = { path = "../../", version = "0.39.0" }
+aprender = { path = "../../", version = "0.40.0" }
 clap = { version = "4", features = ["derive"] }
 rand = "0.9"
 crc32fast = "1.4"

--- a/crates/aprender-verify-ml/Cargo.toml
+++ b/crates/aprender-verify-ml/Cargo.toml
@@ -50,7 +50,7 @@ uuid = { version = "1.11", features = ["v4", "serde"] }
 trueno = "0.7.3"
 
 # Machine learning for bug prediction (optional)
-aprender = { path = "../aprender-core", version = "0.39.0", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.40.0", package = "aprender-core", optional = true }
 
 # LLM fine-tuning integration (optional)
 entrenar = { workspace = true, optional = true }

--- a/crates/aprender-viz/Cargo.toml
+++ b/crates/aprender-viz/Cargo.toml
@@ -29,7 +29,7 @@ base64 = "0.22"
 thiserror = "2.0"
 
 # Optional: ML integration
-aprender = { path = "../aprender-core", version = "0.39.0", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.40.0", package = "aprender-core", optional = true }
 
 # Optional: Graph integration
 trueno-graph = { workspace = true, optional = true, default-features = false }


### PR DESCRIPTION
## v0.40.0 — APR→GGUF export no longer produces corrupt GGUF for AprQ8

**Silent data corruption fix.** Export mapped APR-native `AprQ8` → GGML `Q8_0` and emitted the raw APR bytes **unconverted** under the `Q8_0` label:
- `AprQ8` (id 129): single-whole-tensor-scale 8-bit — `[f32 scale (4B)] + [i8×N]` = **4+N bytes**.
- GGML `Q8_0` (id 8): per-32-block — `[f16 scale (2B) + 32×i8]` = **ceil(N/32)·34 bytes**.

So a 256-elem tensor was 260 bytes labeled as a 272-byte Q8_0 block — any llama.cpp loader misreads it. Reachable via `apr import x.gguf && apr export --format gguf` on Q4_K_M models (which mix Q4K + Q8_0/AprQ8 tensors). `metadata.rs` and `fusion.rs` both had the bug.

**Fix — fail loud, restore symmetry:** move `AprQ8` into the existing rejecting arm alongside `AprQ4` (mirrors the import-side GGUF-`Q8_0` rejection), with a clear error naming AprQ8 vs Q8_0 and pointing to `apr convert` → F32/F16. The false *"(same discriminant values)"* comment is corrected (AprQ8=129 ≠ Q8_0=8).

## Verification
- ✅ FT-APRQ8-001: AprQ8 export now returns `Err` naming "AprQ8" (was `Ok` with a corrupt GGUF).
- ✅ FT-APRQ8-002: F32/Q4K/Q6K export unchanged — **18 export tests green**.
- ✅ `contracts/apr-gguf-export-symmetry-v1.yaml` `pv validate` clean; no public-API change.

Found via an ultracode EV survey (highest EV: stops silent corruption, S effort, isolated). Release: workspace + facade → 0.40.0; CHANGELOG `[0.40.0]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)