### PR TITLE
fix(quant): Q2_K dequant matches ggml — fixes corrupt Q2_K output — v0.41.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.41.0] - 2026-06-11
+
+### Fixed
+
+- **Q2_K dequantization now matches ggml — fixes corrupt Q2_K output**: both
+  Q2_K dequant impls used a "16 sub-blocks reading `qs[j*4]`" scheme that applied
+  the wrong super-block scale to the wrong 2-bit lanes, producing corrupt F32
+  output (**185/256 elements wrong** vs ggml/candle on a representative block).
+  This silently corrupted every Q2_K/Q2_K_S model (common on HF) — both the
+  format path (`apr tensors`/`inspect`/`validate`/`convert`) and the **inference
+  path** (`apr run`/serve). Fixed both (`aprender-core` format dequant +
+  `aprender-serve` inference dequant) to match ggml `dequantize_row_q2_K` /
+  candle `BlockQ2K::to_float` byte-for-byte (golden falsifiers FT-Q2K-001/002,
+  contract `contracts/q2k-dequant-parity-v1.yaml`).
+
 ## [0.40.1] - 2026-06-11
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,7 +284,7 @@ dependencies = [
 
 [[package]]
 name = "apr-cli"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "alimentar",
  "anyhow",
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "aprender"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "apr-cli",
  "aprender-core",
@@ -411,7 +411,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-bench-compute"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "aprender-core",
  "criterion 0.7.0",
@@ -420,7 +420,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-bench-tokenizer"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "aprender-core",
  "criterion 0.7.0",
@@ -429,7 +429,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cbtop"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "aprender-compute",
@@ -454,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cgp"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "aprender-gpu",
@@ -474,7 +474,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-common"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "lz4_flex 0.11.6",
  "zstd",
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-compute"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "aprender-core",
@@ -531,7 +531,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-compute-xtask"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "bashrs",
@@ -544,7 +544,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-contracts"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "aprender-contracts-macros",
  "criterion 0.5.1",
@@ -559,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-contracts-cli"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "aprender-contracts",
  "clap",
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-contracts-macros"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-core"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "aes-gcm",
  "alimentar",
@@ -632,7 +632,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cuda-edge"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "aprender-gpu",
  "proptest",
@@ -643,7 +643,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cupti"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "bindgen 0.71.1",
  "bitflags 2.11.0",
@@ -653,7 +653,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-data"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-db"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "arrow 57.3.0",
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-distribute"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "arrow 57.3.0",
  "bincode",
@@ -781,7 +781,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-explain"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "aprender-gpu",
  "clap",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-fft"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -808,7 +808,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-gemm-codegen"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-gpu"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "aprender-profile",
  "batuta-common",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-graph"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "aprender-core",
@@ -862,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-image"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-mcp"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -886,9 +886,9 @@ dependencies = [
 
 [[package]]
 name = "aprender-monte-carlo"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
- "aprender 0.40.1",
+ "aprender 0.41.0",
  "assert_cmd",
  "chrono",
  "clap",
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-orchestrate"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "alimentar",
  "anyhow",
@@ -979,7 +979,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-cli"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "aprender-present-yaml",
  "clap",
@@ -992,7 +992,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-core"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "aprender-compute",
  "criterion 0.7.0",
@@ -1005,7 +1005,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-layout"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "aprender-present-core",
  "criterion 0.7.0",
@@ -1016,7 +1016,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-lib"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "aprender-present-core",
  "aprender-present-layout",
@@ -1045,7 +1045,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-terminal"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "aprender-present-core",
  "bitvec",
@@ -1067,7 +1067,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-test"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "aprender-present-core",
  "aprender-present-test-macros",
@@ -1078,7 +1078,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-test-macros"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1087,7 +1087,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-widgets"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "aprender-present-core",
  "aprender-present-yaml",
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-yaml"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "aprender-present-core",
  "proptest",
@@ -1109,7 +1109,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-profile"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "addr2line 0.25.1",
  "anyhow",
@@ -1162,7 +1162,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-profile-core"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "hex",
  "serde",
@@ -1172,7 +1172,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-ptx-debug"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "proptest",
  "thiserror 2.0.18",
@@ -1180,7 +1180,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-certify"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "chrono",
  "proptest",
@@ -1190,7 +1190,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-cli"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "aprender-qa-certify",
  "aprender-qa-gen",
@@ -1209,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-gen"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1226,7 +1226,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-report"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "aprender-qa-gen",
@@ -1244,7 +1244,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-runner"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "aprender-qa-gen",
@@ -1269,14 +1269,14 @@ dependencies = [
 
 [[package]]
 name = "aprender-quant"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "half",
 ]
 
 [[package]]
 name = "aprender-rag"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "async-trait",
  "batuta-common",
@@ -1307,7 +1307,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-rand"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1316,7 +1316,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-registry"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "alimentar",
  "anyhow",
@@ -1346,7 +1346,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-serve"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "alimentar",
  "anyhow",
@@ -1413,7 +1413,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-shell"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "aprender-core",
  "assert_cmd",
@@ -1430,7 +1430,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-simulate"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "bincode",
  "bitflags 2.11.0",
@@ -1469,7 +1469,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-solve"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1478,7 +1478,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-sparse"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1487,7 +1487,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-tensor"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1496,7 +1496,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-cli"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "aprender-test-lib",
  "assert_cmd",
@@ -1524,7 +1524,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-derive"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1534,7 +1534,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-js-gen"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -1550,7 +1550,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-lib"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "aprender-compute",
  "aprender-present-core",
@@ -1594,7 +1594,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-showcase"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "aprender-present-terminal",
  "console_error_panic_hook",
@@ -1611,7 +1611,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "alimentar",
  "approx",
@@ -1678,7 +1678,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-bench"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1695,7 +1695,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-common"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "clap",
  "proptest",
@@ -1707,7 +1707,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-distill"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1728,7 +1728,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-inspect"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1744,7 +1744,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-lora"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-shell"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1776,7 +1776,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-wasm"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "proptest",
  "serde",
@@ -1787,9 +1787,9 @@ dependencies = [
 
 [[package]]
 name = "aprender-tsp"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
- "aprender 0.40.1",
+ "aprender 0.41.0",
  "assert_cmd",
  "clap",
  "crc32fast",
@@ -1802,7 +1802,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-verify"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "chrono",
  "criterion 0.5.1",
@@ -1814,7 +1814,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-verify-ml"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "aprender-core",
  "aprender-profile",
@@ -1858,7 +1858,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-viz"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "approx",
  "aprender-core",
@@ -1893,7 +1893,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "aprender-zram-adaptive",
  "aprender-zram-core",
@@ -1903,7 +1903,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-adaptive"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "aprender-zram-core",
  "proptest",
@@ -1912,7 +1912,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-cli"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "aprender-zram-adaptive",
  "aprender-zram-core",
@@ -1926,7 +1926,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-core"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "aprender-gpu",
  "criterion 0.7.0",
@@ -1938,7 +1938,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-generator"
-version = "0.40.1"
+version = "0.41.0"
 dependencies = [
  "aprender-zram-core",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.40.1"
+version = "0.41.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/paiml/aprender"
@@ -171,7 +171,7 @@ minijinja = { version = "2.14", features = ["loader", "serde"] }
 # Contracts
 provable-contracts = "0.3"
 provable-contracts-macros = "0.3"
-aprender-contracts-macros = { path = "crates/aprender-contracts-macros", version = "0.40.1" }
+aprender-contracts-macros = { path = "crates/aprender-contracts-macros", version = "0.41.0" }
 
 # YAML
 serde_yaml = "0.9"
@@ -183,31 +183,31 @@ hf-hub = { version = "0.4", default-features = false, features = ["ureq"] }
 hf-xet = "1.5.1"
 
 # Workspace-internal crates (paths within the monorepo)
-aprender-compute = { path = "crates/aprender-compute", version = "0.40.1" }
-aprender-gpu = { path = "crates/aprender-gpu", version = "0.40.1" }
-aprender-quant = { path = "crates/aprender-quant", version = "0.40.1" }
-aprender-serve = { path = "crates/aprender-serve", version = "0.40.1" }
-realizar = { path = "crates/aprender-serve", version = "0.40.1", package = "aprender-serve" }
-aprender-train = { path = "crates/aprender-train", version = "0.40.1" }
-entrenar = { path = "crates/aprender-train", version = "0.40.1", package = "aprender-train" }
-aprender-train-common = { path = "crates/aprender-train-common", version = "0.40.1" }
-aprender-train-distill = { path = "crates/aprender-train-distill", version = "0.40.1" }
-aprender-orchestrate = { path = "crates/aprender-orchestrate", version = "0.40.1" }
-aprender-contracts = { path = "crates/aprender-contracts", version = "0.40.1" }
-aprender-profile = { path = "crates/aprender-profile", version = "0.40.1" }
-aprender-profile-core = { path = "crates/aprender-profile-core", version = "0.40.1" }
-aprender-zram-core = { path = "crates/aprender-zram-core", version = "0.40.1" }
-aprender-zram-adaptive = { path = "crates/aprender-zram-adaptive", version = "0.40.1" }
-aprender-present-core = { path = "crates/aprender-present-core", version = "0.40.1" }
-aprender-present-terminal = { path = "crates/aprender-present-terminal", version = "0.40.1" }
-aprender-present-widgets = { path = "crates/aprender-present-widgets", version = "0.40.1" }
-aprender-present-layout = { path = "crates/aprender-present-layout", version = "0.40.1" }
-aprender-present-yaml = { path = "crates/aprender-present-yaml", version = "0.40.1" }
-aprender-present-test = { path = "crates/aprender-present-test", version = "0.40.1" }
-aprender-db = { path = "crates/aprender-db", version = "0.40.1" }
-aprender-graph = { path = "crates/aprender-graph", version = "0.40.1" }
-aprender-rag = { path = "crates/aprender-rag", version = "0.40.1" }
-aprender-data = { path = "crates/aprender-data", version = "0.40.1" }
+aprender-compute = { path = "crates/aprender-compute", version = "0.41.0" }
+aprender-gpu = { path = "crates/aprender-gpu", version = "0.41.0" }
+aprender-quant = { path = "crates/aprender-quant", version = "0.41.0" }
+aprender-serve = { path = "crates/aprender-serve", version = "0.41.0" }
+realizar = { path = "crates/aprender-serve", version = "0.41.0", package = "aprender-serve" }
+aprender-train = { path = "crates/aprender-train", version = "0.41.0" }
+entrenar = { path = "crates/aprender-train", version = "0.41.0", package = "aprender-train" }
+aprender-train-common = { path = "crates/aprender-train-common", version = "0.41.0" }
+aprender-train-distill = { path = "crates/aprender-train-distill", version = "0.41.0" }
+aprender-orchestrate = { path = "crates/aprender-orchestrate", version = "0.41.0" }
+aprender-contracts = { path = "crates/aprender-contracts", version = "0.41.0" }
+aprender-profile = { path = "crates/aprender-profile", version = "0.41.0" }
+aprender-profile-core = { path = "crates/aprender-profile-core", version = "0.41.0" }
+aprender-zram-core = { path = "crates/aprender-zram-core", version = "0.41.0" }
+aprender-zram-adaptive = { path = "crates/aprender-zram-adaptive", version = "0.41.0" }
+aprender-present-core = { path = "crates/aprender-present-core", version = "0.41.0" }
+aprender-present-terminal = { path = "crates/aprender-present-terminal", version = "0.41.0" }
+aprender-present-widgets = { path = "crates/aprender-present-widgets", version = "0.41.0" }
+aprender-present-layout = { path = "crates/aprender-present-layout", version = "0.41.0" }
+aprender-present-yaml = { path = "crates/aprender-present-yaml", version = "0.41.0" }
+aprender-present-test = { path = "crates/aprender-present-test", version = "0.41.0" }
+aprender-db = { path = "crates/aprender-db", version = "0.41.0" }
+aprender-graph = { path = "crates/aprender-graph", version = "0.41.0" }
+aprender-rag = { path = "crates/aprender-rag", version = "0.41.0" }
+aprender-data = { path = "crates/aprender-data", version = "0.41.0" }
 
 # Additional external deps needed by sub-crates
 serde_yaml_ng = "0.10"
@@ -252,25 +252,25 @@ wasmtime = "43"
 bollard = "0.17"
 
 # Old crate name aliases (workspace = true refs in migrated sub-crates)
-trueno-zram-core = { path = "crates/aprender-zram-core", version = "0.40.1", package = "aprender-zram-core" }
-trueno-zram-adaptive = { path = "crates/aprender-zram-adaptive", version = "0.40.1", package = "aprender-zram-adaptive" }
-trueno = { path = "crates/aprender-compute", version = "0.40.1", package = "aprender-compute" }
-presentar-core = { path = "crates/aprender-present-core", version = "0.40.1", package = "aprender-present-core" }
-presentar-terminal = { path = "crates/aprender-present-terminal", version = "0.40.1", package = "aprender-present-terminal" }
-presentar-widgets = { path = "crates/aprender-present-widgets", version = "0.40.1", package = "aprender-present-widgets" }
-presentar-layout = { path = "crates/aprender-present-layout", version = "0.40.1", package = "aprender-present-layout" }
-presentar-yaml = { path = "crates/aprender-present-yaml", version = "0.40.1", package = "aprender-present-yaml" }
-presentar-test = { path = "crates/aprender-present-test", version = "0.40.1", package = "aprender-present-test" }
-presentar-test-macros = { path = "crates/aprender-present-test-macros", version = "0.40.1", package = "aprender-present-test-macros" }
-jugar-probar-derive = { path = "crates/aprender-test-derive", version = "0.40.1", package = "aprender-test-derive" }
-batuta-common = { path = "crates/aprender-common", version = "0.40.1", package = "aprender-common" }
+trueno-zram-core = { path = "crates/aprender-zram-core", version = "0.41.0", package = "aprender-zram-core" }
+trueno-zram-adaptive = { path = "crates/aprender-zram-adaptive", version = "0.41.0", package = "aprender-zram-adaptive" }
+trueno = { path = "crates/aprender-compute", version = "0.41.0", package = "aprender-compute" }
+presentar-core = { path = "crates/aprender-present-core", version = "0.41.0", package = "aprender-present-core" }
+presentar-terminal = { path = "crates/aprender-present-terminal", version = "0.41.0", package = "aprender-present-terminal" }
+presentar-widgets = { path = "crates/aprender-present-widgets", version = "0.41.0", package = "aprender-present-widgets" }
+presentar-layout = { path = "crates/aprender-present-layout", version = "0.41.0", package = "aprender-present-layout" }
+presentar-yaml = { path = "crates/aprender-present-yaml", version = "0.41.0", package = "aprender-present-yaml" }
+presentar-test = { path = "crates/aprender-present-test", version = "0.41.0", package = "aprender-present-test" }
+presentar-test-macros = { path = "crates/aprender-present-test-macros", version = "0.41.0", package = "aprender-present-test-macros" }
+jugar-probar-derive = { path = "crates/aprender-test-derive", version = "0.41.0", package = "aprender-test-derive" }
+batuta-common = { path = "crates/aprender-common", version = "0.41.0", package = "aprender-common" }
 # APR-MONO sibling aliases — MUST use workspace refs, NEVER crates.io versions.
 # Hard-pinning these to crates.io creates a diamond: sub-crates pull older
 # aprender versions → multiple `aprender` crates in Cargo.lock = MUDA.
-renacer = { path = "crates/aprender-profile", version = "0.40.1", package = "aprender-profile" }
-entrenar-lora = { path = "crates/aprender-train-lora", version = "0.40.1", package = "aprender-train-lora" }
-batuta = { path = "crates/aprender-orchestrate", version = "0.40.1", package = "aprender-orchestrate" }
-trueno-graph = { path = "crates/aprender-graph", version = "0.40.1", package = "aprender-graph" }
+renacer = { path = "crates/aprender-profile", version = "0.41.0", package = "aprender-profile" }
+entrenar-lora = { path = "crates/aprender-train-lora", version = "0.41.0", package = "aprender-train-lora" }
+batuta = { path = "crates/aprender-orchestrate", version = "0.41.0", package = "aprender-orchestrate" }
+trueno-graph = { path = "crates/aprender-graph", version = "0.41.0", package = "aprender-graph" }
 
 [workspace.lints.rust]
 # Safety
@@ -428,7 +428,7 @@ semicolon_if_nothing_returned = "allow"  # Style preference
 
 [package]
 name = "aprender"
-version = "0.40.1"
+version = "0.41.0"
 edition = "2021"
 rust-version = "1.89"
 authors = ["Noah Gift <noah@paiml.com>"]
@@ -458,7 +458,7 @@ required-features = ["cli"]
 # (e.g. apr-cookbook, downstream apps) don't pull apr-cli's heavy transitive
 # dep graph (renacer/profile/inference/zram/visualization). `cargo install
 # aprender` still works because `cli` is in default features. See GH-1599.
-apr-cli = { path = "crates/apr-cli", version = "0.40.1", default-features = true, optional = true }
+apr-cli = { path = "crates/apr-cli", version = "0.41.0", default-features = true, optional = true }
 # Core ML library (lib name = "aprender")
 aprender_ml = { path = "crates/aprender-core", version = ">=0.29", package = "aprender-core" }
 

--- a/contracts/q2k-dequant-parity-v1.yaml
+++ b/contracts/q2k-dequant-parity-v1.yaml
@@ -1,0 +1,91 @@
+metadata:
+  version: 1.0.0
+  created: '2026-06-11'
+  author: PAIML Engineering
+  description: |
+    Q2_K (GGML type 10) dequantization must match ggml `dequantize_row_q2_K`
+    (and candle `BlockQ2K::to_float`) byte-for-byte. Both aprender Q2_K dequant
+    impls previously used a "16 sub-blocks reading qs[j*4]" scheme that applied
+    the WRONG super-block scale to the WRONG 2-bit lanes, producing corrupt F32
+    output (185/256 elements wrong vs ggml on a representative block — genuinely
+    wrong values, not a reordering). That corruption reached every Q2_K/Q2_K_S
+    model via apr tensors/inspect/validate/convert (format path) and via
+    `apr run`/serve inference (inference path).
+
+    Correct ordering: 256 elements in two groups of 128, each over a 32-byte qs
+    window; within a group, 4 sub-iterations at shift 0/2/4/6, each consuming TWO
+    scale bytes (one for the window's low 16 bytes, one for its high 16), with
+    `y = d*(sc & 0xF)*q - dmin*(sc >> 4)`.
+  references:
+  - 'crates/aprender-core/src/format/gguf/dequantize.rs — dequantize_q2_k (format path)'
+  - 'crates/aprender-serve/src/quantize/dequant_q4k.rs — dequantize_q2_k (inference path)'
+  - 'ggml-quants.c dequantize_row_q2_K / candle-core k_quants.rs BlockQ2K::to_float (reference)'
+  - 'contracts/q3k-dequant-v1.yaml — sibling K-quant dequant contract'
+
+kind: KernelContract
+name: q2k-dequant-parity
+version: 1.0.0
+scope: aprender-core + aprender-serve Q2_K dequantization (GGML type 10)
+
+equations:
+  q2k_dequant_ordering:
+    formula: |
+      For a 256-element super-block (84 bytes: scales[16], qs[64], d:f16,
+      dmin:f16), output element n is produced in ggml order: group g=n/128 over
+      qs window qs[g*32 .. g*32+32]; sub-iter j=(n%128)/32 at shift 2*j; the
+      window's low/high 16 bytes use scale bytes scales[8g + 2j] / scales[8g +
+      2j + 1]; value = d*(sc & 0xF)*((q >> shift) & 3) - dmin*(sc >> 4).
+    domain: 84-byte Q2_K super-block
+    codomain: 256 f32 values
+    invariants:
+    - 'output matches ggml dequantize_row_q2_K / candle BlockQ2K::to_float elementwise'
+    - 'both the format-path and inference-path impls produce identical output'
+    - 'NOT the old "16 sub-blocks reading qs[j*4]" ordering'
+    lean_theorem: Theorems.Q2K_Dequant_Ordering
+
+proof_obligations:
+- type: invariant
+  property: format-path Q2_K dequant matches ggml
+  formal: |
+    aprender-core dequantize_q2_k on a representative block equals the ggml
+    reference elementwise within 1e-6.
+- type: invariant
+  property: inference-path Q2_K dequant matches ggml
+  formal: |
+    aprender-serve dequantize_q2_k on the same block equals the ggml reference
+    elementwise within 1e-6 (so Q2_K inference is no longer corrupt).
+
+falsification_tests:
+- id: FT-Q2K-001
+  rule: format-path Q2_K dequant matches the ggml ordering
+  prediction: |
+    aprender-core dequantize_q2_k on an 84-byte block (varied scales/qs,
+    d=1.0, dmin=0.5) equals the ggml reference; the old scheme was 185/256 off.
+  if_fails: 'the inner loop reverted to the qs[j*4] sub-block scheme.'
+  evidence: cargo test -p aprender-core --lib test_dequantize_q2_k_ggml_golden
+- id: FT-Q2K-002
+  rule: inference-path Q2_K dequant matches the ggml ordering
+  prediction: |
+    aprender-serve dequantize_q2_k on the same block equals the ggml reference.
+  if_fails: 'the serve quantize/dequant_q4k.rs Q2_K branch reverted.'
+  evidence: cargo test -p aprender-serve --lib test_dequantize_q2_k_ggml_golden
+
+kani_harnesses:
+- id: KANI-Q2K-001
+  obligation: exactly 256 outputs, no out-of-bounds
+  property: |
+    For any 84-byte block, dequantize_q2_k consumes scales[0..16], qs[0..64]
+    fully (is reaches 16, qs index reaches 64) and writes exactly 256 outputs;
+    no slice index exceeds bounds.
+  bound: 1
+  strategy: compositional
+  solver: cadical
+  harness: verify_q2k_indices_in_bounds
+
+qa_gate:
+  id: F-Q2K-001
+  name: q2k-dequant-parity-v1 Contract
+  description: Q2_K dequant (format + inference paths) must match ggml byte-for-byte, never the old corrupt qs[j*4] ordering.
+  checks:
+  - validation
+  - falsification

--- a/crates/apr-cli/Cargo.toml
+++ b/crates/apr-cli/Cargo.toml
@@ -103,10 +103,10 @@ libc = "0.2"
 
 [dependencies]
 # Core aprender library
-aprender = { path = "../aprender-core", version = "0.40.1", package = "aprender-core", default-features = true, features = ["format-compression"] }
+aprender = { path = "../aprender-core", version = "0.41.0", package = "aprender-core", default-features = true, features = ["format-compression"] }
 
 # MCP (Model Context Protocol) server — `apr mcp` subcommand
-aprender-mcp = { path = "../aprender-mcp", version = "0.40.1" }
+aprender-mcp = { path = "../aprender-mcp", version = "0.41.0" }
 async-stream = "0.3"
 provable-contracts-macros = "0.3"
 

--- a/crates/aprender-bench-compute/Cargo.toml
+++ b/crates/aprender-bench-compute/Cargo.toml
@@ -11,7 +11,7 @@ disallowed_methods = "allow"
 
 [dependencies]
 # The implementation under test
-aprender = { path = "../aprender-core", version = "0.40.1", package = "aprender-core", features = ["format-quantize"] }
+aprender = { path = "../aprender-core", version = "0.41.0", package = "aprender-core", features = ["format-quantize"] }
 
 # Reference implementation for A/B comparison
 # Pure Rust (no BLAS) to keep comparison fair — both are pure Rust SIMD

--- a/crates/aprender-bench-tokenizer/Cargo.toml
+++ b/crates/aprender-bench-tokenizer/Cargo.toml
@@ -11,7 +11,7 @@ disallowed_methods = "allow"
 
 [dependencies]
 # The implementation under test
-aprender = { path = "../aprender-core", version = "0.40.1", package = "aprender-core" }
+aprender = { path = "../aprender-core", version = "0.41.0", package = "aprender-core" }
 
 # HuggingFace reference for A/B comparison
 # Regular dep (not dev-dep) because [[bench]] harness=false binaries can't see dev-deps

--- a/crates/aprender-cbtop/Cargo.toml
+++ b/crates/aprender-cbtop/Cargo.toml
@@ -23,8 +23,8 @@ presentar-core = "0.3"
 presentar-terminal = "0.3"
 
 # Compute backends
-trueno = { version = "0.40.1", path = "../aprender-compute", package = "aprender-compute" }
-trueno-gpu = { version = "0.40.1", path = "../aprender-gpu", package = "aprender-gpu", optional = true }
+trueno = { version = "0.41.0", path = "../aprender-compute", package = "aprender-compute" }
+trueno-gpu = { version = "0.41.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true }
 
 # Terminal handling
 crossterm = "0.28"

--- a/crates/aprender-cgp/Cargo.toml
+++ b/crates/aprender-cgp/Cargo.toml
@@ -36,7 +36,7 @@ num_cpus = "1.17"
 comfy-table = "7"
 colored = "3"
 # GPU profiling: direct cuBLAS measurement (OWN THE STACK)
-trueno-gpu = { path = "../aprender-gpu", version = "0.40.1", features = ["cuda"], optional = true, package = "aprender-gpu" }
+trueno-gpu = { path = "../aprender-gpu", version = "0.41.0", features = ["cuda"], optional = true, package = "aprender-gpu" }
 
 [features]
 default = []

--- a/crates/aprender-compute/Cargo.toml
+++ b/crates/aprender-compute/Cargo.toml
@@ -38,11 +38,11 @@ futures-intrusive = { version = "0.5", optional = true }
 wasm-bindgen-futures = { version = "0.4", optional = true }
 wasm-bindgen = { version = "0.2", optional = true }
 # Native CUDA monitoring via trueno-gpu (TRUENO-SPEC-010)
-trueno-gpu = { version = "0.40.1", path = "../aprender-gpu", optional = true, package = "aprender-gpu" }
+trueno-gpu = { version = "0.41.0", path = "../aprender-gpu", optional = true, package = "aprender-gpu" }
 # PMAT-336: Provable contracts compile-time enforcement
 provable-contracts-macros = "0.3"
 # P1a: Sovereign GEMM microkernel codegen (compile-time shape specialization)
-trueno-gemm-codegen = { version = "0.40.1", path = "../aprender-gemm-codegen", package = "aprender-gemm-codegen" }
+trueno-gemm-codegen = { version = "0.41.0", path = "../aprender-gemm-codegen", package = "aprender-gemm-codegen" }
 # Tracing/profiling support (renacer integration)
 tracing = { version = "0.1", optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"], optional = true }
@@ -54,7 +54,7 @@ presentar-core = { version = "0.3", optional = true }
 # Stress test reporting types compatible with renacer (TRUENO-SPEC-025)
 # Note: renacer 0.9.1 has compilation issue; using compatible local types instead
 dhat = { version = "0.3", optional = true }
-trueno-quant = { version = "0.40.1", path = "../aprender-quant", package = "aprender-quant" }
+trueno-quant = { version = "0.41.0", path = "../aprender-quant", package = "aprender-quant" }
 num_cpus = "1.17.0"
 anyhow = "1.0.100"
 # Hardware capability detection (PMAT-447)
@@ -62,7 +62,7 @@ chrono = "0.4"
 toml = "0.8"
 # ML tuner integration (SHOWCASE-BRICK-001, Section 12)
 # Uses aprender 0.24.0 RandomForest for learned optimization
-aprender = { path = "../aprender-core", version = "0.40.1", package = "aprender-core", optional = true, default-features = false }
+aprender = { path = "../aprender-core", version = "0.41.0", package = "aprender-core", optional = true, default-features = false }
 # Execution path graph (PAR-201, Section E.7)
 trueno-graph = { workspace = true, optional = true }
 # TUI visualization for execution graphs (PAR-201)
@@ -90,10 +90,10 @@ nalgebra = "0.34"  # For eigendecomposition benchmark comparison
 simular = "0.2.0"
 regex = "1.11"  # For PTX/WGSL pattern validation in falsification tests
 # GPU edge-case test framework (TCE-001)
-trueno-cuda-edge = { version = "0.40.1", path = "../aprender-cuda-edge", package = "aprender-cuda-edge" }
+trueno-cuda-edge = { version = "0.41.0", path = "../aprender-cuda-edge", package = "aprender-cuda-edge" }
 # Sparse and solver crates for contract tests
-trueno-sparse = { version = "0.40.1", path = "../aprender-sparse", package = "aprender-sparse" }
-trueno-solve = { version = "0.40.1", path = "../aprender-solve", package = "aprender-solve" }
+trueno-sparse = { version = "0.41.0", path = "../aprender-sparse", package = "aprender-sparse" }
+trueno-solve = { version = "0.41.0", path = "../aprender-solve", package = "aprender-solve" }
 ndarray = "0.17.2"
 faer = "0.24"  # For GEMM benchmark comparison (fastest pure-Rust BLAS)
 matrixmultiply = "0.3"  # Direct matrixmultiply crate benchmark (engine behind ndarray)

--- a/crates/aprender-contracts-cli/Cargo.toml
+++ b/crates/aprender-contracts-cli/Cargo.toml
@@ -13,7 +13,7 @@ name = "pv"
 path = "src/main.rs"
 
 [dependencies]
-aprender-contracts = { path = "../aprender-contracts", version = "0.40.1" }
+aprender-contracts = { path = "../aprender-contracts", version = "0.41.0" }
 clap = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }

--- a/crates/aprender-contracts/Cargo.toml
+++ b/crates/aprender-contracts/Cargo.toml
@@ -19,7 +19,7 @@ kani = []
 name = "provable_contracts"
 
 [dependencies]
-provable-contracts-macros = { path = "../aprender-contracts-macros", version = "0.40.1", package = "aprender-contracts-macros" }
+provable-contracts-macros = { path = "../aprender-contracts-macros", version = "0.41.0", package = "aprender-contracts-macros" }
 regex = "1"
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/aprender-core/src/format/gguf/dequant_f16_tests.rs
+++ b/crates/aprender-core/src/format/gguf/dequant_f16_tests.rs
@@ -264,6 +264,65 @@ mod tests {
         assert!(result.is_err());
     }
 
+    /// Reference Q2_K dequant matching ggml `dequantize_row_q2_K` /
+    /// candle `BlockQ2K::to_float` — the ordering the production code must
+    /// follow. Two groups of 128 over a 32-byte qs window each; 4 sub-iters at
+    /// shift 0/2/4/6; two scale bytes per sub-iter (low/high 16 of the window).
+    fn q2k_ggml_reference(scales: &[u8], qs: &[u8], d: f32, dmin: f32) -> Vec<f32> {
+        let mut y = Vec::with_capacity(256);
+        let mut is = 0usize;
+        for group in 0..2 {
+            let chunk = &qs[group * 32..group * 32 + 32];
+            let mut shift = 0u8;
+            for _ in 0..4 {
+                let sc = scales[is];
+                is += 1;
+                let dl = d * f32::from(sc & 0x0F);
+                let ml = dmin * f32::from(sc >> 4);
+                for &q in &chunk[0..16] {
+                    y.push(dl * f32::from((q >> shift) & 0x03) - ml);
+                }
+                let sc = scales[is];
+                is += 1;
+                let dl = d * f32::from(sc & 0x0F);
+                let ml = dmin * f32::from(sc >> 4);
+                for &q in &chunk[16..32] {
+                    y.push(dl * f32::from((q >> shift) & 0x03) - ml);
+                }
+                shift += 2;
+            }
+        }
+        y
+    }
+
+    /// FT-Q2K-001: Q2_K dequant must match ggml/candle byte-for-byte. The prior
+    /// "16 sub-blocks reading qs[j*4+l]" scheme applied the wrong scale to the
+    /// wrong 2-bit lanes and produced 185/256 wrong values (corrupt weights →
+    /// broken inference for Q2_K models). Pre-fix this test FAILS; post-fix PASS.
+    #[test]
+    fn test_dequantize_q2_k_ggml_golden() {
+        // 84-byte Q2_K block: [16 scales][64 qs][d:f16][dmin:f16].
+        let scales: Vec<u8> = (0u8..16).map(|i| i.wrapping_mul(9).wrapping_add(5)).collect();
+        let qs: Vec<u8> = (0u8..64).map(|i| i.wrapping_mul(7).wrapping_add(1)).collect();
+        let mut data = Vec::with_capacity(84);
+        data.extend_from_slice(&scales);
+        data.extend_from_slice(&qs);
+        data.extend_from_slice(&0x3C00u16.to_le_bytes()); // d = 1.0
+        data.extend_from_slice(&0x3800u16.to_le_bytes()); // dmin = 0.5
+        assert_eq!(data.len(), 84);
+
+        // 0x3C00 = 1.0, 0x3800 = 0.5 (exact f16 normals; safe_f16_scale agrees).
+        let expected = q2k_ggml_reference(&scales, &qs, 1.0, 0.5);
+        let got = dequantize_q2_k(&data, 0, 256).expect("dequant");
+        assert_eq!(got.len(), 256);
+        for (i, (g, e)) in got.iter().zip(expected.iter()).enumerate() {
+            assert!(
+                (g - e).abs() < 1e-6,
+                "Q2_K elem {i}: got {g}, want {e} (must match ggml dequantize_row_q2_K ordering)"
+            );
+        }
+    }
+
     // =========================================================================
     // Dequantize Q3_K
     // =========================================================================

--- a/crates/aprender-core/src/format/gguf/dequantize.rs
+++ b/crates/aprender-core/src/format/gguf/dequantize.rs
@@ -108,18 +108,33 @@ pub(crate) fn dequantize_q2_k(data: &[u8], start: usize, num_elements: usize) ->
         let dmin = safe_f16_scale(u16::from_le_bytes([data[offset + 2], data[offset + 3]]));
         offset += 4;
 
-        // Dequantize 16 sub-blocks of 16 elements
-        for j in 0..16 {
-            let sc_byte = scales_bytes[j];
-            let scale = d * f32::from(sc_byte & 0x0F);
-            let min_val = dmin * f32::from(sc_byte >> 4);
-
-            for l in 0..4 {
-                let q_byte = qs[j * 4 + l];
-                for k in 0..4 {
-                    let q = (q_byte >> (k * 2)) & 0x03;
-                    result.push(f32::from(q) * scale - min_val);
+        // ggml `dequantize_row_q2_K` ordering (mirrors candle BlockQ2K::to_float
+        // and llama.cpp ggml-quants.c): two groups of 128 elements, each over a
+        // 32-byte qs window. Within a group, 4 sub-iterations at shift 0/2/4/6,
+        // each consuming TWO scale bytes — one for the window's low 16 bytes and
+        // one for its high 16 bytes. The previous "16 sub-blocks reading
+        // qs[j*4+l]" scheme applied the wrong scale to the wrong 2-bit lanes and
+        // produced corrupt output (185/256 elements wrong vs ggml).
+        let mut is = 0usize;
+        for group in 0..2 {
+            let chunk = &qs[group * 32..group * 32 + 32];
+            let mut shift = 0u8;
+            for _ in 0..4 {
+                let sc = scales_bytes[is];
+                is += 1;
+                let dl = d * f32::from(sc & 0x0F);
+                let ml = dmin * f32::from(sc >> 4);
+                for &q in &chunk[0..16] {
+                    result.push(dl * f32::from((q >> shift) & 0x03) - ml);
                 }
+                let sc = scales_bytes[is];
+                is += 1;
+                let dl = d * f32::from(sc & 0x0F);
+                let ml = dmin * f32::from(sc >> 4);
+                for &q in &chunk[16..32] {
+                    result.push(dl * f32::from((q >> shift) & 0x03) - ml);
+                }
+                shift += 2;
             }
         }
     }

--- a/crates/aprender-cuda-edge/Cargo.toml
+++ b/crates/aprender-cuda-edge/Cargo.toml
@@ -15,7 +15,7 @@ name = "trueno_cuda_edge"
 [dependencies]
 thiserror = "2.0"
 serde = { version = "1.0", features = ["derive"] }
-trueno-gpu = { version = "0.40.1", path = "../aprender-gpu", package = "aprender-gpu", optional = true }
+trueno-gpu = { version = "0.41.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true }
 
 [dev-dependencies]
 proptest = "1.6"

--- a/crates/aprender-explain/Cargo.toml
+++ b/crates/aprender-explain/Cargo.toml
@@ -25,7 +25,7 @@ presentar-terminal = "0.3"
 crossterm = "0.28"
 
 # Internal dependency for PTX generation
-trueno-gpu = { version = "0.40.1", path = "../aprender-gpu", package = "aprender-gpu", features = ["cuda"] }
+trueno-gpu = { version = "0.41.0", path = "../aprender-gpu", package = "aprender-gpu", features = ["cuda"] }
 
 [dev-dependencies]
 proptest = "1.4"

--- a/crates/aprender-graph/Cargo.toml
+++ b/crates/aprender-graph/Cargo.toml
@@ -28,7 +28,7 @@ anyhow = "1"
 thiserror = "2"
 
 # Phase 2+ dependencies
-aprender = { path = "../aprender-core", version = "0.40.1", package = "aprender-core" }                                        # Sparse matrix ops, PageRank
+aprender = { path = "../aprender-core", version = "0.41.0", package = "aprender-core" }                                        # Sparse matrix ops, PageRank
 trueno = "0.17"                                          # SIMD primitives
 trueno-db = "0.3.17"                                     # Columnar storage
 

--- a/crates/aprender-monte-carlo/Cargo.toml
+++ b/crates/aprender-monte-carlo/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 name = "aprender-monte-carlo"
 
 [dependencies]
-aprender = { path = "../../", version = "0.40.1" }
+aprender = { path = "../../", version = "0.41.0" }
 clap = { version = "4", features = ["derive"] }
 rand = "0.9"
 rand_chacha = "0.9"

--- a/crates/aprender-orchestrate/Cargo.toml
+++ b/crates/aprender-orchestrate/Cargo.toml
@@ -117,7 +117,7 @@ pacha = { version = "0.2", optional = true }
 realizar = { version = "0.8", optional = true, features = ["cuda"] }
 
 # ML algorithms and training (native-only)
-aprender = { path = "../aprender-core", version = "0.40.1", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.41.0", package = "aprender-core", optional = true }
 entrenar = { workspace = true, optional = true }
 alimentar = { version = "0.2", optional = true }
 

--- a/crates/aprender-profile/Cargo.toml
+++ b/crates/aprender-profile/Cargo.toml
@@ -74,7 +74,7 @@ trueno = { version = "0.17" }
 
 # Machine learning for anomaly detection (Sprint 23)
 # GH-581: Use path dep to avoid trueno version skew with local workspace
-aprender = { path = "../aprender-core", version = "0.40.1", package = "aprender-core" }
+aprender = { path = "../aprender-core", version = "0.41.0", package = "aprender-core" }
 
 # Lock-free data structures for ring buffer (Sprint 40)
 crossbeam = { version = "0.8", default-features = false, features = ["crossbeam-channel", "crossbeam-queue", "std"] }

--- a/crates/aprender-qa-runner/Cargo.toml
+++ b/crates/aprender-qa-runner/Cargo.toml
@@ -29,7 +29,7 @@ sha2 = "0.10"
 regex = { workspace = true }
 num_cpus = "1.16"
 safetensors = { workspace = true }
-jugar-probar = { version = "0.40.1", path = "../aprender-test-lib", package = "aprender-test-lib", features = ["llm-types"] }
+jugar-probar = { version = "0.41.0", path = "../aprender-test-lib", package = "aprender-test-lib", features = ["llm-types"] }
 # Test fixtures dependencies (optional)
 tempfile = { version = "3", optional = true }
 half = { version = "2.4", optional = true }

--- a/crates/aprender-registry/Cargo.toml
+++ b/crates/aprender-registry/Cargo.toml
@@ -42,7 +42,7 @@ zstd = { version = "0.13", optional = true }
 clap = { version = "4", features = ["derive"], optional = true }
 
 # Ecosystem integration
-aprender = { path = "../aprender-core", version = "0.40.1", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.41.0", package = "aprender-core", optional = true }
 alimentar = { version = "0.2.3", optional = true }
 
 # HTTP client (optional)

--- a/crates/aprender-serve/Cargo.toml
+++ b/crates/aprender-serve/Cargo.toml
@@ -39,7 +39,7 @@ name = "realizar"
 trueno = { version = "0.17", features = ["gpu"] }
 # CUDA PTX generation and runtime for NVIDIA GPUs (optional, pure Rust, no LLVM/nvcc)
 # v0.4.12: BatchedQ6K, MultiWarp, RopeNeox, FlashDecoding kernels
-trueno-gpu = { version = "0.40.1", path = "../aprender-gpu", package = "aprender-gpu", optional = true, features = ["cuda"] }  # APR-MONO single-source-of-truth
+trueno-gpu = { version = "0.41.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true, features = ["cuda"] }  # APR-MONO single-source-of-truth
 # KV cache storage (for attention caching)
 trueno-db = { version = "0.3.16", optional = true }
 # K-quantization formats (Q4_K, Q5_K, Q6_K) - Toyota Way: ONE source of truth
@@ -53,7 +53,7 @@ renacer-core = { version = "0.1" }
 
 # ML algorithms and .apr model format (optional for aprender model serving)
 # v0.24.1: chat templates, GGUF tokenizer preservation (local may be newer)
-aprender = { path = "../aprender-core", version = "0.40.1", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.41.0", package = "aprender-core", optional = true }
 
 # Data loading library (optional for data pipeline examples)
 alimentar = { version = "0.2", optional = true, default-features = false, features = ["local", "shuffle"] }

--- a/crates/aprender-serve/src/quantize/dequant_q4k.rs
+++ b/crates/aprender-serve/src/quantize/dequant_q4k.rs
@@ -208,27 +208,35 @@ pub fn dequantize_q2_k(data: &[u8]) -> Result<Vec<f32>> {
         let d = read_f16(&data[sb_start + 80..sb_start + 82]);
         let dmin = read_f16(&data[sb_start + 82..sb_start + 84]);
 
-        for j in 0..16 {
-            let sc = (scales_data[j] & 0x0F) as f32;
-            let m = (scales_data[j] >> 4) as f32;
-
-            let d_sc = d * sc;
-            let dm = dmin * m;
-
-            let qs_offset = j * 4;
-
-            for k in 0..4 {
-                let q_byte = qs[qs_offset + k];
-                let q0 = (q_byte & 0x03) as f32;
-                let q1 = ((q_byte >> 2) & 0x03) as f32;
-                let q2 = ((q_byte >> 4) & 0x03) as f32;
-                let q3 = ((q_byte >> 6) & 0x03) as f32;
-
-                let base_idx = out_start + j * 16 + k * 4;
-                result[base_idx] = d_sc * q0 - dm;
-                result[base_idx + 1] = d_sc * q1 - dm;
-                result[base_idx + 2] = d_sc * q2 - dm;
-                result[base_idx + 3] = d_sc * q3 - dm;
+        // ggml `dequantize_row_q2_K` ordering (matches candle BlockQ2K::to_float
+        // and the aprender-core format-path fix): two groups of 128 over a
+        // 32-byte qs window; 4 sub-iters at shift 0/2/4/6; two scale bytes per
+        // sub-iter (low/high 16 of the window). The prior "16 sub-blocks reading
+        // qs[j*4]" scheme applied the wrong scale to the wrong 2-bit lanes →
+        // corrupt weights → broken Q2_K inference.
+        let mut oi = out_start;
+        let mut is = 0usize;
+        for group in 0..2 {
+            let chunk = &qs[group * 32..group * 32 + 32];
+            let mut shift = 0u8;
+            for _ in 0..4 {
+                let sc = scales_data[is];
+                is += 1;
+                let dl = d * f32::from(sc & 0x0F);
+                let ml = dmin * f32::from(sc >> 4);
+                for &q in &chunk[0..16] {
+                    result[oi] = dl * f32::from((q >> shift) & 0x03) - ml;
+                    oi += 1;
+                }
+                let sc = scales_data[is];
+                is += 1;
+                let dl = d * f32::from(sc & 0x0F);
+                let ml = dmin * f32::from(sc >> 4);
+                for &q in &chunk[16..32] {
+                    result[oi] = dl * f32::from((q >> shift) & 0x03) - ml;
+                    oi += 1;
+                }
+                shift += 2;
             }
         }
     }

--- a/crates/aprender-serve/src/quantize/tests/dequantize_04.rs
+++ b/crates/aprender-serve/src/quantize/tests/dequantize_04.rs
@@ -201,6 +201,56 @@ fn test_dequantize_q2_k_single_block() {
     assert_eq!(values.len(), 256); // QK_K = 256
 }
 
+/// FT-Q2K-002 (inference path): serve dequantize_q2_k must match ggml
+/// `dequantize_row_q2_K` / candle byte-for-byte. The prior scheme applied the
+/// wrong scale to the wrong 2-bit lanes (185/256 elements wrong → corrupt Q2_K
+/// inference).
+#[test]
+fn test_dequantize_q2_k_ggml_golden() {
+    fn reference(scales: &[u8], qs: &[u8], d: f32, dmin: f32) -> Vec<f32> {
+        let mut y = Vec::with_capacity(256);
+        let mut is = 0usize;
+        for group in 0..2 {
+            let chunk = &qs[group * 32..group * 32 + 32];
+            let mut shift = 0u8;
+            for _ in 0..4 {
+                let sc = scales[is];
+                is += 1;
+                let dl = d * f32::from(sc & 0x0F);
+                let ml = dmin * f32::from(sc >> 4);
+                for &q in &chunk[0..16] {
+                    y.push(dl * f32::from((q >> shift) & 0x03) - ml);
+                }
+                let sc = scales[is];
+                is += 1;
+                let dl = d * f32::from(sc & 0x0F);
+                let ml = dmin * f32::from(sc >> 4);
+                for &q in &chunk[16..32] {
+                    y.push(dl * f32::from((q >> shift) & 0x03) - ml);
+                }
+                shift += 2;
+            }
+        }
+        y
+    }
+    let scales: Vec<u8> = (0u8..16).map(|i| i.wrapping_mul(9).wrapping_add(5)).collect();
+    let qs: Vec<u8> = (0u8..64).map(|i| i.wrapping_mul(7).wrapping_add(1)).collect();
+    let mut data = Vec::with_capacity(84);
+    data.extend_from_slice(&scales);
+    data.extend_from_slice(&qs);
+    data.extend_from_slice(&0x3C00u16.to_le_bytes()); // d = 1.0
+    data.extend_from_slice(&0x3800u16.to_le_bytes()); // dmin = 0.5
+    let expected = reference(&scales, &qs, 1.0, 0.5);
+    let got = dequantize_q2_k(&data).expect("dequant");
+    assert_eq!(got.len(), 256);
+    for (i, (g, e)) in got.iter().zip(expected.iter()).enumerate() {
+        assert!(
+            (g - e).abs() < 1e-6,
+            "Q2_K elem {i}: got {g}, want {e} (ggml ordering)"
+        );
+    }
+}
+
 #[test]
 fn test_dequantize_q2_k_multiple_blocks() {
     let data = vec![0u8; 84 * 2];

--- a/crates/aprender-shell/Cargo.toml
+++ b/crates/aprender-shell/Cargo.toml
@@ -24,7 +24,7 @@ harness = false
 
 [dependencies]
 # Use path for local dev, crates.io for release
-aprender = { path = "../aprender-core", version = "0.40.1", package = "aprender-core", features = ["format-encryption", "format-compression", "format-homomorphic"] }
+aprender = { path = "../aprender-core", version = "0.41.0", package = "aprender-core", features = ["format-encryption", "format-compression", "format-homomorphic"] }
 clap = { version = "4", features = ["derive"] }
 dirs = "5"
 serde = { version = "1", features = ["derive"] }

--- a/crates/aprender-test-cli/Cargo.toml
+++ b/crates/aprender-test-cli/Cargo.toml
@@ -24,7 +24,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Core library (was: jugar-probar) — dep key preserves Rust identifier
-jugar-probar = { path = "../aprender-test-lib", version = "0.40.1", package = "aprender-test-lib" }
+jugar-probar = { path = "../aprender-test-lib", version = "0.41.0", package = "aprender-test-lib" }
 
 # CLI framework
 clap = { workspace = true }

--- a/crates/aprender-train-bench/Cargo.toml
+++ b/crates/aprender-train-bench/Cargo.toml
@@ -19,8 +19,8 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-entrenar = { version = "0.40.1", path = "../aprender-train", package = "aprender-train" }
-entrenar-common = { version = "0.40.1", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar = { version = "0.41.0", path = "../aprender-train", package = "aprender-train" }
+entrenar-common = { version = "0.41.0", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/aprender-train-distill/Cargo.toml
+++ b/crates/aprender-train-distill/Cargo.toml
@@ -32,8 +32,8 @@ cuda = ["entrenar/cuda"]
 shard-batch-source = []
 
 [dependencies]
-entrenar = { version = "0.40.1", path = "../aprender-train", package = "aprender-train" }
-entrenar-common = { version = "0.40.1", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar = { version = "0.41.0", path = "../aprender-train", package = "aprender-train" }
+entrenar-common = { version = "0.41.0", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/aprender-train-inspect/Cargo.toml
+++ b/crates/aprender-train-inspect/Cargo.toml
@@ -19,8 +19,8 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-entrenar = { version = "0.40.1", path = "../aprender-train", package = "aprender-train" }
-entrenar-common = { version = "0.40.1", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar = { version = "0.41.0", path = "../aprender-train", package = "aprender-train" }
+entrenar-common = { version = "0.41.0", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/aprender-train-lora/Cargo.toml
+++ b/crates/aprender-train-lora/Cargo.toml
@@ -19,8 +19,8 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-entrenar = { version = "0.40.1", path = "../aprender-train", package = "aprender-train" }
-entrenar-common = { version = "0.40.1", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar = { version = "0.41.0", path = "../aprender-train", package = "aprender-train" }
+entrenar-common = { version = "0.41.0", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/aprender-train-shell/Cargo.toml
+++ b/crates/aprender-train-shell/Cargo.toml
@@ -19,8 +19,8 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-entrenar = { version = "0.40.1", path = "../aprender-train", package = "aprender-train" }
-entrenar-common = { version = "0.40.1", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar = { version = "0.41.0", path = "../aprender-train", package = "aprender-train" }
+entrenar-common = { version = "0.41.0", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 rustyline = "14"
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/aprender-train/Cargo.toml
+++ b/crates/aprender-train/Cargo.toml
@@ -75,9 +75,9 @@ provable-contracts-macros = { version = "0.2" }
 # Core PAIML stack
 ndarray = "0.16"
 trueno = { version = "0.17", features = ["parallel"] }  # SIMD-accelerated compute
-trueno-gpu = { version = "0.40.1", path = "../aprender-gpu", package = "aprender-gpu", optional = true }  # CUDA compute (APR-MONO single-source-of-truth)
+trueno-gpu = { version = "0.41.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true }  # CUDA compute (APR-MONO single-source-of-truth)
 realizar = { version = "0.8", optional = true }  # CUDA inference engine
-aprender = { path = "../aprender-core", version = "0.40.1", package = "aprender-core" }  # ML interpret module + .apr format + tokenizers
+aprender = { path = "../aprender-core", version = "0.41.0", package = "aprender-core" }  # ML interpret module + .apr format + tokenizers
 trueno-viz = { version = "0.2", features = ["terminal"] }  # Terminal visualization
 presentar-terminal = { version = "0.3.5", optional = true }  # Sovereign TUI framework (gated by "tui" feature)
 presentar-core = "0.3.4"  # Presentar core traits (crates.io — path removed, presentar restructured)

--- a/crates/aprender-tsp/Cargo.toml
+++ b/crates/aprender-tsp/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 name = "aprender-tsp"
 
 [dependencies]
-aprender = { path = "../../", version = "0.40.1" }
+aprender = { path = "../../", version = "0.41.0" }
 clap = { version = "4", features = ["derive"] }
 rand = "0.9"
 crc32fast = "1.4"

--- a/crates/aprender-verify-ml/Cargo.toml
+++ b/crates/aprender-verify-ml/Cargo.toml
@@ -50,7 +50,7 @@ uuid = { version = "1.11", features = ["v4", "serde"] }
 trueno = "0.7.3"
 
 # Machine learning for bug prediction (optional)
-aprender = { path = "../aprender-core", version = "0.40.1", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.41.0", package = "aprender-core", optional = true }
 
 # LLM fine-tuning integration (optional)
 entrenar = { workspace = true, optional = true }

--- a/crates/aprender-viz/Cargo.toml
+++ b/crates/aprender-viz/Cargo.toml
@@ -29,7 +29,7 @@ base64 = "0.22"
 thiserror = "2.0"
 
 # Optional: ML integration
-aprender = { path = "../aprender-core", version = "0.40.1", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.41.0", package = "aprender-core", optional = true }
 
 # Optional: Graph integration
 trueno-graph = { workspace = true, optional = true, default-features = false }


### PR DESCRIPTION
## v0.41.0 — Q2_K dequantization no longer corrupt

**High-value corruption fix.** Both Q2_K dequant impls used a "16 sub-blocks reading `qs[j*4]`" scheme that applied the **wrong super-block scale to the wrong 2-bit lanes** → corrupt F32 output (**185/256 elements wrong** vs ggml/candle on a representative block — genuinely wrong values, not a reordering). This silently corrupted **every Q2_K/Q2_K_S model** (common on HF Hub):
- **Format path** (`aprender-core`): `apr tensors` / `inspect` / `validate` / `convert`.
- **Inference path** (`aprender-serve`): `apr run` / serve — Q2_K models produced garbage.

**Fix (both paths)** to match ggml `dequantize_row_q2_K` / candle `BlockQ2K::to_float`: two groups of 128 over a 32-byte qs window; 4 sub-iters at shift 0/2/4/6; two scale bytes per sub-iter (low/high 16 of the window); `y = d*(sc&0xF)*q - dmin*(sc>>4)`. (The per-element formula was already right — only the loop structure / scale↔lane mapping was wrong.)

## Verification
- ✅ FT-Q2K-001 (core golden) + FT-Q2K-002 (serve golden) — byte-for-byte vs the ggml reference (pre-fix FAIL 185/256, post-fix PASS).
- ✅ 10 existing Q2_K tests unaffected; `cargo check --workspace` clean; contract `contracts/q2k-dequant-parity-v1.yaml` `pv validate` clean.

Found via an ultracode corruption-hunt survey — an agent compiled + ran a candle-vs-aprender falsifier. Release: workspace + facade → 0.41.0; CHANGELOG `[0.41.0]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)