### PR TITLE
chore(roadmap): backfill + Unsloth epic + 4-pillar replace-and-beat mission

### DIFF
--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -9769,3 +9769,442 @@ roadmap:
   - inference
   - beat
   notes: null
+- id: PMAT-720
+  github_issue: null
+  item_type: task
+  title: 'Add aprender::datasets module (load_iris, load_digits, load_california_housing via include_str! + make_classification/make_blobs/make_regression/make…'
+  status: planned
+  priority: critical
+  assigned_to: null
+  created: 2026-06-11T06:26:41Z
+  updated: 2026-06-11T06:26:41Z
+  spec: null
+  acceptance_criteria:
+  - 'Parent PMAT-717. Falsifier: datasets::load_digits() returns (1797,64) Matrix + 1797 labels in {0..9}; load_iris() returns (150,4)+3 classes; checksums/shapes asserted in unit tests.'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - pillar-sklearn
+  - beat
+  - cpu-autonomous
+  notes: 'four-pillar beat-analysis rank 1'
+- id: PMAT-721
+  github_issue: null
+  item_type: task
+  title: 'Falsify the LogisticRegression train_acc=0.505 observation: contract-gated test that LogReg reaches >=0.95 train-acc on a margin-separable 2-class se…'
+  status: planned
+  priority: critical
+  assigned_to: null
+  created: 2026-06-11T06:26:41Z
+  updated: 2026-06-11T06:26:41Z
+  spec: null
+  acceptance_criteria:
+  - 'Parent PMAT-717. Falsifier: LogisticRegression on margin-separable synthetic reaches train_acc >= 0.95 within 200 iters; currently observed 0.505 on overlapping data — confirm separable case passes or fix converges.'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - pillar-sklearn
+  - beat
+  - cpu-autonomous
+  notes: 'four-pillar beat-analysis rank 2'
+- id: PMAT-722
+  github_issue: null
+  item_type: task
+  title: 'Commit the head-to-head sklearn-beat bench harness (apr vs sklearn) on digits classification + california regression, CSV/JSON out, CI-failing if apr…'
+  status: planned
+  priority: critical
+  assigned_to: null
+  created: 2026-06-11T06:26:41Z
+  updated: 2026-06-11T06:26:41Z
+  spec: null
+  acceptance_criteria:
+  - 'Parent PMAT-717. Falsifier: apr RandomForestClassifier test_acc >= 0.96 on digits AND apr_walltime_ms <= sklearn_walltime_ms; RandomForestRegressor R2 >= 0.78 on california. Fails CI otherwise.'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - pillar-sklearn
+  - beat
+  - cpu-autonomous
+  notes: 'four-pillar beat-analysis rank 3'
+- id: PMAT-723
+  github_issue: null
+  item_type: task
+  title: 'Ship `apr qa --falsify` adversarial-corpus mode: bundle N>=5 deliberately-broken GGUF/APR artifacts (corrupt quant block, NaN weights, transposed lm_…'
+  status: planned
+  priority: high
+  assigned_to: null
+  created: 2026-06-11T06:26:41Z
+  updated: 2026-06-11T06:26:41Z
+  spec: null
+  acceptance_criteria:
+  - 'Parent PMAT-719. Falsifier: On the 5-artifact corpus `apr qa <broken> --json` flags >=1 gate / exits non-zero on 5/5; llama-cli/ollama exit 0 with garbage on 5/5. Differentiator FALSIFIED if apr false-passes any OR an incumbent catches one.'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - pillar-ollama
+  - beat
+  - cpu-autonomous
+  notes: 'four-pillar beat-analysis rank 4'
+- id: PMAT-724
+  github_issue: null
+  item_type: task
+  title: 'Add finite-difference gradient-correctness gate to core autograd as a proptest (perturb eps=1e-5, assert max|analytic-numeric|<1e-3 over matmul/relu/…'
+  status: planned
+  priority: high
+  assigned_to: null
+  created: 2026-06-11T06:26:41Z
+  updated: 2026-06-11T06:26:41Z
+  spec: null
+  acceptance_criteria:
+  - 'Parent PMAT-718. Falsifier: Any op whose analytic gradient deviates from numeric by >1e-3 fails the gate; passing gate is the machine-checked correctness claim on the training benchmark.'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - pillar-pytorch
+  - beat
+  - cpu-autonomous
+  notes: 'four-pillar beat-analysis rank 5'
+- id: PMAT-725
+  github_issue: null
+  item_type: task
+  title: 'Build the CPU training-time beat-benchmark harness: fixed 2-layer MLP + fixed N=1024 synthetic regression, single-thread CPU, measure wall-clock-to-t…'
+  status: planned
+  priority: high
+  assigned_to: null
+  created: 2026-06-11T06:26:41Z
+  updated: 2026-06-11T06:26:41Z
+  spec: null
+  acceptance_criteria:
+  - 'Parent PMAT-718. Falsifier: apr reaches MSE<=0.05 on the fixed dataset within the fixed step budget single-thread CPU; if it cannot converge the beat-claim is dead on arrival.'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - pillar-pytorch
+  - beat
+  - cpu-autonomous
+  notes: 'four-pillar beat-analysis rank 6'
+- id: PMAT-726
+  github_issue: null
+  item_type: task
+  title: 'PMAT-711: wire QLoRALayer (4-bit NF4 base) into the InstructPipeline CPU train loop (currently Vec<LoRALayer> f32 base, mod.rs:176); reuse the EXISTI…'
+  status: planned
+  priority: high
+  assigned_to: null
+  created: 2026-06-11T06:26:41Z
+  updated: 2026-06-11T06:26:41Z
+  spec: null
+  acceptance_criteria:
+  - 'Parent PMAT-710. Falsifier: Qwen2-0.5B q_proj block: NF4 round-trip mean-abs-error <= 1e-3 vs bitsandbytes per 64-block; QLoRALayer 4-bit footprint <= 0.30x f16; loss monotone-decreasing over 20 CPU steps on 16-sample fixture; cargo test -p aprender-train --lib lora:…'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - pillar-unsloth
+  - beat
+  - cpu-autonomous
+  notes: 'four-pillar beat-analysis rank 7'
+- id: PMAT-727
+  github_issue: null
+  item_type: task
+  title: 'PMAT-712: merge->GGUF as a contract-gated golden test — extend run_merge to optionally emit GGUF, add #[contract] obligation that merged-GGUF forward…'
+  status: planned
+  priority: high
+  assigned_to: null
+  created: 2026-06-11T06:26:41Z
+  updated: 2026-06-11T06:26:41Z
+  spec: null
+  acceptance_criteria:
+  - 'Parent PMAT-710. Falsifier: Load merged GGUF in realizar, forward on 8 fixed inputs; max abs diff vs in-memory base+scale*B@A < 1e-2; pv validate the new merge-export contract; fails if any tensor diverges.'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - pillar-unsloth
+  - beat
+  - cpu-autonomous
+  notes: 'four-pillar beat-analysis rank 8'
+- id: PMAT-728
+  github_issue: null
+  item_type: task
+  title: 'Run pinned PyTorch-CPU baseline (single OMP thread) on the IDENTICAL fixed MLP task; record wall-clock-to-target-loss + peak RSS via /usr/bin/time -v…'
+  status: planned
+  priority: high
+  assigned_to: null
+  created: 2026-06-11T06:26:41Z
+  updated: 2026-06-11T06:26:41Z
+  spec: null
+  acceptance_criteria:
+  - 'Parent PMAT-718. Falsifier: If apr wall-clock > PyTorch-CPU OR apr peak-RSS > PyTorch peak-RSS, the beat is FALSIFIED and reported as such — no vibes.'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - pillar-pytorch
+  - beat
+  - cpu-autonomous
+  notes: 'four-pillar beat-analysis rank 9'
+- id: PMAT-729
+  github_issue: null
+  item_type: task
+  title: 'Unify classifier API onto Estimator (or add a Classifier trait with y:&[usize]) so cross_validate/grid_search work generically over LogReg/RF/GBM/SVM…'
+  status: planned
+  priority: medium
+  assigned_to: null
+  created: 2026-06-11T06:26:41Z
+  updated: 2026-06-11T06:26:41Z
+  spec: null
+  acceptance_criteria:
+  - 'Parent PMAT-717. Falsifier: cross_validate::<RandomForestClassifier>(...) compiles and returns 5-fold CV accuracy on digits matching a manual KFold loop within 1e-4.'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - pillar-sklearn
+  - beat
+  - cpu-autonomous
+  notes: 'four-pillar beat-analysis rank 10'
+- id: PMAT-730
+  github_issue: null
+  item_type: task
+  title: 'Add missing metrics roc_auc_score, log_loss, roc_curve, precision_recall_curve (VERIFIED ABSENT everywhere) + GradientBoostingRegressor to complete t…'
+  status: planned
+  priority: medium
+  assigned_to: null
+  created: 2026-06-11T06:26:41Z
+  updated: 2026-06-11T06:26:41Z
+  spec: null
+  acceptance_criteria:
+  - 'Parent PMAT-717. Falsifier: roc_auc_score on a known scored set matches sklearn within 1e-4; GradientBoostingRegressor R2 on california >= 0.80.'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - pillar-sklearn
+  - beat
+  - cpu-autonomous
+  notes: 'four-pillar beat-analysis rank 11'
+- id: PMAT-731
+  github_issue: null
+  item_type: task
+  title: 'PMAT-713: one-command `apr finetune --qlora --bits 4 --export gguf -o out.gguf` doing load->NF4-QLoRA->CPU-train->merge->export on a tiny fixture (no…'
+  status: planned
+  priority: medium
+  assigned_to: null
+  created: 2026-06-11T06:26:41Z
+  updated: 2026-06-11T06:26:41Z
+  spec: null
+  acceptance_criteria:
+  - 'Parent PMAT-710. Falsifier: Single CLI call on 2-layer fixture .apr + 16-line JSONL produces a loadable merged GGUF; apr qa out.gguf passes; final_loss < initial_loss; e2e integration test in apr-cli.'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - pillar-unsloth
+  - beat
+  - cpu-autonomous
+  notes: 'four-pillar beat-analysis rank 12'
+- id: PMAT-732
+  github_issue: null
+  item_type: task
+  title: 'Wire apr-qa-differential-v1 ollama_parity into a real harness: `apr qa --differential --reference llama.cpp` reporting top-1 agreement >=95% + ppl-ga…'
+  status: planned
+  priority: medium
+  assigned_to: null
+  created: 2026-06-11T06:26:41Z
+  updated: 2026-06-11T06:26:41Z
+  spec: null
+  acceptance_criteria:
+  - 'Parent PMAT-719. Falsifier: `apr qa model.apr --differential` reports top1-agreement + ppl-gap vs llama.cpp on identical prompts, reproducible across 3 runs (CV<5%); falsified if agreement<95% (apr decode wrong) or harness needs GPU.'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - pillar-ollama
+  - beat
+  - cpu-autonomous
+  notes: 'four-pillar beat-analysis rank 13'
+- id: PMAT-733
+  github_issue: null
+  item_type: task
+  title: 'Add preprocessing encoders + sklearn-style Pipeline: OneHotEncoder, LabelEncoder, OrdinalEncoder, PolynomialFeatures, SimpleImputer, Normalizer + Pip…'
+  status: planned
+  priority: medium
+  assigned_to: null
+  created: 2026-06-11T06:26:41Z
+  updated: 2026-06-11T06:26:41Z
+  spec: null
+  acceptance_criteria:
+  - 'Parent PMAT-717. Falsifier: Pipeline::new([StandardScaler, PCA(10)], LogisticRegression).fit(digits).score() >= 0.92; OneHotEncoder on a 3-category column yields a 3-col one-hot matrix asserted element-wise.'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - pillar-sklearn
+  - beat
+  - cpu-autonomous
+  notes: 'four-pillar beat-analysis rank 14'
+- id: PMAT-734
+  github_issue: null
+  item_type: task
+  title: 'PMAT-715: promote Unsloth from static const (score.rs:777) to a tracked competitor ROW in compute_training_step_scorecard reporting apr/unsloth tok/s…'
+  status: planned
+  priority: low
+  assigned_to: null
+  created: 2026-06-11T06:26:41Z
+  updated: 2026-06-11T06:26:41Z
+  spec: null
+  acceptance_criteria:
+  - 'Parent PMAT-710. Falsifier: Fused-adapter forward == sum_i w_i*(scale_i*B_i@A_i@x) within 1e-5 (CPU); scorecard JSON emits unsloth row + ratio (honest concession that ratio <1.0 on throughput).'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - pillar-unsloth
+  - beat
+  - cpu-autonomous
+  notes: 'four-pillar beat-analysis rank 15'
+- id: PMAT-735
+  github_issue: null
+  item_type: task
+  title: 'Add non-linear SVM (RBF/poly kernel SVC) — sklearn SVC''s signature strength; current LinearSVM cannot separate non-linear data. VERIFIED ABSENT (no …'
+  status: planned
+  priority: low
+  assigned_to: null
+  created: 2026-06-11T06:26:41Z
+  updated: 2026-06-11T06:26:41Z
+  spec: null
+  acceptance_criteria:
+  - 'Parent PMAT-717. Falsifier: RBF-SVC on make_circles (non-linearly-separable) test_acc >= 0.95 where LinearSVM scores ~0.50.'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - pillar-sklearn
+  - beat
+  - cpu-autonomous
+  notes: 'four-pillar beat-analysis rank 16'
+- id: PMAT-736
+  github_issue: null
+  item_type: task
+  title: 'Publish a curated `apr registry` short-name catalog (`apr run qwen2.5-coder-1.5b` no URL) with each entry carrying its `apr qa` verdict as a trust ba…'
+  status: planned
+  priority: low
+  assigned_to: null
+  created: 2026-06-11T06:26:41Z
+  updated: 2026-06-11T06:26:41Z
+  spec: null
+  acceptance_criteria:
+  - 'Parent PMAT-719. Falsifier: `apr run qwen2.5-coder-1.5b` (bare short name, cold cache) downloads+runs+emits coherent output AND `apr list` shows each entry''s qa-gate verdict; falsified if a short name doesn''t resolve or catalog has no per-model correctness badge.'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - pillar-ollama
+  - beat
+  - cpu-autonomous
+  notes: 'four-pillar beat-analysis rank 17'
+- id: PMAT-737
+  github_issue: null
+  item_type: task
+  title: '[GPU-GATED — flag] CPU Q4_K decode parity: implement ggml-style pre-interleaved Q4_K weight layout at APR import (documented root cause, five-whys-16…'
+  status: planned
+  priority: low
+  assigned_to: null
+  created: 2026-06-11T06:26:41Z
+  updated: 2026-06-11T06:26:41Z
+  spec: null
+  acceptance_criteria:
+  - 'Parent PMAT-719. Falsifier: `apr bench model.apr --device cpu` 5-iter median >= `llama-cli -n 128 -t <ncores>` on SAME host, 1.5B Q4_K_M. Currently 9.9 vs 81 = 8.2x slower; clearing it is parity, not superiority.'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - pillar-ollama
+  - beat
+  - cpu-autonomous
+  notes: 'four-pillar beat-analysis rank 18'
+- id: PMAT-738
+  github_issue: null
+  item_type: task
+  title: '[GPU-GATED — NOT loop-buildable] Single-GPU QLoRA throughput run on lambda-vector to populate apr-vs-unsloth tok/s bar (6715.7/13659.7) — measurement…'
+  status: planned
+  priority: low
+  assigned_to: null
+  created: 2026-06-11T06:26:41Z
+  updated: 2026-06-11T06:26:41Z
+  spec: null
+  acceptance_criteria:
+  - 'Parent PMAT-710. Falsifier: apr finetune --qlora --gpu-backend cuda reports tok/s + peak VRAM into scorecard; expectation apr<unsloth (concede); goal quantify gap + confirm VRAM within 1.5x of 3515 MB.'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - pillar-unsloth
+  - beat
+  - gpu-gated
+  notes: 'four-pillar beat-analysis rank 19'
+- id: PMAT-739
+  github_issue: null
+  item_type: task
+  title: '[GPU-GATED — multi-week stretch] Drive GPU 1.5B Q4_K_M from 1.32x to 1.5x Ollama via FUSION-004 DP4A Q8_1 (only un-falsified lever; FUSION-003 alread…'
+  status: planned
+  priority: low
+  assigned_to: null
+  created: 2026-06-11T06:26:41Z
+  updated: 2026-06-11T06:26:41Z
+  spec: null
+  acceptance_criteria:
+  - 'Parent PMAT-719. Falsifier: `apr qa <1.5B-q4km> --json` 5-run median 128-tok decode >= 460.7 tok/s (1.5x Ollama) vs current flat ~396; requires RTX-4090-class GPU.'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - pillar-ollama
+  - beat
+  - gpu-gated
+  notes: 'four-pillar beat-analysis rank 20'
+- id: PMAT-740
+  github_issue: null
+  item_type: task
+  title: 'ROADMAP GAP: add a classical-ML (scikit-learn) competitor category (CRUX-S-*) to the CRUX matrix'
+  status: planned
+  priority: high
+  assigned_to: null
+  created: 2026-06-11T06:26:41Z
+  updated: 2026-06-11T06:26:41Z
+  spec: null
+  acceptance_criteria:
+  - 'sklearn is NOT in the CRUX competitor set (Ollama/llama.cpp/PyTorch/HF/vLLM/OpenCLAW). Add a CRUX-S classical-ML story class so datasets/encoders/RBF-SVM/roc_auc/Pipeline gaps are tracked. Unblocks Pillar 1 (PMAT-717).'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - pillar-sklearn
+  - roadmap-structure
+  notes: 'four-pillar beat-analysis roadmap gap #1'
+- id: PMAT-741
+  github_issue: null
+  item_type: task
+  title: 'ROADMAP GAP: add a beat-benchmark contract kind (committed head-to-head, CI-failing, baseline pinned)'
+  status: planned
+  priority: high
+  assigned_to: null
+  created: 2026-06-11T06:26:41Z
+  updated: 2026-06-11T06:26:41Z
+  spec: null
+  acceptance_criteria:
+  - 'No contract schema for FALSIFY-BEAT-* (apr >= incumbent on canonical task, fails CI on regression, incumbent baseline committed). Add the kind so every pillar beat-claim is a machine-checked artifact. Core mission infra.'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - mission
+  - roadmap-structure
+  - beat
+  notes: 'four-pillar beat-analysis roadmap gap #2'

--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -9419,3 +9419,142 @@ roadmap:
   estimated_effort: null
   labels: []
   notes: null
+- id: PMAT-692
+  github_issue: 1915
+  item_type: task
+  title: 'Per-position (full-sequence) knowledge distillation for aprender-train-distill'
+  status: completed
+  priority: high
+  assigned_to: null
+  created: 2026-06-11T06:00:06Z
+  updated: 2026-06-11T06:00:06Z
+  spec: null
+  acceptance_criteria:
+  - 'Shipped v0.36.0 (PR #1915). Contract: contracts/distill-per-position-kd-v1.yaml. Additive/opt-in (APR_DISTILL_PER_POSITION); CUDA path unchanged via trait defaults. Falsifiers FT-PERPOS-001..005.'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - distill
+  - shipped
+  notes: 'Roadmap-traceability backfill 2026-06-11 (was untracked).'
+- id: PMAT-693
+  github_issue: 1893
+  item_type: task
+  title: 'Sharded GGUF pull + auto-merge — run multi-part GGUFs end-to-end (closes #1893)'
+  status: completed
+  priority: high
+  assigned_to: null
+  created: 2026-06-11T06:00:06Z
+  updated: 2026-06-11T06:00:06Z
+  spec: null
+  acceptance_criteria:
+  - 'Shipped v0.37.0 (pull, #1917, contract sharded-gguf-pull-v1) + v0.38.0 (auto-merge, #1918, contract sharded-gguf-merge-v1). Type-agnostic, lossless-metadata, bounded-memory merge. Advances CRUX-A acquisition.'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - crux-a
+  - gguf
+  - shipped
+  notes: 'Roadmap-traceability backfill 2026-06-11.'
+- id: PMAT-694
+  github_issue: 1919
+  item_type: task
+  title: 'BF16 (ggml type 30) GGUF loader support'
+  status: completed
+  priority: medium
+  assigned_to: null
+  created: 2026-06-11T06:00:06Z
+  updated: 2026-06-11T06:00:06Z
+  spec: null
+  acceptance_criteria:
+  - 'Shipped v0.39.0 (PR #1919). Contract: contracts/bf16-dequant-v1.yaml. get_tensor_f32 + tensor_byte_size BF16 arms; FT-BF16-001/002.'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - quant
+  - gguf
+  - shipped
+  notes: 'Roadmap-traceability backfill 2026-06-11.'
+- id: PMAT-695
+  github_issue: 1922
+  item_type: task
+  title: 'APR->GGUF export rejects AprQ8 instead of corrupt-relabeling as Q8_0 (import/export symmetry)'
+  status: completed
+  priority: high
+  assigned_to: null
+  created: 2026-06-11T06:00:06Z
+  updated: 2026-06-11T06:00:06Z
+  spec: null
+  acceptance_criteria:
+  - 'Shipped v0.40.0 (PR #1922). Contract: contracts/apr-gguf-export-symmetry-v1.yaml. Silent-corruption fix; FT-APRQ8-001/002. Gated a-priori by CRUX-M-04 (PMAT-672).'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - crux-m
+  - format-integrity
+  - shipped
+  notes: 'Roadmap-traceability backfill 2026-06-11. Corruption class to be walled by PMAT-671/672.'
+- id: PMAT-696
+  github_issue: 1924
+  item_type: task
+  title: 'Fix corrupt Q2_K dequantization (185/256 elements wrong) — format + inference paths'
+  status: completed
+  priority: critical
+  assigned_to: null
+  created: 2026-06-11T06:00:06Z
+  updated: 2026-06-11T06:00:06Z
+  spec: null
+  acceptance_criteria:
+  - 'Shipped v0.41.0 (PR #1924). Contract: contracts/q2k-dequant-parity-v1.yaml. Both aprender-core + aprender-serve dequant matched to ggml dequantize_row_q2_K; FT-Q2K-001/002. Directly motivates the PMAT-671 standing gate.'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - crux-m
+  - quant-integrity
+  - shipped
+  notes: 'Roadmap-traceability backfill 2026-06-11. Strategic discharge = PMAT-671 (CRUX-M-02 stat-parity gate would have caught this a priori).'
+- id: PMAT-697
+  github_issue: 1925
+  item_type: task
+  title: 'Correct ggml dtype names 26-30 (BF16 was reported as IQ1_M in apr tensors/inspect)'
+  status: completed
+  priority: medium
+  assigned_to: null
+  created: 2026-06-11T06:00:06Z
+  updated: 2026-06-11T06:00:06Z
+  spec: null
+  acceptance_criteria:
+  - 'Shipped v0.41.1 (PR #1925). ggml_dtype_name table reordered to ggml.h (I32=26..BF16=30); exhaustive test pinned. Advances CRUX-F inspect correctness.'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - crux-f
+  - inspect
+  - shipped
+  notes: 'Roadmap-traceability backfill 2026-06-11.'
+- id: PMAT-698
+  github_issue: null
+  item_type: task
+  title: 'Hard-refuse unsupported architectures instead of silent llama fallback (replace FALSIFY-TNAME-005)'
+  status: planned
+  priority: critical
+  assigned_to: null
+  created: 2026-06-11T06:00:06Z
+  updated: 2026-06-11T06:00:06Z
+  spec: null
+  acceptance_criteria:
+  - 'normalize_architecture (tensor_names_fallback.rs:73, tensor_names.rs:282) silently maps unknown arch->llama and FALSIFY-TNAME-005 PINS that garbage-producing behavior; Gemma/Phi3/Falcon run the wrong forward path. Make it return Result/Option + actionable error; INVERT the falsifier to assert clean refusal. Autonomous + CPU-verifiable. Roadmap-aligned target #2.'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - arch-breadth
+  - integrity
+  - roadmap-aligned
+  notes: 'Added 2026-06-11 from roadmap evaluation (refuse-don''t-corrupt theme).'

--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -9684,3 +9684,88 @@ roadmap:
   - unsloth
   - benchmark
   notes: null
+- id: PMAT-716
+  github_issue: null
+  item_type: epic
+  title: 'MISSION: one pure-Rust binary that REPLACES + BEATS sklearn + PyTorch + Unsloth + Ollama/llama.cpp at what each does best'
+  status: planned
+  priority: critical
+  assigned_to: null
+  created: 2026-06-11T06:18:26Z
+  updated: 2026-06-11T06:18:26Z
+  spec: null
+  acceptance_criteria:
+  - 'North-star (user directive 2026-06-11). Whole ML lifecycle (classical -> DL -> fine-tune -> quantize -> serve) in one safe-Rust binary, each stage beating the Python/C++ incumbent at its signature strength. BEAT = a FALSIFIABLE benchmark (apr >= incumbent on its canonical task), not parity. Cross-cutting differentiator: provable contract-gated correctness (none of the 4 have it). Pillars: PMAT-717 (sklearn), PMAT-718 (PyTorch), PMAT-710 (Unsloth), PMAT-719 (Ollama/llama.cpp). Each pillar ships FALSIFY-BEAT-* gates.'
+  phases: []
+  subtasks:
+  - PMAT-717
+  - PMAT-718
+  - PMAT-710
+  - PMAT-719
+  estimated_effort: null
+  labels:
+  - mission
+  - four-pillars
+  - beat
+  notes: 'See memory project_mission_four_pillars. Detailed beat-targets land from the four-pillar beat-analysis (in flight).'
+- id: PMAT-717
+  github_issue: null
+  item_type: epic
+  title: 'Pillar 1: BEAT scikit-learn at classical ML (pure Rust) — fit/predict faster, same accuracy, provably correct'
+  status: planned
+  priority: high
+  assigned_to: null
+  created: 2026-06-11T06:18:26Z
+  updated: 2026-06-11T06:18:26Z
+  spec: null
+  acceptance_criteria:
+  - 'aprender-core already has the TOP-10 classical-ML surface (Estimator/Transformer; LinearRegression/LogisticRegression/DecisionTree/RandomForest/GBM/NaiveBayes/KNN/SVM/KMeans/PCA + model_selection + metrics). MOST-BUILT + MOST-WINNABLE pillar. Beat-benchmark FALSIFY-BEAT-SKLEARN: fit+predict wall-clock <= sklearn AND accuracy within tol on standard datasets (iris/digits/california). ROADMAP GAP: sklearn is NOT a tracked CRUX competitor — this pillar likely needs a new classical-ML category. Mostly CPU-autonomous. Sub-targets from the beat-analysis.'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - pillar-sklearn
+  - classical-ml
+  - beat
+  notes: null
+- id: PMAT-718
+  github_issue: null
+  item_type: epic
+  title: 'Pillar 2: BEAT PyTorch at tensors + autograd + training (bounded task: train-to-loss faster / less memory)'
+  status: planned
+  priority: high
+  assigned_to: null
+  created: 2026-06-11T06:18:26Z
+  updated: 2026-06-11T06:18:26Z
+  spec: null
+  acceptance_criteria:
+  - 'HARDEST pillar (PyTorch moat = flexibility + ecosystem). Compute substrate = aprender-compute (trueno SIMD/GPU) + aprender-train. Beat on the BOUNDED canonical task, not research flexibility: FALSIFY-BEAT-PYTORCH = train a fixed small model to a target loss with apr <= time and/or <= peak memory. CPU-side pieces (autograd correctness, op coverage, a CPU training benchmark) are loop-buildable; the perf run is GPU (lambda-vector). Sub-targets from the beat-analysis.'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - pillar-pytorch
+  - autograd
+  - beat
+  notes: null
+- id: PMAT-719
+  github_issue: null
+  item_type: epic
+  title: 'Pillar 4: BEAT Ollama/llama.cpp at local quantized inference — 1.5x decode tok/s AND provable output-correctness'
+  status: planned
+  priority: high
+  assigned_to: null
+  created: 2026-06-11T06:18:26Z
+  updated: 2026-06-11T06:18:26Z
+  spec: null
+  acceptance_criteria:
+  - 'Their best: fast GGUF decode + simple pull/run UX. aprender perf-path already 440 tok/s vs ollama 307 on 1.5B Q4_K_M (~1.43x; 1.5x = 460 tok/s target). TWO beat-benchmarks: (a) FALSIFY-BEAT-OLLAMA-PERF = decode tok/s >= ollama at fixed quant (target 1.5x); (b) FALSIFY-BEAT-OLLAMA-CORRECT = provable output/dequant correctness (the CRUX-M verify wall / Q2_K-class) that ollama+llama.cpp LACK. CRUX-M-02 (PMAT-671, active) is the correctness leg. Sub-targets from the beat-analysis.'
+  phases: []
+  subtasks:
+  - PMAT-671
+  estimated_effort: null
+  labels:
+  - pillar-ollama
+  - inference
+  - beat
+  notes: null

--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -9558,3 +9558,129 @@ roadmap:
   - integrity
   - roadmap-aligned
   notes: 'Added 2026-06-11 from roadmap evaluation (refuse-don''t-corrupt theme).'
+- id: PMAT-710
+  github_issue: null
+  item_type: epic
+  title: 'Unsloth parity: compete with Unsloth on small-model LoRA/QLoRA fine-tune + distillation (pure Rust)'
+  status: planned
+  priority: high
+  assigned_to: null
+  created: 2026-06-11T06:10:08Z
+  updated: 2026-06-11T06:10:08Z
+  spec: null
+  acceptance_criteria:
+  - 'STRATEGIC (user directive 2026-06-11): the PEFT/QLoRA fine-tune + distillation lane is an EXPLICIT competitor target vs Unsloth. Parity = end-to-end load -> QLoRA(4-bit) -> train -> merge adapter -> export GGUF/safetensors -> publish HF, in pure safe-Rust, CPU-or-single-GPU (lambda-vector). Unsloth already a benchmark in-tree (score.rs TRAINING_TOK_S=6000 unsloth-level; ch23_training_bench). Children: PMAT-711..715. Advances CRUX-D.'
+  phases: []
+  subtasks:
+  - PMAT-711
+  - PMAT-712
+  - PMAT-713
+  - PMAT-714
+  - PMAT-715
+  estimated_effort: null
+  labels:
+  - crux-d
+  - unsloth
+  - finetune
+  - roadmap-aligned
+  notes: 'New competitive epic 2026-06-11. Corrects earlier "not an Unsloth replacement" framing — this is the ONE training lane winnable in pure Rust.'
+- id: PMAT-711
+  github_issue: null
+  item_type: task
+  title: 'QLoRA 4-bit + LoRA fine-tune (apr finetune --qlora --bits 4) — CRUX-D QLoRA (currently MISSING)'
+  status: planned
+  priority: high
+  assigned_to: null
+  created: 2026-06-11T06:10:08Z
+  updated: 2026-06-11T06:10:08Z
+  spec: null
+  acceptance_criteria:
+  - 'Core Unsloth feature. qlora/qlora_default exist in aprender-train; wire the 4-bit NF4 base + LoRA adapter path into apr finetune. Falsifier: loss-monotone over N steps on a tiny fixture; 4-bit base footprint vs f16. CPU-falsifiable math + single-GPU run (lambda-vector).'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - crux-d
+  - unsloth
+  - qlora
+  notes: null
+- id: PMAT-712
+  github_issue: null
+  item_type: task
+  title: 'Complete LoRA-merge + export-to-GGUF (Unsloth save_pretrained_merged equivalent) — CRUX-D partial->supported'
+  status: planned
+  priority: high
+  assigned_to: null
+  created: 2026-06-11T06:10:08Z
+  updated: 2026-06-11T06:10:08Z
+  spec: null
+  acceptance_criteria:
+  - 'aprender-train/src/lora/adapter/merge_export.rs + hf_pipeline/export/exporter.rs exist (partial). Complete: merge LoRA into base, export merged GGUF + safetensors. Falsifier: merged GGUF loads AND forward matches the LoRA-applied base within tol (golden). Fully CPU-verifiable.'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - crux-d
+  - unsloth
+  - export
+  notes: null
+- id: PMAT-713
+  github_issue: null
+  item_type: task
+  title: 'End-to-end apr finetune Unsloth-parity single-command UX (load -> QLoRA -> train -> merge -> export -> publish)'
+  status: planned
+  priority: high
+  assigned_to: null
+  created: 2026-06-11T06:10:08Z
+  updated: 2026-06-11T06:10:08Z
+  spec: null
+  acceptance_criteria:
+  - 'The headline competitive story: one command from base model + dataset to a merged, exported, HF-published fine-tuned model. apr finetune (commands/finetune.rs) exists; wire QLoRA + merge + export + apr publish. Falsifier: e2e on a tiny fixture model produces a loadable merged artifact + the HF-commit dry-run succeeds.'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - crux-d
+  - unsloth
+  - ux
+  notes: null
+- id: PMAT-714
+  github_issue: null
+  item_type: task
+  title: 'Gradient checkpointing for memory (CRUX-D partial) — Unsloth low-VRAM wedge'
+  status: planned
+  priority: medium
+  assigned_to: null
+  created: 2026-06-11T06:10:08Z
+  updated: 2026-06-11T06:10:08Z
+  spec: null
+  acceptance_criteria:
+  - 'Activation/gradient checkpointing to trade compute for memory, enabling larger context/batch on a single GPU. Falsifier: identical loss with vs without checkpointing on a fixture (numerical equivalence) + reduced peak activation memory.'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - crux-d
+  - unsloth
+  - memory
+  notes: null
+- id: PMAT-715
+  github_issue: null
+  item_type: task
+  title: 'Adapter fusion (combine N LoRAs) + promote Unsloth to tracked training-throughput competitor (>=6000 tok/s bar)'
+  status: planned
+  priority: medium
+  assigned_to: null
+  created: 2026-06-11T06:10:08Z
+  updated: 2026-06-11T06:10:08Z
+  spec: null
+  acceptance_criteria:
+  - 'CRUX-D adapter-fusion (missing): merge N LoRA adapters with weights. AND formalize Unsloth as a tracked competitor in the training benchmark (aprender-test-lib/src/llm/score.rs + ch23_training_bench) with the >=6000 tok/s (yoga-RTX) / >=13000 (A100) bar. Falsifier: fused adapter forward == weighted sum of individual; bench reports the unsloth-relative ratio.'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - crux-d
+  - unsloth
+  - benchmark
+  notes: null


### PR DESCRIPTION
Consolidated roadmap update from the roadmap-evaluation + the tightened four-pillar mission.

**1. Traceability backfill (PMAT-692..698):** completed tickets for the shipped v0.36→v0.41.1 work (had no roadmap line) + arch-refuse target.

**2. Unsloth-parity fine-tune epic (PMAT-710..715).**

**3. Four-pillar replace-and-beat MISSION (PMAT-716..719):** one pure-Rust binary that BEATS sklearn / PyTorch / Unsloth / Ollama-llama.cpp at each one's canonical task — "beat" = a falsifiable CI benchmark, not parity.

**4. Operational beat-targets (PMAT-720..741):** the 20 prioritized targets from the four-pillar beat-analysis (each tagged to pillar + falsifier + cpu-autonomous/gpu-gated) + 2 structural-gap tickets (no sklearn category; no beat-benchmark contract kind).

**Key re-prioritization:** the next build pivots to **Pillar 1 (sklearn)** — most-winnable + currently untracked — starting with `aprender::datasets` (PMAT-720, verified absent) and a likely real LogisticRegression convergence bug (PMAT-721). CRUX-M-02 (PMAT-671) stays as the Pillar-4 correctness leg.

Roadmap-maintenance only (no code, no version bump). YAML re-parses (518 items); `pmat roadmap` reads it cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)