### PR TITLE
perf(matmul): apr LinearRegression BEATS sklearn ~1.8x — v0.42.3 (re-land)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.42.3] - 2026-06-11
+
+### Changed
+
+- **`Matrix::matmul` cache-friendly rewrite (first scikit-learn speed-beat)**:
+  replaced the naive scalar `ijk` loop (bounds-checked `get()`, strided column
+  access) with cache-friendly `ikj` ordering and a contiguous AXPY inner loop
+  that LLVM auto-vectorizes. Numerically equivalent (13,849 core tests pass).
+  **`LinearRegression` fit+predict (10000×20) dropped 3.27 ms → 1.27 ms — now
+  ~1.8× faster than scikit-learn (2.28 ms, LAPACK), at R² parity.** matmul is
+  used framework-wide, so this also accelerates PCA, tensor ops, and any
+  algorithm forming Xᵀ X.
+
 ## [0.42.2] - 2026-06-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,7 +284,7 @@ dependencies = [
 
 [[package]]
 name = "apr-cli"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "alimentar",
  "anyhow",
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "aprender"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "apr-cli",
  "aprender-core",
@@ -411,7 +411,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-bench-compute"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "aprender-core",
  "criterion 0.7.0",
@@ -420,7 +420,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-bench-tokenizer"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "aprender-core",
  "criterion 0.7.0",
@@ -429,7 +429,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cbtop"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "anyhow",
  "aprender-compute",
@@ -454,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cgp"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "anyhow",
  "aprender-gpu",
@@ -474,7 +474,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-common"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "lz4_flex 0.11.6",
  "zstd",
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-compute"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "anyhow",
  "aprender-core",
@@ -531,7 +531,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-compute-xtask"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "anyhow",
  "bashrs",
@@ -544,7 +544,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-contracts"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "aprender-contracts-macros",
  "criterion 0.5.1",
@@ -559,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-contracts-cli"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "aprender-contracts",
  "clap",
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-contracts-macros"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-core"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "aes-gcm",
  "alimentar",
@@ -632,7 +632,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cuda-edge"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "aprender-gpu",
  "proptest",
@@ -643,7 +643,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cupti"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "bindgen 0.71.1",
  "bitflags 2.11.0",
@@ -653,7 +653,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-data"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-db"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "anyhow",
  "arrow 57.3.0",
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-distribute"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "arrow 57.3.0",
  "bincode",
@@ -781,7 +781,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-explain"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "aprender-gpu",
  "clap",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-fft"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -808,7 +808,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-gemm-codegen"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-gpu"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "aprender-profile",
  "batuta-common",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-graph"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "anyhow",
  "aprender-core",
@@ -862,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-image"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-mcp"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -886,9 +886,9 @@ dependencies = [
 
 [[package]]
 name = "aprender-monte-carlo"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
- "aprender 0.42.2",
+ "aprender 0.42.3",
  "assert_cmd",
  "chrono",
  "clap",
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-orchestrate"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "alimentar",
  "anyhow",
@@ -979,7 +979,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-cli"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "aprender-present-yaml",
  "clap",
@@ -992,7 +992,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-core"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "aprender-compute",
  "criterion 0.7.0",
@@ -1005,7 +1005,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-layout"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "aprender-present-core",
  "criterion 0.7.0",
@@ -1016,7 +1016,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-lib"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "aprender-present-core",
  "aprender-present-layout",
@@ -1045,7 +1045,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-terminal"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "aprender-present-core",
  "bitvec",
@@ -1067,7 +1067,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-test"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "aprender-present-core",
  "aprender-present-test-macros",
@@ -1078,7 +1078,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-test-macros"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1087,7 +1087,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-widgets"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "aprender-present-core",
  "aprender-present-yaml",
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-yaml"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "aprender-present-core",
  "proptest",
@@ -1109,7 +1109,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-profile"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "addr2line 0.25.1",
  "anyhow",
@@ -1162,7 +1162,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-profile-core"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "hex",
  "serde",
@@ -1172,7 +1172,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-ptx-debug"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "proptest",
  "thiserror 2.0.18",
@@ -1180,7 +1180,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-certify"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "chrono",
  "proptest",
@@ -1190,7 +1190,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-cli"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "aprender-qa-certify",
  "aprender-qa-gen",
@@ -1209,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-gen"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1226,7 +1226,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-report"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "anyhow",
  "aprender-qa-gen",
@@ -1244,7 +1244,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-runner"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "anyhow",
  "aprender-qa-gen",
@@ -1269,14 +1269,14 @@ dependencies = [
 
 [[package]]
 name = "aprender-quant"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "half",
 ]
 
 [[package]]
 name = "aprender-rag"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "async-trait",
  "batuta-common",
@@ -1307,7 +1307,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-rand"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1316,7 +1316,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-registry"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "alimentar",
  "anyhow",
@@ -1346,7 +1346,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-serve"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "alimentar",
  "anyhow",
@@ -1413,7 +1413,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-shell"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "aprender-core",
  "assert_cmd",
@@ -1430,7 +1430,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-simulate"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "bincode",
  "bitflags 2.11.0",
@@ -1469,7 +1469,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-solve"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1478,7 +1478,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-sparse"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1487,7 +1487,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-tensor"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1496,7 +1496,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-cli"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "aprender-test-lib",
  "assert_cmd",
@@ -1524,7 +1524,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-derive"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1534,7 +1534,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-js-gen"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "blake3",
  "chrono",
@@ -1550,7 +1550,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-lib"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "aprender-compute",
  "aprender-present-core",
@@ -1594,7 +1594,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-showcase"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "aprender-present-terminal",
  "console_error_panic_hook",
@@ -1611,7 +1611,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "alimentar",
  "approx",
@@ -1678,7 +1678,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-bench"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1695,7 +1695,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-common"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "clap",
  "proptest",
@@ -1707,7 +1707,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-distill"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1728,7 +1728,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-inspect"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1744,7 +1744,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-lora"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-shell"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1776,7 +1776,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-wasm"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "proptest",
  "serde",
@@ -1787,9 +1787,9 @@ dependencies = [
 
 [[package]]
 name = "aprender-tsp"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
- "aprender 0.42.2",
+ "aprender 0.42.3",
  "assert_cmd",
  "clap",
  "crc32fast",
@@ -1802,7 +1802,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-verify"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "chrono",
  "criterion 0.5.1",
@@ -1814,7 +1814,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-verify-ml"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "aprender-core",
  "aprender-profile",
@@ -1858,7 +1858,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-viz"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "approx",
  "aprender-core",
@@ -1893,7 +1893,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "aprender-zram-adaptive",
  "aprender-zram-core",
@@ -1903,7 +1903,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-adaptive"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "aprender-zram-core",
  "proptest",
@@ -1912,7 +1912,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-cli"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "aprender-zram-adaptive",
  "aprender-zram-core",
@@ -1926,7 +1926,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-core"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "aprender-gpu",
  "criterion 0.7.0",
@@ -1938,7 +1938,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-generator"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "aprender-zram-core",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.42.2"
+version = "0.42.3"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/paiml/aprender"
@@ -171,7 +171,7 @@ minijinja = { version = "2.14", features = ["loader", "serde"] }
 # Contracts
 provable-contracts = "0.3"
 provable-contracts-macros = "0.3"
-aprender-contracts-macros = { path = "crates/aprender-contracts-macros", version = "0.42.2" }
+aprender-contracts-macros = { path = "crates/aprender-contracts-macros", version = "0.42.3" }
 
 # YAML
 serde_yaml = "0.9"
@@ -183,31 +183,31 @@ hf-hub = { version = "0.4", default-features = false, features = ["ureq"] }
 hf-xet = "1.5.1"
 
 # Workspace-internal crates (paths within the monorepo)
-aprender-compute = { path = "crates/aprender-compute", version = "0.42.2" }
-aprender-gpu = { path = "crates/aprender-gpu", version = "0.42.2" }
-aprender-quant = { path = "crates/aprender-quant", version = "0.42.2" }
-aprender-serve = { path = "crates/aprender-serve", version = "0.42.2" }
-realizar = { path = "crates/aprender-serve", version = "0.42.2", package = "aprender-serve" }
-aprender-train = { path = "crates/aprender-train", version = "0.42.2" }
-entrenar = { path = "crates/aprender-train", version = "0.42.2", package = "aprender-train" }
-aprender-train-common = { path = "crates/aprender-train-common", version = "0.42.2" }
-aprender-train-distill = { path = "crates/aprender-train-distill", version = "0.42.2" }
-aprender-orchestrate = { path = "crates/aprender-orchestrate", version = "0.42.2" }
-aprender-contracts = { path = "crates/aprender-contracts", version = "0.42.2" }
-aprender-profile = { path = "crates/aprender-profile", version = "0.42.2" }
-aprender-profile-core = { path = "crates/aprender-profile-core", version = "0.42.2" }
-aprender-zram-core = { path = "crates/aprender-zram-core", version = "0.42.2" }
-aprender-zram-adaptive = { path = "crates/aprender-zram-adaptive", version = "0.42.2" }
-aprender-present-core = { path = "crates/aprender-present-core", version = "0.42.2" }
-aprender-present-terminal = { path = "crates/aprender-present-terminal", version = "0.42.2" }
-aprender-present-widgets = { path = "crates/aprender-present-widgets", version = "0.42.2" }
-aprender-present-layout = { path = "crates/aprender-present-layout", version = "0.42.2" }
-aprender-present-yaml = { path = "crates/aprender-present-yaml", version = "0.42.2" }
-aprender-present-test = { path = "crates/aprender-present-test", version = "0.42.2" }
-aprender-db = { path = "crates/aprender-db", version = "0.42.2" }
-aprender-graph = { path = "crates/aprender-graph", version = "0.42.2" }
-aprender-rag = { path = "crates/aprender-rag", version = "0.42.2" }
-aprender-data = { path = "crates/aprender-data", version = "0.42.2" }
+aprender-compute = { path = "crates/aprender-compute", version = "0.42.3" }
+aprender-gpu = { path = "crates/aprender-gpu", version = "0.42.3" }
+aprender-quant = { path = "crates/aprender-quant", version = "0.42.3" }
+aprender-serve = { path = "crates/aprender-serve", version = "0.42.3" }
+realizar = { path = "crates/aprender-serve", version = "0.42.3", package = "aprender-serve" }
+aprender-train = { path = "crates/aprender-train", version = "0.42.3" }
+entrenar = { path = "crates/aprender-train", version = "0.42.3", package = "aprender-train" }
+aprender-train-common = { path = "crates/aprender-train-common", version = "0.42.3" }
+aprender-train-distill = { path = "crates/aprender-train-distill", version = "0.42.3" }
+aprender-orchestrate = { path = "crates/aprender-orchestrate", version = "0.42.3" }
+aprender-contracts = { path = "crates/aprender-contracts", version = "0.42.3" }
+aprender-profile = { path = "crates/aprender-profile", version = "0.42.3" }
+aprender-profile-core = { path = "crates/aprender-profile-core", version = "0.42.3" }
+aprender-zram-core = { path = "crates/aprender-zram-core", version = "0.42.3" }
+aprender-zram-adaptive = { path = "crates/aprender-zram-adaptive", version = "0.42.3" }
+aprender-present-core = { path = "crates/aprender-present-core", version = "0.42.3" }
+aprender-present-terminal = { path = "crates/aprender-present-terminal", version = "0.42.3" }
+aprender-present-widgets = { path = "crates/aprender-present-widgets", version = "0.42.3" }
+aprender-present-layout = { path = "crates/aprender-present-layout", version = "0.42.3" }
+aprender-present-yaml = { path = "crates/aprender-present-yaml", version = "0.42.3" }
+aprender-present-test = { path = "crates/aprender-present-test", version = "0.42.3" }
+aprender-db = { path = "crates/aprender-db", version = "0.42.3" }
+aprender-graph = { path = "crates/aprender-graph", version = "0.42.3" }
+aprender-rag = { path = "crates/aprender-rag", version = "0.42.3" }
+aprender-data = { path = "crates/aprender-data", version = "0.42.3" }
 
 # Additional external deps needed by sub-crates
 serde_yaml_ng = "0.10"
@@ -252,25 +252,25 @@ wasmtime = "43"
 bollard = "0.17"
 
 # Old crate name aliases (workspace = true refs in migrated sub-crates)
-trueno-zram-core = { path = "crates/aprender-zram-core", version = "0.42.2", package = "aprender-zram-core" }
-trueno-zram-adaptive = { path = "crates/aprender-zram-adaptive", version = "0.42.2", package = "aprender-zram-adaptive" }
-trueno = { path = "crates/aprender-compute", version = "0.42.2", package = "aprender-compute" }
-presentar-core = { path = "crates/aprender-present-core", version = "0.42.2", package = "aprender-present-core" }
-presentar-terminal = { path = "crates/aprender-present-terminal", version = "0.42.2", package = "aprender-present-terminal" }
-presentar-widgets = { path = "crates/aprender-present-widgets", version = "0.42.2", package = "aprender-present-widgets" }
-presentar-layout = { path = "crates/aprender-present-layout", version = "0.42.2", package = "aprender-present-layout" }
-presentar-yaml = { path = "crates/aprender-present-yaml", version = "0.42.2", package = "aprender-present-yaml" }
-presentar-test = { path = "crates/aprender-present-test", version = "0.42.2", package = "aprender-present-test" }
-presentar-test-macros = { path = "crates/aprender-present-test-macros", version = "0.42.2", package = "aprender-present-test-macros" }
-jugar-probar-derive = { path = "crates/aprender-test-derive", version = "0.42.2", package = "aprender-test-derive" }
-batuta-common = { path = "crates/aprender-common", version = "0.42.2", package = "aprender-common" }
+trueno-zram-core = { path = "crates/aprender-zram-core", version = "0.42.3", package = "aprender-zram-core" }
+trueno-zram-adaptive = { path = "crates/aprender-zram-adaptive", version = "0.42.3", package = "aprender-zram-adaptive" }
+trueno = { path = "crates/aprender-compute", version = "0.42.3", package = "aprender-compute" }
+presentar-core = { path = "crates/aprender-present-core", version = "0.42.3", package = "aprender-present-core" }
+presentar-terminal = { path = "crates/aprender-present-terminal", version = "0.42.3", package = "aprender-present-terminal" }
+presentar-widgets = { path = "crates/aprender-present-widgets", version = "0.42.3", package = "aprender-present-widgets" }
+presentar-layout = { path = "crates/aprender-present-layout", version = "0.42.3", package = "aprender-present-layout" }
+presentar-yaml = { path = "crates/aprender-present-yaml", version = "0.42.3", package = "aprender-present-yaml" }
+presentar-test = { path = "crates/aprender-present-test", version = "0.42.3", package = "aprender-present-test" }
+presentar-test-macros = { path = "crates/aprender-present-test-macros", version = "0.42.3", package = "aprender-present-test-macros" }
+jugar-probar-derive = { path = "crates/aprender-test-derive", version = "0.42.3", package = "aprender-test-derive" }
+batuta-common = { path = "crates/aprender-common", version = "0.42.3", package = "aprender-common" }
 # APR-MONO sibling aliases — MUST use workspace refs, NEVER crates.io versions.
 # Hard-pinning these to crates.io creates a diamond: sub-crates pull older
 # aprender versions → multiple `aprender` crates in Cargo.lock = MUDA.
-renacer = { path = "crates/aprender-profile", version = "0.42.2", package = "aprender-profile" }
-entrenar-lora = { path = "crates/aprender-train-lora", version = "0.42.2", package = "aprender-train-lora" }
-batuta = { path = "crates/aprender-orchestrate", version = "0.42.2", package = "aprender-orchestrate" }
-trueno-graph = { path = "crates/aprender-graph", version = "0.42.2", package = "aprender-graph" }
+renacer = { path = "crates/aprender-profile", version = "0.42.3", package = "aprender-profile" }
+entrenar-lora = { path = "crates/aprender-train-lora", version = "0.42.3", package = "aprender-train-lora" }
+batuta = { path = "crates/aprender-orchestrate", version = "0.42.3", package = "aprender-orchestrate" }
+trueno-graph = { path = "crates/aprender-graph", version = "0.42.3", package = "aprender-graph" }
 
 [workspace.lints.rust]
 # Safety
@@ -428,7 +428,7 @@ semicolon_if_nothing_returned = "allow"  # Style preference
 
 [package]
 name = "aprender"
-version = "0.42.2"
+version = "0.42.3"
 edition = "2021"
 rust-version = "1.89"
 authors = ["Noah Gift <noah@paiml.com>"]
@@ -458,7 +458,7 @@ required-features = ["cli"]
 # (e.g. apr-cookbook, downstream apps) don't pull apr-cli's heavy transitive
 # dep graph (renacer/profile/inference/zram/visualization). `cargo install
 # aprender` still works because `cli` is in default features. See GH-1599.
-apr-cli = { path = "crates/apr-cli", version = "0.42.2", default-features = true, optional = true }
+apr-cli = { path = "crates/apr-cli", version = "0.42.3", default-features = true, optional = true }
 # Core ML library (lib name = "aprender")
 aprender_ml = { path = "crates/aprender-core", version = ">=0.29", package = "aprender-core" }
 

--- a/crates/apr-cli/Cargo.toml
+++ b/crates/apr-cli/Cargo.toml
@@ -103,10 +103,10 @@ libc = "0.2"
 
 [dependencies]
 # Core aprender library
-aprender = { path = "../aprender-core", version = "0.42.2", package = "aprender-core", default-features = true, features = ["format-compression"] }
+aprender = { path = "../aprender-core", version = "0.42.3", package = "aprender-core", default-features = true, features = ["format-compression"] }
 
 # MCP (Model Context Protocol) server — `apr mcp` subcommand
-aprender-mcp = { path = "../aprender-mcp", version = "0.42.2" }
+aprender-mcp = { path = "../aprender-mcp", version = "0.42.3" }
 async-stream = "0.3"
 provable-contracts-macros = "0.3"
 

--- a/crates/aprender-bench-compute/Cargo.toml
+++ b/crates/aprender-bench-compute/Cargo.toml
@@ -11,7 +11,7 @@ disallowed_methods = "allow"
 
 [dependencies]
 # The implementation under test
-aprender = { path = "../aprender-core", version = "0.42.2", package = "aprender-core", features = ["format-quantize"] }
+aprender = { path = "../aprender-core", version = "0.42.3", package = "aprender-core", features = ["format-quantize"] }
 
 # Reference implementation for A/B comparison
 # Pure Rust (no BLAS) to keep comparison fair — both are pure Rust SIMD

--- a/crates/aprender-bench-tokenizer/Cargo.toml
+++ b/crates/aprender-bench-tokenizer/Cargo.toml
@@ -11,7 +11,7 @@ disallowed_methods = "allow"
 
 [dependencies]
 # The implementation under test
-aprender = { path = "../aprender-core", version = "0.42.2", package = "aprender-core" }
+aprender = { path = "../aprender-core", version = "0.42.3", package = "aprender-core" }
 
 # HuggingFace reference for A/B comparison
 # Regular dep (not dev-dep) because [[bench]] harness=false binaries can't see dev-deps

--- a/crates/aprender-cbtop/Cargo.toml
+++ b/crates/aprender-cbtop/Cargo.toml
@@ -23,8 +23,8 @@ presentar-core = "0.3"
 presentar-terminal = "0.3"
 
 # Compute backends
-trueno = { version = "0.42.2", path = "../aprender-compute", package = "aprender-compute" }
-trueno-gpu = { version = "0.42.2", path = "../aprender-gpu", package = "aprender-gpu", optional = true }
+trueno = { version = "0.42.3", path = "../aprender-compute", package = "aprender-compute" }
+trueno-gpu = { version = "0.42.3", path = "../aprender-gpu", package = "aprender-gpu", optional = true }
 
 # Terminal handling
 crossterm = "0.28"

--- a/crates/aprender-cgp/Cargo.toml
+++ b/crates/aprender-cgp/Cargo.toml
@@ -36,7 +36,7 @@ num_cpus = "1.17"
 comfy-table = "7"
 colored = "3"
 # GPU profiling: direct cuBLAS measurement (OWN THE STACK)
-trueno-gpu = { path = "../aprender-gpu", version = "0.42.2", features = ["cuda"], optional = true, package = "aprender-gpu" }
+trueno-gpu = { path = "../aprender-gpu", version = "0.42.3", features = ["cuda"], optional = true, package = "aprender-gpu" }
 
 [features]
 default = []

--- a/crates/aprender-compute/Cargo.toml
+++ b/crates/aprender-compute/Cargo.toml
@@ -38,11 +38,11 @@ futures-intrusive = { version = "0.5", optional = true }
 wasm-bindgen-futures = { version = "0.4", optional = true }
 wasm-bindgen = { version = "0.2", optional = true }
 # Native CUDA monitoring via trueno-gpu (TRUENO-SPEC-010)
-trueno-gpu = { version = "0.42.2", path = "../aprender-gpu", optional = true, package = "aprender-gpu" }
+trueno-gpu = { version = "0.42.3", path = "../aprender-gpu", optional = true, package = "aprender-gpu" }
 # PMAT-336: Provable contracts compile-time enforcement
 provable-contracts-macros = "0.3"
 # P1a: Sovereign GEMM microkernel codegen (compile-time shape specialization)
-trueno-gemm-codegen = { version = "0.42.2", path = "../aprender-gemm-codegen", package = "aprender-gemm-codegen" }
+trueno-gemm-codegen = { version = "0.42.3", path = "../aprender-gemm-codegen", package = "aprender-gemm-codegen" }
 # Tracing/profiling support (renacer integration)
 tracing = { version = "0.1", optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"], optional = true }
@@ -54,7 +54,7 @@ presentar-core = { version = "0.3", optional = true }
 # Stress test reporting types compatible with renacer (TRUENO-SPEC-025)
 # Note: renacer 0.9.1 has compilation issue; using compatible local types instead
 dhat = { version = "0.3", optional = true }
-trueno-quant = { version = "0.42.2", path = "../aprender-quant", package = "aprender-quant" }
+trueno-quant = { version = "0.42.3", path = "../aprender-quant", package = "aprender-quant" }
 num_cpus = "1.17.0"
 anyhow = "1.0.100"
 # Hardware capability detection (PMAT-447)
@@ -62,7 +62,7 @@ chrono = "0.4"
 toml = "0.8"
 # ML tuner integration (SHOWCASE-BRICK-001, Section 12)
 # Uses aprender 0.24.0 RandomForest for learned optimization
-aprender = { path = "../aprender-core", version = "0.42.2", package = "aprender-core", optional = true, default-features = false }
+aprender = { path = "../aprender-core", version = "0.42.3", package = "aprender-core", optional = true, default-features = false }
 # Execution path graph (PAR-201, Section E.7)
 trueno-graph = { workspace = true, optional = true }
 # TUI visualization for execution graphs (PAR-201)
@@ -90,10 +90,10 @@ nalgebra = "0.34"  # For eigendecomposition benchmark comparison
 simular = "0.2.0"
 regex = "1.11"  # For PTX/WGSL pattern validation in falsification tests
 # GPU edge-case test framework (TCE-001)
-trueno-cuda-edge = { version = "0.42.2", path = "../aprender-cuda-edge", package = "aprender-cuda-edge" }
+trueno-cuda-edge = { version = "0.42.3", path = "../aprender-cuda-edge", package = "aprender-cuda-edge" }
 # Sparse and solver crates for contract tests
-trueno-sparse = { version = "0.42.2", path = "../aprender-sparse", package = "aprender-sparse" }
-trueno-solve = { version = "0.42.2", path = "../aprender-solve", package = "aprender-solve" }
+trueno-sparse = { version = "0.42.3", path = "../aprender-sparse", package = "aprender-sparse" }
+trueno-solve = { version = "0.42.3", path = "../aprender-solve", package = "aprender-solve" }
 ndarray = "0.17.2"
 faer = "0.24"  # For GEMM benchmark comparison (fastest pure-Rust BLAS)
 matrixmultiply = "0.3"  # Direct matrixmultiply crate benchmark (engine behind ndarray)

--- a/crates/aprender-contracts-cli/Cargo.toml
+++ b/crates/aprender-contracts-cli/Cargo.toml
@@ -13,7 +13,7 @@ name = "pv"
 path = "src/main.rs"
 
 [dependencies]
-aprender-contracts = { path = "../aprender-contracts", version = "0.42.2" }
+aprender-contracts = { path = "../aprender-contracts", version = "0.42.3" }
 clap = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }

--- a/crates/aprender-contracts/Cargo.toml
+++ b/crates/aprender-contracts/Cargo.toml
@@ -19,7 +19,7 @@ kani = []
 name = "provable_contracts"
 
 [dependencies]
-provable-contracts-macros = { path = "../aprender-contracts-macros", version = "0.42.2", package = "aprender-contracts-macros" }
+provable-contracts-macros = { path = "../aprender-contracts-macros", version = "0.42.3", package = "aprender-contracts-macros" }
 regex = "1"
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/aprender-core/src/primitives/matrix.rs
+++ b/crates/aprender-core/src/primitives/matrix.rs
@@ -165,21 +165,30 @@ impl Matrix<f32> {
             return Err("Matrix dimensions don't match for multiplication");
         }
 
-        let mut result = vec![0.0; self.rows * other.cols];
-        for i in 0..self.rows {
-            for j in 0..other.cols {
-                let mut sum = 0.0;
-                for k in 0..self.cols {
-                    sum += self.get(i, k) * other.get(k, j);
+        // Cache-friendly `ikj` ordering: the inner loop is a contiguous AXPY
+        // (`c_row[j] += a_ik * b_row[j]`) over row-major memory, which LLVM
+        // auto-vectorizes — far faster than the naive `ijk` form with strided
+        // `get()` column access (which defeated both the cache and SIMD).
+        let (m, k_dim, n) = (self.rows, self.cols, other.cols);
+        let a = &self.data;
+        let b = &other.data;
+        let mut result = vec![0.0f32; m * n];
+        for i in 0..m {
+            let a_row = &a[i * k_dim..i * k_dim + k_dim];
+            let c_row = &mut result[i * n..i * n + n];
+            for k in 0..k_dim {
+                let a_ik = a_row[k];
+                let b_row = &b[k * n..k * n + n];
+                for j in 0..n {
+                    c_row[j] += a_ik * b_row[j];
                 }
-                result[i * other.cols + j] = sum;
             }
         }
 
         Ok(Self {
             data: result,
-            rows: self.rows,
-            cols: other.cols,
+            rows: m,
+            cols: n,
         })
     }
 

--- a/crates/aprender-cuda-edge/Cargo.toml
+++ b/crates/aprender-cuda-edge/Cargo.toml
@@ -15,7 +15,7 @@ name = "trueno_cuda_edge"
 [dependencies]
 thiserror = "2.0"
 serde = { version = "1.0", features = ["derive"] }
-trueno-gpu = { version = "0.42.2", path = "../aprender-gpu", package = "aprender-gpu", optional = true }
+trueno-gpu = { version = "0.42.3", path = "../aprender-gpu", package = "aprender-gpu", optional = true }
 
 [dev-dependencies]
 proptest = "1.6"

--- a/crates/aprender-explain/Cargo.toml
+++ b/crates/aprender-explain/Cargo.toml
@@ -25,7 +25,7 @@ presentar-terminal = "0.3"
 crossterm = "0.28"
 
 # Internal dependency for PTX generation
-trueno-gpu = { version = "0.42.2", path = "../aprender-gpu", package = "aprender-gpu", features = ["cuda"] }
+trueno-gpu = { version = "0.42.3", path = "../aprender-gpu", package = "aprender-gpu", features = ["cuda"] }
 
 [dev-dependencies]
 proptest = "1.4"

--- a/crates/aprender-graph/Cargo.toml
+++ b/crates/aprender-graph/Cargo.toml
@@ -28,7 +28,7 @@ anyhow = "1"
 thiserror = "2"
 
 # Phase 2+ dependencies
-aprender = { path = "../aprender-core", version = "0.42.2", package = "aprender-core" }                                        # Sparse matrix ops, PageRank
+aprender = { path = "../aprender-core", version = "0.42.3", package = "aprender-core" }                                        # Sparse matrix ops, PageRank
 trueno = "0.17"                                          # SIMD primitives
 trueno-db = "0.3.17"                                     # Columnar storage
 

--- a/crates/aprender-monte-carlo/Cargo.toml
+++ b/crates/aprender-monte-carlo/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 name = "aprender-monte-carlo"
 
 [dependencies]
-aprender = { path = "../../", version = "0.42.2" }
+aprender = { path = "../../", version = "0.42.3" }
 clap = { version = "4", features = ["derive"] }
 rand = "0.9"
 rand_chacha = "0.9"

--- a/crates/aprender-orchestrate/Cargo.toml
+++ b/crates/aprender-orchestrate/Cargo.toml
@@ -117,7 +117,7 @@ pacha = { version = "0.2", optional = true }
 realizar = { version = "0.8", optional = true, features = ["cuda"] }
 
 # ML algorithms and training (native-only)
-aprender = { path = "../aprender-core", version = "0.42.2", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.42.3", package = "aprender-core", optional = true }
 entrenar = { workspace = true, optional = true }
 alimentar = { version = "0.2", optional = true }
 

--- a/crates/aprender-profile/Cargo.toml
+++ b/crates/aprender-profile/Cargo.toml
@@ -74,7 +74,7 @@ trueno = { version = "0.17" }
 
 # Machine learning for anomaly detection (Sprint 23)
 # GH-581: Use path dep to avoid trueno version skew with local workspace
-aprender = { path = "../aprender-core", version = "0.42.2", package = "aprender-core" }
+aprender = { path = "../aprender-core", version = "0.42.3", package = "aprender-core" }
 
 # Lock-free data structures for ring buffer (Sprint 40)
 crossbeam = { version = "0.8", default-features = false, features = ["crossbeam-channel", "crossbeam-queue", "std"] }

--- a/crates/aprender-qa-runner/Cargo.toml
+++ b/crates/aprender-qa-runner/Cargo.toml
@@ -29,7 +29,7 @@ sha2 = "0.10"
 regex = { workspace = true }
 num_cpus = "1.16"
 safetensors = { workspace = true }
-jugar-probar = { version = "0.42.2", path = "../aprender-test-lib", package = "aprender-test-lib", features = ["llm-types"] }
+jugar-probar = { version = "0.42.3", path = "../aprender-test-lib", package = "aprender-test-lib", features = ["llm-types"] }
 # Test fixtures dependencies (optional)
 tempfile = { version = "3", optional = true }
 half = { version = "2.4", optional = true }

--- a/crates/aprender-registry/Cargo.toml
+++ b/crates/aprender-registry/Cargo.toml
@@ -42,7 +42,7 @@ zstd = { version = "0.13", optional = true }
 clap = { version = "4", features = ["derive"], optional = true }
 
 # Ecosystem integration
-aprender = { path = "../aprender-core", version = "0.42.2", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.42.3", package = "aprender-core", optional = true }
 alimentar = { version = "0.2.3", optional = true }
 
 # HTTP client (optional)

--- a/crates/aprender-serve/Cargo.toml
+++ b/crates/aprender-serve/Cargo.toml
@@ -39,7 +39,7 @@ name = "realizar"
 trueno = { version = "0.17", features = ["gpu"] }
 # CUDA PTX generation and runtime for NVIDIA GPUs (optional, pure Rust, no LLVM/nvcc)
 # v0.4.12: BatchedQ6K, MultiWarp, RopeNeox, FlashDecoding kernels
-trueno-gpu = { version = "0.42.2", path = "../aprender-gpu", package = "aprender-gpu", optional = true, features = ["cuda"] }  # APR-MONO single-source-of-truth
+trueno-gpu = { version = "0.42.3", path = "../aprender-gpu", package = "aprender-gpu", optional = true, features = ["cuda"] }  # APR-MONO single-source-of-truth
 # KV cache storage (for attention caching)
 trueno-db = { version = "0.3.16", optional = true }
 # K-quantization formats (Q4_K, Q5_K, Q6_K) - Toyota Way: ONE source of truth
@@ -53,7 +53,7 @@ renacer-core = { version = "0.1" }
 
 # ML algorithms and .apr model format (optional for aprender model serving)
 # v0.24.1: chat templates, GGUF tokenizer preservation (local may be newer)
-aprender = { path = "../aprender-core", version = "0.42.2", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.42.3", package = "aprender-core", optional = true }
 
 # Data loading library (optional for data pipeline examples)
 alimentar = { version = "0.2", optional = true, default-features = false, features = ["local", "shuffle"] }

--- a/crates/aprender-shell/Cargo.toml
+++ b/crates/aprender-shell/Cargo.toml
@@ -24,7 +24,7 @@ harness = false
 
 [dependencies]
 # Use path for local dev, crates.io for release
-aprender = { path = "../aprender-core", version = "0.42.2", package = "aprender-core", features = ["format-encryption", "format-compression", "format-homomorphic"] }
+aprender = { path = "../aprender-core", version = "0.42.3", package = "aprender-core", features = ["format-encryption", "format-compression", "format-homomorphic"] }
 clap = { version = "4", features = ["derive"] }
 dirs = "5"
 serde = { version = "1", features = ["derive"] }

--- a/crates/aprender-test-cli/Cargo.toml
+++ b/crates/aprender-test-cli/Cargo.toml
@@ -24,7 +24,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Core library (was: jugar-probar) — dep key preserves Rust identifier
-jugar-probar = { path = "../aprender-test-lib", version = "0.42.2", package = "aprender-test-lib" }
+jugar-probar = { path = "../aprender-test-lib", version = "0.42.3", package = "aprender-test-lib" }
 
 # CLI framework
 clap = { workspace = true }

--- a/crates/aprender-train-bench/Cargo.toml
+++ b/crates/aprender-train-bench/Cargo.toml
@@ -19,8 +19,8 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-entrenar = { version = "0.42.2", path = "../aprender-train", package = "aprender-train" }
-entrenar-common = { version = "0.42.2", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar = { version = "0.42.3", path = "../aprender-train", package = "aprender-train" }
+entrenar-common = { version = "0.42.3", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/aprender-train-distill/Cargo.toml
+++ b/crates/aprender-train-distill/Cargo.toml
@@ -32,8 +32,8 @@ cuda = ["entrenar/cuda"]
 shard-batch-source = []
 
 [dependencies]
-entrenar = { version = "0.42.2", path = "../aprender-train", package = "aprender-train" }
-entrenar-common = { version = "0.42.2", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar = { version = "0.42.3", path = "../aprender-train", package = "aprender-train" }
+entrenar-common = { version = "0.42.3", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/aprender-train-inspect/Cargo.toml
+++ b/crates/aprender-train-inspect/Cargo.toml
@@ -19,8 +19,8 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-entrenar = { version = "0.42.2", path = "../aprender-train", package = "aprender-train" }
-entrenar-common = { version = "0.42.2", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar = { version = "0.42.3", path = "../aprender-train", package = "aprender-train" }
+entrenar-common = { version = "0.42.3", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/aprender-train-lora/Cargo.toml
+++ b/crates/aprender-train-lora/Cargo.toml
@@ -19,8 +19,8 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-entrenar = { version = "0.42.2", path = "../aprender-train", package = "aprender-train" }
-entrenar-common = { version = "0.42.2", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar = { version = "0.42.3", path = "../aprender-train", package = "aprender-train" }
+entrenar-common = { version = "0.42.3", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/aprender-train-shell/Cargo.toml
+++ b/crates/aprender-train-shell/Cargo.toml
@@ -19,8 +19,8 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-entrenar = { version = "0.42.2", path = "../aprender-train", package = "aprender-train" }
-entrenar-common = { version = "0.42.2", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar = { version = "0.42.3", path = "../aprender-train", package = "aprender-train" }
+entrenar-common = { version = "0.42.3", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 rustyline = "14"
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/aprender-train/Cargo.toml
+++ b/crates/aprender-train/Cargo.toml
@@ -75,9 +75,9 @@ provable-contracts-macros = { version = "0.2" }
 # Core PAIML stack
 ndarray = "0.16"
 trueno = { version = "0.17", features = ["parallel"] }  # SIMD-accelerated compute
-trueno-gpu = { version = "0.42.2", path = "../aprender-gpu", package = "aprender-gpu", optional = true }  # CUDA compute (APR-MONO single-source-of-truth)
+trueno-gpu = { version = "0.42.3", path = "../aprender-gpu", package = "aprender-gpu", optional = true }  # CUDA compute (APR-MONO single-source-of-truth)
 realizar = { version = "0.8", optional = true }  # CUDA inference engine
-aprender = { path = "../aprender-core", version = "0.42.2", package = "aprender-core" }  # ML interpret module + .apr format + tokenizers
+aprender = { path = "../aprender-core", version = "0.42.3", package = "aprender-core" }  # ML interpret module + .apr format + tokenizers
 trueno-viz = { version = "0.2", features = ["terminal"] }  # Terminal visualization
 presentar-terminal = { version = "0.3.5", optional = true }  # Sovereign TUI framework (gated by "tui" feature)
 presentar-core = "0.3.4"  # Presentar core traits (crates.io — path removed, presentar restructured)

--- a/crates/aprender-tsp/Cargo.toml
+++ b/crates/aprender-tsp/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 name = "aprender-tsp"
 
 [dependencies]
-aprender = { path = "../../", version = "0.42.2" }
+aprender = { path = "../../", version = "0.42.3" }
 clap = { version = "4", features = ["derive"] }
 rand = "0.9"
 crc32fast = "1.4"

--- a/crates/aprender-verify-ml/Cargo.toml
+++ b/crates/aprender-verify-ml/Cargo.toml
@@ -50,7 +50,7 @@ uuid = { version = "1.11", features = ["v4", "serde"] }
 trueno = "0.7.3"
 
 # Machine learning for bug prediction (optional)
-aprender = { path = "../aprender-core", version = "0.42.2", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.42.3", package = "aprender-core", optional = true }
 
 # LLM fine-tuning integration (optional)
 entrenar = { workspace = true, optional = true }

--- a/crates/aprender-viz/Cargo.toml
+++ b/crates/aprender-viz/Cargo.toml
@@ -29,7 +29,7 @@ base64 = "0.22"
 thiserror = "2.0"
 
 # Optional: ML integration
-aprender = { path = "../aprender-core", version = "0.42.2", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.42.3", package = "aprender-core", optional = true }
 
 # Optional: Graph integration
 trueno-graph = { workspace = true, optional = true, default-features = false }


### PR DESCRIPTION
## v0.42.3 — first scikit-learn speed-beat (re-landed)

**Why a re-land:** the matmul optimization was accidentally committed to *local main* (a stale local `feat/pillar1-beat-sklearn-iris` branch shadowed `git checkout -b`, so the commit landed on main and the *old* branch state was pushed). #1931 therefore squash-landed v0.42.2 content, leaving main on the naive matmul. Recovered the original commit via cherry-pick onto this cleanly-named branch.

**The change:** `Matrix::matmul` was naive scalar `ijk` (bounds-checked `get()`, strided column access) — cache-hostile, no SIMD. Rewrote as cache-friendly `ikj` with a contiguous AXPY inner loop that LLVM auto-vectorizes.

| | fit+predict 10000×20 | R² |
|---|---|---|
| apr (before) | 3.27 ms | 0.9994 |
| **apr (after)** | **1.27 ms** | 0.9994 |
| scikit-learn (LAPACK) | 2.28 ms | 0.9996 |

→ **apr ~1.8× faster than scikit-learn**, R² parity. Numerically equivalent — **13,849 aprender-core tests pass, 0 fail**. matmul is framework-wide, so this also lifts Pillar 2 (tensors), PCA, and every Xᵀ X.

`cargo check --workspace` clean; GitHub-only release. Advances Pillar 1 (PMAT-717).

🤖 Generated with [Claude Code](https://claude.com/claude-code)