### PR TITLE
fix(coverage): clean:false — root-owned .pv/cache broke checkout on intel

### DIFF
--- a/.github/workflows/coverage-nightly.yml
+++ b/.github/workflows/coverage-nightly.yml
@@ -32,7 +32,13 @@ jobs:
     runs-on: [self-hosted, Linux, X64, clean-room]
     timeout-minutes: 75
     steps:
+      # clean: false — a coverage run builds from source and doesn't need a
+      # pristine tree, and the default git-clean choked on root-owned leftovers
+      # (e.g. contracts/.pv/cache from prior `pv` jobs → EACCES on rmdir),
+      # failing checkout before any coverage ran.
       - uses: actions/checkout@v4
+        with:
+          clean: false
 
       # Data + summary via the maintained Makefile machinery (handles the
       # mold-linker/config.toml dance + slow-test skips correctly). Non-blocking.


### PR DESCRIPTION
The coverage re-validation **ran on intel-clean-room-9** (runner targeting verified ✅) but `actions/checkout@v4` failed before any coverage step:

```
EACCES: permission denied, rmdir 'contracts/.pv/cache'
```

A root-owned leftover from prior `pv` jobs that the default git-clean can't remove — the known intel-runner-hygiene flake class (root-owned per-run dirs). Everything after skipped, so #1935 still shows the stale "unknown".

A coverage run builds from source and doesn't need a pristine tree, so `clean: false` sidesteps the failing clean. After merge I'll re-run `workflow_dispatch` once more and confirm #1935 finally shows a real coverage % + ranked gaps (this run will also be the first real test of the earlier COV_TARGET_DIR/pmat fixes, which never executed because checkout died first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)