### PR TITLE
fix(coverage): skip GPU/CUDA tests in make coverage (panic on GPU-less intel)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -294,6 +294,7 @@ coverage: ## Coverage summary + threshold check (warm: ~3min)
 		   --skip falsification --skip chaos --skip disconnect --skip benchmark_parity \
 		   --skip qwen2_generation --skip qwen2_golden --skip qwen2_weight --skip load_test \
 		   --skip spec_checklist_w --skip spec_checklist_u --skip verify_audio --skip g9_roofline \
+		   --skip cuda --skip gpu_ \
 		|| { test -f ~/.cargo/config.toml.bak && mv ~/.cargo/config.toml.bak ~/.cargo/config.toml; exit 1; }
 	@echo "📊 Phase 2: Coverage report (LCOV → lightweight)..."
 	@$(COV_CARGO_ENV) cargo llvm-cov report --lcov --ignore-filename-regex "$$(cat target/coverage/.exclude-re)" > target/coverage/lcov.info


### PR DESCRIPTION
**The actual coverage blocker, finally.** 4th validation on intel-clean-room (huge RAM, **no GPU**): checkout + `COV_TARGET_DIR` + pmat-resilience all worked — but `make coverage` Phase 1 failed because **aprender-gpu CUDA tests panic without a GPU** (`driver::cuda_tests::test_context_total_memory`, `::test_module_invalid_ptx_error`), so Phase 2 (the `TOTAL:` %) never ran → `pct=unknown`.

Add `--skip cuda --skip gpu_` to the `make coverage` test invocation — coverage is now portable to the GPU-less CI pool. GPU-kernel coverage needs a GPU anyway; CPU line coverage is the target.

After merge I re-run `workflow_dispatch` — expecting #1935 to finally show a real coverage %.

**Separate follow-up (noted, not fixed here):** those CUDA tests should *skip gracefully* without a GPU rather than panic — a test-quality issue in aprender-gpu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)