### PR TITLE
fix(coverage): exclude aprender-gpu crate (31 GPU tests fail on GPU-less intel)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -288,7 +288,7 @@ coverage: ## Coverage summary + threshold check (warm: ~3min)
 	@echo "🧪 Phase 1: Tests with instrumentation (CB-127-A: cargo llvm-cov test, not nextest)..."
 	@PROPTEST_CASES=10 QUICKCHECK_TESTS=10 RUST_MIN_STACK=16777216 CARGO_BUILD_JOBS=4 \
 		$(COV_CARGO_ENV) cargo llvm-cov test --no-report \
-		--workspace --lib \
+		--workspace --exclude aprender-gpu --lib \
 		--ignore-filename-regex "$$(cat target/coverage/.exclude-re)" \
 		-- --skip prop_gbm_expected_value --skip slow --skip heavy --skip h12_ --skip j2_ \
 		   --skip falsification --skip chaos --skip disconnect --skip benchmark_parity \


### PR DESCRIPTION
5th validation: `--skip cuda` cleared the `cuda_tests` panics, but `make coverage` Phase 1 **still failed** — `test result: FAILED. 2292 passed; 31 failed`. The 31 are all aprender-gpu GPU-driver tests (`driver::cublas_tests::*`, `driver::memory_fuzz_tests::*`) that need a GPU. Name-skipping is whack-a-mole; the clean countermeasure is **excluding the whole crate**: `--workspace --exclude aprender-gpu`. GPU-kernel coverage needs a GPU anyway, and the nightly runs on the GPU-less intel pool.

This should finally let Phase 2 emit `TOTAL:` → a real % in #1935. (Separate follow-up: those GPU tests should skip gracefully without hardware rather than fail.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)