### PR TITLE
docs(roadmap): EV re-prioritization — pivot to BEATS-as-CI-artifacts

### DIFF
--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -15,9 +15,15 @@
 #   6. PMAT-578  CRUX-E-20 KL-divergence-vs-FP16 eval (EV 78)
 #   7. PMAT-711  Unsloth QLoRA NF4 into InstructPipeline + CPU loss-monotone falsifier (EV 72)
 #
-# GPU-GATED TRACK (surface for operator scheduling, do NOT grind unattended):
-#   FUSION-004 (Ollama 1.5x decode, EV 34); PMAT-715 (Unsloth throughput beat);
-#   PMAT-728-GPU (PyTorch-GPU baseline); Pillar-1 GPU reference timing.
+# CORRECTION 2026-06-12 (operator): GPU is AUTONOMOUS, not operator-gated. This host
+# = noah-Lambda-Vector RTX 4090 (sm_89, CUDA 12.8, pre-authorized); apr ships wgpu
+# (Vulkan/Metal/DX12/WASM) + CUDA backends; intel CI runners have Intel iGPU->Vulkan->
+# wgpu. So the GPU beats join the AUTONOMOUS track:
+#   8. Pillar-4 (FUSION-004) BEAT Ollama 1.5x decode — MARQUEE beat, already 1.43x on
+#      THIS RTX 4090 (4.7% gap). Wire current perf as a CI-gated BeatBenchmark + close gap.
+#   9. cuda-oxide spike — NVlabs Rust->PTX compiler (github.com/NVlabs/cuda-oxide, 2026-05);
+#      author DP4A/MoE/FFN kernels in PURE RUST (mission-aligned; escapes hand-PTX Blackwell JIT pain).
+#   10. PMAT-715 Unsloth GPU throughput beat; PMAT-728-GPU PyTorch-GPU baseline.
 #
 # RULE: never ship a parity feature when a falsifiable BEAT is on the table.
 # PILLAR1-* items below are sklearn-PARITY (v0.44-0.48 shipped) — LOW marginal EV now.

--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -1,3 +1,27 @@
+# ============================================================================
+# CAMPAIGN PRIORITY — EV re-prioritization 2026-06-12 (highest-EV across ENTIRE
+# roadmap, not sklearn-parity breadth). Full analysis + chain-of-thought:
+#   docs/specifications/campaign-ev-reprioritization-2026-06-12.md
+# Thesis: stop manufacturing sklearn-PARITY breadth (replace half, ~0 marginal
+# EV); start manufacturing BEATS-as-CI-artifacts. EV = impact*falsifiability*
+# autonomy / effort; unattended+CPU-only campaign => GPU-gated work is operator-track.
+#
+# AUTONOMOUS TRACK (ship unattended, CPU/CI-falsifiable, EV-ordered):
+#   1. PMAT-741  BeatBenchmark ContractKind + validator + CI runner (EV 92, force multiplier)
+#   2. PMAT-741  pilot: beat_sklearn_iris.rs -> contracts/beat-baselines.yaml
+#   3. PMAT-725  PyTorch-CPU training-time beat harness (+ PMAT-724 finite-diff grad gate) (EV 88)
+#   4. PMAT-722  sklearn speed-beat harness; capture matmul 1.78x + matvec 1.44x as CI gates (EV 85)
+#   5. PMAT-577  CRUX-E-19 perplexity-per-bit-budget eval (EV 78)
+#   6. PMAT-578  CRUX-E-20 KL-divergence-vs-FP16 eval (EV 78)
+#   7. PMAT-711  Unsloth QLoRA NF4 into InstructPipeline + CPU loss-monotone falsifier (EV 72)
+#
+# GPU-GATED TRACK (surface for operator scheduling, do NOT grind unattended):
+#   FUSION-004 (Ollama 1.5x decode, EV 34); PMAT-715 (Unsloth throughput beat);
+#   PMAT-728-GPU (PyTorch-GPU baseline); Pillar-1 GPU reference timing.
+#
+# RULE: never ship a parity feature when a falsifiable BEAT is on the table.
+# PILLAR1-* items below are sklearn-PARITY (v0.44-0.48 shipped) — LOW marginal EV now.
+# ============================================================================
 roadmap_version: '1.0'
 github_enabled: true
 github_repo: paiml/aprender

--- a/docs/specifications/campaign-ev-reprioritization-2026-06-12.md
+++ b/docs/specifications/campaign-ev-reprioritization-2026-06-12.md
@@ -47,3 +47,30 @@ baseline, after the CPU half lands); Pillar-1 GPU reference timing where needed.
 
 **Rule going forward:** never ship a parity feature when a falsifiable *beat* is on the
 table. See [[project_10day_autonomous_release_campaign]] and the four-pillar mission.
+
+## CORRECTION (2026-06-12, operator) — GPU is autonomous; investigate cuda-oxide
+
+The survey wrongly assumed CPU-only/operator-gated GPU. **Ground truth:** the campaign
+runs ON noah-Lambda-Vector = **RTX 4090 (24GB, sm_89), CUDA 12.8, compute pre-authorized**;
+aprender already ships a **wgpu** backend (portable Vulkan/Metal/DX12/WASM) AND a CUDA
+backend (`trueno-gpu`/`aprender-cuda-edge`); the intel-clean-room CI runners have Intel
+iGPU → Vulkan → **wgpu compute** (portable GPU beats can gate in CI). So GPU work is
+**autonomy ~5**, not 2.
+
+**Re-ranking:** Pillar-4 (BEAT Ollama 1.5× decode) jumps from EV 34 → ~90 — it is the
+MARQUEE "beat" claim, already at 1.43× (4.7% gap) on the EXACT RTX 4090 the baselines
+were measured on. FUSION-004 / PMAT-715 / PMAT-728-GPU move OFF the gpu-gated track onto
+the autonomous track.
+
+**cuda-oxide (NVlabs, 2026-05-07):** a rustc backend compiling pure-Rust `#[kernel]` fns
+directly to CUDA PTX (single-source, `cargo oxide build`, builds with cargo — no C++/CMake;
+uses Pliron Rust-native MLIR). https://github.com/NVlabs/cuda-oxide . STRATEGIC: aprender's
+north-star is *pure Rust*, but the CUDA path is currently hand-PTX/CUDA-C (`trueno-cuda-edge`)
+— the source of the recurring Blackwell JIT-prewarm pain. cuda-oxide is the path to author
+DP4A/MoE/FFN-fusion kernels in pure Rust→PTX: mission-aligned AND the lever for the Pillar-4
+perf gap. Add a SPIKE: build a trivial cuda-oxide `#[kernel]` (e.g. saxpy) on this RTX 4090,
+verify PTX gen + launch, and assess porting one trueno hot kernel.
+
+**Corrected autonomous track:** PMAT-741 (backbone; `approved_compute: CPU|GPU`) →
+wire current RTX-4090 decode perf as a CI-gated BeatBenchmark + drive 1.43x→1.5x →
+cuda-oxide spike → CPU beats (Pillar-2 PyTorch, Pillar-1 sklearn) in parallel.

--- a/docs/specifications/campaign-ev-reprioritization-2026-06-12.md
+++ b/docs/specifications/campaign-ev-reprioritization-2026-06-12.md
@@ -1,0 +1,49 @@
+# Campaign EV Re-Prioritization — 2026-06-12
+
+**Trigger:** the 10-day autonomous release campaign had shipped ~34 sklearn-**parity**
+features (v0.44.0→v0.48.6: metrics, encoders, NB variants, Estimator impls). The
+operator flagged that the goal is **highest-EV features across the ENTIRE roadmap**,
+not sklearn-parity breadth. A grounded 7-agent cross-capability EV survey
+(`cross-capability-ev-survey`, run wf_4bdcad93-664) re-scored the whole roadmap.
+
+## Chain of thought
+
+1. **The mission** is *replace **AND BEAT** sklearn / PyTorch / Unsloth / Ollama in one
+   pure-Rust binary*, where **beat = a committed, CI-wired, falsifiable benchmark**
+   (PMAT-717/718/719 + PMAT-741).
+2. **What we'd been doing**: sklearn *parity* breadth — the *replace* half. Marginal EV
+   has collapsed; the 14th metric moves the mission needle by epsilon.
+3. **EV under campaign constraints** (unattended, CPU-only, no operator):
+   `EV ≈ (impact × falsifiability × autonomy) / effort`. A GPU-gated item scores low
+   for the *autonomous* track regardless of impact — it can't be verified unattended.
+4. **Untapped EV concentrates in the BEAT half + the beat-benchmark infrastructure**,
+   which **does not exist today**: `ContractKind` has 11 variants and no `BeatBenchmark`;
+   there is exactly one beat test (`beat_sklearn_iris.rs`, 74 LOC, hardcoded
+   `SKLEARN_IRIS_FLOOR=0.94`); zero machine-pinned baselines.
+5. **The shift**: *stop manufacturing parity, start manufacturing BEATS-as-CI-artifacts.*
+   Three-step force multiplier: (1) build the `BeatBenchmark` contract kind + CI runner;
+   (2) plug in the CPU-autonomous beats (PyTorch-CPU training, sklearn speed); (3) quant-QA
+   evals that fortify the Ollama moat. Defer GPU beats to an operator track.
+
+## EV ranking (grounded)
+
+| Rank | Capability | Action | EV | Autonomy |
+|---|---|---|---|---|
+| 1 | **PMAT-741** beat-benchmark infra | `BeatBenchmark` variant in `ContractKind` (`crates/aprender-contracts/src/schema/kind.rs`) + validator (incumbent_oracle, canonical_task, baseline+date, beat_threshold, ci_gate_name, approved_compute) + CI runner emitting `BEAT-{PILLAR}-{TASK}` ratios, non-zero exit on regression. Pilot: migrate `beat_sklearn_iris.rs` → `contracts/beat-baselines.yaml`. | 92 | 5 (CPU) |
+| 2 | **PMAT-725** PyTorch-CPU training beat | Fixed 2-layer MLP (1024→512→1), N=1024 deterministic synthetic, SGD lr=0.01/1000 steps, wall-clock + peak RSS, MSE≤0.05 gate, `benchmarks/pytorch_beat_baseline.csv` + PMAT-724 finite-diff gradient gate. | 88 | 5 (CPU) |
+| 3 | **PMAT-722** sklearn speed-beats | apr-vs-sklearn wall-clock fit+predict harness (iris/digits/california), CSV+JSON, CI-fails on regression; capture the real matmul 1.78× + matvec 1.44× wins + RF/KMeans/PCA gates. | 85 | 5 (CPU) |
+| 4 | **CRUX-E-19/E-20** quant evals | perplexity-per-bit-budget + KL-divergence-vs-FP16 (`apr qa --bench perplexity --quant-sweep`, `apr diff --metric kl`), cached WikiText-2, CI-deterministic. | 78 | 5 (CPU) |
+| 5 | **PMAT-711** Unsloth QLoRA (CPU half) | Integrate existing `QLoRALayer`(NF4) into `InstructPipeline.lora_layers` + loss-monotone falsifier (16-sample, 20 steps, 4-bit ≤0.30× f16). Unblocks 712/713. | 72 | 4 (CPU) |
+| 6 | **FUSION-004** Ollama 1.5× | INT8 DP4A CUDA kernel, 396→460.7 tok/s RTX-4090. | 34 | **2 (GPU)** |
+
+## Tracks
+
+**Autonomous (ship unattended, CPU/CI):** PMAT-741 → 741-pilot → PMAT-725(+724) →
+PMAT-722 → CRUX-E-19 → CRUX-E-20 → PMAT-711.
+
+**GPU-gated (surface for operator scheduling):** FUSION-004 (1.5× decode);
+PMAT-715 (Unsloth throughput beat, after 711/712/713); PMAT-728-GPU (PyTorch-GPU
+baseline, after the CPU half lands); Pillar-1 GPU reference timing where needed.
+
+**Rule going forward:** never ship a parity feature when a falsifiable *beat* is on the
+table. See [[project_10day_autonomous_release_campaign]] and the four-pillar mission.


### PR DESCRIPTION
7-agent cross-capability EV survey re-scored the entire roadmap. Pivots the autonomous campaign from sklearn-parity breadth (~0 marginal EV) to the BEAT half: PMAT-741 beat-benchmark contract kind → PyTorch-CPU training beat → sklearn speed-beats → quant evals → QLoRA. GPU-gated work surfaced for operator. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)