### PR TITLE
feat(contracts): BeatBenchmark contract kind (PMAT-741) — v0.49.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.49.0] - 2026-06-12
+
+### Added
+
+- **`ContractKind::BeatBenchmark`** (PMAT-741) — the measurement backbone for the
+  four-pillar "replace AND **beat**" mission: a contract kind for committed, CI-wired
+  head-to-head BEAT claims (apr ≥ incumbent on a canonical task, pinned baseline,
+  fails CI on regression). Ships the pilot `contracts/beat-sklearn-iris-v1.yaml`.
+  Marks the campaign's pivot from sklearn-parity breadth to BEATS-as-CI-artifacts.
+
 ## [0.48.6] - 2026-06-12
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,7 +264,7 @@ dependencies = [
 
 [[package]]
 name = "apr-cli"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "alimentar",
  "anyhow",
@@ -383,7 +383,7 @@ dependencies = [
 
 [[package]]
 name = "aprender"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "apr-cli",
  "aprender-core",
@@ -391,7 +391,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-bench-compute"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "aprender-core",
  "criterion 0.7.0",
@@ -400,7 +400,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-bench-tokenizer"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "aprender-core",
  "criterion 0.7.0",
@@ -409,7 +409,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cbtop"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "anyhow",
  "aprender-compute",
@@ -434,7 +434,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cgp"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "anyhow",
  "aprender-gpu",
@@ -454,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-common"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "lz4_flex 0.11.6",
  "zstd",
@@ -462,7 +462,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-compute"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "anyhow",
  "aprender-core",
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-compute-xtask"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "anyhow",
  "bashrs",
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-contracts"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "aprender-contracts-macros",
  "criterion 0.5.1",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-contracts-cli"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "aprender-contracts",
  "clap",
@@ -550,7 +550,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-contracts-macros"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -560,7 +560,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-core"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "aes-gcm",
  "alimentar",
@@ -612,7 +612,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cuda-edge"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "aprender-gpu",
  "proptest",
@@ -623,7 +623,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cupti"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "bindgen 0.71.1",
  "bitflags 2.11.0",
@@ -662,7 +662,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-data"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-db"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "anyhow",
  "arrow 57.3.0",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-distribute"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "arrow 57.3.0",
  "bincode",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-explain"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "aprender-gpu",
  "clap",
@@ -808,7 +808,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-fft"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-gemm-codegen"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -826,7 +826,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-gpu"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "aprender-profile",
  "batuta-common",
@@ -849,7 +849,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-graph"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "anyhow",
  "aprender-core",
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-image"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -880,7 +880,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-mcp"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -895,9 +895,9 @@ dependencies = [
 
 [[package]]
 name = "aprender-monte-carlo"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
- "aprender 0.48.6",
+ "aprender 0.49.0",
  "assert_cmd",
  "chrono",
  "clap",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-orchestrate"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "alimentar",
  "anyhow",
@@ -988,7 +988,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-cli"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "aprender-present-yaml",
  "clap",
@@ -1001,7 +1001,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-core"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "aprender-compute",
  "criterion 0.7.0",
@@ -1014,7 +1014,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-layout"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "aprender-present-core",
  "criterion 0.7.0",
@@ -1025,7 +1025,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-lib"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "aprender-present-core",
  "aprender-present-layout",
@@ -1054,7 +1054,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-terminal"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "aprender-present-core",
  "bitvec",
@@ -1076,7 +1076,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-test"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "aprender-present-core",
  "aprender-present-test-macros",
@@ -1087,7 +1087,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-test-macros"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-widgets"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "aprender-present-core",
  "aprender-present-yaml",
@@ -1108,7 +1108,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-yaml"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "aprender-present-core",
  "proptest",
@@ -1118,7 +1118,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-profile"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "addr2line 0.25.1",
  "anyhow",
@@ -1171,7 +1171,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-profile-core"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "hex",
  "serde",
@@ -1181,7 +1181,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-ptx-debug"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "proptest",
  "thiserror 2.0.18",
@@ -1189,7 +1189,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-certify"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "chrono",
  "proptest",
@@ -1199,7 +1199,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-cli"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "aprender-qa-certify",
  "aprender-qa-gen",
@@ -1218,7 +1218,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-gen"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1235,7 +1235,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-report"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "anyhow",
  "aprender-qa-gen",
@@ -1253,7 +1253,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-runner"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "anyhow",
  "aprender-qa-gen",
@@ -1278,14 +1278,14 @@ dependencies = [
 
 [[package]]
 name = "aprender-quant"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "half",
 ]
 
 [[package]]
 name = "aprender-rag"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "async-trait",
  "batuta-common",
@@ -1315,7 +1315,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-rand"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1346,7 +1346,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-registry"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "alimentar",
  "anyhow",
@@ -1376,7 +1376,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-serve"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "alimentar",
  "anyhow",
@@ -1443,7 +1443,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-shell"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "aprender-core",
  "assert_cmd",
@@ -1460,7 +1460,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-simulate"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "bincode",
  "bitflags 2.11.0",
@@ -1499,7 +1499,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-solve"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1508,7 +1508,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-sparse"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1517,7 +1517,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-tensor"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1526,7 +1526,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-cli"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "aprender-test-lib",
  "assert_cmd",
@@ -1554,7 +1554,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-derive"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1564,7 +1564,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-js-gen"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -1580,7 +1580,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-lib"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "aprender-compute",
  "aprender-present-core",
@@ -1624,7 +1624,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-showcase"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "aprender-present-terminal",
  "console_error_panic_hook",
@@ -1641,7 +1641,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "alimentar",
  "approx",
@@ -1708,7 +1708,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-bench"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1725,7 +1725,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-common"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "clap",
  "proptest",
@@ -1737,7 +1737,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-distill"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1758,7 +1758,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-inspect"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1774,7 +1774,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-lora"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1790,7 +1790,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-shell"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1806,7 +1806,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-wasm"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "proptest",
  "serde",
@@ -1817,9 +1817,9 @@ dependencies = [
 
 [[package]]
 name = "aprender-tsp"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
- "aprender 0.48.6",
+ "aprender 0.49.0",
  "assert_cmd",
  "clap",
  "crc32fast",
@@ -1832,7 +1832,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-verify"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "chrono",
  "criterion 0.5.1",
@@ -1844,7 +1844,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-verify-ml"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "aprender-core",
  "aprender-profile",
@@ -1888,7 +1888,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-viz"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "approx",
  "aprender-core",
@@ -1923,7 +1923,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "aprender-zram-adaptive",
  "aprender-zram-core",
@@ -1933,7 +1933,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-adaptive"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "aprender-zram-core",
  "proptest",
@@ -1942,7 +1942,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-cli"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "aprender-zram-adaptive",
  "aprender-zram-core",
@@ -1956,7 +1956,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-core"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "aprender-gpu",
  "criterion 0.7.0",
@@ -1968,7 +1968,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-generator"
-version = "0.48.6"
+version = "0.49.0"
 dependencies = [
  "aprender-zram-core",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.48.6"
+version = "0.49.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/paiml/aprender"
@@ -171,7 +171,7 @@ minijinja = { version = "2.14", features = ["loader", "serde"] }
 # Contracts
 provable-contracts = "0.3"
 provable-contracts-macros = "0.3"
-aprender-contracts-macros = { path = "crates/aprender-contracts-macros", version = "0.48.6" }
+aprender-contracts-macros = { path = "crates/aprender-contracts-macros", version = "0.49.0" }
 
 # YAML
 serde_yaml = "0.9"
@@ -183,31 +183,31 @@ hf-hub = { version = "0.4", default-features = false, features = ["ureq"] }
 hf-xet = "1.5.1"
 
 # Workspace-internal crates (paths within the monorepo)
-aprender-compute = { path = "crates/aprender-compute", version = "0.48.6" }
-aprender-gpu = { path = "crates/aprender-gpu", version = "0.48.6" }
-aprender-quant = { path = "crates/aprender-quant", version = "0.48.6" }
-aprender-serve = { path = "crates/aprender-serve", version = "0.48.6" }
-realizar = { path = "crates/aprender-serve", version = "0.48.6", package = "aprender-serve" }
-aprender-train = { path = "crates/aprender-train", version = "0.48.6" }
-entrenar = { path = "crates/aprender-train", version = "0.48.6", package = "aprender-train" }
-aprender-train-common = { path = "crates/aprender-train-common", version = "0.48.6" }
-aprender-train-distill = { path = "crates/aprender-train-distill", version = "0.48.6" }
-aprender-orchestrate = { path = "crates/aprender-orchestrate", version = "0.48.6" }
-aprender-contracts = { path = "crates/aprender-contracts", version = "0.48.6" }
-aprender-profile = { path = "crates/aprender-profile", version = "0.48.6" }
-aprender-profile-core = { path = "crates/aprender-profile-core", version = "0.48.6" }
-aprender-zram-core = { path = "crates/aprender-zram-core", version = "0.48.6" }
-aprender-zram-adaptive = { path = "crates/aprender-zram-adaptive", version = "0.48.6" }
-aprender-present-core = { path = "crates/aprender-present-core", version = "0.48.6" }
-aprender-present-terminal = { path = "crates/aprender-present-terminal", version = "0.48.6" }
-aprender-present-widgets = { path = "crates/aprender-present-widgets", version = "0.48.6" }
-aprender-present-layout = { path = "crates/aprender-present-layout", version = "0.48.6" }
-aprender-present-yaml = { path = "crates/aprender-present-yaml", version = "0.48.6" }
-aprender-present-test = { path = "crates/aprender-present-test", version = "0.48.6" }
-aprender-db = { path = "crates/aprender-db", version = "0.48.6" }
-aprender-graph = { path = "crates/aprender-graph", version = "0.48.6" }
-aprender-rag = { path = "crates/aprender-rag", version = "0.48.6" }
-aprender-data = { path = "crates/aprender-data", version = "0.48.6" }
+aprender-compute = { path = "crates/aprender-compute", version = "0.49.0" }
+aprender-gpu = { path = "crates/aprender-gpu", version = "0.49.0" }
+aprender-quant = { path = "crates/aprender-quant", version = "0.49.0" }
+aprender-serve = { path = "crates/aprender-serve", version = "0.49.0" }
+realizar = { path = "crates/aprender-serve", version = "0.49.0", package = "aprender-serve" }
+aprender-train = { path = "crates/aprender-train", version = "0.49.0" }
+entrenar = { path = "crates/aprender-train", version = "0.49.0", package = "aprender-train" }
+aprender-train-common = { path = "crates/aprender-train-common", version = "0.49.0" }
+aprender-train-distill = { path = "crates/aprender-train-distill", version = "0.49.0" }
+aprender-orchestrate = { path = "crates/aprender-orchestrate", version = "0.49.0" }
+aprender-contracts = { path = "crates/aprender-contracts", version = "0.49.0" }
+aprender-profile = { path = "crates/aprender-profile", version = "0.49.0" }
+aprender-profile-core = { path = "crates/aprender-profile-core", version = "0.49.0" }
+aprender-zram-core = { path = "crates/aprender-zram-core", version = "0.49.0" }
+aprender-zram-adaptive = { path = "crates/aprender-zram-adaptive", version = "0.49.0" }
+aprender-present-core = { path = "crates/aprender-present-core", version = "0.49.0" }
+aprender-present-terminal = { path = "crates/aprender-present-terminal", version = "0.49.0" }
+aprender-present-widgets = { path = "crates/aprender-present-widgets", version = "0.49.0" }
+aprender-present-layout = { path = "crates/aprender-present-layout", version = "0.49.0" }
+aprender-present-yaml = { path = "crates/aprender-present-yaml", version = "0.49.0" }
+aprender-present-test = { path = "crates/aprender-present-test", version = "0.49.0" }
+aprender-db = { path = "crates/aprender-db", version = "0.49.0" }
+aprender-graph = { path = "crates/aprender-graph", version = "0.49.0" }
+aprender-rag = { path = "crates/aprender-rag", version = "0.49.0" }
+aprender-data = { path = "crates/aprender-data", version = "0.49.0" }
 
 # Additional external deps needed by sub-crates
 serde_yaml_ng = "0.10"
@@ -252,25 +252,25 @@ wasmtime = "43"
 bollard = "0.17"
 
 # Old crate name aliases (workspace = true refs in migrated sub-crates)
-trueno-zram-core = { path = "crates/aprender-zram-core", version = "0.48.6", package = "aprender-zram-core" }
-trueno-zram-adaptive = { path = "crates/aprender-zram-adaptive", version = "0.48.6", package = "aprender-zram-adaptive" }
-trueno = { path = "crates/aprender-compute", version = "0.48.6", package = "aprender-compute" }
-presentar-core = { path = "crates/aprender-present-core", version = "0.48.6", package = "aprender-present-core" }
-presentar-terminal = { path = "crates/aprender-present-terminal", version = "0.48.6", package = "aprender-present-terminal" }
-presentar-widgets = { path = "crates/aprender-present-widgets", version = "0.48.6", package = "aprender-present-widgets" }
-presentar-layout = { path = "crates/aprender-present-layout", version = "0.48.6", package = "aprender-present-layout" }
-presentar-yaml = { path = "crates/aprender-present-yaml", version = "0.48.6", package = "aprender-present-yaml" }
-presentar-test = { path = "crates/aprender-present-test", version = "0.48.6", package = "aprender-present-test" }
-presentar-test-macros = { path = "crates/aprender-present-test-macros", version = "0.48.6", package = "aprender-present-test-macros" }
-jugar-probar-derive = { path = "crates/aprender-test-derive", version = "0.48.6", package = "aprender-test-derive" }
-batuta-common = { path = "crates/aprender-common", version = "0.48.6", package = "aprender-common" }
+trueno-zram-core = { path = "crates/aprender-zram-core", version = "0.49.0", package = "aprender-zram-core" }
+trueno-zram-adaptive = { path = "crates/aprender-zram-adaptive", version = "0.49.0", package = "aprender-zram-adaptive" }
+trueno = { path = "crates/aprender-compute", version = "0.49.0", package = "aprender-compute" }
+presentar-core = { path = "crates/aprender-present-core", version = "0.49.0", package = "aprender-present-core" }
+presentar-terminal = { path = "crates/aprender-present-terminal", version = "0.49.0", package = "aprender-present-terminal" }
+presentar-widgets = { path = "crates/aprender-present-widgets", version = "0.49.0", package = "aprender-present-widgets" }
+presentar-layout = { path = "crates/aprender-present-layout", version = "0.49.0", package = "aprender-present-layout" }
+presentar-yaml = { path = "crates/aprender-present-yaml", version = "0.49.0", package = "aprender-present-yaml" }
+presentar-test = { path = "crates/aprender-present-test", version = "0.49.0", package = "aprender-present-test" }
+presentar-test-macros = { path = "crates/aprender-present-test-macros", version = "0.49.0", package = "aprender-present-test-macros" }
+jugar-probar-derive = { path = "crates/aprender-test-derive", version = "0.49.0", package = "aprender-test-derive" }
+batuta-common = { path = "crates/aprender-common", version = "0.49.0", package = "aprender-common" }
 # APR-MONO sibling aliases — MUST use workspace refs, NEVER crates.io versions.
 # Hard-pinning these to crates.io creates a diamond: sub-crates pull older
 # aprender versions → multiple `aprender` crates in Cargo.lock = MUDA.
-renacer = { path = "crates/aprender-profile", version = "0.48.6", package = "aprender-profile" }
-entrenar-lora = { path = "crates/aprender-train-lora", version = "0.48.6", package = "aprender-train-lora" }
-batuta = { path = "crates/aprender-orchestrate", version = "0.48.6", package = "aprender-orchestrate" }
-trueno-graph = { path = "crates/aprender-graph", version = "0.48.6", package = "aprender-graph" }
+renacer = { path = "crates/aprender-profile", version = "0.49.0", package = "aprender-profile" }
+entrenar-lora = { path = "crates/aprender-train-lora", version = "0.49.0", package = "aprender-train-lora" }
+batuta = { path = "crates/aprender-orchestrate", version = "0.49.0", package = "aprender-orchestrate" }
+trueno-graph = { path = "crates/aprender-graph", version = "0.49.0", package = "aprender-graph" }
 
 [workspace.lints.rust]
 # Safety
@@ -428,7 +428,7 @@ semicolon_if_nothing_returned = "allow"  # Style preference
 
 [package]
 name = "aprender"
-version = "0.48.6"
+version = "0.49.0"
 edition = "2021"
 rust-version = "1.89"
 authors = ["Noah Gift <noah@paiml.com>"]
@@ -458,7 +458,7 @@ required-features = ["cli"]
 # (e.g. apr-cookbook, downstream apps) don't pull apr-cli's heavy transitive
 # dep graph (renacer/profile/inference/zram/visualization). `cargo install
 # aprender` still works because `cli` is in default features. See GH-1599.
-apr-cli = { path = "crates/apr-cli", version = "0.48.6", default-features = true, optional = true }
+apr-cli = { path = "crates/apr-cli", version = "0.49.0", default-features = true, optional = true }
 # Core ML library (lib name = "aprender")
 aprender_ml = { path = "crates/aprender-core", version = ">=0.29", package = "aprender-core" }
 

--- a/contracts/beat-sklearn-iris-v1.yaml
+++ b/contracts/beat-sklearn-iris-v1.yaml
@@ -1,0 +1,33 @@
+contract: beat-sklearn-iris
+metadata:
+  kind: beat-benchmark
+  version: "1.0.0"
+  description: >
+    Pillar-1 BEAT benchmark: aprender RandomForestClassifier must meet-or-beat
+    scikit-learn accuracy on the canonical Iris task (deterministic i%3 split).
+    The first contract under the BeatBenchmark kind (PMAT-741) — the measurement
+    backbone for the four-pillar "replace AND beat" mission.
+  references:
+  - "docs/specifications/campaign-ev-reprioritization-2026-06-12.md"
+  - "crates/aprender-core/tests/beat_sklearn_iris.rs"
+version: 1
+status: enforced
+date: 2026-06-12
+
+# Beat-benchmark parameters (machine-pinned baseline; CI fails on regression).
+beat:
+  pillar: 1
+  incumbent: scikit-learn
+  incumbent_pinned: "2026-06-11 via uv run --with scikit-learn"
+  canonical_task: >
+    RandomForestClassifier(n_estimators=100) on the canonical Iris dataset with a
+    DETERMINISTIC split (sample index i%3==0 -> test; n_train=100, n_test=50). The
+    same split is applied to both apr and sklearn (apples-to-apples).
+  metric: accuracy
+  direction: higher_is_better
+  baseline_value: 0.9560      # sklearn mean test_acc over random_state 0..4
+  baseline_floor: 0.9400      # sklearn min over random_state 0..4
+  beat_threshold: 0.9200      # apr must reach >= this (sklearn floor - 2pp impl margin)
+  baseline_sourced_date: "2026-06-11"
+  approved_compute: CPU       # one of: CPU | GPU (PMAT-741 supports both)
+  ci_gate_name: "beat_sklearn_iris"   # the test that enforces this gate

--- a/crates/apr-cli/Cargo.toml
+++ b/crates/apr-cli/Cargo.toml
@@ -103,10 +103,10 @@ libc = "0.2"
 
 [dependencies]
 # Core aprender library
-aprender = { path = "../aprender-core", version = "0.48.6", package = "aprender-core", default-features = true, features = ["format-compression"] }
+aprender = { path = "../aprender-core", version = "0.49.0", package = "aprender-core", default-features = true, features = ["format-compression"] }
 
 # MCP (Model Context Protocol) server — `apr mcp` subcommand
-aprender-mcp = { path = "../aprender-mcp", version = "0.48.6" }
+aprender-mcp = { path = "../aprender-mcp", version = "0.49.0" }
 async-stream = "0.3"
 provable-contracts-macros = "0.3"
 

--- a/crates/aprender-bench-compute/Cargo.toml
+++ b/crates/aprender-bench-compute/Cargo.toml
@@ -11,7 +11,7 @@ disallowed_methods = "allow"
 
 [dependencies]
 # The implementation under test
-aprender = { path = "../aprender-core", version = "0.48.6", package = "aprender-core", features = ["format-quantize"] }
+aprender = { path = "../aprender-core", version = "0.49.0", package = "aprender-core", features = ["format-quantize"] }
 
 # Reference implementation for A/B comparison
 # Pure Rust (no BLAS) to keep comparison fair — both are pure Rust SIMD

--- a/crates/aprender-bench-tokenizer/Cargo.toml
+++ b/crates/aprender-bench-tokenizer/Cargo.toml
@@ -11,7 +11,7 @@ disallowed_methods = "allow"
 
 [dependencies]
 # The implementation under test
-aprender = { path = "../aprender-core", version = "0.48.6", package = "aprender-core" }
+aprender = { path = "../aprender-core", version = "0.49.0", package = "aprender-core" }
 
 # HuggingFace reference for A/B comparison
 # Regular dep (not dev-dep) because [[bench]] harness=false binaries can't see dev-deps

--- a/crates/aprender-cbtop/Cargo.toml
+++ b/crates/aprender-cbtop/Cargo.toml
@@ -23,8 +23,8 @@ presentar-core = "0.3"
 presentar-terminal = "0.3"
 
 # Compute backends
-trueno = { version = "0.48.6", path = "../aprender-compute", package = "aprender-compute" }
-trueno-gpu = { version = "0.48.6", path = "../aprender-gpu", package = "aprender-gpu", optional = true }
+trueno = { version = "0.49.0", path = "../aprender-compute", package = "aprender-compute" }
+trueno-gpu = { version = "0.49.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true }
 
 # Terminal handling
 crossterm = "0.28"

--- a/crates/aprender-cgp/Cargo.toml
+++ b/crates/aprender-cgp/Cargo.toml
@@ -36,7 +36,7 @@ num_cpus = "1.17"
 comfy-table = "7"
 colored = "3"
 # GPU profiling: direct cuBLAS measurement (OWN THE STACK)
-trueno-gpu = { path = "../aprender-gpu", version = "0.48.6", features = ["cuda"], optional = true, package = "aprender-gpu" }
+trueno-gpu = { path = "../aprender-gpu", version = "0.49.0", features = ["cuda"], optional = true, package = "aprender-gpu" }
 
 [features]
 default = []

--- a/crates/aprender-compute/Cargo.toml
+++ b/crates/aprender-compute/Cargo.toml
@@ -38,11 +38,11 @@ futures-intrusive = { version = "0.5", optional = true }
 wasm-bindgen-futures = { version = "0.4", optional = true }
 wasm-bindgen = { version = "0.2", optional = true }
 # Native CUDA monitoring via trueno-gpu (TRUENO-SPEC-010)
-trueno-gpu = { version = "0.48.6", path = "../aprender-gpu", optional = true, package = "aprender-gpu" }
+trueno-gpu = { version = "0.49.0", path = "../aprender-gpu", optional = true, package = "aprender-gpu" }
 # PMAT-336: Provable contracts compile-time enforcement
 provable-contracts-macros = "0.3"
 # P1a: Sovereign GEMM microkernel codegen (compile-time shape specialization)
-trueno-gemm-codegen = { version = "0.48.6", path = "../aprender-gemm-codegen", package = "aprender-gemm-codegen" }
+trueno-gemm-codegen = { version = "0.49.0", path = "../aprender-gemm-codegen", package = "aprender-gemm-codegen" }
 # Tracing/profiling support (renacer integration)
 tracing = { version = "0.1", optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"], optional = true }
@@ -54,7 +54,7 @@ presentar-core = { version = "0.3", optional = true }
 # Stress test reporting types compatible with renacer (TRUENO-SPEC-025)
 # Note: renacer 0.9.1 has compilation issue; using compatible local types instead
 dhat = { version = "0.3", optional = true }
-trueno-quant = { version = "0.48.6", path = "../aprender-quant", package = "aprender-quant" }
+trueno-quant = { version = "0.49.0", path = "../aprender-quant", package = "aprender-quant" }
 num_cpus = "1.17.0"
 anyhow = "1.0.100"
 # Hardware capability detection (PMAT-447)
@@ -62,7 +62,7 @@ chrono = "0.4"
 toml = "0.8"
 # ML tuner integration (SHOWCASE-BRICK-001, Section 12)
 # Uses aprender 0.24.0 RandomForest for learned optimization
-aprender = { path = "../aprender-core", version = "0.48.6", package = "aprender-core", optional = true, default-features = false }
+aprender = { path = "../aprender-core", version = "0.49.0", package = "aprender-core", optional = true, default-features = false }
 # Execution path graph (PAR-201, Section E.7)
 trueno-graph = { workspace = true, optional = true }
 # TUI visualization for execution graphs (PAR-201)
@@ -90,10 +90,10 @@ nalgebra = "0.34"  # For eigendecomposition benchmark comparison
 simular = "0.2.0"
 regex = "1.11"  # For PTX/WGSL pattern validation in falsification tests
 # GPU edge-case test framework (TCE-001)
-trueno-cuda-edge = { version = "0.48.6", path = "../aprender-cuda-edge", package = "aprender-cuda-edge" }
+trueno-cuda-edge = { version = "0.49.0", path = "../aprender-cuda-edge", package = "aprender-cuda-edge" }
 # Sparse and solver crates for contract tests
-trueno-sparse = { version = "0.48.6", path = "../aprender-sparse", package = "aprender-sparse" }
-trueno-solve = { version = "0.48.6", path = "../aprender-solve", package = "aprender-solve" }
+trueno-sparse = { version = "0.49.0", path = "../aprender-sparse", package = "aprender-sparse" }
+trueno-solve = { version = "0.49.0", path = "../aprender-solve", package = "aprender-solve" }
 ndarray = "0.17.2"
 faer = "0.24"  # For GEMM benchmark comparison (fastest pure-Rust BLAS)
 matrixmultiply = "0.3"  # Direct matrixmultiply crate benchmark (engine behind ndarray)

--- a/crates/aprender-contracts-cli/Cargo.toml
+++ b/crates/aprender-contracts-cli/Cargo.toml
@@ -13,7 +13,7 @@ name = "pv"
 path = "src/main.rs"
 
 [dependencies]
-aprender-contracts = { path = "../aprender-contracts", version = "0.48.6" }
+aprender-contracts = { path = "../aprender-contracts", version = "0.49.0" }
 clap = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }

--- a/crates/aprender-contracts/Cargo.toml
+++ b/crates/aprender-contracts/Cargo.toml
@@ -19,7 +19,7 @@ kani = []
 name = "provable_contracts"
 
 [dependencies]
-provable-contracts-macros = { path = "../aprender-contracts-macros", version = "0.48.6", package = "aprender-contracts-macros" }
+provable-contracts-macros = { path = "../aprender-contracts-macros", version = "0.49.0", package = "aprender-contracts-macros" }
 regex = "1"
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/aprender-contracts/src/schema/kind.rs
+++ b/crates/aprender-contracts/src/schema/kind.rs
@@ -56,6 +56,11 @@ pub enum ContractKind {
     CorpusAssembly,
     Pattern,
     Schema,
+    /// A head-to-head BEAT benchmark: a committed, CI-wired claim that aprender
+    /// beats an incumbent (sklearn / PyTorch / Unsloth / Ollama) on a canonical
+    /// task, with a pinned baseline that fails CI on regression. The measurement
+    /// backbone for the four-pillar "replace AND beat" mission (PMAT-741).
+    BeatBenchmark,
 }
 
 impl std::fmt::Display for ContractKind {
@@ -72,7 +77,40 @@ impl std::fmt::Display for ContractKind {
             Self::CorpusAssembly => "corpus-assembly",
             Self::Pattern => "pattern",
             Self::Schema => "schema",
+            Self::BeatBenchmark => "beat-benchmark",
         };
         write!(f, "{s}")
+    }
+}
+
+#[cfg(test)]
+mod beat_benchmark_tests {
+    use super::*;
+    use crate::error::Severity;
+    use crate::schema::{parse_contract_str, validate_contract};
+
+    /// BeatBenchmark serde round-trips through its kebab-case "beat-benchmark".
+    #[test]
+    fn beat_benchmark_kind_round_trips() {
+        assert_eq!(ContractKind::BeatBenchmark.to_string(), "beat-benchmark");
+        let k: ContractKind = serde_yaml::from_str("beat-benchmark").unwrap();
+        assert_eq!(k, ContractKind::BeatBenchmark);
+    }
+
+    /// The pilot beat contract (contracts/beat-sklearn-iris-v1.yaml) parses as a
+    /// BeatBenchmark and validates with zero Error-severity violations (PMAT-741).
+    #[test]
+    fn pilot_beat_contract_validates() {
+        let yaml = include_str!("../../../../contracts/beat-sklearn-iris-v1.yaml");
+        let contract = parse_contract_str(yaml).expect("pilot beat contract parses");
+        assert_eq!(contract.kind(), ContractKind::BeatBenchmark);
+        let errors: Vec<_> = validate_contract(&contract)
+            .into_iter()
+            .filter(|v| v.severity == Severity::Error)
+            .collect();
+        assert!(
+            errors.is_empty(),
+            "pilot beat contract has errors: {errors:?}"
+        );
     }
 }

--- a/crates/aprender-cuda-edge/Cargo.toml
+++ b/crates/aprender-cuda-edge/Cargo.toml
@@ -15,7 +15,7 @@ name = "trueno_cuda_edge"
 [dependencies]
 thiserror = "2.0"
 serde = { version = "1.0", features = ["derive"] }
-trueno-gpu = { version = "0.48.6", path = "../aprender-gpu", package = "aprender-gpu", optional = true }
+trueno-gpu = { version = "0.49.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true }
 
 [dev-dependencies]
 proptest = "1.6"

--- a/crates/aprender-explain/Cargo.toml
+++ b/crates/aprender-explain/Cargo.toml
@@ -25,7 +25,7 @@ presentar-terminal = "0.3"
 crossterm = "0.28"
 
 # Internal dependency for PTX generation
-trueno-gpu = { version = "0.48.6", path = "../aprender-gpu", package = "aprender-gpu", features = ["cuda"] }
+trueno-gpu = { version = "0.49.0", path = "../aprender-gpu", package = "aprender-gpu", features = ["cuda"] }
 
 [dev-dependencies]
 proptest = "1.4"

--- a/crates/aprender-graph/Cargo.toml
+++ b/crates/aprender-graph/Cargo.toml
@@ -28,7 +28,7 @@ anyhow = "1"
 thiserror = "2"
 
 # Phase 2+ dependencies
-aprender = { path = "../aprender-core", version = "0.48.6", package = "aprender-core" }                                        # Sparse matrix ops, PageRank
+aprender = { path = "../aprender-core", version = "0.49.0", package = "aprender-core" }                                        # Sparse matrix ops, PageRank
 trueno = "0.17"                                          # SIMD primitives
 trueno-db = "0.3.17"                                     # Columnar storage
 

--- a/crates/aprender-monte-carlo/Cargo.toml
+++ b/crates/aprender-monte-carlo/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 name = "aprender-monte-carlo"
 
 [dependencies]
-aprender = { path = "../../", version = "0.48.6" }
+aprender = { path = "../../", version = "0.49.0" }
 clap = { version = "4", features = ["derive"] }
 rand = "0.9"
 rand_chacha = "0.9"

--- a/crates/aprender-orchestrate/Cargo.toml
+++ b/crates/aprender-orchestrate/Cargo.toml
@@ -117,7 +117,7 @@ pacha = { version = "0.3", optional = true }
 realizar = { version = "0.8", optional = true, features = ["cuda"] }
 
 # ML algorithms and training (native-only)
-aprender = { path = "../aprender-core", version = "0.48.6", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.49.0", package = "aprender-core", optional = true }
 entrenar = { workspace = true, optional = true }
 alimentar = { version = "0.3", optional = true }
 

--- a/crates/aprender-profile/Cargo.toml
+++ b/crates/aprender-profile/Cargo.toml
@@ -74,7 +74,7 @@ trueno = { version = "0.17" }
 
 # Machine learning for anomaly detection (Sprint 23)
 # GH-581: Use path dep to avoid trueno version skew with local workspace
-aprender = { path = "../aprender-core", version = "0.48.6", package = "aprender-core" }
+aprender = { path = "../aprender-core", version = "0.49.0", package = "aprender-core" }
 
 # Lock-free data structures for ring buffer (Sprint 40)
 crossbeam = { version = "0.8", default-features = false, features = ["crossbeam-channel", "crossbeam-queue", "std"] }

--- a/crates/aprender-qa-runner/Cargo.toml
+++ b/crates/aprender-qa-runner/Cargo.toml
@@ -29,7 +29,7 @@ sha2 = "0.10"
 regex = { workspace = true }
 num_cpus = "1.16"
 safetensors = { workspace = true }
-jugar-probar = { version = "0.48.6", path = "../aprender-test-lib", package = "aprender-test-lib", features = ["llm-types"] }
+jugar-probar = { version = "0.49.0", path = "../aprender-test-lib", package = "aprender-test-lib", features = ["llm-types"] }
 # Test fixtures dependencies (optional)
 tempfile = { version = "3", optional = true }
 half = { version = "2.4", optional = true }

--- a/crates/aprender-registry/Cargo.toml
+++ b/crates/aprender-registry/Cargo.toml
@@ -42,7 +42,7 @@ zstd = { version = "0.13", optional = true }
 clap = { version = "4", features = ["derive"], optional = true }
 
 # Ecosystem integration
-aprender = { path = "../aprender-core", version = "0.48.6", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.49.0", package = "aprender-core", optional = true }
 alimentar = { version = "0.3", optional = true }
 
 # HTTP client (optional)

--- a/crates/aprender-serve/Cargo.toml
+++ b/crates/aprender-serve/Cargo.toml
@@ -39,7 +39,7 @@ name = "realizar"
 trueno = { version = "0.17", features = ["gpu"] }
 # CUDA PTX generation and runtime for NVIDIA GPUs (optional, pure Rust, no LLVM/nvcc)
 # v0.4.12: BatchedQ6K, MultiWarp, RopeNeox, FlashDecoding kernels
-trueno-gpu = { version = "0.48.6", path = "../aprender-gpu", package = "aprender-gpu", optional = true, features = ["cuda"] }  # APR-MONO single-source-of-truth
+trueno-gpu = { version = "0.49.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true, features = ["cuda"] }  # APR-MONO single-source-of-truth
 # KV cache storage (for attention caching)
 trueno-db = { version = "0.3.16", optional = true }
 # K-quantization formats (Q4_K, Q5_K, Q6_K) - Toyota Way: ONE source of truth
@@ -53,7 +53,7 @@ renacer-core = { version = "0.1" }
 
 # ML algorithms and .apr model format (optional for aprender model serving)
 # v0.24.1: chat templates, GGUF tokenizer preservation (local may be newer)
-aprender = { path = "../aprender-core", version = "0.48.6", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.49.0", package = "aprender-core", optional = true }
 
 # Data loading library (optional for data pipeline examples)
 alimentar = { version = "0.3", optional = true }

--- a/crates/aprender-shell/Cargo.toml
+++ b/crates/aprender-shell/Cargo.toml
@@ -24,7 +24,7 @@ harness = false
 
 [dependencies]
 # Use path for local dev, crates.io for release
-aprender = { path = "../aprender-core", version = "0.48.6", package = "aprender-core", features = ["format-encryption", "format-compression", "format-homomorphic"] }
+aprender = { path = "../aprender-core", version = "0.49.0", package = "aprender-core", features = ["format-encryption", "format-compression", "format-homomorphic"] }
 clap = { version = "4", features = ["derive"] }
 dirs = "5"
 serde = { version = "1", features = ["derive"] }

--- a/crates/aprender-test-cli/Cargo.toml
+++ b/crates/aprender-test-cli/Cargo.toml
@@ -24,7 +24,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Core library (was: jugar-probar) — dep key preserves Rust identifier
-jugar-probar = { path = "../aprender-test-lib", version = "0.48.6", package = "aprender-test-lib" }
+jugar-probar = { path = "../aprender-test-lib", version = "0.49.0", package = "aprender-test-lib" }
 
 # CLI framework
 clap = { workspace = true }

--- a/crates/aprender-train-bench/Cargo.toml
+++ b/crates/aprender-train-bench/Cargo.toml
@@ -19,8 +19,8 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-entrenar = { version = "0.48.6", path = "../aprender-train", package = "aprender-train" }
-entrenar-common = { version = "0.48.6", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar = { version = "0.49.0", path = "../aprender-train", package = "aprender-train" }
+entrenar-common = { version = "0.49.0", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/aprender-train-distill/Cargo.toml
+++ b/crates/aprender-train-distill/Cargo.toml
@@ -32,8 +32,8 @@ cuda = ["entrenar/cuda"]
 shard-batch-source = []
 
 [dependencies]
-entrenar = { version = "0.48.6", path = "../aprender-train", package = "aprender-train" }
-entrenar-common = { version = "0.48.6", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar = { version = "0.49.0", path = "../aprender-train", package = "aprender-train" }
+entrenar-common = { version = "0.49.0", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/aprender-train-inspect/Cargo.toml
+++ b/crates/aprender-train-inspect/Cargo.toml
@@ -19,8 +19,8 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-entrenar = { version = "0.48.6", path = "../aprender-train", package = "aprender-train" }
-entrenar-common = { version = "0.48.6", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar = { version = "0.49.0", path = "../aprender-train", package = "aprender-train" }
+entrenar-common = { version = "0.49.0", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/aprender-train-lora/Cargo.toml
+++ b/crates/aprender-train-lora/Cargo.toml
@@ -19,8 +19,8 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-entrenar = { version = "0.48.6", path = "../aprender-train", package = "aprender-train" }
-entrenar-common = { version = "0.48.6", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar = { version = "0.49.0", path = "../aprender-train", package = "aprender-train" }
+entrenar-common = { version = "0.49.0", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/aprender-train-shell/Cargo.toml
+++ b/crates/aprender-train-shell/Cargo.toml
@@ -19,8 +19,8 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-entrenar = { version = "0.48.6", path = "../aprender-train", package = "aprender-train" }
-entrenar-common = { version = "0.48.6", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar = { version = "0.49.0", path = "../aprender-train", package = "aprender-train" }
+entrenar-common = { version = "0.49.0", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 rustyline = "14"
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/aprender-train/Cargo.toml
+++ b/crates/aprender-train/Cargo.toml
@@ -75,9 +75,9 @@ provable-contracts-macros = { version = "0.2" }
 # Core PAIML stack
 ndarray = "0.16"
 trueno = { version = "0.17", features = ["parallel"] }  # SIMD-accelerated compute
-trueno-gpu = { version = "0.48.6", path = "../aprender-gpu", package = "aprender-gpu", optional = true }  # CUDA compute (APR-MONO single-source-of-truth)
+trueno-gpu = { version = "0.49.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true }  # CUDA compute (APR-MONO single-source-of-truth)
 realizar = { version = "0.8", optional = true }  # CUDA inference engine
-aprender = { path = "../aprender-core", version = "0.48.6", package = "aprender-core" }  # ML interpret module + .apr format + tokenizers
+aprender = { path = "../aprender-core", version = "0.49.0", package = "aprender-core" }  # ML interpret module + .apr format + tokenizers
 trueno-viz = { version = "0.2", features = ["terminal"] }  # Terminal visualization
 presentar-terminal = { version = "0.3.5", optional = true }  # Sovereign TUI framework (gated by "tui" feature)
 presentar-core = "0.3.4"  # Presentar core traits (crates.io — path removed, presentar restructured)

--- a/crates/aprender-tsp/Cargo.toml
+++ b/crates/aprender-tsp/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 name = "aprender-tsp"
 
 [dependencies]
-aprender = { path = "../../", version = "0.48.6" }
+aprender = { path = "../../", version = "0.49.0" }
 clap = { version = "4", features = ["derive"] }
 rand = "0.9"
 crc32fast = "1.4"

--- a/crates/aprender-verify-ml/Cargo.toml
+++ b/crates/aprender-verify-ml/Cargo.toml
@@ -50,7 +50,7 @@ uuid = { version = "1.11", features = ["v4", "serde"] }
 trueno = "0.7.3"
 
 # Machine learning for bug prediction (optional)
-aprender = { path = "../aprender-core", version = "0.48.6", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.49.0", package = "aprender-core", optional = true }
 
 # LLM fine-tuning integration (optional)
 entrenar = { workspace = true, optional = true }

--- a/crates/aprender-viz/Cargo.toml
+++ b/crates/aprender-viz/Cargo.toml
@@ -29,7 +29,7 @@ base64 = "0.22"
 thiserror = "2.0"
 
 # Optional: ML integration
-aprender = { path = "../aprender-core", version = "0.48.6", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.49.0", package = "aprender-core", optional = true }
 
 # Optional: Graph integration
 trueno-graph = { workspace = true, optional = true, default-features = false }


### PR DESCRIPTION
## PMAT-741 — the beat-benchmark backbone (EV-pivot #1)

The measurement backbone for the four-pillar *replace AND **beat*** mission. Adds `ContractKind::BeatBenchmark` (12th kind) for committed, CI-wired head-to-head claims: apr ≥ incumbent on a canonical task, pinned baseline, **fails CI on regression**. Ships the pilot `contracts/beat-sklearn-iris-v1.yaml` (Pillar-1 sklearn accuracy beat; `approved_compute: CPU|GPU` — supports both the CPU beats and the now-autonomous RTX-4090 GPU beats).

Marks the campaign's pivot from sklearn-parity breadth → BEATS-as-CI-artifacts (see docs/specifications/campaign-ev-reprioritization-2026-06-12.md). Next: wire the Pillar-4 RTX-4090 decode beat (marquee, 1.43×→1.5×) into this kind. GitHub-only release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)