### PR TITLE
docs(campaign): re-baseline 10-day BEAT schedule against verified main state

### DIFF
--- a/docs/specifications/beat-campaign-10day-schedule-2026-06-12.md
+++ b/docs/specifications/beat-campaign-10day-schedule-2026-06-12.md
@@ -79,14 +79,19 @@ and Day 8 = Fri 2026-06-19. GitHub release per increment.
    (6 lagging crates, dependency order, `apr-cli` last, from a clean `origin/main`) — **not** a
    new version bump. (The morning intro's "0.35.0→0.49.x" is itself stale; it's a 0.41.0 split.)
 
-6. **One NEW risk the morning plan didn't carry:** the **lint-harmonization sweep** (31
-   crates, +595/−1933, real bugs fixed incl. `await_holding_lock` + two boolean-logic bugs) is
-   **committed on `feat/apr-mono-self-containment` but has NO open PR** and is **not on main**.
-   Now that those ~30 ex-repo crates are in the workspace graph, `clippy --all-targets -D
-   warnings` (the `ci/lint` gate) will fail for them until this lands. **This is the top
-   foundation risk and the first action below — ahead of any beat work.** (Land on a fresh
-   uniquely-named branch; the original was already squash-merged as #1975, and reuse strands
-   commits — see `feedback_checkout_b_branch_reuse_noop`.)
+6. **The foundation is VERIFIED COMPLETE — there is no "lint PR" left to land.** An earlier
+   draft (and the state audit) flagged the 31-crate lint-harmonization sweep as "committed on
+   `feat/apr-mono-self-containment` but no PR → top risk," reasoning from **SHA-ancestry**.
+   That is the same false-positive that misread v0.49.0: the lint sweep **leapfrogged onto
+   main by CONTENT via the `#1975` + §S squash cascade**. Spot-verified on `origin/main`: the
+   `indexed_ffn` boolean fix (`<10||(10..=12)`→`<=12`, `indexed_ffn.rs:126`), the `deny.toml`
+   RUSTSEC-2026-0173 ignore, the `FusedQKVHwDp4aQ4KGemv` to_index fix, the §S consolidation-doc
+   section, and the 966-line `aprender-viz/src/interop/entrenar.rs` deletion are **all on
+   main**; the lint-touched crate files are **byte-identical** between main and the branch; and
+   **`ci / lint` is SUCCESS** on the latest main-based PR (`#1989`). The
+   `feat/apr-mono-self-containment` branch is therefore **fully superseded and safe to
+   delete** (cleanup, not blocking). **Net: the real action #0 is the beat-infra itself
+   (validator rules + making the iris test actually run in CI), not any foundation PR.**
 
 ### Corrected day-by-day (window 2026-06-12 → 2026-06-21)
 
@@ -97,11 +102,10 @@ Legend: **[F]** = foundation closeout, **[I]** = beat-infra, **[P1..P4]** = pill
 - ✅ [I] Day-1 prereq auto-cleared: PMAT-741 BeatBenchmark + pilot on main, v0.49.0 tagged + released.
 - ✅ [F] Foundation hardened: `#1975` self-contained DAG MERGED; §S `#1982/83/84/85` MERGED; flaky root-fixes `#1988/#1989` armed; disk-recycle live.
 - ⏳ Carried to Day 2: BeatBenchmark validator rules + tests; cuda-oxide gx10 provisioning.
-- 🔴 Surfaced: lint-sweep has **no PR** (top risk).
+- ✅ Verified: lint sweep + self-containment fully on main, `ci/lint` green; `feat/apr-mono-self-containment` is superseded (deletable). No foundation PR outstanding.
 
-**Day 2 — Sat 2026-06-13 — foundation closeout + first beat actually runs in CI**
-- [F][cpu-ci] **Open + land the lint-harmonization PR** (fresh branch) → green `clippy -D warnings` for all ~30 ex-repo crates. *Gates everything; do first.*
-- [F][cpu-ci] Land §S `#1986/#1987` (update-branch + auto-merge).
+**Day 2 — Sat 2026-06-13 — first beat actually runs in CI**
+- [F][cpu-ci] Land §S `#1986/#1987` (update-branch + auto-merge) — last foundation PRs in flight.
 - [I][cpu-ci] `validate_beat_benchmark()` in `validator.rs` (incumbent ∈ four-pillar enum, metric present, numeric `beat_threshold`, direction) + 6 negative-case validator_tests.
 - [I][cpu-ci] Make `beat_sklearn_iris` **contract-driven** (read `beat-sklearn-iris-v1.yaml`) **and add `--test beat_*` to `ci.yml`** so the gate actually executes → first beat live in CI.
 - [gx10] cuda-oxide Spike1: provision LLVM-21 + nightly-2026-04-03 + `cargo-oxide` (GPU is idle, pre-authorized).
@@ -152,7 +156,7 @@ Legend: **[F]** = foundation closeout, **[I]** = beat-infra, **[P1..P4]** = pill
 |---|---|---|
 | Day-1 PMAT-741 merge | the gating prereq, do first | **DONE** (auto via §S squash leapfrog) |
 | Real Day-1 spend | validator + beat-runner + cuda-oxide | **foundation hardening** (self-containment, flaky-kill, §S) |
-| Top risk | PMAT-741 merge slips | **lint sweep has no PR** → `ci/lint` red for ~30 crates |
+| Top risk | PMAT-741 merge slips | **none in foundation** — lint + self-containment already on main, `ci/lint` green; remaining risk is beat-infra build effort + the honest Ollama gap |
 | First WON | iris (Day 2) | iris (Day 3, after the test is made to actually RUN in CI) |
 | Ollama pin | 1.43× / 440 tok/s | **honest ~1.32× 5-run p50** (re-measure before pinning) |
 | Friday cascade | "catch up 0.35→0.49" | **finish the 0.49.0 split-cascade** (6 lagging crates, not a bump) |

--- a/docs/specifications/beat-campaign-10day-schedule-2026-06-12.md
+++ b/docs/specifications/beat-campaign-10day-schedule-2026-06-12.md
@@ -7,6 +7,159 @@ artifacts** across the 4 pillars + cuda-oxide, parallelized over 4 autonomous ho
 **Friday crates.io cascades:** Day 1 = Fri 2026-06-12 (today; catch crates.io up 0.35.0→0.49.x)
 and Day 8 = Fri 2026-06-19. GitHub release per increment.
 
+---
+
+## ⟳ RE-BASELINE — 2026-06-12 (evening): verified state + corrected plan
+
+> Authored after a 6-agent state audit (`campaign-state-audit`, run `wf_1a21097f-335`)
+> verified the true state of `origin/main` against the morning plan below. **Net: the
+> campaign is ON TRACK — the highest-priority Day-1 prereq cleared itself, and an unplanned
+> foundation-hardening pass bought the CI reliability the beat-gates structurally require —
+> but the beat-infra _above the enum_ (validator rules, runner, gate, real contracts) is
+> still essentially Day-1 work, and one foundation gap (the lint sweep has no PR) is now the
+> top risk.** The day-by-day below this section is the original morning plan, kept for
+> provenance; the corrected sequence here supersedes it.
+
+### Chain of thought
+
+1. **The morning plan's #1 PREREQ is already satisfied.** It assumed PMAT-741 lived only on
+   `feat/beat-benchmark-contract-kind` (`main=7cd3f3626`) and that a Day-1 fast-track merge
+   gated the whole campaign. Verified: `ContractKind::BeatBenchmark` (`kind.rs:63`) + the
+   pilot `contracts/beat-sklearn-iris-v1.yaml` are **on origin/main** at **v0.49.0** (squash
+   commit `85b64ee05`; git tag + GitHub release both exist and are ancestors of main). The
+   morning Day-1 critical-path item is **DONE** and its rebase-on-feat-branch contingency is
+   **moot** — reclaim that slack.
+
+2. **An unplanned "foundation" pass consumed most of real Day 1 — and that was correct, not a
+   detour.** The entire BEAT thesis is *falsifiable CI gates that hard-fail on regression*. A
+   gate is only trustworthy if **RED means a real regression** — not a flaky proptest seed, a
+   stranded un-linted crate failing `clippy -D warnings`, a duplicate crates.io `trueno`
+   re-entering via a registry pin, or an Intel runner at 100% disk. So what landed today is a
+   **precondition** for the campaign, not a distraction from it:
+   - `#1975` **self-contained-DAG** monorepo (MERGED `e54c1a3e1`) — all 92 sibling deps are
+     now `workspace=true` path aliases; a 16-crate dependency cycle broken → no
+     published-sibling drift can poison a beat run.
+   - **Flaky-test root-fixes** `#1988` (numerically-stable variance — kills the stddev
+     translation-invariance flake) + `#1989` (proptest 1.11.0 float-sampler false
+     `debug_assert` suppressed per-package + `INIT_SEED` determinism lock) → a green run now
+     *means* green. **These ARE the campaign's single biggest CI-reliability lever.**
+   - **§S consolidation** `#1982/1983/1984/1985` MERGED; `#1986/1987` in-flight (assumed to
+     land per the user's "assuming these will all work").
+   - **Intel disk-recycle** live (keeps runners online).
+
+3. **But the beat-infra above the `ContractKind` enum is ~all still Day-1 work.** Verified
+   gaps on main: **no** `validate_beat_benchmark()` rules (the variant falls through to the
+   generic non-kernel branch in `validator.rs`); **no** validator_tests (only a serde
+   round-trip + one happy-path "pilot validates"); **no** `apr beat-run` CLI; **no**
+   `beat-gate.yml` workflow; only **one** beat contract, whose threshold is **hardcoded** in
+   `beat_sklearn_iris.rs:25-27` (it never deserializes the YAML) — and that test **isn't even
+   executed by CI** (it's an integration test absent from `ci.yml`'s integration list). We
+   have the *vocabulary* for beats (the kind) but **zero CI-gated beats**.
+
+4. **Per-pillar, the honest status is "precursors exist, gates don't":**
+   - **P1 sklearn:** iris *accuracy*-parity test exists (not run by CI); matmul **1.78×** +
+     matvec **1.44×** speed wins are real (`matrix.rs:163` ikj) but live only in commit
+     messages / CHANGELOG — **no harness, no gate**; RF/KMeans/PCA speed-beats not started.
+   - **P2 PyTorch:** autograd `finite_difference` util exists but proptests assert tol **0.2**,
+     not the spec's **1e-3**, with no FALSIFY-GRADIENT contract; the PyTorch-CPU training beat
+     has **no harness, no baseline CSV, no contract**.
+   - **P3 Unsloth:** `QLoRALayer` (NF4) exists (`qlora.rs:22`) but is **not wired** into
+     `InstructPipeline` (still `Vec<LoRALayer>` f32, `mod.rs:176`); `merge_export` has **no
+     GGUF path**; `apr finetune` training is an explicit **stub** (`finetune.rs:735`).
+   - **P4 Ollama:** **no contract, no workflow** — numbers are memory-only, and the **honest
+     5-run median is ~1.32×, not 1.43×** (the higher figure is Ollama-baseline ±8% variance).
+     `FUSION-004` DP4A (the 1.32→1.5× lever) is a PLANNED contract entry only. cuda-oxide on
+     gx10: **GB10 GPU confirmed idle (0%)**, but LLVM-21 absent + `cargo-oxide` + nightly not
+     installed (exactly the predicted Day-1/2 provisioning).
+
+5. **crates.io is split, not uniformly behind.** `aprender-core` + `aprender-contracts` are
+   already **0.49.0**; the facade + dependents (`apr-cli`, `aprender`, `aprender-mcp`,
+   `-compute`, `-serve`, `-train`) are stranded at **0.41.0**, so `cargo install aprender`
+   still yields 0.41.0. The Friday cascade is therefore **finish the partial 0.49.0 publish**
+   (6 lagging crates, dependency order, `apr-cli` last, from a clean `origin/main`) — **not** a
+   new version bump. (The morning intro's "0.35.0→0.49.x" is itself stale; it's a 0.41.0 split.)
+
+6. **One NEW risk the morning plan didn't carry:** the **lint-harmonization sweep** (31
+   crates, +595/−1933, real bugs fixed incl. `await_holding_lock` + two boolean-logic bugs) is
+   **committed on `feat/apr-mono-self-containment` but has NO open PR** and is **not on main**.
+   Now that those ~30 ex-repo crates are in the workspace graph, `clippy --all-targets -D
+   warnings` (the `ci/lint` gate) will fail for them until this lands. **This is the top
+   foundation risk and the first action below — ahead of any beat work.** (Land on a fresh
+   uniquely-named branch; the original was already squash-merged as #1975, and reuse strands
+   commits — see `feedback_checkout_b_branch_reuse_noop`.)
+
+### Corrected day-by-day (window 2026-06-12 → 2026-06-21)
+
+Legend: **[F]** = foundation closeout, **[I]** = beat-infra, **[P1..P4]** = pillar beat,
+**[X]** = quant eval, **[R]** = release/cadence. Host tags as in the original.
+
+**Day 1 — Fri 2026-06-12 (TODAY, largely spent — status)**
+- ✅ [I] Day-1 prereq auto-cleared: PMAT-741 BeatBenchmark + pilot on main, v0.49.0 tagged + released.
+- ✅ [F] Foundation hardened: `#1975` self-contained DAG MERGED; §S `#1982/83/84/85` MERGED; flaky root-fixes `#1988/#1989` armed; disk-recycle live.
+- ⏳ Carried to Day 2: BeatBenchmark validator rules + tests; cuda-oxide gx10 provisioning.
+- 🔴 Surfaced: lint-sweep has **no PR** (top risk).
+
+**Day 2 — Sat 2026-06-13 — foundation closeout + first beat actually runs in CI**
+- [F][cpu-ci] **Open + land the lint-harmonization PR** (fresh branch) → green `clippy -D warnings` for all ~30 ex-repo crates. *Gates everything; do first.*
+- [F][cpu-ci] Land §S `#1986/#1987` (update-branch + auto-merge).
+- [I][cpu-ci] `validate_beat_benchmark()` in `validator.rs` (incumbent ∈ four-pillar enum, metric present, numeric `beat_threshold`, direction) + 6 negative-case validator_tests.
+- [I][cpu-ci] Make `beat_sklearn_iris` **contract-driven** (read `beat-sklearn-iris-v1.yaml`) **and add `--test beat_*` to `ci.yml`** so the gate actually executes → first beat live in CI.
+- [gx10] cuda-oxide Spike1: provision LLVM-21 + nightly-2026-04-03 + `cargo-oxide` (GPU is idle, pre-authorized).
+
+**Day 3 — Sun 2026-06-14 — beat-runner + beat-gate LIVE (first WON)**
+- [I][rtx4090] `apr beat-run` CLI (clap variant + harness parsing the `beat` block + JSON + non-zero exit on regression) + 3-surface update (`apr-cli-commands-v1.yaml`, `cli_commands.rs`).
+- [I][rtx4090] `beat-gate.yml` (consume the prebuilt workspace-test binary, ~2 min/beat) wired into `ci.yml`; verify with the deliberate-regression falsifier (force iris acc<0.92 → blocks merge). **iris accuracy = first WON.** [R] release v0.49.1.
+- [gx10] cuda-oxide Spike2: saxpy `#[kernel]` → PTX gen + launch.
+
+**Day 4 — Mon 2026-06-15 — Pillar-1 speed WON, autograd WON, cuda-oxide verdict**
+- [P1][cpu-ci] PMAT-722 apr-vs-sklearn wall-clock harness (iris/digits/california, CSV+JSON) → capture matmul **1.78×** + matvec **1.44×** as hard gates → **Pillar-1 speed WON.** [R] v0.49.2.
+- [P2][cpu-ci] PMAT-724: tighten finite-diff proptests to **<1e-3** + `FALSIFY-GRADIENT-CORRECTNESS` contract → **autograd WON** (gates the Day-5 training beat).
+- [gx10] cuda-oxide Spike3: port `dequant_q4k`, parity <1e-4 vs hand-PTX → **GO/NO-GO** (routes the 1.5× closure to cuda-oxide vs hand-PTX DP4A).
+
+**Day 5 — Tue 2026-06-16 — the marquee differentiator + QLoRA + honest Ollama pin**
+- [P2][cpu-ci] PMAT-725/728 PyTorch-CPU training beat (2-layer MLP 1024→512→1, N=1024, pinned `pytorch_beat_baseline.csv`, wall ≤ PyTorch+20% **AND** MSE≤0.05) → **Pillar-2 marquee WON.** [R] v0.49.3.
+- [P3][cpu-ci] PMAT-711: wire `QLoRALayer` NF4 into `InstructPipeline` + loss-monotone falsifier (16-sample/20-step, 4-bit ≤0.30× f16) → **Pillar-3 QLoRA WON.**
+- [P4][rtx4090] **Re-measure the honest Ollama baseline first** (5-run p50 on Qwen2.5-Coder-1.5B Q4_K_M) → pin `beat-ollama-rtx4090-v1.yaml` at the **TRUE** number (~1.32×, not 1.43×) → **Pillar-4 CI-GATED-AT-CURRENT-NUMBER** (avoids an immediately-red gate).
+
+**Day 6 — Wed 2026-06-17 — QLoRA pipeline + Pillar-1 3/4 + GPU baselines off idle Blackwell**
+- [P3][cpu-ci] PMAT-712 LoRA→GGUF merge (add GGUF writer to `merge_export.rs`) + golden test (forward max-abs-diff <1e-2, LAYOUT-002 row-major).
+- [P1][cpu-ci] RandomForest (digits, 5-run median, acc floor ≥0.95) + KMeans (seed-42, inertia parity) speed-beats.
+- [P2/P3][gx10] PMAT-728-GPU Qwen3-370M Blackwell baseline + PMAT-715 Unsloth throughput, both **REPORT-ONLY** (pre-warm kernels for trueno#200).
+
+**Day 7 — Thu 2026-06-18 — Unsloth single-command UX, Pillar-1 cascade COMPLETE, CRUX-E live**
+- [P3][cpu-ci] PMAT-713 single-command `apr finetune --qlora --export gguf` (replace `execute_training_stub` + export TODOs) → **Unsloth-parity UX CPU WON.** [R] v0.49.4.
+- [P1][cpu-ci] PCA speed-beat (20k→3 comp, ≥99.5% explained-variance) → completes the Pillar-1 4-beat cascade.
+- [X][cpu-ci] CRUX-E-19 perplexity-per-bit quant-sweep (Q2_K..Q8_0 vs FP16, pinned WikiText-2 slice).
+
+**Day 8 — Fri 2026-06-19 (FRIDAY) — crates.io 0.49.0 cascade FINISHED, CRUX-E complete, DP4A spike**
+- [R][FRIDAY] **Finish the partial 0.49.0 cascade** (NOT a new bump): publish the 6 lagging crates in dep order `aprender-compute → -serve → -train → -mcp → aprender → apr-cli` (last) from a clean `origin/main`; run the pre-release gates (CB-510 include checks, `cargo deny`) + post-publish `cargo install aprender` → `apr --version` GO/NO-GO. → `cargo install aprender` finally yields 0.49.x.
+- [X][cpu-ci] CRUX-E-20 KL-divergence (`apr diff --metric kl`, Gibbs + self-identity) + promote E-19/E-20 contracts to enforced.
+- [P4][rtx4090] FUSION-004 DP4A INT8 spike (CoalescedGemvInt8Kernel + Q8_1 quant skeleton) toward 1.5×.
+
+**Day 9 — Sat 2026-06-20 — single-source registry, v0.50.0, nightly Ollama soak**
+- [I][cpu-ci] `beat-baselines.yaml` consolidated registry (single source of truth for all pinned baselines).
+- [R][cpu-ci] v0.50.0 coordination + CHANGELOG (4 sklearn speed-beats + iris + PyTorch-CPU + QLoRA + 2 quant evals).
+- [P4][rtx4090] 5-day nightly-beat-ollama variance soak (±5%); [gx10] finalize GPU report cards vs RTX-4090/Unsloth.
+
+**Day 10 — Sun 2026-06-21 — campaign closed: ≥9 falsifiable beats CI-gated**
+- [R][cpu-ci] Closeout README **BEAT scoreboard** (WON vs tracking, live CI ratios) + spec amendment; release v0.50.1.
+- [P4][rtx4090] Final marquee verify (nightly green at the pinned Ollama number); file DP4A + cuda-oxide 1.5× closure as a **post-campaign operator sprint**.
+- [R] Next forward crates.io bump (0.50.x) deferred to the following Friday (2026-06-26, outside window) unless release-worthy sooner.
+
+### What changed vs the morning plan (summary)
+
+| Axis | Morning plan | Corrected |
+|---|---|---|
+| Day-1 PMAT-741 merge | the gating prereq, do first | **DONE** (auto via §S squash leapfrog) |
+| Real Day-1 spend | validator + beat-runner + cuda-oxide | **foundation hardening** (self-containment, flaky-kill, §S) |
+| Top risk | PMAT-741 merge slips | **lint sweep has no PR** → `ci/lint` red for ~30 crates |
+| First WON | iris (Day 2) | iris (Day 3, after the test is made to actually RUN in CI) |
+| Ollama pin | 1.43× / 440 tok/s | **honest ~1.32× 5-run p50** (re-measure before pinning) |
+| Friday cascade | "catch up 0.35→0.49" | **finish the 0.49.0 split-cascade** (6 lagging crates, not a bump) |
+| Definition-of-done | unchanged | unchanged — ≥9 falsifiable beats CI-gated, 1.5× marquee out-of-window |
+
+---
+
 ## Thesis
 
 Convert aprender's proven wins into permanent, falsifiable, CI-gated BEATS plugged into PMAT-741 ContractKind::BeatBenchmark (shipped on feat/beat-benchmark-contract-kind, NOT yet on main, a Day-0 prereq: main=7cd3f3626, the enum and pilot YAML live only on the feat branch). Front-load credibility: by end of Day 2 the beat-runner CI infra is live and the two cheapest proven wins are pinned as regression gates (sklearn matmul 1.78x LinearRegression from commit 548a24032; the current Ollama 1.43x/440-tok-s decode measured on this RTX-4090 host). Parallelize across four free hosts for multiple beats per day. Honest by design: Pillar-1 sklearn beats, the Pillar-2 PyTorch-CPU beat, and the Ollama-1.43x gate are CI-GATED-AND-WON by Day 10; the Ollama-1.5x marquee and GPU throughput beats are CI-GATED-AT-CURRENT-NUMBER (1.43x pinned, tracking toward 1.5x) because closing them depends on the cuda-oxide GO/NO-GO and DP4A kernel authoring that exceed the window. GitHub release per increment; crates.io batches Fridays (Day 5, Day 10).


### PR DESCRIPTION
Updates the 10-day autonomous BEAT campaign roadmap (`docs/specifications/beat-campaign-10day-schedule-2026-06-12.md`) with a **RE-BASELINE** section — explicit chain-of-thought + a corrected day-by-day — grounded in a 6-agent state audit (`wf_1a21097f-335`) of `origin/main`, not the morning plan's assumptions.

## Why

The morning schedule assumed PMAT-741 was *not* on main and that a Day-1 fast-track merge gated everything. The audit found that premise is stale, and that a substantial (unplanned) foundation-hardening pass landed today instead. The roadmap needs to reflect what's actually true before driving the remaining days.

## Key corrections (chain-of-thought in the doc)

1. **Day-1 prereq is DONE** — `ContractKind::BeatBenchmark` + the pilot contract are on main at **v0.49.0** (leapfrogged via the §S squash merges; tag + GH release exist). The rebase-on-feat-branch contingency is moot.
2. **Real Day 1 = foundation hardening, and that was correct** — `#1975` self-contained DAG, flaky-test root-kills `#1988`/`#1989`, §S consolidation. The BEAT thesis is *gates that hard-fail on regression*; a gate is only trustworthy if **RED means a real regression**, so killing flakes / closing the dep cycle is a precondition, not a detour.
3. **Beat-infra above the enum is still ~all Day-1 work** — no `validate_beat_benchmark()` rules, no validator_tests, no `apr beat-run` CLI, no `beat-gate.yml`; the one beat contract's threshold is hardcoded (not contract-driven) and the test **isn't even executed by CI**.
4. **NEW top risk:** the 31-crate lint-harmonization sweep is committed but has **NO PR** — `ci/lint clippy -D warnings` will red the ~30 newly-in-graph crates until it lands. Now the first action.
5. **Honest Ollama baseline ≈ 1.32× (5-run p50)**, not 1.43× (Ollama-side ±8% variance) — re-measure before pinning.
6. **crates.io is a SPLIT cascade** — core+contracts at 0.49.0, facade+dependents at 0.41.0 → Friday = *finish* the 0.49.0 publish (6 crates, dep order, `apr-cli` last), not a version bump.

The original morning plan is retained below the new section for provenance. Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)