### PR TITLE
feat(contracts): BeatBenchmark validator rules + validator_tests (PMAT-741, beat-infra action #0)

### DIFF
--- a/crates/aprender-contracts/src/codegen_tests.rs
+++ b/crates/aprender-contracts/src/codegen_tests.rs
@@ -46,6 +46,7 @@ fn make_contract(equations: BTreeMap<String, Equation>) -> Contract {
         verification_summary: None,
         type_invariants: vec![],
         coq_spec: None,
+        beat: None,
     }
 }
 

--- a/crates/aprender-contracts/src/schema/types.rs
+++ b/crates/aprender-contracts/src/schema/types.rs
@@ -44,6 +44,57 @@ pub struct Contract {
     /// Coq verification specification.
     #[serde(default)]
     pub coq_spec: Option<CoqSpec>,
+    /// BEAT-benchmark parameters (PMAT-741) — present on `metadata.kind:
+    /// beat-benchmark` contracts; pins a machine-measured incumbent baseline so
+    /// CI fails when aprender regresses below it on the incumbent's canonical task.
+    #[serde(default)]
+    pub beat: Option<Beat>,
+}
+
+/// Parameters of a head-to-head BEAT benchmark (`metadata.kind: beat-benchmark`,
+/// PMAT-741): a falsifiable, CI-wired claim that aprender meets-or-beats an
+/// incumbent (scikit-learn / PyTorch / Unsloth / Ollama·llama.cpp) on the
+/// incumbent's own canonical task — the measurement backbone of the four-pillar
+/// "replace AND beat" mission. Required-shape is enforced by
+/// `validate_beat_benchmark` in the validator (BEAT-001..007).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct Beat {
+    /// Which pillar (1=sklearn, 2=PyTorch, 3=Unsloth, 4=Ollama/llama.cpp).
+    #[serde(default)]
+    pub pillar: Option<u8>,
+    /// The incumbent being beaten — must name one of the four pillars.
+    #[serde(default)]
+    pub incumbent: String,
+    /// How/when the baseline was pinned (free-form provenance).
+    #[serde(default)]
+    pub incumbent_pinned: Option<String>,
+    /// The canonical task on which the beat is measured (apples-to-apples).
+    #[serde(default)]
+    pub canonical_task: Option<String>,
+    /// The measured metric (e.g. `accuracy`, `wall_clock_ms`, `tokens_per_sec`, `mse`).
+    #[serde(default)]
+    pub metric: String,
+    /// `higher_is_better` or `lower_is_better` — fixes the regression direction.
+    #[serde(default)]
+    pub direction: String,
+    /// The incumbent's pinned baseline value.
+    #[serde(default)]
+    pub baseline_value: Option<f64>,
+    /// Optional worst-case incumbent value (e.g. sklearn min over seeds).
+    #[serde(default)]
+    pub baseline_floor: Option<f64>,
+    /// The threshold aprender must meet/beat; CI fails on regression past it.
+    #[serde(default)]
+    pub beat_threshold: Option<f64>,
+    /// When the baseline was sourced (ISO date).
+    #[serde(default)]
+    pub baseline_sourced_date: Option<String>,
+    /// `CPU` or `GPU` — the compute approved for this gate.
+    #[serde(default)]
+    pub approved_compute: Option<String>,
+    /// The CI test/gate name that enforces this beat.
+    #[serde(default)]
+    pub ci_gate_name: String,
 }
 
 impl Contract {

--- a/crates/aprender-contracts/src/schema/validator.rs
+++ b/crates/aprender-contracts/src/schema/validator.rs
@@ -35,7 +35,143 @@ pub fn validate_contract(contract: &Contract) -> Vec<Violation> {
         validate_kani_harnesses(contract, &mut violations);
     }
 
+    // BeatBenchmark-only checks (PMAT-741): the `beat:` block must pin a
+    // falsifiable, four-pillar incumbent baseline. Independent of the
+    // kernel/non-kernel split above.
+    if contract.kind() == ContractKind::BeatBenchmark {
+        validate_beat_benchmark(contract, &mut violations);
+    }
+
     violations
+}
+
+/// The four incumbents a BEAT may target (case-insensitive substring match, so
+/// `ollama` and `llama.cpp` both satisfy Pillar 4).
+const BEAT_INCUMBENTS: [&str; 5] = ["scikit-learn", "pytorch", "unsloth", "ollama", "llama.cpp"];
+
+/// Enforce the BeatBenchmark shape (PMAT-741): a `beat-benchmark` contract MUST
+/// carry a well-formed `beat:` block so the claim is a falsifiable CI gate, not
+/// prose. Rules BEAT-001..007.
+fn validate_beat_benchmark(contract: &Contract, violations: &mut Vec<Violation>) {
+    let push = |violations: &mut Vec<Violation>, rule: &str, message: String, field: &str| {
+        violations.push(Violation {
+            severity: Severity::Error,
+            rule: rule.to_string(),
+            message,
+            location: Some(format!("beat.{field}")),
+        });
+    };
+
+    let Some(beat) = contract.beat.as_ref() else {
+        violations.push(Violation {
+            severity: Severity::Error,
+            rule: "BEAT-001".to_string(),
+            message: "beat-benchmark contract must define a `beat:` block \
+                      (incumbent, metric, direction, beat_threshold, ci_gate_name)"
+                .to_string(),
+            location: Some("beat".to_string()),
+        });
+        return;
+    };
+
+    // BEAT-002: incumbent must name one of the four pillars.
+    let incumbent = beat.incumbent.trim().to_lowercase();
+    if incumbent.is_empty() {
+        push(
+            violations,
+            "BEAT-002",
+            "beat.incumbent must not be empty".to_string(),
+            "incumbent",
+        );
+    } else if !BEAT_INCUMBENTS.iter().any(|p| incumbent.contains(p)) {
+        push(
+            violations,
+            "BEAT-002",
+            format!(
+                "beat.incumbent {:?} must name one of the four pillars ({})",
+                beat.incumbent,
+                BEAT_INCUMBENTS.join(", ")
+            ),
+            "incumbent",
+        );
+    }
+
+    // BEAT-003: a measured metric is required.
+    if beat.metric.trim().is_empty() {
+        push(
+            violations,
+            "BEAT-003",
+            "beat.metric must name the measured quantity (e.g. accuracy, wall_clock_ms, \
+             tokens_per_sec)"
+                .to_string(),
+            "metric",
+        );
+    }
+
+    // BEAT-004: direction fixes which way is a regression.
+    match beat.direction.trim() {
+        "higher_is_better" | "lower_is_better" => {}
+        other => push(
+            violations,
+            "BEAT-004",
+            format!(
+                "beat.direction must be `higher_is_better` or `lower_is_better`, got {other:?}"
+            ),
+            "direction",
+        ),
+    }
+
+    // BEAT-005: a finite, machine-pinned threshold is required (the gate value).
+    match beat.beat_threshold {
+        None => push(
+            violations,
+            "BEAT-005",
+            "beat.beat_threshold is required — the pinned value CI fails below".to_string(),
+            "beat_threshold",
+        ),
+        Some(t) if !t.is_finite() => push(
+            violations,
+            "BEAT-005",
+            format!("beat.beat_threshold must be finite, got {t}"),
+            "beat_threshold",
+        ),
+        Some(_) => {}
+    }
+
+    // BEAT-006: the enforcing CI gate must be named.
+    if beat.ci_gate_name.trim().is_empty() {
+        push(
+            violations,
+            "BEAT-006",
+            "beat.ci_gate_name must name the CI test that enforces this gate".to_string(),
+            "ci_gate_name",
+        );
+    }
+
+    // BEAT-007: approved_compute is required and must be CPU or GPU (the
+    // autonomous-vs-operator track distinction depends on it).
+    match beat
+        .approved_compute
+        .as_deref()
+        .map(|c| c.trim().to_uppercase())
+    {
+        None => push(
+            violations,
+            "BEAT-007",
+            "beat.approved_compute is required — must be `CPU` or `GPU`".to_string(),
+            "approved_compute",
+        ),
+        Some(ref c) if c != "CPU" && c != "GPU" => push(
+            violations,
+            "BEAT-007",
+            format!(
+                "beat.approved_compute must be `CPU` or `GPU`, got {:?}",
+                beat.approved_compute
+            ),
+            "approved_compute",
+        ),
+        Some(_) => {}
+    }
 }
 
 /// Enforce the provability invariant: kernel contracts (non-registry) MUST have

--- a/crates/aprender-contracts/src/schema/validator_tests.rs
+++ b/crates/aprender-contracts/src/schema/validator_tests.rs
@@ -276,3 +276,104 @@ falsification_tests: []
 
     #[path = "validator_tests_extra.rs"]
     mod extra;
+
+    // ── PMAT-741 BeatBenchmark validator (BEAT-001..007) ──────────────────────
+
+    /// Wrap a `beat:` block body in a valid beat-benchmark metadata envelope so
+    /// each test isolates a single broken `beat.*` field.
+    fn beat_contract(beat_block: &str) -> String {
+        format!(
+            r#"
+metadata:
+  kind: beat-benchmark
+  version: "1.0.0"
+  description: "BEAT validator test"
+  references:
+    - "docs/specifications/campaign-ev-reprioritization-2026-06-12.md"
+beat:
+{beat_block}"#
+        )
+    }
+
+    /// A well-formed `beat:` block — each negative test mutates exactly one line.
+    const VALID_BEAT_BLOCK: &str = r#"  incumbent: scikit-learn
+  metric: accuracy
+  direction: higher_is_better
+  beat_threshold: 0.92
+  ci_gate_name: beat_sklearn_iris
+  approved_compute: CPU
+"#;
+
+    #[test]
+    fn beat_001_missing_beat_block_errors() {
+        // kind: beat-benchmark but no `beat:` block at all.
+        let yaml = r#"
+metadata:
+  kind: beat-benchmark
+  version: "1.0.0"
+  description: "no beat block"
+  references:
+    - "ref"
+"#;
+        let contract = parse_contract_str(yaml).unwrap();
+        let violations = validate_contract(&contract);
+        assert!(violations.iter().any(|v| v.rule == "BEAT-001"), "{violations:?}");
+    }
+
+    #[test]
+    fn beat_002_incumbent_not_a_pillar_errors() {
+        let block = VALID_BEAT_BLOCK.replace("scikit-learn", "tensorflow");
+        let contract = parse_contract_str(&beat_contract(&block)).unwrap();
+        let violations = validate_contract(&contract);
+        assert!(violations.iter().any(|v| v.rule == "BEAT-002"), "{violations:?}");
+    }
+
+    #[test]
+    fn beat_003_missing_metric_errors() {
+        let block = VALID_BEAT_BLOCK.replace("  metric: accuracy\n", "");
+        let contract = parse_contract_str(&beat_contract(&block)).unwrap();
+        let violations = validate_contract(&contract);
+        assert!(violations.iter().any(|v| v.rule == "BEAT-003"), "{violations:?}");
+    }
+
+    #[test]
+    fn beat_004_bad_direction_errors() {
+        let block = VALID_BEAT_BLOCK.replace("higher_is_better", "bigger_number");
+        let contract = parse_contract_str(&beat_contract(&block)).unwrap();
+        let violations = validate_contract(&contract);
+        assert!(violations.iter().any(|v| v.rule == "BEAT-004"), "{violations:?}");
+    }
+
+    #[test]
+    fn beat_005_missing_threshold_errors() {
+        let block = VALID_BEAT_BLOCK.replace("  beat_threshold: 0.92\n", "");
+        let contract = parse_contract_str(&beat_contract(&block)).unwrap();
+        let violations = validate_contract(&contract);
+        assert!(violations.iter().any(|v| v.rule == "BEAT-005"), "{violations:?}");
+    }
+
+    #[test]
+    fn beat_006_missing_ci_gate_errors() {
+        let block = VALID_BEAT_BLOCK.replace("  ci_gate_name: beat_sklearn_iris\n", "");
+        let contract = parse_contract_str(&beat_contract(&block)).unwrap();
+        let violations = validate_contract(&contract);
+        assert!(violations.iter().any(|v| v.rule == "BEAT-006"), "{violations:?}");
+    }
+
+    #[test]
+    fn beat_007_bad_compute_errors() {
+        let block = VALID_BEAT_BLOCK.replace("approved_compute: CPU", "approved_compute: TPU");
+        let contract = parse_contract_str(&beat_contract(&block)).unwrap();
+        let violations = validate_contract(&contract);
+        assert!(violations.iter().any(|v| v.rule == "BEAT-007"), "{violations:?}");
+    }
+
+    #[test]
+    fn beat_valid_block_has_no_beat_errors() {
+        let contract = parse_contract_str(&beat_contract(VALID_BEAT_BLOCK)).unwrap();
+        let violations = validate_contract(&contract);
+        assert!(
+            !violations.iter().any(|v| v.rule.starts_with("BEAT-")),
+            "a valid beat block must raise no BEAT-* violations: {violations:?}"
+        );
+    }


### PR DESCRIPTION
First beat-infra step of the 10-day BEAT campaign (per the corrected roadmap's **action #0**).

## Problem

`ContractKind::BeatBenchmark` shipped in v0.49.0, but the `beat:` block was **silently dropped on parse** (no `Beat` struct) and `validate_contract()` had **zero rules** for the kind — it fell through to the generic non-kernel branch. A "beat" was vocabulary, not a falsifiable shape; a malformed beat contract would validate clean.

## This PR

- **`Beat` struct** in `schema/types.rs` + `Contract.beat: Option<Beat>` — the `beat:` block now actually deserializes (incumbent, metric, direction, baseline_*, beat_threshold, ci_gate_name, approved_compute, …).
- **`validate_beat_benchmark()`** enforcing **BEAT-001..007** when `kind == BeatBenchmark`:

  | Rule | Enforces |
  |------|----------|
  | BEAT-001 | a `beat:` block is required |
  | BEAT-002 | incumbent names one of the four pillars (scikit-learn / pytorch / unsloth / ollama·llama.cpp) |
  | BEAT-003 | `metric` required |
  | BEAT-004 | `direction` ∈ {higher_is_better, lower_is_better} |
  | BEAT-005 | `beat_threshold` required + finite (the pinned gate value) |
  | BEAT-006 | `ci_gate_name` required (the enforcing test) |
  | BEAT-007 | `approved_compute` ∈ {CPU, GPU} |

- **8 tests** — 7 negative-case (BEAT-001..007, each isolating one broken field) + a valid-block clean pass. The pilot `beat-sklearn-iris-v1.yaml` now validates its beat block *for real* (the pre-existing `pilot_beat_contract_validates` exercises the new rules).

## Verification

- `cargo test -p aprender-contracts --lib` → **1402 passed, 0 failed**.
- `cargo fmt` + `cargo clippy -p aprender-contracts` clean.

## Next in the campaign

Make `beat_sklearn_iris` contract-*driven* (read this validated YAML instead of hardcoded consts) and add it to `ci.yml` so the gate actually runs → first WON. Then `apr beat-run` CLI + `beat-gate.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)