### PR TITLE
feat(contracts): Beat::evaluate — falsifiable BEAT verdict logic (PMAT-741)

### DIFF
--- a/crates/aprender-contracts/src/schema/types.rs
+++ b/crates/aprender-contracts/src/schema/types.rs
@@ -97,6 +97,58 @@ pub struct Beat {
     pub ci_gate_name: String,
 }
 
+/// The outcome of evaluating a measured value against a [`Beat`]'s pinned
+/// threshold — the falsifiable verdict at the heart of `apr beat-run`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum BeatOutcome {
+    /// aprender meets-or-beats the incumbent: measured is on the winning side of
+    /// `beat_threshold` per `direction`.
+    Won,
+    /// aprender regressed below the pinned threshold — CI must fail.
+    Regressed,
+}
+
+impl Beat {
+    /// Evaluate a measured value against this beat's pinned `beat_threshold`,
+    /// honoring `direction`:
+    /// - `higher_is_better` ⇒ `Won` iff `measured >= beat_threshold`
+    /// - `lower_is_better`  ⇒ `Won` iff `measured <= beat_threshold`
+    ///
+    /// Returns `None` when the contract is too malformed to judge (no
+    /// `beat_threshold`, a non-finite threshold/measurement, or an unknown
+    /// `direction`) — the caller should treat that as a hard error, not a pass.
+    /// The validator's BEAT-004/BEAT-005 rules reject such contracts up front,
+    /// so a well-formed contract always yields `Some`.
+    #[must_use]
+    pub fn evaluate(&self, measured: f64) -> Option<BeatOutcome> {
+        let threshold = self.beat_threshold?;
+        if !threshold.is_finite() || !measured.is_finite() {
+            return None;
+        }
+        match self.direction.trim() {
+            "higher_is_better" => Some(if measured >= threshold {
+                BeatOutcome::Won
+            } else {
+                BeatOutcome::Regressed
+            }),
+            "lower_is_better" => Some(if measured <= threshold {
+                BeatOutcome::Won
+            } else {
+                BeatOutcome::Regressed
+            }),
+            _ => None,
+        }
+    }
+
+    /// Convenience: `true` iff [`evaluate`](Self::evaluate) returns
+    /// [`BeatOutcome::Won`]. A malformed contract (`None`) is **not** a win.
+    #[must_use]
+    pub fn is_won(&self, measured: f64) -> bool {
+        self.evaluate(measured) == Some(BeatOutcome::Won)
+    }
+}
+
 impl Contract {
     /// Back-compat: `metadata.registry: true` OR `metadata.kind: registry`.
     pub fn is_registry(&self) -> bool {

--- a/crates/aprender-contracts/src/schema/types_tests.rs
+++ b/crates/aprender-contracts/src/schema/types_tests.rs
@@ -140,3 +140,62 @@ fn explicit_kind_overrides_default() {
     // ModelFamily is not a registry
     assert!(!c.is_registry());
 }
+
+// ── Beat::evaluate — the falsifiable verdict (PMAT-741) ───────────────────────
+
+/// Build a minimal Beat with the given direction + threshold.
+fn beat(direction: &str, threshold: Option<f64>) -> Beat {
+    Beat {
+        direction: direction.to_string(),
+        beat_threshold: threshold,
+        ..Beat::default()
+    }
+}
+
+#[test]
+fn beat_evaluate_higher_is_better() {
+    let b = beat("higher_is_better", Some(0.92));
+    // at/above threshold = won (accuracy: bigger is better)
+    assert_eq!(b.evaluate(0.94), Some(BeatOutcome::Won));
+    assert_eq!(b.evaluate(0.92), Some(BeatOutcome::Won)); // boundary is a win
+    assert_eq!(b.evaluate(0.91), Some(BeatOutcome::Regressed));
+    assert!(b.is_won(0.99));
+    assert!(!b.is_won(0.50));
+}
+
+#[test]
+fn beat_evaluate_lower_is_better() {
+    let b = beat("lower_is_better", Some(440.0));
+    // at/below threshold = won (wall-clock ms: smaller is better)
+    assert_eq!(b.evaluate(400.0), Some(BeatOutcome::Won));
+    assert_eq!(b.evaluate(440.0), Some(BeatOutcome::Won)); // boundary is a win
+    assert_eq!(b.evaluate(441.0), Some(BeatOutcome::Regressed));
+    assert!(b.is_won(10.0));
+    assert!(!b.is_won(1000.0));
+}
+
+#[test]
+fn beat_evaluate_malformed_is_none_not_pass() {
+    // No threshold → cannot judge.
+    assert_eq!(beat("higher_is_better", None).evaluate(0.99), None);
+    // Unknown direction → cannot judge.
+    assert_eq!(beat("sideways", Some(0.9)).evaluate(0.99), None);
+    // Non-finite inputs → cannot judge.
+    assert_eq!(beat("higher_is_better", Some(f64::NAN)).evaluate(0.9), None);
+    assert_eq!(
+        beat("higher_is_better", Some(0.9)).evaluate(f64::INFINITY),
+        None
+    );
+    // A malformed contract is NOT a win.
+    assert!(!beat("sideways", Some(0.9)).is_won(0.99));
+    assert!(!beat("higher_is_better", None).is_won(0.99));
+}
+
+#[test]
+fn beat_evaluate_matches_pilot_iris_contract() {
+    // The shipped pilot: accuracy, higher_is_better, threshold 0.92. apr's
+    // measured 0.94 must read as WON, a hypothetical 0.90 as REGRESSED.
+    let b = beat("higher_is_better", Some(0.9200));
+    assert_eq!(b.evaluate(0.9400), Some(BeatOutcome::Won));
+    assert_eq!(b.evaluate(0.9000), Some(BeatOutcome::Regressed));
+}


### PR DESCRIPTION
Third beat-infra step. Adds the **verdict core** that `apr beat-run` and the beat-gate CI runner will call — so the eventual CLI wiring is a trivial `beat.evaluate(...)` rather than fragile `cargo test` shelling + freeform output parsing.

## API

```rust
impl Beat {
    pub fn evaluate(&self, measured: f64) -> Option<BeatOutcome>; // Won | Regressed
    pub fn is_won(&self, measured: f64) -> bool;
}
```

Honors `direction`:
- `higher_is_better` ⇒ `Won` iff `measured >= beat_threshold` (accuracy, tok/s)
- `lower_is_better` ⇒ `Won` iff `measured <= beat_threshold` (wall_clock_ms, peak-RSS)

Boundary (`measured == threshold`) is a **win**. A malformed contract (no threshold, non-finite value, unknown direction) returns `None` — explicitly **not** a pass — so a broken contract can never silently mark a beat WON. BEAT-004/005 reject those at validation, so well-formed contracts always yield `Some`.

## Why a library method (not the CLI yet)

The `apr beat-run` CLI is a multi-file integration into the 100+ command crate with 3-surface parity + a slow compile — a focused-session change. This lands the **design-unambiguous, fully-testable core** now (higher/lower-is-better is well-defined), keeping the CLI wiring trivial and deferring the opinionated cargo-shelling.

4 new unit tests (both directions, boundaries, malformed-is-None, the pilot iris case); fmt + clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)