### PR TITLE
ci(beat): run beat_sklearn_iris in the integration gate — Pillar-1 iris beat WON

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,7 +247,7 @@ jobs:
             -e CARGO_INCREMENTAL=0 \
             -e CARGO_BUILD_JOBS=8 \
             "$IMAGE" \
-            bash -c 'cargo test -p aprender-core --test monorepo_invariants && cargo test -p aprender-core --test readme_contract && cargo test -p apr-cli --test cli_commands'
+            bash -c 'cargo test -p aprender-core --test monorepo_invariants && cargo test -p aprender-core --test readme_contract && cargo test -p apr-cli --test cli_commands && cargo test -p aprender-core --test beat_sklearn_iris'
       - name: Build.rs crate-root escape check (v0.31.1 yank guard)
         # Static Poka-Yoke: flags build.rs files that panic on files outside
         # CARGO_MANIFEST_DIR, which break `cargo install` from crates.io.


### PR DESCRIPTION
Flips the Pillar-1 iris beat from **PROVEN → WON** — the first falsifiable, CI-gated BEAT of the four-pillar campaign (PMAT-741).

## Problem

The contract-driven `beat_sklearn_iris` test (#1992) compiled but **CI never ran it** — it's an integration test that wasn't in `ci.yml`'s integration step. So apr's RandomForestClassifier could regress below the pinned scikit-learn threshold (`contracts/beat-sklearn-iris-v1.yaml`, 0.92) and merge silently.

## Change

Adds `cargo test -p aprender-core --test beat_sklearn_iris` to the integration step. Every PR now **hard-fails** if apr drops below sklearn's floor on the canonical deterministic iris split.

One-line append to an existing `bash -c` invocation; YAML validated. Additive coverage only — no runner/image/auth changes, no gate weakening — per the operator's 2026-06-13 authorization to make small CI-workflow edits during the campaign.

## Beat-infra status after this lands

validator (BEAT-001..007, #1991) → contract-driven iris (#1992) → verdict logic (#1993) → **iris gate WON (this PR)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)