### PR TITLE
feat(cli): apr beat-run — evaluate a BeatBenchmark contract + verdict (PMAT-741)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,6 +260,7 @@ dependencies = [
  "anyhow",
  "aprender-common",
  "aprender-compute",
+ "aprender-contracts",
  "aprender-core",
  "aprender-data",
  "aprender-mcp",

--- a/contracts/apr-cli-commands-v1.yaml
+++ b/contracts/apr-cli-commands-v1.yaml
@@ -94,6 +94,12 @@ commands:
     requires_model: true
     side_effects: []
 
+  - name: beat-run
+    category: inspection
+    description: "Evaluate a BeatBenchmark contract against a measured value (PMAT-741)"
+    requires_model: false
+    side_effects: []
+
   - name: manifest
     category: model_ops
     description: "Emit SHA-256 manifest of input files (CRUX-G-05)"

--- a/crates/apr-cli/Cargo.toml
+++ b/crates/apr-cli/Cargo.toml
@@ -104,6 +104,8 @@ libc = "0.2"
 [dependencies]
 # Core aprender library
 aprender = { path = "../aprender-core", version = "0.49.0", package = "aprender-core", default-features = true, features = ["format-compression"] }
+# Provable-contracts engine — `apr beat-run` parses + evaluates BeatBenchmark contracts (PMAT-741)
+aprender-contracts = { workspace = true }
 
 # MCP (Model Context Protocol) server — `apr mcp` subcommand
 aprender-mcp = { path = "../aprender-mcp", version = "0.49.0" }

--- a/crates/apr-cli/src/commands/beat_run.rs
+++ b/crates/apr-cli/src/commands/beat_run.rs
@@ -1,0 +1,138 @@
+//! `apr beat-run` — evaluate a BeatBenchmark contract against a measured value.
+//!
+//! The falsifiable runner for the four-pillar "replace AND beat" mission
+//! (PMAT-741). Given a `beat-benchmark` contract and (optionally) a measured
+//! metric value, it reports the pinned incumbent baseline and the WON/REGRESSED
+//! verdict, exiting non-zero on regression so CI hard-fails. The verdict is
+//! computed by the single source of truth, `aprender_contracts::schema::Beat::evaluate`
+//! — no logic is duplicated here.
+
+use std::path::Path;
+
+use provable_contracts::schema::{parse_contract_str, BeatOutcome};
+
+use crate::error::CliError;
+
+/// Run a beat contract.
+///
+/// - Without `measured`: report the contract's pinned beat parameters, exit 0.
+/// - With `measured`: compute the verdict; return `Err` (non-zero exit) on a
+///   regression or an unjudgeable contract, so this can gate CI directly.
+pub fn run(contract: &Path, measured: Option<f64>, json: bool) -> Result<(), CliError> {
+    let yaml = std::fs::read_to_string(contract)
+        .map_err(|e| CliError::InvalidFormat(format!("cannot read {}: {e}", contract.display())))?;
+    let parsed = parse_contract_str(&yaml)
+        .map_err(|e| CliError::InvalidFormat(format!("{}: {e}", contract.display())))?;
+    let beat = parsed.beat.ok_or_else(|| {
+        CliError::ValidationFailed(format!(
+            "{} is not a beat-benchmark contract (no `beat:` block)",
+            contract.display()
+        ))
+    })?;
+
+    let outcome = measured.and_then(|m| beat.evaluate(m));
+
+    if json {
+        let f = |v: Option<f64>| v.map_or_else(|| "null".to_string(), |x| x.to_string());
+        let verdict = match outcome {
+            Some(BeatOutcome::Won) => "\"won\"",
+            Some(BeatOutcome::Regressed) => "\"regressed\"",
+            None => "null",
+        };
+        println!(
+            "{{\"gate\":\"{}\",\"pillar\":{},\"incumbent\":\"{}\",\"metric\":\"{}\",\
+             \"direction\":\"{}\",\"baseline\":{},\"threshold\":{},\"measured\":{},\"verdict\":{}}}",
+            beat.ci_gate_name,
+            beat.pillar.map_or_else(|| "null".to_string(), |p| p.to_string()),
+            beat.incumbent,
+            beat.metric,
+            beat.direction,
+            f(beat.baseline_value),
+            f(beat.beat_threshold),
+            f(measured),
+            verdict,
+        );
+    } else {
+        println!(
+            "BEAT {} (pillar {}) — apr vs {}",
+            beat.ci_gate_name,
+            beat.pillar
+                .map_or_else(|| "?".to_string(), |p| p.to_string()),
+            beat.incumbent
+        );
+        println!(
+            "  metric={}  direction={}  threshold={:?}  baseline={:?}",
+            beat.metric, beat.direction, beat.beat_threshold, beat.baseline_value
+        );
+        match (measured, outcome) {
+            (Some(m), Some(BeatOutcome::Won)) => println!("  measured={m} → WON ✅"),
+            (Some(m), Some(BeatOutcome::Regressed)) => println!("  measured={m} → REGRESSED ❌"),
+            (Some(m), None) => println!("  measured={m} → UNJUDGEABLE (bad direction/threshold)"),
+            (None, _) => println!("  (no --measured given; reporting pinned parameters only)"),
+        }
+    }
+
+    match (measured, outcome) {
+        (Some(_), Some(BeatOutcome::Regressed)) => Err(CliError::ValidationFailed(format!(
+            "BEAT {} REGRESSED: measured value is on the losing side of the pinned \
+             threshold {:?} ({})",
+            beat.ci_gate_name, beat.beat_threshold, beat.direction
+        ))),
+        (Some(_), None) => Err(CliError::ValidationFailed(format!(
+            "BEAT {} is unjudgeable — contract has no finite threshold or a bad direction",
+            beat.ci_gate_name
+        ))),
+        _ => Ok(()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn write_contract(body: &str) -> tempfile::NamedTempFile {
+        let mut f = tempfile::NamedTempFile::new().expect("tmp");
+        write!(
+            f,
+            "metadata:\n  kind: beat-benchmark\n  version: \"1.0.0\"\n  \
+             description: \"t\"\n  references:\n    - \"r\"\nbeat:\n{body}"
+        )
+        .expect("write");
+        f
+    }
+
+    const VALID: &str = "  incumbent: scikit-learn\n  metric: accuracy\n  \
+        direction: higher_is_better\n  beat_threshold: 0.92\n  ci_gate_name: g\n  \
+        approved_compute: CPU\n";
+
+    #[test]
+    fn beat_run_won_exits_ok() {
+        let f = write_contract(VALID);
+        assert!(run(f.path(), Some(0.94), true).is_ok());
+    }
+
+    #[test]
+    fn beat_run_regressed_is_err() {
+        let f = write_contract(VALID);
+        assert!(run(f.path(), Some(0.90), true).is_err());
+    }
+
+    #[test]
+    fn beat_run_report_only_ok() {
+        let f = write_contract(VALID);
+        assert!(run(f.path(), None, false).is_ok());
+    }
+
+    #[test]
+    fn beat_run_missing_beat_block_is_err() {
+        let mut f = tempfile::NamedTempFile::new().expect("tmp");
+        write!(
+            f,
+            "metadata:\n  kind: schema\n  version: \"1.0.0\"\n  description: \"t\"\n  \
+             references:\n    - \"r\"\n"
+        )
+        .expect("write");
+        assert!(run(f.path(), Some(0.9), true).is_err());
+    }
+}

--- a/crates/apr-cli/src/commands/mod.rs
+++ b/crates/apr-cli/src/commands/mod.rs
@@ -15,6 +15,7 @@ pub(crate) mod audio_inspect_lint;
 pub(crate) mod auto_quant;
 pub(crate) mod awq_classifier;
 pub(crate) mod awq_lint;
+pub mod beat_run;
 pub mod bench;
 pub(crate) mod blob_gc;
 pub mod canary;

--- a/crates/apr-cli/src/commands_enum.rs
+++ b/crates/apr-cli/src/commands_enum.rs
@@ -326,6 +326,17 @@ pub enum Commands {
         #[arg(value_name = "FILE")]
         file: PathBuf,
     },
+    /// Evaluate a BeatBenchmark contract against a measured value (PMAT-741)
+    #[command(name = "beat-run")]
+    BeatRun {
+        /// Path to a beat-benchmark contract YAML (e.g. contracts/beat-sklearn-iris-v1.yaml)
+        #[arg(value_name = "CONTRACT")]
+        contract: PathBuf,
+        /// Measured metric value; when given, emit a WON/REGRESSED verdict and
+        /// exit non-zero on regression. Omit to just report the pinned baseline.
+        #[arg(long, value_name = "VALUE")]
+        measured: Option<f64>,
+    },
     /// Emit a SHA-256 manifest of input files (CRUX-G-05)
     Manifest {
         /// Files to include in the manifest (one entry per file)

--- a/crates/apr-cli/src/dispatch.rs
+++ b/crates/apr-cli/src/dispatch.rs
@@ -242,6 +242,10 @@ fn dispatch_inspection_commands(cli: &Cli) -> Option<Result<(), CliError>> {
             crate::pipe::with_stdin_support(file, |p| lint::run(p, j, q))
         }
 
+        Commands::BeatRun { contract, measured } => {
+            commands::beat_run::run(contract, *measured, cli.json)
+        }
+
         Commands::Manifest { files, output } => {
             // CRUX-G-05 — SHA-256 manifest of the input file set.
             commands::manifest::run(files, output, cli.json)

--- a/crates/apr-cli/tests/cli_commands.rs
+++ b/crates/apr-cli/tests/cli_commands.rs
@@ -42,6 +42,7 @@ fn registered_commands() -> Vec<&'static str> {
         "validate",
         "validate-manifest",
         "lint",
+        "beat-run",
         "manifest",
         "explain",
         "tensors",


### PR DESCRIPTION
Adds `apr beat-run`, the campaign's **generic beat runner** — the CLI counterpart to the `Beat::evaluate` core (#1993).

## Usage

```
apr beat-run contracts/beat-sklearn-iris-v1.yaml                 # report pinned baseline/threshold
apr beat-run contracts/beat-sklearn-iris-v1.yaml --measured 0.94 # → WON, exit 0
apr beat-run contracts/beat-sklearn-iris-v1.yaml --measured 0.90 # → REGRESSED, exit non-zero
apr beat-run ... --measured 0.94 --json                          # machine-readable verdict
```

With `--measured`, it emits a WON/REGRESSED verdict and **exits non-zero on regression**, so it can gate CI for *any* beat (not just bespoke per-beat integration tests). The verdict is computed by the single source of truth `Beat::evaluate` (#1993) via the `aprender-contracts` parser — **no logic duplicated**. A contract with no `beat:` block / no finite threshold / a bad direction is a hard error, never a silent pass.

## Surfaces (3-surface drift discipline)

clap variant (`commands_enum.rs`) · dispatch arm (`dispatch.rs`) · handler (`commands/beat_run.rs`) · `contracts/apr-cli-commands-v1.yaml` entry · `cli_commands.rs` registered list. New `aprender-contracts` workspace dep (published, 0.49.0).

## Verification

- 4 unit tests: won / regressed / report-only / missing-`beat:`-block.
- `cli_commands` parity gate: **8/8** (enum ↔ YAML ↔ `--help` all agree).
- fmt + clippy clean.

Beat-infra chain is now: validator (BEAT-001..007) → contract-driven iris (WON, #1994) → verdict core (#1993) → **generic runner (this PR)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)