### PR TITLE
fix(deps): restore Cargo.lock workspace versions to 0.49.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,7 +255,7 @@ dependencies = [
 
 [[package]]
 name = "apr-cli"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "anyhow",
  "aprender-common",
@@ -375,7 +375,7 @@ dependencies = [
 
 [[package]]
 name = "aprender"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "apr-cli",
  "aprender-core",
@@ -383,7 +383,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-bench-compute"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "aprender-core",
  "criterion 0.7.0",
@@ -392,7 +392,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-bench-tokenizer"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "aprender-core",
  "criterion 0.7.0",
@@ -401,7 +401,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cbtop"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "anyhow",
  "aprender-common",
@@ -426,7 +426,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cgp"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "anyhow",
  "aprender-gpu",
@@ -446,7 +446,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-common"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "lz4_flex 0.11.6",
  "zstd",
@@ -454,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-compute"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "anyhow",
  "aprender-core",
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-compute-xtask"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "anyhow",
  "bashrs",
@@ -515,7 +515,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-contracts"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "aprender-contracts-macros",
  "criterion 0.5.1",
@@ -530,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-contracts-cli"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "aprender-contracts",
  "clap",
@@ -541,7 +541,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-contracts-macros"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -551,7 +551,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-core"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "aes-gcm",
  "alsa",
@@ -602,7 +602,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cuda-edge"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "aprender-gpu",
  "proptest",
@@ -613,7 +613,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cupti"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "bindgen 0.71.1",
  "bitflags 2.13.0",
@@ -623,7 +623,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-data"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -675,7 +675,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-db"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "anyhow",
  "aprender-common",
@@ -720,7 +720,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-distribute"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "aprender-compute",
  "aprender-db",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-explain"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "aprender-gpu",
  "aprender-present-core",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-fft"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -778,7 +778,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-gemm-codegen"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-gpu"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "aprender-common",
  "aprender-profile",
@@ -807,7 +807,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-graph"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "anyhow",
  "aprender-compute",
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-image"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -838,7 +838,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-mcp"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -853,9 +853,9 @@ dependencies = [
 
 [[package]]
 name = "aprender-monte-carlo"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
- "aprender 0.49.0",
+ "aprender 0.49.1",
  "assert_cmd",
  "chrono",
  "clap",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-orchestrate"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "anyhow",
  "aprender-common",
@@ -946,7 +946,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-cli"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "aprender-present-yaml",
  "clap",
@@ -959,7 +959,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-core"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -971,7 +971,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-layout"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "aprender-present-core",
  "criterion 0.7.0",
@@ -982,7 +982,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-lib"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "aprender-present-core",
  "aprender-present-layout",
@@ -1011,7 +1011,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-terminal"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "aprender-present-core",
  "aprender-viz",
@@ -1033,7 +1033,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-test"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "aprender-present-core",
  "aprender-present-test-macros",
@@ -1044,7 +1044,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-test-macros"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1053,7 +1053,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-widgets"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "aprender-present-core",
  "aprender-present-yaml",
@@ -1065,7 +1065,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-yaml"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "aprender-present-core",
  "proptest",
@@ -1075,7 +1075,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-profile"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "addr2line 0.25.1",
  "anyhow",
@@ -1128,7 +1128,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-profile-core"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "hex",
  "serde",
@@ -1138,7 +1138,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-ptx-debug"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "proptest",
  "thiserror 2.0.18",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-certify"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "chrono",
  "proptest",
@@ -1156,7 +1156,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-cli"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "aprender-qa-certify",
  "aprender-qa-gen",
@@ -1175,7 +1175,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-gen"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1192,7 +1192,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-report"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "anyhow",
  "aprender-qa-gen",
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-runner"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "anyhow",
  "aprender-qa-gen",
@@ -1235,14 +1235,14 @@ dependencies = [
 
 [[package]]
 name = "aprender-quant"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "half",
 ]
 
 [[package]]
 name = "aprender-rag"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "aprender-common",
  "aprender-compute",
@@ -1290,7 +1290,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-rand"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1299,7 +1299,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-registry"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "anyhow",
  "aprender-core",
@@ -1329,7 +1329,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-serve"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "anyhow",
  "approx",
@@ -1396,7 +1396,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-shell"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "aprender-core",
  "assert_cmd",
@@ -1413,7 +1413,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-simulate"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "aprender-present-core",
  "aprender-present-terminal",
@@ -1452,7 +1452,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-solve"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1461,7 +1461,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-sparse"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1470,7 +1470,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-tensor"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1479,7 +1479,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-cli"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "aprender-test-lib",
  "assert_cmd",
@@ -1507,7 +1507,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-derive"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1517,7 +1517,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-js-gen"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "blake3",
  "chrono",
@@ -1533,7 +1533,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-lib"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "aprender-compute",
  "aprender-present-core",
@@ -1577,7 +1577,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-showcase"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "aprender-present-terminal",
  "console_error_panic_hook",
@@ -1594,7 +1594,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "approx",
  "aprender-common",
@@ -1662,7 +1662,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-bench"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1679,7 +1679,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-common"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "aprender-viz",
  "clap",
@@ -1691,7 +1691,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-distill"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1712,7 +1712,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-inspect"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1728,7 +1728,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-lora"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1744,7 +1744,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-shell"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-wasm"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "proptest",
  "serde",
@@ -1771,9 +1771,9 @@ dependencies = [
 
 [[package]]
 name = "aprender-tsp"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
- "aprender 0.49.0",
+ "aprender 0.49.1",
  "assert_cmd",
  "clap",
  "crc32fast",
@@ -1786,7 +1786,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-verify"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "chrono",
  "criterion 0.5.1",
@@ -1798,7 +1798,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-verify-ml"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "aprender-compute",
  "aprender-core",
@@ -1828,7 +1828,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-viz"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "approx",
  "aprender-common",
@@ -1851,7 +1851,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "aprender-zram-adaptive",
  "aprender-zram-core",
@@ -1861,7 +1861,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-adaptive"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "aprender-zram-core",
  "proptest",
@@ -1870,7 +1870,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-cli"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "aprender-zram-adaptive",
  "aprender-zram-core",
@@ -1884,7 +1884,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-core"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "aprender-gpu",
  "criterion 0.7.0",
@@ -1896,7 +1896,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-generator"
-version = "0.49.0"
+version = "0.49.1"
 dependencies = [
  "aprender-zram-core",
  "serde",


### PR DESCRIPTION
## Problem

The v0.49.1 release PR (#1997) squash-merge (`33793ff0f`) silently dropped the
Cargo.lock workspace-version changes: 76 path-member entries reverted to `0.49.0`
while the manifests stayed at `0.49.1`.

Non-`--locked` CI (`ci/test`, `workspace-test`) auto-heals the lock at build time and
passed, masking it. The **binary-release** workflow's strict
`cargo build --bin pv -p aprender-contracts-cli --target <t> --locked` caught it —
both x86_64 jobs failed (`cannot update the lock file because --locked was passed`),
leaving v0.49.1 with **aarch64-only** binaries.

## Fix

Regenerated `Cargo.lock` so all workspace crates resolve to `0.49.1` (single-file, atomic).

## Verification
- ✅ `cargo build ... --target x86_64-unknown-linux-gnu --locked` → Finished
- ✅ `cargo build ... --target x86_64-unknown-linux-musl --locked` → Finished
- ✅ 0 remaining `version = "0.49.0"` entries

After merge: move tag `v0.49.1` here + re-run binary-release for the missing x86_64 assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)