### PR TITLE
fix(nn): Linear gradient path — NN training was silently not learning (Toyota Way root-cause)

### DIFF
--- a/contracts/nn-training-gradient-path-v1.yaml
+++ b/contracts/nn-training-gradient-path-v1.yaml
@@ -1,0 +1,55 @@
+contract: nn-training-gradient-path
+metadata:
+  kind: training-loop
+  version: "1.0.0"
+  description: >
+    The nn::Sequential/Linear + autograd training loop must actually learn. After
+    loss.backward(), gradients MUST reach Linear weight parameters (not only the
+    bias), so optimizers update weights and the loss converges. Guards the
+    2026-06-13 root-cause fix: Linear cached weight_t = weight.transpose() at
+    construction, and a training loop's per-step clear_graph() wiped that
+    transpose tape-edge, leaving weight with no gradient path
+    (get_grad(weight.id()) == None) — only biases learned, so training silently
+    froze. forward() now re-derives the transpose from the live weight while
+    grad-tracking (cache kept for inference).
+  references:
+  - "crates/aprender-core/src/nn/linear.rs"
+  - "crates/aprender-core/src/nn/optim/tests.rs"
+  - "crates/aprender-core/src/autograd/graph.rs"
+version: 1
+status: enforced
+date: 2026-06-13
+
+proof_obligations:
+  - type: invariant
+    property: >
+      GRAD-FLOW: after loss.backward() on a computation graph that contains
+      Linear::forward, get_grad(weight.id()) is Some for every grad-tracking
+      Linear weight — gradient reaches the weight leaf, not only the bias. This is
+      the precondition for any optimizer to update weights.
+  - type: monotonicity
+    property: >
+      TRAIN-CONVERGE: under the canonical idiom (clear_graph -> forward ->
+      backward -> SGD::step_with_params), a deterministic seeded 2-layer MLP's MSE
+      decreases by >80%. A weights-frozen regression (bias-only learning) yields
+      only ~50% and violates this obligation.
+  - type: equivalence
+    property: >
+      FORWARD-EQUIV: Linear::forward yields identical output whether it reuses the
+      cached weight_t (inference / no grad) or re-derives the transpose from the
+      live weight (training); the gradient-path fix must not change forward values
+      (guarded by the existing nn::linear forward tests).
+
+falsification_tests:
+  - id: FALSIFY-NN-GRAD-FLOW-001
+    name: nn_linear_backward_populates_weight_grad
+    prediction: "after Linear::forward + backward (post clear_graph), get_grad(weight.id()) is Some"
+    test_harness: "cargo test -p aprender-core --lib nn_linear_backward_populates_weight_grad"
+    expected_output: "test result: ok"
+    if_fails: "Linear::forward must transpose the LIVE weight while grad-tracking so the weight_t<-weight edge is on the current tape; a cached construction-time transpose is wiped by clear_graph()."
+  - id: FALSIFY-NN-TRAIN-CONVERGE-001
+    name: nn_mlp_training_converges
+    prediction: "a seeded 2-layer MLP trained via clear_graph+forward+backward+step_with_params drops MSE >80%"
+    test_harness: "cargo test -p aprender-core --lib nn_mlp_training_converges"
+    expected_output: "test result: ok"
+    if_fails: "Weights are frozen (bias-only learning, ~50% drop) — the Linear gradient path regressed; see FALSIFY-NN-GRAD-FLOW-001."

--- a/crates/aprender-core/src/nn/linear.rs
+++ b/crates/aprender-core/src/nn/linear.rs
@@ -223,12 +223,29 @@ impl Module for Linear {
             (input.clone(), None)
         };
 
-        // Use cached transposed weight (computed once during set_weight, not every forward)
-        // This eliminates ~450M element copies per forward pass for Qwen2-0.5B
-        let weight_t = self.weight_t.as_ref().unwrap_or_else(|| {
-            panic!("Linear layer has no cached weight_t. Call set_weight() first or use new().");
-        });
-        let output = reshaped.matmul(weight_t);
+        // Weight transpose, gradient-aware.
+        //
+        // TRAINING (weight tracks grad): transpose the LIVE weight every forward so
+        // the transpose op (weight_t <- weight edge) is recorded on the CURRENT
+        // autograd tape. The cached `weight_t` is built once at construction; a
+        // training loop's per-step `clear_graph()` wipes that construction-time
+        // edge, so a cached transpose would leave `weight` with no path to receive
+        // gradient — get_grad(weight.id()) returns None and the optimizer silently
+        // updates nothing (frozen loss). Re-deriving here keeps the edge live.
+        //
+        // INFERENCE (no grad tracking): reuse the cached transpose to avoid
+        // re-transposing large weight matrices on every forward.
+        let output = if self.weight.requires_grad_enabled() {
+            let weight_t = self.weight.transpose();
+            reshaped.matmul(&weight_t)
+        } else {
+            let weight_t = self.weight_t.as_ref().unwrap_or_else(|| {
+                panic!(
+                    "Linear layer has no cached weight_t. Call set_weight() first or use new()."
+                );
+            });
+            reshaped.matmul(weight_t)
+        };
 
         // Add bias with autograd
         let output = match &self.bias {

--- a/crates/aprender-core/src/nn/optim/mod.rs
+++ b/crates/aprender-core/src/nn/optim/mod.rs
@@ -40,7 +40,14 @@ use crate::autograd::{get_grad, Tensor, TensorId};
 
 /// Common trait for all optimizers.
 pub trait Optimizer {
-    /// Perform a single optimization step using computed gradients.
+    /// Marks the optimizer as having stepped. **This does NOT update parameters.**
+    ///
+    /// Gradients live in a global autograd graph keyed by tensor id, so an
+    /// optimizer (which holds only parameter ids + state) cannot reach the
+    /// parameter tensors from here. To actually apply updates, call
+    /// `step_with_params(&mut params)` (e.g.
+    /// `sgd.step_with_params(&mut model.parameters_mut())`). Canonical training
+    /// loop: `clear_graph(); let loss = ...; loss.backward(); opt.step_with_params(&mut model.parameters_mut());`
     fn step(&mut self);
 
     /// Zero all parameter gradients.

--- a/crates/aprender-core/src/nn/optim/tests.rs
+++ b/crates/aprender-core/src/nn/optim/tests.rs
@@ -454,6 +454,32 @@ mod tests_large_tensors;
 #[path = "tests_state_resize.rs"]
 mod tests_state_resize;
 
+/// REGRESSION (direct): after `Linear::forward` + `backward()`, the layer's WEIGHT
+/// must receive a gradient — not just the bias. This is the exact defect: the
+/// construction-time cached `weight_t` transpose edge is wiped by `clear_graph()`,
+/// leaving `weight` with no path to gradient (`get_grad(weight.id())` == None).
+/// Falsifies proof obligation GRAD-FLOW of `contracts/nn-training-gradient-path-v1.yaml`.
+#[test]
+fn nn_linear_backward_populates_weight_grad() {
+    use crate::autograd::{clear_graph, get_grad, Tensor};
+    use crate::nn::{Linear, Module};
+
+    clear_graph(); // mimics a per-step training reset that wiped the cached edge
+    let layer = Linear::with_seed(4, 3, Some(1));
+    let x = Tensor::from_vec(vec![0.5; 8], &[2, 4]);
+    let out = layer.forward(&x);
+    out.sum().backward();
+
+    assert!(
+        get_grad(layer.weight().id()).is_some(),
+        "Linear weight received NO gradient through forward — the autograd path to \
+         `weight` is broken (cached construction-time transpose wiped by clear_graph)."
+    );
+    if let Some(b) = layer.bias() {
+        assert!(get_grad(b.id()).is_some(), "Linear bias received no gradient either.");
+    }
+}
+
 /// REGRESSION: a 2-layer MLP trained with the canonical idiom (clear_graph →
 /// forward → backward → `SGD::step_with_params`) MUST converge.
 ///

--- a/crates/aprender-core/src/nn/optim/tests.rs
+++ b/crates/aprender-core/src/nn/optim/tests.rs
@@ -453,3 +453,74 @@ mod tests_adamw_contract;
 mod tests_large_tensors;
 #[path = "tests_state_resize.rs"]
 mod tests_state_resize;
+
+/// REGRESSION: a 2-layer MLP trained with the canonical idiom (clear_graph →
+/// forward → backward → `SGD::step_with_params`) MUST converge.
+///
+/// Guards the Linear weight-gradient-path fix (linear.rs forward): a `Linear`
+/// caches `weight_t = weight.transpose()` at construction, but a training loop's
+/// per-step `clear_graph()` wipes that construction-time transpose edge. If
+/// forward reuses the cached transpose, `weight` has no path to receive gradient
+/// (`get_grad(weight.id())` is `None`), the optimizer updates only biases, and the
+/// loss is nearly frozen. forward now re-derives the transpose from the live
+/// weight while grad-tracking, so weights actually learn. Deterministic (seeded).
+#[test]
+fn nn_mlp_training_converges() {
+    use crate::autograd::{clear_graph, Tensor};
+    use crate::nn::{Linear, MSELoss, Module, ReLU, Sequential, SGD};
+
+    let (n, din, dh) = (256usize, 16usize, 8usize);
+    let mut s: u64 = 7;
+    let mut rng = || {
+        s ^= s << 13;
+        s ^= s >> 7;
+        s ^= s << 17;
+        ((s >> 40) as f32 / (1u64 << 24) as f32) - 0.5
+    };
+    let w: Vec<f32> = (0..din).map(|_| rng()).collect();
+    let (mut xd, mut yd) = (Vec::new(), Vec::new());
+    for _ in 0..n {
+        let mut t = 0.0;
+        for j in 0..din {
+            let v = rng();
+            xd.push(v);
+            t += v * w[j];
+        }
+        yd.push(t);
+    }
+    let x = Tensor::from_vec(xd, &[n, din]);
+    let y = Tensor::from_vec(yd, &[n, 1]);
+    let mut model = Sequential::new()
+        .add(Linear::with_seed(din, dh, Some(1)))
+        .add(ReLU)
+        .add(Linear::with_seed(dh, 1, Some(2)));
+    let crit = MSELoss::new();
+    let mut sgd = SGD::new(model.parameters_mut(), 0.1);
+
+    let mut first = 0.0;
+    let mut last = 0.0;
+    for step in 0..500 {
+        clear_graph();
+        let loss = crit.forward(&model.forward(&x), &y);
+        last = loss.item();
+        if step == 0 {
+            first = last;
+        }
+        loss.backward();
+        let mut p = model.parameters_mut();
+        sgd.step_with_params(&mut p);
+    }
+
+    assert!(
+        first > 0.05,
+        "sanity: initial MSE should be non-trivial, got {first}"
+    );
+    // Weights-frozen (the defect) gives only ~50% drop (biases only); a working
+    // weight gradient path drops >98%. 80% is a robust, non-flaky threshold.
+    assert!(
+        last < first * 0.2,
+        "MLP training did not converge: MSE {first:.5} -> {last:.5} (need < {:.5}). \
+         Likely a regression of the Linear live-transpose gradient-path fix.",
+        first * 0.2
+    );
+}


### PR DESCRIPTION
**Toyota Way root-cause fix.** apr's high-level NN training (`nn::Sequential`/`Linear` + `SGD`/`Adam`) silently did not learn its weights — and nothing guarded it.

## Root cause (genchi genbutsu)

`nn::Linear` caches `weight_t = weight.transpose()` **once at construction** — that transpose op records the *only* autograd tape edge `weight_t ← weight`. A real training loop calls `clear_graph()` each step, which **wipes that construction-time edge**. Then `forward`'s `reshaped.matmul(weight_t)` deposits gradient on `weight_t` (a non-leaf) with **no surviving path back to `weight`**, so `get_grad(weight.id())` (what optimizers read) is `None`. The optimizer updated **only biases** → loss dropped ~50% and *looked* "frozen". (Found via a 5-agent isolate-and-read workflow; verified with minimal repros.)

## Fix

`Linear::forward`: when the weight is grad-tracking (training), re-derive the transpose from the **live** weight each forward so the `weight_t ← weight` edge lives on the *current* tape and gradient reaches `weight`. Reuse the cached transpose only when **not** grad-tracking (inference) — perf path preserved.

## Verification

- Deterministic 2-layer MLP: **49% → 98.4%** MSE drop (weights now learn, not just biases).
- **New regression test** `nn_mlp_training_converges` — runs in `cargo test --lib` (CI), asserts >80% drop. *This is the guard that was missing.*
- All **1208** nn lib tests pass; fmt + clippy clean.

## Also

Poka-Yoke'd the footgun that masked this: documented that `Optimizer::step()` does **not** update params (no-op in the global-graph design); `step_with_params(&mut model.parameters_mut())` is the real update.

**Unblocks Pillar-2 (PyTorch training-time beat) and Pillar-3 (QLoRA)** — both depend on this autograd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)