### PR TITLE
fix(qa): format-parity gate — skip circular .converted refs, never crash (PMAT-743)

### DIFF
--- a/contracts/apr-model-qa-v1.yaml
+++ b/contracts/apr-model-qa-v1.yaml
@@ -1,10 +1,25 @@
 metadata:
-  version: 1.4.0
+  version: 1.5.0
   created: '2026-04-04'
-  updated: '2026-05-10'
+  updated: '2026-06-13'
   author: PAIML Engineering
   registry: true
   description: >
+    v1.5.0 (2026-06-13): PMAT-743 — format-parity gate robustness. Added
+    FALSIFY-QA-FMTPARITY-743 + a discovery-robustness invariant. The gate's
+    SafeTensors auto-discovery picked up apr's OWN conversion artifacts
+    (`*.converted*.safetensors`) as if they were independent references —
+    circular, and frequently stale/double-converted — producing a confusing
+    "conversion failed" on a `.converted.converted.safetensors` path. Worse, a
+    corrupt reference (down_proj 100% zeros, F-DATA-QUALITY-001) HARD-CRASHED
+    `apr qa` (exit 5, no report) because only two error substrings were handled
+    gracefully. Fix: (A) discovery excludes `.converted*` artifacts and finds the
+    genuine model.safetensors; (C) ANY reference conversion failure → graceful
+    gate FAIL with the reason, never a crash; (B, aprender-qa-runner) the
+    `.converted` output path is now idempotent (no `.converted.converted…`
+    compounding / cache pollution). Live-verified on RTX 4090, qwen2.5-coder-1.5b
+    Q4_K_M. See contracts note and forward_error.rs / conversion.rs.
+
     Model quality assurance contract — check, validate, qa, lint, probar
     commands that verify model integrity, detect regressions, and enforce
     quality gates before deployment. The defensive layer of apr-cli.
@@ -270,6 +285,20 @@ proof_obligations:
   lean:
     theorem: Theorems.GoldenOutputShipBlockerIdempotent
     status: sorry
+- type: invariant
+  property: >
+    PMAT-743: format-parity discovery ignores apr's own conversion artifacts
+    (`*.converted*.safetensors`) — they are circular references, never independent
+    ones — and a reference that cannot be loaded/converted (missing tensor,
+    unsupported arch, corrupt/zeroed weights) yields a graceful gate FAILURE with an
+    actionable message, never a hard crash of `apr qa`.
+  formal: |
+    is_synthetic_conversion_artifact(name) => name not in discovered_references
+    AND convert(reference) == Err(_) => gate_result == Failed(reason) (never panic/abort)
+  applies_to: format_parity_gate
+  lean:
+    theorem: Theorems.FormatParityDiscoveryRobust
+    status: sorry
 
 falsification_tests:
 - id: FALSIFY-QA-001
@@ -403,6 +432,42 @@ falsification_tests:
     repeatable. Forbid merging any release-blocking PR until fixed.
   spec_reference: ship-two-models-spec.md §12.1, §12.5
   ship_blocking: true
+- id: FALSIFY-QA-FMTPARITY-743
+  rule: >
+    format-parity discovery ignores synthetic `.converted` artifacts and the gate
+    never hard-crashes `apr qa` on a corrupt/unconvertible reference
+  prediction: |
+    (a) Given a snapshot dir containing a genuine shard
+        (model-00001-of-00002.safetensors) plus apr's own
+        `*.converted.safetensors` / `*.converted.converted.safetensors`
+        artifacts, find_safetensors_in_snapshot returns the GENUINE shard,
+        never a `.converted` one.
+    (b) Given a snapshot dir containing ONLY `.converted` artifacts,
+        find_safetensors_in_snapshot returns None (no circular reference).
+    (c) A reference SafeTensors that fails to convert (e.g. corrupt down_proj
+        flagged by F-DATA-QUALITY-001 DENSITY FAILURE) yields a graceful
+        format_parity GATE FAILURE with the reason in the message — `apr qa`
+        completes all gates and prints the summary table (exit reflects gate
+        failure), it does NOT abort mid-run with a bare CliError.
+    Measured 2026-06-13 (RTX 4090, qwen2.5-coder-1.5b Q4_K_M): pre-fix `apr qa`
+    converted `*.converted.converted.safetensors` (circular) → confusing
+    "conversion failed"; or aborted exit-5 with no report when the genuine
+    reference was corrupt. Post-fix: discovery finds the genuine
+    model.safetensors; corrupt reference → clean "Format Parity ✗ FAIL ...
+    DENSITY FAILURE" line + full table.
+  test: |
+    cargo test -p apr-cli --lib forward_error_tests (synthetic_artifact_detection,
+    snapshot_discovery_prefers_genuine_over_converted,
+    snapshot_discovery_skips_when_only_converted_artifacts) +
+    cargo test -p aprender-qa-runner --lib pmat743_converted_path_tests
+    (reconverting_an_artifact_does_not_compound, …)
+  if_fails: |
+    Either format_parity does a vacuous circular comparison (GGUF vs a
+    SafeTensors derived from that GGUF), or `apr qa` crashes on a corrupt
+    reference (the diagnostic tool dies instead of reporting), or the qa-runner
+    compounds `.converted.converted…` and pollutes the model cache unboundedly.
+  spec_reference: PMAT-743
+  ship_blocking: false
 
 kani_harnesses:
 - id: KANI-QA-001

--- a/crates/apr-cli/src/commands/forward_error.rs
+++ b/crates/apr-cli/src/commands/forward_error.rs
@@ -12,6 +12,22 @@ fn strip_quant_suffix(stem: &str) -> &str {
         .trim_end_matches("-f32")
 }
 
+/// True if `filename` is one of apr's OWN conversion outputs
+/// (`<x>.converted.safetensors`, `<x>.converted.converted.safetensors`, …) rather
+/// than an INDEPENDENT SafeTensors reference (PMAT-743).
+///
+/// The format-parity gate compares a GGUF forward pass against an *independent*
+/// SafeTensors forward pass. A SafeTensors that was itself converted FROM the GGUF
+/// under test is a circular reference — comparing a model against a derivative of
+/// itself proves nothing — and in practice these artifacts are frequently stale or
+/// double-converted (`.converted.converted.…`, see the qa-runner idempotency fix),
+/// so converting them back fails with a confusing "conversion failed" message.
+/// Discovery must skip them; genuine HF SafeTensors use `-`/`model-NNNNN-of-NNNNN`
+/// naming and never contain a `.converted.` segment.
+fn is_synthetic_conversion_artifact(filename: &str) -> bool {
+    filename.contains(".converted.")
+}
+
 /// Strategy 2 helper: find a SafeTensors entry point in a sharded model directory.
 /// Returns the first shard (sorted) for sharded models. The format parity gate
 /// handles converter failures for sharded models gracefully.
@@ -27,7 +43,10 @@ fn find_sharded_safetensors(dir: &Path) -> Option<std::path::PathBuf> {
         .filter_map(|entry| {
             let name = entry.file_name();
             let name_str = name.to_string_lossy().to_string();
-            if name_str.ends_with(".safetensors") && name_str != "model.safetensors" {
+            if name_str.ends_with(".safetensors")
+                && name_str != "model.safetensors"
+                && !is_synthetic_conversion_artifact(&name_str)
+            {
                 Some(entry.path())
             } else {
                 None
@@ -66,7 +85,10 @@ fn find_safetensors_in_snapshot(snap_path: &Path) -> Option<std::path::PathBuf> 
         .filter_map(|f| {
             let fname = f.file_name();
             let name = fname.to_string_lossy();
-            if name.ends_with(".safetensors") && name != "model.safetensors" {
+            if name.ends_with(".safetensors")
+                && name != "model.safetensors"
+                && !is_synthetic_conversion_artifact(&name)
+            {
                 Some(f.path())
             } else {
                 None
@@ -430,11 +452,19 @@ fn run_safetensors_forward(
     let model = match transformer {
         Ok(t) => t,
         Err(e) => {
-            let msg = format!("{e}");
-            if msg.contains("Tensor not found") || msg.contains("not supported") {
-                return Err(ForwardError::ConversionFailed(safetensors_path.display().to_string()));
-            }
-            return Err(ForwardError::Cli(CliError::ValidationFailed(format!("SafeTensors convert failed: {e}"))));
+            // PMAT-743: ANY failure to load/convert the REFERENCE SafeTensors means
+            // the parity comparison cannot run — that is a graceful GATE failure with
+            // an actionable message, NEVER a hard crash of `apr qa`. Previously only
+            // "Tensor not found"/"not supported" were handled gracefully; other
+            // errors (e.g. a corrupt reference whose down_proj is all zeros, caught
+            // by F-DATA-QUALITY-001) propagated as a hard CliError and aborted the
+            // whole `apr qa` run (exit 5). The diagnostic tool must survive a bad
+            // reference and report it, not die. The error detail is preserved so the
+            // user knows WHY (missing tensor, unsupported arch, corrupt weights, …).
+            return Err(ForwardError::ConversionFailed(format!(
+                "{} ({e})",
+                safetensors_path.display()
+            )));
         }
     };
 

--- a/crates/apr-cli/src/commands/forward_error_tests.rs
+++ b/crates/apr-cli/src/commands/forward_error_tests.rs
@@ -218,4 +218,61 @@ mod forward_error_tests {
         assert!(result.passed, "skipped gates count as passed");
         assert!(result.message.contains("Non-GGUF"), "got: {}", result.message);
     }
+
+    // ========================================================================
+    // PMAT-743: format-parity discovery must ignore apr's own conversion
+    // artifacts (`*.converted*.safetensors`) — they are circular references,
+    // not independent SafeTensors, and are frequently stale / double-converted.
+    // ========================================================================
+
+    #[test]
+    fn synthetic_artifact_detection() {
+        assert!(is_synthetic_conversion_artifact("m-q4_k_m.converted.safetensors"));
+        assert!(is_synthetic_conversion_artifact(
+            "m-q4_k_m.converted.converted.safetensors"
+        ));
+        // Genuine HF SafeTensors never contain a `.converted.` segment.
+        assert!(!is_synthetic_conversion_artifact("model.safetensors"));
+        assert!(!is_synthetic_conversion_artifact(
+            "model-00001-of-00002.safetensors"
+        ));
+        assert!(!is_synthetic_conversion_artifact("qwen2.5-coder.safetensors"));
+    }
+
+    #[test]
+    fn snapshot_discovery_prefers_genuine_over_converted() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let p = dir.path();
+        // A genuine shard alongside two synthetic conversion artifacts.
+        for name in [
+            "model-00001-of-00002.safetensors",
+            "m-q4_k_m.converted.safetensors",
+            "m-q4_k_m.converted.converted.safetensors",
+        ] {
+            std::fs::write(p.join(name), b"x").expect("write");
+        }
+        let found = super::find_safetensors_in_snapshot(p).expect("a genuine shard exists");
+        assert_eq!(
+            found.file_name().unwrap().to_str().unwrap(),
+            "model-00001-of-00002.safetensors",
+            "must pick the genuine shard, never a .converted artifact"
+        );
+    }
+
+    #[test]
+    fn snapshot_discovery_skips_when_only_converted_artifacts() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let p = dir.path();
+        // Only synthetic artifacts exist (GGUF-only model whose cache was polluted).
+        for name in [
+            "m-q4_k_m.converted.safetensors",
+            "m-q4_k_m.converted.converted.safetensors",
+        ] {
+            std::fs::write(p.join(name), b"x").expect("write");
+        }
+        assert!(
+            super::find_safetensors_in_snapshot(p).is_none(),
+            "must find NO independent reference (artifacts ignored), not pick a circular one"
+        );
+    }
 }

--- a/crates/aprender-qa-runner/src/conversion.rs
+++ b/crates/aprender-qa-runner/src/conversion.rs
@@ -226,6 +226,25 @@ fn format_extension(format: Format) -> &'static str {
     }
 }
 
+/// Build the in-place conversion output path for `source` with `target_ext`,
+/// idempotently (PMAT-743). `Path::with_extension("converted.<ext>")` replaces only
+/// the final extension component, so a source already ending `.converted.<x>` would
+/// compound into `.converted.converted.<x>` and pollute the model cache unboundedly
+/// across re-conversions (observed in the HF cache as
+/// `*.converted.converted.safetensors`). Normalizing the stem first makes the output
+/// stable; for a source that does NOT already contain `.converted` the result is
+/// identical to the old `with_extension` form.
+fn converted_output_path(source: &Path, target_ext: &str) -> PathBuf {
+    let mut stem = source
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("model");
+    while let Some(base) = stem.strip_suffix(".converted") {
+        stem = base;
+    }
+    source.with_file_name(format!("{stem}.converted.{target_ext}"))
+}
+
 fn find_file_by_extension(dir: &Path, ext: &str) -> Option<std::path::PathBuf> {
     std::fs::read_dir(dir).ok()?.flatten().find_map(|entry| {
         let p = entry.path();
@@ -408,3 +427,38 @@ pub struct ConversionTolerance {
 include!("conversion_tolerances.rs");
 include!("semantic_conversion_test.rs");
 include!("conversion_strategies.rs");
+
+#[cfg(test)]
+mod pmat743_converted_path_tests {
+    use super::converted_output_path;
+    use std::path::Path;
+
+    #[test]
+    fn first_conversion_appends_converted_once() {
+        let out = converted_output_path(Path::new("/m/qwen-q4_k_m.gguf"), "safetensors");
+        assert_eq!(out, Path::new("/m/qwen-q4_k_m.converted.safetensors"));
+    }
+
+    #[test]
+    fn reconverting_an_artifact_does_not_compound() {
+        // The bug: with_extension on `*.converted.safetensors` produced
+        // `*.converted.converted.safetensors`. Must stay single `.converted`.
+        let out = converted_output_path(Path::new("/m/qwen-q4_k_m.converted.safetensors"), "apr");
+        assert_eq!(out, Path::new("/m/qwen-q4_k_m.converted.apr"));
+    }
+
+    #[test]
+    fn deeply_compounded_artifact_is_normalized() {
+        let out = converted_output_path(
+            Path::new("/m/qwen.converted.converted.converted.safetensors"),
+            "safetensors",
+        );
+        assert_eq!(out, Path::new("/m/qwen.converted.safetensors"));
+    }
+
+    #[test]
+    fn no_extension_source_is_handled() {
+        let out = converted_output_path(Path::new("/m/model"), "gguf");
+        assert_eq!(out, Path::new("/m/model.converted.gguf"));
+    }
+}

--- a/crates/aprender-qa-runner/src/conversion_executor_impl.rs
+++ b/crates/aprender-qa-runner/src/conversion_executor_impl.rs
@@ -484,7 +484,8 @@ impl ConversionExecutor {
     ) {
         for (source, target) in all_conversion_pairs() {
             let target_ext = format_extension(target);
-            let converted_path = model_path.with_extension(format!("converted.{target_ext}"));
+            // PMAT-743: must match the writer's idempotent path scheme.
+            let converted_path = converted_output_path(model_path, target_ext);
             if !converted_path.exists() {
                 continue;
             }

--- a/crates/aprender-qa-runner/src/conversion_strategies.rs
+++ b/crates/aprender-qa-runner/src/conversion_strategies.rs
@@ -423,8 +423,9 @@ fn convert_to_format(
         Format::Apr => "apr",
     };
 
-    // Create target path with new extension (format determined by extension)
-    let target_path = source_path.with_extension(format!("converted.{target_ext}"));
+    // Create target path with new extension (format determined by extension).
+    // PMAT-743: idempotent — never compound `.converted` on re-conversion.
+    let target_path = converted_output_path(source_path, target_ext);
 
     // Use apr rosetta convert: apr rosetta convert <SOURCE> <TARGET>
     // Format is inferred from output file extension

--- a/crates/aprender-qa-runner/src/conversion_tolerances.rs
+++ b/crates/aprender-qa-runner/src/conversion_tolerances.rs
@@ -423,8 +423,9 @@ impl ConversionTest {
 
             output_dir.output_path("basic", source_name, "converted", self.target_format)
         } else {
-            // Legacy: write to source directory (for backward compatibility in tests)
-            source_path.with_extension(format!("converted.{target_ext}"))
+            // Legacy: write to source directory (for backward compatibility in tests).
+            // PMAT-743: idempotent — never compound `.converted` on re-conversion.
+            converted_output_path(source_path, target_ext)
         };
 
         // Use apr rosetta convert: apr rosetta convert <SOURCE> <TARGET>


### PR DESCRIPTION
## Problem

`apr qa <gguf>` (the *first* diagnostic tool per CLAUDE.md) reported a confusing `format_parity` FAIL — or **hard-crashed (exit 5, no report)** — due to three compounding defects, found via genchi-genbutsu on a real model (qwen2.5-coder-1.5b Q4_K_M, RTX 4090).

## Three root causes

**A — Circular discovery (apr-cli).** The gate auto-discovers a SafeTensors reference to compare against the GGUF, but the snapshot/sharded selectors globbed *any* `*.safetensors` — including apr's **own** conversion outputs (`*.converted.safetensors`, `*.converted.converted.safetensors`). Comparing a GGUF against a SafeTensors derived *from that GGUF* is circular, and these artifacts are often stale/double-converted → "conversion failed: `…converted.converted.safetensors`".
→ `is_synthetic_conversion_artifact()` excludes `.converted*` from discovery. It now finds the **genuine** `model.safetensors` (the real Qwen repo, not the `-GGUF` one).

**B — Compounding `.converted` (aprender-qa-runner).** `source_path.with_extension(format!("converted.{ext}"))` replaces only the final component, so a source already ending `.converted.<x>` became `.converted.converted.<x>` — unbounded cache pollution (the very artifacts above).
→ `converted_output_path()` normalizes the stem first (idempotent; **identical output for non-`.converted` sources** — no behavior change for normal models).

**C — Hard crash on a bad reference (apr-cli).** Only `"Tensor not found"`/`"not supported"` errors were handled gracefully; *any other* error propagated as a hard `CliError` and aborted the whole run. When the discovered genuine `model.safetensors` turned out **corrupt** (down_proj 100% zeros, caught by `F-DATA-QUALITY-001`), `apr qa` died exit-5 with no report.
→ ANY reference load/convert failure → graceful `format_parity` GATE FAIL with the reason; all gates run, full table prints. *A diagnostic must never crash on a corrupt input it exists to diagnose.*

## Verified (RTX 4090)

`apr qa` now skips the circular artifacts, finds the genuine reference, and on its corruption prints a clean line + full table:
```
✗ FAIL Format Parity  SafeTensors conversion failed: .../model.safetensors
        (F-DATA-QUALITY-001: 'ffn_down_weight' DENSITY FAILURE: 100.0% zeros)
```
…instead of a circular comparison or an exit-5 crash.

## Co-evolution (Rule 7)
- **apr-cli**: 3 unit falsifiers (`synthetic_artifact_detection`, `snapshot_discovery_prefers_genuine_over_converted`, `snapshot_discovery_skips_when_only_converted_artifacts`)
- **aprender-qa-runner**: 4 unit falsifiers (`pmat743_converted_path_tests`: idempotent / no-compound / deep-normalize / no-extension)
- **contract** `apr-model-qa-v1` → **1.5.0**: `FALSIFY-QA-FMTPARITY-743` + discovery-robustness invariant; `pv validate` clean

## Verification
- `cargo test -p apr-cli --lib commands::qa` → 210 pass; `cargo test -p aprender-qa-runner --lib conversion` → 372 pass
- `pv validate` clean; `cargo test -p aprender-contracts --lib lint::` → 191 pass; fmt/clippy clean (changed files warning-free)

## Out of scope (noted)
- The corrupt local `model.safetensors` (down_proj zeros) is environmental (bad cache download); apr's density check correctly flags it.
- `performance_regression` gate flakes on run-to-run GPU tok/s variance — separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)