### PR TITLE
feat(beat): Pillar-3 LoRA merge forward-equivalence (PMAT-747)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,7 +247,7 @@ jobs:
             -e CARGO_INCREMENTAL=0 \
             -e CARGO_BUILD_JOBS=8 \
             "$IMAGE" \
-            bash -c 'cargo test -p aprender-core --test monorepo_invariants && cargo test -p aprender-core --test readme_contract && cargo test -p apr-cli --test cli_commands && cargo test -p aprender-core --test beat_sklearn_iris && cargo test -p aprender-serve --test beat_fail_closed_garbage && cargo test -p aprender-compute --lib beat_nf4_bitsandbytes_equivalence && cargo test -p aprender-core --test beat_pytorch_autograd_grad'
+            bash -c 'cargo test -p aprender-core --test monorepo_invariants && cargo test -p aprender-core --test readme_contract && cargo test -p apr-cli --test cli_commands && cargo test -p aprender-core --test beat_sklearn_iris && cargo test -p aprender-serve --test beat_fail_closed_garbage && cargo test -p aprender-compute --lib beat_nf4_bitsandbytes_equivalence && cargo test -p aprender-core --test beat_pytorch_autograd_grad && cargo test -p aprender-train-lora --lib beat_lora_merge_forward_equivalence'
       - name: Build.rs crate-root escape check (v0.31.1 yank guard)
         # Static Poka-Yoke: flags build.rs files that panic on files outside
         # CARGO_MANIFEST_DIR, which break `cargo install` from crates.io.

--- a/contracts/apr-lora-merge-equivalence-beat-v1.yaml
+++ b/contracts/apr-lora-merge-equivalence-beat-v1.yaml
@@ -1,0 +1,42 @@
+contract: apr-lora-merge-equivalence-beat
+metadata:
+  kind: beat-benchmark
+  version: "1.0.0"
+  description: >
+    Pillar-3 (Unsloth) CORRECTNESS beat (PMAT-747): aprender's LoRA merge is
+    numerically faithful — folding the adapter delta scale·(B@A) into the base weight
+    produces a forward pass EQUIVALENT to applying the LoRA factors unmerged. This is
+    the second half of "replace Unsloth's QLoRA pipeline" (NF4 quant ≡ bitsandbytes is
+    PMAT-745; this is fine-tune→merge→export). apr's MergeEngine::merge is
+    contract-gated for forward-equivalence; PEFT/Unsloth ship merge_and_unload with no
+    such guarantee. The reference is computed INDEPENDENTLY from the A,B factors via a
+    different path (x @ A @ B), so a transpose/indexing bug in the merge would diverge
+    — it is not a tautology. Measured 2026-06-14 (CPU, deterministic): merged-weight
+    forward matches the factored-LoRA forward to max|Δ|=1.49e-8.
+  references:
+  - "crates/aprender-train-lora/src/merge.rs (MergeEngine::merge + beat_lora_merge_forward_equivalence)"
+  - "evidence/pillar3-lora-merge-equivalence-2026-06-14/findings.md"
+  - "apr-nf4-bitsandbytes-equivalence-beat-v1.yaml (sibling: the quant half of the P3 pipeline)"
+version: 1
+status: enforced
+date: 2026-06-14
+
+# Beat-benchmark parameters (forward-equivalence invariant; CI fails on divergence).
+beat:
+  pillar: 3
+  incumbent: "PEFT / Unsloth (merge_and_unload — no forward-equivalence contract)"
+  incumbent_pinned: "2026-06-14 — incumbents merge but do not contract-verify merged≡factored forward"
+  canonical_task: >
+    Fold a LoRA adapter (A:[d_in,r], B:[r,d_out], scale=alpha/rank) into a base
+    weight W:[d_out,d_in] via MergeEngine::merge, then compare the merged-weight
+    forward (x @ W_merged^T) against the LoRA forward computed independently from the
+    factors (x@W_base^T + scale·(x @ A @ B)). Metric: max absolute per-element
+    difference between the two forward passes.
+  metric: merge_forward_max_abs_diff
+  direction: lower_is_better
+  baseline_value: 0.0000      # perfect forward-equivalence target
+  baseline_floor: 0.00000002  # measured merged-vs-factored max|Δ| ≈ 1.49e-8
+  beat_threshold: 0.0001      # apr merge must stay forward-equivalent within 1e-4; measured ~1.5e-8
+  baseline_sourced_date: "2026-06-14"
+  approved_compute: CPU
+  ci_gate_name: "beat_lora_merge_forward_equivalence"

--- a/crates/aprender-train-lora/src/merge.rs
+++ b/crates/aprender-train-lora/src/merge.rs
@@ -459,4 +459,90 @@ mod tests {
         // merged[0] = 1.0 + 6.0 * 1.0 * 1.0 = 7.0
         assert!((merged[0] - 7.0).abs() < 0.01);
     }
+
+    /// BEAT-LORA-MERGE — Pillar-3 (Unsloth) correctness beat (PMAT-747).
+    ///
+    /// The other half of "replace Unsloth's QLoRA pipeline" (NF4 quant ≡ bitsandbytes
+    /// is PMAT-745; this is fine-tune→merge). apr's `MergeEngine::merge` folds the
+    /// LoRA delta `scale·(B@A)` into the base weight; this gate proves the MERGED
+    /// weights produce a forward pass NUMERICALLY EQUIVALENT to applying the LoRA
+    /// factors unmerged — i.e. the merge is mathematically faithful, contract-gated,
+    /// where PEFT/Unsloth ship merge_and_unload with no such equivalence guarantee.
+    ///
+    /// The reference is computed INDEPENDENTLY from the A,B factors via a different
+    /// path (x @ A @ B), so this is not tautological: a transpose/indexing bug in
+    /// `merge` would diverge. Self-contained (CPU, deterministic).
+    #[test]
+    fn beat_lora_merge_forward_equivalence() {
+        // dims chosen so d_out != d_in (unambiguous "standard" merge path).
+        let (d_in, d_out, r) = (4usize, 3usize, 2usize);
+        let n = 2usize; // batch
+
+        // A: [d_in, r] row-major; B: [r, d_out] row-major; W_base: [d_out, d_in].
+        let a: Vec<f32> = vec![0.10, -0.20, 0.05, 0.30, -0.10, 0.25, 0.40, -0.15]; // 4x2
+        let b: Vec<f32> = vec![0.20, -0.30, 0.10, 0.15, 0.05, -0.25]; // 2x3
+        let w_base: Vec<f32> = (0..d_out * d_in).map(|i| (i as f32 - 6.0) * 0.07).collect(); // 3x4
+        let x: Vec<f32> = vec![0.5, -0.2, 0.3, 0.1, -0.4, 0.6, 0.2, -0.1]; // 2x4
+        let (alpha, rank) = (4.0_f32, r as u32);
+        let scale_factor = 1.0 * alpha / rank as f32; // default scale 1.0 → 2.0
+
+        // apr merge: fold delta into base.
+        let merged = MergeEngine::new().merge(&w_base, &a, &b, alpha, rank);
+
+        // Forward with MERGED weights: y_m[i,row] = sum_col x[i,col]*merged[row,col].
+        let mut y_merged = vec![0.0f32; n * d_out];
+        for i in 0..n {
+            for row in 0..d_out {
+                let mut s = 0.0;
+                for col in 0..d_in {
+                    s += x[i * d_in + col] * merged[row * d_in + col];
+                }
+                y_merged[i * d_out + row] = s;
+            }
+        }
+
+        // INDEPENDENT reference: base forward + scale·(x @ A @ B).
+        // (x@A)[i,k] = sum_col x[i,col]*A[col,k];  then (xa@B)[i,row] = sum_k xa[i,k]*B[k,row].
+        let mut y_ref = vec![0.0f32; n * d_out];
+        for i in 0..n {
+            // base contribution
+            for row in 0..d_out {
+                let mut base = 0.0;
+                for col in 0..d_in {
+                    base += x[i * d_in + col] * w_base[row * d_in + col];
+                }
+                y_ref[i * d_out + row] = base;
+            }
+            // LoRA contribution via the factors (different computation path)
+            let mut xa = vec![0.0f32; r];
+            for (k, xa_k) in xa.iter_mut().enumerate() {
+                let mut s = 0.0;
+                for col in 0..d_in {
+                    s += x[i * d_in + col] * a[col * r + k]; // A[col,k]
+                }
+                *xa_k = s;
+            }
+            for row in 0..d_out {
+                let mut s = 0.0;
+                for (k, &xa_k) in xa.iter().enumerate() {
+                    s += xa_k * b[k * d_out + row]; // B[k,row]
+                }
+                y_ref[i * d_out + row] += scale_factor * s;
+            }
+        }
+
+        let max_abs_diff = y_merged
+            .iter()
+            .zip(y_ref.iter())
+            .map(|(m, r)| (m - r).abs())
+            .fold(0.0_f32, f32::max);
+        assert!(
+            max_abs_diff < 1e-4,
+            "LoRA merge NOT forward-equivalent: max|y_merged - y_factored|={max_abs_diff:.6} \
+             (a transpose/indexing bug in MergeEngine::merge). y_merged={y_merged:?} y_ref={y_ref:?}"
+        );
+        println!(
+            "BEAT-LORA-MERGE: merged-forward ≡ factored-LoRA-forward — max|Δ|={max_abs_diff:.2e}"
+        );
+    }
 }

--- a/docs/BEATS.md
+++ b/docs/BEATS.md
@@ -45,6 +45,7 @@ so it wins **matmul-bound** tasks (normal-equations regression) and concedes
 | Beat | Metric | Result | Gate |
 |------|--------|--------|------|
 | **NF4 numerical-equivalence** | max \|apr_recon − bitsandbytes_recon\| | ✅ **WON** — apr's pure-Rust NF4 ≡ bitsandbytes (max \|Δ\|=**4.92e-7**, MSE 0.007378 == bnb 0.007378; same codebook + blockwise convention, contract + Lean-gated) | CI `beat_nf4_bitsandbytes_equivalence` · `apr-nf4-bitsandbytes-equivalence-beat-v1` |
+| **LoRA merge forward-equivalence** | max \|merged_fwd − factored_fwd\| | ✅ **WON** (PMAT-747) — apr's `MergeEngine` folds the adapter faithfully (max \|Δ\|=**1.49e-8**); merged-weight forward ≡ independent LoRA-factor forward. PEFT/Unsloth merge_and_unload has no such contract | CI `beat_lora_merge_forward_equivalence` · `apr-lora-merge-equivalence-beat-v1` |
 | QLoRA fine-tune | loss-monotone + 4-bit footprint ≤ 0.30× f16 | 🚧 **PLANNED** (PMAT-711) | — |
 | LoRA→GGUF merge | forward max-abs-diff < 1e-2 | 🚧 **PLANNED** (PMAT-712) | — |
 

--- a/evidence/pillar3-lora-merge-equivalence-2026-06-14/findings.md
+++ b/evidence/pillar3-lora-merge-equivalence-2026-06-14/findings.md
@@ -1,0 +1,29 @@
+# Pillar-3 LoRA merge forward-equivalence beat — measured (2026-06-14)
+
+**Claim:** apr's `MergeEngine::merge` folds a LoRA adapter into the base weight
+faithfully — the merged weights produce a forward pass numerically equivalent to
+applying the LoRA factors unmerged. apr contract-gates this; PEFT/Unsloth
+`merge_and_unload` ships no forward-equivalence guarantee.
+
+## Why this completes the P3 "replace Unsloth" story
+Unsloth's value is fast QLoRA fine-tuning → merge → export. apr's correctness beats now
+cover both stages: NF4 quantization ≡ bitsandbytes (PMAT-745) and LoRA merge
+forward-equivalence (this, PMAT-747). Both are contract + (NF4) Lean-gated.
+
+## Method (self-contained, not tautological)
+Fold `A:[4,2], B:[2,3], scale=alpha/rank=2.0` into `W_base:[3,4]` via
+`MergeEngine::merge`, then forward a fixed `x:[2,4]` two ways:
+1. **merged:** `y = x @ W_merged^T`
+2. **factored (independent path):** `y = x @ W_base^T + scale·(x @ A @ B)`
+
+A transpose/indexing bug in `merge` would make these diverge — the reference is
+computed from the A,B factors via `x@A@B`, never from `W_merged − W_base`.
+
+| metric | value |
+|--------|-------|
+| **max \|y_merged − y_factored\|** | **1.49e-8** (essentially bit-exact) |
+
+## CI-gated form
+`crates/aprender-train-lora/src/merge.rs::tests::beat_lora_merge_forward_equivalence`
+(threshold 1e-4) — deterministic, CPU, no external deps. Contract:
+`contracts/apr-lora-merge-equivalence-beat-v1.yaml`. Wired into ci.yml.


### PR DESCRIPTION
## Pillar-3 (Unsloth) correctness beat #2 — completes the "replace Unsloth" pipeline

Unsloth's value is fast QLoRA fine-tuning → **merge** → export. apr's correctness beats now cover both stages: NF4 quantization ≡ bitsandbytes (PMAT-745) and **LoRA merge forward-equivalence** (this). apr's `MergeEngine::merge` folds the LoRA delta `scale·(B@A)` into the base weight; this beat proves the merged weights produce a forward pass **numerically equivalent** to applying the LoRA factors unmerged — a faithful, contract-gated merge, where PEFT/Unsloth `merge_and_unload` ships no such guarantee.

### Not tautological
The reference forward is computed **independently from the A,B factors** via a different path (`x @ A @ B`), never from `W_merged − W_base`. A transpose/indexing bug in `merge` would diverge.

### Measured (2026-06-14, CPU, deterministic)
Fold `A:[4,2], B:[2,3], scale=2.0` into `W_base:[3,4]`, forward `x:[2,4]` two ways:

| metric | value |
|--------|-------|
| **max \|y_merged − y_factored\|** | **1.49e-8** (essentially bit-exact) |

Evidence: `evidence/pillar3-lora-merge-equivalence-2026-06-14/findings.md`.

### CI gate
`crates/aprender-train-lora/src/merge.rs::tests::beat_lora_merge_forward_equivalence` (threshold 1e-4) — deterministic, no external deps. Contract `apr-lora-merge-equivalence-beat-v1.yaml` (`pv validate` clean). Wired into `ci.yml`.

## Verification
- `cargo test -p aprender-train-lora --lib beat_lora_merge_forward_equivalence` → 1/1 pass (max\|Δ\|=1.49e-8)
- `pv validate` clean; `cargo test -p aprender-contracts --lib lint::` → 191 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)