### PR TITLE
fix(qa): performance_regression gate — per-metric thresholds, no GPU-noise flake (PMAT-748)

### DIFF
--- a/contracts/apr-model-qa-v1.yaml
+++ b/contracts/apr-model-qa-v1.yaml
@@ -1,10 +1,21 @@
 metadata:
-  version: 1.5.0
+  version: 1.6.0
   created: '2026-04-04'
-  updated: '2026-06-13'
+  updated: '2026-06-14'
   author: PAIML Engineering
   registry: true
   description: >
+    v1.6.0 (2026-06-14): PMAT-748 — performance_regression gate noise-robustness.
+    The gate compared current-vs-baseline throughput/ollama_parity/gpu_speedup at one
+    tight threshold (10%); raw ABSOLUTE throughput (tok/s) swings ~13% run-to-run on a
+    shared GPU (load/thermal/concurrent jobs), so it false-failed `apr qa` on
+    environment noise (observed: 409.6 -> 367.8 = 10.2% flagged). Fix: per-metric
+    thresholds — RATIO metrics (ollama_parity, gpu_speedup, measured same-run → cancel
+    env variance) keep the tight gate; raw throughput gets a wider band (2.5×, floored
+    25%) so it catches catastrophic regressions (e.g. a decode hot-path win reverting)
+    without flaking on noise. FALSIFY-QA-PERFREG-748 + a no-flaky-gate invariant.
+    Unit falsifier: gpu_isolation_result.rs pmat748_perf_regression_gate_tests.
+
     v1.5.0 (2026-06-13): PMAT-743 — format-parity gate robustness. Added
     FALSIFY-QA-FMTPARITY-743 + a discovery-robustness invariant. The gate's
     SafeTensors auto-discovery picked up apr's OWN conversion artifacts
@@ -287,6 +298,22 @@ proof_obligations:
     status: sorry
 - type: invariant
   property: >
+    PMAT-748: the performance_regression gate uses per-metric thresholds — same-run
+    RATIO metrics (ollama_parity, gpu_speedup) keep the tight base threshold (they
+    cancel environment variance), while ABSOLUTE throughput uses a wider band
+    (2.5×, floored 25%) so normal GPU tok/s noise (~10-15%) never false-fails the gate
+    but a catastrophic throughput regression (e.g. >25%) still does. A flaky quality
+    gate in the primary diagnostic tool is a defect.
+  formal: |
+    throughput_regression_threshold(base) == max(base*2.5, 0.25)
+    AND regression(throughput, ~10%) => pass  AND  regression(throughput, >25%) => fail
+    AND regression(ratio_metric, >base) => fail
+  applies_to: performance_regression_gate
+  lean:
+    theorem: Theorems.PerfRegressionGateNoiseRobust
+    status: sorry
+- type: invariant
+  property: >
     PMAT-743: format-parity discovery ignores apr's own conversion artifacts
     (`*.converted*.safetensors`) — they are circular references, never independent
     ones — and a reference that cannot be loaded/converted (missing tensor,
@@ -432,6 +459,26 @@ falsification_tests:
     repeatable. Forbid merging any release-blocking PR until fixed.
   spec_reference: ship-two-models-spec.md §12.1, §12.5
   ship_blocking: true
+- id: FALSIFY-QA-PERFREG-748
+  rule: >
+    the performance_regression gate tolerates GPU throughput noise but catches real
+    regressions — per-metric thresholds (wide for absolute throughput, tight for
+    same-run ratios)
+  prediction: |
+    (a) throughput_regression_threshold(0.10) == 0.25 (wider than the 0.10 ratio gate).
+    (b) a ~10% throughput drop (409.6 -> 367.8, real RTX-4090 run-to-run noise) does
+        NOT fire the gate (no false fail).
+    (c) a >25% throughput drop (400 -> 180) DOES fire (catastrophic regression caught).
+    (d) a >10% ollama_parity drop (1.37 -> 1.20) DOES fire at the tight ratio gate (a
+        same-run ratio regression is real, not noise).
+    Pre-fix, `apr qa` false-failed on (b) because all metrics shared the 10% threshold.
+  test: "cargo test -p apr-cli --lib pmat748_perf_regression_gate_tests"
+  if_fails: |
+    Either `apr qa` flakes on GPU throughput noise (a flaky gate in the primary
+    diagnostic tool — false NO-GO), or a real perf/ratio regression slips through
+    (silent degradation, the Bug-206 class this gate exists to catch).
+  spec_reference: PMAT-748
+  ship_blocking: false
 - id: FALSIFY-QA-FMTPARITY-743
   rule: >
     format-parity discovery ignores synthetic `.converted` artifacts and the gate

--- a/crates/apr-cli/src/commands/gpu_isolation_result.rs
+++ b/crates/apr-cli/src/commands/gpu_isolation_result.rs
@@ -307,13 +307,24 @@ fn run_performance_regression_gate(
     let threshold = config.regression_threshold;
     let mut regressions = Vec::new();
 
-    // Compare metrics for gates that have numeric values in both reports
-    let comparable_gates = ["throughput", "ollama_parity", "gpu_speedup"];
-    for gate_name in &comparable_gates {
+    // PMAT-748: per-metric thresholds. RATIO metrics (ollama_parity, gpu_speedup) are
+    // measured in the SAME run, so they cancel environment variance (GPU load, thermal,
+    // concurrent jobs) → a tight point-baseline gate is a real-regression signal. RAW
+    // throughput is ABSOLUTE tok/s and swings run-to-run with GPU state (measured
+    // ~367-421 = ~13% spread on an idle vs loaded RTX 4090), so a tight gate flakes by
+    // design. Give throughput a wider band so it catches catastrophic regressions
+    // (e.g. a decode hot-path win reverting) without false-failing on environment noise.
+    let throughput_threshold = throughput_regression_threshold(threshold);
+    let comparable_gates: [(&str, f64); 3] = [
+        ("throughput", throughput_threshold),
+        ("ollama_parity", threshold),
+        ("gpu_speedup", threshold),
+    ];
+    for (gate_name, gate_threshold) in &comparable_gates {
         let prev_gate = prev_report.gates.iter().find(|g| g.name == *gate_name);
         let curr_gate = current_gates.iter().find(|g| g.name == *gate_name);
 
-        if let Some(msg) = detect_regression(prev_gate, curr_gate, gate_name, threshold) {
+        if let Some(msg) = detect_regression(prev_gate, curr_gate, gate_name, *gate_threshold) {
             regressions.push(msg);
         }
     }
@@ -324,8 +335,9 @@ fn run_performance_regression_gate(
         Ok(GateResult::passed(
             "performance_regression",
             &format!(
-                "No regressions >{:.0}% vs {}",
+                "No regressions (ratios >{:.0}%, throughput >{:.0}%) vs {}",
                 threshold * 100.0,
+                throughput_threshold * 100.0,
                 prev_path.display()
             ),
             Some(0.0),
@@ -341,6 +353,14 @@ fn run_performance_regression_gate(
             duration,
         ))
     }
+}
+
+/// Wider regression band for ABSOLUTE throughput (tok/s), which is environment-sensitive
+/// (GPU load/thermal/concurrent jobs) unlike the same-run RATIO metrics (ollama_parity,
+/// gpu_speedup). 2.5× the base threshold, floored at 25%, so it flags catastrophic
+/// throughput regressions without false-failing on run-to-run GPU noise. PMAT-748.
+fn throughput_regression_threshold(base: f64) -> f64 {
+    (base * 2.5).max(0.25)
 }
 
 /// Compare a single gate's value between previous and current reports for regression.
@@ -363,4 +383,57 @@ fn detect_regression(
         "{name}: {prev_val:.1} -> {curr_val:.1} ({:.0}% regression)",
         regression * 100.0
     ))
+}
+
+#[cfg(test)]
+mod pmat748_perf_regression_gate_tests {
+    use super::{detect_regression, throughput_regression_threshold};
+    use crate::commands::qa::GateResult;
+    use std::time::Duration;
+
+    fn gate(name: &str, value: f64) -> GateResult {
+        GateResult::passed(name, "", Some(value), None, Duration::default())
+    }
+
+    #[test]
+    fn throughput_band_is_wider_than_ratio_band() {
+        // ratio metrics use the base 10% gate; throughput gets a wide env-noise band.
+        assert!((throughput_regression_threshold(0.10) - 0.25).abs() < 1e-9);
+        assert!((throughput_regression_threshold(0.20) - 0.50).abs() < 1e-9); // 2.5x dominates the 0.25 floor
+        assert!(throughput_regression_threshold(0.10) > 0.10);
+    }
+
+    #[test]
+    fn throughput_noise_does_not_false_fail() {
+        // The actual flake: 409.6 -> 367.8 is ~10.2% — real on a shared RTX 4090,
+        // must NOT trip the throughput gate (env-sensitive absolute tok/s).
+        let prev = gate("throughput", 409.6);
+        let curr = gate("throughput", 367.8);
+        let t = throughput_regression_threshold(0.10);
+        assert!(
+            detect_regression(Some(&prev), Some(&curr), "throughput", t).is_none(),
+            "GPU tok/s noise (~10%) must not false-fail the throughput regression gate"
+        );
+    }
+
+    #[test]
+    fn catastrophic_throughput_regression_is_caught() {
+        // A real hot-path revert (e.g. 2x decode win lost) must still fire.
+        let prev = gate("throughput", 400.0);
+        let curr = gate("throughput", 180.0); // 55% drop
+        let t = throughput_regression_threshold(0.10);
+        assert!(detect_regression(Some(&prev), Some(&curr), "throughput", t).is_some());
+    }
+
+    #[test]
+    fn ratio_metric_keeps_tight_gate() {
+        // ollama_parity is a same-run ratio → cancels env variance → a 12% drop is a
+        // REAL regression and must fire at the tight 10% gate.
+        let prev = gate("ollama_parity", 1.37);
+        let curr = gate("ollama_parity", 1.20); // ~12.4% drop
+        assert!(
+            detect_regression(Some(&prev), Some(&curr), "ollama_parity", 0.10).is_some(),
+            "a real ratio regression must still be caught at the tight threshold"
+        );
+    }
 }


### PR DESCRIPTION
## Problem (a real flaky gate, deferred from PMAT-742/743)

`apr qa`'s `performance_regression` gate compared current-vs-baseline `throughput`, `ollama_parity`, and `gpu_speedup` at **one tight threshold (10%)**. Raw **absolute throughput** (tok/s) swings ~13% run-to-run on a shared GPU (load/thermal/concurrent jobs), so the gate **false-failed on environment noise** — observed during earlier work: `throughput: 409.6 -> 367.8 (10% regression)`, which is *not* a regression. A flaky quality gate in the *primary diagnostic tool* is a defect.

## Root cause
Absolute throughput is environment-sensitive. The **ratio** metrics (`ollama_parity = apr/ollama`, `gpu_speedup = apr_gpu/apr_cpu`) are measured in the **same run** and cancel that variance — only they deserve the tight gate.

## Fix — per-metric thresholds
- Ratio metrics keep the base threshold (10%) → real regressions still caught.
- Raw throughput gets a wider band: `throughput_regression_threshold(base) = max(base*2.5, 0.25)` → catches catastrophic regressions (e.g. a decode hot-path win reverting, >25% drop) without flaking on ~10–15% GPU noise.

## Co-evolution (Rule 7)
- **4 unit falsifiers** (`pmat748_perf_regression_gate_tests`): wider-band-than-ratio; 10% throughput noise → no false-fail; 55% throughput drop → caught; 12% `ollama_parity` drop → caught at the tight gate.
- **contract** `apr-model-qa-v1` → **1.6.0**: `FALSIFY-QA-PERFREG-748` + per-metric-threshold invariant. `pv validate` clean.

## Verification
- `cargo test -p apr-cli --lib pmat748_perf_regression_gate_tests` → 4/4 pass
- `pv validate` clean; `cargo test -p aprender-contracts --lib lint::` → 191 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)