### PR TITLE
fix(serve): GQA models panic on adaptive cache-attention at ~64 tokens (PMAT-749)

### DIFF
--- a/contracts/apr-gqa-cache-attention-dispatch-v1.yaml
+++ b/contracts/apr-gqa-cache-attention-dispatch-v1.yaml
@@ -1,0 +1,45 @@
+contract: apr-gqa-cache-attention-dispatch
+metadata:
+  kind: pattern
+  version: "1.0.0"
+  description: >
+    realizar's adaptive KV-cache attention (OwnedQuantizedModel::adaptive_attention_with_cache,
+    the apr serve /v1/completions decode path) must dispatch GQA models to the
+    kv_dim-strided GQA kernel. The MHA path (gpu_attention_with_cache /
+    attention_with_cache) strides the KV cache by q_dim/hidden_dim and indexes
+    current_k/current_v by head*head_dim over num_heads — correct ONLY when
+    num_kv_heads == num_heads. For GQA (num_kv_heads < num_heads) the cache is
+    [seq, kv_dim], so at head >= num_kv_heads the current-K/V slice runs past kv_dim →
+    index-out-of-bounds PANIC once a sequence crosses the >=64 GPU-dispatch threshold.
+    Every prior test of this path used MHA, so GQA was uncovered (PMAT-749). Fix:
+    route num_kv_heads < num_heads to attention_with_cache_gqa (maps each q-head to its
+    kv-head, strides by kv_dim); keep the existing path for MHA (no perf regression).
+    Verified: TinyLlama/Llama-2-3/Mistral/Qwen2 are all GQA.
+  references:
+  - "crates/aprender-serve/src/gguf/inference/attention_gqa.rs (adaptive_attention_with_cache dispatch + attention_with_cache_gqa)"
+  - "crates/aprender-serve/src/gguf/tests/imp_121a.rs (test_pmat749_adaptive_attention_gqa_long_cache)"
+version: 1
+status: enforced
+date: 2026-06-14
+
+proof_obligations:
+  - type: invariant
+    property: >
+      GQA-DISPATCH: adaptive_attention_with_cache routes models with
+      num_kv_heads < num_heads to the kv_dim-strided attention_with_cache_gqa kernel,
+      so the KV cache ([seq, kv_dim]) and current_k/current_v ([kv_dim]) are never
+      sliced past kv_dim. The q_dim-strided MHA path is used only when
+      num_kv_heads == num_heads.
+  - type: equivalence
+    property: >
+      GQA-EQUIV: for a GQA model at any cache length (including past the >=64 GPU
+      threshold), adaptive_attention_with_cache output equals
+      attention_with_cache_gqa output within 1e-5 and never panics.
+
+falsification_tests:
+  - id: FALSIFY-GQA-CACHE-001
+    name: test_pmat749_adaptive_attention_gqa_long_cache
+    prediction: "GQA config (num_heads=8, num_kv_heads=2) + cache_len=64 [seq,kv_dim] → adaptive_attention_with_cache returns a q_dim output matching attention_with_cache_gqa (no panic)"
+    test_harness: "cargo test -p aprender-serve --lib test_pmat749_adaptive_attention_gqa_long_cache"
+    expected_output: "test result: ok"
+    if_fails: "GQA cache-attention regressed to the MHA-only q_dim-strided path — it panics 'range end index out of range' at head==num_kv_heads (apr serve crashes on GQA models at ~64 tokens), or produces wrong attention output."

--- a/crates/aprender-serve/src/gguf/inference/attention_gqa.rs
+++ b/crates/aprender-serve/src/gguf/inference/attention_gqa.rs
@@ -248,6 +248,19 @@ impl OwnedQuantizedModel {
         current_k: &[f32],
         current_v: &[f32],
     ) -> Result<Vec<f32>> {
+        // PMAT-749: the MHA cache-attention path (gpu_attention_with_cache /
+        // attention_with_cache) strides the KV cache by q_dim/hidden_dim and indexes
+        // current_k/current_v by head*head_dim over num_heads — correct ONLY for MHA
+        // (num_kv_heads == num_heads). For GQA models the cache is [seq, kv_dim], so at
+        // head >= num_kv_heads the current-K/V slice runs past kv_dim → panic/garbage
+        // once a sequence crosses the >=64 GPU threshold. Route GQA to the GQA-correct
+        // function (it maps each q-head to its kv-head and strides by kv_dim; it also
+        // handles MHA as q_per_kv==1, but we keep the GPU path for MHA to avoid a perf
+        // regression). Every prior test of this path was MHA, so GQA was uncovered.
+        if self.config.num_kv_heads < self.config.num_heads {
+            return Ok(self.attention_with_cache_gqa(q, k_cache, v_cache, current_k, current_v));
+        }
+
         let hidden_dim = self.config.hidden_dim;
 
         // Calculate cache length
@@ -279,6 +292,11 @@ impl OwnedQuantizedModel {
         current_k: &[f32],
         current_v: &[f32],
     ) -> Result<Vec<f32>> {
+        // PMAT-749: GQA models need the kv_dim-strided path; attention_with_cache is
+        // MHA-only and panics for num_kv_heads < num_heads. See the gpu variant above.
+        if self.config.num_kv_heads < self.config.num_heads {
+            return Ok(self.attention_with_cache_gqa(q, k_cache, v_cache, current_k, current_v));
+        }
         Ok(self.attention_with_cache(q, k_cache, v_cache, current_k, current_v))
     }
 

--- a/crates/aprender-serve/src/gguf/tests/imp_121a.rs
+++ b/crates/aprender-serve/src/gguf/tests/imp_121a.rs
@@ -294,6 +294,68 @@ fn test_imp_122a_adaptive_attention_with_cache() {
     assert!(sum > 0.0, "IMP-122a: Output should have non-zero values");
 }
 
+/// PMAT-749: adaptive_attention_with_cache must handle GQA (num_kv_heads < num_heads)
+/// at a cache length past the GPU threshold (>=64). The MHA-only path strided the KV
+/// cache by q_dim and indexed current_k/v by head*head_dim over num_heads, so at
+/// head == num_kv_heads it sliced past kv_dim → panic/garbage. Every prior test of this
+/// path was MHA (num_heads == num_kv_heads), so GQA was uncovered. This is a regression
+/// guard: it panics pre-fix and must match the GQA-correct reference post-fix.
+#[test]
+fn test_pmat749_adaptive_attention_gqa_long_cache() {
+    // GQA: 8 query heads share 2 KV heads (q_per_kv=4). head_dim=8 → q_dim=64, kv_dim=16.
+    let config = GGUFConfig {
+        architecture: "test".to_string(),
+        constraints: crate::gguf::ArchConstraints::from_architecture("test"),
+        hidden_dim: 64,
+        intermediate_dim: 128,
+        num_layers: 1,
+        num_heads: 8,
+        num_kv_heads: 2,
+        vocab_size: 100,
+        context_length: 256,
+        rope_theta: 10000.0,
+        eps: 1e-5,
+        rope_type: 0,
+        explicit_head_dim: None,
+        bos_token_id: None,
+        eos_token_id: None,
+    };
+    let model = create_test_model_with_config(&config);
+    let q_dim = 64; // num_heads * head_dim
+    let kv_dim = 16; // num_kv_heads * head_dim
+    let cache_len = 64; // >= GPU_CACHE_LEN_THRESHOLD — the path that panicked pre-fix
+
+    let q: Vec<f32> = (0..q_dim).map(|i| (i % 17) as f32 * 0.1).collect();
+    // KV cache is [cache_len, kv_dim] for GQA (NOT q_dim) — this layout is what the
+    // MHA path mis-strided.
+    let k_cache: Vec<f32> = (0..cache_len * kv_dim)
+        .map(|i| (i % 13) as f32 * 0.05)
+        .collect();
+    let v_cache: Vec<f32> = (0..cache_len * kv_dim)
+        .map(|i| (i % 11) as f32 * 0.05)
+        .collect();
+    let current_k: Vec<f32> = (0..kv_dim).map(|i| (i % 7) as f32 * 0.1).collect();
+    let current_v: Vec<f32> = (0..kv_dim).map(|i| (i % 5) as f32 * 0.1).collect();
+
+    // Must NOT panic (the bug) and must produce a q_dim-shaped output.
+    let result = model
+        .adaptive_attention_with_cache(&q, &k_cache, &v_cache, &current_k, &current_v)
+        .expect("GQA adaptive attention must not error");
+    assert_eq!(result.len(), q_dim, "PMAT-749: GQA output must be [q_dim]");
+
+    // Must equal the GQA-correct reference (proves it routed to the right kernel).
+    let reference = model.attention_with_cache_gqa(&q, &k_cache, &v_cache, &current_k, &current_v);
+    let max_diff = result
+        .iter()
+        .zip(reference.iter())
+        .map(|(a, b)| (a - b).abs())
+        .fold(0.0_f32, f32::max);
+    assert!(
+        max_diff < 1e-5,
+        "PMAT-749: adaptive GQA output must match attention_with_cache_gqa (max|Δ|={max_diff})"
+    );
+}
+
 #[test]
 #[cfg(feature = "gpu")]
 fn test_imp_122b_adaptive_matches_standard() {


### PR DESCRIPTION
## A real, high-severity, live defect (found by adversarial bug-hunt)

`apr serve` /v1/completions decode (`adaptive_attention_with_cache`) routed **all** models to the **MHA-only** cache-attention kernels (`gpu_attention_with_cache` / `attention_with_cache`), which stride the KV cache by `q_dim`/`hidden_dim` and index `current_k`/`current_v` by `head*head_dim` over `num_heads`. That's correct **only for MHA** (`num_kv_heads == num_heads`).

For **GQA** models the cache is `[seq, kv_dim]`, so at `head >= num_kv_heads` the current-K/V slice runs past `kv_dim` → **index-out-of-bounds panic** (`range end index N out of range for slice of length kv_dim`). GQA is the norm for modern LLMs (TinyLlama, Llama-2/3, Mistral, Qwen2) — so `apr serve` crashed/garbled on them on the cache-attention path.

**Why 25k+ tests missed it:** every test of this path used `num_heads == num_kv_heads` (MHA) — zero GQA coverage.

## How it was found + verified
- Surfaced by an **adversarial bug-hunt** over the realizar inference hot path (5 subsystem finders → skeptic verification; this was the 1 high-confidence confirmed bug).
- **Mutation-verified:** without the fix, the new GQA test panics at `rope.rs:360` (`range end index 24 out of range for slice of length 16`); with the fix, output matches the GQA-correct reference.

## Fix
`adaptive_attention_with_cache` (both gpu + non-gpu variants) routes `num_kv_heads < num_heads` to the existing **`attention_with_cache_gqa`** (maps each q-head to its kv-head, strides by `kv_dim`). **MHA keeps its existing GPU/CPU path — no perf regression.**

## Co-evolution (Rule 7)
- Regression test `test_pmat749_adaptive_attention_gqa_long_cache` (GQA 8/2 heads, cache_len=64): no panic + matches `attention_with_cache_gqa` within 1e-5. MHA suites unaffected (imp_121a 29, attention_gqa 30).
- Contract `apr-gqa-cache-attention-dispatch-v1` (kind: pattern; GQA-DISPATCH + GQA-EQUIV + FALSIFY-GQA-CACHE-001) — `pv validate` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)