### PR TITLE
fix(serve): fail closed on truncated/corrupt model at load (PMAT-750)

### DIFF
--- a/contracts/apr-load-fail-closed-truncated-v1.yaml
+++ b/contracts/apr-load-fail-closed-truncated-v1.yaml
@@ -1,0 +1,48 @@
+contract: apr-load-fail-closed-truncated
+metadata:
+  kind: pattern
+  version: "1.0.0"
+  description: >
+    realizar's GGUF loader must FAIL CLOSED on a truncated/corrupt model. The
+    chokepoint OwnedQuantizedTensor::from_ref_with_dims silently substitutes an empty
+    data buffer when a tensor's offset+byte_size runs past the file, while keeping the
+    declared in_dim/out_dim — so a truncated GGUF would otherwise load with a dead
+    (all-zero) quantized weight and produce GARBAGE at inference. `apr qa`'s
+    F-DATA-QUALITY density gate catches such a model, but `apr run` / `apr serve` do
+    not run those gates, so the truncated model ran silently. PMAT-750 adds
+    is_truncated() (declared dims but empty data) and a load-time
+    validate_quantized_tensors() walk (all layer weights + lm_head) called from
+    OwnedQuantizedModel::from_mapped, which returns InvalidShape naming the first
+    truncated tensor. This extends the Pillar-4 fail-closed guarantee (PMAT-744) to the
+    load path. Found by an adversarial inference bug-hunt (root cause behind a narrow
+    DIRECT_FP32_GEMV panic).
+  references:
+  - "crates/aprender-serve/src/gguf/quantized.rs (from_ref_with_dims, is_truncated)"
+  - "crates/aprender-serve/src/gguf/embedding.rs (OwnedQuantizedModel::from_mapped + validate_quantized_tensors)"
+  - "crates/aprender-serve/src/gguf/quantized_tests.rs (test_pmat750_truncated_tensor_detected)"
+version: 1
+status: enforced
+date: 2026-06-14
+
+proof_obligations:
+  - type: invariant
+    property: >
+      TRUNCATED-DETECT: OwnedQuantizedTensor::is_truncated() is true iff the tensor
+      declares real dimensions (in_dim>0 && out_dim>0) but has no data — the signature
+      of a tensor whose bytes ran past the model file. A fully-loaded tensor is never
+      flagged (no false positive).
+  - type: invariant
+    property: >
+      LOAD-FAIL-CLOSED: OwnedQuantizedModel::from_mapped runs validate_quantized_tensors
+      over every quantized weight (each layer's qkv/attn_output/ffn_up/ffn_down/ffn_gate
+      + lm_head) and returns Err(InvalidShape) if any is truncated, so a truncated GGUF
+      is rejected at load instead of producing garbage at inference. A well-formed model
+      loads unchanged.
+
+falsification_tests:
+  - id: FALSIFY-LOAD-TRUNCATED-001
+    name: test_pmat750_truncated_tensor_detected
+    prediction: "from_ref_with_dims with byte_size(64) > data.len()(4) yields empty data + declared 8x8 dims; is_truncated() == true; a well-formed tensor is_truncated() == false"
+    test_harness: "cargo test -p aprender-serve --lib test_pmat750_truncated_tensor_detected"
+    expected_output: "test result: ok"
+    if_fails: "truncated tensors are not detected → a corrupt/incomplete GGUF loads with a dead weight and apr run/serve emit garbage instead of failing closed at load."

--- a/crates/aprender-serve/src/gguf/embedding.rs
+++ b/crates/aprender-serve/src/gguf/embedding.rs
@@ -88,7 +88,7 @@ impl OwnedQuantizedModel {
             .map(|l| OwnedQuantizedLayer::from_borrowed(l, data, config))
             .collect();
 
-        Ok(Self {
+        let model = Self {
             config: transformer.config.clone(),
             token_embedding: transformer.token_embedding,
             position_embedding: transformer.position_embedding,
@@ -112,7 +112,57 @@ impl OwnedQuantizedModel {
             cuda_kernel_count: std::sync::atomic::AtomicU64::new(0),
             #[cfg(feature = "cuda")]
             cached_weight_names: std::sync::Mutex::new(std::collections::HashSet::new()),
-        })
+        };
+        // PMAT-750: fail closed on a truncated/corrupt model (a quantized weight
+        // declares real dims but has no data because the file was incomplete) instead
+        // of silently running inference on a dead weight and emitting garbage.
+        model.validate_quantized_tensors()?;
+        Ok(model)
+    }
+
+    /// PMAT-750: reject a truncated/corrupt model at load. `from_ref_with_dims`
+    /// substitutes an empty data buffer when a tensor's bytes run past the file, so a
+    /// truncated GGUF would otherwise load and produce garbage at inference (apr qa's
+    /// density gate catches it, but `apr run` does not run those gates). This fails the
+    /// load with a clear error naming the first truncated tensor — the fail-closed
+    /// guarantee from the Pillar-4 beat (PMAT-744) extended to the load path.
+    pub(crate) fn validate_quantized_tensors(&self) -> Result<()> {
+        fn check(t: &OwnedQuantizedTensor, name: &str) -> Result<()> {
+            if t.is_truncated() {
+                return Err(crate::error::RealizarError::InvalidShape {
+                    reason: format!(
+                        "truncated/corrupt model: tensor '{name}' declares {}x{} but has no data (file is incomplete)",
+                        t.out_dim, t.in_dim
+                    ),
+                });
+            }
+            Ok(())
+        }
+        fn check_layer(layer: &OwnedQuantizedLayer, prefix: &str) -> Result<()> {
+            match &layer.qkv_weight {
+                OwnedQKVWeights::Fused(t) => check(t, &format!("{prefix}.qkv"))?,
+                OwnedQKVWeights::Separate { q, k, v } => {
+                    check(q, &format!("{prefix}.q"))?;
+                    check(k, &format!("{prefix}.k"))?;
+                    check(v, &format!("{prefix}.v"))?;
+                },
+            }
+            check(&layer.attn_output_weight, &format!("{prefix}.attn_output"))?;
+            check(&layer.ffn_up_weight, &format!("{prefix}.ffn_up"))?;
+            check(&layer.ffn_down_weight, &format!("{prefix}.ffn_down"))?;
+            if let Some(g) = &layer.ffn_gate_weight {
+                check(g, &format!("{prefix}.ffn_gate"))?;
+            }
+            Ok(())
+        }
+        for (i, layer) in self.layers.iter().enumerate() {
+            check_layer(layer, &format!("layer.{i}"))?;
+        }
+        for (i, layer) in self.encoder_layers.iter().enumerate() {
+            check_layer(layer, &format!("encoder_layer.{i}"))?;
+        }
+        check(&self.lm_head_weight, "lm_head")?;
+        Ok(())
     }
 
     /// Create a model for testing purposes

--- a/crates/aprender-serve/src/gguf/quantized.rs
+++ b/crates/aprender-serve/src/gguf/quantized.rs
@@ -127,6 +127,16 @@ impl OwnedQuantizedTensor {
             qtype: tensor_ref.qtype,
         }
     }
+
+    /// PMAT-750: true if this tensor declares real dimensions but has NO data —
+    /// the signature of a truncated/corrupt model file. `from_ref_with_dims`
+    /// silently substitutes an empty `Vec` when a tensor's `offset + byte_size`
+    /// exceeds the file, so a truncated GGUF would otherwise load and run inference
+    /// on a dead (all-zero) weight, producing garbage instead of failing at load.
+    #[must_use]
+    pub fn is_truncated(&self) -> bool {
+        self.data.is_empty() && self.in_dim > 0 && self.out_dim > 0
+    }
 }
 
 // ============================================================================

--- a/crates/aprender-serve/src/gguf/quantized_tests.rs
+++ b/crates/aprender-serve/src/gguf/quantized_tests.rs
@@ -321,6 +321,41 @@ fn test_owned_quantized_tensor_exact_bounds() {
     assert_eq!(owned.in_dim, 2);
     assert_eq!(owned.out_dim, 5);
     assert_eq!(owned.qtype, GGUF_TYPE_Q8_0);
+    // A well-formed tensor is NOT flagged truncated (no false positive).
+    assert!(
+        !owned.is_truncated(),
+        "PMAT-750: a fully-loaded tensor must not be flagged truncated"
+    );
+}
+
+/// PMAT-750: a truncated/corrupt model (tensor bytes run past the file) makes
+/// from_ref_with_dims silently substitute an empty data buffer while keeping the
+/// declared dims. is_truncated() must detect that so the load can fail closed
+/// instead of running inference on a dead weight and emitting garbage.
+#[test]
+fn test_pmat750_truncated_tensor_detected() {
+    let tensor_ref = QuantizedTensorRef {
+        offset: 0,
+        byte_size: 64, // declares 64 bytes...
+        num_elements: 64,
+        qtype: GGUF_TYPE_Q8_0,
+    };
+    let data = vec![1u8, 2, 3, 4]; // ...but the file only has 4 → truncated
+
+    let owned = OwnedQuantizedTensor::from_ref_with_dims(&tensor_ref, &data, 8, 8);
+
+    // Pre-PMAT-750 this silently loads with empty data + real dims (the bug).
+    assert!(
+        owned.data.is_empty(),
+        "truncated tensor data was silently emptied"
+    );
+    assert_eq!(owned.in_dim, 8);
+    assert_eq!(owned.out_dim, 8);
+    // The fail-closed detector must catch it.
+    assert!(
+        owned.is_truncated(),
+        "PMAT-750: truncated tensor (declared 8x8, no data) must be flagged so load fails closed"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Real fail-closed gap (root cause behind the bug-hunt's 2nd finding)

`OwnedQuantizedTensor::from_ref_with_dims` silently substitutes an **empty data buffer** when a tensor's `offset + byte_size` runs past the model file, while keeping the declared `in_dim`/`out_dim`. So a truncated/corrupt GGUF (incomplete download, interrupted pull) **loaded with a dead all-zero weight and produced garbage at inference**. `apr qa`'s density gate catches it, but `apr run` / `apr serve` don't run those gates — so the corrupt model ran silently on the default path.

This is the general root cause behind the adversarial bug-hunt's secondary finding (a narrow `DIRECT_FP32_GEMV` panic on undersized weight data). Fixing it at the loader closes the default-path gap, not just the env-var panic.

## Fix (fail-closed, contained — no signature ripple)
- `OwnedQuantizedTensor::is_truncated()` — declared dims but empty data.
- `OwnedQuantizedModel::validate_quantized_tensors()` walks every quantized weight (each layer's qkv/attn_output/ffn_up/ffn_down/ffn_gate + lm_head) and returns `Err(InvalidShape)` naming the first truncated tensor.
- `from_mapped` (the GGUF `Result` load entry) calls it before returning → a truncated GGUF is **rejected at load** with a clear error instead of garbage at run.

Extends the Pillar-4 fail-closed guarantee (PMAT-744) to the load path.

## Co-evolution (Rule 7)
- `test_pmat750_truncated_tensor_detected`: `byte_size > file` → empty data + declared dims → `is_truncated()` true; well-formed tensor → false (no false positive).
- Contract `apr-load-fail-closed-truncated-v1` (kind: pattern; TRUNCATED-DETECT + LOAD-FAIL-CLOSED + FALSIFY-LOAD-TRUNCATED-001) — `pv validate` clean.

## Verification
- Full `aprender-serve` lib suite: **15285 pass, 0 fail**
- Real 1.78B-param GGUF (339 tensors) still loads — no false-positive rejection
- `cargo test -p aprender-contracts --lib lint::` → 191 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)