### PR TITLE
fix(text): BPE prefix space applied to every non-special segment, not just first (PMAT-751)

### DIFF
--- a/contracts/bpe-tokenization-v1.yaml
+++ b/contracts/bpe-tokenization-v1.yaml
@@ -1,9 +1,16 @@
 metadata:
-  version: 1.0.0
+  version: 1.1.0
   created: '2026-03-25'
+  updated: '2026-06-14'
   author: PAIML Engineering
-  description: Byte-pair encoding (BPE) tokenization correctness — merge-based subword tokenization with roundtrip, determinism,
-    and vocabulary invariants
+  description: >
+    Byte-pair encoding (BPE) tokenization correctness — merge-based subword tokenization
+    with roundtrip, determinism, and vocabulary invariants.
+    v1.1.0 (2026-06-14): PMAT-751 — add_prefix_space must apply per non-special segment.
+    encode_segment gated the GPT-2 prefix space on ids.is_empty() (first segment only), so
+    a non-special segment AFTER a special token lost its leading-space marker
+    ("hello<|endoftext|>world" → "world" with no Ġ), diverging from HuggingFace ByteLevel.
+    Found by an adversarial tokenizer bug-hunt; fixed to prefix every non-special chunk.
   references:
   - Sennrich, Haddow & Birch (2016) Neural Machine Translation of Rare Words with Subword Units. ACL. arXiv:1508.07909
   - Radford et al. (2019) Language Models are Unsupervised Multitask Learners (GPT-2 BPE)
@@ -75,6 +82,10 @@ proof_obligations:
   property: Encoding length bounded by input bytes
   formal: len(encode(text)) <= len(bytes(text)) — at most one token per byte
   applies_to: all
+- type: invariant
+  property: add_prefix_space applies per non-special segment (PMAT-751)
+  formal: with add_prefix_space=true, EVERY non-special segment (including one following a special token) is prefixed with a space unless it already starts with one (HuggingFace ByteLevel semantics); hence encode("a<SPECIAL>b") == encode("a<SPECIAL> b")
+  applies_to: gpt2_byte_level
 kernel_structure:
   phases:
   - name: pre_tokenize
@@ -90,6 +101,11 @@ kernel_structure:
     description: Map final token strings to integer IDs
     invariant: All tokens present in vocabulary; unknown tokens handled by byte fallback
 falsification_tests:
+- id: FALSIFY-BPE-PREFIX-751
+  rule: GPT-2 prefix space is applied to every non-special segment, not just the first
+  prediction: 'With add_prefix_space=true (gpt2_base), encode("a<|endoftext|>b") == encode("a<|endoftext|> b") — the post-special segment gets the same implicit prefix space as an explicit one. Pre-fix the implicit form omitted the space marker (Ġ), so token IDs diverged from HuggingFace.'
+  test: 'cargo test -p aprender-core --lib test_pmat751_prefix_space_after_special_token'
+  if_fails: 'A non-special segment after a special token loses its leading-space marker → token IDs diverge from HuggingFace for GPT-2-style (add_prefix_space=true) tokenizers; the model is fed a wrong prompt. Qwen2/Whisper/LLaMA (add_prefix_space=false) are unaffected.'
 - id: FALSIFY-BPE-001
   rule: 'Roundtrip: decode(encode(text)) == text'
   prediction: Roundtrip holds for all valid UTF-8 strings

--- a/crates/aprender-core/src/text/bpe/qwen2bpe_tokenizer.rs
+++ b/crates/aprender-core/src/text/bpe/qwen2bpe_tokenizer.rs
@@ -338,12 +338,19 @@ impl BpeTokenizer {
 
     /// Encode a regular (non-special-token) text segment into token IDs.
     fn encode_segment(&self, segment: &str, ids: &mut Vec<u32>) {
-        let segment_text =
-            if self.config.add_prefix_space && !segment.starts_with(' ') && ids.is_empty() {
-                format!(" {segment}")
-            } else {
-                segment.to_string()
-            };
+        // PMAT-751: apply the GPT-2 prefix space to EVERY non-special segment, not just
+        // the first. encode() calls this once per non-special chunk (special tokens are
+        // split out first), and HF ByteLevel adds the prefix space per chunk. The old
+        // `ids.is_empty()` gate denied the prefix space to any segment AFTER a special
+        // token (e.g. "hello<|endoftext|>world" → "world" lost its leading-space marker),
+        // yielding token IDs that diverge from HuggingFace. The `!starts_with(' ')` guard
+        // already prevents double-spacing; add_prefix_space=false (Qwen2/Whisper/LLaMA)
+        // still short-circuits, so those tokenizers are unaffected.
+        let segment_text = if self.config.add_prefix_space && !segment.starts_with(' ') {
+            format!(" {segment}")
+        } else {
+            segment.to_string()
+        };
 
         for word in self.pre_tokenize(&segment_text) {
             let byte_word = self.bytes_to_bpe_tokens(&word);

--- a/crates/aprender-core/src/text/bpe/tests_encode_decode.rs
+++ b/crates/aprender-core/src/text/bpe/tests_encode_decode.rs
@@ -459,3 +459,29 @@ fn test_bpe_merge_priority() {
     // Both merges should be applied
     assert_eq!(result.len(), 2);
 }
+
+/// PMAT-751: with add_prefix_space=true (GPT-2), the prefix space must be applied to
+/// EVERY non-special segment — including one that follows a special token — matching
+/// HuggingFace ByteLevel. Pre-fix, encode_segment gated the prefix space on
+/// `ids.is_empty()`, so a post-special segment lost its leading-space marker and
+/// produced token IDs diverging from HF. Vocab-independent falsifier: the IMPLICIT
+/// prefix space on a post-special segment must equal the EXPLICIT one.
+#[test]
+fn test_pmat751_prefix_space_after_special_token() {
+    let t = BpeTokenizer::gpt2_base(); // add_prefix_space=true, <|endoftext|> registered
+                                       // "b" after the special must be tokenized as if it were " b" (implicit prefix space).
+    let implicit = t.encode("a<|endoftext|>b");
+    let explicit = t.encode("a<|endoftext|> b");
+    assert_eq!(
+        implicit, explicit,
+        "PMAT-751: post-special segment 'b' must get the same prefix space as explicit ' b' \
+         (HF ByteLevel applies add_prefix_space per non-special chunk). implicit={implicit:?} explicit={explicit:?}"
+    );
+    // And the first segment still gets it (no regression): "a" begins with the space marker.
+    let first = t.encode("a");
+    let spaced = t.encode(" a");
+    assert_eq!(
+        first, spaced,
+        "PMAT-751: first-segment prefix space regressed"
+    );
+}


### PR DESCRIPTION
## Tokenizer bug — wrong token IDs after a special token (found by adversarial bug-hunt)

`encode_segment` gated the GPT-2 prefix space on `ids.is_empty()`, so only the **first** segment received it. `encode()` splits special tokens out first and calls `encode_segment` once per non-special chunk — after a special token pushes an id, `ids` is non-empty, so any non-special segment **after a special token was denied its prefix space.**

For `add_prefix_space=true` (GPT-2-style) tokenizers, this diverges from HuggingFace ByteLevel (which adds the prefix space per non-special chunk):
```
encode("hello<|endoftext|>world")  →  "world" loses its leading-space marker (Ġ)
```
…so the token IDs differ from HF and the model is fed a wrong prompt.

## Fix
Apply the prefix space to **every** non-special segment (drop the `ids.is_empty()` gate; the `!starts_with(' ')` guard already prevents double-spacing). `add_prefix_space=false` (Qwen2/Whisper/LLaMA) still short-circuits → **those tokenizers are unaffected.**

## Verified (mutation)
`test_pmat751_prefix_space_after_special_token`: `encode("a<|endoftext|>b") == encode("a<|endoftext|> b")` (vocab-independent). Stash-the-fix mutation check:
- pre-fix: `implicit=[32,97,50256,98]` ≠ `explicit=[32,97,50256,32,98]` → **FAILS**
- post-fix: equal → passes

No regression (bpe 129, tokenize 122 pass).

## Co-evolution (Rule 7)
- Contract `bpe-tokenization-v1` → **1.1.0**: per-non-special-segment prefix-space invariant + `FALSIFY-BPE-PREFIX-751`. `pv validate` clean.

Found by an adversarial tokenizer bug-hunt (1 confirmed real of 5 findings; 4 refuted by skeptic verification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)