### PR TITLE
fix(serve): speculative decode — roll back GPU KV-cache for verification, not reset (PMAT-752)

### DIFF
--- a/contracts/speculative-decoding-v1.yaml
+++ b/contracts/speculative-decoding-v1.yaml
@@ -1,5 +1,8 @@
 metadata:
-  version: 1.0.0
+  version: 1.1.0
+  updated: '2026-06-14'
+  changelog:
+  - '1.1.0 (2026-06-14): PMAT-752 — GPU KV-cache must be ROLLED BACK (not reset) before the verification phase. generate_speculative_cuda (self-speculative) called reset_kv_cache_gpu() which zeros ALL GPU KV history, desyncing it from the CPU snapshot, so verification attended over an empty K/V and computed wrong logits → wrong acceptance → output diverged from plain greedy (violating the P_spec = P_auto equivalence). Fix: rollback_kv_cache_gpu(cache_snapshot), mirroring the already-fixed two-model path (PAR-105). Found by an adversarial bug-hunt. Latent (only throughput callers today) but a real public-API correctness bug.'
   created: '2026-03-25'
   author: PAIML Engineering
   description: Speculative decoding — draft model generates candidate tokens, target model verifies in a single batched pass.
@@ -76,6 +79,10 @@ proof_obligations:
   property: Acceptance rate increases with draft quality
   formal: E[accepted_tokens] increases as KL(p || q) decreases
   applies_to: all
+- type: invariant
+  property: GPU KV-cache rolled back (not reset) before verification (PMAT-752)
+  formal: before the verification phase, the GPU KV-cache length is rolled back to the pre-draft snapshot length (preserving prefill + previously-accepted K/V), NOT zeroed; otherwise verification attention sees an empty history and verification logits q(x) diverge from the true autoregressive distribution, breaking the P_spec = P_auto equivalence above
+  applies_to: gpu_self_speculative
 kernel_structure:
   phases:
   - name: draft_generation
@@ -91,6 +98,11 @@ kernel_structure:
     description: Emit accepted tokens plus one resampled or bonus token
     invariant: At least 1 token emitted per step; at most K+1 tokens emitted
 falsification_tests:
+- id: FALSIFY-SD-KVSYNC-752
+  rule: GPU self-speculative greedy decode is byte-identical to plain greedy decode
+  prediction: 'On a GPU host, generate_speculative_cuda(prompt, greedy) produces the SAME token sequence as generate_gpu_resident(prompt, greedy) — speculative decode changes speed, never output. Pre-fix, the verification phase reset (zeroed) the GPU KV-cache instead of rolling it back to the snapshot, so verification attended over an empty history and produced divergent tokens / 1-of-k acceptance.'
+  test: 'GPU + model parity: assert generate_speculative_cuda(greedy) == generate_gpu_resident(greedy) (runnable on an RTX 4090 host; the only in-tree callers today are throughput benchmarks). Code: rollback_kv_cache_gpu(cache_snapshot) at speculative.rs verification + all-rejected fallback, mirroring the proven PAR-105 two-model fix.'
+  if_fails: 'GPU KV-cache desync during verification → speculative output diverges from greedy (corrupted text / pathological 1/k acceptance).'
 - id: FALSIFY-SD-001
   rule: Output distribution equivalence
   prediction: Over 10000 samples, KL divergence between speculative and autoregressive output < 0.01

--- a/crates/aprender-serve/src/gguf/cuda/speculative.rs
+++ b/crates/aprender-serve/src/gguf/cuda/speculative.rs
@@ -124,9 +124,15 @@ impl OwnedQuantizedModelCuda {
 
             total_drafts += draft_tokens.len();
 
-            // Step 2: Rollback cache to snapshot for verification
+            // Step 2: Rollback cache to snapshot for verification.
+            // PMAT-752: roll the GPU KV cache back to the snapshot LENGTH (preserving
+            // prefill + previously-accepted history), NOT reset_kv_cache_gpu() which
+            // zeros ALL history — that desyncs the GPU cache (length 0) from the CPU
+            // cache (snapshot length), so verification attends over an empty K/V and
+            // computes wrong logits → wrong acceptance. Mirrors the PAR-105 fix already
+            // applied to the two-model path below.
             cache.rollback_to(cache_snapshot, kv_dim);
-            self.executor.reset_kv_cache_gpu();
+            self.executor.rollback_kv_cache_gpu(cache_snapshot);
 
             // Step 3: Verify - use single-token GPU-resident to check each draft
             // NOTE: Batched verification would be faster but requires refactoring
@@ -162,9 +168,10 @@ impl OwnedQuantizedModelCuda {
 
             // Handle edge case: all drafts rejected
             if num_accepted == 0 && !draft_tokens.is_empty() {
-                // Just generate one token normally
+                // Just generate one token normally.
+                // PMAT-752: same fix as Step 2 — preserve history via rollback, not reset.
                 cache.rollback_to(cache_snapshot, kv_dim);
-                self.executor.reset_kv_cache_gpu();
+                self.executor.rollback_kv_cache_gpu(cache_snapshot);
                 let fallback =
                     self.forward_gpu_resident_to_token_id(last_token, &mut cache, position)?;
                 if config.stop_tokens.contains(&fallback) {


### PR DESCRIPTION
## Speculative-decode correctness bug (found by adversarial bug-hunt)

`generate_speculative_cuda` (self-speculative GPU path) rolled back the **CPU** cache to the pre-draft snapshot but called `reset_kv_cache_gpu()` — which **zeros all GPU KV-cache lengths**, dropping prefill + previously-accepted history. The GPU cache (length 0) then desynced from the CPU snapshot, so each verification forward attended over an almost-empty K/V → **wrong logits → wrong accept/reject → speculative output diverges from plain greedy** (the classic 1-of-k acceptance / corrupted text).

## Already-fixed sibling proves it
The two-model path (PAR-099) does this correctly with `rollback_kv_cache_gpu(snapshot)` and carries a PAR-105 comment documenting this *exact* bug:
> "reset_kv_cache_gpu() was clearing ALL history, causing 1/k acceptance"

The self-speculative path simply never got the same fix.

## Fix
Replace both `reset_kv_cache_gpu()` calls (verification + all-rejected fallback) with `rollback_kv_cache_gpu(cache_snapshot)` — keeping the GPU KV length in lockstep with the CPU snapshot. Mirrors the proven PAR-105 fix exactly (2 lines).

## Severity / verification (honest)
- **Latent today**: the only in-tree callers are throughput benchmarks (`cbtop_measure_batch`) that count `output.len()` and don't validate text — so it's unobserved in current usage, but a real correctness bug in the public API on the default eager GPU path.
- **Verified by**: compiles (cuda); mechanism confirmed (eager attention indexes K/V by the length counter that `reset` zeroes); mirrors the already-verified sibling fix.
- **No automated unit test**: the function is GPU-only with no CPU/mock path. The proper falsifier (`FALSIFY-SD-KVSYNC-752`: greedy speculative == greedy plain) is GPU-host-runnable (documented in the contract), not per-PR CI.

## Co-evolution (Rule 7)
Contract `speculative-decoding-v1` → **1.1.0**: GPU-KV-rollback invariant + `FALSIFY-SD-KVSYNC-752`. `pv validate` clean.

Found by an adversarial bug-hunt over the complex generation paths (1 confirmed real of 8 findings; 7 refuted by skeptic verification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)