### PR TITLE
fix(serve): SSE streaming double `data:` prefix broke every client (PMAT-753)

### DIFF
--- a/contracts/apr-serve-openai-compat-v1.yaml
+++ b/contracts/apr-serve-openai-compat-v1.yaml
@@ -1,0 +1,49 @@
+contract: apr-serve-openai-compat
+metadata:
+  kind: pattern
+  version: "1.0.0"
+  description: >
+    OpenAI-compatible serve layer (/v1/chat/completions, /v1/completions) fidelity
+    invariants. Established by an adversarial audit (2026-06-14) that found 12 confirmed
+    real bugs — see evidence/serve-api-openai-fidelity-audit-2026-06-14/findings.md.
+    This contract is the home for those obligations; they discharge as the follow-up
+    fixes land. PMAT-753 (this revision) discharges the SSE-framing obligation: the
+    streaming handler must pass a BARE JSON payload (or "[DONE]") to axum's
+    Event::data(), NOT a string already prefixed with "data: " — axum's Sse adds the
+    `data: ` field + `\n\n` terminator itself, so a manual prefix produced a DOUBLE
+    `data: data: {json}` on the wire and broke JSON.parse for every spec-compliant SSE
+    client. The correct form is used by openai_handlers.rs.
+  references:
+  - "crates/aprender-serve/src/api/chat_completions_stream.rs (fixed)"
+  - "crates/aprender-serve/src/api/openai_handlers.rs (correct SSE-framing reference)"
+  - "evidence/serve-api-openai-fidelity-audit-2026-06-14/findings.md (full 12-bug audit)"
+version: 1
+status: enforced
+date: 2026-06-14
+
+proof_obligations:
+  - type: invariant
+    property: >
+      SSE-FRAMING (PMAT-753, DISCHARGED): the streaming chat handler passes a bare JSON
+      chunk (or the literal "[DONE]") to Event::default().data(); it never manually
+      prepends "data: " or appends a newline (axum's Sse adds the field framing). So each
+      streamed event's data is parseable JSON, never the literal "data: {...}".
+  - type: invariant
+    property: >
+      STOP-APPLIED (open — audit items 3-6): every completion backend applies the
+      request's stop sequences (post-decode truncation), so generated text never contains
+      a stop string and generation halts at it. Reference: try_cuda_gguf_completions /
+      try_apr_q4k_completions already do this.
+  - type: invariant
+    property: >
+      PARAMS-PLUMBED (open — audit items 7-10): request params (n, seed, top_k,
+      temperature) are honored or explicitly rejected, never silently dropped; the
+      OpenAI-compat temperature default is 1.0 (the codebase's default_temperature()).
+
+falsification_tests:
+  - id: FALSIFY-SSE-FRAMING-753
+    name: chat_completions_stream_no_double_data_prefix
+    prediction: 'chat_completions_stream.rs yields Event::default().data(<bare json>) / .data("[DONE]") — no occurrence of Event::default().data(format!("data: ...")) (which double-prefixes the SSE wire format). Shape gate: catches re-introduction of the manual prefix.'
+    test_harness: '! grep -nE "data\(format!\\(\"data: " crates/aprender-serve/src/api/chat_completions_stream.rs'
+    expected_output: "no match (exit 1 from grep = invariant holds)"
+    if_fails: 'The streaming handler re-added a manual "data: " prefix → axum double-prefixes the SSE wire (data: data: {json}) and every spec-compliant streaming client fails to parse chunks. NOTE: shape gate (greps source); the behavioral wire-format is verified by matching openai_handlers.rs (axum Event is opaque + the test app loads no model, so no in-CI wire assertion).'

--- a/crates/aprender-serve/src/api/chat_completions_stream.rs
+++ b/crates/aprender-serve/src/api/chat_completions_stream.rs
@@ -75,9 +75,15 @@ pub async fn openai_chat_completions_stream_handler(
     let tokenizer_clone = tokenizer;
 
     let stream = async_stream::stream! {
+        // PMAT-753: pass ONLY the JSON payload to Event::data() — axum's Sse adds the
+        // `data: ` field prefix and the `\n\n` terminator itself. The previous
+        // `format!("data: {}\n", data)` produced a DOUBLE prefix on the wire
+        // (`data: data: {json}`), so spec-compliant SSE clients received the literal
+        // string "data: {json}" as the event data and JSON.parse failed → streaming
+        // was broken for every client. Matches the correct form in openai_handlers.rs.
         let initial = ChatCompletionChunk::initial(&request_id_clone, &model_name);
         let data = serde_json::to_string(&initial).unwrap_or_default();
-        yield Ok(Event::default().data(format!("data: {}\n", data)));
+        yield Ok(Event::default().data(data));
 
         for &token_id in &generated_ids {
             let text = match tokenizer_clone.decode(&[token_id]) {
@@ -87,14 +93,14 @@ pub async fn openai_chat_completions_stream_handler(
 
             let chunk = ChatCompletionChunk::content(&request_id_clone, &model_name, &text);
             let data = serde_json::to_string(&chunk).unwrap_or_default();
-            yield Ok(Event::default().data(format!("data: {}\n", data)));
+            yield Ok(Event::default().data(data));
         }
 
         let done = ChatCompletionChunk::done(&request_id_clone, &model_name);
         let data = serde_json::to_string(&done).unwrap_or_default();
-        yield Ok(Event::default().data(format!("data: {}\n", data)));
+        yield Ok(Event::default().data(data));
 
-        yield Ok(Event::default().data("data: [DONE]\n".to_string()));
+        yield Ok(Event::default().data("[DONE]"));
     };
 
     Ok(Sse::new(stream))

--- a/evidence/serve-api-openai-fidelity-audit-2026-06-14/findings.md
+++ b/evidence/serve-api-openai-fidelity-audit-2026-06-14/findings.md
@@ -1,0 +1,46 @@
+# Serve HTTP / OpenAI-compat API — adversarial fidelity audit (2026-06-14)
+
+Adversarial bug-hunt over the serve API layer (param plumbing, stop sequences, SSE
+streaming, response/usage): parallel finders → skeptic verification → confirmed-only.
+**12 confirmed real bugs of 16 findings** — the most bug-dense subsystem audited (the
+user-facing OpenAI-compat surface was under-tested for spec fidelity). Tracked below,
+prioritized; fixed incrementally (one coherent cluster per PR).
+
+## SSE streaming (CRITICAL/HIGH)
+1. **[FIXED PMAT-753]** Double `data:` prefix — `chat_completions_stream.rs` did
+   `Event::default().data(format!("data: {}\n", json))`, but axum's `Sse` adds the
+   `data: ` field itself → wire was `data: data: {json}`, so spec clients `JSON.parse`
+   the literal "data: {json}" and fail. **Streaming broken for every client.** Fixed to
+   `Event::default().data(json)` (matches the correct `openai_handlers.rs` form).
+2. **[TODO]** Multi-byte UTF-8 split across tokens (`chat_completions_stream.rs:83`):
+   `decode(&[token_id])` per token → emoji/CJK spanning two tokens emit replacement
+   chars. Needs a cross-token byte buffer (decode longest valid UTF-8 prefix, carry rest).
+
+## Stop sequences ignored (HIGH) — model doesn't stop / leaks stop text
+3. **[TODO]** `try_cached_completions` (realize_handlers_embed_completion.rs:315) — no stop applied.
+4. **[TODO]** `try_quantized_completions` (realize_handlers_embed_completion.rs:385) — no stop applied.
+5. **[TODO]** `try_gpu_completions` (gpu_completions_handler.rs:39) — no stop applied.
+6. **[TODO]** chat path `openai_chat_completions_handler` (openai_handlers.rs:344) — no stop applied.
+   Fix pattern exists: `try_cuda_gguf_completions` / `try_apr_q4k_completions` already do
+   post-decode stop truncation — copy it to the 4 backends above.
+
+## Param plumbing dropped (HIGH/MEDIUM) — OpenAI fidelity
+7. **[TODO]** `n` accepted but ignored (mod_create_demo.rs:94) — n>1 silently returns 1
+   choice. Min fix: reject n>1 with 400; full: generate n choices.
+8. **[TODO]** `seed` accepted but not plumbed (mod_create_demo.rs:92) — non-reproducible.
+   MoE path already plumbs it (cuda_chat_backend.rs:748); mirror to dense backends.
+9. **[TODO]** `top_k` ignored, hardcoded 40/1 (cuda_chat_backend.rs:252) — mirror MoE plumbing.
+10. **[TODO]** temperature default 0.7 vs OpenAI 1.0 (openai_handlers.rs:99) — the repo's
+    own `default_temperature()`=1.0; chat path hardcodes 0.7. Use the canonical default.
+
+## finish_reason wrong (HIGH/MEDIUM)
+11. **[TODO]** Streaming `finish_reason` always "stop", never "length" when max_tokens hit
+    (mod_create_demo.rs:398).
+12. **[TODO]** `true_streaming_sse_response` lacks max_tokens → can't set finish_reason
+    correctly (openai_handlers.rs:211).
+
+## Method
+All confirmed by skeptic verification (default-refute). Several cite the codebase's OWN
+correct reference (openai_handlers.rs SSE form; default_temperature()=1.0;
+try_cuda_gguf_completions stop truncation; MoE seed/top_k plumbing) — i.e. the bugs are
+drift where one backend/path diverged from a sibling that does it right.


### PR DESCRIPTION
## Critical: streaming chat completions broken for every SSE client

`chat_completions_stream.rs` yielded `Event::default().data(format!("data: {}\n", json))` — but axum's `Sse` adds the `data: ` field + `\n\n` terminator itself. So the wire format was **double-prefixed**: `data: data: {json}`. Spec-compliant SSE clients received the literal string `"data: {json}"` as the event data → `JSON.parse` failed → **streaming chat completions were broken for every client.**

The sibling handler `openai_handlers.rs` already uses the correct bare form — this was drift in one handler.

**Fix:** pass the bare JSON payload (and `[DONE]`) to `Event::data()`; let axum frame it.

## Found by an adversarial audit of the OpenAI-compat serve layer
The hunt confirmed **12 real bugs (16 reviewed)** — the most bug-dense subsystem yet (the user-facing surface was under-tested for spec fidelity). This PR fixes the **single most severe** one (broken streaming) and records the full audit for incremental follow-up: `evidence/serve-api-openai-fidelity-audit-2026-06-14/findings.md` (UTF-8 stream split, stop sequences ×4 backends, `n`/`seed`/`top_k`/temperature plumbing, `finish_reason` ×2).

## Co-evolution (Rule 7)
- Contract `apr-serve-openai-compat-v1` (kind: pattern): SSE-FRAMING obligation **discharged** + STOP-APPLIED/PARAMS-PLUMBED obligations open (tracking the audit) + `FALSIFY-SSE-FRAMING-753` **shape gate** (greps out the double-prefix; passes). `pv validate` clean.
- *Note:* the behavioral wire-format isn't CI-assertable here (axum `Event` is opaque + the test app loads no model), so the fix matches the **proven `openai_handlers.rs` reference**; the shape gate guards against regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)