### PR TITLE
fix(serve): apply OpenAI stop sequences in cached + quantized completion backends (PMAT-754)

### DIFF
--- a/contracts/apr-serve-openai-compat-v1.yaml
+++ b/contracts/apr-serve-openai-compat-v1.yaml
@@ -1,7 +1,7 @@
 contract: apr-serve-openai-compat
 metadata:
   kind: pattern
-  version: "1.0.0"
+  version: "1.1.0"
   description: >
     OpenAI-compatible serve layer (/v1/chat/completions, /v1/completions) fidelity
     invariants. Established by an adversarial audit (2026-06-14) that found 12 confirmed
@@ -30,10 +30,14 @@ proof_obligations:
       streamed event's data is parseable JSON, never the literal "data: {...}".
   - type: invariant
     property: >
-      STOP-APPLIED (open — audit items 3-6): every completion backend applies the
-      request's stop sequences (post-decode truncation), so generated text never contains
-      a stop string and generation halts at it. Reference: try_cuda_gguf_completions /
-      try_apr_q4k_completions already do this.
+      STOP-APPLIED (PARTIAL — PMAT-754): every completion backend applies the request's
+      stop sequences (post-decode truncation at the EARLIEST stop position), so generated
+      text never contains a stop string. DISCHARGED for try_cached_completions and
+      try_quantized_completions via the shared truncate_at_stop() helper. STILL OPEN:
+      try_gpu_completions and the /v1/chat/completions path (build_chat_response needs a
+      stops param threaded through its backends — tracked follow-up). The prior inline
+      forms (gpu_completions_handler.rs) truncate at the first-LISTED stop, not the
+      earliest-POSITION one — should migrate to the helper.
   - type: invariant
     property: >
       PARAMS-PLUMBED (open — audit items 7-10): request params (n, seed, top_k,
@@ -41,6 +45,12 @@ proof_obligations:
       OpenAI-compat temperature default is 1.0 (the codebase's default_temperature()).
 
 falsification_tests:
+  - id: FALSIFY-STOP-TRUNCATE-754
+    name: pmat754_stop_truncation_tests
+    prediction: 'truncate_at_stop(text, stops) truncates at the EARLIEST stop position (not the first-listed): truncate_at_stop("hello world", ["world","hello"]) == ""; keeps text when no stop matches; ignores empty stop strings; unchanged when stops is None. try_cached_completions / try_quantized_completions apply it so their output never contains a stop string.'
+    test_harness: 'cargo test -p aprender-serve --lib pmat754_stop_truncation_tests'
+    expected_output: "test result: ok"
+    if_fails: 'A completion backend returns text containing the stop string (or runs to max_tokens past it), violating OpenAI stop semantics — the pre-PMAT-754 behavior in the cached/quantized backends.'
   - id: FALSIFY-SSE-FRAMING-753
     name: chat_completions_stream_no_double_data_prefix
     prediction: 'chat_completions_stream.rs yields Event::default().data(<bare json>) / .data("[DONE]") — no occurrence of Event::default().data(format!("data: ...")) (which double-prefixes the SSE wire format). Shape gate: catches re-introduction of the manual prefix.'

--- a/crates/aprender-serve/src/api/realize_handlers_embed_completion.rs
+++ b/crates/aprender-serve/src/api/realize_handlers_embed_completion.rs
@@ -260,6 +260,27 @@ async fn try_batch_completion(
     )))
 }
 
+/// PMAT-754: truncate `text` at the EARLIEST occurrence of any stop string (OpenAI
+/// behavior) — the returned text never contains a stop string. Returns `text` unchanged
+/// when there are no stops. Several completion backends previously ignored `request.stop`
+/// entirely (the model's output kept the stop text / ran to max_tokens); this is the
+/// shared, position-correct application (the prior inline form truncated at the
+/// first-LISTED stop, not the earliest-POSITION one).
+fn truncate_at_stop(text: String, stops: Option<&[String]>) -> String {
+    let Some(stops) = stops else {
+        return text;
+    };
+    let cut = stops
+        .iter()
+        .filter(|s| !s.is_empty())
+        .filter_map(|s| text.find(s.as_str()))
+        .min();
+    match cut {
+        Some(pos) => text[..pos].to_string(),
+        None => text,
+    }
+}
+
 /// Cached model backend (includes batch path). Returns None if not available.
 #[cfg(feature = "gpu")]
 async fn try_cached_completions(
@@ -333,6 +354,8 @@ async fn try_cached_completions(
     let text = tokenizer
         .decode(&token_ids)
         .map_err(|e| rerr(state, StatusCode::INTERNAL_SERVER_ERROR, e))?;
+    // PMAT-754: apply OpenAI stop sequences (this backend previously ignored them).
+    let text = truncate_at_stop(text, request.stop.as_deref());
     state
         .metrics
         .record_success(completion_tokens, start.elapsed());
@@ -395,6 +418,8 @@ fn try_quantized_completions(
     let text = tokenizer
         .decode(&token_ids)
         .map_err(|e| rerr(state, StatusCode::INTERNAL_SERVER_ERROR, e))?;
+    // PMAT-754: apply OpenAI stop sequences (this backend previously ignored them).
+    let text = truncate_at_stop(text, request.stop.as_deref());
     state
         .metrics
         .record_success(completion_tokens, start.elapsed());
@@ -407,4 +432,39 @@ fn try_quantized_completions(
         completion_tokens,
         max_tokens,
     )))
+}
+
+#[cfg(test)]
+mod pmat754_stop_truncation_tests {
+    use super::truncate_at_stop;
+
+    #[test]
+    fn no_stops_returns_unchanged() {
+        assert_eq!(truncate_at_stop("hello world".to_string(), None), "hello world");
+        assert_eq!(truncate_at_stop("hello".to_string(), Some(&[])), "hello");
+    }
+
+    #[test]
+    fn truncates_at_earliest_position_not_first_listed() {
+        // "hello" (pos 0) is earlier than "world" (pos 6) despite being listed second.
+        let stops = vec!["world".to_string(), "hello".to_string()];
+        assert_eq!(truncate_at_stop("hello world".to_string(), Some(&stops)), "");
+        let one = vec!["END".to_string()];
+        assert_eq!(
+            truncate_at_stop("keep thisENDdrop that".to_string(), Some(&one)),
+            "keep this"
+        );
+    }
+
+    #[test]
+    fn stop_absent_keeps_text() {
+        let stops = vec!["XYZ".to_string()];
+        assert_eq!(truncate_at_stop("hello".to_string(), Some(&stops)), "hello");
+    }
+
+    #[test]
+    fn empty_stop_strings_ignored() {
+        let stops = vec![String::new(), "stop".to_string()];
+        assert_eq!(truncate_at_stop("a stop b".to_string(), Some(&stops)), "a ");
+    }
 }

--- a/evidence/serve-api-openai-fidelity-audit-2026-06-14/findings.md
+++ b/evidence/serve-api-openai-fidelity-audit-2026-06-14/findings.md
@@ -17,8 +17,8 @@ prioritized; fixed incrementally (one coherent cluster per PR).
    chars. Needs a cross-token byte buffer (decode longest valid UTF-8 prefix, carry rest).
 
 ## Stop sequences ignored (HIGH) — model doesn't stop / leaks stop text
-3. **[TODO]** `try_cached_completions` (realize_handlers_embed_completion.rs:315) — no stop applied.
-4. **[TODO]** `try_quantized_completions` (realize_handlers_embed_completion.rs:385) — no stop applied.
+3. **[FIXED PMAT-754]** `try_cached_completions` (realize_handlers_embed_completion.rs) — now applies stop via shared truncate_at_stop().
+4. **[FIXED PMAT-754]** `try_quantized_completions` (realize_handlers_embed_completion.rs) — now applies stop via shared truncate_at_stop().
 5. **[TODO]** `try_gpu_completions` (gpu_completions_handler.rs:39) — no stop applied.
 6. **[TODO]** chat path `openai_chat_completions_handler` (openai_handlers.rs:344) — no stop applied.
    Fix pattern exists: `try_cuda_gguf_completions` / `try_apr_q4k_completions` already do


### PR DESCRIPTION
## Audit follow-up — stop sequences ignored (serve-API audit items 3-4)

`try_cached_completions` and `try_quantized_completions` (`/v1/completions` backends) decoded the generated text but **never applied `request.stop`** — so the returned completion contained the stop string and generation ran to `max_tokens` instead of halting. An OpenAI-spec violation on every request that sets `stop`.

## Fix
Shared `truncate_at_stop(text, stops)` helper that truncates at the **earliest stop position** (correct OpenAI behavior; the prior inline forms elsewhere truncate at the *first-listed* stop — a separate latent bug noted in the contract). Applied in both backends after decode.

## Co-evolution (Rule 7)
- **4 unit falsifiers** (`pmat754_stop_truncation_tests`): earliest-position truncation, no-stop passthrough, absent-stop, empty-stop-ignored — pure string logic, CI-testable.
- Contract `apr-serve-openai-compat-v1` → **1.1.0**: STOP-APPLIED obligation **partial** (cached + quantized discharged; `try_gpu` + chat path tracked) + `FALSIFY-STOP-TRUNCATE-754`. `pv validate` clean.
- Full `aprender-serve` lib suite: **15289 pass, 0 fail**.

## Remaining (tracked in the audit doc)
`try_gpu_completions` + the `/v1/chat/completions` path (`build_chat_response` needs a `stops` param threaded through its backends — a signature change deserving its own focused PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)