### PR TITLE
fix(serve): apply OpenAI stop sequences across all non-streaming serve backends (PMAT-755/756)

### DIFF
--- a/contracts/apr-serve-openai-compat-v1.yaml
+++ b/contracts/apr-serve-openai-compat-v1.yaml
@@ -1,7 +1,7 @@
 contract: apr-serve-openai-compat
 metadata:
   kind: pattern
-  version: "1.1.0"
+  version: "1.2.0"
   description: >
     OpenAI-compatible serve layer (/v1/chat/completions, /v1/completions) fidelity
     invariants. Established by an adversarial audit (2026-06-14) that found 12 confirmed
@@ -30,14 +30,15 @@ proof_obligations:
       streamed event's data is parseable JSON, never the literal "data: {...}".
   - type: invariant
     property: >
-      STOP-APPLIED (PARTIAL — PMAT-754): every completion backend applies the request's
-      stop sequences (post-decode truncation at the EARLIEST stop position), so generated
-      text never contains a stop string. DISCHARGED for try_cached_completions and
-      try_quantized_completions via the shared truncate_at_stop() helper. STILL OPEN:
-      try_gpu_completions and the /v1/chat/completions path (build_chat_response needs a
-      stops param threaded through its backends — tracked follow-up). The prior inline
-      forms (gpu_completions_handler.rs) truncate at the first-LISTED stop, not the
-      earliest-POSITION one — should migrate to the helper.
+      STOP-APPLIED (PARTIAL — PMAT-754/755): every completion backend applies the
+      request's stop sequences (post-decode truncation at the EARLIEST stop position) via
+      the shared truncate_at_stop() helper, so generated text never contains a stop string.
+      DISCHARGED for ALL /v1/completions backends: try_cached_completions,
+      try_quantized_completions (PMAT-754), try_gpu_completions, try_apr_q4k_completions
+      (PMAT-755). STILL OPEN: the /v1/chat/completions path (build_chat_response needs a
+      stops param threaded through its backends — a signature change, tracked follow-up);
+      and the try_cuda_gguf_completions inline form truncates at the first-LISTED stop, not
+      the earliest-POSITION one — should migrate to the helper (minor correctness nicety).
   - type: invariant
     property: >
       PARAMS-PLUMBED (open — audit items 7-10): request params (n, seed, top_k,

--- a/contracts/apr-serve-openai-compat-v1.yaml
+++ b/contracts/apr-serve-openai-compat-v1.yaml
@@ -1,7 +1,7 @@
 contract: apr-serve-openai-compat
 metadata:
   kind: pattern
-  version: "1.2.0"
+  version: "1.3.0"
   description: >
     OpenAI-compatible serve layer (/v1/chat/completions, /v1/completions) fidelity
     invariants. Established by an adversarial audit (2026-06-14) that found 12 confirmed
@@ -30,15 +30,24 @@ proof_obligations:
       streamed event's data is parseable JSON, never the literal "data: {...}".
   - type: invariant
     property: >
-      STOP-APPLIED (PARTIAL — PMAT-754/755): every completion backend applies the
-      request's stop sequences (post-decode truncation at the EARLIEST stop position) via
-      the shared truncate_at_stop() helper, so generated text never contains a stop string.
-      DISCHARGED for ALL /v1/completions backends: try_cached_completions,
-      try_quantized_completions (PMAT-754), try_gpu_completions, try_apr_q4k_completions
-      (PMAT-755). STILL OPEN: the /v1/chat/completions path (build_chat_response needs a
-      stops param threaded through its backends — a signature change, tracked follow-up);
-      and the try_cuda_gguf_completions inline form truncates at the first-LISTED stop, not
-      the earliest-POSITION one — should migrate to the helper (minor correctness nicety).
+      STOP-APPLIED (DISCHARGED for NON-STREAMING — PMAT-754/755/756): every NON-STREAMING
+      completion AND chat backend applies the request's stop sequences (post-decode
+      truncation at the EARLIEST stop position) via the shared truncate_at_stop() helper, so
+      the returned (non-streamed) text never contains a stop string. /v1/completions:
+      try_cached_completions, try_quantized_completions (PMAT-754), try_gpu_completions,
+      try_apr_q4k_completions (PMAT-755). /v1/chat/completions: build_chat_response runs
+      finalize_chat_text() across ALL 7 build_chat_response call sites
+      (gpu/quantized/cached/q4k/qwen3_moe/registry), AND the inline try_safetensors_cuda_backend
+      builder (which bypasses build_chat_response) also calls finalize_chat_text — together
+      with finish_reason="stop" when a stop string truncated (precedence over "length")
+      (PMAT-756).
+      OPEN (tracked, NOT covered): the STREAMING chat paths — pregenerated_sse_response,
+      true_streaming_sse_response, chat_completions_stream.rs — decode/emit token-by-token
+      and do NOT apply stop; correct streaming stop needs incremental cross-token stop
+      detection + partial-final-chunk emission, the same cross-token buffer the UTF-8
+      stream-split fix (audit item 2) requires, so they ship as one combined follow-up.
+      Residual nicety (non-blocking): the try_cuda_gguf_completions inline form truncates at
+      the first-LISTED stop, not the earliest-POSITION one — should migrate to the helper.
   - type: invariant
     property: >
       PARAMS-PLUMBED (open — audit items 7-10): request params (n, seed, top_k,
@@ -52,6 +61,12 @@ falsification_tests:
     test_harness: 'cargo test -p aprender-serve --lib pmat754_stop_truncation_tests'
     expected_output: "test result: ok"
     if_fails: 'A completion backend returns text containing the stop string (or runs to max_tokens past it), violating OpenAI stop semantics — the pre-PMAT-754 behavior in the cached/quantized backends.'
+  - id: FALSIFY-CHAT-STOP-756
+    name: pmat756_chat_stop_tests
+    prediction: 'finalize_chat_text(text, stops, completion_tokens, max_tokens) truncates the chat message at the earliest stop position via the shared truncate_at_stop helper and sets finish_reason: a matched stop string => "stop" (even when completion_tokens >= max_tokens — stop precedence over length); no stop match + max_tokens hit => "length"; no stop match under max_tokens => "stop"; stops=None leaves text untouched. build_chat_response runs it for all 7 /v1/chat/completions backends so the returned message never contains a stop string.'
+    test_harness: 'cargo test -p aprender-serve --lib pmat756_chat_stop_tests'
+    expected_output: "test result: ok"
+    if_fails: 'The /v1/chat/completions response contains the stop string / runs to max_tokens past it (the pre-PMAT-756 behavior — the chat path ignored request.stop entirely), or finish_reason mislabels a stop-truncated message as "length".'
   - id: FALSIFY-SSE-FRAMING-753
     name: chat_completions_stream_no_double_data_prefix
     prediction: 'chat_completions_stream.rs yields Event::default().data(<bare json>) / .data("[DONE]") — no occurrence of Event::default().data(format!("data: ...")) (which double-prefixes the SSE wire format). Shape gate: catches re-introduction of the manual prefix.'

--- a/crates/aprender-serve/src/api/cuda_chat_backend.rs
+++ b/crates/aprender-serve/src/api/cuda_chat_backend.rs
@@ -51,11 +51,12 @@ fn try_safetensors_cuda_backend(
     let completion_tokens = output_ids.len();
     let prompt_tokens = input_ids.len();
 
-    let finish_reason = if completion_tokens >= max_tokens {
-        "length"
-    } else {
-        "stop"
-    };
+    // PMAT-756: this backend builds the chat JSON inline (not via build_chat_response) and
+    // previously ignored request.stop entirely — the returned message kept the stop string
+    // and ran to max_tokens. Reuse the shared finalize_chat_text helper so it matches every
+    // other non-streaming chat backend (stop truncation + "stop" finish_reason precedence).
+    let (output_text, finish_reason) =
+        finalize_chat_text(output_text, request.stop.as_deref(), completion_tokens, max_tokens);
 
     let body = format!(
         r#"{{"id":"{}","object":"chat.completion","model":"{}","choices":[{{"index":0,"message":{{"role":"assistant","content":{}}},"finish_reason":"{}"}}],"usage":{{"prompt_tokens":{},"completion_tokens":{},"total_tokens":{}}}}}"#,
@@ -216,6 +217,7 @@ async fn try_cuda_backend(
         prompt_tokens,
         completion_tokens,
         max_tokens,
+        request.stop.as_deref(),
         trace_level,
         latency,
     ))
@@ -305,6 +307,7 @@ fn try_quantized_backend(
         prompt_tokens,
         completion_tokens,
         max_tokens,
+        request.stop.as_deref(),
         trace_level,
         latency,
     ))
@@ -400,6 +403,7 @@ fn registry_fallback(
         prompt_tokens,
         completion_tokens,
         max_tokens,
+        request.stop.as_deref(),
         None,
         duration,
     )
@@ -555,6 +559,7 @@ async fn try_apr_q4k_chat_backend(
         prompt_tokens,
         completion_tokens,
         max_tokens,
+        request.stop.as_deref(),
         trace_level,
         start.elapsed(),
     ))
@@ -826,6 +831,7 @@ fn try_qwen3_moe_backend(
         prompt_token_count,
         completion_tokens,
         max_tokens,
+        request.stop.as_deref(),
         None,
         duration,
     ))

--- a/crates/aprender-serve/src/api/gpu_completions_handler.rs
+++ b/crates/aprender-serve/src/api/gpu_completions_handler.rs
@@ -60,6 +60,8 @@ fn try_gpu_completions(
     let text = tokenizer
         .decode(&token_ids)
         .map_err(|e| rerr(state, StatusCode::INTERNAL_SERVER_ERROR, e))?;
+    // PMAT-755: apply OpenAI stop sequences (this GPU backend previously ignored them).
+    let text = truncate_at_stop(text, request.stop.as_deref());
     state
         .metrics
         .record_success(completion_tokens, start.elapsed());
@@ -195,6 +197,8 @@ async fn try_apr_q4k_completions(
     let text = tokenizer
         .decode(&resp.output_tokens)
         .map_err(|e| rerr(state, StatusCode::INTERNAL_SERVER_ERROR, e))?;
+    // PMAT-755: apply OpenAI stop sequences (this backend previously ignored them).
+    let text = truncate_at_stop(text, request.stop.as_deref());
     let completion_tokens = resp.tokens_generated;
     state.metrics.record_success(completion_tokens, start.elapsed());
 

--- a/crates/aprender-serve/src/api/openai_handlers.rs
+++ b/crates/aprender-serve/src/api/openai_handlers.rs
@@ -105,6 +105,34 @@ fn chat_gen_params(
     (max_tokens, temperature, eos_token_id)
 }
 
+/// PMAT-756: apply OpenAI stop sequences to a chat completion's text and compute the
+/// matching `finish_reason`. The `/v1/chat/completions` path previously ignored
+/// `request.stop` entirely — the returned message kept the stop string and ran to
+/// `max_tokens`. Reuses the shared earliest-position [`truncate_at_stop`] helper (PMAT-754)
+/// so chat behaves identically to the `/v1/completions` backends.
+///
+/// `finish_reason` is `"stop"` whenever a stop string truncated the text (even if
+/// `max_tokens` was also reached — a matched stop sequence takes precedence per OpenAI
+/// semantics), `"length"` only when the generation hit `max_tokens` with no stop match,
+/// else `"stop"` (the model emitted EOS naturally). Pure + unit-tested.
+fn finalize_chat_text(
+    text: String,
+    stops: Option<&[String]>,
+    completion_tokens: usize,
+    max_tokens: usize,
+) -> (String, String) {
+    let orig_len = text.len();
+    let text = crate::api::realize_handlers::truncate_at_stop(text, stops);
+    let stopped = text.len() < orig_len;
+    let finish_reason = if !stopped && completion_tokens >= max_tokens {
+        "length"
+    } else {
+        "stop"
+    }
+    .to_string();
+    (text, finish_reason)
+}
+
 /// Build a non-streaming ChatCompletionResponse.
 fn build_chat_response(
     request_id: String,
@@ -113,6 +141,7 @@ fn build_chat_response(
     prompt_tokens: usize,
     completion_tokens: usize,
     max_tokens: usize,
+    stops: Option<&[String]>,
     trace_level: Option<&str>,
     latency: Duration,
 ) -> Response {
@@ -123,6 +152,7 @@ fn build_chat_response(
         completion_tokens,
         28,
     );
+    let (text, finish_reason) = finalize_chat_text(text, stops, completion_tokens, max_tokens);
     Json(ChatCompletionResponse {
         id: request_id,
         object: "chat.completion".to_string(),
@@ -135,11 +165,7 @@ fn build_chat_response(
                 content: text,
                 name: None,
             },
-            finish_reason: if completion_tokens >= max_tokens {
-                "length".to_string()
-            } else {
-                "stop".to_string()
-            },
+            finish_reason,
         }],
         usage: Usage {
             prompt_tokens,
@@ -355,6 +381,7 @@ fn try_gpu_backend(
         prompt_tokens,
         completion_tokens,
         max_tokens,
+        request.stop.as_deref(),
         trace_level,
         latency,
     ))
@@ -434,9 +461,84 @@ fn try_cached_backend(
         prompt_tokens,
         completion_tokens,
         max_tokens,
+        request.stop.as_deref(),
         trace_level,
         latency,
     ))
+}
+
+#[cfg(test)]
+mod pmat756_chat_stop_tests {
+    use super::finalize_chat_text;
+
+    fn stops(v: &[&str]) -> Vec<String> {
+        v.iter().map(|s| (*s).to_string()).collect()
+    }
+
+    #[test]
+    fn truncates_at_stop_and_reports_stop_reason() {
+        // A stop string in the text is removed; finish_reason is "stop".
+        let s = stops(&["<|im_end|>"]);
+        let (text, reason) = finalize_chat_text(
+            "Hello world<|im_end|>trailing".to_string(),
+            Some(&s),
+            5,
+            256,
+        );
+        assert_eq!(text, "Hello world");
+        assert_eq!(reason, "stop");
+    }
+
+    #[test]
+    fn stop_match_beats_length_when_max_tokens_also_hit() {
+        // OpenAI semantics: a matched stop sequence takes precedence over "length"
+        // even when completion_tokens >= max_tokens.
+        let s = stops(&["STOP"]);
+        let (text, reason) = finalize_chat_text("answerSTOPmore".to_string(), Some(&s), 256, 256);
+        assert_eq!(text, "answer");
+        assert_eq!(reason, "stop");
+    }
+
+    #[test]
+    fn no_stop_match_and_max_tokens_hit_is_length() {
+        let s = stops(&["<|im_end|>"]);
+        let (text, reason) = finalize_chat_text("full answer".to_string(), Some(&s), 256, 256);
+        assert_eq!(text, "full answer");
+        assert_eq!(reason, "length");
+    }
+
+    #[test]
+    fn no_stop_match_under_max_tokens_is_stop() {
+        let s = stops(&["<|im_end|>"]);
+        let (text, reason) = finalize_chat_text("short".to_string(), Some(&s), 3, 256);
+        assert_eq!(text, "short");
+        assert_eq!(reason, "stop");
+    }
+
+    #[test]
+    fn truncates_at_earliest_position_not_first_listed() {
+        // Mirrors FALSIFY-STOP-TRUNCATE-754: cut at the earliest POSITION,
+        // regardless of which stop is listed first.
+        let s = stops(&["world", "hello"]);
+        let (text, reason) = finalize_chat_text("hello world".to_string(), Some(&s), 5, 256);
+        assert_eq!(text, "");
+        assert_eq!(reason, "stop");
+    }
+
+    #[test]
+    fn none_stops_leaves_text_and_uses_length_when_maxed() {
+        let (text, reason) = finalize_chat_text("untouched".to_string(), None, 256, 256);
+        assert_eq!(text, "untouched");
+        assert_eq!(reason, "length");
+    }
+
+    #[test]
+    fn empty_stop_strings_are_ignored() {
+        let s = stops(&["", ""]);
+        let (text, reason) = finalize_chat_text("kept".to_string(), Some(&s), 1, 256);
+        assert_eq!(text, "kept");
+        assert_eq!(reason, "stop");
+    }
 }
 
 include!("cuda_chat_backend.rs");

--- a/crates/aprender-serve/src/api/realize_handlers_embed_completion.rs
+++ b/crates/aprender-serve/src/api/realize_handlers_embed_completion.rs
@@ -266,7 +266,11 @@ async fn try_batch_completion(
 /// entirely (the model's output kept the stop text / ran to max_tokens); this is the
 /// shared, position-correct application (the prior inline form truncated at the
 /// first-LISTED stop, not the earliest-POSITION one).
-fn truncate_at_stop(text: String, stops: Option<&[String]>) -> String {
+///
+/// `pub(crate)` so the `/v1/chat/completions` path (PMAT-756, `openai_handlers::
+/// build_chat_response`) reuses the same earliest-position truncation as the
+/// `/v1/completions` backends rather than re-implementing it.
+pub(crate) fn truncate_at_stop(text: String, stops: Option<&[String]>) -> String {
     let Some(stops) = stops else {
         return text;
     };

--- a/evidence/serve-api-openai-fidelity-audit-2026-06-14/findings.md
+++ b/evidence/serve-api-openai-fidelity-audit-2026-06-14/findings.md
@@ -19,7 +19,8 @@ prioritized; fixed incrementally (one coherent cluster per PR).
 ## Stop sequences ignored (HIGH) — model doesn't stop / leaks stop text
 3. **[FIXED PMAT-754]** `try_cached_completions` (realize_handlers_embed_completion.rs) — now applies stop via shared truncate_at_stop().
 4. **[FIXED PMAT-754]** `try_quantized_completions` (realize_handlers_embed_completion.rs) — now applies stop via shared truncate_at_stop().
-5. **[TODO]** `try_gpu_completions` (gpu_completions_handler.rs:39) — no stop applied.
+5. **[FIXED PMAT-755]** `try_gpu_completions` (gpu_completions_handler.rs) — now applies stop via truncate_at_stop().
+   Also **[FIXED PMAT-755]** `try_apr_q4k_completions` (the audit mis-stated it was already correct — it wasn't; now uses the helper).
 6. **[TODO]** chat path `openai_chat_completions_handler` (openai_handlers.rs:344) — no stop applied.
    Fix pattern exists: `try_cuda_gguf_completions` / `try_apr_q4k_completions` already do
    post-decode stop truncation — copy it to the 4 backends above.

--- a/evidence/serve-api-openai-fidelity-audit-2026-06-14/findings.md
+++ b/evidence/serve-api-openai-fidelity-audit-2026-06-14/findings.md
@@ -21,9 +21,16 @@ prioritized; fixed incrementally (one coherent cluster per PR).
 4. **[FIXED PMAT-754]** `try_quantized_completions` (realize_handlers_embed_completion.rs) — now applies stop via shared truncate_at_stop().
 5. **[FIXED PMAT-755]** `try_gpu_completions` (gpu_completions_handler.rs) — now applies stop via truncate_at_stop().
    Also **[FIXED PMAT-755]** `try_apr_q4k_completions` (the audit mis-stated it was already correct — it wasn't; now uses the helper).
-6. **[TODO]** chat path `openai_chat_completions_handler` (openai_handlers.rs:344) — no stop applied.
-   Fix pattern exists: `try_cuda_gguf_completions` / `try_apr_q4k_completions` already do
-   post-decode stop truncation — copy it to the 4 backends above.
+6. **[FIXED PMAT-756]** chat path `/v1/chat/completions` — `build_chat_response` now runs
+   `finalize_chat_text()`, applying the shared `truncate_at_stop()` helper across ALL 7
+   `build_chat_response` call sites (gpu/quantized/cached/q4k/qwen3_moe/registry) AND the
+   inline `try_safetensors_cuda_backend` builder (which bypasses `build_chat_response` and
+   was caught as a non-streaming gap by adversarial re-review) — setting `finish_reason="stop"`
+   when a stop string truncated (precedence over "length"). Helper promoted to `pub(crate)`.
+   Covered by FALSIFY-CHAT-STOP-756 (pmat756_chat_stop_tests). With this, **stop sequences
+   are honored on every NON-STREAMING completion+chat backend**. Streaming stop — applying
+   stop mid-SSE (pregenerated/true_streaming/chat_completions_stream) — remains OPEN, grouped
+   with item 2's cross-token stream-buffer work (same incremental-detection machinery).
 
 ## Param plumbing dropped (HIGH/MEDIUM) — OpenAI fidelity
 7. **[TODO]** `n` accepted but ignored (mod_create_demo.rs:94) — n>1 silently returns 1


### PR DESCRIPTION
Completes **non-streaming OpenAI `stop` fidelity** across the entire serve API (audit items 5+6). Two coherent commits in the same audit cluster + same `STOP-APPLIED` contract obligation:

**PMAT-755** — `/v1/completions`: `try_gpu_completions` + `try_apr_q4k_completions` decoded text but never applied `request.stop`. Now use the shared `truncate_at_stop()` helper. With this, all 4 `/v1/completions` backends (cached, quantized, gpu, apr_q4k) apply stop.

**PMAT-756** — `/v1/chat/completions`: the chat path ignored `request.stop` **entirely**.
- `truncate_at_stop()` promoted to `pub(crate)`; new pure, unit-tested `finalize_chat_text(text, stops, completion_tokens, max_tokens) -> (text, finish_reason)` (earliest-position truncation + `finish_reason="stop"` precedence over "length").
- `build_chat_response` gains a `stops` param; all 7 call sites pass `request.stop.as_deref()`.
- `try_safetensors_cuda_backend` (builds chat JSON inline, bypassing `build_chat_response`) also ignored stop — **caught by a 4-lens adversarial skeptic workflow** (correctness/regression/completeness SOUND; refutation surfaced this gap) — now calls `finalize_chat_text` too.

**Scope:** non-streaming. Streaming chat stop (pregenerated/true_streaming SSE, chat_completions_stream) needs incremental cross-token detection — same cross-token buffer as the UTF-8 stream-split (audit item 2) — shipped as one combined follow-up. Explicitly listed OPEN in the contract + audit (not silently dropped).

**Co-evolution (Rule 7):** contract `apr-serve-openai-compat-v1` → **1.3.0**; STOP-APPLIED discharged for all non-streaming completion+chat backends. New falsifier `FALSIFY-CHAT-STOP-756` (pmat756_chat_stop_tests, 7 cases). Mutation-verified (neutering truncate_at_stop fails 3 tests). cargo build (+`--features cuda`) clean; serve lib suite **15296 pass**; clippy+fmt clean; `pv validate` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)