### PR TITLE
fix(serve): reject non-finite temperature + f32-safe sampling RNG range (PMAT-757)

### DIFF
--- a/contracts/aprender/apr-cli-sampling-v1.yaml
+++ b/contracts/aprender/apr-cli-sampling-v1.yaml
@@ -1,5 +1,5 @@
 metadata:
-  version: 1.0.0
+  version: 1.1.0
   created: '2026-04-06'
   author: PAIML Engineering
   description: >
@@ -30,8 +30,12 @@ equations:
     - Temperature must be non-negative
     - Temperature 0.0 produces deterministic output (GH-637)
     - Temperature 0.0 produces non-empty output on GPU (GH-637)
+    - Temperature must be FINITE — NaN/±inf are rejected (PMAT-757). `NaN <= 0.0` is false
+      (IEEE-754 unordered), so a bare `<= 0.0` guard lets NaN through; `logit / NaN = NaN`
+      then poisons the whole distribution and silently biases sampling to the last token.
     preconditions:
     - temperature >= 0.0
+    - temperature.is_finite()
     postconditions:
     - output tokens are non-empty for valid prompt
     lean_theorem: Theorems.TemperatureBounds
@@ -72,6 +76,12 @@ equations:
     - Same seed produces identical output (GH-570)
     - Determinism holds across runs (no external entropy)
     - --seed 0 uses random seed (convention)
+    - RNG draw value is in the HALF-OPEN interval [0, 1) (PMAT-757). sample_from_distribution
+      selects on `rng_value < cumsum`; a draw of exactly 1.0 matches no token and falls
+      through to the biased last-(lowest-prob)-token fallback. The naive
+      `(state >> 33) as f32 / (1<<31) as f32` yields 1.0 because 2^31-1 rounds UP to 2^31 in
+      f32; the f32-safe construction is `(state >> 40) as f32 / (1<<24) as f32`
+      (numerator exact in f32 -> strictly < 1.0). Determinism is preserved.
     preconditions:
     - seed is a valid u64
     postconditions:
@@ -147,6 +157,20 @@ proof_obligations:
     theorem: Theorems.SeedDeterminism
     status: sorry
 - type: invariant
+  property: Temperature must be finite (NaN/inf rejected)
+  formal: '!temperature.is_finite() => Err(_)'
+  applies_to: temperature_bounds
+  lean:
+    theorem: Theorems.TemperatureBounds
+    status: sorry
+- type: invariant
+  property: RNG draw value is in [0, 1)
+  formal: '0.0 <= lcg_state_to_unit_f32(s) < 1.0 for all s: u64'
+  applies_to: seed_determinism
+  lean:
+    theorem: Theorems.SeedDeterminism
+    status: sorry
+- type: invariant
   property: Penalty 1.0 is identity
   formal: 'apply_penalty(logits, _, 1.0, _) == logits'
   applies_to: repeat_penalty
@@ -198,6 +222,21 @@ falsification_tests:
   test: |
     Run apr train plan with bad --model-size, assert exit code != 0.
   if_fails: Train plan exits 0 on validation failure (GH-632)
+- id: FALSIFY-SAMP-007
+  rule: Non-finite temperature is rejected (PMAT-757)
+  prediction: apply_temperature rejects NaN / +inf / -inf with an error; positive finite still ok
+  test: |
+    cargo test -p aprender-serve --lib test_apply_temperature_rejects_non_finite
+  if_fails: NaN/inf temperature passes the `<= 0.0` guard and `logit / NaN = NaN` poisons the
+    distribution, silently biasing sampling to the last token with no error surfaced.
+- id: FALSIFY-SAMP-008
+  rule: RNG unit draw is in [0, 1) (PMAT-757)
+  prediction: lcg_state_to_unit_f32(state) is in [0,1) for all states incl. u64::MAX (which
+    the old (state>>33)/(1<<31) f32 formula mapped to exactly 1.0)
+  test: |
+    cargo test -p aprender-serve --lib test_lcg_state_to_unit_f32_in_half_open_unit_interval
+  if_fails: rng_value can equal 1.0, so `rng_value < cumsum` never matches and
+    sample_from_distribution falls through to its biased last-(lowest-prob)-token fallback.
 
 kani_harnesses:
 - id: KANI-SAMP-001

--- a/crates/aprender-serve/src/generate/mod.rs
+++ b/crates/aprender-serve/src/generate/mod.rs
@@ -40,6 +40,11 @@ pub use sampler::{
     TopPSampler,
 };
 
+// Shared [0,1) RNG-state mapper (defined in sampler_logit_chain.rs, include!d into sampler).
+// Re-exported pub(crate) so every sampling loop (here + layers::model_model) uses the one
+// f32-safe construction instead of the buggy `(state >> 33)/(1<<31)` idiom.
+pub(crate) use sampler::lcg_state_to_unit_f32;
+
 /// Sample from a probability distribution using a random value
 ///
 /// # Arguments
@@ -219,9 +224,14 @@ impl GenerationConfig {
 /// Returns error if temperature is not positive
 pub fn apply_temperature(logits: &Tensor<f32>, temperature: f32) -> Result<Tensor<f32>> {
     contract_pre_temperature!();
-    if temperature <= 0.0 {
+    // A non-finite temperature (NaN / ±inf) MUST be rejected. `NaN <= 0.0` is FALSE
+    // (IEEE-754 comparisons with NaN are unordered), so the old `temperature <= 0.0`
+    // guard let NaN through; then `x / NaN = NaN` poisons every logit -> NaN softmax ->
+    // the cumulative draw (`rng_value < cumsum`) never fires -> a silent, biased fallback
+    // to the last token, with no error surfaced. Require a positive, FINITE temperature.
+    if !temperature.is_finite() || temperature <= 0.0 {
         return Err(RealizarError::InvalidShape {
-            reason: "Temperature must be positive".to_string(),
+            reason: "Temperature must be a positive finite number".to_string(),
         });
     }
 

--- a/crates/aprender-serve/src/generate/sampler_logit_chain.rs
+++ b/crates/aprender-serve/src/generate/sampler_logit_chain.rs
@@ -162,7 +162,7 @@ impl<M: GenerativeModel> GenerationPipeline<M> {
             rng_state = rng_state
                 .wrapping_mul(6_364_136_223_846_793_005)
                 .wrapping_add(1);
-            let rng_value = (rng_state >> 33) as f32 / (1u64 << 31) as f32;
+            let rng_value = lcg_state_to_unit_f32(rng_state);
 
             let next_token = sample_token(&logits_tensor, &self.config, rng_value)? as u32;
 
@@ -201,6 +201,22 @@ impl<M: GenerativeModel> GenerationPipeline<M> {
     pub fn config(&self) -> &GenerationConfig {
         &self.config
     }
+}
+
+/// Map a 64-bit LCG state to a uniform random float in **[0, 1)**.
+///
+/// The naive `(state >> 33) as f32 / (1u64 << 31) as f32` is wrong: its max integer
+/// numerator is `2^31 - 1 = 2_147_483_647`, but f32 has only a 24-bit mantissa, so
+/// `2_147_483_647 as f32` rounds UP to `2_147_483_648.0` — exactly the divisor — yielding
+/// `rng_value == 1.0`. A draw of `1.0` makes `rng_value < cumsum` false for every token in
+/// `sample_from_distribution`, so the cumulative-distribution loop falls through to its
+/// biased last-(lowest-prob)-token fallback instead of sampling.
+///
+/// Using the top 24 bits over `2^24` keeps the numerator in `[0, 2^24 - 1]` — exactly
+/// representable in f32 — so the quotient is always strictly `< 1.0`. This is the canonical
+/// "random float in [0,1)" construction and preserves seed determinism.
+pub(crate) fn lcg_state_to_unit_f32(state: u64) -> f32 {
+    (state >> 40) as f32 / (1u64 << 24) as f32
 }
 
 // Tests extracted to tests.rs (PMAT-802)

--- a/crates/aprender-serve/src/generate/sampler_tests.rs
+++ b/crates/aprender-serve/src/generate/sampler_tests.rs
@@ -411,3 +411,45 @@ fn test_advanced_generation_config_with_stop_sequences() {
     let config = AdvancedGenerationConfig::new(base).with_stop_sequences(vec!["stop".to_string()]);
     assert!(config.stop_detector.is_some());
 }
+
+// ========================================================================
+// LCG unit-interval RNG tests (sampling RNG range bug)
+// ========================================================================
+
+#[test]
+fn test_lcg_state_to_unit_f32_in_half_open_unit_interval() {
+    // rng_value MUST be in [0, 1): sample_from_distribution does `rng_value < cumsum`,
+    // so a value of exactly 1.0 never matches and biases toward the last (lowest-prob)
+    // token. The boundary state u64::MAX is the case the OLD formula
+    // `(state >> 33) as f32 / (1u64 << 31) as f32` returned exactly 1.0 for, because
+    // (2^31-1) rounds UP to 2^31 in f32. This is the mutation guard.
+    assert!(
+        lcg_state_to_unit_f32(u64::MAX) < 1.0,
+        "max state must map strictly below 1.0, got {}",
+        lcg_state_to_unit_f32(u64::MAX)
+    );
+    assert_eq!(lcg_state_to_unit_f32(0), 0.0);
+
+    // Sweep a spread of states (mix high/low/patterned bits) — all in [0, 1).
+    for &s in &[
+        0u64,
+        1,
+        42,
+        1 << 40,
+        (1 << 40) - 1,
+        u64::MAX - 1,
+        u64::MAX,
+        0x8000_0000_0000_0000,
+        0xFFFF_FFFF_0000_0000,
+        12_345_678_901_234_567,
+    ] {
+        let v = lcg_state_to_unit_f32(s);
+        assert!((0.0..1.0).contains(&v), "rng_value {v} out of [0,1) for state {s}");
+    }
+}
+
+#[test]
+fn test_lcg_state_to_unit_f32_is_deterministic() {
+    // Same state => same value (seed determinism precondition).
+    assert_eq!(lcg_state_to_unit_f32(99), lcg_state_to_unit_f32(99));
+}

--- a/crates/aprender-serve/src/generate/tests_generation_config.rs
+++ b/crates/aprender-serve/src/generate/tests_generation_config.rs
@@ -52,6 +52,28 @@
     }
 
     #[test]
+    fn test_apply_temperature_rejects_non_finite() {
+        // A non-finite temperature must be rejected, NOT silently scaled. `NaN <= 0.0` is
+        // false (IEEE-754 unordered), so the old `temperature <= 0.0` guard let NaN/inf
+        // through and `x / NaN = NaN` poisoned every logit -> silent garbage sampling.
+        let logits = Tensor::from_vec(vec![4], vec![1.0, 2.0, 3.0, 4.0]).expect("test");
+        assert!(
+            apply_temperature(&logits, f32::NAN).is_err(),
+            "NaN temperature must be rejected"
+        );
+        assert!(
+            apply_temperature(&logits, f32::INFINITY).is_err(),
+            "+inf temperature must be rejected"
+        );
+        assert!(
+            apply_temperature(&logits, f32::NEG_INFINITY).is_err(),
+            "-inf temperature must be rejected"
+        );
+        // A positive finite temperature still succeeds (no regression).
+        assert!(apply_temperature(&logits, 0.7).is_ok());
+    }
+
+    #[test]
     fn test_sample_greedy() {
         // Clear winner at index 2
         let logits = Tensor::from_vec(vec![5], vec![1.0, 2.0, 10.0, 3.0, 4.0]).expect("test");

--- a/crates/aprender-serve/src/layers/model_model.rs
+++ b/crates/aprender-serve/src/layers/model_model.rs
@@ -153,8 +153,9 @@ impl Model {
             rng_state = rng_state
                 .wrapping_mul(6_364_136_223_846_793_005)
                 .wrapping_add(1);
-            #[allow(clippy::cast_precision_loss)]
-            let rng_value = (rng_state >> 33) as f32 / (1u64 << 31) as f32;
+            // PMAT-757: f32-safe [0,1) mapping. The old `(state >> 33)/(1<<31)` rounded its
+            // max numerator UP to 2^31 in f32 -> rng_value == 1.0 -> biased last-token draw.
+            let rng_value = crate::generate::lcg_state_to_unit_f32(rng_state);
 
             // Sample next token
             let next_token = sample_token(&last_logits_tensor, config, rng_value)?;

--- a/evidence/sampling-adversarial-audit-2026-06-14/findings.md
+++ b/evidence/sampling-adversarial-audit-2026-06-14/findings.md
@@ -1,0 +1,65 @@
+# Decode sampling subsystem — adversarial bug-hunt (2026-06-14)
+
+Adversarial bug-hunt over `crates/aprender-serve/src/generate/` (the decode sampling path):
+6 finder dimensions (temperature, top-k, top-p, penalties, chain-order, RNG/draw) → each
+finding pipelined into a default-refute skeptic verifier → confirmed-only. **28 findings
+verified → 13 REAL, 15 refuted.** Two of the 13 are "confirmed CORRECT" (the skeptic upheld
+the code). All findings were re-checked by hand against the actual source before action —
+the skeptic verdicts are good but not infallible (see item 10).
+
+## FIXED this PR (PMAT-757 — sampling degenerate-input robustness)
+
+- **[1] NaN temperature not rejected** (`generate/mod.rs:apply_temperature`). `f32::NAN <= 0.0`
+  is false (IEEE-754 unordered) → NaN passed the guard → `x / NaN = NaN` for every logit →
+  NaN softmax → `rng_value < cumsum` never fires → silent biased fallback to the last token,
+  no error. Fix: `!temperature.is_finite() || temperature <= 0.0`. Falsifier
+  `test_apply_temperature_rejects_non_finite` (mutation-verified).
+- **[11/13] RNG draw can equal 1.0** (`generate/sampler_logit_chain.rs`). Integer math
+  `(state>>33)/2^31` is mathematically [0,1), but `2^31-1 as f32` rounds UP to `2^31.0`
+  → `rng_value == 1.0` → `rng_value < cumsum` never matches → biased last-token fallback.
+  Fix: extracted `lcg_state_to_unit_f32` using the f32-safe 24-bit/2^24 construction
+  (numerator exact in f32 → strictly < 1.0). Falsifier
+  `test_lcg_state_to_unit_f32_in_half_open_unit_interval` (mutation-verified at u64::MAX).
+- **[+] Same f32 LCG bug in a second live sampling loop** (`layers/model_model.rs:157`) —
+  fixed to reuse the shared helper (Toyota Way: root-cause all instances). The f64 LCG
+  copies (`cli/display_utils.rs`, `cli/benchmark.rs`) are CORRECT — f64 represents 2^31-1
+  exactly, no rounding to 1.0 — left unchanged.
+
+Co-evolution: contract `apr-cli-sampling-v1` → 1.1.0 (temperature-finite + RNG-[0,1)
+invariants, FALSIFY-SAMP-007/008, 2 proof obligations).
+
+## Confirmed CORRECT (no action — documents that these are NOT bugs)
+
+- **[7] Top-p nucleus cutoff** (`build_nucleus`): pushes the token THEN checks `cumsum >= p`,
+  so the boundary token that crosses p is INCLUDED — matches HF/llama.cpp. Correct.
+- **[9] Repetition-penalty sign** (`sampler.rs`): asymmetric divide-if-positive-else-multiply
+  rule, matches HF `RepetitionPenaltyLogitsProcessor`. Correct.
+
+## FALSE POSITIVE (skeptic erred; rejected on hand re-check)
+
+- **[10] "Top-k computes softmax on the subset, not full vocab"** — NOT a bug. Softmax over
+  the kept set is mathematically identical to full-vocab softmax then renormalizing the kept
+  set: `e^{x_i}/Σ_{j∈S} e^{x_j}` either way. No distribution error.
+
+## DEFERRED (real but separate scope — tracked follow-ups)
+
+- **[2] temperature==0 = error vs greedy** (`apply_temperature` rejects ≤0). Several backends
+  already special-case `temperature==0` via `top_k=1` BEFORE calling apply_temperature
+  (cuda/quantized configs); the registry/CPU path does not. Multi-backend semantics
+  reconciliation — own PR. (PMAT-757's finite-check is orthogonal: it keeps rejecting 0,
+  which should be routed to greedy upstream.)
+- **[4/5] TopKSampler.apply() vs sample_top_k() k=0 / k>=vocab divergence**
+  (`sampler_topk.rs`): TopKSampler.apply() no-ops on k=0 (≈ "disabled", the llama.cpp
+  convention) while sample_top_k() errors. Needs a convention decision (k=0 = disabled?) +
+  alignment — own PR.
+- **[6/8] TopPSampler::new accepts unvalidated p** (p>1 / p≤0): constructor validation gap —
+  own PR (bundle with [4/5] as "sampler-struct input validation").
+- **[3] No API-layer temperature bound check** (`api/types.rs`): bare f32 → generic 500
+  instead of 400 on bad input. Defense-in-depth at the HTTP boundary; [1] already fixes the
+  core NaN propagation. Own PR (bundle with serve-API param-plumbing audit items 7-10).
+
+## Method
+Parallel finders → skeptic verification (default-refute). Several findings cite the
+codebase's OWN reference (HF asymmetric penalty; llama.cpp temp/greedy; f64 LCG copies).
+Each FIXED item ships a unit falsifier + mutation verification (restore the bug, confirm the
+test fails) + a contract obligation.


### PR DESCRIPTION
Two degenerate-input correctness bugs in the decode sampling path, found by an **adversarial bug-hunt** (28 findings → 13 confirmed REAL; 15 refuted). Both silently corrupt the sampled token distribution with **no error surfaced**.

**1. NaN temperature** (`generate/mod.rs` `apply_temperature`): `f32::NAN <= 0.0` is **false** (IEEE-754 unordered), so the `temperature <= 0.0` guard let NaN/±inf pass → `logit / NaN = NaN` poisons every logit → NaN softmax → `rng_value < cumsum` never fires → silent biased fallback to the last token. Fix: require a positive **finite** temperature.

**2. RNG draw could equal 1.0** (`generate/sampler_logit_chain.rs`): integer `(state>>33)/2³¹` is mathematically `[0,1)`, but `2³¹-1 as f32` rounds **up** to `2³¹.0` → `rng_value == 1.0`. `sample_from_distribution` selects on `rng_value < cumsum`, so 1.0 matches no token → biased last-(lowest-prob)-token fallback. Fix: shared f32-safe `lcg_state_to_unit_f32` (24-bit/2²⁴ → numerator exact in f32 → strictly `< 1.0`); determinism preserved.

**Root-cause all instances (Toyota Way):** the same f32 LCG idiom in a second live sampling loop (`layers/model_model.rs:157`) now reuses the helper. The f64 LCG copies (`cli/display_utils.rs`, `cli/benchmark.rs`) are **correct** (f64 represents 2³¹-1 exactly) — left unchanged.

**Co-evolution (Rule 7):** contract `apr-cli-sampling-v1` → **1.1.0** (temperature-finite + RNG-[0,1) invariants, 2 proof obligations, FALSIFY-SAMP-007/008). Falsifiers `test_apply_temperature_rejects_non_finite` + `test_lcg_state_to_unit_f32_in_half_open_unit_interval`, both **mutation-verified** (restore the bug → the test fails). Full serve lib suite **15292 pass**; build/fmt/clippy/`pv validate` clean.

**Triage (in the evidence findings):** 2 confirmed-CORRECT (nucleus cutoff, penalty sign); 1 **false positive** ruled out ("top-k softmax on subset" ≡ renormalized full softmax); 4 real-but-deferred to own PRs (temp==0 greedy routing; TopK/TopP struct validation; API-layer temp bound).

🤖 Generated with [Claude Code](https://claude.com/claude-code)