### PR TITLE
fix(serve): streaming chat — UTF-8 split + stop ignored in SSE handler (PMAT-758)

### DIFF
--- a/contracts/apr-serve-openai-compat-v1.yaml
+++ b/contracts/apr-serve-openai-compat-v1.yaml
@@ -1,7 +1,7 @@
 contract: apr-serve-openai-compat
 metadata:
   kind: pattern
-  version: "1.3.0"
+  version: "1.4.0"
   description: >
     OpenAI-compatible serve layer (/v1/chat/completions, /v1/completions) fidelity
     invariants. Established by an adversarial audit (2026-06-14) that found 12 confirmed
@@ -41,13 +41,21 @@ proof_obligations:
       builder (which bypasses build_chat_response) also calls finalize_chat_text — together
       with finish_reason="stop" when a stop string truncated (precedence over "length")
       (PMAT-756).
-      OPEN (tracked, NOT covered): the STREAMING chat paths — pregenerated_sse_response,
-      true_streaming_sse_response, chat_completions_stream.rs — decode/emit token-by-token
-      and do NOT apply stop; correct streaming stop needs incremental cross-token stop
-      detection + partial-final-chunk emission, the same cross-token buffer the UTF-8
-      stream-split fix (audit item 2) requires, so they ship as one combined follow-up.
+      STREAMING: chat_completions_stream.rs (the openai_chat_completions_stream_handler) now
+      applies stop via streaming_text_deltas() (PMAT-758, DISCHARGED for this handler).
+      STILL OPEN: pregenerated_sse_response + true_streaming_sse_response (the cuda/gpu/cached
+      chat streaming backends) — the live-channel path needs incremental cross-token stop
+      detection; tracked follow-up.
       Residual nicety (non-blocking): the try_cuda_gguf_completions inline form truncates at
       the first-LISTED stop, not the earliest-POSITION one — should migrate to the helper.
+  - type: invariant
+    property: >
+      STREAM-UTF8 (PARTIAL — PMAT-758): streamed SSE deltas must be valid UTF-8 — never a
+      U+FFFD replacement char from decoding a single token that is one byte of a multi-byte
+      char. chat_completions_stream.rs decodes CUMULATIVE token prefixes and holds back a
+      delta until the trailing multi-byte char completes (the HF TextStreamer technique).
+      STILL OPEN: pregenerated_sse_response + true_streaming_sse_response apply the same
+      per-token decode_token() and need the same cumulative/byte-buffer treatment.
   - type: invariant
     property: >
       PARAMS-PLUMBED (open — audit items 7-10): request params (n, seed, top_k,
@@ -67,6 +75,12 @@ falsification_tests:
     test_harness: 'cargo test -p aprender-serve --lib pmat756_chat_stop_tests'
     expected_output: "test result: ok"
     if_fails: 'The /v1/chat/completions response contains the stop string / runs to max_tokens past it (the pre-PMAT-756 behavior — the chat path ignored request.stop entirely), or finish_reason mislabels a stop-truncated message as "length".'
+  - id: FALSIFY-STREAM-DELTA-758
+    name: pmat758_streaming_delta_tests
+    prediction: 'streaming_text_deltas(tokenizer, token_ids, stops) decodes cumulative token prefixes and (a) holds back a delta until a multi-byte UTF-8 char completes — a 4-token 😀 (F0 9F 98 80) yields a single "😀", never U+FFFD; (b) truncates at the earliest stop and halts emission — "abXc" with stop ["X"] streams "ab", never containing "X"; (c) stops=None streams the full text. chat_completions_stream.rs streams these precomputed deltas.'
+    test_harness: 'cargo test -p aprender-serve --lib pmat758_streaming_delta_tests'
+    expected_output: "test result: ok"
+    if_fails: 'The streaming chat handler emits U+FFFD replacement chars for emoji/CJK that span tokens (per-token decode), or leaks the stop string into the stream — the pre-PMAT-758 behavior of openai_chat_completions_stream_handler.'
   - id: FALSIFY-SSE-FRAMING-753
     name: chat_completions_stream_no_double_data_prefix
     prediction: 'chat_completions_stream.rs yields Event::default().data(<bare json>) / .data("[DONE]") — no occurrence of Event::default().data(format!("data: ...")) (which double-prefixes the SSE wire format). Shape gate: catches re-introduction of the manual prefix.'

--- a/crates/aprender-serve/src/api/chat_completions_stream.rs
+++ b/crates/aprender-serve/src/api/chat_completions_stream.rs
@@ -1,4 +1,44 @@
 
+/// Produce char-boundary-safe streaming text deltas from a fully-generated token list.
+///
+/// Fixes two bugs on this pregenerated SSE path (PMAT-758):
+/// 1. **UTF-8 splitting** — decoding one token at a time runs `String::from_utf8_lossy` on
+///    an incomplete byte sequence (a byte-level BPE token can be a single byte of a
+///    multi-byte char), so emoji / CJK that span tokens emit U+FFFD replacement chars. We
+///    decode cumulative prefixes and only advance the emitted offset once the decoded text
+///    no longer ends in U+FFFD — i.e. once the multi-byte char is complete (the HuggingFace
+///    `TextStreamer` technique).
+/// 2. **Stop sequences ignored** — the cumulative text is truncated at the EARLIEST stop via
+///    the shared `truncate_at_stop` helper, and emission stops as soon as a stop matches, so
+///    the streamed text never contains a stop string.
+fn streaming_text_deltas(
+    tokenizer: &BPETokenizer,
+    token_ids: &[u32],
+    stops: Option<&[String]>,
+) -> Vec<String> {
+    let mut deltas = Vec::new();
+    let mut emitted = 0usize;
+    for i in 0..token_ids.len() {
+        let Ok(raw) = tokenizer.decode(&token_ids[..=i]) else {
+            continue;
+        };
+        let text = crate::api::realize_handlers::truncate_at_stop(raw.clone(), stops);
+        let stop_hit = text.len() < raw.len();
+        // Hold back a delta that ends mid-multibyte-char (trailing U+FFFD) until it completes.
+        if !stop_hit && text.ends_with('\u{FFFD}') {
+            continue;
+        }
+        if text.len() > emitted && text.is_char_boundary(emitted) {
+            deltas.push(text[emitted..].to_string());
+            emitted = text.len();
+        }
+        if stop_hit {
+            break;
+        }
+    }
+    deltas
+}
+
 /// OpenAI-compatible /v1/chat/completions streaming endpoint (SSE)
 pub async fn openai_chat_completions_stream_handler(
     State(state): State<AppState>,
@@ -72,26 +112,23 @@ pub async fn openai_chat_completions_stream_handler(
     let generated_ids = token_ids[prompt_len..].to_vec();
     let model_name = request.model.clone();
     let request_id_clone = request_id.clone();
-    let tokenizer_clone = tokenizer;
+
+    // PMAT-758: precompute char-safe, stop-truncated deltas BEFORE streaming. The previous
+    // per-token `decode(&[token_id])` split multi-byte UTF-8 (emoji/CJK -> U+FFFD) and
+    // ignored request.stop entirely. All tokens are already generated here, so we can decode
+    // cumulatively and emit only complete-char, pre-stop deltas.
+    let deltas = streaming_text_deltas(&tokenizer, &generated_ids, request.stop.as_deref());
 
     let stream = async_stream::stream! {
         // PMAT-753: pass ONLY the JSON payload to Event::data() — axum's Sse adds the
-        // `data: ` field prefix and the `\n\n` terminator itself. The previous
-        // `format!("data: {}\n", data)` produced a DOUBLE prefix on the wire
-        // (`data: data: {json}`), so spec-compliant SSE clients received the literal
-        // string "data: {json}" as the event data and JSON.parse failed → streaming
-        // was broken for every client. Matches the correct form in openai_handlers.rs.
+        // `data: ` field prefix and the `\n\n` terminator itself. A manual `data: ` prefix
+        // would double-prefix the wire and break JSON.parse for every spec-compliant client.
         let initial = ChatCompletionChunk::initial(&request_id_clone, &model_name);
         let data = serde_json::to_string(&initial).unwrap_or_default();
         yield Ok(Event::default().data(data));
 
-        for &token_id in &generated_ids {
-            let text = match tokenizer_clone.decode(&[token_id]) {
-                Ok(t) => t,
-                Err(_) => continue,
-            };
-
-            let chunk = ChatCompletionChunk::content(&request_id_clone, &model_name, &text);
+        for delta in &deltas {
+            let chunk = ChatCompletionChunk::content(&request_id_clone, &model_name, delta);
             let data = serde_json::to_string(&chunk).unwrap_or_default();
             yield Ok(Event::default().data(data));
         }
@@ -104,4 +141,48 @@ pub async fn openai_chat_completions_stream_handler(
     };
 
     Ok(Sse::new(stream))
+}
+
+#[cfg(test)]
+mod pmat758_streaming_delta_tests {
+    use super::*;
+
+    fn tok(vocab: &[&str]) -> BPETokenizer {
+        BPETokenizer::new(
+            vocab.iter().map(|s| (*s).to_string()).collect(),
+            vec![],
+            "<unk>",
+        )
+        .expect("test tokenizer")
+    }
+
+    #[test]
+    fn holds_back_multibyte_utf8_until_complete() {
+        // 😀 = U+1F600 = bytes F0 9F 98 80, one byte per token. The old per-token
+        // decode(&[id]) ran from_utf8_lossy on each single byte -> four U+FFFD. Cumulative
+        // decode must hold back until the char completes, emitting a single "😀".
+        let t = tok(&["<unk>", "<0xF0>", "<0x9F>", "<0x98>", "<0x80>"]);
+        let deltas = streaming_text_deltas(&t, &[1, 2, 3, 4], None);
+        assert_eq!(deltas.concat(), "😀");
+        assert!(
+            !deltas.concat().contains('\u{FFFD}'),
+            "no replacement chars in streamed deltas"
+        );
+    }
+
+    #[test]
+    fn applies_stop_and_halts_emission() {
+        // "abXc" with stop ["X"] -> streamed text is "ab", never contains the stop string.
+        let t = tok(&["<unk>", "a", "b", "X", "c"]);
+        let deltas = streaming_text_deltas(&t, &[1, 2, 3, 4], Some(&["X".to_string()]));
+        assert_eq!(deltas.concat(), "ab");
+        assert!(!deltas.concat().contains('X'));
+    }
+
+    #[test]
+    fn no_stop_streams_full_text() {
+        let t = tok(&["<unk>", "a", "b", "X", "c"]);
+        let deltas = streaming_text_deltas(&t, &[1, 2, 3, 4], None);
+        assert_eq!(deltas.concat(), "abXc");
+    }
 }

--- a/evidence/serve-api-openai-fidelity-audit-2026-06-14/findings.md
+++ b/evidence/serve-api-openai-fidelity-audit-2026-06-14/findings.md
@@ -12,9 +12,12 @@ prioritized; fixed incrementally (one coherent cluster per PR).
    `data: ` field itself → wire was `data: data: {json}`, so spec clients `JSON.parse`
    the literal "data: {json}" and fail. **Streaming broken for every client.** Fixed to
    `Event::default().data(json)` (matches the correct `openai_handlers.rs` form).
-2. **[TODO]** Multi-byte UTF-8 split across tokens (`chat_completions_stream.rs:83`):
-   `decode(&[token_id])` per token → emoji/CJK spanning two tokens emit replacement
-   chars. Needs a cross-token byte buffer (decode longest valid UTF-8 prefix, carry rest).
+2. **[FIXED PMAT-758 (chat_completions_stream)]** Multi-byte UTF-8 split across tokens:
+   per-token `decode(&[token_id])` ran `from_utf8_lossy` on incomplete bytes → emoji/CJK
+   spanning tokens emitted U+FFFD. `openai_chat_completions_stream_handler` now precomputes
+   `streaming_text_deltas()` (cumulative decode, hold back until the char completes) which
+   ALSO applies stop. Covered by FALSIFY-STREAM-DELTA-758. STILL OPEN: the same per-token
+   `decode_token()` in `pregenerated_sse_response` + `true_streaming_sse_response`.
 
 ## Stop sequences ignored (HIGH) — model doesn't stop / leaks stop text
 3. **[FIXED PMAT-754]** `try_cached_completions` (realize_handlers_embed_completion.rs) — now applies stop via shared truncate_at_stop().


### PR DESCRIPTION
Serve-API audit items 2 + 6-streaming. `openai_chat_completions_stream_handler` streamed one token per SSE chunk via `decode(&[token_id])`, which:
- **(a) UTF-8 split** — ran `from_utf8_lossy` on an incomplete byte sequence (a byte-level BPE token can be one byte of a multi-byte char) → emoji/CJK spanning tokens emitted **U+FFFD** replacement chars;
- **(b) ignored `request.stop`** — the streamed message kept the stop string and ran to max_tokens.

**Fix:** all tokens are already generated here, so precompute char-safe deltas with a new pure, unit-tested `streaming_text_deltas(tokenizer, token_ids, stops)`:
- decode **cumulative** token prefixes; only advance once the text no longer ends in U+FFFD (HF `TextStreamer` technique) → multi-byte chars held back until complete;
- truncate each cumulative text at the **earliest** stop (shared `truncate_at_stop`, PMAT-754) and halt emission once a stop matches.

**Falsifier** `FALSIFY-STREAM-DELTA-758` / `pmat758_streaming_delta_tests` (3 cases: 4-token 😀 → single "😀" no U+FFFD; "abXc" + stop ["X"] → "ab"; None → full text). **Both behaviors mutation-verified** (remove U+FFFD hold-back → emoji test fails; no-op stop → stop test fails). Full serve lib suite **15302 pass**; build/fmt/clippy/`pv validate` clean.

**Co-evolution (Rule 7):** contract `apr-serve-openai-compat-v1` → **1.4.0** — STOP-APPLIED streaming partially discharged (this handler) + new STREAM-UTF8 obligation. **Still OPEN (tracked):** `pregenerated_sse_response` + `true_streaming_sse_response` use the same per-token decode (the live-channel path needs incremental cross-token detection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)