### PR TITLE
fix(serve): streaming chat — UTF-8 split + stop in pregenerated SSE backends (PMAT-759)

### DIFF
--- a/contracts/apr-serve-openai-compat-v1.yaml
+++ b/contracts/apr-serve-openai-compat-v1.yaml
@@ -1,7 +1,7 @@
 contract: apr-serve-openai-compat
 metadata:
   kind: pattern
-  version: "1.4.0"
+  version: "1.5.0"
   description: >
     OpenAI-compatible serve layer (/v1/chat/completions, /v1/completions) fidelity
     invariants. Established by an adversarial audit (2026-06-14) that found 12 confirmed
@@ -41,21 +41,23 @@ proof_obligations:
       builder (which bypasses build_chat_response) also calls finalize_chat_text — together
       with finish_reason="stop" when a stop string truncated (precedence over "length")
       (PMAT-756).
-      STREAMING: chat_completions_stream.rs (the openai_chat_completions_stream_handler) now
-      applies stop via streaming_text_deltas() (PMAT-758, DISCHARGED for this handler).
-      STILL OPEN: pregenerated_sse_response + true_streaming_sse_response (the cuda/gpu/cached
-      chat streaming backends) — the live-channel path needs incremental cross-token stop
-      detection; tracked follow-up.
+      STREAMING (PRE-GENERATED paths DISCHARGED — PMAT-758/759): chat_completions_stream.rs
+      (PMAT-758) AND pregenerated_sse_response (PMAT-759, the cuda/gpu/cached chat streaming
+      backends + registry fallback) now apply stop via streaming_text_deltas(). STILL OPEN:
+      true_streaming_sse_response (the live mpsc-channel path) — needs incremental cross-token
+      stop detection; tracked follow-up.
       Residual nicety (non-blocking): the try_cuda_gguf_completions inline form truncates at
       the first-LISTED stop, not the earliest-POSITION one — should migrate to the helper.
   - type: invariant
     property: >
-      STREAM-UTF8 (PARTIAL — PMAT-758): streamed SSE deltas must be valid UTF-8 — never a
-      U+FFFD replacement char from decoding a single token that is one byte of a multi-byte
-      char. chat_completions_stream.rs decodes CUMULATIVE token prefixes and holds back a
-      delta until the trailing multi-byte char completes (the HF TextStreamer technique).
-      STILL OPEN: pregenerated_sse_response + true_streaming_sse_response apply the same
-      per-token decode_token() and need the same cumulative/byte-buffer treatment.
+      STREAM-UTF8 (PRE-GENERATED paths DISCHARGED — PMAT-758/759): streamed SSE deltas must be
+      valid UTF-8 — never a U+FFFD replacement char from decoding a single token that is one
+      byte of a multi-byte char. chat_completions_stream.rs (PMAT-758) and
+      pregenerated_sse_response (PMAT-759) decode CUMULATIVE token prefixes via
+      streaming_text_deltas() and hold back a delta until the trailing multi-byte char
+      completes (the HF TextStreamer technique). STILL OPEN: true_streaming_sse_response uses
+      the per-token decode_token() and needs an incremental cross-token byte buffer (the
+      live-channel path can't precompute the full token list).
   - type: invariant
     property: >
       PARAMS-PLUMBED (open — audit items 7-10): request params (n, seed, top_k,
@@ -77,7 +79,7 @@ falsification_tests:
     if_fails: 'The /v1/chat/completions response contains the stop string / runs to max_tokens past it (the pre-PMAT-756 behavior — the chat path ignored request.stop entirely), or finish_reason mislabels a stop-truncated message as "length".'
   - id: FALSIFY-STREAM-DELTA-758
     name: pmat758_streaming_delta_tests
-    prediction: 'streaming_text_deltas(tokenizer, token_ids, stops) decodes cumulative token prefixes and (a) holds back a delta until a multi-byte UTF-8 char completes — a 4-token 😀 (F0 9F 98 80) yields a single "😀", never U+FFFD; (b) truncates at the earliest stop and halts emission — "abXc" with stop ["X"] streams "ab", never containing "X"; (c) stops=None streams the full text. chat_completions_stream.rs streams these precomputed deltas.'
+    prediction: 'streaming_text_deltas(tokenizer, token_ids, stops) decodes cumulative token prefixes and (a) holds back a delta until a multi-byte UTF-8 char completes — a 4-token 😀 (F0 9F 98 80) yields a single "😀", never U+FFFD; (b) truncates at the earliest stop and halts emission — "abXc" with stop ["X"] streams "ab", never containing "X"; (c) stops=None streams the full text. BOTH pre-generated streaming paths — chat_completions_stream.rs (PMAT-758) and pregenerated_sse_response (PMAT-759) — stream these precomputed deltas.'
     test_harness: 'cargo test -p aprender-serve --lib pmat758_streaming_delta_tests'
     expected_output: "test result: ok"
     if_fails: 'The streaming chat handler emits U+FFFD replacement chars for emoji/CJK that span tokens (per-token decode), or leaks the stop string into the stream — the pre-PMAT-758 behavior of openai_chat_completions_stream_handler.'

--- a/crates/aprender-serve/src/api/cuda_chat_backend.rs
+++ b/crates/aprender-serve/src/api/cuda_chat_backend.rs
@@ -383,7 +383,7 @@ fn registry_fallback(
             tokenizer,
             request_id.to_string(),
             request.model.clone(),
-            false,
+            request.stop.as_deref(),
         );
     }
 

--- a/crates/aprender-serve/src/api/openai_handlers.rs
+++ b/crates/aprender-serve/src/api/openai_handlers.rs
@@ -202,24 +202,29 @@ fn decode_token(tokenizer: &BPETokenizer, token_id: u32, clean: bool) -> Option<
 }
 
 /// Build a pre-generated SSE streaming response (all tokens already generated).
+///
+/// PMAT-759: precompute char-safe, stop-truncated deltas (the same fix as PMAT-758's
+/// chat_completions_stream handler) — the previous per-token `decode_token()` split
+/// multi-byte UTF-8 (emoji/CJK -> U+FFFD) and ignored request.stop on the cuda/gpu/cached
+/// chat STREAMING backends (the production GPU streaming path). All three callers passed
+/// `clean = false`, so the old `clean` param is dropped in favour of `stops`.
 fn pregenerated_sse_response(
     token_ids: Vec<u32>,
     tokenizer: Arc<BPETokenizer>,
     request_id: String,
     model_name: String,
-    clean: bool,
+    stops: Option<&[String]>,
 ) -> Response {
+    let deltas = streaming_text_deltas(&tokenizer, &token_ids, stops);
     let stream = async_stream::stream! {
         if let Some(evt) = sse_event(&ChatCompletionChunk::initial(&request_id, &model_name)) {
             yield evt;
         }
 
-        for &token_id in &token_ids {
-            if let Some(text) = decode_token(&tokenizer, token_id, clean) {
-                let chunk = ChatCompletionChunk::content(&request_id, &model_name, &text);
-                if let Some(evt) = sse_event(&chunk) {
-                    yield evt;
-                }
+        for delta in &deltas {
+            let chunk = ChatCompletionChunk::content(&request_id, &model_name, delta);
+            if let Some(evt) = sse_event(&chunk) {
+                yield evt;
             }
         }
 
@@ -363,7 +368,7 @@ fn try_gpu_backend(
             tokenizer,
             request_id.to_string(),
             request.model.clone(),
-            false,
+            request.stop.as_deref(),
         ));
     }
 
@@ -443,7 +448,7 @@ fn try_cached_backend(
             tokenizer,
             request_id.to_string(),
             request.model.clone(),
-            false,
+            request.stop.as_deref(),
         ));
     }
 

--- a/evidence/serve-api-openai-fidelity-audit-2026-06-14/findings.md
+++ b/evidence/serve-api-openai-fidelity-audit-2026-06-14/findings.md
@@ -17,7 +17,8 @@ prioritized; fixed incrementally (one coherent cluster per PR).
    spanning tokens emitted U+FFFD. `openai_chat_completions_stream_handler` now precomputes
    `streaming_text_deltas()` (cumulative decode, hold back until the char completes) which
    ALSO applies stop. Covered by FALSIFY-STREAM-DELTA-758. STILL OPEN: the same per-token
-   `decode_token()` in `pregenerated_sse_response` + `true_streaming_sse_response`.
+   `decode_token()` in `true_streaming_sse_response` (PMAT-759 fixed `pregenerated_sse_response`
+   — the cuda/gpu/cached chat streaming backends — by routing it through the same helper).
 
 ## Stop sequences ignored (HIGH) — model doesn't stop / leaks stop text
 3. **[FIXED PMAT-754]** `try_cached_completions` (realize_handlers_embed_completion.rs) — now applies stop via shared truncate_at_stop().


### PR DESCRIPTION
Extends **PMAT-758** to `pregenerated_sse_response` — the **cuda / gpu / cached chat streaming backends** (the production GPU streaming path) + the registry fallback. Same two bugs: per-token `decode_token()` ran `from_utf8_lossy` on incomplete bytes (emoji/CJK spanning tokens → **U+FFFD**) and **ignored `request.stop`**.

**Fix:** `pregenerated_sse_response` now precomputes char-safe, stop-truncated deltas via the shared `streaming_text_deltas()` helper (PMAT-758) — cumulative decode with U+FFFD hold-back + earliest-stop truncation. All 3 callers passed `clean=false`, so the dead `clean` param is replaced by `stops`, threaded as `request.stop.as_deref()` at each site (try_gpu / try_cached / registry_fallback).

Covered by the existing **FALSIFY-STREAM-DELTA-758** (both pre-generated paths now route through the mutation-verified helper). Full serve lib suite **15302 pass**; build/fmt/clippy/`pv validate` clean.

**Co-evolution (Rule 7):** contract `apr-serve-openai-compat-v1` → **1.5.0** — STOP-APPLIED + STREAM-UTF8 now **discharged for all pre-generated streaming paths**. **Still OPEN (tracked):** `true_streaming_sse_response` (the live mpsc-channel path) needs an incremental cross-token byte buffer + stop detection (can't precompute the full token list) — its own follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)