### PR TITLE
fix(serve): honor request top_k in /v1/chat/completions backends (PMAT-760)

### DIFF
--- a/contracts/apr-serve-openai-compat-v1.yaml
+++ b/contracts/apr-serve-openai-compat-v1.yaml
@@ -1,7 +1,7 @@
 contract: apr-serve-openai-compat
 metadata:
   kind: pattern
-  version: "1.5.0"
+  version: "1.6.0"
   description: >
     OpenAI-compatible serve layer (/v1/chat/completions, /v1/completions) fidelity
     invariants. Established by an adversarial audit (2026-06-14) that found 12 confirmed
@@ -60,9 +60,16 @@ proof_obligations:
       live-channel path can't precompute the full token list).
   - type: invariant
     property: >
-      PARAMS-PLUMBED (open — audit items 7-10): request params (n, seed, top_k,
-      temperature) are honored or explicitly rejected, never silently dropped; the
-      OpenAI-compat temperature default is 1.0 (the codebase's default_temperature()).
+      PARAMS-PLUMBED (PARTIAL — audit items 7-10): request params are honored or explicitly
+      rejected, never silently dropped. top_k DISCHARGED for /v1/chat/completions (PMAT-760):
+      all 4 chat backends (try_gpu/try_cached in openai_handlers, try_cuda/try_quantized in
+      cuda_chat_backend) now resolve top_k via resolve_chat_top_k(temperature, request.top_k)
+      — honor the request's top_k, default 40, temperature==0 (or top_k==1) forces greedy —
+      instead of the hardcoded `if temperature == 0.0 { 1 } else { 40 }` that dropped it
+      (drift from batch.rs which honors it). STILL OPEN: n accepted-but-ignored (should
+      reject n>1), seed not plumbed to dense backends, temperature default 0.7 vs OpenAI 1.0
+      (default_temperature()); and /v1/completions has no top_k field at all (CompletionRequest
+      would need it added — non-standard for completions, deferred).
 
 falsification_tests:
   - id: FALSIFY-STOP-TRUNCATE-754
@@ -83,6 +90,12 @@ falsification_tests:
     test_harness: 'cargo test -p aprender-serve --lib pmat758_streaming_delta_tests'
     expected_output: "test result: ok"
     if_fails: 'The streaming chat handler emits U+FFFD replacement chars for emoji/CJK that span tokens (per-token decode), or leaks the stop string into the stream — the pre-PMAT-758 behavior of openai_chat_completions_stream_handler.'
+  - id: FALSIFY-TOPK-760
+    name: pmat760_top_k_tests
+    prediction: 'resolve_chat_top_k(temperature, requested) honors the request top_k: resolve_chat_top_k(0.7, Some(10)) == 10; None => 40; temperature 0.0 => 1 (greedy) regardless of requested; explicit Some(1) => 1 at any temperature. All 4 /v1/chat/completions backends use it so a client-set top_k is no longer dropped for the hardcoded 40.'
+    test_harness: 'cargo test -p aprender-serve --lib pmat760_top_k_tests'
+    expected_output: "test result: ok"
+    if_fails: 'A chat backend ignores request.top_k and samples with the hardcoded 40 (the pre-PMAT-760 behavior), so a client-specified top_k has no effect on the output distribution.'
   - id: FALSIFY-SSE-FRAMING-753
     name: chat_completions_stream_no_double_data_prefix
     prediction: 'chat_completions_stream.rs yields Event::default().data(<bare json>) / .data("[DONE]") — no occurrence of Event::default().data(format!("data: ...")) (which double-prefixes the SSE wire format). Shape gate: catches re-introduction of the manual prefix.'

--- a/crates/aprender-serve/src/api/cuda_chat_backend.rs
+++ b/crates/aprender-serve/src/api/cuda_chat_backend.rs
@@ -110,7 +110,7 @@ async fn try_cuda_backend(
     let q_config = QuantizedGenerateConfig {
         max_tokens,
         temperature,
-        top_k: if temperature == 0.0 { 1 } else { 40 },
+        top_k: resolve_chat_top_k(temperature, request.top_k),
         stop_tokens: vec![eos_token_id],
         trace: state.should_trace(trace_level),
         ..Default::default()
@@ -251,7 +251,7 @@ fn try_quantized_backend(
     let q_config = QuantizedGenerateConfig {
         max_tokens,
         temperature,
-        top_k: if temperature == 0.0 { 1 } else { 40 },
+        top_k: resolve_chat_top_k(temperature, request.top_k),
         stop_tokens: vec![eos_token_id],
         trace: state.should_trace(trace_level),
         ..Default::default()

--- a/crates/aprender-serve/src/api/openai_handlers.rs
+++ b/crates/aprender-serve/src/api/openai_handlers.rs
@@ -105,6 +105,51 @@ fn chat_gen_params(
     (max_tokens, temperature, eos_token_id)
 }
 
+/// Resolve the effective top-k for a chat sampling config (PMAT-760).
+///
+/// Honors the request's `top_k` (the documented sampling control) when set, else defaults to
+/// 40; `temperature == 0.0` forces greedy (top_k = 1), and an explicit `top_k = 1` likewise
+/// forces greedy regardless of temperature (qwen3-moe-sampling-v1 V1_001). The chat backends
+/// previously hardcoded `if temperature == 0.0 { 1 } else { 40 }`, silently DROPPING
+/// request.top_k — drift from batch.rs, which honors it.
+fn resolve_chat_top_k(temperature: f32, requested: Option<usize>) -> usize {
+    if temperature == 0.0 {
+        1
+    } else {
+        requested.unwrap_or(40)
+    }
+}
+
+#[cfg(test)]
+mod pmat760_top_k_tests {
+    use super::resolve_chat_top_k;
+
+    #[test]
+    fn honors_requested_top_k() {
+        // The request's top_k must be used, not the hardcoded 40 (the pre-PMAT-760 bug).
+        assert_eq!(resolve_chat_top_k(0.7, Some(10)), 10);
+        assert_eq!(resolve_chat_top_k(1.0, Some(100)), 100);
+    }
+
+    #[test]
+    fn defaults_to_40_when_unset() {
+        assert_eq!(resolve_chat_top_k(0.7, None), 40);
+    }
+
+    #[test]
+    fn temperature_zero_forces_greedy() {
+        // temp==0 => greedy (top_k=1) regardless of the requested top_k.
+        assert_eq!(resolve_chat_top_k(0.0, None), 1);
+        assert_eq!(resolve_chat_top_k(0.0, Some(50)), 1);
+    }
+
+    #[test]
+    fn explicit_top_k_one_is_greedy_at_any_temperature() {
+        // qwen3-moe-sampling-v1 V1_001: top_k=1 forces greedy regardless of temperature.
+        assert_eq!(resolve_chat_top_k(0.9, Some(1)), 1);
+    }
+}
+
 /// PMAT-756: apply OpenAI stop sequences to a chat completion's text and compute the
 /// matching `finish_reason`. The `/v1/chat/completions` path previously ignored
 /// `request.stop` entirely — the returned message kept the stop string and ran to
@@ -332,7 +377,7 @@ fn try_gpu_backend(
     let gpu_config = GpuGenerateConfig {
         max_tokens,
         temperature,
-        top_k: if temperature == 0.0 { 1 } else { 40 },
+        top_k: resolve_chat_top_k(temperature, request.top_k),
         stop_tokens: vec![eos_token_id as usize],
         trace: state.should_trace(trace_level),
     };
@@ -422,7 +467,7 @@ fn try_cached_backend(
     let q_config = QuantizedGenerateConfig {
         max_tokens,
         temperature,
-        top_k: if temperature == 0.0 { 1 } else { 40 },
+        top_k: resolve_chat_top_k(temperature, request.top_k),
         stop_tokens: vec![eos_token_id],
         trace: state.should_trace(trace_level),
         ..Default::default()

--- a/evidence/serve-api-openai-fidelity-audit-2026-06-14/findings.md
+++ b/evidence/serve-api-openai-fidelity-audit-2026-06-14/findings.md
@@ -41,7 +41,7 @@ prioritized; fixed incrementally (one coherent cluster per PR).
    choice. Min fix: reject n>1 with 400; full: generate n choices.
 8. **[TODO]** `seed` accepted but not plumbed (mod_create_demo.rs:92) — non-reproducible.
    MoE path already plumbs it (cuda_chat_backend.rs:748); mirror to dense backends.
-9. **[TODO]** `top_k` ignored, hardcoded 40/1 (cuda_chat_backend.rs:252) — mirror MoE plumbing.
+9. **[FIXED PMAT-760 (chat)]** `top_k` was ignored, hardcoded `if temperature==0.0 {1} else {40}` across the 4 chat backends — drift from batch.rs which honors it. Now resolved via the shared `resolve_chat_top_k(temperature, request.top_k)` helper (honor request, default 40, temp==0/top_k==1 => greedy). Covered by FALSIFY-TOPK-760. (/v1/completions has no top_k field on CompletionRequest — deferred, non-standard for completions.)
 10. **[TODO]** temperature default 0.7 vs OpenAI 1.0 (openai_handlers.rs:99) — the repo's
     own `default_temperature()`=1.0; chat path hardcodes 0.7. Use the canonical default.
 


### PR DESCRIPTION
Serve-API audit item 9. All four `/v1/chat/completions` backends (try_gpu + try_cached in openai_handlers, try_cuda + try_quantized in cuda_chat_backend) hardcoded `top_k: if temperature == 0.0 { 1 } else { 40 }`, **silently dropping the request's `top_k`** — a documented sampling control (`ChatCompletionRequest.top_k`) that `batch.rs` already honors. A client setting `top_k=10` got 40, changing the sampled distribution.

**Fix:** shared, unit-tested `resolve_chat_top_k(temperature, request.top_k)` — honor the request's top_k, default 40, force greedy (top_k=1) when `temperature==0` OR `top_k==1` (qwen3-moe-sampling-v1 V1_001). Replaces the hardcoded form at all 4 chat call sites.

**Falsifier** `FALSIFY-TOPK-760` / `pmat760_top_k_tests` (4 cases). **Mutation-verified** (ignore the requested value → `honors_requested_top_k` fails). Full serve lib suite **15306 pass**; build (+`--features cuda`) / fmt / clippy / `pv validate` clean.

**Co-evolution (Rule 7):** contract `apr-serve-openai-compat-v1` → **1.6.0** — PARAMS-PLUMBED now PARTIAL (top_k discharged for chat). **Still OPEN:** `n` accepted-but-ignored (reject n>1), `seed` to dense backends, temperature default 0.7 vs 1.0; `/v1/completions` has no top_k field on CompletionRequest (non-standard, deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)