### PR TITLE
fix(serve): try_cuda_gguf_completions — earliest-position stop, not first-listed (PMAT-761)

### DIFF
--- a/contracts/apr-serve-openai-compat-v1.yaml
+++ b/contracts/apr-serve-openai-compat-v1.yaml
@@ -1,7 +1,7 @@
 contract: apr-serve-openai-compat
 metadata:
   kind: pattern
-  version: "1.6.0"
+  version: "1.7.0"
   description: >
     OpenAI-compatible serve layer (/v1/chat/completions, /v1/completions) fidelity
     invariants. Established by an adversarial audit (2026-06-14) that found 12 confirmed
@@ -46,8 +46,10 @@ proof_obligations:
       backends + registry fallback) now apply stop via streaming_text_deltas(). STILL OPEN:
       true_streaming_sse_response (the live mpsc-channel path) — needs incremental cross-token
       stop detection; tracked follow-up.
-      Residual nicety (non-blocking): the try_cuda_gguf_completions inline form truncates at
-      the first-LISTED stop, not the earliest-POSITION one — should migrate to the helper.
+      Residual nicety (DISCHARGED — PMAT-761): try_cuda_gguf_completions previously truncated
+      at the first-LISTED stop via an inline loop, not the earliest-POSITION one; it now uses
+      the shared truncate_at_stop() helper like every other completion backend. So EVERY
+      completion backend (cached/quantized/gpu/apr_q4k/cuda_gguf) is earliest-position-correct.
   - type: invariant
     property: >
       STREAM-UTF8 (PRE-GENERATED paths DISCHARGED — PMAT-758/759): streamed SSE deltas must be
@@ -96,6 +98,12 @@ falsification_tests:
     test_harness: 'cargo test -p aprender-serve --lib pmat760_top_k_tests'
     expected_output: "test result: ok"
     if_fails: 'A chat backend ignores request.top_k and samples with the hardcoded 40 (the pre-PMAT-760 behavior), so a client-specified top_k has no effect on the output distribution.'
+  - id: FALSIFY-CUDA-GGUF-STOP-761
+    name: gpu_completions_handler_no_first_listed_stop_loop
+    prediction: 'gpu_completions_handler.rs (try_cuda_gguf_completions) applies stop via the shared truncate_at_stop() helper (earliest-position), NOT an inline `for stop in stops { text.truncate(pos); break }` loop (which cuts at the first-LISTED stop). Shape gate: catches re-introduction of the first-listed inline form. The earliest-position behavior itself is covered by FALSIFY-STOP-TRUNCATE-754.'
+    test_harness: '! grep -nE "for stop in stops" crates/aprender-serve/src/api/gpu_completions_handler.rs'
+    expected_output: "no match (exit 1 from grep = invariant holds)"
+    if_fails: 'A completion backend re-added first-LISTED stop truncation, so stop=["world","hello"] on "hello world" keeps "hello " instead of truncating at the earliest position ("") — inconsistent with the other completion backends.'
   - id: FALSIFY-SSE-FRAMING-753
     name: chat_completions_stream_no_double_data_prefix
     prediction: 'chat_completions_stream.rs yields Event::default().data(<bare json>) / .data("[DONE]") — no occurrence of Event::default().data(format!("data: ...")) (which double-prefixes the SSE wire format). Shape gate: catches re-introduction of the manual prefix.'

--- a/crates/aprender-serve/src/api/gpu_completions_handler.rs
+++ b/crates/aprender-serve/src/api/gpu_completions_handler.rs
@@ -277,19 +277,15 @@ async fn try_cuda_gguf_completions(
     }
 
     let completion_tokens = output_tokens.len();
-    let mut text = tokenizer
+    let text = tokenizer
         .decode(&output_tokens)
         .map_err(|e| rerr(state, StatusCode::INTERNAL_SERVER_ERROR, e))?;
 
-    // Truncate at first stop sequence (OpenAI behavior)
-    if let Some(stops) = &request.stop {
-        for stop in stops {
-            if let Some(pos) = text.find(stop.as_str()) {
-                text.truncate(pos);
-                break;
-            }
-        }
-    }
+    // PMAT-761: truncate at the EARLIEST stop POSITION via the shared helper. The previous
+    // inline loop cut at the first-LISTED stop that matched, not the earliest-position one —
+    // e.g. stop=["world","hello"] on "hello world" wrongly kept "hello ". This makes
+    // try_cuda_gguf_completions consistent with every other completion backend (PMAT-754/755).
+    let text = truncate_at_stop(text, request.stop.as_deref());
 
     state.metrics.record_success(completion_tokens, start.elapsed());
 

--- a/evidence/serve-api-openai-fidelity-audit-2026-06-14/findings.md
+++ b/evidence/serve-api-openai-fidelity-audit-2026-06-14/findings.md
@@ -36,6 +36,11 @@ prioritized; fixed incrementally (one coherent cluster per PR).
    stop mid-SSE (pregenerated/true_streaming/chat_completions_stream) — remains OPEN, grouped
    with item 2's cross-token stream-buffer work (same incremental-detection machinery).
 
+**[FIXED PMAT-761]** Residual: `try_cuda_gguf_completions` (gpu_completions_handler.rs) truncated
+at the first-LISTED stop via an inline loop, not the earliest-POSITION one — now uses the shared
+`truncate_at_stop()` helper. ALL completion backends are now earliest-position-correct.
+Covered by FALSIFY-CUDA-GGUF-STOP-761 (shape gate) + FALSIFY-STOP-TRUNCATE-754 (behavior).
+
 ## Param plumbing dropped (HIGH/MEDIUM) — OpenAI fidelity
 7. **[TODO]** `n` accepted but ignored (mod_create_demo.rs:94) — n>1 silently returns 1
    choice. Min fix: reject n>1 with 400; full: generate n choices.


### PR DESCRIPTION
Serve-API audit residual. `try_cuda_gguf_completions` truncated at the first stop in `request.stop` that matched, via an inline `for stop in stops { ...text.truncate(pos); break }` loop — cutting at the **first-listed** stop, not the **earliest-position** one. e.g. `stop=["world","hello"]` on `"hello world"` wrongly kept `"hello "` instead of truncating at the earliest match (`""`).

**Fix:** route through the shared `truncate_at_stop()` helper (PMAT-754) — this backend now matches every other completion backend (cached/quantized/gpu/apr_q4k). **All completion backends are now earliest-position-correct.**

**Falsifier** `FALSIFY-CUDA-GGUF-STOP-761` (shape gate: no first-listed inline loop) + `FALSIFY-STOP-TRUNCATE-754` (earliest-position behavior, already mutation-verified). Full serve suite **15306 pass**; build (+`--features cuda`) / fmt / clippy / `pv validate` clean.

**Co-evolution (Rule 7):** contract `apr-serve-openai-compat-v1` → **1.7.0** — the STOP-APPLIED "residual nicety" is now **discharged**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)