### PR TITLE
fix(serve): Llama2 chat template — system-message loss + double-BOS (PMAT-762)

### DIFF
--- a/contracts/chat-template-v1.yaml
+++ b/contracts/chat-template-v1.yaml
@@ -1,7 +1,7 @@
 metadata:
-  version: "1.3.0"
+  version: "1.4.0"
   created: "2026-04-13"
-  updated: "2026-05-10"
+  updated: "2026-06-14"
   author: PAIML Engineering
   registry: true
   references:
@@ -81,6 +81,19 @@ falsification:
     description: "Missing template produces error, not silent skip"
     test: "PMAT-237 lesson: process validation, not outcome validation"
     evidence: "cargo test -p aprender-core --lib chat_template"
+
+  - id: FALSIFY-CHAT-762
+    description: |
+      Llama2Template::format_conversation preserves system context and emits exactly one BOS.
+      An adversarial chat-template bug-hunt (2026-06-14) found three real defects, all fixed
+      (PMAT-762): (1) a system-only message (no following user) was silently DROPPED — output
+      was just "<s>"; (2) multiple system messages OVERWROTE each other (only the last kept);
+      (3) the [system, user] case emitted a DOUBLE "<s>" (double-BOS) because the new-round
+      "<s>" fired even though only a system message preceded the first user turn. Now: system
+      messages concatenate, an unconsumed system prompt is flushed as a trailing INST block,
+      and the new-round "<s>" only opens AFTER a completed assistant turn (turn_started guard).
+    test: "falsify_ct_762_* in chat_template_contract_tests.rs (system-only, multi-system, double-BOS, multi-turn-separator)"
+    evidence: "cargo test -p aprender-serve --lib falsify_ct_762"
 
   - id: GATE-CHAT-SHIP-008
     description: |

--- a/crates/aprender-serve/src/chat_template_contract_tests.rs
+++ b/crates/aprender-serve/src/chat_template_contract_tests.rs
@@ -211,4 +211,65 @@ mod contract_tests {
         assert_ne!(detect_format_from_name("qwen2"), TemplateFormat::Qwen3NoThink);
         assert_eq!(detect_format_from_name("qwen2"), TemplateFormat::ChatML);
     }
+
+    // ═══ FALSIFY-CT-762: Llama2 system-message handling ═══
+    // Adversarial chat-template bug-hunt (2026-06-14) confirmed Llama2Template dropped
+    // system context when no user message followed, and overwrote multiple system messages.
+
+    #[test]
+    fn falsify_ct_762_llama2_system_only_not_dropped() {
+        // A system-only request must NOT lose the system content (previously returned "<s>").
+        let conv = Llama2Template::new()
+            .format_conversation(&[ChatMessage::system("Be terse.")])
+            .expect("format");
+        assert!(
+            conv.contains("Be terse."),
+            "system-only prompt dropped the system content: {conv:?}"
+        );
+        assert!(conv.contains("<<SYS>>"), "system block markers missing: {conv:?}");
+    }
+
+    #[test]
+    fn falsify_ct_762_llama2_multiple_system_messages_preserved() {
+        // Multiple system messages must all survive (previously only the LAST was kept).
+        let conv = Llama2Template::new()
+            .format_conversation(&[
+                ChatMessage::system("First rule."),
+                ChatMessage::system("Second rule."),
+                ChatMessage::user("hi"),
+            ])
+            .expect("format");
+        assert!(conv.contains("First rule."), "first system message dropped: {conv:?}");
+        assert!(conv.contains("Second rule."), "second system message dropped: {conv:?}");
+    }
+
+    #[test]
+    fn falsify_ct_762_llama2_system_user_still_correct() {
+        // Regression guard: the common [system, user] case stays well-formed.
+        let conv = Llama2Template::new()
+            .format_conversation(&[
+                ChatMessage::system("Be helpful."),
+                ChatMessage::user("2+2?"),
+            ])
+            .expect("format");
+        assert!(conv.starts_with("<s>[INST] <<SYS>>\nBe helpful.\n<</SYS>>\n\n2+2? [/INST]"));
+        // Exactly ONE leading <s> — no double-BOS (the system message must not trigger the
+        // new-round <s> that belongs only after a completed assistant turn).
+        assert_eq!(conv.matches("<s>").count(), 1, "double-BOS for [system,user]: {conv:?}");
+    }
+
+    #[test]
+    fn falsify_ct_762_llama2_multiturn_round_separator_preserved() {
+        // Regression the OTHER way: a genuine new round (after an assistant turn) MUST still
+        // open with <s>, so multi-turn Llama-2 format is intact.
+        let conv = Llama2Template::new()
+            .format_conversation(&[
+                ChatMessage::user("q1"),
+                ChatMessage::assistant("a1"),
+                ChatMessage::user("q2"),
+            ])
+            .expect("format");
+        assert_eq!(conv.matches("<s>").count(), 2, "missing new-round <s>: {conv:?}");
+        assert!(conv.contains("</s><s>[INST] q2 [/INST]"), "bad round boundary: {conv:?}");
+    }
 }

--- a/crates/aprender-serve/src/chat_template_llama2.rs
+++ b/crates/aprender-serve/src/chat_template_llama2.rs
@@ -47,17 +47,33 @@ impl ChatTemplateEngine for Llama2Template {
         let mut result = String::from("<s>");
         let mut system_prompt: Option<String> = None;
         let mut in_user_turn = false;
+        // PMAT-762: have we emitted any [INST] turn yet? A new Llama-2 round opens with <s>,
+        // but only AFTER a completed assistant turn — not after a leading system message.
+        let mut turn_started = false;
 
-        for (i, msg) in messages.iter().enumerate() {
+        for msg in messages.iter() {
             // Sanitize content to prevent prompt injection (F-SEC-220)
             let safe_content = sanitize_special_tokens(&msg.content);
 
             match msg.role.as_str() {
                 "system" => {
-                    system_prompt = Some(safe_content);
+                    // PMAT-762: concatenate multiple system messages instead of overwriting.
+                    // The previous `system_prompt = Some(safe_content)` silently dropped all
+                    // but the LAST system message.
+                    match system_prompt {
+                        Some(ref mut prev) => {
+                            prev.push_str("\n\n");
+                            prev.push_str(&safe_content);
+                        },
+                        None => system_prompt = Some(safe_content),
+                    }
                 },
                 "user" => {
-                    if i > 0 && !in_user_turn {
+                    // Open a new round with <s> only AFTER a completed assistant turn. The
+                    // previous `i > 0 && !in_user_turn` also fired when the only prior message
+                    // was a system one, producing a spurious DOUBLE <s> (double-BOS) for the
+                    // common [system, user] case.
+                    if turn_started && !in_user_turn {
                         result.push_str("<s>");
                     }
                     result.push_str("[INST] ");
@@ -71,6 +87,7 @@ impl ChatTemplateEngine for Llama2Template {
                     result.push_str(&safe_content);
                     result.push_str(" [/INST]");
                     in_user_turn = true;
+                    turn_started = true;
                 },
                 "assistant" => {
                     result.push(' ');
@@ -80,6 +97,19 @@ impl ChatTemplateEngine for Llama2Template {
                 },
                 _ => {},
             }
+        }
+
+        // PMAT-762: flush a system prompt never consumed by a following user message (e.g. a
+        // system-only request, or one ending on a system turn). Previously it was silently
+        // DROPPED — the entire system context was lost. Emit it as a system block inside an
+        // (empty-user) INST turn so the prompt stays well-formed Llama-2.
+        if let Some(sys) = system_prompt.take() {
+            if !in_user_turn {
+                result.push_str("[INST] ");
+            }
+            result.push_str("<<SYS>>\n");
+            result.push_str(&sys);
+            result.push_str("\n<</SYS>>\n\n [/INST]");
         }
 
         Ok(result)

--- a/evidence/chat-template-adversarial-audit-2026-06-14/findings.md
+++ b/evidence/chat-template-adversarial-audit-2026-06-14/findings.md
@@ -1,0 +1,66 @@
+# Chat prompt-construction — adversarial bug-hunt + hand-triage (2026-06-14)
+
+Adversarial bug-hunt over the chat prompt-construction path (templates / roles / special
+tokens): 5 finder dimensions → skeptic verification → **28 findings, 14 marked REAL.** Every
+REAL verdict was then HAND-RE-CHECKED against the source before any fix (lesson from the
+sampling audit, where a skeptic upheld a false positive). The hand-triage materially changed
+the picture — several "REAL" verdicts were false positives, and writing a regression test
+surfaced a *new* higher-impact bug the hunt missed.
+
+## FIXED this PR (PMAT-762 — Llama2Template::format_conversation)
+
+All three in `crates/aprender-serve/src/chat_template_llama2.rs`, covered by
+`falsify_ct_762_*` (chat_template_contract_tests.rs), mutation-verified:
+
+1. **System-only message silently dropped** (finding 1). A `[system]`-only request (or any
+   list ending without a following user) stored the system prompt in a local that was only
+   consumed by a user turn → output was just `"<s>"`, the system context lost. Fix: flush an
+   unconsumed system prompt after the loop as a trailing `[INST] <<SYS>>…<</SYS>> [/INST]`.
+2. **Multiple system messages overwrote** (finding 2). `system_prompt = Some(content)` kept
+   only the LAST. Fix: concatenate with `\n\n`.
+3. **DOUBLE `<s>` (double-BOS) for `[system, user]`** — NOT in the hunt's 14; found by the
+   regression test I wrote for #1/#2. The new-round `<s>` (`if i > 0 && !in_user_turn`) fired
+   at the first user turn whenever a system message preceded it, emitting `"<s><s>[INST]…"`.
+   This hit the COMMON system+user case → higher impact than #1/#2. Fix: a `turn_started`
+   guard so the round-opening `<s>` is added only AFTER a completed assistant turn.
+
+Co-evolution (Rule 7): chat-template-v1 → 1.4.0, FALSIFY-CHAT-762.
+
+## REAL but deferred (own PRs)
+
+- **[10] Missing/divergent BOS in serve chat vs CLI** (HIGH, needs TRACE). `tokenize_chat_prompt`
+  (openai_handlers.rs:74) does `encode(prompt_text)` with no explicit BOS prepend, while the
+  CLI path (`infer/mod.rs:319-330`, GH-278) prepends an arch-aware BOS. BUT the templates embed
+  a literal `<s>`/`<|im_start|>`, so a naive serve-side prepend risks DOUBLE-BOS. Resolving this
+  needs genchi-genbutsu: `apr trace` the actual token IDs for a real Llama model through serve
+  vs CLI vs llama.cpp before changing anything. Do NOT patch blind.
+- **[11] RawTemplate concatenates messages with no separators** (MEDIUM). `RawTemplate::
+  format_conversation` (chat_template_helpers.rs:11-15) is `.map(sanitize).collect::<String>()`
+  → `[user "Hello", assistant "World"]` becomes `"HelloWorld"`. Only hits unknown/None-named
+  models (recognized models get a real template). Fix is a judgment call (the doc says "raw =
+  no formatting"); at minimum it should newline-separate like the realize_handlers fallback.
+
+## FALSE POSITIVES (skeptic upheld; rejected on hand re-check)
+
+- **[3,5,7] Llama2 + [4,6] Mistral "missing generation prompt"** — ending in `[/INST]` IS the
+  correct generation signal for Llama-2/Mistral (the model generates right after `[/INST]`);
+  unlike ChatML/Zephyr these formats have no separate `assistant` marker. Finding 4's own
+  skeptic even wrote "NO FIX NEEDED — correct per Mistral spec," yet it was listed REAL.
+- **[8] RawTemplate doesn't sanitize** — it DOES (chat_template_helpers.rs:6,13). The finding
+  conflated it with the realize_handlers `unwrap_or_else` fallback (which is ~unreachable —
+  `format_messages` returns Ok for all templates incl. Raw, so the error fallback never fires).
+- **[14] "Unicode/emoji loses encoding context" (claimed critical)** — vague mechanism; the
+  BPE encoder handles UTF-8 via byte-level fallback. No concrete malformed-prompt repro.
+
+## LOW / spec-compliant (no action)
+
+- **[9] HF undefined template var → empty string** — minijinja default; matches Jinja2.
+- **[12] empty content → empty token vec** — spec-compliant for an empty string.
+- **[13] special-token literals encoded as text IF special_tokens map empty** — conditional on
+  an empty map (a misconfigured tokenizer), not the normal path.
+
+## Method / lesson
+Skeptic verification kept signal high, but HAND-RE-CHECKING the REAL verdicts was essential:
+of 14 "REAL", ~5 were false positives and the highest-impact bug (double-BOS) was found only
+by writing a regression test. Always hand-verify + regression-test before fixing; the BOS
+question (finding 10) needs trace evidence, not a blind patch.


### PR DESCRIPTION
Found by an adversarial chat-template bug-hunt (28 findings → 14 REAL; **hand-re-checked** — see evidence/). Three real defects in `Llama2Template::format_conversation`, all silently corrupting the prompt:

1. **System-only message DROPPED** — a `[system]`-only request (or any list not ending in a user turn) lost the system context entirely (output was just `"<s>"`). Fix: flush an unconsumed system prompt after the loop as a trailing `[INST] <<SYS>>…<</SYS>> [/INST]`.
2. **Multiple system messages OVERWROTE** (only the last kept). Fix: concatenate with `\n\n`.
3. **DOUBLE `<s>` (double-BOS) for the COMMON `[system, user]` case** — *not* among the hunt's 14; surfaced by the **regression test I wrote** for #1/#2. The new-round `<s>` (`i > 0 && !in_user_turn`) fired at the first user turn whenever a system message preceded it. Fix: a `turn_started` guard so the round-opening `<s>` is added only AFTER a completed assistant turn (genuine multi-turn rounds still get it).

**Falsifier** `FALSIFY-CHAT-762` / `falsify_ct_762_*` (system-only, multi-system, double-BOS, multi-turn-separator). #1 and #3 **mutation-verified**. Full serve suite **15313 pass**; fmt/clippy/`pv validate` clean.

**Co-evolution (Rule 7):** chat-template-v1 → 1.4.0. The hand-triage also recorded the hunt's **false positives** (Llama2/Mistral "missing generation prompt" — ending `[/INST]` *is* correct; RawTemplate "no sanitize" — it does) and **deferred reals** needing their own work: serve-vs-CLI **BOS divergence** (needs `apr trace` evidence — double-BOS risk) + RawTemplate no-separators.

🤖 Generated with [Claude Code](https://claude.com/claude-code)