### PR TITLE
fix(serve): RawTemplate newline-separates chat turns + resolve BOS false-positive (PMAT-763)

### DIFF
--- a/contracts/chat-template-v1.yaml
+++ b/contracts/chat-template-v1.yaml
@@ -1,5 +1,5 @@
 metadata:
-  version: "1.4.0"
+  version: "1.5.0"
   created: "2026-04-13"
   updated: "2026-06-14"
   author: PAIML Engineering
@@ -94,6 +94,32 @@ falsification:
       and the new-round "<s>" only opens AFTER a completed assistant turn (turn_started guard).
     test: "falsify_ct_762_* in chat_template_contract_tests.rs (system-only, multi-system, double-BOS, multi-turn-separator)"
     evidence: "cargo test -p aprender-serve --lib falsify_ct_762"
+
+  - id: FALSIFY-CHAT-763
+    description: |
+      RawTemplate (the fallback selected by detect_format_from_name for unknown / "default"-
+      named models) newline-separates messages instead of bare-concatenating them. The
+      previous `.map(sanitize).collect::<String>()` produced "HelloWorld" for a multi-turn
+      chat — an unparseable prompt. Reachable via format_chat_messages(Some(request.model)) on
+      the registry_fallback + chat_completions_stream paths when the model name matches no
+      template pattern. Fixed (PMAT-763) to emit `content + '\n'` per message, matching the
+      realize_handlers raw fallback. (The cuda/gpu chat backends use real-arch
+      tokenize_chat_prompt, so they were never on the Raw path.)
+    test: "falsify_ct_763_rawtemplate_separates_messages in chat_template_contract_tests.rs"
+    evidence: "cargo test -p aprender-serve --lib falsify_ct_763"
+
+  - id: NOTE-CHAT-BOS-FALSE-POSITIVE
+    description: |
+      The 2026-06-14 chat-template bug-hunt flagged "serve missing BOS vs CLI" (serve's
+      tokenize_chat_prompt does no explicit BOS prepend; CLI infer/mod.rs does, GH-278).
+      RESOLVED as a FALSE POSITIVE via code analysis: BPETokenizer::encode maps a template's
+      literal "<s>"/"<|im_start|>" to its special-token id (bpe_encode special-token split
+      when merge_rules present, else greedy token_to_id match) and does NOT auto-prepend BOS.
+      So serve gets BOS exactly once VIA THE TEMPLATE; the CLI prepends only because its
+      non-templated raw-prompt path has no embedded BOS. A blind serve-side prepend would
+      CAUSE double-BOS — DO NOT add one. No code change; recorded to prevent a harmful fix.
+    test: "n/a (analysis — see evidence/chat-template-adversarial-audit-2026-06-14/findings.md)"
+    evidence: "crates/aprender-serve/src/tokenizer.rs encode() + api/openai_handlers.rs tokenize_chat_prompt()"
 
   - id: GATE-CHAT-SHIP-008
     description: |

--- a/crates/aprender-serve/src/chat_template_contract_tests.rs
+++ b/crates/aprender-serve/src/chat_template_contract_tests.rs
@@ -258,6 +258,29 @@ mod contract_tests {
         assert_eq!(conv.matches("<s>").count(), 1, "double-BOS for [system,user]: {conv:?}");
     }
 
+    // ═══ FALSIFY-CT-763: RawTemplate (unknown/default model fallback) separates turns ═══
+
+    #[test]
+    fn falsify_ct_763_rawtemplate_separates_messages() {
+        // The previous `.collect::<String>()` produced "HelloWorld" (no separators), an
+        // unparseable multi-turn prompt for unknown/"default"-named models. Each message's
+        // content must be newline-delimited so turns are distinguishable.
+        let conv = RawTemplate::new()
+            .format_conversation(&[
+                ChatMessage::user("Hello"),
+                ChatMessage::assistant("World"),
+                ChatMessage::user("Again"),
+            ])
+            .expect("format");
+        assert!(
+            !conv.contains("HelloWorld"),
+            "RawTemplate merged messages with no separator: {conv:?}"
+        );
+        assert!(conv.contains("Hello\n"), "missing newline separator: {conv:?}");
+        assert!(conv.contains("World\n"), "missing newline separator: {conv:?}");
+        assert!(conv.contains("Again"), "dropped a message: {conv:?}");
+    }
+
     #[test]
     fn falsify_ct_762_llama2_multiturn_round_separator_preserved() {
         // Regression the OTHER way: a genuine new round (after an assistant turn) MUST still

--- a/crates/aprender-serve/src/chat_template_helpers.rs
+++ b/crates/aprender-serve/src/chat_template_helpers.rs
@@ -7,11 +7,18 @@ impl ChatTemplateEngine for RawTemplate {
     }
 
     fn format_conversation(&self, messages: &[ChatMessage]) -> Result<String, RealizarError> {
-        // Sanitize content to prevent prompt injection (F-SEC-220)
-        let result: String = messages
+        // Sanitize content to prevent prompt injection (F-SEC-220).
+        // PMAT-763: newline-separate messages. The previous `.collect::<String>()`
+        // concatenated content with NO separators, so a multi-turn chat sent to an
+        // unknown / "default"-named model (RawTemplate is the fallback selected by
+        // detect_format_from_name) became e.g. "HelloWorld" — a prompt the model can't parse
+        // into turns. `join("\n")` separates BETWEEN turns while leaving a single message
+        // verbatim (no spurious trailing newline).
+        let result = messages
             .iter()
             .map(|m| sanitize_special_tokens(&m.content))
-            .collect();
+            .collect::<Vec<_>>()
+            .join("\n");
         Ok(result)
     }
 

--- a/crates/aprender-serve/src/chat_template_message.rs
+++ b/crates/aprender-serve/src/chat_template_message.rs
@@ -335,7 +335,11 @@
             .format_conversation(&messages)
             .expect("operation failed");
 
-        assert_eq!(output, "SystemUserAssistant");
+        // PMAT-763: RawTemplate newline-separates turns. This previously asserted
+        // "SystemUserAssistant" — bare concatenation that codified the no-separator bug
+        // (an unparseable multi-turn prompt for unknown/"default"-named models). A single
+        // message is still emitted verbatim (see test_format_messages_without_model).
+        assert_eq!(output, "System\nUser\nAssistant");
     }
 
     // ========================================================================

--- a/evidence/chat-template-adversarial-audit-2026-06-14/findings.md
+++ b/evidence/chat-template-adversarial-audit-2026-06-14/findings.md
@@ -26,19 +26,23 @@ All three in `crates/aprender-serve/src/chat_template_llama2.rs`, covered by
 
 Co-evolution (Rule 7): chat-template-v1 → 1.4.0, FALSIFY-CHAT-762.
 
-## REAL but deferred (own PRs)
+## RESOLVED after the initial triage
 
-- **[10] Missing/divergent BOS in serve chat vs CLI** (HIGH, needs TRACE). `tokenize_chat_prompt`
-  (openai_handlers.rs:74) does `encode(prompt_text)` with no explicit BOS prepend, while the
-  CLI path (`infer/mod.rs:319-330`, GH-278) prepends an arch-aware BOS. BUT the templates embed
-  a literal `<s>`/`<|im_start|>`, so a naive serve-side prepend risks DOUBLE-BOS. Resolving this
-  needs genchi-genbutsu: `apr trace` the actual token IDs for a real Llama model through serve
-  vs CLI vs llama.cpp before changing anything. Do NOT patch blind.
-- **[11] RawTemplate concatenates messages with no separators** (MEDIUM). `RawTemplate::
-  format_conversation` (chat_template_helpers.rs:11-15) is `.map(sanitize).collect::<String>()`
-  → `[user "Hello", assistant "World"]` becomes `"HelloWorld"`. Only hits unknown/None-named
-  models (recognized models get a real template). Fix is a judgment call (the doc says "raw =
-  no formatting"); at minimum it should newline-separate like the realize_handlers fallback.
+- **[11] RawTemplate concatenates messages with no separators** — **FIXED (PMAT-763)**.
+  `RawTemplate::format_conversation` was `.map(sanitize).collect::<String>()` → `[user "Hello",
+  assistant "World"]` became `"HelloWorld"`. Reachable via `format_chat_messages(Some(
+  request.model))` on the registry_fallback + chat_completions_stream paths when the model name
+  matches no template pattern (e.g. "default"). Now emits `content + '\n'` per message,
+  matching the realize_handlers raw fallback. Falsifier `falsify_ct_763_*` (mutation-verified).
+- **[10] "Missing/divergent BOS in serve chat vs CLI"** — **RESOLVED as a FALSE POSITIVE via
+  code analysis (no model needed)**. `BPETokenizer::encode` (tokenizer.rs:259) maps a template's
+  literal `<s>`/`<|im_start|>` to its special-token id (via `bpe_encode`'s special-token split
+  when merge_rules are present, else the fallback's greedy `token_to_id` match) and does NOT
+  auto-prepend BOS. So serve gets BOS exactly once VIA THE TEMPLATE; the CLI (`infer/mod.rs`)
+  prepends only because its non-templated raw-prompt path has no embedded BOS. The two are
+  different-but-both-valid mechanisms — a blind serve-side prepend would have CAUSED double-BOS.
+  **No code change. Do NOT add a serve-side BOS prepend.** (The "needs evidence, don't patch
+  blind" deferral was vindicated — the obvious fix was the wrong one.)
 
 ## FALSE POSITIVES (skeptic upheld; rejected on hand re-check)
 


### PR DESCRIPTION
Chat-template audit follow-up (evidence/chat-template-adversarial-audit-2026-06-14/).

**Fix (finding 11):** `RawTemplate::format_conversation` — the fallback template for unknown / "default"-named models — used `.map(sanitize).collect::<String>()`, concatenating content with **no separators**. A multi-turn chat became `"SystemUserAssistant"`, an unparseable prompt. Reachable via `format_chat_messages(Some(request.model))` on the registry_fallback + chat_completions_stream paths when the name matches no template pattern. Now `join("\n")` — separates **between** turns while leaving a single message verbatim (no spurious trailing newline). Updated `test_raw_format`, which had codified the no-separator bug as expected output.

**Resolve (finding 10):** the hunt flagged "serve missing BOS vs CLI" — **resolved as a FALSE POSITIVE via code analysis (no code change)**. `BPETokenizer::encode` maps a template's literal `<s>`/`<|im_start|>` to its special-token id and does **not** auto-prepend BOS, so serve gets BOS once *via the template*; the CLI prepends only because its non-templated path lacks one. A blind serve-side prepend would **cause** double-BOS — recorded so it isn't "fixed" later.

**Falsifier** `FALSIFY-CHAT-763` (mutation-verified: revert to bare collect → fails). Full serve suite **15311 pass**; fmt/clippy/`pv validate` clean.

**Co-evolution (Rule 7):** chat-template-v1 → **1.5.0** (FALSIFY-CHAT-763 + NOTE-CHAT-BOS-FALSE-POSITIVE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)