### PR TITLE
docs(evidence): batch-scheduler audit — 7/9 false-positive + ready finding-2 plan

### DIFF
--- a/evidence/batch-scheduler-adversarial-audit-2026-06-14/findings.md
+++ b/evidence/batch-scheduler-adversarial-audit-2026-06-14/findings.md
@@ -50,20 +50,64 @@ constructing a dummy `BatchedDecodeState`. GPU testing required.
 - **[6] HIGH** inconsistency: `add_slot_to_batch` (545-546) uses `max_tokens` only while
   `recycle_slot` (638-640) uses `gen_idx + max_tokens` — same join scenario, different
   termination depending on path.
-- **[7] CRITICAL-ish** `realize_handlers_embed_completion.rs:241` awaits the oneshot response
-  with NO timeout — if the batch processor task crashes/stalls, the HTTP request hangs forever.
-  (Fix needs a generous timeout that won't kill legitimately-slow long generations.)
+- **[7] LARGELY FALSE POSITIVE (hand-verified 2026-06-14)** `try_batch_completion` recv path
+  (realize_handlers_embed_completion.rs:241-243) returns `Ok(None)` on `Err` -> graceful
+  fallthrough to the next backend. A CRASHED processor drops the tx -> recv `Err` -> handled.
+  Only a STALLED processor that holds the tx open and never sends hangs (narrow); a naive
+  timeout there risks killing legitimately-slow long generations. Not a clean fix; deprioritized.
 - **[8] HIGH** `cuda_batch_scheduler.rs:70-72,82` token `try_send` failure breaks the loop
   silently — verify whether this is intended (client disconnected) vs lost-token-on-full-channel.
-- **[9] HIGH** `gpu_handlers.rs:378` queue capacity hardcoded; overflow → `send` Err is
-  swallowed at the handler (realize_handlers_embed_completion.rs:238) → client hang / lost req.
+- **[9] LARGELY FALSE POSITIVE (hand-verified 2026-06-14)** the send path
+  (realize_handlers_embed_completion.rs:238) returns `Ok(None)` on send `Err` -> graceful
+  fallthrough to the next backend, NOT a swallowed hang. Queue-capacity tuning remains a
+  possible enhancement but there is no correctness bug here.
 - **[10] HIGH** `gpu_handlers.rs:410-435` a stuck `process_batch` blocks all subsequent
   requests until the window timeout (liveness).
 - **[3] MEDIUM** `max_tokens_max = configs.iter().map(max_tokens).max()` keeps the batch
   decoding until the LARGEST-limit request finishes — smaller-limit requests are marked done
   (correct output) but the GPU keeps stepping (efficiency, not correctness).
 
+## Finding-2 implementation plan (ready to execute — focused GPU effort)
+
+Scope confirmed (2026-06-14): the logits ALREADY exist on GPU before argmax
+(`batched_forward.rs` `batched_output_norm_lm_head_argmax` fills `workspace.logits_buf` via the
+LM-head GEMV, then calls `batched_gpu_argmax`). The reusable CPU sampler is
+`OwnedQuantizedModel::sample_topk(logits: &[f32], temperature, top_k) -> u32`
+(gguf/inference/fails.rs:92). Validation is feasible: RTX 4090 free + 0.5B models present
+(`/mnt/nvme-raid0/models/qwen2.5-coder-0.5b-instruct-q4k.apr`) + `apr` binary built.
+
+Steps:
+1. Refactor `batched_forward.rs` (non-graphed path only — graphed is a launch-opt; the sampling
+   path can use non-graphed):
+   - extract `batched_forward_run_layers(...)` (embed + per-layer loop, leaves result in
+     hidden_buf2) — currently lines ~38-164.
+   - extract `batched_output_norm_lm_head_into_logits(m, hidden_dim, vocab_size, eps) ->
+     (logits_ptr, logits_size)` (output_norm + LM-head GEMV, NO argmax) — lines ~178-276.
+   - `forward_batched_to_token_ids` = run_layers + into_logits + `batched_gpu_argmax`
+     (behaviorally identical — build-verify with --features cuda).
+   - NEW `forward_batched_to_logits(...) -> Vec<f32>` = run_layers + into_logits +
+     `copy_to_host` the m×vocab logits.
+2. `generate_batched_streaming.rs` `batched_decode_step`: if ALL live slots are greedy
+   (temperature == 0.0) → keep `forward_batched_to_token_ids` (fast GPU argmax). If ANY slot
+   has temperature > 0 → call `forward_batched_to_logits`, then per slot:
+   greedy → argmax the slot's logits slice; else `sample_topk(slot_logits, configs[slot].
+   temperature, configs[slot].top_k)`. (Seed = finding [4] resolved here too once stochastic.)
+3. Unit-test (CPU, no GPU): a pure `select_batched_token(slot_logits, &config) -> u32` helper
+   (argmax vs sample_topk dispatch) — mutation-verifiable.
+4. GPU VALIDATION (mandatory before merge — do NOT auto-merge): `apr serve` the 0.5B model with
+   continuous batching enabled; fire 2+ concurrent requests with temperature 0.0 vs 1.5 and the
+   same prompt+seed; assert temp=0 is deterministic/greedy and temp=1.5 diverges across runs and
+   from the greedy output. Plus a perf check: ITL with all-greedy batch must match the current
+   fast path (the download cost is paid only when sampling is requested).
+
+Risk note: minimal-blast option is to DUPLICATE the body into `forward_batched_to_logits`
+(leaving the proven greedy path byte-untouched) rather than refactor — but both require the GPU
+validation in step 4, so the cleaner refactor is acceptable if step-1 build-verifies + step-4
+passes. Open the PR WITHOUT auto-merge until step 4 is green.
+
 ## Method / lesson
-Hunt + skeptic verification, then hand-verify. The recurring lesson holds: the headline finding
-([2]) is real and high-impact, but the right response is a careful GPU-tested effort, not a
-blind loop-tick patch. Findings recorded so the focused effort starts from a vetted list.
+Hunt + skeptic verification, then HAND-VERIFY each REAL verdict before acting — this audit's
+findings 7 & 9 were verified as FALSE POSITIVES (graceful `Ok(None)` fallthrough already handles
+the send/recv-error paths), and a naive timeout "fix" would have killed slow-but-valid
+generations. The headline ([2]) is real and high-impact, but the right response is a careful
+GPU-tested effort (plan above), not a blind loop-tick patch.


### PR DESCRIPTION
Hand-verification refinement of the batch-scheduler audit (#2025):

- **Findings 7 & 9 verified as LARGELY FALSE POSITIVES** — `try_batch_completion` returns `Ok(None)` on both send-fail and recv-`Err` → graceful fallthrough to the next backend (not a hang/swallow). A crashed processor drops the tx → recv `Err` → handled; only a *stalled* processor hangs (narrow), and a naive timeout would kill slow-but-valid generations. No correctness bug; deprioritized.
- **Added a concrete, ready-to-execute implementation plan for finding 2** (CRITICAL — batched decode ignores per-request temperature/top_k/seed): extract `run_layers` + `into_logits` helpers, add `forward_batched_to_logits` (logits already exist pre-argmax), branch the decode step (all-greedy → fast GPU argmax; any temp>0 → CPU `sample_topk` per slot), CPU-unit-test the selection, GPU-validate (0.5B model + concurrent diverse-temp requests + perf check) before merge.

Evidence-only (no code change). The finding-2 fix is the **next focused GPU effort**, opened WITHOUT auto-merge until GPU validation passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)