### PR TITLE
fix(serve): batched decode honors per-request temperature/top_k — CRITICAL (PMAT-764)

### DIFF
--- a/contracts/continuous-batching-v1.yaml
+++ b/contracts/continuous-batching-v1.yaml
@@ -1,5 +1,5 @@
 metadata:
-  version: 1.0.0
+  version: 1.1.0
   created: '2026-03-09'
   author: PAIML Engineering
   description: Continuous batching scheduler — unified prefill/decode with token budget
@@ -161,6 +161,22 @@ falsification_tests:
   prediction: batched_kv_lengths[i] == prefill_len for all i in 0..M
   test: Add trace after prefill_and_scatter, verify batched_kv_lengths == [S, S, S, S]
   if_fails: prefill_attention_from_packed scatter or batched_kv_lengths update buggy
+- id: FALSIFY-CB-010
+  rule: Per-request sampling honored in batched decode (PMAT-764)
+  prediction: >
+    Two batched requests with the SAME prompt but different temperature produce DIFFERENT
+    output — the batched decode applies each slot's own temperature/top_k, not a forced
+    greedy argmax for all. Restores the "Correctness under batching" equivalence
+    (batched_output(temp) ~= single_output(temp)) which the pre-fix greedy-only path violated.
+  test: >
+    cargo test -p aprender-serve --features cuda --test pmat764_batched_sampling
+    (GPU; validated 2026-06-14 on RTX 4090 / qwen2.5-coder-0.5b-instruct-q4k.apr: slot temp=0
+    and slot temp=1.5 diverge from the first generated token). Mechanism: batched_decode_step
+    routes any temp>0 slot through forward_batched_to_logits + per-slot select_batched_token.
+  if_fails: >
+    Batched decode forced greedy argmax for every slot (the pre-PMAT-764 bug) — continuous
+    batching silently ignored temperature/top_k/seed, so all requests got identical greedy
+    output regardless of their sampling params.
 kani_harnesses:
 - id: KANI-CB-001
   obligation: CB-INV-001

--- a/crates/aprender-serve/src/cuda/executor/layers/batched_forward.rs
+++ b/crates/aprender-serve/src/cuda/executor/layers/batched_forward.rs
@@ -24,17 +24,19 @@ impl CudaExecutor {
     /// # Returns
     ///
     /// M token IDs (greedy argmax)
+    ///
+    /// PMAT-764: the embed + per-layer forward is shared via batched_forward_run_layers so a
+    /// sibling (forward_batched_to_logits) can reuse it for per-request sampling.
     #[allow(clippy::too_many_arguments)]
-    pub fn forward_batched_to_token_ids(
+    fn batched_forward_run_layers(
         &mut self,
         inputs: &[f32],
         positions: &[u32],
         num_layers: usize,
         hidden_dim: u32,
         intermediate_dim: u32,
-        vocab_size: u32,
         epsilon: f32,
-    ) -> Result<Vec<u32>, GpuError> {
+    ) -> Result<(), GpuError> {
         let m = positions.len();
         // PAR-129: Extended to M=32 via 4-warp kernel
         if m == 0 || m > 32 {
@@ -163,18 +165,72 @@ impl CudaExecutor {
             }
         }
 
+        Ok(())
+    }
+
+    /// PMAT-764: batched forward → M greedy token IDs (on-GPU argmax). Behavior is identical
+    /// to the pre-refactor single-method version.
+    #[allow(clippy::too_many_arguments)]
+    pub fn forward_batched_to_token_ids(
+        &mut self,
+        inputs: &[f32],
+        positions: &[u32],
+        num_layers: usize,
+        hidden_dim: u32,
+        intermediate_dim: u32,
+        vocab_size: u32,
+        epsilon: f32,
+    ) -> Result<Vec<u32>, GpuError> {
+        self.batched_forward_run_layers(
+            inputs,
+            positions,
+            num_layers,
+            hidden_dim,
+            intermediate_dim,
+            epsilon,
+        )?;
+        let m = positions.len();
         self.batched_output_norm_lm_head_argmax(m, hidden_dim, vocab_size, epsilon)
     }
 
-    /// Output norm → LM head projection → argmax for batched forward paths
+    /// PMAT-764: batched forward → per-slot LOGITS downloaded to host (m × vocab_size,
+    /// row-major per slot), so the batched decode loop can apply per-request temperature/top_k
+    /// sampling instead of forced greedy argmax. Used only when a slot requests temperature>0.
     #[allow(clippy::too_many_arguments)]
-    fn batched_output_norm_lm_head_argmax(
+    pub fn forward_batched_to_logits(
+        &mut self,
+        inputs: &[f32],
+        positions: &[u32],
+        num_layers: usize,
+        hidden_dim: u32,
+        intermediate_dim: u32,
+        vocab_size: u32,
+        epsilon: f32,
+    ) -> Result<Vec<f32>, GpuError> {
+        self.batched_forward_run_layers(
+            inputs,
+            positions,
+            num_layers,
+            hidden_dim,
+            intermediate_dim,
+            epsilon,
+        )?;
+        let m = positions.len();
+        self.batched_output_norm_lm_head_logits(m, hidden_dim, vocab_size, epsilon)
+    }
+
+    /// PMAT-764: output norm → LM head projection, leaving logits in workspace.logits_buf.
+    /// Returns the device pointer (u64) + element count (m × vocab_size) so the caller can
+    /// either argmax on GPU (greedy) or download for CPU sampling. Extracted unchanged from
+    /// the former batched_output_norm_lm_head_argmax body.
+    #[allow(clippy::too_many_arguments)]
+    fn batched_output_norm_lm_head_into_logits(
         &mut self,
         m: usize,
         hidden_dim: u32,
         vocab_size: u32,
         epsilon: f32,
-    ) -> Result<Vec<u32>, GpuError> {
+    ) -> Result<(u64, usize), GpuError> {
         // Output norm (PAR-115: Batched - single launch for M sequences)
         let output_norm_buf = self.rmsnorm_cache.get("output_norm.gamma").ok_or_else(|| {
             GpuError::InvalidLaunchConfig("PAR-111: output_norm not cached".to_string())
@@ -281,11 +337,43 @@ impl CudaExecutor {
         // LM head GEMV and argmax both execute on self.stream — CUDA stream
         // ordering guarantees GEMV completes before argmax reads logits.
         // batched_gpu_argmax does its own sync after all 2×M kernels (reduces.rs:370).
-        let argmax_ptr = logits_buf.as_ptr();
+        let logits_ptr = logits_buf.as_ptr();
         std::mem::forget(logits_buf); // Non-owning wrapper — prevent double-free
-        let token_ids = self.batched_gpu_argmax(argmax_ptr, vocab_size, m)?;
+        Ok((logits_ptr, m * vocab_size as usize))
+    }
 
-        Ok(token_ids)
+    /// PMAT-764: batched output norm → LM head → on-GPU argmax (greedy). Behavior identical
+    /// to the pre-refactor batched_output_norm_lm_head_argmax.
+    fn batched_output_norm_lm_head_argmax(
+        &mut self,
+        m: usize,
+        hidden_dim: u32,
+        vocab_size: u32,
+        epsilon: f32,
+    ) -> Result<Vec<u32>, GpuError> {
+        let (logits_ptr, _len) =
+            self.batched_output_norm_lm_head_into_logits(m, hidden_dim, vocab_size, epsilon)?;
+        self.batched_gpu_argmax(logits_ptr, vocab_size, m)
+    }
+
+    /// PMAT-764: batched output norm → LM head → DOWNLOAD logits to host (m × vocab_size,
+    /// slot s occupies host[s*vocab_size .. (s+1)*vocab_size]) for per-request CPU sampling.
+    fn batched_output_norm_lm_head_logits(
+        &mut self,
+        m: usize,
+        hidden_dim: u32,
+        vocab_size: u32,
+        epsilon: f32,
+    ) -> Result<Vec<f32>, GpuError> {
+        let (logits_ptr, len) =
+            self.batched_output_norm_lm_head_into_logits(m, hidden_dim, vocab_size, epsilon)?;
+        // SAFETY: logits_ptr is workspace.logits_buf (valid, `len` elements); non-owning wrapper.
+        let logits_buf = unsafe { GpuBuffer::<f32>::from_raw_parts(logits_ptr, len) };
+        let mut host = vec![0.0f32; len];
+        let dl = logits_buf.copy_to_host(&mut host);
+        std::mem::forget(logits_buf); // non-owning — prevent double-free
+        dl.map_err(|e| GpuError::Transfer(format!("PMAT-764 batched logits download: {e}")))?;
+        Ok(host)
     }
 
     /// PAR-121: Graph-captured batched forward pass for M sequences

--- a/crates/aprender-serve/src/gguf/cuda/generate_batched_streaming.rs
+++ b/crates/aprender-serve/src/gguf/cuda/generate_batched_streaming.rs
@@ -1,5 +1,21 @@
 // Batched streaming token generation with per-step lock release for concurrent scheduling.
 
+/// PMAT-764: per-slot token selection for batched decode — greedy argmax when
+/// `temperature == 0.0`, else temperature/top-k sampling (the same `sample_topk` the
+/// single-request decode uses). Defined in the cuda module so the batched loop can honor
+/// each request's temperature/top_k instead of the old forced on-GPU greedy argmax.
+fn select_batched_token(logits: &[f32], temperature: f32, top_k: usize) -> u32 {
+    if temperature == 0.0 {
+        logits
+            .iter()
+            .enumerate()
+            .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
+            .map_or(0, |(idx, _)| idx as u32)
+    } else {
+        crate::gguf::OwnedQuantizedModel::sample_topk(logits, temperature, top_k)
+    }
+}
+
 /// PMAT-072: Decode state for step-wise batched generation.
 ///
 /// Extracted from `generate_batched_streaming` to allow lock release between
@@ -348,7 +364,47 @@ impl OwnedQuantizedModelCuda {
         // Keep eager by default until graph replay is optimized.
         // Enable with BATCHED_GRAPH=1 for testing.
         let use_graph = std::env::var("BATCHED_GRAPH").as_deref() == Ok("1");
-        let token_ids = if use_graph {
+
+        // PMAT-764: if any live request asked for stochastic sampling (temperature > 0),
+        // download per-slot logits and sample each by its OWN config (temperature/top_k) —
+        // the batched path otherwise forces on-GPU greedy argmax for EVERY request, silently
+        // ignoring temperature/top_k/seed. All-greedy batches keep the faster on-GPU argmax.
+        let any_sampling = state
+            .configs
+            .iter()
+            .take(state.m)
+            .any(|c| c.temperature > 0.0);
+
+        let token_ids: Vec<u32> = if any_sampling {
+            let vocab = state.vocab_size;
+            let logits = self
+                .executor
+                .forward_batched_to_logits(
+                    &state.embed_buf,
+                    &state.pos_buf,
+                    state.num_layers,
+                    state.hidden_dim as u32,
+                    state.intermediate_dim as u32,
+                    vocab as u32,
+                    state.eps,
+                )
+                .map_err(|e| RealizarError::UnsupportedOperation {
+                    operation: "forward_batched_to_logits".to_string(),
+                    reason: format!("Batched forward failed: {e}"),
+                })?;
+            (0..state.m)
+                .map(|slot| {
+                    let cfg = &state.configs[slot];
+                    let base = slot * vocab;
+                    let slot_logits = &logits[base..base + vocab];
+                    select_batched_token(
+                        slot_logits,
+                        cfg.temperature,
+                        cfg.top_k,
+                    )
+                })
+                .collect()
+        } else if use_graph {
             self.executor
                 .forward_batched_to_token_ids_graphed(
                     &state.embed_buf,

--- a/crates/aprender-serve/src/gguf/cuda/generate_batched_streaming.rs
+++ b/crates/aprender-serve/src/gguf/cuda/generate_batched_streaming.rs
@@ -991,3 +991,23 @@ impl OwnedQuantizedModelCuda {
         Ok((sequences, positions, last_tokens))
     }
 }
+
+#[cfg(test)]
+mod pmat764_select_batched_token_tests {
+    use super::select_batched_token;
+
+    #[test]
+    fn temperature_zero_is_greedy_argmax() {
+        // temp==0 must pick the max-logit index (deterministic), NOT sample.
+        assert_eq!(select_batched_token(&[1.0, 5.0, 2.0], 0.0, 40), 1);
+        assert_eq!(select_batched_token(&[9.0, 5.0, 2.0], 0.0, 40), 0);
+    }
+
+    #[test]
+    fn top_k_one_is_greedy_at_any_temperature() {
+        // top_k==1 keeps only the single best token → deterministic argmax even when
+        // temperature > 0 (the sampling branch with a 1-token nucleus).
+        assert_eq!(select_batched_token(&[1.0, 5.0, 2.0], 1.5, 1), 1);
+        assert_eq!(select_batched_token(&[9.0, 5.0, 2.0], 0.9, 1), 0);
+    }
+}

--- a/crates/aprender-serve/tests/pmat764_batched_sampling.rs
+++ b/crates/aprender-serve/tests/pmat764_batched_sampling.rs
@@ -1,0 +1,102 @@
+//! PMAT-764: CUDA continuous-batching must honor per-request temperature/top_k.
+//!
+//! Pre-fix, the batched decode (`batched_decode_step` -> `forward_batched_to_token_ids`)
+//! performed on-GPU greedy ARGMAX for EVERY slot, ignoring each request's temperature/top_k.
+//! So two requests with the SAME prompt but different temperature produced IDENTICAL output.
+//!
+//! This loads the real 0.5B model on the GPU, runs a 2-slot batch (slot 0 greedy, slot 1
+//! high-temperature), and asserts the high-temp slot DIVERGES from greedy. Pre-fix the two
+//! sequences were identical -> this assertion is the PMAT-764 falsifier. Skips gracefully if
+//! the model or CUDA is unavailable.
+//!
+//! VALIDATED 2026-06-14 on RTX 4090 with qwen2.5-coder-0.5b-instruct-q4k.apr (run with
+//! SKIP_PARITY_GATE=1 to bypass a SEPARATE pre-existing CPU/GPU forward-parity-gate failure
+//! for this apr — unrelated to the sampling dispatch under test):
+//!   slot0 greedy:  [785, 11, 1879, 374, 198, 4279, 144328, ...]
+//!   slot1 temp1.5: [785, 11, 1879, 374, 86879, 84899, 73787, ...]
+//! Same prompt prefix, immediate divergence at the first generated token -> per-request
+//! temperature is honored. (Without the fix both slots were byte-identical greedy.)
+#![cfg(feature = "cuda")]
+
+use realizar::apr::MappedAprModel;
+use realizar::gguf::{OwnedQuantizedModel, OwnedQuantizedModelCuda, QuantizedGenerateConfig};
+
+const MODEL: &str = "/mnt/nvme-raid0/models/qwen2.5-coder-0.5b-instruct-q4k.apr";
+
+fn cfg(temperature: f32, top_k: usize, seed: u64) -> QuantizedGenerateConfig {
+    QuantizedGenerateConfig {
+        max_tokens: 32,
+        temperature,
+        top_k,
+        seed,
+        stop_tokens: vec![],
+        ..Default::default()
+    }
+}
+
+#[test]
+fn pmat764_batched_honors_per_request_temperature() {
+    if !std::path::Path::new(MODEL).exists() {
+        eprintln!("SKIP pmat764: model missing: {MODEL}");
+        return;
+    }
+    let mapped = match MappedAprModel::from_path(MODEL) {
+        Ok(m) => m,
+        Err(e) => {
+            eprintln!("SKIP pmat764: MappedAprModel::from_path: {e}");
+            return;
+        },
+    };
+    let model = match OwnedQuantizedModel::from_apr(&mapped) {
+        Ok(m) => m,
+        Err(e) => {
+            eprintln!("SKIP pmat764: from_apr: {e}");
+            return;
+        },
+    };
+    let mut cuda = match OwnedQuantizedModelCuda::new(model, 0) {
+        Ok(m) => m,
+        Err(e) => {
+            eprintln!("SKIP pmat764: CUDA unavailable: {e}");
+            return;
+        },
+    };
+
+    // Same prompt for both slots (content is irrelevant to the divergence test).
+    let prompt: Vec<u32> = vec![785, 11, 1879, 374];
+    let prompts = vec![prompt.clone(), prompt.clone()];
+    // slot 0: greedy (temp=0, top_k=1). slot 1: high-temperature sampling.
+    let configs = vec![cfg(0.0, 1, 1), cfg(1.5, 50, 12345)];
+    let on_tokens: Vec<Box<dyn FnMut(u32) -> bool + Send>> =
+        vec![Box::new(|_| true), Box::new(|_| true)];
+
+    let seqs = cuda
+        .generate_batched_streaming(&prompts, &configs, on_tokens)
+        .expect("batched generation failed");
+
+    assert_eq!(seqs.len(), 2, "expected 2 slot sequences");
+    eprintln!(
+        "PMAT-764 slot0 (greedy)  len={}: {:?}",
+        seqs[0].len(),
+        seqs[0]
+    );
+    eprintln!(
+        "PMAT-764 slot1 (temp1.5) len={}: {:?}",
+        seqs[1].len(),
+        seqs[1]
+    );
+    assert!(
+        seqs[0].len() > prompt.len(),
+        "greedy slot generated nothing"
+    );
+    assert!(
+        seqs[1].len() > prompt.len(),
+        "sampled slot generated nothing"
+    );
+    // The fix: high-temperature sampling must DIVERGE from greedy. Pre-fix (forced greedy
+    // argmax for ALL slots) the two identical-prompt sequences were equal -> this fails.
+    assert_ne!(
+        seqs[0], seqs[1],
+        "PMAT-764: batched decode ignored per-request temperature (temp=1.5 slot == greedy slot)"
+    );
+}


### PR DESCRIPTION
**The most impactful bug of the session.** The CUDA continuous-batching decode path
(`batched_decode_step` → `forward_batched_to_token_ids`) did **on-GPU greedy argmax for every
slot**, never consulting `state.configs` — so when continuous batching is active, **every
request was forced to greedy output regardless of its temperature/top_k/seed**. The
single-request path samples correctly → a batched-only divergence that violated
`continuous-batching-v1`'s "Correctness under batching" parity. (Surfaced by the batch-scheduler
audit, #2025, finding 2.)

**Fix:**
- `batched_forward.rs`: extracted `batched_forward_run_layers` + `batched_output_norm_lm_head_into_logits`; `forward_batched_to_token_ids` (greedy, **byte-unchanged**) + new `forward_batched_to_logits` (downloads m×vocab logits).
- `batched_decode_step`: any slot with `temperature>0` → `forward_batched_to_logits` + per-slot `select_batched_token` (argmax for temp=0, else `sample_topk`). **All-greedy batches keep the fast on-GPU argmax path → zero perf risk to the common case**; the download is paid only when sampling is requested.

**GPU-VALIDATED on RTX 4090** (qwen2.5-coder-0.5b-instruct-q4k.apr): a 2-slot batch, same prompt, slot temp=0 vs slot temp=1.5 — **diverges from the first generated token** (pre-fix they were byte-identical greedy). Falsifiers: `pmat764_batched_sampling` (GPU integration) + `pmat764_select_batched_token_tests` (dispatch, mutation-verified). Non-cuda suite + contract lint clean.

**Co-evolution (Rule 7):** `continuous-batching-v1` → 1.1.0 (FALSIFY-CB-010).

Notes: (a) the GPU test bypasses a SEPARATE pre-existing CPU/GPU forward-parity-gate failure for this apr (`SKIP_PARITY_GATE=1`) — unrelated to the sampling dispatch; worth its own look. (b) The cuda test skips gracefully without a GPU.

🤖 Generated with [Claude Code](https://claude.com/claude-code)