### PR TITLE
fix(serve): batch-scheduler cleanup-on-error + mid-batch slot-join budget (PMAT-765)

### DIFF
--- a/contracts/continuous-batching-v1.yaml
+++ b/contracts/continuous-batching-v1.yaml
@@ -1,5 +1,5 @@
 metadata:
-  version: 1.1.0
+  version: 1.2.0
   created: '2026-03-09'
   author: PAIML Engineering
   description: Continuous batching scheduler — unified prefill/decode with token budget
@@ -177,6 +177,30 @@ falsification_tests:
     Batched decode forced greedy argmax for every slot (the pre-PMAT-764 bug) — continuous
     batching silently ignored temperature/top_k/seed, so all requests got identical greedy
     output regardless of their sampling params.
+- id: FALSIFY-CB-011
+  rule: Mid-batch slot-join budget includes gen_idx offset (PMAT-765)
+  prediction: >
+    add_slot_to_batch extends max_tokens_max by `gen_idx + new_config.max_tokens` (NOT just
+    max_tokens), consistent with recycle_slot/recycle_slots_batch. A slot joining at step N
+    with max_tokens M therefore runs until N+M and gets its full M generation steps.
+  test: >
+    Source check: add_slot_to_batch's max_tokens_max update adds state.gen_idx (matches
+    recycle_slot). A slot joined at gen_idx>0 produces max_tokens tokens, not max_tokens-gen_idx.
+  if_fails: >
+    A mid-batch-joined request terminates ~gen_idx steps early (the pre-PMAT-765 bug:
+    add_slot_to_batch used max(max_tokens) without the gen_idx offset).
+- id: FALSIFY-CB-012
+  rule: Aborted setup/prefill resets batched state (PMAT-765)
+  prediction: >
+    On batched_setup_and_prefill error, the scheduler calls reset_batched_state()
+    (batched_kv_stride = 0 + clear_decode_graph) before returning, so the NEXT batch reinits
+    cleanly instead of reusing buffers with a stale stride.
+  test: >
+    Source check: cuda_batch_scheduler.rs setup-error arm calls cuda_model.reset_batched_state()
+    before return; reset_batched_state zeroes batched_kv_stride (mirrors batched_cleanup).
+  if_fails: >
+    A failed setup leaves batched_kv_stride non-zero; the next (buffer-reusing) batch writes
+    K/V to the wrong slots -> cross-request KV corruption (the pre-PMAT-765 bug).
 kani_harnesses:
 - id: KANI-CB-001
   obligation: CB-INV-001

--- a/crates/aprender-serve/src/api/cuda_batch_scheduler.rs
+++ b/crates/aprender-serve/src/api/cuda_batch_scheduler.rs
@@ -328,6 +328,9 @@ fn process_cuda_batch(
                 for req in &pending_joins {
                     let _ = req.token_tx.try_send(Err(e.to_string()));
                 }
+                // PMAT-765: reset stale batched state (batched_kv_stride) before returning, so
+                // the NEXT batch doesn't reuse buffers with a stale stride → KV corruption.
+                cuda_model.reset_batched_state();
                 return;
             },
         }

--- a/crates/aprender-serve/src/gguf/cuda/generate_batched_streaming.rs
+++ b/crates/aprender-serve/src/gguf/cuda/generate_batched_streaming.rs
@@ -458,6 +458,21 @@ impl OwnedQuantizedModelCuda {
     /// VRAM budget: FP16(2944)+KV(896)+Q4K(850)+WS(40) = 4730 MB fits 7.5 GB.
     ///
     /// Caller must hold model write lock for the duration of this call.
+    /// PMAT-765: reset batched logical state after an ABORTED setup/prefill — before any
+    /// `BatchedDecodeState` exists (so the full `batched_cleanup` can't run).
+    /// `batched_setup_and_prefill` may have already called `init_batched_kv_cache_gpu` (which
+    /// sets `batched_kv_stride != 0`) before failing; if the error path returns WITHOUT
+    /// resetting it, the next batch reuses buffers (PMAT-075 high-water mark) with a STALE
+    /// stride and prefill/scatter writes K/V to the wrong slots → cross-request KV corruption.
+    /// Mirrors the stride + decode-graph resets that `batched_cleanup` performs.
+    pub fn reset_batched_state(&mut self) {
+        self.executor.batched_kv_stride = 0;
+        self.executor.clear_decode_graph();
+    }
+
+    /// PMAT-072: Cleanup after step-wise batched generation. Preserves workspace + batched KV
+    /// buffers (PMAT-075 high-water mark for graph reuse) and resets the batched logical state
+    /// (batched_kv_stride, decode graph) so the next batch starts clean.
     pub fn batched_cleanup(&mut self, state: &BatchedDecodeState) {
         // PMAT-061: Disable HGEMM batched decode flag before cleanup.
         self.executor.hgemm_batched_decode_active = false;
@@ -597,9 +612,17 @@ impl OwnedQuantizedModelCuda {
         state.m = new_m;
         state.embed_buf.resize(new_m * state.hidden_dim, 0.0);
         state.pos_buf.resize(new_m, 0);
-        state.max_tokens_max = state
-            .max_tokens_max
-            .max(state.configs.last().expect("configs must not be empty when updating max_tokens").max_tokens);
+        // PMAT-765: a slot joining mid-batch at step `gen_idx` with `max_tokens` M must run
+        // until gen_idx + M, else it terminates ~gen_idx steps early. recycle_slot and
+        // recycle_slots_batch already add the gen_idx offset; add_slot_to_batch did not.
+        state.max_tokens_max = state.max_tokens_max.max(
+            state.gen_idx
+                + state
+                    .configs
+                    .last()
+                    .expect("configs must not be empty when updating max_tokens")
+                    .max_tokens,
+        );
 
         let prefill_ms = prefill_start.elapsed().as_secs_f64() * 1000.0;
         eprintln!(


### PR DESCRIPTION
Two confirmed bugs from the batch-scheduler audit (#2025), each fixed by making the buggy path consistent with its already-correct sibling:

**[1, HIGH] Cleanup on aborted setup** — `cuda_batch_scheduler.rs` returned on `batched_setup_and_prefill` error **without** resetting `batched_kv_stride`. PMAT-075 keeps KV buffers alive across batches, so the next batch reused them with a **stale stride** → prefill/scatter wrote K/V to the wrong slots → cross-request corruption. Fix: new `reset_batched_state()` (`batched_kv_stride=0` + `clear_decode_graph`, mirroring `batched_cleanup`) called on the error path.

**[5/6, HIGH] Mid-batch slot-join budget** — `add_slot_to_batch` extended `max_tokens_max` by `max_tokens` only, omitting the `gen_idx` offset that `recycle_slot`/`recycle_slots_batch` already apply → a slot joining at step N ran until M instead of N+M (~N steps short). Fix: add `gen_idx`.

**Co-evolution (Rule 7):** `continuous-batching-v1` → 1.2.0 (FALSIFY-CB-011, FALSIFY-CB-012). Both are rare GPU edge paths (setup error / mid-batch join) mirroring proven sibling code; cuda + non-cuda + `pv validate` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)