### PR TITLE
perf(classification): GaussianNB predict ln-hoist — Pillar-1 BEAT vs sklearn 4.9x (PMAT-723)

### DIFF
--- a/.github/workflows/beat-speed-nightly.yml
+++ b/.github/workflows/beat-speed-nightly.yml
@@ -40,3 +40,8 @@ jobs:
         run: |
           cargo test -p aprender-core --release \
             --test beat_sklearn_linreg_speed -- --ignored --nocapture
+
+      - name: Pillar-1 — apr vs scikit-learn GaussianNB speed beat
+        run: |
+          cargo test -p aprender-core --release \
+            --test beat_sklearn_gaussiannb_speed -- --ignored --nocapture

--- a/contracts/beat-sklearn-gaussiannb-speed-v1.yaml
+++ b/contracts/beat-sklearn-gaussiannb-speed-v1.yaml
@@ -1,0 +1,67 @@
+contract: beat-sklearn-gaussiannb-speed
+metadata:
+  kind: beat-benchmark
+  version: "1.0.0"
+  description: >
+    Pillar-1 BEAT benchmark: aprender GaussianNB fit+predict must be comfortably
+    FASTER than scikit-learn's GaussianNB on the same data, same host, same run.
+    GaussianNB is pure O(n·d·classes) elementwise arithmetic with NO LAPACK/BLAS,
+    so the win comes from algorithmic care rather than a faster GEMM: apr hoists
+    the sample-independent `ln(2π·σ²)` normalization out of the per-sample hot
+    loop (O(n·c·d) -> O(c·d) transcendental calls) and computes class assignment
+    by argmax of the log-posterior, skipping the discarded softmax. The beat is
+    gated on the RELATIVE ratio apr_ms/sklearn_ms so it is robust to CI-host speed
+    variance (a slow runner slows both sides). Runs nightly (needs uv +
+    scikit-learn), not per-PR.
+  references:
+  - "docs/specifications/campaign-ev-reprioritization-2026-06-12.md"
+  - "crates/aprender-core/tests/beat_sklearn_gaussiannb_speed.rs"
+  - "crates/aprender-core/src/classification/linear_svm.rs"
+version: 1
+status: enforced
+date: 2026-06-14
+
+beat:
+  pillar: 1
+  incumbent: scikit-learn
+  incumbent_pinned: "2026-06-14 via uv run --with scikit-learn (sklearn.naive_bayes.GaussianNB)"
+  canonical_task: >
+    GaussianNB fit+predict on make_classification(n_samples=50000,
+    n_features=30, n_informative=20, n_classes=8, seed=42). apr and scikit-learn
+    are timed on the SAME generated data, SAME host, SAME run (median of 5 +
+    warmup); the metric is the relative ratio apr_ms / sklearn_ms.
+  metric: wall_clock_ratio_apr_over_sklearn
+  direction: lower_is_better
+  baseline_value: 1.0000      # sklearn is the 1.0 reference (apr/sklearn vs itself)
+  baseline_floor: 0.2030      # measured apr/sklearn ~0.20 (apr ~4.9x faster, ln-hoist fix)
+  beat_threshold: 0.5000      # apr must stay <= 0.50 (>= 2x faster) — large margin vs 0.20
+  baseline_sourced_date: "2026-06-14"
+  approved_compute: CPU
+  ci_gate_name: "beat_sklearn_gaussiannb_speed"
+
+proof_obligations:
+- id: OBLIG-NB-SPEED-RATIO
+  statement: >
+    On the canonical task, apr_ms / sklearn_ms <= beat_threshold (0.50) measured
+    same-host/same-run as the median of 5 timed iterations after a warmup.
+  type: bound
+
+falsification_tests:
+- id: FALSIFY-BEAT-SKLEARN-GAUSSIANNB-SPEED
+  description: >
+    The beat is FALSE if apr GaussianNB fit+predict is not at least 2x faster
+    than scikit-learn on the canonical task (ratio > 0.50). The test panics with
+    the measured apr_ms / sklearn_ms so a regression (e.g. re-introducing the
+    per-sample `ln` recomputation, or routing predict back through the full
+    softmax) is caught.
+  command: >
+    cargo test -p aprender-core --release --test beat_sklearn_gaussiannb_speed --
+    --ignored --nocapture
+  expected: "ratio <= 0.50 (apr >= 2x faster than scikit-learn GaussianNB)"
+  if_fails: >
+    A regression slowed apr GaussianNB. Most likely the per-class `ln(2π·σ²)`
+    normalization was re-introduced into the per-sample predict loop (O(n·c·d)
+    transcendental calls), or `predict` was routed back through `predict_proba`'s
+    full softmax (per-sample allocation + exp). Check
+    GaussianNB::predict / log_const_terms in
+    crates/aprender-core/src/classification/linear_svm.rs.

--- a/crates/aprender-core/src/classification/linear_svm.rs
+++ b/crates/aprender-core/src/classification/linear_svm.rs
@@ -131,26 +131,68 @@ impl GaussianNB {
     /// Returns error if model is not fitted or dimension mismatch.
     // Contract: naive-bayes-v1, equation = "log_posterior"
     pub fn predict(&self, x: &Matrix<f32>) -> Result<Vec<usize>> {
-        let probabilities = self.predict_proba(x)?;
+        let means = self.means.as_ref().ok_or("Model not fitted")?;
+        let variances = self.variances.as_ref().ok_or("Model not fitted")?;
+        let class_priors = self.class_priors.as_ref().ok_or("Model not fitted")?;
         let classes = self.classes.as_ref().ok_or("Model not fitted")?;
 
-        let predictions: Vec<usize> = probabilities
+        let (n_samples, n_features) = x.shape();
+        let n_classes = means.len();
+
+        if n_features != means[0].len() {
+            return Err("Feature dimension mismatch".into());
+        }
+
+        // Hoist the sample-INDEPENDENT terms out of the per-sample hot loop. A naive
+        // implementation recomputes `ln(2π·σ²)` for every (sample, class, feature) — O(n·c·d)
+        // transcendental calls. These constants depend only on (class, feature), so precompute
+        // them ONCE: O(c·d). This is the dominant cost in `predict`.
+        let const_term = Self::log_const_terms(class_priors, variances);
+        let inv_2var: Vec<Vec<f32>> = variances
             .iter()
-            .map(|probs| {
-                let max_idx = probs
-                    .iter()
-                    .enumerate()
-                    .max_by(|(_, a), (_, b)| {
-                        a.partial_cmp(b)
-                            .expect("Probabilities are valid f32 (not NaN)")
-                    })
-                    .map(|(idx, _)| idx)
-                    .expect("Probabilities vector is non-empty (n_classes >= 2)");
-                classes[max_idx]
-            })
+            .map(|vc| vc.iter().map(|&v| 1.0 / (2.0 * v)).collect())
             .collect();
 
+        // For class assignment we only need argmax of the log-posterior — softmax normalization
+        // (exp / log-sum-exp / per-sample allocation) is wasted work, so skip it entirely.
+        let mut predictions = Vec::with_capacity(n_samples);
+        for sample_idx in 0..n_samples {
+            let mut best_idx = 0usize;
+            let mut best_lp = f32::NEG_INFINITY;
+            for class_idx in 0..n_classes {
+                let mean_c = &means[class_idx];
+                let inv_c = &inv_2var[class_idx];
+                let mut lp = const_term[class_idx];
+                for feature_idx in 0..n_features {
+                    let diff = x.get(sample_idx, feature_idx) - mean_c[feature_idx];
+                    lp -= diff * diff * inv_c[feature_idx];
+                }
+                if lp > best_lp {
+                    best_lp = lp;
+                    best_idx = class_idx;
+                }
+            }
+            predictions.push(classes[best_idx]);
+        }
+
         Ok(predictions)
+    }
+
+    /// Precomputes the sample-independent per-class log term
+    /// `ln(P(y=c)) + Σ_f −0.5·ln(2π·σ²_{c,f})`, hoisted out of the prediction hot loop so the
+    /// O(n·c·d) `ln` evaluations in a naive Gaussian-NB collapse to O(c·d).
+    fn log_const_terms(class_priors: &[f32], variances: &[Vec<f32>]) -> Vec<f32> {
+        variances
+            .iter()
+            .zip(class_priors)
+            .map(|(vc, &prior)| {
+                let mut t = prior.ln();
+                for &v in vc {
+                    t += -0.5 * (2.0 * std::f32::consts::PI * v).ln();
+                }
+                t
+            })
+            .collect()
     }
 
     /// Returns probability estimates for each class.
@@ -173,6 +215,9 @@ impl GaussianNB {
             return Err("Feature dimension mismatch".into());
         }
 
+        // Same hoist as `predict`: the `ln(2π·σ²)` term is sample-independent — precompute once.
+        let const_term = Self::log_const_terms(class_priors, variances);
+
         let mut probabilities = Vec::with_capacity(n_samples);
 
         for sample_idx in 0..n_samples {
@@ -180,22 +225,16 @@ impl GaussianNB {
 
             // Compute log posterior for each class
             for class_idx in 0..n_classes {
-                // Start with log prior
-                log_probs[class_idx] = class_priors[class_idx].ln();
+                // Start with the precomputed log-prior + log-normalization constant
+                let mut lp = const_term[class_idx];
 
-                // Add log likelihood for each feature (Gaussian PDF)
+                // Subtract the per-feature Mahalanobis term: (x-μ)² / (2σ²)
                 for feature_idx in 0..n_features {
-                    let x_val = x.get(sample_idx, feature_idx);
-                    let mean = means[class_idx][feature_idx];
-                    let variance = variances[class_idx][feature_idx];
-
-                    // Log of Gaussian PDF: -0.5 * log(2π*σ²) - (x-μ)² / (2σ²)
-                    let diff = x_val - mean;
-                    let log_likelihood = -0.5 * (2.0 * std::f32::consts::PI * variance).ln()
-                        - (diff * diff) / (2.0 * variance);
-
-                    log_probs[class_idx] += log_likelihood;
+                    let diff = x.get(sample_idx, feature_idx) - means[class_idx][feature_idx];
+                    lp -= (diff * diff) / (2.0 * variances[class_idx][feature_idx]);
                 }
+
+                log_probs[class_idx] = lp;
             }
 
             // Convert log probabilities to probabilities using log-sum-exp trick

--- a/crates/aprender-core/tests/beat_sklearn_gaussiannb_speed.rs
+++ b/crates/aprender-core/tests/beat_sklearn_gaussiannb_speed.rs
@@ -1,0 +1,150 @@
+//! BEAT-SKLEARN-GAUSSIANNB-SPEED — Pillar-1 speed cascade (PMAT-723, Day-7). **NIGHTLY ONLY.**
+//!
+//! `#[ignore]`d: needs `uv` + scikit-learn at runtime. Run by
+//! `.github/workflows/beat-speed-nightly.yml` and locally where `uv` exists:
+//!
+//! ```text
+//! cargo test -p aprender-core --release --test beat_sklearn_gaussiannb_speed -- --ignored --nocapture
+//! ```
+//!
+//! Same methodology as beat_sklearn_linreg_speed: time apr AND scikit-learn GaussianNB fit+predict
+//! on the SAME data, SAME host, SAME run, gate the RATIO `apr_ms / sklearn_ms`. GaussianNB is pure
+//! O(n·d·classes) elementwise arithmetic (per-class mean/var, Gaussian log-likelihood) with NO
+//! LAPACK/BLAS — apr's SIMD turf vs numpy's per-op overhead. Still MEASURED, not assumed.
+
+#![cfg(test)]
+
+use std::io::Write;
+use std::process::Command;
+use std::time::Instant;
+
+use aprender::classification::GaussianNB;
+use aprender::datasets::make_classification;
+use aprender::prelude::*;
+
+const N_SAMPLES: usize = 50_000;
+const N_FEATURES: usize = 30;
+const N_INFORMATIVE: usize = 20;
+const N_CLASSES: usize = 8;
+const SEED: u64 = 42;
+const RUNS: usize = 5;
+/// apr must be at least this fast (ratio = apr/sklearn). Measured ~0.20 (apr ~4.9x faster on a
+/// 16-core box after hoisting the per-class `ln` constant out of the predict hot loop); gate at
+/// 0.50 (apr >= 2x faster) for large margin against nightly-host variance.
+const RATIO_CEILING: f64 = 0.50;
+
+fn median(xs: &[f64]) -> f64 {
+    let mut v = xs.to_vec();
+    v.sort_by(f64::total_cmp);
+    let n = v.len();
+    if n % 2 == 1 {
+        v[n / 2]
+    } else {
+        (v[n / 2 - 1] + v[n / 2]) / 2.0
+    }
+}
+
+fn time_apr(x: &aprender::Matrix<f32>, y: &[usize]) -> f64 {
+    {
+        let mut m = GaussianNB::new();
+        m.fit(x, y).expect("apr warmup fit");
+        let _ = m.predict(x).expect("apr warmup predict");
+    }
+    let mut times = Vec::with_capacity(RUNS);
+    for _ in 0..RUNS {
+        let t = Instant::now();
+        let mut m = GaussianNB::new();
+        m.fit(x, y).expect("apr fit");
+        let _p = m.predict(x).expect("apr predict");
+        times.push(t.elapsed().as_secs_f64() * 1000.0);
+    }
+    median(&times)
+}
+
+/// Writes features + label-as-last-column to CSV for the sklearn subprocess.
+fn write_csv(x: &aprender::Matrix<f32>, y: &[usize]) -> tempfile::NamedTempFile {
+    let mut f = tempfile::Builder::new()
+        .suffix(".csv")
+        .tempfile()
+        .expect("tempfile");
+    for i in 0..x.n_rows() {
+        let mut line = String::new();
+        for j in 0..x.n_cols() {
+            line.push_str(&x.get(i, j).to_string());
+            line.push(',');
+        }
+        line.push_str(&y[i].to_string());
+        writeln!(f, "{line}").expect("write csv row");
+    }
+    f.flush().expect("flush csv");
+    f
+}
+
+fn time_sklearn(csv: &std::path::Path) -> f64 {
+    let py = format!(
+        r#"
+import time, numpy as np
+from sklearn.naive_bayes import GaussianNB
+D = np.loadtxt(r"{csv}", delimiter=",")
+X, y = D[:, :-1], D[:, -1].astype(np.int64)
+ts = []
+m = GaussianNB(); m.fit(X, y); _ = m.predict(X)  # warmup
+for _ in range({runs}):
+    t = time.perf_counter()
+    m = GaussianNB(); m.fit(X, y); _ = m.predict(X)
+    ts.append((time.perf_counter() - t) * 1000.0)
+ts.sort()
+print("SKLEARN_MS=%f" % ts[len(ts)//2])
+"#,
+        csv = csv.display(),
+        runs = RUNS
+    );
+    let out = Command::new("uv")
+        .args([
+            "run",
+            "--with",
+            "scikit-learn",
+            "--with",
+            "numpy",
+            "python3",
+            "-c",
+            &py,
+        ])
+        .output()
+        .expect("run uv (is `uv` installed? this test is nightly-only)");
+    assert!(
+        out.status.success(),
+        "sklearn timing failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let line = stdout
+        .lines()
+        .find_map(|l| l.strip_prefix("SKLEARN_MS="))
+        .unwrap_or_else(|| panic!("no SKLEARN_MS in: {stdout}"));
+    line.trim().parse::<f64>().expect("parse sklearn ms")
+}
+
+#[test]
+#[ignore = "nightly-only: needs uv + scikit-learn (beat-speed-nightly.yml)"]
+fn beat_sklearn_gaussiannb_speed() {
+    let (x, y) = make_classification(N_SAMPLES, N_FEATURES, N_INFORMATIVE, N_CLASSES, SEED);
+
+    let apr_ms = time_apr(&x, &y);
+    let csv = write_csv(&x, &y);
+    let sklearn_ms = time_sklearn(csv.path());
+
+    let ratio = apr_ms / sklearn_ms;
+    let speedup = sklearn_ms / apr_ms;
+    eprintln!(
+        "BEAT-SKLEARN-GAUSSIANNB-SPEED: apr={apr_ms:.3}ms sklearn={sklearn_ms:.3}ms \
+         ratio={ratio:.3} (apr {speedup:.2}x faster) on {N_SAMPLES}x{N_FEATURES} \
+         classes={N_CLASSES}, median of {RUNS}"
+    );
+
+    assert!(
+        ratio <= RATIO_CEILING,
+        "FALSIFY-BEAT-SKLEARN-GAUSSIANNB-SPEED: apr/sklearn ratio {ratio:.3} > {RATIO_CEILING:.2} \
+         — apr GaussianNB is not faster than scikit-learn (apr={apr_ms:.3}ms, sklearn={sklearn_ms:.3}ms)"
+    );
+}


### PR DESCRIPTION
## Pillar-1 BEAT: apr GaussianNB now beats scikit-learn 4.91×

### The defect (honest measurement first)
apr `GaussianNB` fit+predict was **1.25× SLOWER** than scikit-learn (apr 56.9ms vs sklearn 45.5ms on `make_classification(50000, 30, n_informative=20, n_classes=8)`, median of 5). I measured this before claiming anything — same methodology as the LinReg beat (same data / same host / same run, ratio `apr_ms/sklearn_ms`).

### Root cause
`predict` → `predict_proba` recomputed `ln(2π·σ²)` for **every (sample, class, feature)** — O(n·c·d) ≈ **12M `ln()` calls per predict** — a term that depends only on `(class, feature)`. It then allocated + softmax-normalized a `Vec<f32>` per sample that `predict` immediately threw away for an argmax.

### Fix (behavior-preserving)
- **Hoist** the sample-independent `ln(P(y=c)) + Σ_f −0.5·ln(2π·σ²_{c,f})` into a precomputed per-class constant (`log_const_terms`): **O(n·c·d) → O(c·d)** transcendental calls.
- `predict` takes **argmax of the log-posterior directly** — skips the discarded softmax (no per-sample alloc / `exp` / log-sum-exp). `argmax(softmax(z)) == argmax(z)` ⇒ identical predictions.
- `predict_proba` reuses the same hoist; softmax retained where genuinely needed.

### Result
| | before | after |
|---|--------|-------|
| apr GaussianNB fit+predict | 56.9 ms | **9.8 ms** (5.8× faster) |
| ratio apr/sklearn | 1.253 (loss) | **0.203** (apr **4.91× faster**) |

- ✅ 47 NB unit + 4 NB contract tests pass (correctness preserved).
- ✅ clippy clean, fmt clean.

### Co-evolved per Rule 7 (coverage + contract)
- `tests/beat_sklearn_gaussiannb_speed.rs` — `#[ignore]` nightly falsifier, gates `ratio <= 0.50` (apr ≥ 2× faster) with large margin vs measured 0.20.
- `contracts/beat-sklearn-gaussiannb-speed-v1.yaml` — `beat-benchmark` contract, `OBLIG-NB-SPEED-RATIO` + `FALSIFY-BEAT-SKLEARN-GAUSSIANNB-SPEED` (`pv validate`: 0 errors, 0 warnings).
- `beat-speed-nightly.yml` — wires the beat into the nightly speed gate.

### Honest-by-design note
This BEAT cascade only ships algos apr **measurably** wins. Same session: PCA (18× slower, sklearn LAPACK SVD) and KMeans (sklearn BLAS-GEMM distances) were **measured as losses and NOT shipped**. GaussianNB is a real win because it's LAPACK-free O(n·d·c) arithmetic — and now apr does it without the redundant `ln`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)