### PR TITLE
test(merge): fix <2-files contract tests under --release (PMAT-766)

### DIFF
--- a/crates/apr-cli/src/commands/merge_tests.rs
+++ b/crates/apr-cli/src/commands/merge_tests.rs
@@ -7,12 +7,18 @@ use tempfile::NamedTempFile;
 // Validation Error Tests
 // ========================================================================
 
+// NOTE: the merge precondition is a `debug_assert!` (contract_pre_merge_weight_conservation),
+// so it panics only in debug builds. In `--release` it is compiled out and `run` falls through to
+// `validate_merge_inputs`, which returns `Err(ValidationFailed)`. These tests assert the rejection
+// build-mode-agnostically: debug => panics ("Contract …"), release => Err. Either way <2 files is
+// rejected. (Without the cfg_attr these `#[should_panic]` tests fail under `cargo test --release`.)
+
 #[test]
-#[should_panic(expected = "Contract")]
+#[cfg_attr(debug_assertions, should_panic(expected = "Contract"))]
 fn test_run_insufficient_files() {
-    // Contract pre-condition panics: merge requires >= 2 files
+    // Merge requires >= 2 files.
     let file = NamedTempFile::with_suffix(".apr").expect("create temp file");
-    let _ = run(
+    let result = run(
         &[file.path().to_path_buf()],
         "average",
         Some(Path::new("/tmp/merged.apr")),
@@ -24,13 +30,20 @@ fn test_run_insufficient_files() {
         false,
         false,
     );
+    // Debug: unreachable (panicked above). Release: must be a rejection, not a successful merge.
+    #[cfg(not(debug_assertions))]
+    assert!(
+        result.is_err(),
+        "merge with <2 files must return Err in release"
+    );
+    let _ = result;
 }
 
 #[test]
-#[should_panic(expected = "Contract")]
+#[cfg_attr(debug_assertions, should_panic(expected = "Contract"))]
 fn test_run_empty_files() {
-    // Contract pre-condition panics: merge requires non-empty file list
-    let _ = run(
+    // Merge requires a non-empty file list.
+    let result = run(
         &[],
         "average",
         Some(Path::new("/tmp/merged.apr")),
@@ -42,6 +55,13 @@ fn test_run_empty_files() {
         false,
         false,
     );
+    // Debug: unreachable (panicked above). Release: must be a rejection, not a successful merge.
+    #[cfg(not(debug_assertions))]
+    assert!(
+        result.is_err(),
+        "merge with empty file list must return Err in release"
+    );
+    let _ = result;
 }
 
 #[test]


### PR DESCRIPTION
## apr-cli release-test defect (found by aarch64/gx10 cross-platform validation)

`cargo test -p apr-cli --lib --release` was **red** — 2 failures:
```
test commands::merge::tests::test_run_empty_files - should panic ... FAILED
test commands::merge::tests::test_run_insufficient_files - should panic ... FAILED
```
(Green in CI, which runs the default **debug** profile — so this was latent until a release test run.)

### Root cause
Both are `#[should_panic(expected = "Contract")]` on the merge precondition
`contract_pre_merge_weight_conservation!(files)`, which expands to a **`debug_assert!`**
(`generated_contracts.rs:4089`). In `--release`, `debug_assert!` is compiled out, so `run`
falls through to `validate_merge_inputs`, which **returns `Err(ValidationFailed)`** rather than
panicking — so the `#[should_panic]` tests fail.

The production behavior is *correct in both modes*: <2 files is always rejected (debug via the
contract assert, release via the `Result`). User-input errors returning `Err` instead of panicking
in release is the desired behavior — so **no production change is warranted**.

### Fix (test-only)
`#[cfg_attr(debug_assertions, should_panic(expected = "Contract"))]` + assert `result.is_err()` in
release. Debug ⇒ contract panics; release ⇒ graceful `Err`.

### Verified
- ✅ debug: `test_run_empty_files - should panic ... ok`, `test_run_insufficient_files - should panic ... ok`
- ✅ release: `test_run_empty_files ... ok`, `test_run_insufficient_files ... ok`
- 10/10 `commands::merge::tests::test_run` pass in **both** profiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)