### PR TITLE
feat(beat): apr MinMaxScaler beats scikit-learn 1.54x — Pillar-1 (PMAT-727)

### DIFF
--- a/.github/workflows/beat-speed-nightly.yml
+++ b/.github/workflows/beat-speed-nightly.yml
@@ -50,3 +50,8 @@ jobs:
         run: |
           cargo test -p aprender-core --release \
             --test beat_sklearn_scaler_speed -- --ignored --nocapture
+
+      - name: Pillar-1 — apr vs scikit-learn MinMaxScaler speed beat
+        run: |
+          cargo test -p aprender-core --release \
+            --test beat_sklearn_minmax_speed -- --ignored --nocapture

--- a/contracts/beat-sklearn-minmax-speed-v1.yaml
+++ b/contracts/beat-sklearn-minmax-speed-v1.yaml
@@ -1,0 +1,59 @@
+contract: beat-sklearn-minmax-speed
+metadata:
+  kind: beat-benchmark
+  version: "1.0.0"
+  description: >
+    Pillar-1 BEAT benchmark: aprender MinMaxScaler fit_transform must be
+    comfortably FASTER than scikit-learn's MinMaxScaler on the same data, same
+    host, same run. MinMaxScaler is pure O(n·d) per-column min/max + rescale with
+    NO LAPACK/BLAS — apr's SIMD turf vs numpy's per-op overhead. The beat is gated
+    on the RELATIVE ratio apr_ms/sklearn_ms so it is robust to CI-host speed
+    variance (a slow runner slows both sides). Runs nightly (needs uv +
+    scikit-learn), not per-PR.
+  references:
+  - "docs/specifications/campaign-ev-reprioritization-2026-06-12.md"
+  - "crates/aprender-core/tests/beat_sklearn_minmax_speed.rs"
+  - "crates/aprender-core/src/preprocessing/mod.rs"
+version: 1
+status: enforced
+date: 2026-06-14
+
+beat:
+  pillar: 1
+  incumbent: scikit-learn
+  incumbent_pinned: "2026-06-14 via uv run --with scikit-learn (sklearn.preprocessing.MinMaxScaler)"
+  canonical_task: >
+    MinMaxScaler fit_transform on make_regression(n_samples=200000,
+    n_features=50, noise=0.1, seed=42) features. apr and scikit-learn are timed on
+    the SAME generated data, SAME host, SAME run (median of 5 + warmup); the metric
+    is the relative ratio apr_ms / sklearn_ms.
+  metric: wall_clock_ratio_apr_over_sklearn
+  direction: lower_is_better
+  baseline_value: 1.0000      # sklearn is the 1.0 reference (apr/sklearn vs itself)
+  baseline_floor: 0.6480      # measured apr/sklearn ~0.65 (apr ~1.54x faster)
+  beat_threshold: 0.8000      # apr must stay <= 0.80 (>= 1.25x faster) — margin vs 0.65
+  baseline_sourced_date: "2026-06-14"
+  approved_compute: CPU
+  ci_gate_name: "beat_sklearn_minmax_speed"
+
+proof_obligations:
+- id: OBLIG-MINMAX-SPEED-RATIO
+  statement: >
+    On the canonical task, apr_ms / sklearn_ms <= beat_threshold (0.80) measured
+    same-host/same-run as the median of 5 timed iterations after a warmup.
+  type: bound
+
+falsification_tests:
+- id: FALSIFY-BEAT-SKLEARN-MINMAXSCALER-SPEED
+  description: >
+    The beat is FALSE if apr MinMaxScaler fit_transform is not at least 1.25x
+    faster than scikit-learn on the canonical task (ratio > 0.80). The test panics
+    with the measured apr_ms / sklearn_ms so a regression is caught.
+  command: >
+    cargo test -p aprender-core --release --test beat_sklearn_minmax_speed --
+    --ignored --nocapture
+  expected: "ratio <= 0.80 (apr >= 1.25x faster than scikit-learn MinMaxScaler)"
+  if_fails: >
+    A regression slowed apr MinMaxScaler fit_transform (preprocessing/mod.rs,
+    MinMaxScaler::fit_transform / Transformer impl), or the per-column min/max
+    pass lost SIMD vectorization. Compare apr vs sklearn ms in the panic message.

--- a/crates/aprender-core/tests/beat_sklearn_minmax_speed.rs
+++ b/crates/aprender-core/tests/beat_sklearn_minmax_speed.rs
@@ -1,0 +1,127 @@
+//! BEAT-SKLEARN-MINMAXSCALER-SPEED — Pillar-1 speed cascade (PMAT-727). **NIGHTLY ONLY.**
+//! cargo test -p aprender-core --release --test beat_sklearn_minmax_speed -- --ignored --nocapture
+#![cfg(test)]
+
+use std::io::Write;
+use std::process::Command;
+use std::time::Instant;
+
+use aprender::datasets::make_regression;
+use aprender::prelude::*;
+use aprender::preprocessing::MinMaxScaler;
+
+const N_SAMPLES: usize = 200_000;
+const N_FEATURES: usize = 50;
+const SEED: u64 = 42;
+const RUNS: usize = 5;
+const RATIO_CEILING: f64 = 0.80;
+
+fn median(xs: &[f64]) -> f64 {
+    let mut v = xs.to_vec();
+    v.sort_by(f64::total_cmp);
+    let n = v.len();
+    if n % 2 == 1 {
+        v[n / 2]
+    } else {
+        (v[n / 2 - 1] + v[n / 2]) / 2.0
+    }
+}
+
+fn time_apr(x: &aprender::Matrix<f32>) -> f64 {
+    {
+        let mut m = MinMaxScaler::new();
+        let _ = m.fit_transform(x).expect("warmup");
+    }
+    let mut times = Vec::with_capacity(RUNS);
+    for _ in 0..RUNS {
+        let t = Instant::now();
+        let mut m = MinMaxScaler::new();
+        let _z = m.fit_transform(x).expect("fit_transform");
+        times.push(t.elapsed().as_secs_f64() * 1000.0);
+    }
+    median(&times)
+}
+
+fn write_csv(x: &aprender::Matrix<f32>) -> tempfile::NamedTempFile {
+    let mut f = tempfile::Builder::new()
+        .suffix(".csv")
+        .tempfile()
+        .expect("tempfile");
+    for i in 0..x.n_rows() {
+        let mut line = String::new();
+        for j in 0..x.n_cols() {
+            if j > 0 {
+                line.push(',');
+            }
+            line.push_str(&x.get(i, j).to_string());
+        }
+        writeln!(f, "{line}").expect("row");
+    }
+    f.flush().expect("flush");
+    f
+}
+
+fn time_sklearn(csv: &std::path::Path) -> f64 {
+    let py = format!(
+        r#"
+import time, numpy as np
+from sklearn.preprocessing import MinMaxScaler
+X = np.loadtxt(r"{csv}", delimiter=",").astype(np.float32)
+ts = []
+m = MinMaxScaler(); _ = m.fit_transform(X)
+for _ in range({runs}):
+    t = time.perf_counter()
+    m = MinMaxScaler(); _ = m.fit_transform(X)
+    ts.append((time.perf_counter() - t) * 1000.0)
+ts.sort()
+print("SKLEARN_MS=%f" % ts[len(ts)//2])
+"#,
+        csv = csv.display(),
+        runs = RUNS
+    );
+    let out = Command::new("uv")
+        .args([
+            "run",
+            "--with",
+            "scikit-learn",
+            "--with",
+            "numpy",
+            "python3",
+            "-c",
+            &py,
+        ])
+        .output()
+        .expect("uv");
+    assert!(
+        out.status.success(),
+        "sklearn failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    stdout
+        .lines()
+        .find_map(|l| l.strip_prefix("SKLEARN_MS="))
+        .unwrap_or_else(|| panic!("no SKLEARN_MS: {stdout}"))
+        .trim()
+        .parse::<f64>()
+        .expect("parse")
+}
+
+#[test]
+#[ignore = "nightly-only: needs uv + scikit-learn (beat-speed-nightly.yml)"]
+fn beat_sklearn_minmax_speed() {
+    let (x, _y) = make_regression(N_SAMPLES, N_FEATURES, 0.1, SEED);
+    let apr_ms = time_apr(&x);
+    let csv = write_csv(&x);
+    let sklearn_ms = time_sklearn(csv.path());
+    let ratio = apr_ms / sklearn_ms;
+    eprintln!(
+        "BEAT-SKLEARN-MINMAXSCALER-SPEED: apr={apr_ms:.3}ms sklearn={sklearn_ms:.3}ms \
+         ratio={ratio:.3} (apr {:.2}x faster) on {N_SAMPLES}x{N_FEATURES}, median of {RUNS}",
+        sklearn_ms / apr_ms
+    );
+    assert!(
+        ratio <= RATIO_CEILING,
+        "FALSIFY: ratio {ratio:.3} > {RATIO_CEILING:.2} (apr={apr_ms:.3}ms, sklearn={sklearn_ms:.3}ms)"
+    );
+}


### PR DESCRIPTION
## Pillar-1 BEAT: apr MinMaxScaler beats scikit-learn 1.54×

### Measured (measure-first, honest-by-design)
| | apr | sklearn | ratio | speedup |
|---|-----|---------|-------|---------|
| MinMaxScaler fit_transform, 200k×50 | **21.4 ms** | 32.9 ms | **0.649** | **apr 1.54× faster** |

Same data / same host / same run, median of 5 + warmup, ratio `apr_ms/sklearn_ms` (robust to CI-host variance).

### Why apr wins
MinMaxScaler is pure **O(n·d)** per-column min/max + rescale, **no LAPACK/BLAS** — apr's SIMD turf vs numpy's per-op overhead. Consistent with the measured Pillar-1 pattern (apr wins LAPACK-free elementwise, loses LAPACK/BLAS-bound).

### Fourth Pillar-1 speed beat
LinReg 1.78× · GaussianNB 4.91× · StandardScaler 1.94× · **MinMaxScaler 1.54×** — all CI-gated nightly.

### Co-evolved per Rule 7
- `tests/beat_sklearn_minmax_speed.rs` — `#[ignore]` nightly falsifier, gates `ratio <= 0.80`.
- `contracts/beat-sklearn-minmax-speed-v1.yaml` — `beat-benchmark` contract (`pv validate`: 0/0).
- `beat-speed-nightly.yml` — wires the beat into the nightly speed gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)