### PR TITLE
feat(beat): apr MultinomialNB beats scikit-learn 1.60x — Pillar-1 (PMAT-728)

### DIFF
--- a/.github/workflows/beat-speed-nightly.yml
+++ b/.github/workflows/beat-speed-nightly.yml
@@ -55,3 +55,8 @@ jobs:
         run: |
           cargo test -p aprender-core --release \
             --test beat_sklearn_minmax_speed -- --ignored --nocapture
+
+      - name: Pillar-1 — apr vs scikit-learn MultinomialNB speed beat
+        run: |
+          cargo test -p aprender-core --release \
+            --test beat_sklearn_multinomialnb_speed -- --ignored --nocapture

--- a/contracts/beat-sklearn-multinomialnb-speed-v1.yaml
+++ b/contracts/beat-sklearn-multinomialnb-speed-v1.yaml
@@ -1,0 +1,61 @@
+contract: beat-sklearn-multinomialnb-speed
+metadata:
+  kind: beat-benchmark
+  version: "1.0.0"
+  description: >
+    Pillar-1 BEAT benchmark: aprender MultinomialNB fit+predict must be
+    comfortably FASTER than scikit-learn's MultinomialNB on the same count data,
+    same host, same run. MultinomialNB is COMPUTE-bound (per-class log-prob matvec
+    over counts + argmax) with NO LAPACK/BLAS — apr precomputes feature_log_prob in
+    fit and takes argmax of the log-posterior directly, so (unlike the elementwise
+    scaler beats) this is the ROBUST cross-platform kind of win. The beat is gated
+    on the RELATIVE ratio apr_ms/sklearn_ms so it is robust to CI-host speed
+    variance. Runs nightly (needs uv + scikit-learn), not per-PR.
+  references:
+  - "docs/specifications/campaign-ev-reprioritization-2026-06-12.md"
+  - "crates/aprender-core/tests/beat_sklearn_multinomialnb_speed.rs"
+  - "crates/aprender-core/src/classification/multinomial_nb.rs"
+version: 1
+status: enforced
+date: 2026-06-15
+
+beat:
+  pillar: 1
+  incumbent: scikit-learn
+  incumbent_pinned: "2026-06-15 via uv run --with scikit-learn (sklearn.naive_bayes.MultinomialNB)"
+  canonical_task: >
+    MultinomialNB fit+predict on count features derived from
+    make_classification(n_samples=50000, n_features=30, n_informative=20,
+    n_classes=8, seed=42) via round(|v|*4). apr and scikit-learn are timed on the
+    SAME count data, SAME host, SAME run (median of 5 + warmup); the metric is the
+    relative ratio apr_ms / sklearn_ms.
+  metric: wall_clock_ratio_apr_over_sklearn
+  direction: lower_is_better
+  baseline_value: 1.0000      # sklearn is the 1.0 reference (apr/sklearn vs itself)
+  baseline_floor: 0.6250      # measured apr/sklearn ~0.63 (apr ~1.60x faster)
+  beat_threshold: 0.8000      # apr must stay <= 0.80 (>= 1.25x faster) — margin vs 0.63
+  baseline_sourced_date: "2026-06-15"
+  approved_compute: CPU
+  ci_gate_name: "beat_sklearn_multinomialnb_speed"
+
+proof_obligations:
+- id: OBLIG-MULTINOMIALNB-SPEED-RATIO
+  statement: >
+    On the canonical task, apr_ms / sklearn_ms <= beat_threshold (0.80) measured
+    same-host/same-run as the median of 5 timed iterations after a warmup.
+  type: bound
+
+falsification_tests:
+- id: FALSIFY-BEAT-SKLEARN-MULTINOMIALNB-SPEED
+  description: >
+    The beat is FALSE if apr MultinomialNB fit+predict is not at least 1.25x faster
+    than scikit-learn on the canonical task (ratio > 0.80). The test panics with the
+    measured apr_ms / sklearn_ms so a regression is caught.
+  command: >
+    cargo test -p aprender-core --release --test beat_sklearn_multinomialnb_speed --
+    --ignored --nocapture
+  expected: "ratio <= 0.80 (apr >= 1.25x faster than scikit-learn MultinomialNB)"
+  if_fails: >
+    A regression slowed apr MultinomialNB (multinomial_nb.rs) — e.g. feature_log_prob
+    no longer precomputed in fit, or predict routed through a softmax instead of a
+    direct argmax of the log-posterior. Compare apr vs sklearn ms in the panic message.

--- a/crates/aprender-core/tests/beat_sklearn_multinomialnb_speed.rs
+++ b/crates/aprender-core/tests/beat_sklearn_multinomialnb_speed.rs
@@ -1,0 +1,155 @@
+//! BEAT-SKLEARN-MULTINOMIALNB-SPEED — Pillar-1 speed cascade (PMAT-728). **NIGHTLY ONLY.**
+//!
+//! cargo test -p aprender-core --release --test beat_sklearn_multinomialnb_speed -- --ignored --nocapture
+//!
+//! Time apr AND scikit-learn MultinomialNB fit+predict on the SAME count data, SAME host, SAME run;
+//! gate the RATIO apr_ms/sklearn_ms. MultinomialNB is COMPUTE-bound (per-class log-prob matvec over
+//! counts + argmax) with NO LAPACK/BLAS — apr precomputes feature_log_prob in fit and takes argmax
+//! of the log-posterior directly, so this is the robust (cross-platform) kind of beat. MEASURED.
+
+#![cfg(test)]
+
+use std::io::Write;
+use std::process::Command;
+use std::time::Instant;
+
+use aprender::classification::MultinomialNB;
+use aprender::datasets::make_classification;
+use aprender::prelude::*;
+
+const N_SAMPLES: usize = 50_000;
+const N_FEATURES: usize = 30;
+const N_INFORMATIVE: usize = 20;
+const N_CLASSES: usize = 8;
+const SEED: u64 = 42;
+const RUNS: usize = 5;
+/// apr must be at least this fast (ratio = apr/sklearn). Tightened once measured.
+const RATIO_CEILING: f64 = 0.80;
+
+fn median(xs: &[f64]) -> f64 {
+    let mut v = xs.to_vec();
+    v.sort_by(f64::total_cmp);
+    let n = v.len();
+    if n % 2 == 1 {
+        v[n / 2]
+    } else {
+        (v[n / 2 - 1] + v[n / 2]) / 2.0
+    }
+}
+
+/// MultinomialNB needs non-negative count features. Map make_classification's continuous features
+/// to integer-ish counts via `round(|v| * 4)` — deterministic, class-correlated, same for both sides.
+fn to_counts(x: &aprender::Matrix<f32>) -> aprender::Matrix<f32> {
+    let (r, c) = x.shape();
+    let mut data = Vec::with_capacity(r * c);
+    for i in 0..r {
+        for j in 0..c {
+            data.push((x.get(i, j).abs() * 4.0).round());
+        }
+    }
+    aprender::Matrix::from_vec(r, c, data).expect("counts matrix")
+}
+
+fn time_apr(x: &aprender::Matrix<f32>, y: &[usize]) -> f64 {
+    {
+        let mut m = MultinomialNB::new();
+        m.fit(x, y).expect("warmup fit");
+        let _ = m.predict(x);
+    }
+    let mut times = Vec::with_capacity(RUNS);
+    for _ in 0..RUNS {
+        let t = Instant::now();
+        let mut m = MultinomialNB::new();
+        m.fit(x, y).expect("fit");
+        let _p = m.predict(x);
+        times.push(t.elapsed().as_secs_f64() * 1000.0);
+    }
+    median(&times)
+}
+
+fn write_csv(x: &aprender::Matrix<f32>, y: &[usize]) -> tempfile::NamedTempFile {
+    let mut f = tempfile::Builder::new()
+        .suffix(".csv")
+        .tempfile()
+        .expect("tempfile");
+    for i in 0..x.n_rows() {
+        let mut line = String::new();
+        for j in 0..x.n_cols() {
+            line.push_str(&x.get(i, j).to_string());
+            line.push(',');
+        }
+        line.push_str(&y[i].to_string());
+        writeln!(f, "{line}").expect("row");
+    }
+    f.flush().expect("flush");
+    f
+}
+
+fn time_sklearn(csv: &std::path::Path) -> f64 {
+    let py = format!(
+        r#"
+import time, numpy as np
+from sklearn.naive_bayes import MultinomialNB
+D = np.loadtxt(r"{csv}", delimiter=",")
+X, y = D[:, :-1], D[:, -1].astype(np.int64)
+ts = []
+m = MultinomialNB(); m.fit(X, y); _ = m.predict(X)
+for _ in range({runs}):
+    t = time.perf_counter()
+    m = MultinomialNB(); m.fit(X, y); _ = m.predict(X)
+    ts.append((time.perf_counter() - t) * 1000.0)
+ts.sort()
+print("SKLEARN_MS=%f" % ts[len(ts)//2])
+"#,
+        csv = csv.display(),
+        runs = RUNS
+    );
+    let out = Command::new("uv")
+        .args([
+            "run",
+            "--with",
+            "scikit-learn",
+            "--with",
+            "numpy",
+            "python3",
+            "-c",
+            &py,
+        ])
+        .output()
+        .expect("uv");
+    assert!(
+        out.status.success(),
+        "sklearn failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    stdout
+        .lines()
+        .find_map(|l| l.strip_prefix("SKLEARN_MS="))
+        .unwrap_or_else(|| panic!("no SKLEARN_MS: {stdout}"))
+        .trim()
+        .parse::<f64>()
+        .expect("parse")
+}
+
+#[test]
+#[ignore = "nightly-only: needs uv + scikit-learn (beat-speed-nightly.yml)"]
+fn beat_sklearn_multinomialnb_speed() {
+    let (x_raw, y) = make_classification(N_SAMPLES, N_FEATURES, N_INFORMATIVE, N_CLASSES, SEED);
+    let x = to_counts(&x_raw);
+
+    let apr_ms = time_apr(&x, &y);
+    let csv = write_csv(&x, &y);
+    let sklearn_ms = time_sklearn(csv.path());
+
+    let ratio = apr_ms / sklearn_ms;
+    eprintln!(
+        "BEAT-SKLEARN-MULTINOMIALNB-SPEED: apr={apr_ms:.3}ms sklearn={sklearn_ms:.3}ms \
+         ratio={ratio:.3} (apr {:.2}x faster) on {N_SAMPLES}x{N_FEATURES} classes={N_CLASSES}, median of {RUNS}",
+        sklearn_ms / apr_ms
+    );
+    assert!(
+        ratio <= RATIO_CEILING,
+        "FALSIFY-BEAT-SKLEARN-MULTINOMIALNB-SPEED: ratio {ratio:.3} > {RATIO_CEILING:.2} (apr={apr_ms:.3}ms, sklearn={sklearn_ms:.3}ms)"
+    );
+}


### PR DESCRIPTION
## Pillar-1 BEAT: apr MultinomialNB beats scikit-learn 1.60× (robust, compute-bound)

### Measured (measure-first)
| | apr | sklearn | ratio | speedup |
|---|-----|---------|-------|---------|
| MultinomialNB fit+predict, 50k×30 counts, 8 classes | **8.4 ms** | 13.4 ms | **0.625** | **apr 1.60× faster** |

Same count data / same host / same run, median of 5 + warmup.

### Why this is the *robust* kind of beat
MultinomialNB is **compute-bound** (per-class log-prob matvec over counts + argmax, no LAPACK/BLAS). Per this session's cross-platform finding, compute-bound beats win on **both** x86 and aarch64 (GaussianNB 4.91×/3.56×), unlike the elementwise scaler beats which are x86-only. **No code change needed** — apr's MultinomialNB already precomputes `feature_log_prob` in `fit` and takes a direct argmax of the log-posterior (the GaussianNB ln-hoist lesson, already applied in the impl).

### Fifth Pillar-1 speed beat
LinReg 1.78× · GaussianNB 4.91× · StandardScaler 1.94× · MinMaxScaler 1.54× · **MultinomialNB 1.60×**.

### Co-evolved per Rule 7
- `tests/beat_sklearn_multinomialnb_speed.rs` — `#[ignore]` nightly falsifier, gates `ratio <= 0.80`.
- `contracts/beat-sklearn-multinomialnb-speed-v1.yaml` — `beat-benchmark` contract (`pv validate`: 0/0).
- `beat-speed-nightly.yml` — wires the beat into the nightly speed gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)