### PR TITLE
feat(beat): apr beats sklearn ComplementNB 1.68x + BernoulliNB 1.90x (fix) — Pillar-1 (PMAT-729/730)

### DIFF
--- a/.github/workflows/beat-speed-nightly.yml
+++ b/.github/workflows/beat-speed-nightly.yml
@@ -56,6 +56,16 @@ jobs:
           cargo test -p aprender-core --release \
             --test beat_sklearn_minmax_speed -- --ignored --nocapture
 
+      - name: Pillar-1 — apr vs scikit-learn ComplementNB speed beat
+        run: |
+          cargo test -p aprender-core --release \
+            --test beat_sklearn_complementnb_speed -- --ignored --nocapture
+
+      - name: Pillar-1 — apr vs scikit-learn BernoulliNB speed beat
+        run: |
+          cargo test -p aprender-core --release \
+            --test beat_sklearn_bernoullinb_speed -- --ignored --nocapture
+
       - name: Pillar-1 — apr vs scikit-learn MultinomialNB speed beat
         run: |
           cargo test -p aprender-core --release \

--- a/contracts/beat-sklearn-bernoullinb-speed-v1.yaml
+++ b/contracts/beat-sklearn-bernoullinb-speed-v1.yaml
@@ -1,0 +1,54 @@
+contract: beat-sklearn-bernoullinb-speed
+metadata:
+  kind: beat-benchmark
+  version: "1.0.0"
+  description: >
+    Pillar-1 BEAT benchmark: aprender BernoulliNB fit+predict must be comfortably
+    FASTER than scikit-learn's BernoulliNB on the same binary data, same host, same
+    run. BernoulliNB is COMPUTE-bound (per-class present/absent log-prob
+    accumulation + argmax) with NO LAPACK/BLAS. apr was 0.61x (LOSS) because predict
+    recomputed ln(p) and ln(1-p) for every (sample,class,feature) = O(n*c*d)
+    transcendentals; precomputing both logs in fit (O(c*d)) flipped it to a WIN. The
+    robust cross-platform kind. Gated on ratio apr_ms/sklearn_ms. Runs nightly.
+  references:
+  - "crates/aprender-core/tests/beat_sklearn_bernoullinb_speed.rs"
+  - "crates/aprender-core/src/classification/bernoulli_nb.rs"
+version: 1
+status: enforced
+date: 2026-06-15
+beat:
+  pillar: 1
+  incumbent: scikit-learn
+  incumbent_pinned: "2026-06-15 via uv run --with scikit-learn (sklearn.naive_bayes.BernoulliNB)"
+  canonical_task: >
+    BernoulliNB fit+predict on binary features from make_classification(50000, 30,
+    n_informative=20, n_classes=8, seed=42) binarized at 0. Same data, same host,
+    same run (median of 5 + warmup); metric is ratio apr_ms / sklearn_ms.
+  metric: wall_clock_ratio_apr_over_sklearn
+  direction: lower_is_better
+  baseline_value: 1.0000
+  baseline_floor: 0.5260
+  beat_threshold: 0.8000
+  baseline_sourced_date: "2026-06-15"
+  approved_compute: CPU
+  ci_gate_name: "beat_sklearn_bernoullinb_speed"
+proof_obligations:
+- id: OBLIG-BERNOULLINB-SPEED-RATIO
+  statement: >
+    On the canonical task, apr_ms / sklearn_ms <= beat_threshold (0.80) measured
+    same-host/same-run as the median of 5 timed iterations after a warmup.
+  type: bound
+falsification_tests:
+- id: FALSIFY-BEAT-SKLEARN-BERNOULLINB-SPEED
+  description: >
+    FALSE if apr BernoulliNB fit+predict is not >= 1.25x faster than scikit-learn on
+    the canonical task (ratio > 0.80). Catches re-introducing the per-sample ln(p) /
+    ln(1-p) recompute in predict.
+  command: >
+    cargo test -p aprender-core --release --test beat_sklearn_bernoullinb_speed --
+    --ignored --nocapture
+  expected: "ratio <= 0.80 (apr >= 1.25x faster than scikit-learn BernoulliNB)"
+  if_fails: >
+    A regression slowed apr BernoulliNB (bernoulli_nb.rs) — most likely feature_log_prob
+    / feature_log_neg_prob are no longer precomputed in fit and predict recomputes
+    ln(p)/ln(1-p) per (sample,class,feature). Compare apr vs sklearn ms in the panic.

--- a/contracts/beat-sklearn-complementnb-speed-v1.yaml
+++ b/contracts/beat-sklearn-complementnb-speed-v1.yaml
@@ -1,0 +1,51 @@
+contract: beat-sklearn-complementnb-speed
+metadata:
+  kind: beat-benchmark
+  version: "1.0.0"
+  description: >
+    Pillar-1 BEAT benchmark: aprender ComplementNB fit+predict must be comfortably
+    FASTER than scikit-learn's ComplementNB on the same count data, same host, same
+    run. ComplementNB is COMPUTE-bound (per-class log-weight matvec over counts +
+    argmax) with NO LAPACK/BLAS — the robust cross-platform kind of win. Gated on
+    the RELATIVE ratio apr_ms/sklearn_ms. Runs nightly (needs uv + scikit-learn).
+  references:
+  - "crates/aprender-core/tests/beat_sklearn_complementnb_speed.rs"
+  - "crates/aprender-core/src/classification/complement_nb.rs"
+version: 1
+status: enforced
+date: 2026-06-15
+beat:
+  pillar: 1
+  incumbent: scikit-learn
+  incumbent_pinned: "2026-06-15 via uv run --with scikit-learn (sklearn.naive_bayes.ComplementNB)"
+  canonical_task: >
+    ComplementNB fit+predict on count features from make_classification(50000, 30,
+    n_informative=20, n_classes=8, seed=42) via round(|v|*4). Same data, same host,
+    same run (median of 5 + warmup); metric is ratio apr_ms / sklearn_ms.
+  metric: wall_clock_ratio_apr_over_sklearn
+  direction: lower_is_better
+  baseline_value: 1.0000
+  baseline_floor: 0.5960
+  beat_threshold: 0.8000
+  baseline_sourced_date: "2026-06-15"
+  approved_compute: CPU
+  ci_gate_name: "beat_sklearn_complementnb_speed"
+proof_obligations:
+- id: OBLIG-COMPLEMENTNB-SPEED-RATIO
+  statement: >
+    On the canonical task, apr_ms / sklearn_ms <= beat_threshold (0.80) measured
+    same-host/same-run as the median of 5 timed iterations after a warmup.
+  type: bound
+falsification_tests:
+- id: FALSIFY-BEAT-SKLEARN-COMPLEMENTNB-SPEED
+  description: >
+    FALSE if apr ComplementNB fit+predict is not >= 1.25x faster than scikit-learn
+    on the canonical task (ratio > 0.80).
+  command: >
+    cargo test -p aprender-core --release --test beat_sklearn_complementnb_speed --
+    --ignored --nocapture
+  expected: "ratio <= 0.80 (apr >= 1.25x faster than scikit-learn ComplementNB)"
+  if_fails: >
+    A regression slowed apr ComplementNB (complement_nb.rs) — check that per-class
+    log-weights stay precomputed in fit and predict is a direct argmax (no per-sample
+    ln/softmax). Compare apr vs sklearn ms in the panic message.

--- a/crates/aprender-core/src/classification/bernoulli_nb.rs
+++ b/crates/aprender-core/src/classification/bernoulli_nb.rs
@@ -15,7 +15,10 @@ pub struct BernoulliNB {
     alpha: f32,
     binarize: f32,
     class_log_prior: Vec<f32>,
-    feature_prob: Vec<Vec<f32>>,
+    /// Precomputed `ln(P(j=1|c))` per (class, feature) — hoisted out of the predict hot loop.
+    feature_log_prob: Vec<Vec<f32>>,
+    /// Precomputed `ln(1 - P(j=1|c))` per (class, feature) — the feature-absence term.
+    feature_log_neg_prob: Vec<Vec<f32>>,
     n_features: usize,
 }
 
@@ -33,7 +36,8 @@ impl BernoulliNB {
             alpha: 1.0,
             binarize: 0.0,
             class_log_prior: Vec::new(),
-            feature_prob: Vec::new(),
+            feature_log_prob: Vec::new(),
+            feature_log_neg_prob: Vec::new(),
             n_features: 0,
         }
     }
@@ -79,14 +83,22 @@ impl BernoulliNB {
         self.class_log_prior = (0..n_classes)
             .map(|c| (class_count[c] as f64 / n_samples as f64).ln() as f32)
             .collect();
-        self.feature_prob = (0..n_classes)
-            .map(|c| {
-                let denom = class_count[c] as f64 + 2.0 * alpha;
-                (0..n_features)
-                    .map(|j| ((present[c][j] + alpha) / denom) as f32)
-                    .collect()
-            })
-            .collect();
+        // Precompute ln(p) and ln(1-p) per (class, feature) ONCE here, instead of recomputing both
+        // logs for every (sample, class, feature) in predict (O(n·c·d) -> O(c·d) transcendentals).
+        self.feature_log_prob = Vec::with_capacity(n_classes);
+        self.feature_log_neg_prob = Vec::with_capacity(n_classes);
+        for c in 0..n_classes {
+            let denom = class_count[c] as f64 + 2.0 * alpha;
+            let mut logp = Vec::with_capacity(n_features);
+            let mut logn = Vec::with_capacity(n_features);
+            for j in 0..n_features {
+                let p = (((present[c][j] + alpha) / denom) as f32).clamp(1e-9, 1.0 - 1e-9);
+                logp.push(p.ln());
+                logn.push((1.0 - p).ln());
+            }
+            self.feature_log_prob.push(logp);
+            self.feature_log_neg_prob.push(logn);
+        }
         self.n_features = n_features;
         Ok(())
     }
@@ -101,10 +113,15 @@ impl BernoulliNB {
                 let mut best_ll = f32::NEG_INFINITY;
                 for (c, prior) in self.class_log_prior.iter().enumerate() {
                     let mut ll = *prior;
+                    let logp = &self.feature_log_prob[c];
+                    let logn = &self.feature_log_neg_prob[c];
                     for j in 0..self.n_features {
-                        let b = f32::from(x.get(i, j) > self.binarize);
-                        let p = self.feature_prob[c][j].clamp(1e-9, 1.0 - 1e-9);
-                        ll += b * p.ln() + (1.0 - b) * (1.0 - p).ln();
+                        // Precomputed logs; present feature adds ln(p), absent adds ln(1-p).
+                        if x.get(i, j) > self.binarize {
+                            ll += logp[j];
+                        } else {
+                            ll += logn[j];
+                        }
                     }
                     if ll > best_ll {
                         best_ll = ll;

--- a/crates/aprender-core/tests/beat_sklearn_bernoullinb_speed.rs
+++ b/crates/aprender-core/tests/beat_sklearn_bernoullinb_speed.rs
@@ -1,0 +1,145 @@
+//! BEAT-SKLEARN-BERNOULLINB-SPEED — Pillar-1 speed cascade (PMAT-730). **NIGHTLY ONLY.**
+//! cargo test -p aprender-core --release --test beat_sklearn_bernoullinb_speed -- --ignored --nocapture
+//! Compute-bound NB (binary feature log-prob accumulation + argmax, no LAPACK) — robust cross-platform.
+#![cfg(test)]
+
+use std::io::Write;
+use std::process::Command;
+use std::time::Instant;
+
+use aprender::classification::BernoulliNB;
+use aprender::datasets::make_classification;
+use aprender::prelude::*;
+
+const N_SAMPLES: usize = 50_000;
+const N_FEATURES: usize = 30;
+const N_INFORMATIVE: usize = 20;
+const N_CLASSES: usize = 8;
+const SEED: u64 = 42;
+const RUNS: usize = 5;
+const RATIO_CEILING: f64 = 0.80;
+
+fn median(xs: &[f64]) -> f64 {
+    let mut v = xs.to_vec();
+    v.sort_by(f64::total_cmp);
+    let n = v.len();
+    if n % 2 == 1 {
+        v[n / 2]
+    } else {
+        (v[n / 2 - 1] + v[n / 2]) / 2.0
+    }
+}
+
+/// BernoulliNB needs binary features. Binarize make_classification at 0: v > 0 -> 1, else 0.
+fn to_binary(x: &aprender::Matrix<f32>) -> aprender::Matrix<f32> {
+    let (r, c) = x.shape();
+    let mut data = Vec::with_capacity(r * c);
+    for i in 0..r {
+        for j in 0..c {
+            data.push(if x.get(i, j) > 0.0 { 1.0 } else { 0.0 });
+        }
+    }
+    aprender::Matrix::from_vec(r, c, data).expect("binary matrix")
+}
+
+fn time_apr(x: &aprender::Matrix<f32>, y: &[usize]) -> f64 {
+    {
+        let mut m = BernoulliNB::new();
+        m.fit(x, y).expect("warmup fit");
+        let _ = m.predict(x);
+    }
+    let mut times = Vec::with_capacity(RUNS);
+    for _ in 0..RUNS {
+        let t = Instant::now();
+        let mut m = BernoulliNB::new();
+        m.fit(x, y).expect("fit");
+        let _p = m.predict(x);
+        times.push(t.elapsed().as_secs_f64() * 1000.0);
+    }
+    median(&times)
+}
+
+fn write_csv(x: &aprender::Matrix<f32>, y: &[usize]) -> tempfile::NamedTempFile {
+    let mut f = tempfile::Builder::new()
+        .suffix(".csv")
+        .tempfile()
+        .expect("tempfile");
+    for i in 0..x.n_rows() {
+        let mut line = String::new();
+        for j in 0..x.n_cols() {
+            line.push_str(&x.get(i, j).to_string());
+            line.push(',');
+        }
+        line.push_str(&y[i].to_string());
+        writeln!(f, "{line}").expect("row");
+    }
+    f.flush().expect("flush");
+    f
+}
+
+fn time_sklearn(csv: &std::path::Path) -> f64 {
+    let py = format!(
+        r#"
+import time, numpy as np
+from sklearn.naive_bayes import BernoulliNB
+D = np.loadtxt(r"{csv}", delimiter=",")
+X, y = D[:, :-1], D[:, -1].astype(np.int64)
+ts = []
+m = BernoulliNB(); m.fit(X, y); _ = m.predict(X)
+for _ in range({runs}):
+    t = time.perf_counter()
+    m = BernoulliNB(); m.fit(X, y); _ = m.predict(X)
+    ts.append((time.perf_counter() - t) * 1000.0)
+ts.sort()
+print("SKLEARN_MS=%f" % ts[len(ts)//2])
+"#,
+        csv = csv.display(),
+        runs = RUNS
+    );
+    let out = Command::new("uv")
+        .args([
+            "run",
+            "--with",
+            "scikit-learn",
+            "--with",
+            "numpy",
+            "python3",
+            "-c",
+            &py,
+        ])
+        .output()
+        .expect("uv");
+    assert!(
+        out.status.success(),
+        "sklearn failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    stdout
+        .lines()
+        .find_map(|l| l.strip_prefix("SKLEARN_MS="))
+        .unwrap_or_else(|| panic!("no SKLEARN_MS: {stdout}"))
+        .trim()
+        .parse::<f64>()
+        .expect("parse")
+}
+
+#[test]
+#[ignore = "nightly-only: needs uv + scikit-learn (beat-speed-nightly.yml)"]
+fn beat_sklearn_bernoullinb_speed() {
+    let (x_raw, y) = make_classification(N_SAMPLES, N_FEATURES, N_INFORMATIVE, N_CLASSES, SEED);
+    let x = to_binary(&x_raw);
+    let apr_ms = time_apr(&x, &y);
+    let csv = write_csv(&x, &y);
+    let sklearn_ms = time_sklearn(csv.path());
+    let ratio = apr_ms / sklearn_ms;
+    eprintln!(
+        "BEAT-SKLEARN-BERNOULLINB-SPEED: apr={apr_ms:.3}ms sklearn={sklearn_ms:.3}ms \
+         ratio={ratio:.3} (apr {:.2}x faster) on {N_SAMPLES}x{N_FEATURES} classes={N_CLASSES}, median of {RUNS}",
+        sklearn_ms / apr_ms
+    );
+    assert!(
+        ratio <= RATIO_CEILING,
+        "FALSIFY-BEAT-SKLEARN-BERNOULLINB-SPEED: ratio {ratio:.3} > {RATIO_CEILING:.2} (apr={apr_ms:.3}ms, sklearn={sklearn_ms:.3}ms)"
+    );
+}

--- a/crates/aprender-core/tests/beat_sklearn_complementnb_speed.rs
+++ b/crates/aprender-core/tests/beat_sklearn_complementnb_speed.rs
@@ -1,0 +1,144 @@
+//! BEAT-SKLEARN-COMPLEMENTNB-SPEED — Pillar-1 speed cascade (PMAT-729). **NIGHTLY ONLY.**
+//! cargo test -p aprender-core --release --test beat_sklearn_complementnb_speed -- --ignored --nocapture
+//! Compute-bound NB (count log-prob matvec + argmax, no LAPACK) — the robust cross-platform kind.
+#![cfg(test)]
+
+use std::io::Write;
+use std::process::Command;
+use std::time::Instant;
+
+use aprender::classification::ComplementNB;
+use aprender::datasets::make_classification;
+use aprender::prelude::*;
+
+const N_SAMPLES: usize = 50_000;
+const N_FEATURES: usize = 30;
+const N_INFORMATIVE: usize = 20;
+const N_CLASSES: usize = 8;
+const SEED: u64 = 42;
+const RUNS: usize = 5;
+const RATIO_CEILING: f64 = 0.80;
+
+fn median(xs: &[f64]) -> f64 {
+    let mut v = xs.to_vec();
+    v.sort_by(f64::total_cmp);
+    let n = v.len();
+    if n % 2 == 1 {
+        v[n / 2]
+    } else {
+        (v[n / 2 - 1] + v[n / 2]) / 2.0
+    }
+}
+
+fn to_counts(x: &aprender::Matrix<f32>) -> aprender::Matrix<f32> {
+    let (r, c) = x.shape();
+    let mut data = Vec::with_capacity(r * c);
+    for i in 0..r {
+        for j in 0..c {
+            data.push((x.get(i, j).abs() * 4.0).round());
+        }
+    }
+    aprender::Matrix::from_vec(r, c, data).expect("counts matrix")
+}
+
+fn time_apr(x: &aprender::Matrix<f32>, y: &[usize]) -> f64 {
+    {
+        let mut m = ComplementNB::new();
+        m.fit(x, y).expect("warmup fit");
+        let _ = m.predict(x);
+    }
+    let mut times = Vec::with_capacity(RUNS);
+    for _ in 0..RUNS {
+        let t = Instant::now();
+        let mut m = ComplementNB::new();
+        m.fit(x, y).expect("fit");
+        let _p = m.predict(x);
+        times.push(t.elapsed().as_secs_f64() * 1000.0);
+    }
+    median(&times)
+}
+
+fn write_csv(x: &aprender::Matrix<f32>, y: &[usize]) -> tempfile::NamedTempFile {
+    let mut f = tempfile::Builder::new()
+        .suffix(".csv")
+        .tempfile()
+        .expect("tempfile");
+    for i in 0..x.n_rows() {
+        let mut line = String::new();
+        for j in 0..x.n_cols() {
+            line.push_str(&x.get(i, j).to_string());
+            line.push(',');
+        }
+        line.push_str(&y[i].to_string());
+        writeln!(f, "{line}").expect("row");
+    }
+    f.flush().expect("flush");
+    f
+}
+
+fn time_sklearn(csv: &std::path::Path) -> f64 {
+    let py = format!(
+        r#"
+import time, numpy as np
+from sklearn.naive_bayes import ComplementNB
+D = np.loadtxt(r"{csv}", delimiter=",")
+X, y = D[:, :-1], D[:, -1].astype(np.int64)
+ts = []
+m = ComplementNB(); m.fit(X, y); _ = m.predict(X)
+for _ in range({runs}):
+    t = time.perf_counter()
+    m = ComplementNB(); m.fit(X, y); _ = m.predict(X)
+    ts.append((time.perf_counter() - t) * 1000.0)
+ts.sort()
+print("SKLEARN_MS=%f" % ts[len(ts)//2])
+"#,
+        csv = csv.display(),
+        runs = RUNS
+    );
+    let out = Command::new("uv")
+        .args([
+            "run",
+            "--with",
+            "scikit-learn",
+            "--with",
+            "numpy",
+            "python3",
+            "-c",
+            &py,
+        ])
+        .output()
+        .expect("uv");
+    assert!(
+        out.status.success(),
+        "sklearn failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    stdout
+        .lines()
+        .find_map(|l| l.strip_prefix("SKLEARN_MS="))
+        .unwrap_or_else(|| panic!("no SKLEARN_MS: {stdout}"))
+        .trim()
+        .parse::<f64>()
+        .expect("parse")
+}
+
+#[test]
+#[ignore = "nightly-only: needs uv + scikit-learn (beat-speed-nightly.yml)"]
+fn beat_sklearn_complementnb_speed() {
+    let (x_raw, y) = make_classification(N_SAMPLES, N_FEATURES, N_INFORMATIVE, N_CLASSES, SEED);
+    let x = to_counts(&x_raw);
+    let apr_ms = time_apr(&x, &y);
+    let csv = write_csv(&x, &y);
+    let sklearn_ms = time_sklearn(csv.path());
+    let ratio = apr_ms / sklearn_ms;
+    eprintln!(
+        "BEAT-SKLEARN-COMPLEMENTNB-SPEED: apr={apr_ms:.3}ms sklearn={sklearn_ms:.3}ms \
+         ratio={ratio:.3} (apr {:.2}x faster) on {N_SAMPLES}x{N_FEATURES} classes={N_CLASSES}, median of {RUNS}",
+        sklearn_ms / apr_ms
+    );
+    assert!(
+        ratio <= RATIO_CEILING,
+        "FALSIFY-BEAT-SKLEARN-COMPLEMENTNB-SPEED: ratio {ratio:.3} > {RATIO_CEILING:.2} (apr={apr_ms:.3}ms, sklearn={sklearn_ms:.3}ms)"
+    );
+}


### PR DESCRIPTION
## Pillar-1 BEAT: complete the Naive Bayes family (compute-bound = robust)

| Beat | apr | sklearn | speedup | note |
|------|-----|---------|---------|------|
| ComplementNB | 7.0 ms | 11.8 ms | **1.68×** | no code change (impl already optimal) |
| BernoulliNB | 19.5 ms | 37.0 ms | **1.90×** | **after a real perf fix** (was 0.61× LOSS) |

50k×30, 8 classes, same data/host/run, median of 5 + warmup.

### BernoulliNB: a loss turned into a win by removing redundant work
`predict` recomputed `ln(p)` **and** `ln(1-p)` for **every (sample, class, feature)** = O(n·c·d) ≈ **24M transcendentals/predict** — the same inefficiency fixed in GaussianNB (PMAT-723). Fix: precompute `feature_log_prob` + `feature_log_neg_prob` in `fit` (O(c·d)); `predict` adds the present/absent log term directly. **61.6 ms → 19.5 ms (3.2× faster)**, flipping a 0.61× loss into a 1.90× win. `bernoulli_nb_matches_sklearn` still passes — predictions are identical (same clamp+ln, just hoisted).

### Robust, not x86-only
Both are compute-bound (no LAPACK/BLAS), so — unlike the elementwise scaler beats — they win cross-platform (cf. GaussianNB 3.56× / MultinomialNB 3.50× measured on gx10/aarch64).

### Co-evolved per Rule 7
Each ships its `#[ignore]` nightly falsifier + a `beat-benchmark` contract (`pv validate`: 0/0) + a `beat-speed-nightly.yml` step.

> Note: this PR's workflow edit may need a trivial rebase after #2036 (MultinomialNB) lands, since both append nightly steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)