### PR TITLE
perf(compute): ikj-reorder trueno small-matmul (matmul_naive) — 4.8–5.2× (PMAT-725)

### DIFF
--- a/crates/aprender-compute/src/matrix/ops/arithmetic.rs
+++ b/crates/aprender-compute/src/matrix/ops/arithmetic.rs
@@ -290,7 +290,18 @@ impl Matrix<f32> {
         Matrix::from_vec(1, n, c)
     }
 
-    /// Naive O(n³) matrix multiplication (baseline for small matrices < 64)
+    /// Small-matrix matmul (baseline for dims < 64, below the SIMD/GPU threshold).
+    ///
+    /// Cache-friendly `ikj` ordering: the innermost loop is a contiguous AXPY
+    /// (`c_row[j] += a_ik * b_row[j]`) over row-major memory, which LLVM
+    /// auto-vectorizes. The previous `ijk` form indexed `b[kk * n + j]` with a
+    /// column stride in the hot loop, defeating both the cache and SIMD; it
+    /// measured ~4.7x slower than this AXPY form on 32x32–63x63 matrices — the
+    /// shapes a small-MLP autograd training step hits (the matmul kernel that
+    /// powers the Pillar-1 LinearRegression beat already uses this ordering in
+    /// `aprender::primitives::Matrix::matmul`). `result.data` is pre-zeroed by
+    /// the caller (`Matrix::zeros_with_backend`), so the `+=` accumulation
+    /// starts from 0.
     fn matmul_naive(
         &self,
         other: &Matrix<f32>,
@@ -299,22 +310,19 @@ impl Matrix<f32> {
         let m = self.rows;
         let k = self.cols;
         let n = other.cols;
-        // Direct slice access — eliminates bounds-check + Option::expect
-        // per element in the innermost loop (~30% overhead for small matrices).
         let a = &self.data;
         let b = &other.data;
         let c = &mut result.data;
 
         for i in 0..m {
-            let a_row = i * k;
-            let c_row = i * n;
-            for j in 0..n {
-                let mut sum = 0.0f32;
-                for kk in 0..k {
-                    // a[i,kk] * b[kk,j] — row-major layout
-                    sum += a[a_row + kk] * b[kk * n + j];
+            let a_row = &a[i * k..i * k + k];
+            let c_row = &mut c[i * n..i * n + n];
+            for kk in 0..k {
+                let a_ik = a_row[kk];
+                let b_row = &b[kk * n..kk * n + n];
+                for (cj, &bj) in c_row.iter_mut().zip(b_row.iter()) {
+                    *cj += a_ik * bj;
                 }
-                c[c_row + j] = sum;
             }
         }
         Ok(())


### PR DESCRIPTION
A contained, correctness-preserving perf fix found while investigating Pillar-2 training speed.

`trueno::Matrix::matmul` dispatches all-dims-<64 matrices to `matmul_naive`, which used a strided `ijk` loop (column-stride `b[kk*n+j]` in the hot loop — cache- and SIMD-hostile). This is the path small-MLP **autograd training** hits (forward + both backward matmuls). Reordered to the cache-friendly `ikj` AXPY form (same ordering as the P1 LinearRegression kernel).

### Measured (this box)
- 32×32: 14.2 → 2.7 µs (**5.2×**) · 63×63: 115 → 24 µs (**4.8×**). Large matmuls untouched (still BLIS SIMD parallel).

### Correctness preserved (non-negotiable)
- `beat_pytorch_autograd_grad` passes (gradients bit-equivalent to PyTorch, max|Δ| ≤ 1e-4) · 70 matmul + autograd lib tests green · fmt + clippy clean.

### Context (honest)
This is **not** a Pillar-2 speed beat. The investigation found the autograd matmul *already* uses the trueno SIMD path (the audit's premise was wrong), and the PMAT-725 training step is **overhead-bound** (tape clones + per-forward weight re-transpose + per-grad alloc), not matmul-bound — so apr still **concedes** PyTorch-CPU training throughput (16× at the MLP shape; the shipped autograd-equivalence *correctness* beat remains the Pillar-2 win). This fix is a genuine small-model-training speedup regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)