### PR TITLE
fix(cuda): FP8 warmup OOB read poisons CUDA context (~1-in-6 decode collapse) — PMAT-082

### DIFF
--- a/crates/aprender-serve/src/cuda/executor/layers/cublas_prefill/attention.rs
+++ b/crates/aprender-serve/src/cuda/executor/layers/cublas_prefill/attention.rs
@@ -1416,32 +1416,61 @@ DONE_NORM:
                 self.cublaslt_handle = Some(trueno_gpu::driver::CublasLtHandle::new()?);
             }
 
-            // Use smallest realistic M (padded to 16) with the first cached FP8 weight.
-            // One GEMM is enough — cuBLASLt JIT is per-handle, not per-shape.
+            // PMAT-082 / PMAT-765: One GEMM is enough — cuBLASLt JIT is per-handle,
+            // not per-shape — so we only need *a* valid FP8 GEMM, any shape.
+            //
+            // BUG (intermittent CUDA_ERROR_ILLEGAL_ADDRESS, ~1-in-6 on RTX 4090):
+            // this used to grab `fp8_weight_cache.values().next()` (an arbitrary
+            // weight, picked by non-deterministic HashMap order) while HARDCODING
+            // the GEMM dims to `hidden_dim × hidden_dim`. With `Trans` + lda=k the
+            // weight operand is read as a [k_warmup × n_warmup] matrix, i.e.
+            // `k_warmup * n_warmup = hidden_dim²` FP8 bytes. When HashMap order
+            // happened to return a weight whose buffer is smaller than that
+            // (e.g. a GQA K/V projection: kv_dim×hidden = 256×1536 = 393 KB vs
+            // the 1536×1536 = 2.36 MB the GEMM reads), the kernel read ~2 MB
+            // past the end of the buffer → illegal address → CUDA context
+            // poisoned → silent wgpu/CPU fallback at ~6-12 tok/s (the "stall").
+            //
+            // FIX: derive the warmup square dim from the CHOSEN weight's actual
+            // byte length (1 byte/elem for FP8 E4M3), so the read can never
+            // exceed the buffer regardless of which weight HashMap returns.
+            // dim = floor(sqrt(len)) ⇒ dim*dim ≤ len, always in-bounds.
             let m_warmup: i32 = 16;
-            let n_warmup = hidden_dim as i32;
-            let k_warmup = hidden_dim as i32;
-            let warmup_input_count = m_warmup as usize * k_warmup as usize;
-            let warmup_output_count = n_warmup as usize * m_warmup as usize;
 
-            // Allocate scratch BEFORE borrowing lt_handle (avoid borrow conflict)
-            self.ensure_fp8_activation_scratch(warmup_input_count)?;
-            self.ensure_fp16_activation_scratch(warmup_output_count)?;
-            let input_ptr = self
-                .fp8_activation_scratch
-                .as_ref()
-                .expect("scratch just allocated")
-                .as_ptr();
-            let output_ptr = self
-                .fp16_activation_scratch
-                .as_ref()
-                .expect("scratch just allocated")
-                .as_ptr();
+            // Pick a weight and size the GEMM to it (extract ptr + len before
+            // borrowing lt_handle to avoid a borrow conflict).
+            let fp8_weight = self
+                .fp8_weight_cache
+                .values()
+                .next()
+                .map(|b| (b.as_ptr(), b.len()));
 
-            // Extract weight ptr before borrowing lt_handle
-            let fp8_weight_ptr = self.fp8_weight_cache.values().next().map(|b| b.as_ptr());
+            if let Some((w_ptr, w_len)) = fp8_weight {
+                // Largest square that fits inside the chosen weight buffer.
+                #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+                let raw_dim = (w_len as f64).sqrt().floor() as i32;
+                // Round down to a multiple of 16 for tensor-core alignment;
+                // clamp to ≥16 so a tiny weight can't produce a degenerate GEMM.
+                let dim = (raw_dim & !15).max(16);
+                let n_warmup = dim;
+                let k_warmup = dim;
+                let warmup_input_count = m_warmup as usize * k_warmup as usize;
+                let warmup_output_count = n_warmup as usize * m_warmup as usize;
 
-            if let Some(w_ptr) = fp8_weight_ptr {
+                // Allocate scratch BEFORE borrowing lt_handle (avoid borrow conflict)
+                self.ensure_fp8_activation_scratch(warmup_input_count)?;
+                self.ensure_fp16_activation_scratch(warmup_output_count)?;
+                let input_ptr = self
+                    .fp8_activation_scratch
+                    .as_ref()
+                    .expect("scratch just allocated")
+                    .as_ptr();
+                let output_ptr = self
+                    .fp16_activation_scratch
+                    .as_ref()
+                    .expect("scratch just allocated")
+                    .as_ptr();
+
                 let lt_handle = self.cublaslt_handle.as_ref().expect("just created");
                 let _ = lt_handle.gemm_fp8_e4m3_to_f16(
                     trueno_gpu::driver::GemmOp::Trans,

--- a/evidence/fp8-warmup-oob-poison-2026-06-15/findings.md
+++ b/evidence/fp8-warmup-oob-poison-2026-06-15/findings.md
@@ -1,0 +1,56 @@
+# apr CUDA decode "stall" — root cause: FP8 JIT warmup OOB read (PMAT-082) — 2026-06-15
+
+Host: noah-Lambda-Vector (RTX 4090, sm_89). Binary: apr v0.49.1 --features cuda.
+Model: qwen2.5-coder-1.5b-instruct-q4_k_m.gguf (hidden=1536, heads=12, kv_heads=2, head_dim=128).
+
+## Failure signature (clean vs stalled)
+Clean run (~5s, 60-80 tok/s): startup logs PMAT-082 "cuBLASLt FP8 JIT warmed",
+PMAT-053 "FP8 weight cache: 197 matrices cached", then decode on the CUDA graph path.
+
+Stalled run (~13-24s, ~6-13 tok/s), exact cascade:
+  [PMAT-053] FP8 cache warmup failed (non-fatal): CUDA stream synchronization failed:
+             CUDA driver error: CUDA_ERROR_ILLEGAL_ADDRESS (code: 700)
+  [GH-181]   Workspace reinit failed (non-fatal): ... CUDA_ERROR_ILLEGAL_ADDRESS (code: 700)
+  [PAR-054]  Workspace not ready, using non-graphed path
+  [CUDA-FAILFAST] Context poisoned during executor lifetime ...
+  Backend: wgpu (Vulkan)
+  [PMAT-333] Dequantizing 28 layers ... 6174.9 MB F32       <- wgpu fallback
+  [apr-cpu-vs-gpu-output-parity-v1] wgpu path rejected, cosine vs CPU = 0.884301 (<0.99)  <- CPU fallback
+NOTE: the illegal address happens at STARTUP (FP8 warmup), before any decode token —
+NOT seq_len/graph-replay/EOS. The "stall" is the slow wgpu->CPU fallback path.
+
+## Localized stage / kernel
+warmup_fp8_cache() -> PMAT-082 cuBLASLt FP8 JIT warmup GEMM
+file: crates/aprender-serve/src/cuda/executor/layers/cublas_prefill/attention.rs (~L1419-1464)
+
+## Root cause (verified)
+The warmup picked an ARBITRARY cached weight via fp8_weight_cache.values().next()
+(non-deterministic HashMap iteration order) but HARDCODED the GEMM dims to
+hidden_dim x hidden_dim (1536x1536). With GemmOp::Trans + lda=k the weight operand is
+read as [k x n] = 1536*1536 = 2.36 MB of FP8. The GQA K/V projection weights are only
+kv_dim*hidden = 256*1536 = 393 KB. When HashMap order happened to return a K/V weight,
+the GEMM read ~1.97 MB past the buffer end -> CUDA_ERROR_ILLEGAL_ADDRESS -> context
+poison -> wgpu/CPU fallback. HashMap order varies per process => the ~1-in-6 intermittency.
+
+## Evidence (this box, RTX 4090)
+- Baseline (v0.49.1 stock binary, varied prompts, 256 tok): 2/24 POISONED (~8%).
+- APR_SKIP_FP8_WARMUP=1 (skips ONLY the warmup GEMM, keeps FP8 cache): 0/48 POISONED.
+  => isolates poison to the PMAT-082 warmup GEMM, not FP8 caching or decode.
+- Patched binary: 0/48 POISONED over two batches; decode 75-80 tok/s retained.
+- DIRECT PROOF of HashMap-order trigger: patched warmup log shows the chosen weight's
+  dim VARYING per run: 1536x1536 (attn q/o), 3696x3696 (FFN 8960x1536), and 624x624
+  (the 256x1536 K/V weight — the exact one that OOB'd at 1536x1536 before the fix).
+
+## Fix (low-risk)
+Derive the warmup square dim from the CHOSEN weight's actual byte length
+(1 byte/elem FP8): dim = floor(sqrt(len)) & !15, max 16. Read can never exceed the
+buffer regardless of which weight HashMap returns. cuBLASLt JIT is per-handle not
+per-shape, so any valid shape warms it equally.
+Branch: fix/fp8-warmup-oob-poison-pmat082
+
+## Relation to prior memory
+- FUSION-003 1-in-6 (project_fusion_003_1_5b_falsified): SAME error code, but that was
+  only when FUSION-003 was WIRED (now reverted). This is a SEPARATE, always-live source
+  of the same poison via the PMAT-082 warmup GEMM.
+- cuda-decode-graph-audit-2026-06-14: that audit's batched (m>1, seq>1024) graph-staleness
+  findings are NOT this bug; apr run is c=1 and the poison is at startup, not in decode.


### PR DESCRIPTION
## A ~1-in-6 CUDA context-poison that silently collapsed decode to the CPU path

Diagnosed while investigating apr's intermittent "decode stall." It is **not** a decode-path bug — it's an out-of-bounds GPU read during **startup FP8 JIT warmup** that poisons the CUDA context and forces a silent fallback to the slow wgpu→CPU path (decode drops from ~75 tok/s to ~6–13 tok/s, ~13–24s).

### Root cause
`warmup_fp8_cache()` (the PMAT-082 cuBLASLt FP8 JIT warmup GEMM, `cublas_prefill/attention.rs`) picked an **arbitrary** cached weight via `fp8_weight_cache.values().next()` (non-deterministic HashMap order) but **hardcoded the GEMM dims to `hidden_dim×hidden_dim`** (1536×1536 = 2.36 MB). The GQA **K/V projection** weights are only `kv_dim×hidden = 256×1536 = 393 KB` — so when HashMap order returned a K/V weight, the GEMM read ~2 MB past the buffer → `CUDA_ERROR_ILLEGAL_ADDRESS` → `[CUDA-FAILFAST] Context poisoned` → wgpu/CPU fallback. HashMap order varies per process → the ~1-in-6 intermittency.

### Fix
Size the warmup GEMM to the **chosen weight's actual byte length** (`dim = floor(sqrt(len)) & !15`, min 16) so the read is always in-bounds whichever weight is picked. cuBLASLt JIT is per-handle (not per-shape), so any valid shape warms it equally.

### Verified (RTX 4090)
- **0/48 poisoned after the fix** vs **2/24 baseline** (~1-in-6 historically). Direct proof: post-fix the warmup-weight dim now **varies per run** (1536², 3696², **624²** = the 256×1536 K/V weight that previously OOB'd).
- Falsifier `APR_SKIP_FP8_WARMUP=1` → 0/48 (isolates the GEMM). Decode speed (75–80 tok/s) + full FP8 prefill retained. fmt + pre-commit gates clean. Evidence: `evidence/fp8-warmup-oob-poison-2026-06-15/`.

Unblocks gating the apr-vs-ollama decode beat (PMAT-737) — decode no longer randomly collapses to the CPU fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)