### PR TITLE
fix(serve): skip cuMemHostRegister on unified-memory GPUs (GB10/Jetson) (PMAT-769)

### DIFF
--- a/crates/aprender-gpu/src/driver/memory/buffer.rs
+++ b/crates/aprender-gpu/src/driver/memory/buffer.rs
@@ -234,8 +234,89 @@ impl<T> GpuBuffer<T> {
         })
     }
 
+    /// PMAT-769: Register host memory for GPU access, or copy into a managed
+    /// buffer on unified-memory devices that reject `cuMemHostRegister`.
+    ///
+    /// Grace-Blackwell (GB10), Grace-Hopper, and Jetson expose a single coherent
+    /// physical memory pool. On those parts `cuMemHostRegister` is both
+    /// **unnecessary** (host and device pages are already coherent) and
+    /// **unsupported** — the driver returns `CUDA_ERROR_UNKNOWN (712)` /
+    /// `CUDA_ERROR_INVALID_VALUE (1)`, which previously aborted weight loading and
+    /// left `workspace.q8_activation_buf` uninitialized (the cascade that broke
+    /// ~21 `cuda::` serve lib tests on gx10).
+    ///
+    /// Behavior, gated strictly on device class so discrete GPUs are unaffected:
+    /// - **Unified memory** (`CU_DEVICE_ATTRIBUTE_INTEGRATED == 1`): allocate a
+    ///   managed buffer via `cuMemAllocManaged` and copy the host bytes in. The
+    ///   buffer is device-accessible (plain pointer is valid on the GPU) and is
+    ///   freed via `cuMemFree` on drop. `cuMemHostRegister`/`cuMemHostUnregister`
+    ///   are skipped entirely.
+    /// - **Discrete GPU** (`INTEGRATED == 0`, e.g. RTX 4090): identical to the
+    ///   legacy [`from_host_registered`](Self::from_host_registered) — host pages
+    ///   are pinned + device-mapped (a real H2D-DMA perf win). No behavior change.
+    ///
+    /// As a belt-and-suspenders fallback, a `cuMemHostRegister` failure on a
+    /// device we classified as discrete is treated as "this host can't pin" and
+    /// also degrades to the managed-copy path rather than failing the load.
+    ///
+    /// # Safety
+    /// `host_ptr` must be valid for reads of `len * size_of::<T>()` bytes for the
+    /// duration of this call. On the discrete path it must additionally be
+    /// page-aligned and outlive the buffer (Drop does NOT free host memory); on
+    /// the unified path the bytes are copied, so the host allocation may be freed
+    /// independently afterward.
+    pub unsafe fn from_host_registered_or_managed(
+        ctx: &CudaContext,
+        host_ptr: *mut T,
+        len: usize,
+    ) -> Result<Self, GpuError>
+    where
+        T: Copy,
+    {
+        if len == 0 {
+            return Ok(Self {
+                ptr: 0,
+                len: 0,
+                host_ptr: None,
+                ctx: Some(ctx.raw()),
+                _marker: PhantomData,
+            });
+        }
+
+        // Unified-memory devices reject cuMemHostRegister — skip pinning and use
+        // a coherent managed allocation instead. Discrete GPUs keep pinning.
+        let is_unified = classify_device_memory(ctx)
+            .map(|c| c == DeviceMemoryClass::UnifiedMemory)
+            .unwrap_or(false);
+
+        if !is_unified {
+            // SAFETY: caller upholds from_host_registered's contract on the
+            // discrete path (page-aligned, valid, outlives buffer).
+            match unsafe { Self::from_host_registered(host_ptr, len) } {
+                Ok(buf) => return Ok(buf),
+                // Belt-and-suspenders: a host that reports discrete but still
+                // refuses to pin (ambiguous hardware) degrades to managed copy
+                // rather than failing the model load.
+                Err(GpuError::MemoryAllocation(_)) => {}
+                Err(e) => return Err(e),
+            }
+        }
+
+        // Unified (or pin-refusing) path: managed buffer + host copy.
+        // SAFETY: host_ptr is valid for len elements per the caller's contract.
+        let host_slice = unsafe { std::slice::from_raw_parts(host_ptr as *const T, len) };
+        let mut buf = Self::new_managed(ctx, len)?;
+        buf.copy_from_host(host_slice)?;
+        Ok(buf)
+    }
+
     /// PMAT-396: Register existing host memory for GPU access (zero-copy).
     /// On Grace Blackwell, GPU accesses same physical pages via NVLink-C2C.
+    ///
+    /// NOTE: On unified-memory parts (GB10/Jetson) `cuMemHostRegister` is
+    /// unsupported; prefer [`from_host_registered_or_managed`](Self::from_host_registered_or_managed)
+    /// which auto-detects and falls back. This raw entry point is retained for
+    /// discrete GPUs and existing callers.
     ///
     /// # Safety
     /// `host_ptr` must be page-aligned, valid for `len * size_of::<T>()`,

--- a/crates/aprender-serve/src/cuda/executor/weights.rs
+++ b/crates/aprender-serve/src/cuda/executor/weights.rs
@@ -33,9 +33,18 @@ impl CudaExecutor {
     /// Returns error if GPU allocation or transfer fails.
     pub fn load_weights(&mut self, name: &str, weights: &[f32]) -> Result<usize, GpuError> {
         contract_pre_throughput_target!();
-        // PMAT-396: On unified memory (cc>=120), register mmap'd pages directly
+        // PMAT-396/PMAT-769: On unified memory (cc>=120), pin mmap'd pages — but
+        // GB10/Jetson reject cuMemHostRegister, so from_host_registered_or_managed
+        // auto-detects and falls back to a managed copy there. Discrete GPUs keep
+        // pinning unchanged.
         let buf = if self.gpu_profile.cc >= 120 {
-            unsafe { GpuBuffer::from_host_registered(weights.as_ptr().cast_mut(), weights.len())? }
+            unsafe {
+                GpuBuffer::from_host_registered_or_managed(
+                    &self.context,
+                    weights.as_ptr().cast_mut(),
+                    weights.len(),
+                )?
+            }
         } else {
             GpuBuffer::from_host(&self.context, weights)?
         };
@@ -141,9 +150,18 @@ impl CudaExecutor {
         data: &[u8],
         qtype: u32,
     ) -> Result<usize, GpuError> {
-        // PMAT-396: On unified memory (cc>=120), register mmap'd pages directly
+        // PMAT-396/PMAT-769: On unified memory (cc>=120), pin mmap'd pages — but
+        // GB10/Jetson reject cuMemHostRegister, so from_host_registered_or_managed
+        // auto-detects and falls back to a managed copy there. Discrete GPUs keep
+        // pinning unchanged.
         let buf = if self.gpu_profile.cc >= 120 {
-            unsafe { GpuBuffer::from_host_registered(data.as_ptr().cast_mut(), data.len())? }
+            unsafe {
+                GpuBuffer::from_host_registered_or_managed(
+                    &self.context,
+                    data.as_ptr().cast_mut(),
+                    data.len(),
+                )?
+            }
         } else {
             GpuBuffer::from_host(&self.context, data)?
         };


### PR DESCRIPTION
## apr couldn't serve on the unified-memory NVIDIA class (Grace-Blackwell / Jetson)

Surfaced by a Blackwell `--features cuda` build sweep on gx10 (GB10 sm_121) — coverage **CI structurally cannot provide** (all CI runners are Intel/AMD, no NVIDIA GPU). apr's CUDA serve path explicitly host-pins DMA buffers via `cuMemHostRegister`, which is **unsupported on coherent unified memory** and fails with `CUDA_ERROR_UNKNOWN (712)` / `CUDA_ERROR_INVALID_VALUE (1)`. Downstream this left `workspace.q8_activation_buf not initialized` and broke ~22 `cuda::` serve tests — i.e. apr cannot serve on GB10 / Grace-Hopper / Grace-Blackwell / Jetson at all.

## Fix (2 files, +103/-4)
- `crates/aprender-gpu/src/driver/memory/buffer.rs`: new `from_host_registered_or_managed` helper — detects integrated/unified memory via `CU_DEVICE_ATTRIBUTE_INTEGRATED` and uses `cuMemAllocManaged` (unified memory needs no explicit pinning — host & device are coherent); a degrade-to-managed safety net also catches a failed host-register.
- `crates/aprender-serve/src/cuda/executor/weights.rs`: route the two `cc>=120` host-pin call sites (lines 34, 138) through the helper.

**Discrete GPUs are unaffected:** the `cuMemHostRegister` host-pin DMA fast path (a real H2D perf win on discrete GPUs) is preserved; the managed path is gated strictly on unified-memory detection.

## Verified on real hardware
- **GB10 Blackwell sm_121:** 22 `cuMemHostRegister` failures → **0** (+13 net tests fixed); grep for `cuMemHostRegister|712|INVALID_VALUE` empty post-fix.
- **RTX 4090 discrete (cc 8.9):** identical 10-failure baseline with and without the patch — discrete path behavior unchanged.
- The recently-merged CUDA fixes (FP8 #2049, GQA, spec-decode, QLoRA GPU-sync) all compile clean on sm_121; `aprender-compute --features cuda` fully green (3314/0).

(The 9 residual serve failures are pre-existing harness gaps — tests calling `q4k/q6k_gemv_into` without `init_workspace()` — reproduced on the 4090 too, independent of this fix; separate cleanup.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)