### PR TITLE
feat(beat): fail-closed reject cross-tensor-inconsistent models that safetensors/Transformers/Ollama silently load (PMAT-770)

### DIFF
--- a/contracts/apr-fail-closed-structural-beat-v1.yaml
+++ b/contracts/apr-fail-closed-structural-beat-v1.yaml
@@ -1,0 +1,107 @@
+contract: apr-fail-closed-structural-beat
+metadata:
+  kind: beat-benchmark
+  version: "1.0.0"
+  description: >
+    Pillar-4 CORRECTNESS beat (PMAT-756) — the STRUCTURAL companion to the
+    semantic fail-closed garbage beat (PMAT-744). Where F-DATA-QUALITY-001..005
+    reject a single tensor's broken CONTENTS (all-zero / NaN / Inf / L2~0 /
+    constant / extreme-magnitude), this beat rejects CROSS-TENSOR DIMENSION
+    inconsistencies that a real transformer ALWAYS satisfies but that the
+    SafeTensors container format does NOT enforce: (1) the embedding table and
+    the output head MUST index the same vocabulary — rows(lm_head) ==
+    rows(embed_tokens); (2) attention MUST consume the embedding's hidden vector
+    — in_dim(q_proj) == hidden_dim(embed_tokens). The SafeTensors format only
+    validates each tensor's shape<->byte-length in ISOLATION; it has no
+    model-level semantics. Verified 2026-06-15 (same host): the official
+    `safetensors` library (used by HuggingFace Transformers and Ollama's
+    safetensors import) LOADS, with ZERO error, a model whose embed declares
+    vocab=10 but lm_head declares vocab=8, AND a model whose embed hidden=4 but
+    q_proj input=6 — both tensors individually well-formed (-> garbage / OOB at
+    inference). apr's validate_cross_tensor_structure (F-STRUCT-001) REJECTS both
+    at load and ACCEPTS a real, consistent model (verified no false positive on
+    Qwen2.5-Coder-0.5B: tied embeddings, vocab 151936, hidden 896). apr concedes
+    raw decode speed but wins on "we provably never load a dimensionally-broken
+    model; they provably do." HONESTY NOTE: this is specifically the CROSS-TENSOR
+    class. The same `safetensors` lib DOES reject a single-tensor
+    shape<->byte-length inconsistency, and llama.cpp's GGUF loader DOES
+    cross-check per-tensor arch dims (file bounds, n_embd, n_vocab) — so the
+    asymmetry here is the model-level invariant that a raw safetensors load leaves
+    unchecked.
+  references:
+  - "crates/aprender-serve/tests/beat_fail_closed_structural.rs"
+  - "crates/aprender-serve/src/safetensors/validation.rs (validate_cross_tensor_structure, F-STRUCT-001)"
+  - "crates/aprender-serve/src/safetensors_infer_convert.rs (validate_structural_consistency — wired into the SafeTensors load path)"
+  - "contracts/apr-fail-closed-garbage-beat-v1.yaml (sibling SEMANTIC fail-closed beat, F-DATA-QUALITY-001..005)"
+version: 1
+status: enforced
+date: 2026-06-15
+
+# Beat-benchmark parameters (incumbent baseline measured; CI fails on regression).
+beat:
+  pillar: 4
+  incumbent: "safetensors / HuggingFace Transformers / Ollama (safetensors import)"
+  incumbent_pinned: >
+    2026-06-15 — `uv run --with safetensors --with numpy` ->
+    `safetensors.numpy.load_file` LOADED both crafted-broken artifacts with NO
+    error: {embed:[10,4], lm_head:[8,4]} (vocab mismatch) and
+    {embed:[10,4], q_proj:[6,6]} (hidden mismatch).
+  canonical_task: >
+    Present N classes of structurally cross-inconsistent SafeTensors models whose
+    individual tensors are each well-formed (valid shape<->byte-length) but whose
+    dimensions are mutually inconsistent: (a) embed vocab rows != lm_head/output
+    vocab rows; (b) embed hidden dim != q_proj/qkv input dim; including Llama-style
+    naming (tok_embeddings / output / attention.wq). A fail-closed loader MUST
+    REJECT every one. apr's validate_cross_tensor_structure rejects all N AND
+    accepts every valid model (consistent untied, tied-embedding, unrecognised
+    names — no false positive); safetensors-lib / Transformers / Ollama perform no
+    such model-level cross-tensor gate and reject 0.
+  metric: broken_structural_classes_rejected
+  direction: higher_is_better
+  baseline_value: 0           # incumbents reject 0 cross-tensor-inconsistent classes
+  baseline_floor: 0
+  beat_threshold: 2           # apr must reject BOTH broken structural classes (vocab + hidden)
+  baseline_sourced_date: "2026-06-15"
+  approved_compute: CPU       # the apr-side gate is CPU-deterministic
+  ci_gate_name: "beat_fail_closed_structural"   # crates/aprender-serve/tests/beat_fail_closed_structural.rs
+
+proof_obligations:
+- id: OBLIG-STRUCT-VOCAB-CONSISTENCY
+  statement: >
+    For any SafeTensors model exposing BOTH an embedding (embed_tokens/
+    tok_embeddings) and a separate output head (lm_head/output), apr rejects it at
+    load iff rows(output) != rows(embed). A tied-embedding model (no separate
+    head) is never flagged on this invariant.
+  type: invariant
+- id: OBLIG-STRUCT-HIDDEN-CONSISTENCY
+  statement: >
+    For any SafeTensors model exposing BOTH an embedding and an attention input
+    projection (q_proj/qkv_proj/attention.wq/c_attn), apr rejects it at load iff
+    cols(embed) != cols(q_proj) (the hidden dim the attention matmul consumes).
+  type: invariant
+- id: OBLIG-STRUCT-NO-FALSE-POSITIVE
+  statement: >
+    apr accepts every structurally-consistent model and every model whose role
+    tensors cannot be positively identified — the gate asserts an invariant only
+    when it can ground both sides. Verified on Qwen2.5-Coder-0.5B (real, valid).
+  type: invariant
+
+falsification_tests:
+- id: FALSIFY-BEAT-STRUCT-FAIL-CLOSED
+  description: >
+    FALSE if apr ACCEPTS any cross-tensor-inconsistent model (vocab mismatch or
+    hidden-dim mismatch) — the structural garbage the incumbents load silently —
+    OR if apr REJECTS a structurally-consistent / tied-embedding / unrecognised
+    model (false positive). Catches a regression that drops the gate or makes it
+    over-eager.
+  command: >
+    cargo test -p aprender-serve --test beat_fail_closed_structural -- --nocapture
+  expected: >
+    apr rejected 2/2 structural-mismatch classes (incumbents: 0) and accepted all
+    valid classes (0 false positive).
+  if_fails: >
+    Either validate_cross_tensor_structure stopped rejecting a cross-tensor
+    mismatch (fail-closed regression — check the role-name matching in
+    crates/aprender-serve/src/safetensors/validation.rs), or it started flagging a
+    valid model (false positive — most likely a needle now matches a tensor it
+    shouldn't, or the tied-embedding / unknown-name pass-through broke).

--- a/crates/aprender-serve/src/safetensors/shard.rs
+++ b/crates/aprender-serve/src/safetensors/shard.rs
@@ -172,6 +172,7 @@ pub use validation::{
     // Runtime validation functions (legacy API)
     enforce_embedding_validation,
     enforce_weight_validation,
+    validate_cross_tensor_structure,
     validate_embedding,
     validate_weight,
     // Compile-time enforcement via newtypes (PMAT-235)

--- a/crates/aprender-serve/src/safetensors/validation.rs
+++ b/crates/aprender-serve/src/safetensors/validation.rs
@@ -361,6 +361,151 @@ pub fn enforce_weight_validation(
 }
 
 // =============================================================================
+// F-STRUCT-001: CROSS-TENSOR STRUCTURAL CONSISTENCY GATE (PMAT-756)
+// =============================================================================
+//
+// Pillar-4 fail-closed STRUCTURAL beat (distinct from the F-DATA-QUALITY-00x
+// *semantic* gates). The per-tensor data-quality gates (all-zero / NaN / Inf /
+// L2~0 / extreme-magnitude, PMAT-744/F-DATA-QUALITY-001..005) check the CONTENTS
+// of a single tensor. This gate checks the CROSS-TENSOR DIMENSION INVARIANTS that
+// a real transformer ALWAYS satisfies but that the SafeTensors container format
+// does NOT enforce:
+//
+//   1. VOCAB CONSISTENCY:   rows(lm_head.weight) == rows(embed_tokens.weight)
+//                           (both index the SAME vocabulary).
+//   2. HIDDEN CONSISTENCY:  in_dim(q_proj/qkv) == hidden_dim(embed_tokens)
+//                           (attention consumes the embedding's hidden vector).
+//
+// WHY THIS IS A BEAT (verified 2026-06-15): the SafeTensors format has no
+// model-level semantics — it validates each tensor's shape<->byte-length in
+// isolation. The official `safetensors` library (used by HuggingFace
+// Transformers and Ollama's safetensors import) LOADS a model whose embedding
+// declares vocab=10 but whose lm_head declares vocab=8, or whose embedding
+// hidden=4 but whose q_proj input=6, with ZERO error — both tensors are
+// individually well-formed. Such a model then produces OUT-OF-RANGE token
+// lookups / a dimension-mismatched first matmul -> garbage or OOB at inference.
+// apr fails closed at load instead.
+//
+// FALSE-POSITIVE SAFETY: the gate fires ONLY when it can POSITIVELY identify the
+// relevant tensors AND they disagree. A tied-embedding model (no separate
+// lm_head) passes (invariant vacuously holds). A model that uses a name this gate
+// doesn't recognise passes (no assertion made). A real, consistent model passes.
+
+/// One side of an `(out_rows, in_cols)` 2-D tensor shape, extracted by role.
+#[derive(Debug, Clone, Copy)]
+struct Shape2D {
+    rows: usize,
+    cols: usize,
+}
+
+/// Interpret a SafeTensors shape vector as a 2-D `(rows, cols)` matrix.
+///
+/// Weight matrices in HF/SafeTensors are stored row-major `[out_features,
+/// in_features]`. Returns `None` for shapes that are not 2-D (norms, biases,
+/// scalars) — those carry no cross-tensor dimension invariant here.
+fn as_2d(shape: &[usize]) -> Option<Shape2D> {
+    if shape.len() == 2 {
+        Some(Shape2D {
+            rows: shape[0],
+            cols: shape[1],
+        })
+    } else {
+        None
+    }
+}
+
+/// Find the 2-D shape of the first tensor whose name matches any of `needles`
+/// as a trailing path-segment match (e.g. `embed_tokens.weight` matches
+/// `model.embed_tokens.weight`).
+fn find_shape<'a, I>(tensors: I, needles: &[&str]) -> Option<(&'a str, Shape2D)>
+where
+    I: IntoIterator<Item = (&'a str, &'a [usize])>,
+{
+    for (name, shape) in tensors {
+        for needle in needles {
+            if name == *needle || name.ends_with(needle) {
+                if let Some(s) = as_2d(shape) {
+                    return Some((name, s));
+                }
+            }
+        }
+    }
+    None
+}
+
+/// F-STRUCT-001 — validate cross-tensor structural consistency from a SafeTensors
+/// tensor map (name -> shape).
+///
+/// This is the Pillar-4 STRUCTURAL fail-closed gate. It rejects a model whose
+/// individual tensors are each well-formed but whose dimensions are mutually
+/// inconsistent — the exact class of artifact that `safetensors`-lib /
+/// HuggingFace Transformers / Ollama load and run silently.
+///
+/// # Errors
+///
+/// Returns `RealizarError::FormatError` (rule id `F-STRUCT-001`) if a
+/// cross-tensor invariant is violated. Returns `Ok(())` when no violation is
+/// found OR when the relevant tensors cannot be positively identified (no false
+/// positive).
+pub fn validate_cross_tensor_structure<'a, I>(tensors: I) -> Result<()>
+where
+    I: IntoIterator<Item = (&'a str, &'a [usize])> + Clone,
+{
+    // Canonical role names. We match by trailing path segment so both bare
+    // (`lm_head.weight`) and prefixed (`model.lm_head.weight`) forms work.
+    let embed = find_shape(
+        tensors.clone(),
+        &["embed_tokens.weight", "tok_embeddings.weight"],
+    );
+    let lm_head = find_shape(tensors.clone(), &["lm_head.weight", "output.weight"]);
+    // q_proj (separate) OR a fused qkv_proj; both have in_features == hidden_dim.
+    let q_proj = find_shape(
+        tensors.clone(),
+        &[
+            "self_attn.q_proj.weight",
+            "attention.wq.weight",
+            "self_attn.qkv_proj.weight",
+            "attn.c_attn.weight",
+        ],
+    );
+
+    // Invariant 1: VOCAB CONSISTENCY — rows(lm_head) == rows(embed).
+    // Only assert when BOTH are present (untied). Tied models omit lm_head -> pass.
+    if let (Some((emb_name, emb)), Some((lm_name, lm))) = (embed, lm_head) {
+        if emb.rows != lm.rows {
+            return Err(RealizarError::FormatError {
+                reason: format!(
+                    "[F-STRUCT-001] Vocab-size mismatch: '{emb_name}' has {} rows (vocab) but \
+                     '{lm_name}' has {} rows. The embedding table and the output head MUST index \
+                     the same vocabulary; this model would emit out-of-range token ids and produce \
+                     garbage. (safetensors/Transformers/Ollama load this silently.)",
+                    emb.rows, lm.rows
+                ),
+            });
+        }
+    }
+
+    // Invariant 2: HIDDEN CONSISTENCY — in_features(q_proj) == hidden_dim(embed).
+    // embed is [vocab, hidden]; q_proj/qkv is [out, hidden]. Their hidden (cols)
+    // MUST agree — attention consumes the embedding's hidden vector.
+    if let (Some((emb_name, emb)), Some((q_name, q))) = (embed, q_proj) {
+        if emb.cols != q.cols {
+            return Err(RealizarError::FormatError {
+                reason: format!(
+                    "[F-STRUCT-001] Hidden-dim mismatch: '{emb_name}' has hidden_dim {} but \
+                     attention input '{q_name}' expects hidden_dim {}. The first attention matmul \
+                     would be dimension-mismatched (OOB / garbage). \
+                     (safetensors/Transformers/Ollama load this silently.)",
+                    emb.cols, q.cols
+                ),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+// =============================================================================
 // VALIDATED NEWTYPES - Compile-Time Contract Enforcement (PMAT-235)
 // =============================================================================
 //

--- a/crates/aprender-serve/src/safetensors/validation_tests_02.rs
+++ b/crates/aprender-serve/src/safetensors/validation_tests_02.rs
@@ -437,5 +437,100 @@ fn test_validated_vector_length_mismatch() {
     assert_eq!(result.unwrap_err().rule_id, "F-LAYOUT-CONTRACT-003");
 }
 
+// =============================================================================
+// F-STRUCT-001 — cross-tensor structural consistency gate (PMAT-756)
+// =============================================================================
+
+/// Build a `(name, shape-slice)` view the gate consumes.
+fn struct_view(pairs: &[(&'static str, Vec<usize>)]) -> Vec<(&'static str, Vec<usize>)> {
+    pairs.to_vec()
+}
+
+#[test]
+fn test_f_struct_001_rejects_vocab_mismatch() {
+    let pairs = struct_view(&[
+        ("model.embed_tokens.weight", vec![32, 16]),
+        ("lm_head.weight", vec![24, 16]),
+    ]);
+    let v: Vec<(&str, &[usize])> = pairs.iter().map(|(n, s)| (*n, s.as_slice())).collect();
+    let r = validate_cross_tensor_structure(v);
+    assert!(r.is_err(), "vocab mismatch must be rejected");
+    let msg = format!("{}", r.unwrap_err());
+    assert!(msg.contains("F-STRUCT-001") && msg.contains("Vocab"), "{msg}");
+}
+
+#[test]
+fn test_f_struct_001_rejects_hidden_mismatch() {
+    let pairs = struct_view(&[
+        ("model.embed_tokens.weight", vec![32, 16]),
+        ("model.layers.0.self_attn.q_proj.weight", vec![24, 24]),
+    ]);
+    let v: Vec<(&str, &[usize])> = pairs.iter().map(|(n, s)| (*n, s.as_slice())).collect();
+    let r = validate_cross_tensor_structure(v);
+    assert!(r.is_err(), "hidden-dim mismatch must be rejected");
+    assert!(format!("{}", r.unwrap_err()).contains("Hidden"));
+}
+
+#[test]
+fn test_f_struct_001_accepts_consistent_untied_model() {
+    let pairs = struct_view(&[
+        ("model.embed_tokens.weight", vec![32, 16]),
+        ("lm_head.weight", vec![32, 16]),
+        ("model.layers.0.self_attn.q_proj.weight", vec![16, 16]),
+    ]);
+    let v: Vec<(&str, &[usize])> = pairs.iter().map(|(n, s)| (*n, s.as_slice())).collect();
+    assert!(
+        validate_cross_tensor_structure(v).is_ok(),
+        "consistent untied model must pass (no false positive)"
+    );
+}
+
+#[test]
+fn test_f_struct_001_accepts_tied_embedding() {
+    // No separate lm_head -> vocab invariant vacuous -> must pass.
+    let pairs = struct_view(&[
+        ("model.embed_tokens.weight", vec![32, 16]),
+        ("model.layers.0.self_attn.q_proj.weight", vec![16, 16]),
+    ]);
+    let v: Vec<(&str, &[usize])> = pairs.iter().map(|(n, s)| (*n, s.as_slice())).collect();
+    assert!(
+        validate_cross_tensor_structure(v).is_ok(),
+        "tied-embedding model must pass (no false positive)"
+    );
+}
+
+#[test]
+fn test_f_struct_001_accepts_unknown_names() {
+    // Cannot positively identify roles -> make no assertion -> pass.
+    let pairs = struct_view(&[("foo.weight", vec![10, 4]), ("bar.weight", vec![4, 4])]);
+    let v: Vec<(&str, &[usize])> = pairs.iter().map(|(n, s)| (*n, s.as_slice())).collect();
+    assert!(validate_cross_tensor_structure(v).is_ok());
+}
+
+#[test]
+fn test_f_struct_001_llama_naming_vocab_mismatch() {
+    let pairs = struct_view(&[
+        ("tok_embeddings.weight", vec![100, 8]),
+        ("output.weight", vec![64, 8]),
+    ]);
+    let v: Vec<(&str, &[usize])> = pairs.iter().map(|(n, s)| (*n, s.as_slice())).collect();
+    assert!(
+        validate_cross_tensor_structure(v).is_err(),
+        "Llama-named vocab mismatch must be rejected"
+    );
+}
+
+#[test]
+fn test_f_struct_001_ignores_non_2d_tensors() {
+    // Only 2-D weight matrices carry the invariant; 1-D norms are ignored.
+    let pairs = struct_view(&[
+        ("model.embed_tokens.weight", vec![32, 16]),
+        ("lm_head.weight", vec![32, 16]),
+        ("model.norm.weight", vec![16]),
+    ]);
+    let v: Vec<(&str, &[usize])> = pairs.iter().map(|(n, s)| (*n, s.as_slice())).collect();
+    assert!(validate_cross_tensor_structure(v).is_ok());
+}
+
 include!("validation_tests_contract.rs");
 include!("validation_tests.rs");

--- a/crates/aprender-serve/src/safetensors_infer.rs
+++ b/crates/aprender-serve/src/safetensors_infer.rs
@@ -26,6 +26,8 @@ pub(crate) trait TensorSource {
     fn get_tensor_auto(&self, name: &str) -> Result<Vec<f32>>;
     fn has_tensor(&self, name: &str) -> bool;
     fn tensor_names(&self) -> Vec<&str>;
+    /// Declared shape of a tensor (for the F-STRUCT-001 structural gate).
+    fn tensor_shape(&self, name: &str) -> Option<Vec<usize>>;
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -39,6 +41,9 @@ impl TensorSource for MappedSafeTensorsModel {
     fn tensor_names(&self) -> Vec<&str> {
         MappedSafeTensorsModel::tensor_names(self)
     }
+    fn tensor_shape(&self, name: &str) -> Option<Vec<usize>> {
+        MappedSafeTensorsModel::get_tensor_info(self, name).map(|i| i.shape.clone())
+    }
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -51,6 +56,9 @@ impl TensorSource for ShardedSafeTensorsModel {
     }
     fn tensor_names(&self) -> Vec<&str> {
         ShardedSafeTensorsModel::tensor_names(self)
+    }
+    fn tensor_shape(&self, name: &str) -> Option<Vec<usize>> {
+        ShardedSafeTensorsModel::get_tensor_info(self, name).map(|i| i.shape.clone())
     }
 }
 

--- a/crates/aprender-serve/src/safetensors_infer_convert.rs
+++ b/crates/aprender-serve/src/safetensors_infer_convert.rs
@@ -52,6 +52,12 @@ impl SafetensorsToAprConverter {
         source: &S,
         config: &SafetensorsConfig,
     ) -> Result<ValidatedAprTransformer> {
+        // F-STRUCT-001 (PMAT-756): fail closed on cross-tensor dimension
+        // inconsistencies (vocab/hidden mismatch) BEFORE assembly. The SafeTensors
+        // format does not enforce these — safetensors-lib / Transformers / Ollama
+        // load such artifacts and run garbage; apr rejects them at load.
+        Self::validate_structural_consistency(source)?;
+
         let apr_config = Self::build_apr_config(config)?;
         Self::log_phase2_warning(config);
         Self::log_hybrid_attention_info(config);
@@ -90,6 +96,28 @@ impl SafetensorsToAprConverter {
         };
 
         ValidatedAprTransformer::validate(transformer).map_err(Into::into)
+    }
+
+    /// F-STRUCT-001 (PMAT-756): cross-tensor structural consistency gate.
+    ///
+    /// Collects the declared shapes of the model's tensors and runs
+    /// [`validate_cross_tensor_structure`], which rejects a model whose embedding
+    /// and output head disagree on vocab size, or whose embedding and attention
+    /// disagree on hidden dim — structural garbage the SafeTensors container
+    /// format does not catch (and which `safetensors`-lib / Transformers / Ollama
+    /// load silently). No false positives: the gate only fires when it positively
+    /// identifies disagreeing tensors.
+    fn validate_structural_consistency<S: TensorSource>(source: &S) -> Result<()> {
+        let names = source.tensor_names();
+        let shapes: Vec<(String, Vec<usize>)> = names
+            .iter()
+            .filter_map(|n| source.tensor_shape(n).map(|s| ((*n).to_string(), s)))
+            .collect();
+        let view: Vec<(&str, &[usize])> = shapes
+            .iter()
+            .map(|(n, s)| (n.as_str(), s.as_slice()))
+            .collect();
+        crate::safetensors::validation::validate_cross_tensor_structure(view)
     }
 
     /// Build `AprTransformerConfig` from SafeTensors config.json.

--- a/crates/aprender-serve/tests/beat_fail_closed_structural.rs
+++ b/crates/aprender-serve/tests/beat_fail_closed_structural.rs
@@ -1,0 +1,237 @@
+//! BEAT-FAIL-CLOSED-STRUCT — Pillar-4 STRUCTURAL correctness beat (PMAT-756).
+//!
+//! Distinct from the SEMANTIC fail-closed beat (PMAT-744, all-zero/NaN/Inf/
+//! extreme-magnitude tensor CONTENTS): this beat is about CROSS-TENSOR DIMENSION
+//! INVARIANTS that a real transformer ALWAYS satisfies but that the SafeTensors
+//! container format does NOT enforce.
+//!
+//! The SafeTensors format validates each tensor's shape<->byte-length in
+//! isolation — it has NO model-level semantics. The official `safetensors`
+//! library (used by HuggingFace Transformers and Ollama's safetensors import)
+//! therefore LOADS, with ZERO error, a model whose embedding declares vocab=10
+//! rows but whose lm_head declares vocab=8 rows (the two MUST index the same
+//! vocabulary), or whose embedding hidden_dim=4 but whose q_proj input dim=6
+//! (attention MUST consume the embedding's hidden vector). Such a model then
+//! produces out-of-range token lookups / a dimension-mismatched first matmul ->
+//! garbage or OOB at inference.
+//!
+//! INCUMBENT EVIDENCE (measured 2026-06-15, same host):
+//!   `uv run --with safetensors --with numpy` -> `safetensors.numpy.load_file`
+//!   LOADS both crafted-broken artifacts above with NO error
+//!   (-> {'embed': [10,4], 'lm_head': [8,4]} ; {'embed':[10,4],'q_proj':[6,6]}).
+//!   (NB: the same `safetensors` lib DOES reject a single-tensor shape<->byte
+//!   inconsistency — so this beat is specifically the CROSS-TENSOR class the
+//!   format leaves unchecked, and llama.cpp's GGUF arch-dim checks don't cover
+//!   for a raw safetensors load.)
+//!
+//! apr's `validate_cross_tensor_structure` (F-STRUCT-001) REJECTS both, and
+//! ACCEPTS a real, consistent model (no false positive). This file is the
+//! CI-gated, falsifiable form of that guarantee.
+//!
+//! Contract: contracts/apr-fail-closed-structural-beat-v1.yaml.
+
+use realizar::safetensors::validation::validate_cross_tensor_structure;
+
+/// A named class of model = a list of `(tensor_name, shape)` pairs.
+type ModelClass = (&'static str, Vec<(&'static str, Vec<usize>)>);
+
+/// Build a `(name, shape)` view the gate consumes, mirroring the safetensors
+/// tensor-info map (name -> shape) that the parser produces.
+fn view<'a>(pairs: &'a [(&'a str, Vec<usize>)]) -> Vec<(&'a str, &'a [usize])> {
+    pairs.iter().map(|(n, s)| (*n, s.as_slice())).collect()
+}
+
+/// A real, consistent (untied) model: embed [vocab, hidden], lm_head [vocab,
+/// hidden], q_proj [q_out, hidden]. MUST PASS (no false positive).
+fn healthy_model() -> Vec<(&'static str, Vec<usize>)> {
+    let vocab = 32;
+    let hidden = 16;
+    vec![
+        ("model.embed_tokens.weight", vec![vocab, hidden]),
+        ("lm_head.weight", vec![vocab, hidden]),
+        (
+            "model.layers.0.self_attn.q_proj.weight",
+            vec![hidden, hidden],
+        ),
+        (
+            "model.layers.0.self_attn.k_proj.weight",
+            vec![hidden, hidden],
+        ),
+        ("model.norm.weight", vec![hidden]),
+    ]
+}
+
+#[test]
+fn beat_apr_rejects_vocab_mismatch_fail_closed() {
+    // embed vocab=32, lm_head vocab=24 — DISAGREE. safetensors-lib loads this.
+    let pairs = vec![
+        ("model.embed_tokens.weight", vec![32usize, 16]),
+        ("lm_head.weight", vec![24usize, 16]),
+        ("model.layers.0.self_attn.q_proj.weight", vec![16usize, 16]),
+    ];
+    let r = validate_cross_tensor_structure(view(&pairs));
+    assert!(
+        r.is_err(),
+        "FAIL-CLOSED VIOLATION: apr ACCEPTED a vocab-size mismatch (embed 32 rows vs lm_head 24 \
+         rows) — this is the structural garbage safetensors/Transformers/Ollama load silently."
+    );
+    let msg = format!("{}", r.unwrap_err());
+    assert!(
+        msg.contains("F-STRUCT-001"),
+        "rule id must be present: {msg}"
+    );
+    assert!(
+        msg.contains("Vocab"),
+        "error must name the vocab invariant: {msg}"
+    );
+}
+
+#[test]
+fn beat_apr_rejects_hidden_dim_mismatch_fail_closed() {
+    // embed hidden=16, q_proj input dim=24 — DISAGREE. safetensors-lib loads this.
+    let pairs = vec![
+        ("model.embed_tokens.weight", vec![32usize, 16]),
+        ("lm_head.weight", vec![32usize, 16]),
+        ("model.layers.0.self_attn.q_proj.weight", vec![24usize, 24]),
+    ];
+    let r = validate_cross_tensor_structure(view(&pairs));
+    assert!(
+        r.is_err(),
+        "FAIL-CLOSED VIOLATION: apr ACCEPTED a hidden-dim mismatch (embed hidden 16 vs q_proj \
+         input 24) — the first attention matmul would be dimension-mismatched (OOB/garbage)."
+    );
+    let msg = format!("{}", r.unwrap_err());
+    assert!(
+        msg.contains("F-STRUCT-001"),
+        "rule id must be present: {msg}"
+    );
+    assert!(
+        msg.contains("Hidden"),
+        "error must name the hidden invariant: {msg}"
+    );
+}
+
+#[test]
+fn beat_apr_rejects_llama_naming_vocab_mismatch() {
+    // Llama-style names (tok_embeddings / output / attention.wq) — vocab disagree.
+    let pairs = vec![
+        ("tok_embeddings.weight", vec![100usize, 8]),
+        ("output.weight", vec![64usize, 8]),
+        ("layers.0.attention.wq.weight", vec![8usize, 8]),
+    ];
+    let r = validate_cross_tensor_structure(view(&pairs));
+    assert!(
+        r.is_err(),
+        "FAIL-CLOSED VIOLATION: apr ACCEPTED a Llama-named vocab mismatch (tok_embeddings 100 vs \
+         output 64)."
+    );
+}
+
+#[test]
+fn beat_apr_accepts_healthy_model_no_false_positive() {
+    // The dual obligation: fail-closed must NOT reject a valid model.
+    let pairs = healthy_model();
+    let r = validate_cross_tensor_structure(view(&pairs));
+    assert!(
+        r.is_ok(),
+        "FALSE POSITIVE: apr rejected a structurally-consistent model — fail-closed must not block \
+         valid models. err={:?}",
+        r.err().map(|e| format!("{e}"))
+    );
+}
+
+#[test]
+fn beat_apr_accepts_tied_embedding_no_false_positive() {
+    // Tied-embedding model: NO separate lm_head/output tensor. The vocab
+    // invariant holds vacuously — must PASS, not be flagged.
+    let pairs = vec![
+        ("model.embed_tokens.weight", vec![32usize, 16]),
+        ("model.layers.0.self_attn.q_proj.weight", vec![16usize, 16]),
+        ("model.norm.weight", vec![16usize]),
+    ];
+    let r = validate_cross_tensor_structure(view(&pairs));
+    assert!(
+        r.is_ok(),
+        "FALSE POSITIVE: apr rejected a valid tied-embedding model (no separate lm_head). err={:?}",
+        r.err().map(|e| format!("{e}"))
+    );
+}
+
+#[test]
+fn beat_apr_accepts_unknown_naming_no_false_positive() {
+    // A model whose tensors this gate cannot positively identify must PASS
+    // (the gate makes no assertion it cannot ground).
+    let pairs = vec![
+        ("some.custom.weight", vec![10usize, 4]),
+        ("another.weight", vec![4usize, 4]),
+    ];
+    let r = validate_cross_tensor_structure(view(&pairs));
+    assert!(
+        r.is_ok(),
+        "FALSE POSITIVE: apr asserted an invariant on unrecognised tensor names. err={:?}",
+        r.err().map(|e| format!("{e}"))
+    );
+}
+
+/// Headline beat assertion: apr rejects ALL structural-mismatch classes the
+/// incumbents load silently, AND accepts ALL valid classes (zero false positive).
+#[test]
+fn beat_struct_summary_apr_strict_incumbents_permissive() {
+    // Broken classes apr MUST reject (incumbent safetensors-lib loads all).
+    let broken: Vec<ModelClass> = vec![
+        (
+            "vocab_mismatch",
+            vec![
+                ("model.embed_tokens.weight", vec![32, 16]),
+                ("lm_head.weight", vec![24, 16]),
+            ],
+        ),
+        (
+            "hidden_mismatch",
+            vec![
+                ("model.embed_tokens.weight", vec![32, 16]),
+                ("model.layers.0.self_attn.q_proj.weight", vec![24, 24]),
+            ],
+        ),
+    ];
+    let mut rejected = 0;
+    for (name, pairs) in &broken {
+        let v: Vec<(&str, &[usize])> = pairs.iter().map(|(n, s)| (*n, s.as_slice())).collect();
+        assert!(
+            validate_cross_tensor_structure(v).is_err(),
+            "apr must reject broken structural class `{name}`"
+        );
+        rejected += 1;
+    }
+
+    // Valid classes apr MUST accept (no false positive).
+    let valid: Vec<ModelClass> = vec![
+        ("consistent_untied", healthy_model()),
+        (
+            "tied",
+            vec![
+                ("model.embed_tokens.weight", vec![32, 16]),
+                ("model.layers.0.self_attn.q_proj.weight", vec![16, 16]),
+            ],
+        ),
+    ];
+    let mut accepted = 0;
+    for (name, pairs) in &valid {
+        let v: Vec<(&str, &[usize])> = pairs.iter().map(|(n, s)| (*n, s.as_slice())).collect();
+        assert!(
+            validate_cross_tensor_structure(v).is_ok(),
+            "apr must accept valid class `{name}` (no false positive)"
+        );
+        accepted += 1;
+    }
+
+    assert_eq!(rejected, broken.len(), "all broken classes rejected");
+    assert_eq!(accepted, valid.len(), "all valid classes accepted");
+    println!(
+        "BEAT-FAIL-CLOSED-STRUCT: apr rejected {rejected}/{} structural-mismatch classes \
+         (incumbent safetensors/Transformers/Ollama: 0) and accepted {accepted}/{} valid classes \
+         (0 false positive).",
+        broken.len(),
+        valid.len()
+    );
+}


### PR DESCRIPTION
## Pillar-4 fail-closed beat: cross-tensor dimension inconsistency (F-STRUCT-001)

apr concedes raw decode speed but WINS on fail-closed safety. This beat rejects a model whose individual tensors are each well-formed but whose dimensions are **mutually inconsistent**:
1. **Vocab mismatch**: `rows(lm_head/output) ≠ rows(embed_tokens)` — they must index the same vocabulary.
2. **Hidden mismatch**: `in_dim(q_proj/qkv) ≠ hidden_dim(embed_tokens)` — attention must consume the embedding's hidden vector.

`safetensors.load_file` (what HF Transformers / Ollama load through) accepts both broken artifacts with **zero error** — the SafeTensors format has no model-level semantics. apr fails closed.

## The honesty work (measure-first — rejected the non-beats)
Empirically tested candidates against real incumbents and DISCARDED the ones where they're already strict:
- Single-tensor shape-vs-byte-length: the HF **safetensors lib REJECTS it** (apr was weaker, not a beat) — discarded.
- GGUF shape-too-big / wrong-dim / vocab mismatch: **llama.cpp REJECTED all three** crafted GGUFs (`data not within file bounds`, `wrong shape`, `expected 151936, got 1000`) — discarded.
- Cross-tensor model-level invariants: `safetensors.numpy.load_file` **loaded both broken artifacts with zero error** — the genuine asymmetric gap. ✓

## Deliverables (+621, 7 files)
- Gate `validate_cross_tensor_structure` (F-STRUCT-001) in `safetensors/validation.rs` — operates on the raw `(name → shape)` map, fires only on positively-identified disagreeing role tensors (HF + Llama naming).
- Wired into the **live load path** (`safetensors_infer_convert.rs::validate_structural_consistency` + new `TensorSource::tensor_shape`) — fails closed at convert/load, before assembly.
- 14 falsifier tests (7 integration + 7 unit), models crafted in-test (clean per-PR CPU, no GPU/download).
- Contract `apr-fail-closed-structural-beat-v1.yaml` (pillar 4, incumbent safetensors/Transformers/Ollama) — `pv validate` + `pv lint` PASS.

## Zero false positives (verified)
Gate ACCEPTS: consistent-untied, **tied-embedding** (no separate lm_head → invariant vacuous), and unrecognised-name models. Verified on REAL **Qwen2.5-Coder-0.5B** (tied, vocab 151936, hidden 896) — passes. Full `aprender-serve` lib suite: **15318 passed, 0 failed**; fmt clean; zero clippy warnings.

## Secondary defect surfaced (separate follow-up, not a beat)
apr's raw safetensors `get_tensor_f32` silently derives element count from byte length and ignores declared shape — a real integrity bug, but the safetensors lib already rejects it (parity, not a beat), so excluded here per the honesty requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)