### PR TITLE
fix(serve): reject safetensors tensors whose byte length contradicts declared shape (PMAT-771)

### DIFF
--- a/contracts/safetensors-format-safety-v1.yaml
+++ b/contracts/safetensors-format-safety-v1.yaml
@@ -153,9 +153,27 @@ falsification_tests:
   if_fails: Tensor data corruption — reads wrong weights silently
 - id: FALSIFY-ST-004
   rule: DType size matches tensor bytes
-  prediction: F32 tensor with byte count not divisible by 4 returns FormatError
-  test: Craft tensor with dtype=F32, shape=[3], but 11 bytes (not 12), verify error
-  if_fails: Misaligned read or silent truncation
+  prediction: >
+    A tensor whose declared data_offsets byte length contradicts
+    product(shape) * dtype_size is rejected at read time (fail closed), even when
+    the byte length is itself a multiple of the element size and the file is large
+    enough to cover it. Both the in-memory (SafetensorsModel) and zero-copy mmap
+    (MappedSafeTensorsModel) readers enforce this via
+    SafetensorsTensorInfo::validate_shape_matches_bytes, reaching parity with the
+    HuggingFace safetensors library. A well-formed tensor still loads unchanged.
+  test: >
+    Craft dtype=F32 shape=[3] (expects 12 bytes) with data_offsets=[0,8]
+    (8 bytes, a multiple of 4) and verify the reader returns an error rather than a
+    2-element tensor; a matching shape=[3]/[0,12] tensor loads as 3 elements.
+  test_harness: >
+    cargo test -p aprender-serve --lib test_inmem_rejects_shape_vs_bytes_mismatch
+    test_mapped_rejects_shape_vs_bytes_mismatch test_inmem_valid_shape_still_loads
+    test_mapped_valid_shape_still_loads
+  expected_output: "test result: ok"
+  if_fails: >
+    Reader derives element count from byte length and ignores the declared shape —
+    a crafted/corrupt safetensors loads a wrong-sized tensor (garbage inference /
+    integrity hole) where HF safetensors would reject the file.
 - id: FALSIFY-ST-005
   rule: Zero-copy mmap no heap allocation
   prediction: Loading 4GB tensor via mmap uses <1MB heap memory

--- a/crates/aprender-serve/src/safetensors/mapped_model.rs
+++ b/crates/aprender-serve/src/safetensors/mapped_model.rs
@@ -211,6 +211,12 @@ impl MappedSafeTensorsModel {
                 reason: format!("Tensor '{name}' not found"),
             })?;
 
+        // Integrity: declared byte length must equal product(shape) * dtype_size.
+        // Fail closed on a crafted/corrupt file rather than silently returning a
+        // wrong-sized slice (parity with the HF safetensors library). This is the
+        // shared raw-read entry point, so every dtype variant inherits the check.
+        tensor.validate_shape_matches_bytes()?;
+
         let [start, end] = tensor.data_offsets;
         let abs_start = self.data_offset + start;
         let abs_end = self.data_offset + end;

--- a/crates/aprender-serve/src/safetensors/mod.rs
+++ b/crates/aprender-serve/src/safetensors/mod.rs
@@ -98,6 +98,21 @@ pub enum SafetensorsDtype {
     Bool,
 }
 
+impl SafetensorsDtype {
+    /// Size in bytes of a single element of this dtype.
+    ///
+    /// Matches the official `safetensors` library element widths.
+    #[must_use]
+    pub fn size_in_bytes(&self) -> usize {
+        match self {
+            SafetensorsDtype::F32 | SafetensorsDtype::I32 => 4,
+            SafetensorsDtype::F16 | SafetensorsDtype::BF16 => 2,
+            SafetensorsDtype::I64 => 8,
+            SafetensorsDtype::U8 | SafetensorsDtype::Bool => 1,
+        }
+    }
+}
+
 /// JSON tensor metadata (internal)
 #[derive(Debug, Deserialize)]
 struct TensorMetadata {
@@ -117,6 +132,70 @@ pub struct SafetensorsTensorInfo {
     pub shape: Vec<usize>,
     /// Data offsets in file [start, end)
     pub data_offsets: [usize; 2],
+}
+
+impl SafetensorsTensorInfo {
+    /// Number of bytes occupied by this tensor's data, per `data_offsets`.
+    #[must_use]
+    pub fn byte_len(&self) -> usize {
+        self.data_offsets[1].saturating_sub(self.data_offsets[0])
+    }
+
+    /// Validate that the declared `data_offsets` byte length agrees with the
+    /// declared `shape` and `dtype` element size.
+    ///
+    /// The safetensors spec requires `byte_len == product(shape) * dtype_size`.
+    /// The official `HuggingFace` `safetensors` library rejects any file that
+    /// violates this; aprender's raw reader historically derived the element
+    /// count from the byte length and silently ignored the declared shape, so a
+    /// crafted or corrupt file whose byte length contradicts its shape would
+    /// load with a wrong-sized tensor (garbage inference / integrity hole).
+    /// This check makes the reader fail closed to reach parity with the
+    /// reference implementation (defense-in-depth, per-tensor integrity).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `shape` overflows `usize`, or if the byte length
+    /// does not equal `product(shape) * dtype_size`.
+    pub fn validate_shape_matches_bytes(&self) -> Result<()> {
+        let dtype_size = self.dtype.size_in_bytes();
+
+        let elem_count = self
+            .shape
+            .iter()
+            .try_fold(1usize, |acc, &d| acc.checked_mul(d))
+            .ok_or_else(|| RealizarError::UnsupportedOperation {
+                operation: "validate_shape_matches_bytes".to_string(),
+                reason: format!(
+                    "Tensor '{}' shape {:?} overflows usize",
+                    self.name, self.shape
+                ),
+            })?;
+
+        let expected = elem_count.checked_mul(dtype_size).ok_or_else(|| {
+            RealizarError::UnsupportedOperation {
+                operation: "validate_shape_matches_bytes".to_string(),
+                reason: format!(
+                    "Tensor '{}' byte size (shape {:?} * {dtype_size}) overflows usize",
+                    self.name, self.shape
+                ),
+            }
+        })?;
+
+        let actual = self.byte_len();
+        if actual != expected {
+            return Err(RealizarError::UnsupportedOperation {
+                operation: "validate_shape_matches_bytes".to_string(),
+                reason: format!(
+                    "Tensor '{}' byte length {actual} contradicts declared shape {:?} \
+                     ({:?}, {dtype_size} bytes/elem => expected {expected} bytes)",
+                    self.name, self.shape, self.dtype
+                ),
+            });
+        }
+
+        Ok(())
+    }
 }
 
 /// Safetensors model container

--- a/crates/aprender-serve/src/safetensors/safetensors_parser.rs
+++ b/crates/aprender-serve/src/safetensors/safetensors_parser.rs
@@ -87,6 +87,11 @@ impl SafetensorsModel {
             });
         }
 
+        // Integrity: declared byte length must equal product(shape) * dtype_size.
+        // Fail closed on a crafted/corrupt file rather than silently using the
+        // byte-derived element count (parity with the HF safetensors library).
+        tensor.validate_shape_matches_bytes()?;
+
         // Extract data slice
         let [start, end] = tensor.data_offsets;
         if end > self.data.len() {
@@ -226,6 +231,9 @@ impl SafetensorsModel {
             });
         }
 
+        // Integrity: declared byte length must equal product(shape) * dtype_size.
+        tensor.validate_shape_matches_bytes()?;
+
         let [start, end] = tensor.data_offsets;
         if end > self.data.len() {
             let data_len = self.data.len();
@@ -274,6 +282,9 @@ impl SafetensorsModel {
                 reason: format!("Tensor '{name}' has dtype {dtype:?}, expected BF16"),
             });
         }
+
+        // Integrity: declared byte length must equal product(shape) * dtype_size.
+        tensor.validate_shape_matches_bytes()?;
 
         let [start, end] = tensor.data_offsets;
         if end > self.data.len() {

--- a/crates/aprender-serve/src/safetensors/tests_get_tensor.rs
+++ b/crates/aprender-serve/src/safetensors/tests_get_tensor.rs
@@ -174,4 +174,132 @@ mod mapped_tests_part_02 {
         assert!(!model.has_tensor("nonexistent"));
         assert!(model.get_tensor_info("nonexistent").is_none());
     }
+
+    /// SAFETENSORS-INTEGRITY-001 (falsifier): the mmap reader must REJECT a
+    /// tensor whose declared shape contradicts its `data_offsets` byte length.
+    ///
+    /// Crafted tensor: dtype F32, shape `[3]` (expects 3 * 4 = 12 bytes) but
+    /// `data_offsets:[0,8]` declares only 8 bytes. The byte length is a
+    /// multiple of 4 (passes the old check) and the file is large enough
+    /// (passes the GH-213 truncation check), so the historical reader would
+    /// silently return a 2-element tensor instead of the declared 3.
+    /// The official HF safetensors library rejects this; aprender must too.
+    #[test]
+    fn test_mapped_rejects_shape_vs_bytes_mismatch() {
+        let mut file = tempfile::NamedTempFile::new().expect("temp file");
+        // shape [3] => 12 bytes expected, but data_offsets declare 8 bytes.
+        let json = r#"{"w":{"dtype":"F32","shape":[3],"data_offsets":[0,8]}}"#;
+        file.write_all(&(json.len() as u64).to_le_bytes())
+            .expect("header");
+        file.write_all(json.as_bytes()).expect("metadata");
+        // Provide the full 8 declared bytes so the GH-213 size gate passes.
+        file.write_all(&[0u8; 8]).expect("data");
+        file.flush().expect("flush");
+
+        let model = MappedSafeTensorsModel::load(file.path()).expect("load");
+        let result = model.get_tensor_f32("w");
+        assert!(
+            result.is_err(),
+            "Expected rejection of shape/bytes mismatch, got {} values",
+            result.map(|v| v.len()).unwrap_or(0)
+        );
+        let err = format!("{:?}", result.unwrap_err());
+        assert!(
+            err.contains("contradicts declared shape"),
+            "Expected integrity error, got: {err}"
+        );
+    }
+
+    /// False-positive guard: a well-formed tensor (byte_len == product(shape)
+    /// * dtype_size) must still load through the mmap reader unchanged.
+    #[test]
+    fn test_mapped_valid_shape_still_loads() {
+        let mut file = tempfile::NamedTempFile::new().expect("temp file");
+        // shape [3] => exactly 12 bytes. Well-formed.
+        let json = r#"{"w":{"dtype":"F32","shape":[3],"data_offsets":[0,12]}}"#;
+        file.write_all(&(json.len() as u64).to_le_bytes())
+            .expect("header");
+        file.write_all(json.as_bytes()).expect("metadata");
+        file.write_all(&1.0f32.to_le_bytes()).expect("d0");
+        file.write_all(&2.0f32.to_le_bytes()).expect("d1");
+        file.write_all(&3.0f32.to_le_bytes()).expect("d2");
+        file.flush().expect("flush");
+
+        let model = MappedSafeTensorsModel::load(file.path()).expect("load");
+        let values = model.get_tensor_f32("w").expect("valid tensor must load");
+        assert_eq!(values, vec![1.0, 2.0, 3.0]);
+    }
+}
+
+// ============================================================================
+// SAFETENSORS-INTEGRITY-001: in-memory SafetensorsModel shape-vs-bytes
+// ============================================================================
+
+/// Falsifier: the in-memory reader must REJECT a tensor whose declared shape
+/// contradicts its `data_offsets` byte length (parity with HF safetensors).
+///
+/// Crafted: dtype F32, shape `[3]` (expects 12 bytes) but offsets `[0,8]`
+/// declare 8 bytes. 8 is a multiple of 4, so the historical reader silently
+/// produced a 2-element tensor; the fix makes it fail closed.
+#[test]
+fn test_inmem_rejects_shape_vs_bytes_mismatch_f32() {
+    let json = r#"{"w":{"dtype":"F32","shape":[3],"data_offsets":[0,8]}}"#;
+    let json_bytes = json.as_bytes();
+    let mut data = Vec::new();
+    data.extend_from_slice(&(json_bytes.len() as u64).to_le_bytes());
+    data.extend_from_slice(json_bytes);
+    // 8 declared bytes of tensor data.
+    data.extend_from_slice(&1.0f32.to_le_bytes());
+    data.extend_from_slice(&2.0f32.to_le_bytes());
+
+    let model = SafetensorsModel::from_bytes(&data).expect("parse");
+    let result = model.get_tensor_f32("w");
+    assert!(
+        result.is_err(),
+        "Expected rejection of shape/bytes mismatch, got {} values",
+        result.map(|v| v.len()).unwrap_or(0)
+    );
+    let err = format!("{:?}", result.unwrap_err());
+    assert!(
+        err.contains("contradicts declared shape"),
+        "Expected integrity error, got: {err}"
+    );
+}
+
+/// Falsifier (F16 path): BF16/F16 element size is 2, so shape `[4]` expects
+/// 8 bytes; offsets declaring 6 bytes (a multiple of 2) must be rejected.
+#[test]
+fn test_inmem_rejects_shape_vs_bytes_mismatch_f16() {
+    let json = r#"{"w":{"dtype":"F16","shape":[4],"data_offsets":[0,6]}}"#;
+    let json_bytes = json.as_bytes();
+    let mut data = Vec::new();
+    data.extend_from_slice(&(json_bytes.len() as u64).to_le_bytes());
+    data.extend_from_slice(json_bytes);
+    data.extend_from_slice(&[0u8; 6]);
+
+    let model = SafetensorsModel::from_bytes(&data).expect("parse");
+    let result = model.get_tensor_f16_as_f32("w");
+    assert!(result.is_err(), "Expected rejection of F16 shape/bytes mismatch");
+    let err = format!("{:?}", result.unwrap_err());
+    assert!(
+        err.contains("contradicts declared shape"),
+        "Expected integrity error, got: {err}"
+    );
+}
+
+/// False-positive guard: a well-formed in-memory tensor still loads.
+#[test]
+fn test_inmem_valid_shape_still_loads() {
+    let json = r#"{"w":{"dtype":"F32","shape":[2,3],"data_offsets":[0,24]}}"#;
+    let json_bytes = json.as_bytes();
+    let mut data = Vec::new();
+    data.extend_from_slice(&(json_bytes.len() as u64).to_le_bytes());
+    data.extend_from_slice(json_bytes);
+    for i in 0..6 {
+        data.extend_from_slice(&(i as f32).to_le_bytes());
+    }
+
+    let model = SafetensorsModel::from_bytes(&data).expect("parse");
+    let values = model.get_tensor_f32("w").expect("valid 2x3 tensor must load");
+    assert_eq!(values, vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0]);
 }

--- a/crates/aprender-serve/src/safetensors/tests_temp_file_helper.rs
+++ b/crates/aprender-serve/src/safetensors/tests_temp_file_helper.rs
@@ -245,7 +245,12 @@
 
     #[test]
     fn test_mapped_get_tensor_f32_not_multiple_of_4() {
-        // Create file with misaligned data
+        // Create file with misaligned data. shape [1] (F32) declares 4 bytes
+        // but data_offsets span 7 — this is BOTH a shape-vs-bytes contradiction
+        // and not a multiple of 4. The shape-vs-bytes integrity gate
+        // (validate_shape_matches_bytes) now fires first, which is the more
+        // precise rejection point (parity with the HF safetensors library);
+        // it subsumes the older "not a multiple of 4" downstream check.
         let mut file = tempfile::NamedTempFile::new().expect("temp file");
         let json = r#"{"weight":{"dtype":"F32","shape":[1],"data_offsets":[0,7]}}"#;
         file.write_all(&(json.len() as u64).to_le_bytes())
@@ -259,8 +264,8 @@
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(
-            format!("{err:?}").contains("not a multiple of 4"),
-            "Expected alignment error, got: {err:?}"
+            format!("{err:?}").contains("contradicts declared shape"),
+            "Expected shape/bytes integrity error, got: {err:?}"
         );
     }
 


### PR DESCRIPTION
## Integrity hardening: shape-vs-bytes validation (FALSIFY-ST-004, now enforced)

apr's raw safetensors readers derived element count from the `data_offsets` byte length and silently ignored the declared `shape` (checked `end <= data.len()` and `byte_len % dtype_size == 0`, but never `byte_len == product(shape) × dtype_size`). A crafted/corrupt file whose byte length contradicts its shape loaded silently as a wrong-sized tensor. The HF `safetensors` lib rejects this → integrity/hardening-to-parity fix (defense against crafted models), NOT a Pillar-4 beat. Complements the model-level cross-tensor beat (PMAT-770) at the per-tensor level.

## Dead-twin trap avoided
`safetensors_config.rs`/`mapped_safe_tensors_model.rs` are orphaned copies not in `mod.rs`; the LIVE readers `safetensors_parser.rs` (in-mem) + `mapped_model.rs` (mmap) got the fix.

## Fix (+253, 6 files)
- `mod.rs`: `SafetensorsDtype::size_in_bytes()` + `validate_shape_matches_bytes()` (checked arithmetic, fails closed). Wired into both live readers (`get_tensor_bytes` = one shared entry point).
- 5 falsifier tests (3 rejection + 2 valid-path guards); a pre-existing `[1]`/7-bytes test now caught by the gate first.

## Contract co-evolution (Rule 7)
`safetensors-format-safety-v1.yaml` declared FALSIFY-ST-004 (`byte_count == product(shape)×dtype_size`) but had no harness — now wired. `pv validate` → 0 errors.

## Zero false positives
All 290 real Qwen2.5-Coder-0.5B tensors load (0 rejections); `aprender-serve` lib suite 15316 passed, 0 failed; fmt+clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)