### PR TITLE
test(serve): shrink oversized gpu test config — 33s→0.09s on aarch64 (PMAT-772)

### DIFF
--- a/crates/aprender-serve/src/gpu/tests/resource_limiter.rs
+++ b/crates/aprender-serve/src/gpu/tests/resource_limiter.rs
@@ -260,11 +260,21 @@ fn test_gguf_model_state_small_config() {
 
 #[test]
 fn test_gguf_model_state_large_config() {
-    // Test with larger configuration
-    let result = load_gguf_to_gpu(32000, 4096, 32);
+    // Test with a larger-than-minimal configuration (multi-layer, non-trivial vocab).
+    //
+    // PMAT-772: This previously used (32000, 4096, 32) — full 7B-class dimensions —
+    // which forced `GpuModel::new` to allocate and fill ~25 GB of `vec![0.01f32; N]`
+    // weight buffers. In a debug build that fill is a per-element scalar loop, and on
+    // ARM hosts (GB10/Grace/Jetson) faulting in ~6.5M pages + the memset took >30s
+    // single-threaded at 100% CPU, gating the whole `--lib` run. x86 absorbed it via a
+    // faster fill, so CI never surfaced it. The "larger config" intent — exercising the
+    // multi-layer construction, the lm_head transpose, and vocab_size propagation — is
+    // fully preserved at these dimensions, which complete in well under a second.
+    let vocab_size = 2048;
+    let result = load_gguf_to_gpu(vocab_size, 256, 4);
     assert!(result.is_ok());
 
     let state = result.expect("test value should be present");
     assert!(state.is_ready());
-    assert_eq!(state.vocab_size(), 32000);
+    assert_eq!(state.vocab_size(), vocab_size);
 }


### PR DESCRIPTION
## Pathologically-slow test on aarch64 (33s → 0.09s, ~370×)

Surfaced by a Blackwell sweep: a single CPU-bound test stalled the `aprender-serve --lib` run on aarch64/GB10 (x86 CI never surfaces it). Diagnosed to `gpu::tests::tests_10::test_gguf_model_state_large_config` (`gpu/tests/resource_limiter.rs:262`).

## Root cause — oversized test data, NOT a product bug
The test called `load_gguf_to_gpu(32000, 4096, 32)` (full 7B-class dims) purely to assert `GgufModelState::is_ready()` + `vocab_size` propagation. That config makes `GpuModel::new` allocate + fill **~25 GB** of `vec![0.01f32; N]` across 32 layers. Timing probes: alloc/fill = 30.4s, transpose = 2.0s. In debug the non-zero fill is a per-element scalar loop; on ARM, faulting in ~6.5M pages + the memset dominates (~20M minor page faults observed). x86 absorbs it fast enough to never surface in CI → aarch64-specific.

## Fix
Shrank the test config to `(2048, 256, 4)` and made the assertion use `vocab_size`. Still exercises every intended path (multi-layer construction, the lm_head transpose, `vocab_size` propagation through `GgufModelState`) and asserts the identical property. **Production `load_gguf_to_gpu` untouched.**

## Verification (on gx10 aarch64)
- Test: 33.47s → **0.09s**. Whole `tests_10` module: 33s → 0.25s (136 tests pass).
- Full `gpu::tests`: **787 passed / 0 failed**; no CPU-bound hotspot remains. `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)