### PR TITLE
fix(gpu): cuInit TOCTOU race + close serve --features cuda test harness gaps (PMAT-774)

### DIFF
--- a/crates/aprender-gpu/src/driver/context.rs
+++ b/crates/aprender-gpu/src/driver/context.rs
@@ -17,6 +17,7 @@
 use std::os::raw::c_char;
 use std::ptr;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Once;
 
 use super::sys::{CUcontext, CUdevice, CudaDriver, CUDA_SUCCESS};
 use crate::GpuError;
@@ -25,8 +26,16 @@ use crate::GpuError;
 // Global Initialization State
 // ============================================================================
 
-/// Track whether cuInit has been called
-static CUDA_INITIALIZED: AtomicBool = AtomicBool::new(false);
+/// Serialize the one-time `cuInit` call. A bare `AtomicBool::swap` guard is a
+/// TOCTOU race: a second thread could observe the flag already `true` and call
+/// `cuDeviceGetCount` / `cuDevicePrimaryCtxRetain` *before* the first thread's
+/// `cuInit` returned, getting `count == 0` or a spurious init failure. This
+/// surfaced as flaky `num_devices()`/`CudaExecutor::new(0)` failures when GPU
+/// tests run in parallel. `Once` makes every caller block until `cuInit`
+/// completes exactly once.
+static CUDA_INIT_ONCE: Once = Once::new();
+/// Records whether the one-time `cuInit` succeeded (read after `call_once`).
+static CUDA_INIT_OK: AtomicBool = AtomicBool::new(false);
 
 /// Get the CUDA driver, initializing if needed
 ///
@@ -38,17 +47,18 @@ pub(crate) fn get_driver() -> Result<&'static CudaDriver, GpuError> {
     let driver = CudaDriver::load()
         .ok_or_else(|| GpuError::CudaNotAvailable("CUDA driver not found".to_string()))?;
 
-    // Initialize CUDA if not already done
-    if !CUDA_INITIALIZED.swap(true, Ordering::SeqCst) {
-        // SAFETY: cuInit is safe to call multiple times, we just avoid redundant calls
+    // Initialize CUDA exactly once; concurrent callers BLOCK here until the
+    // single cuInit completes, then all observe the result via CUDA_INIT_OK.
+    CUDA_INIT_ONCE.call_once(|| {
+        // SAFETY: cuInit(0) is the standard CUDA driver init entry point.
         let result = unsafe { (driver.cuInit)(0) };
-        if result != CUDA_SUCCESS {
-            CUDA_INITIALIZED.store(false, Ordering::SeqCst);
-            return Err(GpuError::DeviceInit(format!(
-                "cuInit failed with code {}",
-                result
-            )));
-        }
+        CUDA_INIT_OK.store(result == CUDA_SUCCESS, Ordering::SeqCst);
+    });
+
+    if !CUDA_INIT_OK.load(Ordering::SeqCst) {
+        return Err(GpuError::DeviceInit(
+            "cuInit failed during CUDA driver initialization".to_string(),
+        ));
     }
 
     Ok(driver)

--- a/crates/aprender-serve/src/cuda/executor/core_executor_tests.rs
+++ b/crates/aprender-serve/src/cuda/executor/core_executor_tests.rs
@@ -3,6 +3,7 @@
 #[cfg(feature = "cuda")]
 mod tests {
     use super::*;
+    use serial_test::serial;
 
     fn create_executor() -> Option<CudaExecutor> {
         CudaExecutor::new(0).ok()
@@ -12,13 +13,22 @@ mod tests {
     // Constructor Tests
     // ========================================================================
 
+    // NOTE: These device-enumeration tests touch the process-global CUDA driver
+    // state (context pool / sentinel). Every kernel-launching GPU test in this
+    // suite is #[serial]; these must be too, otherwise creating a context on an
+    // invalid device (test_new_invalid_device) can race a concurrent serial test
+    // and transiently corrupt the shared driver state, making CudaExecutor::new(0)
+    // and num_devices() spuriously fail in the full parallel run (they pass in
+    // isolation).
     #[test]
+    #[serial]
     fn test_new_device_0() {
         let result = CudaExecutor::new(0);
         assert!(result.is_ok());
     }
 
     #[test]
+    #[serial]
     fn test_new_invalid_device() {
         // Device 999 almost certainly doesn't exist
         let result = CudaExecutor::new(999);
@@ -30,6 +40,7 @@ mod tests {
     // ========================================================================
 
     #[test]
+    #[serial]
     fn test_is_available() {
         // On a CUDA-enabled system, this should return true
         let available = CudaExecutor::is_available();
@@ -38,6 +49,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_num_devices() {
         let count = CudaExecutor::num_devices();
         // Should be at least 1 on CUDA system

--- a/crates/aprender-serve/src/cuda/executor/q8_gemv_tests.rs
+++ b/crates/aprender-serve/src/cuda/executor/q8_gemv_tests.rs
@@ -225,6 +225,12 @@ mod tests {
         // Q6_K: 210 bytes per 256 elements
         let k = 256u32;
         let n = 64u32;
+
+        // The HwDp4a Q6K variant (default on sm_75+) quantizes activations into
+        // workspace.q8_activation_buf and would otherwise panic; size it for k.
+        exec.init_workspace(k as usize, k as usize)
+            .expect("init_workspace");
+
         let superblocks = (n as usize) * (k as usize / 256);
         let weights = vec![0u8; superblocks * 210];
 

--- a/crates/aprender-serve/src/cuda/executor/tests_cov017_residual.rs
+++ b/crates/aprender-serve/src/cuda/executor/tests_cov017_residual.rs
@@ -334,6 +334,12 @@ fn test_cov018_q4k_gemv_into_basic() {
     let k = 256u32;
     let n = 32u32;
 
+    // The HwDp4a Q4K variant (default on sm_75+) quantizes activations into
+    // workspace.q8_activation_buf, so the workspace must be sized for k inputs.
+    executor
+        .init_workspace(k as usize, k as usize)
+        .expect("init_workspace");
+
     // Create mock Q4K weights (simplified structure)
     // Q4K: 144 bytes per 256 elements (super_block)
     let num_superblocks = (n as usize * k as usize + 255) / 256;
@@ -361,6 +367,12 @@ fn test_cov018_q6k_gemv_into_basic() {
 
     let k = 256u32;
     let n = 32u32;
+
+    // The HwDp4a Q6K variant (default on sm_75+) quantizes activations into
+    // workspace.q8_activation_buf, so the workspace must be sized for k inputs.
+    executor
+        .init_workspace(k as usize, k as usize)
+        .expect("init_workspace");
 
     // Q6K: 210 bytes per 256 elements
     let num_superblocks = (n as usize * k as usize + 255) / 256;

--- a/crates/aprender-serve/src/cuda/executor/tests_cov026.rs
+++ b/crates/aprender-serve/src/cuda/executor/tests_cov026.rs
@@ -312,6 +312,12 @@ fn test_cov027_q6k_gemv_indexed_async_basic() {
     let n = 32u32;
     let k = 256u32;
 
+    // The HwDp4a Q6K variant (default on sm_75+) quantizes activations into
+    // workspace.q8_activation_buf, so the workspace must be sized for k inputs.
+    executor
+        .init_workspace(k as usize, k as usize)
+        .expect("init_workspace");
+
     // Load Q6_K weights and get pointer
     let weight_bytes = (n as usize) * 210; // Q6_K is 210 bytes per 256 values
     let weights = vec![0u8; weight_bytes];

--- a/crates/aprender-serve/src/cuda/executor/tests_cov030_transformer.rs
+++ b/crates/aprender-serve/src/cuda/executor/tests_cov030_transformer.rs
@@ -335,6 +335,12 @@ fn test_cov031_batched_incremental_attention_into() {
     executor
         .init_batched_kv_cache_gpu(1, batch_size)
         .expect("init batched kv");
+    // batched_incremental_attention_into uploads positions into
+    // workspace.positions_buf, which must be sized for `batch_size` positions.
+    // init_batched_workspace allocates positions_buf with length = batch_size.
+    executor
+        .init_batched_workspace(q_dim, q_dim, batch_size)
+        .expect("init batched workspace");
 
     let q_data = vec![0.1f32; q_dim * batch_size];
     let k_data = vec![0.1f32; kv_dim * batch_size];

--- a/crates/aprender-serve/src/cuda/executor/tests_zeroed_layer.rs
+++ b/crates/aprender-serve/src/cuda/executor/tests_zeroed_layer.rs
@@ -215,6 +215,12 @@ fn test_cov026_q4k_gemv_into_basic() {
     let n = 32u32; // output dim
     let k = 256u32; // input dim (must be divisible by 256)
 
+    // The HwDp4a Q4K variant (default on sm_75+) quantizes activations into
+    // workspace.q8_activation_buf, so the workspace must be sized for k inputs.
+    executor
+        .init_workspace(k as usize, k as usize)
+        .expect("init_workspace");
+
     // Load quantized weights
     let weight_bytes = (n as usize) * 144;
     let weights = vec![0u8; weight_bytes];
@@ -249,6 +255,12 @@ fn test_cov026_q6k_gemv_into_basic() {
 
     let n = 32u32; // output dim
     let k = 256u32; // input dim (must be divisible by 256)
+
+    // The HwDp4a Q6K variant (default on sm_75+) quantizes activations into
+    // workspace.q8_activation_buf, so the workspace must be sized for k inputs.
+    executor
+        .init_workspace(k as usize, k as usize)
+        .expect("init_workspace");
 
     // Load quantized weights
     let weight_bytes = (n as usize) * 210;

--- a/crates/aprender-serve/src/cuda/transformer_workspace.rs
+++ b/crates/aprender-serve/src/cuda/transformer_workspace.rs
@@ -176,7 +176,13 @@ mod tests {
             Some(WeightQuantType::Q6K)
         );
         assert_eq!(WeightQuantType::from_ggml_type(99), None);
-        assert_eq!(WeightQuantType::from_ggml_type(0), None);
+        // GH-374: ggml type 0 is F32 (unquantized). APR checkpoints may carry an
+        // F32 LM head when the source model was not quantized, so from_ggml_type
+        // maps 0 -> Some(F32) rather than None.
+        assert_eq!(
+            WeightQuantType::from_ggml_type(0),
+            Some(WeightQuantType::F32)
+        );
     }
 
     #[test]

--- a/crates/aprender-serve/src/safetensors_cuda_config_extraction.rs
+++ b/crates/aprender-serve/src/safetensors_cuda_config_extraction.rs
@@ -49,9 +49,9 @@ mod tests {
             num_attention_heads: Some(12),
             num_key_value_heads: None, // Will default to num_attention_heads
             vocab_size: Some(50257),
-            intermediate_size: None,       // Will default to 4 * hidden_dim
-            max_position_embeddings: None, // Will default to 2048
-            rope_theta: None,              // Will default to 10000.0
+            intermediate_size: None, // Will default to 4 * hidden_dim
+            max_position_embeddings: None, // Absent => context_length defaults to 0 (unset)
+            rope_theta: None,        // Will default to 10000.0
             rms_norm_eps: None,            // Will default to 1e-6
             architectures: None,
             model_type: None,
@@ -64,7 +64,9 @@ mod tests {
         let config = SafeTensorsCudaModel::extract_config(&json).expect("config");
         assert_eq!(config.hidden_dim, 768);
         assert_eq!(config.intermediate_dim, 768 * 4); // Default
-        assert_eq!(config.context_length, 2048); // Default
+        // extract_config leaves context_length at 0 when max_position_embeddings
+        // is absent (no magic 2048 default); the actual length is resolved later.
+        assert_eq!(config.context_length, 0); // Default (unset)
         assert!((config.rope_theta - 10000.0).abs() < 0.1); // Default
         assert!((config.eps - 1e-6).abs() < 1e-9); // Default
     }


### PR DESCRIPTION
## A real CUDA driver-init race + 10 GPU-host test failures CI is blind to

CI has no NVIDIA runner, so `--features cuda` tests never run there. On a real GPU (RTX 4090 sm_89) the serve `--features cuda` lib suite had **10 failures** → now **0** (1240/10 → 1250/0, stable across 3 reruns; full serve cuda 16881/0; non-cuda 15311/0 unaffected). The real prize: a genuine product concurrency bug.

## Group C — PRODUCT BUG: `cuInit` TOCTOU race (`crates/aprender-gpu/src/driver/context.rs`)
`get_driver` guarded `cuInit` with a bare `AtomicBool::swap` — a second thread observing the flag `true` could call `cuDeviceGetCount` / `cuDevicePrimaryCtxRetain` **before `cuInit` actually returned**, getting `count == 0` (no devices). Real bug for any concurrent GPU init, not just tests. **Fixed by serializing `cuInit` with `std::sync::Once`** so concurrent callers block until it completes exactly once. The `test_new_device_0` / `test_num_devices` failures were downstream casualties (the Group-A panics poisoned the context, then hit this latent race); also marked the 4 device-enum tests `#[serial]` to match the suite.

## Group A — workspace-init test gaps (7, test bugs)
Tests called the public `q4k_gemv_into`/`q6k_gemv_into`/`q6k_gemv_indexed_async` dispatchers, which on sm_75+ route to `HwDp4a` and quantize activations into `workspace.q8_activation_buf`. With no `init_workspace()`, the dispatcher `.expect()`-panics mid-kernel-launch — **poisoning the shared CUDA context** (cascading into Group C). Fix: `init_workspace(k,k)` (or `init_batched_workspace` for the batched-attention test's `positions_buf`) before the GEMV.

## Group B — stale test expectations (2, product correct)
- `from_ggml_type(0)` → ggml type 0 IS F32 (GH-374 maps `0 → Some(F32)` for F32 LM heads); assertion predated it.
- `extract_config` `context_length` → always `max_position_embeddings.unwrap_or(0)` (git-blame confirmed; no magic-2048 default ever existed).

9 files, +89/−17. fmt + clippy clean. (The pre-existing `trueno_gpu` SIGSEGV-on-cleanup is unchanged by this — verified it fails no worse with the patch; separate known issue.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)