### PR TITLE
fix(compute): SIGSEGV in cuLaunchKernel from 5 under-supplied kernel-arg arrays (PMAT-775)

### DIFF
--- a/crates/aprender-gpu/src/memory/resident/attention/helpers/compute.rs
+++ b/crates/aprender-gpu/src/memory/resident/attention/helpers/compute.rs
@@ -218,11 +218,20 @@ pub(in super::super) fn transpose_matrix(
     let input_ptr = input.as_ptr();
     let output_ptr = output.as_ptr();
 
+    // The `transpose` PTX kernel declares FIVE params
+    // (input_ptr, output_ptr, rows, cols, total_elems) and uses `total_elems`
+    // for its in-bounds guard. The args slice MUST supply all five — `cuLaunchKernel`
+    // reads one pointer per declared param, so omitting `total_elems` makes the
+    // driver dereference past the end of `args` (host-side SIGSEGV inside libcuda,
+    // invisible to compute-sanitizer). See trueno_gpu workspace-test flake.
+    let total_elems = total;
+
     let mut args: Vec<*mut std::ffi::c_void> = vec![
         std::ptr::addr_of!(input_ptr) as *mut _,
         std::ptr::addr_of!(output_ptr) as *mut _,
         std::ptr::addr_of!(rows) as *mut _,
         std::ptr::addr_of!(cols) as *mut _,
+        std::ptr::addr_of!(total_elems) as *mut _,
     ];
 
     compile_and_launch(ctx, &cache_key, &ptx, transpose.name(), &config, &mut args)?;

--- a/crates/aprender-gpu/src/memory/resident/attention/helpers/layout.rs
+++ b/crates/aprender-gpu/src/memory/resident/attention/helpers/layout.rs
@@ -51,9 +51,21 @@ pub(in super::super) fn interleaved_to_batched_all(
     let input_ptr = input.as_ptr();
     let output_ptr = output.as_ptr();
 
+    // The `interleaved_to_batched` PTX kernel declares SIX params
+    // (input_ptr, output_ptr, seq_len, n_heads, head_dim, total_elems) and uses
+    // every one of them. The args slice MUST supply all six — `cuLaunchKernel`
+    // reads one pointer per declared param, so under-supplying makes the driver
+    // dereference past the end of `args` (host-side SIGSEGV inside libcuda,
+    // invisible to compute-sanitizer).
+    let total_elems = total_size as u32;
+
     let mut args: Vec<*mut std::ffi::c_void> = vec![
         std::ptr::addr_of!(input_ptr) as *mut _,
         std::ptr::addr_of!(output_ptr) as *mut _,
+        std::ptr::addr_of!(seq_len) as *mut _,
+        std::ptr::addr_of!(n_heads) as *mut _,
+        std::ptr::addr_of!(head_dim) as *mut _,
+        std::ptr::addr_of!(total_elems) as *mut _,
     ];
 
     compile_lock_launch(
@@ -101,12 +113,21 @@ pub(in super::super) fn batched_transpose_all(
     let input_ptr = input.as_ptr();
     let output_ptr = output.as_ptr();
 
+    // The `batched_transpose` PTX kernel declares SIX params
+    // (input_ptr, output_ptr, batch, rows, cols, total_per_batch) and uses
+    // `total_per_batch` for its in-bounds guard and batch stride. The args slice
+    // MUST supply all six — `cuLaunchKernel` reads one pointer per declared param,
+    // so omitting `total_per_batch` makes the driver dereference past the end of
+    // `args` (host-side SIGSEGV inside libcuda, invisible to compute-sanitizer).
+    let total_per_batch = elems_per_batch;
+
     let mut args: Vec<*mut std::ffi::c_void> = vec![
         std::ptr::addr_of!(input_ptr) as *mut _,
         std::ptr::addr_of!(output_ptr) as *mut _,
         std::ptr::addr_of!(batch) as *mut _,
         std::ptr::addr_of!(rows) as *mut _,
         std::ptr::addr_of!(cols) as *mut _,
+        std::ptr::addr_of!(total_per_batch) as *mut _,
     ];
 
     compile_lock_launch(
@@ -156,9 +177,21 @@ pub(in super::super) fn batched_to_interleaved_all(
     let input_ptr = input.as_ptr();
     let output_ptr = output.as_ptr();
 
+    // The `batched_to_interleaved` PTX kernel declares SIX params
+    // (input_ptr, output_ptr, seq_len, n_heads, head_dim, total_elems) and uses
+    // every one of them. The args slice MUST supply all six — `cuLaunchKernel`
+    // reads one pointer per declared param, so under-supplying makes the driver
+    // dereference past the end of `args` (host-side SIGSEGV inside libcuda,
+    // invisible to compute-sanitizer).
+    let total_elems = total_size as u32;
+
     let mut args: Vec<*mut std::ffi::c_void> = vec![
         std::ptr::addr_of!(input_ptr) as *mut _,
         std::ptr::addr_of!(output_ptr) as *mut _,
+        std::ptr::addr_of!(seq_len) as *mut _,
+        std::ptr::addr_of!(n_heads) as *mut _,
+        std::ptr::addr_of!(head_dim) as *mut _,
+        std::ptr::addr_of!(total_elems) as *mut _,
     ];
 
     compile_lock_launch(

--- a/crates/aprender-gpu/src/memory/resident/ops/elementwise.rs
+++ b/crates/aprender-gpu/src/memory/resident/ops/elementwise.rs
@@ -425,9 +425,21 @@ impl GpuResidentTensor<f32> {
         let input_ptr = self.as_ptr();
         let output_ptr = output_buffer.as_ptr();
 
+        // The `interleaved_to_batched` PTX kernel declares SIX params
+        // (input_ptr, output_ptr, seq_len, n_heads, head_dim, total_elems) and uses
+        // every one of them. The args slice MUST supply all six — `cuLaunchKernel`
+        // reads one pointer per declared param, so under-supplying makes the driver
+        // dereference past the end of `args` (host-side SIGSEGV inside libcuda,
+        // invisible to compute-sanitizer).
+        let total_elems_u32 = total_elems as u32;
+
         let mut args: Vec<*mut std::ffi::c_void> = vec![
             std::ptr::addr_of!(input_ptr) as *mut _,
             std::ptr::addr_of!(output_ptr) as *mut _,
+            std::ptr::addr_of!(seq_len) as *mut _,
+            std::ptr::addr_of!(n_heads) as *mut _,
+            std::ptr::addr_of!(head_dim) as *mut _,
+            std::ptr::addr_of!(total_elems_u32) as *mut _,
         ];
 
         launch_cached_kernel(


### PR DESCRIPTION
## Real GPU memory-safety bug: under-supplied kernel argument arrays → SIGSEGV

Found while chasing a "trueno_gpu SIGSEGV-on-cleanup" flake — which turned out to be a **deterministic** SIGSEGV (exit 139, 100% of runs) inside libcuda's `cuLaunchKernel` during *active* kernel launches (gdb: host-side fault in `transpose_matrix` → `cuLaunchKernel`; compute-sanitizer: 0 GPU-memory errors → host-side driver crash).

**Root cause:** `cuLaunchKernel` reads one pointer per *declared* kernel parameter from the `args` array. Five GPU-resident launchers supplied **fewer** args than their kernel declares, so the driver dereferences past the end of the `args` Vec allocation → SIGSEGV. Found via a full static audit of every launcher vs the kernel param-count table (3 apparent mismatches verified correct — `BatchedGemm`, `BiasActivation`, `IncrementalAttention`'s mutually-exclusive `seq_len`/`seq_len_ptr`).

| launcher | file | kernel params vs args |
|---|---|---|
| `transpose_matrix` | `attention/helpers/compute.rs` | 5 vs 4 (missing `total_elems`) |
| `batched_transpose_all` | `attention/helpers/layout.rs` | 6 vs 5 (missing `total_per_batch`) |
| `interleaved_to_batched_all` | `attention/helpers/layout.rs` | 6 vs 2 |
| `batched_to_interleaved_all` | `attention/helpers/layout.rs` | 6 vs 2 |
| `interleaved_to_head_first` | `ops/elementwise.rs` | 6 vs 2 |

These crash any real GPU workload (not just tests) that hits transpose / batched-layout-conversion / head-first-interleave kernels.

## Verification (RTX 4090 sm_89)
- Single-threaded `aprender-gpu --features cuda`: **100% SIGSEGV → 5/5 clean runs, 2562 passed / 0 failed.**
- Non-cuda build: 440 passed, unaffected. fmt + clippy clean. 3 files, +54.

(The cuInit TOCTOU race the agent also encountered is shipped separately in #2058; reverted here to avoid the overlap. The remaining parallel-only GPU-mem-accounting test failures need `#[serial]` — separate follow-up.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)