### PR TITLE
fix(compute): shared wgpu::Instance + serial GPU gguf tests — fix GB10 aarch64 multi-hour test hang (PMAT-778)

### DIFF
--- a/crates/aprender-compute/src/backends/gpu/device/mod.rs
+++ b/crates/aprender-compute/src/backends/gpu/device/mod.rs
@@ -18,6 +18,45 @@ mod reductions;
 #[cfg(any(feature = "gpu", feature = "gpu-wasm"))]
 use super::runtime;
 
+/// Process-global lock serializing native wgpu instance/adapter/device creation.
+///
+/// PMAT-778: On hosts whose Vulkan ICD is unsafe to initialize concurrently
+/// (notably the NVIDIA GB10 / aarch64, where the Mesa freedreno "Turnip" ICD
+/// probes `/dev/dri/renderD128` and **segfaults** when multiple threads create
+/// `wgpu::Instance`s and request adapters/devices simultaneously), every sync
+/// device-creation entry point takes this lock. Device creation is a rare,
+/// one-time-per-scheduler operation off the compute hot path, so serializing it
+/// is free on healthy GPUs and turns a concurrent-init crash into ordered,
+/// correct initialization. This is the companion to the adapter-probe `OnceLock`
+/// cache (PMAT-773): the probe is memoized once, and actual device acquisition
+/// is serialized here.
+#[cfg(all(feature = "gpu", not(target_arch = "wasm32")))]
+static DEVICE_INIT_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Process-global, lazily-created shared `wgpu::Instance`.
+///
+/// PMAT-778: Creating a fresh `wgpu::Instance` enumerates every installed Vulkan
+/// ICD. On the NVIDIA GB10 / aarch64 the host ships ~11 Mesa ICDs (freedreno
+/// "Turnip", panfrost, asahi, …) that are irrelevant to this hardware; the
+/// freedreno ICD spawns its own background Vulkan threads and **segfaults** when
+/// several instances enumerate it concurrently (each open of
+/// `/dev/dri/renderD128` returns `VK_ERROR_INCOMPATIBLE_DRIVER`). Sharing one
+/// instance for the whole process means the broken ICD is enumerated exactly
+/// once, eliminating the concurrent-init race entirely. `wgpu::Instance` is
+/// `Clone`/`Send`/`Sync`, so every adapter/device request can cheaply reuse it.
+#[cfg(all(feature = "gpu", not(target_arch = "wasm32")))]
+pub(crate) fn shared_instance() -> wgpu::Instance {
+    use std::sync::OnceLock;
+    static INSTANCE: OnceLock<wgpu::Instance> = OnceLock::new();
+    INSTANCE
+        .get_or_init(|| {
+            // Serialize the one-time enumeration against any other GPU init.
+            let _guard = DEVICE_INIT_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+            wgpu::Instance::default()
+        })
+        .clone()
+}
+
 /// GPU device manager
 #[derive(Clone)]
 pub struct GpuDevice {
@@ -29,13 +68,16 @@ impl GpuDevice {
     /// Initialize GPU device (sync, native only)
     #[cfg(all(feature = "gpu", not(target_arch = "wasm32")))]
     pub fn new() -> Result<Self, String> {
+        // PMAT-778: serialize concurrent native device creation (freedreno ICD
+        // segfaults on the GB10 when instances/devices are created in parallel).
+        let _guard = DEVICE_INIT_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         runtime::block_on(async { Self::new_async().await })
     }
 
     /// Initialize GPU device (async, works on all platforms)
     pub async fn new_async() -> Result<Self, String> {
         // Create instance
-        let instance = wgpu::Instance::default();
+        let instance = shared_instance();
 
         // Request adapter (GPU)
         let adapter = instance
@@ -75,6 +117,8 @@ impl GpuDevice {
     /// Adapter indices correspond to `Instance::enumerate_adapters()` ordering.
     #[cfg(all(feature = "gpu", not(target_arch = "wasm32")))]
     pub fn new_with_adapter_index(index: u32) -> Result<Self, String> {
+        // PMAT-778: serialize concurrent native device creation (see DEVICE_INIT_LOCK).
+        let _guard = DEVICE_INIT_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         runtime::block_on(async { Self::new_with_adapter_index_async(index).await })
     }
 
@@ -83,7 +127,7 @@ impl GpuDevice {
     /// Use this to select a specific GPU when multiple are available.
     /// Adapter indices correspond to `Instance::enumerate_adapters()` ordering.
     pub async fn new_with_adapter_index_async(index: u32) -> Result<Self, String> {
-        let instance = wgpu::Instance::default();
+        let instance = shared_instance();
         let adapters = instance.enumerate_adapters(wgpu::Backends::all());
 
         if adapters.is_empty() {
@@ -119,12 +163,15 @@ impl GpuDevice {
     /// Returns a list of (index, name, backend) tuples for each adapter.
     #[cfg(all(feature = "gpu", not(target_arch = "wasm32")))]
     pub fn list_adapters() -> Vec<(u32, String, String)> {
+        // PMAT-778: serialize concurrent native instance/adapter enumeration
+        // (freedreno ICD segfaults on the GB10 under concurrent init).
+        let _guard = DEVICE_INIT_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         runtime::block_on(Self::list_adapters_async())
     }
 
     /// List all available GPU adapters (async, all platforms)
     pub async fn list_adapters_async() -> Vec<(u32, String, String)> {
-        let instance = wgpu::Instance::default();
+        let instance = shared_instance();
         let adapters = instance.enumerate_adapters(wgpu::Backends::all());
 
         adapters
@@ -162,7 +209,7 @@ impl GpuDevice {
 
     /// Check if GPU is available (async, works on all platforms)
     pub async fn is_available_async() -> bool {
-        let instance = wgpu::Instance::default();
+        let instance = shared_instance();
         instance
             .request_adapter(&wgpu::RequestAdapterOptions {
                 power_preference: wgpu::PowerPreference::HighPerformance,

--- a/crates/aprender-compute/src/backends/gpu/mod.rs
+++ b/crates/aprender-compute/src/backends/gpu/mod.rs
@@ -61,6 +61,11 @@ pub use batch::{BufferId, GpuCommandBatch, PipelineCache};
 #[cfg(any(feature = "gpu", feature = "gpu-wasm"))]
 pub use device::GpuDevice;
 
+// PMAT-778: process-global shared wgpu instance, reused by every crate-internal
+// adapter/device enumeration so the broken freedreno ICD (GB10) is touched once.
+#[cfg(all(feature = "gpu", not(target_arch = "wasm32")))]
+pub(crate) use device::shared_instance;
+
 /// Re-export wgpu types for downstream crates that need to create persistent
 /// GPU buffers (KAIZEN-015: GPU-resident weights).
 #[cfg(any(feature = "gpu", feature = "gpu-wasm"))]

--- a/crates/aprender-compute/src/backends/gpu/pool.rs
+++ b/crates/aprender-compute/src/backends/gpu/pool.rs
@@ -41,7 +41,9 @@ impl GpuDevicePool {
 
     /// Open all available non-CPU GPU adapters (async)
     pub async fn all_async() -> Result<Self, String> {
-        let instance = wgpu::Instance::default();
+        // PMAT-778: reuse the process-global instance so the broken freedreno
+        // ICD (GB10/aarch64) is enumerated exactly once, never concurrently.
+        let instance = super::device::shared_instance();
         let adapters = instance.enumerate_adapters(wgpu::Backends::all());
 
         if adapters.is_empty() {

--- a/crates/aprender-compute/src/monitor/backends.rs
+++ b/crates/aprender-compute/src/monitor/backends.rs
@@ -17,7 +17,8 @@ pub(crate) fn query_wgpu_device_info(device_index: u32) -> Result<GpuDeviceInfo,
     use crate::backends::gpu::runtime;
 
     runtime::block_on(async {
-        let instance = wgpu::Instance::default();
+        // PMAT-778: reuse the process-global instance (single freedreno enumeration).
+        let instance = crate::backends::gpu::shared_instance();
 
         // Get all adapters (wgpu 27+ returns Vec directly)
         let adapters = instance.enumerate_adapters(wgpu::Backends::all());
@@ -61,7 +62,8 @@ pub(crate) fn enumerate_wgpu_devices() -> Result<Vec<GpuDeviceInfo>, MonitorErro
     use crate::backends::gpu::runtime;
 
     runtime::block_on(async {
-        let instance = wgpu::Instance::default();
+        // PMAT-778: reuse the process-global instance (single freedreno enumeration).
+        let instance = crate::backends::gpu::shared_instance();
         let adapters = instance.enumerate_adapters(wgpu::Backends::all());
 
         if adapters.is_empty() {

--- a/crates/aprender-serve/src/gguf/tests/imp_108c.rs
+++ b/crates/aprender-serve/src/gguf/tests/imp_108c.rs
@@ -1,6 +1,7 @@
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_imp_108c_attention_softmax_normalized() {
     // IMP-108c: Verify attention weights sum to 1 for each position
     let config = GGUFConfig {

--- a/crates/aprender-serve/src/gguf/tests/imp_111c.rs
+++ b/crates/aprender-serve/src/gguf/tests/imp_111c.rs
@@ -153,6 +153,7 @@ fn test_imp_111d_tiled_attention_various_tile_sizes() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_imp_113a_batched_gemm_single_dispatch() {
     // IMP-113a: Verify batched GEMM processes all heads in single dispatch
     // This is the foundation for efficient multi-head attention
@@ -237,6 +238,7 @@ fn test_imp_113a_batched_gemm_single_dispatch() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_imp_113b_single_dispatch_attention_correctness() {
     // IMP-113b: Verify single-dispatch attention matches multi-dispatch
     let config = GGUFConfig {
@@ -301,6 +303,7 @@ fn test_imp_113b_single_dispatch_attention_correctness() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_imp_113c_single_dispatch_dispatch_count() {
     // IMP-113c: Verify single-dispatch uses fewer GPU dispatches
     // This test validates the architectural improvement
@@ -361,6 +364,7 @@ fn test_imp_113c_single_dispatch_dispatch_count() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_imp_113d_batched_softmax_correctness() {
     // IMP-113d: Verify batched softmax with causal mask
     let config = GGUFConfig {

--- a/crates/aprender-serve/src/gguf/tests/imp_114a.rs
+++ b/crates/aprender-serve/src/gguf/tests/imp_114a.rs
@@ -5,6 +5,7 @@
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_imp_114a_flattened_batched_gemm_correctness() {
     // IMP-114a: Verify flattened batched GEMM computes correct results
     // Strategy: Flatten [batch, m, k] @ [batch, k, n] into single large matmul
@@ -85,6 +86,7 @@ fn test_imp_114a_flattened_batched_gemm_correctness() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_imp_114b_flattened_matches_loop() {
     // IMP-114b: Verify flattened approach matches loop-based approach
     let config = GGUFConfig {
@@ -146,6 +148,7 @@ fn test_imp_114b_flattened_matches_loop() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_imp_114c_flattened_attention_correctness() {
     // IMP-114c: Verify flattened attention matches reference
     let config = GGUFConfig {
@@ -208,6 +211,7 @@ fn test_imp_114c_flattened_attention_correctness() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_imp_114d_large_batch_flattened() {
     // IMP-114d: Test with larger batch sizes where flattening benefits
     let config = GGUFConfig {

--- a/crates/aprender-serve/src/gguf/tests/imp_115a.rs
+++ b/crates/aprender-serve/src/gguf/tests/imp_115a.rs
@@ -12,6 +12,7 @@ use crate::gguf::{GGUFConfig, OwnedQuantizedModelCached, QuantizedGenerateConfig
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_imp_115a_fused_single_head_attention_correctness() {
     // IMP-115a: Verify fused attention matches separate operations
     let config = GGUFConfig {
@@ -77,6 +78,7 @@ fn test_imp_115a_fused_single_head_attention_correctness() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_imp_115b_fused_multihead_attention_correctness() {
     // IMP-115b: Verify fused multi-head attention matches reference
     let config = GGUFConfig {
@@ -139,6 +141,7 @@ fn test_imp_115b_fused_multihead_attention_correctness() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_imp_115c_fused_attention_no_intermediate_allocation() {
     // IMP-115c: Verify fused attention doesn't allocate large intermediate tensors
     // We test this by verifying output is correct for larger sequences
@@ -196,6 +199,7 @@ fn test_imp_115c_fused_attention_no_intermediate_allocation() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_imp_115d_fused_causal_mask_correctness() {
     // IMP-115d: Verify causal masking is correctly applied in fused kernel
     let config = GGUFConfig {

--- a/crates/aprender-serve/src/gguf/tests/imp_118a.rs
+++ b/crates/aprender-serve/src/gguf/tests/imp_118a.rs
@@ -5,6 +5,7 @@
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_imp_118a_true_batched_gemm_correctness() {
     // IMP-118a: Verify true batched GEMM produces correct results
     // Strategy: Process all batches in single kernel invocation
@@ -89,6 +90,7 @@ fn test_imp_118a_true_batched_gemm_correctness() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_imp_118b_true_batched_gemm_matches_flattened() {
     // IMP-118b: True batched GEMM should match flattened implementation
     let config = GGUFConfig {
@@ -152,6 +154,7 @@ fn test_imp_118b_true_batched_gemm_matches_flattened() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_imp_118c_true_batched_gemm_large_batch() {
     // IMP-118c: True batched GEMM should handle large batch sizes efficiently
     let config = GGUFConfig {
@@ -212,6 +215,7 @@ fn test_imp_118c_true_batched_gemm_large_batch() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_imp_118d_true_batched_attention() {
     // IMP-118d: Use true batched GEMM for multi-head attention
     let config = GGUFConfig {
@@ -283,6 +287,7 @@ fn test_imp_118d_true_batched_attention() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_imp_119a_gpu_fused_attention_correctness() {
     // IMP-119a: Verify GPU fused attention produces correct results
     // Uses GPU for long sequences where compute dominates transfer overhead
@@ -350,6 +355,7 @@ fn test_imp_119a_gpu_fused_attention_correctness() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_imp_119b_gpu_fused_matches_cpu_fused() {
     // IMP-119b: GPU fused attention should match CPU fused attention
     let config = GGUFConfig {

--- a/crates/aprender-serve/src/gguf/tests/imp_119c.rs
+++ b/crates/aprender-serve/src/gguf/tests/imp_119c.rs
@@ -1,6 +1,7 @@
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_imp_119c_gpu_fused_multihead_long_sequence() {
     // IMP-119c: GPU fused multi-head attention for long sequences
     let config = GGUFConfig {
@@ -65,6 +66,7 @@ fn test_imp_119c_gpu_fused_multihead_long_sequence() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_imp_119d_adaptive_cpu_gpu_dispatch() {
     // IMP-119d: Verify adaptive dispatch chooses CPU for short, GPU for long sequences
     let config = GGUFConfig {

--- a/crates/aprender-serve/src/gguf/tests/imp_121a.rs
+++ b/crates/aprender-serve/src/gguf/tests/imp_121a.rs
@@ -17,6 +17,7 @@ use crate::gguf::{
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_imp_121a_cached_sync_has_adaptive_attention() {
     // IMP-121a: OwnedQuantizedModelCachedSync should expose adaptive attention
     let config = GGUFConfig {
@@ -68,6 +69,7 @@ fn test_imp_121a_cached_sync_has_adaptive_attention() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_imp_121b_cached_sync_adaptive_multihead() {
     // IMP-121b: OwnedQuantizedModelCachedSync should expose adaptive multihead attention
     let config = GGUFConfig {
@@ -118,6 +120,7 @@ fn test_imp_121b_cached_sync_adaptive_multihead() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_imp_121c_generate_with_adaptive_attention() {
     // IMP-121c: Cached model should have generate_with_adaptive_attention
     let config = GGUFConfig {
@@ -164,6 +167,7 @@ fn test_imp_121c_generate_with_adaptive_attention() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_imp_121d_thread_safe_adaptive_attention() {
     // IMP-121d: Verify thread-safe access to adaptive attention
     use std::sync::Arc;
@@ -238,6 +242,7 @@ fn test_imp_121d_thread_safe_adaptive_attention() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_imp_122a_adaptive_attention_with_cache() {
     // IMP-122a: Test attention_with_cache can use adaptive backend
     let config = GGUFConfig {
@@ -358,6 +363,7 @@ fn test_pmat749_adaptive_attention_gqa_long_cache() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_imp_122b_adaptive_matches_standard() {
     // IMP-122b: Adaptive attention with cache should match standard implementation
     let config = GGUFConfig {
@@ -417,6 +423,7 @@ fn test_imp_122b_adaptive_matches_standard() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_imp_122c_long_sequence_uses_gpu() {
     // IMP-122c: Long sequence should automatically use GPU path
     let config = GGUFConfig {
@@ -468,6 +475,7 @@ fn test_imp_122c_long_sequence_uses_gpu() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_imp_123a_dispatch_metrics_struct() {
     // IMP-123a: DispatchMetrics struct should track CPU vs GPU decisions
     let metrics = DispatchMetrics::new();
@@ -479,6 +487,7 @@ fn test_imp_123a_dispatch_metrics_struct() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_imp_123b_record_dispatch_decisions() {
     // IMP-123b: Metrics should correctly record dispatch decisions
     let metrics = DispatchMetrics::new();
@@ -494,6 +503,7 @@ fn test_imp_123b_record_dispatch_decisions() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_imp_123c_dispatch_ratio() {
     // IMP-123c: Should calculate GPU dispatch ratio
     let metrics = DispatchMetrics::new();

--- a/crates/aprender-serve/src/gguf/tests/imp_123d.rs
+++ b/crates/aprender-serve/src/gguf/tests/imp_123d.rs
@@ -1,6 +1,7 @@
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_imp_123d_thread_safe_metrics() {
     // IMP-123d: Metrics should be thread-safe
     use std::sync::Arc;
@@ -53,6 +54,7 @@ fn test_imp_123d_thread_safe_metrics() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_imp_129a_latency_histogram_struct() {
     // IMP-129a: DispatchMetrics should track latency with histogram buckets
     let metrics = DispatchMetrics::new();
@@ -66,6 +68,7 @@ fn test_imp_129a_latency_histogram_struct() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_imp_129b_record_latency() {
     // IMP-129b: Should record latency for CPU and GPU dispatches
     use std::time::Duration;
@@ -100,6 +103,7 @@ fn test_imp_129b_record_latency() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_imp_129c_histogram_buckets() {
     // IMP-129c: Should have histogram bucket counts
     use std::time::Duration;
@@ -134,6 +138,7 @@ fn test_imp_129c_histogram_buckets() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_imp_129d_thread_safe_latency() {
     // IMP-129d: Latency recording should be thread-safe
     use std::sync::Arc;
@@ -184,6 +189,7 @@ fn test_imp_129d_thread_safe_latency() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_imp_124a_forward_single_with_cache_adaptive() {
     // IMP-124a: forward_single_with_cache_adaptive should exist and produce valid output
     let config = GGUFConfig {
@@ -235,6 +241,7 @@ fn test_imp_124a_forward_single_with_cache_adaptive() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_imp_124b_adaptive_matches_standard() {
     // IMP-124b: Adaptive forward should match standard forward
     let config = GGUFConfig {
@@ -285,6 +292,7 @@ fn test_imp_124b_adaptive_matches_standard() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_imp_124c_tracks_metrics_per_layer() {
     // IMP-124c: Each layer should record a dispatch decision
     let config = GGUFConfig {
@@ -340,6 +348,7 @@ fn test_imp_124c_tracks_metrics_per_layer() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_imp_124d_long_cache_uses_gpu() {
     // IMP-124d: Long cache (>= 64 tokens) should trigger GPU dispatch
     let config = GGUFConfig {
@@ -394,6 +403,7 @@ fn test_imp_124d_long_cache_uses_gpu() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_imp_125a_generate_with_cache_adaptive() {
     // IMP-125a: generate_with_cache_adaptive should exist and produce valid tokens
     let config = GGUFConfig {

--- a/crates/aprender-serve/src/gguf/tests/imp_125b.rs
+++ b/crates/aprender-serve/src/gguf/tests/imp_125b.rs
@@ -1,6 +1,7 @@
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_imp_125b_adaptive_matches_standard() {
     // IMP-125b: Adaptive generate should match standard generate
     let config = GGUFConfig {
@@ -51,6 +52,7 @@ fn test_imp_125b_adaptive_matches_standard() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_imp_125c_tracks_metrics_during_generation() {
     // IMP-125c: Should track metrics during full generation
     let config = GGUFConfig {
@@ -101,6 +103,7 @@ fn test_imp_125c_tracks_metrics_during_generation() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_imp_125d_long_generation_uses_gpu() {
     // IMP-125d: Long generation should eventually use GPU
     let config = GGUFConfig {
@@ -158,6 +161,7 @@ fn test_imp_125d_long_generation_uses_gpu() {
 /// PARITY-002a: forward_batch_with_cache should exist and process multiple tokens
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity002a_forward_batch_with_cache_exists() {
     let config = GGUFConfig {
         architecture: "phi2".to_string(),
@@ -201,6 +205,7 @@ fn test_parity002a_forward_batch_with_cache_exists() {
 /// PARITY-002b: Batched prefill should process all tokens and populate cache
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity002b_batched_prefill_populates_cache() {
     let config = GGUFConfig {
         architecture: "phi2".to_string(),
@@ -245,6 +250,7 @@ fn test_parity002b_batched_prefill_populates_cache() {
 /// This test verifies CPU path is used (correct behavior for single-request inference).
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity002c_batched_prefill_triggers_gpu() {
     let config = GGUFConfig {
         architecture: "phi2".to_string(),
@@ -291,6 +297,7 @@ fn test_parity002c_batched_prefill_triggers_gpu() {
 /// PARITY-002d: Batched prefill should produce same result as sequential
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity002d_batched_matches_sequential() {
     let config = GGUFConfig {
         architecture: "phi2".to_string(),
@@ -356,6 +363,7 @@ fn test_parity002d_batched_matches_sequential() {
 /// PARITY-002e: generate_with_batched_prefill should use batched prefill then sequential gen
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity002e_generate_with_batched_prefill() {
     let config = GGUFConfig {
         architecture: "phi2".to_string(),

--- a/crates/aprender-serve/src/gguf/tests/parity018e_performance_target.rs
+++ b/crates/aprender-serve/src/gguf/tests/parity018e_performance_target.rs
@@ -1,6 +1,7 @@
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity018e_performance_targets() {
     use crate::gpu::HybridScheduler;
 
@@ -94,6 +95,7 @@ fn test_parity018e_performance_targets() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity019a_dequantized_ffn_weights_struct() {
     // PARITY-019a: Test DequantizedFFNWeights struct
     //
@@ -170,6 +172,7 @@ fn test_parity019a_dequantized_ffn_weights_struct() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity019b_dequantized_weight_cache_api() {
     // PARITY-019b: Test DequantizedWeightCache production API
     //
@@ -245,6 +248,7 @@ fn test_parity019b_dequantized_weight_cache_api() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity019c_warmup_with_bias() {
     // PARITY-019c: Test warmup_with_bias variant
     //
@@ -301,6 +305,7 @@ fn test_parity019c_warmup_with_bias() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity019d_concurrent_read_access() {
     // PARITY-019d: Test concurrent read access via RwLock
     //
@@ -362,6 +367,7 @@ fn test_parity019d_concurrent_read_access() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity019e_memory_scaling() {
     // PARITY-019e: Test memory scaling for phi-2 dimensions
     //

--- a/crates/aprender-serve/src/gguf/tests/parity020a_batch.rs
+++ b/crates/aprender-serve/src/gguf/tests/parity020a_batch.rs
@@ -13,6 +13,7 @@
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity020a_batch_generation_stats() {
     // PARITY-020a: Test BatchGenerationStats struct and batch_stats() method
     //
@@ -60,6 +61,7 @@ fn test_parity020a_batch_generation_stats() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity020b_batch_generate_requires_warmup() {
     // PARITY-020b: Test that batch_generate_gpu requires warmup
     //
@@ -107,6 +109,7 @@ fn test_parity020b_batch_generate_requires_warmup() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity020c_generation_config() {
     // PARITY-020c: Test QuantizedGenerateConfig for batch generation
     //
@@ -163,6 +166,7 @@ fn test_parity020c_generation_config() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity020d_batch_throughput_projection() {
     // PARITY-020d: Project batch throughput improvements
     //
@@ -239,6 +243,7 @@ fn test_parity020d_batch_throughput_projection() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity020e_integration_checklist() {
     // PARITY-020e: Verify production integration status
     //
@@ -337,6 +342,7 @@ fn test_parity020e_integration_checklist() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity021a_gpu_batch_threshold() {
     // PARITY-021a: Verify GPU batch threshold constant
     //
@@ -381,6 +387,7 @@ fn test_parity021a_gpu_batch_threshold() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity021b_forward_batch_structure() {
     // PARITY-021b: Verify forward_batch_with_gpu_ffn structure
     //

--- a/crates/aprender-serve/src/gguf/tests/parity021c_gpu.rs
+++ b/crates/aprender-serve/src/gguf/tests/parity021c_gpu.rs
@@ -1,6 +1,7 @@
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity021c_gpu_ffn_speedup_projection() {
     // PARITY-021c: Project GPU FFN speedup
     //
@@ -61,6 +62,7 @@ fn test_parity021c_gpu_ffn_speedup_projection() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity021d_batch_generate_gpu_integration() {
     // PARITY-021d: Verify batch_generate_gpu uses forward_batch_with_gpu_ffn
     //
@@ -110,6 +112,7 @@ fn test_parity021d_batch_generate_gpu_integration() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity021e_memory_efficiency() {
     // PARITY-021e: Verify memory efficiency of batched forward
     //
@@ -169,6 +172,7 @@ fn test_parity021e_memory_efficiency() {
 /// PARITY-023a: PendingRequest struct should track request details
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity023a_pending_request_struct() {
     use crate::gguf::PendingRequest;
 
@@ -207,6 +211,7 @@ fn test_parity023a_pending_request_struct() {
 /// PARITY-023b: RequestBatch should aggregate multiple requests
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity023b_request_batch_aggregation() {
     use crate::gguf::{PendingRequest, RequestBatch};
 
@@ -232,6 +237,7 @@ fn test_parity023b_request_batch_aggregation() {
 /// PARITY-023c: BatchRequestCollector should accumulate requests
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity023c_batch_collector_accumulation() {
     use crate::gguf::BatchRequestCollector;
 
@@ -271,6 +277,7 @@ fn test_parity023c_batch_collector_accumulation() {
 /// PARITY-023d: BatchRequestCollector should trigger on threshold
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity023d_batch_collector_threshold_trigger() {
     use crate::gguf::BatchRequestCollector;
 
@@ -310,6 +317,7 @@ fn test_parity023d_batch_collector_threshold_trigger() {
 /// PARITY-023e: BatchingConfig should have latency and throughput presets
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity023e_batching_config_presets() {
     println!("=== PARITY-023e: BatchingConfig Presets ===\n");
 
@@ -368,6 +376,7 @@ fn test_parity023e_batching_config_presets() {
 /// PARITY-024a: batch_qkv_projection_gpu method should exist
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity024a_batch_qkv_projection_exists() {
     println!("=== PARITY-024a: Batch QKV Projection ===\n");
 
@@ -409,6 +418,7 @@ fn test_parity024a_batch_qkv_projection_exists() {
 /// PARITY-024b: batch_attention_output_gpu method should exist
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity024b_batch_attention_output_exists() {
     println!("=== PARITY-024b: Batch Attention Output ===\n");
 

--- a/crates/aprender-serve/src/gguf/tests/parity024c_gpu.rs
+++ b/crates/aprender-serve/src/gguf/tests/parity024c_gpu.rs
@@ -2,6 +2,7 @@
 /// PARITY-024c: GPU path should use batch projections
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity024c_gpu_path_uses_batch_projections() {
     println!("=== PARITY-024c: GPU Path Uses Batch Projections ===\n");
 
@@ -37,6 +38,7 @@ fn test_parity024c_gpu_path_uses_batch_projections() {
 /// PARITY-024d: Speedup analysis for batch attention projections
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity024d_batch_attention_speedup_analysis() {
     println!("=== PARITY-024d: Batch Attention Speedup Analysis ===\n");
 
@@ -123,6 +125,7 @@ fn test_parity024d_batch_attention_speedup_analysis() {
 /// PARITY-024e: Memory efficiency of batch attention
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity024e_batch_attention_memory() {
     println!("=== PARITY-024e: Batch Attention Memory ===\n");
 
@@ -159,6 +162,7 @@ fn test_parity024e_batch_attention_memory() {
 /// PARITY-025a: Verify batch_lm_head_gpu method exists and has correct signature
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity025a_batch_lm_head_exists() {
     println!("=== PARITY-025a: Batch LM Head Method ===\n");
 
@@ -197,6 +201,7 @@ fn test_parity025a_batch_lm_head_exists() {
 /// PARITY-025b: LM head GPU speedup analysis
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity025b_lm_head_speedup_analysis() {
     println!("=== PARITY-025b: LM Head Speedup Analysis ===\n");
 
@@ -244,6 +249,7 @@ fn test_parity025b_lm_head_speedup_analysis() {
 /// PARITY-025c: Forward batch uses GPU LM head when enabled
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity025c_forward_uses_batch_lm_head() {
     println!("=== PARITY-025c: Forward Batch Uses GPU LM Head ===\n");
 
@@ -289,6 +295,7 @@ fn test_parity025c_forward_uses_batch_lm_head() {
 /// PARITY-025d: Memory analysis for batch LM head
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity025d_batch_lm_head_memory() {
     println!("=== PARITY-025d: Batch LM Head Memory ===\n");
 
@@ -322,6 +329,7 @@ fn test_parity025d_batch_lm_head_memory() {
 /// PARITY-025e: Combined GPU coverage analysis
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity025e_combined_gpu_coverage() {
     println!("=== PARITY-025e: Combined GPU Coverage ===\n");
 

--- a/crates/aprender-serve/src/gguf/tests/parity027e_combined.rs
+++ b/crates/aprender-serve/src/gguf/tests/parity027e_combined.rs
@@ -2,6 +2,7 @@
 /// PARITY-027e: Combined GPU optimization coverage
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity027e_combined_optimization_coverage() {
     println!("=== PARITY-027e: Combined GPU Optimization Coverage ===\n");
 
@@ -53,6 +54,7 @@ fn test_parity027e_combined_optimization_coverage() {
 /// PARITY-028a: Verify SlotState enum structure
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity028a_slot_state_structure() {
     println!("=== PARITY-028a: SlotState Enum ===\n");
 
@@ -103,6 +105,7 @@ fn test_parity028a_slot_state_structure() {
 /// PARITY-028b: ContinuousBatchScheduler creation and slot management
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity028b_scheduler_creation() {
     println!("=== PARITY-028b: Scheduler Creation ===\n");
 
@@ -141,6 +144,7 @@ fn test_parity028b_scheduler_creation() {
 /// PARITY-028c: Request submission and slot allocation
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity028c_request_submission() {
     println!("=== PARITY-028c: Request Submission ===\n");
 
@@ -187,6 +191,7 @@ fn test_parity028c_request_submission() {
 /// PARITY-028d: Request completion and slot recycling
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity028d_completion_and_recycling() {
     println!("=== PARITY-028d: Completion and Recycling ===\n");
 
@@ -236,6 +241,7 @@ fn test_parity028d_completion_and_recycling() {
 /// PARITY-028e: Throughput analysis with continuous batching
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity028e_continuous_batching_throughput() {
     println!("=== PARITY-028e: Continuous Batching Throughput ===\n");
 
@@ -295,6 +301,7 @@ fn test_parity028e_continuous_batching_throughput() {
 /// PARITY-029a: SpeculativeConfig default values
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity029a_speculative_config() {
     println!("=== PARITY-029a: Speculative Config ===\n");
 
@@ -327,6 +334,7 @@ fn test_parity029a_speculative_config() {
 /// PARITY-029b: SpeculativeDecoder creation and statistics
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity029b_decoder_creation() {
     println!("=== PARITY-029b: Decoder Creation ===\n");
 
@@ -363,6 +371,7 @@ fn test_parity029b_decoder_creation() {
 /// PARITY-029c: Draft verification with greedy decoding
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity029c_greedy_verification() {
     println!("=== PARITY-029c: Greedy Verification ===\n");
 

--- a/crates/aprender-serve/src/gguf/tests/parity029d_acceptance.rs
+++ b/crates/aprender-serve/src/gguf/tests/parity029d_acceptance.rs
@@ -2,6 +2,7 @@
 /// PARITY-029d: Acceptance rate and speedup calculation
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity029d_acceptance_rate_speedup() {
     println!("=== PARITY-029d: Acceptance Rate and Speedup ===\n");
 
@@ -76,6 +77,7 @@ fn test_parity029d_acceptance_rate_speedup() {
 /// PARITY-029e: Throughput improvement analysis
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity029e_throughput_improvement() {
     println!("=== PARITY-029e: Throughput Improvement ===\n");
 
@@ -135,6 +137,7 @@ fn test_parity029e_throughput_improvement() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity030a_wgpu_flash_attention_structure() {
     println!("=== PARITY-030a: wgpu FlashAttention Structure ===\n");
 
@@ -155,6 +158,7 @@ fn test_parity030a_wgpu_flash_attention_structure() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity030b_gpu_dispatch_threshold() {
     println!("=== PARITY-030b: GPU Dispatch Threshold ===\n");
 
@@ -187,6 +191,7 @@ fn test_parity030b_gpu_dispatch_threshold() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity030c_matmul_operations() {
     println!("=== PARITY-030c: GPU Matmul Operations ===\n");
 
@@ -223,6 +228,7 @@ fn test_parity030c_matmul_operations() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity030d_memory_efficiency() {
     println!("=== PARITY-030d: Memory Efficiency ===\n");
 
@@ -269,6 +275,7 @@ fn test_parity030d_memory_efficiency() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity030e_performance_projection() {
     println!("=== PARITY-030e: Performance Projection ===\n");
 
@@ -335,6 +342,7 @@ fn test_parity030e_performance_projection() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity031a_buffer_pool_creation() {
     println!("=== PARITY-031a: Buffer Pool Creation ===\n");
 
@@ -371,6 +379,7 @@ fn test_parity031a_buffer_pool_creation() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity031b_warmup_pre_allocation() {
     println!("=== PARITY-031b: Warmup Pre-allocation ===\n");
 

--- a/crates/aprender-serve/src/gguf/tests/parity031c_borrow.rs
+++ b/crates/aprender-serve/src/gguf/tests/parity031c_borrow.rs
@@ -1,6 +1,7 @@
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity031c_borrow_and_return() {
     println!("=== PARITY-031c: Borrow and Return ===\n");
 
@@ -40,6 +41,7 @@ fn test_parity031c_borrow_and_return() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity031d_zero_allocation_after_warmup() {
     println!("=== PARITY-031d: Zero Allocation After Warmup ===\n");
 
@@ -87,6 +89,7 @@ fn test_parity031d_zero_allocation_after_warmup() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity031e_memory_usage() {
     println!("=== PARITY-031e: Memory Usage ===\n");
 
@@ -154,6 +157,7 @@ fn test_parity031e_memory_usage() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity032a_async_queue_creation() {
     println!("=== PARITY-032a: Async Queue Creation ===\n");
 
@@ -177,6 +181,7 @@ fn test_parity032a_async_queue_creation() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity032b_submit_and_complete() {
     println!("=== PARITY-032b: Submit and Complete ===\n");
 
@@ -216,6 +221,7 @@ fn test_parity032b_submit_and_complete() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity032c_double_buffering() {
     println!("=== PARITY-032c: Double Buffering ===\n");
 
@@ -257,6 +263,7 @@ fn test_parity032c_double_buffering() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity032d_pipeline_efficiency() {
     println!("=== PARITY-032d: Pipeline Efficiency ===\n");
 
@@ -300,6 +307,7 @@ fn test_parity032d_pipeline_efficiency() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity032e_throughput_improvement() {
     println!("=== PARITY-032e: Throughput Improvement ===\n");
 
@@ -364,6 +372,7 @@ fn test_parity032e_throughput_improvement() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity033a_prefix_cache_creation() {
     println!("=== PARITY-033a: Prefix Cache Creation ===\n");
 
@@ -385,6 +394,7 @@ fn test_parity033a_prefix_cache_creation() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity033b_insert_and_lookup() {
     println!("=== PARITY-033b: Insert and Lookup ===\n");
 

--- a/crates/aprender-serve/src/gguf/tests/parity033c_lru.rs
+++ b/crates/aprender-serve/src/gguf/tests/parity033c_lru.rs
@@ -1,6 +1,7 @@
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity033c_lru_eviction() {
     println!("=== PARITY-033c: LRU Eviction ===\n");
 
@@ -48,6 +49,7 @@ fn test_parity033c_lru_eviction() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity033d_ttft_improvement() {
     println!("=== PARITY-033d: TTFT Improvement ===\n");
 
@@ -94,6 +96,7 @@ fn test_parity033d_ttft_improvement() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity033e_memory_usage() {
     println!("=== PARITY-033e: Memory Usage ===\n");
 
@@ -152,6 +155,7 @@ fn test_parity033e_memory_usage() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity034a_scheduler_creation() {
     println!("=== PARITY-034a: Scheduler Creation ===\n");
 
@@ -175,6 +179,7 @@ fn test_parity034a_scheduler_creation() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity034b_submit_and_decode() {
     println!("=== PARITY-034b: Submit and Decode ===\n");
 
@@ -210,6 +215,7 @@ fn test_parity034b_submit_and_decode() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity034c_token_generation() {
     println!("=== PARITY-034c: Token Generation ===\n");
 
@@ -253,6 +259,7 @@ fn test_parity034c_token_generation() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity034d_scheduling_policies() {
     println!("=== PARITY-034d: Scheduling Policies ===\n");
 
@@ -300,6 +307,7 @@ fn test_parity034d_scheduling_policies() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity034e_throughput_scaling() {
     println!("=== PARITY-034e: Throughput Scaling ===\n");
 

--- a/crates/aprender-serve/src/gguf/tests/parity035a_chunked.rs
+++ b/crates/aprender-serve/src/gguf/tests/parity035a_chunked.rs
@@ -13,6 +13,7 @@
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity035a_chunked_prefill_creation() {
     println!("=== PARITY-035a: Chunked Prefill Creation ===\n");
 
@@ -36,6 +37,7 @@ fn test_parity035a_chunked_prefill_creation() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity035b_chunk_iteration() {
     println!("=== PARITY-035b: Chunk Iteration ===\n");
 
@@ -66,6 +68,7 @@ fn test_parity035b_chunk_iteration() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity035c_progress_tracking() {
     println!("=== PARITY-035c: Progress Tracking ===\n");
 
@@ -114,6 +117,7 @@ fn test_parity035c_progress_tracking() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity035d_ttft_improvement() {
     println!("=== PARITY-035d: TTFT Improvement ===\n");
 
@@ -170,6 +174,7 @@ fn test_parity035d_ttft_improvement() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity035e_stats_and_throughput() {
     println!("=== PARITY-035e: Stats and Throughput ===\n");
 

--- a/crates/aprender-serve/src/gguf/tests/parity051g_summary.rs
+++ b/crates/aprender-serve/src/gguf/tests/parity051g_summary.rs
@@ -56,6 +56,7 @@ fn test_parity051g_summary() {
 /// PARITY-052a: Test BatchConfig default values
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity052a_batch_config_defaults() {
     use crate::api::BatchConfig;
 
@@ -99,6 +100,7 @@ fn test_parity052a_batch_config_defaults() {
 /// PARITY-052b: Test BatchConfig presets
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity052b_batch_config_presets() {
     use crate::api::BatchConfig;
 
@@ -147,6 +149,7 @@ fn test_parity052b_batch_config_presets() {
 /// PARITY-052c: Test BatchConfig decision methods
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity052c_batch_config_decisions() {
     use crate::api::BatchConfig;
 
@@ -197,6 +200,7 @@ fn test_parity052c_batch_config_decisions() {
 /// PARITY-052d: Test ContinuousBatchResponse creation
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity052d_batch_response_creation() {
     use crate::api::ContinuousBatchResponse;
 
@@ -257,6 +261,7 @@ fn test_parity052d_batch_response_creation() {
 /// PARITY-052e: Test AppState batch configuration
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity052e_appstate_batch_config() {
     println!("PARITY-052e: AppState Batch Configuration");
     println!("=========================================");
@@ -288,6 +293,7 @@ fn test_parity052e_appstate_batch_config() {
 /// PARITY-052f: Summary and integration status
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity052f_summary() {
     println!("PARITY-052f: Batch Request Queuing Summary");
     println!("==========================================");
@@ -341,6 +347,7 @@ fn test_parity052f_summary() {
 /// PARITY-053a: Document batch processor architecture
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity053a_batch_processor_architecture() {
     println!("PARITY-053a: Batch Processor Architecture");
     println!("=========================================");
@@ -373,6 +380,7 @@ fn test_parity053a_batch_processor_architecture() {
 /// PARITY-053b: Document batch processor flow
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity053b_batch_processor_flow() {
     println!("PARITY-053b: Batch Processor Flow");
     println!("=================================");
@@ -408,6 +416,7 @@ fn test_parity053b_batch_processor_flow() {
 /// PARITY-053c: Document spawn_batch_processor usage
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity053c_spawn_batch_processor_usage() {
     println!("PARITY-053c: spawn_batch_processor Usage");
     println!("========================================");

--- a/crates/aprender-serve/src/gguf/tests/parity053d_concurrent.rs
+++ b/crates/aprender-serve/src/gguf/tests/parity053d_concurrent.rs
@@ -2,6 +2,7 @@
 /// PARITY-053d: Document concurrent batch processing
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity053d_concurrent_processing() {
     println!("PARITY-053d: Concurrent Batch Processing");
     println!("========================================");
@@ -36,6 +37,7 @@ fn test_parity053d_concurrent_processing() {
 /// PARITY-053e: Document BatchProcessResult
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity053e_batch_process_result() {
     use crate::api::BatchProcessResult;
 
@@ -87,6 +89,7 @@ fn test_parity053e_batch_process_result() {
 /// PARITY-053f: Summary and integration status
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity053f_summary() {
     println!("PARITY-053f: Batch Processor Implementation Summary");
     println!("===================================================");
@@ -139,6 +142,7 @@ fn test_parity053f_summary() {
 /// PARITY-054a: Document handler batch path integration
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity054a_handler_batch_path() {
     println!("PARITY-054a: Handler Batch Path Integration");
     println!("===========================================");
@@ -167,6 +171,7 @@ fn test_parity054a_handler_batch_path() {
 /// PARITY-054b: Document response format changes
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity054b_response_format() {
     println!("PARITY-054b: Response Format Changes");
     println!("====================================");
@@ -199,6 +204,7 @@ fn test_parity054b_response_format() {
 /// PARITY-054c: Document backward compatibility
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity054c_backward_compatibility() {
     println!("PARITY-054c: Backward Compatibility");
     println!("===================================");
@@ -226,6 +232,7 @@ fn test_parity054c_backward_compatibility() {
 /// PARITY-054d: Document batch request structure
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity054d_batch_request_structure() {
     println!("PARITY-054d: Batch Request Structure");
     println!("====================================");
@@ -258,6 +265,7 @@ fn test_parity054d_batch_request_structure() {
 /// PARITY-054e: Document error handling
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity054e_error_handling() {
     println!("PARITY-054e: Error Handling");
     println!("===========================");
@@ -288,6 +296,7 @@ fn test_parity054e_error_handling() {
 /// PARITY-054f: Summary and integration complete
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity054f_summary() {
     println!("PARITY-054f: Handler Batch Integration Summary");
     println!("==============================================");

--- a/crates/aprender-serve/src/gguf/tests/parity056d_interpret.rs
+++ b/crates/aprender-serve/src/gguf/tests/parity056d_interpret.rs
@@ -2,6 +2,7 @@
 /// PARITY-056d: Interpret benchmark output
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity056d_interpret_output() {
     println!("PARITY-056d: Interpret Benchmark Output");
     println!("=======================================");
@@ -49,6 +50,7 @@ fn test_parity056d_interpret_output() {
 /// PARITY-056e: Results recording template
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity056e_results_template() {
     println!("PARITY-056e: Results Recording Template");
     println!("=======================================");
@@ -80,6 +82,7 @@ fn test_parity056e_results_template() {
 /// PARITY-056f: Summary and validation criteria
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity056f_summary() {
     println!("PARITY-056f: Benchmark Execution Summary");
     println!("========================================");
@@ -135,6 +138,7 @@ fn test_parity056f_summary() {
 /// PARITY-057a: Live benchmark setup
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity057a_live_benchmark_setup() {
     println!("PARITY-057a: Live Benchmark Setup");
     println!("=================================");
@@ -164,6 +168,7 @@ fn test_parity057a_live_benchmark_setup() {
 /// PARITY-057b: Benchmark payload
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity057b_benchmark_payload() {
     println!("PARITY-057b: Benchmark Payload");
     println!("==============================");
@@ -192,6 +197,7 @@ fn test_parity057b_benchmark_payload() {
 /// PARITY-057c: Concurrency sweep results
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity057c_concurrency_sweep() {
     println!("PARITY-057c: Concurrency Sweep Results");
     println!("======================================");
@@ -235,6 +241,7 @@ fn test_parity057c_concurrency_sweep() {
 /// PARITY-057d: M4 parity validation
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity057d_m4_parity_validation() {
     println!("PARITY-057d: M4 Parity Validation");
     println!("=================================");
@@ -269,6 +276,7 @@ fn test_parity057d_m4_parity_validation() {
 /// PARITY-057e: Scaling efficiency
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity057e_scaling_efficiency() {
     println!("PARITY-057e: Scaling Efficiency Analysis");
     println!("========================================");
@@ -307,6 +315,7 @@ fn test_parity057e_scaling_efficiency() {
 /// PARITY-057f: Summary and conclusions
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity057f_summary() {
     println!("PARITY-057f: Live Benchmark Summary");
     println!("===================================");
@@ -356,6 +365,7 @@ fn test_parity057f_summary() {
 /// PARITY-058a: Implementation overview
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity058a_implementation_overview() {
     println!("PARITY-058a: Batch Inference Implementation Overview");
     println!("====================================================");
@@ -384,6 +394,7 @@ fn test_parity058a_implementation_overview() {
 /// PARITY-058b: Architecture summary
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity058b_architecture_summary() {
     println!("PARITY-058b: Batch Inference Architecture");
     println!("=========================================");

--- a/crates/aprender-serve/src/gguf/tests/parity058c_performance.rs
+++ b/crates/aprender-serve/src/gguf/tests/parity058c_performance.rs
@@ -2,6 +2,7 @@
 /// PARITY-058c: Performance characteristics
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity058c_performance_characteristics() {
     println!("PARITY-058c: Performance Characteristics");
     println!("========================================");
@@ -44,6 +45,7 @@ fn test_parity058c_performance_characteristics() {
 /// PARITY-058d: API compatibility
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity058d_api_compatibility() {
     println!("PARITY-058d: API Compatibility");
     println!("==============================");
@@ -77,6 +79,7 @@ fn test_parity058d_api_compatibility() {
 /// PARITY-058e: Configuration options
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity058e_configuration_options() {
     println!("PARITY-058e: Configuration Options");
     println!("==================================");
@@ -113,6 +116,7 @@ fn test_parity058e_configuration_options() {
 /// PARITY-058f: Final summary
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity058f_final_summary() {
     println!("PARITY-058f: Batch Inference - Final Summary");
     println!("============================================");
@@ -184,6 +188,7 @@ fn test_parity058f_final_summary() {
 /// PARITY-059a: Speculative decoding overview
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity059a_speculative_overview() {
     println!("PARITY-059a: Speculative Decoding API Integration");
     println!("=================================================");
@@ -217,6 +222,7 @@ fn test_parity059a_speculative_overview() {
 /// PARITY-059b: Speedup calculation
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity059b_speedup_calculation() {
     println!("PARITY-059b: Speculative Decoding Speedup Model");
     println!("===============================================");
@@ -263,6 +269,7 @@ fn test_parity059b_speedup_calculation() {
 /// PARITY-059c: API request format
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity059c_api_request_format() {
     println!("PARITY-059c: API Request Format");
     println!("================================");
@@ -301,6 +308,7 @@ fn test_parity059c_api_request_format() {
 /// PARITY-059d: AppState integration
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity059d_appstate_integration() {
     println!("PARITY-059d: AppState Integration");
     println!("=================================");
@@ -327,6 +335,7 @@ fn test_parity059d_appstate_integration() {
 /// PARITY-059e: Generate with speculative decoding
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity059e_generate_speculative() {
     println!("PARITY-059e: Generate with Speculative Decoding");
     println!("===============================================");
@@ -360,6 +369,7 @@ fn test_parity059e_generate_speculative() {
 /// PARITY-059f: Summary and expected performance
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity059f_summary() {
     println!("PARITY-059f: Speculative Decoding API Summary");
     println!("=============================================");
@@ -409,6 +419,7 @@ fn test_parity059f_summary() {
 /// PARITY-060a: SpeculativeStats struct
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity060a_speculative_stats() {
     println!("PARITY-060a: SpeculativeStats Struct");
     println!("====================================");

--- a/crates/aprender-serve/src/gguf/tests/parity060b_draft_generate.rs
+++ b/crates/aprender-serve/src/gguf/tests/parity060b_draft_generate.rs
@@ -2,6 +2,7 @@
 /// PARITY-060b: Self-speculative draft generation
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity060b_draft_generation() {
     println!("PARITY-060b: Self-Speculative Draft Generation");
     println!("==============================================");
@@ -33,6 +34,7 @@ fn test_parity060b_draft_generation() {
 /// PARITY-060c: Verification with batch forward
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity060c_batch_verification() {
     println!("PARITY-060c: Batch Verification");
     println!("================================");
@@ -64,6 +66,7 @@ fn test_parity060c_batch_verification() {
 /// PARITY-060d: Full generation loop
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity060d_generation_loop() {
     println!("PARITY-060d: Full Generation Loop");
     println!("=================================");
@@ -109,6 +112,7 @@ fn test_parity060d_generation_loop() {
 /// PARITY-060e: Expected performance
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity060e_expected_performance() {
     println!("PARITY-060e: Expected Performance");
     println!("=================================");
@@ -152,6 +156,7 @@ fn test_parity060e_expected_performance() {
 /// PARITY-060f: Summary
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity060f_summary() {
     println!("PARITY-060f: generate_with_speculative() Summary");
     println!("================================================");
@@ -205,6 +210,7 @@ fn test_parity060f_summary() {
 /// PARITY-061a: Handler path selection
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity061a_handler_path_selection() {
     println!("PARITY-061a: Handler Path Selection");
     println!("===================================");
@@ -237,6 +243,7 @@ fn test_parity061a_handler_path_selection() {
 /// PARITY-061b: Request speculative field
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity061b_request_speculative_field() {
     println!("PARITY-061b: Request Speculative Field");
     println!("======================================");
@@ -269,6 +276,7 @@ fn test_parity061b_request_speculative_field() {
 /// PARITY-061c: Response speculative stats
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity061c_response_speculative_stats() {
     println!("PARITY-061c: Response Speculative Stats");
     println!("=======================================");
@@ -314,6 +322,7 @@ fn test_parity061c_response_speculative_stats() {
 /// PARITY-061d: Handler implementation
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity061d_handler_implementation() {
     println!("PARITY-061d: Handler Implementation");
     println!("===================================");
@@ -353,6 +362,7 @@ fn test_parity061d_handler_implementation() {
 /// PARITY-061e: Combined modes
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity061e_combined_modes() {
     println!("PARITY-061e: Combined Modes");
     println!("===========================");
@@ -393,6 +403,7 @@ fn test_parity061e_combined_modes() {
 /// PARITY-061f: Summary
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity061f_summary() {
     println!("PARITY-061f: Handler Speculative Path Summary");
     println!("=============================================");

--- a/crates/aprender-serve/src/gguf/tests/parity062a_benchmark.rs
+++ b/crates/aprender-serve/src/gguf/tests/parity062a_benchmark.rs
@@ -9,6 +9,7 @@
 /// PARITY-062a: Benchmark setup
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity062a_benchmark_setup() {
     println!("PARITY-062a: Speculative Benchmark Setup");
     println!("========================================");
@@ -38,6 +39,7 @@ fn test_parity062a_benchmark_setup() {
 /// PARITY-062b: Expected acceptance rates
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity062b_expected_acceptance_rates() {
     println!("PARITY-062b: Expected Acceptance Rates");
     println!("======================================");
@@ -77,6 +79,7 @@ fn test_parity062b_expected_acceptance_rates() {
 /// PARITY-062c: Benchmark execution
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity062c_benchmark_execution() {
     println!("PARITY-062c: Benchmark Execution");
     println!("================================");
@@ -114,6 +117,7 @@ fn test_parity062c_benchmark_execution() {
 /// PARITY-062d: Results analysis
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity062d_results_analysis() {
     println!("PARITY-062d: Results Analysis");
     println!("=============================");
@@ -154,6 +158,7 @@ fn test_parity062d_results_analysis() {
 /// PARITY-062e: Comparison with batch
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity062e_comparison_with_batch() {
     println!("PARITY-062e: Speculative vs Batch Comparison");
     println!("============================================");
@@ -197,6 +202,7 @@ fn test_parity062e_comparison_with_batch() {
 /// PARITY-062f: Summary
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity062f_summary() {
     println!("PARITY-062f: Speculative Benchmark Summary");
     println!("==========================================");
@@ -251,6 +257,7 @@ fn test_parity062f_summary() {
 /// PARITY-063a: Phase 2 objectives achieved
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity063a_objectives() {
     println!("PARITY-063a: Phase 2 Objectives Achieved");
     println!("=========================================");
@@ -279,6 +286,7 @@ fn test_parity063a_objectives() {
 /// PARITY-063b: Implementation components
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity063b_components() {
     println!("PARITY-063b: Implementation Components");
     println!("======================================");
@@ -324,6 +332,7 @@ fn test_parity063b_components() {
 /// PARITY-063c: Performance metrics
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity063c_performance() {
     println!("PARITY-063c: Performance Metrics");
     println!("================================");
@@ -384,6 +393,7 @@ fn test_parity063c_performance() {
 /// PARITY-063d: API integration summary
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity063d_api_summary() {
     println!("PARITY-063d: API Integration Summary");
     println!("====================================");

--- a/crates/aprender-serve/src/gguf/tests/parity063e_checklist.rs
+++ b/crates/aprender-serve/src/gguf/tests/parity063e_checklist.rs
@@ -2,6 +2,7 @@
 /// PARITY-063e: Verification checklist
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity063e_checklist() {
     println!("PARITY-063e: Verification Checklist");
     println!("===================================");
@@ -47,6 +48,7 @@ fn test_parity063e_checklist() {
 /// PARITY-063f: Complete Phase 2 status
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity063f_status() {
     println!("PARITY-063f: Phase 2 Complete Status");
     println!("====================================");

--- a/crates/aprender-serve/src/gguf/tests/parity071c_dequantize.rs
+++ b/crates/aprender-serve/src/gguf/tests/parity071c_dequantize.rs
@@ -2,6 +2,7 @@
 /// PARITY-071c: Q8_0Block::dequantize() function
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity071c_dequantize_function() {
     use crate::quantize::Q8_0Block;
 
@@ -52,6 +53,7 @@ fn test_parity071c_dequantize_function() {
 /// PARITY-071d: Quantization error analysis
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity071d_error_analysis() {
     use crate::quantize::Q8_0Block;
 
@@ -99,6 +101,7 @@ fn test_parity071d_error_analysis() {
 /// PARITY-071e: quantize_to_q8_blocks() function
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity071e_batch_quantization() {
     use crate::quantize::{dequantize_q8_blocks, quantize_to_q8_blocks};
 
@@ -149,6 +152,7 @@ fn test_parity071e_batch_quantization() {
 /// PARITY-071f: Integration summary
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity071f_integration_summary() {
     use crate::quantize::Q8_0Block;
 
@@ -205,6 +209,7 @@ fn test_parity071f_integration_summary() {
 /// PARITY-072a: Fused kernel signature and purpose
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity072a_kernel_signature() {
     println!("PARITY-072a: Fused Q4xQ8 Kernel Signature");
     println!("==========================================");
@@ -241,6 +246,7 @@ fn test_parity072a_kernel_signature() {
 /// PARITY-072b: Verify fused kernel correctness
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity072b_correctness() {
     use crate::quantize::{fused_q4k_dot, fused_q4k_q8_dot, quantize_to_q8_blocks};
 
@@ -311,6 +317,7 @@ fn test_parity072b_correctness() {
 /// PARITY-072c: Memory traffic analysis
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity072c_memory_analysis() {
     println!("PARITY-072c: Memory Traffic Analysis");
     println!("====================================");
@@ -376,6 +383,7 @@ fn test_parity072c_memory_analysis() {
 /// PARITY-072d: Validation error handling
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity072d_validation() {
     use crate::quantize::{fused_q4k_q8_dot, Q8_0Block};
 

--- a/crates/aprender-serve/src/gguf/tests/parity072e_performance.rs
+++ b/crates/aprender-serve/src/gguf/tests/parity072e_performance.rs
@@ -3,6 +3,7 @@
 #[test]
 #[ignore = "Performance test unreliable - depends on system load"]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity072e_performance() {
     use crate::quantize::{fused_q4k_dot, fused_q4k_q8_dot, quantize_to_q8_blocks};
     use std::time::Instant;
@@ -70,6 +71,7 @@ fn test_parity072e_performance() {
 /// PARITY-072f: Integration summary
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity072f_summary() {
     println!("PARITY-072f: Fused Q4xQ8 Kernel Summary");
     println!("=======================================");
@@ -113,6 +115,7 @@ fn test_parity072f_summary() {
 /// PARITY-073a: FusedQ4Q8Dot kernel type definition
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_073a_fused_q4q8_kernel_type() {
     use crate::cuda::{CudaKernels, KernelType};
 
@@ -162,6 +165,7 @@ fn test_parity_073a_fused_q4q8_kernel_type() {
 /// PARITY-073b: PTX generation verification (now uses trueno)
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_073b_ptx_generation() {
     use crate::cuda::{CudaKernels, KernelType};
 
@@ -217,6 +221,7 @@ fn test_parity_073b_ptx_generation() {
 /// PARITY-073c: Quantization operations (now uses trueno)
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_073c_dp4a_instructions() {
     use crate::cuda::{CudaKernels, KernelType};
 
@@ -275,6 +280,7 @@ fn test_parity_073c_dp4a_instructions() {
 /// PARITY-073d: Trueno GEMM loop structure (replaces hand-rolled super-block loops)
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_073d_superblock_loop() {
     use crate::cuda::{CudaKernels, KernelType};
 
@@ -336,6 +342,7 @@ fn test_parity_073d_superblock_loop() {
 /// PARITY-073e: Memory addressing verification
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_073e_memory_addressing() {
     use crate::cuda::{CudaKernels, KernelType};
 
@@ -388,6 +395,7 @@ fn test_parity_073e_memory_addressing() {
 /// PARITY-073f: Integration summary and next steps
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_073f_integration_summary() {
     println!("PARITY-073f: CUDA PTX Generation Summary");
     println!("=========================================");

--- a/crates/aprender-serve/src/gguf/tests/parity_074a_execute.rs
+++ b/crates/aprender-serve/src/gguf/tests/parity_074a_execute.rs
@@ -5,6 +5,7 @@
 /// PARITY-074a: Execution interface design
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_074a_execution_interface() {
     use crate::cuda::{CudaKernels, KernelType};
 
@@ -55,6 +56,7 @@ fn test_parity_074a_execution_interface() {
 /// PARITY-074b: Buffer layout requirements
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_074b_buffer_layout() {
     println!("PARITY-074b: GPU Buffer Layout Requirements");
     println!("============================================");
@@ -112,6 +114,7 @@ fn test_parity_074b_buffer_layout() {
 /// PARITY-074c: Kernel launch configuration
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_074c_launch_configuration() {
     println!("PARITY-074c: Kernel Launch Configuration");
     println!("=========================================");
@@ -171,6 +174,7 @@ fn test_parity_074c_launch_configuration() {
 /// PARITY-074d: Memory transfer patterns
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_074d_memory_transfers() {
     println!("PARITY-074d: Memory Transfer Patterns");
     println!("=====================================");
@@ -225,6 +229,7 @@ fn test_parity_074d_memory_transfers() {
 /// PARITY-074e: Performance projection
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_074e_performance_projection() {
     println!("PARITY-074e: Performance Projection");
     println!("====================================");
@@ -282,6 +287,7 @@ fn test_parity_074e_performance_projection() {
 /// PARITY-074f: Integration summary
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_074f_integration_summary() {
     println!("PARITY-074f: CUDA Kernel Execution Summary");
     println!("==========================================");
@@ -342,6 +348,7 @@ fn test_parity_074f_integration_summary() {
 /// PARITY-075a: INT8 attention score quantization
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_075a_attention_score_quantization() {
     use crate::quantize::Q8_0Block;
 

--- a/crates/aprender-serve/src/gguf/tests/parity_075b.rs
+++ b/crates/aprender-serve/src/gguf/tests/parity_075b.rs
@@ -2,6 +2,7 @@
 /// PARITY-075b: INT8 Q×K^T computation
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_075b_int8_qk_computation() {
     use crate::quantize::Q8_0Block;
 
@@ -86,6 +87,7 @@ fn test_parity_075b_int8_qk_computation() {
 /// PARITY-075c: Memory bandwidth analysis for attention
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_075c_attention_bandwidth() {
     println!("PARITY-075c: Attention Memory Bandwidth Analysis");
     println!("=================================================");
@@ -167,6 +169,7 @@ fn test_parity_075c_attention_bandwidth() {
 /// PARITY-075d: Softmax with INT8 inputs
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_075d_int8_softmax() {
     println!("PARITY-075d: Softmax with INT8 Inputs");
     println!("=====================================");
@@ -247,6 +250,7 @@ fn test_parity_075d_int8_softmax() {
 /// PARITY-075e: End-to-end INT8 attention flow
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_075e_end_to_end_attention() {
     use crate::quantize::Q8_0Block;
 

--- a/crates/aprender-serve/src/gguf/tests/parity_075d.rs
+++ b/crates/aprender-serve/src/gguf/tests/parity_075d.rs
@@ -2,6 +2,7 @@
 /// PARITY-075d: Softmax with INT8 inputs
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_075d_int8_softmax() {
     println!("PARITY-075d: Softmax with INT8 Inputs");
     println!("=====================================");
@@ -82,6 +83,7 @@ fn test_parity_075d_int8_softmax() {
 /// PARITY-075e: End-to-end INT8 attention flow
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_075e_end_to_end_attention() {
     use crate::quantize::Q8_0Block;
 
@@ -233,6 +235,7 @@ fn test_parity_075e_end_to_end_attention() {
 /// PARITY-075f: Integration summary
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_075f_integration_summary() {
     println!("PARITY-075f: INT8 Attention Summary");
     println!("====================================");
@@ -302,6 +305,7 @@ fn test_parity_075f_integration_summary() {
 /// PARITY-076a: Phase 3 component inventory
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_076a_component_inventory() {
     use crate::cuda::{CudaKernels, KernelType};
     use crate::quantize::Q8_0Block;
@@ -364,6 +368,7 @@ fn test_parity_076a_component_inventory() {
 /// PARITY-076b: Performance projections
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_076b_performance_projections() {
     println!("PARITY-076b: Performance Projections");
     println!("=====================================");

--- a/crates/aprender-serve/src/gguf/tests/parity_075f.rs
+++ b/crates/aprender-serve/src/gguf/tests/parity_075f.rs
@@ -2,6 +2,7 @@
 /// PARITY-075f: Integration summary
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_075f_integration_summary() {
     println!("PARITY-075f: INT8 Attention Summary");
     println!("====================================");
@@ -71,6 +72,7 @@ fn test_parity_075f_integration_summary() {
 /// PARITY-076a: Phase 3 component inventory
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_076a_component_inventory() {
     use crate::cuda::{CudaKernels, KernelType};
     use crate::quantize::Q8_0Block;
@@ -133,6 +135,7 @@ fn test_parity_076a_component_inventory() {
 /// PARITY-076b: Performance projections
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_076b_performance_projections() {
     println!("PARITY-076b: Performance Projections");
     println!("=====================================");
@@ -185,6 +188,7 @@ fn test_parity_076b_performance_projections() {
 /// PARITY-076c: Memory bandwidth summary
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_076c_bandwidth_summary() {
     println!("PARITY-076c: Memory Bandwidth Summary");
     println!("=====================================");
@@ -242,6 +246,7 @@ fn test_parity_076c_bandwidth_summary() {
 /// PARITY-076d: Integration architecture
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_076d_integration_architecture() {
     println!("PARITY-076d: Integration Architecture");
     println!("=====================================");
@@ -307,6 +312,7 @@ fn test_parity_076d_integration_architecture() {
 /// PARITY-076e: Next steps
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_076e_next_steps() {
     println!("PARITY-076e: Next Steps");
     println!("=======================");
@@ -359,6 +365,7 @@ fn test_parity_076e_next_steps() {
 /// PARITY-076f: Phase 3 completion summary
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_076f_phase3_summary() {
     println!("PARITY-076f: Phase 3 Completion Summary");
     println!("========================================");

--- a/crates/aprender-serve/src/gguf/tests/parity_076c.rs
+++ b/crates/aprender-serve/src/gguf/tests/parity_076c.rs
@@ -2,6 +2,7 @@
 /// PARITY-076c: Memory bandwidth summary
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_076c_bandwidth_summary() {
     println!("PARITY-076c: Memory Bandwidth Summary");
     println!("=====================================");
@@ -59,6 +60,7 @@ fn test_parity_076c_bandwidth_summary() {
 /// PARITY-076d: Integration architecture
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_076d_integration_architecture() {
     println!("PARITY-076d: Integration Architecture");
     println!("=====================================");
@@ -124,6 +126,7 @@ fn test_parity_076d_integration_architecture() {
 /// PARITY-076e: Next steps
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_076e_next_steps() {
     println!("PARITY-076e: Next Steps");
     println!("=======================");
@@ -176,6 +179,7 @@ fn test_parity_076e_next_steps() {
 /// PARITY-076f: Phase 3 completion summary
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_076f_phase3_summary() {
     println!("PARITY-076f: Phase 3 Completion Summary");
     println!("========================================");
@@ -238,6 +242,7 @@ fn test_parity_076f_phase3_summary() {
 /// PARITY-077a: Shared memory tile size optimization
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_077a_shared_memory_tile_sizing() {
     println!("PARITY-077a: Shared Memory Tile Size Optimization");
     println!("==================================================");
@@ -334,6 +339,7 @@ fn test_parity_077a_shared_memory_tile_sizing() {
 /// PARITY-077b: Tile iteration order
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_077b_tile_iteration_order() {
     println!("PARITY-077b: Tile Iteration Order");
     println!("==================================");
@@ -400,6 +406,7 @@ fn test_parity_077b_tile_iteration_order() {
 /// PARITY-077c: Multi-query attention (MQA) tile sharing
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_077c_mqa_tile_sharing() {
     println!("PARITY-077c: Multi-Query Attention Tile Sharing");
     println!("================================================");

--- a/crates/aprender-serve/src/gguf/tests/parity_077a.rs
+++ b/crates/aprender-serve/src/gguf/tests/parity_077a.rs
@@ -9,6 +9,7 @@
 /// PARITY-077a: Shared memory tile size optimization
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_077a_shared_memory_tile_sizing() {
     println!("PARITY-077a: Shared Memory Tile Size Optimization");
     println!("==================================================");
@@ -105,6 +106,7 @@ fn test_parity_077a_shared_memory_tile_sizing() {
 /// PARITY-077b: Tile iteration order
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_077b_tile_iteration_order() {
     println!("PARITY-077b: Tile Iteration Order");
     println!("==================================");
@@ -171,6 +173,7 @@ fn test_parity_077b_tile_iteration_order() {
 /// PARITY-077c: Multi-query attention (MQA) tile sharing
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_077c_mqa_tile_sharing() {
     println!("PARITY-077c: Multi-Query Attention Tile Sharing");
     println!("================================================");
@@ -222,6 +225,7 @@ fn test_parity_077c_mqa_tile_sharing() {
 /// PARITY-077d: Warp specialization
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_077d_warp_specialization() {
     println!("PARITY-077d: Warp Specialization");
     println!("=================================");
@@ -268,6 +272,7 @@ fn test_parity_077d_warp_specialization() {
 /// PARITY-077e: Shared memory bank conflict avoidance
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_077e_bank_conflict_avoidance() {
     println!("PARITY-077e: Shared Memory Bank Conflict Avoidance");
     println!("===================================================");
@@ -329,6 +334,7 @@ fn test_parity_077e_bank_conflict_avoidance() {
 /// PARITY-077f: Shared memory tiling summary
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_077f_tiling_summary() {
     println!("PARITY-077f: Shared Memory Tiling Summary");
     println!("==========================================");

--- a/crates/aprender-serve/src/gguf/tests/parity_077d.rs
+++ b/crates/aprender-serve/src/gguf/tests/parity_077d.rs
@@ -2,6 +2,7 @@
 /// PARITY-077d: Warp specialization
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_077d_warp_specialization() {
     println!("PARITY-077d: Warp Specialization");
     println!("=================================");
@@ -48,6 +49,7 @@ fn test_parity_077d_warp_specialization() {
 /// PARITY-077e: Shared memory bank conflict avoidance
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_077e_bank_conflict_avoidance() {
     println!("PARITY-077e: Shared Memory Bank Conflict Avoidance");
     println!("===================================================");
@@ -109,6 +111,7 @@ fn test_parity_077e_bank_conflict_avoidance() {
 /// PARITY-077f: Shared memory tiling summary
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_077f_tiling_summary() {
     println!("PARITY-077f: Shared Memory Tiling Summary");
     println!("==========================================");

--- a/crates/aprender-serve/src/gguf/tests/parity_079c.rs
+++ b/crates/aprender-serve/src/gguf/tests/parity_079c.rs
@@ -2,6 +2,7 @@
 /// PARITY-079c: Fused rescaling
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_079c_fused_rescaling() {
     println!("PARITY-079c: Fused Rescaling Operations");
     println!("========================================");
@@ -43,6 +44,7 @@ fn test_parity_079c_fused_rescaling() {
 /// PARITY-079d: Causal mask optimization
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_079d_causal_mask_optimization() {
     println!("PARITY-079d: Causal Mask Optimization");
     println!("======================================");
@@ -109,6 +111,7 @@ fn test_parity_079d_causal_mask_optimization() {
 /// PARITY-079e: Memory coalescing
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_079e_memory_coalescing() {
     println!("PARITY-079e: Memory Coalescing Analysis");
     println!("========================================");
@@ -170,6 +173,7 @@ fn test_parity_079e_memory_coalescing() {
 /// PARITY-079f: Non-matmul FLOP reduction summary
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_079f_non_matmul_summary() {
     println!("PARITY-079f: Non-matmul FLOP Reduction Summary");
     println!("===============================================");
@@ -206,6 +210,7 @@ fn test_parity_079f_non_matmul_summary() {
 /// PARITY-080a: Tensor Core specifications
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_080a_tensor_core_specs() {
     println!("PARITY-080a: Tensor Core Specifications");
     println!("========================================");
@@ -251,6 +256,7 @@ fn test_parity_080a_tensor_core_specs() {
 /// PARITY-080b: WMMA PTX instructions
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_080b_wmma_ptx_instructions() {
     use crate::cuda::CudaKernels;
 
@@ -295,6 +301,7 @@ fn test_parity_080b_wmma_ptx_instructions() {
 /// PARITY-080c: FP16 accumulation precision
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_080c_fp16_accumulation() {
     println!("PARITY-080c: FP16 Accumulation Precision");
     println!("=========================================");
@@ -368,6 +375,7 @@ fn test_parity_080c_fp16_accumulation() {
 /// PARITY-080d: BF16 for attention
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_080d_bf16_attention() {
     println!("PARITY-080d: BF16 for Attention");
     println!("================================");

--- a/crates/aprender-serve/src/gguf/tests/parity_080e.rs
+++ b/crates/aprender-serve/src/gguf/tests/parity_080e.rs
@@ -2,6 +2,7 @@
 /// PARITY-080e: Mixed precision attention
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_080e_mixed_precision() {
     println!("PARITY-080e: Mixed Precision Attention");
     println!("=======================================");
@@ -53,6 +54,7 @@ fn test_parity_080e_mixed_precision() {
 /// PARITY-080f: Tensor Core integration summary
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_080f_tensor_core_summary() {
     println!("PARITY-080f: Tensor Core Integration Summary");
     println!("=============================================");
@@ -100,6 +102,7 @@ fn test_parity_080f_tensor_core_summary() {
 /// PARITY-081a: Component inventory
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_081a_phase4_component_inventory() {
     println!("PARITY-081a: Phase 4 Component Inventory");
     println!("=========================================");
@@ -134,6 +137,7 @@ fn test_parity_081a_phase4_component_inventory() {
 /// PARITY-081b: Performance projection
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_081b_performance_projection() {
     println!("PARITY-081b: Phase 4 Performance Projection");
     println!("============================================");
@@ -200,6 +204,7 @@ fn test_parity_081b_performance_projection() {
 /// PARITY-081c: Implementation roadmap
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_081c_implementation_roadmap() {
     println!("PARITY-081c: Implementation Roadmap");
     println!("=====================================");
@@ -234,6 +239,7 @@ fn test_parity_081c_implementation_roadmap() {
 /// PARITY-081d: Risk assessment
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_081d_risk_assessment() {
     println!("PARITY-081d: Risk Assessment");
     println!("=============================");
@@ -264,6 +270,7 @@ fn test_parity_081d_risk_assessment() {
 /// PARITY-081e: Success criteria
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_081e_success_criteria() {
     println!("PARITY-081e: Success Criteria");
     println!("==============================");
@@ -304,6 +311,7 @@ fn test_parity_081e_success_criteria() {
 /// PARITY-081f: Phase 4 final summary
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_081f_phase4_summary() {
     println!("PARITY-081f: Phase 4 Final Summary");
     println!("===================================");
@@ -366,6 +374,7 @@ fn test_parity_081f_phase4_summary() {
 /// PARITY-082a: Stream-K algorithm overview
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_082a_streamk_overview() {
     println!("PARITY-082a: Stream-K Algorithm Overview");
     println!("=========================================");

--- a/crates/aprender-serve/src/gguf/tests/parity_082b.rs
+++ b/crates/aprender-serve/src/gguf/tests/parity_082b.rs
@@ -2,6 +2,7 @@
 /// PARITY-082b: Wave quantization problem
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_082b_wave_quantization() {
     println!("PARITY-082b: Wave Quantization Problem");
     println!("=======================================");
@@ -60,6 +61,7 @@ fn test_parity_082b_wave_quantization() {
 /// PARITY-082c: Work-stealing implementation
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_082c_work_stealing() {
     println!("PARITY-082c: Work-Stealing Implementation");
     println!("==========================================");
@@ -117,6 +119,7 @@ fn test_parity_082c_work_stealing() {
 /// PARITY-082d: Partial result accumulation
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_082d_partial_accumulation() {
     println!("PARITY-082d: Partial Result Accumulation");
     println!("=========================================");
@@ -181,6 +184,7 @@ fn test_parity_082d_partial_accumulation() {
 /// PARITY-082e: Tile rasterization order
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_082e_tile_rasterization() {
     println!("PARITY-082e: Tile Rasterization Order");
     println!("======================================");
@@ -240,6 +244,7 @@ fn test_parity_082e_tile_rasterization() {
 /// PARITY-082f: Stream-K summary
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_082f_streamk_summary() {
     println!("PARITY-082f: Stream-K Summary");
     println!("==============================");
@@ -276,6 +281,7 @@ fn test_parity_082f_streamk_summary() {
 /// PARITY-083a: LLM matrix shapes
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_083a_llm_matrix_shapes() {
     println!("PARITY-083a: LLM Matrix Shapes");
     println!("===============================");
@@ -333,6 +339,7 @@ fn test_parity_083a_llm_matrix_shapes() {
 /// PARITY-083b: Padding overhead analysis
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_083b_padding_overhead() {
     println!("PARITY-083b: Padding Overhead Analysis");
     println!("=======================================");
@@ -390,6 +397,7 @@ fn test_parity_083b_padding_overhead() {
 /// PARITY-083c: Predicated execution
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_083c_predicated_execution() {
     println!("PARITY-083c: Predicated Execution");
     println!("===================================");

--- a/crates/aprender-serve/src/gguf/tests/parity_083d.rs
+++ b/crates/aprender-serve/src/gguf/tests/parity_083d.rs
@@ -2,6 +2,7 @@
 /// PARITY-083d: Split-K for tall-skinny matrices
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_083d_tall_skinny_matrices() {
     println!("PARITY-083d: Tall-Skinny Matrix Handling");
     println!("=========================================");
@@ -68,6 +69,7 @@ fn test_parity_083d_tall_skinny_matrices() {
 /// PARITY-083e: Batch dimension handling
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_083e_batch_dimension() {
     println!("PARITY-083e: Batch Dimension Handling");
     println!("======================================");
@@ -134,6 +136,7 @@ fn test_parity_083e_batch_dimension() {
 /// PARITY-083f: Irregular matrix summary
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_083f_irregular_summary() {
     println!("PARITY-083f: Irregular Matrix Handling Summary");
     println!("================================================");
@@ -169,6 +172,7 @@ fn test_parity_083f_irregular_summary() {
 /// PARITY-084a: Request batching strategy
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_084a_request_batching() {
     println!("PARITY-084a: Request Batching Strategy");
     println!("=======================================");
@@ -229,6 +233,7 @@ fn test_parity_084a_request_batching() {
 /// PARITY-084b: Memory pool management
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_084b_memory_pool() {
     println!("PARITY-084b: Memory Pool Management");
     println!("=====================================");
@@ -290,6 +295,7 @@ fn test_parity_084b_memory_pool() {
 /// PARITY-084c: Request scheduling
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_084c_request_scheduling() {
     println!("PARITY-084c: Request Scheduling");
     println!("================================");
@@ -346,6 +352,7 @@ fn test_parity_084c_request_scheduling() {
 /// PARITY-084d: Streaming response
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_084d_streaming_response() {
     println!("PARITY-084d: Streaming Response");
     println!("================================");
@@ -391,6 +398,7 @@ fn test_parity_084d_streaming_response() {
 /// PARITY-084e: Error handling
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_084e_error_handling() {
     println!("PARITY-084e: Production Error Handling");
     println!("=======================================");

--- a/crates/aprender-serve/src/gguf/tests/parity_084f.rs
+++ b/crates/aprender-serve/src/gguf/tests/parity_084f.rs
@@ -2,6 +2,7 @@
 /// PARITY-084f: Production serving summary
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_084f_serving_summary() {
     println!("PARITY-084f: Production Serving Summary");
     println!("========================================");
@@ -40,6 +41,7 @@ fn test_parity_084f_serving_summary() {
 /// PARITY-085a: Benchmark methodology
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_085a_benchmark_methodology() {
     println!("PARITY-085a: Benchmark Methodology");
     println!("====================================");
@@ -91,6 +93,7 @@ fn test_parity_085a_benchmark_methodology() {
 /// PARITY-085b: Comparison targets
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_085b_comparison_targets() {
     println!("PARITY-085b: Comparison Targets");
     println!("================================");
@@ -138,6 +141,7 @@ fn test_parity_085b_comparison_targets() {
 /// PARITY-085c: Microbenchmarks
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_085c_microbenchmarks() {
     println!("PARITY-085c: Microbenchmarks");
     println!("=============================");
@@ -187,6 +191,7 @@ fn test_parity_085c_microbenchmarks() {
 /// PARITY-085d: End-to-end benchmarks
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_085d_e2e_benchmarks() {
     println!("PARITY-085d: End-to-End Benchmarks");
     println!("===================================");
@@ -236,6 +241,7 @@ fn test_parity_085d_e2e_benchmarks() {
 /// PARITY-085e: Regression testing
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_085e_regression_testing() {
     println!("PARITY-085e: Performance Regression Testing");
     println!("============================================");
@@ -286,6 +292,7 @@ fn test_parity_085e_regression_testing() {
 /// PARITY-085f: Benchmark validation summary
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_085f_validation_summary() {
     println!("PARITY-085f: Benchmark Validation Summary");
     println!("==========================================");
@@ -326,6 +333,7 @@ fn test_parity_085f_validation_summary() {
 /// PARITY-086a: Component inventory
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_086a_phase5_inventory() {
     println!("PARITY-086a: Phase 5 Component Inventory");
     println!("=========================================");
@@ -361,6 +369,7 @@ fn test_parity_086a_phase5_inventory() {
 /// PARITY-086b: Cumulative performance
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_086b_cumulative_performance() {
     println!("PARITY-086b: Cumulative Performance");
     println!("=====================================");

--- a/crates/aprender-serve/src/gguf/tests/parity_086c.rs
+++ b/crates/aprender-serve/src/gguf/tests/parity_086c.rs
@@ -2,6 +2,7 @@
 /// PARITY-086c: Implementation status
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_086c_implementation_status() {
     println!("PARITY-086c: Implementation Status");
     println!("====================================");
@@ -40,6 +41,7 @@ fn test_parity_086c_implementation_status() {
 /// PARITY-086d: Test coverage summary
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_086d_test_coverage() {
     println!("PARITY-086d: Test Coverage Summary");
     println!("===================================");
@@ -107,6 +109,7 @@ fn test_parity_086d_test_coverage() {
 /// PARITY-086e: Next steps
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_086e_next_steps() {
     println!("PARITY-086e: Next Steps");
     println!("========================");
@@ -141,6 +144,7 @@ fn test_parity_086e_next_steps() {
 /// PARITY-086f: Phase 5 final summary
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_086f_phase5_summary() {
     println!("PARITY-086f: Phase 5 Final Summary");
     println!("===================================");

--- a/crates/aprender-serve/src/gguf/tests/phase_thread_safe_cache.rs
+++ b/crates/aprender-serve/src/gguf/tests/phase_thread_safe_cache.rs
@@ -19,6 +19,7 @@ use crate::gguf::OwnedQuantizedModelCachedSync;
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_phase34_cached_sync_new() {
     let config = GGUFConfig {
         architecture: "llama".to_string(),
@@ -48,6 +49,7 @@ fn test_phase34_cached_sync_new() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_phase34_cached_sync_model_accessor() {
     let config = GGUFConfig {
         architecture: "llama".to_string(),
@@ -79,6 +81,7 @@ fn test_phase34_cached_sync_model_accessor() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_phase34_cached_sync_concurrent_model_access() {
     use std::sync::Arc;
     use std::thread;
@@ -127,6 +130,7 @@ fn test_phase34_cached_sync_concurrent_model_access() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_phase34_cached_sync_send_sync_bounds() {
     use std::sync::Arc;
 
@@ -164,6 +168,7 @@ fn test_phase34_cached_sync_send_sync_bounds() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_phase34_cached_sync_multiple_configs() {
     // Test with different architectures
     let configs = vec![
@@ -241,6 +246,7 @@ fn test_phase34_cached_sync_no_gpu_feature() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_phase34_cached_sync_rapid_access() {
     let config = GGUFConfig {
         architecture: "llama".to_string(),
@@ -271,6 +277,7 @@ fn test_phase34_cached_sync_rapid_access() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_phase34_cached_sync_thread_stress() {
     use std::sync::Arc;
     use std::thread;

--- a/crates/aprender-serve/src/gguf/tests/tests_02.rs
+++ b/crates/aprender-serve/src/gguf/tests/tests_02.rs
@@ -189,6 +189,7 @@ fn test_imp_106c_prefill_with_batch() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_imp_107a_gpu_batch_matmul_correctness() {
     // IMP-107a: Verify GPU batch matmul produces correct results
     // Uses HybridScheduler which routes to GPU for batch_size > 1
@@ -229,6 +230,7 @@ fn test_imp_107a_gpu_batch_matmul_correctness() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_imp_107b_forward_batch_gpu() {
     // IMP-107b: Verify forward_batch_gpu uses GPU matmul for batch ops
     let config = GGUFConfig {
@@ -283,6 +285,7 @@ fn test_imp_107b_forward_batch_gpu() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_imp_107c_gpu_crossover_decision() {
     // IMP-107c: Verify HybridScheduler makes correct GPU vs CPU decisions
     use crate::gpu::HybridScheduler;
@@ -338,6 +341,7 @@ fn cpu_matmul_reference(a: &[f32], b: &[f32], m: usize, k: usize, n: usize) -> V
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_imp_108a_batched_causal_attention_correctness() {
     // IMP-108a: Verify batched causal attention matches sequential computation
     let config = GGUFConfig {
@@ -402,6 +406,7 @@ fn test_imp_108a_batched_causal_attention_correctness() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_imp_108b_causal_mask_gpu() {
     // IMP-108b: Verify causal mask is correctly applied in GPU attention
     let config = GGUFConfig {

--- a/crates/aprender-serve/src/gguf/tests/tests_03.rs
+++ b/crates/aprender-serve/src/gguf/tests/tests_03.rs
@@ -20,6 +20,7 @@ use crate::gguf::GGUFConfig;
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_imp_109a_fused_dequant_matmul_correctness() {
     // IMP-109a: Verify fused dequant+matmul matches separate operations
     // Uses model's existing quantized weights to validate correctness
@@ -93,6 +94,7 @@ fn test_imp_109a_fused_dequant_matmul_correctness() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_imp_109b_fused_batch_matmul_gpu() {
     // IMP-109b: Verify fused batch matmul produces correct, deterministic results
     // Key optimization: dequantize weight once, reuse for all batch elements
@@ -207,6 +209,7 @@ fn test_imp_109b_fused_batch_matmul_gpu() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_imp_109c_fused_vs_separate_performance_baseline() {
     // IMP-109c: Validate fused kernel produces same results as separate dequant+matmul
     // This establishes correctness baseline before optimizing
@@ -287,6 +290,7 @@ fn test_imp_109c_fused_vs_separate_performance_baseline() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_imp_110a_parallel_heads_correctness() {
     // IMP-110a: Verify parallel multi-head attention matches sequential
     // Process all heads in a single batch dispatch instead of iterating
@@ -356,6 +360,7 @@ fn test_imp_110a_parallel_heads_correctness() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_imp_110b_batched_qkv_reshape() {
     // IMP-110b: Verify Q/K/V reshaping for batched head processing
     // Input: [seq_len, hidden_dim] -> [num_heads, seq_len, head_dim]
@@ -423,6 +428,7 @@ fn test_imp_110b_batched_qkv_reshape() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_imp_110c_parallel_batched_scores() {
     // IMP-110c: Verify batched Q@K^T scores computed correctly for all heads
     // Process all heads in single batched matmul

--- a/crates/aprender-serve/src/gguf/tests/tests_04.rs
+++ b/crates/aprender-serve/src/gguf/tests/tests_04.rs
@@ -20,6 +20,7 @@ use crate::gguf::{GGUFConfig, OwnedQuantizedModelCached};
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_imp_112a_cached_scheduler_initialization() {
     // IMP-112a: Verify cached scheduler initializes lazily and is reused
     // This tests that OwnedQuantizedModelCached provides scheduler caching
@@ -79,6 +80,7 @@ fn test_imp_112a_cached_scheduler_initialization() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_imp_112b_cached_matches_uncached() {
     // IMP-112b: Verify cached scheduler produces identical results to uncached
     //
@@ -146,6 +148,7 @@ fn test_imp_112b_cached_matches_uncached() {
 /// - Grid Y was (n+31)/32 but should be (m+31)/32 for rows
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_114_cuda_gemm_correctness() {
     let config = GGUFConfig {
         architecture: "test".to_string(),
@@ -194,6 +197,7 @@ fn test_parity_114_cuda_gemm_correctness() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_imp_112c_multiple_operations_same_scheduler() {
     // IMP-112c: Verify multiple different operations share the same scheduler
     let config = GGUFConfig {
@@ -245,6 +249,7 @@ fn test_imp_112c_multiple_operations_same_scheduler() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_imp_112d_cached_attention_matches_uncached() {
     // IMP-112d: Verify cached parallel attention matches uncached
     let config = GGUFConfig {

--- a/crates/aprender-serve/src/gguf/tests/tests_11.rs
+++ b/crates/aprender-serve/src/gguf/tests/tests_11.rs
@@ -31,6 +31,7 @@
 /// PARITY-055a: Throughput calculation methodology
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity055a_throughput_methodology() {
     println!("PARITY-055a: Throughput Calculation Methodology");
     println!("===============================================");
@@ -75,6 +76,7 @@ fn test_parity055a_throughput_methodology() {
 /// PARITY-055b: Benchmark configuration
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity055b_benchmark_config() {
     println!("PARITY-055b: Benchmark Configuration");
     println!("====================================");
@@ -120,6 +122,7 @@ fn test_parity055b_benchmark_config() {
 /// PARITY-055c: Latency vs throughput tradeoff
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity055c_latency_tradeoff() {
     println!("PARITY-055c: Latency vs Throughput Tradeoff");
     println!("==========================================");
@@ -171,6 +174,7 @@ fn test_parity055c_latency_tradeoff() {
 /// PARITY-055d: Concurrent batch estimation
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity055d_concurrent_estimation() {
     println!("PARITY-055d: Concurrent Batch Estimation");
     println!("========================================");
@@ -219,6 +223,7 @@ fn test_parity055d_concurrent_estimation() {
 /// PARITY-055e: Benchmark execution script
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity055e_benchmark_script() {
     println!("PARITY-055e: Benchmark Execution Script");
     println!("=======================================");
@@ -263,6 +268,7 @@ fn test_parity055e_benchmark_script() {
 /// PARITY-055f: Summary and M4 parity validation
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity055f_summary() {
     println!("PARITY-055f: Batch Throughput Benchmark Summary");
     println!("===============================================");
@@ -316,6 +322,7 @@ fn test_parity055f_summary() {
 /// PARITY-056a: Benchmark execution prerequisites
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity056a_benchmark_prerequisites() {
     println!("PARITY-056a: Benchmark Execution Prerequisites");
     println!("==============================================");
@@ -352,6 +359,7 @@ fn test_parity056a_benchmark_prerequisites() {
 /// PARITY-056b: Expected benchmark results
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity056b_expected_results() {
     println!("PARITY-056b: Expected Benchmark Results");
     println!("=======================================");
@@ -400,6 +408,7 @@ fn test_parity056b_expected_results() {
 /// PARITY-056c: Benchmark execution steps
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity056c_execution_steps() {
     println!("PARITY-056c: Benchmark Execution Steps");
     println!("======================================");

--- a/crates/aprender-serve/src/gguf/tests/tests_12.rs
+++ b/crates/aprender-serve/src/gguf/tests/tests_12.rs
@@ -25,6 +25,7 @@
 /// PARITY-070a: Problem analysis - dequantize-then-compute bottleneck
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity070a_problem_analysis() {
     println!("PARITY-070a: Dequantize-Then-Compute Bottleneck");
     println!("================================================");
@@ -71,6 +72,7 @@ fn test_parity070a_problem_analysis() {
 /// PARITY-070b: Target architecture - fused MMQ
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity070b_target_architecture() {
     println!("PARITY-070b: Fused MMQ Target Architecture");
     println!("==========================================");
@@ -116,6 +118,7 @@ fn test_parity070b_target_architecture() {
 /// PARITY-070c: INT8 dot product operations (DP4A)
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity070c_int8_operations() {
     println!("PARITY-070c: INT8 Dot Product Operations");
     println!("=========================================");
@@ -168,6 +171,7 @@ fn test_parity070c_int8_operations() {
 /// PARITY-070d: Q8 activation quantization
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity070d_activation_quantization() {
     println!("PARITY-070d: Q8 Activation Quantization");
     println!("=======================================");
@@ -217,6 +221,7 @@ fn test_parity070d_activation_quantization() {
 /// PARITY-070e: Fused Q4xQ8 kernel design
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity070e_fused_kernel_design() {
     println!("PARITY-070e: Fused Q4xQ8 Kernel Design");
     println!("======================================");
@@ -287,6 +292,7 @@ fn test_parity070e_fused_kernel_design() {
 /// PARITY-070f: Phase 3 implementation roadmap
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity070f_roadmap() {
     println!("PARITY-070f: Phase 3 Implementation Roadmap");
     println!("===========================================");
@@ -367,6 +373,7 @@ fn test_parity070f_roadmap() {
 /// PARITY-071a: Q8_0Block structure verification
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity071a_q8_block_struct() {
     use crate::quantize::Q8_0Block;
 
@@ -405,6 +412,7 @@ fn test_parity071a_q8_block_struct() {
 /// PARITY-071b: Q8_0Block::quantize() function
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity071b_quantize_function() {
     use crate::quantize::Q8_0Block;
 

--- a/crates/aprender-serve/src/gguf/tests/tests_12b.rs
+++ b/crates/aprender-serve/src/gguf/tests/tests_12b.rs
@@ -37,6 +37,7 @@
 /// PARITY-074e: Performance projection
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_074e_performance_projection() {
     println!("PARITY-074e: Performance Projection");
     println!("====================================");
@@ -94,6 +95,7 @@ fn test_parity_074e_performance_projection() {
 /// PARITY-074f: Integration summary
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_074f_integration_summary() {
     println!("PARITY-074f: CUDA Kernel Execution Summary");
     println!("==========================================");
@@ -154,6 +156,7 @@ fn test_parity_074f_integration_summary() {
 /// PARITY-075a: INT8 attention score quantization
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_075a_attention_score_quantization() {
     use crate::quantize::Q8_0Block;
 
@@ -214,6 +217,7 @@ fn test_parity_075a_attention_score_quantization() {
 /// PARITY-075b: INT8 Q×K^T computation
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_075b_int8_qk_computation() {
     use crate::quantize::Q8_0Block;
 
@@ -298,6 +302,7 @@ fn test_parity_075b_int8_qk_computation() {
 /// PARITY-075c: Memory bandwidth analysis for attention
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_075c_attention_bandwidth() {
     println!("PARITY-075c: Attention Memory Bandwidth Analysis");
     println!("=================================================");

--- a/crates/aprender-serve/src/gguf/tests/tests_13.rs
+++ b/crates/aprender-serve/src/gguf/tests/tests_13.rs
@@ -23,6 +23,7 @@
 /// PARITY-078a: Sequence parallelism
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_078a_sequence_parallelism() {
     println!("PARITY-078a: Sequence Parallelism");
     println!("==================================");
@@ -82,6 +83,7 @@ fn test_parity_078a_sequence_parallelism() {
 /// PARITY-078b: Batch parallelism
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_078b_batch_parallelism() {
     println!("PARITY-078b: Batch Parallelism");
     println!("===============================");
@@ -139,6 +141,7 @@ fn test_parity_078b_batch_parallelism() {
 /// PARITY-078c: Head parallelism
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_078c_head_parallelism() {
     println!("PARITY-078c: Head Parallelism");
     println!("==============================");
@@ -187,6 +190,7 @@ fn test_parity_078c_head_parallelism() {
 /// PARITY-078d: Work stealing for load balancing
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_078d_work_stealing() {
     println!("PARITY-078d: Work Stealing for Load Balancing");
     println!("==============================================");
@@ -243,6 +247,7 @@ fn test_parity_078d_work_stealing() {
 /// PARITY-078e: Split-K decomposition
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_078e_split_k_decomposition() {
     println!("PARITY-078e: Split-K Decomposition");
     println!("====================================");
@@ -302,6 +307,7 @@ fn test_parity_078e_split_k_decomposition() {
 /// PARITY-078f: Work partitioning summary
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_078f_work_partitioning_summary() {
     println!("PARITY-078f: Work Partitioning Summary");
     println!("=======================================");
@@ -338,6 +344,7 @@ fn test_parity_078f_work_partitioning_summary() {
 /// PARITY-079a: Softmax FLOP analysis
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_079a_softmax_flop_analysis() {
     println!("PARITY-079a: Softmax FLOP Analysis");
     println!("====================================");
@@ -399,6 +406,7 @@ fn test_parity_079a_softmax_flop_analysis() {
 /// PARITY-079b: Online softmax optimization
 #[test]
 #[cfg(feature = "cuda")]
+#[serial_test::serial]
 fn test_parity_079b_online_softmax() {
     println!("PARITY-079b: Online Softmax Optimization");
     println!("=========================================");

--- a/crates/aprender-serve/src/gguf/tests/tests_14.rs
+++ b/crates/aprender-serve/src/gguf/tests/tests_14.rs
@@ -37,6 +37,7 @@ use crate::gguf::{DequantizedFFNWeights, DequantizedWeightCache, QuantizedGenera
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity018a_dequantized_weight_cache_production() {
     use std::collections::HashMap;
     use std::sync::RwLock;
@@ -160,6 +161,7 @@ fn test_parity018a_dequantized_weight_cache_production() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity018b_batch_ffn_gpu_method() {
     use crate::gpu::HybridScheduler;
     use std::time::Instant;
@@ -281,6 +283,7 @@ fn test_parity018b_batch_ffn_gpu_method() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity018c_batch_generate_gpu_flow() {
     // Test the batch_generate_gpu flow without actual model
 
@@ -371,6 +374,7 @@ fn test_parity018c_batch_generate_gpu_flow() {
 
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity018d_integration_with_owned_quantized_model() {
     // Verify that OwnedQuantizedModelCachedSync has the necessary infrastructure
     // for GPU batch FFN integration

--- a/crates/aprender-serve/src/gguf/tests/tests_15.rs
+++ b/crates/aprender-serve/src/gguf/tests/tests_15.rs
@@ -22,6 +22,7 @@
 /// PARITY-026a: Verify flash_attention_tiled method exists and has correct signature
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity026a_flash_attention_exists() {
     println!("=== PARITY-026a: FlashAttention Method ===\n");
 
@@ -52,6 +53,7 @@ fn test_parity026a_flash_attention_exists() {
 /// PARITY-026b: FlashAttention memory savings analysis
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity026b_flash_attention_memory_savings() {
     println!("=== PARITY-026b: FlashAttention Memory Savings ===\n");
 
@@ -98,6 +100,7 @@ fn test_parity026b_flash_attention_memory_savings() {
 /// PARITY-026c: FlashAttention numerical equivalence
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity026c_flash_attention_numerical() {
     println!("=== PARITY-026c: FlashAttention Numerical Equivalence ===\n");
 
@@ -146,6 +149,7 @@ fn test_parity026c_flash_attention_numerical() {
 /// PARITY-026d: Batch FlashAttention throughput analysis
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity026d_batch_flash_attention_throughput() {
     println!("=== PARITY-026d: Batch FlashAttention Throughput ===\n");
 
@@ -196,6 +200,7 @@ fn test_parity026d_batch_flash_attention_throughput() {
 /// PARITY-026e: FlashAttention integration with forward pass
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity026e_flash_attention_integration() {
     println!("=== PARITY-026e: FlashAttention Integration ===\n");
 
@@ -248,6 +253,7 @@ fn test_parity026e_flash_attention_integration() {
 /// PARITY-027a: Verify FlashAttention threshold in forward pass
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity027a_flash_attention_threshold() {
     println!("=== PARITY-027a: FlashAttention Threshold ===\n");
 
@@ -282,6 +288,7 @@ fn test_parity027a_flash_attention_threshold() {
 /// PARITY-027b: Memory savings at threshold boundary
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity027b_threshold_memory_savings() {
     println!("=== PARITY-027b: Memory Savings at Threshold ===\n");
 
@@ -335,6 +342,7 @@ fn test_parity027b_threshold_memory_savings() {
 /// PARITY-027c: FlashAttention integration in forward pass structure
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity027c_forward_pass_integration() {
     println!("=== PARITY-027c: Forward Pass Integration ===\n");
 
@@ -369,6 +377,7 @@ fn test_parity027c_forward_pass_integration() {
 /// PARITY-027d: Hybrid dispatch efficiency analysis
 #[test]
 #[cfg(feature = "gpu")]
+#[serial_test::serial]
 fn test_parity027d_hybrid_dispatch_efficiency() {
     println!("=== PARITY-027d: Hybrid Dispatch Efficiency ===\n");
 


### PR DESCRIPTION
## A driver-level concurrency hang on GB10 aarch64 (not a slow test)

A `gguf::tests` worker pegged a CPU thread at 99.9% for **2h44m** on gx10 (GB10 Blackwell aarch64), blocking the serve `--features cuda` suite. Root-caused to TWO coupled, concurrency-only, GB10-specific driver defects (x86 CI never sees them; single-threaded passes):
1. **SEGFAULT:** concurrent `wgpu::Instance::default()` each enumerate ~11 Vulkan ICDs; the Mesa **freedreno "Turnip"** ICD (irrelevant on this NVIDIA box) fails to open `/dev/dri/renderD128` and its background threads crash when several instances enumerate it at once.
2. **THE HANG:** every libtest worker that touched the GPU runs the NVIDIA `libnvidia-eglcore` TLS destructor (`__nptl_deallocate_tsd`) on thread exit; under the parallel exit storm these spin forever at 100% userspace CPU on a driver-internal priority-inheritance futex (gdb: 27 threads parked in `nptl_deallocate_tsd`).

## Fix (54 files, +414/-7)
- **`aprender-compute`**: a process-global shared `wgpu::Instance` (`OnceLock`, cheap to clone) reused by every adapter/device enumeration (`device::new`/`is_available`/`list_adapters`, `pool::all`, monitor backends) so the broken ICD is enumerated **once**; + a `DEVICE_INIT_LOCK` serializing native device creation. Free on healthy GPUs (off the compute hot path); composes with the merged probe-memoization (#2059).
- **`aprender-serve gguf::tests`**: `#[serial]` on the 351 GPU-feature (`gpu`/`cuda`) tests — the documented purpose of the existing `serial_test` dev-dep — so GPU access (and GPU-touching thread exits) happen one at a time, killing the TLS-cleanup exit storm.

## Verified (gx10 GB10 aarch64)
- Before: hang >600s (timeout; matches the 2h44m SIGTERM) + a separate SIGSEGV at lower thread counts.
- After: `1018 passed; 0 failed; 2 ignored` in **~15s**, stable across 3 parallel + 1 single-threaded runs (`--features cuda`, default parallelism nproc=20).

Real driver-level bug (NVIDIA 590.48.01 EGL TLS + Mesa freedreno on GB10 aarch64); the code makes aprender robust to it. CI is blind to it (x86, no freedreno ICD).

🤖 Generated with [Claude Code](https://claude.com/claude-code)