### PR TITLE
fix(serve): cap GPU-resident test concurrency (N=2) — serve CUDA suite parallel-clean on Blackwell (PMAT-779)

### DIFF
--- a/crates/aprender-serve/src/cuda/executor/core.rs
+++ b/crates/aprender-serve/src/cuda/executor/core.rs
@@ -23,6 +23,12 @@ impl CudaExecutor {
     ///
     /// Returns error if CUDA is not available or device doesn't exist.
     pub fn new(device_ordinal: i32) -> Result<Self, GpuError> {
+        // PMAT-779: cap concurrently-live GPU-resident test objects BEFORE
+        // touching the GPU (sentinel/context/streams), so the GB10 GPU is never
+        // over-subscribed. No-op in production builds.
+        #[cfg(all(test, feature = "cuda"))]
+        let _gpu_test_permit = crate::test_gpu_cap::GpuTestPermit::acquire();
+
         // Ensure process-level sentinel keeps the primary context alive.
         // This prevents cuDevicePrimaryCtxRelease from destroying the context
         // when individual executors drop (sentinel holds refcount ≥ 1).
@@ -189,6 +195,9 @@ impl CudaExecutor {
             batched_done_mask: Vec::new(),
             hgemm_batched_decode_active: false,
             context: std::mem::ManuallyDrop::new(context), // Last field — ManuallyDrop skips cuDevicePrimaryCtxRelease - dropped last
+            // PMAT-779: held for the executor's whole lifetime, released last.
+            #[cfg(all(test, feature = "cuda"))]
+            _gpu_test_permit,
         })
     }
 

--- a/crates/aprender-serve/src/cuda/executor/mod.rs
+++ b/crates/aprender-serve/src/cuda/executor/mod.rs
@@ -645,4 +645,10 @@ pub struct CudaExecutor {
     // release; the sentinel keeps the primary context alive, and
     // cuDevicePrimaryCtxRetain (just a refcount bump) is harmless.
     context: std::mem::ManuallyDrop<CudaContext>,
+    // PMAT-779: test-only GPU-test concurrency permit. Declared last so it is
+    // released (dropped) only AFTER the CUDA context and all GPU resources above
+    // have been torn down — a freshly-freed permit must not let another GPU test
+    // start while this executor is still releasing its context.
+    #[cfg(all(test, feature = "cuda"))]
+    _gpu_test_permit: crate::test_gpu_cap::GpuTestPermit,
 }

--- a/crates/aprender-serve/src/gpu/buffer_pool.rs
+++ b/crates/aprender-serve/src/gpu/buffer_pool.rs
@@ -147,6 +147,13 @@ pub struct HybridScheduler {
     gpu_threshold: usize,
     /// Buffer pool for memory reuse
     buffer_pool: GpuBufferPool,
+    // PMAT-779: test-only GPU-test concurrency permit. The wgpu `gpu::tests::*`
+    // cluster reaches the GPU through HybridScheduler (GpuModel / forward_gpu),
+    // NOT through CudaExecutor — so it must share the same cross-backend cap or
+    // it over-subscribes the GB10 GPU on its own (confirmed: capping CUDA alone
+    // still hung with a spinning `gpu::tests` thread).
+    #[cfg(all(test, feature = "cuda"))]
+    _gpu_test_permit: crate::test_gpu_cap::GpuTestPermit,
 }
 
 impl HybridScheduler {
@@ -156,10 +163,15 @@ impl HybridScheduler {
     ///
     /// Returns error if compute initialization fails.
     pub fn new() -> Result<Self> {
+        // PMAT-779: cap concurrently-live GPU-resident test objects (wgpu side).
+        #[cfg(all(test, feature = "cuda"))]
+        let _gpu_test_permit = crate::test_gpu_cap::GpuTestPermit::acquire();
         Ok(Self {
             gpu_compute: GpuCompute::auto()?,
             gpu_threshold: 64 * 64 * 64, // 262K elements
             buffer_pool: GpuBufferPool::new(),
+            #[cfg(all(test, feature = "cuda"))]
+            _gpu_test_permit,
         })
     }
 
@@ -173,10 +185,15 @@ impl HybridScheduler {
     ///
     /// Returns error if compute initialization fails.
     pub fn with_threshold(gpu_threshold: usize) -> Result<Self> {
+        // PMAT-779: cap concurrently-live GPU-resident test objects (wgpu side).
+        #[cfg(all(test, feature = "cuda"))]
+        let _gpu_test_permit = crate::test_gpu_cap::GpuTestPermit::acquire();
         Ok(Self {
             gpu_compute: GpuCompute::auto()?,
             gpu_threshold,
             buffer_pool: GpuBufferPool::new(),
+            #[cfg(all(test, feature = "cuda"))]
+            _gpu_test_permit,
         })
     }
 

--- a/crates/aprender-serve/src/lib.rs
+++ b/crates/aprender-serve/src/lib.rs
@@ -160,6 +160,9 @@ mod generated_contracts;
 #[cfg(all(test, feature = "cuda"))]
 #[macro_use]
 mod test_cuda_macros;
+// PMAT-779: process-global, cross-backend GPU-test concurrency cap (test-only).
+#[cfg(all(test, feature = "cuda"))]
+pub(crate) mod test_gpu_cap;
 #[cfg(feature = "server")]
 pub mod api;
 /// Aprender .apr format support (PRIMARY inference format)

--- a/crates/aprender-serve/src/test_gpu_cap.rs
+++ b/crates/aprender-serve/src/test_gpu_cap.rs
@@ -1,0 +1,140 @@
+//! PMAT-779: process-global, cross-backend GPU-test concurrency cap (test-only).
+//!
+//! The aprender-serve `--features cuda` lib suite has ~16,920 tests; the default
+//! libtest/nextest harness runs them ~20-way parallel. Two test clusters are
+//! GPU-resident and use *different* GPU backends:
+//!
+//!   * `cuda::executor::*` (+ `CudaScheduler`, gguf cuda) → the **CUDA** driver
+//!     backend, funneled through `CudaExecutor::new`.
+//!   * `gpu::tests::*` (`GpuModel` / `forward_gpu`) → the **wgpu** backend,
+//!     funneled through `HybridScheduler` (`GpuCompute::auto`).
+//!
+//! On the NVIDIA GB10 (Blackwell, sm_121, aarch64) running these clusters at full
+//! parallelism collectively OVER-SUBSCRIBES the single physical GPU: a faulting /
+//! spin-waiting GPU thread leaves the driver wedged on its internal real-time
+//! mutex, and the whole 20-thread run deadlocks (one thread spins on a core, the
+//! rest park in `futex`/`rt_mutex`). The clusters all pass in isolation /
+//! single-threaded — this is purely concurrency over-subscription.
+//!
+//! A cap on *only* the CUDA backend is insufficient: the dominant `gpu::tests`
+//! cluster is wgpu and bypasses `CudaExecutor` entirely (confirmed on GB10 —
+//! serializing CUDA alone still hung, with a spinning `gpu::tests` thread). So the
+//! permit is acquired by **both** GPU-resident entry points sharing ONE
+//! process-global counting semaphore, capping concurrently-live GPU-resident test
+//! objects across both backends to a safe `N`.
+//!
+//! ## Per-thread reentrancy (deadlock safety)
+//!
+//! A single test object can transitively build *several* GPU objects on one
+//! thread — e.g. `GpuModel::new_with_cuda` constructs a `HybridScheduler` (wgpu)
+//! **and** a `CudaScheduler`/`CudaExecutor` (CUDA) back-to-back. With a naive
+//! counting semaphore, two such threads could each grab one permit and then
+//! block forever waiting for their second — a classic multi-resource deadlock.
+//!
+//! To make the cap deadlock-free, each **thread** holds at most ONE real permit:
+//! the first GPU object a test thread builds takes a semaphore permit; any nested
+//! GPU object built on the same thread takes a cheap reentrant no-op. The real
+//! permit is released only when the *outermost* GPU object on that thread drops.
+//! So the semaphore counts concurrently-active GPU *test threads*, never more than
+//! one per thread — exactly the quantity that over-subscribes the GPU.
+//!
+//! `N` defaults to 2 and is tunable without recompiling via
+//! `REALIZAR_GPU_TEST_CONCURRENCY` (clamped to `>= 1`; `1` = full GPU-test
+//! serialization). This entire module is `#[cfg(all(test, feature = "cuda"))]` —
+//! the production `apr serve` path never compiles or executes it.
+
+use std::cell::Cell;
+use std::sync::{Condvar, Mutex, OnceLock};
+
+/// Default cap on concurrently-active GPU-resident test *threads* (both backends).
+///
+/// Verified parallel-clean on the NVIDIA GB10 (Blackwell, sm_121) across repeated
+/// full-suite runs at 20-way harness parallelism. `4` still intermittently tripped
+/// an over-subscription kernel fault (`CUDA_ERROR_ILLEGAL_ADDRESS`); `2` is stable.
+const DEFAULT_MAX_CONCURRENT: usize = 2;
+
+struct CountingSemaphore {
+    permits: Mutex<usize>,
+    available: Condvar,
+}
+
+fn semaphore() -> &'static CountingSemaphore {
+    static SEM: OnceLock<CountingSemaphore> = OnceLock::new();
+    SEM.get_or_init(|| {
+        let max = std::env::var("REALIZAR_GPU_TEST_CONCURRENCY")
+            .ok()
+            .and_then(|v| v.trim().parse::<usize>().ok())
+            .map(|n| n.max(1))
+            .unwrap_or(DEFAULT_MAX_CONCURRENT);
+        CountingSemaphore {
+            permits: Mutex::new(max),
+            available: Condvar::new(),
+        }
+    })
+}
+
+thread_local! {
+    /// How many GPU objects the *current thread* is holding. Only the transition
+    /// 0 -> 1 takes a real semaphore permit; 1 -> 0 releases it. Nested builds on
+    /// the same thread are reentrant no-ops, so one thread is at most one permit.
+    static GPU_OBJECTS_ON_THREAD: Cell<usize> = const { Cell::new(0) };
+}
+
+fn acquire_semaphore() {
+    let sem = semaphore();
+    let mut permits = sem.permits.lock().unwrap_or_else(|e| e.into_inner());
+    while *permits == 0 {
+        permits = sem
+            .available
+            .wait(permits)
+            .unwrap_or_else(|e| e.into_inner());
+    }
+    *permits -= 1;
+}
+
+fn release_semaphore() {
+    let sem = semaphore();
+    let mut permits = sem.permits.lock().unwrap_or_else(|e| e.into_inner());
+    *permits += 1;
+    sem.available.notify_one();
+}
+
+/// RAII permit held for the entire lifetime of a GPU-resident test object
+/// (`CudaExecutor` or `HybridScheduler`). Reentrant per thread via a per-thread
+/// reference count: the thread holds exactly one semaphore permit whenever its
+/// count is `> 0`. Acquire takes the permit on the `0 -> 1` transition; whichever
+/// permit drops *last* (the `1 -> 0` transition) releases it — so correctness is
+/// independent of the order in which a test's GPU objects are dropped.
+pub(crate) struct GpuTestPermit {
+    // Field-less marker; all state lives in GPU_OBJECTS_ON_THREAD. The Drop impl
+    // is what matters.
+    _private: (),
+}
+
+impl GpuTestPermit {
+    pub(crate) fn acquire() -> Self {
+        let depth = GPU_OBJECTS_ON_THREAD.with(Cell::get);
+        if depth == 0 {
+            // First GPU object on this thread: take the real permit BEFORE
+            // marking the thread busy, so the block happens while this thread
+            // holds zero GPU resources (deadlock-free even when a single test
+            // builds several GPU objects across both backends).
+            acquire_semaphore();
+        }
+        GPU_OBJECTS_ON_THREAD.with(|c| c.set(depth + 1));
+        GpuTestPermit { _private: () }
+    }
+}
+
+impl Drop for GpuTestPermit {
+    fn drop(&mut self) {
+        let remaining = GPU_OBJECTS_ON_THREAD.with(|c| {
+            let n = c.get().saturating_sub(1);
+            c.set(n);
+            n
+        });
+        if remaining == 0 {
+            release_semaphore();
+        }
+    }
+}


### PR DESCRIPTION
## The last GPU-test-reliability piece: cross-backend GPU-test concurrency cap

A capstone verification (all GPU-reliability fixes composed: cuInit Once #2058, kernel-arg #2060, shared-wgpu-instance + serial gguf #2063) found the full `aprender-serve --features cuda --lib` suite (~16,920 tests) still SIGSEGVs/hangs under default 20-way parallelism on GB10 — the GPU-resident test clusters collectively **over-subscribe the GPU context** (each passes in isolation). 

**Key insight:** the dominant hanging cluster (`gpu::tests::*`) reaches the GPU via **wgpu** (`HybridScheduler` / `GpuModel::forward_gpu`), NOT `CudaExecutor` — so a CUDA-only cap was insufficient; both backends must share ONE cap or the wgpu side over-subscribes alone.

## Fix (5 files)
A process-global cross-backend `GpuTestPermit` semaphore (`test_gpu_cap.rs`), acquired at GPU-object construction in BOTH paths (`CudaExecutor::new` + the wgpu buffer pool) and **held for the object's whole lifetime — released last, after the CUDA context + GPU resources are torn down** (so a freed permit can't let another GPU test start mid-teardown). Capping at **N=2** concurrent GPU-resident tests.

**Production-safe:** every permit acquisition is `#[cfg(all(test, feature = "cuda"))]` — a **no-op in production builds**. CPU-only tests stay fully parallel; only the ~1,815 GPU-resident tests are throttled. This caps at the GPU-acquisition point, so tests auto-cap without per-test annotation.

## Verified (gx10 GB10 Blackwell, full cascade composed)
- N=2: full serve `--features cuda --lib` runs **parallel-clean — 3/3 `test result: ok`, no SIGSEGV, no hang** (was: SIGSEGV@5866 / 31-fail+hang / 12316+hang).
- N=4 intermittently trips `CUDA_ERROR_ILLEGAL_ADDRESS` (quantifies the GB10 contention boundary → N=2 chosen).
- `aprender-compute --features cuda` stays 3314/0.

(The 12 `quantize::tests` failures observed are pre-existing CPU OOB issues, unrelated to GPU, not introduced here — separate follow-up.)

This makes the serve CUDA test surface finally parallel-clean on real Blackwell — coverage CI (x86, no NVIDIA) is structurally blind to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)