### PR TITLE
fix(cuda): Q4_1 GPU GEMV interleaved-nibble layout bug — legacy-quant GGUF now runs on GPU (PMAT-782)

### DIFF
--- a/crates/aprender-serve/src/cuda/executor/q8_gemv_tests.rs
+++ b/crates/aprender-serve/src/cuda/executor/q8_gemv_tests.rs
@@ -317,4 +317,191 @@ mod tests {
             exec.batched_q6k_gemv_into(weight_buf.as_ptr(), &input_buf, &output_buf, m, n, k);
         let _ = result;
     }
+
+    // ========================================================================
+    // PMAT-782: Legacy-quant GPU↔CPU parity (GGML interleaved nibble layout)
+    //
+    // GGML packs Q4_0/Q4_1/Q5_0 nibbles INTERLEAVED: byte j (0..16) holds value
+    // j in its LOW nibble and value j+16 in its HIGH nibble (see
+    // dequantize_row_q5_0 in ggml-quants.c). The GPU kernels previously assumed
+    // CONSECUTIVE packing (byte = tid/2, low/high = tid&1), so every value index
+    // ≥1 mapped to the wrong nibble → garbage logits. These tests build real
+    // GGML-layout blocks and assert the GPU GEMV matches the CPU dequant
+    // reference that already produces coherent output.
+    // ========================================================================
+
+    /// Build a single-row GGML-spec Q4_0 weight: `n=1`, `k` elements.
+    /// Returns (raw_bytes, dequantized_f32_row).
+    fn ggml_q4_0_row(k: usize, seed: u32) -> (Vec<u8>, Vec<f32>) {
+        use half::f16;
+        let nb = k / 32;
+        let mut data = Vec::with_capacity(nb * 18);
+        for b in 0..nb {
+            let d = 0.05 * (b as f32 + 1.0);
+            data.extend_from_slice(&f16::from_f32(d).to_le_bytes());
+            // qs[j] low nibble = value j, high nibble = value j+16
+            for j in 0..16 {
+                let v_lo = ((b as u32 * 7 + j as u32 * 3 + seed) % 16) as u8;
+                let v_hi = ((b as u32 * 11 + j as u32 * 5 + seed + 1) % 16) as u8;
+                data.push(v_lo | (v_hi << 4));
+            }
+        }
+        let row = crate::quantize::dequantize_q4_0(&data).unwrap();
+        (data, row)
+    }
+
+    /// Build a single-row GGML-spec Q4_1 weight: `n=1`, `k` elements.
+    fn ggml_q4_1_row(k: usize, seed: u32) -> (Vec<u8>, Vec<f32>) {
+        use half::f16;
+        let nb = k / 32;
+        let mut data = Vec::with_capacity(nb * 20);
+        for b in 0..nb {
+            let d = 0.05 * (b as f32 + 1.0);
+            let m = -0.3 * (b as f32 + 1.0);
+            data.extend_from_slice(&f16::from_f32(d).to_le_bytes());
+            data.extend_from_slice(&f16::from_f32(m).to_le_bytes());
+            // qs[j] low nibble = value j, high nibble = value j+16
+            for j in 0..16 {
+                let v_lo = ((b as u32 * 7 + j as u32 * 3 + seed) % 16) as u8;
+                let v_hi = ((b as u32 * 11 + j as u32 * 5 + seed + 1) % 16) as u8;
+                data.push(v_lo | (v_hi << 4));
+            }
+        }
+        let row = crate::quantize::dequantize_q4_1(&data).unwrap();
+        (data, row)
+    }
+
+    /// Build a single-row GGML-spec Q5_0 weight: `n=1`, `k` elements.
+    fn ggml_q5_0_row(k: usize, seed: u32) -> (Vec<u8>, Vec<f32>) {
+        use half::f16;
+        let nb = k / 32;
+        let mut data = Vec::with_capacity(nb * 22);
+        for b in 0..nb {
+            let d = 0.05 * (b as f32 + 1.0);
+            data.extend_from_slice(&f16::from_f32(d).to_le_bytes());
+            // qh: bit v = high (5th) bit of value v
+            let qh: u32 = 0x1357_9BDF_u32.wrapping_mul(b as u32 + 1).wrapping_add(seed);
+            data.extend_from_slice(&qh.to_le_bytes());
+            for j in 0..16 {
+                let v_lo = ((b as u32 * 7 + j as u32 * 3 + seed) % 16) as u8;
+                let v_hi = ((b as u32 * 11 + j as u32 * 5 + seed + 1) % 16) as u8;
+                data.push(v_lo | (v_hi << 4));
+            }
+        }
+        let row = crate::quantize::dequantize_q5_0(&data).unwrap();
+        (data, row)
+    }
+
+    fn cpu_dot(row: &[f32], x: &[f32]) -> f32 {
+        row.iter().zip(x.iter()).map(|(w, v)| w * v).sum()
+    }
+
+    #[test]
+    fn test_q4_0_gemv_matches_cpu_ggml_layout() {
+        let Some(mut exec) = create_executor() else {
+            return;
+        };
+        let k = 256usize;
+        let n = 4usize;
+        let x: Vec<f32> = (0..k).map(|i| (i as f32) * 0.013 - 1.0).collect();
+        // Build n independent rows, concatenate weights row-major.
+        let mut weights = Vec::new();
+        let mut expected = vec![0.0f32; n];
+        for (r, exp) in expected.iter_mut().enumerate() {
+            let (w, row) = ggml_q4_0_row(k, r as u32 + 1);
+            weights.extend_from_slice(&w);
+            *exp = cpu_dot(&row, &x);
+        }
+        let weight_buf = GpuBuffer::from_host(&exec.context, &weights).unwrap();
+        let input_buf = GpuBuffer::from_host(&exec.context, &x).unwrap();
+        let out = vec![0.0f32; n];
+        let output_buf = GpuBuffer::from_host(&exec.context, &out).unwrap();
+        exec.q4_0_gemv_into(weight_buf.as_ptr(), &input_buf, &output_buf, n as u32, k as u32)
+            .expect("q4_0 gemv");
+        exec.stream.synchronize().unwrap();
+        let mut got = vec![0.0f32; n];
+        output_buf.copy_to_host(&mut got).unwrap();
+        for r in 0..n {
+            let diff = (got[r] - expected[r]).abs();
+            let tol = 1e-2 * expected[r].abs().max(1.0);
+            assert!(
+                diff <= tol,
+                "Q4_0 row {r}: GPU {} vs CPU {} (diff {diff} > tol {tol})",
+                got[r],
+                expected[r]
+            );
+        }
+    }
+
+    #[test]
+    fn test_q4_1_gemv_matches_cpu_ggml_layout() {
+        let Some(mut exec) = create_executor() else {
+            return;
+        };
+        let k = 256usize;
+        let n = 4usize;
+        let x: Vec<f32> = (0..k).map(|i| (i as f32) * 0.009 - 0.5).collect();
+        let mut weights = Vec::new();
+        let mut expected = vec![0.0f32; n];
+        for (r, exp) in expected.iter_mut().enumerate() {
+            let (w, row) = ggml_q4_1_row(k, r as u32 + 2);
+            weights.extend_from_slice(&w);
+            *exp = cpu_dot(&row, &x);
+        }
+        let weight_buf = GpuBuffer::from_host(&exec.context, &weights).unwrap();
+        let input_buf = GpuBuffer::from_host(&exec.context, &x).unwrap();
+        let out = vec![0.0f32; n];
+        let output_buf = GpuBuffer::from_host(&exec.context, &out).unwrap();
+        exec.q4_1_gemv_into(weight_buf.as_ptr(), &input_buf, &output_buf, n as u32, k as u32)
+            .expect("q4_1 gemv");
+        exec.stream.synchronize().unwrap();
+        let mut got = vec![0.0f32; n];
+        output_buf.copy_to_host(&mut got).unwrap();
+        for r in 0..n {
+            let diff = (got[r] - expected[r]).abs();
+            let tol = 1e-2 * expected[r].abs().max(1.0);
+            assert!(
+                diff <= tol,
+                "Q4_1 row {r}: GPU {} vs CPU {} (diff {diff} > tol {tol})",
+                got[r],
+                expected[r]
+            );
+        }
+    }
+
+    #[test]
+    fn test_q5_0_gemv_matches_cpu_ggml_layout() {
+        let Some(mut exec) = create_executor() else {
+            return;
+        };
+        let k = 256usize;
+        let n = 4usize;
+        let x: Vec<f32> = (0..k).map(|i| (i as f32) * 0.011 - 0.7).collect();
+        let mut weights = Vec::new();
+        let mut expected = vec![0.0f32; n];
+        for (r, exp) in expected.iter_mut().enumerate() {
+            let (w, row) = ggml_q5_0_row(k, r as u32 + 3);
+            weights.extend_from_slice(&w);
+            *exp = cpu_dot(&row, &x);
+        }
+        let weight_buf = GpuBuffer::from_host(&exec.context, &weights).unwrap();
+        let input_buf = GpuBuffer::from_host(&exec.context, &x).unwrap();
+        let out = vec![0.0f32; n];
+        let output_buf = GpuBuffer::from_host(&exec.context, &out).unwrap();
+        exec.q5_0_gemv_into(weight_buf.as_ptr(), &input_buf, &output_buf, n as u32, k as u32)
+            .expect("q5_0 gemv");
+        exec.stream.synchronize().unwrap();
+        let mut got = vec![0.0f32; n];
+        output_buf.copy_to_host(&mut got).unwrap();
+        for r in 0..n {
+            let diff = (got[r] - expected[r]).abs();
+            let tol = 1e-2 * expected[r].abs().max(1.0);
+            assert!(
+                diff <= tol,
+                "Q5_0 row {r}: GPU {} vs CPU {} (diff {diff} > tol {tol})",
+                got[r],
+                expected[r]
+            );
+        }
+    }
 }

--- a/crates/aprender-serve/src/cuda/kernels_generate_gemm_cuda.rs
+++ b/crates/aprender-serve/src/cuda/kernels_generate_gemm_cuda.rs
@@ -80,7 +80,7 @@ impl CudaKernels {
             KernelType::Q8_0Gemv { k, n } => Q8_0GemvKernel::new(*k, *n).emit_ptx_for_target(target),
             KernelType::Q5_0Gemv { k, n } => generate_q5_0_candle_ptx(*k, *n),
             KernelType::Q4_0Gemv { k, n } => generate_q4_0_candle_ptx(*k, *n),
-            KernelType::Q4_1Gemv { k, n } => Q4_1GemvKernel::new(*k, *n).emit_ptx_for_target(target),
+            KernelType::Q4_1Gemv { k, n } => generate_q4_1_candle_ptx(*k, *n),
             _ => return None,
         };
         Some(ptx)

--- a/crates/aprender-serve/src/cuda/layout.rs
+++ b/crates/aprender-serve/src/cuda/layout.rs
@@ -170,6 +170,175 @@ $L_exit:
     )
 }
 
+/// PMAT-782 FIX: Generate Q4_1 GEMV PTX with correct candle (GGML) layout.
+///
+/// The GGUF Q4_1 format uses the same interleaved "candle layout" as Q4_0:
+/// - 16 bytes contain 32 nibbles for 32 weights
+/// - Low nibbles (byte & 0x0F) map to positions 0-15
+/// - High nibbles (byte >> 4) map to positions 16-31
+///
+/// Q4_1 differs from Q4_0 only in dequantization: it is AFFINE, `val = d*nibble + m`
+/// (a per-block fp16 min `m` at byte offset 2), with NO `- 8` centering. The block is
+/// 20 bytes: `d` (fp16 @0) + `m` (fp16 @2) + 16 packed nibble bytes (@4).
+///
+/// The trueno `Q4_1GemvKernel` incorrectly used CONSECUTIVE layout (byte = tid/2,
+/// nibble = tid&1), so every value index ≥1 mapped to the wrong nibble → garbage
+/// logits for any Q4_1 tensor (e.g. Qwen2-0.5B FFN-down). This is the same defect
+/// class BUG-GGUF-001/002 fixed for Q4_0/Q5_0; Q4_1 was simply never routed to a
+/// candle generator. This function generates correct PTX for GGUF Q4_1 weights.
+fn generate_q4_1_candle_ptx(k: u32, n: u32) -> String {
+    // k and n are used for grid size configuration in the caller, not embedded in PTX
+    let _ = (k, n);
+
+    // Q4_1 block: 2 bytes (d fp16) + 2 bytes (m fp16) + 16 bytes (qs) = 20 bytes
+    // Note: num_blocks is computed dynamically in PTX from k_dim parameter
+    String::from(
+        r"
+.version 7.5
+.target sm_70
+.address_size 64
+
+// PMAT-782 FIX: Q4_1 GEMV with candle nibble layout (affine dequant d*q + m)
+// Each warp (32 threads) computes one output element
+// Thread 0-15: use low nibbles from bytes 0-15
+// Thread 16-31: use high nibbles from bytes 0-15
+.visible .entry q4_1_gemv_warp_reduce(
+    .param .u64 y_ptr,
+    .param .u64 w_ptr,
+    .param .u64 x_ptr,
+    .param .u32 k_dim,
+    .param .u32 n_dim
+)
+{
+    .reg .u32 %r<32>;
+    .reg .u64 %rd<16>;
+    .reg .f32 %f<16>;
+    .reg .b16 %h<4>;
+    .reg .pred %p<8>;
+
+    // r0=tid, r1=ctaid, r2=n_dim, r3=k_dim
+    mov.u32 %r0, %tid.x;
+    mov.u32 %r1, %ctaid.x;
+
+    ld.param.u32 %r2, [n_dim];
+    ld.param.u32 %r3, [k_dim];
+    ld.param.u64 %rd0, [y_ptr];
+    ld.param.u64 %rd1, [w_ptr];
+    ld.param.u64 %rd2, [x_ptr];
+
+    // Bounds check: if ctaid >= n_dim, exit
+    setp.ge.u32 %p0, %r1, %r2;
+    @%p0 bra $L_exit;
+
+    // f0 = accumulator
+    mov.f32 %f0, 0f00000000;
+
+    // r4 = num_blocks = ceil(k_dim / 32)
+    add.u32 %r4, %r3, 31;
+    shr.u32 %r4, %r4, 5;
+
+    // rd3 = row_base = w_ptr + ctaid * num_blocks * 20
+    mul.lo.u32 %r5, %r4, 20;
+    mul.wide.u32 %rd3, %r1, %r5;
+    add.u64 %rd3, %rd1, %rd3;
+
+    // r6 = blk_idx (loop counter)
+    mov.u32 %r6, 0;
+
+$L_blk_loop:
+    setp.ge.u32 %p1, %r6, %r4;
+    @%p1 bra $L_blk_loop_end;
+
+    // rd4 = blk_addr = row_base + blk_idx * 20
+    mul.wide.u32 %rd4, %r6, 20;
+    add.u64 %rd4, %rd3, %rd4;
+
+    // f1 = scale d (fp16 at offset 0)
+    ld.global.b16 %h0, [%rd4];
+    cvt.f32.f16 %f1, %h0;
+
+    // f4 = min m (fp16 at offset 2)
+    add.u64 %rd5, %rd4, 2;
+    ld.global.b16 %h1, [%rd5];
+    cvt.f32.f16 %f4, %h1;
+
+    // rd6 = qs_base = blk_addr + 4
+    add.u64 %rd6, %rd4, 4;
+
+    // CANDLE LAYOUT:
+    // Thread 0-15 read bytes 0-15 (low nibbles -> positions 0-15)
+    // Thread 16-31 read bytes 0-15 (high nibbles -> positions 16-31)
+    // r8 = byte_idx = tid < 16 ? tid : tid - 16
+    setp.ge.u32 %p2, %r0, 16;
+    mov.u32 %r8, %r0;
+    @%p2 sub.u32 %r8, %r0, 16;
+
+    // Load byte from qs[byte_idx]
+    cvt.u64.u32 %rd7, %r8;
+    add.u64 %rd7, %rd6, %rd7;
+    ld.global.u8 %r9, [%rd7];
+
+    // r10 = nibble value
+    // Threads 0-15: low nibble (byte & 0xF)
+    // Threads 16-31: high nibble (byte >> 4)
+    mov.u32 %r10, %r9;
+    @%p2 shr.u32 %r10, %r9, 4;
+    and.b32 %r10, %r10, 15;
+
+    // Q4_1 affine dequant: f2 = d * nibble + m (no centering)
+    cvt.rn.f32.u32 %f2, %r10;
+    fma.rn.f32 %f2, %f1, %f2, %f4;
+
+    // r12 = x_idx = blk_idx * 32 + tid
+    shl.b32 %r12, %r6, 5;
+    add.u32 %r12, %r12, %r0;
+
+    // Bounds check for last block
+    setp.ge.u32 %p3, %r12, %r3;
+    @%p3 bra $L_skip_mul;
+
+    // f3 = x[x_idx]
+    cvt.u64.u32 %rd8, %r12;
+    shl.b64 %rd8, %rd8, 2;
+    add.u64 %rd8, %rd2, %rd8;
+    ld.global.f32 %f3, [%rd8];
+
+    // f0 += f2 * f3
+    fma.rn.f32 %f0, %f2, %f3, %f0;
+
+$L_skip_mul:
+    add.u32 %r6, %r6, 1;
+    bra $L_blk_loop;
+
+$L_blk_loop_end:
+    // Warp reduction using shfl.sync.down
+    shfl.sync.down.b32 %f5, %f0, 16, 31, 0xffffffff;
+    add.f32 %f0, %f0, %f5;
+    shfl.sync.down.b32 %f6, %f0, 8, 31, 0xffffffff;
+    add.f32 %f0, %f0, %f6;
+    shfl.sync.down.b32 %f7, %f0, 4, 31, 0xffffffff;
+    add.f32 %f0, %f0, %f7;
+    shfl.sync.down.b32 %f8, %f0, 2, 31, 0xffffffff;
+    add.f32 %f0, %f0, %f8;
+    shfl.sync.down.b32 %f9, %f0, 1, 31, 0xffffffff;
+    add.f32 %f0, %f0, %f9;
+
+    // Thread 0 writes result
+    setp.ne.u32 %p4, %r0, 0;
+    @%p4 bra $L_exit;
+
+    // y[ctaid] = f0
+    mul.wide.u32 %rd9, %r1, 4;
+    add.u64 %rd9, %rd0, %rd9;
+    st.global.f32 [%rd9], %f0;
+
+$L_exit:
+    ret;
+}
+",
+    )
+}
+
 /// BUG-GGUF-002 FIX: Generate Q5_0 GEMV PTX with correct candle layout
 ///
 /// The GGUF Q5_0 format uses "candle layout" where:

--- a/crates/aprender-serve/src/infer/inference_result.rs
+++ b/crates/aprender-serve/src/infer/inference_result.rs
@@ -356,11 +356,33 @@ fn write_gguf_trace(
     }
 }
 
-/// Check if a quantization type is legacy (Q4_0, Q4_1, Q5_0, Q5_1)
-/// GPU only supports Q4_K/Q5_K/Q6_K; legacy types produce garbage on GPU.
+/// Check if a quantization type lacks a correct GPU GEMV kernel, so the model
+/// MUST run on CPU for correct output.
+///
+/// PMAT-782: the legacy GGML divergence this gate guarded against was a single
+/// kernel bug, not an inherent limitation. GGML packs Q4_0/Q4_1/Q5_0 nibbles
+/// INTERLEAVED — byte `j` (0..16) holds value `j` (low nibble) and value `j+16`
+/// (high nibble) — while the original GPU kernels assumed CONSECUTIVE packing
+/// (byte = tid/2, low/high = tid&1), so every value index ≥1 mapped to the wrong
+/// nibble → garbage logits (rel_gap≈0.54). Q4_0/Q5_0 were already rewritten to the
+/// correct "candle" layout (BUG-GGUF-001/002); Q4_1 was the last one still on the
+/// broken `Q4_1GemvKernel` consecutive layout. PMAT-782 routes Q4_1 to a candle
+/// PTX generator too (`generate_q4_1_candle_ptx` in `cuda/layout.rs`). With all
+/// three fixed, the cpu↔gpu parity gate now PASSES: `qwen2-0_5b-instruct-q4_0`
+/// (Q4_0+Q4_1) cosine=0.99998 and `qwen2.5-coder-0.5b-instruct-q4_k_m` (Q5_0-heavy)
+/// cosine=0.99948 on the RTX 4090, both producing output identical to CPU. So
+/// Q4_0(2)/Q4_1(3)/Q5_0(6) are NO LONGER gated.
+///
+/// Q5_1(7) is still gated: it has NO GPU kernel at all (`WeightQuantType` has no
+/// Q5_1 variant and `from_ggml_type(7)` returns `None`), so a Q5_1 weight would
+/// silently fall through to the Q4_K GEMV and produce garbage.
+///
+/// The parity gate that runs afterwards remains the true correctness backstop and
+/// fail-closes any residual divergence to CPU.
 #[inline]
 fn is_legacy_gguf_quant(qtype: u32) -> bool {
-    matches!(qtype, 2 | 3 | 6 | 7)
+    // Q5_1 (type 7) has no GPU kernel; Q4_0/Q4_1/Q5_0 are fixed (PMAT-782).
+    matches!(qtype, 7)
 }
 
 /// Check if model uses any legacy quantization types

--- a/crates/aprender-serve/src/infer/tests_construction.rs
+++ b/crates/aprender-serve/src/infer/tests_construction.rs
@@ -150,10 +150,12 @@ fn test_prefault_mmap_multi_page() {
 
 #[test]
 fn test_is_legacy_gguf_quant() {
-    assert!(is_legacy_gguf_quant(2)); // Q4_0
-    assert!(is_legacy_gguf_quant(3)); // Q4_1
-    assert!(is_legacy_gguf_quant(6)); // Q5_0
-    assert!(is_legacy_gguf_quant(7)); // Q5_1
+    // PMAT-782: Q4_0/Q4_1/Q5_0 candle-layout kernels now match CPU (parity gate
+    // PASSES, cosine≈0.9998) → GPU-eligible. Only Q5_1 (no GPU kernel) stays gated.
+    assert!(!is_legacy_gguf_quant(2)); // Q4_0 — fixed (candle layout)
+    assert!(!is_legacy_gguf_quant(3)); // Q4_1 — fixed (PMAT-782 candle layout)
+    assert!(!is_legacy_gguf_quant(6)); // Q5_0 — fixed (candle layout)
+    assert!(is_legacy_gguf_quant(7)); // Q5_1 — no GPU kernel → gated
     assert!(!is_legacy_gguf_quant(0)); // F32
     assert!(!is_legacy_gguf_quant(1)); // F16
     assert!(!is_legacy_gguf_quant(8)); // Q8_0

--- a/crates/aprender-serve/src/infer/tests_legacy.rs
+++ b/crates/aprender-serve/src/infer/tests_legacy.rs
@@ -3,24 +3,28 @@
 // is_legacy_gguf_quant tests (GH-219)
 // ============================================================================
 
+// PMAT-782: Q4_0/Q4_1/Q5_0 GPU GEMV kernels now use the correct GGML "candle"
+// interleaved nibble layout and PASS the cpu↔gpu parity gate (cosine≈0.9998), so
+// they are GPU-eligible. Q5_1 has NO GPU kernel and stays gated.
+
 #[test]
 fn test_is_legacy_gguf_quant_q4_0_gh219() {
-    assert!(is_legacy_gguf_quant(2)); // Q4_0
+    assert!(!is_legacy_gguf_quant(2)); // Q4_0 — fixed candle layout, GPU-eligible
 }
 
 #[test]
 fn test_is_legacy_gguf_quant_q4_1_gh219() {
-    assert!(is_legacy_gguf_quant(3)); // Q4_1
+    assert!(!is_legacy_gguf_quant(3)); // Q4_1 — PMAT-782 candle layout, GPU-eligible
 }
 
 #[test]
 fn test_is_legacy_gguf_quant_q5_0_gh219() {
-    assert!(is_legacy_gguf_quant(6)); // Q5_0
+    assert!(!is_legacy_gguf_quant(6)); // Q5_0 — fixed candle layout, GPU-eligible
 }
 
 #[test]
 fn test_is_legacy_gguf_quant_q5_1_gh219() {
-    assert!(is_legacy_gguf_quant(7)); // Q5_1
+    assert!(is_legacy_gguf_quant(7)); // Q5_1 — no GPU kernel → gated
 }
 
 #[test]


### PR DESCRIPTION
## Legacy-quant GGUF models now use the GPU correctly (parity-verified)

The legacy GGML-quant GPU GEMV kernels produced garbage (diverged from CPU, parity-gate FAIL, rel_gap≈0.54) → those models were gated to CPU. Root-caused to a **single contained layout bug** (not column-major — row-major throughout):

- The active legacy-quant GPU GEMV kernels are hand-written PTX in `cuda/layout.rs`. **Q4_0 and Q5_0 were already correct** (GGML candle layout, BUG-GGUF-001/002). **Q4_1 was the lone exception** — routed to the trueno `Q4_1GemvKernel`, which assumes **consecutive** nibble packing (byte=`tid/2`, low/high=`tid&1`).
- But GGML packs Q4_0/Q4_1/Q5_0 nibbles **interleaved**: byte `j` (0..16) holds value `j` in its LOW nibble and value `j+16` in its HIGH nibble (verified against llama.cpp `dequantize_row_q4_1` + aprender's CPU `dequantize_q4_1`). The consecutive-layout kernel maps every value index ≥1 to the wrong nibble → garbage.

## Fix (6 files, 1 commit)
- `cuda/layout.rs`: new `generate_q4_1_candle_ptx` — candle-layout PTX, affine dequant `d*q + m`, 20-byte blocks (d@0, m@2, qs@4).
- `cuda/kernels_generate_gemm_cuda.rs`: route `KernelType::Q4_1Gemv` to it.
- `infer/inference_result.rs`: narrow the legacy GPU gate from `{Q4_0,Q4_1,Q5_0,Q5_1}` → **only Q5_1** (type 7, which has no GPU kernel at all). The CPU↔GPU parity gate remains the fail-closed backstop.
- 3 test files: GPU↔CPU GGML-layout parity tests for Q4_0/Q4_1/Q5_0 (the Q4_1 test FAILS pre-fix, PASSES post-fix).

## Parity verified (RTX 4090, default `--gpu`)
- Q4_0/Q4_1 model: `[PARITY-GATE] PASS cosine=0.99998`, output identical to CPU.
- Q5_0-heavy coder model: PASS cosine=0.99948, coherent.
- Q4_K 1.5B control: PASS cosine=0.98459 — **no regression**.

Surfaced by the GB10 decode characterization (which found legacy-quant models silently falling back to CPU). This fixes the root cause so they use the GPU correctly, rather than just making the fallback loud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)