### PR TITLE
fix(serve): GPU quant gate fails closed for ALL no-kernel quants (Q2_K/Q3_K garbage) — PMAT-783

### DIFF
--- a/crates/aprender-serve/src/infer/inference_result.rs
+++ b/crates/aprender-serve/src/infer/inference_result.rs
@@ -373,26 +373,57 @@ fn write_gguf_trace(
 /// cosine=0.99948 on the RTX 4090, both producing output identical to CPU. So
 /// Q4_0(2)/Q4_1(3)/Q5_0(6) are NO LONGER gated.
 ///
-/// Q5_1(7) is still gated: it has NO GPU kernel at all (`WeightQuantType` has no
-/// Q5_1 variant and `from_ggml_type(7)` returns `None`), so a Q5_1 weight would
-/// silently fall through to the Q4_K GEMV and produce garbage.
-///
-/// The parity gate that runs afterwards remains the true correctness backstop and
-/// fail-closes any residual divergence to CPU.
+/// PMAT-783: this gate now FAILS CLOSED for *every* GGML quant type that lacks a
+/// verified GPU GEMV kernel, not just Q5_1(7). The GPU weight upload resolves a
+/// tensor's GGML type via `WeightQuantType::from_ggml_type(qtype)` and then
+/// `resolve_qtype()` does `.unwrap_or(WeightQuantType::Q4K)` — so ANY type that
+/// `from_ggml_type` does not recognize (Q5_1=7, Q8_1=9, Q2_K=10, Q3_K=11,
+/// Q8_K=15, the IQ* families, and even raw F16=1 / BF16=30 reaching this path)
+/// is SILENTLY decoded as Q4_K → garbage logits. The previous `matches!(qtype, 7)`
+/// caught only Q5_1, leaving Q2_K/Q3_K-quantized GGUF models (common K-quant mixes)
+/// to ship garbage on the unguarded `generate_gpu_resident` call sites where the
+/// parity gate does not run. The whitelist below is the exact set
+/// `WeightQuantType::from_ggml_type` maps to a real kernel:
+///   0=F32, 2=Q4_0, 3=Q4_1, 6=Q5_0, 8=Q8_0, 12=Q4_K, 13=Q5_K, 14=Q6_K.
+/// (Q4_0/Q4_1/Q5_0 kernels were corrected to candle layout in BUG-GGUF-001/002 +
+/// PMAT-782; the cpu↔gpu parity gate remains the correctness backstop on the
+/// primary `apr run`/`apr serve` path.)
 #[inline]
 fn is_legacy_gguf_quant(qtype: u32) -> bool {
-    // Q5_1 (type 7) has no GPU kernel; Q4_0/Q4_1/Q5_0 are fixed (PMAT-782).
-    matches!(qtype, 7)
+    // Returns true (→ force CPU) for any GGML quant WITHOUT a verified GPU kernel.
+    // Whitelist mirrors WeightQuantType::from_ggml_type (cuda/types.rs); anything
+    // outside it would hit resolve_qtype's `.unwrap_or(Q4K)` → wrong-kernel garbage.
+    !matches!(qtype, 0 | 2 | 3 | 6 | 8 | 12 | 13 | 14)
 }
 
-/// Check if model uses any legacy quantization types
+/// Check if model uses any quant type without a verified GPU kernel.
+///
+/// PMAT-783: checks EVERY projection tensor the GPU-resident forward pass would
+/// touch — lm_head, QKV (fused or separate), attn output, and FFN gate/up/down.
+/// The prior version omitted QKV and the FFN gate, so a model carrying an
+/// unsupported quant in those tensors slipped past the gate onto the GPU.
 fn model_has_legacy_quant(model: &crate::gguf::OwnedQuantizedModel) -> bool {
-    is_legacy_gguf_quant(model.lm_head_weight.qtype)
-        || model.layers.iter().any(|l| {
-            is_legacy_gguf_quant(l.ffn_down_weight.qtype)
-                || is_legacy_gguf_quant(l.ffn_up_weight.qtype)
-                || is_legacy_gguf_quant(l.attn_output_weight.qtype)
-        })
+    use crate::gguf::OwnedQKVWeights;
+    if is_legacy_gguf_quant(model.lm_head_weight.qtype) {
+        return true;
+    }
+    model.layers.iter().any(|l| {
+        let qkv_bad = match &l.qkv_weight {
+            OwnedQKVWeights::Fused(t) => is_legacy_gguf_quant(t.qtype),
+            OwnedQKVWeights::Separate { q, k, v } => {
+                is_legacy_gguf_quant(q.qtype)
+                    || is_legacy_gguf_quant(k.qtype)
+                    || is_legacy_gguf_quant(v.qtype)
+            },
+        };
+        qkv_bad
+            || is_legacy_gguf_quant(l.attn_output_weight.qtype)
+            || is_legacy_gguf_quant(l.ffn_up_weight.qtype)
+            || is_legacy_gguf_quant(l.ffn_down_weight.qtype)
+            || l.ffn_gate_weight
+                .as_ref()
+                .is_some_and(|g| is_legacy_gguf_quant(g.qtype))
+    })
 }
 
 /// Log CPU backend selection reason

--- a/crates/aprender-serve/src/infer/tests_11.rs
+++ b/crates/aprender-serve/src/infer/tests_11.rs
@@ -349,24 +349,26 @@ fn test_apr_arch_no_match_defaults_to_llama() {
 
 #[test]
 fn test_is_legacy_quant_boundary_below() {
-    assert!(!is_legacy_gguf_quant(1)); // F16, not legacy
+    // PMAT-783: F16 has no GGUF GPU GEMV kernel → fail closed (would be Q4K garbage).
+    assert!(is_legacy_gguf_quant(1)); // F16, no GPU kernel → gated
 }
 
 #[test]
 fn test_is_legacy_quant_boundary_between_4_and_5() {
-    // 4 and 5 are NOT in the legacy set
-    assert!(!is_legacy_gguf_quant(4));
-    assert!(!is_legacy_gguf_quant(5));
+    // PMAT-783: types 4 and 5 (Q4_2/Q4_3, removed from GGML) have no kernel → gated.
+    assert!(is_legacy_gguf_quant(4));
+    assert!(is_legacy_gguf_quant(5));
 }
 
 #[test]
 fn test_is_legacy_quant_boundary_above() {
-    assert!(!is_legacy_gguf_quant(8)); // Q8_0, not legacy
+    assert!(!is_legacy_gguf_quant(8)); // Q8_0 — GPU-eligible
 }
 
 #[test]
 fn test_is_legacy_quant_u32_max() {
-    assert!(!is_legacy_gguf_quant(u32::MAX));
+    // PMAT-783: unknown type → fail closed (no kernel).
+    assert!(is_legacy_gguf_quant(u32::MAX));
 }
 
 // ============================================================================

--- a/crates/aprender-serve/src/infer/tests_construction.rs
+++ b/crates/aprender-serve/src/infer/tests_construction.rs
@@ -151,17 +151,85 @@ fn test_prefault_mmap_multi_page() {
 #[test]
 fn test_is_legacy_gguf_quant() {
     // PMAT-782: Q4_0/Q4_1/Q5_0 candle-layout kernels now match CPU (parity gate
-    // PASSES, cosine≈0.9998) → GPU-eligible. Only Q5_1 (no GPU kernel) stays gated.
+    // PASSES, cosine≈0.9998) → GPU-eligible.
+    // PMAT-783: the gate FAILS CLOSED for every quant WITHOUT a verified GPU kernel
+    // (anything outside the from_ggml_type whitelist), because resolve_qtype's
+    // `.unwrap_or(Q4K)` would otherwise silently decode it as Q4_K → garbage.
+
+    // GPU-eligible (have a real WeightQuantType kernel) → NOT gated:
+    assert!(!is_legacy_gguf_quant(0)); // F32
     assert!(!is_legacy_gguf_quant(2)); // Q4_0 — fixed (candle layout)
     assert!(!is_legacy_gguf_quant(3)); // Q4_1 — fixed (PMAT-782 candle layout)
     assert!(!is_legacy_gguf_quant(6)); // Q5_0 — fixed (candle layout)
-    assert!(is_legacy_gguf_quant(7)); // Q5_1 — no GPU kernel → gated
-    assert!(!is_legacy_gguf_quant(0)); // F32
-    assert!(!is_legacy_gguf_quant(1)); // F16
     assert!(!is_legacy_gguf_quant(8)); // Q8_0
     assert!(!is_legacy_gguf_quant(12)); // Q4_K
+    assert!(!is_legacy_gguf_quant(13)); // Q5_K
     assert!(!is_legacy_gguf_quant(14)); // Q6_K
-    assert!(!is_legacy_gguf_quant(100)); // Unknown
+
+    // No GPU kernel → MUST be gated to CPU (else silent Q4_K garbage):
+    assert!(is_legacy_gguf_quant(1)); // F16 (no GGUF f16 GEMV here)
+    assert!(is_legacy_gguf_quant(7)); // Q5_1 — no GPU kernel
+    assert!(is_legacy_gguf_quant(9)); // Q8_1
+    assert!(is_legacy_gguf_quant(10)); // Q2_K
+    assert!(is_legacy_gguf_quant(11)); // Q3_K
+    assert!(is_legacy_gguf_quant(15)); // Q8_K
+    assert!(is_legacy_gguf_quant(30)); // BF16
+    assert!(is_legacy_gguf_quant(100)); // Unknown / IQ* families
+}
+
+// PMAT-783: model_has_legacy_quant must inspect EVERY projection tensor —
+// including QKV and the FFN gate, which the pre-PMAT-783 gate omitted. A Q2_K(10)
+// tensor hidden in QKV or the gate must still force CPU (else resolve_qtype's
+// `.unwrap_or(Q4K)` decodes Q2_K bytes as Q4_K → garbage on the GPU-resident path).
+#[test]
+fn test_model_has_legacy_quant_checks_qkv_and_gate() {
+    use crate::gguf::test_helpers::create_test_model_with_config;
+    use crate::gguf::{ArchConstraints, GGUFConfig, OwnedQKVWeights};
+
+    let config = GGUFConfig {
+        architecture: "test".to_string(),
+        constraints: ArchConstraints::from_architecture("test"),
+        hidden_dim: 64,
+        intermediate_dim: 128,
+        num_layers: 1,
+        num_heads: 4,
+        num_kv_heads: 4,
+        vocab_size: 100,
+        context_length: 256,
+        rope_theta: 10000.0,
+        eps: 1e-5,
+        rope_type: 0,
+        explicit_head_dim: None,
+        bos_token_id: None,
+        eos_token_id: None,
+    };
+
+    // Baseline: an all-Q4K model is GPU-eligible.
+    let base = create_test_model_with_config(&config);
+    assert!(
+        !model_has_legacy_quant(&base),
+        "all-Q4K model must be GPU-eligible"
+    );
+
+    // Q2_K (type 10) hidden ONLY in the fused QKV tensor must still gate to CPU.
+    let mut qkv_model = create_test_model_with_config(&config);
+    if let OwnedQKVWeights::Fused(t) = &mut qkv_model.layers[0].qkv_weight {
+        t.qtype = 10; // Q2_K — no GPU kernel
+    }
+    assert!(
+        model_has_legacy_quant(&qkv_model),
+        "Q2_K in QKV must force CPU"
+    );
+
+    // Q3_K (type 11) hidden ONLY in the FFN gate must still gate to CPU.
+    let mut gate_model = create_test_model_with_config(&config);
+    if let Some(g) = gate_model.layers[0].ffn_gate_weight.as_mut() {
+        g.qtype = 11; // Q3_K — no GPU kernel
+        assert!(
+            model_has_legacy_quant(&gate_model),
+            "Q3_K in FFN gate must force CPU"
+        );
+    }
 }
 
 // ============================================================================

--- a/crates/aprender-serve/src/infer/tests_legacy.rs
+++ b/crates/aprender-serve/src/infer/tests_legacy.rs
@@ -29,21 +29,26 @@ fn test_is_legacy_gguf_quant_q5_1_gh219() {
 
 #[test]
 fn test_is_legacy_gguf_quant_non_legacy_types_gh219() {
-    // Q4_K = 12, Q5_K = 13, Q6_K = 14, Q8_0 = 8, F16 = 1, F32 = 0
+    // GPU-eligible types (have a real WeightQuantType GEMV kernel) → NOT gated.
+    // Q4_K = 12, Q5_K = 13, Q6_K = 14, Q8_0 = 8, F32 = 0
     assert!(!is_legacy_gguf_quant(0));  // F32
-    assert!(!is_legacy_gguf_quant(1));  // F16
     assert!(!is_legacy_gguf_quant(8));  // Q8_0
     assert!(!is_legacy_gguf_quant(12)); // Q4_K
     assert!(!is_legacy_gguf_quant(13)); // Q5_K
     assert!(!is_legacy_gguf_quant(14)); // Q6_K
+    // PMAT-783: F16(1) has no GGUF GPU GEMV kernel → gated (would be Q4K garbage).
+    assert!(is_legacy_gguf_quant(1));
 }
 
 #[test]
 fn test_is_legacy_gguf_quant_edge_values_gh219() {
-    assert!(!is_legacy_gguf_quant(4));
-    assert!(!is_legacy_gguf_quant(5));
-    assert!(!is_legacy_gguf_quant(100));
-    assert!(!is_legacy_gguf_quant(u32::MAX));
+    // PMAT-783: every type WITHOUT a verified GPU kernel fails closed to CPU.
+    assert!(is_legacy_gguf_quant(4)); // Q4_2 (removed) — no kernel
+    assert!(is_legacy_gguf_quant(5)); // Q4_3 (removed) — no kernel
+    assert!(is_legacy_gguf_quant(10)); // Q2_K — no kernel
+    assert!(is_legacy_gguf_quant(11)); // Q3_K — no kernel
+    assert!(is_legacy_gguf_quant(100)); // IQ* / unknown — no kernel
+    assert!(is_legacy_gguf_quant(u32::MAX));
 }
 
 // ============================================================================


### PR DESCRIPTION
## GPU silently shipped garbage for Q2_K/Q3_K (common K-quant mixes) — now fails closed

Found by a serve quant/parity audit (following #2069's Q4_1 fix). The GPU-eligibility gate `is_legacy_gguf_quant` was `matches!(qtype, 7)` — blocking **only Q5_1**. But the failure mode is generic: GPU weight upload does `WeightQuantType::from_ggml_type(qtype).unwrap_or(Q4K)` (`cuda/executor/weights.rs:580`), so **any** quant without a verified GPU kernel — **Q2_K, Q3_K, Q8_1, Q8_K, IQ\*, F16/BF16** — is silently decoded as Q4_K → garbage on GPU. A Q2_K/Q3_K GGUF (common K-quant mixes) passed the gate and shipped garbage. The gate's own docstring admitted this but only hardcoded `7`.

Second bug in the same gate: `model_has_legacy_quant` checked only lm_head/ffn_down/ffn_up/attn_output — it **omitted QKV and the FFN gate**, so an unsupported quant hidden there slipped onto the GPU entirely.

## Fix
- The gate now **fails closed** for any qtype outside the verified-kernel whitelist `{F32=0, Q4_0=2, Q4_1=3, Q5_0=6, Q8_0=8, Q4_K=12, Q5_K=13, Q6_K=14}` (the quants with confirmed-correct GPU GEMV kernels). Everything else → CPU (loud).
- Checks **every** projection tensor: lm_head + QKV (fused + separate) + attn_output + ffn gate/up/down.
- Pure widening of the CPU-routed set — supported quants are untouched.

## Verified (RTX 4090)
- Q4_0+Q4_1 model → `Backend: GPU`, "The capital of France is Paris." (the #2069-fixed quants stay on GPU)
- Q4_K control → `Backend: GPU`, coherent — no regression.
- New `test_model_has_legacy_quant_checks_qkv_and_gate` (Q2_K-in-QKV, Q3_K-in-gate → forced CPU); all gate tests pass under `--features cuda`.

## Follow-ups (ranked, separate tickets — same silent-garbage class in other paths)
1. `validate_gpu_first_token` parity gate is bypassed by several `generate_gpu_resident` serve call sites (cuda_chat_backend, cuda_batch_scheduler, gpu_completions_handler, api/batch, cli/gguf_inference_gpu) — wire the gate/parity in there.
2. `acceleration.rs::dequantize_weight` `_ =>` arm treats every non-K-quant as raw f32 → garbage (wgpu + cached paths).
3. `resolve_qtype`/`from_ggml_type` `.unwrap_or(Q4K)` should hard-error (Poka-Yoke), not default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)