### PR TITLE
fix(format): SafeTensors FP16 export flushed subnormals to zero (divergent f16 encoder) — PMAT-787

### DIFF
--- a/crates/aprender-core/src/format/converter/f16_convert.rs
+++ b/crates/aprender-core/src/format/converter/f16_convert.rs
@@ -318,22 +318,24 @@ fn quantize_int4_packed(data: &[f32]) -> Vec<u8> {
 }
 
 /// Convert a single F32 value to F16 (IEEE 754 half-precision).
+///
+/// PMAT-787: Delegates to the canonical [`f32_to_f16`] (defined in
+/// `convert_report.rs`, same `converter` module scope via `include!`).
+/// The previous local implementation diverged from the tested canonical one in
+/// two ways that corrupted the SafeTensors FP16 export path
+/// (`save_safetensors_quantized` → `f32_slice_to_f16_le_bytes`):
+///
+/// 1. It **flushed every f16 subnormal to zero** (`exponent < 113 → sign`).
+///    Any weight with `|v| < 2^-14 ≈ 6.1e-5` became exactly 0 instead of the
+///    nearest f16 subnormal — silent precision loss on small-magnitude weights.
+/// 2. It **truncated** the mantissa (`mantissa >> 13`) instead of rounding to
+///    nearest-even, doubling the worst-case quantization error vs the canonical
+///    implementation.
+///
+/// Keeping one implementation removes the DRY hazard where the unit tests
+/// exercised the correct `f32_to_f16` while production shipped the lossy variant.
 fn f32_to_f16_bits(value: f32) -> u16 {
-    let bits = value.to_bits();
-    let sign = (bits >> 16) & 0x8000;
-    let exponent = ((bits >> 23) & 0xFF) as i32;
-    let mantissa = bits & 0x007F_FFFF;
-
-    let f16 = if exponent == 0xFF {
-        sign | 0x7C00 | if mantissa != 0 { 0x0200 } else { 0 }
-    } else if exponent > 142 {
-        sign | 0x7C00
-    } else if exponent < 113 {
-        sign
-    } else {
-        sign | (((exponent - 112) as u32) << 10) | ((mantissa >> 13) & 0x3FF)
-    };
-    f16 as u16
+    f32_to_f16(value)
 }
 
 /// Convert F32 slice to IEEE 754 half-precision (F16) little-endian bytes.

--- a/crates/aprender-core/src/format/converter/tests/coverage_gap_quantized_save.rs
+++ b/crates/aprender-core/src/format/converter/tests/coverage_gap_quantized_save.rs
@@ -485,3 +485,88 @@ fn test_f32_slice_to_f16_le_bytes_basic() {
     assert_eq!(bytes[2], 0x00);
     assert_eq!(bytes[3], 0x00);
 }
+
+// ============================================================================
+// PMAT-787: f32_to_f16_bits must NOT flush f16 subnormals to zero, and must
+// agree bit-for-bit with the canonical f32_to_f16 used elsewhere in the
+// converter. The old local implementation flushed every |v| < 2^-14 to 0 and
+// truncated (not rounded) the mantissa, silently corrupting the SafeTensors
+// FP16 export path for small-magnitude weights.
+// ============================================================================
+
+#[test]
+fn test_f32_to_f16_bits_preserves_subnormals_pmat787() {
+    // 2^-20 ≈ 9.5e-7 is squarely inside the f16 subnormal range
+    // (f16 subnormals span 2^-24 .. 2^-14). It MUST NOT be flushed to zero.
+    let v = 2f32.powi(-20);
+    let bits = f32_to_f16_bits(v);
+    assert_ne!(
+        bits & 0x7FFF,
+        0,
+        "f16 subnormal {v:e} was flushed to zero (PMAT-787 regression)"
+    );
+    // Round-trips back to a non-zero value of the right sign/magnitude band.
+    let back = f16_to_f32(bits);
+    assert!(back > 0.0, "subnormal lost its value: {back:e}");
+    assert!(
+        (back - v).abs() < v,
+        "subnormal round-trip too far off: {v:e} -> {back:e}"
+    );
+}
+
+#[test]
+fn test_f32_to_f16_bits_smallest_normal_not_flushed_pmat787() {
+    // Smallest f16 NORMAL = 2^-14 ≈ 6.103515625e-5 must round-trip exactly.
+    let v = 2f32.powi(-14);
+    let bits = f32_to_f16_bits(v);
+    assert_eq!(bits, 0x0400, "smallest f16 normal mis-encoded");
+    assert!((f16_to_f32(bits) - v).abs() < 1e-9);
+}
+
+#[test]
+fn test_f32_to_f16_bits_matches_canonical_f32_to_f16_pmat787() {
+    // The two encoders in the converter module MUST agree bit-for-bit so the
+    // tested path and the production SafeTensors-export path can never diverge.
+    let probes: &[f32] = &[
+        0.0, 1.0, -1.0, 0.5, -0.5, 2.0, -2.0, 0.25, 1024.0, 65504.0, 0.001,
+        0.0123, 0.1, 1.001, 3.141_59, -0.0007, 6.1e-5, 3.0e-5, 1.0e-6, 5.96e-8,
+        100_000.0, 1e-10, f32::INFINITY, f32::NEG_INFINITY,
+    ];
+    for &v in probes {
+        assert_eq!(
+            f32_to_f16_bits(v),
+            f32_to_f16(v),
+            "f32_to_f16_bits diverged from canonical f32_to_f16 for {v:e}"
+        );
+    }
+}
+
+#[test]
+fn test_save_safetensors_quantized_fp16_keeps_small_weights_pmat787() {
+    use tempfile::TempDir;
+
+    let dir = TempDir::new().expect("create temp dir");
+    let output = dir.path().join("tiny_weights_fp16.safetensors");
+
+    // A weight tensor of all-subnormal-range values. With the old flush-to-zero
+    // encoder every byte would be 0x00; the round-trip would read back all-zero
+    // weights → dead layer. The corrected encoder must preserve the magnitude.
+    let small = 2f32.powi(-18); // ~3.8e-6, deep in f16 subnormal range
+    let mut tensors = BTreeMap::new();
+    tensors.insert(
+        "model.layers.0.mlp.gate_proj.weight".to_string(),
+        (vec![small; 2048], vec![32, 64]),
+    );
+
+    save_safetensors_quantized(&tensors, &output, QuantizationType::Fp16)
+        .expect("fp16 save");
+
+    // Read back the raw f16 bytes for the tensor and confirm they are NOT all zero.
+    let file = std::fs::read(&output).unwrap();
+    let header_len = u64::from_le_bytes(file[0..8].try_into().unwrap()) as usize;
+    let data = &file[8 + header_len..];
+    assert!(
+        data.iter().any(|&b| b != 0),
+        "FP16 export flushed all small weights to zero (PMAT-787 regression)"
+    );
+}


### PR DESCRIPTION
## Production FP16 SafeTensors export silently zeroed small weights

Found by a format-conversion correctness audit (risks 1-3 — GGUF→APR transpose, quant preservation, round-trip identity — all confirmed **sound**). The defect: the converter shipped **two divergent `f32→f16` encoders**. Production SafeTensors FP16 export (`save_safetensors_quantized` → `f32_slice_to_f16_le_bytes` → `f32_to_f16_bits`, `f16_convert.rs`) used the **lossy** one; the unit tests exercised the **correct** one (`convert_report.rs::f32_to_f16`) — so the DRY divergence shipped green.

`f32_to_f16_bits` was wrong two ways:
1. **Flushed every f16 subnormal to zero** (`exponent < 113 → sign`): any weight `|v| < 2^-14 ≈ 6.1e-5` became exactly 0. Verified: `6.1e-5, 3e-5, 1e-6, 5.96e-8` all → 0 (the canonical impl preserves them as f16 subnormals).
2. **Truncated** the mantissa instead of round-to-nearest.

## Fix
`f32_to_f16_bits` now delegates to the canonical `f32_to_f16` (same module scope) — collapsing the two encoders into one. No more divergence.

## Verification
4 new falsifiers: subnormal-not-flushed, smallest-normal exact, bit-for-bit agreement across 24 probes, end-to-end SafeTensors export of an all-subnormal tensor → non-zero bytes. They **fail 3/4 on the old impl, pass on the fix**. Full converter suite **1284/1284** + 8 f16 roundtrip tests green; clippy + fmt clean. The bit-for-bit agreement test guards against the two impls ever silently diverging again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)