### PR TITLE
fix(serve): centralize fail-closed GPU quant gate at all GPU-resident construction sites (PMAT-785)

### DIFF
--- a/crates/aprender-serve/src/cli/apr_inference.rs
+++ b/crates/aprender-serve/src/cli/apr_inference.rs
@@ -57,29 +57,43 @@ pub fn run_apr_inference(
         let model = OwnedQuantizedModel::from_apr(&mapped).map_err(|e| {
             crate::error::RealizarError::FormatError { reason: format!("APR→GGUF failed: {e}") }
         })?;
-        let mut cuda_model = OwnedQuantizedModelCuda::with_max_seq_len(model, 0, 4096)
-            .map_err(|e| e.error)?;
 
-        // Tokenize using embedded APR tokenizer (same as CPU path)
-        let input_ids = crate::apr::AprV2Model::encode_text(model_path, prompt)
-            .or_else(|| crate::apr::AprV2Model::load_tokenizer(model_path).map(|t| t.encode(prompt)))
-            .unwrap_or_else(|| prompt.chars().map(|c| c as u32).collect());
+        // PMAT-785: fail-closed quant gate before GPU-resident construction. An APR
+        // model carrying a quant type without a verified GPU GEMV kernel would be
+        // silently decoded as Q4_K on the GPU → garbage. Fall through to the CPU
+        // path below (loud) instead of shipping GPU garbage from `apr run --gpu`.
+        if model.has_gpu_unsupported_quant() {
+            eprintln!(
+                "Backend: CPU — APR model uses a quant type without a verified GPU \
+                 kernel (PMAT-785). Running on CPU to avoid silent Q4_K-decode garbage."
+            );
+        } else {
+            let mut cuda_model = OwnedQuantizedModelCuda::with_max_seq_len(model, 0, 4096)
+                .map_err(|e| e.error)?;
 
-        let gen_config = QuantizedGenerateConfig {
-            max_tokens,
-            temperature,
-            top_k: 1,
-            stop_tokens: vec![151645, 151643],
-            trace: false,
-            ..Default::default()
-        };
-        let output_ids = cuda_model.generate_gpu_resident(&input_ids, &gen_config)?;
-        // Decode using APR tokenizer
-        let output_text = crate::apr::AprV2Model::load(model_path)
-            .ok()
-            .and_then(|m| m.load_embedded_tokenizer()).map_or_else(|| output_ids.iter().map(|&id| format!("[{}]", id)).collect(), |tok| tok.decode(&output_ids));
-        print!("{output_text}");
-        return Ok(());
+            // Tokenize using embedded APR tokenizer (same as CPU path)
+            let input_ids = crate::apr::AprV2Model::encode_text(model_path, prompt)
+                .or_else(|| {
+                    crate::apr::AprV2Model::load_tokenizer(model_path).map(|t| t.encode(prompt))
+                })
+                .unwrap_or_else(|| prompt.chars().map(|c| c as u32).collect());
+
+            let gen_config = QuantizedGenerateConfig {
+                max_tokens,
+                temperature,
+                top_k: 1,
+                stop_tokens: vec![151645, 151643],
+                trace: false,
+                ..Default::default()
+            };
+            let output_ids = cuda_model.generate_gpu_resident(&input_ids, &gen_config)?;
+            // Decode using APR tokenizer
+            let output_text = crate::apr::AprV2Model::load(model_path)
+                .ok()
+                .and_then(|m| m.load_embedded_tokenizer()).map_or_else(|| output_ids.iter().map(|&id| format!("[{}]", id)).collect(), |tok| tok.decode(&output_ids));
+            print!("{output_text}");
+            return Ok(());
+        }
     }
 
     let load_start = Instant::now();

--- a/crates/aprender-serve/src/cli/gguf_inference_gpu.rs
+++ b/crates/aprender-serve/src/cli/gguf_inference_gpu.rs
@@ -35,6 +35,22 @@ pub fn run_gguf_inference_gpu(
     let hidden_dim = quantized_model.config.hidden_dim;
     let num_layers = quantized_model.layers.len();
 
+    // PMAT-785: fail-closed quant gate before GPU-resident construction. A model
+    // carrying a quant type without a verified GPU GEMV kernel would be silently
+    // decoded as Q4_K on the GPU → garbage. Run it on CPU (loud) instead of
+    // shipping GPU garbage from this `apr run --gpu` path.
+    if quantized_model.has_gpu_unsupported_quant() {
+        return run_gguf_cpu_fallback_for_unsupported_quant(
+            mapped,
+            quantized_model,
+            prompt,
+            max_tokens,
+            temperature,
+            format,
+            verbose,
+        );
+    }
+
     // PAR-046: Create OwnedQuantizedModelCuda wrapper for actual GPU acceleration
     // The previous implementation used OwnedQuantizedModel.enable_cuda() which only
     // initialized the executor but forward_cached still used CPU code paths.
@@ -147,6 +163,88 @@ pub fn run_gguf_inference_gpu(
 
     print_inference_output(
         "GGUF (CUDA)",
+        prompt,
+        &output_text,
+        tokens_generated,
+        gen_time.as_secs_f64() * 1000.0,
+        tokens_per_sec,
+        temperature,
+        format,
+        verbose,
+    );
+
+    Ok(())
+}
+
+/// PMAT-785: CPU fallback for `apr run --gpu` when the GGUF model carries a quant
+/// type without a verified GPU GEMV kernel. Mirrors the GPU path's tokenize →
+/// generate → decode → print flow, but runs `generate_with_cache` on CPU so the
+/// output is correct instead of silent Q4_K-decode garbage. Loud: prints why.
+#[cfg(feature = "cuda")]
+#[allow(clippy::too_many_arguments)]
+fn run_gguf_cpu_fallback_for_unsupported_quant(
+    mapped: &crate::gguf::MappedGGUFModel,
+    model: crate::gguf::OwnedQuantizedModel,
+    prompt: &str,
+    max_tokens: usize,
+    temperature: f32,
+    format: &str,
+    verbose: bool,
+) -> Result<()> {
+    use crate::gguf::QuantizedGenerateConfig;
+    use std::time::Instant;
+
+    println!(
+        "Backend: CPU — model uses a quant type without a verified GPU kernel \
+         (PMAT-785). Running on CPU to avoid silent Q4_K-decode garbage."
+    );
+
+    // Tokenize prompt using GGUF vocabulary (same as the GPU path).
+    let mut prompt_tokens: Vec<u32> = mapped
+        .model
+        .encode(prompt)
+        .unwrap_or_else(|| prompt.chars().map(|c| c as u32).collect());
+    if let Some(bos) = mapped.model.bos_token_id() {
+        prompt_tokens.insert(0, bos);
+    }
+    let prompt_len = prompt_tokens.len();
+
+    let mut stop_tokens = Vec::new();
+    if let Some(eos) = mapped.model.eos_token_id() {
+        stop_tokens.push(eos);
+    }
+
+    let gen_config = QuantizedGenerateConfig {
+        max_tokens,
+        temperature,
+        top_k: if temperature <= 0.01 { 1 } else { 40 },
+        stop_tokens,
+        trace: false,
+        ..Default::default()
+    };
+
+    let gen_start = Instant::now();
+    let generated = model
+        .generate_with_cache(&prompt_tokens, &gen_config)
+        .map_err(|e| crate::error::RealizarError::InferenceError(format!(
+            "CPU generation failed: {e}"
+        )))?;
+    let gen_time = gen_start.elapsed();
+
+    let tokens_generated = generated.len().saturating_sub(prompt_len);
+    let tokens_per_sec = if gen_time.as_secs_f64() > 0.0 {
+        tokens_generated as f64 / gen_time.as_secs_f64()
+    } else {
+        0.0
+    };
+
+    let output_text = mapped
+        .model
+        .decode(&generated[prompt_len..])
+        .replace('▁', " ");
+
+    print_inference_output(
+        "GGUF (CPU)",
         prompt,
         &output_text,
         tokens_generated,

--- a/crates/aprender-serve/src/cli/mod_server_commands.rs
+++ b/crates/aprender-serve/src/cli/mod_server_commands.rs
@@ -161,6 +161,24 @@ mod server_commands {
             };
             println!("Creating CUDA model ({source})...");
 
+            // PMAT-785: fail-closed quant gate at GPU-resident construction.
+            // The serve chat/completions/batch HTTP handlers all consume the
+            // shared `state.cuda_model()` built here, so gating at this single
+            // choke point protects every one of them. A model carrying a quant
+            // type without a verified GPU GEMV kernel (Q5_1/Q8_1/Q2_K/Q3_K/Q8_K/
+            // F16/IQ*/…) would be silently decoded as Q4_K on the GPU → garbage.
+            // Route it to a CPU-backed AppState (loud) instead of GPU garbage.
+            if quantized_model.has_gpu_unsupported_quant() {
+                println!(
+                    "  Backend: CPU — model uses a quant type without a verified GPU \
+                     kernel (PMAT-785). Serving on CPU to avoid silent Q4_K-decode garbage."
+                );
+                return crate::api::AppState::with_quantized_model_and_vocab(
+                    quantized_model,
+                    vocab,
+                );
+            }
+
             // GH-286: Configurable context length (was hardcoded 4096)
             let max_seq_len = std::env::var("REALIZR_CONTEXT_LENGTH")
                 .ok()
@@ -453,6 +471,35 @@ mod server_commands {
         println!("  Layers: {}, Hidden: {}, Vocab: {}",
             model.config.num_layers, model.config.hidden_dim, model.config.vocab_size);
 
+        // Load vocab from embedded APR metadata (needed for both GPU and CPU paths)
+        let apr_v2 = crate::apr::AprV2Model::load(path).ok();
+        let vocab = apr_v2.as_ref()
+            .and_then(|m| m.metadata().get_embedded_vocabulary())
+            .or_else(|| crate::apr::AprV2Model::load_tokenizer_from_sibling(path).map(|(v, _, _)| v))
+            .unwrap_or_else(|| {
+                println!("  Warning: No tokenizer found");
+                (0..model.config.vocab_size).map(|i| format!("token{i}")).collect()
+            });
+        println!("  Vocab size: {}", vocab.len());
+
+        // PMAT-785: fail-closed quant gate at GPU-resident construction. An APR
+        // model carrying a quant type without a verified GPU GEMV kernel would be
+        // silently decoded as Q4_K on the GPU → garbage. Serve it on CPU (loud,
+        // via the same try_quantized_generate path as the CPU APR serve branch)
+        // instead of shipping GPU garbage through the chat/completions handlers.
+        if model.has_gpu_unsupported_quant() {
+            println!(
+                "  Mode: CPU — APR model uses a quant type without a verified GPU \
+                 kernel (PMAT-785). Serving on CPU to avoid silent Q4_K-decode garbage."
+            );
+            let state = crate::api::AppState::with_quantized_model_and_vocab(model, vocab)?;
+            return Ok(PreparedServer {
+                state,
+                batch_mode_enabled: false,
+                model_type: ModelType::Apr,
+            });
+        }
+
         // GH-286: Configurable context length (was hardcoded 4096)
         let max_seq_len = std::env::var("REALIZR_CONTEXT_LENGTH")
             .ok()
@@ -462,18 +509,6 @@ mod server_commands {
             .map_err(|e| e.error)?;
 
         println!("  CUDA model on GPU: {}", cuda_model.device_name());
-
-        // Load vocab from embedded APR metadata
-        let apr_v2 = crate::apr::AprV2Model::load(path).ok();
-        let vocab = apr_v2.as_ref()
-            .and_then(|m| m.metadata().get_embedded_vocabulary())
-            .or_else(|| crate::apr::AprV2Model::load_tokenizer_from_sibling(path).map(|(v, _, _)| v))
-            .unwrap_or_else(|| {
-                println!("  Warning: No tokenizer found");
-                (0..cuda_model.model().config.vocab_size).map(|i| format!("token{i}")).collect()
-            });
-
-        println!("  Vocab size: {}", vocab.len());
 
         let state = crate::api::AppState::with_cuda_model_and_vocab(cuda_model, vocab)?;
 

--- a/crates/aprender-serve/src/gguf/cuda/mod.rs
+++ b/crates/aprender-serve/src/gguf/cuda/mod.rs
@@ -178,6 +178,44 @@ impl OwnedQuantizedModelCuda {
         Ok(model)
     }
 
+    /// PMAT-785: Quant-eligibility gate — refuse GPU residency for any model
+    /// carrying a GGML quant type without a verified GPU GEMV kernel.
+    ///
+    /// `OwnedQuantizedModel::has_gpu_unsupported_quant` inspects every projection
+    /// tensor (lm_head, QKV, attn output, FFN gate/up/down) against the
+    /// `gpu_unsupported_quant_qtype` whitelist {F32, Q4_0, Q4_1, Q5_0, Q8_0,
+    /// Q4_K, Q5_K, Q6_K}. Anything outside it (F16, Q5_1, Q8_1, Q2_K, Q3_K,
+    /// Q8_K, IQ*, BF16, unknown) would hit the GPU weight upload's
+    /// `resolve_qtype().unwrap_or(Q4K)` and be SILENTLY decoded as Q4_K → garbage
+    /// logits (PMAT-781/783). The model is returned unconsumed so the caller can
+    /// fall back to CPU (loud) without a 1 GB clone.
+    ///
+    /// Centralizes the fail-closed gate at the single CUDA-model constructor that
+    /// every serve `generate_gpu_resident` entry point reaches, closing the
+    /// bypass on the serve chat/completions/batch HTTP handlers (which consume
+    /// the shared `state.cuda_model()` built here) and the `apr run --gpu`
+    /// GGUF/APR CLI paths.
+    fn check_quant_gpu_capability(
+        model: OwnedQuantizedModel,
+    ) -> std::result::Result<OwnedQuantizedModel, CudaInitError> {
+        if model.has_gpu_unsupported_quant() {
+            return Err(CudaInitError {
+                error: RealizarError::CapabilityMismatch {
+                    architecture: model.config.architecture.clone(),
+                    missing_ops: "GPU GEMV kernel for the model's quantization type".to_string(),
+                    suggestion: "Model carries a quant type without a verified GPU kernel \
+                                 (e.g. Q5_1/Q8_1/Q2_K/Q3_K/Q8_K/F16/IQ*). It will use CPU \
+                                 inference to avoid silent Q4_K-decode garbage (PMAT-785). \
+                                 Requantize to a GPU-supported type (Q4_0/Q4_1/Q5_0/Q8_0/\
+                                 Q4_K/Q5_K/Q6_K) for GPU acceleration."
+                        .to_string(),
+                },
+                model: Box::new(model),
+            });
+        }
+        Ok(model)
+    }
+
     /// GH-199/PARITY-GATE: Preload GPU weights and verify correctness.
     /// Extracted to reduce cognitive complexity of `with_max_seq_len`.
     fn preload_and_verify(mut self) -> std::result::Result<Self, CudaInitError> {
@@ -327,6 +365,15 @@ impl OwnedQuantizedModelCuda {
 
         // GH-280: Capability gate — refuse GPU if model requires unsupported ops.
         let model = Self::check_gpu_capability(model)?;
+
+        // PMAT-785: Quant gate — refuse GPU for any quant type lacking a verified
+        // GPU GEMV kernel, so it cannot be silently decoded as Q4_K → garbage.
+        // Centralizes the PMAT-781/783 fail-closed gate at the single CUDA-model
+        // constructor that EVERY serve `generate_gpu_resident` entry point funnels
+        // through (serve chat/completions/batch via the shared state model, and
+        // the `apr run --gpu` GGUF/APR CLI paths). Returns the model unconsumed so
+        // callers fall back to CPU (loud) instead of shipping GPU garbage.
+        let model = Self::check_quant_gpu_capability(model)?;
 
         let mut executor = match CudaExecutor::new(device_ordinal) {
             Ok(e) => e,

--- a/crates/aprender-serve/src/gguf/dtype.rs
+++ b/crates/aprender-serve/src/gguf/dtype.rs
@@ -4,6 +4,30 @@ fn apr_qtype_to_dtype(qtype: u32) -> &'static str {
     crate::gguf::GgmlQuantType::from_id(qtype).map_or("F32", crate::gguf::GgmlQuantType::as_str)
 }
 
+/// PMAT-783/PMAT-785: GGML quant types WITHOUT a verified GPU GEMV kernel.
+///
+/// Single source of truth for the GPU-eligibility whitelist. Returns `true`
+/// (→ MUST run on CPU) for any GGML quant type that
+/// `WeightQuantType::from_ggml_type` (`cuda/types.rs`) does NOT map to a real
+/// kernel. The GPU weight upload resolves an unknown type via
+/// `resolve_qtype()`'s `.unwrap_or(WeightQuantType::Q4K)`, so anything outside
+/// this whitelist is SILENTLY decoded as Q4_K → garbage logits.
+///
+/// The whitelist of GPU-eligible types is exactly:
+///   0=F32, 2=Q4_0, 3=Q4_1, 6=Q5_0, 8=Q8_0, 12=Q4_K, 13=Q5_K, 14=Q6_K.
+/// Everything else — F16(1), Q5_1(7), Q8_1(9), Q2_K(10), Q3_K(11), Q8_K(15),
+/// the IQ* families, BF16(30), unknown — is gated to CPU.
+///
+/// `inference_result::is_legacy_gguf_quant` (the primary `apr run`/`apr serve`
+/// path gate) and `OwnedQuantizedModel::has_gpu_unsupported_quant` (the
+/// construction-time gate consumed by every `generate_gpu_resident` entry point)
+/// both delegate here so the policy can never drift between paths.
+#[inline]
+#[must_use]
+pub(crate) fn gpu_unsupported_quant_qtype(qtype: u32) -> bool {
+    !matches!(qtype, 0 | 2 | 3 | 6 | 8 | 12 | 13 | 14)
+}
+
 /// GH-321: Convert APR dtype string to byte using unified enum.
 /// GH-191 FIX: Use GGML dtype values directly so they match TensorEntry::from_binary reader.
 fn apr_dtype_to_byte(dtype: &str) -> u8 {
@@ -51,6 +75,43 @@ fn write_apr_tensor_entry(
 }
 
 impl OwnedQuantizedModel {
+    /// PMAT-785: Does this model carry ANY quant type without a verified GPU
+    /// GEMV kernel on a tensor the GPU-resident forward pass would touch?
+    ///
+    /// Inspects EVERY projection tensor the GPU path reads — lm_head, QKV
+    /// (fused or separate), attention output, and FFN gate/up/down — using the
+    /// `gpu_unsupported_quant_qtype` whitelist. Returns `true` if the model
+    /// MUST run on CPU to avoid the PMAT-781/783 silent-garbage class (an
+    /// unsupported quant decoded as Q4_K on the GPU).
+    ///
+    /// This is the centralized construction-time gate: every serve entry point
+    /// that builds an `OwnedQuantizedModelCuda` from one of these CPU models
+    /// (`OwnedQuantizedModelCuda::with_max_seq_len` → `check_quant_gpu_capability`)
+    /// is protected by this single check, so an unsupported-quant model routes
+    /// to CPU (loud) or errors rather than shipping GPU garbage.
+    #[must_use]
+    pub(crate) fn has_gpu_unsupported_quant(&self) -> bool {
+        if gpu_unsupported_quant_qtype(self.lm_head_weight.qtype) {
+            return true;
+        }
+        self.layers.iter().any(|l| {
+            let qkv_bad = match &l.qkv_weight {
+                OwnedQKVWeights::Fused(t) => gpu_unsupported_quant_qtype(t.qtype),
+                OwnedQKVWeights::Separate { q, k, v } => {
+                    gpu_unsupported_quant_qtype(q.qtype)
+                        || gpu_unsupported_quant_qtype(k.qtype)
+                        || gpu_unsupported_quant_qtype(v.qtype)
+                },
+            };
+            qkv_bad
+                || gpu_unsupported_quant_qtype(l.attn_output_weight.qtype)
+                || gpu_unsupported_quant_qtype(l.ffn_up_weight.qtype)
+                || gpu_unsupported_quant_qtype(l.ffn_down_weight.qtype)
+                || l.ffn_gate_weight
+                    .as_ref()
+                    .is_some_and(|g| gpu_unsupported_quant_qtype(g.qtype))
+        })
+    }
 
     /// Serialize model to APR format with quantized weights preserved
     ///

--- a/crates/aprender-serve/src/gguf/mod.rs
+++ b/crates/aprender-serve/src/gguf/mod.rs
@@ -85,6 +85,11 @@ pub use cuda::{BatchedDecodeState, CudaBackend, CudaInitError};
 #[cfg(feature = "cuda")]
 pub use cuda_model::*;
 pub use model::*;
+// PMAT-785: single-source-of-truth GPU quant whitelist predicate, shared between
+// the primary `apr run`/`apr serve` gate (infer::is_legacy_gguf_quant) and the
+// construction-time gate (OwnedQuantizedModel::has_gpu_unsupported_quant).
+// `loader.rs` include!()s `dtype.rs`, where the predicate is defined.
+pub(crate) use loader::gpu_unsupported_quant_qtype;
 pub use quantized::*;
 pub use runtime::*;
 #[cfg(feature = "gpu")]

--- a/crates/aprender-serve/src/gguf/tests/mod.rs
+++ b/crates/aprender-serve/src/gguf/tests/mod.rs
@@ -49,6 +49,7 @@ mod phase_gguf_parsing_error;
 mod phase_matmul_coverage;
 mod phase_thread_safe_cache;
 mod phase_transformer_structure;
+mod pmat785_gpu_quant_gate; // PMAT-785: centralized GPU quant-eligibility gate
 mod tests_02;
 mod tests_03;
 mod tests_04;

--- a/crates/aprender-serve/src/gguf/tests/pmat785_gpu_quant_gate.rs
+++ b/crates/aprender-serve/src/gguf/tests/pmat785_gpu_quant_gate.rs
@@ -1,0 +1,144 @@
+//! PMAT-785: centralized GPU-resident quant-eligibility gate tests.
+//!
+//! These tests lock the single source of truth used by BOTH the primary
+//! `apr run`/`apr serve` path (`infer::is_legacy_gguf_quant` /
+//! `model_has_legacy_quant`) AND the construction-time gate that protects every
+//! serve `generate_gpu_resident` entry point
+//! (`OwnedQuantizedModel::has_gpu_unsupported_quant`, called from
+//! `OwnedQuantizedModelCuda::with_max_seq_len`).
+//!
+//! Invariant: a model carrying a quant type WITHOUT a verified GPU GEMV kernel
+//! must be flagged so it routes to CPU (loud) or errors, never shipping silent
+//! Q4_K-decode garbage on the GPU (PMAT-781/783 class).
+
+use crate::gguf::gpu_unsupported_quant_qtype;
+use crate::gguf::test_helpers::create_test_model_with_config;
+use crate::gguf::{ArchConstraints, GGUFConfig, OwnedQKVWeights};
+
+fn test_config() -> GGUFConfig {
+    GGUFConfig {
+        architecture: "test".to_string(),
+        constraints: ArchConstraints::from_architecture("test"),
+        hidden_dim: 64,
+        intermediate_dim: 128,
+        num_layers: 1,
+        num_heads: 4,
+        num_kv_heads: 4,
+        vocab_size: 100,
+        context_length: 256,
+        rope_theta: 10000.0,
+        eps: 1e-5,
+        rope_type: 0,
+        explicit_head_dim: None,
+        bos_token_id: None,
+        eos_token_id: None,
+    }
+}
+
+/// The whitelist predicate is the single source of truth. GPU-eligible set is
+/// exactly {F32(0), Q4_0(2), Q4_1(3), Q5_0(6), Q8_0(8), Q4_K(12), Q5_K(13),
+/// Q6_K(14)}; everything else gates to CPU. This is what the construction gate
+/// and the primary-path gate both consume — they MUST agree.
+#[test]
+fn gpu_unsupported_quant_qtype_whitelist_is_exact() {
+    // Supported → NOT gated.
+    for &q in &[0u32, 2, 3, 6, 8, 12, 13, 14] {
+        assert!(
+            !gpu_unsupported_quant_qtype(q),
+            "qtype {q} has a verified GPU kernel and must be GPU-eligible"
+        );
+    }
+    // Unsupported → gated to CPU (would hit resolve_qtype's unwrap_or(Q4K)).
+    for &q in &[
+        1u32, /*F16*/
+        7,    /*Q5_1*/
+        9,    /*Q8_1*/
+        10,   /*Q2_K*/
+        11,   /*Q3_K*/
+        15,   /*Q8_K*/
+        30,   /*BF16*/
+        100,  /*IQ*/
+    ] {
+        assert!(
+            gpu_unsupported_quant_qtype(q),
+            "qtype {q} has no verified GPU kernel and MUST force CPU"
+        );
+    }
+}
+
+/// A model whose every projection tensor is Q4_K must NOT be flagged: supported
+/// quants stay GPU-eligible (no regression).
+#[test]
+fn supported_q4k_model_is_gpu_eligible() {
+    let model = create_test_model_with_config(&test_config());
+    assert!(
+        !model.has_gpu_unsupported_quant(),
+        "all-Q4K model must remain GPU-eligible (no regression)"
+    );
+}
+
+/// An unsupported quant hidden in the lm_head must flag the whole model.
+#[test]
+fn unsupported_quant_in_lm_head_forces_cpu() {
+    let mut model = create_test_model_with_config(&test_config());
+    model.lm_head_weight.qtype = 7; // Q5_1 — no GPU kernel
+    assert!(
+        model.has_gpu_unsupported_quant(),
+        "Q5_1 in lm_head must force CPU"
+    );
+}
+
+/// An unsupported quant hidden ONLY in the fused QKV tensor must flag the model
+/// (the pre-PMAT-783 gate omitted QKV; the centralized method must cover it).
+#[test]
+fn unsupported_quant_in_qkv_forces_cpu() {
+    let mut model = create_test_model_with_config(&test_config());
+    if let OwnedQKVWeights::Fused(t) = &mut model.layers[0].qkv_weight {
+        t.qtype = 10; // Q2_K — no GPU kernel
+    }
+    assert!(
+        model.has_gpu_unsupported_quant(),
+        "Q2_K hidden in QKV must force CPU"
+    );
+}
+
+/// An unsupported quant hidden ONLY in the FFN gate must flag the model.
+#[test]
+fn unsupported_quant_in_ffn_gate_forces_cpu() {
+    let mut model = create_test_model_with_config(&test_config());
+    if let Some(g) = model.layers[0].ffn_gate_weight.as_mut() {
+        g.qtype = 11; // Q3_K — no GPU kernel
+        assert!(
+            model.has_gpu_unsupported_quant(),
+            "Q3_K hidden in the FFN gate must force CPU"
+        );
+    }
+}
+
+/// An unsupported quant in attn_output / ffn_up / ffn_down must each flag the
+/// model — every tensor the GPU-resident forward pass touches is covered.
+#[test]
+fn unsupported_quant_in_each_projection_forces_cpu() {
+    let cfg = test_config();
+
+    let mut m_out = create_test_model_with_config(&cfg);
+    m_out.layers[0].attn_output_weight.qtype = 9; // Q8_1
+    assert!(
+        m_out.has_gpu_unsupported_quant(),
+        "Q8_1 in attn_output must force CPU"
+    );
+
+    let mut m_up = create_test_model_with_config(&cfg);
+    m_up.layers[0].ffn_up_weight.qtype = 15; // Q8_K
+    assert!(
+        m_up.has_gpu_unsupported_quant(),
+        "Q8_K in ffn_up must force CPU"
+    );
+
+    let mut m_down = create_test_model_with_config(&cfg);
+    m_down.layers[0].ffn_down_weight.qtype = 1; // F16
+    assert!(
+        m_down.has_gpu_unsupported_quant(),
+        "F16 in ffn_down must force CPU"
+    );
+}

--- a/crates/aprender-serve/src/infer/inference_result.rs
+++ b/crates/aprender-serve/src/infer/inference_result.rs
@@ -388,12 +388,18 @@ fn write_gguf_trace(
 /// (Q4_0/Q4_1/Q5_0 kernels were corrected to candle layout in BUG-GGUF-001/002 +
 /// PMAT-782; the cpu↔gpu parity gate remains the correctness backstop on the
 /// primary `apr run`/`apr serve` path.)
+///
+/// PMAT-785: delegates to `gguf::gpu_unsupported_quant_qtype` (the single source
+/// of truth shared with the construction-time gate
+/// `OwnedQuantizedModel::has_gpu_unsupported_quant`) so the whitelist can never
+/// drift between the primary `apr run`/`apr serve` path and the
+/// `generate_gpu_resident` construction entry points.
 #[inline]
 fn is_legacy_gguf_quant(qtype: u32) -> bool {
     // Returns true (→ force CPU) for any GGML quant WITHOUT a verified GPU kernel.
     // Whitelist mirrors WeightQuantType::from_ggml_type (cuda/types.rs); anything
     // outside it would hit resolve_qtype's `.unwrap_or(Q4K)` → wrong-kernel garbage.
-    !matches!(qtype, 0 | 2 | 3 | 6 | 8 | 12 | 13 | 14)
+    crate::gguf::gpu_unsupported_quant_qtype(qtype)
 }
 
 /// Check if model uses any quant type without a verified GPU kernel.
@@ -402,28 +408,13 @@ fn is_legacy_gguf_quant(qtype: u32) -> bool {
 /// touch — lm_head, QKV (fused or separate), attn output, and FFN gate/up/down.
 /// The prior version omitted QKV and the FFN gate, so a model carrying an
 /// unsupported quant in those tensors slipped past the gate onto the GPU.
+///
+/// PMAT-785: delegates to `OwnedQuantizedModel::has_gpu_unsupported_quant`, the
+/// shared construction-time gate, so this `apr run`/`apr serve`-path check and
+/// the `generate_gpu_resident` construction gate apply identical tensor coverage
+/// and the same quant whitelist.
 fn model_has_legacy_quant(model: &crate::gguf::OwnedQuantizedModel) -> bool {
-    use crate::gguf::OwnedQKVWeights;
-    if is_legacy_gguf_quant(model.lm_head_weight.qtype) {
-        return true;
-    }
-    model.layers.iter().any(|l| {
-        let qkv_bad = match &l.qkv_weight {
-            OwnedQKVWeights::Fused(t) => is_legacy_gguf_quant(t.qtype),
-            OwnedQKVWeights::Separate { q, k, v } => {
-                is_legacy_gguf_quant(q.qtype)
-                    || is_legacy_gguf_quant(k.qtype)
-                    || is_legacy_gguf_quant(v.qtype)
-            },
-        };
-        qkv_bad
-            || is_legacy_gguf_quant(l.attn_output_weight.qtype)
-            || is_legacy_gguf_quant(l.ffn_up_weight.qtype)
-            || is_legacy_gguf_quant(l.ffn_down_weight.qtype)
-            || l.ffn_gate_weight
-                .as_ref()
-                .is_some_and(|g| is_legacy_gguf_quant(g.qtype))
-    })
+    model.has_gpu_unsupported_quant()
 }
 
 /// Log CPU backend selection reason


### PR DESCRIPTION
## Close the serve-path bypass of the fail-closed GPU quant gate

#2070 (PMAT-783) made the GPU quant gate fail-closed, but it + the `validate_gpu_first_token` parity check only ran on the primary `apr run`/`apr serve` GGUF path. The other serve `generate_gpu_resident*` entry points built an `OwnedQuantizedModelCuda` **without** the gate — so an unsupported-quant model (Q5_1/Q8_1/Q2_K/Q3_K/Q8_K/F16/IQ*/BF16) served via those paths was silently decoded as Q4_K → GPU garbage.

## Root-cause centralization
Every bypassing site funnels through one constructor: `OwnedQuantizedModelCuda::with_max_seq_len`. The gate now lives **there** (single choke point):
- `gguf::gpu_unsupported_quant_qtype(qtype)` — single source of truth for the verified-kernel whitelist {F32, Q4_0, Q4_1, Q5_0, Q8_0, Q4_K, Q5_K, Q6_K} (`gguf/dtype.rs`).
- `OwnedQuantizedModel::has_gpu_unsupported_quant()` — checks every projection tensor (lm_head, QKV fused/separate, attn_output, FFN gate/up/down).
- `check_quant_gpu_capability` runs inside `with_max_seq_len` (next to the GH-280 capability gate) → returns `CudaInitError` (model preserved) for CPU fallback.
- The primary-path gate now **delegates** to the same predicate so policy can't drift.

## Sites covered (5, via 2 choke points + 2 CLI paths)
The 4 serve HTTP handlers (cuda_chat_backend, gpu_completions_handler, api/batch, cuda_batch_scheduler) all consume `state.cuda_model()` built in `prepare_gguf_cuda_state`/`_from_apr` → now build a CPU AppState (loud) for unsupported quants; `cli/gguf_inference_gpu.rs` + `cli/apr_inference.rs` fall back to CPU loudly.

## Verified
- Supported quants take the identical path (`has_gpu_unsupported_quant` → false), no regression.
- 6 new gate tests (whitelist exactness + unsupported-quant-in-each-projection-tensor → CPU); existing PMAT-783 gate tests pass; full `aprender-serve` lib suite **16899 passed, 0 failed**; clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)