### PR TITLE
fix(cuda): RoPE NORM GPU kernel rotated only head 0 — LLaMA/Mistral GPU decode garbage (PMAT-792)

### DIFF
--- a/crates/aprender-serve/src/cuda/executor/fused_ffn.rs
+++ b/crates/aprender-serve/src/cuda/executor/fused_ffn.rs
@@ -248,11 +248,14 @@ impl CudaExecutor {
             .get_mut(&cache_key)
             .expect("module just inserted");
 
-        // Grid: 1 thread per rotation pair = num_heads * (head_dim / 2)
-        let num_pairs = num_heads * (head_dim / 2);
-        let threads = 256;
-        let blocks = (num_pairs + threads - 1) / threads;
-        let config = LaunchConfig::grid_2d(blocks, 1, threads, 1);
+        // PMAT-792: The `Rope` (NORM) PTX kernel indexes head = blockIdx.x and
+        // pair = threadIdx.x (see kernels/elementwise/rope/standard.rs). It MUST
+        // be launched as (num_heads blocks) × (head_dim/2 threads) — one block
+        // per head. The previous flat `num_pairs / 256` grid collapsed every
+        // head into block 0, so only head 0 was rotated and heads 1.. were left
+        // unwritten (output 0.0) for any multi-head NORM model. Match the NEOX
+        // launch (rope_neox_into) which already uses this 2D grid.
+        let config = LaunchConfig::grid_2d(num_heads, 1, head_dim / 2, 1);
 
         let mut ptr_input = input.as_ptr();
         let mut ptr_output = output.as_ptr();
@@ -327,11 +330,10 @@ impl CudaExecutor {
             .get_mut(&cache_key)
             .expect("module just inserted");
 
-        // Grid: 1 thread per rotation pair = num_heads * (head_dim / 2)
-        let num_pairs = num_heads * (head_dim / 2);
-        let threads = 256;
-        let blocks = (num_pairs + threads - 1) / threads;
-        let config = LaunchConfig::grid_2d(blocks, 1, threads, 1);
+        // PMAT-792: Same fix as `rope_into` — the `RopeIndirect` (NORM) kernel
+        // indexes head = blockIdx.x, pair = threadIdx.x, so launch one block per
+        // head with head_dim/2 threads. The old flat grid only rotated head 0.
+        let config = LaunchConfig::grid_2d(num_heads, 1, head_dim / 2, 1);
 
         let mut ptr_input = input.as_ptr();
         let mut ptr_output = output.as_ptr();

--- a/crates/aprender-serve/src/cuda/executor/residual.rs
+++ b/crates/aprender-serve/src/cuda/executor/residual.rs
@@ -96,6 +96,66 @@ impl CudaExecutor {
         Ok(())
     }
 
+    /// PMAT-792: RoPE NORM-style on GPU with host input/output (convenience).
+    ///
+    /// NORM (LLaMA default, `rope_type == 0`) rotates adjacent pairs
+    /// `(2*i, 2*i+1)`. This wrapper handles host↔device transfers so the
+    /// `Rope` PTX kernel can be parity-tested directly against the CPU
+    /// `OwnedQuantizedModel::apply_rope` reference. `input` must hold
+    /// `num_heads * head_dim` contiguous f32 values.
+    pub fn rope_host(
+        &mut self,
+        input: &[f32],
+        output: &mut [f32],
+        position: u32,
+        num_heads: u32,
+        head_dim: u32,
+        theta: f32,
+    ) -> Result<(), GpuError> {
+        let input_gpu = GpuBuffer::from_host(&self.context, input)?;
+        let output_gpu = GpuBuffer::new(&self.context, input.len())?;
+        self.rope_into(
+            &input_gpu,
+            &output_gpu,
+            position,
+            num_heads,
+            head_dim,
+            theta,
+        )?;
+        self.stream.synchronize()?;
+        output_gpu.copy_to_host(output)?;
+        Ok(())
+    }
+
+    /// PMAT-792: RoPE NEOX-style on GPU with host input/output (convenience).
+    ///
+    /// NEOX (`rope_type == 2`, Qwen/GPT-NeoX) rotates split halves
+    /// `(i, i + head_dim/2)`. Wrapper for parity-testing the `RopeNeox`
+    /// PTX kernel against the CPU `apply_rope` NEOX branch.
+    pub fn rope_neox_host(
+        &mut self,
+        input: &[f32],
+        output: &mut [f32],
+        position: u32,
+        num_heads: u32,
+        head_dim: u32,
+        theta: f32,
+    ) -> Result<(), GpuError> {
+        let input_gpu = GpuBuffer::from_host(&self.context, input)?;
+        let output_gpu = GpuBuffer::new(&self.context, input.len())?;
+        self.rope_neox_into(
+            &input_gpu,
+            &output_gpu,
+            position,
+            num_heads,
+            head_dim,
+            theta,
+        )?;
+        self.stream.synchronize()?;
+        output_gpu.copy_to_host(output)?;
+        Ok(())
+    }
+
     /// PAR-023: Residual Add on GPU with host input/output (synchronous convenience method)
     ///
     /// This is a convenience wrapper around `residual_add_gpu` that handles

--- a/crates/aprender-serve/tests/rope_kernel_parity.rs
+++ b/crates/aprender-serve/tests/rope_kernel_parity.rs
@@ -1,0 +1,199 @@
+//! PMAT-792: RoPE GPU kernel CPU↔GPU parity (NORM + NEOX pairing)
+//!
+//! Falsifiable, tolerance-bearing parity test for the GPU RoPE kernels,
+//! filling the gap left by `rope_parity.rs` (which is end-to-end argmax-only
+//! and never `assert!`s on divergence).
+//!
+//! This pins the two distinct RoPE pairing conventions on hardware:
+//!   - NORM  (`rope_type == 0`, LLaMA): adjacent pairs `(2*i, 2*i+1)`
+//!   - NEOX  (`rope_type == 2`, Qwen/GPT-NeoX): split halves `(i, i+head_dim/2)`
+//!
+//! The CPU reference below is byte-for-byte the math in
+//! `OwnedQuantizedModel::apply_rope` (crates/aprender-serve/src/gguf/inference/rope.rs):
+//!   freq = 1 / theta^(2*i / head_dim);  angle = pos * freq
+//!   x0' = x0*cos - x1*sin;  x1' = x0*sin + x1*cos
+//!
+//! A divergence here is the PMAT-216 / #2749 bug class: a GPU kernel that
+//! pairs elements differently from CPU silently corrupts every rotated vector.
+
+#![cfg(feature = "cuda")]
+
+/// CPU reference RoPE — mirrors `OwnedQuantizedModel::apply_rope`.
+/// `rope_neox = true` selects the NEOX split-half pairing; `false` is NORM.
+fn cpu_rope(
+    x: &[f32],
+    position: u32,
+    num_heads: u32,
+    head_dim: u32,
+    theta: f32,
+    rope_neox: bool,
+) -> Vec<f32> {
+    let head_dim = head_dim as usize;
+    let half_dim = head_dim / 2;
+    let pos_f32 = position as f32;
+    let head_dim_f32 = head_dim as f32;
+
+    // Pre-compute cos/sin for this position (reused across all heads).
+    let mut cos_vals = vec![0.0f32; half_dim];
+    let mut sin_vals = vec![0.0f32; half_dim];
+    for i in 0..half_dim {
+        let freq = 1.0f32 / theta.powf(2.0 * i as f32 / head_dim_f32);
+        let angle = pos_f32 * freq;
+        let (sin_v, cos_v) = angle.sin_cos();
+        cos_vals[i] = cos_v;
+        sin_vals[i] = sin_v;
+    }
+
+    let mut out = x.to_vec();
+    for h in 0..num_heads as usize {
+        let head_start = h * head_dim;
+        if head_start + head_dim > out.len() {
+            continue;
+        }
+        for i in 0..half_dim {
+            let (idx0, idx1) = if rope_neox {
+                // NEOX: split halves (i, i + half_dim)
+                (head_start + i, head_start + i + half_dim)
+            } else {
+                // NORM: adjacent pairs (2*i, 2*i+1)
+                (head_start + 2 * i, head_start + 2 * i + 1)
+            };
+            let x0 = x[idx0];
+            let x1 = x[idx1];
+            let cos_v = cos_vals[i];
+            let sin_v = sin_vals[i];
+            out[idx0] = x0 * cos_v - x1 * sin_v;
+            out[idx1] = x0 * sin_v + x1 * cos_v;
+        }
+    }
+    out
+}
+
+/// Deterministic pseudo-random-ish input so the test is reproducible.
+fn make_input(num_heads: u32, head_dim: u32) -> Vec<f32> {
+    let n = (num_heads * head_dim) as usize;
+    (0..n)
+        .map(|i| ((i as f32 * 0.137).sin() * 1.7) + ((i % 7) as f32 - 3.0) * 0.11)
+        .collect()
+}
+
+fn max_abs_diff(a: &[f32], b: &[f32]) -> (f32, usize) {
+    let mut max_diff = 0.0f32;
+    let mut max_idx = 0;
+    for (i, (x, y)) in a.iter().zip(b.iter()).enumerate() {
+        let d = (x - y).abs();
+        if d > max_diff {
+            max_diff = d;
+            max_idx = i;
+        }
+    }
+    (max_diff, max_idx)
+}
+
+/// PMAT-792: NORM-style RoPE GPU parity vs CPU `apply_rope` (rope_type 0).
+#[test]
+#[ignore] // Run with --features cuda -- --ignored on a CUDA host.
+fn test_cpu_gpu_rope_norm_parity() {
+    use realizar::cuda::CudaExecutor;
+
+    let mut executor = match CudaExecutor::new(0) {
+        Ok(e) => e,
+        Err(e) => {
+            eprintln!("CUDA init failed, cannot run RoPE parity: {e:?}");
+            panic!("PMAT-792: CUDA required for RoPE parity test");
+        },
+    };
+
+    // head_dim=128 (typical), theta=10000 (LLaMA), several positions + heads.
+    let head_dim = 128u32;
+    let theta = 10000.0f32;
+    let tolerance = 1e-3f32;
+
+    for &num_heads in &[1u32, 4, 8] {
+        let input = make_input(num_heads, head_dim);
+        for &position in &[0u32, 1, 7, 64, 511] {
+            let cpu = cpu_rope(&input, position, num_heads, head_dim, theta, false);
+
+            let mut gpu = vec![0.0f32; input.len()];
+            executor
+                .rope_host(&input, &mut gpu, position, num_heads, head_dim, theta)
+                .expect("rope_host (NORM) failed");
+
+            let (max_diff, idx) = max_abs_diff(&cpu, &gpu);
+            eprintln!(
+                "NORM  heads={num_heads:>2} pos={position:>4}  max_diff={max_diff:.3e} @ {idx}"
+            );
+            assert!(
+                max_diff < tolerance,
+                "PMAT-792 FAIL: NORM RoPE GPU diverged {max_diff:.3e} (> {tolerance:.0e}) \
+                 from CPU at idx {idx} (heads={num_heads}, pos={position}); CPU={:.6} GPU={:.6}",
+                cpu[idx],
+                gpu[idx],
+            );
+        }
+    }
+}
+
+/// PMAT-792: NEOX-style RoPE GPU parity vs CPU `apply_rope` (rope_type 2).
+#[test]
+#[ignore] // Run with --features cuda -- --ignored on a CUDA host.
+fn test_cpu_gpu_rope_neox_parity() {
+    use realizar::cuda::CudaExecutor;
+
+    let mut executor = match CudaExecutor::new(0) {
+        Ok(e) => e,
+        Err(e) => {
+            eprintln!("CUDA init failed, cannot run RoPE parity: {e:?}");
+            panic!("PMAT-792: CUDA required for RoPE parity test");
+        },
+    };
+
+    let head_dim = 128u32;
+    let theta = 1_000_000.0f32; // Qwen-style high theta stresses trig precision.
+    let tolerance = 1e-3f32;
+
+    for &num_heads in &[1u32, 4, 8] {
+        let input = make_input(num_heads, head_dim);
+        for &position in &[0u32, 1, 7, 64, 511] {
+            let cpu = cpu_rope(&input, position, num_heads, head_dim, theta, true);
+
+            let mut gpu = vec![0.0f32; input.len()];
+            executor
+                .rope_neox_host(&input, &mut gpu, position, num_heads, head_dim, theta)
+                .expect("rope_neox_host (NEOX) failed");
+
+            let (max_diff, idx) = max_abs_diff(&cpu, &gpu);
+            eprintln!(
+                "NEOX  heads={num_heads:>2} pos={position:>4}  max_diff={max_diff:.3e} @ {idx}"
+            );
+            assert!(
+                max_diff < tolerance,
+                "PMAT-792 FAIL: NEOX RoPE GPU diverged {max_diff:.3e} (> {tolerance:.0e}) \
+                 from CPU at idx {idx} (heads={num_heads}, pos={position}); CPU={:.6} GPU={:.6}",
+                cpu[idx],
+                gpu[idx],
+            );
+        }
+    }
+}
+
+/// Cross-check: NORM and NEOX produce DIFFERENT results for the same input
+/// (guards against the two kernels collapsing to the same pairing — which
+/// would mask a pairing bug). This runs CPU-only, no GPU required.
+#[test]
+fn test_norm_vs_neox_differ() {
+    let head_dim = 128u32;
+    let num_heads = 4u32;
+    let theta = 10000.0f32;
+    let input = make_input(num_heads, head_dim);
+    let position = 7u32;
+
+    let norm = cpu_rope(&input, position, num_heads, head_dim, theta, false);
+    let neox = cpu_rope(&input, position, num_heads, head_dim, theta, true);
+
+    let (max_diff, _) = max_abs_diff(&norm, &neox);
+    assert!(
+        max_diff > 1e-2,
+        "NORM and NEOX pairings should differ substantially; max_diff={max_diff:.3e}"
+    );
+}


### PR DESCRIPTION
## RoPE NORM GPU kernel rotated only head 0 — fixed (parity improved; NOT a full LLaMA-GPU fix)

Found by a CPU↔GPU kernel parity audit on real Blackwell (GB10 sm_121). The `Rope`/`RopeIndirect` **NORM** PTX kernels (LLaMA/Mistral/TinyLlama pairing) index `head = blockIdx.x`, `pair = threadIdx.x` — they require **(num_heads blocks) × (head_dim/2 threads)**, one block per head. But `rope_into`/`rope_indirect_into` (`cuda/executor/fused_ffn.rs`) launched a **flat grid**, collapsing every head into block 0 → **only head 0 was rotated; heads 1..N-1 stayed 0.0**. The NEOX kernels (Qwen) used the correct per-head 2D grid, so they were unaffected and this stayed hidden.

## Fix
Launch both NORM rope kernels with `grid_2d(num_heads, 1, head_dim/2, 1)`, matching NEOX.

## Verified on GB10 (real hardware)
- **Kernel parity** (`rope_kernel_parity.rs`, NORM heads∈{1,4,8} all positions): max_diff **2.03 → ~1e-4**. All heads now rotate.
- **End-to-end first-token cosine** (TinyLlama-1.1B NORM GQA): **0.954 → 0.969** — a real improvement.
- RMSNorm/attention(GQA)/SwiGLU all parity-clean; Qwen (NEOX) GPU decode unaffected (coherent, cosine ≥ 0.98).

## HONEST SCOPE (corrected after end-to-end verification)
This is **necessary but not sufficient** for LLaMA-family GPU coherence. After the fix, TinyLlama's first-token cosine (0.969) is **still below the 0.98 parity gate**, so `apr run --gpu` still (correctly) **falls back to CPU** for LLaMA-NORM-GQA models. A **separate residual non-RoPE GPU divergence** remains in that forward path — tracked as a follow-up (PMAT-798). So the claim is "RoPE NORM now rotates all heads / parity improved 0.954→0.969", NOT "LLaMA/Mistral GPU decode is now coherent."

🤖 Generated with [Claude Code](https://claude.com/claude-code)