### PR TITLE
fix(serve): single-request quantized generation ignored top_p (nucleus sampling) — PMAT-794

### DIFF
--- a/contracts/sampling-algorithms-v1.yaml
+++ b/contracts/sampling-algorithms-v1.yaml
@@ -1,5 +1,5 @@
 metadata:
-  version: 1.0.0
+  version: 1.1.0
   created: '2026-02-18'
   author: PAIML Engineering
   description: Sampling algorithm invariants for autoregressive generation
@@ -95,6 +95,19 @@ falsification_tests:
   prediction: SIMD sampling matches scalar
   test: proptest
   if_fails: ' compare scalar vs SIMD sampling:SIMD sampler selects different tokens'
+- id: FALSIFY-SA-006
+  rule: Single-request quantized path honors top_p
+  prediction: >-
+    The live single-request quantized sampler (OwnedQuantizedModel::sample_topk_top_p,
+    PMAT-794) applies the per-request top_p nucleus cutoff. Logits [3,0,0,0] at temp
+    1.0, top_k 4, top_p 0.85 collapse the nucleus to {token0} so every draw returns
+    index 0. With top_p >= 1.0 the nucleus is a no-op (no regression vs sample_topk).
+  test: >-
+    aprender-serve sample_topk_top_p unit tests
+    (test_sample_topk_top_p_restricts_nucleus_to_dominant_token + no-regression cases)
+  if_fails: >-
+    top_p silently dropped (the pre-PMAT-794 bug) — low-probability tokens leak through
+    the full top_k distribution even when the request restricts the nucleus
 kani_harnesses:
 - id: KANI-SA-001
   obligation: SA-EQ-001
@@ -137,5 +150,6 @@ qa_gate:
   - top_k_cardinality
   - top_p_cumulative
   - temperature_identity
-  pass_criteria: All 5 falsification tests pass
+  - single_request_top_p
+  pass_criteria: All 6 falsification tests pass
   falsification: Set K=0 to observe empty filtered set

--- a/crates/aprender-serve/src/gguf/cuda/generate_1.rs
+++ b/crates/aprender-serve/src/gguf/cuda/generate_1.rs
@@ -175,7 +175,12 @@ impl OwnedQuantizedModelCuda {
                 tok
             } else {
                 let logits = self.forward_gpu_resident(last_token, &mut cache, position)?;
-                OwnedQuantizedModel::sample_topk(&logits, config.temperature, config.top_k)
+                OwnedQuantizedModel::sample_topk_top_p(
+                    &logits,
+                    config.temperature,
+                    config.top_k,
+                    config.top_p,
+                )
             };
 
             // Check stop tokens

--- a/crates/aprender-serve/src/gguf/cuda/generate_2.rs
+++ b/crates/aprender-serve/src/gguf/cuda/generate_2.rs
@@ -525,8 +525,13 @@ impl OwnedQuantizedModelCuda {
                 self.forward_gpu_resident_to_token_id(last_token, &mut cache, position)?
             } else {
                 let logits = self.forward_gpu_resident(last_token, &mut cache, position)?;
-                // entrenar#318: use simple top-k sampling (sample_advanced not yet compiled)
-                OwnedQuantizedModel::sample_topk(&logits, config.temperature, config.top_k)
+                // PMAT-794: honor per-request top_p (nucleus) — sample_topk silently dropped it.
+                OwnedQuantizedModel::sample_topk_top_p(
+                    &logits,
+                    config.temperature,
+                    config.top_k,
+                    config.top_p,
+                )
             };
 
             if config.trace {
@@ -664,7 +669,13 @@ impl OwnedQuantizedModelCuda {
             let next_token = if greedy {
                 OwnedQuantizedModel::argmax(&logits)
             } else {
-                OwnedQuantizedModel::sample_topk(&logits, config.temperature, config.top_k)
+                // PMAT-794: honor per-request top_p (nucleus) — sample_topk silently dropped it.
+                OwnedQuantizedModel::sample_topk_top_p(
+                    &logits,
+                    config.temperature,
+                    config.top_k,
+                    config.top_p,
+                )
             };
             token_logprobs.push(TokenLogprob {
                 token_id: next_token,

--- a/crates/aprender-serve/src/gguf/inference/forward/batched.rs
+++ b/crates/aprender-serve/src/gguf/inference/forward/batched.rs
@@ -336,10 +336,11 @@ impl OwnedQuantizedModel {
             let next_token = if config.temperature == 0.0 || config.top_k == 1 {
                 ops::argmax(&logits)
             } else {
-                crate::gguf::OwnedQuantizedModel::sample_topk(
+                crate::gguf::OwnedQuantizedModel::sample_topk_top_p(
                     &logits,
                     config.temperature,
                     config.top_k,
+                    config.top_p,
                 )
             };
 
@@ -413,10 +414,11 @@ impl OwnedQuantizedModel {
             let next_token = if config.temperature == 0.0 || config.top_k == 1 {
                 ops::argmax(&logits)
             } else {
-                crate::gguf::OwnedQuantizedModel::sample_topk(
+                crate::gguf::OwnedQuantizedModel::sample_topk_top_p(
                     &logits,
                     config.temperature,
                     config.top_k,
+                    config.top_p,
                 )
             };
 

--- a/crates/aprender-serve/src/gguf/inference/generate_quantized.rs
+++ b/crates/aprender-serve/src/gguf/inference/generate_quantized.rs
@@ -59,8 +59,13 @@ impl OwnedQuantizedModel {
                 // Greedy decoding
                 Self::argmax(&logits)
             } else {
-                // Temperature + top-k sampling
-                Self::sample_topk(&logits, config.temperature, config.top_k)
+                // Temperature + top-k + top-p (nucleus) sampling (PMAT-794)
+                Self::sample_topk_top_p(
+                    &logits,
+                    config.temperature,
+                    config.top_k,
+                    config.top_p,
+                )
             };
 
             // Check stop condition
@@ -110,6 +115,64 @@ impl OwnedQuantizedModel {
         let mut rng = rand::rng();
         let r: f32 = rng.random();
 
+        let mut cumulative = 0.0;
+        for &(idx, prob) in &probs {
+            cumulative += prob;
+            if cumulative >= r {
+                return idx as u32;
+            }
+        }
+
+        probs.last().map_or(0, |(idx, _)| *idx as u32)
+    }
+
+    /// Top-k + top-p (nucleus) sampling with temperature (PMAT-794).
+    ///
+    /// This is the live single-request sampler. It applies the full
+    /// `temperature → top-k truncate → top-p nucleus → softmax → inverse-CDF sample`
+    /// pipeline, honoring the per-request `top_p` that plain [`sample_topk`] silently
+    /// dropped. When `top_p >= 1.0` (or out of `(0,1)`) the nucleus step is a no-op, so
+    /// every all-default and top_k-only request behaves exactly as the old `sample_topk`
+    /// path — no regression. Mirrors the batched-decode fix (`select_batched_token`,
+    /// PMAT-792b / #2080) so single-request and continuous-batching paths sample identically.
+    pub fn sample_topk_top_p(logits: &[f32], temperature: f32, top_k: usize, top_p: f32) -> u32 {
+        // 1. Temperature scaling.
+        let scaled: Vec<f32> = logits.iter().map(|&x| x / temperature).collect();
+
+        // 2. Top-k: sort descending, truncate.
+        let mut indexed: Vec<(usize, f32)> = scaled.iter().copied().enumerate().collect();
+        indexed.sort_by(|(_, a), (_, b)| b.partial_cmp(a).unwrap_or(std::cmp::Ordering::Equal));
+        indexed.truncate(top_k);
+
+        // 3. Top-p (nucleus): keep the smallest prefix whose cumulative probability reaches
+        //    top_p. Skipped when top_p is out of (0,1) — a no-op preserving the top_k path.
+        if top_p > 0.0 && top_p < 1.0 {
+            let max_val = indexed.first().map_or(0.0, |(_, v)| *v);
+            let exp_vals: Vec<f32> = indexed.iter().map(|(_, v)| (v - max_val).exp()).collect();
+            let total: f32 = exp_vals.iter().sum();
+            let mut cumulative = 0.0;
+            let mut cutoff = indexed.len();
+            for (i, &ev) in exp_vals.iter().enumerate() {
+                cumulative += ev / total;
+                if cumulative >= top_p {
+                    cutoff = i + 1;
+                    break;
+                }
+            }
+            indexed.truncate(cutoff);
+        }
+
+        // 4. Softmax over the surviving set.
+        let max_val = indexed.first().map_or(0.0, |(_, v)| *v);
+        let exp_sum: f32 = indexed.iter().map(|(_, v)| (v - max_val).exp()).sum();
+        let probs: Vec<(usize, f32)> = indexed
+            .iter()
+            .map(|(i, v)| (*i, (v - max_val).exp() / exp_sum))
+            .collect();
+
+        // 5. Inverse-CDF sample.
+        let mut rng = rand::rng();
+        let r: f32 = rng.random();
         let mut cumulative = 0.0;
         for &(idx, prob) in &probs {
             cumulative += prob;
@@ -239,10 +302,11 @@ impl OwnedQuantizedModel {
             let next_token = if config.temperature == 0.0 || config.top_k == 1 {
                 ops::argmax(&logits)
             } else {
-                crate::gguf::OwnedQuantizedModel::sample_topk(
+                crate::gguf::OwnedQuantizedModel::sample_topk_top_p(
                     &logits,
                     config.temperature,
                     config.top_k,
+                    config.top_p,
                 )
             };
 
@@ -416,10 +480,11 @@ impl OwnedQuantizedModel {
             let next_token = if config.temperature == 0.0 || config.top_k == 1 {
                 ops::argmax(&logits)
             } else {
-                crate::gguf::OwnedQuantizedModel::sample_topk(
+                crate::gguf::OwnedQuantizedModel::sample_topk_top_p(
                     &logits,
                     config.temperature,
                     config.top_k,
+                    config.top_p,
                 )
             };
 

--- a/crates/aprender-serve/src/gguf/inference/generate_scratch.rs
+++ b/crates/aprender-serve/src/gguf/inference/generate_scratch.rs
@@ -81,10 +81,11 @@ impl OwnedQuantizedModel {
             let next_token = if config.temperature == 0.0 || config.top_k == 1 {
                 ops::argmax(&scratch.logits)
             } else {
-                crate::gguf::OwnedQuantizedModel::sample_topk(
+                crate::gguf::OwnedQuantizedModel::sample_topk_top_p(
                     &scratch.logits,
                     config.temperature,
                     config.top_k,
+                    config.top_p,
                 )
             };
 
@@ -186,10 +187,11 @@ impl OwnedQuantizedModel {
             let next_token = if config.temperature == 0.0 || config.top_k == 1 {
                 ops::argmax(&logits)
             } else {
-                crate::gguf::OwnedQuantizedModel::sample_topk(
+                crate::gguf::OwnedQuantizedModel::sample_topk_top_p(
                     &logits,
                     config.temperature,
                     config.top_k,
+                    config.top_p,
                 )
             };
 

--- a/crates/aprender-serve/src/gguf/inference/generation_argmax_basic.rs
+++ b/crates/aprender-serve/src/gguf/inference/generation_argmax_basic.rs
@@ -202,4 +202,79 @@ mod tests {
             assert!(result < 3, "Invalid token index: {}", result);
         }
     }
+
+    // ============================================================================
+    // PMAT-794: sample_topk_top_p — single-request nucleus (top-p) sampling.
+    //
+    // Mirrors the batched-decode fix (PMAT-792b / #2080). The live single-request
+    // sampler `sample_topk` silently dropped `config.top_p`, so a request asking for
+    // e.g. top_p=0.1 got the full top_k distribution sampled (low-prob tokens leaked).
+    // `sample_topk_top_p` applies temperature → top-k truncate → top-p nucleus →
+    // softmax → inverse-CDF sample, honoring the per-request top_p.
+    // ============================================================================
+
+    #[test]
+    fn test_sample_topk_top_p_restricts_nucleus_to_dominant_token() {
+        // PMAT-794 FALSIFIER (the load-bearing test). Logits [3.0, 0, 0, 0] at temp 1.0
+        // softmax to P(token0) ≈ 0.870, P(each other) ≈ 0.043. With top_p = 0.85 the
+        // nucleus (smallest prefix with cumulative prob >= top_p) is exactly {token0}
+        // (0.870 >= 0.85), so EVERY draw must return index 0. top_k = 4 keeps the whole
+        // vocabulary, so the only thing that can restrict the sample is top_p.
+        //
+        // BEFORE the fix the single-request path called `sample_topk`, which silently
+        // dropped top_p: the full 4-way distribution stayed samplable, P(non-token0) ≈
+        // 0.13 per draw, and over 512 draws a non-zero token is effectively certain
+        // (0.87^512 ≈ 0) → this loop fails (RED). AFTER the fix the nucleus collapses to
+        // {token0} and every draw is deterministic (GREEN).
+        let logits = [3.0_f32, 0.0, 0.0, 0.0];
+        for _ in 0..512 {
+            let tok = OwnedQuantizedModel::sample_topk_top_p(&logits, 1.0, 4, 0.85);
+            assert_eq!(
+                tok, 0,
+                "top_p=0.85 must collapse the nucleus to the dominant token 0, got {tok} \
+                 (top_p silently dropped → low-prob token leaked through)"
+            );
+        }
+    }
+
+    #[test]
+    fn test_sample_topk_top_p_one_is_a_noop_nucleus() {
+        // No-regression: top_p == 1.0 (and > 1.0) skips the nucleus cutoff → identical to
+        // the pure top_k path. top_k == 1 always returns the argmax, verifying equivalence.
+        assert_eq!(
+            OwnedQuantizedModel::sample_topk_top_p(&[1.0, 5.0, 2.0], 1.5, 1, 1.0),
+            1
+        );
+        assert_eq!(
+            OwnedQuantizedModel::sample_topk_top_p(&[1.0, 5.0, 2.0], 1.5, 1, 2.0),
+            1
+        );
+        assert_eq!(
+            OwnedQuantizedModel::sample_topk_top_p(&[9.0, 5.0, 2.0], 0.9, 1, 1.0),
+            0
+        );
+    }
+
+    #[test]
+    fn test_sample_topk_top_p_reachable_with_top_p_one() {
+        // No-regression: with top_p == 1.0 the result is always a valid in-range token
+        // and stays within the top_k set — same observable behavior as `sample_topk`.
+        let logits = vec![1.0, 2.0, 3.0, 0.5, 0.1];
+        for _ in 0..64 {
+            let tok = OwnedQuantizedModel::sample_topk_top_p(&logits, 1.0, 3, 1.0);
+            // top_k == 3 keeps tokens {2, 1, 0} (logits 3,2,1); top_p == 1.0 is a no-op.
+            assert!(tok < 3, "top_p=1.0 must keep the full top_k set, got {tok}");
+        }
+    }
+
+    #[test]
+    fn test_sample_topk_top_p_low_p_concentrates_on_argmax() {
+        // A very small top_p (0.05) keeps only the single most-probable token even when
+        // top_k is large — the nucleus can never be empty (always >= 1 token).
+        let logits = vec![0.0, 0.0, 8.0, 0.0, 0.0];
+        for _ in 0..128 {
+            let tok = OwnedQuantizedModel::sample_topk_top_p(&logits, 1.0, 40, 0.05);
+            assert_eq!(tok, 2, "tiny top_p must collapse to the dominant token, got {tok}");
+        }
+    }
 }


### PR DESCRIPTION
## top_p silently dropped across ALL quantized single-request generation

Found by the batching audit's secondary finding (companion to #2080's batched fix). The live single-request quantized sampler `OwnedQuantizedModel::sample_topk(logits, temperature, top_k)` (`gguf/inference/generate_quantized.rs`) applied only temperature + top-k and **never received `config.top_p`** — even though `QuantizedGenerateConfig.top_p` exists and is plumbed per request. So `apr run`/`apr serve` requests asking `top_p=0.1` got the full top_k distribution sampled (low-prob tokens leak). The only top_p-aware sampler (`sample_advanced` in `fails.rs`) is **dead code** (no live `mod`/`include!`).

## Fix
New `sample_topk_top_p` applying the canonical pipeline (temperature → top-k truncate → **top-p nucleus** → softmax → inverse-CDF), **reusing the exact verified nucleus logic from #2080** so single-request and continuous-batching sample identically. `sample_topk` left byte-identical (its other callers untouched). All live single-request decode sites now pass `config.top_p`: CPU (`generate`/`_with_cache`/streaming, `generate_with_scratch`, batched-prefill), and GPU-resident (`generate_gpu_resident`/`_logprobs`/`_streaming`).

## Verified
- Falsifier `test_sample_topk_top_p_restricts_nucleus_to_dominant_token` (`[3,0,0,0]` @ temp 1.0, top_k 4, top_p 0.85 → nucleus `{token0}`): **RED** with nucleus disabled (token 3 leaked), **GREEN** with the fix. Plus a low-p concentrate test.
- No-regression: `top_p >= 1.0` is a no-op nucleus → identical to pure top_k (verified); greedy (temp==0/top_k==1) handled before sampling, unaffected.
- **15312 aprender-serve lib tests pass**, 0 failed; 63 generation tests pass; fmt + clippy clean; `cargo check --features cuda` types the GPU sites.
- Contract co-evolution (Rule 7): `sampling-algorithms-v1.yaml` 1.0.0→1.1.0, `FALSIFY-SA-006` + `single_request_top_p` gate; `pv validate` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)