### PR TITLE
fix(serve): /v1/embeddings rejected batch array input (HTTP 422) — PMAT-802

### DIFF
--- a/crates/aprender-serve/src/api/mod.rs
+++ b/crates/aprender-serve/src/api/mod.rs
@@ -86,8 +86,8 @@ pub(crate) use realize_handlers::{logprobs_handler, perplexity_handler};
 // Public exports for tests
 pub use realize_handlers::{
     CompletionChoice, CompletionRequest, CompletionResponse, ContextWindowConfig,
-    ContextWindowManager, EmbeddingData, EmbeddingRequest, EmbeddingResponse, EmbeddingUsage,
-    ModelLineage, ModelMetadataResponse, ReloadRequest, ReloadResponse,
+    ContextWindowManager, EmbeddingData, EmbeddingInput, EmbeddingRequest, EmbeddingResponse,
+    EmbeddingUsage, ModelLineage, ModelMetadataResponse, ReloadRequest, ReloadResponse,
 };
 mod apr_handlers;
 pub(crate) use apr_handlers::{apr_audit_handler, apr_explain_handler, apr_predict_handler};

--- a/crates/aprender-serve/src/api/realize_handlers.rs
+++ b/crates/aprender-serve/src/api/realize_handlers.rs
@@ -269,11 +269,75 @@ pub fn clean_chat_output(text: &str) -> String {
 // Native Realizar API Handlers (spec §5.2)
 // ============================================================================
 
+/// OpenAI `/v1/embeddings` `input` field: a single string OR an array of strings.
+///
+/// PMAT-802: the OpenAI Embeddings API contract accepts `input` as either a JSON
+/// string (`"hello"`) or a JSON array of strings (`["a", "b"]`), returning one
+/// embedding per input. Previously `input` was typed `String`, so any batch request
+/// (`["a","b"]`) was rejected at deserialization with a 4xx — every OpenAI SDK that
+/// batches embeddings failed against this server. This untagged form accepts both.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum EmbeddingInput {
+    /// Single input string.
+    Single(String),
+    /// Batch of input strings (one embedding returned per element, in order).
+    Batch(Vec<String>),
+}
+
+impl EmbeddingInput {
+    /// Number of inputs (1 for a single string, N for a batch).
+    #[must_use]
+    pub fn len(&self) -> usize {
+        match self {
+            EmbeddingInput::Single(_) => 1,
+            EmbeddingInput::Batch(v) => v.len(),
+        }
+    }
+
+    /// True when this is a `Batch` with no elements.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        match self {
+            EmbeddingInput::Single(_) => false,
+            EmbeddingInput::Batch(v) => v.is_empty(),
+        }
+    }
+
+    /// Iterate the input strings in request order (preserves index ordering).
+    pub fn iter(&self) -> impl Iterator<Item = &str> {
+        // Box to unify the two iterator types.
+        let it: Box<dyn Iterator<Item = &str>> = match self {
+            EmbeddingInput::Single(s) => Box::new(std::iter::once(s.as_str())),
+            EmbeddingInput::Batch(v) => Box::new(v.iter().map(String::as_str)),
+        };
+        it
+    }
+}
+
+impl From<String> for EmbeddingInput {
+    fn from(s: String) -> Self {
+        EmbeddingInput::Single(s)
+    }
+}
+
+impl From<&str> for EmbeddingInput {
+    fn from(s: &str) -> Self {
+        EmbeddingInput::Single(s.to_string())
+    }
+}
+
+impl From<Vec<String>> for EmbeddingInput {
+    fn from(v: Vec<String>) -> Self {
+        EmbeddingInput::Batch(v)
+    }
+}
+
 /// Request for embeddings
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EmbeddingRequest {
-    /// Text to embed
-    pub input: String,
+    /// Text to embed (single string or batch array — OpenAI contract).
+    pub input: EmbeddingInput,
     /// Model ID (optional)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,

--- a/crates/aprender-serve/src/api/realize_handlers_completion_request.rs
+++ b/crates/aprender-serve/src/api/realize_handlers_completion_request.rs
@@ -309,28 +309,30 @@
 
     #[test]
     fn test_embedding_request_empty_input() {
+        // A single empty string is still ONE input (len 1); round-trips as a JSON string.
         let request = EmbeddingRequest {
-            input: String::new(),
+            input: String::new().into(),
             model: None,
         };
         let json = serde_json::to_string(&request).expect("serialize");
         let parsed: EmbeddingRequest = serde_json::from_str(&json).expect("deserialize");
-        assert!(parsed.input.is_empty());
+        assert_eq!(parsed.input.len(), 1);
     }
 
     #[test]
     fn test_embedding_request_long_input() {
+        // input.len() is the NUMBER OF INPUTS (OpenAI semantics), not the char count.
         let request = EmbeddingRequest {
-            input: "word ".repeat(1000),
+            input: "word ".repeat(1000).into(),
             model: Some("ada".to_string()),
         };
-        assert_eq!(request.input.len(), 5000);
+        assert_eq!(request.input.len(), 1);
     }
 
     #[test]
     fn test_embedding_request_debug() {
         let request = EmbeddingRequest {
-            input: "test".to_string(),
+            input: "test".to_string().into(),
             model: None,
         };
         let debug = format!("{:?}", request);
@@ -339,13 +341,71 @@
 
     #[test]
     fn test_embedding_request_clone() {
+        use crate::api::realize_handlers::EmbeddingInput;
         let request = EmbeddingRequest {
-            input: "clone test".to_string(),
+            input: "clone test".to_string().into(),
             model: Some("model-a".to_string()),
         };
         let cloned = request.clone();
-        assert_eq!(cloned.input, "clone test");
+        assert_eq!(cloned.input, EmbeddingInput::Single("clone test".to_string()));
         assert_eq!(cloned.model, Some("model-a".to_string()));
+    }
+
+    // =========================================================================
+    // PMAT-802 FALSIFIER: OpenAI `/v1/embeddings` accepts `input` as a single
+    // string OR an array of strings. Before the fix, `input` was typed `String`,
+    // so an array request was rejected at deserialization (4xx) — every OpenAI SDK
+    // that batches embeddings failed against this server. These tests pin the
+    // string-or-array contract and the untagged serialization shape.
+    // =========================================================================
+
+    #[test]
+    fn test_embedding_request_accepts_batch_array_input() {
+        use crate::api::realize_handlers::EmbeddingInput;
+        // FALSIFIER: this JSON array body MUST deserialize. Pre-fix (`input: String`)
+        // this returned a serde error, not a request.
+        let json = r#"{"input":["alpha","beta","gamma"],"model":"m"}"#;
+        let req: EmbeddingRequest =
+            serde_json::from_str(json).expect("array input must deserialize (OpenAI contract)");
+        assert_eq!(
+            req.input,
+            EmbeddingInput::Batch(vec![
+                "alpha".to_string(),
+                "beta".to_string(),
+                "gamma".to_string(),
+            ])
+        );
+        assert_eq!(req.input.len(), 3);
+        // Index order is preserved by `iter()` (so response data[i].index == i).
+        let collected: Vec<&str> = req.input.iter().collect();
+        assert_eq!(collected, vec!["alpha", "beta", "gamma"]);
+    }
+
+    #[test]
+    fn test_embedding_request_still_accepts_single_string() {
+        use crate::api::realize_handlers::EmbeddingInput;
+        // Backward compatibility: the single-string form is unchanged.
+        let json = r#"{"input":"just one"}"#;
+        let req: EmbeddingRequest =
+            serde_json::from_str(json).expect("string input must still deserialize");
+        assert_eq!(req.input, EmbeddingInput::Single("just one".to_string()));
+        assert_eq!(req.input.len(), 1);
+    }
+
+    #[test]
+    fn test_embedding_input_untagged_serialize_roundtrip() {
+        use crate::api::realize_handlers::EmbeddingInput;
+        // Single serializes as a bare JSON string; batch as a JSON array (untagged).
+        let single = EmbeddingInput::Single("x".to_string());
+        assert_eq!(serde_json::to_string(&single).expect("ser"), r#""x""#);
+        let batch = EmbeddingInput::Batch(vec!["a".to_string(), "b".to_string()]);
+        assert_eq!(serde_json::to_string(&batch).expect("ser"), r#"["a","b"]"#);
+        // Round-trip both forms.
+        for v in [single, batch] {
+            let j = serde_json::to_string(&v).expect("ser");
+            let back: EmbeddingInput = serde_json::from_str(&j).expect("de");
+            assert_eq!(v, back);
+        }
     }
 
     // =========================================================================

--- a/crates/aprender-serve/src/api/realize_handlers_context_window.rs
+++ b/crates/aprender-serve/src/api/realize_handlers_context_window.rs
@@ -244,18 +244,19 @@
 
     #[test]
     fn test_embedding_request_basic() {
+        use crate::api::realize_handlers::EmbeddingInput;
         let request = EmbeddingRequest {
-            input: "Hello world".to_string(),
+            input: "Hello world".to_string().into(),
             model: Some("text-embedding-ada-002".to_string()),
         };
-        assert_eq!(request.input, "Hello world");
+        assert_eq!(request.input, EmbeddingInput::Single("Hello world".to_string()));
         assert!(request.model.is_some());
     }
 
     #[test]
     fn test_embedding_request_serialization() {
         let request = EmbeddingRequest {
-            input: "test".to_string(),
+            input: "test".to_string().into(),
             model: None,
         };
         let json = serde_json::to_string(&request).expect("serialize");
@@ -266,9 +267,10 @@
 
     #[test]
     fn test_embedding_request_deserialization() {
+        use crate::api::realize_handlers::EmbeddingInput;
         let json = r#"{"input": "hello"}"#;
         let request: EmbeddingRequest = serde_json::from_str(json).expect("deserialize");
-        assert_eq!(request.input, "hello");
+        assert_eq!(request.input, EmbeddingInput::Single("hello".to_string()));
         assert!(request.model.is_none());
     }
 

--- a/crates/aprender-serve/src/api/realize_handlers_embed_completion.rs
+++ b/crates/aprender-serve/src/api/realize_handlers_embed_completion.rs
@@ -14,35 +14,45 @@ pub async fn realize_embed_handler(
         )
     })?;
 
-    // Tokenize input
-    let token_ids = tokenizer.encode(&request.input);
-    let prompt_tokens = token_ids.len();
+    // PMAT-802: OpenAI `/v1/embeddings` accepts `input` as a single string OR an array
+    // of strings, returning one embedding per input in request order. Loop over every
+    // input so a batch request yields `data[i]` with `index == i` (previously only the
+    // single-string form was supported — array input was rejected at deserialization).
+    let mut data = Vec::with_capacity(request.input.len());
+    let mut prompt_tokens = 0usize;
 
-    // Generate simple embedding from token frequencies
-    // In production, this would use the model's hidden states
-    let mut embedding = vec![0.0f32; 384]; // 384-dim embedding
+    for (index, text) in request.input.iter().enumerate() {
+        let token_ids = tokenizer.encode(text);
+        prompt_tokens += token_ids.len();
 
-    for (i, &token_id) in token_ids.iter().enumerate() {
-        let idx = (token_id as usize) % embedding.len();
-        let pos_weight = 1.0 / (1.0 + i as f32);
-        embedding[idx] += pos_weight;
-    }
+        // Generate simple embedding from token frequencies
+        // In production, this would use the model's hidden states
+        let mut embedding = vec![0.0f32; 384]; // 384-dim embedding
 
-    // L2 normalize
-    let norm: f32 = embedding.iter().map(|x| x * x).sum::<f32>().sqrt();
-    if norm > 0.0 {
-        for v in &mut embedding {
-            *v /= norm;
+        for (i, &token_id) in token_ids.iter().enumerate() {
+            let idx = (token_id as usize) % embedding.len();
+            let pos_weight = 1.0 / (1.0 + i as f32);
+            embedding[idx] += pos_weight;
         }
+
+        // L2 normalize
+        let norm: f32 = embedding.iter().map(|x| x * x).sum::<f32>().sqrt();
+        if norm > 0.0 {
+            for v in &mut embedding {
+                *v /= norm;
+            }
+        }
+
+        data.push(EmbeddingData {
+            object: "embedding".to_string(),
+            index,
+            embedding,
+        });
     }
 
     Ok(Json(EmbeddingResponse {
         object: "list".to_string(),
-        data: vec![EmbeddingData {
-            object: "embedding".to_string(),
-            index: 0,
-            embedding,
-        }],
+        data,
         model: request.model.unwrap_or_else(|| "default".to_string()),
         usage: EmbeddingUsage {
             prompt_tokens,

--- a/crates/aprender-serve/src/api/tests/chat_completion_03.rs
+++ b/crates/aprender-serve/src/api/tests/chat_completion_03.rs
@@ -380,11 +380,11 @@ fn test_context_window_config_default_cov() {
 #[test]
 fn test_embedding_request_fields_cov() {
     let req = EmbeddingRequest {
-        input: "Some text to embed".to_string(),
+        input: "Some text to embed".to_string().into(),
         model: Some("text-embedding".to_string()),
     };
     assert!(req.model.is_some());
-    assert!(req.input.contains("embed"));
+    assert!(req.input.iter().any(|s| s.contains("embed")));
 }
 
 // =========================================================================

--- a/crates/aprender-serve/src/api/tests/context_window_serde.rs
+++ b/crates/aprender-serve/src/api/tests/context_window_serde.rs
@@ -359,21 +359,23 @@ fn test_clean_chat_output_double_newline_user() {
 
 #[test]
 fn test_embedding_request_serde() {
+    use crate::api::realize_handlers::EmbeddingInput;
     let req = EmbeddingRequest {
-        input: "test".to_string(),
+        input: "test".to_string().into(),
         model: Some("default".to_string()),
     };
     let json = serde_json::to_string(&req).expect("JSON serialization failed");
     let parsed: EmbeddingRequest = serde_json::from_str(&json).expect("JSON deserialization failed");
-    assert_eq!(parsed.input, "test");
+    assert_eq!(parsed.input, EmbeddingInput::Single("test".to_string()));
     assert_eq!(parsed.model.as_deref(), Some("default"));
 }
 
 #[test]
 fn test_embedding_request_no_model() {
+    use crate::api::realize_handlers::EmbeddingInput;
     let json = r#"{"input":"hello"}"#;
     let req: EmbeddingRequest = serde_json::from_str(json).expect("JSON deserialization failed");
-    assert_eq!(req.input, "hello");
+    assert_eq!(req.input, EmbeddingInput::Single("hello".to_string()));
     assert!(req.model.is_none());
 }
 

--- a/crates/aprender-serve/src/api/tests/deep_apicov.rs
+++ b/crates/aprender-serve/src/api/tests/deep_apicov.rs
@@ -88,6 +88,50 @@ async fn test_deep_apicov_realize_embed_default_model() {
     assert_eq!(result.data[0].embedding.len(), 384); // 384-dim embedding
 }
 
+/// PMAT-802 FALSIFIER (e2e): a batch `input` array must yield one embedding per
+/// input, with `data[i].index == i` in request order. Pre-fix the array body was
+/// rejected at deserialization (422). Tolerates mock-state error responses (as the
+/// sibling tests do), but when OK the batch shape is asserted.
+#[tokio::test]
+async fn test_deep_apicov_embeddings_batch_array_input() {
+    let app = create_test_app_shared();
+    let json = r#"{"input":["first input","second input","third input"]}"#;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/embeddings")
+                .header("content-type", "application/json")
+                .body(Body::from(json))
+                .expect("test"),
+        )
+        .await
+        .expect("test");
+
+    // The array body must NOT be rejected as malformed (422 UNPROCESSABLE_ENTITY).
+    assert_ne!(
+        response.status(),
+        StatusCode::UNPROCESSABLE_ENTITY,
+        "batch array input must deserialize (OpenAI contract)"
+    );
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("test");
+    let result: EmbeddingResponse = match serde_json::from_slice(&body) {
+        Ok(v) => v,
+        Err(_) => return, // Mock state: error response, skip body assertions
+    };
+    assert_eq!(result.object, "list");
+    assert_eq!(result.data.len(), 3, "one embedding per input");
+    for (i, d) in result.data.iter().enumerate() {
+        assert_eq!(d.index, i, "data[i].index must equal i (request order)");
+        assert_eq!(d.embedding.len(), 384);
+        assert!(d.embedding.iter().all(|v| v.is_finite()));
+    }
+}
+
 #[tokio::test]
 async fn test_deep_apicov_openai_embeddings_endpoint() {
     let app = create_test_app_shared();
@@ -251,7 +295,7 @@ fn test_deep_apicov_default_functions() {
 #[test]
 fn test_deep_apicov_embedding_request_serialize() {
     let req = EmbeddingRequest {
-        input: "test input".to_string(),
+        input: "test input".to_string().into(),
         model: Some("test-model".to_string()),
     };
     let json = serde_json::to_string(&req).expect("serialize");

--- a/crates/aprender-serve/src/api/tests/models_response.rs
+++ b/crates/aprender-serve/src/api/tests/models_response.rs
@@ -399,7 +399,7 @@ fn test_tokenize_response_large_ext_cov() {
 #[test]
 fn test_embedding_request_serialize_ext_cov() {
     let req = EmbeddingRequest {
-        input: "Embed this text".to_string(),
+        input: "Embed this text".to_string().into(),
         model: Some("text-embedding-ada-002".to_string()),
     };
     let json = serde_json::to_string(&req).expect("serialize");
@@ -408,9 +408,10 @@ fn test_embedding_request_serialize_ext_cov() {
 
 #[test]
 fn test_embedding_request_deserialize_ext_cov() {
+    use crate::api::realize_handlers::EmbeddingInput;
     let json = r#"{"input":"Hello","model":"test-model"}"#;
     let req: EmbeddingRequest = serde_json::from_str(json).expect("deserialize");
-    assert_eq!(req.input, "Hello");
+    assert_eq!(req.input, EmbeddingInput::Single("Hello".to_string()));
     assert_eq!(req.model, Some("test-model".to_string()));
 }
 

--- a/crates/aprender-serve/src/api/tests/tests_07.rs
+++ b/crates/aprender-serve/src/api/tests/tests_07.rs
@@ -312,7 +312,7 @@ fn test_clean_chat_output_with_end_tag() {
 #[test]
 fn test_embedding_request_serialization() {
     let req = EmbeddingRequest {
-        input: "Test text".to_string(),
+        input: "Test text".to_string().into(),
         model: Some("test-model".to_string()),
     };
 
@@ -321,14 +321,17 @@ fn test_embedding_request_serialization() {
     assert!(json.contains("test-model"));
 
     let parsed: EmbeddingRequest = serde_json::from_str(&json).expect("deserialize");
-    assert_eq!(parsed.input, "Test text");
+    assert_eq!(
+        parsed.input,
+        crate::api::realize_handlers::EmbeddingInput::Single("Test text".to_string())
+    );
     assert_eq!(parsed.model, Some("test-model".to_string()));
 }
 
 #[test]
 fn test_embedding_request_without_model() {
     let req = EmbeddingRequest {
-        input: "Text only".to_string(),
+        input: "Text only".to_string().into(),
         model: None,
     };
 

--- a/crates/aprender-serve/src/api/tests/tests_28.rs
+++ b/crates/aprender-serve/src/api/tests/tests_28.rs
@@ -297,21 +297,23 @@ fn test_format_chat_messages_empty() {
 
 #[test]
 fn test_embedding_request_serde() {
+    use crate::api::realize_handlers::EmbeddingInput;
     let req = EmbeddingRequest {
-        input: "Hello world".to_string(),
+        input: "Hello world".to_string().into(),
         model: Some("test-model".to_string()),
     };
     let json = serde_json::to_string(&req).expect("serialize");
     let parsed: EmbeddingRequest = serde_json::from_str(&json).expect("deserialize");
-    assert_eq!(parsed.input, "Hello world");
+    assert_eq!(parsed.input, EmbeddingInput::Single("Hello world".to_string()));
     assert_eq!(parsed.model, Some("test-model".to_string()));
 }
 
 #[test]
 fn test_embedding_request_no_model() {
+    use crate::api::realize_handlers::EmbeddingInput;
     let json = r#"{"input":"test text"}"#;
     let parsed: EmbeddingRequest = serde_json::from_str(json).expect("deserialize");
-    assert_eq!(parsed.input, "test text");
+    assert_eq!(parsed.input, EmbeddingInput::Single("test text".to_string()));
     assert!(parsed.model.is_none());
 }
 

--- a/crates/aprender-serve/tests/api_coverage.rs
+++ b/crates/aprender-serve/tests/api_coverage.rs
@@ -747,14 +747,17 @@ fn test_predict_response_classification() {
 #[test]
 fn test_embedding_request_serialization() {
     let request = EmbeddingRequest {
-        input: "test input text".to_string(),
+        input: "test input text".to_string().into(),
         model: Some("text-embedding-ada".to_string()),
     };
 
     let json = serde_json::to_string(&request).expect("should serialize");
     let deserialized: EmbeddingRequest = serde_json::from_str(&json).expect("should deserialize");
 
-    assert_eq!(deserialized.input, "test input text");
+    assert_eq!(
+        deserialized.input,
+        realizar::api::EmbeddingInput::Single("test input text".to_string())
+    );
     assert_eq!(deserialized.model, Some("text-embedding-ada".to_string()));
 }
 
@@ -1431,7 +1434,10 @@ fn test_embedding_request_no_model() {
     let json = r#"{"input": "test text"}"#;
     let request: EmbeddingRequest = serde_json::from_str(json).expect("should deserialize");
 
-    assert_eq!(request.input, "test text");
+    assert_eq!(
+        request.input,
+        realizar::api::EmbeddingInput::Single("test text".to_string())
+    );
     assert!(request.model.is_none());
 }
 
@@ -3606,7 +3612,7 @@ fn test_shap_explanation_edge_cases() {
 fn test_embedding_request_variations() {
     // Single input string
     let request = EmbeddingRequest {
-        input: "single string".to_string(),
+        input: "single string".to_string().into(),
         model: None,
     };
     let json = serde_json::to_string(&request).expect("should serialize");
@@ -3614,7 +3620,7 @@ fn test_embedding_request_variations() {
 
     // With model specified
     let request2 = EmbeddingRequest {
-        input: "test input".to_string(),
+        input: "test input".to_string().into(),
         model: Some("text-embedding-ada-002".to_string()),
     };
     let json2 = serde_json::to_string(&request2).expect("should serialize");
@@ -5025,7 +5031,7 @@ fn test_openai_models_response_roundtrip() {
 #[test]
 fn test_embedding_request_roundtrip() {
     let original = EmbeddingRequest {
-        input: "Text to embed".to_string(),
+        input: "Text to embed".to_string().into(),
         model: Some("text-embedding-3-small".to_string()),
     };
     let json = serde_json::to_string(&original).expect("serialize");


### PR DESCRIPTION
## /v1/embeddings rejected OpenAI batch input

Found by an embeddings-endpoint audit. `EmbeddingRequest.input` was typed `String`, so an OpenAI batch request (`{"input":["a","b"]}`) was rejected at deserialization with **HTTP 422** (`invalid type: sequence, expected a string`) — every OpenAI SDK that batches embeddings failed against apr.

## Fix
New `EmbeddingInput::{Single, Batch}` (`#[serde(untagged)]`, `From<String>/<&str>/<Vec<String>>`, `len`/`iter`). The handler loops all inputs → one `EmbeddingData` per input with `index == i` in request order, accumulating token usage.

## Verified (falsifiers RED on the pre-fix `String` type)
4 new tests: array→`Batch(3)` deserialize, single-string back-compat, untagged round-trip, and an e2e POST of `{"input":[...3...]}` asserting no-422 + `data.len()==3` + `data[i].index==i` + finite 384-dim vectors. All 142 lib embedding tests + `api_coverage.rs` pass; clippy + fmt clean.

## ⚠️ Honest note — the endpoint is still a STUB
Separately (tracked, NOT fixed here): `/v1/embeddings` currently returns a *token-frequency hash*, not real model hidden-state embeddings (the handler never runs the model forward; the code comment admits it). This PR fixes the request-schema interop so batch input works correctly **for when real embeddings are wired** — it does not make the embeddings meaningful. Real model-backed embeddings (mean-pool hidden states, dim == hidden_size) are a separate substantive fix, being addressed next. L2-normalization is already correct (it just normalizes a meaningless vector).

🤖 Generated with [Claude Code](https://claude.com/claude-code)