### PR TITLE
fix(mcp): server replied to JSON-RPC notifications (no-id) — desyncs conformant clients (PMAT-804)

### DIFF
--- a/contracts/apr-mcp-server-v1.yaml
+++ b/contracts/apr-mcp-server-v1.yaml
@@ -167,14 +167,30 @@ falsification_conditions:
     test_name: migrated_tools_match_yaml_contract_byte_for_byte
     status: ENFORCED
 
+  - id: FALSIFY-MCP-009
+    description: >
+      The `apr mcp` stdio server MUST NOT reply to a JSON-RPC 2.0
+      notification. Per JSON-RPC 2.0 §4.1 a notification is defined solely
+      by the ABSENCE of an `id` member — not by a `notifications/` method
+      prefix. A no-id request whose method is otherwise id-bearing
+      (`initialize`, an unknown method, …) is a notification; emitting any
+      response for it (in particular `{"id":null,...}`) is a protocol
+      violation that desyncs the client's request/response pairing. The
+      falsifier sends two no-id requests followed by one real id-bearing
+      `tools/list`, and asserts the first (and only) response line is the
+      id-bearing reply.
+    test_file: crates/aprender-mcp/tests/falsify_mcp_dogfood_001.rs
+    test_name: falsify_mcp_009_no_reply_to_notification
+    status: ENFORCED
+
 # ── Acceptance gate ──
-# Promoting this contract out of ACTIVE requires all 8 conditions above to
+# Promoting this contract out of ACTIVE requires all 9 conditions above to
 # hold simultaneously on a clean checkout with `cargo test -p aprender-mcp`.
 
 qa_gate:
   id: F-MCP-SERVER-GATE
   name: "apr mcp end-to-end contract"
-  pass_criteria: "All 8 FALSIFY-MCP-* tests listed in falsification_conditions pass"
+  pass_criteria: "All 9 FALSIFY-MCP-* tests listed in falsification_conditions pass"
   run: "cargo test -p aprender-mcp --no-fail-fast"
   falsification: >
     Rename or delete any referenced test_file / test_name and the
@@ -183,8 +199,9 @@ qa_gate:
 
 toyota_way_principles:
   jidoka: >
-    "Automation with a human touch" — every protocol gate (001, 005, 007)
-    rejects malformed traffic BEFORE dispatching to any tool handler.
+    "Automation with a human touch" — every protocol gate (001, 005, 007,
+    009) rejects malformed or unanswerable traffic BEFORE dispatching to any
+    tool handler; 009 in particular drops JSON-RPC notifications silently.
     Schema gates (002, 008) meta-validate at test time so drift cannot
     ship. Cancellation (006) halts in-flight work within a bounded grace
     window — the subprocess cannot outlive the client's notification.

--- a/crates/aprender-contracts/tests/apr_mcp_server_contract.rs
+++ b/crates/aprender-contracts/tests/apr_mcp_server_contract.rs
@@ -5,8 +5,8 @@
 //!
 //! 1. The YAML file exists and parses as valid YAML.
 //! 2. Top-level `status: ACTIVE`.
-//! 3. Exactly 8 entries in `falsification_conditions`, with ids
-//!    FALSIFY-MCP-001 through FALSIFY-MCP-008 (no gaps, no duplicates).
+//! 3. Exactly 9 entries in `falsification_conditions`, with ids
+//!    FALSIFY-MCP-001 through FALSIFY-MCP-009 (no gaps, no duplicates).
 //! 4. Every entry has a non-empty `test_file` that exists on disk relative
 //!    to the workspace root, plus a non-empty `test_name` and
 //!    `status: ENFORCED`.
@@ -76,28 +76,28 @@ fn apr_mcp_server_contract_is_active() {
 }
 
 #[test]
-fn apr_mcp_server_contract_has_exactly_eight_conditions() {
+fn apr_mcp_server_contract_has_exactly_nine_conditions() {
     let contract = load_contract();
     assert_eq!(
         contract.falsification_conditions.len(),
-        8,
-        "spec defines 8 FALSIFY-MCP gates; contract has {}",
+        9,
+        "spec defines 9 FALSIFY-MCP gates; contract has {}",
         contract.falsification_conditions.len()
     );
 }
 
 #[test]
-fn apr_mcp_server_contract_ids_are_falsify_mcp_001_through_008() {
+fn apr_mcp_server_contract_ids_are_falsify_mcp_001_through_009() {
     let contract = load_contract();
     let actual: Vec<String> = contract
         .falsification_conditions
         .iter()
         .map(|c| c.id.clone())
         .collect();
-    let expected: Vec<String> = (1..=8).map(|n| format!("FALSIFY-MCP-{n:03}")).collect();
+    let expected: Vec<String> = (1..=9).map(|n| format!("FALSIFY-MCP-{n:03}")).collect();
     assert_eq!(
         actual, expected,
-        "ids must be exactly FALSIFY-MCP-001..008 in order (no gaps, no duplicates)"
+        "ids must be exactly FALSIFY-MCP-001..009 in order (no gaps, no duplicates)"
     );
 }
 

--- a/crates/aprender-mcp/src/server.rs
+++ b/crates/aprender-mcp/src/server.rs
@@ -342,6 +342,18 @@ impl AprMcpServer {
             "tools/call" => self.spawn_tools_call_worker(req, stdout),
             // Fast inline paths.
             _ => {
+                // FALSIFY-MCP-009: JSON-RPC 2.0 §4.1 — a Request object
+                // without an `id` member is a *Notification*, and "The Server
+                // MUST NOT reply to a Notification." The `notifications/*`
+                // method prefix is an MCP convention, but conformance is
+                // determined by the *absence of an id*, not the method name. A
+                // client that sends e.g. `{"jsonrpc":"2.0","method":"initialize"}`
+                // (no id) or an unknown method with no id is issuing a
+                // notification; emitting a response with `id:null` would
+                // corrupt the stream for a strict peer. Drop it silently.
+                if req.id.is_none() {
+                    return Ok(());
+                }
                 let resp = self.handle_request(&req);
                 write_response(stdout, &resp)
             }

--- a/crates/aprender-mcp/tests/falsify_mcp_dogfood_001.rs
+++ b/crates/aprender-mcp/tests/falsify_mcp_dogfood_001.rs
@@ -552,3 +552,128 @@ fn falsify_mcp_dogfood_001_full_client_session() {
         "full dogfood session must complete in <10s (spec budget 2s + CI slack), took {elapsed:?}"
     );
 }
+
+/// Build a JSON-RPC 2.0 *notification* — a Request object with NO `id`
+/// member. Per JSON-RPC 2.0 §4.1 this signifies the client's lack of
+/// interest in a response, and "The Server MUST NOT reply to a
+/// Notification."
+fn notification(method: &str, params: serde_json::Value) -> serde_json::Value {
+    serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": method,
+        "params": params,
+    })
+}
+
+/// FALSIFY-MCP-009 — the `apr mcp` binary MUST NOT reply to a JSON-RPC
+/// notification, even when the notification's method is a normally-
+/// id-bearing request method (`initialize`, an unknown method, etc.).
+///
+/// # The defect this falsifies
+///
+/// JSON-RPC 2.0 §4.1 defines a Notification purely by the *absence of an
+/// `id`* — not by the method name. The pre-fix dispatcher only suppressed
+/// responses for methods literally prefixed with `notifications/`; a
+/// no-id `initialize` or no-id unknown method fell through to the inline
+/// `handle_request` path and got a `{"jsonrpc":"2.0","id":null,...}`
+/// response written to stdout. That stray response desyncs the client:
+/// the next real request's reply is one slot behind, so the client
+/// matches the wrong id.
+///
+/// # Why this assertion catches it without racing on "no output"
+///
+/// "Assert nothing was written" is inherently a timeout/race. Instead we
+/// rely on *stream ordering*: send two notifications (no-id `initialize`,
+/// no-id unknown method), then a real id-bearing request. Stdio responses
+/// are written in order on a single mutex-guarded handle, so the FIRST
+/// line we read after the notifications MUST be the real request's
+/// response (`id == 7`). If the buggy server emitted an `id:null`
+/// response for either notification, that line arrives first and the
+/// assertion `resp["id"] == 7` fails deterministically — no timeout
+/// needed.
+#[test]
+#[cfg(unix)]
+fn falsify_mcp_009_no_reply_to_notification() {
+    let tmp = tempdir_fallback();
+    write_mock_apr_shim(&tmp);
+    let path_value = path_with_mock_first(&tmp);
+
+    let bin_path = {
+        let candidate = assert_cmd::cargo::cargo_bin("apr");
+        if candidate.is_file() {
+            candidate
+        } else {
+            build_apr_binary()
+        }
+    };
+
+    let mut cmd = Command::new(&bin_path);
+    cmd.arg("mcp")
+        .env("PATH", &path_value)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit());
+
+    let mut child = cmd.spawn().expect("spawn `apr mcp`");
+    let mut stdin = child.stdin.take().expect("piped stdin");
+    let stdout = child.stdout.take().expect("piped stdout");
+
+    let (tx, rx) = mpsc::channel::<String>();
+    let reader_handle = spawn_stdout_reader(stdout, tx);
+
+    // Two notifications (no `id`): a normally-id-bearing request method and
+    // an unknown method. A conformant server emits NOTHING for either.
+    send(
+        &mut stdin,
+        &notification(
+            "initialize",
+            serde_json::json!({ "protocolVersion": "2024-11-05" }),
+        ),
+    );
+    send(
+        &mut stdin,
+        &notification("this/method/does/not/exist", serde_json::json!({})),
+    );
+
+    // Now a real request. With a conformant server this is the only message
+    // that produces output, so it must be the first (and only) line read.
+    send(&mut stdin, &request(7, "tools/list", serde_json::json!({})));
+
+    let resp = recv(&rx);
+    assert_eq!(
+        resp["id"], 7,
+        "first response after two notifications must be the tools/list reply (id=7). \
+         A different id (especially null) means the server illegally replied to a \
+         notification and desynced the stream — JSON-RPC 2.0 §4.1 violation. got: {resp:?}"
+    );
+    assert!(
+        resp.get("error").is_none(),
+        "tools/list must succeed; got: {resp:?}"
+    );
+    assert!(
+        resp["result"]["tools"].is_array(),
+        "tools/list result.tools must be an array; got: {resp:?}"
+    );
+
+    // Belt-and-braces: drain stdin, let the server exit, and confirm NO
+    // further response lines were buffered (e.g. a delayed id:null). Any
+    // extra line here is also a §4.1 violation.
+    drop(stdin);
+    let exit = child.wait().expect("apr mcp must exit cleanly");
+    assert!(
+        exit.success(),
+        "apr mcp must exit 0 on stdin EOF, got: {exit:?}"
+    );
+    reader_handle.join().expect("stdout reader joins cleanly");
+
+    let mut extra = Vec::new();
+    while let Ok(line) = rx.try_recv() {
+        extra.push(line);
+    }
+    assert!(
+        extra.is_empty(),
+        "server emitted {} response line(s) beyond the single tools/list reply; \
+         notifications must produce no response (JSON-RPC 2.0 §4.1). Extra lines: {extra:?}",
+        extra.len()
+    );
+}


### PR DESCRIPTION
## MCP server replied to JSON-RPC notifications, desyncing clients

Found by an MCP protocol audit (the server is otherwise protocol-correct across initialize / tools-list / tools-call / error-codes / id-echo). The defect: `route_stdio_message` (the production stdio path) treated only methods literally prefixed `notifications/` as notifications. Per **JSON-RPC 2.0 §4.1, a notification is defined by the ABSENCE of `id`**, not the method name. A no-id `initialize` (or no-id unknown method) fell through to `handle_request` and got a `{"jsonrpc":"2.0","id":null,...}` line written to stdout — violating "The Server MUST NOT reply to a Notification." That stray `id:null` line **shifts every subsequent reply one slot**, so a conformant client matches the wrong id → desync.

## Fix
Drop any no-id request silently in the inline stdio arm (matching the spec).

## Falsifier (e2e against the shipped binary)
`falsify_mcp_009_no_reply_to_notification` spawns the real `apr mcp` binary, sends a no-id `initialize` + a no-id unknown method, then a real `id=7 tools/list`, and asserts the first/only response carries `id=7`. Verified **RED** (server replied to the notification with `id:null`) / **GREEN** after. All aprender-mcp tests pass (54 unit + integration/dogfood); `apr` rebuilt so the e2e exercises the real executable; clippy + fmt clean.

## Contract (Rule 7)
`contracts/apr-mcp-server-v1.yaml` + `FALSIFY-MCP-009`; `apr_mcp_server_contract.rs` updated 8→9 gates; `pv validate` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)