### PR TITLE
fix(train): CPU LoRA fine-tuning silently broken — forward_with_lora + missing RopeBackward (PMAT-805, supersedes #2051)

### DIFF
--- a/contracts/lora-gradient-flow-v1.yaml
+++ b/contracts/lora-gradient-flow-v1.yaml
@@ -1,19 +1,23 @@
 metadata:
-  version: "1.0.0"
+  version: "1.1.0"
   created: "2026-04-13"
   author: PAIML Engineering
   registry: true
   description: "LoRA gradient flow correctness"
   references:
     - "Provable contract for lora-gradient-flow-v1"
+    - "PMAT-805: CPU train_step routed through model.forward() (no LoRA) and apply_rope severed the autograd graph for the Q projection — both adapters silently untrained on the default q_proj+v_proj target set"
 
 kind: AlgorithmContract
 name: lora-gradient-flow
-version: "1.0.0"
+version: "1.1.0"
 scope: "crates/aprender-train/src/finetune/"
 
 description: |
   LoRA adapter gradients flow correctly: dL/dA and dL/dB computed via chain rule through frozen base.
+  The CPU forward used for loss MUST route through `forward_with_lora` (not plain `model.forward`),
+  and every op between the loss and the adapters — including RoPE — MUST be autograd-connected so
+  gradients reach BOTH the q_proj and v_proj adapters (PMAT-805).
 
 equations:
   frozen_base:
@@ -21,16 +25,25 @@ equations:
     formula: "∇W_base == 0 during LoRA training"
 
   adapter_gradient:
-    description: "∇A, ∇B non-zero for non-zero loss"
+    description: "∇A, ∇B non-zero for non-zero loss (BOTH q_proj and v_proj adapters)"
     formula: "∇A, ∇B non-zero for non-zero loss"
+
+  rope_backward:
+    description: "RoPE is autograd-connected: grad_x = R(-θ)·grad_out (transpose rotation)"
+    formula: "grad_x[i] = g[i]·cos(θ) + g[i+half]·sin(θ); grad_x[i+half] = -g[i]·sin(θ) + g[i+half]·cos(θ)"
 
 falsification:
   - id: FALSIFY-LORA_GRADIENT_FLOW_V1_001
     description: "∇W_base == 0 during LoRA training"
-    test: "Related tests in crates/aprender-train/src/finetune/"
-    evidence: "cargo test --lib"
+    test: "crates/aprender-train/src/finetune/instruct_pipeline/tests.rs::falsify_pmat805_cpu_train_step_trains_lora_overfit_one_batch (base weights frozen; only lora_layers stepped)"
+    evidence: "cargo test -p aprender-train --lib falsify_pmat805"
 
   - id: FALSIFY-LORA_GRADIENT_FLOW_V1_002
-    description: "∇A, ∇B non-zero for non-zero loss"
-    test: "Related tests in crates/aprender-train/src/finetune/"
-    evidence: "cargo test --lib"
+    description: "∇A, ∇B non-zero for non-zero loss — overfit-one-batch moves BOTH Q and V adapters and strictly decreases loss"
+    test: "crates/aprender-train/src/finetune/instruct_pipeline/tests.rs::falsify_pmat805_cpu_train_step_trains_lora_overfit_one_batch"
+    evidence: "cargo test -p aprender-train --lib falsify_pmat805_cpu_train_step_trains_lora_overfit_one_batch"
+
+  - id: FALSIFY-LORA_GRADIENT_FLOW_V1_003
+    description: "RoPE backward matches finite-difference gradients (graph not severed at RoPE)"
+    test: "crates/aprender-train/src/transformer/attention.rs::tests::falsify_pmat805_rope_backward_matches_finite_difference"
+    evidence: "cargo test -p aprender-train --lib falsify_pmat805_rope_backward_matches_finite_difference"

--- a/crates/aprender-train/src/finetune/instruct_pipeline/tests.rs
+++ b/crates/aprender-train/src/finetune/instruct_pipeline/tests.rs
@@ -2,6 +2,71 @@
 
 use super::*;
 
+/// PMAT-805 falsifier: CPU train_step must actually train the LoRA adapters.
+///
+/// Overfit-one-batch: repeatedly step on the SAME (prompt, response) pair.
+/// A correct LoRA trainer must (a) move the LoRA A/B parameters away from their
+/// init and (b) strictly decrease the loss. The #2051-class bug routed the CPU
+/// forward through `model.forward()` (plain attention, no LoRA), orphaning the
+/// `lora_layers` from the autograd graph → zero LoRA gradients → flat loss.
+#[test]
+fn falsify_pmat805_cpu_train_step_trains_lora_overfit_one_batch() {
+    let model_config = TransformerConfig::tiny();
+    let instruct_config = InstructConfig {
+        lora_rank: 8,
+        lora_alpha: 16.0,
+        learning_rate: 1e-2,
+        max_seq_len: 64,
+        gradient_clip_norm: None,
+        ..InstructConfig::default()
+    };
+    let mut pipeline = InstructPipeline::new(&model_config, instruct_config);
+
+    let prompt_ids: Vec<u32> = vec![1, 2, 3, 4, 5];
+    let response_ids: Vec<u32> = vec![6, 7, 8, 9, 10];
+
+    // Snapshot LoRA B params before training (init: B is zeros → snapshot is zeros).
+    // index 0 = Q0 (goes through RoPE), index 1 = V0 (no RoPE).
+    let q_b_before: Vec<f32> = pipeline.lora_layers[0].lora_b().data().to_vec();
+    let b_before: Vec<f32> = pipeline.lora_layers[1].lora_b().data().to_vec();
+
+    let first = pipeline.train_step(&prompt_ids, &response_ids);
+    let mut last_loss = first.loss;
+    assert!(first.loss.is_finite() && first.loss > 0.0, "initial loss must be finite & positive");
+
+    for _ in 0..25 {
+        let r = pipeline.train_step(&prompt_ids, &response_ids);
+        last_loss = r.loss;
+    }
+
+    // (a) LoRA params must have CHANGED (B starts at zero; gradient must move it).
+    let q_b_after: Vec<f32> = pipeline.lora_layers[0].lora_b().data().to_vec();
+    let b_after: Vec<f32> = pipeline.lora_layers[1].lora_b().data().to_vec();
+    let q_delta =
+        q_b_before.iter().zip(&q_b_after).map(|(a, b)| (a - b).abs()).fold(0.0_f32, f32::max);
+    let max_delta =
+        b_before.iter().zip(&b_after).map(|(a, b)| (a - b).abs()).fold(0.0_f32, f32::max);
+    eprintln!("[PMAT-805] q_delta(RoPE path)={q_delta} v_delta(no-RoPE path)={max_delta}");
+    assert!(
+        max_delta > 1e-6,
+        "FALSIFIED: LoRA V B params did not change after 26 steps (max_delta={max_delta}). \
+         CPU train_step is not training the adapters."
+    );
+    assert!(
+        q_delta > 1e-6,
+        "FALSIFIED: LoRA Q B params did not change after 26 steps (q_delta={q_delta}). \
+         RoPE severs the autograd graph for the Q projection."
+    );
+
+    // (b) Loss must strictly decrease on overfit-one-batch.
+    assert!(
+        last_loss < first.loss - 1e-3,
+        "FALSIFIED: loss did not decrease ({} -> {}). Adapters orphaned from autograd graph.",
+        first.loss,
+        last_loss
+    );
+}
+
 #[test]
 fn test_instruct_pipeline_new() {
     let model_config = TransformerConfig::tiny();

--- a/crates/aprender-train/src/finetune/instruct_pipeline/training.rs
+++ b/crates/aprender-train/src/finetune/instruct_pipeline/training.rs
@@ -65,7 +65,18 @@ impl InstructPipeline {
         }
 
         // 2. Forward pass → logits [seq_len, vocab_size]
-        let logits = self.model.forward(&full_ids);
+        //
+        // PMAT-805 (#2051-class): route through `forward_with_lora` when LoRA
+        // adapters exist. `model.forward()` runs plain attention and never
+        // touches `self.lora_layers`, so the adapter params stay orphaned from
+        // the autograd graph → `op.backward()` produces zero LoRA gradients →
+        // flat loss (the adapters never train). `forward_with_lora` wires the
+        // [Q0,V0,Q1,V1,...] adapters into the Q/V projections (KAIZEN-011 path).
+        let logits = if self.lora_layers.is_empty() {
+            self.model.forward(&full_ids)
+        } else {
+            self.model.forward_with_lora(&full_ids, &self.lora_layers)
+        };
         let logits_data = logits.data().as_slice().expect("contiguous logits").to_vec();
 
         // 3. Causal LM loss on response tokens only
@@ -455,7 +466,13 @@ impl InstructPipeline {
             let vocab_size = self.model.config().vocab_size;
             let prompt_len = prompt_len.min(seq_len);
 
-            let logits = self.model.forward(&full_ids);
+            // PMAT-805: evaluate the LoRA-adapted model so val_loss reflects the
+            // trained adapters (matches train_step's forward_with_lora path).
+            let logits = if self.lora_layers.is_empty() {
+                self.model.forward(&full_ids)
+            } else {
+                self.model.forward_with_lora(&full_ids, &self.lora_layers)
+            };
             let logits_data = logits.data().as_slice().expect("contiguous logits").to_vec();
 
             let loss_start = prompt_len.saturating_sub(1);

--- a/crates/aprender-train/src/transformer/attention.rs
+++ b/crates/aprender-train/src/transformer/attention.rs
@@ -110,9 +110,82 @@ fn apply_rope(
         }
     }
 
-    let result = Tensor::from_vec(out, x.requires_grad());
+    let requires_grad = x.requires_grad();
+    let mut result = Tensor::from_vec(out, requires_grad);
+
+    // PMAT-805: RoPE is a fixed per-position orthogonal rotation. Without a
+    // backward op the returned tensor is an autograd leaf, which SEVERS the
+    // graph for Q/K — gradients never reach the Q/K projections (and the Q
+    // LoRA adapter never trains). Attach the transpose-rotation backward so
+    // the graph stays connected through RoPE.
+    if requires_grad {
+        let backward_op = Rc::new(RopeBackward {
+            x: x.clone(),
+            inv_freq,
+            seq_len,
+            num_heads,
+            head_dim,
+            half_dim,
+            total_dim,
+            result_grad: result.grad_cell(),
+        });
+        result.set_backward_op(backward_op);
+    }
+
     contract_post_rope!(result.data().as_slice().unwrap_or(&[]));
     result
+}
+
+/// Backward for [`apply_rope`].
+///
+/// RoPE applies a 2×2 rotation `R(θ)` to each `(x[i], x[i+half])` pair:
+///   out[i]      =  x1·cos − x2·sin
+///   out[i+half] =  x2·cos + x1·sin
+/// The rotation is orthogonal, so the Jacobian-transpose (the gradient) is the
+/// inverse rotation `R(−θ)`:
+///   ∂L/∂x1 =  g[i]·cos + g[i+half]·sin
+///   ∂L/∂x2 = −g[i]·sin + g[i+half]·cos
+struct RopeBackward {
+    x: Tensor,
+    inv_freq: Vec<f32>,
+    seq_len: usize,
+    num_heads: usize,
+    head_dim: usize,
+    half_dim: usize,
+    total_dim: usize,
+    result_grad: Rc<RefCell<Option<Array1<f32>>>>,
+}
+
+impl BackwardOp for RopeBackward {
+    fn backward(&self) {
+        if !self.x.requires_grad() {
+            return;
+        }
+        let Some(grad_out) = self.result_grad.borrow().as_ref().cloned() else { return };
+        let go = grad_out.as_slice().expect("rope grad contiguous");
+        let mut grad_x = vec![0.0f32; self.seq_len * self.total_dim];
+
+        for pos in 0..self.seq_len {
+            for h in 0..self.num_heads {
+                let offset = pos * self.total_dim + h * self.head_dim;
+                for i in 0..self.half_dim {
+                    let freq = pos as f32 * self.inv_freq[i];
+                    let cos_f = freq.cos();
+                    let sin_f = freq.sin();
+                    let g_first = go[offset + i];
+                    let g_second = go[offset + i + self.half_dim];
+                    // Inverse rotation R(-θ) = R(θ)^T
+                    grad_x[offset + i] = g_first * cos_f + g_second * sin_f;
+                    grad_x[offset + i + self.half_dim] = -g_first * sin_f + g_second * cos_f;
+                }
+            }
+        }
+
+        self.x.accumulate_grad(Array1::from(grad_x));
+        if let Some(op) = self.x.backward_op() {
+            op.backward();
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1064,6 +1137,52 @@ impl MultiHeadAttentionWithLoRA {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// PMAT-805: RoPE must propagate gradients (it is no longer an autograd
+    /// leaf). Validate `RopeBackward` against finite differences of a scalar
+    /// loss `L = sum(rope(x) * w)` so dL/dx = rope_backward(w).
+    #[test]
+    fn falsify_pmat805_rope_backward_matches_finite_difference() {
+        let seq_len = 3usize;
+        let num_heads = 2usize;
+        let head_dim = 4usize; // half_dim = 2
+        let total = seq_len * num_heads * head_dim;
+        let theta = 10000.0f32;
+
+        // Deterministic input + upstream gradient weights.
+        let x_data: Vec<f32> =
+            (0..total).map(|i| ((i as f32 * 0.37).sin() * 1.5) + 0.1).collect();
+        let w: Vec<f32> = (0..total).map(|i| ((i as f32 * 0.21).cos() * 0.8) - 0.05).collect();
+
+        // Analytical gradient via RopeBackward.
+        let x = Tensor::from_vec(x_data.clone(), true);
+        let y = apply_rope(&x, seq_len, num_heads, head_dim, theta);
+        y.set_grad(Array1::from(w.clone()));
+        y.backward_op().expect("rope must have a backward op").backward();
+        let analytical = x.grad().expect("x must have grad after rope backward").to_vec();
+
+        // Numerical gradient: dL/dx_j ≈ (L(x+h) - L(x-h)) / 2h, L = sum(rope(x) · w).
+        let h = 1e-3f32;
+        let loss = |xv: &[f32]| -> f32 {
+            let t = Tensor::from_vec(xv.to_vec(), false);
+            let r = apply_rope(&t, seq_len, num_heads, head_dim, theta);
+            r.data().iter().zip(&w).map(|(a, b)| a * b).sum()
+        };
+        for j in 0..total {
+            let mut xp = x_data.clone();
+            let mut xm = x_data.clone();
+            xp[j] += h;
+            xm[j] -= h;
+            let numerical = (loss(&xp) - loss(&xm)) / (2.0 * h);
+            let diff = (analytical[j] - numerical).abs();
+            assert!(
+                diff < 1e-2,
+                "FALSIFIED: RoPE grad[{j}] analytical={} numerical={} diff={diff}",
+                analytical[j],
+                numerical
+            );
+        }
+    }
 
     #[test]
     fn test_multi_head_attention_tiny() {


### PR DESCRIPTION
## CPU LoRA fine-tuning didn't train the adapters — two compounding bugs

Found by a training-correctness audit. `apr finetune`'s CPU LoRA path silently failed to train, from two compounding root causes (both proven on a tiny synthetic model, no GPU):

1. **`train_step`/`evaluate` used `model.forward()` not `forward_with_lora`** — plain attention never consults `pipeline.lora_layers`, orphaning the adapters from the autograd graph → zero LoRA gradients → flat loss. (This is the #2051-class bug.)
2. **`apply_rope` had NO backward op** (`transformer/attention.rs`) — RoPE returned an autograd **leaf**, severing the graph for the Q projection. So **even after fix #1, only the V adapter trained** (V skips RoPE); the **q_proj adapter received zero gradient** — and q_proj is half the default QLoRA target set. **This is why #2051 alone is incomplete.**

## Supersedes #2051
#2051 fixed only #1 (`forward_with_lora`). With the missing RopeBackward, #2051 alone would still leave q_proj untrained (only V learns). This PR contains **both** fixes, so #2051 is closed as subsumed.

## Fix
- Route CPU forward through `forward_with_lora` when adapters exist.
- Add `RopeBackward`: RoPE is an orthogonal rotation R(θ), so its gradient is the inverse rotation R(−θ) — verified against finite differences (diff < 1e-2).

## Verified (empirical, falsifier)
- Overfit-one-batch: `q_delta=0, v_delta=0` (broken) → **`q_delta=0.22, v_delta=0.14` with loss strictly decreasing** (fixed). Both adapters now train.
- 7596 aprender-train tests pass + 2 new falsifiers. Contract co-evolution: `lora-gradient-flow-v1` → 1.1.0, `pv validate` clean.

## Audit verdict on the rest — CLEAN
Loss (causal-LM CE, next-token aligned, prompt-masked), AdamW (decoupled decay, bias correction, SIMD==scalar), LR schedule (warmup→cosine continuous), checkpoint/PEFT round-trip — all confirmed correct.

## Follow-up flagged
`apply_qk_norm` has the same autograd-leaf-severance pattern as RoPE did (would block gradient flow through Q/K-norm for Qwen3-class QK-norm models during training) — sibling ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)