### PR TITLE
fix(serve): fail loud on Gemma instead of running it silently-wrong (PMAT-807)

### DIFF
--- a/contracts/apr-load-fail-closed-gemma-v1.yaml
+++ b/contracts/apr-load-fail-closed-gemma-v1.yaml
@@ -1,0 +1,59 @@
+contract: apr-load-fail-closed-gemma
+metadata:
+  kind: pattern
+  version: "1.0.0"
+  description: >
+    realizar must FAIL LOUD when asked to run a Gemma-family model (gemma / gemma2 /
+    gemma3) rather than silently producing garbage. Gemma requires four
+    architecture-specific behaviors that realizar's LLaMA-style forward path does NOT
+    implement: (a) GELU-gating FFN (GeGLU) — apr_transformer::inference hardcodes SiLU
+    when a gate weight is present; (b) (1 + weight) RMSNorm — helpers::rms_norm applies
+    x_normed * w, not x_normed * (1 + w); (c) token-embedding scaling by
+    sqrt(hidden_size) — absent from the forward path; (d) attention + final-logit
+    tanh-softcapping (Gemma2) — absent. With the arch recognized in the loader, a Gemma
+    GGUF/safetensors would otherwise load and run with LLaMA behavior = silently-wrong
+    output for a popular model family. PMAT-807 adds a fail-loud Gate 0 in
+    contract_gate::validate_model_load — THE single enforcement point every
+    inference-weight-loading path (GGUF/APR/SafeTensors, CPU + CUDA) funnels through —
+    that refuses Gemma with a clear error naming the unimplemented behaviors. The gate
+    fires ONLY when building an inference model; apr convert / apr inspect / apr validate
+    read metadata directly and are unaffected, so Gemma models can still be inspected and
+    converted. This extends the Pillar-4 fail-closed guarantee (PMAT-744, PMAT-750):
+    refuse a model apr cannot run CORRECTLY instead of emitting garbage.
+  references:
+  - "crates/aprender-serve/src/contract_gate.rs (validate_supported_architecture, is_gemma_family, Gate 0 in validate_model_load)"
+  - "crates/aprender-serve/src/apr_transformer/inference.rs (hardcoded SiLU when gate present — behavior (a))"
+  - "crates/aprender-serve/src/apr_transformer/helpers.rs (rms_norm: x_normed * w, no (1+w) — behavior (b))"
+  - "crates/aprender-serve/src/contract_gate.rs::tests (test_gemma_family_rejected_at_load, test_non_gemma_architectures_unaffected)"
+version: 1
+status: enforced
+date: 2026-06-16
+
+proof_obligations:
+  - type: invariant
+    property: >
+      GEMMA-DETECT: is_gemma_family(arch) is true iff the lowercased architecture name
+      begins with "gemma" — covering raw GGUF strings (gemma/gemma2/gemma3), HF class
+      names (GemmaForCausalLM/Gemma2ForCausalLM/Gemma3ForCausalLM), the normalized form
+      (gemma), and future point variants. Non-Gemma names (llama/qwen2/qwen3/mistral/
+      phi/phi2/deepseek/gpt2/unknown_future_arch) are never flagged (no false positive).
+  - type: invariant
+    property: >
+      GEMMA-FAIL-LOUD: validate_model_load / validate_model_load_basic return
+      Err(gate="architecture_supported") for every Gemma-family architecture, so a Gemma
+      model is refused at load instead of running with LLaMA-style behavior. A non-Gemma
+      model that is otherwise valid loads unchanged (gate is a no-op for it).
+
+falsification_tests:
+  - id: FALSIFY-LOAD-GEMMA-001
+    name: test_gemma_family_rejected_at_load
+    prediction: "validate_model_load with architecture in {gemma, gemma2, gemma3, GemmaForCausalLM, Gemma2ForCausalLM, Gemma3ForCausalLM, gemma3n} returns Err(gate=architecture_supported) whose reason names the missing Gemma behaviors (Gemma + softcapping)"
+    test_harness: "cargo test -p aprender-serve --lib test_gemma_family_rejected_at_load"
+    expected_output: "test result: ok"
+    if_fails: "a Gemma model is accepted at load → apr run/serve execute it with LLaMA-style FFN/RMSNorm/embedding/logits and emit silently-wrong output for a popular family."
+  - id: FALSIFY-LOAD-GEMMA-002
+    name: test_non_gemma_architectures_unaffected
+    prediction: "validate_model_load with architecture in {llama, qwen2, qwen3, mistral, phi, phi2, deepseek, gpt2, unknown_future_arch} is Ok — the Gemma gate does not regress any other family"
+    test_harness: "cargo test -p aprender-serve --lib test_non_gemma_architectures_unaffected"
+    expected_output: "test result: ok"
+    if_fails: "the Gemma fail-loud gate over-triggers and refuses a non-Gemma model that apr CAN run correctly = a regression for llama/qwen/mistral/etc."

--- a/crates/aprender-serve/src/contract_gate.rs
+++ b/crates/aprender-serve/src/contract_gate.rs
@@ -162,6 +162,12 @@ impl From<ModelLoadError> for RealizarError {
 pub fn validate_model_load(
     config: &ModelLoadConfig,
 ) -> std::result::Result<ModelLoadProof, ModelLoadError> {
+    // Gate 0: Architecture is one realizar can run CORRECTLY (honest-by-design,
+    // PMAT-807). Fail LOUD rather than silently produce garbage for families
+    // whose architecture-specific behaviors are not yet implemented in the
+    // forward path.
+    validate_supported_architecture(&config.architecture)?;
+
     // Gate 1: Dimension plausibility
     validate_dimensions(config)?;
 
@@ -259,6 +265,62 @@ fn validate_architecture(arch_name: &str) -> std::result::Result<ArchConstraints
     // This is by design: new architectures can load with base constraints and fail later
     // at the ValidatedLayerWeights level if they have unexpected weight patterns.
     Ok(arch)
+}
+
+// ============================================================================
+// PMAT-807: Honest-by-design architecture support gate
+// ============================================================================
+
+/// Returns `true` when `arch_name` denotes a Gemma-family architecture.
+///
+/// Matches the raw GGUF arch strings (`gemma`, `gemma2`, `gemma3`), their HF
+/// `architectures[]` class names (`GemmaForCausalLM`, `Gemma2ForCausalLM`,
+/// `Gemma3ForCausalLM`), and the normalized form `gemma`. Matching is
+/// case-insensitive and prefix-based on the lowercased name so future point
+/// variants (`gemma3n`, ...) are also caught — fail-loud is the safe default.
+#[must_use]
+pub fn is_gemma_family(arch_name: &str) -> bool {
+    let lower = arch_name.to_ascii_lowercase();
+    lower.starts_with("gemma")
+}
+
+/// Fail LOUD for architectures whose required behaviors realizar's forward path
+/// does not yet implement, instead of silently producing wrong output.
+///
+/// # Why Gemma is rejected (PMAT-807)
+///
+/// Gemma / Gemma2 / Gemma3 require four architecture-specific behaviors that the
+/// LLaMA-style forward path in `apr_transformer::inference` does NOT implement:
+///
+/// 1. **GELU-gating FFN** — Gemma uses a `gelu_tanh` gated MLP (GeGLU). When a
+///    gate weight is present, the forward path hardcodes SiLU (SwiGLU).
+/// 2. **`(1 + weight)` RMSNorm** — Gemma's RMSNorm is `x_normed * (1 + w)`; the
+///    forward path applies `x_normed * w`.
+/// 3. **Embedding scaling by `sqrt(hidden_size)`** — Gemma scales token
+///    embeddings; the forward path does not.
+/// 4. **Attention / final-logit softcapping** — Gemma2 tanh-softcaps attention
+///    scores and final logits; the forward path has neither.
+///
+/// Loading such a model with LLaMA-style behavior yields silently-wrong output.
+/// Refusing is honest-by-design: the same fail-closed posture as rejecting a
+/// semantically-broken model rather than running it.
+///
+/// Non-Gemma architectures (llama, qwen2, qwen3, mistral, phi, deepseek, gpt2,
+/// ...) are unaffected.
+fn validate_supported_architecture(arch_name: &str) -> std::result::Result<(), ModelLoadError> {
+    if is_gemma_family(arch_name) {
+        return Err(ModelLoadError {
+            gate: "architecture_supported",
+            reason: format!(
+                "Gemma architecture '{arch_name}' requires GELU-gating FFN, \
+                 (1+weight) RMSNorm, sqrt(hidden_size) embedding scaling, and \
+                 attention/logit softcapping — none of which realizar's forward \
+                 path implements yet. Running it would silently produce incorrect \
+                 output, so it is refused. Track support at PMAT-807."
+            ),
+        });
+    }
+    Ok(())
 }
 
 fn validate_completeness(
@@ -578,6 +640,90 @@ mod tests {
         let proof = validate_model_load_basic("unknown_future_arch", 1, 128, 4, 4, 512, 1000)
             .expect("unknown arch should pass with base constraints");
         assert_eq!(proof.architecture(), "unknown_future_arch");
+    }
+
+    // ------------------------------------------------------------------
+    // PMAT-807: Gemma fail-loud gate
+    // ------------------------------------------------------------------
+
+    /// FALSIFIER: every Gemma-family arch string is rejected at the gate.
+    /// If any is silently accepted, this test fails (silent-garbage regression).
+    #[test]
+    fn test_gemma_family_rejected_at_load() {
+        let gemma_names = [
+            "gemma",
+            "gemma2",
+            "gemma3",
+            "GemmaForCausalLM",
+            "Gemma2ForCausalLM",
+            "Gemma3ForCausalLM",
+            "gemma3n", // future point variant — fail-loud is the safe default
+        ];
+        for name in gemma_names {
+            let mut config = valid_config();
+            config.architecture = name.to_string();
+            let err = validate_model_load(&config)
+                .expect_err(&format!("Gemma arch '{name}' must be refused, not run"));
+            assert_eq!(
+                err.gate, "architecture_supported",
+                "'{name}' rejected by wrong gate: {}",
+                err.gate
+            );
+            // The error must explain WHY (the missing Gemma behaviors).
+            assert!(
+                err.reason.contains("Gemma") && err.reason.contains("softcapping"),
+                "'{name}' error must name the missing behaviors: {}",
+                err.reason
+            );
+        }
+    }
+
+    /// `validate_model_load_basic` (the path real loaders call) also rejects Gemma.
+    #[test]
+    fn test_gemma_rejected_via_basic_loader_path() {
+        let err = validate_model_load_basic("gemma2", 26, 2304, 8, 4, 9216, 256_000)
+            .expect_err("gemma2 must be refused at the basic loader gate");
+        assert_eq!(err.gate, "architecture_supported");
+    }
+
+    /// CONTROL: non-Gemma architectures are unaffected — no regression.
+    #[test]
+    fn test_non_gemma_architectures_unaffected() {
+        for arch in [
+            "llama",
+            "qwen2",
+            "qwen3",
+            "mistral",
+            "phi",
+            "phi2",
+            "deepseek",
+            "gpt2",
+            "unknown_future_arch",
+        ] {
+            assert!(
+                !is_gemma_family(arch),
+                "'{arch}' wrongly classified as Gemma"
+            );
+            let mut config = valid_config();
+            config.architecture = arch.to_string();
+            // Dimensions in valid_config() are llama-shaped and pass; the point is
+            // that the architecture_supported gate does NOT trip for these.
+            assert!(
+                validate_model_load(&config).is_ok(),
+                "non-Gemma arch '{arch}' must still load"
+            );
+        }
+    }
+
+    /// `is_gemma_family` is case-insensitive and prefix-based.
+    #[test]
+    fn test_is_gemma_family_classification() {
+        assert!(is_gemma_family("gemma"));
+        assert!(is_gemma_family("GEMMA"));
+        assert!(is_gemma_family("Gemma2ForCausalLM"));
+        assert!(!is_gemma_family("llama"));
+        assert!(!is_gemma_family("gem")); // not a Gemma model
+        assert!(!is_gemma_family(""));
     }
 
     #[test]


### PR DESCRIPTION
## apr ran Gemma models silently-WRONG — now fails loud

Measure-first finding: apr recognizes `gemma`/`gemma2`/`gemma3` as a valid architecture and runs it straight through the **LLaMA-style forward path** — but all four Gemma-specific behaviors are absent (confirmed in source):
- **GELU-gating FFN** — `apr_transformer/inference.rs:333` hardcodes SiLU when a gate is present (Gemma needs GeGLU/gelu_tanh).
- **`(1+w)` RMSNorm** — `helpers.rs:367` does `normalized * w`, not `* (1 + w)`.
- **`sqrt(hidden_size)` embedding scaling** — absent.
- **attn/final-logit softcapping** — absent.

So a Gemma model loads and produces silently-wrong output for a popular family, with no guard. This is the silent-garbage class the campaign exists to reject.

## Fix (honest-by-design fail-loud, NOT a full Gemma impl)
**Gate 0** in `contract_gate.rs::validate_model_load` — the single enforcement point every inference-weight-loading path funnels through (GGUF/APR/SafeTensors, CPU + CUDA; all ~10 loaders verified to call it + propagate the error). `is_gemma_family()` + `validate_supported_architecture()` return a clear error naming the four unimplemented behaviors. Strictly gated to Gemma (llama/qwen2/qwen3/mistral/phi/deepseek/gpt2 + unknown future archs unaffected — control test proves it). Diagnostics (`apr convert`/`inspect`/`validate`) read metadata directly and are unaffected, so Gemma can still be inspected/converted. Mirrors the fail-closed beats (PMAT-744/750): refuse a model apr can't run correctly rather than emit garbage. (Full Gemma support is a separate effort that will relax this gate.)

## Verified
4 new falsifiers + **15,334 aprender-serve lib tests pass, 0 regressions**; fmt + clippy clean. Contract co-evolution: `apr-load-fail-closed-gemma-v1.yaml` (2 obligations, 2 falsifiers), `pv validate` clean, 191 contract-lint tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)