### PR TITLE
fix(compute): AVX-512 Q4_K GEMV heap over-read for non-256-aligned in_dim (PMAT-812)

### DIFF
--- a/contracts/avx512-q4k-v1.yaml
+++ b/contracts/avx512-q4k-v1.yaml
@@ -1,5 +1,5 @@
 metadata:
-  version: "1.0.0"
+  version: "1.1.0"
   created: "2026-04-13"
   author: PAIML Engineering
   registry: true
@@ -12,7 +12,7 @@ metadata:
 
 kind: KernelContract
 name: avx512-q4k
-version: "1.0.0"
+version: "1.1.0"
 scope: "crates/aprender-compute/src/backends/q4k/gemv/avx512.rs"
 
 description: |
@@ -35,9 +35,16 @@ equations:
     note: "16-wide vs 8-wide; overhead from zmm register management limits to ~1.5x (not 2x)"
 
   C-AVX512-Q4K-003:
-    description: "Super-block processing is complete (no elements skipped)"
-    formula: "∀ row: Σ elements_processed = in_dim (with remainder handling)"
-    note: "Scalar fallback handles remainder elements after SIMD loop"
+    description: "Super-block processing is complete (no elements skipped) AND every activation load stays within [0, in_dim) — no heap over-read"
+    formula: "∀ row: Σ elements_processed = in_dim ∧ ∀ SIMD load at base b reading w lanes: b + w ≤ in_dim"
+    note: |
+      A 64-element chunk maps low nibbles → activation [base,base+32) and high
+      nibbles → [base+32,base+64) — DIFFERENT positions, so the high-nibble loads
+      need their OWN bound. Full chunks (base+64 ≤ in_dim) use unguarded loads;
+      the partial tail uses masked loads (_mm512_maskz_loadu_ps) that read only
+      the in-bounds lanes and zero the rest. Pre-1.1.0 the high-nibble loads
+      shared the low-nibble guard (base+32 ≤ in_dim), over-reading up to 128 bytes
+      AND dropping the valid tail for in_dim ≡ 32/96/160/224 (mod 256).
 
 falsification:
   - id: FALSIFY-AVX512-Q4K-001
@@ -49,3 +56,8 @@ falsification:
     description: "Performance threshold verified by benchmark"
     test: "Q4K GEMV benchmark"
     evidence: "cargo bench -p aprender-compute -- q4k"
+
+  - id: FALSIFY-AVX512-Q4K-003
+    description: "Non-256-aligned in_dim: the AVX-512 GEMV reads only [0,in_dim) (no heap over-read) and matches the scalar reference exactly (no skipped/garbage high-nibble tail). Discharges the previously-unwired C-AVX512-Q4K-003."
+    test: "falsify_avx512_q4k_003_non_aligned_in_dim_no_oob — activation buffer carries a non-zero sentinel tail past in_dim inside the allocation; pre-fix over-read injects the sentinel (RED, e.g. in_dim=32 → SIMD 7.4e9 vs scalar 532), masked-load fix matches scalar (GREEN). Covers in_dim ∈ {32,48,96,160,224} (mod-256 mid-chunk cases) + 256 control."
+    evidence: "cargo test -p aprender-compute --lib falsify_avx512_q4k_003"

--- a/crates/aprender-compute/src/backends/q4k/gemv/avx512.rs
+++ b/crates/aprender-compute/src/backends/q4k/gemv/avx512.rs
@@ -55,6 +55,35 @@ pub(crate) unsafe fn matmul_q4k_f32_avx512(
     }
 }
 
+/// Bounds-aware 16-wide activation load for the Q4_K reduction tail.
+///
+/// Contract: avx512-q4k-v1.yaml (C-AVX512-Q4K-003).
+/// Lanes whose activation index is ≥ `in_dim` are masked: they are NOT read
+/// (no heap over-read past the activation buffer) and load as `0.0` (so the
+/// downstream FMA contributes nothing for those positions). Used only on the
+/// partial-chunk tail; the full-chunk hot path uses unguarded loads.
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx512f")]
+#[inline]
+unsafe fn load16_bounded(
+    input_ptr: *const f32,
+    base: usize,
+    in_dim: usize,
+) -> std::arch::x86_64::__m512 {
+    use std::arch::x86_64::*;
+    unsafe {
+        if base + 16 <= in_dim {
+            _mm512_loadu_ps(input_ptr.add(base))
+        } else if base < in_dim {
+            // 1..=15 valid low lanes; the rest are masked (unread, zeroed).
+            let mask: __mmask16 = ((1u32 << (in_dim - base)) - 1) as __mmask16;
+            _mm512_maskz_loadu_ps(mask, input_ptr.add(base))
+        } else {
+            _mm512_setzero_ps()
+        }
+    }
+}
+
 /// Process one Q4K super-block with AVX-512 (16-wide), fully unrolled.
 ///
 /// Each super-block = 256 elements in 4 chunks of 64.
@@ -96,6 +125,14 @@ unsafe fn process_q4k_superblock_avx512(
         for chunk_i in 0..4 {
             let chunk_start = chunk_i * 64;
             let q_start = chunk_i * 32;
+            let input_base_lo0 = input_offset + chunk_start;
+
+            // Skip chunks whose activation positions are entirely beyond the
+            // reduction dim (the original code skipped these via its bounds
+            // guard; we make it explicit so the tail branch below stays simple).
+            if input_base_lo0 >= in_dim {
+                continue;
+            }
 
             let d1 = d * f32::from(scales[chunk_i * 2]);
             let dm1 = dmin * f32::from(mins[chunk_i * 2]);
@@ -107,42 +144,60 @@ unsafe fn process_q4k_superblock_avx512(
             let d2_vec = _mm512_set1_ps(d2);
             let dm2_vec = _mm512_set1_ps(dm2);
 
-            // Low nibbles: 2×16 = 32 elements, fully unrolled
-            let input_base_lo0 = input_offset + chunk_start;
-            if input_base_lo0 + 32 <= in_dim {
-                // First 16 low nibbles
-                let q0 = _mm_loadu_si128(qs_ptr.add(q_start) as *const __m128i);
-                let q0_i32 = _mm512_cvtepu8_epi32(q0);
-                let q0_low = _mm512_and_si512(q0_i32, low_mask);
-                let q0_f32 = _mm512_cvtepi32_ps(q0_low);
+            // Dequant the 4×16 weight groups. `qs` is always fully in bounds (a
+            // super-block is always SUPER_BLOCK_BYTES). Low nibbles map to
+            // activation positions [base, base+32); high nibbles to
+            // [base+32, base+64) — DIFFERENT positions, which is why the high
+            // loads need their own bound (the bug this fixes).
+            let q0 = _mm_loadu_si128(qs_ptr.add(q_start) as *const __m128i);
+            let q0_i32 = _mm512_cvtepu8_epi32(q0);
+            let q1 = _mm_loadu_si128(qs_ptr.add(q_start + 16) as *const __m128i);
+            let q1_i32 = _mm512_cvtepu8_epi32(q1);
+            let dq0 = _mm512_fmsub_ps(
+                d1_vec,
+                _mm512_cvtepi32_ps(_mm512_and_si512(q0_i32, low_mask)),
+                dm1_vec,
+            );
+            let dq1 = _mm512_fmsub_ps(
+                d1_vec,
+                _mm512_cvtepi32_ps(_mm512_and_si512(q1_i32, low_mask)),
+                dm1_vec,
+            );
+            let dqh0 =
+                _mm512_fmsub_ps(d2_vec, _mm512_cvtepi32_ps(_mm512_srli_epi32(q0_i32, 4)), dm2_vec);
+            let dqh1 =
+                _mm512_fmsub_ps(d2_vec, _mm512_cvtepi32_ps(_mm512_srli_epi32(q1_i32, 4)), dm2_vec);
+
+            let input_base_hi0 = input_base_lo0 + 32;
+
+            if input_base_lo0 + 64 <= in_dim {
+                // FAST PATH: the whole 64-element chunk is in bounds (the common
+                // 256-aligned case) — unguarded 16-wide loads, hot-path perf
+                // preserved.
                 let x0 = _mm512_loadu_ps(input_ptr.add(input_base_lo0));
-                let dq0 = _mm512_fmsub_ps(d1_vec, q0_f32, dm1_vec);
-                *acc = _mm512_fmadd_ps(dq0, x0, *acc);
-
-                // Second 16 low nibbles
-                let q1 = _mm_loadu_si128(qs_ptr.add(q_start + 16) as *const __m128i);
-                let q1_i32 = _mm512_cvtepu8_epi32(q1);
-                let q1_low = _mm512_and_si512(q1_i32, low_mask);
-                let q1_f32 = _mm512_cvtepi32_ps(q1_low);
                 let x1 = _mm512_loadu_ps(input_ptr.add(input_base_lo0 + 16));
-                let dq1 = _mm512_fmsub_ps(d1_vec, q1_f32, dm1_vec);
-                *acc = _mm512_fmadd_ps(dq1, x1, *acc);
-
-                // High nibbles: 2×16 = 32 elements, fully unrolled
-                let input_base_hi0 = input_offset + chunk_start + 32;
-
-                // First 16 high nibbles (reuse q0 loaded above)
-                let q0_high = _mm512_srli_epi32(q0_i32, 4);
-                let q0h_f32 = _mm512_cvtepi32_ps(q0_high);
                 let xh0 = _mm512_loadu_ps(input_ptr.add(input_base_hi0));
-                let dqh0 = _mm512_fmsub_ps(d2_vec, q0h_f32, dm2_vec);
-                *acc = _mm512_fmadd_ps(dqh0, xh0, *acc);
-
-                // Second 16 high nibbles (reuse q1 loaded above)
-                let q1_high = _mm512_srli_epi32(q1_i32, 4);
-                let q1h_f32 = _mm512_cvtepi32_ps(q1_high);
                 let xh1 = _mm512_loadu_ps(input_ptr.add(input_base_hi0 + 16));
-                let dqh1 = _mm512_fmsub_ps(d2_vec, q1h_f32, dm2_vec);
+                *acc = _mm512_fmadd_ps(dq0, x0, *acc);
+                *acc = _mm512_fmadd_ps(dq1, x1, *acc);
+                *acc = _mm512_fmadd_ps(dqh0, xh0, *acc);
+                *acc = _mm512_fmadd_ps(dqh1, xh1, *acc);
+            } else {
+                // TAIL PATH: partial chunk — bounded masked loads. Lanes ≥ in_dim
+                // are NOT read (no heap over-read) and load as 0.0 (0 FMA
+                // contribution). Fixes C-AVX512-Q4K-003: the previous single
+                // `input_base_lo0 + 32 <= in_dim` guard covered only the low
+                // loads, so the high-nibble loads at [+32,+64) over-read up to
+                // 128 bytes for any non-256-aligned in_dim (32/96/160/224 mod
+                // 256). It also silently dropped the valid high-nibble tail —
+                // masked loads compute it correctly.
+                let x0 = load16_bounded(input_ptr, input_base_lo0, in_dim);
+                let x1 = load16_bounded(input_ptr, input_base_lo0 + 16, in_dim);
+                let xh0 = load16_bounded(input_ptr, input_base_hi0, in_dim);
+                let xh1 = load16_bounded(input_ptr, input_base_hi0 + 16, in_dim);
+                *acc = _mm512_fmadd_ps(dq0, x0, *acc);
+                *acc = _mm512_fmadd_ps(dq1, x1, *acc);
+                *acc = _mm512_fmadd_ps(dqh0, xh0, *acc);
                 *acc = _mm512_fmadd_ps(dqh1, xh1, *acc);
             }
         }

--- a/crates/aprender-compute/src/backends/q4k/tests_core/parity.rs
+++ b/crates/aprender-compute/src/backends/q4k/tests_core/parity.rs
@@ -149,3 +149,69 @@ fn test_determinism() {
         assert_eq!(a.to_bits(), b.to_bits(), "Row {}: Non-deterministic output: {} vs {}", i, a, b);
     }
 }
+
+/// FALSIFIER C-AVX512-Q4K-003: the AVX-512 Q4_K GEMV must not read the
+/// activation buffer out of bounds for a non-256-aligned `in_dim`, and must
+/// match the scalar reference exactly.
+///
+/// The pre-fix kernel wrapped the high-nibble loads (activation positions
+/// `[base+32, base+64)`) in the low-nibble guard `base + 32 <= in_dim`, so for
+/// any `in_dim` that is `32/96/160/224 (mod 256)` the guard passed but the
+/// `_mm512_loadu_ps` over-read up to 128 bytes past the buffer (and it also
+/// silently dropped the valid high-nibble tail).
+///
+/// RED-on-bug: the activation buffer has a non-zero SENTINEL tail in the
+/// allocation past `in_dim` (len() stays == in_dim for the dispatch assert), so
+/// the pre-fix over-read injects the sentinel → divergence from scalar. The fix
+/// uses masked loads that read only `[0, in_dim)` and zero the rest → exact
+/// parity. On non-AVX-512 hosts the dispatch routes to AVX2/scalar (already
+/// correct), so this self-gates to a no-op parity check there.
+#[test]
+#[cfg(target_arch = "x86_64")]
+fn falsify_avx512_q4k_003_non_aligned_in_dim_no_oob() {
+    // All < 256 (single padded super-block, supported by the scalar reference)
+    // and each ≡ 32/96/160/224 (mod 256) or a mid-chunk tail — the cases where
+    // the pre-fix high-nibble load over-reads. 256 is the aligned control.
+    for &in_dim in &[32usize, 48, 96, 160, 224, 256] {
+        let out_dim = 3;
+        let num_blocks = in_dim.div_ceil(SUPER_BLOCK_SIZE);
+        let mut q4k_data = Vec::with_capacity(out_dim * num_blocks * SUPER_BLOCK_BYTES);
+        for row in 0..out_dim {
+            for _ in 0..num_blocks {
+                q4k_data.extend_from_slice(&[0x00, 0x3C]); // d ~ 1.0 (f16)
+                q4k_data.extend_from_slice(&[0x00, 0x38]); // dmin ~ 0.5 (f16)
+                q4k_data.extend_from_slice(&[0x21u8; 12]); // packed scales/mins
+                let mut qs = [0u8; 128];
+                for (i, q) in qs.iter_mut().enumerate() {
+                    let low = ((row + i + 3) % 16) as u8;
+                    let high = ((row * 2 + i + 7) % 16) as u8;
+                    *q = low | (high << 4);
+                }
+                q4k_data.extend_from_slice(&qs);
+            }
+        }
+
+        // Activation buffer: capacity is a full multiple of 256 (>= in_dim) with
+        // a NON-ZERO sentinel tail past in_dim still inside the allocation; then
+        // len() is truncated to in_dim so the dispatch assert holds. A pre-fix
+        // high-nibble over-read past in_dim reads the sentinel and diverges.
+        let cap = num_blocks * SUPER_BLOCK_SIZE;
+        let mut input = vec![1.0e6_f32; cap];
+        for (i, v) in input.iter_mut().enumerate().take(in_dim) {
+            *v = ((i % 17) as f32) * 0.05 - 0.3;
+        }
+        input.truncate(in_dim);
+
+        let simd = matmul_q4k_f32_dispatch(&q4k_data, &input, out_dim, in_dim);
+        let scalar = matmul_q4k_f32_scalar(&q4k_data, &input, out_dim, in_dim);
+
+        for (i, (a, s)) in simd.iter().zip(scalar.iter()).enumerate() {
+            assert!(
+                (a - s).abs() < 1e-2,
+                "in_dim={in_dim} row={i}: SIMD {a} vs scalar {s} (diff {}) — \
+                 non-256-aligned in_dim must not over-read or drop the high-nibble tail",
+                (a - s).abs()
+            );
+        }
+    }
+}


### PR DESCRIPTION
## AVX-512 Q4_K GEMV over-reads the activation buffer (heap over-read)

Found by a **parallel adversarial correctness-audit workflow** (memory-safety finder, survived 2 independent verification lenses) — a class my serial single-agent audits missed.

`process_q4k_superblock_avx512` (`backends/q4k/gemv/avx512.rs`) wrapped **both** the low-nibble loads (activation `[base,base+32)`) and the high-nibble loads (`[base+32,base+64)`) in one guard `input_base_lo0 + 32 <= in_dim`. The high-nibble `_mm512_loadu_ps` reads `[base+32,base+64)`, valid only when `base+64 <= in_dim` — so for any **`in_dim ≡ 32/96/160/224 (mod 256)`** the guard passes but the load **over-reads up to 128 bytes** past the activation buffer. Release-reachable (the dispatch only `debug_assert`s `in_dim`, a no-op in release) via **both** the serial and the parallel (FFN/lm_head ≥8M work) paths. The AVX2 and Q6_K siblings re-guard each high group; the AVX-512 "bounds check hoisted out of hot loop" rewrite dropped it.

## Fix
- **Fast path unchanged** for full chunks (`base+64 <= in_dim` — the common 256-aligned case): unguarded 16-wide loads, hot-path perf preserved.
- **Bounded tail path** for partial chunks: `_mm512_maskz_loadu_ps` — lanes `≥ in_dim` are **not read** (no over-read) and load as `0.0` (0 FMA contribution). This *also* fixes a latent correctness bug: the old all-or-nothing guard silently **dropped** the valid high-nibble tail for partial chunks.

## Falsifier (RED-on-bug verified on an AVX-512 host)
`falsify_avx512_q4k_003_non_aligned_in_dim_no_oob`: the activation buffer carries a non-zero **sentinel tail** past `in_dim` inside the allocation (`len()==in_dim` for the dispatch assert). Pre-fix, the high-nibble over-read injects the sentinel → **`in_dim=32` gives SIMD 7.4e9 vs scalar 532.125**; the masked-load fix → **exact scalar parity**. Covers `in_dim ∈ {32,48,96,160,224}` + 256 control. Self-gates to a no-op on non-AVX-512 hosts (dispatch routes to AVX2/scalar, already correct).

## Verified
85 q4k tests pass (no regression); fmt + clippy clean. Contract co-evolution (Rule 7): `avx512-q4k-v1.yaml` 1.0.0→1.1.0 — wires `FALSIFY-AVX512-Q4K-003`, **discharging the previously-DECLARED-but-UNWIRED obligation C-AVX512-Q4K-003**; `pv validate` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)