### PR TITLE
feat(serve): Gemma2 CPU inference — softcapping + post-norms, llama.cpp-verified (PMAT-810b)

### DIFF
--- a/contracts/apr-load-fail-closed-gemma-v1.yaml
+++ b/contracts/apr-load-fail-closed-gemma-v1.yaml
@@ -1,40 +1,51 @@
 contract: apr-load-fail-closed-gemma
 metadata:
   kind: pattern
-  version: "2.0.0"
+  version: "3.0.0"
   description: >
     Gemma support is honest-by-design and version-gated. Gemma v1 (general.architecture
-    == "gemma") is now IMPLEMENTED in realizar's CPU forward path and is verified coherent
-    against the llama.cpp reference for the same GGUF (PMAT-809). Gemma2 / Gemma3 are STILL
-    refused at load because they additionally require attention/final-logit tanh-softcapping
-    which is NOT implemented; running them with uncapped LLaMA-style attention would emit
-    silently-wrong output. PMAT-809 implements the three Gemma-v1 behaviors the LLaMA-style
-    forward path lacked: (a) GeGLU FFN — gelu_tanh(gate(x)) * up(x) instead of SiLU/SwiGLU,
-    dispatched via OwnedQuantizedModel::gemma_gate_activation; (c) sqrt(hidden_size)
-    embedding scaling applied in embed()/embed_into() (GGUFConfig::embed_scale). Behavior
+    == "gemma", PMAT-809) AND Gemma v2 (general.architecture == "gemma2", PMAT-810) are now
+    IMPLEMENTED in realizar's CPU forward path and verified coherent against the llama.cpp
+    reference for the same GGUF. Gemma3 / Gemma3n are STILL refused at load because they
+    additionally require behaviors (per-layer embedding scaling, alternating local/global
+    attention with QK-norm) that are NOT implemented; running them with the gemma2 forward
+    would emit silently-wrong output. PMAT-809 implemented the three Gemma-v1 behaviors the
+    LLaMA-style forward path lacked: (a) GeGLU FFN — gelu_tanh(gate(x)) * up(x) instead of
+    SiLU/SwiGLU; (c) sqrt(hidden_size) embedding scaling (GGUFConfig::embed_scale). Behavior
     (b) — the Gemma (1 + weight) RMSNorm — is satisfied WITHOUT a runtime offset on the GGUF
     path: llama.cpp's GGUF converter (GemmaModel.modify_tensors: data_torch + 1) pre-adds 1.0
     to every *norm.weight at conversion time, so a GGUF gemma already stores (1 + w_hf)
     (verified empirically: norm weight mean ≈ 1.5–2.6, not ≈ 0) and the STANDARD x_normed * w
-    norm is correct; GGUFConfig::rmsnorm_unit_offset therefore returns false. Behavior (d),
-    softcapping, remains unimplemented → gemma2/gemma3 stay fail-loud. The single
-    enforcement point is contract_gate::validate_supported_architecture (Gate 0 in
+    norm is correct; GGUFConfig::rmsnorm_unit_offset therefore returns false. PMAT-810 adds the
+    FOUR Gemma-v2 behaviors on top of v1: (d) attention-logit tanh softcap 50*tanh(scores/50)
+    before softmax (ops::softcap, GGUFConfig::attn_logit_softcap); (e) final lm_head-logit tanh
+    softcap 30*tanh(logits/30) after the output projection (GGUFConfig::final_logit_softcap);
+    (f) 1/sqrt(query_pre_attn_scalar) attention query scaling (GGUFConfig::attn_scale; equals
+    1/sqrt(head_dim) for gemma-2-2b where the key is absent and head_dim==256, so byte-identical
+    there, but correct for 9b/27b where query_pre_attn_scalar==224); and (g) the per-layer
+    POST-attention and POST-feedforward RMSNorms (blk.N.post_attention_norm.weight /
+    blk.N.post_ffw_norm.weight) applied to each sub-block output BEFORE its residual add —
+    Gemma2 has FOUR norms per layer, not two. Without (g) the output is INCOHERENT (verified:
+    "The capital of France is" -> "is is is is" RED; with (d)-(g) -> "...Paris" GREEN). The
+    single enforcement point is contract_gate::validate_supported_architecture (Gate 0 in
     validate_model_load), which every inference-weight-loading path funnels through:
-    is_gemma1_supported(arch) is allowed; any other gemma-family arch is refused with a clear
-    error. apr convert / inspect / validate read metadata directly and are unaffected. This
-    extends the Pillar-4 fail-closed posture (PMAT-744, PMAT-750, PMAT-807): run what apr can
-    run CORRECTLY, refuse what it cannot, never emit garbage.
+    is_gemma1_supported(arch) and is_gemma2_supported(arch) are allowed; gemma3/gemma3n and any
+    other gemma-family arch are refused with a clear error. apr convert / inspect / validate read
+    metadata directly and are unaffected. This extends the Pillar-4 fail-closed posture
+    (PMAT-744, PMAT-750, PMAT-807): run what apr can run CORRECTLY, refuse what it cannot, never
+    emit garbage.
   references:
-  - "crates/aprender-serve/src/contract_gate.rs (validate_supported_architecture, is_gemma1_supported, is_gemma_family, Gate 0 in validate_model_load)"
-  - "crates/aprender-serve/src/gguf/config.rs (GGUFConfig::is_gemma1/embed_scale/geglu_ffn/rmsnorm_unit_offset — PMAT-809)"
-  - "crates/aprender-serve/src/gguf/ops.rs (rms_norm_unit_offset / rms_norm_unit_offset_into — HF-weight variant, gated)"
-  - "crates/aprender-serve/src/gguf/inference/forward/gemma_dispatch.rs (rms_norm_arch, rms_norm_into_arch, gemma_gate_activation)"
-  - "crates/aprender-serve/src/gguf/inference/matmul_fused.rs (embed/embed_into apply sqrt(hidden) scaling — behavior (c))"
-  - "crates/aprender-serve/src/gguf/inference/forward/ffn_block.rs + forward_fused_q4k.rs + forward_single_profiled.rs (GeGLU + arch-dispatched norm)"
+  - "crates/aprender-serve/src/contract_gate.rs (validate_supported_architecture, is_gemma1_supported, is_gemma2_supported, is_gemma_family, Gate 0 in validate_model_load)"
+  - "crates/aprender-serve/src/gguf/config.rs (GGUFConfig::is_gemma1/is_gemma2/embed_scale/geglu_ffn/rmsnorm_unit_offset/attn_logit_softcap/final_logit_softcap/attn_scale)"
+  - "crates/aprender-serve/src/gguf/ops.rs (softcap — cap*tanh(x/cap) in place; rms_norm for the GGUF pre-shifted post-norms)"
+  - "crates/aprender-serve/src/gguf/inference/attention_gqa.rs (attention_with_cache_gqa{,_into}: attn_scale + attn-logit softcap before softmax)"
+  - "crates/aprender-serve/src/gguf/inference/forward/ffn_block.rs (forward_single_with_cache: post_attn_norm + post_ffw_norm before residual; single_cache_final_output: final-logit softcap)"
+  - "crates/aprender-serve/src/gguf/transformer.rs + quantized.rs + loader_apr_quantized.rs (load post_attention_norm.weight + post_ffw_norm.weight)"
+  - "crates/aprender-serve/src/gguf/metadata.rs (attn_logit_softcapping / final_logit_softcapping / query_pre_attn_scalar accessors)"
   references_external:
-  - "llama.cpp convert_hf_to_gguf.py GemmaModel.modify_tensors: `data_torch = data_torch + 1` for *norm.weight (the GGUF +1 pre-shift)"
-  - "llama.cpp src/models/gemma.cpp: build_ffn(..., LLM_FFN_GELU, LLM_FFN_PAR) — GeGLU confirmation"
-version: 2
+  - "llama.cpp convert_hf_to_gguf.py GemmaModel.modify_tensors: `data_torch = data_torch + 1` for *norm.weight (the GGUF +1 pre-shift, applies to all 4 gemma2 norms)"
+  - "llama.cpp src/models/gemma2.cpp: ggml_tanh(ggml_scale(kq, 1/cap))*cap softcap, post_attention_norm/post_ffw_norm, n_embd_head_k query scale default"
+version: 3
 status: enforced
 date: 2026-06-16
 
@@ -43,51 +54,76 @@ proof_obligations:
     property: >
       GEMMA1-SUPPORTED: is_gemma1_supported(arch) is true iff the lowercased architecture is
       exactly "gemma" (or "gemmaforcausallm"); it is false for gemma2/gemma3/gemma3n and for
-      every non-gemma arch. validate_model_load returns Ok for a Gemma-v1 model so apr can run
-      it, having implemented behaviors (a) GeGLU, (b) standard norm over GGUF pre-shifted
-      weights, and (c) sqrt(hidden) embedding scaling.
+      every non-gemma arch. validate_model_load returns Ok for a Gemma-v1 model.
   - type: invariant
     property: >
-      GEMMA2-FAIL-LOUD: validate_model_load / validate_model_load_basic return
-      Err(gate="architecture_supported") for every NON-v1 Gemma architecture (gemma2, gemma3,
-      gemma3n, Gemma2ForCausalLM, Gemma3ForCausalLM), so a model that needs unimplemented
-      softcapping is refused instead of running silently-wrong. Non-Gemma archs load unchanged.
+      GEMMA2-SUPPORTED: is_gemma2_supported(arch) is true iff the lowercased architecture is
+      exactly "gemma2" (or "gemma2forcausallm"); it is false for gemma/gemma3/gemma3n and for
+      every non-gemma arch. validate_model_load / validate_model_load_basic return Ok for a
+      Gemma-v2 model so apr can run it, having implemented behaviors (d) attn-logit softcap,
+      (e) final-logit softcap, (f) query_pre_attn_scalar scaling, and (g) post-attn/post-ffn
+      RMSNorms in addition to the v1 behaviors.
   - type: invariant
     property: >
-      GEMMA1-FORWARD-PARITY: with Gemma-v1 behaviors active, GGUFConfig::embed_scale is
-      Some(sqrt(hidden_size)) and rmsnorm_unit_offset is false (GGUF weights pre-shifted), and
-      the runtime forward produces COHERENT output that matches the llama.cpp reference on the
-      same GGUF (e.g. "The capital of France is" -> "Paris", "2+2=" -> "4", "The sky is" ->
-      "the limit"). Non-Gemma archs are byte-identical (embed_scale None, standard norm, SiLU).
+      GEMMA3-FAIL-LOUD: validate_model_load / validate_model_load_basic return
+      Err(gate="architecture_supported") for every Gemma architecture beyond v2 (gemma3,
+      gemma3n, Gemma3ForCausalLM), so a model that needs further-unimplemented behaviors is
+      refused instead of running silently-wrong. Non-Gemma archs load unchanged.
+  - type: invariant
+    property: >
+      GEMMA2-FORWARD-PARITY: with Gemma-v2 behaviors active, the runtime forward produces
+      COHERENT output that matches the llama.cpp reference on the same GGUF
+      (gemma-2-2b-it-Q4_K_M, greedy: "What is the capital of France?" -> "...Paris",
+      "What is 2+2?" -> "2 + 2 = 4"). The attn-logit softcap, final-logit softcap, and
+      post-attention/post-ffn RMSNorms are each necessary: removing the post-norms alone
+      collapses output to incoherent token repetition ("is is is is").
+  - type: invariant
+    property: >
+      SOFTCAP-MATH: ops::softcap(x, cap) == cap*tanh(x/cap) elementwise, bounds every output
+      into (-cap, cap), is ~identity near 0, and is a no-op for a non-positive or non-finite
+      cap. GGUFConfig::attn_logit_softcap/final_logit_softcap return Some(50.0)/Some(30.0) for
+      gemma2 and None for every other architecture (so non-gemma2 logits/scores are untouched).
+  - type: invariant
+    property: >
+      NON-GEMMA-BYTE-IDENTICAL: for every non-Gemma2 architecture the post-norms are absent
+      (loaded as None → skipped), attn_logit_softcap/final_logit_softcap are None (no softcap),
+      and query_pre_attn_scalar is None so attn_scale falls back to 1/sqrt(head_dim) — the
+      forward path is byte-identical to before PMAT-810 (e.g. qwen2/llama output unchanged).
 
 falsification_tests:
   - id: FALSIFY-LOAD-GEMMA-001
-    name: test_gemma2_gemma3_rejected_at_load
-    prediction: "validate_model_load with architecture in {gemma2, gemma3, Gemma2ForCausalLM, Gemma3ForCausalLM, gemma3n} returns Err(gate=architecture_supported) whose reason names the missing softcapping behavior"
-    test_harness: "cargo test -p aprender-serve --lib test_gemma2_gemma3_rejected_at_load"
+    name: test_gemma3_rejected_at_load
+    prediction: "validate_model_load with architecture in {gemma3, Gemma3ForCausalLM, gemma3n} returns Err(gate=architecture_supported) whose reason names the refused Gemma3 architecture"
+    test_harness: "cargo test -p aprender-serve --lib test_gemma3_rejected_at_load"
     expected_output: "test result: ok"
-    if_fails: "a gemma2/gemma3 model is accepted at load → apr runs it WITHOUT softcapping and emits silently-wrong output."
+    if_fails: "a gemma3/gemma3n model is accepted at load → apr runs it with the gemma2 forward (missing further behaviors) and emits silently-wrong output."
   - id: FALSIFY-LOAD-GEMMA-002
+    name: test_gemma2_now_supported
+    prediction: "validate_model_load with architecture in {gemma2, GEMMA2, Gemma2ForCausalLM} is Ok (PMAT-810 implemented the v2 behaviors), while is_gemma2_supported(gemma/gemma3/gemma3n) is false"
+    test_harness: "cargo test -p aprender-serve --lib test_gemma2_now_supported"
+    expected_output: "test result: ok"
+    if_fails: "either Gemma v2 is wrongly re-refused (no inference for a supported family) or gemma3/3n is wrongly accepted (silent garbage)."
+  - id: FALSIFY-LOAD-GEMMA-003
     name: test_gemma1_now_supported
-    prediction: "validate_model_load with architecture in {gemma, GEMMA, GemmaForCausalLM} is Ok (PMAT-809 implemented the v1 behaviors), while is_gemma1_supported(gemma2/gemma3/gemma3n) is false"
+    prediction: "validate_model_load with architecture in {gemma, GEMMA, GemmaForCausalLM} is Ok (PMAT-809), while is_gemma1_supported(gemma2/gemma3/gemma3n) is false"
     test_harness: "cargo test -p aprender-serve --lib test_gemma1_now_supported"
     expected_output: "test result: ok"
-    if_fails: "either Gemma v1 is wrongly re-refused (no inference for a supported family) or gemma2/3 is wrongly accepted (silent garbage)."
-  - id: FALSIFY-LOAD-GEMMA-003
+    if_fails: "Gemma v1 is wrongly re-refused, or a non-v1 family is wrongly classified as v1."
+  - id: FALSIFY-LOAD-GEMMA-004
     name: test_non_gemma_architectures_unaffected
     prediction: "validate_model_load with architecture in {llama, qwen2, qwen3, mistral, phi, phi2, deepseek, gpt2, unknown_future_arch} is Ok — the Gemma gate does not regress any other family"
     test_harness: "cargo test -p aprender-serve --lib test_non_gemma_architectures_unaffected"
     expected_output: "test result: ok"
     if_fails: "the Gemma gate over-triggers and refuses a non-Gemma model that apr CAN run correctly = a regression."
-  - id: FALSIFY-LOAD-GEMMA-004
+  - id: FALSIFY-LOAD-GEMMA-005
     name: gemma_config_helpers
-    prediction: "GGUFConfig helpers: is_gemma1 true only for v1; embed_scale == sqrt(hidden) for gemma1 and None otherwise; geglu_ffn true only for gemma1; rmsnorm_unit_offset false for the GGUF path (weights pre-shifted)"
+    prediction: "GGUFConfig helpers: is_gemma1/is_gemma2 true only for their exact arch; embed_scale == sqrt(hidden) for gemma1 AND gemma2 and None otherwise; geglu_ffn true for gemma1 AND gemma2; rmsnorm_unit_offset false for the GGUF path"
     test_harness: "cargo test -p aprender-serve --lib gemma_config_tests"
     expected_output: "test result: ok"
-    if_fails: "a Gemma-v1 forward behavior is mis-gated (wrong embedding scale, wrong activation, or a double-counted (1+w) norm) = wrong output."
-  - id: FALSIFY-LOAD-GEMMA-005
-    name: gemma_rmsnorm_unit_offset_math
-    prediction: "rms_norm_unit_offset(x, w) == rms_norm(x, w+1) elementwise, and with zero-centered weights the offset variant yields RMS ~= 1 while plain rms_norm yields ~0 — proving the (1+w) HF-weight semantics are implemented correctly for the (future) raw-HF path"
-    test_harness: "cargo test -p aprender-serve --lib gemma_rmsnorm_tests"
+    if_fails: "a Gemma forward behavior is mis-gated (wrong embedding scale, wrong activation, or a double-counted (1+w) norm) = wrong output."
+  - id: FALSIFY-LOAD-GEMMA-006
+    name: softcap_tests
+    prediction: "ops::softcap(x, cap) == cap*tanh(x/cap) within 1e-4, bounds outputs into ±cap for extreme inputs, is ~identity near 0, and is a no-op for cap<=0 or non-finite cap"
+    test_harness: "cargo test -p aprender-serve --lib softcap_tests"
     expected_output: "test result: ok"
-    if_fails: "the (1+w) RMSNorm primitive is wrong; any raw-HF gemma loader relying on it would produce wrong output."
+    if_fails: "the gemma2 tanh softcap primitive is wrong → attention/final logits are not capped correctly → wrong sampling → divergent output."

--- a/crates/aprender-serve/src/api/test_helpers.rs
+++ b/crates/aprender-serve/src/api/test_helpers.rs
@@ -151,6 +151,8 @@ pub fn create_test_quantized_model(
             ffn_norm_bias: None,
             attn_q_norm_weight: None,
             attn_k_norm_weight: None,
+            post_attn_norm_weight: None,
+            post_ffw_norm_weight: None,
         })
         .collect();
 

--- a/crates/aprender-serve/src/api/tests/apr_audit.rs
+++ b/crates/aprender-serve/src/api/tests/apr_audit.rs
@@ -258,6 +258,7 @@ fn test_imp_116a_appstate_cached_model_storage() {
 
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -298,6 +299,7 @@ async fn test_imp_116b_cached_model_thread_safety() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -344,6 +346,7 @@ async fn test_imp_116c_completions_uses_cached_model() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };

--- a/crates/aprender-serve/src/api/tests/chat_template_contract.rs
+++ b/crates/aprender-serve/src/api/tests/chat_template_contract.rs
@@ -21,6 +21,7 @@ fn make_config(architecture: &str) -> GGUFConfig {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     }

--- a/crates/aprender-serve/src/api/tests/gpu_model.rs
+++ b/crates/aprender-serve/src/api/tests/gpu_model.rs
@@ -86,6 +86,7 @@ async fn test_quantized_model_empty_messages_error() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -147,6 +148,7 @@ async fn test_quantized_model_temperature_zero() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -201,6 +203,7 @@ async fn test_quantized_model_max_tokens() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -368,6 +371,7 @@ async fn test_empty_prompt_after_tokenization() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -429,6 +433,7 @@ async fn test_finish_reason_length() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };

--- a/crates/aprender-serve/src/api/tests/imp_127d.rs
+++ b/crates/aprender-serve/src/api/tests/imp_127d.rs
@@ -48,6 +48,7 @@ async fn test_imp_128a_prometheus_format_endpoint() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -106,6 +107,7 @@ async fn test_imp_128b_prometheus_format_structure() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -167,6 +169,7 @@ async fn test_imp_128c_default_format_is_json() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -219,6 +222,7 @@ async fn test_imp_128d_explicit_json_format() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -272,6 +276,7 @@ async fn test_imp_130a_prometheus_includes_cpu_latency_histogram() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -341,6 +346,7 @@ async fn test_imp_130b_prometheus_includes_gpu_latency_histogram() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -409,6 +415,7 @@ async fn test_imp_130c_prometheus_latency_buckets_have_correct_labels() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };

--- a/crates/aprender-serve/src/api/tests/imp_130d.rs
+++ b/crates/aprender-serve/src/api/tests/imp_130d.rs
@@ -19,6 +19,7 @@ async fn test_imp_130d_prometheus_latency_has_help_and_type() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -90,6 +91,7 @@ async fn test_imp_141a_prometheus_includes_throughput_rps() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -152,6 +154,7 @@ async fn test_imp_141b_prometheus_includes_elapsed_seconds() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -206,6 +209,7 @@ async fn test_imp_141c_throughput_rps_has_help_and_type() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -263,6 +267,7 @@ async fn test_imp_141d_elapsed_seconds_has_help_and_type() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -385,6 +390,7 @@ async fn test_imp_131c_json_response_includes_percentiles() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };

--- a/crates/aprender-serve/src/api/tests/imp_132a.rs
+++ b/crates/aprender-serve/src/api/tests/imp_132a.rs
@@ -24,6 +24,7 @@ fn test_imp_132a_adaptive_attention_records_cpu_latency() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -76,6 +77,7 @@ fn test_imp_132b_latency_values_are_reasonable() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -128,6 +130,7 @@ fn test_imp_132c_latency_count_matches_dispatch_count() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -182,6 +185,7 @@ fn test_imp_132d_gpu_dispatches_record_latency() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };

--- a/crates/aprender-serve/src/api/tests/quantized_multi.rs
+++ b/crates/aprender-serve/src/api/tests/quantized_multi.rs
@@ -23,6 +23,7 @@ async fn test_quantized_multi_turn_conversation() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };

--- a/crates/aprender-serve/src/api/tests/tests_02.rs
+++ b/crates/aprender-serve/src/api/tests/tests_02.rs
@@ -36,6 +36,7 @@ async fn test_imp_116d_scheduler_reuse_across_requests() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -90,6 +91,7 @@ fn test_imp_126a_appstate_has_dispatch_metrics() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -141,6 +143,7 @@ fn test_imp_126b_cached_sync_has_generate_adaptive() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -191,6 +194,7 @@ fn test_imp_126c_dispatch_metrics_integration() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -241,6 +245,7 @@ fn test_imp_126d_handler_uses_adaptive_generation() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -304,6 +309,7 @@ async fn test_imp_127a_dispatch_metrics_endpoint_exists() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -362,6 +368,7 @@ async fn test_imp_127b_dispatch_metrics_response_structure() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -428,6 +435,7 @@ async fn test_imp_127c_dispatch_metrics_starts_zero() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };

--- a/crates/aprender-serve/src/api/tests/tests_15.rs
+++ b/crates/aprender-serve/src/api/tests/tests_15.rs
@@ -42,6 +42,7 @@ async fn test_quantized_model_chat_completions_routing() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -104,6 +105,7 @@ async fn test_quantized_model_streaming_path() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -159,6 +161,7 @@ async fn test_quantized_model_with_trace_headers() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -221,6 +224,7 @@ async fn test_cached_model_chat_completions_routing() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -282,6 +286,7 @@ async fn test_cached_model_streaming_path() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };

--- a/crates/aprender-serve/src/api/tests/tests_24.rs
+++ b/crates/aprender-serve/src/api/tests/tests_24.rs
@@ -40,6 +40,7 @@ mod potemkin_village {
             eps: 1e-5,
             rope_type: 0, // 0 = NORM (standard LLaMA)
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
             bos_token_id: None,
             eos_token_id: None,
         };

--- a/crates/aprender-serve/src/apr_transformer/tests/convert_gguf.rs
+++ b/crates/aprender-serve/src/apr_transformer/tests/convert_gguf.rs
@@ -21,6 +21,7 @@ fn make_gguf_config(hidden: usize, layers: usize, heads: usize, kv_heads: usize)
         rope_type: 2,
         context_length: 2048,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     }

--- a/crates/aprender-serve/src/apr_transformer/tests/q4_simd_forward.rs
+++ b/crates/aprender-serve/src/apr_transformer/tests/q4_simd_forward.rs
@@ -377,6 +377,7 @@ fn test_from_gguf_basic_fused_qkv() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };

--- a/crates/aprender-serve/src/apr_transformer/tests/q4_simd_gguf.rs
+++ b/crates/aprender-serve/src/apr_transformer/tests/q4_simd_gguf.rs
@@ -24,6 +24,7 @@ fn test_from_gguf_separate_qkv() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -53,6 +54,8 @@ fn test_from_gguf_separate_qkv() {
         ffn_norm_bias: None,
         attn_q_norm_weight: None,
         attn_k_norm_weight: None,
+        post_attn_norm_weight: None,
+        post_ffw_norm_weight: None,
     };
 
     let model = OwnedQuantizedModel {
@@ -111,6 +114,7 @@ fn test_from_gguf_gqa_config() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -146,6 +150,7 @@ fn test_from_gguf_with_ffn_gate() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -170,6 +175,8 @@ fn test_from_gguf_with_ffn_gate() {
         ffn_norm_bias: None,
         attn_q_norm_weight: None,
         attn_k_norm_weight: None,
+        post_attn_norm_weight: None,
+        post_ffw_norm_weight: None,
     };
 
     let model = OwnedQuantizedModel {

--- a/crates/aprender-serve/src/contract_gate.rs
+++ b/crates/aprender-serve/src/contract_gate.rs
@@ -293,13 +293,33 @@ pub fn is_gemma_family(arch_name: &str) -> bool {
 /// the llama.cpp reference for the same GGUF (PMAT-809). It has NO softcapping, so
 /// it is correct without it.
 ///
-/// Gemma2 / Gemma3 ALSO require attention- and final-logit softcapping, which is
+/// Gemma3 / Gemma3n ALSO require behaviors beyond softcapping (e.g. per-layer
+/// embedding scaling, alternating local/global attention with QK-norm) that are
 /// NOT implemented — so they are deliberately EXCLUDED here and remain fail-loud.
 #[must_use]
 pub fn is_gemma1_supported(arch_name: &str) -> bool {
     let lower = arch_name.to_ascii_lowercase();
     // EXACT v1 only — never gemma2/gemma3/gemma3n (those need softcapping).
     lower == "gemma" || lower == "gemmaforcausallm"
+}
+
+/// PMAT-810: Returns `true` when `arch_name` is the Gemma-**v2** architecture
+/// that realizar's CPU forward path now implements CORRECTLY.
+///
+/// Gemma v2 (`gemma2`, `Gemma2ForCausalLM`) adds three behaviors on top of
+/// Gemma v1's GeGLU FFN + `(1 + weight)` RMSNorm + `sqrt(hidden)` embed scaling:
+/// attention-logit tanh softcap (`50 * tanh(scores/50)`), final-logit tanh
+/// softcap (`30 * tanh(logits/30)`), and `1/sqrt(query_pre_attn_scalar)` query
+/// scaling. All three are implemented (`ops::softcap`, `config.attn_scale`) and
+/// verified coherent against llama.cpp on gemma-2-2b-it Q4_K_M (PMAT-810):
+/// "capital of France" → "Paris", "2+2=" → "4", top-token match.
+///
+/// EXACT `gemma2` only — `gemma3`/`gemma3n` need further behaviors and stay
+/// fail-loud (honest-by-design).
+#[must_use]
+pub fn is_gemma2_supported(arch_name: &str) -> bool {
+    let lower = arch_name.to_ascii_lowercase();
+    lower == "gemma2" || lower == "gemma2forcausallm"
 }
 
 /// Fail LOUD for architectures whose required behaviors realizar's forward path
@@ -323,15 +343,21 @@ fn validate_supported_architecture(arch_name: &str) -> std::result::Result<(), M
     if is_gemma1_supported(arch_name) {
         return Ok(());
     }
+    // PMAT-810: Gemma v2 is now implemented (softcapping + query_pre_attn_scalar),
+    // verified coherent vs llama.cpp on gemma-2-2b-it Q4_K_M — allow it through.
+    if is_gemma2_supported(arch_name) {
+        return Ok(());
+    }
     if is_gemma_family(arch_name) {
         return Err(ModelLoadError {
             gate: "architecture_supported",
             reason: format!(
-                "Gemma2/Gemma3 architecture '{arch_name}' additionally requires \
-                 attention/logit tanh-softcapping, which realizar's forward path \
-                 does not implement yet. Running it would silently produce incorrect \
-                 output, so it is refused. (Gemma v1 IS supported — PMAT-809.) \
-                 Track Gemma2/3 support at PMAT-807."
+                "Gemma3/Gemma3n architecture '{arch_name}' requires behaviors \
+                 (per-layer embedding scaling, alternating local/global attention \
+                 with QK-norm) that realizar's forward path does not implement yet. \
+                 Running it would silently produce incorrect output, so it is \
+                 refused. (Gemma v1 — PMAT-809 — and Gemma v2 — PMAT-810 — ARE \
+                 supported.) Track Gemma3 support at PMAT-807."
             ),
         });
     }
@@ -664,14 +690,13 @@ mod tests {
     /// FALSIFIER: every Gemma-family arch string is rejected at the gate.
     /// If any is silently accepted, this test fails (silent-garbage regression).
     ///
-    /// PMAT-809: Gemma2/Gemma3 are STILL refused (they need softcapping). Gemma v1
-    /// is now SUPPORTED, so it is asserted separately in `test_gemma1_now_supported`.
+    /// PMAT-810: Gemma3/Gemma3n are STILL refused (further behaviors unimplemented).
+    /// Gemma v1 (PMAT-809) and Gemma v2 (PMAT-810) are now SUPPORTED, asserted
+    /// separately in `test_gemma1_now_supported` / `test_gemma2_now_supported`.
     #[test]
-    fn test_gemma2_gemma3_rejected_at_load() {
+    fn test_gemma3_rejected_at_load() {
         let gemma_names = [
-            "gemma2",
             "gemma3",
-            "Gemma2ForCausalLM",
             "Gemma3ForCausalLM",
             "gemma3n", // future point variant — fail-loud is the safe default
         ];
@@ -679,19 +704,43 @@ mod tests {
             let mut config = valid_config();
             config.architecture = name.to_string();
             let err = validate_model_load(&config)
-                .expect_err(&format!("Gemma2/3 arch '{name}' must be refused, not run"));
+                .expect_err(&format!("Gemma3 arch '{name}' must be refused, not run"));
             assert_eq!(
                 err.gate, "architecture_supported",
                 "'{name}' rejected by wrong gate: {}",
                 err.gate
             );
-            // The error must explain WHY (the missing softcapping behavior).
+            // The error must name the architecture it refused.
             assert!(
-                err.reason.contains("Gemma") && err.reason.contains("softcapping"),
-                "'{name}' error must name the missing behavior: {}",
+                err.reason.contains("Gemma3"),
+                "'{name}' error must name the refused architecture: {}",
                 err.reason
             );
         }
+    }
+
+    /// PMAT-810 FALSIFIER: Gemma v2 now LOADS (it was fail-loud under PMAT-807/809).
+    ///
+    /// If the forward path ever regresses and Gemma v2 is re-rejected, this fails.
+    /// Coherence vs llama.cpp is the separate end-to-end falsifier (PMAT-810).
+    #[test]
+    fn test_gemma2_now_supported() {
+        for name in ["gemma2", "GEMMA2", "Gemma2ForCausalLM"] {
+            assert!(
+                is_gemma2_supported(name),
+                "'{name}' must be recognized as supported Gemma v2"
+            );
+            let mut config = valid_config();
+            config.architecture = name.to_string();
+            assert!(
+                validate_model_load(&config).is_ok(),
+                "Gemma v2 arch '{name}' must now load (PMAT-810)"
+            );
+        }
+        // The exclusions: gemma3/gemma3n are NOT "supported v2".
+        assert!(!is_gemma2_supported("gemma3"));
+        assert!(!is_gemma2_supported("gemma3n"));
+        assert!(!is_gemma2_supported("gemma"));
     }
 
     /// PMAT-809 FALSIFIER: Gemma v1 now LOADS (it was fail-loud under PMAT-807).
@@ -718,12 +767,12 @@ mod tests {
         assert!(!is_gemma1_supported("gemma3n"));
     }
 
-    /// `validate_model_load_basic` (the path real loaders call) still rejects Gemma2.
+    /// PMAT-810: `validate_model_load_basic` (the path real loaders call) now
+    /// ACCEPTS Gemma v2 (gemma-2-2b-it dims: 26 layers, 2304 hidden, 8/4 heads).
     #[test]
-    fn test_gemma2_rejected_via_basic_loader_path() {
-        let err = validate_model_load_basic("gemma2", 26, 2304, 8, 4, 9216, 256_000)
-            .expect_err("gemma2 must be refused at the basic loader gate");
-        assert_eq!(err.gate, "architecture_supported");
+    fn test_gemma2_accepted_via_basic_loader_path() {
+        validate_model_load_basic("gemma2", 26, 2304, 8, 4, 9216, 256_000)
+            .expect("gemma2 must now load at the basic loader gate (PMAT-810)");
     }
 
     /// `validate_model_load_basic` now ACCEPTS Gemma v1 (PMAT-809).

--- a/crates/aprender-serve/src/convert/tests.rs
+++ b/crates/aprender-serve/src/convert/tests.rs
@@ -84,6 +84,7 @@ mod tests {
             eps: 1e-6,
             rope_type: 2, // NEOX style
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
             bos_token_id: None,
             eos_token_id: None,
         };

--- a/crates/aprender-serve/src/convert/tests_conversion_stats.rs
+++ b/crates/aprender-serve/src/convert/tests_conversion_stats.rs
@@ -352,6 +352,7 @@ fn test_from_gguf_transformer_preserves_config() {
             eps: 1e-6,
             rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
             bos_token_id: None,
             eos_token_id: None,
         },

--- a/crates/aprender-serve/src/convert/tests_convert.rs
+++ b/crates/aprender-serve/src/convert/tests_convert.rs
@@ -130,6 +130,7 @@ fn test_from_gguf_transformer_preserves_layer_biases() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -200,6 +201,7 @@ fn test_from_gguf_transformer_no_biases() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -262,6 +264,7 @@ fn test_from_gguf_transformer_multi_layer() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };

--- a/crates/aprender-serve/src/convert/tests_deep_ccov.rs
+++ b/crates/aprender-serve/src/convert/tests_deep_ccov.rs
@@ -266,6 +266,7 @@
             eps: 1e-5,
             rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
             bos_token_id: None,
             eos_token_id: None,
         };
@@ -327,6 +328,7 @@
             eps: 1e-5,
             rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
             bos_token_id: None,
             eos_token_id: None,
         };

--- a/crates/aprender-serve/src/convert/tests_gguf_field_preservation.rs
+++ b/crates/aprender-serve/src/convert/tests_gguf_field_preservation.rs
@@ -177,6 +177,7 @@
             eps: 1e-5,
             rope_type: 0, // NORM style (adjacent pairs)
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
             bos_token_id: None,
             eos_token_id: None,
         };

--- a/crates/aprender-serve/src/gguf/config.rs
+++ b/crates/aprender-serve/src/gguf/config.rs
@@ -1207,7 +1207,8 @@ mod gemma_config_tests {
         assert!(!cfg("qwen2", 1536).is_gemma1());
     }
 
-    /// (c) embed scale is `sqrt(hidden)` for gemma1, `None` otherwise.
+    /// (c) embed scale is `sqrt(hidden)` for gemma1 AND gemma2 (PMAT-810:
+    /// gemma2 shares gemma1's `sqrt(hidden)` embedding scaling), `None` otherwise.
     #[test]
     fn embed_scale_is_sqrt_hidden_for_gemma_only() {
         let g = cfg("gemma", 2048);
@@ -1216,17 +1217,26 @@ mod gemma_config_tests {
             (s - (2048f32).sqrt()).abs() < 1e-3,
             "scale {s} != sqrt(2048)"
         );
+        // PMAT-810: gemma2 also scales embeddings by sqrt(hidden).
+        let s2 = cfg("gemma2", 2304)
+            .embed_scale()
+            .expect("gemma2 must scale embeddings");
+        assert!(
+            (s2 - (2304f32).sqrt()).abs() < 1e-3,
+            "gemma2 scale {s2} != sqrt(2304)"
+        );
         assert!(cfg("llama", 4096).embed_scale().is_none());
         assert!(cfg("qwen2", 1536).embed_scale().is_none());
-        assert!(cfg("gemma2", 2304).embed_scale().is_none());
     }
 
-    /// (a) GeGLU FFN enabled for gemma1 only.
+    /// (a) GeGLU FFN enabled for gemma1 AND gemma2 (PMAT-810: gemma2 shares
+    /// gemma1's GeGLU FFN), disabled for non-Gemma archs.
     #[test]
     fn geglu_enabled_for_gemma1_only() {
         assert!(cfg("gemma", 2048).geglu_ffn());
+        assert!(cfg("gemma2", 2304).geglu_ffn());
         assert!(!cfg("llama", 4096).geglu_ffn());
-        assert!(!cfg("gemma2", 2304).geglu_ffn());
+        assert!(!cfg("qwen2", 1536).geglu_ffn());
     }
 
     /// (b) GGUF gemma weights are pre-shifted (+1 at conversion), so NO runtime

--- a/crates/aprender-serve/src/gguf/config.rs
+++ b/crates/aprender-serve/src/gguf/config.rs
@@ -1255,8 +1255,16 @@ mod gemma_config_tests {
         assert_eq!(g2.attn_logit_softcap(), Some(50.0));
         assert_eq!(g2.final_logit_softcap(), Some(30.0));
         for arch in ["gemma", "gemma3", "llama", "qwen2"] {
-            assert_eq!(cfg(arch, 2048).attn_logit_softcap(), None, "{arch} attn softcap");
-            assert_eq!(cfg(arch, 2048).final_logit_softcap(), None, "{arch} final softcap");
+            assert_eq!(
+                cfg(arch, 2048).attn_logit_softcap(),
+                None,
+                "{arch} attn softcap"
+            );
+            assert_eq!(
+                cfg(arch, 2048).final_logit_softcap(),
+                None,
+                "{arch} final softcap"
+            );
         }
     }
 

--- a/crates/aprender-serve/src/gguf/config.rs
+++ b/crates/aprender-serve/src/gguf/config.rs
@@ -1247,4 +1247,35 @@ mod gemma_config_tests {
         assert!(!cfg("gemma", 2048).rmsnorm_unit_offset());
         assert!(!cfg("llama", 4096).rmsnorm_unit_offset());
     }
+
+    /// PMAT-810: gemma2 softcap constants are 50 (attn) / 30 (final); None elsewhere.
+    #[test]
+    fn softcap_constants_gemma2_only() {
+        let g2 = cfg("gemma2", 2304);
+        assert_eq!(g2.attn_logit_softcap(), Some(50.0));
+        assert_eq!(g2.final_logit_softcap(), Some(30.0));
+        for arch in ["gemma", "gemma3", "llama", "qwen2"] {
+            assert_eq!(cfg(arch, 2048).attn_logit_softcap(), None, "{arch} attn softcap");
+            assert_eq!(cfg(arch, 2048).final_logit_softcap(), None, "{arch} final softcap");
+        }
+    }
+
+    /// PMAT-810: attn_scale falls back to 1/sqrt(head_dim) when
+    /// query_pre_attn_scalar is absent (== llama.cpp n_embd_head_k default), and
+    /// uses 1/sqrt(query_pre_attn_scalar) when present.
+    #[test]
+    fn attn_scale_query_pre_attn_scalar_fallback_and_override() {
+        // Default (key absent): 1/sqrt(head_dim). cfg() sets hidden=2304, heads=8
+        // → head_dim = 2304/8 = 288 (no explicit_head_dim in the helper).
+        let mut g = cfg("gemma2", 2304);
+        let hd = g.head_dim() as f32;
+        assert!(g.query_pre_attn_scalar.is_none());
+        assert!((g.attn_scale() - 1.0 / hd.sqrt()).abs() < 1e-6);
+        // Override (9b/27b style): query_pre_attn_scalar=224 → 1/sqrt(224).
+        g.query_pre_attn_scalar = Some(224.0);
+        assert!((g.attn_scale() - 1.0 / 224f32.sqrt()).abs() < 1e-6);
+        // Non-gemma config (llama): None → 1/sqrt(head_dim), unchanged.
+        let l = cfg("llama", 4096);
+        assert!((l.attn_scale() - 1.0 / (l.head_dim() as f32).sqrt()).abs() < 1e-6);
+    }
 }

--- a/crates/aprender-serve/src/gguf/config.rs
+++ b/crates/aprender-serve/src/gguf/config.rs
@@ -278,6 +278,13 @@ pub struct GGUFConfig {
     ///
     /// Source: GGUF metadata `{arch}.attention.key_length`.
     pub explicit_head_dim: Option<usize>,
+    /// PMAT-810: Gemma2 pre-attention query scale denominator
+    /// (`{arch}.attention.query_pre_attn_scalar`). When `Some(d)`, the attention
+    /// scale is `1/sqrt(d)` instead of `1/sqrt(head_dim)`. `None` (every non-Gemma2
+    /// arch, and gemma-2-2b which omits the key) → fall back to `head_dim`, which
+    /// matches llama.cpp's default (`n_embd_head_k`). Equal to head_dim (256) for
+    /// gemma-2-2b (so a no-op there); 224 for gemma-2-9b/27b.
+    pub query_pre_attn_scalar: Option<f32>,
     /// BOS token ID from GGUF metadata (used for GPU validation probe)
     /// None means BOS is unknown — GPU validation will be skipped.
     pub bos_token_id: Option<u32>,
@@ -545,6 +552,7 @@ impl GGUFConfig {
             rope_type,
             context_length,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
             bos_token_id,
             eos_token_id,
         })
@@ -561,6 +569,23 @@ impl GGUFConfig {
         } else {
             self.hidden_dim
         })
+    }
+
+    /// PMAT-810: Pre-softmax attention scale `1/sqrt(d)`.
+    ///
+    /// For almost every architecture `d = head_dim`, giving the standard
+    /// `1/sqrt(head_dim)`. Gemma2 instead scales queries by
+    /// `1/sqrt(query_pre_attn_scalar)`: 256 for gemma-2-2b (== head_dim, so this
+    /// is a no-op there) but 224 for gemma-2-9b/27b. When the GGUF omits the key
+    /// (`query_pre_attn_scalar == None`) we fall back to `head_dim`, exactly like
+    /// llama.cpp's default of `n_embd_head_k`.
+    #[inline]
+    #[must_use]
+    pub fn attn_scale(&self) -> f32 {
+        let denom = self
+            .query_pre_attn_scalar
+            .unwrap_or_else(|| self.head_dim() as f32);
+        1.0 / denom.sqrt()
     }
 
     /// Total Q projection dimension: `num_heads * head_dim`.
@@ -718,6 +743,11 @@ impl GGUFConfig {
         // GH-305: Infer head_dim from GGUF metadata or tensor shapes.
         let explicit_head_dim = Self::infer_explicit_head_dim(model, hidden_dim, num_heads);
 
+        // PMAT-810: Gemma2 pre-attention query scale denominator. None for every
+        // other arch (and gemma-2-2b, which omits the key) → attn_scale() falls
+        // back to head_dim, matching llama.cpp's default (n_embd_head_k).
+        let query_pre_attn_scalar = model.query_pre_attn_scalar();
+
         // Read rope_type: 0 = NORM (adjacent pairs, default for LLaMA), 2 = NEOX (split halves)
         // LLaMA models use type 0 (adjacent pairs) per llama.cpp's LLAMA_ROPE_TYPE_NORM
         let rope_type = model.rope_type().unwrap_or(0);
@@ -756,6 +786,7 @@ impl GGUFConfig {
             eps,
             rope_type,
             explicit_head_dim,
+            query_pre_attn_scalar,
             bos_token_id,
             eos_token_id,
         })
@@ -933,6 +964,7 @@ impl ValidatedModelConfig {
             eps,
             rope_type,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
             bos_token_id: config.bos_token_id,
             eos_token_id: config.eos_token_id,
         };
@@ -1154,6 +1186,7 @@ mod gemma_config_tests {
             eps: 1e-6,
             rope_type: 2,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
             bos_token_id: Some(2),
             eos_token_id: Some(1),
         }

--- a/crates/aprender-serve/src/gguf/config.rs
+++ b/crates/aprender-serve/src/gguf/config.rs
@@ -379,6 +379,47 @@ impl GGUFConfig {
         a == "gemma" || a == "gemmaforcausallm"
     }
 
+    /// PMAT-810: Whether this is a Gemma-**v2**-family architecture
+    /// (`gemma2`, GGUF `general.architecture == "gemma2"`).
+    ///
+    /// Gemma2 shares Gemma1's GeGLU FFN + `sqrt(hidden)` embedding scaling, and
+    /// ADDS attention- and final-logit tanh softcapping. EXACT `gemma2` only —
+    /// not `gemma3`/`gemma3n` (those have further behaviors and stay fail-loud).
+    #[must_use]
+    pub fn is_gemma2(&self) -> bool {
+        let a = self.architecture.to_ascii_lowercase();
+        a == "gemma2" || a == "gemma2forcausallm"
+    }
+
+    /// PMAT-810: Gemma2 attention-logit softcap constant, applied as
+    /// `cap * tanh(scores / cap)` before the attention softmax.
+    ///
+    /// Returns `Some(50.0)` for Gemma2 (the canonical `attn_logit_softcapping` for
+    /// every gemma-2-* checkpoint), `None` for all other architectures — `None`
+    /// disables softcapping so non-Gemma2 attention stays byte-identical.
+    #[must_use]
+    pub fn attn_logit_softcap(&self) -> Option<f32> {
+        if self.is_gemma2() {
+            Some(50.0)
+        } else {
+            None
+        }
+    }
+
+    /// PMAT-810: Gemma2 final lm_head-logit softcap constant, applied as
+    /// `cap * tanh(logits / cap)` after the output projection.
+    ///
+    /// Returns `Some(30.0)` for Gemma2 (the canonical `final_logit_softcapping`
+    /// for every gemma-2-* checkpoint), `None` otherwise.
+    #[must_use]
+    pub fn final_logit_softcap(&self) -> Option<f32> {
+        if self.is_gemma2() {
+            Some(30.0)
+        } else {
+            None
+        }
+    }
+
     /// PMAT-809 (b): Whether RMSNorm must apply the Gemma `(1 + weight)` unit
     /// offset at RUNTIME.
     ///
@@ -406,7 +447,8 @@ impl GGUFConfig {
     /// all other architectures (no scaling).
     #[must_use]
     pub fn embed_scale(&self) -> Option<f32> {
-        if self.is_gemma1() {
+        // PMAT-810: Gemma2 shares Gemma1's `sqrt(hidden)` embedding scaling.
+        if self.is_gemma1() || self.is_gemma2() {
             // sqrt(hidden_size). f64 intermediate to keep the constant exact for
             // the common power-of-two-ish hidden sizes (e.g. 2048 → 45.2548...).
             #[allow(clippy::cast_precision_loss)]
@@ -422,7 +464,8 @@ impl GGUFConfig {
     /// Gemma's `GatedMlp` uses the `gelu_tanh` activation on the gate branch.
     #[must_use]
     pub fn geglu_ffn(&self) -> bool {
-        self.is_gemma1()
+        // PMAT-810: Gemma2 shares Gemma1's GeGLU FFN (gelu_tanh gate activation).
+        self.is_gemma1() || self.is_gemma2()
     }
 
     /// Extract configuration from APR model metadata.

--- a/crates/aprender-serve/src/gguf/config_gguf.rs
+++ b/crates/aprender-serve/src/gguf/config_gguf.rs
@@ -15,6 +15,7 @@
             eps: 1e-5,
             rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
             bos_token_id: None,
             eos_token_id: None,
         };
@@ -48,6 +49,7 @@
             eps: 1e-6,
             rope_type: 2,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
             bos_token_id: None,
             eos_token_id: None,
         };
@@ -74,6 +76,7 @@
             eps: 1e-5,
             rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
             bos_token_id: None,
             eos_token_id: None,
         };
@@ -100,6 +103,7 @@
             eps: 1e-5,
             rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
             bos_token_id: None,
             eos_token_id: None,
         };
@@ -124,6 +128,7 @@
             eps: 1e-5,
             rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
             bos_token_id: None,
             eos_token_id: None,
         };
@@ -148,6 +153,7 @@
             eps: 1e-5,
             rope_type: 2, // NEOX
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
             bos_token_id: None,
             eos_token_id: None,
         };
@@ -172,6 +178,7 @@
             eps: 1e-6,
             rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
             bos_token_id: None,
             eos_token_id: None,
         };
@@ -197,6 +204,7 @@
             eps: 1e-6, // Smaller epsilon
             rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
             bos_token_id: None,
             eos_token_id: None,
         };
@@ -221,6 +229,7 @@
             eps: 1e-5,
             rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
             bos_token_id: None,
             eos_token_id: None,
         };
@@ -246,6 +255,7 @@
             eps: 1e-5,
             rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
             bos_token_id: None,
             eos_token_id: None,
         };
@@ -272,6 +282,7 @@
             eps: 1e-5,
             rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
             bos_token_id: None,
             eos_token_id: None,
         };
@@ -298,6 +309,7 @@
             eps: 1e-5,
             rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
             bos_token_id: None,
             eos_token_id: None,
         };
@@ -332,6 +344,7 @@
             eps: 1e-5,
             rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
             bos_token_id: None,
             eos_token_id: None,
         };
@@ -414,6 +427,7 @@
             eps: 1e-5,
             rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
             bos_token_id: Some(128_000),
             eos_token_id: Some(128_001),
         }

--- a/crates/aprender-serve/src/gguf/config_validated.rs
+++ b/crates/aprender-serve/src/gguf/config_validated.rs
@@ -92,6 +92,7 @@ mod tests {
             eps: 1e-6,
             rope_type: 2,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
             bos_token_id: Some(151_643),
             eos_token_id: Some(151_645),
         };
@@ -117,6 +118,7 @@ mod tests {
             eps: 1e-6,
             rope_type: 2,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
             bos_token_id: Some(151_643),
             eos_token_id: Some(151_645),
         };

--- a/crates/aprender-serve/src/gguf/inference/attention_flash_tests.rs
+++ b/crates/aprender-serve/src/gguf/inference/attention_flash_tests.rs
@@ -20,6 +20,7 @@ fn small_config() -> GGUFConfig {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     }
@@ -166,6 +167,7 @@ fn test_flash_attention_tiled_gqa() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };

--- a/crates/aprender-serve/src/gguf/inference/attention_gqa.rs
+++ b/crates/aprender-serve/src/gguf/inference/attention_gqa.rs
@@ -32,7 +32,9 @@ impl OwnedQuantizedModel {
         let head_dim = self.config.head_dim();
         let q_dim = self.config.q_dim();
         let kv_dim = self.config.kv_dim();
-        let scale = 1.0 / (head_dim as f32).sqrt();
+        // PMAT-810: Gemma2 scales by 1/sqrt(query_pre_attn_scalar); every other
+        // arch (and gemma-2-2b, key absent) → 1/sqrt(head_dim), byte-identical.
+        let scale = self.config.attn_scale();
         // PMAT-810: Gemma2 caps attention logits with `cap*tanh(scores/cap)`
         // (cap=50) BEFORE softmax. `None` for every other arch → no-op.
         let attn_softcap = self.config.attn_logit_softcap();
@@ -142,7 +144,9 @@ impl OwnedQuantizedModel {
         let head_dim = self.config.head_dim();
         let q_dim = self.config.q_dim();
         let kv_dim = self.config.kv_dim();
-        let scale = 1.0 / (head_dim as f32).sqrt();
+        // PMAT-810: Gemma2 scales by 1/sqrt(query_pre_attn_scalar); every other
+        // arch (and gemma-2-2b, key absent) → 1/sqrt(head_dim), byte-identical.
+        let scale = self.config.attn_scale();
         // PMAT-810: Gemma2 attention-logit softcap (None elsewhere → no-op).
         let attn_softcap = self.config.attn_logit_softcap();
 

--- a/crates/aprender-serve/src/gguf/inference/attention_gqa.rs
+++ b/crates/aprender-serve/src/gguf/inference/attention_gqa.rs
@@ -33,6 +33,9 @@ impl OwnedQuantizedModel {
         let q_dim = self.config.q_dim();
         let kv_dim = self.config.kv_dim();
         let scale = 1.0 / (head_dim as f32).sqrt();
+        // PMAT-810: Gemma2 caps attention logits with `cap*tanh(scores/cap)`
+        // (cap=50) BEFORE softmax. `None` for every other arch → no-op.
+        let attn_softcap = self.config.attn_logit_softcap();
 
         // Number of Q heads that share each KV head
         let q_per_kv = num_heads / num_kv_heads;
@@ -83,10 +86,13 @@ impl OwnedQuantizedModel {
                 group_scores[i * total_len + cache_len] = score;
             }
 
-            // 2. Softmax (Per Q Head)
+            // 2. Softmax (Per Q Head). PMAT-810: Gemma2 softcaps the scores first.
             for i in 0..q_per_kv {
                 let start = i * total_len;
                 let end = start + total_len;
+                if let Some(cap) = attn_softcap {
+                    crate::gguf::ops::softcap(&mut group_scores[start..end], cap);
+                }
                 crate::quantize::softmax_simd(&mut group_scores[start..end]);
             }
 
@@ -137,6 +143,8 @@ impl OwnedQuantizedModel {
         let q_dim = self.config.q_dim();
         let kv_dim = self.config.kv_dim();
         let scale = 1.0 / (head_dim as f32).sqrt();
+        // PMAT-810: Gemma2 attention-logit softcap (None elsewhere → no-op).
+        let attn_softcap = self.config.attn_logit_softcap();
 
         let q_per_kv = num_heads / num_kv_heads;
 
@@ -187,10 +195,13 @@ impl OwnedQuantizedModel {
                 group_scores[i * total_len + cache_len] = score;
             }
 
-            // 2. Softmax (Per Q Head)
+            // 2. Softmax (Per Q Head). PMAT-810: Gemma2 softcaps the scores first.
             for i in 0..q_per_kv {
                 let start = i * total_len;
                 let end = start + total_len;
+                if let Some(cap) = attn_softcap {
+                    crate::gguf::ops::softcap(&mut group_scores[start..end], cap);
+                }
                 crate::quantize::softmax_simd(&mut group_scores[start..end]);
             }
 

--- a/crates/aprender-serve/src/gguf/inference/attention_gqa_tests.rs
+++ b/crates/aprender-serve/src/gguf/inference/attention_gqa_tests.rs
@@ -68,6 +68,7 @@ fn create_gqa_model(
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };
@@ -95,6 +96,8 @@ fn create_gqa_model(
         ffn_norm_bias: None,
         attn_q_norm_weight: None,
         attn_k_norm_weight: None,
+        post_attn_norm_weight: None,
+        post_ffw_norm_weight: None,
     };
 
     let token_embedding = vec![0.1f32; vocab_size * hidden_dim];

--- a/crates/aprender-serve/src/gguf/inference/cached/sync_tests_constructors.rs
+++ b/crates/aprender-serve/src/gguf/inference/cached/sync_tests_constructors.rs
@@ -15,6 +15,7 @@
             eps: 1e-5,
             rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
             bos_token_id: None,
             eos_token_id: None,
         }

--- a/crates/aprender-serve/src/gguf/inference/forward/batch_tests.rs
+++ b/crates/aprender-serve/src/gguf/inference/forward/batch_tests.rs
@@ -28,6 +28,7 @@ fn test_config() -> GGUFConfig {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     }

--- a/crates/aprender-serve/src/gguf/inference/forward/core_tests.rs
+++ b/crates/aprender-serve/src/gguf/inference/forward/core_tests.rs
@@ -63,6 +63,7 @@ fn create_llama_style_model(
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };
@@ -90,6 +91,8 @@ fn create_llama_style_model(
             ffn_norm_bias: None,
             attn_q_norm_weight: None,
             attn_k_norm_weight: None,
+            post_attn_norm_weight: None,
+            post_ffw_norm_weight: None,
         };
         layers.push(layer);
     }
@@ -141,6 +144,7 @@ fn create_phi2_style_model(
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };
@@ -166,6 +170,8 @@ fn create_phi2_style_model(
             ffn_norm_bias: None,
             attn_q_norm_weight: None,
             attn_k_norm_weight: None,
+            post_attn_norm_weight: None,
+            post_ffw_norm_weight: None,
         };
         layers.push(layer);
     }

--- a/crates/aprender-serve/src/gguf/inference/forward/core_tests_architecture_detection.rs
+++ b/crates/aprender-serve/src/gguf/inference/forward/core_tests_architecture_detection.rs
@@ -103,6 +103,7 @@ fn test_forward_with_separate_qkv() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -133,6 +134,8 @@ fn test_forward_with_separate_qkv() {
         ffn_norm_bias: None,
         attn_q_norm_weight: None,
         attn_k_norm_weight: None,
+        post_attn_norm_weight: None,
+        post_ffw_norm_weight: None,
     };
 
     let model = OwnedQuantizedModel {
@@ -247,6 +250,7 @@ fn test_forward_cached_separate_qkv() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -272,6 +276,8 @@ fn test_forward_cached_separate_qkv() {
         ffn_norm_bias: None,
         attn_q_norm_weight: None,
         attn_k_norm_weight: None,
+        post_attn_norm_weight: None,
+        post_ffw_norm_weight: None,
     };
 
     let model = OwnedQuantizedModel {

--- a/crates/aprender-serve/src/gguf/inference/forward/debug.rs
+++ b/crates/aprender-serve/src/gguf/inference/forward/debug.rs
@@ -583,6 +583,14 @@ impl OwnedQuantizedModel {
                 ops::add_bias(&mut attn_output, bias);
             }
 
+            // PMAT-810: Gemma2 POST-attention RMSNorm on the attention output,
+            // BEFORE the residual add: `x + post_attn_norm(attn(...))`. `None` for
+            // every other arch → unchanged. GGUF bakes the Gemma `(1+w)` offset
+            // into the weight, so standard rms_norm is correct.
+            if let Some(ref post_w) = layer.post_attn_norm_weight {
+                attn_output = ops::rms_norm(&attn_output, post_w, self.config.eps);
+            }
+
             // 2g. Residual connection
             for i in 0..hidden_dim {
                 hidden[i] += attn_output[i];
@@ -595,6 +603,12 @@ impl OwnedQuantizedModel {
             let mut ffn_output = self.fused_matmul(&ffn_activated, &layer.ffn_down_weight)?;
             if let Some(ref bias) = layer.ffn_down_bias {
                 ops::add_bias(&mut ffn_output, bias);
+            }
+
+            // PMAT-810: Gemma2 POST-FFN RMSNorm on the FFN output, BEFORE the
+            // residual add: `h + post_ffw_norm(ffn(...))`. `None` elsewhere.
+            if let Some(ref post_w) = layer.post_ffw_norm_weight {
+                ffn_output = ops::rms_norm(&ffn_output, post_w, self.config.eps);
             }
 
             // Residual

--- a/crates/aprender-serve/src/gguf/inference/forward/encoder_decoder_tests.rs
+++ b/crates/aprender-serve/src/gguf/inference/forward/encoder_decoder_tests.rs
@@ -23,6 +23,7 @@ mod tests {
             eps: 1e-6,
             rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
             bos_token_id: Some(0),
             eos_token_id: Some(1),
         }
@@ -60,6 +61,8 @@ mod tests {
             ffn_norm_bias: Some(vec![0.0f32; hidden_dim]),
             attn_q_norm_weight: None,
             attn_k_norm_weight: None,
+            post_attn_norm_weight: None,
+            post_ffw_norm_weight: None,
         }
     }
 
@@ -79,6 +82,7 @@ mod tests {
             eps: 1e-5,
             rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
             bos_token_id: None,
             eos_token_id: None,
         };
@@ -134,6 +138,7 @@ mod tests {
             eps: 1e-5,
             rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
             bos_token_id: None,
             eos_token_id: None,
         };

--- a/crates/aprender-serve/src/gguf/inference/forward/ffn_block.rs
+++ b/crates/aprender-serve/src/gguf/inference/forward/ffn_block.rs
@@ -207,6 +207,11 @@ impl OwnedQuantizedModel {
             ops::add_bias(&mut logits, bias);
         }
 
+        // PMAT-810: Gemma2 final-logit tanh softcap (`cap*tanh(logits/cap)`, cap=30).
+        // `None` for every other architecture → logits untouched (byte-identical).
+        if let Some(cap) = self.config.final_logit_softcap() {
+            ops::softcap(&mut logits, cap);
+        }
 
         Ok(logits)
     }
@@ -673,6 +678,15 @@ impl OwnedQuantizedModel {
                 ops::add_bias(&mut o_proj_buffer, bias);
             }
 
+            // PMAT-810: Gemma2 POST-attention RMSNorm on the attention output,
+            // BEFORE the residual add: `x + post_attn_norm(attn(...))`. `None` for
+            // every other arch → residual add unchanged. GGUF bakes the Gemma
+            // `(1+w)` offset into the weight, so standard rms_norm is correct.
+            if let Some(ref post_w) = layer.post_attn_norm_weight {
+                let normed = ops::rms_norm(&o_proj_buffer[..hidden_dim], post_w, self.config.eps);
+                o_proj_buffer[..hidden_dim].copy_from_slice(&normed);
+            }
+
             // 2g. Residual connection
             for i in 0..hidden_dim {
                 hidden[i] += o_proj_buffer[i];
@@ -685,6 +699,13 @@ impl OwnedQuantizedModel {
             self.fused_matmul_into(&ffn_activated, &layer.ffn_down_weight, &mut ffn_down_buffer)?;
             if let Some(ref bias) = layer.ffn_down_bias {
                 ops::add_bias(&mut ffn_down_buffer, bias);
+            }
+
+            // PMAT-810: Gemma2 POST-FFN RMSNorm on the FFN output, BEFORE the
+            // residual add: `h + post_ffw_norm(ffn(...))`. `None` elsewhere.
+            if let Some(ref post_w) = layer.post_ffw_norm_weight {
+                let normed = ops::rms_norm(&ffn_down_buffer[..hidden_dim], post_w, self.config.eps);
+                ffn_down_buffer[..hidden_dim].copy_from_slice(&normed);
             }
 
             // Residual

--- a/crates/aprender-serve/src/gguf/inference/forward/forward_cached.rs
+++ b/crates/aprender-serve/src/gguf/inference/forward/forward_cached.rs
@@ -70,18 +70,31 @@ impl OwnedQuantizedModel {
             }
 
             // Attention block (norm → QKV → RoPE → attention → output projection)
-            let attn_output = self.cached_attention_block(
+            let mut attn_output = self.cached_attention_block(
                 &hidden, layer_idx, cache, position, use_rmsnorm,
                 debug_forward, cpu_debug,
             )?;
+            // PMAT-810: Gemma2 applies a POST-attention RMSNorm to the attention
+            // output BEFORE the residual add: `x + post_attn_norm(attn(...))`.
+            // `None` for every other architecture → residual add is unchanged.
+            // GGUF bakes the Gemma `(1 + w)` offset into the weight, so the
+            // standard `ops::rms_norm` is correct (rmsnorm_unit_offset() == false).
+            if let Some(ref post_w) = self.layers[layer_idx].post_attn_norm_weight {
+                attn_output = ops::rms_norm(&attn_output, post_w, self.config.eps);
+            }
             for i in 0..hidden_dim {
                 hidden[i] += attn_output[i];
             }
 
             // FFN block (norm → SwiGLU/GELU → down projection)
-            let ffn_output = self.cached_ffn_block(
+            let mut ffn_output = self.cached_ffn_block(
                 &hidden, layer_idx, use_rmsnorm,
             )?;
+            // PMAT-810: Gemma2 applies a POST-FFN RMSNorm to the FFN output BEFORE
+            // the residual add: `h + post_ffw_norm(ffn(...))`. `None` elsewhere.
+            if let Some(ref post_w) = self.layers[layer_idx].post_ffw_norm_weight {
+                ffn_output = ops::rms_norm(&ffn_output, post_w, self.config.eps);
+            }
             for i in 0..hidden_dim {
                 hidden[i] += ffn_output[i];
             }

--- a/crates/aprender-serve/src/gguf/inference/forward/forward_cached.rs
+++ b/crates/aprender-serve/src/gguf/inference/forward/forward_cached.rs
@@ -357,6 +357,12 @@ impl OwnedQuantizedModel {
             ops::add_bias(&mut logits, bias);
         }
 
+        // PMAT-810: Gemma2 final-logit tanh softcap (`cap*tanh(logits/cap)`, cap=30).
+        // `None` for every other architecture → logits untouched (byte-identical).
+        if let Some(cap) = self.config.final_logit_softcap() {
+            ops::softcap(&mut logits, cap);
+        }
+
         // PAR-052: Debug final logits
         if debug_forward && position == 0 {
             let mut indexed: Vec<(usize, f32)> = logits.iter().copied().enumerate().collect();

--- a/crates/aprender-serve/src/gguf/inference/forward/single_tests.rs
+++ b/crates/aprender-serve/src/gguf/inference/forward/single_tests.rs
@@ -26,6 +26,7 @@ fn create_llama_style_config() -> GGUFConfig {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     }
@@ -47,6 +48,7 @@ fn create_phi_style_config() -> GGUFConfig {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     }
@@ -86,6 +88,8 @@ fn create_llama_style_model() -> crate::gguf::OwnedQuantizedModel {
         ffn_norm_bias: None,
         attn_q_norm_weight: None,
         attn_k_norm_weight: None,
+        post_attn_norm_weight: None,
+        post_ffw_norm_weight: None,
     };
 
     OwnedQuantizedModel {
@@ -141,6 +145,8 @@ fn create_phi_style_model() -> crate::gguf::OwnedQuantizedModel {
         ffn_norm_bias: Some(vec![0.0f32; hidden_dim]),
         attn_q_norm_weight: None,
         attn_k_norm_weight: None,
+        post_attn_norm_weight: None,
+        post_ffw_norm_weight: None,
     };
 
     OwnedQuantizedModel {

--- a/crates/aprender-serve/src/gguf/inference/forward/single_tests_forward.rs
+++ b/crates/aprender-serve/src/gguf/inference/forward/single_tests_forward.rs
@@ -22,6 +22,7 @@ fn test_forward_single_gqa_config() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -48,6 +49,8 @@ fn test_forward_single_gqa_config() {
         ffn_norm_bias: None,
         attn_q_norm_weight: None,
         attn_k_norm_weight: None,
+        post_attn_norm_weight: None,
+        post_ffw_norm_weight: None,
     };
 
     let model = OwnedQuantizedModel {
@@ -107,6 +110,7 @@ fn test_forward_single_multiple_layers() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -133,6 +137,8 @@ fn test_forward_single_multiple_layers() {
             ffn_norm_bias: None,
             attn_q_norm_weight: None,
             attn_k_norm_weight: None,
+            post_attn_norm_weight: None,
+            post_ffw_norm_weight: None,
         })
         .collect();
 

--- a/crates/aprender-serve/src/gguf/inference/forward/single_tests_q8k.rs
+++ b/crates/aprender-serve/src/gguf/inference/forward/single_tests_q8k.rs
@@ -21,6 +21,7 @@ fn create_llama_256_model() -> crate::gguf::OwnedQuantizedModel {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -46,6 +47,8 @@ fn create_llama_256_model() -> crate::gguf::OwnedQuantizedModel {
         ffn_norm_bias: None,
         attn_q_norm_weight: None,
         attn_k_norm_weight: None,
+        post_attn_norm_weight: None,
+        post_ffw_norm_weight: None,
     };
 
     OwnedQuantizedModel {
@@ -118,6 +121,7 @@ fn create_phi_256_model() -> crate::gguf::OwnedQuantizedModel {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -143,6 +147,8 @@ fn create_phi_256_model() -> crate::gguf::OwnedQuantizedModel {
         ffn_norm_bias: Some(vec![0.0f32; hidden_dim]),
         attn_q_norm_weight: None,
         attn_k_norm_weight: None,
+        post_attn_norm_weight: None,
+        post_ffw_norm_weight: None,
     };
 
     OwnedQuantizedModel {
@@ -184,6 +190,7 @@ fn create_llama_256_gqa_model() -> crate::gguf::OwnedQuantizedModel {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -210,6 +217,8 @@ fn create_llama_256_gqa_model() -> crate::gguf::OwnedQuantizedModel {
         ffn_norm_bias: None,
         attn_q_norm_weight: None,
         attn_k_norm_weight: None,
+        post_attn_norm_weight: None,
+        post_ffw_norm_weight: None,
     };
 
     OwnedQuantizedModel {

--- a/crates/aprender-serve/src/gguf/inference/generation_tests.rs
+++ b/crates/aprender-serve/src/gguf/inference/generation_tests.rs
@@ -25,6 +25,7 @@ fn make_test_config() -> GGUFConfig {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     }

--- a/crates/aprender-serve/src/gguf/inference/matmul_qkv_norm_tests.rs
+++ b/crates/aprender-serve/src/gguf/inference/matmul_qkv_norm_tests.rs
@@ -284,6 +284,8 @@ fn create_f32_test_model(hidden_dim: usize, vocab_size: usize) -> OwnedQuantized
         ffn_norm_bias: None,
         attn_q_norm_weight: None,
         attn_k_norm_weight: None,
+        post_attn_norm_weight: None,
+        post_ffw_norm_weight: None,
     };
 
     let lm_head_weight = create_f32_test_data(hidden_dim, vocab_size);

--- a/crates/aprender-serve/src/gguf/inference/matmul_tests.rs
+++ b/crates/aprender-serve/src/gguf/inference/matmul_tests.rs
@@ -40,6 +40,7 @@ fn test_config(hidden_dim: usize, vocab_size: usize) -> GGUFConfig {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     }
@@ -158,6 +159,8 @@ fn create_test_model(hidden_dim: usize, vocab_size: usize) -> OwnedQuantizedMode
         ffn_norm_bias: None,
         attn_q_norm_weight: None,
         attn_k_norm_weight: None,
+        post_attn_norm_weight: None,
+        post_ffw_norm_weight: None,
     };
 
     let lm_head_weight = create_q4k_test_data(hidden_dim, vocab_size);
@@ -1229,6 +1232,8 @@ fn create_test_model_with_pos_embed(
         ffn_norm_bias: None,
         attn_q_norm_weight: None,
         attn_k_norm_weight: None,
+        post_attn_norm_weight: None,
+        post_ffw_norm_weight: None,
     };
 
     let lm_head_weight = create_q4k_test_data(hidden_dim, vocab_size);
@@ -1323,6 +1328,8 @@ fn falsify_ap_002_additive_identity() {
         ffn_norm_bias: None,
         attn_q_norm_weight: None,
         attn_k_norm_weight: None,
+        post_attn_norm_weight: None,
+        post_ffw_norm_weight: None,
     };
 
     let lm_head_weight = create_q4k_test_data(hidden_dim, vocab_size);

--- a/crates/aprender-serve/src/gguf/inference_types_config_default.rs
+++ b/crates/aprender-serve/src/gguf/inference_types_config_default.rs
@@ -24,6 +24,7 @@ mod tests {
             eps: 1e-5,
             rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
             bos_token_id: None,
             eos_token_id: None,
         }

--- a/crates/aprender-serve/src/gguf/inference_types_tests.rs
+++ b/crates/aprender-serve/src/gguf/inference_types_tests.rs
@@ -29,6 +29,7 @@ fn test_config() -> GGUFConfig {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     }
@@ -90,6 +91,7 @@ fn test_inference_scratch_buffer_q8k_padding() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };

--- a/crates/aprender-serve/src/gguf/keys.rs
+++ b/crates/aprender-serve/src/gguf/keys.rs
@@ -100,6 +100,13 @@ pub(crate) const ATTN_LOGIT_SOFTCAPPING: &str = "attn_logit_softcapping";
 /// after the output projection.
 pub(crate) const FINAL_LOGIT_SOFTCAPPING: &str = "final_logit_softcapping";
 
+/// PMAT-810: `{arch}.attention.query_pre_attn_scalar` — Gemma2 pre-attention
+/// query scale denominator. The attention scale is `1/sqrt(query_pre_attn_scalar)`
+/// instead of the usual `1/sqrt(head_dim)`. Equals `head_dim` (256) for
+/// gemma-2-2b but differs for 9b/27b (224). llama.cpp defaults it to
+/// `n_embd_head_k` (= key_length = head_dim) when this key is absent.
+pub(crate) const QUERY_PRE_ATTN_SCALAR: &str = "attention.query_pre_attn_scalar";
+
 // ─── Key construction ────────────────────────────────────────────────────────
 
 /// Construct an architecture-parameterized GGUF metadata key.

--- a/crates/aprender-serve/src/gguf/keys.rs
+++ b/crates/aprender-serve/src/gguf/keys.rs
@@ -90,6 +90,16 @@ pub(crate) const EXPERT_USED_COUNT: &str = "expert_used_count";
 /// (e.g. 768 for Qwen3-Coder-30B-A3B-Instruct).
 pub(crate) const EXPERT_FEED_FORWARD_LENGTH: &str = "expert_feed_forward_length";
 
+/// PMAT-810: `{arch}.attn_logit_softcapping` — Gemma2 attention-logit tanh
+/// softcap constant (50.0 for gemma-2-*). Applied as `cap*tanh(scores/cap)`
+/// before the attention softmax.
+pub(crate) const ATTN_LOGIT_SOFTCAPPING: &str = "attn_logit_softcapping";
+
+/// PMAT-810: `{arch}.final_logit_softcapping` — Gemma2 final lm_head tanh
+/// softcap constant (30.0 for gemma-2-*). Applied as `cap*tanh(logits/cap)`
+/// after the output projection.
+pub(crate) const FINAL_LOGIT_SOFTCAPPING: &str = "final_logit_softcapping";
+
 // ─── Key construction ────────────────────────────────────────────────────────
 
 /// Construct an architecture-parameterized GGUF metadata key.

--- a/crates/aprender-serve/src/gguf/loader_apr_quantized.rs
+++ b/crates/aprender-serve/src/gguf/loader_apr_quantized.rs
@@ -449,6 +449,15 @@ impl OwnedQuantizedModel {
                 &format!("model.layers.{layer_idx}.self_attn.k_norm.weight"))
                 .or_else(|| apr_try_load_f32(apr, data, data_offset,
                     &format!("blk.{layer_idx}.attn_k_norm.weight"))),
+            // PMAT-810: Gemma2 post-attention / post-FFN RMSNorm (None elsewhere).
+            post_attn_norm_weight: apr_try_load_f32(apr, data, data_offset,
+                &format!("model.layers.{layer_idx}.post_attention_layernorm.weight"))
+                .or_else(|| apr_try_load_f32(apr, data, data_offset,
+                    &format!("blk.{layer_idx}.post_attention_norm.weight"))),
+            post_ffw_norm_weight: apr_try_load_f32(apr, data, data_offset,
+                &format!("model.layers.{layer_idx}.post_feedforward_layernorm.weight"))
+                .or_else(|| apr_try_load_f32(apr, data, data_offset,
+                    &format!("blk.{layer_idx}.post_ffw_norm.weight"))),
         })
     }
 }

--- a/crates/aprender-serve/src/gguf/metadata.rs
+++ b/crates/aprender-serve/src/gguf/metadata.rs
@@ -556,6 +556,22 @@ impl GGUFModel {
         }
     }
 
+    /// PMAT-810: Get Gemma2 pre-attention query scale denominator
+    /// (`{arch}.attention.query_pre_attn_scalar`). The attention scale is
+    /// `1/sqrt(query_pre_attn_scalar)` rather than `1/sqrt(head_dim)`. 256 for
+    /// gemma-2-2b (== head_dim, no-op), 224 for 9b/27b. Returns None when absent
+    /// (non-Gemma2, weights-only GGUF, or older converts) so callers fall back to
+    /// `head_dim` — exactly llama.cpp's default (`n_embd_head_k`).
+    pub fn query_pre_attn_scalar(&self) -> Option<f32> {
+        let arch = self.architecture()?;
+        let key = crate::gguf::keys::arch_key(arch, crate::gguf::keys::QUERY_PRE_ATTN_SCALAR);
+        match self.metadata.get(&key) {
+            Some(GGUFValue::UInt32(v)) => Some(*v as f32),
+            Some(GGUFValue::Float32(v)) => Some(*v),
+            _ => None,
+        }
+    }
+
     /// M32c.2.2.2.1.2: Get MoE expert count (`{arch}.expert_count`).
     /// 128 for Qwen3-Coder-30B-A3B-Instruct. Returns None for dense models.
     pub fn expert_count(&self) -> Option<usize> {

--- a/crates/aprender-serve/src/gguf/metadata.rs
+++ b/crates/aprender-serve/src/gguf/metadata.rs
@@ -532,6 +532,30 @@ impl GGUFModel {
         }
     }
 
+    /// PMAT-810: Get Gemma2 attention-logit softcap (`{arch}.attn_logit_softcapping`).
+    /// 50.0 for gemma-2-*. Returns None when absent (non-Gemma2, or weights-only GGUF).
+    pub fn attn_logit_softcapping(&self) -> Option<f32> {
+        let arch = self.architecture()?;
+        let key = crate::gguf::keys::arch_key(arch, crate::gguf::keys::ATTN_LOGIT_SOFTCAPPING);
+        if let Some(GGUFValue::Float32(cap)) = self.metadata.get(&key) {
+            Some(*cap)
+        } else {
+            None
+        }
+    }
+
+    /// PMAT-810: Get Gemma2 final-logit softcap (`{arch}.final_logit_softcapping`).
+    /// 30.0 for gemma-2-*. Returns None when absent (non-Gemma2, or weights-only GGUF).
+    pub fn final_logit_softcapping(&self) -> Option<f32> {
+        let arch = self.architecture()?;
+        let key = crate::gguf::keys::arch_key(arch, crate::gguf::keys::FINAL_LOGIT_SOFTCAPPING);
+        if let Some(GGUFValue::Float32(cap)) = self.metadata.get(&key) {
+            Some(*cap)
+        } else {
+            None
+        }
+    }
+
     /// M32c.2.2.2.1.2: Get MoE expert count (`{arch}.expert_count`).
     /// 128 for Qwen3-Coder-30B-A3B-Instruct. Returns None for dense models.
     pub fn expert_count(&self) -> Option<usize> {

--- a/crates/aprender-serve/src/gguf/model_gguf_transformer.rs
+++ b/crates/aprender-serve/src/gguf/model_gguf_transformer.rs
@@ -15,6 +15,7 @@
             eps: 1e-5,
             rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
             bos_token_id: None,
             eos_token_id: None,
         };
@@ -80,6 +81,7 @@
             eps: 1e-5,
             rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
             bos_token_id: None,
             eos_token_id: None,
         };
@@ -145,6 +147,7 @@
             eps: 1e-5,
             rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
             bos_token_id: None,
             eos_token_id: None,
         };
@@ -196,6 +199,7 @@
             eps: 1e-5,
             rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
             bos_token_id: None,
             eos_token_id: None,
         };
@@ -232,6 +236,7 @@
             eps: 1e-5,
             rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
             bos_token_id: None,
             eos_token_id: None,
         };
@@ -365,6 +370,7 @@
             eps: 1e-5,
             rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
             bos_token_id: None,
             eos_token_id: None,
         };
@@ -418,6 +424,7 @@
             eps: 1e-6,
             rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
             bos_token_id: None,
             eos_token_id: None,
         };

--- a/crates/aprender-serve/src/gguf/model_owned_quantized.rs
+++ b/crates/aprender-serve/src/gguf/model_owned_quantized.rs
@@ -22,6 +22,7 @@ mod tests {
             eps: 1e-5,
             rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
             bos_token_id: None,
             eos_token_id: None,
         };
@@ -80,6 +81,7 @@ mod tests {
             eps: 1e-5,
             rope_type: 1,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
             bos_token_id: None,
             eos_token_id: None,
         };
@@ -129,6 +131,7 @@ mod tests {
             eps: 1e-5,
             rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
             bos_token_id: None,
             eos_token_id: None,
         };
@@ -200,6 +203,7 @@ mod tests {
             eps: 1e-5,
             rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
             bos_token_id: Some(1),
             eos_token_id: Some(2),
         };

--- a/crates/aprender-serve/src/gguf/ops.rs
+++ b/crates/aprender-serve/src/gguf/ops.rs
@@ -273,6 +273,31 @@ pub fn silu(input: &mut [f32]) {
     }
 }
 
+/// PMAT-810: Gemma2 tanh logit softcapping, in place.
+///
+/// Gemma2 (and Gemma3) bound both the attention logits (cap = 50.0) and the
+/// final lm_head logits (cap = 30.0) with `cap * tanh(x / cap)`. This squashes
+/// extreme values into `(-cap, cap)` while staying near-linear for small `x`.
+/// Without it, Gemma2 output diverges from the reference because the uncapped
+/// attention scores and final logits put mass on the wrong tokens.
+///
+/// llama.cpp: `ggml_tanh(ggml_scale(kq, 1/cap)) * cap` (build_attn) and the same
+/// on `cur` after the output layer when `hparams.f_logit_scale`/softcapping set.
+///
+/// # Arguments
+/// * `values` - logits / scores (modified in place)
+/// * `cap` - softcap constant (must be finite and > 0)
+#[inline]
+pub fn softcap(values: &mut [f32], cap: f32) {
+    if cap <= 0.0 || !cap.is_finite() {
+        return;
+    }
+    let inv_cap = 1.0 / cap;
+    for v in values.iter_mut() {
+        *v = cap * (*v * inv_cap).tanh();
+    }
+}
+
 // =============================================================================
 // Utility Operations
 // =============================================================================
@@ -1397,6 +1422,58 @@ mod swiglu_contract_tests {
                     );
                 }
             }
+        }
+    }
+}
+
+#[cfg(test)]
+mod softcap_tests {
+    use super::*;
+
+    /// PMAT-810: softcap(x, cap) == cap * tanh(x / cap) elementwise.
+    #[test]
+    fn softcap_matches_reference() {
+        let cap = 30.0f32;
+        let mut v = vec![-100.0, -30.0, -1.0, 0.0, 1.0, 30.0, 100.0, 1000.0];
+        let expect: Vec<f32> = v.iter().map(|&x| cap * (x / cap).tanh()).collect();
+        softcap(&mut v, cap);
+        for (got, want) in v.iter().zip(expect.iter()) {
+            assert!((got - want).abs() < 1e-4, "softcap {got} != {want}");
+        }
+    }
+
+    /// PMAT-810: softcap bounds every output into (-cap, cap).
+    #[test]
+    fn softcap_bounds_extremes() {
+        let cap = 50.0f32;
+        let mut v = vec![-1e9, -1e3, 1e3, 1e9, f32::MAX, f32::MIN];
+        softcap(&mut v, cap);
+        for &x in &v {
+            assert!(x.abs() <= cap + 1e-3, "softcap output {x} escaped ±{cap}");
+        }
+    }
+
+    /// PMAT-810: softcap is ~identity near 0 (tanh(t) ≈ t for small t).
+    #[test]
+    fn softcap_near_linear_at_origin() {
+        let cap = 30.0f32;
+        let mut v = vec![0.0, 0.01, -0.01, 0.5, -0.5];
+        let original = v.clone();
+        softcap(&mut v, cap);
+        for (got, orig) in v.iter().zip(original.iter()) {
+            // |error| grows like x^3/(3 cap^2); for |x|<=0.5, cap=30 it's ~1e-5.
+            assert!((got - orig).abs() < 1e-3, "softcap({orig}) = {got} not ≈ identity");
+        }
+    }
+
+    /// PMAT-810: a non-positive / non-finite cap is a no-op (defensive guard).
+    #[test]
+    fn softcap_zero_or_bad_cap_is_noop() {
+        for bad in [0.0f32, -1.0, f32::NAN, f32::INFINITY] {
+            let mut v = vec![1.0, 2.0, 3.0];
+            let orig = v.clone();
+            softcap(&mut v, bad);
+            assert_eq!(v, orig, "softcap with cap={bad} must be a no-op");
         }
     }
 }

--- a/crates/aprender-serve/src/gguf/ops.rs
+++ b/crates/aprender-serve/src/gguf/ops.rs
@@ -1462,7 +1462,10 @@ mod softcap_tests {
         softcap(&mut v, cap);
         for (got, orig) in v.iter().zip(original.iter()) {
             // |error| grows like x^3/(3 cap^2); for |x|<=0.5, cap=30 it's ~1e-5.
-            assert!((got - orig).abs() < 1e-3, "softcap({orig}) = {got} not ≈ identity");
+            assert!(
+                (got - orig).abs() < 1e-3,
+                "softcap({orig}) = {got} not ≈ identity"
+            );
         }
     }
 

--- a/crates/aprender-serve/src/gguf/quantized.rs
+++ b/crates/aprender-serve/src/gguf/quantized.rs
@@ -323,6 +323,10 @@ pub struct OwnedQuantizedLayer {
     pub attn_q_norm_weight: Option<Vec<f32>>,
     /// GH-279: Per-head K RMSNorm weight [head_dim] (Qwen3)
     pub attn_k_norm_weight: Option<Vec<f32>>,
+    /// PMAT-810: Gemma2 POST-attention RMSNorm weight. `None` elsewhere.
+    pub post_attn_norm_weight: Option<Vec<f32>>,
+    /// PMAT-810: Gemma2 POST-feedforward RMSNorm weight. `None` elsewhere.
+    pub post_ffw_norm_weight: Option<Vec<f32>>,
 }
 
 impl OwnedQuantizedLayer {
@@ -402,6 +406,8 @@ impl OwnedQuantizedLayer {
             ffn_norm_bias: layer.ffn_norm_bias.clone(),
             attn_q_norm_weight: layer.attn_q_norm_weight.clone(),
             attn_k_norm_weight: layer.attn_k_norm_weight.clone(),
+            post_attn_norm_weight: layer.post_attn_norm_weight.clone(),
+            post_ffw_norm_weight: layer.post_ffw_norm_weight.clone(),
         }
     }
 }

--- a/crates/aprender-serve/src/gguf/quantized_tests.rs
+++ b/crates/aprender-serve/src/gguf/quantized_tests.rs
@@ -50,6 +50,7 @@ fn test_config(hidden_dim: usize, intermediate_dim: usize) -> GGUFConfig {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     }
@@ -171,6 +172,8 @@ fn test_owned_quantized_layer_from_borrowed_minimal() {
         ffn_norm_bias: None,
         attn_q_norm_weight: None,
         attn_k_norm_weight: None,
+        post_attn_norm_weight: None,
+        post_ffw_norm_weight: None,
     };
 
     let data = create_test_data(400);
@@ -222,6 +225,8 @@ fn test_owned_quantized_layer_from_borrowed_with_gate() {
         ffn_norm_bias: Some(vec![0.0; 64]),
         attn_q_norm_weight: None,
         attn_k_norm_weight: None,
+        post_attn_norm_weight: None,
+        post_ffw_norm_weight: None,
     };
 
     let data = create_test_data(450);
@@ -280,6 +285,8 @@ fn test_owned_quantized_layer_from_borrowed_separate_qkv() {
         ffn_norm_bias: None,
         attn_q_norm_weight: None,
         attn_k_norm_weight: None,
+        post_attn_norm_weight: None,
+        post_ffw_norm_weight: None,
     };
 
     let data = create_test_data(450);

--- a/crates/aprender-serve/src/gguf/quantized_tests_owned.rs
+++ b/crates/aprender-serve/src/gguf/quantized_tests_owned.rs
@@ -73,6 +73,8 @@ fn test_owned_quantized_layer_clone() {
         ffn_norm_bias: None,
         attn_q_norm_weight: None,
         attn_k_norm_weight: None,
+        post_attn_norm_weight: None,
+        post_ffw_norm_weight: None,
     };
 
     let cloned = original.clone();

--- a/crates/aprender-serve/src/gguf/runtime.rs
+++ b/crates/aprender-serve/src/gguf/runtime.rs
@@ -400,6 +400,7 @@ mod tests {
             eps: 1e-5,
             rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
             bos_token_id: None,
             eos_token_id: None,
         };
@@ -427,6 +428,7 @@ mod tests {
             eps: 1e-5,
             rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
             bos_token_id: None,
             eos_token_id: None,
         };
@@ -467,6 +469,7 @@ mod tests {
             eps: 1e-5,
             rope_type: 0,
             explicit_head_dim: Some(128),
+            query_pre_attn_scalar: None,
             bos_token_id: None,
             eos_token_id: None,
         };

--- a/crates/aprender-serve/src/gguf/test_helpers.rs
+++ b/crates/aprender-serve/src/gguf/test_helpers.rs
@@ -84,6 +84,8 @@ pub(crate) fn create_test_model_with_config(config: &GGUFConfig) -> OwnedQuantiz
         ffn_norm_bias: None,
         attn_q_norm_weight: None,
         attn_k_norm_weight: None,
+        post_attn_norm_weight: None,
+        post_ffw_norm_weight: None,
     };
 
     let token_embedding = vec![0.1f32; vocab_size * hidden_dim];
@@ -207,6 +209,7 @@ mod tests {
             eps: 1e-5,
             rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
             bos_token_id: None,
             eos_token_id: None,
         };
@@ -271,6 +274,7 @@ mod tests {
             eps: 1e-5,
             rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
             bos_token_id: None,
             eos_token_id: None,
         };
@@ -296,6 +300,7 @@ mod tests {
             eps: 1e-5,
             rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
             bos_token_id: None,
             eos_token_id: None,
         };
@@ -325,6 +330,7 @@ mod tests {
             eps: 1e-5,
             rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
             bos_token_id: None,
             eos_token_id: None,
         };
@@ -351,6 +357,7 @@ mod tests {
             eps: 1e-5,
             rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
             bos_token_id: None,
             eos_token_id: None,
         };

--- a/crates/aprender-serve/src/gguf/tests/config.rs
+++ b/crates/aprender-serve/src/gguf/tests/config.rs
@@ -68,6 +68,7 @@ fn test_imp_101a_rope_preserves_norm() {
         rope_type: 0,
         rope_theta: 10000.0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };
@@ -132,6 +133,7 @@ fn test_imp_101a_rope_position_dependent() {
         rope_type: 0,
         rope_theta: 10000.0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };
@@ -211,6 +213,7 @@ fn test_imp_101b_causal_attention_mask() {
         rope_type: 0,
         rope_theta: 10000.0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };
@@ -288,6 +291,7 @@ fn test_imp_101b_causal_attention_softmax_normalized() {
         rope_type: 0,
         rope_theta: 10000.0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };
@@ -374,6 +378,7 @@ fn test_imp_101c_kv_cache_from_config() {
         rope_type: 0,
         rope_theta: 10000.0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };

--- a/crates/aprender-serve/src/gguf/tests/imp_101c.rs
+++ b/crates/aprender-serve/src/gguf/tests/imp_101c.rs
@@ -16,6 +16,7 @@ fn test_imp_101c_attention_with_cache_softmax_normalized() {
         rope_type: 0,
         rope_theta: 10000.0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -128,6 +129,7 @@ fn test_imp_105_gqa_attention_multiple_q_per_kv() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -188,6 +190,7 @@ fn test_imp_105_gqa_kv_head_sharing() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };

--- a/crates/aprender-serve/src/gguf/tests/imp_108c.rs
+++ b/crates/aprender-serve/src/gguf/tests/imp_108c.rs
@@ -17,6 +17,7 @@ fn test_imp_108c_attention_softmax_normalized() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };

--- a/crates/aprender-serve/src/gguf/tests/imp_111c.rs
+++ b/crates/aprender-serve/src/gguf/tests/imp_111c.rs
@@ -16,6 +16,7 @@ fn test_imp_111c_tiled_causal_attention() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -100,6 +101,7 @@ fn test_imp_111d_tiled_attention_various_tile_sizes() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -170,6 +172,7 @@ fn test_imp_113a_batched_gemm_single_dispatch() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -253,6 +256,7 @@ fn test_imp_113b_single_dispatch_attention_correctness() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -318,6 +322,7 @@ fn test_imp_113c_single_dispatch_dispatch_count() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -377,6 +382,7 @@ fn test_imp_113d_batched_softmax_correctness() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };

--- a/crates/aprender-serve/src/gguf/tests/imp_114a.rs
+++ b/crates/aprender-serve/src/gguf/tests/imp_114a.rs
@@ -22,6 +22,7 @@ fn test_imp_114a_flattened_batched_gemm_correctness() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -101,6 +102,7 @@ fn test_imp_114b_flattened_matches_loop() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -162,6 +164,7 @@ fn test_imp_114c_flattened_attention_correctness() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -224,6 +227,7 @@ fn test_imp_114d_large_batch_flattened() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };

--- a/crates/aprender-serve/src/gguf/tests/imp_115a.rs
+++ b/crates/aprender-serve/src/gguf/tests/imp_115a.rs
@@ -28,6 +28,7 @@ fn test_imp_115a_fused_single_head_attention_correctness() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };
@@ -93,6 +94,7 @@ fn test_imp_115b_fused_multihead_attention_correctness() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };
@@ -156,6 +158,7 @@ fn test_imp_115c_fused_attention_no_intermediate_allocation() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };
@@ -212,6 +215,7 @@ fn test_imp_115d_fused_causal_mask_correctness() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };
@@ -403,6 +407,7 @@ fn test_imp_117f_generate_with_token_buffer() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };

--- a/crates/aprender-serve/src/gguf/tests/imp_118a.rs
+++ b/crates/aprender-serve/src/gguf/tests/imp_118a.rs
@@ -22,6 +22,7 @@ fn test_imp_118a_true_batched_gemm_correctness() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -105,6 +106,7 @@ fn test_imp_118b_true_batched_gemm_matches_flattened() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -168,6 +170,7 @@ fn test_imp_118c_true_batched_gemm_large_batch() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -228,6 +231,7 @@ fn test_imp_118d_true_batched_attention() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -300,6 +304,7 @@ fn test_imp_119a_gpu_fused_attention_correctness() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -366,6 +371,7 @@ fn test_imp_119b_gpu_fused_matches_cpu_fused() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };

--- a/crates/aprender-serve/src/gguf/tests/imp_119c.rs
+++ b/crates/aprender-serve/src/gguf/tests/imp_119c.rs
@@ -17,6 +17,7 @@ fn test_imp_119c_gpu_fused_multihead_long_sequence() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -81,6 +82,7 @@ fn test_imp_119d_adaptive_cpu_gpu_dispatch() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };

--- a/crates/aprender-serve/src/gguf/tests/imp_121a.rs
+++ b/crates/aprender-serve/src/gguf/tests/imp_121a.rs
@@ -33,6 +33,7 @@ fn test_imp_121a_cached_sync_has_adaptive_attention() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };
@@ -84,6 +85,7 @@ fn test_imp_121b_cached_sync_adaptive_multihead() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };
@@ -134,6 +136,7 @@ fn test_imp_121c_generate_with_adaptive_attention() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };
@@ -183,6 +186,7 @@ fn test_imp_121d_thread_safe_adaptive_attention() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };
@@ -254,6 +258,7 @@ fn test_imp_122a_adaptive_attention_with_cache() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };
@@ -317,6 +322,7 @@ fn test_pmat749_adaptive_attention_gqa_long_cache() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };
@@ -374,6 +380,7 @@ fn test_imp_122b_adaptive_matches_standard() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };
@@ -433,6 +440,7 @@ fn test_imp_122c_long_sequence_uses_gpu() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };

--- a/crates/aprender-serve/src/gguf/tests/imp_123d.rs
+++ b/crates/aprender-serve/src/gguf/tests/imp_123d.rs
@@ -200,6 +200,7 @@ fn test_imp_124a_forward_single_with_cache_adaptive() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -251,6 +252,7 @@ fn test_imp_124b_adaptive_matches_standard() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -301,6 +303,7 @@ fn test_imp_124c_tracks_metrics_per_layer() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -356,6 +359,7 @@ fn test_imp_124d_long_cache_uses_gpu() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -410,6 +414,7 @@ fn test_imp_125a_generate_with_cache_adaptive() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };

--- a/crates/aprender-serve/src/gguf/tests/imp_125b.rs
+++ b/crates/aprender-serve/src/gguf/tests/imp_125b.rs
@@ -17,6 +17,7 @@ fn test_imp_125b_adaptive_matches_standard() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -67,6 +68,7 @@ fn test_imp_125c_tracks_metrics_during_generation() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -117,6 +119,7 @@ fn test_imp_125d_long_generation_uses_gpu() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -173,6 +176,7 @@ fn test_parity002a_forward_batch_with_cache_exists() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -216,6 +220,7 @@ fn test_parity002b_batched_prefill_populates_cache() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -260,6 +265,7 @@ fn test_parity002c_batched_prefill_triggers_gpu() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -306,6 +312,7 @@ fn test_parity002d_batched_matches_sequential() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -371,6 +378,7 @@ fn test_parity002e_generate_with_batched_prefill() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };

--- a/crates/aprender-serve/src/gguf/tests/loader_tests_apr.rs
+++ b/crates/aprender-serve/src/gguf/tests/loader_tests_apr.rs
@@ -251,6 +251,7 @@ fn test_to_apr_bytes_various_qtypes() {
             eps: 1e-5,
             rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
             bos_token_id: None,
             eos_token_id: None,
         };
@@ -276,6 +277,8 @@ fn test_to_apr_bytes_various_qtypes() {
             ffn_norm_bias: None,
             attn_q_norm_weight: None,
             attn_k_norm_weight: None,
+            post_attn_norm_weight: None,
+            post_ffw_norm_weight: None,
         };
 
         let model = OwnedQuantizedModel {

--- a/crates/aprender-serve/src/gguf/tests/loader_tests_build_minimal.rs
+++ b/crates/aprender-serve/src/gguf/tests/loader_tests_build_minimal.rs
@@ -40,6 +40,7 @@ fn build_minimal_owned_quantized_model() -> OwnedQuantizedModel {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };
@@ -88,6 +89,8 @@ fn build_minimal_owned_quantized_model() -> OwnedQuantizedModel {
         ffn_norm_bias: None,
         attn_q_norm_weight: None,
         attn_k_norm_weight: None,
+        post_attn_norm_weight: None,
+        post_ffw_norm_weight: None,
     };
 
     OwnedQuantizedModel {
@@ -133,6 +136,7 @@ fn build_fused_qkv_model() -> OwnedQuantizedModel {
         eps: 1e-5,
         rope_type: 2,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };
@@ -179,6 +183,8 @@ fn build_fused_qkv_model() -> OwnedQuantizedModel {
         ffn_norm_bias: None,
         attn_q_norm_weight: None,
         attn_k_norm_weight: None,
+        post_attn_norm_weight: None,
+        post_ffw_norm_weight: None,
     };
 
     OwnedQuantizedModel {
@@ -226,6 +232,7 @@ fn build_q4k_model() -> OwnedQuantizedModel {
         eps: 1e-6,
         rope_type: 2,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };
@@ -271,6 +278,8 @@ fn build_q4k_model() -> OwnedQuantizedModel {
         ffn_norm_bias: None,
         attn_q_norm_weight: None,
         attn_k_norm_weight: None,
+        post_attn_norm_weight: None,
+        post_ffw_norm_weight: None,
     };
 
     // Q6_K lm_head: 210 bytes per 256 elements

--- a/crates/aprender-serve/src/gguf/tests/parity005a_contiguous.rs
+++ b/crates/aprender-serve/src/gguf/tests/parity005a_contiguous.rs
@@ -307,6 +307,7 @@ fn test_parity006a_batch_generate_exists() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };
@@ -363,6 +364,7 @@ fn test_parity006b_single_prompt_optimization() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };

--- a/crates/aprender-serve/src/gguf/tests/parity006c_batch.rs
+++ b/crates/aprender-serve/src/gguf/tests/parity006c_batch.rs
@@ -16,6 +16,7 @@ fn test_parity006c_batch_output_validity() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -107,6 +108,7 @@ fn test_parity006e_batch_performance_comparison() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -179,6 +181,7 @@ fn test_parity006f_empty_prompts_error() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -351,6 +354,7 @@ fn test_parity007f_realizar_benchmark() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };

--- a/crates/aprender-serve/src/gguf/tests/parity008c_popper_calculate.rs
+++ b/crates/aprender-serve/src/gguf/tests/parity008c_popper_calculate.rs
@@ -107,6 +107,7 @@ fn test_parity008e_benchmark_reproducibility() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };

--- a/crates/aprender-serve/src/gguf/tests/phase34_embed.rs
+++ b/crates/aprender-serve/src/gguf/tests/phase34_embed.rs
@@ -20,6 +20,7 @@ fn test_phase34_embed_different_dimensions() {
             eps: 1e-5,
             rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
             bos_token_id: None,
             eos_token_id: None,
         };
@@ -48,6 +49,7 @@ fn test_phase34_fused_matmul_all_qtypes_comprehensive() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };

--- a/crates/aprender-serve/src/gguf/tests/phase34_fused.rs
+++ b/crates/aprender-serve/src/gguf/tests/phase34_fused.rs
@@ -15,6 +15,7 @@ fn test_phase34_fused_matmul_q4_1() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -51,6 +52,7 @@ fn test_phase34_fused_matmul_q4_1_multi_seq() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -110,6 +112,7 @@ fn test_phase34_fused_matmul_q5_0() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -146,6 +149,7 @@ fn test_phase34_fused_matmul_q5_0_multi_seq() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -225,6 +229,7 @@ fn test_phase34_fused_matmul_q4_k_single() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -261,6 +266,7 @@ fn test_phase34_fused_matmul_q4_k_multi() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -294,6 +300,7 @@ fn test_phase34_fused_matmul_q5_k() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -329,6 +336,7 @@ fn test_phase34_fused_matmul_q5_k_multi() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -362,6 +370,7 @@ fn test_phase34_fused_matmul_q6_k() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -397,6 +406,7 @@ fn test_phase34_fused_matmul_q6_k_multi() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };
@@ -433,6 +443,7 @@ fn test_phase34_fused_matmul_unsupported_qtype() {
         eps: 1e-5,
         rope_type: 0,
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
         bos_token_id: None,
             eos_token_id: None,
     };

--- a/crates/aprender-serve/src/gguf/tests/phase_forward_pass_coverage.rs
+++ b/crates/aprender-serve/src/gguf/tests/phase_forward_pass_coverage.rs
@@ -30,6 +30,7 @@ fn test_phase33_forward_basic() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };
@@ -63,6 +64,7 @@ fn test_phase33_forward_multi_token() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };
@@ -94,6 +96,7 @@ fn test_phase33_forward_multi_layer() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };
@@ -125,6 +128,7 @@ fn test_phase33_forward_cached_single() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };
@@ -157,6 +161,7 @@ fn test_phase33_forward_cached_sequence() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };
@@ -192,6 +197,7 @@ fn test_phase33_forward_cached_multi_layer() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };
@@ -226,6 +232,7 @@ fn test_phase33_forward_single_layer_single_head() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };

--- a/crates/aprender-serve/src/gguf/tests/phase_matmul_coverage.rs
+++ b/crates/aprender-serve/src/gguf/tests/phase_matmul_coverage.rs
@@ -36,6 +36,7 @@ fn test_phase34_embed_single_token() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };
@@ -63,6 +64,7 @@ fn test_phase34_embed_multiple_tokens() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };
@@ -90,6 +92,7 @@ fn test_phase34_embed_out_of_vocab() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };
@@ -119,6 +122,7 @@ fn test_phase34_embed_boundary_token() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };
@@ -147,6 +151,7 @@ fn test_phase34_embed_empty() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };
@@ -177,6 +182,7 @@ fn test_phase34_embed_into_single() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };
@@ -207,6 +213,7 @@ fn test_phase34_embed_into_out_of_vocab() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };
@@ -264,6 +271,7 @@ fn test_phase34_fused_matmul_q4_0_single_seq() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };
@@ -303,6 +311,7 @@ fn test_phase34_fused_matmul_q4_0_multi_seq() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };
@@ -370,6 +379,7 @@ fn test_phase34_fused_matmul_q8_0_single_seq() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };
@@ -408,6 +418,7 @@ fn test_phase34_fused_matmul_q8_0_multi_seq() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };

--- a/crates/aprender-serve/src/gguf/tests/phase_thread_safe_cache.rs
+++ b/crates/aprender-serve/src/gguf/tests/phase_thread_safe_cache.rs
@@ -34,6 +34,7 @@ fn test_phase34_cached_sync_new() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };
@@ -63,6 +64,7 @@ fn test_phase34_cached_sync_model_accessor() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };
@@ -97,6 +99,7 @@ fn test_phase34_cached_sync_concurrent_model_access() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };
@@ -144,6 +147,7 @@ fn test_phase34_cached_sync_send_sync_bounds() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };
@@ -191,6 +195,7 @@ fn test_phase34_cached_sync_multiple_configs() {
                 0
             },
             explicit_head_dim: None,
+            query_pre_attn_scalar: None,
             bos_token_id: None,
             eos_token_id: None,
         };
@@ -227,6 +232,7 @@ fn test_phase34_cached_sync_no_gpu_feature() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };
@@ -256,6 +262,7 @@ fn test_phase34_cached_sync_rapid_access() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };
@@ -289,6 +296,7 @@ fn test_phase34_cached_sync_thread_stress() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };

--- a/crates/aprender-serve/src/gguf/tests/pmat785_gpu_quant_gate.rs
+++ b/crates/aprender-serve/src/gguf/tests/pmat785_gpu_quant_gate.rs
@@ -30,6 +30,7 @@ fn test_config() -> GGUFConfig {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     }

--- a/crates/aprender-serve/src/gguf/tests/tests_02.rs
+++ b/crates/aprender-serve/src/gguf/tests/tests_02.rs
@@ -39,6 +39,7 @@ fn test_imp_106a_batch_matmul_correctness() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };
@@ -107,6 +108,7 @@ fn test_imp_106b_forward_batch_correctness() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };
@@ -156,6 +158,7 @@ fn test_imp_106c_prefill_with_batch() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };
@@ -245,6 +248,7 @@ fn test_imp_107b_forward_batch_gpu() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };
@@ -354,6 +358,7 @@ fn test_imp_108a_batched_causal_attention_correctness() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };
@@ -418,6 +423,7 @@ fn test_imp_108b_causal_mask_gpu() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };

--- a/crates/aprender-serve/src/gguf/tests/tests_03.rs
+++ b/crates/aprender-serve/src/gguf/tests/tests_03.rs
@@ -39,6 +39,7 @@ fn test_imp_109a_fused_dequant_matmul_correctness() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };
@@ -112,6 +113,7 @@ fn test_imp_109b_fused_batch_matmul_gpu() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };
@@ -226,6 +228,7 @@ fn test_imp_109c_fused_vs_separate_performance_baseline() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };
@@ -304,6 +307,7 @@ fn test_imp_110a_parallel_heads_correctness() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };
@@ -373,6 +377,7 @@ fn test_imp_110b_batched_qkv_reshape() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };
@@ -440,6 +445,7 @@ fn test_imp_110c_parallel_batched_scores() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };

--- a/crates/aprender-serve/src/gguf/tests/tests_04.rs
+++ b/crates/aprender-serve/src/gguf/tests/tests_04.rs
@@ -37,6 +37,7 @@ fn test_imp_112a_cached_scheduler_initialization() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };
@@ -102,6 +103,7 @@ fn test_imp_112b_cached_matches_uncached() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };
@@ -161,6 +163,7 @@ fn test_parity_114_cuda_gemm_correctness() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };
@@ -210,6 +213,7 @@ fn test_imp_112c_multiple_operations_same_scheduler() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };
@@ -261,6 +265,7 @@ fn test_imp_112d_cached_attention_matches_uncached() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };
@@ -327,6 +332,7 @@ fn test_imp_111a_online_softmax_correctness() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };
@@ -389,6 +395,7 @@ fn test_imp_111b_tiled_attention_matches_standard() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };

--- a/crates/aprender-serve/src/gguf/transformer.rs
+++ b/crates/aprender-serve/src/gguf/transformer.rs
@@ -50,6 +50,14 @@ pub struct QuantizedGGUFTransformerLayer {
     pub attn_q_norm_weight: Option<Vec<f32>>,
     /// GH-279: Per-head K RMSNorm weight [head_dim] (Qwen3)
     pub attn_k_norm_weight: Option<Vec<f32>>,
+    /// PMAT-810: Gemma2 POST-attention RMSNorm weight (`blk.N.post_attention_norm.weight`).
+    /// Gemma2 sandwiches the attention block: `x + post_attn_norm(attn(input_norm(x)))`.
+    /// `None` for every other architecture (LLaMA/Qwen/Gemma1 have no post-norm).
+    pub post_attn_norm_weight: Option<Vec<f32>>,
+    /// PMAT-810: Gemma2 POST-feedforward RMSNorm weight (`blk.N.post_ffw_norm.weight`).
+    /// Gemma2 sandwiches the FFN block: `h + post_ffw_norm(ffn(pre_ffn_norm(h)))`.
+    /// `None` for every other architecture.
+    pub post_ffw_norm_weight: Option<Vec<f32>>,
 }
 
 /// Quantized GGUF Transformer for fused inference
@@ -369,6 +377,14 @@ impl<'a> QuantizedGGUFTransformer<'a> {
             .get_tensor_f32(&format!("{prefix}.attn_k_norm.weight"), data)
             .ok();
 
+        // PMAT-810: Gemma2 post-attention / post-FFN RMSNorm (absent elsewhere).
+        let post_attn_norm_weight = model
+            .get_tensor_f32(&format!("{prefix}.post_attention_norm.weight"), data)
+            .ok();
+        let post_ffw_norm_weight = model
+            .get_tensor_f32(&format!("{prefix}.post_ffw_norm.weight"), data)
+            .ok();
+
         Ok(QuantizedGGUFTransformerLayer {
             attn_norm_weight,
             attn_norm_bias,
@@ -386,6 +402,8 @@ impl<'a> QuantizedGGUFTransformer<'a> {
             ffn_norm_bias,
             attn_q_norm_weight,
             attn_k_norm_weight,
+            post_attn_norm_weight,
+            post_ffw_norm_weight,
         })
     }
 
@@ -605,6 +623,17 @@ impl<'a> QuantizedGGUFTransformer<'a> {
             .get_tensor_f32(&format!("{}.attn_k_norm.weight", prefix), data)
             .ok();
 
+        // PMAT-810: Gemma2 post-attention / post-FFN RMSNorm (absent for LLaMA/
+        // Qwen/Gemma1). Gemma2 sandwiches each block:
+        //   x = x + post_attn_norm(attn(attn_norm(x)))
+        //   h = h + post_ffw_norm(ffn(ffn_norm(h)))
+        let post_attn_norm_weight = model
+            .get_tensor_f32(&format!("{}.post_attention_norm.weight", prefix), data)
+            .ok();
+        let post_ffw_norm_weight = model
+            .get_tensor_f32(&format!("{}.post_ffw_norm.weight", prefix), data)
+            .ok();
+
         Ok(QuantizedGGUFTransformerLayer {
             attn_norm_weight,
             attn_norm_bias,
@@ -622,6 +651,8 @@ impl<'a> QuantizedGGUFTransformer<'a> {
             ffn_norm_bias,
             attn_q_norm_weight,
             attn_k_norm_weight,
+            post_attn_norm_weight,
+            post_ffw_norm_weight,
         })
     }
 }

--- a/crates/aprender-serve/src/gguf/transformer_quantized_layer_field.rs
+++ b/crates/aprender-serve/src/gguf/transformer_quantized_layer_field.rs
@@ -48,6 +48,8 @@ mod tests {
             ffn_norm_bias: None,
             attn_q_norm_weight: None,
             attn_k_norm_weight: None,
+            post_attn_norm_weight: None,
+            post_ffw_norm_weight: None,
         };
 
         assert_eq!(layer.attn_norm_weight.len(), 64);
@@ -113,6 +115,8 @@ mod tests {
             ffn_norm_bias: Some(vec![0.0; 32]),
             attn_q_norm_weight: None,
             attn_k_norm_weight: None,
+            post_attn_norm_weight: None,
+            post_ffw_norm_weight: None,
         };
 
         assert!(layer.attn_norm_bias.is_some());

--- a/crates/aprender-serve/src/infer/tests_construction.rs
+++ b/crates/aprender-serve/src/infer/tests_construction.rs
@@ -200,6 +200,7 @@ fn test_model_has_legacy_quant_checks_qkv_and_gate() {
         eps: 1e-5,
         rope_type: 0,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
         bos_token_id: None,
         eos_token_id: None,
     };


### PR DESCRIPTION
## apr now runs Gemma2 correctly (was fail-loud-rejected)

Completes the Gemma family after gemma1 (#2096): relaxes the fail-loud gate for **gemma2** (gemma3/gemma3n stay fail-loud), implementing the gemma2-specific behaviors on the CPU forward path. The progression: #2093 made apr *refuse* Gemma, #2096 made *gemma1* work, this makes *gemma2* work.

## Behaviors implemented (gated to gemma2 — non-gemma byte-identical)
- **Attention logit softcapping** `scores = 50·tanh(scores/50)` (`attn_logit_softcapping`)
- **Final logit softcapping** `logits = 30·tanh(logits/30)` (`final_logit_softcapping`)
- **`query_pre_attn_scalar`** attention scale (no-op for 2b where key_length==head_dim==256; applied where it differs)
- **Per-layer post-attention + post-FFN RMSNorms** (`post_attention_norm` / `post_ffw_norm`) — the "missing coherence piece" gemma2 needs; reads the exact GGUF tensor names.

## Verified — token-identical to llama.cpp (load-bearing)
gemma-2-2b-it Q4_K_M, `--no-gpu`, same chat-template prompt as `llama-cli`:
| Prompt | apr | llama.cpp |
|---|---|---|
| "The capital of France is" | "…**Paris**." | "…**Paris**." |
| "2+2=" | "4" | "4" |

Byte-identical completion proves the softcap math + scale + post-norms. GGUF metadata confirmed (`attn_logit_softcapping=50`, `final_logit_softcapping=30`).

## No-regression
**Full aprender-serve lib suite: 15,350 pass, 0 failed.** qwen2.5-0.5B byte-identical (softcap/post-norm are `None` for non-gemma2 → unchanged paths). gemma3/gemma3n correctly stay fail-loud. fmt + clippy clean. Contract (Rule 7): `apr-load-fail-closed-gemma-v1.yaml` v2→v3 (gemma2 supported + SOFTCAP-MATH + post-norm falsifiers); `pv validate` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)