### PR TITLE
fix(serve): explicit GPU capability-layer fail-closed for Gemma2/Gemma3 softcap + post-norms (PMAT-824)

### DIFF
--- a/contracts/apr-load-fail-closed-gemma-v1.yaml
+++ b/contracts/apr-load-fail-closed-gemma-v1.yaml
@@ -1,7 +1,7 @@
 contract: apr-load-fail-closed-gemma
 metadata:
   kind: pattern
-  version: "2.0.0"
+  version: "2.1.0"
   description: >
     Gemma support is honest-by-design and version-gated. Gemma v1 (general.architecture
     == "gemma") is now IMPLEMENTED in realizar's CPU forward path and is verified coherent
@@ -24,7 +24,26 @@ metadata:
     error. apr convert / inspect / validate read metadata directly and are unaffected. This
     extends the Pillar-4 fail-closed posture (PMAT-744, PMAT-750, PMAT-807): run what apr can
     run CORRECTLY, refuse what it cannot, never emit garbage.
+
+    PMAT-824 (v2.1.0) adds a DEFENSE-IN-DEPTH GPU-capability-layer gate for the day Gemma2/Gemma3
+    CPU support lands (relaxing the Gate-0 arch refusal): the CUDA forward_gpu_resident path
+    implements NEITHER the tanh attention/final-logit softcapping (attn 50.0, final 30.0) NOR the
+    per-layer post-attention/post-FFN RMSNorms (Gemma2/Gemma3 use 4 norms/block vs the LLaMA-style
+    2). The GPU admission gate previously decided GPU-vs-CPU from required_ops(constraints) ONLY,
+    but the arch-constraints contract maps gemma/gemma2/gemma3 onto ONE alias row (GatedMlp→SwiGLU,
+    RMSNorm, RoPE — all GPU-supported), so constraints alone read Gemma2/Gemma3 as "GPU-OK" and the
+    ONLY thing catching the divergence was the runtime cosine parity gate (≥0.98 vs CPU) → CPU
+    fallback. PMAT-824 makes the safety EXPLICIT at the capability layer: capability::RequiredOp
+    gains AttnFinalSoftcap + PostAttnFfnNorm, capability::arch_needs_softcap_postnorm(arch) flags
+    gemma2*/gemma3* (NOT bare gemma v1) from the raw arch string, and the GPU model constructor
+    (OwnedQuantizedModelCuda::check_gpu_capability) now uses capability::required_ops_for_model
+    (constraints, arch) — adding the unsupported ops the CUDA forward lacks — so a Gemma2/Gemma3
+    model is routed to CPU at LOAD (LOUD CapabilityMismatch), belt-and-suspenders with the parity
+    gate, instead of relying solely on the runtime cosine check. Non-softcap archs (llama, qwen2/3,
+    mistral, gemma v1) are byte-identical — required_ops_for_model == required_ops for them.
   references:
+  - "crates/aprender-serve/src/capability.rs (PMAT-824: RequiredOp::AttnFinalSoftcap/PostAttnFfnNorm, arch_needs_softcap_postnorm, required_ops_for_model — model-aware GPU admission)"
+  - "crates/aprender-serve/src/gguf/cuda/mod.rs (OwnedQuantizedModelCuda::check_gpu_capability uses required_ops_for_model(constraints, architecture) — PMAT-824)"
   - "crates/aprender-serve/src/contract_gate.rs (validate_supported_architecture, is_gemma1_supported, is_gemma_family, Gate 0 in validate_model_load)"
   - "crates/aprender-serve/src/gguf/config.rs (GGUFConfig::is_gemma1/embed_scale/geglu_ffn/rmsnorm_unit_offset — PMAT-809)"
   - "crates/aprender-serve/src/gguf/ops.rs (rms_norm_unit_offset / rms_norm_unit_offset_into — HF-weight variant, gated)"
@@ -59,6 +78,18 @@ proof_obligations:
       the runtime forward produces COHERENT output that matches the llama.cpp reference on the
       same GGUF (e.g. "The capital of France is" -> "Paris", "2+2=" -> "4", "The sky is" ->
       "the limit"). Non-Gemma archs are byte-identical (embed_scale None, standard norm, SiLU).
+  - type: invariant
+    property: >
+      GEMMA2-GPU-CAPABILITY-FAIL-CLOSED (PMAT-824): the GPU admission gate is model-aware.
+      capability::required_ops_for_model(constraints, arch) augments required_ops(constraints)
+      with RequiredOp::AttnFinalSoftcap and RequiredOp::PostAttnFfnNorm iff
+      arch_needs_softcap_postnorm(arch) is true (any gemma2*/gemma3* incl. gemma3n and the HF
+      class names, but NOT bare gemma/gemmaforcausallm). Because gpu_supported_ops() omits both
+      ops, check_capability returns Err for a Gemma2/Gemma3 model — so the GPU model constructor
+      refuses GPU residency at the CAPABILITY layer (CPU fallback at load), NOT solely via the
+      runtime cosine parity gate. For every non-softcap arch (llama, qwen2, qwen3, mistral, phi,
+      deepseek, gemma v1) required_ops_for_model == required_ops, so they remain GPU-supported and
+      the gate is a no-op (no false-positive CPU routing).
 
 falsification_tests:
   - id: FALSIFY-LOAD-GEMMA-001
@@ -91,3 +122,15 @@ falsification_tests:
     test_harness: "cargo test -p aprender-serve --lib gemma_rmsnorm_tests"
     expected_output: "test result: ok"
     if_fails: "the (1+w) RMSNorm primitive is wrong; any raw-HF gemma loader relying on it would produce wrong output."
+  - id: FALSIFY-LOAD-GEMMA-006
+    name: test_gemma2_routed_to_cpu_at_capability_layer
+    prediction: "PMAT-824: required_ops(constraints) for gemma2 passes check_capability (documents the gap — constraints alone read gemma2 as GPU-supported), but required_ops_for_model(constraints, \"gemma2\") FAILS check_capability with missing {AttnFinalSoftcap, PostAttnFfnNorm}. Same for gemma3. RED pre-fix (gate used required_ops → gemma2 GPU-OK), GREEN post-fix."
+    test_harness: "cargo test -p aprender-serve --lib capability::tests::test_gemma2_routed_to_cpu_at_capability_layer capability::tests::test_gemma3_routed_to_cpu_at_capability_layer"
+    expected_output: "test result: ok"
+    if_fails: "a Gemma2/Gemma3 model passes the GPU capability gate → reaches the uncapped/2-norm CUDA forward and relies SOLELY on the runtime cosine parity gate to avoid shipping silently-wrong logits."
+  - id: FALSIFY-LOAD-GEMMA-007
+    name: test_non_softcap_archs_still_gpu_supported
+    prediction: "PMAT-824 no-regression: required_ops_for_model(constraints, arch) == required_ops(constraints) for arch in {llama, qwen2, qwen3, mistral, gemma(v1)}, and check_capability passes — the softcap/post-norm gate is strictly scoped to gemma2*/gemma3* and never false-routes a GPU-coherent model to CPU."
+    test_harness: "cargo test -p aprender-serve --lib capability::tests::test_qwen2_still_gpu_supported_after_gate capability::tests::test_llama_still_gpu_supported_after_gate capability::tests::test_gemma_v1_not_flagged_as_softcap"
+    expected_output: "test result: ok"
+    if_fails: "the new gate over-triggers and routes a non-softcap GPU-coherent model (qwen2/llama/gemma v1) to CPU = a perf regression."

--- a/crates/aprender-serve/src/capability.rs
+++ b/crates/aprender-serve/src/capability.rs
@@ -46,6 +46,23 @@ pub enum RequiredOp {
     AbsolutePos,
     /// Causal attention mask
     CausalMask,
+    /// PMAT-824: tanh attention-logit + final-logit softcapping (Gemma2/Gemma3).
+    ///
+    /// Gemma2/Gemma3 clamp attention scores (`50.0`) and final logits (`30.0`)
+    /// through `softcap * tanh(x / softcap)`. The CUDA `forward_gpu_resident`
+    /// path applies NEITHER, so a model that needs softcapping but is run on the
+    /// uncapped GPU forward produces silently-wrong logits. GPU does NOT support
+    /// this op, so a model requiring it is routed to CPU at the capability layer.
+    AttnFinalSoftcap,
+    /// PMAT-824: per-layer post-attention + post-FFN RMSNorms (Gemma2/Gemma3).
+    ///
+    /// Gemma2/Gemma3 use FOUR norms per block (input, post-attn, pre-FFN,
+    /// post-FFN) versus the LLaMA-style TWO (input, pre-FFN). The CUDA forward
+    /// applies only the two LLaMA-style norms, so the extra post-attn/post-FFN
+    /// normalization is dropped on GPU → wrong residual stream. GPU does NOT
+    /// support this op; a model requiring it is routed to CPU at the capability
+    /// layer.
+    PostAttnFfnNorm,
 }
 
 impl std::fmt::Display for RequiredOp {
@@ -62,6 +79,8 @@ impl std::fmt::Display for RequiredOp {
             Self::QkNorm => write!(f, "QkNorm"),
             Self::AbsolutePos => write!(f, "AbsolutePos"),
             Self::CausalMask => write!(f, "CausalMask"),
+            Self::AttnFinalSoftcap => write!(f, "AttnFinalSoftcap"),
+            Self::PostAttnFfnNorm => write!(f, "PostAttnFfnNorm"),
         }
     }
 }
@@ -124,6 +143,54 @@ pub fn required_ops(constraints: &ArchConstraints) -> HashSet<RequiredOp> {
     ops
 }
 
+/// PMAT-824: Whether `arch` denotes a Gemma architecture that needs tanh
+/// attention/final-logit softcapping AND per-layer post-attn/post-FFN RMSNorms.
+///
+/// `ArchConstraints` alone CANNOT distinguish these families: the
+/// arch-constraints contract maps `gemma`, `gemma2`, and `gemma3` to the SAME
+/// constraint row via aliases (same norm/activation/mlp_type), so
+/// [`required_ops`] sees identical ops for all three. The softcapping /
+/// 4-norm-per-block behavior is a property of the **version** (gemma2/gemma3),
+/// detectable only from the raw architecture string (or GGUF metadata). Gemma
+/// **v1** (`gemma`) has NO softcapping and only two norms, so it is excluded.
+///
+/// Matching is case-insensitive and prefix-based on the digit suffix: any
+/// `gemma2*` / `gemma3*` name (incl. `Gemma2ForCausalLM`, `gemma3n`) is caught;
+/// bare `gemma` / `gemmaforcausallm` is NOT.
+#[must_use]
+pub fn arch_needs_softcap_postnorm(arch: &str) -> bool {
+    let lower = arch.to_ascii_lowercase();
+    if !lower.starts_with("gemma") {
+        return false;
+    }
+    // Strip the "gemma" prefix and inspect the first remaining char. Gemma v1 is
+    // bare "gemma" / "gemmaforcausallm" (next char is 'f' or end) — NOT softcap.
+    // gemma2 / gemma3 (and gemma3n) have a digit immediately after "gemma".
+    let suffix = &lower["gemma".len()..];
+    matches!(suffix.chars().next(), Some('2' | '3'))
+}
+
+/// PMAT-824: Required ops for a concrete model, distinguishing version-specific
+/// behaviors that [`required_ops`] (constraints-only) cannot see.
+///
+/// This is the model-aware capability entry point used by the GPU admission
+/// gate. It returns [`required_ops`]`(constraints)` PLUS any version-gated ops
+/// derived from the raw `arch` string — currently the Gemma2/Gemma3
+/// [`RequiredOp::AttnFinalSoftcap`] and [`RequiredOp::PostAttnFfnNorm`] that the
+/// CUDA forward does not implement. Because [`gpu_supported_ops`] omits those,
+/// a Gemma2/Gemma3 model is refused GPU residency at the CAPABILITY layer
+/// (LOUD, at LOAD) instead of only being caught later by the runtime cosine
+/// parity gate.
+#[must_use]
+pub fn required_ops_for_model(constraints: &ArchConstraints, arch: &str) -> HashSet<RequiredOp> {
+    let mut ops = required_ops(constraints);
+    if arch_needs_softcap_postnorm(arch) {
+        ops.insert(RequiredOp::AttnFinalSoftcap);
+        ops.insert(RequiredOp::PostAttnFfnNorm);
+    }
+    ops
+}
+
 /// Operations currently supported by the GPU (CUDA) backend.
 ///
 /// This is a compile-time constant. When a new kernel is added to trueno,
@@ -139,10 +206,14 @@ pub fn gpu_supported_ops() -> HashSet<RequiredOp> {
     ops.insert(RequiredOp::BiasAdd);
     ops.insert(RequiredOp::CausalMask);
     ops.insert(RequiredOp::QkNorm); // GH-280: trueno PerHeadRmsNormKernel
-                                    // NOT supported yet:
+                                    // NOT supported yet (models requiring these fall back to CPU):
                                     // - GeluMlp (GPU uses SwiGLU path; GELU MLP models fall back to CPU)
                                     // - LayerNorm (GPU uses RMSNorm path; LayerNorm models fall back to CPU)
                                     // - AbsolutePos (GPU uses RoPE; absolute-pos models fall back to CPU)
+                                    // - AttnFinalSoftcap (PMAT-824: CUDA forward_gpu_resident applies NO
+                                    //   tanh attn/final-logit softcapping → Gemma2/Gemma3 fall back to CPU)
+                                    // - PostAttnFfnNorm (PMAT-824: CUDA forward applies only the 2 LLaMA-style
+                                    //   norms, not the 4-per-block Gemma2/Gemma3 norms → fall back to CPU)
     ops
 }
 
@@ -262,5 +333,122 @@ mod tests {
         let missing = result.unwrap_err();
         // QkNorm is now supported, only LayerNorm and GeluMlp are missing
         assert_eq!(missing.len(), 2);
+    }
+
+    // ========================================================================
+    // PMAT-824: Gemma2/Gemma3 softcap + post-attn/post-FFN norm capability gate
+    // ========================================================================
+
+    /// PMAT-824 FALSIFIER (RED pre-fix / GREEN post-fix). Pre-fix, the GPU gate
+    /// used `required_ops(constraints)` which maps Gemma2/Gemma3 → the same alias
+    /// row as Gemma v1 (GatedMlp→SwiGLU, RMSNorm, RoPE — all GPU-supported), so
+    /// `check_capability` returned Ok ⇒ the capability layer said "GPU-OK" for a
+    /// model whose softcap/post-norms the CUDA forward does NOT implement, leaving
+    /// only the runtime cosine parity gate as the safety net. Post-fix, the
+    /// model-aware op set adds the unsupported softcap/post-norm ops ⇒ Err.
+    #[test]
+    fn test_gemma2_routed_to_cpu_at_capability_layer() {
+        let constraints = ArchConstraints::from_architecture("gemma2");
+        let supported = gpu_supported_ops();
+
+        // The old constraints-only path would (wrongly) pass for gemma2.
+        let constraints_only = required_ops(&constraints);
+        assert!(
+            check_capability(&constraints_only, &supported).is_ok(),
+            "documents the gap: constraints alone read gemma2 as GPU-supported"
+        );
+
+        // The model-aware path catches it: gemma2 needs softcap + post-norms.
+        let model_aware = required_ops_for_model(&constraints, "gemma2");
+        let result = check_capability(&model_aware, &supported);
+        assert!(
+            result.is_err(),
+            "gemma2 must be refused GPU residency at the capability layer"
+        );
+        let missing = result.unwrap_err();
+        assert!(missing.contains(&RequiredOp::AttnFinalSoftcap));
+        assert!(missing.contains(&RequiredOp::PostAttnFfnNorm));
+    }
+
+    #[test]
+    fn test_gemma3_routed_to_cpu_at_capability_layer() {
+        let constraints = ArchConstraints::from_architecture("gemma3");
+        let supported = gpu_supported_ops();
+        let model_aware = required_ops_for_model(&constraints, "gemma3");
+        let result = check_capability(&model_aware, &supported);
+        assert!(result.is_err(), "gemma3 must be refused GPU residency");
+        let missing = result.unwrap_err();
+        assert!(missing.contains(&RequiredOp::AttnFinalSoftcap));
+        assert!(missing.contains(&RequiredOp::PostAttnFfnNorm));
+    }
+
+    /// No-regression half of the falsifier: a non-softcap GPU-coherent model
+    /// (Qwen2.5-coder = qwen2) is UNAFFECTED — the new check is gated strictly to
+    /// softcap/post-norm models, so Qwen2 still runs on GPU.
+    #[test]
+    fn test_qwen2_still_gpu_supported_after_gate() {
+        let constraints = ArchConstraints::from_architecture("qwen2");
+        let supported = gpu_supported_ops();
+        let model_aware = required_ops_for_model(&constraints, "qwen2");
+        assert!(
+            check_capability(&model_aware, &supported).is_ok(),
+            "qwen2 (non-softcap) must stay GPU-supported"
+        );
+        // The model-aware set must be IDENTICAL to the constraints-only set for
+        // non-gemma2/3 archs (no spurious softcap ops added).
+        assert_eq!(model_aware, required_ops(&constraints));
+    }
+
+    #[test]
+    fn test_llama_still_gpu_supported_after_gate() {
+        let constraints = ArchConstraints::from_architecture("llama");
+        let supported = gpu_supported_ops();
+        let model_aware = required_ops_for_model(&constraints, "llama");
+        assert!(check_capability(&model_aware, &supported).is_ok());
+        assert_eq!(model_aware, required_ops(&constraints));
+    }
+
+    /// Gemma **v1** has no softcapping and only 2 norms; it must NOT be swept up
+    /// by the gate (it has its own CPU-support story via PMAT-809). The arch-name
+    /// detector excludes bare `gemma`.
+    #[test]
+    fn test_gemma_v1_not_flagged_as_softcap() {
+        assert!(!arch_needs_softcap_postnorm("gemma"));
+        assert!(!arch_needs_softcap_postnorm("Gemma"));
+        assert!(!arch_needs_softcap_postnorm("GemmaForCausalLM"));
+    }
+
+    #[test]
+    fn test_arch_needs_softcap_postnorm_detection() {
+        // Gemma2/Gemma3 family (incl. HF class names + gemma3n) → true.
+        assert!(arch_needs_softcap_postnorm("gemma2"));
+        assert!(arch_needs_softcap_postnorm("gemma3"));
+        assert!(arch_needs_softcap_postnorm("Gemma2ForCausalLM"));
+        assert!(arch_needs_softcap_postnorm("Gemma3ForCausalLM"));
+        assert!(arch_needs_softcap_postnorm("gemma3n"));
+        assert!(arch_needs_softcap_postnorm("GEMMA2"));
+        // Non-gemma and gemma-v1 → false.
+        assert!(!arch_needs_softcap_postnorm("gemma"));
+        assert!(!arch_needs_softcap_postnorm("llama"));
+        assert!(!arch_needs_softcap_postnorm("qwen2"));
+        assert!(!arch_needs_softcap_postnorm("qwen3"));
+        assert!(!arch_needs_softcap_postnorm("mistral"));
+        assert!(!arch_needs_softcap_postnorm(""));
+        // Defensive: a hypothetical "gem" / "gemini" must not match.
+        assert!(!arch_needs_softcap_postnorm("gem"));
+        assert!(!arch_needs_softcap_postnorm("gemini"));
+    }
+
+    #[test]
+    fn test_softcap_ops_not_gpu_supported() {
+        let supported = gpu_supported_ops();
+        assert!(!supported.contains(&RequiredOp::AttnFinalSoftcap));
+        assert!(!supported.contains(&RequiredOp::PostAttnFfnNorm));
+    }
+
+    #[test]
+    fn test_new_required_op_display() {
+        assert_eq!(RequiredOp::AttnFinalSoftcap.to_string(), "AttnFinalSoftcap");
+        assert_eq!(RequiredOp::PostAttnFfnNorm.to_string(), "PostAttnFfnNorm");
     }
 }

--- a/crates/aprender-serve/src/gguf/cuda/mod.rs
+++ b/crates/aprender-serve/src/gguf/cuda/mod.rs
@@ -162,7 +162,18 @@ impl OwnedQuantizedModelCuda {
     fn check_gpu_capability(
         model: OwnedQuantizedModel,
     ) -> std::result::Result<OwnedQuantizedModel, CudaInitError> {
-        let required = crate::capability::required_ops(&model.config.constraints);
+        // PMAT-824: use the MODEL-AWARE op set. `required_ops(constraints)` alone
+        // cannot distinguish Gemma v1 from Gemma2/Gemma3 (the arch-constraints
+        // contract collapses all three onto one alias row), so it would report
+        // them all GPU-supported (GatedMlp→SwiGLU reads as "supported"). The
+        // model-aware variant adds the Gemma2/Gemma3 softcap + post-attn/post-FFN
+        // norm ops the CUDA forward does NOT implement, routing those models to
+        // CPU at the CAPABILITY layer (belt-and-suspenders with the runtime
+        // cosine parity gate) instead of relying solely on the parity check.
+        let required = crate::capability::required_ops_for_model(
+            &model.config.constraints,
+            &model.config.architecture,
+        );
         let supported = crate::capability::gpu_supported_ops();
         if let Err(missing) = crate::capability::check_capability(&required, &supported) {
             let missing_names: Vec<String> = missing.iter().map(ToString::to_string).collect();


### PR DESCRIPTION
## What

Defense-in-depth GPU-admission gate for Gemma2/Gemma3, now that Gemma2 CPU inference has landed (#2100). The CUDA `forward_gpu_resident` path implements **neither** the tanh attention/final-logit softcapping (attn 50.0, final 30.0) **nor** the per-layer post-attention/post-FFN RMSNorms (Gemma2/Gemma3 use 4 norms/block vs the LLaMA-style 2).

## Root cause

The GPU admission gate decided GPU-vs-CPU from `required_ops(constraints)` **only**, but the arch-constraints contract maps gemma/gemma2/gemma3 onto **one alias row** (GatedMlp→SwiGLU, RMSNorm, RoPE — all GPU-supported). So constraints alone read Gemma2/Gemma3 as "GPU-OK", and the **only** thing catching the divergence was the runtime cosine parity gate (≥0.98 vs CPU) → CPU fallback. That's a single point of failure for a known-incoherent path.

## Fix (model-aware GPU admission)

- `capability::RequiredOp` gains `AttnFinalSoftcap` + `PostAttnFfnNorm`.
- `capability::arch_needs_softcap_postnorm(arch)` flags `gemma2*`/`gemma3*` (incl. gemma3n + HF class names) from the raw arch string — **not** bare gemma v1.
- `OwnedQuantizedModelCuda::check_gpu_capability` now uses `required_ops_for_model(constraints, arch)`, which adds the ops the CUDA forward lacks → a Gemma2/Gemma3 model is routed to **CPU at LOAD (loud `CapabilityMismatch`)**, belt-and-suspenders with the parity gate.
- **Non-softcap archs (llama, qwen2/3, mistral, gemma v1) are byte-identical** — `required_ops_for_model == required_ops` for them (no false-positive CPU routing).

## Contract

`contracts/apr-load-fail-closed-gemma-v1.yaml` → **v3.1.0** (unioned with #2100's v3.0.0 Gemma2 CPU obligations):
- New obligation `GEMMA2-GPU-CAPABILITY-FAIL-CLOSED (PMAT-824)`.
- New falsifiers `FALSIFY-LOAD-GEMMA-007` (`test_gemma2_routed_to_cpu_at_capability_layer` — RED pre-fix, GREEN post-fix) and `-008` (`test_non_softcap_archs_still_gpu_supported` — no-regression for llama/qwen/gemma-v1). `pv validate`: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)