### PR TITLE
fix(stats): incomplete_beta extra /a corrupted ALL t-test/ANOVA p-values (PMAT-827)

### DIFF
--- a/contracts/incomplete-beta-correctness-v1.yaml
+++ b/contracts/incomplete-beta-correctness-v1.yaml
@@ -1,0 +1,59 @@
+metadata:
+  version: "1.0.0"
+  created: "2026-06-18"
+  author: PAIML Engineering
+  registry: true
+  references:
+    - "Press, Teukolsky, Vetterling, Flannery — Numerical Recipes, §6.4 betai/betacf (the reference algorithm)"
+    - "scipy.special.betainc (oracle, pinned 2026-06-18 via `uv run --with scipy`)"
+    - "scipy.stats.ttest_1samp (downstream oracle)"
+  description: |
+    Correctness contract for the regularized incomplete beta function I_x(a,b)
+    (aprender-core stats::hypothesis::incomplete_beta) and the t- / F-distribution
+    p-values that depend on it. Pillar-1 (scipy/sklearn parity) provable-correctness.
+
+kind: KernelContract
+name: incomplete-beta-correctness
+version: "1.0.0"
+scope: "crates/aprender-core/src/stats/hypothesis.rs"
+
+description: |
+  I_x(a,b) is the regularized incomplete beta. The Numerical-Recipes form is
+
+      bt          = x^a (1-x)^b / B(a,b)
+      I_x(a,b)    = bt * betacf(a,b,x) / a            if x < (a+1)/(a+b+2)
+                  = 1 - bt * betacf(b,a,1-x) / b      otherwise
+
+  The 1/a and 1/b normalizers appear ONLY in the final returns. PMAT-827 fixed a
+  defect where `bt` carried a spurious extra `/a`, double-dividing the if-branch
+  (factor 1/a too small) and `b/a`-scaling the else-branch. The error was invisible
+  ONLY at a == 1 (1/1 = identity) — and every pre-existing test used a == b == 1, so
+  the bug shipped green. It corrupted every t-test (df ≤ 30) and ANOVA F-test p-value:
+  values came out too small → falsely significant (e.g. a one-sample t-test reported
+  p = 0.1151 when scipy gives 0.2302).
+
+equations:
+  C-IBETA-001:
+    description: "I_x(a,b) matches the scipy.special.betainc oracle for general a (not only a==1)"
+    formula: "|incomplete_beta(a,b,x) - betainc(a,b,x)| < ε, ε = 1e-3; e.g. I_0.4(2,3)=0.5248, I_0.5(4,0.5)=0.022204"
+    note: "The a==1 identity case is necessary but NOT sufficient — it is the single value the historical extra-/a bug left correct."
+
+  C-IBETA-002:
+    description: "Symmetry I_0.5(a,a) = 1/2 for all a > 0"
+    formula: "incomplete_beta(a, a, 0.5) = 0.5 ∀ a > 0"
+    note: "A pure structural check independent of any external oracle; RED on the extra-/a bug (gave 0.8 at a=2.5)."
+
+  C-IBETA-003:
+    description: "Downstream: one-sample t-test p-value (df ≤ 30 beta path) matches scipy.stats.ttest_1samp"
+    formula: "ttest_1samp([2.3,2.5,2.7,2.9,3.1], 2.5).pvalue ≈ 0.2302 (scipy); 2-tail p = incomplete_beta(df/2, 1/2, df/(df+t²))"
+    note: "Guards against false-significant inference: the bug halved this p-value (0.1151) → spurious null rejection."
+
+falsification:
+  - id: FALSIFY-STATS-BETA-001
+    description: "I_x(a,b) equals the scipy oracle for a != 1 (and still for a == 1). Discharges C-IBETA-001 + C-IBETA-002."
+    test: "test_incomplete_beta_matches_scipy_oracle — I_0.4(2,3): RED 0.2624 → GREEN 0.5248; I_0.5(4,0.5): RED 0.00555 → GREEN 0.022204; I_0.5(2.5,2.5): RED 0.8 → GREEN 0.5; a==1 identity regression-guarded."
+    evidence: "cargo test -p aprender-core --lib test_incomplete_beta_matches_scipy_oracle"
+  - id: FALSIFY-STATS-BETA-002
+    description: "One-sample t-test p-value matches scipy (downstream of the beta fix). Discharges C-IBETA-003."
+    test: "test_ttest_1samp_pvalue_matches_scipy — RED 0.1151 (falsely significant) → GREEN 0.2302 == scipy.stats.ttest_1samp."
+    evidence: "cargo test -p aprender-core --lib test_ttest_1samp_pvalue_matches_scipy"

--- a/crates/aprender-core/src/stats/hypothesis.rs
+++ b/crates/aprender-core/src/stats/hypothesis.rs
@@ -418,8 +418,11 @@ fn incomplete_beta(a: f32, b: f32, x: f32) -> f32 {
         return 1.0;
     }
 
-    // Simplified approximation using continued fraction
-    let bt = (x.powf(a) * (1.0 - x).powf(b)) / (a * beta_function(a, b));
+    // Numerical-Recipes `betai` prefactor: bt = x^a (1-x)^b / B(a,b).
+    // The 1/a and 1/b normalizers belong ONLY in the final returns below — folding a
+    // `/a` in here double-divided the if-branch (and `b/a`-scaled the else-branch),
+    // making I_x(a,b) wrong for a != 1 (it was correct only at the a==1 identity).
+    let bt = (x.powf(a) * (1.0 - x).powf(b)) / beta_function(a, b);
 
     if x < (a + 1.0) / (a + b + 2.0) {
         bt * beta_continued_fraction(a, b, x) / a

--- a/crates/aprender-core/src/stats/hypothesis_tests.rs
+++ b/crates/aprender-core/src/stats/hypothesis_tests.rs
@@ -350,6 +350,50 @@ mod tests {
         assert!(val > 0.0 && val < 1.0);
     }
 
+    /// FALSIFY-STATS-BETA-001: the regularized incomplete beta I_x(a,b) must match the
+    /// `scipy.special.betainc` oracle for a != 1. The historical extra `/a` in `bt`
+    /// (hypothesis.rs `incomplete_beta`) was invisible ONLY at a == b == 1 (1/1 = identity),
+    /// which is exactly why every prior test here used a == b == 1 and the bug shipped green.
+    /// Oracle pinned 2026-06-18 via `uv run --with scipy`.
+    #[test]
+    fn test_incomplete_beta_matches_scipy_oracle() {
+        // if-branch, a=2: RED pre-fix = 0.2624 (off by 1/a). GREEN post-fix = 0.5248.
+        assert!(
+            (incomplete_beta(2.0, 3.0, 0.4) - 0.524_800).abs() < 1e-3,
+            "I_0.4(2,3) = {} != 0.5248 (scipy)",
+            incomplete_beta(2.0, 3.0, 0.4)
+        );
+        // else-branch, a=4: RED pre-fix = 0.00555 (off by 1/a = 1/4). GREEN = 0.022204.
+        assert!(
+            (incomplete_beta(4.0, 0.5, 0.5) - 0.022_204).abs() < 1e-4,
+            "I_0.5(4,0.5) = {} != 0.022204 (scipy)",
+            incomplete_beta(4.0, 0.5, 0.5)
+        );
+        // Symmetry I_0.5(a,a) = 0.5 — RED pre-fix (0.8), GREEN post-fix.
+        assert!(
+            (incomplete_beta(2.5, 2.5, 0.5) - 0.5).abs() < 1e-3,
+            "I_0.5(2.5,2.5) = {} != 0.5 (symmetry)",
+            incomplete_beta(2.5, 2.5, 0.5)
+        );
+        // Regression guard: the a == 1 identity case the old tests used must STILL hold.
+        assert!((incomplete_beta(1.0, 1.0, 0.2) - 0.2).abs() < 1e-3);
+    }
+
+    /// FALSIFY-STATS-BETA-002 (downstream): a one-sample t-test with df <= 30 routes its
+    /// p-value through `incomplete_beta(df/2, 0.5, x)`; the extra `/a` made the p-value
+    /// WRONG (smaller → falsely significant). Oracle: `scipy.stats.ttest_1samp` = 0.23020.
+    #[test]
+    fn test_ttest_1samp_pvalue_matches_scipy() {
+        let sample = vec![2.3, 2.5, 2.7, 2.9, 3.1];
+        let result = ttest_1samp(&sample, 2.5).expect("valid t-test");
+        assert_eq!(result.df, 4.0);
+        assert!(
+            (result.pvalue - 0.230_20).abs() < 3e-3,
+            "ttest_1samp p = {} != 0.2302 (scipy.stats.ttest_1samp); extra /a halved/scaled it",
+            result.pvalue
+        );
+    }
+
     #[test]
     fn test_incomplete_gamma_zero_x() {
         let val = incomplete_gamma(1.0, 0.0);


### PR DESCRIPTION
## Root cause (Pillar-1 scipy-parity correctness)

`stats::hypothesis::incomplete_beta` (the regularized incomplete beta `I_x(a,b)`) built its Numerical-Recipes prefactor as `bt = x^a (1-x)^b / (a * B(a,b))` — a **spurious extra `/a`**. The `1/a` and `1/b` normalizers belong **only** in the final returns:

```
bt        = x^a (1-x)^b / B(a,b)          # NO /a here
I_x(a,b)  = bt * betacf(a,b,x) / a        if x < (a+1)/(a+b+2)
          = 1 - bt * betacf(b,a,1-x) / b  otherwise
```

So the if-branch double-divided by `a`; the else-branch got a `b/a` scale. `I_x(a,b)` was wrong for **every `a != 1`** — correct only at `a == 1` (1/1 = identity).

## Impact

Every **t-test p-value with df ≤ 30** (the t-distribution beta path) and every **ANOVA F-test** p-value (`f_oneway`) was too small → **falsely significant**. The library's own documented sample:

```
ttest_1samp([2.3,2.5,2.7,2.9,3.1], 2.5)  →  apr p = 0.1151   scipy p = 0.2302
```

A user rejects a true null at p<0.05 that is really p≈0.23.

## Why it shipped green

Every pre-existing `incomplete_beta` test used `a == b == 1` (the single bug-invisible value) and asserted only `0 < p < 1`. No oracle p-value was ever pinned → the falsifier was missing.

## Fix + falsifiers (RED→GREEN, scipy-pinned)

One line (drop the extra `/a`). New tests verified RED on the bug, GREEN after:
- `test_incomplete_beta_matches_scipy_oracle` — `I_0.4(2,3)` 0.2624→**0.5248**, `I_0.5(4,0.5)` 0.00555→**0.022204**, symmetry `I_0.5(2.5,2.5)` 0.8→**0.5**; `a==1` identity regression-guarded.
- `test_ttest_1samp_pvalue_matches_scipy` — p 0.1151→**0.2302** (== `scipy.stats.ttest_1samp`).

Contract `contracts/incomplete-beta-correctness-v1.yaml` (C-IBETA-001..003, FALSIFY-STATS-BETA-001/002), `pv validate` clean. All 186 stats tests pass; nothing pinned the buggy behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)