### PR TITLE
fix(lora): rsLoRA adapter scale silently dropped on load — corrupted reload (PMAT-828)

### DIFF
--- a/contracts/lora-adapter-scale-roundtrip-v1.yaml
+++ b/contracts/lora-adapter-scale-roundtrip-v1.yaml
@@ -1,0 +1,45 @@
+metadata:
+  version: "1.0.0"
+  created: "2026-06-18"
+  author: PAIML Engineering
+  registry: true
+  references:
+    - "Kalajdzievski, 2023 — A Rank Stabilization Scaling Factor for Fine-Tuning with LoRA (rsLoRA: scale = alpha/sqrt(rank))"
+    - "Hu et al., 2021 — LoRA: Low-Rank Adaptation (Standard scale = alpha/rank)"
+  description: |
+    Correctness contract for LoRA adapter serialization round-trip (aprender-train
+    lora::adapter::LoRAAdapter). Pillar-3 (Unsloth fine-tune) provable correctness:
+    a saved adapter must reload to a numerically-identical layer.
+
+kind: KernelContract
+name: lora-adapter-scale-roundtrip
+version: "1.0.0"
+scope: "crates/aprender-train/src/lora/adapter/lora_adapter.rs"
+
+description: |
+  A LoRALayer's effective update is `scale * (B @ A)`, where `scale` depends on the
+  scaling mode: Standard = alpha/rank, rsLoRA = alpha/sqrt(rank). LoRAAdapter::from_layer
+  correctly serializes the resulting `scale` value. PMAT-828 fixed LoRAAdapter::to_layer,
+  which rebuilt the layer via `LoRALayer::new` (recomputing Standard alpha/rank) and
+  DISCARDED the serialized scale — silently re-scaling an rsLoRA adapter by sqrt(rank)
+  (e.g. 4x at rank=16) on load, with no error, corrupting every reloaded/merged rsLoRA model.
+  The bug was invisible for Standard adapters (scale == alpha/rank already), which is why
+  every prior test (make_test_adapter: scale=2.0=alpha/rank) missed it. Fix: restore the
+  serialized scale via the new LoRALayer::with_scale builder.
+
+equations:
+  C-LORA-SCALE-001:
+    description: "Adapter scale survives a from_layer -> to_layer round-trip for ALL scaling modes"
+    formula: "to_layer(from_layer(L)).scale == L.scale ∀ L (incl. rsLoRA: alpha/sqrt(rank))"
+    note: "Standard (alpha/rank) was always correct; the obligation is the GENERAL case where serialized scale != alpha/rank."
+
+  C-LORA-SCALE-002:
+    description: "Restoration uses the serialized scale value, not a recomputed mode"
+    formula: "to_layer reads self.scale (the stored value); it does NOT recompute alpha/rank or alpha/sqrt(rank)"
+    note: "The adapter stores the scale VALUE, not the scaling mode, so reconstruction must be value-based (LoRALayer::with_scale)."
+
+falsification:
+  - id: FALSIFY-LORA-ADAPTER-SCALE-001
+    description: "rsLoRA scale (alpha/sqrt(rank)) survives the adapter round-trip. Discharges C-LORA-SCALE-001/002."
+    test: "test_rslora_scale_survives_roundtrip — rank=16, alpha=16: rsLoRA scale = 4.0; RED pre-fix reloaded.scale()=1.0 (alpha/rank), GREEN post-fix 4.0."
+    evidence: "cargo test -p aprender-train --lib test_rslora_scale_survives_roundtrip"

--- a/crates/aprender-train/src/lora/adapter/lora_adapter.rs
+++ b/crates/aprender-train/src/lora/adapter/lora_adapter.rs
@@ -94,8 +94,12 @@ impl LoRAAdapter {
             )));
         }
 
-        // Create layer with loaded weights
-        let mut layer = LoRALayer::new(base_weight, self.d_out, self.d_in, self.rank, self.alpha);
+        // Create layer with loaded weights. `new` recomputes scale = alpha/rank
+        // (Standard mode); restore the SERIALIZED scale so a non-Standard adapter
+        // (e.g. rsLoRA, scale = alpha/sqrt(rank)) round-trips losslessly instead of
+        // being silently re-scaled to alpha/rank.
+        let mut layer = LoRALayer::new(base_weight, self.d_out, self.d_in, self.rank, self.alpha)
+            .with_scale(self.scale);
 
         // Replace LoRA weights with loaded values
         *layer.lora_a_mut().data_mut() = ndarray::arr1(&self.lora_a);
@@ -186,6 +190,44 @@ mod tests {
         let layer = adapter.to_layer(base_weight).expect("operation should succeed");
         assert_eq!(layer.d_out(), 8);
         assert_eq!(layer.d_in(), 16);
+    }
+
+    /// FALSIFY-LORA-ADAPTER-SCALE-001: an rsLoRA adapter's scale (= alpha/sqrt(rank))
+    /// must survive a from_layer -> to_layer round-trip. `to_layer` previously rebuilt
+    /// the layer via `LoRALayer::new`, which recomputes Standard scale = alpha/rank and
+    /// discarded the serialized scale — silently re-scaling rsLoRA by a factor of
+    /// sqrt(rank) (e.g. 4x for rank=16) with no error, corrupting the reloaded model.
+    /// Every prior test used scale == alpha/rank (the Standard case the bug left intact).
+    #[test]
+    fn test_rslora_scale_survives_roundtrip() {
+        use crate::lora::LoRAScaling;
+        let (d_out, d_in, rank, alpha) = (4usize, 4usize, 16usize, 16.0f32);
+        let base = Tensor::zeros(d_out * d_in, false);
+        // rsLoRA scale = alpha / sqrt(rank) = 16 / 4 = 4.0  (Standard would be 16/16 = 1.0)
+        let layer = LoRALayer::new_with_scaling(
+            base.clone(),
+            d_out,
+            d_in,
+            rank,
+            alpha,
+            LoRAScaling::RsLoRA,
+        );
+        assert!(
+            (layer.scale() - 4.0).abs() < 1e-6,
+            "precondition: rsLoRA scale = {} (expected 4.0)",
+            layer.scale()
+        );
+
+        let adapter = LoRAAdapter::from_layer(&layer, rank, alpha);
+        assert!((adapter.metadata().scale - 4.0).abs() < 1e-6, "from_layer must capture 4.0");
+
+        let reloaded = adapter.to_layer(base).expect("to_layer should succeed");
+        // RED pre-fix: reloaded.scale() == alpha/rank == 1.0. GREEN post-fix: 4.0.
+        assert!(
+            (reloaded.scale() - 4.0).abs() < 1e-6,
+            "rsLoRA scale dropped on load: reloaded scale = {} (expected 4.0 = alpha/sqrt(rank))",
+            reloaded.scale()
+        );
     }
 
     #[test]

--- a/crates/aprender-train/src/lora/layer/core.rs
+++ b/crates/aprender-train/src/lora/layer/core.rs
@@ -106,6 +106,18 @@ impl LoRALayer {
         layer
     }
 
+    /// Override the LoRA scaling factor.
+    ///
+    /// Used when restoring a serialized adapter whose `scale` was produced by a
+    /// non-Standard mode (e.g. rsLoRA, where `scale = alpha / sqrt(rank)` rather than
+    /// the `alpha / rank` that [`LoRALayer::new`] recomputes). The adapter stores the
+    /// resulting scale *value*, not the scaling mode, so restoration sets it directly.
+    #[must_use]
+    pub fn with_scale(mut self, scale: f32) -> Self {
+        self.scale = scale;
+        self
+    }
+
     /// Forward pass: y = W@x + scale * (B @ (A @ x))
     ///
     /// # Arguments


### PR DESCRIPTION
## Root cause (Pillar-3 Unsloth fine-tune correctness)

`LoRAAdapter::to_layer` rebuilt the layer via `LoRALayer::new(...)` — which recomputes the **Standard** `scale = alpha/rank` — then overwrote only `lora_a`/`lora_b`, **never restoring the serialized `self.scale`**.

For an **rsLoRA** adapter (`scale = alpha/sqrt(rank)`, captured correctly by `from_layer`), this silently re-scaled the adapter by a factor of `sqrt(rank)` on every save→load (e.g. **4× at rank=16**), with no error. The reloaded/merged model then produced different (wrong) outputs than the trained model.

## Why it shipped green

`make_test_adapter()` and every existing `to_layer` test used `scale == alpha/rank` (Standard) — the single case where the discard is invisible. None constructed an rsLoRA layer and asserted `to_layer().scale() == original`. The falsifier was missing.

## Fix + falsifier (RED→GREEN)

- Add `LoRALayer::with_scale(scale)` builder; `to_layer` restores the serialized scale **value** (the adapter stores the value, not the scaling mode, so reconstruction must be value-based).
- `test_rslora_scale_survives_roundtrip` — rank=16, alpha=16, rsLoRA scale=4.0: **RED** pre-fix `reloaded.scale()=1.0`, **GREEN** post-fix `4.0`.

Contract `contracts/lora-adapter-scale-roundtrip-v1.yaml` (C-LORA-SCALE-001/002, FALSIFY-LORA-ADAPTER-SCALE-001), `pv validate` clean. All 196 lora tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)