### PR TITLE
fix(train): --grad-clip was a silent no-op on the CPU trainer (PMAT-829)

### DIFF
--- a/contracts/trainer-grad-clip-v1.yaml
+++ b/contracts/trainer-grad-clip-v1.yaml
@@ -1,0 +1,47 @@
+metadata:
+  version: "1.0.0"
+  created: "2026-06-18"
+  author: PAIML Engineering
+  registry: true
+  references:
+    - "torch.nn.utils.clip_grad_norm_ (the reference global-norm gradient-clipping semantics)"
+    - "crates/aprender-train/src/optim/clip.rs::clip_grad_norm_refs (the tested in-tree helper)"
+  description: |
+    Correctness contract for gradient clipping in the CPU TransformerTrainer
+    (aprender-train train::transformer_trainer). Pillar-2 (PyTorch-parity training)
+    provable correctness: a configured grad-clip MUST actually bound the gradients
+    used by the optimizer step.
+
+kind: KernelContract
+name: trainer-grad-clip
+version: "1.0.0"
+scope: "crates/aprender-train/src/train/transformer_trainer/trainer.rs"
+
+description: |
+  TransformerTrainer::clip_and_step must apply global-norm gradient clipping (torch
+  clip_grad_norm_) to the parameters being optimized when config.base.max_grad_norm is
+  set, BEFORE the optimizer step. PMAT-829 fixed a defect where the clip coefficient was
+  computed and then discarded (`let _ = scale;`): no gradient was ever scaled, so
+  `--grad-clip` / `with_grad_clip(..)` was a silent no-op on the CPU training path
+  (LM-pretrain and LoRA-finetune). Training ran with raw unclipped gradients (loss-spike
+  divergence risk), while the sibling WGPU trainer clips correctly — a silent CPU-vs-GPU
+  optimization divergence for identical configs. Fix: call the tested clip_grad_norm_refs
+  helper on the exact param set passed to step_refs, in both the LoRA and full-finetune
+  branches.
+
+equations:
+  C-GRADCLIP-001:
+    description: "When max_grad_norm is set, the optimizer steps on gradients whose global L2 norm <= max_grad_norm"
+    formula: "global_norm(grads_at_step) <= max_grad_norm whenever config.base.max_grad_norm = Some(max_grad_norm)"
+    note: "torch clip_grad_norm_: if ||g|| > c then g *= c/||g|| over the OPTIMIZED params; identity when ||g|| <= c."
+
+  C-GRADCLIP-002:
+    description: "Clipping is applied (not merely computed) — the clip coefficient must scale the gradients in place"
+    formula: "clip_and_step calls clip_grad_norm_refs(params, max_norm) on the same params given to step_refs; no computed scale is discarded"
+    note: "Regression guard against the `let _ = scale;` discard. CPU and WGPU trainers must agree."
+
+falsification:
+  - id: FALSIFY-TRAINER-GRADCLIP-001
+    description: "clip_and_step actually clips an oversized gradient to max_grad_norm. Discharges C-GRADCLIP-001/002."
+    test: "falsify_clip_and_step_actually_clips_gradients — inject grad norm ~4420 with max_grad_norm=1.0; RED pre-fix post-step norm 4420 (unclipped), GREEN post-fix <= 1.0."
+    evidence: "cargo test -p aprender-train --lib falsify_clip_and_step_actually_clips_gradients"

--- a/crates/aprender-train/src/train/transformer_trainer/trainer.rs
+++ b/crates/aprender-train/src/train/transformer_trainer/trainer.rs
@@ -3,7 +3,7 @@
 use crate::autograd::{checkpoint, GradScaler};
 use crate::io::{save_model, Model, ModelFormat, ModelMetadata, SaveConfig};
 use crate::lora::LoRALayer;
-use crate::optim::{AdamW, Optimizer};
+use crate::optim::{clip_grad_norm_refs, AdamW, Optimizer};
 use crate::train::{CausalLMLoss, LossFn, MetricsTracker};
 use crate::transformer::Transformer;
 use crate::Tensor;
@@ -228,25 +228,6 @@ impl TransformerTrainer {
 
     /// Apply gradient clipping and run the optimizer step, then reset accumulation.
     fn clip_and_step(&mut self) {
-        if let Some(max_norm) = self.config.base.max_grad_norm {
-            let params = if let Some(ref lora) = self.lora_layers {
-                lora.iter().flat_map(|l| vec![l.lora_a(), l.lora_b()]).collect::<Vec<_>>()
-            } else {
-                self.model.parameters()
-            };
-            let total_norm: f32 = params
-                .iter()
-                .filter_map(|p| p.grad())
-                .map(|g| g.iter().map(|x| x * x).sum::<f32>())
-                .sum::<f32>()
-                .sqrt();
-
-            if total_norm > max_norm {
-                let scale = max_norm / (total_norm + 1e-6);
-                let _ = scale;
-            }
-        }
-
         // ENT-LoRA-002: Only update trainable params (LoRA A/B + norms when active)
         if let Some(ref mut lora) = self.lora_layers {
             // ENT-LoRA-006: LoRA+ gradient scaling for B matrices
@@ -268,9 +249,17 @@ impl TransformerTrainer {
                 params.push(&mut layer.post_attn_norm.weight);
             }
             params.push(&mut self.model.norm.weight);
+            // Clip the gradients ACTUALLY being optimized (torch clip_grad_norm_) BEFORE
+            // the step. Previously the clip coefficient was computed then discarded (no-op).
+            if let Some(max_norm) = self.config.base.max_grad_norm {
+                clip_grad_norm_refs(&mut params, max_norm);
+            }
             self.optimizer.step_refs(&mut params);
         } else {
             let mut params = self.model.parameters_mut();
+            if let Some(max_norm) = self.config.base.max_grad_norm {
+                clip_grad_norm_refs(&mut params, max_norm);
+            }
             self.optimizer.step_refs(&mut params);
         }
 
@@ -594,5 +583,51 @@ impl TransformerTrainer {
             }
         }
         format!("{:x}", hasher.finalize())
+    }
+}
+
+#[cfg(test)]
+mod clip_and_step_tests {
+    use super::*;
+    use crate::transformer::TransformerConfig;
+
+    /// FALSIFY-TRAINER-GRADCLIP-001 (PMAT-829): `clip_and_step` computed the clip
+    /// coefficient and then DISCARDED it (`let _ = scale;`), so `--grad-clip` /
+    /// `with_grad_clip(..)` was a silent no-op on the CPU trainer — training ran with raw,
+    /// unclipped gradients (divergence risk), while the WGPU trainer clips correctly
+    /// (silent CPU-vs-GPU divergence). Prior tests only asserted the config field
+    /// (`base.max_grad_norm`), never that gradients are actually clipped at step time.
+    #[test]
+    fn falsify_clip_and_step_actually_clips_gradients() {
+        let config = TransformerTrainConfig::new(TransformerConfig::tiny())
+            .with_lr(0.001)
+            .with_grad_clip(1.0);
+        let mut trainer = TransformerTrainer::new(config);
+
+        // Inject a known oversized gradient (global norm >> max_norm=1.0) on every param.
+        for p in trainer.model.parameters() {
+            p.set_grad(ndarray::Array1::from_elem(p.len(), 10.0_f32));
+        }
+        let norm = |t: &TransformerTrainer| -> f32 {
+            t.model
+                .parameters()
+                .iter()
+                .filter_map(|p| p.grad())
+                .map(|g| g.iter().map(|x| x * x).sum::<f32>())
+                .sum::<f32>()
+                .sqrt()
+        };
+        let before = norm(&trainer);
+        assert!(before > 1.0, "precondition: injected grad norm {before} must exceed max_norm 1.0");
+
+        trainer.clip_and_step();
+
+        // After clip_and_step the global grad norm MUST be clipped to ~max_norm (1.0).
+        // RED pre-fix: grads untouched (norm == `before` >> 1.0). GREEN post-fix: ~1.0.
+        let after = norm(&trainer);
+        assert!(
+            after <= 1.0 + 1e-2,
+            "clip_and_step did not clip gradients: global norm = {after} (expected <= 1.0); --grad-clip is a no-op"
+        );
     }
 }


### PR DESCRIPTION
## Root cause (Pillar-2 training correctness)

`TransformerTrainer::clip_and_step` computed the global gradient norm and the clip coefficient `scale = max_norm / (total_norm + 1e-6)` — then **discarded it with `let _ = scale;`**. No gradient was ever scaled, so the block had **zero effect**; the optimizer stepped on raw, unclipped gradients.

## Impact

Configuring `with_grad_clip(c)` / `--grad-clip c` on the CPU `TransformerTrainer` (the LM-pretrain and LoRA-finetune path) **silently disabled gradient clipping**. On a loss spike / bad batch the update is unbounded → the run can diverge (NaN/Inf, loss explosion) exactly when grad-clip is supposed to prevent it, while the config reports success. The sibling **WGPU trainer clips correctly**, so the same config produced different CPU-vs-GPU optimization dynamics — a silent backend divergence.

## Why it shipped green

The only grad-clip tests asserted the **config field** (`config.base.max_grad_norm == Some(x)`). None ran `clip_and_step` with an oversized gradient and asserted the gradients were actually clipped — the behavior falsifier was missing.

## Fix + falsifier (RED→GREEN)

Call the existing tested `clip_grad_norm_refs(&mut params, max_norm)` (torch `clip_grad_norm_` semantics) on the exact param set passed to `step_refs`, in both the LoRA and full-finetune branches, before the step.

- `falsify_clip_and_step_actually_clips_gradients` — inject grad norm ~4420 with `max_grad_norm=1.0`: **RED** post-step norm 4420 (unclipped), **GREEN** ≤ 1.0.

Contract `contracts/trainer-grad-clip-v1.yaml` (C-GRADCLIP-001/002, FALSIFY-TRAINER-GRADCLIP-001), `pv validate` clean. All 227 transformer_trainer tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)