### PR TITLE
fix(prune): --sparsity below --target-ratio default silently over-pruned (PMAT-830)

### DIFF
--- a/contracts/prune-sparsity-correctness-v1.yaml
+++ b/contracts/prune-sparsity-correctness-v1.yaml
@@ -1,0 +1,44 @@
+metadata:
+  version: "1.0.0"
+  created: "2026-06-18"
+  author: PAIML Engineering
+  registry: true
+  references:
+    - "crates/apr-cli/src/commands/prune.rs (apply_pruning, effective_prune_fraction)"
+    - "crates/apr-cli/src/model_ops_commands.rs (Prune clap args: --target-ratio default 0.5, --sparsity default 0.0)"
+  description: |
+    Correctness contract for `apr prune` magnitude-class methods. The fraction of weights
+    actually zeroed MUST equal the user's requested sparsity, and the output metadata MUST
+    not misreport it. Pillar-adjacent (model-ops CLI) provable correctness.
+
+kind: KernelContract
+name: prune-sparsity-correctness
+version: "1.0.0"
+scope: "crates/apr-cli/src/commands/prune.rs"
+
+description: |
+  `apr prune` exposes two overlapping knobs for the prune fraction: `--target-ratio`
+  (default 0.5) and `--sparsity` (default 0.0). PMAT-830 fixed apply_pruning, which fed
+  `sparsity.max(target_ratio)` to prune_magnitude: any explicit `--sparsity` BELOW the
+  0.5 `--target-ratio` default was silently raised to 0.5. So `apr prune --method
+  magnitude --sparsity 0.3` zeroed 50% of weights, not 30%, exited success, and stamped
+  `pruning_sparsity = 0.3` into the output metadata — an over-pruned model whose metadata
+  contradicts what was applied. Fix: `effective_prune_fraction` honors an explicit
+  `--sparsity` (> 0) and falls back to `--target-ratio` otherwise (no silent raise).
+
+equations:
+  C-PRUNE-001:
+    description: "Magnitude pruning zeros the user-requested fraction when --sparsity is given"
+    formula: "zeroed_count ≈ round(num_elems × sparsity) when sparsity > 0; e.g. 64 distinct magnitudes, sparsity 0.25 → 16 zeros (NOT 32)"
+    note: "prune_magnitude zeros below the value at cutoff_idx = floor(len × fraction); the fraction must be the user's sparsity, not max(sparsity, target_ratio)."
+
+  C-PRUNE-002:
+    description: "An explicit --sparsity is never silently raised toward the --target-ratio default"
+    formula: "effective_prune_fraction(target_ratio, sparsity) = sparsity if sparsity > 0 else target_ratio; never max(·)"
+    note: "Regression guard against the sparsity.max(target_ratio) override. Keeps the applied fraction consistent with the stamped pruning_sparsity metadata."
+
+falsification:
+  - id: FALSIFY-PRUNE-SPARSITY-001
+    description: "--sparsity below the target-ratio default is honored, not raised. Discharges C-PRUNE-001/002."
+    test: "test_magnitude_sparsity_below_target_ratio_not_overridden — 64 distinct magnitudes, --sparsity 0.25 (target_ratio default 0.5): RED pre-fix 32/64 zeroed (50%), GREEN post-fix 16/64 (25%)."
+    evidence: "cargo test -p apr-cli --lib test_magnitude_sparsity_below_target_ratio_not_overridden"

--- a/crates/apr-cli/src/commands/prune.rs
+++ b/crates/apr-cli/src/commands/prune.rs
@@ -286,6 +286,22 @@ fn execute_pruning(
     })
 }
 
+/// Effective fraction of weights to zero.
+///
+/// `--sparsity` and `--target-ratio` are two knobs for the same quantity. An explicit
+/// `--sparsity` (> 0) is the user's requested fraction and takes precedence; otherwise we
+/// fall back to `--target-ratio` (default 0.5). Previously this was
+/// `sparsity.max(target_ratio)`, which silently RAISED any `--sparsity` below the 0.5
+/// `--target-ratio` default — e.g. `--sparsity 0.3` pruned 50%, not 30%, while the output
+/// metadata still stamped `pruning_sparsity = 0.3` (a self-contradicting, over-pruned model).
+fn effective_prune_fraction(target_ratio: f32, sparsity: f32) -> f32 {
+    if sparsity > 0.0 {
+        sparsity
+    } else {
+        target_ratio
+    }
+}
+
 /// Apply the selected pruning method to the tensor map.
 #[allow(clippy::type_complexity)]
 fn apply_pruning(
@@ -295,18 +311,15 @@ fn apply_pruning(
     sparsity: f32,
     remove_layers: Option<&str>,
 ) -> Result<std::collections::BTreeMap<String, (Vec<f32>, Vec<usize>)>> {
+    let frac = effective_prune_fraction(target_ratio, sparsity);
     match prune_method {
-        PruneMethod::Magnitude => Ok(prune_magnitude(tensors, sparsity.max(target_ratio))),
+        PruneMethod::Magnitude => Ok(prune_magnitude(tensors, frac)),
         PruneMethod::Depth => {
             let layers = remove_layers.expect("validated above");
             prune_depth(tensors, layers)
         }
-        PruneMethod::Structured | PruneMethod::Width => {
-            Ok(prune_magnitude(tensors, sparsity.max(target_ratio)))
-        }
-        PruneMethod::Wanda | PruneMethod::SparseGpt => {
-            Ok(prune_magnitude(tensors, sparsity.max(target_ratio)))
-        }
+        PruneMethod::Structured | PruneMethod::Width => Ok(prune_magnitude(tensors, frac)),
+        PruneMethod::Wanda | PruneMethod::SparseGpt => Ok(prune_magnitude(tensors, frac)),
     }
 }
 

--- a/crates/apr-cli/src/commands/prune_include_01.rs
+++ b/crates/apr-cli/src/commands/prune_include_01.rs
@@ -422,4 +422,46 @@ mod tests {
         let meta = std::fs::metadata(output.path()).expect("output exists");
         assert!(meta.len() > 0, "Output file should not be empty");
     }
+
+    /// FALSIFY-PRUNE-SPARSITY-001 (PMAT-830): `--sparsity` below the 0.5 `--target-ratio`
+    /// default was silently raised by `sparsity.max(target_ratio)`, so
+    /// `apr prune --method magnitude --sparsity 0.25` zeroed 50% of weights, not 25% — and
+    /// stamped pruning_sparsity=0.25 into the output (a self-contradicting, over-pruned model).
+    /// Prior tests only used sparsity=0.0, where `0.0.max(0.5) = 0.5` hid the override.
+    #[test]
+    fn test_magnitude_sparsity_below_target_ratio_not_overridden() {
+        let mut writer = aprender::serialization::apr::AprWriter::new();
+        // 64 distinct non-zero magnitudes so the zeroed count == round(64 * fraction).
+        let weights: Vec<f32> = (1..=64).map(|i| i as f32).collect();
+        writer.add_tensor_f32("layers.0.self_attn.q_proj.weight", vec![8, 8], &weights);
+        let bytes = writer.to_bytes().expect("serialize");
+        let input = NamedTempFile::with_suffix(".apr").expect("input");
+        std::fs::write(input.path(), &bytes).expect("write");
+        let output = NamedTempFile::with_suffix(".apr").expect("output");
+
+        // User asks for 25% sparsity; --target-ratio left at its CLI default of 0.5.
+        let r = run(
+            input.path(),
+            "magnitude",
+            0.5,  // target_ratio (default)
+            0.25, // sparsity (explicit user request)
+            Some(output.path()),
+            None,
+            false,
+            false,
+            None,
+            false,
+        );
+        assert!(r.is_ok(), "{:?}", r.err());
+
+        let tensors =
+            aprender::format::converter::load_model_tensors(output.path()).expect("load output");
+        let zeros = tensors["layers.0.self_attn.q_proj.weight"]
+            .0
+            .iter()
+            .filter(|v| **v == 0.0)
+            .count();
+        // EXPECT 16 (25% of 64). RED pre-fix produced 32 (50%) via sparsity.max(0.5).
+        assert_eq!(zeros, 16, "expected 25% pruned (16/64), got {zeros}/64");
+    }
 }


### PR DESCRIPTION
## Root cause (model-ops CLI correctness)

`apr prune`'s `apply_pruning` fed `sparsity.max(target_ratio)` to `prune_magnitude`. The two clap knobs default to `sparsity=0.0` and `target_ratio=0.5`, so any explicit `--sparsity` **below 0.5** (with `--target-ratio` left at default) was silently raised to 0.5:

```
apr prune model.apr --method magnitude --sparsity 0.3 -o out.apr
  → zeroed 50% of weights, not 30%   (0.3.max(0.5) == 0.5)
```

It exited success, printed `Sparsity: 0.30`, and stamped `pruning_sparsity=0.3` into the output metadata — an **over-pruned model whose metadata contradicts what was applied**.

## Why it shipped green

Every magnitude test passed `sparsity=0.0` (where `0.0.max(0.5)=0.5` is the intended value by coincidence). The only non-zero-sparsity tests hit the validation-error or plan-mode paths, which never call `apply_pruning`. No test set `sparsity < target_ratio` and asserted the zeroed-element count.

## Fix + falsifier (RED→GREEN)

`effective_prune_fraction(target_ratio, sparsity)` = `sparsity` when `sparsity > 0`, else `target_ratio` — an explicit `--sparsity` is honored, never raised. Applied to all magnitude-class arms (Magnitude/Structured/Width/Wanda/SparseGpt).

- `test_magnitude_sparsity_below_target_ratio_not_overridden` — 64 distinct magnitudes, `--sparsity 0.25`: **RED** 32/64 zeroed (50%), **GREEN** 16/64 (25%).

Contract `contracts/prune-sparsity-correctness-v1.yaml` (C-PRUNE-001/002, FALSIFY-PRUNE-SPARSITY-001), `pv validate` clean. All 13 prune tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)