### PR TITLE
fix(gbm): GradientBoostingClassifier used a ±1 step not a regression fit — predict_proba saturated (PMAT-831)

### DIFF
--- a/contracts/gbm-v1.yaml
+++ b/contracts/gbm-v1.yaml
@@ -1,5 +1,5 @@
 metadata:
-  version: 1.0.0
+  version: 1.1.0
   created: '2026-02-19'
   author: PAIML Engineering
   description: Gradient Boosting Machine -- sequential ensemble with gradient descent in function space
@@ -71,6 +71,12 @@ proof_obligations:
   property: Training loss non-increasing
   formal: L_m <= L_{m-1} for each boosting round m
   applies_to: all
+- type: bound
+  property: predict_proba calibrates to the base rate (PMAT-831)
+  formal: 'for inputs with identical features and class-1 fraction r in (0,1), predict_proba(x)[1]
+    -> r (not 0/1); the weak learner is a REGRESSION tree fit to the continuous pseudo-residuals
+    y - sigma(F) with leaf = mean residual, NOT a classification tree + constant ±1 step'
+  applies_to: all
 falsification_tests:
 - id: FALSIFY-GBM-001
   rule: Binary prediction
@@ -92,6 +98,15 @@ falsification_tests:
   prediction: Predictions only contain labels seen in training
   test: 'proptest: fit GBM, check prediction set is subset of training label set'
   if_fails: Label encoding error in multi-class or binary mapping
+- id: FALSIFY-GBM-005
+  rule: predict_proba calibrates to base rate (PMAT-831)
+  prediction: 'On 4 identical-feature samples with labels [1,1,1,0], predict_proba(x)[1] ~= 0.75
+    (sklearn GradientBoostingClassifier), NOT ~1.0; the regression-tree weak learner converges
+    raw -> ln(3) so sigma -> 0.75'
+  test: 'cargo test -p aprender-core --lib falsify_gbm_005_proba_calibration_base_rate'
+  if_fails: 'The weak learner fits a classification tree to sign(residual) and adds a fixed ±1
+    step (discarding residual magnitude) — raw_predictions grow unbounded and predict_proba
+    saturates to 0/1 (measured 0.99998) instead of converging to the conditional base rate'
 enforcement:
   binary:
     description: Predictions must be binary
@@ -145,5 +160,5 @@ qa_gate:
   - prediction_deterministic
   - ensemble_output_finite
   - fit_predict_consistency
-  pass_criteria: All 4 falsification tests pass + Kani harnesses verify
+  pass_criteria: All 5 falsification tests pass + Kani harnesses verify
   falsification: Ensemble accumulates Inf after many boosting rounds with large learning rate

--- a/crates/aprender-core/src/tree/gradient_boosting.rs
+++ b/crates/aprender-core/src/tree/gradient_boosting.rs
@@ -2,7 +2,7 @@
 //!
 //! Implements gradient boosting with decision trees as weak learners.
 
-use super::DecisionTreeClassifier;
+use super::DecisionTreeRegressor;
 use crate::error::Result;
 
 /// Gradient Boosting Classifier.
@@ -29,7 +29,7 @@ pub struct GradientBoostingClassifier {
     /// Initial prediction (log-odds for class 1)
     init_prediction: f32,
     /// Ensemble of decision trees
-    estimators: Vec<DecisionTreeClassifier>,
+    estimators: Vec<DecisionTreeRegressor>,
 }
 
 impl GradientBoostingClassifier {
@@ -138,25 +138,16 @@ impl GradientBoostingClassifier {
                 .map(|(&yi, &pi)| yi - pi)
                 .collect();
 
-            // Convert residuals to discrete labels for tree fitting
-            // Positive residual -> predict 1, Negative residual -> predict 0
-            let residual_labels = self.residuals_to_labels(&residuals);
+            // Fit a REGRESSION tree to the CONTINUOUS pseudo-residuals (Friedman 2001
+            // gradient step). The previous code fit a *classification* tree to sign(residual)
+            // and added a fixed ±1 step, discarding the residual magnitude — so raw_predictions
+            // grew without bound and predict_proba saturated to 0/1 instead of converging to
+            // the conditional base rate (measured: P=0.99998 vs the correct 0.75 on a 3:1 split).
+            let mut tree = DecisionTreeRegressor::new().with_max_depth(self.max_depth);
+            tree.fit(x, &crate::primitives::Vector::from_slice(&residuals))?;
 
-            // Fit a tree to the residuals
-            let mut tree = DecisionTreeClassifier::new().with_max_depth(self.max_depth);
-            tree.fit(x, &residual_labels)?;
-
-            // Get tree predictions (these are class labels 0 or 1)
-            let tree_preds = tree.predict(x);
-
-            // Convert tree predictions back to residual estimates
-            // Map 0 -> -1, 1 -> +1 for residual direction
-            let tree_residuals: Vec<f32> = tree_preds
-                .iter()
-                .map(|&pred| if pred == 0 { -1.0 } else { 1.0 })
-                .collect();
-
-            // Update raw predictions
+            // Continuous leaf values (per-leaf mean residual) = the gradient step h_m(x).
+            let tree_residuals = tree.predict(x);
             for i in 0..n_samples {
                 raw_predictions[i] += self.learning_rate * tree_residuals[i];
             }
@@ -165,14 +156,6 @@ impl GradientBoostingClassifier {
         }
 
         Ok(())
-    }
-
-    /// Converts residuals to class labels for tree fitting.
-    ///
-    /// Positive residuals -> class 1, negative residuals -> class 0
-    #[allow(clippy::unused_self)]
-    fn residuals_to_labels(&self, residuals: &[f32]) -> Vec<usize> {
-        residuals.iter().map(|&r| usize::from(r >= 0.0)).collect()
     }
 
     /// Predicts class labels for the given samples.
@@ -213,12 +196,7 @@ impl GradientBoostingClassifier {
 
         // Sum predictions from all trees
         for tree in &self.estimators {
-            let tree_preds = tree.predict(x);
-            let tree_residuals: Vec<f32> = tree_preds
-                .iter()
-                .map(|&pred| if pred == 0 { -1.0 } else { 1.0 })
-                .collect();
-
+            let tree_residuals = tree.predict(x);
             for i in 0..n_samples {
                 raw_predictions[i] += self.learning_rate * tree_residuals[i];
             }
@@ -261,7 +239,7 @@ impl GradientBoostingClassifier {
 
     /// Returns a reference to the estimators.
     #[must_use]
-    pub fn estimators(&self) -> &[DecisionTreeClassifier] {
+    pub fn estimators(&self) -> &[DecisionTreeRegressor] {
         &self.estimators
     }
 }

--- a/crates/aprender-core/src/tree/tests_gbm_contract.rs
+++ b/crates/aprender-core/src/tree/tests_gbm_contract.rs
@@ -113,6 +113,27 @@ fn falsify_gbm_004_better_than_random() {
     );
 }
 
+/// FALSIFY-GBM-005 (PMAT-831): `predict_proba` must converge to the conditional base rate,
+/// not saturate to 0/1. The weak learner previously fit a CLASSIFICATION tree to
+/// sign(residual) and added a fixed ±1 step, discarding residual magnitude → `raw` grew
+/// unbounded → P saturated. On 4 identical-feature samples with labels [1,1,1,0] the
+/// Bayes-optimal P(class=1) is 0.75 (sklearn GradientBoostingClassifier agrees). Every prior
+/// GBM test only checked hard labels on well-separated data, where saturation is invisible.
+#[test]
+fn falsify_gbm_005_proba_calibration_base_rate() {
+    let x = Matrix::from_vec(4, 1, vec![1.0, 1.0, 1.0, 1.0]).expect("valid");
+    let y = vec![1_usize, 1, 1, 0];
+    let mut gbm = GradientBoostingClassifier::new();
+    gbm.fit(&x, &y).expect("fit");
+    let p1 = gbm.predict_proba(&x).expect("proba")[0][1];
+    // sklearn => 0.75; a correct GBM converges to the base rate, never saturating to ~1.0.
+    // RED pre-fix: ~0.99998 (constant ±1 step). GREEN post-fix: ~0.75.
+    assert!(
+        (p1 - 0.75).abs() < 0.10,
+        "GBM predict_proba did not converge to base rate: P(class=1)={p1}, expected ~0.75 (sklearn)"
+    );
+}
+
 mod gbm_proptest_falsify {
     use super::*;
     use proptest::prelude::*;


### PR DESCRIPTION
## Root cause (Pillar-1 sklearn parity — a TOP-10 algorithm)

`GradientBoostingClassifier`'s weak learner fit a **`DecisionTreeClassifier`** to the **sign** of the pseudo-residuals (`residuals_to_labels`: `r>=0 → 1`) and mapped its output to a **fixed ±1 step** (`if pred == 0 { -1.0 } else { 1.0 }`), discarding the residual **magnitude**.

That is not gradient boosting: `h_m` must be a **regression tree fit to the continuous pseudo-residuals** `y − σ(F)` (Friedman 2001, sklearn, and this crate's own `gbm-v1` `negative_gradient` equation).

## Impact

`predict_proba` is uncalibrated and **saturates** whenever the optimal probability isn't ~0/1. On 4 identical-feature samples with labels `[1,1,1,0]` (base rate 0.75): every tree adds a constant `+0.1`, `raw_predictions` grow unbounded → `σ` saturates to 1.0.

```
apr GBM predict_proba P(class=1) = 0.99998     sklearn = 0.75
```

`predict()` (argmax at 0.5) is robust on separable data, so all hard-label tests passed — but every **probability** consumer (calibration, ranking, thresholding, log-loss) gets garbage.

## Why it shipped green

FALSIFY-GBM-001..004 + proptests only assert hard labels ∈ {0,1}, prediction count, exact labels on well-separated clusters, and accuracy>0.5. **None inspects `predict_proba` values**, so a degenerate sign-step ensemble passes them all. (The module comment even flagged: *"Why 5: GBM was 'obviously correct'."*)

## Fix + falsifier (RED→GREEN, sklearn-pinned)

Weak learner is now a `DecisionTreeRegressor` fit to the continuous `residuals`; its per-leaf mean-residual predictions are the gradient step `h_m(x)`. With the existing base-rate init (log-odds of the prior) the ensemble converges `raw → ln(3)`, `σ → 0.75`.

- `falsify_gbm_005_proba_calibration_base_rate` — P(class=1) **0.99998 → 0.75** (±0.10).

Contract `gbm-v1.yaml → 1.1.0` (+ predict_proba-calibration obligation + FALSIFY-GBM-005), `pv validate` clean. All 15 GBM tests pass; separable-data hard-label tests unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)