### PR TITLE
fix(gguf): Q3_K dequant unpacked 6-bit scales as 4-bit — corrupt weights on import (PMAT-832)

### DIFF
--- a/contracts/q3k-dequant-correctness-v1.yaml
+++ b/contracts/q3k-dequant-correctness-v1.yaml
@@ -1,0 +1,46 @@
+metadata:
+  version: "1.0.0"
+  created: "2026-06-18"
+  author: PAIML Engineering
+  registry: true
+  references:
+    - "ggml dequantize_row_q3_K (llama.cpp) — the reference Q3_K dequant algorithm"
+    - "crates/aprender-serve/src/quantize/dequant_q4k.rs::dequantize_q3_k (in-repo correct reference, ported from)"
+  description: |
+    Correctness contract for GGUF Q3_K dequantization in aprender-core's import path
+    (format::gguf::dequantize::dequantize_q3_k). Pillar-4-adjacent (model import correctness):
+    a Q3_K GGUF tensor must dequantize to f32 values matching the GGML reference.
+
+kind: KernelContract
+name: q3k-dequant-correctness
+version: "1.0.0"
+scope: "crates/aprender-core/src/format/gguf/dequantize.rs"
+
+description: |
+  GGML Q3_K stores, per 256-element super-block: a 32-byte high-bit mask, 64 bytes of 2-bit
+  quants, 12 bytes packing 16 SIX-bit signed scales, and an f16 d. PMAT-832 fixed
+  dequantize_q3_k, which (a) unpacked the scales as 16 FOUR-bit values from only 8 of the 12
+  bytes with a -8 offset — clipping the true SIX-bit [-32,31] range to [-8,7] and dropping the
+  upper 2 bits — and (b) used a flat j-in-0..256 quant/high-bit addressing that does not match
+  GGML's two-128-element-half × four-shift-block (0/2/4/6) × two-16-lane-group layout. ~252/256
+  elements were wrong (maxabs ~4.4× too small), silently corrupting every imported Q3_K_S/Q3_K_M
+  model (apr import/convert/tensors/trace). Fix: reconstruct the 16 six-bit scales via the GGML
+  kmask1=0x03030303 / kmask2=0x0f0f0f0f aux shuffle (offset -32) and dequantize with the correct
+  half/shift-block layout (value = d*(scale-32)*(low-high), high = 4 iff the hmask bit is clear).
+
+equations:
+  C-Q3K-001:
+    description: "Q3_K dequant matches the GGML reference element-wise"
+    formula: "|dequantize_q3_k(block)[i] - ggml_q3k(block)[i]| < 1e-3 for all i; e.g. seed-7 block d=1.0 -> out[1] = -84 (not 12), maxabs = 124 (not 28)"
+    note: "16 six-bit scales (aux shuffle, -32 offset); two 128-elem halves, shift 0/2/4/6, hmask bit per block."
+
+  C-Q3K-002:
+    description: "Scales use the full six-bit signed range, not a clipped four-bit nibble"
+    formula: "scale in [-32, 31] (six-bit, offset -32); NOT (nibble & 0x0F) - 8 in [-8, 7]"
+    note: "Regression guard against the 4-bit nibble unpack that dropped the upper 2 bits of 8 of the 12 scale bytes."
+
+falsification:
+  - id: FALSIFY-DEQUANT-Q3K-001
+    description: "Q3_K dequant of a non-trivial block equals the GGML reference. Discharges C-Q3K-001/002."
+    test: "test_dequantize_q3_k_ggml_golden — seed-7 deterministic 110-byte block, d=1.0: RED pre-fix out[1]=12 / maxabs ~28, GREEN post-fix out[1]=-84 / maxabs 124 (numpy GGML oracle). All-zero-input tests cannot distinguish (both yield zeros)."
+    evidence: "cargo test -p aprender-core --lib test_dequantize_q3_k_ggml_golden"

--- a/crates/aprender-core/src/format/gguf/dequant_f16_tests.rs
+++ b/crates/aprender-core/src/format/gguf/dequant_f16_tests.rs
@@ -342,6 +342,54 @@ mod tests {
         assert!(result.is_err());
     }
 
+    /// FALSIFY-DEQUANT-Q3K-001 (PMAT-832): Q3_K dequant must match the GGML reference.
+    /// The prior code unpacked the super-block scales as 16 FOUR-bit values from 8 of the 12
+    /// scale bytes (offset -8), clipping every scale from the true SIX-bit range [-32,31] and
+    /// dropping the upper 2 bits, plus a wrong quant/high-bit addressing — so ~252/256 elements
+    /// were wrong (maxabs 28 vs the correct 124). Both existing Q3_K tests feed ALL-ZERO input,
+    /// where buggy and correct impls both yield zeros (the bug was invisible). Oracle: numpy GGML
+    /// reference (kmask1/kmask2 aux-shuffle, -32 offset, two-half/shift-block layout), seed-7
+    /// deterministic block, d = f16(1.0).
+    #[test]
+    fn test_dequantize_q3_k_ggml_golden() {
+        let hmask: [u8; 32] = [
+            175, 240, 136, 19, 196, 228, 50, 58, 25, 194, 168, 199, 246, 41, 168, 81, 67, 150, 59,
+            112, 211, 208, 108, 250, 151, 3, 53, 185, 103, 54, 161, 116,
+        ];
+        let qs: [u8; 64] = [
+            92, 133, 93, 250, 185, 236, 217, 78, 142, 221, 218, 137, 23, 10, 141, 67, 72, 110, 73,
+            128, 89, 209, 52, 22, 110, 241, 113, 18, 42, 250, 91, 107, 218, 106, 184, 68, 136, 179,
+            18, 4, 167, 76, 248, 127, 230, 151, 27, 135, 68, 4, 226, 173, 176, 197, 105, 222, 127,
+            215, 193, 205, 135, 225, 177, 84,
+        ];
+        let scales: [u8; 12] = [172, 91, 133, 97, 0, 222, 151, 100, 75, 52, 225, 16];
+        let mut block = Vec::with_capacity(110);
+        block.extend_from_slice(&hmask);
+        block.extend_from_slice(&qs);
+        block.extend_from_slice(&scales);
+        block.extend_from_slice(&0x3C00u16.to_le_bytes()); // f16(1.0)
+
+        let out = dequantize_q3_k(&block, 0, 256).expect("dequant");
+        assert_eq!(out.len(), 256);
+        // GGML reference, first 16 (d = 1.0). RED pre-fix: a wrong, ~4.4x-smaller vector.
+        let expected16 = [
+            0.0, -84.0, -84.0, 56.0, -84.0, -112.0, -84.0, -56.0, 56.0, -84.0, -56.0, 28.0, -28.0,
+            56.0, -84.0, 84.0,
+        ];
+        for (i, &e) in expected16.iter().enumerate() {
+            assert!(
+                (out[i] - e).abs() < 1e-3,
+                "elem {i}: got {} expected {e} (GGML reference)",
+                out[i]
+            );
+        }
+        let maxabs = out.iter().fold(0.0f32, |m, &v| m.max(v.abs()));
+        assert!(
+            (maxabs - 124.0).abs() < 1e-2,
+            "maxabs {maxabs} != 124 (GGML); the pre-fix 4-bit-scale bug gives ~28"
+        );
+    }
+
     // =========================================================================
     // Dequantize IQ approximate
     // =========================================================================

--- a/crates/aprender-core/src/format/gguf/dequantize.rs
+++ b/crates/aprender-core/src/format/gguf/dequantize.rs
@@ -180,27 +180,64 @@ pub(crate) fn dequantize_q3_k(data: &[u8], start: usize, num_elements: usize) ->
         let d = safe_f16_scale(u16::from_le_bytes([data[offset], data[offset + 1]]));
         offset += 2;
 
-        // Unpack scales
+        // Reconstruct the 16 SIX-bit signed scales from the 12 packed bytes via the GGML
+        // aux[] shuffle (kmask1/kmask2). The previous code read only the low/high nibbles of
+        // the first 8 bytes — 16 FOUR-bit values with a -8 offset — clipping every scale from
+        // [-32,31] to [-8,7] and dropping the upper 2 bits, so ~252/256 elements were wrong.
+        const KMASK1: u32 = 0x0303_0303;
+        const KMASK2: u32 = 0x0f0f_0f0f;
+        let mut aux = [
+            u32::from_le_bytes([scales_bytes[0], scales_bytes[1], scales_bytes[2], scales_bytes[3]]),
+            u32::from_le_bytes([scales_bytes[4], scales_bytes[5], scales_bytes[6], scales_bytes[7]]),
+            u32::from_le_bytes([
+                scales_bytes[8],
+                scales_bytes[9],
+                scales_bytes[10],
+                scales_bytes[11],
+            ]),
+            0u32,
+        ];
+        let tmp = aux[2];
+        aux[2] = ((aux[0] >> 4) & KMASK2) | (((tmp >> 4) & KMASK1) << 4);
+        aux[3] = ((aux[1] >> 4) & KMASK2) | (((tmp >> 6) & KMASK1) << 4);
+        aux[0] = (aux[0] & KMASK2) | ((tmp & KMASK1) << 4);
+        aux[1] = (aux[1] & KMASK2) | (((tmp >> 2) & KMASK1) << 4);
         let mut scales = [0i8; 16];
-        for i in 0..8 {
-            scales[i] = (scales_bytes[i] & 0x0F) as i8 - 8;
-            scales[i + 8] = (scales_bytes[i] >> 4) as i8 - 8;
+        for (w, word) in aux.iter().enumerate() {
+            for (k, &b) in word.to_le_bytes().iter().enumerate() {
+                scales[w * 4 + k] = b as i8; // 6-bit value; the -32 offset is applied below
+            }
         }
 
-        // Dequantize
-        for j in 0..256 {
-            let sub_block = j / 16;
-            let q_idx = j / 4;
-            let q_shift = (j % 4) * 2;
-            let h_idx = j / 8;
-            let h_shift = j % 8;
-
-            let q_low = (qs[q_idx] >> q_shift) & 0x03;
-            let q_high = ((hmask[h_idx] >> h_shift) & 1) << 2;
-            let q = (q_low | q_high) as i8 - 4;
-
-            result.push(d * f32::from(scales[sub_block]) * f32::from(q));
+        // Dequantize: two 128-element halves (qs advances 32 bytes per half); within a half,
+        // four 32-element shift-blocks (shift = 0,2,4,6) each carrying two 16-lane scale
+        // groups; the high-mask bit `m` advances per shift-block. value = d*(scale-32)*(low-high)
+        // where high = 4 when the hmask bit is CLEAR, else 0.
+        let mut block_out = [0.0f32; 256];
+        let mut m: u32 = 1;
+        let mut is = 0usize;
+        for half in 0..2 {
+            let qs_half = &qs[half * 32..half * 32 + 32];
+            let out_half = half * 128;
+            let mut shift: u32 = 0;
+            for blk in 0..4 {
+                let out_blk = out_half + blk * 32;
+                for scale_index in 0..2 {
+                    let dl = d * (f32::from(scales[is]) - 32.0);
+                    let out_grp = out_blk + scale_index * 16;
+                    for i in 0..16 {
+                        let idx = i + 16 * scale_index;
+                        let low = ((qs_half[idx] >> shift) & 3) as i8;
+                        let high = if u32::from(hmask[idx]) & m == 0 { 4i8 } else { 0i8 };
+                        block_out[out_grp + i] = dl * f32::from(low - high);
+                    }
+                    is += 1;
+                }
+                shift += 2;
+                m <<= 1;
+            }
         }
+        result.extend_from_slice(&block_out);
     }
 
     result.truncate(num_elements);


### PR DESCRIPTION
## Root cause (model-import correctness)

`dequantize_q3_k` unpacked the super-block scales as **16 four-bit values from only 8 of the 12 scale bytes** with a `-8` offset, clipping the true **six-bit** signed range `[-32,31]` to `[-8,7]` and dropping the upper 2 bits — and addressed the 2-bit quants / high-bit mask with a flat `j∈0..256` scheme that doesn't match GGML's **two-128-element-half × four-shift-block (0/2/4/6) × two-16-lane-group** layout. Net: **~252/256 elements wrong**, maxabs ~4.4× too small.

## Impact

`apr import` / `convert` / `tensors` / `trace` on any **Q3_K (Q3_K_S / Q3_K_M)** GGUF dequantizes the weights into garbage — finite, no error, so the model loads and runs but emits incoherent output. Same silent-corruption class as the earlier Q2_K fix in this file; Q3_K_M is a very common quant.

## Why it shipped green

Both Q3_K tests fed **all-zero** 110-byte blocks (`d=0`, `scales=0` → all zeros in buggy *and* correct impls). No value-golden test existed in aprender-core (Q2_K has one; the only Q3_K value-golden lived in the excluded `aprender-serve` crate).

## Fix + falsifier (RED→GREEN, numpy GGML oracle)

Reconstruct the 16 six-bit scales via the GGML `kmask1`/`kmask2` aux shuffle (offset −32) and dequantize with the correct half/shift-block layout (`value = d·(scale−32)·(low−high)`, `high = 4` iff the hmask bit is clear) — ported from the in-repo correct reference (`aprender-serve::dequantize_q3_k`), keeping the `safe_f16_scale` NaN/Inf clamp.

- `test_dequantize_q3_k_ggml_golden` — seed-7 block, d=1.0: **out[1] 12 → −84, maxabs 28 → 124**.

Contract `contracts/q3k-dequant-correctness-v1.yaml` (C-Q3K-001/002, FALSIFY-DEQUANT-Q3K-001), `pv validate` clean. All 5 Q3_K dequant tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)