### PR TITLE
fix(convert): SafeTensors import dropped num_experts/head_dim — MoE models converted to dense (PMAT-833)

### DIFF
--- a/contracts/converter-moe-headdim-import-v1.yaml
+++ b/contracts/converter-moe-headdim-import-v1.yaml
@@ -1,0 +1,40 @@
+metadata:
+  version: "1.0.0"
+  created: "2026-06-18"
+  author: PAIML Engineering
+  registry: true
+  references:
+    - "HuggingFace config.json: num_local_experts/num_experts, num_experts_per_tok, moe_intermediate_size, head_dim"
+    - "crates/aprender-serve safetensors_infer_convert.rs (is_moe = num_experts.is_some()) — the downstream gate this feeds"
+  description: |
+    Correctness contract for the SafeTensors→APR import config loader
+    (format::converter::source_load_result::load_model_config_from_json). Pillar-4-adjacent
+    (model import): the converted .apr metadata must reflect the source config.json architecture.
+kind: KernelContract
+name: converter-moe-headdim-import
+version: "1.0.0"
+scope: "crates/aprender-core/src/format/converter/source_load_result.rs"
+description: |
+  load_model_config_from_json parses HF config.json into GgufModelConfig. PMAT-833 fixed a
+  defect where it hardcoded num_experts=None, num_experts_per_tok=None, moe_intermediate_size=None,
+  and head_dim=None even though these keys are present in config.json and the write path
+  propagates them. Consequence: a MoE SafeTensors model (Mixtral/Qwen3-MoE/DeepSeek-MoE)
+  converted to a DENSE .apr — realizar gates the entire MoE FFN on num_experts.is_some(), so the
+  experts were silently skipped (wrong architecture, garbage output, no error). The dropped
+  explicit head_dim caused realizar to fall back to hidden/heads, computing wrong RoPE/attention
+  dims for models where head_dim != hidden/heads (Qwen3/Gemma2/Phi3). Fix: read all four via the
+  existing json_usize_with_aliases helper (num_local_experts/num_experts/n_routed_experts, etc.).
+equations:
+  C-CONVERT-MOE-001:
+    description: "MoE keys from config.json populate the converted config"
+    formula: "config.json{num_local_experts|num_experts: E, num_experts_per_tok: T} ⇒ cfg.num_experts=Some(E), cfg.num_experts_per_tok=Some(T); NOT None"
+    note: "realizar is_moe = num_experts.is_some(); None ⇒ MoE model decoded as dense."
+  C-CONVERT-MOE-002:
+    description: "Explicit head_dim from config.json is preserved"
+    formula: "config.json{head_dim: H} ⇒ cfg.head_dim=Some(H); NOT None"
+    note: "Dropped head_dim ⇒ realizar falls back to hidden/heads ⇒ wrong RoPE/attention dims (Qwen3/Gemma2/Phi3)."
+falsification:
+  - id: FALSIFY-CONVERT-MOE-HEADDIM-001
+    description: "MoE + head_dim keys are read from config.json, not hardcoded None. Discharges C-CONVERT-MOE-001/002."
+    test: "loads_moe_and_head_dim_from_config — Mixtral-style config.json (num_local_experts=8, num_experts_per_tok=2, head_dim=128): RED pre-fix all None, GREEN post-fix Some(8)/Some(2)/Some(128)."
+    evidence: "cargo test -p aprender-core --lib loads_moe_and_head_dim_from_config"

--- a/crates/aprender-core/src/format/converter/source_load_result.rs
+++ b/crates/aprender-core/src/format/converter/source_load_result.rs
@@ -275,6 +275,18 @@ pub(crate) fn load_model_config_from_json(model_path: &Path) -> Option<GgufModel
     let rope_theta = json_f64_with_aliases(&json, &["rope_theta"], 10000.0);
     let rms_norm_eps = json_f64_with_aliases(&json, CONFIG_ALIASES_NORM_EPS, 1e-6);
 
+    // MoE + explicit head_dim — these are present in HF config.json but were previously
+    // hardcoded to None below, so a MoE SafeTensors model (Mixtral/Qwen3-MoE/DeepSeek-MoE)
+    // silently converted to a DENSE .apr (num_experts=None ⇒ realizar skips the MoE FFN),
+    // and an explicit head_dim was dropped (realizar falls back to hidden/heads → wrong
+    // RoPE/attention dims for Qwen3/Gemma2/Phi3). Read them like every other field.
+    let head_dim = json_usize_with_aliases(&json, &["head_dim"]);
+    let num_experts =
+        json_usize_with_aliases(&json, &["num_local_experts", "num_experts", "n_routed_experts"]);
+    let num_experts_per_tok =
+        json_usize_with_aliases(&json, &["num_experts_per_tok", "num_experts_per_token"]);
+    let moe_intermediate_size = json_usize_with_aliases(&json, &["moe_intermediate_size"]);
+
     let architecture = json
         .get("model_type")
         .and_then(|v| v.as_str())
@@ -318,10 +330,10 @@ pub(crate) fn load_model_config_from_json(model_path: &Path) -> Option<GgufModel
         rope_theta: Some(rope_theta as f32),
         rms_norm_eps: Some(rms_norm_eps as f32),
         rope_type,
-        head_dim: None,
-        num_experts: None,
-        num_experts_per_tok: None,
-        moe_intermediate_size: None,
+        head_dim,
+        num_experts,
+        num_experts_per_tok,
+        moe_intermediate_size,
     })
 }
 
@@ -570,6 +582,41 @@ mod load_model_config_from_json_tests {
         assert_eq!(cfg.architecture.as_deref(), Some("qwen2"));
         assert_eq!(cfg.hf_architecture.as_deref(), Some("Qwen2ForCausalLM"));
         assert_eq!(cfg.hf_model_type.as_deref(), Some("qwen2"));
+    }
+
+    /// FALSIFY-CONVERT-MOE-HEADDIM-001 (PMAT-833): `load_model_config_from_json` MUST read the
+    /// MoE keys (num_experts / num_experts_per_tok / moe_intermediate_size) and an explicit
+    /// `head_dim` from config.json. They were hardcoded to None, so a MoE SafeTensors model
+    /// (Mixtral / Qwen3-MoE / DeepSeek-MoE) silently converted to a DENSE .apr (realizar gates
+    /// the MoE FFN on `num_experts.is_some()`), and an explicit `head_dim` was dropped (realizar
+    /// falls back to hidden/heads → wrong RoPE/attention dims for Qwen3/Gemma2/Phi3).
+    #[test]
+    fn loads_moe_and_head_dim_from_config() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let model_path = tmp.path().join("model.safetensors");
+        let config_path = tmp.path().join("config.json");
+        let config_json = serde_json::json!({
+            "model_type": "mixtral",
+            "architectures": ["MixtralForCausalLM"],
+            "hidden_size": 4096,
+            "num_hidden_layers": 32,
+            "num_attention_heads": 32,
+            "num_key_value_heads": 8,
+            "vocab_size": 32000,
+            "intermediate_size": 14336,
+            "num_local_experts": 8,
+            "num_experts_per_tok": 2,
+            "head_dim": 128,
+        });
+        let mut f = std::fs::File::create(&config_path).expect("create config.json");
+        f.write_all(config_json.to_string().as_bytes())
+            .expect("write config.json");
+
+        let cfg = load_model_config_from_json(&model_path).expect("config");
+        // RED pre-fix: all None (hardcoded). GREEN post-fix: read from config.json.
+        assert_eq!(cfg.num_experts, Some(8), "num_experts dropped → MoE model silently dense");
+        assert_eq!(cfg.num_experts_per_tok, Some(2));
+        assert_eq!(cfg.head_dim, Some(128), "head_dim dropped → wrong RoPE/attention dims");
     }
 
     /// PMAT-690 P0-K: empty/missing `architectures` array means


### PR DESCRIPTION
## Root cause (model-import correctness)

`load_model_config_from_json` parses ~12 keys from HF `config.json` but then **hardcoded** `head_dim=None, num_experts=None, num_experts_per_tok=None, moe_intermediate_size=None` — even though these keys are present in `config.json` and the APR write path explicitly propagates them (`write.rs: num_experts: model_config.and_then(|c| c.num_experts)`, dead for SafeTensors).

## Impact

`apr convert model.safetensors` / `apr import` on a **MoE** model (Mixtral, Qwen3-MoE, DeepSeek-MoE) produces an APR with `num_experts=None`. realizar gates the entire MoE FFN on `is_moe = config.num_experts.is_some()`, so the experts are **silently skipped** — the `.apr` is decoded as a **dense** model (wrong architecture, garbage / no-MoE output), no error. The dropped explicit `head_dim` makes realizar fall back to hidden/heads (the GH-479 hazard), computing **wrong RoPE/attention dims** for models where `head_dim != hidden/heads` (Qwen3, Gemma2, Phi3).

## Why it shipped green

The converter test suite only exercises dense models; the fields default to `None`, the struct constructs, the APR writes fine — the bug only manifests at inference on a MoE/explicit-head_dim model, which import tests never covered.

## Fix + falsifier (RED→GREEN)

Read all four via the existing `json_usize_with_aliases` helper (`num_local_experts`/`num_experts`/`n_routed_experts`; `num_experts_per_tok`; `moe_intermediate_size`; `head_dim`).

- `loads_moe_and_head_dim_from_config` — Mixtral-style config.json: `num_experts` **None→Some(8)**, `num_experts_per_tok` None→Some(2), `head_dim` **None→Some(128)**.

Contract `contracts/converter-moe-headdim-import-v1.yaml` (C-CONVERT-MOE-001/002, FALSIFY-CONVERT-MOE-HEADDIM-001), `pv validate` clean. *(The tensor-inference fallback for the no-config.json case is a separate follow-up.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)