### PR TITLE
fix(arima): forecast for d>=2 re-seeded reverse-differencing with y[n] — wrong forecasts (PMAT-834)

### DIFF
--- a/contracts/arima-v1.yaml
+++ b/contracts/arima-v1.yaml
@@ -1,5 +1,5 @@
 metadata:
-  version: 1.0.0
+  version: 1.1.0
   created: '2026-02-19'
   author: PAIML Engineering
   description: ARIMA -- Autoregressive Integrated Moving Average time series forecasting
@@ -69,6 +69,11 @@ proof_obligations:
   property: Forecast deterministic
   formal: forecast(model, n) = forecast(model, n) for same model and data
   applies_to: all
+- type: invariant
+  property: Reverse-differencing seeds each pass with the matching intermediate difference (PMAT-834)
+  formal: 'for d >= 2, the pass that undoes the k-th difference is seeded with the last value of
+    the (k-1)-th-order difference of y (tail[0] = y[n]); NOT y[n] for every pass'
+  applies_to: all
 falsification_tests:
 - id: FALSIFY-ARIMA-001
   rule: Forecast length
@@ -90,6 +95,15 @@ falsification_tests:
   prediction: forecast(model, n) = forecast(model, n)
   test: 'proptest: forecast twice with same model, compare element-wise'
   if_fails: Non-deterministic state or random initialization leak
+- id: FALSIFY-ARIMA-INTEGRATE-D2
+  rule: Reverse-differencing seeds intermediate differences for d >= 2 (PMAT-834)
+  prediction: 'ARIMA(0,2,0) on the quadratic series [10,20,35,55,80] (constant 2nd difference)
+    forecasts ~110 (continues the parabola). The pre-fix code re-seeded every un-differencing
+    pass with y[n]=80, overshooting to ~165.'
+  test: 'cargo test -p aprender-core --lib falsify_arima_integrate_d2_seeds_intermediate_difference'
+  if_fails: 'Reverse-differencing seeds every pass with y[n] instead of the last value of the
+    corresponding intermediate difference, so every ARIMA forecast with d >= 2 is numerically
+    wrong (the error compounds with the differencing order).'
 enforcement:
   forecast_length:
     description: Forecast must return exactly n_periods values
@@ -143,5 +157,5 @@ qa_gate:
   - forecast_finiteness
   - differencing_length
   - forecast_deterministic
-  pass_criteria: All 4 falsification tests pass + Kani harnesses verify
+  pass_criteria: All 5 falsification tests pass + Kani harnesses verify
   falsification: AR recursion diverges producing Inf/NaN forecasts

--- a/crates/aprender-core/src/time_series/mod.rs
+++ b/crates/aprender-core/src/time_series/mod.rs
@@ -262,11 +262,26 @@ impl ARIMA {
             residual_history.push(0.0); // Assume zero future errors
         }
 
-        // Integrate (reverse differencing)
+        // Integrate (reverse differencing). The forecasts are in d-th-difference space; each
+        // un-differencing pass must be seeded with the last value of the corresponding
+        // INTERMEDIATE differenced series, not y[n] every time. Previously every pass re-seeded
+        // with original_data.last() (= y[n]) — correct only for d == 1. For d >= 2 the pass that
+        // undoes the k-th difference must be seeded with the last value of the (k-1)-th
+        // difference, so the seeding error compounded with each extra differencing order.
+        //
+        // tail[k] = last value of the k-th-order difference of the original data (tail[0] = y[n]).
+        let mut tails = Vec::with_capacity(self.d.max(1));
+        let mut series = original_data.clone();
+        tails.push(series.as_slice().last().copied().unwrap_or(0.0));
+        for _ in 1..self.d {
+            series = Self::difference(&series)?;
+            tails.push(series.as_slice().last().copied().unwrap_or(0.0));
+        }
+        // Undo from the highest difference order downward: undo the d-th difference (seed
+        // tail[d-1]) … finally undo the 1st difference (seed tail[0] = y[n]).
         let mut integrated = forecasts;
-        for _ in 0..self.d {
-            let last_value = original_data.as_slice().last().copied().unwrap_or(0.0);
-            integrated = Self::integrate(&integrated, last_value)?;
+        for k in (0..self.d).rev() {
+            integrated = Self::integrate(&integrated, tails[k])?;
         }
 
         Ok(Vector::from_vec(integrated))

--- a/crates/aprender-core/src/time_series/tests_arima_contract.rs
+++ b/crates/aprender-core/src/time_series/tests_arima_contract.rs
@@ -136,3 +136,24 @@ mod arima_proptest_falsify {
         }
     }
 }
+
+/// FALSIFY-ARIMA-INTEGRATE-D2 (PMAT-834): reverse-differencing for d >= 2 must seed each
+/// un-differencing pass with the last value of the corresponding INTERMEDIATE difference, not
+/// y[n] every time. On a perfectly quadratic series y_t (constant 2nd difference) the 1-step
+/// forecast must continue the parabola; the prior code re-seeded every pass with y[n], so for
+/// d == 2 the forecast overshoots badly. Series [10,20,35,55,80] (1st diffs 10,15,20,25; 2nd
+/// diff constant 5) continues to 110. Pre-fix (both seeds = y[n] = 80) overshoots to ~165.
+#[test]
+fn falsify_arima_integrate_d2_seeds_intermediate_difference() {
+    let data = Vector::from_slice(&[10.0, 20.0, 35.0, 55.0, 80.0]);
+    let mut arima = ARIMA::new(0, 2, 0);
+    arima.fit(&data).expect("fit");
+    let f = arima.forecast(1).expect("forecast");
+    // Correct continuation of the parabola is 110 (next 1st diff 30, plus y[n]=80).
+    // RED pre-fix: ~165 (double-counts y[n]). GREEN post-fix: ~110.
+    assert!(
+        f[0] < 135.0,
+        "ARIMA(0,2,0) forecast {} overshot — reverse-differencing re-seeded with y[n] instead of the last 1st-difference (expected ~110, pre-fix ~165)",
+        f[0]
+    );
+}


### PR DESCRIPTION
## Root cause (Pillar-1 time-series correctness)

`ARIMA::forecast`'s reverse-differencing loop ran `d` times but **re-seeded every pass** with `original_data.last()` (= `y[n]`). That's correct only for `d == 1`. For `d >= 2` the pass that undoes the k-th difference must be seeded with the last value of the **(k-1)-th-order intermediate difference**, not `y[n]` — so undoing the 2nd difference was wrongly seeded with `y[n]` instead of the last first-difference `w[n]=y[n]-y[n-1]`, and the error compounds with each differencing order.

## Impact

Every ARIMA(p,**d≥2**,q) forecast returns finite but numerically wrong values. On the quadratic series `[10,20,35,55,80]` (constant 2nd difference, true continuation **110**), `ARIMA(0,2,0)` forecast returned **165** — a 50% overshoot.

## Why it shipped green

Every ARIMA test used `d=0` or `d=1` (where one pass seeded with `y[n]` is correct) and asserted only length / finiteness / determinism — none pinned a `d≥2` forecast value.

## Fix + falsifier (RED→GREEN)

Precompute `tail[k]` = last value of the k-th-order difference (`tail[0]=y[n]`) and integrate from the highest order downward, seeding the pass that undoes the k-th difference with `tail[k-1]`. `d=0`/`d=1` unchanged.

- `falsify_arima_integrate_d2_seeds_intermediate_difference` — `ARIMA(0,2,0)` on `[10,20,35,55,80]`: forecast **165 → ~110**.

Contract `arima-v1.yaml → 1.1.0` (+ reverse-diff-seeding obligation + FALSIFY-ARIMA-INTEGRATE-D2), `pv validate` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)