### PR TITLE
fix(eval): pass@k inflated under single greedy sample — falsely SotA HumanEval/MBPP (PMAT-835)

### DIFF
--- a/contracts/eval-passk-single-sample-v1.yaml
+++ b/contracts/eval-passk-single-sample-v1.yaml
@@ -1,0 +1,40 @@
+metadata:
+  version: "1.0.0"
+  created: "2026-06-18"
+  author: PAIML Engineering
+  registry: true
+  references:
+    - "Chen et al. (2021) Evaluating Large Language Models Trained on Code — the pass@k estimator 1 - C(n-c,k)/C(n,k)"
+    - "OpenAI/human-eval pass_at_k reference"
+  description: |
+    Correctness contract for HumanEval/MBPP pass@k reporting in `apr eval`
+    (apr-cli commands::eval). Honest-by-design: pass@k under single-sample greedy decoding
+    must equal pass@1, never an inflated value.
+kind: KernelContract
+name: eval-passk-single-sample
+version: "1.0.0"
+scope: "crates/apr-cli/src/commands/eval/code_eval.rs"
+description: |
+  The Chen et al. pass@k estimator 1 - C(n-c,k)/C(n,k) takes n = samples-PER-PROBLEM and
+  c = correct-samples for ONE problem. PMAT-835 fixed compute_multisample_pass_at_k (and the
+  duplicate site print_humaneval_results), which in the num_samples==1 case fed the
+  problem-COUNT (total) and solved-COUNT (passed) into the (n, c) slots. For k>1 this is
+  dimensionally wrong: a model solving 50/164 HumanEval problems with one greedy sample reported
+  pass@1=30.5% (correct) but pass@10=97.7% and pass@100=100% — falsely presenting a mediocre
+  model as SotA in the CI-consumed JSON and the human table. With one deterministic sample per
+  problem, pass@k collapses to pass@1 = passed/total for EVERY k (it cannot exceed pass@1). Fix:
+  return passed/total for all k in the single-sample case. The multi-sample (num_samples>1) path
+  was already correct.
+equations:
+  C-PASSK-001:
+    description: "Single deterministic sample ⇒ pass@k = pass@1 for every k"
+    formula: "num_samples == 1 ⇒ pass@k = passed/total ∀ k; e.g. 50/164 ⇒ 0.3049 for k ∈ {1,10,100}, NOT 0.3049/0.977/1.0"
+    note: "pass@k is non-decreasing in samples; with one sample it cannot exceed pass@1."
+  C-PASSK-002:
+    description: "The per-sample estimator's n slot is samples-per-problem, not problem count"
+    formula: "compute_pass_at_k(n, c, k): n = samples per problem, c = correct samples; NEVER n=total_problems, c=solved_problems"
+falsification:
+  - id: FALSIFY-EVAL-PASSK-SINGLE-SAMPLE
+    description: "Single-sample pass@k collapses to pass@1. Discharges C-PASSK-001/002."
+    test: "single_sample_pass_at_k_collapses_to_pass_at_1 — 164 problems, 50 solved, num_samples=1, k=[1,10,100]: RED pre-fix 0.305/0.977/1.0, GREEN post-fix 0.305 for all."
+    evidence: "cargo test -p apr-cli --lib single_sample_pass_at_k_collapses_to_pass_at_1"

--- a/crates/apr-cli/src/commands/eval/code_eval.rs
+++ b/crates/apr-cli/src/commands/eval/code_eval.rs
@@ -276,8 +276,17 @@ pub(super) fn compute_multisample_pass_at_k(
         .iter()
         .map(|&k| {
             let rate = if num_samples == 1 {
+                // One deterministic (greedy) sample per problem ⇒ pass@k collapses to
+                // pass@1 = fraction of problems solved, for EVERY k. The previous code fed
+                // the problem-count (total) and solved-count (passed) into compute_pass_at_k's
+                // per-sample (n, c) slots — 1 - C(total-passed, k)/C(total, k) — which inflates
+                // pass@10/pass@100 (e.g. 50/164 → 0.977/1.000 instead of the true 0.305).
                 let passed = per_problem_correct.iter().filter(|p| p.2 > 0).count();
-                compute_pass_at_k(total, passed, k)
+                if total == 0 {
+                    0.0
+                } else {
+                    passed as f64 / total as f64
+                }
             } else {
                 let sum: f64 = per_problem_correct
                     .iter()
@@ -462,4 +471,29 @@ pub(super) fn compute_pass_at_k(n: usize, c: usize, k: usize) -> f64 {
         result *= nci / ni;
     }
     1.0 - result
+}
+
+#[cfg(test)]
+mod pass_at_k_tests {
+    use super::*;
+
+    /// FALSIFY-EVAL-PASSK-SINGLE-SAMPLE (PMAT-835): with one deterministic (greedy) sample per
+    /// problem (num_samples == 1), pass@k MUST equal pass@1 = fraction of problems solved for
+    /// EVERY k — it cannot exceed pass@1 under single-sampling. The prior code fed the
+    /// problem-count and solved-count into compute_pass_at_k's per-sample (n, c) slots,
+    /// inflating pass@10/pass@100 (50/164 → 0.977/1.000 instead of the true 0.305).
+    #[test]
+    fn single_sample_pass_at_k_collapses_to_pass_at_1() {
+        // 164 HumanEval-style problems, 50 solved.
+        let problems: Vec<(String, String, usize)> = (0..164)
+            .map(|i| (format!("t{i}"), "ep".to_string(), usize::from(i < 50)))
+            .collect();
+        let expected = 50.0 / 164.0;
+        for (k, rate) in compute_multisample_pass_at_k(&problems, 1, &[1, 10, 100]) {
+            assert!(
+                (rate - expected).abs() < 1e-9,
+                "pass@{k} = {rate}, expected {expected} (single greedy sample) — pre-fix inflated to ~0.98/1.0"
+            );
+        }
+    }
 }

--- a/crates/apr-cli/src/commands/eval/inference.rs
+++ b/crates/apr-cli/src/commands/eval/inference.rs
@@ -10,7 +10,7 @@ use colored::Colorize;
 use std::path::Path;
 use std::time::Instant;
 
-use super::code_eval::{compute_pass_at_k, emit_eval_results, run_multisample_loop};
+use super::code_eval::{emit_eval_results, run_multisample_loop};
 
 // --- HumanEval benchmark evaluation (R-020, survey #62/#69) ---
 
@@ -1403,7 +1403,14 @@ pub(super) fn print_humaneval_results(
 
     println!();
     for &k in k_values {
-        let rate = compute_pass_at_k(total, passed, k);
+        // Single greedy sample per problem ⇒ pass@k = pass@1 = fraction of problems solved,
+        // for every k. compute_pass_at_k(total, passed, k) wrongly fed #problems/#solved into
+        // the per-sample (n, c) slots, inflating pass@10/pass@100 (see compute_multisample_pass_at_k).
+        let rate = if total == 0 {
+            0.0
+        } else {
+            passed as f64 / total as f64
+        };
         output::kv(&format!("pass@{k}"), format!("{:.1}%", rate * 100.0));
     }
     output::kv("Time", format!("{elapsed:.2}s"));


### PR DESCRIPTION
## Root cause (benchmark integrity / honest-by-design)

The Chen et al. pass@k estimator `1 - C(n-c,k)/C(n,k)` takes `n` = samples-**per-problem** and `c` = correct-**samples** for one problem. `compute_multisample_pass_at_k`'s `num_samples == 1` branch fed the **problem-count** (`total`) and **solved-count** (`passed`) into the `(n, c)` slots: `compute_pass_at_k(total, passed, k)`. For `k > 1` that's dimensionally wrong. The duplicate site `print_humaneval_results` made the identical misuse.

## Impact

`apr eval --task humaneval|mbpp` defaults to samples=1, temperature 0.0 (greedy), k=[1,10,100]. A model solving **50/164** HumanEval problems reports:

| metric | reported | correct |
|---|---|---|
| pass@1 | 30.5% | 30.5% ✓ |
| pass@10 | **97.7%** | 30.5% |
| pass@100 | **100.0%** | 30.5% |

Under one deterministic sample per problem, pass@k **cannot exceed pass@1**. The inflated values go to the **CI-consumed JSON** (`build_passk_json`) and the human table — falsely presenting a mediocre model as near-perfect / SotA-competitive.

## Why it shipped green

`compute_multisample_pass_at_k` had **zero tests**; the companion `compute_pass_at_k` is itself correct (and tested), masking the misuse one level up; only pass@1 (correct by coincidence at k=1) was exercised. The wrong k>1 values are plausible percentages — no panic/assert.

## Fix + falsifier (RED→GREEN)

Single-sample case returns `passed/total` for all k (pass@k collapses to pass@1); fixed both sites. Multi-sample path was already correct.

- `single_sample_pass_at_k_collapses_to_pass_at_1` — 164 problems / 50 solved, k=[1,10,100]: **0.305/0.977/1.0 → 0.305 for all k**.

Contract `contracts/eval-passk-single-sample-v1.yaml` (C-PASSK-001/002, FALSIFY-EVAL-PASSK-SINGLE-SAMPLE), `pv validate` clean. 85 eval tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)