### PR TITLE
fix(export): user __metadata__ dropped on every export — wrong APR v2 header offsets (PMAT-836)

### DIFF
--- a/contracts/export-user-metadata-roundtrip-v1.yaml
+++ b/contracts/export-user-metadata-roundtrip-v1.yaml
@@ -1,0 +1,36 @@
+metadata:
+  version: "1.0.0"
+  created: "2026-06-18"
+  author: PAIML Engineering
+  registry: true
+  references:
+    - "crates/aprender-core/src/format/v2/header_impl.rs::to_bytes (the real 64-byte APR v2 header layout)"
+    - "SafeTensors __metadata__ section (the user metadata preserved on import, PMAT-223)"
+  description: |
+    Correctness contract for user-metadata preservation on APR export
+    (format::converter::tensor::extract_user_metadata). Export round-trip fidelity:
+    SafeTensors __metadata__ imported into an APR file must survive re-export.
+kind: KernelContract
+name: export-user-metadata-roundtrip
+version: "1.0.0"
+scope: "crates/aprender-core/src/format/converter/tensor.rs"
+description: |
+  On import (write.rs build_f32_custom_metadata, PMAT-223) the user's SafeTensors __metadata__
+  is preserved into APR metadata.custom["source_metadata"]. PMAT-836 fixed extract_user_metadata,
+  which read the wrong header layout (an 8-byte "metadata_len" at byte 8 and the JSON at byte 16)
+  whereas the real APR v2 header is 64 bytes with metadata_offset (u64 @ 12), metadata_size (u32 @
+  20), and the JSON at metadata_offset (= 64). It also looked for "source_metadata" nested under a
+  "custom" object, but AprV2Metadata.custom is #[serde(flatten)] so the key is top-level. The
+  bounds guard therefore ALWAYS failed → empty result → every `apr export --format safetensors|mlx|
+  gguf` silently DROPPED the user's __metadata__. Fix: read the real header offsets and look at the
+  top level (with a nested fallback).
+equations:
+  C-EXPORT-META-001:
+    description: "User source_metadata survives APR export round-trip"
+    formula: "extract_user_metadata(apr) reads metadata JSON at header.metadata_offset[12..20] for header.metadata_size[20..24] bytes; returns the top-level source_metadata map (non-empty when present)"
+    note: "Real header is 64 bytes; the JSON begins at metadata_offset, NOT byte 16; custom is flattened so source_metadata is top-level."
+falsification:
+  - id: FALSIFY-EXPORT-USERMETA-001
+    description: "extract_user_metadata reads source_metadata from a real v2 header. Discharges C-EXPORT-META-001."
+    test: "reads_source_metadata_from_real_v2_header — 64-byte header (metadata_offset=64, size=len) + JSON {source_metadata:{foo:bar,baz:qux}}: RED pre-fix empty, GREEN post-fix {foo:bar, baz:qux}."
+    evidence: "cargo test -p aprender-core --lib reads_source_metadata_from_real_v2_header"

--- a/crates/aprender-core/src/format/converter/export_tests_infer_attn.rs
+++ b/crates/aprender-core/src/format/converter/export_tests_infer_attn.rs
@@ -177,14 +177,14 @@ fn test_extract_user_metadata_with_source_metadata() {
     let _ = fs::create_dir_all(&dir);
     let path = dir.join("with_meta.apr");
 
-    let json = r#"{"custom":{"source_metadata":{"key1":"val1","key2":"val2"}}}"#;
-    let mut data = Vec::new();
-    data.extend_from_slice(b"APR\x00"); // magic
-    data.extend_from_slice(&2u32.to_le_bytes()); // version
-    let json_bytes = json.as_bytes();
-    let len = json_bytes.len() as u64;
-    data.extend_from_slice(&len.to_le_bytes()); // metadata_len
-    data.extend_from_slice(json_bytes);
+    // Real APR v2 header (64 bytes): metadata_offset u64 @ 12, metadata_size u32 @ 20, JSON @ 64.
+    // source_metadata is at the TOP level (AprV2Metadata.custom is #[serde(flatten)]).
+    let json = r#"{"source_metadata":{"key1":"val1","key2":"val2"}}"#;
+    let mut data = vec![0u8; 64];
+    data[0..4].copy_from_slice(b"APR\x00");
+    data[12..20].copy_from_slice(&64u64.to_le_bytes());
+    data[20..24].copy_from_slice(&(json.len() as u32).to_le_bytes());
+    data.extend_from_slice(json.as_bytes());
 
     fs::write(&path, &data).expect("write failed");
 
@@ -206,14 +206,13 @@ fn test_extract_user_metadata_without_source_metadata() {
     let _ = fs::create_dir_all(&dir);
     let path = dir.join("no_source_meta.apr");
 
-    let json = r#"{"custom":{"other_key":"other_val"}}"#;
-    let mut data = Vec::new();
-    data.extend_from_slice(b"APR\x00");
-    data.extend_from_slice(&2u32.to_le_bytes());
-    let json_bytes = json.as_bytes();
-    let len = json_bytes.len() as u64;
-    data.extend_from_slice(&len.to_le_bytes());
-    data.extend_from_slice(json_bytes);
+    // Real APR v2 header; no source_metadata present ⇒ empty result.
+    let json = r#"{"other_key":"other_val"}"#;
+    let mut data = vec![0u8; 64];
+    data[0..4].copy_from_slice(b"APR\x00");
+    data[12..20].copy_from_slice(&64u64.to_le_bytes());
+    data[20..24].copy_from_slice(&(json.len() as u32).to_le_bytes());
+    data.extend_from_slice(json.as_bytes());
 
     fs::write(&path, &data).expect("write failed");
 
@@ -233,14 +232,13 @@ fn test_extract_user_metadata_non_string_values_skipped() {
     let _ = fs::create_dir_all(&dir);
     let path = dir.join("mixed_types.apr");
 
-    let json = r#"{"custom":{"source_metadata":{"str_key":"str_val","num_key":42,"bool_key":true,"null_key":null}}}"#;
-    let mut data = Vec::new();
-    data.extend_from_slice(b"APR\x00");
-    data.extend_from_slice(&2u32.to_le_bytes());
-    let json_bytes = json.as_bytes();
-    let len = json_bytes.len() as u64;
-    data.extend_from_slice(&len.to_le_bytes());
-    data.extend_from_slice(json_bytes);
+    // Real APR v2 header; top-level source_metadata with mixed value types.
+    let json = r#"{"source_metadata":{"str_key":"str_val","num_key":42,"bool_key":true,"null_key":null}}"#;
+    let mut data = vec![0u8; 64];
+    data[0..4].copy_from_slice(b"APR\x00");
+    data[12..20].copy_from_slice(&64u64.to_le_bytes());
+    data[20..24].copy_from_slice(&(json.len() as u32).to_le_bytes());
+    data.extend_from_slice(json.as_bytes());
 
     fs::write(&path, &data).expect("write failed");
 

--- a/crates/aprender-core/src/format/converter/tensor.rs
+++ b/crates/aprender-core/src/format/converter/tensor.rs
@@ -391,18 +391,23 @@ fn extract_user_metadata(apr_path: &Path) -> UserMetadata {
         Err(_) => return UserMetadata::new(),
     };
 
-    // APR v2 format: magic(4) + version(4) + metadata_len(8) + metadata_json
-    if data.len() < 16 {
+    // Real APR v2 header (header_impl.rs::to_bytes, 64 bytes): magic[0..4], version[4..6],
+    // flags[6..8], tensor_count u32 [8..12], metadata_offset u64 [12..20], metadata_size u32
+    // [20..24]; the metadata JSON begins at `metadata_offset` (= HEADER_SIZE_V2 = 64). The prior
+    // code read an 8-byte "metadata_len" at byte 8 (= tensor_count | metadata_offset<<32 ≈ 2.7e11)
+    // and the JSON at byte 16, so the bounds guard ALWAYS failed and this returned empty — silently
+    // dropping the user's SafeTensors __metadata__ on every `apr export`.
+    if data.len() < 24 {
         return UserMetadata::new();
     }
+    let metadata_offset = u64::from_le_bytes(data[12..20].try_into().unwrap_or([0u8; 8])) as usize;
+    let metadata_size = u32::from_le_bytes(data[20..24].try_into().unwrap_or([0u8; 4])) as usize;
+    let end = match metadata_offset.checked_add(metadata_size) {
+        Some(e) if e <= data.len() => e,
+        _ => return UserMetadata::new(),
+    };
 
-    let metadata_len = u64::from_le_bytes(data[8..16].try_into().unwrap_or([0u8; 8])) as usize;
-
-    if data.len() < 16 + metadata_len {
-        return UserMetadata::new();
-    }
-
-    let metadata_json = match std::str::from_utf8(&data[16..16 + metadata_len]) {
+    let metadata_json = match std::str::from_utf8(&data[metadata_offset..end]) {
         Ok(s) => s,
         Err(_) => return UserMetadata::new(),
     };
@@ -412,10 +417,12 @@ fn extract_user_metadata(apr_path: &Path) -> UserMetadata {
         Err(_) => return UserMetadata::new(),
     };
 
-    // Look for custom.source_metadata
-    if let Some(serde_json::Value::Object(map)) =
-        parsed.get("custom").and_then(|c| c.get("source_metadata"))
-    {
+    // `custom` is #[serde(flatten)] in AprV2Metadata, so "source_metadata" is at the TOP level
+    // of the metadata JSON (not nested under a "custom" object). Accept both for robustness.
+    let source = parsed
+        .get("source_metadata")
+        .or_else(|| parsed.get("custom").and_then(|c| c.get("source_metadata")));
+    if let Some(serde_json::Value::Object(map)) = source {
         let mut result = UserMetadata::new();
         for (k, v) in map {
             if let serde_json::Value::String(s) = v {
@@ -468,4 +475,36 @@ pub(crate) fn detect_apr_quantization(apr_path: &Path) -> Option<QuantizationTyp
 
     // Q6K not yet in QuantizationType — treat as no auto-detect
     None
+}
+
+#[cfg(test)]
+mod extract_user_metadata_tests {
+    use super::*;
+
+    /// FALSIFY-EXPORT-USERMETA-001 (PMAT-836): extract_user_metadata must read the REAL APR v2
+    /// header — metadata_offset (u64 @ byte 12), metadata_size (u32 @ byte 20), JSON at
+    /// metadata_offset — and find "source_metadata" at the TOP level (AprV2Metadata.custom is
+    /// #[serde(flatten)]). The prior code read an 8-byte length at byte 8 and the JSON at byte
+    /// 16, so the bounds guard always failed and it returned empty — silently dropping the user's
+    /// SafeTensors __metadata__ on every `apr export`.
+    #[test]
+    fn reads_source_metadata_from_real_v2_header() {
+        let json = r#"{"source_metadata":{"foo":"bar","baz":"qux"}}"#;
+        let mut data = vec![0u8; 64]; // HEADER_SIZE_V2
+        data[12..20].copy_from_slice(&64u64.to_le_bytes()); // metadata_offset
+        data[20..24].copy_from_slice(&(json.len() as u32).to_le_bytes()); // metadata_size
+        data.extend_from_slice(json.as_bytes());
+
+        let tmp = tempfile::NamedTempFile::with_suffix(".apr").expect("tmp");
+        std::fs::write(tmp.path(), &data).expect("write apr");
+
+        let meta = extract_user_metadata(tmp.path());
+        // RED pre-fix: empty (wrong offsets). GREEN post-fix: both source_metadata entries.
+        assert_eq!(
+            meta.get("foo").map(String::as_str),
+            Some("bar"),
+            "source_metadata dropped on export"
+        );
+        assert_eq!(meta.get("baz").map(String::as_str), Some("qux"));
+    }
 }


### PR DESCRIPTION
## Root cause (export round-trip fidelity)

`extract_user_metadata` read a **fabricated header layout** — an 8-byte "metadata_len" at byte 8 and the JSON at byte 16. The **real** APR v2 header (`header_impl.rs::to_bytes`) is 64 bytes: `tensor_count` u32 @ 8, `metadata_offset` u64 @ 12, `metadata_size` u32 @ 20, JSON at `metadata_offset` (= 64). Reading `data[8..16]` yields `tensor_count | (64<<32)` ≈ 2.7e11, so the bounds guard was **always** true → returned empty. It also looked for `source_metadata` nested under a `"custom"` object, but `AprV2Metadata.custom` is `#[serde(flatten)]` → the key is top-level.

## Impact

On every APR-source `apr export --format safetensors|mlx|gguf`, the user's original SafeTensors `__metadata__` was **silently dropped**. The import path (PMAT-223) correctly preserves it into APR `custom["source_metadata"]`, but `extract_user_metadata` always returned empty → exports wrote no `__metadata__`. Silent round-trip fidelity loss, no error.

## Fix + falsifier (RED→GREEN)

Read `metadata_offset` (u64 @ 12) + `metadata_size` (u32 @ 20), slice the JSON at `metadata_offset`, and look for `source_metadata` at the top level (nested fallback retained).

- `reads_source_metadata_from_real_v2_header` — 64-byte header + `{source_metadata:{foo:bar,baz:qux}}`: **empty → {foo:bar, baz:qux}**.

Contract `contracts/export-user-metadata-roundtrip-v1.yaml` (C-EXPORT-META-001, FALSIFY-EXPORT-USERMETA-001), `pv validate` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)