### PR TITLE
fix(serve): GPT-2 byte-level BPE decode mangled all non-ASCII output (PMAT-837)

### DIFF
--- a/contracts/gpt2-bpe-decode-roundtrip-v1.yaml
+++ b/contracts/gpt2-bpe-decode-roundtrip-v1.yaml
@@ -1,0 +1,40 @@
+metadata:
+  version: "1.0.0"
+  created: "2026-06-19"
+  author: PAIML Engineering
+  registry: true
+  references:
+    - "HuggingFace GPT-2 bytes_to_unicode / byte_decoder (the reference byte-level-BPE map)"
+    - "crates/aprender-serve/src/gguf/utils.rs::gpt2_unicode_to_byte (the in-crate correct inverse)"
+  description: |
+    Correctness contract for GPT-2 byte-level BPE decoding in the serve tokenizer
+    (aprender-serve BPETokenizer::decode). Pillar-4 (Ollama/serve) correctness: non-ASCII
+    generated text must decode to the real characters, not mojibake.
+kind: KernelContract
+name: gpt2-bpe-decode-roundtrip
+version: "1.0.0"
+scope: "crates/aprender-serve/src/tokenizer.rs"
+description: |
+  GPT-2 byte-level BPE maps each of the 256 bytes to a printable unicode codepoint; decode must
+  invert that map. PMAT-837 fixed BPETokenizer::gpt2_char_to_byte, which treated the U+0100..
+  region as a LINEAR `code - 0x100` offset (accepting only 0..=32 | 127..=160 | 173) and omitted
+  the Latin-1 self-mapped bytes entirely. GPT-2's byte_encoder above U+0120 is a STAIRCASE
+  (U+0121→0x7F, U+0122..=U+0142→0x80..=0xA0, U+0143→0xAD), and bytes 0xA1..=0xFF map to themselves.
+  So 129 of 256 byte values returned None and decode() re-encoded the codepoint as multi-byte
+  UTF-8 — turning every non-ASCII generation from a GPT-2 / byte-level-BPE model into mojibake
+  (中 → "ä¸Ń") on the OpenAI-compatible serve path. Fix: delegate to the correct in-crate inverse
+  map gguf::utils::gpt2_unicode_to_byte.
+equations:
+  C-GPT2BPE-001:
+    description: "Every byte 0..=255 round-trips through the GPT-2 byte-level map"
+    formula: "∀ b in 0..=255: gpt2_char_to_byte(byte_encoder(b)) == Some(b); e.g. U+0121→0x7F, U+0143→0xAD, U+00E9→0xE9 (NOT None)"
+    note: "The staircase (U+0121..U+0143) and the Latin-1 self-mapped region (cp ≤ 0xFF) must both invert."
+  C-GPT2BPE-002:
+    description: "Non-ASCII generated text decodes to the real characters, not mojibake"
+    formula: "decode(byte_level_glyphs(中)) == \"中\"; NOT the UTF-8-re-encoded \"ä¸Ń\""
+    note: "decode must not fall through to char::encode_utf8 for a remapped byte glyph."
+falsification:
+  - id: FALSIFY-TOKENIZER-GPT2-NONASCII
+    description: "GPT-2 byte-level decode round-trips a non-ASCII char. Discharges C-GPT2BPE-001/002."
+    test: "falsify_gpt2_decode_non_ascii_roundtrip — vocab ['ä','¸','Ń'] (bytes 0xE4,0xB8,0xAD) decodes to 中: RED pre-fix 'ä¸Ń' (mojibake), GREEN post-fix '中'."
+    evidence: "cargo test -p aprender-serve --lib falsify_gpt2_decode_non_ascii_roundtrip"

--- a/crates/aprender-serve/src/tokenizer.rs
+++ b/crates/aprender-serve/src/tokenizer.rs
@@ -404,27 +404,17 @@ impl BPETokenizer {
         Ok(result)
     }
 
-    /// Convert GPT-2 unicode character to original byte value
+    /// Convert a GPT-2 byte-level-BPE unicode character back to its original byte.
+    ///
+    /// PMAT-837: the prior body treated the U+0100.. region as a LINEAR `code - 0x100`
+    /// offset and only accepted `0..=32 | 127..=160 | 173`. GPT-2's byte_encoder above
+    /// U+0120 is a STAIRCASE (U+0121→0x7F, U+0122..=U+0142→0x80..=0xA0, U+0143→0xAD), and
+    /// the Latin-1 self-mapped bytes (cp ≤ 0xFF) were omitted entirely — so 129/256 byte
+    /// values returned None and `decode` re-encoded the codepoint as multi-byte UTF-8,
+    /// turning every non-ASCII generation into mojibake. Delegate to the correct in-crate
+    /// inverse map (the GGUF path's `gpt2_unicode_to_byte`).
     fn gpt2_char_to_byte(c: char) -> Option<u8> {
-        // GPT-2 maps bytes 0-255 to unicode characters
-        // Printable ASCII (33-126) maps to itself
-        // Other bytes map to unicode range starting at U+0100
-        let code = c as u32;
-        if (33..=126).contains(&code) || code == 32 {
-            Some(code as u8)
-        } else if (0x100..=0x100 + 255).contains(&code) {
-            // GPT-2 remapped bytes
-            let byte = (code - 0x100) as u8;
-            // Map back based on GPT-2's byte_encoder
-            match byte {
-                0..=32 => Some(byte),    // Control chars + space
-                127..=160 => Some(byte), // DEL + extended ASCII
-                173 => Some(173),        // Soft hyphen
-                _ => None,
-            }
-        } else {
-            None
-        }
+        crate::gguf::utils::gpt2_unicode_to_byte(c)
     }
 
     /// Get vocabulary size (cached, O(1))

--- a/crates/aprender-serve/src/tokenizer_sentencepiece_encode.rs
+++ b/crates/aprender-serve/src/tokenizer_sentencepiece_encode.rs
@@ -211,6 +211,26 @@ mod tests {
         assert_eq!(decoded, " a");
     }
 
+    /// FALSIFY-TOKENIZER-GPT2-NONASCII (PMAT-837): GPT-2 byte-level-BPE decode must round-trip
+    /// non-ASCII. The CJK char 中 is UTF-8 [0xE4, 0xB8, 0xAD], stored byte-level as the glyphs
+    /// 'ä' (U+00E4, byte 0xE4), '¸' (U+00B8, byte 0xB8), 'Ń' (U+0143, the staircase glyph for
+    /// byte 0xAD). The buggy gpt2_char_to_byte returned None for all three (Latin-1 omitted +
+    /// linear-offset staircase), so decode re-encoded each codepoint as multi-byte UTF-8 →
+    /// mojibake instead of "中". 129/256 byte values were affected.
+    #[test]
+    fn falsify_gpt2_decode_non_ascii_roundtrip() {
+        let vocab = vec![
+            "<unk>".to_string(),
+            "\u{00E4}".to_string(), // byte 0xE4
+            "\u{00B8}".to_string(), // byte 0xB8
+            "\u{0143}".to_string(), // byte 0xAD (GPT-2 staircase)
+        ];
+        let tok = BPETokenizer::new(vocab, vec![], "<unk>").expect("tokenizer");
+        let decoded = tok.decode(&[1, 2, 3]).expect("decode");
+        // RED pre-fix: mojibake (the codepoints re-encoded as UTF-8). GREEN: the real char.
+        assert_eq!(decoded, "\u{4E2D}", "GPT-2 byte-level decode produced mojibake for non-ASCII");
+    }
+
     #[test]
     fn test_sentencepiece_vocab_size() {
         let vocab = vec![


### PR DESCRIPTION
## Pillar-4 (serve / Ollama) correctness — beat #11 for 0.50.0

`BPETokenizer::gpt2_char_to_byte` inverted the GPT-2 byte-level map with a **linear `code - 0x100` offset** (accepting only `0..=32 | 127..=160 | 173`) and **omitted the Latin-1 self-mapped bytes** entirely. GPT-2's `byte_encoder` above U+0120 is a **staircase** (U+0121→0x7F, U+0122..=U+0142→0x80..=0xA0, U+0143→0xAD) and bytes 0xA1..=0xFF map to themselves.

**Impact:** 129 of 256 byte values returned `None`, so `decode()` re-encoded the codepoint as multi-byte UTF-8 — turning **every non-ASCII generation** from a GPT-2 / byte-level-BPE model into mojibake (中 → `ä¸Ń`) on the OpenAI-compatible HTTP serve path (`openai_handlers.rs`, streaming, cuda/batch backends). The corruption is valid-but-wrong UTF-8 (not U+FFFD), so the PMAT-758 multibyte streaming guard does not mask it.

**Why green:** every `decode` test used pure ASCII (`"hello world"`), which lives in the fast arm. No test exercised any byte in 0x7F–0xFF. The correct twin (`gguf/utils.rs::gpt2_unicode_to_byte`, with its own passing tests) was never compared.

**Fix:** delegate to the correct in-crate inverse map.

**Falsifier** (`falsify_gpt2_decode_non_ascii_roundtrip`): decode the byte-level glyphs for 中 → RED `"ä¸Ń"`, GREEN `"中"` (proven RED-on-bug / GREEN-on-fix locally).

Contract: `gpt2-bpe-decode-roundtrip-v1` (C-GPT2BPE-001/002, `pv`-validated). Found by the release-day Pillar-4 sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)