### PR TITLE
fix(glm): IRLS swapped link/inverse-link derivative — wrong GLM coefficients (PMAT-838)

### DIFF
--- a/contracts/glm-irls-link-derivative-v1.yaml
+++ b/contracts/glm-irls-link-derivative-v1.yaml
@@ -1,0 +1,39 @@
+metadata:
+  version: "1.0.0"
+  created: "2026-06-19"
+  author: PAIML Engineering
+  registry: true
+  references:
+    - "McCullagh & Nelder, Generalized Linear Models (2nd ed.) — IRLS working response & weights"
+    - "statsmodels.genmod.GLM / scipy reference IRLS"
+  description: |
+    Correctness contract for the GLM IRLS solver (aprender-core glm). Pillar-1 (sklearn/statsmodels
+    parity): GLM::fit must converge to the correct maximum-likelihood coefficients for the
+    exponential family.
+kind: KernelContract
+name: glm-irls-link-derivative
+version: "1.0.0"
+scope: "crates/aprender-core/src/glm/mod.rs"
+description: |
+  Iteratively Reweighted Least Squares (IRLS) forms a working response z and weights W each step:
+  z = η + (y - μ)·g'(μ) and W = 1/(V(μ)·g'(μ)²), where g'(μ) = dη/dμ is the LINK derivative.
+  PMAT-838: `Link::derivative` returns the INVERSE-link derivative dμ/dη (its own doc says
+  "Derivative of inverse link: dμ/dη"; Log→exp(η)=μ, Logit→μ(1-μ)). compute_working_response_and_weights
+  used that value directly for g'(μ), swapping dμ/dη and dη/dμ in BOTH z and W. Result: fit
+  converged to systematically wrong coefficients (Binomial/logit slope 1.0333 vs correct 1.1266,
+  ~8% error; predicted probabilities ~18% off) and diverged outright for strong-signal Poisson.
+  Fix: use g'(μ) = 1/(dμ/dη) (guarding the boundary dμ/dη → 0).
+equations:
+  C-GLMIRLS-001:
+    description: "IRLS uses the link derivative dη/dμ = 1/(dμ/dη), not the inverse-link derivative"
+    formula: "z = η + (y-μ)/(dμ/dη);  W = 1/(V(μ)·(1/(dμ/dη))²) = (dμ/dη)²/V(μ)"
+    note: "Link::derivative returns dμ/dη; the IRLS update must invert it."
+  C-GLMIRLS-002:
+    description: "GLM::fit recovers the correct MLE coefficients on a known logistic fit"
+    formula: "Binomial/logit on x=[-2..2], y=[0.1..0.9] ⇒ slope ≈ 1.1266, P(y|x=-2) ≈ 0.0951"
+    note: "The link-derivative swap yields slope 1.0333 / P 0.1124."
+falsification:
+  - id: FALSIFY-GLM-IRLS-LINK-DERIV
+    description: "GLM IRLS converges to the correct logistic coefficients. Discharges C-GLMIRLS-001/002."
+    test: "falsify_glm_irls_link_derivative — Binomial/logit fit: RED slope 1.0333 / P 0.1124, GREEN slope 1.1266 / P 0.0951."
+    evidence: "cargo test -p aprender-core --lib falsify_glm_irls_link_derivative"

--- a/crates/aprender-core/src/glm/glm_tests.rs
+++ b/crates/aprender-core/src/glm/glm_tests.rs
@@ -270,3 +270,29 @@ fn test_builder_pattern() {
     assert!(model.coefficients().is_none());
     assert!(model.intercept().is_none());
 }
+
+/// FALSIFY-GLM-IRLS-LINK-DERIV (PMAT-838): IRLS must use the LINK derivative g'(μ) = dη/dμ =
+/// 1/(dμ/dη) in the working response and weights, NOT the inverse-link derivative dμ/dη.
+/// With the two swapped, Binomial/logit on this data converged to slope 1.0333 (8.3% low) and
+/// P(y=1 | x=-2) = 0.1124; the correct IRLS (matching a statsmodels/scipy reference) gives
+/// slope 1.1266 and P = 0.0951.
+#[test]
+fn falsify_glm_irls_link_derivative() {
+    let x =
+        Matrix::from_vec(8, 1, vec![-2.0, -1.5, -1.0, -0.5, 0.5, 1.0, 1.5, 2.0]).expect("matrix");
+    let y = Vector::from_vec(vec![0.1, 0.15, 0.25, 0.35, 0.65, 0.75, 0.85, 0.9]);
+    let mut model = GLM::new(Family::Binomial);
+    model.fit(&x, &y).expect("fit");
+    let slope = model.coefficients().expect("coef")[0];
+    let p_at_neg2 = model.predict(&x).expect("predict").as_slice()[0];
+    // RED (link/inverse-link swapped): slope ~1.0333, P ~0.1124.
+    // GREEN (correct IRLS): slope ~1.1266, P ~0.0951.
+    assert!(
+        (slope - 1.1266).abs() < 0.01,
+        "GLM IRLS slope {slope:.4} != correct 1.1266 (link-derivative swap?)"
+    );
+    assert!(
+        (p_at_neg2 - 0.0951).abs() < 0.005,
+        "GLM predicted P(x=-2) {p_at_neg2:.4} != correct 0.0951"
+    );
+}

--- a/crates/aprender-core/src/glm/mod.rs
+++ b/crates/aprender-core/src/glm/mod.rs
@@ -392,7 +392,19 @@ impl GLM {
         let mut z = Vec::with_capacity(n);
         let mut weights = Vec::with_capacity(n);
         for i in 0..n {
-            let deriv = self.link.derivative(eta[i]);
+            // IRLS uses the LINK derivative g'(μ) = dη/dμ, which is 1/(dμ/dη). `Link::derivative`
+            // returns the INVERSE-link derivative dμ/dη (its own doc says so), so it must be
+            // inverted here. PMAT-838: the prior code used dμ/dη directly in both the working
+            // response (z = η + (y-μ)·g'(μ)) and the weight (W = 1/(V·g'(μ)²)), swapping dμ/dη and
+            // dη/dμ — so `fit` converged to systematically wrong coefficients (and diverged for
+            // strong-signal Poisson). Guard the boundary where dμ/dη → 0 (e.g. logit at μ=0/1).
+            let dmu_deta = self.link.derivative(eta[i]);
+            let deriv = 1.0
+                / if dmu_deta.abs() < 1e-10 {
+                    1e-10_f32.copysign(dmu_deta)
+                } else {
+                    dmu_deta
+                };
             z.push(eta[i] + (y[i] - mu[i]) * deriv);
 
             let var = self.family.variance(mu[i], self.dispersion).max(1e-10);


### PR DESCRIPTION
## Pillar-1 (sklearn/statsmodels parity) correctness — beat #12 for 0.50.0

The GLM IRLS solver used the **inverse-link** derivative dμ/dη where the **link** derivative g'(μ) = dη/dμ = 1/(dμ/dη) is required, in **both** the working response and the weights:

```
z = η + (y-μ)·g'(μ)      W = 1/(V(μ)·g'(μ)²)
```

`Link::derivative` returns dμ/dη (its own doc: *"Derivative of inverse link: dμ/dη"* — Log→exp(η), Logit→μ(1-μ)), but `compute_working_response_and_weights` fed it straight in as g'(μ), swapping dμ/dη and dη/dμ.

**Impact:** `GLM::fit` converged to systematically wrong coefficients — Binomial/logit on the shipped test data gives slope **1.0333** vs the correct **1.1266** (~8% error), predicted probabilities ~18% off — and **diverged outright** for strong-signal Poisson. `predict`/`coefficients`/`intercept` all biased.

**Why green:** all 21 GLM tests assert only shape/sign (predictions in [0,1], `fit().is_ok()`), never an exact coefficient — so the wrong fit shipped green.

**Fix:** use g'(μ) = 1/(dμ/dη), guarding the boundary where dμ/dη → 0.

**Falsifier** (`falsify_glm_irls_link_derivative`): Binomial/logit fit → RED slope 1.0333 / P(x=-2) 0.1124, GREEN slope 1.1266 / P 0.0951 (proven RED-on-bug / GREEN-on-fix; measured value matches the statsmodels reference exactly).

Contract: `glm-irls-link-derivative-v1` (C-GLMIRLS-001/002, `pv`-validated). Found by the release-day sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)