### PR TITLE
fix(train): gradient accumulation stepped on SUM not MEAN — K-fold LR inflation (PMAT-839)

### DIFF
--- a/contracts/gradient-accumulation-mean-v1.yaml
+++ b/contracts/gradient-accumulation-mean-v1.yaml
@@ -1,0 +1,42 @@
+metadata:
+  version: "1.0.0"
+  created: "2026-06-19"
+  author: PAIML Engineering
+  registry: true
+  references:
+    - "PyTorch gradient accumulation convention: loss = loss / accumulation_steps before backward"
+    - "crates/aprender-train/src/train/config.rs:27 (Effective batch size = batch_size * gradient_accumulation_steps)"
+  description: |
+    Correctness contract for gradient accumulation in the aprender-train Trainer. Pillar-2/3
+    (PyTorch/Unsloth training parity): K-step accumulation must reproduce a single batch of the
+    effective size, not inflate the effective learning rate.
+kind: KernelContract
+name: gradient-accumulation-mean
+version: "1.0.0"
+scope: "crates/aprender-train/src/train/trainer/train_loop/basic.rs"
+description: |
+  With gradient_accumulation_steps = K, the trainer zeroes grads only at the window start and
+  the backward ops ADD each micro-batch's gradient into the shared param grad cell, so at the
+  accumulation boundary param.grad holds the SUM over the window. PMAT-839: maybe_clip_and_step
+  clipped and stepped on that SUM, making the realized update gradient exactly K× the mean over
+  the effective batch — a silent K-fold effective-LR inflation (K=8 → 8× LR) whenever accumulation
+  is enabled, contradicting config.rs:27's "effective batch size" contract and causing
+  divergence/loss-spikes mis-attributed to the LR. (Default grad clipping at norm 1.0 partially
+  masks it: when the summed norm exceeds the threshold both sum and mean clip identically, so the
+  defect surfaces in the sub-threshold regime — late training / small gradients.) Fix: scale each
+  param.grad by 1/window before clip+step, where window = (step % accum_steps) + 1 (correct also
+  for a short final window).
+equations:
+  C-GRADACC-001:
+    description: "The optimizer steps on the MEAN of the window's micro-batch gradients"
+    formula: "g_step = (1/W)·Σ_{i in window} g_i,  W = (step % accum_steps) + 1"
+    note: "Backward accumulates the SUM; the boundary must divide by the window count."
+  C-GRADACC-002:
+    description: "K-step accumulation over K identical micro-batches equals a single batch (same LR)"
+    formula: "param(accum=K, K identical batches) == param(accum=1, 1 batch), same optimizer/LR"
+    note: "The pre-fix SUM moved the parameter K× as far."
+falsification:
+  - id: FALSIFY-GRAD-ACCUM-MEAN
+    description: "Accumulation steps on the mean, not the sum. Discharges C-GRADACC-001/002."
+    test: "falsify_gradient_accumulation_is_mean_not_sum — SGD(lr=1), clip off: accum=2 over two identical batches vs accum=1 over one. RED b=[3,4] (2× move), GREEN b=[2,3]==a."
+    evidence: "cargo test -p aprender-train --lib falsify_gradient_accumulation_is_mean_not_sum"

--- a/crates/aprender-train/src/train/trainer/train_loop/basic.rs
+++ b/crates/aprender-train/src/train/trainer/train_loop/basic.rs
@@ -177,6 +177,19 @@ impl Trainer {
         let is_accum_boundary = (step + 1).is_multiple_of(accum_steps);
         let is_last_batch = step + 1 == steps_per_epoch;
         if is_accum_boundary || is_last_batch {
+            // PMAT-839: gradients accumulate ADDITIVELY across the window, so at the boundary
+            // each param.grad holds the SUM over the window's micro-batches. Scale to the MEAN
+            // before clipping/stepping, so K-step accumulation reproduces a single batch of the
+            // effective size (the PyTorch `loss /= accum_steps` convention) instead of inflating
+            // the effective learning rate K-fold. The window count is `(step % accum_steps) + 1`,
+            // which also yields the correct divisor for a short final window (is_last_batch).
+            let window = (step % accum_steps) + 1;
+            if window > 1 {
+                let inv = 1.0 / window as f32;
+                for p in self.params.iter() {
+                    p.scale_grad(inv);
+                }
+            }
             if let Some(max_norm) = self.config.max_grad_norm {
                 clip_grad_norm(&mut self.params, max_norm);
             }

--- a/crates/aprender-train/src/train/trainer/train_loop/tests.rs
+++ b/crates/aprender-train/src/train/trainer/train_loop/tests.rs
@@ -422,4 +422,50 @@ mod tests {
         assert!(!result.stopped_early);
         assert!(result.final_loss.is_finite());
     }
+
+    /// FALSIFY-GRAD-ACCUM-MEAN (PMAT-839): K-step gradient accumulation must step on the MEAN of
+    /// the K micro-batch gradients, not their SUM. Train the SAME problem two ways under SGD(lr=1)
+    /// with grad clipping OFF (clipping normalizes the magnitude and would mask the bug whenever
+    /// the summed norm exceeds the threshold): (A) accum=1 over one batch, (B) accum=2 over two
+    /// IDENTICAL batches. Correct mean-scaling makes the final parameter identical; the pre-fix
+    /// SUM moved it twice as far (K-fold effective-LR inflation). The forward returns the
+    /// (Rc-shared) parameter so the MSE gradient reaches it.
+    #[test]
+    fn falsify_gradient_accumulation_is_mean_not_sum() {
+        use crate::optim::SGD;
+
+        fn run(accum: usize, n_batches: usize) -> Vec<f32> {
+            let param = Tensor::from_vec(vec![1.0, 2.0], true);
+            let fwd_param = param.clone(); // shares the Rc grad cell
+            let optimizer = SGD::new(1.0, 0.0); // lr=1, no momentum → param -= grad (linear)
+            let config = TrainConfig::new()
+                .with_log_interval(100)
+                .without_grad_clip() // clipping would normalize away the SUM-vs-MEAN difference
+                .with_gradient_accumulation(accum);
+            let mut trainer = Trainer::new(vec![param], Box::new(optimizer), config);
+            trainer.set_loss(Box::new(MSELoss));
+            let batches: Vec<Batch> = (0..n_batches)
+                .map(|_| {
+                    Batch::new(
+                        Tensor::from_vec(vec![0.0, 0.0], false),
+                        Tensor::from_vec(vec![2.0, 3.0], false),
+                    )
+                })
+                .collect();
+            let fwd = move |_input: &Tensor| fwd_param.clone();
+            trainer.train(1, || batches.clone(), fwd);
+            trainer.params()[0].data().to_vec()
+        }
+
+        let a = run(1, 1); // single batch
+        let b = run(2, 2); // two identical micro-batches accumulated
+                           // RED (sum): b moved 2× as far as a. GREEN (mean): b == a.
+        assert_eq!(a.len(), b.len());
+        for (x, y) in a.iter().zip(b.iter()) {
+            assert!(
+                (x - y).abs() < 1e-5,
+                "accum=2 param {b:?} != accum=1 param {a:?} — accumulation stepped on the SUM, not the MEAN"
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Pillar-2/3 (PyTorch/Unsloth training parity) correctness — beat #13 for 0.50.0

With `gradient_accumulation_steps = K`, the backward ops **add** each micro-batch's gradient into the shared `param.grad` cell and `zero_grad` runs only at the window start — so at the accumulation boundary `param.grad` holds the **sum** over the window. `maybe_clip_and_step` then clipped and stepped on that sum.

**Impact:** the realized update gradient is exactly **K× the mean** over the effective batch — a silent **K-fold effective-LR inflation** (K=8 → 8× LR) whenever accumulation is enabled. This directly contradicts the documented contract (`config.rs:27`: *"Effective batch size = batch_size × gradient_accumulation_steps"*), whose whole purpose is to simulate a larger batch *at the same gradient scale*, and causes divergence / loss spikes that practitioners mis-attribute to a bad LR. (Default grad clipping at norm 1.0 partially masks it: when the summed norm exceeds the threshold, sum and mean clip identically — so the defect surfaces in the sub-threshold regime, i.e. late training / small gradients.)

**Why green:** the two accumulation tests assert only optimizer-step *counts* and `final_loss.is_finite()`, and their batches use `requires_grad=false` inputs so no gradient even reaches the params. A K×-too-large gradient is consistent with every green assertion — the missing obligation was "accumulated gradient == mean over the window".

**Fix:** scale `param.grad` by `1/window` before clip+step, where `window = (step % accum_steps) + 1` (also correct for a short final window).

**Falsifier** (`falsify_gradient_accumulation_is_mean_not_sum`): SGD(lr=1), clipping off — accum=2 over two identical batches vs accum=1 over one → RED `b=[3,4]` (moved 2×), GREEN `b=[2,3]==a` (proven RED-on-bug / GREEN-on-fix). All 23 train_loop + 27 accumulation tests stay green.

Contract: `gradient-accumulation-mean-v1` (C-GRADACC-001/002, `pv`-validated). Found by the release-day sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)