### PR TITLE
fix(orchestrate): macOS build broken — Linux-only prctl(PR_SET_PDEATHSIG) gated cfg(unix) (PMAT-840)

### DIFF
--- a/contracts/orchestrate-macos-portability-v1.yaml
+++ b/contracts/orchestrate-macos-portability-v1.yaml
@@ -1,0 +1,36 @@
+metadata:
+  version: "1.0.0"
+  created: "2026-06-19"
+  author: PAIML Engineering
+  registry: true
+  references:
+    - "Linux prctl(2) PR_SET_PDEATHSIG — Linux-only; absent on macOS/BSD libc"
+    - "Nightly macOS cross-build (x86_64-apple-darwin, aarch64-apple-darwin)"
+  description: |
+    Portability contract for aprender-orchestrate's parent-death-signal helper. `cargo install
+    aprender` must build on macOS — apr-cli depends on aprender-orchestrate (as `batuta`), so a
+    non-portable orchestrate breaks the published `apr` binary on Darwin.
+kind: KernelContract
+name: orchestrate-macos-portability
+version: "1.0.0"
+scope: "crates/aprender-orchestrate/src/agent/driver/apr_serve.rs"
+description: |
+  PMAT-840: configure_parent_death_signal used `libc::prctl(libc::PR_SET_PDEATHSIG, ...)` under
+  `#[cfg(unix)]`. PR_SET_PDEATHSIG and this prctl form are LINUX-ONLY, but `unix` also matches
+  macOS/BSD, where those libc items do not exist — so `aprender-orchestrate` (lib) failed to
+  compile on *-apple-darwin (E0425: cannot find `prctl` / `PR_SET_PDEATHSIG`), breaking
+  `cargo install aprender` for every macOS user (Nightly macOS build red ≥5 consecutive days).
+  Fix: gate the prctl path to `#[cfg(target_os = "linux")]` and broaden the no-op fallback to
+  `#[cfg(not(target_os = "linux"))]` (Drop's `kill -TERM` shell path stays `#[cfg(unix)]` — that
+  is genuinely portable across Unix). Orphan reaping is Linux-only by design; the stub keeps the
+  crate building on other targets (graceful-exit Drop cleanup still runs everywhere).
+equations:
+  C-ORCHPORT-001:
+    description: "Linux-only prctl(PR_SET_PDEATHSIG) is gated to target_os=linux, not unix"
+    formula: "configure_parent_death_signal using libc::PR_SET_PDEATHSIG ⟹ #[cfg(target_os = \"linux\")]; non-Linux ⟹ no-op stub"
+    note: "PR_SET_PDEATHSIG ∉ macOS/BSD libc; `unix` gate breaks the Darwin build."
+falsification:
+  - id: FALSIFY-ORCH-MACOS-PRCTL-GATE
+    description: "The PR_SET_PDEATHSIG path is Linux-gated (shape gate; behavioral proof is the macOS cross-build). Discharges C-ORCHPORT-001."
+    test: "! grep -B2 'libc::prctl(libc::PR_SET_PDEATHSIG' crates/aprender-orchestrate/src/agent/driver/apr_serve.rs | grep -q 'cfg(unix)'  — the prctl fn must NOT be under cfg(unix); it is under cfg(target_os = \"linux\")."
+    evidence: "grep -B2 'fn configure_parent_death_signal' apr_serve.rs shows #[cfg(target_os = \"linux\")] and #[cfg(not(target_os = \"linux\"))]; Linux falsify_1712 tests still pass."

--- a/crates/aprender-orchestrate/src/agent/driver/apr_serve.rs
+++ b/crates/aprender-orchestrate/src/agent/driver/apr_serve.rs
@@ -487,7 +487,10 @@ fn strip_thinking_blocks(text: &str) -> String {
 /// A `getppid()==1` check immediately after `prctl` closes the small race
 /// where the parent dies between fork and prctl (in which case the death
 /// signal has already missed its window).
-#[cfg(unix)]
+// PR_SET_PDEATHSIG / this `prctl` form are LINUX-ONLY — gate to `target_os = "linux"`, NOT the
+// broader `unix` (which also matches macOS/BSD, where `libc::prctl` and `libc::PR_SET_PDEATHSIG`
+// do not exist and the build fails: `cargo install aprender` was broken on macOS, PMAT-840).
+#[cfg(target_os = "linux")]
 #[allow(unsafe_code)] // pre_exec is unsafe-by-API; body uses only async-signal-safe calls
 fn configure_parent_death_signal(cmd: &mut Command) {
     use std::os::unix::process::CommandExt;
@@ -508,9 +511,11 @@ fn configure_parent_death_signal(cmd: &mut Command) {
     }
 }
 
-#[cfg(not(unix))]
+#[cfg(not(target_os = "linux"))]
 fn configure_parent_death_signal(_cmd: &mut Command) {
-    // Windows: no equivalent — orphans on parent death still possible.
+    // Only Linux has PR_SET_PDEATHSIG (via prctl). macOS/BSD/Windows have no portable
+    // equivalent — abrupt-parent-death orphan reaping is best-effort there (Drop still runs
+    // on graceful exit). The point of this stub is to keep the crate building on those targets.
 }
 
 /// Find the `apr` binary on PATH.

--- a/crates/aprender-orchestrate/src/agent/driver/apr_serve_tests.rs
+++ b/crates/aprender-orchestrate/src/agent/driver/apr_serve_tests.rs
@@ -191,7 +191,7 @@ fn falsify_http_001_tool_call_format() {
 // The end-to-end behaviour is verified by spawning a `sleep` child with the
 // same hook from a short-lived parent shell and asserting the child dies.
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 #[test]
 fn falsify_1712_pdeathsig_helper_installs_pre_exec() {
     // The helper must not panic on a fresh Command.


### PR DESCRIPTION
## macOS release blocker for 0.50.0 — found via the red Nightly cross-build

`aprender-orchestrate::configure_parent_death_signal` called `libc::prctl(libc::PR_SET_PDEATHSIG, …)` under `#[cfg(unix)]`. But **`PR_SET_PDEATHSIG` and this `prctl` form are Linux-only** — `unix` also matches macOS/BSD, where those libc items don't exist.

**Impact:** `aprender-orchestrate` (lib) failed to compile on `x86_64-apple-darwin` / `aarch64-apple-darwin` (`E0425: cannot find value PR_SET_PDEATHSIG` / `cannot find function prctl`). Since **`apr-cli` depends on `aprender-orchestrate`** (as `batuta`), this broke `cargo install aprender` for **every macOS user** — the Nightly macOS cross-build has been red ≥5 consecutive days. A release blocker for cross-platform 0.50.0.

**Fix:** gate the `prctl` path to `#[cfg(target_os = "linux")]` and broaden the no-op fallback to `#[cfg(not(target_os = "linux"))]`. (The `Drop` `kill -TERM` shell path stays `#[cfg(unix)]` — genuinely portable.) Orphan reaping via PR_SET_PDEATHSIG is Linux-only by design; the stub keeps the crate building elsewhere, and graceful-exit `Drop` cleanup still runs on all platforms. The FALSIFY-1712 PDEATHSIG tests are likewise gated to `target_os = "linux"` and still pass on Linux.

Contract: `orchestrate-macos-portability-v1` (C-ORCHPORT-001, `pv`-validated). Falsifier `FALSIFY-ORCH-MACOS-PRCTL-GATE` is a shape gate; the behavioral proof is the macOS cross-build going green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)