### PR TITLE
fix(serve): batched-GPU path crashed on every GQA model — MHA-only QKV dispatch (PMAT-841)

### DIFF
--- a/contracts/serve-batched-gpu-gqa-dispatch-v1.yaml
+++ b/contracts/serve-batched-gpu-gqa-dispatch-v1.yaml
@@ -1,0 +1,62 @@
+metadata:
+  version: "1.0.0"
+  created: "2026-06-19"
+  author: PAIML Engineering
+  registry: true
+  references:
+    - "PMAT-749: GQA serve panic — adaptive_attention_with_cache routed GQA to MHA-only kernels"
+    - "Qwen2.5-7B-Instruct: hidden=3584, num_heads=28, num_kv_heads=4, head_dim=128 (GQA)"
+    - "crates/aprender-serve/src/api/batch_processing.rs — /v1/batch/completions handler"
+  description: |
+    Dispatch-safety contract for apr's batched-GPU serving path (the "2.8x Ollama, 800+ tok/s"
+    feature). The batched path must produce correct output — or cleanly route around itself — for
+    grouped-query-attention (GQA) models, which are the entire modern-LLM class (Qwen2, Llama-3,
+    Mistral, ...). It must NEVER crash with a CUDA GEMM size mismatch.
+kind: KernelContract
+name: serve-batched-gpu-gqa-dispatch
+version: "1.0.0"
+scope: "crates/aprender-serve/src/gguf/inference/cached/sync_owned_quantized_02.rs"
+description: |
+  PMAT-841: `OwnedQuantizedModelCachedSync::batch_generate_gpu` dispatches to
+  `forward_batch_with_gpu_ffn` whenever the active batch is >= 32. That function is MHA-only —
+  it treats the fused QKV projection as `3 * hidden_dim` wide and slices Q/K/V each as
+  `hidden_dim` (its own comments say `// non-GQA code path`). For a GQA model the real QKV
+  projection is `q_dim + 2*kv_dim` wide (e.g. Qwen2.5-7B: 3584 + 2*512 = 4608, not 3*3584 =
+  10752), so the batched path crashes: the GPU GEMM rejects the weight with
+  `GEMM size mismatch: B[..] expected 3*hidden*hidden` (measured live on an RTX 4090: a 32-prompt
+  /v1/batch/completions request to a Qwen2.5-7B GGUF returned
+  `CUDA GEMM failed ... B[16515072] expected 38535168`), and the CPU branch panics slicing
+  `qkv[2*hidden..3*hidden]` past the buffer. Both reach production via the /v1/batch/completions
+  HTTP endpoint and via concurrent >=32-request batching.
+
+  Fix: gate the batched-path dispatch with an MHA-layout precondition
+  `q_dim == hidden_dim && kv_dim == hidden_dim`. When false (GQA, or any non-standard head_dim),
+  every prompt is routed through the per-prompt `forward_single_with_cache` path — the same
+  GQA-correct path used by prefill and by single `/v1/completions` requests. apr concedes the
+  batched-GPU speedup for GQA (a future optimization: a GQA-aware batched QKV/attention kernel)
+  but WINS on correctness: it returns valid completions instead of crashing, where the headline
+  batched feature was previously dead for every modern model.
+equations:
+  C-SERVE-GQA-DISPATCH-001:
+    description: "The MHA-only batched-GPU path is selected only when the MHA layout precondition holds."
+    formula: "select(forward_batch_with_gpu_ffn) ⟹ (q_dim == hidden_dim) ∧ (kv_dim == hidden_dim)"
+    note: "GQA ⟺ kv_dim < hidden_dim (num_kv_heads < num_heads) ⟹ per-prompt forward_single_with_cache path."
+  C-SERVE-GQA-DISPATCH-002:
+    description: "Batched generation on a GQA model terminates with one output sequence per prompt — never a GEMM size mismatch or slice panic."
+    formula: "batch_generate_gpu(prompts, cfg) on GQA ⟹ Ok(seqs) ∧ |seqs| == |prompts|"
+    note: "Holds for any batch size, including >= the 32-prompt GPU threshold."
+proof_obligations:
+  - id: PO-SERVE-GQA-DISPATCH-001
+    kind: safety
+    statement: "batch_generate_gpu never dispatches a GQA model (kv_dim != hidden_dim) into the MHA-only forward_batch_with_gpu_ffn batched branch."
+    discharged_by: FALSIFY-SERVE-GQA-BATCH-NO-CRASH
+falsification:
+  - id: FALSIFY-SERVE-GQA-BATCH-NO-CRASH
+    description: "A GQA model run through batch_generate_gpu with >=32 prompts returns Ok with one sequence per prompt (no CUDA GEMM mismatch, no OOB slice panic). Discharges C-SERVE-GQA-DISPATCH-001/002 and PO-SERVE-GQA-DISPATCH-001."
+    test: "cargo test -p aprender-serve --lib falsify_pmat841_batched_gpu_gqa_no_crash"
+    evidence: |
+      RED (guard stashed): Err(UnsupportedOperation { operation: "batch_matmul_gpu_prefer_cuda",
+      reason: "Matrix B size 8192 doesn't match k*n=64*192=12288" }) — the fixture-scale twin of the
+      live RTX 4090 7B crash (B[16515072] expected 38535168). GREEN (guard in place): 32 sequences,
+      each retaining its prompt tokens. Live GPU verification: 32-prompt /v1/batch/completions to a
+      Qwen2.5-7B GGUF returns completions after the fix (was a GEMM size-mismatch 500 before).

--- a/crates/aprender-serve/src/gguf/inference/cached/sync_owned_quantized_02.rs
+++ b/crates/aprender-serve/src/gguf/inference/cached/sync_owned_quantized_02.rs
@@ -44,6 +44,19 @@ impl OwnedQuantizedModelCachedSync {
         let num_prompts = prompts.len();
         let max_seq_len = prompts.iter().map(Vec::len).max().unwrap_or(0) + config.max_tokens;
 
+        // PMAT-841 (GQA dispatch guard): `forward_batch_with_gpu_ffn` is MHA-only — it
+        // treats the fused QKV projection as `3 * hidden_dim` wide and slices Q/K/V each
+        // as `hidden_dim` (see its `// non-GQA code path` comments). For GQA models
+        // (`kv_dim != hidden_dim`, e.g. Qwen2.5-7B: q_dim 3584, kv_dim 512) the real QKV
+        // projection is `q_dim + 2*kv_dim` wide, so the batched path crashes with a CUDA
+        // GEMM size mismatch (or panics slicing past the QKV buffer on its CPU branch).
+        // Only the MHA layout (`q_dim == hidden == kv_dim`) is safe for the batched path;
+        // route everything else through the per-prompt `forward_single_with_cache` path,
+        // which is GQA-correct (the same path prefill and single requests use).
+        // Contract: contracts/serve-batched-gpu-gqa-dispatch-v1.yaml.
+        let mha_batched_layout = self.model.config.q_dim() == self.model.config.hidden_dim
+            && self.model.config.kv_dim() == self.model.config.hidden_dim;
+
         // Initialize KV caches for each prompt
         let mut caches: Vec<OwnedQuantizedKVCache> = prompts
             .iter()
@@ -83,10 +96,12 @@ impl OwnedQuantizedModelCachedSync {
             let active_count = active_indices.len();
 
             // Use batched forward when we have enough active prompts for GPU benefit
-            // GPU batch threshold is 32 (from IMP-600 analysis)
+            // GPU batch threshold is 32 (from IMP-600 analysis).
+            // PMAT-841: AND require the MHA layout — the batched path is MHA-only and
+            // crashes on GQA models, so GQA falls through to the per-prompt path below.
             const GPU_BATCH_THRESHOLD: usize = 32;
 
-            if active_count >= GPU_BATCH_THRESHOLD {
+            if active_count >= GPU_BATCH_THRESHOLD && mha_batched_layout {
                 // PARITY-021: Batched forward with GPU FFN
                 // Collect tokens, positions, and cache slices for active prompts
                 let batch_tokens: Vec<u32> = active_indices

--- a/crates/aprender-serve/src/gguf/inference/cached/sync_tests_constructors.rs
+++ b/crates/aprender-serve/src/gguf/inference/cached/sync_tests_constructors.rs
@@ -435,3 +435,81 @@
         // The batch_size calculation would be wrong, leading to error
         assert!(result.is_ok() || result.is_err());
     }
+
+    // ========================================================================
+    // PMAT-841: Batched-GPU GQA dispatch falsifier
+    // ========================================================================
+
+    /// Grouped-query-attention config: fewer KV heads than query heads, so the
+    /// fused QKV projection is `q_dim + 2*kv_dim` wide (NOT `3 * hidden_dim`).
+    /// num_heads=4, num_kv_heads=2, hidden=64 → head_dim=16, q_dim=64, kv_dim=32,
+    /// qkv width = 64 + 2*32 = 128 (vs the MHA assumption 3*64 = 192).
+    fn gqa_test_config() -> GGUFConfig {
+        GGUFConfig {
+            architecture: "test".to_string(),
+            constraints: crate::gguf::ArchConstraints::from_architecture("test"),
+            hidden_dim: 64,
+            intermediate_dim: 128,
+            num_heads: 4,
+            num_kv_heads: 2,
+            num_layers: 1,
+            vocab_size: 100,
+            rope_theta: 10000.0,
+            context_length: 512,
+            eps: 1e-5,
+            rope_type: 0,
+            explicit_head_dim: None,
+            query_pre_attn_scalar: None,
+            bos_token_id: None,
+            eos_token_id: None,
+        }
+    }
+
+    /// PMAT-841 falsifier: `batch_generate_gpu` must NOT crash on a GQA model.
+    ///
+    /// RED (pre-fix): with ≥32 active prompts the dispatch unconditionally enters
+    /// `forward_batch_with_gpu_ffn`, whose MHA-only QKV split (`qkv[2*hidden..3*hidden]`,
+    /// stride `3*hidden`) reads past the `hidden + 2*kv_dim`-wide GQA QKV buffer → an
+    /// out-of-bounds panic (the GPU build hits the equivalent CUDA GEMM size mismatch
+    /// `B[..] expected 3*hidden*hidden, got (hidden+2*kv_dim)*hidden`).
+    ///
+    /// GREEN (post-fix): the dispatch guard `mha_batched_layout` is false for GQA, so
+    /// every prompt is routed through the per-prompt `forward_single_with_cache` path
+    /// (GQA-correct), and generation returns one sequence per prompt with no crash.
+    #[test]
+    fn falsify_pmat841_batched_gpu_gqa_no_crash() {
+        let config = gqa_test_config();
+
+        // Document the layout invariant the MHA batched path violates for GQA.
+        let head_dim = config.hidden_dim / config.num_heads;
+        let real_qkv_width = config.q_dim() + 2 * config.kv_dim();
+        let mha_assumed_width = 3 * config.hidden_dim;
+        assert_eq!(
+            real_qkv_width,
+            config.hidden_dim + 2 * config.num_kv_heads * head_dim
+        );
+        assert!(
+            real_qkv_width < mha_assumed_width,
+            "GQA QKV width {real_qkv_width} must be < MHA assumption {mha_assumed_width}"
+        );
+        assert_ne!(config.kv_dim(), config.hidden_dim, "fixture must be GQA");
+
+        let model = OwnedQuantizedModelCachedSync::new(create_test_model_with_config(&config));
+        let _ = model.warmup_gpu_cache(); // is_gpu_cache_warm() == true (CPU dequant cache)
+
+        // ≥32 prompts crosses GPU_BATCH_THRESHOLD and would select the MHA batched path.
+        let prompts: Vec<Vec<u32>> = (0..32).map(|_| vec![1u32, 2, 3]).collect();
+        let gen_config = QuantizedGenerateConfig::deterministic(2);
+
+        let result = model.batch_generate_gpu(&prompts, &gen_config);
+
+        assert!(
+            result.is_ok(),
+            "PMAT-841: batched generation on a GQA model must not crash, got {result:?}"
+        );
+        let sequences = result.expect("GQA batch generation must succeed");
+        assert_eq!(sequences.len(), 32, "one output sequence per prompt");
+        for seq in &sequences {
+            assert!(seq.len() >= 3, "each sequence retains its prompt tokens");
+        }
+    }


### PR DESCRIPTION
## Summary

apr's headline **batched-GPU serving path** (the "2.8× Ollama, 800+ tok/s" `/v1/batch/completions` feature) **crashed on every grouped-query-attention (GQA) model** — i.e. the entire modern-LLM class (Qwen2, Llama-3, Mistral, …).

`batch_generate_gpu` dispatches to `forward_batch_with_gpu_ffn` whenever the active batch is ≥ 32. That function is **MHA-only**: it treats the fused QKV projection as `3 * hidden_dim` wide and slices Q/K/V each as `hidden_dim` (its own comments say `// non-GQA code path`). For a GQA model the real QKV projection is `q_dim + 2*kv_dim` wide (Qwen2.5-7B: `3584 + 2*512 = 4608`, not `3*3584 = 10752`), so the batched path crashes.

## Live reproduction (RTX 4090)

A 32-prompt `/v1/batch/completions` request to a Qwen2.5-7B GGUF returned a 500:
```
CUDA GEMM failed: GEMM size mismatch: B[16515072] expected 38535168
```
(`16515072 = 3584×4608` GQA QKV; `38535168 = 3584×10752` MHA assumption.) The CPU branch panics slicing `qkv[2*hidden..3*hidden]` past the buffer.

## Fix

Gate the batched-path dispatch with an MHA-layout precondition `q_dim == hidden_dim && kv_dim == hidden_dim`. When false (GQA, or any non-standard `head_dim`), every prompt is routed through the per-prompt `forward_single_with_cache` path — the same GQA-correct path used by prefill and single `/v1/completions` requests.

apr concedes the batched-GPU *speedup* for GQA (a future GQA-aware batched kernel) but **wins on correctness**: valid completions instead of a crash, where the headline batched feature was previously dead for every modern model. Same remedy class as PMAT-749.

## Falsifier (RED/GREEN, GPU-free)

`falsify_pmat841_batched_gpu_gqa_no_crash` builds a GQA fixture (num_heads=4, num_kv_heads=2) and runs 32 prompts through `batch_generate_gpu`:
- **RED** (guard stashed): `Err(... batch_matmul_gpu_prefer_cuda ... Matrix B size 8192 doesn't match k*n=64*192=12288)` — the fixture-scale twin of the live 7B crash.
- **GREEN**: 32 sequences, each retaining its prompt tokens.

## Contract

`contracts/serve-batched-gpu-gqa-dispatch-v1.yaml` (pv-validated, 0 errors): `C-SERVE-GQA-DISPATCH-001/002`, `PO-SERVE-GQA-DISPATCH-001`.

## Verification

- `cargo test -p aprender-serve --lib falsify_pmat841_batched_gpu_gqa_no_crash` — RED→GREEN confirmed
- `cargo test -p aprender-serve --lib` — **15428 passed / 0 failed**
- `pv validate contracts/serve-batched-gpu-gqa-dispatch-v1.yaml` — valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)