### PR TITLE
fix(q5k): correct GGUF Q5_K dequant nibble layout — stride-32 not sequential (PMAT-842)

### DIFF
--- a/contracts/q5k-dequant-correctness-v1.yaml
+++ b/contracts/q5k-dequant-correctness-v1.yaml
@@ -1,0 +1,60 @@
+metadata:
+  version: "1.0.0"
+  created: "2026-06-19"
+  author: PAIML Engineering
+  registry: true
+  references:
+    - "ggml dequantize_row_q5_K (llama.cpp ggml-quants.c) — the reference Q5_K dequant algorithm"
+    - "crates/aprender-compute/src/backends/q4k/dequant.rs::dequantize_q4k_to_f32 (in-repo correct stride-32 reference for the sibling K-quant)"
+  description: |
+    Correctness contract for GGUF Q5_K dequantization in aprender-compute's transformer
+    inference helper (inference::model::dequantize_q5k_to_f32). Pillar-4-adjacent (model
+    import / weight-load correctness): a Q5_K GGUF tensor must dequantize to f32 values
+    matching the GGML reference layout. NOTE on reachability: this function lives in the
+    aprender-compute trueno-internal Llama loader (load_weight_matrix /
+    load_f32_or_dequant_tensor in the same file), NOT the canonical realizar serving path
+    (`apr serve` / `apr run`). It is the alternate/secondary inference path inside the
+    compute crate; the bug corrupts Q5_K weights wherever this loader is used.
+
+kind: KernelContract
+name: q5k-dequant-correctness
+version: "1.0.0"
+scope: "crates/aprender-compute/src/inference/model.rs"
+
+description: |
+  GGML Q5_K stores, per 256-element super-block (176 bytes): f16 d, f16 dmin, 12 bytes
+  packing 8 SIX-bit scales + 8 SIX-bit mins (Q4_K layout), 32 bytes of high bits (qh, one
+  5th-bit per element), and 128 bytes of low nibbles (qs, two 4-bit values per byte).
+  PMAT-842 fixed dequantize_q5k_to_f32, which walked the output index sequentially as
+  idx = 0..255 with low4 = (qs[idx/2] >> ((idx%2)*4)) & 0x0F and high1 = (qh[idx/8] >>
+  (idx%8)) & 0x01. That is NOT the GGML K-quant layout: it placed the HIGH nibble of qs[0]
+  at output index 1 instead of index 32, permuting the entire weight vector. The correct
+  GGML layout processes the super-block in four 64-element chunks (it = 0..4, ql_base =
+  it*32): for l in 0..32, the LOW nibble of qs[ql_base+l] lands at out[it*64+l] with
+  scale=d*scales[2*it], min=dmin*mins[2*it] and 5th bit from qh[l] bit (2*it); the HIGH
+  nibble lands at out[it*64+32+l] with scale=d*scales[2*it+1], min=dmin*mins[2*it+1] and
+  5th bit from qh[l] bit (2*it+1). i.e. the low and high nibble of the same qs byte are a
+  STRIDE OF 32 apart (u1 = 1<<(2*it), u2 = 2<<(2*it)). This matches the in-repo correct
+  Q4_K reference (backends/q4k/dequant.rs), which already uses the four-chunk stride-32
+  layout.
+
+equations:
+  C-Q5K-001:
+    description: "Q5_K dequant matches the GGML reference element-wise (stride-32 nibble layout)"
+    formula: "out[it*64 + l] = d*scales[2*it]*((qs[it*32+l] & 0xF) + (qh[l] & (1<<(2*it)) ? 16 : 0)) - dmin*mins[2*it]; out[it*64 + 32 + l] = d*scales[2*it+1]*((qs[it*32+l] >> 4) + (qh[l] & (2<<(2*it)) ? 16 : 0)) - dmin*mins[2*it+1] for it in 0..4, l in 0..32"
+    note: "Low and high nibble of qs[it*32+l] are a stride of 32 apart; the buggy sequential idx/2 indexing put them adjacent."
+
+  C-Q5K-002:
+    description: "The 5th bit comes from qh[l] using bit (2*it) for the low nibble and bit (2*it+1) for the high nibble"
+    formula: "u1 = 1 << (2*it); u2 = 2 << (2*it); low gains 16 iff qh[l] & u1; high gains 16 iff qh[l] & u2; NOT (qh[idx/8] >> (idx%8)) & 1"
+    note: "Regression guard against the per-element bit addressing that read the wrong qh byte/bit for elements 8..255."
+
+falsification:
+  - id: FALSIFY-DEQUANT-Q5K-001
+    description: "Q5_K dequant of a 176-byte block places the high nibble of qs[0] at out[32], not out[1]. Discharges C-Q5K-001."
+    test: "test_q5k_dequant_stride32_nibble_layout — d=1.0, dmin=0.0, scales=1/mins=0, qh=0, qs[0]=0x21: RED pre-fix out[1]=2.0 / out[32]=0.0; GREEN post-fix out[0]=1.0 / out[1]=0.0 / out[32]=2.0. All-zero qs cannot distinguish (both yield zeros)."
+    evidence: "cargo test -p aprender-compute --lib q5k_dequant_tests::test_q5k_dequant_stride32_nibble_layout"
+  - id: FALSIFY-DEQUANT-Q5K-002
+    description: "Q5_K dequant reads the 5th bit from qh[l] bit (2*it)/(2*it+1). Discharges C-Q5K-002."
+    test: "test_q5k_dequant_fifth_bit_placement — qh[0]=0x03 (bits 0,1 set), qs[0]=0x21: RED pre-fix out[32]=0.0; GREEN post-fix out[0]=17.0 (1+16) / out[32]=18.0 (2+16)."
+    evidence: "cargo test -p aprender-compute --lib q5k_dequant_tests::test_q5k_dequant_fifth_bit_placement"

--- a/crates/aprender-compute/src/inference/model.rs
+++ b/crates/aprender-compute/src/inference/model.rs
@@ -826,16 +826,26 @@ fn dequantize_q5k_to_f32(data: &[u8], num_elements: usize) -> Vec<f32> {
         let qs = &block[48..176];
 
         let out_base = sb * BLOCK_SIZE;
-        for sub in 0..8usize {
-            let scale = d * scales[sub] as f32;
-            let min = dmin * mins[sub] as f32;
-            let sub_off = sub * 32;
-            for j in 0..32usize {
-                let idx = sub_off + j;
-                let low4 = (qs[idx / 2] >> ((idx % 2) * 4)) & 0x0F;
-                let high1 = (qh[idx / 8] >> (idx % 8)) & 0x01;
-                let q5 = (low4 | (high1 << 4)) as f32;
-                result[out_base + idx] = scale * q5 - min;
+        // llama.cpp `dequantize_row_q5_K` layout: process the 256-element
+        // super-block in four 64-element chunks. For each chunk `it`, the low
+        // and high nibble of the SAME `qs` byte land a STRIDE OF 32 apart, and
+        // `qh[l]` holds the 5th bit across the four chunks (u1 = 1<<(2*it),
+        // u2 = 2<<(2*it)). See contracts/q5k-dequant-correctness-v1.yaml.
+        for it in 0..4usize {
+            let ql_base = it * 32;
+            let scale_lo = d * scales[2 * it] as f32;
+            let min_lo = dmin * mins[2 * it] as f32;
+            let scale_hi = d * scales[2 * it + 1] as f32;
+            let min_hi = dmin * mins[2 * it + 1] as f32;
+            let u1 = 1u8 << (2 * it);
+            let u2 = 2u8 << (2 * it);
+            for l in 0..32usize {
+                let qsb = qs[ql_base + l];
+                let qhb = qh[l];
+                let lo = (qsb & 0x0F) + if qhb & u1 != 0 { 16 } else { 0 };
+                result[out_base + it * 64 + l] = scale_lo * (lo as f32) - min_lo;
+                let hi = (qsb >> 4) + if qhb & u2 != 0 { 16 } else { 0 };
+                result[out_base + it * 64 + 32 + l] = scale_hi * (hi as f32) - min_hi;
             }
         }
     }
@@ -945,4 +955,89 @@ fn dequantize_q4_1_to_f32(data: &[u8], num_elements: usize) -> Vec<f32> {
 
     result.truncate(num_elements);
     result
+}
+
+#[cfg(test)]
+mod q5k_dequant_tests {
+    use super::dequantize_q5k_to_f32;
+
+    /// Build a single 176-byte Q5_K super-block.
+    ///
+    /// `d` / `dmin` are f16 bit patterns. `scale_bytes` is the 12-byte packed
+    /// scales+mins. `qh` is 32 bytes (one bit per element). `qs` is 128 bytes
+    /// (two 4-bit values per byte).
+    fn build_q5k_block(
+        d: u16,
+        dmin: u16,
+        scale_bytes: [u8; 12],
+        qh: [u8; 32],
+        qs: [u8; 128],
+    ) -> Vec<u8> {
+        let mut block = Vec::with_capacity(176);
+        block.extend_from_slice(&d.to_le_bytes());
+        block.extend_from_slice(&dmin.to_le_bytes());
+        block.extend_from_slice(&scale_bytes);
+        block.extend_from_slice(&qh);
+        block.extend_from_slice(&qs);
+        assert_eq!(block.len(), 176, "Q5_K super-block must be 176 bytes");
+        block
+    }
+
+    /// Scale bytes that decode (via the Q4_K-style 6-bit unpack) to all eight
+    /// scales == 1 and all eight mins == 0.
+    fn scales_all_one_mins_zero() -> [u8; 12] {
+        // scales[0..4] low6 = bytes[0..4]; mins[0..4] low6 = bytes[4..8];
+        // scales[4..8] = (bytes[8..12] & 0x0F) | ((bytes[0..4] >> 6) << 4);
+        // mins[4..8]   = (bytes[8..12] >> 4)   | ((bytes[4..8] >> 6) << 4).
+        // bytes[0..4]=1 -> scales[0..4]=1, high-2 contribution 0.
+        // bytes[4..8]=0 -> mins[0..4]=0.
+        // bytes[8..12]=1 -> scales[4..8]=1, mins[4..8]=0.
+        [1, 1, 1, 1, 0, 0, 0, 0, 1, 1, 1, 1]
+    }
+
+    /// FALSIFIER (PMAT-842): the GGUF/llama.cpp Q5_K layout places the low and
+    /// high nibble of the SAME `qs` byte a STRIDE OF 32 apart, NOT at adjacent
+    /// output indices. With qs[0] = 0x21, low nibble (1) -> out[0], high nibble
+    /// (2) -> out[32]; out[1] comes from qs[1] (0). The buggy sequential-index
+    /// implementation produced out[1] == 2.0 and out[32] == 0.0.
+    #[test]
+    fn test_q5k_dequant_stride32_nibble_layout() {
+        let d = 0x3C00; // f16 1.0
+        let dmin = 0x0000; // f16 0.0
+        let mut qs = [0u8; 128];
+        qs[0] = 0x21; // low nibble = 1, high nibble = 2
+        let block = build_q5k_block(d, dmin, scales_all_one_mins_zero(), [0u8; 32], qs);
+
+        let out = dequantize_q5k_to_f32(&block, 256);
+
+        // low nibble of qs[0] -> output index 0
+        assert_eq!(out[0], 1.0, "out[0] must come from qs[0] low nibble (=1)");
+        // output index 1 comes from qs[1] (=0), NOT qs[0] high nibble
+        assert_eq!(out[1], 0.0, "out[1] must come from qs[1] low nibble (=0)");
+        // high nibble of qs[0] -> output index 32 (stride of 32)
+        assert_eq!(out[32], 2.0, "out[32] must come from qs[0] high nibble (=2)");
+    }
+
+    /// FALSIFIER (PMAT-842): the 5th bit lives in `qh[l]`, with the low nibble
+    /// using bit (2*it) and the high nibble using bit (2*it+1). For the first
+    /// chunk (it=0): u1 = 0b01, u2 = 0b10. With qh[0] = 0x03 both bits are set,
+    /// so the low value gains +16 (out[0]=17) and the high value gains +16
+    /// (out[32]=18).
+    #[test]
+    fn test_q5k_dequant_fifth_bit_placement() {
+        let d = 0x3C00; // f16 1.0
+        let dmin = 0x0000; // f16 0.0
+        let mut qs = [0u8; 128];
+        qs[0] = 0x21; // low nibble = 1, high nibble = 2
+        let mut qh = [0u8; 32];
+        qh[0] = 0x03; // set bits 0 (u1) and 1 (u2) for chunk it=0
+        let block = build_q5k_block(d, dmin, scales_all_one_mins_zero(), qh, qs);
+
+        let out = dequantize_q5k_to_f32(&block, 256);
+
+        // low nibble: 1 + 16 (bit 0 set) = 17
+        assert_eq!(out[0], 17.0, "out[0] low nibble must add 16 for qh bit 0");
+        // high nibble: 2 + 16 (bit 1 set) = 18, at stride-32 index
+        assert_eq!(out[32], 18.0, "out[32] high nibble must add 16 for qh bit 1");
+    }
 }


### PR DESCRIPTION
## Summary

`dequantize_q5k_to_f32` in `crates/aprender-compute/src/inference/model.rs` (the trueno-internal Llama loader) walked the output index **sequentially** (`idx = 0..255`):

```rust
let low4  = (qs[idx / 2] >> ((idx % 2) * 4)) & 0x0F;
let high1 = (qh[idx / 8] >> (idx % 8)) & 0x01;
```

This is **NOT** the GGUF/llama.cpp K-quant layout. It placed the **high nibble of `qs[0]` at output index 1 instead of index 32**, permuting the entire dequantized weight vector — corrupting every Q5_K weight loaded via this path.

## The correct GGML layout (`dequantize_row_q5_K`)

Process the 256-element super-block in **four 64-element chunks** (`it = 0..4`, `ql_base = it*32`); the low and high nibble of the same `qs` byte are a **STRIDE OF 32 apart**:

- low nibble of `qs[ql_base+l]` → `out[it*64+l]`, scale `d*scales[2*it]`, min `dmin*mins[2*it]`, 5th bit from `qh[l]` bit `2*it` (`u1 = 1<<(2*it)`)
- high nibble → `out[it*64+32+l]`, scale `d*scales[2*it+1]`, min `dmin*mins[2*it+1]`, 5th bit from `qh[l]` bit `2*it+1` (`u2 = 2<<(2*it)`)

This matches the in-repo correct Q4_K reference (`backends/q4k/dequant.rs`), which already uses the four-chunk stride-32 layout. The 12-byte scale/min unpack was already correct (identical to `parse_q4k_header`); only the inner element loop is changed.

## Reachability (honest assessment)

This loader (`load_weight_matrix` / `load_f32_or_dequant_tensor`) is the **aprender-compute trueno-internal Llama inference path**, NOT the canonical realizar serving path (`apr serve` / `apr run`). It is the alternate/secondary inference path inside the compute crate; the bug corrupts Q5_K weights wherever this loader is exercised. Not "every Q5_K model on the serving path."

## Falsifier-first (RED → GREEN)

Two unit tests added in `q5k_dequant_tests`, proven RED before the fix, GREEN after:

| Test | Input | RED (pre-fix) | GREEN (post-fix) |
|------|-------|---------------|------------------|
| `test_q5k_dequant_stride32_nibble_layout` | `qs[0]=0x21` | `out[1]=2.0`, `out[32]=0.0` | `out[0]=1.0`, `out[1]=0.0`, `out[32]=2.0` |
| `test_q5k_dequant_fifth_bit_placement` | `qh[0]=0x03` | `out[32]=0.0` | `out[0]=17.0`, `out[32]=18.0` |

## Verification

- `cargo test -p aprender-compute --lib` → **3501 passed, 0 failed** (no sibling test had encoded the buggy layout)
- `cargo build -p aprender-compute` → OK
- `cargo clippy -p aprender-compute --lib` → clean
- `cargo fmt -p aprender-compute -- --check` → clean
- `pv validate contracts/q5k-dequant-correctness-v1.yaml` → **0 error(s)**

## Contract

`contracts/q5k-dequant-correctness-v1.yaml` (`KernelContract`): equations `C-Q5K-001`/`C-Q5K-002`, falsifiers `FALSIFY-DEQUANT-Q5K-001`/`002`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)