### PR TITLE
fix(metrics): macro average over present labels only, not max+1 (PMAT-844)

### DIFF
--- a/contracts/metrics-macro-average-v1.yaml
+++ b/contracts/metrics-macro-average-v1.yaml
@@ -1,0 +1,114 @@
+metadata:
+  version: "1.0.0"
+  created: "2026-06-19"
+  author: PAIML Engineering
+  registry: true
+  references:
+    - "scikit-learn sklearn.metrics.precision_recall_fscore_support — average='macro' averages over labels = unique_labels(y_true, y_pred)"
+    - "scikit-learn sklearn.utils.multiclass.unique_labels — sorted union of observed labels"
+    - "Sokolova & Lapalme (2009) A Systematic Analysis of Performance Measures for Classification Tasks"
+    - "paiml/aprender contracts/metrics-classification-v1.yaml — sibling contract (per-class formulas)"
+    - "PMAT-844 — macro divisor counted absent intermediate labels (max+1) instead of present labels"
+  description: "Macro averaging must average per-class metrics only over labels present in y_true ∪ y_pred (scikit-learn parity)"
+
+kind: KernelContract
+name: metrics-macro-average
+version: "1.0.0"
+scope: "crates/aprender-core/src/metrics/classification.rs::{precision,recall,f1_score,jaccard_score,fbeta_score} (Average::Macro) + classification_include_01.rs::present_classes"
+
+description: |
+  PMAT-844. The `Average::Macro` branch of every multi-class metric in
+  `classification.rs` computed `n_classes = max(y_true ∪ y_pred) + 1` and
+  divided the per-class metric sum by `n_classes`. When labels are
+  non-contiguous (e.g. {0, 2}), the absent intermediate index 1 has
+  tp = fp = fn = 0, so its per-class metric is 0.0, and that spurious zero is
+  folded into the macro mean. A PERFECT classifier on labels {0, 2} therefore
+  scored macro precision = (1.0 + 0.0 + 1.0) / 3 = 0.6667 instead of 1.0.
+
+  scikit-learn's `average='macro'` averages only over the labels ACTUALLY
+  PRESENT — its default `labels = unique_labels(y_true, y_pred)` is the sorted
+  union of observed labels. A label index i is present iff it appears in
+  y_true (`support[i] > 0`) OR was predicted on a sample whose true label
+  differs (`fp[i] > 0`); a correctly-predicted label is necessarily in y_true,
+  so `support[i] > 0` already covers it.
+
+  ## Fix
+
+  `present_classes(fp, support)` returns the indices i with
+  `support[i] > 0 || fp[i] > 0`. Each Macro branch now averages the per-class
+  metric over `present` and divides by `present.len()` (returning 0.0 when the
+  present set is empty — preserving the existing all-zero degenerate guard).
+  `Average::Micro` (pools TP/FP/FN globally) and `Average::Weighted` (divides
+  by total support, so absent classes weight 0 already) are unchanged and were
+  already correct.
+
+equations:
+  present_labels:
+    description: "Macro averages only over labels present in y_true ∪ y_pred (scikit-learn unique_labels default)"
+    formula: |
+      present = { i : support[i] > 0 OR fp[i] > 0 }
+              = unique_labels(y_true, y_pred)   (sorted union of observed labels)
+  macro_average:
+    description: "Per-class metric averaged over present labels only"
+    formula: |
+      macro(metric) = ( Σ_{i ∈ present} metric_i ) / |present|
+      # NOT  ( Σ_{i = 0..max+1} metric_i ) / (max + 1)
+  perfect_classifier_identity:
+    description: "A perfect classifier scores 1.0 under macro averaging for ANY label set, contiguous or not"
+    formula: |
+      ŷ = y  ⇒  macro_precision = macro_recall = macro_f1 = 1.0
+      # holds for non-contiguous labels e.g. {0, 2}; pre-fix this returned 2/3
+
+falsification:
+  - id: FALSIFY-METRICS_MACRO_AVERAGE_V1_001
+    description: "Perfect classifier on non-contiguous labels {0,2} scores macro precision/recall/f1 = 1.0 (was 0.6667)"
+    test: |
+      Unit test: y_true = y_pred = [0,2,0,2]. precision/recall/f1 with
+      Average::Macro must all equal 1.0 (±1e-6). RED (max+1 divisor):
+      (1.0 + 0.0 + 1.0)/3 = 0.6667. GREEN (present-label divisor):
+      (1.0 + 1.0)/2 = 1.0. Verified against scikit-learn
+      precision_recall_fscore_support(average='macro') = 1.0.
+    evidence: "cargo test -p aprender-core --lib tests_macro_present_labels::macro_average_noncontiguous_labels"
+  - id: FALSIFY-METRICS_MACRO_AVERAGE_V1_002
+    description: "Swapped predictions on {0,2} score macro precision = 0.5 (was 0.3333)"
+    test: |
+      Unit test: y_true = [0,0,2,2], y_pred = [0,2,2,0]. Each present class has
+      precision 0.5, so macro = (0.5 + 0.5)/2 = 0.5. RED (max+1 divisor):
+      (0.5 + 0.0 + 0.5)/3 = 0.3333. Verified against scikit-learn = 0.5.
+    evidence: "cargo test -p aprender-core --lib tests_macro_present_labels::macro_average_noncontiguous_labels"
+  - id: FALSIFY-METRICS_MACRO_AVERAGE_V1_003
+    description: "jaccard_score and fbeta_score share the divisor and also reach 1.0 on perfect {0,2}"
+    test: |
+      Unit test: y_true = y_pred = [0,2,0,2]. jaccard_score and fbeta_score
+      (beta=1.0 and beta=0.5) with Average::Macro all equal 1.0 (±1e-6).
+      RED: 2/3 (absent class 1 folds a 0.0 in). GREEN: 1.0.
+    evidence: "cargo test -p aprender-core --lib tests_macro_present_labels::macro_average_noncontiguous_jaccard_fbeta"
+  - id: FALSIFY-METRICS_MACRO_AVERAGE_V1_004
+    description: "Contiguous labels {0,1,2} are unchanged — every class present ⇒ divisor == n_classes"
+    test: |
+      Unit test: perfect dense {0,1,2} still scores 1.0; the known imperfect
+      dense case (y_true=[0,1,2,0,1,2], y_pred=[0,2,1,0,0,1]) keeps macro
+      precision = (2/3)/3. Guards against the fix altering already-correct
+      contiguous-label behavior.
+    evidence: "cargo test -p aprender-core --lib tests_macro_present_labels::macro_average_contiguous_labels_unchanged"
+
+scope_extension:
+  in_scope:
+    - "present_classes(fp, support) helper in classification_include_01.rs"
+    - "Average::Macro divisor for precision, recall, f1_score, jaccard_score, fbeta_score"
+  out_of_scope:
+    - "Average::Micro (pools TP/FP/FN globally — already correct, unchanged)"
+    - "Average::Weighted (divides by total support; absent classes weight 0 — already correct, unchanged)"
+    - "per-class helpers precision_per_class / recall_per_class (return one value per index 0..max; explicitly index-ordered, not macro-averaged)"
+
+status_history:
+  - version: "1.0.0"
+    date: "2026-06-19"
+    pr: "paiml/aprender fix/pmat-844-macro-average-present-labels"
+    summary: |
+      Initial contract registered alongside the PMAT-844 fix. RED proven:
+      macro precision = 0.6666667 for perfect {0,2}. GREEN after introducing
+      present_classes() and averaging over present labels: 1.0. Five Macro
+      branches corrected (precision, recall, f1_score, jaccard_score,
+      fbeta_score). Micro and Weighted unchanged. Four falsification unit
+      tests added in tests_macro_present_labels.

--- a/crates/aprender-core/src/metrics/classification.rs
+++ b/crates/aprender-core/src/metrics/classification.rs
@@ -117,16 +117,14 @@ pub fn precision(y_pred: &[usize], y_true: &[usize], average: Average) -> f32 {
             }
         }
         Average::Macro => {
-            let precisions: Vec<f32> = (0..n_classes)
-                .map(|i| {
-                    if tp[i] + fp[i] == 0 {
-                        0.0
-                    } else {
-                        tp[i] as f32 / (tp[i] + fp[i]) as f32
-                    }
-                })
-                .collect();
-            precisions.iter().sum::<f32>() / n_classes as f32
+            // Average only over labels present in y_true ∪ y_pred (PMAT-844),
+            // matching sklearn's default labels = unique_labels(y_true, y_pred).
+            let present = present_classes(&fp, &support);
+            if present.is_empty() {
+                return 0.0;
+            }
+            let sum: f32 = present.iter().map(|&i| class_precision(tp[i], fp[i])).sum();
+            sum / present.len() as f32
         }
         Average::Weighted => {
             let total_support: usize = support.iter().sum();
@@ -192,7 +190,7 @@ pub fn recall(y_pred: &[usize], y_true: &[usize], average: Average) -> f32 {
         return 0.0;
     }
 
-    let (tp, _, fn_counts, support) = compute_tp_fp_fn(y_pred, y_true, n_classes);
+    let (tp, fp, fn_counts, support) = compute_tp_fp_fn(y_pred, y_true, n_classes);
 
     match average {
         Average::Micro => {
@@ -205,16 +203,16 @@ pub fn recall(y_pred: &[usize], y_true: &[usize], average: Average) -> f32 {
             }
         }
         Average::Macro => {
-            let recalls: Vec<f32> = (0..n_classes)
-                .map(|i| {
-                    if tp[i] + fn_counts[i] == 0 {
-                        0.0
-                    } else {
-                        tp[i] as f32 / (tp[i] + fn_counts[i]) as f32
-                    }
-                })
-                .collect();
-            recalls.iter().sum::<f32>() / n_classes as f32
+            // Average only over labels present in y_true ∪ y_pred (PMAT-844).
+            let present = present_classes(&fp, &support);
+            if present.is_empty() {
+                return 0.0;
+            }
+            let sum: f32 = present
+                .iter()
+                .map(|&i| class_recall(tp[i], fn_counts[i]))
+                .sum();
+            sum / present.len() as f32
         }
         Average::Weighted => {
             let total_support: usize = support.iter().sum();
@@ -324,10 +322,16 @@ pub fn f1_score(y_pred: &[usize], y_true: &[usize], average: Average) -> f32 {
             class_f1(total_tp, total_fp, total_fn)
         }
         Average::Macro => {
-            let f1_sum: f32 = (0..n_classes)
-                .map(|i| class_f1(tp[i], fp[i], fn_counts[i]))
+            // Average only over labels present in y_true ∪ y_pred (PMAT-844).
+            let present = present_classes(&fp, &support);
+            if present.is_empty() {
+                return 0.0;
+            }
+            let f1_sum: f32 = present
+                .iter()
+                .map(|&i| class_f1(tp[i], fp[i], fn_counts[i]))
                 .sum();
-            f1_sum / n_classes as f32
+            f1_sum / present.len() as f32
         }
         Average::Weighted => {
             let total_support: usize = support.iter().sum();
@@ -482,10 +486,16 @@ pub fn jaccard_score(y_pred: &[usize], y_true: &[usize], average: Average) -> f3
     match average {
         Average::Micro => class_jaccard(tp.iter().sum(), fp.iter().sum(), fn_counts.iter().sum()),
         Average::Macro => {
-            (0..n_classes)
-                .map(|i| class_jaccard(tp[i], fp[i], fn_counts[i]))
+            // Average only over labels present in y_true ∪ y_pred (PMAT-844).
+            let present = present_classes(&fp, &support);
+            if present.is_empty() {
+                return 0.0;
+            }
+            present
+                .iter()
+                .map(|&i| class_jaccard(tp[i], fp[i], fn_counts[i]))
                 .sum::<f32>()
-                / n_classes as f32
+                / present.len() as f32
         }
         Average::Weighted => {
             let total: usize = support.iter().sum();
@@ -533,10 +543,16 @@ pub fn fbeta_score(y_pred: &[usize], y_true: &[usize], beta: f32, average: Avera
     match average {
         Average::Micro => class_fbeta(tp.iter().sum(), fp.iter().sum(), fn_counts.iter().sum()),
         Average::Macro => {
-            (0..n_classes)
-                .map(|i| class_fbeta(tp[i], fp[i], fn_counts[i]))
+            // Average only over labels present in y_true ∪ y_pred (PMAT-844).
+            let present = present_classes(&fp, &support);
+            if present.is_empty() {
+                return 0.0;
+            }
+            present
+                .iter()
+                .map(|&i| class_fbeta(tp[i], fp[i], fn_counts[i]))
                 .sum::<f32>()
-                / n_classes as f32
+                / present.len() as f32
         }
         Average::Weighted => {
             let total: usize = support.iter().sum();
@@ -563,5 +579,84 @@ mod tests_jaccard_fbeta {
         assert!((jaccard_score(&yp, &yt, Average::Micro) - 0.454_545).abs() < 1e-4);
         assert!((fbeta_score(&yp, &yt, 0.5, Average::Macro) - 0.625).abs() < 1e-4);
         assert!((fbeta_score(&yp, &yt, 2.0, Average::Macro) - 0.620_301).abs() < 1e-4);
+    }
+}
+
+#[cfg(test)]
+mod tests_macro_present_labels {
+    use super::*;
+
+    /// PMAT-844 / PO-MACRO-001: `Average::Macro` must average per-class metrics
+    /// only over the labels ACTUALLY PRESENT (sorted union of y_true ∪ y_pred),
+    /// matching `sklearn.metrics.precision_recall_fscore_support(average='macro')`
+    /// whose default `labels = unique_labels(y_true, y_pred)`.
+    ///
+    /// Before the fix, the divisor was `max(labels)+1`, so absent intermediate
+    /// class indices (e.g. class 1 when labels are {0, 2}) contributed spurious
+    /// 0.0 terms. A PERFECT classifier on {0, 2} scored 2/3 instead of 1.0.
+    ///
+    /// RED (buggy): precision/recall/f1 = 0.6667 for the perfect {0,2} case,
+    ///              precision = 0.3333 for the swapped {0,2} case.
+    /// GREEN (fixed): 1.0 and 0.5 respectively (verified against scikit-learn).
+    #[test]
+    fn macro_average_noncontiguous_labels() {
+        // Perfect classifier on non-contiguous labels {0, 2} → all metrics 1.0.
+        let yt = vec![0usize, 2, 0, 2];
+        let yp = vec![0usize, 2, 0, 2];
+        let p = precision(&yp, &yt, Average::Macro);
+        let r = recall(&yp, &yt, Average::Macro);
+        let f = f1_score(&yp, &yt, Average::Macro);
+        assert!(
+            (p - 1.0).abs() < 1e-6,
+            "FALSIFIED PMAT-844: macro precision={p} for perfect {{0,2}}, expected 1.0"
+        );
+        assert!(
+            (r - 1.0).abs() < 1e-6,
+            "FALSIFIED PMAT-844: macro recall={r} for perfect {{0,2}}, expected 1.0"
+        );
+        assert!(
+            (f - 1.0).abs() < 1e-6,
+            "FALSIFIED PMAT-844: macro f1={f} for perfect {{0,2}}, expected 1.0"
+        );
+
+        // Swapped predictions on {0, 2}: each class has precision 0.5 → macro 0.5.
+        let yt2 = vec![0usize, 0, 2, 2];
+        let yp2 = vec![0usize, 2, 2, 0];
+        let p2 = precision(&yp2, &yt2, Average::Macro);
+        assert!(
+            (p2 - 0.5).abs() < 1e-6,
+            "FALSIFIED PMAT-844: macro precision={p2} for swapped {{0,2}}, expected 0.5"
+        );
+    }
+
+    /// PMAT-844 sibling metrics: `jaccard_score` and `fbeta_score` share the
+    /// same Macro divisor and must also restrict to present labels.
+    /// Perfect classifier on {0, 2} → both 1.0 (sklearn parity).
+    #[test]
+    fn macro_average_noncontiguous_jaccard_fbeta() {
+        let yt = vec![0usize, 2, 0, 2];
+        let yp = vec![0usize, 2, 0, 2];
+        assert!((jaccard_score(&yp, &yt, Average::Macro) - 1.0).abs() < 1e-6);
+        assert!((fbeta_score(&yp, &yt, 1.0, Average::Macro) - 1.0).abs() < 1e-6);
+        assert!((fbeta_score(&yp, &yt, 0.5, Average::Macro) - 1.0).abs() < 1e-6);
+    }
+
+    /// Regression guard: contiguous labels {0, 1, 2} must be unchanged by the
+    /// present-label fix (every class is present, so divisor == n_classes).
+    #[test]
+    fn macro_average_contiguous_labels_unchanged() {
+        // Perfect classifier on dense {0, 1, 2} → all metrics 1.0.
+        let y = vec![0usize, 1, 2, 0, 1, 2];
+        assert!((precision(&y, &y, Average::Macro) - 1.0).abs() < 1e-6);
+        assert!((recall(&y, &y, Average::Macro) - 1.0).abs() < 1e-6);
+        assert!((f1_score(&y, &y, Average::Macro) - 1.0).abs() < 1e-6);
+
+        // Known imperfect dense case keeps its established value (all 3 classes
+        // present, divisor unchanged at 3).
+        let yt = vec![0usize, 1, 2, 0, 1, 2];
+        let yp = vec![0usize, 2, 1, 0, 0, 1];
+        // class0: tp=2,fp=1 → 2/3; class1: tp=0,fp=2 → 0; class2: tp=0,fp=1 → 0.
+        let expected = (2.0_f32 / 3.0) / 3.0;
+        assert!((precision(&yp, &yt, Average::Macro) - expected).abs() < 1e-6);
     }
 }

--- a/crates/aprender-core/src/metrics/classification_include_01.rs
+++ b/crates/aprender-core/src/metrics/classification_include_01.rs
@@ -126,6 +126,23 @@ fn compute_tp_fp_fn(
     (tp, fp, fn_counts, support)
 }
 
+/// Indices of the class labels ACTUALLY PRESENT in `y_true ∪ y_pred`.
+///
+/// `Average::Macro` averages a per-class metric only over the labels that
+/// actually occur, matching scikit-learn's
+/// `labels = unique_labels(y_true, y_pred)` default. A class index `i`
+/// (with `0 ≤ i < n_classes`) is present iff it appears in `y_true`
+/// (`support[i] > 0`) OR was predicted on a sample whose true label differs
+/// (`fp[i] > 0`); a correctly-predicted label is necessarily in `y_true`, so
+/// `support[i] > 0` already covers it. Absent intermediate indices (e.g.
+/// class 1 when labels are `{0, 2}`) are excluded so their spurious 0.0
+/// per-class scores no longer dilute the macro mean (PMAT-844).
+fn present_classes(fp: &[usize], support: &[usize]) -> Vec<usize> {
+    (0..support.len())
+        .filter(|&i| support[i] > 0 || fp[i] > 0)
+        .collect()
+}
+
 #[path = "classification_report.rs"]
 mod classification_report;
 pub use classification_report::classification_report;


### PR DESCRIPTION
## PMAT-844 — Pillar-4 correctness beat: macro averaging now matches scikit-learn

### The bug
`Average::Macro` for `precision` / `recall` / `f1_score` / `jaccard_score` / `fbeta_score`
divided the per-class metric sum by `n_classes = max(y_true ∪ y_pred) + 1`. With
non-contiguous labels (e.g. `{0, 2}`) the absent intermediate index `1` has
`tp = fp = fn = 0`, so its per-class metric `0.0` is folded into the macro mean.

A **perfect** classifier on `{0, 2}` scored macro precision `(1.0 + 0.0 + 1.0)/3 = 0.6667`
instead of `1.0`.

### The fix
scikit-learn's `average='macro'` averages **only over labels actually present** — its
default `labels = unique_labels(y_true, y_pred)` (sorted union of observed labels).

Adds `present_classes(fp, support)` returning indices `i` with `support[i] > 0`
(appears in `y_true`) OR `fp[i] > 0` (predicted-but-wrong, i.e. appears in `y_pred`).
Each Macro branch now sums over present labels and divides by `present.len()`.

`Average::Micro` (pools TP/FP/FN globally) and `Average::Weighted` (divides by total
support; absent classes weight 0) were already correct and are **unchanged**.

### Falsifier — RED → GREEN (verified vs scikit-learn)
| input | metric | aprender (RED) | aprender (GREEN) | sklearn |
|-------|--------|----------------|------------------|---------|
| `yt=yp=[0,2,0,2]` | macro precision/recall/f1 | 0.6667 | **1.0** | 1.0 |
| `yt=[0,0,2,2] yp=[0,2,2,0]` | macro precision | 0.3333 | **0.5** | 0.5 |
| `yt=yp=[0,2,0,2]` | macro jaccard / fβ | 0.6667 | **1.0** | 1.0 |

Contiguous `{0,1,2}` cases are unchanged (regression guard included).

### Evidence
- `cargo test -p aprender-core --lib tests_macro_present_labels` — 3/3 pass (RED before fix)
- `cargo test -p aprender-core --lib` — **13904 passed, 0 failed**, 2 ignored
- `cargo fmt -p aprender-core --check` clean; `cargo clippy -p aprender-core` clean
- Contract `contracts/metrics-macro-average-v1.yaml` (`kind: KernelContract`) — `pv validate`: **0 error(s)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)