### PR TITLE
fix(format): f16->f32 subnormals halved by exponent off-by-one (PMAT-843)

### DIFF
--- a/contracts/f16-to-f32-subnormal-v1.yaml
+++ b/contracts/f16-to-f32-subnormal-v1.yaml
@@ -1,0 +1,80 @@
+metadata:
+  version: "1.0.0"
+  created: "2026-06-19"
+  author: PAIML Engineering
+  registry: true
+  references:
+    - "IEEE 754-2019 §3.6 binary16 — subnormals have biased exponent field 0 and value mantissa * 2^-24"
+    - "half crate (half::f16::from_bits(bits).to_f32()) — the bit-exact conversion oracle"
+    - "crates/aprender-core/src/format/onnx/mod.rs::f16_to_f32 (ONNX import path)"
+    - "crates/aprender-core/src/format/safetensors.rs::f16_to_f32 (SafeTensors/apr tensors path)"
+  description: |
+    Correctness contract for IEEE-754 half-precision (binary16) -> single-precision
+    (binary32) conversion in the two aprender-core format readers. Pillar-4 (Ollama/serve)
+    + diagnostic correctness: apr tensors / apr inspect / apr validate --quality on F16
+    SafeTensors and ONNX models must report exact tensor statistics.
+
+kind: KernelContract
+name: f16-to-f32-subnormal
+version: "1.0.0"
+scope: "crates/aprender-core/src/format/onnx/mod.rs, crates/aprender-core/src/format/safetensors.rs"
+
+description: |
+  binary16 subnormals (biased exponent field == 0, mantissa != 0) have value
+  mantissa * 2^-24. Both f16_to_f32 implementations normalize the subnormal mantissa
+  with a shift loop, then reconstruct the f32 biased exponent. PMAT-843 fixed an
+  off-by-one in the reconstructed exponent that HALVED every subnormal value:
+
+    - onnx/mod.rs: the loop counter `e` starts at 0, so the f32 exponent needs a +1
+      bias correction. It read `let f32_exp = 127 - 15 - e;` (missing +1).
+    - safetensors.rs: the loop counter `e` starts at 1, so the f32 exponent needs a +2
+      bias correction. It read `(127 - 15 - e + 1) << 23` (only +1, i.e. +1 too low).
+
+  The ratio of buggy:correct is exactly 2.0 for ALL 2046 subnormal bit patterns
+  (exponent field 0, nonzero mantissa). Normals, +/-zero, +/-inf and NaN were already
+  correct. Impact: apr tensors / apr inspect / apr validate --quality on any F16
+  SafeTensors or ONNX model report min / mean / std with every subnormal weight at half
+  magnitude, which can flip a fail-closed near-zero / dead-weight quality threshold
+  (Pillar-4). The ONNX path also corrupts ONNX import tensor extraction.
+
+equations:
+  C-F16SUB-001:
+    description: "The smallest positive subnormal converts exactly, not halved"
+    formula: "f16_to_f32(0x0001).to_bits() == 0x33800000 (5.9604645e-8 == 2^-24); buggy gave 0x33000000 (2.9802322e-8 == 2^-25)"
+    note: "The single canonical falsifier — a dropped +1 in the reconstructed exponent halves the value."
+  C-F16SUB-002:
+    description: "Every binary16 bit pattern (NaN excluded) converts bit-exactly to the half-crate oracle"
+    formula: "∀ bits in 0..=0xFFFF \\ NaN: f16_to_f32(bits).to_bits() == half::f16::from_bits(bits).to_f32().to_bits()"
+    note: "RED mismatch count = 2046 (all subnormals halved) before fix; GREEN = 0 after fix. Holds for BOTH onnx and safetensors readers."
+  C-F16SUB-003:
+    description: "Subnormal value law: a binary16 subnormal equals mantissa * 2^-24"
+    formula: "for exponent field 0 and mantissa m != 0: f16_to_f32(bits) == (m as f32) * 2^-24"
+    note: "Structural law independent of the half crate; RED gave m * 2^-25 (off-by-one exponent)."
+
+proof_obligations:
+  - id: PO-F16SUB-001
+    type: equivalence
+    property: "f16_to_f32 matches the half-crate oracle over all non-NaN bit patterns"
+    formal: "∀ bits (non-NaN): f16_to_f32(bits).to_bits() == half::f16::from_bits(bits).to_f32().to_bits()"
+    applies_to: all
+  - id: PO-F16SUB-002
+    type: invariant
+    property: "Subnormal magnitude is preserved (not halved)"
+    formal: "f16_to_f32(0x0001).to_bits() == 0x33800000"
+    applies_to: all
+  - id: PO-F16SUB-003
+    type: bound
+    property: "Subnormal mantissa scaling is exactly 2^-24"
+    formal: "exponent field 0, mantissa m != 0 ⟹ f16_to_f32(bits) == (m as f32) * 2^-24"
+    tolerance: 0.0
+    applies_to: all
+
+falsification:
+  - id: FALSIFY-F16SUB-001
+    description: "Smallest positive subnormal is not halved (onnx + safetensors readers). Discharges C-F16SUB-001 / PO-F16SUB-002."
+    test: "smallest_subnormal_not_halved (in both format::onnx::f16_tests and format::tensors::f16_tests) — RED 0x33000000 (2.9802322e-8) → GREEN 0x33800000 (5.9604645e-8 == half::f16::from_bits(1).to_f32())."
+    evidence: "cargo test -p aprender-core --lib f16_tests::smallest_subnormal_not_halved"
+  - id: FALSIFY-F16SUB-002
+    description: "Full-range bit-exact conversion vs the half oracle (onnx + safetensors readers). Discharges C-F16SUB-002 / C-F16SUB-003 / PO-F16SUB-001 / PO-F16SUB-003."
+    test: "all_bit_patterns_match_golden (in both format::onnx::f16_tests and format::tensors::f16_tests) — loops 0..=u16::MAX, skips NaN, compares against a self-contained golden oracle bit-verified against half::f16. RED mismatch count = 2046 (all subnormals); GREEN = 0."
+    evidence: "cargo test -p aprender-core --lib f16_tests::all_bit_patterns_match_golden"

--- a/crates/aprender-core/src/format/onnx/mod.rs
+++ b/crates/aprender-core/src/format/onnx/mod.rs
@@ -160,7 +160,9 @@ fn f16_to_f32(bits: u16) -> f32 {
                 m <<= 1;
                 e += 1;
             }
-            let f32_exp = 127 - 15 - e;
+            // PMAT-843: `e` starts at 0, so the reconstructed f32 exponent
+            // needs a +1 bias correction; without it every subnormal is halved.
+            let f32_exp = 127 - 15 - e + 1;
             let f32_mant = (m & 0x3FF) << 13;
             f32::from_bits((sign << 31) | (f32_exp << 23) | f32_mant)
         }
@@ -205,3 +207,69 @@ pub struct OnnxReader {
 }
 
 include!("reader.rs");
+
+#[cfg(test)]
+mod f16_tests {
+    use super::f16_to_f32;
+
+    /// Self-contained, bit-exact IEEE-754 binary16 -> binary32 reference
+    /// (golden oracle). Verified bit-identical to `half::f16::to_f32()` across
+    /// all 65536 patterns (NaN excluded). PMAT-843.
+    fn golden_f16_to_f32(bits: u16) -> f32 {
+        let sign = (bits >> 15) & 1;
+        let exp = i32::from((bits >> 10) & 0x1F);
+        let man = u32::from(bits & 0x3FF);
+        let s = (sign as f32).mul_add(-2.0, 1.0); // +1.0 if sign=0, -1.0 if sign=1
+        if exp == 0 {
+            // zero or subnormal: value = mantissa * 2^-24
+            s * (man as f32) * 2f32.powi(-24)
+        } else if exp == 0x1F {
+            if man == 0 {
+                if sign == 1 {
+                    f32::NEG_INFINITY
+                } else {
+                    f32::INFINITY
+                }
+            } else {
+                f32::NAN
+            }
+        } else {
+            // normal: value = (1 + mantissa/1024) * 2^(exp-15)
+            s * (1.0 + (man as f32) / 1024.0) * 2f32.powi(exp - 15)
+        }
+    }
+
+    /// PMAT-843 falsifier: smallest positive subnormal must NOT be halved.
+    /// RED (buggy): 0x33000000 (2.9802322e-8) = exactly half. GREEN:
+    /// 0x33800000 (5.9604645e-8) = `half::f16::from_bits(1).to_f32()`.
+    #[test]
+    fn smallest_subnormal_not_halved() {
+        let got = f16_to_f32(0x0001).to_bits();
+        assert_eq!(
+            got, 0x3380_0000,
+            "f16_to_f32(0x0001) = {got:#010x}, expected 0x33800000 (5.9604645e-8)"
+        );
+    }
+
+    /// PMAT-843 strong falsifier: every f16 bit pattern (NaN excluded) must
+    /// convert bit-exactly to the golden oracle. RED count (buggy) = 2046
+    /// (all subnormals halved); GREEN = 0.
+    #[test]
+    fn all_bit_patterns_match_golden() {
+        let mut mismatches = 0u32;
+        for bits in 0..=u16::MAX {
+            let exp = (bits >> 10) & 0x1F;
+            let man = bits & 0x3FF;
+            if exp == 0x1F && man != 0 {
+                continue; // skip NaN (bit pattern not canonical)
+            }
+            if f16_to_f32(bits).to_bits() != golden_f16_to_f32(bits).to_bits() {
+                mismatches += 1;
+            }
+        }
+        assert_eq!(
+            mismatches, 0,
+            "{mismatches} f16->f32 conversions disagree with golden oracle"
+        );
+    }
+}

--- a/crates/aprender-core/src/format/safetensors.rs
+++ b/crates/aprender-core/src/format/safetensors.rs
@@ -1,4 +1,3 @@
-
 /// Bytes per element for GGML data types (table lookup, O(1)).
 ///
 /// Block-quantized types use approximate bytes-per-element.
@@ -9,10 +8,9 @@ fn ggml_dtype_element_size(dtype: u32) -> f64 {
     //         IQ3_XXS, IQ1_S, IQ4_NL, IQ3_S, IQ2_S, IQ4_XS, I8, I16,
     //         BF16, I32, I64, F64, IQ1_M]
     const SIZES: [f64; 31] = [
-        4.0, 2.0, 0.5625, 0.625, 4.0, 4.0, 0.6875, 0.75,
-        1.0625, 1.125, 0.3125, 0.4375, 0.5625, 0.6875, 0.8125, 1.0625,
-        0.5625, 0.625, 0.6875, 0.4375, 0.5625, 0.4375, 0.625, 0.5,
-        1.0, 2.0, 2.0, 4.0, 8.0, 8.0, 0.375,
+        4.0, 2.0, 0.5625, 0.625, 4.0, 4.0, 0.6875, 0.75, 1.0625, 1.125, 0.3125, 0.4375, 0.5625,
+        0.6875, 0.8125, 1.0625, 0.5625, 0.625, 0.6875, 0.4375, 0.5625, 0.4375, 0.625, 0.5, 1.0,
+        2.0, 2.0, 4.0, 8.0, 8.0, 0.375,
     ];
     SIZES.get(dtype as usize).copied().unwrap_or(4.0)
 }
@@ -294,7 +292,9 @@ fn f16_to_f32(bits: u16) -> f32 {
             m <<= 1;
             e += 1;
         }
-        let f32_exp = (127 - 15 - e + 1) << 23;
+        // PMAT-843: `e` starts at 1, so the reconstructed f32 exponent needs a
+        // +2 bias correction (was +1); without it every subnormal is halved.
+        let f32_exp = (127 - 15 - e + 2) << 23;
         let f32_mant = (m & 0x3FF) << 13;
         f32::from_bits(sign | f32_exp | f32_mant)
     } else if exponent == 31 {
@@ -386,4 +386,69 @@ pub fn list_tensors(
     result.file = path.display().to_string();
 
     Ok(result)
+}
+
+#[cfg(test)]
+mod f16_tests {
+    use super::f16_to_f32;
+
+    /// Self-contained, bit-exact IEEE-754 binary16 -> binary32 reference
+    /// (golden oracle). Verified bit-identical to `half::f16::to_f32()` across
+    /// all 65536 patterns (NaN excluded). PMAT-843.
+    fn golden_f16_to_f32(bits: u16) -> f32 {
+        let sign = (bits >> 15) & 1;
+        let exp = i32::from((bits >> 10) & 0x1F);
+        let man = u32::from(bits & 0x3FF);
+        let s = (sign as f32).mul_add(-2.0, 1.0); // +1.0 if sign=0, -1.0 if sign=1
+        if exp == 0 {
+            // zero or subnormal: value = mantissa * 2^-24
+            s * (man as f32) * 2f32.powi(-24)
+        } else if exp == 0x1F {
+            if man == 0 {
+                if sign == 1 {
+                    f32::NEG_INFINITY
+                } else {
+                    f32::INFINITY
+                }
+            } else {
+                f32::NAN
+            }
+        } else {
+            // normal: value = (1 + mantissa/1024) * 2^(exp-15)
+            s * (1.0 + (man as f32) / 1024.0) * 2f32.powi(exp - 15)
+        }
+    }
+
+    /// PMAT-843 falsifier: smallest positive subnormal must NOT be halved.
+    /// RED (buggy): 0x33000000 (2.9802322e-8). GREEN: 0x33800000 (5.9604645e-8).
+    #[test]
+    fn smallest_subnormal_not_halved() {
+        let got = f16_to_f32(0x0001).to_bits();
+        assert_eq!(
+            got, 0x3380_0000,
+            "f16_to_f32(0x0001) = {got:#010x}, expected 0x33800000 (5.9604645e-8)"
+        );
+    }
+
+    /// PMAT-843 strong falsifier: every f16 bit pattern (NaN excluded) must
+    /// convert bit-exactly to the golden oracle. RED count (buggy) = 2046
+    /// (all subnormals halved); GREEN = 0.
+    #[test]
+    fn all_bit_patterns_match_golden() {
+        let mut mismatches = 0u32;
+        for bits in 0..=u16::MAX {
+            let exp = (bits >> 10) & 0x1F;
+            let man = bits & 0x3FF;
+            if exp == 0x1F && man != 0 {
+                continue; // skip NaN (bit pattern not canonical)
+            }
+            if f16_to_f32(bits).to_bits() != golden_f16_to_f32(bits).to_bits() {
+                mismatches += 1;
+            }
+        }
+        assert_eq!(
+            mismatches, 0,
+            "{mismatches} f16->f32 conversions disagree with golden oracle"
+        );
+    }
 }


### PR DESCRIPTION
## PMAT-843 — f16→f32 subnormals were halved (correctness bug, conf 0.97)

IEEE-754 binary16 subnormals (exponent field `0`, mantissa `!= 0`) have value `mantissa · 2⁻²⁴`. Both `f16_to_f32` readers reconstructed the f32 biased exponent **one too low**, halving **every** subnormal value. The ratio buggy:correct is exactly `2.0` for all **2046** subnormal bit patterns. Normals, ±zero, ±inf and NaN were already correct.

### Root cause (a dropped `+1` in the reconstructed exponent)
- `crates/aprender-core/src/format/onnx/mod.rs` — loop counter `e` starts at `0` → needs `+1`. Was `127 - 15 - e` → now `127 - 15 - e + 1`.
- `crates/aprender-core/src/format/safetensors.rs` — loop counter `e` starts at `1` → needs `+2`. Was `(127 - 15 - e + 1) << 23` → now `(127 - 15 - e + 2) << 23`.

### Repro
`f16_to_f32(0x0001)` returned `0x33000000` (`2.9802322e-8` = `2⁻²⁵`); correct is `0x33800000` (`5.9604645e-8` = `2⁻²⁴` = `half::f16::from_bits(1).to_f32()`).

### Impact (Pillar-4)
`apr tensors` / `apr inspect` / `apr validate --quality` on any F16 SafeTensors or ONNX model reported min/mean/std with every subnormal weight at **half** magnitude — which can flip a fail-closed near-zero / dead-weight quality threshold. The ONNX path also corrupted ONNX import tensor extraction.

### Falsifier-first (RED → GREEN)
One direct + one full-range loop test per reader module (`format::onnx::f16_tests`, `format::tensors::f16_tests`):
- `smallest_subnormal_not_halved`: **RED** `0x33000000` → **GREEN** `0x33800000`.
- `all_bit_patterns_match_golden`: loops `0..=u16::MAX` (NaN excluded) against a self-contained golden oracle, bit-verified against the `half` crate over all 65536 patterns. **RED mismatch count = 2046** (all subnormals) → **GREEN = 0**.

Proven RED before the fix, GREEN after. No new dependency added (golden oracle is self-contained, verified bit-identical to `half`).

### Verification
- `cargo test -p aprender-core --lib f16_tests` — 4/4 pass (GREEN).
- `cargo test -p aprender-core --lib` — 13903 pass, 0 failures attributable to this change. (Two `citl::compiler` cargo-spawning tests flake under concurrent worktree load; they pass on a clean checkout and in worktree isolation — unrelated to `format`.)
- `cargo build -p aprender-core` — OK. `cargo clippy -p aprender-core --lib` — clean. `rustfmt --check` — clean.

### Contract
`contracts/f16-to-f32-subnormal-v1.yaml` (`kind: KernelContract`): equations `C-F16SUB-001..003`, proof obligations `PO-F16SUB-001..003`, falsification `FALSIFY-F16SUB-001/002` with RED/GREEN evidence + the 2046 mismatch count; references IEEE-754 binary16 + the `half` crate.
`pv validate` → **0 error(s), 0 warning(s)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)