### PR TITLE
fix(metrics): silhouette_score scored singleton clusters +1.0 instead of 0 (PMAT-845)

### DIFF
--- a/contracts/silhouette-singleton-v1.yaml
+++ b/contracts/silhouette-singleton-v1.yaml
@@ -1,0 +1,111 @@
+metadata:
+  version: 1.0.0
+  created: '2026-06-19'
+  author: PAIML Engineering
+  description: |
+    PMAT-845: silhouette_score must assign exactly 0 to any sample whose cluster
+    has size 1 (a singleton), matching scikit-learn.
+
+    sklearn computes the per-sample intra-cluster distance as
+    intra_clust_dist = sum_intra / (cluster_size - 1). For a singleton cluster
+    that is 0 / 0 = NaN, which sklearn then runs through np.nan_to_num → 0, and
+    the silhouette_samples docstring states: "clusters of size 1 ... are
+    assigned a value of 0."
+
+    aprender's mean_intra_cluster_distance previously returned a_i = 0.0 for the
+    empty-distances (singleton) branch. silhouette_coefficient(0.0, b_i) then
+    computed (b_i - 0)/max(0, b_i) = +1.0 — the BEST possible value — for any
+    b_i > 0. silhouette_score averages these, biasing the score upward. The fix
+    makes mean_intra_cluster_distance return Option<f32> (None for a singleton)
+    and the per-sample map assigns 0.0 on None.
+
+    Verified repro vs sklearn:
+      data = [[0,0],[0.1,0],[10,0]], labels = [0,0,1]  (cluster 1 is a singleton)
+      sklearn silhouette_samples = [0.99, 0.9899, 0.0]  → score = 0.6600
+      aprender (buggy)            = [0.99, 0.9899, 1.0]  → score = 0.9933
+      aprender (fixed)            = [0.99, 0.9899, 0.0]  → score = 0.6600
+  references:
+  - 'scikit-learn metrics/cluster/_unsupervised.py::silhouette_samples — intra_clust_dist = sum/(size-1) → np.nan_to_num; size-1 clusters assigned 0'
+  - 'Rousseeuw (1987) Silhouettes: a graphical aid to interpretation of cluster analysis'
+  - 'crates/aprender-core/src/metrics/mod.rs — mean_intra_cluster_distance (Option<f32>), silhouette_score singleton branch'
+
+kind: KernelContract
+name: silhouette-singleton-zero
+version: 1.0.0
+scope: aprender-core silhouette_score singleton-cluster convention (metrics/mod.rs)
+
+equations:
+  C-SINGLETON-SILHOUETTE-ZERO:
+    formula: |
+      For sample i in cluster c with |c| = 1 (singleton), the per-sample
+      silhouette s(i) = 0. Equivalently a(i) is undefined (sum/(|c|-1) = 0/0)
+      and sklearn nan_to_num maps it to 0, so s(i) := 0 regardless of b(i).
+      For |c| >= 2, s(i) = (b(i) - a(i)) / max(a(i), b(i)) as usual.
+    domain: data ∈ ℝ^{n×d}, labels ∈ {0..K-1}ⁿ, K ≥ 2, n ≥ 2
+    codomain: s(i) ∈ [-1, 1]; s(i) = 0 exactly when |cluster(i)| = 1
+    invariants:
+    - 'a singleton sample contributes 0 (NOT +1.0) to the mean silhouette'
+    - 'an all-singleton clustering scores exactly 0.0'
+    - 'silhouette_score never exceeds the sklearn reference for the same input'
+    - 'non-singleton samples are unaffected (s(i) unchanged for |c| >= 2)'
+    lean_theorem: Theorems.Silhouette_Singleton_Zero
+
+proof_obligations:
+- type: invariant
+  property: PO-SINGLETON-ZERO singleton sample silhouette is zero
+  formal: |
+    For data=[[0,0],[0.1,0],[10,0]], labels=[0,0,1], the singleton cluster 1
+    contributes 0 to the mean, so silhouette_score ≈ 0.6600 (sklearn parity),
+    NOT the buggy 0.9933 produced by treating the singleton's a_i as 0.0.
+- type: invariant
+  property: PO-ALL-SINGLETON-ZERO all-singleton clustering scores zero
+  formal: |
+    For any labeling where every cluster has size 1, every per-sample silhouette
+    is 0, so silhouette_score = 0.0 exactly.
+- type: invariant
+  property: PO-NON-SINGLETON-UNAFFECTED clusters of size >= 2 unchanged
+  formal: |
+    For data with all clusters of size >= 2 (e.g. well-separated pairs), the
+    score is unchanged by the fix (no singleton branch is taken).
+
+falsification_tests:
+- id: FT-SILHOUETTE-SINGLETON-001
+  rule: a singleton cluster contributes 0 (not +1.0) to the silhouette mean
+  prediction: |
+    silhouette_score([[0,0],[0.1,0],[10,0]], [0,0,1]) ≈ 0.6600 (sklearn parity).
+    RED (pre-fix): 0.9933 — singleton scored +1.0 via (b-0)/max(0,b).
+    GREEN (post-fix): 0.6600 — singleton scored 0.
+  if_fails: 'mean_intra_cluster_distance returns 0.0 (not None) for the empty/singleton branch.'
+  evidence: cargo test -p aprender-core --lib test_silhouette_score_singleton_cluster_pmat845
+- id: FT-SILHOUETTE-SINGLETON-002
+  rule: an all-singleton clustering scores exactly 0.0
+  prediction: |
+    silhouette_score with every point in its own cluster = 0.0.
+    RED (pre-fix): 1.0. GREEN (post-fix): 0.0.
+  if_fails: 'the singleton silhouette is not forced to 0 in the per-sample map.'
+  evidence: cargo test -p aprender-core --lib test_silhouette_score_all_singletons_pmat845
+- id: FT-SILHOUETTE-SINGLETON-003
+  rule: clusters of size >= 2 are unaffected by the singleton fix
+  prediction: 'well-separated size-2 clusters still score > 0.9 (no regression).'
+  if_fails: 'the Option<f32> change altered the non-singleton path.'
+  evidence: cargo test -p aprender-core --lib test_silhouette_score_good
+
+kani_harnesses:
+- id: KANI-SILHOUETTE-SINGLETON-001
+  obligation: PO-SINGLETON-ZERO singleton sample silhouette is zero
+  property: |
+    For all b in [0, B]: silhouette_coefficient applied to a singleton sample
+    is replaced by 0, so the singleton's contribution is 0 (NOT (b-0)/max(0,b)=1
+    for b>0). No panic; result in [-1, 1].
+  bound: 1
+  strategy: stub_float
+  solver: cadical
+  harness: verify_singleton_silhouette_is_zero
+
+qa_gate:
+  id: F-SILHOUETTE-SINGLETON-001
+  name: silhouette-singleton-v1 Contract
+  description: silhouette_score must assign 0 to size-1 clusters (sklearn parity), not the +1.0 produced by treating a singleton's intra-cluster distance as 0.0.
+  checks:
+  - validation
+  - falsification

--- a/crates/aprender-core/src/metrics/metrics_tests.rs
+++ b/crates/aprender-core/src/metrics/metrics_tests.rs
@@ -146,17 +146,54 @@ fn test_silhouette_score_single_sample() {
 
 #[test]
 fn test_silhouette_score_two_samples() {
-    // Test with exactly 2 samples - catches n_samples < 2 → <= 2 mutation (line 288)
+    // PMAT-845: 2 samples in 2 distinct clusters = ALL singletons.
+    // sklearn convention: a sample whose cluster has size 1 gets silhouette 0
+    // (intra_clust_dist = sum/(size-1) → 0/0 = NaN → nan_to_num → 0).
+    // So the mean over two singletons is exactly 0.0.
+    // Previously this test asserted `score.abs() > 0.0`, which ENCODED the bug
+    // (singleton wrongly scored +1.0 via (b-0)/max(0,b)).
     let data = Matrix::from_vec(2, 2, vec![0.0, 0.0, 10.0, 10.0])
         .expect("Matrix dimensions (2x2) match data length (4)");
     let labels = vec![0, 1];
     let score = silhouette_score(&data, &labels);
 
-    // With 2 samples in different clusters, silhouette should be meaningful (not 0)
-    // If mutation changes < to <=, this would return 0.0
     assert!(
-        score.abs() > 0.0,
-        "Score with 2 samples should be non-zero, got {score}"
+        score.abs() < 1e-6,
+        "All-singleton clustering must score 0.0 (sklearn convention), got {score}"
+    );
+}
+
+#[test]
+fn test_silhouette_score_singleton_cluster_pmat845() {
+    // PMAT-845 falsifier: cluster 1 is a singleton (point [10,0]).
+    // Verified against sklearn.metrics.silhouette_score:
+    //   data=[[0,0],[0.1,0],[10,0]], labels=[0,0,1]
+    //   silhouette_samples = [0.99, 0.9899..., 0.0]  (singleton → 0)
+    //   silhouette_score    = 0.6600 (mean of the three)
+    // Buggy aprender produced singleton s=1.0 → score ≈ 0.9933.
+    let data = Matrix::from_vec(3, 2, vec![0.0, 0.0, 0.1, 0.0, 10.0, 0.0])
+        .expect("Matrix dimensions (3x2) match data length (6)");
+    let labels = vec![0, 0, 1];
+    let score = silhouette_score(&data, &labels);
+
+    assert!(
+        (score - 0.6600).abs() < 1e-3,
+        "Singleton cluster must score 0.0 (sklearn parity); expected ~0.6600, got {score}"
+    );
+}
+
+#[test]
+fn test_silhouette_score_all_singletons_pmat845() {
+    // PMAT-845 falsifier: every point in its own cluster → every sample is a
+    // singleton → every per-sample silhouette is 0 → mean score is 0.0.
+    let data = Matrix::from_vec(3, 2, vec![0.0, 0.0, 1.0, 0.0, 2.0, 0.0])
+        .expect("Matrix dimensions (3x2) match data length (6)");
+    let labels = vec![0, 1, 2];
+    let score = silhouette_score(&data, &labels);
+
+    assert!(
+        score.abs() < 1e-6,
+        "All-singleton clustering must score 0.0 (sklearn convention), got {score}"
     );
 }
 

--- a/crates/aprender-core/src/metrics/mod.rs
+++ b/crates/aprender-core/src/metrics/mod.rs
@@ -212,12 +212,19 @@ pub fn inertia(data: &Matrix<f32>, centroids: &Matrix<f32>, labels: &[usize]) ->
 }
 
 /// Computes the mean distance from a point to other points in the same cluster.
+///
+/// Returns `None` when the point's cluster has size 1 (no other members), i.e. a
+/// singleton cluster. sklearn computes `intra_clust_dist = sum / (size - 1)`, which
+/// is `0 / 0 = NaN` for a singleton; it then `np.nan_to_num`s that to 0, and the
+/// docstring states "clusters of size 1 ... are assigned a value of 0". Returning
+/// `None` lets the caller assign that sample a silhouette of exactly 0, rather than
+/// the wrong `+1.0` produced by treating the intra-distance as 0.0 (PMAT-845).
 fn mean_intra_cluster_distance(
     data: &Matrix<f32>,
     point_idx: usize,
     cluster: usize,
     labels: &[usize],
-) -> f32 {
+) -> Option<f32> {
     let point = data.row(point_idx);
     let distances: Vec<f32> = labels
         .iter()
@@ -230,9 +237,10 @@ fn mean_intra_cluster_distance(
         .collect();
 
     if distances.is_empty() {
-        0.0
+        // Singleton cluster: sklearn assigns silhouette 0 to this sample.
+        None
     } else {
-        distances.iter().sum::<f32>() / distances.len() as f32
+        Some(distances.iter().sum::<f32>() / distances.len() as f32)
     }
 }
 
@@ -332,9 +340,13 @@ pub fn silhouette_score(data: &Matrix<f32>, labels: &[usize]) -> f32 {
     let silhouettes: Vec<f32> = (0..n_samples)
         .map(|i| {
             let cluster = labels[i];
-            let a_i = mean_intra_cluster_distance(data, i, cluster, labels);
             let b_i = min_inter_cluster_distance(data, i, cluster, labels, n_clusters);
-            silhouette_coefficient(a_i, b_i)
+            // PMAT-845: a singleton cluster (no intra-cluster neighbors) is assigned
+            // silhouette 0 per sklearn, not (b_i - 0)/max(0, b_i) = +1.0.
+            match mean_intra_cluster_distance(data, i, cluster, labels) {
+                None => 0.0,
+                Some(a_i) => silhouette_coefficient(a_i, b_i),
+            }
         })
         .collect();
 


### PR DESCRIPTION
## Summary

`silhouette_score` scored a **singleton cluster at +1.0** (the best possible value) instead of scikit-learn's **0**, biasing the overall score upward.

A point that is the sole member of its cluster has no intra-cluster neighbors, so `mean_intra_cluster_distance` returned `a_i = 0.0`; then `silhouette_coefficient(0, b_i) = (b_i - 0)/max(0, b_i) = +1.0` for any `b_i > 0`.

scikit-learn assigns any size-1 cluster a silhouette of exactly 0 (`intra_clust_dist = sum/(size-1) = 0/0 = NaN → nan_to_num → 0`; *"clusters of size 1 are assigned a value of 0"*).

## Repro (verified vs sklearn)
`data=[[0,0],[0.1,0],[10,0]]`, `labels=[0,0,1]` → sklearn `0.6600`, aprender `0.9933`.

## Fix
`mean_intra_cluster_distance` now returns `Option<f32>` (`None` for a singleton); `silhouette_score` maps `None → 0.0`.

## Verification
- RED: `test_silhouette_score_singleton_cluster_pmat845` fails at `0.9933` with the fix stashed.
- GREEN: passes at `0.6600`; `test_silhouette_score_all_singletons_pmat845` → 0.
- Corrected `test_silhouette_score_two_samples` (it had asserted the buggy non-zero score).
- `cargo test -p aprender-core --lib` → **13903 passed / 0 failed**.
- `contracts/silhouette-singleton-v1.yaml` — `pv validate` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)