### PR TITLE
fix(serve): XTC sampling removed the boundary token it must keep — inverted algorithm (PMAT-846)

### DIFF
--- a/contracts/xtc-sampling-correctness-v1.yaml
+++ b/contracts/xtc-sampling-correctness-v1.yaml
@@ -1,0 +1,58 @@
+metadata:
+  version: "1.0.0"
+  created: "2026-06-19"
+  author: PAIML Engineering
+  registry: true
+  references:
+    - "llama.cpp src/llama-sampling.cpp llama_sample_xtc_apply"
+    - "XTC (Exclude Top Choices) sampling — text-generation-webui / llama.cpp"
+  description: |
+    Correctness contract for apr's XTC (Exclude Top Choices) sampler. XTC must remove the
+    strictly-most-probable above-threshold tokens to increase diversity while ALWAYS preserving
+    the boundary token (the least-probable token at/above the threshold) and the entire
+    below-threshold tail. apr beats Ollama/llama.cpp on parity only if it keeps that boundary.
+kind: KernelContract
+name: xtc-sampling-correctness
+version: "1.0.0"
+scope: "crates/aprender-serve/src/generate/dry_penalty.rs"
+description: |
+  PMAT-846: `apply_xtc` excluded EVERY token with `prob >= threshold` (setting it to
+  -inf), gated only by `data.len() - excluded_count > config.min_keep`. Because the guard
+  subtracts from `data.len()` (the FULL vocabulary, e.g. 32000) rather than from the number of
+  tokens that would remain, with any realistic vocab and small `min_keep` it removed the ENTIRE
+  above-threshold set — including the boundary token XTC is specifically designed to keep. It
+  also lacked the canonical `threshold > 0.5` no-op guard.
+
+  For logits `[4,3,2,-10,-10]`, threshold 0.1, min_keep 1: softmax `[0.665,0.245,0.090,~0,~0]`,
+  tokens 0 and 1 are above threshold. llama.cpp computes `pos_last = 1` (the sorted index of the
+  LAST above-threshold token) and removes only `[0, pos_last)` — i.e. drops the top token (idx 0)
+  and KEEPS the boundary (idx 1, value 3.0). apr instead set idx 1 to -inf.
+
+  Fix: reimplement to canonical XTC — early no-op when `threshold > 0.5`; scan the
+  probability-sorted-descending array for `pos_last` (last index with `p >= threshold`); and only
+  when `len - pos_last >= min_keep && pos_last > 0`, set the first `pos_last` (strictly-most-
+  probable) tokens to -inf, leaving the boundary token and the below-threshold tail finite.
+equations:
+  C-XTC-001:
+    description: "XTC preserves the boundary token (last token with p >= threshold) and the below-threshold tail."
+    formula: "apply_xtc(logits) ⟹ finite(logits[boundary]) ∧ ∀ t: p(t) < threshold ⟹ finite(logits[t])"
+    note: "boundary = argmin over {t : p(t) >= threshold} of p(t); only the strictly-more-probable above-threshold tokens are removed."
+  C-XTC-002:
+    description: "XTC is a no-op when fewer than two tokens are above threshold, or when threshold > 0.5."
+    formula: "(|{t : p(t) >= threshold}| < 2) ∨ (threshold > 0.5) ⟹ apply_xtc(logits) == logits"
+    note: "pos_last > 0 requires at least two above-threshold tokens before any removal occurs."
+proof_obligations:
+  - id: PO-XTC-001
+    kind: correctness
+    statement: "apply_xtc never sets the boundary (least-probable above-threshold) token to -inf when it fires."
+    discharged_by: FALSIFY-XTC-KEEP-BOUNDARY
+falsification:
+  - id: FALSIFY-XTC-KEEP-BOUNDARY
+    description: "On logits [4,3,2,-10,-10] with threshold 0.1, min_keep 1, XTC removes the top token (idx 0) but keeps the boundary token (idx 1 = 3.0). Discharges C-XTC-001 and PO-XTC-001."
+    test: "cargo test -p aprender-serve --lib test_apply_xtc_keeps_boundary_token_pmat846"
+    evidence: |
+      RED (pre-fix): the boundary token (idx 1) was set to -inf ("boundary token (idx 1) must NOT
+      be excluded, got -inf"). GREEN (post-fix): idx 0 == -inf (top removed), idx 1 == 3.0 finite
+      (boundary kept), idx 2/3/4 finite (tail kept). Two sibling tests that had asserted the buggy
+      remove-all behavior (test_apply_xtc_excludes_top_token, test_xtc_excludes_top_tokens) were
+      corrected to canonical XTC. Full aprender-serve lib suite: 15430 passed / 0 failed.

--- a/crates/aprender-serve/src/generate/algorithms_tests.rs
+++ b/crates/aprender-serve/src/generate/algorithms_tests.rs
@@ -396,11 +396,15 @@ fn test_apply_xtc_too_few_tokens() {
 
 #[test]
 fn test_apply_xtc_excludes_top_token() {
-    let logits = Tensor::from_vec(vec![3], vec![0.0, 0.0, 100.0]).expect("test");
-    let config = XtcConfig::new(1.0).with_threshold(0.5).with_min_keep(1);
-    // Token 2 has high probability, should be excluded
+    // PMAT-846: canonical XTC removes the strictly-most-probable above-threshold
+    // tokens but KEEPS the boundary (least-probable above-threshold) token. With
+    // logits [0,5,6] and threshold 0.05, tokens 1 and 2 are above threshold; XTC
+    // removes the top (idx 2) and keeps the boundary (idx 1).
+    let logits = Tensor::from_vec(vec![3], vec![0.0, 5.0, 6.0]).expect("test");
+    let config = XtcConfig::new(1.0).with_threshold(0.05).with_min_keep(1);
     let result = apply_xtc(&logits, &config, 0.0);
-    assert_eq!(result.data()[2], f32::NEG_INFINITY);
+    assert_eq!(result.data()[2], f32::NEG_INFINITY, "top token excluded");
+    assert!(result.data()[1].is_finite(), "boundary token kept");
 }
 
 #[test]
@@ -411,6 +415,64 @@ fn test_apply_xtc_respects_min_keep() {
     // Should keep at least 2 tokens (not NEG_INFINITY)
     let finite_count = result.data().iter().filter(|&&x| x.is_finite()).count();
     assert!(finite_count >= 2);
+}
+
+// PMAT-846 falsifier: XTC must KEEP the boundary token (the LAST token whose
+// prob >= threshold), matching llama.cpp `llama_sample_xtc_apply`. The buggy
+// implementation subtracted the excluded count from the FULL vocab length, so
+// with a real vocab + small min_keep it removed the ENTIRE above-threshold set,
+// including the boundary token it must preserve.
+//
+// Repro: logits=[4.0,3.0,2.0,-10.0,-10.0], threshold=0.1, min_keep=1, rng=0.0.
+// softmax ~= [0.665, 0.245, 0.090, ~0, ~0]; tokens 0 and 1 are >= 0.1.
+// llama.cpp: pos_last = 1 (sorted index of LAST token >= threshold) -> remove
+// only sorted index 0 (orig idx 0, the strictly-most-probable), KEEP boundary
+// (orig idx 1 = value 3.0) and the whole below-threshold tail.
+#[test]
+fn test_apply_xtc_keeps_boundary_token_pmat846() {
+    let logits = Tensor::from_vec(vec![5], vec![4.0, 3.0, 2.0, -10.0, -10.0]).expect("test");
+    let config = XtcConfig::new(1.0).with_threshold(0.1).with_min_keep(1);
+    // rng=0.0 < probability=1.0 => XTC fires deterministically.
+    let result = apply_xtc(&logits, &config, 0.0);
+    let out = result.data();
+
+    // The strictly-most-probable above-threshold token (orig idx 0) is removed.
+    assert_eq!(
+        out[0],
+        f32::NEG_INFINITY,
+        "top token (idx 0) must be excluded"
+    );
+    // The BOUNDARY token (orig idx 1, the LAST above-threshold token) must stay
+    // finite and unchanged at 3.0. The buggy impl set this to NEG_INFINITY.
+    assert!(
+        out[1].is_finite(),
+        "boundary token (idx 1) must NOT be excluded, got {}",
+        out[1]
+    );
+    assert!(
+        (out[1] - 3.0).abs() < 1e-6,
+        "boundary token must be unchanged (3.0), got {}",
+        out[1]
+    );
+    // Below-threshold tail must remain finite (XTC only touches top choices).
+    assert!(out[2].is_finite(), "below-threshold token idx 2 must stay");
+    assert!(out[3].is_finite(), "below-threshold token idx 3 must stay");
+    assert!(out[4].is_finite(), "below-threshold token idx 4 must stay");
+}
+
+// PMAT-846: canonical `threshold > 0.5` no-op guard (llama.cpp short-circuits
+// when xtc_threshold > 0.5 because at most one token can clear that bar, so
+// removing it would violate the keep-the-boundary invariant). Output == input.
+#[test]
+fn test_apply_xtc_threshold_above_half_is_noop_pmat846() {
+    let logits = Tensor::from_vec(vec![5], vec![4.0, 3.0, 2.0, -10.0, -10.0]).expect("test");
+    let config = XtcConfig::new(1.0).with_threshold(0.6).with_min_keep(1);
+    let result = apply_xtc(&logits, &config, 0.0);
+    assert_eq!(
+        result.data(),
+        logits.data(),
+        "threshold > 0.5 must be a no-op (output == input)"
+    );
 }
 
 // =============================================================================

--- a/crates/aprender-serve/src/generate/dry_penalty.rs
+++ b/crates/aprender-serve/src/generate/dry_penalty.rs
@@ -162,7 +162,9 @@ pub fn apply_xtc(logits: &Tensor<f32>, config: &XtcConfig, rng_value: f32) -> Te
     }
 
     let data = logits.data();
-    if data.len() <= config.min_keep {
+    // Canonical XTC no-op (llama.cpp early-returns): a threshold > 0.5 leaves at most
+    // one token above it, so there is nothing meaningful to exclude.
+    if config.threshold > 0.5 || data.len() <= config.min_keep || data.len() < 2 {
         return logits.clone();
     }
 
@@ -172,19 +174,33 @@ pub fn apply_xtc(logits: &Tensor<f32>, config: &XtcConfig, rng_value: f32) -> Te
     let sum: f32 = exp_logits.iter().sum();
     let probs: Vec<f32> = exp_logits.iter().map(|&x| x / sum).collect();
 
-    // Find tokens above threshold
-    let mut excluded_count = 0;
-    let mut modified = data.to_vec();
-
-    // Sort by probability descending to find top tokens
+    // Sort by probability descending.
     let mut indexed: Vec<(usize, f32)> = probs.iter().enumerate().map(|(i, &p)| (i, p)).collect();
     indexed.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
 
-    // Exclude top tokens above threshold, respecting min_keep
-    for (idx, prob) in &indexed {
-        if *prob >= config.threshold && data.len() - excluded_count > config.min_keep {
+    // PMAT-846: canonical XTC (llama.cpp `llama_sample_xtc_apply`). Scan the sorted
+    // array from the top to find `pos_last` = the index of the LAST token with
+    // `p >= threshold` (stop at the first below-threshold token). Then exclude only
+    // the strictly-most-probable tokens `[0, pos_last)`, which ALWAYS preserves the
+    // boundary token at `pos_last` and the entire below-threshold tail. The previous
+    // code excluded EVERY above-threshold token (including the boundary) because its
+    // min_keep guard subtracted the excluded count from the FULL vocab length rather
+    // than from the number of tokens that would remain.
+    let mut pos_last = 0usize;
+    for (i, (_, p)) in indexed.iter().enumerate() {
+        if *p >= config.threshold {
+            pos_last = i;
+        } else {
+            break;
+        }
+    }
+
+    let mut modified = data.to_vec();
+    // Keep at least `min_keep` tokens, and only act when there is a top token to
+    // remove (`pos_last > 0` ⟺ ≥ 2 above-threshold tokens, so the boundary survives).
+    if indexed.len() - pos_last >= config.min_keep && pos_last > 0 {
+        for (idx, _) in indexed.iter().take(pos_last) {
             modified[*idx] = f32::NEG_INFINITY;
-            excluded_count += 1;
         }
     }
 

--- a/crates/aprender-serve/src/generate/tests_beam_search.rs
+++ b/crates/aprender-serve/src/generate/tests_beam_search.rs
@@ -242,11 +242,15 @@
 
     #[test]
     fn test_xtc_excludes_top_tokens() {
-        let logits = Tensor::from_vec(vec![5], vec![10.0, 1.0, 0.5, 0.1, -1.0]).expect("test");
-        let config = XtcConfig::new(1.0).with_threshold(0.5); // Always exclude, high threshold
+        // PMAT-846: canonical XTC removes the strictly-most-probable above-threshold
+        // token(s) but KEEPS the boundary token. With logits [6,5,0.5,0.1,-1] and
+        // threshold 0.05, tokens 0 and 1 are above threshold; XTC removes the top
+        // (idx 0) and preserves the boundary (idx 1) and the below-threshold tail.
+        let logits = Tensor::from_vec(vec![5], vec![6.0, 5.0, 0.5, 0.1, -1.0]).expect("test");
+        let config = XtcConfig::new(1.0).with_threshold(0.05);
         let result = apply_xtc(&logits, &config, 0.0); // rng < probability
-        // Top token (index 0) should be excluded (set to NEG_INFINITY)
-        assert_eq!(result.data()[0], f32::NEG_INFINITY);
+        assert_eq!(result.data()[0], f32::NEG_INFINITY, "top token excluded");
+        assert!(result.data()[1].is_finite(), "boundary token kept");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

XTC (Exclude Top Choices) sampling **removed the boundary token it is specifically designed to keep**, inverting the algorithm.

`apply_xtc` set *every* token with `prob >= threshold` to `-inf`, gated only by `data.len() - excluded_count > min_keep`. The guard subtracted from the **full vocab length** (e.g. 32000), not the count of tokens that would remain, so with any realistic vocab + small `min_keep` it removed the **entire** above-threshold set — including the least-probable above-threshold (boundary) token. It also lacked the canonical `threshold > 0.5` no-op.

## Canonical XTC (llama.cpp `llama_sample_xtc_apply`)

On the prob-sorted-descending array, find `pos_last` = last index with `p >= threshold`, then remove only the strictly-most-probable tokens `[0, pos_last)` — preserving the boundary token at `pos_last` and the whole below-threshold tail.

For `logits=[4,3,2,-10,-10]`, `threshold=0.1`, `min_keep=1`: removes idx 0, **keeps idx 1 (3.0)**.

## Verification
- Falsifier `test_apply_xtc_keeps_boundary_token_pmat846` — RED: boundary idx 1 → `-inf`; GREEN: idx 0 `-inf` (top removed), idx 1 = 3.0 (boundary kept), tail finite.
- Corrected two sibling tests (`test_apply_xtc_excludes_top_token`, `test_xtc_excludes_top_tokens`) that had asserted the buggy remove-all behavior using a single above-threshold token.
- `cargo test -p aprender-serve --lib` → **15430 passed / 0 failed**.
- `contracts/xtc-sampling-correctness-v1.yaml` — `pv validate` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)