### PR TITLE
fix(ica): build whitening matrix row-major to satisfy Cov(X_white)=I (PMAT-847)

### DIFF
--- a/contracts/ica-whitening-v1.yaml
+++ b/contracts/ica-whitening-v1.yaml
@@ -1,0 +1,90 @@
+metadata:
+  version: 1.0.0
+  created: '2026-06-19'
+  author: PAIML Engineering
+  description: >-
+    ICA whitening invariant — the whitening matrix W = V Λ^(-1/2) built from the
+    eigendecomposition of the data covariance must decorrelate and unit-scale the
+    centered data, so that Cov(X_white) = I. Guards against the PMAT-847 transpose
+    defect where W was constructed transposed relative to the eigenvector storage
+    convention, yielding a non-identity whitened covariance.
+  references:
+  - 'Hyvarinen & Oja (2000) Independent Component Analysis: Algorithms and Applications'
+  - 'scikit-learn FastICA whiten="unit-variance" (decomposition/_fastica.py)'
+  - 'numpy: cov=(Xc.T@Xc)/n; w,V=np.linalg.eigh(cov); W=V@diag(1/sqrt(w)); ((Xc@W).T@(Xc@W))/n == I'
+  lessons_learned:
+  - 'PMAT-847: eigen_decomposition stores eigenvector c as ROW c (length-p block wrapped
+    row-major as Matrix::from_vec(p, k, ...)). whiten_data read it as COLUMN j and filled
+    the whitening matrix column-major, producing a transposed W. Measured Cov(X_white)[0][0]
+    = 5.96 instead of 1.0 on seeded correlated 2-feature data.'
+equations:
+  whitening:
+    formula: W = V Λ^(-1/2) ; X_white = X_centered W ; Cov(X_white) = (1/n) X_white^T X_white = I
+    domain: X_centered ∈ ℝ^{n×p} (zero column means), V ∈ ℝ^{p×k} eigenvectors, Λ = diag(λ_1..λ_k) > 0
+    codomain: X_white ∈ ℝ^{n×k} with identity covariance
+    invariants:
+    - 'W[i][j] = V_j[i] / sqrt(λ_j) where V_j is the j-th eigenvector (stored as ROW j)'
+    - 'Cov(X_white)[d][d] ≈ 1 for all d (unit variance)'
+    - 'Cov(X_white)[d][e] ≈ 0 for d != e (decorrelated)'
+    preconditions:
+    - x_centered.n_rows() > 0
+    - x_centered.n_cols() > 0
+    - n_components <= x_centered.n_cols()
+    lean_theorem: Theorems.IcaWhitening
+proof_obligations:
+- type: invariant
+  property: Whitened covariance is identity on the diagonal (unit variance)
+  formal: forall d, |Cov(whiten_data(center_data(X)))[d][d] - 1| < tol
+  applies_to: whitening
+- type: invariant
+  property: Whitened covariance is zero off-diagonal (decorrelated)
+  formal: forall d != e, |Cov(whiten_data(center_data(X)))[d][e]| < tol
+  applies_to: whitening
+- type: equivalence
+  property: Whitening matrix reads eigenvector j as stored ROW j
+  formal: W[i][j] == eigenvectors.get(j, i) / sqrt(eigenvalues[j])
+  applies_to: whitening
+falsification_tests:
+- id: FALSIFY-ICA-WHITEN-001
+  rule: Whitened covariance is the identity matrix
+  prediction: 'Cov(X_white) = I within tol 0.05 on seeded correlated data (f0=2a+b, f1=a+3b, n=200)'
+  test: 'cargo test -p aprender-core --lib decomposition::ica::tests::test_ica_whitening_covariance_is_identity'
+  evidence_red: 'RED (transposed W): Cov(X_white)[0][0] = 4.601778 (test_ica_whitening fixture: 5.961843)'
+  evidence_green: 'GREEN (row-major W): Cov(X_white) ≈ I; 25/25 decomposition::ica tests pass'
+  if_fails: Whitening matrix transposed relative to eigenvector storage; or eigenvalue/eigenvector misalignment
+- id: FALSIFY-ICA-WHITEN-002
+  rule: Existing whitening test enforces the covariance invariant
+  prediction: 'test_ica_whitening asserts Cov(X_white) ≈ I, not just output shape'
+  test: 'cargo test -p aprender-core --lib decomposition::ica::tests::test_ica_whitening'
+  evidence_red: 'RED: var[0] = 5.961843 (shape-only assertion would have passed silently)'
+  evidence_green: 'GREEN: var[0] ≈ 1, var[1] ≈ 1, cross-cov ≈ 0'
+  if_fails: Shape-only gate let the transpose defect through; strengthen to covariance invariant
+- id: FALSIFY-ICA-WHITEN-003
+  rule: Whitening matrix reads eigenvector j as the stored ROW j
+  prediction: 'W[i][j] = eigenvectors.get(j, i) / sqrt(eigenvalues[j]); both whitening tests pass'
+  test: 'cargo test -p aprender-core --lib decomposition::ica'
+  evidence_red: 'RED (get(i,j), column-major fill): 2 failed (test_ica_whitening, test_ica_whitening_covariance_is_identity)'
+  evidence_green: 'GREEN (get(j,i), row-major fill): 25 passed; 0 failed'
+  if_fails: Eigenvector row-vs-column storage convention mismatched between eigen_decomposition and whiten_data
+enforcement:
+  whitening_covariance:
+    description: Whitened data must have identity covariance (unit variance, decorrelated)
+    check: contract_tests::FALSIFY-ICA-WHITEN-001
+    severity: ERROR
+qa_gate:
+  id: F-ICA-WHITEN-001
+  name: ICA Whitening Contract
+  description: Whitening must yield Cov(X_white) = I (unit variance, decorrelated)
+  checks:
+  - whitened_unit_variance
+  - whitened_decorrelated
+  - eigenvector_row_read
+  pass_criteria: All 3 falsification tests pass + Kani harness verifies
+  falsification: Build the whitening matrix transposed relative to eigenvector storage
+kani_harnesses:
+- id: KANI-ICA-WHITEN-001
+  obligation: Whitened covariance diagonal is unit variance within tolerance
+  property: forall d, |Cov(whiten_data(center_data(X)))[d][d] - 1| < tol
+  bound: 8
+  strategy: stub_float
+  solver: cadical

--- a/crates/aprender-core/src/decomposition/ica.rs
+++ b/crates/aprender-core/src/decomposition/ica.rs
@@ -277,13 +277,20 @@ impl ICA {
         // Eigen decomposition (simplified - use power iteration for top components)
         let (eigenvalues, eigenvectors) = Self::eigen_decomposition(&cov_scaled, n_components)?;
 
-        // Compute whitening matrix: V Λ^(-1/2)
-        // where V are eigenvectors and Λ are eigenvalues
+        // Compute whitening matrix: W = V Λ^(-1/2), shape (p × n_components), row-major.
+        //
+        // PMAT-847: `eigen_decomposition` stores eigenvector c as ROW c of `eigenvectors`
+        // (each length-p eigenvector is appended contiguously, then wrapped row-major).
+        // So component i of eigenvector j is `eigenvectors.get(j, i)`, and W[i][j] must be
+        // built row-major (outer i over features, inner j over components). The previous
+        // code read `eigenvectors.get(i, j)` and filled column-major, producing a
+        // transposed W so that Cov(X_centered @ W) != I. The corrected form yields
+        // Cov(X_white) = I (matches scikit-learn FastICA whiten='unit-variance').
         let mut whitening_data = Vec::with_capacity(p * n_components);
-        for j in 0..n_components {
-            let scale = 1.0 / eigenvalues[j].sqrt();
-            for i in 0..p {
-                whitening_data.push(eigenvectors.get(i, j) * scale);
+        for i in 0..p {
+            for j in 0..n_components {
+                let scale = 1.0 / eigenvalues[j].sqrt();
+                whitening_data.push(eigenvectors.get(j, i) * scale);
             }
         }
         let whitening_matrix = Matrix::from_vec(p, n_components, whitening_data)

--- a/crates/aprender-core/src/decomposition/ica_tests.rs
+++ b/crates/aprender-core/src/decomposition/ica_tests.rs
@@ -196,6 +196,100 @@ fn test_ica_whitening() {
 
     assert_eq!(whitened.n_rows(), 10);
     assert_eq!(whitened.n_cols(), 2);
+
+    // PMAT-847: whitening invariant — Cov(X_white) must be the identity matrix.
+    // (unit variance on the diagonal, zero pairwise correlation off-diagonal)
+    let n = whitened.n_rows();
+    let mut cov = [[0.0_f32; 2]; 2];
+    for r in 0..2 {
+        for c in 0..2 {
+            let mut sum = 0.0_f32;
+            for i in 0..n {
+                sum += whitened.get(i, r) * whitened.get(i, c);
+            }
+            cov[r][c] = sum / n as f32;
+        }
+    }
+    assert!(
+        (cov[0][0] - 1.0).abs() < 0.05,
+        "whitened var[0] must be ~1, got {}",
+        cov[0][0]
+    );
+    assert!(
+        (cov[1][1] - 1.0).abs() < 0.05,
+        "whitened var[1] must be ~1, got {}",
+        cov[1][1]
+    );
+    assert!(
+        cov[0][1].abs() < 0.05,
+        "whitened cross-cov must be ~0, got {}",
+        cov[0][1]
+    );
+}
+
+/// PMAT-847 falsifier: whitening must yield Cov(X_white) = I on seeded correlated data.
+///
+/// Reference: scikit-learn `FastICA` (whiten='unit-variance'); numpy:
+///   cov = (Xc.T @ Xc) / n; w, V = np.linalg.eigh(cov); W = V @ diag(1/sqrt(w));
+///   ((Xc @ W).T @ (Xc @ W)) / n == I
+///
+/// The transposed-whitening-matrix bug makes the whitened covariance non-identity
+/// (e.g. diag[0][0] ~= 5.97 instead of 1.0 on this fixture).
+#[test]
+fn test_ica_whitening_covariance_is_identity() {
+    // Build n=200 correlated rows: f0 = 2a + b, f1 = a + 3b, where (a,b) are
+    // pseudo-random in [0,1) from a deterministic LCG (reproducible fixture).
+    let n = 200usize;
+    let mut state: u64 = 42;
+    let mut next = || -> f32 {
+        // glibc LCG constants; masked to 31 bits.
+        state = state.wrapping_mul(1_103_515_245).wrapping_add(12_345) & 0x7fff_ffff;
+        (state % 1000) as f32 / 1000.0
+    };
+    let mut data = Vec::with_capacity(n * 2);
+    for _ in 0..n {
+        let a = next();
+        let b = next();
+        let f0 = 2.0 * a + b;
+        let f1 = a + 3.0 * b;
+        data.push(f0);
+        data.push(f1);
+    }
+    let x = Matrix::from_vec(n, 2, data).expect("Valid matrix");
+
+    let (centered, _mean) = ICA::center_data(&x).expect("Should center");
+    let (whitened, _w) = ICA::whiten_data(&centered, 2).expect("Should whiten");
+
+    assert_eq!(whitened.n_rows(), n);
+    assert_eq!(whitened.n_cols(), 2);
+
+    // cov = (1/n) Xw^T Xw
+    let mut cov = [[0.0_f32; 2]; 2];
+    for r in 0..2 {
+        for c in 0..2 {
+            let mut sum = 0.0_f32;
+            for i in 0..n {
+                sum += whitened.get(i, r) * whitened.get(i, c);
+            }
+            cov[r][c] = sum / n as f32;
+        }
+    }
+
+    assert!(
+        (cov[0][0] - 1.0).abs() < 0.05,
+        "Cov(X_white)[0][0] must be ~1 (unit variance), got {}",
+        cov[0][0]
+    );
+    assert!(
+        (cov[1][1] - 1.0).abs() < 0.05,
+        "Cov(X_white)[1][1] must be ~1 (unit variance), got {}",
+        cov[1][1]
+    );
+    assert!(
+        cov[0][1].abs() < 0.05,
+        "Cov(X_white)[0][1] must be ~0 (decorrelated), got {}",
+        cov[0][1]
+    );
 }
 
 #[test]


### PR DESCRIPTION
## PMAT-847: ICA whitening matrix transpose defect

### Bug
`ICA::whiten_data` built the whitening matrix `W = V Λ^(-1/2)` **transposed** relative to how `ICA::eigen_decomposition` stores eigenvectors.

`eigen_decomposition` appends each length-`p` eigenvector contiguously and wraps it row-major as `Matrix::from_vec(p, k, ...)`, so eigenvector `j` is stored as **ROW `j`**. `whiten_data` read it as **COLUMN `j`** (`eigenvectors.get(i, j)`) and filled the whitening matrix column-major, producing a transposed `W`. Net effect: `X_white = X_centered @ W` did **NOT** satisfy `Cov(X_white) = I`.

Measured on seeded correlated 2-feature data (`f0 = 2a + b`, `f1 = a + 3b`, `n = 200`): whitened covariance diagonal was `4.60` / `5.96` instead of `1.0`.

### Fix
Read eigenvector `j` as the stored ROW `j` (`eigenvectors.get(j, i)`) and build `W` row-major. This yields `Cov(X_white) = I`, matching scikit-learn `FastICA` (`whiten='unit-variance'`) and numpy eigh-based whitening.

### Falsifier-first (RED → GREEN)
- **RED** (transposed `W`): `test_ica_whitening` `var[0] = 5.961843`; `test_ica_whitening_covariance_is_identity` `Cov[0][0] = 4.601778` — **2 failed**.
- **GREEN** (row-major `W`): `Cov(X_white) ≈ I`; **25/25** `decomposition::ica` tests pass.

### Tests
- **New** `test_ica_whitening_covariance_is_identity`: asserts `|Cov − I| < 0.05` on a deterministic LCG fixture of `n=200` correlated rows.
- **Strengthened** the shape-only `test_ica_whitening` with the same covariance invariant.

### Contract
`contracts/ica-whitening-v1.yaml` (KernelContract) pins the whitening invariant `Cov(whiten_data(center_data(X))) == I` with proof obligations + falsification tests carrying RED/GREEN evidence; references sklearn FastICA / numpy eigh.
`pv validate` → **0 errors, 0 warnings**.

### Verification
- `cargo test -p aprender-core --lib` → **13909 passed, 0 failed, 2 ignored**
- `rustfmt --check` + `cargo clippy -p aprender-core` clean on changed files
- Only 3 files touched: `ica.rs`, `ica_tests.rs`, `contracts/ica-whitening-v1.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)