### PR TITLE
fix(linear_model): Lasso/ElasticNet alpha must match scikit-learn 1/(2n) convention (PMAT-848)

### DIFF
--- a/contracts/lasso-elasticnet-alpha-v1.yaml
+++ b/contracts/lasso-elasticnet-alpha-v1.yaml
@@ -1,0 +1,95 @@
+metadata:
+  version: "1.0.0"
+  created: "2026-06-19"
+  author: PAIML Engineering
+  registry: true
+  references:
+    - "scikit-learn Lasso: minimize (1/(2*n_samples))*||y - Xb||^2 + alpha*||b||_1 (the alpha-convention oracle)"
+    - "scikit-learn ElasticNet: minimize (1/(2*n_samples))*||y - Xb||^2 + alpha*l1_ratio*||b||_1 + 0.5*alpha*(1-l1_ratio)*||b||^2"
+    - "Friedman, Hastie & Tibshirani (2010) Regularization Paths for Generalized Linear Models via Coordinate Descent"
+    - "crates/aprender-core/src/linear_model/lasso_impl.rs (Lasso coordinate descent fit)"
+    - "crates/aprender-core/src/linear_model/input.rs (ElasticNet coordinate descent fit)"
+  description: |
+    Correctness contract for the alpha (regularization-strength) convention of the
+    Lasso and ElasticNet coordinate-descent solvers. Pillar-1 (replace+beat
+    scikit-learn): for a given alpha/l1_ratio aprender must produce the SAME
+    coefficients and intercept as scikit-learn, otherwise users porting code silently
+    get under-regularized models.
+
+kind: KernelContract
+name: lasso-elasticnet-alpha
+version: "1.0.0"
+scope: "crates/aprender-core/src/linear_model/lasso_impl.rs, crates/aprender-core/src/linear_model/input.rs"
+
+description: |
+  scikit-learn minimizes the SAMPLE-MEAN squared error with a 1/(2*n_samples)
+  data-fit factor:
+
+    Lasso:      (1/(2*n_samples))*||y - Xb||^2 + alpha*||b||_1
+    ElasticNet: (1/(2*n_samples))*||y - Xb||^2
+                + alpha*l1_ratio*||b||_1
+                + 0.5*alpha*(1 - l1_ratio)*||b||^2
+
+  The coordinate-descent update for feature j is
+
+    rho_j   = sum_i x_centered[i][j] * residual_i           (no 1/n inside rho)
+    beta[j] = soft_threshold(rho_j, n_samples*alpha*l1_ratio)
+              / (col_norms_sq[j] + n_samples*alpha*(1 - l1_ratio))
+
+  so the L1 threshold scales with n_samples*alpha and the L2 denominator term with
+  n_samples*alpha*(1 - l1_ratio). For pure Lasso (l1_ratio == 1) this reduces to
+  beta[j] = soft_threshold(rho_j, n_samples*alpha) / col_norms_sq[j].
+
+  PMAT-848 fixed the omission of the n_samples factor in BOTH solvers. The buggy
+  update thresholded at `alpha` (Lasso) / `alpha*l1_ratio` (ElasticNet) with no
+  n_samples factor, making the effective penalty ~n_samples times too weak, so the
+  produced coefficients did not match scikit-learn's `alpha`.
+
+  Falsifier (X=[[1],[2],[3],[4],[5]], y=[2,4,6,8,10], n_samples=5):
+    - Lasso(alpha=1.0):           RED coef~1.90, intercept~0.30  -> GREEN coef=1.5, intercept=1.5
+    - ElasticNet(alpha=1.0, 0.5): RED coef~1.857, intercept      -> GREEN coef=1.4, intercept=1.8
+  scikit-learn reference (Lasso(1.0): coef_=1.5, intercept_=1.5; ElasticNet(1.0, 0.5):
+  coef_=1.4, intercept_=1.8) generated with `uv run --with scikit-learn python3`.
+
+equations:
+  C-LASSO-ALPHA-001:
+    description: "Lasso coordinate update thresholds rho at n_samples*alpha (scikit-learn convention)"
+    formula: "beta[j] = soft_threshold(rho_j, n_samples*alpha) / col_norms_sq[j], where rho_j = sum_i x_centered[i][j]*residual_i"
+    note: "Buggy version thresholded at `alpha` (dropped n_samples) -> penalty ~n times too weak."
+  C-LASSO-ALPHA-002:
+    description: "ElasticNet coordinate update uses n_samples*alpha scaling for BOTH L1 and L2 penalties"
+    formula: "beta[j] = soft_threshold(rho_j, n_samples*alpha*l1_ratio) / (col_norms_sq[j] + n_samples*alpha*(1 - l1_ratio))"
+    note: "Buggy version used alpha*l1_ratio and alpha*(1-l1_ratio) with no n_samples factor."
+  C-LASSO-ALPHA-003:
+    description: "On a perfect line, aprender matches scikit-learn coefficient/intercept to < 0.05"
+    formula: "Lasso(1.0) on (X=[[1]..[5]], y=[2..10]) => coef ~= 1.5, intercept ~= 1.5; ElasticNet(1.0, 0.5) => coef ~= 1.4, intercept ~= 1.8"
+    note: "Sample-level scikit-learn reference values; RED coef ~= 1.90 (Lasso) before the fix."
+
+proof_obligations:
+  - id: PO-LASSO-ALPHA-001
+    type: equivalence
+    property: "Lasso coefficients/intercept match scikit-learn Lasso(alpha) within tolerance"
+    formal: "Lasso(1.0).fit(X,y).coef ~= 1.5 and intercept ~= 1.5 for X=[[1],[2],[3],[4],[5]], y=[2,4,6,8,10]"
+    tolerance: 0.05
+    applies_to: all
+  - id: PO-LASSO-ALPHA-002
+    type: equivalence
+    property: "ElasticNet coefficients/intercept match scikit-learn ElasticNet(alpha, l1_ratio) within tolerance"
+    formal: "ElasticNet(1.0, 0.5).fit(X,y).coef ~= 1.4 and intercept ~= 1.8 for X=[[1],[2],[3],[4],[5]], y=[2,4,6,8,10]"
+    tolerance: 0.05
+    applies_to: all
+  - id: PO-LASSO-ALPHA-003
+    type: invariant
+    property: "Soft-threshold L1 penalty scales linearly with n_samples (alpha convention)"
+    formal: "the coordinate-descent L1 threshold equals n_samples*alpha*l1_ratio (l1_ratio == 1 for Lasso)"
+    applies_to: all
+
+falsification:
+  - id: FALSIFY-LASSO-ALPHA-001
+    description: "Lasso(1.0) matches scikit-learn (coef 1.5, intercept 1.5). Discharges C-LASSO-ALPHA-001 / C-LASSO-ALPHA-003 / PO-LASSO-ALPHA-001 / PO-LASSO-ALPHA-003."
+    test: "test_lasso_sklearn_alpha_parity (crates/aprender-core/src/linear_model/tests_lasso.rs) — RED coef=1.9, intercept=0.30 -> GREEN coef=1.5, intercept=1.5."
+    evidence: "cargo test -p aprender-core --lib test_lasso_sklearn_alpha_parity"
+  - id: FALSIFY-LASSO-ALPHA-002
+    description: "ElasticNet(1.0, 0.5) matches scikit-learn (coef 1.4, intercept 1.8). Discharges C-LASSO-ALPHA-002 / C-LASSO-ALPHA-003 / PO-LASSO-ALPHA-002."
+    test: "test_elastic_net_sklearn_alpha_parity (crates/aprender-core/src/linear_model/tests_lasso.rs) — RED coef=1.857 -> GREEN coef=1.4, intercept=1.8."
+    evidence: "cargo test -p aprender-core --lib test_elastic_net_sklearn_alpha_parity"

--- a/crates/aprender-core/src/linear_model/elastic_net.rs
+++ b/crates/aprender-core/src/linear_model/elastic_net.rs
@@ -1,11 +1,17 @@
 
 /// Elastic Net regression with combined L1 and L2 regularization.
 ///
-/// Fits a linear model with both L1 and L2 penalties:
+/// Fits a linear model with both L1 and L2 penalties, matching the
+/// scikit-learn convention:
 ///
 /// ```text
-/// minimize ||y - Xβ||² + α * l1_ratio * ||β||₁ + α * (1 - l1_ratio) * ||β||²
+/// minimize (1/(2*n_samples))*||y - Xβ||²
+///          + α * l1_ratio * ||β||₁
+///          + 0.5 * α * (1 - l1_ratio) * ||β||²
 /// ```
+///
+/// The `1/(2*n_samples)` data-fit normalization makes `α`/`l1_ratio` identical
+/// to scikit-learn's `ElasticNet(alpha=α, l1_ratio=l1_ratio)`.
 ///
 /// # Parameters
 ///

--- a/crates/aprender-core/src/linear_model/input.rs
+++ b/crates/aprender-core/src/linear_model/input.rs
@@ -65,9 +65,19 @@ impl Estimator for ElasticNet {
             }
         }
 
-        // L1 and L2 penalties
-        let l1_penalty = self.alpha * self.l1_ratio;
-        let l2_penalty = self.alpha * (1.0 - self.l1_ratio);
+        // L1 and L2 penalties.
+        //
+        // scikit-learn minimizes
+        //   (1/(2*n_samples))*||y - Xb||^2
+        //     + alpha*l1_ratio*||b||_1
+        //     + 0.5*alpha*(1 - l1_ratio)*||b||^2,
+        // whose coordinate update thresholds rho at n_samples*alpha*l1_ratio and
+        // divides by (col_norms_sq + n_samples*alpha*(1 - l1_ratio)) (PMAT-848).
+        // The n_samples factor is required for `alpha`/`l1_ratio` to match the
+        // scikit-learn convention; omitting it makes both penalties ~n times too weak.
+        let n = n_samples as f32;
+        let l1_penalty = n * self.alpha * self.l1_ratio;
+        let l2_penalty = n * self.alpha * (1.0 - self.l1_ratio);
 
         // Coordinate descent
         for _ in 0..self.max_iter {

--- a/crates/aprender-core/src/linear_model/lasso.rs
+++ b/crates/aprender-core/src/linear_model/lasso.rs
@@ -273,13 +273,15 @@ impl Estimator for Ridge {
 /// Lasso regression with L1 regularization.
 ///
 /// Fits a linear model with L1 penalty on coefficient magnitudes.
-/// The optimization objective is:
+/// The optimization objective matches the scikit-learn convention:
 ///
 /// ```text
-/// minimize ||y - Xβ||² + α||β||₁
+/// minimize (1/(2*n_samples))*||y - Xβ||² + α*||β||₁
 /// ```
 ///
-/// where `α` (alpha) controls the regularization strength.
+/// where `α` (alpha) controls the regularization strength. The
+/// `1/(2*n_samples)` data-fit normalization makes `α` scale-invariant in the
+/// number of samples and identical to scikit-learn's `Lasso(alpha=α)`.
 ///
 /// # Solver
 ///

--- a/crates/aprender-core/src/linear_model/lasso_impl.rs
+++ b/crates/aprender-core/src/linear_model/lasso_impl.rs
@@ -335,9 +335,15 @@ impl Estimator for Lasso {
                     rho += x_centered.get(i, j) * residual;
                 }
 
-                // Update coefficient with soft-thresholding
+                // Update coefficient with soft-thresholding.
+                //
+                // scikit-learn minimizes (1/(2*n_samples))*||y - Xb||^2 + alpha*||b||_1,
+                // whose coordinate update thresholds rho at n_samples*alpha (PMAT-848).
+                // Without the n_samples factor the effective penalty is ~n times too
+                // weak, so `alpha` would not match the scikit-learn convention.
                 let old_beta = beta[j];
-                beta[j] = Self::soft_threshold(rho, self.alpha) / col_norms_sq[j];
+                let n = n_samples as f32;
+                beta[j] = Self::soft_threshold(rho, n * self.alpha) / col_norms_sq[j];
 
                 let change = (beta[j] - old_beta).abs();
                 if change > max_change {

--- a/crates/aprender-core/src/linear_model/tests_lasso.rs
+++ b/crates/aprender-core/src/linear_model/tests_lasso.rs
@@ -163,6 +163,62 @@ fn test_lasso_with_tol() {
     assert!(model.is_fitted());
 }
 
+// PMAT-848: Lasso/ElasticNet must match scikit-learn's `alpha` convention, i.e.
+// minimize (1/(2*n_samples))*||y - Xb||^2 + alpha*||b||_1. The coordinate-descent
+// update must threshold rho at n_samples*alpha. Reference values produced with
+// `uv run --with scikit-learn python3` (scikit-learn 1.x).
+#[test]
+fn test_lasso_sklearn_alpha_parity() {
+    // X=[[1],[2],[3],[4],[5]], y=[2,4,6,8,10] (perfect y = 2x line).
+    // sklearn Lasso(alpha=1.0): coef_=[1.5], intercept_=1.5.
+    // Pre-fix (missing 1/n) this returned coef~1.90, intercept~0.30, i.e.
+    // alpha was ~n times too weak.
+    let x = Matrix::from_vec(5, 1, vec![1.0, 2.0, 3.0, 4.0, 5.0])
+        .expect("Valid matrix dimensions for test");
+    let y = Vector::from_slice(&[2.0, 4.0, 6.0, 8.0, 10.0]);
+
+    let mut model = Lasso::new(1.0);
+    model
+        .fit(&x, &y)
+        .expect("Fit should succeed with valid test data");
+
+    let coef = model.coefficients()[0];
+    let intercept = model.intercept();
+    assert!(
+        (coef - 1.5).abs() < 0.05,
+        "Lasso(1.0) coef must match sklearn 1.5, got {coef}"
+    );
+    assert!(
+        (intercept - 1.5).abs() < 0.05,
+        "Lasso(1.0) intercept must match sklearn 1.5, got {intercept}"
+    );
+}
+
+#[test]
+fn test_elastic_net_sklearn_alpha_parity() {
+    // X=[[1],[2],[3],[4],[5]], y=[2,4,6,8,10].
+    // sklearn ElasticNet(alpha=1.0, l1_ratio=0.5): coef_=[1.4], intercept_=1.8.
+    let x = Matrix::from_vec(5, 1, vec![1.0, 2.0, 3.0, 4.0, 5.0])
+        .expect("Valid matrix dimensions for test");
+    let y = Vector::from_slice(&[2.0, 4.0, 6.0, 8.0, 10.0]);
+
+    let mut model = ElasticNet::new(1.0, 0.5);
+    model
+        .fit(&x, &y)
+        .expect("Fit should succeed with valid test data");
+
+    let coef = model.coefficients()[0];
+    let intercept = model.intercept();
+    assert!(
+        (coef - 1.4).abs() < 0.05,
+        "ElasticNet(1.0, 0.5) coef must match sklearn 1.4, got {coef}"
+    );
+    assert!(
+        (intercept - 1.8).abs() < 0.05,
+        "ElasticNet(1.0, 0.5) intercept must match sklearn 1.8, got {intercept}"
+    );
+}
+
 #[test]
 fn test_lasso_soft_threshold() {
     // Test the soft-thresholding function


### PR DESCRIPTION
## PMAT-848: Lasso/ElasticNet alpha vs scikit-learn

### Bug (HIGH severity, Pillar-1 sklearn parity)
The Lasso and ElasticNet coordinate-descent solvers **omitted the `1/n_samples` loss normalization**, so `alpha` did not match scikit-learn's convention and coefficients were **under-regularized by a factor ~n_samples**.

scikit-learn minimizes:
- Lasso: `(1/(2*n_samples))*||y - Xb||² + alpha*||b||₁`
- ElasticNet: `(1/(2*n_samples))*||y - Xb||² + alpha*l1_ratio*||b||₁ + 0.5*alpha*(1-l1_ratio)*||b||²`

The coordinate update must threshold `rho` at `n_samples*alpha` (Lasso) / `n_samples*alpha*l1_ratio` (ElasticNet) and divide by `(col_norms_sq + n_samples*alpha*(1-l1_ratio))`. Dropping the `n_samples` factor made the effective penalty ~n times too weak.

### Fix
- `lasso_impl.rs`: `beta[j] = soft_threshold(rho, n*self.alpha) / col_norms_sq[j]`
- `input.rs` (ElasticNet): `l1_penalty = n*alpha*l1_ratio`, `l2_penalty = n*alpha*(1-l1_ratio)` (denominator form unchanged)
- Corrected the Lasso/ElasticNet objective docstrings to the `(1/(2n))` form

### Falsifier-first (`tests_lasso.rs`)
`X=[[1],[2],[3],[4],[5]]`, `y=[2,4,6,8,10]`, n_samples=5:

| case | RED (buggy) | GREEN (fixed) | sklearn ref |
|------|-------------|---------------|-------------|
| `Lasso(1.0)` | coef=1.9, intercept=0.30 | coef=1.5, intercept=1.5 | coef_=1.5, intercept_=1.5 |
| `ElasticNet(1.0, 0.5)` | coef=1.857 | coef=1.4, intercept=1.8 | coef_=1.4, intercept_=1.8 |

scikit-learn reference values produced with `uv run --with scikit-learn python3`.

### Verification
- **RED proven** (source fix stashed): `Lasso(1.0)` coef=1.9, `ElasticNet(1.0,0.5)` coef=1.857.
- **GREEN proven** (fix restored): both parity falsifiers pass.
- **Full crate**: `cargo test -p aprender-core --lib` → **13910 passed, 0 failed**.
- **No sibling tests corrected**: existing Lasso/ElasticNet tests use small alpha (0.01–0.5) with tolerant assertions (R² thresholds, `|coef - true| < 0.5`, structural/roundtrip checks), so none had hard-coded the un-normalized coefficients.
- clippy + fmt clean on changed files; `cargo build -p aprender-core` OK.

### Contract
`contracts/lasso-elasticnet-alpha-v1.yaml` (`kind: KernelContract`): equations `C-LASSO-ALPHA-001..003`, proof obligations `PO-LASSO-ALPHA-001..003`, falsification `FALSIFY-LASSO-ALPHA-001..002`. `pv validate` → **0 errors, 0 warnings**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)