### PR TITLE
fix(cluster): Ward linkage used wrong Lance-Williams coefficient — flipped merges vs scipy (PMAT-849)

### DIFF
--- a/contracts/ward-linkage-v1.yaml
+++ b/contracts/ward-linkage-v1.yaml
@@ -1,0 +1,104 @@
+metadata:
+  version: "1.0.0"
+  created: "2026-06-19"
+  author: PAIML Engineering
+  registry: true
+  references:
+    - "Ward, J.H. (1963) 'Hierarchical Grouping to Optimize an Objective Function', JASA 58(301):236-244"
+    - "Lance, G.N. & Williams, W.T. (1967) 'A general theory of classificatory sorting strategies'"
+    - "scipy.cluster.hierarchy.linkage(method='ward') — https://docs.scipy.org/doc/scipy/reference/generated/scipy.cluster.hierarchy.linkage.html"
+    - "sklearn.cluster.AgglomerativeClustering(linkage='ward')"
+  description: |
+    Ward-linkage agglomerative-clustering merge-distance contract (PMAT-849).
+    Pins the inter-cluster Ward distance to the scipy/sklearn Lance-Williams form
+    so that aprender's AgglomerativeClustering(Linkage::Ward) produces the same
+    merge order (and thus the same partition) as the reference implementations.
+
+kind: KernelContract
+name: ward-linkage
+version: "1.0.0"
+scope: "crates/aprender-core/src/cluster/agglomerative.rs"
+
+description: |
+  Ward's minimum-variance linkage for agglomerative (hierarchical) clustering.
+  The inter-cluster merge distance is the Lance-Williams Ward form, identical to
+  scipy.cluster.hierarchy.linkage(method='ward') and
+  sklearn.cluster.AgglomerativeClustering(linkage='ward').
+
+  For two clusters A and B with sizes |A|, |B| and centroids c_A, c_B:
+
+      d(A, B) = sqrt( 2 * |A| * |B| / (|A| + |B|) ) * ||c_A - c_B||_2
+
+  where ||.||_2 is the (non-squared) Euclidean distance between centroids.
+
+  A prior defect (PMAT-849) implemented the coefficient as
+  ( |A| * |B| / (|A| + |B|) ) * ||c_A - c_B||_2 — omitting the factor of 2
+  inside the radical AND the outer square root. That coefficient under-penalizes
+  merging into larger clusters, flipping which pair merges and producing a
+  partition that disagrees with scipy/sklearn on the reference dataset below.
+
+equations:
+  C-WARD-001:
+    description: "Ward inter-cluster merge distance (Lance-Williams form)"
+    formula: "d(A,B) = sqrt(2 * |A| * |B| / (|A| + |B|)) * ||c_A - c_B||_2"
+    note: |
+      Matches scipy/sklearn Ward. c_X is the arithmetic mean (centroid) of the
+      points in cluster X. ||.||_2 is the raw (non-squared) Euclidean distance.
+
+  C-WARD-002:
+    description: "Singleton-singleton merges reduce to plain Euclidean distance"
+    formula: "|A| = |B| = 1 ⟹ d(A,B) = sqrt(2*1*1/(1+1)) * ||c_A - c_B||_2 = ||c_A - c_B||_2"
+    note: |
+      The coefficient sqrt(2*n1*n2/(n1+n2)) equals 1 for n1=n2=1, so the first
+      merge step is consistent with the raw initial pairwise distance matrix
+      (which stores plain Euclidean distances). The buggy coefficient
+      (1*1/(1+1)) = 0.5 instead, halving every singleton distance — internally
+      consistent but NOT the Ward objective and NOT scipy/sklearn.
+
+  C-WARD-003:
+    description: "Partition parity with scipy/sklearn on the reference dataset"
+    formula: "ward(X, k=2) induces partition {1,4,5} | {0,2,3} for the reference X"
+    note: |
+      X = [[5.5,7.2],[6.0,5.4],[4.2,6.5],[4.4,8.9],[9.6,3.8],[7.9,5.3]] (row-major).
+      Verified against scipy.cluster.hierarchy (labels [1,2,1,1,2,2]) and
+      sklearn.cluster.AgglomerativeClustering(linkage='ward'). The buggy
+      coefficient instead grouped {0,1,2,3} | {4,5}.
+
+proof_obligations:
+- type: precondition
+  property: "Cluster sizes are positive and centroids are finite"
+  formal: "|A| >= 1 ∧ |B| >= 1 ∧ ∀k: isFinite(c_A[k]) ∧ isFinite(c_B[k])"
+- type: postcondition
+  property: "Merge distance is non-negative and finite"
+  formal: "d(A,B) >= 0 ∧ isFinite(d(A,B))"
+  requires: WARD-PRE-001
+- type: bound
+  property: "Coefficient reduces to 1 for singleton-singleton merges"
+  formal: "sqrt(2 * 1 * 1 / (1 + 1)) = 1"
+  applies_to: all
+- type: invariant
+  property: "Merge distance is symmetric in its arguments"
+  formal: "d(A,B) = d(B,A)"
+  applies_to: all
+- type: equivalence
+  property: "Ward partition matches scipy/sklearn reference partition"
+  formal: "ward(X_ref, k=2) ≡ {1,4,5} | {0,2,3} (up to label permutation)"
+  tolerance: 0.0
+
+falsification:
+  - id: FALSIFY-WARD-001
+    description: |
+      AgglomerativeClustering(Linkage::Ward) with n_clusters=2 on the reference
+      dataset induces the scipy/sklearn partition {1,4,5} | {0,2,3}. Discharges
+      C-WARD-001/002/003 by asserting the permutation-invariant partition:
+      labels[1]==labels[4]==labels[5] ∧ labels[0]==labels[2]==labels[3]
+      ∧ labels[1] != labels[0].
+    test: "falsify_hc_004_ward_matches_scipy"
+    evidence: |
+      cargo test -p aprender-core --lib falsify_hc_004_ward_matches_scipy
+      RED  (buggy coefficient (n1*n2/(n1+n2))*centroid_dist): partition
+           {0,1,2,3} | {4,5} → labels[1]==labels[0]==0, labels[4]==1 →
+           assertion "point 1 and point 4 must share a cluster" FAILS (0 vs 1).
+      GREEN (fixed coefficient sqrt(2*n1*n2/(n1+n2))*centroid_dist): partition
+           {1,4,5} | {0,2,3} → all assertions pass, matches scipy labels
+           [1,2,1,1,2,2] and sklearn ward.

--- a/crates/aprender-core/src/cluster/agglomerative.rs
+++ b/crates/aprender-core/src/cluster/agglomerative.rs
@@ -232,7 +232,11 @@ impl AgglomerativeClustering {
                     crate::nn::functional::euclidean_distance(&merged_centroid, &other_centroid);
                 let n1 = merged_cluster.len() as f32;
                 let n2 = other_cluster.len() as f32;
-                ((n1 * n2) / (n1 + n2)) * centroid_dist
+                // Lance-Williams Ward inter-cluster distance (scipy/sklearn):
+                //   d(A, B) = sqrt(2 * |A| * |B| / (|A| + |B|)) * ||c_A - c_B||_2
+                // Reduces to plain Euclidean for singleton merges (sqrt(2*1*1/2) = 1),
+                // consistent with the raw initial distance matrix. PMAT-849.
+                (2.0 * n1 * n2 / (n1 + n2)).sqrt() * centroid_dist
             }
         };
 

--- a/crates/aprender-core/src/cluster/tests_agglomerative_contract.rs
+++ b/crates/aprender-core/src/cluster/tests_agglomerative_contract.rs
@@ -101,6 +101,63 @@ fn falsify_hc_003_distinct_clusters() {
     );
 }
 
+/// FALSIFY-HC-004 (PMAT-849): Ward linkage merge distance matches scipy/sklearn.
+///
+/// The Lance-Williams Ward inter-cluster distance is
+///   d(A, B) = sqrt(2 * |A| * |B| / (|A| + |B|)) * ||centroid(A) - centroid(B)||_2
+/// A prior bug used `(|A|*|B|/(|A|+|B|)) * ||..||` (no factor of 2, no outer sqrt),
+/// which under-penalizes merging into larger clusters and flips which pair merges.
+///
+/// Reference dataset (verified vs scipy.cluster.hierarchy.linkage(method='ward')
+/// and sklearn.cluster.AgglomerativeClustering(linkage='ward')):
+///   X = [[5.5,7.2],[6.0,5.4],[4.2,6.5],[4.4,8.9],[9.6,3.8],[7.9,5.3]], n_clusters=2
+/// scipy partition: {1,4,5} together and {0,2,3} together.
+/// The buggy coefficient produced {0,1,2,3} together and {4,5} alone instead.
+#[test]
+fn falsify_hc_004_ward_matches_scipy() {
+    let data = Matrix::from_vec(
+        6,
+        2,
+        vec![5.5, 7.2, 6.0, 5.4, 4.2, 6.5, 4.4, 8.9, 9.6, 3.8, 7.9, 5.3],
+    )
+    .expect("valid matrix");
+
+    let mut hc = AgglomerativeClustering::new(2, Linkage::Ward);
+    hc.fit(&data).expect("fit succeeds");
+
+    let labels = hc.labels();
+
+    // Labels are permutation-invariant, so compare the induced partition.
+    // scipy/sklearn ward groups point 1 with the high-x points {4, 5},
+    // and points {0, 2, 3} together. Point 1 must NOT be with point 0.
+    assert_eq!(
+        labels[1], labels[4],
+        "FALSIFIED HC-004: point 1 and point 4 must share a cluster (scipy ward), got {} vs {}",
+        labels[1], labels[4]
+    );
+    assert_eq!(
+        labels[4], labels[5],
+        "FALSIFIED HC-004: point 4 and point 5 must share a cluster (scipy ward), got {} vs {}",
+        labels[4], labels[5]
+    );
+    assert_ne!(
+        labels[1], labels[0],
+        "FALSIFIED HC-004: point 1 must NOT be with point 0 (scipy ward partition is {{1,4,5}} | {{0,2,3}}), both got {}",
+        labels[1]
+    );
+    // The {0,2,3} side must be internally consistent.
+    assert_eq!(
+        labels[0], labels[2],
+        "FALSIFIED HC-004: point 0 and point 2 must share a cluster (scipy ward), got {} vs {}",
+        labels[0], labels[2]
+    );
+    assert_eq!(
+        labels[2], labels[3],
+        "FALSIFIED HC-004: point 2 and point 3 must share a cluster (scipy ward), got {} vs {}",
+        labels[2], labels[3]
+    );
+}
+
 mod hc_proptest_falsify {
     use super::*;
     use proptest::prelude::*;


### PR DESCRIPTION
## Summary

`AgglomerativeClustering`'s **Ward** linkage used the wrong Lance-Williams coefficient, producing a different clustering than scipy/scikit-learn.

It computed the merge distance as `(n1·n2/(n1+n2)) · centroid_dist`, omitting both the factor of 2 inside and the outer square root. The correct Ward distance is `sqrt(2·n1·n2/(n1+n2)) · ||c_A − c_B||₂`. The wrong coefficient under-penalizes merges into larger clusters, flipping which pair merges.

## Repro (verified vs scipy)
`[5.5,7.2, 6.0,5.4, 4.2,6.5, 4.4,8.9, 9.6,3.8, 7.9,5.3]`, `n_clusters=2`, Ward → buggy groups point 1 with {0,2,3}; scipy/sklearn group it with {4,5}.

## Fix
`(2.0 * n1 * n2 / (n1 + n2)).sqrt() * centroid_dist` — reduces to plain Euclidean for singleton merges (`sqrt(2·1·1/2)=1`).

## Verification
- RED: `falsify_hc_004_ward_matches_scipy` fails ("point 1 and point 4 must share a cluster, got 0 vs 1").
- GREEN: passes.
- `cargo test -p aprender-core --lib` → **13909 passed / 0 failed**.
- `contracts/ward-linkage-v1.yaml` — `pv validate` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)