### PR TITLE
fix(scheduler): ReduceLROnPlateau reduces on (patience+1)-th bad epoch (PMAT-850)

### DIFF
--- a/contracts/reduce-lr-plateau-v1.yaml
+++ b/contracts/reduce-lr-plateau-v1.yaml
@@ -1,0 +1,120 @@
+metadata:
+  version: 1.0.0
+  created: '2026-06-19'
+  author: PAIML Engineering
+  description: |
+    PMAT-850: ReduceLROnPlateau must reduce the learning rate only when the
+    number of consecutive non-improving epochs is STRICTLY GREATER than patience
+    (num_bad_epochs > patience), matching PyTorch.
+
+    PyTorch's torch.optim.lr_scheduler.ReduceLROnPlateau documents patience as
+    "the number of allowed epochs with no improvement after which the learning
+    rate will be reduced." So patience=N tolerates N non-improving epochs and
+    reduces on the (N+1)-th. Internally PyTorch increments num_bad_epochs and
+    fires when `num_bad_epochs > patience`.
+
+    aprender's step_with_metric previously triggered on
+    `num_bad_epochs >= patience`, firing one epoch too early — with patience=N
+    it reduced on the N-th non-improving epoch instead of the (N+1)-th. This
+    over-eagerly decays the LR, harming convergence parity with PyTorch.
+
+    Verified repro (mode=Min, factor=0.5, initial lr=0.1, patience=1):
+      epoch 1: metric 1.0 -> baseline (num_bad_epochs=0), lr stays 0.1
+      epoch 2: metric 1.0 -> 1 bad epoch (num_bad_epochs=1)
+        buggy (>=): 1 >= 1 -> reduce to 0.05  (WRONG, one epoch early)
+        fixed (> ): 1 >  1  -> no reduce, lr stays 0.1  (PyTorch parity)
+      epoch 3: metric 1.0 -> 2 bad epochs (num_bad_epochs=2)
+        fixed (> ): 2 >  1  -> reduce to 0.05  (the (patience+1)-th epoch)
+  references:
+  - 'PyTorch torch.optim.lr_scheduler.ReduceLROnPlateau — patience is "the number of allowed epochs with no improvement after which the learning rate will be reduced"; reduction fires when num_bad_epochs > patience'
+  - 'crates/aprender-core/src/nn/scheduler/improvement.rs — ReduceLROnPlateau::step_with_metric reduction guard (num_bad_epochs > patience)'
+  - 'crates/aprender-core/src/nn/scheduler/tests.rs — test_reduce_on_plateau_patience_strictly_greater (PMAT-850 falsifier)'
+
+kind: KernelContract
+name: reduce-lr-plateau-patience-strictly-greater
+version: 1.0.0
+scope: aprender-core ReduceLROnPlateau patience semantics (nn/scheduler/improvement.rs)
+
+equations:
+  C-PLATEAU-PATIENCE-STRICT:
+    formula: |
+      Let p = patience and b = num_bad_epochs (count of consecutive epochs with
+      no metric improvement beyond threshold). The learning rate is reduced
+      (lr := max(lr * factor, min_lr), when that is < lr) exactly when b > p.
+      On a reduction, num_bad_epochs resets to 0. An improving epoch also resets
+      num_bad_epochs to 0. Thus patience=N tolerates N non-improving epochs and
+      reduces on the (N+1)-th.
+    domain: patience ∈ ℕ, factor ∈ (0,1), metric ∈ ℝ, threshold ≥ 0
+    codomain: lr ∈ [min_lr, lr₀]; reduction occurs iff num_bad_epochs > patience
+    invariants:
+    - 'with patience=N, exactly N consecutive non-improving epochs do NOT reduce LR'
+    - 'the (N+1)-th consecutive non-improving epoch reduces LR by factor'
+    - 'an improving epoch resets num_bad_epochs to 0 (no reduction)'
+    - 'reduction uses strict greater-than (>), never >= (which fires one epoch early)'
+    lean_theorem: Theorems.ReduceLROnPlateau_Patience_Strict
+
+proof_obligations:
+- type: invariant
+  property: PO-PATIENCE-TOLERATES-N N non-improving epochs do not reduce LR
+  formal: |
+    For mode=Min, factor=0.5, lr₀=0.1, patience=1: after the baseline epoch and
+    exactly 1 non-improving epoch (num_bad_epochs=1), 1 > 1 is false, so lr
+    remains 0.1 (NOT 0.05). Generalizes: for patience=N, N non-improving epochs
+    leave lr unchanged.
+- type: invariant
+  property: PO-REDUCE-ON-N-PLUS-1 the (N+1)-th non-improving epoch reduces LR
+  formal: |
+    Continuing the above, the 2nd non-improving epoch (num_bad_epochs=2) gives
+    2 > 1 true, so lr reduces to lr₀ * factor = 0.05. Generalizes: for
+    patience=N, the (N+1)-th non-improving epoch reduces lr by factor.
+- type: invariant
+  property: PO-IMPROVEMENT-RESETS an improving epoch prevents reduction
+  formal: |
+    For continuous improvement (each metric better than best by > threshold),
+    num_bad_epochs stays 0, so b > p is never true and lr never decreases,
+    regardless of the number of epochs.
+
+falsification_tests:
+- id: FT-PLATEAU-PATIENCE-001
+  rule: patience=1 tolerates 1 non-improving epoch without reducing LR
+  prediction: |
+    ReduceLROnPlateau(Min, factor=0.5, patience=1), lr₀=0.1: after baseline
+    (metric 1.0) and ONE non-improving epoch (metric 1.0), lr is STILL 0.1.
+    RED (pre-fix, num_bad_epochs >= patience): lr = 0.05 (reduced one epoch early).
+    GREEN (post-fix, num_bad_epochs > patience): lr = 0.1.
+  if_fails: 'the reduction guard uses >= instead of > (off-by-one, fires on the N-th not the (N+1)-th bad epoch).'
+  evidence: cargo test -p aprender-core --lib test_reduce_on_plateau_patience_strictly_greater
+- id: FT-PLATEAU-PATIENCE-002
+  rule: the (patience+1)-th non-improving epoch reduces LR by factor
+  prediction: |
+    Same scheduler: a SECOND non-improving epoch (num_bad_epochs=2 > 1) reduces
+    lr to 0.05.
+    RED (pre-fix): already reduced at epoch 1, so this asserts the wrong epoch.
+    GREEN (post-fix): lr = 0.05 exactly at the (patience+1)-th epoch.
+  if_fails: 'reduction never fires, or fires at the wrong epoch count.'
+  evidence: cargo test -p aprender-core --lib test_reduce_on_plateau_patience_strictly_greater
+- id: FT-PLATEAU-PATIENCE-003
+  rule: continuous improvement never reduces LR
+  prediction: 'a strictly-improving metric sequence leaves lr at lr₀ regardless of epoch count.'
+  if_fails: 'num_bad_epochs is not reset on improvement, or the guard fires on improving epochs.'
+  evidence: cargo test -p aprender-core --lib test_reduce_on_plateau_continuous_improvement
+
+kani_harnesses:
+- id: KANI-PLATEAU-PATIENCE-001
+  obligation: PO-PATIENCE-TOLERATES-N N non-improving epochs do not reduce LR
+  property: |
+    For all patience p in [0, P] and bad-epoch count b in [0, p]: the reduction
+    guard (b > p) is false, so lr is unchanged. The guard becomes true only at
+    b = p + 1. No panic; lr stays in [min_lr, lr₀].
+  bound: 1
+  strategy: stub_float
+  solver: cadical
+  harness: verify_plateau_patience_strictly_greater
+
+qa_gate:
+  id: F-PLATEAU-PATIENCE-001
+  name: reduce-lr-plateau-v1 Contract
+  description: ReduceLROnPlateau must reduce LR only when num_bad_epochs > patience (PyTorch parity), not >= which fires one epoch too early.
+  checks:
+  - validation
+  - falsification

--- a/crates/aprender-core/src/nn/scheduler/improvement.rs
+++ b/crates/aprender-core/src/nn/scheduler/improvement.rs
@@ -64,8 +64,11 @@ impl ReduceLROnPlateau {
             self.num_bad_epochs += 1;
         }
 
-        // Reduce LR if patience exceeded
-        if self.num_bad_epochs >= self.patience {
+        // Reduce LR if patience exceeded.
+        // PyTorch semantics: patience=N tolerates N non-improving epochs and
+        // reduces only on the (N+1)-th, i.e. strictly `> patience`, not `>=`.
+        // (PMAT-850 off-by-one fix; see contracts/reduce-lr-plateau-v1.yaml.)
+        if self.num_bad_epochs > self.patience {
             let new_lr = (self.current_lr * self.factor).max(self.min_lr);
             if new_lr < self.current_lr {
                 self.current_lr = new_lr;

--- a/crates/aprender-core/src/nn/scheduler/tests.rs
+++ b/crates/aprender-core/src/nn/scheduler/tests.rs
@@ -134,13 +134,59 @@ fn test_reduce_on_plateau() {
     scheduler.step_with_metric(&mut optimizer, 0.9);
     assert!((optimizer.lr() - 0.1).abs() < 1e-6);
 
-    // Plateau (no improvement for 3 epochs)
-    scheduler.step_with_metric(&mut optimizer, 0.9);
-    scheduler.step_with_metric(&mut optimizer, 0.9);
-    scheduler.step_with_metric(&mut optimizer, 0.9);
+    // Plateau. PyTorch semantics (PMAT-850): patience=3 tolerates 3
+    // non-improving epochs and reduces only on the 4th (num_bad_epochs > patience).
+    scheduler.step_with_metric(&mut optimizer, 0.9); // bad #1
+    scheduler.step_with_metric(&mut optimizer, 0.9); // bad #2
+    scheduler.step_with_metric(&mut optimizer, 0.9); // bad #3 — still 0.1 (3 > 3 is false)
+    assert!(
+        (optimizer.lr() - 0.1).abs() < 1e-6,
+        "patience=3 tolerates 3 non-improving epochs without reducing"
+    );
+
+    scheduler.step_with_metric(&mut optimizer, 0.9); // bad #4 — now reduces (4 > 3)
 
     // LR should be reduced
     assert!((optimizer.lr() - 0.01).abs() < 1e-6);
+}
+
+// PMAT-850 falsifier: PyTorch ReduceLROnPlateau reduces only when
+// num_bad_epochs > patience (strictly greater). patience=N tolerates N
+// non-improving epochs and reduces on the (N+1)-th.
+//
+// RED (buggy `>=`): one non-improving epoch reduces LR to 0.05 immediately.
+// GREEN (correct `>`): first non-improving epoch keeps LR at 0.1; the SECOND
+// non-improving epoch reduces it to 0.05.
+//
+// Reference: torch.optim.lr_scheduler.ReduceLROnPlateau — patience is "the
+// number of allowed epochs with no improvement after which the LR is reduced."
+#[test]
+fn test_reduce_on_plateau_patience_strictly_greater() {
+    let mut optimizer = MockOptimizer::new(0.1);
+    let mut scheduler = ReduceLROnPlateau::new(PlateauMode::Min, 0.5, 1);
+
+    // Epoch 1: establish baseline (best_metric = 1.0, num_bad_epochs = 0).
+    scheduler.step_with_metric(&mut optimizer, 1.0);
+    assert!(
+        (optimizer.lr() - 0.1).abs() < 1e-6,
+        "baseline epoch must not reduce LR"
+    );
+
+    // Epoch 2: first non-improving epoch (num_bad_epochs = 1). With patience=1,
+    // 1 > 1 is false, so LR MUST stay at 0.1 (this is the RED assertion under `>=`).
+    scheduler.step_with_metric(&mut optimizer, 1.0);
+    assert!(
+        (optimizer.lr() - 0.1).abs() < 1e-6,
+        "patience=1 tolerates 1 non-improving epoch: LR must remain 0.1, not reduce early"
+    );
+
+    // Epoch 3: second non-improving epoch (num_bad_epochs = 2). 2 > 1 is true,
+    // so LR reduces by factor 0.5 to 0.05.
+    scheduler.step_with_metric(&mut optimizer, 1.0);
+    assert!(
+        (optimizer.lr() - 0.05).abs() < 1e-6,
+        "LR must reduce to 0.05 on the (patience+1)-th non-improving epoch"
+    );
 }
 
 #[test]
@@ -153,9 +199,16 @@ fn test_reduce_on_plateau_max_mode() {
     scheduler.step_with_metric(&mut optimizer, 0.6);
     assert!((optimizer.lr() - 0.1).abs() < 1e-6);
 
-    // Plateau
-    scheduler.step_with_metric(&mut optimizer, 0.6);
-    scheduler.step_with_metric(&mut optimizer, 0.6);
+    // Plateau. PyTorch semantics (PMAT-850): patience=2 tolerates 2
+    // non-improving epochs and reduces only on the 3rd (num_bad_epochs > patience).
+    scheduler.step_with_metric(&mut optimizer, 0.6); // bad #1
+    scheduler.step_with_metric(&mut optimizer, 0.6); // bad #2 — still 0.1 (2 > 2 is false)
+    assert!(
+        (optimizer.lr() - 0.1).abs() < 1e-6,
+        "patience=2 tolerates 2 non-improving epochs without reducing"
+    );
+
+    scheduler.step_with_metric(&mut optimizer, 0.6); // bad #3 — now reduces (3 > 2)
 
     // LR should be reduced
     assert!((optimizer.lr() - 0.05).abs() < 1e-6);
@@ -271,12 +324,21 @@ fn test_reduce_on_plateau_min_lr_clamp() {
     let mut optimizer = MockOptimizer::new(0.001);
     let mut scheduler = ReduceLROnPlateau::new(PlateauMode::Min, 0.1, 1).min_lr(0.0005);
 
-    // First metric establishes baseline
+    // First metric establishes baseline (num_bad_epochs = 0).
     scheduler.step_with_metric(&mut optimizer, 1.0);
-    // No improvement triggers reduction
+    // PyTorch semantics (PMAT-850): patience=1 tolerates 1 non-improving epoch,
+    // so the first bad epoch does NOT reduce yet (1 > 1 is false).
+    scheduler.step_with_metric(&mut optimizer, 1.0);
+    assert!(
+        (scheduler.get_lr() - 0.001).abs() < 1e-8,
+        "patience=1 tolerates 1 non-improving epoch without reducing"
+    );
+    // Second bad epoch (2 > 1) triggers reduction: 0.001 * 0.1 = 0.0001,
+    // clamped up to min_lr = 0.0005.
     scheduler.step_with_metric(&mut optimizer, 1.0);
     // LR should be clamped at min_lr
     assert!(scheduler.get_lr() >= 0.0005);
+    assert!((scheduler.get_lr() - 0.0005).abs() < 1e-8);
 }
 
 #[test]

--- a/crates/aprender-core/src/nn/scheduler/tests_warmup_cosine.rs
+++ b/crates/aprender-core/src/nn/scheduler/tests_warmup_cosine.rs
@@ -86,15 +86,21 @@ fn test_reduce_on_plateau_multiple_reductions() {
     let mut optimizer = MockOptimizer::new(0.1);
     let mut scheduler = ReduceLROnPlateau::new(PlateauMode::Min, 0.5, 2).min_lr(0.001);
 
-    scheduler.step_with_metric(&mut optimizer, 1.0);
+    scheduler.step_with_metric(&mut optimizer, 1.0); // baseline (num_bad_epochs = 0)
 
-    // First plateau - reduce from 0.1 to 0.05
-    scheduler.step_with_metric(&mut optimizer, 1.0);
-    scheduler.step_with_metric(&mut optimizer, 1.0);
+    // First plateau. PyTorch semantics (PMAT-850): patience=2 tolerates 2
+    // non-improving epochs and reduces only on the 3rd (num_bad_epochs > patience).
+    scheduler.step_with_metric(&mut optimizer, 1.0); // bad #1
+    scheduler.step_with_metric(&mut optimizer, 1.0); // bad #2 — still 0.1
+    assert!((optimizer.lr() - 0.1).abs() < 1e-6);
+    scheduler.step_with_metric(&mut optimizer, 1.0); // bad #3 — reduce 0.1 -> 0.05
     assert!((optimizer.lr() - 0.05).abs() < 1e-6);
 
-    // Second plateau - reduce from 0.05 to 0.025
-    scheduler.step_with_metric(&mut optimizer, 1.0);
-    scheduler.step_with_metric(&mut optimizer, 1.0);
+    // Second plateau - num_bad_epochs resets to 0 after a reduction, so another
+    // 3 non-improving epochs are required to reduce from 0.05 to 0.025.
+    scheduler.step_with_metric(&mut optimizer, 1.0); // bad #1
+    scheduler.step_with_metric(&mut optimizer, 1.0); // bad #2 — still 0.05
+    assert!((optimizer.lr() - 0.05).abs() < 1e-6);
+    scheduler.step_with_metric(&mut optimizer, 1.0); // bad #3 — reduce 0.05 -> 0.025
     assert!((optimizer.lr() - 0.025).abs() < 1e-6);
 }


### PR DESCRIPTION
## PMAT-850 — ReduceLROnPlateau off-by-one (PyTorch parity)

### Bug
`ReduceLROnPlateau::step_with_metric` (crates/aprender-core/src/nn/scheduler/improvement.rs) triggered the LR reduction on `num_bad_epochs >= patience`, firing **one epoch too early**. With `patience=N` it decayed the LR on the N-th consecutive non-improving epoch instead of the (N+1)-th.

### Correct (PyTorch)
`torch.optim.lr_scheduler.ReduceLROnPlateau` documents `patience` as "the number of allowed epochs with no improvement after which the learning rate will be reduced" — `patience=N` tolerates N non-improving epochs and reduces only on the **(N+1)-th**. The guard must be strictly `num_bad_epochs > patience`.

### Fix
One-character semantics fix: `>=` → `>` in the reduction guard.

### Falsifier-first (RED → GREEN)
New `test_reduce_on_plateau_patience_strictly_greater` (patience=1, mode=Min, factor=0.5, lr0=0.1):
- **RED** (pre-fix `>=`): first non-improving epoch reduces lr to 0.05 → assertion "LR must remain 0.1" FAILED at `tests.rs:171`.
- **GREEN** (post-fix `>`): first non-improving epoch keeps lr=0.1; the **second** non-improving epoch reduces lr to 0.05. PASSES.

### Sibling tests corrected (each annotated; they encoded the off-by-one)
- `test_reduce_on_plateau` (patience=3): now needs a 4th bad epoch
- `test_reduce_on_plateau_max_mode` (patience=2): now needs a 3rd bad epoch
- `test_reduce_on_plateau_min_lr_clamp` (patience=1): now needs a 2nd bad epoch (also tightened to assert the clamp value exactly)
- `tests_warmup_cosine::test_reduce_on_plateau_multiple_reductions` (patience=2): each reduction now needs 3 bad epochs

### Verification
- `cargo test -p aprender-core --lib nn::scheduler` → **42 passed, 0 failed**
- `cargo build -p aprender-core` clean; clippy + rustfmt clean on the changed files
- Contract `contracts/reduce-lr-plateau-v1.yaml` (KernelContract): `pv validate` → **0 errors, 0 warnings**

### Contract
Adds `contracts/reduce-lr-plateau-v1.yaml` with equation `C-PLATEAU-PATIENCE-STRICT`, obligations `PO-PATIENCE-TOLERATES-N` / `PO-REDUCE-ON-N-PLUS-1` / `PO-IMPROVEMENT-RESETS`, and falsifiers `FT-PLATEAU-PATIENCE-001..003`, referencing PyTorch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)