### PR TITLE
fix(stats): exact Student-t p-value for all df, drop df>30 normal shortcut (PMAT-853)

### DIFF
--- a/contracts/ttest-exact-pvalue-v1.yaml
+++ b/contracts/ttest-exact-pvalue-v1.yaml
@@ -1,0 +1,81 @@
+metadata:
+  version: "1.0.0"
+  created: "2026-06-19"
+  author: PAIML Engineering
+  registry: true
+  references:
+    - "scipy.stats.t.sf (oracle for the one-tailed Student-t survival function, pinned 2026-06-19 via `uv run --with scipy`)"
+    - "scipy.stats.ttest_1samp / ttest_ind / ttest_rel (downstream two-tailed p-value oracles)"
+    - "Abramowitz & Stegun 26.7.1 — Student-t CDF via the regularized incomplete beta I_x(df/2, 1/2)"
+    - "Companion contract: incomplete-beta-correctness-v1 (PMAT-827) — the exact path this fix completes"
+  description: |
+    Correctness contract for the two-tailed Student-t p-value
+    (aprender-core stats::hypothesis::t_distribution_pvalue) for ALL degrees of
+    freedom. Pillar-1 (scipy/sklearn parity) provable-correctness, ticket PMAT-853.
+
+kind: KernelContract
+name: ttest-exact-pvalue
+version: "1.0.0"
+scope: "crates/aprender-core/src/stats/hypothesis.rs"
+
+description: |
+  The two-tailed p-value of a Student-t statistic t with df degrees of freedom is
+  the regularized incomplete beta tail, exact for EVERY df:
+
+      x            = df / (df + t²)
+      p_two_tailed = I_x(df/2, 1/2)          (= 2 * scipy.stats.t.sf(|t|, df))
+
+  PMAT-853 removed a defect where `t_distribution_pvalue` short-circuited
+  `df > 30.0` and returned the standard-normal two-tailed tail
+  `2 * normal_cdf(-|t|)` instead of the exact I_x(df/2, 1/2) path it already
+  implements for df <= 30. The normal approximation UNDERSTATES the moderate-df
+  t-tail (heavier tails than the Gaussian), so it reports p-values that are too
+  small and flips significance decisions near alpha. Example at df = 40, t = 2.02:
+  the normal approximation gives p = 0.043383 (falsely "significant" at 0.05)
+  while the exact t-tail gives p = 0.050116 (NOT significant) — scipy agrees with
+  the exact value. The exact path is accurate only because PMAT-827 corrected the
+  underlying `incomplete_beta`; this contract completes that correction by routing
+  ALL df through the exact tail and deleting the `df > 30` shortcut.
+
+equations:
+  C-TTEST-001:
+    description: "Two-tailed Student-t p-value uses the exact incomplete-beta tail for ALL df (no df>30 normal shortcut)"
+    formula: "t_distribution_pvalue(t, df) = clamp(I_x(df/2, 1/2), 0, 1), x = df/(df + t^2), for every df > 0"
+    note: "Matches 2*scipy.stats.t.sf(|t|, df). RED at df=40, t=2.04: normal-approx 0.041350; GREEN exact 0.047992."
+
+  C-TTEST-002:
+    description: "The exact t-tail must DIFFER from the standard-normal approximation for moderate df (they are not interchangeable)"
+    formula: "|t_distribution_pvalue(t, df) - 2*normal_cdf(-|t|)| > 5e-3 at df=40, t=2.04 (exact 0.047992 vs normal 0.041350)"
+    note: "Refutes the deleted shortcut's premise that df>30 is 'close enough' to normal near alpha."
+
+  C-TTEST-003:
+    description: "Significance-decision parity with scipy near alpha for df>30 (no false-positive null rejection)"
+    formula: "df=40, t=2.02: t_distribution_pvalue = 0.050116 > 0.05 (NOT significant), matching 2*scipy.stats.t.sf; normal-approx 0.043383 falsely rejects"
+    note: "The headline beat: apr's inference decision agrees with scipy where the normal approximation diverges."
+
+  C-TTEST-004:
+    description: "Small-df path (df <= 30, already exact) is UNCHANGED by the fix"
+    formula: "df=5, t=2.0: t_distribution_pvalue = 0.101939 == 2*scipy.stats.t.sf(2.0, 5)"
+    note: "Regression guard — deleting the df>30 branch must not perturb the df<=30 branch."
+
+proof_obligations:
+  - type: equivalence
+    property: "PO-TTEST-001 exact t-tail matches scipy for all df"
+    formal: "|t_distribution_pvalue(t, df) - 2*scipy.stats.t.sf(|t|, df)| < 1e-3 for all df > 0; df>30 routes through I_x(df/2,1/2), not the normal CDF"
+    tolerance: 0.001
+    applies_to: all
+  - type: invariant
+    property: "PO-TTEST-002 small-df path unchanged by the fix"
+    formal: "t_distribution_pvalue(2.0, 5) = 0.101939 (df<=30 incomplete-beta path stable across deletion of the df>30 branch)"
+    tolerance: 0.001
+    applies_to: "df <= 30"
+
+falsification:
+  - id: FALSIFY-STATS-TTEST-003
+    description: "Exact two-tailed t p-value matches scipy.stats.t.sf for df>30 and the small-df path is unchanged. Discharges C-TTEST-001..004 and PO-TTEST-001/002."
+    test: "test_t_distribution_pvalue_exact_all_df_matches_scipy — df=40,t=2.04: RED 0.041350 (normal approx) -> GREEN 0.047992 (scipy t.sf); df=40,t=2.02 significance-flip: RED 0.043383 (<0.05, falsely significant) -> GREEN 0.050116 (>0.05); df=5,t=2.0 regression 0.101939 unchanged."
+    command: "cargo test -p aprender-core --lib test_t_distribution_pvalue_exact_all_df_matches_scipy"
+    red: "0.041350 (2*normal_cdf(-2.04), the deleted df>30 shortcut) at df=40, t=2.04"
+    green: "0.047992 (2*scipy.stats.t.sf(2.04, 40), the exact incomplete-beta tail) at df=40, t=2.04"
+    scipy_reference: "2*scipy.stats.t.sf(2.04, 40) = 0.0479916; 2*scipy.stats.t.sf(2.02, 40) = 0.0501163; 2*scipy.stats.t.sf(2.0, 5) = 0.1019395"
+    evidence: "cargo test -p aprender-core --lib test_t_distribution_pvalue_exact_all_df_matches_scipy"

--- a/crates/aprender-core/src/stats/hypothesis.rs
+++ b/crates/aprender-core/src/stats/hypothesis.rs
@@ -345,20 +345,23 @@ pub fn f_oneway(groups: &[Vec<f32>]) -> Result<AnovaResult> {
 // Distribution p-value approximations
 // ============================================================================
 
-/// Approximates the two-tailed p-value for a t-distribution.
+/// Computes the exact two-tailed p-value for a Student's t-distribution.
 ///
-/// Uses numerical approximation for t-distribution CDF.
+/// Uses the regularized incomplete beta identity for the t-distribution tail,
+/// matching `scipy.stats.t.sf` for ALL degrees of freedom:
+///
+///   two-tailed p = I_x(df/2, 1/2),  where  x = df / (df + t²)
+///
+/// PMAT-853: a previous `df > 30.0` shortcut returned the standard-normal
+/// approximation `2 * normal_cdf(-|t|)`, which understates the moderate-df
+/// t-tail and flips significance decisions near alpha. The exact path below
+/// (now accurate after the PMAT-827 `incomplete_beta` correction) is used for
+/// every df, so the shortcut has been removed.
 fn t_distribution_pvalue(t: f32, df: f32) -> f32 {
-    // For large df, t-distribution approaches standard normal
-    if df > 30.0 {
-        return 2.0 * normal_cdf(-t.abs());
-    }
-
-    // Simple approximation using beta function relationship
-    // P(T > t) ≈ 1 - I_x(df/2, 1/2) where x = df/(df + t²)
+    // P(|T| > |t|) = I_x(df/2, 1/2) with x = df/(df + t²).
     let x = df / (df + t * t);
     let p_one_tail = 0.5 * incomplete_beta(df / 2.0, 0.5, x);
-    2.0 * p_one_tail.clamp(0.0, 1.0)
+    (2.0 * p_one_tail).clamp(0.0, 1.0)
 }
 
 /// Approximates the p-value for a chi-square distribution.
@@ -377,11 +380,18 @@ fn f_distribution_pvalue(f: f32, df1: usize, df2: usize) -> f32 {
 }
 
 /// Standard normal CDF approximation (using error function).
+///
+/// Test-only since PMAT-853 removed the `df > 30` normal-approximation
+/// shortcut from `t_distribution_pvalue`; retained as a reference oracle for
+/// the falsification tests that contrast the exact t-tail against the normal
+/// approximation.
+#[cfg(test)]
 fn normal_cdf(x: f32) -> f32 {
     0.5 * (1.0 + erf(x / 2.0_f32.sqrt()))
 }
 
 /// Error function approximation (delegates to batuta-common).
+#[cfg(test)]
 fn erf(x: f32) -> f32 {
     batuta_common::math::erf_f32(x)
 }

--- a/crates/aprender-core/src/stats/hypothesis_tests.rs
+++ b/crates/aprender-core/src/stats/hypothesis_tests.rs
@@ -311,13 +311,68 @@ mod tests {
     // =========================================================================
 
     #[test]
-    fn test_t_distribution_large_df_uses_normal_approx() {
-        // df > 30 triggers the normal approximation branch
+    fn test_t_distribution_large_df_exact_path() {
+        // df > 30 routes through the EXACT incomplete-beta path (PMAT-853).
+        // Previously this branch short-circuited to a standard-normal approximation;
+        // it now uses I_x(df/2, 1/2) for ALL df, matching scipy.stats.t.sf.
         let large_sample: Vec<f32> = (0..50).map(|i| i as f32 * 0.1).collect();
         let result = ttest_1samp(&large_sample, 0.0).expect("Valid t-test with large n");
-        // df = 49, which is > 30, so normal approximation path is taken
+        // df = 49, which is > 30 — exact path is taken.
         assert!(result.df > 30.0);
         assert!(result.pvalue >= 0.0 && result.pvalue <= 1.0);
+    }
+
+    /// FALSIFY-STATS-TTEST-003 (PMAT-853): `t_distribution_pvalue` previously
+    /// short-circuited `df > 30.0` to `2 * normal_cdf(-|t|)`, the standard-normal
+    /// two-tailed tail, abandoning the exact t-distribution tail it already
+    /// computes for df <= 30 via `incomplete_beta(df/2, 1/2, x)`. The normal
+    /// approximation UNDERSTATES the moderate-df t-tail, flipping significance
+    /// decisions near alpha. scipy.stats.t.sf is the oracle (pinned 2026-06-19
+    /// via `uv run --with scipy`). The fix deletes the shortcut so ALL df use
+    /// the exact path.
+    #[test]
+    fn test_t_distribution_pvalue_exact_all_df_matches_scipy() {
+        // df = 40, t = 2.04 (> 30, hits the deleted shortcut).
+        //   RED  (normal approx 2*norm.sf(2.04)) = 0.041350
+        //   GREEN (exact 2*t.sf(2.04, 40))        = 0.047992  <- scipy oracle
+        let p_t40 = t_distribution_pvalue(2.04, 40.0);
+        assert!(
+            (p_t40 - 0.047_992).abs() < 1e-3,
+            "FALSIFIED PMAT-853: t_distribution_pvalue(2.04, 40) = {p_t40} != \
+             0.047992 (2*scipy.stats.t.sf); normal-approx RED value was 0.041350"
+        );
+        // The exact t-value must DIFFER from the normal approximation at df=40
+        // (this is the whole point — they are not interchangeable for moderate df).
+        let normal_approx = 2.0 * normal_cdf(-2.04_f32.abs());
+        assert!(
+            (p_t40 - normal_approx).abs() > 5e-3,
+            "FALSIFIED PMAT-853: exact t p-value {p_t40} collapsed onto the \
+             normal approximation {normal_approx} at df=40"
+        );
+
+        // Significance-flip witness: df = 40, t = 2.02.
+        //   normal approx = 0.043383  -> "significant" at alpha=0.05 (WRONG)
+        //   exact t.sf    = 0.050116  -> NOT significant at alpha=0.05 (scipy)
+        let p_flip = t_distribution_pvalue(2.02, 40.0);
+        assert!(
+            (p_flip - 0.050_116).abs() < 1e-3,
+            "FALSIFIED PMAT-853: t_distribution_pvalue(2.02, 40) = {p_flip} != \
+             0.050116 (2*scipy.stats.t.sf)"
+        );
+        assert!(
+            p_flip > 0.05,
+            "FALSIFIED PMAT-853: exact p {p_flip} must be > 0.05 (scipy=0.050116); \
+             the normal approx 0.043383 falsely declared significance"
+        );
+
+        // Small-df regression: the df <= 30 path must be UNCHANGED.
+        //   exact 2*scipy.stats.t.sf(2.0, 5) = 0.101939
+        let p_t5 = t_distribution_pvalue(2.0, 5.0);
+        assert!(
+            (p_t5 - 0.101_939).abs() < 1e-3,
+            "REGRESSION PMAT-853: t_distribution_pvalue(2.0, 5) = {p_t5} != \
+             0.101939 (2*scipy.stats.t.sf) — small-df path changed"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## PMAT-853 — exact Student-t p-value for all degrees of freedom

### Bug
`t_distribution_pvalue` (`crates/aprender-core/src/stats/hypothesis.rs`) short-circuited `df > 30.0` and returned the standard-normal two-tailed tail `2 * normal_cdf(-|t|)` instead of the exact incomplete-beta tail `I_x(df/2, 1/2)` (`x = df/(df + t²)`) that the **same function already implements** for `df ≤ 30` and that matches `scipy.stats.t.sf` for **all** df.

Student's t has heavier tails than the Gaussian, so the normal approximation **understates** the moderate-df t-tail → p-values too small → significance decisions flipped near alpha vs scipy.

### Fix
Delete the `if df > 30.0 { … }` shortcut so every df routes through the exact `incomplete_beta(df/2, 1/2, x)` path. This **completes PMAT-827** (which corrected the underlying `incomplete_beta`; the exact path is accurate only after that fix). `normal_cdf`/`erf` lose their only production caller and are now `#[cfg(test)]` reference oracles used by the falsifier.

### Falsifier — `test_t_distribution_pvalue_exact_all_df_matches_scipy`
| case | RED (normal approx) | GREEN (exact = scipy `2*t.sf`) |
|------|--------------------|-------------------------------|
| df=40, t=2.04 | 0.041350 | **0.047992** |
| df=40, t=2.02 (significance flip) | 0.043383 → falsely *significant* at 0.05 | **0.050116** → NOT significant |
| df=5, t=2.0 (regression, df≤30) | — | **0.101939** unchanged |

RED proven before the fix (`t_distribution_pvalue(2.04, 40) = 0.041350` ≠ scipy 0.047992); GREEN after. The df=40, t=2.02 case is a real significance-decision flip: the old normal approximation called it significant, the exact t-tail (and scipy) does not.

### Contract
`contracts/ttest-exact-pvalue-v1.yaml` — `KernelContract`, equations `C-TTEST-001..004`, proof obligations `PO-TTEST-001/002`, falsification `FALSIFY-STATS-TTEST-003`, oracle `scipy.stats.t.sf`. `pv validate` → **0 errors, 0 warnings**.

### Verification
- `cargo test -p aprender-core --lib` → **13910 pass, 0 real failures** (1 unrelated `citl::compiler` cargo-subprocess flake that passes in isolation; my diff only touches `stats/`).
- `cargo build -p aprender-core` clean (no dead_code warnings).
- clippy + fmt clean on changed files.

Pillar-1 (scipy/sklearn parity) provable-correctness beat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)