### PR TITLE
fix(lora): MergeEngine::merge transposed PEFT adapters — apr finetune merge folded wrong delta (PMAT-854)

### DIFF
--- a/contracts/apr-lora-merge-equivalence-beat-v1.yaml
+++ b/contracts/apr-lora-merge-equivalence-beat-v1.yaml
@@ -27,11 +27,12 @@ beat:
   incumbent: "PEFT / Unsloth (merge_and_unload — no forward-equivalence contract)"
   incumbent_pinned: "2026-06-14 — incumbents merge but do not contract-verify merged≡factored forward"
   canonical_task: >
-    Fold a LoRA adapter (A:[d_in,r], B:[r,d_out], scale=alpha/rank) into a base
-    weight W:[d_out,d_in] via MergeEngine::merge, then compare the merged-weight
-    forward (x @ W_merged^T) against the LoRA forward computed independently from the
-    factors (x@W_base^T + scale·(x @ A @ B)). Metric: max absolute per-element
-    difference between the two forward passes.
+    Fold a LoRA adapter in STANDARD PEFT layout (A:[rank,d_in], B:[d_out,rank],
+    scale=alpha/rank) into a base weight W:[d_out,d_in] via MergeEngine::merge, then
+    compare the merged-weight forward (x @ W_merged^T) against the LoRA forward computed
+    independently from the factors (x@W_base^T + scale·(x @ A^T @ B^T), ΔW=B@A). Metric:
+    max absolute per-element difference between the two forward passes. (PMAT-854 fixed
+    the prior transposed indexing that read both factors in the wrong layout.)
   metric: merge_forward_max_abs_diff
   direction: lower_is_better
   baseline_value: 0.0000      # perfect forward-equivalence target

--- a/contracts/lora-merge-peft-layout-v1.yaml
+++ b/contracts/lora-merge-peft-layout-v1.yaml
@@ -1,0 +1,165 @@
+metadata:
+  version: 1.0.0
+  created: '2026-06-19'
+  author: PAIML Engineering
+  description: |
+    PMAT-854: `MergeEngine::merge` (crates/aprender-train-lora/src/merge.rs),
+    invoked by the production `apr finetune merge` CLI, must fold a LoRA adapter
+    into the base weight using the STANDARD PEFT adapter layout that `apr finetune`
+    actually writes: `lora_a` is [rank, d_in] and `lora_b` is [d_out, rank], both
+    row-major (crates/apr-cli/src/commands/finetune.rs:842,845).
+
+    The pre-fix code computed
+      result[row*d_in+col] += scale · sum_k lora_b[k*d_out+row] · lora_a[col*r+k]
+    which assumes the TRANSPOSED layout A:[d_in,rank], B:[rank,d_out]. It therefore
+    read BOTH factors transposed and folded a scrambled delta into the base weight —
+    a silent correctness defect in fine-tune→merge.
+
+    The correct merge is ΔW = B @ A (shape [d_out, d_in]) with
+      result[row*d_in+col] += scale · sum_k lora_b[row*r+k] · lora_a[k*d_in+col]
+    the SAME indexing the in-repo correct twin `QLoRALayer::merge_to_f32`
+    (crates/aprender-train/src/lora/qlora.rs:240-245, doc at line 232
+    "A:[rank,d_in], B:[d_out,rank]") already uses. The two merge paths now agree.
+
+    Reference: PEFT `tuners/lora/layer.py` get_delta_weight/merge — lora_A:[r,in],
+    lora_B:[out,r], ΔW = scaling·(B@A). Unsloth merge_and_unload is identical.
+  references:
+  - 'crates/aprender-train-lora/src/merge.rs (MergeEngine::merge + merge_uses_peft_layout + beat_lora_merge_forward_equivalence)'
+  - 'crates/aprender-train/src/lora/qlora.rs:223-250 (QLoRALayer::merge_to_f32 — the correct in-repo twin)'
+  - 'crates/apr-cli/src/commands/finetune.rs:842,845 (producer: writes lora_a [rank,d_in], lora_b [d_out,rank])'
+  - 'PEFT tuners/lora/layer.py get_delta_weight (ΔW = scaling·(B@A), lora_A:[r,in], lora_B:[out,r])'
+  - 'Unsloth merge_and_unload (identical PEFT layout)'
+
+kind: KernelContract
+name: lora-merge-peft-layout
+version: 1.0.0
+scope: aprender-train-lora MergeEngine::merge (apr finetune merge CLI)
+
+equations:
+  delta_weight_peft:
+    formula: |
+      For the STANDARD PEFT adapter layout produced by `apr finetune`:
+        A := lora_a, shape [rank, d_in], row-major
+        B := lora_b, shape [d_out, rank], row-major
+        W := base_weights, shape [d_out, d_in], row-major
+        scale := merge_scale * alpha / rank
+      the merged weight is
+        W_merged[row, col] = W[row, col] + scale * sum_{k=0}^{rank-1} B[row, k] * A[k, col]
+      i.e. W_merged = W + scale * (B @ A), with ΔW = B @ A of shape [d_out, d_in].
+      In flat row-major indexing:
+        result[row*d_in + col] += scale * sum_k lora_b[row*rank + k] * lora_a[k*d_in + col]
+    domain: lora_a in R^{rank*d_in}; lora_b in R^{d_out*rank}; base in R^{d_out*d_in}; rank>=1
+    codomain: result in R^{d_out*d_in}, row-major [d_out, d_in]
+    invariants:
+    - 'A is indexed [rank, d_in]: A[k,col] = lora_a[k*d_in + col] (NOT lora_a[col*rank + k])'
+    - 'B is indexed [d_out, rank]: B[row,k] = lora_b[row*rank + k] (NOT lora_b[k*d_out + row])'
+    - 'The indexing is byte-identical to QLoRALayer::merge_to_f32 (the correct in-repo twin)'
+    - 'For rank=1 the transposed and PEFT indexings coincide, so legacy rank-1 tests are unaffected'
+    preconditions:
+    - lora_a.len() == rank * d_in and lora_b.len() == d_out * rank and base.len() == d_out * d_in
+    lean_theorem: Theorems.Delta_Weight_Peft
+
+  forward_equivalence:
+    formula: |
+      The merged weight must be forward-equivalent to applying the unmerged LoRA
+      factors. For an input row x in R^{d_in}:
+        x @ W_merged^T  ==  x @ W^T + scale * (x @ A^T @ B^T)
+      to within f32 tolerance (ΔW = B@A). A transpose/indexing bug in merge breaks
+      this equality because the reference is computed via an INDEPENDENT path.
+    domain: x in R^{d_in}; PEFT-layout A, B, W as above
+    codomain: y in R^{d_out}; max|y_merged - y_factored| < 1e-4
+    invariants:
+    - 'The reference forward is computed from the A,B factors, not from W_merged (non-tautological)'
+    - 'Measured CPU deterministic max|Δ| ~ 1.5e-8 << 1e-4 threshold'
+    preconditions:
+    - 'd_out != d_in chosen so the merge path is unambiguous'
+    lean_theorem: Theorems.Forward_Equivalence
+
+proof_obligations:
+- type: invariant
+  property: merge uses PEFT layout A:[rank,d_in], B:[d_out,rank]
+  formal: |
+    For the repro (d_in=3, d_out=2, rank=2, alpha=2 -> scale=1, W=zeros),
+    A = [[1,0,0],[0,2,0]] ([rank,d_in]), B = identity ([d_out,rank]):
+    MergeEngine::new().merge(&W, &A, &B, 2.0, 2) == [1,0,0, 0,2,0] (= B@A).
+    The pre-fix transposed code yields the WRONG [1,0,2, 0,0,0] (max abs error 2.0).
+- type: invariant
+  property: merge agrees with QLoRALayer::merge_to_f32
+  formal: |
+    For every (rank, d_in, d_out) and any A:[rank,d_in], B:[d_out,rank], W:[d_out,d_in]:
+    MergeEngine::merge(W, A, B, alpha, rank) with scale=alpha/rank produces the same
+    flat result as QLoRALayer::merge_to_f32 over the same dequantized W and factors.
+- type: classification
+  property: merged weight is forward-equivalent to unmerged LoRA factors
+  formal: |
+    For every input x: x @ W_merged^T equals x @ W^T + scale*(x @ A^T @ B^T)
+    within max abs diff < 1e-4, where the reference is computed from A,B independently.
+
+falsification_tests:
+- id: FT-MERGE-001
+  rule: MergeEngine::merge honors PEFT layout (A:[rank,d_in], B:[d_out,rank])
+  prediction: |
+    With A=[1,0,0, 0,2,0] ([rank2,d_in3]), B=[1,0, 0,1] ([d_out2,rank2] identity),
+    W=zeros(2x3), alpha=2, rank=2 (scale=1): merge returns [1,0,0, 0,2,0] (= B@A).
+  if_fails: |
+    The merge reads the factors transposed (assumes A:[d_in,rank], B:[rank,d_out]).
+    RED (pre-fix): returns [1,0,2, 0,0,0], max abs error 2.0. Fix the flat indexing in
+    MergeEngine::merge to lora_b[row*r+k]*lora_a[k*d_in+col] (match QLoRALayer::merge_to_f32).
+  evidence: |
+    RED:   cargo test -p aprender-train-lora --lib merge_uses_peft_layout
+           -> FAILED, got [1.0,0.0,2.0,0.0,0.0,0.0] (max abs error 2.0)
+    GREEN: cargo test -p aprender-train-lora --lib merge_uses_peft_layout
+           -> ok (returns [1.0,0.0,0.0,0.0,2.0,0.0])
+- id: FT-MERGE-002
+  rule: merged-weight forward equals unmerged-LoRA forward (PEFT layout)
+  prediction: |
+    For d_in=4, d_out=3, rank=2 with A:[rank,d_in], B:[d_out,rank]: the forward pass
+    using the merged weights matches x@W^T + scale*(x @ A^T @ B^T) to max|Δ| < 1e-4.
+  if_fails: |
+    A transpose/indexing bug in merge diverges from the independently-factored forward.
+    Check the B@A indexing matches QLoRALayer::merge_to_f32.
+  evidence: |
+    GREEN: cargo test -p aprender-train-lora --lib beat_lora_merge_forward_equivalence
+           -> ok (max|Δ| ~ 1.5e-8, after correcting the test to PEFT layout)
+- id: FT-MERGE-003
+  rule: MergeEngine::merge agrees with the QLoRALayer::merge_to_f32 twin
+  prediction: |
+    For any A:[rank,d_in], B:[d_out,rank], W:[d_out,d_in], the flat result of
+    MergeEngine::merge (scale=alpha/rank) is element-wise equal to the in-repo
+    correct twin QLoRALayer::merge_to_f32 over the same factors and dequantized base.
+  if_fails: |
+    The two production merge paths disagree — one of them transposes the factors.
+    Make MergeEngine::merge use lora_b[row*r+k]*lora_a[k*d_in+col] (the twin's indexing).
+  evidence: |
+    GREEN: both paths use result[row*d_in+col] += scale*sum_k B[row,k]*A[k,col]
+           (merge.rs main loop == qlora.rs:240-245).
+
+kani_harnesses:
+- id: KANI-MERGE-001
+  obligation: delta_weight_peft indexing is exact (no transpose)
+  property: |
+    For all (rank in [1..4], d_in in [1..4], d_out in [1..4]) and bounded f32 factors:
+    MergeEngine::merge(W, A:[rank,d_in], B:[d_out,rank], alpha, rank) yields
+    result[row*d_in+col] == W[row*d_in+col] + scale * sum_k B[row*rank+k]*A[k*d_in+col].
+  bound: 4
+  strategy: bounded_int
+  solver: cadical
+  harness: verify_merge_peft_indexing
+- id: KANI-MERGE-002
+  obligation: rank-1 legacy indexing is invariant under the fix
+  property: |
+    For rank=1 and all (d_in in [1..4], d_out in [1..4]): the PEFT indexing
+    lora_b[row*1+0]*lora_a[0*d_in+col] equals the legacy lora_b[0*d_out+row]*lora_a[col*1+0],
+    so the fix does not regress rank-1 callers.
+  bound: 4
+  strategy: bounded_int
+  solver: cadical
+  harness: verify_rank1_indexing_invariant
+
+qa_gate:
+  id: F-MERGE-PEFT-001
+  name: lora-merge-peft-layout-v1 Contract
+  description: MergeEngine::merge must fold ΔW=scale·(B@A) using the PEFT adapter layout A:[rank,d_in], B:[d_out,rank] that apr finetune writes, matching the QLoRALayer::merge_to_f32 twin and forward-equivalent to the unmerged factors.
+  checks:
+  - validation
+  - falsification

--- a/crates/aprender-train-lora/src/merge.rs
+++ b/crates/aprender-train-lora/src/merge.rs
@@ -32,8 +32,11 @@ impl MergeEngine {
     /// For each LoRA target module:
     /// W_merged = W_base + (scale * alpha / rank) * (B @ A)
     ///
-    /// A is [d_in, rank], B is [rank, d_out] (or transposed depending on convention).
-    /// The merge computes the outer product B×A and adds it to W_base.
+    /// Uses the STANDARD PEFT adapter layout produced by `apr finetune`
+    /// (`crates/apr-cli/src/commands/finetune.rs:842,845`):
+    /// `lora_a` is [rank, d_in] and `lora_b` is [d_out, rank], both row-major.
+    /// The merge computes ΔW = B @ A (shape [d_out, d_in]) and adds scale·ΔW to W_base.
+    /// This matches the in-repo correct twin `QLoRALayer::merge_to_f32`.
     pub fn merge(
         &self,
         base_weights: &[f32],
@@ -45,25 +48,24 @@ impl MergeEngine {
         let scale_factor = self.scale * alpha / rank as f32;
         let r = rank as usize;
 
-        // Infer matrix dimensions from flat arrays and rank
-        // A: [d_in, r] stored row-major → lora_a.len() = d_in * r
-        // B: [r, d_out] stored row-major → lora_b.len() = r * d_out
+        // Infer matrix dimensions from flat arrays and rank (PEFT layout).
+        // A: [r, d_in] stored row-major → lora_a.len() = r * d_in
+        // B: [d_out, r] stored row-major → lora_b.len() = d_out * r
         let d_in = lora_a.len() / r;
         let d_out = lora_b.len() / r;
 
-        // W_base is [d_out, d_in] stored row-major (standard weight layout)
-        // W_merged = W_base + scale * B^T @ A^T
-        // where B^T is [d_out, r] and A^T is [r, d_in]
+        // W_base is [d_out, d_in] stored row-major (standard weight layout).
+        // W_merged = W_base + scale * (B @ A)
+        // where B is [d_out, r] and A is [r, d_in]
         // Result: [d_out, d_in] — same shape as W_base
         let mut result = base_weights.to_vec();
 
         if d_out * d_in != base_weights.len() {
-            // Dimensions don't match — try transposed interpretation
-            // A: [r, d_in], B: [d_out, r]
+            // Defensive re-derivation of dims (same PEFT layout: A:[r,d_in], B:[d_out,r]).
             let d_in_alt = lora_a.len() / r;
             let d_out_alt = lora_b.len() / r;
             if d_out_alt * d_in_alt == base_weights.len() {
-                // B[d_out, r] @ A[r, d_in] = [d_out, d_in]
+                // ΔW = B[d_out, r] @ A[r, d_in] = [d_out, d_in]
                 for row in 0..d_out_alt {
                     for col in 0..d_in_alt {
                         let mut sum = 0.0f32;
@@ -87,19 +89,16 @@ impl MergeEngine {
             return result;
         }
 
-        // Standard: A[d_in, r], B[r, d_out]
-        // Compute B @ A = [r, d_out]^T @ [d_in, r]^T ...
-        // Actually: W += scale * (lora_b^T @ lora_a^T) where result is [d_out, d_in]
-        // lora_b as [r, d_out]: lora_b^T is [d_out, r]
-        // lora_a as [d_in, r]: lora_a^T is [r, d_in]
-        // [d_out, r] @ [r, d_in] = [d_out, d_in] ✓
+        // PEFT layout: A is [r, d_in], B is [d_out, r].
+        // ΔW = B @ A = [d_out, r] @ [r, d_in] = [d_out, d_in] ✓
+        // W_merged = W_base + scale · ΔW (same indexing as QLoRALayer::merge_to_f32).
         for row in 0..d_out {
             for col in 0..d_in {
                 let mut sum = 0.0f32;
                 for k in 0..r {
-                    // B^T[row, k] = B[k, row] = lora_b[k * d_out + row]
-                    // A^T[k, col] = A[col, k] = lora_a[col * r + k]
-                    sum += lora_b[k * d_out + row] * lora_a[col * r + k];
+                    // B[row, k] = lora_b[row * r + k]
+                    // A[k, col] = lora_a[k * d_in + col]
+                    sum += lora_b[row * r + k] * lora_a[k * d_in + col];
                 }
                 result[row * d_in + col] += scale_factor * sum;
             }
@@ -460,6 +459,43 @@ mod tests {
         assert!((merged[0] - 7.0).abs() < 0.01);
     }
 
+    /// PMAT-854 falsifier: `MergeEngine::merge` must honor the STANDARD PEFT
+    /// adapter layout produced by `apr finetune` — A:[rank,d_in], B:[d_out,rank]
+    /// (see `crates/apr-cli/src/commands/finetune.rs:842,845`). The merge must fold
+    /// `W += scale·(B@A)` using THAT indexing, matching the in-repo correct twin
+    /// `QLoRALayer::merge_to_f32` (`crates/aprender-train/src/lora/qlora.rs:240-245`).
+    ///
+    /// Repro (d_in=3, d_out=2, rank=2, alpha=2 → scale=alpha/rank=1, W=zeros):
+    ///   A = [[1,0,0],[0,2,0]]  ([rank,d_in])
+    ///   B = identity           ([d_out,rank])
+    ///   B@A = [[1,0,0],[0,2,0]]
+    /// Correct merge → [1,0,0, 0,2,0]. The pre-fix (transposed) code yielded
+    /// [1,0,2, 0,0,0] (max abs error 2.0) because it read BOTH factors transposed.
+    #[test]
+    fn merge_uses_peft_layout() {
+        // PEFT layout: A is [rank, d_in], B is [d_out, rank].
+        let a: Vec<f32> = vec![1.0, 0.0, 0.0, 0.0, 2.0, 0.0]; // [2,3] = [rank, d_in]
+        let b: Vec<f32> = vec![1.0, 0.0, 0.0, 1.0]; // [2,2] = [d_out, rank] identity
+        let w_base: Vec<f32> = vec![0.0; 6]; // [d_out=2, d_in=3]
+
+        // alpha=2, rank=2 → scale_factor = 1.0 * 2.0 / 2 = 1.0
+        let merged = MergeEngine::new().merge(&w_base, &a, &b, 2.0, 2);
+
+        // B@A = [[1,0,0],[0,2,0]] → W + 1.0*(B@A).
+        let expected = vec![1.0, 0.0, 0.0, 0.0, 2.0, 0.0];
+        let max_abs_diff = merged
+            .iter()
+            .zip(expected.iter())
+            .map(|(m, e)| (m - e).abs())
+            .fold(0.0_f32, f32::max);
+        assert!(
+            max_abs_diff < 1e-6,
+            "PMAT-854: MergeEngine::merge does NOT honor PEFT layout (A:[rank,d_in], \
+             B:[d_out,rank]). Got {merged:?}, expected {expected:?} (= W + scale·(B@A)). \
+             The pre-fix transposed code yields [1,0,2, 0,0,0]."
+        );
+    }
+
     /// BEAT-LORA-MERGE — Pillar-3 (Unsloth) correctness beat (PMAT-747).
     ///
     /// The other half of "replace Unsloth's QLoRA pipeline" (NF4 quant ≡ bitsandbytes
@@ -474,13 +510,14 @@ mod tests {
     /// `merge` would diverge. Self-contained (CPU, deterministic).
     #[test]
     fn beat_lora_merge_forward_equivalence() {
-        // dims chosen so d_out != d_in (unambiguous "standard" merge path).
+        // dims chosen so d_out != d_in (unambiguous merge path).
         let (d_in, d_out, r) = (4usize, 3usize, 2usize);
         let n = 2usize; // batch
 
-        // A: [d_in, r] row-major; B: [r, d_out] row-major; W_base: [d_out, d_in].
-        let a: Vec<f32> = vec![0.10, -0.20, 0.05, 0.30, -0.10, 0.25, 0.40, -0.15]; // 4x2
-        let b: Vec<f32> = vec![0.20, -0.30, 0.10, 0.15, 0.05, -0.25]; // 2x3
+        // PEFT layout (matches `apr finetune`): A:[rank,d_in] row-major (2x4),
+        // B:[d_out,rank] row-major (3x2); W_base:[d_out,d_in] (3x4).
+        let a: Vec<f32> = vec![0.10, -0.20, 0.05, 0.30, -0.10, 0.25, 0.40, -0.15]; // 2x4 [rank,d_in]
+        let b: Vec<f32> = vec![0.20, -0.30, 0.10, 0.15, 0.05, -0.25]; // 3x2 [d_out,rank]
         let w_base: Vec<f32> = (0..d_out * d_in).map(|i| (i as f32 - 6.0) * 0.07).collect(); // 3x4
         let x: Vec<f32> = vec![0.5, -0.2, 0.3, 0.1, -0.4, 0.6, 0.2, -0.1]; // 2x4
         let (alpha, rank) = (4.0_f32, r as u32);
@@ -501,8 +538,9 @@ mod tests {
             }
         }
 
-        // INDEPENDENT reference: base forward + scale·(x @ A @ B).
-        // (x@A)[i,k] = sum_col x[i,col]*A[col,k];  then (xa@B)[i,row] = sum_k xa[i,k]*B[k,row].
+        // INDEPENDENT reference: base forward + scale·(x @ A^T @ B^T) where ΔW = B@A.
+        // PEFT layout: A[k,col]=a[k*d_in+col]; B[row,k]=b[row*r+k].
+        // (x@A^T)[i,k] = sum_col x[i,col]*A[k,col]; then (..@B^T)[i,row] = sum_k xat[i,k]*B[row,k].
         let mut y_ref = vec![0.0f32; n * d_out];
         for i in 0..n {
             // base contribution
@@ -514,18 +552,18 @@ mod tests {
                 y_ref[i * d_out + row] = base;
             }
             // LoRA contribution via the factors (different computation path)
-            let mut xa = vec![0.0f32; r];
-            for (k, xa_k) in xa.iter_mut().enumerate() {
+            let mut xat = vec![0.0f32; r];
+            for (k, xat_k) in xat.iter_mut().enumerate() {
                 let mut s = 0.0;
                 for col in 0..d_in {
-                    s += x[i * d_in + col] * a[col * r + k]; // A[col,k]
+                    s += x[i * d_in + col] * a[k * d_in + col]; // A[k,col]
                 }
-                *xa_k = s;
+                *xat_k = s;
             }
             for row in 0..d_out {
                 let mut s = 0.0;
-                for (k, &xa_k) in xa.iter().enumerate() {
-                    s += xa_k * b[k * d_out + row]; // B[k,row]
+                for (k, &xat_k) in xat.iter().enumerate() {
+                    s += xat_k * b[row * r + k]; // B[row,k]
                 }
                 y_ref[i * d_out + row] += scale_factor * s;
             }


### PR DESCRIPTION
## Summary (HIGH — production `apr finetune merge` corruption)

`MergeEngine::merge` folded the LoRA delta assuming **transposed** layout (`A:[d_in,rank]`, `B:[rank,d_out]`), but `apr finetune` writes adapters in **standard PEFT layout** — `lora_a:[rank,d_in]`, `lora_b:[d_out,rank]` (`crates/apr-cli/src/commands/finetune.rs:842,845`). So every `apr finetune merge` folded a **scrambled delta** into the base weight.

The correct in-repo twin `QLoRALayer::merge_to_f32` already uses the right indexing — the two merge paths disagreed, and `MergeEngine` was wrong.

## Repro
d_in=3, d_out=2, rank=2, `A=[[1,0,0],[0,2,0]]` ([rank,d_in]), `B=identity` ([d_out,rank]), scale=1 → correct `B@A = [[1,0,0],[0,2,0]]`, but buggy code returned `[[1,0,2],[0,0,0]]` (max abs error 2.0).

## Fix
`sum += lora_b[k*d_out+row] * lora_a[col*r+k]` → `sum += lora_b[row*r+k] * lora_a[k*d_in+col]` (matching `QLoRALayer::merge_to_f32` + PEFT `tuners/lora/layer.py`).

## Verification
- Falsifier `merge_uses_peft_layout` — RED `[1,0,2,0,0,0]` → GREEN `[1,0,0,0,2,0]`.
- Corrected the bug-encoding `beat_lora_merge_forward_equivalence` test to PEFT layout (passes at max|Δ| ~1.5e-8).
- `cargo test -p aprender-train-lora --lib` → **55 passed / 0 failed**.
- `contracts/lora-merge-peft-layout-v1.yaml` — `pv validate` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)