### PR TITLE
fix(serve): HF byte-level BPE encode dropped every non-ASCII char — mojibake/data-loss (PMAT-855)

### DIFF
--- a/contracts/bpe-encode-bytes-to-unicode-v1.yaml
+++ b/contracts/bpe-encode-bytes-to-unicode-v1.yaml
@@ -1,0 +1,50 @@
+metadata:
+  version: "1.0.0"
+  created: "2026-06-19"
+  author: PAIML Engineering
+  registry: true
+  references:
+    - "HuggingFace GPT-2 bytes_to_unicode (the reference byte-level-BPE byte->char map)"
+    - "crates/aprender-serve/src/gguf/utils.rs::gpt2_byte_to_unicode (the in-crate encode map)"
+    - "crates/aprender-serve/src/gguf/utils.rs::gpt2_unicode_to_byte (the inverse / decode map)"
+    - "PMAT-837 decode twin: contracts/gpt2-bpe-decode-roundtrip-v1.yaml (the same map, decode direction)"
+  description: |
+    Correctness contract for GPT-2 byte-level BPE ENCODING in the serve HF tokenizer
+    (aprender-serve BpeTokenizer::encode -> bpe_encode -> byte_to_bpe_char). Pillar-4
+    (Ollama/serve) correctness: a non-ASCII prompt must reach the model intact, not be
+    silently dropped before inference.
+kind: KernelContract
+name: bpe-encode-bytes-to-unicode
+version: "1.0.0"
+scope: "crates/aprender-serve/src/apr/tokenizer.rs"
+description: |
+  GPT-2 byte-level BPE maps each of the 256 bytes to a printable unicode codepoint; ENCODE must
+  apply that map to every UTF-8 byte of the input so the resulting glyph tokens hit the vocab keys
+  the HuggingFace tokenizer.json was trained on. PMAT-855 fixed byte_to_bpe_char (and the
+  char-level caller char_to_bpe_tokens / bpe_encode_segment), which for bytes >= 0x80 returned the
+  SentencePiece/GGUF byte-fallback string "<0xNN>" (e.g. 0xC3 -> "<0xC3>"). Those strings never
+  exist in a GPT-2/Qwen byte-level vocab, so bpe_encode_segment's `vocab.get(t)` under filter_map
+  silently DROPPED every accented-Latin / CJK / emoji / smart-quote character before it reached the
+  model. The caller also (a) cast each multi-byte char to a single truncated u8 and (b) concatenated
+  a char's glyphs into one combined vocab key, missing the per-glyph entries. Fix: map each UTF-8
+  BYTE through gpt2_byte_to_unicode (the exact inverse of the PMAT-837 decode helper
+  gpt2_unicode_to_byte), emitting one glyph token per byte. The "<0xNN>" byte-fallback belongs ONLY
+  on the GGUF greedy path (BPETokenizer::encode), which is unchanged.
+equations:
+  C-GPT2BPE-ENC-001:
+    description: "The encode byte->char map is the exact inverse of the decode char->byte map for all 256 bytes"
+    formula: "∀ b in 0..=255: gpt2_unicode_to_byte(byte_to_bpe_char(b)) == Some(b); each glyph is exactly one char; e.g. 0xC3->'Ã', 0xA9->'©', 0x00->U+0100, 0x7F->U+0121, 0xAD->U+0143, 0xFF->'ÿ'"
+    note: "Printable ASCII 0x21-0x7E and Latin-1 0xA1-0xAC/0xAE-0xFF self-map; the rest ride the U+0100.. staircase."
+  C-GPT2BPE-ENC-002:
+    description: "A non-ASCII char is encoded to its per-byte glyph token ids, not silently dropped"
+    formula: "bpe_encode(\"é\", vocab{'Ã':10,'©':11}, [], {}) == [10, 11]; NOT [] (é = UTF-8 [0xC3,0xA9])"
+    note: "Each UTF-8 byte becomes its own bytes_to_unicode glyph token so the per-glyph vocab entries resolve."
+falsification:
+  - id: FALSIFY-TOKENIZER-GPT2-ENC-NONASCII
+    description: "GPT-2 byte-level encode keeps a non-ASCII char. Discharges C-GPT2BPE-ENC-002."
+    test: "falsify_bpe_encode_non_ascii_accented_latin — vocab {'Ã':10,'©':11}, encode 'é' (bytes 0xC3,0xA9): RED pre-fix [] (byte_to_bpe_char returned absent '<0xC3>'/'<0xA9>' -> filter_map drops both), GREEN post-fix [10,11]."
+    evidence: "cargo test -p aprender-serve --lib falsify_bpe_encode_non_ascii_accented_latin"
+  - id: FALSIFY-TOKENIZER-GPT2-ENC-ROUNDTRIP
+    description: "Encode byte->glyph inverts decode glyph->byte for every byte. Discharges C-GPT2BPE-ENC-001."
+    test: "falsify_byte_to_bpe_char_roundtrips_all_bytes / falsify_gpt2_byte_to_unicode_roundtrip_all_bytes — ∀ b in 0..=255: gpt2_unicode_to_byte(byte_to_bpe_char(b)) == Some(b): RED pre-fix (bytes >=0x80 returned multi-char '<0xNN>'), GREEN post-fix all 256 round-trip."
+    evidence: "cargo test -p aprender-serve --lib falsify_byte_to_bpe_char_roundtrips_all_bytes"

--- a/crates/aprender-serve/src/apr/tests_apr.rs
+++ b/crates/aprender-serve/src/apr/tests_apr.rs
@@ -306,9 +306,10 @@
 
     #[test]
     fn test_byte_to_bpe_char_null_more_cov() {
+        // PMAT-855: NUL maps to U+0100 under GPT-2 bytes_to_unicode (HF merge path),
+        // not the SentencePiece/GGUF `<0xNN>` byte-fallback form.
         let result = crate::apr::byte_to_bpe_char(0x00);
-        assert!(!result.is_empty());
-        assert!(result.starts_with("<0x"));
+        assert_eq!(result, "\u{0100}");
     }
 
     #[test]

--- a/crates/aprender-serve/src/apr/tests_dtype_and_tokenizer.rs
+++ b/crates/aprender-serve/src/apr/tests_dtype_and_tokenizer.rs
@@ -424,16 +424,19 @@
 
     #[test]
     fn test_byte_to_bpe_char_non_printable() {
-        // Non-printable control character
+        // PMAT-855: the HF merge path uses GPT-2 bytes_to_unicode, NOT the
+        // SentencePiece/GGUF `<0xNN>` byte-fallback. Control byte 0x01 maps to
+        // U+0101 on the staircase and round-trips back to 0x01.
         let result = byte_to_bpe_char(0x01);
-        assert!(result.starts_with("<0x"));
-        assert!(result.ends_with('>'));
+        assert_eq!(result, "\u{0101}");
+        assert_eq!(result.chars().count(), 1);
     }
 
     #[test]
     fn test_byte_to_bpe_char_high_byte() {
+        // PMAT-855: 0xFF self-maps under bytes_to_unicode (Latin-1), not "<0xFF>".
         let result = byte_to_bpe_char(0xFF);
-        assert_eq!(result, "<0xFF>");
+        assert_eq!(result, "ÿ");
     }
 
     // =========================================================================

--- a/crates/aprender-serve/src/apr/tokenizer.rs
+++ b/crates/aprender-serve/src/apr/tokenizer.rs
@@ -206,21 +206,22 @@ fn split_by_special_tokens(text: &str, special_tokens: &HashMap<String, u32>) ->
     segments
 }
 
-/// Convert a character to its byte-level BPE token representation (GPT-2/Qwen style)
-fn char_to_bpe_token(c: char) -> String {
-    match c {
-        ' ' => "Ġ".to_string(),
-        '\n' => "Ċ".to_string(),
-        '\t' => "ĉ".to_string(),
-        c if c.is_ascii() => c.to_string(),
-        c => {
-            let mut buf = [0u8; 4];
-            let s = c.encode_utf8(&mut buf);
-            s.chars()
-                .map(|byte_char| byte_to_bpe_char(byte_char as u8))
-                .collect()
-        },
-    }
+/// Convert a character to its byte-level BPE token glyphs (GPT-2/Qwen style).
+///
+/// PMAT-855: maps EACH of the char's UTF-8 bytes through `byte_to_bpe_char` (the canonical
+/// `bytes_to_unicode` map), returning ONE glyph token PER BYTE. The prior body short-circuited
+/// every ASCII char to `c.to_string()` — correct only for printable ASCII — and, worse, for
+/// non-ASCII chars iterated `s.chars()` (the original single char) and cast it to `u8`, truncating
+/// a multi-byte codepoint to one wrong byte instead of mapping its real UTF-8 bytes. It also
+/// returned a SINGLE concatenated string per char, so the combined key (e.g. `Ã©` for `é`) missed
+/// the per-glyph vocab entries `Ã`/`©`. Emitting one token per byte makes `é` (0xC3,0xA9) → `[Ã, ©]`
+/// and `中` (0xE4,0xB8,0xAD) → `[ä, ¸, Ń]`, matching the HF vocab glyphs and letting merges run.
+fn char_to_bpe_tokens(c: char) -> Vec<String> {
+    let mut buf = [0u8; 4];
+    c.encode_utf8(&mut buf)
+        .bytes()
+        .map(byte_to_bpe_char)
+        .collect()
 }
 
 /// Apply a single BPE merge rule to the token list, returning true if any merge was applied
@@ -244,7 +245,11 @@ fn bpe_encode_segment(
     vocab: &HashMap<String, u32>,
     merges: &[(String, String)],
 ) -> Vec<u32> {
-    let mut tokens: Vec<String> = text.chars().map(char_to_bpe_token).collect();
+    // PMAT-855: byte-level BPE — each UTF-8 BYTE becomes its own initial token
+    // (one `bytes_to_unicode` glyph), so merges and `vocab.get` resolve per-glyph.
+    // A multi-byte char (é, 中, …) must NOT collapse into a single concatenated
+    // string, or the combined key (e.g. "Ã©") misses the per-glyph vocab entries.
+    let mut tokens: Vec<String> = text.chars().flat_map(char_to_bpe_tokens).collect();
 
     // Apply BPE merges iteratively
     for (first, second) in merges {
@@ -259,17 +264,18 @@ fn bpe_encode_segment(
         .collect()
 }
 
-/// Convert byte to BPE character representation
+/// Convert a raw byte to its GPT-2/Qwen byte-level BPE character.
+///
+/// PMAT-855: the HuggingFace merge path (`BpeTokenizer::encode`) loads a vocab keyed on the
+/// GPT-2 `bytes_to_unicode` glyphs (0xC3 → 'Ã', 0xA9 → '©', space → 'Ġ', '\n' → 'Ċ'), so EVERY
+/// byte must map to its canonical glyph — the exact inverse of `gpt2_unicode_to_byte` (the
+/// PMAT-837 decode helper). The prior body returned the SentencePiece/GGUF byte-fallback form
+/// `<0xNN>` for bytes >= 0x80; those strings never exist in a GPT-2/Qwen vocab, so every accented
+/// /CJK/emoji/smart-quote char was silently dropped by the `vocab.get` filter in
+/// `bpe_encode_segment`, vanishing from the prompt before it reached the model. The `<0xNN>` form
+/// belongs ONLY on the GGUF greedy byte-fallback path (`BPETokenizer::encode`), not here.
 pub fn byte_to_bpe_char(b: u8) -> String {
-    // GPT-2/Qwen byte-level BPE uses specific unicode mappings
-    // This is a simplified version - real tokenizers use a full byte-to-unicode table
-    match b {
-        b' ' => "Ġ".to_string(),
-        b'\n' => "Ċ".to_string(),
-        b'\t' => "ĉ".to_string(),
-        _ if b.is_ascii_graphic() || b.is_ascii_alphanumeric() => (b as char).to_string(),
-        _ => format!("<0x{:02X}>", b),
-    }
+    crate::gguf::utils::gpt2_byte_to_unicode(b).to_string()
 }
 
 include!("tokenizer_tests.rs");

--- a/crates/aprender-serve/src/apr/tokenizer_tests.rs
+++ b/crates/aprender-serve/src/apr/tokenizer_tests.rs
@@ -208,10 +208,71 @@ mod tests {
 
     #[test]
     fn test_byte_to_bpe_char_non_printable() {
-        // Non-printable bytes get hex encoding
-        assert_eq!(byte_to_bpe_char(0x00), "<0x00>");
-        assert_eq!(byte_to_bpe_char(0x7F), "<0x7F>");
-        assert_eq!(byte_to_bpe_char(0xFF), "<0xFF>");
+        // PMAT-855: the HF merge path uses GPT-2 bytes_to_unicode, NOT the
+        // SentencePiece/GGUF `<0xNN>` byte-fallback form. Non-printable bytes map
+        // onto the U+0100.. staircase; high Latin-1 bytes self-map.
+        assert_eq!(byte_to_bpe_char(0x00), "\u{0100}"); // NUL -> Ā
+        assert_eq!(byte_to_bpe_char(0x7F), "\u{0121}"); // DEL -> ġ
+        assert_eq!(byte_to_bpe_char(0xFF), "ÿ"); // 0xFF self-maps (Latin-1)
+        assert_eq!(byte_to_bpe_char(0xAD), "\u{0143}"); // soft hyphen -> ŃŃ remap
+        assert_eq!(byte_to_bpe_char(0xC3), "Ã"); // first byte of 'é'
+        assert_eq!(byte_to_bpe_char(0xA9), "©"); // second byte of 'é'
+    }
+
+    // -------------------------------------------------------------------------
+    // PMAT-855: HF byte-level BPE encode maps UTF-8 bytes via bytes_to_unicode,
+    // not the GGUF `<0xNN>` byte-fallback. The ENCODE twin of the PMAT-837 decode
+    // fix. Falsifier: a non-ASCII char must NOT vanish from the prompt.
+    // -------------------------------------------------------------------------
+
+    /// PMAT-855 falsifier: 'é' (UTF-8 0xC3 0xA9) must encode to the vocab ids for
+    /// its bytes_to_unicode glyphs "Ã" + "©", NOT silently drop to [].
+    /// RED pre-fix: byte_to_bpe_char returned "<0xC3>"/"<0xA9>" (absent from vocab)
+    /// → filter_map drops both → []. GREEN post-fix: [10, 11].
+    #[test]
+    fn falsify_bpe_encode_non_ascii_accented_latin() {
+        let mut vocab = HashMap::new();
+        vocab.insert("Ã".to_string(), 10);
+        vocab.insert("©".to_string(), 11);
+        let special: HashMap<String, u32> = HashMap::new();
+
+        let result = bpe_encode("é", &vocab, &[], &special);
+        assert_eq!(
+            result,
+            vec![10, 11],
+            "non-ASCII 'é' must map to its bytes_to_unicode glyph ids, not vanish"
+        );
+    }
+
+    /// PMAT-855: a CJK char ('中' = UTF-8 0xE4 0xB8 0xAD) maps to its three
+    /// byte-level glyphs "ä" + "¸" + "Ń" (0xAD remaps to U+0143).
+    #[test]
+    fn test_bpe_encode_cjk_byte_level() {
+        let mut vocab = HashMap::new();
+        vocab.insert("ä".to_string(), 1); // 0xE4 self-maps
+        vocab.insert("¸".to_string(), 2); // 0xB8 self-maps
+        vocab.insert("\u{0143}".to_string(), 3); // 0xAD -> U+0143
+        let special: HashMap<String, u32> = HashMap::new();
+
+        let result = bpe_encode("中", &vocab, &[], &special);
+        assert_eq!(result, vec![1, 2, 3]);
+    }
+
+    /// PMAT-855: every byte 0..=255 round-trips byte -> glyph -> byte through the
+    /// HF map, proving byte_to_bpe_char is the exact inverse of the decode path.
+    #[test]
+    fn falsify_byte_to_bpe_char_roundtrips_all_bytes() {
+        for b in 0u8..=255 {
+            let glyph = byte_to_bpe_char(b);
+            let chars: Vec<char> = glyph.chars().collect();
+            assert_eq!(chars.len(), 1, "byte 0x{b:02X} must map to a single glyph");
+            assert_eq!(
+                crate::gguf::utils::gpt2_unicode_to_byte(chars[0]),
+                Some(b),
+                "byte 0x{b:02X} -> '{}' did not invert back",
+                chars[0]
+            );
+        }
     }
 
     // -------------------------------------------------------------------------

--- a/crates/aprender-serve/src/gguf/utils.rs
+++ b/crates/aprender-serve/src/gguf/utils.rs
@@ -54,6 +54,33 @@ pub(crate) fn gpt2_unicode_to_byte(c: char) -> Option<u8> {
     }
 }
 
+/// Convert a raw byte to its GPT-2 style byte-level BPE unicode character.
+///
+/// This is the EXACT inverse of [`gpt2_unicode_to_byte`] (HuggingFace/GPT-2
+/// `bytes_to_unicode`). PMAT-855 uses it on the ENCODE direction so the serve
+/// HF tokenizer emits the same byte-level glyphs the vocab/merges were trained
+/// on, instead of the SentencePiece/GGUF `<0xNN>` byte-fallback form (which
+/// never exists in a GPT-2/Qwen vocab and was silently dropped).
+///
+/// Mapping (the GPT-2 staircase, inverse of `gpt2_unicode_to_byte`):
+/// - Printable ASCII `0x21-0x7E` and Latin-1 `0xA1-0xAC`, `0xAE-0xFF` map to `char(b)`.
+/// - The remaining bytes `0x00-0x20`, `0x7F-0xA0`, `0xAD` map to `U+0100 + n`,
+///   where `n` is the byte's position in the ordered set of "other" bytes:
+///   `0x00-0x20` → n=0..32, `0x7F` → n=33, `0x80-0xA0` → n=34..66, `0xAD` → n=67.
+#[inline]
+pub(crate) fn gpt2_byte_to_unicode(b: u8) -> char {
+    let cp: u32 = match b {
+        // Directly-mapped printable ranges: char == byte.
+        0x21..=0x7E | 0xA1..=0xAC | 0xAE..=0xFF => u32::from(b),
+        // "Other" bytes are remapped onto the U+0100.. staircase, in order.
+        0x00..=0x20 => 0x0100 + u32::from(b), // n = 0..32
+        0x7F => 0x0121,                       // n = 33 (DEL)
+        0x80..=0xA0 => 0x0100 + 34 + u32::from(b - 0x80), // n = 34..66
+        0xAD => 0x0143,                       // n = 67 (soft hyphen)
+    };
+    char::from_u32(cp).unwrap_or('\u{FFFD}')
+}
+
 /// Decode a GPT-2 style byte-level BPE token to raw bytes.
 ///
 /// Each character in the token may represent either a direct byte (printable ASCII/Latin-1)
@@ -207,6 +234,46 @@ mod tests {
         let first = verbose();
         let second = verbose();
         assert_eq!(first, second);
+    }
+
+    // =========================================================================
+    // PMAT-855: gpt2_byte_to_unicode is the exact inverse of gpt2_unicode_to_byte
+    // =========================================================================
+
+    /// PMAT-855 falsifier (round-trip): the ENCODE map must be the exact inverse
+    /// of the DECODE map for every byte 0..=255. Discharges C-GPT2BPE-ENC-001.
+    #[test]
+    fn falsify_gpt2_byte_to_unicode_roundtrip_all_bytes() {
+        for b in 0u8..=255 {
+            let c = gpt2_byte_to_unicode(b);
+            assert_eq!(
+                gpt2_unicode_to_byte(c),
+                Some(b),
+                "byte 0x{:02X} -> '{}' (U+{:04X}) did not invert back to itself",
+                b,
+                c,
+                c as u32,
+            );
+        }
+    }
+
+    #[test]
+    fn test_gpt2_byte_to_unicode_known_points() {
+        // Latin-1 self-mapped: 'é' = UTF-8 [0xC3, 0xA9] -> 'Ã' + '©'
+        assert_eq!(gpt2_byte_to_unicode(0xC3), 'Ã');
+        assert_eq!(gpt2_byte_to_unicode(0xA9), '©');
+        // Printable ASCII self-maps
+        assert_eq!(gpt2_byte_to_unicode(b'A'), 'A');
+        assert_eq!(gpt2_byte_to_unicode(b'!'), '!');
+        // Staircase boundaries
+        assert_eq!(gpt2_byte_to_unicode(0x00), '\u{0100}'); // NUL
+        assert_eq!(gpt2_byte_to_unicode(b' '), '\u{0120}'); // Space -> Ġ
+        assert_eq!(gpt2_byte_to_unicode(b'\n'), '\u{010A}'); // Newline -> Ċ
+        assert_eq!(gpt2_byte_to_unicode(b'\t'), '\u{0109}'); // Tab -> ĉ
+        assert_eq!(gpt2_byte_to_unicode(0x7F), '\u{0121}'); // DEL
+        assert_eq!(gpt2_byte_to_unicode(0x80), '\u{0122}'); // 0x80
+        assert_eq!(gpt2_byte_to_unicode(0xA0), '\u{0142}'); // 0xA0
+        assert_eq!(gpt2_byte_to_unicode(0xAD), '\u{0143}'); // soft hyphen
     }
 
     // =========================================================================


### PR DESCRIPTION
## Summary (HIGH — the ENCODE twin of PMAT-837's decode fix)

The HF-tokenizer encode path (`BpeTokenizer::encode` → `bpe_encode` → `char_to_bpe_token`/`byte_to_bpe_char`) mapped every byte ≥ 0x80 to the SentencePiece/GGUF byte-fallback string `<0xNN>` instead of the GPT-2/Qwen `bytes_to_unicode` glyph. Since `bpe_encode_segment` resolves via `vocab.get(t)` under `filter_map`, every **accented-Latin / CJK / emoji / smart-quote char was silently dropped** before reaching the model.

Two co-located defects also fixed: `char_to_bpe_token` truncated each multi-byte char to a `u8` (iterating `.chars()` not bytes), and concatenated a char's glyphs into one vocab key.

## Repro
`bpe_encode("é", vocab{'Ã':10,'©':11}, …)` → `[]` (should be `[10,11]`; 'é' = UTF-8 `[0xC3,0xA9]`).

## Fix
Added `gpt2_byte_to_unicode` to `gguf/utils.rs` as the exact inverse of the PMAT-837 decode helper `gpt2_unicode_to_byte` (one shared source of truth); `byte_to_bpe_char` delegates to it and each UTF-8 byte maps to one glyph token. The GGUF byte-fallback path (`BPETokenizer::encode`) is untouched.

## Verification
- Falsifier `falsify_bpe_encode_non_ascii_accented_latin` — RED `[]` → GREEN `[10,11]`; CJK `[1,2,3]`; round-trip over all 256 bytes.
- 4 sibling tests that asserted the `<0xNN>` HF-path output corrected.
- `cargo test -p aprender-serve --lib` → **15433 passed / 0 failed**.
- `contracts/bpe-encode-bytes-to-unicode-v1.yaml` — `pv validate` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)