### PR TITLE
fix(tree): feature_importances used raw sample counts, not impurity decrease (MDI) — wrong vs sklearn (PMAT-851)

### DIFF
--- a/contracts/tree-feature-importances-mdi-v1.yaml
+++ b/contracts/tree-feature-importances-mdi-v1.yaml
@@ -1,0 +1,139 @@
+metadata:
+  version: "1.0.0"
+  created: "2026-06-19"
+  author: PAIML Engineering
+  registry: true
+  references:
+    - "Breiman, L. et al. (1984) 'Classification and Regression Trees' (CART), §4.5 variable importance"
+    - "scikit-learn tree/_tree.pyx::compute_feature_importances — https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/tree/_tree.pyx"
+    - "sklearn.ensemble.RandomForestRegressor.feature_importances_ / RandomForestClassifier.feature_importances_ (impurity-based / MDI)"
+  description: |
+    Decision-tree feature-importance contract (PMAT-851). Pins aprender's
+    per-tree feature importance to the scikit-learn Mean Decrease in Impurity
+    (MDI) formula so that RandomForestRegressor::feature_importances() and
+    RandomForestClassifier::feature_importances() rank features by how much each
+    split REDUCES impurity, identically to sklearn — not by the raw sample count
+    reaching each split node.
+
+kind: KernelContract
+name: tree-feature-importances-mdi
+version: "1.0.0"
+scope: "crates/aprender-core/src/tree/regression_helpers.rs"
+
+description: |
+  Mean Decrease in Impurity (MDI) feature importance for CART decision trees and
+  the random-forest ensembles built on them.
+
+  For every internal (split) node N that splits on feature f, the importance
+  contribution is the WEIGHTED IMPURITY DECREASE:
+
+      importance[f] += n_N * impurity(N)
+                     - n_L * impurity(L)
+                     - n_R * impurity(R)
+
+  where:
+    - n_N, n_L, n_R are the sample counts reaching node N and its left/right
+      children L, R (n_N = n_L + n_R),
+    - impurity(.) is gini for classification and variance for regression,
+      computed over the samples reaching that node at FIT time.
+
+  Per-tree contributions are summed over all split nodes, averaged across the
+  forest's trees, and normalized to sum 1 (the existing consumer behaviour).
+  This is exactly scikit-learn's tree/_tree.pyx::compute_feature_importances.
+
+  A prior defect (PMAT-851) accumulated only the raw sample count reaching each
+  split node:
+
+      importance[f] += n_N        # WRONG — drops the impurity-decrease factor
+
+  The Node / RegressionNode structs stored no impurity, so the decrease could not
+  be computed. This ranks features purely by where splits happen by sample
+  volume, disagreeing with sklearn whenever a split over FEWER samples removes
+  MORE impurity than a split over more samples. The fix adds per-node `impurity`
+  and `n_node_samples` (stamped at fit time, before the split, on both internal
+  nodes and leaves) and rewrites the two traversal helpers to the MDI formula.
+
+equations:
+  C-MDI-001:
+    description: "Per-split weighted impurity decrease (sklearn MDI)"
+    formula: "imp[f] += n_N*impurity(N) - n_L*impurity(L) - n_R*impurity(R)"
+    note: |
+      impurity = gini (classification) or variance (regression), measured on the
+      samples reaching the node at fit time. Accumulated over all split nodes.
+
+  C-MDI-002:
+    description: "Leaves contribute no importance (no split is made there)"
+    formula: "isLeaf(N) ⟹ Δimp = 0"
+    note: |
+      A leaf makes no split, so it has no impurity-decrease term. Its stored
+      impurity is still used by its PARENT split as impurity(L) or impurity(R).
+
+  C-MDI-003:
+    description: "Variance-decrease ranking beats raw-count ranking (the bug)"
+    formula: "feature that drives the larger impurity decrease ranks higher, even with fewer samples"
+    note: |
+      Reference regression tree: root splits feature 0 over 20 samples (root
+      variance small); right child splits feature 1 over 10 samples separating
+      0.0 vs 100.0 (variance 2500 -> 0). MDI: imp[0] = 20*var_root - 10*var_right,
+      imp[1] = 10*var_right, so imp[1] > imp[0]. The buggy count-only code yields
+      imp = [20.0, 10.0] -> feature 0 ranked higher (WRONG).
+
+proof_obligations:
+- type: precondition
+  property: "Split nodes carry the sample count and impurity of the samples reaching them"
+  formal: "isNode(N) ⟹ N.n_node_samples = n_L + n_R ∧ isFinite(N.impurity) ∧ N.impurity >= 0"
+- type: postcondition
+  property: "Each split's contribution is its weighted impurity decrease"
+  formal: "Δimp[f] = n_N*impurity(N) - n_L*impurity(L) - n_R*impurity(R)"
+  requires: MDI-PRE-001
+- type: bound
+  property: "A split's impurity decrease is non-negative under a greedy impurity criterion"
+  formal: "n_N*impurity(N) - n_L*impurity(L) - n_R*impurity(R) >= 0"
+  applies_to: all
+- type: invariant
+  property: "Leaf nodes add nothing to any feature's importance"
+  formal: "isLeaf(N) ⟹ ∀f: Δimp[f] = 0"
+  applies_to: all
+- type: equivalence
+  property: "Variance-decrease ranking outranks the high-count low-decrease feature"
+  formal: "imp[1] > imp[0] for the PMAT-851 reference regression tree"
+  tolerance: 0.1
+
+falsification:
+  - id: FALSIFY-MDI-001
+    description: |
+      compute_regression_tree_feature_importances on the PMAT-851 reference tree
+      (root split feature 0 over 20 samples; right child split feature 1 over 10
+      samples separating variance 2500 -> 0) must rank feature 1 above feature 0
+      and match the weighted-variance-decrease formula. Discharges C-MDI-001/003.
+    test: "test_regression_mdi_outranks_by_variance_decrease_not_count"
+    evidence: |
+      cargo test -p aprender-core --lib test_regression_mdi_outranks_by_variance_decrease_not_count
+      RED  (count-only: imp[f] += count_regression_tree_samples(node)): importances
+           = [20.0, 10.0] → assertion "MDI must rank feature 1 > feature 0" FAILS
+           (20.0 vs 10.0 → feature 0 wins by raw count).
+      GREEN (MDI: imp[f] += n_N*var(N) - n_L*var(L) - n_R*var(R)): imp[1] (= 10*2500
+           = 25000) > imp[0] (= 20*var_root - 10*2500) → all assertions pass.
+  - id: FALSIFY-MDI-002
+    description: |
+      compute_tree_feature_importances (classification, gini) attributes the
+      weighted gini decrease per split, not the subtree sample count. A root
+      split over 12 samples (gini 0.5) whose right child splits 6 samples
+      (gini 0.5 -> pure) must give feature 0 = 3.0 and feature 1 = 3.0, NOT
+      feature 0 = 12 and feature 1 = 6. Discharges C-MDI-001/002.
+    test: "test_classification_mdi_uses_gini_decrease_not_count"
+    evidence: |
+      cargo test -p aprender-core --lib test_classification_mdi_uses_gini_decrease_not_count
+      RED  (count-only): importances = [12.0, 6.0] → assertion (imp[0] == 3.0) FAILS.
+      GREEN (MDI): feature 0 = 12*0.5 - 6*0.0 - 6*0.5 = 3.0, feature 1 = 6*0.5 = 3.0 → pass.
+  - id: FALSIFY-MDI-003
+    description: |
+      End-to-end: a FITTED RandomForestRegressor on PMAT-851-shaped data stamps
+      per-node impurity at fit time so feature_importances() (averaged +
+      normalized) ranks the high-variance-decrease feature 1 above feature 0 and
+      sums to 1. Discharges the fit-time precondition (MDI-PRE-001) and C-MDI-003.
+    test: "test_fitted_regressor_feature_importances_mdi_ranking"
+    evidence: |
+      cargo test -p aprender-core --lib test_fitted_regressor_feature_importances_mdi_ranking
+      GREEN: importances[1] > importances[0] and sum(importances) ≈ 1.0.
+      (Under the count-only bug this fitted-path ranking flips to feature 0.)

--- a/crates/aprender-core/src/tree/helpers.rs
+++ b/crates/aprender-core/src/tree/helpers.rs
@@ -85,10 +85,14 @@ pub(super) fn reconstruct_tree_node(
     right_children: &[f32],
 ) -> TreeNode {
     if features[idx] < 0.0 {
-        // Leaf node
+        // Leaf node. The flat SafeTensors schema does not persist per-node
+        // impurity / n_node_samples, so they default to 0 on reconstruct. These
+        // fields only feed MDI feature-importance, which is computed on the live
+        // fitted tree, not a deserialized one.
         TreeNode::Leaf(Leaf {
             class_label: classes[idx] as usize,
             n_samples: samples[idx] as usize,
+            impurity: 0.0,
         })
     } else {
         // Internal node
@@ -98,6 +102,8 @@ pub(super) fn reconstruct_tree_node(
         TreeNode::Node(Node {
             feature_idx: features[idx] as usize,
             threshold: thresholds[idx],
+            impurity: 0.0,
+            n_node_samples: 0,
             left: Box::new(reconstruct_tree_node(
                 left_idx,
                 features,
@@ -361,6 +367,7 @@ pub(super) fn check_stopping_criteria(
         return Some(TreeNode::Leaf(Leaf {
             class_label: y[0],
             n_samples,
+            impurity: gini_impurity(y),
         }));
     }
 
@@ -370,6 +377,7 @@ pub(super) fn check_stopping_criteria(
             return Some(TreeNode::Leaf(Leaf {
                 class_label: majority_class(y),
                 n_samples,
+                impurity: gini_impurity(y),
             }));
         }
     }
@@ -413,6 +421,10 @@ pub(super) fn build_tree(
 ) -> TreeNode {
     let n_samples = y.len();
 
+    // Impurity (gini) of the samples reaching this node, computed BEFORE the
+    // split. Drives MDI feature-importance (tree-feature-importances-mdi-v1).
+    let node_impurity = gini_impurity(y);
+
     // Check stopping criteria
     if let Some(leaf) = check_stopping_criteria(y, depth, max_depth) {
         return leaf;
@@ -423,6 +435,7 @@ pub(super) fn build_tree(
         return TreeNode::Leaf(Leaf {
             class_label: majority_class(y),
             n_samples,
+            impurity: node_impurity,
         });
     };
 
@@ -433,6 +446,7 @@ pub(super) fn build_tree(
         return TreeNode::Leaf(Leaf {
             class_label: majority_class(y),
             n_samples,
+            impurity: node_impurity,
         });
     };
 
@@ -447,6 +461,8 @@ pub(super) fn build_tree(
     TreeNode::Node(Node {
         feature_idx,
         threshold,
+        impurity: node_impurity,
+        n_node_samples: n_samples,
         left: Box::new(left_child),
         right: Box::new(right_child),
     })

--- a/crates/aprender-core/src/tree/helpers_tests_flatten.rs
+++ b/crates/aprender-core/src/tree/helpers_tests_flatten.rs
@@ -4,13 +4,17 @@
         let tree = TreeNode::Node(Node {
             feature_idx: 0,
             threshold: 2.5,
+            impurity: 0.0,
+            n_node_samples: 0,
             left: Box::new(TreeNode::Leaf(Leaf {
                 class_label: 0,
                 n_samples: 3,
+                impurity: 0.0,
             })),
             right: Box::new(TreeNode::Leaf(Leaf {
                 class_label: 1,
                 n_samples: 2,
+                impurity: 0.0,
             })),
         });
 

--- a/crates/aprender-core/src/tree/helpers_tests_gini.rs
+++ b/crates/aprender-core/src/tree/helpers_tests_gini.rs
@@ -346,6 +346,7 @@
         let leaf = TreeNode::Leaf(Leaf {
             class_label: 2,
             n_samples: 10,
+            impurity: 0.0,
         });
 
         let mut features = Vec::new();

--- a/crates/aprender-core/src/tree/helpers_tests_regression_and_importance.rs
+++ b/crates/aprender-core/src/tree/helpers_tests_regression_and_importance.rs
@@ -36,6 +36,7 @@
         let leaf = TreeNode::Leaf(Leaf {
             class_label: 0,
             n_samples: 42,
+            impurity: 0.0,
         });
         assert_eq!(count_tree_samples(&leaf), 42);
     }
@@ -45,13 +46,17 @@
         let tree = TreeNode::Node(Node {
             feature_idx: 0,
             threshold: 1.0,
+            impurity: 0.0,
+            n_node_samples: 0,
             left: Box::new(TreeNode::Leaf(Leaf {
                 class_label: 0,
                 n_samples: 10,
+                impurity: 0.0,
             })),
             right: Box::new(TreeNode::Leaf(Leaf {
                 class_label: 1,
                 n_samples: 20,
+                impurity: 0.0,
             })),
         });
         assert_eq!(count_tree_samples(&tree), 30);
@@ -62,6 +67,7 @@
         let leaf = TreeNode::Leaf(Leaf {
             class_label: 0,
             n_samples: 10,
+            impurity: 0.0,
         });
         let mut importances = vec![0.0; 3];
         compute_tree_feature_importances(&leaf, &mut importances);
@@ -70,23 +76,28 @@
 
     #[test]
     fn test_compute_tree_feature_importances_single_split() {
+        // MDI: feature 1 split over 8 samples, root gini 0.5, pure children.
+        // importance = 8*0.5 - 5*0.0 - 3*0.0 = 4.0
         let tree = TreeNode::Node(Node {
             feature_idx: 1,
             threshold: 2.0,
+            impurity: 0.5,
+            n_node_samples: 8,
             left: Box::new(TreeNode::Leaf(Leaf {
                 class_label: 0,
                 n_samples: 5,
+                impurity: 0.0,
             })),
             right: Box::new(TreeNode::Leaf(Leaf {
                 class_label: 1,
                 n_samples: 3,
+                impurity: 0.0,
             })),
         });
         let mut importances = vec![0.0; 3];
         compute_tree_feature_importances(&tree, &mut importances);
-        // Feature 1 used at root with 8 total samples
         assert!((importances[0] - 0.0).abs() < 1e-7);
-        assert!((importances[1] - 8.0).abs() < 1e-7);
+        assert!((importances[1] - 4.0).abs() < 1e-7);
         assert!((importances[2] - 0.0).abs() < 1e-7);
     }
 
@@ -99,6 +110,7 @@
         let leaf = RegressionTreeNode::Leaf(RegressionLeaf {
             value: 3.5,
             n_samples: 15,
+            impurity: 0.0,
         });
         assert_eq!(count_regression_tree_samples(&leaf), 15);
     }
@@ -108,13 +120,17 @@
         let tree = RegressionTreeNode::Node(RegressionNode {
             feature_idx: 0,
             threshold: 1.0,
+            impurity: 0.0,
+            n_node_samples: 0,
             left: Box::new(RegressionTreeNode::Leaf(RegressionLeaf {
                 value: 1.0,
                 n_samples: 7,
+                impurity: 0.0,
             })),
             right: Box::new(RegressionTreeNode::Leaf(RegressionLeaf {
                 value: 5.0,
                 n_samples: 13,
+                impurity: 0.0,
             })),
         });
         assert_eq!(count_regression_tree_samples(&tree), 20);
@@ -122,21 +138,27 @@
 
     #[test]
     fn test_compute_regression_tree_feature_importances() {
+        // MDI: feature 2 split over 10 samples, root variance 2.0, pure leaves.
+        // importance = 10*2.0 - 4*0.0 - 6*0.0 = 20.0
         let tree = RegressionTreeNode::Node(RegressionNode {
             feature_idx: 2,
             threshold: 3.0,
+            impurity: 2.0,
+            n_node_samples: 10,
             left: Box::new(RegressionTreeNode::Leaf(RegressionLeaf {
                 value: 1.0,
                 n_samples: 4,
+                impurity: 0.0,
             })),
             right: Box::new(RegressionTreeNode::Leaf(RegressionLeaf {
                 value: 9.0,
                 n_samples: 6,
+                impurity: 0.0,
             })),
         });
         let mut importances = vec![0.0; 4];
         compute_regression_tree_feature_importances(&tree, &mut importances);
-        assert!((importances[2] - 10.0).abs() < 1e-7);
+        assert!((importances[2] - 20.0).abs() < 1e-7);
         assert!((importances[0] - 0.0).abs() < 1e-7);
         assert!((importances[1] - 0.0).abs() < 1e-7);
         assert!((importances[3] - 0.0).abs() < 1e-7);
@@ -218,21 +240,28 @@
         let tree = TreeNode::Node(Node {
             feature_idx: 0,
             threshold: 5.0,
+            impurity: 0.0,
+            n_node_samples: 0,
             left: Box::new(TreeNode::Node(Node {
                 feature_idx: 1,
                 threshold: 2.0,
+                impurity: 0.0,
+                n_node_samples: 0,
                 left: Box::new(TreeNode::Leaf(Leaf {
                     class_label: 0,
                     n_samples: 2,
+                    impurity: 0.0,
                 })),
                 right: Box::new(TreeNode::Leaf(Leaf {
                     class_label: 1,
                     n_samples: 3,
+                    impurity: 0.0,
                 })),
             })),
             right: Box::new(TreeNode::Leaf(Leaf {
                 class_label: 2,
                 n_samples: 5,
+                impurity: 0.0,
             })),
         });
 
@@ -301,32 +330,162 @@
 
     #[test]
     fn test_compute_tree_feature_importances_nested() {
-        // Root splits on feature 0, left child splits on feature 1
+        // Root splits on feature 0 (n=10, gini 0.6), left child splits on
+        // feature 1 (n=5, gini 0.48). Children pure. MDI per split:
+        //   feature 0 = 10*0.6 - 5*0.48 - 5*0.0 = 3.6
+        //   feature 1 =  5*0.48 - 2*0.0  - 3*0.0 = 2.4
         let tree = TreeNode::Node(Node {
             feature_idx: 0,
             threshold: 5.0,
+            impurity: 0.6,
+            n_node_samples: 10,
             left: Box::new(TreeNode::Node(Node {
                 feature_idx: 1,
                 threshold: 2.0,
+                impurity: 0.48,
+                n_node_samples: 5,
                 left: Box::new(TreeNode::Leaf(Leaf {
                     class_label: 0,
                     n_samples: 2,
+                    impurity: 0.0,
                 })),
                 right: Box::new(TreeNode::Leaf(Leaf {
                     class_label: 1,
                     n_samples: 3,
+                    impurity: 0.0,
                 })),
             })),
             right: Box::new(TreeNode::Leaf(Leaf {
                 class_label: 2,
                 n_samples: 5,
+                impurity: 0.0,
             })),
         });
         let mut importances = vec![0.0; 3];
         compute_tree_feature_importances(&tree, &mut importances);
-        // feature 0 at root: total samples = 2+3+5 = 10
-        assert!((importances[0] - 10.0).abs() < 1e-7);
-        // feature 1 at left subtree: total samples = 2+3 = 5
-        assert!((importances[1] - 5.0).abs() < 1e-7);
+        assert!((importances[0] - 3.6).abs() < 1e-6);
+        assert!((importances[1] - 2.4).abs() < 1e-6);
         assert!((importances[2] - 0.0).abs() < 1e-7);
+    }
+
+    // ========================================================================
+    // PMAT-851 FALSIFIER: MDI feature-importance must reflect impurity decrease,
+    // not raw split sample-count.
+    //
+    // Repro tree (regression):
+    //   root: split feature 0 over 20 samples
+    //     left  -> leaf value=1.0 n=10 (var 0)
+    //     right -> internal split feature 1 over 10 samples (var ~2500 -> 0)
+    //                left  -> leaf value=0.0 n=5
+    //                right -> leaf value=100.0 n=5
+    //
+    // Feature 1 fully separates a high-variance subset (variance 2500 -> 0), so
+    // its impurity decrease (25000) dwarfs feature 0's (root variance is small).
+    // The OLD count-only code attributed [20.0, 10.0] -> feature 0 ranked higher.
+    // Correct MDI ranks feature 1 ABOVE feature 0.
+    // ========================================================================
+    #[test]
+    fn test_regression_mdi_outranks_by_variance_decrease_not_count() {
+        // ten 1.0, five 0.0, five 100.0
+        let y_root: Vec<f32> = std::iter::repeat_n(1.0_f32, 10)
+            .chain(std::iter::repeat_n(0.0_f32, 5))
+            .chain(std::iter::repeat_n(100.0_f32, 5))
+            .collect();
+        let root_var = variance_f32(&y_root);
+        let right_var = variance_f32(&[0.0, 0.0, 0.0, 0.0, 0.0, 100.0, 100.0, 100.0, 100.0, 100.0]);
+
+        let tree = RegressionTreeNode::Node(RegressionNode {
+            feature_idx: 0,
+            threshold: 0.5,
+            impurity: root_var,
+            n_node_samples: 20,
+            left: Box::new(RegressionTreeNode::Leaf(RegressionLeaf {
+                value: 1.0,
+                n_samples: 10,
+                impurity: 0.0,
+            })),
+            right: Box::new(RegressionTreeNode::Node(RegressionNode {
+                feature_idx: 1,
+                threshold: 50.0,
+                impurity: right_var,
+                n_node_samples: 10,
+                left: Box::new(RegressionTreeNode::Leaf(RegressionLeaf {
+                    value: 0.0,
+                    n_samples: 5,
+                    impurity: 0.0,
+                })),
+                right: Box::new(RegressionTreeNode::Leaf(RegressionLeaf {
+                    value: 100.0,
+                    n_samples: 5,
+                    impurity: 0.0,
+                })),
+            })),
+        });
+
+        let mut importances = vec![0.0_f32; 2];
+        compute_regression_tree_feature_importances(&tree, &mut importances);
+
+        // FALSIFIER: feature 1's variance drop must outrank feature 0.
+        // (Old count-only code yields [20.0, 10.0] -> feature 0 wins, FAILS this.)
+        assert!(
+            importances[1] > importances[0],
+            "MDI must rank feature 1 > feature 0; got {importances:?}"
+        );
+
+        // Weighted-decrease formula check:
+        //   feature 0 = 20*root_var - 10*0 - 10*right_var
+        //   feature 1 = 10*right_var - 5*0 - 5*0
+        let expected_f0 = 20.0 * root_var - 10.0 * right_var;
+        let expected_f1 = 10.0 * right_var;
+        assert!(
+            (importances[0] - expected_f0).abs() < 1e-1,
+            "feature 0 MDI mismatch: got {}, want {expected_f0}",
+            importances[0]
+        );
+        assert!(
+            (importances[1] - expected_f1).abs() < 1e-1,
+            "feature 1 MDI mismatch: got {}, want {expected_f1}",
+            importances[1]
+        );
+    }
+
+    // PMAT-851 classification analog: gini impurity decrease, not raw count.
+    #[test]
+    fn test_classification_mdi_uses_gini_decrease_not_count() {
+        // Root split (feature 0) over 12 samples: gini 0.5. Left child (feature 1)
+        // splits a 6-sample mixed subset (gini 0.5 -> pure). Right leaf pure.
+        //   feature 0 = 12*0.5 - 6*0.0 - 6*0.5 = 6 - 3 = 3.0
+        //   feature 1 =  6*0.5 - 3*0.0 - 3*0.0 = 3.0
+        // Count-only code would give feature 0 = 12 (the whole subtree) > feature 1 = 6.
+        let tree = TreeNode::Node(Node {
+            feature_idx: 0,
+            threshold: 0.5,
+            impurity: 0.5,
+            n_node_samples: 12,
+            left: Box::new(TreeNode::Leaf(Leaf {
+                class_label: 0,
+                n_samples: 6,
+                impurity: 0.0,
+            })),
+            right: Box::new(TreeNode::Node(Node {
+                feature_idx: 1,
+                threshold: 0.5,
+                impurity: 0.5,
+                n_node_samples: 6,
+                left: Box::new(TreeNode::Leaf(Leaf {
+                    class_label: 1,
+                    n_samples: 3,
+                    impurity: 0.0,
+                })),
+                right: Box::new(TreeNode::Leaf(Leaf {
+                    class_label: 2,
+                    n_samples: 3,
+                    impurity: 0.0,
+                })),
+            })),
+        });
+        let mut importances = vec![0.0_f32; 2];
+        compute_tree_feature_importances(&tree, &mut importances);
+        assert!((importances[0] - 3.0).abs() < 1e-6, "got {importances:?}");
+        assert!((importances[1] - 3.0).abs() < 1e-6, "got {importances:?}");
     }

--- a/crates/aprender-core/src/tree/mod.rs
+++ b/crates/aprender-core/src/tree/mod.rs
@@ -60,6 +60,15 @@ pub struct Node {
     pub feature_idx: usize,
     /// Threshold value for the split
     pub threshold: f32,
+    /// Gini impurity of the samples reaching this node (computed at fit time,
+    /// before the split). Drives MDI feature-importance (see
+    /// `contracts/tree-feature-importances-mdi-v1.yaml`).
+    #[serde(default)]
+    pub impurity: f32,
+    /// Number of training samples reaching this node (computed at fit time).
+    /// The MDI weight for the split made here.
+    #[serde(default)]
+    pub n_node_samples: usize,
     /// Left subtree (samples where feature <= threshold)
     pub left: Box<TreeNode>,
     /// Right subtree (samples where feature > threshold)
@@ -76,6 +85,11 @@ pub struct Leaf {
     pub class_label: usize,
     /// Number of training samples in this leaf
     pub n_samples: usize,
+    /// Gini impurity of the samples in this leaf (computed at fit time).
+    /// Used by parent splits in the MDI feature-importance formula (see
+    /// `contracts/tree-feature-importances-mdi-v1.yaml`).
+    #[serde(default)]
+    pub impurity: f32,
 }
 
 /// A node in a decision tree (either internal node or leaf).
@@ -114,6 +128,11 @@ pub struct RegressionLeaf {
     pub value: f32,
     /// Number of training samples in this leaf
     pub n_samples: usize,
+    /// Variance of the target values in this leaf (computed at fit time).
+    /// Used by parent splits in the MDI feature-importance formula (see
+    /// `contracts/tree-feature-importances-mdi-v1.yaml`).
+    #[serde(default)]
+    pub impurity: f32,
 }
 
 /// Internal node in a regression tree.
@@ -126,6 +145,15 @@ pub struct RegressionNode {
     pub feature_idx: usize,
     /// Threshold value for the split
     pub threshold: f32,
+    /// Variance of the target values reaching this node (computed at fit time,
+    /// before the split). Drives MDI feature-importance (see
+    /// `contracts/tree-feature-importances-mdi-v1.yaml`).
+    #[serde(default)]
+    pub impurity: f32,
+    /// Number of training samples reaching this node (computed at fit time).
+    /// The MDI weight for the split made here.
+    #[serde(default)]
+    pub n_node_samples: usize,
     /// Left subtree (samples where feature <= threshold)
     pub left: Box<RegressionTreeNode>,
     /// Right subtree (samples where feature > threshold)

--- a/crates/aprender-core/src/tree/random_forest.rs
+++ b/crates/aprender-core/src/tree/random_forest.rs
@@ -230,7 +230,13 @@ impl RandomForestRegressor {
         Some(crate::metrics::r_squared(y_train, &oob_preds))
     }
 
-    /// Returns feature importances based on mean decrease in variance.
+    /// Returns feature importances based on Mean Decrease in Impurity (MDI).
+    ///
+    /// For each split node, the contribution is the weighted variance decrease
+    /// `n_node·variance − n_left·left_variance − n_right·right_variance`
+    /// (sklearn `tree/_tree.pyx::compute_feature_importances`), averaged across
+    /// trees and normalized to sum 1. See
+    /// `contracts/tree-feature-importances-mdi-v1.yaml`.
     #[must_use]
     pub fn feature_importances(&self) -> Option<Vec<f32>> {
         if self.trees.is_empty() || self.x_train.is_none() {

--- a/crates/aprender-core/src/tree/random_forest_classifier.rs
+++ b/crates/aprender-core/src/tree/random_forest_classifier.rs
@@ -231,7 +231,13 @@ impl RandomForestClassifier {
         Some(correct as f32 / y_train.len() as f32)
     }
 
-    /// Returns feature importances based on mean decrease in impurity.
+    /// Returns feature importances based on Mean Decrease in Impurity (MDI).
+    ///
+    /// For each split node, the contribution is the weighted gini decrease
+    /// `n_node·gini − n_left·left_gini − n_right·right_gini`
+    /// (sklearn `tree/_tree.pyx::compute_feature_importances`), averaged across
+    /// trees and normalized to sum 1. See
+    /// `contracts/tree-feature-importances-mdi-v1.yaml`.
     #[must_use]
     pub fn feature_importances(&self) -> Option<Vec<f32>> {
         if self.trees.is_empty() || self.x_train.is_none() {

--- a/crates/aprender-core/src/tree/random_forest_tests_regressor.rs
+++ b/crates/aprender-core/src/tree/random_forest_tests_regressor.rs
@@ -377,3 +377,51 @@
             );
         }
     }
+
+    // PMAT-851 end-to-end: feature importances from a FITTED forest must use MDI
+    // (variance decrease), not raw split sample-count. Feature 1 carves out a
+    // high-variance subset (0 vs 100) while feature 0 only separates a small,
+    // low-variance group. MDI must therefore rank feature 1 above feature 0.
+    #[test]
+    fn test_fitted_regressor_feature_importances_mdi_ranking() {
+        // 20 rows, 2 features. Feature 0 splits off ten low-value (1.0) rows;
+        // feature 1 separates the remaining ten into 0.0 vs 100.0.
+        let mut data = Vec::with_capacity(20 * 2);
+        let mut targets = Vec::with_capacity(20);
+        // ten rows: feature0=0, feature1=0  -> target 1.0 (low variance group)
+        for _ in 0..10 {
+            data.push(0.0);
+            data.push(0.0);
+            targets.push(1.0);
+        }
+        // five rows: feature0=1, feature1=0 -> target 0.0
+        for _ in 0..5 {
+            data.push(1.0);
+            data.push(0.0);
+            targets.push(0.0);
+        }
+        // five rows: feature0=1, feature1=1 -> target 100.0
+        for _ in 0..5 {
+            data.push(1.0);
+            data.push(1.0);
+            targets.push(100.0);
+        }
+        let x = Matrix::from_vec(20, 2, data).expect("matrix creation");
+        let y = Vector::from_vec(targets);
+
+        let mut rf = RandomForestRegressor::new(1).with_random_state(7);
+        rf.fit(&x, &y).expect("fit should succeed");
+
+        let importances = rf
+            .feature_importances()
+            .expect("fitted forest yields importances");
+        assert_eq!(importances.len(), 2);
+        // MDI ranks the high-variance-decrease feature 1 above feature 0.
+        assert!(
+            importances[1] > importances[0],
+            "MDI must rank feature 1 > feature 0; got {importances:?}"
+        );
+        // Normalized to sum 1.
+        let sum: f32 = importances.iter().sum();
+        assert!((sum - 1.0).abs() < 1e-5, "importances must sum to 1: {sum}");
+    }

--- a/crates/aprender-core/src/tree/regression_helpers.rs
+++ b/crates/aprender-core/src/tree/regression_helpers.rs
@@ -170,10 +170,14 @@ pub(super) fn split_regression_data_by_indices(
 }
 
 /// Create a regression leaf node from y values.
+///
+/// Stores the leaf's variance (impurity) so parent splits can use it in the MDI
+/// feature-importance formula (see `tree-feature-importances-mdi-v1`).
 pub(super) fn make_regression_leaf(y_slice: &[f32], n_samples: usize) -> RegressionTreeNode {
     RegressionTreeNode::Leaf(RegressionLeaf {
         value: mean_f32(y_slice),
         n_samples,
+        impurity: variance_f32(y_slice),
     })
 }
 
@@ -213,11 +217,12 @@ pub(super) fn build_regression_tree(
     let n_samples = y.len();
     let y_slice: Vec<f32> = y.as_slice().to_vec();
 
+    // Impurity (variance) of the samples reaching this node, computed BEFORE the
+    // split. Drives MDI feature-importance (tree-feature-importances-mdi-v1).
+    let node_impurity = variance_f32(&y_slice);
+
     // Early stopping checks
-    if n_samples < min_samples_split
-        || at_max_depth(depth, max_depth)
-        || variance_f32(&y_slice) < 1e-10
-    {
+    if n_samples < min_samples_split || at_max_depth(depth, max_depth) || node_impurity < 1e-10 {
         return make_regression_leaf(&y_slice, n_samples);
     }
 
@@ -260,6 +265,8 @@ pub(super) fn build_regression_tree(
     RegressionTreeNode::Node(RegressionNode {
         feature_idx,
         threshold,
+        impurity: node_impurity,
+        n_node_samples: n_samples,
         left: Box::new(left_child),
         right: Box::new(right_child),
     })
@@ -269,16 +276,36 @@ pub(super) fn build_regression_tree(
 // Feature Importance Helpers
 // ============================================================================
 
+/// Returns `(n_node_samples, impurity)` for any classification tree node.
+///
+/// Leaves carry their own sample count and gini impurity; internal nodes carry
+/// the values recorded at fit time for the samples reaching them.
+fn tree_node_n_and_impurity(node: &TreeNode) -> (f32, f32) {
+    match node {
+        TreeNode::Leaf(leaf) => (leaf.n_samples as f32, leaf.impurity),
+        TreeNode::Node(n) => (n.n_node_samples as f32, n.impurity),
+    }
+}
+
 /// Compute feature importances from a classification tree by traversing it.
+///
+/// Uses the sklearn Mean Decrease in Impurity (MDI) formula
+/// (`tree/_tree.pyx::compute_feature_importances`): for each split node,
+/// `importance[feature] += n_node·impurity − n_left·left_impurity − n_right·right_impurity`.
+/// Consumers normalize the accumulated importances to sum 1.
 pub(super) fn compute_tree_feature_importances(node: &TreeNode, importances: &mut [f32]) {
     match node {
         TreeNode::Leaf(_) => {
-            // Leaf nodes don't contribute to feature importance
+            // Leaf nodes don't make a split → no impurity decrease to attribute.
         }
         TreeNode::Node(n) => {
-            // Add importance for this feature based on number of samples
-            let n_samples = count_tree_samples(node) as f32;
-            importances[n.feature_idx] += n_samples;
+            let n_node = n.n_node_samples as f32;
+            let (n_left, left_impurity) = tree_node_n_and_impurity(&n.left);
+            let (n_right, right_impurity) = tree_node_n_and_impurity(&n.right);
+
+            // MDI weighted impurity decrease for the split made at this node.
+            importances[n.feature_idx] +=
+                n_node * n.impurity - n_left * left_impurity - n_right * right_impurity;
 
             // Recursively process children
             compute_tree_feature_importances(&n.left, importances);
@@ -287,7 +314,11 @@ pub(super) fn compute_tree_feature_importances(node: &TreeNode, importances: &mu
     }
 }
 
-/// Count total samples in a tree/subtree
+/// Count total samples in a tree/subtree.
+///
+/// Retained for test coverage of tree-sample accounting; MDI feature-importance
+/// (the production consumer) now reads per-node `n_node_samples` directly.
+#[cfg(test)]
 pub(super) fn count_tree_samples(node: &TreeNode) -> usize {
     match node {
         TreeNode::Leaf(leaf) => leaf.n_samples,
@@ -298,19 +329,39 @@ pub(super) fn count_tree_samples(node: &TreeNode) -> usize {
     }
 }
 
+/// Returns `(n_node_samples, impurity)` for any regression tree node.
+///
+/// Leaves carry their own sample count and variance; internal nodes carry the
+/// values recorded at fit time for the samples reaching them.
+fn regression_node_n_and_impurity(node: &RegressionTreeNode) -> (f32, f32) {
+    match node {
+        RegressionTreeNode::Leaf(leaf) => (leaf.n_samples as f32, leaf.impurity),
+        RegressionTreeNode::Node(n) => (n.n_node_samples as f32, n.impurity),
+    }
+}
+
 /// Compute feature importances from a regression tree by traversing it.
+///
+/// Uses the sklearn Mean Decrease in Impurity (MDI) formula
+/// (`tree/_tree.pyx::compute_feature_importances`): for each split node,
+/// `importance[feature] += n_node·variance − n_left·left_variance − n_right·right_variance`.
+/// Consumers normalize the accumulated importances to sum 1.
 pub(super) fn compute_regression_tree_feature_importances(
     node: &RegressionTreeNode,
     importances: &mut [f32],
 ) {
     match node {
         RegressionTreeNode::Leaf(_) => {
-            // Leaf nodes don't contribute to feature importance
+            // Leaf nodes don't make a split → no variance decrease to attribute.
         }
         RegressionTreeNode::Node(n) => {
-            // Add importance for this feature based on number of samples
-            let n_samples = count_regression_tree_samples(node) as f32;
-            importances[n.feature_idx] += n_samples;
+            let n_node = n.n_node_samples as f32;
+            let (n_left, left_impurity) = regression_node_n_and_impurity(&n.left);
+            let (n_right, right_impurity) = regression_node_n_and_impurity(&n.right);
+
+            // MDI weighted variance decrease for the split made at this node.
+            importances[n.feature_idx] +=
+                n_node * n.impurity - n_left * left_impurity - n_right * right_impurity;
 
             // Recursively process children
             compute_regression_tree_feature_importances(&n.left, importances);
@@ -319,7 +370,11 @@ pub(super) fn compute_regression_tree_feature_importances(
     }
 }
 
-/// Count total samples in a regression tree/subtree
+/// Count total samples in a regression tree/subtree.
+///
+/// Retained for test coverage of tree-sample accounting; MDI feature-importance
+/// (the production consumer) now reads per-node `n_node_samples` directly.
+#[cfg(test)]
 pub(super) fn count_regression_tree_samples(node: &RegressionTreeNode) -> usize {
     match node {
         RegressionTreeNode::Leaf(leaf) => leaf.n_samples,

--- a/crates/aprender-core/src/tree/tests/advanced_flatten_and_traits.rs
+++ b/crates/aprender-core/src/tree/tests/advanced_flatten_and_traits.rs
@@ -8,20 +8,27 @@ fn test_flatten_and_reconstruct_tree() {
     let original = TreeNode::Node(Node {
         feature_idx: 0,
         threshold: 0.5,
+        impurity: 0.0,
+        n_node_samples: 0,
         left: Box::new(TreeNode::Leaf(Leaf {
             class_label: 0,
             n_samples: 5,
+            impurity: 0.0,
         })),
         right: Box::new(TreeNode::Node(Node {
             feature_idx: 1,
             threshold: 0.3,
+            impurity: 0.0,
+            n_node_samples: 0,
             left: Box::new(TreeNode::Leaf(Leaf {
                 class_label: 1,
                 n_samples: 3,
+                impurity: 0.0,
             })),
             right: Box::new(TreeNode::Leaf(Leaf {
                 class_label: 2,
                 n_samples: 2,
+                impurity: 0.0,
             })),
         })),
     });
@@ -62,23 +69,31 @@ fn test_flatten_and_reconstruct_tree() {
 
 #[test]
 fn test_compute_tree_feature_importances() {
+    // MDI = n_node*impurity - n_left*left_imp - n_right*right_imp per split.
     let tree = TreeNode::Node(Node {
         feature_idx: 0,
         threshold: 0.5,
+        impurity: 0.5,
+        n_node_samples: 20,
         left: Box::new(TreeNode::Leaf(Leaf {
             class_label: 0,
             n_samples: 10,
+            impurity: 0.0,
         })),
         right: Box::new(TreeNode::Node(Node {
             feature_idx: 1,
             threshold: 0.3,
+            impurity: 0.4,
+            n_node_samples: 10,
             left: Box::new(TreeNode::Leaf(Leaf {
                 class_label: 1,
                 n_samples: 5,
+                impurity: 0.0,
             })),
             right: Box::new(TreeNode::Leaf(Leaf {
                 class_label: 2,
                 n_samples: 5,
+                impurity: 0.0,
             })),
         })),
     });
@@ -86,30 +101,37 @@ fn test_compute_tree_feature_importances() {
     let mut importances = vec![0.0; 2];
     compute_tree_feature_importances(&tree, &mut importances);
 
-    // Feature 0 splits 20 samples, feature 1 splits 10 samples
-    assert!(importances[0] > 0.0);
-    assert!(importances[1] > 0.0);
+    // Feature 0: 20*0.5 - 10*0.0 - 10*0.4 = 6.0
+    // Feature 1: 10*0.4 - 5*0.0 - 5*0.0   = 4.0
+    assert!((importances[0] - 6.0).abs() < 1e-5);
+    assert!((importances[1] - 4.0).abs() < 1e-5);
 }
 
 #[test]
 fn test_compute_regression_tree_feature_importances() {
+    // MDI = n_node*variance - n_left*left_var - n_right*right_var per split.
     let tree = RegressionTreeNode::Node(RegressionNode {
         feature_idx: 0,
         threshold: 0.5,
+        impurity: 0.25,
+        n_node_samples: 20,
         left: Box::new(RegressionTreeNode::Leaf(RegressionLeaf {
             value: 1.0,
             n_samples: 10,
+            impurity: 0.0,
         })),
         right: Box::new(RegressionTreeNode::Leaf(RegressionLeaf {
             value: 2.0,
             n_samples: 10,
+            impurity: 0.0,
         })),
     });
 
     let mut importances = vec![0.0; 2];
     compute_regression_tree_feature_importances(&tree, &mut importances);
 
-    assert!(importances[0] > 0.0);
+    // Feature 0: 20*0.25 - 10*0.0 - 10*0.0 = 5.0
+    assert!((importances[0] - 5.0).abs() < 1e-5);
     assert_eq!(importances[1], 0.0); // Feature 1 not used
 }
 

--- a/crates/aprender-core/src/tree/tests/advanced_gbm_and_scoring.rs
+++ b/crates/aprender-core/src/tree/tests/advanced_gbm_and_scoring.rs
@@ -72,6 +72,7 @@ fn test_leaf_struct_fields() {
     let leaf = Leaf {
         class_label: 2,
         n_samples: 50,
+        impurity: 0.0,
     };
     assert_eq!(leaf.class_label, 2);
     assert_eq!(leaf.n_samples, 50);
@@ -82,6 +83,7 @@ fn test_regression_leaf_struct_fields() {
     let leaf = RegressionLeaf {
         value: 3.14,
         n_samples: 25,
+        impurity: 0.0,
     };
     assert!((leaf.value - 3.14).abs() < 1e-6);
     assert_eq!(leaf.n_samples, 25);
@@ -92,15 +94,19 @@ fn test_node_struct_fields() {
     let left = TreeNode::Leaf(Leaf {
         class_label: 0,
         n_samples: 5,
+        impurity: 0.0,
     });
     let right = TreeNode::Leaf(Leaf {
         class_label: 1,
         n_samples: 5,
+        impurity: 0.0,
     });
 
     let node = Node {
         feature_idx: 2,
         threshold: 1.5,
+        impurity: 0.0,
+        n_node_samples: 0,
         left: Box::new(left),
         right: Box::new(right),
     };
@@ -114,15 +120,19 @@ fn test_regression_node_struct_fields() {
     let left = RegressionTreeNode::Leaf(RegressionLeaf {
         value: 1.0,
         n_samples: 5,
+        impurity: 0.0,
     });
     let right = RegressionTreeNode::Leaf(RegressionLeaf {
         value: 2.0,
         n_samples: 5,
+        impurity: 0.0,
     });
 
     let node = RegressionNode {
         feature_idx: 1,
         threshold: 0.75,
+        impurity: 0.0,
+        n_node_samples: 0,
         left: Box::new(left),
         right: Box::new(right),
     };
@@ -136,19 +146,24 @@ fn test_tree_node_variants() {
     let leaf_node = TreeNode::Leaf(Leaf {
         class_label: 0,
         n_samples: 10,
+        impurity: 0.0,
     });
     assert_eq!(leaf_node.depth(), 0);
 
     let internal_node = TreeNode::Node(Node {
         feature_idx: 0,
         threshold: 0.5,
+        impurity: 0.0,
+        n_node_samples: 0,
         left: Box::new(TreeNode::Leaf(Leaf {
             class_label: 0,
             n_samples: 5,
+            impurity: 0.0,
         })),
         right: Box::new(TreeNode::Leaf(Leaf {
             class_label: 1,
             n_samples: 5,
+            impurity: 0.0,
         })),
     });
     assert_eq!(internal_node.depth(), 1);
@@ -159,19 +174,24 @@ fn test_regression_tree_node_variants() {
     let leaf = RegressionTreeNode::Leaf(RegressionLeaf {
         value: 5.0,
         n_samples: 10,
+        impurity: 0.0,
     });
     assert_eq!(leaf.depth(), 0);
 
     let internal = RegressionTreeNode::Node(RegressionNode {
         feature_idx: 0,
         threshold: 0.5,
+        impurity: 0.0,
+        n_node_samples: 0,
         left: Box::new(RegressionTreeNode::Leaf(RegressionLeaf {
             value: 3.0,
             n_samples: 5,
+            impurity: 0.0,
         })),
         right: Box::new(RegressionTreeNode::Leaf(RegressionLeaf {
             value: 7.0,
             n_samples: 5,
+            impurity: 0.0,
         })),
     });
     assert_eq!(internal.depth(), 1);
@@ -410,19 +430,24 @@ fn test_count_tree_samples() {
     let leaf = TreeNode::Leaf(Leaf {
         class_label: 0,
         n_samples: 42,
+        impurity: 0.0,
     });
     assert_eq!(count_tree_samples(&leaf), 42);
 
     let node = TreeNode::Node(Node {
         feature_idx: 0,
         threshold: 0.5,
+        impurity: 0.0,
+        n_node_samples: 0,
         left: Box::new(TreeNode::Leaf(Leaf {
             class_label: 0,
             n_samples: 10,
+            impurity: 0.0,
         })),
         right: Box::new(TreeNode::Leaf(Leaf {
             class_label: 1,
             n_samples: 20,
+            impurity: 0.0,
         })),
     });
     assert_eq!(count_tree_samples(&node), 30);

--- a/crates/aprender-core/src/tree/tests/advanced_oob_and_serialization.rs
+++ b/crates/aprender-core/src/tree/tests/advanced_oob_and_serialization.rs
@@ -4,19 +4,24 @@ fn test_count_regression_tree_samples() {
     let leaf = RegressionTreeNode::Leaf(RegressionLeaf {
         value: 5.0,
         n_samples: 15,
+        impurity: 0.0,
     });
     assert_eq!(count_regression_tree_samples(&leaf), 15);
 
     let node = RegressionTreeNode::Node(RegressionNode {
         feature_idx: 0,
         threshold: 0.5,
+        impurity: 0.0,
+        n_node_samples: 0,
         left: Box::new(RegressionTreeNode::Leaf(RegressionLeaf {
             value: 1.0,
             n_samples: 5,
+            impurity: 0.0,
         })),
         right: Box::new(RegressionTreeNode::Leaf(RegressionLeaf {
             value: 2.0,
             n_samples: 8,
+            impurity: 0.0,
         })),
     });
     assert_eq!(count_regression_tree_samples(&node), 13);

--- a/crates/aprender-core/src/tree/tests/advanced_regressor_importances.rs
+++ b/crates/aprender-core/src/tree/tests/advanced_regressor_importances.rs
@@ -333,19 +333,24 @@ fn test_regression_tree_node_depth() {
     let leaf = RegressionTreeNode::Leaf(RegressionLeaf {
         value: 5.0,
         n_samples: 10,
+        impurity: 0.0,
     });
     assert_eq!(leaf.depth(), 0);
 
     let node = RegressionTreeNode::Node(RegressionNode {
         feature_idx: 0,
         threshold: 0.5,
+        impurity: 0.0,
+        n_node_samples: 0,
         left: Box::new(RegressionTreeNode::Leaf(RegressionLeaf {
             value: 3.0,
             n_samples: 5,
+            impurity: 0.0,
         })),
         right: Box::new(RegressionTreeNode::Leaf(RegressionLeaf {
             value: 7.0,
             n_samples: 5,
+            impurity: 0.0,
         })),
     });
     assert_eq!(node.depth(), 1);

--- a/crates/aprender-core/src/tree/tests/core.rs
+++ b/crates/aprender-core/src/tree/tests/core.rs
@@ -15,6 +15,7 @@ fn test_leaf_creation() {
     let leaf = Leaf {
         class_label: 1,
         n_samples: 10,
+        impurity: 0.0,
     };
     assert_eq!(leaf.class_label, 1);
     assert_eq!(leaf.n_samples, 10);
@@ -25,15 +26,19 @@ fn test_node_creation() {
     let left = TreeNode::Leaf(Leaf {
         class_label: 0,
         n_samples: 5,
+        impurity: 0.0,
     });
     let right = TreeNode::Leaf(Leaf {
         class_label: 1,
         n_samples: 5,
+        impurity: 0.0,
     });
 
     let node = Node {
         feature_idx: 0,
         threshold: 0.5,
+        impurity: 0.0,
+        n_node_samples: 0,
         left: Box::new(left),
         right: Box::new(right),
     };
@@ -48,6 +53,7 @@ fn test_tree_depth() {
     let leaf = TreeNode::Leaf(Leaf {
         class_label: 0,
         n_samples: 1,
+        impurity: 0.0,
     });
     assert_eq!(leaf.depth(), 0);
 
@@ -55,13 +61,17 @@ fn test_tree_depth() {
     let tree = TreeNode::Node(Node {
         feature_idx: 0,
         threshold: 0.5,
+        impurity: 0.0,
+        n_node_samples: 0,
         left: Box::new(TreeNode::Leaf(Leaf {
             class_label: 0,
             n_samples: 1,
+            impurity: 0.0,
         })),
         right: Box::new(TreeNode::Leaf(Leaf {
             class_label: 1,
             n_samples: 1,
+            impurity: 0.0,
         })),
     });
     assert_eq!(tree.depth(), 1);
@@ -70,10 +80,13 @@ fn test_tree_depth() {
     let deep_tree = TreeNode::Node(Node {
         feature_idx: 0,
         threshold: 0.5,
+        impurity: 0.0,
+        n_node_samples: 0,
         left: Box::new(tree),
         right: Box::new(TreeNode::Leaf(Leaf {
             class_label: 1,
             n_samples: 1,
+            impurity: 0.0,
         })),
     });
     assert_eq!(deep_tree.depth(), 2);


### PR DESCRIPTION
## Summary

RandomForest/DecisionTree `feature_importances()` accumulated only the **sample count** reaching each split node, dropping the impurity-decrease factor — so importances ranked features by split volume, not how much they reduce impurity (wrong vs scikit-learn MDI).

## Fix
Added `impurity` + `n_node_samples` to `Node`/`RegressionNode` (stamped at fit time via existing `gini_impurity`/`variance`); helpers now accumulate sklearn MDI: `n·impurity − n_left·left_impurity − n_right·right_impurity`.

## Verification
- RED: regression repro yields `[20,10]` (feature 0 wins by count); GREEN: feature 1 (huge variance drop) outranks; sums to 1.
- `cargo test -p aprender-core --lib` -> **13916 passed / 0 failed** (12 constructor/test files updated for new fields).
- `contracts/tree-feature-importances-mdi-v1.yaml` -> `pv validate` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)