### PR TITLE
fix(quantize): InterleavedQ4K mis-decoded 6-bit scales for 7/8 sub-blocks vs ggml (PMAT-856)

### DIFF
--- a/contracts/q4k-interleaved-scale-min-v1.yaml
+++ b/contracts/q4k-interleaved-scale-min-v1.yaml
@@ -1,0 +1,171 @@
+metadata:
+  version: 1.0.0
+  created: '2026-06-19'
+  author: PAIML Engineering
+  description: |
+    `InterleavedQ4K::dot` (aprender-serve quantize::product) must decode the
+    12-byte packed 6-bit Q4_K block scales via ggml's `get_scale_min_k4`, the
+    same decoder used by `dequantize_q4_k`. Before this contract the bespoke
+    helper `extract_scale_min_from_slice` decoded the scales with
+    `scale_idx = idx/2`, `min_idx = idx/2 + 4` and an even/odd split. That
+    layout agrees with `get_scale_min_k4` ONLY for sub-block 0; for sub-blocks
+    1..7 it read the wrong bytes and returned wrong (scale, min) pairs, so the
+    InterleavedQ4K Q4_K matmul produced wrong results on 7 of the 8 sub-blocks
+    of every super-block (PMAT-856). The fix deletes the bespoke helper and
+    decodes via the proven `extract_scale_min`, making `InterleavedQ4K::dot`
+    bit-identical to `dequantize_q4_k` for all 8 sub-blocks. This is a
+    correctness BEAT: llama.cpp/Ollama use get_scale_min_k4 exactly; the prior
+    apr path silently diverged.
+  references:
+  - 'PMAT-856 -- the correctness defect this fixes'
+  - 'ggml-quants.c get_scale_min_k4 -- canonical 6-bit scale/min unpacking'
+  - 'ggml dequantize_row_q4_K -- canonical Q4_K dequant using get_scale_min_k4'
+  - 'aprender-serve quantize::dequant_q4k::dequantize_q4_k -- the proven in-tree path InterleavedQ4K::dot must match'
+  - 'aprender-serve quantize::simd::extract_scale_min -- the proven get_scale_min_k4 implementation'
+  - 'contracts/q4k-q6k-superblock-v1.yaml -- Q4_K/Q6_K super-block byte layout'
+
+kind: KernelContract
+name: q4k-interleaved-scale-min
+version: 1.0.0
+scope: aprender-serve quantize::product InterleavedQ4K::dot (dot_scalar + dot_avx2) scale/min decode
+
+equations:
+  get_scale_min_k4:
+    formula: |
+      For a 12-byte packed scales array q and sub-block index j in [0..8]
+      (ggml get_scale_min_k4):
+        j < 4:  scale = q[j] & 63
+                min   = q[j + 4] & 63
+        j >= 4: scale = (q[j + 4] & 0x0F) | ((q[j - 4] >> 6) << 4)
+                min   = (q[j + 4] >> 4)  | ((q[j]     >> 6) << 4)
+      Each (scale, min) is a 6-bit value in [0, 63]. This is exactly what
+      extract_scale_min implements and dequantize_q4_k uses.
+    domain: q is &[u8; 12]; j in [0..8]
+    codomain: (scale, min) each in [0, 63]
+    invariants:
+    - 'j == 0 -> (q[0] & 63, q[4] & 63); the ONLY sub-block the prior bespoke decoder also got right'
+    - 'the decode reads only q[0..12]; never out of bounds'
+    - 'returned scale, min are both in [0, 63] for any input bytes'
+    lean_theorem: Theorems.Q4K_GetScaleMinK4
+
+  interleaved_dot_decode_parity:
+    formula: |
+      For a Q4_K super-block, InterleavedQ4K::dot dequantizes each weight as
+        w = d * scale_sub * q_nibble - dmin * min_sub
+      where (scale_sub, min_sub) = get_scale_min_k4(scales, is) for the low
+      nibbles and get_scale_min_k4(scales, is+1) for the high nibbles, with
+      is = j/32 advancing over the 8 sub-blocks. These are the SAME (scale, min)
+      pairs dequantize_q4_k uses for the same weights, so for every super-block
+      the dequantized weights are identical and
+        InterleavedQ4K::dot(act) == sum_i dequantize_q4_k()[i] * act[i]
+      up to floating-point accumulation order.
+    domain: a valid Q4_K super-block (144 bytes) + activations of length 256*num_super_blocks
+    codomain: a single f32 dot product
+    invariants:
+    - 'sub-blocks 1..7 use the SAME (scale, min) as dequantize_q4_k (the bug was here)'
+    - 'd == 0 -> dot is 0 regardless of scales/min/quants; no panic'
+    - 'the 12-byte scale slice is consumed via a fixed &[u8; 12]; a malformed super-block can never index out of range'
+    lean_theorem: Theorems.Q4K_Interleaved_Dot_Parity
+
+proof_obligations:
+- type: invariant
+  property: InterleavedQ4K decode equals dequantize_q4_k for all 8 sub-blocks
+  formal: |
+    For every valid Q4_K super-block (any d, dmin, 12 scale bytes, 128 qs
+    bytes) and any activations of length 256, InterleavedQ4K::dot(act) equals
+    sum_i dequantize_q4_k(block)[i] * act[i] within floating-point accumulation
+    tolerance. In particular the (scale, min) pair applied to sub-blocks 1..7
+    matches get_scale_min_k4, not the prior bespoke idx/2 decoder.
+- type: invariant
+  property: scale/min decode is ggml get_scale_min_k4 exactly
+  formal: |
+    For the adversarial scales [0xAD,0x72,0xC3,0x1E,0xB5,0x49,0xE6,0x3C,0x96,
+    0x6B,0x2D,0xD4], extract_scale_min returns the ggml get_scale_min_k4 values
+    (45,53),(50,9),(3,38),(30,60),(38,41),(27,22),(61,50),(4,13) for idx 0..8.
+    The prior extract_scale_min_from_slice disagreed on 7 of these 8.
+- type: invariant
+  property: zero super-block scale yields zero dot without panic
+  formal: |
+    For a super-block with d == 0, InterleavedQ4K::dot returns exactly 0.0 for
+    any activations; the decode never panics or reads out of bounds.
+- type: classification
+  property: InterleavedQ4K::dot length guard rejects mismatched activations
+  formal: |
+    For activations whose length != num_super_blocks*256, InterleavedQ4K::dot
+    returns Err(InvalidShape); it never panics.
+
+falsification:
+  command: cargo test -p aprender-serve --lib pmat856
+  red_evidence: |
+    With the bespoke extract_scale_min_from_slice decoder (idx/2 split), the
+    repro scales mismatch ggml get_scale_min_k4 on 7 of 8 sub-blocks, e.g.
+    idx=2 -> (50,9) instead of (3,38); dequant of q=15 at d=dmin=1.0 yields
+    741 instead of the correct 7. The dot-vs-dequant falsifier
+    test_pmat856_interleaved_q4k_dot_matches_dequantize_q4_k FAILS with a gross
+    divergence (measured got=-6060.97 vs expected=11847.88, tol~1.19).
+  green_evidence: |
+    After deleting extract_scale_min_from_slice and decoding via
+    extract_scale_min on a fixed &[u8; 12], all 8 sub-blocks match
+    get_scale_min_k4 and InterleavedQ4K::dot is bit-parity with
+    dequantize_q4_k. Both PMAT-856 tests pass; full crate suite 15406 passed,
+    0 failed.
+
+falsification_tests:
+- id: FT-Q4KISM-001
+  rule: InterleavedQ4K::dot is parity with dequantize_q4_k on adversarial scales
+  prediction: |
+    For a Q4_K super-block carrying the repro scale bytes and non-uniform
+    quants/activations, InterleavedQ4K::dot equals the plain dot over
+    dequantize_q4_k output within tolerance.
+  if_fails: |
+    The scale/min decode in product.rs diverged from get_scale_min_k4 again
+    (the PMAT-856 regression). Confirm dot_scalar/dot_avx2 call
+    simd::extract_scale_min on a &[u8; 12], not a bespoke idx/2 decoder.
+  evidence: cargo test -p aprender-serve --lib test_pmat856_interleaved_q4k_dot_matches_dequantize_q4_k
+- id: FT-Q4KISM-002
+  rule: extract_scale_min reproduces ggml get_scale_min_k4 for all 8 sub-blocks
+  prediction: |
+    extract_scale_min on the repro scales returns
+    (45,53),(50,9),(3,38),(30,60),(38,41),(27,22),(61,50),(4,13) for idx 0..8.
+  if_fails: |
+    extract_scale_min no longer matches ggml get_scale_min_k4. Check the j<4 vs
+    j>=4 branches in quantize::simd::extract_scale_min against ggml-quants.c.
+  evidence: cargo test -p aprender-serve --lib test_pmat856_q4k_scale_min_decode_is_ggml_get_scale_min_k4
+- id: FT-Q4KISM-003
+  rule: zero super-block scale zeroes the dot without panic
+  prediction: |
+    InterleavedQ4K::from_q4k of a 144-byte block with d=0 then dot(&[1.0; 256])
+    returns Ok(0.0).
+  if_fails: |
+    A NaN/division crept into the dequant path or the d=0 case panics. Check the
+    d * scale * q - dmin * min computation in dot_scalar/dot_avx2.
+  evidence: cargo test -p aprender-serve --lib test_interleaved_q4k_dot_with_zero_d
+- id: FT-Q4KISM-004
+  rule: mismatched activation length is rejected, never panics
+  prediction: |
+    InterleavedQ4K::from_q4k of a 144-byte block then dot(&[1.0; 100]) returns
+    Err(InvalidShape) because 100 != num_super_blocks*256.
+  if_fails: |
+    The activation-length guard in InterleavedQ4K::dot is missing or wrong, so
+    the kernel indexes activations out of bounds. Check the
+    activations.len() != self.num_values() check at the top of dot.
+  evidence: cargo test -p aprender-serve --lib test_interleaved_q4k_dot_dim_mismatch_cov
+
+kani_harnesses:
+- id: KANI-Q4KISM-001
+  obligation: get_scale_min_k4 reads only the 12 scale bytes and returns 6-bit values
+  property: |
+    For all (scales in [u8; 12], j in [0..8]): extract_scale_min(&scales, j)
+    indexes only scales[0..12] and returns (scale, min) with both in [0, 63].
+  bound: 8
+  strategy: bounded_int
+  solver: cadical
+  harness: verify_q4k_get_scale_min_k4_range
+
+qa_gate:
+  id: F-Q4KISM-001
+  name: q4k-interleaved-scale-min-v1 Contract
+  description: InterleavedQ4K::dot must decode Q4_K packed 6-bit scales via ggml get_scale_min_k4 so its Q4_K matmul is bit-parity with dequantize_q4_k on all 8 sub-blocks (PMAT-856 correctness beat).
+  checks:
+  - validation
+  - falsification

--- a/crates/aprender-serve/src/quantize/mod.rs
+++ b/crates/aprender-serve/src/quantize/mod.rs
@@ -119,7 +119,7 @@ pub use parallel_dequant::{
 };
 
 // Re-export SIMD utilities (for tests and internal use)
-pub use simd::{extract_scale_min, extract_scale_min_from_slice, read_f16};
+pub use simd::{extract_scale_min, read_f16};
 
 // Re-export format trait and generic kernels (Contract: quantized-dot-product-v1.yaml)
 pub use format_trait::{Q4_0Fmt, Q8_0Fmt, QuantBlockFormat, QuantFamily, Q4K, Q5K, Q6K};

--- a/crates/aprender-serve/src/quantize/product.rs
+++ b/crates/aprender-serve/src/quantize/product.rs
@@ -148,15 +148,22 @@ impl InterleavedQ4K {
             let scales_start = sb * 12;
             let qs_start = sb * 128;
 
+            // Decode the super-block's 12-byte packed 6-bit scales via the
+            // proven ggml get_scale_min_k4 implementation (extract_scale_min),
+            // exactly as dequantize_q4_k does. The former bespoke
+            // extract_scale_min_from_slice decoder only agreed for is=0 and
+            // returned wrong (scale, min) pairs for 7 of 8 sub-blocks (PMAT-856).
+            let sb_scales: &[u8; 12] = self.scales[scales_start..scales_start + 12]
+                .try_into()
+                .expect("super-block carries exactly 12 scale bytes");
+
             // Process 4 chunks of 64 values each
             for j in (0..QK_K).step_by(64) {
                 let q_start = qs_start + j / 2;
                 let is = j / 32;
 
-                let (sc1, m1) =
-                    simd::extract_scale_min_from_slice(&self.scales[scales_start..], is);
-                let (sc2, m2) =
-                    simd::extract_scale_min_from_slice(&self.scales[scales_start..], is + 1);
+                let (sc1, m1) = simd::extract_scale_min(sb_scales, is);
+                let (sc2, m2) = simd::extract_scale_min(sb_scales, is + 1);
 
                 // Process 32 low nibbles
                 for i in 0..32 {
@@ -214,15 +221,20 @@ impl InterleavedQ4K {
                 _mm_prefetch(self.qs.as_ptr().add(next_qs).cast::<i8>(), _MM_HINT_T0);
             }
 
+            // Decode the super-block's 12-byte packed 6-bit scales via the
+            // proven ggml get_scale_min_k4 implementation (extract_scale_min),
+            // exactly as dequantize_q4_k does (PMAT-856).
+            let sb_scales: &[u8; 12] = self.scales[scales_start..scales_start + 12]
+                .try_into()
+                .expect("super-block carries exactly 12 scale bytes");
+
             // Process 4 chunks of 64 values
             for j in (0..QK_K).step_by(64) {
                 let q_start = qs_start + j / 2;
                 let is = j / 32;
 
-                let (sc1, m1) =
-                    simd::extract_scale_min_from_slice(&self.scales[scales_start..], is);
-                let (sc2, m2) =
-                    simd::extract_scale_min_from_slice(&self.scales[scales_start..], is + 1);
+                let (sc1, m1) = simd::extract_scale_min(sb_scales, is);
+                let (sc2, m2) = simd::extract_scale_min(sb_scales, is + 1);
 
                 let d_scale1 = d * sc1;
                 let dm1 = dmin * m1;

--- a/crates/aprender-serve/src/quantize/simd.rs
+++ b/crates/aprender-serve/src/quantize/simd.rs
@@ -4,7 +4,7 @@
 //!
 //! ## Contents
 //! - f16 reading: `read_f16`
-//! - Scale extraction: `extract_scale_min`, `extract_scale_min_from_slice`
+//! - Scale extraction: `extract_scale_min` (ggml `get_scale_min_k4`)
 //!
 //! Note: `f16_to_f32` is exported from `dequant.rs`.
 //! SIMD activations (`softmax_simd`, `fused_swiglu_simd`, `apply_rope_rotation_simd`)
@@ -55,24 +55,6 @@ pub fn extract_scale_min(scales: &[u8; 12], block_idx: usize) -> (f32, f32) {
     let min = f32::from(min_bits);
 
     (scale, min)
-}
-
-/// Extract scale and min from packed 6-bit scales (helper for InterleavedQ4K)
-pub fn extract_scale_min_from_slice(scales: &[u8], idx: usize) -> (f32, f32) {
-    // Same logic as extract_scale_min but works with slice
-    let scale_idx = idx / 2;
-    let min_idx = idx / 2 + 4;
-
-    let (scale_raw, min_raw) = if idx.is_multiple_of(2) {
-        (scales[scale_idx] & 0x3F, scales[min_idx] & 0x3F)
-    } else {
-        (
-            (scales[scale_idx] >> 6) | ((scales[scale_idx + 2] & 0x0F) << 2),
-            (scales[min_idx] >> 6) | ((scales[min_idx + 2] & 0x0F) << 2),
-        )
-    };
-
-    (scale_raw as f32, min_raw as f32)
 }
 
 #[cfg(test)]
@@ -186,15 +168,5 @@ mod tests {
         // min = (scales[8] >> 4) | ((scales[4] >> 6) << 4) = 3 | 0 = 3
         assert_eq!(scale, 49.0);
         assert_eq!(min, 3.0);
-    }
-
-    // ============= extract_scale_min_from_slice tests =============
-
-    #[test]
-    fn test_extract_scale_min_from_slice_even() {
-        let scales: [u8; 8] = [10, 20, 30, 40, 5, 15, 25, 35];
-        let (scale, min) = extract_scale_min_from_slice(&scales, 0);
-        assert_eq!(scale, 10.0);
-        assert_eq!(min, 5.0);
     }
 }

--- a/crates/aprender-serve/src/quantize/tests/dequantize_06.rs
+++ b/crates/aprender-serve/src/quantize/tests/dequantize_06.rs
@@ -159,36 +159,6 @@ fn test_read_f16_negative() {
 }
 
 #[test]
-fn test_extract_scale_min_from_slice_first_block() {
-    // Test extraction for index 0 (first block - simple layout)
-    let scales: [u8; 8] = [0x3F, 0x1F, 0x0F, 0x07, 0x20, 0x10, 0x08, 0x04];
-    let (scale, min) = extract_scale_min_from_slice(&scales, 0);
-    // idx=0: scale = scales[0] & 0x3F = 0x3F = 63
-    // idx=0: min = scales[4] & 0x3F = 0x20 = 32
-    assert!(
-        (scale - 63.0).abs() < 0.001,
-        "scale should be 63, got {}",
-        scale
-    );
-    assert!((min - 32.0).abs() < 0.001, "min should be 32, got {}", min);
-}
-
-#[test]
-fn test_extract_scale_min_from_slice_second_block() {
-    // Test extraction for index 2 (even, simple layout)
-    let scales: [u8; 8] = [0x3F, 0x1F, 0x0F, 0x07, 0x20, 0x10, 0x08, 0x04];
-    let (scale, min) = extract_scale_min_from_slice(&scales, 2);
-    // idx=2: scale_idx = 1, scale = scales[1] & 0x3F = 0x1F = 31
-    // idx=2: min_idx = 5, min = scales[5] & 0x3F = 0x10 = 16
-    assert!(
-        (scale - 31.0).abs() < 0.001,
-        "scale should be 31, got {}",
-        scale
-    );
-    assert!((min - 16.0).abs() < 0.001, "min should be 16, got {}", min);
-}
-
-#[test]
 fn test_extract_scale_min_first_blocks() {
     // Test extract_scale_min for first 4 blocks (simple layout)
     let scales: [u8; 12] = [

--- a/crates/aprender-serve/src/quantize/tests/extract_scale.rs
+++ b/crates/aprender-serve/src/quantize/tests/extract_scale.rs
@@ -3,18 +3,6 @@
 // Coverage Tests: extract_scale_min_from_slice
 // =========================================================================
 
-/// Test extract_scale_min_from_slice with various block indices
-#[test]
-fn test_extract_scale_min_from_slice_all_blocks() {
-    let scales = [0u8; 12];
-    // Test all 8 blocks
-    for idx in 0..8 {
-        let (scale, min) = extract_scale_min_from_slice(&scales, idx);
-        assert!(scale >= 0.0);
-        assert!(min >= 0.0);
-    }
-}
-
 // =========================================================================
 // Coverage Tests: fused_q4_0_q8_0_parallel_matvec_into
 // =========================================================================

--- a/crates/aprender-serve/src/quantize/tests/extract_scale_02.rs
+++ b/crates/aprender-serve/src/quantize/tests/extract_scale_02.rs
@@ -34,59 +34,12 @@ fn test_extract_scale_min_all_blocks_max_values() {
     }
 }
 
-// =============================================================================
-// extract_scale_min_from_slice Additional Tests
-// =============================================================================
-
-#[test]
-fn test_extract_scale_min_from_slice_odd_index_3() {
-    let mut scales = [0u8; 12];
-    // For idx=3: scale_idx=1, min_idx=5
-    // scale = (scales[1] >> 6) | ((scales[3] & 0x0F) << 2)
-    // min = (scales[5] >> 6) | ((scales[7] & 0x0F) << 2)
-    scales[1] = 0b10_000000; // high 2 bits = 2
-    scales[3] = 0b0000_0111; // low 4 bits = 7
-    scales[5] = 0b11_000000; // high 2 bits = 3
-    scales[7] = 0b0000_1010; // low 4 bits = 10
-
-    let (s, m) = extract_scale_min_from_slice(&scales, 3);
-    // scale = 2 | (7 << 2) = 2 + 28 = 30
-    assert_eq!(s, 30.0, "idx=3 scale");
-    // min = 3 | (10 << 2) = 3 + 40 = 43
-    assert_eq!(m, 43.0, "idx=3 min");
-}
-
-#[test]
-fn test_extract_scale_min_from_slice_odd_index_5() {
-    let mut scales = [0u8; 12];
-    // For idx=5: scale_idx=2, min_idx=6
-    scales[2] = 0b01_000000; // high 2 bits = 1
-    scales[4] = 0b0000_1100; // low 4 bits = 12
-    scales[6] = 0b11_000000; // high 2 bits = 3
-    scales[8] = 0b0000_0001; // low 4 bits = 1
-
-    let (s, m) = extract_scale_min_from_slice(&scales, 5);
-    // scale = 1 | (12 << 2) = 1 + 48 = 49
-    assert_eq!(s, 49.0, "idx=5 scale");
-    // min = 3 | (1 << 2) = 3 + 4 = 7
-    assert_eq!(m, 7.0, "idx=5 min");
-}
-
-#[test]
-fn test_extract_scale_min_from_slice_odd_index_7() {
-    let mut scales = [0u8; 12];
-    // For idx=7: scale_idx=3, min_idx=7
-    scales[3] = 0b00_000000; // high 2 bits = 0
-    scales[5] = 0b0000_1111; // low 4 bits = 15
-    scales[7] = 0b10_000000; // high 2 bits = 2
-    scales[9] = 0b0000_0011; // low 4 bits = 3
-
-    let (s, m) = extract_scale_min_from_slice(&scales, 7);
-    // scale = 0 | (15 << 2) = 60
-    assert_eq!(s, 60.0, "idx=7 scale");
-    // min = 2 | (3 << 2) = 2 + 12 = 14
-    assert_eq!(m, 14.0, "idx=7 min");
-}
+// NOTE (PMAT-856): The three former `test_extract_scale_min_from_slice_odd_index_*`
+// tests were DELETED. They asserted the output of `extract_scale_min_from_slice`,
+// a bespoke Q4_K 6-bit scale decoder that did NOT implement ggml's
+// `get_scale_min_k4` and returned wrong (scale, min) pairs for 7 of the 8
+// sub-blocks. Both the function and its callers (InterleavedQ4K::dot) now use the
+// proven `extract_scale_min`, so these buggy-behavior assertions are obsolete.
 
 // =============================================================================
 // InterleavedQ4K Additional Tests

--- a/crates/aprender-serve/src/quantize/tests/f16.rs
+++ b/crates/aprender-serve/src/quantize/tests/f16.rs
@@ -9,7 +9,7 @@
 
 use proptest::prelude::*;
 
-use crate::quantize::simd::{extract_scale_min, extract_scale_min_from_slice, read_f16};
+use crate::quantize::simd::{extract_scale_min, read_f16};
 use crate::quantize::{f16_to_f32, fused_swiglu_simd, softmax_simd};
 
 // =============================================================================
@@ -198,16 +198,6 @@ fn test_extract_scale_min_all_zeros() {
         assert_eq!(s, 0.0, "Block {} scale should be 0", i);
         assert_eq!(m, 0.0, "Block {} min should be 0", i);
     }
-}
-
-#[test]
-fn test_extract_scale_min_from_slice_basic() {
-    let scales: [u8; 12] = [10, 20, 30, 40, 5, 15, 25, 35, 0, 0, 0, 0];
-
-    let (s0, m0) = extract_scale_min_from_slice(&scales, 0);
-    // idx=0: scale_idx=0, min_idx=4, using & 0x3F
-    assert_eq!(s0, 10.0);
-    assert_eq!(m0, 5.0);
 }
 
 proptest! {

--- a/crates/aprender-serve/src/quantize/tests/f16_02.rs
+++ b/crates/aprender-serve/src/quantize/tests/f16_02.rs
@@ -8,7 +8,6 @@
 //! Note: Horizontal sum functions (hsum_epi32_*, horizontal_sum_*) are now
 //! internal to fused_k.rs and tested there to avoid dead code.
 
-use crate::quantize::simd::extract_scale_min_from_slice;
 use crate::quantize::{f16_to_f32, fused_swiglu_simd, softmax_simd};
 
 // =============================================================================
@@ -41,97 +40,6 @@ fn test_f16_to_f32_positive_subnormals() {
 // =============================================================================
 // extract_scale_min_from_slice: Odd Index Coverage (lines 114-117)
 // =============================================================================
-
-/// Test extract_scale_min_from_slice with all odd indices 1,3,5,7
-#[test]
-fn test_extract_scale_min_from_slice_odd_indices() {
-    // For odd idx: scale = (scales[idx/2] >> 6) | ((scales[idx/2+2] & 0x0F) << 2)
-    //              min = (scales[idx/2+4] >> 6) | ((scales[idx/2+6] & 0x0F) << 2)
-
-    // idx=1: scale_idx=0, min_idx=4
-    let scales1: [u8; 12] = [
-        0b11_000000,
-        0,
-        0b0000_0101,
-        0,
-        0b01_000000,
-        0,
-        0b0000_0111,
-        0,
-        0,
-        0,
-        0,
-        0,
-    ];
-    let (s, m) = extract_scale_min_from_slice(&scales1, 1);
-    assert_eq!(s, 23.0, "idx=1 scale: 3|(5<<2)");
-    assert_eq!(m, 29.0, "idx=1 min: 1|(7<<2)");
-
-    // idx=3: scale_idx=1, min_idx=5
-    let scales3: [u8; 12] = [
-        0,
-        0b10_000000,
-        0,
-        0b0000_0110,
-        0,
-        0b00_000000,
-        0,
-        0b0000_1000,
-        0,
-        0,
-        0,
-        0,
-    ];
-    let (s, m) = extract_scale_min_from_slice(&scales3, 3);
-    assert_eq!(s, 26.0, "idx=3 scale: 2|(6<<2)");
-    assert_eq!(m, 32.0, "idx=3 min: 0|(8<<2)");
-
-    // idx=5: scale_idx=2, min_idx=6
-    let scales5: [u8; 12] = [
-        0,
-        0,
-        0b01_000000,
-        0,
-        0b0000_1010,
-        0,
-        0b11_000000,
-        0,
-        0b0000_1111,
-        0,
-        0,
-        0,
-    ];
-    let (s, m) = extract_scale_min_from_slice(&scales5, 5);
-    assert_eq!(s, 41.0, "idx=5 scale: 1|(10<<2)");
-    assert_eq!(m, 63.0, "idx=5 min: 3|(15<<2)");
-
-    // idx=7: scale_idx=3, min_idx=7
-    let scales7: [u8; 12] = [
-        0,
-        0,
-        0,
-        0b11_000000,
-        0,
-        0b0000_1111,
-        0,
-        0b10_000000,
-        0,
-        0b0000_1100,
-        0,
-        0,
-    ];
-    let (s, m) = extract_scale_min_from_slice(&scales7, 7);
-    assert_eq!(s, 63.0, "idx=7 scale: 3|(15<<2)");
-    assert_eq!(m, 50.0, "idx=7 min: 2|(12<<2)");
-
-    // Zeros for all odd indices
-    let zeros: [u8; 12] = [0; 12];
-    for idx in [1, 3, 5, 7] {
-        let (s, m) = extract_scale_min_from_slice(&zeros, idx);
-        assert_eq!(s, 0.0);
-        assert_eq!(m, 0.0);
-    }
-}
 
 // =============================================================================
 // Additional Edge Cases for SIMD Paths

--- a/crates/aprender-serve/src/quantize/tests/f16_03.rs
+++ b/crates/aprender-serve/src/quantize/tests/f16_03.rs
@@ -171,23 +171,6 @@ fn test_quantize_activations_q8_0_zeros_values() {
 // Extract Scale Min from Slice Tests (Coverage: scale extraction helpers)
 // =========================================================================
 
-#[test]
-fn test_extract_scale_min_from_slice_all_max_check() {
-    let scales: [u8; 8] = [0x3F; 8];
-    let (scale, _min) = extract_scale_min_from_slice(&scales, 0);
-    assert!((scale - 63.0).abs() < 0.001);
-}
-
-#[test]
-fn test_extract_scale_min_from_slice_alternating_check() {
-    let scales: [u8; 8] = [0x15, 0x2A, 0x15, 0x2A, 0x15, 0x2A, 0x15, 0x2A];
-    let (scale0, _min0) = extract_scale_min_from_slice(&scales, 0);
-    let (scale2, _min2) = extract_scale_min_from_slice(&scales, 2);
-    // Should be consistent
-    assert!((scale0 - 21.0).abs() < 0.001);
-    assert!((scale2 - 42.0).abs() < 0.001);
-}
-
 // =========================================================================
 // Coverage Tests: Q4_0Block struct
 // =========================================================================

--- a/crates/aprender-serve/src/quantize/tests/fused_03.rs
+++ b/crates/aprender-serve/src/quantize/tests/fused_03.rs
@@ -337,60 +337,6 @@ fn test_extract_scale_min_block_7() {
 // extract_scale_min_from_slice tests
 // =============================================================================
 
-#[test]
-fn test_extract_scale_min_from_slice_even_idx() {
-    // idx = 0 (even)
-    let scales: Vec<u8> = vec![
-        0x3F, 0x1F, 0x0F, 0x07, 0x2A, 0x15, 0x0A, 0x05, 0x00, 0x00, 0x00, 0x00,
-    ];
-    let (scale, min) = extract_scale_min_from_slice(&scales, 0);
-    // scale_idx = 0, min_idx = 4
-    // scale = scales[0] & 0x3F = 0x3F = 63
-    // min = scales[4] & 0x3F = 0x2A = 42
-    assert_eq!(scale, 63.0);
-    assert_eq!(min, 42.0);
-}
-
-#[test]
-fn test_extract_scale_min_from_slice_even_idx_2() {
-    let scales: Vec<u8> = vec![
-        0x3F, 0x1F, 0x0F, 0x07, 0x2A, 0x15, 0x0A, 0x05, 0x00, 0x00, 0x00, 0x00,
-    ];
-    let (scale, min) = extract_scale_min_from_slice(&scales, 2);
-    // scale_idx = 1, min_idx = 5
-    // scale = scales[1] & 0x3F = 0x1F = 31
-    // min = scales[5] & 0x3F = 0x15 = 21
-    assert_eq!(scale, 31.0);
-    assert_eq!(min, 21.0);
-}
-
-#[test]
-fn test_extract_scale_min_from_slice_odd_idx() {
-    // idx = 1 (odd) - uses different extraction logic
-    let scales: Vec<u8> = vec![
-        0xC0, 0x00, 0x0F, 0x00, 0x00, 0x00, 0x0F, 0x00, 0x00, 0x00, 0x00, 0x00,
-    ];
-    let (scale, min) = extract_scale_min_from_slice(&scales, 1);
-    // scale_idx = 0, min_idx = 4
-    // scale = (scales[0] >> 6) | ((scales[2] & 0x0F) << 2) = (0xC0 >> 6) | ((0x0F & 0x0F) << 2) = 3 | 60 = 63
-    // min = (scales[4] >> 6) | ((scales[6] & 0x0F) << 2) = (0 >> 6) | ((0x0F & 0x0F) << 2) = 0 | 60 = 60
-    assert_eq!(scale, 63.0);
-    assert_eq!(min, 60.0);
-}
-
-#[test]
-fn test_extract_scale_min_from_slice_odd_idx_3() {
-    let scales: Vec<u8> = vec![
-        0x00, 0xC0, 0x00, 0x0F, 0x00, 0x00, 0x00, 0x0F, 0x00, 0x00, 0x00, 0x00,
-    ];
-    let (scale, min) = extract_scale_min_from_slice(&scales, 3);
-    // scale_idx = 1, min_idx = 5
-    // scale = (scales[1] >> 6) | ((scales[3] & 0x0F) << 2) = (0xC0 >> 6) | ((0x0F) << 2) = 3 | 60 = 63
-    // min = (scales[5] >> 6) | ((scales[7] & 0x0F) << 2) = 0 | 60 = 60
-    assert_eq!(scale, 63.0);
-    assert_eq!(min, 60.0);
-}
-
 // =============================================================================
 // fused_q4_0_q8_0_dot_scalar tests
 // =============================================================================

--- a/crates/aprender-serve/src/quantize/tests/interleaved_q4k.rs
+++ b/crates/aprender-serve/src/quantize/tests/interleaved_q4k.rs
@@ -441,5 +441,94 @@ fn test_quantize_activations_q8k_into_valid_cov() {
     assert!(scales[0] > 0.0);
 }
 
+// =========================================================================
+// PMAT-856: InterleavedQ4K::dot must decode the packed 6-bit scales via
+// ggml get_scale_min_k4 (extract_scale_min), identically to dequantize_q4_k.
+//
+// The former extract_scale_min_from_slice decoder agreed with extract_scale_min
+// ONLY for sub-block is=0; for is=1..7 it read the wrong scale bytes and
+// returned wrong (scale, min) pairs -> InterleavedQ4K Q4_K matmul produced wrong
+// results on 7 of 8 sub-blocks. Contract: contracts/q4k-interleaved-scale-min-v1.yaml
+// =========================================================================
+
+/// Build a single valid Q4_K super-block (144 bytes) with the supplied f16 d/dmin,
+/// the ticket's adversarial 12 packed scale bytes, and a deterministic non-uniform
+/// quant pattern so that every sub-block exercises a distinct (scale, min) pair.
+#[cfg(test)]
+fn pmat856_build_superblock() -> Vec<u8> {
+    let mut data = vec![0u8; 144];
+    // d = 1.5, dmin = 0.75 (non-trivial, both nonzero so min term is exercised)
+    data[0..2].copy_from_slice(&half::f16::from_f32(1.5).to_le_bytes());
+    data[2..4].copy_from_slice(&half::f16::from_f32(0.75).to_le_bytes());
+    // Adversarial packed scales (PMAT-856 repro): the 7/8-mismatch case.
+    let scales: [u8; 12] = [
+        0xAD, 0x72, 0xC3, 0x1E, 0xB5, 0x49, 0xE6, 0x3C, 0x96, 0x6B, 0x2D, 0xD4,
+    ];
+    data[4..16].copy_from_slice(&scales);
+    // qs: 128 bytes, distinct per-byte nibbles so each of the 256 weights differs.
+    for (i, b) in data[16..144].iter_mut().enumerate() {
+        let lo = (i % 16) as u8;
+        let hi = ((i / 16 + 1) % 16) as u8;
+        *b = (hi << 4) | lo;
+    }
+    data
+}
+
+#[test]
+fn test_pmat856_interleaved_q4k_dot_matches_dequantize_q4_k() {
+    let data = pmat856_build_superblock();
+
+    // Reference: full dequant via the proven path, then a plain dot.
+    let dequant = dequantize_q4_k(&data).expect("dequantize_q4_k");
+    assert_eq!(dequant.len(), 256);
+
+    // Non-uniform activations so any wrong (scale, min) on sub-blocks 1..7
+    // (which the buggy decoder produced) cannot cancel out.
+    let activations: Vec<f32> = (0..256).map(|i| ((i as f32) - 128.0) / 37.0).collect();
+
+    let expected: f32 = dequant
+        .iter()
+        .zip(activations.iter())
+        .map(|(w, a)| w * a)
+        .sum();
+
+    let iq = InterleavedQ4K::from_q4k(&data).expect("from_q4k");
+    let got = iq.dot(&activations).expect("dot");
+
+    // The dot reuses the exact dequant arithmetic; the only allowed delta is
+    // FP accumulation order (scalar vs AVX2 lanes). The pre-fix decoder produced
+    // a gross divergence (e.g. dequant of q=15 at is=2 was 741 vs correct 7).
+    let tol = expected.abs().mul_add(1e-4, 1e-3);
+    assert!(
+        (got - expected).abs() <= tol,
+        "InterleavedQ4K::dot diverged from dequantize_q4_k: got={got} expected={expected} (tol={tol})"
+    );
+}
+
+#[test]
+fn test_pmat856_q4k_scale_min_decode_is_ggml_get_scale_min_k4() {
+    // Directly pin the ggml get_scale_min_k4 values for the repro scales so a
+    // future regression of extract_scale_min is caught even without a full dot.
+    let scales: [u8; 12] = [
+        0xAD, 0x72, 0xC3, 0x1E, 0xB5, 0x49, 0xE6, 0x3C, 0x96, 0x6B, 0x2D, 0xD4,
+    ];
+    // (scale, min) per ggml get_scale_min_k4 for sub-blocks 0..8.
+    let expected: [(f32, f32); 8] = [
+        (45.0, 53.0),
+        (50.0, 9.0),
+        (3.0, 38.0),
+        (30.0, 60.0),
+        (38.0, 41.0),
+        (27.0, 22.0),
+        (61.0, 50.0),
+        (4.0, 13.0),
+    ];
+    for (idx, &(sc, m)) in expected.iter().enumerate() {
+        let (got_sc, got_m) = extract_scale_min(&scales, idx);
+        assert_eq!(got_sc, sc, "sub-block {idx} scale (ggml get_scale_min_k4)");
+        assert_eq!(got_m, m, "sub-block {idx} min (ggml get_scale_min_k4)");
+    }
+}
+
 include!("quantize_activations_03.rs");
 include!("q4_1_matmul.rs");

--- a/crates/aprender-serve/src/quantize/tests/interleaved_q4k_03.rs
+++ b/crates/aprender-serve/src/quantize/tests/interleaved_q4k_03.rs
@@ -369,47 +369,6 @@ fn test_fused_q4_0_q8_0_dot_scalar_truncated_block_deep_qcov_020() {
 // extract_scale_min_from_slice Coverage Tests
 // -------------------------------------------------------------------------
 
-#[test]
-fn test_extract_scale_min_from_slice_odd_indices_deep_qcov_021() {
-    // Test odd index paths (different bit manipulation)
-    let mut scales = [0u8; 12];
-    // Set up for odd index extraction
-    scales[0] = 0xC0; // High 2 bits for odd scale
-    scales[2] = 0x0F; // Low 4 bits for odd scale
-    scales[4] = 0x80; // High 2 bits for odd min
-    scales[6] = 0x07; // Low 4 bits for odd min
-
-    let (scale1, min1) = extract_scale_min_from_slice(&scales, 1);
-    assert!(scale1 >= 0.0);
-    assert!(min1 >= 0.0);
-
-    // Test index 3, 5, 7
-    for idx in [3, 5, 7] {
-        let (s, m) = extract_scale_min_from_slice(&scales, idx);
-        assert!(s >= 0.0);
-        assert!(m >= 0.0);
-    }
-}
-
-#[test]
-fn test_extract_scale_min_from_slice_even_indices_deep_qcov_022() {
-    // Test even index paths
-    let mut scales = [0u8; 12];
-    scales[0] = 0x3F; // max 6-bit scale for idx=0
-    scales[4] = 0x20; // min for idx=0
-
-    let (scale0, min0) = extract_scale_min_from_slice(&scales, 0);
-    assert_eq!(scale0, 63.0);
-    assert_eq!(min0, 32.0);
-
-    // Test indices 2, 4, 6
-    for idx in [2, 4, 6] {
-        let (s, m) = extract_scale_min_from_slice(&scales, idx);
-        assert!(s >= 0.0);
-        assert!(m >= 0.0);
-    }
-}
-
 // -------------------------------------------------------------------------
 // fused_q4_0_q8_0_parallel_matvec Error Path Tests
 // -------------------------------------------------------------------------

--- a/crates/aprender-serve/src/quantize/tests/quantize_activations_02.rs
+++ b/crates/aprender-serve/src/quantize/tests/quantize_activations_02.rs
@@ -175,25 +175,6 @@ fn test_interleaved_q4k_dot_wrong_size_ext_cov() {
 // Extended Coverage Tests for extract_scale_min_from_slice
 // =========================================================================
 
-#[test]
-fn test_extract_scale_min_from_slice_even_idx_ext_cov() {
-    let scales = [31u8, 0, 0, 0, 15, 0, 0, 0, 0, 0, 0, 0];
-    let (scale, min) = extract_scale_min_from_slice(&scales, 0);
-    assert!((scale - 31.0).abs() < 1e-6);
-    assert!((min - 15.0).abs() < 1e-6);
-}
-
-#[test]
-fn test_extract_scale_min_from_slice_odd_idx_ext_cov() {
-    let mut scales = [0u8; 12];
-    scales[0] = 0b11_000000; // high 2 bits contribute to scale[1]
-    scales[2] = 0b0000_0011; // low 4 bits contribute to scale[1]
-    let (scale, _) = extract_scale_min_from_slice(&scales, 1);
-    // scale = (scales[0] >> 6) | ((scales[2] & 0x0F) << 2)
-    // = (0b11_000000 >> 6) | ((0x03 & 0x0F) << 2) = 3 | 12 = 15
-    assert!((scale - 15.0).abs() < 1e-6);
-}
-
 // =========================================================================
 // Extended Coverage Tests for Q4_KBlock/Q5_KBlock/Q6_KBlock Clone/Debug
 // =========================================================================

--- a/crates/aprender-serve/src/quantize/tests/tests_10.rs
+++ b/crates/aprender-serve/src/quantize/tests/tests_10.rs
@@ -11,7 +11,7 @@
 //! - Scalar fallback paths
 //! - Horizontal sum helpers (x86_64 specific)
 
-use crate::quantize::simd::{extract_scale_min, extract_scale_min_from_slice, read_f16};
+use crate::quantize::simd::{extract_scale_min, read_f16};
 use crate::quantize::{f16_to_f32, fused_swiglu_simd, softmax_simd};
 
 // =============================================================================
@@ -234,52 +234,6 @@ fn test_extract_scale_min_max_values() {
         assert_eq!(s, 63.0, "Block {} scale should be 63", i);
         assert_eq!(m, 63.0, "Block {} min should be 63", i);
     }
-}
-
-#[test]
-fn test_extract_scale_min_from_slice_odd_indices() {
-    // Test odd indices which use different bit extraction
-    let scales: [u8; 12] = [
-        0b11_001010, // byte 0
-        0b10_001100, // byte 1
-        0b00001111,  // byte 2: contributes to odd index extractions
-        0b00110011,  // byte 3
-        0b01_010101, // byte 4
-        0b11_011011, // byte 5
-        0b00001111,  // byte 6: contributes to odd index extractions
-        0b00110011,  // byte 7
-        0,
-        0,
-        0,
-        0,
-    ];
-
-    // idx=1 is odd: scale_idx=0, uses different formula
-    let (s1, m1) = extract_scale_min_from_slice(&scales, 1);
-    // scale = (scales[0] >> 6) | ((scales[2] & 0x0F) << 2) = 3 | (0xF << 2) = 3 | 60 = 63
-    // min = (scales[4] >> 6) | ((scales[6] & 0x0F) << 2) = 1 | (0xF << 2) = 1 | 60 = 61
-    assert_eq!(s1, 63.0, "Index 1 scale");
-    assert_eq!(m1, 61.0, "Index 1 min");
-}
-
-#[test]
-fn test_extract_scale_min_from_slice_even_indices() {
-    // Test even indices
-    let scales: [u8; 12] = [
-        10, 20, 30, 40, // scales for indices 0, 2, 4, 6
-        5, 15, 25, 35, // mins for indices 0, 2, 4, 6
-        0, 0, 0, 0,
-    ];
-
-    // idx=0 (even): scale = scales[0] & 0x3F = 10, min = scales[4] & 0x3F = 5
-    let (s0, m0) = extract_scale_min_from_slice(&scales, 0);
-    assert_eq!(s0, 10.0, "Index 0 scale");
-    assert_eq!(m0, 5.0, "Index 0 min");
-
-    // idx=2 (even): scale = scales[1] & 0x3F = 20, min = scales[5] & 0x3F = 15
-    let (s2, m2) = extract_scale_min_from_slice(&scales, 2);
-    assert_eq!(s2, 20.0, "Index 2 scale");
-    assert_eq!(m2, 15.0, "Index 2 min");
 }
 
 // =============================================================================

--- a/crates/aprender-serve/src/quantize/tests/tests_13.rs
+++ b/crates/aprender-serve/src/quantize/tests/tests_13.rs
@@ -9,7 +9,7 @@
 //! - fused_q8_0_q8_0_parallel_matvec_into error paths
 
 use crate::quantize::{
-    dequantize_q8_blocks, extract_scale_min, extract_scale_min_from_slice,
+    dequantize_q8_blocks, extract_scale_min,
     fused_q4_0_q8_0_dot_scalar, fused_q4_0_q8_0_parallel_matvec,
     fused_q4_0_q8_0_parallel_matvec_into, fused_q8_0_q8_0_dot_scalar,
     fused_q8_0_q8_0_parallel_matvec, fused_q8_0_q8_0_parallel_matvec_into,
@@ -219,59 +219,6 @@ fn test_extract_scale_min_mod_high_bits_contribution() {
     // Block 4: d = (scales[8] & 0x0F) | ((scales[0] >> 6) << 4) = 1 | (3 << 4) = 49
     let (s4, _) = extract_scale_min(&scales, 4);
     assert_eq!(s4, 49.0, "Scale4 with high bits contribution");
-}
-
-#[test]
-fn test_extract_scale_min_from_slice_mod_all_indices() {
-    let scales: [u8; 12] = [
-        10, 20, 30, 40, // bytes 0-3
-        5, 15, 25, 35, // bytes 4-7
-        0, 0, 0, 0, // bytes 8-11
-    ];
-
-    // Even indices use simple extraction
-    // idx=0: scale_idx=0, min_idx=4
-    let (s0, m0) = extract_scale_min_from_slice(&scales, 0);
-    assert_eq!(s0, 10.0);
-    assert_eq!(m0, 5.0);
-
-    // idx=2: scale_idx=1, min_idx=5
-    let (s2, m2) = extract_scale_min_from_slice(&scales, 2);
-    assert_eq!(s2, 20.0);
-    assert_eq!(m2, 15.0);
-
-    // idx=4: scale_idx=2, min_idx=6
-    let (s4, m4) = extract_scale_min_from_slice(&scales, 4);
-    assert_eq!(s4, 30.0);
-    assert_eq!(m4, 25.0);
-
-    // idx=6: scale_idx=3, min_idx=7
-    let (s6, m6) = extract_scale_min_from_slice(&scales, 6);
-    assert_eq!(s6, 40.0);
-    assert_eq!(m6, 35.0);
-}
-
-#[test]
-fn test_extract_scale_min_from_slice_mod_odd_indices_formula() {
-    // For odd indices:
-    // scale_idx = idx / 2
-    // min_idx = scale_idx + 4
-    // scale = (scales[scale_idx] >> 6) | ((scales[scale_idx + 2] & 0x0F) << 2)
-    // min = (scales[min_idx] >> 6) | ((scales[min_idx + 2] & 0x0F) << 2)
-
-    let mut scales: [u8; 12] = [0; 12];
-    // For idx=1: scale_idx=0, uses bytes 0 and 2
-    scales[0] = 0b11_000000; // high 2 bits = 3
-    scales[2] = 0b0000_1111; // low 4 bits = 15
-                             // scale = 3 | (15 << 2) = 3 + 60 = 63
-
-    scales[4] = 0b10_000000; // high 2 bits = 2
-    scales[6] = 0b0000_0101; // low 4 bits = 5
-                             // min = 2 | (5 << 2) = 2 + 20 = 22
-
-    let (s1, m1) = extract_scale_min_from_slice(&scales, 1);
-    assert_eq!(s1, 63.0, "idx=1 scale");
-    assert_eq!(m1, 22.0, "idx=1 min");
 }
 
 // =============================================================================

--- a/crates/aprender-serve/src/quantize/tests/tests_16.rs
+++ b/crates/aprender-serve/src/quantize/tests/tests_16.rs
@@ -19,7 +19,7 @@ use crate::quantize::{
 
 // These are pub(crate), available within the crate
 use crate::quantize::{
-    extract_scale_min, extract_scale_min_from_slice, fused_q4_0_q8_0_dot_scalar,
+    extract_scale_min, fused_q4_0_q8_0_dot_scalar,
     fused_q4_0_q8_0_dot_simd, fused_q8_0_q8_0_dot_scalar,
 };
 

--- a/crates/aprender-serve/src/quantize/tests/tests_18.rs
+++ b/crates/aprender-serve/src/quantize/tests/tests_18.rs
@@ -9,7 +9,7 @@
 //!
 //! Focus: Edge cases, alignment requirements, and fallback paths.
 
-use crate::quantize::simd::{extract_scale_min, extract_scale_min_from_slice, read_f16};
+use crate::quantize::simd::{extract_scale_min, read_f16};
 use crate::quantize::{f16_to_f32, fused_swiglu_simd, softmax_simd};
 
 // =============================================================================
@@ -183,94 +183,6 @@ fn test_read_f16_special_values() {
 // =============================================================================
 // extract_scale_min_from_slice: Complete Branch Coverage
 // =============================================================================
-
-/// Test extract_scale_min_from_slice with all even indices 0-6
-#[test]
-fn test_extract_scale_min_from_slice_all_even() {
-    let scales: [u8; 12] = [
-        1, 2, 3, 4, // bytes 0-3 for scale indices
-        11, 12, 13, 14, // bytes 4-7 for min indices
-        0, 0, 0, 0,
-    ];
-
-    // idx=0: scale_idx=0, min_idx=4
-    let (s0, m0) = extract_scale_min_from_slice(&scales, 0);
-    assert_eq!(s0, 1.0, "idx=0 scale");
-    assert_eq!(m0, 11.0, "idx=0 min");
-
-    // idx=2: scale_idx=1, min_idx=5
-    let (s2, m2) = extract_scale_min_from_slice(&scales, 2);
-    assert_eq!(s2, 2.0, "idx=2 scale");
-    assert_eq!(m2, 12.0, "idx=2 min");
-
-    // idx=4: scale_idx=2, min_idx=6
-    let (s4, m4) = extract_scale_min_from_slice(&scales, 4);
-    assert_eq!(s4, 3.0, "idx=4 scale");
-    assert_eq!(m4, 13.0, "idx=4 min");
-
-    // idx=6: scale_idx=3, min_idx=7
-    let (s6, m6) = extract_scale_min_from_slice(&scales, 6);
-    assert_eq!(s6, 4.0, "idx=6 scale");
-    assert_eq!(m6, 14.0, "idx=6 min");
-}
-
-/// Test extract_scale_min_from_slice with all odd indices 1,3,5,7
-#[test]
-fn test_extract_scale_min_from_slice_all_odd() {
-    // For odd indices, the formula uses different bit extraction:
-    // scale = (scales[scale_idx] >> 6) | ((scales[scale_idx + 2] & 0x0F) << 2)
-    // min = (scales[min_idx] >> 6) | ((scales[min_idx + 2] & 0x0F) << 2)
-    let scales: [u8; 12] = [
-        0b11_000000, // byte 0: high bits = 3 for scale idx=1
-        0b10_000000, // byte 1: high bits = 2 for scale idx=3
-        0b00000101,  // byte 2: low nibble = 5 for scale idx=1
-        0b00000110,  // byte 3: low nibble = 6 for scale idx=3
-        0b01_000000, // byte 4: high bits = 1 for min idx=1
-        0b00_000000, // byte 5: high bits = 0 for min idx=3
-        0b00000111,  // byte 6: low nibble = 7 for min idx=1
-        0b00001000,  // byte 7: low nibble = 8 for min idx=3
-        0,
-        0,
-        0,
-        0,
-    ];
-
-    // idx=1: scale = (byte0 >> 6) | ((byte2 & 0x0F) << 2) = 3 | (5 << 2) = 3 | 20 = 23
-    //        min = (byte4 >> 6) | ((byte6 & 0x0F) << 2) = 1 | (7 << 2) = 1 | 28 = 29
-    let (s1, m1) = extract_scale_min_from_slice(&scales, 1);
-    assert_eq!(s1, 23.0, "idx=1 scale");
-    assert_eq!(m1, 29.0, "idx=1 min");
-
-    // idx=3: scale = (byte1 >> 6) | ((byte3 & 0x0F) << 2) = 2 | (6 << 2) = 2 | 24 = 26
-    //        min = (byte5 >> 6) | ((byte7 & 0x0F) << 2) = 0 | (8 << 2) = 0 | 32 = 32
-    let (s3, m3) = extract_scale_min_from_slice(&scales, 3);
-    assert_eq!(s3, 26.0, "idx=3 scale");
-    assert_eq!(m3, 32.0, "idx=3 min");
-}
-
-/// Test extract_scale_min_from_slice boundary with max 6-bit values
-#[test]
-fn test_extract_scale_min_from_slice_max_values() {
-    // Set up for idx=0 to return max value 63 (all 1s in low 6 bits)
-    let scales: [u8; 12] = [
-        0b00_111111, // byte 0: 63 for scale idx=0
-        0,
-        0,
-        0,
-        0b00_111111, // byte 4: 63 for min idx=0
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-    ];
-
-    let (s0, m0) = extract_scale_min_from_slice(&scales, 0);
-    assert_eq!(s0, 63.0, "idx=0 max scale");
-    assert_eq!(m0, 63.0, "idx=0 max min");
-}
 
 // =============================================================================
 // extract_scale_min: Extended Coverage for Blocks 4-7

--- a/crates/aprender-serve/src/quantize/tests/tests_24.rs
+++ b/crates/aprender-serve/src/quantize/tests/tests_24.rs
@@ -18,7 +18,7 @@ use crate::quantize::{
 
 // Import internal functions for direct testing
 use crate::quantize::{
-    extract_scale_min, extract_scale_min_from_slice, fused_q4_0_q8_0_dot_scalar,
+    extract_scale_min, fused_q4_0_q8_0_dot_scalar,
     fused_q8_0_q8_0_dot_scalar,
 };
 


### PR DESCRIPTION
## Summary

`extract_scale_min_from_slice` decoded the packed Q4_K 6-bit scales with the wrong scheme — correct only for sub-block 0; sub-blocks 1..7 read the wrong bytes. So `InterleavedQ4K::dot` produced wrong Q4_K matmul results on 7/8 sub-blocks (the proven `extract_scale_min` ggml `get_scale_min_k4` decoder exists in the same file).

## Fix
Deleted `extract_scale_min_from_slice`; `dot_scalar`/`dot_avx2` now use `extract_scale_min` on a `&[u8;12]` -> bit-parity with `dequantize_q4_k` for all 8 sub-blocks.

## Verification
- RED: idx=2 -> (50,9) vs canonical (3,38); dot got -6060.97 vs 11847.88. GREEN: all 8 match, full parity.
- `cargo test -p aprender-serve --lib` -> **15406 passed / 0 failed** (22 obsolete tests removed).
- `contracts/q4k-interleaved-scale-min-v1.yaml` -> `pv validate` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)