### PR TITLE
fix(serve): ALiBi head slopes off-by-one in exponent — 2^(-8h/n) not 2^(-8(h+1)/n) (PMAT-858)

### DIFF
--- a/contracts/alibi-slopes-v1.yaml
+++ b/contracts/alibi-slopes-v1.yaml
@@ -1,0 +1,114 @@
+metadata:
+  kind: kernel
+  version: 1.0.0
+  created: '2026-06-19'
+  author: PAIML Engineering
+  description: ALiBi head-slope exponent — slope[h] = 2^(-8(h+1)/n) (PMAT-858 fix).
+    Pins the head-slope formula used by aprender-serve's ALiBi positional encoding
+    so that head 0 carries slope 2^(-8/n) (e.g. 0.5 for n=8), NOT the buggy 2^0 = 1.0.
+  references:
+  - 'Press, Smith, Lewis (2021) "Train Short, Test Long: Attention with Linear Biases
+    Enables Input Length Extrapolation" — https://arxiv.org/abs/2108.12409'
+  - 'llama.cpp ggml soft_max_ext ALiBi: m0 = powf(2, -8/n); slope = powf(m0, h+1)'
+equations:
+  alibi_slope_exponent:
+    formula: m[h] = 2^(-8(h+1)/n)
+    domain: h in {0, ..., n - 1}, n >= 1
+    codomain: m[h] in (0, 1)
+    invariants:
+    - m[h] > 0 for all heads (slopes are strictly positive)
+    - m[h] < 1 for all heads (head 0 = 2^(-8/n) < 1, NOT 1.0)
+    - m[0] = 2^(-8/n) (first head slope, the (h+1) offset is load-bearing)
+    - m[n-1] = 2^(-8) for n a power of two (e.g. n=8 gives 2^-8 = 0.00390625)
+    - m[0] > m[1] > ... > m[n-1] within the power-of-two block (monotone decreasing)
+    preconditions:
+    - num_heads >= 1
+    lean_theorem: Theorems.Alibi_Slope_Exponent
+proof_obligations:
+- type: equivalence
+  property: Head-zero slope equals m0
+  formal: m[0] = 2^(-8/n) and in particular m[0] = 0.5 when n = 8
+  applies_to: all
+- type: bound
+  property: Slopes are below one
+  formal: m[h] = 2^(-8(h+1)/n) < 1 for all h in {0, ..., n-1}, n >= 1
+  applies_to: all
+- type: equivalence
+  property: Matches ggml reference exponent
+  formal: m[h] = m0^(h+1) with m0 = 2^(-8/n) (llama.cpp soft_max_ext)
+  applies_to: all
+kernel_structure:
+  phases:
+  - name: compute_slopes
+    description: Compute m[h] = 2^(-8(h+1)/n) for each attention head h
+    invariant: all slopes in (0, 1), strictly decreasing in the power-of-two block
+simd_dispatch:
+  alibi_slope_exponent:
+    scalar: ALiBi::compute_slopes
+enforcement:
+  head_zero_slope:
+    description: Head 0 slope must be 2^(-8/n), never 1.0
+    check: contract_tests::FALSIFY-AS-001
+    severity: ERROR
+  slopes_below_one:
+    description: Every ALiBi slope must be strictly below 1.0
+    check: contract_tests::FALSIFY-AS-002
+    severity: ERROR
+  reference_parity:
+    description: Slopes must match the Press et al. / ggml closed form
+    check: contract_tests::FALSIFY-AS-003
+    severity: ERROR
+falsification_tests:
+- id: FALSIFY-AS-001
+  rule: Head-zero slope equals m0
+  prediction: ALiBi::new(8).slopes()[0] == 0.5 (within 1e-7), NOT 1.0
+  test: 'cargo test -p aprender-serve --lib pmat_858_alibi_slope_falsifier::falsifier_alibi_slopes_power_of_two_match_reference'
+  red_state: buggy exponent -8h/n yields slopes()[0] = 2^0 = 1.0 (FAIL)
+  green_state: fixed exponent -8(h+1)/n yields slopes()[0] = 2^(-1) = 0.5 (PASS)
+  if_fails: Missing (h+1) offset in compute_slopes; every head carries an extra m0 factor
+- id: FALSIFY-AS-002
+  rule: Slopes are below one
+  prediction: every ALiBi slope < 1.0 for n in {1, 2, 4, 8, 12, 16, 32}
+  test: 'cargo test -p aprender-serve --lib pmat_858_alibi_slope_falsifier::falsifier_alibi_slopes_strictly_below_one'
+  red_state: buggy formula gives head-0 slope = 1.0 (NOT < 1.0) (FAIL)
+  green_state: all slopes strictly in (0, 1) (PASS)
+  if_fails: Exponent off-by-one re-introducing the 2^0 = 1.0 head-0 slope
+- id: FALSIFY-AS-003
+  rule: Matches ggml reference exponent
+  prediction: 'ALiBi::new(8).slopes() == [2^-1, 2^-2, ..., 2^-8]; ALiBi::new(1).slopes()[0] == 2^-8'
+  test: 'cargo test -p aprender-serve --lib pmat_858_alibi_slope_falsifier'
+  red_state: buggy slopes = [2^0, 2^-1, ..., 2^-7] diverge from ggml by a factor of m0 (FAIL)
+  green_state: slopes equal 2^(-8(h+1)/8), matching llama.cpp soft_max_ext (PASS)
+  if_fails: compute_slopes diverges from Press et al. 2021 / ggml closed form
+kani_harnesses:
+- id: KANI-AS-001
+  obligation: Head-zero slope equals m0
+  property: m[0] = 2^(-8/n), e.g. 0.5 for n = 8
+  bound: 8
+  strategy: stub_float
+  solver: cadical
+  harness: verify_alibi_head_zero_slope
+- id: KANI-AS-002
+  obligation: Slopes are below one
+  property: m[h] = 2^(-8(h+1)/n) < 1 for all h, n >= 1
+  bound: 8
+  strategy: stub_float
+  solver: cadical
+  harness: verify_alibi_slopes_below_one
+- id: KANI-AS-003
+  obligation: Matches ggml reference exponent
+  property: m[h] = m0^(h+1) with m0 = 2^(-8/n)
+  bound: 8
+  strategy: stub_float
+  solver: cadical
+  harness: verify_alibi_ggml_reference_exponent
+qa_gate:
+  id: F-AS-001
+  name: ALiBi Slope Exponent Contract
+  description: Pins ALiBi head-slope exponent to 2^(-8(h+1)/n) per Press et al. 2021 + ggml
+  checks:
+  - head_zero_slope
+  - slopes_below_one
+  - reference_parity
+  pass_criteria: All 3 falsification tests PASS (GREEN) on the fixed kernel
+  falsification: Drop the (h+1) offset (use -8h/n) — head 0 becomes 1.0, FALSIFY-AS-001/002/003 all FAIL

--- a/crates/aprender-serve/src/layers/a_li_bi.rs
+++ b/crates/aprender-serve/src/layers/a_li_bi.rs
@@ -317,8 +317,12 @@ impl ScaledRoPE {
 /// ```
 ///
 /// where m[h] is the head-specific slope computed as:
-/// - For powers of 2: m[h] = 2^(-8h/n) where n is the number of heads
+/// - For powers of 2: m[h] = 2^(-8(h+1)/n) where n is the number of heads
 /// - For non-powers of 2: interpolation between adjacent powers of 2
+///
+/// This matches the ALiBi paper (Press et al. 2021) and llama.cpp ggml
+/// `soft_max_ext` (`m0 = 2^(-8/n)`, `slope = m0^(h+1)`). For n=8 the slopes
+/// are 0.5, 0.25, ..., down to 2^(-8) = 0.00390625 (NOT 1.0 .. 2^(-7)).
 ///
 /// # References
 ///

--- a/crates/aprender-serve/src/layers/alibi.rs
+++ b/crates/aprender-serve/src/layers/alibi.rs
@@ -24,8 +24,13 @@ impl ALiBi {
 
     /// Compute head-specific slopes following `ALiBi` paper algorithm
     ///
-    /// For powers of 2: m[h] = 2^(-8h/n)
+    /// For powers of 2: m[h] = 2^(-8(h+1)/n)
     /// For non-powers of 2: interpolate between adjacent powers of 2
+    ///
+    /// Matches Press et al. 2021 and llama.cpp ggml `soft_max_ext`
+    /// (`m0 = 2^(-8/n)`, `slope = m0^(h+1)`). For n=8: slopes are
+    /// 0.5, 0.25, ..., 2^(-8) = 0.00390625. The `+ 1` is load-bearing:
+    /// without it head 0 carries slope 1.0 (an extra factor of `m0`).
     fn compute_slopes(num_heads: usize) -> Vec<f32> {
         // Find closest power of 2
         let closest_power_of_2 = if num_heads.is_power_of_two() {
@@ -39,10 +44,13 @@ impl ALiBi {
 
         let mut slopes = Vec::with_capacity(num_heads);
 
-        // Compute slopes for power of 2 heads
+        // Compute slopes for power of 2 heads.
+        // slope[h] = 2^(-8(h+1)/n) — the (i + 1) is load-bearing (PMAT-858):
+        // without it, head 0 gets 2^0 = 1.0 (an extra factor of m0 = 2^(8/n))
+        // instead of the correct 2^(-8/n).
         for i in 0..closest_power_of_2.min(num_heads) {
             #[allow(clippy::cast_precision_loss)]
-            let exponent = -(i as f32) * ratio;
+            let exponent = -((i + 1) as f32) * ratio;
             slopes.push(2_f32.powf(exponent));
         }
 
@@ -114,5 +122,128 @@ impl ALiBi {
     #[must_use]
     pub fn slopes(&self) -> &[f32] {
         &self.slopes
+    }
+}
+
+// ============================================================================
+// PMAT-858: ALiBi slope exponent falsifier
+//
+// Bug: compute_slopes used exponent = -h * (8/n), giving slope[h] = 2^(-8h/n).
+// For h=0 that is 2^0 = 1.0 — every head carried an extra factor of m0 = 2^(8/n)
+// vs the reference. The correct ALiBi slope (Press et al. 2021 + llama.cpp ggml
+// soft_max_ext: m0 = 2^(-8/n), slope = m0^(h+1)) is slope[h] = 2^(-8(h+1)/n).
+//
+// RED   (buggy code): slopes()[0] == 1.0
+// GREEN (fixed code): slopes()[0] == 0.5 for n=8, slopes()[7] == 2^(-8).
+// ============================================================================
+#[cfg(test)]
+mod pmat_858_alibi_slope_falsifier {
+    use super::ALiBi;
+
+    /// Reference slope per Press et al. 2021 / llama.cpp ggml:
+    /// m0 = 2^(-8/n), slope[h] = m0^(h+1) = 2^(-8(h+1)/n).
+    fn reference_slope(h: usize, num_heads: usize) -> f32 {
+        #[allow(clippy::cast_precision_loss)]
+        let exponent = -8.0 * ((h + 1) as f32) / (num_heads as f32);
+        2_f32.powf(exponent)
+    }
+
+    #[test]
+    fn falsifier_alibi_slopes_power_of_two_match_reference() {
+        // n=8: reference slopes are 2^(-1), 2^(-2), ..., 2^(-8).
+        let alibi = ALiBi::new(8).expect("8 heads is valid");
+        let slopes = alibi.slopes();
+        assert_eq!(slopes.len(), 8);
+
+        // Headline falsifier: head 0 must be 0.5, NOT the buggy 1.0.
+        assert!(
+            (slopes[0] - 0.5).abs() < 1e-7,
+            "PMAT-858: slopes[0] must be 0.5 (2^(-8/8)), got {} (buggy code yields 1.0)",
+            slopes[0]
+        );
+        // Last head: 2^(-8) = 0.003_906_25 (buggy code yields 2^(-7) = 0.007_812_5).
+        assert!(
+            (slopes[7] - 0.003_906_25).abs() < 1e-7,
+            "PMAT-858: slopes[7] must be 2^(-8) = 0.00390625, got {}",
+            slopes[7]
+        );
+
+        // Every head must match the closed-form reference exactly (within fp tol).
+        for (h, &s) in slopes.iter().enumerate() {
+            let want = reference_slope(h, 8);
+            assert!(
+                (s - want).abs() < 1e-7,
+                "PMAT-858: slopes[{h}] = {s}, reference 2^(-8(h+1)/8) = {want}"
+            );
+        }
+    }
+
+    #[test]
+    fn falsifier_alibi_slopes_single_head() {
+        // n=1: slope[0] = 2^(-8) (NOT 2^0 = 1.0).
+        let alibi = ALiBi::new(1).expect("1 head is valid");
+        let slopes = alibi.slopes();
+        assert_eq!(slopes.len(), 1);
+        assert!(
+            (slopes[0] - 0.003_906_25).abs() < 1e-7,
+            "PMAT-858: single-head slope must be 2^(-8) = 0.00390625, got {}",
+            slopes[0]
+        );
+    }
+
+    #[test]
+    fn falsifier_alibi_slopes_non_power_of_two_match_paper() {
+        // n=12 exercises the interpolation branch. The original ALiBi paper
+        // get_slopes(12) = get_slopes_power_of_2(8) followed by the even
+        // entries of get_slopes(16):
+        //   [2^-1, 2^-2, .., 2^-8, 2^-0.5, 2^-1.5, 2^-2.5, 2^-3.5]
+        let alibi = ALiBi::new(12).expect("12 heads is valid");
+        let slopes = alibi.slopes();
+        assert_eq!(slopes.len(), 12);
+
+        let expected: [f32; 12] = [
+            // power-of-2 block (closest_power_of_2 = 8): 2^(-8(h+1)/8)
+            0.5,
+            0.25,
+            0.125,
+            0.062_5,
+            0.031_25,
+            0.015_625,
+            0.007_812_5,
+            0.003_906_25,
+            // interpolation block: 2^(-4(2i+1)/8) = 2^(-(2i+1)/2)
+            2_f32.powf(-0.5),
+            2_f32.powf(-1.5),
+            2_f32.powf(-2.5),
+            2_f32.powf(-3.5),
+        ];
+        for (h, (&got, &want)) in slopes.iter().zip(expected.iter()).enumerate() {
+            assert!(
+                (got - want).abs() < 1e-6,
+                "PMAT-858: slopes[{h}] = {got}, paper get_slopes(12)[{h}] = {want}"
+            );
+        }
+
+        // First head of the power-of-2 block must still be 0.5, not 1.0.
+        assert!(
+            (slopes[0] - 0.5).abs() < 1e-7,
+            "PMAT-858: non-power-of-2 head 0 must be 0.5, got {}",
+            slopes[0]
+        );
+    }
+
+    #[test]
+    fn falsifier_alibi_slopes_strictly_below_one() {
+        // With the fix, no slope can be >= 1.0 (the buggy head-0 = 1.0 is gone).
+        for n in [1usize, 2, 4, 8, 12, 16, 32] {
+            let alibi = ALiBi::new(n).expect("valid head count");
+            for (h, &s) in alibi.slopes().iter().enumerate() {
+                assert!(s > 0.0, "PMAT-858: slope[{h}] (n={n}) must be > 0, got {s}");
+                assert!(
+                    s < 1.0,
+                    "PMAT-858: slope[{h}] (n={n}) must be < 1.0 (buggy head 0 = 1.0), got {s}"
+                );
+            }
+        }
     }
 }

--- a/crates/aprender-serve/src/layers/position_alibi_get.rs
+++ b/crates/aprender-serve/src/layers/position_alibi_get.rs
@@ -94,18 +94,19 @@ mod tests {
 
     #[test]
     fn test_alibi_non_power_of_two_slopes() {
-        // For 6 heads: closest power of 2 is 4
-        // First 4 slopes: 2^(-8h/4) = 2^(-2h) for h=0..4
-        // Extra 2 slopes: 2^(-(2h+1)*4/4) = 2^(-2h-1) for h=0..2
+        // PMAT-858: slope[h] = 2^(-8(h+1)/n) (Press et al. 2021 / llama.cpp ggml).
+        // For 6 heads: closest power of 2 is 4, ratio = 8/4 = 2.
+        // First 4 slopes: 2^(-2(h+1)) = [0.25, 0.0625, 0.015625, 0.00390625].
+        // Extra 2 slopes: 2^(-(2i+1) * 4/4) = 2^(-(2i+1)) = [0.5, 0.125].
         let alibi = ALiBi::new(6).expect("alibi");
         let slopes = alibi.slopes();
         assert_eq!(slopes.len(), 6);
-        // First 4: [1.0, 0.25, 0.0625, 0.015625]
-        assert!((slopes[0] - 1.0).abs() < 1e-6);
-        assert!((slopes[3] - 0.015625).abs() < 1e-6);
-        // Extra 2 have different computation
-        assert!(slopes[4] > 0.0);
-        assert!(slopes[5] > 0.0);
+        // Head 0 must be 0.25, NOT the buggy 1.0.
+        assert!((slopes[0] - 0.25).abs() < 1e-6);
+        assert!((slopes[3] - 0.003_906_25).abs() < 1e-6);
+        // Extra interpolation block.
+        assert!((slopes[4] - 0.5).abs() < 1e-6);
+        assert!((slopes[5] - 0.125).abs() < 1e-6);
     }
 include!("position_rope.rs");
 }

--- a/crates/aprender-serve/src/layers/position_rope.rs
+++ b/crates/aprender-serve/src/layers/position_rope.rs
@@ -425,23 +425,24 @@
     fn test_alibi_slopes_power_of_two() {
         let alibi = ALiBi::new(4).expect("alibi");
         let slopes = alibi.slopes();
-        // For n=4: m[h] = 2^(-8h/4) = 2^(-2h)
-        // slopes = [2^0, 2^-2, 2^-4, 2^-6] = [1.0, 0.25, 0.0625, 0.015625]
-        assert!((slopes[0] - 1.0).abs() < 1e-6);
-        assert!((slopes[1] - 0.25).abs() < 1e-6);
-        assert!((slopes[2] - 0.0625).abs() < 1e-6);
-        assert!((slopes[3] - 0.015625).abs() < 1e-6);
+        // PMAT-858: m[h] = 2^(-8(h+1)/n) (Press et al. 2021 / llama.cpp ggml).
+        // For n=4: m[h] = 2^(-2(h+1))
+        // slopes = [2^-2, 2^-4, 2^-6, 2^-8] = [0.25, 0.0625, 0.015625, 0.00390625]
+        assert!((slopes[0] - 0.25).abs() < 1e-6);
+        assert!((slopes[1] - 0.0625).abs() < 1e-6);
+        assert!((slopes[2] - 0.015625).abs() < 1e-6);
+        assert!((slopes[3] - 0.003_906_25).abs() < 1e-6);
     }
 
     #[test]
     fn test_alibi_slopes_8_heads() {
         let alibi = ALiBi::new(8).expect("alibi");
         let slopes = alibi.slopes();
-        // For n=8: m[h] = 2^(-8h/8) = 2^(-h)
-        // slopes[0] = 2^0 = 1.0
-        // slopes[1] = 2^-1 = 0.5
-        // slopes[7] = 2^-7 = 0.0078125
-        assert!((slopes[0] - 1.0).abs() < 1e-6);
-        assert!((slopes[1] - 0.5).abs() < 1e-6);
-        assert!((slopes[7] - 0.0078125).abs() < 1e-6);
+        // PMAT-858: m[h] = 2^(-8(h+1)/8) = 2^(-(h+1))
+        // slopes[0] = 2^-1 = 0.5 (NOT the buggy 2^0 = 1.0)
+        // slopes[1] = 2^-2 = 0.25
+        // slopes[7] = 2^-8 = 0.00390625
+        assert!((slopes[0] - 0.5).abs() < 1e-6);
+        assert!((slopes[1] - 0.25).abs() < 1e-6);
+        assert!((slopes[7] - 0.003_906_25).abs() < 1e-6);
     }

--- a/crates/aprender-serve/src/layers/tests/scaled_rope.rs
+++ b/crates/aprender-serve/src/layers/tests/scaled_rope.rs
@@ -182,15 +182,16 @@ fn test_alibi_zero_heads_error() {
 
 #[test]
 fn test_alibi_slopes_power_of_2() {
-    // For 8 heads (power of 2), slopes should follow: 2^(-8h/8) = 2^(-h)
+    // PMAT-858: m[h] = 2^(-8(h+1)/n) (Press et al. 2021 / llama.cpp ggml).
+    // For 8 heads (power of 2): 2^(-8(h+1)/8) = 2^(-(h+1))
     let alibi = ALiBi::new(8).expect("test");
     let slopes = alibi.slopes();
 
-    // Expected slopes: 2^0, 2^-1, 2^-2, 2^-3, 2^-4, 2^-5, 2^-6, 2^-7
-    assert!((slopes[0] - 1.0).abs() < 1e-6); // 2^0 = 1.0
-    assert!((slopes[1] - 0.5).abs() < 1e-6); // 2^-1 = 0.5
-    assert!((slopes[2] - 0.25).abs() < 1e-6); // 2^-2 = 0.25
-    assert!((slopes[3] - 0.125).abs() < 1e-6); // 2^-3 = 0.125
+    // Expected slopes: 2^-1, 2^-2, 2^-3, ..., 2^-8
+    assert!((slopes[0] - 0.5).abs() < 1e-6); // 2^-1 = 0.5 (NOT the buggy 1.0)
+    assert!((slopes[1] - 0.25).abs() < 1e-6); // 2^-2 = 0.25
+    assert!((slopes[2] - 0.125).abs() < 1e-6); // 2^-3 = 0.125
+    assert!((slopes[3] - 0.0625).abs() < 1e-6); // 2^-4 = 0.0625
 }
 
 #[test]
@@ -201,13 +202,13 @@ fn test_alibi_slopes_non_power_of_2() {
 
     assert_eq!(slopes.len(), 6);
 
-    // First 4 slopes follow 2^(-8h/4) = 2^(-2h)
-    assert!((slopes[0] - 1.0).abs() < 1e-6); // 2^0
-    assert!((slopes[1] - 0.25).abs() < 1e-6); // 2^-2
-    assert!((slopes[2] - 0.0625).abs() < 1e-6); // 2^-4
-    assert!((slopes[3] - 0.015_625).abs() < 1e-6); // 2^-6
+    // PMAT-858: first 4 slopes follow 2^(-8(h+1)/4) = 2^(-2(h+1))
+    assert!((slopes[0] - 0.25).abs() < 1e-6); // 2^-2 (NOT the buggy 1.0)
+    assert!((slopes[1] - 0.0625).abs() < 1e-6); // 2^-4
+    assert!((slopes[2] - 0.015_625).abs() < 1e-6); // 2^-6
+    assert!((slopes[3] - 0.003_906_25).abs() < 1e-6); // 2^-8
 
-    // Extra 2 slopes follow 2^(-4h/4) with step=2
+    // Extra 2 slopes follow 2^(-(2i+1)) with step=2
     // slopes[4] = 2^(-1) = 0.5
     // slopes[5] = 2^(-3) = 0.125
     assert!((slopes[4] - 0.5).abs() < 1e-6);
@@ -277,16 +278,17 @@ fn test_alibi_bias_computation() {
     let slopes = alibi.slopes();
     let bias = alibi.get_bias(3).expect("test");
 
-    // For 2 heads: slopes = [1.0, 0.0625]
-    // bias[0, 2, 0] = -slopes[0] * |0 - 2| = -1.0 * 2 = -2.0
+    // PMAT-858: For 2 heads, slopes = 2^(-4(h+1)) = [0.0625, 0.00390625]
+    // bias[0, 2, 0] = -slopes[0] * |0 - 2| = -0.0625 * 2 = -0.125
     let idx = 2 * 2;
+    let expected = -slopes[0] * 2.0;
     assert!(
-        (bias.data()[idx] - (-2.0)).abs() < 1e-6,
-        "Expected -2.0, got {}",
+        (bias.data()[idx] - expected).abs() < 1e-6,
+        "Expected {expected}, got {}",
         bias.data()[idx]
     );
 
-    // bias[1, 2, 1] = -slopes[1] * |1 - 2| = -0.0625 * 1 = -0.0625
+    // bias[1, 2, 1] = -slopes[1] * |1 - 2| = -slopes[1]
     let idx = 3 * 2 + 2 * 2 + 1;
     let expected = -slopes[1];
     assert!(
@@ -309,22 +311,18 @@ fn test_alibi_bias_negative() {
 
 #[test]
 fn test_alibi_bias_distance_proportional() {
-    // Bias should be proportional to distance
+    // Bias should be proportional to distance: bias[0, d] = -slope * d.
     let alibi = ALiBi::new(1).expect("test");
+    let slope = alibi.slopes()[0]; // PMAT-858: single head slope = 2^(-8) = 0.00390625
     let bias = alibi.get_bias(5).expect("test");
-
-    // For head 0, slope is 1.0
-    // bias[0, 1] = -1.0 * 1 = -1.0
-    // bias[0, 2] = -1.0 * 2 = -2.0
-    // bias[0, 3] = -1.0 * 3 = -3.0
 
     let bias_01 = bias.data()[1];
     let bias_02 = bias.data()[2];
     let bias_03 = bias.data()[3];
 
-    assert!((bias_01 - (-1.0)).abs() < 1e-6);
-    assert!((bias_02 - (-2.0)).abs() < 1e-6);
-    assert!((bias_03 - (-3.0)).abs() < 1e-6);
+    assert!((bias_01 - (-slope)).abs() < 1e-6);
+    assert!((bias_02 - (-slope * 2.0)).abs() < 1e-6);
+    assert!((bias_03 - (-slope * 3.0)).abs() < 1e-6);
 }
 
 #[test]
@@ -332,7 +330,8 @@ fn test_alibi_single_head() {
     let alibi = ALiBi::new(1).expect("test");
     assert_eq!(alibi.num_heads(), 1);
     assert_eq!(alibi.slopes().len(), 1);
-    assert!((alibi.slopes()[0] - 1.0).abs() < 1e-6); // First slope is 2^0 = 1.0
+    // PMAT-858: single-head slope is 2^(-8(0+1)/1) = 2^-8 = 0.00390625 (NOT 2^0 = 1.0).
+    assert!((alibi.slopes()[0] - 0.003_906_25).abs() < 1e-6);
 }
 
 #[test]
@@ -347,8 +346,8 @@ fn test_alibi_large_num_heads() {
         assert!(*slope > 0.0, "Slope should be positive, got {slope}");
     }
 
-    // First head should have largest slope (1.0)
-    assert!((alibi.slopes()[0] - 1.0).abs() < 1e-6);
+    // PMAT-858: head 0 of the power-of-2 block has slope 2^(-8/8) = 0.5 (NOT 1.0).
+    assert!((alibi.slopes()[0] - 0.5).abs() < 1e-6);
 }
 
 #[test]


### PR DESCRIPTION
ALiBi `compute_slopes` used `2^(-8h/n)` so head 0 had slope 1.0 (one extra factor of m0 per head) vs the Press et al. 2021 / llama.cpp ggml formula `2^(-8(h+1)/n)`. For n=8: slopes[0] 1.0->0.5, slopes[7] 0.0078125->0.00390625. One-line exponent fix `-(i)` -> `-((i+1))`.

Falsifier RED slopes[0]=1.0 -> GREEN 0.5; matches paper get_slopes for n in {1,2,4,5,6,8,12,16}. 6 sibling tests corrected. `cargo test -p aprender-serve --lib` -> 15434/0. `contracts/alibi-slopes-v1.yaml` pv-valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)