### PR TITLE
fix(format): SafeTensors BF16 export truncated instead of round-to-nearest-even + NaN->Inf (PMAT-859)

### DIFF
--- a/contracts/safetensors-bf16-round-v1.yaml
+++ b/contracts/safetensors-bf16-round-v1.yaml
@@ -1,0 +1,95 @@
+metadata:
+  version: "1.0.0"
+  created: "2026-06-19"
+  author: PAIML Engineering
+  registry: true
+  references:
+    - "IEEE 754-2019 §4.3.1 roundTiesToEven (the default rounding-direction attribute)"
+    - "half::bf16::from_f32 (Rust `half` crate, round-to-nearest-even reference oracle; pinned dev-dependency)"
+    - "PyTorch torch.Tensor.bfloat16() / aten bf16 cast (round-to-nearest-even)"
+    - "HuggingFace safetensors BF16 serialization (round-to-nearest-even, NaN-preserving)"
+  description: |
+    Correctness contract for f32 -> BF16 (brain-float-16) encoding in the
+    SafeTensors export path
+    (aprender-core crates/aprender-core/src/serialization/safetensors.rs
+    f32_slice_to_bf16_bytes, reached from `apr export --format safetensors`
+    via encode_tensor_for_dtype for tensors whose dtype is BF16).
+
+    PMAT-859: the prior implementation encoded by pure truncation
+    (`let bf16 = (bits >> 16) as u16;`). This is NOT the IEEE / PyTorch /
+    HF-safetensors behavior. Two defects followed:
+      (1) every value was biased toward zero — e.g. f32 0x3F81_C000, whose
+          discarded low half (0xC000) is above the halfway point, must round
+          UP to 0x3F82 but truncation produced 0x3F81;
+      (2) an f32 NaN whose only set mantissa bits live in the low 16 bits
+          (e.g. 0x7F80_0001) silently became +Inf, because truncation kept an
+          all-ones exponent with a zero mantissa.
+    The fix performs round-to-nearest-even and preserves NaN, matching
+    half::bf16::from_f32.
+
+kind: KernelContract
+name: safetensors-bf16-round
+version: "1.0.0"
+scope: "crates/aprender-core/src/serialization/safetensors.rs"
+
+description: |
+  BF16 occupies the high 16 bits of an f32. Correct encoding is
+  round-to-nearest-even (the IEEE-754 default), implemented as
+
+      rounding_bias = 0x7FFF + ((bits >> 16) & 1)        // 0x7FFF, +1 if kept-lsb is odd
+      bf16          = ((bits + rounding_bias) >> 16) as u16   // for finite, non-NaN
+      bf16(NaN)     = ((bits >> 16) as u16) | 0x0040          // force a mantissa bit
+
+  The `| 0x0040` guarantees the retained 16-bit pattern keeps a non-zero
+  mantissa, so a NaN stays NaN instead of collapsing to Inf.
+
+equations:
+  C-BF16-001:
+    description: "f32 -> BF16 is round-to-nearest-even, matching half::bf16::from_f32 for every finite input"
+    formula: "bf16(x) = half::bf16::from_f32(x).to_bits() ; e.g. bf16(f32 0x3F81_C000) = 0x3F82 (truncation gives 0x3F81)"
+    note: "The all-zero-low-half (already-exact) case is necessary but NOT sufficient — it is exactly what the truncation bug left correct. The falsifier MUST exercise a non-zero low half (0xC000)."
+  C-BF16-002:
+    description: "Round-to-nearest-even ties (low half == 0x8000) round to the even kept value"
+    formula: "bf16(0x3F80_8000) = 0x3F80 (kept lsb even, stays) ; bf16(0x3F81_8000) = 0x3F82 (kept lsb odd, rounds up)"
+    note: "Distinguishes round-to-nearest-even from round-half-up; both tie cases are structural and oracle-independent."
+  C-BF16-003:
+    description: "NaN is preserved across the cast — a NaN f32 encodes to a NaN BF16, never Inf"
+    formula: "x.is_nan()  =>  decode_bf16(bf16(x)).is_nan() ∧ ¬decode_bf16(bf16(x)).is_infinite() ; e.g. x = f32 0x7F80_0001"
+    note: "RED on the truncation bug, which dropped the only mantissa bit (low 16 bits) and produced +Inf (0x7F80)."
+
+proof_obligations:
+- type: equivalence
+  property: "BF16 encoding equals the half::bf16 round-to-nearest-even oracle"
+  formal: "∀ finite x: f32_slice_to_bf16_bytes([x])[0..2] == half::bf16::from_f32(x).to_le_bytes()"
+  applies_to: all
+- type: bound
+  property: "Round-to-nearest-even error is at most half a BF16 ulp"
+  formal: "|decode_bf16(bf16(x)) - x| ≤ 0.5 ulp_bf16(x) for finite x (truncation can reach a full ulp)"
+  tolerance: 0.0
+  applies_to: finite
+- type: invariant
+  property: "NaN preservation (no NaN -> Inf collapse)"
+  formal: "x.is_nan() ⇒ decode_bf16(bf16(x)).is_nan()"
+  applies_to: nan
+- type: roundtrip
+  property: "Already-exact BF16 values are unchanged (no spurious round-up from the bias)"
+  formal: "(x.to_bits() & 0x0000_FFFF) == 0 ⇒ bf16(x) == (x.to_bits() >> 16) as u16"
+  applies_to: exact
+
+falsification:
+  - id: FALSIFY-BF16-ROUND-001
+    description: "Round-to-nearest-even: f32 0x3F81_C000 must encode to 0x3F82, not the truncated 0x3F81. Discharges C-BF16-001."
+    test: "test_bf16_round_to_nearest_even_falsifier — RED 0x3F81 (truncation) -> GREEN 0x3F82 (round-to-nearest-even)."
+    evidence: "cargo test -p aprender-core --lib test_bf16_round_to_nearest_even_falsifier"
+  - id: FALSIFY-BF16-ROUND-002
+    description: "Tie-to-even: 0x3F80_8000 stays 0x3F80 (even) and 0x3F81_8000 rounds up to 0x3F82 (odd). Discharges C-BF16-002."
+    test: "test_bf16_round_to_nearest_even_halfway_to_even — RED 0x3F81 for the odd tie -> GREEN 0x3F82."
+    evidence: "cargo test -p aprender-core --lib test_bf16_round_to_nearest_even_halfway_to_even"
+  - id: FALSIFY-BF16-NAN-001
+    description: "NaN preservation: f32 0x7F80_0001 (NaN, mantissa only in low 16 bits) must stay NaN, not become Inf. Discharges C-BF16-003."
+    test: "test_bf16_preserves_nan_not_inf — RED bf16 0x7F80 decodes to +Inf -> GREEN 0x7FC0 decodes to NaN."
+    evidence: "cargo test -p aprender-core --lib test_bf16_preserves_nan_not_inf"
+  - id: FALSIFY-BF16-PARITY-001
+    description: "2048-sample sweep over mixed exponent/mantissa bit patterns matches half::bf16::from_f32 bit-for-bit. Discharges C-BF16-001 (oracle parity)."
+    test: "test_bf16_parity_with_half_crate (feature = format-quantize) — every sample's BF16 bits equal half::bf16::from_f32(v).to_bits()."
+    evidence: "cargo test -p aprender-core --lib --features format-quantize test_bf16_parity_with_half_crate"

--- a/crates/aprender-core/src/serialization/safetensors.rs
+++ b/crates/aprender-core/src/serialization/safetensors.rs
@@ -229,16 +229,34 @@ pub fn save_safetensors_with_metadata<P: AsRef<Path>>(
     Ok(())
 }
 
-/// PMAT-260: Serialize F32 data as BF16 bytes.
+/// PMAT-260 / PMAT-859: Serialize F32 data as BF16 bytes.
 ///
 /// BF16 is the upper 16 bits of F32. For data that originated as BF16,
-/// the F32 representation has zeros in the lower 16 bits, so this
-/// truncation is lossless.
+/// the F32 representation has zeros in the lower 16 bits, so this is
+/// lossless.
+///
+/// PMAT-859: Earlier this function truncated (`(bits >> 16) as u16`), which
+/// (a) biased every value toward zero — not the IEEE / PyTorch / HF-safetensors
+/// behavior — and (b) silently turned f32 NaNs whose mantissa bits live only
+/// in the low 16 bits into +/-Inf. It now performs round-to-nearest-even and
+/// preserves NaN, matching `half::bf16::from_f32`.
+///
+/// Round-to-nearest-even adds a bias of `0x7FFF + (lsb of the kept half)` before
+/// the shift; this rounds halfway cases to even (the IEEE-754 default). NaN is
+/// preserved by forcing a mantissa bit in the retained half so the result stays
+/// NaN rather than collapsing to Inf.
 fn f32_slice_to_bf16_bytes(data: &[f32]) -> Vec<u8> {
     let mut bytes = Vec::with_capacity(data.len() * 2);
     for &value in data {
         let bits = value.to_bits();
-        let bf16 = (bits >> 16) as u16;
+        let bf16 = if value.is_nan() {
+            // Force a mantissa bit in the retained half so NaN stays NaN, not Inf.
+            ((bits >> 16) as u16) | 0x0040
+        } else {
+            // Round-to-nearest-even: bias by 0x7FFF plus the lsb of the kept half.
+            let rounding_bias = 0x7FFF + ((bits >> 16) & 1);
+            ((bits + rounding_bias) >> 16) as u16
+        };
         bytes.extend_from_slice(&bf16.to_le_bytes());
     }
     bytes

--- a/crates/aprender-core/src/serialization/safetensors_tests_core.rs
+++ b/crates/aprender-core/src/serialization/safetensors_tests_core.rs
@@ -432,3 +432,127 @@ fn test_get_tensor_raw_f32() {
 
     fs::remove_file(path).ok();
 }
+
+// ====================================================================
+// PMAT-859: f32 -> BF16 round-to-nearest-even + NaN preservation
+//
+// Falsifiers for the export encoding bug. The previous implementation
+// truncated (`(bits >> 16) as u16`), biasing every value low and turning
+// f32 NaNs whose mantissa bits live only in the low 16 bits into +/-Inf.
+// Correct behavior matches IEEE / PyTorch / HF-safetensors / half::bf16.
+// ====================================================================
+
+/// Read the first little-endian u16 produced by `f32_slice_to_bf16_bytes`.
+fn bf16_first_u16(bytes: &[u8]) -> u16 {
+    u16::from_le_bytes([bytes[0], bytes[1]])
+}
+
+/// Decode a BF16 bit pattern back into f32 (BF16 occupies the high 16 bits).
+fn bf16_bits_to_f32(bf16: u16) -> f32 {
+    f32::from_bits((bf16 as u32) << 16)
+}
+
+#[test]
+fn test_bf16_round_to_nearest_even_falsifier() {
+    // 0x3F81_C000: the discarded low half is 0xC000 (> 0x8000), so the
+    // correct round-to-nearest result is 0x3F82, NOT 0x3F81 (truncation).
+    let input = f32::from_bits(0x3F81_C000);
+    let bytes = super::super::f32_slice_to_bf16_bytes(&[input]);
+    let bf16 = bf16_first_u16(&bytes);
+    assert_eq!(
+        bf16, 0x3F82,
+        "round-to-nearest-even expected 0x3F82, got {bf16:#06X} \
+         (truncation bug yields 0x3F81)"
+    );
+}
+
+#[test]
+fn test_bf16_round_to_nearest_even_halfway_to_even() {
+    // Exact halfway (low half == 0x8000) ties to even.
+    // 0x3F80_8000: kept lsb is 0 (even) -> stays 0x3F80.
+    let down = super::super::f32_slice_to_bf16_bytes(&[f32::from_bits(0x3F80_8000)]);
+    assert_eq!(
+        bf16_first_u16(&down),
+        0x3F80,
+        "tie-to-even (even kept) stays"
+    );
+    // 0x3F81_8000: kept lsb is 1 (odd) -> rounds up to even 0x3F82.
+    let up = super::super::f32_slice_to_bf16_bytes(&[f32::from_bits(0x3F81_8000)]);
+    assert_eq!(
+        bf16_first_u16(&up),
+        0x3F82,
+        "tie-to-even (odd kept) rounds up"
+    );
+}
+
+#[test]
+fn test_bf16_preserves_nan_not_inf() {
+    // A signaling NaN whose mantissa bit lives only in the low 16 bits.
+    // Truncation drops it -> exponent all-ones + zero mantissa == +Inf.
+    // The fix must keep it a NaN.
+    let nan = f32::from_bits(0x7F80_0001);
+    assert!(nan.is_nan(), "test input must be NaN");
+    let bytes = super::super::f32_slice_to_bf16_bytes(&[nan]);
+    let decoded = bf16_bits_to_f32(bf16_first_u16(&bytes));
+    assert!(
+        decoded.is_nan(),
+        "NaN must survive BF16 encoding (truncation produced Inf): bits {:#06X}",
+        bf16_first_u16(&bytes)
+    );
+    assert!(!decoded.is_infinite(), "NaN must not become Inf");
+}
+
+#[test]
+fn test_bf16_exact_values_lossless() {
+    // Values that already fit in BF16 (zero low half) are unchanged and
+    // are NOT pushed up by the rounding bias.
+    for &(bits, expected) in &[
+        (0x3F80_0000u32, 0x3F80u16), // 1.0
+        (0x4000_0000, 0x4000),       // 2.0
+        (0x0000_0000, 0x0000),       // +0.0
+        (0x8000_0000, 0x8000),       // -0.0
+        (0xBF80_0000, 0xBF80),       // -1.0
+    ] {
+        let bytes = super::super::f32_slice_to_bf16_bytes(&[f32::from_bits(bits)]);
+        assert_eq!(
+            bf16_first_u16(&bytes),
+            expected,
+            "exact BF16 value {bits:#010X} must round-trip to {expected:#06X}"
+        );
+    }
+}
+
+#[test]
+fn test_bf16_infinity_preserved() {
+    let pos_inf = super::super::f32_slice_to_bf16_bytes(&[f32::INFINITY]);
+    assert_eq!(bf16_first_u16(&pos_inf), 0x7F80, "+Inf -> 0x7F80");
+    let neg_inf = super::super::f32_slice_to_bf16_bytes(&[f32::NEG_INFINITY]);
+    assert_eq!(bf16_first_u16(&neg_inf), 0xFF80, "-Inf -> 0xFF80");
+}
+
+#[cfg(feature = "format-quantize")]
+#[test]
+fn test_bf16_parity_with_half_crate() {
+    // Oracle parity against half::bf16::from_f32 (round-to-nearest-even).
+    // Sweep a deterministic range of representative bit patterns.
+    let samples: Vec<f32> = (0..2048)
+        .map(|i| {
+            // Mix exponent and mantissa bits to exercise rounding boundaries.
+            let bits = ((i as u32) << 13) ^ 0x3F00_0000;
+            f32::from_bits(bits)
+        })
+        .filter(|v| !v.is_nan() && v.is_finite())
+        .collect();
+
+    let bytes = super::super::f32_slice_to_bf16_bytes(&samples);
+    for (idx, &v) in samples.iter().enumerate() {
+        let ours = u16::from_le_bytes([bytes[idx * 2], bytes[idx * 2 + 1]]);
+        let oracle = half::bf16::from_f32(v).to_bits();
+        assert_eq!(
+            ours,
+            oracle,
+            "BF16 parity mismatch for f32 {:#010X}: ours {ours:#06X}, half {oracle:#06X}",
+            v.to_bits()
+        );
+    }
+}


### PR DESCRIPTION
`f32_slice_to_bf16_bytes` (reached by `apr export --format safetensors` for BF16 tensors) cast f32->bf16 by pure truncation: every value biased toward zero, and f32 NaN silently became +Inf. Fixed to round-to-nearest-even (`0x7FFF + ((bits>>16)&1)`) + NaN guard (`|0x0040`), bit-matching `half::bf16::from_f32`.

Falsifier RED 0x3F81 / NaN->Inf -> GREEN 0x3F82 / NaN preserved; 2048-sample parity vs `half`. `cargo test -p aprender-core --lib` -> 13923/0. `contracts/safetensors-bf16-round-v1.yaml` pv-valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)