### PR TITLE
fix(graph): Brandes betweenness counted the source's own dependency — every score wrong (PMAT-860)

### DIFF
--- a/contracts/graph-centrality-v1.yaml
+++ b/contracts/graph-centrality-v1.yaml
@@ -1,5 +1,5 @@
 metadata:
-  version: 1.0.0
+  version: 1.1.0
   created: '2026-02-19'
   author: PAIML Engineering
   description: Graph centrality measures — node importance in network structures
@@ -150,6 +150,15 @@ falsification_tests:
   prediction: x_v > 0 for all v when β > 0 and α < 1/λ_max
   test: proptest with random graphs, α drawn below spectral radius inverse
   if_fails: Attenuation factor α too large or β=0 edge case
+- id: FALSIFY-GC-009
+  rule: Betweenness pendant is zero
+  prediction: C_B(v) = 0 for every pendant (degree-1) node; path 0-1-2 yields
+    [0,1,0] and star K_{1,3} yields [3,0,0,0] under networkx
+    betweenness_centrality(G, normalized=False)
+  test: graph::tests::core::betweenness_pendant_must_be_zero
+  if_fails: Brandes accumulation is missing the `if w != s` source guard, so each
+    BFS source adds its own δ_s(s) and pendant nodes get nonzero betweenness
+    (PMAT-860)
 kani_harnesses:
 - id: KANI-GC-001
   obligation: '1'

--- a/crates/aprender-core/src/graph/centrality.rs
+++ b/crates/aprender-core/src/graph/centrality.rs
@@ -372,6 +372,13 @@ fn brandes_bfs_from_source(graph: &Graph, source: NodeId) -> Vec<f64> {
         }
     }
 
+    // PMAT-860: canonical Brandes (2001) accumulates `C_B[w] += δ_s(w)` only for
+    // `w != s`. The source's own dependency δ_s(s) is never part of any
+    // betweenness sum, so zero it before returning this per-source partial.
+    // Without this guard, pendant (degree-1) nodes get nonzero betweenness
+    // (e.g. path 0-1-2 endpoints would be 1.0 instead of networkx's 0.0).
+    dependency[source] = 0.0;
+
     dependency
 }
 

--- a/crates/aprender-core/src/graph/tests/core.rs
+++ b/crates/aprender-core/src/graph/tests/core.rs
@@ -378,6 +378,61 @@ fn test_betweenness_centrality_disconnected() {
     assert!((bc[2] - bc[3]).abs() < 1e-6);
 }
 
+#[test]
+fn betweenness_pendant_must_be_zero() {
+    // PMAT-860: canonical Brandes (2001) guards `if w != s` when accumulating
+    // dependency, so a BFS source never adds its own δ_s(s). Without that guard,
+    // pendant (degree-1) nodes receive nonzero betweenness. networkx
+    // betweenness_centrality(G, normalized=False) is the reference.
+
+    // Path 0 -- 1 -- 2: endpoints are pendant -> 0, middle lies on the only
+    // shortest path between the endpoints -> 1. networkx: [0.0, 1.0, 0.0].
+    let path = Graph::from_edges(&[(0, 1), (1, 2)], false);
+    let bc = path.betweenness_centrality();
+    assert_eq!(bc.len(), 3);
+    assert!(
+        (bc[0] - 0.0).abs() < 1e-9,
+        "pendant node 0 must be 0, got {}",
+        bc[0]
+    );
+    assert!(
+        (bc[1] - 1.0).abs() < 1e-9,
+        "middle node must be 1, got {}",
+        bc[1]
+    );
+    assert!(
+        (bc[2] - 0.0).abs() < 1e-9,
+        "pendant node 2 must be 0, got {}",
+        bc[2]
+    );
+
+    // Star K_{1,3}: center on every leaf-leaf shortest path -> 3, leaves pendant
+    // -> 0. networkx: [3.0, 0.0, 0.0, 0.0].
+    let star = Graph::from_edges(&[(0, 1), (0, 2), (0, 3)], false);
+    let bc = star.betweenness_centrality();
+    assert_eq!(bc.len(), 4);
+    assert!(
+        (bc[0] - 3.0).abs() < 1e-9,
+        "star center must be 3, got {}",
+        bc[0]
+    );
+    assert!(
+        (bc[1] - 0.0).abs() < 1e-9,
+        "leaf 1 must be 0, got {}",
+        bc[1]
+    );
+    assert!(
+        (bc[2] - 0.0).abs() < 1e-9,
+        "leaf 2 must be 0, got {}",
+        bc[2]
+    );
+    assert!(
+        (bc[3] - 0.0).abs() < 1e-9,
+        "leaf 3 must be 0, got {}",
+        bc[3]
+    );
+}
+
 // Community Detection Tests
 
 #[test]


### PR DESCRIPTION
betweenness_centrality summed each BFS source dependency vector INCLUDING the source itself (missing Brandes 2001 `if w != s` guard), so degree-1 pendant nodes got nonzero betweenness. Path 0-1-2: apr [1,2,1] vs networkx [0,1,0]; star K1,3: apr [4.5,1.5,1.5,1.5] vs [3,0,0,0]. Fix: zero `dependency[source]` before return.

Falsifier RED endpoint=1.0 -> GREEN [0,1,0]/[3,0,0,0] (networkx parity). 13919/0. contracts/graph-centrality-v1.yaml -> 1.1.0, pv-valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)