### PR TITLE
fix(text): TfidfVectorizer omitted L2 row normalization (sklearn default norm=l2) (PMAT-861)

### DIFF
--- a/contracts/tfidf-l2-norm-v1.yaml
+++ b/contracts/tfidf-l2-norm-v1.yaml
@@ -94,34 +94,31 @@ falsification_tests:
   - id: FALSIFY-TFIDF_L2_NORM_V1_001
     rule: "Default fit_transform of ['a b','a c'] yields sklearn norm='l2' values for row 'a b'"
     prediction: "row 'a b' = [0.5797387, 0.8148025, 0.0] (±1e-5)"
-    test: |
-      cargo test -p aprender-core --lib \
-        text::vectorize::tests::test_tfidf_l2_normalization_sklearn_parity_pmat861
-      # RED (raw tf*idf, normalization disabled): row0[a] = 1.0 (panic: expected 0.5797387)
-      # GREEN (L2-normalized): row0[a] = 0.5797387, row0[b] = 0.8148025, row0[c] = 0.0
-      # sklearn reference: TfidfVectorizer(token_pattern=r'\b\w+\b').fit_transform(['a b','a c'])
+    test: "cargo test -p aprender-core --lib text::vectorize::tests::test_tfidf_l2_normalization_sklearn_parity_pmat861"
+    notes: |
+      RED (raw tf*idf, normalization disabled): row0[a] = 1.0 (panic: expected 0.5797387).
+      GREEN (L2-normalized): row0[a] = 0.5797387, row0[b] = 0.8148025, row0[c] = 0.0.
+      sklearn reference: TfidfVectorizer(token_pattern=r'\b\w+\b').fit_transform(['a b','a c']).
     if_fails: "Output rows are not L2-normalized; apr diverges from sklearn TfidfVectorizer default"
   - id: FALSIFY-TFIDF_L2_NORM_V1_002
     rule: "Every non-zero document row has unit L2 norm under the default norm"
     prediction: "sqrt(Σ row²) = 1.0 (±1e-6) for each row of ['a b','a c']"
-    test: |
-      Same unit test asserts, for every row, sqrt(Σ_c X[r][c]²) ≈ 1.0.
+    test: "cargo test -p aprender-core --lib text::vectorize::tests::test_tfidf_l2_normalization_sklearn_parity_pmat861"
+    notes: |
+      The same parity test also asserts, for every row, sqrt(Σ_c X[r][c]²) ≈ 1.0.
       RED (raw): row L2 = 1.724915 (panic). GREEN: 1.0.
     if_fails: "Rows are not unit-length; cosine similarity / classification parity with sklearn breaks"
   - id: FALSIFY-TFIDF_L2_NORM_V1_003
     rule: "Norm::None reproduces raw tf*idf (sklearn norm=None) — the documented escape hatch"
     prediction: "with_norm(Norm::None) row 'a b' = [1.0, 1.4054651, 0.0] (±1e-6), L2 norm = 1.724915"
-    test: |
-      cargo test -p aprender-core --lib \
-        text::vectorize::tests::test_tfidf_norm_none_matches_raw_tfidf_pmat861
-      # sklearn reference: TfidfVectorizer(norm=None) = [1.0, 1.40546511, 0.0]
+    test: "cargo test -p aprender-core --lib text::vectorize::tests::test_tfidf_norm_none_matches_raw_tfidf_pmat861"
+    notes: |
+      sklearn reference: TfidfVectorizer(norm=None) = [1.0, 1.40546511, 0.0].
     if_fails: "Norm::None does not match sklearn norm=None raw weighting; idf/tf computation regressed"
   - id: FALSIFY-TFIDF_L2_NORM_V1_004
     rule: "Norm::L1 yields rows whose absolute values sum to 1 (sklearn norm='l1')"
     prediction: "Σ_c |X[r][c]| = 1.0 (±1e-6) for every non-zero row under Norm::L1"
-    test: |
-      cargo test -p aprender-core --lib \
-        text::vectorize::tests::test_tfidf_norm_l1_unit_sum_pmat861
+    test: "cargo test -p aprender-core --lib text::vectorize::tests::test_tfidf_norm_l1_unit_sum_pmat861"
     if_fails: "L1 normalization divisor is wrong; norm='l1' parity with sklearn broken"
 
 status_history:

--- a/contracts/tfidf-l2-norm-v1.yaml
+++ b/contracts/tfidf-l2-norm-v1.yaml
@@ -1,0 +1,141 @@
+metadata:
+  version: "1.0.0"
+  created: "2026-06-19"
+  author: PAIML Engineering
+  registry: true
+  references:
+    - "scikit-learn sklearn.feature_extraction.text.TfidfVectorizer — norm='l2' is the DEFAULT; output rows are L2-normalized to unit length"
+    - "scikit-learn TfidfVectorizer = CountVectorizer + TfidfTransformer; TfidfTransformer applies sklearn.preprocessing.normalize(X, norm) after tf*idf weighting"
+    - "scikit-learn sklearn.preprocessing.normalize — norm='l2' divides each row by sqrt(Σ xᵢ²); norm='l1' by Σ|xᵢ|; norm=None leaves raw values"
+    - "Manning, Raghavan & Schütze (2008) Introduction to Information Retrieval §6.3 — cosine normalization of tf-idf document vectors"
+    - "PMAT-861 — apr's TfidfVectorizer::transform emitted raw tf*idf with NO normalization (no `norm` field, no sqrt/L2 code), diverging from sklearn's norm='l2' default"
+  description: "TfidfVectorizer output rows must be L2-normalized by default to match scikit-learn's norm='l2' default (each document vector has unit Euclidean length)"
+
+kind: KernelContract
+name: tfidf-l2-norm
+version: "1.0.0"
+scope: "crates/aprender-core/src/text/vectorize/tfidf_vectorizer.rs::Norm + hashing_vectorizer.rs::TfidfVectorizer::{new,with_norm,transform}"
+
+description: |
+  PMAT-861 (Pillar-1 sklearn-parity correctness beat). `TfidfVectorizer::transform`
+  built each output row as raw `tf * idf` and returned it directly — there was no
+  `norm` field on the struct and no L2/sqrt normalization code anywhere in the
+  transform path. scikit-learn's `TfidfVectorizer` defaults to `norm='l2'`:
+  after tf*idf weighting, every document row is divided by its Euclidean norm so
+  the row has unit length (cosine-ready). apr therefore produced numerically
+  different TF-IDF features than sklearn for the IDENTICAL inputs and settings,
+  silently breaking downstream similarity/classification parity.
+
+  The `smooth_idf` computation (`idf = ln((N+1)/(df+1)) + 1`) was already correct
+  and is unchanged; only the missing row normalization was the defect.
+
+  ## Repro
+  docs = ["a b", "a c"], whitespace tokenizer, vocab {a:0, b:1, c:2},
+  idf = [1.0, 1.40546511, 1.40546511].
+    - apr (pre-fix, raw tf*idf):  row "a b" = [1.0,        1.4054651,  0.0]   (L2 norm = 1.724915)
+    - sklearn (norm='l2', default): row "a b" = [0.5797387, 0.8148025, 0.0]   (L2 norm = 1.0)
+  0.5797387 = 1.0 / 1.724915 ; 0.8148025 = 1.4054651 / 1.724915.
+
+  ## Fix
+  Added a `Norm` enum (`L2` default, plus `L1` and `None`) and a `norm: Norm`
+  field on `TfidfVectorizer` (defaulted to `Norm::L2` in `new()`), with a
+  `with_norm(norm)` builder. `transform()` now builds each row's tf*idf values,
+  computes the row scale (`L2 = sqrt(Σ xᵢ²)`, `L1 = Σ|xᵢ|`, `None = 1`), and
+  divides each element by the scale (skipping division when scale == 0 to leave
+  an all-zero row untouched). `Norm::None` reproduces sklearn `norm=None` =
+  apr's old raw values, used by the sublinear-TF unit test that observes raw
+  magnitudes.
+
+equations:
+  C-tfidf-row:
+    description: "Each document row is tf*idf weighted, then L2-normalized (sklearn norm='l2' default)"
+    formula: |
+      let wᵢ = tf_i · idf_i                                  (tf weighting; sublinear tf optional)
+      row(L2) = w / ‖w‖₂   where ‖w‖₂ = sqrt( Σ_i wᵢ² ),   if ‖w‖₂ > 0 else w
+      ⇒ ‖row(L2)‖₂ = 1  for every non-zero document row
+  C-tfidf-norm-variants:
+    description: "Norm strategy selects the row divisor (sklearn norm parameter)"
+    formula: |
+      scale(L2)   = sqrt( Σ_i wᵢ² )      (Euclidean)   → ‖row‖₂ = 1
+      scale(L1)   = Σ_i |wᵢ|             (Manhattan)   → Σ_i |row_i| = 1
+      scale(None) = 1                    (raw tf*idf, sklearn norm=None)
+      row_i = wᵢ / scale   (scale>0); else row_i = wᵢ
+  C-tfidf-idf-unchanged:
+    description: "smooth IDF is unchanged by this fix"
+    formula: |
+      idf_i = ln( (N + 1) / (df_i + 1) ) + 1     (N = #docs, df_i = #docs containing term i)
+
+proof_obligations:
+  - type: equivalence
+    property: "Default TfidfVectorizer output equals scikit-learn TfidfVectorizer (norm='l2') row-for-row"
+    formal: |
+      For docs = ["a b","a c"] with a whitespace tokenizer, the default
+      (norm=L2) fit_transform row for "a b" equals
+      [0.5797387, 0.8148025, 0.0] (±1e-5) at vocab indices (a,b,c),
+      matching sklearn TfidfVectorizer(token_pattern=r'\b\w+\b').fit_transform.
+  - type: invariant
+    property: "Every non-zero document row has unit L2 norm under the default norm=L2"
+    formal: |
+      ∀ row r with at least one non-zero entry:
+      sqrt( Σ_c transform(docs)[r][c]² ) = 1  (±1e-6).
+      All-zero rows (no in-vocabulary terms) are left untouched (scale skipped).
+  - type: equivalence
+    property: "Norm::None reproduces the pre-fix raw tf*idf values (sklearn norm=None)"
+    formal: |
+      with_norm(Norm::None).fit_transform(["a b","a c"]) row "a b" =
+      [1.0, 1.4054651, 0.0] (±1e-6); its L2 norm = 1.724915 — the divisor the
+      default L2 path applies.
+  - type: invariant
+    property: "Norm::L1 yields rows whose absolute values sum to 1 (sklearn norm='l1')"
+    formal: |
+      ∀ non-zero row r under Norm::L1: Σ_c |transform(docs)[r][c]| = 1 (±1e-6).
+
+falsification_tests:
+  - id: FALSIFY-TFIDF_L2_NORM_V1_001
+    rule: "Default fit_transform of ['a b','a c'] yields sklearn norm='l2' values for row 'a b'"
+    prediction: "row 'a b' = [0.5797387, 0.8148025, 0.0] (±1e-5)"
+    test: |
+      cargo test -p aprender-core --lib \
+        text::vectorize::tests::test_tfidf_l2_normalization_sklearn_parity_pmat861
+      # RED (raw tf*idf, normalization disabled): row0[a] = 1.0 (panic: expected 0.5797387)
+      # GREEN (L2-normalized): row0[a] = 0.5797387, row0[b] = 0.8148025, row0[c] = 0.0
+      # sklearn reference: TfidfVectorizer(token_pattern=r'\b\w+\b').fit_transform(['a b','a c'])
+    if_fails: "Output rows are not L2-normalized; apr diverges from sklearn TfidfVectorizer default"
+  - id: FALSIFY-TFIDF_L2_NORM_V1_002
+    rule: "Every non-zero document row has unit L2 norm under the default norm"
+    prediction: "sqrt(Σ row²) = 1.0 (±1e-6) for each row of ['a b','a c']"
+    test: |
+      Same unit test asserts, for every row, sqrt(Σ_c X[r][c]²) ≈ 1.0.
+      RED (raw): row L2 = 1.724915 (panic). GREEN: 1.0.
+    if_fails: "Rows are not unit-length; cosine similarity / classification parity with sklearn breaks"
+  - id: FALSIFY-TFIDF_L2_NORM_V1_003
+    rule: "Norm::None reproduces raw tf*idf (sklearn norm=None) — the documented escape hatch"
+    prediction: "with_norm(Norm::None) row 'a b' = [1.0, 1.4054651, 0.0] (±1e-6), L2 norm = 1.724915"
+    test: |
+      cargo test -p aprender-core --lib \
+        text::vectorize::tests::test_tfidf_norm_none_matches_raw_tfidf_pmat861
+      # sklearn reference: TfidfVectorizer(norm=None) = [1.0, 1.40546511, 0.0]
+    if_fails: "Norm::None does not match sklearn norm=None raw weighting; idf/tf computation regressed"
+  - id: FALSIFY-TFIDF_L2_NORM_V1_004
+    rule: "Norm::L1 yields rows whose absolute values sum to 1 (sklearn norm='l1')"
+    prediction: "Σ_c |X[r][c]| = 1.0 (±1e-6) for every non-zero row under Norm::L1"
+    test: |
+      cargo test -p aprender-core --lib \
+        text::vectorize::tests::test_tfidf_norm_l1_unit_sum_pmat861
+    if_fails: "L1 normalization divisor is wrong; norm='l1' parity with sklearn broken"
+
+status_history:
+  - version: "1.0.0"
+    date: "2026-06-19"
+    pr: "paiml/aprender fix/pmat-861-tfidf-l2-normalization"
+    summary: |
+      Initial contract registered alongside the PMAT-861 fix. RED proven by
+      disabling the normalization branch: fit_transform(['a b','a c']) row 'a b'
+      = [1.0, 1.4054651, 0.0] (raw tf*idf, row L2 = 1.724915) — panics against
+      the sklearn norm='l2' reference [0.5797387, 0.8148025, 0.0]. GREEN after
+      adding the Norm enum + norm:L2 default + per-row L2 division in transform():
+      row 'a b' = [0.5797387, 0.8148025, 0.0], every non-zero row L2 norm = 1.0.
+      Norm::None restores sklearn norm=None raw values; Norm::L1 gives unit-L1
+      rows. Four falsification unit tests added in text::vectorize::tests; the
+      pre-existing sublinear-TF test was repointed to Norm::None (it observes raw
+      magnitudes, which L2 normalization collapses to 1.0 for single-term docs).

--- a/crates/aprender-core/src/text/vectorize/hashing_vectorizer.rs
+++ b/crates/aprender-core/src/text/vectorize/hashing_vectorizer.rs
@@ -15,6 +15,7 @@ impl TfidfVectorizer {
             count_vectorizer: CountVectorizer::new(),
             idf_values: Vec::new(),
             sublinear_tf: false,
+            norm: Norm::L2,
         }
     }
 
@@ -24,6 +25,25 @@ impl TfidfVectorizer {
     #[must_use]
     pub fn with_sublinear_tf(mut self, enable: bool) -> Self {
         self.sublinear_tf = enable;
+        self
+    }
+
+    /// Set the row normalization strategy (sklearn `norm`, default L2).
+    ///
+    /// scikit-learn's `TfidfVectorizer` defaults to `norm='l2'`, dividing each
+    /// document row by its Euclidean norm so rows have unit length. Pass
+    /// [`Norm::None`] to obtain raw `tf * idf` values.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use aprender::text::vectorize::{Norm, TfidfVectorizer};
+    ///
+    /// let vectorizer = TfidfVectorizer::new().with_norm(Norm::None);
+    /// ```
+    #[must_use]
+    pub fn with_norm(mut self, norm: Norm) -> Self {
+        self.norm = norm;
         self
     }
 
@@ -234,13 +254,17 @@ impl TfidfVectorizer {
         // Get count matrix (TF)
         let tf_matrix = self.count_vectorizer.transform(documents)?;
 
-        // Apply IDF weighting with optional sublinear TF scaling
+        // Apply IDF weighting with optional sublinear TF scaling, then
+        // normalize each document row per the configured strategy (sklearn
+        // `TfidfVectorizer` defaults to `norm='l2'`).
         let n_docs = tf_matrix.n_rows();
         let vocab_size = tf_matrix.n_cols();
         let mut tfidf_data = Vec::with_capacity(n_docs * vocab_size);
+        let mut row_values = vec![0.0_f64; vocab_size];
 
         for row in 0..n_docs {
-            for col in 0..vocab_size {
+            // Build the raw tf * idf row.
+            for (col, value) in row_values.iter_mut().enumerate() {
                 let raw_tf = tf_matrix.get(row, col);
                 // Apply sublinear TF: tf = 1 + log(tf) if tf > 0
                 let tf = if self.sublinear_tf && raw_tf > 0.0 {
@@ -248,9 +272,23 @@ impl TfidfVectorizer {
                 } else {
                     raw_tf
                 };
-                let idf = self.idf_values[col];
-                tfidf_data.push(tf * idf);
+                *value = tf * self.idf_values[col];
             }
+
+            // Normalize the row in place (skip when the norm is zero to avoid
+            // dividing an all-zero row by zero).
+            let scale = match self.norm {
+                Norm::L2 => row_values.iter().map(|x| x * x).sum::<f64>().sqrt(),
+                Norm::L1 => row_values.iter().map(|x| x.abs()).sum::<f64>(),
+                Norm::None => 1.0,
+            };
+            if self.norm != Norm::None && scale > 0.0 {
+                for value in &mut row_values {
+                    *value /= scale;
+                }
+            }
+
+            tfidf_data.extend_from_slice(&row_values);
         }
 
         Matrix::from_vec(n_docs, vocab_size, tfidf_data)

--- a/crates/aprender-core/src/text/vectorize/tests.rs
+++ b/crates/aprender-core/src/text/vectorize/tests.rs
@@ -118,12 +118,18 @@ fn test_max_df_filtering() {
 fn test_sublinear_tf() {
     let docs = vec!["word word word word"]; // word appears 4 times
 
-    let mut vectorizer_normal =
-        TfidfVectorizer::new().with_tokenizer(Box::new(WhitespaceTokenizer::new()));
+    // Use norm=None so the raw tf*idf magnitudes are observable. With the
+    // default L2 normalization a single-term document always collapses to a
+    // unit-length row (1.0), masking the sublinear-TF dampening this test
+    // exercises (PMAT-861).
+    let mut vectorizer_normal = TfidfVectorizer::new()
+        .with_tokenizer(Box::new(WhitespaceTokenizer::new()))
+        .with_norm(Norm::None);
 
     let mut vectorizer_sublinear = TfidfVectorizer::new()
         .with_tokenizer(Box::new(WhitespaceTokenizer::new()))
-        .with_sublinear_tf(true);
+        .with_sublinear_tf(true)
+        .with_norm(Norm::None);
 
     let matrix_normal = vectorizer_normal
         .fit_transform(&docs)
@@ -422,6 +428,120 @@ fn test_count_vectorizer_default() {
 fn test_tfidf_vectorizer_default() {
     let vectorizer = TfidfVectorizer::default();
     assert!(!vectorizer.sublinear_tf);
+    // sklearn parity: default normalization is L2 (PMAT-861).
+    assert_eq!(vectorizer.norm, Norm::L2);
+}
+
+/// PMAT-861 falsifier: `TfidfVectorizer` must L2-normalize each output row
+/// to match scikit-learn's `TfidfVectorizer` default (`norm='l2'`).
+///
+/// Reference (scikit-learn, `token_pattern=r'\b\w+\b'`):
+/// ```text
+/// docs = ["a b", "a c"]              vocab: a=0, b=1, c=2
+/// idf_ = [1.0, 1.40546511, 1.40546511]
+/// X (norm='l2'):  row "a b" = [0.57973867, 0.81480247, 0.0]
+/// X (norm=None):  row "a b" = [1.0,        1.40546511, 0.0]   (apr's old buggy output)
+/// ```
+///
+/// RED (pre-fix, raw tf*idf): row = [1.0, 1.4054651, 0.0], L2 norm = 1.7249.
+/// GREEN (L2-normalized):     row = [0.5797387, 0.8148025, 0.0], L2 norm = 1.0.
+#[test]
+fn test_tfidf_l2_normalization_sklearn_parity_pmat861() {
+    let docs = vec!["a b", "a c"];
+
+    let mut vectorizer =
+        TfidfVectorizer::new().with_tokenizer(Box::new(WhitespaceTokenizer::new()));
+
+    let matrix = vectorizer
+        .fit_transform(&docs)
+        .expect("fit_transform should succeed");
+
+    // Vocabulary is frequency-then-alphabetical: a(2), b(1), c(1) -> a=0, b=1, c=2.
+    let vocab = vectorizer.vocabulary();
+    let a = *vocab.get("a").expect("vocab has 'a'");
+    let b = *vocab.get("b").expect("vocab has 'b'");
+    let c = *vocab.get("c").expect("vocab has 'c'");
+
+    // Row 0 = "a b": sklearn norm='l2' reference values.
+    assert!(
+        (matrix.get(0, a) - 0.5797387).abs() < 1e-5,
+        "row0[a] = {} (expected 0.5797387)",
+        matrix.get(0, a)
+    );
+    assert!(
+        (matrix.get(0, b) - 0.8148025).abs() < 1e-5,
+        "row0[b] = {} (expected 0.8148025)",
+        matrix.get(0, b)
+    );
+    assert!(
+        matrix.get(0, c).abs() < 1e-5,
+        "row0[c] = {} (expected 0.0)",
+        matrix.get(0, c)
+    );
+
+    // Every row must have unit L2 norm (the defining property of norm='l2').
+    for row in 0..matrix.n_rows() {
+        let l2: f64 = (0..matrix.n_cols())
+            .map(|col| matrix.get(row, col).powi(2))
+            .sum::<f64>()
+            .sqrt();
+        assert!(
+            (l2 - 1.0).abs() < 1e-6,
+            "row {row} L2 norm = {l2} (expected 1.0)"
+        );
+    }
+}
+
+/// PMAT-861: `Norm::None` reproduces the pre-fix raw `tf * idf` values, matching
+/// scikit-learn `TfidfVectorizer(norm=None)`.
+#[test]
+fn test_tfidf_norm_none_matches_raw_tfidf_pmat861() {
+    let docs = vec!["a b", "a c"];
+
+    let mut vectorizer = TfidfVectorizer::new()
+        .with_tokenizer(Box::new(WhitespaceTokenizer::new()))
+        .with_norm(Norm::None);
+
+    let matrix = vectorizer
+        .fit_transform(&docs)
+        .expect("fit_transform should succeed");
+
+    let vocab = vectorizer.vocabulary();
+    let a = *vocab.get("a").expect("vocab has 'a'");
+    let b = *vocab.get("b").expect("vocab has 'b'");
+
+    // Raw tf*idf: tf=1, idf(a)=1.0, idf(b)=ln(3/2)+1=1.4054651.
+    assert!((matrix.get(0, a) - 1.0).abs() < 1e-6);
+    assert!((matrix.get(0, b) - 1.4054651).abs() < 1e-6);
+
+    // The raw row's L2 norm is the 1.7249 divisor used by the L2 path.
+    let l2: f64 = (0..matrix.n_cols())
+        .map(|col| matrix.get(0, col).powi(2))
+        .sum::<f64>()
+        .sqrt();
+    assert!((l2 - 1.724915).abs() < 1e-4, "raw row0 L2 = {l2}");
+}
+
+/// PMAT-861: `Norm::L1` divides each row by the sum of absolute values, giving
+/// rows whose absolute values sum to 1 (sklearn `norm='l1'`).
+#[test]
+fn test_tfidf_norm_l1_unit_sum_pmat861() {
+    let docs = vec!["a b", "a c"];
+
+    let mut vectorizer = TfidfVectorizer::new()
+        .with_tokenizer(Box::new(WhitespaceTokenizer::new()))
+        .with_norm(Norm::L1);
+
+    let matrix = vectorizer
+        .fit_transform(&docs)
+        .expect("fit_transform should succeed");
+
+    for row in 0..matrix.n_rows() {
+        let l1: f64 = (0..matrix.n_cols())
+            .map(|col| matrix.get(row, col).abs())
+            .sum();
+        assert!((l1 - 1.0).abs() < 1e-6, "row {row} L1 sum = {l1}");
+    }
 }
 
 #[test]

--- a/crates/aprender-core/src/text/vectorize/tfidf_vectorizer.rs
+++ b/crates/aprender-core/src/text/vectorize/tfidf_vectorizer.rs
@@ -423,6 +423,29 @@ impl Default for CountVectorizer {
 /// let matrix = vectorizer.fit_transform(&docs).expect("fit_transform should succeed");
 /// assert_eq!(matrix.n_rows(), 2);  // 2 documents
 /// ```
+/// Row normalization strategy for TF-IDF output (sklearn-compatible).
+///
+/// Matches scikit-learn's `TfidfVectorizer` `norm` parameter. After each
+/// document row is built as `tf * idf`, the row is rescaled according to
+/// this strategy:
+///
+/// - [`Norm::L2`] (default): divide by the Euclidean norm so each row has
+///   unit length (`sqrt(Σ x²) == 1`). This is scikit-learn's default.
+/// - [`Norm::L1`]: divide by the sum of absolute values (`Σ |x|`).
+/// - [`Norm::None`]: leave raw `tf * idf` values (sklearn `norm=None`).
+///
+/// Rows whose norm is zero are left untouched (no division by zero).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Norm {
+    /// L2 (Euclidean) normalization — unit-length rows. scikit-learn default.
+    #[default]
+    L2,
+    /// L1 (Manhattan) normalization — rows sum to 1 in absolute value.
+    L1,
+    /// No normalization — raw `tf * idf` values.
+    None,
+}
+
 #[allow(missing_debug_implementations)]
 pub struct TfidfVectorizer {
     /// Count vectorizer for term frequencies
@@ -431,4 +454,6 @@ pub struct TfidfVectorizer {
     idf_values: Vec<f64>,
     /// Use sublinear TF scaling: tf = 1 + log(tf) if tf > 0
     sublinear_tf: bool,
+    /// Row normalization strategy (sklearn `norm`, default L2)
+    norm: Norm,
 }


### PR DESCRIPTION
TfidfVectorizer::transform returned raw tf*idf with no normalization; sklearn defaults to norm=l2 (unit-length rows). docs=[\"a b\",\"a c\"]: apr row [1.0,1.4055,0] vs sklearn [0.5797,0.8148,0]. Added Norm enum (L2 default/L1/None) + per-row normalization.

Falsifier RED raw -> GREEN L2 (sklearn parity, uv-verified). 13921/0. contracts/tfidf-l2-norm-v1.yaml pv-valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)