### PR TITLE
fix(time_series): ARIMA AR coefficients estimated on uncentered data — forecasts diverge ~2x (PMAT-862)

### DIFF
--- a/contracts/arima-ar-centering-v1.yaml
+++ b/contracts/arima-ar-centering-v1.yaml
@@ -1,0 +1,204 @@
+metadata:
+  version: 1.0.0
+  created: '2026-06-19'
+  author: PAIML Engineering
+  description: |
+    ARIMA(p,0,q) AR-coefficient estimation MUST use the MEAN-CENTERED
+    Box-Jenkins model `y_t - mu = sum_k phi_k (y_{t-k} - mu) + e_t`, matching
+    statsmodels `ARIMA(order=(p,0,q))`, which fits the demeaned series.
+
+    PMAT-862 (HIGH severity correctness): `ARIMA::estimate_ar_parameters`
+    estimated coefficients on the UNCENTERED levels:
+      phi_lag = sum_i y_i * y_{i-1-lag} / sum_i (y_{i-1-lag})^2
+    For a stationary series with nonzero mean mu, BOTH sums are dominated by
+    n*mu^2, so every coefficient collapsed to ~1.0 regardless of the true
+    autocorrelation. Combined with a constant term stored as `mu` (rather
+    than `mu*(1 - sum phi_k)`), `ARIMA(1,0,0)` one-step forecasts diverged to
+    ~2x the series level.
+
+    Fix: center the lagged products in estimate_ar_parameters,
+      phi_lag = sum (y_i - mu)(y_{i-1-lag} - mu) / sum (y_{i-1-lag} - mu)^2,
+    and store the constant as `mu*(1 - sum phi_k)` so the forecast loop
+    `intercept + sum phi_k * y_{t-1-k}` equals `mu + sum phi_k (y_{t-1-k} - mu)`.
+
+    This is a distinct defect from PMAT-834 (reverse-differencing seeding for
+    d >= 2); the d >= 1 differencing/integration path is unchanged (for the
+    differenced series mu ~= 0, so mu*(1 - sum phi) ~= mu).
+  references:
+  - 'Box, Jenkins, Reinsel (2015) Time Series Analysis: Forecasting and Control -- ARMA mean-centering'
+  - 'statsmodels.tsa.arima.model.ARIMA(order=(p,0,q)) -- fits the demeaned model'
+  - 'PMAT-862 (this contract): ARIMA AR estimation on uncentered levels collapses phi to ~1.0'
+  - 'PMAT-834 (arima-v1.yaml FALSIFY-ARIMA-INTEGRATE-D2) -- the distinct reverse-differencing defect'
+
+kind: KernelContract
+name: arima-ar-centering
+version: 1.0.0
+scope: aprender-core time_series ARIMA::estimate_ar_parameters + fit (constant term) + forecast
+
+equations:
+  C-AR-CENTERED-PHI:
+    formula: |
+      phi_lag = sum_{i>lag} (y_i - mu)(y_{i-1-lag} - mu)
+                / sum_{i>lag} (y_{i-1-lag} - mu)^2,
+      where mu = (1/n) sum_i y_i.
+    domain: y in R^n (stationary working series), n > lag + 1, mu in R
+    codomain: phi_lag in R (the demeaned least-squares AR coefficient)
+    invariants:
+    - AR coefficients are estimated on the MEAN-CENTERED series, never on raw levels
+    - 'For a stationary AR(1) with true phi in (-1, 1), the estimated phi stays away from 1.0
+      regardless of the series mean (a nonzero mean must NOT push phi toward 1.0)'
+    - Centering is mean-translation-invariant by construction (y_i - mu unaffected by adding a constant to all y)
+    preconditions:
+    - input.len() > 1
+    - input.iter().all(|v| v.is_finite())
+  C-AR-FORECAST-CENTERED:
+    formula: |
+      y_hat_{n+1} = mu + sum_{k=1}^{p} phi_k (y_{n+1-k} - mu)
+                  = mu*(1 - sum_k phi_k) + sum_{k=1}^{p} phi_k * y_{n+1-k}.
+    domain: fitted ARIMA(p,0,q), phi in R^p, y in R^n, mu in R
+    codomain: y_hat_{n+1} in R
+    invariants:
+    - 'The stored constant term equals mu*(1 - sum_k phi_k), NOT mu'
+    - 'For a stationary series the one-step forecast sits near the series level:
+      |y_hat_{n+1} - mu| < 0.5 * (max(y) - min(y))'
+    - Forecast equals the Box-Jenkins demeaned prediction mu + sum phi_k (y_{n+1-k} - mu)
+    preconditions:
+    - input.len() > 0
+    - input.iter().all(|v| v.is_finite())
+
+proof_obligations:
+- type: invariant
+  property: AR coefficients estimated on mean-centered data
+  formal: |
+    For every working series y with mean mu, estimate_ar_parameters computes
+    phi_lag = sum (y_i - mu)(y_{i-1-lag} - mu) / sum (y_{i-1-lag} - mu)^2.
+    Adding any constant c to every y_i leaves every phi_lag unchanged
+    (mean-translation invariance), so a nonzero series mean cannot bias phi toward 1.0.
+- type: bound
+  property: stationary AR(1) coefficient stays away from 1.0
+  formal: |
+    For a stationary AR(1) series with true phi = 0.5 and mean ~50 (range ~5),
+    the estimated AR(1) coefficient satisfies |phi - 0.37| < 0.05 and phi < 0.9.
+    (Demeaned OLS phi_hat = 0.370; statsmodels ARIMA(1,0,0) ar.L1 = 0.364.)
+- type: invariant
+  property: forecast constant reflects mean-centering
+  formal: |
+    The stored intercept equals mu*(1 - sum_k phi_k) so that the forecast loop
+    intercept + sum_k phi_k * y_{n+1-k} = mu + sum_k phi_k (y_{n+1-k} - mu).
+- type: bound
+  property: one-step forecast sits near the series level
+  formal: |
+    For a stationary series with mean mu and range R = max(y) - min(y),
+    the ARIMA(p,0,q) one-step forecast satisfies |y_hat_{n+1} - mu| < 0.5 * R.
+    (Pre-fix the forecast was ~2x the level, violating this bound.)
+- type: invariant
+  property: d >= 1 differencing/integration path unchanged
+  formal: |
+    For d >= 1 the working series is the d-th difference (mu ~= 0), so
+    mu*(1 - sum phi) ~= mu and the integrate/seed path (PMAT-834) is unaffected.
+
+falsification_tests:
+- id: FALSIFY-ARIMA-AR-CENTERING-COEF
+  rule: AR(1) coefficient equals the demeaned phi, not ~1.0
+  prediction: |
+    On a deterministic stationary AR(1) series with mu ~= 49.84, true phi = 0.5,
+    range ~= 4.74 (statsmodels seed 7), `ARIMA::new(1,0,0).fit(...)` yields an
+    AR(1) coefficient ~= 0.370 (demeaned OLS phi_hat; statsmodels ar.L1 = 0.364),
+    satisfying |phi - 0.37| < 0.05.
+    RED (pre-fix, uncentered): coef ~= 1.0000619 (collapsed to 1.0).
+    GREEN (post-fix, centered): coef ~= 0.370.
+  if_fails: |
+    AR coefficients are being estimated on UNCENTERED levels (sum y_i*y_{i-1-lag}
+    / sum y_{i-1-lag}^2), so for a nonzero-mean series the coefficient collapses
+    to ~1.0. Center the products in estimate_ar_parameters.
+  test: 'cargo test -p aprender-core --lib falsify_arima_ar_centering_nonzero_mean_ar1'
+  evidence: |
+    crates/aprender-core/src/time_series/tests_arima_contract.rs
+    ::falsify_arima_ar_centering_nonzero_mean_ar1 (coef assertion; RED pre-fix, GREEN post-fix)
+- id: FALSIFY-ARIMA-AR-CENTERING-FORECAST
+  rule: ARIMA(1,0,0) one-step forecast sits near the series level, not ~2x it
+  prediction: |
+    On the same series (mu ~= 49.84, range ~= 4.74), the one-step forecast is
+    ~= 50.30 (statsmodels reference 50.30), satisfying |forecast - mean| < 0.5*range.
+    RED (pre-fix): forecast ~= 100.93 (~2x level). GREEN (post-fix): ~= 50.30.
+  if_fails: |
+    The constant term is stored as mu instead of mu*(1 - sum phi_k), and/or AR
+    coefficients collapsed to ~1.0, so the forecast diverges to ~2x the level.
+  test: 'cargo test -p aprender-core --lib falsify_arima_ar_centering_nonzero_mean_ar1'
+  evidence: |
+    crates/aprender-core/src/time_series/tests_arima_contract.rs
+    ::falsify_arima_ar_centering_nonzero_mean_ar1 (forecast band assertion)
+- id: FALSIFY-ARIMA-AR-CENTERING-STATSMODELS
+  rule: forecast matches the statsmodels ARIMA(1,0,0) reference
+  prediction: |
+    The one-step forecast equals the statsmodels `ARIMA(order=(1,0,0))` reference
+    value 50.30 to within +/-0.5 on the seed-7 series.
+  if_fails: |
+    The fitted constant or AR coefficient diverges from the Box-Jenkins demeaned
+    model that statsmodels implements.
+  test: 'cargo test -p aprender-core --lib falsify_arima_ar_centering_nonzero_mean_ar1'
+  evidence: |
+    crates/aprender-core/src/time_series/tests_arima_contract.rs
+    ::falsify_arima_ar_centering_nonzero_mean_ar1 (statsmodels reference assertion)
+- id: FALSIFY-ARIMA-AR-MEAN-INVARIANCE
+  rule: AR coefficient is mean-translation-invariant
+  prediction: |
+    Estimating phi on y and on y + c (constant shift) gives the same coefficient,
+    because the products use (y_i - mu); a nonzero series mean cannot push phi
+    toward 1.0.
+  if_fails: |
+    AR estimation depends on the absolute level (uncentered), so adding a constant
+    to the series changes phi -- the hallmark of the uncentered defect.
+  test: 'cargo test -p aprender-core --lib falsify_arima_ar_centering_nonzero_mean_ar1'
+  evidence: |
+    crates/aprender-core/src/time_series/tests_arima_contract.rs
+    ::falsify_arima_ar_centering_nonzero_mean_ar1 (coef ~= true phi for mean ~50 series)
+- id: FALSIFY-ARIMA-AR-CENTERING-D-PRESERVED
+  rule: d >= 1 differencing/integration path is unchanged
+  prediction: |
+    ARIMA(0,2,0) on the quadratic series [10,20,35,55,80] still forecasts ~110
+    (PMAT-834 behavior) -- the mean-centering change does not regress the
+    integrate/seed path because the differenced series has mu ~= 0.
+  if_fails: |
+    The constant-term change leaked into the d >= 1 path and broke reverse
+    differencing.
+  test: 'cargo test -p aprender-core --lib falsify_arima_integrate_d2_seeds_intermediate_difference'
+  evidence: |
+    crates/aprender-core/src/time_series/tests_arima_contract.rs
+    ::falsify_arima_integrate_d2_seeds_intermediate_difference (still GREEN post-fix)
+
+kani_harnesses:
+- id: KANI-ARIMA-CENTER-001
+  obligation: AR coefficients estimated on mean-centered data
+  property: AR estimation is mean-translation-invariant (phi unchanged by adding a constant to y)
+  bound: 8
+  strategy: stub_float
+  solver: cadical
+  harness: verify_ar_centering_translation_invariant
+- id: KANI-ARIMA-CENTER-002
+  obligation: forecast constant reflects mean-centering
+  property: stored constant equals mu*(1 - sum phi_k) so forecast = mu + sum phi_k (y - mu)
+  bound: 8
+  strategy: stub_float
+  solver: cadical
+  harness: verify_forecast_constant_mean_centered
+
+enforcement:
+  ar_mean_centering:
+    description: AR coefficients must be estimated on the mean-centered series
+    check: contract_tests::FALSIFY-ARIMA-AR-CENTERING
+    severity: ERROR
+  forecast_near_level:
+    description: ARIMA(p,0,q) one-step forecast must sit near the series level, not ~2x it
+    check: contract_tests::FALSIFY-ARIMA-AR-CENTERING
+    severity: ERROR
+
+qa_gate:
+  id: F-ARIMA-CENTER-001
+  name: ARIMA AR Mean-Centering Contract
+  description: ARIMA(p,0,q) AR estimation + forecast must use the demeaned Box-Jenkins model
+  checks:
+  - ar_mean_centering
+  - forecast_near_level
+  pass_criteria: FALSIFY-ARIMA-AR-CENTERING passes (coef ~= true phi, forecast ~= level)
+  falsification: AR estimated on uncentered levels -> phi ~= 1.0 -> forecast diverges to ~2x level

--- a/crates/aprender-core/src/time_series/mod.rs
+++ b/crates/aprender-core/src/time_series/mod.rs
@@ -179,8 +179,20 @@ impl ARIMA {
             self.ma_coef = Some(self.estimate_ma_parameters(&working_data)?);
         }
 
-        // Calculate intercept (mean of stationary series)
-        self.intercept = working_data.as_slice().iter().sum::<f64>() / working_data.len() as f64;
+        // Calculate the constant term for the mean-centered AR model (PMAT-862,
+        // contract arima-ar-centering-v1). Box-Jenkins fits y_t - mu = sum phi_k (y_{t-k} - mu),
+        // i.e. y_t = mu*(1 - sum phi_k) + sum phi_k * y_{t-k}. The forecast loop adds
+        // `self.intercept + sum ar_coef[k]*y_{t-1-k}`, so the stored constant must be
+        // `mu * (1 - sum phi_k)`, NOT mu alone. With the previous `intercept = mu` and AR coefs
+        // that summed to ~1.0 on uncentered data, forecasts diverged to ~2x the series level.
+        // For the differenced (d >= 1) path mu ~= 0, so mu*(1 - sum phi) ~= mu and the integrated
+        // forecast path is unchanged.
+        let mu = working_data.as_slice().iter().sum::<f64>() / working_data.len() as f64;
+        let phi_sum: f64 = self
+            .ar_coef
+            .as_ref()
+            .map_or(0.0, |c| c.as_slice().iter().sum());
+        self.intercept = mu * (1.0 - phi_sum);
 
         // Calculate residuals for MA component
         self.residuals = Some(self.calculate_residuals(&working_data)?);
@@ -314,21 +326,35 @@ impl ARIMA {
     }
 
     /// Estimate AR parameters using simplified Yule-Walker equations.
+    ///
+    /// Box-Jenkins / statsmodels `ARIMA(order=(p,0,q))` fit the MEAN-CENTERED model
+    /// `y_t - mu = sum_k phi_k (y_{t-k} - mu) + e_t`. The coefficients must therefore be
+    /// estimated on the demeaned series:
+    /// `phi = sum (y_i - mu)(y_{i-1-lag} - mu) / sum (y_{i-1-lag} - mu)^2`.
+    /// Estimating on the raw (uncentered) levels makes both sums dominated by `n * mu^2` for a
+    /// series with nonzero mean, collapsing every coefficient to ~1.0 regardless of the true
+    /// autocorrelation — which in turn drives ARIMA(p,0,q) forecasts to ~2x the series level
+    /// (PMAT-862, contract arima-ar-centering-v1).
     #[allow(clippy::unnecessary_wraps)]
     fn estimate_ar_parameters(&self, data: &Vector<f64>) -> Result<Vector<f64>, AprenderError> {
-        // Simplified: use least squares on lagged values
+        // Simplified: least squares on the MEAN-CENTERED lagged values (Box-Jenkins).
         let n = data.len();
         let mut coefs = vec![0.1; self.p]; // Initialize with small values
 
-        // Simple estimation: use autocorrelations
+        // Mean-center the series before forming the lagged products/sums.
+        let mu = data.as_slice().iter().sum::<f64>() / n as f64;
+
+        // Simple estimation: use (centered) autocorrelations
         for lag in 0..self.p {
             if n > lag + 1 {
                 let mut sum_prod = 0.0;
                 let mut sum_sq = 0.0;
 
                 for i in (lag + 1)..n {
-                    sum_prod += data[i] * data[i - lag - 1];
-                    sum_sq += data[i - lag - 1] * data[i - lag - 1];
+                    let x_t = data[i] - mu;
+                    let x_lag = data[i - lag - 1] - mu;
+                    sum_prod += x_t * x_lag;
+                    sum_sq += x_lag * x_lag;
                 }
 
                 if sum_sq > 1e-10 {

--- a/crates/aprender-core/src/time_series/tests_arima_contract.rs
+++ b/crates/aprender-core/src/time_series/tests_arima_contract.rs
@@ -157,3 +157,64 @@ fn falsify_arima_integrate_d2_seeds_intermediate_difference() {
         f[0]
     );
 }
+
+/// FALSIFY-ARIMA-AR-CENTERING (PMAT-862, contract arima-ar-centering-v1):
+/// `ARIMA(p,0,q)` must fit the MEAN-CENTERED Box-Jenkins model
+/// `y_t - mu = sum phi_k (y_{t-k} - mu) + e_t`. The buggy code estimated AR coefficients on the
+/// UNCENTERED levels: `phi = sum y_i*y_{i-1-lag} / sum y_{i-1-lag}^2`. For a stationary series with
+/// nonzero mean mu, both sums are dominated by `n*mu^2`, so every coefficient collapsed to ~1.0
+/// regardless of the true autocorrelation, and `ARIMA(1,0,0)` 1-step forecasts diverged to ~2x the
+/// series level.
+///
+/// Series: a deterministic stationary AR(1) with mu ~= 49.84, true phi = 0.5 (mild positive
+/// autocorrelation), range ~= 4.74 (generated with statsmodels, seed 7).
+///   RED  (uncentered): coef ~= 1.0000, 1-step forecast ~= 100.93 (~2x level).
+///   GREEN (centered) : coef ~= 0.370 (demeaned OLS phi_hat), 1-step forecast ~= 50.30 (~level).
+/// statsmodels `ARIMA(order=(1,0,0))` reference on the same series: ar.L1 = 0.364, forecast = 50.30.
+#[test]
+fn falsify_arima_ar_centering_nonzero_mean_ar1() {
+    // Deterministic stationary AR(1), mu ~= 50, phi = 0.5 (statsmodels seed 7).
+    let series = [
+        50.0, 49.5341, 49.7999, 50.3074, 49.3648, 49.6845, 49.8413, 48.1659, 50.1006, 50.6508,
+        49.7, 49.6784, 50.3445, 49.9109, 49.7127, 48.4031, 49.7561, 50.0019, 50.2754, 48.6112,
+        50.9563, 50.6325, 49.9291, 51.9936, 50.9514, 49.025, 49.1073, 47.2653, 49.6821, 49.4246,
+        48.9697, 50.5573, 48.6276, 49.8492, 47.8602, 48.2679, 47.9297, 50.4269, 51.9796, 50.6604,
+        51.1709, 50.4055, 50.7708, 49.6326, 48.1079, 47.2509, 49.0086, 51.7519, 51.1453, 50.0481,
+        51.9361, 51.2053, 50.7041, 50.6046, 50.1699, 49.7755, 48.4528, 49.728, 49.7692, 51.0777,
+    ];
+    let data = Vector::from_slice(&series);
+
+    let n = series.len() as f64;
+    let mean: f64 = series.iter().sum::<f64>() / n;
+    let range = series.iter().copied().fold(f64::NEG_INFINITY, f64::max)
+        - series.iter().copied().fold(f64::INFINITY, f64::min);
+
+    let mut arima = ARIMA::new(1, 0, 0);
+    arima.fit(&data).expect("fit");
+
+    // The estimated AR(1) coefficient must be the true (centered) phi, NOT ~1.0.
+    let phi = arima.ar_coefficients().expect("ar coef present").as_slice()[0];
+    assert!(
+        (phi - 0.37).abs() < 0.05,
+        "FALSIFIED ARIMA-AR-CENTERING: AR(1) coef {phi} (expected demeaned phi_hat ~0.37, statsmodels 0.364). \
+         coef ~= 1.0 means AR was estimated on UNCENTERED levels."
+    );
+    assert!(
+        phi < 0.9,
+        "FALSIFIED ARIMA-AR-CENTERING: AR(1) coef {phi} collapsed toward 1.0 — AR estimated on uncentered data."
+    );
+
+    // The 1-step forecast must sit near the series level, NOT ~2x it.
+    let fc = arima.forecast(1).expect("forecast")[0];
+    assert!(
+        (fc - mean).abs() < 0.5 * range,
+        "FALSIFIED ARIMA-AR-CENTERING: 1-step forecast {fc} diverged from level (mean {mean}, range {range}); \
+         band |fc - mean| < 0.5*range = {}. Pre-fix forecast ~100.93 (~2x level).",
+        0.5 * range
+    );
+    // statsmodels ARIMA(1,0,0) reference forecast on this series is 50.30.
+    assert!(
+        (fc - 50.30).abs() < 0.5,
+        "FALSIFIED ARIMA-AR-CENTERING: 1-step forecast {fc} != statsmodels reference 50.30 (+/-0.5)."
+    );
+}


### PR DESCRIPTION
ARIMA estimate_ar_parameters computed AR coefs on uncentered levels; for nonzero-mean series both sums are dominated by mu^2 so coefs collapse to ~1.0 and ARIMA(p,0,q) forecasts diverge to ~2x the level. Fixed to Box-Jenkins mean-centered estimation + mu*(1-sum_phi) intercept.

Falsifier RED coef 1.0/forecast 100.9 -> GREEN coef 0.37/forecast 50.3 (statsmodels ARIMA(1,0,0) parity). 13919/0. contracts/arima-ar-centering-v1.yaml pv-valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)