### PR TITLE
fix(bayesian): logistic MAP averaged only data term by n — converged to n*lambda precision mode (PMAT-864)

### DIFF
--- a/contracts/bayesian-logistic-map-v1.yaml
+++ b/contracts/bayesian-logistic-map-v1.yaml
@@ -1,0 +1,141 @@
+metadata:
+  version: 1.0.0
+  created: '2026-06-19'
+  author: PAIML Engineering
+  description: |
+    Bayesian Logistic Regression (Laplace approximation) MAP gradient/Hessian
+    must target the SAME posterior at the DECLARED prior precision λ.
+
+    BayesianLogisticRegression::fit finds the MAP β by gradient ascent on the
+    un-normalized log-posterior
+
+        ℓ(β) = Σ_i [ y_i log p_i + (1−y_i) log(1−p_i) ] − (λ/2)‖β‖²,
+        p_i = σ(x_iᵀ β),
+
+    whose gradient is ∇ℓ = Xᵀ(y − p) − λβ, and then builds the Laplace
+    covariance from the Hessian of the negative log-posterior,
+    H = XᵀWX + λI with W = diag(p_i(1 − p_i)), evaluated at that mode.
+
+    PMAT-864 (HIGH, correctness): the fit divided ONLY the data term of the
+    gradient by n (`grad_j /= n`) while leaving the prior gradient λβ
+    un-averaged. The stationary point then satisfied (1/n)·Xᵀ(y − p) = λβ, i.e.
+    Xᵀ(y − p) = (n·λ)β — the MAP of a model with prior precision n·λ, NOT λ.
+    The posterior mean was over-shrunk ~n× toward 0, and the un-averaged
+    Hessian H = XᵀWX + λI was evaluated at the WRONG mode, corrupting BOTH the
+    posterior mean AND the credible intervals.
+
+    The fix removes the 1/n factor so the gradient is the un-averaged
+    Xᵀ(y − p) − λβ, consistent with the un-averaged Hessian. A positive scalar
+    1/n is applied to the WHOLE gradient-ascent STEP only (β ← β + (η/n)·∇ℓ) to
+    keep the fixed-LR step well-conditioned; scaling the entire gradient by a
+    positive constant does NOT move the stationary point, so the fit converges
+    to the λ-MAP where Xᵀ(y − p) = λβ.
+  references:
+  - 'Bishop, PRML §4.5 — Laplace approximation for Bayesian logistic regression'
+  - 'scikit-learn logistic-regression MAP: gradient Xᵀ(y − p) − λβ, Hessian XᵀWX + λI at the same mode'
+  - 'crates/aprender-core/src/bayesian/logistic.rs — BayesianLogisticRegression::fit (gradient ∇ℓ = Xᵀ(y − p) − λβ; Hessian H = XᵀWX + λI)'
+
+kind: KernelContract
+name: bayesian-logistic-map
+version: 1.0.0
+scope: aprender-core BayesianLogisticRegression::fit MAP estimation and Laplace covariance
+
+equations:
+  C-LOGPOST-GRADIENT:
+    formula: |
+      ∇ℓ(β) = Xᵀ(y − p) − λβ,   p_i = σ(x_iᵀ β)
+    domain: X ∈ ℝ^{n×d}, y ∈ {0,1}^n, β ∈ ℝ^d, λ > 0
+    codomain: ∇ℓ ∈ ℝ^d
+    invariants:
+    - 'The data term Xᵀ(y − p) is NOT averaged by n (no 1/n factor)'
+    - 'The prior term is exactly −λβ, with the SAME λ that scales the Hessian'
+    - 'Data and prior terms share one normalization (both un-averaged)'
+    lean_theorem: Theorems.LogPostGradient
+  C-MAP-PRECISION:
+    formula: |
+      ∇ℓ(β_MAP) = 0  ⇔  Xᵀ(y − p) = λ·β_MAP
+    domain: X ∈ ℝ^{n×d}, y ∈ {0,1}^n, λ > 0
+    codomain: β_MAP ∈ ℝ^d
+    invariants:
+    - 'β_MAP is the MAP at the DECLARED precision λ, never at n·λ'
+    - 'Doubling n with the same per-sample distribution does NOT shrink β_MAP toward 0'
+    lean_theorem: Theorems.MapPrecision
+  C-HESSIAN-SAME-POSTERIOR:
+    formula: |
+      H = XᵀWX + λI,   W = diag(p_i(1 − p_i)),   evaluated at β_MAP
+    domain: X ∈ ℝ^{n×d}, β_MAP ∈ ℝ^d, λ > 0
+    codomain: H ∈ ℝ^{d×d}, symmetric positive-definite
+    invariants:
+    - 'H is the Hessian of the SAME negative log-posterior whose gradient is C-LOGPOST-GRADIENT'
+    - 'H is un-averaged (XᵀWX, not (1/n)XᵀWX) and uses the SAME λ as the gradient'
+    - 'The Laplace covariance Σ = H⁻¹ is evaluated at the gradient''s stationary point β_MAP'
+    lean_theorem: Theorems.HessianSamePosterior
+
+proof_obligations:
+- type: invariant
+  property: Gradient and Hessian share one posterior and one normalization
+  formal: |
+    The fit gradient is Xᵀ(y − p) − λβ (un-averaged) and the Hessian is
+    XᵀWX + λI (un-averaged), with the SAME λ; neither the data term nor the
+    prior term carries a 1/n factor. (A 1/n on only the data term shifts the
+    stationary point to precision n·λ.)
+- type: classification
+  property: Fit targets the declared precision λ, not n·λ
+  formal: |
+    For data with a known MAP, BayesianLogisticRegression::new(λ).fit(X, y)
+    converges to β_MAP solving Xᵀ(y − p) = λβ_MAP, and is clearly distinct from
+    the over-shrunk mode solving Xᵀ(y − p) = (n·λ)β.
+- type: invariant
+  property: Step scaling preserves the stationary point
+  formal: |
+    The update β ← β + (η/n)·∇ℓ scales the WHOLE gradient by a positive
+    constant, so its fixed point is exactly ∇ℓ = 0; the 1/n affects step size
+    only and never the mode the fit converges to.
+
+falsification_tests:
+- id: FT-BLR-MAP-001
+  rule: Fit converges to the λ-MAP, not the over-shrunk n·λ-MAP
+  prediction: |
+    For an 8-sample monotone-ordered logistic dataset with λ = 0.2, the fitted
+    β converges to the independently-computed λ-MAP (≈ 2.316) within 1e-2 and is
+    clearly distinct from the n·λ-MAP (≈ 1.021). Before the fix the fit returned
+    ≈ 1.021 (the n·λ-MAP) — the data term was divided by n while the prior was
+    not.
+  if_fails: 'A 1/n (or any asymmetric) normalization of the data term has crept back into the gradient; the gradient and Hessian no longer describe the same posterior.'
+  evidence: cargo test -p aprender-core --lib test_pmat864_map_targets_declared_precision_not_n_lambda
+- id: FT-BLR-MAP-002
+  rule: Stronger prior precision shrinks coefficients monotonically
+  prediction: |
+    |β_MAP(λ=10)| ≤ |β_MAP(λ=0.1)| on the same data — λ controls shrinkage
+    correctly once the gradient and Hessian agree on λ.
+  if_fails: 'The prior gradient λβ is mis-scaled relative to the data term, so increasing λ no longer monotonically shrinks the MAP.'
+  evidence: cargo test -p aprender-core --lib test_prior_precision_effects
+- id: FT-BLR-MAP-003
+  rule: Replicating samples (more evidence at fixed λ) does NOT shrink the MAP
+  prediction: |
+    Doubling the dataset by replicating every sample (same per-sample
+    distribution) at fixed λ doubles the likelihood term Xᵀ(y − p), so |β_MAP|
+    grows. Under the bug (data term averaged by n) it instead shrank toward 0 —
+    the precision-n·λ signature.
+  if_fails: 'The data term still carries a 1/n (or any n-dependent) factor, so adding identical evidence weakens rather than strengthens the posterior.'
+  evidence: cargo test -p aprender-core --lib test_pmat864_replicating_samples_does_not_shrink_map
+
+kani_harnesses:
+- id: KANI-BLR-MAP-001
+  obligation: Gradient and Hessian share one normalization
+  property: |
+    For the log-posterior ℓ(β) = Σ_i ℓ_i(β) − (λ/2)‖β‖², the implemented
+    gradient equals Xᵀ(y − p) − λβ and the implemented Hessian equals
+    XᵀWX + λI: data terms un-averaged, prior terms scaled by the same λ.
+  bound: 2
+  strategy: compositional
+  solver: cadical
+  harness: verify_blr_gradient_hessian_same_posterior
+
+qa_gate:
+  id: F-BLR-MAP-001
+  name: bayesian-logistic-map-v1 Contract
+  description: Bayesian logistic regression fit must converge to the MAP at the declared prior precision λ (gradient Xᵀ(y − p) − λβ consistent with Hessian XᵀWX + λI at the same mode), never the over-shrunk precision-n·λ mode.
+  checks:
+  - validation
+  - falsification

--- a/crates/aprender-core/src/bayesian/logistic.rs
+++ b/crates/aprender-core/src/bayesian/logistic.rs
@@ -173,24 +173,43 @@ impl BayesianLogisticRegression {
                 predictions.push(Self::sigmoid(z));
             }
 
-            // Compute gradient: ∇ℓ = X^T(y - p) - λβ
+            // Compute gradient of the (un-normalized) log-posterior:
+            //   ℓ(β) = Σ_i [y_i log p_i + (1−y_i) log(1−p_i)] − (λ/2)‖β‖²
+            //   ∇ℓ  = Xᵀ(y − p) − λβ
+            // PMAT-864: the data term Σ_i x_ij (y_i − p_i) MUST NOT be divided
+            // by n. The Hessian used for the Laplace covariance below is the
+            // un-averaged H = XᵀWX + λI; averaging only the data term (while
+            // the prior gradient λβ stays un-averaged) would shift the
+            // stationary point to Xᵀ(y − p) = (n·λ)β — the MAP of a model with
+            // precision n·λ — so the posterior mean would be over-shrunk ~n×
+            // and the covariance would be evaluated at the wrong mode.
             let mut gradient = vec![0.0_f32; p];
             for j in 0..p {
                 let mut grad_j = 0.0_f32;
                 for i in 0..n {
                     grad_j += x.get(i, j) * (y[i] - predictions[i]);
                 }
-                // Average by number of samples for numerical stability
-                grad_j /= n as f32;
                 // Add prior gradient: -λβ_j
                 grad_j -= self.prior_precision * beta[j];
                 gradient[j] = grad_j;
             }
 
-            // Update parameters: β ← β + η∇ℓ
+            // Update parameters: β ← β + (η/n)·∇ℓ
+            //
+            // The STEP is scaled by 1/n purely to keep the gradient-ascent step
+            // magnitude in the same, well-conditioned range as before the
+            // PMAT-864 fix (the un-averaged gradient is ~n× larger, so an
+            // unscaled fixed-LR step would overshoot and oscillate). Scaling
+            // the WHOLE gradient by a positive constant does NOT move the
+            // stationary point: ∇ℓ = 0 ⇔ (1/n)·∇ℓ = 0, so the fit still
+            // converges to the λ-MAP where Xᵀ(y − p) = λβ — consistent with the
+            // un-averaged Hessian H = XᵀWX + λI used for the Laplace covariance.
+            // (This differs from the bug, which scaled ONLY the data term and
+            // thereby shifted the stationary point to precision n·λ.)
+            let step_scale = self.learning_rate / n as f32;
             let mut max_update = 0.0_f32;
             for j in 0..p {
-                let update = self.learning_rate * gradient[j];
+                let update = step_scale * gradient[j];
                 beta[j] += update;
                 max_update = max_update.max(update.abs());
             }

--- a/crates/aprender-core/src/bayesian/logistic_tests.rs
+++ b/crates/aprender-core/src/bayesian/logistic_tests.rs
@@ -393,3 +393,156 @@ fn test_wide_credible_interval() {
         width_90
     );
 }
+
+// ========================================================================
+// PMAT-864: MAP gradient/Hessian must target the SAME posterior (precision λ)
+//
+// Falsifier for the gradient/Hessian inconsistency: the log-posterior
+// gradient must be the UN-AVERAGED ∇ = Xᵀ(y − p) − λβ so that its stationary
+// point coincides with the mode used by the un-averaged Hessian
+// H = XᵀWX + λI. If the data term is divided by n (the bug) while the prior
+// term is not, the fit converges to the MAP of a model with precision n·λ —
+// the coefficients are shrunk ~n× toward zero — and the Laplace covariance is
+// then evaluated at the WRONG mode.
+//
+// Reference: Bishop PRML §4.5 (Laplace approximation); sklearn MAP for
+// logistic regression: ∇ = Xᵀ(y − p) − λβ, H = XᵀWX + λI at the same mode.
+// ========================================================================
+
+/// Reference Newton solver for the logistic-regression MAP at a given prior
+/// precision `lambda`. Solves the stationary equation Xᵀ(y − p) = λβ exactly
+/// (full Newton on the un-averaged log-posterior), independent of the model's
+/// gradient-ascent code path under test. Single feature column, no intercept.
+fn reference_map_1d(x_col: &[f32], y: &[f32], lambda: f32) -> f32 {
+    let mut beta = 0.0_f64;
+    let lambda = f64::from(lambda);
+    for _ in 0..200 {
+        // p_i = σ(x_i β); gradient g = Σ x_i (y_i − p_i) − λβ
+        // Hessian h = Σ x_i² p_i(1 − p_i) + λ
+        let mut g = -lambda * beta;
+        let mut h = lambda;
+        for (&xi, &yi) in x_col.iter().zip(y.iter()) {
+            let xi = f64::from(xi);
+            let z = xi * beta;
+            let p = 1.0 / (1.0 + (-z).exp());
+            g += xi * (f64::from(yi) - p);
+            h += xi * xi * p * (1.0 - p);
+        }
+        let step = g / h;
+        beta += step;
+        if step.abs() < 1e-12 {
+            break;
+        }
+    }
+    beta as f32
+}
+
+/// PMAT-864 falsifier: the fitted posterior mean must equal the MAP at the
+/// DECLARED precision λ, NOT the over-shrunk MAP at precision n·λ.
+///
+/// RED (bug present, data term divided by n): `beta_fitted ≈ map(n·λ)`, badly
+/// failing the `≈ map(λ)` assertion (and the `is clearly distinct from
+/// map(n·λ)` assertion).
+/// GREEN (fix, un-averaged gradient): `beta_fitted ≈ map(λ)`.
+#[test]
+fn test_pmat864_map_targets_declared_precision_not_n_lambda() {
+    // n = 8 samples, single feature. Monotone-ordered labels give a strong
+    // signal so the (finite, regularized) λ-MAP is large; the n·λ-MAP is
+    // shrunk to ~½ of it — a clean, unambiguous separation between the two
+    // candidate modes.
+    let x_col = vec![-3.0_f32, -2.0, -1.0, -0.5, 0.5, 1.0, 2.0, 3.0];
+    let y_vec = vec![0.0_f32, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0];
+    let n = x_col.len();
+    let lambda = 0.2_f32;
+
+    let x = Matrix::from_vec(n, 1, x_col.clone()).expect("Valid matrix");
+    let y = Vector::from_vec(y_vec.clone());
+
+    let mut model = BayesianLogisticRegression::new(lambda)
+        .with_learning_rate(0.3)
+        .with_max_iter(200_000)
+        .with_tolerance(1e-5);
+    model.fit(&x, &y).expect("Fit should converge");
+    let beta_fitted = model
+        .coefficients_map
+        .as_ref()
+        .expect("MAP estimate exists")[0];
+
+    // Reference modes computed by an independent Newton solver.
+    let beta_lambda = reference_map_1d(&x_col, &y_vec, lambda);
+    let beta_n_lambda = reference_map_1d(&x_col, &y_vec, lambda * n as f32);
+
+    // Sanity: the two modes are materially different (n·λ shrinks ~toward 0).
+    assert!(
+        beta_lambda.abs() > 2.0 * beta_n_lambda.abs(),
+        "test design: λ-mode ({beta_lambda}) should be far larger in magnitude \
+         than the n·λ-mode ({beta_n_lambda})"
+    );
+
+    // PRIMARY: fitted posterior mean must match the DECLARED-precision MAP.
+    assert!(
+        (beta_fitted - beta_lambda).abs() < 1e-2,
+        "PMAT-864: fitted β ({beta_fitted}) must converge to the λ-MAP \
+         ({beta_lambda}), not the over-shrunk n·λ-MAP ({beta_n_lambda}). \
+         A match to the n·λ-MAP indicates the data term is divided by n while \
+         the prior term is not (gradient/Hessian inconsistency)."
+    );
+
+    // GUARD: fitted mean must be clearly distinct from the buggy n·λ-mode.
+    assert!(
+        (beta_fitted - beta_n_lambda).abs() > 0.5 * (beta_lambda - beta_n_lambda).abs(),
+        "PMAT-864: fitted β ({beta_fitted}) is too close to the over-shrunk \
+         n·λ-MAP ({beta_n_lambda}) — the 1/n data-term scaling has crept back in."
+    );
+}
+
+/// PMAT-864 falsifier: replicating every sample (doubling n with the SAME
+/// per-sample distribution) must NOT shrink the MAP toward 0. The likelihood
+/// term Xᵀ(y − p) doubles, so the MAP at fixed precision λ grows (more data,
+/// stronger evidence) — it MUST NOT shrink. Under the bug, the data term was
+/// averaged by n, so doubling n halved the effective evidence-to-prior ratio
+/// and shrank β toward 0 (the precision-n·λ signature).
+#[test]
+fn test_pmat864_replicating_samples_does_not_shrink_map() {
+    let base_x = [-3.0_f32, -2.0, -1.0, -0.5, 0.5, 1.0, 2.0, 3.0];
+    let base_y = [0.0_f32, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0];
+    let lambda = 0.2_f32;
+
+    let fit_beta = |reps: usize| -> f32 {
+        let mut xv = Vec::new();
+        let mut yv = Vec::new();
+        for _ in 0..reps {
+            xv.extend_from_slice(&base_x);
+            yv.extend_from_slice(&base_y);
+        }
+        let n = xv.len();
+        let x = Matrix::from_vec(n, 1, xv).expect("Valid matrix");
+        let y = Vector::from_vec(yv);
+        let mut model = BayesianLogisticRegression::new(lambda)
+            .with_learning_rate(0.3)
+            .with_max_iter(200_000)
+            .with_tolerance(1e-5);
+        model.fit(&x, &y).expect("Fit should converge");
+        model
+            .coefficients_map
+            .as_ref()
+            .expect("MAP estimate exists")[0]
+    };
+
+    let beta_1x = fit_beta(1);
+    let beta_2x = fit_beta(2);
+
+    // More (replicated) data at the same prior precision => MORE evidence =>
+    // |β| must grow, never shrink toward 0.
+    assert!(
+        beta_2x.abs() >= beta_1x.abs() - 1e-3,
+        "PMAT-864: doubling the sample count (same distribution) shrank the MAP \
+         from {beta_1x} to {beta_2x} — the data term is being averaged by n \
+         (precision-n·λ signature)."
+    );
+    assert!(
+        beta_2x.abs() > beta_1x.abs(),
+        "PMAT-864: doubling evidence at fixed λ must strictly grow |β| \
+         ({beta_1x} -> {beta_2x})."
+    );
+}


### PR DESCRIPTION
BayesianLogisticRegression::fit divided the data-term gradient by n but subtracted the full prior gradient lambda*beta, so it converged to the MAP at precision n*lambda (over-shrunk) and the Laplace covariance was evaluated at the wrong mode. Fixed to the un-averaged gradient X^T(y-p)-lambda*beta (consistent with the Hessian); step scaled by 1/n to keep convergence.

Falsifier RED beta=1.02 (n*lambda mode) -> GREEN beta=2.32 (lambda mode). 13923/0. contracts/bayesian-logistic-map-v1.yaml pv-valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)