### PR TITLE
fix(classification): KNN tie-break used randomized HashMap order, not smallest label (PMAT-865)

### DIFF
--- a/contracts/knn-tie-smallest-label-v1.yaml
+++ b/contracts/knn-tie-smallest-label-v1.yaml
@@ -1,0 +1,96 @@
+metadata:
+  version: "1.0.0"
+  created: "2026-06-19"
+  author: PAIML Engineering
+  registry: true
+  references:
+    - "scikit-learn KNeighborsClassifier.predict (oracle for the tie-break rule — on a mode tie it returns the SMALLEST class label)"
+    - "scipy.stats.mode — returns the lowest value among tied modes"
+    - "numpy.argmax over np.bincount(labels) — returns the lowest index achieving the maximum count"
+    - "Cover & Hart (1967) — Nearest Neighbor Pattern Classification"
+  description: |
+    Correctness contract for the k-NN vote tie-break in
+    aprender-core classification::gaussian_nb (KNearestNeighbors::majority_vote and
+    KNearestNeighbors::weighted_vote). Pillar-1 (scikit-learn parity)
+    provable-correctness, ticket PMAT-865.
+
+kind: KernelContract
+name: knn-tie-smallest-label
+version: "1.0.0"
+scope: "crates/aprender-core/src/classification/gaussian_nb.rs"
+
+description: |
+  When two or more class labels tie for the highest k-NN vote (count, or weighted
+  inverse-distance weight), the predicted label MUST be the SMALLEST label among
+  the tied modes, deterministically on every call and every process:
+
+      predict_tie(labels) = min { c : votes(c) == max_c' votes(c') }
+
+  This matches scikit-learn KNeighborsClassifier.predict, whose tie-break reduces
+  to argmax over a bincount / scipy.stats.mode — both return the LOWEST index/value
+  among tied modes.
+
+  PMAT-865 removed a defect where `majority_vote` accumulated counts into a
+  `std::collections::HashMap` and returned `class_counts.iter().max_by_key(count)`,
+  and `weighted_vote` did the same with `max_by(weight)`. `max_by_key` / `max_by`
+  return the LAST maximal element in iteration order, and HashMap iteration order
+  is randomized per-process (Rust `RandomState`). On a vote tie the prediction was
+  therefore NON-DETERMINISTIC across runs: a 2-neighbor tie between labels 0 and 2
+  resolved to 0 in some processes and 2 in others (measured: `left: 2, right: 0`).
+  The fix replaces the HashMap with a `BTreeMap` (ascending-label iteration) and
+  keeps the FIRST label achieving the running max (strict `>`), so the smallest
+  tied label always wins. Distance-weighting logic is unchanged; `predict_proba`
+  (already a per-label `vec`, deterministic) is unaffected.
+
+equations:
+  C-KNN-TIE-001:
+    description: "Unweighted majority vote on a count tie returns the SMALLEST tied label, deterministically"
+    formula: "majority_vote(neighbors) = min { c : count(c) == max_c' count(c') }; for a 2-neighbor tie {(d,0),(d,2)} the result is 0 on every call, independent of neighbor order"
+    note: "Matches sklearn argmax(bincount). RED (HashMap+max_by_key): {0,2} tie -> 2 in some processes; GREEN (BTreeMap+keep-first): always 0."
+
+  C-KNN-TIE-002:
+    description: "Weighted (inverse-distance) vote on a weight tie returns the SMALLEST tied label, deterministically"
+    formula: "weighted_vote(neighbors) = min { c : weight(c) == max_c' weight(c') }; equal distances => equal weights => smallest label wins (0 for a {0,2} tie)"
+    note: "Same tie-break rule as the unweighted path; distance-weighting otherwise unchanged."
+
+  C-KNN-TIE-003:
+    description: "Tie-break is order-independent and deterministic across processes (no HashMap RandomState dependence)"
+    formula: "majority_vote([(d,0),(d,2)]) == majority_vote([(d,2),(d,0)]) == 0 over arbitrarily many calls and processes"
+    note: "Refutes the deleted HashMap path whose per-process iteration order made tied predictions vary run-to-run."
+
+  C-KNN-TIE-004:
+    description: "Three-way mode tie resolves to the smallest label"
+    formula: "majority_vote([(d,1),(d,2),(d,0)]) = 0 (one neighbor each of labels 0,1,2)"
+    note: "Generalizes the smallest-label rule beyond the 2-way case."
+
+  C-KNN-TIE-005:
+    description: "Non-tie (clear majority) predictions are UNCHANGED by the fix"
+    formula: "k-set {0,0,1} -> majority class 0 (2 votes vs 1); a strict winner is unaffected by the BTreeMap migration"
+    note: "Regression guard — FALSIFY-KNN-005 (k-set {0,0,1}) still predicts 0."
+
+proof_obligations:
+  - type: equivalence
+    property: "PO-KNN-TIE-001 mode tie returns the smallest tied label, matching sklearn"
+    formal: "for any neighbor set whose argmax-vote labels form a set S with |S| > 1, majority_vote / weighted_vote returns min(S) = argmax(bincount) = scipy.stats.mode lowest mode"
+    tolerance: 0.0
+    applies_to: all
+  - type: invariant
+    property: "PO-KNN-TIE-002 tie prediction is deterministic and order-independent"
+    formal: "majority_vote(p) == majority_vote(reverse(p)) for every permutation p of a tied neighbor set; result is constant across processes (no HashMap RandomState)"
+    tolerance: 0.0
+    applies_to: "tied neighbor sets"
+  - type: invariant
+    property: "PO-KNN-TIE-003 strict-winner predictions unchanged"
+    formal: "for a neighbor set with a unique argmax-vote label c*, majority_vote / weighted_vote returns c* (BTreeMap migration preserves all non-tie predictions)"
+    tolerance: 0.0
+    applies_to: "neighbor sets with a unique mode"
+
+falsification:
+  - id: FALSIFY-KNN-TIE-001
+    description: "k-NN vote ties resolve to the smallest tied label, deterministically, via majority_vote, weighted_vote, and the public predict API. Discharges C-KNN-TIE-001..005 and PO-KNN-TIE-001/002/003."
+    test: "falsify_knn_tie_001_majority_vote_smallest_label, falsify_knn_tie_002_weighted_vote_smallest_label, falsify_knn_tie_003_predict_tie_smallest_label, falsify_knn_tie_004_three_way_tie_smallest_label"
+    command: "cargo test -p aprender-core --lib falsify_knn_tie"
+    red: "majority_vote([(1.0,0),(1.0,2)]) = 2 (HashMap + max_by_key returns the LAST max in randomized iteration order — non-deterministic; observed `left: 2, right: 0`)"
+    green: "majority_vote([(1.0,0),(1.0,2)]) = 0 (BTreeMap ascending + keep-first-on-strict-greater returns the smallest tied label, deterministically, on every call and process)"
+    sklearn_reference: "KNeighborsClassifier.predict tie-break = argmax(np.bincount(labels)) = smallest tied label (0 for a {0,2} tie)"
+    evidence: "cargo test -p aprender-core --lib falsify_knn_tie"

--- a/crates/aprender-core/src/classification/gaussian_nb.rs
+++ b/crates/aprender-core/src/classification/gaussian_nb.rs
@@ -232,36 +232,62 @@ impl KNearestNeighbors {
     }
 
     /// Performs majority voting among k nearest neighbors.
+    ///
+    /// On a vote tie, resolves deterministically to the **smallest class label**
+    /// among the tied modes, matching scikit-learn `KNeighborsClassifier.predict`
+    /// (scipy `stats.mode` / `argmax` over `bincount` both return the lowest index on
+    /// ties). A `BTreeMap` yields ascending-label iteration, and we keep the *first*
+    /// label that achieves the running max (`>`, not `>=`), so the smallest tied label
+    /// wins. (Refs PMAT-865: a previous `HashMap` + `max_by_key` returned the *last*
+    /// max in randomized iteration order — non-deterministic tie predictions.)
     #[allow(clippy::unused_self)]
     fn majority_vote(&self, neighbors: &[(f32, usize)]) -> usize {
-        let mut class_counts = std::collections::HashMap::new();
+        let mut class_counts = std::collections::BTreeMap::new();
 
         for (_dist, label) in neighbors {
             *class_counts.entry(*label).or_insert(0) += 1;
         }
 
-        *class_counts
-            .iter()
-            .max_by_key(|(_, count)| *count)
-            .map(|(label, _)| label)
-            .expect("Neighbors slice is non-empty (k >= 1)")
+        let mut best_label = 0;
+        let mut best_count = 0;
+        // Ascending label order (BTreeMap): strict `>` keeps the FIRST (smallest)
+        // label achieving the max count on ties.
+        for (&label, &count) in &class_counts {
+            if count > best_count {
+                best_count = count;
+                best_label = label;
+            }
+        }
+        best_label
     }
 
     /// Performs weighted voting (inverse distance weighting).
+    ///
+    /// On a weight tie, resolves deterministically to the **smallest class label**
+    /// among the tied modes (same rule as [`Self::majority_vote`], matching
+    /// scikit-learn). A `BTreeMap` yields ascending-label iteration, and we keep the
+    /// *first* label that achieves the running max (strict `>`), so the smallest tied
+    /// label wins. (Refs PMAT-865.)
     #[allow(clippy::unused_self)]
     fn weighted_vote(&self, neighbors: &[(f32, usize)]) -> usize {
-        let mut class_weights = std::collections::HashMap::new();
+        let mut class_weights = std::collections::BTreeMap::new();
 
         for (dist, label) in neighbors {
             let weight = if *dist < 1e-10 { 1.0 } else { 1.0 / dist };
             *class_weights.entry(*label).or_insert(0.0) += weight;
         }
 
-        *class_weights
-            .iter()
-            .max_by(|(_, a), (_, b)| a.total_cmp(b))
-            .map(|(label, _)| label)
-            .expect("Neighbors slice is non-empty (k >= 1)")
+        let mut best_label = 0;
+        let mut best_weight = f32::NEG_INFINITY;
+        // Ascending label order (BTreeMap): strict `>` keeps the FIRST (smallest)
+        // label achieving the max weight on ties.
+        for (&label, &weight) in &class_weights {
+            if weight > best_weight {
+                best_weight = weight;
+                best_label = label;
+            }
+        }
+        best_label
     }
 }
 

--- a/crates/aprender-core/src/classification/tests_knn_contract.rs
+++ b/crates/aprender-core/src/classification/tests_knn_contract.rs
@@ -151,6 +151,114 @@ fn falsify_knn_005_partial_select_ties_stable() {
     );
 }
 
+// =========================================================================
+// FALSIFY-KNN-TIE (PMAT-865): on a VOTE-COUNT tie among modes, the predicted
+// label MUST be the smallest tied label, deterministically, matching
+// scikit-learn KNeighborsClassifier.predict (scipy.stats.mode / argmax over
+// bincount both return the lowest index on ties).
+//
+// RED (pre-fix): majority_vote/weighted_vote used a HashMap + max_by_key/max_by,
+// which return the LAST maximal element in iteration order. HashMap iteration
+// order is randomized per-process (Rust RandomState), so a tie between labels
+// 0 and 2 could resolve to EITHER 0 or 2 depending on the process.
+// GREEN (post-fix): BTreeMap (ascending labels) + keep-first-on-strict-greater
+// always returns the smallest tied label (0).
+// =========================================================================
+
+/// FALSIFY-KNN-TIE-001: a balanced 2-neighbor vote tie (label 0 vs label 2,
+/// one neighbor each) resolves to the SMALLEST label (0) via the unweighted
+/// `majority_vote` helper directly. Repeated across many calls to surface any
+/// nondeterminism.
+#[test]
+fn falsify_knn_tie_001_majority_vote_smallest_label() {
+    let knn = KNearestNeighbors::new(2);
+
+    // One neighbor of class 0, one of class 2, identical distance -> exact tie.
+    let neighbors: Vec<(f32, usize)> = vec![(1.0, 0), (1.0, 2)];
+    // Also test the reversed iteration order to prove order-independence: the
+    // result must be the smallest label regardless of neighbor ordering.
+    let neighbors_rev: Vec<(f32, usize)> = vec![(1.0, 2), (1.0, 0)];
+
+    for _ in 0..1000 {
+        assert_eq!(
+            knn.majority_vote(&neighbors),
+            0,
+            "FALSIFIED KNN-TIE-001: tie {{0,2}} did not resolve to smallest label 0"
+        );
+        assert_eq!(
+            knn.majority_vote(&neighbors_rev),
+            0,
+            "FALSIFIED KNN-TIE-001: reversed tie {{2,0}} did not resolve to smallest label 0"
+        );
+    }
+}
+
+/// FALSIFY-KNN-TIE-002: a balanced weighted vote tie (equal inverse-distance
+/// weights for labels 0 and 2) resolves to the SMALLEST label (0) via the
+/// `weighted_vote` helper directly.
+#[test]
+fn falsify_knn_tie_002_weighted_vote_smallest_label() {
+    let knn = KNearestNeighbors::new(2).with_weights(true);
+
+    // Identical distances => identical inverse-distance weights => weight tie.
+    let neighbors: Vec<(f32, usize)> = vec![(2.0, 0), (2.0, 2)];
+    let neighbors_rev: Vec<(f32, usize)> = vec![(2.0, 2), (2.0, 0)];
+
+    for _ in 0..1000 {
+        assert_eq!(
+            knn.weighted_vote(&neighbors),
+            0,
+            "FALSIFIED KNN-TIE-002: weighted tie {{0,2}} did not resolve to smallest label 0"
+        );
+        assert_eq!(
+            knn.weighted_vote(&neighbors_rev),
+            0,
+            "FALSIFIED KNN-TIE-002: reversed weighted tie {{2,0}} did not resolve to smallest label 0"
+        );
+    }
+}
+
+/// FALSIFY-KNN-TIE-003: end-to-end via the public `predict` API. A k=2 query
+/// equidistant from one class-0 point and one class-2 point is a true vote tie;
+/// the prediction MUST be the smallest label (0), deterministically across
+/// repeated `predict` calls.
+#[test]
+fn falsify_knn_tie_003_predict_tie_smallest_label() {
+    // Two training points equidistant from the query (0.0, 0.0):
+    //   (1, 0) class 0, dist 1 ; (-1, 0) class 2, dist 1.
+    let x = Matrix::from_vec(2, 2, vec![1.0, 0.0, -1.0, 0.0]).expect("valid");
+    let y = vec![0_usize, 2];
+
+    let mut knn = KNearestNeighbors::new(2);
+    knn.fit(&x, &y).expect("fit");
+
+    let query = Matrix::from_vec(1, 2, vec![0.0, 0.0]).expect("valid");
+
+    // Determinism + correctness: smallest tied label (0) on every call.
+    for _ in 0..200 {
+        let pred = knn.predict(&query).expect("predict");
+        assert_eq!(
+            pred[0], 0,
+            "FALSIFIED KNN-TIE-003: 2-way vote tie {{0,2}} did not resolve to smallest label 0"
+        );
+    }
+}
+
+/// FALSIFY-KNN-TIE-004: a three-way mode tie among labels 0, 1, 2 (k=3, one
+/// neighbor each) resolves to the smallest label (0).
+#[test]
+fn falsify_knn_tie_004_three_way_tie_smallest_label() {
+    let knn = KNearestNeighbors::new(3);
+    let neighbors: Vec<(f32, usize)> = vec![(1.0, 1), (1.0, 2), (1.0, 0)];
+    for _ in 0..1000 {
+        assert_eq!(
+            knn.majority_vote(&neighbors),
+            0,
+            "FALSIFIED KNN-TIE-004: 3-way tie {{0,1,2}} did not resolve to smallest label 0"
+        );
+    }
+}
+
 mod knn_proptest_falsify {
     use super::*;
     use proptest::prelude::*;


### PR DESCRIPTION
KNN majority_vote/weighted_vote counted into a HashMap and took max_by_key (keeps LAST max in randomized iteration order), so tied predictions were non-deterministic across runs. sklearn breaks ties to the smallest label. Fixed to BTreeMap + first-max.

Falsifier RED tie {0,2}->2 (nondeterministic) -> GREEN ->0 always. 13925/0. contracts/knn-tie-smallest-label-v1.yaml pv-valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)