### PR TITLE
fix(model_selection): StratifiedKFold dumped every class remainder in low folds — sizes off by >1 (PMAT-866)

### DIFF
--- a/contracts/stratified-kfold-balance-v1.yaml
+++ b/contracts/stratified-kfold-balance-v1.yaml
@@ -1,0 +1,126 @@
+metadata:
+  version: 1.0.0
+  created: '2026-06-19'
+  author: PAIML Engineering
+  description: |
+    StratifiedKFold::split must distribute each class's per-fold remainder
+    across folds with a CUMULATIVE offset, so that test-fold sizes differ by at
+    most 1 — matching scikit-learn's StratifiedKFold / _make_test_folds.
+
+    BUG (PMAT-866): each class assigned its remainder = class_size % n_splits
+    extra samples ALWAYS to the lowest-index folds (`if i < remainder`). With no
+    cumulative offset across classes, every class dumped its leftovers onto folds
+    0..remainder-1, where they accumulated. For y = [0]*10 + [1]*10, n_splits=3,
+    both classes have remainder=1 → fold 0 received +1 from BOTH → test sizes
+    [8, 6, 6] (max-min = 2), violating the k-fold balance invariant. sklearn
+    yields [7, 7, 6].
+
+    FIX: maintain a running `offset` across classes; assign each class's extras
+    to folds (offset + 0), (offset + 1), ... (mod n_splits), then advance
+    `offset` by `remainder` after each class. Classes are iterated in stable
+    sorted-label order (not HashMap order) for cross-run/platform determinism.
+    Coverage is preserved: every sample index lands in exactly one test fold.
+  references:
+  - 'crates/aprender-core/src/model_selection/mod.rs — StratifiedKFold::split (cumulative-offset remainder distribution)'
+  - 'crates/aprender-core/src/model_selection/tests_stratified.rs — FALSIFY-SKF-BAL-001..003'
+  - 'scikit-learn StratifiedKFold / _make_test_folds — per-fold sizes differ by at most 1'
+
+kind: KernelContract
+name: stratified-kfold-balance
+version: 1.0.0
+scope: aprender-core model_selection StratifiedKFold::split fold-size balance
+
+equations:
+  C-BALANCE:
+    formula: |
+      For all folds i, j in [0, n_splits):
+        | |test_fold_i| - |test_fold_j| | <= 1
+    domain: y in R^n (n labels), n_splits in [2, n], at least n_splits per class
+    codomain: n_splits (train, test) index partitions
+    invariants:
+    - 'max_i |test_fold_i| - min_i |test_fold_i| <= 1 (sklearn StratifiedKFold parity)'
+    - 'per-class remainders round-robin via a cumulative offset carried across classes'
+    - 'class iteration order is stable (sorted labels), not HashMap order'
+    preconditions:
+    - n_splits >= 2
+    - 'each class has at least n_splits samples (well-defined stratification)'
+    lean_theorem: Theorems.StratifiedKFold_Balance
+  C-COVERAGE:
+    formula: |
+      The test folds partition [0, n): every sample index appears in exactly one
+      test fold, and sum_i |test_fold_i| = n.
+    domain: y in R^n, n_splits in [2, n]
+    codomain: n_splits disjoint test-index sets whose union is [0, n)
+    invariants:
+    - 'for every index k in [0, n): exactly one fold i has k in test_fold_i'
+    - 'sum over folds of |test_fold_i| equals n (no leaks, no duplicates)'
+    - 'within a fold, train and test index sets are disjoint'
+    preconditions:
+    - n_splits >= 2
+    lean_theorem: Theorems.StratifiedKFold_Coverage
+
+proof_obligations:
+- type: bound
+  property: Fold sizes differ by at most 1
+  formal: |
+    For all i, j in [0, n_splits): abs(len(test_fold_i) - len(test_fold_j)) <= 1.
+  applies_to: all
+- type: invariant
+  property: Test folds partition the sample set exactly once
+  formal: |
+    For all k in [0, n): exactly one i has k in test_fold_i, and
+    sum_i len(test_fold_i) = n.
+  applies_to: all
+- type: invariant
+  property: Class iteration is deterministic (stable sorted-label order)
+  formal: |
+    The remainder-distribution order over classes is the ascending order of the
+    integer class labels, independent of HashMap iteration order.
+  applies_to: all
+
+falsification_tests:
+- id: FALSIFY-SKF-BAL-001
+  rule: Test-fold sizes differ by at most 1 (sklearn parity)
+  prediction: |
+    For y = [0]*10 + [1]*10 with n_splits=3, sorted test-fold sizes are
+    [6, 7, 7] (max-min = 1). Before the fix they were [6, 6, 8] (max-min = 2),
+    because each class's single extra was forced onto fold 0.
+  if_fails: 'the per-class remainder offset is not carried across classes (extras pile onto the lowest-index folds).'
+  evidence: cargo test -p aprender-core --lib falsify_skf_bal_001_fold_sizes_differ_by_at_most_one
+- id: FALSIFY-SKF-BAL-002
+  rule: Test folds cover every sample index exactly once
+  prediction: |
+    For y = [0]*10 + [1]*10 with n_splits=3, the test folds sum to 20 samples and
+    every index in [0, 20) appears in exactly one test fold.
+  if_fails: 'the offset-based remainder distribution leaks or duplicates an index (coverage invariant broken).'
+  evidence: cargo test -p aprender-core --lib falsify_skf_bal_002_coverage_every_index_once
+- id: FALSIFY-SKF-BAL-003
+  rule: Balance generalizes across classes with differing remainders
+  prediction: |
+    For class sizes (7, 7, 4) with n_splits=3, overall fold sizes differ by at
+    most 1 AND each class's per-fold count differs by at most 1. Before the fix
+    the overall sizes were [5, 5, 8] (max-min = 3).
+  if_fails: 'the cumulative offset is reset per class or computed without wrap-around mod n_splits.'
+  evidence: cargo test -p aprender-core --lib falsify_skf_bal_003_general_balance
+
+kani_harnesses:
+- id: KANI-SKF-BAL-001
+  obligation: Fold sizes differ by at most 1
+  property: |
+    For a class of size c distributed over k folds with a starting offset o,
+    each fold receives floor(c/k) or floor(c/k)+1 samples, and exactly
+    (c mod k) folds — namely (o+0)..(o+(c mod k)-1) mod k — receive the +1.
+    Aggregated over all classes with the offset carried forward, no fold's total
+    exceeds another's by more than 1.
+  bound: 4
+  strategy: compositional
+  solver: cadical
+  harness: verify_stratified_kfold_balance
+
+qa_gate:
+  id: F-SKF-BAL-001
+  name: stratified-kfold-balance-v1 Contract
+  description: StratifiedKFold::split must keep test-fold sizes balanced to within 1 (sklearn parity) while preserving exact coverage, by round-robining per-class remainders with a cumulative offset.
+  checks:
+  - validation
+  - falsification

--- a/crates/aprender-core/src/model_selection/mod.rs
+++ b/crates/aprender-core/src/model_selection/mod.rs
@@ -521,24 +521,39 @@ impl StratifiedKFold {
         // Initialize folds
         let mut fold_indices: Vec<Vec<usize>> = vec![Vec::new(); self.n_splits];
 
-        // Distribute each class across folds
-        for indices in class_indices.values() {
+        // PMAT-866: distribute each class across folds with a *cumulative* offset
+        // so that per-class remainders round-robin across folds instead of always
+        // piling onto the lowest-index folds. This keeps fold sizes balanced to
+        // within 1 (sklearn StratifiedKFold / _make_test_folds parity).
+        //
+        // Iterate classes in stable sorted-label order (NOT HashMap order) so the
+        // split is deterministic across runs and platforms.
+        let mut sorted_labels: Vec<i32> = class_indices.keys().copied().collect();
+        sorted_labels.sort_unstable();
+
+        // `offset` is carried across classes: each class assigns its `remainder`
+        // extra samples to folds (offset + 0), (offset + 1), ..., wrapping mod
+        // n_splits, then advances `offset` by `remainder`.
+        let mut offset = 0usize;
+        for label in sorted_labels {
+            let indices = &class_indices[&label];
             let class_size = indices.len();
             let fold_size = class_size / self.n_splits;
             let remainder = class_size % self.n_splits;
 
             let mut start = 0;
-            for (i, fold) in fold_indices.iter_mut().enumerate() {
-                let current_size = if i < remainder {
-                    fold_size + 1
-                } else {
-                    fold_size
-                };
+            for k in 0..self.n_splits {
+                // Fold k receives one extra sample iff it is among the `remainder`
+                // folds starting at the running offset (wrapping mod n_splits).
+                let gets_extra = (0..remainder).any(|r| (offset + r) % self.n_splits == k);
+                let current_size = fold_size + usize::from(gets_extra);
                 let end = start + current_size;
 
-                fold.extend_from_slice(&indices[start..end]);
+                fold_indices[k].extend_from_slice(&indices[start..end]);
                 start = end;
             }
+
+            offset = (offset + remainder) % self.n_splits;
         }
 
         // Create train/test splits

--- a/crates/aprender-core/src/model_selection/tests_stratified.rs
+++ b/crates/aprender-core/src/model_selection/tests_stratified.rs
@@ -441,3 +441,127 @@ fn test_stratified_kfold_with_shuffle_false() {
     let splits = skfold.split(&y);
     assert_eq!(splits.len(), 2);
 }
+
+// ==================== PMAT-866: StratifiedKFold fold-balance ====================
+//
+// FALSIFY-SKF-BAL-001: per-class remainders must round-robin across folds so
+// that test-fold sizes differ by at most 1 (sklearn StratifiedKFold parity).
+//
+// BUG (pre-fix): each class assigned its `remainder = class_size % n_splits`
+// extra samples ALWAYS to the lowest-index folds (`if i < remainder`). With
+// y = [0]*10 + [1]*10 and n_splits=3 both classes (remainder=1 each) dumped
+// their extra into fold 0 -> test sizes [8, 6, 6] (max-min = 2), violating the
+// k-fold balance invariant. sklearn yields [7, 7, 6].
+//
+// Reference: sklearn StratifiedKFold / _make_test_folds (sizes differ by <= 1).
+
+/// FALSIFY-SKF-BAL-001: test-fold sizes differ by at most 1 (sklearn parity).
+///
+/// RED (pre-fix):  sorted test sizes = [6, 6, 8] (max-min = 2) -> FAIL
+/// GREEN (fixed):  sorted test sizes = [6, 7, 7] (max-min = 1) -> PASS
+#[test]
+fn falsify_skf_bal_001_fold_sizes_differ_by_at_most_one() {
+    // 2 classes, 10 samples each -> 20 total, n_splits=3.
+    // Per class: 10 / 3 = 3 with remainder 1. Round-robin offset must push the
+    // two extras to different folds, not both to fold 0.
+    let mut labels = vec![0.0f32; 10];
+    labels.extend(std::iter::repeat(1.0f32).take(10));
+    let y = Vector::from_slice(&labels);
+
+    let skfold = StratifiedKFold::new(3);
+    let splits = skfold.split(&y);
+
+    assert_eq!(splits.len(), 3, "expected exactly 3 folds");
+
+    let mut test_sizes: Vec<usize> = splits.iter().map(|(_, test)| test.len()).collect();
+    test_sizes.sort_unstable();
+
+    let min = *test_sizes.iter().min().expect("non-empty folds");
+    let max = *test_sizes.iter().max().expect("non-empty folds");
+
+    assert!(
+        max - min <= 1,
+        "FALSIFIED SKF-BAL-001: test-fold sizes {test_sizes:?} have max-min = {} > 1 \
+         (k-fold balance invariant violated; sklearn gives [6, 7, 7])",
+        max - min
+    );
+
+    // Concretely: sorted sizes must be exactly [6, 7, 7] for this input.
+    assert_eq!(
+        test_sizes,
+        vec![6, 7, 7],
+        "FALSIFIED SKF-BAL-001: expected sorted test sizes [6, 7, 7], got {test_sizes:?}"
+    );
+}
+
+/// FALSIFY-SKF-BAL-002: coverage -- every index appears in exactly one test fold,
+/// and the test sizes sum to the sample count (no leaks, no duplicates).
+#[test]
+fn falsify_skf_bal_002_coverage_every_index_once() {
+    let mut labels = vec![0.0f32; 10];
+    labels.extend(std::iter::repeat(1.0f32).take(10));
+    let y = Vector::from_slice(&labels);
+
+    let skfold = StratifiedKFold::new(3);
+    let splits = skfold.split(&y);
+
+    // Total of all test folds equals sample count.
+    let total: usize = splits.iter().map(|(_, test)| test.len()).sum();
+    assert_eq!(total, 20, "test folds must cover all 20 samples exactly once");
+
+    // Every index in [0, 20) appears in exactly one test fold.
+    let mut counts = vec![0usize; 20];
+    for (_, test) in &splits {
+        for &idx in test {
+            assert!(idx < 20, "test index {idx} out of range");
+            counts[idx] += 1;
+        }
+    }
+    for (i, &c) in counts.iter().enumerate() {
+        assert_eq!(
+            c, 1,
+            "FALSIFIED SKF-BAL-002: index {i} appears in {c} test folds (expected 1)"
+        );
+    }
+}
+
+/// FALSIFY-SKF-BAL-003: balance generalizes -- for classes with different
+/// remainders, every class's per-fold count differs by at most 1 AND the overall
+/// fold sizes differ by at most 1 (the round-robin offset is carried across
+/// classes, not reset per class).
+#[test]
+fn falsify_skf_bal_003_general_balance() {
+    // class 0: 7 samples, class 1: 7 samples, class 2: 4 samples; n_splits = 3.
+    let mut labels = vec![0.0f32; 7];
+    labels.extend(std::iter::repeat(1.0f32).take(7));
+    labels.extend(std::iter::repeat(2.0f32).take(4));
+    let y = Vector::from_slice(&labels);
+
+    let skfold = StratifiedKFold::new(3);
+    let splits = skfold.split(&y);
+
+    let mut test_sizes: Vec<usize> = splits.iter().map(|(_, test)| test.len()).collect();
+    test_sizes.sort_unstable();
+    let min = *test_sizes.iter().min().expect("non-empty");
+    let max = *test_sizes.iter().max().expect("non-empty");
+    assert!(
+        max - min <= 1,
+        "FALSIFIED SKF-BAL-003: overall fold sizes {test_sizes:?} differ by {} > 1",
+        max - min
+    );
+
+    // Per-class balance: each class's count per fold differs by at most 1.
+    for class in [0.0f32, 1.0, 2.0] {
+        let per_fold: Vec<usize> = splits
+            .iter()
+            .map(|(_, test)| test.iter().filter(|&&idx| y[idx] == class).count())
+            .collect();
+        let cmin = *per_fold.iter().min().expect("non-empty");
+        let cmax = *per_fold.iter().max().expect("non-empty");
+        assert!(
+            cmax - cmin <= 1,
+            "FALSIFIED SKF-BAL-003: class {class} per-fold counts {per_fold:?} differ by {} > 1",
+            cmax - cmin
+        );
+    }
+}


### PR DESCRIPTION
StratifiedKFold assigned each class remainder to the lowest folds unconditionally, so they accumulated -> fold sizes differ by >1 (y=[0]*10+[1]*10,k=3 -> [8,6,6]) vs sklearn [7,7,6]. Fixed with a cumulative cross-class offset so extras rotate.

Falsifier RED [6,6,8] -> GREEN [6,7,7] (max-min<=1). 13929/0. contracts/stratified-kfold-balance-v1.yaml pv-valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)