### PR TITLE
fix(format): GGUF K-quant bytes-per-element table wrong for Q2_K/Q3_K/Q6_K/Q8_K (PMAT-869)

### DIFF
--- a/contracts/gguf-kquant-element-size-v1.yaml
+++ b/contracts/gguf-kquant-element-size-v1.yaml
@@ -1,0 +1,131 @@
+metadata:
+  version: 1.0.0
+  created: '2026-06-19'
+  author: PAIML Engineering
+  description: |
+    GGUF/GGML K-quant tensors report bytes-per-element via an O(1) lookup table
+    in ggml_dtype_element_size (crates/aprender-core/src/format/safetensors.rs).
+    Each K-quant super-block packs exactly QK_K=256 elements; bytes-per-element
+    is therefore the EXACT ratio block_bytes / 256.
+
+    Four entries were WRONG (PMAT-869): Q2_K stored 0.3125 (=80/256), Q3_K 0.4375
+    (=112/256), Q6_K 0.8125 (=208/256), Q8_K 1.0625 (=272/256) — none match the
+    real ggml-common.h super-block sizes. So `apr tensors` / size reporting
+    under-counted K-quant tensor byte sizes (e.g. a 256-element Q2_K tensor was
+    reported as 80 bytes instead of 84). Q4_K (144/256=0.5625) and Q5_K
+    (176/256=0.6875) were already correct.
+
+    Fix: correct the four entries to the exact dyadic ratios 84/256, 110/256,
+    210/256, 292/256. All six K-quant bytes/elem now equal block_bytes/256.
+  references:
+  - 'ggml-common.h: sizeof(block_q2_K) = 2*sizeof(ggml_half) + QK_K/16 + QK_K/4 = 84'
+  - 'ggml-common.h: sizeof(block_q3_K) = sizeof(ggml_half) + QK_K/4 + QK_K/8 + 12 = 110'
+  - 'ggml-common.h: sizeof(block_q4_K) = 2*sizeof(ggml_half) + 12 + QK_K/2 = 144'
+  - 'ggml-common.h: sizeof(block_q5_K) = 2*sizeof(ggml_half) + 12 + QK_K/8 + QK_K/2 = 176'
+  - 'ggml-common.h: sizeof(block_q6_K) = QK_K/2 + QK_K/4 + QK_K/16 + sizeof(ggml_half) = 210'
+  - 'ggml-common.h: sizeof(block_q8_K) = sizeof(float) + QK_K + QK_K/16*sizeof(int16_t) = 292'
+  - 'ggml-common.h: QK_K = 256'
+  - 'crates/aprender-core/src/format/safetensors.rs — ggml_dtype_element_size SIZES table (idx 10/11/14/15)'
+  - 'crates/aprender-core/src/format/tensors.rs — ggml_dtype_name GGML type enum order'
+
+kind: KernelContract
+name: gguf-kquant-element-size
+version: 1.0.0
+scope: aprender-core GGUF K-quant byte-size reporting (safetensors.rs ggml_dtype_element_size)
+
+description: |
+  K-quant (Q2_K, Q3_K, Q4_K, Q5_K, Q6_K, Q8_K) bytes-per-element MUST equal the
+  exact ratio block_bytes / QK_K, where QK_K=256 and block_bytes is the ggml.h
+  super-block size in bytes. This is the per-element weight ggml_dtype_element_size
+  must return so that total tensor byte size = num_elements * bytes_per_element is
+  reported correctly by `apr tensors` and GGUF size accounting.
+
+equations:
+  kquant_bytes_per_element:
+    description: 'bytes_per_element(dtype) = block_bytes(dtype) / 256 for every K-quant'
+    formula: |
+      Q2_K = 84/256  = 0.328125
+      Q3_K = 110/256 = 0.4296875
+      Q4_K = 144/256 = 0.5625
+      Q5_K = 176/256 = 0.6875
+      Q6_K = 210/256 = 0.8203125
+      Q8_K = 292/256 = 1.140625
+    domain: GGML dtype codes {10:Q2_K, 11:Q3_K, 12:Q4_K, 13:Q5_K, 14:Q6_K, 15:Q8_K}
+    codomain: bytes per element (f64, exact dyadic fraction)
+    invariants:
+    - 'QK_K = 256 elements per K-quant super-block'
+    - 'bytes_per_element = block_bytes / 256 (exact, no approximation)'
+    - 'Q4_K (144/256) and Q5_K (176/256) unchanged — already correct'
+    - 'monotonic in bits: Q2_K < Q3_K < Q4_K < Q5_K < Q6_K < Q8_K'
+    lean_theorem: Theorems.KQuant_Element_Size
+
+  total_tensor_bytes:
+    description: 'reported tensor size = num_elements * bytes_per_element'
+    formula: 'size_bytes = floor(num_elements * (block_bytes / 256))'
+    domain: 'num_elements a positive multiple of 256'
+    codomain: byte count (usize)
+    invariants:
+    - 'a 256-element Q2_K tensor reports 84 bytes (was 80 before the fix)'
+    - 'a 256-element Q8_K tensor reports 292 bytes (was 272 before the fix)'
+    lean_theorem: Theorems.Total_Tensor_Bytes
+
+proof_obligations:
+- type: invariant
+  property: K-quant bytes-per-element equals block_bytes/256
+  formal: |
+    For every K-quant dtype code c in {10,11,12,13,14,15} with ggml.h super-block
+    size block_bytes(c) in {84,110,144,176,210,292}:
+      ggml_dtype_element_size(c) == block_bytes(c) / 256.0  (exact).
+- type: invariant
+  property: Q4_K and Q5_K unchanged
+  formal: |
+    ggml_dtype_element_size(12) == 0.5625 AND ggml_dtype_element_size(13) == 0.6875
+    (these two were already correct and must not regress).
+- type: equivalence
+  property: total tensor byte size for a 256-element Q2_K tensor
+  formal: |
+    floor(256 * ggml_dtype_element_size(10)) == 84  (not 80).
+
+falsification_tests:
+- id: FT-KQUANT-001
+  rule: K-quant bytes-per-element equals exact block_bytes/256 ratio
+  prediction: |
+    ggml_dtype_element_size returns 0.328125 (Q2_K), 0.4296875 (Q3_K),
+    0.8203125 (Q6_K), 1.140625 (Q8_K). Before the fix it returned 0.3125,
+    0.4375, 0.8125, 1.0625 respectively.
+  test: cargo test -p aprender-core --lib test_kquant_element_size_exact_block_ratio_pmat869
+  if_fails: 'a K-quant SIZES table entry (idx 10/11/14/15) regressed to a wrong byte/elem value.'
+  evidence: |
+    RED (buggy table): panics "Q2_K (code 10): expected 0.328125 (= 84/256), got 0.3125".
+    GREEN (fixed table): test passes; 256-element Q2_K tensor reports 84 bytes.
+- id: FT-KQUANT-002
+  rule: Q4_K and Q5_K element sizes are unchanged
+  prediction: 'ggml_dtype_element_size(12)==0.5625 and (13)==0.6875 stay correct.'
+  test: cargo test -p aprender-core --lib test_kquant_element_size_exact_block_ratio_pmat869
+  if_fails: 'the fix over-reached and altered the already-correct Q4_K/Q5_K entries.'
+  evidence: cargo test -p aprender-core --lib
+- id: FT-KQUANT-003
+  rule: total reported byte size for a 256-element Q2_K tensor is 84 bytes
+  prediction: 'floor(256 * ggml_dtype_element_size(10)) == 84 (was 80 before the fix).'
+  test: cargo test -p aprender-core --lib test_kquant_element_size_exact_block_ratio_pmat869
+  if_fails: 'the Q2_K entry is under-counting, so GGUF tensor sizes are mis-reported.'
+  evidence: cargo test -p aprender-core --lib
+
+kani_harnesses:
+- id: KANI-KQUANT-001
+  obligation: K-quant bytes-per-element equals block_bytes/256
+  property: |
+    For all c in {10,11,12,13,14,15}, ggml_dtype_element_size(c) ==
+    block_bytes(c)/256.0 with block_bytes = [84,110,144,176,210,292]. No panic.
+  bound: 1
+  strategy: exhaustive
+  solver: cadical
+  harness: verify_kquant_element_size
+
+qa_gate:
+  id: F-KQUANT-001
+  name: gguf-kquant-element-size-v1 Contract
+  description: GGUF K-quant tensors must report bytes-per-element equal to the exact ggml.h super-block ratio block_bytes/256, so total tensor byte sizes are reported correctly.
+  checks:
+  - validation
+  - falsification

--- a/crates/aprender-core/src/format/safetensors.rs
+++ b/crates/aprender-core/src/format/safetensors.rs
@@ -1,16 +1,20 @@
 /// Bytes per element for GGML data types (table lookup, O(1)).
 ///
-/// Block-quantized types use approximate bytes-per-element.
+/// Block-quantized types use exact bytes-per-element = block_bytes / block_elems.
+/// K-quant super-blocks pack QK_K=256 elements (ggml-common.h):
+///   Q2_K=84, Q3_K=110, Q4_K=144, Q5_K=176, Q6_K=210, Q8_K=292 bytes
+///   → 84/256, 110/256, 144/256, 176/256, 210/256, 292/256 (all exact dyadic).
 /// Unknown dtypes default to 4.0 (F32 size) as a conservative overestimate.
+/// See contracts/gguf-kquant-element-size-v1.yaml (PMAT-869).
 fn ggml_dtype_element_size(dtype: u32) -> f64 {
     // Index: [F32, F16, Q4_0, Q4_1, (4), (5), Q5_0, Q5_1, Q8_0, Q8_1,
     //         Q2_K, Q3_K, Q4_K, Q5_K, Q6_K, Q8_K, IQ2_XXS, IQ2_XS,
     //         IQ3_XXS, IQ1_S, IQ4_NL, IQ3_S, IQ2_S, IQ4_XS, I8, I16,
     //         BF16, I32, I64, F64, IQ1_M]
     const SIZES: [f64; 31] = [
-        4.0, 2.0, 0.5625, 0.625, 4.0, 4.0, 0.6875, 0.75, 1.0625, 1.125, 0.3125, 0.4375, 0.5625,
-        0.6875, 0.8125, 1.0625, 0.5625, 0.625, 0.6875, 0.4375, 0.5625, 0.4375, 0.625, 0.5, 1.0,
-        2.0, 2.0, 4.0, 8.0, 8.0, 0.375,
+        4.0, 2.0, 0.5625, 0.625, 4.0, 4.0, 0.6875, 0.75, 1.0625, 1.125, 0.328_125, 0.429_687_5,
+        0.5625, 0.6875, 0.820_312_5, 1.140_625, 0.5625, 0.625, 0.6875, 0.4375, 0.5625, 0.4375,
+        0.625, 0.5, 1.0, 2.0, 2.0, 4.0, 8.0, 8.0, 0.375,
     ];
     SIZES.get(dtype as usize).copied().unwrap_or(4.0)
 }

--- a/crates/aprender-core/src/format/tensors_tests_stats.rs
+++ b/crates/aprender-core/src/format/tensors_tests_stats.rs
@@ -305,18 +305,18 @@ fn test_ggml_dtype_element_size_exhaustive() {
     assert!((super::ggml_dtype_element_size(8) - 1.0625).abs() < 0.01);
     // Q8_1
     assert!((super::ggml_dtype_element_size(9) - 1.125).abs() < 0.01);
-    // Q2_K
-    assert!((super::ggml_dtype_element_size(10) - 0.3125).abs() < 0.01);
-    // Q3_K
-    assert!((super::ggml_dtype_element_size(11) - 0.4375).abs() < 0.01);
-    // Q4_K
+    // Q2_K = 84/256 (PMAT-869: was 0.3125)
+    assert!((super::ggml_dtype_element_size(10) - 0.328_125).abs() < 0.01);
+    // Q3_K = 110/256 (PMAT-869: was 0.4375)
+    assert!((super::ggml_dtype_element_size(11) - 0.429_687_5).abs() < 0.01);
+    // Q4_K = 144/256
     assert!((super::ggml_dtype_element_size(12) - 0.5625).abs() < 0.01);
-    // Q5_K
+    // Q5_K = 176/256
     assert!((super::ggml_dtype_element_size(13) - 0.6875).abs() < 0.01);
-    // Q6_K
-    assert!((super::ggml_dtype_element_size(14) - 0.8125).abs() < 0.01);
-    // Q8_K
-    assert!((super::ggml_dtype_element_size(15) - 1.0625).abs() < 0.01);
+    // Q6_K = 210/256 (PMAT-869: was 0.8125)
+    assert!((super::ggml_dtype_element_size(14) - 0.820_312_5).abs() < 0.01);
+    // Q8_K = 292/256 (PMAT-869: was 1.0625)
+    assert!((super::ggml_dtype_element_size(15) - 1.140_625).abs() < 0.01);
     // BF16
     assert!((super::ggml_dtype_element_size(26) - 2.0).abs() < 0.001);
     // I-quant types
@@ -338,6 +338,51 @@ fn test_ggml_dtype_element_size_exhaustive() {
     // Unknown defaults to F32 (4.0) — conservative size estimate
     assert!((super::ggml_dtype_element_size(99) - 4.0).abs() < 0.001);
     assert!((super::ggml_dtype_element_size(u32::MAX) - 4.0).abs() < 0.001);
+}
+
+// ====================================================================
+// PMAT-869: K-quant bytes-per-element must equal block_bytes / QK_K(256).
+// Falsifier — RED on the buggy table (Q2_K=0.3125, Q3_K=0.4375,
+// Q6_K=0.8125, Q8_K=1.0625), GREEN on the corrected exact ratios.
+// Reference ggml-common.h block sizes (QK_K=256):
+//   block_q2_K=84, block_q3_K=110, block_q4_K=144, block_q5_K=176,
+//   block_q6_K=210, block_q8_K=292.
+// Contract: contracts/gguf-kquant-element-size-v1.yaml
+// ====================================================================
+
+#[test]
+fn test_kquant_element_size_exact_block_ratio_pmat869() {
+    const QK_K: f64 = 256.0;
+    // (dtype code, block_bytes, label)
+    let cases: [(u32, f64, &str); 6] = [
+        (10, 84.0, "Q2_K"),
+        (11, 110.0, "Q3_K"),
+        (12, 144.0, "Q4_K"),
+        (13, 176.0, "Q5_K"),
+        (14, 210.0, "Q6_K"),
+        (15, 292.0, "Q8_K"),
+    ];
+    for (code, block_bytes, label) in cases {
+        let expected = block_bytes / QK_K;
+        let actual = super::ggml_dtype_element_size(code);
+        assert!(
+            (actual - expected).abs() < 1e-9,
+            "{label} (code {code}): expected {expected} (= {block_bytes}/256), got {actual}"
+        );
+    }
+
+    // Exact spec values (no tolerance slack — these are exact dyadic fractions).
+    assert_eq!(super::ggml_dtype_element_size(10), 0.328_125); // Q2_K  = 84/256
+    assert_eq!(super::ggml_dtype_element_size(11), 0.429_687_5); // Q3_K = 110/256
+    assert_eq!(super::ggml_dtype_element_size(12), 0.562_5); // Q4_K   = 144/256 (unchanged)
+    assert_eq!(super::ggml_dtype_element_size(13), 0.687_5); // Q5_K   = 176/256 (unchanged)
+    assert_eq!(super::ggml_dtype_element_size(14), 0.820_312_5); // Q6_K = 210/256
+    assert_eq!(super::ggml_dtype_element_size(15), 1.140_625); // Q8_K  = 292/256
+
+    // End-to-end: a tensor of N=256 Q2_K elements must report 84 bytes, not 80.
+    let n = 256.0_f64;
+    let q2k_bytes = (n * super::ggml_dtype_element_size(10)) as usize;
+    assert_eq!(q2k_bytes, 84, "256 Q2_K elements must report 84 bytes");
 }
 
 // ====================================================================


### PR DESCRIPTION
The ggml_dtype_element_size SIZES table mis-encoded 4 K-quant types (block_bytes/256): Q2_K 0.3125->0.328125, Q3_K 0.4375->0.4296875, Q6_K 0.8125->0.8203125, Q8_K 1.0625->1.140625, so apr mis-reported K-quant tensor byte sizes.

Falsifier RED 0.3125 -> GREEN 0.328125 (256 Q2_K elems = 84 bytes). 13927/0. contracts/gguf-kquant-element-size-v1.yaml pv-valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)