### PR TITLE
fix(calibration): IsotonicRegression interpolated inside pooled PAV blocks — not flat (PMAT-870)

### DIFF
--- a/contracts/isotonic-pav-flatness-v1.yaml
+++ b/contracts/isotonic-pav-flatness-v1.yaml
@@ -1,0 +1,141 @@
+# Isotonic Regression — PAV pooled-block flatness (sklearn parity)
+#
+# PMAT-870: After Pool-Adjacent-Violators (PAV) pooling, the fitted isotonic
+# function MUST be piecewise-constant (FLAT) at the pooled value across the whole
+# x-range of each pooled block. Both endpoints (x_min and x_max) of a pooled block
+# are kept as knots so that a query strictly inside a pooled block returns the
+# constant pooled value, and interpolation only happens BETWEEN the max-x edge of
+# one block and the min-x edge of the next. This matches sklearn's
+# IsotonicRegression (X_thresholds_ / y_thresholds_).
+kind: KernelContract
+metadata:
+  version: 1.0.0
+  created: '2026-06-20'
+  author: PAIML Engineering
+  description: >-
+    Isotonic Regression PAV flatness contract — the fitted calibrator is
+    piecewise-constant on pooled Pool-Adjacent-Violators blocks; both block
+    endpoints (x_min, x_max) are recorded as knots so interior queries return the
+    constant pooled value (sklearn IsotonicRegression parity).
+  references:
+  - 'Zadrozny & Elkan (2002) Transforming classifier scores into accurate multiclass probability estimates'
+  - 'Ayer et al. (1955) An empirical distribution function for sampling with incomplete information (PAV)'
+  - 'scikit-learn sklearn.isotonic.IsotonicRegression (X_thresholds_, y_thresholds_)'
+  lessons_learned:
+  - 'PMAT-870: recording only block x_min discarded x_max → interior queries inside a pooled block were linearly interpolated toward the next block instead of returning the flat pooled value.'
+equations:
+  pav_pooled_value:
+    formula: 'v_b = (1/|B|) * sum_{i in B} y_i'
+    domain: 'B = pooled PAV block of (x_i, y_i) pairs, y_i in {0, 1}'
+    codomain: v_b in [0, 1]
+    invariants:
+    - Pooled value is the mean of the labels in the block
+    - Block values are non-decreasing across blocks (monotone isotonic fit)
+    preconditions:
+    - predictions.len() == labels.len()
+  piecewise_constant_block:
+    formula: 'f(x) = v_b for all x in [x_min(B), x_max(B)]'
+    domain: 'x in [x_min(B), x_max(B)], pooled block B with x_max(B) >= x_min(B)'
+    codomain: f(x) in [0, 1]
+    invariants:
+    - The fit is FLAT (constant v_b) across the entire x-range of a pooled block
+    - Both endpoints x_min(B) and x_max(B) are kept as knots with value v_b
+    - A multi-point pooled block emits TWO equal-value knots; a single-point block emits ONE
+    preconditions:
+    - 'block knots are sorted ascending in x'
+  inter_block_interpolation:
+    formula: 'f(x) = v_a + (x - x_max(A)) / (x_min(C) - x_max(A)) * (v_c - v_a)'
+    domain: 'x in (x_max(A), x_min(C)) between adjacent blocks A and C'
+    codomain: f(x) in [v_a, v_c]
+    invariants:
+    - Interpolation occurs ONLY between the max-x edge of one block and the min-x edge of the next
+    - Degenerate equal-x knots (x_max(A) == x_min(C)) return the left value (no division by zero)
+    preconditions:
+    - 'x_min(C) - x_max(A) guarded by < 1e-10 threshold'
+proof_obligations:
+- type: invariant
+  property: Piecewise-constant on pooled blocks
+  formal: 'for all x in [x_min(B), x_max(B)], predict(x) == v_b'
+  applies_to: all
+- type: invariant
+  property: Both block endpoints kept as knots
+  formal: 'x_max(B) > x_min(B) implies (x_min(B), v_b) and (x_max(B), v_b) are both knots'
+  applies_to: all
+- type: ordering
+  property: Inter-block interpolation only
+  formal: 'predict(x) interpolates only for x in (x_max(A), x_min(C)) between adjacent blocks A, C'
+  applies_to: all
+- type: monotonicity
+  property: Monotone non-decreasing fit
+  formal: 'p1 <= p2 implies predict(p1) <= predict(p2)'
+  applies_to: all
+- type: bound
+  property: Calibrated value in unit interval
+  formal: '0 <= predict(x) <= 1'
+  applies_to: all
+falsification_tests:
+- id: FALSIFY-ISO-PAV-001
+  rule: Flat pooled block (max-x edge)
+  prediction: 'fit X=[0.0,0.1,0.2,0.3] y=[0,1,0,1] (PAV pools x=0.1,0.2 to 0.5); predict(0.2)==0.5'
+  test: 'crates/aprender-core/src/calibration_tests.rs::test_isotonic_pav_block_is_flat_pmat_870'
+  if_fails: 'Only x_min kept as knot — interior query interpolates toward next block (RED: 0.75)'
+- id: FALSIFY-ISO-PAV-002
+  rule: Flat pooled block (interior)
+  prediction: 'same fit; predict(0.15)==0.5 (strictly inside pooled [0.1,0.2] block)'
+  test: 'crates/aprender-core/src/calibration_tests.rs::test_isotonic_pav_block_is_flat_pmat_870'
+  if_fails: 'Block max-x knot missing — interior interpolates (RED: 0.625)'
+- id: FALSIFY-ISO-PAV-003
+  rule: Inter-block interpolation
+  prediction: 'same fit; predict(0.25)==0.75 (between block edge x=0.2 v=0.5 and x=0.3 v=1.0)'
+  test: 'crates/aprender-core/src/calibration_tests.rs::test_isotonic_pav_block_is_flat_pmat_870'
+  if_fails: 'Interpolation anchored on wrong edge (RED: 0.875)'
+- id: FALSIFY-ISO-PAV-004
+  rule: No-pool guard (unchanged behavior)
+  prediction: 'fit X=[0,0.2,0.4,0.6,0.8,1.0] y=[0,0,0,1,1,1]; predict(0.5)==0.5 (interp between half blocks)'
+  test: 'crates/aprender-core/src/calibration_tests.rs::test_isotonic_no_pool_guard_pmat_870'
+  if_fails: 'Two-knot emission changed non-pooled-interior behavior (regression)'
+- id: FALSIFY-ISO-PAV-005
+  rule: Monotone non-decreasing
+  prediction: 'predict(x) is non-decreasing in x for any fitted calibrator'
+  test: 'crates/aprender-core/src/calibration_tests.rs::test_isotonic_monotonic'
+  if_fails: 'PAV merge or knot emission broke monotonicity'
+falsification:
+  command: 'cargo test -p aprender-core --lib pmat_870'
+  red:
+    description: 'Bug present (only x_min kept as knot): pooled block is not flat.'
+    predict_0_2: 0.75
+    predict_0_15: 0.625
+    predict_0_25: 0.875
+  green:
+    description: 'Fix present (both x_min and x_max kept as knots): pooled block is flat.'
+    predict_0_2: 0.5
+    predict_0_15: 0.5
+    predict_0_25: 0.75
+  sklearn_reference:
+    model: 'sklearn.isotonic.IsotonicRegression().fit([0.0,0.1,0.2,0.3], [0,1,0,1])'
+    x_thresholds: [0.0, 0.1, 0.2, 0.3]
+    y_thresholds: [0.0, 0.5, 0.5, 1.0]
+    predict_0_2: 0.5
+    predict_0_15: 0.5
+    predict_0_25: 0.75
+kani_harnesses:
+- id: KANI-ISO-PAV-001
+  obligation: Piecewise-constant on pooled blocks
+  property: 'Query inside a pooled block returns the constant pooled value'
+  bound: 4
+  strategy: stub_float
+- id: KANI-ISO-PAV-002
+  obligation: Monotone non-decreasing fit
+  property: 'predict is non-decreasing in its argument'
+  bound: 4
+  strategy: stub_float
+qa_gate:
+  id: F-ISO-PAV-001
+  name: Isotonic PAV Flatness Contract
+  description: 'PAV pooled blocks are piecewise-constant; both endpoints kept as knots (sklearn parity)'
+  checks:
+  - flat_pooled_block
+  - inter_block_interpolation_only
+  - monotone_fit
+  pass_criteria: 'All 5 falsification tests pass; predict matches sklearn X_thresholds_/y_thresholds_'
+  falsification: 'Record only block x_min as knot — pooled-block interior queries interpolate toward the next block'

--- a/crates/aprender-core/src/calibration.rs
+++ b/crates/aprender-core/src/calibration.rs
@@ -251,20 +251,25 @@ impl IsotonicRegression {
             return;
         }
 
-        // PAV algorithm: merge adjacent violators
-        let mut blocks: Vec<(f32, f32, usize)> = Vec::new(); // (x_min, sum, count)
+        // PAV algorithm: merge adjacent violators.
+        // Track BOTH endpoints of each pooled block (x_min, x_max) so the fitted
+        // function is FLAT across the whole x-range of a pooled block (sklearn
+        // IsotonicRegression parity, PMAT-870). Recording only x_min would leave a
+        // pooled block as a single knot and cause interior queries to interpolate
+        // toward the next block instead of returning the constant pooled value.
+        let mut blocks: Vec<(f32, f32, f32, usize)> = Vec::new(); // (x_min, x_max, sum, count)
 
         for (x, y) in pairs {
-            blocks.push((x, y, 1));
+            blocks.push((x, x, y, 1));
 
             // While last two blocks violate monotonicity, merge them
             while blocks.len() >= 2 {
                 let len = blocks.len();
-                let avg_last = blocks[len - 1].1 / blocks[len - 1].2 as f32;
-                let avg_prev = blocks[len - 2].1 / blocks[len - 2].2 as f32;
+                let avg_last = blocks[len - 1].2 / blocks[len - 1].3 as f32;
+                let avg_prev = blocks[len - 2].2 / blocks[len - 2].3 as f32;
 
                 if avg_last < avg_prev {
-                    // Merge: keep x_min from prev, sum totals
+                    // Merge: keep x_min from prev, x_max from last, sum totals.
                     // Safe: we check blocks.len() >= 2 in the while condition
                     let last = blocks
                         .pop()
@@ -272,20 +277,28 @@ impl IsotonicRegression {
                     let prev = blocks
                         .pop()
                         .expect("blocks guaranteed to have 2+ elements by while condition");
-                    blocks.push((prev.0, prev.1 + last.1, prev.2 + last.2));
+                    blocks.push((prev.0, last.1, prev.2 + last.2, prev.3 + last.3));
                 } else {
                     break;
                 }
             }
         }
 
-        // Extract thresholds and values
+        // Extract thresholds and values. For a pooled block spanning [x_min, x_max]
+        // with x_max > x_min, emit TWO knots at the same value so predict()
+        // interpolates to the constant across the block interior; degenerate
+        // single-point blocks emit one knot.
         self.thresholds.clear();
         self.values.clear();
 
-        for (x_min, sum, count) in blocks {
+        for (x_min, x_max, sum, count) in blocks {
+            let val = sum / count as f32;
             self.thresholds.push(x_min);
-            self.values.push(sum / count as f32);
+            self.values.push(val);
+            if x_max > x_min {
+                self.thresholds.push(x_max);
+                self.values.push(val);
+            }
         }
     }
 

--- a/crates/aprender-core/src/calibration_tests.rs
+++ b/crates/aprender-core/src/calibration_tests.rs
@@ -174,6 +174,74 @@ fn test_isotonic_monotonic() {
     }
 }
 
+// PMAT-870: PAV pooled-block flatness (sklearn IsotonicRegression parity).
+//
+// After Pool-Adjacent-Violators pooling, the fitted function must be FLAT at the
+// pooled value across the WHOLE x-range of a pooled block. The bug recorded only
+// the block's min-x as a knot, discarding the max-x, so a query strictly inside a
+// pooled block was linearly interpolated toward the NEXT block instead of returning
+// the constant pooled value.
+//
+// Reference: sklearn.isotonic.IsotonicRegression
+//   X=[0.0,0.1,0.2,0.3], y=[0,1,0,1] → PAV pools x=0.1,0.2 to value 0.5
+//   X_thresholds_=[0.0,0.1,0.2,0.3], y_thresholds_=[0.0,0.5,0.5,1.0]
+//   predict(0.2)=0.5, predict(0.15)=0.5, predict(0.25)=0.75
+#[test]
+fn test_isotonic_pav_block_is_flat_pmat_870() {
+    let mut iso = IsotonicRegression::new();
+    let predictions = vec![0.0, 0.1, 0.2, 0.3];
+    let labels = vec![false, true, false, true]; // y = [0, 1, 0, 1]
+
+    iso.fit(&predictions, &labels);
+
+    // Inside the pooled [0.1, 0.2] block → flat at the pooled value 0.5.
+    // RED (bug): predict(0.2)=0.75, predict(0.15)=0.625
+    // GREEN (fix): both = 0.5
+    let p_max_edge = iso.predict(0.2);
+    let p_mid = iso.predict(0.15);
+    assert!(
+        (p_max_edge - 0.5).abs() < 1e-5,
+        "PMAT-870 FALSIFIED: predict(0.2)={p_max_edge}, expected 0.5 (flat pooled block)"
+    );
+    assert!(
+        (p_mid - 0.5).abs() < 1e-5,
+        "PMAT-870 FALSIFIED: predict(0.15)={p_mid}, expected 0.5 (flat pooled block)"
+    );
+
+    // Between the pooled block (val 0.5 at x=0.2) and the final block (val 1.0 at
+    // x=0.3): linear interpolation. predict(0.25) = 0.5 + 0.5*(1.0-0.5) = 0.75.
+    // RED (bug): 0.875
+    let p_interp = iso.predict(0.25);
+    assert!(
+        (p_interp - 0.75).abs() < 1e-5,
+        "PMAT-870 FALSIFIED: predict(0.25)={p_interp}, expected 0.75 (interp between blocks)"
+    );
+}
+
+// PMAT-870: NO-POOL guard — when no adjacent violators exist, behavior must be
+// unchanged. Each x is its own block, so interpolation between distinct single-point
+// blocks still applies. X=[0,0.2,0.4,0.6,0.8,1.0], y=[0,0,0,1,1,1].
+// PAV pools the two halves: block A (x 0..0.4, val 0) and block B (x 0.6..1.0, val 1).
+// predict(0.5) interpolates between A's max-edge (x=0.4, val 0) and B's min-edge
+// (x=0.6, val 1): 0.0 + 0.5*(1.0-0.0) = 0.5.
+#[test]
+fn test_isotonic_no_pool_guard_pmat_870() {
+    let mut iso = IsotonicRegression::new();
+    let predictions = vec![0.0, 0.2, 0.4, 0.6, 0.8, 1.0];
+    let labels = vec![false, false, false, true, true, true];
+
+    iso.fit(&predictions, &labels);
+
+    let p = iso.predict(0.5);
+    assert!(
+        (p - 0.5).abs() < 1e-5,
+        "PMAT-870 FALSIFIED (no-pool guard): predict(0.5)={p}, expected 0.5"
+    );
+    // Endpoints stay clamped at the block values.
+    assert!((iso.predict(0.1) - 0.0).abs() < 1e-5);
+    assert!((iso.predict(0.9) - 1.0).abs() < 1e-5);
+}
+
 #[test]
 fn test_reliability_diagram() {
     let predictions = vec![0.1, 0.2, 0.8, 0.9];


### PR DESCRIPTION
IsotonicRegression kept only x_min per PAV block, discarding x_max, so queries inside a multi-point pooled block were interpolated toward the next block instead of returning the flat pooled value. [0,0.1,0.2,0.3]/[0,1,0,1]: apr predict(0.2)=0.75 vs sklearn 0.5. Fixed to emit both block endpoints as knots (sklearn y_thresholds_).

Falsifier RED 0.75 -> GREEN 0.5. 13932/0. contracts/isotonic-pav-flatness-v1.yaml pv-valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)