### PR TITLE
fix(metrics): Calinski-Harabasz/Davies-Bouldin counted phantom empty clusters (k=max+1) — not relabel-invariant (PMAT-871)

### DIFF
--- a/contracts/clustering-metrics-relabel-invariant-v1.yaml
+++ b/contracts/clustering-metrics-relabel-invariant-v1.yaml
@@ -1,0 +1,81 @@
+metadata:
+  version: "1.0.0"
+  created: "2026-06-20"
+  author: PAIML Engineering
+  registry: true
+  references:
+    - "sklearn.metrics.calinski_harabasz_score (oracle — uses LabelEncoder → dense 0..n_labels)"
+    - "sklearn.metrics.davies_bouldin_score (oracle — uses LabelEncoder → dense 0..n_labels)"
+    - "Caliński & Harabasz (1974) A dendrite method for cluster analysis"
+    - "Davies & Bouldin (1979) A Cluster Separation Measure, IEEE TPAMI"
+  description: |
+    Correctness contract for the Calinski–Harabasz and Davies–Bouldin clustering
+    metrics in aprender-core (metrics::calinski_harabasz_score /
+    metrics::davies_bouldin_score). Pillar-1 (sklearn parity) provable-correctness.
+
+    PMAT-871 fixed a defect where both functions derived the cluster count as
+    `k = labels.iter().max() + 1`, treating labels as a contiguous `0..=max` range.
+    For NON-contiguous labels (a gap left by a dropped cluster, e.g. [0,0,2,2,2], or
+    DBSCAN-style sparse output) every gap index became a PHANTOM empty cluster
+    (count = 0, centroid at the origin). For CH this corrupts both the (k-1)
+    numerator and (n-k) denominator of the variance-ratio F; for DB the phantom
+    origin-centroid pollutes the centroid-distance ratios and the 1/k average.
+    The same partition therefore returned DIFFERENT scores under relabeling.
+
+    Measured on data [[1,1],[1.5,2],[3,4],[5,7],[3.5,5]] with the SAME partition
+    {0,1}|{2,3,4}: labels [0,0,1,1,1] gave CH=10.3140, but [0,0,2,2,2] gave
+    CH=3.4380 (a 3x error) and DB=0.3721 vs 0.4150. sklearn (LabelEncoder) gives
+    CH=10.3140, DB=0.4150 for BOTH encodings. The fix remaps labels to a dense
+    0..n_distinct range and sets k = |distinct labels| before computing centroids,
+    scatter, B/W, and the (k-1)/(n-k) divisors — exactly sklearn's semantics.
+
+kind: KernelContract
+name: clustering-metrics-relabel-invariant
+version: "1.0.0"
+scope: "crates/aprender-core/src/metrics/mod.rs"
+
+description: |
+  Clustering metrics depend ONLY on the partition (the equivalence relation the
+  labels induce), NOT on the particular integer names assigned to clusters. Both
+  CH and DB must therefore be INVARIANT under any relabeling (bijection on the
+  label set), and the cluster count must be the number of DISTINCT labels present,
+  never `max(labels) + 1`. Gaps in the label set must not create empty clusters.
+
+equations:
+  C-CLUSTER-RELABEL-001:
+    description: "Cluster count k is the number of distinct labels (sklearn LabelEncoder), not max+1"
+    formula: "k = |{ labels[i] : 0 ≤ i < n }|  (NOT max(labels) + 1)"
+    note: "For labels [0,0,2,2,2] the correct k is 2, not 3; index 1 must NOT become a phantom empty cluster."
+
+  C-CLUSTER-RELABEL-002:
+    description: "Calinski–Harabasz is invariant under relabeling and matches the sklearn oracle"
+    formula: "calinski_harabasz_score(X, sigma.L) = calinski_harabasz_score(X, L) for all bijections sigma; e.g. X=[[1,1],[1.5,2],[3,4],[5,7],[3.5,5]], L=[0,0,1,1,1] => CH=10.3140 == CH for L=[0,0,2,2,2]"
+    note: "RED (max+1 bug): gapped [0,0,2,2,2] => CH=3.4380 (3x error). GREEN: CH=10.3140 for both."
+
+  C-CLUSTER-RELABEL-003:
+    description: "Davies–Bouldin is invariant under relabeling and matches the sklearn oracle"
+    formula: "davies_bouldin_score(X, sigma.L) = davies_bouldin_score(X, L) for all bijections sigma; same X => DB=0.4150 for both [0,0,1,1,1] and [0,0,2,2,2]"
+    note: "RED (max+1 bug): gapped [0,0,2,2,2] => DB=0.3721 (phantom origin-centroid + inflated k). GREEN: DB=0.4150 for both."
+
+proof_obligations:
+  - type: invariant
+    property: cluster count equals number of distinct labels
+    formal: |
+      k computed by both calinski_harabasz_score and davies_bouldin_score equals
+      |distinct(labels)|; no index in (max+1 minus distinct) contributes a cluster.
+  - type: equivalence
+    property: Calinski-Harabasz invariant under relabeling
+    formal: |
+      For any bijection sigma on the label set, CH(X, sigma.L) == CH(X, L); the
+      gapped encoding [0,0,2,2,2] yields the same score (10.3140) as [0,0,1,1,1].
+  - type: equivalence
+    property: Davies-Bouldin invariant under relabeling
+    formal: |
+      For any bijection sigma on the label set, DB(X, sigma.L) == DB(X, L); the
+      gapped encoding [0,0,2,2,2] yields the same score (0.4150) as [0,0,1,1,1].
+
+falsification:
+  - id: FALSIFY-CLUSTER-RELABEL-001
+    description: "CH and DB are relabeling-invariant and match the sklearn oracle for a gapped (non-contiguous) labeling. Discharges C-CLUSTER-RELABEL-001/002/003."
+    test: "clustering_metrics_relabel_invariant_pmat_871 — CH: gapped RED 3.4380 → GREEN 10.3140 == contiguous; DB: gapped RED 0.3721 → GREEN 0.4150 == contiguous. sklearn reference: CH=10.3140, DB=0.4150 for both [0,0,1,1,1] and [0,0,2,2,2]."
+    evidence: "cargo test -p aprender-core --lib clustering_metrics_relabel_invariant_pmat_871"

--- a/crates/aprender-core/src/metrics/mod.rs
+++ b/crates/aprender-core/src/metrics/mod.rs
@@ -370,13 +370,37 @@ mod tests_clustering_contract;
 mod tests_ranking_contract;
 pub use classification::{fbeta_score, jaccard_score};
 
+/// Remaps cluster labels to a dense `0..k` range based on the set of DISTINCT
+/// labels present, mirroring sklearn's `LabelEncoder`. Returns the dense labels
+/// and `k = n_distinct`. This makes clustering metrics invariant under relabeling
+/// and avoids phantom empty clusters when labels are non-contiguous (e.g. a cluster
+/// was dropped, leaving a gap, or DBSCAN-style sparse output).
+fn dense_relabel(labels: &[usize]) -> (Vec<usize>, usize) {
+    let mut distinct: Vec<usize> = labels.to_vec();
+    distinct.sort_unstable();
+    distinct.dedup();
+    let dense: Vec<usize> = labels
+        .iter()
+        .map(|&l| {
+            distinct
+                .binary_search(&l)
+                .expect("label present in distinct set")
+        })
+        .collect();
+    (dense, distinct.len())
+}
+
 /// Davies–Bouldin score (lower is better), matching `sklearn.metrics.davies_bouldin_score`.
 /// Mean over clusters of the worst-case ratio `(S_i + S_j) / d(c_i, c_j)`, where
 /// `S` is mean intra-cluster distance to centroid and `d` is centroid distance.
+///
+/// The score depends only on the partition and is invariant under relabeling:
+/// cluster count is `k = |distinct labels|`, so non-contiguous labels never create
+/// phantom empty clusters (sklearn `LabelEncoder` semantics).
 #[must_use]
 pub fn davies_bouldin_score(data: &Matrix<f32>, labels: &[usize]) -> f32 {
     let (n, nf) = data.shape();
-    let k = labels.iter().max().map_or(0, |&m| m + 1);
+    let (labels, k) = dense_relabel(labels);
     if k < 2 {
         return 0.0;
     }
@@ -438,10 +462,15 @@ pub fn davies_bouldin_score(data: &Matrix<f32>, labels: &[usize]) -> f32 {
 
 /// Calinski–Harabasz score (variance ratio; higher is better), matching
 /// `sklearn.metrics.calinski_harabasz_score`: `(B/(k-1)) / (W/(n-k))`.
+///
+/// The score depends only on the partition and is invariant under relabeling:
+/// cluster count is `k = |distinct labels|`, so non-contiguous labels never create
+/// phantom empty clusters that would corrupt the `(k-1)` and `(n-k)` divisors
+/// (sklearn `LabelEncoder` semantics).
 #[must_use]
 pub fn calinski_harabasz_score(data: &Matrix<f32>, labels: &[usize]) -> f32 {
     let (n, nf) = data.shape();
-    let k = labels.iter().max().map_or(0, |&m| m + 1);
+    let (labels, k) = dense_relabel(labels);
     if k < 2 || n <= k {
         return 0.0;
     }
@@ -508,6 +537,49 @@ mod tests_clustering_extra {
         let labels = [0usize, 0, 1, 1, 1, 1, 1];
         assert!((davies_bouldin_score(&data, &labels) - 0.364_795).abs() < 1e-3);
         assert!((calinski_harabasz_score(&data, &labels) - 16.742_773).abs() < 1e-2);
+    }
+
+    /// PMAT-871 falsifier: clustering metrics depend ONLY on the partition and must
+    /// be invariant under relabeling. Non-contiguous labels (a gap left by a dropped
+    /// cluster, or DBSCAN-style sparse output) must NOT create phantom empty clusters.
+    ///
+    /// data = [[1,1],[1.5,2],[3,4],[5,7],[3.5,5]]; the partition `{0,1}|{2,3,4}` is the
+    /// same whether encoded `[0,0,1,1,1]` (contiguous) or `[0,0,2,2,2]` (gap at index 1).
+    /// sklearn (LabelEncoder → dense labels) gives CH=10.3140, DB=0.4150 for BOTH.
+    ///
+    /// RED (pre-fix, `k = max+1`): gapped CH=3.4380 (3x error), gapped DB=0.3721.
+    /// GREEN (post-fix, `k = |distinct|`): both encodings give CH≈10.3140, DB≈0.4150.
+    #[test]
+    fn clustering_metrics_relabel_invariant_pmat_871() {
+        let data = Matrix::from_vec(5, 2, vec![1.0, 1.0, 1.5, 2.0, 3.0, 4.0, 5.0, 7.0, 3.5, 5.0])
+            .expect("valid");
+        let contiguous = [0usize, 0, 1, 1, 1];
+        let gapped = [0usize, 0, 2, 2, 2];
+
+        let ch_contig = calinski_harabasz_score(&data, &contiguous);
+        let ch_gapped = calinski_harabasz_score(&data, &gapped);
+        let db_contig = davies_bouldin_score(&data, &contiguous);
+        let db_gapped = davies_bouldin_score(&data, &gapped);
+
+        // Invariance under relabeling.
+        assert!(
+            (ch_contig - ch_gapped).abs() < 1e-2,
+            "CH must be relabeling-invariant: contiguous={ch_contig} gapped={ch_gapped}"
+        );
+        assert!(
+            (db_contig - db_gapped).abs() < 1e-3,
+            "DB must be relabeling-invariant: contiguous={db_contig} gapped={db_gapped}"
+        );
+
+        // Absolute match to sklearn reference.
+        assert!(
+            (ch_gapped - 10.3140).abs() < 1e-2,
+            "CH must match sklearn 10.3140, got {ch_gapped}"
+        );
+        assert!(
+            (db_gapped - 0.4150).abs() < 1e-3,
+            "DB must match sklearn 0.4150, got {db_gapped}"
+        );
     }
 }
 


### PR DESCRIPTION
calinski_harabasz_score/davies_bouldin_score used k=max(label)+1, so non-contiguous labels created phantom empty clusters and the same partition scored differently under relabeling. [0,0,1,1,1] CH=10.31 vs [0,0,2,2,2] CH=3.44. Fixed to dense-remap distinct labels (sklearn LabelEncoder).

Falsifier RED 3.44 -> GREEN 10.31 (invariant). 13931/0. contracts/clustering-metrics-relabel-invariant-v1.yaml pv-valid.

Generated with Claude Code