### PR TITLE
fix(test): orchestrate env tests raced on global APR_CONFIG — flaky workspace-test (PMAT-876)

### DIFF
--- a/contracts/orchestrate-env-test-hermeticity-v1.yaml
+++ b/contracts/orchestrate-env-test-hermeticity-v1.yaml
@@ -1,0 +1,167 @@
+metadata:
+  version: "1.0.0"
+  created: "2026-06-20"
+  updated: "2026-06-20"
+  author: PAIML Engineering
+  registry: true
+  references:
+    - "Rust std::env docs — set_var/remove_var are process-global; the environment table is shared by every thread in the process (https://doc.rust-lang.org/std/env/fn.set_var.html)"
+    - "The Rust Programming Language — `cargo test` runs tests in parallel by default; --test-threads controls the thread pool (https://doc.rust-lang.org/book/ch11-02-running-tests.html)"
+    - "PMAT-876 — workspace-test intermittently fails at agent::auto_memory::tests::root_uses_config_dir_when_env_unset; three separate module-private env_lock mutexes did NOT serialize across modules that mutate the SAME APR_CONFIG variable"
+    - "paiml/aprender PR #1567 — original per-module env_lock pattern (agent::instructions::tests) the three-module duplication descended from"
+  description: "Env-mutating tests in aprender-orchestrate acquire ONE crate-wide lock and restore prior env values, so they are deterministic under parallel test execution"
+
+kind: KernelContract
+name: orchestrate-env-test-hermeticity
+version: "1.0.0"
+scope: "crates/aprender-orchestrate/src/agent/{env_test_support.rs,auto_memory.rs,settings.rs,instructions.rs}::tests + crates/aprender-orchestrate/src/cli/agent_tests.rs::test_build_driver_remote_no_key_returns_mock"
+
+description: |
+  PMAT-876. `std::env` is PROCESS-GLOBAL: a single environment table is
+  shared by every thread in the process. `cargo test` / nextest run
+  `#[test]` functions in PARALLEL by default. Therefore two tests that
+  each `set_var` / `remove_var` the SAME variable (or one mutates while
+  another reads it) interleave non-deterministically and observe the
+  wrong value.
+
+  In aprender-orchestrate, three test modules — `agent::auto_memory`,
+  `agent::settings`, and `agent::instructions` — all mutate the SAME
+  `APR_CONFIG` variable. Each module historically defined its OWN
+  module-private `static LOCK: Mutex<()>` and acquired only that lock.
+  That serializes tests WITHIN a module but NOT ACROSS modules, so a
+  test in `auto_memory` racing a test in `settings` still corrupted the
+  shared env: e.g. `auto_memory::tests::root_uses_config_dir_when_env_unset`
+  removed `APR_CONFIG`, asserted it was unset, but a parallel
+  `settings`/`instructions` test had just `set_var`'d it — intermittent
+  `workspace-test` FAILURE that repeatedly broke the merge queue.
+
+  This contract codifies the hermetic-test invariant:
+
+  1. There is exactly ONE crate-wide lock
+     (`agent::env_test_support::ENV_LOCK`). EVERY test that touches
+     process env across the whole crate acquires THIS lock for the full
+     duration it touches the env. Non-env tests stay parallel.
+  2. Every env-mutating test SAVES the prior value, sets/removes its
+     value, runs, then RESTORES the prior value (via the
+     `ScopedEnv` RAII guard) — the env is never left mutated for the
+     next test to observe.
+  3. The lock is poison-tolerant
+     (`lock().unwrap_or_else(|e| e.into_inner())`): a panicking test
+     poisons the mutex, but the lock guards no data we care about (it
+     only serializes access to the global env table), so we recover the
+     guard rather than cascading failures.
+
+  The result is determinism under parallelism: the falsifier
+  (multi-run / `--test-threads=8`) passes with 0 failures every time.
+
+  ## status_line is already hermetic (no change needed)
+  `agent::status_line::short_cwd(path, home: Option<&Path>)` takes the
+  home dir as a PARAMETER (dependency injection), so its tests
+  (`short_cwd_falls_back_when_home_is_none`) never touch global env and
+  are unaffected. The ideal pattern — pass the env in — is preserved
+  where it already exists.
+
+equations:
+  single_shared_lock:
+    description: "All env-mutating tests in the crate serialize on ONE lock; concurrent env access is impossible"
+    formula: |
+      ENV_LOCK : Mutex<()>                       # exactly one, crate-wide
+      for every env-mutating test T:
+          guard = ENV_LOCK.lock()                # held across set -> assert -> restore
+          # ... mutate/read process env ...
+      held(guard_A) AND held(guard_B) => A == B  # mutual exclusion
+
+  save_then_restore:
+    description: "Each env-mutating test restores the prior value (or absence) on drop — the env table is unchanged after the test"
+    formula: |
+      prior = env::var(KEY).ok()                 # ScopedEnv::set/remove saves this
+      env::set_var(KEY, v)  OR  env::remove_var(KEY)
+      # ... test body ...
+      on drop: match prior { Some(v) => set_var(KEY, v), None => remove_var(KEY) }
+      env_table_after == env_table_before        # idempotent on the env
+
+  determinism_under_parallelism:
+    description: "Same test set + any thread count => identical pass result (0 failures)"
+    formula: |
+      run(tests, threads=N) == PASS   for all N >= 1, over repeated runs
+
+falsification_tests:
+  - id: F-ENV-HERMETIC-001
+    rule: single_shared_lock
+    prediction: "auto_memory + settings + instructions env tests run at --test-threads=8/16 pass 0 failures across repeated runs"
+    test: |
+      cargo test -p aprender-orchestrate --lib -- --test-threads=16 \
+        agent::auto_memory::tests agent::settings::tests \
+        agent::instructions::tests agent::env_test_support
+      Repeat 5x; every run must report `0 failed`. RED on the bug: with
+      three separate per-module mutexes, the cross-module APR_CONFIG race
+      fails ~1-in-3 runs (reproduced pre-fix: run 3 = 56 passed; 1 failed,
+      panic at auto_memory.rs root_uses_config_dir_when_env_unset and
+      siblings). GREEN on the fix: 5/5 runs pass (60 passed; 0 failed).
+    if_fails: "An env-mutating test is not acquiring the single crate-wide ENV_LOCK (or a new module reintroduced a private mutex) — route it through agent::env_test_support::env_lock"
+
+  - id: F-ENV-HERMETIC-002
+    rule: save_then_restore
+    prediction: "ScopedEnv restores the prior value: set over an absent var leaves it absent; remove over a present var restores the value"
+    test: |
+      cargo test -p aprender-orchestrate --lib -- \
+        agent::env_test_support::tests
+      scoped_env_set_restores_prior_absence and
+      scoped_env_remove_restores_prior_value assert the env table is
+      unchanged after the guard drops. RED if Drop is wrong (leaves the
+      var mutated); GREEN with correct save/restore.
+    if_fails: "ScopedEnv::drop does not restore the saved prior value/absence — a later test will observe a leaked env mutation"
+
+  - id: F-ENV-HERMETIC-003
+    rule: determinism_under_parallelism
+    prediction: "The full aprender-orchestrate lib test suite passes 0 failures at --test-threads=8 across repeated runs"
+    test: |
+      cargo test -p aprender-orchestrate --lib -- --test-threads=8
+      Repeat 3x; every run must report 0 failed (measured: 6506 passed;
+      0 failed, 3/3 runs post-fix). RED on the bug: the cross-module
+      APR_CONFIG race surfaces intermittently in the full parallel run
+      (the original workspace-test signature: 6538 passed; 1 failed).
+    if_fails: "A process-global env mutation in the crate is unguarded; grep set_var|remove_var under crates/aprender-orchestrate/src and route every hit through the shared lock + ScopedEnv"
+
+proof_obligations:
+  - type: determinism
+    property: "Env-mutating tests are deterministic under parallel execution (one shared lock serializes all global-env access)"
+    formal: "for all thread counts N>=1 and repeated runs: run(env_tests, N) == PASS"
+    applies_to: single_shared_lock
+
+  - type: idempotency
+    property: "Each env-mutating test leaves the process env table unchanged (save prior, mutate, restore prior on drop)"
+    formal: "env_table_after_test == env_table_before_test"
+    applies_to: save_then_restore
+
+  - type: independence
+    property: "No two env-mutating tests observe each other's transient env mutation (mutual exclusion on the global env table)"
+    formal: "held(guard_A) AND held(guard_B) => A == B (the same single ENV_LOCK)"
+    applies_to: single_shared_lock
+
+scope_extension:
+  in_scope:
+    - "agent::env_test_support: the single crate-wide ENV_LOCK + ScopedEnv save/restore RAII guard (test-only module)"
+    - "agent::auto_memory / settings / instructions tests: route through the shared env_lock + ScopedEnv; remove the three per-module mutexes"
+    - "cli::agent_tests::test_build_driver_remote_no_key_returns_mock: ANTHROPIC_API_KEY guarded with a self-contained lock + restore (this test compiles in the BINARY test crate, which cannot reach the lib-side test-only module)"
+  out_of_scope:
+    - "agent::status_line tests — already hermetic; short_cwd takes home as a parameter and never touches global env"
+    - "Production code reads of env (auto_memory_root, settings, instructions, apr_serve config) — unchanged; only TEST hermeticity is in scope"
+    - "Migrating the binary-crate ANTHROPIC_API_KEY test to a shared lib lock — blocked by crate boundary (cli/* is declared in main.rs, not the batuta lib); a self-contained guard with identical semantics is used instead"
+
+status_history:
+  - version: "1.0.0"
+    date: "2026-06-20"
+    pr: "paiml/aprender (PMAT-876 impl PR — fix/pmat-876-orchestrate-env-test-hermeticity)"
+    summary: |
+      Initial contract registered + DISCHARGED in the same PR. Root
+      cause: three separate per-module env_lock mutexes did not
+      serialize across modules that all mutate the SAME APR_CONFIG var,
+      so parallel tests raced the global env (intermittent workspace-test
+      FAIL: 6538 passed; 1 failed at auto_memory root_uses_config_dir_
+      when_env_unset). Fix: one crate-wide ENV_LOCK +ScopedEnv save/restore
+      in agent::env_test_support, used by auto_memory + settings +
+      instructions; ANTHROPIC_API_KEY test guarded self-contained.
+      F-ENV-HERMETIC-001 verified RED-on-bug (1-in-3 fail with the three
+      separate mutexes) / GREEN-on-fix (5/5 runs at --test-threads=16,
+      3/3 full-crate runs at --test-threads=8 = 6506 passed; 0 failed).

--- a/crates/aprender-orchestrate/src/agent/auto_memory.rs
+++ b/crates/aprender-orchestrate/src/agent/auto_memory.rs
@@ -140,6 +140,13 @@ pub fn load_auto_memory(cwd: &Path, warnings: &mut Vec<String>) -> Option<String
 #[cfg(test)]
 mod tests {
     use super::*;
+    // PMAT-876: tests below mutate the process-wide `APR_CONFIG` env var.
+    // `std::env` is process-global and `cargo test` runs tests in parallel,
+    // so they all acquire ONE crate-wide lock (env_test_support::env_lock)
+    // — shared across auto_memory + settings + instructions, all of which
+    // touch the SAME variable — and use ScopedEnv to restore the prior
+    // value on drop so the env is never left mutated for another test.
+    use crate::agent::env_test_support::{env_lock, ScopedEnv};
     use std::fs;
     use std::path::Path;
 
@@ -148,14 +155,6 @@ mod tests {
             fs::create_dir_all(p).expect("mkdir");
         }
         fs::write(path, body).expect("write");
-    }
-
-    // CI flake prevention: tests below mutate the process-wide
-    // `APR_CONFIG` env var. Same Mutex pattern as
-    // agent::settings::tests + agent::instructions::tests.
-    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
-        static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-        LOCK.lock().unwrap_or_else(|e| e.into_inner())
     }
 
     // ── project_slug ───────────────────────────────────────────────
@@ -196,16 +195,15 @@ mod tests {
     fn root_honors_apr_config_env() {
         let _guard = env_lock();
         let dir = tempfile::tempdir().expect("tempdir");
-        std::env::set_var("APR_CONFIG", dir.path());
+        let _env = ScopedEnv::set("APR_CONFIG", dir.path());
         let r = auto_memory_root().expect("root resolved");
-        std::env::remove_var("APR_CONFIG");
         assert_eq!(r, dir.path().join("projects"));
     }
 
     #[test]
     fn root_uses_config_dir_when_env_unset() {
         let _guard = env_lock();
-        std::env::remove_var("APR_CONFIG");
+        let _env = ScopedEnv::remove("APR_CONFIG");
         let r = auto_memory_root().expect("root resolved on supported platform");
         // Should end in apr/projects regardless of host home.
         assert!(r.ends_with("apr/projects"), "unexpected root: {r:?}");
@@ -217,9 +215,8 @@ mod tests {
     fn project_memory_dir_layout() {
         let _guard = env_lock();
         let cfg = tempfile::tempdir().expect("cfg");
-        std::env::set_var("APR_CONFIG", cfg.path());
+        let _env = ScopedEnv::set("APR_CONFIG", cfg.path());
         let dir = project_memory_dir(Path::new("/tmp/myproj")).expect("dir");
-        std::env::remove_var("APR_CONFIG");
         assert_eq!(dir, cfg.path().join("projects").join("-tmp-myproj").join("memory"));
     }
 
@@ -229,11 +226,10 @@ mod tests {
     fn load_returns_none_when_no_dir() {
         let _guard = env_lock();
         let cfg = tempfile::tempdir().expect("cfg");
-        std::env::set_var("APR_CONFIG", cfg.path());
+        let _env = ScopedEnv::set("APR_CONFIG", cfg.path());
         let mut warns = Vec::new();
         // Project memory dir doesn't exist (no `projects/<slug>/memory/`).
         let out = load_auto_memory(Path::new("/tmp/never"), &mut warns);
-        std::env::remove_var("APR_CONFIG");
         assert!(out.is_none());
         assert!(warns.is_empty());
     }
@@ -242,12 +238,11 @@ mod tests {
     fn load_returns_none_when_dir_empty() {
         let _guard = env_lock();
         let cfg = tempfile::tempdir().expect("cfg");
-        std::env::set_var("APR_CONFIG", cfg.path());
         let mem_dir = cfg.path().join("projects").join("-tmp-x").join("memory");
         fs::create_dir_all(&mem_dir).expect("mkdir");
+        let _env = ScopedEnv::set("APR_CONFIG", cfg.path());
         let mut warns = Vec::new();
         let out = load_auto_memory(Path::new("/tmp/x"), &mut warns);
-        std::env::remove_var("APR_CONFIG");
         assert!(out.is_none(), "empty memory dir → None, got: {out:?}");
         assert!(warns.is_empty());
     }
@@ -260,10 +255,9 @@ mod tests {
         write(&mem_dir.join("MEMORY.md"), "# Top-of-memory index\n");
         write(&mem_dir.join("zzz_user.md"), "User notes\n");
         write(&mem_dir.join("feedback_x.md"), "Feedback X\n");
-        std::env::set_var("APR_CONFIG", cfg.path());
+        let _env = ScopedEnv::set("APR_CONFIG", cfg.path());
         let mut warns = Vec::new();
         let out = load_auto_memory(Path::new("/tmp/y"), &mut warns).expect("loaded");
-        std::env::remove_var("APR_CONFIG");
         assert!(warns.is_empty());
         // MEMORY.md (uppercase M) sorts before lowercase f/z.
         let memory_idx = out.find("Top-of-memory index").expect("MEMORY present");
@@ -285,10 +279,9 @@ mod tests {
         write(&mem_dir.join("note.md"), "kept\n");
         write(&mem_dir.join("note.txt"), "skipped\n");
         write(&mem_dir.join("note.json"), "skipped\n");
-        std::env::set_var("APR_CONFIG", cfg.path());
+        let _env = ScopedEnv::set("APR_CONFIG", cfg.path());
         let mut warns = Vec::new();
         let out = load_auto_memory(Path::new("/tmp/skip"), &mut warns).expect("loaded");
-        std::env::remove_var("APR_CONFIG");
         assert!(out.contains("kept"));
         assert!(!out.contains("skipped"), "non-md files must NOT be loaded");
     }
@@ -302,10 +295,9 @@ mod tests {
         // Subdirectory under memory/ — must not recurse.
         fs::create_dir_all(mem_dir.join("nested")).expect("mkdir nested");
         write(&mem_dir.join("nested").join("hidden.md"), "hidden-content\n");
-        std::env::set_var("APR_CONFIG", cfg.path());
+        let _env = ScopedEnv::set("APR_CONFIG", cfg.path());
         let mut warns = Vec::new();
         let out = load_auto_memory(Path::new("/tmp/sub"), &mut warns).expect("loaded");
-        std::env::remove_var("APR_CONFIG");
         assert!(out.contains("ok-content"));
         assert!(!out.contains("hidden-content"), "must not recurse into subdirs");
     }

--- a/crates/aprender-orchestrate/src/agent/env_test_support.rs
+++ b/crates/aprender-orchestrate/src/agent/env_test_support.rs
@@ -1,0 +1,131 @@
+//! Shared test-support for env-mutating tests (PMAT-876).
+//!
+//! `std::env` is **process-global**: a single environment table is
+//! shared by every thread in the process. `cargo test` / nextest run
+//! `#[test]` functions in PARALLEL by default, so two tests that each
+//! `set_var` / `remove_var` the *same* variable (or one mutates while
+//! another reads) interleave non-deterministically and observe the
+//! wrong value. This produced an intermittent `workspace-test` failure
+//! (`agent::auto_memory::tests::root_uses_config_dir_when_env_unset`
+//! and siblings) that repeatedly broke the merge queue.
+//!
+//! ## Why a single shared lock
+//!
+//! Historically `auto_memory`, `settings`, and `instructions` each
+//! defined their *own* module-private `Mutex` and acquired it in their
+//! own tests. That serializes tests *within* one module but NOT across
+//! modules — yet all three mutate the **same** `APR_CONFIG` variable.
+//! Two tests in different modules therefore still raced. The fix is one
+//! crate-wide [`ENV_LOCK`]: every test that touches process env acquires
+//! THIS lock, so all env-mutating tests across the whole crate are
+//! serialized against each other while non-env tests stay parallel.
+//!
+//! ## Usage
+//!
+//! ```ignore
+//! use crate::agent::env_test_support::env_lock;
+//!
+//! #[test]
+//! fn my_env_test() {
+//!     let _guard = env_lock();              // held for the whole test
+//!     let _restore = ScopedEnv::set("APR_CONFIG", "/tmp/x");
+//!     // ... assert against the env-dependent behavior ...
+//! }   // _restore drops → prior value restored; _guard drops → lock freed
+//! ```
+
+#![cfg(test)]
+
+use std::sync::{Mutex, MutexGuard};
+
+/// Process-wide lock serializing every env-mutating test in the crate.
+///
+/// Poison-tolerant: a panicking test would poison the mutex, but the
+/// lock itself protects no data we care about (it only serializes
+/// access to the global env table), so we recover the guard via
+/// `into_inner()` rather than propagating the poison.
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+/// Acquire the crate-wide env lock for the duration of a test.
+///
+/// Hold the returned guard across the full set → assert → restore
+/// sequence so no other env-mutating test can interleave.
+pub fn env_lock() -> MutexGuard<'static, ()> {
+    ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+/// RAII guard that sets an env var and restores its prior value (or
+/// absence) on drop. Combined with [`env_lock`], this keeps the global
+/// env table hermetic: a test never leaves a variable mutated for the
+/// next test to observe.
+#[must_use = "the prior env value is restored when this guard is dropped"]
+pub struct ScopedEnv {
+    key: String,
+    prior: Option<String>,
+}
+
+impl ScopedEnv {
+    /// Save the current value of `key`, then set it to `value`.
+    pub fn set(key: &str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+        let prior = std::env::var(key).ok();
+        std::env::set_var(key, value);
+        Self { key: key.to_string(), prior }
+    }
+
+    /// Save the current value of `key`, then remove it.
+    pub fn remove(key: &str) -> Self {
+        let prior = std::env::var(key).ok();
+        std::env::remove_var(key);
+        Self { key: key.to_string(), prior }
+    }
+}
+
+impl Drop for ScopedEnv {
+    fn drop(&mut self) {
+        match &self.prior {
+            Some(v) => std::env::set_var(&self.key, v),
+            None => std::env::remove_var(&self.key),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scoped_env_set_restores_prior_absence() {
+        let _guard = env_lock();
+        // Pick a name unlikely to exist in CI.
+        let key = "PMAT_876_SCOPED_PROBE_A";
+        std::env::remove_var(key); // ensure absent baseline
+        {
+            let _s = ScopedEnv::set(key, "value");
+            assert_eq!(std::env::var(key).as_deref(), Ok("value"));
+        }
+        // Restored to absence.
+        assert!(std::env::var(key).is_err());
+    }
+
+    #[test]
+    fn scoped_env_remove_restores_prior_value() {
+        let _guard = env_lock();
+        let key = "PMAT_876_SCOPED_PROBE_B";
+        std::env::set_var(key, "original");
+        {
+            let _s = ScopedEnv::remove(key);
+            assert!(std::env::var(key).is_err());
+        }
+        // Restored to the original value.
+        assert_eq!(std::env::var(key).as_deref(), Ok("original"));
+        std::env::remove_var(key); // clean up
+    }
+
+    #[test]
+    fn env_lock_is_reentrant_safe_across_calls() {
+        // Sequential acquisition must not deadlock (guard dropped between).
+        {
+            let _g = env_lock();
+        }
+        let _g2 = env_lock();
+    }
+}

--- a/crates/aprender-orchestrate/src/agent/instructions.rs
+++ b/crates/aprender-orchestrate/src/agent/instructions.rs
@@ -250,6 +250,11 @@ pub fn load_layered_instructions(
 #[cfg(test)]
 mod tests {
     use super::*;
+    // PMAT-876: shared crate-wide env lock + save/restore guard, shared
+    // with auto_memory + settings tests (all touch the same global
+    // `APR_CONFIG`). `std::env` is process-global and tests run in
+    // parallel, so one lock serializes them ALL.
+    use crate::agent::env_test_support::{env_lock, ScopedEnv};
     use std::fs;
 
     fn write(path: &Path, body: &str) {
@@ -453,28 +458,20 @@ mod tests {
 
     // ── find_user_global_instructions / load_layered_instructions ──
     //
-    // CI flake fix: tests below mutate the process-wide `APR_CONFIG` env
-    // var. cargo test runs `#[test]` functions in parallel by default;
-    // without serialization, two parallel tests can corrupt each other's
-    // view of the env (test A sets, test B reads, test A removes). Local
-    // runs happened to pass because of timing; CI hit the race.
-    //
-    // The Mutex below serializes all env-mutating tests in this module.
-    // The `.lock()` is held for the duration of each test so neither
-    // `set_var` nor `remove_var` can interleave.
-    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
-        static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-        LOCK.lock().unwrap_or_else(|e| e.into_inner())
-    }
+    // PMAT-876: tests below mutate the process-wide `APR_CONFIG` env var.
+    // `std::env` is process-global and cargo test runs `#[test]` fns in
+    // parallel by default, so they all acquire the ONE crate-wide
+    // `env_test_support::env_lock` (shared with auto_memory + settings,
+    // which touch the same variable) and use ScopedEnv to restore the
+    // prior value on drop.
 
     #[test]
     fn user_global_honors_apr_config_env_first() {
         let _guard = env_lock();
         let dir = tempfile::tempdir().expect("tempdir");
         write(&dir.path().join("CLAUDE.md"), "user-global-content");
-        std::env::set_var("APR_CONFIG", dir.path());
+        let _env = ScopedEnv::set("APR_CONFIG", dir.path());
         let p = find_user_global_instructions().expect("found");
-        std::env::remove_var("APR_CONFIG");
         assert_eq!(p, dir.path().join("CLAUDE.md"));
     }
 
@@ -484,9 +481,8 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         write(&dir.path().join("APR.md"), "apr-version");
         write(&dir.path().join("CLAUDE.md"), "claude-version");
-        std::env::set_var("APR_CONFIG", dir.path());
+        let _env = ScopedEnv::set("APR_CONFIG", dir.path());
         let p = find_user_global_instructions().expect("found");
-        std::env::remove_var("APR_CONFIG");
         assert_eq!(p, dir.path().join("APR.md"), "APR.md wins over CLAUDE.md within a layer");
     }
 
@@ -495,10 +491,9 @@ mod tests {
         let _guard = env_lock();
         let cfg = tempfile::tempdir().expect("cfg");
         let proj = tempfile::tempdir().expect("proj");
-        std::env::set_var("APR_CONFIG", cfg.path());
+        let _env = ScopedEnv::set("APR_CONFIG", cfg.path());
         let mut warns = Vec::new();
         let out = load_layered_instructions(proj.path(), 4096, &mut warns);
-        std::env::remove_var("APR_CONFIG");
         assert!(out.is_none());
     }
 
@@ -509,10 +504,9 @@ mod tests {
         let proj = tempfile::tempdir().expect("proj");
         write(&cfg.path().join("CLAUDE.md"), "USER-GLOBAL-BODY\n");
         write(&proj.path().join("CLAUDE.md"), "PROJECT-BODY\n");
-        std::env::set_var("APR_CONFIG", cfg.path());
+        let _env = ScopedEnv::set("APR_CONFIG", cfg.path());
         let mut warns = Vec::new();
         let out = load_layered_instructions(proj.path(), 65536, &mut warns).expect("loaded");
-        std::env::remove_var("APR_CONFIG");
         let user_idx = out.find("USER-GLOBAL-BODY").expect("user-global present");
         let proj_idx = out.find("PROJECT-BODY").expect("project present");
         assert!(
@@ -534,10 +528,9 @@ mod tests {
         // project: imports a sibling file
         write(&proj.path().join("CLAUDE.md"), "PROJ\n@./conv.md\n");
         write(&proj.path().join("conv.md"), "PROJ-CONV\n");
-        std::env::set_var("APR_CONFIG", cfg.path());
+        let _env = ScopedEnv::set("APR_CONFIG", cfg.path());
         let mut warns = Vec::new();
         let out = load_layered_instructions(proj.path(), 65536, &mut warns).expect("loaded");
-        std::env::remove_var("APR_CONFIG");
         assert!(out.contains("USER-SHARED"));
         assert!(out.contains("PROJ-CONV"));
         assert!(warns.is_empty(), "no warnings expected, got: {warns:?}");

--- a/crates/aprender-orchestrate/src/agent/mod.rs
+++ b/crates/aprender-orchestrate/src/agent/mod.rs
@@ -34,6 +34,11 @@ mod code_prompts;
 pub mod contracts;
 pub mod custom_agents;
 pub mod driver;
+/// Shared test-support for env-mutating tests (PMAT-876): a single
+/// process-wide `ENV_LOCK` + save/restore guard so all env-touching
+/// tests across the crate serialize against each other.
+#[cfg(test)]
+pub(crate) mod env_test_support;
 pub mod guard;
 pub mod hooks;
 pub mod instructions;

--- a/crates/aprender-orchestrate/src/agent/settings.rs
+++ b/crates/aprender-orchestrate/src/agent/settings.rs
@@ -165,6 +165,11 @@ impl AprSettings {
 #[cfg(test)]
 mod tests {
     use super::*;
+    // PMAT-876: shared crate-wide env lock + save/restore guard. All
+    // env-mutating tests across auto_memory + settings + instructions
+    // serialize on this ONE lock because they touch the same global
+    // `APR_CONFIG` variable.
+    use crate::agent::env_test_support::{env_lock, ScopedEnv};
     use std::fs;
     use std::path::Path;
 
@@ -316,24 +321,13 @@ mod tests {
         assert!(msg.contains("invalid settings JSON") || msg.contains("settings.json"));
     }
 
-    // CI flake prevention: tests below mutate the process-wide
-    // `APR_CONFIG` env var. cargo test runs `#[test]` fns in parallel
-    // by default; without serialization, two parallel tests can corrupt
-    // each other's view of the env (test A sets, test B reads, test A
-    // removes). Same fix as agent::instructions::tests (PR #1567).
-    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
-        static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-        LOCK.lock().unwrap_or_else(|e| e.into_inner())
-    }
-
     #[test]
     fn user_global_honors_apr_config_env() {
         let _guard = env_lock();
         let dir = tempfile::tempdir().expect("tempdir");
-        std::env::set_var("APR_CONFIG", dir.path());
+        let _env = ScopedEnv::set("APR_CONFIG", dir.path());
         let p = AprSettings::user_global_path().expect("path resolved");
         assert_eq!(p, dir.path().join("settings.json"));
-        std::env::remove_var("APR_CONFIG");
     }
 
     #[test]
@@ -351,9 +345,8 @@ mod tests {
         let proj_dir = tempfile::tempdir().expect("proj tempdir");
         write(&cfg_dir.path().join("settings.json"), r#"{"model":"user-global","max_turns":5}"#);
         write(&proj_dir.path().join(".apr").join("settings.json"), r#"{"model":"project-local"}"#);
-        std::env::set_var("APR_CONFIG", cfg_dir.path());
+        let _env = ScopedEnv::set("APR_CONFIG", cfg_dir.path());
         let s = AprSettings::load_layered(proj_dir.path()).expect("load");
-        std::env::remove_var("APR_CONFIG");
 
         assert_eq!(s.model.as_deref(), Some("project-local"), "project must win");
         assert_eq!(s.max_turns, Some(5), "user-global field passes through when project is silent");
@@ -365,9 +358,8 @@ mod tests {
         let cfg_dir = tempfile::tempdir().expect("cfg tempdir");
         let proj_dir = tempfile::tempdir().expect("proj tempdir");
         // No settings.json written anywhere.
-        std::env::set_var("APR_CONFIG", cfg_dir.path());
+        let _env = ScopedEnv::set("APR_CONFIG", cfg_dir.path());
         let s = AprSettings::load_layered(proj_dir.path()).expect("load");
-        std::env::remove_var("APR_CONFIG");
         assert_eq!(s, AprSettings::default());
     }
 }

--- a/crates/aprender-orchestrate/src/cli/agent_tests.rs
+++ b/crates/aprender-orchestrate/src/cli/agent_tests.rs
@@ -138,11 +138,38 @@ fn test_build_driver_no_model_returns_mock() {
     assert!(driver.is_ok(), "should return MockDriver when no model_path");
 }
 
+// PMAT-876: `ANTHROPIC_API_KEY` is process-global env. This test runs in
+// the BINARY test crate (cli/* is declared in main.rs, not the `batuta`
+// lib), so it cannot reach the lib-side `agent::env_test_support`. Use a
+// self-contained lock + save/restore guard with the same semantics:
+// serialize env-mutating tests in THIS test binary and never leave the
+// var clobbered for another parallel test.
+fn anthropic_key_env_lock() -> std::sync::MutexGuard<'static, ()> {
+    static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    LOCK.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+struct RestoreEnv {
+    key: &'static str,
+    prior: Option<String>,
+}
+impl Drop for RestoreEnv {
+    fn drop(&mut self) {
+        match &self.prior {
+            Some(v) => std::env::set_var(self.key, v),
+            None => std::env::remove_var(self.key),
+        }
+    }
+}
+
 #[test]
 fn test_build_driver_remote_no_key_returns_mock() {
+    let _guard = anthropic_key_env_lock();
+    let _restore =
+        RestoreEnv { key: "ANTHROPIC_API_KEY", prior: std::env::var("ANTHROPIC_API_KEY").ok() };
+    std::env::remove_var("ANTHROPIC_API_KEY");
     let mut manifest = batuta::agent::AgentManifest::default();
     manifest.model.remote_model = Some("claude-sonnet-4-20250514".into());
-    std::env::remove_var("ANTHROPIC_API_KEY");
     let driver = build_driver(&manifest);
     assert!(driver.is_ok(), "should return mock when API key missing");
 }


### PR DESCRIPTION
CI-reliability fix. auto_memory/settings/instructions test modules each held their OWN module-private mutex around the shared process-global APR_CONFIG env var — serialized within a module but NOT across modules, so cross-module parallel tests raced -> intermittent workspace-test failures that repeatedly stalled the merge queue. Replaced with ONE crate-wide ENV_LOCK + ScopedEnv save/restore RAII guard.

Reproduced pre-fix (~1-in-3 fail at --test-threads=16); GREEN 5/5 + 3/3 deterministic post-fix. 6506/0. contracts/orchestrate-env-test-hermeticity-v1.yaml pv-valid.

Generated with Claude Code