### PR TITLE
fix(serve): DRY penalty exponent off-by-one — match_len counted the candidate token (PMAT-873)

### DIFF
--- a/contracts/dry-penalty-repeat-len-v1.yaml
+++ b/contracts/dry-penalty-repeat-len-v1.yaml
@@ -1,0 +1,59 @@
+metadata:
+  version: "1.0.0"
+  created: "2026-06-20"
+  author: PAIML Engineering
+  registry: true
+  references:
+    - "llama.cpp src/llama-sampling.cpp llama_sampler_dry_apply (DRY sampler)"
+    - "DRY (Don't Repeat Yourself) sampling — penalty = dry_base ^ (repeat_len - dry_allowed_length)"
+  description: |
+    Correctness contract for apr's DRY (Don't Repeat Yourself) penalty. The DRY penalty exponent
+    must be computed from `repeat_len` — the length of the in-context repeated suffix EXCLUDING the
+    candidate token being scored — exactly as llama.cpp does. apr beats Ollama/llama.cpp on parity
+    only if its DRY penalty magnitude matches llama.cpp's `dry_base ^ (repeat_len - dry_allowed_length)`.
+kind: KernelContract
+name: dry-penalty-repeat-len
+version: "1.0.0"
+scope: "crates/aprender-serve/src/generate/dry_penalty.rs"
+description: |
+  PMAT-873: `find_ngram_match_length` returned `end_pos + 1` — the length of the repeated suffix
+  PLUS the candidate next token. `apply_dry_penalty` then computes the penalty exponent as
+  `match_len - allowed_length`. Because `match_len` already included the candidate token, the
+  exponent was one too large, so every DRY penalty was `base`x too strong vs llama.cpp.
+
+  llama.cpp's DRY sampler computes `penalty = dry_base ^ (repeat_len - dry_allowed_length)`, where
+  `repeat_len` is the length of the matched repeated suffix that ALREADY exists in the context and
+  EXCLUDES the candidate being scored. In `find_ngram_match_length`, the loop variable `end_pos` is
+  exactly that repeated-suffix length: for each `end_pos` the function takes the last `end_pos`
+  tokens of the context as the suffix and checks whether that same `end_pos`-length suffix occurs
+  earlier in the context AND is followed by the candidate `next_token`. So `end_pos == repeat_len`;
+  the `+1` double-counted the candidate.
+
+  Fix: `max_match = max_match.max(end_pos)` (drop the `+1`). This keeps the gate
+  `match_len >= allowed_length` and the exponent `match_len - allowed_length` consistent with
+  llama.cpp `repeat_len >= dry_allowed_length` and `repeat_len - dry_allowed_length`.
+equations:
+  C-DRY-001:
+    description: "DRY penalty magnitude equals llama.cpp: base raised to (repeat_len - allowed_length)."
+    formula: "fires(t) ⟹ penalty(t) = multiplier * base^(repeat_len(t) - allowed_length)"
+    note: "repeat_len(t) is the length of the repeated suffix in context that, followed by candidate t, recurs an earlier occurrence; it EXCLUDES t. This is llama.cpp dry_base ^ (repeat_len - dry_allowed_length)."
+  C-DRY-002:
+    description: "match_len equals the repeated-suffix length excluding the candidate token (== llama.cpp repeat_len)."
+    formula: "find_ngram_match_length(context, t, allowed_length) = max { end_pos : suffix_{end_pos}(context) recurs earlier followed by t }"
+    note: "end_pos counts only tokens already present in context; the candidate t is NOT counted. The penalty gate is match_len >= allowed_length and the exponent is match_len - allowed_length."
+proof_obligations:
+  - id: PO-DRY-001
+    kind: correctness
+    statement: "When DRY fires, the applied penalty exponent is (repeat_len - allowed_length), never (repeat_len + 1 - allowed_length); the penalty is not base-x too strong vs llama.cpp."
+    discharged_by: FALSIFY-DRY-REPEAT-LEN-EXPONENT
+falsification:
+  - id: FALSIFY-DRY-REPEAT-LEN-EXPONENT
+    description: "For context [7,7] with allowed_length 1, multiplier 1.0, base 1.75, the 1-token suffix [7] recurs at index 0 followed by candidate 7, so repeat_len = 1. The penalized logit for token 7 must be base_logit - multiplier*base^(1-1) = 5.0 - 1.0 = 4.0 (llama.cpp), NOT base_logit - multiplier*base^(2-1) = 5.0 - 1.75 = 3.25 (off-by-one). Discharges C-DRY-001, C-DRY-002 and PO-DRY-001."
+    test: "cargo test -p aprender-serve --lib test_dry_penalty_exponent_matches_llama_cpp_repeat_len"
+    evidence: |
+      RED (pre-fix): expected penalized logit 4 (penalty=1, repeat_len=1), got 3.25 — the penalty
+      was base=1.75x too strong because match_len = end_pos + 1 included the candidate token.
+      GREEN (post-fix): the penalized logit is 4.0, matching llama.cpp
+      dry_base ^ (repeat_len - dry_allowed_length). No sibling DRY test asserted an exact penalty
+      magnitude (existing tests only check penalty direction / config fields), so none encoded the
+      off-by-one. Full aprender-serve lib suite passes with 0 failures.

--- a/crates/aprender-serve/src/generate/dry_penalty.rs
+++ b/crates/aprender-serve/src/generate/dry_penalty.rs
@@ -80,7 +80,13 @@ fn find_ngram_match_length(context: &[usize], next_token: usize, min_len: usize)
         // Look for this suffix earlier in the context
         for start in 0..(context.len() - end_pos) {
             if check_ngram_match(context, suffix, start, end_pos, next_token) {
-                max_match = max_match.max(end_pos + 1);
+                // PMAT-873: `end_pos` is the length of the repeated suffix that
+                // already exists in the context (== llama.cpp `repeat_len`). It
+                // must NOT include the candidate `next_token`, otherwise the
+                // exponent `match_len - allowed_length` computed in
+                // `apply_dry_penalty` is one too large and every DRY penalty is
+                // `base`x too strong vs llama.cpp.
+                max_match = max_match.max(end_pos);
             }
         }
     }

--- a/crates/aprender-serve/src/generate/tests_sample_min.rs
+++ b/crates/aprender-serve/src/generate/tests_sample_min.rs
@@ -408,6 +408,57 @@
         assert!(result.data().iter().sum::<f32>() > 0.0);
     }
 
+    // PMAT-873 FALSIFIER (F-DRY-REPEAT-LEN-001):
+    // The DRY penalty exponent must equal `repeat_len - allowed_length`, where
+    // `repeat_len` is the length of the in-context repeated suffix EXCLUDING the
+    // candidate token being scored (== llama.cpp `repeat_len`).
+    //
+    // Construct a context where repeat_len is exactly known. Context [7, 7] with
+    // allowed_length = 1: the 1-token suffix [7] occurs earlier (at index 0) and
+    // is followed by candidate token 7. So repeat_len = 1.
+    //   Correct (llama.cpp): exponent = repeat_len - allowed_length = 1 - 1 = 0
+    //                        penalty  = multiplier * base^0 = multiplier
+    //   Off-by-one bug:      match_len = repeat_len + 1 = 2, exponent = 1
+    //                        penalty  = multiplier * base^1 = multiplier * base
+    // The buggy penalty is `base`x too strong. We pin the exact magnitude so the
+    // off-by-one is RED and the llama.cpp-parity fix is GREEN.
+    #[test]
+    fn test_dry_penalty_exponent_matches_llama_cpp_repeat_len() {
+        let base_logit = 5.0_f32;
+        let logits = Tensor::from_vec(vec![8], vec![base_logit; 8]).expect("test");
+        let multiplier = 1.0_f32;
+        let base = 1.75_f32;
+        let allowed_length = 1_usize;
+        let config = DryConfig {
+            multiplier,
+            base,
+            allowed_length,
+            penalty_last_n: 64,
+        };
+        // repeat_len for candidate 7 is 1 (suffix [7] matched at index 0).
+        let context = vec![7_usize, 7_usize];
+
+        let result = apply_dry_penalty(&logits, &context, &config);
+
+        // llama.cpp: penalty = multiplier * base^(repeat_len - allowed_length)
+        //          = 1.0 * 1.75^(1 - 1) = 1.0
+        let repeat_len = 1_i32;
+        let expected_penalty = multiplier * base.powi(repeat_len - allowed_length as i32);
+        let expected_logit = base_logit - expected_penalty;
+        let actual_logit = result.data()[7];
+
+        // Buggy value would be base_logit - multiplier*base^1 = 5.0 - 1.75 = 3.25,
+        // which is `base`x too strong and would fail this assertion.
+        let buggy_logit = base_logit - multiplier * base.powi(repeat_len + 1 - allowed_length as i32);
+        assert!(
+            (actual_logit - expected_logit).abs() < 1e-5,
+            "DRY exponent off-by-one: expected penalized logit {expected_logit} \
+             (penalty={expected_penalty}, repeat_len={repeat_len}), got {actual_logit}. \
+             A `base`x-too-strong penalty (logit {buggy_logit}) means match_len included \
+             the candidate token."
+        );
+    }
+
     // ===== Beam Search Tests =====
 
     #[test]


### PR DESCRIPTION
find_ngram_match_length returned end_pos+1 (repeated-suffix length PLUS the candidate token), so apply_dry_penalty exponent match_len-allowed_length was one too large -> every DRY penalty was base× too strong vs llama.cpp (dry_base^(repeat_len-allowed_length)). Fixed to end_pos (== llama.cpp repeat_len).

Falsifier RED logit 3.25 -> GREEN 4.0 (llama.cpp parity). 15442/0. contracts/dry-penalty-repeat-len-v1.yaml pv-valid.

Generated with Claude Code