### PR TITLE
fix(serve): YaRN RoPE extrapolated dims used NTK-modified base instead of original (PMAT-874)

### DIFF
--- a/contracts/yarn-rope-original-base-v1.yaml
+++ b/contracts/yarn-rope-original-base-v1.yaml
@@ -1,0 +1,133 @@
+metadata:
+  version: 1.0.0
+  created: '2026-06-20'
+  author: PAIML Engineering
+  description: |
+    PMAT-874: YaRN RoPE scaling must use the ORIGINAL rope base for the
+    extrapolated (high-frequency / short-wavelength) dimension pairs. It must NOT
+    apply the NTK-by-parts base modification `base * scale^(dim/(dim-2))` — that is
+    a DIFFERENT scaling type (RopeScalingType::Ntk / DynamicNtk).
+
+    The bug: ScaledRoPE::compute_frequencies built the YaRN inv_freq vector from
+    `scaled_base = base * scale^(dim/(dim-2))` (the NTK-modified base), so every
+    extrapolated high-frequency dim used the NTK base instead of the original base,
+    corrupting the high-frequency rotations and silently degrading long-context
+    inference. The forward() ramp then blended an NTK-based extrapolation angle with
+    an original-base interpolation angle — mixing two distinct scaling methods.
+
+    The fix (YaRN, Peng et al. 2023): the YaRN arm returns the ORIGINAL base, so
+    inv_freq derives from `1 / base^(2i/dim)` (original base) for the extrapolated
+    dims; the interpolated low-frequency dims use that frequency divided by the
+    scale factor `L_new / L_orig`; the beta_fast/beta_slow ramp blends the two per
+    dimension. mscale (attention factor) handling is unchanged.
+
+    This matches HuggingFace `modeling_rope_utils._compute_yarn_parameters`, where
+    `inv_freq_extrapolation = 1.0 / pos_freqs` (pos_freqs = base^(arange/dim),
+    ORIGINAL base) and `inv_freq_interpolation = 1.0 / (factor * pos_freqs)`.
+  references:
+  - 'Peng et al. (2023) YaRN: Efficient Context Window Extension of Large Language Models (arXiv:2309.00071)'
+  - 'HuggingFace transformers modeling_rope_utils._compute_yarn_parameters (inv_freq_extrapolation uses the original base)'
+  - 'llama.cpp ggml_rope_yarn (extrapolation = original theta; NTK-by-parts is a separate scaling mode)'
+  - 'crates/aprender-serve/src/layers/scaled_rope.rs — ScaledRoPE::compute_frequencies (YaRN arm) + ScaledRoPE::forward (YaRN ramp)'
+  depends_on:
+  - rope-extrapolation-v1
+  - rope-kernel-v1
+
+kind: KernelContract
+name: yarn-rope-original-base
+version: 1.0.0
+scope: aprender-serve ScaledRoPE YaRN frequency derivation (compute_frequencies + forward)
+
+equations:
+  C-YARN-EXTRAP-ORIGINAL-BASE:
+    formula: |
+      For YaRN scaling, inv_freq_extrapolation[i] = 1 / base^(2i/dim) using the
+      ORIGINAL rope base. The NTK base modification base*scale^(dim/(dim-2)) is
+      NOT applied. Therefore ScaledRoPE::scaled_base == base for YaRN, and
+      ScaledRoPE::inv_freq()[i] == base^(-2i/dim).
+    domain: base = original rope theta, dim = head_dim, i in [0, dim/2)
+    codomain: inv_freq[i] (extrapolated frequency) in (0, 1]
+    invariants:
+    - 'scaled_base == base for YaRN (no NTK modification)'
+    - 'inv_freq[i] == base^(-2i/dim) (original base), NOT (base*scale^(dim/(dim-2)))^(-2i/dim)'
+    - 'inv_freq[0] == 1.0'
+    - 'inv_freq strictly decreasing in i; all entries > 0'
+    lean_theorem: Theorems.Yarn_Extrap_Original_Base
+  C-YARN-INTERP-BASE-OVER-SCALE:
+    formula: |
+      For YaRN scaling, the interpolated (low-frequency / long-wavelength) dims use
+      inv_freq_interpolation[i] = (1 / base^(2i/dim)) / scale, where
+      scale = target_max_len / original_max_len. The forward() ramp blends
+      extrapolation and interpolation per dimension:
+      angle_i = (1 - ramp_i) * inv_freq[i]*pos + ramp_i * (inv_freq[i]/scale)*pos.
+    domain: scale = L_new / L_orig >= 1, ramp_i in [0, 1]
+    codomain: blended rotation angle for dim pair i
+    invariants:
+    - 'extrapolation regime (ramp=0): effective freq == original-base inv_freq[i]'
+    - 'interpolation regime (ramp=1): effective freq == inv_freq[i] / scale'
+    - 'both endpoints derive from the ORIGINAL base (NTK base never appears)'
+    lean_theorem: Theorems.Yarn_Interp_Base_Over_Scale
+
+proof_obligations:
+- type: invariant
+  property: YaRN extrapolated dims use the original base, not the NTK-modified base
+  formal: |
+    For a YaRN ScaledRoPE with base B, dim D, scale S = L_new/L_orig:
+    inv_freq[1] == B^(-2/D)  AND  inv_freq[1] != (B*S^(D/(D-2)))^(-2/D).
+    Equivalently scaled_base == B (not B*S^(D/(D-2))).
+- type: invariant
+  property: YaRN base equals the original base
+  formal: |
+    ScaledRoPE::scaled_base() == original base for RopeScalingType::Yarn (the NTK
+    base modification is a property of RopeScalingType::Ntk / DynamicNtk only).
+- type: classification
+  property: NTK base modification is exclusive to NTK scaling types
+  formal: |
+    base*scale^(dim/(dim-2)) is applied for Ntk and DynamicNtk, and NEVER for Yarn.
+
+falsification_tests:
+- id: FT-YARN-874-001
+  rule: YaRN extrapolated high-frequency dim uses the ORIGINAL base (matches HF reference)
+  prediction: |
+    For dim=64, base=10000, original_max_len=2048, target_max_len=8192 (scale=4),
+    beta_fast=32, beta_slow=1: inv_freq[1] == 10000^(-2/64) = 0.749_894_2 (original
+    base / HF YaRN). Before the fix it was (10000*4^(64/62))^(-2/64) = 0.717_098_3
+    (NTK-modified base), so the test fails RED on the bug and passes GREEN on the fix.
+  if_fails: 'the YaRN arm of compute_frequencies built inv_freq from the NTK base (scaled_base = base*scale^(dim/(dim-2))) instead of the original base.'
+  evidence: cargo test -p aprender-serve --lib test_scaled_rope_yarn_extrapolation_uses_original_base
+- id: FT-YARN-874-002
+  rule: YaRN scaled_base equals the original base (no NTK modification)
+  prediction: |
+    A YaRN ScaledRoPE(dim=64, base=10000) reports scaled_base() == 10000.0 (within
+    1e-3). Before the fix scaled_base() was the NTK-modified base (~174969 for
+    scale=16), so the assertion fails RED on the bug and passes GREEN on the fix.
+  if_fails: 'the YaRN arm returns the NTK-modified base (ntk_base) as scaled_base instead of the original base.'
+  evidence: cargo test -p aprender-serve --lib test_scaled_rope_yarn
+- id: FT-YARN-874-003
+  rule: NTK base modification stays exclusive to the NTK scaling types
+  prediction: |
+    NTK / DynamicNtk ScaledRoPE still reports scaled_base() > original base
+    (base*scale^(dim/(dim-2))), while YaRN reports scaled_base() == original base.
+    This proves the fix did not regress NTK and that the NTK base modification is
+    applied for Ntk/DynamicNtk only, never for Yarn.
+  if_fails: 'the NTK base modification was removed from the Ntk/DynamicNtk arms, or re-added to the Yarn arm.'
+  evidence: cargo test -p aprender-serve --lib test_scaled_rope_ntk_scaling test_scaled_rope_dynamic_ntk_scaling
+
+kani_harnesses:
+- id: KANI-YARN-874-001
+  obligation: YaRN extrapolated dims use the original base
+  property: |
+    For a YaRN ScaledRoPE, every inv_freq[i] equals base^(-2i/dim) (original base);
+    the NTK base never appears. No panic.
+  bound: 8
+  strategy: bounded_int
+  solver: cadical
+  harness: verify_yarn_inv_freq_uses_original_base
+
+qa_gate:
+  id: F-YARN-874-001
+  name: yarn-rope-original-base-v1 Contract
+  description: YaRN RoPE scaling must use the original rope base for extrapolated dims (interp = base-freq/scale, ramp blends), never the NTK-by-parts base modification.
+  checks:
+  - validation
+  - falsification

--- a/crates/aprender-serve/src/layers/scaled_rope.rs
+++ b/crates/aprender-serve/src/layers/scaled_rope.rs
@@ -81,14 +81,16 @@ impl ScaledRoPE {
                 beta_fast,
                 beta_slow,
             } => {
-                // YaRN combines NTK with attention scaling
+                // PMAT-874: YaRN (Peng et al. 2023, arXiv:2309.00071) does NOT apply the
+                // NTK-by-parts base modification `base * scale^(dim/(dim-2))` — that is a
+                // DIFFERENT scaling type. YaRN keeps the ORIGINAL base for the extrapolated
+                // (high-frequency / short-wavelength) dims; the interpolated (low-frequency)
+                // dims use base-freq / scale; a per-frequency ramp (driven by beta_fast /
+                // beta_slow) blends the two in the forward pass. See HuggingFace
+                // `modeling_rope_utils._compute_yarn_parameters`: `inv_freq_extrapolation`
+                // is `1 / base^(2i/dim)` (original base), `inv_freq_interpolation` is that
+                // divided by the scale factor.
                 let scale = (*target_max_len as f32) / (*original_max_len as f32);
-                let dim_f = dim as f32;
-
-                // Compute NTK-style base modification
-                // YaRN uses a smoother interpolation based on frequency
-                let exponent = dim_f / (dim_f - 2.0);
-                let ntk_base = base * scale.powf(exponent);
 
                 // Compute mscale (attention factor)
                 // Default: sqrt(1 + ln(scale) / ln(original_max_len))
@@ -104,7 +106,8 @@ impl ScaledRoPE {
                 // but are applied per-frequency in the forward pass
                 let _ = (beta_fast, beta_slow); // Used in forward
 
-                (ntk_base, mscale)
+                // YaRN's base frequency is the ORIGINAL base (no NTK modification).
+                (base, mscale)
             },
         };
 
@@ -191,20 +194,24 @@ impl ScaledRoPE {
                 let low_freq_wavelen = (*original_max_len as f32) / *beta_slow;
                 let high_freq_wavelen = (*original_max_len as f32) / *beta_fast;
 
+                // PMAT-874: YaRN ramp. ramp=0 => full extrapolation using the ORIGINAL
+                // base (inv_f is now original-base; the NTK modification is NOT applied).
+                // ramp=1 => full interpolation (original base, position scaled by 1/scale).
                 let ramp = if wavelength < high_freq_wavelen {
-                    0.0 // Full extrapolation (use NTK-scaled frequency)
+                    0.0 // Full extrapolation (original-base frequency, unscaled position)
                 } else if wavelength > low_freq_wavelen {
-                    1.0 // Full interpolation (use linear-scaled position)
+                    1.0 // Full interpolation (original-base frequency, scaled position)
                 } else {
                     // Linear ramp between extrapolation and interpolation
                     (wavelength - high_freq_wavelen) / (low_freq_wavelen - high_freq_wavelen)
                 };
 
-                // Interpolate between NTK angle and linear angle
+                // Interpolate between extrapolation angle and interpolation angle.
                 let scale = (*target_max_len as f32) / (*original_max_len as f32);
                 let linear_pos = effective_pos / scale;
 
-                // Original frequency from unscaled base
+                // Interpolation frequency: original (unscaled) base; same as inv_f here,
+                // but kept explicit for clarity / future-proofing.
                 let orig_inv_f = self
                     .original_base
                     .powf(-2.0 * (i as f32) / (self.dim as f32));

--- a/crates/aprender-serve/src/layers/tests/scaled_rope.rs
+++ b/crates/aprender-serve/src/layers/tests/scaled_rope.rs
@@ -56,8 +56,67 @@ fn test_scaled_rope_yarn() {
     assert!((scaled.context_length_multiplier() - 16.0).abs() < 1e-6);
     // YaRN should have mscale > 1.0 for large extensions
     assert!(scaled.mscale() > 1.0);
-    // YaRN should have modified base
-    assert!(scaled.scaled_base() > 10000.0);
+    // PMAT-874: YaRN does NOT apply the NTK base modification (that is a different
+    // scaling type). YaRN uses the ORIGINAL base for the extrapolation (high-frequency)
+    // dims; interpolation (low-frequency) dims use base-freq / scale. So scaled_base
+    // must remain the original base, NOT base * scale^(dim/(dim-2)).
+    assert!(
+        (scaled.scaled_base() - 10000.0).abs() < 1e-3,
+        "YaRN must use the original base, got {}",
+        scaled.scaled_base()
+    );
+}
+
+/// PMAT-874 falsifier: YaRN extrapolated (high-frequency) dims must use the ORIGINAL
+/// base, not the NTK-modified base `base * scale^(dim/(dim-2))`.
+///
+/// Reference: YaRN (Peng et al. 2023, arXiv:2309.00071);
+/// HuggingFace `modeling_rope_utils._compute_yarn_parameters` — in the full-extrapolation
+/// regime, `inv_freq[i] == 1.0 / base^(2i/dim)` derived from the ORIGINAL base.
+///
+/// For dim=64, base=10000, scale=8192/2048=4.0, beta_fast=32, beta_slow=1:
+///   - dim pair i=1 lies in the full-extrapolation regime (HF correction range low=8).
+///   - HF / original-base YaRN inv_freq[1] = 10000^(-2/64) = 0.749_894_2 (GREEN).
+///   - The buggy NTK-base value would be (10000 * 4^(64/62))^(-2/64) = 0.717_098_3 (RED).
+#[test]
+fn test_scaled_rope_yarn_extrapolation_uses_original_base() {
+    let dim = 64usize;
+    let base = 10000.0f32;
+    let scaling = RopeScalingType::Yarn {
+        original_max_len: 2048,
+        target_max_len: 8192,
+        attn_factor: 1.0,
+        beta_fast: 32.0,
+        beta_slow: 1.0,
+    };
+    let scaled = ScaledRoPE::new(dim, base, scaling).expect("test");
+
+    // Reference (HF / original-base YaRN) value for the high-frequency dim pair i=1.
+    #[allow(clippy::cast_precision_loss)]
+    let original_base_inv_freq_1 = base.powf(-2.0 * 1.0 / (dim as f32));
+    // The buggy NTK-modified base value (what the bug produced) for i=1.
+    #[allow(clippy::cast_precision_loss)]
+    let ntk_base = base * 4.0f32.powf((dim as f32) / ((dim as f32) - 2.0));
+    #[allow(clippy::cast_precision_loss)]
+    let ntk_inv_freq_1 = ntk_base.powf(-2.0 * 1.0 / (dim as f32));
+
+    let inv_freq = scaled.inv_freq();
+    assert!(inv_freq.len() > 1, "need at least 2 frequency pairs");
+
+    // GREEN: extrapolated dim 1 matches the ORIGINAL-base reference (HF YaRN).
+    assert!(
+        (inv_freq[1] - original_base_inv_freq_1).abs() < 1e-5,
+        "PMAT-874: YaRN extrapolated dim 1 must use the ORIGINAL base \
+         (expected {original_base_inv_freq_1}, got {})",
+        inv_freq[1]
+    );
+    // RED guard: it must NOT equal the NTK-modified-base value.
+    assert!(
+        (inv_freq[1] - ntk_inv_freq_1).abs() > 1e-4,
+        "PMAT-874: YaRN must NOT apply the NTK base modification \
+         (got {} which matches the buggy NTK value {ntk_inv_freq_1})",
+        inv_freq[1]
+    );
 }
 
 #[test]


### PR DESCRIPTION
ScaledRoPE YaRN branch built inv_freq from the NTK-modified base (base*scale^(dim/(dim-2))), so extrapolated high-freq dims rotated at the wrong frequency, mixing NTK-by-parts into YaRN. YaRN (Peng 2023) uses the ORIGINAL base for extrapolation. Fixed to original base.

Falsifier RED 0.717 -> GREEN 0.749 (HF _compute_yarn_parameters parity). 15442/0. contracts/yarn-rope-original-base-v1.yaml pv-valid.

Generated with Claude Code