### PR TITLE
fix(ensemble): MoE load-balance aux loss computed P_i over top-k only, not full router softmax (PMAT-875)

### DIFF
--- a/contracts/moe-load-balance-loss-v1.yaml
+++ b/contracts/moe-load-balance-loss-v1.yaml
@@ -1,0 +1,151 @@
+metadata:
+  version: 1.0.0
+  created: '2026-06-20'
+  author: PAIML Engineering
+  description: |
+    Mixture-of-Experts (Switch Transformer) load-balancing auxiliary loss must
+    compute the per-expert router-probability term P_i as the MEAN of the FULL
+    router softmax over ALL tokens — every expert on every token — NOT only the
+    gate probabilities of the experts that landed in a token's top-k set.
+
+    PMAT-875 (BEAT campaign: beat Switch/Mixtral MoE). Before the fix,
+    MixtureOfExperts::compute_load_balance_loss accumulated P_i only when expert
+    i was inside a token's top-k:
+        for (idx, prob) in indexed.iter().take(top_k) {
+            expert_counts[idx] += 1;
+            expert_probs[idx] += prob;   // BUG: top-k-only P_i
+        }
+    So P_i summed the gate probability only over tokens ROUTED to expert i. The
+    Switch Transformer aux loss (Fedus et al. 2021, Eq. 4-6) and HF Mixtral's
+    load_balancing_loss_func instead define P_i = (1/N) * sum over ALL tokens of
+    softmax(router)_i, the mean router probability mass assigned to expert i
+    across every token, including tokens that were dispatched elsewhere. f_i (the
+    hard top-k dispatch fraction) is unchanged.
+
+    Symptom: the auxiliary loss was systematically under-counted whenever routing
+    was non-uniform (an expert that wins some tokens still receives softmax mass
+    on tokens it loses, and that mass was being dropped). The fix splits the
+    accumulation: hard top-k counting for f_i, full softmax over all experts for
+    P_i.
+  references:
+  - 'Fedus, Zoph & Shazeer (2021) Switch Transformers, Eq. 4-6 (f_i, P_i, aux loss = alpha * N * sum_i f_i * P_i)'
+  - 'Shazeer et al. (2017) Outrageously Large Neural Networks (load balancing)'
+  - 'HuggingFace transformers Mixtral load_balancing_loss_func (router_prob = mean of softmax over all tokens per expert)'
+  - 'crates/aprender-core/src/ensemble/moe.rs — MixtureOfExperts::compute_load_balance_loss'
+  - 'crates/aprender-core/src/ensemble/gating.rs — SoftmaxGating::forward (full softmax over experts)'
+
+kind: KernelContract
+name: moe-load-balance-loss
+version: 1.0.0
+scope: aprender-core MoE Switch-Transformer load-balance auxiliary loss (ensemble/moe.rs)
+
+equations:
+  switch_load_balance_loss:
+    formula: |
+      loss = alpha * N * sum_{i=1..N} f_i * P_i
+        where
+          N     = number of experts
+          alpha = load_balance_weight
+          f_i   = (number of tokens whose top-k set contains expert i)
+                  / (n_samples * top_k)        # hard top-k dispatch fraction
+          P_i   = (1 / n_samples) * sum_{t=1..n_samples} softmax(router(x_t))_i
+                  # MEAN of the FULL router softmax over ALL tokens, every expert
+    domain: |
+      n_samples >= 1 tokens, N >= 1 experts, top_k in [1, N], alpha >= 0;
+      router softmax weights for each token sum to 1 over the N experts.
+    codomain: loss in R_>=0
+    invariants:
+    - 'P_i accumulates the full softmax for EVERY expert on EVERY token, not top-k-only'
+    - 'sum_i P_i == 1 (P_i is a mean of per-token softmaxes, each summing to 1)'
+    - 'sum_i f_i == 1 when normalized by (n_samples * top_k)'
+    - 'under uniform routing (f_i = 1/N, P_i = 1/N for all i) loss == alpha (its minimum)'
+    - 'an expert with f_i > 0 contributes its FULL mean softmax mass to the loss, including mass from tokens routed elsewhere'
+    lean_theorem: Theorems.Switch_Load_Balance_Loss
+
+proof_obligations:
+- type: precondition
+  property: Hyperparameters valid, non-empty batch
+  formal: 'n_samples >= 1 ∧ N >= 1 ∧ 1 <= top_k <= N ∧ alpha >= 0'
+- type: invariant
+  property: P_i is the mean FULL router softmax over all tokens
+  formal: |
+    P_i = (1/n_samples) * Σ_t softmax(router(x_t))_i, summed over ALL N experts
+    on EVERY token (NOT restricted to a token's top-k set).
+- type: postcondition
+  property: Loss equals the Switch Transformer aux loss
+  formal: 'loss = alpha * N * Σ_i f_i * P_i  with P_i = mean full-softmax, f_i = top-k dispatch fraction'
+  requires: MOE-PRE-001
+- type: bound
+  property: Loss minimized under uniform routing
+  formal: 'uniform routing (f_i = P_i = 1/N ∀i) ⇒ loss = alpha (the minimum)'
+  applies_to: all
+- type: equivalence
+  property: Top-k-only P_i is wrong unless routing is uniform
+  formal: |
+    full-softmax P_i ≠ top-k-only P_i whenever some expert with f_i > 0 also
+    carries softmax mass on tokens where it is NOT in the top-k.
+
+falsification_tests:
+- id: FT-MOE-LB-001
+  rule: P_i uses the FULL router softmax over all tokens (top_k=1)
+  prediction: |
+    For a 4-expert MoE with top_k=1 and a batch whose tokens route to different
+    experts, compute_load_balance_loss equals alpha * N * Σ_i f_i * P_i computed
+    with P_i = mean of the full per-token softmax, and DIFFERS from the value
+    obtained with the buggy top-k-only P_i accumulation.
+  if_fails: |
+    P_i is being accumulated only over a token's top-k experts (the original
+    bug), so the aux loss is under-counted under non-uniform routing.
+  evidence: cargo test -p aprender-core --lib test_moe_load_balance_uses_full_softmax_p_topk1
+- id: FT-MOE-LB-002
+  rule: P_i uses the FULL router softmax over all tokens (top_k=2)
+  prediction: |
+    Same as FT-MOE-LB-001 but with top_k=2 across all four experts; the loss
+    equals the full-softmax reference and differs from the top-k-only value.
+  if_fails: 'top-k-only accumulation regressed for multi-expert dispatch.'
+  evidence: cargo test -p aprender-core --lib test_moe_load_balance_uses_full_softmax_p_topk2
+- id: FT-MOE-LB-003
+  rule: Loss minimized at alpha under uniform routing
+  prediction: |
+    With near-zero inputs (uniform softmax) and top_k = N, every f_i = 1/N and
+    every P_i = 1/N, so compute_load_balance_loss == alpha (the minimum).
+  if_fails: |
+    The alpha * N scaling or the f_i / P_i normalization convention is wrong, so
+    the loss does not bottom out at alpha for a perfectly balanced router.
+  evidence: cargo test -p aprender-core --lib test_moe_load_balance_minimized_under_uniform_routing
+- id: FT-MOE-LB-004
+  rule: Empty batch yields zero loss (precondition / boundary)
+  prediction: 'compute_load_balance_loss on a zero-row input matrix returns 0.0.'
+  if_fails: 'division by zero (n_samples = 0) or an unguarded accumulation on an empty batch.'
+  evidence: cargo test -p aprender-core --lib test_moe_load_balance_loss_empty
+- id: FT-MOE-LB-005
+  rule: f_i counts only the top-k dispatch (full-softmax mass does not leak into f_i)
+  prediction: |
+    The full-softmax accumulation added for P_i must NOT change the dispatch
+    counts f_i: f_i still uses the hard top-k selection, so the two terms are
+    accumulated independently and the reference (which keeps f_i top-k while
+    varying only P_i) matches the implementation.
+  if_fails: |
+    f_i was also switched to the full softmax (e.g. counting every expert per
+    token), making every f_i = 1 and breaking the dispatch-fraction semantics.
+  evidence: cargo test -p aprender-core --lib test_moe_load_balance_uses_full_softmax_p_topk2
+
+kani_harnesses:
+- id: KANI-MOE-LB-001
+  obligation: P_i is the mean FULL router softmax over all tokens
+  property: |
+    For any batch of router softmax rows (each summing to 1 over N experts), the
+    accumulated P_i equals the per-expert mean over ALL tokens, so sum_i P_i = 1
+    and no expert's mass is dropped regardless of the top-k selection.
+  bound: 2
+  strategy: compositional
+  solver: cadical
+  harness: verify_moe_load_balance_full_softmax_pi
+
+qa_gate:
+  id: F-MOE-LB-001
+  name: moe-load-balance-loss-v1 Contract
+  description: MoE Switch-Transformer load-balance aux loss must accumulate P_i as the mean FULL router softmax over all tokens (every expert), not the top-k-only gate probability.
+  checks:
+  - validation
+  - falsification

--- a/crates/aprender-core/src/ensemble/moe.rs
+++ b/crates/aprender-core/src/ensemble/moe.rs
@@ -151,9 +151,13 @@ impl<E: Estimator, G: GatingNetwork> MixtureOfExperts<E, G> {
     /// Encourages even distribution of inputs across experts to prevent
     /// expert collapse (all inputs routed to single expert).
     ///
-    /// Loss = `sum_i(f_i` * `P_i`) where:
-    /// - `f_i` = fraction of inputs routed to expert i
-    /// - `P_i` = average gate probability for expert i
+    /// Switch Transformer (Fedus et al. 2021, Eq. 4-6) auxiliary loss:
+    /// Loss = `alpha * N * sum_i(f_i * P_i)` where:
+    /// - `N` = number of experts
+    /// - `alpha` = `load_balance_weight`
+    /// - `f_i` = fraction of tokens dispatched to expert i (hard top-k)
+    /// - `P_i` = MEAN router softmax probability for expert i over ALL tokens
+    ///   (full softmax, every expert, every token — NOT top-k-only)
     ///
     /// # Arguments
     ///
@@ -178,14 +182,22 @@ impl<E: Estimator, G: GatingNetwork> MixtureOfExperts<E, G> {
             let row = inputs.row(i);
             let weights = self.gating.forward(row.as_slice());
 
-            // Find top-k experts
+            // f_i term: hard top-k dispatch counting (fraction of tokens routed to
+            // expert i). Switch Transformer Eq. 4 counts only the top-k experts.
             let mut indexed: Vec<(usize, f32)> = weights.iter().copied().enumerate().collect();
             indexed.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
 
             let top_k = self.config.top_k.min(n_experts);
-            for (idx, prob) in indexed.iter().take(top_k) {
+            for (idx, _prob) in indexed.iter().take(top_k) {
                 expert_counts[*idx] += 1;
-                expert_probs[*idx] += prob;
+            }
+
+            // P_i term: mean router softmax probability for expert i over ALL tokens.
+            // Switch Transformer Eq. 5 (and HF Mixtral `load_balancing_loss_func`):
+            // P_i accumulates the FULL softmax for EVERY expert on EVERY token, not
+            // only the top-k routed experts.
+            for (e, &w) in weights.iter().enumerate() {
+                expert_probs[e] += w;
             }
         }
 

--- a/crates/aprender-core/src/ensemble/moe_tests.rs
+++ b/crates/aprender-core/src/ensemble/moe_tests.rs
@@ -251,3 +251,207 @@ fn test_moe_builder_debug() {
     let debug_str = format!("{:?}", builder);
     assert!(debug_str.contains("MoeBuilder"));
 }
+
+// ---------------------------------------------------------------------------
+// PMAT-875: Switch Transformer load-balance aux loss must use the FULL router
+// softmax for P_i (mean over ALL tokens, every expert), NOT the top-k-only
+// gate probability. Reference: Fedus et al. 2021 Eq. 4-6; HF Mixtral
+// `load_balancing_loss_func`.
+// ---------------------------------------------------------------------------
+
+/// Build a 4-expert / 3-feature MoE with non-trivial differentiated routing.
+fn build_falsifier_moe(
+    top_k: usize,
+    alpha: f32,
+) -> MixtureOfExperts<LinearRegression, SoftmaxGating> {
+    let n_experts = 4usize;
+    let n_features = 3usize;
+
+    // Fit identical (trivial) experts; the load-balance loss only depends on
+    // the router, not on expert outputs.
+    let xtr = Matrix::from_vec(
+        5,
+        n_features,
+        vec![
+            1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 0.0, 0.0, 1.0, 1.0,
+        ],
+    )
+    .expect("valid train matrix");
+    let ytr = Vector::from_slice(&[1.0, 2.0, 3.0, 4.0, 5.0]);
+
+    let mut builder = MixtureOfExperts::builder();
+    for _ in 0..n_experts {
+        let mut e = LinearRegression::new();
+        e.fit(&xtr, &ytr).expect("fit expert");
+        builder = builder.expert(e);
+    }
+
+    let config = MoeConfig::default()
+        .with_top_k(top_k)
+        .with_load_balance_weight(alpha);
+    builder
+        .gating(SoftmaxGating::new(n_features, n_experts))
+        .config(config)
+        .build()
+        .expect("build moe")
+}
+
+/// Reference Switch-Transformer aux loss.
+///
+/// `full_softmax_p`: if true, accumulate P_i over the FULL softmax for every
+/// expert on every token (CORRECT). If false, accumulate P_i only over the
+/// top-k routed experts (the OLD BUGGY behaviour).
+fn reference_aux_loss(
+    moe: &MixtureOfExperts<LinearRegression, SoftmaxGating>,
+    inputs: &Matrix<f32>,
+    full_softmax_p: bool,
+) -> f32 {
+    let n_samples = inputs.n_rows();
+    let n_experts = moe.n_experts();
+    if n_samples == 0 || n_experts == 0 {
+        return 0.0;
+    }
+    let top_k = moe.config().top_k.min(n_experts);
+
+    let mut counts = vec![0.0f32; n_experts];
+    let mut probs = vec![0.0f32; n_experts];
+
+    for i in 0..n_samples {
+        let row = inputs.row(i);
+        let weights = moe.get_routing_weights(row.as_slice());
+
+        let mut indexed: Vec<(usize, f32)> = weights.iter().copied().enumerate().collect();
+        indexed.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+
+        // f_i: hard top-k dispatch.
+        for (idx, _w) in indexed.iter().take(top_k) {
+            counts[*idx] += 1.0;
+        }
+
+        // P_i: full softmax (correct) or top-k only (buggy).
+        if full_softmax_p {
+            for (e, &w) in weights.iter().enumerate() {
+                probs[e] += w;
+            }
+        } else {
+            for (idx, w) in indexed.iter().take(top_k) {
+                probs[*idx] += w;
+            }
+        }
+    }
+
+    let n_tokens = (n_samples * top_k) as f32;
+    let mut loss = 0.0f32;
+    for e in 0..n_experts {
+        let f_i = counts[e] / n_tokens.max(1.0);
+        let p_i = probs[e] / n_samples as f32;
+        loss += f_i * p_i;
+    }
+    loss * n_experts as f32 * moe.config().load_balance_weight
+}
+
+#[test]
+fn test_moe_load_balance_uses_full_softmax_p_topk1() {
+    let alpha = 0.01f32;
+    let moe = build_falsifier_moe(1, alpha);
+
+    // The gate routes by sign of sum(x): sum(x) > 0 picks the highest-index
+    // expert, sum(x) < 0 the lowest. Mixing signs gives several experts a
+    // nonzero dispatch fraction f_i, AND each picks up softmax mass on tokens
+    // routed elsewhere — exactly the regime where top-k-only P_i and
+    // full-softmax P_i diverge. Rows (by sum sign): +, -, +, -
+    //   -> top-1 routes to experts 3, 0, 3, 0 respectively.
+    let inputs = Matrix::from_vec(
+        4,
+        3,
+        vec![
+            3.0, 1.0, 1.0, -3.0, -1.0, -1.0, 2.0, 2.0, 2.0, -4.0, -1.0, -1.0,
+        ],
+    )
+    .expect("valid inputs");
+
+    let actual = moe.compute_load_balance_loss(&inputs);
+    let expected_full = reference_aux_loss(&moe, &inputs, true);
+    let expected_topk_only = reference_aux_loss(&moe, &inputs, false);
+
+    // GREEN: matches the full-softmax Switch aux loss.
+    assert!(
+        (actual - expected_full).abs() < 1e-6,
+        "load balance loss must equal full-softmax reference: actual={actual}, expected_full={expected_full}"
+    );
+
+    // The two references must genuinely differ, else the test cannot falsify
+    // the bug.
+    assert!(
+        (expected_full - expected_topk_only).abs() > 1e-5,
+        "test setup invalid: full-softmax and top-k-only references coincide \
+         (full={expected_full}, topk_only={expected_topk_only})"
+    );
+
+    // RED guard: the (now fixed) code must NOT reproduce the top-k-only value.
+    assert!(
+        (actual - expected_topk_only).abs() > 1e-5,
+        "load balance loss still equals the buggy top-k-only value: \
+         actual={actual}, topk_only={expected_topk_only}"
+    );
+}
+
+#[test]
+fn test_moe_load_balance_uses_full_softmax_p_topk2() {
+    let alpha = 0.02f32;
+    let moe = build_falsifier_moe(2, alpha);
+
+    // sum(x) > 0 -> top-2 = {expert 3, expert 2}; sum(x) < 0 -> {expert 0,
+    // expert 1}. Mixed signs (rows: +, -, +, -, +) dispatch all four experts
+    // and each carries softmax mass on tokens routed elsewhere.
+    let inputs = Matrix::from_vec(
+        5,
+        3,
+        vec![
+            4.0, 1.0, 1.0, -4.0, -1.0, -1.0, 3.0, 2.0, 1.0, -3.0, -2.0, -1.0, 5.0, 1.0, 1.0,
+        ],
+    )
+    .expect("valid inputs");
+
+    let actual = moe.compute_load_balance_loss(&inputs);
+    let expected_full = reference_aux_loss(&moe, &inputs, true);
+    let expected_topk_only = reference_aux_loss(&moe, &inputs, false);
+
+    assert!(
+        (actual - expected_full).abs() < 1e-6,
+        "top_k=2 load balance loss must equal full-softmax reference: \
+         actual={actual}, expected_full={expected_full}"
+    );
+    assert!(
+        (expected_full - expected_topk_only).abs() > 1e-5,
+        "test setup invalid: references coincide for top_k=2"
+    );
+    assert!(
+        (actual - expected_topk_only).abs() > 1e-5,
+        "top_k=2 loss still equals the buggy top-k-only value"
+    );
+}
+
+#[test]
+fn test_moe_load_balance_minimized_under_uniform_routing() {
+    // Under perfectly uniform routing (f_i = 1/N for all i, P_i = 1/N for all
+    // i), the Switch aux loss equals alpha:
+    //   loss = alpha * N * sum_i (1/N)(1/N) = alpha * N * N * (1/N^2) = alpha.
+    // We approximate uniform routing with a near-zero input row, so every
+    // logit is ~0 and the softmax is ~uniform. With top_k = N, every expert is
+    // dispatched once per token, giving f_i = 1/N exactly.
+    let alpha = 0.05f32;
+    let n_experts = 4usize;
+    let moe = build_falsifier_moe(n_experts, alpha); // top_k = n_experts
+
+    // A single near-zero row -> uniform softmax, every expert in the top-k.
+    let inputs = Matrix::from_vec(1, 3, vec![0.0, 0.0, 0.0]).expect("valid inputs");
+
+    let loss = moe.compute_load_balance_loss(&inputs);
+
+    // Loss is minimized at exactly alpha under uniform routing.
+    assert!(
+        (loss - alpha).abs() < 1e-5,
+        "uniform-routing aux loss must equal alpha={alpha}, got {loss}"
+    );
+}


### PR DESCRIPTION
compute_load_balance_loss accumulated P_i only over top-k-selected experts, but the Switch/Mixtral aux loss needs P_i = mean full router softmax over ALL tokens for ALL experts (f_i stays hard top-k). Fixed to accumulate P_i over the full softmax.

Falsifier RED 0.0074 (top-k-only) -> GREEN 0.0104 (full softmax). 13933/0. contracts/moe-load-balance-loss-v1.yaml pv-valid.

Generated with Claude Code