### PR TITLE
fix(release): make 0.50.0 crates.io-publishable — version fields + break dev-dep cycles

### DIFF
--- a/crates/apr-cli/Cargo.toml
+++ b/crates/apr-cli/Cargo.toml
@@ -119,7 +119,7 @@ batuta-common = { workspace = true }
 # Non-optional since claude-code-parity-apr M150 (outcome-parity Phase 3
 # requires apr code in default builds). GH-344: path dep via
 # .cargo/config.toml.dev-overrides; CI uses checkout+symlink.
-batuta = { path = "../aprender-orchestrate", package = "aprender-orchestrate", default-features = false, features = ["agents", "agents-inference", "agents-mcp", "rag"] }
+batuta = { version = "0.50.0", path = "../aprender-orchestrate", package = "aprender-orchestrate", default-features = false, features = ["agents", "agents-inference", "agents-mcp", "rag"] }
 
 # Inference engine (workspace path dep — enables cuda/gpu feature forwarding)
 # GH-573: shim (0.9.1) didn't forward cuda feature → 0.7 tok/s instead of 273 tok/s

--- a/crates/aprender-compute/Cargo.toml
+++ b/crates/aprender-compute/Cargo.toml
@@ -94,16 +94,16 @@ tokio = { version = "1", features = ["macros", "rt"] }
 serde_json = "1.0"
 nalgebra = "0.34"  # For eigendecomposition benchmark comparison
 # Simulation testing framework (TRUENO-SPEC-012)
-simular = { workspace = true }
+simular = { path = "../aprender-simulate", package = "aprender-simulate" }
 regex = "1.11"  # For PTX/WGSL pattern validation in falsification tests
 # GPU edge-case test framework (TCE-001)
-trueno-cuda-edge = { workspace = true }
+trueno-cuda-edge = { path = "../aprender-cuda-edge", package = "aprender-cuda-edge" }
 # Sparse and solver crates for contract tests
-trueno-sparse = { version = "0.50.0", path = "../aprender-sparse", package = "aprender-sparse" }
-trueno-solve = { version = "0.50.0", path = "../aprender-solve", package = "aprender-solve" }
+trueno-sparse = { path = "../aprender-sparse", package = "aprender-sparse" }
+trueno-solve = { path = "../aprender-solve", package = "aprender-solve" }
 # ML-tuner showcase (SHOWCASE-BRICK-001): aprender RandomForest, DEV-only to avoid the
 # compute→core layer inversion. Path dev-dep cycle is legal + dropped on publish.
-aprender = { version = "0.50.0", path = "../aprender-core", package = "aprender-core", default-features = false }
+aprender = { path = "../aprender-core", package = "aprender-core", default-features = false }
 ndarray = "0.17.2"
 faer = "0.24"  # For GEMM benchmark comparison (fastest pure-Rust BLAS)
 matrixmultiply = "0.3"  # Direct matrixmultiply crate benchmark (engine behind ndarray)

--- a/crates/aprender-compute/Cargo.toml
+++ b/crates/aprender-compute/Cargo.toml
@@ -103,7 +103,7 @@ trueno-sparse = { version = "0.50.0", path = "../aprender-sparse", package = "ap
 trueno-solve = { version = "0.50.0", path = "../aprender-solve", package = "aprender-solve" }
 # ML-tuner showcase (SHOWCASE-BRICK-001): aprender RandomForest, DEV-only to avoid the
 # compute→core layer inversion. Path dev-dep cycle is legal + dropped on publish.
-aprender = { path = "../aprender-core", package = "aprender-core", default-features = false }
+aprender = { version = "0.50.0", path = "../aprender-core", package = "aprender-core", default-features = false }
 ndarray = "0.17.2"
 faer = "0.24"  # For GEMM benchmark comparison (fastest pure-Rust BLAS)
 matrixmultiply = "0.3"  # Direct matrixmultiply crate benchmark (engine behind ndarray)

--- a/crates/aprender-core/Cargo.toml
+++ b/crates/aprender-core/Cargo.toml
@@ -166,14 +166,14 @@ criterion = { workspace = true }
 # aprender-core's publish requires entrenar/renacer at workspace 0.32.0 on
 # crates.io BEFORE aprender-core itself ships, but those crates can't ship
 # until aprender-core does).
-renacer = { workspace = true }
+renacer = { path = "../aprender-profile", package = "aprender-profile" }
 tempfile = "3.14"  # For format module tests
 jugar-probar = "0.5"  # TUI/GUI testing framework with coverage tracking (spec §8)
 ctrlc = "3.4"  # Signal handling for SIGINT/SIGTERM (PMAT-098-PF: zombie process mitigation)
 provable-contracts = "0.3"  # Contract enforcement (dev-only)
 # Integration tests for InferenceMonitor (GH-305: was runtime dep, now dev-only).
 # Same publish-time cycle break as renacer above.
-entrenar = { workspace = true }
+entrenar = { path = "../aprender-train", package = "aprender-train" }
 serde_yaml = "0.9"  # YAML contract binding in tests (FALSIFY-SHIP-009 GATE-APR-PROV-004)
 
 [features]

--- a/crates/aprender-gpu/Cargo.toml
+++ b/crates/aprender-gpu/Cargo.toml
@@ -48,7 +48,7 @@ manzana = { version = "0.2.0", optional = true }
 [dev-dependencies]
 proptest = "1.9"
 criterion = { workspace = true }
-simular = { workspace = true }
+simular = { path = "../aprender-simulate", package = "aprender-simulate" }
 pollster = "0.4"
 bytemuck = { version = "1.21", features = ["derive"] }
 

--- a/crates/aprender-gpu/Cargo.toml
+++ b/crates/aprender-gpu/Cargo.toml
@@ -52,9 +52,9 @@ simular = { workspace = true }
 pollster = "0.4"
 bytemuck = { version = "1.21", features = ["derive"] }
 
-# renacer is Linux-only (uses ptrace syscalls)
-[target.'cfg(target_os = "linux")'.dev-dependencies]
-renacer = { workspace = true }
+# NOTE: renacer (=aprender-profile) dev-dep removed — unused (0 references) and its
+# ^0.50.0 version pin closed a crates.io publish cycle
+# (aprender-compute → aprender-gpu → aprender-profile → aprender-core → aprender-compute).
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # GPU pixel testing with TUI visualization (Sovereign Stack)

--- a/crates/aprender-orchestrate/Cargo.toml
+++ b/crates/aprender-orchestrate/Cargo.toml
@@ -302,7 +302,7 @@ criterion = { version = "0.8", features = ["html_reports"] }
 proptest = "1.5"
 blake3 = "1.8"
 filetime = "0.2"
-trueno-cuda-edge = { workspace = true }
+trueno-cuda-edge = { path = "../aprender-cuda-edge", package = "aprender-cuda-edge" }
 jugar-probar = { version = "1.0", features = ["browser"] }
 tokio-tungstenite = "0.24"
 

--- a/crates/aprender-present-lib/Cargo.toml
+++ b/crates/aprender-present-lib/Cargo.toml
@@ -37,7 +37,7 @@ getrandom = { workspace = true }
 
 [dev-dependencies]
 provable-contracts = "0.3"
-presentar-test = { workspace = true }
+presentar-test = { path = "../aprender-present-test", package = "aprender-present-test" }
 sha2 = "0.10"
 hex = "0.4"
 regex = "1"

--- a/crates/aprender-present-terminal/Cargo.toml
+++ b/crates/aprender-present-terminal/Cargo.toml
@@ -32,11 +32,12 @@ thiserror = "2.0"
 proptest = { workspace = true }
 criterion = { workspace = true }
 
-# ttop and trueno-viz for parity testing against the reference implementation
+# ttop for parity testing against the reference implementation
 # See SPEC-024 Section 11 - Visual Comparison Findings
 ttop = "2.0"
-# NOTE: `monitor` feature removed upstream (#1979); this crate uses only viz primitives.
-trueno-viz = { workspace = true }
+# NOTE: trueno-viz dev-dep removed — it was unused (0 references) and its ^0.50.0
+# requirement created a crates.io publish cycle
+# (aprender-compute → aprender-present-terminal → aprender-viz → aprender-compute).
 
 [[bench]]
 name = "terminal"

--- a/crates/aprender-profile/Cargo.toml
+++ b/crates/aprender-profile/Cargo.toml
@@ -112,7 +112,7 @@ crossterm = "0.28"
 
 # SIMD-accelerated visualization primitives (sister project)
 # NOTE: `monitor` feature removed upstream (#1979); this crate uses only viz primitives.
-trueno-viz = { path = "../aprender-viz", package = "aprender-viz", default-features = false }
+trueno-viz = { version = "0.50.0", path = "../aprender-viz", package = "aprender-viz", default-features = false }
 
 # OpenTelemetry for distributed tracing (Sprint 30)
 opentelemetry = { version = "0.31.0", optional = true }

--- a/crates/aprender-qa-cli/Cargo.toml
+++ b/crates/aprender-qa-cli/Cargo.toml
@@ -23,10 +23,10 @@ serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 clap = { workspace = true }
 chrono = { workspace = true }
-aprender-qa-gen = { path = "../aprender-qa-gen" }
-aprender-qa-runner = { path = "../aprender-qa-runner" }
-aprender-qa-report = { path = "../aprender-qa-report" }
-aprender-qa-certify = { path = "../aprender-qa-certify" }
+aprender-qa-gen = { version = "0.50.0", path = "../aprender-qa-gen" }
+aprender-qa-runner = { version = "0.50.0", path = "../aprender-qa-runner" }
+aprender-qa-report = { version = "0.50.0", path = "../aprender-qa-report" }
+aprender-qa-certify = { version = "0.50.0", path = "../aprender-qa-certify" }
 ctrlc = "3.4"
 safetensors = { workspace = true }
 colored = "2.2"

--- a/crates/aprender-qa-report/Cargo.toml
+++ b/crates/aprender-qa-report/Cargo.toml
@@ -18,8 +18,8 @@ anyhow = { workspace = true }
 chrono = { workspace = true }
 colored = "2.2"
 csv = "1.3"
-aprender-qa-gen = { path = "../aprender-qa-gen" }
-aprender-qa-runner = { path = "../aprender-qa-runner" }
+aprender-qa-gen = { version = "0.50.0", path = "../aprender-qa-gen" }
+aprender-qa-runner = { version = "0.50.0", path = "../aprender-qa-runner" }
 
 [dev-dependencies]
 proptest = { workspace = true }

--- a/crates/aprender-qa-runner/Cargo.toml
+++ b/crates/aprender-qa-runner/Cargo.toml
@@ -22,7 +22,7 @@ anyhow = { workspace = true }
 tokio = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }
 tracing = { workspace = true }
-aprender-qa-gen = { path = "../aprender-qa-gen" }
+aprender-qa-gen = { version = "0.50.0", path = "../aprender-qa-gen" }
 hostname = "0.4"
 rayon = "1.10"
 sha2 = "0.10"

--- a/crates/aprender-rag/Cargo.toml
+++ b/crates/aprender-rag/Cargo.toml
@@ -64,7 +64,7 @@ fastembed = { version = "5", optional = true }
 
 # NVIDIA Embed Nemotron 8B via realizar GGUF infrastructure (GH-3)
 # Large model (~4-32GB depending on quantization), requires GGUF file
-realizar = { path = "../aprender-serve", package = "aprender-serve", default-features = false, optional = true }
+realizar = { version = "0.50.0", path = "../aprender-serve", package = "aprender-serve", default-features = false, optional = true }
 
 # Speech-to-text via whisper-apr (Whisper ASR, .apr model format)
 # Sovereign stack: whisper-apr + aprender + trueno for pure-Rust transcription

--- a/crates/aprender-serve/Cargo.toml
+++ b/crates/aprender-serve/Cargo.toml
@@ -163,7 +163,7 @@ provable-contracts = { version = "0.2" }
 jugar-probar = { version = "0.4", features = ["tui", "gpu"] }
 
 # GPU edge-case test framework (null fuzzing, boundary probing, lifecycle chaos)
-trueno-cuda-edge = { workspace = true }
+trueno-cuda-edge = { path = "../aprender-cuda-edge", package = "aprender-cuda-edge" }
 
 # Benchmarking
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/crates/aprender-simulate/Cargo.toml
+++ b/crates/aprender-simulate/Cargo.toml
@@ -101,7 +101,7 @@ tempfile = "3.14"
 # jugar-probar removed from dev-deps to reduce Cargo.lock (CB-081)
 # Tests in tests/probar_*.rs require jugar-probar and are gated via required-features
 # Presentar TUI testing framework (SPEC-024 Section 12 & 13)
-presentar-test = { workspace = true }
+presentar-test = { path = "../aprender-present-test", package = "aprender-present-test" }
 
 [features]
 default = []

--- a/crates/aprender-simulate/Cargo.toml
+++ b/crates/aprender-simulate/Cargo.toml
@@ -53,7 +53,7 @@ crossterm = { version = "0.28", optional = true }
 # ComputeBlocks from presentar-terminal (SIMD-optimized TUI widgets)
 # Path deps to avoid jugar-probar prod dep chain (CB-081)
 presentar-terminal = { workspace = true, optional = true }
-presentar-core = { path = "../aprender-present-core", package = "aprender-present-core", default-features = false, optional = true }
+presentar-core = { version = "0.50.0", path = "../aprender-present-core", package = "aprender-present-core", default-features = false, optional = true }
 
 # WASM (optional)
 wasm-bindgen = { version = "0.2", optional = true }

--- a/crates/aprender-verify-ml/Cargo.toml
+++ b/crates/aprender-verify-ml/Cargo.toml
@@ -68,7 +68,7 @@ pest_derive = { version = "2.7", optional = true }
 [dev-dependencies]
 proptest = "1.6"
 criterion = { workspace = true }
-renacer = { workspace = true }
+renacer = { path = "../aprender-profile", package = "aprender-profile" }
 tempfile = "3.14"
 
 [features]

--- a/crates/aprender-viz/Cargo.toml
+++ b/crates/aprender-viz/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["visualization", "graphics", "science", "wasm"]
 
 [dependencies]
 # Core SIMD/GPU acceleration
-trueno = { path = "../aprender-compute", package = "aprender-compute", default-features = false }
+trueno = { version = "0.50.0", path = "../aprender-compute", package = "aprender-compute", default-features = false }
 
 # Shared Batuta stack utilities (display traits, formatting)
 batuta-common = { workspace = true }
@@ -32,7 +32,7 @@ thiserror = "2.0"
 aprender = { path = "../aprender-core", version = "0.50.0", package = "aprender-core", optional = true }
 
 # Optional: Graph integration
-trueno-graph = { path = "../aprender-graph", package = "aprender-graph", default-features = false, optional = true }
+trueno-graph = { version = "0.50.0", path = "../aprender-graph", package = "aprender-graph", default-features = false, optional = true }
 
 # Optional: Database integration
 trueno-db = { workspace = true, optional = true }


### PR DESCRIPTION
Release-recovery for 0.50.0. The first-ever full 81-crate cascade publish exposed blockers that path-deps had masked:

1. 14 sibling path-deps lacked version fields (cargo publish requires them).
2. Two unused dev-deps closed publish cycles: trueno-viz in aprender-present-terminal (compute->present-terminal->viz->compute) and renacer in aprender-gpu (compute->gpu->profile->core->compute). Both 0 refs; removed.
3. 13 sibling dev-deps were version-pinned; crates.io strips version-LESS dev-deps, so made them path-only to break all remaining dev-dep cycles.

cargo metadata confirms NO normal-dep cycles. All 68 publishable crates now LIVE at 0.50.0.

Generated with Claude Code