### PR TITLE
fix(nn): BatchNorm1d never updated running_mean/var — eval-mode normalization wrong vs PyTorch (PMAT-877)

### DIFF
--- a/contracts/batchnorm-running-stats-v1.yaml
+++ b/contracts/batchnorm-running-stats-v1.yaml
@@ -1,0 +1,117 @@
+metadata:
+  version: 1.0.0
+  created: '2026-06-21'
+  author: PAIML Engineering
+  registry: true
+  description: |
+    BatchNorm1d running-statistics buffer update (PyTorch parity, PMAT-877).
+
+    PyTorch's torch.nn.BatchNorm1d maintains two non-learnable buffers,
+    running_mean and running_var, that are updated on EVERY training-mode
+    forward via an exponential moving average:
+
+        running = (1 - momentum) * running + momentum * batch_stat
+
+    with PyTorch's convention that `momentum` (default 0.1) weights the NEW
+    batch. running_mean uses the batch mean; running_var uses the UNBIASED
+    batch variance (divisor N-1), while the in-graph normalization itself uses
+    the BIASED batch variance (divisor N). In eval mode the buffers are frozen
+    and used for normalization.
+
+    Defect (PMAT-877): aprender's BatchNorm1d computed the batch mean/var during
+    training but NEVER wrote them back to running_mean/running_var, so the
+    buffers stayed at their init (0 / 1) forever. Consequently eval()-mode
+    normalization was wrong (it always divided by 1 and subtracted 0).
+  references:
+  - 'Ioffe & Szegedy (2015) Batch Normalization: Accelerating Deep Network Training'
+  - 'PyTorch torch.nn.BatchNorm1d — running_mean/running_var buffer semantics, momentum default 0.1'
+  - 'crates/aprender-core/src/nn/normalization/mod.rs — BatchNorm1d::forward (fix site)'
+  - 'crates/aprender-contracts/src/kernels/batchnorm.rs — reference EMA update'
+
+kind: KernelContract
+name: batchnorm-running-stats
+version: 1.0.0
+scope: crates/aprender-core/src/nn/normalization/ — BatchNorm1d running-statistics buffers
+
+description: |
+  Training-mode forward of BatchNorm1d must update the running_mean and
+  running_var buffers via a momentum EMA so that eval-mode normalization uses
+  statistics estimated over training, matching PyTorch BatchNorm1d.
+
+equations:
+  running_mean_ema:
+    formula: running_mean_c <- (1 - m) * running_mean_c + m * batch_mean_c
+    domain: momentum m in (0, 1); batch_mean_c in R per feature c
+    codomain: running_mean_c in R
+    invariants:
+    - 'Applied once per training-mode forward, per feature channel c'
+    - 'batch_mean_c = (1/N) * sum_n x_{n,c} (biased mean over batch+spatial)'
+    - 'After K forwards on a fixed batch: running_mean_c = batch_mean_c * (1 - (1-m)^K)'
+    - 'Eval mode does NOT modify running_mean (buffers frozen)'
+    preconditions:
+    - input.iter().all(|v| v.is_finite())
+    - input.len() > 0
+    lean_theorem: Theorems.Running_Mean_Ema
+  running_var_ema:
+    formula: running_var_c <- (1 - m) * running_var_c + m * unbiased_batch_var_c
+    domain: momentum m in (0, 1); unbiased_batch_var_c in R_>=0 per feature c
+    codomain: running_var_c in R_>=0
+    invariants:
+    - 'running_var uses the UNBIASED batch variance (divisor N-1), per PyTorch'
+    - 'Normalization output uses the BIASED batch variance (divisor N)'
+    - 'For N == 1 the unbiased estimate is undefined, so running_var is left unchanged'
+    - 'running_var_c >= 0 after any number of updates (EMA of non-negative quantities)'
+    preconditions:
+    - input.iter().all(|v| v.is_finite())
+    - input.len() > 0
+    lean_theorem: Theorems.Running_Var_Ema
+
+proof_obligations:
+- type: invariant
+  property: Training forward updates running_mean toward the batch mean
+  formal: |
+    For a BatchNorm1d with momentum m and a fixed batch with per-feature mean
+    mu_c != 0: after K >= 1 training-mode forwards, running_mean_c equals
+    mu_c * (1 - (1-m)^K), which is strictly between the init value 0 and mu_c.
+    In particular running_mean_c is NOT 0 (the buggy fixed point).
+  tolerance: 1.0e-04
+  applies_to: all
+- type: invariant
+  property: Training forward updates running_var off its init
+  formal: |
+    For a fixed batch with non-zero per-feature variance and N > 1: after one or
+    more training-mode forwards, running_var_c differs from its init value 1.0.
+  applies_to: all
+- type: bound
+  property: Running variance stays non-negative
+  formal: running_var_c >= 0 after any number of EMA updates when batch_var >= 0
+  applies_to: all
+- type: equivalence
+  property: Eval mode freezes and uses running stats
+  formal: |
+    In eval mode BatchNorm1d normalizes with the current running_mean/running_var
+    and does not modify them; output uses running stats, not batch statistics.
+  applies_to: all
+
+falsification_tests:
+- id: FALSIFY-BN-RUNSTAT-001
+  rule: Training updates running_mean/running_var via momentum EMA
+  prediction: |
+    After 20 training-mode forwards on a fixed batch whose per-feature means are
+    250 and 25 (momentum 0.1), running_mean climbs monotonically toward those
+    means (matching batch * (1 - 0.9^20)) and running_var moves off its init of
+    1.0. Pre-fix: running_mean stays 0 forever (RED at step 0).
+  if_fails: |
+    The training branch of BatchNorm1d::forward computes batch stats but does not
+    write them back into the running_mean/running_var buffers. Add the EMA update
+    inside the `if self.training` arm, per crates/aprender-contracts batchnorm.rs.
+  test: cargo test -p aprender-core --lib falsify_bn_007_training_updates_running_stats
+  evidence: cargo test -p aprender-core --lib falsify_bn_007_training_updates_running_stats
+
+qa_gate:
+  id: F-BN-RUNSTAT-001
+  name: batchnorm-running-stats-v1 Contract
+  description: BatchNorm1d must update running_mean/running_var via momentum EMA during training (PyTorch parity).
+  checks:
+  - validation
+  - falsification

--- a/crates/aprender-core/src/nn/normalization/mod.rs
+++ b/crates/aprender-core/src/nn/normalization/mod.rs
@@ -14,6 +14,7 @@
 use super::init::{constant, zeros};
 use super::module::Module;
 use crate::autograd::Tensor;
+use std::sync::Mutex;
 
 /// Layer Normalization (Ba et al., 2016).
 ///
@@ -190,10 +191,13 @@ pub struct BatchNorm1d {
     weight: Tensor,
     /// Learnable shift
     bias: Tensor,
-    /// Running mean (not learnable)
-    running_mean: Tensor,
-    /// Running variance (not learnable)
-    running_var: Tensor,
+    /// Running mean (not learnable; PyTorch buffer). `Mutex` (a `Sync` interior-
+    /// mutability cell, required by `Module: Send + Sync`) so the EMA update can
+    /// be applied during `Module::forward(&self)` in training mode.
+    running_mean: Mutex<Vec<f32>>,
+    /// Running variance (not learnable; PyTorch buffer). Updated with the
+    /// **unbiased** batch variance per PyTorch's `BatchNorm1d` convention.
+    running_var: Mutex<Vec<f32>>,
     /// Training mode
     training: bool,
 }
@@ -212,8 +216,8 @@ impl BatchNorm1d {
             momentum: 0.1,
             weight: constant(&[num_features], 1.0).requires_grad(),
             bias: zeros(&[num_features]).requires_grad(),
-            running_mean: zeros(&[num_features]),
-            running_var: constant(&[num_features], 1.0),
+            running_mean: Mutex::new(vec![0.0; num_features]),
+            running_var: Mutex::new(vec![1.0; num_features]),
             training: true,
         }
     }
@@ -230,6 +234,30 @@ impl BatchNorm1d {
     pub fn with_eps(mut self, eps: f32) -> Self {
         self.eps = eps;
         self
+    }
+
+    /// Current running mean per feature (PyTorch `running_mean` buffer).
+    ///
+    /// Initialised to 0 and updated each training-mode `forward` via an
+    /// exponential moving average. Used (frozen) in eval mode.
+    #[must_use]
+    pub fn running_mean(&self) -> Vec<f32> {
+        self.running_mean
+            .lock()
+            .expect("BatchNorm1d running_mean lock poisoned")
+            .clone()
+    }
+
+    /// Current running variance per feature (PyTorch `running_var` buffer).
+    ///
+    /// Initialised to 1 and updated each training-mode `forward` via an
+    /// exponential moving average of the **unbiased** batch variance.
+    #[must_use]
+    pub fn running_var(&self) -> Vec<f32> {
+        self.running_var
+            .lock()
+            .expect("BatchNorm1d running_var lock poisoned")
+            .clone()
     }
 }
 
@@ -289,19 +317,45 @@ impl Module for BatchNorm1d {
         let input_data = input.data();
         let mut output_data = vec![0.0; input_data.len()];
 
+        // Interior-mutable PyTorch buffers (only written in training mode).
+        let mut running_mean = self
+            .running_mean
+            .lock()
+            .expect("BatchNorm1d running_mean lock poisoned");
+        let mut running_var = self
+            .running_var
+            .lock()
+            .expect("BatchNorm1d running_var lock poisoned");
+
         for f in 0..features {
             let indices = Self::feature_indices(shape, f);
 
             let (mean, var) = if self.training {
+                let n = indices.len() as f32;
                 let sum: f32 = indices.iter().map(|&i| input_data[i]).sum();
-                let mean = sum / indices.len() as f32;
+                let mean = sum / n;
                 let var_sum: f32 = indices
                     .iter()
                     .map(|&i| (input_data[i] - mean).powi(2))
                     .sum();
-                (mean, var_sum / indices.len() as f32)
+                // Biased variance (÷N) is used for normalization (Ioffe & Szegedy).
+                let batch_var = var_sum / n;
+
+                // PyTorch EMA update of the running buffers (training only):
+                //   running = (1 - momentum) * running + momentum * batch_stat
+                // PyTorch updates running_var with the UNBIASED batch variance
+                // (÷(N-1)). With N == 1 the unbiased estimate is undefined, so
+                // (matching PyTorch) leave running_var unchanged for that step.
+                running_mean[f] = (1.0 - self.momentum) * running_mean[f] + self.momentum * mean;
+                if indices.len() > 1 {
+                    let unbiased_var = var_sum / (n - 1.0);
+                    running_var[f] =
+                        (1.0 - self.momentum) * running_var[f] + self.momentum * unbiased_var;
+                }
+
+                (mean, batch_var)
             } else {
-                (self.running_mean.data()[f], self.running_var.data()[f])
+                (running_mean[f], running_var[f])
             };
 
             let std_inv = 1.0 / (var + self.eps).sqrt();
@@ -315,6 +369,9 @@ impl Module for BatchNorm1d {
                 self.bias.data()[f],
             );
         }
+
+        drop(running_mean);
+        drop(running_var);
 
         Tensor::new(&output_data, shape)
     }

--- a/crates/aprender-core/src/nn/normalization/tests_batchnorm_contract.rs
+++ b/crates/aprender-core/src/nn/normalization/tests_batchnorm_contract.rs
@@ -87,6 +87,91 @@ fn falsify_bn_004_eval_uses_running_stats() {
     );
 }
 
+/// FALSIFY-BN-007 (PMAT-877): Training updates running stats via momentum EMA.
+///
+/// PyTorch `BatchNorm1d` updates the `running_mean`/`running_var` buffers on
+/// every training-mode forward:
+///   running = (1 - momentum) * running + momentum * batch_stat
+///
+/// Regression guard: the old aprender code computed the batch stats but NEVER
+/// wrote them back, so `running_mean` stayed at its init (0) forever, making
+/// eval-mode normalization wrong. This is RED on the buggy code (running_mean
+/// stays 0) and GREEN after the fix (running_mean moves toward the batch mean).
+#[test]
+fn falsify_bn_007_training_updates_running_stats() {
+    let momentum = 0.1_f32;
+    let norm = BatchNorm1d::new(2).with_momentum(momentum);
+
+    // Init: running_mean == 0, running_var == 1.
+    let init_mean = norm.running_mean();
+    let init_var = norm.running_var();
+    assert_eq!(init_mean, vec![0.0, 0.0], "init running_mean must be 0");
+    assert_eq!(init_var, vec![1.0, 1.0], "init running_var must be 1");
+
+    // A fixed batch whose per-feature mean is far from 0.
+    //   feature 0: [100, 200, 300, 400] -> batch_mean = 250
+    //   feature 1: [ 10,  20,  30,  40] -> batch_mean = 25
+    let x = Tensor::new(
+        &[
+            100.0, 10.0, // sample 0
+            200.0, 20.0, // sample 1
+            300.0, 30.0, // sample 2
+            400.0, 40.0, // sample 3
+        ],
+        &[4, 2],
+    );
+    let batch_mean = [250.0_f32, 25.0_f32];
+
+    // Run N training forwards on the SAME batch; running_mean must climb
+    // monotonically toward batch_mean (geometric approach with rate momentum).
+    let n_steps = 20;
+    let mut prev = init_mean.clone();
+    for step in 0..n_steps {
+        let _ = norm.forward(&x);
+        let rm = norm.running_mean();
+        for c in 0..2 {
+            assert!(
+                rm[c] > prev[c],
+                "FALSIFIED BN-007: running_mean[{c}] did not increase at step {step} \
+                 (prev={}, now={}); training never updated running stats",
+                prev[c],
+                rm[c]
+            );
+        }
+        prev = rm;
+    }
+
+    // After N updates, running_mean must have moved a long way toward batch_mean.
+    // Closed form for a fixed batch: running = batch * (1 - (1-m)^N).
+    let final_mean = norm.running_mean();
+    for c in 0..2 {
+        let expected = batch_mean[c] * (1.0 - (1.0 - momentum).powi(n_steps));
+        assert!(
+            (final_mean[c] - expected).abs() < 1e-2 * batch_mean[c].abs().max(1.0),
+            "FALSIFIED BN-007: running_mean[{c}]={} != EMA closed form {expected}",
+            final_mean[c]
+        );
+        // And it is decisively away from the buggy init value of 0.
+        assert!(
+            final_mean[c] > 0.5 * batch_mean[c],
+            "FALSIFIED BN-007: running_mean[{c}]={} stuck near init 0 (expected > {})",
+            final_mean[c],
+            0.5 * batch_mean[c]
+        );
+    }
+
+    // running_var must also have moved off its init of 1 toward the (unbiased)
+    // batch variance, which is large here (hundreds / thousands).
+    let final_var = norm.running_var();
+    for c in 0..2 {
+        assert!(
+            final_var[c] > 1.0 + 1e-3,
+            "FALSIFIED BN-007: running_var[{c}]={} did not move off init 1.0",
+            final_var[c]
+        );
+    }
+}
+
 /// FALSIFY-BN-006: Boundary batch_size=1 — zero variance yields beta
 ///
 /// With N=1, variance is 0, so output = gamma * 0 + beta = beta (= 0 by default).


### PR DESCRIPTION
BatchNorm1d computed batch stats during training but never wrote running_mean/running_var (stayed at init 0/1 forever), so eval() normalization was wrong. Fixed to PyTorch EMA: running=(1-momentum)*running+momentum*batch (unbiased var for running). Falsifier RED (running stays 0) -> GREEN (climbs to batch mean). 13952/0. contracts/batchnorm-running-stats-v1.yaml pv-valid.

Generated with Claude Code