### PR TITLE
fix(nn): Linear bias init was zeros — PyTorch uses uniform(±1/sqrt(fan_in)) (PMAT-878)

### DIFF
--- a/contracts/linear-bias-init-v1.yaml
+++ b/contracts/linear-bias-init-v1.yaml
@@ -1,0 +1,98 @@
+metadata:
+  version: 1.0.0
+  created: '2026-06-21'
+  author: PAIML Engineering
+  description: |
+    PMAT-878: aprender's Linear layer must initialize its bias the way PyTorch's
+    torch.nn.Linear.reset_parameters does — sampled from U(-bound, +bound) where
+    bound = 1/sqrt(fan_in) and fan_in = in_features — NOT from zeros.
+
+    The previous init used `zeros(&[out_features])`, so every seeded Linear shipped
+    a bias of exactly 0.0. That diverges from PyTorch parity (Pillar-2): a model
+    trained or evaluated against PyTorch reference weights starts from a different
+    bias prior, and zero-bias initialization is a measurable correctness defect for
+    any pre-bias-update forward pass and for reproducing PyTorch training dynamics.
+
+    The fix samples the bias from U(-1/sqrt(fan_in), +1/sqrt(fan_in)) using the same
+    seeded StdRng mechanism as the weights (seed + 1, so the bias stream stays
+    deterministic but decorrelated from the weight stream). The degenerate fan_in = 0
+    case falls back to zeros to avoid an empty U(0, 0) sampling range.
+  references:
+  - 'torch.nn.Linear.reset_parameters (PyTorch reference): bias ~ U(-1/sqrt(fan_in), +1/sqrt(fan_in))'
+  - 'crates/aprender-core/src/nn/linear.rs — Linear::with_seed bias init'
+  - 'crates/aprender-core/src/nn/init.rs — uniform(shape, low, high, seed)'
+
+kind: KernelContract
+name: linear-bias-init
+version: 1.0.0
+scope: aprender-core Linear layer bias initialization (nn/linear.rs Linear::with_seed)
+
+equations:
+  linear_bias_init:
+    formula: |
+      bias[i] ~ U(-bound, +bound)  for all i in [0, out_features),
+      where bound = 1 / sqrt(fan_in) and fan_in = in_features (in_features > 0).
+    domain: in_features in N_{>0}, out_features in N_{>0}, seed in Option<u64>
+    codomain: bias in R^{out_features}
+    invariants:
+    - 'Bounded: -1/sqrt(fan_in) <= bias[i] <= 1/sqrt(fan_in) for all i'
+    - 'Not degenerate: bias is NOT identically zero for in_features > 0'
+    - 'Reproducible: same seed produces the same bias vector'
+    - 'Shape: bias.len() = out_features'
+    lean_theorem: Theorems.Linear_Bias_Init
+
+proof_obligations:
+- type: invariant
+  property: bias is within the PyTorch bound
+  formal: |
+    for all i: bias[i] in [-1/sqrt(in_features), +1/sqrt(in_features)] when in_features > 0.
+- type: invariant
+  property: bias is not all-zero
+  formal: |
+    exists i: bias[i] != 0  for a seeded Linear with in_features > 0
+    (falsifies the old zeros() initialization).
+- type: invariant
+  property: bias initialization is reproducible
+  formal: |
+    with_seed(in, out, Some(s)).bias() == with_seed(in, out, Some(s)).bias().
+
+falsification_tests:
+- id: FT-LBI-001
+  rule: every bias component lies within +/- 1/sqrt(fan_in)
+  prediction: |
+    Linear::with_seed(64, 32, Some(42)).bias() has every component in [-1/8, +1/8]
+    (1/sqrt(64) = 0.125).
+  if_fails: 'the bias init uses the wrong bound (not 1/sqrt(fan_in)).'
+  test: cargo test -p aprender-core --lib falsify_lp_bias_878_uniform_init
+- id: FT-LBI-002
+  rule: seeded bias is not all-zero
+  prediction: |
+    Linear::with_seed(64, 32, Some(42)).bias() has at least one non-zero component.
+    Before the fix the bias was all 0.0.
+  if_fails: 'the bias init reverted to zeros().'
+  test: cargo test -p aprender-core --lib falsify_lp_bias_878_uniform_init
+- id: FT-LBI-003
+  rule: seeded bias is reproducible across constructions
+  prediction: |
+    Two Linear::with_seed(16, 8, Some(7)) layers produce byte-identical bias vectors.
+  if_fails: 'the bias seed is non-deterministic or derived from entropy.'
+  test: cargo test -p aprender-core --lib falsify_lp_bias_878_reproducible
+
+kani_harnesses:
+- id: KANI-LBI-001
+  obligation: bias is within the PyTorch bound
+  property: |
+    For all i in [0, out_features): |bias[i]| <= 1/sqrt(in_features) when
+    in_features > 0. The uniform sampler never emits a value outside [low, high).
+  bound: 1
+  strategy: stub_float
+  solver: cadical
+  harness: verify_linear_bias_within_bound
+
+qa_gate:
+  id: F-LBI-001
+  name: linear-bias-init-v1 Contract
+  description: aprender Linear bias must be initialized from U(-1/sqrt(fan_in), +1/sqrt(fan_in)) for PyTorch torch.nn.Linear parity, never from zeros.
+  checks:
+  - validation
+  - falsification

--- a/crates/aprender-core/src/nn/linear.rs
+++ b/crates/aprender-core/src/nn/linear.rs
@@ -7,7 +7,7 @@
 //! - Glorot, X., & Bengio, Y. (2010). Understanding the difficulty of training
 //!   deep feedforward neural networks. AISTATS.
 
-use super::init::{xavier_uniform, zeros};
+use super::init::{uniform, xavier_uniform, zeros};
 use super::module::Module;
 use crate::autograd::Tensor;
 
@@ -80,7 +80,26 @@ impl Linear {
         )
         .requires_grad();
         let weight_t = Some(weight.transpose());
-        let bias = zeros(&[out_features]).requires_grad();
+
+        // Bias init matches PyTorch `torch.nn.Linear.reset_parameters`:
+        // bias ~ U(-bound, +bound) where bound = 1/sqrt(fan_in), fan_in = in_features.
+        // (PMAT-878: was previously `zeros()`, which diverges from PyTorch.)
+        // A distinct-but-deterministic seed (`seed + 1`) keeps the bias stream
+        // reproducible while decorrelated from the weight stream.
+        let bias = if in_features == 0 {
+            // Degenerate fan_in: bound = 1/sqrt(0) is undefined; fall back to zeros
+            // (avoids an empty `U(0, 0)` range, which would panic).
+            zeros(&[out_features]).requires_grad()
+        } else {
+            let bound = 1.0 / (in_features as f32).sqrt();
+            uniform(
+                &[out_features],
+                -bound,
+                bound,
+                seed.map(|s| s.wrapping_add(1)),
+            )
+            .requires_grad()
+        };
 
         Self {
             weight,

--- a/crates/aprender-core/src/nn/linear_tests.rs
+++ b/crates/aprender-core/src/nn/linear_tests.rs
@@ -342,3 +342,61 @@ fn falsify_lp_002b_zero_preservation_no_bias() {
         );
     }
 }
+
+// =========================================================================
+// PMAT-878: PyTorch-parity bias initialization
+//
+// torch.nn.Linear.reset_parameters initializes the bias from
+//   U(-bound, +bound),  bound = 1/sqrt(fan_in),  fan_in = in_features
+// NOT from zeros. This falsifier is RED on the old `zeros()` init (every
+// bias component is exactly 0.0) and GREEN once the uniform init lands.
+//
+// Reference: torch.nn.Linear.reset_parameters
+//   contracts/linear-bias-init-v1.yaml
+// =========================================================================
+
+/// FALSIFY-LP-BIAS-878: seeded bias is NOT all-zero and lies in [-1/sqrt(fan_in), +1/sqrt(fan_in)]
+#[test]
+fn falsify_lp_bias_878_uniform_init() {
+    let in_features = 64usize;
+    let out_features = 32usize;
+    let bound = 1.0 / (in_features as f32).sqrt();
+
+    let layer = Linear::with_seed(in_features, out_features, Some(42));
+    let bias = layer.bias().expect("seeded Linear has bias");
+    let data = bias.data();
+
+    assert_eq!(
+        data.len(),
+        out_features,
+        "FALSIFIED LP-BIAS-878: bias len {} != out_features {out_features}",
+        data.len()
+    );
+
+    // NOT all-zero (RED on the old `zeros()` init).
+    let any_nonzero = data.iter().any(|&v| v.abs() > 0.0);
+    assert!(
+        any_nonzero,
+        "FALSIFIED LP-BIAS-878: bias is all-zero (expected U(-{bound}, {bound}) per torch.nn.Linear)"
+    );
+
+    // Every component within the PyTorch bound.
+    for (i, &v) in data.iter().enumerate() {
+        assert!(
+            v >= -bound && v <= bound,
+            "FALSIFIED LP-BIAS-878: bias[{i}] = {v} outside [-{bound}, {bound}]"
+        );
+    }
+}
+
+/// FALSIFY-LP-BIAS-878-repro: seeded bias is reproducible across constructions
+#[test]
+fn falsify_lp_bias_878_reproducible() {
+    let a = Linear::with_seed(16, 8, Some(7));
+    let b = Linear::with_seed(16, 8, Some(7));
+    assert_eq!(
+        a.bias().expect("bias a").data(),
+        b.bias().expect("bias b").data(),
+        "FALSIFIED LP-BIAS-878-repro: same seed produced different bias"
+    );
+}


### PR DESCRIPTION
Linear initialized bias with zeros; torch.nn.Linear uses U(-1/sqrt(fan_in),+1/sqrt(fan_in)). Fixed (seed-deterministic). Falsifier RED (all-zero) -> GREEN (in band, not zero). 13953/0. contracts/linear-bias-init-v1.yaml pv-valid.

Generated with Claude Code