### PR TITLE
fix(serve): fail-closed on inconsistent GQA KV-cache dims (silent OOB → garbage) (PMAT-880)

### DIFF
--- a/contracts/gqa-kv-dim-fail-closed-v1.yaml
+++ b/contracts/gqa-kv-dim-fail-closed-v1.yaml
@@ -1,0 +1,148 @@
+metadata:
+  version: 1.0.0
+  created: '2026-06-21'
+  author: PAIML Engineering
+  description: |
+    PMAT-880 — Pillar-4 fail-closed CORRECTNESS beat for GQA KV-cache
+    dimension consistency. The GQA cached-attention kernel
+    (attention_with_cache_gqa / _into in
+    crates/aprender-serve/src/gguf/inference/attention_gqa.rs) indexes the KV
+    cache as k_cache[pos * kv_dim + kv_head * head_dim ..][..head_dim] and the
+    current-position K/V as current_k[kv_head * head_dim ..][..head_dim], where
+    kv_dim == num_kv_heads * head_dim. A model/config whose supplied KV cache is
+    inconsistent with these dims (cache length not a whole multiple of kv_dim,
+    current_k/current_v shorter than kv_dim, or q shorter than q_dim) makes the
+    kernel silently read the WRONG memory — garbage attention, incoherent output
+    — or run past the slice (out of bounds). llama.cpp validates KV-cache shape
+    before attention; apr must REJECT with a clear error. This is the same
+    fail-closed class as the shipped garbage / extreme-magnitude beats
+    (PMAT-744 / PMAT-732) and complements the PMAT-749 GQA cache fix by adding
+    the previously-missing dimension guard. The guard is O(1) and leaves the
+    happy path byte-identical: valid GQA and MHA models pass unchanged
+    (zero false-positives).
+  references:
+  - 'PMAT-880 (this contract): GQA KV-dim fail-closed guard'
+  - 'crates/aprender-serve/src/gguf/inference/attention_gqa.rs (validate_gqa_kv_dims + adaptive_attention_with_cache wiring)'
+  - 'crates/aprender-serve/src/gguf/inference/attention_gqa_tests.rs (PMAT-880 falsifiers + positive tests)'
+  - 'apr-gqa-cache-attention-dispatch-v1.yaml (PMAT-749: GQA cache dispatch; this adds the missing guard)'
+  - 'apr-fail-closed-garbage-beat-v1.yaml (PMAT-744: sibling Pillar-4 fail-closed beat)'
+  - 'llama.cpp llama_kv_cache shape validation (reference: incumbents validate cache shape)'
+
+kind: KernelContract
+name: gqa-kv-dim-fail-closed
+version: 1.0.0
+scope: aprender-serve GQA cached-attention KV-dimension consistency guard
+
+equations:
+  kv_dim_consistency:
+    formula: kv_dim = num_kv_heads * head_dim
+    domain: num_kv_heads > 0, head_dim > 0, num_heads >= num_kv_heads
+    codomain: kv_dim in Z+
+    invariants:
+    - 'kv_dim equals num_kv_heads * head_dim (per-position cache stride matches per-head layout)'
+    - 'k_cache.len() and v_cache.len() are whole multiples of kv_dim (cache is [seq, kv_dim] row-major)'
+    - 'k_cache.len() == v_cache.len() (K and V describe the same sequence length)'
+    - 'current_k.len() >= kv_dim and current_v.len() >= kv_dim (current K/V cover all KV heads)'
+    - 'q.len() >= q_dim where q_dim = num_heads * head_dim (query covers all attention heads)'
+    preconditions:
+    - num_kv_heads >= 1
+    - head_dim >= 1
+    postconditions:
+    - kv_dim == num_kv_heads * head_dim
+    - validate_gqa_kv_dims returns Ok iff every kv_dim_consistency invariant holds
+    lean_theorem: Theorems.Gqa_Kv_Dim_Consistency
+
+proof_obligations:
+- type: invariant
+  property: reject-on-violation — inconsistent KV dims are rejected (fail-closed)
+  formal: |
+    For every (q, k_cache, v_cache, current_k, current_v) that violates any
+    kv_dim_consistency invariant (kv_dim != num_kv_heads * head_dim, cache length
+    not a multiple of kv_dim, K/V length mismatch, current_k/current_v shorter
+    than kv_dim, or q shorter than q_dim), validate_gqa_kv_dims returns
+    Err(RealizarError::InvalidConfiguration) and adaptive_attention_with_cache
+    propagates that error rather than indexing the wrong memory or panicking.
+- type: invariant
+  property: no-false-positive-on-valid — valid GQA/MHA models pass unchanged
+  formal: |
+    For every (q, k_cache, v_cache, current_k, current_v) that satisfies every
+    kv_dim_consistency invariant (including the empty-cache first-token case and
+    the MHA degenerate case num_kv_heads == num_heads), validate_gqa_kv_dims
+    returns Ok(()) and the attention output is identical to the pre-guard
+    behavior (the guard is a pure precondition check with no side effects).
+
+falsification_tests:
+- id: FT-GQA-KVDIM-001
+  rule: k_cache length not a multiple of kv_dim is rejected
+  prediction: validate_gqa_kv_dims with k_cache.len() not divisible by kv_dim returns Err (pre-guard the kernel truncated cache_len into garbage attention)
+  test: cargo test -p aprender-serve --lib test_pmat880_kcache_not_multiple_of_kv_dim_rejected
+  if_fails: the multiple-of-kv_dim check was removed; the cache is silently truncated and attention is garbage
+- id: FT-GQA-KVDIM-002
+  rule: current_k shorter than kv_dim is rejected
+  prediction: validate_gqa_kv_dims with current_k.len() < kv_dim returns Err (pre-guard the per-head slice ran out of bounds and panicked)
+  test: cargo test -p aprender-serve --lib test_pmat880_current_k_shorter_than_kv_dim_rejected
+  if_fails: the current_k length check was removed; the kernel indexes out of bounds for the last KV head
+- id: FT-GQA-KVDIM-003
+  rule: K and V caches with different sequence lengths are rejected
+  prediction: validate_gqa_kv_dims with k_cache.len() != v_cache.len() returns Err
+  test: cargo test -p aprender-serve --lib test_pmat880_kv_cache_length_mismatch_rejected
+  if_fails: the K/V length-equality check was removed; K and V imply different seq lengths and attention is garbage
+- id: FT-GQA-KVDIM-004
+  rule: fail-closed error propagates through the public adaptive cached-attention entry point
+  prediction: adaptive_attention_with_cache on a GQA model with an inconsistent KV cache returns Err (production path fails closed, not just the helper)
+  test: cargo test -p aprender-serve --lib test_pmat880_adaptive_attention_propagates_fail_closed
+  if_fails: the guard was not wired into adaptive_attention_with_cache; production silently produces garbage
+- id: FT-GQA-KVDIM-005
+  rule: valid GQA config with a consistent cache passes (zero false-positive)
+  prediction: validate_gqa_kv_dims on a valid GQA model returns Ok and attention output is q_dim long and finite
+  test: cargo test -p aprender-serve --lib test_pmat880_valid_gqa_passes_no_false_positive
+  if_fails: the guard is too strict and rejects a legitimate GQA model (false positive)
+- id: FT-GQA-KVDIM-006
+  rule: empty KV cache (first token, cache_len == 0) passes
+  prediction: validate_gqa_kv_dims with an empty k_cache/v_cache returns Ok (0 is a multiple of kv_dim)
+  test: cargo test -p aprender-serve --lib test_pmat880_empty_cache_first_token_passes
+  if_fails: the guard rejects the first-token empty-cache case, breaking generation start
+- id: FT-GQA-KVDIM-007
+  rule: valid MHA config (num_kv_heads == num_heads) passes
+  prediction: validate_gqa_kv_dims on a valid MHA model returns Ok (no false positive on the degenerate case)
+  test: cargo test -p aprender-serve --lib test_pmat880_valid_mha_passes_no_false_positive
+  if_fails: the guard mishandles the MHA degenerate case and rejects a valid model
+
+kani_harnesses:
+- id: KANI-GQA-KVDIM-001
+  obligation: kv_dim_consistency — kv_dim equals num_kv_heads * head_dim
+  property: |
+    For all (num_kv_heads in [1..16], head_dim in [1..256]):
+    expected_kv_dim = num_kv_heads * head_dim, and validate_gqa_kv_dims rejects
+    any supplied kv_dim != expected_kv_dim.
+  bound: 16
+  strategy: bounded_int
+  solver: cadical
+  harness: verify_kv_dim_equals_num_kv_heads_times_head_dim
+- id: KANI-GQA-KVDIM-002
+  obligation: reject-on-violation — cache length not a multiple of kv_dim is rejected
+  property: |
+    For all (kv_dim in [1..256], extra in [1..kv_dim-1]):
+    a cache length of (n * kv_dim + extra) makes validate_gqa_kv_dims return Err.
+  bound: 16
+  strategy: bounded_int
+  solver: cadical
+  harness: verify_non_multiple_cache_length_rejected
+- id: KANI-GQA-KVDIM-003
+  obligation: no-false-positive-on-valid — consistent dims pass
+  property: |
+    For all (num_kv_heads in [1..16], head_dim in [1..256], seq in [0..8]):
+    a cache of length seq * kv_dim with current_k/current_v of length kv_dim and
+    q of length q_dim makes validate_gqa_kv_dims return Ok.
+  bound: 16
+  strategy: bounded_int
+  solver: cadical
+  harness: verify_consistent_dims_pass
+
+qa_gate:
+  id: F-GQA-KVDIM-001
+  name: gqa-kv-dim-fail-closed-v1 Contract
+  description: GQA cached-attention must REJECT a KV cache inconsistent with kv_dim = num_kv_heads * head_dim (fail-closed), with zero false-positives on valid GQA/MHA models.
+  checks:
+  - validation
+  - falsification

--- a/crates/aprender-serve/src/gguf/inference/attention_gqa.rs
+++ b/crates/aprender-serve/src/gguf/inference/attention_gqa.rs
@@ -1,5 +1,123 @@
 impl OwnedQuantizedModel {
 
+    /// PMAT-880: Fail-closed guard for GQA KV-cache dimension consistency.
+    ///
+    /// The GQA cached-attention kernels index the KV cache as
+    /// `k_cache[pos * kv_dim + kv_head * head_dim ..][..head_dim]` and the
+    /// current-position K/V as `current_k[kv_head * head_dim ..][..head_dim]`,
+    /// where `kv_dim == num_kv_heads * head_dim`. If a model/config carries
+    /// inconsistent KV dims (e.g. a KV cache that was not allocated for the
+    /// same `kv_dim`, or a `current_k`/`current_v`/`q` shorter than required),
+    /// those indices silently read the WRONG memory → garbage attention →
+    /// incoherent output, or run past the slice → out-of-bounds.
+    ///
+    /// llama.cpp validates KV-cache shape before attention. This is the same
+    /// FAIL-CLOSED class as the shipped garbage/extreme-magnitude beats
+    /// (PMAT-744 / PMAT-732): `apr` REJECTS a broken model with a clear error
+    /// where llama.cpp/Ollama silently produce garbage. It relates to the
+    /// PMAT-749 GQA cache fix — this adds the previously-missing guard.
+    ///
+    /// The check is O(1) and leaves the happy path byte-identical: a valid GQA
+    /// (or MHA) model satisfies every invariant and proceeds unchanged.
+    ///
+    /// # Errors
+    /// Returns [`RealizarError::InvalidConfiguration`] when:
+    /// - `head_dim == 0` or `num_kv_heads == 0` (degenerate KV geometry), or
+    /// - `kv_dim != num_kv_heads * head_dim` (config invariant violated), or
+    /// - `k_cache`/`v_cache` length is not a whole multiple of `kv_dim`, or the
+    ///   two caches imply different sequence lengths, or
+    /// - `current_k`/`current_v` is shorter than `kv_dim`, or
+    /// - `q` is shorter than `q_dim` (`num_heads * head_dim`).
+    pub fn validate_gqa_kv_dims(
+        &self,
+        q: &[f32],
+        k_cache: &[f32],
+        v_cache: &[f32],
+        current_k: &[f32],
+        current_v: &[f32],
+    ) -> Result<()> {
+        let num_heads = self.config.num_heads;
+        let num_kv_heads = self.config.num_kv_heads;
+        let head_dim = self.config.head_dim();
+        let q_dim = self.config.q_dim();
+        let kv_dim = self.config.kv_dim();
+
+        // Degenerate geometry: kv_dim==0 would make the cache_len division
+        // (k_cache.len() / kv_dim) panic and every KV index meaningless.
+        if head_dim == 0 || num_kv_heads == 0 {
+            return Err(RealizarError::InvalidConfiguration(format!(
+                "PMAT-880: GQA KV geometry is degenerate (head_dim={head_dim}, \
+                 num_kv_heads={num_kv_heads}); kv_dim would be 0 and the KV-cache \
+                 stride is undefined"
+            )));
+        }
+
+        // Core invariant: kv_dim must equal num_kv_heads * head_dim, otherwise the
+        // per-position stride used to index the cache is inconsistent with the
+        // per-head layout and reads the wrong memory.
+        let expected_kv_dim = num_kv_heads * head_dim;
+        if kv_dim != expected_kv_dim {
+            return Err(RealizarError::InvalidConfiguration(format!(
+                "PMAT-880: inconsistent KV dimensions — kv_dim ({kv_dim}) != \
+                 num_kv_heads * head_dim ({num_kv_heads} * {head_dim} = {expected_kv_dim}); \
+                 the KV cache stride does not match the per-head layout"
+            )));
+        }
+
+        // The KV cache is laid out as [seq, kv_dim] row-major; its length must be
+        // a whole multiple of kv_dim, and K and V must describe the same seq len.
+        if k_cache.len() % kv_dim != 0 {
+            return Err(RealizarError::InvalidConfiguration(format!(
+                "PMAT-880: k_cache length ({}) is not a multiple of kv_dim ({kv_dim}); \
+                 the KV cache was not allocated for these dimensions",
+                k_cache.len()
+            )));
+        }
+        if v_cache.len() % kv_dim != 0 {
+            return Err(RealizarError::InvalidConfiguration(format!(
+                "PMAT-880: v_cache length ({}) is not a multiple of kv_dim ({kv_dim}); \
+                 the KV cache was not allocated for these dimensions",
+                v_cache.len()
+            )));
+        }
+        if k_cache.len() != v_cache.len() {
+            return Err(RealizarError::InvalidConfiguration(format!(
+                "PMAT-880: k_cache length ({}) != v_cache length ({}); \
+                 the K and V caches imply different sequence lengths",
+                k_cache.len(),
+                v_cache.len()
+            )));
+        }
+
+        // The current position's K/V are indexed up to kv_dim; they must be long
+        // enough or the per-head slice runs out of bounds.
+        if current_k.len() < kv_dim {
+            return Err(RealizarError::InvalidConfiguration(format!(
+                "PMAT-880: current_k length ({}) < kv_dim ({kv_dim}); \
+                 the current-position key does not cover all KV heads",
+                current_k.len()
+            )));
+        }
+        if current_v.len() < kv_dim {
+            return Err(RealizarError::InvalidConfiguration(format!(
+                "PMAT-880: current_v length ({}) < kv_dim ({kv_dim}); \
+                 the current-position value does not cover all KV heads",
+                current_v.len()
+            )));
+        }
+
+        // The query is indexed up to q_dim = num_heads * head_dim.
+        if q.len() < q_dim {
+            return Err(RealizarError::InvalidConfiguration(format!(
+                "PMAT-880: q length ({}) < q_dim ({q_dim} = {num_heads} * {head_dim}); \
+                 the query does not cover all attention heads",
+                q.len()
+            )));
+        }
+
+        Ok(())
+    }
+
     /// Compute attention with Grouped Query Attention (GQA) support (IMP-105)
     ///
     /// GQA uses fewer KV heads than Q heads, with multiple Q heads sharing each KV head.
@@ -273,6 +391,8 @@ impl OwnedQuantizedModel {
         // handles MHA as q_per_kv==1, but we keep the GPU path for MHA to avoid a perf
         // regression). Every prior test of this path was MHA, so GQA was uncovered.
         if self.config.num_kv_heads < self.config.num_heads {
+            // PMAT-880: fail closed on inconsistent KV-cache dims before indexing.
+            self.validate_gqa_kv_dims(q, k_cache, v_cache, current_k, current_v)?;
             return Ok(self.attention_with_cache_gqa(q, k_cache, v_cache, current_k, current_v));
         }
 
@@ -310,6 +430,8 @@ impl OwnedQuantizedModel {
         // PMAT-749: GQA models need the kv_dim-strided path; attention_with_cache is
         // MHA-only and panics for num_kv_heads < num_heads. See the gpu variant above.
         if self.config.num_kv_heads < self.config.num_heads {
+            // PMAT-880: fail closed on inconsistent KV-cache dims before indexing.
+            self.validate_gqa_kv_dims(q, k_cache, v_cache, current_k, current_v)?;
             return Ok(self.attention_with_cache_gqa(q, k_cache, v_cache, current_k, current_v));
         }
         Ok(self.attention_with_cache(q, k_cache, v_cache, current_k, current_v))

--- a/crates/aprender-serve/src/gguf/inference/attention_gqa_tests.rs
+++ b/crates/aprender-serve/src/gguf/inference/attention_gqa_tests.rs
@@ -437,4 +437,197 @@ fn test_qkv_out_dim_matches_gqa_formula() {
     assert_eq!(weights.out_dim(), 96);
 }
 
+// =============================================================================
+// PMAT-880: Fail-closed guard for GQA KV-cache dimension consistency
+//
+// A model/config with KV dims inconsistent with the supplied KV cache (cache
+// length not a multiple of kv_dim, current_k/current_v shorter than kv_dim, or
+// a q shorter than q_dim) makes the GQA kernel index the WRONG memory →
+// garbage attention (incoherent output), or run out of bounds. llama.cpp
+// validates cache shape; apr must REJECT with a clear error (FAIL CLOSED).
+//
+// RED (before guard): validate_gqa_kv_dims did not exist; the kernel silently
+// proceeded (truncated cache_len → garbage) or panicked OOB on the current K/V.
+// GREEN (after guard): validate_gqa_kv_dims returns Err on every violation and
+// the adaptive cached-attention entry point propagates it; valid GQA models are
+// unaffected (zero false-positives).
+// =============================================================================
+
+/// FALSIFIER (RED→GREEN): k_cache length not a multiple of kv_dim is rejected.
+///
+/// GQA 4:1, hidden_dim=64, head_dim=8, kv_dim=16. A cache that was allocated
+/// for a DIFFERENT kv_dim leaves a length that is not a whole multiple of 16.
+/// Without the guard the kernel truncates cache_len and silently produces
+/// garbage attention; with the guard it fails closed.
+#[test]
+fn test_pmat880_kcache_not_multiple_of_kv_dim_rejected() {
+    let model = create_gqa_model(64, 8, 2);
+    let q_dim = 64;
+    let kv_dim = 16;
+
+    let q = vec![0.1f32; q_dim];
+    // 3 full rows (48) + 5 extra = 53: NOT a multiple of kv_dim (16).
+    let k_cache = vec![0.1f32; 3 * kv_dim + 5];
+    let v_cache = vec![0.1f32; 3 * kv_dim + 5];
+    let current_k = vec![0.1f32; kv_dim];
+    let current_v = vec![0.1f32; kv_dim];
+
+    let result = model.validate_gqa_kv_dims(&q, &k_cache, &v_cache, &current_k, &current_v);
+    assert!(
+        result.is_err(),
+        "PMAT-880: a k_cache length that is not a multiple of kv_dim must be REJECTED \
+         (fail-closed), not silently truncated into garbage attention"
+    );
+    let msg = format!("{}", result.unwrap_err());
+    assert!(
+        msg.contains("PMAT-880") && msg.contains("kv_dim"),
+        "error must clearly explain the KV-dim violation, got: {msg}"
+    );
+}
+
+/// FALSIFIER (RED→GREEN): current_k shorter than kv_dim is rejected.
+///
+/// The kernel reads `current_k[kv_head * head_dim ..][..head_dim]` for every
+/// KV head, so a current_k shorter than kv_dim runs out of bounds (panic) for
+/// the last head. The guard rejects it with a clear error instead.
+#[test]
+fn test_pmat880_current_k_shorter_than_kv_dim_rejected() {
+    let model = create_gqa_model(64, 8, 2);
+    let q_dim = 64;
+    let kv_dim = 16;
+
+    let q = vec![0.1f32; q_dim];
+    let k_cache = vec![0.1f32; 2 * kv_dim];
+    let v_cache = vec![0.1f32; 2 * kv_dim];
+    // current_k covers only ONE kv head (8) instead of all heads (kv_dim=16).
+    let current_k = vec![0.1f32; kv_dim - 8];
+    let current_v = vec![0.1f32; kv_dim];
+
+    let result = model.validate_gqa_kv_dims(&q, &k_cache, &v_cache, &current_k, &current_v);
+    assert!(
+        result.is_err(),
+        "PMAT-880: a current_k shorter than kv_dim must be REJECTED (fail-closed), \
+         not indexed out of bounds"
+    );
+}
+
+/// FALSIFIER (RED→GREEN): k_cache and v_cache implying different seq lens rejected.
+#[test]
+fn test_pmat880_kv_cache_length_mismatch_rejected() {
+    let model = create_gqa_model(64, 8, 2);
+    let q_dim = 64;
+    let kv_dim = 16;
+
+    let q = vec![0.1f32; q_dim];
+    let k_cache = vec![0.1f32; 3 * kv_dim];
+    let v_cache = vec![0.1f32; 2 * kv_dim]; // different seq len than K
+    let current_k = vec![0.1f32; kv_dim];
+    let current_v = vec![0.1f32; kv_dim];
+
+    let result = model.validate_gqa_kv_dims(&q, &k_cache, &v_cache, &current_k, &current_v);
+    assert!(
+        result.is_err(),
+        "PMAT-880: K and V caches with different sequence lengths must be REJECTED"
+    );
+}
+
+/// FALSIFIER (RED→GREEN): the fail-closed error PROPAGATES through the public
+/// adaptive cached-attention entry point (production path), not just the helper.
+#[test]
+fn test_pmat880_adaptive_attention_propagates_fail_closed() {
+    let model = create_gqa_model(64, 8, 2);
+    let q_dim = 64;
+    let kv_dim = 16;
+
+    let q = vec![0.1f32; q_dim];
+    // Malformed cache: not a multiple of kv_dim.
+    let k_cache = vec![0.1f32; 2 * kv_dim + 3];
+    let v_cache = vec![0.1f32; 2 * kv_dim + 3];
+    let current_k = vec![0.1f32; kv_dim];
+    let current_v = vec![0.1f32; kv_dim];
+
+    let result =
+        model.adaptive_attention_with_cache(&q, &k_cache, &v_cache, &current_k, &current_v);
+    assert!(
+        result.is_err(),
+        "PMAT-880: adaptive_attention_with_cache must propagate the fail-closed error \
+         for a GQA model with an inconsistent KV cache"
+    );
+}
+
+// =============================================================================
+// PMAT-880: POSITIVE tests — zero false-positives on VALID models
+// =============================================================================
+
+/// A valid GQA config + consistent cache must PASS the guard (no false-positive).
+#[test]
+fn test_pmat880_valid_gqa_passes_no_false_positive() {
+    let model = create_gqa_model(64, 8, 2);
+    let q_dim = 64;
+    let kv_dim = 16;
+
+    // cache_len = 3 → exact multiple of kv_dim; current K/V exactly kv_dim.
+    let q = vec![0.1f32; q_dim];
+    let k_cache = vec![0.1f32; 3 * kv_dim];
+    let v_cache = vec![0.1f32; 3 * kv_dim];
+    let current_k = vec![0.1f32; kv_dim];
+    let current_v = vec![0.1f32; kv_dim];
+
+    let result = model.validate_gqa_kv_dims(&q, &k_cache, &v_cache, &current_k, &current_v);
+    assert!(
+        result.is_ok(),
+        "PMAT-880: a valid GQA config with a consistent KV cache must PASS the guard \
+         (zero false-positives), got: {result:?}"
+    );
+
+    // And the happy path still produces correctly-shaped, finite output.
+    let out = model.attention_with_cache_gqa(&q, &k_cache, &v_cache, &current_k, &current_v);
+    assert_eq!(out.len(), q_dim, "valid GQA output must be q_dim long");
+    assert!(
+        out.iter().all(|x| x.is_finite()),
+        "valid GQA output must be finite"
+    );
+}
+
+/// An empty KV cache (first token: cache_len=0) is valid and must PASS.
+#[test]
+fn test_pmat880_empty_cache_first_token_passes() {
+    let model = create_gqa_model(64, 8, 2);
+    let q_dim = 64;
+    let kv_dim = 16;
+
+    let q = vec![0.1f32; q_dim];
+    let k_cache: Vec<f32> = vec![]; // 0 is a multiple of kv_dim
+    let v_cache: Vec<f32> = vec![];
+    let current_k = vec![0.1f32; kv_dim];
+    let current_v = vec![0.1f32; kv_dim];
+
+    let result = model.validate_gqa_kv_dims(&q, &k_cache, &v_cache, &current_k, &current_v);
+    assert!(
+        result.is_ok(),
+        "PMAT-880: an empty cache (first token) is valid and must PASS, got: {result:?}"
+    );
+}
+
+/// A valid MHA config (num_kv_heads == num_heads) must also PASS the guard.
+#[test]
+fn test_pmat880_valid_mha_passes_no_false_positive() {
+    // MHA: 4 Q heads, 4 KV heads, hidden_dim=64 → head_dim=16, kv_dim=q_dim=64.
+    let model = create_gqa_model(64, 4, 4);
+    let q_dim = 64;
+    let kv_dim = 64;
+
+    let q = vec![0.1f32; q_dim];
+    let k_cache = vec![0.1f32; 2 * kv_dim];
+    let v_cache = vec![0.1f32; 2 * kv_dim];
+    let current_k = vec![0.1f32; kv_dim];
+    let current_v = vec![0.1f32; kv_dim];
+
+    let result = model.validate_gqa_kv_dims(&q, &k_cache, &v_cache, &current_k, &current_v);
+    assert!(
+        result.is_ok(),
+        "PMAT-880: a valid MHA config must PASS the guard (zero false-positives), got: {result:?}"
+    );
+}
+
 include!("attention_gqa_tests_forward_cached.rs");


### PR DESCRIPTION
Pillar-4 fail-closed beat: attention_with_cache_gqa did not validate kv_dim==num_kv_heads*head_dim nor cache-length consistency, so a corrupt config silently read wrong memory -> garbage attention (llama.cpp validates). Added validate_gqa_kv_dims guard (returns Err, no panic) wired into both adaptive paths; valid models unchanged (zero false-positive). Falsifiers RED->GREEN. 15426/0. contracts/gqa-kv-dim-fail-closed-v1.yaml pv-valid.

Generated with Claude Code