### PR TITLE
fix(lora): apply dropout to input in LoRA forward — HF PEFT parity (PMAT-879)

### DIFF
--- a/contracts/lora-dropout-placement-v1.yaml
+++ b/contracts/lora-dropout-placement-v1.yaml
@@ -1,0 +1,122 @@
+metadata:
+  version: 1.0.0
+  created: '2026-06-21'
+  author: PAIML Engineering
+  description: LoRA dropout placement — dropout applied to the INPUT x before the down-projection
+    A, matching HuggingFace PEFT lora.Linear.forward (PMAT-879)
+  references:
+  - 'HF PEFT lora.Linear.forward: result = result + lora_B(lora_A(dropout(x))) * scaling'
+  - Hu et al. (2021) LoRA — Low-Rank Adaptation of Large Language Models
+  - Srivastava et al. (2014) Dropout — A Simple Way to Prevent Overfitting
+equations:
+  lora_forward_with_dropout:
+    formula: y = W x + s * B (A (dropout(x)))
+    domain: x in R^d_in, W in R^(d_out x d_in), A in R^(r x d_in), B in R^(d_out x r), s > 0, p in [0, 1)
+    codomain: y in R^d_out
+    invariants:
+    - Dropout is applied to the input x before A, never to A@x or B@(A@x)
+    - In eval mode dropout is the identity so inference output is unchanged
+    - Training-mode inverted dropout preserves expectation E[dropout(x)] = x
+    preconditions:
+    - x.len() == d_in
+    - p in [0, 1)
+    postconditions:
+    - y.len() == d_out
+    - '!training || p == 0 implies y == W x + s B (A x)'
+    lean_theorem: Theorems.LoRA_Dropout_Placement
+  inverted_dropout:
+    formula: dropout(x)_i = 0 with prob p, else x_i / (1 - p)
+    domain: x in R^d, p in [0, 1)
+    codomain: dropout(x) in R^d
+    invariants:
+    - Survivors scaled by 1/(1-p) so expectation is preserved
+    - Identity when p == 0 or in eval mode
+    preconditions:
+    - p in [0, 1)
+    postconditions:
+    - dropout(x).len() == x.len()
+    - 'E[dropout(x)] == x (expectation preserved)'
+    lean_theorem: Theorems.Inverted_Dropout
+proof_obligations:
+- type: postcondition
+  property: Dropout on input is train-only; eval is identity (dropout-on-input-train-only)
+  formal: 'training ∧ p > 0 ⇒ y_lora = s·B(A(dropout(x))) ; ¬training ∨ p = 0 ⇒ y_lora = s·B(A(x))'
+- type: invariant
+  property: Eval-mode forward is deterministic and dropout-free (inference parity)
+  formal: ¬training ⇒ forward(x) byte-identical to no-dropout forward(x)
+  applies_to: all
+- type: invariant
+  property: Deterministic mask for a fixed seed
+  formal: same dropout_seed ⇒ same mask sequence
+  applies_to: all
+- type: bound
+  property: Inverted-dropout scale finite
+  formal: p ∈ [0, 1) ⇒ 1/(1-p) is finite
+  applies_to: all
+falsification_tests:
+- id: F-DROPOUT-001
+  rule: Dropout changes training output
+  prediction: With p>0, fixed seed, training mode, LoRA output differs from no-dropout path
+  test: test_falsify_f_dropout_001_training_dropout_changes_output
+  if_fails: Dropout is not applied to the LoRA-branch input (pre-fix bug)
+- id: F-DROPOUT-002
+  rule: Eval mode is identity
+  prediction: In eval mode the dropout-configured output equals the no-dropout output exactly
+  test: test_falsify_f_dropout_002_eval_mode_is_identity
+  if_fails: Dropout leaks into inference (eval mode not the identity)
+- id: F-DROPOUT-003
+  rule: Deterministic seeded mask
+  prediction: Two training layers with the same seed produce identical output
+  test: test_falsify_f_dropout_003_seed_is_deterministic
+  if_fails: Dropout RNG is not seeded deterministically
+- id: F-DROPOUT-004
+  rule: Inverted dropout alters contribution
+  prediction: With p=0.5 in training, the LoRA contribution differs from the un-dropped one
+  test: test_falsify_f_dropout_004_some_inputs_zeroed_in_training
+  if_fails: Inverted dropout is a no-op (mask or scale not applied)
+kani_harnesses:
+- id: KANI-LDP-001
+  obligation: Dropout on input is train-only; eval is identity
+  property: Training-mode dropout changes the LoRA output relative to no-dropout
+  bound: 4
+  strategy: stub_float
+  solver: cadical
+  harness: verify_lora_dropout_train_only
+- id: KANI-LDP-002
+  obligation: Eval-mode forward is deterministic and dropout-free
+  property: Eval-mode forward equals the no-dropout forward
+  bound: 4
+  strategy: stub_float
+  solver: cadical
+  harness: verify_lora_dropout_eval_identity
+- id: KANI-LDP-003
+  obligation: Deterministic mask for a fixed seed
+  property: Same seed yields same mask
+  bound: 4
+  strategy: exhaustive
+  harness: verify_lora_dropout_seed_determinism
+- id: KANI-LDP-004
+  obligation: Inverted-dropout scale finite
+  property: 1/(1-p) is finite for p in [0, 1)
+  bound: 4
+  strategy: stub_float
+  solver: cadical
+  harness: verify_lora_dropout_inv_scale_finite
+enforcement:
+  dropout_on_input_train_only:
+    description: Dropout must be applied to input x before A, and only in training mode
+    check: contract_tests::F-DROPOUT-001
+    severity: ERROR
+  eval_identity:
+    description: Eval-mode forward must be dropout-free (inference parity)
+    check: contract_tests::F-DROPOUT-002
+    severity: ERROR
+qa_gate:
+  id: F-LDP-001
+  name: LoRA Dropout Placement Contract
+  description: PEFT-parity dropout placement quality gate
+  checks:
+  - dropout_on_input_train_only
+  - eval_identity
+  pass_criteria: All 4 falsification tests pass
+  falsification: Apply dropout to A@x instead of x, or apply dropout in eval mode

--- a/crates/aprender-train/src/lora/layer/core.rs
+++ b/crates/aprender-train/src/lora/layer/core.rs
@@ -8,9 +8,19 @@
 //!
 //! Forward pass: y = (W + α·B·A) @ x = W@x + α·(B@(A@x))
 //! where α is a scaling factor (typically alpha/r)
+//!
+//! Dropout placement (PMAT-879): matching HF PEFT `lora.Linear.forward`, dropout
+//! is applied to the INPUT `x` *before* the down-projection `A`:
+//!
+//! `y = W@x + scale · B(A(dropout(x)))`
+//!
+//! Dropout is active only in training mode; in eval mode (the default) it is the
+//! identity, so inference output is unchanged. Inverted dropout scales the
+//! surviving activations by `1/(1-p)` so the expected value is preserved.
 
 use crate::autograd::matmul;
 use crate::Tensor;
+use std::cell::Cell;
 
 /// LoRA scaling mode (ENT-LoRA-004)
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -54,6 +64,18 @@ pub struct LoRALayer {
     scale: f32,
     /// Whether the adapter is merged into base_weight
     merged: bool,
+    /// LoRA dropout probability applied to the input `x` in the LoRA branch
+    /// (PMAT-879). `0.0` disables dropout (identity). Active only in training mode.
+    dropout: f32,
+    /// Training mode flag. `false` (eval) is the default so inference output is
+    /// deterministic and dropout-free, matching PEFT (`nn.Dropout` is identity in eval).
+    training: bool,
+    /// Base seed for the deterministic dropout RNG (PMAT-879).
+    dropout_seed: u64,
+    /// Per-forward counter that advances the dropout RNG so successive training
+    /// steps draw fresh, but reproducible, masks. Interior mutability keeps
+    /// `forward(&self)` (shared borrow) while remaining deterministic for a seed.
+    dropout_step: Cell<u64>,
 }
 
 impl LoRALayer {
@@ -87,7 +109,20 @@ impl LoRALayer {
 
         let scale = alpha / rank as f32;
 
-        Self { base_weight, lora_a, lora_b, d_out, d_in, rank, scale, merged: false }
+        Self {
+            base_weight,
+            lora_a,
+            lora_b,
+            d_out,
+            d_in,
+            rank,
+            scale,
+            merged: false,
+            dropout: 0.0,
+            training: false,
+            dropout_seed: 0,
+            dropout_step: Cell::new(0),
+        }
     }
 
     /// Create a new LoRA layer with explicit scaling mode (ENT-LoRA-004)
@@ -118,7 +153,92 @@ impl LoRALayer {
         self
     }
 
-    /// Forward pass: y = W@x + scale * (B @ (A @ x))
+    /// Set the LoRA dropout probability (PMAT-879).
+    ///
+    /// Matches HF PEFT `lora_dropout`: dropout is applied to the input `x` before
+    /// the down-projection `A`. `p` is clamped to `[0.0, 1.0)`; `0.0` disables
+    /// dropout. Dropout is only active in training mode (see [`LoRALayer::train`]).
+    #[must_use]
+    pub fn with_dropout(mut self, p: f32) -> Self {
+        // Clamp to [0, 1): p == 1.0 would zero everything and divide by zero in
+        // the inverted-dropout scale, which is never a valid configuration.
+        self.dropout = p.clamp(0.0, 0.999_999);
+        self
+    }
+
+    /// Set the deterministic dropout RNG seed (PMAT-879).
+    ///
+    /// With a fixed seed, dropout masks are fully reproducible, which makes the
+    /// training-mode forward path testable.
+    #[must_use]
+    pub fn with_dropout_seed(mut self, seed: u64) -> Self {
+        self.dropout_seed = seed;
+        self
+    }
+
+    /// Switch the layer to training mode. Dropout is active when `dropout > 0.0`.
+    pub fn train(&mut self) {
+        self.training = true;
+    }
+
+    /// Switch the layer to evaluation mode (the default). Dropout is the identity,
+    /// so inference output is unchanged — matching PEFT `nn.Dropout` in eval.
+    pub fn eval(&mut self) {
+        self.training = false;
+    }
+
+    /// Set training/eval mode explicitly.
+    pub fn set_training(&mut self, training: bool) {
+        self.training = training;
+    }
+
+    /// Whether the layer is in training mode.
+    pub fn is_training(&self) -> bool {
+        self.training
+    }
+
+    /// LoRA dropout probability.
+    pub fn dropout(&self) -> f32 {
+        self.dropout
+    }
+
+    /// Apply inverted dropout to the LoRA-branch input (PMAT-879).
+    ///
+    /// Returns `x` unchanged when not in training mode or when `p == 0.0` (the
+    /// identity), exactly mirroring PEFT's `nn.Dropout`/`nn.Identity` placement.
+    /// Otherwise each element is independently zeroed with probability `p` and the
+    /// survivors are scaled by `1/(1-p)` so the expectation is preserved.
+    ///
+    /// Uses a deterministic RNG seeded from `(dropout_seed, dropout_step)` so the
+    /// mask is reproducible for a given seed while advancing per forward call.
+    fn apply_input_dropout(&self, x: &Tensor) -> Tensor {
+        if !self.training || self.dropout <= 0.0 {
+            return x.clone();
+        }
+
+        use rand::rngs::StdRng;
+        use rand::{Rng, SeedableRng};
+
+        let step = self.dropout_step.get();
+        self.dropout_step.set(step.wrapping_add(1));
+
+        // Mix seed and step so each forward draws a fresh, reproducible mask.
+        let mixed = self.dropout_seed ^ step.wrapping_mul(0x9E37_79B9_7F4A_7C15);
+        let mut rng = StdRng::seed_from_u64(mixed);
+
+        let keep = 1.0 - self.dropout;
+        let inv_keep = 1.0 / keep;
+
+        let dropped: Vec<f32> = x
+            .data()
+            .iter()
+            .map(|&v| if rng.random::<f32>() < self.dropout { 0.0 } else { v * inv_keep })
+            .collect();
+
+        Tensor::from_vec(dropped, x.requires_grad())
+    }
+
+    /// Forward pass: y = W@x + scale * (B @ (A @ dropout(x)))
     ///
     /// # Arguments
     /// * `x` - Input tensor `[d_in]`
@@ -135,9 +255,13 @@ impl LoRALayer {
             // If merged, W already includes LoRA adaptation
             base_output
         } else {
-            // LoRA forward: scale * (B @ (A @ x))
-            // Step 1: A @ x [r, d_in] @ [d_in, 1] -> [r, 1]
-            let lora_out_a = matmul(&self.lora_a, x, self.rank, self.d_in, 1);
+            // LoRA forward: scale * (B @ (A @ dropout(x)))
+            // PEFT placement: dropout is applied to the INPUT x before A.
+            // In eval mode (default) or with dropout == 0.0 this is the identity.
+            let dropped_x = self.apply_input_dropout(x);
+
+            // Step 1: A @ dropout(x) [r, d_in] @ [d_in, 1] -> [r, 1]
+            let lora_out_a = matmul(&self.lora_a, &dropped_x, self.rank, self.d_in, 1);
 
             // Step 2: B @ (A @ x) [d_out, r] @ [r, 1] -> [d_out, 1]
             let lora_out_b = matmul(&self.lora_b, &lora_out_a, self.d_out, self.rank, 1);

--- a/crates/aprender-train/src/lora/layer/falsify_tests.rs
+++ b/crates/aprender-train/src/lora/layer/falsify_tests.rs
@@ -178,6 +178,138 @@ fn test_falsify_f_math_008_nf4_dequantize_tolerance() {
 }
 
 // ========================================================================
+// PMAT-879: LoRA DROPOUT PLACEMENT (PEFT parity)
+//
+// Reference: HF PEFT lora.Linear.forward —
+//   result = result + lora_B(lora_A(dropout(x))) * scaling
+// Dropout is applied to the INPUT x before lora_A, and is the identity in
+// eval mode. These falsifiers fail on the pre-fix code (no dropout applied).
+// ========================================================================
+
+/// Helper: build a LoRA layer with non-zero A and B so the LoRA contribution is
+/// non-trivial (B is zeroed at init, which would mask the dropout effect).
+fn lora_with_nonzero_adapter(d_out: usize, d_in: usize, rank: usize) -> LoRALayer {
+    let base = Tensor::from_vec(vec![0.0; d_out * d_in], false);
+    let mut lora = LoRALayer::new(base, d_out, d_in, rank, rank as f32);
+    let a: Vec<f32> = (0..rank * d_in).map(|i| (i as f32 * 0.13).sin() * 0.5 + 0.3).collect();
+    let b: Vec<f32> = (0..d_out * rank).map(|i| (i as f32 * 0.17).cos() * 0.5 + 0.4).collect();
+    *lora.lora_a_mut().data_mut() = ndarray::Array1::from_vec(a);
+    *lora.lora_b_mut().data_mut() = ndarray::Array1::from_vec(b);
+    lora
+}
+
+/// F-DROPOUT-001: In TRAINING mode with p > 0 and a fixed seed, the LoRA output
+/// must DIFFER from the no-dropout output. RED on pre-fix code (dropout ignored).
+#[test]
+fn test_falsify_f_dropout_001_training_dropout_changes_output() {
+    let d_out = 8;
+    let d_in = 16;
+    let rank = 4;
+    let x = Tensor::from_vec((0..d_in).map(|i| (i as f32 * 0.21).sin() + 1.0).collect(), true);
+
+    // No dropout (eval-equivalent baseline).
+    let baseline = lora_with_nonzero_adapter(d_out, d_in, rank);
+    let y_baseline = baseline.forward(&x);
+
+    // Training mode with dropout p = 0.5 and a fixed seed.
+    let mut dropped =
+        lora_with_nonzero_adapter(d_out, d_in, rank).with_dropout(0.5).with_dropout_seed(42);
+    dropped.train();
+    let y_dropped = dropped.forward(&x);
+
+    let max_diff = y_baseline
+        .data()
+        .iter()
+        .zip(y_dropped.data().iter())
+        .map(|(a, b)| (a - b).abs())
+        .fold(0.0f32, f32::max);
+
+    assert!(
+        max_diff > 1e-6,
+        "F-DROPOUT-001 violated: training-mode dropout produced an IDENTICAL output to \
+         the no-dropout path (max_diff={max_diff}). Dropout is not applied in the LoRA branch."
+    );
+}
+
+/// F-DROPOUT-002: In EVAL mode, dropout is the IDENTITY — output must be byte-for-byte
+/// equal to the no-dropout output regardless of the configured p. Inference unchanged.
+#[test]
+fn test_falsify_f_dropout_002_eval_mode_is_identity() {
+    let d_out = 8;
+    let d_in = 16;
+    let rank = 4;
+    let x = Tensor::from_vec((0..d_in).map(|i| (i as f32 * 0.21).sin() + 1.0).collect(), true);
+
+    let baseline = lora_with_nonzero_adapter(d_out, d_in, rank);
+    let y_baseline = baseline.forward(&x);
+
+    // Configure dropout but stay in eval mode (default).
+    let eval_layer =
+        lora_with_nonzero_adapter(d_out, d_in, rank).with_dropout(0.5).with_dropout_seed(42);
+    assert!(!eval_layer.is_training(), "Layer must default to eval mode");
+    let y_eval = eval_layer.forward(&x);
+
+    for i in 0..d_out {
+        assert_eq!(
+            y_baseline.data()[i],
+            y_eval.data()[i],
+            "F-DROPOUT-002 violated: eval-mode dropout is NOT the identity at index {i}"
+        );
+    }
+}
+
+/// F-DROPOUT-003: Determinism — same seed ⇒ identical training-mode mask. Two
+/// freshly-constructed training layers with the same seed must produce equal output.
+#[test]
+fn test_falsify_f_dropout_003_seed_is_deterministic() {
+    let d_out = 6;
+    let d_in = 12;
+    let rank = 3;
+    let x = Tensor::from_vec((0..d_in).map(|i| (i as f32 * 0.31).cos() + 1.0).collect(), true);
+
+    let mut a = lora_with_nonzero_adapter(d_out, d_in, rank).with_dropout(0.4).with_dropout_seed(7);
+    a.train();
+    let mut b = lora_with_nonzero_adapter(d_out, d_in, rank).with_dropout(0.4).with_dropout_seed(7);
+    b.train();
+
+    let ya = a.forward(&x);
+    let yb = b.forward(&x);
+
+    for i in 0..d_out {
+        assert_eq!(
+            ya.data()[i],
+            yb.data()[i],
+            "F-DROPOUT-003 violated: identical seed produced different masks at index {i}"
+        );
+    }
+}
+
+/// F-DROPOUT-004: Inverted dropout changes the LoRA contribution in training. With
+/// p>0 some contributions are zeroed and survivors amplified by 1/(1-p); the
+/// resulting output must differ from the un-dropped contribution.
+#[test]
+fn test_falsify_f_dropout_004_some_inputs_zeroed_in_training() {
+    let d_out = 4;
+    let d_in = 32;
+    let rank = 2;
+    let x = Tensor::from_vec(vec![1.0; d_in], true);
+
+    let baseline = lora_with_nonzero_adapter(d_out, d_in, rank);
+    let y_baseline = baseline.forward(&x);
+
+    let mut dropped =
+        lora_with_nonzero_adapter(d_out, d_in, rank).with_dropout(0.5).with_dropout_seed(99);
+    dropped.train();
+    let y_dropped = dropped.forward(&x);
+
+    let differs = (0..d_out).any(|i| (y_baseline.data()[i] - y_dropped.data()[i]).abs() > 1e-6);
+    assert!(
+        differs,
+        "F-DROPOUT-004 violated: inverted dropout did not change the LoRA contribution"
+    );
+}
+
+// ========================================================================
 // LAYER 1: WEIGHT FREEZING
 // ========================================================================
 


### PR DESCRIPTION
LoRALayer forward computed scale*(B@(A@x)) with NO dropout (configured rate never wired in), so LoRA fine-tuning trained with zero regularization. HF PEFT: y=W x+s*B(A(dropout(x))) — dropout on INPUT, train-only, eval=identity. Fixed (inverted dropout, seeded, deterministic). Falsifier RED (identical with/without dropout) -> GREEN. LoRA module 200/0; 3 pre-existing prune snapshot drifts unrelated (stash-confirmed on main). contracts/lora-dropout-placement-v1.yaml pv-valid.

Generated with Claude Code