### PR TITLE
fix(contract): Blackwell decode throughput-floor guard — catch F2 false-fallback/stale-binary (PMAT-885)

### DIFF
--- a/contracts/apr-cpu-vs-gpu-output-parity-v1.yaml
+++ b/contracts/apr-cpu-vs-gpu-output-parity-v1.yaml
@@ -1,6 +1,6 @@
 metadata:
   kind: schema
-  version: 1.9.0
+  version: 1.10.0
   status: ACTIVE
   created: '2026-05-03'
   author: PAIML Engineering
@@ -16,6 +16,7 @@ metadata:
   - 'crates/aprender-serve/src/gguf/cuda/mod.rs:268-279 (gate enforcement, with SKIP_PARITY_GATE=1 bypass)'
   - 'crates/aprender-serve/src/infer/gguf_gpu_generate.rs:487-494 (load_apr_cuda_model — visible-fallback log added 2026-05-03)'
   changelog:
+  - '1.10.0 - 2026-06-21 - added FALSIFY-CPU-GPU-010 + a Blackwell decode-throughput-floor invariant (PMAT-885). PMAT-884 found attention is <0.3% of the per-token budget, so the ~10.4 tok/s gx10 GB10 decode was elsewhere. On-device diagnosis: the deployed gx10 `apr` was the April-6 v0.4.11 binary (4b030b0c), which PREDATES PMAT-742 (Jun 13). Its validate_gpu_first_token used hard BOS-argmax-equality, so a harmless Blackwell FP near-tie flipped the first-token argmax and F2 FALSE-rejected the correct GPU path (`[GH-480] F2 validation FAILED — falling back to CPU`, no [F2-VALIDATION] reason line = pre-PMAT-742 gate). Default apr run then fell to CPU (wgpu also dead: VK_ERROR_INCOMPATIBLE_DRIVER) and decoded ~10.4 tok/s; nvidia-smi dmon SM peak ~8%. ISOLATION: SKIP_PARITY_GATE=1 on the SAME stale binary -> F2 PASSED -> 647-kernel CUDA graph -> 125.7 tok/s; apr qa (gate-free) PASSED golden_output at 97.6 tok/s. So the GPU kernels are fine on GB10; the F2 gate was the sole blocker. FIX is operational (NOT a code defect on main): current main already fixes this via PMAT-742 (near-tie) + PMAT-806/810 (Blackwell eager-decode/serial-prefill). Verified: v0.49.1 (7966da8ee) with NO env vars passes F2, runs ON GPU (SM peak 95%), coherent output, 112.9 tok/s (10.9x). Remediated: reinstalled v0.49.1 as gx10 default apr (backup ~/.cargo/bin/apr.v0.4.11.bak.pmat885). total_obligations 9 to 10.'
   - '1.9.0 - 2026-06-16 - added FALSIFY-CPU-GPU-009 + a Blackwell GPU-generation-parity invariant (PMAT-810). On-device sweep (gx10 GB10 sm_121, binary from PMAT-806 #2095 base) found the ENTIRE GPU path unusable on Blackwell via TWO stacked defects PMAT-806 did not cover: (1) PRIMARY the trueno#243 MANUAL CUDA-graph decode (graphed_capture, default-on cc>=89) corrupts the sm_121 forward (apr parity avg cosine 0.1912, generation empty/single-token) while the IDENTICAL eager path is correct (0.9929, coherent); (2) SECONDARY (the originally-flagged prefill divergence) once graph is fixed BATCHED prefill still diverges on Blackwell (NOT the activation-quant outlier: reproduces with FP8_PREFILL=0/HGEMM; 2 of 4 prompts wrong incl. one to Chinese) while SERIAL prefill is byte-exact (6 of 6). Fix: graphed_fast_path cc-default = cc>=89 && cc<120 (eager decode on Blackwell; CUDA_GRAPH_ENABLE=1 opts in); run_prefill defaults Blackwell to serial (BATCHED_PREFILL=1 opts in). LIVE: default apr run matches --no-gpu 5 of 5 and runs ON GPU; discrete sm_89 unchanged by construction. total_obligations 8 to 9.'
   - '1.8.0 — 2026-06-16 — added FALSIFY-CPU-GPU-008 + a Blackwell parity invariant (PMAT-806). The GPU HwDp4a Q4_K path quantizes RMSNorm activations to INT8 (Q8_1) before the DP4A dot; a massive-activation outlier channel (dim 408 of Qwen2.5-coder-1.5B, ~26× rms) collapses the per-block INT8 range and is mis-estimated ~15%, latent until a deep FFN cancels the outlier → catastrophic cancellation → CPU/GPU cosine craters (load-gate 0.9817 on the 28-layer model; deeper models drop further). Fix: detect_q4k() defaults Q4kVariant::Mwv (fp32 activations, no Q8_1 quant) on Blackwell (cc≥120); discrete GPUs (RTX 4090 cc=89) keep the fast HwDp4a path. LIVE on gx10 GB10: 0.981714→0.993891 (1.5B), 0.983273→0.999744 (Qwen3-8B), argmax matches, coherent generation. Q6K left on HwDp4a (MWV-Q6K lm_head diverges, tracked separately). GPU-free unit falsifier pmat806_outlier_tests. total_obligations 7 → 8.'
   - '1.7.0 — 2026-06-13 — added FALSIFY-CPU-GPU-007 + a no-false-positive invariant (PMAT-742). The CUDA first-token parity gate (validate_gpu_first_token) used a single BOS-only probe + EXACT argmax equality, which false-rejected a CORRECT fast GPU path: default `apr run --gpu` ran at 8 tok/s (CPU fallback, BOS rel_gap=0.60) while the same correct GPU path does ~405 tok/s steady-state under SKIP_PARITY_GATE=1 (apr qa: Golden-Output PASS, Ollama-Parity 1.37, Throughput 421). Fix: probe with the REAL prompt context (peaked distribution → CPU/GPU agree) and tolerate a genuine near-tie (gpu_probe_token_acceptable, rel_gap <= 0.15); batch model-init keeps a BOS fallback. GPU-free unit falsifier in aprender-serve (pmat742_parity_gate_tests). Live-verified on RTX 4090 (qwen2.5-coder-1.5b Q4_K_M): default apr run now 8 -> ~405 tok/s, beats ollama 330 by 1.23x. total_obligations 6 -> 7.'
@@ -393,6 +394,45 @@ falsification_tests:
   - "LIVE DISCHARGE 2026-06-16 on gx10 (GB10 sm_121, cc=121): default `apr run --gpu` load-gate cosine 0.981714 → 0.993891 (Qwen2.5-coder-1.5B); Qwen3-8B 0.983273 → 0.999744; argmax matches; GPU generation coherent (`def add(a, b): return a`). Baseline reproduced exactly (HW_DP4A_Q4K=1 → 0.981714). No regression on the apr-parity manual-graph path (load-gate identical) nor RTX 4090 (cc=89 keeps HwDp4a by construction)."
   - "Massive-activation criterion is captured as a pure, GPU-free, unit-tested helper is_massive_activation_outlier (q6k_gemv_indexed.rs, pmat806_outlier_tests) for the FUTURE device-side selective version: a per-layer fp32 fixup that keeps DP4A on non-outlier columns requires a DEVICE-side outlier-detection kernel (host readback mid-forward corrupts the CUDA graph-recording/capture paths — measured: apr parity manual-graph cosine 0.98→0.84). That selective optimization is scoped but not in this fix; the profile-level fp32-MWV-Q4K default is the contained, correctness-first Blackwell fix."
 
+- id: FALSIFY-CPU-GPU-010
+  rule: >
+    On Blackwell (cc>=120, e.g. GB10 sm_121) the default `apr run --gpu` decode
+    throughput for a 1.5B Q4_K_M model MUST be >= 100 tok/s — i.e. it MUST take
+    the on-GPU resident path, never silently fall back to CPU/wgpu. A measured
+    decode throughput around the CPU-fallback band (~10 tok/s) on GB10 falsifies
+    this: the GPU path is being rejected (stale binary lacking PMAT-742/806/810,
+    or a re-introduced false-fallback in validate_gpu_first_token).
+  prediction: |
+    Root cause (PMAT-885, on-device gx10 GB10 sm_121, 2026-06-21): the deployed
+    `apr` was the April-6 v0.4.11 binary, which predates PMAT-742 (Jun 13) —
+    validate_gpu_first_token used hard BOS-argmax-equality, so a harmless
+    Blackwell FP near-tie flipped the first-token argmax and F2 FALSE-rejected
+    the correct GPU path. Default `apr run` then fell to CPU (wgpu also fails:
+    VK_ERROR_INCOMPATIBLE_DRIVER on /dev/dri/renderD128) and decoded at
+    ~10.4 tok/s — ~12x slower than the working GPU path. apr qa independently
+    confirmed the GPU path is CORRECT (golden_output PASS, 97.6 tok/s). With
+    SKIP_PARITY_GATE=1 on the SAME stale binary, F2 PASSED and the GPU path ran
+    at 125.7 tok/s — proving the gate, not the kernels, was the bottleneck.
+    PREDICTION: a current binary (>= v0.49.1, contains PMAT-742 near-tie +
+    PMAT-810 Blackwell eager-decode/serial-prefill defaults) passes F2 with no
+    env vars and decodes >= 100 tok/s on GB10. The fix is operational
+    (reinstall current `apr`), not a new code defect on main.
+  test: |
+    # On Blackwell (gx10 GB10 sm_121), default settings (NO env vars, NO skip):
+    apr bench --fast qwen2.5-coder-1.5b-instruct-q4_k_m.apr \
+      --max-tokens 64 --warmup 1 --iterations 3 --json | jq -e '.tokens_per_second >= 100'
+    # MUST be true. Pre-fix (v0.4.11, F2 false-fallback): ~10.4 tok/s -> FAILS.
+    # Post-fix (v0.49.1, F2 PASSED, GPU SM peak 95%): 112.9 tok/s -> PASSES.
+    # GPU-free unit falsifier: pmat742_parity_gate_tests (the gate logic that
+    #   regressing would re-introduce the false fallback) in aprender-serve.
+  if_fails: "Default apr run on GB10 silently CPU-falls-back and decodes ~10 tok/s (40x below the RTX 4090 reference, below the 100+ 1B target) — the highest-EV Pillar-4 lever is dark because the deployed binary predates the F2 near-tie fix."
+  binds_to: greedy_argmax_parity
+  status: DISCHARGED
+  algorithm_evidence:
+  - "ROOT CAUSE: deployed gx10 `apr` was v0.4.11 (4b030b0c, Apr 6) — predates PMAT-742 (validate_gpu_first_token near-tie, inference_result.rs:455 gpu_probe_token_acceptable, Jun 13). Trace: `[GH-480] F2 validation FAILED — falling back to CPU` with no [F2-VALIDATION] reason line = pre-PMAT-742 hard-argmax gate. GPU never engaged: nvidia-smi dmon SM peak ~8% during decode."
+  - "ISOLATION: SKIP_PARITY_GATE=1 on the SAME v0.4.11 binary -> `[GH-480] F2 validation PASSED` -> 647-kernel CUDA graph runs -> 125.7 tok/s. Proves the GPU kernels are fine on GB10; the F2 gate was the sole blocker. apr qa (gate-free GPU path) independently PASSED golden_output at 97.6 tok/s."
+  - "LIVE DISCHARGE 2026-06-21 on gx10 (GB10 sm_121): a current binary (v0.49.1 7966da8ee, contains PMAT-742 + PMAT-806 + PMAT-810) with NO env vars passes F2 (`F2 validation PASSED`), runs ON GPU (SM peak 95%), emits coherent output matching --no-gpu (`def add_numbers(a, b): return a + b`), and decodes 112.9 tok/s — up from 10.4 tok/s (10.9x). Remediation: reinstalled v0.49.1 as the gx10 default `apr` (old binary backed up to ~/.cargo/bin/apr.v0.4.11.bak.pmat885)."
+
 proof_obligations:
 - type: invariant
   property: "the CUDA first-token parity gate accepts a near-tie argmax flip on a peaked real-context probe and rejects only real divergence (no false-positive CPU fallback on a correct GPU path) — PMAT-742"
@@ -401,7 +441,7 @@ proof_obligations:
 - type: invariant
   property: "apr run with .apr file MUST run parity gate (currently only .gguf path has one)"
 - type: completeness
-  property: "all 8 falsifiers (greedy argmax, cosine, CUDA gate enforced, no-gpu honored, wgpu gate enforced, multi-step wgpu, no-false-positive, PMAT-810 Blackwell graph+prefill) cover the parity surface"
+  property: "all 9 falsifiers (greedy argmax, cosine, CUDA gate enforced, no-gpu honored, wgpu gate enforced, multi-step wgpu, no-false-positive, PMAT-810 Blackwell graph+prefill, PMAT-885 Blackwell decode-throughput floor) cover the parity surface"
 - type: liveness
   property: "if GPU parity gate fails on ANY backend (CUDA or wgpu), user gets either an explicit error OR a CPU fallback — never silent gibberish"
 - type: invariant
@@ -412,8 +452,11 @@ proof_obligations:
 - type: invariant
   property: "on Blackwell (cc>=120) default apr run greedy GPU generation matches --no-gpu token-for-token AND runs on GPU - the manual CUDA-graph decode (graphed_capture) and batched prefill (run_prefill) both corrupt the Blackwell forward and default to eager / serial respectively (PMAT-810)"
 
+- type: invariant
+  property: "on Blackwell (cc>=120) default apr run --gpu decode throughput for a 1.5B Q4_K_M model is >= 100 tok/s (on-GPU resident path, no silent CPU/wgpu fallback); ~10 tok/s falsifies it as an F2 false-fallback / stale binary (PMAT-885)"
+
 verification_summary:
-  total_obligations: 9
+  total_obligations: 10
   proven: 0
   tested: 1
   status: pending


### PR DESCRIPTION
PMAT-884 measured ~10 tok/s decode on gx10 GB10 and wrongly concluded host-bound. Root cause: STALE v0.4.11 binary (262 commits behind, pre-PMAT-742) whose F2 gate false-rejected the GPU path -> CPU fallback. On current v0.49.1: GPU engaged (SM 95%), 112.9 tok/s = 10.9x (meets 100+ 1B-Q4_K target). gx10 remediated (reinstalled v0.49.1). Adds FALSIFY-CPU-GPU-010 + a Blackwell decode-throughput-floor invariant (>=100 tok/s) to apr-cpu-vs-gpu-output-parity-v1.yaml (v1.10.0) so this regression class is falsifiable; binds GPU-free pmat742_parity_gate_tests (5/5). pv validate 0 errors.

Generated with Claude Code