### PR TITLE
fix(serve): P0 — non-Gemma2 .apr inference garbage (ungated Gemma2 post-attn-norm load) (PMAT-888)

### DIFF
--- a/contracts/apr-load-fail-closed-gemma-v1.yaml
+++ b/contracts/apr-load-fail-closed-gemma-v1.yaml
@@ -1,7 +1,7 @@
 contract: apr-load-fail-closed-gemma
 metadata:
   kind: pattern
-  version: "3.1.0"
+  version: "3.2.0"
   description: >
     Gemma support is honest-by-design and version-gated. Gemma v1 (general.architecture
     == "gemma", PMAT-809) AND Gemma v2 (general.architecture == "gemma2", PMAT-810) are now
@@ -59,14 +59,16 @@ metadata:
   - "crates/aprender-serve/src/gguf/ops.rs (softcap — cap*tanh(x/cap) in place; rms_norm for the GGUF pre-shifted post-norms)"
   - "crates/aprender-serve/src/gguf/inference/attention_gqa.rs (attention_with_cache_gqa{,_into}: attn_scale + attn-logit softcap before softmax)"
   - "crates/aprender-serve/src/gguf/inference/forward/ffn_block.rs (forward_single_with_cache: post_attn_norm + post_ffw_norm before residual; single_cache_final_output: final-logit softcap)"
-  - "crates/aprender-serve/src/gguf/transformer.rs + quantized.rs + loader_apr_quantized.rs (load post_attention_norm.weight + post_ffw_norm.weight)"
+  - "crates/aprender-serve/src/gguf/transformer.rs + quantized.rs (GGUF load post_attention_norm.weight + post_ffw_norm.weight — disambiguated names, None for non-Gemma2)"
+  - "crates/aprender-serve/src/gguf/loader_apr_quantized.rs (PMAT-888: APR post-norm load gated on config.is_gemma2() — the HF name post_attention_layernorm.weight is the FFN norm for non-Gemma2)"
+  - "crates/aprender-serve/src/tensor_names_fallback.rs (FfnNormWeight: post_attention_layernorm.weight is the FFN norm for llama/qwen2/qwen3/mistral/phi/deepseek)"
   - "crates/aprender-serve/src/gguf/metadata.rs (attn_logit_softcapping / final_logit_softcapping / query_pre_attn_scalar accessors)"
   references_external:
   - "llama.cpp convert_hf_to_gguf.py GemmaModel.modify_tensors: `data_torch = data_torch + 1` for *norm.weight (the GGUF +1 pre-shift, applies to all 4 gemma2 norms)"
   - "llama.cpp src/models/gemma2.cpp: ggml_tanh(ggml_scale(kq, 1/cap))*cap softcap, post_attention_norm/post_ffw_norm, n_embd_head_k query scale default"
-version: 3
+version: 4
 status: enforced
-date: 2026-06-16
+date: 2026-06-21
 
 proof_obligations:
   - type: invariant
@@ -127,6 +129,24 @@ proof_obligations:
       (loaded as None → skipped), attn_logit_softcap/final_logit_softcap are None (no softcap),
       and query_pre_attn_scalar is None so attn_scale falls back to 1/sqrt(head_dim) — the
       forward path is byte-identical to before PMAT-810 (e.g. qwen2/llama output unchanged).
+  - type: invariant
+    property: >
+      NON-GEMMA-APR-POSTNORM-NONE (PMAT-888): OwnedQuantizedModel::from_apr loads the
+      Gemma2-only post_attn_norm_weight / post_ffw_norm_weight slots ONLY when
+      config.is_gemma2(); for every non-Gemma2 architecture both slots are None on every
+      layer. This is REQUIRED because the HF tensor name post_attention_layernorm.weight is
+      the FFN (pre-feedforward) norm for llama/qwen2/qwen3/mistral/phi/deepseek (see
+      tensor_names_fallback::FfnNormWeight) — the same tensor the loader already loads into
+      ffn_norm_weight. Without the arch gate the APR loader populated post_attn_norm_weight
+      from that FFN-norm tensor, and ffn_block::forward_single_with_cache (which gates the
+      post-norm apply on is_some(), not on arch) applied a SPURIOUS extra RMSNorm to the
+      attention output before the residual add, producing garbage output (PMAT-887 repro:
+      the mojibake token stream from qwen2.5-coder-1.5b) on EVERY non-Gemma2 .apr, CPU and
+      GPU. The byte-identical GGUF stayed coherent because the GGUF loader (transformer.rs)
+      reads the disambiguated post_attention_norm.weight / post_ffw_norm.weight (no "layer"),
+      which do not exist in non-Gemma2 GGUFs. The FFN norm MUST still populate ffn_norm_weight.
+      This restores the NON-GEMMA-BYTE-IDENTICAL guarantee for the .apr inference path
+      (regression introduced by PMAT-810b #2100, shipped in v0.50.0; fixed by PMAT-888).
 
 falsification_tests:
   - id: FALSIFY-LOAD-GEMMA-001
@@ -177,3 +197,9 @@ falsification_tests:
     test_harness: "cargo test -p aprender-serve --lib capability::tests::test_qwen2_still_gpu_supported_after_gate capability::tests::test_llama_still_gpu_supported_after_gate capability::tests::test_gemma_v1_not_flagged_as_softcap"
     expected_output: "test result: ok"
     if_fails: "the new gate over-triggers and routes a non-softcap GPU-coherent model (qwen2/llama/gemma v1) to CPU = a perf regression."
+  - id: FALSIFY-LOAD-GEMMA-009
+    name: test_pmat888_non_gemma2_apr_has_no_post_attn_norm
+    prediction: "PMAT-888: OwnedQuantizedModel::from_apr on a non-Gemma2 (.apr arch=llama) model that DOES contain model.layers.0.post_attention_layernorm.weight (its FFN norm) leaves post_attn_norm_weight==None and post_ffw_norm_weight==None on every layer, while ffn_norm_weight stays Some. RED pre-fix (post_attn_norm_weight==Some(ffn-norm) → ffn_block applies a spurious extra RMSNorm → garbage output for every non-Gemma2 .apr, CPU and GPU). GREEN post-fix (post-norm load gated on config.is_gemma2())."
+    test_harness: "cargo test -p aprender-serve --lib test_pmat888_non_gemma2_apr_has_no_post_attn_norm"
+    expected_output: "test result: ok"
+    if_fails: "the .apr loader populates the Gemma2 post-attention-norm slot from the non-Gemma2 FFN-norm tensor (post_attention_layernorm.weight); ffn_block then applies it, corrupting all output of every non-Gemma2 .apr (the v0.50.0 PMAT-887 regression)."

--- a/crates/aprender-serve/src/gguf/loader_apr_quantized.rs
+++ b/crates/aprender-serve/src/gguf/loader_apr_quantized.rs
@@ -231,6 +231,19 @@ impl OwnedQuantizedModel {
         // GH-479: q_dim may differ from hidden_dim (Qwen3 head_dim != hidden/heads)
         let q_dim = config.q_dim();
         let kv_dim = config.kv_dim();
+        // PMAT-888: Gemma2 POST-attention / POST-FFN RMSNorms are loaded ONLY for
+        // Gemma2. The HF tensor name `post_attention_layernorm.weight` is the
+        // *FFN (pre-feedforward) norm* for qwen2/llama/mistral/phi/deepseek/qwen3
+        // (see `tensor_names_fallback::FfnNormWeight`), NOT a post-attention norm.
+        // Loading it into the Gemma2 `post_attn_norm_weight` slot — and the
+        // `ffn_block` forward then applying it (it gates only on `is_some()`, not on
+        // arch) — injected a spurious extra RMSNorm into EVERY non-Gemma2 `.apr`,
+        // producing garbage output (PMAT-887 repro: `çļĦåıªæĺ¯…`). The GGUF loader
+        // never hit this because it reads the disambiguated `post_attention_norm`
+        // / `post_ffw_norm` names (no "layer"), which do not exist in non-Gemma2
+        // GGUFs. Gate the APR post-norm load on the architecture, mirroring GGUF's
+        // `None` for non-Gemma2.
+        let is_gemma2 = config.is_gemma2();
         let mut layers = Vec::with_capacity(num_layers);
 
         for layer_idx in 0..num_layers {
@@ -244,6 +257,7 @@ impl OwnedQuantizedModel {
                 kv_dim,
                 intermediate_dim,
                 transpose,
+                is_gemma2,
             )?);
         }
 
@@ -327,6 +341,11 @@ impl OwnedQuantizedModel {
     }
 
     /// Load a single transformer layer from APR format.
+    ///
+    /// PMAT-888: `is_gemma2` gates loading the Gemma2-only post-attention /
+    /// post-FFN RMSNorms. For non-Gemma2 archs, `post_attention_layernorm.weight`
+    /// is the FFN norm (already loaded as `ffn_norm_weight`), so it must NOT be
+    /// loaded into the post-attn-norm slot.
     #[allow(clippy::too_many_arguments)]
     fn load_apr_layer(
         apr: &crate::apr::MappedAprModel,
@@ -338,6 +357,7 @@ impl OwnedQuantizedModel {
         kv_dim: usize,
         intermediate_dim: usize,
         transpose: bool,
+        is_gemma2: bool,
     ) -> Result<OwnedQuantizedLayer> {
         // HF names (primary, from SafeTensors->APR pipeline)
         let hf_q = format!("model.layers.{layer_idx}.self_attn.q_proj.weight");
@@ -449,15 +469,30 @@ impl OwnedQuantizedModel {
                 &format!("model.layers.{layer_idx}.self_attn.k_norm.weight"))
                 .or_else(|| apr_try_load_f32(apr, data, data_offset,
                     &format!("blk.{layer_idx}.attn_k_norm.weight"))),
-            // PMAT-810: Gemma2 post-attention / post-FFN RMSNorm (None elsewhere).
-            post_attn_norm_weight: apr_try_load_f32(apr, data, data_offset,
-                &format!("model.layers.{layer_idx}.post_attention_layernorm.weight"))
-                .or_else(|| apr_try_load_f32(apr, data, data_offset,
-                    &format!("blk.{layer_idx}.post_attention_norm.weight"))),
-            post_ffw_norm_weight: apr_try_load_f32(apr, data, data_offset,
-                &format!("model.layers.{layer_idx}.post_feedforward_layernorm.weight"))
-                .or_else(|| apr_try_load_f32(apr, data, data_offset,
-                    &format!("blk.{layer_idx}.post_ffw_norm.weight"))),
+            // PMAT-810 / PMAT-888: Gemma2 post-attention / post-FFN RMSNorm
+            // (None for every other architecture). Gated on `is_gemma2` because the
+            // HF name `post_attention_layernorm.weight` is the FFN norm for
+            // qwen2/llama/mistral/phi/deepseek/qwen3 — loading it here would apply a
+            // spurious extra RMSNorm in the forward (which gates only on `is_some()`)
+            // and corrupt all output. Gemma2's true FFN norm is the distinct
+            // `pre_feedforward_layernorm`, so this name collision only harms
+            // non-Gemma2 models.
+            post_attn_norm_weight: if is_gemma2 {
+                apr_try_load_f32(apr, data, data_offset,
+                    &format!("model.layers.{layer_idx}.post_attention_layernorm.weight"))
+                    .or_else(|| apr_try_load_f32(apr, data, data_offset,
+                        &format!("blk.{layer_idx}.post_attention_norm.weight")))
+            } else {
+                None
+            },
+            post_ffw_norm_weight: if is_gemma2 {
+                apr_try_load_f32(apr, data, data_offset,
+                    &format!("model.layers.{layer_idx}.post_feedforward_layernorm.weight"))
+                    .or_else(|| apr_try_load_f32(apr, data, data_offset,
+                        &format!("blk.{layer_idx}.post_ffw_norm.weight")))
+            } else {
+                None
+            },
         })
     }
 }

--- a/crates/aprender-serve/src/gguf/tests/loader_tests_apr.rs
+++ b/crates/aprender-serve/src/gguf/tests/loader_tests_apr.rs
@@ -434,3 +434,73 @@ fn test_from_apr_uses_metadata_defaults() {
 
     let _ = std::fs::remove_file(&path);
 }
+
+// ============================================================================
+// PMAT-888: .apr non-Gemma2 post-norm collision (APR-PARITY falsifier)
+// ============================================================================
+
+/// PMAT-888 RED→GREEN falsifier: `OwnedQuantizedModel::from_apr` must NOT
+/// populate the Gemma2-only `post_attn_norm_weight` / `post_ffw_norm_weight`
+/// slots for a non-Gemma2 (`llama`/`qwen2`/...) `.apr`.
+///
+/// ROOT CAUSE: the HF tensor name `post_attention_layernorm.weight` is the
+/// *FFN (pre-feedforward) norm* for llama/qwen2/mistral/phi/deepseek/qwen3 (see
+/// `tensor_names_fallback::FfnNormWeight`). PMAT-810b added a Gemma2 post-norm
+/// load to the APR loader keyed on that exact HF name, so for every non-Gemma2
+/// `.apr` the FFN norm was ALSO loaded into the post-attention-norm slot, and
+/// `ffn_block::forward_single_with_cache` — which gates only on `is_some()`, not
+/// on arch — applied a spurious extra RMSNorm to the attention output before the
+/// residual add. Result: garbage output (`çļĦåıªæĺ¯…`) for every non-Gemma2
+/// `.apr` (CPU and GPU), while the byte-identical GGUF ran coherently (the GGUF
+/// loader reads the disambiguated `post_attention_norm.weight`, no "layer").
+///
+/// `build_executable_pygmy_apr` is `architecture == "llama"` and DOES contain
+/// `model.layers.0.post_attention_layernorm.weight` (its FFN norm), so it is the
+/// exact collision fixture.
+///
+/// RED before the fix: `post_attn_norm_weight == Some(..)` (the FFN norm).
+/// GREEN after the fix: `None` (gated on `config.is_gemma2()`).
+///
+/// Contract: apr-load-fail-closed-gemma-v1.yaml §NON-GEMMA-APR-POSTNORM-NONE.
+#[test]
+fn test_pmat888_non_gemma2_apr_has_no_post_attn_norm() {
+    let apr_bytes = crate::apr::test_factory::build_executable_pygmy_apr();
+    let dir = std::env::temp_dir();
+    let path = dir.join("test_pmat888_non_gemma2_postnorm.apr");
+    std::fs::write(&path, &apr_bytes).expect("should write file");
+
+    let mapped = crate::apr::MappedAprModel::from_path(&path).expect("should load apr");
+    // Sanity: the FFN-norm tensor whose HF name collides with the Gemma2
+    // post-attn-norm name IS present in this non-Gemma2 model.
+    assert!(
+        mapped
+            .find_tensor("model.layers.0.post_attention_layernorm.weight")
+            .is_some(),
+        "fixture must contain the colliding FFN-norm tensor for the test to be load-bearing"
+    );
+
+    let model = OwnedQuantizedModel::from_apr(&mapped).expect("from_apr should succeed");
+    assert_eq!(model.config.architecture, "llama");
+    assert!(!model.config.is_gemma2(), "fixture is non-Gemma2");
+
+    for (i, layer) in model.layers.iter().enumerate() {
+        assert!(
+            layer.post_attn_norm_weight.is_none(),
+            "PMAT-888: non-Gemma2 .apr layer {i} must NOT load post_attn_norm_weight \
+             (the HF name post_attention_layernorm.weight is the FFN norm, not a \
+             post-attention norm — loading + applying it corrupts all output)"
+        );
+        assert!(
+            layer.post_ffw_norm_weight.is_none(),
+            "PMAT-888: non-Gemma2 .apr layer {i} must NOT load post_ffw_norm_weight"
+        );
+        // The FFN norm itself MUST still be loaded into its correct slot.
+        assert!(
+            layer.ffn_norm_weight.is_some(),
+            "PMAT-888: the post_attention_layernorm.weight tensor must still populate \
+             the FFN-norm slot (ffn_norm_weight) for layer {i}"
+        );
+    }
+
+    let _ = std::fs::remove_file(&path);
+}


### PR DESCRIPTION
**P0, ships in v0.50.0.** Every non-Gemma2 .apr (the majority of models) produces GARBAGE on inference (CPU+GPU) while the same model as GGUF is coherent. Root cause: PMAT-810b (#2100) added a Gemma2 post-attention-norm load in loader_apr_quantized.rs keyed on the HF name post_attention_layernorm.weight — but that name IS the FFN norm for qwen2/llama/mistral/phi/deepseek/qwen3, and the load was UN-GATED by architecture. So non-Gemma2 .apr loaded the FFN norm into post_attn_norm_weight -> ffn_block applies a spurious extra RMSNorm -> garbage. GGUF immune (reads the disambiguated post_attention_norm.weight). Fix: gate the APR post_attn/post_ffw norm load on config.is_gemma2() (mirrors the GGUF loader). RED->GREEN: .apr CPU+GPU 2+2->\"4\" (was garbage), GGUF unchanged. Falsifier test_pmat888_non_gemma2_apr_has_no_post_attn_norm (RED on main, GREEN with fix); 22 loader + 28 gemma tests pass. Contract apr-load-fail-closed-gemma-v1.yaml v3.2.0 (FALSIFY-LOAD-GEMMA-009) pv-valid. WARRANTS A HOTFIX before 0.51.0.

Generated with Claude Code