### PR TITLE
chore(release): 0.51.0 — P0 .apr hotfix + PMAT-877..888 wave

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.51.0] - 2026-06-21
+
+Hotfix-driven release (brought forward from the Friday cadence by a P0). Each fix ships a named
+proof-obligation + a RED-on-bug / GREEN-on-fix falsifier + a `pv`-validated contract.
+
+### Fixed
+
+- **P0 — non-Gemma2 `.apr` inference produced garbage** (PMAT-888, regressed in 0.50.0 via PMAT-810b)
+  — every non-Gemma2 `.apr` (qwen2/llama/mistral/phi/deepseek/qwen3 — the majority of models) generated
+  garbage on inference (CPU **and** GPU) while the same model as GGUF was coherent. PMAT-810b added a
+  Gemma2 post-attention-norm load keyed on the HF name `post_attention_layernorm.weight` — which is the
+  **FFN norm** for all those architectures — **un-gated by architecture**, so a spurious extra RMSNorm
+  was applied. Now gated on `config.is_gemma2()`, mirroring the GGUF loader. GGUF was never affected.
+- **`BatchNorm1d` never updated `running_mean`/`running_var`** (PMAT-877, Pillar-2) — they stayed at
+  init (0/1) forever, so eval-mode normalization was wrong vs PyTorch. Now EMA-updated each training
+  forward (`running = (1-momentum)·running + momentum·batch`).
+- **`Linear` bias initialized to zeros** (PMAT-878, Pillar-2) — PyTorch uses `U(±1/√fan_in)`; now matches
+  (seed-deterministic).
+- **LoRA dropout never applied** (PMAT-879, Pillar-3) — `LoRALayer::forward` ignored the configured
+  dropout, so fine-tuning trained with zero regularization. Now applies dropout to the input
+  (`y = Wx + s·B(A(dropout(x)))`, train-only), matching HF PEFT.
+- **Batched-GPU GQA fail-closed** (PMAT-880, Pillar-4) — `attention_with_cache_gqa` did not validate
+  `kv_dim == num_kv_heads·head_dim`/cache consistency, silently reading wrong memory on a corrupt config;
+  now returns a clear error (zero false-positives on valid models), where llama.cpp/Ollama run garbage.
+
+### Performance — GPU (Blackwell / GB10)
+
+- **First pure-Rust cuda-oxide `#[kernel]` to BEAT hand-PTX** (PMAT-882) — the incremental KV-cache
+  attention kernel: bit-exact (cos = 1.0) and **1.7–2.9× faster** than the production hand-PTX kernel on
+  GB10 (true on-device A/B). FMA/softmax kernels are not DP4A-bound, so pure-Rust competes and wins.
+- **Blackwell CUDA-graph replay fixed + re-enabled** (PMAT-886a) — the default sm_121 Q4K GEMV variant
+  was not recorded into the manual graph, so graph replay dropped ~6 GEMVs/layer → stale buffers →
+  garbage (cosine 0.53). Now recorded; parity 0.53→0.9934 (== eager, token-for-token), graph decode
+  re-defaulted ON for Blackwell, **+16% decode** (96→112 tok/s).
+- **Blackwell decode throughput-floor guard** (PMAT-885) — a stale-binary / F2-false-fallback that
+  silently drops the GPU path to ~10 tok/s CPU is now a falsifiable invariant (≥100 tok/s on GB10).
+
+### Infrastructure
+
+- **Pre-release Gate 11** (`cargo publish -p aprender --dry-run`) — catches the two classes that broke
+  the 0.50.0 cascade mid-publish (sibling path-deps missing a `version`; version-pinned sibling dev-deps
+  forming publish cycles) which `cargo metadata` does not detect.
+- **Dogfood Gate 18** (fresh-convert `.apr` inference parity vs GGUF, CPU+GPU) — catches the PMAT-888
+  class that `inspect`/`validate`/`tensors` and a stale pre-existing `.apr` all pass through.
+
 ## [0.50.0] - 2026-06-21
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,7 +255,7 @@ dependencies = [
 
 [[package]]
 name = "apr-cli"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "anyhow",
  "aprender-common",
@@ -375,7 +375,7 @@ dependencies = [
 
 [[package]]
 name = "aprender"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "apr-cli",
  "aprender-core",
@@ -383,7 +383,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-bench-compute"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "aprender-core",
  "criterion 0.7.0",
@@ -392,7 +392,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-bench-tokenizer"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "aprender-core",
  "criterion 0.7.0",
@@ -401,7 +401,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cbtop"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "anyhow",
  "aprender-common",
@@ -426,7 +426,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cgp"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "anyhow",
  "aprender-gpu",
@@ -446,7 +446,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-common"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "lz4_flex 0.11.6",
  "zstd",
@@ -454,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-compute"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "anyhow",
  "aprender-core",
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-compute-xtask"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "anyhow",
  "bashrs",
@@ -515,7 +515,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-contracts"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "aprender-contracts-macros",
  "criterion 0.5.1",
@@ -530,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-contracts-cli"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "aprender-contracts",
  "clap",
@@ -541,7 +541,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-contracts-macros"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -551,7 +551,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-core"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "aes-gcm",
  "alsa",
@@ -602,7 +602,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cuda-edge"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "aprender-gpu",
  "proptest",
@@ -613,7 +613,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cupti"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "bindgen 0.71.1",
  "bitflags 2.13.0",
@@ -623,7 +623,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-data"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -675,7 +675,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-db"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "anyhow",
  "aprender-common",
@@ -720,7 +720,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-distribute"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "aprender-compute",
  "aprender-db",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-explain"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "aprender-gpu",
  "aprender-present-core",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-fft"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -778,7 +778,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-gemm-codegen"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -787,10 +787,9 @@ dependencies = [
 
 [[package]]
 name = "aprender-gpu"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "aprender-common",
- "aprender-profile",
  "aprender-simulate",
  "bytemuck",
  "criterion 0.7.0",
@@ -807,7 +806,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-graph"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "anyhow",
  "aprender-compute",
@@ -829,7 +828,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-image"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -838,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-mcp"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -853,9 +852,9 @@ dependencies = [
 
 [[package]]
 name = "aprender-monte-carlo"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
- "aprender 0.50.0",
+ "aprender 0.51.0",
  "assert_cmd",
  "chrono",
  "clap",
@@ -872,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-orchestrate"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "anyhow",
  "aprender-common",
@@ -946,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-cli"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "aprender-present-yaml",
  "clap",
@@ -959,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-core"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -971,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-layout"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "aprender-present-core",
  "criterion 0.7.0",
@@ -982,7 +981,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-lib"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "aprender-present-core",
  "aprender-present-layout",
@@ -1011,10 +1010,9 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-terminal"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "aprender-present-core",
- "aprender-viz",
  "bitvec",
  "clap",
  "compact_str 0.8.2",
@@ -1033,7 +1031,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-test"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "aprender-present-core",
  "aprender-present-test-macros",
@@ -1044,7 +1042,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-test-macros"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1053,7 +1051,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-widgets"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "aprender-present-core",
  "aprender-present-yaml",
@@ -1065,7 +1063,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-yaml"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "aprender-present-core",
  "proptest",
@@ -1075,7 +1073,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-profile"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "addr2line 0.25.1",
  "anyhow",
@@ -1128,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-profile-core"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "hex",
  "serde",
@@ -1138,7 +1136,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-ptx-debug"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "proptest",
  "thiserror 2.0.18",
@@ -1146,7 +1144,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-certify"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "chrono",
  "proptest",
@@ -1156,7 +1154,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-cli"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "aprender-qa-certify",
  "aprender-qa-gen",
@@ -1175,7 +1173,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-gen"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1192,7 +1190,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-report"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "anyhow",
  "aprender-qa-gen",
@@ -1210,7 +1208,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-runner"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "anyhow",
  "aprender-qa-gen",
@@ -1235,14 +1233,14 @@ dependencies = [
 
 [[package]]
 name = "aprender-quant"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "half",
 ]
 
 [[package]]
 name = "aprender-rag"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "aprender-common",
  "aprender-compute",
@@ -1290,7 +1288,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-rand"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1299,7 +1297,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-registry"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "anyhow",
  "aprender-core",
@@ -1329,7 +1327,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-serve"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "anyhow",
  "approx",
@@ -1396,7 +1394,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-shell"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "aprender-core",
  "assert_cmd",
@@ -1413,7 +1411,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-simulate"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "aprender-present-core",
  "aprender-present-terminal",
@@ -1452,7 +1450,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-solve"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1461,7 +1459,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-sparse"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1470,7 +1468,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-tensor"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1479,7 +1477,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-cli"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "aprender-test-lib",
  "assert_cmd",
@@ -1507,7 +1505,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-derive"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1517,7 +1515,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-js-gen"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -1533,7 +1531,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-lib"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "aprender-compute",
  "aprender-present-core",
@@ -1577,7 +1575,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-showcase"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "aprender-present-terminal",
  "console_error_panic_hook",
@@ -1594,7 +1592,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "approx",
  "aprender-common",
@@ -1662,7 +1660,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-bench"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1679,7 +1677,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-common"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "aprender-viz",
  "clap",
@@ -1691,7 +1689,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-distill"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1712,7 +1710,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-inspect"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1728,7 +1726,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-lora"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1744,7 +1742,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-shell"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1760,7 +1758,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-wasm"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "proptest",
  "serde",
@@ -1771,9 +1769,9 @@ dependencies = [
 
 [[package]]
 name = "aprender-tsp"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
- "aprender 0.50.0",
+ "aprender 0.51.0",
  "assert_cmd",
  "clap",
  "crc32fast",
@@ -1786,7 +1784,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-verify"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "chrono",
  "criterion 0.5.1",
@@ -1798,7 +1796,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-verify-ml"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "aprender-compute",
  "aprender-core",
@@ -1828,7 +1826,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-viz"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "approx",
  "aprender-common",
@@ -1851,7 +1849,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "aprender-zram-adaptive",
  "aprender-zram-core",
@@ -1861,7 +1859,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-adaptive"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "aprender-zram-core",
  "proptest",
@@ -1870,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-cli"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "aprender-zram-adaptive",
  "aprender-zram-core",
@@ -1884,7 +1882,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-core"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "aprender-gpu",
  "criterion 0.7.0",
@@ -1896,7 +1894,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-generator"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "aprender-zram-core",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.50.0"
+version = "0.51.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/paiml/aprender"
@@ -172,7 +172,7 @@ minijinja = { version = "2.14", features = ["loader", "serde"] }
 # Contracts
 provable-contracts = "0.3"
 provable-contracts-macros = "0.3"
-aprender-contracts-macros = { path = "crates/aprender-contracts-macros", version = "0.50.0" }
+aprender-contracts-macros = { path = "crates/aprender-contracts-macros", version = "0.51.0" }
 
 # YAML
 serde_yaml = "0.9"
@@ -184,43 +184,43 @@ hf-hub = { version = "0.4", default-features = false, features = ["ureq"] }
 hf-xet = "1.5.1"
 
 # Workspace-internal crates (paths within the monorepo)
-aprender-compute = { path = "crates/aprender-compute", version = "0.50.0" }
-aprender-gpu = { path = "crates/aprender-gpu", version = "0.50.0" }
-aprender-quant = { path = "crates/aprender-quant", version = "0.50.0" }
-aprender-serve = { path = "crates/aprender-serve", version = "0.50.0" }
-realizar = { path = "crates/aprender-serve", version = "0.50.0", package = "aprender-serve" }
-alimentar = { path = "crates/aprender-data", version = "0.50.0", package = "aprender-data" }
-pacha = { path = "crates/aprender-registry", version = "0.50.0", package = "aprender-registry" }
+aprender-compute = { path = "crates/aprender-compute", version = "0.51.0" }
+aprender-gpu = { path = "crates/aprender-gpu", version = "0.51.0" }
+aprender-quant = { path = "crates/aprender-quant", version = "0.51.0" }
+aprender-serve = { path = "crates/aprender-serve", version = "0.51.0" }
+realizar = { path = "crates/aprender-serve", version = "0.51.0", package = "aprender-serve" }
+alimentar = { path = "crates/aprender-data", version = "0.51.0", package = "aprender-data" }
+pacha = { path = "crates/aprender-registry", version = "0.51.0", package = "aprender-registry" }
 # APR-MONO self-containment: legacy sibling lib-name aliases -> in-monorepo crates (2026-06-12)
-trueno-quant = { path = "crates/aprender-quant", version = "0.50.0", package = "aprender-quant" }
-trueno-db = { path = "crates/aprender-db", version = "0.50.0", package = "aprender-db" }
-trueno-viz = { path = "crates/aprender-viz", version = "0.50.0", package = "aprender-viz" }
-trueno-rag = { path = "crates/aprender-rag", version = "0.50.0", package = "aprender-rag" }
-trueno-cuda-edge = { path = "crates/aprender-cuda-edge", version = "0.50.0", package = "aprender-cuda-edge" }
-renacer-core = { path = "crates/aprender-profile-core", version = "0.50.0", package = "aprender-profile-core" }
-repartir = { path = "crates/aprender-distribute", version = "0.50.0", package = "aprender-distribute" }
-simular = { path = "crates/aprender-simulate", version = "0.50.0", package = "aprender-simulate" }
-probar = { path = "crates/aprender-test-lib", version = "0.50.0", package = "aprender-test-lib" }
-aprender-train = { path = "crates/aprender-train", version = "0.50.0" }
-entrenar = { path = "crates/aprender-train", version = "0.50.0", package = "aprender-train" }
-aprender-train-common = { path = "crates/aprender-train-common", version = "0.50.0" }
-aprender-train-distill = { path = "crates/aprender-train-distill", version = "0.50.0" }
-aprender-orchestrate = { path = "crates/aprender-orchestrate", version = "0.50.0" }
-aprender-contracts = { path = "crates/aprender-contracts", version = "0.50.0" }
-aprender-profile = { path = "crates/aprender-profile", version = "0.50.0" }
-aprender-profile-core = { path = "crates/aprender-profile-core", version = "0.50.0" }
-aprender-zram-core = { path = "crates/aprender-zram-core", version = "0.50.0" }
-aprender-zram-adaptive = { path = "crates/aprender-zram-adaptive", version = "0.50.0" }
-aprender-present-core = { path = "crates/aprender-present-core", version = "0.50.0" }
-aprender-present-terminal = { path = "crates/aprender-present-terminal", version = "0.50.0" }
-aprender-present-widgets = { path = "crates/aprender-present-widgets", version = "0.50.0" }
-aprender-present-layout = { path = "crates/aprender-present-layout", version = "0.50.0" }
-aprender-present-yaml = { path = "crates/aprender-present-yaml", version = "0.50.0" }
-aprender-present-test = { path = "crates/aprender-present-test", version = "0.50.0" }
-aprender-db = { path = "crates/aprender-db", version = "0.50.0" }
-aprender-graph = { path = "crates/aprender-graph", version = "0.50.0" }
-aprender-rag = { path = "crates/aprender-rag", version = "0.50.0" }
-aprender-data = { path = "crates/aprender-data", version = "0.50.0" }
+trueno-quant = { path = "crates/aprender-quant", version = "0.51.0", package = "aprender-quant" }
+trueno-db = { path = "crates/aprender-db", version = "0.51.0", package = "aprender-db" }
+trueno-viz = { path = "crates/aprender-viz", version = "0.51.0", package = "aprender-viz" }
+trueno-rag = { path = "crates/aprender-rag", version = "0.51.0", package = "aprender-rag" }
+trueno-cuda-edge = { path = "crates/aprender-cuda-edge", version = "0.51.0", package = "aprender-cuda-edge" }
+renacer-core = { path = "crates/aprender-profile-core", version = "0.51.0", package = "aprender-profile-core" }
+repartir = { path = "crates/aprender-distribute", version = "0.51.0", package = "aprender-distribute" }
+simular = { path = "crates/aprender-simulate", version = "0.51.0", package = "aprender-simulate" }
+probar = { path = "crates/aprender-test-lib", version = "0.51.0", package = "aprender-test-lib" }
+aprender-train = { path = "crates/aprender-train", version = "0.51.0" }
+entrenar = { path = "crates/aprender-train", version = "0.51.0", package = "aprender-train" }
+aprender-train-common = { path = "crates/aprender-train-common", version = "0.51.0" }
+aprender-train-distill = { path = "crates/aprender-train-distill", version = "0.51.0" }
+aprender-orchestrate = { path = "crates/aprender-orchestrate", version = "0.51.0" }
+aprender-contracts = { path = "crates/aprender-contracts", version = "0.51.0" }
+aprender-profile = { path = "crates/aprender-profile", version = "0.51.0" }
+aprender-profile-core = { path = "crates/aprender-profile-core", version = "0.51.0" }
+aprender-zram-core = { path = "crates/aprender-zram-core", version = "0.51.0" }
+aprender-zram-adaptive = { path = "crates/aprender-zram-adaptive", version = "0.51.0" }
+aprender-present-core = { path = "crates/aprender-present-core", version = "0.51.0" }
+aprender-present-terminal = { path = "crates/aprender-present-terminal", version = "0.51.0" }
+aprender-present-widgets = { path = "crates/aprender-present-widgets", version = "0.51.0" }
+aprender-present-layout = { path = "crates/aprender-present-layout", version = "0.51.0" }
+aprender-present-yaml = { path = "crates/aprender-present-yaml", version = "0.51.0" }
+aprender-present-test = { path = "crates/aprender-present-test", version = "0.51.0" }
+aprender-db = { path = "crates/aprender-db", version = "0.51.0" }
+aprender-graph = { path = "crates/aprender-graph", version = "0.51.0" }
+aprender-rag = { path = "crates/aprender-rag", version = "0.51.0" }
+aprender-data = { path = "crates/aprender-data", version = "0.51.0" }
 
 # Additional external deps needed by sub-crates
 serde_yaml_ng = "0.10"
@@ -265,25 +265,25 @@ wasmtime = "43"
 bollard = "0.17"
 
 # Old crate name aliases (workspace = true refs in migrated sub-crates)
-trueno-zram-core = { path = "crates/aprender-zram-core", version = "0.50.0", package = "aprender-zram-core" }
-trueno-zram-adaptive = { path = "crates/aprender-zram-adaptive", version = "0.50.0", package = "aprender-zram-adaptive" }
-trueno = { path = "crates/aprender-compute", version = "0.50.0", package = "aprender-compute" }
-presentar-core = { path = "crates/aprender-present-core", version = "0.50.0", package = "aprender-present-core" }
-presentar-terminal = { path = "crates/aprender-present-terminal", version = "0.50.0", package = "aprender-present-terminal" }
-presentar-widgets = { path = "crates/aprender-present-widgets", version = "0.50.0", package = "aprender-present-widgets" }
-presentar-layout = { path = "crates/aprender-present-layout", version = "0.50.0", package = "aprender-present-layout" }
-presentar-yaml = { path = "crates/aprender-present-yaml", version = "0.50.0", package = "aprender-present-yaml" }
-presentar-test = { path = "crates/aprender-present-test", version = "0.50.0", package = "aprender-present-test" }
-presentar-test-macros = { path = "crates/aprender-present-test-macros", version = "0.50.0", package = "aprender-present-test-macros" }
-jugar-probar-derive = { path = "crates/aprender-test-derive", version = "0.50.0", package = "aprender-test-derive" }
-batuta-common = { path = "crates/aprender-common", version = "0.50.0", package = "aprender-common" }
+trueno-zram-core = { path = "crates/aprender-zram-core", version = "0.51.0", package = "aprender-zram-core" }
+trueno-zram-adaptive = { path = "crates/aprender-zram-adaptive", version = "0.51.0", package = "aprender-zram-adaptive" }
+trueno = { path = "crates/aprender-compute", version = "0.51.0", package = "aprender-compute" }
+presentar-core = { path = "crates/aprender-present-core", version = "0.51.0", package = "aprender-present-core" }
+presentar-terminal = { path = "crates/aprender-present-terminal", version = "0.51.0", package = "aprender-present-terminal" }
+presentar-widgets = { path = "crates/aprender-present-widgets", version = "0.51.0", package = "aprender-present-widgets" }
+presentar-layout = { path = "crates/aprender-present-layout", version = "0.51.0", package = "aprender-present-layout" }
+presentar-yaml = { path = "crates/aprender-present-yaml", version = "0.51.0", package = "aprender-present-yaml" }
+presentar-test = { path = "crates/aprender-present-test", version = "0.51.0", package = "aprender-present-test" }
+presentar-test-macros = { path = "crates/aprender-present-test-macros", version = "0.51.0", package = "aprender-present-test-macros" }
+jugar-probar-derive = { path = "crates/aprender-test-derive", version = "0.51.0", package = "aprender-test-derive" }
+batuta-common = { path = "crates/aprender-common", version = "0.51.0", package = "aprender-common" }
 # APR-MONO sibling aliases — MUST use workspace refs, NEVER crates.io versions.
 # Hard-pinning these to crates.io creates a diamond: sub-crates pull older
 # aprender versions → multiple `aprender` crates in Cargo.lock = MUDA.
-renacer = { path = "crates/aprender-profile", version = "0.50.0", package = "aprender-profile" }
-entrenar-lora = { path = "crates/aprender-train-lora", version = "0.50.0", package = "aprender-train-lora" }
-batuta = { path = "crates/aprender-orchestrate", version = "0.50.0", package = "aprender-orchestrate" }
-trueno-graph = { path = "crates/aprender-graph", version = "0.50.0", package = "aprender-graph" }
+renacer = { path = "crates/aprender-profile", version = "0.51.0", package = "aprender-profile" }
+entrenar-lora = { path = "crates/aprender-train-lora", version = "0.51.0", package = "aprender-train-lora" }
+batuta = { path = "crates/aprender-orchestrate", version = "0.51.0", package = "aprender-orchestrate" }
+trueno-graph = { path = "crates/aprender-graph", version = "0.51.0", package = "aprender-graph" }
 
 [workspace.lints.rust]
 # Safety
@@ -441,7 +441,7 @@ semicolon_if_nothing_returned = "allow"  # Style preference
 
 [package]
 name = "aprender"
-version = "0.50.0"
+version = "0.51.0"
 edition = "2021"
 rust-version = "1.89"
 authors = ["Noah Gift <noah@paiml.com>"]
@@ -471,7 +471,7 @@ required-features = ["cli"]
 # (e.g. apr-cookbook, downstream apps) don't pull apr-cli's heavy transitive
 # dep graph (renacer/profile/inference/zram/visualization). `cargo install
 # aprender` still works because `cli` is in default features. See GH-1599.
-apr-cli = { path = "crates/apr-cli", version = "0.50.0", default-features = true, optional = true }
+apr-cli = { path = "crates/apr-cli", version = "0.51.0", default-features = true, optional = true }
 # Core ML library (lib name = "aprender")
 aprender_ml = { path = "crates/aprender-core", version = ">=0.29", package = "aprender-core" }
 

--- a/crates/apr-cli/Cargo.toml
+++ b/crates/apr-cli/Cargo.toml
@@ -103,12 +103,12 @@ libc = "0.2"
 
 [dependencies]
 # Core aprender library
-aprender = { path = "../aprender-core", version = "0.50.0", package = "aprender-core", default-features = true, features = ["format-compression"] }
+aprender = { path = "../aprender-core", version = "0.51.0", package = "aprender-core", default-features = true, features = ["format-compression"] }
 # Provable-contracts engine — `apr beat-run` parses + evaluates BeatBenchmark contracts (PMAT-741)
 aprender-contracts = { workspace = true }
 
 # MCP (Model Context Protocol) server — `apr mcp` subcommand
-aprender-mcp = { path = "../aprender-mcp", version = "0.50.0" }
+aprender-mcp = { path = "../aprender-mcp", version = "0.51.0" }
 async-stream = "0.3"
 provable-contracts-macros = "0.3"
 
@@ -119,7 +119,7 @@ batuta-common = { workspace = true }
 # Non-optional since claude-code-parity-apr M150 (outcome-parity Phase 3
 # requires apr code in default builds). GH-344: path dep via
 # .cargo/config.toml.dev-overrides; CI uses checkout+symlink.
-batuta = { version = "0.50.0", path = "../aprender-orchestrate", package = "aprender-orchestrate", default-features = false, features = ["agents", "agents-inference", "agents-mcp", "rag"] }
+batuta = { version = "0.51.0", path = "../aprender-orchestrate", package = "aprender-orchestrate", default-features = false, features = ["agents", "agents-inference", "agents-mcp", "rag"] }
 
 # Inference engine (workspace path dep — enables cuda/gpu feature forwarding)
 # GH-573: shim (0.9.1) didn't forward cuda feature → 0.7 tok/s instead of 273 tok/s

--- a/crates/aprender-bench-compute/Cargo.toml
+++ b/crates/aprender-bench-compute/Cargo.toml
@@ -11,7 +11,7 @@ disallowed_methods = "allow"
 
 [dependencies]
 # The implementation under test
-aprender = { path = "../aprender-core", version = "0.50.0", package = "aprender-core", features = ["format-quantize"] }
+aprender = { path = "../aprender-core", version = "0.51.0", package = "aprender-core", features = ["format-quantize"] }
 
 # Reference implementation for A/B comparison
 # Pure Rust (no BLAS) to keep comparison fair — both are pure Rust SIMD

--- a/crates/aprender-bench-tokenizer/Cargo.toml
+++ b/crates/aprender-bench-tokenizer/Cargo.toml
@@ -11,7 +11,7 @@ disallowed_methods = "allow"
 
 [dependencies]
 # The implementation under test
-aprender = { path = "../aprender-core", version = "0.50.0", package = "aprender-core" }
+aprender = { path = "../aprender-core", version = "0.51.0", package = "aprender-core" }
 
 # HuggingFace reference for A/B comparison
 # Regular dep (not dev-dep) because [[bench]] harness=false binaries can't see dev-deps

--- a/crates/aprender-cbtop/Cargo.toml
+++ b/crates/aprender-cbtop/Cargo.toml
@@ -24,7 +24,7 @@ presentar-terminal = { workspace = true }
 
 # Compute backends
 trueno = { workspace = true }
-trueno-gpu = { version = "0.50.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true }
+trueno-gpu = { version = "0.51.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true }
 
 # Terminal handling
 crossterm = "0.28"

--- a/crates/aprender-cgp/Cargo.toml
+++ b/crates/aprender-cgp/Cargo.toml
@@ -36,7 +36,7 @@ num_cpus = "1.17"
 comfy-table = "7"
 colored = "3"
 # GPU profiling: direct cuBLAS measurement (OWN THE STACK)
-trueno-gpu = { path = "../aprender-gpu", version = "0.50.0", features = ["cuda"], optional = true, package = "aprender-gpu" }
+trueno-gpu = { path = "../aprender-gpu", version = "0.51.0", features = ["cuda"], optional = true, package = "aprender-gpu" }
 
 [features]
 default = []

--- a/crates/aprender-compute/Cargo.toml
+++ b/crates/aprender-compute/Cargo.toml
@@ -41,11 +41,11 @@ futures-intrusive = { version = "0.5", optional = true }
 wasm-bindgen-futures = { version = "0.4", optional = true }
 wasm-bindgen = { version = "0.2", optional = true }
 # Native CUDA monitoring via trueno-gpu (TRUENO-SPEC-010)
-trueno-gpu = { version = "0.50.0", path = "../aprender-gpu", optional = true, package = "aprender-gpu" }
+trueno-gpu = { version = "0.51.0", path = "../aprender-gpu", optional = true, package = "aprender-gpu" }
 # PMAT-336: Provable contracts compile-time enforcement
 provable-contracts-macros = "0.3"
 # P1a: Sovereign GEMM microkernel codegen (compile-time shape specialization)
-trueno-gemm-codegen = { version = "0.50.0", path = "../aprender-gemm-codegen", package = "aprender-gemm-codegen" }
+trueno-gemm-codegen = { version = "0.51.0", path = "../aprender-gemm-codegen", package = "aprender-gemm-codegen" }
 # Tracing/profiling support (renacer integration)
 tracing = { version = "0.1", optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"], optional = true }

--- a/crates/aprender-contracts-cli/Cargo.toml
+++ b/crates/aprender-contracts-cli/Cargo.toml
@@ -13,7 +13,7 @@ name = "pv"
 path = "src/main.rs"
 
 [dependencies]
-aprender-contracts = { path = "../aprender-contracts", version = "0.50.0" }
+aprender-contracts = { path = "../aprender-contracts", version = "0.51.0" }
 clap = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }

--- a/crates/aprender-contracts/Cargo.toml
+++ b/crates/aprender-contracts/Cargo.toml
@@ -19,7 +19,7 @@ kani = []
 name = "provable_contracts"
 
 [dependencies]
-provable-contracts-macros = { path = "../aprender-contracts-macros", version = "0.50.0", package = "aprender-contracts-macros" }
+provable-contracts-macros = { path = "../aprender-contracts-macros", version = "0.51.0", package = "aprender-contracts-macros" }
 regex = "1"
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/aprender-cuda-edge/Cargo.toml
+++ b/crates/aprender-cuda-edge/Cargo.toml
@@ -15,7 +15,7 @@ name = "trueno_cuda_edge"
 [dependencies]
 thiserror = "2.0"
 serde = { version = "1.0", features = ["derive"] }
-trueno-gpu = { version = "0.50.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true }
+trueno-gpu = { version = "0.51.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true }
 
 [dev-dependencies]
 proptest = "1.6"

--- a/crates/aprender-explain/Cargo.toml
+++ b/crates/aprender-explain/Cargo.toml
@@ -25,7 +25,7 @@ presentar-terminal = { workspace = true }
 crossterm = "0.28"
 
 # Internal dependency for PTX generation
-trueno-gpu = { version = "0.50.0", path = "../aprender-gpu", package = "aprender-gpu", features = ["cuda"] }
+trueno-gpu = { version = "0.51.0", path = "../aprender-gpu", package = "aprender-gpu", features = ["cuda"] }
 
 [dev-dependencies]
 proptest = "1.4"

--- a/crates/aprender-gpu/Cargo.toml
+++ b/crates/aprender-gpu/Cargo.toml
@@ -53,7 +53,7 @@ pollster = "0.4"
 bytemuck = { version = "1.21", features = ["derive"] }
 
 # NOTE: renacer (=aprender-profile) dev-dep removed — unused (0 references) and its
-# ^0.50.0 version pin closed a crates.io publish cycle
+# ^0.51.0 version pin closed a crates.io publish cycle
 # (aprender-compute → aprender-gpu → aprender-profile → aprender-core → aprender-compute).
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/crates/aprender-graph/Cargo.toml
+++ b/crates/aprender-graph/Cargo.toml
@@ -28,7 +28,7 @@ anyhow = "1"
 thiserror = "2"
 
 # Phase 2+ dependencies
-aprender = { path = "../aprender-core", version = "0.50.0", package = "aprender-core" }                                        # Sparse matrix ops, PageRank
+aprender = { path = "../aprender-core", version = "0.51.0", package = "aprender-core" }                                        # Sparse matrix ops, PageRank
 trueno = { workspace = true }
 trueno-db = { workspace = true }
 

--- a/crates/aprender-monte-carlo/Cargo.toml
+++ b/crates/aprender-monte-carlo/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 name = "aprender-monte-carlo"
 
 [dependencies]
-aprender = { path = "../../", version = "0.50.0" }
+aprender = { path = "../../", version = "0.51.0" }
 clap = { version = "4", features = ["derive"] }
 rand = "0.9"
 rand_chacha = "0.9"

--- a/crates/aprender-orchestrate/Cargo.toml
+++ b/crates/aprender-orchestrate/Cargo.toml
@@ -120,7 +120,7 @@ pacha = { workspace = true, optional = true }
 realizar = { workspace = true, optional = true }
 
 # ML algorithms and training (native-only)
-aprender = { path = "../aprender-core", version = "0.50.0", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.51.0", package = "aprender-core", optional = true }
 entrenar = { workspace = true, optional = true }
 alimentar = { workspace = true, optional = true }
 

--- a/crates/aprender-present-terminal/Cargo.toml
+++ b/crates/aprender-present-terminal/Cargo.toml
@@ -35,7 +35,7 @@ criterion = { workspace = true }
 # ttop for parity testing against the reference implementation
 # See SPEC-024 Section 11 - Visual Comparison Findings
 ttop = "2.0"
-# NOTE: trueno-viz dev-dep removed — it was unused (0 references) and its ^0.50.0
+# NOTE: trueno-viz dev-dep removed — it was unused (0 references) and its ^0.51.0
 # requirement created a crates.io publish cycle
 # (aprender-compute → aprender-present-terminal → aprender-viz → aprender-compute).
 

--- a/crates/aprender-profile/Cargo.toml
+++ b/crates/aprender-profile/Cargo.toml
@@ -74,7 +74,7 @@ trueno = { workspace = true }
 
 # Machine learning for anomaly detection (Sprint 23)
 # GH-581: Use path dep to avoid trueno version skew with local workspace
-aprender = { path = "../aprender-core", version = "0.50.0", package = "aprender-core" }
+aprender = { path = "../aprender-core", version = "0.51.0", package = "aprender-core" }
 
 # Lock-free data structures for ring buffer (Sprint 40)
 crossbeam = { version = "0.8", default-features = false, features = ["crossbeam-channel", "crossbeam-queue", "std"] }
@@ -112,7 +112,7 @@ crossterm = "0.28"
 
 # SIMD-accelerated visualization primitives (sister project)
 # NOTE: `monitor` feature removed upstream (#1979); this crate uses only viz primitives.
-trueno-viz = { version = "0.50.0", path = "../aprender-viz", package = "aprender-viz", default-features = false }
+trueno-viz = { version = "0.51.0", path = "../aprender-viz", package = "aprender-viz", default-features = false }
 
 # OpenTelemetry for distributed tracing (Sprint 30)
 opentelemetry = { version = "0.31.0", optional = true }

--- a/crates/aprender-qa-cli/Cargo.toml
+++ b/crates/aprender-qa-cli/Cargo.toml
@@ -23,10 +23,10 @@ serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 clap = { workspace = true }
 chrono = { workspace = true }
-aprender-qa-gen = { version = "0.50.0", path = "../aprender-qa-gen" }
-aprender-qa-runner = { version = "0.50.0", path = "../aprender-qa-runner" }
-aprender-qa-report = { version = "0.50.0", path = "../aprender-qa-report" }
-aprender-qa-certify = { version = "0.50.0", path = "../aprender-qa-certify" }
+aprender-qa-gen = { version = "0.51.0", path = "../aprender-qa-gen" }
+aprender-qa-runner = { version = "0.51.0", path = "../aprender-qa-runner" }
+aprender-qa-report = { version = "0.51.0", path = "../aprender-qa-report" }
+aprender-qa-certify = { version = "0.51.0", path = "../aprender-qa-certify" }
 ctrlc = "3.4"
 safetensors = { workspace = true }
 colored = "2.2"

--- a/crates/aprender-qa-report/Cargo.toml
+++ b/crates/aprender-qa-report/Cargo.toml
@@ -18,8 +18,8 @@ anyhow = { workspace = true }
 chrono = { workspace = true }
 colored = "2.2"
 csv = "1.3"
-aprender-qa-gen = { version = "0.50.0", path = "../aprender-qa-gen" }
-aprender-qa-runner = { version = "0.50.0", path = "../aprender-qa-runner" }
+aprender-qa-gen = { version = "0.51.0", path = "../aprender-qa-gen" }
+aprender-qa-runner = { version = "0.51.0", path = "../aprender-qa-runner" }
 
 [dev-dependencies]
 proptest = { workspace = true }

--- a/crates/aprender-qa-runner/Cargo.toml
+++ b/crates/aprender-qa-runner/Cargo.toml
@@ -22,14 +22,14 @@ anyhow = { workspace = true }
 tokio = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }
 tracing = { workspace = true }
-aprender-qa-gen = { version = "0.50.0", path = "../aprender-qa-gen" }
+aprender-qa-gen = { version = "0.51.0", path = "../aprender-qa-gen" }
 hostname = "0.4"
 rayon = "1.10"
 sha2 = "0.10"
 regex = { workspace = true }
 num_cpus = "1.16"
 safetensors = { workspace = true }
-jugar-probar = { version = "0.50.0", path = "../aprender-test-lib", package = "aprender-test-lib", features = ["llm-types"] }
+jugar-probar = { version = "0.51.0", path = "../aprender-test-lib", package = "aprender-test-lib", features = ["llm-types"] }
 # Test fixtures dependencies (optional)
 tempfile = { version = "3", optional = true }
 half = { version = "2.4", optional = true }

--- a/crates/aprender-rag/Cargo.toml
+++ b/crates/aprender-rag/Cargo.toml
@@ -64,7 +64,7 @@ fastembed = { version = "5", optional = true }
 
 # NVIDIA Embed Nemotron 8B via realizar GGUF infrastructure (GH-3)
 # Large model (~4-32GB depending on quantization), requires GGUF file
-realizar = { version = "0.50.0", path = "../aprender-serve", package = "aprender-serve", default-features = false, optional = true }
+realizar = { version = "0.51.0", path = "../aprender-serve", package = "aprender-serve", default-features = false, optional = true }
 
 # Speech-to-text via whisper-apr (Whisper ASR, .apr model format)
 # Sovereign stack: whisper-apr + aprender + trueno for pure-Rust transcription

--- a/crates/aprender-registry/Cargo.toml
+++ b/crates/aprender-registry/Cargo.toml
@@ -42,7 +42,7 @@ zstd = { version = "0.13", optional = true }
 clap = { version = "4", features = ["derive"], optional = true }
 
 # Ecosystem integration
-aprender = { path = "../aprender-core", version = "0.50.0", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.51.0", package = "aprender-core", optional = true }
 alimentar = { workspace = true, optional = true }
 
 # HTTP client (optional)

--- a/crates/aprender-serve/Cargo.toml
+++ b/crates/aprender-serve/Cargo.toml
@@ -39,7 +39,7 @@ name = "realizar"
 trueno = { workspace = true, features = ["gpu"] }
 # CUDA PTX generation and runtime for NVIDIA GPUs (optional, pure Rust, no LLVM/nvcc)
 # v0.4.12: BatchedQ6K, MultiWarp, RopeNeox, FlashDecoding kernels
-trueno-gpu = { version = "0.50.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true, features = ["cuda"] }  # APR-MONO single-source-of-truth
+trueno-gpu = { version = "0.51.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true, features = ["cuda"] }  # APR-MONO single-source-of-truth
 # KV cache storage (for attention caching)
 trueno-db = { workspace = true, optional = true }
 # K-quantization formats (Q4_K, Q5_K, Q6_K) - Toyota Way: ONE source of truth
@@ -53,7 +53,7 @@ renacer-core = { workspace = true }
 
 # ML algorithms and .apr model format (optional for aprender model serving)
 # v0.24.1: chat templates, GGUF tokenizer preservation (local may be newer)
-aprender = { path = "../aprender-core", version = "0.50.0", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.51.0", package = "aprender-core", optional = true }
 
 # Data loading library (optional for data pipeline examples)
 alimentar = { workspace = true, optional = true }

--- a/crates/aprender-shell/Cargo.toml
+++ b/crates/aprender-shell/Cargo.toml
@@ -24,7 +24,7 @@ harness = false
 
 [dependencies]
 # Use path for local dev, crates.io for release
-aprender = { path = "../aprender-core", version = "0.50.0", package = "aprender-core", features = ["format-encryption", "format-compression", "format-homomorphic"] }
+aprender = { path = "../aprender-core", version = "0.51.0", package = "aprender-core", features = ["format-encryption", "format-compression", "format-homomorphic"] }
 clap = { version = "4", features = ["derive"] }
 dirs = "5"
 serde = { version = "1", features = ["derive"] }

--- a/crates/aprender-simulate/Cargo.toml
+++ b/crates/aprender-simulate/Cargo.toml
@@ -53,7 +53,7 @@ crossterm = { version = "0.28", optional = true }
 # ComputeBlocks from presentar-terminal (SIMD-optimized TUI widgets)
 # Path deps to avoid jugar-probar prod dep chain (CB-081)
 presentar-terminal = { workspace = true, optional = true }
-presentar-core = { version = "0.50.0", path = "../aprender-present-core", package = "aprender-present-core", default-features = false, optional = true }
+presentar-core = { version = "0.51.0", path = "../aprender-present-core", package = "aprender-present-core", default-features = false, optional = true }
 
 # WASM (optional)
 wasm-bindgen = { version = "0.2", optional = true }

--- a/crates/aprender-test-cli/Cargo.toml
+++ b/crates/aprender-test-cli/Cargo.toml
@@ -24,7 +24,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Core library (was: jugar-probar) — dep key preserves Rust identifier
-jugar-probar = { path = "../aprender-test-lib", version = "0.50.0", package = "aprender-test-lib" }
+jugar-probar = { path = "../aprender-test-lib", version = "0.51.0", package = "aprender-test-lib" }
 
 # CLI framework
 clap = { workspace = true }

--- a/crates/aprender-train-bench/Cargo.toml
+++ b/crates/aprender-train-bench/Cargo.toml
@@ -20,7 +20,7 @@ workspace = true
 
 [dependencies]
 entrenar = { workspace = true }
-entrenar-common = { version = "0.50.0", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar-common = { version = "0.51.0", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/aprender-train-distill/Cargo.toml
+++ b/crates/aprender-train-distill/Cargo.toml
@@ -33,7 +33,7 @@ shard-batch-source = []
 
 [dependencies]
 entrenar = { workspace = true }
-entrenar-common = { version = "0.50.0", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar-common = { version = "0.51.0", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/aprender-train-inspect/Cargo.toml
+++ b/crates/aprender-train-inspect/Cargo.toml
@@ -20,7 +20,7 @@ workspace = true
 
 [dependencies]
 entrenar = { workspace = true }
-entrenar-common = { version = "0.50.0", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar-common = { version = "0.51.0", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/aprender-train-lora/Cargo.toml
+++ b/crates/aprender-train-lora/Cargo.toml
@@ -20,7 +20,7 @@ workspace = true
 
 [dependencies]
 entrenar = { workspace = true }
-entrenar-common = { version = "0.50.0", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar-common = { version = "0.51.0", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/aprender-train-shell/Cargo.toml
+++ b/crates/aprender-train-shell/Cargo.toml
@@ -20,7 +20,7 @@ workspace = true
 
 [dependencies]
 entrenar = { workspace = true }
-entrenar-common = { version = "0.50.0", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar-common = { version = "0.51.0", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 rustyline = "14"
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/aprender-train/Cargo.toml
+++ b/crates/aprender-train/Cargo.toml
@@ -78,9 +78,9 @@ provable-contracts-macros = { version = "0.2" }
 # Core PAIML stack
 ndarray = "0.16"
 trueno = { workspace = true, features = ["parallel"] }
-trueno-gpu = { version = "0.50.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true }  # CUDA compute (APR-MONO single-source-of-truth)
+trueno-gpu = { version = "0.51.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true }  # CUDA compute (APR-MONO single-source-of-truth)
 realizar = { workspace = true, optional = true }
-aprender = { path = "../aprender-core", version = "0.50.0", package = "aprender-core" }  # ML interpret module + .apr format + tokenizers
+aprender = { path = "../aprender-core", version = "0.51.0", package = "aprender-core" }  # ML interpret module + .apr format + tokenizers
 trueno-viz = { workspace = true, features = ["terminal"] }
 batuta-common = { workspace = true, optional = true }  # WithDimensions trait for `viz` feature (APR-MONO §S #1978)
 presentar-terminal = { workspace = true, optional = true }

--- a/crates/aprender-tsp/Cargo.toml
+++ b/crates/aprender-tsp/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 name = "aprender-tsp"
 
 [dependencies]
-aprender = { path = "../../", version = "0.50.0" }
+aprender = { path = "../../", version = "0.51.0" }
 clap = { version = "4", features = ["derive"] }
 rand = "0.9"
 crc32fast = "1.4"

--- a/crates/aprender-verify-ml/Cargo.toml
+++ b/crates/aprender-verify-ml/Cargo.toml
@@ -50,7 +50,7 @@ uuid = { version = "1.11", features = ["v4", "serde"] }
 trueno = { workspace = true }
 
 # Machine learning for bug prediction (optional)
-aprender = { path = "../aprender-core", version = "0.50.0", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.51.0", package = "aprender-core", optional = true }
 
 # LLM fine-tuning integration (optional)
 entrenar = { workspace = true, optional = true }

--- a/crates/aprender-viz/Cargo.toml
+++ b/crates/aprender-viz/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["visualization", "graphics", "science", "wasm"]
 
 [dependencies]
 # Core SIMD/GPU acceleration
-trueno = { version = "0.50.0", path = "../aprender-compute", package = "aprender-compute", default-features = false }
+trueno = { version = "0.51.0", path = "../aprender-compute", package = "aprender-compute", default-features = false }
 
 # Shared Batuta stack utilities (display traits, formatting)
 batuta-common = { workspace = true }
@@ -29,10 +29,10 @@ base64 = "0.22"
 thiserror = "2.0"
 
 # Optional: ML integration
-aprender = { path = "../aprender-core", version = "0.50.0", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.51.0", package = "aprender-core", optional = true }
 
 # Optional: Graph integration
-trueno-graph = { version = "0.50.0", path = "../aprender-graph", package = "aprender-graph", default-features = false, optional = true }
+trueno-graph = { version = "0.51.0", path = "../aprender-graph", package = "aprender-graph", default-features = false, optional = true }
 
 # Optional: Database integration
 trueno-db = { workspace = true, optional = true }


### PR DESCRIPTION
## Release 0.51.0 (hotfix-driven, brought forward from Friday)

**Headline P0:** PMAT-888 — non-Gemma2 .apr inference produced garbage in 0.50.0 (ungated Gemma2 norm load); fixed (gate on is_gemma2). The majority of .apr models were broken for inference; GGUF unaffected.

**Wave (877-888):** BatchNorm/Linear/LoRA/GQA correctness; cuda-oxide attention kernel (first pure-Rust #[kernel] to beat hand-PTX, 1.7-2.9x on Blackwell); Blackwell CUDA-graph replay fix (+16