### PR TITLE
fix(naive-bayes): GaussianNB var_smoothing = var_smoothing*max_var (sklearn parity) — F-GAUSSIANNB-EPSILON-003 (PMAT-890)

### DIFF
--- a/contracts/naive-bayes-v1.yaml
+++ b/contracts/naive-bayes-v1.yaml
@@ -63,6 +63,10 @@ proof_obligations:
   property: Fit-predict class range
   formal: predict(x) ∈ training_classes for all x
   applies_to: all
+- type: invariant
+  property: F-GAUSSIANNB-EPSILON-003 — variance smoothing scaled by max feature variance (sklearn parity)
+  formal: 'epsilon = var_smoothing · max_j Var(X[:,j]); σ²_jk_smoothed = σ²_jk + epsilon for all j,k'
+  applies_to: all
 falsification_tests:
 - id: FALSIFY-NB-001
   rule: Prior sums to 1
@@ -89,6 +93,18 @@ falsification_tests:
   prediction: accuracy > 0.9 on well-separated Gaussian clusters
   test: 'proptest: generate K well-separated clusters, fit and predict'
   if_fails: Likelihood computation error or variance estimation bug
+- id: F-GAUSSIANNB-EPSILON-003
+  rule: Variance smoothing equals var_smoothing × max feature variance (scikit-learn GaussianNB parity)
+  prediction: |
+    On a mixed-scale fixture (feature0 var ~3.25e6, feature1 var ~1e-4, two classes), the stored
+    smoothed variance for the small-variance feature equals raw_var + var_smoothing·max_feature_var
+    = 1e-4 + 1e-9·3.25e6 = 3.35e-3. Before the fix it stored raw_var + var_smoothing = ~1.0e-4
+    (epsilon NOT scaled by max feature variance), a ~33.5× error in the smoothed variance.
+  test: cargo test -p aprender-core --lib test_gaussian_nb_var_smoothing_scaled_by_max_feature_var
+  if_fails: 'GaussianNB::fit added a raw additive var_smoothing instead of epsilon = var_smoothing·X.var(axis=0).max(); the Gaussian log-likelihood / Mahalanobis term is mis-scaled on mixed-scale data and predict can flip.'
+  evidence: |
+    RED (raw 1e-9): panics "stored=1.000009943e-4, sklearn_expected=3.350000000e-3, rel_err=9.70e-1".
+    GREEN (epsilon = var_smoothing·max_var): test passes; predict_proba rows finite and sum to ~1.
 enforcement:
   valid_distribution:
     description: Priors must form valid probability distribution

--- a/crates/aprender-core/src/classification/linear_svm.rs
+++ b/crates/aprender-core/src/classification/linear_svm.rs
@@ -26,7 +26,10 @@ impl GaussianNB {
 
     /// Sets the variance smoothing parameter.
     ///
-    /// Adds this value to variances to avoid numerical instability.
+    /// Matches scikit-learn: the smoothing added to every per-class feature variance is
+    /// `epsilon = var_smoothing * X.var(axis=0).max()` (this value scaled by the largest
+    /// feature variance), not a raw additive constant. Avoids numerical instability while
+    /// staying scale-aware on mixed-scale data.
     ///
     /// # Example
     ///
@@ -74,6 +77,32 @@ impl GaussianNB {
 
         let n_classes = classes.len();
 
+        // scikit-learn `GaussianNB` defines the variance-smoothing term as the single scalar
+        //   epsilon = var_smoothing * X.var(axis=0).max()
+        // i.e. `var_smoothing` is SCALED by the largest *feature* variance (computed over ALL
+        // training rows, biased/population variance `/n`), then that one `epsilon` is added to
+        // EVERY per-class feature variance. A raw additive `var_smoothing` would be thousands
+        // of times too small on mixed-scale data, distorting the Gaussian log-likelihood.
+        // Refs PMAT-890 / F-GAUSSIANNB-EPSILON-003.
+        let mut max_feature_var = 0.0_f32;
+        for feature_idx in 0..n_features {
+            let mut sum = 0.0_f32;
+            for sample_idx in 0..n_samples {
+                sum += x.get(sample_idx, feature_idx);
+            }
+            let mean = sum / n_samples as f32;
+            let mut sum_sq_diff = 0.0_f32;
+            for sample_idx in 0..n_samples {
+                let diff = x.get(sample_idx, feature_idx) - mean;
+                sum_sq_diff += diff * diff;
+            }
+            let feature_var = sum_sq_diff / n_samples as f32;
+            if feature_var > max_feature_var {
+                max_feature_var = feature_var;
+            }
+        }
+        let epsilon = self.var_smoothing * max_feature_var;
+
         // Initialize storage
         let mut class_priors = vec![0.0; n_classes];
         let mut means = vec![vec![0.0; n_features]; n_classes];
@@ -110,7 +139,7 @@ impl GaussianNB {
                         diff * diff
                     })
                     .sum();
-                *variance_val = sum_sq_diff / n_class_samples + self.var_smoothing;
+                *variance_val = sum_sq_diff / n_class_samples + epsilon;
             }
         }
 

--- a/crates/aprender-core/src/classification/tests_naive_bayes_svm.rs
+++ b/crates/aprender-core/src/classification/tests_naive_bayes_svm.rs
@@ -147,6 +147,90 @@ fn test_gaussian_nb_probabilities_sum_to_one() {
     }
 }
 
+/// F-GAUSSIANNB-EPSILON-003 (PMAT-890): variance smoothing must scale `var_smoothing`
+/// by the largest *feature* variance, matching scikit-learn:
+///   `epsilon = var_smoothing * X.var(axis=0).max()`
+/// then add that single `epsilon` to EVERY per-class feature variance.
+///
+/// On `main` the code added a raw additive `var_smoothing` (1e-9) directly — on a
+/// mixed-scale dataset the smoothed variance for a tiny-variance feature is thousands of
+/// times too small, distorting the Gaussian log-likelihood / Mahalanobis term. This is a
+/// LIVE wrong-answer bug vs the provably-correct sklearn reference.
+///
+/// Fixture (no Python required): 2 features on wildly different scales, 2 classes (2 rows
+/// each). Per-class population variance (`/n`, biased) and the global per-feature variance
+/// (over all 4 rows) are computed below in closed form, so the expected sklearn `epsilon`
+/// is exact.
+#[test]
+fn test_gaussian_nb_var_smoothing_scaled_by_max_feature_var() {
+    // Rows are (feature0_large_scale, feature1_tiny_scale).
+    //   class 0: (0, 0.00), (2000, 0.02)
+    //   class 1: (3000, 0.50), (5000, 0.52)
+    let x = Matrix::from_vec(
+        4,
+        2,
+        vec![
+            0.0, 0.00, // class 0
+            2000.0, 0.02, // class 0
+            3000.0, 0.50, // class 1
+            5000.0, 0.52, // class 1
+        ],
+    )
+    .expect("4x2 mixed-scale fixture");
+    let y = vec![0, 0, 1, 1];
+
+    let var_smoothing = 1e-9_f64;
+    let mut model = GaussianNB::new().with_var_smoothing(var_smoothing as f32);
+    model.fit(&x, &y).expect("fit on mixed-scale data");
+
+    // --- Closed-form sklearn reference (all in f64) ---
+    // Per-class population variance (biased, /n) for the TINY feature (feature1):
+    //   class 0 feature1: mean=0.01, var = ((-0.01)^2 + (0.01)^2)/2 = 1e-4
+    let raw_var_small_feature_class0 = 1.0e-4_f64;
+    // Global per-feature population variance over ALL 4 rows:
+    //   feature0 = var([0,2000,3000,5000]) = 3.25e6  (the MAX feature variance)
+    //   feature1 = var([0,0.02,0.5,0.52])  = 0.0626
+    let max_feature_var = 3.25e6_f64; // = X.var(axis=0).max()
+    let sklearn_epsilon = var_smoothing * max_feature_var; // = 3.25e-3
+    let expected_smoothed_small = raw_var_small_feature_class0 + sklearn_epsilon;
+
+    // What `main` (buggy) would store: raw_var + var_smoothing (epsilon NOT scaled by max_var)
+    let buggy_smoothed_small = raw_var_small_feature_class0 + var_smoothing; // ~= 1.000001e-4
+
+    let variances = model
+        .variances
+        .as_ref()
+        .expect("fitted model exposes per-class variances");
+    // class 0 (index 0), feature1 (index 1) — the small-variance feature.
+    let stored_small = f64::from(variances[0][1]);
+
+    // The sklearn value and the buggy value differ by a factor of ~33.5x — any tolerance
+    // far below that distinguishes them. Use a tight relative tolerance.
+    let rel_err = (stored_small - expected_smoothed_small).abs() / expected_smoothed_small;
+    assert!(
+        rel_err < 1e-4,
+        "F-GAUSSIANNB-EPSILON-003: stored smoothed variance for the small feature must equal \
+         raw_var + var_smoothing*max_feature_var (sklearn). \
+         stored={stored_small:.9e}, sklearn_expected={expected_smoothed_small:.9e} \
+         (epsilon={sklearn_epsilon:.9e}), buggy_main_would_store={buggy_smoothed_small:.9e}, \
+         rel_err={rel_err:.6e}"
+    );
+
+    // predict_proba rows must be finite and sum to ~1.
+    let proba = model.predict_proba(&x).expect("predict_proba succeeds");
+    for row in &proba {
+        let sum: f32 = row.iter().sum();
+        assert!(
+            row.iter().all(|p| p.is_finite()),
+            "all predict_proba entries must be finite, got {row:?}"
+        );
+        assert!(
+            (sum - 1.0).abs() < 1e-5,
+            "predict_proba row must sum to ~1, got sum={sum}"
+        );
+    }
+}
+
 #[test]
 fn test_gaussian_nb_default() {
     let model1 = GaussianNB::new();


### PR DESCRIPTION
## PMAT-890 — Pillar-1 GaussianNB var_smoothing parity (F-GAUSSIANNB-EPSILON-003)

LIVE wrong-answer bug vs scikit-learn (the provably-correct reference).

### Defect
`GaussianNB::fit` (in `crates/aprender-core/src/classification/linear_svm.rs`) added a **raw additive** `var_smoothing` (default `1e-9`) directly to each per-class feature variance:

```rust
*variance_val = sum_sq_diff / n_class_samples + self.var_smoothing;
```

scikit-learn instead defines the smoothing as a **single scalar scaled by the largest feature variance**:

```
epsilon = var_smoothing * X.var(axis=0).max()
```

added uniformly to every per-class feature variance. On a mixed-scale dataset (one feature var ~`3.25e6`, another ~`1e-4`) the raw additive constant makes the smoothed variance for the small feature **~33.5× too small**, mis-scaling the Gaussian log-likelihood / Mahalanobis term — able to flip `predict`.

### Fix
Compute `max_feature_var = max_j Var(X[:,j])` over all training rows (biased/population variance, matching the existing convention), set `epsilon = var_smoothing * max_feature_var`, add that single `epsilon` to every per-class feature variance. `var_smoothing` stays configurable (default `1e-9`).

### RED → GREEN evidence
Falsifier `test_gaussian_nb_var_smoothing_scaled_by_max_feature_var` (no Python/sklearn required; closed-form sklearn reference):

- **RED (main, buggy):** `stored=1.000009943e-4` vs `sklearn_expected=3.350000000e-3` (epsilon=`3.25e-3`), `rel_err=0.97` → FAIL
- **GREEN (fixed):** passes; `predict_proba` rows finite and sum to ~1

### Full crate tests
`cargo test -p aprender-core --lib` → **13955 passed; 0 failed; 2 ignored** (no sibling test encoded the old raw-1e-9 behavior). `cargo fmt --all --check` clean, `cargo clippy -p aprender-core -- -D warnings` clean.

### Contract
`F-GAUSSIANNB-EPSILON-003` proof_obligation + single-line `cargo test` falsifier added to `contracts/naive-bayes-v1.yaml`. `pv lint contracts/` → **PASS** (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)