### PR TITLE
fix(autograd): CrossEntropyLoss backward respects reduction mode (Sum grad not /batch) — F-AUTOGRAD-CE-REDUCTION-001 (PMAT-891)

### DIFF
--- a/contracts/cross-entropy-kernel-v1.yaml
+++ b/contracts/cross-entropy-kernel-v1.yaml
@@ -80,9 +80,24 @@ proof_obligations:
   property: SIMD matches scalar within ULP
   tolerance: 8.0
   applies_to: simd
+- type: equivalence
+  property: Backward gradient respects reduction mode (PyTorch parity)
+  formal: >-
+    dCE/dlogits = (softmax(logits) - onehot(targets)) * s, where the upstream
+    scale s is: 1/batch for Reduction::Mean, 1 for Reduction::Sum, and the
+    per-sample upstream gradient upstream[b] broadcast across sample b's classes
+    for Reduction::None. Sum MUST NOT divide by batch.
+  tolerance: 1.0e-06
+  applies_to: all
+  id: F-AUTOGRAD-CE-REDUCTION-001
+  notes: >-
+    Before PMAT-891 the backward unconditionally divided by batch (Mean-only) and
+    read only grad_output[0], so Sum grad was batch× too small and None
+    mis-broadcast the per-sample upstream. Closed-form softmax+NLL gradient is
+    softmax-onehot, requiring no PyTorch reference (Bishop 2006, eq. 4.108).
 verification_summary:
-  total_obligations: 5
-  l2_property_tested: 5
+  total_obligations: 6
+  l2_property_tested: 6
   l3_kani_proved: 3
   l4_lean_proved: 2
   l4_sorry_count: 0
@@ -146,6 +161,21 @@ falsification_tests:
   prediction: CE(one_hot(k), logits) approaches 0 as logits_k >> logits_j
   test: proptest with dominant logit at target index
   if_fails: Loss not approaching zero for confident predictions
+- id: F-AUTOGRAD-CE-REDUCTION-001-SUM
+  rule: Sum-reduction backward grad is softmax-onehot (NOT divided by batch)
+  prediction: 'dCE/dlogits under Reduction::Sum == softmax(logits) - onehot(targets)'
+  test: cargo test -p aprender-core --lib falsify_ce_reduction_001_sum_grad_not_divided_by_batch
+  if_fails: Backward divides Sum-reduction grad by batch (PyTorch divergence, batch× too small)
+- id: F-AUTOGRAD-CE-REDUCTION-001-MEAN
+  rule: Mean-reduction backward grad is (softmax-onehot)/batch (no regression)
+  prediction: 'dCE/dlogits under Reduction::Mean == (softmax(logits) - onehot(targets)) / batch'
+  test: cargo test -p aprender-core --lib falsify_ce_reduction_001_mean_grad_divided_by_batch
+  if_fails: Mean-reduction default behavior regressed
+- id: F-AUTOGRAD-CE-REDUCTION-001-NONE
+  rule: None-reduction backward scales each sample row by its own per-sample upstream
+  prediction: 'dCE/dlogits[b] under Reduction::None == (softmax-onehot)[b] * upstream[b]'
+  test: cargo test -p aprender-core --lib falsify_ce_reduction_001_none_per_sample_upstream
+  if_fails: Backward reads only grad_output[0] and mis-broadcasts the per-sample upstream
 kani_harnesses:
 - id: KANI-CE-001
   obligation: CE-INV-001

--- a/crates/aprender-core/src/autograd/grad_fn.rs
+++ b/crates/aprender-core/src/autograd/grad_fn.rs
@@ -435,12 +435,19 @@ impl GradFn for SoftmaxBackward {
 }
 
 /// Gradient function for Cross-Entropy Loss (combined softmax + NLL)
-/// For L = -log(softmax(x)[target]), the gradient is:
+/// For L = -log(softmax(x)[target]), the per-sample gradient is:
 /// ∂`L/∂x_i` = softmax(x)_i - 1 if i == target else softmax(x)_i
-/// This is simply: grad = softmax(logits) - `one_hot(targets)`
+/// i.e. grad = softmax(logits) - `one_hot(targets)`.
+///
+/// The final input gradient depends on the loss `reduction` mode (PyTorch parity,
+/// F-AUTOGRAD-CE-REDUCTION-001):
+/// - `Mean`: grad = (softmax - onehot) / batch   (upstream is a scalar)
+/// - `Sum`:  grad = (softmax - onehot)            (upstream is a scalar; NO /batch)
+/// - `None`: grad = (softmax - onehot) * upstream\[b]  (per-sample upstream row-scale)
 pub(crate) struct CrossEntropyBackward {
-    pub(crate) softmax_output: Tensor, // softmax(logits)
-    pub(crate) targets: Vec<usize>,    // target class indices
+    pub(crate) softmax_output: Tensor,                // softmax(logits)
+    pub(crate) targets: Vec<usize>,                   // target class indices
+    pub(crate) reduction: crate::nn::loss::Reduction, // loss reduction mode
 }
 
 include!("gradient.rs");

--- a/crates/aprender-core/src/autograd/gradient.rs
+++ b/crates/aprender-core/src/autograd/gradient.rs
@@ -1,25 +1,53 @@
 
 impl GradFn for CrossEntropyBackward {
     fn backward(&self, grad_output: &Tensor) -> Vec<Tensor> {
+        use crate::nn::loss::Reduction;
+
         let (batch, num_classes) = (
             self.softmax_output.shape()[0],
             self.softmax_output.shape()[1],
         );
+
+        // Base per-sample gradient: grad = softmax - one_hot(targets).
+        // This is the EXACT closed-form gradient of softmax+NLL (Bishop 2006),
+        // BEFORE any reduction scaling.
         let mut grad_input = self.softmax_output.data().to_vec();
-
-        // grad = softmax - one_hot(targets)
-        // Then multiply by upstream gradient (for reduction)
-        let grad_scale = grad_output.data()[0]; // scalar after mean reduction
-
         for b in 0..batch {
             let target = self.targets[b];
             let idx = b * num_classes + target;
             grad_input[idx] -= 1.0;
         }
 
-        // Scale by upstream gradient and divide by batch size (for mean reduction)
-        for g in &mut grad_input {
-            *g *= grad_scale / batch as f32;
+        // Apply reduction-aware upstream scaling (PyTorch parity,
+        // F-AUTOGRAD-CE-REDUCTION-001). For Mean/Sum the loss is a scalar and
+        // `grad_output` is `[1]`; for None it is the per-sample upstream `[batch]`.
+        let upstream = grad_output.data();
+        match self.reduction {
+            // Mean: divide by batch (loss = sum(per_sample) / batch).
+            Reduction::Mean => {
+                let scale = upstream[0] / batch as f32;
+                for g in &mut grad_input {
+                    *g *= scale;
+                }
+            }
+            // Sum: NO division by batch (loss = sum(per_sample)).
+            Reduction::Sum => {
+                let scale = upstream[0];
+                for g in &mut grad_input {
+                    *g *= scale;
+                }
+            }
+            // None: scale each sample's row by its OWN per-sample upstream
+            // gradient — broadcast `upstream[b]` across that sample's classes,
+            // NOT `upstream[0]`.
+            Reduction::None => {
+                for b in 0..batch {
+                    let scale = upstream[b];
+                    for i in 0..num_classes {
+                        grad_input[b * num_classes + i] *= scale;
+                    }
+                }
+            }
         }
 
         vec![Tensor::new(&grad_input, self.softmax_output.shape())]

--- a/crates/aprender-core/src/autograd/tests_elementwise_backward.rs
+++ b/crates/aprender-core/src/autograd/tests_elementwise_backward.rs
@@ -302,6 +302,7 @@
         let grad_fn = CrossEntropyBackward {
             softmax_output,
             targets,
+            reduction: crate::nn::loss::Reduction::Mean,
         };
         let grad_out = Tensor::from_slice(&[1.0]); // scalar after mean reduction
         let grads = grad_fn.backward(&grad_out);

--- a/crates/aprender-core/src/autograd/tests_matmul_backward.rs
+++ b/crates/aprender-core/src/autograd/tests_matmul_backward.rs
@@ -87,6 +87,7 @@
         let grad_fn = CrossEntropyBackward {
             softmax_output,
             targets,
+            reduction: crate::nn::loss::Reduction::Mean,
         };
         let grad_out = Tensor::from_slice(&[1.0]);
         let grads = grad_fn.backward(&grad_out);
@@ -141,6 +142,7 @@
             CrossEntropyBackward {
                 softmax_output: Tensor::from_slice(&[1.0]),
                 targets: vec![0],
+                reduction: crate::nn::loss::Reduction::Mean,
             }
             .name(),
             SigmoidBackward {

--- a/crates/aprender-core/src/nn/loss.rs
+++ b/crates/aprender-core/src/nn/loss.rs
@@ -332,6 +332,7 @@ impl CrossEntropyLoss {
             let grad_fn = Arc::new(CrossEntropyBackward {
                 softmax_output: softmax_output.clone(),
                 targets: target_indices,
+                reduction: self.reduction,
             });
             loss.set_grad_fn(grad_fn.clone());
 

--- a/crates/aprender-core/src/nn/loss_tests_ce_contract.rs
+++ b/crates/aprender-core/src/nn/loss_tests_ce_contract.rs
@@ -138,6 +138,137 @@ mod tests {
         }
     }
 
+    /// Analytic CE-with-softmax input gradient: `softmax(logits) - onehot(targets)`.
+    ///
+    /// This is the EXACT gradient of the combined softmax+NLL with NO reduction
+    /// scaling. Needs no PyTorch — it is the closed-form gradient (Bishop 2006,
+    /// eq. 4.108). Returned flat in row-major `[batch * num_classes]` order.
+    fn softmax_minus_onehot(
+        logits: &[f32],
+        targets: &[usize],
+        batch: usize,
+        nc: usize,
+    ) -> Vec<f32> {
+        let mut out = Vec::with_capacity(batch * nc);
+        for b in 0..batch {
+            let row = &logits[b * nc..(b + 1) * nc];
+            let max = row.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+            let exps: Vec<f32> = row.iter().map(|&x| (x - max).exp()).collect();
+            let sum: f32 = exps.iter().sum();
+            for (i, &e) in exps.iter().enumerate() {
+                let mut g = e / sum;
+                if i == targets[b] {
+                    g -= 1.0;
+                }
+                out.push(g);
+            }
+        }
+        out
+    }
+
+    /// FALSIFY-CE-REDUCTION-001 (Sum): backward under `Reduction::Sum` MUST equal
+    /// `softmax(logits) - onehot(targets)` EXACTLY (no division by batch).
+    ///
+    /// PyTorch reference: `nn.CrossEntropyLoss(reduction="sum").backward()` yields
+    /// `softmax - onehot` (un-normalized). On the buggy main, every element is
+    /// divided by batch=2 → exactly HALF the correct value → this FALSIFIES.
+    #[test]
+    fn falsify_ce_reduction_001_sum_grad_not_divided_by_batch() {
+        let logits_data = vec![1.0_f32, 2.0, 0.5, 0.1, 3.0, 0.2];
+        let targets_idx = vec![1_usize, 2_usize];
+        let batch = 2;
+        let nc = 3;
+
+        let criterion = CrossEntropyLoss::with_reduction(Reduction::Sum);
+        let logits = Tensor::new(&logits_data, &[batch, nc]).requires_grad();
+        let logits_id = logits.id();
+        let targets = Tensor::new(&[1.0_f32, 2.0], &[batch]);
+
+        let loss = criterion.forward(&logits, &targets);
+        loss.backward();
+
+        let grad = crate::autograd::get_grad(logits_id).expect("logits must have a gradient");
+        let expected = softmax_minus_onehot(&logits_data, &targets_idx, batch, nc);
+
+        for (i, (&g, &e)) in grad.data().iter().zip(expected.iter()).enumerate() {
+            assert!(
+                (g - e).abs() < 1e-6,
+                "FALSIFIED CE-REDUCTION-001 (Sum)[{i}]: grad = {g}, expected (softmax-onehot) = {e}; \
+                 buggy main divides by batch → {} (half)",
+                e / batch as f32
+            );
+        }
+    }
+
+    /// FALSIFY-CE-REDUCTION-001 (Mean): backward under `Reduction::Mean` (the
+    /// default) MUST equal `(softmax - onehot) / batch`. Proves the fix does NOT
+    /// regress the historical Mean behavior.
+    #[test]
+    fn falsify_ce_reduction_001_mean_grad_divided_by_batch() {
+        let logits_data = vec![1.0_f32, 2.0, 0.5, 0.1, 3.0, 0.2];
+        let targets_idx = vec![1_usize, 2_usize];
+        let batch = 2;
+        let nc = 3;
+
+        let criterion = CrossEntropyLoss::with_reduction(Reduction::Mean);
+        let logits = Tensor::new(&logits_data, &[batch, nc]).requires_grad();
+        let logits_id = logits.id();
+        let targets = Tensor::new(&[1.0_f32, 2.0], &[batch]);
+
+        let loss = criterion.forward(&logits, &targets);
+        loss.backward();
+
+        let grad = crate::autograd::get_grad(logits_id).expect("logits must have a gradient");
+        let raw = softmax_minus_onehot(&logits_data, &targets_idx, batch, nc);
+
+        for (i, (&g, &r)) in grad.data().iter().zip(raw.iter()).enumerate() {
+            let expected = r / batch as f32;
+            assert!(
+                (g - expected).abs() < 1e-6,
+                "FALSIFIED CE-REDUCTION-001 (Mean)[{i}]: grad = {g}, expected (softmax-onehot)/batch = {expected}"
+            );
+        }
+    }
+
+    /// FALSIFY-CE-REDUCTION-001 (None): backward under `Reduction::None` MUST
+    /// scale each sample's gradient row by its OWN per-sample upstream gradient
+    /// `g_b`, not by `upstream[0]`. With distinct per-sample upstreams, the buggy
+    /// main (which reads only element[0]) mis-broadcasts row 1.
+    #[test]
+    fn falsify_ce_reduction_001_none_per_sample_upstream() {
+        let logits_data = vec![1.0_f32, 2.0, 0.5, 0.1, 3.0, 0.2];
+        let targets_idx = vec![1_usize, 2_usize];
+        let batch = 2;
+        let nc = 3;
+
+        let criterion = CrossEntropyLoss::with_reduction(Reduction::None);
+        let logits = Tensor::new(&logits_data, &[batch, nc]).requires_grad();
+        let logits_id = logits.id();
+        let targets = Tensor::new(&[1.0_f32, 2.0], &[batch]);
+
+        let loss = criterion.forward(&logits, &targets);
+        // Distinct per-sample upstream gradients: row 0 scaled by 2.0, row 1 by 5.0.
+        let upstream = Tensor::new(&[2.0_f32, 5.0], &[batch]);
+        loss.backward_with_grad(upstream);
+
+        let grad = crate::autograd::get_grad(logits_id).expect("logits must have a gradient");
+        let raw = softmax_minus_onehot(&logits_data, &targets_idx, batch, nc);
+        let per_sample = [2.0_f32, 5.0];
+
+        for b in 0..batch {
+            for i in 0..nc {
+                let idx = b * nc + i;
+                let expected = raw[idx] * per_sample[b];
+                let g = grad.data()[idx];
+                assert!(
+                    (g - expected).abs() < 1e-6,
+                    "FALSIFIED CE-REDUCTION-001 (None)[{b},{i}]: grad = {g}, \
+                     expected (softmax-onehot)*upstream[{b}] = {expected}"
+                );
+            }
+        }
+    }
+
     mod ce_proptest_falsify {
         use super::super::super::*;
         use proptest::prelude::*;


### PR DESCRIPTION
## PMAT-891 — Pillar-2 (PyTorch) CrossEntropyLoss backward respects reduction mode

**Silent training-correctness bug vs PyTorch.** `CrossEntropyLoss`'s autograd backward (`CrossEntropyBackward`) unconditionally divided the input gradient by the batch size and read only `grad_output[0]`, **ignoring the loss's reduction mode**.

The closed-form softmax+NLL input gradient is exactly `softmax(logits) - onehot(targets)` (Bishop 2006, eq. 4.108). The correct reduction-aware scaling is:

| Reduction | Correct grad | Old (buggy) grad |
|-----------|--------------|------------------|
| `Mean`    | `(softmax - onehot) / batch` | `(softmax - onehot) / batch` ✅ |
| `Sum`     | `(softmax - onehot)`         | `(softmax - onehot) / batch` ❌ **batch× too small** |
| `None`    | `(softmax - onehot) * upstream[b]` | `(softmax - onehot) * upstream[0] / batch` ❌ mis-broadcast |

Under `Sum`, the model learned at `1/batch` the intended rate vs PyTorch. Under `None`, the per-sample upstream was mis-broadcast (only element 0 read). `Mean` (the default) was correct and is **preserved bit-for-bit**.

### Fix
Thread the loss's `Reduction` into `CrossEntropyBackward` and branch on it in the backward pass (`crates/aprender-core/src/autograd/gradient.rs`).

### Falsifier-first (no PyTorch needed — analytic gradient)
`crates/aprender-core/src/nn/loss_tests_ce_contract.rs`, batch=2 `[2,3]` logits:

**RED (buggy body):**
```
Sum  [0]:   grad = 0.11561195, expected (softmax-onehot)       = 0.2312239  (exactly half)
None [0,0]: grad = 0.2312239,  expected *upstream[0]=2.0       = 0.4624478  (exactly half)
Mean:       PASS  (default behavior unchanged)
test result: FAILED. 1 passed; 2 failed
```

**GREEN (fix):**
```
falsify_ce_reduction_001_mean_grad_divided_by_batch ... ok
falsify_ce_reduction_001_none_per_sample_upstream ... ok
falsify_ce_reduction_001_sum_grad_not_divided_by_batch ... ok
test result: ok. 3 passed; 0 failed
```

### Full crate regression
```
cargo test -p aprender-core --lib
test result: ok. 13957 passed; 0 failed; 2 ignored
```
(Two pre-existing direct `CrossEntropyBackward { .. }` test literals updated for the new `reduction` field — `tests_elementwise_backward.rs`, `tests_matmul_backward.rs` — both Mean, no behavior change. No test asserted the buggy Sum behavior.)

### Contract
`contracts/cross-entropy-kernel-v1.yaml` gains proof_obligation **F-AUTOGRAD-CE-REDUCTION-001** (`type: equivalence`, tol 1e-6) + three single-line `cargo test` falsification entries binding the Sum/Mean/None falsifiers. `pv lint contracts/` → **PASS (0 errors)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
