### PR TITLE
fix(validate): reject dead output row (zero lm_head/embed row) — F-DATA-QUALITY-007 (PMAT-889)

### DIFF
--- a/contracts/apr-fail-closed-garbage-beat-v1.yaml
+++ b/contracts/apr-fail-closed-garbage-beat-v1.yaml
@@ -9,9 +9,11 @@ metadata:
     apr concedes raw CPU decode throughput but wins on "we provably never ship
     garbage; they provably do." A tensor that PARSES (valid magic/shape/dtype)
     but is semantically dead — all-zero, NaN, Inf, effectively-empty (L2~0),
-    constant, or extreme-magnitude (max|w| > 1e6, PMAT-732/F-DATA-QUALITY-005) —
-    is rejected by apr's Poka-Yoke validation (PMAT-234/235,
-    F-DATA-QUALITY-001..005), while llama.cpp loads it with zero error lines.
+    constant, extreme-magnitude (max|w| > 1e6, PMAT-732/F-DATA-QUALITY-005), or
+    a DEAD OUTPUT ROW (one fully-zero row of an lm_head/embed/output projection,
+    PMAT-889/F-DATA-QUALITY-007) — is rejected by apr's Poka-Yoke validation
+    (PMAT-234/235, F-DATA-QUALITY-001..007), while llama.cpp loads it with zero
+    error lines.
     Measured 2026-06-13 (RTX 4090): a copy of qwen2.5-coder-1.5b-instruct-q4_k_m
     GGUF with blk.0.ffn_down.weight zeroed → `apr validate` FAILs the tensor
     ([F-DATA-QUALITY-001] all zero + [F-DATA-QUALITY-003] L2~0/constant);
@@ -19,6 +21,8 @@ metadata:
   references:
   - "crates/aprender-serve/tests/beat_fail_closed_garbage.rs"
   - "crates/aprender-serve/src/safetensors/validation.rs (validate_weight/validate_embedding, F-DATA-QUALITY-001..005)"
+  - "crates/aprender-core/src/format/rosetta/validate_inspect.rs (compute_tensor_validation_with_shape/check_dead_output_row, F-DATA-QUALITY-007)"
+  - "crates/aprender-core/src/format/rosetta/computation.rs (pmat889_* falsifier + FP-bound tests)"
   - "evidence/pillar4-fail-closed-2026-06-13/findings.md"
   - "garbage-oracle-v1.yaml (sibling: OUTPUT-garbage oracle; this contract is INPUT-artifact fail-closed)"
 version: 1
@@ -45,3 +49,48 @@ beat:
   baseline_sourced_date: "2026-06-13"
   approved_compute: CPU       # the apr-side gate is CPU-deterministic
   ci_gate_name: "beat_fail_closed_garbage"   # crates/aprender-serve/tests/beat_fail_closed_garbage.rs
+
+# PMAT-889: F-DATA-QUALITY-007 dead-output-row gate. The whole-tensor gates
+# (F-DATA-QUALITY-001..005) check tensor CONTENTS in aggregate (density / NaN /
+# Inf / L2 / constant / extreme magnitude). They all MISS a single fully-zero
+# OUTPUT ROW of an lm_head/embed/output projection because one zero row is a tiny
+# fraction of a large tensor — yet that row is a structurally-dead token (its
+# logit can never carry positive evidence; its embedding is unreachable).
+# llama.cpp / Ollama load and run such a model silently. apr fails closed via the
+# per-output-row L2 scan in compute_tensor_validation_with_shape (apr validate).
+proof_obligations:
+- id: OBLIG-DATA-QUALITY-007-DEAD-OUTPUT-ROW
+  statement: >
+    For a 2-D output-projection weight (lm_head / output head / token embedding)
+    interpreted row-major as [out_units, in_dim], apr rejects it at validate iff
+    at least one output row has L2 ~ 0 (< 1e-6). This catches a dead token whose
+    logit is structurally constant / whose embedding vector is zero — corruption
+    that passes every whole-tensor density / L2 / constant gate.
+  type: invariant
+- id: OBLIG-DATA-QUALITY-007-NO-FALSE-POSITIVE
+  statement: >
+    apr accepts a healthy output-projection tensor with no zero rows, and the
+    dead-row gate is SCOPED to output-projection roles only — a structurally-zero
+    row in a non-output tensor (generic intermediate / q/k/v / gate/up/down) does
+    NOT trip F-DATA-QUALITY-007. The gate asserts only where a zero row is
+    unambiguously corrupt, so it raises no false positive on legitimate models.
+  type: invariant
+
+falsification_tests:
+- id: FALSIFY-BEAT-DATA-QUALITY-007-DEAD-ROW
+  description: >
+    FALSE if apr ACCEPTS an lm_head/embed with a fully-zero output row (the dead
+    token garbage the incumbents load silently) OR if apr REJECTS a healthy
+    output-projection tensor / fires on a non-output role (false positive).
+  command: cargo test -p aprender-core --lib pmat889
+  expected: >
+    4 passed; 0 failed — both dead-row classes (lm_head, embed) rejected with
+    F-DATA-QUALITY-007, and both FP-bound cases (healthy lm_head, non-output-role
+    zero row) accepted.
+  if_fails: >
+    Either check_dead_output_row stopped scanning per-output-row L2 (fail-closed
+    regression — verify compute_tensor_validation_with_shape is wired into
+    validate_apr and the role allow-list still matches lm_head/embed/output), or
+    the gate became over-eager (false positive — the role allow-list or the 1e-6
+    row-L2 threshold widened) in
+    crates/aprender-core/src/format/rosetta/validate_inspect.rs.

--- a/crates/aprender-core/src/format/rosetta/computation.rs
+++ b/crates/aprender-core/src/format/rosetta/computation.rs
@@ -439,3 +439,134 @@ fn p070h_compute_validation_inf_mixed_with_valid() {
     assert!((tv.min - 2.0).abs() < 1e-6);
     assert!((tv.max - 6.0).abs() < 1e-6);
 }
+
+// ========================================================================
+// PMAT-889: F-DATA-QUALITY-007 — DEAD OUTPUT ROW
+// ========================================================================
+//
+// Pillar-4 fail-closed BEAT. A weight tensor whose individual entries are all
+// finite, whose whole-tensor zero density is well under the 50%/80% gate, and
+// whose global L2 norm is large can STILL be semantically corrupt if one
+// OUTPUT ROW is entirely zero. For an lm_head `[vocab, hidden]` that means one
+// token's logit is structurally a constant (its dot-product against any hidden
+// state is 0) -> that token can never be emitted with positive evidence (dead
+// token). For an embedding `[vocab, hidden]` a zero row is a dead/unreachable
+// token vector. The whole-tensor gates (F-DATA-QUALITY-001..005) all MISS this
+// because a single zero row is a tiny fraction of the tensor. llama.cpp / Ollama
+// load and run such a model silently. apr must fail closed.
+
+/// Build a healthy `[out, in]` row-major weight: dense, finite, varied, L2 >> 0,
+/// no exact zeros, mean ~ 0.
+fn healthy_rowmajor(out: usize, in_dim: usize) -> Vec<f32> {
+    (0..out * in_dim)
+        .map(|i| {
+            let x = ((i % 17) as f32) - 8.0;
+            if x == 0.0 {
+                0.5
+            } else {
+                x * 0.01
+            }
+        })
+        .collect()
+}
+
+/// RED (PMAT-889): an lm_head `[256, 64]` that is healthy EXCEPT one fully-zero
+/// output row must be REJECTED with rule id `F-DATA-QUALITY-007`. On current
+/// main this fails — the whole-tensor gates do not scan rows, so the dead row
+/// passes clean. The fix is the shape-aware `compute_tensor_validation_with_shape`.
+#[test]
+fn pmat889_red_dead_output_row_lm_head_rejected() {
+    let rosetta = RosettaStone::new();
+    let (out, in_dim) = (256usize, 64usize);
+    let mut data = healthy_rowmajor(out, in_dim);
+    // Force output row 7 fully zero (one dead vocab token).
+    let dead = 7usize;
+    for v in data.iter_mut().skip(dead * in_dim).take(in_dim) {
+        *v = 0.0;
+    }
+
+    let tv = rosetta.compute_tensor_validation_with_shape("lm_head.weight", &data, &[out, in_dim]);
+    assert!(
+        !tv.is_valid,
+        "FAIL-CLOSED VIOLATION: apr ACCEPTED an lm_head with a fully-zero output row \
+         (dead token logit -> -inf). This is the garbage llama.cpp/Ollama ship silently. \
+         failures={:?}",
+        tv.failures
+    );
+    assert!(
+        tv.failures
+            .iter()
+            .any(|f| f.contains("F-DATA-QUALITY-007")),
+        "Dead output row must be reported as F-DATA-QUALITY-007: {:?}",
+        tv.failures
+    );
+}
+
+/// RED (PMAT-889): same dead-row gate for `embed_tokens.weight`.
+#[test]
+fn pmat889_red_dead_output_row_embed_rejected() {
+    let rosetta = RosettaStone::new();
+    let (vocab, hidden) = (200usize, 48usize);
+    let mut data = healthy_rowmajor(vocab, hidden);
+    let dead = 3usize;
+    for v in data.iter_mut().skip(dead * hidden).take(hidden) {
+        *v = 0.0;
+    }
+    let tv =
+        rosetta.compute_tensor_validation_with_shape("model.embed_tokens.weight", &data, &[vocab, hidden]);
+    assert!(
+        !tv.is_valid,
+        "FAIL-CLOSED VIOLATION: apr ACCEPTED an embedding with a dead token row. failures={:?}",
+        tv.failures
+    );
+    assert!(
+        tv.failures.iter().any(|f| f.contains("F-DATA-QUALITY-007")),
+        "Dead embedding row must be F-DATA-QUALITY-007: {:?}",
+        tv.failures
+    );
+}
+
+/// FALSE-POSITIVE BOUND (PMAT-889): a fully healthy lm_head with NO zero rows
+/// must still validate clean — fail-closed must not block legitimate models.
+#[test]
+fn pmat889_fp_bound_healthy_lm_head_accepted() {
+    let rosetta = RosettaStone::new();
+    let (out, in_dim) = (256usize, 64usize);
+    let data = healthy_rowmajor(out, in_dim);
+    let tv = rosetta.compute_tensor_validation_with_shape("lm_head.weight", &data, &[out, in_dim]);
+    assert!(
+        tv.is_valid,
+        "FALSE POSITIVE: apr rejected a healthy lm_head (no dead rows). failures={:?}",
+        tv.failures
+    );
+    assert!(
+        !tv.failures.iter().any(|f| f.contains("F-DATA-QUALITY-007")),
+        "Healthy lm_head must not trigger the dead-row gate: {:?}",
+        tv.failures
+    );
+}
+
+/// FALSE-POSITIVE BOUND (PMAT-889): a non-output-role tensor (e.g. a generic
+/// intermediate buffer) with a zero row must NOT trip the dead-row gate — the
+/// gate is intentionally scoped to lm_head/embed/output roles to avoid FPs on
+/// roles where a structurally-zero row is not unambiguously corrupt.
+#[test]
+fn pmat889_fp_bound_non_output_role_zero_row_accepted_by_dead_row_gate() {
+    let rosetta = RosettaStone::new();
+    let (out, in_dim) = (64usize, 32usize);
+    let mut data = healthy_rowmajor(out, in_dim);
+    for v in data.iter_mut().skip(5 * in_dim).take(in_dim) {
+        *v = 0.0;
+    }
+    // A name that does NOT match the output-projection role allow-list.
+    let tv = rosetta.compute_tensor_validation_with_shape(
+        "model.layers.0.mlp.intermediate_buffer",
+        &data,
+        &[out, in_dim],
+    );
+    assert!(
+        !tv.failures.iter().any(|f| f.contains("F-DATA-QUALITY-007")),
+        "Dead-row gate must be scoped to output roles, not fire on a generic tensor: {:?}",
+        tv.failures
+    );
+}

--- a/crates/aprender-core/src/format/rosetta/validate_inspect.rs
+++ b/crates/aprender-core/src/format/rosetta/validate_inspect.rs
@@ -53,7 +53,14 @@ impl RosettaStone {
         for name in reader.tensor_names() {
             // Use get_tensor_as_f32 which handles dequantization
             if let Some(f32_data) = reader.get_tensor_as_f32(name) {
-                let tv = self.compute_tensor_validation(name, &f32_data);
+                // PMAT-889: pass the on-disk 2-D shape so the dead-output-row gate
+                // (F-DATA-QUALITY-007) can scan per-output-row L2 for output-projection
+                // tensors. Falls back to the shape-free gates for non-2-D tensors.
+                let shape: Vec<usize> = reader
+                    .get_tensor(name)
+                    .map(|e| e.shape.clone())
+                    .unwrap_or_default();
+                let tv = self.compute_tensor_validation_with_shape(name, &f32_data, &shape);
 
                 total_nan += tv.nan_count;
                 total_inf += tv.inf_count;
@@ -101,6 +108,85 @@ impl RosettaStone {
     /// Clamp infinite min/max to 0.0 for reporting.
     fn clamp_infinite(v: f32) -> f32 {
         if v.is_infinite() { 0.0 } else { v }
+    }
+
+    /// Shape-aware tensor validation (PMAT-889).
+    ///
+    /// Runs the whole-tensor data-quality gates (`compute_tensor_validation`) and,
+    /// when the tensor is a 2-D output projection (lm_head / embed / output), ALSO
+    /// runs the per-output-row dead-row gate (F-DATA-QUALITY-007). The flat row-major
+    /// `data` is interpreted as `[shape[0], shape[1]]` = `[out_units, in_dim]`.
+    fn compute_tensor_validation_with_shape(
+        &self,
+        name: &str,
+        data: &[f32],
+        shape: &[usize],
+    ) -> TensorValidation {
+        let mut tv = self.compute_tensor_validation(name, data);
+        Self::check_dead_output_row(name, data, shape, &mut tv.failures);
+        tv.is_valid = tv.failures.is_empty();
+        tv
+    }
+
+    /// F-DATA-QUALITY-007 (PMAT-889): reject a 2-D output-projection weight that
+    /// has at least one fully-zero (L2 ~ 0) OUTPUT ROW.
+    ///
+    /// For an `lm_head`/`output` `[vocab, hidden]` a zero row makes that token's
+    /// logit structurally a constant (its dot-product against any hidden state is
+    /// 0) — a dead token that can never be emitted with positive evidence. For an
+    /// `embed_tokens` `[vocab, hidden]` a zero row is a dead/unreachable token
+    /// vector. The whole-tensor density / L2 / constant gates MISS this because a
+    /// single zero row is a tiny fraction of a large tensor. llama.cpp / Ollama
+    /// load and run such a model silently; apr fails closed.
+    ///
+    /// Scope (false-positive safety): the gate fires ONLY when (a) the shape is
+    /// 2-D and (b) the tensor's ROLE is an output projection whose zero row is
+    /// unambiguously corrupt — `lm_head` / `embed` / `output`. Other roles (q/k/v,
+    /// gate/up/down, norms, biases, generic buffers) are intentionally excluded to
+    /// avoid false positives on tensors where a structurally-zero row may be valid.
+    fn check_dead_output_row(
+        name: &str,
+        data: &[f32],
+        shape: &[usize],
+        failures: &mut Vec<String>,
+    ) {
+        // Gate only on 2-D output-projection roles.
+        if shape.len() != 2 || !Self::is_output_projection_role(name) {
+            return;
+        }
+        let (out_units, in_dim) = (shape[0], shape[1]);
+        // Guard against shape/data inconsistency (a separate concern handled by
+        // shape gates elsewhere) — only scan when the flat length matches.
+        if in_dim == 0 || out_units == 0 || out_units * in_dim != data.len() {
+            return;
+        }
+        for row in 0..out_units {
+            let start = row * in_dim;
+            let slice = &data[start..start + in_dim];
+            let sum_sq: f64 = slice.iter().map(|&v| f64::from(v) * f64::from(v)).sum();
+            let row_l2 = sum_sq.sqrt() as f32;
+            if row_l2 < 1e-6 {
+                failures.push(format!(
+                    "[F-DATA-QUALITY-007] DEAD OUTPUT ROW: output row {row}/{out_units} has \
+                     L2~0 (dead token — logit is structurally constant; the incumbents load \
+                     and run this silently)"
+                ));
+                // One representative dead row is sufficient to fail closed.
+                break;
+            }
+        }
+    }
+
+    /// Roles whose fully-zero output row is unambiguously corrupt (PMAT-889).
+    /// Conservative allow-list: lm_head / output head and the token embedding.
+    fn is_output_projection_role(name: &str) -> bool {
+        let n = name.to_lowercase();
+        n.contains("lm_head")
+            || n == "output.weight"
+            || n.ends_with("output.weight")
+            || n.contains("embed")
+            || n.contains("tok_embeddings")
+            || n.contains("wte")
     }
 
     fn compute_tensor_validation(&self, name: &str, data: &[f32]) -> TensorValidation {


### PR DESCRIPTION
## Pillar-4 fail-closed correctness BEAT (PMAT-889)

**apr now provably REJECTS a model that llama.cpp / Ollama silently load and run.** This is the mission-headline pattern that already won with the zeroed-ffn beat (PMAT-744).

### The defect
A weight tensor with one fully-ZERO output ROW — e.g. an `lm_head.weight` `[vocab, hidden]` where one vocab row is all zeros, so that token's logit is structurally constant (its dot-product against any hidden state is 0 → a dead token that can never be emitted with positive evidence), or an `embed_tokens.weight` zero row (a dead/unreachable token vector) — passed `apr validate` **clean** until now.

The existing whole-tensor data-quality gates **F-DATA-QUALITY-001..005** (zero density under a 50%/80% gate, global L2, constant) all **MISS** this, because one zero row is a tiny fraction of a large tensor. The incumbents load and run it silently with zero error lines.

### The fix (F-DATA-QUALITY-007)
Adds a shape-aware validation path `compute_tensor_validation_with_shape` (in `crates/aprender-core/src/format/rosetta/validate_inspect.rs`) that runs the existing whole-tensor gates and then, for **2-D output-projection roles only** (`lm_head` / `output` / token `embed` — conservatively scoped to avoid false positives), interprets the dequantized flat f32 as `[out_units, in_dim]` row-major, scans each output row's L2 norm, and rejects with rule id `F-DATA-QUALITY-007` when any row L2 < 1e-6. Wired into the `apr validate` APR path (`validate_apr`), which supplies the on-disk 2-D shape. Non-2-D and non-output-role tensors are untouched.

### RED → GREEN (falsifiers in `computation.rs`)
- `pmat889_red_dead_output_row_lm_head_rejected` — dead lm_head row → rejected
- `pmat889_red_dead_output_row_embed_rejected` — dead embedding row → rejected
- `pmat889_fp_bound_healthy_lm_head_accepted` — healthy lm_head still validates (FP bound)
- `pmat889_fp_bound_non_output_role_zero_row_accepted_by_dead_row_gate` — gate scoped to output roles (no FP on a generic tensor)

Both RED tests **failed on current main** (apr ACCEPTED the dead-row model, `failures=[]`); all 4 pass after the per-output-row scan.

### Verification
- RED confirmed (`2 failed` on the no-op stub), GREEN confirmed (`4 passed`)
- `cargo test -p aprender-core --lib`: 13956 passed. The only 2 failures are `citl::*cargo_mode_detects*` nested-cargo tests, which PASS in isolation on pristine main — load-sensitive flakes, unrelated to this `format/rosetta` change
- `cargo clippy -p aprender-core --lib -- -D warnings`: clean
- `cargo fmt --all --check`: my files already formatted
- `pv lint contracts/`: **PASS** (0 errors); this contract is clean

### Contract
Adds `OBLIG-DATA-QUALITY-007-DEAD-OUTPUT-ROW` + `OBLIG-DATA-QUALITY-007-NO-FALSE-POSITIVE` proof_obligations and `FALSIFY-BEAT-DATA-QUALITY-007-DEAD-ROW` to `contracts/apr-fail-closed-garbage-beat-v1.yaml` (the same contract holding F-DATA-QUALITY-001..005).

🤖 Generated with [Claude Code](https://claude.com/claude-code)