### PR TITLE
feat(classification): LDA + QDA estimators with sklearn parity (LAPACK-free Cholesky) — F-{QDA,LDA}-PARITY (PMAT-892)

### DIFF
--- a/contracts/discriminant-analysis-v1.yaml
+++ b/contracts/discriminant-analysis-v1.yaml
@@ -1,0 +1,147 @@
+metadata:
+  version: 1.0.0
+  created: '2026-06-22'
+  author: PAIML Engineering
+  description: Linear and Quadratic Discriminant Analysis — Gaussian classifiers with sklearn parity (LAPACK-free Cholesky)
+  references:
+  - 'Hastie, Tibshirani, Friedman (2009) ESL, §4.3 Linear Discriminant Analysis'
+  - 'Murphy (2012) Machine Learning: A Probabilistic Perspective, §4.2'
+  - 'scikit-learn discriminant_analysis: LinearDiscriminantAnalysis(solver=lsqr), QuadraticDiscriminantAnalysis(reg_param=0)'
+equations:
+  qda_log_likelihood:
+    formula: log P(x | C_k) = -0.5 (d ln(2π) + ln|Σ_k| + (x-μ_k)ᵀ Σ_k⁻¹ (x-μ_k))
+    domain: x ∈ ℝ^d, μ_k ∈ ℝ^d, Σ_k ∈ ℝ^{d×d} positive-definite
+    codomain: log-likelihood ∈ ℝ (finite for finite x and PSD Σ_k)
+    invariants:
+    - ln|Σ_k| computed as 2·Σ ln(L_ii) from the Cholesky factor Σ_k = L Lᵀ
+    - Mahalanobis term (x-μ_k)ᵀ Σ_k⁻¹ (x-μ_k) ≥ 0 via the triangular solve L z = (x-μ_k), ‖z‖²
+    - Log-likelihood is finite when Σ_k is positive-definite
+    preconditions:
+    - input.len() > 0
+    - input.iter().all(|v| v.is_finite())
+    lean_theorem: Theorems.Qda_Log_Likelihood
+  qda_class_covariance:
+    formula: 'Σ_k = Σ_{i where y_i=k} (x_i - μ_k)(x_i - μ_k)ᵀ / (n_k - 1)'
+    domain: class k with n_k ≥ 2 samples in ℝ^d
+    codomain: Σ_k ∈ ℝ^{d×d} symmetric positive-semidefinite
+    invariants:
+    - Σ_k is symmetric
+    - Cholesky factor of Σ_k exists (PSD), with a small diagonal ridge retried if non-PD
+    - Unbiased estimator (denominator n_k - 1) matches sklearn QDA reg_param=0
+    preconditions:
+    - input.len() > 0
+    - input.iter().all(|v| v.is_finite())
+    lean_theorem: Theorems.Qda_Class_Covariance
+  lda_decision_function:
+    formula: f_k(x) = w_kᵀ x + b_k, with Σ_pooled w_k = μ_k and b_k = -0.5 w_kᵀ μ_k + ln P(C_k)
+    domain: x ∈ ℝ^d, pooled within-class covariance Σ_pooled ∈ ℝ^{d×d} positive-definite
+    codomain: decision values ∈ ℝ^K
+    invariants:
+    - w_k solved via Cholesky factorization of Σ_pooled (LAPACK-free, no SVD/BLAS)
+    - Σ_pooled is the biased pooled within-class covariance (/n), matching sklearn solver=lsqr
+    - Predicted class = argmax_k f_k(x)
+    - Deterministic for same input
+    preconditions:
+    - input.len() > 0
+    - input.iter().all(|v| v.is_finite())
+    lean_theorem: Theorems.Lda_Decision_Function
+proof_obligations:
+- type: invariant
+  property: QDA predict-parity with scikit-learn
+  formal: F-QDA-PARITY-001 — QDA.predict equals sklearn QuadraticDiscriminantAnalysis(reg_param=0) labels exactly and predict_proba within 1e-4 on the pinned fixture
+  applies_to: all
+- type: invariant
+  property: QDA per-class covariance positive-definite (Cholesky exists)
+  formal: F-QDA-FIT-PSD-002 — every fitted class covariance admits a Cholesky factor (PSD), so log-likelihood and predict_proba are finite
+  applies_to: all
+- type: invariant
+  property: LDA predict-parity with scikit-learn
+  formal: F-LDA-PARITY-004 — LDA(lsqr).predict equals sklearn LinearDiscriminantAnalysis(solver=lsqr) labels exactly and coef_/intercept_/predict_proba match the pinned fixture
+  applies_to: all
+- type: invariant
+  property: Prediction deterministic
+  formal: predict(x) = predict(x) for all x (both LDA and QDA)
+  applies_to: all
+- type: invariant
+  property: Posterior probability valid
+  formal: predict_proba rows sum to 1 and each entry ∈ [0, 1]
+  applies_to: all
+falsification_tests:
+- id: F-QDA-PARITY-001
+  rule: QDA predict + predict_proba match pinned scikit-learn QDA(reg_param=0)
+  prediction: QDA.predict equals sklearn labels exactly; predict_proba within 1e-4 on ambiguous rows
+  test: cargo test -p aprender-core --lib falsify_qda_parity_001_predict_and_proba_match_sklearn
+  if_fails: Per-class covariance denominator wrong (n vs n-1), Cholesky/log-det error, or softmax bug
+- id: F-QDA-FIT-PSD-002
+  rule: Each fitted QDA class covariance is positive-definite (Cholesky factor exists)
+  prediction: fit succeeds and predict_proba is finite for every class on the fixture
+  test: cargo test -p aprender-core --lib falsify_qda_fit_psd_002_per_class_cholesky_finite_loglik
+  if_fails: Covariance non-PSD without ridge retry, or NaN/Inf log-likelihood from a bad log-det
+- id: F-LDA-PARITY-004
+  rule: LDA(lsqr) predict + coef_/intercept_ + predict_proba match pinned scikit-learn
+  prediction: LDA.predict equals sklearn labels exactly; coef_/intercept_/proba match the fixture
+  test: cargo test -p aprender-core --lib falsify_lda_parity_004_predict_coef_proba_match_sklearn
+  if_fails: Pooled covariance denominator wrong, cholesky_solve misuse, or intercept formula error
+- id: F-LDA-DECISION-005
+  rule: LDA decision_function matches sklearn and its argmax equals predict
+  prediction: decision values match pinned sklearn; argmax over decision equals the predicted class
+  test: cargo test -p aprender-core --lib falsify_lda_decision_function_matches_sklearn
+  if_fails: Decision function or argmax tie-break diverges from sklearn
+- id: F-DA-SEPARABLE-006
+  rule: Both estimators perfectly classify well-separated cluster centers
+  prediction: LDA and QDA both recover the class of each well-separated cluster center
+  test: cargo test -p aprender-core --lib falsify_da_separable_clusters_perfect_recall
+  if_fails: Likelihood/decision computation error or class-label mapping bug
+enforcement:
+  parity:
+    description: LDA and QDA predictions must match scikit-learn on the pinned fixture
+    check: contract_tests::F-QDA-PARITY-001, F-LDA-PARITY-004
+    severity: ERROR
+  psd_covariance:
+    description: Every fitted class covariance must be positive-definite
+    check: contract_tests::F-QDA-FIT-PSD-002
+    severity: ERROR
+kani_harnesses:
+- id: KANI-DA-001
+  obligation: F-QDA-PARITY-001
+  property: QDA predict matches scikit-learn labels on the pinned fixture
+  bound: 8
+  strategy: stub_float
+  solver: cadical
+  harness: verify_qda_predict_parity
+- id: KANI-DA-002
+  obligation: F-QDA-FIT-PSD-002
+  property: Each fitted QDA class covariance is positive-definite (Cholesky exists)
+  bound: 8
+  strategy: stub_float
+  solver: cadical
+  harness: verify_qda_covariance_psd
+- id: KANI-DA-003
+  obligation: F-LDA-PARITY-004
+  property: LDA predict matches scikit-learn labels on the pinned fixture
+  bound: 8
+  strategy: stub_float
+  solver: cadical
+  harness: verify_lda_predict_parity
+- id: KANI-DA-004
+  obligation: Posterior probability valid
+  property: predict_proba rows sum to 1 and each entry in [0, 1]
+  bound: 8
+  strategy: exhaustive
+- id: KANI-DA-005
+  obligation: Prediction deterministic
+  property: predict(x) = predict(x) for all x
+  bound: 8
+  strategy: exhaustive
+qa_gate:
+  id: F-DA-001
+  name: Discriminant Analysis Contract
+  description: LDA + QDA sklearn-parity and PSD-covariance quality gate
+  checks:
+  - qda_predict_parity
+  - qda_covariance_psd
+  - lda_predict_parity
+  - lda_decision_function
+  - separable_perfect_recall
+  pass_criteria: All 5 falsification tests pass (predict-parity + per-class Cholesky PSD)
+  falsification: Use biased covariance for QDA or unbiased pooled covariance for LDA (breaks sklearn parity)

--- a/crates/aprender-core/src/classification/discriminant_analysis.rs
+++ b/crates/aprender-core/src/classification/discriminant_analysis.rs
@@ -1,0 +1,605 @@
+//! Discriminant Analysis classifiers: LDA and QDA.
+//!
+//! Mirrors scikit-learn's `discriminant_analysis` module, implemented LAPACK-free
+//! via the same `Matrix::cholesky_solve` that `LinearRegression` uses (no SVD,
+//! no col-major / BLAS path). Both estimators are pure-Rust O(n·d²) per-class-stats
+//! + scalar d×d Cholesky — the shape that wins GaussianNB 4.91× / LinReg 1.78×.
+//!
+//! Contract: `contracts/discriminant-analysis-v1.yaml`
+//!
+//! # Estimators
+//!
+//! - [`QuadraticDiscriminantAnalysis`] — one covariance PER class. Predicts via the
+//!   per-class multivariate-Gaussian log-likelihood (log-det from the Cholesky
+//!   diagonal + Mahalanobis distance from a triangular solve) plus the log-prior.
+//!   Parity target: sklearn `QuadraticDiscriminantAnalysis(reg_param=0.0)`, which
+//!   uses the unbiased (`/(n_c − 1)`) per-class covariance.
+//! - [`LinearDiscriminantAnalysis`] — one POOLED (shared) covariance across classes,
+//!   class linear coefficients via `cholesky_solve` on that pooled covariance.
+//!   Parity target: sklearn `LinearDiscriminantAnalysis(solver='lsqr', shrinkage=None)`,
+//!   which uses the biased (`/n`) pooled within-class covariance.
+//!
+//! Honest speed note: the LAPACK-free speed edge holds vs sklearn `solver='lsqr'`
+//! (LDA) and `reg_param`-regularized QDA (sklearn runs a full SVD per class). It does
+//! NOT claim to beat sklearn's `svd` default LDA solver. Primary value is sklearn
+//! parity + filling the previously-missing LDA/QDA gap.
+
+use crate::error::Result;
+use crate::primitives::{Matrix, Vector};
+
+/// Quadratic Discriminant Analysis classifier.
+///
+/// Fits one Gaussian per class with its own covariance matrix, so decision
+/// boundaries are quadratic. Each class covariance is factored with Cholesky;
+/// prediction uses the per-class Gaussian log-likelihood + log-prior, and
+/// [`predict`](Self::predict) returns the argmax class.
+///
+/// Matches scikit-learn `QuadraticDiscriminantAnalysis(reg_param=0.0)`:
+/// the per-class covariance is **unbiased** (`Σ (x−μ)(x−μ)ᵀ / (n_c − 1)`).
+///
+/// # Example
+///
+/// ```
+/// use aprender::classification::QuadraticDiscriminantAnalysis;
+/// use aprender::primitives::Matrix;
+///
+/// let x = Matrix::from_vec(6, 2, vec![
+///     0.0, 0.0,  0.5, 0.2,  0.2, 0.6,   // class 0
+///     5.0, 5.0,  5.4, 4.8,  4.7, 5.3,   // class 1
+/// ]).expect("6x2 matrix");
+/// let y = vec![0, 0, 0, 1, 1, 1];
+///
+/// let mut model = QuadraticDiscriminantAnalysis::new();
+/// model.fit(&x, &y).expect("valid training data");
+/// let preds = model.predict(&x).expect("model is fitted");
+/// assert_eq!(preds, vec![0, 0, 0, 1, 1, 1]);
+/// ```
+#[derive(Debug, Clone)]
+pub struct QuadraticDiscriminantAnalysis {
+    /// Sorted unique class labels.
+    classes: Option<Vec<usize>>,
+    /// Per-class mean vectors: `means[class][feature]`.
+    means: Option<Vec<Vec<f32>>>,
+    /// Per-class log-prior: `log_priors[class]`.
+    log_priors: Option<Vec<f32>>,
+    /// Per-class lower-triangular Cholesky factor `L` (row-major `d×d`) of the
+    /// class covariance: `Σ_c = L Lᵀ`.
+    chol: Option<Vec<Vec<f32>>>,
+    /// Per-class log-determinant of `Σ_c` = `2·Σ ln(L_ii)`.
+    log_det: Option<Vec<f32>>,
+    /// Regularization added to the covariance diagonal if the raw covariance is
+    /// not positive-definite (a small ridge), retried before erroring.
+    reg_param: f32,
+}
+
+impl QuadraticDiscriminantAnalysis {
+    /// Creates a new QDA classifier (no covariance regularization by default,
+    /// matching sklearn `reg_param=0.0`).
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            classes: None,
+            means: None,
+            log_priors: None,
+            chol: None,
+            log_det: None,
+            reg_param: 0.0,
+        }
+    }
+
+    /// Sets the covariance-diagonal regularization (ridge) used when a raw class
+    /// covariance is not positive-definite. The ridge is `reg_param · mean(diag)`.
+    #[must_use]
+    pub fn with_reg_param(mut self, reg_param: f32) -> Self {
+        self.reg_param = reg_param;
+        self
+    }
+
+    /// Returns the sorted unique class labels (after fitting).
+    #[must_use]
+    pub fn classes(&self) -> Option<&[usize]> {
+        self.classes.as_deref()
+    }
+
+    /// Fits one Gaussian per class.
+    ///
+    /// For each class `c`: computes the mean, the unbiased covariance
+    /// `Σ_c = Σ_i (x_i − μ_c)(x_i − μ_c)ᵀ / (n_c − 1)`, and its lower Cholesky
+    /// factor `L_c`. If `Σ_c` is not positive-definite, a small ridge
+    /// (`reg_param · mean(diag)`, or `1e-6 · mean(diag)` when `reg_param == 0`)
+    /// is added to the diagonal and the factorization is retried; it errors only
+    /// if still non-PSD.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if X/y dimensions disagree, the data is empty, there are
+    /// fewer than 2 classes, any class has fewer than 2 samples, or a class
+    /// covariance remains non-PSD even after regularization.
+    pub fn fit(&mut self, x: &Matrix<f32>, y: &[usize]) -> Result<()> {
+        let (n_samples, n_features) = x.shape();
+        if n_samples == 0 {
+            return Err("Cannot fit with empty data".into());
+        }
+        if y.len() != n_samples {
+            return Err("Number of samples in X and y must match".into());
+        }
+
+        let classes = unique_sorted(y);
+        if classes.len() < 2 {
+            return Err("Need at least 2 classes".into());
+        }
+
+        let mut means = Vec::with_capacity(classes.len());
+        let mut log_priors = Vec::with_capacity(classes.len());
+        let mut chol = Vec::with_capacity(classes.len());
+        let mut log_det = Vec::with_capacity(classes.len());
+
+        for &class_label in &classes {
+            let rows: Vec<usize> = (0..n_samples).filter(|&i| y[i] == class_label).collect();
+            let n_c = rows.len();
+            if n_c < 2 {
+                return Err("Each class needs at least 2 samples for a covariance".into());
+            }
+
+            let mean = class_mean(x, &rows, n_features);
+            // Unbiased covariance (sklearn QDA reg_param=0 uses /(n_c - 1)).
+            let cov = class_covariance(x, &rows, &mean, n_features, (n_c - 1) as f32);
+
+            let l = self.cholesky_with_ridge(&cov, n_features)?;
+            let ld = log_det_from_cholesky(&l, n_features);
+
+            means.push(mean);
+            log_priors.push((n_c as f32 / n_samples as f32).ln());
+            chol.push(l);
+            log_det.push(ld);
+        }
+
+        self.classes = Some(classes);
+        self.means = Some(means);
+        self.log_priors = Some(log_priors);
+        self.chol = Some(chol);
+        self.log_det = Some(log_det);
+        Ok(())
+    }
+
+    /// Cholesky factor of `cov`, retrying once with a diagonal ridge if non-PSD.
+    fn cholesky_with_ridge(&self, cov: &[f32], d: usize) -> Result<Vec<f32>> {
+        if let Some(l) = cholesky_lower(cov, d) {
+            return Ok(l);
+        }
+        // Regularize the diagonal with a small ridge and retry.
+        let mean_diag = (0..d).map(|i| cov[i * d + i]).sum::<f32>() / d as f32;
+        let ridge = if self.reg_param > 0.0 {
+            self.reg_param * mean_diag
+        } else {
+            1e-6 * mean_diag.max(1e-12)
+        };
+        let mut reg = cov.to_vec();
+        for i in 0..d {
+            reg[i * d + i] += ridge;
+        }
+        cholesky_lower(&reg, d).ok_or_else(|| {
+            "Class covariance is not positive-definite even after regularization".into()
+        })
+    }
+
+    /// Per-class log-likelihood + log-prior log-posteriors for one sample.
+    fn log_posteriors_row(&self, x: &Matrix<f32>, row: usize) -> Vec<f32> {
+        let means = self.means.as_ref().expect("fitted");
+        let chol = self.chol.as_ref().expect("fitted");
+        let log_det = self.log_det.as_ref().expect("fitted");
+        let log_priors = self.log_priors.as_ref().expect("fitted");
+        let d = means[0].len();
+        let two_pi_term = d as f32 * (2.0 * std::f32::consts::PI).ln();
+
+        let mut out = Vec::with_capacity(means.len());
+        for c in 0..means.len() {
+            // diff = x - mu_c
+            let mut diff = vec![0.0f32; d];
+            for (j, dj) in diff.iter_mut().enumerate() {
+                *dj = x.get(row, j) - means[c][j];
+            }
+            // Mahalanobis: solve L z = diff (forward substitution), then ||z||².
+            let z = forward_substitute(&chol[c], &diff, d);
+            let mahal: f32 = z.iter().map(|&v| v * v).sum();
+            // log N(x; mu, Sigma) + log prior
+            let lp = -0.5 * (two_pi_term + log_det[c] + mahal) + log_priors[c];
+            out.push(lp);
+        }
+        out
+    }
+
+    /// Predicts the class label (argmax log-posterior) for each sample.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the model is not fitted or feature dimensions mismatch.
+    pub fn predict(&self, x: &Matrix<f32>) -> Result<Vec<usize>> {
+        let classes = self.classes.as_ref().ok_or("Model not fitted")?;
+        let means = self.means.as_ref().ok_or("Model not fitted")?;
+        let (n_samples, n_features) = x.shape();
+        if n_features != means[0].len() {
+            return Err("Feature dimension mismatch".into());
+        }
+        let mut preds = Vec::with_capacity(n_samples);
+        for row in 0..n_samples {
+            let lp = self.log_posteriors_row(x, row);
+            preds.push(classes[argmax(&lp)]);
+        }
+        Ok(preds)
+    }
+
+    /// Returns the softmax of the per-class log-posteriors for each sample.
+    ///
+    /// Each inner vector is in the class order returned by [`classes`](Self::classes).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the model is not fitted or feature dimensions mismatch.
+    pub fn predict_proba(&self, x: &Matrix<f32>) -> Result<Vec<Vec<f32>>> {
+        let means = self.means.as_ref().ok_or("Model not fitted")?;
+        let (n_samples, n_features) = x.shape();
+        if n_features != means[0].len() {
+            return Err("Feature dimension mismatch".into());
+        }
+        let mut out = Vec::with_capacity(n_samples);
+        for row in 0..n_samples {
+            out.push(softmax(&self.log_posteriors_row(x, row)));
+        }
+        Ok(out)
+    }
+}
+
+impl Default for QuadraticDiscriminantAnalysis {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Linear Discriminant Analysis classifier (`solver='lsqr'`, no shrinkage).
+///
+/// Fits one POOLED (shared) within-class covariance across all classes, so the
+/// decision boundaries are linear. The per-class linear coefficients are obtained
+/// by solving `Σ_pooled · wᵀ = μ_cᵀ` with `Matrix::cholesky_solve` (LAPACK-free),
+/// and the decision function is `f_c(x) = wᵀ x + b_c` with
+/// `b_c = −0.5 · wᵀμ_c + ln P(c)`.
+///
+/// Matches scikit-learn `LinearDiscriminantAnalysis(solver='lsqr', shrinkage=None)`:
+/// the pooled within-class covariance is **biased** (`Σ_c Σ_i (x−μ_c)(x−μ_c)ᵀ / n`).
+///
+/// # Example
+///
+/// ```
+/// use aprender::classification::LinearDiscriminantAnalysis;
+/// use aprender::primitives::Matrix;
+///
+/// let x = Matrix::from_vec(6, 2, vec![
+///     0.0, 0.0,  0.5, 0.2,  0.2, 0.6,   // class 0
+///     5.0, 5.0,  5.4, 4.8,  4.7, 5.3,   // class 1
+/// ]).expect("6x2 matrix");
+/// let y = vec![0, 0, 0, 1, 1, 1];
+///
+/// let mut model = LinearDiscriminantAnalysis::new();
+/// model.fit(&x, &y).expect("valid training data");
+/// let preds = model.predict(&x).expect("model is fitted");
+/// assert_eq!(preds, vec![0, 0, 0, 1, 1, 1]);
+/// ```
+#[derive(Debug, Clone)]
+pub struct LinearDiscriminantAnalysis {
+    /// Sorted unique class labels.
+    classes: Option<Vec<usize>>,
+    /// Per-class linear coefficients: `coef[class][feature]`.
+    coef: Option<Vec<Vec<f32>>>,
+    /// Per-class intercept: `intercept[class]`.
+    intercept: Option<Vec<f32>>,
+}
+
+impl LinearDiscriminantAnalysis {
+    /// Creates a new LDA classifier (`solver='lsqr'`, no shrinkage).
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            classes: None,
+            coef: None,
+            intercept: None,
+        }
+    }
+
+    /// Returns the sorted unique class labels (after fitting).
+    #[must_use]
+    pub fn classes(&self) -> Option<&[usize]> {
+        self.classes.as_deref()
+    }
+
+    /// Returns the per-class linear coefficients (after fitting).
+    #[must_use]
+    pub fn coef(&self) -> Option<&Vec<Vec<f32>>> {
+        self.coef.as_ref()
+    }
+
+    /// Returns the per-class intercepts (after fitting).
+    #[must_use]
+    pub fn intercept(&self) -> Option<&[f32]> {
+        self.intercept.as_deref()
+    }
+
+    /// Fits the pooled-covariance LDA model.
+    ///
+    /// Computes the per-class means, the biased pooled within-class covariance
+    /// `Σ_pooled = Σ_c Σ_i (x_i − μ_c)(x_i − μ_c)ᵀ / n`, then solves
+    /// `Σ_pooled · w_cᵀ = μ_cᵀ` per class via `cholesky_solve`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if X/y dimensions disagree, the data is empty, there are
+    /// fewer than 2 classes, or the pooled covariance is not positive-definite
+    /// (singular within-class scatter).
+    pub fn fit(&mut self, x: &Matrix<f32>, y: &[usize]) -> Result<()> {
+        let (n_samples, n_features) = x.shape();
+        if n_samples == 0 {
+            return Err("Cannot fit with empty data".into());
+        }
+        if y.len() != n_samples {
+            return Err("Number of samples in X and y must match".into());
+        }
+
+        let classes = unique_sorted(y);
+        if classes.len() < 2 {
+            return Err("Need at least 2 classes".into());
+        }
+
+        // Per-class means + accumulate the pooled within-class scatter.
+        let mut means = Vec::with_capacity(classes.len());
+        let mut log_priors = Vec::with_capacity(classes.len());
+        let mut scatter = vec![0.0f32; n_features * n_features];
+
+        for &class_label in &classes {
+            let rows: Vec<usize> = (0..n_samples).filter(|&i| y[i] == class_label).collect();
+            let n_c = rows.len();
+            let mean = class_mean(x, &rows, n_features);
+            for &i in &rows {
+                for a in 0..n_features {
+                    let da = x.get(i, a) - mean[a];
+                    for b in 0..n_features {
+                        let db = x.get(i, b) - mean[b];
+                        scatter[a * n_features + b] += da * db;
+                    }
+                }
+            }
+            log_priors.push((n_c as f32 / n_samples as f32).ln());
+            means.push(mean);
+        }
+
+        // Biased pooled within-class covariance: scatter / n (sklearn _class_cov).
+        let inv_n = 1.0 / n_samples as f32;
+        let cov_data: Vec<f32> = scatter.iter().map(|&v| v * inv_n).collect();
+        let cov = Matrix::from_vec(n_features, n_features, cov_data)
+            .map_err(Into::<crate::error::AprenderError>::into)?;
+
+        // Per-class coefficients: solve Sigma_pooled * w_c = mu_c (cholesky_solve).
+        let mut coef = Vec::with_capacity(classes.len());
+        let mut intercept = Vec::with_capacity(classes.len());
+        for c in 0..classes.len() {
+            let mu = Vector::from_vec(means[c].clone());
+            let w = cov
+                .cholesky_solve(&mu)
+                .map_err(Into::<crate::error::AprenderError>::into)?;
+            let w_vec: Vec<f32> = (0..n_features).map(|j| w[j]).collect();
+            // intercept = -0.5 * w . mu + ln(prior)
+            let dot: f32 = (0..n_features).map(|j| w_vec[j] * means[c][j]).sum();
+            intercept.push(-0.5 * dot + log_priors[c]);
+            coef.push(w_vec);
+        }
+
+        self.classes = Some(classes);
+        self.coef = Some(coef);
+        self.intercept = Some(intercept);
+        Ok(())
+    }
+
+    /// Computes the per-class decision function `f_c(x) = w_cᵀ x + b_c`
+    /// for one sample row.
+    fn decision_row(&self, x: &Matrix<f32>, row: usize) -> Vec<f32> {
+        let coef = self.coef.as_ref().expect("fitted");
+        let intercept = self.intercept.as_ref().expect("fitted");
+        let d = coef[0].len();
+        (0..coef.len())
+            .map(|c| {
+                let mut acc = intercept[c];
+                for j in 0..d {
+                    acc += coef[c][j] * x.get(row, j);
+                }
+                acc
+            })
+            .collect()
+    }
+
+    /// Returns the per-class decision function values for each sample.
+    ///
+    /// Each inner vector is in the class order returned by [`classes`](Self::classes),
+    /// matching sklearn `LinearDiscriminantAnalysis.decision_function` for K > 2.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the model is not fitted or feature dimensions mismatch.
+    pub fn decision_function(&self, x: &Matrix<f32>) -> Result<Vec<Vec<f32>>> {
+        let coef = self.coef.as_ref().ok_or("Model not fitted")?;
+        let (n_samples, n_features) = x.shape();
+        if n_features != coef[0].len() {
+            return Err("Feature dimension mismatch".into());
+        }
+        Ok((0..n_samples)
+            .map(|row| self.decision_row(x, row))
+            .collect())
+    }
+
+    /// Predicts the class label (argmax decision function) for each sample.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the model is not fitted or feature dimensions mismatch.
+    pub fn predict(&self, x: &Matrix<f32>) -> Result<Vec<usize>> {
+        let classes = self.classes.as_ref().ok_or("Model not fitted")?;
+        let coef = self.coef.as_ref().ok_or("Model not fitted")?;
+        let (n_samples, n_features) = x.shape();
+        if n_features != coef[0].len() {
+            return Err("Feature dimension mismatch".into());
+        }
+        let mut preds = Vec::with_capacity(n_samples);
+        for row in 0..n_samples {
+            let dec = self.decision_row(x, row);
+            preds.push(classes[argmax(&dec)]);
+        }
+        Ok(preds)
+    }
+
+    /// Returns the softmax of the per-class decision values for each sample.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the model is not fitted or feature dimensions mismatch.
+    pub fn predict_proba(&self, x: &Matrix<f32>) -> Result<Vec<Vec<f32>>> {
+        let coef = self.coef.as_ref().ok_or("Model not fitted")?;
+        let (n_samples, n_features) = x.shape();
+        if n_features != coef[0].len() {
+            return Err("Feature dimension mismatch".into());
+        }
+        let mut out = Vec::with_capacity(n_samples);
+        for row in 0..n_samples {
+            out.push(softmax(&self.decision_row(x, row)));
+        }
+        Ok(out)
+    }
+}
+
+impl Default for LinearDiscriminantAnalysis {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Shared numeric helpers
+// ---------------------------------------------------------------------------
+
+/// Sorted unique class labels.
+fn unique_sorted(y: &[usize]) -> Vec<usize> {
+    let mut c = y.to_vec();
+    c.sort_unstable();
+    c.dedup();
+    c
+}
+
+/// Mean feature vector over the given sample rows.
+fn class_mean(x: &Matrix<f32>, rows: &[usize], n_features: usize) -> Vec<f32> {
+    let mut mean = vec![0.0f32; n_features];
+    for &i in rows {
+        for (j, mj) in mean.iter_mut().enumerate() {
+            *mj += x.get(i, j);
+        }
+    }
+    let inv = 1.0 / rows.len() as f32;
+    for m in &mut mean {
+        *m *= inv;
+    }
+    mean
+}
+
+/// Covariance `Σ (x−μ)(x−μ)ᵀ / denom` (row-major `d×d`), `denom` = `n_c−1`
+/// (unbiased) or `n_c` (biased).
+fn class_covariance(
+    x: &Matrix<f32>,
+    rows: &[usize],
+    mean: &[f32],
+    n_features: usize,
+    denom: f32,
+) -> Vec<f32> {
+    let mut cov = vec![0.0f32; n_features * n_features];
+    for &i in rows {
+        for a in 0..n_features {
+            let da = x.get(i, a) - mean[a];
+            for b in 0..n_features {
+                let db = x.get(i, b) - mean[b];
+                cov[a * n_features + b] += da * db;
+            }
+        }
+    }
+    let inv = 1.0 / denom;
+    for v in &mut cov {
+        *v *= inv;
+    }
+    cov
+}
+
+/// Lower-triangular Cholesky factor `L` (row-major `d×d`) of a symmetric matrix,
+/// or `None` if not positive-definite.
+fn cholesky_lower(a: &[f32], n: usize) -> Option<Vec<f32>> {
+    let mut l = vec![0.0f32; n * n];
+    for i in 0..n {
+        for j in 0..=i {
+            let mut sum = 0.0;
+            if i == j {
+                for k in 0..j {
+                    sum += l[j * n + k] * l[j * n + k];
+                }
+                let diag = a[j * n + j] - sum;
+                if diag <= 0.0 {
+                    return None;
+                }
+                l[j * n + j] = diag.sqrt();
+            } else {
+                for k in 0..j {
+                    sum += l[i * n + k] * l[j * n + k];
+                }
+                l[i * n + j] = (a[i * n + j] - sum) / l[j * n + j];
+            }
+        }
+    }
+    Some(l)
+}
+
+/// Forward substitution: solve `L z = b` for lower-triangular `L` (row-major `n×n`).
+fn forward_substitute(l: &[f32], b: &[f32], n: usize) -> Vec<f32> {
+    let mut z = vec![0.0f32; n];
+    for i in 0..n {
+        let mut sum = 0.0;
+        for j in 0..i {
+            sum += l[i * n + j] * z[j];
+        }
+        z[i] = (b[i] - sum) / l[i * n + i];
+    }
+    z
+}
+
+/// Log-determinant of `Σ = L Lᵀ` from the Cholesky diagonal: `2·Σ ln(L_ii)`.
+fn log_det_from_cholesky(l: &[f32], n: usize) -> f32 {
+    2.0 * (0..n).map(|i| l[i * n + i].ln()).sum::<f32>()
+}
+
+/// Index of the maximum element (first on ties — matches sklearn `argmax`).
+fn argmax(v: &[f32]) -> usize {
+    let mut best = 0;
+    let mut best_v = f32::NEG_INFINITY;
+    for (i, &x) in v.iter().enumerate() {
+        if x > best_v {
+            best_v = x;
+            best = i;
+        }
+    }
+    best
+}
+
+/// Numerically-stable softmax (subtract max).
+fn softmax(logits: &[f32]) -> Vec<f32> {
+    let m = logits.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+    let mut exps: Vec<f32> = logits.iter().map(|&v| (v - m).exp()).collect();
+    let sum: f32 = exps.iter().sum();
+    for e in &mut exps {
+        *e /= sum;
+    }
+    exps
+}
+
+#[cfg(test)]
+#[path = "tests_discriminant_analysis.rs"]
+mod tests_discriminant_analysis;

--- a/crates/aprender-core/src/classification/mod.rs
+++ b/crates/aprender-core/src/classification/mod.rs
@@ -735,10 +735,12 @@ pub struct KNearestNeighbors {
 
 mod bernoulli_nb;
 mod complement_nb;
+mod discriminant_analysis;
 mod gaussian_nb;
 mod multinomial_nb;
 pub use bernoulli_nb::BernoulliNB;
 pub use complement_nb::ComplementNB;
+pub use discriminant_analysis::{LinearDiscriminantAnalysis, QuadraticDiscriminantAnalysis};
 pub use gaussian_nb::*;
 pub use multinomial_nb::MultinomialNB;
 mod linear_svm;

--- a/crates/aprender-core/src/classification/tests_discriminant_analysis.rs
+++ b/crates/aprender-core/src/classification/tests_discriminant_analysis.rs
@@ -1,0 +1,299 @@
+//! Parity falsifiers for LDA + QDA against pinned scikit-learn reference values.
+//!
+//! Reference values generated (RED gate, before implementation) with:
+//! `uv run --with scikit-learn --with numpy python ...` on the fixed 3-class,
+//! 2-feature, 15-row fixture below.
+//!
+//! - QDA  : `QuadraticDiscriminantAnalysis(reg_param=0.0)` — unbiased per-class cov.
+//! - LDA  : `LinearDiscriminantAnalysis(solver='lsqr', shrinkage=None)` — biased pooled cov.
+//!
+//! Contract: `contracts/discriminant-analysis-v1.yaml`
+//! (`F-QDA-PARITY-001`, `F-QDA-FIT-PSD-002`, `F-LDA-PARITY-004`).
+
+use super::{LinearDiscriminantAnalysis, QuadraticDiscriminantAnalysis};
+use crate::primitives::Matrix;
+
+/// Fixed 3-class fixture: 5 samples/class, 2 features (15 rows).
+fn fixture() -> (Matrix<f32>, Vec<usize>, Matrix<f32>) {
+    #[rustfmt::skip]
+    let x_train = Matrix::from_vec(15, 2, vec![
+        0.0, 0.0,  1.0, 0.5,  0.5, 1.0,  -0.5, 0.2,  0.3, -0.4,   // class 0 ~ (0,0)
+        3.0, 3.0,  3.5, 2.6,  2.6, 3.4,   3.2, 2.8,  2.8,  3.2,   // class 1 ~ (3,3)
+        0.0, 3.5,  0.5, 3.0, -0.4, 3.8,   0.3, 3.3,  0.1,  4.0,   // class 2 ~ (0,3.5)
+    ])
+    .expect("15x2 fixture");
+    let y_train = vec![0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2];
+    #[rustfmt::skip]
+    let x_test = Matrix::from_vec(5, 2, vec![
+        0.2, 0.2,   // near class 0
+        3.0, 3.0,   // near class 1
+        0.0, 3.5,   // near class 2
+        1.5, 1.8,   // ambiguous
+        1.2, 2.5,   // ambiguous (between 0 and 2)
+    ])
+    .expect("5x2 test");
+    (x_train, y_train, x_test)
+}
+
+// ---------------------------------------------------------------------------
+// QDA parity (F-QDA-PARITY-001)
+// ---------------------------------------------------------------------------
+
+/// F-QDA-PARITY-001: QDA `predict` must equal pinned sklearn labels EXACTLY,
+/// and `predict_proba` on the ambiguous rows within 1e-4 of pinned sklearn proba.
+#[test]
+fn falsify_qda_parity_001_predict_and_proba_match_sklearn() {
+    let (x_train, y_train, x_test) = fixture();
+    let mut qda = QuadraticDiscriminantAnalysis::new();
+    qda.fit(&x_train, &y_train).expect("QDA fit succeeds");
+
+    // Pinned sklearn QuadraticDiscriminantAnalysis(reg_param=0.0).predict
+    let expected_pred = vec![0usize, 1, 2, 0, 2];
+    let pred = qda.predict(&x_test).expect("QDA predict");
+    assert_eq!(
+        pred, expected_pred,
+        "QDA predict must match sklearn exactly"
+    );
+
+    // Pinned sklearn predict_proba on the two ambiguous rows (rows 3 and 4).
+    let proba = qda.predict_proba(&x_test).expect("QDA predict_proba");
+    // row 3: [0.9872614743, 0.0, 0.0127385257]
+    assert!(
+        (proba[3][0] - 0.9872614743).abs() < 1e-4,
+        "qda proba[3][0]={}",
+        proba[3][0]
+    );
+    assert!(
+        (proba[3][1] - 0.0).abs() < 1e-4,
+        "qda proba[3][1]={}",
+        proba[3][1]
+    );
+    assert!(
+        (proba[3][2] - 0.0127385257).abs() < 1e-4,
+        "qda proba[3][2]={}",
+        proba[3][2]
+    );
+    // row 4: [0.0081517123, 0.0, 0.9918482877]
+    assert!(
+        (proba[4][0] - 0.0081517123).abs() < 1e-4,
+        "qda proba[4][0]={}",
+        proba[4][0]
+    );
+    assert!(
+        (proba[4][1] - 0.0).abs() < 1e-4,
+        "qda proba[4][1]={}",
+        proba[4][1]
+    );
+    assert!(
+        (proba[4][2] - 0.9918482877).abs() < 1e-4,
+        "qda proba[4][2]={}",
+        proba[4][2]
+    );
+
+    // proba rows must be valid distributions.
+    for row in &proba {
+        let s: f32 = row.iter().sum();
+        assert!((s - 1.0).abs() < 1e-5, "qda proba row sums to {s}");
+        assert!(row.iter().all(|&p| (0.0..=1.0).contains(&p)));
+    }
+}
+
+/// F-QDA-FIT-PSD-002: each fitted class covariance is positive-definite
+/// (its Cholesky factor exists), so log-likelihood is finite — verified by
+/// finite, valid log-posteriors / proba on the fixture.
+#[test]
+fn falsify_qda_fit_psd_002_per_class_cholesky_finite_loglik() {
+    let (x_train, y_train, x_test) = fixture();
+    let mut qda = QuadraticDiscriminantAnalysis::new();
+    qda.fit(&x_train, &y_train)
+        .expect("QDA fit must succeed (each class cov PSD)");
+    assert_eq!(qda.classes(), Some(&[0usize, 1, 2][..]));
+
+    let proba = qda.predict_proba(&x_test).expect("QDA predict_proba");
+    for row in &proba {
+        assert!(
+            row.iter().all(|&p| p.is_finite()),
+            "non-finite proba implies non-PSD covariance / bad log-det"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// LDA parity (F-LDA-PARITY-004)
+// ---------------------------------------------------------------------------
+
+/// F-LDA-PARITY-004: LDA(lsqr) `predict` matches pinned sklearn labels EXACTLY,
+/// `coef_`/`intercept_` match sklearn, and `predict_proba` on the ambiguous row
+/// is within 1e-4 of pinned sklearn proba.
+#[test]
+fn falsify_lda_parity_004_predict_coef_proba_match_sklearn() {
+    let (x_train, y_train, x_test) = fixture();
+    let mut lda = LinearDiscriminantAnalysis::new();
+    lda.fit(&x_train, &y_train).expect("LDA fit succeeds");
+
+    // Pinned sklearn LinearDiscriminantAnalysis(solver='lsqr').predict
+    let expected_pred = vec![0usize, 1, 2, 2, 2];
+    let pred = lda.predict(&x_test).expect("LDA predict");
+    assert_eq!(
+        pred, expected_pred,
+        "LDA predict must match sklearn exactly"
+    );
+
+    // Pinned sklearn coef_ (per-class) and intercept_.
+    let coef = lda.coef().expect("fitted coef");
+    // class 0 coef: [2.1633121636, 2.2146565979]
+    assert!(
+        (coef[0][0] - 2.1633121636).abs() < 1e-3,
+        "lda coef[0][0]={}",
+        coef[0][0]
+    );
+    assert!(
+        (coef[0][1] - 2.2146565979).abs() < 1e-3,
+        "lda coef[0][1]={}",
+        coef[0][1]
+    );
+    // class 1 coef: [25.1021622589, 25.5792705404]
+    assert!(
+        (coef[1][0] - 25.1021622589).abs() < 1e-2,
+        "lda coef[1][0]={}",
+        coef[1][0]
+    );
+    assert!(
+        (coef[1][1] - 25.5792705404).abs() < 1e-2,
+        "lda coef[1][1]={}",
+        coef[1][1]
+    );
+    // class 2 coef: [5.1994797097, 25.6156066016]
+    assert!(
+        (coef[2][0] - 5.1994797097).abs() < 1e-2,
+        "lda coef[2][0]={}",
+        coef[2][0]
+    );
+    assert!(
+        (coef[2][1] - 25.6156066016).abs() < 1e-2,
+        "lda coef[2][1]={}",
+        coef[2][1]
+    );
+
+    let intercept = lda.intercept().expect("fitted intercept");
+    // intercept_: [-1.6677482277, -77.3717831103, -46.4420538929]
+    assert!(
+        (intercept[0] - (-1.6677482277)).abs() < 1e-2,
+        "lda intercept[0]={}",
+        intercept[0]
+    );
+    assert!(
+        (intercept[1] - (-77.3717831103)).abs() < 5e-2,
+        "lda intercept[1]={}",
+        intercept[1]
+    );
+    assert!(
+        (intercept[2] - (-46.4420538929)).abs() < 5e-2,
+        "lda intercept[2]={}",
+        intercept[2]
+    );
+
+    // Pinned sklearn predict_proba on the ambiguous row 3:
+    // [0.1016630464, 0.2175022585, 0.6808346951]
+    let proba = lda.predict_proba(&x_test).expect("LDA predict_proba");
+    assert!(
+        (proba[3][0] - 0.1016630464).abs() < 1e-4,
+        "lda proba[3][0]={}",
+        proba[3][0]
+    );
+    assert!(
+        (proba[3][1] - 0.2175022585).abs() < 1e-4,
+        "lda proba[3][1]={}",
+        proba[3][1]
+    );
+    assert!(
+        (proba[3][2] - 0.6808346951).abs() < 1e-4,
+        "lda proba[3][2]={}",
+        proba[3][2]
+    );
+
+    for row in &proba {
+        let s: f32 = row.iter().sum();
+        assert!((s - 1.0).abs() < 1e-5, "lda proba row sums to {s}");
+        assert!(row.iter().all(|&p| (0.0..=1.0).contains(&p)));
+    }
+}
+
+/// LDA `decision_function` matches pinned sklearn decision values on the
+/// well-separated rows (sanity that the linear discriminants are correct).
+#[test]
+fn falsify_lda_decision_function_matches_sklearn() {
+    let (x_train, y_train, x_test) = fixture();
+    let mut lda = LinearDiscriminantAnalysis::new();
+    lda.fit(&x_train, &y_train).expect("LDA fit");
+    let dec = lda.decision_function(&x_test).expect("decision_function");
+    // Pinned sklearn decision_function row 0: [-0.79215448, -67.23549655, -40.27903663]
+    assert!(
+        (dec[0][0] - (-0.79215448)).abs() < 1e-2,
+        "dec[0][0]={}",
+        dec[0][0]
+    );
+    assert!(
+        (dec[0][1] - (-67.23549655)).abs() < 1e-1,
+        "dec[0][1]={}",
+        dec[0][1]
+    );
+    assert!(
+        (dec[0][2] - (-40.27903663)).abs() < 1e-1,
+        "dec[0][2]={}",
+        dec[0][2]
+    );
+    // argmax of decision == predict
+    let pred = lda.predict(&x_test).expect("predict");
+    for (row, &p) in dec.iter().zip(pred.iter()) {
+        let am = row
+            .iter()
+            .enumerate()
+            .max_by(|a, b| a.1.partial_cmp(b.1).unwrap())
+            .map(|(i, _)| i)
+            .unwrap();
+        assert_eq!(am, p, "decision argmax must equal predicted class index");
+    }
+}
+
+/// Both estimators perfectly classify their own well-separated training clusters.
+#[test]
+fn falsify_da_separable_clusters_perfect_recall() {
+    let (x_train, y_train, _x_test) = fixture();
+    // Well-separated cluster centers (one per class).
+    let centers = Matrix::from_vec(3, 2, vec![0.0, 0.0, 3.0, 3.0, 0.0, 3.5]).expect("3x2");
+    let expected = vec![0usize, 1, 2];
+
+    let mut qda = QuadraticDiscriminantAnalysis::new();
+    qda.fit(&x_train, &y_train).expect("QDA fit");
+    assert_eq!(qda.predict(&centers).expect("qda predict"), expected);
+
+    let mut lda = LinearDiscriminantAnalysis::new();
+    lda.fit(&x_train, &y_train).expect("LDA fit");
+    assert_eq!(lda.predict(&centers).expect("lda predict"), expected);
+}
+
+/// Fit-time guards: empty data, mismatched lengths, and < 2 classes error.
+#[test]
+fn falsify_da_fit_guards_reject_bad_input() {
+    let x = Matrix::from_vec(3, 2, vec![0.0, 0.0, 1.0, 1.0, 2.0, 2.0]).expect("3x2");
+
+    // Single class -> error for both.
+    let mut qda = QuadraticDiscriminantAnalysis::new();
+    assert!(
+        qda.fit(&x, &[0, 0, 0]).is_err(),
+        "QDA must reject < 2 classes"
+    );
+    let mut lda = LinearDiscriminantAnalysis::new();
+    assert!(
+        lda.fit(&x, &[0, 0, 0]).is_err(),
+        "LDA must reject < 2 classes"
+    );
+
+    // Length mismatch.
+    let mut qda2 = QuadraticDiscriminantAnalysis::new();
+    assert!(
+        qda2.fit(&x, &[0, 1]).is_err(),
+        "QDA must reject len mismatch"
+    );
+}


### PR DESCRIPTION
## PMAT-892 — Pillar-1 Discriminant Analysis estimators (LDA + QDA)

Fills a named scikit-learn-parity gap: aprender had **no** `LinearDiscriminantAnalysis` or `QuadraticDiscriminantAnalysis`. Both estimators ship in ONE new module (`crates/aprender-core/src/classification/discriminant_analysis.rs`), mirroring sklearn's `discriminant_analysis.py`, implemented **LAPACK-free** via the same `Matrix::cholesky_solve` that `LinearRegression` uses (no SVD, no col-major/BLAS path).

### QuadraticDiscriminantAnalysis
- per-class mean + **unbiased** per-class covariance (`/(n_c − 1)`)
- fit factors each class covariance with Cholesky; a small diagonal ridge is retried if non-PSD, erroring only if still non-PSD (`F-QDA-FIT-PSD-002`)
- predict via per-class Gaussian log-likelihood (log-det from the Cholesky diagonal + Mahalanobis from a forward triangular solve) + log-prior
- `predict` = argmax log-posterior; `predict_proba` = softmax of log-posteriors
- parity target: sklearn `QuadraticDiscriminantAnalysis(reg_param=0.0)`

### LinearDiscriminantAnalysis (`solver='lsqr'`, shrinkage=None)
- one **biased** pooled within-class covariance (`/n`) across classes
- per-class coefficients via `cholesky_solve(Σ_pooled, μ_c)`
- `decision_function`/`predict`/`predict_proba` matching sklearn `LDA(solver='lsqr')`
- parity target: sklearn `LinearDiscriminantAnalysis(solver='lsqr', shrinkage=None)`

### Honest speed note
The LAPACK-free edge holds vs `solver='lsqr'` (LDA) and `reg_param`-regularized QDA (sklearn runs a full SVD per class). It does **NOT** claim to beat sklearn's `svd` default LDA solver. Primary value is **sklearn parity + filling the previously-missing LDA/QDA gap** (same O(n·d²) per-class-stats + scalar d×d Cholesky shape that won GaussianNB 4.91× / LinReg 1.78×).

### RED → GREEN (parity falsifiers first)
Parity falsifiers written **before** implementation against PINNED scikit-learn reference values generated with `uv run --with scikit-learn --with numpy` on a fixed 3-class, 2-feature, 15-row fixture.

- RED: `grep -ri 'DiscriminantAnalysis' crates/` exited 1 (types absent) on main.
- GREEN: `predict` matches sklearn **EXACTLY** (QDA `[0,1,2,0,2]`, LDA `[0,1,2,2,2]`); `predict_proba` within `1e-4`; LDA `coef_`/`intercept_` match.

### Contract
`contracts/discriminant-analysis-v1.yaml` (kernel) with proof obligations:
- `F-QDA-PARITY-001` — QDA predict-parity
- `F-QDA-FIT-PSD-002` — per-class Cholesky PSD
- `F-LDA-PARITY-004` — LDA predict-parity
- plus `F-LDA-DECISION-005`, `F-DA-SEPARABLE-006`

Each falsification `test:` is a single-line `cargo test` ref. Validated with **both** `pv lint contracts/` (PASS, 0 errors) **and** `cargo test -p aprender-contracts --lib lint::` (191 passed). Library estimator only — no clap/CLI wiring needed.

### Tests
`cargo test -p aprender-core --lib` → **13960 passed; 0 failed; 2 ignored**. 6 new DA parity tests + 2 doctests. `cargo fmt --all --check` clean, `cargo clippy -p aprender-core --lib -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)