### PR TITLE
fix(serve): reject NaN/Inf quantized weights at GGUF/APR load — OBLIG-GGUF-LOAD-NANINF (PMAT-895)

### DIFF
--- a/contracts/apr-load-fail-closed-truncated-v1.yaml
+++ b/contracts/apr-load-fail-closed-truncated-v1.yaml
@@ -1,7 +1,7 @@
 contract: apr-load-fail-closed-truncated
 metadata:
   kind: pattern
-  version: "1.0.0"
+  version: "1.1.0"
   description: >
     realizar's GGUF loader must FAIL CLOSED on a truncated/corrupt model. The
     chokepoint OwnedQuantizedTensor::from_ref_with_dims silently substitutes an empty
@@ -16,13 +16,25 @@ metadata:
     truncated tensor. This extends the Pillar-4 fail-closed guarantee (PMAT-744) to the
     load path. Found by an adversarial inference bug-hunt (root cause behind a narrow
     DIRECT_FP32_GEMV panic).
+    PMAT-895 (v1.1.0) extends the same validate_quantized_tensors load-time walk to
+    reject NaN/Inf quantized weights: a quantized super-block whose f16 scale d/dmin is
+    f16 +Inf (0x7C00) or NaN (0x7E00) dequantizes to NaN/Inf at every element of that
+    block, so inference emits garbage. Before PMAT-895, from_mapped accepted such a
+    model — validate_quantized_tensors only called is_truncated, with no finiteness
+    check. llama.cpp / Ollama also load it (their check_tensors defaults to false,
+    common.h:441; --check-tensors is opt-in), so apr rejecting it at load is a genuine
+    Pillar-4 BEAT, not parity. The NaN/Inf guarantee already existed on the SafeTensors
+    path (F-DATA-QUALITY-002, safetensors/validation.rs); PMAT-895 wires it into the
+    quantized load path by scanning the f16 scale field(s) per block (O(num_blocks)).
   references:
   - "crates/aprender-serve/src/gguf/quantized.rs (from_ref_with_dims, is_truncated)"
-  - "crates/aprender-serve/src/gguf/embedding.rs (OwnedQuantizedModel::from_mapped + validate_quantized_tensors)"
+  - "crates/aprender-serve/src/gguf/embedding.rs (OwnedQuantizedModel::from_mapped + validate_quantized_tensors + quant_scale_first_nonfinite)"
   - "crates/aprender-serve/src/gguf/quantized_tests.rs (test_pmat750_truncated_tensor_detected)"
+  - "crates/aprender-serve/src/gguf/tests/beat_fail_closed_naninf.rs (PMAT-895 gguf_naninf_quant_scale_rejected_at_load)"
+  - "crates/aprender-serve/src/safetensors/validation.rs (F-DATA-QUALITY-002 NaN/Inf gate, mirrored)"
 version: 1
 status: enforced
-date: 2026-06-14
+date: 2026-06-22
 
 proof_obligations:
   - type: invariant
@@ -38,6 +50,18 @@ proof_obligations:
       + lm_head) and returns Err(InvalidShape) if any is truncated, so a truncated GGUF
       is rejected at load instead of producing garbage at inference. A well-formed model
       loads unchanged.
+  - type: invariant
+    property: >
+      OBLIG-GGUF-LOAD-NANINF (PMAT-895): validate_quantized_tensors also scans each
+      quantized weight's f16 scale field(s) per block (quant_scale_first_nonfinite) and
+      OwnedQuantizedModel::from_mapped returns Err(InvalidShape) naming the first tensor
+      whose f16 scale d/dmin is non-finite (NaN/Inf, e.g. f16 +Inf 0x7C00 or NaN 0x7E00),
+      because such a scale dequantizes every element of its block to NaN/Inf and produces
+      garbage at inference. A model with all-finite scales (incl. legitimate all-zero or
+      f16(0.1) scales) loads unchanged — the finiteness check is orthogonal to the
+      density/zero gates and raises no false positive. This wires the SafeTensors
+      F-DATA-QUALITY-002 NaN/Inf guarantee into the quantized load path; llama.cpp /
+      Ollama load such a model by default, so apr fails closed where they do not.
 
 falsification_tests:
   - id: FALSIFY-LOAD-TRUNCATED-001
@@ -46,3 +70,9 @@ falsification_tests:
     test_harness: "cargo test -p aprender-serve --lib test_pmat750_truncated_tensor_detected"
     expected_output: "test result: ok"
     if_fails: "truncated tensors are not detected → a corrupt/incomplete GGUF loads with a dead weight and apr run/serve emit garbage instead of failing closed at load."
+  - id: FALSIFY-GGUF-LOAD-NANINF-001
+    name: gguf_naninf_quant_scale_rejected_at_load
+    prediction: "a pygmy GGUF with one Q4_0 super-block f16 scale set to f16 +Inf (0x7C00) or NaN (0x7E00) makes OwnedQuantizedModel::from_mapped return Err(InvalidShape) naming OBLIG-GGUF-LOAD-NANINF; the unmodified (all-finite-scale) pygmy still loads Ok"
+    test_harness: "cargo test -p aprender-serve --lib gguf_naninf_quant_scale_rejected_at_load"
+    expected_output: "test result: ok"
+    if_fails: "a quantized GGUF with a non-finite f16 scale loads silently → apr dequantizes it to NaN/Inf and emits garbage at inference instead of failing closed at load (Pillar-4 beat regressed to parity with llama.cpp/Ollama)."

--- a/crates/aprender-serve/src/gguf/embedding.rs
+++ b/crates/aprender-serve/src/gguf/embedding.rs
@@ -5,6 +5,62 @@ fn transpose_f32_matrix(data: &[f32], rows: usize, cols: usize) -> Vec<f32> {
     crate::contract_gate::transpose_f32(data, rows, cols)
 }
 
+/// PMAT-895 (OBLIG-GGUF-LOAD-NANINF): scan the f16 scale field(s) of a quantized
+/// tensor's raw bytes for a non-finite value (NaN/Inf). Returns the first offending
+/// scale value if any, else `None`.
+///
+/// The block / super-block scale layouts mirror the dequant code
+/// (`quantize/dequant.rs`, `quantize/dequant_q4k.rs`): each block leads with (or, for
+/// Q6_K/Q2_K/Q3_K, ends with) one or two f16 scales. We read ONLY those f16 fields —
+/// O(num_blocks), not O(num_elements). A non-finite `d`/`dmin` poisons every element
+/// of its block at dequant, so checking the scales is both cheap and sufficient. F32
+/// tensors (embeddings/norms) are stored separately and are not handled here.
+fn quant_scale_first_nonfinite(data: &[u8], qtype: u32) -> Option<f32> {
+    use crate::gguf::types::{
+        GGUF_TYPE_Q2_K, GGUF_TYPE_Q3_K, GGUF_TYPE_Q4_0, GGUF_TYPE_Q4_1, GGUF_TYPE_Q4_K,
+        GGUF_TYPE_Q5_0, GGUF_TYPE_Q5_1, GGUF_TYPE_Q5_K, GGUF_TYPE_Q6_K, GGUF_TYPE_Q8_0,
+    };
+    use crate::quantize::read_f16;
+
+    if data.is_empty() {
+        return None;
+    }
+
+    // (block_bytes, &[scale_offsets_within_block]) for each supported quant type.
+    // Each offset marks a 2-byte little-endian f16 scale field.
+    let (block_bytes, scale_offsets): (usize, &[usize]) = match qtype {
+        // 32-element blocks (one or two leading f16 scales).
+        t if t == GGUF_TYPE_Q4_0 => (18, &[0]),
+        t if t == GGUF_TYPE_Q8_0 => (34, &[0]),
+        t if t == GGUF_TYPE_Q4_1 => (20, &[0, 2]),
+        t if t == GGUF_TYPE_Q5_0 => (22, &[0]),
+        t if t == GGUF_TYPE_Q5_1 => (24, &[0, 2]),
+        // 256-element K-quant super-blocks.
+        t if t == GGUF_TYPE_Q4_K => (144, &[0, 2]),    // d, dmin
+        t if t == GGUF_TYPE_Q5_K => (176, &[0, 2]),    // d, dmin
+        t if t == GGUF_TYPE_Q6_K => (210, &[208]),     // d (trailing)
+        t if t == GGUF_TYPE_Q2_K => (84, &[80, 82]),   // d, dmin (trailing)
+        t if t == GGUF_TYPE_Q3_K => (110, &[108]),     // d_all (trailing)
+        // F16/F32/BF16/unknown: not a scaled-block layout — skip here.
+        _ => return None,
+    };
+
+    if block_bytes == 0 || !data.len().is_multiple_of(block_bytes) {
+        // Malformed block size for this qtype: leave to the existing shape gates.
+        return None;
+    }
+
+    for block in data.chunks_exact(block_bytes) {
+        for &off in scale_offsets {
+            let scale = read_f16(&block[off..off + 2]);
+            if !scale.is_finite() {
+                return Some(scale);
+            }
+        }
+    }
+    None
+}
+
 /// Dequantize token embedding from APR format to f32 based on dtype.
 ///
 /// Refs realizar#85: Added BF16/F16 support for aprender's GH-205/GH-353 passthrough.
@@ -126,6 +182,16 @@ impl OwnedQuantizedModel {
     /// density gate catches it, but `apr run` does not run those gates). This fails the
     /// load with a clear error naming the first truncated tensor — the fail-closed
     /// guarantee from the Pillar-4 beat (PMAT-744) extended to the load path.
+    ///
+    /// PMAT-895 (OBLIG-GGUF-LOAD-NANINF): also reject a model whose quantized weights
+    /// dequantize to NaN/Inf. A super-block whose f16 scale `d`/`dmin` is f16 +Inf
+    /// (`0x7C00`) or NaN (`0x7E00`) makes EVERY element of that block non-finite at
+    /// dequant; inference then emits garbage. llama.cpp / Ollama load such a model
+    /// (their `check_tensors` defaults to false), so apr failing closed here is a
+    /// genuine Pillar-4 BEAT. The same NaN/Inf guarantee already exists on the
+    /// SafeTensors path (F-DATA-QUALITY-002, `safetensors/validation.rs`); this wires
+    /// it into the quantized load path. We scan only the f16 scale field(s) per block
+    /// (O(num_blocks), not O(num_elements)) — the scales are what corrupt the dequant.
     pub(crate) fn validate_quantized_tensors(&self) -> Result<()> {
         fn check(t: &OwnedQuantizedTensor, name: &str) -> Result<()> {
             if t.is_truncated() {
@@ -133,6 +199,17 @@ impl OwnedQuantizedModel {
                     reason: format!(
                         "truncated/corrupt model: tensor '{name}' declares {}x{} but has no data (file is incomplete)",
                         t.out_dim, t.in_dim
+                    ),
+                });
+            }
+            // PMAT-895: fail closed on a non-finite quant scale (NaN/Inf dequant).
+            if let Some(bad) = quant_scale_first_nonfinite(&t.data, t.qtype) {
+                return Err(crate::error::RealizarError::InvalidShape {
+                    reason: format!(
+                        "OBLIG-GGUF-LOAD-NANINF: tensor '{name}' (qtype {}) has a non-finite \
+                         f16 quant scale (value {bad}); it dequantizes to NaN/Inf and produces \
+                         garbage at inference — apr fails closed at load (F-DATA-QUALITY-002)",
+                        t.qtype
                     ),
                 });
             }

--- a/crates/aprender-serve/src/gguf/tests/beat_fail_closed_naninf.rs
+++ b/crates/aprender-serve/src/gguf/tests/beat_fail_closed_naninf.rs
@@ -1,0 +1,99 @@
+//! PMAT-895 — Pillar-4 fail-closed: reject NaN/Inf quantized weights at the
+//! GGUF/APR LOAD path (OBLIG-GGUF-LOAD-NANINF).
+//!
+//! THE BEAT (a real win, not just parity): a quantized GGUF whose Q4_0/Q4_K
+//! super-block f16 scale `d`/`dmin` is f16 +Inf (`0x7C00`) or NaN (`0x7E00`)
+//! dequantizes to NaN/Inf at every element of that block. `OwnedQuantizedModel::
+//! from_mapped` accepted it BEFORE this fix — `validate_quantized_tensors` only
+//! called `is_truncated`, with NO finiteness check.
+//!
+//! llama.cpp / Ollama ALSO load such a model: their `check_tensors` defaults to
+//! `false` (`common.h:441`); `--check-tensors` is opt-in. So `apr` REJECTING it
+//! at load is a genuine fail-closed BEAT (PMAT-744 lineage), not parity.
+//!
+//! The NaN/Inf gate already existed on the SafeTensors path (F-DATA-QUALITY-002
+//! in `safetensors/validation.rs`). PMAT-895 WIRES that finiteness guarantee into
+//! the quantized load path.
+
+use std::io::Write;
+
+use crate::gguf::model::OwnedQuantizedModel;
+use crate::gguf::test_factory::build_executable_pygmy_gguf;
+use crate::gguf::MappedGGUFModel;
+
+/// The pygmy builder fills every Q4_0 weight block with `create_q4_0_data`:
+/// `[f16(0.1) scale: 2 bytes][0x88 × 16 quant nibbles]`. A run of 16 consecutive
+/// `0x88` bytes is a distinctive Q4_0 block signature that does NOT occur in the
+/// GGUF header/metadata. We locate the FIRST such block, then overwrite its 2
+/// scale bytes (the 2 bytes IMMEDIATELY BEFORE the 0x88 run) with the given
+/// non-finite f16 bit pattern. This corrupts exactly ONE super-block's f16 scale
+/// `d` — the minimal "Q4_0 weight super-block whose scale is non-finite".
+fn corrupt_first_q4_0_scale(gguf: &mut [u8], scale_le_bytes: [u8; 2]) -> usize {
+    const QUANT_RUN: [u8; 16] = [0x88; 16];
+    let run_pos = gguf
+        .windows(QUANT_RUN.len())
+        .position(|w| w == QUANT_RUN)
+        .expect("pygmy GGUF must contain a Q4_0 block (16×0x88 quants)");
+    assert!(
+        run_pos >= 2,
+        "0x88 run must be preceded by a 2-byte f16 scale"
+    );
+    let scale_off = run_pos - 2;
+    gguf[scale_off] = scale_le_bytes[0];
+    gguf[scale_off + 1] = scale_le_bytes[1];
+    scale_off
+}
+
+fn write_temp(gguf: &[u8]) -> tempfile::NamedTempFile {
+    let mut f = tempfile::NamedTempFile::new().expect("create temp gguf");
+    f.write_all(gguf).expect("write gguf bytes");
+    f.flush().expect("flush gguf bytes");
+    f
+}
+
+/// RED → GREEN falsifier for OBLIG-GGUF-LOAD-NANINF.
+///
+/// On current `main` (before the fix) `from_mapped` returned `Ok` for BOTH the
+/// +Inf and NaN corrupted scales — the gate was missing. After the fix it MUST
+/// return `Err` naming the non-finite tensor.
+#[test]
+fn gguf_naninf_quant_scale_rejected_at_load() {
+    // f16 +Inf = bits 0x7C00 = little-endian [0x00, 0x7C].
+    // f16 NaN  = bits 0x7E00 = little-endian [0x00, 0x7E].
+    for (label, scale_le) in [("+Inf", [0x00u8, 0x7C]), ("NaN", [0x00u8, 0x7E])] {
+        let mut gguf = build_executable_pygmy_gguf();
+        let off = corrupt_first_q4_0_scale(&mut gguf, scale_le);
+        eprintln!("[PMAT-895] corrupted Q4_0 f16 scale ({label}) at byte offset {off}");
+
+        let tmp = write_temp(&gguf);
+        let mapped = MappedGGUFModel::from_path(tmp.path()).expect("mmap corrupted GGUF");
+        let result = OwnedQuantizedModel::from_mapped(&mapped);
+
+        assert!(
+            result.is_err(),
+            "OBLIG-GGUF-LOAD-NANINF FAIL ({label}): from_mapped accepted a model whose \
+             Q4_0 super-block f16 scale is non-finite — it dequantizes to {label} and \
+             produces garbage at inference. apr must fail closed at load."
+        );
+        let msg = format!("{:?}", result.err().unwrap());
+        eprintln!("[PMAT-895] rejected ({label}) with: {msg}");
+    }
+}
+
+/// FP-bound: a HEALTHY pygmy model (all weights finite) still loads `Ok`, and the
+/// existing all-zero / all-`0x88` synthetic builders are NOT rejected. All-zero
+/// quantized data dequantizes to 0.0 (finite), and f16(0.1) is finite — a pure
+/// NaN/Inf finiteness check is orthogonal to the density/zero gates and must not
+/// reject these legitimate test models.
+#[test]
+fn healthy_quant_model_still_loads_ok() {
+    let gguf = build_executable_pygmy_gguf();
+    let tmp = write_temp(&gguf);
+    let mapped = MappedGGUFModel::from_path(tmp.path()).expect("mmap healthy GGUF");
+    let result = OwnedQuantizedModel::from_mapped(&mapped);
+    assert!(
+        result.is_ok(),
+        "FP-bound FAIL: NaN/Inf gate rejected a healthy (finite-scale) quantized model: {:?}",
+        result.err()
+    );
+}

--- a/crates/aprender-serve/src/gguf/tests/mod.rs
+++ b/crates/aprender-serve/src/gguf/tests/mod.rs
@@ -31,6 +31,7 @@
 //! - `part_24.rs`: Phase 52 - GGUF Loader Metadata Types (state-space exhaustion)
 //! - `part_25.rs`: Phase 54 - Fixture-Based Loader Tests (ModelFixture pattern)
 
+mod beat_fail_closed_naninf; // PMAT-895 OBLIG-GGUF-LOAD-NANINF (reject non-finite quant scales at load)
 mod bytes; // T-COV-95 Coverage Bridge B6 (loader.rs metadata, parsing, transformer)
 mod bytes_02; // T-COV-95 Synthetic Falsification (loader.rs via Pygmy GGUF models)
 mod config;


### PR DESCRIPTION
## PMAT-895 — Pillar-4 fail-closed: reject NaN/Inf quantized weights at load

`OwnedQuantizedModel::from_mapped` **accepted** a quantized model whose weights dequantize to NaN/Inf (e.g. a Q4_0/Q4_K super-block whose f16 `d`/`dmin` scale is f16 `+Inf` `0x7C00` or NaN) — `validate_quantized_tensors` only checked `is_truncated`, no finiteness gate. A non-finite scale poisons every dequantized element of its block.

**The BEAT:** llama.cpp/Ollama load such a model by default (`check_tensors=false`; `--check-tensors` is opt-in), so apr **failing closed at load** is a genuine Pillar-4 win — wiring the existing SafeTensors F-DATA-QUALITY-002 NaN/Inf guarantee into the quantized load path.

### RED→GREEN (verified on origin/main `684a70839`)
- **RED:** `from_mapped` returned `Ok` for a +Inf-scale Q4_0 model.
- **GREEN:** both +Inf and NaN scales now rejected with rule id `OBLIG-GGUF-LOAD-NANINF`.
- **FP-bound:** healthy all-zero-weight synthetic models (finite scales) still load `Ok` — the finiteness check is orthogonal to the density/zero gates.

### Verification
- `cargo test -p aprender-serve --lib` → **15429 passed, 0 failed** (incl. ~30 all-zero synthetic `from_mapped` loaders — no regression).
- Scans only the f16 scale field(s) per block — O(num_blocks) — across all 10 supported quant types.
- Contract `apr-load-fail-closed-truncated-v1.yaml` v1.1.0: obligation `OBLIG-GGUF-LOAD-NANINF` + falsifier `FALSIFY-GGUF-LOAD-NANINF-001`; `pv lint contracts/` → 0 errors.

clippy + fmt clean. No version bump (batched at release).