### PR TITLE
fix(autograd): L1Loss backward propagates gradient via AbsBackward sign(x) — F-L1LOSS-BACKWARD-GRAD-001 (PMAT-896)

### DIFF
--- a/contracts/loss-functions-v1.yaml
+++ b/contracts/loss-functions-v1.yaml
@@ -66,6 +66,8 @@ equations:
     - L1 = 0 iff ŷ = y
     - L1(y, ŷ) = L1(ŷ, y) (symmetry)
     - L1 = MAE (identical function)
+    - 'gradient: ∂L1/∂ŷ = sign(ŷ-y)/n (mean), sign(ŷ-y) (sum); sign(0)=0'
+    - 'autograd: loss.backward() yields get_grad(pred.id()) = Some (graph not severed)'
     preconditions:
     - predicted.len() == target.len()
     - predicted.len() > 0
@@ -103,6 +105,12 @@ proof_obligations:
   property: L1 symmetry
   formal: L1(y, ŷ) = L1(ŷ, y)
   applies_to: l1_loss
+- type: equivalence
+  property: F-L1LOSS-BACKWARD-GRAD-001 L1 backward propagates gradient
+  formal: 'after loss.backward(): get_grad(pred.id()) = Some, and equals sign(pred-target)/n
+    for mean reduction (sign(pred-target) for sum); sign(0)=0. abs() must register an
+    AbsBackward grad_fn so the autograd graph is not severed (PMAT-896).'
+  applies_to: l1_loss
 - type: bound
   property: NLL lower bound
   formal: NLL ≥ 0
@@ -138,6 +146,11 @@ falsification_tests:
   prediction: NLL ≥ 0 for random logits and valid class indices
   test: proptest with random logits and uniform class labels
   if_fails: Softmax normalization error or log of non-positive value
+- id: F-L1LOSS-BACKWARD-GRAD-001
+  rule: L1 backward propagates gradient (PMAT-896)
+  prediction: 'L1Loss(mean).forward(pred,target).backward() => get_grad(pred.id()) = Some([-1/3,0,1/3]) for pred=[1,2,3], target=[2,2,2]'
+  test: cargo test -p aprender-core --lib test_l1_loss_gradient
+  if_fails: abs() severs autograd (no AbsBackward grad_fn) so L1Loss yields no input gradient and trains silently to zero
 kani_harnesses:
 - id: KANI-LF-001
   obligation: '1'

--- a/crates/aprender-core/src/autograd/grad_fn.rs
+++ b/crates/aprender-core/src/autograd/grad_fn.rs
@@ -267,6 +267,42 @@ impl GradFn for SqrtBackward {
     }
 }
 
+/// Gradient function for abs: z = |x|
+///
+/// PMAT-896: without this grad_fn, `abs()` severed the autograd graph and
+/// `L1Loss` (which is `mean(|pred - target|)`) produced no input gradient,
+/// silently training to zero. ∂|x|/∂x = sign(x), with sign(0) = 0 to match
+/// PyTorch's subgradient convention at the non-differentiable point.
+pub(crate) struct AbsBackward {
+    pub(crate) x: Tensor,
+}
+
+impl GradFn for AbsBackward {
+    fn backward(&self, grad_output: &Tensor) -> Vec<Tensor> {
+        // ∂|x|/∂x = sign(x); sign(0) = 0 (PyTorch subgradient convention)
+        let grad_data: Vec<f32> = grad_output
+            .data()
+            .iter()
+            .zip(self.x.data().iter())
+            .map(|(&g, &x)| {
+                let sign = if x > 0.0 {
+                    1.0
+                } else if x < 0.0 {
+                    -1.0
+                } else {
+                    0.0
+                };
+                g * sign
+            })
+            .collect();
+        vec![Tensor::new(&grad_data, grad_output.shape())]
+    }
+
+    fn name(&self) -> &'static str {
+        "AbsBackward"
+    }
+}
+
 // ============================================================================
 // Reduction Operations
 // ============================================================================

--- a/crates/aprender-core/src/autograd/ops/mod.rs
+++ b/crates/aprender-core/src/autograd/ops/mod.rs
@@ -9,10 +9,10 @@
 use std::sync::Arc;
 
 use super::grad_fn::{
-    AddBackward, BroadcastAddBackward, DivBackward, ExpBackward, GeluBackward, LeakyReluBackward,
-    LogBackward, MatmulBackward, MeanBackward, MulBackward, NegBackward, PowBackward, ReluBackward,
-    SigmoidBackward, SoftmaxBackward, SqrtBackward, SubBackward, SumBackward, TanhBackward,
-    TransposeBackward, ViewBackward,
+    AbsBackward, AddBackward, BroadcastAddBackward, DivBackward, ExpBackward, GeluBackward,
+    LeakyReluBackward, LogBackward, MatmulBackward, MeanBackward, MulBackward, NegBackward,
+    PowBackward, ReluBackward, SigmoidBackward, SoftmaxBackward, SqrtBackward, SubBackward,
+    SumBackward, TanhBackward, TransposeBackward, ViewBackward,
 };
 use super::tensor::Tensor;
 use super::{is_grad_enabled, with_graph};
@@ -272,6 +272,31 @@ impl Tensor {
             let grad_fn = Arc::new(SqrtBackward {
                 output: result.clone(),
             });
+            result.set_grad_fn(grad_fn.clone());
+
+            with_graph(|graph| {
+                graph.register_tensor(self.clone());
+                graph.record(result.id(), grad_fn, vec![self.id()]);
+            });
+        }
+
+        result
+    }
+
+    /// Element-wise absolute value: z = |self|
+    ///
+    /// PMAT-896: this is the autograd-aware `abs`. ∂|x|/∂x = sign(x)
+    /// (with sign(0) = 0, PyTorch subgradient convention). Without the
+    /// recorded `AbsBackward` grad_fn, `L1Loss` = `mean(|pred - target|)`
+    /// produced no input gradient and trained silently to zero.
+    #[must_use]
+    pub fn abs(&self) -> Tensor {
+        let data: Vec<f32> = self.data().iter().map(|&a| a.abs()).collect();
+        let mut result = Tensor::from_vec(data, self.shape());
+
+        if is_grad_enabled() && self.requires_grad_enabled() {
+            result.requires_grad_(true);
+            let grad_fn = Arc::new(AbsBackward { x: self.clone() });
             result.set_grad_fn(grad_fn.clone());
 
             with_graph(|graph| {

--- a/crates/aprender-core/src/autograd/tests_elementwise_backward.rs
+++ b/crates/aprender-core/src/autograd/tests_elementwise_backward.rs
@@ -43,6 +43,19 @@
         assert_eq!(grads[0].data(), &[0.0, 0.0, 1.0, 1.0]);
     }
 
+    /// PMAT-896: ∂|x|/∂x = sign(x), with sign(0) = 0 (PyTorch convention).
+    #[test]
+    fn test_abs_backward() {
+        let x = Tensor::from_slice(&[-3.0, 0.0, 2.0, -1.0]);
+        let grad_fn = AbsBackward { x };
+
+        let grad_out = Tensor::from_slice(&[1.0, 1.0, 1.0, 1.0]);
+        let grads = grad_fn.backward(&grad_out);
+
+        // grad = grad_out * sign(x) = [-1, 0, 1, -1]
+        assert_eq!(grads[0].data(), &[-1.0, 0.0, 1.0, -1.0]);
+    }
+
     #[test]
     fn test_sum_backward() {
         let grad_fn = SumBackward {

--- a/crates/aprender-core/src/nn/loss_tests.rs
+++ b/crates/aprender-core/src/nn/loss_tests.rs
@@ -61,6 +61,62 @@ mod tests {
         assert!((loss.item() - 2.0 / 3.0).abs() < 1e-5);
     }
 
+    /// F-L1LOSS-BACKWARD-GRAD-001 falsifier (PMAT-896).
+    ///
+    /// `L1Loss::forward(...).backward()` MUST propagate a gradient to `pred`.
+    /// For mean reduction, ∂mean(|pred - target|)/∂pred = sign(pred - target) / N.
+    /// Before the `AbsBackward` fix, `abs()` severed the autograd graph
+    /// (built its result with `Tensor::from_vec`, no grad_fn), so
+    /// `get_grad(pred.id())` returned `None` and every model trained with
+    /// L1Loss silently did not learn.
+    #[test]
+    fn test_l1_loss_gradient() {
+        clear_graph();
+
+        let pred = Tensor::from_slice(&[1.0, 2.0, 3.0]).requires_grad();
+        let pred_id = pred.id();
+        let target = Tensor::from_slice(&[2.0, 2.0, 2.0]);
+
+        let criterion = L1Loss::new();
+        let loss = criterion.forward(&pred, &target);
+        loss.backward();
+
+        // Gradient MUST exist — None means the autograd graph is severed.
+        let grad = crate::autograd::get_grad(pred_id)
+            .expect("L1Loss must propagate a gradient to pred (F-L1LOSS-BACKWARD-GRAD-001)");
+
+        // ∂mean(|pred - target|)/∂pred = sign(pred - target) / N
+        // diff = [-1, 0, 1] -> sign = [-1, 0, 1] -> /3 = [-1/3, 0, 1/3]
+        let expected = [-1.0 / 3.0, 0.0, 1.0 / 3.0];
+        for (g, e) in grad.data().iter().zip(expected.iter()) {
+            assert!((g - e).abs() < 1e-5, "Expected {e}, got {g}");
+        }
+    }
+
+    /// F-L1LOSS-BACKWARD-GRAD-001: Sum reduction has no 1/N factor.
+    /// ∂sum(|pred - target|)/∂pred = sign(pred - target).
+    #[test]
+    fn test_l1_loss_gradient_sum_reduction() {
+        clear_graph();
+
+        let pred = Tensor::from_slice(&[1.0, 2.0, 3.0]).requires_grad();
+        let pred_id = pred.id();
+        let target = Tensor::from_slice(&[2.0, 2.0, 2.0]);
+
+        let criterion = L1Loss::with_reduction(Reduction::Sum);
+        let loss = criterion.forward(&pred, &target);
+        loss.backward();
+
+        let grad = crate::autograd::get_grad(pred_id)
+            .expect("L1Loss (sum) must propagate a gradient (F-L1LOSS-BACKWARD-GRAD-001)");
+
+        // diff = [-1, 0, 1] -> sign = [-1, 0, 1] (no /N for sum reduction)
+        let expected = [-1.0, 0.0, 1.0];
+        for (g, e) in grad.data().iter().zip(expected.iter()) {
+            assert!((g - e).abs() < 1e-5, "Expected {e}, got {g}");
+        }
+    }
+
     #[test]
     fn test_smooth_l1_loss() {
         let pred = Tensor::from_slice(&[0.0]);

--- a/crates/aprender-core/src/nn/ucbd.rs
+++ b/crates/aprender-core/src/nn/ucbd.rs
@@ -36,9 +36,13 @@ impl NLLLoss {
 // ============================================================================
 
 /// Element-wise absolute value.
+///
+/// PMAT-896: delegates to the autograd-aware `Tensor::abs` so the
+/// computation graph stays connected. The previous `Tensor::from_vec`
+/// implementation severed autograd, which silently zeroed every
+/// `L1Loss` gradient (`L1Loss = mean(|pred - target|)`).
 pub(super) fn abs(x: &Tensor) -> Tensor {
-    let data: Vec<f32> = x.data().iter().map(|&v| v.abs()).collect();
-    Tensor::from_vec(data, x.shape())
+    x.abs()
 }
 
 /// Softmax computation for gradient tracking.


### PR DESCRIPTION
## PMAT-896 — Pillar-2: L1Loss autograd backward was SEVERED (silent zero-learning)

`L1Loss::forward(...).backward()` produced **no input gradient** — `get_grad(pred.id())` returned `None` — so any model trained with L1Loss silently did not learn. Root cause: `nn/ucbd.rs::abs()` built its result with `Tensor::from_vec` (no `grad_fn`), severing autograd at the `|pred - target|` edge (the only nonlinear edge in `L1Loss = mean(|pred-target|)`).

### Fix (mirrors the existing `pow`/`relu` unary-op pattern)
- New `AbsBackward` grad_fn: `d|x|/dx = sign(x)`, `sign(0)=0` (PyTorch subgradient convention).
- Autograd-aware `Tensor::abs()` records `AbsBackward`; `ucbd.rs::abs()` delegates (forward values unchanged).

### RED→GREEN (vs PyTorch reference)
- **RED** (main): `get_grad(pred.id())` → `None`.
- **GREEN**: for `pred=[1,2,3], target=[2,2,2]` mean reduction → grad `[-1/3, 0, 1/3]` = analytic `sign(pred-target)/N`; sum reduction → `[-1, 0, 1]`. Within 1e-5.

### Verification
- `cargo test -p aprender-core --lib` → **13958 passed, 0 failed** (+3 new tests, no regressions).
- Contract `loss-functions-v1.yaml`: added `F-L1LOSS-BACKWARD-GRAD-001` (its obligations previously covered loss VALUE only, never the gradient); `pv lint contracts/` → 0 errors.

clippy + fmt clean. No version bump (batched at release).