### PR TITLE
fix(optim): SGD momentum applies lr fresh per step (PyTorch parity under lr schedule) — F-SGD-MOMENTUM-LRSCHED-001 (PMAT-898)

### DIFF
--- a/contracts/sgd-momentum-lrsched-v1.yaml
+++ b/contracts/sgd-momentum-lrsched-v1.yaml
@@ -1,0 +1,128 @@
+metadata:
+  version: 1.0.0
+  created: '2026-06-22'
+  author: PAIML Engineering
+  registry: true
+  description: |
+    SGD-with-momentum learning-rate-schedule parity (PyTorch parity, PMAT-898).
+
+    PyTorch's torch.optim.SGD with momentum keeps an UNSCALED velocity buffer
+    and applies the learning rate FRESH at update time on every step:
+
+        b   <- momentum * b + grad        (buffer, lr-free)
+        theta <- theta - lr * b           (lr read fresh each step)
+
+    Because lr is never baked into b, changing lr mid-training (an LR schedule,
+    e.g. via Optimizer::set_lr or a scheduler) takes effect on the very next
+    step without dragging a stale lr through the momentum term.
+
+    Defect (PMAT-898): aprender's SGD baked lr INTO the velocity buffer
+    (b <- momentum*b - lr*grad; theta <- theta + b) in BOTH the scalar
+    fallback path and the SIMD path. After a set_lr() the momentum component
+    still carried the OLD lr, so the trajectory diverged from PyTorch under any
+    LR schedule. Closed-form witness (g=1.0, mu=0.9, theta0=0, lr 0.1 -> 0.01):
+    PyTorch theta2 = -0.119; buggy aprender theta2 = -0.200 (~40% off).
+  references:
+  - 'PyTorch torch.optim.SGD — momentum buffer is lr-free; lr applied per step (b = mu*b + g; p -= lr*b)'
+  - 'Sutskever et al. (2013) On the importance of initialization and momentum in deep learning'
+  - 'crates/aprender-train/src/optim/sgd.rs — SGD::step scalar + SIMD paths (fix site)'
+  - 'crates/aprender-train/src/optim/simd/axpy.rs — simd_axpy fused y += a*x'
+
+kind: KernelContract
+name: sgd-momentum-lrsched
+version: 1.0.0
+scope: crates/aprender-train/src/optim/sgd.rs — SGD momentum velocity buffer + lr application
+
+description: |
+  SGD-with-momentum must keep an UNSCALED velocity buffer (b = momentum*b + grad)
+  and apply the learning rate fresh at parameter-update time (theta -= lr*b), so a
+  mid-training learning-rate change (LR schedule) matches PyTorch exactly. The
+  scalar fallback path and the SIMD path must produce identical results.
+
+equations:
+  momentum_buffer_update:
+    formula: b_c <- momentum * b_c + grad_c
+    domain: momentum in [0, 1); grad_c in R per parameter c; b initialized to 0
+    codomain: b_c in R
+    invariants:
+    - 'Buffer is lr-FREE: no learning rate appears in the buffer recurrence'
+    - 'First step (b init 0): b_c = grad_c'
+    - 'Applied once per SGD::step per parameter element c'
+    - 'Scalar path (len < 16) and SIMD path (len >= 16) compute identical b_c'
+    preconditions:
+    - grad.iter().all(|v| v.is_finite())
+    - grad.len() > 0
+    lean_theorem: Theorems.Sgd_Momentum_Buffer_Update
+  parameter_update_fresh_lr:
+    formula: theta_c <- theta_c - lr * b_c
+    domain: lr in R_>0 read at update time; b_c in R; theta_c in R
+    codomain: theta_c in R
+    invariants:
+    - 'lr is read FRESH on every step, never baked into b'
+    - 'A set_lr(lr2) between steps applies lr2 to the next theta update immediately'
+    - 'Constant lr is unchanged: lr-baked and lr-fresh rules coincide when lr never changes'
+    - 'Closed-form (g=1, mu=0.9, theta0=0, lr 0.1->0.01): theta2 = -0.119 (PyTorch)'
+    preconditions:
+    - grad.iter().all(|v| v.is_finite())
+    - grad.len() > 0
+    lean_theorem: Theorems.Sgd_Parameter_Update_Fresh_Lr
+
+proof_obligations:
+- type: equivalence
+  property: SGD momentum matches PyTorch under an LR schedule
+  formal: |
+    For one parameter with grad g=1.0, momentum mu=0.9, theta0=0.0: stepping at
+    lr=0.1, then set_lr(0.01), then stepping again yields theta2 = -0.119 (the
+    PyTorch closed form b=mu*b+g, theta-=lr*b), NOT the lr-baked -0.200.
+  tolerance: 1.0e-06
+  applies_to: all
+- type: equivalence
+  property: Scalar and SIMD paths agree under an LR schedule
+  formal: |
+    The scalar fallback (length < 16) and SIMD (length >= 16) paths produce the
+    same per-element result for identical inputs; both give theta2 = -0.119 on the
+    lr-scheduled witness above.
+  tolerance: 1.0e-06
+  applies_to: all
+- type: invariant
+  property: Constant-lr behavior is preserved (no regression)
+  formal: |
+    With lr fixed (never changed), two steps of (g=1.0, mu=0.9, theta0=0.0) give
+    theta2 = -0.29, identical for the lr-baked and lr-fresh rules. The fix changes
+    behavior ONLY when lr changes mid-training.
+  tolerance: 1.0e-06
+  applies_to: all
+
+falsification_tests:
+- id: FALSIFY-SGD-LRSCHED-001
+  rule: SGD momentum keeps an lr-free buffer and applies lr fresh per step
+  prediction: |
+    Stepping a single parameter (g=1.0, mu=0.9, theta0=0.0) at lr=0.1, calling
+    set_lr(0.01), then stepping again gives theta2 = -0.119 (PyTorch). Pre-fix the
+    scalar path baked lr into the velocity buffer and produced theta2 = -0.200.
+  if_fails: |
+    SGD::step's momentum branch bakes lr into the velocity buffer
+    (b = mu*b - lr*grad; theta += b) instead of keeping b = mu*b + grad and
+    applying theta -= lr*b with lr read fresh. Fix both the scalar fallback and
+    the SIMD axpy path in crates/aprender-train/src/optim/sgd.rs.
+  test: cargo test -p aprender-train --lib falsify_sgd_momentum_lrsched_scalar
+  evidence: cargo test -p aprender-train --lib falsify_sgd_momentum_lrsched_scalar
+- id: FALSIFY-SGD-LRSCHED-002
+  rule: SIMD path matches the scalar path under an LR schedule
+  prediction: |
+    The 16-element SIMD path on the same lr-scheduled witness gives each element
+    theta2 = -0.119. Pre-fix the SIMD path also baked lr into the buffer and gave
+    -0.200.
+  if_fails: |
+    The SIMD branch of SGD::step still scales the velocity by momentum and adds
+    -lr*grad (baking lr). Change it to b += grad then theta += -lr*b.
+  test: cargo test -p aprender-train --lib falsify_sgd_momentum_lrsched_simd
+  evidence: cargo test -p aprender-train --lib falsify_sgd_momentum_lrsched_simd
+
+qa_gate:
+  id: F-SGD-MOMENTUM-LRSCHED-001
+  name: sgd-momentum-lrsched-v1 Contract
+  description: SGD momentum must keep an lr-free buffer and apply lr fresh per step (PyTorch parity under an LR schedule).
+  checks:
+  - validation
+  - falsification

--- a/crates/aprender-train/src/optim/sgd.rs
+++ b/crates/aprender-train/src/optim/sgd.rs
@@ -48,17 +48,21 @@ impl Optimizer for SGD {
                         let velocity_slice =
                             velocity.as_slice_mut().expect("velocity array is contiguous");
 
-                        // v = momentum * v - lr * grad (using SIMD)
-                        // First scale velocity by momentum
+                        // PyTorch SGD+momentum (F-SGD-MOMENTUM-LRSCHED-001):
+                        // buffer stays UNSCALED so a mid-training lr change
+                        // (LR schedule) applies the FRESH lr each step.
+                        //   b = momentum * b + grad
+                        //   param -= lr * b   (lr read fresh, not baked into b)
+                        // First scale the buffer by momentum.
                         for v in velocity_slice.iter_mut() {
                             *v *= self.momentum;
                         }
 
-                        // Then add -lr * grad using SIMD axpy
-                        super::simd::simd_axpy(-self.lr, grad_slice, velocity_slice);
+                        // b += grad (a=1.0) using SIMD axpy
+                        super::simd::simd_axpy(1.0, grad_slice, velocity_slice);
 
-                        // param = param + velocity (using SIMD axpy with a=1.0)
-                        super::simd::simd_axpy(1.0, velocity_slice, param_slice);
+                        // param += -lr * b (lr applied fresh at update time)
+                        super::simd::simd_axpy(-self.lr, velocity_slice, param_slice);
                     } else {
                         // Simple SGD: param -= lr * grad (using SIMD axpy)
                         super::simd::simd_axpy(-self.lr, grad_slice, param_slice);
@@ -66,14 +70,17 @@ impl Optimizer for SGD {
                 } else {
                     // Fallback to scalar implementation for small tensors
                     if self.momentum > 0.0 {
-                        // v = momentum * v - lr * grad
+                        // PyTorch SGD+momentum (F-SGD-MOMENTUM-LRSCHED-001):
+                        // UNSCALED buffer b = momentum * b + grad, then
+                        // param -= lr * b with lr read FRESH each step (so an
+                        // LR schedule never carries a stale lr in the buffer).
                         let velocity = if let Some(v) = &self.velocities[i] {
-                            v * self.momentum - &grad * self.lr
+                            v * self.momentum + &grad
                         } else {
-                            &grad * (-self.lr)
+                            grad.clone()
                         };
 
-                        *param.data_mut() = param.data() + &velocity;
+                        *param.data_mut() = param.data() - &(&velocity * self.lr);
                         self.velocities[i] = Some(velocity);
                     } else {
                         // Simple SGD: param -= lr * grad
@@ -144,6 +151,117 @@ mod tests {
         assert!((opt.lr() - 0.1).abs() < 1e-6);
         opt.set_lr(0.01);
         assert!((opt.lr() - 0.01).abs() < 1e-6);
+    }
+
+    /// FALSIFY F-SGD-MOMENTUM-LRSCHED-001 (scalar path):
+    /// SGD-with-momentum must match PyTorch under an LR schedule.
+    ///
+    /// PyTorch SGD+momentum: `b = mu*b + g` (UNSCALED buffer), then
+    /// `theta -= lr*b` (lr read FRESH each step). aprender previously baked
+    /// `lr` into the velocity buffer, so after `set_lr` the momentum term
+    /// carried a STALE lr → divergence.
+    ///
+    /// Closed-form (g=1.0, mu=0.9, theta0=0.0, lr 0.1 → set_lr(0.01)):
+    ///   b1 = 0.9*0 + 1   = 1.0   ; theta1 = 0    - 0.1 *1.0 = -0.1
+    ///   b2 = 0.9*1 + 1   = 1.9   ; theta2 = -0.1 - 0.01*1.9 = -0.119
+    /// On the buggy (lr-baked) path theta2 = -0.200 (~40% off).
+    #[test]
+    fn falsify_sgd_momentum_lrsched_scalar() {
+        // 1 element → scalar fallback path (< 16 elements).
+        let param = Tensor::from_vec(vec![0.0], true);
+        let mut opt = SGD::new(0.1, 0.9);
+
+        param.set_grad(Array1::from_vec(vec![1.0]));
+        let mut params = [param];
+        opt.step(&mut params);
+        // theta1 = -0.1
+        assert!(
+            (params[0].data()[0] - (-0.1)).abs() < 1e-6,
+            "FALSIFIED: theta1 = {} != -0.1 (PyTorch step 1)",
+            params[0].data()[0]
+        );
+
+        opt.set_lr(0.01);
+        params[0].set_grad(Array1::from_vec(vec![1.0]));
+        opt.step(&mut params);
+        // theta2 = -0.119 (PyTorch). Buggy lr-baked path gives -0.200.
+        assert!(
+            (params[0].data()[0] - (-0.119)).abs() < 1e-6,
+            "FALSIFIED F-SGD-MOMENTUM-LRSCHED-001 (scalar): theta2 = {} != -0.119 \
+             (PyTorch rule b=mu*b+g, theta-=lr*b). lr baked into velocity buffer?",
+            params[0].data()[0]
+        );
+    }
+
+    /// FALSIFY F-SGD-MOMENTUM-LRSCHED-001 (SIMD path): identical assertion as
+    /// the scalar test but with 16 elements (>= 16 triggers the SIMD path).
+    /// Every element is independent and shares the same closed-form, so each
+    /// must equal -0.119 after the lr-scheduled second step.
+    #[test]
+    fn falsify_sgd_momentum_lrsched_simd() {
+        let n = 16;
+        let param = Tensor::from_vec(vec![0.0; n], true);
+        let mut opt = SGD::new(0.1, 0.9);
+
+        param.set_grad(Array1::from_vec(vec![1.0; n]));
+        let mut params = [param];
+        opt.step(&mut params);
+        for &x in params[0].data().iter() {
+            assert!(
+                (x - (-0.1)).abs() < 1e-6,
+                "FALSIFIED: theta1 = {x} != -0.1 (SIMD, PyTorch step 1)"
+            );
+        }
+
+        opt.set_lr(0.01);
+        params[0].set_grad(Array1::from_vec(vec![1.0; n]));
+        opt.step(&mut params);
+        for &x in params[0].data().iter() {
+            assert!(
+                (x - (-0.119)).abs() < 1e-6,
+                "FALSIFIED F-SGD-MOMENTUM-LRSCHED-001 (SIMD): theta2 = {x} != -0.119 \
+                 (PyTorch rule b=mu*b+g, theta-=lr*b)."
+            );
+        }
+    }
+
+    /// Control: constant lr must NOT regress. With lr fixed at 0.1, two steps
+    /// of (g=1.0, mu=0.9, theta0=0.0):
+    ///   b1=1.0; theta1 = -0.1
+    ///   b2=1.9; theta2 = -0.1 - 0.1*1.9 = -0.29
+    /// This holds identically for the old and new rules (lr never changes).
+    #[test]
+    fn test_sgd_momentum_constant_lr_no_regression() {
+        // Scalar path.
+        let param = Tensor::from_vec(vec![0.0], true);
+        let mut opt = SGD::new(0.1, 0.9);
+        param.set_grad(Array1::from_vec(vec![1.0]));
+        let mut params = [param];
+        opt.step(&mut params);
+        assert!((params[0].data()[0] - (-0.1)).abs() < 1e-6);
+        params[0].set_grad(Array1::from_vec(vec![1.0]));
+        opt.step(&mut params);
+        assert!(
+            (params[0].data()[0] - (-0.29)).abs() < 1e-6,
+            "constant-lr scalar regression: theta2 = {} != -0.29",
+            params[0].data()[0]
+        );
+
+        // SIMD path (16 elements), same closed-form.
+        let n = 16;
+        let param = Tensor::from_vec(vec![0.0; n], true);
+        let mut opt = SGD::new(0.1, 0.9);
+        param.set_grad(Array1::from_vec(vec![1.0; n]));
+        let mut params = [param];
+        opt.step(&mut params);
+        params[0].set_grad(Array1::from_vec(vec![1.0; n]));
+        opt.step(&mut params);
+        for &x in params[0].data().iter() {
+            assert!(
+                (x - (-0.29)).abs() < 1e-6,
+                "constant-lr SIMD regression: theta2 = {x} != -0.29"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## PMAT-898 — Pillar-2: SGD-with-momentum diverges from PyTorch under an LR schedule

### The bug
aprender's SGD-with-momentum baked the learning rate **into** the velocity buffer (`b = mu*b - lr*grad; theta += b`) in **both** the scalar fallback path and the SIMD path. After a mid-training `set_lr()` (an LR schedule), the momentum term still carried the **old** lr, diverging from PyTorch.

PyTorch keeps an **unscaled** buffer and applies lr fresh each step:
```
b     = mu*b + grad        (lr-free)
theta = theta - lr*b       (lr read fresh each step)
```

### RED → GREEN
Closed-form witness (g=1.0, mu=0.9, theta0=0.0, lr 0.1 → `set_lr(0.01)`):

| step | PyTorch (correct) | aprender on `main` (buggy) |
|------|-------------------|----------------------------|
| theta1 | -0.1 | -0.1 |
| theta2 | **-0.119** | **-0.200** (~40% off) |

- **RED on main:** `falsify_sgd_momentum_lrsched_scalar` and `_simd` both panic with `theta2 = -0.19999999 != -0.119`.
- **GREEN after fix:** both falsifiers pass; both paths now give -0.119.
- **No regression:** `test_sgd_momentum_constant_lr_no_regression` asserts constant-lr behavior (theta2 = -0.29) is unchanged — the lr-baked and lr-fresh rules coincide when lr never changes.

### The fix
Both paths now store `b = mu*b + grad` (unscaled) and apply `theta -= lr*b` reading `lr` fresh at update time. Scalar and SIMD paths verified to agree.

### Tests
`cargo test -p aprender-train --lib`: **7607 passed; 3 failed** — the 3 failures are the known pre-existing `prune::snapshot_tests` insta-drift (unrelated). No new failures; +3 passing SGD tests added.

### Contract
`contracts/sgd-momentum-lrsched-v1.yaml` — qa_gate **F-SGD-MOMENTUM-LRSCHED-001** with proof obligations (PyTorch equivalence under lr schedule, scalar==SIMD agreement, constant-lr no-regression) + falsifiers `FALSIFY-SGD-LRSCHED-001/002`.
- `pv validate`: 0 errors
- `pv lint contracts/`: **0 errors, PASS**

🤖 Generated with [Claude Code](https://claude.com/claude-code)