### PR TITLE
fix(stats): finite p-values for df>=72 — log-space gamma (PMAT-904)

### DIFF
--- a/contracts/incomplete-beta-correctness-v1.yaml
+++ b/contracts/incomplete-beta-correctness-v1.yaml
@@ -1,5 +1,5 @@
 metadata:
-  version: "1.0.0"
+  version: "1.1.0"
   created: "2026-06-18"
   author: PAIML Engineering
   registry: true
@@ -14,7 +14,7 @@ metadata:
 
 kind: KernelContract
 name: incomplete-beta-correctness
-version: "1.0.0"
+version: "1.1.0"
 scope: "crates/aprender-core/src/stats/hypothesis.rs"
 
 description: |
@@ -48,6 +48,21 @@ equations:
     formula: "ttest_1samp([2.3,2.5,2.7,2.9,3.1], 2.5).pvalue ≈ 0.2302 (scipy); 2-tail p = incomplete_beta(df/2, 1/2, df/(df+t²))"
     note: "Guards against false-significant inference: the bug halved this p-value (0.1151) → spurious null rejection."
 
+  C-IBETA-004:
+    description: "Large-df p-value finiteness: prefactors are combined in LOG space so no intermediate overflows f32 (PMAT-904)"
+    formula: "∀ df ∈ {72,100,200}: chi_square_pvalue, t_distribution_pvalue, f_distribution_pvalue are FINITE and within 1e-3 of scipy"
+    note: "Raw-space gamma(z) overflows f32 at z ≳ 36 (Γ(36) ≈ 1e40); df ≥ 72 ⟹ a = df/2 ≥ 36 ⟹ incomplete_gamma / beta_function returned Inf/Inf = NaN. Fix: ln_gamma in log space, single bounded exp at the end."
+
+proof_obligations:
+  - type: invariant
+    property: "OBLIG-CHISQUARE-PVALUE-FINITE: chi-square survival p-value is finite for all degrees of freedom"
+    formal: "∀ df > 0, χ² ≥ 0: chi_square_pvalue(χ², df) ∈ [0,1] ∧ is_finite (in particular finite for df ≥ 72 where raw-space gamma(df/2) overflowed f32)"
+    applies_to: C-IBETA-004
+  - type: invariant
+    property: "OBLIG-HYPOTHESIS-PVALUE-FINITE: t- and F-distribution p-values are finite for all degrees of freedom"
+    formal: "∀ df ≥ 1: t_distribution_pvalue(t, df) ∈ [0,1] ∧ is_finite; ∀ df1,df2 ≥ 1: f_distribution_pvalue(f, df1, df2) ∈ [0,1] ∧ is_finite (finite for df ≥ 72 where the incomplete_beta gamma prefactor overflowed f32)"
+    applies_to: C-IBETA-004
+
 falsification:
   - id: FALSIFY-STATS-BETA-001
     description: "I_x(a,b) equals the scipy oracle for a != 1 (and still for a == 1). Discharges C-IBETA-001 + C-IBETA-002."
@@ -57,3 +72,15 @@ falsification:
     description: "One-sample t-test p-value matches scipy (downstream of the beta fix). Discharges C-IBETA-003."
     test: "test_ttest_1samp_pvalue_matches_scipy — RED 0.1151 (falsely significant) → GREEN 0.2302 == scipy.stats.ttest_1samp."
     evidence: "cargo test -p aprender-core --lib test_ttest_1samp_pvalue_matches_scipy"
+  - id: FALSIFY-HT-CHI2-FINITE
+    description: "Discharges OBLIG-CHISQUARE-PVALUE-FINITE (C-IBETA-004): chi-square p-value is finite and scipy-accurate for df in {72,100,200}. RED on the raw-space gamma overflow (NaN), GREEN after ln_gamma."
+    test: "cargo test -p aprender-core --lib falsify_ht_chi2_pvalue_finite_large_df"
+    evidence: "cargo test -p aprender-core --lib falsify_ht_chi2_pvalue_finite_large_df"
+  - id: FALSIFY-HT-T-FINITE
+    description: "Discharges OBLIG-HYPOTHESIS-PVALUE-FINITE (C-IBETA-004): two-tailed t p-value is finite and scipy-accurate for df in {72,100,200}."
+    test: "cargo test -p aprender-core --lib falsify_ht_t_pvalue_finite_large_df"
+    evidence: "cargo test -p aprender-core --lib falsify_ht_t_pvalue_finite_large_df"
+  - id: FALSIFY-HT-F-FINITE
+    description: "Discharges OBLIG-HYPOTHESIS-PVALUE-FINITE (C-IBETA-004): one-way ANOVA F p-value is finite and scipy-accurate for df2 in {72,100,200}."
+    test: "cargo test -p aprender-core --lib falsify_ht_f_pvalue_finite_large_df"
+    evidence: "cargo test -p aprender-core --lib falsify_ht_f_pvalue_finite_large_df"

--- a/crates/aprender-core/src/stats/beta_continued_fraction.rs
+++ b/crates/aprender-core/src/stats/beta_continued_fraction.rs
@@ -55,7 +55,39 @@ fn beta_continued_fraction(a: f32, b: f32, x: f32) -> f32 {
     h
 }
 
+/// Log-gamma function `ln Γ(z)` (Lanczos approximation).
+///
+/// PMAT-904: the raw-space `gamma()` below evaluates `(...).exp()` directly,
+/// which overflows f32 (Γ(36) ≈ 1e40, Inf at z ≳ 36). p-value paths for
+/// degrees-of-freedom df ≳ 72 must combine gamma terms in LOG space (divide
+/// gammas as a subtraction of `ln_gamma`, then a single final `exp`) so no
+/// intermediate ever overflows. `ln Γ` grows only ~ z ln z, never overflowing
+/// f32 for any df reachable here.
+fn ln_gamma(z: f32) -> f32 {
+    if z < 0.5 {
+        // Reflection: ln Γ(z) = ln(π / sin(πz)) − ln Γ(1−z).
+        let sin_pz = (PI * z).sin();
+        (PI / sin_pz).ln() - ln_gamma(1.0 - z)
+    } else {
+        // Lanczos series, evaluated entirely in log space.
+        let z = z - 1.0;
+        let tmp = z + 5.5;
+        let tmp = (z + 0.5) * tmp.ln() - tmp;
+        let ser = 1.0 + 76.180_09_f32 / (z + 1.0) - 86.505_32_f32 / (z + 2.0)
+            + 24.014_1_f32 / (z + 3.0)
+            - 1.231_739_5_f32 / (z + 4.0)
+            + 0.001_208_58_f32 / (z + 5.0)
+            - 0.000_005_363_82_f32 / (z + 6.0);
+        tmp + (ser * (2.0 * PI).sqrt()).ln()
+    }
+}
+
 /// Gamma function approximation (Stirling's approximation).
+///
+/// NOTE: this raw-space form overflows f32 for z ≳ 36. Production p-value code
+/// uses `ln_gamma` and combines in log space (PMAT-904); this raw form is kept
+/// only for the small-argument unit tests.
+#[cfg(test)]
 fn gamma(z: f32) -> f32 {
     if z < 0.5 {
         // Reflection formula: Γ(z) = π / (sin(πz) * Γ(1-z))

--- a/crates/aprender-core/src/stats/hypothesis.rs
+++ b/crates/aprender-core/src/stats/hypothesis.rs
@@ -405,7 +405,11 @@ fn incomplete_gamma(a: f32, x: f32) -> f32 {
         return 1.0;
     }
 
-    // Series expansion: γ(a,x) = e^(-x) * x^a * Σ x^n / Γ(a+n+1)
+    // Series expansion: γ(a,x)/Γ(a) = e^(-x) * x^a * Σ x^n / Γ(a+n+1).
+    // The bounded `sum` factors Γ(a) back out; the e^(-x) x^a / Γ(a) prefactor
+    // is combined in LOG space (PMAT-904) so that for large `a` (df ≳ 72) the
+    // x^a and Γ(a) terms — each individually Inf in raw f32 — never materialize:
+    //   prefactor = exp(-x + a·ln(x) − ln Γ(a)).
     let mut sum = 1.0 / a;
     let mut term = 1.0 / a;
     for n in 1..100 {
@@ -416,7 +420,8 @@ fn incomplete_gamma(a: f32, x: f32) -> f32 {
         }
     }
 
-    ((-x).exp() * x.powf(a) * sum / gamma(a)).clamp(0.0, 1.0)
+    let ln_prefactor = -x + a * x.ln() - ln_gamma(a);
+    (ln_prefactor.exp() * sum).clamp(0.0, 1.0)
 }
 
 /// Incomplete beta function approximation.
@@ -432,7 +437,14 @@ fn incomplete_beta(a: f32, b: f32, x: f32) -> f32 {
     // The 1/a and 1/b normalizers belong ONLY in the final returns below — folding a
     // `/a` in here double-divided the if-branch (and `b/a`-scaled the else-branch),
     // making I_x(a,b) wrong for a != 1 (it was correct only at the a==1 identity).
-    let bt = (x.powf(a) * (1.0 - x).powf(b)) / beta_function(a, b);
+    //
+    // PMAT-904: combine the whole prefactor in LOG space. With B(a,b) =
+    // Γ(a)Γ(b)/Γ(a+b), ln(bt) = a·ln(x) + b·ln(1−x) + ln Γ(a+b) − ln Γ(a) − ln Γ(b).
+    // For large df (a or b ≳ 36) each raw Γ overflows f32 to Inf, so the old
+    // `x^a/B(a,b)` form yielded Inf/Inf = NaN p-values; the log-space form does
+    // a single bounded `exp` at the end and never overflows.
+    let ln_bt = a * x.ln() + b * (1.0 - x).ln() + ln_gamma(a + b) - ln_gamma(a) - ln_gamma(b);
+    let bt = ln_bt.exp();
 
     if x < (a + 1.0) / (a + b + 2.0) {
         bt * beta_continued_fraction(a, b, x) / a
@@ -442,6 +454,12 @@ fn incomplete_beta(a: f32, b: f32, x: f32) -> f32 {
 }
 
 /// Beta function B(a, b) = Γ(a)Γ(b)/Γ(a+b).
+///
+/// PMAT-904: production `incomplete_beta` now builds its prefactor in log space
+/// via `ln_gamma`, so the raw-space `beta_function`/`gamma` pair (which overflows
+/// f32 for large arguments) is retained only as a small-argument reference for
+/// the unit tests.
+#[cfg(test)]
 fn beta_function(a: f32, b: f32) -> f32 {
     gamma(a) * gamma(b) / gamma(a + b)
 }

--- a/crates/aprender-core/src/stats/hypothesis_tests.rs
+++ b/crates/aprender-core/src/stats/hypothesis_tests.rs
@@ -572,4 +572,73 @@ mod tests {
             "t-stat should be 0 for identical samples"
         );
     }
+
+
+    /// FALSIFY-STATS-PVALUE-FINITE-DF72 (PMAT-904): chi-square, two-tailed t, and
+    /// one-way ANOVA F p-values must be FINITE and scipy-accurate for large df
+    /// (df >= 72), where the raw-space `gamma()` overflowed f32 (z >= ~36) and
+    /// poisoned `incomplete_gamma` / `beta_function` -> NaN p-values.
+    ///
+    /// scipy oracle (pinned via `uv run --with scipy python3`):
+    ///   chi2.sf(df, df):  df=72 -> 0.4778333327, df=100 -> 0.4811916845, df=200 -> 0.4867012017
+    ///   2*t.sf(2.0, df):  df=72 -> 0.0492731583, df=100 -> 0.0482121787, df=200 -> 0.0468531862
+    ///   f.sf(2.0,df1,df2): (2,72) -> 0.1427843305, (3,100) -> 0.1188424679, (4,200) -> 0.0959540406
+    ///
+    /// Discharges OBLIG-CHISQUARE-PVALUE-FINITE + OBLIG-HYPOTHESIS-PVALUE-FINITE.
+    #[test]
+    fn test_pvalue_finite_for_large_df_matches_scipy() {
+        // --- chi-square: P(chi2 > x) at x = df (near the mean) ---
+        let chi_cases = [
+            (72usize, 0.477_833_33_f32),
+            (100, 0.481_191_68),
+            (200, 0.486_701_2),
+        ];
+        for (df, scipy_p) in chi_cases {
+            let p = chi_square_pvalue(df as f32, df);
+            assert!(
+                p.is_finite(),
+                "chi-square p-value NaN/Inf at df={df} (raw-space gamma overflow)"
+            );
+            assert!(
+                (p - scipy_p).abs() < 1e-3,
+                "chi-square df={df}: apr p={p} vs scipy {scipy_p}"
+            );
+        }
+
+        // --- two-tailed Student-t ---
+        let t_cases = [
+            (72.0f32, 0.049_273_16_f32),
+            (100.0, 0.048_212_18),
+            (200.0, 0.046_853_19),
+        ];
+        for (df, scipy_p) in t_cases {
+            let p = t_distribution_pvalue(2.0, df);
+            assert!(
+                p.is_finite(),
+                "t-test p-value NaN/Inf at df={df} (incomplete_beta gamma overflow)"
+            );
+            assert!(
+                (p - scipy_p).abs() < 1e-3,
+                "t-test df={df}: apr p={p} vs scipy {scipy_p}"
+            );
+        }
+
+        // --- one-way ANOVA F survival ---
+        let f_cases = [
+            (2usize, 72usize, 0.142_784_33_f32),
+            (3, 100, 0.118_842_47),
+            (4, 200, 0.095_954_04),
+        ];
+        for (df1, df2, scipy_p) in f_cases {
+            let p = f_distribution_pvalue(2.0, df1, df2);
+            assert!(
+                p.is_finite(),
+                "ANOVA F p-value NaN/Inf at df1={df1} df2={df2} (incomplete_beta gamma overflow)"
+            );
+            assert!(
+                (p - scipy_p).abs() < 1e-3,
+                "ANOVA F df1={df1} df2={df2}: apr p={p} vs scipy {scipy_p}"
+            );
+        }
+    }
 }

--- a/crates/aprender-core/src/stats/tests_hypothesis_contract.rs
+++ b/crates/aprender-core/src/stats/tests_hypothesis_contract.rs
@@ -73,6 +73,108 @@ fn falsify_ht_004_chisq_pvalue_bounded() {
     );
 }
 
+// =========================================================================
+// FALSIFY-HT-FINITE: finite p-values for large degrees of freedom (PMAT-904)
+//
+// Root cause: raw-space `gamma(z)` overflows f32 at z >= ~36 (Gamma(36) ~ 1e40).
+// For df >= ~72 the chi-square `incomplete_gamma` and the t/F `beta_function`
+// prefactors divide by an overflowed gamma -> Inf/Inf = NaN p-values.
+//
+// Oracle: scipy.stats (chi2.sf / t.sf / f.sf), assert |apr_p - scipy_p| < TOL.
+// TOL = 1e-5: f32 machine epsilon is ~1.2e-7; the series/continued-fraction
+// accumulation on order-1 p-values (~0.12..0.48) bottoms out near 1e-6 absolute
+// error, so 1e-5 is the numerically-honest f64-vs-f32 agreement bound. The PRE-FIX
+// failure mode was NaN (non-finite), not a near-miss tolerance, so the
+// `is_finite` assertion below is the load-bearing falsifier; TOL only guards
+// against a wrong-but-finite regression.
+// =========================================================================
+
+/// scipy-vs-f32 agreement tolerance (see module note above).
+const PVALUE_SCIPY_TOL: f32 = 1e-5;
+
+/// OBLIG-CHISQUARE-PVALUE-FINITE / FALSIFY-HT-CHI2-FINITE:
+/// chi-square survival p-value is finite and matches scipy for df in {72,100,200}.
+#[test]
+fn falsify_ht_chi2_pvalue_finite_large_df() {
+    // scipy.stats.chi2.sf(df, df) for chi2 == df:
+    //   df=72  -> 4.7783333265e-01
+    //   df=100 -> 4.8119168453e-01
+    //   df=200 -> 4.8670120172e-01
+    let cases: [(usize, f32); 3] = [
+        (72, 4.778_333_3e-01),
+        (100, 4.811_917e-01),
+        (200, 4.867_012e-01),
+    ];
+    for (df, scipy_p) in cases {
+        let chi2 = df as f32;
+        let p = chi_square_pvalue(chi2, df);
+        assert!(
+            p.is_finite(),
+            "FALSIFIED HT-CHI2-FINITE: chi-square p-value is non-finite ({p}) at df={df} (raw-space gamma overflow)"
+        );
+        assert!(
+            (p - scipy_p).abs() < PVALUE_SCIPY_TOL,
+            "FALSIFIED HT-CHI2-FINITE: chi-square p={p} != scipy {scipy_p} at df={df} (|diff|={})",
+            (p - scipy_p).abs()
+        );
+    }
+}
+
+/// OBLIG-HYPOTHESIS-PVALUE-FINITE / FALSIFY-HT-T-FINITE:
+/// two-tailed t-distribution p-value is finite and matches scipy for df in {72,100,200}.
+#[test]
+fn falsify_ht_t_pvalue_finite_large_df() {
+    // 2*scipy.stats.t.sf(2.0, df):
+    //   df=72  -> 4.9273158278e-02
+    //   df=100 -> 4.8212178731e-02
+    //   df=200 -> 4.6853186187e-02
+    let cases: [(f32, f32); 3] = [
+        (72.0, 4.927_315_8e-02),
+        (100.0, 4.821_217_9e-02),
+        (200.0, 4.685_318_6e-02),
+    ];
+    for (df, scipy_p) in cases {
+        let p = t_distribution_pvalue(2.0, df);
+        assert!(
+            p.is_finite(),
+            "FALSIFIED HT-T-FINITE: t p-value is non-finite ({p}) at df={df} (raw-space gamma overflow)"
+        );
+        assert!(
+            (p - scipy_p).abs() < PVALUE_SCIPY_TOL,
+            "FALSIFIED HT-T-FINITE: t p={p} != scipy {scipy_p} at df={df} (|diff|={})",
+            (p - scipy_p).abs()
+        );
+    }
+}
+
+/// OBLIG-HYPOTHESIS-PVALUE-FINITE / FALSIFY-HT-F-FINITE:
+/// one-way ANOVA F-distribution p-value is finite and matches scipy for df2 in {72,100,200}.
+#[test]
+fn falsify_ht_f_pvalue_finite_large_df() {
+    // scipy.stats.f.sf(2.0, 3, df2):
+    //   df2=72  -> 1.2161927540e-01
+    //   df2=100 -> 1.1884246789e-01
+    //   df2=200 -> 1.1524280145e-01
+    let cases: [(usize, f32); 3] = [
+        (72, 1.216_192_8e-01),
+        (100, 1.188_424_7e-01),
+        (200, 1.152_428e-01),
+    ];
+    let df1 = 3usize;
+    for (df2, scipy_p) in cases {
+        let p = f_distribution_pvalue(2.0, df1, df2);
+        assert!(
+            p.is_finite(),
+            "FALSIFIED HT-F-FINITE: F p-value is non-finite ({p}) at df2={df2} (raw-space gamma overflow)"
+        );
+        assert!(
+            (p - scipy_p).abs() < PVALUE_SCIPY_TOL,
+            "FALSIFIED HT-F-FINITE: F p={p} != scipy {scipy_p} at df2={df2} (|diff|={})",
+            (p - scipy_p).abs()
+        );
+    }
+}
+
 mod ht_proptest_falsify {
     use super::*;
     use proptest::prelude::*;


### PR DESCRIPTION
## Pillar-1 scipy.stats parity beat (PMAT-904)

### Bug
`chi_square_pvalue`, `t_distribution_pvalue`, and one-way ANOVA `f_distribution_pvalue` returned **NaN** for degrees-of-freedom `df >= ~72`.

### Root cause (single)
The raw-space Lanczos `gamma()` in `crates/aprender-core/src/stats/beta_continued_fraction.rs` evaluated `(tmp + ln(ser)).exp()` directly, which **overflows f32** for `z >= ~36` (`Γ(36) ≈ 1e40 > f32::MAX ≈ 3.4e38`).

For `df >= ~72` the gamma argument `a = df/2 >= 36`, so:
- `incomplete_gamma`: `x^a / Γ(a)` → `Inf / Inf = NaN` (chi-square)
- `incomplete_beta` prefactor: `x^a (1-x)^b / B(a,b)`, `B = Γ(a)Γ(b)/Γ(a+b)` → `Inf` → `NaN` (t-test, ANOVA F)

### Fix (minimal, numerically correct)
Add `ln_gamma(z)` (log-space Lanczos) and combine prefactors in **log space**, with a single bounded `exp` at the end so no intermediate overflows:

```
incomplete_gamma:  exp(-x + a*ln(x) - ln_gamma(a)) * sum
incomplete_beta:   ln(bt) = a*ln(x) + b*ln(1-x) + ln_gamma(a+b) - ln_gamma(a) - ln_gamma(b)
```

The raw-space `gamma()`/`beta_function()` are demoted to `#[cfg(test)]` (private, no production callers; retained as a small-argument unit-test reference).

### Falsifiers (scipy oracle pinned via `uv run --with scipy`)
RED on raw-space overflow (NaN) → GREEN after `ln_gamma`, for `df ∈ {72,100,200}`:
- `falsify_ht_chi2_pvalue_finite_large_df` (chi2.sf)
- `falsify_ht_t_pvalue_finite_large_df` (2·t.sf)
- `falsify_ht_f_pvalue_finite_large_df` (f.sf)
- `test_pvalue_finite_for_large_df_matches_scipy`

The load-bearing assertion is `is_finite` (pre-fix failure mode is NaN). The scipy-agreement assertion (`1e-5` in contract tests, `1e-3` inline) guards against a *wrong-but-finite* regression. `1e-6` was unachievable in f32 on order-1 p-values (~0.48) — f32 epsilon ~1.2e-7 floors the accumulated series/continued-fraction error near 1e-6 absolute.

**Mutation-verified non-tautological:** reintroducing the raw-space overflow makes all four falsifiers FAIL; reverting restores GREEN.

### Contract
`contracts/incomplete-beta-correctness-v1.yaml` bumped `1.0.0 → 1.1.0`:
- new equation `C-IBETA-004` (large-df finiteness)
- named proof_obligations `OBLIG-CHISQUARE-PVALUE-FINITE` + `OBLIG-HYPOTHESIS-PVALUE-FINITE`
- three single-line `cargo test` falsification refs

`pv validate` ✓ and `pv lint contracts/` ✓ (Gate-4: no dangling refs).

### Verification
- `cargo test -p aprender-core --lib` → 13975 passed, 0 failed
- `cargo fmt -p aprender-core --check` ✓, `cargo clippy -p aprender-core --lib` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)