### PR TITLE
fix(serve): fail-closed reject vocab/weight-shape config mismatch at APR load (PMAT-906)

### DIFF
--- a/contracts/apr-load-fail-closed-config-v1.yaml
+++ b/contracts/apr-load-fail-closed-config-v1.yaml
@@ -1,0 +1,79 @@
+contract: apr-load-fail-closed-config
+metadata:
+  kind: pattern
+  version: "1.0.0"
+  description: >
+    realizar's APR loader (AprV2Model::from_model_data, reached via load() and
+    from_bytes()) must FAIL CLOSED on a structurally-INCONSISTENT model whose
+    declared transformer config (the .apr metadata block: vocab_size, hidden_size)
+    disagrees with the SHAPES of the loaded weight tensors. Before PMAT-906,
+    from_model_data parsed the tensor index and returned Ok with NO config<->shape
+    cross-check: an APR whose metadata declares vocab_size=99 while the embedding /
+    lm_head matrix has only 10 rows would load fine, and token IDs in [10,99) would
+    index PAST the embedding table at inference (garbage / OOB); an APR whose
+    metadata declares hidden_size=64 while the embedding matrix has only 8 columns
+    would load fine, and every matmul would read the hidden vector with the wrong
+    stride (garbage). This is the same Pillar-4 fail-closed CLASS as the GGUF
+    truncated/NaN-Inf load gate (apr-load-fail-closed-truncated, OBLIG-GGUF-LOAD-NANINF)
+    and the SafeTensors cross-tensor structural beat (apr-fail-closed-structural-beat,
+    OBLIG-STRUCT-*), but applied to the APR config<->tensor-shape boundary. PMAT-906
+    adds AprV2Model::validate_config_consistency(), called from from_model_data, which
+    returns Err(FormatError) naming the inconsistent tensor and the declared-vs-actual
+    dims. llama.cpp / Ollama load mismatched-metadata models silently (check_tensors
+    defaults to off), so apr rejecting it at load is a genuine Pillar-4 BEAT, not parity.
+    The gate is enforced only for transformer models that declare BOTH vocab_size and
+    hidden_size; non-transformer / simple predict() models and models that omit the
+    config are untouched (no false positive).
+  references:
+  - "crates/aprender-serve/src/apr/loading_mmap.rs (AprV2Model::from_model_data + validate_config_consistency)"
+  - "crates/aprender-serve/src/apr/beat_fail_closed_config.rs (PMAT-906 falsifiers)"
+  - "contracts/apr-load-fail-closed-truncated-v1.yaml (sibling GGUF-load fail-closed gate, OBLIG-GGUF-LOAD-NANINF)"
+  - "contracts/apr-fail-closed-structural-beat-v1.yaml (sibling SafeTensors cross-tensor structural beat, OBLIG-STRUCT-*)"
+version: 1
+status: enforced
+date: 2026-06-23
+
+proof_obligations:
+  - type: invariant
+    property: >
+      OBLIG-APR-VOCAB-EMBED-CONSISTENT: when the .apr metadata declares both
+      vocab_size and hidden_size, AprV2Model::validate_config_consistency (called from
+      from_model_data) returns Err(FormatError) iff config.vocab_size is not one of the
+      two dims of the 2-D token-embedding matrix (model.embed_tokens.weight /
+      embed_tokens.weight / transformer.wte.weight / embeddings.word_embeddings.weight /
+      tok_embeddings.weight / token_embd.weight) — or, when a separate untied lm_head.weight
+      is present, not one of its two dims. A vocab mismatch means token IDs would index out
+      of bounds in the embedding table (or logits target the wrong vocabulary) and inference
+      would produce garbage, so apr fails closed at load. A model whose embedding rows match
+      the declared vocab_size loads unchanged (no false positive).
+  - type: invariant
+    property: >
+      OBLIG-APR-WEIGHT-SHAPE-MATCHES-CONFIG: when the .apr metadata declares both
+      vocab_size and hidden_size, AprV2Model::validate_config_consistency returns
+      Err(FormatError) iff config.hidden_size is not one of the two dims of the 2-D
+      token-embedding matrix (or, when present, the untied lm_head.weight). A hidden-dim
+      mismatch means every matmul would read the hidden vector with the wrong stride and
+      inference would produce garbage, so apr fails closed at load. A model whose embedding
+      columns match the declared hidden_size loads unchanged (no false positive). Only
+      transformer models declaring BOTH config dims are gated; models omitting the config
+      (e.g. simple predict() models) are never flagged.
+
+falsification_tests:
+  - id: FALSIFY-APR-LOAD-VOCAB-001
+    name: vocab_embed_mismatch_rejected_at_load
+    prediction: "an APR whose metadata declares vocab_size=99 but whose embedding/lm_head matrices have 10 rows makes AprV2Model::from_bytes return Err(FormatError) naming OBLIG-APR-VOCAB-EMBED-CONSISTENT; a self-consistent APR (vocab=10, hidden=8) still loads Ok"
+    test_harness: "cargo test -p aprender-serve --lib vocab_embed_mismatch_rejected_at_load"
+    expected_output: "test result: ok"
+    if_fails: "an APR whose declared vocab_size disagrees with its embedding rows loads silently → token IDs index out of bounds and apr run/serve emit garbage instead of failing closed at load (Pillar-4 beat regressed to parity with llama.cpp/Ollama)."
+  - id: FALSIFY-APR-LOAD-HIDDEN-001
+    name: weight_shape_hidden_mismatch_rejected_at_load
+    prediction: "an APR whose metadata declares hidden_size=64 but whose embedding/lm_head matrices have 8 columns makes AprV2Model::from_bytes return Err(FormatError) naming OBLIG-APR-WEIGHT-SHAPE-MATCHES-CONFIG; a self-consistent APR (vocab=10, hidden=8) still loads Ok"
+    test_harness: "cargo test -p aprender-serve --lib weight_shape_hidden_mismatch_rejected_at_load"
+    expected_output: "test result: ok"
+    if_fails: "an APR whose declared hidden_size disagrees with its weight columns loads silently → every matmul reads the hidden vector with the wrong stride and apr run/serve emit garbage instead of failing closed at load."
+  - id: FALSIFY-APR-LOAD-NO-FALSE-POSITIVE-001
+    name: consistent_apr_still_loads_ok
+    prediction: "a fully self-consistent pygmy APR (vocab_size=10 matching 10 embedding rows, hidden_size=8 matching 8 embedding columns) loads Ok — the config-consistency gate raises no false positive"
+    test_harness: "cargo test -p aprender-serve --lib consistent_apr_still_loads_ok"
+    expected_output: "test result: ok"
+    if_fails: "the config-consistency gate became over-eager and rejects a valid, self-consistent APR model → apr fails to load legitimate models at load time."

--- a/crates/aprender-serve/src/apr/beat_fail_closed_config.rs
+++ b/crates/aprender-serve/src/apr/beat_fail_closed_config.rs
@@ -1,0 +1,251 @@
+//! PMAT-906 — Pillar-4 fail-closed: reject a structurally-INCONSISTENT APR model
+//! at the LOAD path (`AprV2Model::from_bytes` / `load`), rather than accepting it
+//! and emitting garbage at inference.
+//!
+//! THE BEAT (a real win, not just parity): an APR whose declared `config.vocab_size`
+//! does not match the embedding/lm_head ROW count, or whose weight tensor shape does
+//! not match the dims implied by `config.hidden_size`, is structurally broken — every
+//! token lookup / matmul reads with the wrong stride (or indexes out of bounds) and
+//! produces garbage. Before this fix, `from_model_data` accepted such a model `Ok`
+//! and only blew up (or silently garbled) deep inside `forward()`.
+//!
+//! llama.cpp / Ollama ALSO load mismatched-metadata models (their `check_tensors`
+//! defaults to off). So `apr` REJECTING it at LOAD is a genuine fail-closed BEAT
+//! (PMAT-744 / PMAT-895 lineage).
+//!
+//!   - OBLIG-APR-VOCAB-EMBED-CONSISTENT
+//!   - OBLIG-APR-WEIGHT-SHAPE-MATCHES-CONFIG
+
+use crate::apr::{AprV2Model, HEADER_SIZE, MAGIC};
+
+/// Tensor definition: (name, dtype byte, shape, byte_size).
+type TensorDef = (&'static str, u8, Vec<u64>, usize);
+
+/// Serialize one APR v2 tensor index entry (variable-size format):
+/// name_len(2) + name + dtype(1) + ndim(1) + dims(8×ndim) + offset(8) + size(8).
+fn tensor_entry(name: &str, dtype: u8, shape: &[u64], offset: u64, size: u64) -> Vec<u8> {
+    let mut data = Vec::new();
+    data.extend_from_slice(&(name.len() as u16).to_le_bytes());
+    data.extend_from_slice(name.as_bytes());
+    data.push(dtype);
+    data.push(shape.len() as u8);
+    for &dim in shape {
+        data.extend_from_slice(&dim.to_le_bytes());
+    }
+    data.extend_from_slice(&offset.to_le_bytes());
+    data.extend_from_slice(&size.to_le_bytes());
+    data
+}
+
+/// Build a minimal F32 APR v2 model with caller-controlled metadata config dims
+/// and tensor shapes. This lets a falsifier inject EXACTLY one mismatch
+/// (vocab_size vs embedding rows, or hidden_size vs weight cols) while keeping
+/// everything else self-consistent.
+fn build_apr(
+    meta_vocab_size: usize,
+    meta_hidden_size: usize,
+    tensor_defs: &[TensorDef],
+) -> Vec<u8> {
+    let metadata = format!(
+        r#"{{
+        "architecture": "llama",
+        "hidden_size": {meta_hidden_size},
+        "num_layers": 1,
+        "num_heads": 2,
+        "num_kv_heads": 2,
+        "vocab_size": {meta_vocab_size},
+        "intermediate_size": 16,
+        "max_position_embeddings": 512,
+        "rms_norm_eps": 1e-6
+    }}"#
+    );
+    let metadata_bytes = metadata.as_bytes();
+    let metadata_padded_size = metadata_bytes.len().div_ceil(64) * 64;
+
+    let mut entries = Vec::new();
+    let mut current_offset = 0u64;
+    for (name, dtype, shape, byte_size) in tensor_defs {
+        entries.push(tensor_entry(
+            name,
+            *dtype,
+            shape,
+            current_offset,
+            *byte_size as u64,
+        ));
+        current_offset += *byte_size as u64;
+    }
+    let tensor_index: Vec<u8> = entries.iter().flat_map(|e| e.iter().copied()).collect();
+    let tensor_count = tensor_defs.len() as u32;
+    let total_data_size = current_offset as usize;
+
+    let tensor_index_offset = HEADER_SIZE as u64 + metadata_padded_size as u64;
+    let data_offset = tensor_index_offset + tensor_index.len() as u64;
+    let total_size = data_offset as usize + total_data_size;
+
+    let mut data = vec![0u8; total_size];
+    data[0..4].copy_from_slice(&MAGIC);
+    data[4] = 2; // version major
+    data[5] = 0; // version minor
+    data[8..12].copy_from_slice(&tensor_count.to_le_bytes());
+    data[12..20].copy_from_slice(&(HEADER_SIZE as u64).to_le_bytes());
+    data[20..24].copy_from_slice(&(metadata_bytes.len() as u32).to_le_bytes());
+    data[24..32].copy_from_slice(&tensor_index_offset.to_le_bytes());
+    data[32..40].copy_from_slice(&data_offset.to_le_bytes());
+
+    data[HEADER_SIZE..HEADER_SIZE + metadata_bytes.len()].copy_from_slice(metadata_bytes);
+
+    let idx_start = tensor_index_offset as usize;
+    data[idx_start..idx_start + tensor_index.len()].copy_from_slice(&tensor_index);
+
+    // Fill tensor data with small finite values (orthogonal to the config gate).
+    let data_start = data_offset as usize;
+    let num_floats = total_data_size / 4;
+    for i in 0..num_floats {
+        let val = ((i % 10) as f32 - 5.0) * 0.1;
+        data[data_start + i * 4..data_start + i * 4 + 4].copy_from_slice(&val.to_le_bytes());
+    }
+    data
+}
+
+/// Full self-consistent tensor set for a pygmy llama (vocab=V, hidden=H, inter=16).
+/// All weights match the config; mutate ONE entry to forge an inconsistency.
+fn consistent_tensor_defs(vocab: usize, hidden: usize) -> Vec<TensorDef> {
+    let inter = 16usize;
+    vec![
+        (
+            "model.embed_tokens.weight",
+            0,
+            vec![vocab as u64, hidden as u64],
+            vocab * hidden * 4,
+        ),
+        (
+            "model.layers.0.input_layernorm.weight",
+            0,
+            vec![hidden as u64],
+            hidden * 4,
+        ),
+        (
+            "model.layers.0.self_attn.q_proj.weight",
+            0,
+            vec![hidden as u64, hidden as u64],
+            hidden * hidden * 4,
+        ),
+        (
+            "model.layers.0.self_attn.k_proj.weight",
+            0,
+            vec![hidden as u64, hidden as u64],
+            hidden * hidden * 4,
+        ),
+        (
+            "model.layers.0.self_attn.v_proj.weight",
+            0,
+            vec![hidden as u64, hidden as u64],
+            hidden * hidden * 4,
+        ),
+        (
+            "model.layers.0.self_attn.o_proj.weight",
+            0,
+            vec![hidden as u64, hidden as u64],
+            hidden * hidden * 4,
+        ),
+        (
+            "model.layers.0.post_attention_layernorm.weight",
+            0,
+            vec![hidden as u64],
+            hidden * 4,
+        ),
+        (
+            "model.layers.0.mlp.gate_proj.weight",
+            0,
+            vec![inter as u64, hidden as u64],
+            hidden * inter * 4,
+        ),
+        (
+            "model.layers.0.mlp.up_proj.weight",
+            0,
+            vec![inter as u64, hidden as u64],
+            hidden * inter * 4,
+        ),
+        (
+            "model.layers.0.mlp.down_proj.weight",
+            0,
+            vec![hidden as u64, inter as u64],
+            hidden * inter * 4,
+        ),
+        ("model.norm.weight", 0, vec![hidden as u64], hidden * 4),
+        (
+            "lm_head.weight",
+            0,
+            vec![vocab as u64, hidden as u64],
+            vocab * hidden * 4,
+        ),
+    ]
+}
+
+/// FP-bound: a fully self-consistent pygmy APR (vocab=10, hidden=8) still loads `Ok`.
+/// The config gate must not reject a legitimate model.
+#[test]
+fn consistent_apr_still_loads_ok() {
+    let defs = consistent_tensor_defs(10, 8);
+    let bytes = build_apr(10, 8, &defs);
+    let result = AprV2Model::from_bytes(bytes);
+    assert!(
+        result.is_ok(),
+        "FP-bound FAIL: config-consistency gate rejected a self-consistent APR: {:?}",
+        result.err()
+    );
+}
+
+/// RED → GREEN falsifier for OBLIG-APR-VOCAB-EMBED-CONSISTENT.
+///
+/// The embedding/lm_head matrices have 10 rows (vocab=10), but the declared
+/// `config.vocab_size` is 99. On `main` (before the fix) `from_bytes` returned
+/// `Ok` — token IDs in [10,99) would index PAST the 10-row embedding table at
+/// inference (garbage / OOB). After the fix it MUST return `Err`.
+#[test]
+fn vocab_embed_mismatch_rejected_at_load() {
+    // Weights physically sized for vocab=10, hidden=8 ...
+    let defs = consistent_tensor_defs(10, 8);
+    // ... but the metadata LIES: it declares vocab_size=99.
+    let bytes = build_apr(99, 8, &defs);
+
+    let result = AprV2Model::from_bytes(bytes);
+    assert!(
+        result.is_err(),
+        "OBLIG-APR-VOCAB-EMBED-CONSISTENT FAIL: from_bytes accepted an APR whose declared \
+         vocab_size=99 != embedding rows=10. Token IDs would index out of bounds and inference \
+         would produce garbage. apr must fail closed at load."
+    );
+    let msg = format!("{:?}", result.err().unwrap());
+    assert!(
+        msg.contains("OBLIG-APR-VOCAB-EMBED-CONSISTENT"),
+        "rejection must name the obligation, got: {msg}"
+    );
+}
+
+/// RED → GREEN falsifier for OBLIG-APR-WEIGHT-SHAPE-MATCHES-CONFIG.
+///
+/// The embedding/lm_head matrices have 8 columns (hidden=8), but the declared
+/// `config.hidden_size` is 64. On `main` (before the fix) `from_bytes` returned
+/// `Ok` — every matmul would read the hidden vector with the wrong stride
+/// (garbage). After the fix it MUST return `Err`.
+#[test]
+fn weight_shape_hidden_mismatch_rejected_at_load() {
+    // Weights physically sized for vocab=10, hidden=8 ...
+    let defs = consistent_tensor_defs(10, 8);
+    // ... but the metadata LIES: it declares hidden_size=64.
+    let bytes = build_apr(10, 64, &defs);
+
+    let result = AprV2Model::from_bytes(bytes);
+    assert!(
+        result.is_err(),
+        "OBLIG-APR-WEIGHT-SHAPE-MATCHES-CONFIG FAIL: from_bytes accepted an APR whose declared \
+         hidden_size=64 != embedding cols=8. Every matmul would read the hidden vector with the \
+         wrong stride and inference would produce garbage. apr must fail closed at load."
+    );
+    let msg = format!("{:?}", result.err().unwrap());
+    assert!(
+        msg.contains("OBLIG-APR-WEIGHT-SHAPE-MATCHES-CONFIG"),
+        "rejection must name the obligation, got: {msg}"
+    );
+}

--- a/crates/aprender-serve/src/apr/loading_mmap.rs
+++ b/crates/aprender-serve/src/apr/loading_mmap.rs
@@ -145,12 +145,127 @@ impl AprV2Model {
             }
         }
 
-        Ok(Self {
+        let model = Self {
             header,
             metadata,
             tensors,
             data,
-        })
+        };
+
+        // PMAT-906 / Pillar-4 fail-closed: reject a structurally-inconsistent model
+        // at LOAD rather than producing garbage at inference. llama.cpp / Ollama
+        // silently load such a model; apr fails closed.
+        //   - OBLIG-APR-VOCAB-EMBED-CONSISTENT: config.vocab_size == embedding rows
+        //   - OBLIG-APR-WEIGHT-SHAPE-MATCHES-CONFIG: weight cols == config.hidden_size
+        model.validate_config_consistency()?;
+
+        Ok(model)
+    }
+
+    /// PMAT-906 — Pillar-4 fail-closed: verify the declared transformer config
+    /// is structurally consistent with the loaded weight tensors.
+    ///
+    /// Two checks, mirroring the GGUF/SafeTensors fail-closed gates
+    /// (OBLIG-GGUF-LOAD-NANINF, F-DATA-QUALITY-*):
+    ///
+    /// - **OBLIG-APR-VOCAB-EMBED-CONSISTENT**: `config.vocab_size` MUST equal the
+    ///   row count of the token-embedding matrix (and of `lm_head` when present
+    ///   and untied). A mismatch means token IDs index past the embedding table
+    ///   (or logits are projected to the wrong vocabulary) → garbage / OOB.
+    /// - **OBLIG-APR-WEIGHT-SHAPE-MATCHES-CONFIG**: the inner (column) dimension of
+    ///   the token-embedding / `lm_head` matrix MUST equal `config.hidden_size`.
+    ///   A mismatch means every matmul reads the hidden vector with the wrong
+    ///   stride → garbage.
+    ///
+    /// Only enforced for transformer models that declare BOTH `vocab_size` and
+    /// `hidden_size`; non-transformer / simple `predict` models are untouched.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RealizarError::FormatError`] naming the inconsistent tensor and
+    /// the declared-vs-actual dimensions.
+    fn validate_config_consistency(&self) -> Result<()> {
+        let Some(vocab_size) = self.metadata.vocab_size else {
+            return Ok(());
+        };
+        let Some(hidden_size) = self.metadata.hidden_size else {
+            return Ok(());
+        };
+
+        // Token-embedding matrix is [vocab_size, hidden_size] (row-major).
+        const EMBED_NAMES: &[&str] = &[
+            "model.embed_tokens.weight",
+            "embed_tokens.weight",
+            "transformer.wte.weight",
+            "embeddings.word_embeddings.weight",
+            "tok_embeddings.weight",
+            "token_embd.weight",
+        ];
+        if let Some(embed) = EMBED_NAMES.iter().find_map(|n| self.get_tensor(n)) {
+            if embed.shape.len() == 2 {
+                let (rows, cols) = (embed.shape[0], embed.shape[1]);
+                // Embedding may be stored as [vocab, hidden] (HF/SafeTensors) or
+                // [hidden, vocab] (some tied/GGUF layouts). Accept either
+                // orientation, but vocab_size MUST be one of the two dims and
+                // hidden_size the other.
+                let vocab_ok = rows == vocab_size || cols == vocab_size;
+                let hidden_ok = rows == hidden_size || cols == hidden_size;
+                if !vocab_ok {
+                    return Err(RealizarError::FormatError {
+                        reason: format!(
+                            "OBLIG-APR-VOCAB-EMBED-CONSISTENT: config vocab_size={vocab_size} \
+                             does not match embedding tensor '{}' shape {:?} — neither dim is \
+                             {vocab_size}. The declared vocabulary is inconsistent with the \
+                             embedding matrix; token IDs would index out of bounds and inference \
+                             would produce garbage. Re-convert the model.",
+                            embed.name, embed.shape
+                        ),
+                    });
+                }
+                if !hidden_ok {
+                    return Err(RealizarError::FormatError {
+                        reason: format!(
+                            "OBLIG-APR-WEIGHT-SHAPE-MATCHES-CONFIG: config hidden_size={hidden_size} \
+                             does not match embedding tensor '{}' shape {:?} — neither dim is \
+                             {hidden_size}. The hidden vector would be read with the wrong stride \
+                             and inference would produce garbage. Re-convert the model.",
+                            embed.name, embed.shape
+                        ),
+                    });
+                }
+            }
+        }
+
+        // Separate (untied) lm_head, when present, is [vocab_size, hidden_size].
+        if let Some(lm_head) = self.get_tensor("lm_head.weight") {
+            if lm_head.shape.len() == 2 {
+                let (rows, cols) = (lm_head.shape[0], lm_head.shape[1]);
+                if rows != vocab_size && cols != vocab_size {
+                    return Err(RealizarError::FormatError {
+                        reason: format!(
+                            "OBLIG-APR-VOCAB-EMBED-CONSISTENT: config vocab_size={vocab_size} \
+                             does not match lm_head tensor '{}' shape {:?}. The output projection \
+                             targets the wrong vocabulary; inference would produce garbage. \
+                             Re-convert the model.",
+                            lm_head.name, lm_head.shape
+                        ),
+                    });
+                }
+                if rows != hidden_size && cols != hidden_size {
+                    return Err(RealizarError::FormatError {
+                        reason: format!(
+                            "OBLIG-APR-WEIGHT-SHAPE-MATCHES-CONFIG: config hidden_size={hidden_size} \
+                             does not match lm_head tensor '{}' shape {:?}. The output projection \
+                             reads the hidden vector with the wrong stride; inference would produce \
+                             garbage. Re-convert the model.",
+                            lm_head.name, lm_head.shape
+                        ),
+                    });
+                }
+            }
+        }
+
+        Ok(())
     }
 
     /// Decompress APR data based on compression flags (GH-35)

--- a/crates/aprender-serve/src/apr/special_tokens.rs
+++ b/crates/aprender-serve/src/apr/special_tokens.rs
@@ -232,6 +232,11 @@ mod apr_tests_part_03;
 #[path = "tests_pygmy_apr.rs"]
 mod apr_tests_pygmy_apr;
 
+// PMAT-906 Pillar-4 fail-closed: reject vocab/weight-shape config mismatch at APR load
+#[cfg(test)]
+#[path = "beat_fail_closed_config.rs"]
+mod apr_beat_fail_closed_config;
+
 // T-COV-95 Coverage Bridge (Part 05 - AprFlags, AprHeader, TensorEntry, AprMetadata, dtype_to_qtype)
 #[cfg(test)]
 #[path = "tests_apr_flags_02.rs"]


### PR DESCRIPTION
## Pillar-4 fail-closed correctness beat (PMAT-906, EV 8.4)

The APR loader (`AprV2Model::from_model_data`, reached via `load()` / `from_bytes()`) accepted a structurally-**inconsistent** model and produced garbage at inference — exactly the class apr's mission says it must REJECT (fail-closed) where llama.cpp / Ollama silently load+run.

### The bug
Two checks were missing at the APR load path:
- **(A) `OBLIG-APR-VOCAB-EMBED-CONSISTENT`** — `config.vocab_size` must equal the embedding/`lm_head` matrix ROW count. A mismatch (e.g. declared `vocab_size=99` but 10 embedding rows) indexes token IDs past the embedding table at inference → garbage / OOB.
- **(B) `OBLIG-APR-WEIGHT-SHAPE-MATCHES-CONFIG`** — `config.hidden_size` must equal the embedding/`lm_head` matrix COLUMN count. A mismatch (e.g. declared `hidden_size=64` but 8 embedding cols) makes every matmul read the hidden vector with the wrong stride → garbage.

Before this fix, `from_model_data` parsed the tensor index and returned `Ok` with **no** config↔shape cross-check.

### The fix
Add `AprV2Model::validate_config_consistency()`, called from `from_model_data`, returning a clear actionable `Err(FormatError)` naming the inconsistent tensor and the declared-vs-actual dims. Mirrors the existing fail-closed style (`apr-load-fail-closed-truncated` `OBLIG-GGUF-LOAD-NANINF`, `apr-fail-closed-structural-beat` `OBLIG-STRUCT-*`).

Only enforced for transformer models declaring **both** `vocab_size` and `hidden_size`; simple `predict()` / config-less models are untouched (no false positive).

### Verification (full beat discipline)
- **RED confirmed**: with `validate_config_consistency()?` removed, both mismatch falsifiers FAIL (loader accepts the broken model `Ok`) while the consistent FP-bound test still passes — proves the falsifiers are non-tautological and genuinely exercise the new check.
- **GREEN confirmed**: 3/3 new falsifiers pass; full `cargo test -p aprender-serve --lib` = 15432 passed, 0 failed.
- **Contract** `contracts/apr-load-fail-closed-config-v1.yaml`: `pv validate` → valid; `pv lint contracts/` → PASS (Gate-4).

Falsifiers (`crates/aprender-serve/src/apr/beat_fail_closed_config.rs`):
- `vocab_embed_mismatch_rejected_at_load`
- `weight_shape_hidden_mismatch_rejected_at_load`
- `consistent_apr_still_loads_ok` (FP-bound)

🤖 Generated with [Claude Code](https://claude.com/claude-code)