### PR TITLE
fix(autograd): LayerNorm+RMSNorm backward flows gradient to affine params — transformers fine-tunable (PMAT-907)

### DIFF
--- a/contracts/norm-backward-gradflow-v1.yaml
+++ b/contracts/norm-backward-gradflow-v1.yaml
@@ -1,0 +1,71 @@
+contract: norm-backward-gradflow
+metadata:
+  kind: training-loop
+  version: "1.0.0"
+  description: >
+    LayerNorm and RMSNorm backward MUST flow gradient to their AFFINE parameters
+    (LayerNorm: scale gamma=weight + shift beta=bias; RMSNorm: scale gamma=weight)
+    AND to the input x. Guards the PMAT-907 root-cause fix: the canonical
+    nn::functional::layer_norm / rms_norm built their output via Tensor::from_vec,
+    which severs the autograd graph — after loss.backward(), get_grad(weight.id())
+    / get_grad(bias.id()) were None, so the norm scale/shift never updated. Every
+    transformer using LayerNorm/RMSNorm was therefore NON-FINE-TUNABLE. The
+    functional norms now record LayerNormBackward / RmsNormBackward on the tape,
+    wiring x, gamma, beta as graph inputs.
+  references:
+  - "crates/aprender-core/src/nn/functional.rs"
+  - "crates/aprender-core/src/autograd/grad_fn.rs"
+  - "crates/aprender-core/src/nn/normalization/tests_norm_backward_gradflow.rs"
+version: 1
+status: enforced
+date: 2026-06-23
+
+proof_obligations:
+  - type: invariant
+    property: >
+      OBLIG-LAYERNORM-BACKWARD-GRAD-FLOW: after loss.backward() on a graph
+      containing the affine LayerNorm forward, get_grad is Some for gamma
+      (weight), beta (bias), and the input x. The analytic gradients match a
+      central finite-difference gradcheck within tolerance: dL/dgamma_i =
+      sum_batch g_i * x_hat_i; dL/dbeta_i = sum_batch g_i; and dL/dx flows through
+      the mean/var normalization (std_inv * (g' - mean(g') - x_hat*mean(g'*x_hat))).
+  - type: invariant
+    property: >
+      OBLIG-RMSNORM-BACKWARD-GRAD-FLOW: after loss.backward() on a graph
+      containing the affine RMSNorm forward, get_grad is Some for gamma (weight)
+      and the input x. The analytic gradients match a central finite-difference
+      gradcheck within tolerance: dL/dgamma_i = sum_batch g_i * x_hat_i (x_hat =
+      x/rms); dL/dx_j = (1/rms) * (g'_j - x_hat_j * mean_i(g'_i * x_hat_i)), with
+      NO mean-subtraction term (unlike LayerNorm).
+  - type: equivalence
+    property: >
+      GRADCHECK-NON-TAUTOLOGICAL: the falsifier is a finite-difference gradcheck,
+      not an is_some assertion on a hardcoded value. Re-severing or scaling any one
+      parameter's backward edge makes the central-difference comparison go RED for
+      that parameter (mutation-verified: gamma += g*xhat*1.5 fails the gradcheck).
+
+falsification_tests:
+  - id: FALSIFY-LAYERNORM-BACKWARD-GRAD-FLOW-001
+    name: layernorm_backward_flows_grad_to_gamma_and_beta
+    prediction: "LayerNorm gamma+beta grads are Some and match the finite-difference gradcheck within tol"
+    test_harness: "cargo test -p aprender-core --lib layernorm_backward_flows_grad_to_gamma_and_beta"
+    expected_output: "test result: ok"
+    if_fails: "nn::functional::layer_norm severed the autograd graph (Tensor::from_vec). Record LayerNormBackward on the tape with inputs [x, weight, bias]."
+  - id: FALSIFY-LAYERNORM-BACKWARD-GRAD-FLOW-002
+    name: layernorm_backward_flows_grad_to_input
+    prediction: "LayerNorm input x grad is Some and matches the finite-difference gradcheck within tol"
+    test_harness: "cargo test -p aprender-core --lib layernorm_backward_flows_grad_to_input"
+    expected_output: "test result: ok"
+    if_fails: "LayerNorm dL/dx must include the mean/var coupling terms; a missing edge freezes stacked norm layers."
+  - id: FALSIFY-RMSNORM-BACKWARD-GRAD-FLOW-001
+    name: rmsnorm_backward_flows_grad_to_gamma
+    prediction: "RMSNorm gamma grad is Some and matches the finite-difference gradcheck within tol"
+    test_harness: "cargo test -p aprender-core --lib rmsnorm_backward_flows_grad_to_gamma"
+    expected_output: "test result: ok"
+    if_fails: "nn::functional::rms_norm severed the autograd graph. Record RmsNormBackward on the tape with inputs [x, weight]."
+  - id: FALSIFY-RMSNORM-BACKWARD-GRAD-FLOW-002
+    name: rmsnorm_backward_flows_grad_to_input
+    prediction: "RMSNorm input x grad is Some and matches the finite-difference gradcheck within tol"
+    test_harness: "cargo test -p aprender-core --lib rmsnorm_backward_flows_grad_to_input"
+    expected_output: "test result: ok"
+    if_fails: "RMSNorm dL/dx must use r_inv*(g' - x_hat*mean(g'*x_hat)) with NO mean-subtraction term."

--- a/crates/aprender-core/src/autograd/grad_fn.rs
+++ b/crates/aprender-core/src/autograd/grad_fn.rs
@@ -486,5 +486,159 @@ pub(crate) struct CrossEntropyBackward {
     pub(crate) reduction: crate::nn::loss::Reduction, // loss reduction mode
 }
 
+// ============================================================================
+// Normalization Operations (PMAT-907)
+// ============================================================================
+
+/// Gradient function for affine LayerNorm: y = x_hat * gamma + beta,
+/// where x_hat = (x - mean) / sqrt(var + eps) per normalized row.
+///
+/// Obligation: OBLIG-LAYERNORM-BACKWARD-GRAD-FLOW.
+///
+/// Before PMAT-907 the canonical functional `layer_norm` built its output via
+/// `Tensor::from_vec`, severing the autograd graph: gamma/beta/x received no
+/// gradient, making every LayerNorm transformer non-fine-tunable. This grad_fn
+/// flows gradient to ALL THREE inputs (x, gamma, beta), in that input order.
+///
+/// Math (per row of width `norm_dim`, with std_inv = 1/sqrt(var+eps)):
+/// - dL/dgamma_i = sum_batch g_i * x_hat_i
+/// - dL/dbeta_i  = sum_batch g_i
+/// - dL/dx_i     = std_inv * (g'_i - mean_j(g'_j) - x_hat_i * mean_j(g'_j * x_hat_j))
+///   where g'_i = g_i * gamma_i  (the gradient scaled by the affine weight).
+pub(crate) struct LayerNormBackward {
+    pub(crate) x: Tensor,
+    pub(crate) gamma: Tensor,
+    pub(crate) eps: f32,
+}
+
+impl GradFn for LayerNormBackward {
+    fn backward(&self, grad_output: &Tensor) -> Vec<Tensor> {
+        let norm_dim = self.gamma.data().len();
+        let x_data = self.x.data();
+        let gamma_data = self.gamma.data();
+        let g_data = grad_output.data();
+        let batch = x_data.len() / norm_dim;
+        let n = norm_dim as f32;
+
+        let mut grad_x = vec![0.0f32; x_data.len()];
+        let mut grad_gamma = vec![0.0f32; norm_dim];
+        let mut grad_beta = vec![0.0f32; norm_dim];
+
+        for b in 0..batch {
+            let off = b * norm_dim;
+            let xs = &x_data[off..off + norm_dim];
+            let gs = &g_data[off..off + norm_dim];
+
+            let mean: f32 = xs.iter().sum::<f32>() / n;
+            let var: f32 = xs.iter().map(|&v| (v - mean) * (v - mean)).sum::<f32>() / n;
+            let std_inv = 1.0 / (var + self.eps).sqrt();
+
+            // x_hat and g' = g * gamma; accumulate affine-param grads.
+            let mut x_hat = vec![0.0f32; norm_dim];
+            let mut g_prime = vec![0.0f32; norm_dim];
+            for i in 0..norm_dim {
+                let xh = (xs[i] - mean) * std_inv;
+                x_hat[i] = xh;
+                g_prime[i] = gs[i] * gamma_data[i];
+                grad_gamma[i] += gs[i] * xh;
+                grad_beta[i] += gs[i];
+            }
+
+            let mean_gp: f32 = g_prime.iter().sum::<f32>() / n;
+            let mean_gp_xhat: f32 = g_prime
+                .iter()
+                .zip(x_hat.iter())
+                .map(|(&a, &b)| a * b)
+                .sum::<f32>()
+                / n;
+
+            for i in 0..norm_dim {
+                grad_x[off + i] = std_inv * (g_prime[i] - mean_gp - x_hat[i] * mean_gp_xhat);
+            }
+        }
+
+        vec![
+            Tensor::new(&grad_x, self.x.shape()),
+            Tensor::new(&grad_gamma, self.gamma.shape()),
+            Tensor::new(&grad_beta, self.gamma.shape()),
+        ]
+    }
+
+    fn name(&self) -> &'static str {
+        "LayerNormBackward"
+    }
+}
+
+/// Gradient function for affine RMSNorm: y = x_hat * gamma,
+/// where x_hat = x / rms and rms = sqrt(mean(x^2) + eps) per normalized row.
+///
+/// Obligation: OBLIG-RMSNORM-BACKWARD-GRAD-FLOW.
+///
+/// Flows gradient to BOTH inputs (x, gamma), in that input order. RMSNorm has
+/// no mean-subtraction term (unlike LayerNorm).
+///
+/// Math (per row, with r = rms, x_hat_i = x_i / r):
+/// - dL/dgamma_i = sum_batch g_i * x_hat_i
+/// - dL/dx_j     = (1/r) * (g'_j - x_hat_j * mean_i(g'_i * x_hat_i))
+///   where g'_i = g_i * gamma_i.
+pub(crate) struct RmsNormBackward {
+    pub(crate) x: Tensor,
+    pub(crate) gamma: Tensor,
+    pub(crate) eps: f32,
+}
+
+impl GradFn for RmsNormBackward {
+    fn backward(&self, grad_output: &Tensor) -> Vec<Tensor> {
+        let norm_dim = self.gamma.data().len();
+        let x_data = self.x.data();
+        let gamma_data = self.gamma.data();
+        let g_data = grad_output.data();
+        let batch = x_data.len() / norm_dim;
+        let n = norm_dim as f32;
+
+        let mut grad_x = vec![0.0f32; x_data.len()];
+        let mut grad_gamma = vec![0.0f32; norm_dim];
+
+        for b in 0..batch {
+            let off = b * norm_dim;
+            let xs = &x_data[off..off + norm_dim];
+            let gs = &g_data[off..off + norm_dim];
+
+            let ms: f32 = xs.iter().map(|&v| v * v).sum::<f32>() / n;
+            let r = (ms + self.eps).sqrt();
+            let r_inv = 1.0 / r;
+
+            let mut x_hat = vec![0.0f32; norm_dim];
+            let mut g_prime = vec![0.0f32; norm_dim];
+            for i in 0..norm_dim {
+                let xh = xs[i] * r_inv;
+                x_hat[i] = xh;
+                g_prime[i] = gs[i] * gamma_data[i];
+                grad_gamma[i] += gs[i] * xh;
+            }
+
+            let mean_gp_xhat: f32 = g_prime
+                .iter()
+                .zip(x_hat.iter())
+                .map(|(&a, &b)| a * b)
+                .sum::<f32>()
+                / n;
+
+            for i in 0..norm_dim {
+                grad_x[off + i] = r_inv * (g_prime[i] - x_hat[i] * mean_gp_xhat);
+            }
+        }
+
+        vec![
+            Tensor::new(&grad_x, self.x.shape()),
+            Tensor::new(&grad_gamma, self.gamma.shape()),
+        ]
+    }
+
+    fn name(&self) -> &'static str {
+        "RmsNormBackward"
+    }
+}
+
 include!("gradient.rs");
 include!("grad_fn_tests.rs");

--- a/crates/aprender-core/src/nn/functional.rs
+++ b/crates/aprender-core/src/nn/functional.rs
@@ -377,23 +377,63 @@ pub fn layer_norm(x: &Tensor, weight: &Tensor, bias: &Tensor, eps: f32) -> Tenso
 
     // Delegate to trueno's AVX2+FMA SIMD layer_norm per row.
     // Contract: provable-contracts/contracts/layernorm-kernel-v1.yaml
-    if batch_size == 1 {
+    let output = if batch_size == 1 {
         // Fast path: single row, use alloc variant (no zero-fill)
-        let output = trueno::blis::norms::layer_norm_alloc(data, weight_data, bias_data, eps);
-        return Tensor::from_vec(output, shape);
+        trueno::blis::norms::layer_norm_alloc(data, weight_data, bias_data, eps)
+    } else {
+        let mut out = vec![0.0f32; data.len()];
+        for b in 0..batch_size {
+            let start = b * norm_dim;
+            let slice = &data[start..start + norm_dim];
+            let out_slice = &mut out[start..start + norm_dim];
+
+            trueno::blis::norms::layer_norm(slice, weight_data, bias_data, eps, out_slice)
+                .expect("layer_norm: dimension mismatch (should be impossible)");
+        }
+        out
+    };
+
+    let mut result = Tensor::from_vec(output, shape);
+
+    // PMAT-907 / OBLIG-LAYERNORM-BACKWARD-GRAD-FLOW: wire the autograd backward
+    // so gradients flow to the affine params (gamma=weight, beta=bias) AND the
+    // input x. Without this the layer is non-fine-tunable (graph severed).
+    record_layer_norm_backward(x, weight, bias, eps, &mut result);
+
+    result
+}
+
+/// Record the LayerNorm backward edge on the autograd tape (PMAT-907).
+fn record_layer_norm_backward(
+    x: &Tensor,
+    weight: &Tensor,
+    bias: &Tensor,
+    eps: f32,
+    result: &mut Tensor,
+) {
+    use crate::autograd::{is_grad_enabled, with_graph};
+    use std::sync::Arc;
+
+    if is_grad_enabled()
+        && (x.requires_grad_enabled()
+            || weight.requires_grad_enabled()
+            || bias.requires_grad_enabled())
+    {
+        result.requires_grad_(true);
+        let grad_fn = Arc::new(crate::autograd::grad_fn::LayerNormBackward {
+            x: x.clone(),
+            gamma: weight.clone(),
+            eps,
+        });
+        result.set_grad_fn(grad_fn.clone());
+
+        with_graph(|graph| {
+            graph.register_tensor(x.clone());
+            graph.register_tensor(weight.clone());
+            graph.register_tensor(bias.clone());
+            graph.record(result.id(), grad_fn, vec![x.id(), weight.id(), bias.id()]);
+        });
     }
-
-    let mut output = vec![0.0f32; data.len()];
-    for b in 0..batch_size {
-        let start = b * norm_dim;
-        let slice = &data[start..start + norm_dim];
-        let out_slice = &mut output[start..start + norm_dim];
-
-        trueno::blis::norms::layer_norm(slice, weight_data, bias_data, eps, out_slice)
-            .expect("layer_norm: dimension mismatch (should be impossible)");
-    }
-
-    Tensor::from_vec(output, shape)
 }
 
 /// RMS normalization over the last dimension of an ND tensor.
@@ -418,23 +458,51 @@ pub fn rms_norm(x: &Tensor, weight: &Tensor, eps: f32) -> Tensor {
 
     // Delegate to trueno's AVX2+FMA SIMD rms_norm per row.
     // Contract: provable-contracts/contracts/rmsnorm-kernel-v1.yaml
-    if batch_size == 1 {
+    let output = if batch_size == 1 {
         // Fast path: single row, use alloc variant (no zero-fill)
-        let output = trueno::blis::norms::rms_norm_alloc(data, weight_data, eps);
-        return Tensor::from_vec(output, shape);
+        trueno::blis::norms::rms_norm_alloc(data, weight_data, eps)
+    } else {
+        let mut out = vec![0.0f32; data.len()];
+        for b in 0..batch_size {
+            let start = b * norm_dim;
+            let slice = &data[start..start + norm_dim];
+            let out_slice = &mut out[start..start + norm_dim];
+
+            trueno::blis::norms::rms_norm(slice, weight_data, eps, out_slice)
+                .expect("rms_norm: dimension mismatch (should be impossible)");
+        }
+        out
+    };
+
+    let mut result = Tensor::from_vec(output, shape);
+
+    // PMAT-907 / OBLIG-RMSNORM-BACKWARD-GRAD-FLOW: wire the autograd backward so
+    // gradients flow to the affine scale (gamma=weight) AND the input x.
+    record_rms_norm_backward(x, weight, eps, &mut result);
+
+    result
+}
+
+/// Record the RMSNorm backward edge on the autograd tape (PMAT-907).
+fn record_rms_norm_backward(x: &Tensor, weight: &Tensor, eps: f32, result: &mut Tensor) {
+    use crate::autograd::{is_grad_enabled, with_graph};
+    use std::sync::Arc;
+
+    if is_grad_enabled() && (x.requires_grad_enabled() || weight.requires_grad_enabled()) {
+        result.requires_grad_(true);
+        let grad_fn = Arc::new(crate::autograd::grad_fn::RmsNormBackward {
+            x: x.clone(),
+            gamma: weight.clone(),
+            eps,
+        });
+        result.set_grad_fn(grad_fn.clone());
+
+        with_graph(|graph| {
+            graph.register_tensor(x.clone());
+            graph.register_tensor(weight.clone());
+            graph.record(result.id(), grad_fn, vec![x.id(), weight.id()]);
+        });
     }
-
-    let mut output = vec![0.0f32; data.len()];
-    for b in 0..batch_size {
-        let start = b * norm_dim;
-        let slice = &data[start..start + norm_dim];
-        let out_slice = &mut output[start..start + norm_dim];
-
-        trueno::blis::norms::rms_norm(slice, weight_data, eps, out_slice)
-            .expect("rms_norm: dimension mismatch (should be impossible)");
-    }
-
-    Tensor::from_vec(output, shape)
 }
 
 /// Linear transformation: y = x @ weight^T + bias

--- a/crates/aprender-core/src/nn/normalization/mod.rs
+++ b/crates/aprender-core/src/nn/normalization/mod.rs
@@ -111,6 +111,18 @@ impl LayerNorm {
     pub fn set_bias(&mut self, bias: Tensor) {
         self.bias = bias;
     }
+
+    /// Get a reference to the affine scale (γ / weight) tensor.
+    #[must_use]
+    pub fn weight(&self) -> &Tensor {
+        &self.weight
+    }
+
+    /// Get a reference to the affine shift (β / bias) tensor.
+    #[must_use]
+    pub fn bias(&self) -> &Tensor {
+        &self.bias
+    }
 }
 
 impl Module for LayerNorm {

--- a/crates/aprender-core/src/nn/normalization/tests.rs
+++ b/crates/aprender-core/src/nn/normalization/tests.rs
@@ -450,6 +450,8 @@ mod tests_batchnorm_contract;
 mod tests_batchnorm_groupnorm;
 #[path = "tests_layernorm_contract.rs"]
 mod tests_layernorm_contract;
+#[path = "tests_norm_backward_gradflow.rs"]
+mod tests_norm_backward_gradflow;
 #[path = "tests_norm_edge_cases.rs"]
 mod tests_norm_edge_cases;
 #[path = "tests_rmsnorm_contract.rs"]

--- a/crates/aprender-core/src/nn/normalization/tests_norm_backward_gradflow.rs
+++ b/crates/aprender-core/src/nn/normalization/tests_norm_backward_gradflow.rs
@@ -1,0 +1,285 @@
+//! Falsifier: LayerNorm + RMSNorm backward MUST flow gradient to affine params.
+//!
+//! Obligations:
+//! - OBLIG-LAYERNORM-BACKWARD-GRAD-FLOW
+//! - OBLIG-RMSNORM-BACKWARD-GRAD-FLOW
+//!
+//! BUG (PMAT-907): the canonical `nn::functional::layer_norm` / `rms_norm`
+//! built their output via `Tensor::from_vec`, which severs the autograd graph.
+//! After `loss.backward()`, `weight.grad()` / `bias.grad()` were `None` — the
+//! affine scale (gamma) and shift (beta) never received gradient, so every
+//! transformer using LayerNorm/RMSNorm was NON-FINE-TUNABLE (the norm params
+//! could never update).
+//!
+//! These tests are a self-contained finite-difference gradcheck (no torch dep):
+//! perturb each gamma[i] / beta[i] by ±eps, recompute the scalar loss, and
+//! compare the central difference (L(+eps) - L(-eps)) / 2eps against the
+//! analytic `.grad`. They also assert grad is non-None (the severed-graph
+//! guard). The finite-diff comparison genuinely catches a wrong/missing
+//! gradient — it is not a tautological `is_some` on a hardcoded value.
+
+use crate::autograd::{self, Tensor};
+use crate::nn::normalization::{LayerNorm, RMSNorm};
+use crate::nn::Module;
+
+/// Fixed, non-uniform upstream coefficient. Multiplying the norm output by a
+/// per-feature constant and summing makes BOTH dL/dgamma and dL/dbeta nonzero
+/// (a bare `sum(output)` leaves dL/dgamma ~ sum(x_hat) ~ 0 for LayerNorm, which
+/// would not exercise the gamma gradient path).
+fn coeff(n: usize) -> Vec<f32> {
+    (0..n).map(|i| 0.3 + 0.17 * (i as f32)).collect()
+}
+
+/// Scalar loss = sum_b sum_i c_i * y[b, i], where y is the norm output.
+/// `c` is detached (no grad) so the only graph edges are through gamma/beta/x.
+fn scalar_loss(output: &Tensor, c: &[f32]) -> Tensor {
+    let shape = output.shape();
+    let feat = c.len();
+    let batch = output.numel() / feat;
+    let mut cvec = Vec::with_capacity(output.numel());
+    for _ in 0..batch {
+        cvec.extend_from_slice(c);
+    }
+    let c_tensor = Tensor::new(&cvec, shape);
+    output.mul(&c_tensor).sum()
+}
+
+/// Re-run forward + loss WITHOUT building a graph, with the affine params
+/// (gamma, optional beta) overridden by the supplied perturbed values.
+/// Used for the finite-difference reference — pure function of the params.
+fn forward_loss_layernorm(x: &Tensor, gamma: &[f32], beta: &[f32], eps: f32, c: &[f32]) -> f32 {
+    autograd::no_grad(|| {
+        let g = Tensor::new(gamma, &[gamma.len()]);
+        let b = Tensor::new(beta, &[beta.len()]);
+        let y = crate::nn::functional::layer_norm(x, &g, &b, eps);
+        scalar_loss(&y, c).item()
+    })
+}
+
+fn forward_loss_rmsnorm(x: &Tensor, gamma: &[f32], eps: f32, c: &[f32]) -> f32 {
+    autograd::no_grad(|| {
+        let g = Tensor::new(gamma, &[gamma.len()]);
+        let y = crate::nn::functional::rms_norm(x, &g, eps);
+        scalar_loss(&y, c).item()
+    })
+}
+
+const FD_EPS: f32 = 1e-3;
+const TOL: f32 = 2e-2; // f32 central-difference on this composite is ~1e-2 accurate
+
+fn assert_close(analytic: f32, numeric: f32, what: &str) {
+    let denom = analytic.abs().max(numeric.abs()).max(1.0);
+    let rel = (analytic - numeric).abs() / denom;
+    assert!(
+        rel < TOL,
+        "{what}: analytic grad {analytic} != finite-diff {numeric} (rel err {rel})"
+    );
+}
+
+#[test]
+fn layernorm_backward_flows_grad_to_gamma_and_beta() {
+    autograd::clear_graph();
+
+    let feat = 5usize;
+    let batch = 3usize;
+    let eps = 1e-5f32;
+    // Deterministic, non-degenerate input (varying per feature & per row).
+    let x_data: Vec<f32> = (0..batch * feat)
+        .map(|k| {
+            let r = (k / feat) as f32;
+            let f = (k % feat) as f32;
+            0.5 + 0.4 * f - 0.3 * r + 0.05 * (f * r)
+        })
+        .collect();
+    let x = Tensor::new(&x_data, &[batch, feat]);
+    let c = coeff(feat);
+
+    // Non-trivial affine params (not all-ones / all-zeros) so a severed gamma
+    // OR beta edge is observable.
+    let gamma0: Vec<f32> = (0..feat).map(|i| 1.0 + 0.2 * (i as f32)).collect();
+    let beta0: Vec<f32> = (0..feat).map(|i| -0.1 + 0.15 * (i as f32)).collect();
+
+    let mut ln = LayerNorm::with_eps(&[feat], eps);
+    ln.set_weight(Tensor::new(&gamma0, &[feat]).requires_grad());
+    ln.set_bias(Tensor::new(&beta0, &[feat]).requires_grad());
+
+    let gamma_id = ln.weight().id();
+    let beta_id = ln.bias().id();
+
+    let y = ln.forward(&x);
+    let loss = scalar_loss(&y, &c);
+    loss.backward();
+
+    // Severed-graph guard: grads MUST exist.
+    let gamma_grad = autograd::get_grad(gamma_id)
+        .expect("LayerNorm gamma (weight) received NO gradient — autograd graph severed");
+    let beta_grad = autograd::get_grad(beta_id)
+        .expect("LayerNorm beta (bias) received NO gradient — autograd graph severed");
+
+    // Finite-difference gradcheck for every gamma[i] and beta[i].
+    for i in 0..feat {
+        let mut gp = gamma0.clone();
+        gp[i] += FD_EPS;
+        let mut gm = gamma0.clone();
+        gm[i] -= FD_EPS;
+        let num = (forward_loss_layernorm(&x, &gp, &beta0, eps, &c)
+            - forward_loss_layernorm(&x, &gm, &beta0, eps, &c))
+            / (2.0 * FD_EPS);
+        assert_close(
+            gamma_grad.data()[i],
+            num,
+            &format!("LayerNorm dL/dgamma[{i}]"),
+        );
+
+        let mut bp = beta0.clone();
+        bp[i] += FD_EPS;
+        let mut bm = beta0.clone();
+        bm[i] -= FD_EPS;
+        let num_b = (forward_loss_layernorm(&x, &gamma0, &bp, eps, &c)
+            - forward_loss_layernorm(&x, &gamma0, &bm, eps, &c))
+            / (2.0 * FD_EPS);
+        assert_close(
+            beta_grad.data()[i],
+            num_b,
+            &format!("LayerNorm dL/dbeta[{i}]"),
+        );
+    }
+
+    // Grads must be finite and at least one component nonzero.
+    assert!(gamma_grad.data().iter().all(|g| g.is_finite()));
+    assert!(beta_grad.data().iter().all(|g| g.is_finite()));
+    assert!(gamma_grad.data().iter().any(|&g| g.abs() > 1e-6));
+    assert!(beta_grad.data().iter().any(|&g| g.abs() > 1e-6));
+}
+
+#[test]
+fn rmsnorm_backward_flows_grad_to_gamma() {
+    autograd::clear_graph();
+
+    let feat = 5usize;
+    let batch = 3usize;
+    let eps = 1e-6f32;
+    let x_data: Vec<f32> = (0..batch * feat)
+        .map(|k| {
+            let r = (k / feat) as f32;
+            let f = (k % feat) as f32;
+            0.6 + 0.35 * f - 0.25 * r + 0.04 * (f * r)
+        })
+        .collect();
+    let x = Tensor::new(&x_data, &[batch, feat]);
+    let c = coeff(feat);
+
+    let gamma0: Vec<f32> = (0..feat).map(|i| 0.9 + 0.18 * (i as f32)).collect();
+
+    let mut rn = RMSNorm::with_eps(&[feat], eps);
+    rn.set_weight(Tensor::new(&gamma0, &[feat]).requires_grad());
+
+    let gamma_id = rn.weight().id();
+
+    let y = rn.forward(&x);
+    let loss = scalar_loss(&y, &c);
+    loss.backward();
+
+    let gamma_grad = autograd::get_grad(gamma_id)
+        .expect("RMSNorm gamma (weight) received NO gradient — autograd graph severed");
+
+    for i in 0..feat {
+        let mut gp = gamma0.clone();
+        gp[i] += FD_EPS;
+        let mut gm = gamma0.clone();
+        gm[i] -= FD_EPS;
+        let num = (forward_loss_rmsnorm(&x, &gp, eps, &c) - forward_loss_rmsnorm(&x, &gm, eps, &c))
+            / (2.0 * FD_EPS);
+        assert_close(
+            gamma_grad.data()[i],
+            num,
+            &format!("RMSNorm dL/dgamma[{i}]"),
+        );
+    }
+
+    assert!(gamma_grad.data().iter().all(|g| g.is_finite()));
+    assert!(gamma_grad.data().iter().any(|&g| g.abs() > 1e-6));
+}
+
+/// Gradient must also flow to the INPUT x (so stacked norm layers train), not
+/// just the affine params. Finite-difference check on each x entry.
+#[test]
+fn layernorm_backward_flows_grad_to_input() {
+    autograd::clear_graph();
+
+    let feat = 4usize;
+    let eps = 1e-5f32;
+    let x_data: Vec<f32> = vec![0.5, -0.2, 1.1, 0.3];
+    let gamma0: Vec<f32> = vec![1.0, 1.3, 0.7, 1.1];
+    let beta0: Vec<f32> = vec![0.0, 0.2, -0.1, 0.05];
+    let c = coeff(feat);
+
+    let x = Tensor::new(&x_data, &[1, feat]).requires_grad();
+    let x_id = x.id();
+
+    let g = Tensor::new(&gamma0, &[feat]).requires_grad();
+    let b = Tensor::new(&beta0, &[feat]).requires_grad();
+    let y = crate::nn::functional::layer_norm(&x, &g, &b, eps);
+    let loss = scalar_loss(&y, &c);
+    loss.backward();
+
+    let x_grad = autograd::get_grad(x_id).expect("LayerNorm input x received NO gradient");
+
+    let recompute = |xd: &[f32]| -> f32 {
+        autograd::no_grad(|| {
+            let xx = Tensor::new(xd, &[1, feat]);
+            let gg = Tensor::new(&gamma0, &[feat]);
+            let bb = Tensor::new(&beta0, &[feat]);
+            let yy = crate::nn::functional::layer_norm(&xx, &gg, &bb, eps);
+            scalar_loss(&yy, &c).item()
+        })
+    };
+
+    for i in 0..feat {
+        let mut xp = x_data.clone();
+        xp[i] += FD_EPS;
+        let mut xm = x_data.clone();
+        xm[i] -= FD_EPS;
+        let num = (recompute(&xp) - recompute(&xm)) / (2.0 * FD_EPS);
+        assert_close(x_grad.data()[i], num, &format!("LayerNorm dL/dx[{i}]"));
+    }
+}
+
+#[test]
+fn rmsnorm_backward_flows_grad_to_input() {
+    autograd::clear_graph();
+
+    let feat = 4usize;
+    let eps = 1e-6f32;
+    let x_data: Vec<f32> = vec![0.7, -0.3, 1.2, 0.4];
+    let gamma0: Vec<f32> = vec![0.9, 1.2, 0.8, 1.05];
+    let c = coeff(feat);
+
+    let x = Tensor::new(&x_data, &[1, feat]).requires_grad();
+    let x_id = x.id();
+
+    let g = Tensor::new(&gamma0, &[feat]).requires_grad();
+    let y = crate::nn::functional::rms_norm(&x, &g, eps);
+    let loss = scalar_loss(&y, &c);
+    loss.backward();
+
+    let x_grad = autograd::get_grad(x_id).expect("RMSNorm input x received NO gradient");
+
+    let recompute = |xd: &[f32]| -> f32 {
+        autograd::no_grad(|| {
+            let xx = Tensor::new(xd, &[1, feat]);
+            let gg = Tensor::new(&gamma0, &[feat]);
+            let yy = crate::nn::functional::rms_norm(&xx, &gg, eps);
+            scalar_loss(&yy, &c).item()
+        })
+    };
+
+    for i in 0..feat {
+        let mut xp = x_data.clone();
+        xp[i] += FD_EPS;
+        let mut xm = x_data.clone();
+        xm[i] -= FD_EPS;
+        let num = (recompute(&xp) - recompute(&xm)) / (2.0 * FD_EPS);
+        assert_close(x_grad.data()[i], num, &format!("RMSNorm dL/dx[{i}]"));
+    }
+}


### PR DESCRIPTION
## Summary

The HEADLINE v0.54 Pillar-2 (autograd) correctness beat. LayerNorm and RMSNorm backward did **not** flow gradients to their affine parameters (LayerNorm: scale gamma=weight + shift beta=bias; RMSNorm: scale gamma=weight) **or** to the input x. After `loss.backward()`, `get_grad(weight.id())` / `get_grad(bias.id())` were `None` — the norm scale/shift never updated, so **every transformer using LayerNorm/RMSNorm was NON-FINE-TUNABLE**.

## Root cause

`nn::functional::layer_norm` / `rms_norm` (the ONE-PATH canonical norms that `LayerNorm`/`RMSNorm` Modules delegate to) built their output via `Tensor::from_vec`, which produces a leaf tensor with no `grad_fn` — severing the autograd graph entirely.

## Fix

- Add `LayerNormBackward` + `RmsNormBackward` to `autograd/grad_fn.rs`.
- Record them on the autograd tape from the functional norms, wiring `[x, weight, bias]` (LayerNorm) / `[x, weight]` (RMSNorm) as graph inputs.

Backward math:
- **LayerNorm**: `dL/dgamma_i = Σ_b g_i·x̂_i`; `dL/dbeta_i = Σ_b g_i`; `dL/dx = std_inv·(g' − mean(g') − x̂·mean(g'·x̂))`
- **RMSNorm**: `dL/dgamma_i = Σ_b g_i·x̂_i` (x̂ = x/rms); `dL/dx = r_inv·(g' − x̂·mean(g'·x̂))` (no mean-subtraction term)

## Falsifier (RED→GREEN)

Self-contained central finite-difference gradcheck (no torch dep) for gamma, beta, and x on **both** norms in `tests_norm_backward_gradflow.rs`:
- asserts grad is non-None (severed-graph guard), AND
- matches the numeric gradient `(L(+ε) − L(−ε))/2ε` within tol.

- **RED confirmed** on main: all 4 falsifiers fail with "received NO gradient — autograd graph severed".
- **GREEN** after fix: 4/4 pass.
- **Mutation-verified non-tautological**: scaling the gamma backward edge by 1.5 makes the gradcheck go RED (`analytic −1.91 != finite-diff −1.27`), proving the finite-diff comparison genuinely catches a wrong gradient.

## Contract

`contracts/norm-backward-gradflow-v1.yaml` — obligations `OBLIG-LAYERNORM-BACKWARD-GRAD-FLOW` + `OBLIG-RMSNORM-BACKWARD-GRAD-FLOW`. `pv validate` + `pv lint contracts/` both PASS (0 errors).

## Verification

- `cargo test -p aprender-core --lib`: **13979 passed, 0 failed** (whole crate — no autograd ripple).
- New falsifiers: 4/4 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)