### PR TITLE
fix(serve): fail-closed reject special-token id >= vocab_size at config load (PMAT-908)

### DIFF
--- a/contracts/special-tokens-registry-v1.yaml
+++ b/contracts/special-tokens-registry-v1.yaml
@@ -219,6 +219,10 @@ proof_obligations:
   property: Architecture mapping complete
   formal: all architecture_mapping values reference valid families
   applies_to: all
+- type: bound
+  property: OBLIG-SPECIAL-TOKEN-WITHIN-VOCAB
+  formal: "for every present special-token id t in {eos, bos}: t < vocab_size, enforced at ValidatedModelConfig::validate (PMAT-908)"
+  applies_to: all
 
 kani_harnesses:
 - id: st-kani-001
@@ -264,6 +268,14 @@ falsification_tests:
     status: "IMPLEMENTED"
     implementation: "src/format/special_tokens_contract_falsify.rs"
     if_fails: "YAML has invalid token ID (>= vocab_size)"
+
+  - id: FALSIFY-ST-005
+    rule: "OBLIG-SPECIAL-TOKEN-WITHIN-VOCAB: config load fail-closes a present special-token id >= vocab_size (PMAT-908)"
+    prediction: "ValidatedModelConfig::validate() returns Err naming the offending token when eos/bos id >= vocab_size, and Ok when all present ids < vocab_size or absent"
+    status: "IMPLEMENTED"
+    test: "cargo test -p aprender-serve --lib test_validated_config_rejects_eos_ge_vocab"
+    implementation: "crates/aprender-serve/src/gguf/config_gguf.rs::test_validated_config_rejects_eos_ge_vocab"
+    if_fails: "A model with a stop-token id >= vocab_size loads silently — generation can never stop (runs to max_tokens) or OOB-indexes the vocab; apr must reject where llama.cpp/Ollama silently load+run"
 
 qa_gate:
   id: F-SPECIAL-TOKENS-GATE

--- a/crates/aprender-serve/src/gguf/config.rs
+++ b/crates/aprender-serve/src/gguf/config.rs
@@ -539,11 +539,13 @@ impl GGUFConfig {
             .rope_type
             .unwrap_or_else(|| infer_rope_type(&architecture));
         let context_length = apr.metadata.max_position_embeddings.unwrap_or(0);
-        // GH-330: EOS from APR metadata, with architecture contract fallback
-        let eos_token_id = apr
-            .metadata
-            .get_embedded_eos_token_id()
-            .or_else(|| default_eos_for_architecture(&architecture));
+        // GH-330: EOS from APR metadata, with architecture contract fallback.
+        // OBLIG-SPECIAL-TOKEN-WITHIN-VOCAB (PMAT-908): only fall back to the
+        // architecture default when it is a reachable logit (< vocab_size); a
+        // small-vocab model must not inherit a large arch-default eos.
+        let eos_token_id = apr.metadata.get_embedded_eos_token_id().or_else(|| {
+            default_eos_for_architecture(&architecture).filter(|&id| (id as usize) < vocab_size)
+        });
         let bos_token_id = apr.metadata.get_embedded_bos_token_id();
 
         Ok(Self {
@@ -763,8 +765,11 @@ impl GGUFConfig {
         // BOS token ID from GGUF metadata, with architecture-based fallback.
         // Weights-only GGUFs (e.g., from pacha) lack tokenizer.ggml.bos_token_id.
         // Without a BOS token, GPU validation (F2-VALIDATION) is skipped entirely.
+        // OBLIG-SPECIAL-TOKEN-WITHIN-VOCAB (PMAT-908): the architecture default is
+        // only a valid fallback when it is a reachable logit (< vocab_size).
         let bos_token_id = model.bos_token_id().or_else(|| {
-            let fallback = default_bos_for_architecture(&architecture);
+            let fallback =
+                default_bos_for_architecture(&architecture).filter(|&id| (id as usize) < vocab_size);
             if fallback.is_some() {
                 eprintln!(
                     "[BOS-FALLBACK] No tokenizer.ggml.bos_token_id in GGUF — using architecture default for '{architecture}'"
@@ -776,9 +781,11 @@ impl GGUFConfig {
         // GH-330: EOS token ID from GGUF metadata.
         // Design by Contract: this is the class invariant — the config carries
         // the model's own EOS token. No hardcoded fallback (Meyer 1992).
-        let eos_token_id = model
-            .eos_token_id()
-            .or_else(|| default_eos_for_architecture(&architecture));
+        // OBLIG-SPECIAL-TOKEN-WITHIN-VOCAB (PMAT-908): arch-default eos must be
+        // within vocab to be a usable stop token.
+        let eos_token_id = model.eos_token_id().or_else(|| {
+            default_eos_for_architecture(&architecture).filter(|&id| (id as usize) < vocab_size)
+        });
 
         Ok(Self {
             architecture,
@@ -884,6 +891,13 @@ impl ValidatedModelConfig {
 
         // Upper-bound + range checks from model-metadata-bounds-v1.yaml
         validate_metadata_bounds(&config)?;
+
+        // OBLIG-SPECIAL-TOKEN-WITHIN-VOCAB (PMAT-908): every PRESENT special-token
+        // id must be a reachable logit, i.e. < vocab_size. A stop-token id >=
+        // vocab_size can never be produced by sampling, so generation never stops
+        // (runs to max_tokens) or OOB-indexes. apr fail-closes here where
+        // llama.cpp / Ollama silently load+run. Absent (None) ids are not checked.
+        validate_special_tokens_within_vocab(&config)?;
 
         Ok(Self { inner: config })
     }
@@ -1169,6 +1183,35 @@ fn check_usize_max(value: usize, max: usize, field: &str) -> Result<()> {
         return Err(RealizarError::InvalidShape {
             reason: format!("{field} {value} exceeds max {max} (model-metadata-bounds-v1)"),
         });
+    }
+    Ok(())
+}
+
+/// OBLIG-SPECIAL-TOKEN-WITHIN-VOCAB (PMAT-908): reject a config whose present
+/// special-token id is `>= vocab_size`.
+///
+/// Valid token ids span `0..vocab_size`; an id `>= vocab_size` is unreachable as
+/// a logit. A stop-token (eos/bos) at such an id can never match during sampling,
+/// so generation runs to `max_tokens` every time (or OOB-indexes the vocab). This
+/// is a Pillar-4 fail-closed gate: apr REJECTS at load where llama.cpp / Ollama
+/// silently accept the model. Absent (`None`) ids are not checked.
+fn validate_special_tokens_within_vocab(config: &GGUFConfig) -> Result<()> {
+    check_token_within_vocab(config.eos_token_id, config.vocab_size, "eos_token_id")?;
+    check_token_within_vocab(config.bos_token_id, config.vocab_size, "bos_token_id")?;
+    Ok(())
+}
+
+/// Check a single optional special-token id is `< vocab_size` when present.
+fn check_token_within_vocab(token_id: Option<u32>, vocab_size: usize, field: &str) -> Result<()> {
+    if let Some(id) = token_id {
+        if id as usize >= vocab_size {
+            return Err(RealizarError::InvalidShape {
+                reason: format!(
+                    "{field} {id} >= vocab_size {vocab_size}: special token is an unreachable \
+                     logit, so generation cannot stop (OBLIG-SPECIAL-TOKEN-WITHIN-VOCAB)"
+                ),
+            });
+        }
     }
     Ok(())
 }

--- a/crates/aprender-serve/src/gguf/config_gguf.rs
+++ b/crates/aprender-serve/src/gguf/config_gguf.rs
@@ -428,8 +428,9 @@
             rope_type: 0,
             explicit_head_dim: None,
             query_pre_attn_scalar: None,
-            bos_token_id: Some(128_000),
-            eos_token_id: Some(128_001),
+            // In-vocab special tokens (vocab_size = 32000). TinyLlama-style.
+            bos_token_id: Some(1),
+            eos_token_id: Some(2),
         }
     }
 
@@ -455,7 +456,7 @@
         assert!((v.rope_theta() - 10000.0).abs() < f32::EPSILON);
         assert!((v.eps() - 1e-5).abs() < f32::EPSILON);
         assert_eq!(v.rope_type(), 0);
-        assert_eq!(v.bos_token_id(), Some(128_000));
+        assert_eq!(v.bos_token_id(), Some(1));
     }
 
     #[test]
@@ -508,4 +509,71 @@
         let debug = format!("{v:?}");
         assert!(debug.contains("ValidatedModelConfig"));
         assert!(debug.contains("llama"));
+    }
+
+    // -----------------------------------------------------------------------
+    // OBLIG-SPECIAL-TOKEN-WITHIN-VOCAB (PMAT-908): fail-closed reject a model
+    // config whose special-token id (eos/bos) is >= vocab_size. Such a token is
+    // an unreachable logit, so the stop-token never matches → generation never
+    // stops (runs to max_tokens) or OOB-indexes. apr REJECTS where llama.cpp /
+    // Ollama silently load+run.
+    // -----------------------------------------------------------------------
+
+    /// F-SPECIAL-TOKEN-EOS-001: eos_token_id == vocab_size (just past the last
+    /// valid id, since valid ids are 0..vocab_size) must be rejected at load.
+    #[test]
+    fn test_validated_config_rejects_eos_ge_vocab() {
+        let mut cfg = valid_llama_config();
+        cfg.eos_token_id = Some(cfg.vocab_size as u32); // == vocab_size → OOB
+        let err = ValidatedModelConfig::validate(cfg).unwrap_err();
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("eos_token_id"),
+            "error must name the offending token, got: {msg}"
+        );
+    }
+
+    /// F-SPECIAL-TOKEN-EOS-002: eos_token_id far above vocab_size rejected.
+    #[test]
+    fn test_validated_config_rejects_eos_far_above_vocab() {
+        let mut cfg = valid_llama_config();
+        cfg.eos_token_id = Some(999_999); // vocab is 32000
+        assert!(ValidatedModelConfig::validate(cfg).is_err());
+    }
+
+    /// F-SPECIAL-TOKEN-BOS-001: bos_token_id >= vocab_size rejected at load.
+    #[test]
+    fn test_validated_config_rejects_bos_ge_vocab() {
+        let mut cfg = valid_llama_config();
+        cfg.bos_token_id = Some(cfg.vocab_size as u32 + 5);
+        let err = ValidatedModelConfig::validate(cfg).unwrap_err();
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("bos_token_id"),
+            "error must name the offending token, got: {msg}"
+        );
+    }
+
+    /// F-SPECIAL-TOKEN-NEG-001 (no false-positive): a config whose special tokens
+    /// are all < vocab_size still loads Ok, and a config with absent (None) token
+    /// ids is NOT rejected by this check.
+    #[test]
+    fn test_validated_config_accepts_special_tokens_within_vocab() {
+        // Boundary: vocab_size - 1 is the largest valid id.
+        let mut cfg = valid_llama_config();
+        cfg.eos_token_id = Some(cfg.vocab_size as u32 - 1);
+        cfg.bos_token_id = Some(0);
+        assert!(
+            ValidatedModelConfig::validate(cfg).is_ok(),
+            "tokens within vocab must load"
+        );
+
+        // Absent token ids must not trip the check.
+        let mut cfg_none = valid_llama_config();
+        cfg_none.eos_token_id = None;
+        cfg_none.bos_token_id = None;
+        assert!(
+            ValidatedModelConfig::validate(cfg_none).is_ok(),
+            "absent token ids must not be rejected"
+        );
     }

--- a/crates/aprender-serve/src/gguf/config_validated.rs
+++ b/crates/aprender-serve/src/gguf/config_validated.rs
@@ -242,7 +242,8 @@ mod tests {
     fn test_validated_config_eos_token_id_getter() {
         let cfg = valid_llama_config();
         let v = ValidatedModelConfig::validate(cfg).expect("valid");
-        assert_eq!(v.eos_token_id(), Some(128_001));
+        // valid_llama_config uses an in-vocab eos (vocab_size = 32000).
+        assert_eq!(v.eos_token_id(), Some(2));
     }
 
     // -- FALSIFY: Verify Rust bounds match YAML contract --


### PR DESCRIPTION
## Pillar-4 fail-closed correctness beat (PMAT-908)

A model config whose special-token id (`eos_token_id` / `bos_token_id`) is `>= vocab_size` loaded **SILENTLY**. Such an id is an unreachable logit, so the stop-token never matches during sampling: **generation never stops** (runs to `max_tokens` every time) or OOB-indexes the vocab. apr's mission is to REJECT this where llama.cpp / Ollama silently load+run.

### Obligation
`OBLIG-SPECIAL-TOKEN-WITHIN-VOCAB` — for every PRESENT special-token id `t` in `{eos, bos}`: `t < vocab_size`, enforced at `ValidatedModelConfig::validate`.

### Fix (`crates/aprender-serve/src/gguf/config.rs`)
- `validate()` gains `validate_special_tokens_within_vocab()` — returns a clear actionable `Err` naming the offending token, its id, and `vocab_size`. Absent (`None`) ids are NOT rejected (only present ones checked).
- Defense-in-depth: the architecture-default eos/bos fallback in `from_gguf` / `from_apr` now only applies when the default id is `< vocab_size`, so a small-vocab model never INHERITS a large arch-default stop token.

### Contract (`contracts/special-tokens-registry-v1.yaml`)
- New proof obligation `OBLIG-SPECIAL-TOKEN-WITHIN-VOCAB`.
- New falsification test `FALSIFY-ST-005` (single-line cargo test ref). `pv validate` + `pv lint contracts/` PASS.

### Falsifiers — RED-on-bug / GREEN-on-fix, mutation-verified
- `test_validated_config_rejects_eos_ge_vocab` (eos == vocab_size boundary)
- `test_validated_config_rejects_eos_far_above_vocab`
- `test_validated_config_rejects_bos_ge_vocab`
- `test_validated_config_accepts_special_tokens_within_vocab` (no false-positive: in-vocab ids and absent ids both load Ok)

### Verification
- RED confirmed on origin/main: the 3 reject falsifiers fail (config loads Ok despite OOB token).
- Mutation: removing `validate_special_tokens_within_vocab()` flips all three reject falsifiers RED; the accepts test stays GREEN (non-tautological).
- `cargo test -p aprender-serve --lib`: **15433 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)