### PR TITLE
fix(loss): CrossEntropy label_smoothing uses eps/C off-target mass (PyTorch parity, PMAT-910)

### DIFF
--- a/contracts/cross-entropy-kernel-v1.yaml
+++ b/contracts/cross-entropy-kernel-v1.yaml
@@ -95,8 +95,27 @@ proof_obligations:
     read only grad_output[0], so Sum grad was batch× too small and None
     mis-broadcast the per-sample upstream. Closed-form softmax+NLL gradient is
     softmax-onehot, requiring no PyTorch reference (Bishop 2006, eq. 4.108).
+- type: equivalence
+  property: Label smoothing distributes eps/C off-target mass (PyTorch parity)
+  formal: >-
+    For CrossEntropyLoss(label_smoothing=eps) on C classes the smoothed target
+    distribution is q_target = 1 - eps + eps/C and q_{i!=target} = eps/C, so
+    loss = -sum_i q_i * log_softmax(logits)_i
+         = -(1 - eps) * log p_target - (eps/C) * sum_i log p_i.
+    This equals torch.nn.CrossEntropyLoss(label_smoothing=eps) exactly, and
+    reduces to plain cross-entropy at eps = 0.
+  tolerance: 1.0e-05
+  applies_to: all
+  id: OBLIG-CE-LABEL-SMOOTHING-UNIFORM-MASS
+  notes: >-
+    Before PMAT-910 the off-target per-class mass was (1-eps)/C instead of eps/C,
+    inflating the smoothed loss by ~3.2x for typical eps/C (e.g. eps=0.1, C=5 gave
+    2.384 vs the correct 0.7244). The uniform smoothing mass is eps/C per class
+    (Szegedy et al. 2016, Rethinking the Inception Architecture, eq. label
+    smoothing); backward is unaffected because autograd is only recorded when
+    label_smoothing == 0.0.
 verification_summary:
-  total_obligations: 6
+  total_obligations: 7
   l2_property_tested: 6
   l3_kani_proved: 3
   l4_lean_proved: 2
@@ -176,6 +195,16 @@ falsification_tests:
   prediction: 'dCE/dlogits[b] under Reduction::None == (softmax-onehot)[b] * upstream[b]'
   test: cargo test -p aprender-core --lib falsify_ce_reduction_001_none_per_sample_upstream
   if_fails: Backward reads only grad_output[0] and mis-broadcasts the per-sample upstream
+- id: OBLIG-CE-LABEL-SMOOTHING-UNIFORM-MASS-ORACLE
+  rule: Label-smoothed CE equals the analytic/torch eps/C-mass oracle
+  prediction: 'CrossEntropyLoss(eps).forward == -(1-eps)*log p_t - (eps/C)*sum_i log p_i (== torch)'
+  test: cargo test -p aprender-core --lib test_cross_entropy_label_smoothing_uniform_mass_oracle
+  if_fails: Off-target per-class mass is not eps/C (e.g. the (1-eps)/C bug, ~3.2x too large)
+- id: OBLIG-CE-LABEL-SMOOTHING-UNIFORM-MASS-EPS0
+  rule: eps=0 label smoothing reduces to plain cross-entropy
+  prediction: 'CrossEntropyLoss(0.0).forward == CrossEntropyLoss::new().forward'
+  test: cargo test -p aprender-core --lib test_cross_entropy_label_smoothing_zero_equals_plain
+  if_fails: Smoothing branch does not reduce to plain CE at eps=0 (regression)
 kani_harnesses:
 - id: KANI-CE-001
   obligation: CE-INV-001

--- a/crates/aprender-core/src/nn/loss.rs
+++ b/crates/aprender-core/src/nn/loss.rs
@@ -293,14 +293,20 @@ impl CrossEntropyLoss {
 
         for (b, &target_class) in target_indices.iter().enumerate() {
             if self.label_smoothing > 0.0 {
-                // Label smoothing: distribute some probability mass to other classes
-                let smooth_target = (1.0 - self.label_smoothing) / num_classes as f32;
+                // Label smoothing (PyTorch parity, OBLIG-CE-LABEL-SMOOTHING-UNIFORM-MASS):
+                // distribute eps/C of the probability mass to EVERY class, so the
+                // smoothed target distribution is
+                //   q_target      = 1 - eps + eps/C
+                //   q_{i!=target} = eps/C
+                // giving loss = -sum_i q_i * log p_i. This matches
+                // torch.nn.CrossEntropyLoss(label_smoothing=eps) exactly.
+                let off_target_mass = self.label_smoothing / num_classes as f32;
                 let mut loss = 0.0;
                 for c in 0..num_classes {
                     let target_prob = if c == target_class {
-                        1.0 - self.label_smoothing + smooth_target
+                        1.0 - self.label_smoothing + off_target_mass
                     } else {
-                        smooth_target
+                        off_target_mass
                     };
                     loss -= target_prob * log_probs.data()[b * num_classes + c];
                 }

--- a/crates/aprender-core/src/nn/loss_tests.rs
+++ b/crates/aprender-core/src/nn/loss_tests.rs
@@ -566,6 +566,64 @@ mod tests {
         );
     }
 
+    /// Falsifier for OBLIG-CE-LABEL-SMOOTHING-UNIFORM-MASS (PMAT-910).
+    ///
+    /// PyTorch parity: the smoothed target distribution must put eps/C of the
+    /// probability mass on EACH class (so q_target = 1-eps+eps/C, q_{i!=t} = eps/C).
+    /// The previous code used (1-eps)/C as the per-class off-target mass, giving a
+    /// loss ~3.2x too large. This test pins the analytic oracle:
+    ///   smoothed CE = -(1-eps)*log p_target - (eps/C) * sum_i log p_i
+    /// which equals torch.nn.CrossEntropyLoss(label_smoothing=eps) exactly.
+    #[test]
+    fn test_cross_entropy_label_smoothing_uniform_mass_oracle() {
+        // C=5, target=0, eps=0.1. torch gives 0.7244379 for these logits.
+        let logits = Tensor::new(&[2.0, 1.0, 0.0, -1.0, 0.5], &[1, 5]);
+        let targets = Tensor::from_slice(&[0.0]);
+        let eps = 0.1_f32;
+        let c = 5usize;
+        let target = 0usize;
+
+        let criterion = CrossEntropyLoss::with_label_smoothing(eps);
+        let loss = criterion.forward(&logits, &targets);
+
+        // Analytic oracle (self-contained, == torch CrossEntropyLoss(label_smoothing)).
+        let lp = log_softmax(&logits);
+        let lp = lp.data();
+        let sum_lp: f32 = (0..c).map(|i| lp[i]).sum();
+        let oracle = -(1.0 - eps) * lp[target] - (eps / c as f32) * sum_lp;
+
+        assert!(
+            (loss.item() - oracle).abs() < 1e-5,
+            "label-smoothed CE must match analytic/torch oracle: got {} expected {} (eps/C off-target mass)",
+            loss.item(),
+            oracle
+        );
+
+        // Hard pin to the torch reference value to defend against drift.
+        assert!(
+            (loss.item() - 0.724_437_9).abs() < 1e-4,
+            "label-smoothed CE must equal torch reference 0.7244379, got {}",
+            loss.item()
+        );
+    }
+
+    /// eps=0 must reduce exactly to plain cross-entropy (no regression).
+    #[test]
+    fn test_cross_entropy_label_smoothing_zero_equals_plain() {
+        let logits = Tensor::new(&[2.0, 1.0, 0.0, -1.0, 0.5], &[1, 5]);
+        let targets = Tensor::from_slice(&[0.0]);
+
+        let plain = CrossEntropyLoss::new().forward(&logits, &targets);
+        let smoothed_zero = CrossEntropyLoss::with_label_smoothing(0.0).forward(&logits, &targets);
+
+        assert!(
+            (plain.item() - smoothed_zero.item()).abs() < 1e-6,
+            "eps=0 must equal plain CE: plain={} smoothed_zero={}",
+            plain.item(),
+            smoothed_zero.item()
+        );
+    }
+
     #[test]
     fn test_cross_entropy_forward_label_smoothing_multi_class() {
         // 1 sample, 5 classes - exercises the inner loop over all classes

--- a/crates/aprender-core/src/nn/optim/tests.rs
+++ b/crates/aprender-core/src/nn/optim/tests.rs
@@ -476,7 +476,10 @@ fn nn_linear_backward_populates_weight_grad() {
          `weight` is broken (cached construction-time transpose wiped by clear_graph)."
     );
     if let Some(b) = layer.bias() {
-        assert!(get_grad(b.id()).is_some(), "Linear bias received no gradient either.");
+        assert!(
+            get_grad(b.id()).is_some(),
+            "Linear bias received no gradient either."
+        );
     }
 }
 


### PR DESCRIPTION
## Bug (Pillar-2 loss correctness, EV 7.8)

`CrossEntropyLoss::forward` mis-weighted the off-target probability mass under label smoothing: it used `(1-eps)/C` as the per-class off-target mass instead of `eps/C`, inflating the smoothed loss by ~3.2x for typical eps/class-count.

**Oracle (self-contained, == `torch.nn.CrossEntropyLoss(label_smoothing=eps)`):**
```
smoothed CE = -(1-eps)*log p_target - (eps/C) * sum_i log p_i
q_target = 1 - eps + eps/C ,  q_{i!=target} = eps/C
```

Measured (eps=0.1, C=5, target=0, logits `[2,1,0,-1,0.5]`):
- apr (buggy): **2.383988**
- torch / analytic oracle: **0.7244379** (apr now matches within 1e-5)

## Fix

`crates/aprender-core/src/nn/loss.rs` — off-target per-class mass is now `eps/C`. Backward is unaffected (autograd is only recorded when `label_smoothing == 0.0`).

## Contract — OBLIG-CE-LABEL-SMOOTHING-UNIFORM-MASS

Added to `contracts/cross-entropy-kernel-v1.yaml` (new proof obligation + two single-line falsifier refs). `pv validate` + `pv lint contracts/` PASS.

## Verification (full beat discipline)

- RED confirmed on buggy `(1-eps)/C` (test got 2.383988, expected 0.7244379)
- GREEN after fix; falsifier matches analytic + torch oracle
- Mutation-verify (non-tautological): reverting to `(1-eps)/C` flips falsifier RED; restored
- `eps=0` reduces to plain CE (no regression) — dedicated falsifier
- Whole-crate `cargo test -p aprender-core --lib` passes (13981)

🤖 Generated with [Claude Code](https://claude.com/claude-code)