### PR TITLE
fix(autograd): BatchNorm1d+GroupNorm backward flows gradient to affine params (PMAT-911)

### DIFF
--- a/contracts/norm-backward-gradflow-v1.yaml
+++ b/contracts/norm-backward-gradflow-v1.yaml
@@ -1,24 +1,30 @@
 contract: norm-backward-gradflow
 metadata:
   kind: training-loop
-  version: "1.0.0"
+  version: "1.1.0"
   description: >
-    LayerNorm and RMSNorm backward MUST flow gradient to their AFFINE parameters
-    (LayerNorm: scale gamma=weight + shift beta=bias; RMSNorm: scale gamma=weight)
-    AND to the input x. Guards the PMAT-907 root-cause fix: the canonical
-    nn::functional::layer_norm / rms_norm built their output via Tensor::from_vec,
-    which severs the autograd graph — after loss.backward(), get_grad(weight.id())
-    / get_grad(bias.id()) were None, so the norm scale/shift never updated. Every
-    transformer using LayerNorm/RMSNorm was therefore NON-FINE-TUNABLE. The
-    functional norms now record LayerNormBackward / RmsNormBackward on the tape,
-    wiring x, gamma, beta as graph inputs.
+    The whole NORM FAMILY backward MUST flow gradient to its AFFINE parameters
+    (LayerNorm: scale gamma=weight + shift beta=bias; RMSNorm: scale gamma=weight;
+    BatchNorm1d: per-feature gamma+beta; GroupNorm: per-channel gamma+beta) AND to
+    the input x. Guards the PMAT-907 (LayerNorm/RMSNorm) and PMAT-911
+    (BatchNorm1d/GroupNorm) root-cause fixes: the canonical forwards built their
+    output via Tensor::from_vec / Tensor::new, which severs the autograd graph —
+    after loss.backward(), get_grad(weight.id()) / get_grad(bias.id()) were None,
+    so the norm scale/shift never updated. Every model using these norms was
+    therefore NON-FINE-TUNABLE. The forwards now record LayerNormBackward /
+    RmsNormBackward / BatchNorm1dBackward / GroupNormBackward on the tape, wiring
+    x, gamma, (beta) as graph inputs. BatchNorm1d differentiates through the BATCH
+    statistics (train mode), the trickiest of the four.
   references:
   - "crates/aprender-core/src/nn/functional.rs"
   - "crates/aprender-core/src/autograd/grad_fn.rs"
+  - "crates/aprender-core/src/nn/normalization/mod.rs"
+  - "crates/aprender-core/src/nn/normalization/group_norm.rs"
   - "crates/aprender-core/src/nn/normalization/tests_norm_backward_gradflow.rs"
+  - "crates/aprender-core/src/nn/normalization/tests_batchnorm_groupnorm_backward.rs"
 version: 1
 status: enforced
-date: 2026-06-23
+date: 2026-06-24
 
 proof_obligations:
   - type: invariant
@@ -37,12 +43,34 @@ proof_obligations:
       gradcheck within tolerance: dL/dgamma_i = sum_batch g_i * x_hat_i (x_hat =
       x/rms); dL/dx_j = (1/rms) * (g'_j - x_hat_j * mean_i(g'_i * x_hat_i)), with
       NO mean-subtraction term (unlike LayerNorm).
+  - type: invariant
+    property: >
+      OBLIG-BATCHNORM1D-BACKWARD-GRAD-FLOW: after loss.backward() on a graph
+      containing the affine BatchNorm1d forward in TRAIN mode, get_grad is Some
+      for gamma (weight), beta (bias), and the input x. The backward uses the
+      BATCH statistics (mean/biased var over the N*spatial elements per feature,
+      matching the forward's normalization). The analytic gradients match a
+      central finite-difference gradcheck within tolerance: dL/dgamma_j =
+      sum_set g * x_hat; dL/dbeta_j = sum_set g; and the standard batchnorm-backward
+      dL/dx_k = (gamma_j*std_inv/m) * (m*g_k - sum_set(g) - x_hat_k*sum_set(g*x_hat)).
+  - type: invariant
+    property: >
+      OBLIG-GROUPNORM-BACKWARD-GRAD-FLOW: after loss.backward() on a graph
+      containing the affine GroupNorm forward, get_grad is Some for the per-channel
+      gamma (weight), per-channel beta (bias), and the input x. Each (sample, group)
+      normalizes over channels_per_group*spatial. The analytic gradients match a
+      central finite-difference gradcheck within tolerance: dL/dgamma_c =
+      sum_{n,spatial} g*x_hat; dL/dbeta_c = sum_{n,spatial} g; and dL/dx like
+      LayerNorm but within each group (std_inv*(g' - mean_grp(g') - x_hat*mean_grp(g'*x_hat))).
   - type: equivalence
     property: >
       GRADCHECK-NON-TAUTOLOGICAL: the falsifier is a finite-difference gradcheck,
       not an is_some assertion on a hardcoded value. Re-severing or scaling any one
       parameter's backward edge makes the central-difference comparison go RED for
-      that parameter (mutation-verified: gamma += g*xhat*1.5 fails the gradcheck).
+      that parameter (mutation-verified for all four norms: gamma/beta/x edge
+      *= 1.5 fails the corresponding gradcheck). For BatchNorm1d the loss
+      coefficient varies across the BATCH reduction so dL/dgamma is genuinely
+      nonzero (a feature-constant coefficient gives sum_b x_hat == 0, vacuous).
 
 falsification_tests:
   - id: FALSIFY-LAYERNORM-BACKWARD-GRAD-FLOW-001
@@ -69,3 +97,27 @@ falsification_tests:
     test_harness: "cargo test -p aprender-core --lib rmsnorm_backward_flows_grad_to_input"
     expected_output: "test result: ok"
     if_fails: "RMSNorm dL/dx must use r_inv*(g' - x_hat*mean(g'*x_hat)) with NO mean-subtraction term."
+  - id: FALSIFY-BATCHNORM1D-BACKWARD-GRAD-FLOW-001
+    name: batchnorm1d_train_backward_flows_grad_to_gamma_and_beta
+    prediction: "BatchNorm1d (train) gamma+beta grads are Some and match the finite-difference gradcheck within tol"
+    test_harness: "cargo test -p aprender-core --lib batchnorm1d_train_backward_flows_grad_to_gamma_and_beta"
+    expected_output: "test result: ok"
+    if_fails: "BatchNorm1d::forward severed the autograd graph (Tensor::new). Record BatchNorm1dBackward on the tape with inputs [x, weight, bias] using BATCH stats in train mode."
+  - id: FALSIFY-BATCHNORM1D-BACKWARD-GRAD-FLOW-002
+    name: batchnorm1d_train_backward_flows_grad_to_input
+    prediction: "BatchNorm1d (train) input x grad is Some and matches the finite-difference gradcheck within tol"
+    test_harness: "cargo test -p aprender-core --lib batchnorm1d_train_backward_flows_grad_to_input"
+    expected_output: "test result: ok"
+    if_fails: "BatchNorm1d dL/dx must use the standard batchnorm-backward (m*g - sum(g) - x_hat*sum(g*x_hat)) scaled by gamma*std_inv/m over the batch set."
+  - id: FALSIFY-GROUPNORM-BACKWARD-GRAD-FLOW-001
+    name: groupnorm_backward_flows_grad_to_gamma_and_beta
+    prediction: "GroupNorm gamma+beta grads are Some and match the finite-difference gradcheck within tol"
+    test_harness: "cargo test -p aprender-core --lib groupnorm_backward_flows_grad_to_gamma_and_beta"
+    expected_output: "test result: ok"
+    if_fails: "GroupNorm::forward severed the autograd graph (Tensor::new). Record GroupNormBackward on the tape with inputs [x, weight, bias]; gamma/beta are per-channel."
+  - id: FALSIFY-GROUPNORM-BACKWARD-GRAD-FLOW-002
+    name: groupnorm_backward_flows_grad_to_input
+    prediction: "GroupNorm input x grad is Some and matches the finite-difference gradcheck within tol"
+    test_harness: "cargo test -p aprender-core --lib groupnorm_backward_flows_grad_to_input"
+    expected_output: "test result: ok"
+    if_fails: "GroupNorm dL/dx is LayerNorm-like WITHIN each group: std_inv*(g' - mean_grp(g') - x_hat*mean_grp(g'*x_hat))."

--- a/crates/aprender-core/src/autograd/grad_fn.rs
+++ b/crates/aprender-core/src/autograd/grad_fn.rs
@@ -640,5 +640,216 @@ impl GradFn for RmsNormBackward {
     }
 }
 
+/// Gradient function for affine BatchNorm1d in TRAIN mode: y = x_hat * gamma + beta,
+/// where x_hat = (x - mu_batch) / sqrt(var_batch + eps), with mu/var computed over the
+/// BATCH (and spatial) dimension per feature using the BIASED (÷N) variance — matching
+/// the forward used for normalization (Ioffe & Szegedy).
+///
+/// Obligation: OBLIG-BATCHNORM1D-BACKWARD-GRAD-FLOW.
+///
+/// Before PMAT-911 the `BatchNorm1d::forward` built its output via `Tensor::new`,
+/// severing the autograd graph: gamma/beta/x received no gradient, making every
+/// BatchNorm layer non-fine-tunable. This grad_fn flows gradient to ALL THREE inputs
+/// (x, gamma, beta), in that input order.
+///
+/// Layout: input is `[N, C]` (2D) or `[N, C, L]` (3D); feature axis is dim 1. For
+/// each feature `j`, the reduction set is every (n, l) index with channel `j`
+/// (size `m = N * L`). With std_inv = 1/sqrt(var+eps):
+/// - dL/dgamma_j = sum_set g * x_hat
+/// - dL/dbeta_j  = sum_set g
+/// - dL/dx_k     = (gamma_j * std_inv / m) * (m*g_k - sum_set(g) - x_hat_k * sum_set(g*x_hat))
+///   (the standard batchnorm-backward; mean over the BATCH set, not the feature dim).
+pub(crate) struct BatchNorm1dBackward {
+    pub(crate) x: Tensor,
+    pub(crate) gamma: Tensor,
+    pub(crate) eps: f32,
+}
+
+impl BatchNorm1dBackward {
+    /// Indices for one feature across batch (and spatial) dims — mirrors
+    /// `BatchNorm1d::feature_indices`.
+    fn feature_indices(shape: &[usize], feature: usize) -> Vec<usize> {
+        let (batch_size, features) = (shape[0], shape[1]);
+        if shape.len() == 2 {
+            (0..batch_size).map(|b| b * features + feature).collect()
+        } else {
+            let length = shape[2];
+            let mut indices = Vec::with_capacity(batch_size * length);
+            for b in 0..batch_size {
+                for l in 0..length {
+                    indices.push(b * features * length + feature * length + l);
+                }
+            }
+            indices
+        }
+    }
+}
+
+impl GradFn for BatchNorm1dBackward {
+    fn backward(&self, grad_output: &Tensor) -> Vec<Tensor> {
+        let shape = self.x.shape();
+        let features = shape[1];
+        let x_data = self.x.data();
+        let gamma_data = self.gamma.data();
+        let g_data = grad_output.data();
+
+        let mut grad_x = vec![0.0f32; x_data.len()];
+        let mut grad_gamma = vec![0.0f32; features];
+        let mut grad_beta = vec![0.0f32; features];
+
+        for f in 0..features {
+            let indices = Self::feature_indices(shape, f);
+            let m = indices.len() as f32;
+
+            // Batch statistics (train mode), biased variance (÷N) as in forward.
+            let mean: f32 = indices.iter().map(|&i| x_data[i]).sum::<f32>() / m;
+            let var: f32 = indices
+                .iter()
+                .map(|&i| (x_data[i] - mean).powi(2))
+                .sum::<f32>()
+                / m;
+            let std_inv = 1.0 / (var + self.eps).sqrt();
+
+            // x_hat and the two reductions over the batch set.
+            let mut sum_g = 0.0f32;
+            let mut sum_g_xhat = 0.0f32;
+            for &i in &indices {
+                let xh = (x_data[i] - mean) * std_inv;
+                let g = g_data[i];
+                sum_g += g;
+                sum_g_xhat += g * xh;
+                grad_gamma[f] += g * xh;
+                grad_beta[f] += g;
+            }
+
+            let scale = gamma_data[f] * std_inv / m;
+            for &i in &indices {
+                let xh = (x_data[i] - mean) * std_inv;
+                grad_x[i] = scale * (m * g_data[i] - sum_g - xh * sum_g_xhat);
+            }
+        }
+
+        vec![
+            Tensor::new(&grad_x, self.x.shape()),
+            Tensor::new(&grad_gamma, self.gamma.shape()),
+            Tensor::new(&grad_beta, self.gamma.shape()),
+        ]
+    }
+
+    fn name(&self) -> &'static str {
+        "BatchNorm1dBackward"
+    }
+}
+
+/// Gradient function for affine GroupNorm: y = x_hat * gamma_c + beta_c,
+/// where x_hat normalizes within each (sample, group) over the
+/// `channels_per_group * spatial` elements (biased ÷group_size variance).
+///
+/// Obligation: OBLIG-GROUPNORM-BACKWARD-GRAD-FLOW.
+///
+/// Before PMAT-911 `GroupNorm::forward` built its output via `Tensor::new`,
+/// severing the autograd graph. This grad_fn flows gradient to ALL THREE inputs
+/// (x, gamma, beta), in that input order. gamma/beta are PER-CHANNEL.
+///
+/// Math (per (n, group), group of size `gs`, std_inv = 1/sqrt(var+eps)):
+/// - dL/dgamma_c = sum_{n, spatial} g * x_hat   (accumulated over the channel c)
+/// - dL/dbeta_c  = sum_{n, spatial} g
+/// - dL/dx_k     = std_inv * (g'_k - mean_grp(g') - x_hat_k * mean_grp(g'*x_hat))
+///   where g'_k = g_k * gamma_{c(k)}, and the means are over the whole group
+///   (channels_per_group * spatial), like LayerNorm but within each group.
+pub(crate) struct GroupNormBackward {
+    pub(crate) x: Tensor,
+    pub(crate) gamma: Tensor,
+    pub(crate) num_groups: usize,
+    pub(crate) eps: f32,
+}
+
+impl GradFn for GroupNormBackward {
+    fn backward(&self, grad_output: &Tensor) -> Vec<Tensor> {
+        let shape = self.x.shape();
+        let batch_size = shape[0];
+        let channels = shape[1];
+        let channels_per_group = channels / self.num_groups;
+        let spatial_size: usize = shape[2..].iter().product();
+        let group_size = channels_per_group * spatial_size;
+        let gs = group_size as f32;
+
+        let x_data = self.x.data();
+        let gamma_data = self.gamma.data();
+        let g_data = grad_output.data();
+
+        let mut grad_x = vec![0.0f32; x_data.len()];
+        let mut grad_gamma = vec![0.0f32; channels];
+        let mut grad_beta = vec![0.0f32; channels];
+
+        for n in 0..batch_size {
+            for grp in 0..self.num_groups {
+                // Group mean / biased variance.
+                let mut sum = 0.0f32;
+                for c in 0..channels_per_group {
+                    let channel_idx = grp * channels_per_group + c;
+                    for s in 0..spatial_size {
+                        let idx = n * channels * spatial_size + channel_idx * spatial_size + s;
+                        sum += x_data[idx];
+                    }
+                }
+                let mean = sum / gs;
+                let mut var_sum = 0.0f32;
+                for c in 0..channels_per_group {
+                    let channel_idx = grp * channels_per_group + c;
+                    for s in 0..spatial_size {
+                        let idx = n * channels * spatial_size + channel_idx * spatial_size + s;
+                        var_sum += (x_data[idx] - mean).powi(2);
+                    }
+                }
+                let var = var_sum / gs;
+                let std_inv = 1.0 / (var + self.eps).sqrt();
+
+                // First pass: x_hat, g' = g*gamma, group reductions, affine grads.
+                let mut sum_gp = 0.0f32;
+                let mut sum_gp_xhat = 0.0f32;
+                for c in 0..channels_per_group {
+                    let channel_idx = grp * channels_per_group + c;
+                    let gamma_c = gamma_data[channel_idx];
+                    for s in 0..spatial_size {
+                        let idx = n * channels * spatial_size + channel_idx * spatial_size + s;
+                        let xh = (x_data[idx] - mean) * std_inv;
+                        let g = g_data[idx];
+                        let gp = g * gamma_c;
+                        sum_gp += gp;
+                        sum_gp_xhat += gp * xh;
+                        grad_gamma[channel_idx] += g * xh;
+                        grad_beta[channel_idx] += g;
+                    }
+                }
+                let mean_gp = sum_gp / gs;
+                let mean_gp_xhat = sum_gp_xhat / gs;
+
+                // Second pass: dx within the group.
+                for c in 0..channels_per_group {
+                    let channel_idx = grp * channels_per_group + c;
+                    let gamma_c = gamma_data[channel_idx];
+                    for s in 0..spatial_size {
+                        let idx = n * channels * spatial_size + channel_idx * spatial_size + s;
+                        let xh = (x_data[idx] - mean) * std_inv;
+                        let gp = g_data[idx] * gamma_c;
+                        grad_x[idx] = std_inv * (gp - mean_gp - xh * mean_gp_xhat);
+                    }
+                }
+            }
+        }
+
+        vec![
+            Tensor::new(&grad_x, self.x.shape()),
+            Tensor::new(&grad_gamma, self.gamma.shape()),
+            Tensor::new(&grad_beta, self.gamma.shape()),
+        ]
+    }
+
+    fn name(&self) -> &'static str {
+        "GroupNormBackward"
+    }
+}
+
 include!("gradient.rs");
 include!("grad_fn_tests.rs");

--- a/crates/aprender-core/src/nn/normalization/group_norm.rs
+++ b/crates/aprender-core/src/nn/normalization/group_norm.rs
@@ -66,6 +66,61 @@ impl GroupNorm {
     pub fn num_channels(&self) -> usize {
         self.num_channels
     }
+
+    /// Set the affine scale (γ / weight) tensor (e.g. to attach `requires_grad`).
+    pub fn set_weight(&mut self, weight: Tensor) {
+        self.weight = weight;
+    }
+
+    /// Set the affine shift (β / bias) tensor.
+    pub fn set_bias(&mut self, bias: Tensor) {
+        self.bias = bias;
+    }
+
+    /// Get a reference to the affine scale (γ / weight) tensor.
+    #[must_use]
+    pub fn weight(&self) -> &Tensor {
+        &self.weight
+    }
+
+    /// Get a reference to the affine shift (β / bias) tensor.
+    #[must_use]
+    pub fn bias(&self) -> &Tensor {
+        &self.bias
+    }
+
+    /// Record the GroupNorm backward edge on the autograd tape
+    /// (PMAT-911 / OBLIG-GROUPNORM-BACKWARD-GRAD-FLOW).
+    fn record_groupnorm_backward(&self, input: &Tensor, result: &mut Tensor) {
+        use crate::autograd::{is_grad_enabled, with_graph};
+        use std::sync::Arc;
+
+        if is_grad_enabled()
+            && (input.requires_grad_enabled()
+                || self.weight.requires_grad_enabled()
+                || self.bias.requires_grad_enabled())
+        {
+            result.requires_grad_(true);
+            let grad_fn = Arc::new(crate::autograd::grad_fn::GroupNormBackward {
+                x: input.clone(),
+                gamma: self.weight.clone(),
+                num_groups: self.num_groups,
+                eps: self.eps,
+            });
+            result.set_grad_fn(grad_fn.clone());
+
+            with_graph(|graph| {
+                graph.register_tensor(input.clone());
+                graph.register_tensor(self.weight.clone());
+                graph.register_tensor(self.bias.clone());
+                graph.record(
+                    result.id(),
+                    grad_fn,
+                    vec![input.id(), self.weight.id(), self.bias.id()],
+                );
+            });
+        }
+    }
 }
 
 impl Module for GroupNorm {
@@ -136,7 +191,17 @@ impl Module for GroupNorm {
             }
         }
 
-        Tensor::new(&output_data, shape)
+        let mut result = Tensor::new(&output_data, shape);
+
+        // PMAT-911 / OBLIG-GROUPNORM-BACKWARD-GRAD-FLOW: wire the autograd backward
+        // so gradients flow to the per-channel affine params (gamma=weight,
+        // beta=bias) AND the input x. Only the affine path is differentiable
+        // (non-affine GroupNorm has no learnable params and a frozen output).
+        if self.affine {
+            self.record_groupnorm_backward(input, &mut result);
+        }
+
+        result
     }
 
     fn parameters(&self) -> Vec<&Tensor> {

--- a/crates/aprender-core/src/nn/normalization/mod.rs
+++ b/crates/aprender-core/src/nn/normalization/mod.rs
@@ -271,6 +271,28 @@ impl BatchNorm1d {
             .expect("BatchNorm1d running_var lock poisoned")
             .clone()
     }
+
+    /// Set the affine scale (γ / weight) tensor (e.g. to attach `requires_grad`).
+    pub fn set_weight(&mut self, weight: Tensor) {
+        self.weight = weight;
+    }
+
+    /// Set the affine shift (β / bias) tensor.
+    pub fn set_bias(&mut self, bias: Tensor) {
+        self.bias = bias;
+    }
+
+    /// Get a reference to the affine scale (γ / weight) tensor.
+    #[must_use]
+    pub fn weight(&self) -> &Tensor {
+        &self.weight
+    }
+
+    /// Get a reference to the affine shift (β / bias) tensor.
+    #[must_use]
+    pub fn bias(&self) -> &Tensor {
+        &self.bias
+    }
 }
 
 impl BatchNorm1d {
@@ -288,6 +310,38 @@ impl BatchNorm1d {
                 }
             }
             indices
+        }
+    }
+
+    /// Record the BatchNorm1d (train-mode) backward edge on the autograd tape
+    /// (PMAT-911 / OBLIG-BATCHNORM1D-BACKWARD-GRAD-FLOW).
+    fn record_batchnorm_backward(&self, input: &Tensor, result: &mut Tensor) {
+        use crate::autograd::{is_grad_enabled, with_graph};
+        use std::sync::Arc;
+
+        if is_grad_enabled()
+            && (input.requires_grad_enabled()
+                || self.weight.requires_grad_enabled()
+                || self.bias.requires_grad_enabled())
+        {
+            result.requires_grad_(true);
+            let grad_fn = Arc::new(crate::autograd::grad_fn::BatchNorm1dBackward {
+                x: input.clone(),
+                gamma: self.weight.clone(),
+                eps: self.eps,
+            });
+            result.set_grad_fn(grad_fn.clone());
+
+            with_graph(|graph| {
+                graph.register_tensor(input.clone());
+                graph.register_tensor(self.weight.clone());
+                graph.register_tensor(self.bias.clone());
+                graph.record(
+                    result.id(),
+                    grad_fn,
+                    vec![input.id(), self.weight.id(), self.bias.id()],
+                );
+            });
         }
     }
 
@@ -385,7 +439,19 @@ impl Module for BatchNorm1d {
         drop(running_mean);
         drop(running_var);
 
-        Tensor::new(&output_data, shape)
+        let mut result = Tensor::new(&output_data, shape);
+
+        // PMAT-911 / OBLIG-BATCHNORM1D-BACKWARD-GRAD-FLOW: wire the autograd
+        // backward so gradients flow to the affine params (gamma=weight,
+        // beta=bias) AND the input x. Without this the layer is non-fine-tunable
+        // (graph severed by Tensor::new). Train-mode uses BATCH statistics for
+        // the gradient (the eval-mode running-stat path is a frozen affine and
+        // is intentionally not differentiated through here).
+        if self.training {
+            self.record_batchnorm_backward(input, &mut result);
+        }
+
+        result
     }
 
     fn parameters(&self) -> Vec<&Tensor> {

--- a/crates/aprender-core/src/nn/normalization/tests.rs
+++ b/crates/aprender-core/src/nn/normalization/tests.rs
@@ -448,6 +448,8 @@ fn test_batch_norm_1d_parameters_mut() {
 mod tests_batchnorm_contract;
 #[path = "tests_batchnorm_groupnorm.rs"]
 mod tests_batchnorm_groupnorm;
+#[path = "tests_batchnorm_groupnorm_backward.rs"]
+mod tests_batchnorm_groupnorm_backward;
 #[path = "tests_layernorm_contract.rs"]
 mod tests_layernorm_contract;
 #[path = "tests_norm_backward_gradflow.rs"]

--- a/crates/aprender-core/src/nn/normalization/tests_batchnorm_groupnorm_backward.rs
+++ b/crates/aprender-core/src/nn/normalization/tests_batchnorm_groupnorm_backward.rs
@@ -1,0 +1,359 @@
+//! Falsifier: BatchNorm1d (train mode) + GroupNorm backward MUST flow gradient
+//! to their affine params (and input x).
+//!
+//! Obligations:
+//! - OBLIG-BATCHNORM1D-BACKWARD-GRAD-FLOW
+//! - OBLIG-GROUPNORM-BACKWARD-GRAD-FLOW
+//!
+//! BUG (PMAT-911, sibling of PMAT-907): `BatchNorm1d::forward` and
+//! `GroupNorm::forward` built their output via `Tensor::new`, which severs the
+//! autograd graph. After `loss.backward()`, `weight.grad()` / `bias.grad()`
+//! were `None` — the affine scale (gamma) and shift (beta) never received
+//! gradient, so every BatchNorm/GroupNorm layer was NON-FINE-TUNABLE.
+//!
+//! These tests are a self-contained central finite-difference gradcheck (no
+//! torch dep): perturb each gamma[i] / beta[i] by ±eps, recompute the scalar
+//! loss, and compare the central difference against the analytic `.grad`. They
+//! also assert grad is non-None (the severed-graph guard). The finite-diff
+//! comparison genuinely catches a wrong/missing gradient — it is NOT a
+//! tautological `is_some` on a hardcoded value.
+//!
+//! BatchNorm1d is tested in TRAIN mode: the backward differentiates through the
+//! BATCH statistics (the standard, trickiest batchnorm-backward), matching the
+//! biased (÷N) variance the forward uses for normalization.
+
+use crate::autograd::{self, Tensor};
+use crate::nn::normalization::{BatchNorm1d, GroupNorm};
+use crate::nn::Module;
+
+/// Fixed, non-uniform upstream coefficient so BOTH dL/dgamma and dL/dbeta are
+/// nonzero (a bare `sum(output)` leaves dL/dgamma ~ sum(x_hat) ~ 0).
+fn coeff(n: usize) -> Vec<f32> {
+    (0..n).map(|i| 0.3 + 0.17 * (i as f32)).collect()
+}
+
+const FD_EPS: f32 = 1e-3;
+const TOL: f32 = 2e-2;
+
+fn assert_close(analytic: f32, numeric: f32, what: &str) {
+    let denom = analytic.abs().max(numeric.abs()).max(1.0);
+    let rel = (analytic - numeric).abs() / denom;
+    assert!(
+        rel < TOL,
+        "{what}: analytic grad {analytic} != finite-diff {numeric} (rel err {rel})"
+    );
+}
+
+// ============================================================================
+// BatchNorm1d (TRAIN mode)
+// ============================================================================
+
+/// Per-ELEMENT (per [b, j]) detached loss coefficient. CRITICAL: the
+/// coefficient must vary across the BATCH reduction (rows), not only across
+/// features. dL/dgamma_j = sum_b c[b,j] * x_hat[b,j]; with a feature-constant
+/// c, sum_b x_hat[b,j] == 0 (batch-normalized) ⟹ dgamma == 0 and the gamma
+/// gradcheck would be vacuous (a scale-by-1.5 mutation would survive). A
+/// row-varying coefficient makes dgamma genuinely nonzero.
+fn batch_coeff(batch: usize, feat: usize) -> Vec<f32> {
+    let mut v = Vec::with_capacity(batch * feat);
+    for b in 0..batch {
+        for j in 0..feat {
+            v.push(0.3 + 0.17 * (j as f32) + 0.23 * (b as f32) - 0.07 * ((b * j) as f32));
+        }
+    }
+    v
+}
+
+/// Scalar loss = sum_{b,j} cvec[b,j] * y[b, j] over a 2D output `[N, C]`.
+/// `cvec` is detached so the only graph edges are through gamma/beta/x.
+fn scalar_loss_2d(output: &Tensor, cvec: &[f32]) -> Tensor {
+    let c_tensor = Tensor::new(cvec, output.shape());
+    output.mul(&c_tensor).sum()
+}
+
+/// Re-run BatchNorm1d (train mode) forward + loss WITHOUT a graph, with the
+/// affine params overridden. Pure function of (gamma, beta) — the finite-diff
+/// reference. A FRESH layer each call keeps running-stat buffers irrelevant
+/// (train-mode normalization uses batch stats, not running stats).
+fn forward_loss_batchnorm(x: &Tensor, gamma: &[f32], beta: &[f32], eps: f32, c: &[f32]) -> f32 {
+    autograd::no_grad(|| {
+        let mut bn = BatchNorm1d::new(gamma.len()).with_eps(eps);
+        bn.set_weight(Tensor::new(gamma, &[gamma.len()]));
+        bn.set_bias(Tensor::new(beta, &[beta.len()]));
+        let y = bn.forward(x);
+        scalar_loss_2d(&y, c).item()
+    })
+}
+
+#[test]
+fn batchnorm1d_train_backward_flows_grad_to_gamma_and_beta() {
+    autograd::clear_graph();
+
+    let feat = 4usize;
+    let batch = 5usize; // N>1 so batch variance is well-defined
+    let eps = 1e-5f32;
+    let x_data: Vec<f32> = (0..batch * feat)
+        .map(|k| {
+            let r = (k / feat) as f32;
+            let f = (k % feat) as f32;
+            0.5 + 0.4 * f - 0.3 * r + 0.05 * (f * r)
+        })
+        .collect();
+    let x = Tensor::new(&x_data, &[batch, feat]);
+    let c = batch_coeff(batch, feat);
+
+    let gamma0: Vec<f32> = (0..feat).map(|i| 1.0 + 0.2 * (i as f32)).collect();
+    let beta0: Vec<f32> = (0..feat).map(|i| -0.1 + 0.15 * (i as f32)).collect();
+
+    let mut bn = BatchNorm1d::new(feat).with_eps(eps);
+    bn.set_weight(Tensor::new(&gamma0, &[feat]).requires_grad());
+    bn.set_bias(Tensor::new(&beta0, &[feat]).requires_grad());
+    assert!(bn.training(), "must be train mode for batch-stat backward");
+
+    let gamma_id = bn.weight().id();
+    let beta_id = bn.bias().id();
+
+    let y = bn.forward(&x);
+    let loss = scalar_loss_2d(&y, &c);
+    loss.backward();
+
+    let gamma_grad = autograd::get_grad(gamma_id)
+        .expect("BatchNorm1d gamma (weight) received NO gradient — autograd graph severed");
+    let beta_grad = autograd::get_grad(beta_id)
+        .expect("BatchNorm1d beta (bias) received NO gradient — autograd graph severed");
+
+    for i in 0..feat {
+        let mut gp = gamma0.clone();
+        gp[i] += FD_EPS;
+        let mut gm = gamma0.clone();
+        gm[i] -= FD_EPS;
+        let num = (forward_loss_batchnorm(&x, &gp, &beta0, eps, &c)
+            - forward_loss_batchnorm(&x, &gm, &beta0, eps, &c))
+            / (2.0 * FD_EPS);
+        assert_close(
+            gamma_grad.data()[i],
+            num,
+            &format!("BatchNorm1d dL/dgamma[{i}]"),
+        );
+
+        let mut bp = beta0.clone();
+        bp[i] += FD_EPS;
+        let mut bm = beta0.clone();
+        bm[i] -= FD_EPS;
+        let num_b = (forward_loss_batchnorm(&x, &gamma0, &bp, eps, &c)
+            - forward_loss_batchnorm(&x, &gamma0, &bm, eps, &c))
+            / (2.0 * FD_EPS);
+        assert_close(
+            beta_grad.data()[i],
+            num_b,
+            &format!("BatchNorm1d dL/dbeta[{i}]"),
+        );
+    }
+
+    assert!(gamma_grad.data().iter().all(|g| g.is_finite()));
+    assert!(beta_grad.data().iter().all(|g| g.is_finite()));
+    assert!(gamma_grad.data().iter().any(|&g| g.abs() > 1e-6));
+    assert!(beta_grad.data().iter().any(|&g| g.abs() > 1e-6));
+}
+
+#[test]
+fn batchnorm1d_train_backward_flows_grad_to_input() {
+    autograd::clear_graph();
+
+    let feat = 3usize;
+    let batch = 4usize;
+    let eps = 1e-5f32;
+    let x_data: Vec<f32> = vec![
+        0.5, -0.2, 1.1, 0.3, 0.7, -0.4, -0.1, 0.9, 0.2, 0.6, -0.3, 0.4,
+    ];
+    let gamma0: Vec<f32> = vec![1.0, 1.3, 0.7];
+    let beta0: Vec<f32> = vec![0.0, 0.2, -0.1];
+    let c = batch_coeff(batch, feat);
+
+    let x = Tensor::new(&x_data, &[batch, feat]).requires_grad();
+    let x_id = x.id();
+
+    let mut bn = BatchNorm1d::new(feat).with_eps(eps);
+    bn.set_weight(Tensor::new(&gamma0, &[feat]).requires_grad());
+    bn.set_bias(Tensor::new(&beta0, &[feat]).requires_grad());
+
+    let y = bn.forward(&x);
+    let loss = scalar_loss_2d(&y, &c);
+    loss.backward();
+
+    let x_grad = autograd::get_grad(x_id).expect("BatchNorm1d input x received NO gradient");
+
+    let recompute = |xd: &[f32]| -> f32 {
+        autograd::no_grad(|| {
+            let xx = Tensor::new(xd, &[batch, feat]);
+            forward_loss_batchnorm(&xx, &gamma0, &beta0, eps, &c)
+        })
+    };
+
+    for i in 0..(batch * feat) {
+        let mut xp = x_data.clone();
+        xp[i] += FD_EPS;
+        let mut xm = x_data.clone();
+        xm[i] -= FD_EPS;
+        let num = (recompute(&xp) - recompute(&xm)) / (2.0 * FD_EPS);
+        assert_close(x_grad.data()[i], num, &format!("BatchNorm1d dL/dx[{i}]"));
+    }
+}
+
+// ============================================================================
+// GroupNorm
+// ============================================================================
+
+/// Scalar loss for a GroupNorm output `[N, C, *]`. Coefficient is per-channel
+/// (broadcast across spatial), detached.
+fn scalar_loss_groupnorm(output: &Tensor, c_per_channel: &[f32], spatial: usize) -> Tensor {
+    let shape = output.shape();
+    let batch = shape[0];
+    let channels = shape[1];
+    let mut cvec = Vec::with_capacity(output.numel());
+    for _ in 0..batch {
+        for &cc in c_per_channel.iter().take(channels) {
+            for _ in 0..spatial {
+                cvec.push(cc);
+            }
+        }
+    }
+    let c_tensor = Tensor::new(&cvec, shape);
+    output.mul(&c_tensor).sum()
+}
+
+fn forward_loss_groupnorm(
+    x: &Tensor,
+    num_groups: usize,
+    channels: usize,
+    gamma: &[f32],
+    beta: &[f32],
+    eps: f32,
+    c: &[f32],
+    spatial: usize,
+) -> f32 {
+    autograd::no_grad(|| {
+        let mut gn = GroupNorm::with_eps(num_groups, channels, eps);
+        gn.set_weight(Tensor::new(gamma, &[channels]));
+        gn.set_bias(Tensor::new(beta, &[channels]));
+        let y = gn.forward(x);
+        scalar_loss_groupnorm(&y, c, spatial).item()
+    })
+}
+
+#[test]
+fn groupnorm_backward_flows_grad_to_gamma_and_beta() {
+    autograd::clear_graph();
+
+    let num_groups = 2usize;
+    let channels = 4usize;
+    let spatial = 3usize; // [N, C, L]
+    let batch = 2usize;
+    let eps = 1e-5f32;
+    let total = batch * channels * spatial;
+    let x_data: Vec<f32> = (0..total)
+        .map(|k| 0.4 + 0.31 * (k as f32) - 0.05 * ((k * k % 7) as f32))
+        .collect();
+    let x = Tensor::new(&x_data, &[batch, channels, spatial]);
+    let c = coeff(channels);
+
+    let gamma0: Vec<f32> = (0..channels).map(|i| 1.0 + 0.2 * (i as f32)).collect();
+    let beta0: Vec<f32> = (0..channels).map(|i| -0.1 + 0.15 * (i as f32)).collect();
+
+    let mut gn = GroupNorm::with_eps(num_groups, channels, eps);
+    gn.set_weight(Tensor::new(&gamma0, &[channels]).requires_grad());
+    gn.set_bias(Tensor::new(&beta0, &[channels]).requires_grad());
+
+    let gamma_id = gn.weight().id();
+    let beta_id = gn.bias().id();
+
+    let y = gn.forward(&x);
+    let loss = scalar_loss_groupnorm(&y, &c, spatial);
+    loss.backward();
+
+    let gamma_grad = autograd::get_grad(gamma_id)
+        .expect("GroupNorm gamma (weight) received NO gradient — autograd graph severed");
+    let beta_grad = autograd::get_grad(beta_id)
+        .expect("GroupNorm beta (bias) received NO gradient — autograd graph severed");
+
+    for i in 0..channels {
+        let mut gp = gamma0.clone();
+        gp[i] += FD_EPS;
+        let mut gm = gamma0.clone();
+        gm[i] -= FD_EPS;
+        let num = (forward_loss_groupnorm(&x, num_groups, channels, &gp, &beta0, eps, &c, spatial)
+            - forward_loss_groupnorm(&x, num_groups, channels, &gm, &beta0, eps, &c, spatial))
+            / (2.0 * FD_EPS);
+        assert_close(
+            gamma_grad.data()[i],
+            num,
+            &format!("GroupNorm dL/dgamma[{i}]"),
+        );
+
+        let mut bp = beta0.clone();
+        bp[i] += FD_EPS;
+        let mut bm = beta0.clone();
+        bm[i] -= FD_EPS;
+        let num_b =
+            (forward_loss_groupnorm(&x, num_groups, channels, &gamma0, &bp, eps, &c, spatial)
+                - forward_loss_groupnorm(&x, num_groups, channels, &gamma0, &bm, eps, &c, spatial))
+                / (2.0 * FD_EPS);
+        assert_close(
+            beta_grad.data()[i],
+            num_b,
+            &format!("GroupNorm dL/dbeta[{i}]"),
+        );
+    }
+
+    assert!(gamma_grad.data().iter().all(|g| g.is_finite()));
+    assert!(beta_grad.data().iter().all(|g| g.is_finite()));
+    assert!(gamma_grad.data().iter().any(|&g| g.abs() > 1e-6));
+    assert!(beta_grad.data().iter().any(|&g| g.abs() > 1e-6));
+}
+
+#[test]
+fn groupnorm_backward_flows_grad_to_input() {
+    autograd::clear_graph();
+
+    let num_groups = 2usize;
+    let channels = 4usize;
+    let spatial = 2usize;
+    let batch = 1usize;
+    let eps = 1e-5f32;
+    let total = batch * channels * spatial;
+    let x_data: Vec<f32> = (0..total)
+        .map(|k| 0.3 + 0.27 * (k as f32) - 0.04 * ((k * 3 % 5) as f32))
+        .collect();
+    let gamma0: Vec<f32> = vec![1.0, 1.3, 0.7, 1.1];
+    let beta0: Vec<f32> = vec![0.0, 0.2, -0.1, 0.05];
+    let c = coeff(channels);
+
+    let x = Tensor::new(&x_data, &[batch, channels, spatial]).requires_grad();
+    let x_id = x.id();
+
+    let mut gn = GroupNorm::with_eps(num_groups, channels, eps);
+    gn.set_weight(Tensor::new(&gamma0, &[channels]).requires_grad());
+    gn.set_bias(Tensor::new(&beta0, &[channels]).requires_grad());
+
+    let y = gn.forward(&x);
+    let loss = scalar_loss_groupnorm(&y, &c, spatial);
+    loss.backward();
+
+    let x_grad = autograd::get_grad(x_id).expect("GroupNorm input x received NO gradient");
+
+    let recompute = |xd: &[f32]| -> f32 {
+        autograd::no_grad(|| {
+            let xx = Tensor::new(xd, &[batch, channels, spatial]);
+            forward_loss_groupnorm(&xx, num_groups, channels, &gamma0, &beta0, eps, &c, spatial)
+        })
+    };
+
+    for i in 0..total {
+        let mut xp = x_data.clone();
+        xp[i] += FD_EPS;
+        let mut xm = x_data.clone();
+        xm[i] -= FD_EPS;
+        let num = (recompute(&xp) - recompute(&xm)) / (2.0 * FD_EPS);
+        assert_close(x_grad.data()[i], num, &format!("GroupNorm dL/dx[{i}]"));
+    }
+}


### PR DESCRIPTION
## Summary

Completes the **norm-backward family** (Pillar-2 autograd correctness beat, v0.54). Sibling of #2196 (PMAT-907, LayerNorm/RMSNorm).

`BatchNorm1d::forward` and `GroupNorm::forward` built their output via `Tensor::new`, which **severs the autograd graph**. After `loss.backward()`, `get_grad(weight.id())` / `get_grad(bias.id())` were `None` — the affine scale (gamma) and shift (beta) never received gradient, so every BatchNorm/GroupNorm layer was **NON-FINE-TUNABLE**.

Confirmed RED before fixing: a tiny BatchNorm1d (train mode) and GroupNorm with `requires_grad` weight/bias → forward → scalar loss → backward produced `None` grads for both weight and bias.

## Fix

Add `BatchNorm1dBackward` + `GroupNormBackward` `GradFn` impls (mirroring #2196) and record them on the autograd tape from the forwards, wiring `[x, gamma, beta]` as graph inputs.

- **BatchNorm1d (TRAIN mode)** — differentiates through the BATCH statistics (biased ÷N variance, matching the forward's normalization):
  - `dL/dgamma_j = sum_set g*x_hat`, `dL/dbeta_j = sum_set g`
  - `dL/dx_k = (gamma_j*std_inv/m) * (m*g_k - sum_set(g) - x_hat_k*sum_set(g*x_hat))`
- **GroupNorm** — LayerNorm-like within each `(sample, group)`, per-channel affine:
  - `dL/dgamma_c = sum g*x_hat`, `dL/dbeta_c = sum g`
  - `dL/dx = std_inv*(g' - mean_grp(g') - x_hat*mean_grp(g'*x_hat))`, `g'=g*gamma`

Eval-mode BatchNorm (frozen running-stat affine) is intentionally not differentiated through; non-affine GroupNorm has no learnable params.

## Falsifier (self-contained finite-difference gradcheck, no torch)

4 tests covering gamma, beta, and x on both norms. Central difference vs analytic `.grad` within rel tol 2e-2, plus a non-None severed-graph guard. BatchNorm is exercised in **train mode** with a per-row-varying loss coefficient so `dL/dgamma` is genuinely nonzero (a feature-constant coefficient gives `sum_b x_hat == 0` → vacuous gamma check).

**Mutation-verified non-tautological:** scaling each of the 6 backward edges (BN gamma/beta/x, GN gamma/beta/x) by 1.5 individually makes the corresponding gradcheck go RED; restored → all GREEN.

## Gates

- `cargo test -p aprender-core --lib` → **13983 passed, 0 failed**
- `cargo clippy -p aprender-core --lib -- -D warnings` → clean
- `cargo fmt --check` → clean
- `pv validate contracts/norm-backward-gradflow-v1.yaml` → valid
- `pv lint contracts/` → PASS (0 errors)

## Obligations / Contract

- `OBLIG-BATCHNORM1D-BACKWARD-GRAD-FLOW`
- `OBLIG-GROUPNORM-BACKWARD-GRAD-FLOW`
- `contracts/norm-backward-gradflow-v1.yaml` extended to v1.1.0 (4 new falsifiers, single-line refs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)