### PR TITLE
fix(autograd): Embedding/Flatten/Pool backward flow gradient (PMAT-913)

### DIFF
--- a/contracts/pool-flatten-embedding-backward-gradflow-v1.yaml
+++ b/contracts/pool-flatten-embedding-backward-gradflow-v1.yaml
@@ -1,0 +1,131 @@
+contract: pool-flatten-embedding-backward-gradflow
+metadata:
+  kind: training-loop
+  version: "1.0.0"
+  description: >
+    The shape/pooling/lookup layers (Flatten, MaxPool1d, MaxPool2d, AvgPool2d,
+    GlobalAvgPool2d) MUST flow gradient to their INPUT, and the token Embedding
+    MUST flow gradient to its weight TABLE. Guards the PMAT-913 root-cause fix:
+    these forwards built their output via Tensor::new, which severs the autograd
+    graph — after loss.backward(), get_grad(input.id()) / get_grad(weight.id())
+    were None, so any network with a pooling/flatten layer in the middle could
+    not propagate gradient to the upstream conv/linear weights, and the token
+    embeddings were NON-TRAINABLE. The forwards now record FlattenBackward /
+    MaxPool1dBackward / MaxPool2dBackward / AvgPool2dBackward /
+    GlobalAvgPool2dBackward / EmbeddingBackward on the tape. Embedding backward is
+    a SCATTER-ADD (dW[idx[i]] += grad_out[i]) so repeated token ids accumulate.
+  references:
+  - "crates/aprender-core/src/nn/conv/mod.rs"
+  - "crates/aprender-core/src/nn/conv/conv2d.rs"
+  - "crates/aprender-core/src/nn/conv/maxpool2d.rs"
+  - "crates/aprender-core/src/autograd/grad_fn.rs"
+  - "crates/aprender-core/src/models/qwen2/mod.rs"
+  - "crates/aprender-core/src/nn/conv/tests_pool_flatten_backward_gradflow.rs"
+  - "crates/aprender-core/src/models/qwen2/tests_embedding_backward_gradflow.rs"
+version: 1
+status: enforced
+date: 2026-06-24
+
+proof_obligations:
+  - type: invariant
+    property: >
+      OBLIG-FLATTEN-BACKWARD-GRAD-FLOW: after loss.backward() on a graph
+      containing Flatten::forward, get_grad is Some for the input x, has the input
+      shape, and equals grad_output reshaped to the input shape (Flatten is a pure
+      view: dL/dx = reshape(grad_output, input_shape)). Matches a central
+      finite-difference gradcheck within tolerance.
+  - type: invariant
+    property: >
+      OBLIG-MAXPOOL1D-BACKWARD-GRAD-FLOW: after loss.backward() on a graph
+      containing MaxPool1d::forward, get_grad is Some for the input x. The
+      gradient is routed to the argmax position of each pooling window (subgradient
+      of max; ties to the first max). dL/dx[argmax(window)] += grad_out[window].
+      Matches a central finite-difference gradcheck within tolerance (distinct
+      per-window maxima so argmax is unambiguous).
+  - type: invariant
+    property: >
+      OBLIG-MAXPOOL2D-BACKWARD-GRAD-FLOW: after loss.backward() on a graph
+      containing MaxPool2d::forward, get_grad is Some for the input x. The gradient
+      is routed to the argmax position of each 2D window per channel.
+      dL/dx[argmax(window)] += grad_out[window]. Matches a central
+      finite-difference gradcheck within tolerance.
+  - type: invariant
+    property: >
+      OBLIG-AVGPOOL2D-BACKWARD-GRAD-FLOW: after loss.backward() on a graph
+      containing AvgPool2d::forward, get_grad is Some for the input x. The gradient
+      is distributed evenly: each input element in a window receives
+      grad_out[window] / (kernel_h*kernel_w). Matches a central finite-difference
+      gradcheck within tolerance.
+  - type: invariant
+    property: >
+      OBLIG-GLOBALAVGPOOL2D-BACKWARD-GRAD-FLOW: after loss.backward() on a graph
+      containing GlobalAvgPool2d::forward, get_grad is Some for the input x. Each
+      input element in plane (n,c) receives grad_out[n,c] / (H*W). Matches a
+      central finite-difference gradcheck within tolerance.
+  - type: invariant
+    property: >
+      OBLIG-EMBEDDING-BACKWARD-GRAD-FLOW: after loss.backward() on a graph
+      containing Embedding::forward, get_grad is Some for the weight TABLE, shaped
+      [vocab, hidden]. The backward SCATTER-ADDs each upstream row into the
+      corresponding table row by index: dW[idx[i]] += grad_out[i]. Repeated token
+      ids ACCUMULATE (ADD, not overwrite). Rows for never-referenced ids stay zero.
+      Matches a central finite-difference gradcheck of the table within tolerance.
+  - type: equivalence
+    property: >
+      GRADCHECK-NON-TAUTOLOGICAL: every falsifier is a finite-difference gradcheck
+      (plus a severed-graph is_some guard and an all-zero guard), not an is_some
+      assertion on a hardcoded value. Mutation-verified: AvgPool2d grad/area ->
+      grad*area, MaxPool2d argmax -> fixed window corner, Flatten backward -> zeros,
+      and Embedding scatter ADD -> overwrite each make the corresponding gradcheck
+      go RED. The Embedding additive test uses a REPEATED index so an overwrite
+      (last-write-wins) is observably wrong.
+
+falsification_tests:
+  - id: FALSIFY-FLATTEN-BACKWARD-GRAD-FLOW-001
+    name: flatten_backward_flows_grad_to_input
+    prediction: "Flatten input grad is Some and matches the finite-difference gradcheck within tol"
+    test_harness: "cargo test -p aprender-core --lib flatten_backward_flows_grad_to_input"
+    expected_output: "test result: ok"
+    if_fails: "Flatten::forward severed the autograd graph (Tensor::new). Record FlattenBackward (pure reshape) on the tape with input [x]."
+  - id: FALSIFY-MAXPOOL1D-BACKWARD-GRAD-FLOW-001
+    name: maxpool1d_backward_routes_grad_to_argmax
+    prediction: "MaxPool1d input grad is Some, routed to argmax, and matches the finite-difference gradcheck within tol"
+    test_harness: "cargo test -p aprender-core --lib maxpool1d_backward_routes_grad_to_argmax"
+    expected_output: "test result: ok"
+    if_fails: "MaxPool1d::forward severed the autograd graph. Record MaxPool1dBackward routing grad to the argmax position per window."
+  - id: FALSIFY-MAXPOOL2D-BACKWARD-GRAD-FLOW-001
+    name: maxpool2d_backward_routes_grad_to_argmax
+    prediction: "MaxPool2d input grad is Some, routed to argmax, and matches the finite-difference gradcheck within tol"
+    test_harness: "cargo test -p aprender-core --lib maxpool2d_backward_routes_grad_to_argmax"
+    expected_output: "test result: ok"
+    if_fails: "MaxPool2d::forward severed the autograd graph. Record MaxPool2dBackward routing grad to the argmax position per 2D window."
+  - id: FALSIFY-MAXPOOL2D-BACKWARD-GRAD-FLOW-002
+    name: maxpool2d_two_channel_independent_argmax
+    prediction: "MaxPool2d routes grad to the correct per-channel argmax for a 2-channel input"
+    test_harness: "cargo test -p aprender-core --lib maxpool2d_two_channel_independent_argmax"
+    expected_output: "test result: ok"
+    if_fails: "MaxPool2d backward must index per (n,c) plane; a channel-blind index lands grad in the wrong channel."
+  - id: FALSIFY-AVGPOOL2D-BACKWARD-GRAD-FLOW-001
+    name: avgpool2d_backward_distributes_grad
+    prediction: "AvgPool2d input grad is Some, distributes grad/area, and matches the finite-difference gradcheck within tol"
+    test_harness: "cargo test -p aprender-core --lib avgpool2d_backward_distributes_grad"
+    expected_output: "test result: ok"
+    if_fails: "AvgPool2d::forward severed the autograd graph. Record AvgPool2dBackward distributing grad_out/(kh*kw) to each window element."
+  - id: FALSIFY-GLOBALAVGPOOL2D-BACKWARD-GRAD-FLOW-001
+    name: globalavgpool2d_backward_distributes_grad
+    prediction: "GlobalAvgPool2d input grad is Some, distributes grad/(H*W), and matches the finite-difference gradcheck within tol"
+    test_harness: "cargo test -p aprender-core --lib globalavgpool2d_backward_distributes_grad"
+    expected_output: "test result: ok"
+    if_fails: "GlobalAvgPool2d::forward severed the autograd graph. Record GlobalAvgPool2dBackward distributing grad_out[n,c]/(H*W)."
+  - id: FALSIFY-EMBEDDING-BACKWARD-GRAD-FLOW-001
+    name: embedding_backward_scatter_add_gradcheck
+    prediction: "Embedding weight-table grad is Some and matches the finite-difference gradcheck within tol"
+    test_harness: "cargo test -p aprender-core --lib embedding_backward_scatter_add_gradcheck"
+    expected_output: "test result: ok"
+    if_fails: "Embedding::forward severed the autograd graph (Tensor::new). Record EmbeddingBackward scatter-adding grad_out rows into the weight table by token index."
+  - id: FALSIFY-EMBEDDING-BACKWARD-GRAD-FLOW-002
+    name: embedding_backward_is_additive_for_repeated_index
+    prediction: "Embedding backward ACCUMULATES (ADD) gradient across repeated token ids"
+    test_harness: "cargo test -p aprender-core --lib embedding_backward_is_additive_for_repeated_index"
+    expected_output: "test result: ok"
+    if_fails: "Embedding scatter must be ADD (dW[idx] += g), not overwrite; an overwrite loses gradient from all but the last occurrence of a repeated token."

--- a/crates/aprender-core/src/autograd/grad_fn.rs
+++ b/crates/aprender-core/src/autograd/grad_fn.rs
@@ -851,5 +851,283 @@ impl GradFn for GroupNormBackward {
     }
 }
 
+// ============================================================================
+// Shape / Pooling / Embedding Operations (PMAT-913)
+//
+// Before PMAT-913 the canonical nn Flatten / MaxPool1d / MaxPool2d / AvgPool2d /
+// GlobalAvgPool2d forwards built their output via `Tensor::new`, severing the
+// autograd graph: `input.grad` was `None` after `backward()`, so any model with
+// a pooling/flatten layer in the middle could not propagate gradient to the
+// upstream conv/linear weights. Likewise the token `Embedding` forward built its
+// lookup output via `Tensor::new`, so the embedding TABLE never received
+// gradient (non-trainable token embeddings). These grad_fns wire the missing
+// backward edges.
+// ============================================================================
+
+/// Gradient function for `Flatten` (and any pure reshape view).
+///
+/// Obligation: OBLIG-FLATTEN-BACKWARD-GRAD-FLOW.
+///
+/// Flatten is a pure view: it only changes the shape, not the values. The
+/// backward is therefore the identity on values, reshaped back to the input
+/// shape: `dL/dx = reshape(grad_output, input_shape)`.
+pub(crate) struct FlattenBackward {
+    pub(crate) input_shape: Vec<usize>,
+}
+
+impl GradFn for FlattenBackward {
+    fn backward(&self, grad_output: &Tensor) -> Vec<Tensor> {
+        // Pure reshape: same data, original shape.
+        vec![Tensor::new(grad_output.data(), &self.input_shape)]
+    }
+
+    fn name(&self) -> &'static str {
+        "FlattenBackward"
+    }
+}
+
+/// Gradient function for `MaxPool1d`: route grad_output to the argmax position
+/// within each pooling window (subgradient of max). Ties go to the FIRST max
+/// (matching the forward `max()` left-to-right scan).
+///
+/// Obligation: OBLIG-MAXPOOL1D-BACKWARD-GRAD-FLOW.
+///
+/// Input `[N, C, L]`, output `[N, C, L_out]`, `L_out = (L - k)/s + 1`.
+pub(crate) struct MaxPool1dBackward {
+    pub(crate) input: Tensor,
+    pub(crate) kernel_size: usize,
+    pub(crate) stride: usize,
+}
+
+impl GradFn for MaxPool1dBackward {
+    fn backward(&self, grad_output: &Tensor) -> Vec<Tensor> {
+        let shape = self.input.shape();
+        let (batch, channels, in_len) = (shape[0], shape[1], shape[2]);
+        let out_len = (in_len - self.kernel_size) / self.stride + 1;
+        let x = self.input.data();
+        let g = grad_output.data();
+        let mut grad_x = vec![0.0f32; x.len()];
+
+        for n in 0..batch {
+            for c in 0..channels {
+                let base = n * channels * in_len + c * in_len;
+                for ol in 0..out_len {
+                    let mut max_val = f32::NEG_INFINITY;
+                    let mut argmax = 0usize;
+                    for k in 0..self.kernel_size {
+                        let il = ol * self.stride + k;
+                        let v = x[base + il];
+                        if v > max_val {
+                            max_val = v;
+                            argmax = il;
+                        }
+                    }
+                    let out_idx = n * channels * out_len + c * out_len + ol;
+                    grad_x[base + argmax] += g[out_idx];
+                }
+            }
+        }
+
+        vec![Tensor::new(&grad_x, shape)]
+    }
+
+    fn name(&self) -> &'static str {
+        "MaxPool1dBackward"
+    }
+}
+
+/// Gradient function for `MaxPool2d`: route grad_output to the argmax position
+/// within each 2D window. Ties go to the FIRST max in row-major (kh, kw) scan.
+///
+/// Obligation: OBLIG-MAXPOOL2D-BACKWARD-GRAD-FLOW.
+///
+/// Input `[N, C, H, W]`, output `[N, C, H_out, W_out]`.
+pub(crate) struct MaxPool2dBackward {
+    pub(crate) input: Tensor,
+    pub(crate) kernel_h: usize,
+    pub(crate) kernel_w: usize,
+    pub(crate) stride_h: usize,
+    pub(crate) stride_w: usize,
+}
+
+impl GradFn for MaxPool2dBackward {
+    fn backward(&self, grad_output: &Tensor) -> Vec<Tensor> {
+        let shape = self.input.shape();
+        let (batch, channels, in_h, in_w) = (shape[0], shape[1], shape[2], shape[3]);
+        let out_h = (in_h - self.kernel_h) / self.stride_h + 1;
+        let out_w = (in_w - self.kernel_w) / self.stride_w + 1;
+        let x = self.input.data();
+        let g = grad_output.data();
+        let mut grad_x = vec![0.0f32; x.len()];
+
+        for n in 0..batch {
+            for c in 0..channels {
+                let plane = n * channels * in_h * in_w + c * in_h * in_w;
+                for oh in 0..out_h {
+                    for ow in 0..out_w {
+                        let mut max_val = f32::NEG_INFINITY;
+                        let mut argmax = 0usize;
+                        for kh in 0..self.kernel_h {
+                            for kw in 0..self.kernel_w {
+                                let ih = oh * self.stride_h + kh;
+                                let iw = ow * self.stride_w + kw;
+                                let idx = plane + ih * in_w + iw;
+                                if x[idx] > max_val {
+                                    max_val = x[idx];
+                                    argmax = idx;
+                                }
+                            }
+                        }
+                        let out_idx =
+                            n * channels * out_h * out_w + c * out_h * out_w + oh * out_w + ow;
+                        grad_x[argmax] += g[out_idx];
+                    }
+                }
+            }
+        }
+
+        vec![Tensor::new(&grad_x, shape)]
+    }
+
+    fn name(&self) -> &'static str {
+        "MaxPool2dBackward"
+    }
+}
+
+/// Gradient function for `AvgPool2d`: distribute `grad_output / kernel_area`
+/// evenly to every input element in the pooling window.
+///
+/// Obligation: OBLIG-AVGPOOL2D-BACKWARD-GRAD-FLOW.
+pub(crate) struct AvgPool2dBackward {
+    pub(crate) input_shape: Vec<usize>,
+    pub(crate) kernel_h: usize,
+    pub(crate) kernel_w: usize,
+    pub(crate) stride_h: usize,
+    pub(crate) stride_w: usize,
+}
+
+impl GradFn for AvgPool2dBackward {
+    fn backward(&self, grad_output: &Tensor) -> Vec<Tensor> {
+        let (batch, channels, in_h, in_w) = (
+            self.input_shape[0],
+            self.input_shape[1],
+            self.input_shape[2],
+            self.input_shape[3],
+        );
+        let out_h = (in_h - self.kernel_h) / self.stride_h + 1;
+        let out_w = (in_w - self.kernel_w) / self.stride_w + 1;
+        let g = grad_output.data();
+        let area = (self.kernel_h * self.kernel_w) as f32;
+        let mut grad_x = vec![0.0f32; batch * channels * in_h * in_w];
+
+        for n in 0..batch {
+            for c in 0..channels {
+                let plane = n * channels * in_h * in_w + c * in_h * in_w;
+                for oh in 0..out_h {
+                    for ow in 0..out_w {
+                        let out_idx =
+                            n * channels * out_h * out_w + c * out_h * out_w + oh * out_w + ow;
+                        let share = g[out_idx] / area;
+                        for kh in 0..self.kernel_h {
+                            for kw in 0..self.kernel_w {
+                                let ih = oh * self.stride_h + kh;
+                                let iw = ow * self.stride_w + kw;
+                                grad_x[plane + ih * in_w + iw] += share;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        vec![Tensor::new(&grad_x, &self.input_shape)]
+    }
+
+    fn name(&self) -> &'static str {
+        "AvgPool2dBackward"
+    }
+}
+
+/// Gradient function for `GlobalAvgPool2d`: each output `[n, c]` is the mean of
+/// the whole `H x W` plane, so every input element in that plane receives
+/// `grad_output[n, c] / (H * W)`.
+///
+/// Obligation: OBLIG-GLOBALAVGPOOL2D-BACKWARD-GRAD-FLOW.
+pub(crate) struct GlobalAvgPool2dBackward {
+    pub(crate) input_shape: Vec<usize>,
+}
+
+impl GradFn for GlobalAvgPool2dBackward {
+    fn backward(&self, grad_output: &Tensor) -> Vec<Tensor> {
+        let (batch, channels, in_h, in_w) = (
+            self.input_shape[0],
+            self.input_shape[1],
+            self.input_shape[2],
+            self.input_shape[3],
+        );
+        let spatial = (in_h * in_w) as f32;
+        let g = grad_output.data();
+        let mut grad_x = vec![0.0f32; batch * channels * in_h * in_w];
+
+        for n in 0..batch {
+            for c in 0..channels {
+                let share = g[n * channels + c] / spatial;
+                let plane = n * channels * in_h * in_w + c * in_h * in_w;
+                for k in 0..(in_h * in_w) {
+                    grad_x[plane + k] = share;
+                }
+            }
+        }
+
+        vec![Tensor::new(&grad_x, &self.input_shape)]
+    }
+
+    fn name(&self) -> &'static str {
+        "GlobalAvgPool2dBackward"
+    }
+}
+
+/// Gradient function for the token `Embedding` lookup table.
+///
+/// Obligation: OBLIG-EMBEDDING-BACKWARD-GRAD-FLOW.
+///
+/// Forward gathers row `idx[i]` of the `[vocab, hidden]` weight into output row
+/// `i`. The backward SCATTER-ADDs each upstream gradient row back into the
+/// corresponding weight row: `dW[idx[i]] += grad_output[i]`. Because multiple
+/// positions can reference the SAME token id, the accumulation MUST be additive
+/// (not an overwrite) — otherwise repeated tokens would lose gradient. The token
+/// indices themselves are integers and carry no gradient.
+pub(crate) struct EmbeddingBackward {
+    pub(crate) indices: Vec<u32>,
+    pub(crate) vocab_size: usize,
+    pub(crate) hidden_size: usize,
+}
+
+impl GradFn for EmbeddingBackward {
+    fn backward(&self, grad_output: &Tensor) -> Vec<Tensor> {
+        let g = grad_output.data();
+        let h = self.hidden_size;
+        let mut grad_w = vec![0.0f32; self.vocab_size * h];
+
+        for (i, &tok) in self.indices.iter().enumerate() {
+            let row = tok as usize;
+            if row >= self.vocab_size {
+                continue; // OOB token contributes no gradient (matches forward N-09 escape).
+            }
+            let g_off = i * h;
+            let w_off = row * h;
+            for j in 0..h {
+                grad_w[w_off + j] += g[g_off + j];
+            }
+        }
+
+        vec![Tensor::new(&grad_w, &[self.vocab_size, h])]
+    }
+
+    fn name(&self) -> &'static str {
+        "EmbeddingBackward"
+    }
+}
+
 include!("gradient.rs");
 include!("grad_fn_tests.rs");

--- a/crates/aprender-core/src/models/qwen2/mod.rs
+++ b/crates/aprender-core/src/models/qwen2/mod.rs
@@ -127,10 +127,41 @@ impl Embedding {
         let batch_size = 1;
         let mut output = vec![0.0f32; batch_size * input_ids.len() * self.hidden_size];
         self.forward_into(input_ids, &mut output);
-        let result = Tensor::new(&output, &[batch_size, input_ids.len(), self.hidden_size]);
+        let mut result = Tensor::new(&output, &[batch_size, input_ids.len(), self.hidden_size]);
+
+        // PMAT-913 / OBLIG-EMBEDDING-BACKWARD-GRAD-FLOW: scatter-add the upstream
+        // gradient back into the embedding TABLE rows by token index so the
+        // token embeddings are trainable (previously severed via Tensor::new).
+        self.record_embedding_backward(input_ids, &mut result);
+
         contract_post_embedding_lookup!(result.data());
         contract_post_inference_determinism!(result.data());
         result
+    }
+
+    /// Record the Embedding backward edge on the autograd tape (PMAT-913).
+    ///
+    /// Wires the embedding `weight` table as the sole graph input. The backward
+    /// scatter-adds `grad_output[i]` into `dW[input_ids[i]]`; repeated token ids
+    /// accumulate (ADD, not overwrite). Only runs when grad is enabled and the
+    /// weight requires grad.
+    fn record_embedding_backward(&self, input_ids: &[u32], result: &mut Tensor) {
+        use crate::autograd::{is_grad_enabled, with_graph};
+        use std::sync::Arc;
+
+        if is_grad_enabled() && self.weight.requires_grad_enabled() {
+            result.requires_grad_(true);
+            let grad_fn = Arc::new(crate::autograd::grad_fn::EmbeddingBackward {
+                indices: input_ids.to_vec(),
+                vocab_size: self.vocab_size,
+                hidden_size: self.hidden_size,
+            });
+            result.set_grad_fn(grad_fn.clone());
+            with_graph(|graph| {
+                graph.register_tensor(self.weight.clone());
+                graph.record(result.id(), grad_fn, vec![self.weight.id()]);
+            });
+        }
     }
 
     /// Set weights from external tensor.
@@ -355,6 +386,10 @@ pub struct Qwen2Model {
 #[cfg(test)]
 #[path = "tests_embedding_contract.rs"]
 mod tests_embedding_contract;
+
+#[cfg(test)]
+#[path = "tests_embedding_backward_gradflow.rs"]
+mod tests_embedding_backward_gradflow;
 
 include!("constructors.rs");
 include!("element-wise.rs");

--- a/crates/aprender-core/src/models/qwen2/tests_embedding_backward_gradflow.rs
+++ b/crates/aprender-core/src/models/qwen2/tests_embedding_backward_gradflow.rs
@@ -1,0 +1,147 @@
+//! Falsifier: token `Embedding` backward MUST scatter-ADD gradient into the
+//! embedding TABLE rows by index — so token embeddings are trainable.
+//!
+//! Obligation: OBLIG-EMBEDDING-BACKWARD-GRAD-FLOW.
+//!
+//! BUG (PMAT-913): `Embedding::forward` built its lookup output via
+//! `Tensor::new`, severing the autograd graph: after `loss.backward()` the
+//! weight table received NO gradient (`get_grad(weight.id()) == None`), making
+//! token embeddings NON-TRAINABLE.
+//!
+//! Two checks:
+//! 1. Severed-graph guard + finite-difference gradcheck of the scatter-add dW
+//!    against a self-contained central difference on the embedding table.
+//! 2. Scatter is ADD not overwrite: a REPEATED token id must accumulate the
+//!    gradient from every position that referenced it.
+
+use super::Embedding;
+use crate::autograd::{self, Tensor};
+
+const FD_EPS: f32 = 1e-3;
+const TOL: f32 = 2e-2;
+
+fn coeff(n: usize) -> Vec<f32> {
+    (0..n).map(|i| 0.29 + 0.17 * (i as f32)).collect()
+}
+
+fn scalar_loss(output: &Tensor, c: &[f32]) -> Tensor {
+    let ct = Tensor::new(c, output.shape());
+    output.mul(&ct).sum()
+}
+
+/// Forward + loss WITHOUT a graph, with weight value at `flat_idx` perturbed.
+fn perturbed_loss(
+    w_data: &[f32],
+    vocab: usize,
+    hidden: usize,
+    ids: &[u32],
+    flat_idx: usize,
+    delta: f32,
+    c: &[f32],
+) -> f32 {
+    autograd::no_grad(|| {
+        let mut wd = w_data.to_vec();
+        wd[flat_idx] += delta;
+        let mut emb = Embedding::new(vocab, hidden);
+        emb.set_weight(Tensor::new(&wd, &[vocab, hidden]));
+        let y = emb.forward(ids);
+        scalar_loss(&y, c).item()
+    })
+}
+
+#[test]
+fn embedding_backward_scatter_add_gradcheck() {
+    autograd::clear_graph();
+    let vocab = 6usize;
+    let hidden = 4usize;
+    // REPEATED index 2 (positions 0 and 3) exercises the scatter-ADD path.
+    let ids = [2u32, 5, 0, 2];
+
+    // Non-degenerate weight table.
+    let w_data: Vec<f32> = (0..vocab * hidden)
+        .map(|i| 0.1 + 0.013 * (i as f32) - 0.002 * ((i * i) as f32))
+        .collect();
+
+    let mut emb = Embedding::new(vocab, hidden);
+    emb.set_weight(Tensor::new(&w_data, &[vocab, hidden]).requires_grad());
+    let wid = emb.weight().id();
+
+    let y = emb.forward(&ids);
+    let c = coeff(y.numel());
+    let loss = scalar_loss(&y, &c);
+    loss.backward();
+
+    let grad = autograd::get_grad(wid)
+        .expect("Embedding weight received NO gradient — autograd graph severed");
+    assert_eq!(grad.shape(), &[vocab, hidden]);
+    assert!(grad.data().iter().all(|v| v.is_finite()));
+    assert!(grad.data().iter().any(|&v| v.abs() > 1e-9));
+
+    // Finite-difference gradcheck over the whole table.
+    for i in 0..w_data.len() {
+        let num = (perturbed_loss(&w_data, vocab, hidden, &ids, i, FD_EPS, &c)
+            - perturbed_loss(&w_data, vocab, hidden, &ids, i, -FD_EPS, &c))
+            / (2.0 * FD_EPS);
+        let denom = grad.data()[i].abs().max(num.abs()).max(1.0);
+        let rel = (grad.data()[i] - num).abs() / denom;
+        assert!(
+            rel < TOL,
+            "Embedding dW[{i}]: analytic {} != finite-diff {num} (rel {rel})",
+            grad.data()[i]
+        );
+    }
+
+    // Rows never referenced (1, 3, 4) must have ZERO gradient.
+    for &unused in &[1usize, 3, 4] {
+        for j in 0..hidden {
+            assert!(
+                grad.data()[unused * hidden + j].abs() < 1e-9,
+                "Embedding: unused row {unused} got nonzero grad"
+            );
+        }
+    }
+}
+
+#[test]
+fn embedding_backward_is_additive_for_repeated_index() {
+    // Pure scatter-add check: grad_output row i = c[i*h..]. The dW row for the
+    // repeated id MUST equal the SUM of both contributing positions, not just
+    // the last (which an overwrite would yield).
+    autograd::clear_graph();
+    let vocab = 5usize;
+    let hidden = 3usize;
+    let ids = [4u32, 1, 4]; // id 4 appears at positions 0 and 2.
+
+    let w_data: Vec<f32> = (0..vocab * hidden).map(|i| 0.01 * (i as f32)).collect();
+    let mut emb = Embedding::new(vocab, hidden);
+    emb.set_weight(Tensor::new(&w_data, &[vocab, hidden]).requires_grad());
+    let wid = emb.weight().id();
+
+    let y = emb.forward(&ids);
+    let c = coeff(y.numel()); // length = 3 positions * 3 hidden = 9
+    let loss = scalar_loss(&y, &c);
+    loss.backward();
+
+    let grad = autograd::get_grad(wid).expect("severed");
+    let g = grad.data();
+
+    // dW[4] should be c[pos0] + c[pos2] (positions 0 and 2 in the [3,3] output).
+    for j in 0..hidden {
+        let c_pos0 = c[0 * hidden + j];
+        let c_pos2 = c[2 * hidden + j];
+        let expect = c_pos0 + c_pos2;
+        let got = g[4 * hidden + j];
+        assert!(
+            (got - expect).abs() < 1e-5,
+            "Embedding scatter must ADD: dW[4][{j}] = {got}, expected sum {expect} (overwrite would give {c_pos2})"
+        );
+        // The ADD sum is strictly larger than either single contribution.
+        assert!(got > c_pos2 + 1e-6 && got > c_pos0 + 1e-6);
+    }
+
+    // dW[1] (single reference at position 1) = c[pos1].
+    for j in 0..hidden {
+        let expect = c[1 * hidden + j];
+        assert!((g[1 * hidden + j] - expect).abs() < 1e-5);
+    }
+}

--- a/crates/aprender-core/src/nn/conv/conv2d.rs
+++ b/crates/aprender-core/src/nn/conv/conv2d.rs
@@ -444,7 +444,20 @@ impl Module for MaxPool1d {
             }
         }
 
-        Tensor::new(&output, &[batch_size, channels, out_length])
+        let mut result = Tensor::new(&output, &[batch_size, channels, out_length]);
+
+        // PMAT-913 / OBLIG-MAXPOOL1D-BACKWARD-GRAD-FLOW: route grad to argmax.
+        super::record_single_input_backward(
+            input,
+            &mut result,
+            std::sync::Arc::new(crate::autograd::grad_fn::MaxPool1dBackward {
+                input: input.clone(),
+                kernel_size: self.kernel_size,
+                stride: self.stride,
+            }),
+        );
+
+        result
     }
 }
 

--- a/crates/aprender-core/src/nn/conv/maxpool2d.rs
+++ b/crates/aprender-core/src/nn/conv/maxpool2d.rs
@@ -89,7 +89,22 @@ impl Module for MaxPool2d {
             }
         }
 
-        Tensor::new(&output, &[batch_size, channels, out_h, out_w])
+        let mut result = Tensor::new(&output, &[batch_size, channels, out_h, out_w]);
+
+        // PMAT-913 / OBLIG-MAXPOOL2D-BACKWARD-GRAD-FLOW: route grad to argmax.
+        super::record_single_input_backward(
+            input,
+            &mut result,
+            std::sync::Arc::new(crate::autograd::grad_fn::MaxPool2dBackward {
+                input: input.clone(),
+                kernel_h: self.kernel_h,
+                kernel_w: self.kernel_w,
+                stride_h: self.stride_h,
+                stride_w: self.stride_w,
+            }),
+        );
+
+        result
     }
 }
 
@@ -182,7 +197,22 @@ impl Module for AvgPool2d {
             }
         }
 
-        Tensor::new(&output, &[batch_size, channels, out_h, out_w])
+        let mut result = Tensor::new(&output, &[batch_size, channels, out_h, out_w]);
+
+        // PMAT-913 / OBLIG-AVGPOOL2D-BACKWARD-GRAD-FLOW: distribute grad/area.
+        super::record_single_input_backward(
+            input,
+            &mut result,
+            std::sync::Arc::new(crate::autograd::grad_fn::AvgPool2dBackward {
+                input_shape: input.shape().to_vec(),
+                kernel_h: self.kernel_h,
+                kernel_w: self.kernel_w,
+                stride_h: self.stride_h,
+                stride_w: self.stride_w,
+            }),
+        );
+
+        result
     }
 }
 
@@ -232,7 +262,18 @@ impl Module for GlobalAvgPool2d {
             }
         }
 
-        Tensor::new(&output, &[batch_size, channels])
+        let mut result = Tensor::new(&output, &[batch_size, channels]);
+
+        // PMAT-913 / OBLIG-GLOBALAVGPOOL2D-BACKWARD-GRAD-FLOW: spread grad/(H*W).
+        super::record_single_input_backward(
+            input,
+            &mut result,
+            std::sync::Arc::new(crate::autograd::grad_fn::GlobalAvgPool2dBackward {
+                input_shape: input.shape().to_vec(),
+            }),
+        );
+
+        result
     }
 }
 
@@ -277,7 +318,19 @@ impl Module for Flatten {
         let flattened_size: usize = shape[self.start_dim..].iter().product();
         new_shape.push(flattened_size);
 
-        Tensor::new(input.data(), &new_shape)
+        let mut result = Tensor::new(input.data(), &new_shape);
+
+        // PMAT-913 / OBLIG-FLATTEN-BACKWARD-GRAD-FLOW: wire the autograd backward
+        // (pure reshape) so gradient flows to the upstream tensor.
+        super::record_single_input_backward(
+            input,
+            &mut result,
+            std::sync::Arc::new(crate::autograd::grad_fn::FlattenBackward {
+                input_shape: shape.to_vec(),
+            }),
+        );
+
+        result
     }
 }
 

--- a/crates/aprender-core/src/nn/conv/mod.rs
+++ b/crates/aprender-core/src/nn/conv/mod.rs
@@ -408,3 +408,27 @@ mod conv2d;
 pub use conv2d::*;
 mod maxpool2d;
 pub use maxpool2d::*;
+
+#[cfg(test)]
+#[path = "tests_pool_flatten_backward_gradflow.rs"]
+mod tests_pool_flatten_backward_gradflow;
+
+/// Record a single-input autograd backward edge for shape/pooling layers
+/// (PMAT-913). Only runs when grad is enabled and the input requires grad; the
+/// supplied `grad_fn` MUST return exactly one gradient (w.r.t. the input).
+pub(crate) fn record_single_input_backward(
+    input: &Tensor,
+    result: &mut Tensor,
+    grad_fn: std::sync::Arc<dyn crate::autograd::grad_fn::GradFn>,
+) {
+    use crate::autograd::{is_grad_enabled, with_graph};
+
+    if is_grad_enabled() && input.requires_grad_enabled() {
+        result.requires_grad_(true);
+        result.set_grad_fn(grad_fn.clone());
+        with_graph(|graph| {
+            graph.register_tensor(input.clone());
+            graph.record(result.id(), grad_fn, vec![input.id()]);
+        });
+    }
+}

--- a/crates/aprender-core/src/nn/conv/tests_pool_flatten_backward_gradflow.rs
+++ b/crates/aprender-core/src/nn/conv/tests_pool_flatten_backward_gradflow.rs
@@ -1,0 +1,175 @@
+//! Falsifier: Flatten / MaxPool1d / MaxPool2d / AvgPool2d / GlobalAvgPool2d
+//! backward MUST flow gradient to their input (severed-graph guard + gradcheck).
+//!
+//! Obligations:
+//! - OBLIG-FLATTEN-BACKWARD-GRAD-FLOW
+//! - OBLIG-MAXPOOL1D-BACKWARD-GRAD-FLOW
+//! - OBLIG-MAXPOOL2D-BACKWARD-GRAD-FLOW
+//! - OBLIG-AVGPOOL2D-BACKWARD-GRAD-FLOW
+//! - OBLIG-GLOBALAVGPOOL2D-BACKWARD-GRAD-FLOW
+//!
+//! BUG (PMAT-913): these forwards built their output via `Tensor::new`, which
+//! severs the autograd graph. After `loss.backward()`, `input.grad` was `None`,
+//! so a pooling/flatten layer in the middle of a network blocked gradient from
+//! reaching the upstream conv/linear weights. Each test below asserts the input
+//! grad is non-None (severed-graph guard) AND matches a self-contained central
+//! finite-difference gradcheck (no torch dep) — not a tautological `is_some`.
+//!
+//! The MaxPool inputs use DISTINCT values per window so the argmax is
+//! unambiguous (the subgradient of `max` is well defined and the finite
+//! difference is exact away from ties).
+
+use super::{AvgPool2d, Flatten, GlobalAvgPool2d, MaxPool1d, MaxPool2d};
+use crate::autograd::{self, Tensor};
+use crate::nn::Module;
+
+const FD_EPS: f32 = 1e-3;
+const TOL: f32 = 2e-2;
+
+/// Detached, non-uniform upstream coefficient vector.
+fn coeff(n: usize) -> Vec<f32> {
+    (0..n).map(|i| 0.37 + 0.13 * (i as f32)).collect()
+}
+
+/// Scalar loss = sum_i c_i * y_i, with c detached (no graph edge through it).
+fn scalar_loss(output: &Tensor, c: &[f32]) -> Tensor {
+    let ct = Tensor::new(c, output.shape());
+    output.mul(&ct).sum()
+}
+
+/// Run forward + loss WITHOUT a graph, with the input value at `flat_idx`
+/// perturbed by `delta`. Used for the finite-difference reference.
+fn perturbed_loss<F>(
+    x_data: &[f32],
+    x_shape: &[usize],
+    flat_idx: usize,
+    delta: f32,
+    fwd: F,
+    c: &[f32],
+) -> f32
+where
+    F: Fn(&Tensor) -> Tensor,
+{
+    autograd::no_grad(|| {
+        let mut xd = x_data.to_vec();
+        xd[flat_idx] += delta;
+        let x = Tensor::new(&xd, x_shape);
+        let y = fwd(&x);
+        scalar_loss(&y, c).item()
+    })
+}
+
+fn assert_close(analytic: f32, numeric: f32, what: &str) {
+    let denom = analytic.abs().max(numeric.abs()).max(1.0);
+    let rel = (analytic - numeric).abs() / denom;
+    assert!(
+        rel < TOL,
+        "{what}: analytic grad {analytic} != finite-diff {numeric} (rel err {rel})"
+    );
+}
+
+/// Generic gradcheck driver: forward `fwd(x)`, build scalar loss, backward,
+/// assert input grad present + finite + matches central finite difference at
+/// every input element.
+fn gradcheck_input<F>(name: &str, x_data: &[f32], x_shape: &[usize], fwd: F)
+where
+    F: Fn(&Tensor) -> Tensor,
+{
+    autograd::clear_graph();
+    let x = Tensor::new(x_data, x_shape).requires_grad();
+    let xid = x.id();
+    let y = fwd(&x);
+    let c = coeff(y.numel());
+    let loss = scalar_loss(&y, &c);
+    loss.backward();
+
+    let grad = autograd::get_grad(xid)
+        .unwrap_or_else(|| panic!("{name}: input received NO gradient — autograd graph severed"));
+    assert_eq!(grad.shape(), x_shape, "{name}: grad shape mismatch");
+    assert!(
+        grad.data().iter().all(|v| v.is_finite()),
+        "{name}: non-finite grad"
+    );
+    assert!(
+        grad.data().iter().any(|&v| v.abs() > 1e-9),
+        "{name}: all-zero grad"
+    );
+
+    for i in 0..x_data.len() {
+        let num = (perturbed_loss(x_data, x_shape, i, FD_EPS, &fwd, &c)
+            - perturbed_loss(x_data, x_shape, i, -FD_EPS, &fwd, &c))
+            / (2.0 * FD_EPS);
+        assert_close(grad.data()[i], num, &format!("{name} dL/dx[{i}]"));
+    }
+}
+
+#[test]
+fn flatten_backward_flows_grad_to_input() {
+    // [2,3,4] -> [2,12]; pure view, grad is identity reshaped.
+    let x: Vec<f32> = (0..24)
+        .map(|i| 0.2 + 0.05 * (i as f32) - 0.01 * ((i * i) as f32))
+        .collect();
+    gradcheck_input("Flatten", &x, &[2, 3, 4], |t| Flatten::new().forward(t));
+}
+
+#[test]
+fn maxpool1d_backward_routes_grad_to_argmax() {
+    // [1,2,6], kernel=2 stride=2 -> [1,2,3]. Distinct values => unambiguous argmax.
+    let x: Vec<f32> = vec![
+        0.1, 0.9, 0.3, 0.8, 0.2, 0.7, // channel 0
+        1.5, 0.4, 1.1, 0.6, 1.9, 0.5, // channel 1
+    ];
+    gradcheck_input("MaxPool1d", &x, &[1, 2, 6], |t| {
+        MaxPool1d::new(2).forward(t)
+    });
+}
+
+#[test]
+fn maxpool2d_backward_routes_grad_to_argmax() {
+    // [1,1,4,4], kernel=2 stride=2 -> [1,1,2,2]. Distinct per-window maxima.
+    let x: Vec<f32> = vec![
+        0.1, 0.2, 0.5, 0.4, //
+        0.9, 0.3, 0.6, 0.45, //
+        0.15, 0.25, 0.8, 0.35, //
+        0.7, 0.2, 0.55, 0.95, //
+    ];
+    gradcheck_input("MaxPool2d", &x, &[1, 1, 4, 4], |t| {
+        MaxPool2d::new(2).forward(t)
+    });
+}
+
+#[test]
+fn avgpool2d_backward_distributes_grad() {
+    let x: Vec<f32> = (0..16).map(|i| 0.3 + 0.07 * (i as f32)).collect();
+    gradcheck_input("AvgPool2d", &x, &[1, 1, 4, 4], |t| {
+        AvgPool2d::new(2).forward(t)
+    });
+}
+
+#[test]
+fn globalavgpool2d_backward_distributes_grad() {
+    let x: Vec<f32> = (0..16).map(|i| 0.4 + 0.09 * (i as f32)).collect();
+    gradcheck_input("GlobalAvgPool2d", &x, &[1, 1, 4, 4], |t| {
+        GlobalAvgPool2d::new().forward(t)
+    });
+}
+
+#[test]
+fn maxpool2d_two_channel_independent_argmax() {
+    // Distinct argmax per channel/window; confirms grad lands per-channel.
+    let x: Vec<f32> = vec![
+        // channel 0
+        2.0, 0.1, 0.2, 0.3, //
+        0.4, 0.5, 0.6, 0.7, //
+        0.8, 0.9, 3.0, 1.0, //
+        1.1, 1.2, 1.3, 1.4, //
+        // channel 1
+        0.05, 5.0, 0.15, 0.25, //
+        0.35, 0.45, 0.55, 0.65, //
+        0.75, 0.85, 0.95, 6.0, //
+        1.05, 1.15, 1.25, 1.35, //
+    ];
+    gradcheck_input("MaxPool2d-2ch", &x, &[1, 2, 4, 4], |t| {
+        MaxPool2d::new(2).forward(t)
+    });
+}


### PR DESCRIPTION
## Pillar-2 autograd correctness beat (PMAT-913)

Extends the norm-backward severed-graph fixes (**PMAT-907** #2196, **PMAT-911** #2200) to the simpler shape/pooling/lookup layers.

### The bug (RED-confirmed for all six)
Each of these forwards built its output via `Tensor::new`, which severs the autograd graph. After `loss.backward()`, `get_grad(input.id())` / `get_grad(weight.id())` were `None`:
- any network with a **Flatten** or **pooling** layer in the middle could NOT propagate gradient to upstream conv/linear weights;
- the token **Embedding** table received NO gradient → **non-trainable token embeddings**.

Probed RED first; **all six existing layers were severed**: `Flatten`, `MaxPool1d`, `MaxPool2d`, `AvgPool2d`, `GlobalAvgPool2d`, `Embedding`.

### The fix
Add the backward `grad_fn`s and record them on the tape from the forwards (only when grad is enabled + the relevant tensor requires grad):

| Layer | Backward |
|-------|----------|
| `FlattenBackward` | pure reshape: `dL/dx = reshape(grad_out, input_shape)` |
| `MaxPool1d/2dBackward` | route grad to the **argmax** position per window (subgradient of max; ties→first), indexed per `(n,c)` plane |
| `AvgPool2dBackward` | distribute `grad_out/(kh*kw)` to each window element |
| `GlobalAvgPool2dBackward` | spread `grad_out[n,c]/(H*W)` over the plane |
| `EmbeddingBackward` | **scatter-ADD** rows into the weight table by token index (`dW[idx[i]] += grad_out[i]`); repeated ids ACCUMULATE; indices carry no grad |

A shared `record_single_input_backward` helper wires the pool/flatten edges; Embedding wires its weight table as the sole graph input.

### Falsifiers (self-contained central finite-difference gradcheck — no torch dep)
6 pool/flatten input gradchecks + 2 Embedding table gradchecks (scatter-add + repeated-index additivity). All assert grad is non-None (severed-graph guard) AND match the numeric gradient within tol — **not a tautological `is_some`**. Inputs genuinely exercise the path: distinct per-window maxima for MaxPool argmax, a **repeated token id** for the Embedding scatter-ADD accumulation.

**Mutation-verified non-tautological**: AvgPool2d `grad/area`→`grad*area`, MaxPool2d argmax→fixed window corner, Flatten backward→zeros, and Embedding ADD→overwrite each make the corresponding gradcheck go **RED**.

### Contract
`contracts/pool-flatten-embedding-backward-gradflow-v1.yaml` — obligations `OBLIG-{FLATTEN,MAXPOOL1D,MAXPOOL2D,AVGPOOL2D,GLOBALAVGPOOL2D,EMBEDDING}-BACKWARD-GRAD-FLOW`. `pv validate` + `pv lint contracts/` pass (0 errors).

### Verification
- `cargo test -p aprender-core --lib` → **13995 passed**, 0 failed
- `cargo fmt --all --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
