### PR TITLE
fix(autograd): attention backward flows gradient to Q/K/V (end-to-end transformer trainability, PMAT-914)

### DIFF
--- a/contracts/attention-backward-gradflow-v1.yaml
+++ b/contracts/attention-backward-gradflow-v1.yaml
@@ -1,0 +1,62 @@
+contract: attention-backward-gradflow
+metadata:
+  kind: training-loop
+  version: "1.0.0"
+  description: >
+    MultiHeadAttention backward MUST flow gradient to the Q/K/V/out projection
+    weights — the CAPSTONE of the severed-graph sweep that establishes
+    end-to-end transformer fine-tunability. Guards the PMAT-914 root-cause fix.
+    The scaled-dot-product attention core built EVERY intermediate via
+    Tensor::from_vec / Tensor::new, severing the autograd graph: matmul_batched
+    (4D QK^T and attn@V), transpose_last_two (K^T), nn::functional::softmax
+    (attn weights), reshape_for_attention (split heads), reshape_from_attention
+    (concat heads). After loss.backward(), get_grad(q_proj.weight.id()) was None
+    — the Q/K/V projection weights (and the attention-side path to the out
+    projection) never received gradient, so a transformer attention block was
+    NON-FINE-TUNABLE despite the earlier norm (PMAT-907/911) and
+    embedding/flatten/pool (PMAT-913) gradflow fixes. The attention helpers now
+    record SoftmaxLastDimBackward, TransposeLastTwoBackward,
+    BatchedMatmul4dBackward, ReshapeForAttentionBackward, and
+    ReshapeFromAttentionBackward on the tape, keeping the chain
+    loss -> out_proj -> sdpa -> reshape -> {q,k,v}_proj unbroken.
+  references:
+  - "crates/aprender-core/src/nn/transformer/positional_encoding.rs"
+  - "crates/aprender-core/src/nn/transformer/mod.rs"
+  - "crates/aprender-core/src/autograd/grad_fn.rs"
+  - "crates/aprender-core/src/nn/transformer/tests_attention_backward_gradflow.rs"
+version: 1
+status: enforced
+date: 2026-06-24
+
+proof_obligations:
+  - type: invariant
+    property: >
+      OBLIG-ATTENTION-BACKWARD-GRAD-FLOW: after loss.backward() on a graph
+      containing a MultiHeadAttention self-attention forward with grad-tracked
+      Q/K/V/out projection weights, get_grad is Some AND finite-nonzero for all
+      four projection weights. The analytic gradients match a central
+      finite-difference gradcheck (every weight entry probed) within tolerance.
+      The backward composes the per-helper edges: BatchedMatmul4dBackward
+      (dA = grad @ B^T, dB = A^T @ grad per batch,head) for both QK^T and attn@V;
+      SoftmaxLastDimBackward (y * (g - <g,y>) over the last dim) for the attention
+      weights; TransposeLastTwoBackward (its own inverse) for K^T; and the
+      head split/concat reshapes (mutually-inverse permutations). Without the
+      recorded edges the graph is severed and the projection weights are frozen.
+  - type: equivalence
+    property: >
+      GRADCHECK-NON-TAUTOLOGICAL: the falsifier is a finite-difference gradcheck,
+      not an is_some assertion on a hardcoded value. The input/weight magnitudes
+      are chosen so the QK^T scores have wide spread (softmax strongly
+      non-uniform), making the Q/K gradient edges well above tolerance.
+      Mutation-verified: zeroing the BatchedMatmul4dBackward dA edge makes the
+      q_proj grad all-zero (RED); scaling that dA edge by 1.5 OR dropping the
+      SoftmaxLastDimBackward Jacobian dot term makes the k_proj central-difference
+      comparison go RED. The correct math is GREEN.
+
+falsification_tests:
+  - id: FALSIFY-ATTENTION-BACKWARD-GRAD-FLOW-001
+    name: attention_backward_flows_grad_to_qkv_and_out_proj
+    prediction: "MHA Q/K/V/out projection grads are Some + finite-nonzero and match the finite-difference gradcheck within tol"
+    test_harness: "cargo test -p aprender-core --lib attention_backward_flows_grad_to_qkv_and_out_proj"
+    expected_output: "test result: ok"
+    if_fails: "The scaled-dot-product attention helpers severed the autograd graph (Tensor::from_vec). Record SoftmaxLastDimBackward / TransposeLastTwoBackward / BatchedMatmul4dBackward / ReshapeFor+FromAttentionBackward on the tape so gradient flows back to the Q/K/V/out projection weights."

--- a/crates/aprender-core/src/autograd/grad_fn.rs
+++ b/crates/aprender-core/src/autograd/grad_fn.rs
@@ -851,5 +851,238 @@ impl GradFn for GroupNormBackward {
     }
 }
 
+// ============================================================================
+// Attention Operations (PMAT-914) — OBLIG-ATTENTION-BACKWARD-GRAD-FLOW
+//
+// The scaled-dot-product attention core built its intermediates via
+// `Tensor::from_vec` / `Tensor::new`, severing the autograd graph so the
+// Q/K/V/out projection weights received no gradient (transformer attention
+// non-fine-tunable). These grad_fns flow gradient through each helper so the
+// chain loss -> out_proj -> sdpa -> reshape -> {q,k,v}_proj stays unbroken.
+// ============================================================================
+
+/// Backward for softmax over the LAST dimension of an N-D tensor.
+///
+/// Treats the tensor as (rows = product of all leading dims) × (features = last
+/// dim). For each row: dL/dx = y * (g - <g, y>), the standard softmax Jacobian.
+pub(crate) struct SoftmaxLastDimBackward {
+    pub(crate) output: Tensor, // softmax output y (same shape as input)
+}
+
+impl GradFn for SoftmaxLastDimBackward {
+    fn backward(&self, grad_output: &Tensor) -> Vec<Tensor> {
+        let shape = self.output.shape();
+        let ndim = shape.len();
+        let features = if ndim == 0 { 1 } else { shape[ndim - 1] };
+        let total = self.output.numel();
+        let rows = if features == 0 { 0 } else { total / features };
+
+        let out_data = self.output.data();
+        let grad_data = grad_output.data();
+        let mut grad_input = vec![0.0; total];
+
+        for r in 0..rows {
+            let base = r * features;
+            let mut dot = 0.0;
+            for j in 0..features {
+                dot += grad_data[base + j] * out_data[base + j];
+            }
+            for j in 0..features {
+                let idx = base + j;
+                grad_input[idx] = out_data[idx] * (grad_data[idx] - dot);
+            }
+        }
+
+        vec![Tensor::new(&grad_input, shape)]
+    }
+
+    fn name(&self) -> &'static str {
+        "SoftmaxLastDimBackward"
+    }
+}
+
+/// Backward for `transpose_last_two`: the operation is its own inverse, so the
+/// incoming gradient is transposed back along the last two dims.
+pub(crate) struct TransposeLastTwoBackward {
+    pub(crate) input_shape: Vec<usize>, // shape of the ORIGINAL (pre-transpose) input
+}
+
+impl GradFn for TransposeLastTwoBackward {
+    fn backward(&self, grad_output: &Tensor) -> Vec<Tensor> {
+        let g = transpose_last_two_raw(grad_output);
+        // g now has the original input's shape.
+        vec![Tensor::new(g.data(), &self.input_shape)]
+    }
+
+    fn name(&self) -> &'static str {
+        "TransposeLastTwoBackward"
+    }
+}
+
+/// Backward for 4D batched matmul C = A @ B where
+/// A:[B,H,M,K], B:[B,H,K,N], C:[B,H,M,N].
+/// dA = grad @ B^T  (per batch,head);  dB = A^T @ grad  (per batch,head).
+pub(crate) struct BatchedMatmul4dBackward {
+    pub(crate) a: Tensor,
+    pub(crate) b: Tensor,
+}
+
+impl GradFn for BatchedMatmul4dBackward {
+    fn backward(&self, grad_output: &Tensor) -> Vec<Tensor> {
+        let a_shape = self.a.shape();
+        let b_shape = self.b.shape();
+        let (batch, heads, m, k) = (a_shape[0], a_shape[1], a_shape[2], a_shape[3]);
+        let n = b_shape[3];
+
+        let a = self.a.data();
+        let b = self.b.data();
+        let g = grad_output.data();
+
+        let mut grad_a = vec![0.0f32; batch * heads * m * k];
+        let mut grad_b = vec![0.0f32; batch * heads * k * n];
+
+        for bh in 0..(batch * heads) {
+            let a_off = bh * m * k;
+            let b_off = bh * k * n;
+            let g_off = bh * m * n;
+
+            // dA[m,k] = sum_n grad[m,n] * B[k,n]
+            for i in 0..m {
+                for kk in 0..k {
+                    let mut acc = 0.0;
+                    for j in 0..n {
+                        acc += g[g_off + i * n + j] * b[b_off + kk * n + j];
+                    }
+                    grad_a[a_off + i * k + kk] = acc;
+                }
+            }
+
+            // dB[k,n] = sum_m A[m,k] * grad[m,n]
+            for kk in 0..k {
+                for j in 0..n {
+                    let mut acc = 0.0;
+                    for i in 0..m {
+                        acc += a[a_off + i * k + kk] * g[g_off + i * n + j];
+                    }
+                    grad_b[b_off + kk * n + j] = acc;
+                }
+            }
+        }
+
+        vec![Tensor::new(&grad_a, a_shape), Tensor::new(&grad_b, b_shape)]
+    }
+
+    fn name(&self) -> &'static str {
+        "BatchedMatmul4dBackward"
+    }
+}
+
+/// Backward for `reshape_for_attention`: [b,s,embed] -> [b,heads,s,head_dim].
+/// The inverse permutation is exactly `reshape_from_attention`.
+pub(crate) struct ReshapeForAttentionBackward {
+    pub(crate) batch: usize,
+    pub(crate) seq_len: usize,
+    pub(crate) num_heads: usize,
+    pub(crate) head_dim: usize,
+}
+
+impl GradFn for ReshapeForAttentionBackward {
+    fn backward(&self, grad_output: &Tensor) -> Vec<Tensor> {
+        // grad_output: [b, heads, s, head_dim]; produce [b, s, embed].
+        let embed = self.num_heads * self.head_dim;
+        let g = grad_output.data();
+        let mut out = vec![0.0f32; self.batch * self.seq_len * embed];
+        for b in 0..self.batch {
+            for s in 0..self.seq_len {
+                for h in 0..self.num_heads {
+                    for d in 0..self.head_dim {
+                        let in_idx = b * self.num_heads * self.seq_len * self.head_dim
+                            + h * self.seq_len * self.head_dim
+                            + s * self.head_dim
+                            + d;
+                        let out_idx = b * self.seq_len * embed + s * embed + h * self.head_dim + d;
+                        out[out_idx] = g[in_idx];
+                    }
+                }
+            }
+        }
+        vec![Tensor::new(&out, &[self.batch, self.seq_len, embed])]
+    }
+
+    fn name(&self) -> &'static str {
+        "ReshapeForAttentionBackward"
+    }
+}
+
+/// Backward for `reshape_from_attention`: [b,heads,s,head_dim] -> [b,s,embed].
+/// The inverse permutation is exactly `reshape_for_attention`.
+pub(crate) struct ReshapeFromAttentionBackward {
+    pub(crate) batch: usize,
+    pub(crate) seq_len: usize,
+    pub(crate) num_heads: usize,
+    pub(crate) head_dim: usize,
+}
+
+impl GradFn for ReshapeFromAttentionBackward {
+    fn backward(&self, grad_output: &Tensor) -> Vec<Tensor> {
+        // grad_output: [b, s, embed]; produce [b, heads, s, head_dim].
+        let embed = self.num_heads * self.head_dim;
+        let g = grad_output.data();
+        let mut out = vec![0.0f32; self.batch * self.num_heads * self.seq_len * self.head_dim];
+        for b in 0..self.batch {
+            for s in 0..self.seq_len {
+                for h in 0..self.num_heads {
+                    for d in 0..self.head_dim {
+                        let out_idx = b * self.num_heads * self.seq_len * self.head_dim
+                            + h * self.seq_len * self.head_dim
+                            + s * self.head_dim
+                            + d;
+                        let in_idx = b * self.seq_len * embed + s * embed + h * self.head_dim + d;
+                        out[out_idx] = g[in_idx];
+                    }
+                }
+            }
+        }
+        vec![Tensor::new(
+            &out,
+            &[self.batch, self.num_heads, self.seq_len, self.head_dim],
+        )]
+    }
+
+    fn name(&self) -> &'static str {
+        "ReshapeFromAttentionBackward"
+    }
+}
+
+/// Pure (non-autograd) transpose of the last two dims of an N-D tensor.
+/// Shared by the forward helper and `TransposeLastTwoBackward`.
+pub(crate) fn transpose_last_two_raw(x: &Tensor) -> Tensor {
+    let shape = x.shape();
+    let ndim = shape.len();
+    if ndim < 2 {
+        return Tensor::new(x.data(), shape);
+    }
+    let last = shape[ndim - 1];
+    let second_last = shape[ndim - 2];
+    let mut new_shape = shape.to_vec();
+    new_shape[ndim - 2] = last;
+    new_shape[ndim - 1] = second_last;
+
+    let batch_size: usize = shape[..ndim - 2].iter().product();
+    let matrix_size = last * second_last;
+    let src = x.data();
+    let mut output = vec![0.0; src.len()];
+    for b in 0..batch_size {
+        let offset = b * matrix_size;
+        for i in 0..second_last {
+            let src_base = offset + i * last;
+            for j in 0..last {
+                output[offset + j * second_last + i] = src[src_base + j];
+            }
+        }
+    }
+    Tensor::from_vec(output, &new_shape)
+}
+
 include!("gradient.rs");
 include!("grad_fn_tests.rs");

--- a/crates/aprender-core/src/nn/transformer/positional_encoding.rs
+++ b/crates/aprender-core/src/nn/transformer/positional_encoding.rs
@@ -254,7 +254,54 @@ pub(crate) fn transpose_last_two(x: &Tensor) -> Tensor {
         }
     }
 
-    Tensor::from_vec(output, &new_shape)
+    let mut result = Tensor::from_vec(output, &new_shape);
+
+    // PMAT-914 / OBLIG-ATTENTION-BACKWARD-GRAD-FLOW: record the transpose edge so
+    // gradient flows back through K^T to the key projection.
+    record_attention_grad(x, &mut result, || {
+        std::sync::Arc::new(crate::autograd::grad_fn::TransposeLastTwoBackward {
+            input_shape: shape.to_vec(),
+        })
+    });
+
+    result
+}
+
+/// Record a single-input attention helper backward edge on the autograd tape
+/// (PMAT-914). No-op unless grad tracking is on AND the input requires grad.
+fn record_attention_grad<F>(input: &Tensor, result: &mut Tensor, make: F)
+where
+    F: FnOnce() -> std::sync::Arc<dyn crate::autograd::GradFn>,
+{
+    use crate::autograd::{is_grad_enabled, with_graph};
+    if is_grad_enabled() && input.requires_grad_enabled() {
+        result.requires_grad_(true);
+        let grad_fn = make();
+        result.set_grad_fn(grad_fn.clone());
+        with_graph(|graph| {
+            graph.register_tensor(input.clone());
+            graph.record(result.id(), grad_fn, vec![input.id()]);
+        });
+    }
+}
+
+/// Record a two-input attention helper backward edge (PMAT-914).
+/// No-op unless grad tracking is on AND at least one input requires grad.
+fn record_attention_grad2<F>(a: &Tensor, b: &Tensor, result: &mut Tensor, make: F)
+where
+    F: FnOnce() -> std::sync::Arc<dyn crate::autograd::GradFn>,
+{
+    use crate::autograd::{is_grad_enabled, with_graph};
+    if is_grad_enabled() && (a.requires_grad_enabled() || b.requires_grad_enabled()) {
+        result.requires_grad_(true);
+        let grad_fn = make();
+        result.set_grad_fn(grad_fn.clone());
+        with_graph(|graph| {
+            graph.register_tensor(a.clone());
+            graph.register_tensor(b.clone());
+            graph.record(result.id(), grad_fn, vec![a.id(), b.id()]);
+        });
+    }
 }
 
 /// Batched matrix multiplication using SIMD-accelerated Trueno.
@@ -286,7 +333,18 @@ pub(crate) fn matmul_batched(a: &Tensor, b: &Tensor) -> Tensor {
         let output = Matrix::batched_matmul_4d(a.data(), b.data(), batch, heads, m, k1, n)
             .expect("batched_matmul_4d failed: dimensions validated but operation failed");
 
-        Tensor::from_vec(output, &[batch, heads, m, n])
+        let mut result = Tensor::from_vec(output, &[batch, heads, m, n]);
+
+        // PMAT-914 / OBLIG-ATTENTION-BACKWARD-GRAD-FLOW: record the 4D matmul edge
+        // (QK^T and attn@V) so gradient flows to Q, K, and V.
+        record_attention_grad2(a, b, &mut result, || {
+            std::sync::Arc::new(crate::autograd::grad_fn::BatchedMatmul4dBackward {
+                a: a.clone(),
+                b: b.clone(),
+            })
+        });
+
+        result
     } else {
         // Fallback for 2D/3D - uses Tensor's SIMD matmul
         a.matmul(b)
@@ -319,7 +377,18 @@ pub(super) fn add_mask(scores: &Tensor, mask: &Tensor) -> Tensor {
 ///
 /// ONE PATH: Delegates to `nn::functional::softmax` (UCBD §4).
 pub(super) fn softmax_last_dim(x: &Tensor) -> Tensor {
-    crate::nn::functional::softmax(x, -1)
+    let mut result = crate::nn::functional::softmax(x, -1);
+
+    // PMAT-914 / OBLIG-ATTENTION-BACKWARD-GRAD-FLOW: record the softmax edge so
+    // gradient flows back through the attention weights to Q and K.
+    let out_for_grad = Tensor::from_vec(result.data().to_vec(), result.shape());
+    record_attention_grad(x, &mut result, move || {
+        std::sync::Arc::new(crate::autograd::grad_fn::SoftmaxLastDimBackward {
+            output: out_for_grad,
+        })
+    });
+
+    result
 }
 
 /// ONE PATH: Delegates to `nn::functional::dropout` (UCBD §4).
@@ -357,7 +426,19 @@ pub(super) fn reshape_for_attention(
         }
     }
 
-    Tensor::from_vec(output, &[batch, num_heads, seq_len, head_dim])
+    let mut result = Tensor::from_vec(output, &[batch, num_heads, seq_len, head_dim]);
+
+    // PMAT-914 / OBLIG-ATTENTION-BACKWARD-GRAD-FLOW: record the head-split edge.
+    record_attention_grad(x, &mut result, || {
+        std::sync::Arc::new(crate::autograd::grad_fn::ReshapeForAttentionBackward {
+            batch,
+            seq_len,
+            num_heads,
+            head_dim,
+        })
+    });
+
+    result
 }
 
 /// Reshape from multi-head attention: [batch, heads, seq, `head_dim`] -> [batch, seq, embed]
@@ -391,7 +472,19 @@ pub(crate) fn reshape_from_attention(
         }
     }
 
-    Tensor::from_vec(output, &[batch, seq_len, embed_dim])
+    let mut result = Tensor::from_vec(output, &[batch, seq_len, embed_dim]);
+
+    // PMAT-914 / OBLIG-ATTENTION-BACKWARD-GRAD-FLOW: record the head-concat edge.
+    record_attention_grad(x, &mut result, || {
+        std::sync::Arc::new(crate::autograd::grad_fn::ReshapeFromAttentionBackward {
+            batch,
+            seq_len,
+            num_heads,
+            head_dim,
+        })
+    });
+
+    result
 }
 
 /// ONE PATH: Delegates to `nn::functional::gelu` (UCBD §4).

--- a/crates/aprender-core/src/nn/transformer/tests.rs
+++ b/crates/aprender-core/src/nn/transformer/tests.rs
@@ -438,6 +438,8 @@ fn test_alibi_creation() {
 mod tests_alibi_contract;
 #[path = "tests_alibi_mha.rs"]
 mod tests_alibi_mha;
+#[path = "tests_attention_backward_gradflow.rs"]
+mod tests_attention_backward_gradflow;
 #[path = "tests_attention_contract.rs"]
 mod tests_attention_contract;
 #[path = "tests_attention_scaling_contract.rs"]

--- a/crates/aprender-core/src/nn/transformer/tests_attention_backward_gradflow.rs
+++ b/crates/aprender-core/src/nn/transformer/tests_attention_backward_gradflow.rs
@@ -1,0 +1,225 @@
+//! Falsifier: MultiHeadAttention backward MUST flow gradient to the Q/K/V/out
+//! projection weights — end-to-end transformer trainability.
+//!
+//! Obligation: OBLIG-ATTENTION-BACKWARD-GRAD-FLOW
+//!
+//! BUG (PMAT-914): the scaled-dot-product attention core built its intermediate
+//! tensors via `Tensor::from_vec` / `Tensor::new`, which severs the autograd
+//! graph:
+//!   - `matmul_batched` (4D path)   -> `Tensor::from_vec`   (QK^T and attn@V)
+//!   - `transpose_last_two`         -> `Tensor::from_vec`   (K^T)
+//!   - `reshape_for_attention`      -> `Tensor::from_vec`   (split heads)
+//!   - `reshape_from_attention`     -> `Tensor::from_vec`   (concat heads)
+//!   - `nn::functional::softmax`    -> `Tensor::from_vec`   (attn weights)
+//! After `loss.backward()`, `get_grad(q_proj.weight.id())` etc. were `None` —
+//! the Q/K/V (and the attention-side path to out) projection weights never
+//! received gradient, so a transformer attention block was NON-FINE-TUNABLE
+//! despite the earlier norm / embedding / pool gradflow fixes.
+//!
+//! This test is a self-contained finite-difference gradcheck (no torch dep):
+//! perturb each projection weight[k] by ±eps, recompute the scalar loss, and
+//! compare the central difference against the analytic `.grad`. It also asserts
+//! grad is non-None (the severed-graph guard). The finite-diff comparison
+//! genuinely catches a wrong/missing gradient — not a tautological `is_some`.
+
+use crate::autograd::{self, Tensor};
+use crate::nn::transformer::MultiHeadAttention;
+use crate::nn::Module;
+
+const FD_EPS: f32 = 1e-3;
+const TOL: f32 = 2e-2;
+
+/// Fixed, non-uniform upstream coefficient so dL/dW is non-degenerate.
+fn coeff(n: usize) -> Vec<f32> {
+    (0..n).map(|i| 0.21 + 0.13 * (i as f32)).collect()
+}
+
+/// Scalar loss = sum over all output elements of c[feat] * out[.., feat],
+/// where `c` is detached (no grad). The only live edges are through the
+/// projection weights and the input.
+fn scalar_loss(output: &Tensor, c: &[f32]) -> Tensor {
+    let shape = output.shape();
+    let feat = c.len();
+    let batch = output.numel() / feat;
+    let mut cvec = Vec::with_capacity(output.numel());
+    for _ in 0..batch {
+        cvec.extend_from_slice(c);
+    }
+    let c_tensor = Tensor::new(&cvec, shape);
+    output.mul(&c_tensor).sum()
+}
+
+fn assert_close(analytic: f32, numeric: f32, what: &str) {
+    let denom = analytic.abs().max(numeric.abs()).max(1.0);
+    let rel = (analytic - numeric).abs() / denom;
+    assert!(
+        rel < TOL,
+        "{what}: analytic grad {analytic} != finite-diff {numeric} (rel err {rel})"
+    );
+}
+
+/// Deterministic [batch, seq, embed] input. Amplitudes are deliberately large
+/// so the QK^T scores have a wide spread across keys — this makes the softmax
+/// strongly NON-uniform, so the softmax Jacobian (and hence the Q/K gradient
+/// edges) are well above the finite-difference tolerance and genuinely probed.
+fn make_input(batch: usize, seq: usize, embed: usize) -> Vec<f32> {
+    (0..batch * seq * embed)
+        .map(|k| {
+            let b = (k / (seq * embed)) as f32;
+            let s = ((k / embed) % seq) as f32;
+            let e = (k % embed) as f32;
+            0.4 + 0.5 * e - 0.6 * s + 0.3 * b - 0.2 * (e * s)
+        })
+        .collect()
+}
+
+/// Deterministic projection weight matrix [out, in].
+fn make_weight(out: usize, inp: usize, seed: f32) -> Vec<f32> {
+    (0..out * inp)
+        .map(|k| {
+            let r = (k / inp) as f32;
+            let c = (k % inp) as f32;
+            seed + 0.35 * ((r - c) as f32) + 0.2 * c - 0.1 * r
+        })
+        .collect()
+}
+
+const SEEDS: [f32; 4] = [0.30, 0.45, 0.25, 0.35]; // q, k, v, out
+
+/// Install deterministic, zero-bias projection weights on an MHA. `track_grad`
+/// controls whether the weights require grad (true for the analytic forward,
+/// false for the finite-difference reference forward).
+fn install_weights(
+    mha: &mut MultiHeadAttention,
+    embed: usize,
+    weights: &[Vec<f32>],
+    track_grad: bool,
+) {
+    let mk = |data: &[f32]| {
+        let t = Tensor::new(data, &[embed, embed]);
+        if track_grad {
+            t.requires_grad()
+        } else {
+            t
+        }
+    };
+    let zero_bias = || Tensor::new(&vec![0.0f32; embed], &[embed]);
+
+    mha.q_proj_mut().set_weight(mk(&weights[0]));
+    mha.q_proj_mut().set_bias(zero_bias());
+    mha.k_proj_mut().set_weight(mk(&weights[1]));
+    mha.k_proj_mut().set_bias(zero_bias());
+    mha.v_proj_mut().set_weight(mk(&weights[2]));
+    mha.v_proj_mut().set_bias(zero_bias());
+    mha.out_proj_mut().set_weight(mk(&weights[3]));
+    mha.out_proj_mut().set_bias(zero_bias());
+}
+
+fn base_weights(embed: usize) -> Vec<Vec<f32>> {
+    SEEDS
+        .iter()
+        .map(|&s| make_weight(embed, embed, s))
+        .collect()
+}
+
+/// Recompute the scalar loss for a perturbed copy of one projection's weights,
+/// WITHOUT building an autograd graph (pure function of the weights).
+fn forward_loss_with(
+    x: &Tensor,
+    embed: usize,
+    heads: usize,
+    base: &[Vec<f32>],
+    which: usize,
+    perturbed: &[f32],
+    c: &[f32],
+) -> f32 {
+    autograd::no_grad(|| {
+        let mut mha = MultiHeadAttention::new(embed, heads);
+        let mut w = base.to_vec();
+        w[which] = perturbed.to_vec();
+        install_weights(&mut mha, embed, &w, false);
+        let (out, _) = mha.forward_self(x, None);
+        scalar_loss(&out, c).item()
+    })
+}
+
+/// Finite-difference gradcheck for one projection's weights against `.grad`.
+fn gradcheck_proj(
+    label: &str,
+    x: &Tensor,
+    embed: usize,
+    heads: usize,
+    base: &[Vec<f32>],
+    which: usize,
+    analytic_grad: &[f32],
+    c: &[f32],
+) {
+    let w = &base[which];
+    // Probe EVERY weight entry (embed is small; full O(n^2) forward cost is fine)
+    // so a wrong gradient on any single entry is caught.
+    for idx in 0..w.len() {
+        let mut wp = w.clone();
+        let mut wm = w.clone();
+        wp[idx] += FD_EPS;
+        wm[idx] -= FD_EPS;
+        let lp = forward_loss_with(x, embed, heads, base, which, &wp, c);
+        let lm = forward_loss_with(x, embed, heads, base, which, &wm, c);
+        let numeric = (lp - lm) / (2.0 * FD_EPS);
+        assert_close(
+            analytic_grad[idx],
+            numeric,
+            &format!("{label} weight[{idx}]"),
+        );
+    }
+}
+
+#[test]
+fn attention_backward_flows_grad_to_qkv_and_out_proj() {
+    autograd::clear_graph();
+
+    let embed = 4usize;
+    let heads = 2usize;
+    let batch = 2usize;
+    let seq = 3usize;
+
+    let x = Tensor::new(&make_input(batch, seq, embed), &[batch, seq, embed]);
+    let c = coeff(embed);
+    let base = base_weights(embed);
+
+    let mut mha = MultiHeadAttention::new(embed, heads);
+    install_weights(&mut mha, embed, &base, true);
+    let q_id = mha.q_proj_mut().weight().id();
+    let k_id = mha.k_proj_mut().weight().id();
+    let v_id = mha.v_proj_mut().weight().id();
+    let out_id = mha.out_proj_mut().weight().id();
+
+    let (output, _) = mha.forward_self(&x, None);
+    let loss = scalar_loss(&output, &c);
+    loss.backward();
+
+    // ---- Severed-graph guard: grad MUST be present and finite-nonzero. ----
+    for (name, id) in [("q", q_id), ("k", k_id), ("v", v_id), ("out", out_id)] {
+        let g = autograd::get_grad(id)
+            .unwrap_or_else(|| panic!("{name}_proj weight grad is None — autograd graph SEVERED"));
+        let gd = g.data();
+        assert!(
+            gd.iter().all(|v| v.is_finite()),
+            "{name}_proj grad has non-finite entries"
+        );
+        assert!(
+            gd.iter().any(|&v| v.abs() > 1e-8),
+            "{name}_proj grad is all-zero — no gradient flowed"
+        );
+    }
+
+    // ---- Finite-difference gradcheck for each projection. ----
+    let qg = autograd::get_grad(q_id).expect("q grad");
+    let kg = autograd::get_grad(k_id).expect("k grad");
+    let vg = autograd::get_grad(v_id).expect("v grad");
+    let og = autograd::get_grad(out_id).expect("out grad");
+
+    gradcheck_proj("out_proj", &x, embed, heads, &base, 3, og.data(), &c);
+    gradcheck_proj("v_proj", &x, embed, heads, &base, 2, vg.data(), &c);
+    gradcheck_proj("k_proj", &x, embed, heads, &base, 1, kg.data(), &c);
+    gradcheck_proj("q_proj", &x, embed, heads, &base, 0, qg.data(), &c);
+}


### PR DESCRIPTION
## Capstone of the severed-graph sweep

A sequence of merged beats fixed severed autograd graphs — norms (PMAT-907 #2196, PMAT-911 #2200) and Embedding/Flatten/Pool (PMAT-913 #2202). The linchpin question for "transformers are fine-tunable" was whether the **attention block** is also severed. **It was.**

### Bug

The scaled-dot-product attention core built EVERY intermediate via `Tensor::from_vec` / `Tensor::new`, severing the autograd graph:

| helper | sever |
|---|---|
| `matmul_batched` (4D path) | `Tensor::from_vec` (QK^T and attn@V) |
| `transpose_last_two` | `Tensor::from_vec` (K^T) |
| `nn::functional::softmax` | `Tensor::from_vec` (attn weights) |
| `reshape_for_attention` | `Tensor::from_vec` (split heads) |
| `reshape_from_attention` | `Tensor::from_vec` (concat heads) |

After `loss.backward()` on a `MultiHeadAttention` forward, `get_grad(q_proj.weight)` was **None** — the Q/K/V projection weights (and the attention-side path to the out projection) never received gradient. A transformer attention block was **NON-FINE-TUNABLE** despite all prior severed-graph fixes. With this fix, transformers are end-to-end trainable.

### Fix

Record a backward edge on the autograd tape from each attention helper (mirrors the PMAT-907 functional-norm pattern). New grad_fns in `grad_fn.rs`:

- `SoftmaxLastDimBackward` — `y * (g - <g,y>)` over the last dim (N-D rows)
- `TransposeLastTwoBackward` — its own inverse along the last two dims
- `BatchedMatmul4dBackward` — `dA = grad @ B^T`, `dB = A^T @ grad` (per batch,head)
- `ReshapeForAttentionBackward` / `ReshapeFromAttentionBackward` — mutually-inverse head split/concat permutations

The Linear projections + scale (`mul_scalar`) already tracked; only the `from_vec`/`new` wrappers severed.

### Falsifier (self-contained finite-difference gradcheck, no torch dep)

Build a tiny MHA with deterministic grad-tracked Q/K/V/out weights, forward → scalar loss → backward; assert each projection grad is `Some` + finite-nonzero AND that **every** weight entry's analytic grad matches the central finite-difference within rel tol 2e-2. Input/weight magnitudes are tuned so QK^T scores spread (softmax strongly non-uniform), so the Q/K edges are well above tolerance and genuinely probed.

**Mutation-verified non-tautological:**
- zero the `BatchedMatmul4d` dA edge → `q_proj` grad all-zero (RED)
- scale dA by 1.5 → `k_proj` gradcheck RED
- drop the softmax Jacobian dot term → `k_proj` gradcheck RED
- correct math → GREEN

### Verification
- `cargo test -p aprender-core --lib` — 13988 passed, 0 failed
- `pv validate contracts/attention-backward-gradflow-v1.yaml` — valid
- `pv lint contracts/` — PASS (0 errors)
- `cargo fmt --check` + `cargo clippy -D warnings` — clean

Obligation: `OBLIG-ATTENTION-BACKWARD-GRAD-FLOW`
Contract: `contracts/attention-backward-gradflow-v1.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)