### PR TITLE
fix(loss): KLDiv/NLL/BCEWithLogits/Huber/focal PyTorch parity (PMAT-915)

### DIFF
--- a/contracts/loss-functions-v1.yaml
+++ b/contracts/loss-functions-v1.yaml
@@ -115,6 +115,13 @@ proof_obligations:
   property: NLL lower bound
   formal: NLL ≥ 0
   applies_to: nll
+- type: equivalence
+  property: OBLIG-BCE-POSWEIGHT-PYTORCH-PARITY BCEWithLogits pos_weight weights only the positive term
+  formal: 'BCEWithLogitsLoss::with_pos_weight(w).forward(logits, y) matches torch.nn.functional.binary_cross_entropy_with_logits(logits, y, pos_weight=w)
+    within 1e-5. PyTorch applies pos_weight ONLY to the positive (log σ(x)) term: log_weight = 1 + (w-1)·y;
+    loss = (1-y)·x + log_weight·(log(1+exp(-|x|)) + max(-x,0)). The previous whole-loss scaling base·(y·(w-1)+1)
+    coincides only for hard y ∈ {0,1}; it diverges for soft targets 0 < y < 1.'
+  applies_to: bce
 falsification_tests:
 - id: FALSIFY-LF-001
   rule: Non-negativity
@@ -151,6 +158,11 @@ falsification_tests:
   prediction: 'L1Loss(mean).forward(pred,target).backward() => get_grad(pred.id()) = Some([-1/3,0,1/3]) for pred=[1,2,3], target=[2,2,2]'
   test: cargo test -p aprender-core --lib test_l1_loss_gradient
   if_fails: abs() severs autograd (no AbsBackward grad_fn) so L1Loss yields no input gradient and trains silently to zero
+- id: OBLIG-BCE-POSWEIGHT-PYTORCH-PARITY
+  rule: BCEWithLogits pos_weight weights only the positive term (PyTorch parity, PMAT-915)
+  prediction: 'BCEWithLogitsLoss::with_pos_weight(3.0).forward([0.5,-1.2,2.0,0.1], soft=[0.7,0.2,0.9,0.4]) mean == torch 1.0379231 within 1e-5'
+  test: cargo test -p aprender-core --lib falsify_lf_007_bce_pos_weight_pytorch_parity
+  if_fails: pos_weight scales the whole loss instead of only the positive log-sigmoid term, diverging from PyTorch for soft targets
 kani_harnesses:
 - id: KANI-LF-001
   obligation: '1'

--- a/crates/aprender-core/src/nn/loss.rs
+++ b/crates/aprender-core/src/nn/loss.rs
@@ -406,17 +406,22 @@ impl BCEWithLogitsLoss {
             .iter()
             .zip(targets.data().iter())
             .map(|(&x, &y)| {
-                let max_val = x.max(0.0);
-                let base_loss = max_val - x * y + (1.0 + (-x.abs()).exp()).ln();
-
-                // Apply positive weight if specified
+                // Numerically stable log(1 + exp(-|x|)) + max(-x, 0).
+                let log_term = (1.0 + (-x.abs()).exp()).ln() + (-x).max(0.0);
                 match self.pos_weight {
                     Some(w) => {
-                        // weight positive samples more
-                        let weight = y * (w - 1.0) + 1.0;
-                        base_loss * weight
+                        // PyTorch BCEWithLogits pos_weight: the weight multiplies ONLY
+                        // the positive (log σ(x)) term, NOT the whole loss. This matters
+                        // for soft targets 0 < y < 1; it coincides with the previous
+                        // whole-loss scaling only for hard 0/1 targets.
+                        //   log_weight = 1 + (pos_weight - 1) * y
+                        //   loss = (1 - y) * x + log_weight * log_term
+                        let log_weight = 1.0 + (w - 1.0) * y;
+                        (1.0 - y) * x + log_weight * log_term
                     }
-                    None => base_loss,
+                    // None reduces to standard stable BCE:
+                    // (1 - y) * x + log_term == max(x,0) - x*y + log(1 + exp(-|x|)).
+                    None => (1.0 - y) * x + log_term,
                 }
             })
             .collect();

--- a/crates/aprender-core/src/nn/loss_tests_lf_contract.rs
+++ b/crates/aprender-core/src/nn/loss_tests_lf_contract.rs
@@ -16,6 +16,50 @@
 mod tests {
     use super::super::*;
 
+    /// OBLIG-BCE-POSWEIGHT-PYTORCH-PARITY (PMAT-915).
+    ///
+    /// PyTorch `binary_cross_entropy_with_logits` applies `pos_weight` ONLY to the
+    /// positive (log σ(x)) term, not the whole loss:
+    ///   log_weight = 1 + (w - 1) * y
+    ///   loss = (1 - y) * x + log_weight * (log(1 + exp(-|x|)) + max(-x, 0))
+    ///
+    /// The previous aprender impl scaled the WHOLE loss by `y*(w-1)+1`, which only
+    /// coincides with PyTorch for hard targets y ∈ {0,1}. With SOFT targets the two
+    /// diverge — this falsifier uses soft targets so the bug is observable.
+    ///
+    /// Reference (torch 2.x, CPU):
+    ///   logits = [0.5, -1.2, 2.0, 0.1], y = [0.7, 0.2, 0.9, 0.4], pos_weight = 3.0
+    ///   F.binary_cross_entropy_with_logits(..., reduction="mean") == 1.0379231
+    #[test]
+    #[allow(clippy::float_cmp)]
+    fn falsify_lf_007_bce_pos_weight_pytorch_parity() {
+        let logits = Tensor::from_slice(&[0.5, -1.2, 2.0, 0.1]);
+        let soft = Tensor::from_slice(&[0.7, 0.2, 0.9, 0.4]);
+
+        // Mean reduction (with_pos_weight forces Mean).
+        let mean = BCEWithLogitsLoss::with_pos_weight(3.0)
+            .forward(&logits, &soft)
+            .data()[0];
+        let torch_mean = 1.037_923_1_f32;
+        assert!(
+            (mean - torch_mean).abs() < 1e-5,
+            "FALSIFIED OBLIG-BCE-POSWEIGHT-PYTORCH-PARITY (mean): apr={mean} torch={torch_mean}"
+        );
+
+        // Hard targets must STILL match PyTorch after the fix (regression guard:
+        // the new positive-term weighting reduces to the old behaviour for y ∈ {0,1}).
+        // torch(pos_weight=3, hard, mean) = 0.7026735
+        let hard = Tensor::from_slice(&[1.0, 0.0, 1.0, 0.0]);
+        let hard_mean = BCEWithLogitsLoss::with_pos_weight(3.0)
+            .forward(&logits, &hard)
+            .data()[0];
+        let torch_hard_mean = 0.702_673_5_f32;
+        assert!(
+            (hard_mean - torch_hard_mean).abs() < 1e-5,
+            "FALSIFIED OBLIG-BCE-POSWEIGHT-PYTORCH-PARITY (hard): apr={hard_mean} torch={torch_hard_mean}"
+        );
+    }
+
     /// FALSIFY-LF-001: MSE is non-negative
     #[test]
     fn falsify_lf_001_mse_non_negative() {


### PR DESCRIPTION
## Pillar-2 loss-correctness beat (PyTorch parity)

Probed every loss that **exists** in `crates/aprender-core/src/nn/loss.rs` against the PyTorch reference (`uv run --with torch`), testing mean/sum/none reductions plus the relevant parameter. Scoped strictly to the loss that was actually broken.

### Losses probed
| Loss | exists? | PyTorch parity (before) | verdict |
|------|---------|-------------------------|---------|
| `BCEWithLogitsLoss` (pos_weight, **soft** targets) | yes | **FAIL** apr=1.0964 vs torch=1.0379 | **FIXED** |
| `BCEWithLogitsLoss` (plain / hard-target pos_weight) | yes | match | unchanged (regression-guarded) |
| `SmoothL1Loss` / Huber (beta 1.0 & 0.5) | yes | match | not a bug |
| `NLLLoss` (mean) | yes | match | not a bug |
| `KLDivLoss` | **no** | — | skipped (does not exist) |
| `FocalLoss` | **no** | — | skipped (does not exist) |
| `CrossEntropyLoss` | yes | already fixed PMAT-891/910 | out of scope |

### The bug (RED confirmed)
`BCEWithLogitsLoss::with_pos_weight(w)` multiplied the **whole** loss by `y*(w-1)+1`. PyTorch applies `pos_weight` **only to the positive (log σ(x)) term**:

```
log_weight = 1 + (pos_weight - 1) * y
loss = (1 - y) * x + log_weight * (log(1 + exp(-|x|)) + max(-x, 0))
```

The whole-loss scaling coincides with PyTorch only for **hard** targets `y ∈ {0,1}` — so the existing 0/1-target tests masked it. With soft targets it diverges (measured diff 0.0585 ≫ 1e-5).

### Fix
Reworked the per-element BCE map to PyTorch's positive-term weighting. The `None`/no-pos_weight branch reduces algebraically to the prior stable BCE (`(1-y)x + log_term == max(x,0) - xy + log(1+e^-|x|)`), so plain BCE and all reductions stay byte-stable.

### Contract
`OBLIG-BCE-POSWEIGHT-PYTORCH-PARITY` added to `contracts/loss-functions-v1.yaml` (proof_obligation + single-line falsifier ref). `pv validate` + `pv lint contracts/` PASS (0 errors).

### Verification
- GREEN: `falsify_lf_007_bce_pos_weight_pytorch_parity` passes (apr == torch within 1e-5, soft + hard).
- Mutation-verified: reverting the fix flips the falsifier **RED** (apr=1.0964 ≠ torch=1.0379) — non-tautological.
- `cargo test -p aprender-core --lib`: **13988 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)