### PR TITLE
build: gate duckdb competitive bench behind a feature — kill the merge_group cold-build flake

### DIFF
--- a/crates/aprender-db/Cargo.toml
+++ b/crates/aprender-db/Cargo.toml
@@ -143,6 +143,15 @@ distributed = ["tonic", "prost"]
 # Phase 4: WASM build (no tokio/rayon - not WASM compatible)
 wasm = []
 
+# Competitive benchmarks vs DuckDB + SQLite (CORE-009). OFF by default: the
+# `duckdb` dev-dep uses features=["bundled"], compiling DuckDB's entire C++ from
+# source (~7-8 min). Built under `--all-targets` (ci.yml lint, workspace-test),
+# its cold C++ build is the recurring merge_group flake that ejects PRs from the
+# queue. Gating the bench behind this feature keeps duckdb/rusqlite (used ONLY by
+# competitive_benchmarks) out of the normal CI build. Run the comparison with:
+#   cargo bench -p aprender-db --features competitive-benchmarks --bench competitive_benchmarks
+competitive-benchmarks = []
+
 [[bench]]
 name = "storage_benchmarks"
 harness = false
@@ -158,6 +167,7 @@ harness = false
 [[bench]]
 name = "competitive_benchmarks"
 harness = false
+required-features = ["competitive-benchmarks"]
 
 [[bench]]
 name = "kernel_fusion"


### PR DESCRIPTION
**Root-causes the recurring merge-queue flake** that has ejected PRs all session (the `cc1plus: can't create ...storage_table.o` failures in cold `merge_group` builds).

**Why duckdb was building:** `crates/aprender-db` (the `trueno_db` analytics DB) has a `competitive_benchmarks` bench that races it against DuckDB. The `duckdb` dev-dep uses `features=["bundled"]` → compiles DuckDB's entire C++ from source (~7–8 min). `cargo clippy --all-targets` (lint) + workspace-test build benches, so **every cold merge_group recompiled DuckDB's C++**, and under parallel load the C++ build raced on its output dir and failed → PR ejected from the queue.

**Fix:** `competitive-benchmarks` feature (off by default) + `required-features` on the `[[bench]]`. duckdb/rusqlite (used ONLY by that bench) are no longer compiled on the CI critical path.

**Verified:** `cargo build -p aprender-db --bench competitive_benchmarks` (no feature) → `error: ... requires the features: competitive-benchmarks` (no DuckDB compile). Comparison still runs via `--features competitive-benchmarks`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)