### PR TITLE
fix(compute): repair/gate coop_gemm_bench example for wgpu 27 (--all-targets build break)

### DIFF
--- a/crates/aprender-compute/Cargo.toml
+++ b/crates/aprender-compute/Cargo.toml
@@ -112,6 +112,11 @@ matrixmultiply = "0.3"  # Direct matrixmultiply crate benchmark (engine behind n
 default = []
 parallel = ["rayon"]
 gpu = ["wgpu", "pollster", "bytemuck", "futures-intrusive"]
+# Opt-in: builds the cooperative-matrix GEMM bench example. The underlying
+# cooperative-matrix capability was a Vulkan-specific extension dropped by wgpu 27
+# (cooperative_matrix_properties / COOPERATIVE_GEMM_SHADER are gone), so this
+# example does not compile against wgpu 27 and is gated off by default.
+cooperative-matrix = ["gpu"]
 # GPU for WASM (WebGPU) - uses wasm-bindgen-futures instead of pollster
 gpu-wasm = ["wgpu", "bytemuck", "futures-intrusive", "wasm-bindgen-futures", "wasm-bindgen", "web-sys"]
 # Native CUDA monitoring via trueno-gpu (TRUENO-SPEC-010)
@@ -203,7 +208,9 @@ required-features = ["gpu"]
 
 [[example]]
 name = "coop_gemm_bench"
-required-features = ["gpu"]
+# Requires the opt-in cooperative-matrix feature: relies on the wgpu Vulkan
+# cooperative-matrix extension that wgpu 27 removed (does not build otherwise).
+required-features = ["cooperative-matrix"]
 
 [[example]]
 name = "gpu_monitor_demo"


### PR DESCRIPTION
## Summary

`crates/aprender-compute/examples/coop_gemm_bench.rs` failed to compile against **wgpu 27.0** (7 errors). It slipped past the wgpu-27 bump because CI builds via the `--lib` path and never compiles examples — but `cargo build/clippy --all-targets` **does** build it, so this was a **latent `--all-targets` build break** (same class as the recently-fixed duckdb-bench flake).

**Found by Apple-Metal verification** on the `mini` host (Apple M4, Metal, macOS arm64).

## Root cause

The cooperative-matrix path the example exercises was a **Vulkan-specific extension that wgpu 27 dropped**. The API drift:

- `shaders::cooperative::COOPERATIVE_GEMM_SHADER` path gone (E0433 — the `cooperative.rs` shader file was never even wired into `shaders/mod.rs`)
- `InstanceDescriptor::new_without_display_handle()` removed
- `Instance::new` now takes `&InstanceDescriptor`
- `adapter.cooperative_matrix_properties()` removed
- `PipelineLayoutDescriptor.bind_group_layouts` is now `&[&BindGroupLayout]` and the `immediate_size` field was removed

## Fix (minimal — build hygiene, not a feature change)

Since the cooperative-matrix capability no longer exists in wgpu 27, porting would mean rewriting the example's entire premise. This is a **dead bench example** — referenced only by its own `[[example]]` block (confirmed via `grep -rn coop_gemm_bench`), not shipped code.

Lowest-risk fix: gate it behind a new **opt-in `cooperative-matrix` feature** (off by default, **not** implied by `gpu`) so `cargo build/clippy --all-targets --features gpu` stays clean. The example source is preserved for history rather than deleted.

```toml
cooperative-matrix = ["gpu"]   # off by default

[[example]]
name = "coop_gemm_bench"
required-features = ["cooperative-matrix"]
```

## Verification (Apple Metal — mini, M4, macOS arm64, wgpu 27)

```
cargo build -p aprender-compute --all-targets --features gpu   -> 0 errors (clean)
cargo build -p aprender-compute --features gpu (lib)           -> clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
