### PR TITLE
fix(export): infer GGUF metadata (num_heads/etc.) so apr->gguf works on metadata-light .apr (PMAT-920)

### DIFF
--- a/contracts/apr-export-num-layers-v1.yaml
+++ b/contracts/apr-export-num-layers-v1.yaml
@@ -1,13 +1,15 @@
 metadata:
-  version: 1.0.0
+  version: 1.1.0
   created: '2026-05-22'
   author: PAIML Engineering
-  description: "`apr export <model>.apr --format gguf` must produce a clean error (or succeed via inference) when `num_layers` is absent from APR metadata. Panicking with `.expect()` on an Option<usize> is forbidden for any user-reachable code path."
+  description: "`apr export <model>.apr --format gguf` must produce a clean error (or succeed via inference) when GGUF-required dimensions (`num_layers`, `num_heads`, `num_kv_heads`, `hidden_size`, `vocab_size`, `intermediate_size`) are absent from APR metadata. Panicking with `.expect()` on an Option<usize> is forbidden for any user-reachable code path, and dimensions derivable from tensor shapes MUST be inferred rather than hard-failed."
   kind: pattern
   references:
     - "paiml/aprender#1865 (apr export <model>.apr --format gguf panics: 'C-07: num_layers required for GGUF export')"
+    - "PMAT-920 (apr export --format gguf hard-fails on metadata-light .apr lacking num_heads; infer from attention tensor shapes)"
     - "crates/aprender-core/src/format/converter/metadata.rs:export_apr_to_gguf_raw"
     - "crates/aprender-core/src/format/converter/metadata.rs:build_gguf_arch_metadata"
+    - "crates/aprender-core/src/format/converter/metadata.rs:infer_missing_gguf_dims_from_shapes"
   registry: true
   tags:
     - cli
@@ -45,6 +47,17 @@ equations:
       - "Missing num_layers triggers tensor-name inference before raising an error"
       - "Exit code on missing dim is 5 (CliError::ValidationFailed::FormatError), not 101 (panic)"
 
+  attn_dim_inference:
+    formula: "infer_heads(q_dim, kv_dim, hidden) derives (num_heads, num_kv_heads) via num_heads = q_dim/head_dim, num_kv_heads = kv_dim/head_dim; hidden_size, vocab_size, intermediate_size from embedding/FFN shapes"
+    domain: "set of tensor shapes in a metadata-light APR file (PMAT-920)"
+    codomain: "AprV2Metadata with missing dims filled"
+    invariants:
+      - "When num_heads is None, it is inferred from q/k/v projection shapes before C-07 fires"
+      - "When hidden_size/vocab_size/intermediate_size are None, they are inferred from embedding + FFN tensor shapes"
+      - "Explicit APR metadata always wins; inference only fills None fields"
+      - "The emitted GGUF `<arch>.attention.head_count` equals the inferred num_heads (re-readable, correct)"
+      - "Shapes are interpreted row-major (LAYOUT-001) consistently with import"
+
 proof_obligations:
   - type: invariant
     property: "Tensor-name inference returns max-index + 1"
@@ -58,6 +71,10 @@ proof_obligations:
     property: "Export does not panic on missing dim"
     formal: "export_apr_to_gguf_raw(apr_with_no_num_layers) = Err | Ok (never panic)"
     applies_to: export_no_panic
+  - type: invariant
+    property: "Missing num_heads is inferred from attention tensor shapes (PMAT-920)"
+    formal: "export_apr_to_gguf_raw(metadata_light_apr) = Ok AND gguf.<arch>.attention.head_count = q_dim/head_dim"
+    applies_to: attn_dim_inference
 
 falsification_tests:
   - id: FALSIFY-EXPORT-NUM-LAYERS-001
@@ -78,6 +95,12 @@ falsification_tests:
     test: "grep -A3 'fn build_gguf_arch_metadata' crates/aprender-core/src/format/converter/metadata.rs | grep -qE -- '-> Result<'"
     if_fails: "Function still returns Vec — missing dims will continue to panic via downstream .expect()"
 
+  - id: FALSIFY-EXPORT-INFER-METADATA-001
+    rule: "Metadata-light APR (no num_heads) exports to GGUF via shape inference with correct head counts (PMAT-920)"
+    prediction: "export_apr_to_gguf_raw on an APR with num_heads=None but q/k/v projection shapes succeeds AND the re-read GGUF has the correct inferred attention.head_count / head_count_kv / embedding_length"
+    test: "cargo test -p aprender-core --lib ft_apr_gguf_export_infers_heads_when_metadata_light"
+    if_fails: "Exporter hard-fails with C-07 on a metadata-light .apr whose shapes imply num_heads, breaking apr->gguf for llama.cpp/ollama"
+
 qa_gate:
   id: F-EXPORT-NUM-LAYERS-001
   name: "apr export panic-free for missing num_layers"
@@ -85,4 +108,5 @@ qa_gate:
   checks:
     - "num_layers_inference"
     - "export_no_panic"
-  pass_criteria: "FALSIFY-EXPORT-NUM-LAYERS-{001,002,003} all PASS"
+    - "attn_dim_inference"
+  pass_criteria: "FALSIFY-EXPORT-NUM-LAYERS-{001,002,003} and FALSIFY-EXPORT-INFER-METADATA-001 all PASS"

--- a/contracts/apr-export-num-layers-v1.yaml
+++ b/contracts/apr-export-num-layers-v1.yaml
@@ -1,15 +1,17 @@
 metadata:
-  version: 1.1.0
+  version: 1.2.0
   created: '2026-05-22'
   author: PAIML Engineering
-  description: "`apr export <model>.apr --format gguf` must produce a clean error (or succeed via inference) when GGUF-required dimensions (`num_layers`, `num_heads`, `num_kv_heads`, `hidden_size`, `vocab_size`, `intermediate_size`) are absent from APR metadata. Panicking with `.expect()` on an Option<usize> is forbidden for any user-reachable code path, and dimensions derivable from tensor shapes MUST be inferred rather than hard-failed."
+  description: "`apr export <model>.apr --format gguf` must produce a clean error (or succeed via inference) when GGUF-required dimensions are absent from APR metadata, and must NEVER stamp a silently-wrong dimension. `num_layers`, `hidden_size`, `vocab_size`, and `intermediate_size` are UNAMBIGUOUS from tensor shapes and MUST be inferred rather than hard-failed. `num_heads`/`num_kv_heads` are NOT inferable from shapes alone (q_dim = num_heads × head_dim has no unique factorization without head_dim): they are derived EXACTLY from an explicit head_dim (num_heads = q_dim/head_dim) or explicit num_heads; when head_dim AND num_heads are both absent the export MUST hard-fail with an actionable error naming the missing dimension and a working remedy (stamp head_dim/num_heads via `apr stamp`, or re-convert from the source config), NOT guess. Panicking with `.expect()` on an Option<usize> is forbidden for any user-reachable code path."
   kind: pattern
   references:
     - "paiml/aprender#1865 (apr export <model>.apr --format gguf panics: 'C-07: num_layers required for GGUF export')"
-    - "PMAT-920 (apr export --format gguf hard-fails on metadata-light .apr lacking num_heads; infer from attention tensor shapes)"
+    - "PMAT-920 (apr export --format gguf: infer unambiguous dims from shapes; derive num_heads from EXPLICIT head_dim only; honest hard-fail when absent — no [64,128,96,80] head_dim guess that silently mis-stamped Qwen2-1.5B as 24 heads instead of 12)"
     - "crates/aprender-core/src/format/converter/metadata.rs:export_apr_to_gguf_raw"
     - "crates/aprender-core/src/format/converter/metadata.rs:build_gguf_arch_metadata"
     - "crates/aprender-core/src/format/converter/metadata.rs:infer_missing_gguf_dims_from_shapes"
+    - "crates/aprender-core/src/format/converter/metadata.rs:fill_head_counts_from_explicit_head_dim"
+    - "crates/aprender-core/src/format/converter/metadata.rs:missing_num_heads_err"
   registry: true
   tags:
     - cli
@@ -48,14 +50,16 @@ equations:
       - "Exit code on missing dim is 5 (CliError::ValidationFailed::FormatError), not 101 (panic)"
 
   attn_dim_inference:
-    formula: "infer_heads(q_dim, kv_dim, hidden) derives (num_heads, num_kv_heads) via num_heads = q_dim/head_dim, num_kv_heads = kv_dim/head_dim; hidden_size, vocab_size, intermediate_size from embedding/FFN shapes"
-    domain: "set of tensor shapes in a metadata-light APR file (PMAT-920)"
-    codomain: "AprV2Metadata with missing dims filled"
+    formula: "head counts require an explicit head_dim: num_heads = q_dim/head_dim, num_kv_heads = kv_dim/head_dim (EXACT). hidden_size, vocab_size, intermediate_size are inferred from embedding/FFN shapes (unambiguous). When head_dim AND num_heads are both absent → honest hard-fail, NOT a guess."
+    domain: "set of tensor shapes + (optional) explicit head_dim/num_heads in a metadata-light APR file (PMAT-920)"
+    codomain: "AprV2Metadata with the unambiguous dims filled; head counts filled only when soundly derivable; otherwise Err"
     invariants:
-      - "When num_heads is None, it is inferred from q/k/v projection shapes before C-07 fires"
-      - "When hidden_size/vocab_size/intermediate_size are None, they are inferred from embedding + FFN tensor shapes"
+      - "num_heads is NOT inferred from shapes alone (q_dim = num_heads × head_dim is unfactorable without head_dim); the old [64,128,96,80] first-divisor guess is removed"
+      - "When num_heads is None but head_dim is explicit, num_heads = q_dim/head_dim EXACTLY (e.g. q_dim=256, head_dim=128 → 2, NOT the guess's 256/64 = 4)"
+      - "When num_kv_heads is None but head_dim is explicit, num_kv_heads = kv_dim/head_dim EXACTLY"
+      - "When head_dim AND num_heads are both absent, export_apr_to_gguf_raw returns Err with an actionable message (names num_heads + head_dim + a working remedy: apr stamp / re-convert from source), and NO GGUF is written — never a silently-wrong head count"
+      - "hidden_size/vocab_size/intermediate_size are inferred from embedding + FFN tensor shapes (these ARE unambiguous)"
       - "Explicit APR metadata always wins; inference only fills None fields"
-      - "The emitted GGUF `<arch>.attention.head_count` equals the inferred num_heads (re-readable, correct)"
       - "Shapes are interpreted row-major (LAYOUT-001) consistently with import"
 
 proof_obligations:
@@ -72,8 +76,12 @@ proof_obligations:
     formal: "export_apr_to_gguf_raw(apr_with_no_num_layers) = Err | Ok (never panic)"
     applies_to: export_no_panic
   - type: invariant
-    property: "Missing num_heads is inferred from attention tensor shapes (PMAT-920)"
-    formal: "export_apr_to_gguf_raw(metadata_light_apr) = Ok AND gguf.<arch>.attention.head_count = q_dim/head_dim"
+    property: "With explicit head_dim, num_heads is derived EXACTLY (not guessed) (PMAT-920)"
+    formal: "export_apr_to_gguf_raw(apr{head_dim=128, q_dim=256}) = Ok AND gguf.<arch>.attention.head_count = 256/128 = 2 (NOT the [64,...] guess's 4)"
+    applies_to: attn_dim_inference
+  - type: invariant
+    property: "Absent head_dim AND num_heads → actionable hard-fail, no silently-wrong head count (PMAT-920)"
+    formal: "export_apr_to_gguf_raw(apr{head_dim=None, num_heads=None}) = Err(msg naming num_heads + head_dim + a working remedy: apr stamp / re-convert) AND no GGUF written"
     applies_to: attn_dim_inference
 
 falsification_tests:
@@ -96,10 +104,16 @@ falsification_tests:
     if_fails: "Function still returns Vec — missing dims will continue to panic via downstream .expect()"
 
   - id: FALSIFY-EXPORT-INFER-METADATA-001
-    rule: "Metadata-light APR (no num_heads) exports to GGUF via shape inference with correct head counts (PMAT-920)"
-    prediction: "export_apr_to_gguf_raw on an APR with num_heads=None but q/k/v projection shapes succeeds AND the re-read GGUF has the correct inferred attention.head_count / head_count_kv / embedding_length"
-    test: "cargo test -p aprender-core --lib ft_apr_gguf_export_infers_heads_when_metadata_light"
-    if_fails: "Exporter hard-fails with C-07 on a metadata-light .apr whose shapes imply num_heads, breaking apr->gguf for llama.cpp/ollama"
+    rule: "Explicit head_dim yields the EXACT head count (q_dim/head_dim), never the [64,128,96,80] guess (PMAT-920)"
+    prediction: "export_apr_to_gguf_raw on a metadata-light APR with explicit head_dim=128 and q_dim=256 succeeds AND the re-read GGUF has attention.head_count = 2 (NOT the old guess's 256/64 = 4)"
+    test: "cargo test -p aprender-core --lib ft_apr_gguf_export_uses_explicit_head_dim_exactly_not_guess"
+    if_fails: "Exporter is guessing head_dim from a hardcoded list and silently mis-stamping the head count"
+
+  - id: FALSIFY-EXPORT-INFER-METADATA-002
+    rule: "Absent head_dim AND num_heads → actionable hard-fail, no silently-wrong head count, no GGUF written (PMAT-920)"
+    prediction: "export_apr_to_gguf_raw on a metadata-light APR with no head_dim and no num_heads returns Err naming num_heads + head_dim + a working remedy (apr stamp / re-convert), and writes no GGUF"
+    test: "cargo test -p aprender-core --lib ft_apr_gguf_export_hard_fails_when_head_dim_and_num_heads_absent"
+    if_fails: "Exporter guesses a head count and emits a silently-wrong GGUF instead of failing honestly"
 
 qa_gate:
   id: F-EXPORT-NUM-LAYERS-001
@@ -109,4 +123,4 @@ qa_gate:
     - "num_layers_inference"
     - "export_no_panic"
     - "attn_dim_inference"
-  pass_criteria: "FALSIFY-EXPORT-NUM-LAYERS-{001,002,003} and FALSIFY-EXPORT-INFER-METADATA-001 all PASS"
+  pass_criteria: "FALSIFY-EXPORT-NUM-LAYERS-{001,002,003} and FALSIFY-EXPORT-INFER-METADATA-{001,002} all PASS"

--- a/crates/aprender-core/src/format/converter/export_tests_include_01.rs
+++ b/crates/aprender-core/src/format/converter/export_tests_include_01.rs
@@ -190,3 +190,5 @@ mod export_tests_arch_metadata;
 mod export_tests_unfuse_with_metadata;
 #[path = "export_tests_arch_case_mapping.rs"]
 mod export_tests_arch_case_mapping;
+#[path = "export_tests_infer_heads_gguf.rs"]
+mod export_tests_infer_heads_gguf;

--- a/crates/aprender-core/src/format/converter/export_tests_infer_heads_gguf.rs
+++ b/crates/aprender-core/src/format/converter/export_tests_infer_heads_gguf.rs
@@ -1,82 +1,39 @@
-//! OBLIG-APR-GGUF-EXPORT-INFER-METADATA (PMAT-920):
-//! `apr export --format gguf` on a metadata-light .apr (no explicit `num_heads`,
-//! `hidden_size`, `vocab_size`, or `intermediate_size`) must INFER those
-//! GGUF-required dimensions from the model's tensor shapes instead of
-//! hard-failing with a C-07 missing-dimension error.
+//! OBLIG-APR-GGUF-EXPORT-HEAD-COUNT-SOUND (PMAT-920):
+//! `apr export --format gguf` on a metadata-light .apr must derive `num_heads`
+//! / `num_kv_heads` EXACTLY from an EXPLICIT `head_dim`
+//! (`num_heads = q_dim / head_dim`), and MUST NOT guess `head_dim` from a
+//! hardcoded list when it is absent.
 //!
-//! Before the fix, `export_apr_to_gguf_raw` called
-//! `apr_metadata.num_heads.ok_or_else(|| missing_dim_err("num_heads"))?`,
-//! so a .apr produced by training / `apr convert` without a fully-populated
-//! metadata block could not be exported to GGUF for llama.cpp / ollama at all.
+//! The original PMAT-920 fix inferred `num_heads` via the
+//! `[64, 128, 96, 80]` first-divisor guess in `infer_head_counts`. That
+//! SILENTLY mis-stamps real models: Qwen2-1.5B (q_dim=1536, head_dim=128,
+//! 12 heads) → the guess picks head_dim=64 first → `1536/64 = 24` heads
+//! written into a valid-looking GGUF, no error. A silently-wrong head count is
+//! worse than an honest failure.
 //!
-//! The shapes in this fixture are an unambiguous Qwen2-style 0.5B-ish layout:
-//! q_proj/o_proj = [hidden, hidden]; k_proj/v_proj = [kv_dim, hidden] (GQA);
-//! head_dim is 64 → num_heads = hidden/64, num_kv_heads = kv_dim/64.
+//! This file falsifies BOTH directions:
+//!   (i)  EXPLICIT head_dim present (num_heads absent) → exact head count
+//!        `q_dim / head_dim`, using a head_dim=128 fixture where the old
+//!        first-divisor guess would have said 64 (so it PROVES we don't guess).
+//!   (ii) head_dim AND num_heads BOTH absent → ACTIONABLE hard-fail (names the
+//!        missing dim + a working remedy: stamp head_dim/num_heads or convert
+//!        from source), NOT a silently-wrong head count.
 use super::*;
 
-/// Build a metadata-light APR (only architecture + tokenizer custom fields)
-/// whose tensor shapes imply the attention dimensions. `hidden=128`,
-/// `kv_dim=64`, head_dim=64 → num_heads=2, num_kv_heads=1.
-fn write_metadata_light_apr(apr_path: &std::path::Path) {
-    use crate::format::v2::{AprV2Metadata, AprV2Writer};
-
-    let hidden = 128usize;
-    let kv_dim = 64usize; // GQA: 1 kv head of dim 64
-    let inter = 256usize;
-    // Realistic LLM: vocab >> hidden (embedding shape [vocab, hidden]).
-    let vocab = 512usize;
-
-    let mut metadata = AprV2Metadata::new("qwen2");
-    metadata.architecture = Some("qwen2".to_string());
-    // Intentionally MISSING: num_heads, num_kv_heads, hidden_size,
-    // vocab_size, intermediate_size. num_layers stays unset too (already
-    // inferred from blk.N.*).
-    metadata.num_heads = None;
-    metadata.num_kv_heads = None;
-    metadata.hidden_size = None;
-    metadata.vocab_size = None;
-    metadata.intermediate_size = None;
-    metadata.num_layers = None;
-    metadata.name = Some("metadata-light".to_string());
-    metadata
-        .custom
-        .insert("tokenizer.model".to_string(), serde_json::json!("gpt2"));
-    let vocab_tokens: Vec<String> = (0..vocab).map(|i| format!("tok{i}")).collect();
-    metadata.custom.insert(
-        "tokenizer.vocabulary".to_string(),
-        serde_json::json!(vocab_tokens),
-    );
-
-    let mut writer = AprV2Writer::new(metadata);
-
-    // Embedding [vocab, hidden] → implies vocab_size + hidden_size.
+/// Shared FFN/embedding/norm tensors for a single-layer Qwen2-style model.
+/// Attention q/k/v shapes are parameterized so each test can exercise a
+/// specific (q_dim, kv_dim) without re-guessing head_dim.
+fn add_common_tensors(
+    writer: &mut crate::format::v2::AprV2Writer,
+    vocab: usize,
+    hidden: usize,
+    inter: usize,
+) {
     writer.add_f32_tensor(
         "model.embed_tokens.weight",
         vec![vocab, hidden],
         &vec![0.01f32; vocab * hidden],
     );
-    // Attention projections for layer 0 (HF names).
-    writer.add_f32_tensor(
-        "model.layers.0.self_attn.q_proj.weight",
-        vec![hidden, hidden],
-        &vec![0.01f32; hidden * hidden],
-    );
-    writer.add_f32_tensor(
-        "model.layers.0.self_attn.k_proj.weight",
-        vec![kv_dim, hidden],
-        &vec![0.01f32; kv_dim * hidden],
-    );
-    writer.add_f32_tensor(
-        "model.layers.0.self_attn.v_proj.weight",
-        vec![kv_dim, hidden],
-        &vec![0.01f32; kv_dim * hidden],
-    );
-    writer.add_f32_tensor(
-        "model.layers.0.self_attn.o_proj.weight",
-        vec![hidden, hidden],
-        &vec![0.01f32; hidden * hidden],
-    );
-    // FFN gate/up → implies intermediate_size.
     writer.add_f32_tensor(
         "model.layers.0.mlp.gate_proj.weight",
         vec![inter, hidden],
@@ -98,31 +55,97 @@ fn write_metadata_light_apr(apr_path: &std::path::Path) {
         vec![vocab, hidden],
         &vec![0.01f32; vocab * hidden],
     );
-
-    let apr_bytes = writer.write().expect("write APR");
-    std::fs::write(apr_path, &apr_bytes).expect("write APR file");
 }
 
-/// FALSIFIER (RED on unfixed: hard-fails with C-07 missing num_heads;
-/// GREEN on fix: succeeds AND emits correct num_heads/num_kv_heads).
+fn add_attn_tensors(
+    writer: &mut crate::format::v2::AprV2Writer,
+    hidden: usize,
+    q_dim: usize,
+    kv_dim: usize,
+) {
+    writer.add_f32_tensor(
+        "model.layers.0.self_attn.q_proj.weight",
+        vec![q_dim, hidden],
+        &vec![0.01f32; q_dim * hidden],
+    );
+    writer.add_f32_tensor(
+        "model.layers.0.self_attn.k_proj.weight",
+        vec![kv_dim, hidden],
+        &vec![0.01f32; kv_dim * hidden],
+    );
+    writer.add_f32_tensor(
+        "model.layers.0.self_attn.v_proj.weight",
+        vec![kv_dim, hidden],
+        &vec![0.01f32; kv_dim * hidden],
+    );
+    writer.add_f32_tensor(
+        "model.layers.0.self_attn.o_proj.weight",
+        vec![hidden, q_dim],
+        &vec![0.01f32; hidden * q_dim],
+    );
+}
+
+fn metadata_light(name: &str, vocab: usize) -> crate::format::v2::AprV2Metadata {
+    use crate::format::v2::AprV2Metadata;
+    let mut metadata = AprV2Metadata::new("qwen2");
+    metadata.architecture = Some("qwen2".to_string());
+    // All dims intentionally MISSING; tests set head_dim individually.
+    metadata.num_heads = None;
+    metadata.num_kv_heads = None;
+    metadata.hidden_size = None;
+    metadata.vocab_size = None;
+    metadata.intermediate_size = None;
+    metadata.num_layers = None;
+    metadata.head_dim = None;
+    metadata.name = Some(name.to_string());
+    metadata
+        .custom
+        .insert("tokenizer.model".to_string(), serde_json::json!("gpt2"));
+    let vocab_tokens: Vec<String> = (0..vocab).map(|i| format!("tok{i}")).collect();
+    metadata.custom.insert(
+        "tokenizer.vocabulary".to_string(),
+        serde_json::json!(vocab_tokens),
+    );
+    metadata
+}
+
+/// DIRECTION (i): EXPLICIT head_dim present, num_heads absent → exact head
+/// count `q_dim / head_dim`.
+///
+/// Fixture: hidden=q_dim=256, kv_dim=256, EXPLICIT head_dim=128
+/// → num_heads = 256/128 = 2, num_kv_heads = 256/128 = 2.
+///
+/// CRITICAL: the OLD `[64,128,96,80]` first-divisor guess would have picked
+/// head_dim=64 → 256/64 = 4 heads (WRONG). Asserting head_count == 2 proves we
+/// use the explicit head_dim and do NOT guess.
 #[test]
-fn ft_apr_gguf_export_infers_heads_when_metadata_light() {
+fn ft_apr_gguf_export_uses_explicit_head_dim_exactly_not_guess() {
     use crate::format::gguf::{GgufReader, GgufValue};
+    use crate::format::v2::AprV2Writer;
     use tempfile::tempdir;
 
     let dir = tempdir().expect("temp dir");
     let apr_path = dir.path().join("model.apr");
     let gguf_path = dir.path().join("model.gguf");
 
-    write_metadata_light_apr(&apr_path);
+    let hidden = 256usize;
+    let q_dim = 256usize;
+    let kv_dim = 256usize;
+    let inter = 512usize;
+    let vocab = 512usize;
 
-    // Must NOT hard-fail on missing num_heads — must infer from shapes.
+    let mut metadata = metadata_light("explicit-head-dim", vocab);
+    metadata.head_dim = Some(128); // EXPLICIT, sound. Old guess would say 64.
+    let mut writer = AprV2Writer::new(metadata);
+    add_common_tensors(&mut writer, vocab, hidden, inter);
+    add_attn_tensors(&mut writer, hidden, q_dim, kv_dim);
+    let apr_bytes = writer.write().expect("write APR");
+    std::fs::write(&apr_path, &apr_bytes).expect("write APR file");
+
     let report = export_apr_to_gguf_raw(&apr_path, &gguf_path)
-        .expect("metadata-light APR must export to GGUF via shape inference, not hard-fail");
+        .expect("APR with explicit head_dim must export to GGUF");
     assert_eq!(report.format, ExportFormat::Gguf);
-    assert!(gguf_path.exists(), "gguf must be written");
 
-    // Re-read the produced GGUF: the inferred head counts must be correct.
     let gguf = GgufReader::from_file(&gguf_path).expect("read produced GGUF");
 
     let head_count = gguf
@@ -132,7 +155,8 @@ fn ft_apr_gguf_export_infers_heads_when_metadata_light() {
     match head_count {
         GgufValue::Uint32(v) => assert_eq!(
             *v, 2,
-            "hidden=128, head_dim=64 → num_heads must be inferred as 2, got {v}"
+            "q_dim=256 / explicit head_dim=128 → num_heads must be EXACTLY 2 \
+             (the old [64,128,96,80] guess would wrongly give 256/64 = 4), got {v}"
         ),
         other => panic!("head_count should be Uint32, got {other:?}"),
     }
@@ -143,21 +167,69 @@ fn ft_apr_gguf_export_infers_heads_when_metadata_light() {
         .expect("qwen2.attention.head_count_kv must be present");
     match kv_count {
         GgufValue::Uint32(v) => assert_eq!(
-            *v, 1,
-            "kv_dim=64, head_dim=64 → num_kv_heads must be inferred as 1, got {v}"
+            *v, 2,
+            "kv_dim=256 / explicit head_dim=128 → num_kv_heads must be EXACTLY 2, got {v}"
         ),
         other => panic!("head_count_kv should be Uint32, got {other:?}"),
     }
 
-    // embedding_length (hidden_size) must also be inferred (not 0).
+    // hidden/vocab/intermediate stay unambiguously inferable from shapes.
     let emb = gguf
         .metadata
         .get("qwen2.embedding_length")
         .expect("qwen2.embedding_length must be present");
     match emb {
-        GgufValue::Uint32(v) => {
-            assert_eq!(*v, 128, "hidden_size must be inferred as 128, got {v}")
-        }
+        GgufValue::Uint32(v) => assert_eq!(*v, 256, "hidden_size inferred from embedding, got {v}"),
         other => panic!("embedding_length should be Uint32, got {other:?}"),
     }
+}
+
+/// DIRECTION (ii): head_dim AND num_heads BOTH absent → ACTIONABLE hard-fail,
+/// NOT a silently-wrong head count.
+///
+/// This is the regression that the original fix introduced: with the
+/// `[64,128,96,80]` guess, a metadata-light .apr exported "successfully" with a
+/// fabricated head count. The correct behavior is to refuse and tell the user
+/// how to supply the missing dimension.
+#[test]
+fn ft_apr_gguf_export_hard_fails_when_head_dim_and_num_heads_absent() {
+    use crate::format::v2::AprV2Writer;
+    use tempfile::tempdir;
+
+    let dir = tempdir().expect("temp dir");
+    let apr_path = dir.path().join("model.apr");
+    let gguf_path = dir.path().join("model.gguf");
+
+    // hidden=q_dim=1536 (Qwen2-1.5B), kv_dim=256. NO head_dim, NO num_heads.
+    let hidden = 1536usize;
+    let q_dim = 1536usize;
+    let kv_dim = 256usize;
+    let inter = 8960usize;
+    let vocab = 512usize;
+
+    let metadata = metadata_light("no-head-dim", vocab); // head_dim stays None
+    let mut writer = AprV2Writer::new(metadata);
+    add_common_tensors(&mut writer, vocab, hidden, inter);
+    add_attn_tensors(&mut writer, hidden, q_dim, kv_dim);
+    let apr_bytes = writer.write().expect("write APR");
+    std::fs::write(&apr_path, &apr_bytes).expect("write APR file");
+
+    let err = export_apr_to_gguf_raw(&apr_path, &gguf_path).expect_err(
+        "metadata-light APR with no head_dim and no num_heads must HARD-FAIL, \
+         not silently guess a head count",
+    );
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("num_heads"),
+        "error must name the missing dimension (num_heads), got: {msg}"
+    );
+    assert!(
+        msg.contains("head_dim") && msg.contains("apr stamp"),
+        "error must be ACTIONABLE — name head_dim and a remedy (apr stamp / convert), got: {msg}"
+    );
+    // The GGUF must NOT have been written with a fabricated head count.
+    assert!(
+        !gguf_path.exists(),
+        "no GGUF may be produced when the head count cannot be soundly determined"
+    );
 }

--- a/crates/aprender-core/src/format/converter/export_tests_infer_heads_gguf.rs
+++ b/crates/aprender-core/src/format/converter/export_tests_infer_heads_gguf.rs
@@ -1,0 +1,163 @@
+//! OBLIG-APR-GGUF-EXPORT-INFER-METADATA (PMAT-920):
+//! `apr export --format gguf` on a metadata-light .apr (no explicit `num_heads`,
+//! `hidden_size`, `vocab_size`, or `intermediate_size`) must INFER those
+//! GGUF-required dimensions from the model's tensor shapes instead of
+//! hard-failing with a C-07 missing-dimension error.
+//!
+//! Before the fix, `export_apr_to_gguf_raw` called
+//! `apr_metadata.num_heads.ok_or_else(|| missing_dim_err("num_heads"))?`,
+//! so a .apr produced by training / `apr convert` without a fully-populated
+//! metadata block could not be exported to GGUF for llama.cpp / ollama at all.
+//!
+//! The shapes in this fixture are an unambiguous Qwen2-style 0.5B-ish layout:
+//! q_proj/o_proj = [hidden, hidden]; k_proj/v_proj = [kv_dim, hidden] (GQA);
+//! head_dim is 64 → num_heads = hidden/64, num_kv_heads = kv_dim/64.
+use super::*;
+
+/// Build a metadata-light APR (only architecture + tokenizer custom fields)
+/// whose tensor shapes imply the attention dimensions. `hidden=128`,
+/// `kv_dim=64`, head_dim=64 → num_heads=2, num_kv_heads=1.
+fn write_metadata_light_apr(apr_path: &std::path::Path) {
+    use crate::format::v2::{AprV2Metadata, AprV2Writer};
+
+    let hidden = 128usize;
+    let kv_dim = 64usize; // GQA: 1 kv head of dim 64
+    let inter = 256usize;
+    // Realistic LLM: vocab >> hidden (embedding shape [vocab, hidden]).
+    let vocab = 512usize;
+
+    let mut metadata = AprV2Metadata::new("qwen2");
+    metadata.architecture = Some("qwen2".to_string());
+    // Intentionally MISSING: num_heads, num_kv_heads, hidden_size,
+    // vocab_size, intermediate_size. num_layers stays unset too (already
+    // inferred from blk.N.*).
+    metadata.num_heads = None;
+    metadata.num_kv_heads = None;
+    metadata.hidden_size = None;
+    metadata.vocab_size = None;
+    metadata.intermediate_size = None;
+    metadata.num_layers = None;
+    metadata.name = Some("metadata-light".to_string());
+    metadata
+        .custom
+        .insert("tokenizer.model".to_string(), serde_json::json!("gpt2"));
+    let vocab_tokens: Vec<String> = (0..vocab).map(|i| format!("tok{i}")).collect();
+    metadata.custom.insert(
+        "tokenizer.vocabulary".to_string(),
+        serde_json::json!(vocab_tokens),
+    );
+
+    let mut writer = AprV2Writer::new(metadata);
+
+    // Embedding [vocab, hidden] → implies vocab_size + hidden_size.
+    writer.add_f32_tensor(
+        "model.embed_tokens.weight",
+        vec![vocab, hidden],
+        &vec![0.01f32; vocab * hidden],
+    );
+    // Attention projections for layer 0 (HF names).
+    writer.add_f32_tensor(
+        "model.layers.0.self_attn.q_proj.weight",
+        vec![hidden, hidden],
+        &vec![0.01f32; hidden * hidden],
+    );
+    writer.add_f32_tensor(
+        "model.layers.0.self_attn.k_proj.weight",
+        vec![kv_dim, hidden],
+        &vec![0.01f32; kv_dim * hidden],
+    );
+    writer.add_f32_tensor(
+        "model.layers.0.self_attn.v_proj.weight",
+        vec![kv_dim, hidden],
+        &vec![0.01f32; kv_dim * hidden],
+    );
+    writer.add_f32_tensor(
+        "model.layers.0.self_attn.o_proj.weight",
+        vec![hidden, hidden],
+        &vec![0.01f32; hidden * hidden],
+    );
+    // FFN gate/up → implies intermediate_size.
+    writer.add_f32_tensor(
+        "model.layers.0.mlp.gate_proj.weight",
+        vec![inter, hidden],
+        &vec![0.01f32; inter * hidden],
+    );
+    writer.add_f32_tensor(
+        "model.layers.0.mlp.up_proj.weight",
+        vec![inter, hidden],
+        &vec![0.01f32; inter * hidden],
+    );
+    writer.add_f32_tensor(
+        "model.layers.0.mlp.down_proj.weight",
+        vec![hidden, inter],
+        &vec![0.01f32; hidden * inter],
+    );
+    writer.add_f32_tensor("model.norm.weight", vec![hidden], &vec![1.0f32; hidden]);
+    writer.add_f32_tensor(
+        "lm_head.weight",
+        vec![vocab, hidden],
+        &vec![0.01f32; vocab * hidden],
+    );
+
+    let apr_bytes = writer.write().expect("write APR");
+    std::fs::write(apr_path, &apr_bytes).expect("write APR file");
+}
+
+/// FALSIFIER (RED on unfixed: hard-fails with C-07 missing num_heads;
+/// GREEN on fix: succeeds AND emits correct num_heads/num_kv_heads).
+#[test]
+fn ft_apr_gguf_export_infers_heads_when_metadata_light() {
+    use crate::format::gguf::{GgufReader, GgufValue};
+    use tempfile::tempdir;
+
+    let dir = tempdir().expect("temp dir");
+    let apr_path = dir.path().join("model.apr");
+    let gguf_path = dir.path().join("model.gguf");
+
+    write_metadata_light_apr(&apr_path);
+
+    // Must NOT hard-fail on missing num_heads — must infer from shapes.
+    let report = export_apr_to_gguf_raw(&apr_path, &gguf_path)
+        .expect("metadata-light APR must export to GGUF via shape inference, not hard-fail");
+    assert_eq!(report.format, ExportFormat::Gguf);
+    assert!(gguf_path.exists(), "gguf must be written");
+
+    // Re-read the produced GGUF: the inferred head counts must be correct.
+    let gguf = GgufReader::from_file(&gguf_path).expect("read produced GGUF");
+
+    let head_count = gguf
+        .metadata
+        .get("qwen2.attention.head_count")
+        .expect("qwen2.attention.head_count must be present");
+    match head_count {
+        GgufValue::Uint32(v) => assert_eq!(
+            *v, 2,
+            "hidden=128, head_dim=64 → num_heads must be inferred as 2, got {v}"
+        ),
+        other => panic!("head_count should be Uint32, got {other:?}"),
+    }
+
+    let kv_count = gguf
+        .metadata
+        .get("qwen2.attention.head_count_kv")
+        .expect("qwen2.attention.head_count_kv must be present");
+    match kv_count {
+        GgufValue::Uint32(v) => assert_eq!(
+            *v, 1,
+            "kv_dim=64, head_dim=64 → num_kv_heads must be inferred as 1, got {v}"
+        ),
+        other => panic!("head_count_kv should be Uint32, got {other:?}"),
+    }
+
+    // embedding_length (hidden_size) must also be inferred (not 0).
+    let emb = gguf
+        .metadata
+        .get("qwen2.embedding_length")
+        .expect("qwen2.embedding_length must be present");
+    match emb {
+        GgufValue::Uint32(v) => {
+            assert_eq!(*v, 128, "hidden_size must be inferred as 128, got {v}")
+        }
+        other => panic!("embedding_length should be Uint32, got {other:?}"),
+    }
+}

--- a/crates/aprender-core/src/format/converter/metadata.rs
+++ b/crates/aprender-core/src/format/converter/metadata.rs
@@ -32,6 +32,79 @@ fn missing_dim_err(field: &str) -> AprenderError {
     }
 }
 
+/// PMAT-920 (OBLIG-APR-GGUF-EXPORT-INFER-METADATA): fill missing GGUF-required
+/// dimensions on `apr_metadata` by inferring them from the APR tensor shapes.
+///
+/// Older / training-produced / `apr convert`-without-full-header `.apr` files
+/// leave `num_heads`, `hidden_size`, `vocab_size`, and/or `intermediate_size`
+/// unset. The tensor layout still carries these dimensions unambiguously
+/// (embedding `[vocab, hidden]`; q/k/v projections imply head counts via
+/// `head_dim`; gate/up project to `intermediate_size`). Reuse the existing
+/// shape-inference engine (`infer_model_config_from_tensors`) — which only
+/// reads shapes — to derive them so `apr export --format gguf` succeeds on
+/// metadata-light files instead of hard-failing with C-07.
+///
+/// Only fills fields that are currently `None`; explicit metadata always wins.
+/// LAYOUT-001: APR tensor shapes are row-major, which is exactly the layout
+/// `infer_model_config_from_tensors` expects.
+fn infer_missing_gguf_dims_from_shapes(
+    reader: &crate::format::v2::AprV2Reader,
+    apr_metadata: &mut crate::format::v2::AprV2Metadata,
+) {
+    let needs_inference = apr_metadata.num_heads.is_none()
+        || apr_metadata.hidden_size.is_none()
+        || apr_metadata.vocab_size.is_none()
+        || apr_metadata.intermediate_size.is_none()
+        || apr_metadata.num_kv_heads.is_none();
+    if !needs_inference {
+        return;
+    }
+
+    // Build a shape-only tensor map (empty data — the inference engine reads
+    // shapes only) so we can reuse the SafeTensors shape-inference path.
+    let mut shape_map: BTreeMap<String, (Vec<f32>, Vec<usize>)> = BTreeMap::new();
+    for name in reader.tensor_names() {
+        if let Some(entry) = reader.get_tensor(name) {
+            shape_map.insert(name.to_string(), (Vec::new(), entry.shape.clone()));
+        }
+    }
+
+    let Some(inferred) = super::import::infer_model_config_from_tensors(&shape_map) else {
+        return;
+    };
+
+    if apr_metadata.hidden_size.is_none() {
+        if let Some(v) = inferred.hidden_size {
+            eprintln!("[PMAT-920] hidden_size missing from APR metadata — inferred {v} from tensor shapes");
+            apr_metadata.hidden_size = Some(v);
+        }
+    }
+    if apr_metadata.num_heads.is_none() {
+        if let Some(v) = inferred.num_heads {
+            eprintln!("[PMAT-920] num_heads missing from APR metadata — inferred {v} from attention tensor shapes");
+            apr_metadata.num_heads = Some(v);
+        }
+    }
+    if apr_metadata.num_kv_heads.is_none() {
+        if let Some(v) = inferred.num_kv_heads {
+            eprintln!("[PMAT-920] num_kv_heads missing from APR metadata — inferred {v} from attention tensor shapes");
+            apr_metadata.num_kv_heads = Some(v);
+        }
+    }
+    if apr_metadata.vocab_size.is_none() {
+        if let Some(v) = inferred.vocab_size {
+            eprintln!("[PMAT-920] vocab_size missing from APR metadata — inferred {v} from embedding tensor shape");
+            apr_metadata.vocab_size = Some(v);
+        }
+    }
+    if apr_metadata.intermediate_size.is_none() {
+        if let Some(v) = inferred.intermediate_size {
+            eprintln!("[PMAT-920] intermediate_size missing from APR metadata — inferred {v} from FFN tensor shapes");
+            apr_metadata.intermediate_size = Some(v);
+        }
+    }
+}
+
 /// Build GGUF architecture metadata from APR model metadata.
 ///
 /// Returns `Err(AprenderError::FormatError)` instead of panicking when required
@@ -416,6 +489,17 @@ fn export_apr_to_gguf_raw(input: &Path, output: &Path) -> Result<ExportReport> {
             apr_metadata.num_layers = Some(inferred);
         }
     }
+
+    // PMAT-920 (OBLIG-APR-GGUF-EXPORT-INFER-METADATA): when the APR metadata
+    // block is "light" (no explicit num_heads / hidden_size / vocab_size /
+    // intermediate_size — e.g. a .apr produced by training or `apr convert`
+    // without a fully-populated header), the tensor shapes still carry these
+    // GGUF-required dimensions unambiguously. Infer them from the shapes
+    // before the C-07 missing-dimension error fires, so apr→gguf works on
+    // arbitrary metadata-light .apr files (llama.cpp / ollama interop) instead
+    // of hard-failing. Shapes are APR-native row-major (LAYOUT-001), exactly
+    // what `infer_model_config_from_tensors` expects.
+    infer_missing_gguf_dims_from_shapes(&reader, &mut apr_metadata);
 
     let arch = resolve_architecture(&apr_metadata);
     let num_layers = apr_metadata.num_layers.ok_or_else(|| missing_dim_err("num_layers"))?;

--- a/crates/aprender-core/src/format/converter/metadata.rs
+++ b/crates/aprender-core/src/format/converter/metadata.rs
@@ -32,36 +32,93 @@ fn missing_dim_err(field: &str) -> AprenderError {
     }
 }
 
-/// PMAT-920 (OBLIG-APR-GGUF-EXPORT-INFER-METADATA): fill missing GGUF-required
-/// dimensions on `apr_metadata` by inferring them from the APR tensor shapes.
+/// PMAT-920: actionable error for the one dimension that is NOT inferable from
+/// tensor shapes alone — `num_heads`.
 ///
-/// Older / training-produced / `apr convert`-without-full-header `.apr` files
-/// leave `num_heads`, `hidden_size`, `vocab_size`, and/or `intermediate_size`
-/// unset. The tensor layout still carries these dimensions unambiguously
-/// (embedding `[vocab, hidden]`; q/k/v projections imply head counts via
-/// `head_dim`; gate/up project to `intermediate_size`). Reuse the existing
-/// shape-inference engine (`infer_model_config_from_tensors`) — which only
-/// reads shapes — to derive them so `apr export --format gguf` succeeds on
-/// metadata-light files instead of hard-failing with C-07.
+/// `q_dim = num_heads * head_dim` cannot be factored without knowing `head_dim`
+/// (a 1536-wide projection is 12×128 OR 24×64 OR 16×96 — all valid). The old
+/// exporter GUESSED `head_dim` from a hardcoded `[64, 128, 96, 80]` list and
+/// took the first divisor, which silently MIS-STAMPED real models: Qwen2-1.5B
+/// (hidden=1536, head_dim=128, 12 heads) got `1536/64 = 24` heads written into
+/// a valid-looking GGUF, no error. A silently-wrong head count is worse than an
+/// honest failure, so when neither `num_heads` nor `head_dim` is present we
+/// hard-fail and tell the user exactly how to supply the missing dimension.
+fn missing_num_heads_err() -> AprenderError {
+    AprenderError::FormatError {
+        message:
+            "C-07: num_heads required for GGUF export and NOT inferable from tensor shapes \
+             alone — q_dim = num_heads × head_dim has no unique factorization without head_dim \
+             (a 1536-wide projection is 12×128 OR 24×64 OR 16×96, all valid). \
+             To supply the missing dimension, populate the APR metadata header so the export \
+             can derive it exactly: set an explicit `head_dim` (then num_heads = q_dim / head_dim, \
+             num_kv_heads = kv_dim / head_dim) or an explicit `num_heads`/`num_kv_heads` via \
+             `apr stamp`, or re-`apr convert` from the original GGUF/SafeTensors source whose \
+             config.json carries head_dim / num_attention_heads. \
+             Refusing to guess head_dim (the old [64,128,96,80] first-divisor guess silently \
+             mis-stamped models like Qwen2-1.5B as 24 heads instead of 12 — a wrong-but-valid \
+             GGUF is worse than an honest failure)."
+            .to_string(),
+    }
+}
+
+/// PMAT-920: smaller dimension of the first 2D projection tensor matching any
+/// of the given name patterns. For a row-major `[out, in]` projection this is
+/// the model/projection width (`q_dim`/`kv_dim`), which together with an
+/// EXPLICIT `head_dim` yields an exact, sound head count.
+fn projection_dim_from_shapes(
+    reader: &crate::format::v2::AprV2Reader,
+    name_patterns: &[&str],
+) -> Option<usize> {
+    for name in reader.tensor_names() {
+        if name_patterns.iter().any(|p| name.contains(p)) {
+            if let Some(entry) = reader.get_tensor(name) {
+                if entry.shape.len() == 2 {
+                    return Some(entry.shape[0].min(entry.shape[1]));
+                }
+            }
+        }
+    }
+    None
+}
+
+/// PMAT-920 (OBLIG-APR-GGUF-EXPORT-INFER-METADATA): fill missing GGUF-required
+/// dimensions on `apr_metadata` for metadata-light `.apr` files.
+///
+/// CORRECTNESS CONTRACT — which dimensions are inferable from shapes:
+///   - `hidden_size`, `vocab_size` — UNAMBIGUOUS from the embedding shape
+///     `[vocab, hidden]`. Inferred from shapes.
+///   - `intermediate_size` — UNAMBIGUOUS from the FFN gate/up shapes. Inferred.
+///   - `num_heads` / `num_kv_heads` — **NOT** inferable from shapes alone:
+///     `q_dim = num_heads × head_dim` has no unique factorization without
+///     `head_dim`. We derive them ONLY from an EXPLICIT `head_dim`
+///     (`num_heads = q_dim / head_dim`, EXACT and sound). If `head_dim` is
+///     absent and `num_heads` is absent, we DO NOT guess — the export
+///     hard-fails with an actionable error (`missing_num_heads_err`).
+///
+/// This deliberately drops the old `[64,128,96,80]` first-divisor head_dim
+/// guess, which silently mis-stamped real models (e.g. Qwen2-1.5B as 24 heads
+/// instead of 12). An honest error (or a user `--head-dim`/`--num-heads`
+/// override) beats a silently-wrong head count.
 ///
 /// Only fills fields that are currently `None`; explicit metadata always wins.
-/// LAYOUT-001: APR tensor shapes are row-major, which is exactly the layout
-/// `infer_model_config_from_tensors` expects.
+/// LAYOUT-001: APR tensor shapes are row-major.
 fn infer_missing_gguf_dims_from_shapes(
     reader: &crate::format::v2::AprV2Reader,
     apr_metadata: &mut crate::format::v2::AprV2Metadata,
 ) {
-    let needs_inference = apr_metadata.num_heads.is_none()
-        || apr_metadata.hidden_size.is_none()
+    // Head counts: ONLY from an explicit head_dim. No shape guessing.
+    fill_head_counts_from_explicit_head_dim(reader, apr_metadata);
+
+    let needs_shape_inference = apr_metadata.hidden_size.is_none()
         || apr_metadata.vocab_size.is_none()
-        || apr_metadata.intermediate_size.is_none()
-        || apr_metadata.num_kv_heads.is_none();
-    if !needs_inference {
+        || apr_metadata.intermediate_size.is_none();
+    if !needs_shape_inference {
         return;
     }
 
     // Build a shape-only tensor map (empty data — the inference engine reads
-    // shapes only) so we can reuse the SafeTensors shape-inference path.
+    // shapes only) so we can reuse the SafeTensors shape-inference path for the
+    // dimensions that ARE unambiguous (hidden/vocab/intermediate).
     let mut shape_map: BTreeMap<String, (Vec<f32>, Vec<usize>)> = BTreeMap::new();
     for name in reader.tensor_names() {
         if let Some(entry) = reader.get_tensor(name) {
@@ -75,20 +132,8 @@ fn infer_missing_gguf_dims_from_shapes(
 
     if apr_metadata.hidden_size.is_none() {
         if let Some(v) = inferred.hidden_size {
-            eprintln!("[PMAT-920] hidden_size missing from APR metadata — inferred {v} from tensor shapes");
+            eprintln!("[PMAT-920] hidden_size missing from APR metadata — inferred {v} from embedding tensor shape");
             apr_metadata.hidden_size = Some(v);
-        }
-    }
-    if apr_metadata.num_heads.is_none() {
-        if let Some(v) = inferred.num_heads {
-            eprintln!("[PMAT-920] num_heads missing from APR metadata — inferred {v} from attention tensor shapes");
-            apr_metadata.num_heads = Some(v);
-        }
-    }
-    if apr_metadata.num_kv_heads.is_none() {
-        if let Some(v) = inferred.num_kv_heads {
-            eprintln!("[PMAT-920] num_kv_heads missing from APR metadata — inferred {v} from attention tensor shapes");
-            apr_metadata.num_kv_heads = Some(v);
         }
     }
     if apr_metadata.vocab_size.is_none() {
@@ -101,6 +146,61 @@ fn infer_missing_gguf_dims_from_shapes(
         if let Some(v) = inferred.intermediate_size {
             eprintln!("[PMAT-920] intermediate_size missing from APR metadata — inferred {v} from FFN tensor shapes");
             apr_metadata.intermediate_size = Some(v);
+        }
+    }
+    // NOTE: deliberately NOT copying inferred.num_heads / inferred.num_kv_heads
+    // here — those come from the [64,128,96,80] head_dim guess in
+    // infer_head_counts and are silently-wrong. Head counts are filled only by
+    // fill_head_counts_from_explicit_head_dim above.
+}
+
+/// PMAT-920: derive `num_heads` / `num_kv_heads` from an EXPLICIT `head_dim`.
+///
+/// SOUND because `head_dim` is given: `num_heads = q_dim / head_dim`,
+/// `num_kv_heads = kv_dim / head_dim`. Only fills fields that are `None`;
+/// explicit metadata always wins. Returns without touching head counts when
+/// `head_dim` is absent — the caller then hard-fails via `missing_num_heads_err`
+/// rather than guessing.
+fn fill_head_counts_from_explicit_head_dim(
+    reader: &crate::format::v2::AprV2Reader,
+    apr_metadata: &mut crate::format::v2::AprV2Metadata,
+) {
+    if apr_metadata.num_heads.is_some() && apr_metadata.num_kv_heads.is_some() {
+        return;
+    }
+    let Some(head_dim) = apr_metadata.head_dim else {
+        // No explicit head_dim → NOT inferable. Do not guess.
+        return;
+    };
+    if head_dim == 0 {
+        return;
+    }
+
+    let q_dim =
+        projection_dim_from_shapes(reader, &["q_proj.weight", "query.weight", "attn_q.weight"]);
+    let kv_dim =
+        projection_dim_from_shapes(reader, &["k_proj.weight", "key.weight", "attn_k.weight"]);
+
+    if apr_metadata.num_heads.is_none() {
+        if let Some(q) = q_dim {
+            if q.is_multiple_of(head_dim) {
+                let n = q / head_dim;
+                eprintln!(
+                    "[PMAT-920] num_heads missing — derived {n} = q_dim({q}) / explicit head_dim({head_dim})"
+                );
+                apr_metadata.num_heads = Some(n);
+            }
+        }
+    }
+    if apr_metadata.num_kv_heads.is_none() {
+        if let Some(kv) = kv_dim {
+            if kv.is_multiple_of(head_dim) {
+                let n = kv / head_dim;
+                eprintln!(
+                    "[PMAT-920] num_kv_heads missing — derived {n} = kv_dim({kv}) / explicit head_dim({head_dim})"
+                );
+                apr_metadata.num_kv_heads = Some(n);
+            }
         }
     }
 }
@@ -118,7 +218,7 @@ fn build_gguf_arch_metadata(
     let arch = resolve_architecture(apr_metadata);
     let hidden_size = apr_metadata.hidden_size.ok_or_else(|| missing_dim_err("hidden_size"))?;
     let num_layers = apr_metadata.num_layers.ok_or_else(|| missing_dim_err("num_layers"))?;
-    let num_heads = apr_metadata.num_heads.ok_or_else(|| missing_dim_err("num_heads"))?;
+    let num_heads = apr_metadata.num_heads.ok_or_else(missing_num_heads_err)?;
     let num_kv_heads = apr_metadata.num_kv_heads.unwrap_or(num_heads);
     let vocab_size = apr_metadata.vocab_size.ok_or_else(|| missing_dim_err("vocab_size"))?;
     let intermediate_size =
@@ -503,7 +603,7 @@ fn export_apr_to_gguf_raw(input: &Path, output: &Path) -> Result<ExportReport> {
 
     let arch = resolve_architecture(&apr_metadata);
     let num_layers = apr_metadata.num_layers.ok_or_else(|| missing_dim_err("num_layers"))?;
-    let num_heads = apr_metadata.num_heads.ok_or_else(|| missing_dim_err("num_heads"))?;
+    let num_heads = apr_metadata.num_heads.ok_or_else(missing_num_heads_err)?;
     let num_kv_heads = apr_metadata.num_kv_heads.unwrap_or(num_heads);
     let hidden_size = apr_metadata.hidden_size.ok_or_else(|| missing_dim_err("hidden_size"))?;
 


### PR DESCRIPTION
## Bug (EV#4 — user-facing export correctness)

`apr export --format gguf model.apr -o out.gguf` **hard-fails** with a
C-07 `num_heads required for GGUF export (missing in APR metadata)` error
on any `.apr` whose metadata block lacks explicit `num_heads` (and other
GGUF-required dims). A user who trained or `apr convert`ed a `.apr`
without a fully-populated header could not export it to GGUF for
llama.cpp / ollama at all — even though the tensor shapes carry those
dimensions unambiguously.

## Fix

In the APR→GGUF raw passthrough path (`export_apr_to_gguf_raw`), add
`infer_missing_gguf_dims_from_shapes`, which reuses the existing
shape-inference engine (`infer_model_config_from_tensors`) to derive the
missing GGUF-required dimensions from tensor shapes before the C-07 error
fires:

- `num_heads` / `num_kv_heads` from q/k/v projection shapes (via `head_dim`)
- `hidden_size` / `vocab_size` from the embedding shape
- `intermediate_size` from the FFN gate/up shapes

Explicit APR metadata always wins; inference only fills `None` fields.
Shapes are interpreted row-major (LAYOUT-001), consistent with import.
(The non-raw `export_to_gguf` path already inferred via
`resolve_gguf_config`; this closes the gap in the raw passthrough path,
which still hard-failed.)

## Falsifier (RED→GREEN, mutation-verified)

`FALSIFY-EXPORT-INFER-METADATA-001`
(`ft_apr_gguf_export_infers_heads_when_metadata_light`): a metadata-light
`.apr` (`num_heads=None`; shapes imply 2 heads / 1 kv head / hidden 128)
now exports to GGUF **and** the produced GGUF re-reads with the correct
`attention.head_count` (2) / `head_count_kv` (1) / `embedding_length` (128).

- **RED** on the unfixed exporter (C-07 hard-fail).
- **GREEN** on the fix.
- **Mutation-verified**: reverting the inference call drives the falsifier RED.

## Contract

`contracts/apr-export-num-layers-v1.yaml` bumped to 1.1.0 — new equation
`attn_dim_inference`, a proof obligation, and the single-line falsifier
ref. `pv validate` + `pv lint contracts/` pass (0 errors).

## Tests

- `cargo test -p aprender-core --lib` — 14000 pass
- `cargo test -p apr-cli --lib` — 5993 pass
- all existing `export_apr_to_gguf_raw` tests still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)