### PR TITLE
fix(autograd): route nn-layer functional::* activations through autograd-aware Tensor ops (sever-graph sweep, PMAT-922)

### DIFF
--- a/contracts/transformer-end-to-end-trainable-v1.yaml
+++ b/contracts/transformer-end-to-end-trainable-v1.yaml
@@ -20,10 +20,22 @@ metadata:
     identical tanh GELU approximation, so forward numerics are unchanged; only
     the backward edge is restored). This contract guards the composed graph, not
     a single layer.
+    PMAT-922 extends this contract with the severed-graph CLASS sweep: the SAME
+    Tensor::from_vec sever pattern recurs in (1) TransformerDecoderLayer's FFN
+    (the decoder twin of the PMAT-921 encoder gelu), (2) the Dropout layer's
+    training-mode forward, and (3) nn::functional::dropout (used by attention's
+    apply_dropout) — each rebuilt its output as a fresh leaf with no grad_fn,
+    freezing every parameter upstream of it in any real training run. Fixes route
+    gelu through Tensor::gelu and dropout through a constant mask applied via the
+    autograd-aware Tensor::mul (identical forward numerics, backward edge restored).
   references:
   - "crates/aprender-core/src/nn/transformer/mod.rs"
+  - "crates/aprender-core/src/nn/transformer/positional_encoding.rs"
+  - "crates/aprender-core/src/nn/dropout/mod.rs"
+  - "crates/aprender-core/src/nn/functional.rs"
   - "crates/aprender-core/src/autograd/ops/activation.rs"
   - "crates/aprender-core/src/nn/transformer/tests_e2e_training_smoke.rs"
+  - "crates/aprender-core/src/nn/transformer/tests_decoder_grad_flow.rs"
 version: 1
 status: enforced
 date: 2026-06-24
@@ -55,6 +67,26 @@ proof_obligations:
       though the loss still drops via the FFN+lm_head — proving guard (b) is an
       independent severed-graph detector that per-layer gradchecks miss in
       composition. The correct autograd-aware Tensor::gelu path is GREEN.
+  - type: invariant
+    property: >
+      OBLIG-FUNCTIONAL-GELU-BACKWARD-GRAD (PMAT-922 decoder twin): in
+      TransformerDecoderLayer::forward_with_memory with dropout disabled, the FFN
+      activation is the only non-autograd op left on the FFN path. Routing it
+      through Tensor::gelu (NOT nn::functional::gelu / the local gelu helper, which
+      build the output via Tensor::from_vec) MUST let gradient reach linear1.weight
+      and norm3.gamma (both UPSTREAM of the FFN gelu) while linear2.weight
+      (downstream) also receives gradient. A severed gelu gives linear2 a gradient
+      but leaves linear1/norm3 frozen.
+  - type: invariant
+    property: >
+      OBLIG-FUNCTIONAL-DROPOUT-BACKWARD-GRAD (PMAT-922): in TRAINING mode with
+      p>0, both the Dropout layer's forward and nn::functional::dropout MUST route
+      gradient back to their input. The inverted-dropout mask is built as a CONSTANT
+      tensor (0 where dropped, 1/(1-p) where kept) and applied via the autograd-aware
+      Tensor::mul, recording a MulBackward edge. The previous Tensor::new /
+      Tensor::from_vec path produced a fresh leaf with no grad_fn, severing the
+      graph and freezing every parameter upstream of any training-mode dropout.
+      Forward numerics are identical (per-element input * mask = the old scaled value).
 
 falsification_tests:
   - id: FALSIFY-TRANSFORMER-END-TO-END-TRAINABLE-001
@@ -63,3 +95,21 @@ falsification_tests:
     test_harness: "cargo test -p aprender-core --lib tiny_transformer_trains_to_decreasing_loss_all_params_update"
     expected_output: "test result: ok"
     if_fails: "A layer's gradient is severed in composition (e.g. an FFN GELU or residual-add built via Tensor::from_vec). Route the offending op through its autograd-aware Tensor method so the backward edge is recorded and the upstream parameter is trainable end-to-end."
+  - id: FALSIFY-FUNCTIONAL-GELU-BACKWARD-GRAD-002
+    name: decoder_ffn_gelu_grad_flows_to_linear1_and_norm3
+    prediction: "With dropout off, TransformerDecoderLayer's FFN gelu routes gradient to linear1.weight and norm3.gamma (upstream) as well as linear2.weight (downstream)"
+    test_harness: "cargo test -p aprender-core --lib decoder_ffn_gelu_grad_flows_to_linear1_and_norm3"
+    expected_output: "test result: ok"
+    if_fails: "The decoder FFN gelu is severing the graph (Tensor::from_vec). Route it through Tensor::gelu like the PMAT-921 encoder fix."
+  - id: FALSIFY-FUNCTIONAL-DROPOUT-BACKWARD-GRAD-003
+    name: dropout_layer_grad_flows_to_input_in_training_mode
+    prediction: "Dropout layer forward in training mode (p>0) routes a finite non-zero gradient back to its input"
+    test_harness: "cargo test -p aprender-core --lib dropout_layer_grad_flows_to_input_in_training_mode"
+    expected_output: "test result: ok"
+    if_fails: "Dropout::forward is severing the graph (Tensor::new). Apply the inverted-dropout mask via Tensor::mul so a MulBackward edge is recorded."
+  - id: FALSIFY-FUNCTIONAL-DROPOUT-BACKWARD-GRAD-004
+    name: functional_dropout_grad_flows_to_input
+    prediction: "nn::functional::dropout (training=true, p>0) routes a finite non-zero gradient back to its input"
+    test_harness: "cargo test -p aprender-core --lib functional_dropout_grad_flows_to_input"
+    expected_output: "test result: ok"
+    if_fails: "nn::functional::dropout is severing the graph (Tensor::from_vec). Apply the inverted-dropout mask via Tensor::mul so a MulBackward edge is recorded."

--- a/crates/aprender-core/src/nn/dropout/mod.rs
+++ b/crates/aprender-core/src/nn/dropout/mod.rs
@@ -109,19 +109,28 @@ impl Module for Dropout {
         let mut rng = self.rng.lock().expect("Dropout RNG lock poisoned");
         let scale = 1.0 / (1.0 - self.p);
 
-        let data: Vec<f32> = input
+        // PMAT-922 (severed-graph sweep): build the inverted-dropout mask as a
+        // CONSTANT tensor (0 where dropped, `scale` where kept) and apply it via
+        // the autograd-aware `Tensor::mul`. The previous `Tensor::new(&data, ...)`
+        // path baked the scaled values into a fresh leaf with no grad_fn, SEVERING
+        // the graph and freezing every parameter upstream of any training-mode
+        // dropout. The mask is a non-grad constant, so `input.mul(&mask)` is
+        // numerically identical (per-element x*mask) but records a MulBackward edge
+        // routing gradient straight through the kept elements.
+        let mask_data: Vec<f32> = input
             .data()
             .iter()
-            .map(|&x| {
+            .map(|_| {
                 if rng.random::<f32>() < self.p {
                     0.0
                 } else {
-                    x * scale
+                    scale
                 }
             })
             .collect();
 
-        Tensor::new(&data, input.shape())
+        let mask = Tensor::new(&mask_data, input.shape());
+        input.mul(&mask)
     }
 
     fn train(&mut self) {

--- a/crates/aprender-core/src/nn/functional.rs
+++ b/crates/aprender-core/src/nn/functional.rs
@@ -339,19 +339,22 @@ pub fn dropout(x: &Tensor, p: f32, training: bool) -> Tensor {
     let mut rng = rand::rng();
     let scale = 1.0 / (1.0 - p);
 
-    let data: Vec<f32> = x
+    // PMAT-922 (severed-graph sweep): build the inverted-dropout mask as a
+    // CONSTANT tensor and apply it via the autograd-aware `Tensor::mul`. The
+    // previous `Tensor::from_vec` path produced a fresh leaf with no grad_fn,
+    // SEVERING the graph (and freezing everything upstream) whenever dropout ran
+    // inside a training forward pass — e.g. attention's `apply_dropout`. The mask
+    // is a non-grad constant, so `x.mul(&mask)` is numerically identical (per-
+    // element v*mask) yet records a MulBackward edge that routes gradient through
+    // the kept elements.
+    let mask_data: Vec<f32> = x
         .data()
         .iter()
-        .map(|&v| {
-            if rng.random::<f32>() < p {
-                0.0
-            } else {
-                v * scale
-            }
-        })
+        .map(|_| if rng.random::<f32>() < p { 0.0 } else { scale })
         .collect();
 
-    Tensor::from_vec(data, x.shape())
+    let mask = Tensor::from_vec(mask_data, x.shape());
+    x.mul(&mask)
 }
 
 /// Layer normalization over the last dimension of an ND tensor.

--- a/crates/aprender-core/src/nn/transformer/positional_encoding.rs
+++ b/crates/aprender-core/src/nn/transformer/positional_encoding.rs
@@ -55,7 +55,13 @@ impl TransformerDecoderLayer {
         // Feed-forward
         let tgt_norm = self.norm3.forward(&tgt);
         let ff_out = self.linear1.forward(&tgt_norm);
-        let ff_out = gelu(&ff_out);
+        // PMAT-922 (decoder twin of PMAT-921): use the autograd-aware Tensor::gelu,
+        // NOT the local `gelu` helper / nn::functional::gelu, which builds its
+        // output via Tensor::from_vec and SEVERS the graph — freezing linear1 +
+        // norm3 in any end-to-end decoder training run. Both paths use the
+        // identical tanh GELU approximation, so forward numerics are unchanged;
+        // only the backward edge is restored.
+        let ff_out = ff_out.gelu();
         let ff_out = self.dropout.forward(&ff_out);
         let ff_out = self.linear2.forward(&ff_out);
         let ff_out = self.dropout3.forward(&ff_out);

--- a/crates/aprender-core/src/nn/transformer/positional_encoding.rs
+++ b/crates/aprender-core/src/nn/transformer/positional_encoding.rs
@@ -493,11 +493,6 @@ pub(crate) fn reshape_from_attention(
     result
 }
 
-/// ONE PATH: Delegates to `nn::functional::gelu` (UCBD §4).
-pub(super) fn gelu(x: &Tensor) -> Tensor {
-    crate::nn::functional::gelu(x)
-}
-
 /// Compute sinusoidal positional encoding.
 fn compute_positional_encoding(d_model: usize, max_len: usize) -> Tensor {
     let mut pe = vec![0.0; max_len * d_model];

--- a/crates/aprender-core/src/nn/transformer/tests.rs
+++ b/crates/aprender-core/src/nn/transformer/tests.rs
@@ -444,6 +444,8 @@ mod tests_attention_backward_gradflow;
 mod tests_attention_contract;
 #[path = "tests_attention_scaling_contract.rs"]
 mod tests_attention_scaling_contract;
+#[path = "tests_decoder_grad_flow.rs"]
+mod tests_decoder_grad_flow;
 #[path = "tests_decoder_rope.rs"]
 mod tests_decoder_rope;
 #[path = "tests_e2e_training_smoke.rs"]

--- a/crates/aprender-core/src/nn/transformer/tests_alibi_mha.rs
+++ b/crates/aprender-core/src/nn/transformer/tests_alibi_mha.rs
@@ -264,7 +264,10 @@ fn test_add_tensors() {
 #[test]
 fn test_gelu_activation() {
     let x = Tensor::new(&[0.0, 1.0, -1.0], &[3]);
-    let y = gelu(&x);
+    // PMAT-922: the local `gelu` wrapper was removed (its sole production caller
+    // now uses the autograd-aware Tensor::gelu). Exercise the canonical functional
+    // GELU directly — identical tanh approximation, same numerics.
+    let y = crate::nn::functional::gelu(&x);
     // GELU(0) ≈ 0
     assert!((y.data()[0] - 0.0).abs() < 0.01);
     // GELU(1) ≈ 0.841

--- a/crates/aprender-core/src/nn/transformer/tests_decoder_grad_flow.rs
+++ b/crates/aprender-core/src/nn/transformer/tests_decoder_grad_flow.rs
@@ -1,0 +1,136 @@
+//! PMAT-922: severed-graph sweep — grad-flow guards for the functional::*
+//! activations used INSIDE nn layer forward paths.
+//!
+//! PMAT-921 proved the ENCODER FFN's `nn::functional::gelu` severed the autograd
+//! graph (builds its output via `Tensor::from_vec`, no grad_fn) and fixed the
+//! encoder by routing through the autograd-aware `Tensor::gelu`. This sweep
+//! closes the CLASS: the DECODER layer has the exact same severed `gelu(&ff_out)`
+//! call, and `Dropout::forward` severs in training mode via `Tensor::new`.
+//!
+//! Each guard below trains/back-props a layer and asserts a specific upstream
+//! param receives a finite, non-zero gradient. RED on the severed version,
+//! GREEN on the autograd-aware fix.
+
+use crate::autograd;
+use crate::autograd::Tensor;
+use crate::nn::transformer::TransformerDecoderLayer;
+use crate::nn::Module;
+
+/// Deterministic small fill so the test is CI-stable (no RNG).
+fn filled(n: usize, seed: f32) -> Vec<f32> {
+    (0..n)
+        .map(|i| ((i as f32) * 0.013 + seed).sin() * 0.1)
+        .collect()
+}
+
+/// Returns true iff the tensor with `id` received a finite, non-zero gradient.
+fn saw_grad(id: autograd::TensorId) -> bool {
+    autograd::get_grad(id).is_some_and(|g| {
+        let gd = g.data();
+        gd.iter().all(|v| v.is_finite()) && gd.iter().any(|&v| v.abs() > 1e-12)
+    })
+}
+
+/// GELU-SEVER GUARD: with dropout OFF (eval), the only non-autograd op left on
+/// the FFN path is `gelu`. If `gelu` severs the graph, gradient cannot reach
+/// `linear1.weight` / `norm3.gamma` (everything UPSTREAM of the FFN's gelu),
+/// even though `linear2` (downstream of gelu) still gets a gradient.
+///
+/// This is the decoder twin of the PMAT-921 encoder bug.
+#[test]
+fn decoder_ffn_gelu_grad_flows_to_linear1_and_norm3() {
+    const D: usize = 8;
+    const HEADS: usize = 2;
+    const FFN: usize = 16;
+    const SEQ: usize = 4;
+
+    let mut layer = TransformerDecoderLayer::new(D, HEADS, FFN);
+    // eval() => all Dropout::forward become identity clones (no sever), so the
+    // ONLY remaining graph-severing candidate on the FFN path is gelu.
+    layer.eval();
+
+    autograd::clear_graph();
+
+    let tgt = Tensor::new(&filled(SEQ * D, 0.1), &[1, SEQ, D]).requires_grad();
+    let out = layer.forward(&tgt);
+    let loss = out.sum();
+    loss.backward();
+
+    // linear1 (FFN in-projection) and norm3 (the pre-FFN LayerNorm) are UPSTREAM
+    // of the FFN gelu. With a severed gelu they get NO gradient.
+    // Decoder parameters() order: self_attn(q,k,v,out × {w,b}=8) + cross_attn(8) +
+    // linear1{w,b}=16,17 + linear2{w,b}=18,19 + norm1{γ,β}=20,21 + norm2=22,23 +
+    // norm3{γ,β}=24,25.
+    let params = layer.parameters();
+    assert_eq!(
+        params.len(),
+        26,
+        "decoder param layout changed; update indices"
+    );
+    let linear1_w = params[16].id(); // linear1.weight (upstream of FFN gelu)
+    let linear2_w = params[18].id(); // linear2.weight (downstream of gelu)
+    let norm3_gamma = params[24].id(); // norm3.gamma (pre-FFN LayerNorm, upstream of gelu)
+
+    assert!(
+        saw_grad(linear2_w),
+        "linear2 (downstream of gelu) must always get a gradient — if not, the \
+         test wiring is wrong, not the gelu edge"
+    );
+    assert!(
+        saw_grad(linear1_w),
+        "linear1.weight got NO gradient — the FFN gelu SEVERED the autograd graph \
+         (PMAT-922 decoder twin of PMAT-921). Route gelu through Tensor::gelu."
+    );
+    assert!(
+        saw_grad(norm3_gamma),
+        "norm3.gamma got NO gradient — the FFN gelu SEVERED the autograd graph \
+         upstream of the pre-FFN LayerNorm (PMAT-922)."
+    );
+}
+
+/// DROPOUT-SEVER GUARD (Dropout layer): in TRAINING mode with p>0, the layer's
+/// forward must route gradient back to its input. The old `Tensor::new(scaled)`
+/// path produced a fresh leaf with no grad_fn, severing the graph and freezing
+/// every parameter upstream of any training-mode dropout. The mask+mul fix
+/// records a MulBackward edge.
+#[test]
+fn dropout_layer_grad_flows_to_input_in_training_mode() {
+    use crate::nn::Dropout;
+
+    autograd::clear_graph();
+
+    // Deterministic seed so exactly-zero-everywhere (which would also "sever"
+    // benignly) cannot happen by chance: with p=0.5 over 64 elems some are kept.
+    let mut d = Dropout::with_seed(0.5, 0xC0FFEE);
+    d.train();
+
+    let x = Tensor::new(&filled(64, 0.2), &[8, 8]).requires_grad();
+    let y = d.forward(&x);
+    let loss = y.sum();
+    loss.backward();
+
+    assert!(
+        saw_grad(x.id()),
+        "Dropout(train, p>0) SEVERED the autograd graph — its input got NO \
+         gradient. Apply the mask via Tensor::mul, not Tensor::new (PMAT-922)."
+    );
+}
+
+/// DROPOUT-SEVER GUARD (functional::dropout): the canonical functional dropout
+/// (used by attention's `apply_dropout`) must also record a backward edge.
+#[test]
+fn functional_dropout_grad_flows_to_input() {
+    autograd::clear_graph();
+
+    let x = Tensor::new(&filled(64, 0.3), &[8, 8]).requires_grad();
+    // training=true, p>0 => the masking branch (the severed branch pre-fix).
+    let y = crate::nn::functional::dropout(&x, 0.5, true);
+    let loss = y.sum();
+    loss.backward();
+
+    assert!(
+        saw_grad(x.id()),
+        "nn::functional::dropout SEVERED the autograd graph — input got NO \
+         gradient. Apply the mask via Tensor::mul, not Tensor::from_vec (PMAT-922)."
+    );
+}


### PR DESCRIPTION
## Severed-graph sweep (PMAT-922)

Stacked on #2213 (PMAT-921). PMAT-921 proved the ENCODER FFN's `nn::functional::gelu` severed the autograd graph (builds output via `Tensor::from_vec`, no grad_fn) — freezing `ffn.linear1` + `norm2` in every real end-to-end training run while the isolated per-layer gradcheck stayed green. That is a **CLASS**: any nn LAYER whose forward calls a functional helper that rebuilds its output as a fresh leaf (`Tensor::from_vec`/`Tensor::new`) severs autograd for everything upstream. This PR enumerates the rest and fixes them.

### Enumeration (`functional::*` from `crates/aprender-core/src/nn/**` forward paths)
| call site | verdict |
|---|---|
| `rnn.rs` sigmoid/tanh → `x.sigmoid()`/`x.tanh_()` | autograd-aware ✓ |
| `transformer/mod.rs` `softmax_last_dim` (records `SoftmaxLastDimBackward`, PMAT-914) | not severed ✓ |
| `normalization` layer_norm / group_norm rms_norm | already fixed (PMAT-907) ✓ |
| encoder FFN gelu | fixed by PMAT-921 ✓ |
| **decoder FFN `gelu(&ff_out)`** (`positional_encoding.rs`) | **SEVERED** → `Tensor::gelu` |
| **`Dropout::forward`** train-mode (`dropout/mod.rs`) | **SEVERED** → mask + `Tensor::mul` |
| **`nn::functional::dropout`** (attention `apply_dropout`) | **SEVERED** → mask + `Tensor::mul` |

### Fixes
All three preserve forward numerics exactly (`x*mask` == old scaled value; `Tensor::gelu` uses the identical tanh GELU approximation). Only the backward edge is restored.

### Falsifiers (RED on bug, GREEN on fix, mutation-verified)
- `decoder_ffn_gelu_grad_flows_to_linear1_and_norm3` — severed decoder gelu gives linear2 (downstream) a gradient but freezes linear1.weight + norm3.gamma (upstream).
- `dropout_layer_grad_flows_to_input_in_training_mode`
- `functional_dropout_grad_flows_to_input`

All 14007 `aprender-core` lib tests pass.

### Contract
`transformer-end-to-end-trainable-v1.yaml` extended with `OBLIG-FUNCTIONAL-GELU-BACKWARD-GRAD` (decoder) + `OBLIG-FUNCTIONAL-DROPOUT-BACKWARD-GRAD` and single-line falsifier refs 002/003/004. `pv validate`: 0 err / 0 warn; `pv lint contracts/`: PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)