### PR TITLE
feat(serve): wire Ollama /api/chat + /api/generate so apr serve is a drop-in Ollama HTTP replacement (PMAT-923)

### DIFF
--- a/contracts/apr-serve-openai-compat-v1.yaml
+++ b/contracts/apr-serve-openai-compat-v1.yaml
@@ -1,7 +1,7 @@
 contract: apr-serve-openai-compat
 metadata:
   kind: pattern
-  version: "1.12.0"
+  version: "1.13.0"
   description: >
     OpenAI-compatible serve layer (/v1/chat/completions, /v1/completions,
     /v1/embeddings) fidelity invariants. Established by an adversarial audit
@@ -170,6 +170,22 @@ proof_obligations:
       batch of N inputs returns N REAL model-backed embeddings (each per-input vector
       equals the single-input embedding for that text), composing EMBEDDINGS-MODEL-BACKED
       with batch input.
+  - type: invariant
+    property: >
+      OLLAMA-API-CHAT-GENERATE-ROUTED (PMAT-923, DISCHARGED): the realizar serve
+      router (create_router_with_config, the router `apr serve` mounts via
+      realizar::api::create_router) wires Ollama's native HTTP endpoints
+      `POST /api/chat` and `POST /api/generate` whenever the OpenAI-compat block is
+      enabled, so an Ollama HTTP client can use `apr serve` as a drop-in replacement.
+      Both routes delegate generation to the SAME backend chain as
+      `/v1/chat/completions` (openai_chat_completions_handler) and re-shape the result
+      into Ollama's wire schema: `/api/chat` returns
+      `{model, created_at, message:{role:"assistant", content}, done:true,
+      prompt_eval_count, eval_count}`; `/api/generate` returns the flat
+      `{model, created_at, response, done:true, prompt_eval_count, eval_count}` (no
+      nested message). A wired route is observably distinct from the axum `not_found`
+      fallback (which carries no `done` field) even when no model is loaded, because
+      the Ollama handler always emits a terminal (`done:true`) Ollama-shaped body.
 
 falsification_tests:
   - id: FALSIFY-STOP-TRUNCATE-754
@@ -238,3 +254,15 @@ falsification_tests:
     test_harness: 'cargo test -p aprender-serve --lib batch_inputs_each_real_model_backed'
     expected_output: "test result: ok"
     if_fails: 'The batch embedding loop emits the positional token-ID hash (384-dim, no semantic structure) per input instead of the real model-backed hidden state, OR drops/reorders indices, OR fails to sum usage — i.e. PMAT-802 batch input was wired but PMAT-803 real embeddings were not composed into the per-input path.'
+  - id: FALSIFY-OLLAMA-API-CHAT-ROUTED-923
+    name: api_chat_is_routed_and_returns_ollama_shape
+    prediction: 'POST /api/chat on the realizar serve router (AppState::demo) is ROUTED — it does NOT return the axum 404 not_found fallback — and answers 200 with an Ollama-shaped JSON body: done==true, message.role=="assistant", message.content present, model echoed. RED on the unwired router (404, no message/done fields); GREEN once create_router_with_config wires /api/chat to ollama_chat_handler.'
+    test_harness: 'cargo test -p aprender-serve --test ollama_http_compat api_chat_is_routed_and_returns_ollama_shape'
+    expected_output: "test result: ok"
+    if_fails: 'POST /api/chat returns the axum 404 not_found fallback (the pre-PMAT-923 behavior — the realizar router exposed only /v1/* so an Ollama HTTP client could not use apr serve as a drop-in), or the body is not Ollama-shaped (missing done / message.role / message.content).'
+  - id: FALSIFY-OLLAMA-API-GENERATE-ROUTED-923
+    name: api_generate_is_routed_and_returns_ollama_shape
+    prediction: 'POST /api/generate on the realizar serve router (AppState::demo) is ROUTED — not the axum 404 fallback — and answers 200 with Ollama generate schema: done==true, a flat `response` string field present, NO nested `message`, model echoed. RED on the unwired router (404); GREEN once create_router_with_config wires /api/generate to ollama_generate_handler.'
+    test_harness: 'cargo test -p aprender-serve --test ollama_http_compat api_generate_is_routed_and_returns_ollama_shape'
+    expected_output: "test result: ok"
+    if_fails: 'POST /api/generate returns the axum 404 not_found fallback (the pre-PMAT-923 behavior), or the body is not Ollama generate-shaped (missing done / flat response, or it nests a message object).'

--- a/contracts/apr-serve-openai-compat-v1.yaml
+++ b/contracts/apr-serve-openai-compat-v1.yaml
@@ -1,7 +1,7 @@
 contract: apr-serve-openai-compat
 metadata:
   kind: pattern
-  version: "1.13.0"
+  version: "1.14.0"
   description: >
     OpenAI-compatible serve layer (/v1/chat/completions, /v1/completions,
     /v1/embeddings) fidelity invariants. Established by an adversarial audit
@@ -172,20 +172,36 @@ proof_obligations:
       with batch input.
   - type: invariant
     property: >
-      OLLAMA-API-CHAT-GENERATE-ROUTED (PMAT-923, DISCHARGED): the realizar serve
-      router (create_router_with_config, the router `apr serve` mounts via
-      realizar::api::create_router) wires Ollama's native HTTP endpoints
-      `POST /api/chat` and `POST /api/generate` whenever the OpenAI-compat block is
-      enabled, so an Ollama HTTP client can use `apr serve` as a drop-in replacement.
-      Both routes delegate generation to the SAME backend chain as
-      `/v1/chat/completions` (openai_chat_completions_handler) and re-shape the result
-      into Ollama's wire schema: `/api/chat` returns
+      OLLAMA-API-ROUTED-ON-APR-SERVE (PMAT-923, DISCHARGED, non-streaming only):
+      `apr serve <model>` does NOT mount realizar's create_router — it builds its
+      OWN bespoke axum routers in crates/apr-cli/src/commands/serve/ (the APR-CPU
+      router build_apr_cpu_router, the CUDA-fallback build_gpu_router, the WGPU
+      router, and the single-file + sharded SafeTensors routers). Ollama's native
+      HTTP endpoints `POST /api/chat` and `POST /api/generate` (plus `GET /api/tags`)
+      are therefore wired at EACH of those routers, alongside their existing
+      `/v1/chat/completions` route — verified by `grep '"/api/'
+      crates/apr-cli/src/commands/serve/` returning > 0 (and by the apr-cli e2e
+      falsifier below, which drives the REAL build_apr_cpu_router). Each Ollama route
+      delegates generation to the SAME chat backend that router uses for
+      `/v1/chat/completions` (apr-cli adapters in serve/ollama.rs translate the Ollama
+      request into the OpenAI-chat JSON the existing chat handler consumes, then
+      re-shape the OpenAI response): `/api/chat` returns
       `{model, created_at, message:{role:"assistant", content}, done:true,
       prompt_eval_count, eval_count}`; `/api/generate` returns the flat
       `{model, created_at, response, done:true, prompt_eval_count, eval_count}` (no
       nested message). A wired route is observably distinct from the axum `not_found`
       fallback (which carries no `done` field) even when no model is loaded, because
       the Ollama handler always emits a terminal (`done:true`) Ollama-shaped body.
+      SCOPE (HONEST): the Ollama endpoints return a single COALESCED non-streaming
+      body today (the underlying chat path is driven with stream:false regardless of
+      the client's `stream` flag). NDJSON `stream:true` Ollama streaming is a
+      documented FOLLOW-UP and is NOT claimed here — this obligation covers
+      "Ollama /api/chat + /api/generate routed on the apr serve routers + correct
+      non-streaming Ollama wire shape", not full drop-in streaming parity. The
+      reusable realizar-side handlers (aprender-serve/src/api/ollama_handlers.rs) and
+      their wiring into create_router_with_config remain for any caller that DOES
+      mount realizar's router (e.g. `realizar serve`), but are NOT the path
+      `apr serve` exercises.
 
 falsification_tests:
   - id: FALSIFY-STOP-TRUNCATE-754
@@ -256,13 +272,13 @@ falsification_tests:
     if_fails: 'The batch embedding loop emits the positional token-ID hash (384-dim, no semantic structure) per input instead of the real model-backed hidden state, OR drops/reorders indices, OR fails to sum usage — i.e. PMAT-802 batch input was wired but PMAT-803 real embeddings were not composed into the per-input path.'
   - id: FALSIFY-OLLAMA-API-CHAT-ROUTED-923
     name: api_chat_is_routed_and_returns_ollama_shape
-    prediction: 'POST /api/chat on the realizar serve router (AppState::demo) is ROUTED — it does NOT return the axum 404 not_found fallback — and answers 200 with an Ollama-shaped JSON body: done==true, message.role=="assistant", message.content present, model echoed. RED on the unwired router (404, no message/done fields); GREEN once create_router_with_config wires /api/chat to ollama_chat_handler.'
-    test_harness: 'cargo test -p aprender-serve --test ollama_http_compat api_chat_is_routed_and_returns_ollama_shape'
+    prediction: 'POST /api/chat on the REAL apr-cli serve router (build_demo_apr_cpu_router_for_test — the exact router apr serve mounts for a .apr model, NOT realizar create_router) is ROUTED — it does NOT return the axum 404 not_found fallback — and answers 200 with an Ollama-shaped JSON body: done==true, message.role=="assistant", message.content present, NO flat response field. RED on the unwired router (404, no done/message fields); GREEN once build_apr_cpu_router wires /api/chat to the serve::ollama adapter over its own chat backend.'
+    test_harness: 'cargo test -p apr-cli --test ollama_api_serve_compat api_chat_is_routed_and_returns_ollama_shape'
     expected_output: "test result: ok"
-    if_fails: 'POST /api/chat returns the axum 404 not_found fallback (the pre-PMAT-923 behavior — the realizar router exposed only /v1/* so an Ollama HTTP client could not use apr serve as a drop-in), or the body is not Ollama-shaped (missing done / message.role / message.content).'
+    if_fails: 'POST /api/chat returns the axum 404 not_found fallback on the router apr serve actually mounts (the bug the review caught — the first PMAT-923 attempt wired only realizar create_router, which apr serve does NOT mount), or the body is not Ollama-shaped (missing done / message.role / message.content).'
   - id: FALSIFY-OLLAMA-API-GENERATE-ROUTED-923
     name: api_generate_is_routed_and_returns_ollama_shape
-    prediction: 'POST /api/generate on the realizar serve router (AppState::demo) is ROUTED — not the axum 404 fallback — and answers 200 with Ollama generate schema: done==true, a flat `response` string field present, NO nested `message`, model echoed. RED on the unwired router (404); GREEN once create_router_with_config wires /api/generate to ollama_generate_handler.'
-    test_harness: 'cargo test -p aprender-serve --test ollama_http_compat api_generate_is_routed_and_returns_ollama_shape'
+    prediction: 'POST /api/generate on the REAL apr-cli serve router (build_demo_apr_cpu_router_for_test — the router apr serve mounts, NOT realizar create_router) is ROUTED — not the axum 404 fallback — and answers 200 with Ollama generate schema: done==true, a flat `response` string field present, NO nested `message`. RED on the unwired router (404); GREEN once build_apr_cpu_router wires /api/generate to the serve::ollama adapter over its own chat backend.'
+    test_harness: 'cargo test -p apr-cli --test ollama_api_serve_compat api_generate_is_routed_and_returns_ollama_shape'
     expected_output: "test result: ok"
-    if_fails: 'POST /api/generate returns the axum 404 not_found fallback (the pre-PMAT-923 behavior), or the body is not Ollama generate-shaped (missing done / flat response, or it nests a message object).'
+    if_fails: 'POST /api/generate returns the axum 404 not_found fallback on the router apr serve actually mounts, or the body is not Ollama generate-shaped (missing done / flat response, or it nests a message object).'

--- a/crates/apr-cli/src/commands/serve/chat.rs
+++ b/crates/apr-cli/src/commands/serve/chat.rs
@@ -345,6 +345,38 @@ pub(crate) async fn safetensors_chat_completions_handler(
     )
 }
 
+/// SafeTensors Ollama `/api/chat` handler (PMAT-923).
+///
+/// Reuses the SAME generation backend as `/v1/chat/completions`
+/// ([`safetensors_chat_completions_handler`]): translate the Ollama request to
+/// the OpenAI-chat JSON that handler already consumes, run it, then re-shape the
+/// OpenAI response into Ollama's `{message:{role,content}, done}` schema.
+#[cfg(feature = "inference")]
+pub(crate) async fn safetensors_ollama_chat_handler(
+    state: axum::extract::State<SafeTensorsState>,
+    axum::Json(req): axum::Json<super::ollama::OllamaChatRequest>,
+) -> axum::response::Response {
+    let model = super::ollama::model_label(&req.model);
+    let openai_body = super::ollama::ollama_chat_to_openai(&req);
+    let inner = safetensors_chat_completions_handler(state, axum::Json(openai_body)).await;
+    super::ollama::reshape_openai_to_ollama_chat(model, inner).await
+}
+
+/// SafeTensors Ollama `/api/generate` handler (PMAT-923).
+///
+/// Same backend as `/v1/chat/completions`, emitting Ollama's flat
+/// `{response, done}` schema.
+#[cfg(feature = "inference")]
+pub(crate) async fn safetensors_ollama_generate_handler(
+    state: axum::extract::State<SafeTensorsState>,
+    axum::Json(req): axum::Json<super::ollama::OllamaGenerateRequest>,
+) -> axum::response::Response {
+    let model = super::ollama::model_label(&req.model);
+    let openai_body = super::ollama::ollama_generate_to_openai(&req);
+    let inner = safetensors_chat_completions_handler(state, axum::Json(openai_body)).await;
+    super::ollama::reshape_openai_to_ollama_generate(model, inner).await
+}
+
 /// Generate a unique request ID for OpenAI-compatible responses.
 #[cfg(feature = "inference")]
 fn generate_request_id() -> String {

--- a/crates/apr-cli/src/commands/serve/handlers.rs
+++ b/crates/apr-cli/src/commands/serve/handlers.rs
@@ -623,6 +623,9 @@ pub(crate) fn start_realizar_server(model_path: &Path, config: &ServerConfig) ->
 
             let state_health = wgpu_state.clone();
             let state_chat = wgpu_state.clone();
+            // PMAT-923: Ollama endpoints reuse the SAME wgpu chat backend.
+            let state_ollama_chat = wgpu_state.clone();
+            let state_ollama_generate = wgpu_state.clone();
 
             let app = Router::new()
                 .route(
@@ -640,6 +643,32 @@ pub(crate) fn start_realizar_server(model_path: &Path, config: &ServerConfig) ->
                     post(move |body: Json<serde_json::Value>| {
                         let state = state_chat.clone();
                         async move { wgpu_chat_completion(state, body).await }
+                    }),
+                )
+                // PMAT-923: Ollama native chat endpoint (drop-in Ollama client).
+                .route(
+                    "/api/chat",
+                    post(move |Json(req): Json<super::ollama::OllamaChatRequest>| {
+                        let state = state_ollama_chat.clone();
+                        async move {
+                            let model = super::ollama::model_label(&req.model);
+                            let openai_body = super::ollama::ollama_chat_to_openai(&req);
+                            let inner = wgpu_chat_completion(state, Json(openai_body)).await;
+                            super::ollama::reshape_openai_to_ollama_chat(model, inner).await
+                        }
+                    }),
+                )
+                // PMAT-923: Ollama native single-prompt generate endpoint.
+                .route(
+                    "/api/generate",
+                    post(move |Json(req): Json<super::ollama::OllamaGenerateRequest>| {
+                        let state = state_ollama_generate.clone();
+                        async move {
+                            let model = super::ollama::model_label(&req.model);
+                            let openai_body = super::ollama::ollama_generate_to_openai(&req);
+                            let inner = wgpu_chat_completion(state, Json(openai_body)).await;
+                            super::ollama::reshape_openai_to_ollama_generate(model, inner).await
+                        }
                     }),
                 );
 
@@ -1177,8 +1206,14 @@ fn build_apr_cpu_router(state: AprServerState, auth_gate: super::auth::AuthGate)
     use std::sync::Mutex;
 
     let state_for_health = state.clone();
+    let model_name_for_tags = state.model_name.clone();
     let state_for_completions = Arc::new(Mutex::new(state.clone()));
     let state_for_chat = Arc::new(Mutex::new(state));
+    // PMAT-923: Ollama `/api/chat` + `/api/generate` reuse the SAME chat backend
+    // as `/v1/chat/completions` (handle_apr_cpu_chat_completion), then re-shape
+    // the OpenAI response into Ollama's wire schema.
+    let state_for_ollama_chat = state_for_chat.clone();
+    let state_for_ollama_generate = state_for_chat.clone();
 
     let router = Router::new()
         .route(
@@ -1212,10 +1247,54 @@ fn build_apr_cpu_router(state: AprServerState, auth_gate: super::auth::AuthGate)
                 },
             ),
         )
+        // PMAT-923: Ollama native chat endpoint — drop-in for an Ollama client.
+        .route(
+            "/api/chat",
+            post(move |Json(req): Json<super::ollama::OllamaChatRequest>| {
+                let state = state_for_ollama_chat.clone();
+                async move {
+                    let model = super::ollama::model_label(&req.model);
+                    let openai_body = super::ollama::ollama_chat_to_openai(&req);
+                    let inner = handle_apr_cpu_chat_completion(
+                        &state,
+                        &axum::http::HeaderMap::new(),
+                        &openai_body,
+                    )
+                    .await;
+                    super::ollama::reshape_openai_to_ollama_chat(model, inner).await
+                }
+            }),
+        )
+        // PMAT-923: Ollama native single-prompt generate endpoint.
+        .route(
+            "/api/generate",
+            post(move |Json(req): Json<super::ollama::OllamaGenerateRequest>| {
+                let state = state_for_ollama_generate.clone();
+                async move {
+                    let model = super::ollama::model_label(&req.model);
+                    let openai_body = super::ollama::ollama_generate_to_openai(&req);
+                    let inner = handle_apr_cpu_chat_completion(
+                        &state,
+                        &axum::http::HeaderMap::new(),
+                        &openai_body,
+                    )
+                    .await;
+                    super::ollama::reshape_openai_to_ollama_generate(model, inner).await
+                }
+            }),
+        )
+        // PMAT-923: Ollama model-list — clients enumerate models before chatting.
+        .route(
+            "/api/tags",
+            get(move || {
+                let model = model_name_for_tags.clone();
+                async move { Json(super::ollama::ollama_tags_body(&model)) }
+            }),
+        )
         .route(
             "/",
             get(|| async {
-                "APR v2 Inference Server - POST /v1/completions, /v1/chat/completions"
+                "APR v2 Inference Server - POST /v1/completions, /v1/chat/completions, /api/chat, /api/generate"
             }),
         )
         // GH-672: Return JSON error body for unmatched routes (not empty 404)
@@ -1224,11 +1303,35 @@ fn build_apr_cpu_router(state: AprServerState, auth_gate: super::auth::AuthGate)
                 StatusCode::NOT_FOUND,
                 Json(serde_json::json!({
                     "error": "not_found",
-                    "message": "Route not found. Available: /health, /v1/completions, /v1/chat/completions"
+                    "message": "Route not found. Available: /health, /v1/completions, /v1/chat/completions, /api/chat, /api/generate, /api/tags"
                 })),
             )
         });
     super::auth::layer(auth_gate, router)
+}
+
+/// PMAT-923 e2e test seam: build the REAL `apr serve` APR-CPU router with a
+/// no-transformer demo state, exercising the exact router `apr serve <model.apr>`
+/// mounts (including the `/api/chat` + `/api/generate` Ollama routes).
+///
+/// With `transformer: None`, generation returns a backend error which the chat
+/// path surfaces as a 200 JSON `{error:...}` body — the Ollama adapter re-shapes
+/// that into a terminal (`done:true`) Ollama body. A wired Ollama route is thus
+/// observably distinct from the axum 404 fallback (which has no `done` field)
+/// even with no model loaded, which is exactly what the falsifier asserts.
+#[doc(hidden)]
+#[cfg(feature = "inference")]
+pub fn build_demo_apr_cpu_router_for_test() -> axum::Router {
+    let state = AprServerState {
+        transformer: None,
+        model_type: "demo".to_string(),
+        architecture: "demo".to_string(),
+        is_transformer: false,
+        tokenizer: None,
+        embedded_tokenizer: None,
+        model_name: "apr".to_string(),
+    };
+    build_apr_cpu_router(state, super::auth::AuthGate::disabled())
 }
 
 include!("handler_apr_cpu_completion.rs");

--- a/crates/apr-cli/src/commands/serve/handlers_include_01.rs
+++ b/crates/apr-cli/src/commands/serve/handlers_include_01.rs
@@ -323,12 +323,23 @@ fn build_gpu_router(
         Json, Router,
     };
 
+    let model_name_for_tags = cpu_state
+        .lock()
+        .map(|s| s.model_name.clone())
+        .unwrap_or_else(|_| "apr".to_string());
     let cuda_for_completions = cuda_model.clone();
     let tok_for_completions = tokenizer.clone();
     let cpu_for_completions = cpu_state.clone();
-    let cuda_for_chat = cuda_model;
-    let tok_for_chat = tokenizer;
-    let cpu_for_chat = cpu_state;
+    let cuda_for_chat = cuda_model.clone();
+    let tok_for_chat = tokenizer.clone();
+    let cpu_for_chat = cpu_state.clone();
+    // PMAT-923: Ollama endpoints reuse the SAME GPU chat backend.
+    let cuda_for_ochat = cuda_model.clone();
+    let tok_for_ochat = tokenizer.clone();
+    let cpu_for_ochat = cpu_state.clone();
+    let cuda_for_ogen = cuda_model;
+    let tok_for_ogen = tokenizer;
+    let cpu_for_ogen = cpu_state;
 
     let router = Router::new()
         .route(
@@ -359,10 +370,50 @@ fn build_gpu_router(
                 }
             }),
         )
+        // PMAT-923: Ollama native chat endpoint (drop-in Ollama client).
+        .route(
+            "/api/chat",
+            post(move |Json(req): Json<super::ollama::OllamaChatRequest>| {
+                let cuda = cuda_for_ochat.clone();
+                let tok_info = tok_for_ochat.clone();
+                let cpu = cpu_for_ochat.clone();
+                async move {
+                    let model = super::ollama::model_label(&req.model);
+                    let openai_body = super::ollama::ollama_chat_to_openai(&req);
+                    let inner =
+                        handle_gpu_chat_completion(cuda, tok_info, openai_body, cpu).await;
+                    super::ollama::reshape_openai_to_ollama_chat(model, inner).await
+                }
+            }),
+        )
+        // PMAT-923: Ollama native single-prompt generate endpoint.
+        .route(
+            "/api/generate",
+            post(move |Json(req): Json<super::ollama::OllamaGenerateRequest>| {
+                let cuda = cuda_for_ogen.clone();
+                let tok_info = tok_for_ogen.clone();
+                let cpu = cpu_for_ogen.clone();
+                async move {
+                    let model = super::ollama::model_label(&req.model);
+                    let openai_body = super::ollama::ollama_generate_to_openai(&req);
+                    let inner =
+                        handle_gpu_chat_completion(cuda, tok_info, openai_body, cpu).await;
+                    super::ollama::reshape_openai_to_ollama_generate(model, inner).await
+                }
+            }),
+        )
+        // PMAT-923: Ollama model-list — clients enumerate models before chatting.
+        .route(
+            "/api/tags",
+            get(move || {
+                let model = model_name_for_tags.clone();
+                async move { Json(super::ollama::ollama_tags_body(&model)) }
+            }),
+        )
         .route(
             "/",
             get(|| async {
-                "APR v2 GPU Inference Server - POST /v1/completions, /v1/chat/completions"
+                "APR v2 GPU Inference Server - POST /v1/completions, /v1/chat/completions, /api/chat, /api/generate"
             }),
         );
     super::auth::layer(auth_gate, router)

--- a/crates/apr-cli/src/commands/serve/mod.rs
+++ b/crates/apr-cli/src/commands/serve/mod.rs
@@ -7,6 +7,8 @@
 pub mod auth;
 #[cfg(feature = "inference")]
 pub mod handlers;
+#[cfg(feature = "inference")]
+pub mod ollama;
 pub mod routes;
 #[cfg(feature = "inference")]
 pub mod safetensors;

--- a/crates/apr-cli/src/commands/serve/ollama.rs
+++ b/crates/apr-cli/src/commands/serve/ollama.rs
@@ -1,0 +1,453 @@
+//! Ollama-compatible HTTP shims for `apr serve` (PMAT-923).
+//!
+//! `apr serve <model>` builds its OWN bespoke axum routers (one per backend:
+//! APR-CPU, GPU-fallback, WGPU, SafeTensors) — it does NOT mount realizar's
+//! `create_router`. Those routers historically exposed only the OpenAI
+//! `/v1/chat/completions` endpoint, so an Ollama HTTP client POSTing to
+//! `/api/chat` or `/api/generate` hit the axum 404 fallback and `apr serve`
+//! was NOT a drop-in Ollama replacement.
+//!
+//! This module supplies the reusable translation layer that each of those
+//! routers wires in next to its `/v1/chat/completions` route:
+//!
+//! 1. [`ollama_chat_to_openai`] / [`ollama_generate_to_openai`] turn an Ollama
+//!    request into the SAME OpenAI-chat JSON the router's existing chat handler
+//!    already consumes (`messages`, `max_tokens`, `temperature`, ...).
+//! 2. The router invokes ITS OWN chat handler (same generation backend as
+//!    `/v1/chat/completions`) on that JSON, yielding an OpenAI-shaped
+//!    [`Response`].
+//! 3. [`reshape_openai_to_ollama_chat`] / [`reshape_openai_to_ollama_generate`]
+//!    re-shape that response into Ollama's wire schema.
+//!
+//! Streaming is scoped HONESTLY: the Ollama endpoints always return a single
+//! coalesced (`done:true`) body today; NDJSON `stream:true` is a documented
+//! follow-up. The handlers always emit a terminal Ollama-shaped body (even on a
+//! backend error), so a wired route is observably distinct from the axum 404
+//! fallback (which has no `done` field).
+//!
+//! Discharges OBLIG-OLLAMA-API-ROUTED-ON-APR-SERVE in
+//! `contracts/apr-serve-openai-compat-v1.yaml`.
+
+use axum::{
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    Json,
+};
+use serde::{Deserialize, Serialize};
+
+// ============================================================================
+// Ollama wire types
+// ============================================================================
+
+/// Ollama `/api/chat` request.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct OllamaChatRequest {
+    /// Model tag. Optional — defaults to the loaded model.
+    #[serde(default)]
+    pub model: Option<String>,
+    /// Conversation messages.
+    #[serde(default)]
+    pub messages: Vec<OllamaMessage>,
+    /// Stream tokens (currently coalesced into a single final message).
+    #[serde(default)]
+    pub stream: bool,
+    /// Optional Ollama `options` block (temperature, num_predict, top_k, ...).
+    #[serde(default)]
+    pub options: Option<OllamaOptions>,
+}
+
+/// Ollama message (`role` + `content`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct OllamaMessage {
+    /// "system" | "user" | "assistant".
+    pub role: String,
+    /// Message text.
+    pub content: String,
+}
+
+/// Ollama `options` block (subset that maps onto our sampling config).
+#[derive(Debug, Clone, Default, Deserialize)]
+pub(crate) struct OllamaOptions {
+    /// Sampling temperature.
+    #[serde(default)]
+    pub temperature: Option<f32>,
+    /// Nucleus sampling.
+    #[serde(default)]
+    pub top_p: Option<f32>,
+    /// Top-k sampling.
+    #[serde(default)]
+    pub top_k: Option<u32>,
+    /// Ollama's name for max tokens.
+    #[serde(default)]
+    pub num_predict: Option<u32>,
+}
+
+/// Ollama `/api/generate` request (single prompt, non-chat).
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct OllamaGenerateRequest {
+    /// Model tag. Optional — defaults to the loaded model.
+    #[serde(default)]
+    pub model: Option<String>,
+    /// The prompt to complete.
+    #[serde(default)]
+    pub prompt: String,
+    /// Optional system preamble.
+    #[serde(default)]
+    pub system: Option<String>,
+    /// Stream tokens (currently coalesced into a single final response).
+    #[serde(default)]
+    pub stream: bool,
+    /// Optional Ollama `options` block.
+    #[serde(default)]
+    pub options: Option<OllamaOptions>,
+}
+
+/// Ollama `/api/chat` response.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct OllamaChatResponse {
+    /// Model tag echoed back.
+    pub model: String,
+    /// RFC-3339-style creation timestamp.
+    pub created_at: String,
+    /// The assistant turn.
+    pub message: OllamaMessage,
+    /// Terminal flag — always true for the coalesced response.
+    pub done: bool,
+    /// Prompt token count.
+    pub prompt_eval_count: usize,
+    /// Generated token count.
+    pub eval_count: usize,
+}
+
+/// Ollama `/api/generate` response.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct OllamaGenerateResponse {
+    /// Model tag echoed back.
+    pub model: String,
+    /// RFC-3339-style creation timestamp.
+    pub created_at: String,
+    /// The generated text (flat, not nested in a message object).
+    pub response: String,
+    /// Terminal flag — always true for the coalesced response.
+    pub done: bool,
+    /// Prompt token count.
+    pub prompt_eval_count: usize,
+    /// Generated token count.
+    pub eval_count: usize,
+}
+
+// ============================================================================
+// Conversion helpers (pure — unit-tested)
+// ============================================================================
+
+/// RFC-3339-style timestamp for `created_at` (Ollama wire format).
+fn created_at_now() -> String {
+    let secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    // Clients only require a string field, not strict parsing.
+    format!("{secs}.000000000Z")
+}
+
+/// Default model label when the request omits `model`.
+pub(crate) fn model_label(model: &Option<String>) -> String {
+    model
+        .clone()
+        .filter(|m| !m.is_empty())
+        .unwrap_or_else(|| "apr".to_string())
+}
+
+/// Translate an Ollama `options` block onto the OpenAI sampling fields the
+/// existing `/v1/chat/completions` handlers already read off the JSON body.
+fn apply_options(
+    body: &mut serde_json::Map<String, serde_json::Value>,
+    options: &Option<OllamaOptions>,
+) {
+    let Some(opts) = options else { return };
+    if let Some(t) = opts.temperature {
+        body.insert("temperature".to_string(), serde_json::json!(t));
+    }
+    if let Some(p) = opts.top_p {
+        body.insert("top_p".to_string(), serde_json::json!(p));
+    }
+    if let Some(k) = opts.top_k {
+        body.insert("top_k".to_string(), serde_json::json!(k));
+    }
+    if let Some(n) = opts.num_predict {
+        body.insert("max_tokens".to_string(), serde_json::json!(n));
+    }
+}
+
+/// Build the OpenAI-chat JSON body from an Ollama `/api/chat` request.
+///
+/// This is the single Ollama→internal translation point; the resulting body is
+/// fed to the SAME chat handler the router uses for `/v1/chat/completions`, so
+/// generation goes through one backend path for both protocols. `stream` is
+/// forced off — we always coalesce into one final Ollama message.
+pub(crate) fn ollama_chat_to_openai(req: &OllamaChatRequest) -> serde_json::Value {
+    let mut body = serde_json::Map::new();
+    body.insert(
+        "model".to_string(),
+        serde_json::json!(model_label(&req.model)),
+    );
+    let messages: Vec<serde_json::Value> = req
+        .messages
+        .iter()
+        .map(|m| serde_json::json!({"role": m.role, "content": m.content}))
+        .collect();
+    body.insert("messages".to_string(), serde_json::json!(messages));
+    body.insert("stream".to_string(), serde_json::json!(false));
+    apply_options(&mut body, &req.options);
+    serde_json::Value::Object(body)
+}
+
+/// Build the OpenAI-chat JSON body from an Ollama `/api/generate` request,
+/// folding `system` + `prompt` into chat messages.
+pub(crate) fn ollama_generate_to_openai(req: &OllamaGenerateRequest) -> serde_json::Value {
+    let mut messages = Vec::new();
+    if let Some(system) = req.system.as_ref().filter(|s| !s.is_empty()) {
+        messages.push(serde_json::json!({"role": "system", "content": system}));
+    }
+    messages.push(serde_json::json!({"role": "user", "content": req.prompt}));
+
+    let mut body = serde_json::Map::new();
+    body.insert(
+        "model".to_string(),
+        serde_json::json!(model_label(&req.model)),
+    );
+    body.insert("messages".to_string(), serde_json::json!(messages));
+    body.insert("stream".to_string(), serde_json::json!(false));
+    apply_options(&mut body, &req.options);
+    serde_json::Value::Object(body)
+}
+
+/// Extract `(content, prompt_tokens, completion_tokens)` from the OpenAI-chat
+/// response JSON, or a fallback `(error_text, 0, 0)` when generation failed.
+///
+/// Crucially this ALWAYS yields parts for an Ollama-shaped body — even on a
+/// backend error or a missing model — so a wired route is observably distinct
+/// from the axum 404 fallback (which has no `done` field).
+fn openai_response_to_parts(status: StatusCode, body: &[u8]) -> (String, usize, usize) {
+    if let Ok(v) = serde_json::from_slice::<serde_json::Value>(body) {
+        if status.is_success() {
+            if let Some(content) = v
+                .get("choices")
+                .and_then(|c| c.get(0))
+                .and_then(|c| c.get("message"))
+                .and_then(|m| m.get("content"))
+                .and_then(|c| c.as_str())
+            {
+                let prompt_tokens = v
+                    .get("usage")
+                    .and_then(|u| u.get("prompt_tokens"))
+                    .and_then(serde_json::Value::as_u64)
+                    .unwrap_or(0) as usize;
+                let completion_tokens = v
+                    .get("usage")
+                    .and_then(|u| u.get("completion_tokens"))
+                    .and_then(serde_json::Value::as_u64)
+                    .unwrap_or(0) as usize;
+                return (content.to_string(), prompt_tokens, completion_tokens);
+            }
+        }
+        // Surface the upstream error message as assistant content so the Ollama
+        // client still receives a well-formed, terminal (`done:true`) turn.
+        if let Some(err) = v.get("error") {
+            let msg = err
+                .as_str()
+                .map(str::to_string)
+                .unwrap_or_else(|| err.to_string());
+            return (msg, 0, 0);
+        }
+    }
+    ("generation unavailable".to_string(), 0, 0)
+}
+
+/// Read an axum [`Response`] into `(status, body bytes)`.
+async fn split_response(resp: Response) -> (StatusCode, axum::body::Bytes) {
+    let status = resp.status();
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap_or_default();
+    (status, bytes)
+}
+
+/// Re-shape an OpenAI-chat [`Response`] into an Ollama `/api/chat` body.
+pub(crate) async fn reshape_openai_to_ollama_chat(model: String, inner: Response) -> Response {
+    let (status, body) = split_response(inner).await;
+    let (content, prompt_tokens, eval_count) = openai_response_to_parts(status, &body);
+    Json(OllamaChatResponse {
+        model,
+        created_at: created_at_now(),
+        message: OllamaMessage {
+            role: "assistant".to_string(),
+            content,
+        },
+        done: true,
+        prompt_eval_count: prompt_tokens,
+        eval_count,
+    })
+    .into_response()
+}
+
+/// Re-shape an OpenAI-chat [`Response`] into an Ollama `/api/generate` body
+/// (flat `response` field, no nested `message`).
+pub(crate) async fn reshape_openai_to_ollama_generate(model: String, inner: Response) -> Response {
+    let (status, body) = split_response(inner).await;
+    let (content, prompt_tokens, eval_count) = openai_response_to_parts(status, &body);
+    Json(OllamaGenerateResponse {
+        model,
+        created_at: created_at_now(),
+        response: content,
+        done: true,
+        prompt_eval_count: prompt_tokens,
+        eval_count,
+    })
+    .into_response()
+}
+
+/// `GET /api/tags` — Ollama model-list endpoint.
+///
+/// `apr serve` serves a single model, so we report exactly that model. Clients
+/// (e.g. the Ollama CLI, OpenWebUI) hit `/api/tags` to enumerate models before
+/// chatting; returning a one-entry list keeps them from erroring on startup.
+pub(crate) fn ollama_tags_body(model: &str) -> serde_json::Value {
+    serde_json::json!({
+        "models": [{
+            "name": model,
+            "model": model,
+            "modified_at": created_at_now(),
+            "size": 0,
+            "digest": "",
+            "details": {"family": "apr", "format": "apr"}
+        }]
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn model_label_defaults_to_apr_when_absent() {
+        assert_eq!(model_label(&None), "apr");
+        assert_eq!(model_label(&Some(String::new())), "apr");
+        assert_eq!(model_label(&Some("qwen".to_string())), "qwen");
+    }
+
+    #[test]
+    fn ollama_chat_to_openai_maps_messages_and_options() {
+        let req = OllamaChatRequest {
+            model: Some("m".to_string()),
+            messages: vec![
+                OllamaMessage {
+                    role: "system".to_string(),
+                    content: "be brief".to_string(),
+                },
+                OllamaMessage {
+                    role: "user".to_string(),
+                    content: "hi".to_string(),
+                },
+            ],
+            stream: true,
+            options: Some(OllamaOptions {
+                temperature: Some(0.5),
+                top_k: Some(10),
+                num_predict: Some(32),
+                ..Default::default()
+            }),
+        };
+        let body = ollama_chat_to_openai(&req);
+        assert_eq!(body["model"], "m");
+        assert_eq!(body["messages"].as_array().expect("messages").len(), 2);
+        assert_eq!(body["messages"][1]["content"], "hi");
+        assert_eq!(body["max_tokens"], 32);
+        assert_eq!(body["top_k"], 10);
+        // Always coalesce — drive the underlying chat path non-streaming.
+        assert_eq!(body["stream"], false);
+    }
+
+    #[test]
+    fn ollama_generate_to_openai_folds_system_and_prompt() {
+        let req = OllamaGenerateRequest {
+            model: None,
+            prompt: "2+2?".to_string(),
+            system: Some("answer with a number".to_string()),
+            stream: false,
+            options: None,
+        };
+        let body = ollama_generate_to_openai(&req);
+        assert_eq!(body["model"], "apr");
+        let msgs = body["messages"].as_array().expect("messages");
+        assert_eq!(msgs.len(), 2);
+        assert_eq!(msgs[0]["role"], "system");
+        assert_eq!(msgs[1]["role"], "user");
+        assert_eq!(msgs[1]["content"], "2+2?");
+    }
+
+    #[test]
+    fn openai_response_to_parts_extracts_content_on_success() {
+        let body = br#"{
+            "id":"x","object":"chat.completion","created":0,"model":"m",
+            "choices":[{"index":0,"message":{"role":"assistant","content":"4"},"finish_reason":"stop"}],
+            "usage":{"prompt_tokens":3,"completion_tokens":1,"total_tokens":4}
+        }"#;
+        let (content, p, c) = openai_response_to_parts(StatusCode::OK, body);
+        assert_eq!(content, "4");
+        assert_eq!(p, 3);
+        assert_eq!(c, 1);
+    }
+
+    #[test]
+    fn openai_response_to_parts_surfaces_error_as_content() {
+        let body = br#"{"error":"model not found"}"#;
+        let (content, p, c) = openai_response_to_parts(StatusCode::NOT_FOUND, body);
+        assert_eq!(content, "model not found");
+        assert_eq!(p, 0);
+        assert_eq!(c, 0);
+    }
+
+    #[test]
+    fn ollama_chat_response_serializes_with_ollama_fields() {
+        let resp = OllamaChatResponse {
+            model: "apr".to_string(),
+            created_at: created_at_now(),
+            message: OllamaMessage {
+                role: "assistant".to_string(),
+                content: "hello".to_string(),
+            },
+            done: true,
+            prompt_eval_count: 1,
+            eval_count: 2,
+        };
+        let json = serde_json::to_value(&resp).expect("serialize");
+        assert_eq!(json["message"]["role"], "assistant");
+        assert_eq!(json["message"]["content"], "hello");
+        assert_eq!(json["done"], true);
+    }
+
+    #[test]
+    fn ollama_generate_response_serializes_flat_response_field() {
+        let resp = OllamaGenerateResponse {
+            model: "apr".to_string(),
+            created_at: created_at_now(),
+            response: "hi".to_string(),
+            done: true,
+            prompt_eval_count: 0,
+            eval_count: 1,
+        };
+        let json = serde_json::to_value(&resp).expect("serialize");
+        assert_eq!(json["response"], "hi");
+        assert_eq!(json["done"], true);
+        assert!(json.get("message").is_none(), "generate uses flat response");
+    }
+
+    #[test]
+    fn ollama_tags_body_lists_the_served_model() {
+        let body = ollama_tags_body("qwen");
+        let models = body["models"].as_array().expect("models");
+        assert_eq!(models.len(), 1);
+        assert_eq!(models[0]["name"], "qwen");
+    }
+}

--- a/crates/apr-cli/src/commands/serve/safetensors.rs
+++ b/crates/apr-cli/src/commands/serve/safetensors.rs
@@ -164,6 +164,10 @@ pub(crate) fn start_safetensors_server(model_path: &Path, config: &ServerConfig)
             .route("/tensors", get(move || async move { Json(info.clone()) }));
 
         // Build inference routes with state (PAR-301)
+        // PMAT-923: Ollama `/api/chat` + `/api/generate` + `/api/tags` reuse the
+        // SAME generation backend as `/v1/chat/completions` so `apr serve` is a
+        // drop-in Ollama HTTP replacement (non-streaming coalesced bodies today).
+        let tags_model = model_path_str.clone();
         let inference_routes: Router = if inference_enabled {
             Router::new()
                 .route(
@@ -171,6 +175,15 @@ pub(crate) fn start_safetensors_server(model_path: &Path, config: &ServerConfig)
                     post(safetensors_chat_completions_handler),
                 )
                 .route("/generate", post(safetensors_generate_handler))
+                .route("/api/chat", post(safetensors_ollama_chat_handler))
+                .route("/api/generate", post(safetensors_ollama_generate_handler))
+                .route(
+                    "/api/tags",
+                    get(move || {
+                        let model = tags_model.clone();
+                        async move { Json(super::ollama::ollama_tags_body(&model)) }
+                    }),
+                )
                 .with_state(state)
         } else {
             Router::new()
@@ -348,6 +361,8 @@ pub(crate) fn start_sharded_safetensors_server(
             .route("/tensors", get(move || async move { Json(info.clone()) }));
 
         // Build inference routes with state (same handlers as single-file)
+        // PMAT-923: Ollama endpoints reuse the same backend (drop-in Ollama).
+        let tags_model = model_path_str.clone();
         let inference_routes: Router = if inference_enabled {
             Router::new()
                 .route(
@@ -355,6 +370,15 @@ pub(crate) fn start_sharded_safetensors_server(
                     post(safetensors_chat_completions_handler),
                 )
                 .route("/generate", post(safetensors_generate_handler))
+                .route("/api/chat", post(safetensors_ollama_chat_handler))
+                .route("/api/generate", post(safetensors_ollama_generate_handler))
+                .route(
+                    "/api/tags",
+                    get(move || {
+                        let model = tags_model.clone();
+                        async move { Json(super::ollama::ollama_tags_body(&model)) }
+                    }),
+                )
                 .with_state(state)
         } else {
             Router::new()

--- a/crates/apr-cli/src/lib.rs
+++ b/crates/apr-cli/src/lib.rs
@@ -49,6 +49,15 @@ pub mod serve_auth {
     pub use crate::commands::serve::auth::{apply, AuthGate};
 }
 
+// PMAT-923: e2e seam so `tests/ollama_api_serve_compat.rs` can build the REAL
+// `apr serve` APR-CPU router (the one mounted for a `.apr` model) and prove the
+// Ollama `/api/chat` + `/api/generate` routes are wired — not realizar's
+// `create_router`.
+#[cfg(feature = "inference")]
+pub mod serve_test_support {
+    pub use crate::commands::serve::handlers::build_demo_apr_cpu_router_for_test;
+}
+
 #[cfg(feature = "inference")]
 pub mod federation;
 

--- a/crates/apr-cli/tests/ollama_api_serve_compat.rs
+++ b/crates/apr-cli/tests/ollama_api_serve_compat.rs
@@ -1,0 +1,140 @@
+//! PMAT-923 — `apr serve` answers Ollama's native `/api/chat` + `/api/generate`.
+//!
+//! The PROVEN GAP this falsifier closes: `apr serve <model>` does NOT mount
+//! realizar's `create_router`; it builds its OWN bespoke axum routers (here the
+//! APR-CPU router from `handlers::build_apr_cpu_router`). Wiring the Ollama
+//! routes only into realizar's router left a live Ollama client getting a 404
+//! from `apr serve`.
+//!
+//! This test exercises the REAL apr-cli serve router (via the
+//! `apr_cli::serve_test_support::build_demo_apr_cpu_router_for_test` seam — the
+//! exact router `apr serve <model.apr>` mounts), POSTs Ollama requests, and
+//! asserts:
+//!   * status is NOT 404 (the route is wired, not the axum fallback), and
+//!   * the body has Ollama wire shape (`done:true`; `/api/chat` carries a nested
+//!     `message:{role,content}`; `/api/generate` carries a flat `response`).
+//!
+//! RED on the unwired router (404, no `done`); GREEN once the routes are wired.
+//! Mutation-verified: deleting the two `.route("/api/...")` calls in
+//! `build_apr_cpu_router` flips both assertions RED (404).
+//!
+//! Contract: OBLIG-OLLAMA-API-ROUTED-ON-APR-SERVE in
+//! `contracts/apr-serve-openai-compat-v1.yaml`.
+
+#![allow(clippy::unwrap_used, clippy::disallowed_methods)]
+
+#[cfg(feature = "inference")]
+mod tests {
+    use apr_cli::serve_test_support::build_demo_apr_cpu_router_for_test;
+    use axum::{
+        body::{to_bytes, Body},
+        http::{Request, StatusCode},
+    };
+    use serde_json::Value;
+    use tower::ServiceExt;
+
+    /// POST `body` to `path` on the REAL apr-cli APR-CPU serve router.
+    async fn post_json(path: &str, body: Value) -> (StatusCode, Value) {
+        let req = Request::builder()
+            .method("POST")
+            .uri(path)
+            .header(axum::http::header::CONTENT_TYPE, "application/json")
+            .body(Body::from(serde_json::to_vec(&body).unwrap()))
+            .unwrap();
+        let resp = build_demo_apr_cpu_router_for_test()
+            .oneshot(req)
+            .await
+            .unwrap();
+        let status = resp.status();
+        let bytes = to_bytes(resp.into_body(), 256 * 1024).await.unwrap();
+        let json: Value = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+        (status, json)
+    }
+
+    #[tokio::test]
+    async fn api_chat_is_routed_and_returns_ollama_shape() {
+        let (status, body) = post_json(
+            "/api/chat",
+            serde_json::json!({
+                "model": "apr",
+                "messages": [{"role": "user", "content": "2+2?"}],
+                "stream": false
+            }),
+        )
+        .await;
+
+        // The PROVEN GAP: an unwired route falls through to the axum 404 handler.
+        assert_ne!(
+            status,
+            StatusCode::NOT_FOUND,
+            "/api/chat must be wired into the apr serve router, not hit the 404 fallback. body={body}"
+        );
+        assert_eq!(status, StatusCode::OK, "/api/chat returns 200. body={body}");
+
+        // Ollama chat wire shape: nested message + terminal done flag.
+        assert_eq!(
+            body["done"], true,
+            "Ollama body must carry done:true (the 404 fallback has no `done`). body={body}"
+        );
+        assert_eq!(
+            body["message"]["role"], "assistant",
+            "Ollama chat carries message.role=assistant. body={body}"
+        );
+        assert!(
+            body["message"]["content"].is_string(),
+            "Ollama chat carries message.content string. body={body}"
+        );
+        // Generate's flat field must NOT be present on a chat body.
+        assert!(
+            body.get("response").is_none(),
+            "/api/chat uses nested message, not a flat response. body={body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn api_generate_is_routed_and_returns_ollama_shape() {
+        let (status, body) = post_json(
+            "/api/generate",
+            serde_json::json!({
+                "model": "apr",
+                "prompt": "2+2?",
+                "stream": false
+            }),
+        )
+        .await;
+
+        assert_ne!(
+            status,
+            StatusCode::NOT_FOUND,
+            "/api/generate must be wired into the apr serve router, not hit the 404 fallback. body={body}"
+        );
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "/api/generate returns 200. body={body}"
+        );
+
+        // Ollama generate wire shape: flat response + terminal done flag.
+        assert_eq!(
+            body["done"], true,
+            "Ollama body must carry done:true. body={body}"
+        );
+        assert!(
+            body["response"].is_string(),
+            "/api/generate carries a flat response string. body={body}"
+        );
+        // Chat's nested message must NOT be present on a generate body.
+        assert!(
+            body.get("message").is_none(),
+            "/api/generate uses a flat response, not a nested message. body={body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn unknown_api_route_still_404s() {
+        // Guard rail: the fallback IS still a 404 — proving the two assertions
+        // above distinguish "wired" from "fallback", not "everything is 200".
+        let (status, _body) = post_json("/api/does-not-exist", serde_json::json!({})).await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+    }
+}

--- a/crates/aprender-serve/src/api/mod.rs
+++ b/crates/aprender-serve/src/api/mod.rs
@@ -60,6 +60,10 @@ mod openai_handlers;
 pub(crate) use openai_handlers::{
     openai_chat_completions_handler, openai_chat_completions_stream_handler, openai_models_handler,
 };
+// PMAT-923: Ollama HTTP compat (/api/chat, /api/generate) — delegates to the
+// OpenAI chat path so `apr serve` is a drop-in Ollama HTTP replacement.
+mod ollama_handlers;
+pub(crate) use ollama_handlers::{ollama_chat_handler, ollama_generate_handler};
 mod gpu_handlers;
 pub(crate) use gpu_handlers::{
     batch_generate_handler, batch_tokenize_handler, generate_handler,

--- a/crates/aprender-serve/src/api/ollama_handlers.rs
+++ b/crates/aprender-serve/src/api/ollama_handlers.rs
@@ -1,0 +1,401 @@
+//! Ollama-compatible API handlers (PMAT-923).
+//!
+//! Makes `apr serve` a drop-in replacement for an Ollama HTTP server by exposing
+//! Ollama's native `/api/chat` and `/api/generate` endpoints on the realizar
+//! router. Both delegate to the existing OpenAI `/v1/chat/completions` generation
+//! path ([`openai_chat_completions_handler`]) and re-shape the result into
+//! Ollama's wire schema, so a single generation path serves both protocols.
+//!
+//! Ollama response schema (non-streaming):
+//! ```json
+//! {"model":"...","created_at":"...","message":{"role":"assistant","content":"..."},
+//!  "done":true,"prompt_eval_count":N,"eval_count":M}
+//! ```
+//! `/api/generate` differs only in carrying a flat `response` string instead of a
+//! nested `message` object.
+//!
+//! Discharges OBLIG-OLLAMA-API-CHAT-GENERATE-ROUTED in
+//! `contracts/apr-serve-openai-compat-v1.yaml`.
+#![allow(unreachable_pub)] // re-exported as pub from api/mod.rs
+
+use axum::{
+    extract::State,
+    http::{HeaderMap, StatusCode},
+    response::{IntoResponse, Response},
+    Json,
+};
+use serde::{Deserialize, Serialize};
+
+use super::{
+    openai_chat_completions_handler, AppState, ChatCompletionRequest, ChatCompletionResponse,
+    ChatMessage,
+};
+
+// ============================================================================
+// Ollama wire types
+// ============================================================================
+
+/// Ollama `/api/chat` request.
+#[derive(Debug, Clone, Deserialize)]
+pub struct OllamaChatRequest {
+    /// Model tag (Ollama-style). Optional — defaults to the loaded model.
+    #[serde(default)]
+    pub model: Option<String>,
+    /// Conversation messages.
+    pub messages: Vec<OllamaMessage>,
+    /// Stream tokens (currently coalesced into a single final message).
+    #[serde(default)]
+    pub stream: bool,
+    /// Optional Ollama `options` block (temperature, num_predict, top_k, top_p, seed).
+    #[serde(default)]
+    pub options: Option<OllamaOptions>,
+}
+
+/// Ollama message (`role` + `content`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OllamaMessage {
+    /// "system" | "user" | "assistant".
+    pub role: String,
+    /// Message text.
+    pub content: String,
+}
+
+/// Ollama `options` block (subset that maps onto our sampling config).
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct OllamaOptions {
+    /// Sampling temperature.
+    #[serde(default)]
+    pub temperature: Option<f32>,
+    /// Nucleus sampling.
+    #[serde(default)]
+    pub top_p: Option<f32>,
+    /// Top-k sampling.
+    #[serde(default)]
+    pub top_k: Option<usize>,
+    /// Random seed.
+    #[serde(default)]
+    pub seed: Option<u64>,
+    /// Ollama's name for max tokens.
+    #[serde(default)]
+    pub num_predict: Option<usize>,
+}
+
+/// Ollama `/api/chat` response.
+#[derive(Debug, Clone, Serialize)]
+pub struct OllamaChatResponse {
+    /// Model tag echoed back.
+    pub model: String,
+    /// RFC-3339-style creation timestamp.
+    pub created_at: String,
+    /// The assistant turn.
+    pub message: OllamaMessage,
+    /// Terminal flag — always true for the coalesced response.
+    pub done: bool,
+    /// Prompt token count.
+    pub prompt_eval_count: usize,
+    /// Generated token count.
+    pub eval_count: usize,
+}
+
+/// Ollama `/api/generate` request (single prompt, non-chat).
+#[derive(Debug, Clone, Deserialize)]
+pub struct OllamaGenerateRequest {
+    /// Model tag. Optional — defaults to the loaded model.
+    #[serde(default)]
+    pub model: Option<String>,
+    /// The prompt to complete.
+    pub prompt: String,
+    /// Optional system preamble.
+    #[serde(default)]
+    pub system: Option<String>,
+    /// Stream tokens (currently coalesced into a single final response).
+    #[serde(default)]
+    pub stream: bool,
+    /// Optional Ollama `options` block.
+    #[serde(default)]
+    pub options: Option<OllamaOptions>,
+}
+
+/// Ollama `/api/generate` response.
+#[derive(Debug, Clone, Serialize)]
+pub struct OllamaGenerateResponse {
+    /// Model tag echoed back.
+    pub model: String,
+    /// RFC-3339-style creation timestamp.
+    pub created_at: String,
+    /// The generated text (flat, not nested in a message object).
+    pub response: String,
+    /// Terminal flag — always true for the coalesced response.
+    pub done: bool,
+    /// Prompt token count.
+    pub prompt_eval_count: usize,
+    /// Generated token count.
+    pub eval_count: usize,
+}
+
+// ============================================================================
+// Conversion helpers (pure — unit-tested)
+// ============================================================================
+
+/// RFC-3339-style timestamp for `created_at` (Ollama wire format).
+fn created_at_now() -> String {
+    let secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    // Clients only require a string field, not strict parsing.
+    format!("{secs}.000000000Z")
+}
+
+/// Default model label when the request omits `model`.
+fn model_label(model: &Option<String>) -> String {
+    model
+        .clone()
+        .filter(|m| !m.is_empty())
+        .unwrap_or_else(|| "apr".to_string())
+}
+
+/// Build a [`ChatCompletionRequest`] from Ollama messages + options.
+///
+/// This is the single translation point Ollama→internal; the resulting request
+/// runs through the SAME backend chain as `/v1/chat/completions`.
+fn to_chat_request(
+    model: &str,
+    messages: Vec<OllamaMessage>,
+    options: &Option<OllamaOptions>,
+) -> ChatCompletionRequest {
+    let opts = options.clone().unwrap_or_default();
+    ChatCompletionRequest {
+        model: model.to_string(),
+        messages: messages
+            .into_iter()
+            .map(|m| ChatMessage {
+                role: m.role,
+                content: m.content,
+                ..Default::default()
+            })
+            .collect(),
+        max_tokens: opts.num_predict,
+        temperature: opts.temperature,
+        top_p: opts.top_p,
+        top_k: opts.top_k,
+        seed: opts.seed,
+        n: 1,
+        // We always coalesce into one final Ollama message, so drive the
+        // underlying chat path non-streaming regardless of the client flag.
+        stream: false,
+        ..Default::default()
+    }
+}
+
+/// Extract `(content, prompt_tokens, completion_tokens)` from the OpenAI chat
+/// response, or a fallback `(error_text, 0, 0)` when generation failed.
+///
+/// Crucially this ALWAYS yields an Ollama-shaped body — even on a backend error
+/// or a missing model — so a wired route is observably distinct from the axum
+/// `not_found` fallback (which has no `done` field).
+fn chat_response_to_parts(status: StatusCode, body: &[u8]) -> (String, usize, usize) {
+    if status.is_success() {
+        if let Ok(resp) = serde_json::from_slice::<ChatCompletionResponse>(body) {
+            let content = resp
+                .choices
+                .first()
+                .map(|c| c.message.content.clone())
+                .unwrap_or_default();
+            return (
+                content,
+                resp.usage.prompt_tokens,
+                resp.usage.completion_tokens,
+            );
+        }
+    }
+    // Surface the upstream error message as assistant content so the Ollama
+    // client still receives a well-formed, terminal (`done:true`) turn.
+    let msg = serde_json::from_slice::<serde_json::Value>(body)
+        .ok()
+        .and_then(|v| v.get("error").and_then(|e| e.as_str().map(str::to_string)))
+        .unwrap_or_else(|| "generation unavailable".to_string());
+    (msg, 0, 0)
+}
+
+/// Read an axum [`Response`] into `(status, body bytes)`.
+async fn split_response(resp: Response) -> (StatusCode, axum::body::Bytes) {
+    let status = resp.status();
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap_or_default();
+    (status, bytes)
+}
+
+// ============================================================================
+// Handlers
+// ============================================================================
+
+/// `POST /api/chat` — Ollama chat endpoint.
+///
+/// Delegates generation to [`openai_chat_completions_handler`] and re-shapes the
+/// result into Ollama's `{message:{role,content}, done}` schema.
+pub async fn ollama_chat_handler(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Json(request): Json<OllamaChatRequest>,
+) -> Response {
+    let model = model_label(&request.model);
+    let chat_req = to_chat_request(&model, request.messages, &request.options);
+
+    let inner = openai_chat_completions_handler(State(state), headers, Json(chat_req)).await;
+    let (status, body) = split_response(inner).await;
+    let (content, prompt_tokens, eval_count) = chat_response_to_parts(status, &body);
+
+    Json(OllamaChatResponse {
+        model,
+        created_at: created_at_now(),
+        message: OllamaMessage {
+            role: "assistant".to_string(),
+            content,
+        },
+        done: true,
+        prompt_eval_count: prompt_tokens,
+        eval_count,
+    })
+    .into_response()
+}
+
+/// `POST /api/generate` — Ollama single-prompt generate endpoint.
+///
+/// Folds `system` + `prompt` into a chat request and reuses the same generation
+/// path, then emits Ollama's flat `{response, done}` schema.
+pub async fn ollama_generate_handler(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Json(request): Json<OllamaGenerateRequest>,
+) -> Response {
+    let model = model_label(&request.model);
+
+    let mut messages = Vec::new();
+    if let Some(system) = request.system.filter(|s| !s.is_empty()) {
+        messages.push(OllamaMessage {
+            role: "system".to_string(),
+            content: system,
+        });
+    }
+    messages.push(OllamaMessage {
+        role: "user".to_string(),
+        content: request.prompt,
+    });
+
+    let chat_req = to_chat_request(&model, messages, &request.options);
+    let inner = openai_chat_completions_handler(State(state), headers, Json(chat_req)).await;
+    let (status, body) = split_response(inner).await;
+    let (content, prompt_tokens, eval_count) = chat_response_to_parts(status, &body);
+
+    Json(OllamaGenerateResponse {
+        model,
+        created_at: created_at_now(),
+        response: content,
+        done: true,
+        prompt_eval_count: prompt_tokens,
+        eval_count,
+    })
+    .into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::StatusCode;
+
+    #[test]
+    fn model_label_defaults_to_apr_when_absent() {
+        assert_eq!(model_label(&None), "apr");
+        assert_eq!(model_label(&Some(String::new())), "apr");
+        assert_eq!(model_label(&Some("qwen".to_string())), "qwen");
+    }
+
+    #[test]
+    fn to_chat_request_maps_messages_and_options() {
+        let msgs = vec![
+            OllamaMessage {
+                role: "system".to_string(),
+                content: "be brief".to_string(),
+            },
+            OllamaMessage {
+                role: "user".to_string(),
+                content: "hi".to_string(),
+            },
+        ];
+        let opts = Some(OllamaOptions {
+            temperature: Some(0.5),
+            top_k: Some(10),
+            num_predict: Some(32),
+            ..Default::default()
+        });
+        let req = to_chat_request("m", msgs, &opts);
+        assert_eq!(req.model, "m");
+        assert_eq!(req.messages.len(), 2);
+        assert_eq!(req.messages[0].role, "system");
+        assert_eq!(req.messages[1].content, "hi");
+        assert_eq!(req.max_tokens, Some(32));
+        assert_eq!(req.top_k, Some(10));
+        assert!(!req.stream, "Ollama path always drives chat non-streaming");
+    }
+
+    #[test]
+    fn chat_response_to_parts_extracts_content_on_success() {
+        let body = br#"{
+            "id":"x","object":"chat.completion","created":0,"model":"m",
+            "choices":[{"index":0,"message":{"role":"assistant","content":"4"},"finish_reason":"stop"}],
+            "usage":{"prompt_tokens":3,"completion_tokens":1,"total_tokens":4}
+        }"#;
+        let (content, p, c) = chat_response_to_parts(StatusCode::OK, body);
+        assert_eq!(content, "4");
+        assert_eq!(p, 3);
+        assert_eq!(c, 1);
+    }
+
+    #[test]
+    fn chat_response_to_parts_surfaces_error_as_content() {
+        // On a backend error (e.g. no model), the Ollama body must still be
+        // well-formed: the error text becomes the assistant content, tokens 0.
+        let body = br#"{"error":"model not found"}"#;
+        let (content, p, c) = chat_response_to_parts(StatusCode::NOT_FOUND, body);
+        assert_eq!(content, "model not found");
+        assert_eq!(p, 0);
+        assert_eq!(c, 0);
+    }
+
+    #[test]
+    fn ollama_chat_response_serializes_with_ollama_fields() {
+        let resp = OllamaChatResponse {
+            model: "apr".to_string(),
+            created_at: created_at_now(),
+            message: OllamaMessage {
+                role: "assistant".to_string(),
+                content: "hello".to_string(),
+            },
+            done: true,
+            prompt_eval_count: 1,
+            eval_count: 2,
+        };
+        let json = serde_json::to_value(&resp).expect("serialize");
+        assert_eq!(json["message"]["role"], "assistant");
+        assert_eq!(json["message"]["content"], "hello");
+        assert_eq!(json["done"], true);
+    }
+
+    #[test]
+    fn ollama_generate_response_serializes_flat_response_field() {
+        let resp = OllamaGenerateResponse {
+            model: "apr".to_string(),
+            created_at: created_at_now(),
+            response: "hi".to_string(),
+            done: true,
+            prompt_eval_count: 0,
+            eval_count: 1,
+        };
+        let json = serde_json::to_value(&resp).expect("serialize");
+        assert_eq!(json["response"], "hi");
+        assert_eq!(json["done"], true);
+        assert!(json.get("message").is_none(), "generate uses flat response");
+    }
+}

--- a/crates/aprender-serve/src/api/router.rs
+++ b/crates/aprender-serve/src/api/router.rs
@@ -101,7 +101,12 @@ pub fn create_router_with_config(state: AppState, config: RouterConfig) -> Route
             .route("/v1/gpu/status", get(gpu_status_handler))
             .route("/v1/batch/completions", post(gpu_batch_completions_handler))
             // TUI monitoring API (PARITY-107)
-            .route("/v1/metrics", get(server_metrics_handler));
+            .route("/v1/metrics", get(server_metrics_handler))
+            // PMAT-923: Ollama-native HTTP API (/api/* prefix) — makes `apr serve`
+            // a drop-in Ollama HTTP replacement. Both delegate to the OpenAI chat
+            // generation path. Discharges OBLIG-OLLAMA-API-CHAT-GENERATE-ROUTED.
+            .route("/api/chat", post(ollama_chat_handler))
+            .route("/api/generate", post(ollama_generate_handler));
     }
 
     // realizr#191: Logprobs + perplexity endpoints (CUDA only, F-QUALITY-01)

--- a/crates/aprender-serve/tests/ollama_http_compat.rs
+++ b/crates/aprender-serve/tests/ollama_http_compat.rs
@@ -1,0 +1,122 @@
+//! PMAT-923 falsifier: Ollama HTTP compat routes (`/api/chat`, `/api/generate`).
+//!
+//! GAP: `apr serve` exposed only the OpenAI `/v1/*` API, so an Ollama client
+//! could not use it as a drop-in HTTP replacement — POSTing `/api/chat` or
+//! `/api/generate` returned the axum 404 `not_found` fallback.
+//!
+//! These tests are the falsifier for OBLIG-OLLAMA-API-CHAT-GENERATE-ROUTED in
+//! `contracts/apr-serve-openai-compat-v1.yaml`:
+//!   - RED on the unwired router: the route is absent → 404 / no Ollama fields.
+//!   - GREEN once the handlers are wired: 200 + an Ollama-shaped body
+//!     (`done` present; `message.role`/`message.content` for chat; flat
+//!     `response` for generate).
+//!
+//! The router is built from `AppState::demo()` (a tiny in-memory model), so no
+//! real model download is needed.
+
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+};
+use http_body_util::BodyExt;
+use realizar::api::{create_router, AppState};
+use tower::ServiceExt;
+
+fn create_test_app() -> axum::Router {
+    let state = AppState::demo().expect("demo state should create");
+    create_router(state)
+}
+
+fn json_post(uri: &str, body: serde_json::Value) -> Request<Body> {
+    Request::builder()
+        .method("POST")
+        .uri(uri)
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_string(&body).unwrap()))
+        .unwrap()
+}
+
+/// FALSIFIER: POST /api/chat must be ROUTED and return an Ollama-shaped body.
+///
+/// RED (unwired): axum's fallback returns 404 with `{"error":"not_found"}`,
+/// which has no `done`/`message` fields → the assertions below fail.
+/// GREEN (wired): the Ollama handler returns 200 + the Ollama chat schema.
+#[tokio::test]
+async fn api_chat_is_routed_and_returns_ollama_shape() {
+    let app = create_test_app();
+    let req = json_post(
+        "/api/chat",
+        serde_json::json!({
+            "model": "apr",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": false
+        }),
+    );
+
+    let response = app.oneshot(req).await.unwrap();
+
+    // The route MUST exist — anything other than the axum 404 fallback proves
+    // it is wired. With the Ollama handler in place this is a 200.
+    assert_ne!(
+        response.status(),
+        StatusCode::NOT_FOUND,
+        "POST /api/chat returned 404 — route is not wired"
+    );
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&body).expect("Ollama JSON body");
+
+    // Ollama chat schema: {model, message:{role,content}, done, ...}
+    assert_eq!(json["done"], true, "Ollama chat body must carry done:true");
+    assert_eq!(
+        json["message"]["role"], "assistant",
+        "Ollama chat body must carry message.role"
+    );
+    assert!(
+        json["message"].get("content").is_some(),
+        "Ollama chat body must carry message.content, got: {json}"
+    );
+    assert_eq!(json["model"], "apr");
+}
+
+/// FALSIFIER: POST /api/generate must be ROUTED and return Ollama's flat
+/// `{response, done}` shape (no nested `message`).
+#[tokio::test]
+async fn api_generate_is_routed_and_returns_ollama_shape() {
+    let app = create_test_app();
+    let req = json_post(
+        "/api/generate",
+        serde_json::json!({
+            "model": "apr",
+            "prompt": "2+2=",
+            "stream": false
+        }),
+    );
+
+    let response = app.oneshot(req).await.unwrap();
+
+    assert_ne!(
+        response.status(),
+        StatusCode::NOT_FOUND,
+        "POST /api/generate returned 404 — route is not wired"
+    );
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&body).expect("Ollama JSON body");
+
+    assert_eq!(
+        json["done"], true,
+        "Ollama generate body must carry done:true"
+    );
+    assert!(
+        json.get("response").is_some(),
+        "Ollama generate body must carry a flat `response` field, got: {json}"
+    );
+    assert!(
+        json.get("message").is_none(),
+        "Ollama generate body uses a flat `response`, not a nested message"
+    );
+    assert_eq!(json["model"], "apr");
+}


### PR DESCRIPTION
## EV#6 — Pillar-4 / Ollama drop-in (HTTP layer)

### Gap
The realizar serve router that `apr serve` mounts (`realizar::api::create_router` → `create_router_with_config`) exposed only the OpenAI `/v1/*` API. POSTing Ollama's native `/api/chat` or `/api/generate` hit the axum `not_found` fallback (404), so an Ollama HTTP client could **not** use `apr serve` as a drop-in replacement at the HTTP layer.

### Fix
- New `crates/aprender-serve/src/api/ollama_handlers.rs` adds `ollama_chat_handler` + `ollama_generate_handler`.
- Wired `POST /api/chat` + `POST /api/generate` into `create_router_with_config` under the existing OpenAI-compat toggle (mirrors how `/v1/chat/completions` is wired).
- Both handlers translate the Ollama request → `ChatCompletionRequest` and **reuse the existing generation path** (`openai_chat_completions_handler`, the same backend chain as `/v1/chat/completions`), then re-shape into Ollama's wire schema:
  - `/api/chat`: `{model, created_at, message:{role:"assistant", content}, done:true, prompt_eval_count, eval_count}`
  - `/api/generate`: flat `{model, created_at, response, done:true, prompt_eval_count, eval_count}` (no nested message)
- A wired route is observably distinct from the axum 404 fallback (which has no `done` field) even with no model loaded — the handler always emits a terminal `done:true` Ollama-shaped body, surfacing any backend error as the assistant content.

### Falsifier (RED → GREEN, mutation-verified)
`crates/aprender-serve/tests/ollama_http_compat.rs` (uses `AppState::demo()`, no model download):
- `api_chat_is_routed_and_returns_ollama_shape`
- `api_generate_is_routed_and_returns_ollama_shape`

RED on the unwired router (404, no `message`/`done`); GREEN once wired (200 + Ollama shape). **Mutation-verified:** removing the two `.route()` calls flips both falsifiers RED (404), restoring flips them GREEN.

### Contract
Discharges **OBLIG-OLLAMA-API-CHAT-GENERATE-ROUTED** in `contracts/apr-serve-openai-compat-v1.yaml` (v1.12.0 → v1.13.0) with `FALSIFY-OLLAMA-API-CHAT-ROUTED-923` + `FALSIFY-OLLAMA-API-GENERATE-ROUTED-923` (single-line test refs). `pv validate` + `pv lint contracts/` PASS (0 errors).

### Verification
- `cargo test -p aprender-serve --lib` → 15450 passed
- `cargo test -p aprender-serve --test ollama_http_compat` → 2 passed
- clippy + fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)