### PR TITLE
fix(compute): constrain wgpu adapter enumeration to exclude GLES — Linux/AMD-RADV SIGABRT-in-Drop + enumeration hang (PMAT-925)

### DIFF
--- a/contracts/apr-wgpu-adapter-enumeration-excludes-gles-v1.yaml
+++ b/contracts/apr-wgpu-adapter-enumeration-excludes-gles-v1.yaml
@@ -1,0 +1,70 @@
+metadata:
+  version: 1.0.0
+  created: '2026-06-24'
+  author: PAIML Engineering
+  description: "wgpu adapter-enumeration backend mask MUST exclude GLES/EGL — on Linux hosts with both Vulkan and GLES (intel AMD-RADV cross-silicon baseline), wgpu::Backends::all() instantiates a GLES adapter whose EglContext::make_current panics inside Drop (wgpu-hal-27.0.4 gles/egl.rs:305) → SIGABRT 'panic in a destructor during cleanup' aborting the whole process; the enumeration mask must be platform-appropriate (PRIMARY = VULKAN|METAL|DX12|BROWSER_WEBGPU) and NEVER include GL"
+  references:
+    - "PMAT-925 (wgpu GLES adapter SIGABRT-in-Drop on Linux/AMD-RADV)"
+    - "intel AMD-Vulkan/RADV cross-silicon baseline finding"
+    - "wgpu-hal-27.0.4 src/gles/egl.rs:305 (EglContext::make_current unwrap in Drop)"
+    - "wgpu-types-27.0.1 src/lib.rs:275 (Backends::PRIMARY excludes GL; GL is SECONDARY only)"
+  registry: true
+  tags:
+    - gpu
+    - wgpu
+    - cross-silicon
+    - enumeration
+    - five-whys
+  kind: kernel
+
+five_whys:
+  symptom: "On the intel AMD-RADV (Linux, Vulkan+GLES) cross-silicon baseline host, aprender-compute GPU adapter enumeration (list_adapters / is_available / pool::all / monitor enumerate) aborts the whole process with SIGABRT: 'panic in a destructor during cleanup', backtrace at wgpu-hal-27.0.4 gles/egl.rs:305"
+  why_1: "enumerate_adapters / Instance creation used wgpu::Backends::all(), which includes wgpu::Backends::GL"
+  why_2: "Including GL makes wgpu instantiate a GLES/EGL adapter on Linux hosts that expose EGL alongside Vulkan"
+  why_3: "That GLES adapter's EglContext::make_current() calls .unwrap() and fails on this host's EGL config; the failure occurs while the adapter/context is being dropped"
+  why_4: "A panic inside a Drop implementation during cleanup is a double-panic → the Rust runtime aborts the entire process (SIGABRT), not just the enumeration call"
+  why_5: "No contract bound GPU adapter enumeration to a non-GLES backend mask — the compute kernels are correct, but enumeration was free to touch the broken GLES/EGL path"
+  root_cause: "Adapter enumeration used the all-backends mask (incl. GL); the platform-appropriate mask must exclude GLES so the broken EGL Drop path is never instantiated, while still finding the real Vulkan/Metal/DX12 GPU."
+
+equations:
+  enumeration_mask_excludes_gles:
+    formula: "gpu_backends() ∩ Backends::GL = ∅ ∧ real_backend(platform) ⊆ gpu_backends()"
+    domain: "the backend mask used for every wgpu Instance construction and enumerate_adapters call in aprender-compute"
+    codomain: "boolean — whether enumeration can ever touch the GLES/EGL adapter"
+    invariants:
+      - "gpu_backends() MUST NOT contain wgpu::Backends::GL (no GLES/EGL adapter is ever instantiated)"
+      - "On Linux, gpu_backends() MUST contain wgpu::Backends::VULKAN (the real GPU, e.g. AMD-RADV / NVIDIA, is still found)"
+      - "On macOS, gpu_backends() MUST contain wgpu::Backends::METAL (Apple Silicon GPU is still found)"
+      - "On Windows, gpu_backends() MUST contain wgpu::Backends::VULKAN or wgpu::Backends::DX12"
+      - "The shared wgpu::Instance is constructed with this mask so the GLES backend is never registered, and every enumerate_adapters call passes this mask"
+
+proof_obligations:
+  - type: invariant
+    property: "OBLIG-WGPU-ADAPTER-ENUMERATION-EXCLUDES-GLES: enumeration mask never includes GLES"
+    formal: "gpu_backends() ∩ Backends::GL = ∅"
+    applies_to: enumeration_mask_excludes_gles
+  - type: invariant
+    property: "Real platform GPU backend is still enumerable"
+    formal: "real_backend(platform) ⊆ gpu_backends()"
+    applies_to: enumeration_mask_excludes_gles
+
+falsification_tests:
+  - id: FALSIFY-WGPU-ENUM-GLES-001
+    rule: "gpu_backends() excludes GLES and includes the platform GPU backend"
+    prediction: "The backend mask used by aprender-compute GPU enumeration does NOT contain Backends::GL but DOES contain the platform's real backend; RED on Backends::all() (contains GL), GREEN on Backends::PRIMARY"
+    test: "cargo test -p aprender-compute --features gpu --lib test_gpu_backends_excludes_gles"
+    if_fails: "Enumeration mask still includes GLES (or dropped the real backend) — Linux/AMD-RADV will SIGABRT in the GLES Drop path again"
+
+kani_harnesses:
+  - id: KANI-WGPU-ENUM-GLES-001
+    obligation: "gpu_backends() ∩ Backends::GL = ∅"
+    bound: 4
+    strategy: bounded_int
+
+qa_gate:
+  id: F-WGPU-ENUM-GLES-001
+  name: "wgpu adapter enumeration excludes GLES"
+  description: "Every wgpu Instance construction and enumerate_adapters call in aprender-compute uses a platform-appropriate backend mask (Backends::PRIMARY) that excludes GLES/EGL, so the broken GLES Drop path is never instantiated on Linux/AMD-RADV while the real Vulkan/Metal/DX12 GPU is still found."
+  checks:
+    - "enumeration_mask_excludes_gles"
+  pass_criteria: "FALSIFY-WGPU-ENUM-GLES-001 PASSES; on intel (AMD-RADV) the enumeration no longer SIGABRTs and the Vulkan adapter is still found; on mini (Apple Metal) the Metal adapter is still enumerated and parity tests still pass."

--- a/crates/aprender-compute/src/backends/gpu/device/mod.rs
+++ b/crates/aprender-compute/src/backends/gpu/device/mod.rs
@@ -33,6 +33,33 @@ use super::runtime;
 #[cfg(all(feature = "gpu", not(target_arch = "wasm32")))]
 static DEVICE_INIT_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
+/// Platform-appropriate wgpu backend mask for adapter enumeration.
+///
+/// PMAT-925: `wgpu::Backends::all()` includes [`wgpu::Backends::GL`], which on
+/// Linux hosts that have both Vulkan and GLES/EGL (notably the intel AMD-RADV
+/// cross-silicon baseline box) instantiates a GLES adapter whose
+/// `EglContext::make_current` **panics inside `Drop`** (wgpu-hal-27.0.4
+/// `gles/egl.rs:305`). A panic in a destructor during cleanup aborts the whole
+/// process with SIGABRT ("panic in a destructor during cleanup"); standalone
+/// `list_adapters()` / `is_available()` could also spin/hang on the broken EGL
+/// path. The compute kernels themselves are correct — the fragility is purely in
+/// adapter *enumeration* and the GLES `Drop` path.
+///
+/// We return [`wgpu::Backends::PRIMARY`], which in wgpu 27 is
+/// `VULKAN | METAL | DX12 | BROWSER_WEBGPU` and **excludes** `GL` (GL lives only
+/// in `Backends::SECONDARY`). This keeps the real GPU on every platform — Vulkan
+/// on Linux/AMD-RADV, Metal on Apple, DX12 on Windows — while guaranteeing the
+/// broken GLES/EGL adapter is never created.
+///
+/// The mask is applied at BOTH the `wgpu::Instance` construction site (so the
+/// GLES backend is never even registered on the instance) and every
+/// `enumerate_adapters` call site.
+#[cfg(all(feature = "gpu", not(target_arch = "wasm32")))]
+pub(crate) const fn gpu_backends() -> wgpu::Backends {
+    // PRIMARY = VULKAN | METAL | DX12 | BROWSER_WEBGPU (never GL/GLES).
+    wgpu::Backends::PRIMARY
+}
+
 /// Process-global, lazily-created shared `wgpu::Instance`.
 ///
 /// PMAT-778: Creating a fresh `wgpu::Instance` enumerates every installed Vulkan
@@ -52,7 +79,14 @@ pub(crate) fn shared_instance() -> wgpu::Instance {
         .get_or_init(|| {
             // Serialize the one-time enumeration against any other GPU init.
             let _guard = DEVICE_INIT_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-            wgpu::Instance::default()
+            // PMAT-925: constrain the instance to a non-GLES backend mask so the
+            // broken GLES/EGL adapter (SIGABRT-in-Drop on Linux/AMD-RADV) is never
+            // registered. `Instance::default()` would use `Backends::all()`
+            // (which includes GL).
+            wgpu::Instance::new(&wgpu::InstanceDescriptor {
+                backends: gpu_backends(),
+                ..Default::default()
+            })
         })
         .clone()
 }
@@ -128,7 +162,8 @@ impl GpuDevice {
     /// Adapter indices correspond to `Instance::enumerate_adapters()` ordering.
     pub async fn new_with_adapter_index_async(index: u32) -> Result<Self, String> {
         let instance = shared_instance();
-        let adapters = instance.enumerate_adapters(wgpu::Backends::all());
+        // PMAT-925: exclude GLES (see `gpu_backends`).
+        let adapters = instance.enumerate_adapters(gpu_backends());
 
         if adapters.is_empty() {
             return Err("No GPU adapters found".to_string());
@@ -172,7 +207,8 @@ impl GpuDevice {
     /// List all available GPU adapters (async, all platforms)
     pub async fn list_adapters_async() -> Vec<(u32, String, String)> {
         let instance = shared_instance();
-        let adapters = instance.enumerate_adapters(wgpu::Backends::all());
+        // PMAT-925: exclude GLES (see `gpu_backends`).
+        let adapters = instance.enumerate_adapters(gpu_backends());
 
         adapters
             .iter()
@@ -433,6 +469,45 @@ impl GpuDevice {
 #[cfg(all(test, feature = "gpu", not(target_arch = "wasm32")))]
 mod tests {
     use super::*;
+
+    /// PMAT-925 FALSIFIER: the adapter-enumeration backend mask MUST NOT contain
+    /// GLES (`wgpu::Backends::GL`), and MUST contain the platform's real backend.
+    ///
+    /// RED on `Backends::all()` (contains GL → GLES/EGL adapter → SIGABRT-in-Drop
+    /// on Linux/AMD-RADV). GREEN on `Backends::PRIMARY`. Host-independent: it
+    /// inspects the bitmask, it does not create any adapter.
+    #[test]
+    fn test_gpu_backends_excludes_gles() {
+        let mask = gpu_backends();
+
+        // The whole point: GLES/EGL must never be enumerated.
+        assert!(
+            !mask.contains(wgpu::Backends::GL),
+            "gpu_backends() must NOT include Backends::GL (GLES/EGL panics in Drop \
+             on Linux/AMD-RADV → SIGABRT). mask = {:?}",
+            mask
+        );
+
+        // The real GPU backend on each platform must still be present.
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        assert!(
+            mask.contains(wgpu::Backends::VULKAN),
+            "gpu_backends() must include VULKAN on Linux (AMD-RADV/NVIDIA). mask = {:?}",
+            mask
+        );
+        #[cfg(target_os = "macos")]
+        assert!(
+            mask.contains(wgpu::Backends::METAL),
+            "gpu_backends() must include METAL on macOS (Apple Silicon). mask = {:?}",
+            mask
+        );
+        #[cfg(target_os = "windows")]
+        assert!(
+            mask.contains(wgpu::Backends::VULKAN) || mask.contains(wgpu::Backends::DX12),
+            "gpu_backends() must include VULKAN or DX12 on Windows. mask = {:?}",
+            mask
+        );
+    }
 
     #[test]
     fn test_is_available_consistency() {

--- a/crates/aprender-compute/src/backends/gpu/mod.rs
+++ b/crates/aprender-compute/src/backends/gpu/mod.rs
@@ -66,6 +66,12 @@ pub use device::GpuDevice;
 #[cfg(all(feature = "gpu", not(target_arch = "wasm32")))]
 pub(crate) use device::shared_instance;
 
+// PMAT-925: non-GLES backend mask, reused by every crate-internal
+// `enumerate_adapters` call so the broken GLES/EGL adapter (SIGABRT-in-Drop on
+// Linux/AMD-RADV) is never instantiated.
+#[cfg(all(feature = "gpu", not(target_arch = "wasm32")))]
+pub(crate) use device::gpu_backends;
+
 /// Re-export wgpu types for downstream crates that need to create persistent
 /// GPU buffers (KAIZEN-015: GPU-resident weights).
 #[cfg(any(feature = "gpu", feature = "gpu-wasm"))]

--- a/crates/aprender-compute/src/backends/gpu/pool.rs
+++ b/crates/aprender-compute/src/backends/gpu/pool.rs
@@ -44,7 +44,9 @@ impl GpuDevicePool {
         // PMAT-778: reuse the process-global instance so the broken freedreno
         // ICD (GB10/aarch64) is enumerated exactly once, never concurrently.
         let instance = super::device::shared_instance();
-        let adapters = instance.enumerate_adapters(wgpu::Backends::all());
+        // PMAT-925: exclude GLES so the broken GLES/EGL adapter (SIGABRT-in-Drop
+        // on Linux/AMD-RADV) is never instantiated (see `device::gpu_backends`).
+        let adapters = instance.enumerate_adapters(super::device::gpu_backends());
 
         if adapters.is_empty() {
             return Err("No GPU adapters found".to_string());

--- a/crates/aprender-compute/src/monitor/backends.rs
+++ b/crates/aprender-compute/src/monitor/backends.rs
@@ -20,8 +20,9 @@ pub(crate) fn query_wgpu_device_info(device_index: u32) -> Result<GpuDeviceInfo,
         // PMAT-778: reuse the process-global instance (single freedreno enumeration).
         let instance = crate::backends::gpu::shared_instance();
 
-        // Get all adapters (wgpu 27+ returns Vec directly)
-        let adapters = instance.enumerate_adapters(wgpu::Backends::all());
+        // Get all adapters (wgpu 27+ returns Vec directly).
+        // PMAT-925: exclude GLES (SIGABRT-in-Drop on Linux/AMD-RADV).
+        let adapters = instance.enumerate_adapters(crate::backends::gpu::gpu_backends());
 
         if adapters.is_empty() {
             return Err(MonitorError::NoDevice);
@@ -64,7 +65,8 @@ pub(crate) fn enumerate_wgpu_devices() -> Result<Vec<GpuDeviceInfo>, MonitorErro
     runtime::block_on(async {
         // PMAT-778: reuse the process-global instance (single freedreno enumeration).
         let instance = crate::backends::gpu::shared_instance();
-        let adapters = instance.enumerate_adapters(wgpu::Backends::all());
+        // PMAT-925: exclude GLES (SIGABRT-in-Drop on Linux/AMD-RADV).
+        let adapters = instance.enumerate_adapters(crate::backends::gpu::gpu_backends());
 
         if adapters.is_empty() {
             return Err(MonitorError::NoDevice);


### PR DESCRIPTION
## Summary

Fixes a real **wgpu portability bug** surfaced by the **intel AMD-Vulkan/RADV cross-silicon baseline**. Every GPU adapter-enumeration path in `aprender-compute` enumerated with `wgpu::Backends::all()`, which **includes `Backends::GL`**. On Linux hosts that expose GLES/EGL alongside Vulkan (the AMD-RADV box — and reproduced on this lambda RTX 4090 box), `all()` instantiates a GLES adapter whose `EglContext::make_current()` `.unwrap()`s and **fails inside `Drop`** → a panic in a destructor during cleanup → **SIGABRT** ("panic in a destructor during cleanup"), backtrace at `wgpu-hal-27.0.4 src/gles/egl.rs:305`, aborting the **whole process**. Standalone `list_adapters()`/`is_available()` could also spin/hang on the broken EGL path.

The compute kernels are correct — the fragility is purely adapter **enumeration** + the GLES `Drop` path.

## Fix

Add `gpu_backends()` → `wgpu::Backends::PRIMARY` (`= VULKAN | METAL | DX12 | BROWSER_WEBGPU` in wgpu 27; `GL` lives **only** in `SECONDARY`). Apply at:
- `device::shared_instance()` — construct the process-global `Instance` with this mask, so the **GLES backend is never even registered**.
- `GpuDevice::list_adapters_async` / `new_with_adapter_index_async` (`device/mod.rs`)
- `GpuDevicePool::all_async` (`pool.rs`)
- `monitor::backends` enumerate / query (`monitor/backends.rs`)

CUDA paths untouched (wgpu-only). Real GPU still found on every platform: Vulkan (Linux/AMD-RADV), Metal (Apple), DX12 (Windows).

## Falsifier (host-independent)

`test_gpu_backends_excludes_gles` inspects the bitmask: asserts it does **NOT** contain `Backends::GL` and **DOES** contain the platform's real backend.
- **RED** on `Backends::all()` (mask = `NOOP|VULKAN|GL|METAL|DX12|BROWSER_WEBGPU`) — mutation-verified.
- **GREEN** on `PRIMARY`.

## On-device evidence (this Linux box reproduces the GLES path)

- **BEFORE** (`Backends::all()`): 8 gpu/monitor tests FAIL, **all** panicking at `wgpu-hal gles/egl.rs:305` — the exact SIGABRT-in-Drop bug.
- **AFTER** (`PRIMARY`): `cargo test -p aprender-compute --features gpu --lib` = **3566 passed, 0 failed**, ZERO `egl.rs:305` panics; Vulkan adapter still enumerated.

## Cross-silicon verification (per cross-silicon directive)

- **intel (AMD-RADV / Vulkan)**: where it repros — confirm NO SIGABRT / NO hang, RADV/Vulkan adapter still found, parity passes. _(see PR comment)_
- **mini (Apple M4 / Metal)**: confirm Metal adapter still enumerated, parity tests still pass (mask didn't exclude Metal). _(see PR comment)_

## Contract

`contracts/apr-wgpu-adapter-enumeration-excludes-gles-v1.yaml` — `OBLIG-WGPU-ADAPTER-ENUMERATION-EXCLUDES-GLES`, `FALSIFY-WGPU-ENUM-GLES-001` (single-line ref). `pv validate` + `pv lint contracts/` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
