### PR TITLE
fix(db,graph): constrain wgpu adapter enumeration to exclude GLES — close the SIGABRT class (PMAT-927)

### DIFF
--- a/contracts/apr-wgpu-adapter-enumeration-excludes-gles-v1.yaml
+++ b/contracts/apr-wgpu-adapter-enumeration-excludes-gles-v1.yaml
@@ -1,12 +1,15 @@
 metadata:
-  version: 1.0.0
+  version: 1.1.0
   created: '2026-06-24'
   author: PAIML Engineering
-  description: "wgpu adapter-enumeration backend mask MUST exclude GLES/EGL — on Linux hosts with both Vulkan and GLES (intel AMD-RADV cross-silicon baseline), wgpu::Backends::all() instantiates a GLES adapter whose EglContext::make_current panics inside Drop (wgpu-hal-27.0.4 gles/egl.rs:305) → SIGABRT 'panic in a destructor during cleanup' aborting the whole process; the enumeration mask must be platform-appropriate (PRIMARY = VULKAN|METAL|DX12|BROWSER_WEBGPU) and NEVER include GL"
+  description: "wgpu adapter-enumeration backend mask MUST exclude GLES/EGL — on Linux hosts with both Vulkan and GLES (intel AMD-RADV cross-silicon baseline), wgpu::Backends::all() instantiates a GLES adapter whose EglContext::make_current panics inside Drop → SIGABRT 'panic in a destructor during cleanup' aborting the whole process; the enumeration mask must be platform-appropriate (PRIMARY = VULKAN|METAL|DX12|BROWSER_WEBGPU) and NEVER include GL. v1.1.0 (PMAT-927) extends the obligation from aprender-compute to ALL workspace crates that enumerate wgpu adapters: aprender-db, aprender-graph (wgpu 22) and aprender-distribute (wgpu 23) — PRIMARY excludes GL in every pinned wgpu version (22/23/27)."
   references:
-    - "PMAT-925 (wgpu GLES adapter SIGABRT-in-Drop on Linux/AMD-RADV)"
+    - "PMAT-925 (wgpu GLES adapter SIGABRT-in-Drop on Linux/AMD-RADV — aprender-compute)"
+    - "PMAT-927 (class follow-up: aprender-db / aprender-graph / aprender-distribute had the same latent Backends::all()/Instance::default() enumeration)"
     - "intel AMD-Vulkan/RADV cross-silicon baseline finding"
     - "wgpu-hal-27.0.4 src/gles/egl.rs:305 (EglContext::make_current unwrap in Drop)"
+    - "wgpu-types-22.0.0 src/lib.rs:181 (Backends::PRIMARY = VULKAN|METAL|DX12|BROWSER_WEBGPU; GL is SECONDARY only)"
+    - "wgpu-types-23.0.0 src/lib.rs:183 (Backends::PRIMARY excludes GL; GL is SECONDARY only)"
     - "wgpu-types-27.0.1 src/lib.rs:275 (Backends::PRIMARY excludes GL; GL is SECONDARY only)"
   registry: true
   tags:
@@ -37,6 +40,7 @@ equations:
       - "On macOS, gpu_backends() MUST contain wgpu::Backends::METAL (Apple Silicon GPU is still found)"
       - "On Windows, gpu_backends() MUST contain wgpu::Backends::VULKAN or wgpu::Backends::DX12"
       - "The shared wgpu::Instance is constructed with this mask so the GLES backend is never registered, and every enumerate_adapters call passes this mask"
+      - "This invariant holds in EVERY workspace crate that enumerates wgpu adapters: aprender-compute (wgpu 27), aprender-db and aprender-graph (wgpu 22), aprender-distribute (wgpu 23); Backends::PRIMARY excludes GL in all of those wgpu versions"
 
 proof_obligations:
   - type: invariant
@@ -50,10 +54,25 @@ proof_obligations:
 
 falsification_tests:
   - id: FALSIFY-WGPU-ENUM-GLES-001
-    rule: "gpu_backends() excludes GLES and includes the platform GPU backend"
+    rule: "aprender-compute gpu_backends() excludes GLES and includes the platform GPU backend"
     prediction: "The backend mask used by aprender-compute GPU enumeration does NOT contain Backends::GL but DOES contain the platform's real backend; RED on Backends::all() (contains GL), GREEN on Backends::PRIMARY"
     test: "cargo test -p aprender-compute --features gpu --lib test_gpu_backends_excludes_gles"
     if_fails: "Enumeration mask still includes GLES (or dropped the real backend) — Linux/AMD-RADV will SIGABRT in the GLES Drop path again"
+  - id: FALSIFY-WGPU-ENUM-GLES-002
+    rule: "aprender-db gpu_backends() excludes GLES and includes the platform GPU backend"
+    prediction: "The backend mask used by aprender-db GpuEngine / MultiGpuManager enumeration does NOT contain Backends::GL but DOES contain the platform's real backend; RED on Backends::all(), GREEN on Backends::PRIMARY (wgpu 22)"
+    test: "cargo test -p aprender-db --features gpu --lib test_gpu_backends_excludes_gles"
+    if_fails: "aprender-db enumeration still includes GLES — Linux/AMD-RADV SIGABRT in the GLES Drop path"
+  - id: FALSIFY-WGPU-ENUM-GLES-003
+    rule: "aprender-graph gpu_backends() excludes GLES and includes the platform GPU backend"
+    prediction: "The backend mask used by aprender-graph GpuDevice enumeration does NOT contain Backends::GL but DOES contain the platform's real backend; RED on Backends::all(), GREEN on Backends::PRIMARY (wgpu 22)"
+    test: "cargo test -p aprender-graph --features gpu --lib test_gpu_backends_excludes_gles"
+    if_fails: "aprender-graph enumeration still includes GLES — Linux/AMD-RADV SIGABRT in the GLES Drop path"
+  - id: FALSIFY-WGPU-ENUM-GLES-004
+    rule: "aprender-distribute gpu_backends() excludes GLES and includes the platform GPU backend"
+    prediction: "The backend mask used by the aprender-distribute GpuExecutor does NOT contain Backends::GL but DOES contain the platform's real backend; RED on Instance::default()/Backends::all(), GREEN on Backends::PRIMARY (wgpu 23)"
+    test: "cargo test -p aprender-distribute --features gpu --lib test_gpu_backends_excludes_gles"
+    if_fails: "aprender-distribute enumeration still includes GLES — Linux/AMD-RADV SIGABRT in the GLES Drop path"
 
 kani_harnesses:
   - id: KANI-WGPU-ENUM-GLES-001
@@ -64,7 +83,7 @@ kani_harnesses:
 qa_gate:
   id: F-WGPU-ENUM-GLES-001
   name: "wgpu adapter enumeration excludes GLES"
-  description: "Every wgpu Instance construction and enumerate_adapters call in aprender-compute uses a platform-appropriate backend mask (Backends::PRIMARY) that excludes GLES/EGL, so the broken GLES Drop path is never instantiated on Linux/AMD-RADV while the real Vulkan/Metal/DX12 GPU is still found."
+  description: "Every wgpu Instance construction and enumerate_adapters call across the workspace (aprender-compute, aprender-db, aprender-graph, aprender-distribute) uses a platform-appropriate backend mask (Backends::PRIMARY) that excludes GLES/EGL, so the broken GLES Drop path is never instantiated on Linux/AMD-RADV while the real Vulkan/Metal/DX12 GPU is still found."
   checks:
     - "enumeration_mask_excludes_gles"
-  pass_criteria: "FALSIFY-WGPU-ENUM-GLES-001 PASSES; on intel (AMD-RADV) the enumeration no longer SIGABRTs and the Vulkan adapter is still found; on mini (Apple Metal) the Metal adapter is still enumerated and parity tests still pass."
+  pass_criteria: "FALSIFY-WGPU-ENUM-GLES-001..004 PASS; on intel (AMD-RADV) enumeration in all four crates no longer SIGABRTs and the Vulkan adapter is still found; on mini (Apple Metal) the Metal adapter is still enumerated and parity/gpu tests still pass."

--- a/crates/aprender-db/src/gpu/kernels.rs
+++ b/crates/aprender-db/src/gpu/kernels.rs
@@ -656,7 +656,12 @@ mod tests {
         let data = Int32Array::from(vec![1, 2, 3, 4, 5]);
 
         // Create mock device/queue (not used by count())
-        let instance = wgpu::Instance::default();
+        // PMAT-927: non-GLES mask (Instance::default() == Backends::all() includes
+        // GL → SIGABRT-in-Drop on Linux/AMD-RADV).
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
+            backends: crate::gpu::gpu_backends(),
+            ..Default::default()
+        });
         let Some(adapter) = instance.request_adapter(&wgpu::RequestAdapterOptions::default()).await
         else {
             eprintln!("Skipping GPU test (no GPU available)");
@@ -677,7 +682,12 @@ mod tests {
     async fn test_count_empty_array() {
         let data = Int32Array::from(vec![] as Vec<i32>);
 
-        let instance = wgpu::Instance::default();
+        // PMAT-927: non-GLES mask (Instance::default() == Backends::all() includes
+        // GL → SIGABRT-in-Drop on Linux/AMD-RADV).
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
+            backends: crate::gpu::gpu_backends(),
+            ..Default::default()
+        });
         let Some(adapter) = instance.request_adapter(&wgpu::RequestAdapterOptions::default()).await
         else {
             eprintln!("Skipping GPU test (no GPU available)");
@@ -699,7 +709,12 @@ mod tests {
         // sum_f32 is placeholder - should return error
         let data = Float32Array::from(vec![1.0, 2.0, 3.0]);
 
-        let instance = wgpu::Instance::default();
+        // PMAT-927: non-GLES mask (Instance::default() == Backends::all() includes
+        // GL → SIGABRT-in-Drop on Linux/AMD-RADV).
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
+            backends: crate::gpu::gpu_backends(),
+            ..Default::default()
+        });
         let Some(adapter) = instance.request_adapter(&wgpu::RequestAdapterOptions::default()).await
         else {
             eprintln!("Skipping GPU test (no GPU available)");

--- a/crates/aprender-db/src/gpu/mod.rs
+++ b/crates/aprender-db/src/gpu/mod.rs
@@ -23,6 +23,32 @@ pub mod jit;
 pub mod kernels;
 pub mod multigpu;
 
+/// Platform-appropriate wgpu backend mask for adapter enumeration.
+///
+/// PMAT-927 (class follow-up to PMAT-925): `wgpu::Backends::all()` includes
+/// [`wgpu::Backends::GL`], which on Linux hosts that expose both Vulkan and
+/// GLES/EGL (notably the intel AMD-RADV cross-silicon baseline box) instantiates
+/// a GLES adapter whose `EglContext::make_current` **panics inside `Drop`**. A
+/// panic in a destructor during cleanup aborts the whole process with SIGABRT
+/// ("panic in a destructor during cleanup"); standalone enumeration can also
+/// spin/hang on the broken EGL path. The compute kernels themselves are correct
+/// — the fragility is purely in adapter *enumeration* and the GLES `Drop` path.
+///
+/// We return [`wgpu::Backends::PRIMARY`], which in wgpu 22 (this crate's pin) is
+/// `VULKAN | METAL | DX12 | BROWSER_WEBGPU` and **excludes** `GL` (GL lives only
+/// in `Backends::SECONDARY`). This keeps the real GPU on every platform — Vulkan
+/// on Linux/AMD-RADV, Metal on Apple, DX12 on Windows — while guaranteeing the
+/// broken GLES/EGL adapter is never created.
+///
+/// The mask is applied at BOTH the `wgpu::Instance` construction site (so the
+/// GLES backend is never even registered on the instance) and every
+/// `enumerate_adapters` call site.
+#[must_use]
+pub const fn gpu_backends() -> wgpu::Backends {
+    // PRIMARY = VULKAN | METAL | DX12 | BROWSER_WEBGPU (never GL/GLES).
+    wgpu::Backends::PRIMARY
+}
+
 /// GPU compute engine for aggregations
 pub struct GpuEngine {
     /// GPU device handle (public for benchmarking)
@@ -39,9 +65,11 @@ impl GpuEngine {
     /// # Errors
     /// Returns error if GPU initialization fails (no GPU available, driver issues, etc.)
     pub async fn new() -> Result<Self> {
-        // Request GPU adapter
+        // Request GPU adapter.
+        // PMAT-927: constrain to a non-GLES backend mask so the broken GLES/EGL
+        // adapter (SIGABRT-in-Drop on Linux/AMD-RADV) is never registered.
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
-            backends: wgpu::Backends::all(),
+            backends: gpu_backends(),
             ..Default::default()
         });
 
@@ -302,6 +330,42 @@ impl GpuEngine {
 mod tests {
     use super::*;
     use arrow::array::Int32Array;
+
+    /// PMAT-927 FALSIFIER: the wgpu adapter-enumeration backend mask used by
+    /// aprender-db MUST NOT contain GLES (`wgpu::Backends::GL`), and MUST contain
+    /// the platform's real backend.
+    ///
+    /// RED on `Backends::all()` (contains GL → GLES/EGL adapter → SIGABRT-in-Drop
+    /// on Linux/AMD-RADV). GREEN on `Backends::PRIMARY`. Host-independent: it
+    /// inspects the bitmask, it does not create any adapter.
+    #[test]
+    fn test_gpu_backends_excludes_gles() {
+        let mask = gpu_backends();
+
+        // The whole point: GLES/EGL must never be enumerated.
+        assert!(
+            !mask.contains(wgpu::Backends::GL),
+            "gpu_backends() must NOT include Backends::GL (GLES/EGL panics in Drop \
+             on Linux/AMD-RADV → SIGABRT). mask = {mask:?}"
+        );
+
+        // The real GPU backend on each platform must still be present.
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        assert!(
+            mask.contains(wgpu::Backends::VULKAN),
+            "gpu_backends() must include VULKAN on Linux (AMD-RADV/NVIDIA). mask = {mask:?}"
+        );
+        #[cfg(target_os = "macos")]
+        assert!(
+            mask.contains(wgpu::Backends::METAL),
+            "gpu_backends() must include METAL on macOS (Apple Silicon). mask = {mask:?}"
+        );
+        #[cfg(target_os = "windows")]
+        assert!(
+            mask.contains(wgpu::Backends::VULKAN) || mask.contains(wgpu::Backends::DX12),
+            "gpu_backends() must include VULKAN or DX12 on Windows. mask = {mask:?}"
+        );
+    }
 
     #[tokio::test]
     async fn test_gpu_init() {

--- a/crates/aprender-db/src/gpu/multigpu.rs
+++ b/crates/aprender-db/src/gpu/multigpu.rs
@@ -41,13 +41,16 @@ impl MultiGpuManager {
     /// # Errors
     /// Returns error if GPU enumeration fails
     pub fn new() -> Result<Self> {
+        // PMAT-927: constrain to a non-GLES backend mask (see `super::gpu_backends`)
+        // so the broken GLES/EGL adapter (SIGABRT-in-Drop on Linux/AMD-RADV) is
+        // never registered, at BOTH the instance and the enumerate_adapters site.
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
-            backends: wgpu::Backends::all(),
+            backends: super::gpu_backends(),
             ..Default::default()
         });
 
-        // Enumerate all adapters
-        let adapters = instance.enumerate_adapters(wgpu::Backends::all());
+        // Enumerate all adapters (non-GLES mask).
+        let adapters = instance.enumerate_adapters(super::gpu_backends());
 
         // Convert adapters to device info
         let devices: Vec<GpuDeviceInfo> = adapters

--- a/crates/aprender-db/src/topk.rs
+++ b/crates/aprender-db/src/topk.rs
@@ -493,9 +493,7 @@ mod tests {
         let values: Vec<f64> = (0..1_000_000).map(|i| f64::from(i)).collect();
         let batch = create_test_batch(values);
 
-        let start = std::time::Instant::now();
         let result = batch.top_k(1, 10, SortOrder::Descending).unwrap();
-        let duration = start.elapsed();
 
         assert_eq!(result.num_rows(), 10);
 

--- a/crates/aprender-db/tests/backend_story.rs
+++ b/crates/aprender-db/tests/backend_story.rs
@@ -229,7 +229,6 @@ fn test_backend_equivalence_large_dataset() {
 
 #[cfg(feature = "gpu")]
 mod gpu_tests {
-    use super::*;
     use arrow::array::Int32Array;
     use trueno_db::gpu::GpuEngine;
 

--- a/crates/aprender-distribute/src/executor/gpu.rs
+++ b/crates/aprender-distribute/src/executor/gpu.rs
@@ -46,6 +46,27 @@ use std::sync::Arc;
 use tracing::{debug, info, warn};
 use wgpu::{util::DeviceExt, Device, Instance, Queue};
 
+/// Platform-appropriate wgpu backend mask for adapter enumeration.
+///
+/// PMAT-927 (class follow-up to PMAT-925): `Instance::default()` uses
+/// `wgpu::Backends::all()`, which includes [`wgpu::Backends::GL`]. On Linux hosts
+/// that expose both Vulkan and GLES/EGL (notably the intel AMD-RADV cross-silicon
+/// baseline box) this instantiates a GLES adapter whose `EglContext::make_current`
+/// **panics inside `Drop`**, aborting the whole process with SIGABRT ("panic in a
+/// destructor during cleanup"); standalone enumeration can also spin/hang on the
+/// broken EGL path.
+///
+/// We return [`wgpu::Backends::PRIMARY`], which in wgpu 23 (this crate's pin) is
+/// `VULKAN | METAL | DX12 | BROWSER_WEBGPU` and **excludes** `GL` (GL lives only
+/// in `Backends::SECONDARY`). This keeps the real GPU on every platform — Vulkan
+/// on Linux/AMD-RADV, Metal on Apple, DX12 on Windows — while guaranteeing the
+/// broken GLES/EGL adapter is never created.
+#[must_use]
+pub const fn gpu_backends() -> wgpu::Backends {
+    // PRIMARY = VULKAN | METAL | DX12 | BROWSER_WEBGPU (never GL/GLES).
+    wgpu::Backends::PRIMARY
+}
+
 /// GPU executor using wgpu for cross-platform compute.
 ///
 /// This executor provides GPU-accelerated task execution using WebGPU/wgpu.
@@ -92,8 +113,14 @@ impl GpuExecutor {
     pub async fn new() -> Result<Self> {
         info!("Initializing GPU executor with wgpu");
 
-        // Create wgpu instance
-        let instance = Instance::default();
+        // Create wgpu instance.
+        // PMAT-927: constrain to a non-GLES backend mask (see `gpu_backends`) so
+        // the broken GLES/EGL adapter (SIGABRT-in-Drop on Linux/AMD-RADV) is never
+        // registered. `Instance::default()` would use `Backends::all()`.
+        let instance = Instance::new(wgpu::InstanceDescriptor {
+            backends: gpu_backends(),
+            ..Default::default()
+        });
 
         // Request adapter (GPU)
         let adapter = instance
@@ -495,6 +522,40 @@ impl Executor for GpuExecutor {
 )]
 mod tests {
     use super::*;
+
+    /// PMAT-927 FALSIFIER: the wgpu adapter-enumeration backend mask used by the
+    /// GPU executor MUST NOT contain GLES (`wgpu::Backends::GL`), and MUST contain
+    /// the platform's real backend.
+    ///
+    /// RED on `Backends::all()` / `Instance::default()` (contains GL → GLES/EGL
+    /// adapter → SIGABRT-in-Drop on Linux/AMD-RADV). GREEN on `Backends::PRIMARY`.
+    /// Host-independent: it inspects the bitmask, it does not create any adapter.
+    #[test]
+    fn test_gpu_backends_excludes_gles() {
+        let mask = gpu_backends();
+
+        assert!(
+            !mask.contains(wgpu::Backends::GL),
+            "gpu_backends() must NOT include Backends::GL (GLES/EGL panics in Drop \
+             on Linux/AMD-RADV → SIGABRT). mask = {mask:?}"
+        );
+
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        assert!(
+            mask.contains(wgpu::Backends::VULKAN),
+            "gpu_backends() must include VULKAN on Linux (AMD-RADV/NVIDIA). mask = {mask:?}"
+        );
+        #[cfg(target_os = "macos")]
+        assert!(
+            mask.contains(wgpu::Backends::METAL),
+            "gpu_backends() must include METAL on macOS (Apple Silicon). mask = {mask:?}"
+        );
+        #[cfg(target_os = "windows")]
+        assert!(
+            mask.contains(wgpu::Backends::VULKAN) || mask.contains(wgpu::Backends::DX12),
+            "gpu_backends() must include VULKAN or DX12 on Windows. mask = {mask:?}"
+        );
+    }
 
     #[tokio::test]
     async fn test_gpu_executor_creation() {

--- a/crates/aprender-graph/src/gpu/device.rs
+++ b/crates/aprender-graph/src/gpu/device.rs
@@ -5,6 +5,29 @@
 use thiserror::Error;
 use wgpu::util::DeviceExt;
 
+/// Platform-appropriate wgpu backend mask for adapter enumeration.
+///
+/// PMAT-927 (class follow-up to PMAT-925): `wgpu::Backends::all()` includes
+/// [`wgpu::Backends::GL`], which on Linux hosts that expose both Vulkan and
+/// GLES/EGL (notably the intel AMD-RADV cross-silicon baseline box) instantiates
+/// a GLES adapter whose `EglContext::make_current` **panics inside `Drop`**. A
+/// panic in a destructor during cleanup aborts the whole process with SIGABRT
+/// ("panic in a destructor during cleanup"); standalone enumeration can also
+/// spin/hang on the broken EGL path. The graph compute kernels themselves are
+/// correct — the fragility is purely in adapter *enumeration* and the GLES
+/// `Drop` path.
+///
+/// We return [`wgpu::Backends::PRIMARY`], which in wgpu 22 (this crate's pin) is
+/// `VULKAN | METAL | DX12 | BROWSER_WEBGPU` and **excludes** `GL` (GL lives only
+/// in `Backends::SECONDARY`). This keeps the real GPU on every platform — Vulkan
+/// on Linux/AMD-RADV, Metal on Apple, DX12 on Windows — while guaranteeing the
+/// broken GLES/EGL adapter is never created.
+#[must_use]
+pub const fn gpu_backends() -> wgpu::Backends {
+    // PRIMARY = VULKAN | METAL | DX12 | BROWSER_WEBGPU (never GL/GLES).
+    wgpu::Backends::PRIMARY
+}
+
 /// GPU device initialization errors
 #[derive(Debug, Error)]
 pub enum GpuDeviceError {
@@ -57,7 +80,10 @@ impl GpuDevice {
     /// - Device request fails
     /// - Required features not supported
     pub async fn new() -> Result<Self, GpuDeviceError> {
-        Self::new_with_backend(wgpu::Backends::all()).await
+        // PMAT-927: use the non-GLES mask (see `gpu_backends`) instead of
+        // Backends::all() so the broken GLES/EGL adapter (SIGABRT-in-Drop on
+        // Linux/AMD-RADV) is never registered.
+        Self::new_with_backend(gpu_backends()).await
     }
 
     /// Initialize GPU device with specific backend
@@ -162,6 +188,42 @@ impl GpuDevice {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// PMAT-927 FALSIFIER: the wgpu adapter-enumeration backend mask used by
+    /// aprender-graph MUST NOT contain GLES (`wgpu::Backends::GL`), and MUST
+    /// contain the platform's real backend.
+    ///
+    /// RED on `Backends::all()` (contains GL → GLES/EGL adapter → SIGABRT-in-Drop
+    /// on Linux/AMD-RADV). GREEN on `Backends::PRIMARY`. Host-independent: it
+    /// inspects the bitmask, it does not create any adapter.
+    #[test]
+    fn test_gpu_backends_excludes_gles() {
+        let mask = gpu_backends();
+
+        // The whole point: GLES/EGL must never be enumerated.
+        assert!(
+            !mask.contains(wgpu::Backends::GL),
+            "gpu_backends() must NOT include Backends::GL (GLES/EGL panics in Drop \
+             on Linux/AMD-RADV → SIGABRT). mask = {mask:?}"
+        );
+
+        // The real GPU backend on each platform must still be present.
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        assert!(
+            mask.contains(wgpu::Backends::VULKAN),
+            "gpu_backends() must include VULKAN on Linux (AMD-RADV/NVIDIA). mask = {mask:?}"
+        );
+        #[cfg(target_os = "macos")]
+        assert!(
+            mask.contains(wgpu::Backends::METAL),
+            "gpu_backends() must include METAL on macOS (Apple Silicon). mask = {mask:?}"
+        );
+        #[cfg(target_os = "windows")]
+        assert!(
+            mask.contains(wgpu::Backends::VULKAN) || mask.contains(wgpu::Backends::DX12),
+            "gpu_backends() must include VULKAN or DX12 on Windows. mask = {mask:?}"
+        );
+    }
 
     #[tokio::test]
     async fn test_gpu_device_creation() {

--- a/crates/aprender-graph/src/gpu/paged_bfs.rs
+++ b/crates/aprender-graph/src/gpu/paged_bfs.rs
@@ -44,7 +44,7 @@ use std::collections::VecDeque;
 /// Process a single node's neighbors within its tile, updating distances
 #[allow(clippy::cast_possible_truncation)]
 fn process_node_neighbors(
-    coordinator: &PagingCoordinator<'_>,
+    coordinator: &PagingCoordinator,
     node: NodeId,
     distances: &mut [u32],
     current_level: u32,
@@ -70,6 +70,15 @@ fn process_node_neighbors(
     Ok(())
 }
 
+/// Run GPU breadth-first search over a graph that may exceed VRAM.
+///
+/// When the graph fits in GPU memory this delegates to the in-VRAM
+/// [`super::gpu_bfs`]; otherwise it tiles the graph via [`PagingCoordinator`] and
+/// processes each tile in turn.
+///
+/// # Errors
+///
+/// Returns an error if GPU paging setup or any tile traversal fails.
 #[allow(clippy::cast_possible_truncation)]
 pub async fn gpu_bfs_paged(
     device: &GpuDevice,


### PR DESCRIPTION
## Summary

Class follow-up to **PMAT-925** (#2217). The PMAT-925 review found the SAME latent wgpu portability bug (GLES adapter SIGABRT-in-Drop on Linux/AMD-RADV) in every workspace crate that enumerates GPU adapters but was NOT touched by #2217:

| Crate | wgpu | Site |
|-------|------|------|
| aprender-db | 22 | `gpu/mod.rs` (Instance), `gpu/multigpu.rs` (Instance + enumerate_adapters), `gpu/kernels.rs` (3 test sites) |
| aprender-graph | 22 | `gpu/device.rs` (`Backends::all()`) |
| aprender-distribute | 23 | `executor/gpu.rs` (`Instance::default()`) |

Each passed `wgpu::Backends::all()` (or `Instance::default()`, which == `all()`), which includes `Backends::GL`. On Linux hosts that expose GLES/EGL alongside Vulkan (the intel AMD-RADV cross-silicon baseline box, reproduced on the lambda RTX 4090 box), `all()` instantiates a GLES adapter whose `EglContext::make_current()` unwraps and fails inside `Drop` → a panic in a destructor during cleanup aborts the WHOLE process with SIGABRT.

## Fix

Add a `gpu_backends()` helper in each crate returning `wgpu::Backends::PRIMARY`, applied at BOTH the `Instance` construction site (so the GLES backend is never registered — wgpu-core skips creating a hal instance for backends not in the descriptor) AND every `enumerate_adapters` call.

**Per-version verified:** `PRIMARY = VULKAN|METAL|DX12|BROWSER_WEBGPU` and `GL = SECONDARY` in wgpu-types **22, 23 AND 27** (checked the pinned source for each crate), so `PRIMARY` is the correct GL-excluding mask in every version.

## Falsifier (host-independent, per crate)

`test_gpu_backends_excludes_gles` asserts the mask does NOT contain `Backends::GL` and DOES contain the platform real backend.
- **RED** on `Backends::all()` (mask = `VULKAN|GL|METAL|DX12|BROWSER_WEBGPU`) — verified by temporarily reverting db to `all()`: test FAILS `"must NOT include Backends::GL"`.
- **GREEN** on `PRIMARY`.

## On-device evidence (lambda RTX 4090, reproduces the GLES path)

```
cargo test -p aprender-db -p aprender-graph -p aprender-distribute --features gpu --lib
  = 133 (graph) + 104 (db) + 93 (distribute) passed, 0 failed,
    ZERO egl SIGABRT; the real Vulkan adapter is still enumerated.
```

Cross-silicon verification on intel (AMD-RADV, where the crash repros) and mini (Apple Metal) is in progress and will be posted as a comment.

## Incidental fixes (pre-existing debt in the now-buildable gpu feature)

- `aprender-graph paged_bfs.rs`: stale `PagingCoordinator<'_>` lifetime arg (struct has 0 lifetime params) blocked `--features gpu` from compiling at all.
- `missing_docs` on `gpu_bfs_paged`; unused `duration` var (`topk.rs`) + unused `use super::*` (backend_story gpu_tests) surfaced once gpu compiled.

## Contract

`contracts/apr-wgpu-adapter-enumeration-excludes-gles-v1.yaml` bumped 1.0.0 → 1.1.0 — `FALSIFY-WGPU-ENUM-GLES-002/003/004` (db/graph/distribute), single-line falsifier refs. `pv validate` + `pv lint contracts/` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)