### PR TITLE
feat(validate): implement fail-closed structural checks + honor --strict (PMAT-926)

### DIFF
--- a/contracts/apr-validate-fail-closed-v1.yaml
+++ b/contracts/apr-validate-fail-closed-v1.yaml
@@ -1,0 +1,121 @@
+contract: apr-validate-fail-closed
+metadata:
+  version: 1.0.0
+  created: '2026-06-24'
+  author: PAIML Engineering
+  description: >
+    PMAT-926 Pillar-4 fail-closed parity for the `.apr` path of `apr validate`.
+    Before this contract, `apr validate <file.apr>` routed to the stubbed
+    `AprValidator`, whose `validate_bytes -> validate_structure` only checks
+    magic / header size / version / flags (4 real checks) — every Section-A
+    structural check 5-25 and every Section-B physics check is a
+    `Skip("Not implemented")` placeholder, and `--strict` printed
+    "not yet implemented, flag ignored." A semantically-broken `.apr`
+    (all-zero `lm_head.weight`, NaN/Inf tensor, constant/dead-row weight) was
+    reported `VALID 4/100` and ran silently — exactly the garbage llama.cpp /
+    Ollama load and run (PMAT-744 class). The fully-implemented `.apr` content
+    validator (`RosettaStone::validate_apr -> compute_tensor_validation_with_shape`,
+    F-DATA-QUALITY-001..007) already existed but was UNREACHABLE from the CLI.
+    This contract binds the fix: `apr validate <file.apr>` now ALSO runs the
+    Rosetta content gates and gates its exit code on them (parity with the
+    GGUF/SafeTensors path), and `--strict` is honored — any NaN / Inf /
+    all-zero finding escalates to a hard non-zero exit. A healthy `.apr` still
+    validates clean (no false positives); `--skip-contract` bypasses the gate.
+  kind: pattern
+  references:
+    - "paiml/aprender PMAT-926 (apr validate .apr fail-closed + --strict wiring)"
+    - "crates/apr-cli/src/commands/validate.rs (run_apr_validation/gate_apr_content/strict_blocking_issues)"
+    - "crates/aprender-core/src/format/rosetta/validate_inspect.rs (validate_apr/compute_tensor_validation_with_shape, F-DATA-QUALITY-001..007)"
+    - "crates/aprender-core/src/format/rosetta/arch_inference.rs (RosettaStone::validate dispatch)"
+    - "contracts/apr-fail-closed-garbage-beat-v1.yaml (F-DATA-QUALITY-001..007 obligations reused via the dispatch)"
+    - "contracts/apr-validate-quality-threshold-v1.yaml (structural 100-point report still drives the human-readable summary)"
+  registry: true
+  tags:
+    - cli
+    - validate
+    - fail-closed
+    - pillar-4
+    - strict
+
+five_whys:
+  symptom: "`apr validate model.apr` on a model whose lm_head.weight is entirely zero (a dead model) reports `VALID 4/100 points` and exits 0 — the same artifact llama.cpp / Ollama load and run silently."
+  why_1: "validate.rs dispatched FormatType::Apr to the stubbed AprValidator, whose validate_bytes only runs validate_structure (magic/header/version/flags)."
+  why_2: "Section-A structural checks 5-25 and the Section-B physics checks (NaN/Inf/all-zero/layernorm) live in validate_tensors(), which the CLI never calls — no add_tensor_stats() is populated, so on the .apr path they are no-ops."
+  why_3: "The REAL content gates (F-DATA-QUALITY-001..007) exist in RosettaStone::validate_apr but the CLI only routed GGUF/SafeTensors to RosettaStone — the .apr branch never reached them (dead code from the entry point)."
+  why_4: "--strict was explicitly a no-op on the .apr path (print_apr_validation_json / print_summary eprintln 'not yet implemented, flag ignored'), so even an operator opting into strict mode got VALID on garbage."
+  why_5: "No contract bound the .apr validate exit code to the data-quality gates — 'apr validate is fail-closed for every format it accepts' was an unstated, unenforced invariant; it held for GGUF/ST but silently not for .apr."
+  root_cause: "The .apr CLI path never ran content validation. The fix runs RosettaStone::validate(path) for .apr and gates the exit code via gate_apr_content (fail-closed) + strict_blocking_issues (--strict), reaching parity with the GGUF/SafeTensors path while preserving the structural 100-point report for the human-readable table."
+
+equations:
+  apr_content_gate:
+    formula: "fail_closed(report) = NOT skip_contract AND ((strict AND strict_blocking(report)) OR NOT report.is_valid)"
+    domain: "apr validate <file.apr> invocation; report = RosettaStone.validate(file.apr)"
+    codomain: "boolean: should exit non-zero (ValidationFailed)"
+    invariants:
+      - "A content-broken .apr (any tensor failing an F-DATA-QUALITY gate) fails closed when skip_contract is false"
+      - "A healthy .apr (report.is_valid, no strict-blocking findings) passes — no false positive"
+      - "--skip-contract bypasses the gate entirely (parity with GGUF/SafeTensors)"
+      - "A structural parse failure (bad magic / truncated / checksum mismatch) surfaces as ValidationFailed"
+
+  strict_blocking:
+    formula: "strict_blocking(report) = report.total_nan_count > 0 OR report.total_inf_count > 0 OR report.all_zero_tensors non-empty"
+    domain: "RosettaStone validation reports (APR and GGUF/SafeTensors identically)"
+    codomain: "boolean: --strict must escalate to non-zero exit"
+    invariants:
+      - "A NaN, Inf, or all-zero finding is strict-blocking on BOTH the .apr and the GGUF/SafeTensors path"
+      - "A report with zero NaN, zero Inf, and no all-zero tensors is NOT strict-blocking"
+      - "strict_blocking_issues() returns None iff strict_blocking(report) is false"
+
+proof_obligations:
+  - type: invariant
+    property: "Content-broken .apr is rejected from the CLI (dispatch re-route)"
+    formal: "all_zero(lm_head) OR has_nan(tensor) ⟹ fail_closed(validate(file.apr))"
+    applies_to: apr_content_gate
+  - type: invariant
+    property: "Healthy .apr still validates clean (no false positive)"
+    formal: "healthy(file.apr) ⟹ NOT fail_closed(validate(file.apr))"
+    applies_to: apr_content_gate
+  - type: invariant
+    property: "--strict escalates an all-zero / NaN / Inf finding to non-zero exit on the .apr path"
+    formal: "strict AND strict_blocking(report) ⟹ fail_closed(report)"
+    applies_to: strict_blocking
+  - type: invariant
+    property: "--skip-contract bypasses the content gate"
+    formal: "skip_contract ⟹ NOT fail_closed(report)"
+    applies_to: apr_content_gate
+
+falsification_tests:
+  - id: FALSIFY-VALIDATE-APR-DISPATCH-001
+    rule: "apr validate REJECTS an all-zero lm_head .apr (content gate now reachable)"
+    prediction: "run() on a valid-header .apr with an all-zero lm_head.weight returns Err"
+    test: "cargo test -p apr-cli --lib pmat926_falsifier_all_zero_lm_head_apr_rejected"
+    if_fails: "The .apr path still routes to the stubbed AprValidator and accepts garbage"
+  - id: FALSIFY-VALIDATE-APR-DISPATCH-002
+    rule: "apr validate REJECTS a NaN tensor in a .apr"
+    prediction: "run() on a .apr with NaN weights returns Err"
+    test: "cargo test -p apr-cli --lib pmat926_falsifier_nan_tensor_apr_rejected"
+    if_fails: "NaN .apr content is never inspected from the CLI"
+  - id: FALSIFY-VALIDATE-APR-NOFALSEPOS-001
+    rule: "apr validate ACCEPTS a healthy .apr (no false positive)"
+    prediction: "run() on a .apr of varied finite non-zero weights returns Ok"
+    test: "cargo test -p apr-cli --lib pmat926_valid_apr_still_passes"
+    if_fails: "The fail-closed gate rejects good models"
+  - id: FALSIFY-VALIDATE-STRICT-001
+    rule: "--strict escalates an all-zero-tensor .apr to a non-zero exit"
+    prediction: "run() with strict=true on a .apr with an all-zero tensor returns Err"
+    test: "cargo test -p apr-cli --lib pmat926_falsifier_strict_apr_all_zero_nonzero_exit"
+    if_fails: "--strict remains a no-op on the .apr path"
+  - id: FALSIFY-VALIDATE-SKIP-001
+    rule: "--skip-contract bypasses the .apr content gate"
+    prediction: "run() with skip_contract=true on a content-broken .apr returns Ok"
+    test: "cargo test -p apr-cli --lib pmat926_skip_contract_bypasses_content_gate"
+    if_fails: "--skip-contract no longer bypasses the gate (regression vs GGUF/ST parity)"
+
+qa_gate:
+  id: F-VALIDATE-APR-FAIL-CLOSED-001
+  name: "apr validate is fail-closed on the .apr path with --strict honored"
+  description: "A content-broken .apr (all-zero/NaN/Inf/constant/dead-row) is REJECTED at parity with the GGUF/SafeTensors path; a healthy .apr passes; --strict escalates warn-level findings to a non-zero exit; --skip-contract bypasses the gate."
+  checks:
+    - "apr_content_gate"
+    - "strict_blocking"
+  pass_criteria: "FALSIFY-VALIDATE-APR-DISPATCH-{001,002}, FALSIFY-VALIDATE-APR-NOFALSEPOS-001, FALSIFY-VALIDATE-STRICT-001, FALSIFY-VALIDATE-SKIP-001 all PASS"

--- a/crates/apr-cli/src/commands/validate.rs
+++ b/crates/apr-cli/src/commands/validate.rs
@@ -5,6 +5,7 @@
 
 use crate::error::CliError;
 use crate::output;
+use aprender::error::AprenderError;
 use aprender::format::rosetta::{
     FormatType, RosettaStone, ValidationReport as RosettaValidationReport,
 };
@@ -58,7 +59,23 @@ pub(crate) fn run(
     result
 }
 
-/// APR validation via 100-point QA checklist (existing path)
+/// APR validation via 100-point QA checklist + fail-closed content gates.
+///
+/// PMAT-926: the 100-point structural report (`AprValidator`) only covers
+/// magic / header / version / flags on the `.apr` path — every Section-A
+/// structural check 5-25 and every Section-B physics check is a
+/// `Skip("Not implemented")` stub, and `--strict` was a no-op. The REAL
+/// fail-closed content gates (F-DATA-QUALITY-001..007: all-zero, NaN/Inf,
+/// L2~0, constant, density, dead output row) already exist in
+/// `RosettaStone::validate_apr` but were UNREACHABLE from the CLI.
+///
+/// We now run BOTH:
+///   1. the structural 100-point report (for the human-readable table), and
+///   2. the Rosetta content gates on the dequantized `.apr` tensors,
+/// and gate the exit code on the content gates so a content-broken `.apr`
+/// (e.g. an all-zero `lm_head.weight`, or a NaN/Inf tensor) is REJECTED at
+/// parity with the GGUF / SafeTensors path. `--strict` is now honored:
+/// any NaN / Inf / all-zero finding escalates to a hard non-zero exit.
 fn run_apr_validation(
     path: &Path,
     quality: bool,
@@ -71,12 +88,18 @@ fn run_apr_validation(
     let mut validator = AprValidator::new();
     let report = validator.validate_bytes(&data);
 
+    // PMAT-926: run the real fail-closed content gates on the .apr tensors.
+    // If the structural parse fails (bad magic / truncated / checksum
+    // mismatch), `content` is the parse error — surfaced below so the
+    // existing "invalid file" behavior is preserved.
+    let content = RosettaStone::new().validate(path);
+
     if json {
-        return print_apr_validation_json(path, report, strict, min_score);
+        return print_apr_validation_json(path, report, &content, strict, min_score, skip_contract);
     }
 
     print_check_results(report);
-    print_summary(report, strict)?;
+    print_summary(report)?;
 
     if quality {
         print_quality_assessment(report);
@@ -113,7 +136,83 @@ fn run_apr_validation(
         // canonical pass/fail gate per CLAUDE.md.)
     }
 
-    Ok(())
+    // PMAT-926: fail-closed content gate (F-DATA-QUALITY-001..007) +
+    // --strict wiring, applied identically to the Rosetta GGUF/ST path.
+    gate_apr_content(&content, strict, skip_contract)
+}
+
+/// PMAT-926: gate the `.apr` exit code on the Rosetta content gates.
+///
+/// `--skip-contract` bypasses the content gate entirely (matches the
+/// GGUF/SafeTensors path). Otherwise:
+///   * `--strict` escalates any NaN / Inf / all-zero / L2~0 finding to a
+///     hard non-zero exit (F-VALIDATE-STRICT-001), and
+///   * any tensor that fails a data-quality gate (constant weight, density,
+///     dead output row, NaN/Inf) fails closed (F-VALIDATE-APR-DISPATCH-001).
+///
+/// A clean, valid model produces an empty failure set → `Ok(())` (no false
+/// positives). A structural parse error (bad magic / truncated / checksum
+/// mismatch) surfaces as `ValidationFailed`.
+fn gate_apr_content(
+    content: &Result<RosettaValidationReport, AprenderError>,
+    strict: bool,
+    skip_contract: bool,
+) -> Result<(), CliError> {
+    if skip_contract {
+        return Ok(());
+    }
+
+    let report = match content {
+        Ok(report) => report,
+        Err(e) => {
+            // Structural parse failure (magic / header / checksum / truncated).
+            return Err(CliError::ValidationFailed(format!(
+                "APR content validation failed: {e}"
+            )));
+        }
+    };
+
+    if strict {
+        if let Some(issues) = strict_blocking_issues(report) {
+            return Err(CliError::ValidationFailed(format!("Strict mode: {issues}")));
+        }
+    }
+
+    if report.is_valid {
+        Ok(())
+    } else {
+        Err(CliError::ValidationFailed(format!(
+            "{} tensors failed data-quality validation (F-DATA-QUALITY)",
+            report.failed_tensor_count
+        )))
+    }
+}
+
+/// Summarize the strict-blocking findings (NaN / Inf / all-zero) for a
+/// Rosetta report, or `None` if there are none. Shared by the APR and the
+/// GGUF/SafeTensors `--strict` gates so both paths behave identically
+/// (F-VALIDATE-STRICT-001).
+fn strict_blocking_issues(report: &RosettaValidationReport) -> Option<String> {
+    if report.total_nan_count == 0
+        && report.total_inf_count == 0
+        && report.all_zero_tensors.is_empty()
+    {
+        return None;
+    }
+    let mut issues = Vec::new();
+    if report.total_nan_count > 0 {
+        issues.push(format!("{} NaN values", report.total_nan_count));
+    }
+    if report.total_inf_count > 0 {
+        issues.push(format!("{} Inf values", report.total_inf_count));
+    }
+    if !report.all_zero_tensors.is_empty() {
+        issues.push(format!(
+            "{} all-zero tensors",
+            report.all_zero_tensors.len()
+        ));
+    }
+    Some(issues.join(", "))
 }
 
 /// GGUF/SafeTensors validation via RosettaStone (physics constraints)
@@ -132,31 +231,12 @@ fn run_rosetta_validation(
 
     if json {
         // GH-610: Apply strict checks before JSON output (was previously skipped)
-        if strict
-            && !skip_contract
-            && (report.total_nan_count > 0
-                || report.total_inf_count > 0
-                || !report.all_zero_tensors.is_empty())
-        {
-            let mut issues = Vec::new();
-            if report.total_nan_count > 0 {
-                issues.push(format!("{} NaN values", report.total_nan_count));
+        if strict && !skip_contract {
+            if let Some(issues) = strict_blocking_issues(&report) {
+                // Still print the JSON report before returning error
+                let _ = print_rosetta_validation_json(path, &report, format, quality);
+                return Err(CliError::ValidationFailed(format!("Strict mode: {issues}")));
             }
-            if report.total_inf_count > 0 {
-                issues.push(format!("{} Inf values", report.total_inf_count));
-            }
-            if !report.all_zero_tensors.is_empty() {
-                issues.push(format!(
-                    "{} all-zero tensors",
-                    report.all_zero_tensors.len()
-                ));
-            }
-            // Still print the JSON report before returning error
-            let _ = print_rosetta_validation_json(path, &report, format, quality);
-            return Err(CliError::ValidationFailed(format!(
-                "Strict mode: {}",
-                issues.join(", ")
-            )));
         }
         return print_rosetta_validation_json(path, &report, format, quality);
     }
@@ -194,29 +274,10 @@ fn run_rosetta_validation(
 
     // GH-507: --strict fails on warnings (NaN, Inf, all-zero tensors)
     // GH-642: --skip-contract bypasses strict contract checks
-    if strict
-        && !skip_contract
-        && (report.total_nan_count > 0
-            || report.total_inf_count > 0
-            || !report.all_zero_tensors.is_empty())
-    {
-        let mut issues = Vec::new();
-        if report.total_nan_count > 0 {
-            issues.push(format!("{} NaN values", report.total_nan_count));
+    if strict && !skip_contract {
+        if let Some(issues) = strict_blocking_issues(&report) {
+            return Err(CliError::ValidationFailed(format!("Strict mode: {issues}")));
         }
-        if report.total_inf_count > 0 {
-            issues.push(format!("{} Inf values", report.total_inf_count));
-        }
-        if !report.all_zero_tensors.is_empty() {
-            issues.push(format!(
-                "{} all-zero tensors",
-                report.all_zero_tensors.len()
-            ));
-        }
-        return Err(CliError::ValidationFailed(format!(
-            "Strict mode: {}",
-            issues.join(", ")
-        )));
     }
 
     // GH-658: A model with 0 tensors is invalid (truncated/corrupt).
@@ -301,15 +362,15 @@ fn print_contract_violations(failures: &[(&str, &str)]) {
 fn print_apr_validation_json(
     path: &Path,
     report: &ValidationReport,
+    content: &Result<RosettaValidationReport, AprenderError>,
     strict: bool,
     min_score: Option<u8>,
+    skip_contract: bool,
 ) -> Result<(), CliError> {
-    // GH-531: Warn that --strict is not yet implemented for APR JSON output
-    if strict {
-        eprintln!(
-            "Warning: --strict is not yet implemented for APR JSON validation. Flag ignored."
-        );
-    }
+    // PMAT-926: --strict is now honored on the APR JSON path. The structural
+    // 100-point report still drives `passed`, but the fail-closed content
+    // gate (F-DATA-QUALITY) is applied AFTER the JSON is printed so machine
+    // consumers always get a report, and the exit code fails closed.
     let passed =
         report.failed_checks().is_empty() && min_score.is_none_or(|min| report.total_score >= min);
     // GH-251: Only include executed checks (PASS/FAIL) — SKIP/WARN are not actionable
@@ -334,6 +395,19 @@ fn print_apr_validation_json(
             })
         })
         .collect();
+    // PMAT-926: surface the fail-closed content-gate summary in the JSON so
+    // machine consumers can see WHY the .apr was rejected (parity with the
+    // human-readable path).
+    let (content_passed, content_nan, content_inf, content_zero, content_failed) = match content {
+        Ok(r) => (
+            r.is_valid,
+            r.total_nan_count,
+            r.total_inf_count,
+            r.all_zero_tensors.len(),
+            r.failed_tensor_count,
+        ),
+        Err(_) => (false, 0, 0, 0, 0),
+    };
     let output = serde_json::json!({
         "model": path.display().to_string(),
         "format": "apr",
@@ -342,7 +416,12 @@ fn print_apr_validation_json(
         "checks": checks_json,
         "total_checks": report.checks.len(),
         "failed": report.failed_checks().len(),
-        "passed": passed,
+        "passed": passed && content_passed,
+        "content_passed": content_passed,
+        "content_total_nan": content_nan,
+        "content_total_inf": content_inf,
+        "content_all_zero_tensors": content_zero,
+        "content_failed_tensors": content_failed,
     });
     println!(
         "{}",
@@ -354,7 +433,8 @@ fn print_apr_validation_json(
             report.total_score
         )));
     }
-    Ok(())
+    // PMAT-926: fail-closed content gate + --strict, after the JSON is printed.
+    gate_apr_content(content, strict, skip_contract)
 }
 
 /// Print Rosetta validation report as JSON (GH-240/GH-251: machine-parseable output).
@@ -463,13 +543,10 @@ fn print_check_results(report: &ValidationReport) {
     );
 }
 
-fn print_summary(report: &ValidationReport, strict: bool) -> Result<(), CliError> {
-    // GH-531: Warn that --strict is not yet implemented for APR validation summary
-    if strict {
-        eprintln!(
-            "Warning: --strict is not yet implemented for APR validation summary. Flag ignored."
-        );
-    }
+fn print_summary(report: &ValidationReport) -> Result<(), CliError> {
+    // PMAT-926: --strict is now honored via the fail-closed content gate
+    // (`gate_apr_content`), not ignored here. This function prints only the
+    // structural 100-point summary table.
     println!();
 
     let failed_checks = report.failed_checks();

--- a/crates/apr-cli/src/commands/validate_tests.rs
+++ b/crates/apr-cli/src/commands/validate_tests.rs
@@ -203,7 +203,7 @@ fn test_print_summary_valid_report() {
         category_scores: HashMap::new(),
     };
 
-    let result = print_summary(&report, false);
+    let result = print_summary(&report);
     assert!(result.is_ok());
 }
 
@@ -346,4 +346,169 @@ fn test_run_gguf_with_physics_violations() {
     // Should fail due to NaN physics violation
     let result = run(file.path(), false, false, None, false, false);
     assert!(result.is_err(), "Should fail with NaN tensors");
+}
+
+// ========================================================================
+// PMAT-926: APR fail-closed content gates + --strict wiring
+//
+// Contract: apr-validate-fail-closed-v1.yaml
+//   - F-VALIDATE-APR-DISPATCH-001 (content-broken .apr REJECTED)
+//   - F-VALIDATE-STRICT-001        (--strict escalates warn → non-zero exit)
+//
+// Before PMAT-926 the `.apr` path routed to the stubbed `AprValidator`
+// (magic/header/version/flags only) and `--strict` printed
+// "not yet implemented, flag ignored" — so a semantically-broken `.apr`
+// (all-zero lm_head, NaN/Inf, constant weight) was reported VALID and ran
+// silently, exactly the class of garbage llama.cpp / Ollama load and run.
+// These falsifiers go RED on the stub and GREEN on the fix; a valid model
+// still passes (no false positives).
+// ========================================================================
+
+/// Build a syntactically-valid `.apr` file from `(name, shape, data)` tensors.
+/// Header checksum + offsets are computed by `AprV2Writer`, so the file is a
+/// genuinely-parseable model — only the *content* of the tensors varies.
+fn write_apr_fixture(tensors: &[(&str, Vec<usize>, Vec<f32>)]) -> NamedTempFile {
+    use aprender::format::v2::{AprV2Metadata, AprV2Writer};
+
+    let metadata = AprV2Metadata::new("test");
+    let mut writer = AprV2Writer::new(metadata);
+    for (name, shape, data) in tensors {
+        writer.add_tensor_f32_owned(*name, shape.clone(), data.clone());
+    }
+    let mut apr_bytes = Vec::new();
+    writer.write_to(&mut apr_bytes).expect("write APR fixture");
+
+    let mut file = NamedTempFile::with_suffix(".apr").expect("create temp file");
+    file.write_all(&apr_bytes).expect("write apr bytes");
+    file
+}
+
+/// A healthy weight column with variation (passes all data-quality gates).
+fn healthy_weights(n: usize) -> Vec<f32> {
+    (0..n).map(|i| ((i as f32) * 0.013 - 0.5) * 0.2).collect()
+}
+
+/// FALSIFIER (F-VALIDATE-APR-DISPATCH-001): a valid-header `.apr` whose
+/// `lm_head.weight` is entirely zero must be REJECTED. RED on the stub
+/// (`AprValidator` never inspects tensor content → returns VALID), GREEN
+/// after re-routing through the Rosetta content gates.
+#[test]
+fn pmat926_falsifier_all_zero_lm_head_apr_rejected() {
+    // 8x4 lm_head, every weight zero (dead model). 4x4 healthy embed so the
+    // file is otherwise well-formed.
+    let file = write_apr_fixture(&[
+        ("lm_head.weight", vec![8, 4], vec![0.0; 32]),
+        ("model.embed_tokens.weight", vec![4, 4], healthy_weights(16)),
+    ]);
+
+    let result = run(file.path(), false, false, None, false, false);
+    assert!(
+        result.is_err(),
+        "all-zero lm_head .apr must be REJECTED (F-VALIDATE-APR-DISPATCH-001), got Ok"
+    );
+}
+
+/// FALSIFIER (F-VALIDATE-APR-DISPATCH-001): a `.apr` with NaN weights is
+/// REJECTED. The incumbents load and run NaN weights silently.
+#[test]
+fn pmat926_falsifier_nan_tensor_apr_rejected() {
+    let mut nan_block = healthy_weights(32);
+    nan_block[5] = f32::NAN;
+    nan_block[17] = f32::NAN;
+    let file = write_apr_fixture(&[
+        ("lm_head.weight", vec![8, 4], healthy_weights(32)),
+        ("model.layers.0.mlp.down_proj.weight", vec![8, 4], nan_block),
+    ]);
+
+    let result = run(file.path(), false, false, None, false, false);
+    assert!(
+        result.is_err(),
+        "NaN .apr must be REJECTED (F-VALIDATE-APR-DISPATCH-001), got Ok"
+    );
+}
+
+/// NO-FALSE-POSITIVE: a healthy `.apr` (varied, non-zero, finite weights)
+/// must still validate clean. Guards the fail-closed gate against rejecting
+/// good models.
+#[test]
+fn pmat926_valid_apr_still_passes() {
+    let file = write_apr_fixture(&[
+        ("lm_head.weight", vec![8, 4], healthy_weights(32)),
+        ("model.embed_tokens.weight", vec![8, 4], healthy_weights(32)),
+        (
+            "model.layers.0.mlp.down_proj.weight",
+            vec![8, 4],
+            healthy_weights(32),
+        ),
+    ]);
+
+    let result = run(file.path(), false, false, None, false, false);
+    assert!(
+        result.is_ok(),
+        "healthy .apr must still PASS (no false positives), got {result:?}"
+    );
+}
+
+/// FALSIFIER (F-VALIDATE-STRICT-001): `--strict` escalates a warn-level
+/// finding to a hard non-zero exit on the `.apr` path. Before PMAT-926
+/// `--strict` was a documented no-op for APR ("flag ignored").
+#[test]
+fn pmat926_falsifier_strict_apr_all_zero_nonzero_exit() {
+    // A standalone all-zero tensor (not an output-projection role) lands in
+    // `all_zero_tensors` — a strict-blocking finding.
+    let file = write_apr_fixture(&[
+        ("lm_head.weight", vec![8, 4], healthy_weights(32)),
+        (
+            "model.layers.0.self_attn.q_proj.bias",
+            vec![8],
+            vec![0.0; 8],
+        ),
+    ]);
+
+    // strict = true must fail closed.
+    let strict_result = run(file.path(), false, true, None, false, false);
+    assert!(
+        strict_result.is_err(),
+        "--strict on an all-zero-tensor .apr must exit non-zero (F-VALIDATE-STRICT-001), got Ok"
+    );
+}
+
+/// `--skip-contract` bypasses the fail-closed content gate (parity with the
+/// GGUF/SafeTensors path) — a broken `.apr` is accepted when the operator
+/// explicitly opts out.
+#[test]
+fn pmat926_skip_contract_bypasses_content_gate() {
+    let file = write_apr_fixture(&[
+        ("lm_head.weight", vec![8, 4], vec![0.0; 32]),
+        ("model.embed_tokens.weight", vec![4, 4], healthy_weights(16)),
+    ]);
+
+    let result = run(
+        file.path(),
+        false,
+        false,
+        None,
+        false,
+        /* skip_contract */ true,
+    );
+    assert!(
+        result.is_ok(),
+        "--skip-contract must bypass the content gate, got {result:?}"
+    );
+}
+
+/// JSON path also fails closed on a content-broken `.apr` (the report is
+/// still printed, but the exit code is non-zero).
+#[test]
+fn pmat926_json_apr_all_zero_lm_head_rejected() {
+    let file = write_apr_fixture(&[
+        ("lm_head.weight", vec![8, 4], vec![0.0; 32]),
+        ("model.embed_tokens.weight", vec![4, 4], healthy_weights(16)),
+    ]);
+
+    let result = run(file.path(), false, false, None, /* json */ true, false);
+    assert!(
+        result.is_err(),
+        "JSON .apr path must fail closed on content-broken model, got Ok"
+    );
 }


### PR DESCRIPTION
## Summary

The `.apr` path of `apr validate` was **not fail-closed**. `validate.rs` routed `FormatType::Apr` to the stubbed `AprValidator`, whose `validate_bytes -> validate_structure` runs only 4 real checks (magic / header size / version / flags). Section-A structural checks 5-25 and every Section-B physics check are `Skip("Not implemented")` placeholders, and `--strict` printed *"not yet implemented, flag ignored."*

A semantically-broken `.apr` (all-zero `lm_head.weight`, NaN/Inf, constant/dead-row weight) was reported `VALID 4/100` and exited 0 — exactly the garbage llama.cpp / Ollama load and run silently (the PMAT-744 Pillar-4 class). The fully-implemented `.apr` content validator (`RosettaStone::validate_apr`, `F-DATA-QUALITY-001..007` incl. PMAT-889 dead-row L2) already existed but was **unreachable** from the CLI.

## Fix

`run_apr_validation` now ALSO runs `RosettaStone::validate(path)` and gates the exit code on the content gates:
- `gate_apr_content` — fail-closed on any `F-DATA-QUALITY` failure (all-zero / NaN / Inf / constant / density / dead output row)
- `strict_blocking_issues` — `--strict` escalates any NaN / Inf / all-zero finding to a hard non-zero exit (both human + JSON output), now **shared** with the GGUF/SafeTensors path (de-duplicated)
- `--skip-contract` bypasses the gate (parity with GGUF/SafeTensors)
- structural 100-point report preserved for the human-readable table

A healthy `.apr` still validates clean — **no false positives**.

## Checks implemented (now real on the `.apr` CLI path)

- **F-VALIDATE-APR-DISPATCH-001** — content-broken `.apr` REJECTED (all-zero lm_head / NaN / Inf / constant / dead output row)
- **F-VALIDATE-STRICT-001** — `--strict` escalates warn-level findings to non-zero exit (previously a documented no-op for APR)

## Falsifiers (RED on stub, GREEN on fix; mutation-verified)

Disabling `gate_apr_content` flips the 4 reject/strict falsifiers RED while the 2 accept falsifiers stay GREEN — the gate is load-bearing:

| Test | Asserts |
|------|---------|
| `pmat926_falsifier_all_zero_lm_head_apr_rejected` | all-zero lm_head `.apr` → Err |
| `pmat926_falsifier_nan_tensor_apr_rejected` | NaN `.apr` → Err |
| `pmat926_falsifier_strict_apr_all_zero_nonzero_exit` | `--strict` all-zero `.apr` → Err |
| `pmat926_json_apr_all_zero_lm_head_rejected` | JSON path fails closed |
| `pmat926_valid_apr_still_passes` | healthy `.apr` → Ok (no false positive) |
| `pmat926_skip_contract_bypasses_content_gate` | `--skip-contract` → Ok |

## Contract

`contracts/apr-validate-fail-closed-v1.yaml` — `pv validate` + `pv lint contracts/` pass (0 errors); `lint_passes_on_real_contracts` green.

## Verification

- `cargo test -p apr-cli --lib` → 6014 pass
- `cargo test -p aprender-core --lib` → 14009 pass
- `cargo test -p aprender-contracts --lib lint` → 191 pass
- `cargo fmt -p apr-cli --check` clean; clippy clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)