### PR TITLE
test(serve): PMAT-125 B3 — CPU-only unit tests for serve/* HTTP + plan layer (+89 tests)

### DIFF
--- a/crates/apr-cli/src/commands/serve/chat.rs
+++ b/crates/apr-cli/src/commands/serve/chat.rs
@@ -477,3 +477,288 @@ fn build_chat_response(
         .into_response()
     }
 }
+
+// ============================================================================
+// PMAT-125 B3: unit tests for SafeTensors chat/tokenizer pure helpers.
+//
+// `chat.rs` is `include!`d into the `serve::safetensors` module, so these
+// helpers (plus `parse_special_token` / `classify_bos_eos` /
+// `merge_special_tokens_into_vocab` defined in `safetensors.rs` itself) are all
+// in that scope. The `types` module is a sibling under `serve`, reached via
+// `super::super::types`. CPU-only: no transformer, no GPU.
+// ============================================================================
+#[cfg(all(test, feature = "inference"))]
+mod chat_helper_tests {
+    use super::*;
+
+    // ---- classify_bos_eos ---------------------------------------------
+
+    #[test]
+    fn classify_bos_eos_detects_bos_markers() {
+        assert_eq!(classify_bos_eos("<s>"), (true, false));
+        assert_eq!(classify_bos_eos("<|bos|>"), (true, false));
+    }
+
+    #[test]
+    fn classify_bos_eos_detects_eos_markers() {
+        assert_eq!(classify_bos_eos("</s>"), (false, true));
+        assert_eq!(classify_bos_eos("<|eos|>"), (false, true));
+        assert_eq!(classify_bos_eos("<|im_end|>"), (false, true));
+    }
+
+    #[test]
+    fn classify_bos_eos_plain_token_is_neither() {
+        assert_eq!(classify_bos_eos("hello"), (false, false));
+    }
+
+    // ---- parse_special_token ------------------------------------------
+
+    #[test]
+    fn parse_special_token_extracts_id_and_content() {
+        let tok = serde_json::json!({"id": 5, "content": "<|im_end|>"});
+        assert_eq!(
+            parse_special_token(&tok),
+            Some((5, "<|im_end|>".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_special_token_none_when_missing_fields() {
+        assert!(parse_special_token(&serde_json::json!({"id": 1})).is_none());
+        assert!(parse_special_token(&serde_json::json!({"content": "x"})).is_none());
+        assert!(parse_special_token(&serde_json::json!({"id": "nan", "content": "x"})).is_none());
+    }
+
+    // ---- merge_special_tokens_into_vocab ------------------------------
+
+    #[test]
+    fn merge_special_tokens_none_added_tokens_keeps_vocab() {
+        let mut vocab = vec!["a".to_string(), "b".to_string()];
+        let (bos, eos) = merge_special_tokens_into_vocab(None, &mut vocab);
+        assert_eq!(vocab, vec!["a", "b"]);
+        assert!(bos.is_none());
+        assert!(eos.is_none());
+    }
+
+    #[test]
+    fn merge_special_tokens_overwrites_in_range_and_detects_eos() {
+        let added = vec![serde_json::json!({"id": 1, "content": "<|im_end|>"})];
+        let mut vocab = vec!["a".to_string(), "b".to_string()];
+        let (bos, eos) = merge_special_tokens_into_vocab(Some(&added), &mut vocab);
+        assert_eq!(vocab[1], "<|im_end|>");
+        assert!(bos.is_none());
+        assert_eq!(eos, Some(1));
+    }
+
+    #[test]
+    fn merge_special_tokens_resizes_vocab_for_high_id() {
+        let added = vec![
+            serde_json::json!({"id": 4, "content": "</s>"}),
+            serde_json::json!({"id": 3, "content": "<s>"}),
+        ];
+        let mut vocab = vec!["a".to_string()];
+        let (bos, eos) = merge_special_tokens_into_vocab(Some(&added), &mut vocab);
+        // resized to max_id (4) + 1 = 5 entries; gap filled with "<unused>".
+        assert_eq!(vocab.len(), 5);
+        assert_eq!(vocab[2], "<unused>");
+        assert_eq!(vocab[3], "<s>");
+        assert_eq!(vocab[4], "</s>");
+        assert_eq!(bos, Some(3));
+        assert_eq!(eos, Some(4));
+    }
+
+    // ---- parse_chat_completion_request --------------------------------
+
+    #[test]
+    fn parse_chat_completion_structured_path() {
+        let req = serde_json::json!({
+            "model": "apr",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 16,
+            "stream": true,
+            "temperature": 0.3
+        });
+        let parsed = parse_chat_completion_request(&req).expect("structured parse");
+        assert_eq!(parsed.messages.len(), 1);
+        assert_eq!(parsed.messages[0].role, "user");
+        assert_eq!(parsed.max_tokens, Some(16));
+        assert!(parsed.stream);
+        assert_eq!(parsed.temperature, Some(0.3));
+    }
+
+    #[test]
+    fn parse_chat_completion_missing_messages_is_err() {
+        let req = serde_json::json!({"model": "apr"});
+        let result = parse_chat_completion_request(&req);
+        assert!(result.is_err(), "missing messages must yield a 400 response");
+        let resp = result.err().expect("error response");
+        assert_eq!(resp.status(), axum::http::StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn parse_chat_completion_fallback_extracts_fields() {
+        // A messages entry whose `content` is non-string forces the structured
+        // deserialize to fail (content must be Option<String>), exercising the
+        // raw-JSON fallback path.
+        let req = serde_json::json!({
+            "messages": [
+                {"role": "user", "content": 12345},
+                {"role": "assistant", "content": "ok"}
+            ],
+            "max_tokens": 8
+        });
+        let parsed = parse_chat_completion_request(&req).expect("fallback parse");
+        assert!(parsed.messages.iter().any(|m| m.role == "assistant"));
+        assert_eq!(
+            parsed.model, "default",
+            "model defaults to 'default' in fallback"
+        );
+        assert_eq!(parsed.max_tokens, Some(8));
+    }
+
+    // ---- build_chatml_prompt ------------------------------------------
+
+    fn user_request(content: &str) -> ChatCompletionRequest {
+        ChatCompletionRequest {
+            model: "apr".to_string(),
+            messages: vec![ChatMessage {
+                role: "user".to_string(),
+                content: Some(content.to_string()),
+                tool_calls: None,
+                tool_call_id: None,
+                name: None,
+            }],
+            tools: None,
+            tool_choice: None,
+            max_tokens: None,
+            stream: false,
+            temperature: None,
+            top_p: None,
+        }
+    }
+
+    #[test]
+    fn build_chatml_prompt_no_tools_basic() {
+        let req = user_request("hello");
+        let prompt = build_chatml_prompt(&req, false);
+        assert!(prompt.contains("<|im_start|>user\nhello<|im_end|>\n"));
+        assert!(prompt.ends_with("<|im_start|>assistant\n"));
+    }
+
+    #[test]
+    fn build_chatml_prompt_with_tools_injects_system() {
+        let mut req = user_request("weather?");
+        req.tools = Some(vec![super::super::types::Tool {
+            tool_type: "function".to_string(),
+            function: super::super::types::FunctionDef {
+                name: "get_weather".to_string(),
+                description: Some("Look up weather".to_string()),
+                parameters: None,
+            },
+        }]);
+        let prompt = build_chatml_prompt(&req, true);
+        // No system message present → synthesized system block carrying tools.
+        assert!(prompt.contains("<|im_start|>system\n"));
+        assert!(prompt.contains("get_weather"), "tool definition injected");
+    }
+
+    #[test]
+    fn build_chatml_prompt_tool_role_renders_tool_result() {
+        let mut req = user_request("ignored");
+        req.messages = vec![ChatMessage {
+            role: "tool".to_string(),
+            content: Some("sunny".to_string()),
+            tool_calls: None,
+            tool_call_id: Some("call_42".to_string()),
+            name: None,
+        }];
+        let prompt = build_chatml_prompt(&req, false);
+        assert!(prompt.contains("[Tool Result for call_42]"));
+        assert!(prompt.contains("sunny"));
+    }
+
+    // ---- generate_request_id (chat.rs variant) ------------------------
+
+    #[test]
+    fn chat_generate_request_id_prefix() {
+        let id = generate_request_id();
+        assert!(id.starts_with("chatcmpl-"));
+        assert_eq!(id.split('-').count(), 3);
+    }
+
+    // ---- build_chat_response ------------------------------------------
+
+    #[tokio::test]
+    async fn build_chat_response_non_streaming_json_body() {
+        use axum::body::to_bytes;
+        let resp = build_chat_response(
+            "the answer".to_string(),
+            None,
+            false,
+            5,
+            3,
+            std::time::Duration::from_millis(10),
+            300.0,
+        );
+        let bytes = to_bytes(resp.into_body(), 64 * 1024).await.expect("body");
+        let v: serde_json::Value = serde_json::from_slice(&bytes).expect("json");
+        assert_eq!(v["object"], "chat.completion");
+        assert_eq!(v["choices"][0]["message"]["content"], "the answer");
+        assert_eq!(v["choices"][0]["finish_reason"], "stop");
+        assert_eq!(v["usage"]["prompt_tokens"], 5);
+        assert_eq!(v["usage"]["completion_tokens"], 3);
+        assert_eq!(v["usage"]["total_tokens"], 8);
+    }
+
+    #[tokio::test]
+    async fn build_chat_response_with_tool_calls_sets_finish_reason() {
+        use axum::body::to_bytes;
+        let tool_calls = vec![super::super::types::ToolCall {
+            id: "call_1".to_string(),
+            tool_type: "function".to_string(),
+            function: super::super::types::FunctionCall {
+                name: "f".to_string(),
+                arguments: "{}".to_string(),
+            },
+        }];
+        let resp = build_chat_response(
+            String::new(),
+            Some(tool_calls),
+            false,
+            2,
+            0,
+            std::time::Duration::from_millis(1),
+            0.0,
+        );
+        let bytes = to_bytes(resp.into_body(), 64 * 1024).await.expect("body");
+        let v: serde_json::Value = serde_json::from_slice(&bytes).expect("json");
+        assert_eq!(v["choices"][0]["finish_reason"], "tool_calls");
+        assert!(v["choices"][0]["message"]["content"].is_null());
+        assert_eq!(
+            v["choices"][0]["message"]["tool_calls"][0]["function"]["name"],
+            "f"
+        );
+    }
+
+    #[tokio::test]
+    async fn build_chat_response_streaming_is_sse() {
+        let resp = build_chat_response(
+            "hi".to_string(),
+            None,
+            true,
+            1,
+            1,
+            std::time::Duration::from_millis(1),
+            1.0,
+        );
+        let ct = resp
+            .headers()
+            .get(axum::http::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        assert!(
+            ct.contains("text/event-stream"),
+            "streaming mode is SSE, got {ct}"
+        );
+    }
+}

--- a/crates/apr-cli/src/commands/serve/handler_apr_cpu_completion.rs
+++ b/crates/apr-cli/src/commands/serve/handler_apr_cpu_completion.rs
@@ -652,4 +652,216 @@ struct GpuCompletionResponse {
     tok_per_sec: f64,
 }
 
+// ============================================================================
+// PMAT-125 B3: unit tests for APR-CPU completion pure helpers
+//
+// These functions are `include!`d into the `serve::handlers` module, so this
+// test module exercises them at that scope (CPU-only; no transformer/GPU).
+// ============================================================================
+#[cfg(all(test, feature = "inference"))]
+mod apr_cpu_completion_tests {
+    use super::*;
+
+    // ---- validate_request_model ---------------------------------------
+
+    #[test]
+    fn validate_request_model_accepts_missing_field() {
+        let req = serde_json::json!({"messages": []});
+        assert!(validate_request_model(&req, "qwen2.5-1.5b").is_none());
+    }
+
+    #[test]
+    fn validate_request_model_accepts_exact_match() {
+        let req = serde_json::json!({"model": "qwen2.5-1.5b"});
+        assert!(validate_request_model(&req, "qwen2.5-1.5b").is_none());
+    }
+
+    #[test]
+    fn validate_request_model_accepts_apr_wildcard() {
+        let req = serde_json::json!({"model": "apr"});
+        assert!(validate_request_model(&req, "anything").is_none());
+    }
+
+    #[test]
+    fn validate_request_model_rejects_mismatch() {
+        let req = serde_json::json!({"model": "gpt-4"});
+        let resp = validate_request_model(&req, "qwen2.5-1.5b");
+        assert!(
+            resp.is_some(),
+            "mismatched model name must produce a 404 response"
+        );
+        assert_eq!(
+            resp.expect("response").status(),
+            axum::http::StatusCode::NOT_FOUND
+        );
+    }
+
+    #[test]
+    fn validate_request_model_non_string_model_field_accepted() {
+        // as_str() yields None for a numeric model field → accept.
+        let req = serde_json::json!({"model": 123});
+        assert!(validate_request_model(&req, "loaded").is_none());
+    }
+
+    // ---- insert_trace_data --------------------------------------------
+
+    #[test]
+    fn insert_trace_data_none_level_is_noop() {
+        let mut resp = serde_json::json!({"a": 1});
+        insert_trace_data(&mut resp, None, serde_json::json!({"x": 1}));
+        assert!(resp.get("brick_trace").is_none());
+        assert!(resp.get("step_trace").is_none());
+        assert!(resp.get("layer_trace").is_none());
+    }
+
+    #[test]
+    fn insert_trace_data_unknown_level_is_noop() {
+        let mut resp = serde_json::json!({"a": 1});
+        insert_trace_data(&mut resp, Some("garbage"), serde_json::json!({"x": 1}));
+        assert_eq!(resp.as_object().expect("obj").len(), 1);
+    }
+
+    #[test]
+    fn insert_trace_data_maps_levels_to_keys() {
+        for (level, key) in [
+            ("brick", "brick_trace"),
+            ("step", "step_trace"),
+            ("layer", "layer_trace"),
+        ] {
+            let mut resp = serde_json::json!({});
+            insert_trace_data(&mut resp, Some(level), serde_json::json!({"layers": 28}));
+            assert_eq!(resp[key]["layers"], 28, "level {level} → key {key}");
+        }
+    }
+
+    // ---- ollama_sampling ----------------------------------------------
+
+    #[test]
+    fn ollama_sampling_defaults_when_none() {
+        let (max_tokens, temp) = ollama_sampling(&None);
+        assert_eq!(max_tokens, 32);
+        assert!((temp).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn ollama_sampling_reads_options() {
+        let opts = super::super::ollama::OllamaOptions {
+            temperature: Some(0.7),
+            num_predict: Some(128),
+            ..Default::default()
+        };
+        let (max_tokens, temp) = ollama_sampling(&Some(opts));
+        assert_eq!(max_tokens, 128);
+        assert!((temp - 0.7).abs() < 1e-6);
+    }
+
+    #[test]
+    fn ollama_sampling_clamps_max_tokens_to_4096() {
+        let opts = super::super::ollama::OllamaOptions {
+            num_predict: Some(100_000),
+            ..Default::default()
+        };
+        let (max_tokens, _) = ollama_sampling(&Some(opts));
+        assert_eq!(max_tokens, 4096, "max_tokens is capped at 4096");
+    }
+
+    // ---- eos_token_id -------------------------------------------------
+
+    #[test]
+    fn eos_token_id_uses_default_when_no_tokenizer() {
+        assert_eq!(eos_token_id(None, 2), 2);
+    }
+
+    // ---- extract_new_tokens -------------------------------------------
+
+    #[test]
+    fn extract_new_tokens_slices_after_prompt() {
+        let output = [1u32, 2, 3, 4, 5];
+        assert_eq!(extract_new_tokens(&output, 2), &[3, 4, 5]);
+    }
+
+    #[test]
+    fn extract_new_tokens_returns_all_when_not_longer() {
+        let output = [1u32, 2, 3];
+        // input_len >= output.len() → return whole slice (defensive).
+        assert_eq!(extract_new_tokens(&output, 3), &[1, 2, 3]);
+        assert_eq!(extract_new_tokens(&output, 10), &[1, 2, 3]);
+    }
+
+    #[test]
+    fn extract_new_tokens_empty_output() {
+        let output: [u32; 0] = [];
+        assert!(extract_new_tokens(&output, 0).is_empty());
+    }
+
+    // ---- compute_tok_per_sec ------------------------------------------
+
+    #[test]
+    fn compute_tok_per_sec_positive_duration() {
+        let tps = compute_tok_per_sec(100, std::time::Duration::from_secs(2));
+        assert!((tps - 50.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn compute_tok_per_sec_zero_duration_is_zero() {
+        let tps = compute_tok_per_sec(100, std::time::Duration::ZERO);
+        assert!((tps).abs() < f64::EPSILON, "no divide-by-zero blowup");
+    }
+
+    #[test]
+    fn compute_tok_per_sec_zero_tokens() {
+        let tps = compute_tok_per_sec(0, std::time::Duration::from_secs(1));
+        assert!((tps).abs() < f64::EPSILON);
+    }
+
+    // ---- generate_request_id ------------------------------------------
+
+    #[test]
+    fn generate_request_id_has_chatcmpl_prefix_and_pid() {
+        let id = generate_request_id();
+        assert!(id.starts_with("chatcmpl-"), "got {id}");
+        // Format is chatcmpl-<nanos>-<pid>; three dash-separated parts.
+        let parts: Vec<&str> = id.split('-').collect();
+        assert_eq!(parts.len(), 3, "id should be chatcmpl-<nanos>-<pid>: {id}");
+        assert!(parts[1].chars().all(|c| c.is_ascii_digit()));
+        assert!(parts[2].chars().all(|c| c.is_ascii_digit()));
+    }
+
+    // ---- format_chatml ------------------------------------------------
+
+    #[test]
+    fn format_chatml_wraps_messages_and_appends_assistant() {
+        let msgs = vec![
+            serde_json::json!({"role": "system", "content": "be brief"}),
+            serde_json::json!({"role": "user", "content": "hi"}),
+        ];
+        let prompt = format_chatml(&msgs);
+        assert!(prompt.contains("<|im_start|>system\nbe brief<|im_end|>\n"));
+        assert!(prompt.contains("<|im_start|>user\nhi<|im_end|>\n"));
+        assert!(prompt.ends_with("<|im_start|>assistant\n"));
+    }
+
+    #[test]
+    fn format_chatml_defaults_role_and_content() {
+        // Missing role defaults to "user"; missing content defaults to "".
+        let msgs = vec![serde_json::json!({})];
+        let prompt = format_chatml(&msgs);
+        assert!(prompt.contains("<|im_start|>user\n<|im_end|>\n"));
+        assert!(prompt.ends_with("<|im_start|>assistant\n"));
+    }
+
+    #[test]
+    fn format_chatml_empty_messages_just_assistant_header() {
+        let prompt = format_chatml(&[]);
+        assert_eq!(prompt, "<|im_start|>assistant\n");
+    }
+
+    // ---- default_max_tokens_gpu ---------------------------------------
+
+    #[test]
+    fn default_max_tokens_gpu_is_32() {
+        assert_eq!(default_max_tokens_gpu(), 32);
+    }
+}
+
 include!("handlers_include_01.rs");

--- a/crates/apr-cli/src/commands/serve/routes.rs
+++ b/crates/apr-cli/src/commands/serve/routes.rs
@@ -366,3 +366,72 @@ pub fn create_router_with_auth(
         .with_state(state);
     super::auth::layer(auth_gate, router)
 }
+
+// ============================================================================
+// PMAT-125 B3: unit tests for the request-body validation seam.
+// ============================================================================
+#[cfg(all(test, feature = "inference"))]
+mod routes_tests {
+    use super::super::types::{GenerateRequest, ServerMetrics};
+    use super::*;
+
+    #[test]
+    fn validate_and_parse_success_parses_typed_body() {
+        let metrics = ServerMetrics::new();
+        let body = br#"{"prompt": "hi", "max_tokens": 8}"#;
+        let parsed: GenerateRequest =
+            validate_and_parse(body, &metrics).expect("valid JSON parses");
+        assert_eq!(parsed.prompt, "hi");
+        assert_eq!(parsed.max_tokens, 8);
+        // No client error recorded on success.
+        assert_eq!(
+            metrics
+                .requests_client_error
+                .load(std::sync::atomic::Ordering::Relaxed),
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn validate_and_parse_oversized_body_is_413_and_counts_error() {
+        let metrics = ServerMetrics::new();
+        let big = vec![b'x'; MAX_REQUEST_SIZE + 1];
+        let result: std::result::Result<serde_json::Value, _> = validate_and_parse(&big, &metrics);
+        let resp = result.err().expect("oversized body must be rejected");
+        assert_eq!(resp.status(), StatusCode::PAYLOAD_TOO_LARGE);
+        assert_eq!(
+            metrics
+                .requests_client_error
+                .load(std::sync::atomic::Ordering::Relaxed),
+            1,
+            "client error counter incremented"
+        );
+    }
+
+    #[tokio::test]
+    async fn validate_and_parse_invalid_json_is_400_and_counts_error() {
+        let metrics = ServerMetrics::new();
+        let body = b"{not valid json";
+        let result: std::result::Result<GenerateRequest, _> = validate_and_parse(body, &metrics);
+        let resp = result.err().expect("invalid JSON must be rejected");
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(
+            metrics
+                .requests_client_error
+                .load(std::sync::atomic::Ordering::Relaxed),
+            1
+        );
+    }
+
+    #[test]
+    fn validate_and_parse_at_size_limit_boundary_still_parses() {
+        // Exactly MAX_REQUEST_SIZE bytes (not > limit) is allowed through to
+        // the JSON parser; padded whitespace keeps it valid JSON.
+        let metrics = ServerMetrics::new();
+        let mut body = br#"{"prompt":"x"}"#.to_vec();
+        body.resize(MAX_REQUEST_SIZE, b' ');
+        let parsed: GenerateRequest =
+            validate_and_parse(&body, &metrics).expect("boundary-size valid JSON parses");
+        assert_eq!(parsed.prompt, "x");
+    }
+}

--- a/crates/apr-cli/src/commands/serve_plan.rs
+++ b/crates/apr-cli/src/commands/serve_plan.rs
@@ -1171,4 +1171,609 @@ mod serve_plan_tests {
         assert!(!hw.gpu_name.is_empty());
         assert!(hw.bandwidth_gbps > 0.0);
     }
+
+    // ====================================================================
+    // PMAT-125 B3: additional coverage for serve_plan pure helpers
+    // ====================================================================
+
+    use aprender::format::model_family::ModelSizeConfig;
+    use aprender::format::rosetta::{FormatType, InspectionReport, TensorInfo};
+    use std::collections::BTreeMap;
+
+    fn make_size_config(hidden_dim: usize, num_layers: usize, num_heads: usize) -> ModelSizeConfig {
+        ModelSizeConfig {
+            parameters: "1.5B".to_string(),
+            hidden_dim,
+            num_layers,
+            num_heads,
+            num_kv_heads: num_heads,
+            intermediate_dim: hidden_dim * 4,
+            vocab_size: 32_000,
+            max_position_embeddings: 4096,
+            head_dim: if num_heads > 0 {
+                hidden_dim / num_heads
+            } else {
+                128
+            },
+            rope_theta: 10_000.0,
+            norm_eps: 1e-5,
+        }
+    }
+
+    fn empty_report() -> InspectionReport {
+        InspectionReport {
+            format: FormatType::Gguf,
+            file_size: 0,
+            metadata: BTreeMap::new(),
+            tensors: Vec::new(),
+            total_params: 0,
+            quantization: None,
+            architecture: None,
+        }
+    }
+
+    fn tensor(name: &str, shape: Vec<usize>) -> TensorInfo {
+        TensorInfo {
+            name: name.to_string(),
+            dtype: "F16".to_string(),
+            shape,
+            size_bytes: 0,
+            stats: None,
+        }
+    }
+
+    fn make_kernels(tps_cpu: Option<f64>) -> KernelCompatibility {
+        KernelCompatibility {
+            supported_quantizations: Vec::new(),
+            attention_kernel: "flash".to_string(),
+            ffn_kernel: "swiglu".to_string(),
+            estimated_tps_cpu: tps_cpu,
+            estimated_tps_gpu: None,
+            memory_required_mb: 0.0,
+            notes: Vec::new(),
+        }
+    }
+
+    // ---- PlanVerdict Display ------------------------------------------
+
+    #[test]
+    fn plan_verdict_display_strings() {
+        assert_eq!(PlanVerdict::Ready.to_string(), "READY");
+        assert_eq!(PlanVerdict::Warnings.to_string(), "WARNINGS");
+        assert_eq!(PlanVerdict::Blocked.to_string(), "BLOCKED");
+    }
+
+    // ---- parse_model_source -------------------------------------------
+
+    #[test]
+    fn parse_model_source_explicit_hf_prefix() {
+        match parse_model_source("hf://org/model-7b") {
+            ServePlanSource::HuggingFace { repo_id } => assert_eq!(repo_id, "org/model-7b"),
+            ServePlanSource::Local(_) => panic!("expected HuggingFace source"),
+        }
+    }
+
+    #[test]
+    fn parse_model_source_bare_org_repo_is_hf() {
+        match parse_model_source("Qwen/Qwen2.5-1.5B") {
+            ServePlanSource::HuggingFace { repo_id } => assert_eq!(repo_id, "Qwen/Qwen2.5-1.5B"),
+            ServePlanSource::Local(_) => panic!("bare org/repo should resolve to HuggingFace"),
+        }
+    }
+
+    #[test]
+    fn parse_model_source_path_with_model_extension_is_local() {
+        // A slash + a known model extension must stay local even if absent on disk.
+        match parse_model_source("models/qwen.gguf") {
+            ServePlanSource::Local(p) => assert_eq!(p, PathBuf::from("models/qwen.gguf")),
+            ServePlanSource::HuggingFace { .. } => panic!("model file extension must stay local"),
+        }
+    }
+
+    #[test]
+    fn parse_model_source_no_slash_is_local() {
+        match parse_model_source("model.gguf") {
+            ServePlanSource::Local(p) => assert_eq!(p, PathBuf::from("model.gguf")),
+            ServePlanSource::HuggingFace { .. } => panic!("no slash → local"),
+        }
+    }
+
+    #[test]
+    fn parse_model_source_parent_traversal_stays_local() {
+        match parse_model_source("../weights/foo") {
+            ServePlanSource::Local(p) => assert_eq!(p, PathBuf::from("../weights/foo")),
+            ServePlanSource::HuggingFace { .. } => panic!(".. traversal must stay local"),
+        }
+    }
+
+    #[test]
+    fn parse_model_source_three_segment_path_is_local() {
+        // More than two non-empty segments is not a bare org/repo → local.
+        match parse_model_source("a/b/c") {
+            ServePlanSource::Local(p) => assert_eq!(p, PathBuf::from("a/b/c")),
+            ServePlanSource::HuggingFace { .. } => panic!("3-segment path is not org/repo"),
+        }
+    }
+
+    // ---- json_usize_or / json_f64_or ----------------------------------
+
+    #[test]
+    fn json_usize_or_picks_first_present_alias() {
+        let v = serde_json::json!({"hidden_size": 4096, "n_embd": 1024});
+        assert_eq!(json_usize_or(&v, &["n_embd", "hidden_size"], 0), 1024);
+        assert_eq!(json_usize_or(&v, &["hidden_size"], 0), 4096);
+    }
+
+    #[test]
+    fn json_usize_or_returns_default_when_missing() {
+        let v = serde_json::json!({"other": 1});
+        assert_eq!(json_usize_or(&v, &["absent", "missing"], 777), 777);
+    }
+
+    #[test]
+    fn json_usize_or_default_on_non_integer() {
+        let v = serde_json::json!({"x": "not-a-number"});
+        assert_eq!(json_usize_or(&v, &["x"], 42), 42);
+    }
+
+    #[test]
+    fn json_f64_or_reads_float_and_default() {
+        let v = serde_json::json!({"rope_theta": 1_000_000.0});
+        assert!((json_f64_or(&v, &["rope_theta"], 10_000.0) - 1_000_000.0).abs() < 1e-6);
+        assert!((json_f64_or(&v, &["absent"], 10_000.0) - 10_000.0).abs() < 1e-6);
+    }
+
+    // ---- estimate_param_string ----------------------------------------
+
+    #[test]
+    fn estimate_param_string_scales_to_billions() {
+        // ~7B-class architecture should land in the "B" range.
+        let s = estimate_param_string(4096, 32, 11_008, 32_000);
+        assert!(s.ends_with('B'), "expected billions, got {s}");
+    }
+
+    #[test]
+    fn estimate_param_string_small_model_is_millions_or_less() {
+        let s = estimate_param_string(256, 2, 512, 1_000);
+        assert!(
+            s.ends_with('M') || s.chars().all(|c| c.is_ascii_digit()),
+            "expected millions or raw count, got {s}"
+        );
+    }
+
+    // ---- infer_quant_from_repo_name -----------------------------------
+
+    #[test]
+    fn infer_quant_from_repo_name_specific_quant() {
+        assert_eq!(
+            infer_quant_from_repo_name("TheBloke/Llama-2-7B-GGUF-q4_k_m"),
+            Some("Q4_K_M".to_string())
+        );
+        assert_eq!(
+            infer_quant_from_repo_name("foo-q8_0-bar"),
+            Some("Q8_0".to_string())
+        );
+    }
+
+    #[test]
+    fn infer_quant_from_repo_name_gguf_default_q4km() {
+        assert_eq!(
+            infer_quant_from_repo_name("org/some-model-GGUF"),
+            Some("Q4_K_M".to_string())
+        );
+    }
+
+    #[test]
+    fn infer_quant_from_repo_name_none_when_unknown() {
+        assert_eq!(
+            infer_quant_from_repo_name("org/plain-safetensors-model"),
+            None
+        );
+    }
+
+    // ---- resolve_quantization -----------------------------------------
+
+    #[test]
+    fn resolve_quantization_prefers_report_field() {
+        let mut report = empty_report();
+        report.quantization = Some("Q6_K".to_string());
+        assert_eq!(
+            resolve_quantization(&report, Path::new("ignored.gguf")),
+            Some("Q6_K".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_quantization_ignores_zero_quant_field() {
+        let mut report = empty_report();
+        report.quantization = Some("0".to_string());
+        // Falls back to filename pattern.
+        assert_eq!(
+            resolve_quantization(&report, Path::new("model-q5_k_m.gguf")),
+            Some("Q5_K_M".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_quantization_filename_fallback() {
+        let report = empty_report();
+        assert_eq!(
+            resolve_quantization(&report, Path::new("/tmp/llama-q4_0.gguf")),
+            Some("Q4_0".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_quantization_none_when_no_hint() {
+        let report = empty_report();
+        assert_eq!(
+            resolve_quantization(&report, Path::new("plain-model.bin")),
+            None
+        );
+    }
+
+    // ---- infer_from_metadata / infer_hidden_dim / infer_num_layers ----
+
+    #[test]
+    fn infer_from_metadata_first_match_wins() {
+        let mut report = empty_report();
+        report
+            .metadata
+            .insert("n_embd".to_string(), "2048".to_string());
+        report
+            .metadata
+            .insert("llama.embedding_length".to_string(), "4096".to_string());
+        assert_eq!(
+            infer_from_metadata(&report, &["n_embd", "llama.embedding_length"]),
+            Some(2048)
+        );
+    }
+
+    #[test]
+    fn infer_from_metadata_none_when_absent_or_unparsable() {
+        let mut report = empty_report();
+        report.metadata.insert("k".to_string(), "abc".to_string());
+        assert_eq!(infer_from_metadata(&report, &["k"]), None);
+        assert_eq!(infer_from_metadata(&report, &["missing"]), None);
+    }
+
+    #[test]
+    fn infer_hidden_dim_from_metadata() {
+        let mut report = empty_report();
+        report
+            .metadata
+            .insert("qwen2.embedding_length".to_string(), "1536".to_string());
+        assert_eq!(infer_hidden_dim(&report), 1536);
+    }
+
+    #[test]
+    fn infer_hidden_dim_from_embedding_tensor() {
+        let mut report = empty_report();
+        report
+            .tensors
+            .push(tensor("token_embd.weight", vec![151936, 1536]));
+        // min(shape) is the hidden dim.
+        assert_eq!(infer_hidden_dim_from_tensors(&report), 1536);
+        assert_eq!(infer_hidden_dim(&report), 1536);
+    }
+
+    #[test]
+    fn infer_hidden_dim_zero_when_no_signal() {
+        assert_eq!(infer_hidden_dim_from_tensors(&empty_report()), 0);
+        assert_eq!(infer_hidden_dim(&empty_report()), 0);
+    }
+
+    #[test]
+    fn infer_num_layers_from_metadata() {
+        let mut report = empty_report();
+        report
+            .metadata
+            .insert("llama.block_count".to_string(), "28".to_string());
+        assert_eq!(infer_num_layers(&report), 28);
+    }
+
+    #[test]
+    fn infer_num_layers_from_tensor_indices() {
+        let mut report = empty_report();
+        report
+            .tensors
+            .push(tensor("blk.0.attn_q.weight", vec![1, 1]));
+        report
+            .tensors
+            .push(tensor("blk.5.attn_q.weight", vec![1, 1]));
+        report.tensors.push(tensor("blk.3.ffn.weight", vec![1, 1]));
+        // max index 5 → 6 layers.
+        assert_eq!(infer_num_layers(&report), 6);
+    }
+
+    #[test]
+    fn infer_num_layers_zero_when_no_layer_tensors() {
+        let mut report = empty_report();
+        report.tensors.push(tensor("token_embd.weight", vec![1, 1]));
+        assert_eq!(infer_num_layers(&report), 0);
+    }
+
+    // ---- build_inferred_size_config -----------------------------------
+
+    #[test]
+    fn build_inferred_size_config_uses_metadata_and_defaults() {
+        let mut report = empty_report();
+        report.total_params = 1_500_000_000;
+        report
+            .metadata
+            .insert("n_heads".to_string(), "16".to_string());
+        report
+            .metadata
+            .insert("n_ff".to_string(), "8960".to_string());
+        let cfg = build_inferred_size_config(&report, 1536, 28);
+        assert_eq!(cfg.hidden_dim, 1536);
+        assert_eq!(cfg.num_layers, 28);
+        assert_eq!(cfg.num_heads, 16);
+        assert_eq!(cfg.intermediate_dim, 8960);
+        // num_kv_heads defaults to num_heads when not provided.
+        assert_eq!(cfg.num_kv_heads, 16);
+        // head_dim = hidden_dim / num_heads.
+        assert_eq!(cfg.head_dim, 1536 / 16);
+        assert!(cfg.parameters.ends_with('B'));
+    }
+
+    #[test]
+    fn build_inferred_size_config_defaults_when_metadata_absent() {
+        let report = empty_report();
+        let cfg = build_inferred_size_config(&report, 1024, 12);
+        assert_eq!(cfg.num_heads, 32); // default
+        assert_eq!(cfg.intermediate_dim, 1024 * 4); // hidden*4 default
+        assert_eq!(cfg.vocab_size, 32_000); // default
+        assert_eq!(cfg.max_position_embeddings, 4096); // default
+        assert!((cfg.rope_theta - 10_000.0).abs() < 1e-6);
+    }
+
+    // ---- compute_memory_budget ----------------------------------------
+
+    #[test]
+    fn compute_memory_budget_cpu_has_no_gpu_fields() {
+        let stats = make_test_stats(2000.0, 1_000_000, 2_000_000);
+        let size = make_size_config(1536, 28, 12);
+        let budget = compute_memory_budget(&stats, &size, None, 1, 2048);
+        assert!((budget.weights_mb - 2000.0).abs() < 1e-6);
+        assert!(budget.kv_cache_mb >= 0.0);
+        assert!(
+            (budget.overhead_mb).abs() < f64::EPSILON,
+            "no CUDA overhead on CPU"
+        );
+        assert!(budget.gpu_total_mb.is_none());
+        assert!(budget.utilization_pct.is_none());
+        assert!(budget.max_batch.is_none());
+        assert_eq!(budget.batch_size, 1);
+        assert_eq!(budget.seq_len, 2048);
+        // total = weights + kv + activations (no overhead).
+        let expected = budget.weights_mb + budget.kv_cache_mb + budget.activations_mb;
+        assert!((budget.total_mb - expected).abs() < 1e-6);
+    }
+
+    #[test]
+    fn compute_memory_budget_gpu_populates_utilization() {
+        let stats = make_test_stats(2000.0, 1_000_000, 2_000_000);
+        let size = make_size_config(1536, 28, 12);
+        let hw = ServePlanHardware {
+            gpu_name: "GPU".to_string(),
+            vram_mb: 24_000.0,
+            bandwidth_gbps: 900.0,
+            peak_tflops: 80.0,
+        };
+        let budget = compute_memory_budget(&stats, &size, Some(&hw), 4, 4096);
+        assert_eq!(budget.gpu_total_mb, Some(24_000.0));
+        assert!(
+            (budget.overhead_mb - 512.0).abs() < 1e-6,
+            "CUDA overhead present"
+        );
+        let util = budget.utilization_pct.expect("utilization on GPU");
+        assert!((util - budget.total_mb / 24_000.0 * 100.0).abs() < 1e-6);
+        assert!(budget.max_batch.is_some());
+    }
+
+    #[test]
+    fn compute_memory_budget_gpu_zero_vram_no_utilization() {
+        let stats = make_test_stats(1000.0, 1, 1);
+        let size = make_size_config(1024, 12, 8);
+        let hw = ServePlanHardware {
+            gpu_name: "GPU".to_string(),
+            vram_mb: 0.0,
+            bandwidth_gbps: 100.0,
+            peak_tflops: 1.0,
+        };
+        let budget = compute_memory_budget(&stats, &size, Some(&hw), 1, 1024);
+        assert!(
+            budget.utilization_pct.is_none(),
+            "zero VRAM → no utilization"
+        );
+        assert_eq!(budget.max_batch, Some(0), "no room → max batch 0");
+    }
+
+    // ---- compute_throughput -------------------------------------------
+
+    #[test]
+    fn compute_throughput_cpu_uses_kernel_estimate() {
+        let kernels = make_kernels(Some(42.0));
+        let t = compute_throughput(&kernels, None, 1);
+        assert!((t.single_decode_tps - 42.0).abs() < 1e-6);
+        assert!(t.batched_tps.is_none(), "batch=1 has no batched estimate");
+        assert_eq!(t.batch_size, 1);
+    }
+
+    #[test]
+    fn compute_throughput_cpu_default_tps_when_absent() {
+        let kernels = make_kernels(None);
+        let t = compute_throughput(&kernels, None, 1);
+        assert!((t.single_decode_tps - 50.0).abs() < 1e-6, "default 50 tps");
+    }
+
+    #[test]
+    fn compute_throughput_batched_scales_sqrt() {
+        let kernels = make_kernels(Some(100.0));
+        let t = compute_throughput(&kernels, None, 4);
+        let batched = t.batched_tps.expect("batched estimate for batch>1");
+        assert!((batched - 100.0 * 2.0).abs() < 1e-6, "sqrt(4)=2 scaling");
+    }
+
+    #[test]
+    fn compute_throughput_gpu_uses_roofline_ceiling() {
+        let kernels = make_kernels(Some(10.0));
+        let roof = RooflineEstimate {
+            bandwidth_gbps: 900.0,
+            bandwidth_ceiling_tps: 333.0,
+            compute_ceiling_tps: 500.0,
+            bottleneck: "MEMORY-BOUND".to_string(),
+        };
+        let t = compute_throughput(&kernels, Some(&roof), 1);
+        assert!(
+            (t.single_decode_tps - 333.0).abs() < 1e-6,
+            "GPU uses roofline, not cpu kernel"
+        );
+    }
+
+    // ---- compute_roofline bottleneck classification -------------------
+
+    #[test]
+    fn compute_roofline_compute_bound_when_huge_model() {
+        // Big model_size_q4 → tiny bandwidth ceiling; tiny flops → huge compute ceiling.
+        let stats = make_test_stats(100_000.0, 1, 1);
+        let hw = make_test_hw();
+        let roof = compute_roofline(&stats, &hw);
+        assert_eq!(roof.bottleneck, "MEMORY-BOUND");
+    }
+
+    #[test]
+    fn compute_roofline_zero_flops_compute_ceiling_zero() {
+        let stats = make_test_stats(10.0, 0, 0);
+        let hw = make_test_hw();
+        let roof = compute_roofline(&stats, &hw);
+        assert!((roof.compute_ceiling_tps).abs() < f64::EPSILON);
+    }
+
+    // ---- run_contract_checks + determine_verdict ----------------------
+
+    fn budget_fixture(total_mb: f64, weights_mb: f64, batch_size: usize) -> MemoryBudget {
+        MemoryBudget {
+            weights_mb,
+            kv_cache_mb: 100.0,
+            activations_mb: 50.0,
+            overhead_mb: 512.0,
+            total_mb,
+            gpu_total_mb: Some(24_000.0),
+            utilization_pct: Some(total_mb / 24_000.0 * 100.0),
+            max_batch: Some(8),
+            batch_size,
+            seq_len: 4096,
+        }
+    }
+
+    #[test]
+    fn run_contract_checks_cpu_only_single_check_passes() {
+        let budget = budget_fixture(2000.0, 1500.0, 1);
+        let checks = run_contract_checks(&budget, None);
+        assert_eq!(checks.len(), 1);
+        assert_eq!(checks[0].id, "BUDGET-003");
+        assert!(checks[0].passed);
+    }
+
+    #[test]
+    fn run_contract_checks_gpu_all_pass_within_budget() {
+        let hw = ServePlanHardware {
+            gpu_name: "GPU".to_string(),
+            vram_mb: 24_000.0,
+            bandwidth_gbps: 900.0,
+            peak_tflops: 80.0,
+        };
+        let budget = budget_fixture(2000.0, 1500.0, 1);
+        let checks = run_contract_checks(&budget, Some(&hw));
+        // batch_size 1 → no BUDGET-004; expect 001/002/003.
+        let ids: Vec<&str> = checks.iter().map(|c| c.id.as_str()).collect();
+        assert!(ids.contains(&"BUDGET-001"));
+        assert!(ids.contains(&"BUDGET-002"));
+        assert!(ids.contains(&"BUDGET-003"));
+        assert!(!ids.contains(&"BUDGET-004"));
+        assert!(checks.iter().all(|c| c.passed), "all should fit in 24GB");
+    }
+
+    #[test]
+    fn run_contract_checks_gpu_batch_adds_budget_004() {
+        let hw = ServePlanHardware {
+            gpu_name: "GPU".to_string(),
+            vram_mb: 24_000.0,
+            bandwidth_gbps: 900.0,
+            peak_tflops: 80.0,
+        };
+        let budget = budget_fixture(3000.0, 1500.0, 8);
+        let checks = run_contract_checks(&budget, Some(&hw));
+        assert!(checks.iter().any(|c| c.id == "BUDGET-004"));
+    }
+
+    #[test]
+    fn run_contract_checks_gpu_oversized_fails_budget_001() {
+        let hw = ServePlanHardware {
+            gpu_name: "tiny".to_string(),
+            vram_mb: 1000.0,
+            bandwidth_gbps: 100.0,
+            peak_tflops: 1.0,
+        };
+        // total well above 95% of 1000 MB.
+        let budget = budget_fixture(5000.0, 4000.0, 1);
+        let checks = run_contract_checks(&budget, Some(&hw));
+        let b001 = checks
+            .iter()
+            .find(|c| c.id == "BUDGET-001")
+            .expect("BUDGET-001");
+        assert!(!b001.passed, "5000 MB must not fit in 1000 MB");
+    }
+
+    #[test]
+    fn determine_verdict_ready_when_all_pass() {
+        let checks = vec![ContractCheck {
+            id: "BUDGET-001".to_string(),
+            name: "x".to_string(),
+            passed: true,
+            detail: String::new(),
+        }];
+        assert_eq!(determine_verdict(&checks), PlanVerdict::Ready);
+    }
+
+    #[test]
+    fn determine_verdict_blocked_on_critical_failure() {
+        let checks = vec![ContractCheck {
+            id: "BUDGET-002".to_string(),
+            name: "x".to_string(),
+            passed: false,
+            detail: String::new(),
+        }];
+        assert_eq!(determine_verdict(&checks), PlanVerdict::Blocked);
+    }
+
+    #[test]
+    fn determine_verdict_warnings_on_noncritical_failure() {
+        let checks = vec![
+            ContractCheck {
+                id: "BUDGET-001".to_string(),
+                name: "x".to_string(),
+                passed: true,
+                detail: String::new(),
+            },
+            ContractCheck {
+                id: "BUDGET-004".to_string(),
+                name: "x".to_string(),
+                passed: false,
+                detail: String::new(),
+            },
+        ];
+        assert_eq!(determine_verdict(&checks), PlanVerdict::Warnings);
+    }
+
+    // ---- contracts_candidate_paths ------------------------------------
+
+    #[test]
+    fn contracts_candidate_paths_includes_ancestors() {
+        let paths = contracts_candidate_paths();
+        assert!(paths.iter().any(|p| p == &PathBuf::from("./contracts")));
+        assert!(paths.iter().any(|p| p.ends_with("contracts")));
+    }
 }


### PR DESCRIPTION
## PMAT-125 Coverage — Batch B3: serve/* HTTP + plan layer (CPU only)

Adds **89 thorough, CPU-only unit tests** for previously-uncovered pure helpers in the self-contained `serve/` HTTP family and the `serve plan` layer. Tests-only — **no `src` behavior change**.

### Coverage targets (per-module)
| Module | New tests | What's covered |
|---|---:|---|
| `serve_plan.rs` | 44 | `parse_model_source` (hf://, bare org/repo, local, traversal), `json_usize_or`/`json_f64_or`, `estimate_param_string`, `infer_quant_from_repo_name`, `resolve_quantization`, `infer_from_metadata`/`infer_hidden_dim`(`_from_tensors`)/`infer_num_layers`, `build_inferred_size_config`, `compute_memory_budget` (CPU + GPU + zero-VRAM), `compute_throughput` (cpu/default/batched-sqrt/gpu-roofline), `compute_roofline` bottleneck, `run_contract_checks` (CPU/GPU/batch/oversized), `determine_verdict`, `PlanVerdict` Display, `contracts_candidate_paths` |
| `serve/handler_apr_cpu_completion.rs` | 23 | `validate_request_model` (missing/exact/apr-wildcard/mismatch-404/non-string), `insert_trace_data` (none/unknown/level→key), `ollama_sampling` (defaults/options/4096-cap), `eos_token_id`, `extract_new_tokens`, `compute_tok_per_sec` (zero-duration guard), `generate_request_id`, `format_chatml` (defaults/empty), `default_max_tokens_gpu` |
| `serve/chat.rs` | 18 | `classify_bos_eos`, `parse_special_token`, `merge_special_tokens_into_vocab` (resize/overwrite/eos), `parse_chat_completion_request` (structured + raw-JSON fallback + missing-messages 400), `build_chatml_prompt` (tools system-injection + tool-role), `build_chat_response` (json/tool_calls/SSE) |
| `serve/routes.rs` | 4 | `validate_and_parse` (success / oversized 413 / invalid-JSON 400 / size-limit boundary) |

### Scope discipline
- **GPU/CUDA explicitly excluded**: `serve/handler_gpu_completion.rs` and the `#[cfg(feature = "wgpu")]` helpers (`wgpu_detokenize_one`, `tokenize_greedy`) are untouched.
- No new seams added — every tested function was already callable at module scope.

### Verification
- `cargo test -p apr-cli --lib commands::serve` → **290 passed, 0 failed** (was 198 baseline).
- `cargo clippy -p apr-cli --lib` → clean (zero warnings from changed files).
- `cargo fmt` applied.

### Coverage delta (estimate)
Targets the four lowest-covered serve modules (handlers.rs 0%, chat.rs 0%, safetensors.rs 0%, serve_plan.rs 14.2%). Estimated **+5–8 pp** for the serve/* + serve_plan family by exercising request-parsing, ChatML prompt construction, ServerConfig/plan-budget computation, contract verification, and quant/arch inference paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)