### PR TITLE
feat(metrics): finfo-eps clamping for log_loss/MAPE + average_precision no-positive=0.0 (sklearn parity, PMAT-929)

### DIFF
--- a/contracts/metrics-sklearn-eps-parity-v1.yaml
+++ b/contracts/metrics-sklearn-eps-parity-v1.yaml
@@ -1,0 +1,133 @@
+metadata:
+  version: 1.0.0
+  created: '2026-06-25'
+  author: PAIML Engineering
+  description: >-
+    Pillar-1 (beat scikit-learn) metric EDGE-CASE parity — finfo(float64).eps
+    clamping for log_loss and mean_absolute_percentage_error, and the
+    no-positive-samples average_precision_score = 0.0 convention (PMAT-929).
+    sklearn clips/floors with eps = np.finfo(float64).eps = 2.220446049250313e-16
+    (Rust f64::EPSILON), NOT a hand-rolled 1e-15. On boundary inputs apr
+    previously diverged from sklearn 1.9.0: log_loss([0,1],[0.0,1.0]) returned
+    9.99e-16 vs sklearn 2.22e-16 (>4x); MAPE([0.0],[0.5]) returned 5.0e14 vs
+    sklearn 2.25e15 (~78%); and average_precision_score with no positives
+    returned NaN instead of sklearn's 0.0 (which poisons downstream means).
+  references:
+  - 'crates/aprender-core/src/metrics/probabilistic.rs (log_loss, average_precision_score, FINFO_F64_EPS)'
+  - 'crates/aprender-core/src/metrics/regression.rs (mean_absolute_percentage_error)'
+  - 'scikit-learn 1.9.0 sklearn.metrics.log_loss / mean_absolute_percentage_error / average_precision_score'
+  - 'numpy: np.finfo(np.float64).eps = 2.220446049250313e-16'
+equations:
+  log_loss_eps_clamp:
+    formula: 'p_clamped = clamp(p, eps, 1 - eps), eps = finfo(float64).eps; loss = -mean(y*ln(p_clamped) + (1-y)*ln(1-p_clamped))'
+    domain: y in {0,1}, p in [0,1], n >= 1
+    codomain: loss in [0, inf), finite
+    invariants:
+    - log_loss output is always finite (clamp prevents ln(0) = -inf)
+    - clamp uses eps = finfo(float64).eps (2.220446049250313e-16), matching sklearn
+    - 'log_loss([0,1],[0.0,1.0]) = -ln(1-eps) = 2.220446049250313e-16'
+    preconditions:
+    - y_true.len() == y_prob.len()
+    - y_true.len() > 0
+    postconditions:
+    - result.is_finite()
+    - result >= 0.0
+  mape_eps_floor:
+    formula: 'MAPE = mean(|y_true - y_pred| / max(eps, |y_true|)), eps = finfo(float64).eps'
+    domain: y_true, y_pred real, n >= 1
+    codomain: MAPE in [0, inf), finite
+    invariants:
+    - MAPE output is always finite (denominator floored at eps prevents div-by-zero)
+    - denominator floor uses eps = finfo(float64).eps, matching sklearn max(eps, |y_true|)
+    - 'MAPE([0.0],[0.5]) = 0.5 / eps = 2251799813685248.0'
+    preconditions:
+    - y_true.len() == y_pred.len()
+    - y_true.len() > 0
+    postconditions:
+    - result.is_finite()
+    - result >= 0.0
+  average_precision_no_positive:
+    formula: 'AP = 0.0 when sum(y_true) == 0 (no positive samples), else step-function PR area'
+    domain: y_true in {0,1}, y_score real
+    codomain: AP in [0, 1]
+    invariants:
+    - average_precision_score with zero positive samples returns 0.0 (sklearn convention), never NaN
+    - average_precision_score on empty input returns 0.0
+    preconditions:
+    - y_true.len() == y_score.len()
+    postconditions:
+    - '!result.is_nan()'
+    - result >= 0.0 && result <= 1.0
+proof_obligations:
+- type: invariant
+  property: log_loss clamps with finfo eps
+  formal: 'log_loss([0,1],[0.0,1.0]) == -ln(1 - finfo_eps) == 2.220446049250313e-16, finite'
+  applies_to: log_loss
+- type: invariant
+  property: MAPE floors denominator with finfo eps
+  formal: 'MAPE([0.0],[0.5]) == 0.5 / finfo_eps == 2251799813685248.0, finite (no div-by-zero)'
+  applies_to: mean_absolute_percentage_error
+- type: invariant
+  property: average_precision no-positive equals zero
+  formal: 'sum(y_true) == 0 implies average_precision_score(y_true, y_score) == 0.0 (not NaN)'
+  applies_to: average_precision_score
+falsification_tests:
+- id: FALSIFY-METRIC-EPS-001
+  rule: log_loss clamps predictions by finfo(float64).eps, matching sklearn
+  prediction: log_loss([0,1],[0.0,1.0]) equals 2.220446049250313e-16 (finite), not the 1e-15-floor 9.99e-16
+  test: cargo test -p aprender-core --lib log_loss_clamps_finfo_eps_at_bounds
+  if_fails: log_loss uses a non-finfo eps floor (e.g. legacy 1e-15) or ln(0) leaks inf/nan
+- id: FALSIFY-METRIC-EPS-002
+  rule: MAPE floors the per-sample denominator at finfo(float64).eps, matching sklearn max(eps, |y_true|)
+  prediction: MAPE([0.0],[0.5]) equals 2251799813685248.0 (finite), not the 1e-15-floor 5.0e14
+  test: cargo test -p aprender-core --lib mape_floors_denominator_at_finfo_eps
+  if_fails: MAPE uses a non-finfo eps floor (e.g. legacy 1e-15) or divides by zero on a zero target
+- id: FALSIFY-METRIC-EPS-003
+  rule: average_precision_score with no positive samples returns 0.0 (sklearn convention)
+  prediction: average_precision_score([0,0,0], scores) equals 0.0, never NaN
+  test: cargo test -p aprender-core --lib average_precision_no_positives_is_zero
+  if_fails: average_precision_score returns NaN with no positives, poisoning downstream means
+enforcement:
+  log_loss_finite_finfo_eps:
+    description: log_loss must clamp with finfo eps and stay finite
+    check: contract_tests::FALSIFY-METRIC-EPS-001
+    severity: ERROR
+  mape_finite_finfo_eps:
+    description: MAPE must floor the denominator at finfo eps and stay finite
+    check: contract_tests::FALSIFY-METRIC-EPS-002
+    severity: ERROR
+  ap_no_positive_zero:
+    description: average_precision_score must return 0.0 with no positives
+    check: contract_tests::FALSIFY-METRIC-EPS-003
+    severity: ERROR
+kani_harnesses:
+- id: KANI-METRIC-EPS-001
+  obligation: log_loss clamps with finfo eps
+  property: log_loss output is finite for all p in [0,1] (clamp prevents ln(0))
+  bound: 8
+  strategy: stub_float
+  solver: cadical
+  harness: verify_log_loss_finite
+- id: KANI-METRIC-EPS-002
+  obligation: MAPE floors denominator with finfo eps
+  property: MAPE output is finite for all y_true incl. zero (denominator floored at eps)
+  bound: 8
+  strategy: stub_float
+  solver: cadical
+  harness: verify_mape_finite
+- id: KANI-METRIC-EPS-003
+  obligation: average_precision no-positive equals zero
+  property: average_precision_score returns 0.0 (not NaN) when sum(y_true) == 0
+  bound: 8
+  strategy: exhaustive
+  harness: verify_ap_no_positive_zero
+qa_gate:
+  id: F-METRIC-EPS-001
+  name: sklearn Metric Eps-Parity Contract
+  description: Edge-case parity for log_loss/MAPE finfo-eps clamping and average_precision no-positive convention
+  checks:
+  - log_loss_finite_finfo_eps
+  - mape_finite_finfo_eps
+  - ap_no_positive_zero
+  pass_criteria: All 3 falsification tests pass (apr matches sklearn 1.9.0 on each edge case)
+  falsification: log_loss/MAPE use a non-finfo eps floor, or average_precision returns NaN with no positives

--- a/crates/aprender-core/src/metrics/probabilistic.rs
+++ b/crates/aprender-core/src/metrics/probabilistic.rs
@@ -8,6 +8,12 @@
 
 use core::cmp::Ordering;
 
+/// Machine epsilon for IEEE-754 binary64, matching `np.finfo(float64).eps`.
+/// sklearn clips/floors with this exact value (e.g. `log_loss` clamps
+/// predictions to `[EPS, 1 − EPS]`); the legacy `1e-15` floor diverged by >4×
+/// on boundary inputs. PMAT-929.
+const FINFO_F64_EPS: f64 = f64::EPSILON; // 2.220446049250313e-16
+
 /// Binary ROC AUC via the Mann–Whitney U statistic (rank-based, tie-averaged).
 ///
 /// `y_true`: labels in {0, 1}. `y_score`: predicted scores (higher ⇒ more
@@ -60,8 +66,9 @@ pub fn roc_auc_score(y_true: &[usize], y_score: &[f32]) -> f32 {
 /// Binary log loss (cross-entropy), matching `sklearn.metrics.log_loss`.
 ///
 /// `y_true`: labels in {0, 1}. `y_prob`: predicted P(y = 1), clamped to
-/// `[1e-15, 1 − 1e-15]` to keep the log finite. Accumulates in f64 to match
-/// sklearn's precision.
+/// `[eps, 1 − eps]` with `eps = finfo(float64).eps` (≈2.22e-16) to keep the
+/// log finite — matching sklearn's clip exactly (PMAT-929). Accumulates in f64
+/// to match sklearn's precision.
 ///
 /// # Panics
 /// Panics if `y_true` and `y_prob` differ in length.
@@ -76,10 +83,9 @@ pub fn log_loss(y_true: &[usize], y_prob: &[f32]) -> f32 {
     if n == 0 {
         return 0.0;
     }
-    const EPS: f64 = 1e-15;
     let mut sum = 0.0f64;
     for k in 0..n {
-        let p = f64::from(y_prob[k]).clamp(EPS, 1.0 - EPS);
+        let p = f64::from(y_prob[k]).clamp(FINFO_F64_EPS, 1.0 - FINFO_F64_EPS);
         let y = y_true[k] as f64;
         sum += -(y * p.ln() + (1.0 - y) * (1.0 - p).ln());
     }
@@ -93,7 +99,9 @@ pub fn log_loss(y_true: &[usize], y_prob: &[f32]) -> f32 {
 /// thresholds (descending), with tied scores grouped into one threshold (so the
 /// result is rank-only, not threshold-position dependent). `y_true`: labels in
 /// {0, 1}. `y_score`: predicted scores (higher ⇒ more likely positive).
-/// Returns `NaN` if there are no positives.
+/// Returns `0.0` when there are no positive samples, matching sklearn's
+/// convention ("No positive class found"; recall→1, AP→0.0) — PMAT-929. Also
+/// returns `0.0` for empty input.
 ///
 /// # Panics
 /// Panics if `y_true` and `y_score` differ in length.
@@ -107,7 +115,8 @@ pub fn average_precision_score(y_true: &[usize], y_score: &[f32]) -> f32 {
     let n = y_true.len();
     let n_pos = y_true.iter().filter(|&&y| y == 1).count();
     if n == 0 || n_pos == 0 {
-        return f32::NAN;
+        // sklearn convention: AP is 0.0 with no positives (not undefined).
+        return 0.0;
     }
     // Sort by score descending.
     let mut idx: Vec<usize> = (0..n).collect();
@@ -167,12 +176,46 @@ mod tests {
         assert!(log_loss(&[0, 1], &[1e-9, 1.0 - 1e-9]) < 1e-3);
     }
 
+    /// FT-METRIC-LOGLOSS-EPS (PMAT-929): probabilities at the exact bounds
+    /// {0.0, 1.0} must be clamped by `finfo(float64).eps` (≈2.220446e-16), not
+    /// the legacy 1e-15 floor. sklearn 1.9.0 oracle:
+    /// `log_loss([0,1],[0.0,1.0]) = 2.220446049250313e-16` (= −log(1−eps)).
+    /// With a 1e-15 floor apr returned ≈9.99e-16 — a >4× divergence. log(0)
+    /// must never produce inf/nan.
+    #[test]
+    fn log_loss_clamps_finfo_eps_at_bounds() {
+        // Both predictions perfect at the exact boundary ⇒ loss = −log(1−eps).
+        let got = log_loss(&[0, 1], &[0.0, 1.0]);
+        assert!(got.is_finite(), "log(0) leaked inf/nan: {got}");
+        // sklearn oracle: 2.220446049250313e-16 (f32 round ≈ 2.220446e-16).
+        let sklearn = 2.220_446e-16_f32;
+        assert!(
+            (got - sklearn).abs() < 1e-18,
+            "log_loss bound-clamp diverges from sklearn: apr={got}, sklearn={sklearn}"
+        );
+    }
+
     /// FT-METRIC-AVGPREC: matches `sklearn.metrics.average_precision_score` within 1e-4.
     #[test]
     fn average_precision_matches_sklearn() {
         assert!((average_precision_score(&YT, &YS) - 0.916_667).abs() < 1e-4);
         assert!((average_precision_score(&[0, 0, 1, 1], &[0.1, 0.2, 0.8, 0.9]) - 1.0).abs() < 1e-4);
         assert!((average_precision_score(&[1, 1, 0, 0], &[0.9, 0.8, 0.2, 0.1]) - 1.0).abs() < 1e-4);
-        assert!(average_precision_score(&[0, 0], &[0.1, 0.2]).is_nan());
+    }
+
+    /// FT-METRIC-AVGPREC-NOPOS (PMAT-929): with NO positive samples sklearn
+    /// returns 0.0 (warns "No positive class found", recall→1, AP→0.0), NOT
+    /// nan. sklearn 1.9.0 oracle: `average_precision_score([0,0,0],…) = 0.0`.
+    /// apr previously returned `f32::NAN`, which poisons downstream means.
+    #[test]
+    fn average_precision_no_positives_is_zero() {
+        let got = average_precision_score(&[0, 0, 0], &[0.1, 0.2, 0.3]);
+        assert!(!got.is_nan(), "AP with no positives returned nan, not 0.0");
+        assert!(
+            (got - 0.0).abs() < 1e-7,
+            "AP no-positive diverges from sklearn (expected 0.0): apr={got}"
+        );
+        // Two-element no-positive case (legacy test used .is_nan() here).
+        assert_eq!(average_precision_score(&[0, 0], &[0.1, 0.2]), 0.0);
     }
 }

--- a/crates/aprender-core/src/metrics/regression.rs
+++ b/crates/aprender-core/src/metrics/regression.rs
@@ -148,8 +148,11 @@ pub fn mean_squared_log_error(y_true: &[f32], y_pred: &[f32]) -> f32 {
 }
 
 /// Mean absolute percentage error, matching
-/// `sklearn.metrics.mean_absolute_percentage_error` (denominator floored at
-/// machine epsilon to avoid division by zero, as sklearn does).
+/// `sklearn.metrics.mean_absolute_percentage_error`. The per-sample denominator
+/// is floored at `finfo(float64).eps` (≈2.22e-16) — sklearn's
+/// `max(eps, |y_true|)` — so a zero target never causes a division by zero.
+/// PMAT-929: the legacy `1e-15` floor diverged from sklearn by ~78% on
+/// zero-target inputs.
 ///
 /// # Panics
 /// Panics if `y_true` and `y_pred` differ in length.
@@ -164,11 +167,12 @@ pub fn mean_absolute_percentage_error(y_true: &[f32], y_pred: &[f32]) -> f32 {
     if n == 0 {
         return 0.0;
     }
-    const EPS: f64 = 1e-15;
+    // sklearn floors the denominator at finfo(float64).eps = f64::EPSILON.
+    const FINFO_F64_EPS: f64 = f64::EPSILON;
     let s: f64 = y_true
         .iter()
         .zip(y_pred)
-        .map(|(&t, &p)| (f64::from(t) - f64::from(p)).abs() / f64::from(t).abs().max(EPS))
+        .map(|(&t, &p)| (f64::from(t) - f64::from(p)).abs() / f64::from(t).abs().max(FINFO_F64_EPS))
         .sum();
     (s / n as f64) as f32
 }
@@ -244,5 +248,24 @@ mod tests {
         let ypp = [2.5f32, 5.0, 3.0, 8.0, 1.2];
         assert!((mean_squared_log_error(&ytp, &ypp) - 0.011_724).abs() < 1e-4);
         assert!((mean_absolute_percentage_error(&ytp, &ypp) - 0.141_905).abs() < 1e-4);
+    }
+
+    /// FT-METRIC-MAPE-EPS (PMAT-929): the per-sample denominator must be
+    /// floored at `finfo(float64).eps` (≈2.220446e-16), matching sklearn's
+    /// `max(eps, |y_true|)`, NOT the legacy 1e-15. With `y_true=[0.0]`,
+    /// `y_pred=[0.5]` sklearn 1.9.0 returns `2251799813685248.0` (= 0.5/eps).
+    /// A 1e-15 floor gave ≈4.99e14 — a ~78% relative divergence. Must never
+    /// divide by zero (no inf/nan).
+    #[test]
+    fn mape_floors_denominator_at_finfo_eps() {
+        let got = mean_absolute_percentage_error(&[0.0], &[0.5]);
+        assert!(got.is_finite(), "MAPE div-by-zero leaked inf/nan: {got}");
+        // sklearn oracle: 0.5 / finfo_eps = 2251799813685248.0 (exact in f32).
+        let sklearn = 2_251_799_813_685_248.0_f32;
+        let rel = (got - sklearn).abs() / sklearn;
+        assert!(
+            rel < 1e-4,
+            "MAPE eps-floor diverges from sklearn: apr={got}, sklearn={sklearn}, rel={rel}"
+        );
     }
 }


### PR DESCRIPTION
## P1 correctness beat — scikit-learn parity (metric-eps SWEEP, PMAT-929)

Closes three metric edge-case divergences from **scikit-learn 1.9.0** by switching to the exact machine epsilon sklearn uses — `eps = np.finfo(float64).eps = 2.220446049250313e-16` (Rust `f64::EPSILON`) — and adopting sklearn's no-positive convention.

### Bugs fixed (each RED-confirmed before the fix)

| Metric | Edge input | apr (before) | sklearn 1.9.0 | apr (after) |
|---|---|---|---|---|
| `log_loss` | `([0,1],[0.0,1.0])` | `9.99e-16` (1e-15 floor, >4×) | `2.220446e-16` | `2.220446e-16` ✅ |
| `mean_absolute_percentage_error` | `([0.0],[0.5])` | `5.0e14` (1e-15 floor, ~78%) | `2.2518e15` | `2.2518e15` ✅ |
| `average_precision_score` | no positives | `NaN` | `0.0` | `0.0` ✅ |

- **log_loss** now clamps predictions to `[eps, 1-eps]` with finfo eps (not the legacy `1e-15`). `log(0)` never leaks inf/nan.
- **MAPE** now floors the per-sample denominator at finfo eps — sklearn's `max(eps, |y_true|)`. No division by zero on a zero target.
- **average_precision_score** with no positive samples returns `0.0` (sklearn: "No positive class found", recall→1, AP→0.0), not `NaN` (which poisoned downstream means).

### Discipline
- **RED confirmed** first: each falsifier failed against the pre-fix code with the exact divergence shown above.
- **GREEN**: `cargo test -p aprender-core --lib metrics::` → **281 passed**. `cargo clippy -p aprender-core --lib -D warnings` → clean.
- **Mutation-verified**: reverting each eps back to `1e-15` (and AP back to `NaN`) flips its falsifier RED — confirmed individually.
- **Contract**: `contracts/metrics-sklearn-eps-parity-v1.yaml` (3 proof obligations OBLIG/FALSIFY-METRIC-EPS-001..003, single-line `cargo test` falsifier refs). `pv validate` → 0 errors; `pv lint contracts/` → **0 errors, PASS**.

### Falsifiers
- `log_loss_clamps_finfo_eps_at_bounds` (metrics/probabilistic.rs)
- `mape_floors_denominator_at_finfo_eps` (metrics/regression.rs)
- `average_precision_no_positives_is_zero` (metrics/probabilistic.rs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)