### PR TITLE
test(apr-cli): PMAT-125 B2 — CPU-only unit tests for eval/inference/check commands

### DIFF
--- a/crates/apr-cli/src/commands/eval/code_eval.rs
+++ b/crates/apr-cli/src/commands/eval/code_eval.rs
@@ -497,3 +497,421 @@ mod pass_at_k_tests {
         }
     }
 }
+
+#[cfg(test)]
+mod code_eval_tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    // ── compute_pass_at_k: the unbiased estimator ──────────────────────────
+
+    #[test]
+    fn pass_at_k_zero_problems_is_zero() {
+        assert_eq!(compute_pass_at_k(0, 0, 1), 0.0);
+        assert_eq!(compute_pass_at_k(0, 5, 3), 0.0);
+    }
+
+    #[test]
+    fn pass_at_k_zero_k_is_zero() {
+        assert_eq!(compute_pass_at_k(10, 5, 0), 0.0);
+    }
+
+    #[test]
+    fn pass_at_k_all_correct_is_one() {
+        // c >= n ⇒ certain to find a correct sample.
+        assert_eq!(compute_pass_at_k(5, 5, 1), 1.0);
+        assert_eq!(compute_pass_at_k(5, 7, 3), 1.0);
+    }
+
+    #[test]
+    fn pass_at_k_none_correct_is_zero() {
+        // c == 0 ⇒ impossible to draw a correct sample.
+        assert_eq!(compute_pass_at_k(10, 0, 1), 0.0);
+        assert_eq!(compute_pass_at_k(10, 0, 5), 0.0);
+    }
+
+    #[test]
+    fn pass_at_k_k_greater_than_n() {
+        // k > n with some correct ⇒ 1.0; with none ⇒ 0.0.
+        assert_eq!(compute_pass_at_k(3, 1, 5), 1.0);
+        assert_eq!(compute_pass_at_k(3, 0, 5), 0.0);
+    }
+
+    #[test]
+    fn pass_at_k_partial_matches_closed_form() {
+        // n=5, c=1, k=1 ⇒ pass@1 = c/n = 1/5 = 0.2
+        let p = compute_pass_at_k(5, 1, 1);
+        assert!((p - 0.2).abs() < 1e-9, "got {p}");
+        // n=5, c=2, k=2 ⇒ 1 - C(3,2)/C(5,2) = 1 - 3/10 = 0.7
+        let p2 = compute_pass_at_k(5, 2, 2);
+        assert!((p2 - 0.7).abs() < 1e-9, "got {p2}");
+    }
+
+    #[test]
+    fn pass_at_k_monotonic_in_k() {
+        // pass@k is non-decreasing in k for fixed (n, c).
+        let a = compute_pass_at_k(10, 3, 1);
+        let b = compute_pass_at_k(10, 3, 3);
+        let c = compute_pass_at_k(10, 3, 5);
+        assert!(a <= b + 1e-12);
+        assert!(b <= c + 1e-12);
+    }
+
+    // ── compute_multisample_pass_at_k ──────────────────────────────────────
+
+    #[test]
+    fn multisample_empty_is_zero_for_all_k() {
+        let problems: Vec<(String, String, usize)> = vec![];
+        for (_k, rate) in compute_multisample_pass_at_k(&problems, 1, &[1, 5, 10]) {
+            assert_eq!(rate, 0.0);
+        }
+    }
+
+    #[test]
+    fn multisample_all_solved_single_sample_is_one() {
+        let problems: Vec<(String, String, usize)> = (0..4)
+            .map(|i| (format!("t{i}"), String::new(), 1))
+            .collect();
+        for (_k, rate) in compute_multisample_pass_at_k(&problems, 1, &[1, 10]) {
+            assert!((rate - 1.0).abs() < 1e-9);
+        }
+    }
+
+    #[test]
+    fn multisample_multi_sample_averages_per_problem() {
+        // 2 problems, n=4 samples each. p0 solved 4/4, p1 solved 0/4.
+        // pass@1 = avg( pass@1(4,4), pass@1(4,0) ) = (1.0 + 0.0)/2 = 0.5
+        let problems = vec![
+            ("p0".to_string(), "e".to_string(), 4usize),
+            ("p1".to_string(), "e".to_string(), 0usize),
+        ];
+        let rates = compute_multisample_pass_at_k(&problems, 4, &[1]);
+        assert_eq!(rates.len(), 1);
+        assert!((rates[0].1 - 0.5).abs() < 1e-9, "got {}", rates[0].1);
+    }
+
+    // ── build_passk_json ───────────────────────────────────────────────────
+
+    #[test]
+    fn build_passk_json_core_fields() {
+        let problems = vec![
+            ("HumanEval/0".to_string(), "foo".to_string(), 2usize),
+            ("HumanEval/1".to_string(), "bar".to_string(), 0usize),
+        ];
+        let model = PathBuf::from("/models/m.apr");
+        let json = build_passk_json(
+            "humaneval",
+            &model,
+            &problems,
+            5,
+            0.8,
+            &[1, 10],
+            12.5,
+            "inference",
+            None,
+        );
+        assert_eq!(json["benchmark"], "humaneval");
+        assert_eq!(json["problems"], 2);
+        assert_eq!(json["passed"], 1); // only p0 has correct>0
+        assert_eq!(json["samples_per_problem"], 5);
+        assert_eq!(json["mode"], "inference");
+        // pass_at_k array present with two entries
+        assert_eq!(json["pass_at_k"].as_array().unwrap().len(), 2);
+        // per-problem entry_point populated when non-empty
+        let per = json["per_problem_results"].as_array().unwrap();
+        assert_eq!(per[0]["entry_point"], "foo");
+        assert_eq!(per[0]["passed"], true);
+        assert_eq!(per[1]["passed"], false);
+    }
+
+    #[test]
+    fn build_passk_json_omits_empty_entry_point() {
+        let problems = vec![("t".to_string(), String::new(), 1usize)];
+        let model = PathBuf::from("m.apr");
+        let json = build_passk_json(
+            "mbpp",
+            &model,
+            &problems,
+            1,
+            0.0,
+            &[1],
+            1.0,
+            "structural",
+            None,
+        );
+        let per = json["per_problem_results"].as_array().unwrap();
+        assert!(per[0].get("entry_point").is_none());
+    }
+
+    #[test]
+    fn build_passk_json_includes_extra_kv() {
+        let problems = vec![("t".to_string(), "e".to_string(), 0usize)];
+        let model = PathBuf::from("m.apr");
+        let json = build_passk_json(
+            "humaneval",
+            &model,
+            &problems,
+            1,
+            0.0,
+            &[1],
+            1.0,
+            "inference_failed",
+            Some(("error", "spawn failed")),
+        );
+        assert_eq!(json["error"], "spawn failed");
+    }
+
+    // ── evaluate_code_problem ──────────────────────────────────────────────
+
+    fn problem(prompt: &str, test: &str, canonical: Option<&str>) -> CodeBenchProblem {
+        CodeBenchProblem {
+            prompt: prompt.to_string(),
+            test: test.to_string(),
+            task_id: None,
+            canonical_solution: canonical.map(String::from),
+        }
+    }
+
+    #[test]
+    fn evaluate_empty_prompt_fails() {
+        let p = problem("   ", "assert f() == 1", Some("return 1"));
+        let r = evaluate_code_problem(Path::new("m.apr"), &p, 64).unwrap();
+        assert!(!r.passed);
+        assert_eq!(r.error.as_deref(), Some("Empty prompt"));
+    }
+
+    #[test]
+    fn evaluate_empty_test_fails() {
+        let p = problem("def f(): pass", "  ", Some("return 1"));
+        let r = evaluate_code_problem(Path::new("m.apr"), &p, 64).unwrap();
+        assert!(!r.passed);
+        assert_eq!(r.error.as_deref(), Some("Empty test assertion"));
+    }
+
+    #[test]
+    fn evaluate_valid_canonical_solution_passes() {
+        let p = problem("def add(a,b):", "assert add(1,2)==3", Some("return a + b"));
+        let r = evaluate_code_problem(Path::new("m.apr"), &p, 64).unwrap();
+        assert!(r.passed);
+        assert!(r.error.is_none());
+    }
+
+    #[test]
+    fn evaluate_canonical_without_code_markers_fails() {
+        // Non-empty solution but no return/print/= ⇒ validation fails.
+        let p = problem("def f():", "assert f()", Some("pass"));
+        let r = evaluate_code_problem(Path::new("m.apr"), &p, 64).unwrap();
+        assert!(!r.passed);
+        assert_eq!(
+            r.error.as_deref(),
+            Some("Canonical solution validation failed")
+        );
+    }
+
+    #[test]
+    fn evaluate_no_canonical_requires_inference() {
+        let p = problem("def f():", "assert f()", None);
+        let r = evaluate_code_problem(Path::new("m.apr"), &p, 64).unwrap();
+        assert!(!r.passed);
+        assert!(r.error.unwrap().contains("Inference required"));
+    }
+
+    #[test]
+    fn evaluate_canonical_with_print_passes() {
+        let p = problem("def f():", "assert True", Some("print('hi')"));
+        let r = evaluate_code_problem(Path::new("m.apr"), &p, 64).unwrap();
+        assert!(r.passed);
+    }
+
+    // ── print_code_eval_results: smoke + JSON-mode return ──────────────────
+
+    #[test]
+    fn print_code_eval_results_json_mode_ok() {
+        let problems = vec![problem("def a():", "assert True", Some("return 1"))];
+        let results = vec![CodeBenchResult {
+            passed: true,
+            error: None,
+        }];
+        // json_output true: should produce no panic and Ok(()).
+        let r = print_code_eval_results(
+            Path::new("m.apr"),
+            Path::new("bench.jsonl"),
+            &problems,
+            &results,
+            1.5,
+            50.0,
+            true,
+        );
+        assert!(r.is_ok());
+    }
+
+    #[test]
+    fn print_code_eval_results_human_mode_ok() {
+        let problems = vec![
+            problem("def a():", "assert True", None),
+            problem("def b():", "assert True", None),
+        ];
+        let results = vec![
+            CodeBenchResult {
+                passed: true,
+                error: None,
+            },
+            CodeBenchResult {
+                passed: false,
+                error: Some("boom".to_string()),
+            },
+        ];
+        let r = print_code_eval_results(
+            Path::new("m.apr"),
+            Path::new("bench.jsonl"),
+            &problems,
+            &results,
+            2.0,
+            90.0,
+            false,
+        );
+        assert!(r.is_ok());
+    }
+
+    #[test]
+    fn print_code_eval_results_empty_is_zero_rate() {
+        let problems: Vec<CodeBenchProblem> = vec![];
+        let results: Vec<CodeBenchResult> = vec![];
+        let r = print_code_eval_results(
+            Path::new("m.apr"),
+            Path::new("bench.jsonl"),
+            &problems,
+            &results,
+            0.0,
+            0.0,
+            true,
+        );
+        assert!(r.is_ok());
+    }
+
+    // ── print_multisample_table: smoke ─────────────────────────────────────
+
+    #[test]
+    fn print_multisample_table_smoke() {
+        let problems = vec![
+            ("p0".to_string(), "e".to_string(), 2usize),
+            ("p1".to_string(), "e".to_string(), 0usize),
+        ];
+        // Should not panic.
+        print_multisample_table(&problems, 4, 0.7, &[1, 4]);
+    }
+
+    // ── run_multisample_loop ───────────────────────────────────────────────
+
+    #[test]
+    fn multisample_loop_accumulates_correct_counts() {
+        let mut acc = vec![
+            ("p0".to_string(), "e".to_string(), 0usize),
+            ("p1".to_string(), "e".to_string(), 0usize),
+        ];
+        // Each sample: p0 passes, p1 fails.
+        let ok = run_multisample_loop::<_, ()>(&mut acc, 3, true, || {
+            Ok((
+                1,
+                vec![
+                    ("p0".to_string(), "e".to_string(), true),
+                    ("p1".to_string(), "e".to_string(), false),
+                ],
+            ))
+        });
+        assert!(ok);
+        assert_eq!(acc[0].2, 3); // p0 passed all 3 samples
+        assert_eq!(acc[1].2, 0); // p1 never passed
+    }
+
+    #[test]
+    fn multisample_loop_first_sample_error_aborts() {
+        let mut acc = vec![("p0".to_string(), "e".to_string(), 0usize)];
+        let ok = run_multisample_loop::<_, &str>(&mut acc, 5, true, || Err("boom"));
+        assert!(!ok); // never succeeded
+        assert_eq!(acc[0].2, 0);
+    }
+
+    #[test]
+    fn multisample_loop_later_errors_tolerated() {
+        let mut acc = vec![("p0".to_string(), "e".to_string(), 0usize)];
+        let mut call = 0;
+        let ok = run_multisample_loop::<_, &str>(&mut acc, 3, true, || {
+            call += 1;
+            if call == 1 {
+                Ok((1, vec![("p0".to_string(), "e".to_string(), true)]))
+            } else {
+                Err("transient")
+            }
+        });
+        assert!(ok); // first sample succeeded
+        assert_eq!(acc[0].2, 1); // only the first sample counted
+    }
+
+    // ── run_code_eval: error paths (no inference required) ─────────────────
+
+    #[test]
+    fn run_code_eval_missing_data_path_errors() {
+        let r = run_code_eval(Path::new("m.apr"), None, 64, 50.0, true);
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn run_code_eval_nonexistent_data_errors() {
+        let r = run_code_eval(
+            Path::new("/models/m.apr"),
+            Some(Path::new("/nonexistent/bench.jsonl")),
+            64,
+            50.0,
+            true,
+        );
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn run_code_eval_nonexistent_model_errors() {
+        let dir = std::env::temp_dir().join(format!("apr_codeeval_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let bench = dir.join("bench.jsonl");
+        std::fs::write(
+            &bench,
+            "{\"prompt\":\"def f():\",\"test\":\"assert f()\"}\n",
+        )
+        .unwrap();
+        let r = run_code_eval(
+            Path::new("/definitely/missing/model.apr"),
+            Some(&bench),
+            64,
+            50.0,
+            true,
+        );
+        assert!(r.is_err());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn run_code_eval_empty_benchmark_errors() {
+        let dir = std::env::temp_dir().join(format!("apr_codeeval_empty_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let bench = dir.join("bench.jsonl");
+        std::fs::write(&bench, "\n   \n").unwrap();
+        let model = dir.join("m.apr");
+        std::fs::write(&model, b"x").unwrap();
+        let r = run_code_eval(&model, Some(&bench), 64, 50.0, true);
+        assert!(r.is_err());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn run_code_eval_invalid_json_errors() {
+        let dir = std::env::temp_dir().join(format!("apr_codeeval_badjson_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let bench = dir.join("bench.jsonl");
+        std::fs::write(&bench, "not json at all\n").unwrap();
+        let model = dir.join("m.apr");
+        std::fs::write(&model, b"x").unwrap();
+        let r = run_code_eval(&model, Some(&bench), 64, 50.0, true);
+        assert!(r.is_err());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/crates/apr-cli/src/commands/eval/eval_mod_tests.rs
+++ b/crates/apr-cli/src/commands/eval/eval_mod_tests.rs
@@ -1,0 +1,450 @@
+// PMAT-125 B2: CPU-only unit tests for pure helpers in eval/mod.rs.
+
+use super::*;
+use std::str::FromStr;
+
+// ── Dataset::from_str ──────────────────────────────────────────────────────
+
+#[test]
+fn dataset_parses_wikitext_aliases() {
+    assert_eq!(Dataset::from_str("wikitext-2").unwrap(), Dataset::WikiText2);
+    assert_eq!(Dataset::from_str("wikitext2").unwrap(), Dataset::WikiText2);
+    assert_eq!(Dataset::from_str("WikiText-2").unwrap(), Dataset::WikiText2);
+}
+
+#[test]
+fn dataset_parses_lambada_and_custom() {
+    assert_eq!(Dataset::from_str("lambada").unwrap(), Dataset::Lambada);
+    assert_eq!(Dataset::from_str("LAMBADA").unwrap(), Dataset::Lambada);
+    assert_eq!(Dataset::from_str("custom").unwrap(), Dataset::Custom);
+}
+
+#[test]
+fn dataset_rejects_unknown() {
+    let err = Dataset::from_str("squad").unwrap_err();
+    assert!(err.contains("Unknown dataset"));
+}
+
+// ── extract_ngrams + compute_ngram_overlap ─────────────────────────────────
+
+#[test]
+fn extract_ngrams_basic() {
+    let grams = extract_ngrams("abcd", 2);
+    // "ab", "bc", "cd"
+    assert_eq!(grams.len(), 3);
+    assert!(grams.contains("ab"));
+    assert!(grams.contains("cd"));
+}
+
+#[test]
+fn extract_ngrams_dedups_repeats() {
+    // "aaaa" with n=2 ⇒ only "aa".
+    let grams = extract_ngrams("aaaa", 2);
+    assert_eq!(grams.len(), 1);
+    assert!(grams.contains("aa"));
+}
+
+#[test]
+fn extract_ngrams_too_short_is_empty() {
+    assert!(extract_ngrams("ab", 5).is_empty());
+    assert!(extract_ngrams("", 1).is_empty());
+}
+
+#[test]
+fn ngram_overlap_identical_is_one() {
+    let a = extract_ngrams("hello world", 3);
+    let b = extract_ngrams("hello world", 3);
+    assert!((compute_ngram_overlap(&a, &b) - 1.0).abs() < 1e-6);
+}
+
+#[test]
+fn ngram_overlap_disjoint_is_zero() {
+    let a = extract_ngrams("aaaa", 2);
+    let b = extract_ngrams("bbbb", 2);
+    assert_eq!(compute_ngram_overlap(&a, &b), 0.0);
+}
+
+#[test]
+fn ngram_overlap_empty_is_zero() {
+    let a = extract_ngrams("abc", 2);
+    let empty = std::collections::HashSet::new();
+    assert_eq!(compute_ngram_overlap(&a, &empty), 0.0);
+    assert_eq!(compute_ngram_overlap(&empty, &a), 0.0);
+}
+
+#[test]
+fn ngram_overlap_partial_is_jaccard() {
+    // a = {ab, bc}, b = {bc, cd} ⇒ intersection 1, union 3 ⇒ 1/3.
+    let a = extract_ngrams("abc", 2);
+    let b = extract_ngrams("bcd", 2);
+    let j = compute_ngram_overlap(&a, &b);
+    assert!((j - 1.0 / 3.0).abs() < 1e-6, "got {j}");
+}
+
+// ── format_bytes ───────────────────────────────────────────────────────────
+
+#[test]
+fn format_bytes_units() {
+    assert_eq!(format_bytes(512), "512 B");
+    assert_eq!(format_bytes(2048), "2.0 KiB");
+    assert_eq!(format_bytes(1_048_576), "1.0 MiB");
+    assert_eq!(format_bytes(1_073_741_824), "1.00 GiB");
+}
+
+#[test]
+fn format_bytes_boundaries() {
+    assert_eq!(format_bytes(1023), "1023 B");
+    assert_eq!(format_bytes(1024), "1.0 KiB");
+    assert_eq!(format_bytes(1_048_575), "1024.0 KiB");
+}
+
+// ── format_archive_size (GB/MB/KB variant) ─────────────────────────────────
+
+#[test]
+fn format_archive_size_units() {
+    assert_eq!(format_archive_size(100), "100 B");
+    assert_eq!(format_archive_size(1536), "1.5 KB");
+    assert_eq!(format_archive_size(1_572_864), "1.5 MB");
+    assert_eq!(format_archive_size(1_610_612_736), "1.5 GB");
+}
+
+// ── compute_file_hash (FNV-1a) ─────────────────────────────────────────────
+
+#[test]
+fn file_hash_is_deterministic() {
+    let h1 = compute_file_hash(b"hello");
+    let h2 = compute_file_hash(b"hello");
+    assert_eq!(h1, h2);
+    assert_eq!(h1.len(), 16); // 64-bit hex
+}
+
+#[test]
+fn file_hash_differs_on_content() {
+    assert_ne!(compute_file_hash(b"hello"), compute_file_hash(b"world"));
+}
+
+#[test]
+fn file_hash_empty_input() {
+    // FNV-1a offset basis for empty input.
+    assert_eq!(compute_file_hash(b""), "cbf29ce484222325");
+}
+
+// ── pearson_correlation ────────────────────────────────────────────────────
+
+#[test]
+fn pearson_perfect_positive() {
+    let x = [1.0, 2.0, 3.0, 4.0];
+    let y = [2.0, 4.0, 6.0, 8.0];
+    assert!((pearson_correlation(&x, &y) - 1.0).abs() < 1e-9);
+}
+
+#[test]
+fn pearson_perfect_negative() {
+    let x = [1.0, 2.0, 3.0, 4.0];
+    let y = [4.0, 3.0, 2.0, 1.0];
+    assert!((pearson_correlation(&x, &y) + 1.0).abs() < 1e-9);
+}
+
+#[test]
+fn pearson_too_few_points_is_zero() {
+    assert_eq!(pearson_correlation(&[1.0], &[2.0]), 0.0);
+    assert_eq!(pearson_correlation(&[], &[]), 0.0);
+}
+
+#[test]
+fn pearson_zero_variance_is_zero() {
+    // Constant x ⇒ undefined correlation, guarded to 0.
+    let x = [5.0, 5.0, 5.0];
+    let y = [1.0, 2.0, 3.0];
+    assert_eq!(pearson_correlation(&x, &y), 0.0);
+}
+
+// ── compute_ranks + spearman_correlation ───────────────────────────────────
+
+#[test]
+fn compute_ranks_no_ties() {
+    // values 30,10,20 ⇒ ranks 3,1,2
+    let ranks = compute_ranks(&[30.0, 10.0, 20.0]);
+    assert_eq!(ranks, vec![3.0, 1.0, 2.0]);
+}
+
+#[test]
+fn compute_ranks_with_ties_averages() {
+    // values 10,10,20 ⇒ first two tied at ranks (1+2)/2=1.5, third = 3.
+    let ranks = compute_ranks(&[10.0, 10.0, 20.0]);
+    assert_eq!(ranks, vec![1.5, 1.5, 3.0]);
+}
+
+#[test]
+fn spearman_monotonic_is_one() {
+    // Strictly monotonic (non-linear) ⇒ Spearman = 1 even though Pearson < 1.
+    let x = [1.0, 2.0, 3.0, 4.0];
+    let y = [1.0, 4.0, 9.0, 16.0];
+    assert!((spearman_correlation(&x, &y) - 1.0).abs() < 1e-9);
+}
+
+// ── interpret_correlation ──────────────────────────────────────────────────
+
+#[test]
+fn interpret_correlation_strength_buckets() {
+    assert!(interpret_correlation(0.95).contains("Very strong"));
+    assert!(interpret_correlation(0.8).contains("Strong"));
+    assert!(interpret_correlation(0.6).contains("Moderate"));
+    assert!(interpret_correlation(0.4).contains("Weak"));
+    assert!(interpret_correlation(0.1).contains("Very weak"));
+}
+
+#[test]
+fn interpret_correlation_direction() {
+    assert!(interpret_correlation(-0.8).contains("negative"));
+    assert!(interpret_correlation(0.8).contains("positive"));
+}
+
+// ── encryption primitives: apply_keystream + compute_mac ───────────────────
+
+#[test]
+fn keystream_roundtrips_to_plaintext() {
+    let key = [7u8; 32];
+    let nonce = [9u8; 32];
+    let plaintext = b"the quick brown fox jumps over the lazy dog repeatedly".to_vec();
+    let ct = apply_keystream(&key, &nonce, &plaintext);
+    assert_ne!(ct, plaintext); // actually encrypted
+    let pt = apply_keystream(&key, &nonce, &ct);
+    assert_eq!(pt, plaintext); // XOR cipher is its own inverse
+}
+
+#[test]
+fn keystream_spans_multiple_blocks() {
+    // >64 bytes forces multiple keystream blocks.
+    let key = [1u8; 32];
+    let nonce = [2u8; 32];
+    let plaintext = vec![0xABu8; 200];
+    let ct = apply_keystream(&key, &nonce, &plaintext);
+    assert_eq!(ct.len(), 200);
+    let pt = apply_keystream(&key, &nonce, &ct);
+    assert_eq!(pt, plaintext);
+}
+
+#[test]
+fn keystream_different_nonce_differs() {
+    let key = [3u8; 32];
+    let data = b"same plaintext".to_vec();
+    let a = apply_keystream(&key, &[0u8; 32], &data);
+    let b = apply_keystream(&key, &[1u8; 32], &data);
+    assert_ne!(a, b);
+}
+
+#[test]
+fn mac_is_deterministic_and_content_sensitive() {
+    let key = [4u8; 32];
+    let nonce = [5u8; 32];
+    let m1 = compute_mac(&key, &nonce, b"data");
+    let m2 = compute_mac(&key, &nonce, b"data");
+    assert_eq!(m1.as_bytes(), m2.as_bytes());
+    let m3 = compute_mac(&key, &nonce, b"datb");
+    assert_ne!(m1.as_bytes(), m3.as_bytes());
+}
+
+// ── derive_encryption_key ──────────────────────────────────────────────────
+
+#[test]
+fn derive_key_from_32_byte_file_uses_raw_bytes() {
+    let dir = std::env::temp_dir().join(format!("apr_key_{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let kf = dir.join("key.bin");
+    let raw = [0x5Au8; 32];
+    std::fs::write(&kf, raw).unwrap();
+    let key = derive_encryption_key(Some(&kf)).unwrap();
+    assert_eq!(key, raw);
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn derive_key_from_short_file_derives() {
+    let dir = std::env::temp_dir().join(format!("apr_key_short_{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let kf = dir.join("key.bin");
+    std::fs::write(&kf, b"short").unwrap();
+    let key = derive_encryption_key(Some(&kf)).unwrap();
+    // Derived key is a BLAKE3 derive_key of the content — deterministic.
+    let expected = blake3::derive_key("albor model encryption 2026", b"short");
+    assert_eq!(key, expected);
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn derive_key_missing_file_errors() {
+    let r = derive_encryption_key(Some(Path::new("/nonexistent/key.bin")));
+    assert!(r.is_err());
+}
+
+// ── extract_ppl_from_jsonl ─────────────────────────────────────────────────
+
+#[test]
+fn extract_ppl_normalizes_steps() {
+    let dir = std::env::temp_dir().join(format!("apr_ppl_{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let f = dir.join("log.jsonl");
+    std::fs::write(
+        &f,
+        "{\"step\":0,\"val_ppl\":10.0}\n{\"step\":100,\"val_ppl\":5.0}\n",
+    )
+    .unwrap();
+    let pairs = extract_ppl_from_jsonl(&f);
+    assert_eq!(pairs.len(), 2);
+    // (ppl, step/max_step): (10.0, 0.0), (5.0, 1.0)
+    assert_eq!(pairs[0], (10.0, 0.0));
+    assert_eq!(pairs[1], (5.0, 1.0));
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn extract_ppl_single_entry_is_empty() {
+    let dir = std::env::temp_dir().join(format!("apr_ppl_one_{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let f = dir.join("log.jsonl");
+    std::fs::write(&f, "{\"step\":0,\"val_ppl\":10.0}\n").unwrap();
+    assert!(extract_ppl_from_jsonl(&f).is_empty());
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn extract_ppl_missing_file_is_empty() {
+    assert!(extract_ppl_from_jsonl(Path::new("/nonexistent/log.jsonl")).is_empty());
+}
+
+// ── read_json_f64 ──────────────────────────────────────────────────────────
+
+#[test]
+fn read_json_f64_reads_value() {
+    let dir = std::env::temp_dir().join(format!("apr_jf64_{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let f = dir.join("eval.json");
+    std::fs::write(&f, "{\"perplexity\": 3.5, \"name\": \"x\"}").unwrap();
+    assert_eq!(read_json_f64(&f, "perplexity"), Some(3.5));
+    assert_eq!(read_json_f64(&f, "name"), None); // not an f64
+    assert_eq!(read_json_f64(&f, "missing"), None);
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn read_json_f64_missing_file_is_none() {
+    assert_eq!(read_json_f64(Path::new("/no/such.json"), "k"), None);
+}
+
+// ── extract_loss_history_pairs ─────────────────────────────────────────────
+
+#[test]
+fn loss_history_maps_to_exp_and_progress() {
+    let dir = std::env::temp_dir().join(format!("apr_lh_{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let f = dir.join("training_state.json");
+    std::fs::write(&f, "{\"loss_history\": [0.0, 1.0]}").unwrap();
+    let pairs = extract_loss_history_pairs(&f);
+    assert_eq!(pairs.len(), 2);
+    // (exp(loss), (i+1)/n): (1.0, 0.5), (e, 1.0)
+    assert!((pairs[0].0 - 1.0).abs() < 1e-9);
+    assert!((pairs[0].1 - 0.5).abs() < 1e-9);
+    assert!((pairs[1].0 - std::f64::consts::E).abs() < 1e-9);
+    assert!((pairs[1].1 - 1.0).abs() < 1e-9);
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn loss_history_too_short_is_empty() {
+    let dir = std::env::temp_dir().join(format!("apr_lh_short_{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let f = dir.join("training_state.json");
+    std::fs::write(&f, "{\"loss_history\": [1.0]}").unwrap();
+    assert!(extract_loss_history_pairs(&f).is_empty());
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn loss_history_no_field_is_empty() {
+    let dir = std::env::temp_dir().join(format!("apr_lh_none_{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let f = dir.join("training_state.json");
+    std::fs::write(&f, "{\"other\": 1}").unwrap();
+    assert!(extract_loss_history_pairs(&f).is_empty());
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+// ── count_safetensors_keys ─────────────────────────────────────────────────
+
+#[test]
+fn count_safetensors_keys_excludes_metadata() {
+    let dir = std::env::temp_dir().join(format!("apr_st_{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let f = dir.join("model.safetensors");
+    // Build a minimal safetensors file: [8-byte header_len][header json].
+    let header = r#"{"__metadata__":{"k":"v"},"w1":{"dtype":"F32"},"w2":{"dtype":"F32"}}"#;
+    let mut bytes = (header.len() as u64).to_le_bytes().to_vec();
+    bytes.extend_from_slice(header.as_bytes());
+    std::fs::write(&f, &bytes).unwrap();
+    // Two real tensors, __metadata__ excluded.
+    assert_eq!(count_safetensors_keys(&f), 2);
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn count_safetensors_keys_truncated_is_zero() {
+    let dir = std::env::temp_dir().join(format!("apr_st_bad_{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let f = dir.join("bad.safetensors");
+    std::fs::write(&f, b"abc").unwrap(); // < 8 bytes
+    assert_eq!(count_safetensors_keys(&f), 0);
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn count_safetensors_keys_missing_is_zero() {
+    assert_eq!(
+        count_safetensors_keys(Path::new("/no/model.safetensors")),
+        0
+    );
+}
+
+// ── load_eval_prompts + default_code_eval_prompts ──────────────────────────
+
+#[test]
+fn load_eval_prompts_from_jsonl() {
+    let dir = std::env::temp_dir().join(format!("apr_prompts_{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let f = dir.join("prompts.jsonl");
+    std::fs::write(&f, "{\"prompt\":\"def a():\"}\n{\"prompt\":\"def b():\"}\n").unwrap();
+    let prompts = load_eval_prompts(&f).unwrap();
+    assert_eq!(
+        prompts,
+        vec!["def a():".to_string(), "def b():".to_string()]
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn load_eval_prompts_plaintext_fallback() {
+    let dir = std::env::temp_dir().join(format!("apr_prompts_txt_{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let f = dir.join("prompts.txt");
+    std::fs::write(&f, "line one\nline two\n").unwrap();
+    let prompts = load_eval_prompts(&f).unwrap();
+    assert_eq!(
+        prompts,
+        vec!["line one".to_string(), "line two".to_string()]
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn load_eval_prompts_missing_file_errors() {
+    assert!(load_eval_prompts(Path::new("/no/prompts.jsonl")).is_err());
+}
+
+#[test]
+fn default_prompts_are_nonempty_python() {
+    let prompts = default_code_eval_prompts();
+    assert_eq!(prompts.len(), 10);
+    for p in &prompts {
+        assert!(p.contains("def ") || p.contains("class "));
+    }
+}

--- a/crates/apr-cli/src/commands/eval/inference.rs
+++ b/crates/apr-cli/src/commands/eval/inference.rs
@@ -1876,3 +1876,238 @@ fn run_mbpp_inference_cuda(
 ) -> std::result::Result<(usize, Vec<(String, String, bool)>), String> {
     Err("CUDA not available (compile with --features cuda)".to_string())
 }
+
+#[cfg(test)]
+mod inference_helper_tests {
+    use super::*;
+
+    fn he_problem(prompt: &str, test: &str, canonical: Option<&str>) -> HumanEvalProblem {
+        HumanEvalProblem {
+            task_id: "HumanEval/0".to_string(),
+            prompt: prompt.to_string(),
+            canonical_solution: canonical.map(String::from),
+            test: test.to_string(),
+            entry_point: None,
+        }
+    }
+
+    // ── sample_token ───────────────────────────────────────────────────────
+
+    #[test]
+    fn sample_token_greedy_on_zero_temperature() {
+        // temperature <= 0 ⇒ argmax.
+        let logits = [0.1f32, 0.5, 0.2, 9.0, 0.3];
+        let mut rng = 42u64;
+        assert_eq!(sample_token(&logits, 0.0, &mut rng), 3);
+    }
+
+    #[test]
+    fn sample_token_greedy_on_negative_temperature() {
+        let logits = [5.0f32, 1.0, 2.0];
+        let mut rng = 1u64;
+        assert_eq!(sample_token(&logits, -1.0, &mut rng), 0);
+    }
+
+    #[test]
+    fn sample_token_empty_logits_returns_zero() {
+        let logits: [f32; 0] = [];
+        let mut rng = 7u64;
+        assert_eq!(sample_token(&logits, 1.0, &mut rng), 0);
+        assert_eq!(sample_token(&logits, 0.0, &mut rng), 0);
+    }
+
+    #[test]
+    fn sample_token_temperature_in_valid_range() {
+        // With temperature > 0, result must be a valid index into logits.
+        let logits = [1.0f32, 2.0, 3.0, 4.0];
+        let mut rng = 0x1234_5678_9abc_def0u64;
+        for _ in 0..50 {
+            let tok = sample_token(&logits, 0.8, &mut rng);
+            assert!((tok as usize) < logits.len(), "out of range: {tok}");
+        }
+    }
+
+    #[test]
+    fn sample_token_dominant_logit_usually_wins() {
+        // One overwhelmingly large logit ⇒ low-temperature sampling should
+        // almost always select it.
+        let logits = [0.0f32, 0.0, 50.0, 0.0];
+        let mut rng = 0xdead_beef_0000_0001u64;
+        let mut hits = 0;
+        for _ in 0..100 {
+            if sample_token(&logits, 0.1, &mut rng) == 2 {
+                hits += 1;
+            }
+        }
+        assert!(
+            hits >= 95,
+            "dominant logit should win nearly always: {hits}"
+        );
+    }
+
+    #[test]
+    fn sample_token_is_deterministic_for_seed() {
+        let logits = [1.0f32, 2.0, 3.0, 0.5, 1.5];
+        let mut a = 999u64;
+        let mut b = 999u64;
+        let seq_a: Vec<u32> = (0..10)
+            .map(|_| sample_token(&logits, 0.9, &mut a))
+            .collect();
+        let seq_b: Vec<u32> = (0..10)
+            .map(|_| sample_token(&logits, 0.9, &mut b))
+            .collect();
+        assert_eq!(seq_a, seq_b);
+    }
+
+    // ── validate_humaneval_problem ─────────────────────────────────────────
+
+    #[test]
+    fn validate_rejects_empty_prompt() {
+        let p = he_problem("   ", "assert f()", Some("return 1"));
+        assert!(!validate_humaneval_problem(&p));
+    }
+
+    #[test]
+    fn validate_rejects_empty_test() {
+        let p = he_problem("def f():", "  \n ", Some("return 1"));
+        assert!(!validate_humaneval_problem(&p));
+    }
+
+    #[test]
+    fn validate_accepts_with_canonical_solution() {
+        let p = he_problem("anything", "assert True", Some("return 42"));
+        assert!(validate_humaneval_problem(&p));
+    }
+
+    #[test]
+    fn validate_rejects_empty_canonical_without_def() {
+        // canonical present but blank ⇒ falls through to def-check, no "def ".
+        let p = he_problem("no function here", "assert True", Some("   "));
+        assert!(!validate_humaneval_problem(&p));
+    }
+
+    #[test]
+    fn validate_accepts_def_without_canonical() {
+        let p = he_problem("def foo():\n    pass", "assert foo() is None", None);
+        assert!(validate_humaneval_problem(&p));
+    }
+
+    #[test]
+    fn validate_rejects_no_def_no_canonical() {
+        let p = he_problem("just some text", "assert True", None);
+        assert!(!validate_humaneval_problem(&p));
+    }
+
+    // ── extract_function_name ──────────────────────────────────────────────
+
+    #[test]
+    fn extract_function_name_simple() {
+        assert_eq!(extract_function_name("def add(a, b):"), Some("add"));
+    }
+
+    #[test]
+    fn extract_function_name_with_leading_lines() {
+        let prompt = "from typing import List\n\ndef has_close_elements(nums: List[float], t: float) -> bool:\n    pass";
+        assert_eq!(extract_function_name(prompt), Some("has_close_elements"));
+    }
+
+    #[test]
+    fn extract_function_name_indented_def() {
+        // The function picks up the first `def ` even when indented.
+        let prompt = "    def inner(x):\n        return x";
+        assert_eq!(extract_function_name(prompt), Some("inner"));
+    }
+
+    #[test]
+    fn extract_function_name_none_when_no_def() {
+        assert_eq!(extract_function_name("x = 1\ny = 2"), None);
+    }
+
+    #[test]
+    fn extract_function_name_none_when_def_has_no_paren() {
+        assert_eq!(extract_function_name("def malformed:"), None);
+    }
+
+    #[test]
+    fn extract_function_name_first_of_many() {
+        let prompt = "def first():\n    pass\ndef second():\n    pass";
+        assert_eq!(extract_function_name(prompt), Some("first"));
+    }
+
+    // ── truncate_at_function_boundary ──────────────────────────────────────
+
+    #[test]
+    fn truncate_stops_at_next_def() {
+        let c = "    return a + b\n\ndef other():\n    pass";
+        assert_eq!(truncate_at_function_boundary(c), "    return a + b\n");
+    }
+
+    #[test]
+    fn truncate_stops_at_next_class() {
+        let c = "    return 1\nclass Foo:\n    pass";
+        assert_eq!(truncate_at_function_boundary(c), "    return 1");
+    }
+
+    #[test]
+    fn truncate_passthrough_when_no_boundary() {
+        let c = "    return a + b";
+        assert_eq!(truncate_at_function_boundary(c), c);
+    }
+
+    #[test]
+    fn truncate_prefers_earliest_def_over_class() {
+        // \ndef appears before \nclass ⇒ cut at def.
+        let c = "x\ndef d():\n y\nclass C:\n z";
+        assert_eq!(truncate_at_function_boundary(c), "x");
+    }
+
+    // ── print_humaneval_results: smoke + zero-division guard ───────────────
+
+    #[test]
+    fn print_humaneval_results_smoke() {
+        let results = vec![
+            ("HumanEval/0".to_string(), "f".to_string(), true),
+            ("HumanEval/1".to_string(), "g".to_string(), false),
+        ];
+        // Should not panic.
+        print_humaneval_results(&results, 2, 1, &[1, 10], 3.5, "inference");
+    }
+
+    #[test]
+    fn print_humaneval_results_zero_total_no_panic() {
+        let results: Vec<(String, String, bool)> = vec![];
+        print_humaneval_results(&results, 0, 0, &[1], 0.0, "structural");
+    }
+
+    // ── write_apr_eval_debug: writes a JSON debug file ─────────────────────
+
+    #[test]
+    fn write_apr_eval_debug_creates_file() {
+        let exec = PythonExecResult {
+            success: false,
+            exit_code: Some(1),
+            stderr_capture: "AssertionError".to_string(),
+            timed_out: false,
+            spawn_error: None,
+        };
+        let task = format!("dbgtest/{}", std::process::id());
+        write_apr_eval_debug(
+            &task,
+            "def f(): pass",
+            "response text",
+            "    return 1",
+            "def f():\n    return 1",
+            &exec,
+        );
+        let safe = task.replace(['/', '\\', ' '], "_");
+        let path = std::env::temp_dir().join(format!("apr_eval_debug_{safe}.json"));
+        assert!(path.exists(), "debug file not written: {}", path.display());
+        let content = std::fs::read_to_string(&path).unwrap();
+        let json: serde_json::Value = serde_json::from_str(&content).unwrap();
+        assert_eq!(json["exit_code"], 1);
+        assert_eq!(json["success"], false);
+        assert_eq!(json["stderr"], "AssertionError");
+        assert_eq!(json["response_len"], "response text".len());
+        let _ = std::fs::remove_file(&path);
+    }
+}

--- a/crates/apr-cli/src/commands/eval/mod.rs
+++ b/crates/apr-cli/src/commands/eval/mod.rs
@@ -1789,4 +1789,7 @@ fn format_archive_size(bytes: u64) -> String {
     }
 }
 
+#[cfg(test)]
+mod eval_mod_tests;
+
 include!("../using.rs");

--- a/crates/apr-cli/src/commands/rosetta_08.rs
+++ b/crates/apr-cli/src/commands/rosetta_08.rs
@@ -19,4 +19,5 @@ include!("rosetta_compute_tensor_get.rs");
 include!("rosetta_print_fingerprint.rs");
 include!("rosetta_verification_report.rs");
 include!("rosetta_print_inference_tests.rs");
+include!("rosetta_inference_result_tests.rs");
 }

--- a/crates/apr-cli/src/commands/rosetta_inference_result_tests.rs
+++ b/crates/apr-cli/src/commands/rosetta_inference_result_tests.rs
@@ -1,0 +1,151 @@
+
+// PMAT-125 B2: unit tests for inference_result.rs trace-parsing helpers
+// (rosetta-scoped). Included into rosetta_08.rs's `mod tests`.
+
+#[test]
+fn parse_selected_token_extracts_id_and_logit() {
+    let line = "  Selected token: 42 (logit: 7.5)";
+    assert_eq!(parse_selected_token(line), Some((42, Some(7.5))));
+}
+
+#[test]
+fn parse_selected_token_id_without_logit() {
+    let line = "Selected token: 100 (foo)";
+    assert_eq!(parse_selected_token(line), Some((100, None)));
+}
+
+#[test]
+fn parse_selected_token_none_on_unrelated_line() {
+    assert_eq!(parse_selected_token("Loading model..."), None);
+}
+
+#[test]
+fn parse_selected_token_none_on_non_numeric_id() {
+    assert_eq!(parse_selected_token("Selected token: abc (logit: 1.0)"), None);
+}
+
+#[test]
+fn parse_top5_line_extracts_ids() {
+    let line = "Top 5 tokens: (10, 0.5), (20, 0.3), (30, 0.1)";
+    assert_eq!(parse_top5_line(line), Some(vec![10, 20, 30]));
+}
+
+#[test]
+fn parse_top5_line_none_on_unrelated() {
+    assert_eq!(parse_top5_line("nothing here"), None);
+}
+
+#[test]
+fn parse_top5_line_none_when_empty() {
+    // "Top 5 tokens:" marker but no parseable pairs.
+    assert_eq!(parse_top5_line("Top 5 tokens: garbage"), None);
+}
+
+#[test]
+fn parse_trace_lines_collects_tokens_logits_top5() {
+    let combined = "\
+Loading\n\
+Selected token: 5 (logit: 1.5)\n\
+Top 5 tokens: (5, 0.9), (6, 0.05)\n\
+Selected token: 6 (logit: 2.0)\n\
+Top 5 tokens: (6, 0.8), (7, 0.1)\n";
+    let (tokens, logits, top5) = parse_trace_lines(combined);
+    assert_eq!(tokens, vec![5, 6]);
+    assert_eq!(logits, vec![1.5, 2.0]);
+    assert_eq!(top5, vec![vec![5, 6], vec![6, 7]]);
+}
+
+#[test]
+fn parse_trace_lines_token_without_logit_skips_logit_vec() {
+    let combined = "Selected token: 9 (no logit field)\n";
+    let (tokens, logits, top5) = parse_trace_lines(combined);
+    assert_eq!(tokens, vec![9]);
+    assert!(logits.is_empty());
+    assert!(top5.is_empty());
+}
+
+#[test]
+fn strip_ansi_removes_color_codes() {
+    let colored = "\x1b[31mred\x1b[0m text";
+    assert_eq!(strip_ansi(colored), "red text");
+}
+
+#[test]
+fn strip_ansi_passes_through_plain_text() {
+    assert_eq!(strip_ansi("plain"), "plain");
+}
+
+#[test]
+fn extract_clean_output_filters_noise_lines() {
+    let stdout = "\
+Loading model\n\
+Model loaded in 1s\n\
+Prompt tokens: 3\n\
+Temperature: 0.0\n\
+Hello world\n\
+Generated (5 tokens)\n\
+12.0 tok/s\n";
+    // Only the real content line survives.
+    assert_eq!(extract_clean_output(stdout), "Hello world");
+}
+
+#[test]
+fn extract_clean_output_strips_spinner_and_ansi() {
+    let stdout = "\x1b[32m⠋⠙Answer\x1b[0m\n";
+    assert_eq!(extract_clean_output(stdout), "Answer");
+}
+
+#[test]
+fn extract_clean_output_empty_when_all_noise() {
+    let stdout = "Loading\n[debug]\nERROR boom\n";
+    assert_eq!(extract_clean_output(stdout), "");
+}
+
+#[test]
+fn is_transposed_dims_detects_swap() {
+    assert!(is_transposed_dims(&[10, 20], &[20, 10]));
+}
+
+#[test]
+fn is_transposed_dims_false_on_identical_square() {
+    assert!(!is_transposed_dims(&[896, 896], &[896, 896]));
+}
+
+#[test]
+fn is_transposed_dims_false_on_non_2d() {
+    assert!(!is_transposed_dims(&[10, 20, 30], &[30, 20, 10]));
+    assert!(!is_transposed_dims(&[10], &[10]));
+}
+
+#[test]
+fn normalize_tensor_name_gguf_to_canonical() {
+    assert_eq!(
+        normalize_tensor_name("blk.0.attn_q.weight"),
+        "0.q_proj.weight"
+    );
+    assert_eq!(
+        normalize_tensor_name("blk.3.ffn_gate.weight"),
+        "3.gate_proj.weight"
+    );
+}
+
+#[test]
+fn normalize_tensor_name_hf_to_canonical() {
+    assert_eq!(
+        normalize_tensor_name("model.layers.0.self_attn.q_proj.weight"),
+        "0.q_proj.weight"
+    );
+}
+
+#[test]
+fn normalize_tensor_name_output_to_lm_head() {
+    assert_eq!(normalize_tensor_name("output.weight"), "lm_head.weight");
+}
+
+#[test]
+fn normalize_tensor_name_token_embd() {
+    assert_eq!(
+        normalize_tensor_name("token_embd.weight"),
+        "embed_tokens.weight"
+    );
+}


### PR DESCRIPTION
## Summary

PMAT-125 coverage batch **B2** (eval + inference + check subcommands). Adds **124 CPU-only unit tests** for previously-uncovered pure functions. **Tests only — no `src` logic changes**, so this can only help the 95% coverage bar.

Targets the 2nd-largest gap cluster: `eval/mod.rs` (was 2.2% cov) and `eval/inference.rs` (was 34.8%).

## What's covered

**`eval/code_eval.rs`** (+32): `compute_pass_at_k` unbiased estimator (zero/all/none/k>n/closed-form/monotonicity), `compute_multisample_pass_at_k`, `build_passk_json` shaping, `evaluate_code_problem` happy+error paths, `print_code_eval_results` (JSON/human/empty), `run_multisample_loop` accumulation + first-sample-abort, `run_code_eval` error paths.

**`eval/inference.rs`** (+27): `sample_token` (greedy/temperature/empty/determinism/dominant-logit), `validate_humaneval_problem`, `extract_function_name`, `truncate_at_function_boundary`, `print_humaneval_results`, `write_apr_eval_debug`.

**`eval/mod.rs`** (new `eval_mod_tests.rs`, +44): `Dataset::from_str`, `extract_ngrams`/`compute_ngram_overlap` (Jaccard), `format_bytes`/`format_archive_size`, `compute_file_hash` (FNV-1a), `pearson`/`spearman`/`compute_ranks`/`interpret_correlation`, `apply_keystream` roundtrip + `compute_mac` + `derive_encryption_key`, `extract_ppl_from_jsonl`, `read_json_f64`, `extract_loss_history_pairs`, `count_safetensors_keys`, `load_eval_prompts`.

**rosetta `inference_result.rs`** (new `rosetta_inference_result_tests.rs`, +21): `parse_selected_token`/`parse_top5_line`/`parse_trace_lines`, `strip_ansi`, `extract_clean_output` noise filtering, `is_transposed_dims`, `normalize_tensor_name` GGUF↔HF canonicalization.

## Notes
- `check_*` modules (check_aggregation/check_qkv_ffn_detection/check_stage_print_results/check_tensor_stage_json/check_full_model_has) are already test-only includes — no production gaps to fill there.
- `inference_output.rs` shard/brace parse helpers are already covered (run_07 test suite); its remaining functions are network/feature-gated I/O, not CPU-testable.
- Excluded `check_finite_lint.rs` + `check_finite_classifier.rs` (owned by batch B5).

## Verification
- `cargo test -p apr-cli --lib`: **6132 passed, 0 failed**
- `cargo clippy -p apr-cli --tests`: clean (no lints on changed files)
- `cargo fmt` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)