### PR TITLE
test(lora): LoRA adapter trains to decreasing loss with base frozen (PMAT-931)

### DIFF
--- a/contracts/lora-adapter-trains-base-frozen-v1.yaml
+++ b/contracts/lora-adapter-trains-base-frozen-v1.yaml
@@ -1,0 +1,79 @@
+contract: lora-adapter-trains-base-frozen
+metadata:
+  kind: training-loop
+  version: "1.0.0"
+  description: >
+    P3 / Unsloth-pillar END-TO-END capability proof for LoRA fine-tuning,
+    extending the PMAT-921 end-to-end-training-proof methodology (a real model
+    trained to a DECREASING loss with the right params updating) from a full
+    transformer to the LoRA adapter path (PMAT-931).
+    A tiny frozen base weight wrapped in a LoRALayer (low-rank A/B) MUST train a
+    fixed deterministic regression task to a substantially decreasing loss while
+    obeying the LoRA invariant: the adapter params A and B update from init and
+    receive finite non-zero gradients, and the BASE weight stays EXACTLY frozen.
+    The pre-existing LoRA gradient tests (lora/gradient_tests.rs) only check the
+    STATIC requires_grad flags and MANUALLY-injected gradients — they never run a
+    real backward pass through LoRALayer::forward, so a severed integration path
+    stays green. PMAT-931 surfaced exactly such a bug: LoRALayer::forward rebuilt
+    its output via `Tensor::new(scaled_lora_data, false)` for the scaled LoRA
+    branch and `Tensor::new(result_data, ..)` for the base+LoRA sum, which SEVERS
+    the autograd graph (the same Tensor::from_vec/Tensor::new sever class as the
+    PMAT-921/922 sweep). The forward output dropped requires_grad and had no
+    backward op, so NO gradient ever reached lora_a/lora_b — the adapter was
+    silently frozen and LoRA fine-tuning could not train at all, while every
+    static requires_grad/manual-gradient test passed. The fix routes the scaled
+    LoRA branch through the autograd-aware `scale` op and the base+LoRA sum
+    through the autograd-aware `add` op (identical forward numerics; only the
+    backward edge is restored). This contract guards the composed LoRA training
+    graph, not a static flag.
+  references:
+  - "crates/aprender-train/src/lora/layer/core.rs"
+  - "crates/aprender-train/src/lora/train_to_loss_tests.rs"
+  - "crates/aprender-train/src/autograd/ops/basic.rs"
+  - "crates/aprender-train/src/autograd/ops/matmul.rs"
+version: 1
+status: enforced
+date: 2026-06-25
+
+proof_obligations:
+  - type: invariant
+    property: >
+      OBLIG-LORA-ADAPTER-TRAINS-BASE-FROZEN: after N gradient-descent steps on a
+      fixed deterministic regression target, a tiny LoRALayer (frozen base + rank-r
+      A/B adapter, scale=1) satisfies THREE guards. Guard (a): the final
+      squared-error loss collapses far below the initial (final < 0.5 * initial;
+      observed final ~= 0 as the rank-r branch reaches the target). Guard (b): both
+      adapter params A and B genuinely CHANGED from init (Σ|Δ| > 1e-4) AND received
+      a finite non-zero gradient on at least one step. Guard (c): the BASE weight is
+      EXACTLY unchanged (|w_final - w_init| < 1e-12 elementwise) and stays
+      requires_grad=false. A severed edge in LoRALayer::forward freezes the adapter
+      (||Δ||=0, no gradient — guard b RED) independently of the loss; a backward
+      path that leaked into the base would move it (guard c RED).
+  - type: equivalence
+    property: >
+      LORA-FALSIFIER-NON-TAUTOLOGICAL: the test is a real end-to-end LoRA-training
+      guard, not an is_some / requires_grad flag assertion. Everything is LCG-seeded
+      so the loss trajectory and per-param deltas are deterministic and CI-stable.
+      RED-confirmed by reverting LoRALayer::forward to the graph-severing
+      `Tensor::new(scaled_lora_data, false)` + `Tensor::new(result_data, ..)` path:
+      the forward output reports requires_grad=false and no backward op, lora_a and
+      lora_b receive NO gradient (guard b RED), and the loss does not decrease
+      because the adapter cannot move. The autograd-aware `scale`+`add` path is
+      GREEN. A second minimal structural guard
+      (lora_forward_backward_reaches_adapter_not_base) asserts the forward output
+      keeps a live backward op, the adapter gets a gradient, and the frozen base
+      does NOT — catching a re-sever in one forward/backward.
+
+falsification_tests:
+  - id: FALSIFY-LORA-ADAPTER-TRAINS-BASE-FROZEN-001
+    name: falsify_lora_adapter_trains_to_decreasing_loss_base_frozen
+    prediction: "A tiny LoRA adapter trains the fixed regression task to final loss < 0.5*initial AND both adapter params A/B change from init with a finite non-zero gradient while the base weight stays exactly frozen"
+    test_harness: "cargo test -p aprender-train --lib falsify_lora_adapter_trains_to_decreasing_loss_base_frozen"
+    expected_output: "test result: ok"
+    if_fails: "LoRALayer::forward is severing the autograd graph (Tensor::new on the scaled LoRA branch or the base+LoRA sum). Route the scale through the autograd-aware `scale` op and the sum through `add` so the backward edge reaches lora_a/lora_b and the adapter is trainable end-to-end."
+  - id: FALSIFY-LORA-FORWARD-BACKWARD-REACHES-ADAPTER-002
+    name: lora_forward_backward_reaches_adapter_not_base
+    prediction: "LoRALayer::forward output keeps a live backward op; after backward the adapter A/B receive gradient and the frozen base does not"
+    test_harness: "cargo test -p aprender-train --lib lora_forward_backward_reaches_adapter_not_base"
+    expected_output: "test result: ok"
+    if_fails: "LoRALayer::forward dropped the backward op (Tensor::new with requires_grad=false). Build the LoRA output via autograd-aware ops so the result carries a backward op reaching the adapter while leaving the frozen base ungraded."

--- a/crates/aprender-train/src/lora/layer/core.rs
+++ b/crates/aprender-train/src/lora/layer/core.rs
@@ -19,6 +19,7 @@
 //! surviving activations by `1/(1-p)` so the expected value is preserved.
 
 use crate::autograd::matmul;
+use crate::autograd::ops::{add, scale};
 use crate::Tensor;
 use std::cell::Cell;
 
@@ -266,19 +267,20 @@ impl LoRALayer {
             // Step 2: B @ (A @ x) [d_out, r] @ [r, 1] -> [d_out, 1]
             let lora_out_b = matmul(&self.lora_b, &lora_out_a, self.d_out, self.rank, 1);
 
-            // Step 3: scale * LoRA output
-            let mut scaled_lora_data = lora_out_b.data().to_owned();
-            for val in &mut scaled_lora_data {
-                *val *= self.scale;
-            }
-            let scaled_lora = Tensor::new(scaled_lora_data, false);
+            // Step 3: scale * LoRA output.
+            //
+            // PMAT-931: route the scale through the autograd-aware `scale` op
+            // instead of rebuilding the tensor with `Tensor::new(.., false)`,
+            // which SEVERS the backward edge to lora_a/lora_b (the same
+            // graph-severing class as the PMAT-921/922 sweep). Without this the
+            // adapter receives no gradient and LoRA fine-tuning silently fails
+            // to train.
+            let scaled_lora = scale(&lora_out_b, self.scale);
 
-            // Step 4: base + LoRA
-            let mut result_data = base_output.data().to_owned();
-            for (i, val) in result_data.iter_mut().enumerate() {
-                *val += scaled_lora.data()[i];
-            }
-            Tensor::new(result_data, base_output.requires_grad())
+            // Step 4: base + LoRA, again through the autograd-aware `add` op so
+            // the result keeps a live backward op reaching both the frozen base
+            // matmul (no-grad, dropped) AND the trainable LoRA branch.
+            add(&base_output, &scaled_lora)
         }
     }
 

--- a/crates/aprender-train/src/lora/mod.rs
+++ b/crates/aprender-train/src/lora/mod.rs
@@ -16,6 +16,8 @@ mod qlora;
 mod benchmarks;
 #[cfg(test)]
 mod gradient_tests;
+#[cfg(test)]
+mod train_to_loss_tests;
 
 pub use adapter::{
     load_adapter, load_adapter_peft, merge_and_collect, merge_qlora_and_collect, save_adapter,

--- a/crates/aprender-train/src/lora/train_to_loss_tests.rs
+++ b/crates/aprender-train/src/lora/train_to_loss_tests.rs
@@ -1,0 +1,244 @@
+//! End-to-end LoRA training proof (PMAT-931).
+//!
+//! This is the P3 / Unsloth-pillar capability proof, extending the PMAT-921
+//! end-to-end-training-proof methodology (a real model trained to a decreasing
+//! loss) from a full transformer to the LoRA fine-tuning path.
+//!
+//! The existing LoRA gradient tests (`gradient_tests.rs`) only check the *static*
+//! `requires_grad` flags and *manually-injected* gradients — they never run a
+//! real backward pass through `LoRALayer::forward`. A composition of
+//! individually-correct ops can still SEVER the autograd graph on the
+//! integration path (exactly the PMAT-921/922 graph-severing class), freezing
+//! the adapter while every per-flag test stays green.
+//!
+//! This module trains a tiny LoRA adapter on a frozen base weight for a few
+//! deterministic steps and asserts the LoRA invariant directly:
+//!
+//!   (a) the loss DECREASES substantially, and
+//!   (b) the LoRA adapter params A and B genuinely UPDATE from init AND received
+//!       a finite non-zero gradient, while
+//!   (c) the BASE weight stays EXACTLY FROZEN.
+//!
+//! Falsifier (OBLIG-LORA-ADAPTER-TRAINS-BASE-FROZEN):
+//!   - RED if the adapter does not train (graph severed / frozen adapter), OR
+//!   - RED if the base weight moves (frozen-base violated).
+//!   - GREEN only on correct LoRA training.
+//!
+//! Everything is LCG-seeded / closed-form deterministic for CI stability and
+//! runs as a fast per-PR CPU test (tiny dims, bounded steps).
+
+#[cfg(test)]
+mod tests {
+    use crate::autograd::backward;
+    use crate::autograd::ops::{add, mul, scale, sum};
+    use crate::lora::LoRALayer;
+    use crate::Tensor;
+    use ndarray::Array1;
+
+    /// Tiny deterministic LCG so the test is seeded and CI-stable (no `rand`
+    /// dependence, no clock, fully reproducible).
+    struct Lcg(u64);
+    impl Lcg {
+        fn new(seed: u64) -> Self {
+            Self(seed)
+        }
+        /// Next f32 in roughly [-0.5, 0.5].
+        fn next_f32(&mut self) -> f32 {
+            // Numerical Recipes LCG constants.
+            self.0 = self
+                .0
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1_442_695_040_888_963_407);
+            let bits = (self.0 >> 33) as u32; // top 31 bits
+            (bits as f32 / u32::MAX as f32) - 0.5
+        }
+    }
+
+    /// Squared-error loss `Σ (y - target)^2` built entirely from autograd-aware
+    /// ops so the backward pass flows from the scalar loss all the way back into
+    /// the LoRA adapter. `target` is a constant (no grad).
+    fn squared_error(y: &Tensor, target: &Tensor) -> Tensor {
+        // diff = y + (-1)*target   (target is a no-grad constant)
+        let neg_target = scale(target, -1.0);
+        let diff = add(y, &neg_target);
+        let sq = mul(&diff, &diff);
+        sum(&sq)
+    }
+
+    /// PMAT-931 / OBLIG-LORA-ADAPTER-TRAINS-BASE-FROZEN.
+    ///
+    /// Trains a tiny LoRA adapter on a fixed deterministic regression target and
+    /// asserts the full LoRA invariant: adapter trains (loss decreases, A and B
+    /// move from init with finite non-zero gradients) while the base stays frozen.
+    #[test]
+    fn falsify_lora_adapter_trains_to_decreasing_loss_base_frozen() {
+        // ---- Tiny deterministic problem -----------------------------------
+        let d_out = 4;
+        let d_in = 4;
+        let rank = 2;
+        // alpha == rank → scale = alpha/rank = 1.0. A larger scale amplifies the
+        // effective adapter learning rate (it multiplies both the forward LoRA
+        // branch and its backward gradients), which makes a fixed lr diverge; a
+        // unit scale keeps this tiny CPU test numerically stable.
+        let alpha = 2.0;
+        let steps = 400;
+        let lr = 0.05;
+
+        let mut rng = Lcg::new(0xC0FF_EE13);
+
+        // Frozen base weight W (d_out x d_in). Some structure so base@x != 0.
+        let base_data: Vec<f32> = (0..d_out * d_in).map(|_| rng.next_f32()).collect();
+        let base_snapshot = base_data.clone();
+        let base = Tensor::from_vec(base_data, false);
+
+        let mut lora = LoRALayer::new(base, d_out, d_in, rank, alpha);
+
+        // Initialise B with small non-zero values so the LoRA branch is alive
+        // from step 0 (canonical LoRA inits B=0, which would make the FIRST
+        // gradient-to-A vanish; we want a tiny live signal both directions).
+        let a_init: Vec<f32> = (0..rank * d_in).map(|_| 0.10 * rng.next_f32()).collect();
+        let b_init: Vec<f32> = (0..d_out * rank).map(|_| 0.10 * rng.next_f32()).collect();
+        *lora.lora_a_mut().data_mut() = Array1::from(a_init.clone());
+        *lora.lora_b_mut().data_mut() = Array1::from(b_init.clone());
+
+        // Fixed input and a target the base alone cannot reach, so the adapter
+        // MUST move to reduce the loss.
+        let x = Tensor::from_vec(vec![0.5, -0.3, 0.8, 0.2], false);
+        let target = Tensor::from_vec(vec![1.0, -1.0, 0.5, -0.5], false);
+
+        // ---- Snapshots / accumulators -------------------------------------
+        let initial_loss = {
+            let y = lora.forward(&x);
+            squared_error(&y, &target).data()[0]
+        };
+
+        // Track whether A and B ever received a finite NON-ZERO gradient during
+        // training. If the forward graph is severed, these stay false → RED.
+        let mut a_saw_nonzero_grad = false;
+        let mut b_saw_nonzero_grad = false;
+        let mut last_loss = initial_loss;
+
+        for _ in 0..steps {
+            // Fresh gradients each step.
+            lora.lora_a().zero_grad();
+            lora.lora_b().zero_grad();
+
+            // Forward + scalar loss.
+            let y = lora.forward(&x);
+            let mut loss = squared_error(&y, &target);
+            last_loss = loss.data()[0];
+
+            // Backward from the scalar loss through the whole LoRA graph.
+            backward(&mut loss, None);
+
+            // The adapter MUST have received gradients here. Record finiteness
+            // and non-zero magnitude (the falsifier signal).
+            let ga = lora.lora_a().grad().expect(
+                "OBLIG-LORA-ADAPTER-TRAINS: lora_a received NO gradient — \
+                 LoRA forward severed the autograd graph (frozen adapter)",
+            );
+            let gb = lora.lora_b().grad().expect(
+                "OBLIG-LORA-ADAPTER-TRAINS: lora_b received NO gradient — \
+                 LoRA forward severed the autograd graph (frozen adapter)",
+            );
+            assert!(ga.iter().all(|v| v.is_finite()), "grad_A must be finite");
+            assert!(gb.iter().all(|v| v.is_finite()), "grad_B must be finite");
+            if ga.iter().any(|&v| v.abs() > 1e-9) {
+                a_saw_nonzero_grad = true;
+            }
+            if gb.iter().any(|&v| v.abs() > 1e-9) {
+                b_saw_nonzero_grad = true;
+            }
+
+            // Manual SGD step on the trainable adapter ONLY (A and B). The base
+            // is deliberately never touched — that is the frozen-base invariant.
+            let ga = lora.lora_a().grad().expect("grad_A present");
+            let gb = lora.lora_b().grad().expect("grad_B present");
+            {
+                let a_data = lora.lora_a_mut().data_mut();
+                *a_data = &*a_data - &(&ga * lr);
+            }
+            {
+                let b_data = lora.lora_b_mut().data_mut();
+                *b_data = &*b_data - &(&gb * lr);
+            }
+        }
+
+        let final_loss = last_loss;
+
+        // ---- (a) loss decreased substantially -----------------------------
+        assert!(
+            final_loss < initial_loss * 0.5,
+            "OBLIG-LORA-ADAPTER-TRAINS: loss did not decrease substantially \
+             (initial={initial_loss:.6}, final={final_loss:.6}); the adapter is \
+             not training through LoRALayer::forward"
+        );
+
+        // ---- (b) the adapter genuinely UPDATED + got real gradients -------
+        assert!(
+            a_saw_nonzero_grad,
+            "OBLIG-LORA-ADAPTER-TRAINS: lora_a never received a non-zero gradient \
+             (graph severed / adapter frozen)"
+        );
+        assert!(
+            b_saw_nonzero_grad,
+            "OBLIG-LORA-ADAPTER-TRAINS: lora_b never received a non-zero gradient \
+             (graph severed / adapter frozen)"
+        );
+
+        let a_final = lora.lora_a().data().to_vec();
+        let b_final = lora.lora_b().data().to_vec();
+        let a_moved: f32 = a_final.iter().zip(&a_init).map(|(f, i)| (f - i).abs()).sum();
+        let b_moved: f32 = b_final.iter().zip(&b_init).map(|(f, i)| (f - i).abs()).sum();
+        assert!(
+            a_moved > 1e-4,
+            "OBLIG-LORA-ADAPTER-TRAINS: lora_a did not move from init (Σ|Δ|={a_moved:.2e})"
+        );
+        assert!(
+            b_moved > 1e-4,
+            "OBLIG-LORA-ADAPTER-TRAINS: lora_b did not move from init (Σ|Δ|={b_moved:.2e})"
+        );
+
+        // ---- (c) the BASE weight stayed EXACTLY frozen --------------------
+        let base_final = lora.base_weight().data().to_vec();
+        assert_eq!(base_final.len(), base_snapshot.len(), "base weight length changed");
+        for (i, (got, exp)) in base_final.iter().zip(&base_snapshot).enumerate() {
+            assert!(
+                (got - exp).abs() < 1e-12,
+                "OBLIG-LORA-BASE-FROZEN: base weight[{i}] moved during training \
+                 (got={got}, expected frozen {exp}); LoRA must NEVER update the base"
+            );
+        }
+        // Base must also remain ungraded — it never participates as a trainable.
+        assert!(
+            !lora.base_weight().requires_grad(),
+            "OBLIG-LORA-BASE-FROZEN: base weight must stay requires_grad=false"
+        );
+    }
+
+    /// Single-step structural guard for the same obligation, kept minimal so a
+    /// mutation that re-severs `LoRALayer::forward` is caught fast: one forward,
+    /// one backward, the adapter must receive gradient and the base must not.
+    #[test]
+    fn lora_forward_backward_reaches_adapter_not_base() {
+        let base = Tensor::from_vec(vec![1.0, 0.0, 0.0, 1.0], false);
+        let mut lora = LoRALayer::new(base, 2, 2, 2, 4.0);
+        *lora.lora_a_mut().data_mut() = Array1::from(vec![0.1, 0.2, 0.3, 0.4]);
+        *lora.lora_b_mut().data_mut() = Array1::from(vec![0.5, 0.3, 0.2, 0.7]);
+
+        let x = Tensor::from_vec(vec![1.0, 1.0], false);
+        let y = lora.forward(&x);
+
+        // The forward output MUST keep a live autograd graph.
+        assert!(y.requires_grad(), "LoRA forward output severed requires_grad");
+        assert!(y.backward_op().is_some(), "LoRA forward output has no backward op");
+
+        let mut loss = sum(&y);
+        backward(&mut loss, None);
+
+        assert!(lora.lora_a().grad().is_some(), "adapter A got no gradient");
+        assert!(lora.lora_b().grad().is_some(), "adapter B got no gradient");
+        // Base is frozen: it never accumulates a gradient.
+        assert!(lora.base_weight().grad().is_none(), "frozen base must not accumulate gradient");
+    }
+}


### PR DESCRIPTION
## P3 / Unsloth-pillar end-to-end LoRA training proof (PMAT-931)

Extends the **PMAT-921 end-to-end-training-proof** methodology (a real model trained to a DECREASING loss with the right params updating) from a full transformer to the **LoRA fine-tuning path** — advancing the weakest pillar (P3, Unsloth/fine-tuning).

A tiny frozen base weight wrapped in a `LoRALayer` (low-rank A/B) trains a fixed deterministic regression task and the test asserts the **LoRA invariant** directly:

- **(a)** the squared-error loss DECREASES substantially (`final < 0.5 * initial`; observed `final ~= 0` as the rank-r branch reaches the target)
- **(b)** the adapter params A and B genuinely UPDATE from init AND receive a finite non-zero gradient on a **real backward pass**, while
- **(c)** the BASE weight stays **EXACTLY frozen** (elementwise unchanged, `requires_grad` stays `false`)

Everything is LCG-seeded for CI determinism; tiny dims + bounded steps make it a fast per-PR CPU test, not a slow bench.

## REAL BUG FOUND (the proof did its job)

`LoRALayer::forward` rebuilt its output via `Tensor::new(scaled_lora_data, false)` for the scaled LoRA branch and `Tensor::new(result_data, ..)` for the base+LoRA sum, which **SEVERS the autograd graph** (the same `Tensor::new`/`Tensor::from_vec` sever class as the PMAT-921/922 sweep). The forward output dropped `requires_grad` and had no backward op, so **NO gradient ever reached `lora_a`/`lora_b`** — the adapter was silently **FROZEN** and LoRA fine-tuning could not train at all, while every pre-existing static `requires_grad` / manual-gradient test stayed green (they never run a real backward through `forward`).

**Fix:** route the scaled LoRA branch through the autograd-aware `scale` op and the base+LoRA sum through the autograd-aware `add` op. Forward numerics are identical; only the backward edge is restored. All **202 LoRA lib tests still pass**.

## Falsifier (mutation-verified)

Reverting `forward` to the graph-severing `Tensor::new` path makes the forward output report `requires_grad=false` / no backward op, `lora_a` and `lora_b` receive **NO** gradient, and the loss does not decrease — **both falsifier tests go RED** with the exact obligation messages; **GREEN** on the fix.

- `falsify_lora_adapter_trains_to_decreasing_loss_base_frozen` — full train-to-loss + frozen-base invariant
- `lora_forward_backward_reaches_adapter_not_base` — minimal structural re-sever guard

## Contract

`contracts/lora-adapter-trains-base-frozen-v1.yaml` — **OBLIG-LORA-ADAPTER-TRAINS-BASE-FROZEN** (`pv validate` + `pv lint contracts/` PASS, single-line falsifier refs).

## Gates

- `cargo test -p aprender-train --lib lora::` → 202 passed, 0 failed
- `cargo clippy -p aprender-train --all-targets -- -D warnings` → clean (PMAT-922 lesson)
- `cargo fmt -p aprender-train -- --check` → clean
- `cargo test -p aprender-contracts --lib lint::` → 191 passed
- `pv validate` + `pv lint contracts/` → PASS (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)