### PR TITLE
test(apr-cli): PMAT-125 B4 — CPU unit tests for data/model-ops + observability subcommands

### DIFF
--- a/crates/apr-cli/src/commands/experiment.rs
+++ b/crates/apr-cli/src/commands/experiment.rs
@@ -505,3 +505,141 @@ fn truncate(s: &str, max: usize) -> &str {
         &s[..max]
     }
 }
+
+// =============================================================================
+// PMAT-125 B4: pure-helper coverage
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use entrenar::storage::ParameterValue;
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_truncate_shorter_unchanged() {
+        assert_eq!(truncate("hi", 10), "hi");
+        assert_eq!(truncate("exact", 5), "exact");
+    }
+
+    #[test]
+    fn test_truncate_longer_clipped() {
+        assert_eq!(truncate("hello world", 5), "hello");
+        assert_eq!(truncate("abcdef", 0), "");
+    }
+
+    #[test]
+    fn test_param_to_json_scalars() {
+        assert_eq!(
+            param_to_json(&ParameterValue::String("adam".into())),
+            serde_json::json!("adam")
+        );
+        assert_eq!(param_to_json(&ParameterValue::Int(7)), serde_json::json!(7));
+        assert_eq!(
+            param_to_json(&ParameterValue::Float(0.5)),
+            serde_json::json!(0.5)
+        );
+        assert_eq!(
+            param_to_json(&ParameterValue::Bool(true)),
+            serde_json::json!(true)
+        );
+    }
+
+    #[test]
+    fn test_param_to_json_nested() {
+        let list = ParameterValue::List(vec![
+            ParameterValue::Int(1),
+            ParameterValue::String("x".into()),
+        ]);
+        assert_eq!(param_to_json(&list), serde_json::json!([1, "x"]));
+
+        let mut d = HashMap::new();
+        d.insert("lr".to_string(), ParameterValue::Float(0.01));
+        let dict = ParameterValue::Dict(d);
+        assert_eq!(param_to_json(&dict), serde_json::json!({"lr": 0.01}));
+    }
+
+    #[test]
+    fn test_param_map_json_unwraps_all_keys() {
+        let mut params = HashMap::new();
+        params.insert("opt".to_string(), ParameterValue::String("adam".into()));
+        params.insert("epochs".to_string(), ParameterValue::Int(3));
+        let json = param_map_json(&params);
+        assert_eq!(json["opt"], serde_json::json!("adam"));
+        assert_eq!(json["epochs"], serde_json::json!(3));
+    }
+
+    #[test]
+    fn test_param_map_json_empty() {
+        let params = HashMap::new();
+        let json = param_map_json(&params);
+        assert_eq!(json, serde_json::json!({}));
+    }
+
+    #[test]
+    fn test_render_braille_empty_inputs() {
+        assert!(render_braille(&[], 10, 4).is_empty());
+        assert!(render_braille(&[1.0, 2.0], 0, 4).is_empty());
+        assert!(render_braille(&[1.0, 2.0], 10, 0).is_empty());
+    }
+
+    #[test]
+    fn test_render_braille_dimensions() {
+        let data: Vec<f64> = (0..40).map(|i| (i as f64).sin()).collect();
+        let rows = render_braille(&data, 16, 4);
+        assert_eq!(rows.len(), 4);
+        for row in &rows {
+            assert_eq!(row.chars().count(), 16);
+            assert!(row.chars().all(|c| (0x2800..=0x28FF).contains(&(c as u32))));
+        }
+    }
+
+    #[test]
+    fn test_build_braille_grid_shape() {
+        let data: Vec<f64> = vec![0.0, 1.0, 2.0, 3.0];
+        let grid = build_braille_grid(&data, 8, 4);
+        assert_eq!(grid.len(), 16);
+        assert!(grid.iter().all(|r| r.len() == 16));
+        assert!(grid.iter().any(|r| r.iter().any(|&b| b)));
+    }
+
+    #[test]
+    fn test_build_braille_grid_empty() {
+        assert!(build_braille_grid(&[], 8, 4).is_empty());
+        assert!(build_braille_grid(&[1.0], 0, 4).is_empty());
+    }
+
+    #[test]
+    fn test_build_braille_grid_constant_data_no_div_by_zero() {
+        let data = vec![5.0; 10];
+        let grid = build_braille_grid(&data, 8, 4);
+        assert_eq!(grid.len(), 16);
+    }
+
+    #[test]
+    fn test_encode_braille_cell_all_unset_is_base() {
+        let grid = vec![vec![false; 4]; 8];
+        let ch = encode_braille_cell(&grid, 0, 0, 4, 8);
+        assert_eq!(ch, '\u{2800}');
+    }
+
+    #[test]
+    fn test_encode_braille_cell_top_left_dot() {
+        let mut grid = vec![vec![false; 4]; 8];
+        grid[0][0] = true; // dot 1 → +0x01
+        let ch = encode_braille_cell(&grid, 0, 0, 4, 8);
+        assert_eq!(ch as u32, 0x2800 + 0x01);
+    }
+
+    #[test]
+    fn test_encode_braille_cell_full_cell() {
+        let mut grid = vec![vec![false; 2]; 4];
+        for row in grid.iter_mut() {
+            for cell in row.iter_mut() {
+                *cell = true;
+            }
+        }
+        let ch = encode_braille_cell(&grid, 0, 0, 2, 4);
+        assert_eq!(ch as u32, 0x28FF);
+    }
+}

--- a/crates/apr-cli/src/commands/golden_output.rs
+++ b/crates/apr-cli/src/commands/golden_output.rs
@@ -484,5 +484,44 @@ fn throughput_apr(
     ))
 }
 
+// =============================================================================
+// PMAT-125 B4: golden_test_cases fixture coverage
+// =============================================================================
+
+#[cfg(test)]
+mod golden_output_tests {
+    use super::*;
+
+    #[test]
+    fn test_golden_test_cases_nonempty_and_structured() {
+        let cases = golden_test_cases();
+        assert!(!cases.is_empty());
+        for (prompt, patterns) in &cases {
+            assert!(prompt.contains("<|im_start|>assistant"));
+            assert!(prompt.contains("<|im_start|>user"));
+            assert!(!patterns.is_empty());
+        }
+    }
+
+    #[test]
+    fn test_golden_test_cases_arithmetic_case_present() {
+        let cases = golden_test_cases();
+        let arith = cases
+            .iter()
+            .find(|(p, _)| p.contains("2+2"))
+            .expect("arithmetic golden case must exist");
+        assert!(arith.1.contains(&"4"));
+    }
+
+    #[test]
+    fn test_golden_test_cases_deterministic() {
+        let a = golden_test_cases();
+        let b = golden_test_cases();
+        assert_eq!(a.len(), b.len());
+        for ((pa, _), (pb, _)) in a.iter().zip(b.iter()) {
+            assert_eq!(pa, pb);
+        }
+    }
+}
 
 include!("throughput.rs");

--- a/crates/apr-cli/src/commands/profile_09.rs
+++ b/crates/apr-cli/src/commands/profile_09.rs
@@ -11,4 +11,5 @@ include!("profile_filter_results.rs");
 include!("profile_profile.rs");
 include!("profile_print_flamegraph.rs");
 include!("profile_filter_mlp.rs");
+include!("profile_pct_change_classify_tests.rs");
 }

--- a/crates/apr-cli/src/commands/profile_pct_change_classify_tests.rs
+++ b/crates/apr-cli/src/commands/profile_pct_change_classify_tests.rs
@@ -1,0 +1,109 @@
+
+    // ========================================================================
+    // PMAT-125 B4: pct_change / classify_metric pure-logic tests
+    // ========================================================================
+
+    #[test]
+    fn test_pct_change_positive_increase() {
+        assert!((pct_change(100.0, 150.0) - 50.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_pct_change_decrease() {
+        assert!((pct_change(200.0, 150.0) - (-25.0)).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_pct_change_zero_baseline_returns_zero() {
+        assert_eq!(pct_change(0.0, 123.0), 0.0);
+        assert_eq!(pct_change(-1.0, 5.0), 0.0);
+    }
+
+    #[test]
+    fn test_pct_change_no_change() {
+        assert_eq!(pct_change(42.0, 42.0), 0.0);
+    }
+
+    #[test]
+    fn test_classify_metric_latency_regression() {
+        let mut regs = Vec::new();
+        let mut imps = Vec::new();
+        classify_metric(
+            "p99", 20.0, 5.0, 10.0, 12.0, "ms", false, &mut regs, &mut imps,
+        );
+        assert_eq!(regs.len(), 1);
+        assert!(imps.is_empty());
+        assert!(regs[0].contains("p99"));
+        assert!(regs[0].contains("slower"));
+        assert!(regs[0].contains("ms"));
+    }
+
+    #[test]
+    fn test_classify_metric_latency_improvement() {
+        let mut regs = Vec::new();
+        let mut imps = Vec::new();
+        classify_metric(
+            "p50", -30.0, 5.0, 10.0, 7.0, "ms", false, &mut regs, &mut imps,
+        );
+        assert!(regs.is_empty());
+        assert_eq!(imps.len(), 1);
+        assert!(imps[0].contains("faster"));
+    }
+
+    #[test]
+    fn test_classify_metric_throughput_regression() {
+        let mut regs = Vec::new();
+        let mut imps = Vec::new();
+        classify_metric(
+            "tok/s", -15.0, 5.0, 100.0, 85.0, "tok/s", true, &mut regs, &mut imps,
+        );
+        assert_eq!(regs.len(), 1);
+        assert!(imps.is_empty());
+        assert!(regs[0].contains("slower"));
+    }
+
+    #[test]
+    fn test_classify_metric_throughput_improvement() {
+        let mut regs = Vec::new();
+        let mut imps = Vec::new();
+        classify_metric(
+            "tok/s", 25.0, 5.0, 100.0, 125.0, "tok/s", true, &mut regs, &mut imps,
+        );
+        assert!(regs.is_empty());
+        assert_eq!(imps.len(), 1);
+        assert!(imps[0].contains("faster"));
+    }
+
+    #[test]
+    fn test_classify_metric_within_threshold_is_neutral() {
+        let mut regs = Vec::new();
+        let mut imps = Vec::new();
+        classify_metric(
+            "p99", 2.0, 5.0, 10.0, 10.2, "ms", false, &mut regs, &mut imps,
+        );
+        assert!(regs.is_empty());
+        assert!(imps.is_empty());
+    }
+
+    #[test]
+    fn test_classify_metric_exactly_at_threshold_is_neutral() {
+        let mut regs = Vec::new();
+        let mut imps = Vec::new();
+        classify_metric(
+            "p99", 5.0, 5.0, 10.0, 10.5, "ms", false, &mut regs, &mut imps,
+        );
+        assert!(regs.is_empty());
+        assert!(imps.is_empty());
+    }
+
+    #[test]
+    fn test_classify_metric_appends_preserving_existing() {
+        let mut regs = vec!["existing-reg".to_string()];
+        let mut imps = vec!["existing-imp".to_string()];
+        classify_metric(
+            "p99", 30.0, 5.0, 10.0, 13.0, "ms", false, &mut regs, &mut imps,
+        );
+        assert_eq!(regs.len(), 2);
+        assert_eq!(regs[0], "existing-reg");
+        assert_eq!(imps.len(), 1);
+    }

--- a/crates/apr-cli/src/commands/runs.rs
+++ b/crates/apr-cli/src/commands/runs.rs
@@ -1122,4 +1122,192 @@ mod runs_tests {
         let result = braille_chart(&[1.0], 10, 3);
         assert!(!result.is_empty());
     }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // PMAT-125 B4: additional coverage for braille / metric / param helpers
+    // ═══════════════════════════════════════════════════════════════════
+
+    #[test]
+    fn test_sparkline_truncates_to_width() {
+        let data: Vec<f64> = (0..100).map(|i| i as f64).collect();
+        let result = sparkline(&data, 12);
+        assert_eq!(result.chars().count(), 12);
+    }
+
+    #[test]
+    fn test_sparkline_descending_endpoints() {
+        let data: Vec<f64> = (0..8).rev().map(|i| i as f64).collect();
+        let result = sparkline(&data, 8);
+        let chars: Vec<char> = result.chars().collect();
+        assert!(chars[0] >= chars[7]);
+    }
+
+    #[test]
+    fn test_sample_braille_data_fewer_points_than_dots() {
+        let data = vec![0.0, 1.0, 2.0];
+        let samples = sample_braille_data(&data, 8, 8, 0.0, 2.0);
+        assert_eq!(samples.len(), 8);
+        assert!(samples.iter().all(|&y| y < 8));
+        assert_eq!(samples[2], 0); // value 2.0 normalized=1.0 → top row
+        assert_eq!(samples[0], 7); // value 0.0 normalized=0.0 → bottom row
+    }
+
+    #[test]
+    fn test_sample_braille_data_more_points_than_dots() {
+        let data: Vec<f64> = (0..50).map(|i| i as f64).collect();
+        let samples = sample_braille_data(&data, 10, 8, 0.0, 49.0);
+        assert_eq!(samples.len(), 10);
+        assert!(samples.iter().all(|&y| y < 8));
+    }
+
+    #[test]
+    fn test_render_braille_row_produces_braille_chars() {
+        let samples = vec![0usize, 1, 2, 3, 4, 5, 6, 7];
+        let dot_bits: [[u8; 4]; 2] = [[0, 1, 2, 6], [3, 4, 5, 7]];
+        let row = render_braille_row(&samples, 0, 4, &dot_bits);
+        assert_eq!(row.chars().count(), 4);
+        assert!(row.chars().all(|c| (0x2800..=0x28FF).contains(&(c as u32))));
+    }
+
+    #[test]
+    fn test_render_braille_row_blank_when_no_dots_in_range() {
+        let samples = vec![7usize; 8];
+        let dot_bits: [[u8; 4]; 2] = [[0, 1, 2, 6], [3, 4, 5, 7]];
+        let row = render_braille_row(&samples, 0, 4, &dot_bits);
+        assert!(row.chars().all(|c| c == '\u{2800}'));
+    }
+
+    #[test]
+    fn test_braille_chart_multiline_structure() {
+        let data: Vec<f64> = (0..20).map(|i| (i as f64).sin()).collect();
+        let chart = braille_chart(&data, 16, 4);
+        let lines: Vec<&str> = chart.lines().collect();
+        assert_eq!(lines.len(), 4 + 2);
+        assert!(lines[0].contains('│'));
+        assert!(lines[4].contains('└'));
+        assert!(lines[5].contains("20"));
+    }
+
+    #[test]
+    fn test_metric_values_extracts_values_in_order() {
+        use entrenar::storage::MetricPoint;
+        let points = vec![
+            MetricPoint::new(0, 1.5),
+            MetricPoint::new(1, 0.9),
+            MetricPoint::new(2, 0.4),
+        ];
+        assert_eq!(metric_values(&points), vec![1.5, 0.9, 0.4]);
+    }
+
+    #[test]
+    fn test_metric_values_empty() {
+        assert!(metric_values(&[]).is_empty());
+    }
+
+    #[test]
+    fn test_min_val_negative_and_mixed() {
+        assert_eq!(min_val(&[2.0, -5.0, 0.0, 3.0]), Some(-5.0));
+        assert_eq!(min_val(&[42.0]), Some(42.0));
+    }
+
+    #[test]
+    fn test_format_duration_long_boundaries() {
+        assert_eq!(format_duration_long(60), "60s");
+        assert_eq!(format_duration_long(3600), "60m 0s");
+        assert_eq!(format_duration_long(86400), "24h 0m 0s");
+        assert_eq!(format_duration_long(0), "0s");
+    }
+
+    #[test]
+    fn test_param_display_scalar_variants() {
+        use entrenar::storage::ParameterValue;
+        assert_eq!(
+            param_display(&ParameterValue::String("adam".into())),
+            "adam"
+        );
+        assert_eq!(param_display(&ParameterValue::Int(42)), "42");
+        assert_eq!(param_display(&ParameterValue::Bool(true)), "true");
+        assert_eq!(param_display(&ParameterValue::Float(0.001)), "0.001");
+    }
+
+    #[test]
+    fn test_param_display_list_falls_back_to_json() {
+        use entrenar::storage::ParameterValue;
+        let pv = ParameterValue::List(vec![ParameterValue::Int(1), ParameterValue::Int(2)]);
+        let s = param_display(&pv);
+        assert!(s.contains("Int") || s.contains('1'));
+    }
+
+    #[test]
+    fn test_param_to_value_scalars() {
+        use entrenar::storage::ParameterValue;
+        assert_eq!(
+            param_to_value(&ParameterValue::String("x".into())),
+            serde_json::json!("x")
+        );
+        assert_eq!(
+            param_to_value(&ParameterValue::Int(7)),
+            serde_json::json!(7)
+        );
+        assert_eq!(
+            param_to_value(&ParameterValue::Bool(false)),
+            serde_json::json!(false)
+        );
+        assert_eq!(
+            param_to_value(&ParameterValue::Float(2.5)),
+            serde_json::json!(2.5)
+        );
+    }
+
+    #[test]
+    fn test_param_to_value_nested_list_and_dict() {
+        use entrenar::storage::ParameterValue;
+        use std::collections::HashMap;
+        let list = ParameterValue::List(vec![ParameterValue::Int(1), ParameterValue::Bool(true)]);
+        assert_eq!(param_to_value(&list), serde_json::json!([1, true]));
+
+        let mut d = HashMap::new();
+        d.insert("lr".to_string(), ParameterValue::Float(0.01));
+        let dict = ParameterValue::Dict(d);
+        assert_eq!(param_to_value(&dict), serde_json::json!({"lr": 0.01}));
+    }
+
+    #[test]
+    fn test_config_diff_detects_differences_and_skips_equal() {
+        use entrenar::storage::ParameterValue;
+        use std::collections::HashMap;
+        let mut a = HashMap::new();
+        a.insert("lr".to_string(), ParameterValue::Float(0.01));
+        a.insert("opt".to_string(), ParameterValue::String("adam".into()));
+        a.insert("only_a".to_string(), ParameterValue::Int(1));
+
+        let mut b = HashMap::new();
+        b.insert("lr".to_string(), ParameterValue::Float(0.02));
+        b.insert("opt".to_string(), ParameterValue::String("adam".into()));
+        b.insert("only_b".to_string(), ParameterValue::Int(2));
+
+        let diffs = config_diff(&a, &b);
+        let keys: Vec<&str> = diffs.iter().map(|(k, _, _)| k.as_str()).collect();
+        assert!(!keys.contains(&"opt"));
+        assert!(keys.contains(&"lr"));
+        assert!(keys.contains(&"only_a"));
+        assert!(keys.contains(&"only_b"));
+        let mut sorted = keys.clone();
+        sorted.sort_unstable();
+        assert_eq!(keys, sorted);
+        let only_a = diffs.iter().find(|(k, _, _)| k == "only_a").unwrap();
+        assert_eq!(only_a.2, "—");
+        let only_b = diffs.iter().find(|(k, _, _)| k == "only_b").unwrap();
+        assert_eq!(only_b.1, "—");
+    }
+
+    #[test]
+    fn test_config_diff_identical_maps_empty() {
+        use entrenar::storage::ParameterValue;
+        use std::collections::HashMap;
+        let mut a = HashMap::new();
+        a.insert("x".to_string(), ParameterValue::Int(1));
+        let b = a.clone();
+        assert!(config_diff(&a, &b).is_empty());
+    }
 }

--- a/crates/apr-cli/src/commands/tokenize.rs
+++ b/crates/apr-cli/src/commands/tokenize.rs
@@ -3273,4 +3273,195 @@ mod tests {
             other => panic!("unexpected error variant: {other:?}"),
         }
     }
+
+    // ════════════════════════════════════════════════════════════════════
+    // PMAT-125 B4: pure validator / formatter coverage
+    // ════════════════════════════════════════════════════════════════════
+
+    #[test]
+    fn test_validate_algorithm_supported() {
+        assert!(validate_algorithm("bpe").is_ok());
+        assert!(validate_algorithm("wordpiece").is_ok());
+        assert!(validate_algorithm("unigram").is_ok());
+    }
+
+    #[test]
+    fn test_validate_algorithm_rejects_unknown() {
+        let err = validate_algorithm("sentencepiece").unwrap_err();
+        match err {
+            CliError::ValidationFailed(msg) => {
+                assert!(msg.contains("sentencepiece"));
+                assert!(msg.contains("bpe"));
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+        assert!(validate_algorithm("").is_err());
+        assert!(validate_algorithm("BPE").is_err()); // case-sensitive
+    }
+
+    #[test]
+    fn test_validate_vocab_size_bounds() {
+        assert!(validate_vocab_size(10).is_ok());
+        assert!(validate_vocab_size(32_000).is_ok());
+        assert!(validate_vocab_size(1_000_000).is_ok());
+    }
+
+    #[test]
+    fn test_validate_vocab_size_too_small() {
+        let err = validate_vocab_size(9).unwrap_err();
+        match err {
+            CliError::ValidationFailed(msg) => assert!(msg.contains("at least 10")),
+            other => panic!("unexpected: {other:?}"),
+        }
+        assert!(validate_vocab_size(0).is_err());
+    }
+
+    #[test]
+    fn test_validate_vocab_size_too_large() {
+        let err = validate_vocab_size(1_000_001).unwrap_err();
+        match err {
+            CliError::ValidationFailed(msg) => assert!(msg.contains("unreasonably large")),
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_validate_normalization_ok_and_err() {
+        assert!(validate_normalization("none").is_ok());
+        assert!(validate_normalization("nfc").is_ok());
+        let err = validate_normalization("nfkc").unwrap_err();
+        match err {
+            CliError::ValidationFailed(msg) => {
+                assert!(msg.contains("nfkc"));
+                assert!(msg.contains("none, nfc"));
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_estimate_training_time_scales_with_vocab() {
+        let one_mb = 1024 * 1024;
+        let base = estimate_training_time(one_mb, 16_000);
+        assert!((base - (1.0 / 60.0)).abs() < 1e-6);
+        let big = estimate_training_time(one_mb, 64_000);
+        assert!((big - base * 2.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_estimate_training_time_zero_bytes() {
+        assert_eq!(estimate_training_time(0, 32_000), 0.0);
+    }
+
+    #[test]
+    fn test_plan_verdict_blocked_empty() {
+        let stats = CorpusStats {
+            lines: 0,
+            bytes: 0,
+            unique_chars: 0,
+        };
+        assert_eq!(plan_verdict(&stats, 32_000), "blocked");
+    }
+
+    #[test]
+    fn test_plan_verdict_warning_vocab_too_large_for_chars() {
+        let stats = CorpusStats {
+            lines: 5,
+            bytes: 100,
+            unique_chars: 10,
+        };
+        assert_eq!(plan_verdict(&stats, 5_000), "warning"); // 5000 > 1000
+    }
+
+    #[test]
+    fn test_plan_verdict_ready() {
+        let stats = CorpusStats {
+            lines: 100,
+            bytes: 10_000,
+            unique_chars: 80,
+        };
+        assert_eq!(plan_verdict(&stats, 5_000), "ready"); // 5000 <= 8000
+    }
+
+    #[test]
+    fn test_format_number_thresholds() {
+        assert_eq!(format_number(999), "999");
+        assert_eq!(format_number(1_000), "1.0K");
+        assert_eq!(format_number(1_500), "1.5K");
+        assert_eq!(format_number(999_999), "1000.0K");
+        assert_eq!(format_number(1_000_000), "1.0M");
+        assert_eq!(format_number(2_500_000), "2.5M");
+        assert_eq!(format_number(0), "0");
+    }
+
+    #[test]
+    fn test_format_bytes_tokenize_units() {
+        assert_eq!(format_bytes(0), "0 B");
+        assert_eq!(format_bytes(512), "512 B");
+        assert_eq!(format_bytes(1024), "1.0 KB");
+        assert_eq!(format_bytes(1_048_576), "1.0 MB");
+        assert_eq!(format_bytes(1_073_741_824), "1.0 GB");
+        assert_eq!(format_bytes(5 * 1_073_741_824), "5.0 GB");
+    }
+
+    #[test]
+    fn test_format_duration_buckets() {
+        assert_eq!(format_duration(0.5), "30 sec");
+        assert_eq!(format_duration(1.0), "1.0 min");
+        assert_eq!(format_duration(45.0), "45.0 min");
+        assert_eq!(format_duration(90.0), "1.5 hours");
+        assert_eq!(format_duration(120.0), "2.0 hours");
+    }
+
+    #[test]
+    fn test_resolve_num_workers_explicit() {
+        assert_eq!(resolve_num_workers(Some(4)).unwrap(), 4);
+        assert_eq!(resolve_num_workers(Some(1)).unwrap(), 1);
+    }
+
+    #[test]
+    fn test_resolve_num_workers_zero_is_error() {
+        let err = resolve_num_workers(Some(0)).unwrap_err();
+        match err {
+            CliError::ValidationFailed(msg) => assert!(msg.contains(">= 1")),
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_resolve_num_workers_none_uses_parallelism() {
+        let n = resolve_num_workers(None).unwrap();
+        assert!(n >= 1);
+    }
+
+    #[test]
+    fn test_is_jsonl_extension() {
+        assert!(is_jsonl(Path::new("corpus.jsonl")));
+        assert!(is_jsonl(Path::new("/a/b/data.jsonl")));
+        assert!(!is_jsonl(Path::new("corpus.json")));
+        assert!(!is_jsonl(Path::new("corpus.parquet")));
+        assert!(!is_jsonl(Path::new("corpus")));
+        assert!(!is_jsonl(Path::new("corpus.JSONL"))); // case-sensitive
+    }
+
+    #[test]
+    fn test_format_eta_iso8601_utc_shape_and_determinism() {
+        let s = format_eta_iso8601_utc(0);
+        assert_eq!(s.len(), 20); // YYYY-MM-DDTHH:MM:SSZ
+        assert!(s.ends_with('Z'));
+        assert_eq!(&s[4..5], "-");
+        assert_eq!(&s[7..8], "-");
+        assert_eq!(&s[10..11], "T");
+        assert_eq!(&s[13..14], ":");
+        let later = format_eta_iso8601_utc(3600);
+        assert!(later >= s);
+    }
+
+    #[test]
+    fn test_format_eta_iso8601_utc_known_epoch_offset() {
+        let a = format_eta_iso8601_utc(0);
+        let b = format_eta_iso8601_utc(86_400);
+        assert_ne!(&a[0..10], &b[0..10]); // date advances by a day
+        assert_eq!(&a[11..19], &b[11..19]); // same HH:MM:SS
+    }
 }

--- a/crates/apr-cli/src/commands/tui.rs
+++ b/crates/apr-cli/src/commands/tui.rs
@@ -958,4 +958,143 @@ mod tests {
         app.select_prev();
         assert_eq!(app.selected, 0);
     }
+
+    // ── PMAT-125 B4: additional coverage ──────────────────────────────────
+
+    #[test]
+    fn test_tab_all_titles_distinct() {
+        let titles: Vec<&str> = Tab::ALL.iter().map(|t| t.title()).collect();
+        assert_eq!(titles, [" Overview ", " Tensors ", " Stats ", " Help "]);
+    }
+
+    #[test]
+    fn test_tab_from_index_wraps_modulo_four() {
+        // from_index uses i % 4, so out-of-range indices wrap.
+        assert_eq!(Tab::from_index(4), Tab::Overview);
+        assert_eq!(Tab::from_index(5), Tab::Tensors);
+        assert_eq!(Tab::from_index(6), Tab::Stats);
+        assert_eq!(Tab::from_index(7), Tab::Help);
+    }
+
+    #[test]
+    fn test_truncate_name_tiny_max_len() {
+        // max_len < 4 → raw char-take, no ellipsis.
+        assert_eq!(truncate_name("abcdef", 3), "abc");
+        assert_eq!(truncate_name("abcdef", 1), "a");
+        assert_eq!(truncate_name("abcdef", 0), "");
+    }
+
+    #[test]
+    fn test_truncate_name_exact_boundary() {
+        // name.len() == max_len → unchanged.
+        assert_eq!(truncate_name("exactly10!", 10), "exactly10!");
+    }
+
+    #[test]
+    fn test_truncate_name_multibyte_char_boundary() {
+        // Multi-byte chars must not be split mid-codepoint.
+        let name = "αβγδεζηθικλμν"; // each Greek letter is 2 bytes
+        let out = truncate_name(name, 8);
+        assert!(out.ends_with("..."));
+        // Result must be valid UTF-8 (no panic on slicing).
+        assert!(out.chars().count() > 0);
+    }
+
+    #[test]
+    fn test_build_sparkline_zero_width() {
+        let stats = sample_stats();
+        assert_eq!(build_sparkline(&stats, 0), "");
+    }
+
+    #[test]
+    fn test_build_sparkline_is_bell_shaped() {
+        let stats = sample_stats();
+        let spark = build_sparkline(&stats, 21);
+        let chars: Vec<char> = spark.chars().collect();
+        assert_eq!(chars.len(), 21);
+        // Gaussian peaks in the middle: center char should be the tallest block.
+        let center = chars[10];
+        assert_eq!(center, '█');
+        // Edges are the shortest.
+        assert!(chars[0] < center);
+        assert!(chars[20] < center);
+    }
+
+    #[test]
+    fn test_text_style_sets_color_default_weight() {
+        let c = Color {
+            r: 0.5,
+            g: 0.6,
+            b: 0.7,
+            a: 1.0,
+        };
+        let s = text_style(c);
+        assert_eq!(s.color.r, 0.5);
+        assert_eq!(s.weight, presentar_core::FontWeight::Normal);
+    }
+
+    #[test]
+    fn test_bold_style_sets_bold_weight() {
+        let c = Color {
+            r: 1.0,
+            g: 1.0,
+            b: 1.0,
+            a: 1.0,
+        };
+        let s = bold_style(c);
+        assert_eq!(s.color.r, 1.0);
+        assert_eq!(s.weight, presentar_core::FontWeight::Bold);
+    }
+
+    #[test]
+    fn test_selected_tensor_none_when_empty() {
+        let app = App::new(None);
+        assert!(app.selected_tensor().is_none());
+    }
+
+    #[test]
+    fn test_handle_key_home_end_and_help() {
+        let mut app = App::new(None);
+        // Help via '?' and '4'.
+        assert!(!app.handle_key(KeyCode::Char('?')));
+        assert_eq!(app.current_tab, Tab::Help);
+        assert!(!app.handle_key(KeyCode::Char('1')));
+        assert_eq!(app.current_tab, Tab::Overview);
+        // Home/End on an empty tensor list keep selection sane.
+        assert!(!app.handle_key(KeyCode::Home));
+        assert_eq!(app.selected, 0);
+        assert!(!app.handle_key(KeyCode::End));
+        assert_eq!(app.selected, 0); // saturating_sub on empty list
+    }
+
+    #[test]
+    fn test_handle_key_unmapped_is_noop() {
+        let mut app = App::new(None);
+        let before = app.current_tab;
+        assert!(!app.handle_key(KeyCode::Char('z')));
+        assert_eq!(app.current_tab, before);
+    }
+
+    #[test]
+    fn test_handle_key_tab_and_backtab() {
+        let mut app = App::new(None);
+        assert!(!app.handle_key(KeyCode::Tab));
+        assert_eq!(app.current_tab, Tab::Tensors);
+        assert!(!app.handle_key(KeyCode::BackTab));
+        assert_eq!(app.current_tab, Tab::Overview);
+    }
+
+    fn sample_stats() -> TensorStats {
+        TensorStats {
+            name: "w".to_string(),
+            count: 100,
+            min: -1.0,
+            max: 1.0,
+            mean: 0.0,
+            std: 0.5,
+            zero_count: 0,
+            nan_count: 0,
+            inf_count: 0,
+        }
+    }
 }

--- a/crates/apr-cli/src/commands/vector_stats.rs
+++ b/crates/apr-cli/src/commands/vector_stats.rs
@@ -463,3 +463,72 @@ fn format_std_colored(std_dev: f32) -> colored::ColoredString {
         formatted.green()
     }
 }
+
+// =============================================================================
+// PMAT-125 B4: compute_vector_stats / format_std_colored coverage
+// =============================================================================
+
+#[cfg(test)]
+mod vector_stats_tests {
+    use super::*;
+
+    #[test]
+    fn test_compute_vector_stats_basic() {
+        let stats = compute_vector_stats(&[1.0, 2.0, 3.0, 4.0]);
+        assert!((stats.mean - 2.5).abs() < 1e-5);
+        assert!((stats.min - 1.0).abs() < 1e-5);
+        assert!((stats.max - 4.0).abs() < 1e-5);
+        assert!((stats.l2_norm - 30.0_f32.sqrt()).abs() < 1e-3);
+        assert_eq!(stats.nan_count, 0);
+        assert_eq!(stats.inf_count, 0);
+    }
+
+    #[test]
+    fn test_compute_vector_stats_empty() {
+        let stats = compute_vector_stats(&[]);
+        assert_eq!(stats.mean, 0.0);
+        assert_eq!(stats.min, 0.0);
+        assert_eq!(stats.max, 0.0);
+        assert_eq!(stats.l2_norm, 0.0);
+        assert_eq!(stats.nan_count, 0);
+        assert_eq!(stats.inf_count, 0);
+    }
+
+    #[test]
+    fn test_compute_vector_stats_counts_nan_and_inf() {
+        let data = [1.0, f32::NAN, 2.0, f32::INFINITY, f32::NEG_INFINITY, 3.0];
+        let stats = compute_vector_stats(&data);
+        assert_eq!(stats.nan_count, 1);
+        assert_eq!(stats.inf_count, 2);
+        assert!((stats.mean - 2.0).abs() < 1e-5);
+        assert!((stats.min - 1.0).abs() < 1e-5);
+        assert!((stats.max - 3.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_compute_vector_stats_all_nan_no_valid() {
+        let data = [f32::NAN, f32::NAN];
+        let stats = compute_vector_stats(&data);
+        assert_eq!(stats.nan_count, 2);
+        assert_eq!(stats.mean, 0.0);
+        assert_eq!(stats.min, 0.0);
+        assert_eq!(stats.max, 0.0);
+    }
+
+    #[test]
+    fn test_compute_vector_stats_negative_values() {
+        let stats = compute_vector_stats(&[-5.0, -1.0, -3.0]);
+        assert!((stats.min - (-5.0)).abs() < 1e-5);
+        assert!((stats.max - (-1.0)).abs() < 1e-5);
+        assert!((stats.mean - (-3.0)).abs() < 1e-5);
+    }
+
+    #[cfg(feature = "inference")]
+    #[test]
+    fn test_format_std_colored_thresholds() {
+        for v in [5.0_f32, 25.0, 75.0, 150.0] {
+            let s = format_std_colored(v);
+            assert!(s.to_string().contains(&format!("{v:.4}")));
+        }
+    }
+}


### PR DESCRIPTION
## PMAT-125 B4 — coverage for data/model-ops + observability subcommands

Tests-only PR. Adds **84 CPU-only unit tests** for previously-uncovered pure logic
across the B4 module set. No `src` behavior change — every change is inside
`#[cfg(test)]` modules or new test-fragment files.

### Modules covered
- **tokenize.rs** — `validate_algorithm` / `validate_vocab_size` / `validate_normalization`,
  `estimate_training_time`, `plan_verdict`, `format_number` / `format_bytes` / `format_duration`,
  `resolve_num_workers`, `is_jsonl`, `format_eta_iso8601_utc` (Howard-Hinnant civil-date math).
- **runs.rs** — `sample_braille_data`, `render_braille_row`, `braille_chart` structure,
  `metric_values`, `config_diff`, `param_display` / `param_to_value`,
  `format_duration_long` boundary buckets, sparkline edge cases.
- **tui.rs** — `Tab::from_index` modulo wrap, `truncate_name` (tiny / exact / multibyte
  boundaries), `build_sparkline` (zero-width + bell-shape), `text_style` / `bold_style`,
  `handle_key` Home/End/Tab/BackTab/unmapped, `selected_tensor`.
- **experiment.rs** — `param_to_json` / `param_map_json`, `render_braille` /
  `build_braille_grid` / `encode_braille_cell` (dot-bit encoding).
- **vector_stats.rs** — `compute_vector_stats` (NaN/Inf counting, empty, all-NaN,
  negatives), `format_std_colored` thresholds.
- **golden_output.rs** — `golden_test_cases` fixture structure + determinism.
- **profile pct_change / classify_metric** — regression / improvement / neutral buckets,
  zero-baseline guard, threshold-edge behavior (new `profile_pct_change_classify_tests.rs`).

### Verification
- `cargo test -p apr-cli --lib`: **6170 passed, 0 failed, 12 ignored**
- `cargo clippy -p apr-cli --lib`: clean
- `cargo fmt -p apr-cli -- --check`: clean

### Coverage delta (estimate)
Heavy on pure string/number-formatting and resolution logic. Estimated **+8–12 pp**
of line coverage across the touched B4 modules (tokenize, runs, tui, experiment,
vector_stats, golden_output, profile pct/classify), concentrated in formatting and
braille-rendering helpers that had no prior direct tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)