### PR TITLE
docs(beats): track Claude Code as the 5th parity pillar — apr code function-scale 1.0000 WON, project-scale Arena 0.20 GAP (CCPA v1.32.0)

### DIFF
--- a/contracts/beat-claude-code-parity-v1.yaml
+++ b/contracts/beat-claude-code-parity-v1.yaml
@@ -1,0 +1,174 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# beat-claude-code-parity-v1
+#
+# Pillar-5 (Claude Code / `apr code` agentic coding) TRACKING beat. This is a
+# THIN aprender-side POINTER, NOT a duplicate of the full CCPA harness contract.
+# The authoritative, byte-for-byte parity contract is
+# `contracts/claude-code-parity-apr-v1.yaml` (v1.32.0, 20 gates, kind: pattern),
+# whose runtime ENFORCEMENT lives in the companion repo
+# https://github.com/paiml/claude-code-parity-apr (the CCPA harness).
+#
+# Why a separate tracking contract: the four-pillar BEAT machinery
+# (kind: beat-benchmark, validator BEAT-002) is hardcoded to the four incumbents
+# scikit-learn / PyTorch / Unsloth / Ollama·llama.cpp. Claude Code is the FIFTH
+# incumbent; rather than widen the hardcoded BEAT_INCUMBENTS list (a schema PR of
+# its own — PMAT-CONTRACTS-CCPA-002), this contract registers the 5th-pillar beat
+# as a `kind: pattern` parity-tracking pointer — the same kind the authoritative
+# CCPA contract and its siblings (apr-code-parity-v1, apr-claude-proxy-v1) use.
+#
+# HONEST STATE (do NOT overclaim — the BEATS.md honesty rule applies):
+#   * FUNCTION-SCALE outcome parity = 1.0000 — WON / interchangeable.
+#     Canonical corpus 30/30 (fixtures/canonical/measured-parity.json),
+#     HumanEval n=5 (evidence/phase-3/multipl-e-rust-scores.json), and
+#     cross-swap test-survival 1.0000 (evidence/phase-3/test-survival.json).
+#   * PROJECT-SCALE Arena = 0.20 (1/5) — the OPEN GAP, tracked here as the
+#     parallel work to advance. Live multi-turn, claude teacher = 0.20
+#     (teacher_pass_rate 1/5), apr code student = 0.00 (0/5), measured in
+#     evidence/phase-5/arena-scores.json (companion-repo M234).
+#   * The static-fixture approach is self-described as Popperian-FALSIFIED as a
+#     project-scale predictor (companion-repo M224 design-audit.md §5,
+#     StaticFalsified). The 1.0000 corpus number is METER validation (the differ
+#     recognizes equivalent traces), NOT system-level project-scale parity.
+#   * Leading hypothesis for the project-scale gap (V1_004 chain, M286-M294):
+#     model-family choice is load-bearing for agentic tool-calling. The
+#     Qwen-Coder finetune family emits 0 tool_calls, while non-Coder
+#     Qwen3-30B-A3B-Instruct emits them — so the gap is a model/agentic-emission
+#     gap at project scale, NOT a function-scale code-quality gap.
+# ─────────────────────────────────────────────────────────────────────────────
+contract: beat-claude-code-parity
+metadata:
+  kind: pattern   # parity-tracking pointer, not a mathematical kernel and not a
+                  # four-pillar beat-benchmark (Claude Code is the 5th incumbent).
+  version: "1.0.0"
+  created: '2026-06-25'
+  last_modified: '2026-06-25'
+  author: PAIML Engineering
+  description: >
+    Pillar-5 (Claude Code) parity TRACKING pointer. Registers `apr code` agentic
+    coding as the fifth parity pillar alongside sklearn / PyTorch / Unsloth /
+    Ollama·llama.cpp, and records the honest split measured by the CCPA harness:
+    FUNCTION-SCALE outcome parity = 1.0000 (WON — canonical corpus 30/30 +
+    HumanEval n=5 + cross-swap test-survival 1.0000), and PROJECT-SCALE live
+    multi-turn Arena = 0.20 (1/5, claude teacher) = the OPEN GAP this contract
+    tracks. The authoritative full parity contract is
+    claude-code-parity-apr-v1.yaml (v1.32.0, 20 gates); the runtime harness lives
+    in the companion repo paiml/claude-code-parity-apr. This is a thin pointer
+    that does NOT duplicate the CCPA contract; its single obligation is that the
+    project-scale Arena oracle-pass parity must reach a threshold, with the CCPA
+    Arena bench (evidence/phase-5/arena-scores.json) as the measurement.
+  references:
+    - 'contracts/claude-code-parity-apr-v1.yaml — AUTHORITATIVE full CCPA parity contract (v1.32.0, 20 gates) this pointer tracks'
+    - 'contracts/apr-code-parity-v1.yaml — sibling: STATIC apr-code↔Claude-Code feature matrix'
+    - 'contracts/apr-claude-proxy-v1.yaml — sibling: Anthropic Messages-API request/response shape'
+    - 'https://github.com/paiml/claude-code-parity-apr — companion repo (CCPA harness, runtime enforcement)'
+    - 'companion-repo fixtures/canonical/measured-parity.json — function-scale corpus 30/30 aggregate 1.0000'
+    - 'companion-repo evidence/phase-3/multipl-e-rust-scores.json — HumanEval n=5 outcome parity 1.0000'
+    - 'companion-repo evidence/phase-5/arena-scores.json — project-scale Arena 0.20 (1/5) = the OPEN GAP'
+    - 'companion-repo book / The V1_004 chain (M286-M294) — model-family is load-bearing for agentic tool-calling'
+    - 'docs/BEATS.md § "Pillar 5 — Claude Code parity (`apr code`)"'
+    - 'paiml/aprender#1078 — CCPA M0 spec + DRAFT contract (now stale vs v1.32.0; see status note)'
+    - 'Cassano et al. 2022 (arXiv:2208.08227) — MultiPL-E (function-scale outcome-parity benchmark)'
+    - 'Jimenez et al. 2023 (arXiv:2310.06770) — SWE-bench (project-scale Arena corpus design)'
+
+name: beat-claude-code-parity
+version: "1.0.0"
+# TRACKING: the function-scale leg is WON (1.0000); the project-scale Arena leg
+# (0.20, 1/5) is the OPEN GAP this pointer tracks so the 5th pillar is advanced in
+# parallel with the four-pillar beat queue. Enforcement is companion-repo-side.
+status: TRACKING
+
+scope: >
+  The aprender-side registration of Claude Code as the 5th parity pillar. This
+  contract OWNS the tracking obligation (project-scale Arena parity must reach a
+  threshold) and POINTS at claude-code-parity-apr-v1.yaml for the full,
+  authoritative parity surface. It does NOT re-specify the CCPA trace schema,
+  per-tool equivalence rules, sovereignty constraint, or the 20 CCPA gates —
+  those live in the authoritative contract and are enforced by the companion repo
+  CI. Out of scope: re-implementing or duplicating any CCPA gate here.
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Authoritative-contract pointer + measured split (audit anchor)
+# ─────────────────────────────────────────────────────────────────────────────
+authoritative_contract:
+  file: 'contracts/claude-code-parity-apr-v1.yaml'
+  version: '1.32.0'
+  gates: 20            # 16 ACTIVE_RUNTIME + 4 PROPOSED
+  enforcement_repo: 'https://github.com/paiml/claude-code-parity-apr'
+
+measured_split:
+  function_scale:
+    verdict: WON
+    outcome_parity: 1.0000
+    corpus: '30/30 canonical (fixtures/canonical/measured-parity.json)'
+    humaneval: '5/5 (evidence/phase-3/multipl-e-rust-scores.json)'
+    test_survival_cross_swap: 1.0000
+  project_scale:
+    verdict: OPEN_GAP
+    arena_oracle_pass_teacher: 0.20      # claude teacher 1/5
+    arena_oracle_pass_student: 0.00      # apr code student 0/5
+    source: 'evidence/phase-5/arena-scores.json (companion-repo M234)'
+    popperian_verdict: StaticFalsified   # static fixtures falsified as a project-scale predictor
+    leading_hypothesis: >
+      V1_004 chain (M286-M294): model-family choice is load-bearing for agentic
+      tool-calling. Qwen-Coder finetunes emit 0 tool_calls; non-Coder
+      Qwen3-30B-A3B-Instruct emits them. Project-scale gap is an agentic-emission
+      / model-family gap, not a function-scale code-quality gap.
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Proof obligations (schema-validated even on kind: pattern)
+# ─────────────────────────────────────────────────────────────────────────────
+proof_obligations:
+  - id: OBLIG-CCPA-FUNCTION-SCALE-WON
+    type: equivalence
+    property: >
+      At FUNCTION scale, `apr code` and Claude Code are outcome-interchangeable:
+      the CCPA canonical-corpus aggregate parity score is >= 0.95 (measured
+      1.0000 on 30/30 fixtures) and HumanEval cross-swap test-survival is 1.0000.
+      This leg is WON and is the FLOOR, not the claim — it does NOT imply
+      project-scale parity (see the project-scale obligation, which is the gap).
+  - id: OBLIG-CCPA-PROJECT-SCALE-PARITY-GAP
+    type: bound
+    property: >
+      At PROJECT scale, the live multi-turn CCPA Arena oracle-pass parity must
+      reach a threshold. The TRACKED GAP: current claude-teacher Arena oracle
+      pass-rate is 0.20 (1/5) and apr-code-student is 0.00 (0/5) per
+      evidence/phase-5/arena-scores.json. The obligation is that a future
+      operator-dispatched Arena bench lifts the student oracle-pass parity to
+      >= the CCPA-018 floor (oracle_passed_rate >= 0.3); until then this leg is
+      an OPEN GAP, NOT a win. This is the load-bearing 5th-pillar work to advance
+      in parallel; the leading hypothesis is the V1_004 model-family finding.
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Falsification tests — single-line `test:` ref into the CCPA Arena evidence.
+# These point at the companion-repo harness (the authoritative measurement); they
+# do NOT re-implement any CCPA gate.
+# ─────────────────────────────────────────────────────────────────────────────
+falsification_tests:
+  - id: FALSIFY-BEAT-CCPA-FUNCTION-SCALE
+    rule: >
+      FALSE if the CCPA function-scale corpus parity regresses below the
+      aggregate floor (0.95) — i.e. if `apr code` stops being outcome-equivalent
+      to Claude Code on the 30 canonical fixtures + HumanEval cross-swap.
+    test: ccpa corpus fixtures/canonical/ --json
+    prediction: 'aggregate_score >= 0.95 and every per-fixture score >= 0.80 (measured 1.0000, 30/30); function-scale leg stays WON.'
+    if_fails: >
+      Function-scale outcome parity regressed — inspect the drift_category in the
+      ccpa-differ ParityReport; a per-tool equivalence rule or the apr-code agent
+      loop changed. Root-cause in the companion repo (paiml/claude-code-parity-apr)
+      crates/ccpa-differ; this is the WON leg, so any drop is a regression.
+  - id: FALSIFY-BEAT-CCPA-PROJECT-SCALE-ARENA
+    rule: >
+      FALSE-as-a-WIN-claim while the project-scale Arena oracle-pass parity stays
+      below the CCPA-018 floor. This is the OPEN GAP: apr-code student
+      oracle_passed_rate is 0.00 (0/5) vs claude teacher 0.20 (1/5). The gate is
+      DISCHARGED only when a fresh operator-dispatched Arena bench records
+      student oracle_passed_rate >= 0.3 in evidence/phase-5/arena-scores.json.
+    test: ccpa arena fixtures/project-scale/ --json
+    prediction: 'TRACKED GAP — student oracle_passed_rate currently 0.00 (< 0.3 floor); claude teacher 0.20 (1/5). NOT yet a win; advance via the V1_004 model-family fix.'
+    if_fails: >
+      Expected while the gap is open. Discharge requires lifting the apr-code
+      student project-scale Arena oracle-pass parity to >= 0.3 — leading lever is
+      the V1_004 finding (swap the Qwen-Coder finetune, which emits 0 tool_calls,
+      for a tool-call-emitting non-Coder model such as Qwen3-30B-A3B-Instruct).
+      Re-run scripts/phase-5-arena-bench.sh in the companion repo and update
+      evidence/phase-5/arena-scores.json.

--- a/docs/BEATS.md
+++ b/docs/BEATS.md
@@ -1,9 +1,16 @@
 # aprender BEAT Scoreboard
 
-The four-pillar mission: **replace _and beat_** scikit-learn, PyTorch, Unsloth, and
-Ollama/llama.cpp in one pure-Rust binary. A "beat" is never parity — it is a
-**falsifiable, CI-gated benchmark** showing apr ≥ the incumbent on the incumbent's
-own canonical task (PMAT-741).
+The five-pillar mission: **replace _and beat_** scikit-learn, PyTorch, Unsloth,
+Ollama/llama.cpp, **and Claude Code** (`apr code` agentic coding) in one pure-Rust
+binary. A "beat" is never parity — it is a **falsifiable, CI-gated benchmark**
+showing apr ≥ the incumbent on the incumbent's own canonical task (PMAT-741).
+
+> **Pillar 5 (Claude Code) is TRACKED, not yet a clean WON.** Unlike pillars 1–4,
+> the Claude-Code pillar splits into two scales with two different verdicts:
+> function-scale outcome parity is **WON (1.0000)**, project-scale agentic
+> multi-turn Arena is an **OPEN GAP (0.20)**. The honesty rule below forbids
+> reporting the function-scale win as a project-scale win — see the dedicated
+> Pillar 5 section.
 
 > **Honesty rule:** a beat that apr fails never ships. We do **not** make a blanket
 > "speed conceded" claim — apr wins speed in many measured, CI-gated cases (see the
@@ -140,6 +147,59 @@ diverges CPU-vs-GPU even when real generation is correct). Fixed by validating o
 prompt context + near-tie tolerance → default `apr run` reaches the GPU fast path that the
 re-measured 412.3 tok/s decode beat is built on.
 
+## Pillar 5 — Claude Code parity (`apr code`)
+
+The fifth incumbent: **Claude Code** (Anthropic's agentic coding agent). The beat
+is `apr code` — aprender's pure-Rust, sovereign agentic coding agent — measured
+against Claude Code at the **action-stream level** by the CCPA harness (record →
+replay → distill). This pillar is **TRACKED, not yet a clean WON**: it splits into
+two scales with two honest verdicts.
+
+| Beat | Scale / Metric | Result | Gate |
+|------|----------------|--------|------|
+| **Function-scale outcome parity** | aggregate parity score on 30 canonical fixtures + HumanEval | ✅ **WON** — apr code ≡ Claude Code, **1.0000** (corpus **30/30**, HumanEval **5/5**, cross-swap **test-survival 1.0000**); the two are outcome-interchangeable at function scale | CCPA `ccpa corpus fixtures/canonical/` (FALSIFY-CCPA-008/013/016) · `claude-code-parity-apr-v1.yaml` v1.32.0 · `fixtures/canonical/measured-parity.json` |
+| **Project-scale Arena** (live multi-turn) | oracle-pass rate, 5 real GitHub-issue fixtures | 📊 **TRACKED GAP** — claude teacher **0.20 (1/5)**, apr code student **0.00 (0/5)**; the static-fixture predictor is **Popperian-falsified** at project scale (StaticFalsified, M224 §5). This is the **open work** to advance in parallel | CCPA `ccpa arena fixtures/project-scale/` (FALSIFY-CCPA-017/018, PROPOSED) · `evidence/phase-5/arena-scores.json` |
+| **Sovereignty on replay** | zero `api.anthropic.com` egress | ✅ **WON** — `apr code` replay opens **0** outbound sockets to Anthropic; pure-Rust local model, no Claude API | CCPA `FALSIFY-CCPA-006` · `claude-code-parity-apr-v1.yaml` |
+
+**Honest split — function-scale WON, project-scale GAP (do NOT conflate):** at
+**function scale** the two systems are functionally interchangeable — the CCPA
+canonical corpus aggregates to **1.0000** (30/30 fixtures, 0 drift), the
+real-binary HumanEval bilateral bench (claude 2.1.139 + apr 0.32.0 +
+Qwen2.5-Coder-1.5B-Instruct-Q4_K_M) scores **1.0000** on MultiPL-E-Rust 5/5, and
+cross-swap **test-survival is 1.0000** (10/10). That leg is a real, measured WON.
+At **project scale**, the live multi-turn Arena (claude teacher vs `apr code`
+student over real GitHub-issue fixtures) is the **OPEN GAP**: the claude teacher
+itself only clears **0.20 (1/5)** and `apr code` clears **0.00 (0/5)**
+(`evidence/phase-5/arena-scores.json`, M234). CCPA self-describes its
+static-fixture approach as **Popperian-falsified** as a *project-scale* predictor
+(M224 `design-audit.md` §5, verdict `StaticFalsified`) — the 1.0000 corpus number
+validates **the meter** (the differ recognizes equivalent traces), **not**
+system-level project-scale parity. Per the honesty rule, the specific gap is
+**project-scale agentic multi-turn**, NOT function-scale code quality.
+
+**Leading hypothesis for the gap (V1_004 chain, M286–M294):** the load-bearing
+variable for 0% tool-call emission is the **model family**, not the inference
+stack, active-param count, or MoE-vs-dense architecture. The **Qwen-Coder
+finetune family emits 0 tool_calls**, while the non-Coder
+**Qwen3-30B-A3B-Instruct** emits them (`{"name":"file_read",...}` in 20 tokens).
+So the project-scale gap is an **agentic-emission / model-family** gap, not a
+function-scale code-quality gap — the leading lever to advance Pillar 5 is to swap
+the Qwen-Coder finetune for a tool-call-emitting non-Coder model.
+
+**Source-of-truth split (monorepo policy):** the authoritative parity contract is
+[`contracts/claude-code-parity-apr-v1.yaml`](../contracts/claude-code-parity-apr-v1.yaml)
+(**v1.32.0**, 20 gates = 16 ACTIVE_RUNTIME + 4 PROPOSED) — aprender stays canonical
+for contract TEXT. The thin aprender-side **tracking pointer** is
+[`contracts/beat-claude-code-parity-v1.yaml`](../contracts/beat-claude-code-parity-v1.yaml),
+which owns the obligation *"project-scale Arena parity must reach the CCPA-018
+floor"* and points at the CCPA arena evidence as the measurement. Runtime
+**enforcement** (CI, coverage, the live Arena bench) lives in the companion repo
+**[paiml/claude-code-parity-apr](https://github.com/paiml/claude-code-parity-apr)**.
+(`paiml/aprender#1078` authored the M0 spec + DRAFT contract; its body — 12 gates,
+pre-v1.0.0 — is now **stale** vs the current v1.32.0 / 20-gate contract in-tree,
+which is the authoritative, up-to-date copy. aprender-side tracking only; the CCPA
+repo is not rewritten here.)
+
 ## Compute kernels — trueno / cuda-oxide
 
 apr's compute foundation (trueno SIMD + cuda-oxide pure-Rust GPU kernels) wins on raw
@@ -177,8 +237,14 @@ The machinery every beat plugs into:
    scoreboard above); where it loses, name the **specific case** and root cause — never
    a blanket "speed conceded" stance.
 
-_Last updated: 2026-06-25 — promoted the Ollama GPU-decode beat from TRACKING to
-ENFORCED (1.371× median, 412.3 vs 300.7 tok/s); asserted the evidence-backed cold-start
-(~528–5000×), LAPACK-free ML (1.6–4.9×), cuda-oxide/SIMD (1.4–17×), and footprint
-(15.8–17.1×) speed wins; replaced blanket-concession wording with specific, sourced
-narrow-loss cases._
+_Last updated: 2026-06-25 — promoted the mission from FOUR-pillar to FIVE-pillar:
+added Pillar 5 (Claude Code / `apr code`) with the honest split — function-scale
+outcome parity WON (1.0000, corpus 30/30 + HumanEval + test-survival), project-scale
+Arena TRACKED GAP (0.20, 1/5), per the CCPA harness (claude-code-parity-apr-v1.yaml
+v1.32.0, 20 gates) + the new aprender-side tracking pointer
+beat-claude-code-parity-v1.yaml; V1_004 model-family finding noted as the leading
+hypothesis for the gap. Earlier 2026-06-25 edit promoted the Ollama GPU-decode beat
+from TRACKING to ENFORCED (1.371× median, 412.3 vs 300.7 tok/s); asserted the
+evidence-backed cold-start (~528–5000×), LAPACK-free ML (1.6–4.9×), cuda-oxide/SIMD
+(1.4–17×), and footprint (15.8–17.1×) speed wins; replaced blanket-concession wording
+with specific, sourced narrow-loss cases._


### PR DESCRIPTION
## Summary

Promotes the aprender BEAT mission from **FOUR-pillar to FIVE-pillar**: registers **Claude Code** (`apr code` agentic coding) as the 5th incumbent alongside scikit-learn / PyTorch / Unsloth / Ollama·llama.cpp, **tracked in parallel** via the CCPA harness ([paiml/claude-code-parity-apr](https://github.com/paiml/claude-code-parity-apr)).

This is a **TRACKING integration**, not a duplication. The authoritative parity contract already exists in-tree and is up to date.

## The honest 5th-pillar split (no overclaim)

| Scale | Verdict | Number | Source |
|---|---|---|---|
| **Function-scale** outcome parity | ✅ **WON / interchangeable** | **1.0000** | canonical corpus **30/30** (`fixtures/canonical/measured-parity.json`), HumanEval **5/5**, cross-swap **test-survival 1.0000** |
| **Project-scale** live multi-turn Arena | 📊 **OPEN GAP** | **0.20 (1/5)** claude teacher / **0.00 (0/5)** apr student | `evidence/phase-5/arena-scores.json` (M234); static-fixture predictor is **Popperian-falsified** (StaticFalsified, M224 §5) |

Per the BEATS.md honesty rule, the named gap is **project-scale agentic multi-turn**, NOT function-scale code quality. The leading hypothesis (V1_004 chain, M286–M294) is that **model family** is load-bearing: the Qwen-Coder finetune family emits **0** tool_calls while non-Coder Qwen3-30B-A3B-Instruct emits them.

## Changes

- **`docs/BEATS.md`** — four→five-pillar header + intro + Pillar-5 honesty caveat; a dedicated **"Pillar 5 — Claude Code parity (`apr code`)"** scoreboard with the honest split, sources, the V1_004 finding, and the source-of-truth split; footer note.
- **`contracts/beat-claude-code-parity-v1.yaml`** (NEW, thin tracking pointer) — `kind: pattern` (Claude Code is the 5th incumbent; the four-pillar `beat-benchmark` validator BEAT-002 hardcodes the four incumbents, so a `kind: beat-benchmark` Claude-Code contract would fail BEAT-002 — widening that list is a separate schema PR, PMAT-CONTRACTS-CCPA-002). Records the obligation *"project-scale Arena oracle-pass parity must reach the CCPA-018 floor"* with the CCPA Arena bench as the measurement + single-line falsifier refs. **Does NOT duplicate** the full CCPA contract; points at the authoritative `claude-code-parity-apr-v1.yaml` (v1.32.0, 20 gates).

## Did an aprender-side authoritative contract already exist?

**Yes.** `contracts/claude-code-parity-apr-v1.yaml` (**v1.32.0**, 20 gates = 16 ACTIVE_RUNTIME + 4 PROPOSED, `kind: pattern`, ACTIVE_RUNTIME) is already in-tree and current. `paiml/aprender#1078` authored the M0 spec + DRAFT contract; its **body is stale** (12 gates, pre-v1.0.0) vs the current in-tree contract — noted in the new pointer's references. This PR adds only the thin tracking pointer + the BEATS.md section. aprender-side tracking only; the CCPA companion repo is **not** rewritten.

## The concrete OPEN GAP (parallel work to advance)

**Project-scale Arena 0.20 (1/5)** — lift the `apr code` student project-scale Arena oracle-pass parity to ≥ 0.3 (CCPA-018 floor). Leading lever per V1_004: swap the 0-tool_call Qwen-Coder finetune for a tool-call-emitting non-Coder model, then re-run `scripts/phase-5-arena-bench.sh`.

## Validation

- `pv validate contracts/beat-claude-code-parity-v1.yaml` → **0 errors, 0 warnings**
- `pv lint contracts/` → **Result: PASS** (0 errors; new contract contributes 0 findings)
- `cargo test -p aprender-contracts --lib lint::` → **191 passed**
- No Rust touched (docs + YAML only); single-line `test:` refs, `metadata.description` present, enum-only `proof_obligations.type`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)