### PR TITLE
fix(finetune): truthful gpu-backend banner + honor --max-seq-len + per-step progress

### DIFF
--- a/crates/apr-cli/src/commands/finetune.rs
+++ b/crates/apr-cli/src/commands/finetune.rs
@@ -229,6 +229,111 @@ fn display_memory_breakdown(req: &MemoryRequirement, vram_gb: f64) {
     }
 }
 
+/// Effective compute backend plus a *truthful* user-facing notice for a run.
+///
+/// Root cause (Defect 1): the old banner printed
+/// `[gpu-backend] CUDA selected — using cuBLAS backward path` purely off the
+/// `--gpu-backend` flag. But `InstructPipeline::from_apr` only calls `init_cuda`
+/// when `quantize_nf4 == true` (i.e. QLoRA — see
+/// `aprender-train/src/finetune/instruct_pipeline/constructors.rs`). For plain
+/// `-m lora` the model trains on the CPU F32 path, so the CUDA banner was a
+/// false claim that cost real debugging time. This keeps the GPU/cuBLAS claim
+/// gated on `quantize_nf4`, and otherwise warns that plain LoRA runs on CPU.
+#[cfg(feature = "training")]
+#[derive(Debug, PartialEq, Eq)]
+struct GpuBackendPlan {
+    /// Whether to route to the WGPU pipeline (`execute_training_wgpu`).
+    use_wgpu: bool,
+    /// Human-readable, accurate notice describing the effective backend.
+    notice: String,
+}
+
+/// Decide the effective training backend and an accurate notice.
+///
+/// * `quantize_nf4` — true only for QLoRA; the sole condition under which
+///   `InstructPipeline::from_apr` initializes CUDA/cuBLAS.
+/// * `wgpu_available` — pass `cfg!(feature = "wgpu")` from the call site.
+#[cfg(feature = "training")]
+fn gpu_backend_notice(
+    gpu_backend: &str,
+    quantize_nf4: bool,
+    wgpu_available: bool,
+) -> GpuBackendPlan {
+    match gpu_backend {
+        "wgpu" => GpuBackendPlan {
+            use_wgpu: true,
+            notice: "[gpu-backend] WGPU selected — using WGSL compute shader path".to_string(),
+        },
+        "cuda" => {
+            if quantize_nf4 {
+                GpuBackendPlan {
+                    use_wgpu: false,
+                    notice: "[gpu-backend] CUDA selected — using cuBLAS backward path (QLoRA/NF4)"
+                        .to_string(),
+                }
+            } else {
+                GpuBackendPlan {
+                    use_wgpu: false,
+                    notice: "[gpu-backend] WARNING: plain LoRA (-m lora) runs on the CPU F32 \
+                             path — --gpu-backend cuda does NOT engage the GPU here \
+                             (CUDA is only initialized for QLoRA/NF4). Use -m qlora for the \
+                             cuBLAS backward path."
+                        .to_string(),
+                }
+            }
+        }
+        _ => {
+            // "auto": prefer WGPU for NF4 (fast Q4K load) when compiled in;
+            // full/plain LoRA has no GPU init, so it stays on the CPU F32 path.
+            if quantize_nf4 && wgpu_available {
+                GpuBackendPlan {
+                    use_wgpu: true,
+                    notice: "[gpu-backend] auto → WGPU (NF4 fast load path)".to_string(),
+                }
+            } else if quantize_nf4 {
+                GpuBackendPlan {
+                    use_wgpu: false,
+                    notice: "[gpu-backend] auto → CUDA cuBLAS backward path (QLoRA/NF4)"
+                        .to_string(),
+                }
+            } else {
+                GpuBackendPlan {
+                    use_wgpu: false,
+                    notice: "[gpu-backend] auto → plain LoRA (-m lora) runs on the CPU F32 \
+                             path. Use -m qlora for GPU (CUDA cuBLAS / WGPU) training."
+                        .to_string(),
+                }
+            }
+        }
+    }
+}
+
+/// Build the `InstructConfig` for the default LoRA/QLoRA training path.
+///
+/// Root cause (Defect 2): the old inline construction hardcoded
+/// `max_seq_len: 512`, silently dropping the CLI `--max-seq-len` value on the
+/// instruct path (only the `classify`/multi-adapter paths honored it). This
+/// threads the flag through, falling back to entrenar's default (512) when the
+/// flag is absent.
+#[cfg(feature = "training")]
+fn build_instruct_config(
+    config: &OptimalConfig,
+    learning_rate: f64,
+    epochs: u32,
+    max_seq_len: Option<usize>,
+) -> entrenar::finetune::instruct_pipeline::InstructConfig {
+    use entrenar::finetune::instruct_pipeline::InstructConfig;
+    InstructConfig {
+        lora_rank: config.rank as usize,
+        lora_alpha: config.alpha,
+        learning_rate: learning_rate as f32,
+        epochs: epochs as usize,
+        max_seq_len: max_seq_len.unwrap_or(InstructConfig::default().max_seq_len),
+        gradient_clip_norm: Some(1.0),
+        quantize_nf4: matches!(config.method, Method::QLoRA),
+    }
+}
+
 /// Execute LoRA adapter creation from model tensors.
 /// §26: Execute QLoRA training via entrenar InstructPipeline bridge.
 ///
@@ -250,9 +355,9 @@ fn execute_training(
     json_output: bool,
     model_size: Option<&str>,
     gpu_backend: &str,
+    max_seq_len: Option<usize>,
 ) -> Result<()> {
     use entrenar::finetune::instruct_corpus::InstructSample;
-    use entrenar::finetune::instruct_pipeline::InstructConfig;
     use entrenar::finetune::instruct_pipeline::InstructPipeline;
     use entrenar::finetune::instruct_trainer::{InstructTrainer, InstructTrainingConfig};
 
@@ -300,16 +405,9 @@ fn execute_training(
         println!("  Training samples: {}", corpus.len());
     }
 
-    // 3. Create InstructPipeline from APR model
-    let instruct_config = InstructConfig {
-        lora_rank: config.rank as usize,
-        lora_alpha: config.alpha,
-        learning_rate: learning_rate as f32,
-        epochs: epochs as usize,
-        max_seq_len: 512,
-        gradient_clip_norm: Some(1.0),
-        quantize_nf4: matches!(config.method, Method::QLoRA),
-    };
+    // 3. Create InstructPipeline from APR model.
+    // Defect 2 fix: thread the CLI --max-seq-len through instead of hardcoding 512.
+    let instruct_config = build_instruct_config(config, learning_rate, epochs, max_seq_len);
 
     if !json_output {
         output::pipeline_stage("Training", output::StageStatus::Running);
@@ -319,31 +417,17 @@ fn execute_training(
         println!("  Data: {} samples", corpus.len());
     }
 
-    // PMAT-494 FIX: Route based on --gpu-backend flag.
-    // "cuda" → InstructPipeline with cuBLAS backward (proper per-layer backward with
-    //   RMSNorm, SiLU, attention backward + cuBLAS GEMM = 15-40x faster LoRA backward)
-    // "wgpu" → WgpuInstructPipeline (portable but 336 WGSL dispatches/step)
-    // "auto" → WGPU for NF4 (fast load), CUDA for full FT
-    let use_wgpu = match gpu_backend {
-        "cuda" => {
-            eprintln!("[gpu-backend] CUDA selected — using cuBLAS backward path");
-            false
-        }
-        "wgpu" => {
-            eprintln!("[gpu-backend] WGPU selected — using WGSL compute shader path");
-            true
-        }
-        _ => {
-            // "auto": prefer WGPU for NF4 (fast Q4K load), CUDA for full FT
-            if instruct_config.quantize_nf4 && cfg!(feature = "wgpu") {
-                eprintln!("[gpu-backend] auto → WGPU (NF4 fast load path)");
-                true
-            } else {
-                eprintln!("[gpu-backend] auto → CUDA (full FT path)");
-                false
-            }
-        }
-    };
+    // PMAT-494 FIX / Defect 1: Route based on --gpu-backend flag with a TRUTHFUL
+    // notice. The CUDA/cuBLAS backward path is only engaged when NF4 (QLoRA) is
+    // active, since InstructPipeline::from_apr only calls init_cuda then; for
+    // plain LoRA we must NOT claim GPU — gpu_backend_notice warns it runs on CPU.
+    let backend_plan = gpu_backend_notice(
+        gpu_backend,
+        instruct_config.quantize_nf4,
+        cfg!(feature = "wgpu"),
+    );
+    eprintln!("{}", backend_plan.notice);
+    let use_wgpu = backend_plan.use_wgpu;
 
     #[cfg(feature = "wgpu")]
     if use_wgpu {
@@ -1157,10 +1241,12 @@ pub(crate) fn run(
         json_output,
         model_size,
         gpu_backend,
+        max_seq_len,
     )
 }
 
 /// Validate inputs and execute the LoRA training pipeline.
+#[allow(clippy::too_many_arguments)]
 fn run_finetune_training(
     model_path: Option<&Path>,
     data_path: Option<&Path>,
@@ -1171,6 +1257,7 @@ fn run_finetune_training(
     json_output: bool,
     model_size: Option<&str>,
     gpu_backend: &str,
+    max_seq_len: Option<usize>,
 ) -> Result<()> {
     let data = match data_path {
         Some(d) if d.exists() => d,
@@ -1207,6 +1294,7 @@ fn run_finetune_training(
         json_output,
         model_size,
         gpu_backend,
+        max_seq_len,
     )
 }
 

--- a/crates/apr-cli/src/commands/finetune_tests.rs
+++ b/crates/apr-cli/src/commands/finetune_tests.rs
@@ -1161,6 +1161,86 @@ fn build_classify_config_defaults_max_seq_len_when_none() {
     assert_eq!(cfg.max_seq_len, ClassifyConfig::default().max_seq_len);
 }
 
+// ── build_instruct_config (Defect 2: honor --max-seq-len on the LoRA path) ───
+
+#[test]
+fn build_instruct_config_threads_max_seq_len() {
+    // A user-supplied --max-seq-len must reach InstructConfig.max_seq_len on the
+    // instruct/LoRA path, NOT be silently dropped to the old hardcoded 512.
+    let mut config = plan(1_000_000_000, 24.0, Method::LoRA).expect("plan lora");
+    config.method = Method::LoRA;
+    let cfg = build_instruct_config(&config, 1e-4, 3, Some(384));
+    assert_eq!(
+        cfg.max_seq_len, 384,
+        "--max-seq-len 384 must be honored, not dropped to 512"
+    );
+    assert_eq!(cfg.epochs, 3);
+    assert!(!cfg.quantize_nf4, "plain LoRA → NF4 off");
+}
+
+#[test]
+fn build_instruct_config_defaults_max_seq_len_to_512_when_absent() {
+    use entrenar::finetune::instruct_pipeline::InstructConfig;
+    let mut config = plan(1_000_000_000, 24.0, Method::QLoRA).expect("plan qlora");
+    config.method = Method::QLoRA;
+    let cfg = build_instruct_config(&config, 5e-5, 1, None);
+    assert_eq!(cfg.max_seq_len, InstructConfig::default().max_seq_len);
+    assert_eq!(cfg.max_seq_len, 512);
+    assert!(cfg.quantize_nf4, "QLoRA method → NF4 on");
+}
+
+// ── gpu_backend_notice (Defect 1: truthful GPU banner) ──────────────────────
+
+#[test]
+fn gpu_backend_notice_cuda_plain_lora_warns_cpu() {
+    // --gpu-backend cuda + plain LoRA (quantize_nf4=false) must NOT claim cuBLAS;
+    // it must WARN that training actually runs on CPU (init_cuda is QLoRA-only).
+    let p = gpu_backend_notice("cuda", false, false);
+    assert!(!p.use_wgpu);
+    assert!(p.notice.contains("WARNING"), "must warn: {}", p.notice);
+    assert!(p.notice.to_lowercase().contains("cpu"));
+    assert!(
+        !p.notice.contains("using cuBLAS backward path (QLoRA/NF4)"),
+        "must not make a false cuBLAS claim for plain LoRA: {}",
+        p.notice
+    );
+}
+
+#[test]
+fn gpu_backend_notice_cuda_qlora_claims_cublas() {
+    let p = gpu_backend_notice("cuda", true, false);
+    assert!(!p.use_wgpu);
+    assert!(
+        p.notice.contains("cuBLAS"),
+        "QLoRA on CUDA truthfully engages cuBLAS: {}",
+        p.notice
+    );
+    assert!(!p.notice.contains("WARNING"));
+}
+
+#[test]
+fn gpu_backend_notice_wgpu_selects_wgpu() {
+    let p = gpu_backend_notice("wgpu", false, true);
+    assert!(p.use_wgpu);
+    assert!(p.notice.contains("WGPU"));
+}
+
+#[test]
+fn gpu_backend_notice_auto_plain_lora_is_cpu() {
+    let p = gpu_backend_notice("auto", false, true);
+    assert!(!p.use_wgpu, "plain LoRA under auto stays on the CPU path");
+    assert!(p.notice.to_lowercase().contains("cpu"));
+}
+
+#[test]
+fn gpu_backend_notice_auto_qlora_prefers_wgpu_when_available() {
+    let with_wgpu = gpu_backend_notice("auto", true, true);
+    assert!(with_wgpu.use_wgpu, "NF4 + wgpu available → WGPU fast path");
+    let without_wgpu = gpu_backend_notice("auto", true, false);
+    assert!(!without_wgpu.use_wgpu, "no wgpu feature → CUDA path");
+    assert!(without_wgpu.notice.contains("cuBLAS"));
+}
+
 // ── run (top-level dispatch) error paths ────────────────────────────────────
 
 #[test]

--- a/crates/aprender-train/src/finetune/instruct_trainer.rs
+++ b/crates/aprender-train/src/finetune/instruct_trainer.rs
@@ -193,8 +193,15 @@ impl InstructTrainer {
             // ── Train ──
             let mut epoch_loss = 0.0f32;
             let mut epoch_tokens = 0usize;
+            let n_steps = train_prepared.len();
 
-            for sample in &train_prepared {
+            // Per-step progress so a slow CPU epoch does not look like a frozen
+            // hang. Low-noise: emit on every 10th step, on the final step, and
+            // at least once every ~10s. Pure stderr logging — the training math
+            // (loss/token accumulation, scheduler) is unchanged.
+            let mut last_step_log = std::time::Instant::now();
+
+            for (step, sample) in train_prepared.iter().enumerate() {
                 let lr = scheduler.get_lr();
                 self.pipeline.set_learning_rate(lr);
 
@@ -202,6 +209,20 @@ impl InstructTrainer {
                 epoch_loss += result.loss * result.num_response_tokens as f32;
                 epoch_tokens += result.num_response_tokens;
                 scheduler.step();
+
+                let is_last_step = step + 1 == n_steps;
+                if (step + 1) % 10 == 0 || is_last_step || last_step_log.elapsed().as_secs() >= 10 {
+                    eprintln!(
+                        "  Epoch {}/{} step {}/{}: loss={:.4} lr={:.2e}",
+                        epoch + 1,
+                        self.config.epochs,
+                        step + 1,
+                        n_steps,
+                        result.loss,
+                        lr,
+                    );
+                    last_step_log = std::time::Instant::now();
+                }
             }
 
             let train_loss = if epoch_tokens > 0 { epoch_loss / epoch_tokens as f32 } else { 0.0 };


### PR DESCRIPTION
Fixes three real `apr finetune` UX/correctness defects, each with a falsifiable, RED→GREEN-verified test.

## Defect 1 — false GPU banner (misleading; cost real debugging time)
`crates/apr-cli/src/commands/finetune.rs` printed `[gpu-backend] CUDA selected — using cuBLAS backward path` purely off the `--gpu-backend` flag, independent of whether CUDA was actually initialized. `InstructPipeline::from_apr` only calls `init_cuda` when `quantize_nf4 == true` (`crates/aprender-train/src/finetune/instruct_pipeline/constructors.rs:293`), and `quantize_nf4` is set only for QLoRA (`matches!(config.method, Method::QLoRA)`). So for plain `-m lora`, the banner was a **false claim** — training silently ran on CPU.

**Fix:** extracted a pure, testable `gpu_backend_notice(gpu_backend, quantize_nf4, wgpu_available) -> GpuBackendPlan`. It only claims cuBLAS/GPU when NF4 (QLoRA) is active; for plain LoRA it prints a clear WARNING that training runs on the CPU F32 path and to use `-m qlora` for GPU. Correct for `wgpu` and `auto` too.

## Defect 2 — `--max-seq-len` silently ignored on the instruct/LoRA path
The CLI exposes `--max-seq-len` and plumbs it clap → `dispatch.rs` → `finetune::run`, but `execute_training` hardcoded `InstructConfig { max_seq_len: 512, .. }` (old `finetune.rs:309`), so `apr finetune ... --max-seq-len 384` was silently dropped for LoRA/QLoRA (only the `classify`/multi-adapter paths honored it).

**Fix:** new `build_instruct_config(config, lr, epochs, max_seq_len)` helper threads the flag through (falls back to entrenar's default 512 when absent); plumbed `max_seq_len` through `run` → `run_finetune_training` → `execute_training`.

## Defect 3 — no per-step training progress (a slow CPU epoch looks like a hang)
`crates/aprender-train/src/finetune/instruct_trainer.rs` (`InstructTrainer::train`) logged only per-EPOCH, so a multi-minute first epoch looked frozen.

**Fix:** low-noise per-step stderr progress — emitted on every 10th step, on the final step, or at least every ~10s — with step index/total, loss, and lr. Pure logging; the training math (loss/token accumulation, scheduler) is unchanged.

## Tests (RED→GREEN verified by temporarily reintroducing each bug)
- `build_instruct_config_threads_max_seq_len` — 384 must reach `InstructConfig.max_seq_len` (RED = 512 when bug present)
- `build_instruct_config_defaults_max_seq_len_to_512_when_absent`
- `gpu_backend_notice_cuda_plain_lora_warns_cpu` — RED = false cuBLAS claim
- `gpu_backend_notice_cuda_qlora_claims_cublas`, `_wgpu_selects_wgpu`, `_auto_plain_lora_is_cpu`, `_auto_qlora_prefers_wgpu_when_available`

All 62 finetune + 5 instruct_trainer lib tests pass; `cargo fmt` + clippy clean on touched files. No contract was bumped — these are UX/correctness fixes (not kernel math), so a test-backed fix is used per repo guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)