### PR TITLE
fix(train): NF4 QLoRA forward self-deadlock — wave of 4 in fused_residual_rmsnorm_forward (unblocks GPU finetune)

### DIFF
--- a/contracts/cuda-fused-residual-rmsnorm-v1.yaml
+++ b/contracts/cuda-fused-residual-rmsnorm-v1.yaml
@@ -1,0 +1,174 @@
+metadata:
+  id: C-CUDA-FUSED-RESIDUAL-RMSNORM
+  version: 1.0.0
+  created: '2026-07-01'
+  author: PAIML Engineering
+  kind: pattern
+  status: ACTIVE_ALGORITHM_LEVEL
+  description: |
+    Pins liveness and correctness of the fused residual-add + RMSNorm
+    CUDA forward (`fused_residual_rmsnorm_forward`), the post-attention
+    norm of the NF4 QLoRA transformer block.
+
+    BACKGROUND. Every `apr finetune -m qlora` run on RTX 4090 froze on
+    the FIRST `CudaNf4TransformerBlock::forward` — GPU 0% util, process
+    cputime frozen, all threads in futex_wait. gdb thread-apply-all-bt
+    (2026-07-01, live deadlock capture) showed thread 1:
+
+      #1 std::sys::sync::mutex::futex::Mutex::lock_contended
+      #2 entrenar::..::elementwise::residual_add_forward
+      #3 entrenar::..::normalization::fused_residual_rmsnorm_forward
+      #4 CudaNf4TransformerBlock::forward
+
+    Root-cause audit surfaced a WAVE OF 4 defects, all latent because
+    the path had never once executed to completion (defect 1 fired on
+    first ever use):
+
+      1. SELF-DEADLOCK: the function held the FORWARD_KERNEL_CACHE
+         mutex guard for its whole body, then called the public
+         `residual_add_forward`, which re-locks the SAME non-reentrant
+         std::sync::Mutex on the same thread. Permanent futex wait.
+      2. SINGLE-ROW KERNEL LAUNCHED AS BATCHED: the old
+         `FusedResidualRmsNormKernel` has no ctaid indexing (one warp,
+         one row) but was launched with grid.y = batch_size. Every
+         block redundantly computed row 0; rows 1.. were never
+         written (verified: max_diff=2.36 vs CPU reference).
+      3. EPS NOT THREADED: kernel default eps=1e-5 (Llama) silently
+         used for Qwen2 models (rms_norm_eps=1e-6). Same defect class
+         as C-APR-PRETRAIN-CUDA-RMSNORM-EPS-PARITY, one function down.
+      4. NO PRE-WARM ENTRY: the kernel JIT-compiled mid-training
+         ([FWD-CACHE] Compiling at first block forward) — the
+         Blackwell sm_121 stream-poisoning class from PMAT-698.
+
+    FIX (all four in one structural change): switch to
+    `BatchedFusedResidualRmsNormKernel` (PMAT-092), which indexes rows
+    via ctaid.y AND writes `residual_out` itself — the nested
+    `residual_add_forward` call is gone entirely (deadlock eliminated
+    structurally, not by lock-scope reordering); thread `eps` from
+    `config.rms_norm_eps` with eps-bits in the cache key; pre-warm at
+    both Qwen2 (1e-6) and Llama (1e-5) eps.
+
+    RED-then-GREEN cycle (verified live on RTX 4090, sm_89):
+      RED  (pre-fix): falsifier deadlocks — 120s watchdog fires with
+           the exact production signature ([FWD-CACHE] OK
+           'fused_residual_rmsnorm_1536' then freeze). After fix #1
+           alone, oracle 2 still RED at max_diff=2.36 (defect #2).
+      GREEN (post-fix): completes in <0.2s; residual_out exactly
+           residual+input; output within 1e-4 of CPU RMSNorm
+           reference at eps=1e-6 across ALL batch rows.
+
+  references:
+    - 'crates/aprender-train/src/autograd/cuda_forward/normalization.rs:448 (fused_residual_rmsnorm_forward, rewritten)'
+    - 'crates/aprender-train/src/autograd/cuda_forward/cache.rs:237 (pre_warm_for_model, fused-residual warm added)'
+    - 'crates/aprender-train/src/transformer/cuda_block.rs:3262 (NF4 post-attn callsite, eps threaded)'
+    - 'crates/aprender-gpu/src/kernels/elementwise/residual.rs:359 (BatchedFusedResidualRmsNormKernel, PMAT-092)'
+    - 'crates/aprender-gpu/src/kernels/elementwise/residual.rs:201 (single-row FusedResidualRmsNormKernel, no longer used here)'
+  depends_on:
+    - 'apr-pretrain-cuda-rmsnorm-eps-parity-v1'
+
+equations:
+  fused_rmsnorm_liveness:
+    formula: |
+      fused_residual_rmsnorm_forward(residual_out ≠ residual) terminates
+    domain: |
+      The forward MUST NOT acquire FORWARD_KERNEL_CACHE and then call
+      another public cuda_forward entry point that re-locks it. The
+      batched kernel writes residual_out itself, so no nested public
+      call exists on this path.
+    invariants:
+    - 'no nested FORWARD_KERNEL_CACHE lock acquisition on the same thread'
+    - 'call completes for distinct residual_out buffers (the NF4 block always passes distinct)'
+    preconditions:
+    - 'kernel cache initialized (init_forward_kernel_cache)'
+
+  fused_rmsnorm_batched_row_parity:
+    formula: |
+      ∀ row m < batch_size:
+        residual_out[m] = residual[m] + input[m]
+        output[m] = rmsnorm(residual[m] + input[m], gamma, eps)
+    domain: |
+      Every batch row is computed, not just row 0. The kernel indexes
+      rows via ctaid.y; the launch supplies grid.y = batch_size. CPU
+      reference parity within 1e-4 max abs diff on Qwen-magnitude
+      activations (std~0.02); residual_out exact (single f32 add).
+    invariants:
+    - 'rows 1..batch_size written (pre-fix: only row 0)'
+    - 'max abs diff vs CPU reference < 1e-4 at threaded eps'
+    - 'residual_out == residual + input exactly'
+    preconditions:
+    - 'fused_rmsnorm_liveness holds'
+
+  fused_rmsnorm_eps_threading:
+    formula: |
+      fused_residual_rmsnorm_forward(eps = config.rms_norm_eps)
+      ⇒ kernel_eps == config.rms_norm_eps
+    domain: |
+      Same invariant as C-APR-PRETRAIN-CUDA-RMSNORM-EPS-PARITY but for
+      the fused residual+norm path: eps is a function parameter, the
+      kernel is constructed via .with_epsilon(eps), and the PTX cache
+      key includes eps bits so modules at different eps cannot shadow
+      each other. Pre-warm covers both 1e-6 (Qwen2) and 1e-5 (Llama).
+    invariants:
+    - 'kernel_eps == provided_eps (no hardcoded 1e-5 default)'
+    - 'cache_key includes eps_bits'
+    - 'pre_warm_for_model warms both Qwen2 and Llama eps variants'
+    preconditions:
+    - 'caller passes config.rms_norm_eps (cuda_block.rs NF4 post-attn site)'
+
+proof_obligations:
+- type: invariant
+  property: fused residual RMSNorm forward terminates with distinct residual_out
+  formal: 'terminates(fused_residual_rmsnorm_forward) ∧ ¬self_deadlock(FORWARD_KERNEL_CACHE)'
+  applies_to: fused_rmsnorm_liveness
+- type: invariant
+  property: all batch rows match CPU reference
+  formal: '∀m<M: |output[m] - cpu_rmsnorm(residual[m]+input[m], gamma, eps)|_∞ < 1e-4'
+  applies_to: fused_rmsnorm_batched_row_parity
+- type: invariant
+  property: kernel epsilon equals caller-provided epsilon
+  formal: 'BatchedFusedResidualRmsNormKernel.epsilon == eps_arg'
+  applies_to: fused_rmsnorm_eps_threading
+
+falsification_tests:
+- id: FALSIFY-CUDA-FUSED-RMSNORM-DEADLOCK-001
+  rule: |
+    `fused_residual_rmsnorm_forward` with a residual_out buffer
+    DISTINCT from residual completes within the watchdog window AND
+    produces row-complete, eps-correct output.
+  prediction: |
+    Build 4 rows × 1536 hidden (Qwen2.5-Coder-1.5B dims — the live
+    repro), Qwen-magnitude activations, distinct residual_out.
+    Run the call in a worker thread; a 120s watchdog converts the
+    pre-fix deadlock into a bounded failure. On completion assert
+    (a) residual_out == residual + input exactly, and
+    (b) output matches CPU rmsnorm(residual+input, gamma, 1e-6)*gamma
+    within 1e-4 on ALL rows.
+  test: cargo test -p aprender-train --features cuda --lib falsify_cuda_fused_rmsnorm_distinct_residual_out_no_deadlock
+  if_fails: |
+    Timeout ⇒ a nested FORWARD_KERNEL_CACHE lock re-entered this path
+    (someone re-added a public cuda_forward call inside the guard
+    scope). Row mismatch ⇒ the single-row kernel was reintroduced or
+    the batched kernel's ctaid indexing regressed. Eps mismatch ⇒
+    .with_epsilon dropped or cache key lost its eps bits (stale PTX
+    shadowing).
+  ship_blocking: true
+  counter_example_classes:
+  - nested_lock_self_deadlock
+  - single_row_kernel_launched_as_batched
+  - eps_hardcoded_at_construction
+  - cache_key_collision_across_eps
+
+qa_gate:
+  id: QA-CUDA-FUSED-RESIDUAL-RMSNORM-001
+  name: Fused residual RMSNorm liveness + parity gate
+  description: |
+    The falsifier passes on a CUDA host: no self-deadlock, all batch
+    rows written, CPU-reference parity at the threaded eps, exact
+    residual_out materialization. Unblocks apr finetune -m qlora GPU
+    training (Pillar 3).
+  checks:
+  - fused_rmsnorm_liveness
+  - fused_rmsnorm_batched_row_parity
+  - fused_rmsnorm_eps_threading
+  pass_criteria: FALSIFY-CUDA-FUSED-RMSNORM-DEADLOCK-001 passes
+  falsification: Any failure fails the gate (ship-blocking)

--- a/crates/aprender-train/src/autograd/cuda_forward/cache.rs
+++ b/crates/aprender-train/src/autograd/cuda_forward/cache.rs
@@ -234,6 +234,22 @@ impl ForwardKernelCache {
             );
         }
 
+        // 1b. Fused residual add + RMSNorm (post-attention norm in the NF4
+        // QLoRA block). FALSIFY-CUDA-FUSED-RMSNORM-DEADLOCK-001 fix #4: this
+        // kernel previously had NO pre-warm entry and JIT-compiled
+        // mid-training (Blackwell stream-poisoning class, PMAT-698). Warm at
+        // both Qwen2 (1e-6) and Llama (1e-5) eps like batched_rmsnorm_fwd.
+        {
+            use trueno_gpu::kernels::BatchedFusedResidualRmsNormKernel;
+            for eps in [1.0e-6_f32, 1.0e-5_f32] {
+                let eps_bits = eps.to_bits();
+                warm!(
+                    format!("batched_fused_residual_rmsnorm_{h}_eps{eps_bits:08x}"),
+                    BatchedFusedResidualRmsNormKernel::new(h, 1).with_epsilon(eps)
+                );
+            }
+        }
+
         // PMAT-700 (SPEC-BLACKWELL-FIX-001 Fix #2): when cuBLAS is available
         // and the runtime takes its fast path for the standard 2D GEMMs
         // (Q/K/V/O/gate/up/down projections — see ALB-075 dispatch in

--- a/crates/aprender-train/src/autograd/cuda_forward/normalization.rs
+++ b/crates/aprender-train/src/autograd/cuda_forward/normalization.rs
@@ -7,8 +7,8 @@
 use trueno_gpu::driver::{CudaStream, GpuBuffer, LaunchConfig};
 #[cfg(feature = "cuda")]
 use trueno_gpu::kernels::{
-    BatchedRopeBackwardKernel, BatchedRopeKernel, BatchedVectorizedRmsNormKernel,
-    FusedResidualRmsNormKernel, Kernel, LayerNormKernel, PerHeadRmsNormKernel, RopeNeoxKernel,
+    BatchedFusedResidualRmsNormKernel, BatchedRopeBackwardKernel, BatchedRopeKernel,
+    BatchedVectorizedRmsNormKernel, Kernel, LayerNormKernel, PerHeadRmsNormKernel, RopeNeoxKernel,
 };
 
 use crate::autograd::cuda_tensor::{CudaTensorError, Result};
@@ -453,63 +453,80 @@ pub fn fused_residual_rmsnorm_forward(
     gamma: &GpuBuffer<f32>,
     batch_size: u32,
     hidden_size: u32,
+    eps: f32,
     stream: &CudaStream,
 ) -> Result<()> {
+    // FALSIFY-CUDA-FUSED-RMSNORM-DEADLOCK-001 (wave of 4, all fixed here):
+    //
+    // 1. Self-deadlock: this function held the FORWARD_KERNEL_CACHE mutex
+    //    guard while calling the public `residual_add_forward`, which
+    //    re-locks the SAME non-reentrant `std::sync::Mutex` on the same
+    //    thread — `Mutex::lock_contended` futex-waited forever and froze
+    //    every `apr finetune -m qlora` run on the first transformer block
+    //    forward. Fixed structurally: the batched kernel writes
+    //    `residual_out` itself, so the nested call is gone entirely.
+    // 2. Single-row kernel launched as batched: the old
+    //    `FusedResidualRmsNormKernel` has no ctaid indexing (one warp, one
+    //    row) but was launched with grid.y = batch_size — every block
+    //    redundantly computed row 0 and rows 1.. were never written.
+    //    `BatchedFusedResidualRmsNormKernel` (PMAT-092) indexes rows via
+    //    ctaid.y.
+    // 3. eps not threaded: the kernel default (1e-5, Llama) was silently
+    //    used for Qwen2 models (1e-6). Callers now pass
+    //    `config.rms_norm_eps`, and the cache key includes the eps bits
+    //    (PMAT-698k lesson: eps-less keys shadow stale PTX).
+    // 4. Missing pre-warm: this kernel JIT-compiled mid-training
+    //    (Blackwell stream-poisoning class, PMAT-698). pre_warm_for_model
+    //    now warms it at both Qwen2 (1e-6) and Llama (1e-5) eps.
     let cache = FORWARD_KERNEL_CACHE.get().ok_or(CudaTensorError::DeviceNotInitialized)?;
     let mut cache = cache.lock().map_err(|_err| {
         CudaTensorError::KernelError("Failed to acquire kernel cache lock".to_string())
     })?;
 
-    let key = format!("fused_residual_rmsnorm_{hidden_size}");
+    let eps_bits = eps.to_bits();
+    let key = format!("batched_fused_residual_rmsnorm_{hidden_size}_eps{eps_bits:08x}");
     let module = match cache.get_cached(&key) {
         Some(m) => m,
         None => {
-            let kernel = FusedResidualRmsNormKernel::new(hidden_size);
+            let kernel =
+                BatchedFusedResidualRmsNormKernel::new(hidden_size, batch_size).with_epsilon(eps);
             let ptx = kernel.emit_ptx_for_target(cache.sm_target());
             cache.get_or_compile(&key, &ptx)?
         }
     };
 
-    // Grid: (1, batch_size, 1) — one block per row
-    // Block: (32, 1, 1) — single warp for reduction
-    let config = LaunchConfig { grid: (1, batch_size, 1), block: (32, 1, 1), shared_mem: 0 };
+    // Grid: (1, batch_size, 1) — one block per row via ctaid.y
+    // Block: (256, 1, 1) — 8 warps; shared: 8 warp partial sums (f32)
+    let config = LaunchConfig { grid: (1, batch_size, 1), block: (256, 1, 1), shared_mem: 8 * 4 };
 
     let residual_ptr = residual.as_ptr();
     let input_ptr = input.as_ptr();
+    let residual_out_ptr = residual_out.as_ptr();
     let output_ptr = output.as_ptr();
     let gamma_ptr = gamma.as_ptr();
 
-    let mut args: [*mut std::ffi::c_void; 4] = [
+    let mut args: [*mut std::ffi::c_void; 5] = [
         &residual_ptr as *const _ as *mut _,
         &input_ptr as *const _ as *mut _,
+        &residual_out_ptr as *const _ as *mut _,
         &output_ptr as *const _ as *mut _,
         &gamma_ptr as *const _ as *mut _,
     ];
 
-    // Also store the un-normalized residual sum for backward pass
-    // The fused kernel writes residual+input to output before normalizing,
-    // so we need to save it separately if residual_out != output
-    if residual_out.as_ptr() != residual.as_ptr() {
-        // First do the residual add into residual_out
-        crate::autograd::cuda_forward::residual_add_forward(
-            residual,
-            input,
-            residual_out,
-            batch_size * hidden_size,
-            stream,
-        )?;
-    }
-
-    // Launch fused kernel: output = RMSNorm(residual + input) * gamma
+    // Launch fused kernel:
+    //   residual_out = residual + input
+    //   output       = RMSNorm(residual + input) * gamma
+    // (`residual_out` may alias `residual`: pass 1 reads each element before
+    // writing it back, per-thread, so the aliased store is ordered safely.)
     // SAFETY: launches a CUDA kernel via the driver API. The argument pointer array, grid/block config, and module/function name match the kernel's signature, and every referenced device buffer is allocated, correctly sized, and lives until the stream-ordered launch completes.
     unsafe {
-        stream.launch_kernel(module, "fused_residual_rmsnorm", &config, &mut args).map_err(
-            |e| {
+        stream
+            .launch_kernel(module, "batched_fused_residual_rmsnorm", &config, &mut args)
+            .map_err(|e| {
                 CudaTensorError::KernelError(format!(
                     "Fused residual+RMSNorm forward failed: {e:?}"
                 ))
-            },
-        )?;
+            })?;
     }
 
     Ok(())
@@ -610,6 +627,159 @@ mod tests {
              `rms_norm_forward_with_eps(.., eps, ..)` threads `config.rms_norm_eps` \
              into the kernel and the cache key includes eps bits to avoid stale \
              PTX shadowing. See contract apr-pretrain-cuda-rmsnorm-eps-parity-v1.yaml."
+        );
+    }
+
+    /// FALSIFY-CUDA-FUSED-RMSNORM-DEADLOCK-001: `fused_residual_rmsnorm_forward`
+    /// with a `residual_out` buffer DISTINCT from `residual` must complete
+    /// (liveness) and produce correct results (oracle).
+    ///
+    /// On main pre-fix this test DEADLOCKS: the function acquired the
+    /// `FORWARD_KERNEL_CACHE` mutex guard for its whole body, then called the
+    /// public `residual_add_forward` (normalization.rs:494) which re-locks the
+    /// SAME non-reentrant `std::sync::Mutex` on the same thread →
+    /// `Mutex::lock_contended` futex-waits forever. This froze every
+    /// `apr finetune -m qlora` run on the first `CudaNf4TransformerBlock::
+    /// forward` (gdb: thread 1 stuck in lock_contended ← residual_add_forward
+    /// ← fused_residual_rmsnorm_forward ← CudaNf4TransformerBlock::forward).
+    ///
+    /// The watchdog thread converts the pre-fix deadlock into a bounded test
+    /// failure instead of a hung test binary.
+    ///
+    /// Oracle (not just liveness): `residual_out == residual + input`
+    /// element-wise, and `output` matches the CPU RMSNorm reference of
+    /// `residual + input` at the threaded eps=1e-6 (Qwen2). The output
+    /// oracle also caught the single-row kernel being launched as batched
+    /// (rows 1.. never written, max_diff=2.36 vs reference) — see the
+    /// wave-of-4 fix note in `fused_residual_rmsnorm_forward`.
+    #[test]
+    fn falsify_cuda_fused_rmsnorm_distinct_residual_out_no_deadlock() {
+        use std::sync::mpsc;
+        use std::time::Duration;
+
+        let hidden_size = 1536usize; // Qwen2.5-Coder-1.5B hidden (live repro dims)
+        let batch_size = 4u32;
+        let total = batch_size as usize * hidden_size;
+
+        let residual_data: Vec<f32> =
+            (0..total).map(|i| (((i as f32) * 0.017).sin()) * 0.02).collect();
+        let input_data: Vec<f32> =
+            (0..total).map(|i| (((i as f32) * 0.011).cos()) * 0.02).collect();
+        let gamma_data: Vec<f32> =
+            (0..hidden_size).map(|i| 1.0 + ((i as f32) * 0.007).cos() * 0.1).collect();
+
+        enum Outcome {
+            NoCuda(String),
+            Done { residual_out: Vec<f32>, output: Vec<f32> },
+        }
+
+        let (tx, rx) = mpsc::channel();
+        let res_clone = residual_data.clone();
+        let inp_clone = input_data.clone();
+        let gam_clone = gamma_data.clone();
+        // Detached worker: on the pre-fix deadlock it blocks forever and the
+        // watchdog below fails the test after the timeout instead of hanging.
+        std::thread::spawn(move || {
+            let device = match CudaDevice::default_device() {
+                Ok(d) => d,
+                Err(e) => {
+                    let _ = tx.send(Outcome::NoCuda(format!("{e}")));
+                    return;
+                }
+            };
+            let ctx = device.context().clone();
+            let stream = device.stream();
+            if let Err(e) = init_forward_kernel_cache(ctx.clone()) {
+                let _ = tx.send(Outcome::NoCuda(format!("cache init: {e}")));
+                return;
+            }
+
+            let residual_gpu = GpuBuffer::from_host(&ctx, &res_clone).expect("residual");
+            let input_gpu = GpuBuffer::from_host(&ctx, &inp_clone).expect("input");
+            let gamma_gpu = GpuBuffer::from_host(&ctx, &gam_clone).expect("gamma");
+            // DISTINCT residual_out buffer — the deadlock precondition.
+            let mut residual_out_gpu =
+                GpuBuffer::<f32>::new(&ctx, res_clone.len()).expect("residual_out alloc");
+            let mut output_gpu =
+                GpuBuffer::<f32>::new(&ctx, res_clone.len()).expect("output alloc");
+
+            fused_residual_rmsnorm_forward(
+                &residual_gpu,
+                &input_gpu,
+                &mut residual_out_gpu,
+                &mut output_gpu,
+                &gamma_gpu,
+                batch_size,
+                hidden_size as u32,
+                1e-6, // Qwen2 rms_norm_eps (the live repro model family)
+                stream,
+            )
+            .expect("fused_residual_rmsnorm_forward");
+            stream.synchronize().expect("sync");
+
+            let mut residual_out = vec![0.0f32; res_clone.len()];
+            let mut output = vec![0.0f32; res_clone.len()];
+            residual_out_gpu.copy_to_host(&mut residual_out).expect("download residual_out");
+            output_gpu.copy_to_host(&mut output).expect("download output");
+            let _ = tx.send(Outcome::Done { residual_out, output });
+        });
+
+        let outcome = rx.recv_timeout(Duration::from_secs(120)).unwrap_or_else(|_| {
+            panic!(
+                "FALSIFY-CUDA-FUSED-RMSNORM-DEADLOCK-001: \
+                 fused_residual_rmsnorm_forward did not complete within 120s with a \
+                 distinct residual_out buffer. Pre-fix root cause: the function held \
+                 the FORWARD_KERNEL_CACHE mutex guard while calling the public \
+                 residual_add_forward, which re-locks the same non-reentrant mutex \
+                 on the same thread (self-deadlock). Fix: enqueue the residual add \
+                 BEFORE acquiring the cache lock."
+            )
+        });
+
+        let (residual_out, output) = match outcome {
+            Outcome::NoCuda(reason) => {
+                eprintln!(
+                    "[falsify-cuda-fused-rmsnorm-deadlock-001] skipping (no CUDA host): {reason}"
+                );
+                return;
+            }
+            Outcome::Done { residual_out, output } => (residual_out, output),
+        };
+
+        // Oracle 1: residual_out = residual + input (single f32 add — exact).
+        let max_add_diff = residual_data
+            .iter()
+            .zip(input_data.iter())
+            .zip(residual_out.iter())
+            .map(|((r, i), out)| (r + i - out).abs())
+            .fold(0.0f32, f32::max);
+        assert!(
+            max_add_diff == 0.0,
+            "FALSIFY-CUDA-FUSED-RMSNORM-DEADLOCK-001: residual_out != residual + input \
+             (max_diff={max_add_diff})"
+        );
+
+        // Oracle 2: output = RMSNorm(residual + input) * gamma at the eps the
+        // caller threads through (1e-6, Qwen2). Pre-fix the kernel silently
+        // used its 1e-5 default AND only ever wrote row 0 (single-row kernel
+        // launched with grid.y = batch_size), so this oracle also falsifies
+        // the batched-row and eps-threading defects, not just liveness.
+        let summed: Vec<f32> =
+            residual_data.iter().zip(input_data.iter()).map(|(r, i)| r + i).collect();
+        let mut cpu_out = Vec::with_capacity(total);
+        for b in 0..batch_size as usize {
+            let row = &summed[b * hidden_size..(b + 1) * hidden_size];
+            cpu_out.extend(cpu_rmsnorm_reference(row, &gamma_data, 1e-6));
+        }
+        let max_norm_diff = cpu_out
+            .iter()
+            .zip(output.iter())
+            .map(|(c, g)| (c - g).abs())
+            .fold(0.0f32, f32::max);
+        assert!(
+            max_norm_diff < 1e-4,
+            "FALSIFY-CUDA-FUSED-RMSNORM-DEADLOCK-001: output disagrees with CPU \
+             RMSNorm(residual+input) reference (max_diff={max_norm_diff})"
         );
     }
 }

--- a/crates/aprender-train/src/transformer/cuda_block.rs
+++ b/crates/aprender-train/src/transformer/cuda_block.rs
@@ -3267,6 +3267,7 @@ impl CudaNf4TransformerBlock {
             &self.post_attn_norm_weight,
             saturating_u32(seq_len),
             saturating_u32(hidden_size),
+            self.config.rms_norm_eps,
             stream,
         )?;
 


### PR DESCRIPTION
## Summary

Every `apr finetune -m qlora` run froze on the **first** transformer block forward (GPU 0% util, cputime frozen, all threads in futex_wait). gdb live capture of the deadlocked process:

```
#1 std::sys::sync::mutex::futex::Mutex::lock_contended
#2 entrenar::…::elementwise::residual_add_forward
#3 entrenar::…::normalization::fused_residual_rmsnorm_forward
#4 CudaNf4TransformerBlock::forward
```

`fused_residual_rmsnorm_forward` held the `FORWARD_KERNEL_CACHE` mutex guard for its whole body, then called the public `residual_add_forward`, which re-locks the **same non-reentrant `std::sync::Mutex` on the same thread** → permanent self-deadlock.

## Wave of 4 (the path had never executed once)

1. **Self-deadlock** — nested same-thread lock via `residual_add_forward` (above).
2. **Single-row kernel launched as batched** — `FusedResidualRmsNormKernel` has no ctaid indexing but was launched with `grid.y = batch_size`; every block computed row 0, rows 1.. were never written (measured max_diff=2.36 vs CPU reference).
3. **eps not threaded** — kernel default 1e-5 (Llama) silently used for Qwen2 (1e-6); same class as FALSIFY-CUDA-RMSNORM-EPS-PARITY-001, one function down.
4. **No pre-warm entry** — kernel JIT-compiled mid-training (PMAT-698 Blackwell stream-poisoning class).

## Fix

Switch to `BatchedFusedResidualRmsNormKernel` (PMAT-092): indexes rows via ctaid.y **and writes `residual_out` itself**, so the nested public call is gone structurally (not just lock-scope reordering). Thread `eps` from `config.rms_norm_eps` with eps bits in the cache key; pre-warm at both Qwen2 (1e-6) and Llama (1e-5) eps.

## Verification (RTX 4090, sm_89)

- **Falsifier** `FALSIFY-CUDA-FUSED-RMSNORM-DEADLOCK-001` (watchdog thread + CPU-reference oracle over all rows):
  - RED on bug: 120s watchdog fires with the exact production signature
  - After fix #1 alone: oracle still RED at max_diff=2.36 (caught defect #2 independently)
  - GREEN post-fix: 0.17s, `residual_out == residual + input` exact, output < 1e-4 vs CPU reference on all rows
- **Contract**: `contracts/cuda-fused-residual-rmsnorm-v1.yaml` — `pv validate` + `pv lint contracts/` PASS
- **E2E**: `apr finetune qwen2.5-coder-1.5b-q4k.apr -m qlora --gpu-backend cuda` now **trains to completion** (previously deadlocked 100% of runs; verified 3× today pre-fix): `Epoch 1 complete … Training complete … time=13s`, checkpoints saved
- **Full crate**: `cargo test -p aprender-train --lib --features cuda` → 7695 pass; the 6 failures are pre-existing on the base commit (bf16 ptxas env issue, insta snapshot drift) — verified by running them on base
- Pre-push: fmt ✓, contracts lib (1412) ✓, deny advisories ✓, non-cuda `cargo check` ✓

Known follow-on (separate beat): one training step logs `NaN/Inf loss detected — skipping backward` on the toy dataset; liveness and kernel parity are discharged here, the NaN loss is the next falsifier in the cascade.

Unblocks GPU QLoRA finetune on RTX 4090 (Pillar 3) and the apr-code tool_call flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)