### PR TITLE
fix(finetune): CUDA loss window honors --max-seq-len — kill hardcoded 512 clamp that silently trained nothing

### DIFF
--- a/contracts/finetune-cuda-loss-window-v1.yaml
+++ b/contracts/finetune-cuda-loss-window-v1.yaml
@@ -1,0 +1,125 @@
+metadata:
+  id: C-FINETUNE-CUDA-LOSS-WINDOW
+  version: 1.0.0
+  created: '2026-07-01'
+  author: PAIML Engineering
+  kind: pattern
+  status: ACTIVE_ALGORITHM_LEVEL
+  description: |
+    Pins the invariant that the CUDA instruct-training loss window clamps
+    to the SAME sequence capacity as the forward pass (GPU-scratch-driven,
+    i.e. the `--max-seq-len` the user configured), never a hardcoded 512.
+
+    BACKGROUND. Discovered live on the apr-code tool_call flip
+    (2026-07-01, first training run after the NF4 QLoRA deadlock fix,
+    cuda-fused-residual-rmsnorm-v1.yaml). `apr finetune -m qlora
+    --max-seq-len` threading was fixed in PR #2247 (buffers size from
+    `InstructConfig::max_seq_len`), and `forward_cuda_training` clamps to
+    the scratch capacity — but `cuda_train_step` had a SECOND, older
+    hardcoded clamp (entrenar#318):
+
+      let max_pos = self.model.config().max_position_embeddings.min(512);
+
+    For any sample whose PROMPT exceeded 512 tokens, prompt_len and
+    seq_len both clamped to 512 → loss_start == loss_end →
+    num_loss_tokens == 0 → the step silently returned loss=0.0 with zero
+    gradient. On the apr-code SFT corpus (CODE_SYSTEM_PROMPT alone ≫ 512
+    tokens) that was essentially EVERY sample: a full epoch "trained"
+    with no learning — observed as steps printing loss=0.0000, epoch
+    avg_loss=93.87 (dominated by NaN sentinels), and 559 loss tokens
+    across 160 samples (~3.5/sample for 30-60-token responses).
+
+    FIX. Window math extracted to the pure function `cuda_loss_window`
+    (single correctness surface): effective capacity = scratch capacity
+    when CUDA scratch exists, `max_position_embeddings.min(512)` only as
+    the no-scratch fallback — mirroring forward_cuda_training exactly.
+    Zero-token samples (prompt overflows even the configured window) now
+    skip LOUDLY with a per-sample stderr warning instead of silently
+    contributing a 0.0 loss.
+
+    RED-then-GREEN: falsifier verified RED under the pre-fix behavior by
+    mutation (restore the hardcoded `.min(512)` → the scratch-capacity
+    assertion fails), GREEN on the fix.
+
+  references:
+    - 'crates/aprender-train/src/finetune/instruct_pipeline/training.rs (cuda_loss_window + cuda_train_step)'
+    - 'crates/aprender-train/src/finetune/instruct_pipeline/cuda_forward.rs:27 (forward capacity derivation, mirrored)'
+    - 'crates/aprender-train/src/finetune/instruct_pipeline/cuda_init.rs:130 (scratch sized from config.max_seq_len)'
+    - 'crates/apr-cli/src/commands/finetune.rs:331 (PR #2247 --max-seq-len threading)'
+  depends_on:
+    - 'cuda-fused-residual-rmsnorm-v1'
+
+equations:
+  loss_window_capacity_parity:
+    formula: |
+      effective_max(loss_window) == effective_max(forward)
+      where effective_max = scratch_capacity if scratch exists
+                            else min(max_position_embeddings, 512)
+    domain: |
+      The loss window and the forward pass MUST clamp the sequence to the
+      same capacity. A window clamped tighter than the forward silently
+      drops response tokens from training; looser would index past the
+      forward's computed logits.
+    invariants:
+    - 'scratch present ⇒ loss window honors scratch capacity (not 512)'
+    - 'no scratch ⇒ conservative min(max_position_embeddings, 512) fallback'
+    preconditions:
+    - 'scratch buffers sized from InstructConfig::max_seq_len (cuda_init.rs)'
+
+  zero_token_samples_are_loud:
+    formula: |
+      num_loss_tokens == 0 ⇒ stderr warning emitted ∧ step excluded from
+      token-weighted epoch loss
+    domain: |
+      A sample whose prompt fills the whole window cannot train; it must
+      be visibly skipped, never silently averaged as loss=0.0.
+    invariants:
+    - 'per-sample skip warning names prompt_len, window, and the --max-seq-len remedy'
+    preconditions:
+    - 'epoch aggregation is token-weighted (instruct_trainer.rs)'
+
+proof_obligations:
+- type: invariant
+  property: loss window honors configured scratch capacity
+  formal: 'cuda_loss_window(p, s, Some(cap), mpe).seq_len == min(s, cap)'
+  applies_to: loss_window_capacity_parity
+- type: invariant
+  property: zero-token samples skip loudly
+  formal: 'num_loss_tokens == 0 ⇒ eprintln(sample skipped)'
+  applies_to: zero_token_samples_are_loud
+
+falsification_tests:
+- id: FALSIFY-CUDA-LOSS-WINDOW-512-001
+  rule: |
+    With a scratch sized for 2048 rows, a 600-token prompt + 100-token
+    response keeps all 100 response tokens in the loss window.
+  prediction: |
+    cuda_loss_window(600, 700, Some(2048), 32768) returns
+    num_loss_tokens=100 with seq_len=700 unclamped. Pre-fix (hardcoded
+    .min(512), verified by mutation) both clamp to 512 and
+    num_loss_tokens=0.
+  test: cargo test -p aprender-train --features cuda --lib falsify_cuda_loss_window_honors_scratch_capacity
+  if_fails: |
+    The hardcoded 512 clamp regressed into cuda_train_step (or
+    cuda_loss_window lost its scratch_capacity argument). Long-prompt
+    corpora silently train nothing; check the epoch log for loss=0.0000
+    floods and tokens/samples ratios far below the corpus response
+    length.
+  ship_blocking: true
+  counter_example_classes:
+  - hardcoded_seq_clamp_reintroduced
+  - loss_window_diverges_from_forward_capacity
+  - silent_zero_loss_on_prompt_overflow
+
+qa_gate:
+  id: QA-FINETUNE-CUDA-LOSS-WINDOW-001
+  name: CUDA instruct loss-window capacity gate
+  description: |
+    Loss window honors the configured --max-seq-len (scratch capacity);
+    prompt-overflow samples skip loudly. Makes long-system-prompt SFT
+    corpora (apr-code tool_call) trainable.
+  checks:
+  - loss_window_capacity_parity
+  - zero_token_samples_are_loud
+  pass_criteria: FALSIFY-CUDA-LOSS-WINDOW-512-001 passes
+  falsification: Failure fails the gate (ship-blocking)

--- a/crates/aprender-train/src/finetune/instruct_pipeline/training.rs
+++ b/crates/aprender-train/src/finetune/instruct_pipeline/training.rs
@@ -130,15 +130,30 @@ impl InstructPipeline {
         seq_len: usize,
         vocab_size: usize,
     ) -> InstructStepResult {
-        // entrenar#318: truncate seq_len to match forward_cuda_training's max
-        let max_pos = self.model.config().max_position_embeddings.min(512);
-        let seq_len = seq_len.min(max_pos);
-        let prompt_len = prompt_len.min(seq_len);
-        let loss_start = prompt_len.saturating_sub(1);
-        let loss_end = seq_len - 1;
-        let num_loss_tokens = loss_end.saturating_sub(loss_start);
+        // FALSIFY-CUDA-LOSS-WINDOW-512-001: clamp the loss window to the SAME
+        // capacity the forward uses (scratch-driven), not a hardcoded 512.
+        // Pre-fix this was `max_position_embeddings.min(512)` regardless of
+        // `--max-seq-len`, so any sample whose prompt exceeded 512 tokens had
+        // its ENTIRE response clamped out of the window — silent loss=0.0,
+        // zero gradient. On the apr-code SFT corpus (system prompt ≫ 512
+        // tokens) that was ~all samples: an epoch "trained" with no learning.
+        let hidden_size = self.model.config().hidden_size;
+        let scratch_capacity = self.shared_scratch.as_ref().map(|s| s.max_seq_len(hidden_size));
+        let (loss_start, loss_end, num_loss_tokens, seq_len, prompt_len) = cuda_loss_window(
+            prompt_len,
+            seq_len,
+            scratch_capacity,
+            self.model.config().max_position_embeddings,
+        );
 
         if num_loss_tokens == 0 {
+            // Loud skip: silent 0.0 made a no-op epoch look like training.
+            // Token-weighted epoch aggregation ignores this step (0 tokens).
+            eprintln!(
+                "[CUDA] sample skipped: prompt ({prompt_len} tokens) fills the \
+                 {seq_len}-token training window — 0 response tokens to train on \
+                 (raise --max-seq-len)"
+            );
             return InstructStepResult { loss: 0.0, num_response_tokens: 0, perplexity: 1.0 };
         }
 
@@ -549,5 +564,94 @@ impl InstructPipeline {
         let avg_loss = if num_loss_tokens > 0 { total_loss / num_loss_tokens as f32 } else { 0.0 };
 
         (avg_loss, grad_logits)
+    }
+}
+
+/// Compute the causal-LM loss window for a CUDA training step.
+///
+/// FALSIFY-CUDA-LOSS-WINDOW-512-001: the effective sequence capacity is the
+/// GPU scratch's row capacity when CUDA scratch exists (sized from
+/// `config.max_seq_len` at init — the value `--max-seq-len` threads through),
+/// with `max_position_embeddings.min(512)` ONLY as the no-scratch fallback.
+/// This mirrors `forward_cuda_training` (cuda_forward.rs) exactly — the loss
+/// window and the forward MUST clamp to the same capacity or response tokens
+/// silently fall outside the trained window.
+///
+/// Pre-fix `cuda_train_step` hardcoded `.min(512)` unconditionally: with
+/// `--max-seq-len 2048` the buffers held 2048 rows but the loss window was
+/// still cut at 512, so any prompt longer than 512 tokens yielded
+/// `num_loss_tokens == 0` → silent `loss=0.0`, zero gradient, no learning.
+///
+/// Returns `(loss_start, loss_end, num_loss_tokens, clamped_seq_len,
+/// clamped_prompt_len)`.
+#[cfg(feature = "cuda")]
+pub(crate) fn cuda_loss_window(
+    prompt_len: usize,
+    seq_len: usize,
+    scratch_capacity: Option<usize>,
+    max_position_embeddings: usize,
+) -> (usize, usize, usize, usize, usize) {
+    let max_pos = scratch_capacity.unwrap_or_else(|| max_position_embeddings.min(512));
+    let seq_len = seq_len.min(max_pos);
+    let prompt_len = prompt_len.min(seq_len);
+    let loss_start = prompt_len.saturating_sub(1);
+    let loss_end = seq_len.saturating_sub(1);
+    let num_loss_tokens = loss_end.saturating_sub(loss_start);
+    (loss_start, loss_end, num_loss_tokens, seq_len, prompt_len)
+}
+
+#[cfg(all(test, feature = "cuda"))]
+mod loss_window_tests {
+    use super::cuda_loss_window;
+
+    /// FALSIFY-CUDA-LOSS-WINDOW-512-001: with a scratch sized for 2048 rows
+    /// (`--max-seq-len 2048`), a 600-token prompt + 100-token response MUST
+    /// produce a non-empty loss window. Pre-fix the hardcoded `.min(512)`
+    /// clamped seq AND prompt to 512 → `num_loss_tokens == 0` → the step
+    /// silently returned loss=0.0 and the epoch trained nothing (observed
+    /// live on the apr-code SFT corpus: every step 0.0/NaN, avg_loss=93.87
+    /// from NaN sentinels, 559 loss tokens across 160 samples).
+    #[test]
+    fn falsify_cuda_loss_window_honors_scratch_capacity() {
+        let (loss_start, loss_end, num_loss_tokens, seq_len, prompt_len) =
+            cuda_loss_window(600, 700, Some(2048), 32768);
+        assert_eq!(seq_len, 700, "seq must not be clamped below scratch capacity");
+        assert_eq!(prompt_len, 600);
+        assert_eq!(loss_start, 599);
+        assert_eq!(loss_end, 699);
+        assert_eq!(
+            num_loss_tokens, 100,
+            "FALSIFY-CUDA-LOSS-WINDOW-512-001: a 600-token prompt with a \
+             2048-capacity scratch must keep all 100 response tokens in the \
+             loss window (pre-fix: hardcoded .min(512) clamp yielded 0)"
+        );
+    }
+
+    /// No-scratch fallback preserves the conservative entrenar#318 clamp.
+    #[test]
+    fn cuda_loss_window_no_scratch_falls_back_to_512() {
+        let (_, _, num_loss_tokens, seq_len, prompt_len) = cuda_loss_window(600, 700, None, 32768);
+        assert_eq!(seq_len, 512);
+        assert_eq!(prompt_len, 512);
+        assert_eq!(num_loss_tokens, 0, "prompt fills the fallback window — nothing to train");
+    }
+
+    /// Prompt overflowing even the scratch capacity yields an empty window
+    /// (the caller must skip LOUDLY, never train on it silently).
+    #[test]
+    fn cuda_loss_window_prompt_overflow_is_empty() {
+        let (_, _, num_loss_tokens, seq_len, prompt_len) =
+            cuda_loss_window(3000, 3050, Some(2048), 32768);
+        assert_eq!(seq_len, 2048);
+        assert_eq!(prompt_len, 2048);
+        assert_eq!(num_loss_tokens, 0);
+    }
+
+    /// max_position_embeddings below 512 still bounds the fallback.
+    #[test]
+    fn cuda_loss_window_small_model_fallback() {
+        let (_, _, num_loss_tokens, seq_len, _) = cuda_loss_window(10, 40, None, 128);
+        assert_eq!(seq_len, 40);
+        assert_eq!(num_loss_tokens, 30);
     }
 }


### PR DESCRIPTION
## Summary

`cuda_train_step` had a second, older hardcoded clamp (entrenar#318) — `max_position_embeddings.min(512)` — independent of #2247's `--max-seq-len` threading and of the scratch capacity the forward actually uses. Any sample whose **prompt** exceeded 512 tokens had its entire response clamped out of the loss window: `num_loss_tokens == 0` → **silent `loss=0.0`, zero gradient**.

Observed live on the apr-code SFT corpus (system prompt ≫ 512 tokens): a full qlora epoch "trained" with no learning — `loss=0.0000` floods, `avg_loss=93.87` (dominated by NaN sentinels), 559 loss tokens across 160 samples (~3.5/sample for 30–60-token responses).

## Fix

- Window math extracted to pure fn `cuda_loss_window` (single correctness surface): effective capacity = **GPU scratch capacity** when present (sized from `InstructConfig::max_seq_len` at init), `min(max_position_embeddings, 512)` only as the no-scratch fallback — mirroring `forward_cuda_training` exactly.
- Prompt-overflow samples now skip **loudly** (per-sample stderr warning naming the `--max-seq-len` remedy) instead of averaging silent zeros. Token-weighted epoch aggregation already excludes them.

## Verification

- Falsifier `FALSIFY-CUDA-LOSS-WINDOW-512-001` **mutation-verified**: restoring the hardcoded clamp → `falsify_cuda_loss_window_honors_scratch_capacity` goes RED (`seq must not be clamped below scratch capacity`); GREEN on fix. 3 companion tests pin the fallback and overflow semantics. Pure-fn tests — run in CI without a GPU.
- Contract `contracts/finetune-cuda-loss-window-v1.yaml` — `pv lint contracts/` PASS.
- fmt ✓, non-cuda `cargo check` ✓.
- E2E (RTX 4090): `apr finetune -m qlora --max-seq-len 2048` on `datasets/apr_code_sft_balanced.jsonl` — in flight, evidence in PR comment.

Cascade position: 2nd falsifier after the NF4 QLoRA deadlock fix (#2249). Together they take `apr finetune -m qlora` from *freezes on first forward* → *trains long-system-prompt corpora on the 4090*. Directly unblocks the apr-code tool_call flip (5th pillar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)