### PR TITLE
fix(train): NF4 QLoRA NaN loss — per-call cuBLAS stream binding kills cross-stream data race

### DIFF
--- a/contracts/cuda-nf4-forward-stream-ordering-v1.yaml
+++ b/contracts/cuda-nf4-forward-stream-ordering-v1.yaml
@@ -1,0 +1,176 @@
+metadata:
+  id: C-CUDA-NF4-FORWARD-STREAM-ORDERING
+  version: 1.0.0
+  created: '2026-07-01'
+  author: PAIML Engineering
+  kind: pattern
+  status: ACTIVE_ALGORITHM_LEVEL
+  description: |
+    Pins cross-stream ordering for the NF4 QLoRA CUDA training forward:
+    every cuBLAS GEMM must execute on the SAME stream as the PTX kernels
+    that produce its inputs and consume its outputs.
+
+    BACKGROUND. `apr finetune -m qlora` on RTX 4090 (sm_89) returned
+    loss=NaN from `fused_causal_cross_entropy_cuda` on the FIRST training
+    step — before any optimizer update — on ~ALL steps at seq 512-2048
+    and ~1/3 of steps at seq ~30. Every individual kernel (rmsnorm,
+    softmax, rope, NF4 GEMM, fused residual rmsnorm) passed direct
+    numeric parity tests; the batched fused residual RMSNorm was
+    explicitly exonerated (0 NaN, 2.6e-6 CPU parity at 512/2048/30 rows).
+
+    ROOT CAUSE (5-whys). The trainer's stream is created with
+    CU_STREAM_NON_BLOCKING (driver/stream.rs), which opts OUT of implicit
+    synchronization with the legacy default stream. A fresh cuBLAS handle
+    (cublasCreate) issues its GEMMs on that legacy DEFAULT stream until
+    cublasSetStream binds it elsewhere. The finetune instruct pipeline's
+    `autograd::cuda_training::CudaTrainer` initialized the forward and
+    backward kernel caches (which create the cuBLAS handles) but nothing
+    on the QLoRA path ever bound them — the per-step binding exists only
+    in the PRETRAINING path (train/transformer_trainer/cuda_trainer.rs).
+    Result: every PTX→cuBLAS and cuBLAS→PTX boundary in the block forward
+    (rmsnorm→QKV GEMM, Q@K^T→scale/mask/softmax, softmax→scores@V,
+    final-norm→lm_head GEMM, lm_head→cross-entropy kernel) was an
+    unsynchronized data race — cuBLAS read activations while the
+    producer kernel was still writing them. Longer sequences widen the
+    race window (bigger kernels ⇒ more overlap), explaining the
+    seq-length-dependent NaN rate. The same class also affected the
+    NULL-stream cuMemcpyDtoD `copy_from_buffer` snapshots of
+    layer_inputs/blocks_output in `forward_cuda_training` (backward
+    inputs), fixed by stream-ordered `copy_from_buffer_async`.
+
+    FIX. Per-call stream binding: every cuBLAS dispatch site binds the
+    handle to the CALLER's stream via `bind_cublas_stream` before the
+    GEMM (cuda_forward::matmul, matmul_f16; cuda_backward::gemm). A
+    bind-once-at-trainer-construction variant was tried first and
+    REJECTED: the process-global handle dangles on the DESTROYED stream
+    after the owning trainer drops — SIGSEGV in any process that creates
+    multiple CudaTrainers (the full aprender-train test suite). Per-call
+    binding is ~100ns (handle field write) per GEMM, executed under the
+    kernel-cache mutex so bind+launch is atomic across threads, and the
+    caller's stream is alive by construction (&CudaStream argument).
+
+    DIAGNOSIS EVIDENCE (Heisenbug signature). An env-gated per-op NaN
+    scanner (APR_NAN_SCAN=1, cuda_block.rs) that synchronizes the trainer
+    stream and downloads each intermediate buffer made ALL NaN vanish
+    (3/3 clean toy runs, zero non-finite intermediates) while unscanned
+    runs produced NaN on the same data — the defect disappears exactly
+    when per-op synchronization is inserted, which is only consistent
+    with a stream-ordering race, not kernel math.
+
+    RED-then-GREEN cycle (verified live on RTX 4090, sm_89):
+      RED  (binding removed): falsifier worst |Δ| = 401,408 of expected
+           413,696 — the cuBLAS row-sum GEMM observed the producer chain
+           at ~3% progress. E2E: 15/16 steps NaN at --max-seq-len 2048
+           on apr_code_sft_balanced; 1/2 toy steps NaN at seq ~30.
+      GREEN (binding present): falsifier exact (3/3 runs); toy epoch
+           3/3 runs 0 NaN with DETERMINISTIC losses (14.1996, 14.0399);
+           2048-run 16/16 finite losses in [12.62, 14.11], 0 NaN lines.
+
+  references:
+    - 'crates/aprender-train/src/autograd/cuda_forward/matmul.rs:32 (bind_cublas_stream helper + gemm_forward/gemm_forward_bt/batched_4d/NF4-cuBLAS sites)'
+    - 'crates/aprender-train/src/autograd/cuda_forward/matmul_f16.rs:51 (fp16 GEMM sites bound per call)'
+    - 'crates/aprender-train/src/autograd/cuda_backward/gemm.rs:55 (backward GEMM sites bound per call)'
+    - 'crates/aprender-train/src/finetune/instruct_pipeline/cuda_forward.rs:139 (layer_inputs stream-ordered D2D copy)'
+    - 'crates/aprender-train/src/finetune/instruct_pipeline/cuda_forward.rs:214 (blocks_output stream-ordered D2D copy)'
+    - 'crates/aprender-gpu/src/driver/stream.rs:64 (CU_STREAM_NON_BLOCKING creation)'
+    - 'crates/aprender-train/src/transformer/cuda_block.rs:81 (APR_NAN_SCAN per-op forward NaN scanner)'
+  depends_on:
+    - 'cuda-fused-residual-rmsnorm-v1'
+
+equations:
+  cublas_per_call_stream_binding:
+    formula: |
+      ∀ cuBLAS dispatch site f(..., stream):
+        cublasSetStream(handle, stream) happens-before gemm_launch(f)
+    domain: |
+      Both global kernel caches own a cuBLAS handle created on the
+      legacy default stream. Every dispatch site receives the caller's
+      stream and MUST bind the handle to it before launching, under the
+      kernel-cache mutex (bind+launch atomic). Bind-once designs dangle
+      when the bound stream is destroyed before the handle.
+    invariants:
+    - 'bind_cublas_stream(cublas, stream) precedes every cublas.gemm_* launch'
+    - 'no cuBLAS launch on the legacy default stream from training paths'
+    - 'handle never left bound to a destroyed stream across trainer drops'
+    preconditions:
+    - 'kernel caches initialized (init_forward_kernel_cache / init_kernel_cache)'
+
+  forward_single_stream_ordering:
+    formula: |
+      ∀ producer p, consumer c in forward_cuda_training:
+        writes(p, buf) ∧ reads(c, buf) ⇒ stream(p) == stream(c)
+        ∨ explicit_sync(p, c)
+    domain: |
+      The NF4 block forward interleaves PTX kernels (trainer stream)
+      with cuBLAS GEMMs and D2D copies. All work touching shared
+      activation buffers within one step must be stream-ordered on the
+      trainer stream; the legacy default stream provides NO implicit
+      ordering against a non-blocking stream.
+    invariants:
+    - 'cuBLAS GEMMs execute on the trainer stream (per-call binding)'
+    - 'layer_inputs/blocks_output snapshots use copy_from_buffer_async on the trainer stream, not NULL-stream cuMemcpyDtoD'
+    - 'first-step loss is finite at any seq_len that fits the scratch capacity'
+    preconditions:
+    - 'cublas_per_call_stream_binding holds'
+
+proof_obligations:
+- type: invariant
+  property: every cuBLAS GEMM launch is preceded by binding to the caller stream
+  formal: '∀ site: cublasSetStream(handle, caller_stream) ≺ gemm_launch(site)'
+  applies_to: cublas_per_call_stream_binding
+- type: invariant
+  property: cuBLAS consumer observes fully-written producer output
+  formal: '∀ buf: gemm_read(buf) happens-after producer_write(buf) (single-stream order)'
+  applies_to: forward_single_stream_ordering
+- type: invariant
+  property: QLoRA forward loss finite on first step
+  formal: 'is_finite(fused_causal_cross_entropy_cuda(forward_logits_gpu_resident(x))) at step 0'
+  applies_to: forward_single_stream_ordering
+
+falsification_tests:
+- id: FALSIFY-CUDA-NF4-FORWARD-NAN-001
+  rule: |
+    A cuBLAS GEMM issued immediately after a long chain of PTX kernels
+    on the trainer's non-blocking stream must observe the CHAIN-FINAL
+    values of its input buffer, never intermediate ones.
+  prediction: |
+    Warm up cuBLAS (first-call lazy init would otherwise mask the race),
+    then run 100 chained elementwise adds (4096x4096, ~20ms GPU) on the
+    trainer stream so X = 101.0 everywhere, and issue the cuBLAS row-sum
+    GEMM out = X @ ones right behind it from the host. Bound per call
+    (GREEN): every out[i] == 101*4096 = 413,696 exactly. Unbound (RED):
+    the GEMM overlaps the add chain on the default stream and reads X
+    mid-chain — measured worst |Δ| = 401,408 (~3% progress). Skips
+    vacuously without CUDA/cuBLAS (PTX fallback is single-stream).
+  test: cargo test -p aprender-train --features cuda --lib falsify_cuda_nf4_forward_nan_001_cublas_stream_ordering
+  if_fails: |
+    A cuBLAS dispatch site lost its per-call bind_cublas_stream call —
+    someone removed the bind from cuda_forward::matmul / matmul_f16 /
+    cuda_backward::gemm, or added a NEW cuBLAS dispatch site without the
+    bind, or reverted to a bind-once-at-construction design (which also
+    SIGSEGVs multi-trainer test processes via dangling streams). The
+    QLoRA forward will NaN on the first step at seq >= 512. Diagnose
+    with APR_NAN_SCAN=1 (per-op scanner in cuda_block.rs): if NaN
+    vanishes under the scanner, it is this stream-ordering class.
+  ship_blocking: true
+  counter_example_classes:
+  - cublas_handle_unbound_default_stream
+  - nonblocking_stream_no_implicit_sync
+  - null_stream_d2d_copy_races_producer
+  - lazy_cublas_init_masks_race_in_test
+  - bind_once_dangles_after_trainer_drop
+
+qa_gate:
+  id: QA-CUDA-NF4-FORWARD-STREAM-ORDERING-001
+  name: NF4 QLoRA forward cross-stream ordering gate
+  description: |
+    The falsifier passes on a CUDA host: cuBLAS GEMMs are stream-ordered
+    with their PTX producers/consumers via per-call handle binding, so
+    the QLoRA training forward produces finite first-step losses at all
+    supported sequence lengths. Unblocks apr finetune -m qlora GPU
+    training (Pillar 3).
+  checks:
+  - cublas_per_call_stream_binding
+  - forward_single_stream_ordering
+  pass_criteria: FALSIFY-CUDA-NF4-FORWARD-NAN-001 passes
+  falsification: Any failure fails the gate (ship-blocking)

--- a/crates/aprender-train/src/autograd/cuda_backward/gemm.rs
+++ b/crates/aprender-train/src/autograd/cuda_backward/gemm.rs
@@ -16,7 +16,9 @@ use super::cache::KERNEL_CACHE;
 
 // cuBLAS backward dispatch (ALB-075)
 #[cfg(feature = "cuda")]
-use crate::autograd::cuda_forward::{cublas_gemm_backward_a, cublas_gemm_backward_b};
+use crate::autograd::cuda_forward::{
+    bind_cublas_stream, cublas_gemm_backward_a, cublas_gemm_backward_b,
+};
 
 /// Tile size for backward GEMM kernels (C-TILE-BWD-001).
 ///
@@ -50,6 +52,7 @@ pub fn gemm_backward_a(
     // on transposed GEMMs with gradient magnitudes ~1e5. Forward GEMMs remain
     // on tensor cores since NoTrans/NoTrans is unaffected.
     if let Some(cublas) = cache.cublas() {
+        bind_cublas_stream(cublas, stream)?;
         return cublas_gemm_backward_a(cublas, grad_output, b, grad_a, m, k, n);
     }
 
@@ -127,6 +130,7 @@ pub fn gemm_backward_b(
     // on transposed GEMMs with gradient magnitudes ~1e5. Forward GEMMs remain
     // on tensor cores since NoTrans/NoTrans is unaffected.
     if let Some(cublas) = cache.cublas() {
+        bind_cublas_stream(cublas, stream)?;
         return cublas_gemm_backward_b(cublas, a, grad_output, grad_b, m, k, n);
     }
 
@@ -190,7 +194,7 @@ pub fn gemm_backward_a_accumulate(
     m: u32,
     k: u32,
     n: u32,
-    _stream: &CudaStream,
+    stream: &CudaStream,
 ) -> Result<()> {
     let cache = KERNEL_CACHE.get().ok_or(CudaTensorError::DeviceNotInitialized)?;
     let cache = cache.lock().map_err(|_err| {
@@ -200,6 +204,7 @@ pub fn gemm_backward_a_accumulate(
     // cuBLAS accumulate path (beta=1.0) — this is the only path that matters
     // in production since cuBLAS is always initialized for NF4 QLoRA training.
     if let Some(cublas) = cache.cublas() {
+        bind_cublas_stream(cublas, stream)?;
         return crate::autograd::cuda_forward::cublas_gemm_backward_a_accumulate(
             cublas,
             grad_output,

--- a/crates/aprender-train/src/autograd/cuda_forward/matmul.rs
+++ b/crates/aprender-train/src/autograd/cuda_forward/matmul.rs
@@ -16,6 +16,25 @@ use crate::autograd::cuda_tensor::{CudaTensorError, Result};
 #[cfg(feature = "cuda")]
 use super::cache::FORWARD_KERNEL_CACHE;
 
+/// Bind a cuBLAS handle to the caller's stream before dispatching a GEMM.
+///
+/// FALSIFY-CUDA-NF4-FORWARD-NAN-001 (cuda-nf4-forward-stream-ordering-v1):
+/// a fresh cuBLAS handle issues its GEMMs on the legacy DEFAULT stream, and a
+/// `CU_STREAM_NON_BLOCKING` trainer stream never implicitly synchronizes with
+/// it — so an unbound GEMM races the PTX producer/consumer kernels around it
+/// (rmsnorm→QKV, softmax→scores@V, final-norm→lm_head), yielding NaN losses
+/// on the FIRST QLoRA training step. Binding per call (instead of bind-once
+/// at trainer construction) also keeps the process-global handle off
+/// DESTROYED streams after a trainer drops. `cublasSetStream_v2` is a handle
+/// field write (~100ns) — negligible next to any GEMM. Callers hold the
+/// kernel-cache mutex, so bind+launch is atomic across threads.
+#[cfg(feature = "cuda")]
+pub(crate) fn bind_cublas_stream(cublas: &CublasHandle, stream: &CudaStream) -> Result<()> {
+    cublas
+        .set_stream(stream)
+        .map_err(|e| CudaTensorError::KernelError(format!("cuBLAS set_stream failed: {e:?}")))
+}
+
 /// Fused SwiGLU forward pass on GPU (ENT-150)
 ///
 /// Computes: output = SiLU(gate) * up
@@ -88,6 +107,7 @@ pub fn gemm_forward(
         CudaTensorError::KernelError("Failed to acquire kernel cache lock".to_string())
     })?;
     if let Some(cublas) = cache.cublas() {
+        bind_cublas_stream(cublas, stream)?;
         return cublas_gemm_forward(cublas, a, b, c, m, k, n);
     }
 
@@ -147,11 +167,12 @@ pub fn gemm_forward_bt(
     m: u32,
     k: u32,
     n: u32,
-    _stream: &CudaStream,
+    stream: &CudaStream,
 ) -> Result<()> {
     let cache = FORWARD_KERNEL_CACHE.get().ok_or(CudaTensorError::DeviceNotInitialized)?;
     let cache = cache.lock().map_err(|_| CudaTensorError::KernelError("cache lock".to_string()))?;
     if let Some(cublas) = cache.cublas() {
+        bind_cublas_stream(cublas, stream)?;
         return cublas_gemm_forward_bt(cublas, a, b, c, m, k, n);
     }
     Err(CudaTensorError::KernelError("gemm_forward_bt requires cuBLAS".to_string()))
@@ -344,6 +365,7 @@ pub fn batched_4d_gemm_forward(
 
     // ALB-075 Phase 4: cuBLAS strided batched GEMM for attention (16x faster than PTX)
     if let Some(cublas) = cache.cublas() {
+        bind_cublas_stream(cublas, stream)?;
         let batch_count = (batch * heads) as i32;
         let stride_a = i64::from(m) * i64::from(k);
         let stride_b = i64::from(k) * i64::from(n);
@@ -852,8 +874,6 @@ pub fn gemm_nf4_dequant_cublas(
     n: u32,
     stream: &CudaStream,
 ) -> Result<()> {
-    let _ = stream; // cuBLAS uses its own stream (set via set_forward_cublas_stream)
-
     let cache = FORWARD_KERNEL_CACHE.get().ok_or(CudaTensorError::DeviceNotInitialized)?;
     let cache = cache.lock().map_err(|_err| {
         CudaTensorError::KernelError("Failed to acquire kernel cache lock".to_string())
@@ -862,6 +882,7 @@ pub fn gemm_nf4_dequant_cublas(
     let cublas = cache.cublas().ok_or_else(|| {
         CudaTensorError::KernelError("cuBLAS not available for NF4 dequant GEMM".to_string())
     })?;
+    bind_cublas_stream(cublas, stream)?;
 
     // C[M,N] = A[M,K] @ W[N,K]^T
     // col-major: C_cm[N,M] = W_cm_transposed[N,K] @ A_cm[K,M]
@@ -925,8 +946,6 @@ pub fn gemm_nf4_backward_a_cublas(
     n: u32,
     stream: &CudaStream,
 ) -> Result<()> {
-    let _ = stream; // cuBLAS uses its own stream (set via set_forward_cublas_stream)
-
     let cache = FORWARD_KERNEL_CACHE.get().ok_or(CudaTensorError::DeviceNotInitialized)?;
     let cache = cache.lock().map_err(|_err| {
         CudaTensorError::KernelError("Failed to acquire kernel cache lock".to_string())
@@ -935,6 +954,7 @@ pub fn gemm_nf4_backward_a_cublas(
     let cublas = cache.cublas().ok_or_else(|| {
         CudaTensorError::KernelError("cuBLAS not available for NF4 backward GEMM".to_string())
     })?;
+    bind_cublas_stream(cublas, stream)?;
 
     // grad_in[M,K] = grad_out[M,N] @ W[N,K]
     // col-major: C_cm[K,M] = W_cm[K,N] @ A_cm[N,M]

--- a/crates/aprender-train/src/autograd/cuda_forward/matmul_f16.rs
+++ b/crates/aprender-train/src/autograd/cuda_forward/matmul_f16.rs
@@ -48,7 +48,7 @@ pub fn gemm_forward_f16(
     let cublas = cache.cublas().ok_or_else(|| {
         CudaTensorError::KernelError("cuBLAS handle required for fp16 GEMM".to_string())
     })?;
-    let _ = stream; // cuBLAS handle already bound to stream
+    super::matmul::bind_cublas_stream(cublas, stream)?;
     cublas
         .gemm_f16(
             GemmOp::NoTrans,
@@ -160,7 +160,7 @@ pub fn gemm_f16_to_f32_backward_a(
     let cublas = cache.cublas().ok_or_else(|| {
         CudaTensorError::KernelError("cuBLAS handle required for fp16→fp32 backward".to_string())
     })?;
-    let _ = stream;
+    super::matmul::bind_cublas_stream(cublas, stream)?;
     cublas
         .gemm_f16_to_f32(
             GemmOp::Trans,
@@ -206,7 +206,7 @@ pub fn gemm_f16_to_f32_forward(
     let cublas = cache.cublas().ok_or_else(|| {
         CudaTensorError::KernelError("cuBLAS handle required for fp16→fp32 GEMM".to_string())
     })?;
-    let _ = stream;
+    super::matmul::bind_cublas_stream(cublas, stream)?;
     cublas
         .gemm_f16_to_f32(
             GemmOp::NoTrans,

--- a/crates/aprender-train/src/autograd/cuda_forward/mod.rs
+++ b/crates/aprender-train/src/autograd/cuda_forward/mod.rs
@@ -63,7 +63,8 @@ pub use matmul::{
 };
 #[cfg(feature = "cuda")]
 pub(crate) use matmul::{
-    cublas_gemm_backward_a, cublas_gemm_backward_a_accumulate, cublas_gemm_backward_b,
+    bind_cublas_stream, cublas_gemm_backward_a, cublas_gemm_backward_a_accumulate,
+    cublas_gemm_backward_b,
 };
 #[cfg(feature = "cuda")]
 pub use matmul::{gemm_nf4_backward_a_cublas, gemm_nf4_dequant_cublas};

--- a/crates/aprender-train/src/autograd/cuda_training.rs
+++ b/crates/aprender-train/src/autograd/cuda_training.rs
@@ -75,6 +75,12 @@ impl CudaTrainer {
         init_kernel_cache(ctx.clone())?;
         init_optim_kernel_cache(ctx.clone())?;
 
+        // FALSIFY-CUDA-NF4-FORWARD-NAN-001: no bind-once cuBLAS stream setup
+        // here. Every cuBLAS dispatch site binds the handle to the CALLER's
+        // stream per call (see cuda_forward::bind_cublas_stream) — a global
+        // bind-once would dangle when the owning trainer (and its stream)
+        // drops while the process-global handle lives on.
+
         Ok(Self { ctx, stream, step: 0 })
     }
 
@@ -290,6 +296,93 @@ mod tests {
         let trainer = trainer.expect("operation should succeed");
         assert!(!trainer.device_name().is_empty());
         assert!(trainer.total_memory() > 0);
+    }
+
+    /// FALSIFY-CUDA-NF4-FORWARD-NAN-001
+    /// (contract: cuda-nf4-forward-stream-ordering-v1.yaml)
+    ///
+    /// Cross-stream ordering oracle: PTX kernels enqueue on the trainer's
+    /// CU_STREAM_NON_BLOCKING stream while cuBLAS GEMMs execute on whatever
+    /// stream the handle is bound to. Every cuBLAS dispatch site MUST bind
+    /// the handle to the caller's stream (`bind_cublas_stream`); otherwise
+    /// cuBLAS runs on the legacy default stream, which a non-blocking
+    /// stream does NOT implicitly synchronize with — the GEMM reads its
+    /// input while the producer kernels are still writing it.
+    ///
+    /// This is the root cause of the `apr finetune -m qlora` NaN-loss
+    /// defect: rmsnorm→QKV-GEMM, softmax→scores@V and final-norm→lm_head
+    /// all raced, producing NaN on the FIRST training step (~all steps at
+    /// seq≥512, ~1/3 at seq~30). The oracle below makes the race
+    /// deterministic: a ~20ms chain of elementwise adds on the trainer
+    /// stream produces X = 1+STEPS everywhere; the cuBLAS row-sum GEMM
+    /// issued right behind it reads X mid-chain when unbound (RED) and
+    /// the exact final value when bound (GREEN).
+    ///
+    /// Skips (passes vacuously) when CUDA or cuBLAS is unavailable —
+    /// without cuBLAS `gemm_forward` falls back to a PTX kernel on the
+    /// trainer stream and no cross-stream boundary exists.
+    #[test]
+    #[cfg(feature = "cuda")]
+    fn falsify_cuda_nf4_forward_nan_001_cublas_stream_ordering() {
+        use crate::autograd::cuda_forward::{gemm_forward, residual_add_forward};
+
+        if !cuda_training_available() {
+            return;
+        }
+        let trainer = CudaTrainer::new().expect("CUDA trainer");
+        let stream = trainer.stream();
+
+        const DIM: usize = 4096;
+        const STEPS: usize = 100; // ~20ms of producer work on the trainer stream
+        let n = DIM * DIM;
+
+        let mut buf_x = trainer.upload(&vec![1.0f32; n]).expect("upload x");
+        let mut buf_y = trainer.zeros(n).expect("alloc y");
+        let delta = trainer.upload(&vec![1.0f32; n]).expect("upload delta");
+        let ones_col = trainer.upload(&vec![1.0f32; DIM]).expect("upload ones");
+        let mut out = trainer.zeros(DIM).expect("alloc out");
+
+        // Pre-warm cuBLAS + the PTX add kernel OUTSIDE the timed race:
+        // the first SGEMM per handle pays lazy kernel-selection cost
+        // (tens of ms host-side) that would otherwise let the producer
+        // chain drain before the consumer is even issued, masking the
+        // missing stream binding. Quiesce both streams afterwards.
+        gemm_forward(&buf_x, &ones_col, &mut out, DIM as u32, DIM as u32, 1, stream)
+            .expect("cuBLAS warm-up gemm");
+        residual_add_forward(&buf_x, &delta, &mut buf_y, n as u32, stream).expect("warm-up add");
+        trainer.synchronize().expect("trainer stream quiesce");
+        let _ = trainer.download(&out).expect("NULL stream quiesce");
+        // Reset X to 1.0 after warm-up (buf_y holds warm-up garbage; the
+        // chain below overwrites it on the first iteration).
+        buf_x.copy_from_host(&vec![1.0f32; n]).expect("reset x");
+
+        // Producer chain on the trainer stream: X ends as (1 + STEPS) everywhere.
+        for _ in 0..STEPS {
+            residual_add_forward(&buf_x, &delta, &mut buf_y, n as u32, stream)
+                .expect("residual add");
+            std::mem::swap(&mut buf_x, &mut buf_y);
+        }
+
+        // Consumer: cuBLAS row-sum GEMM, out[DIM,1] = X[DIM,DIM] @ ones[DIM,1].
+        // Issued from the host immediately — if the handle is unbound this
+        // overlaps the still-running add chain on the default stream.
+        gemm_forward(&buf_x, &ones_col, &mut out, DIM as u32, DIM as u32, 1, stream)
+            .expect("cuBLAS gemm");
+
+        trainer.synchronize().expect("stream sync");
+        let result = trainer.download(&out).expect("download out");
+
+        let expected = (1.0 + STEPS as f32) * DIM as f32; // 413,696
+        let worst = result.iter().fold(0.0f32, |acc, &v| acc.max((v - expected).abs()));
+        assert!(
+            worst <= expected * 1e-3,
+            "FALSIFY-CUDA-NF4-FORWARD-NAN-001: cuBLAS GEMM read the activation \
+             matrix while the producer stream was still writing it \
+             (worst |Δ|={worst}, expected {expected}). The cuBLAS handle is not \
+             bound to the caller's CU_STREAM_NON_BLOCKING stream — restore the \
+             per-call bind_cublas_stream() at the cuBLAS dispatch sites \
+             (cuda_forward::matmul / matmul_f16, cuda_backward::gemm)."
+        );
     }
 
     #[test]

--- a/crates/aprender-train/src/finetune/instruct_pipeline/cuda_forward.rs
+++ b/crates/aprender-train/src/finetune/instruct_pipeline/cuda_forward.rs
@@ -35,6 +35,13 @@ impl InstructPipeline {
         let hidden_data = hidden.data();
         let hidden_slice = hidden_data.as_slice().expect("contiguous hidden");
 
+        if crate::transformer::cuda_block::nan_scan_enabled() {
+            let bad = hidden_slice.iter().filter(|v| !v.is_finite()).count();
+            if bad > 0 {
+                eprintln!("[NAN-SCAN] embed (CPU): {bad}/{} non-finite", hidden_slice.len());
+            }
+        }
+
         // PMAT-420 / entrenar#316: Use seq_len-sized fresh buffers (like inference forward).
         training_state.fwd_scratch_a = trainer
             .upload(hidden_slice)
@@ -119,10 +126,20 @@ impl InstructPipeline {
                     }
                 };
 
-                training_state.layer_inputs[i]
-                    .copy_from_buffer(gpu_input)
-                    .map_err(|e| eprintln!("[CUDA] layer_input copy L{i}: {e}"))
-                    .ok()?;
+                // FALSIFY-CUDA-NF4-FORWARD-NAN-001: stream-ordered D2D copy.
+                // The sync `copy_from_buffer` (cuMemcpyDtoD) issues on the
+                // legacy default stream, which does NOT wait for this
+                // CU_STREAM_NON_BLOCKING stream — it can snapshot gpu_input
+                // before the previous layer finished writing it.
+                // SAFETY: both buffers outlive the stream-ordered copy
+                // (training_state and the ping-pong scratch live for the
+                // whole step); subsequent use is on the same stream.
+                unsafe {
+                    training_state.layer_inputs[i]
+                        .copy_from_buffer_async(gpu_input, stream)
+                        .map_err(|e| eprintln!("[CUDA] layer_input copy L{i}: {e}"))
+                        .ok()?;
+                }
 
                 // PMAT-483: Per-layer forward profiling
                 training_state.profiler_layer_start = Some(std::time::Instant::now());
@@ -188,11 +205,16 @@ impl InstructPipeline {
                 .map_err(|e| eprintln!("[CUDA] blocks_output realloc failed: {e}"))
                 .ok()?;
         }
-        training_state
-            .blocks_output
-            .copy_from_buffer(final_output)
-            .map_err(|e| eprintln!("[CUDA] blocks_output copy: {e}"))
-            .ok()?;
+        // FALSIFY-CUDA-NF4-FORWARD-NAN-001: stream-ordered D2D copy (see above).
+        // SAFETY: both buffers outlive the stream-ordered copy; subsequent
+        // reads (RMSNorm backward) run on the same stream.
+        unsafe {
+            training_state
+                .blocks_output
+                .copy_from_buffer_async(final_output, stream)
+                .map_err(|e| eprintln!("[CUDA] blocks_output copy: {e}"))
+                .ok()?;
+        }
 
         crate::autograd::cuda_backward::rms_norm_forward(
             final_output,
@@ -204,6 +226,13 @@ impl InstructPipeline {
         )
         .map_err(|e| eprintln!("[CUDA] GPU RMSNorm forward failed: {e}"))
         .ok()?;
+
+        crate::transformer::cuda_block::nan_scan_f32(
+            "final-norm",
+            &training_state.lm_head_hidden_buf,
+            seq_len * hidden_size,
+            stream,
+        );
 
         Some(())
     }
@@ -501,6 +530,13 @@ impl InstructPipeline {
             eprintln!("[RES-FALSE] BT GEMM failed");
             return false;
         }
+
+        crate::transformer::cuda_block::nan_scan_f32(
+            "lm-head-logits",
+            &training.logits_buf,
+            seq_len * vocab_size,
+            stream,
+        );
 
         true
     }

--- a/crates/aprender-train/src/transformer/cuda_block.rs
+++ b/crates/aprender-train/src/transformer/cuda_block.rs
@@ -72,6 +72,50 @@ fn leak<T>(val: T) {
     let _ = std::mem::ManuallyDrop::new(val);
 }
 
+/// APR_NAN_SCAN=1: env-gated per-op NaN/Inf bisection for the CUDA forward.
+///
+/// Diagnostic only — synchronizes the stream and downloads buffers, so it is
+/// slow. Do NOT combine with CUDA_GRAPH=1 (sync inside capture is invalid).
+#[cfg(feature = "cuda")]
+#[inline]
+pub(crate) fn nan_scan_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var("APR_NAN_SCAN").as_deref() == Ok("1"))
+}
+
+/// Download the first `n` elements of `buf` and report non-finite values.
+/// Returns the non-finite count (0 when APR_NAN_SCAN is unset).
+#[cfg(feature = "cuda")]
+pub(crate) fn nan_scan_f32(
+    tag: &str,
+    buf: &GpuBuffer<f32>,
+    n: usize,
+    stream: &CudaStream,
+) -> usize {
+    if !nan_scan_enabled() {
+        return 0;
+    }
+    if let Err(e) = stream.synchronize() {
+        eprintln!("[NAN-SCAN] {tag}: sync failed: {e:?}");
+        return 0;
+    }
+    let n = n.min(buf.len());
+    let mut host = vec![0.0f32; n];
+    if let Err(e) = buf.copy_to_host(&mut host) {
+        eprintln!("[NAN-SCAN] {tag}: download failed: {e:?}");
+        return 0;
+    }
+    let bad = host.iter().filter(|v| !v.is_finite()).count();
+    if bad > 0 {
+        let first_idx = host.iter().position(|v| !v.is_finite()).unwrap_or(0);
+        eprintln!(
+            "[NAN-SCAN] {tag}: {bad}/{n} non-finite (first at [{first_idx}]={})",
+            host[first_idx]
+        );
+    }
+    bad
+}
+
 #[cfg(feature = "cuda")]
 use trueno_gpu::driver::{CudaContext, CudaStream, GpuBuffer};
 
@@ -3128,6 +3172,12 @@ impl CudaNf4TransformerBlock {
         )?;
         scratch.op_end(_t, OP_RMSNORM_ATTN);
 
+        if nan_scan_enabled() {
+            let l = self.layer_idx;
+            nan_scan_f32(&format!("L{l} input"), input, seq_len * hidden_size, stream);
+            nan_scan_f32(&format!("L{l} norm1"), &scratch.norm1_out, seq_len * hidden_size, stream);
+        }
+
         // === Q, K, V Projections ===
         // Backend selection:
         //   FP16_GEMM=1: fp16 tensor core GEMM (Tier 2 parity, 2x BW savings)
@@ -3226,10 +3276,22 @@ impl CudaNf4TransformerBlock {
             cuda_add_inplace(&mut scratch.v, &scratch.lora_temp, seq_len * kv_hidden_size, stream)?;
         }
 
+        if nan_scan_enabled() {
+            let l = self.layer_idx;
+            nan_scan_f32(&format!("L{l} q-proj"), &scratch.q, seq_len * q_dim, stream);
+            nan_scan_f32(&format!("L{l} k-proj"), &scratch.k, seq_len * kv_hidden_size, stream);
+            nan_scan_f32(&format!("L{l} v-proj"), &scratch.v, seq_len * kv_hidden_size, stream);
+        }
+
         // === Multi-Head Attention (GPU-only, zero CPU transfers) ===
         let _t = scratch.op_begin();
         self.compute_attention_cuda(seq_len, stream, scratch)?;
         scratch.op_end(_t, OP_ATTENTION);
+
+        if nan_scan_enabled() {
+            let l = self.layer_idx;
+            nan_scan_f32(&format!("L{l} attn-out"), &scratch.attn_out, seq_len * q_dim, stream);
+        }
 
         // === Output Projection ===
         let _t = scratch.op_begin();
@@ -3254,6 +3316,11 @@ impl CudaNf4TransformerBlock {
 
         scratch.op_end(_t, OP_O_PROJ);
 
+        if nan_scan_enabled() {
+            let l = self.layer_idx;
+            nan_scan_f32(&format!("L{l} o-proj"), &scratch.o_proj_out, seq_len * hidden_size, stream);
+        }
+
         // === Fused Residual Add + RMSNorm (entrenar#321: eliminates NaN cascade) ===
         let _t = scratch.op_begin();
         // The separate cuda_add + rms_norm_forward allows activation explosion between
@@ -3272,6 +3339,12 @@ impl CudaNf4TransformerBlock {
         )?;
 
         scratch.op_end(_t, OP_RMSNORM_FFN); // Fused residual + RMSNorm
+
+        if nan_scan_enabled() {
+            let l = self.layer_idx;
+            nan_scan_f32(&format!("L{l} residual1"), &scratch.residual1, seq_len * hidden_size, stream);
+            nan_scan_f32(&format!("L{l} norm2"), &scratch.norm2_out, seq_len * hidden_size, stream);
+        }
 
         // === FFN: Gate + Up + SwiGLU + Down ===
         let _t = scratch.op_begin(); // Gate+Up GEMM timing
@@ -3310,11 +3383,22 @@ impl CudaNf4TransformerBlock {
 
         scratch.op_end(_t, OP_GATE_UP_GEMM);
 
+        if nan_scan_enabled() {
+            let l = self.layer_idx;
+            nan_scan_f32(&format!("L{l} gate"), &scratch.gate_out, seq_len * intermediate_size, stream);
+            nan_scan_f32(&format!("L{l} up"), &scratch.up_out, seq_len * intermediate_size, stream);
+        }
+
         // === FFN: Fused SwiGLU ===
         let _t = scratch.op_begin();
         fused_swiglu_forward(&scratch.gate_out, &scratch.up_out, &mut scratch.swiglu_out,
             saturating_u32(seq_len * intermediate_size), stream)?;
         scratch.op_end(_t, OP_SILU);
+
+        if nan_scan_enabled() {
+            let l = self.layer_idx;
+            nan_scan_f32(&format!("L{l} swiglu"), &scratch.swiglu_out, seq_len * intermediate_size, stream);
+        }
 
         // === FFN: Down Projection ===
         let _t = scratch.op_begin();
@@ -3339,8 +3423,18 @@ impl CudaNf4TransformerBlock {
 
         scratch.op_end(_t, OP_DOWN_GEMM);
 
+        if nan_scan_enabled() {
+            let l = self.layer_idx;
+            nan_scan_f32(&format!("L{l} down"), &scratch.ffn_out, seq_len * hidden_size, stream);
+        }
+
         // === Final Residual Add ===
         cuda_add(&scratch.residual1, &scratch.ffn_out, output, seq_len * hidden_size, stream)?;
+
+        if nan_scan_enabled() {
+            let l = self.layer_idx;
+            nan_scan_f32(&format!("L{l} block-out"), output, seq_len * hidden_size, stream);
+        }
 
         Ok(())
     }
@@ -3422,6 +3516,22 @@ impl CudaNf4TransformerBlock {
             )?;
         }
 
+        if nan_scan_enabled() {
+            let l = self.layer_idx;
+            nan_scan_f32(
+                &format!("L{l} attn.rope-q"),
+                &scratch.q,
+                seq_len * num_heads * head_dim,
+                stream,
+            );
+            nan_scan_f32(
+                &format!("L{l} attn.rope-k"),
+                &scratch.k,
+                seq_len * num_kv_heads * head_dim,
+                stream,
+            );
+        }
+
         // Q: interleaved → batched layout
         interleaved_to_batched_forward(&scratch.q, &mut scratch.attn_q_batched, s, nh, hd, stream)?;
 
@@ -3474,6 +3584,28 @@ impl CudaNf4TransformerBlock {
             stream,
         )?;
 
+        if nan_scan_enabled() {
+            let l = self.layer_idx;
+            nan_scan_f32(
+                &format!("L{l} attn.q-batched"),
+                &scratch.attn_q_batched,
+                num_heads * seq_len * head_dim,
+                stream,
+            );
+            nan_scan_f32(
+                &format!("L{l} attn.kT"),
+                &scratch.attn_kv_temp,
+                num_heads * seq_len * head_dim,
+                stream,
+            );
+            nan_scan_f32(
+                &format!("L{l} attn.scores-raw"),
+                &scratch.attn_scores,
+                num_heads * seq_len * seq_len,
+                stream,
+            );
+        }
+
         // Scale by 1/sqrt(head_dim)
         let scale_factor = 1.0 / (head_dim as f32).sqrt();
         let total_scores = num_heads * seq_len * seq_len;
@@ -3524,6 +3656,21 @@ impl CudaNf4TransformerBlock {
             }
         }
 
+        if nan_scan_enabled() {
+            let l = self.layer_idx;
+            // -inf from the causal mask is expected here; only NaN is a defect.
+            if stream.synchronize().is_ok() {
+                let n = num_heads * seq_len * seq_len;
+                let mut host = vec![0.0f32; n.min(scratch.attn_scores.len())];
+                if scratch.attn_scores.copy_to_host(&mut host).is_ok() {
+                    let nan = host.iter().filter(|v| v.is_nan()).count();
+                    if nan > 0 {
+                        eprintln!("[NAN-SCAN] L{l} attn.scores-masked: {nan}/{n} NaN");
+                    }
+                }
+            }
+        }
+
         // SAFETY: The softmax kernel reads each row completely into shared memory / registers
         // before writing output. The view is forgotten to prevent double-free.
         let scores_view = unsafe {
@@ -3540,6 +3687,16 @@ impl CudaNf4TransformerBlock {
             stream,
         )?;
         leak(scores_view);
+
+        if nan_scan_enabled() {
+            let l = self.layer_idx;
+            nan_scan_f32(
+                &format!("L{l} attn.softmax"),
+                &scratch.attn_scores,
+                num_heads * seq_len * seq_len,
+                stream,
+            );
+        }
 
         // V: interleaved → batched, then GQA expand
         interleaved_to_batched_forward(&scratch.v, &mut scratch.attn_kv_temp, s, nkv, hd, stream)?;
@@ -3569,6 +3726,16 @@ impl CudaNf4TransformerBlock {
             }
         }
 
+        if nan_scan_enabled() {
+            let l = self.layer_idx;
+            nan_scan_f32(
+                &format!("L{l} attn.v-expanded"),
+                &scratch.attn_kv_temp2,
+                num_heads * seq_len * head_dim,
+                stream,
+            );
+        }
+
         // attn_scores @ V → attention output
         batched_4d_gemm_forward(
             &scratch.attn_scores,
@@ -3581,6 +3748,16 @@ impl CudaNf4TransformerBlock {
             s,
             stream,
         )?;
+
+        if nan_scan_enabled() {
+            let l = self.layer_idx;
+            nan_scan_f32(
+                &format!("L{l} attn.scoresV"),
+                &scratch.attn_q_batched,
+                num_heads * seq_len * head_dim,
+                stream,
+            );
+        }
 
         // Batched → interleaved layout
         batched_to_interleaved_forward(


### PR DESCRIPTION
## Summary

Cascade defect #3 in the qlora-training series (#2249 deadlock → #2250 loss window → this): after those fixes, `apr finetune -m qlora` trained but ~all steps at seq 512–2048 (and ~1/3 at seq ~30) returned **loss=NaN on the first step** — a pure forward defect.

**Root cause: not a kernel-math bug — a cross-stream data race at every PTX↔cuBLAS boundary.** `CudaTrainer::with_device` creates its stream with `CU_STREAM_NON_BLOCKING` (opts out of implicit legacy-stream sync), but the finetune path **never bound the cuBLAS handles to any stream** (binding existed only in the pretraining path). Every cuBLAS GEMM ran on the legacy default stream while rmsnorm/rope/softmax/swiglu PTX kernels ran on the trainer stream — zero producer/consumer ordering. cuBLAS read activations mid-write at rmsnorm→QKV, Q@Kᵀ→softmax, softmax→scores@V, final-norm→lm_head, lm_head→fused-CE. Race window scales with kernel duration → seq-length-dependent NaN rate.

**Heisenbug evidence**: an env-gated per-op NaN scanner (`APR_NAN_SCAN=1`, syncs + downloads after each op) made ALL NaN vanish 3/3 runs — only consistent with a stream-ordering race.

## Fix

- **Per-call cuBLAS stream binding**: `bind_cublas_stream` helper called at all 11 live cuBLAS dispatch sites (`cuda_forward/matmul.rs` ×5, `matmul_f16.rs` ×3, `cuda_backward/gemm.rs` ×3). Bind+launch is atomic under the existing kernel-cache mutex; ~100ns/GEMM. (Bind-once-at-construction was tried and rejected: it fixes the NaN but SIGSEGVs the suite — the global handle dangles on a destroyed stream after trainer drop. Per-call binding is the invariant: cuBLAS runs on the stream you pass, which is alive by construction.)
- **Stream-ordered D2D copies** for `layer_inputs`/`blocks_output` backward snapshots (were NULL-stream `cuMemcpyDtoD` — same race class).
- `APR_NAN_SCAN=1` per-op non-finite scanner kept, env-gated, as a permanent diagnostic.

## Verification (RTX 4090, sm_89)

- Falsifier `FALSIFY-CUDA-NF4-FORWARD-NAN-001`: cuBLAS pre-warm + 100-kernel PTX chain (4096², ~20ms) on the trainer stream + cuBLAS row-sum GEMM issued right behind it; exact oracle 101×4096. **Mutation-verified**: bind removed → RED (`worst |Δ|=401408` — the GEMM saw the chain at ~3% progress); fix → GREEN exact, 3/3. Re-verified GREEN on this cherry-picked branch (0.44s).
- Contract `contracts/cuda-nf4-forward-stream-ordering-v1.yaml` — `pv lint contracts/` PASS.
- E2E: toy 3-sample 3/3 runs 0 NaN; `apr_code_sft_balanced` @ `--max-seq-len 2048`: **16/16 finite** losses (pre-fix baseline same data: 15/16 NaN).
- Full crate `--features cuda`: 7701 pass; 5 failures reproduce on baseline (pre-existing: bf16 ptxas env, prune insta snapshots).

Known follow-on (separate beat, already under investigation): losses are finite but **wrong in magnitude** (CE ≈ ln(V)+2 on trivial targets) — the GPU training forward/loss has a remaining correctness defect that this PR does not claim to fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)