### PR TITLE
fix(train): NF4 QLoRA CUDA forward computed the WRONG MODEL — NeoX rope pairing + Q/K/V biases + full-warp softmax + causal CPU oracle

### DIFF
--- a/contracts/cuda-nf4-train-loss-parity-v1.yaml
+++ b/contracts/cuda-nf4-train-loss-parity-v1.yaml
@@ -1,0 +1,225 @@
+metadata:
+  id: C-CUDA-NF4-TRAIN-LOSS-PARITY
+  version: 1.0.0
+  created: '2026-07-02'
+  author: PAIML Engineering
+  kind: pattern
+  status: ACTIVE_ALGORITHM_LEVEL
+  description: |
+    Pins functional parity between the NF4 QLoRA CUDA training forward
+    (CudaNf4TransformerBlock path + GPU-resident lm_head/fused causal CE)
+    and a quantization-matched CPU oracle: on the same tokens the GPU
+    training loss must equal the CPU loss computed through NF4-round-
+    tripped weights within tolerance, and the full [seq, vocab] logits
+    must agree within NF4 noise.
+
+    BACKGROUND (cascade defect #4). After the stream-ordering fix
+    (cuda-nf4-forward-stream-ordering-v1) `apr finetune -m qlora`
+    trained end-to-end but the loss sat FLAT at CE 13-14 — ABOVE
+    ln(151936)=11.93, i.e. worse than a uniform distribution — on
+    apr-code SFT data whose responses the base model emits correctly in
+    inference, and on trivial toy data ("What is 2+2?" -> "4"). After
+    ~125 optimizer steps at lr 2e-4/rank 256 the garbage gradients blew
+    the adapters into permanent NaN. The forward was FINITE but WRONG.
+
+    ROOT CAUSES (oracle-based bisection: pure-CPU CE vs GPU-forward+CPU-CE
+    vs GPU-forward+fused-GPU-CE localized the defect to the transformer
+    forward; per-op layer-0 bisection against a manual CPU replay
+    localized the ops). FOUR stacked defects:
+
+    1. WRONG ROPE PAIRING (dominant). entrenar's batched_rope_neox_forward
+       / _backward wrappers (ALB-119 batched launch) instantiated
+       BatchedRopeKernel, which rotates ADJACENT pairs (2i, 2i+1) — the
+       GPT-J convention that realizar reserves for non-NeoX rope types.
+       Qwen2/LLaMA weights require NEOX split-half pairs (i, i+d/2)
+       (CORRECTNESS-011), which the CPU apply_rope and realizar use.
+       Every layer's Q/K were rotated in the wrong basis: post-rope Q/K
+       relL2 vs oracle = 0.42/0.65 while un-roped V matched at 0.09
+       (pure quant noise). Fix: new BatchedRopeNeoxKernel /
+       BatchedRopeNeoxBackwardKernel (precise trig, CORRECTNESS-013)
+       wired into the wrappers; BatchedRopeKernel semantics preserved
+       for realizar's non-NeoX consumers.
+
+    2. DROPPED Q/K/V BIASES. CudaNf4TransformerBlock never received or
+       applied the attention projection biases (Qwen2 use_bias=true;
+       blk.N.attn_{q,k,v}.bias exist in the model and the CPU path adds
+       them). The FP32 block had bias support since
+       FALSIFY-CUDA-FORWARD-PARITY-002 but the instruct init site passed
+       None and the NF4 block had no bias fields at all. Dropping them
+       alone shifts toy causal CE 2.13 -> 4.49. Fix: replicated bias
+       buffers + cuda_add_inplace after each projection GEMM (before
+       QK-norm/RoPE, matching CPU order), threaded from all three NF4
+       construction sites and the instruct FP32 site.
+
+    3. PARTIAL-WARP SHFL UB IN SOFTMAX. batched_softmax_forward (and the
+       softmax backward wrappers) launched block=(32.min(row_size)); the
+       kernels' max/sum reductions use shfl.sync with membermask
+       0xFFFFFFFF, which is UNDEFINED when named lanes are inactive
+       (PTX ISA). For seq < 32 the row max/sum picked up garbage data-
+       dependently -> exp(x - garbage) rows summing to 0 -> 0/0 = NaN.
+       Surfaced the moment defects 1-2 were fixed (bias-included scores
+       changed register contents). Fix: always launch a FULL 32-lane
+       warp — the per-lane loops already guard i < row_size and idle
+       lanes carry the reduction identities (-inf/0.0).
+
+    4. NON-CAUSAL CPU ORACLE (label leakage). autograd::ops::attention
+       applied NO causal mask — softmax over ALL positions. The CPU
+       train/eval path for decoder-only models attended bidirectionally,
+       leaking future (label) tokens backwards: toy causal CE is 2.13,
+       but the leaky CPU forward reported 0.17. This both corrupted the
+       CPU training/eval path (deceptively low losses, wrong gradients)
+       and masked GPU defects during comparison. Fix: attention_causal
+       (masked scores, shared softmax backward — masked weights are
+       exactly 0 so the gradient math is unchanged) selected for
+       ModelArchitecture::Decoder; encoders (BERT/RoBERTa) remain
+       bidirectional.
+
+    RED-then-GREEN (live on RTX 4090, sm_89, Qwen2.5-Coder-1.5B q4k):
+      RED  (pre-fix): GPU toy loss 6.54 vs causal-CPU 2.13 / NF4-CPU
+           oracle 0.66; production runs flat at CE 13-14 then NaN.
+      GREEN (post-fix): GPU fused loss 0.6820 vs NF4-matched CPU oracle
+           0.6557 (|delta| = 0.026 < 0.5); fused GPU CE vs CPU CE on the
+           SAME logits |delta| = 0.0005; full-logits relL2 = 0.047.
+      MUTATION-VERIFIED (each fix reverted individually -> RED):
+        rope revert    -> logits relL2 0.183 (> 0.10)   RED
+        bias drop      -> loss 5.17 vs 0.66, relL2 0.97 RED
+        partial warp   -> fused loss NaN                RED
+
+  references:
+    - 'crates/aprender-gpu/src/kernels/elementwise/rope/neox.rs (BatchedRopeNeoxKernel + BatchedRopeNeoxBackwardKernel)'
+    - 'crates/aprender-train/src/autograd/cuda_forward/normalization.rs (batched_rope_neox_forward/_backward rewired to NEOX kernels)'
+    - 'crates/aprender-train/src/autograd/cuda_forward/cache.rs (pre-warm keys track the NEOX kernels)'
+    - 'crates/aprender-train/src/transformer/cuda_block.rs (NF4 b_q/b_k/b_v replicated buffers + forward bias adds)'
+    - 'crates/aprender-train/src/finetune/instruct_pipeline/cuda_init.rs (bias threading, NF4 + FP32 sites)'
+    - 'crates/aprender-train/src/finetune/classify_pipeline/gpu.rs (bias threading)'
+    - 'crates/aprender-train/src/train/transformer_trainer/cuda_trainer.rs (bias threading)'
+    - 'crates/aprender-train/src/autograd/cuda_forward/activations.rs (full-warp batched softmax launch)'
+    - 'crates/aprender-train/src/autograd/cuda_backward/structured.rs (full-warp softmax backward launches)'
+    - 'crates/aprender-train/src/autograd/ops/attention.rs (attention_causal)'
+    - 'crates/aprender-train/src/transformer/attention.rs (Decoder -> attention_causal dispatch)'
+    - 'crates/aprender-train/src/finetune/instruct_pipeline/parity_probe.rs (falsifier + layer bisect probes)'
+    - 'crates/aprender-train/src/transformer/cuda_block_parity_probe.rs (per-op layer-0 bisect probe)'
+  depends_on:
+    - 'cuda-nf4-forward-stream-ordering-v1'
+
+equations:
+  gpu_cpu_loss_parity:
+    formula: |
+      |CE_gpu(x) - CE_cpu_nf4(x)| < 0.5  ∧  CE_gpu(x_toy) < 6.0
+      where CE_cpu_nf4 uses dequantize_nf4(quantize_nf4(W)) weights
+    domain: |
+      Same tokens, same loss window, LoRA B = 0 (base model). The CPU
+      oracle round-trips every projection weight through the SAME NF4
+      quantizer the GPU blocks use, so quantization noise is common to
+      both sides and any residual gap is STRUCTURAL (rope convention,
+      biases, masking, reductions, layout).
+    invariants:
+    - 'GPU training loss within 0.5 nats of the NF4-matched causal CPU oracle'
+    - 'toy-sample CE far below ln(vocab): a finite-garbage forward cannot hide'
+    - 'fused GPU causal CE equals CPU CE on identical logits within 0.05'
+    preconditions:
+    - 'cuda-nf4-forward-stream-ordering-v1 holds (finite forward)'
+
+  gpu_cpu_logits_parity:
+    formula: |
+      relL2(logits_gpu, logits_cpu_nf4) < 0.10 over the full [seq, vocab]
+    domain: |
+      The scalar loss on a short response window is too weak to falsify
+      every structural defect (a consistently-wrong rope pairing moved
+      toy CE by only ~0.05 nats). The full logits compare the ENTIRE
+      function surface: rope mutation -> 0.183, bias drop -> 0.97,
+      correct -> 0.047.
+    invariants:
+    - 'full-logits relL2 vs the NF4-matched CPU oracle below 0.10'
+    preconditions:
+    - 'gpu_cpu_loss_parity preconditions hold'
+
+  decoder_attention_causality:
+    formula: |
+      ∀ decoder model, positions i, j:  j > i ⇒ attn_weight[i][j] = 0
+    domain: |
+      Causal LM training and evaluation. The CPU tape attention
+      (autograd::ops::attention) must mask future positions for
+      ModelArchitecture::Decoder; encoder models remain bidirectional.
+      Unmasked decoder attention leaks label tokens backwards, reporting
+      deceptively low train/val losses and mis-training adapters.
+    invariants:
+    - 'CPU decoder forward attends only to j <= i (attention_causal)'
+    - 'masked positions carry exactly 0 weight, so the shared softmax backward is unchanged'
+    - 'encoder (BERT/RoBERTa) paths keep bidirectional attention'
+    preconditions:
+    - 'model config architecture is Decoder'
+
+proof_obligations:
+- type: invariant
+  property: GPU training loss matches the NF4-matched CPU oracle within 0.5 nats
+  formal: '|CE_gpu(x) - CE_cpu_nf4(x)| < 0.5'
+  applies_to: gpu_cpu_loss_parity
+- type: invariant
+  property: GPU logits match the NF4-matched CPU oracle within relL2 0.10
+  formal: 'relL2(logits_gpu, logits_cpu_nf4) < 0.10'
+  applies_to: gpu_cpu_logits_parity
+- type: invariant
+  property: fused GPU causal CE equals CPU CE on identical logits
+  formal: '|CE_fused(logits) - CE_cpu(logits)| < 0.05'
+  applies_to: gpu_cpu_loss_parity
+- type: invariant
+  property: decoder CPU attention is causal
+  formal: '∀ i, j > i: softmax_row_i[j] = 0'
+  applies_to: decoder_attention_causality
+
+falsification_tests:
+- id: FALSIFY-CUDA-NF4-TRAIN-LOSS-PARITY-001
+  rule: |
+    On the same tokens (toy instruction sample, LoRA B = 0), the NF4
+    QLoRA GPU training forward + fused causal CE must produce the same
+    loss and logits as a causal CPU forward through NF4-round-tripped
+    weights, within quantization-free tolerances (|dCE| < 0.5, logits
+    relL2 < 0.10, toy CE < 6.0, fused-vs-CPU CE on identical logits
+    < 0.05).
+  prediction: |
+    GREEN (all four fixes): GPU fused CE 0.6820 vs oracle 0.6557,
+    logits relL2 0.047. RED under any single reverted fix (mutation-
+    verified live): GPT-J rope pairing -> relL2 0.183; dropped Q/K/V
+    biases -> CE 5.17 / relL2 0.97; partial-warp softmax launch ->
+    NaN loss. Pre-fix production signature: CE flat at 13-14 (worse
+    than uniform), adapters NaN after ~125 steps. Skips vacuously
+    without a CUDA device or when APR_PARITY_MODEL is unset.
+  test: cargo test -p aprender-train --features cuda --lib falsify_cuda_nf4_train_loss_parity_001
+  if_fails: |
+    The GPU training forward is computing a DIFFERENT FUNCTION than the
+    model being fine-tuned. Bisect with the companion probes:
+    parity_probe_layer_bisect (per-layer, NF4-matched CPU replay) and
+    parity_probe_layer0_per_op (per-op layer-0). Known defect classes:
+    rope pairing convention (NEOX split-half vs GPT-J adjacent — check
+    batched_rope_neox_* wrappers instantiate the *Neox* kernels),
+    dropped Q/K/V projection biases (Qwen2 use_bias), partial-warp
+    shfl.sync launches (block must be a full 32-lane warp), non-causal
+    CPU oracle (decoder must dispatch attention_causal), layout/
+    transpose (LAYOUT-001/002). Do NOT loosen the tolerances: they are
+    calibrated so quantization noise passes and every known structural
+    defect fails.
+  ship_blocking: true
+  counter_example_classes:
+  - rope_pairing_convention_mismatch
+  - qkv_projection_bias_dropped
+  - partial_warp_shfl_sync_undefined
+  - noncausal_decoder_attention_label_leakage
+  - finite_garbage_forward_worse_than_uniform
+
+qa_gate:
+  id: QA-CUDA-NF4-TRAIN-LOSS-PARITY-001
+  name: NF4 QLoRA training forward/loss functional parity gate
+  description: |
+    The falsifier passes on a CUDA host with APR_PARITY_MODEL set: the
+    QLoRA GPU training forward computes the SAME function as the model
+    being fine-tuned (NF4-matched CPU oracle), so training losses start
+    at the model's true CE (~1-4 on apr-code SFT) instead of
+    worse-than-uniform 13-14, gradients are meaningful, and adapters do
+    not blow up. Unblocks apr finetune -m qlora learning (Pillar 3).
+  checks:
+  - gpu_cpu_loss_parity
+  - gpu_cpu_logits_parity
+  - decoder_attention_causality
+  pass_criteria: FALSIFY-CUDA-NF4-TRAIN-LOSS-PARITY-001 passes
+  falsification: Any failure fails the gate (ship-blocking)

--- a/crates/aprender-gpu/src/kernels/elementwise/mod.rs
+++ b/crates/aprender-gpu/src/kernels/elementwise/mod.rs
@@ -68,8 +68,9 @@ pub use residual::{
     ResidualAddKernel,
 };
 pub use rope::{
-    BatchedRopeBackwardKernel, BatchedRopeKernel, PreciseRopeIndirectKernel, PreciseRopeKernel,
-    RopeIndirectKernel, RopeKernel, RopeNeoxIndirectKernel, RopeNeoxKernel,
+    BatchedRopeBackwardKernel, BatchedRopeKernel, BatchedRopeNeoxBackwardKernel,
+    BatchedRopeNeoxKernel, PreciseRopeIndirectKernel, PreciseRopeKernel, RopeIndirectKernel,
+    RopeKernel, RopeNeoxIndirectKernel, RopeNeoxKernel,
 };
 pub use swiglu::{BatchedSwigluKernel, FusedSwigluKernel};
 pub use transform::{

--- a/crates/aprender-gpu/src/kernels/elementwise/rope/mod.rs
+++ b/crates/aprender-gpu/src/kernels/elementwise/rope/mod.rs
@@ -18,7 +18,9 @@ mod precise;
 mod standard;
 
 pub use batched::{BatchedRopeBackwardKernel, BatchedRopeKernel};
-pub use neox::{RopeNeoxIndirectKernel, RopeNeoxKernel};
+pub use neox::{
+    BatchedRopeNeoxBackwardKernel, BatchedRopeNeoxKernel, RopeNeoxIndirectKernel, RopeNeoxKernel,
+};
 pub use precise::{PreciseRopeIndirectKernel, PreciseRopeKernel};
 pub use standard::{RopeIndirectKernel, RopeKernel};
 

--- a/crates/aprender-gpu/src/kernels/elementwise/rope/neox.rs
+++ b/crates/aprender-gpu/src/kernels/elementwise/rope/neox.rs
@@ -117,6 +117,278 @@ impl Kernel for RopeNeoxKernel {
     }
 }
 
+/// Batched RoPE NEOX Kernel: NEOX/half-rotation RoPE over M sequence positions.
+///
+/// FALSIFY-CUDA-NF4-TRAIN-LOSS-PARITY-001: `BatchedRopeKernel` rotates
+/// ADJACENT pairs `(2i, 2i+1)` (GPT-J/standard convention). Qwen2/LLaMA
+/// weights require NEOX split-half pairs `(i, i + head_dim/2)`. The entrenar
+/// QLoRA training forward (ALB-119 batched launch) was wired to the adjacent
+/// -pair kernel, so every layer's Q/K were rotated in the WRONG basis —
+/// finite-garbage attention, CE ≈ 13-14 (worse than uniform) on data the
+/// base model predicts at CE < 1. This kernel is the batched twin of
+/// `RopeNeoxKernel` (CORRECTNESS-011) with positions read from a GPU buffer.
+///
+/// Uses precise polynomial sin/cos (CORRECTNESS-013): theta=1e6 (Qwen2.5)
+/// high-frequency components are sensitive to `sin.approx.f32` error.
+///
+/// # Grid Configuration
+///
+/// - Grid: (num_heads, batch_size, 1)
+/// - Block: (head_dim / 2, 1, 1)
+///
+/// Input layout: `[batch, num_heads * head_dim]` (interleaved rows).
+#[derive(Debug, Clone)]
+pub struct BatchedRopeNeoxKernel {
+    /// Number of heads
+    pub num_heads: u32,
+    /// Head dimension
+    pub head_dim: u32,
+    /// Batch size (M sequence positions)
+    pub batch_size: u32,
+    /// Rope theta base (typically 10000.0 or 1000000.0)
+    pub theta: f32,
+}
+
+impl BatchedRopeNeoxKernel {
+    /// Create a new batched NEOX-style RoPE kernel
+    #[must_use]
+    pub fn new(num_heads: u32, head_dim: u32, batch_size: u32, theta: f32) -> Self {
+        Self {
+            num_heads,
+            head_dim,
+            batch_size,
+            theta,
+        }
+    }
+}
+
+impl Kernel for BatchedRopeNeoxKernel {
+    fn name(&self) -> &str {
+        "batched_rope_neox"
+    }
+
+    fn build_ptx(&self) -> PtxKernel {
+        let head_dim = self.head_dim;
+        let num_heads = self.num_heads;
+        let theta = self.theta;
+        let half_dim = head_dim / 2;
+
+        PtxKernel::new("batched_rope_neox")
+            .param(PtxType::U64, "x_ptr")
+            .param(PtxType::U64, "out_ptr")
+            .param(PtxType::U64, "positions_ptr")
+            .build(move |ctx| {
+                let tid = ctx.special_reg(PtxReg::TidX);
+                let head_idx = ctx.special_reg(PtxReg::CtaIdX);
+                let batch_idx = ctx.special_reg(PtxReg::CtaIdY);
+
+                let x_ptr = ctx.load_param_u64("x_ptr");
+                let out_ptr = ctx.load_param_u64("out_ptr");
+                let positions_ptr = ctx.load_param_u64("positions_ptr");
+
+                let pair_idx = tid;
+
+                let half_dim_reg = ctx.mov_u32_imm(half_dim);
+                let in_bounds = ctx.setp_lt_u32(pair_idx, half_dim_reg);
+                ctx.branch_if_not(in_bounds, "exit");
+
+                let four = ctx.mov_u32_imm(4);
+                let pos_byte_offset = ctx.mul_lo_u32(batch_idx, four);
+                let pos_byte_offset_64 = ctx.cvt_u64_u32(pos_byte_offset);
+                let pos_addr = ctx.add_u64(positions_ptr, pos_byte_offset_64);
+                let pos = ctx.ld_global_u32(pos_addr);
+
+                // NEOX split-half pairing: (i, i + half_dim)
+                let elem0 = pair_idx;
+                let elem1 = ctx.add_u32_reg(pair_idx, half_dim_reg);
+
+                let heads_per_seq = ctx.mov_u32_imm(num_heads);
+                let dim = ctx.mov_u32_imm(head_dim);
+                let seq_stride = ctx.mul_lo_u32(heads_per_seq, dim);
+                let batch_offset = ctx.mul_lo_u32(batch_idx, seq_stride);
+                let head_offset = ctx.mul_lo_u32(head_idx, dim);
+                let base_offset = ctx.add_u32_reg(batch_offset, head_offset);
+                let offset0 = ctx.add_u32_reg(base_offset, elem0);
+                let offset1 = ctx.add_u32_reg(base_offset, elem1);
+
+                let bytes0 = ctx.mul_lo_u32(offset0, four);
+                let bytes1 = ctx.mul_lo_u32(offset1, four);
+                let bytes0_64 = ctx.cvt_u64_u32(bytes0);
+                let bytes1_64 = ctx.cvt_u64_u32(bytes1);
+
+                let addr0 = ctx.add_u64(x_ptr, bytes0_64);
+                let addr1 = ctx.add_u64(x_ptr, bytes1_64);
+                let out_addr0 = ctx.add_u64(out_ptr, bytes0_64);
+                let out_addr1 = ctx.add_u64(out_ptr, bytes1_64);
+
+                let x0 = ctx.ld_global_f32(addr0);
+                let x1 = ctx.ld_global_f32(addr1);
+
+                let pair_f32 = ctx.cvt_f32_u32(pair_idx);
+                let dim_f32 = ctx.mov_f32_imm(head_dim as f32);
+                let neg_two = ctx.mov_f32_imm(-2.0);
+                let exponent = ctx.mul_f32(pair_f32, neg_two);
+                let exponent_scaled = ctx.div_f32(exponent, dim_f32);
+                let log2_theta = ctx.mov_f32_imm(theta.log2());
+                let power = ctx.mul_f32(exponent_scaled, log2_theta);
+                let freq_base = ctx.ex2_f32(power);
+
+                let pos_f32 = ctx.cvt_f32_u32(pos);
+                let angle = ctx.mul_f32(pos_f32, freq_base);
+
+                // CORRECTNESS-013: precise polynomial sin/cos
+                let cos_val = ctx.cos_f32_precise(angle);
+                let sin_val = ctx.sin_f32_precise(angle);
+
+                let x0_cos = ctx.mul_f32(x0, cos_val);
+                let x1_sin = ctx.mul_f32(x1, sin_val);
+                let new_x0 = ctx.sub_f32(x0_cos, x1_sin);
+
+                let x0_sin = ctx.mul_f32(x0, sin_val);
+                let x1_cos = ctx.mul_f32(x1, cos_val);
+                let new_x1 = ctx.add_f32(x0_sin, x1_cos);
+
+                ctx.st_global_f32(out_addr0, new_x0);
+                ctx.st_global_f32(out_addr1, new_x1);
+
+                ctx.label("exit");
+                ctx.ret();
+            })
+    }
+}
+
+/// Batched RoPE NEOX Backward Kernel: inverse (transpose) NEOX rotation.
+///
+/// Twin of [`BatchedRopeNeoxKernel`] applying `R^T(θ) = R(-θ)` so Q/K
+/// projection backward receives gradients in the unrotated frame:
+/// - Forward:  x0' = x0·cos − x1·sin,  x1' = x0·sin + x1·cos
+/// - Backward: x0' = x0·cos + x1·sin,  x1' = x1·cos − x0·sin
+///
+/// # Grid Configuration
+///
+/// - Grid: (num_heads, batch_size, 1)
+/// - Block: (head_dim / 2, 1, 1)
+#[derive(Debug, Clone)]
+pub struct BatchedRopeNeoxBackwardKernel {
+    /// Number of heads
+    pub num_heads: u32,
+    /// Head dimension
+    pub head_dim: u32,
+    /// Batch size (M sequence positions)
+    pub batch_size: u32,
+    /// Rope theta base (typically 10000.0 or 1000000.0)
+    pub theta: f32,
+}
+
+impl BatchedRopeNeoxBackwardKernel {
+    /// Create a new batched NEOX-style RoPE backward kernel
+    #[must_use]
+    pub fn new(num_heads: u32, head_dim: u32, batch_size: u32, theta: f32) -> Self {
+        Self {
+            num_heads,
+            head_dim,
+            batch_size,
+            theta,
+        }
+    }
+}
+
+impl Kernel for BatchedRopeNeoxBackwardKernel {
+    fn name(&self) -> &str {
+        "batched_rope_neox_backward"
+    }
+
+    fn build_ptx(&self) -> PtxKernel {
+        let head_dim = self.head_dim;
+        let num_heads = self.num_heads;
+        let theta = self.theta;
+        let half_dim = head_dim / 2;
+
+        PtxKernel::new("batched_rope_neox_backward")
+            .param(PtxType::U64, "x_ptr")
+            .param(PtxType::U64, "out_ptr")
+            .param(PtxType::U64, "positions_ptr")
+            .build(move |ctx| {
+                let tid = ctx.special_reg(PtxReg::TidX);
+                let head_idx = ctx.special_reg(PtxReg::CtaIdX);
+                let batch_idx = ctx.special_reg(PtxReg::CtaIdY);
+
+                let x_ptr = ctx.load_param_u64("x_ptr");
+                let out_ptr = ctx.load_param_u64("out_ptr");
+                let positions_ptr = ctx.load_param_u64("positions_ptr");
+
+                let pair_idx = tid;
+
+                let half_dim_reg = ctx.mov_u32_imm(half_dim);
+                let in_bounds = ctx.setp_lt_u32(pair_idx, half_dim_reg);
+                ctx.branch_if_not(in_bounds, "exit");
+
+                let four = ctx.mov_u32_imm(4);
+                let pos_byte_offset = ctx.mul_lo_u32(batch_idx, four);
+                let pos_byte_offset_64 = ctx.cvt_u64_u32(pos_byte_offset);
+                let pos_addr = ctx.add_u64(positions_ptr, pos_byte_offset_64);
+                let pos = ctx.ld_global_u32(pos_addr);
+
+                // NEOX split-half pairing: (i, i + half_dim)
+                let elem0 = pair_idx;
+                let elem1 = ctx.add_u32_reg(pair_idx, half_dim_reg);
+
+                let heads_per_seq = ctx.mov_u32_imm(num_heads);
+                let dim = ctx.mov_u32_imm(head_dim);
+                let seq_stride = ctx.mul_lo_u32(heads_per_seq, dim);
+                let batch_offset = ctx.mul_lo_u32(batch_idx, seq_stride);
+                let head_offset = ctx.mul_lo_u32(head_idx, dim);
+                let base_offset = ctx.add_u32_reg(batch_offset, head_offset);
+                let offset0 = ctx.add_u32_reg(base_offset, elem0);
+                let offset1 = ctx.add_u32_reg(base_offset, elem1);
+
+                let bytes0 = ctx.mul_lo_u32(offset0, four);
+                let bytes1 = ctx.mul_lo_u32(offset1, four);
+                let bytes0_64 = ctx.cvt_u64_u32(bytes0);
+                let bytes1_64 = ctx.cvt_u64_u32(bytes1);
+
+                let addr0 = ctx.add_u64(x_ptr, bytes0_64);
+                let addr1 = ctx.add_u64(x_ptr, bytes1_64);
+                let out_addr0 = ctx.add_u64(out_ptr, bytes0_64);
+                let out_addr1 = ctx.add_u64(out_ptr, bytes1_64);
+
+                let x0 = ctx.ld_global_f32(addr0);
+                let x1 = ctx.ld_global_f32(addr1);
+
+                let pair_f32 = ctx.cvt_f32_u32(pair_idx);
+                let dim_f32 = ctx.mov_f32_imm(head_dim as f32);
+                let neg_two = ctx.mov_f32_imm(-2.0);
+                let exponent = ctx.mul_f32(pair_f32, neg_two);
+                let exponent_scaled = ctx.div_f32(exponent, dim_f32);
+                let log2_theta = ctx.mov_f32_imm(theta.log2());
+                let power = ctx.mul_f32(exponent_scaled, log2_theta);
+                let freq_base = ctx.ex2_f32(power);
+
+                let pos_f32 = ctx.cvt_f32_u32(pos);
+                let angle = ctx.mul_f32(pos_f32, freq_base);
+
+                // CORRECTNESS-013: precise polynomial sin/cos
+                let cos_val = ctx.cos_f32_precise(angle);
+                let sin_val = ctx.sin_f32_precise(angle);
+
+                // Inverse rotation: R^T = R(-θ)
+                let x0_cos = ctx.mul_f32(x0, cos_val);
+                let x1_sin = ctx.mul_f32(x1, sin_val);
+                let new_x0 = ctx.add_f32(x0_cos, x1_sin);
+
+                let x0_sin = ctx.mul_f32(x0, sin_val);
+                let x1_cos = ctx.mul_f32(x1, cos_val);
+                let new_x1 = ctx.sub_f32(x1_cos, x0_sin);
+
+                ctx.st_global_f32(out_addr0, new_x0);
+                ctx.st_global_f32(out_addr1, new_x1);
+
+                ctx.label("exit");
+                ctx.ret();
+            })
+    }
+}
+
 /// RoPE NEOX Indirect Kernel: CUDA Graph compatible NEOX-style version
 #[derive(Debug, Clone)]
 pub struct RopeNeoxIndirectKernel {

--- a/crates/aprender-gpu/src/kernels/mod.rs
+++ b/crates/aprender-gpu/src/kernels/mod.rs
@@ -52,6 +52,8 @@ pub use elementwise::{
     BatchedResidualAddKernel,
     BatchedRopeBackwardKernel,
     BatchedRopeKernel,
+    BatchedRopeNeoxBackwardKernel,
+    BatchedRopeNeoxKernel,
     BatchedScaleKernel,
     BatchedSoftmaxKernel,
     BatchedSwigluKernel,

--- a/crates/aprender-train/src/autograd/cuda_backward/structured.rs
+++ b/crates/aprender-train/src/autograd/cuda_backward/structured.rs
@@ -50,10 +50,15 @@ pub fn softmax_backward(
         }
     };
 
-    // Softmax backward uses warp-parallel reduction
+    // Softmax backward uses warp-parallel reduction.
+    // FALSIFY-CUDA-NF4-TRAIN-LOSS-PARITY-001: launch a FULL 32-lane warp —
+    // the kernel's shfl.sync reductions use membermask 0xFFFFFFFF, which is
+    // undefined if any named lane is inactive (seq_len < 32 launched a
+    // partial warp). Lanes >= seq_len use predicated loads (identity 0.0),
+    // so a full warp is correct for every seq_len.
     let config = LaunchConfig {
         grid: (batch_size, 1, 1),
-        block: (32.min(seq_len), 1, 1), // Warp size
+        block: (32, 1, 1), // FULL warp — see above
         shared_mem: 0,
     };
 
@@ -119,9 +124,12 @@ pub fn batched_softmax_backward(
         }
     };
 
-    // One warp (32 threads) per row, one block per row
-    let config =
-        LaunchConfig { grid: (total_rows, 1, 1), block: (32.min(row_size), 1, 1), shared_mem: 0 };
+    // One FULL warp (32 threads) per row, one block per row.
+    // FALSIFY-CUDA-NF4-TRAIN-LOSS-PARITY-001: was `32.min(row_size)` — a
+    // partial warp makes the kernel's 0xFFFFFFFF shfl.sync reductions
+    // undefined (garbage row reductions for seq < 32). Guarded loops carry
+    // identity 0.0 on idle lanes, so a full warp is correct.
+    let config = LaunchConfig { grid: (total_rows, 1, 1), block: (32, 1, 1), shared_mem: 0 };
 
     let output_ptr = softmax_output.as_ptr();
     let grad_out_ptr = grad_output.as_ptr();

--- a/crates/aprender-train/src/autograd/cuda_forward/activations.rs
+++ b/crates/aprender-train/src/autograd/cuda_forward/activations.rs
@@ -246,9 +246,19 @@ pub fn batched_softmax_forward(
         }
     };
 
-    // One warp (32 threads) per row, one block per row
-    let config =
-        LaunchConfig { grid: (total_rows, 1, 1), block: (32.min(row_size), 1, 1), shared_mem: 72 };
+    // One FULL warp (32 threads) per row, one block per row.
+    //
+    // FALSIFY-CUDA-NF4-TRAIN-LOSS-PARITY-001: this was `32.min(row_size)`.
+    // The kernel's max/sum reductions use `shfl.sync` with membermask
+    // 0xFFFFFFFF — every lane of the warp MUST be active or the shuffle
+    // result is undefined (PTX ISA). With row_size < 32 (e.g. short
+    // sequences: 15 tokens → 15 threads) lanes 15-31 named in the mask
+    // did not exist, so `row_max` picked up garbage data-dependently →
+    // exp(x - garbage) rows summing to 0 → 0/0 = NaN in softmax output.
+    // The per-lane loops already guard `i < row_size`; idle lanes carry
+    // the reduction identities (-inf for max, 0.0 for sum), so a full
+    // warp is correct for every row_size.
+    let config = LaunchConfig { grid: (total_rows, 1, 1), block: (32, 1, 1), shared_mem: 72 };
 
     let input_ptr = input.as_ptr();
     let output_ptr = output.as_ptr();

--- a/crates/aprender-train/src/autograd/cuda_forward/cache.rs
+++ b/crates/aprender-train/src/autograd/cuda_forward/cache.rs
@@ -12,7 +12,7 @@ use std::sync::{Mutex, OnceLock};
 use trueno_gpu::driver::{CublasHandle, CudaContext, CudaModule, CudaStream};
 #[cfg(feature = "cuda")]
 use trueno_gpu::kernels::{
-    Batched4DGemmKernel, BatchedRopeBackwardKernel, BatchedSoftmaxKernel,
+    Batched4DGemmKernel, BatchedRopeNeoxBackwardKernel, BatchedSoftmaxKernel,
     BatchedToInterleavedKernel, BatchedTransposeKernel, BatchedVectorizedRmsNormKernel,
     ElementwiseMulKernel, FusedSwigluKernel, GemmKernel, InterleavedToBatchedKernel, Kernel,
     Nf4GemmKernel, Nf4GemmTransposeKernel, ResidualAddKernel, ScaleKernel, SiluKernel,
@@ -292,7 +292,7 @@ impl ForwardKernelCache {
         // Stage C/D dispatch on gx10 confirmed runtime emits 2 [FWD-CACHE]
         // Compiling events post-pre-warm for rope_fwd at seq=256 — avoidable
         // JIT-cache pressure that PMAT-700-B closed for GEMMs.
-        use trueno_gpu::kernels::BatchedRopeKernel;
+        use trueno_gpu::kernels::BatchedRopeNeoxKernel;
         let qwen_theta = 1_000_000.0_f32;
         let qwen_theta_bits = qwen_theta.to_bits();
         let phase4_rope_seq: u32 = std::env::var("APR_DISTILL_SMOKE_SEQ_LEN")
@@ -302,13 +302,13 @@ impl ForwardKernelCache {
         let nkv = _nkv;
         for rope_seq in [1_u32, phase4_rope_seq] {
             warm!(
-                format!("batched_rope_fwd_{nh}_{hd}_{rope_seq}_th{qwen_theta_bits:08x}"),
-                BatchedRopeKernel::new(nh, hd, rope_seq, qwen_theta)
+                format!("batched_rope_neox_fwd_{nh}_{hd}_{rope_seq}_th{qwen_theta_bits:08x}"),
+                BatchedRopeNeoxKernel::new(nh, hd, rope_seq, qwen_theta)
             );
             if nkv != nh {
                 warm!(
-                    format!("batched_rope_fwd_{nkv}_{hd}_{rope_seq}_th{qwen_theta_bits:08x}"),
-                    BatchedRopeKernel::new(nkv, hd, rope_seq, qwen_theta)
+                    format!("batched_rope_neox_fwd_{nkv}_{hd}_{rope_seq}_th{qwen_theta_bits:08x}"),
+                    BatchedRopeNeoxKernel::new(nkv, hd, rope_seq, qwen_theta)
                 );
             }
         }
@@ -603,13 +603,13 @@ fn pre_warm_backward_kernels_in_forward_cache(
     let s = max_seq_len as u32;
     let qwen_theta_bits = 1_000_000.0_f32.to_bits();
     warm!(
-        format!("batched_rope_bwd_{nh}_{hd}_{s}_th{qwen_theta_bits:08x}"),
-        BatchedRopeBackwardKernel::new(nh, hd, s, 1_000_000.0)
+        format!("batched_rope_neox_bwd_{nh}_{hd}_{s}_th{qwen_theta_bits:08x}"),
+        BatchedRopeNeoxBackwardKernel::new(nh, hd, s, 1_000_000.0)
     );
     if nkv != nh {
         warm!(
-            format!("batched_rope_bwd_{nkv}_{hd}_{s}_th{qwen_theta_bits:08x}"),
-            BatchedRopeBackwardKernel::new(nkv, hd, s, 1_000_000.0)
+            format!("batched_rope_neox_bwd_{nkv}_{hd}_{s}_th{qwen_theta_bits:08x}"),
+            BatchedRopeNeoxBackwardKernel::new(nkv, hd, s, 1_000_000.0)
         );
     }
 

--- a/crates/aprender-train/src/autograd/cuda_forward/normalization.rs
+++ b/crates/aprender-train/src/autograd/cuda_forward/normalization.rs
@@ -7,7 +7,7 @@
 use trueno_gpu::driver::{CudaStream, GpuBuffer, LaunchConfig};
 #[cfg(feature = "cuda")]
 use trueno_gpu::kernels::{
-    BatchedFusedResidualRmsNormKernel, BatchedRopeBackwardKernel, BatchedRopeKernel,
+    BatchedFusedResidualRmsNormKernel, BatchedRopeNeoxBackwardKernel, BatchedRopeNeoxKernel,
     BatchedVectorizedRmsNormKernel, Kernel, LayerNormKernel, PerHeadRmsNormKernel, RopeNeoxKernel,
 };
 
@@ -332,13 +332,17 @@ pub fn batched_rope_neox_forward(
         CudaTensorError::KernelError("Failed to acquire kernel cache lock".to_string())
     })?;
 
-    let kernel = BatchedRopeKernel::new(num_heads, head_dim, seq_len, theta);
+    // FALSIFY-CUDA-NF4-TRAIN-LOSS-PARITY-001: MUST be the NEOX split-half
+    // kernel. `BatchedRopeKernel` rotates ADJACENT pairs (GPT-J convention);
+    // wiring it here (ALB-119) rotated Q/K in the wrong basis for
+    // Qwen2/LLaMA weights -> finite-garbage CE ~13-14, flat loss, NaN adapters.
+    let kernel = BatchedRopeNeoxKernel::new(num_heads, head_dim, seq_len, theta);
 
     // FALSIFY-CUDA-ROPE-THETA-CACHE-KEY-001: cache key MUST include
     // theta_bits (and seq_len, which is also baked in via grid sizing).
     // See `rope_neox_forward` rationale.
     let theta_bits = theta.to_bits();
-    let key = format!("batched_rope_fwd_{num_heads}_{head_dim}_{seq_len}_th{theta_bits:08x}");
+    let key = format!("batched_rope_neox_fwd_{num_heads}_{head_dim}_{seq_len}_th{theta_bits:08x}");
     let module = match cache.get_cached(&key) {
         Some(m) => m,
         None => {
@@ -362,7 +366,7 @@ pub fn batched_rope_neox_forward(
 
     // SAFETY: launches a CUDA kernel via the driver API. The argument pointer array, grid/block config, and module/function name match the kernel's signature, and every referenced device buffer is allocated, correctly sized, and lives until the stream-ordered launch completes.
     unsafe {
-        stream.launch_kernel(module, "batched_rope", &config, &mut args).map_err(|e| {
+        stream.launch_kernel(module, "batched_rope_neox", &config, &mut args).map_err(|e| {
             CudaTensorError::KernelError(format!("Batched RoPE NeoX forward failed: {e:?}"))
         })?;
     }
@@ -391,12 +395,14 @@ pub fn batched_rope_neox_backward(
         CudaTensorError::KernelError("Failed to acquire kernel cache lock".to_string())
     })?;
 
-    let kernel = BatchedRopeBackwardKernel::new(num_heads, head_dim, seq_len, theta);
+    // FALSIFY-CUDA-NF4-TRAIN-LOSS-PARITY-001: NEOX transpose rotation (must
+    // mirror the NEOX forward above, not the adjacent-pair kernel).
+    let kernel = BatchedRopeNeoxBackwardKernel::new(num_heads, head_dim, seq_len, theta);
 
     // FALSIFY-CUDA-ROPE-THETA-CACHE-KEY-001: cache key MUST include
     // theta_bits. See `rope_neox_forward` rationale.
     let theta_bits = theta.to_bits();
-    let key = format!("batched_rope_bwd_{num_heads}_{head_dim}_{seq_len}_th{theta_bits:08x}");
+    let key = format!("batched_rope_neox_bwd_{num_heads}_{head_dim}_{seq_len}_th{theta_bits:08x}");
     let module = match cache.get_cached(&key) {
         Some(m) => m,
         None => {
@@ -420,9 +426,9 @@ pub fn batched_rope_neox_backward(
 
     // SAFETY: launches a CUDA kernel via the driver API. The argument pointer array, grid/block config, and module/function name match the kernel's signature, and every referenced device buffer is allocated, correctly sized, and lives until the stream-ordered launch completes.
     unsafe {
-        stream.launch_kernel(module, "batched_rope_backward", &config, &mut args).map_err(|e| {
-            CudaTensorError::KernelError(format!("Batched RoPE NeoX backward failed: {e:?}"))
-        })?;
+        stream.launch_kernel(module, "batched_rope_neox_backward", &config, &mut args).map_err(
+            |e| CudaTensorError::KernelError(format!("Batched RoPE NeoX backward failed: {e:?}")),
+        )?;
     }
 
     Ok(())
@@ -771,11 +777,8 @@ mod tests {
             let row = &summed[b * hidden_size..(b + 1) * hidden_size];
             cpu_out.extend(cpu_rmsnorm_reference(row, &gamma_data, 1e-6));
         }
-        let max_norm_diff = cpu_out
-            .iter()
-            .zip(output.iter())
-            .map(|(c, g)| (c - g).abs())
-            .fold(0.0f32, f32::max);
+        let max_norm_diff =
+            cpu_out.iter().zip(output.iter()).map(|(c, g)| (c - g).abs()).fold(0.0f32, f32::max);
         assert!(
             max_norm_diff < 1e-4,
             "FALSIFY-CUDA-FUSED-RMSNORM-DEADLOCK-001: output disagrees with CPU \

--- a/crates/aprender-train/src/autograd/ops/attention.rs
+++ b/crates/aprender-train/src/autograd/ops/attention.rs
@@ -29,8 +29,42 @@ pub fn attention(
     v: &Tensor,
     seq_len: usize,
     d_k: usize,
+    k_seq_len: usize,
+    d_v: usize,
+) -> Tensor {
+    attention_impl(q, k, v, seq_len, d_k, k_seq_len, d_v, false)
+}
+
+/// Causal (masked) Scaled Dot-Product Attention.
+///
+/// FALSIFY-CUDA-NF4-TRAIN-LOSS-PARITY-001: decoder-only causal LM training
+/// MUST mask future positions (`j > i`) before the softmax. The unmasked
+/// [`attention`] leaks the label tokens' embeddings backwards through the
+/// sequence, so CPU train/eval losses were deceptively LOW (label leakage)
+/// and diverged from the (correctly causal) CUDA training forward.
+/// Bidirectional [`attention`] remains for encoder models (BERT/RoBERTa).
+pub fn attention_causal(
+    q: &Tensor,
+    k: &Tensor,
+    v: &Tensor,
+    seq_len: usize,
+    d_k: usize,
+    k_seq_len: usize,
+    d_v: usize,
+) -> Tensor {
+    attention_impl(q, k, v, seq_len, d_k, k_seq_len, d_v, true)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn attention_impl(
+    q: &Tensor,
+    k: &Tensor,
+    v: &Tensor,
+    seq_len: usize,
+    d_k: usize,
     _k_seq_len: usize, // Kept for API compatibility, assumes same as seq_len
     d_v: usize,
+    causal: bool,
 ) -> Tensor {
     let scale = (d_k as f32).sqrt();
 
@@ -47,7 +81,19 @@ pub fn attention(
         *score /= scale;
     }
 
+    // Causal mask: position i may attend only to j <= i.
+    if causal {
+        for i in 0..seq_len {
+            for j in (i + 1)..seq_len {
+                scores[i * seq_len + j] = f32::NEG_INFINITY;
+            }
+        }
+    }
+
     // Step 2: Apply softmax row-wise (CPU for numerical stability)
+    // Masked entries carry exactly 0.0 weight, so the shared softmax
+    // backward (AttentionBackward) stays correct: grad w.r.t. a masked
+    // score is w_j * (…) = 0.
     let mut attention_weights = vec![0.0; seq_len * seq_len];
     for i in 0..seq_len {
         let row_start = i * seq_len;

--- a/crates/aprender-train/src/autograd/ops/mod.rs
+++ b/crates/aprender-train/src/autograd/ops/mod.rs
@@ -12,7 +12,7 @@ mod normalize;
 
 // Re-export all public operations
 pub use activations::{gelu, relu, softmax, swish};
-pub use attention::attention;
+pub use attention::{attention, attention_causal};
 pub use basic::{add, add_scaled, mul, scale, sum};
 #[cfg(feature = "realizar")]
 pub use matmul::pre_warm_realizador_gemm;

--- a/crates/aprender-train/src/finetune/classify_pipeline/gpu.rs
+++ b/crates/aprender-train/src/finetune/classify_pipeline/gpu.rs
@@ -292,6 +292,23 @@ impl ClassifyPipeline {
                     .as_ref()
                     .map(|t| t.data().as_slice().expect("contiguous k_norm").to_vec());
 
+                // FALSIFY-CUDA-NF4-TRAIN-LOSS-PARITY-001: thread Q/K/V biases
+                let b_q_data = layer
+                    .self_attn
+                    .b_q
+                    .as_ref()
+                    .map(|t| t.data().as_slice().expect("contiguous b_q").to_vec());
+                let b_k_data = layer
+                    .self_attn
+                    .b_k
+                    .as_ref()
+                    .map(|t| t.data().as_slice().expect("contiguous b_k").to_vec());
+                let b_v_data = layer
+                    .self_attn
+                    .b_v
+                    .as_ref()
+                    .map(|t| t.data().as_slice().expect("contiguous b_v").to_vec());
+
                 crate::transformer::CudaNf4TransformerBlock::new(
                     model_config,
                     i,
@@ -312,6 +329,9 @@ impl ClassifyPipeline {
                     lora_rank,
                     q_norm_data.as_deref(),
                     k_norm_data.as_deref(),
+                    b_q_data.as_deref(),
+                    b_k_data.as_deref(),
+                    b_v_data.as_deref(),
                 )
                 .map(CudaBlock::Nf4)
             } else {

--- a/crates/aprender-train/src/finetune/instruct_pipeline/cuda_init.rs
+++ b/crates/aprender-train/src/finetune/instruct_pipeline/cuda_init.rs
@@ -258,6 +258,24 @@ impl InstructPipeline {
                     .as_ref()
                     .map(|t| t.data().as_slice().expect("contiguous k_norm").to_vec());
 
+                // FALSIFY-CUDA-NF4-TRAIN-LOSS-PARITY-001: thread Q/K/V biases
+                // (Qwen2 family) into the GPU block — pre-fix they were dropped.
+                let b_q_data = layer
+                    .self_attn
+                    .b_q
+                    .as_ref()
+                    .map(|t| t.data().as_slice().expect("contiguous b_q").to_vec());
+                let b_k_data = layer
+                    .self_attn
+                    .b_k
+                    .as_ref()
+                    .map(|t| t.data().as_slice().expect("contiguous b_k").to_vec());
+                let b_v_data = layer
+                    .self_attn
+                    .b_v
+                    .as_ref()
+                    .map(|t| t.data().as_slice().expect("contiguous b_v").to_vec());
+
                 crate::transformer::CudaNf4TransformerBlock::new(
                     model_config,
                     i,
@@ -278,9 +296,30 @@ impl InstructPipeline {
                     lora_rank,
                     q_norm_data.as_deref(),
                     k_norm_data.as_deref(),
+                    b_q_data.as_deref(),
+                    b_k_data.as_deref(),
+                    b_v_data.as_deref(),
                 )
                 .map(CudaBlock::Nf4)
             } else {
+                // FALSIFY-CUDA-NF4-TRAIN-LOSS-PARITY-001: surface biases on the
+                // FP32 path too (block already supported them since
+                // FALSIFY-CUDA-FORWARD-PARITY-002; this site passed None).
+                let b_q_data = layer
+                    .self_attn
+                    .b_q
+                    .as_ref()
+                    .map(|t| t.data().as_slice().expect("contiguous b_q").to_vec());
+                let b_k_data = layer
+                    .self_attn
+                    .b_k
+                    .as_ref()
+                    .map(|t| t.data().as_slice().expect("contiguous b_k").to_vec());
+                let b_v_data = layer
+                    .self_attn
+                    .b_v
+                    .as_ref()
+                    .map(|t| t.data().as_slice().expect("contiguous b_v").to_vec());
                 CudaTransformerBlock::new(
                     model_config,
                     i,
@@ -295,9 +334,9 @@ impl InstructPipeline {
                     w_up,
                     w_down,
                     max_seq_len,
-                    None, // b_q (instruct pipeline doesn't surface biases yet)
-                    None, // b_k
-                    None, // b_v
+                    b_q_data.as_deref(),
+                    b_k_data.as_deref(),
+                    b_v_data.as_deref(),
                 )
                 .map(CudaBlock::Fp32)
             };

--- a/crates/aprender-train/src/finetune/instruct_pipeline/mod.rs
+++ b/crates/aprender-train/src/finetune/instruct_pipeline/mod.rs
@@ -25,6 +25,8 @@ mod generate;
 mod training;
 mod wgpu;
 
+#[cfg(all(test, feature = "cuda"))]
+mod parity_probe;
 #[cfg(test)]
 mod tests;
 #[cfg(test)]

--- a/crates/aprender-train/src/finetune/instruct_pipeline/parity_probe.rs
+++ b/crates/aprender-train/src/finetune/instruct_pipeline/parity_probe.rs
@@ -1,0 +1,395 @@
+//! FALSIFY-CUDA-NF4-TRAIN-LOSS-PARITY-001 — oracle-based loss-parity probe.
+//!
+//! Defect #4 (NF4 QLoRA CUDA training): the GPU training forward/loss produced
+//! finite-garbage cross-entropy (~13-14 > ln(151936)=11.93 — worse than
+//! uniform) on data the base model can already emit, so training never learned
+//! and adapters eventually blew up into NaN.
+//!
+//! Bisection oracles, strongest first:
+//!   (c) pure-CPU forward + CPU CE          — ground truth
+//!   (b) GPU transformer forward + GPU lm_head + CPU CE — isolates forward
+//!   (a) GPU-resident forward + fused GPU CE — full production path
+//!
+//! (a)≈(b)≫(c) ⟹ the GPU transformer forward diverges from the CPU model.
+//! Root cause: `CudaNf4TransformerBlock` never received or applied the Q/K/V
+//! projection biases (Qwen2 family `use_bias=true`); the CPU model loads and
+//! applies them (`attention.rs::add_bias`).
+//!
+//! Env-gated on APR_PARITY_MODEL (path to a Qwen2-family .apr with an
+//! embedded tokenizer). Requires a CUDA GPU. Run:
+//!
+//! ```text
+//! APR_PARITY_MODEL=~/models/qwen2.5-coder-1.5b-instruct-q4k.apr \
+//!   cargo test -p aprender-train --lib --features cuda \
+//!   falsify_cuda_nf4_train_loss_parity -- --ignored --nocapture
+//! ```
+
+#[allow(clippy::wildcard_imports)]
+use super::*;
+
+use crate::autograd::cuda_optim::fused_causal_cross_entropy_cuda;
+
+/// Relative L2 difference between two activation slices.
+fn rel_l2(a: &[f32], b: &[f32]) -> f32 {
+    let mut num = 0.0f64;
+    let mut den = 0.0f64;
+    for (&x, &y) in a.iter().zip(b.iter()) {
+        num += f64::from(x - y) * f64::from(x - y);
+        den += f64::from(y) * f64::from(y);
+    }
+    ((num / den.max(1e-30)) as f32).sqrt()
+}
+
+/// Layer-by-layer bisection of the GPU NF4 forward vs the CPU oracle.
+///
+/// Downloads the per-layer input snapshots the GPU forward saves for backward
+/// (`layer_inputs[i]` = input of layer i, `blocks_output` = final output) and
+/// compares them against a CPU replay through the same layers, both WITH
+/// biases (true model) and WITHOUT Q/K/V biases (bias-drop hypothesis).
+#[test]
+#[ignore = "requires CUDA GPU + APR_PARITY_MODEL pointing at a Qwen2-family .apr"]
+fn parity_probe_layer_bisect() {
+    let Ok(model_path) = std::env::var("APR_PARITY_MODEL") else {
+        eprintln!("[layer-bisect] SKIP: APR_PARITY_MODEL unset");
+        return;
+    };
+    let model_path = std::path::PathBuf::from(model_path);
+    if !model_path.exists() {
+        return;
+    }
+
+    let model_config = qwen2_1_5b_config();
+    let instruct_config = InstructConfig {
+        lora_rank: 8,
+        lora_alpha: 16.0,
+        learning_rate: 1e-9,
+        epochs: 1,
+        max_seq_len: 64,
+        gradient_clip_norm: Some(1.0),
+        quantize_nf4: true,
+    };
+    let mut p = InstructPipeline::from_apr(&model_path, &model_config, instruct_config)
+        .expect("pipeline from_apr");
+    assert!(p.cuda_blocks.is_some(), "CUDA blocks must initialize");
+
+    let prompt_ids = p.tokenize("What is 2+2? Answer with just the number.\n");
+    let response_ids = p.tokenize("4");
+    let full_ids: Vec<u32> = prompt_ids.iter().chain(response_ids.iter()).copied().collect();
+    let seq_len = full_ids.len();
+    let hidden = p.model.config().hidden_size;
+
+    // GPU forward populates layer_inputs + blocks_output.
+    p.forward_logits_gpu(&full_ids).expect("GPU forward");
+
+    let (gpu_layer_inputs, gpu_final): (Vec<Vec<f32>>, Vec<f32>) = {
+        let trainer = p.cuda_trainer.as_ref().expect("trainer");
+        let training = p.gpu_training.as_ref().expect("training state");
+        let inputs = training
+            .layer_inputs
+            .iter()
+            .map(|b| {
+                let v = trainer.download(b).expect("download layer input");
+                v[..seq_len * hidden].to_vec()
+            })
+            .collect();
+        let f = trainer.download(&training.blocks_output).expect("download final");
+        (inputs, f[..seq_len * hidden].to_vec())
+    };
+
+    // GPU-vs-GPU cross-check: run pipeline block 0 standalone on the same
+    // embed and compare against the pipeline forward's layer_inputs[1].
+    {
+        let embed = p.model.embed_tokens.forward(&full_ids);
+        let x = embed.data().as_slice().expect("contiguous").to_vec();
+        let trainer = p.cuda_trainer.as_ref().expect("trainer");
+        let stream = trainer.stream();
+        let gpu_in = trainer.upload(&x).expect("upload");
+        let mut gpu_out = trainer.zeros(seq_len * hidden).expect("out");
+        let blocks = p.cuda_blocks.as_mut().expect("blocks");
+        if let Some(ref mut scratch) = p.shared_scratch {
+            scratch.zero_forward_buffers(stream);
+        }
+        blocks[0]
+            .forward(&gpu_in, &mut gpu_out, seq_len, stream, p.shared_scratch.as_mut())
+            .expect("standalone block0 forward");
+        stream.synchronize().expect("sync");
+        let standalone = trainer.download(&gpu_out).expect("download");
+        let d = rel_l2(&standalone[..seq_len * hidden], &gpu_layer_inputs[1]);
+        eprintln!("[layer-bisect] GPU-vs-GPU block0 (standalone vs pipeline): relL2={d:.6}");
+    }
+
+    // NF4-matched CPU oracle: requantize the CPU model's projection weights
+    // with the same NF4 round-trip the GPU blocks use, so the replay isolates
+    // STRUCTURAL divergence from quantization noise.
+    {
+        use trueno_gpu::kernels::{dequantize_nf4, quantize_nf4};
+        let cfg = p.model.config().clone();
+        let q_dim = cfg.q_dim();
+        let kv_dim = cfg.num_kv_heads * cfg.head_dim();
+        let inter = cfg.intermediate_size;
+        let requant = |t: &Tensor, rows: usize, cols: usize| -> Tensor {
+            let d = t.data();
+            let s = d.as_slice().expect("contiguous weight");
+            Tensor::from_vec(dequantize_nf4(&quantize_nf4(s, rows, cols)), false)
+        };
+        for layer in &mut p.model.layers {
+            layer.self_attn.w_q = requant(&layer.self_attn.w_q, q_dim, hidden);
+            layer.self_attn.w_k = requant(&layer.self_attn.w_k, kv_dim, hidden);
+            layer.self_attn.w_v = requant(&layer.self_attn.w_v, kv_dim, hidden);
+            layer.self_attn.w_o = requant(&layer.self_attn.w_o, hidden, q_dim);
+            layer.ffn.w_gate = requant(&layer.ffn.w_gate, inter, hidden);
+            layer.ffn.w_up = requant(&layer.ffn.w_up, inter, hidden);
+            layer.ffn.w_down = requant(&layer.ffn.w_down, hidden, inter);
+        }
+    }
+
+    // CPU replay: full-precision (truth) and NF4-matched.
+    let embed = p.model.embed_tokens.forward(&full_ids);
+    let mut h_nf4 = embed.data().as_slice().expect("contiguous").to_vec();
+
+    let num_layers = p.model.layers.len();
+    for i in 0..num_layers {
+        let d_nf4 = rel_l2(&gpu_layer_inputs[i], &h_nf4);
+        eprintln!("[layer-bisect] L{i:02} input:  relL2(gpu,cpu_nf4)={d_nf4:.4}");
+
+        let t = Tensor::from_vec(h_nf4.clone(), false);
+        let out = p.model.layers[i].forward(&t, seq_len);
+        h_nf4 = out.data().as_slice().expect("contiguous").to_vec();
+    }
+
+    let d_nf4 = rel_l2(&gpu_final, &h_nf4);
+    eprintln!("[layer-bisect] FINAL output: relL2(gpu,cpu_nf4)={d_nf4:.4}");
+}
+
+/// Tolerance for GPU-vs-CPU loss parity. NF4 quantization of the frozen
+/// weights costs real accuracy, so the GPU loss cannot be bit-equal to the
+/// F32 CPU loss — but it must be the SAME MODEL, not garbage. Empirically
+/// NF4 costs <0.4 nats on this corpus; 0.5 is a loud-failure bound.
+const PARITY_TOL: f32 = 0.5;
+
+fn qwen2_1_5b_config() -> TransformerConfig {
+    TransformerConfig::from_apr_metadata(
+        Some(1536),
+        Some(12),
+        Some(2),
+        Some(8960),
+        Some(28),
+        Some(151_936),
+        Some(32_768),
+        Some(1e-6),
+        Some(1_000_000.0),
+        Some("qwen2"),
+    )
+    .expect("qwen2 config from metadata")
+}
+
+#[test]
+fn falsify_cuda_nf4_train_loss_parity_001() {
+    // Env-gated: skips (vacuous pass) unless APR_PARITY_MODEL points at a
+    // Qwen2-family .apr and a CUDA GPU is present. Run explicitly with:
+    //   APR_PARITY_MODEL=~/models/qwen2.5-coder-1.5b-instruct-q4k.apr \
+    //   cargo test -p aprender-train --features cuda --lib \
+    //     falsify_cuda_nf4_train_loss_parity_001 --release -- --nocapture
+    if !trueno_gpu::driver::cuda_available() {
+        eprintln!("[parity-probe] SKIP: no CUDA device");
+        return;
+    }
+    let Ok(model_path) = std::env::var("APR_PARITY_MODEL") else {
+        eprintln!("[parity-probe] SKIP: APR_PARITY_MODEL unset");
+        return;
+    };
+    let model_path = std::path::PathBuf::from(model_path);
+    if !model_path.exists() {
+        eprintln!("[parity-probe] SKIP: {} does not exist", model_path.display());
+        return;
+    }
+
+    let model_config = qwen2_1_5b_config();
+    let instruct_config = InstructConfig {
+        lora_rank: 8,
+        lora_alpha: 16.0,
+        learning_rate: 1e-9,
+        epochs: 1,
+        max_seq_len: 64,
+        gradient_clip_norm: Some(1.0),
+        quantize_nf4: true,
+    };
+
+    let mut p = InstructPipeline::from_apr(&model_path, &model_config, instruct_config)
+        .expect("pipeline from_apr");
+    assert!(p.cuda_blocks.is_some(), "CUDA blocks must initialize (GPU present?)");
+    assert!(p.gpu_training.is_some(), "GPU training state must initialize");
+
+    let prompt_ids = p.tokenize("What is 2+2? Answer with just the number.\n");
+    let response_ids = p.tokenize("4");
+    let full_ids: Vec<u32> = prompt_ids.iter().chain(response_ids.iter()).copied().collect();
+    let seq_len = full_ids.len();
+    let prompt_len = prompt_ids.len();
+    let vocab_size = p.model.config().vocab_size;
+    let loss_start = prompt_len.saturating_sub(1);
+    let loss_end = seq_len - 1;
+    eprintln!(
+        "[parity-probe] seq_len={seq_len} prompt_len={prompt_len} loss window=[{loss_start},{loss_end})"
+    );
+
+    // ── (c) pure-CPU oracle: CPU forward + CPU CE ─────────────────────
+    // LoRA B matrices are zero-init, so the base model's loss is the truth.
+    let logits = p.model.forward(&full_ids);
+    let logits_cpu = logits.data().as_slice().expect("contiguous logits").to_vec();
+    let (loss_cpu, _) = InstructPipeline::compute_causal_lm_loss(
+        &logits_cpu,
+        &full_ids,
+        loss_start,
+        loss_end,
+        vocab_size,
+    );
+    eprintln!("[parity-probe] (c) CPU forward + CPU CE:        loss={loss_cpu:.4}");
+
+    // ── (b) GPU transformer + GPU lm_head + CPU CE ────────────────────
+    let logits_gpu = p.forward_logits_gpu(&full_ids).expect("GPU forward with logits download");
+    let (loss_gpu_fwd, _) = InstructPipeline::compute_causal_lm_loss(
+        &logits_gpu,
+        &full_ids,
+        loss_start,
+        loss_end,
+        vocab_size,
+    );
+    eprintln!("[parity-probe] (b) GPU forward + CPU CE:        loss={loss_gpu_fwd:.4}");
+
+    // ── (a) GPU-resident forward + fused GPU causal CE ────────────────
+    assert!(p.forward_logits_gpu_resident(&full_ids), "GPU-resident forward failed");
+    let targets: Vec<u32> = (0..seq_len)
+        .map(|pos| if pos + 1 < full_ids.len() { full_ids[pos + 1] } else { 0 })
+        .collect();
+    let num_loss_tokens = loss_end - loss_start;
+    let scale = 1.0 / num_loss_tokens as f32;
+    let loss_gpu_fused = {
+        let trainer = p.cuda_trainer.as_ref().expect("trainer");
+        let stream = trainer.stream();
+        let training = p.gpu_training.as_mut().expect("training state");
+        fused_causal_cross_entropy_cuda(
+            &mut training.logits_buf,
+            &targets,
+            seq_len as u32,
+            vocab_size as u32,
+            loss_start as u32,
+            loss_end as u32,
+            scale,
+            stream,
+        )
+        .expect("fused causal CE")
+    };
+    eprintln!("[parity-probe] (a) GPU forward + fused GPU CE:  loss={loss_gpu_fused:.4}");
+
+    // ── mechanism experiment: CPU forward WITHOUT Q/K/V biases ────────
+    // If dropping the biases from the CPU oracle reproduces the GPU loss,
+    // the missing-bias hypothesis explains the full magnitude of the defect.
+    let saved: Vec<(Option<Tensor>, Option<Tensor>, Option<Tensor>)> = p
+        .model
+        .layers
+        .iter_mut()
+        .map(|l| (l.self_attn.b_q.take(), l.self_attn.b_k.take(), l.self_attn.b_v.take()))
+        .collect();
+    let logits_nb = p.model.forward(&full_ids);
+    let logits_nb = logits_nb.data().as_slice().expect("contiguous logits").to_vec();
+    let (loss_cpu_nobias, _) = InstructPipeline::compute_causal_lm_loss(
+        &logits_nb, &full_ids, loss_start, loss_end, vocab_size,
+    );
+    for (l, (bq, bk, bv)) in p.model.layers.iter_mut().zip(saved) {
+        l.self_attn.b_q = bq;
+        l.self_attn.b_k = bk;
+        l.self_attn.b_v = bv;
+    }
+    eprintln!("[parity-probe] (x) CPU forward, biases DROPPED: loss={loss_cpu_nobias:.4}");
+
+    // ── (y) quantization-matched oracle: CPU forward through the SAME
+    //    NF4-quantized weights the GPU uses ──────────────────────────────
+    // The GPU block quantizes the 7 projection weights to NF4 (block-64
+    // absmax) and runs GEMMs on the dequantized fp32 copies. Replaying that
+    // on CPU isolates STRUCTURAL divergence (rope convention, biases,
+    // masking, reductions) from irreducible quantization noise.
+    {
+        use trueno_gpu::kernels::{dequantize_nf4, quantize_nf4};
+        let cfg = p.model.config().clone();
+        let hidden = cfg.hidden_size;
+        let q_dim = cfg.q_dim();
+        let kv_dim = cfg.num_kv_heads * cfg.head_dim();
+        let inter = cfg.intermediate_size;
+        let requant = |t: &Tensor, rows: usize, cols: usize| -> Tensor {
+            let d = t.data();
+            let s = d.as_slice().expect("contiguous weight");
+            Tensor::from_vec(dequantize_nf4(&quantize_nf4(s, rows, cols)), false)
+        };
+        for layer in &mut p.model.layers {
+            layer.self_attn.w_q = requant(&layer.self_attn.w_q, q_dim, hidden);
+            layer.self_attn.w_k = requant(&layer.self_attn.w_k, kv_dim, hidden);
+            layer.self_attn.w_v = requant(&layer.self_attn.w_v, kv_dim, hidden);
+            layer.self_attn.w_o = requant(&layer.self_attn.w_o, hidden, q_dim);
+            layer.ffn.w_gate = requant(&layer.ffn.w_gate, inter, hidden);
+            layer.ffn.w_up = requant(&layer.ffn.w_up, inter, hidden);
+            layer.ffn.w_down = requant(&layer.ffn.w_down, hidden, inter);
+        }
+    }
+    let logits_nf4 = p.model.forward(&full_ids);
+    let logits_nf4 = logits_nf4.data().as_slice().expect("contiguous logits").to_vec();
+    let (loss_cpu_nf4, _) = InstructPipeline::compute_causal_lm_loss(
+        &logits_nf4,
+        &full_ids,
+        loss_start,
+        loss_end,
+        vocab_size,
+    );
+    eprintln!("[parity-probe] (y) CPU forward, NF4 weights:   loss={loss_cpu_nf4:.4}");
+
+    // ── full-logits oracle: GPU logits vs NF4-matched CPU logits ──────
+    // The scalar loss on a 1-token window is too weak to falsify every
+    // structural defect (a consistently-wrong rope pairing shifted it by
+    // only ~0.05 nats on this sample). The full [seq, vocab] logits compare
+    // the ENTIRE function: rope-pairing mutation ⇒ relL2 ≈ 0.5-1.0;
+    // quantization noise alone ⇒ relL2 ≈ 0.03.
+    let logits_rel_l2 = rel_l2(&logits_gpu, &logits_nf4);
+    eprintln!("[parity-probe] (z) logits relL2(gpu, cpu_nf4) = {logits_rel_l2:.4}");
+
+    // ── falsifier assertions ──────────────────────────────────────────
+    assert!(
+        loss_cpu < 8.0,
+        "CPU oracle itself is broken (loss={loss_cpu:.4}) — cannot falsify GPU path"
+    );
+    assert!(
+        (loss_gpu_fused - loss_gpu_fwd).abs() < 0.05,
+        "fused GPU CE diverges from CPU CE on the SAME GPU logits: \
+         fused={loss_gpu_fused:.4} cpu_ce={loss_gpu_fwd:.4}"
+    );
+    // Structural parity: GPU vs the quantization-matched CPU oracle. NF4
+    // noise is common to both sides, so this bound is TIGHT — any rope/bias/
+    // mask/reduction defect blows it (pre-fix: gpu=6.54 vs nf4-cpu≈0.6).
+    assert!(
+        (loss_gpu_fused - loss_cpu_nf4).abs() < PARITY_TOL,
+        "FALSIFY-CUDA-NF4-TRAIN-LOSS-PARITY-001: GPU training loss diverges \
+         from the NF4-matched CPU oracle: gpu={loss_gpu_fused:.4} \
+         cpu_nf4={loss_cpu_nf4:.4} (|Δ|={:.4} > {PARITY_TOL}). The GPU \
+         forward is computing a DIFFERENT MODEL (pre-fix: GPT-J rope pairing \
+         + dropped Q/K/V biases + partial-warp softmax UB).",
+        (loss_gpu_fused - loss_cpu_nf4).abs()
+    );
+    // Absolute sanity: toy CE must sit FAR below ln(V)=11.93. Pre-fix the
+    // GPU path scored 13-14 (worse than uniform) on this same sample.
+    assert!(
+        loss_gpu_fused < 6.0,
+        "FALSIFY-CUDA-NF4-TRAIN-LOSS-PARITY-001: GPU training loss \
+         {loss_gpu_fused:.4} is not meaningfully below ln(vocab)=11.93 — \
+         finite-garbage forward (pre-fix signature: CE 13-14)"
+    );
+    // Full-function parity: the GPU forward must compute the SAME function
+    // as the NF4-matched CPU oracle over the whole [seq, vocab] logits.
+    // Mutation-verified: reverting the NeoX rope fix → relL2 0.183 (RED);
+    // dropping Q/K/V biases → RED; fixed → 0.047 (GREEN). Quantization
+    // noise is common to both sides.
+    assert!(
+        logits_rel_l2 < 0.10,
+        "FALSIFY-CUDA-NF4-TRAIN-LOSS-PARITY-001: GPU logits diverge from the \
+         NF4-matched CPU oracle (relL2={logits_rel_l2:.4} > 0.10) — the GPU \
+         forward computes a structurally different function (rope pairing / \
+         biases / masking / reductions)"
+    );
+}

--- a/crates/aprender-train/src/train/transformer_trainer/cuda_trainer.rs
+++ b/crates/aprender-train/src/train/transformer_trainer/cuda_trainer.rs
@@ -898,6 +898,23 @@ impl CudaTransformerTrainer {
                     .as_ref()
                     .map(|t| t.data().as_slice().expect("contiguous k_norm").to_vec());
 
+                // FALSIFY-CUDA-NF4-TRAIN-LOSS-PARITY-001: thread Q/K/V biases
+                let b_q_data = layer
+                    .self_attn
+                    .b_q
+                    .as_ref()
+                    .map(|t| t.data().as_slice().expect("contiguous b_q").to_vec());
+                let b_k_data = layer
+                    .self_attn
+                    .b_k
+                    .as_ref()
+                    .map(|t| t.data().as_slice().expect("contiguous b_k").to_vec());
+                let b_v_data = layer
+                    .self_attn
+                    .b_v
+                    .as_ref()
+                    .map(|t| t.data().as_slice().expect("contiguous b_v").to_vec());
+
                 let block = crate::transformer::CudaNf4TransformerBlock::new(
                     mc,
                     i,
@@ -918,6 +935,9 @@ impl CudaTransformerTrainer {
                     lora_rank,
                     q_norm_data.as_deref(),
                     k_norm_data.as_deref(),
+                    b_q_data.as_deref(),
+                    b_k_data.as_deref(),
+                    b_v_data.as_deref(),
                 )
                 .map_err(|e| {
                     crate::error::Error::ConfigError(format!("NF4 block {i} upload failed: {e:?}"))

--- a/crates/aprender-train/src/transformer/attention.rs
+++ b/crates/aprender-train/src/transformer/attention.rs
@@ -9,7 +9,7 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
 
-use super::config::TransformerConfig;
+use super::config::{ModelArchitecture, TransformerConfig};
 
 /// Add a bias vector to a projected tensor: output[s] += bias for each sequence position.
 /// Input shape: (seq_len × dim) flattened. Bias shape: (dim).
@@ -556,9 +556,20 @@ impl MultiHeadAttention {
             let k_tensor = Tensor::from_vec(k_head, requires_grad);
             let v_tensor = Tensor::from_vec(v_head, requires_grad);
 
-            let attn_out = crate::autograd::attention(
-                &q_tensor, &k_tensor, &v_tensor, seq_len, head_dim, seq_len, head_dim,
-            );
+            // FALSIFY-CUDA-NF4-TRAIN-LOSS-PARITY-001: decoder-only models
+            // MUST use causal attention. The unmasked path let every position
+            // attend to FUTURE tokens, leaking the training labels backwards
+            // (deceptively low train/eval loss) and diverging from the
+            // causal CUDA training forward. Encoders stay bidirectional.
+            let attn_out = if self.config.architecture == ModelArchitecture::Decoder {
+                crate::autograd::attention_causal(
+                    &q_tensor, &k_tensor, &v_tensor, seq_len, head_dim, seq_len, head_dim,
+                )
+            } else {
+                crate::autograd::attention(
+                    &q_tensor, &k_tensor, &v_tensor, seq_len, head_dim, seq_len, head_dim,
+                )
+            };
 
             head_q_tensors.push(q_tensor);
             head_k_tensors.push(k_tensor);
@@ -731,9 +742,20 @@ impl MultiHeadAttention {
             let k_tensor = Tensor::from_vec(k_head, requires_grad);
             let v_tensor = Tensor::from_vec(v_head, requires_grad);
 
-            let attn_out = crate::autograd::attention(
-                &q_tensor, &k_tensor, &v_tensor, seq_len, head_dim, seq_len, head_dim,
-            );
+            // FALSIFY-CUDA-NF4-TRAIN-LOSS-PARITY-001: decoder-only models
+            // MUST use causal attention. The unmasked path let every position
+            // attend to FUTURE tokens, leaking the training labels backwards
+            // (deceptively low train/eval loss) and diverging from the
+            // causal CUDA training forward. Encoders stay bidirectional.
+            let attn_out = if self.config.architecture == ModelArchitecture::Decoder {
+                crate::autograd::attention_causal(
+                    &q_tensor, &k_tensor, &v_tensor, seq_len, head_dim, seq_len, head_dim,
+                )
+            } else {
+                crate::autograd::attention(
+                    &q_tensor, &k_tensor, &v_tensor, seq_len, head_dim, seq_len, head_dim,
+                )
+            };
 
             head_q_tensors.push(q_tensor);
             head_k_tensors.push(k_tensor);
@@ -1070,9 +1092,20 @@ impl MultiHeadAttentionWithLoRA {
             let k_tensor = Tensor::from_vec(k_head, false);
             let v_tensor = Tensor::from_vec(v_head, false);
 
-            let attn_out = crate::autograd::attention(
-                &q_tensor, &k_tensor, &v_tensor, seq_len, head_dim, seq_len, head_dim,
-            );
+            // FALSIFY-CUDA-NF4-TRAIN-LOSS-PARITY-001: decoder-only models
+            // MUST use causal attention. The unmasked path let every position
+            // attend to FUTURE tokens, leaking the training labels backwards
+            // (deceptively low train/eval loss) and diverging from the
+            // causal CUDA training forward. Encoders stay bidirectional.
+            let attn_out = if self.config.architecture == ModelArchitecture::Decoder {
+                crate::autograd::attention_causal(
+                    &q_tensor, &k_tensor, &v_tensor, seq_len, head_dim, seq_len, head_dim,
+                )
+            } else {
+                crate::autograd::attention(
+                    &q_tensor, &k_tensor, &v_tensor, seq_len, head_dim, seq_len, head_dim,
+                )
+            };
 
             attn_outputs.extend_from_slice(
                 attn_out.data().as_slice().expect("contiguous attention output"),
@@ -1150,8 +1183,7 @@ mod tests {
         let theta = 10000.0f32;
 
         // Deterministic input + upstream gradient weights.
-        let x_data: Vec<f32> =
-            (0..total).map(|i| ((i as f32 * 0.37).sin() * 1.5) + 0.1).collect();
+        let x_data: Vec<f32> = (0..total).map(|i| ((i as f32 * 0.37).sin() * 1.5) + 0.1).collect();
         let w: Vec<f32> = (0..total).map(|i| ((i as f32 * 0.21).cos() * 0.8) - 0.05).collect();
 
         // Analytical gradient via RopeBackward.

--- a/crates/aprender-train/src/transformer/cuda_block.rs
+++ b/crates/aprender-train/src/transformer/cuda_block.rs
@@ -2800,6 +2800,14 @@ pub struct CudaNf4TransformerBlock {
     // QK-norm weights (ENT-270: per-head RMSNorm on Q and K, shape=[head_dim])
     q_norm_weight: Option<GpuBuffer<f32>>,
     k_norm_weight: Option<GpuBuffer<f32>>,
+    // FALSIFY-CUDA-NF4-TRAIN-LOSS-PARITY-001: Q/K/V projection biases
+    // replicated across max_seq_len rows (Qwen2 family use_bias=true).
+    // Pre-fix the NF4 QLoRA block silently DROPPED the biases the CPU model
+    // applies (attention.rs add_bias) — every layer's attention computed a
+    // different function than the model being fine-tuned.
+    b_q_replicated: Option<GpuBuffer<f32>>,
+    b_k_replicated: Option<GpuBuffer<f32>>,
+    b_v_replicated: Option<GpuBuffer<f32>>,
     // FP16 weight buffers for Tier 2 parity (PMAT-470): halve memory BW
     // When set, forward uses gemm_f16_to_f32 (fp16 weights × fp16 activations → fp32 output)
     w_q_fp16: Option<GpuBuffer<u16>>,
@@ -2833,7 +2841,7 @@ impl CudaNf4TransformerBlock {
         w_gate: &[f32],
         w_up: &[f32],
         w_down: &[f32],
-        _max_seq_len: usize, // NF4 blocks use shared scratch (C-SCRATCH-001)
+        max_seq_len: usize, // used for bias replication; scratch is shared (C-SCRATCH-001)
         // ENT-153: Optional LoRA adapters for Q and V projections
         q_lora: Option<(&[f32], &[f32])>,
         v_lora: Option<(&[f32], &[f32])>,
@@ -2842,6 +2850,11 @@ impl CudaNf4TransformerBlock {
         // ENT-270: Optional QK-norm weights (per-head RMSNorm, shape=[head_dim])
         q_norm: Option<&[f32]>,
         k_norm: Option<&[f32]>,
+        // FALSIFY-CUDA-NF4-TRAIN-LOSS-PARITY-001: Q/K/V projection biases
+        // (Qwen2 family use_bias=true; None for LLaMA/Qwen3)
+        b_q: Option<&[f32]>,
+        b_k: Option<&[f32]>,
+        b_v: Option<&[f32]>,
     ) -> Result<Self> {
         use trueno_gpu::kernels::{quantize_nf4, NF4_BLOCK_SIZE};
 
@@ -3054,6 +3067,32 @@ impl CudaNf4TransformerBlock {
             None => None,
         };
 
+        // FALSIFY-CUDA-NF4-TRAIN-LOSS-PARITY-001: replicate Q/K/V biases
+        // across max_seq_len rows (same pattern as the FP32 block's
+        // FALSIFY-CUDA-FORWARD-PARITY-002). Applied by cuda_add_inplace
+        // after each projection GEMM in forward().
+        let replicate = |bias: Option<&[f32]>, dim: usize| -> Result<Option<GpuBuffer<f32>>> {
+            match bias {
+                Some(slice) => {
+                    assert_eq!(
+                        slice.len(),
+                        dim,
+                        "NF4 bias slice len {} != expected dim {dim}",
+                        slice.len()
+                    );
+                    let mut repl: Vec<f32> = Vec::with_capacity(max_seq_len * dim);
+                    for _ in 0..max_seq_len {
+                        repl.extend_from_slice(slice);
+                    }
+                    Ok(Some(GpuBuffer::from_host(&ctx, &repl)?))
+                }
+                None => Ok(None),
+            }
+        };
+        let b_q_replicated = replicate(b_q, q_dim)?;
+        let b_k_replicated = replicate(b_k, kv_hidden_size)?;
+        let b_v_replicated = replicate(b_v, kv_hidden_size)?;
+
         Ok(Self {
             config: config.clone(),
             layer_idx,
@@ -3088,6 +3127,9 @@ impl CudaNf4TransformerBlock {
             lora_rank,
             q_norm_weight,
             k_norm_weight,
+            b_q_replicated,
+            b_k_replicated,
+            b_v_replicated,
             // FP16 weights: None by default, populated by set_fp16_weights() (PMAT-470)
             w_q_fp16: None,
             w_k_fp16: None,
@@ -3217,6 +3259,13 @@ impl CudaNf4TransformerBlock {
                 saturating_u32(seq_len), saturating_u32(hidden_size), saturating_u32(q_dim), stream)?;
         }
 
+        // FALSIFY-CUDA-NF4-TRAIN-LOSS-PARITY-001: Q projection bias
+        // (Qwen2 family). Must be applied BEFORE QK-norm/RoPE, matching the
+        // CPU path (attention.rs: projection → bias → qk-norm → rope).
+        if let Some(b_q_repl) = self.b_q_replicated.as_ref() {
+            cuda_add_inplace(&mut scratch.q, b_q_repl, seq_len * q_dim, stream)?;
+        }
+
         // ENT-153: Q LoRA: q += (norm1_out @ A_q) @ B_q  (B_q pre-scaled by lora_scale)
         if let (Some(a_q), Some(b_q)) = (&self.lora_a_q, &self.lora_b_q) {
             let s = saturating_u32(seq_len);
@@ -3258,6 +3307,15 @@ impl CudaNf4TransformerBlock {
                 saturating_u32(seq_len), saturating_u32(hidden_size), saturating_u32(kv_hidden_size), stream)?;
             gemm_forward(&scratch.norm1_out, &self.w_v_fp32, &mut scratch.v,
                 saturating_u32(seq_len), saturating_u32(hidden_size), saturating_u32(kv_hidden_size), stream)?;
+        }
+
+        // FALSIFY-CUDA-NF4-TRAIN-LOSS-PARITY-001: K/V projection biases
+        // (Qwen2 family), applied for ALL K/V GEMM dispatch variants above.
+        if let Some(b_k_repl) = self.b_k_replicated.as_ref() {
+            cuda_add_inplace(&mut scratch.k, b_k_repl, seq_len * kv_hidden_size, stream)?;
+        }
+        if let Some(b_v_repl) = self.b_v_replicated.as_ref() {
+            cuda_add_inplace(&mut scratch.v, b_v_repl, seq_len * kv_hidden_size, stream)?;
         }
 
         scratch.op_end(_t, OP_QKV_GEMM); // End QKV timing (includes Q/K/V GEMMs + Q LoRA)
@@ -5181,6 +5239,10 @@ impl CudaNf4TransformerBlock {
         Ok(())
     }
 }
+
+#[cfg(all(test, feature = "cuda"))]
+#[path = "cuda_block_parity_probe.rs"]
+mod parity_probe;
 
 #[cfg(test)]
 mod tests {

--- a/crates/aprender-train/src/transformer/cuda_block_parity_probe.rs
+++ b/crates/aprender-train/src/transformer/cuda_block_parity_probe.rs
@@ -1,0 +1,307 @@
+//! FALSIFY-CUDA-NF4-TRAIN-LOSS-PARITY-001 — per-op bisection of layer 0.
+//!
+//! Runs ONE `CudaNf4TransformerBlock::forward` on the real model's layer 0
+//! and compares every intermediate scratch buffer against a plain-Rust CPU
+//! replay of the same ops. The first op whose relative L2 error jumps far
+//! beyond NF4 quantization noise (~1-5%) is the defect.
+//!
+//! Env-gated on APR_PARITY_MODEL. Child module of `cuda_block` so it can read
+//! the private scratch buffers.
+
+use super::*;
+use crate::autograd::cuda_training::CudaTrainer;
+use crate::transformer::{Transformer, TransformerConfig};
+
+fn rel_l2(a: &[f32], b: &[f32]) -> f32 {
+    let mut num = 0.0f64;
+    let mut den = 0.0f64;
+    for (&x, &y) in a.iter().zip(b.iter()) {
+        num += f64::from(x - y) * f64::from(x - y);
+        den += f64::from(y) * f64::from(y);
+    }
+    ((num / den.max(1e-30)) as f32).sqrt()
+}
+
+fn download(buf: &GpuBuffer<f32>, n: usize) -> Vec<f32> {
+    let mut host = vec![0.0f32; buf.len()];
+    buf.copy_to_host(&mut host).expect("download");
+    host.truncate(n);
+    host
+}
+
+/// x[m,k] @ w[n,k]^T -> [m,n] (HF row-major weight convention)
+fn matmul_nt(x: &[f32], w: &[f32], m: usize, k: usize, n: usize) -> Vec<f32> {
+    crate::autograd::ops::matmul::matmul_nt_compute(x, w, m, k, n)
+}
+
+fn add_bias(x: &mut [f32], bias: &[f32], rows: usize) {
+    let dim = bias.len();
+    for r in 0..rows {
+        for (i, b) in bias.iter().enumerate() {
+            x[r * dim + i] += b;
+        }
+    }
+}
+
+fn rms_norm(x: &[f32], weight: &[f32], rows: usize, dim: usize, eps: f32) -> Vec<f32> {
+    let mut out = vec![0.0f32; rows * dim];
+    for r in 0..rows {
+        let row = &x[r * dim..(r + 1) * dim];
+        let ms: f32 = row.iter().map(|v| v * v).sum::<f32>() / dim as f32;
+        let inv = 1.0 / (ms + eps).sqrt();
+        for i in 0..dim {
+            out[r * dim + i] = row[i] * inv * weight[i];
+        }
+    }
+    out
+}
+
+/// NeoX half-rotation RoPE, matching `attention.rs::apply_rope`.
+fn rope(x: &mut [f32], seq_len: usize, num_heads: usize, head_dim: usize, theta: f32) {
+    let total = num_heads * head_dim;
+    let half = head_dim / 2;
+    let inv_freq: Vec<f32> =
+        (0..half).map(|i| 1.0 / theta.powf(2.0 * i as f32 / head_dim as f32)).collect();
+    for pos in 0..seq_len {
+        for h in 0..num_heads {
+            let off = pos * total + h * head_dim;
+            for i in 0..half {
+                let f = pos as f32 * inv_freq[i];
+                let (s, c) = f.sin_cos();
+                let a = x[off + i];
+                let b = x[off + i + half];
+                x[off + i] = a * c - b * s;
+                x[off + i + half] = b * c + a * s;
+            }
+        }
+    }
+}
+
+/// Causal softmax attention, GQA, interleaved layout in/out.
+fn attention(
+    q: &[f32],
+    k: &[f32],
+    v: &[f32],
+    seq_len: usize,
+    num_heads: usize,
+    num_kv_heads: usize,
+    head_dim: usize,
+) -> Vec<f32> {
+    let q_dim = num_heads * head_dim;
+    let kv_dim = num_kv_heads * head_dim;
+    let heads_per_kv = num_heads / num_kv_heads;
+    let scale = 1.0 / (head_dim as f32).sqrt();
+    let mut out = vec![0.0f32; seq_len * q_dim];
+    for h in 0..num_heads {
+        let kv_h = h / heads_per_kv;
+        for i in 0..seq_len {
+            // scores over j <= i
+            let mut scores = vec![0.0f32; i + 1];
+            for (j, sc) in scores.iter_mut().enumerate() {
+                let mut dot = 0.0f32;
+                for d in 0..head_dim {
+                    dot += q[i * q_dim + h * head_dim + d] * k[j * kv_dim + kv_h * head_dim + d];
+                }
+                *sc = dot * scale;
+            }
+            let m = scores.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+            let mut denom = 0.0f32;
+            for sc in &mut scores {
+                *sc = (*sc - m).exp();
+                denom += *sc;
+            }
+            for d in 0..head_dim {
+                let mut acc = 0.0f32;
+                for (j, sc) in scores.iter().enumerate() {
+                    acc += sc * v[j * kv_dim + kv_h * head_dim + d];
+                }
+                out[i * q_dim + h * head_dim + d] = acc / denom;
+            }
+        }
+    }
+    out
+}
+
+#[test]
+#[ignore = "requires CUDA GPU + APR_PARITY_MODEL pointing at a Qwen2-family .apr"]
+fn parity_probe_layer0_per_op() {
+    let Ok(model_path) = std::env::var("APR_PARITY_MODEL") else {
+        eprintln!("[op-probe] SKIP: APR_PARITY_MODEL unset");
+        return;
+    };
+    let config = TransformerConfig::from_apr_metadata(
+        Some(1536),
+        Some(12),
+        Some(2),
+        Some(8960),
+        Some(28),
+        Some(151_936),
+        Some(32_768),
+        Some(1e-6),
+        Some(1_000_000.0),
+        Some("qwen2"),
+    )
+    .expect("config");
+
+    let model = Transformer::from_apr(&model_path, &config).expect("model");
+    let layer = &model.layers[0];
+
+    let seq_len = 15usize;
+    let max_seq = 16usize;
+    let hidden = config.hidden_size;
+    let q_dim = config.q_dim();
+    let kv_dim = config.num_kv_heads * config.head_dim();
+    let inter = config.intermediate_size;
+    let num_heads = config.num_attention_heads;
+    let num_kv = config.num_kv_heads;
+    let head_dim = config.head_dim();
+    let eps = config.rms_norm_eps;
+    let theta = config.rope_theta;
+
+    // Deterministic pseudo-input: embed of a fixed token sequence.
+    let token_ids: Vec<u32> =
+        vec![3838, 374, 220, 17, 10, 17, 30, 21806, 448, 1101, 279, 1372, 13, 198, 19];
+    let embed = model.embed_tokens.forward(&token_ids);
+    let x = embed.data().as_slice().expect("contiguous").to_vec();
+    assert_eq!(x.len(), seq_len * hidden);
+
+    // ── GPU: build layer-0 NF4 block + scratch, run forward once ──────
+    let trainer = CudaTrainer::new().expect("CUDA trainer");
+    let ctx = std::sync::Arc::clone(trainer.context());
+    let stream = trainer.stream();
+
+    let g = |t: &crate::Tensor| -> Vec<f32> { t.data().as_slice().expect("contiguous").to_vec() };
+    let input_norm_w = g(&layer.input_norm.weight);
+    let post_norm_w = g(&layer.post_attn_norm.weight);
+    let w_q = g(&layer.self_attn.w_q);
+    let w_k = g(&layer.self_attn.w_k);
+    let w_v = g(&layer.self_attn.w_v);
+    let w_o = g(&layer.self_attn.w_o);
+    let w_gate = g(&layer.ffn.w_gate);
+    let w_up = g(&layer.ffn.w_up);
+    let w_down = g(&layer.ffn.w_down);
+    let b_q = layer.self_attn.b_q.as_ref().map(|t| g(t));
+    let b_k = layer.self_attn.b_k.as_ref().map(|t| g(t));
+    let b_v = layer.self_attn.b_v.as_ref().map(|t| g(t));
+
+    let block = CudaNf4TransformerBlock::new(
+        &config,
+        0,
+        std::sync::Arc::clone(&ctx),
+        &input_norm_w,
+        &post_norm_w,
+        &w_q,
+        &w_k,
+        &w_v,
+        &w_o,
+        &w_gate,
+        &w_up,
+        &w_down,
+        max_seq,
+        None,
+        None,
+        1.0,
+        8,
+        None,
+        None,
+        b_q.as_deref(),
+        b_k.as_deref(),
+        b_v.as_deref(),
+    )
+    .expect("NF4 block");
+    let mut scratch = CudaBlockScratch::new(&config, max_seq, &ctx, 8).expect("scratch");
+    scratch.zero_forward_buffers(stream);
+
+    let gpu_in = trainer.upload(&x).expect("upload");
+    let mut gpu_out = trainer.zeros(seq_len * hidden).expect("out");
+    block.forward(&gpu_in, &mut gpu_out, seq_len, stream, &mut scratch).expect("forward");
+    stream.synchronize().expect("sync");
+
+    let g_norm1 = download(&scratch.norm1_out, seq_len * hidden);
+    let g_q = download(&scratch.q, seq_len * q_dim);
+    let g_k = download(&scratch.k, seq_len * kv_dim);
+    let g_v = download(&scratch.v, seq_len * kv_dim);
+    let g_attn = download(&scratch.attn_out, seq_len * q_dim);
+    let g_oproj = download(&scratch.o_proj_out, seq_len * hidden);
+    let g_res1 = download(&scratch.residual1, seq_len * hidden);
+    let g_norm2 = download(&scratch.norm2_out, seq_len * hidden);
+    let g_gate = download(&scratch.gate_out, seq_len * inter);
+    let g_up = download(&scratch.up_out, seq_len * inter);
+    let g_swiglu = download(&scratch.swiglu_out, seq_len * inter);
+    let g_ffn = download(&scratch.ffn_out, seq_len * hidden);
+    let g_out = download(&gpu_out, seq_len * hidden);
+
+    // ── CPU replay (no biases — matching what the GPU block computes; the
+    //    bias gap is reported separately at the q/k/v stage) ─────────────
+    let norm1 = rms_norm(&x, &input_norm_w, seq_len, hidden, eps);
+    eprintln!("[op-probe] norm1:        relL2={:.4}", rel_l2(&g_norm1, &norm1));
+
+    let mut q_nb = matmul_nt(&norm1, &w_q, seq_len, hidden, q_dim);
+    let mut k_nb = matmul_nt(&norm1, &w_k, seq_len, hidden, kv_dim);
+    let v_nb = matmul_nt(&norm1, &w_v, seq_len, hidden, kv_dim);
+    let mut q_b = q_nb.clone();
+    let mut k_b = k_nb.clone();
+    let mut v_b = v_nb.clone();
+    if let Some(ref b) = b_q {
+        add_bias(&mut q_b, b, seq_len);
+    }
+    if let Some(ref b) = b_k {
+        add_bias(&mut k_b, b, seq_len);
+    }
+    if let Some(ref b) = b_v {
+        add_bias(&mut v_b, b, seq_len);
+    }
+    rope(&mut q_nb, seq_len, num_heads, head_dim, theta);
+    rope(&mut k_nb, seq_len, num_kv, head_dim, theta);
+    rope(&mut q_b, seq_len, num_heads, head_dim, theta);
+    rope(&mut k_b, seq_len, num_kv, head_dim, theta);
+
+    eprintln!(
+        "[op-probe] q (post-rope): relL2(gpu,nobias)={:.4}  relL2(gpu,bias)={:.4}",
+        rel_l2(&g_q, &q_nb),
+        rel_l2(&g_q, &q_b)
+    );
+    eprintln!(
+        "[op-probe] k (post-rope): relL2(gpu,nobias)={:.4}  relL2(gpu,bias)={:.4}",
+        rel_l2(&g_k, &k_nb),
+        rel_l2(&g_k, &k_b)
+    );
+    eprintln!(
+        "[op-probe] v:             relL2(gpu,nobias)={:.4}  relL2(gpu,bias)={:.4}",
+        rel_l2(&g_v, &v_nb),
+        rel_l2(&g_v, &v_b)
+    );
+
+    let attn_nb = attention(&q_nb, &k_nb, &v_nb, seq_len, num_heads, num_kv, head_dim);
+    let attn_b = attention(&q_b, &k_b, &v_b, seq_len, num_heads, num_kv, head_dim);
+    eprintln!(
+        "[op-probe] attn_out:      relL2(gpu,nobias)={:.4}  relL2(gpu,bias)={:.4}",
+        rel_l2(&g_attn, &attn_nb),
+        rel_l2(&g_attn, &attn_b)
+    );
+
+    // continue CPU replay from the WITH-BIAS attention (the true model)
+    let oproj = matmul_nt(&attn_b, &w_o, seq_len, q_dim, hidden);
+    eprintln!("[op-probe] o_proj:        relL2={:.4}", rel_l2(&g_oproj, &oproj));
+
+    let res1: Vec<f32> = x.iter().zip(oproj.iter()).map(|(a, b)| a + b).collect();
+    eprintln!("[op-probe] residual1:     relL2={:.4}", rel_l2(&g_res1, &res1));
+
+    let norm2 = rms_norm(&res1, &post_norm_w, seq_len, hidden, eps);
+    eprintln!("[op-probe] norm2:         relL2={:.4}", rel_l2(&g_norm2, &norm2));
+
+    let gate = matmul_nt(&norm2, &w_gate, seq_len, hidden, inter);
+    let up = matmul_nt(&norm2, &w_up, seq_len, hidden, inter);
+    eprintln!("[op-probe] gate:          relL2={:.4}", rel_l2(&g_gate, &gate));
+    eprintln!("[op-probe] up:            relL2={:.4}", rel_l2(&g_up, &up));
+
+    let swiglu: Vec<f32> =
+        gate.iter().zip(up.iter()).map(|(&gv, &uv)| (gv / (1.0 + (-gv).exp())) * uv).collect();
+    eprintln!("[op-probe] swiglu:        relL2={:.4}", rel_l2(&g_swiglu, &swiglu));
+
+    let ffn = matmul_nt(&swiglu, &w_down, seq_len, inter, hidden);
+    eprintln!("[op-probe] ffn_down:      relL2={:.4}", rel_l2(&g_ffn, &ffn));
+
+    let out: Vec<f32> = res1.iter().zip(ffn.iter()).map(|(a, b)| a + b).collect();
+    eprintln!("[op-probe] block_out:     relL2={:.4}", rel_l2(&g_out, &out));
+}


### PR DESCRIPTION
## Summary

Cascade defect #4 (after #2249 deadlock, #2250 loss window, #2251 stream race): training ran NaN-free but **never learned** — CE flat at 13-14 (> ln(V)=11.93, worse than uniform) on trivially predictable targets, then adapter poisoning after ~125 steps. Three-oracle bisection (GPU-fused vs GPU-forward+CPU-CE vs pure-CPU) localized it to the transformer forward and exonerated the fused CE kernel — then per-op layer-0 bisection found **four stacked defects**:

1. **Wrong RoPE pairing (dominant)** — `batched_rope_neox_forward/_backward` instantiated `BatchedRopeKernel` (GPT-J *adjacent* pairs, `elem0=2*pair_idx`) despite the NeoX name. Qwen2 weights need NeoX *split-half* `(i, i+d/2)`. Fix: new `BatchedRopeNeoxKernel`/`BatchedRopeNeoxBackwardKernel` (precise trig per CORRECTNESS-013); wrappers + pre-warm keys rewired. `BatchedRopeKernel` untouched — realizar uses it for non-NeoX rope types.
2. **Dropped Q/K/V biases** — `CudaNf4TransformerBlock` had zero bias support; Qwen2 sets `use_bias=true` and the model carries `blk.N.attn_{q,k,v}.bias` (CPU path applies them). Fix: replicated bias buffers + `cuda_add_inplace` after each projection GEMM, threaded from all 3 NF4 sites + the instruct FP32 site. Backward unchanged (activation-checkpoint re-runs the fixed forward; biases frozen).
3. **Partial-warp `shfl.sync` UB** — batched softmax fwd/bwd launched `block=(32.min(row_size))` while reducing with membermask `0xFFFFFFFF` → undefined for seq<32 → data-dependent NaN rows. Fix: always full 32-lane warp.
4. **Non-causal CPU oracle (label leakage)** — `autograd/ops/attention.rs` had no causal mask; the CPU train/eval path attended bidirectionally (toy causal CE 2.13 misreported as 0.17). Fix: `attention_causal` dispatched for `ModelArchitecture::Decoder` (encoders stay bidirectional); shared backward exact since masked weights are 0.

## Verification (RTX 4090, sm_89)

- **Falsifier** `FALSIFY-CUDA-NF4-TRAIN-LOSS-PARITY-001` (`parity_probe.rs`): GPU loss + full logits vs an NF4-quantization-matched **causal** CPU oracle. GREEN: CE 0.6820 vs 0.6557 (|Δ|=0.026 < 0.5), logits relL2 0.047 < 0.10. **Mutation-verified RED per individually reverted fix**: rope → relL2 0.183; biases → CE 5.17 / relL2 0.97; warp → NaN. Companion probes: per-layer bisect + per-op layer-0.
- **Contract** `contracts/cuda-nf4-train-loss-parity-v1.yaml` — `pv validate` + `pv lint contracts/` PASS.
- **E2E** (`apr_code_sft_balanced.jsonl`, 160 samples, `--max-seq-len 2048`): first-step CE **1.58** (pre-fix: 13-14); at lr 2e-5 loss descends 4.31→0.29 by step 50, **epoch avg 1.55, 0 NaN** — independently reproduced on this cherry-picked content: epoch 1 avg_loss=1.5842, 0 NaN, run still converging.
- `aprender-gpu --lib` 440/440; `aprender-train --lib` failures (6) all reproduce on the base commit (pre-existing: release-mode debug_assert class, insta snapshot drift).

## Known follow-ups (separate beats, not claimed here)

- Auto-config **lr 2e-4 @ rank 256 diverges** after ~25 steps (finite) — training-dynamics defect; lr 2e-5 proven stable/decreasing.
- `evaluate()` val_loss is byte-identical across runs with different lr (pre-existing) — likely no GPU→CPU LoRA sync before eval; needs its own bisection.
- `rms_norm_backward` hardcodes eps=1e-5 (backward-only precision vs Qwen2 1e-6).
- Single-row `SoftmaxKernel` broken by construction for all lengths (not on the training path).

With this, `apr finetune -m qlora` **trains the correct model** on the 4090 end-to-end — the apr-code tool_call flip is running on it now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)