### PR TITLE
ci: wire 3 claimed-not-wired beat gates into the per-PR integration chain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,7 +291,7 @@ jobs:
             -e CARGO_INCREMENTAL=0 \
             -e CARGO_BUILD_JOBS=8 \
             "$IMAGE" \
-            bash -c 'cargo test -p aprender-core --test monorepo_invariants && cargo test -p aprender-core --test readme_contract && cargo test -p apr-cli --test cli_commands && cargo test -p aprender-core --test beat_sklearn_iris && cargo test -p aprender-serve --test beat_fail_closed_garbage && cargo test -p aprender-compute --lib beat_nf4_bitsandbytes_equivalence && cargo test -p aprender-core --test beat_pytorch_autograd_grad && cargo test -p aprender-train-lora --lib beat_lora_merge_forward_equivalence'
+            bash -c 'cargo test -p aprender-core --test monorepo_invariants && cargo test -p aprender-core --test readme_contract && cargo test -p apr-cli --test cli_commands && cargo test -p aprender-core --test beat_sklearn_iris && cargo test -p aprender-serve --test beat_fail_closed_garbage && cargo test -p aprender-compute --lib beat_nf4_bitsandbytes_equivalence && cargo test -p aprender-core --test beat_pytorch_autograd_grad && cargo test -p aprender-train-lora --lib beat_lora_merge_forward_equivalence && cargo test -p apr-cli --test beat_pytorch_deploy_footprint && cargo test -p aprender-serve --test beat_fail_closed_structural && cargo test -p aprender-serve --test ollama_http_compat'
       - name: Build.rs crate-root escape check (v0.31.1 yank guard)
         # Static Poka-Yoke: flags build.rs files that panic on files outside
         # CARGO_MANIFEST_DIR, which break `cargo install` from crates.io.


### PR DESCRIPTION
Pillar audit (2026-07-02) found three beats whose contracts/docs claim CI
enforcement but which ran in no workflow — 'declared-but-unwired', the
exact gap-mode from the contracts-ratchet rule:

- beat_pytorch_deploy_footprint (P2, 15.8x deploy-size win): contract +
  docs/BEATS.md say "CI beat_pytorch_deploy_footprint"; no workflow ran it.
- beat_fail_closed_structural (P4, PMAT-756 cross-tensor dim mismatch —
  apr rejects 2/2 classes that safetensors/HF/Ollama silently load):
  contract status said enforced; no workflow ran it.
- ollama_http_compat (P4, /api NDJSON framing falsifiers): integration
  tests existed outside any chain.

All three verified locally: 10/10 tests pass, <10s combined, CPU-only,
no network. One-line append to the workspace-test integration chain
(required status check) — converts three measured wins from
claimed-not-wired to ENFORCED per-PR.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
