### PR TITLE
ci(security): exempt RUSTSEC-2026-0194/-0195 (quick-xml NsReader DoS — not the affected path)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -42,4 +42,11 @@ ignore = [
     "RUSTSEC-2026-0098",
     "RUSTSEC-2026-0099",
     "RUSTSEC-2026-0104",
+
+    # quick-xml 0.37.5 — quadratic parse of duplicate-attribute start tags (DoS,
+    # not RCE). Affected ONLY via NsReader; orchestrate's sole use (oracle/arxiv.rs)
+    # is quick_xml::Reader, not NsReader — not the affected path. Patched >=0.41.0
+    # is a 0.37->0.41 API break deferred past v0.57.0.
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",  # quick-xml NsReader namespace-alloc DoS — same not-affected path as -0194
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -40,6 +40,13 @@ ignore = [
     { id = "RUSTSEC-2026-0094", reason = "wasmtime: test-only dep (aprender-test-lib)" },
     { id = "RUSTSEC-2026-0096", reason = "wasmtime: test-only dep (aprender-test-lib)" },
     { id = "RUSTSEC-2026-0114", reason = "wasmtime 43 table allocation panic: test-only dep, availability bug not RCE" },
+    # quick-xml 0.37.5 quadratic parse of duplicate-attribute start tags (DoS, not
+    # RCE). Advisory: affected ONLY via `NsReader`; aprender-orchestrate's sole use
+    # (oracle/arxiv.rs) is `quick_xml::Reader`, never `NsReader`, so we do not hit
+    # the vulnerable path. Patched >=0.41.0 is a 0.37->0.41 API break deferred past
+    # v0.57.0; provably not-affected in the interim.
+    { id = "RUSTSEC-2026-0194", reason = "quick-xml 0.37.5: DoS via NsReader only; orchestrate uses Reader (arxiv.rs), not the affected path. Bump to 0.41 deferred." },
+    { id = "RUSTSEC-2026-0195", reason = "quick-xml 0.37.5: NsReader namespace-alloc DoS; orchestrate uses Reader (arxiv.rs), not NsReader. Same not-affected + deferred-bump rationale as -0194." },
     # rustls-webpki 0.101.7 — transitive via aws-smithy-http-client (rustls 0.21).
     # Direct 0.103.x path already patched to >=0.103.12; 0.101.7 is pinned inside
     # the AWS SDK graph and can only move via a major SDK bump.


### PR DESCRIPTION
Two quick-xml advisories published 2026-07-02 (0194 quadratic dup-attr
parse; 0195 unbounded namespace-declaration alloc) fail cargo-audit +
cargo-deny on every fresh run, blocking the whole merge queue.

Both are affected ONLY via `NsReader`. aprender-orchestrate's sole
quick-xml use (oracle/arxiv.rs) is `quick_xml::Reader`, never NsReader,
so we do not reach the vulnerable code. Patched is >=0.41.0 — a
0.37->0.41 API break deferred past v0.57.0. Exempted with the
not-affected rationale in both deny.toml and .cargo/audit.toml (mirror).

cargo deny check advisories: ok.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
