### PR TITLE
fix(finetune): rank-aware learning rate — default `apr finetune -m qlora` no longer diverges

### DIFF
--- a/contracts/qlora-rank-aware-lr-v1.yaml
+++ b/contracts/qlora-rank-aware-lr-v1.yaml
@@ -1,0 +1,138 @@
+metadata:
+  id: C-QLORA-RANK-AWARE-LR
+  version: 1.0.0
+  created: '2026-07-02'
+  author: PAIML Engineering
+  kind: pattern
+  status: ACTIVE_ALGORITHM_LEVEL
+  description: |
+    Pins the auto-selected learning rate for `apr finetune -m lora/qlora` to the
+    convergent regime at the high LoRA ranks the planner picks to fill VRAM.
+
+    BACKGROUND. `LoraOptimizer::find_optimal_rank` binary-searches the LARGEST
+    rank that fits the VRAM budget (up to 256), then `apr finetune` used a fixed
+    CLI default learning rate of 2e-4. That pairing DIVERGES: measured live on an
+    RTX 4090, a 1.5B QLoRA run at lr 2e-4 / rank 256 / seq 2048 on
+    apr_code_sft_balanced went 4.31 -> 1.44 (learning) then blew up to 11-16,
+    epoch avg 11.18 — worse than the untrained model. The classic 2e-4 is a
+    known-good default only for the small ranks (<= ~32) LoRA papers use; at the
+    VRAM-filling ranks this optimizer auto-selects it is far too hot.
+
+    ROOT CAUSE. `OptimalConfig` recommended `rank` and `alpha` but NOT a learning
+    rate, and the CLI default (2e-4) was decoupled from the auto-selected rank.
+    So the two knobs the optimizer controls (rank up, lr fixed) combined into a
+    divergent configuration out of the box.
+
+    FIX. `OptimalConfig` gains a rank-aware `learning_rate`, computed by
+    `recommended_learning_rate(method, rank)`: anchored at 2e-4 for rank <= 32
+    (no regression for typical LoRA) and scaled inversely with rank above that,
+    clamped to [1e-5, 2e-4]:
+      rank 32 -> 2e-4, 64 -> 1e-4, 128 -> 5e-5, 256 -> 2.5e-5 (~ the stable 2e-5);
+      full fine-tuning (rank 0) -> a conservative fixed 1e-5.
+    `apr finetune` makes `--learning-rate` optional: when omitted it uses the
+    rank-aware recommendation (recomputed if `--rank` is overridden); an explicit
+    value still wins. Early sub-modes (merge/classify/multi-adapter) keep the
+    classic 2e-4 default — the divergence was measured on the instruct LoRA/QLoRA
+    path, so the auto-lowering is scoped there.
+
+  references:
+    - 'crates/aprender-train-lora/src/optimizer.rs:47 (recommended_learning_rate)'
+    - 'crates/aprender-train-lora/src/optimizer.rs:35 (OptimalConfig.learning_rate field)'
+    - 'crates/aprender-train-lora/src/optimizer.rs:149 (optimize() populates it)'
+    - 'crates/apr-cli/src/commands/finetune.rs:1210 (CLI resolves rank-aware lr when --learning-rate omitted)'
+    - 'crates/apr-cli/src/model_ops_commands.rs:38 (--learning-rate now Option<f64>)'
+
+equations:
+  rank_aware_lr:
+    formula: |
+      lr(method, rank) =
+        1e-5                                        if method = Full or rank = 0
+        clamp(2e-4 * 32 / rank, 1e-5, 2e-4)         otherwise
+    domain: |
+      The planner auto-selects rank to fill VRAM (up to 256). The learning rate
+      must decrease with rank so the update magnitude stays in the convergent
+      band; the classic 2e-4 is retained only where it is known-good (rank<=32).
+    invariants:
+    - '0 < lr(method, rank) <= 2e-4 for all rank'
+    - 'lr is non-increasing in rank'
+    - 'lr(_, rank) <= 5e-5 for rank >= 128 (convergent band; 2e-4 diverges there)'
+    - 'lr(_, rank) == 2e-4 for 0 < rank <= 32 (no regression for typical LoRA)'
+    preconditions:
+    - 'rank is the planner-selected or user-overridden LoRA rank'
+
+proof_obligations:
+- type: invariant
+  property: auto-selected learning rate is convergent at high ranks
+  formal: 'rank >= 128 ⇒ recommended_learning_rate(m, rank) <= 5e-5'
+  applies_to: rank_aware_lr
+- type: invariant
+  property: never hotter than the classic default and monotonic in rank
+  formal: '∀ r: 0 < lr(r) <= 2e-4 ∧ (r1 < r2 ⇒ lr(r1) >= lr(r2))'
+  applies_to: rank_aware_lr
+- type: invariant
+  property: optimize() populates the rank-aware lr end to end
+  formal: 'optimize().learning_rate == recommended_learning_rate(method, rank)'
+  applies_to: rank_aware_lr
+
+falsification_tests:
+- id: FALSIFY-QLORA-RANK-AWARE-LR-001
+  rule: |
+    The learning rate the optimizer recommends for its auto-selected high ranks
+    must sit in the empirically-convergent band, not the classic 2e-4 that
+    diverges there.
+  prediction: |
+    recommended_learning_rate(QLoRA, 256) <= 5e-5 (measured convergent ~2.5e-5);
+    the pre-fix behavior (a fixed 2e-4) is > 5e-5 and FAILS. Also checks rank 128.
+  test: cargo test -p aprender-train-lora --lib falsify_qlora_rank_aware_lr_001_high_rank_is_convergent
+  if_fails: |
+    recommended_learning_rate stopped scaling down with rank (reverted to a fixed
+    2e-4, or the anchor/clamp changed). `apr finetune -m qlora` will diverge again
+    at the auto-selected rank 256 (loss climbs past the untrained baseline).
+  ship_blocking: true
+  counter_example_classes:
+  - fixed_2e4_default_at_high_rank
+  - lr_decoupled_from_auto_selected_rank
+- id: FALSIFY-QLORA-RANK-AWARE-LR-002
+  rule: |
+    The recommendation is never hotter than the classic 2e-4, is unchanged for
+    the small ranks where 2e-4 is known-good, and is monotonically non-increasing
+    in rank.
+  prediction: |
+    lr(16)=lr(32)=2e-4; lr in (0,2e-4] and non-increasing across
+    ranks 8..512; lr(Full,0)=1e-5.
+  test: cargo test -p aprender-train-lora --lib falsify_qlora_rank_aware_lr_002_bounds_and_monotonic
+  if_fails: |
+    The lr curve regressed a small-rank value (breaking typical LoRA) or lost
+    monotonicity/bounds. Check the clamp and anchor in recommended_learning_rate.
+  ship_blocking: true
+  counter_example_classes:
+  - small_rank_regression
+  - non_monotonic_lr_curve
+- id: FALSIFY-QLORA-RANK-AWARE-LR-003
+  rule: |
+    A real end-to-end OptimalConfig for a VRAM-constrained model must not hand
+    back the diverging 2e-4 at its auto-selected high rank.
+  prediction: |
+    LoraOptimizer::new(1.5e9, 24.0).optimize(QLoRA).learning_rate ==
+    recommended_learning_rate(QLoRA, rank), and <= 5e-5 when rank >= 128.
+  test: cargo test -p aprender-train-lora --lib falsify_qlora_rank_aware_lr_003_optimize_populates_convergent_lr
+  if_fails: |
+    optimize() stopped populating learning_rate from recommended_learning_rate
+    (field left at a default, or wired to a constant). The CLI would fall back to
+    the diverging value.
+  ship_blocking: true
+  counter_example_classes:
+  - optimize_does_not_populate_lr
+
+qa_gate:
+  id: QA-QLORA-RANK-AWARE-LR-001
+  name: QLoRA rank-aware learning-rate gate
+  description: |
+    The optimizer recommends a convergent, rank-aware learning rate and the CLI
+    consumes it when --learning-rate is omitted, so `apr finetune -m qlora`
+    converges out of the box at the VRAM-filling ranks it auto-selects instead of
+    diverging under the classic fixed 2e-4.
+  checks:
+  - rank_aware_lr
+  pass_criteria: FALSIFY-QLORA-RANK-AWARE-LR-001..003 pass
+  falsification: Any failure fails the gate (ship-blocking)

--- a/crates/apr-cli/src/commands/finetune.rs
+++ b/crates/apr-cli/src/commands/finetune.rs
@@ -14,7 +14,10 @@
 use crate::error::{CliError, Result};
 use crate::output;
 use colored::Colorize;
-use entrenar_lora::{plan, MemoryPlanner, MemoryRequirement, MergeEngine, Method, OptimalConfig};
+use entrenar_lora::{
+    plan, recommended_learning_rate, MemoryPlanner, MemoryRequirement, MergeEngine, Method,
+    OptimalConfig,
+};
 use std::path::Path;
 
 /// Fine-tuning method selection
@@ -1123,7 +1126,7 @@ pub(crate) fn run(
     adapter_path: Option<&Path>,
     merge_mode: bool,
     epochs: u32,
-    learning_rate: f64,
+    learning_rate: Option<f64>,
     model_size: Option<&str>,
     task: Option<&str>,
     num_classes: usize,
@@ -1158,6 +1161,11 @@ pub(crate) fn run(
         wait_for_gpu_vram(wait_gpu, vram_gb, task)?;
     }
 
+    // Early sub-modes (merge / classify / multi-adapter) keep the classic 2e-4
+    // default when --learning-rate is omitted. The rank-aware auto-lowering
+    // below applies to the instruct LoRA/QLoRA path, where the 2e-4 divergence
+    // at high auto-selected ranks was actually measured.
+    let dispatch_lr = learning_rate.unwrap_or(2e-4);
     if let Some(dispatched) = dispatch_finetune_mode(
         merge_mode,
         model_path,
@@ -1168,7 +1176,7 @@ pub(crate) fn run(
         num_classes,
         rank,
         epochs,
-        learning_rate,
+        dispatch_lr,
         plan_only,
         checkpoint_format,
         oversample,
@@ -1197,15 +1205,6 @@ pub(crate) fn run(
     }
 
     let model_params = resolve_model_params(model_size, model_path)?;
-    display_run_header(
-        ft_method,
-        model_params,
-        vram_gb,
-        rank,
-        epochs,
-        learning_rate,
-        json_output,
-    );
 
     let mut config = plan(model_params, vram_gb, ft_method.into())
         .map_err(|e| CliError::ValidationFailed(format!("Failed to plan config: {e}")))?;
@@ -1215,7 +1214,25 @@ pub(crate) fn run(
     if let Some(user_rank) = rank {
         config.rank = user_rank;
         config.alpha = user_rank as f32 * 2.0; // alpha = 2 * rank (standard)
+                                               // Keep the LR consistent with the (now overridden) rank.
+        config.learning_rate = recommended_learning_rate(config.method, user_rank);
     }
+
+    // FALSIFY-QLORA-RANK-AWARE-LR: resolve the effective learning rate. An
+    // explicit --learning-rate wins; otherwise use the rank-aware recommendation
+    // — the classic 2e-4 default diverges at the high ranks auto-selected to
+    // fill VRAM (measured: 1.5B QLoRA @ 2e-4/rank256 blew up to loss ~11-16).
+    let learning_rate = learning_rate.unwrap_or_else(|| f64::from(config.learning_rate));
+
+    display_run_header(
+        ft_method,
+        model_params,
+        vram_gb,
+        rank,
+        epochs,
+        learning_rate,
+        json_output,
+    );
 
     display_finetune_plan(
         &config,

--- a/crates/apr-cli/src/commands/finetune_contract_tests.rs
+++ b/crates/apr-cli/src/commands/finetune_contract_tests.rs
@@ -118,6 +118,7 @@ fn falsify_ft_008_optimal_config_fields() {
         memory_gb: 4.0,
         utilization_percent: 80.0,
         speedup: 3.0,
+        learning_rate: 2e-4,
     };
     assert_eq!(config.rank, 16, "FALSIFY-FT-008: rank");
     assert!(

--- a/crates/apr-cli/src/commands/finetune_tests.rs
+++ b/crates/apr-cli/src/commands/finetune_tests.rs
@@ -59,7 +59,7 @@ fn test_run_no_model() {
         None,
         false,
         3,
-        2e-4,
+        Some(2e-4),
         None,
         None,
         5,
@@ -96,7 +96,7 @@ fn test_run_plan_with_model_size() {
         None,
         false,
         3,
-        2e-4,
+        Some(2e-4),
         Some("7B"),
         None,
         5,
@@ -133,7 +133,7 @@ fn test_run_plan_json() {
         None,
         false,
         3,
-        2e-4,
+        Some(2e-4),
         Some("14B"),
         None,
         5,
@@ -172,7 +172,7 @@ fn test_run_with_model_file() {
         None,
         false,
         3,
-        2e-4,
+        Some(2e-4),
         None,
         None,
         5,
@@ -302,7 +302,7 @@ fn test_run_training_creates_adapter() {
         None,
         false,
         3,
-        2e-4,
+        Some(2e-4),
         Some("0.5B"),
         None,
         5,
@@ -1289,7 +1289,7 @@ fn run_with_missing_model_file_errors() {
         None,          // adapter_path
         false,         // merge_mode
         1,             // epochs
-        1e-4,          // learning_rate
+        Some(1e-4),    // learning_rate
         None,          // model_size
         None,          // task
         2,             // num_classes

--- a/crates/apr-cli/src/model_ops_commands.rs
+++ b/crates/apr-cli/src/model_ops_commands.rs
@@ -34,9 +34,12 @@ pub enum ModelOpsCommands {
         /// Training epochs
         #[arg(long, default_value = "3")]
         epochs: u32,
-        /// Learning rate
-        #[arg(long, default_value = "0.0002")]
-        learning_rate: f64,
+        /// Learning rate. Default is rank-aware: the classic 2e-4 diverges at
+        /// the high LoRA ranks auto-selected to fill VRAM (e.g. rank 256), so
+        /// when omitted the recommendation is auto-lowered (2e-4 at rank<=32
+        /// down to ~2.5e-5 at rank 256). Pass an explicit value to override.
+        #[arg(long)]
+        learning_rate: Option<f64>,
         /// Model size for planning (e.g., "7B", "1.5B")
         #[arg(long, value_name = "SIZE")]
         model_size: Option<String>,

--- a/crates/aprender-train-lora/src/lib.rs
+++ b/crates/aprender-train-lora/src/lib.rs
@@ -17,7 +17,7 @@ pub mod optimizer;
 
 pub use memory::{MemoryPlanner, MemoryRequirement};
 pub use merge::MergeEngine;
-pub use optimizer::{LoraOptimizer, OptimalConfig};
+pub use optimizer::{recommended_learning_rate, LoraOptimizer, OptimalConfig};
 
 use entrenar_common::Result;
 

--- a/crates/aprender-train-lora/src/optimizer.rs
+++ b/crates/aprender-train-lora/src/optimizer.rs
@@ -25,6 +25,34 @@ pub struct OptimalConfig {
     pub utilization_percent: f64,
     /// Training speedup compared to full fine-tuning
     pub speedup: f64,
+    /// Rank-aware recommended learning rate.
+    ///
+    /// The classic 2e-4 LoRA default DIVERGES at the high ranks this optimizer
+    /// auto-selects to fill VRAM (e.g. rank 256 on a 24 GB card): measured on an
+    /// RTX 4090, a 1.5B QLoRA run at lr 2e-4 / rank 256 went 4.31 -> 1.44 then
+    /// blew up to 11-16 (avg 11.18). lr 2e-5 is stable at rank 256. See
+    /// `recommended_learning_rate`.
+    pub learning_rate: f32,
+}
+
+/// Rank-aware LoRA learning rate.
+///
+/// Anchored at the classic 2e-4 for the small ranks where it is known-good
+/// (<= 32) and scaled down inversely with rank above that, so the VRAM-filling
+/// ranks this optimizer selects stay in the convergent regime:
+/// rank 32 -> 2e-4, rank 64 -> 1e-4, rank 128 -> 5e-5, rank 256 -> 2.5e-5
+/// (matching the empirically-stable ~2e-5). Full fine-tuning (rank 0) uses a
+/// conservative fixed 1e-5. Clamped to `[1e-5, 2e-4]` so it is never hotter
+/// than the classic default nor absurdly cold.
+#[must_use]
+pub fn recommended_learning_rate(method: Method, rank: u32) -> f32 {
+    const BASE_LR: f32 = 2e-4;
+    const ANCHOR_RANK: f32 = 32.0;
+    const MIN_LR: f32 = 1e-5;
+    if method == Method::Full || rank == 0 {
+        return MIN_LR;
+    }
+    (BASE_LR * ANCHOR_RANK / rank as f32).clamp(MIN_LR, BASE_LR)
 }
 
 impl OptimalConfig {
@@ -118,6 +146,7 @@ impl LoraOptimizer {
             memory_gb,
             utilization_percent: utilization,
             speedup,
+            learning_rate: recommended_learning_rate(method, rank),
         })
     }
 
@@ -447,6 +476,76 @@ mod tests {
             assert!(c.trainable_params > 0);
             assert!(c.speedup > 0.0);
             assert!(c.rank >= 8);
+        }
+    }
+
+    /// FALSIFY-QLORA-RANK-AWARE-LR-001: the auto-selected learning rate for the
+    /// high LoRA ranks this optimizer chooses to fill VRAM MUST sit in the
+    /// empirically-convergent band, not the classic 2e-4 that diverges there.
+    #[test]
+    fn falsify_qlora_rank_aware_lr_001_high_rank_is_convergent() {
+        // Measured on RTX 4090: 1.5B QLoRA at lr 2e-4 / rank 256 diverged
+        // (4.31 -> 1.44 -> 11-16); lr ~2e-5 is stable. So the recommendation at
+        // rank 256 must be well below the diverging default.
+        let lr256 = recommended_learning_rate(Method::QLoRA, 256);
+        assert!(
+            lr256 <= 5e-5,
+            "FALSIFY-QLORA-RANK-AWARE-LR-001: rank-256 lr {lr256:.2e} is in the \
+             divergent regime (must be <= 5e-5; classic 2e-4 blows up here)"
+        );
+        assert!(lr256 > 0.0, "lr must be positive");
+        // 128 is also a commonly auto-selected rank; still convergent.
+        assert!(recommended_learning_rate(Method::QLoRA, 128) <= 5e-5);
+    }
+
+    /// FALSIFY-QLORA-RANK-AWARE-LR-002: never hotter than the classic default,
+    /// unchanged for the small ranks where 2e-4 is known-good, and monotonically
+    /// non-increasing in rank.
+    #[test]
+    fn falsify_qlora_rank_aware_lr_002_bounds_and_monotonic() {
+        // Small ranks keep the classic 2e-4 (no regression for typical LoRA).
+        assert!((recommended_learning_rate(Method::LoRA, 16) - 2e-4).abs() < 1e-9);
+        assert!((recommended_learning_rate(Method::LoRA, 32) - 2e-4).abs() < 1e-9);
+        // Never exceeds the classic default at any rank.
+        // Non-increasing as rank grows.
+        let mut prev = f32::INFINITY;
+        for r in [8u32, 16, 32, 64, 128, 256, 512] {
+            let lr = recommended_learning_rate(Method::QLoRA, r);
+            assert!(
+                lr > 0.0 && lr <= 2e-4,
+                "lr {lr:.2e} out of (0, 2e-4] at rank {r}"
+            );
+            assert!(
+                lr <= prev,
+                "lr must be non-increasing in rank ({lr:.2e} > {prev:.2e} at {r})"
+            );
+            prev = lr;
+        }
+        // Full fine-tuning (rank 0) uses a conservative fixed rate.
+        assert!((recommended_learning_rate(Method::Full, 0) - 1e-5).abs() < 1e-9);
+    }
+
+    /// FALSIFY-QLORA-RANK-AWARE-LR-003: optimize() actually populates the
+    /// rank-aware lr — a real end-to-end config for a VRAM-constrained model
+    /// must not hand back the diverging 2e-4 at its auto-selected high rank.
+    #[test]
+    fn falsify_qlora_rank_aware_lr_003_optimize_populates_convergent_lr() {
+        // A 1.5B model on a small VRAM budget → QLoRA at a high auto rank.
+        let opt = LoraOptimizer::new(1_500_000_000, 24.0);
+        let config = opt.optimize(Method::QLoRA).expect("optimize");
+        assert_eq!(
+            config.learning_rate,
+            recommended_learning_rate(Method::QLoRA, config.rank),
+            "optimize() must use recommended_learning_rate"
+        );
+        if config.rank >= 128 {
+            assert!(
+                config.learning_rate <= 5e-5,
+                "FALSIFY-QLORA-RANK-AWARE-LR-003: optimize() returned diverging lr \
+                 {:.2e} at rank {}",
+                config.learning_rate,
+                config.rank,
+            );
         }
     }
 }


### PR DESCRIPTION
## The bug

`LoraOptimizer::find_optimal_rank` binary-searches the **largest** LoRA rank that fits the VRAM budget (up to 256), but `apr finetune` used a fixed CLI default learning rate of **2e-4**. That pairing **diverges** out of the box.

Measured live on an **RTX 4090** — 1.5B QLoRA, lr 2e-4 / rank 256 / seq 2048 on `apr_code_sft_balanced`:

| step | 10 | 20 | 30 | 40 | 50 | … | 160 | epoch avg |
|---|---|---|---|---|---|---|---|---|
| loss | 4.31 | **1.44** | 7.08 | 15.06 | 16.02 | … | 13.83 | **11.18** |

It starts learning (4.31 → 1.44) then blows up past the untrained baseline. 2e-4 is only known-good for the small ranks (≤ ~32) LoRA papers use.

## Root cause

`OptimalConfig` recommended `rank` and `alpha` but **not** a learning rate — so the two knobs the optimizer controls (rank ↑, lr fixed) combined into a divergent config.

## The fix

`OptimalConfig` gains a rank-aware `learning_rate` via `recommended_learning_rate(method, rank)`:

| rank | ≤32 | 64 | 128 | 256 | Full (0) |
|---|---|---|---|---|---|
| lr | 2e-4 | 1e-4 | 5e-5 | 2.5e-5 | 1e-5 |

Anchored at the classic 2e-4 for small ranks (no regression), scaled inversely above, clamped to `[1e-5, 2e-4]`. The rank-256 value (~2.5e-5) matches the empirically-stable ~2e-5.

`apr finetune` makes `--learning-rate` **optional**: omitted → the rank-aware recommendation (recomputed if `--rank` is overridden); an explicit value still wins. Early sub-modes (merge/classify/multi-adapter) keep the classic 2e-4 — the divergence was measured on the instruct LoRA/QLoRA path, so the auto-lowering is scoped there.

## Falsifiers — `FALSIFY-QLORA-RANK-AWARE-LR-001..003`

Pure **unit tests** (CI-enforced, no GPU needed): rank-256 lr ≤ 5e-5 (convergent band; **RED** on the old fixed 2e-4), bounds + monotonicity, and `optimize()` populates it end-to-end. Contract `qlora-rank-aware-lr-v1.yaml` (`pv validate`/`pv lint` clean).

## Testing

- `aprender-train-lora`: 58 pass (incl. 3 new falsifiers)
- `apr-cli` finetune: 69 pass; `--learning-rate` → `Option<f64>` threaded through `run()` + test callers
- fmt clean, clippy clean (touched files)

## Related

Complements #2257 (QLoRA per-epoch val_loss now reflects trained adapters) — honest val_loss makes exactly this kind of divergence visible during training instead of hidden behind a constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)