### PR TITLE
fix(train): CPU LoRA forward drops Q/K/V biases + evaluate() runs the GPU forward (111×)

### DIFF
--- a/contracts/cpu-lora-forward-bias-parity-v1.yaml
+++ b/contracts/cpu-lora-forward-bias-parity-v1.yaml
@@ -1,0 +1,120 @@
+metadata:
+  id: C-CPU-LORA-FORWARD-BIAS-PARITY
+  version: 1.0.0
+  created: '2026-07-03'
+  author: PAIML Engineering
+  kind: pattern
+  status: ACTIVE_ALGORITHM_LEVEL
+  description: |
+    Pins CPU LoRA forward parity: `forward_with_lora` must compute the SAME
+    model as `forward()` when the adapter delta is zero — in particular it must
+    apply the Q/K/V projection biases on `use_bias=true` (Qwen2-family) models.
+
+    BACKGROUND. `AttentionLayer::forward_with_lora` (the KAIZEN-010/011 path
+    every CPU LoRA train_step and evaluate() forward runs through) computed
+    Q = x@W_q + scale·(x@A^T)@B^T, K = x@W_k, V analogous — and never added
+    b_q/b_k/b_v, which `forward()` applies via `add_bias`. On Qwen2-family
+    models (use_bias=true) every CPU LoRA training and evaluation forward
+    therefore ran a DIFFERENT (bias-less) model than inference.
+
+    MEASURED (qwen2.5-coder-1.5b-instruct-q4k, RTX-4090 host, CPU paths):
+      sample B ("What is 2+2?...\n" -> "4", seq 15):
+        forward() CE = 2.1309; forward_with_lora(B=0) CE = 4.4892 — a
+        bit-exact match to the parity probe's "(x) CPU forward, biases
+        DROPPED" oracle, fingerprinting the mechanism.
+      sample A (44-token prompt -> 10-token response):
+        forward() CE = 1.9298; forward_with_lora(B=0) CE = 14.5337 — worse
+        than uniform (ln 151936 = 11.93): the "wrong model, not noise"
+        signature (same diagnostic class as the #2252 GPU bias drop).
+
+    FIX. `forward_with_lora` applies b_q/b_k/b_v after the base+LoRA
+    projections (before qk-norm/RoPE, mirroring forward()'s order). CRITICALLY
+    it must NOT reuse forward()'s `add_bias` helper: that returns
+    `Tensor::from_vec` with no backward op, severing the autograd chain and
+    orphaning the LoRA A/B gradients (PMAT-805 class — loss frozen, adapters
+    never move). The fix broadcasts the bias to (seq × dim) as a non-trainable
+    tensor and uses the autograd-aware `add_scaled`, which passes gradient to
+    its first argument unchanged and recurses its backward chain.
+
+  references:
+    - 'crates/aprender-train/src/transformer/attention.rs:677 (bias application in forward_with_lora)'
+    - 'crates/aprender-train/src/transformer/attention.rs:486 (forward() bias application being mirrored)'
+    - 'crates/aprender-train/src/transformer/attention.rs:16 (add_bias helper — severs autograd, must not be used on the LoRA path)'
+    - 'crates/aprender-train/src/autograd/ops/basic.rs:144 (add_scaled — autograd-aware add used instead)'
+    - 'crates/aprender-train/src/finetune/instruct_pipeline/parity_probe.rs:1 (three-oracle probe whose biases-DROPPED oracle fingerprinted the defect)'
+
+equations:
+  lora_zero_delta_identity:
+    formula: |
+      B = 0 ⇒ forward_with_lora(x, A, B) == forward(x)
+      (LoRA delta scale·B·(A·x) = 0; biases must appear in BOTH paths)
+    domain: |
+      Zero-initialized LoRA B is the standard adapter init, so this identity
+      is exercised on the very first training/eval forward. Any divergence is
+      structural (a dropped term), not numerical.
+    invariants:
+    - 'forward_with_lora applies b_q, b_k, b_v whenever forward() does'
+    - 'bias application precedes qk-norm and RoPE (same order as forward())'
+    - 'LoRA A/B gradients flow through the bias add (autograd-aware op only)'
+    preconditions:
+    - 'LoRA B zero-initialized (standard init) for the identity check'
+
+proof_obligations:
+- type: invariant
+  property: zero-adapter LoRA forward equals the plain forward on bias models
+  formal: 'B=0 ∧ use_bias ⇒ |CE(forward_with_lora) - CE(forward)| < 1e-4'
+  applies_to: lora_zero_delta_identity
+- type: invariant
+  property: bias application preserves LoRA gradient flow
+  formal: 'use_bias ⇒ train_step moves lora_b ∧ overfit-one-batch loss strictly decreases'
+  applies_to: lora_zero_delta_identity
+
+falsification_tests:
+- id: FALSIFY-CPU-LORA-QKV-BIAS-001
+  rule: |
+    With zero-initialized LoRA B on a use_bias=true model with NONZERO biases,
+    forward_with_lora must agree with forward() (the adapter delta is
+    mathematically zero, so any gap is a dropped/extra term).
+  prediction: |
+    Tiny decoder config with use_bias=true and deterministic nonzero b_q/b_k/
+    b_v: |ΔCE| < 1e-4 (GREEN, measured ~0). RED (biases dropped on the LoRA
+    path): ΔCE = 1.3e-3 on the tiny model; 2.36-12.6 nats on the real 1.5B.
+  test: cargo test -p aprender-train --lib falsify_cpu_lora_qkv_bias_001_forward_parity
+  if_fails: |
+    forward_with_lora stopped applying a Q/K/V bias (or applies one forward()
+    does not). CPU LoRA training and evaluation on Qwen2-family models run a
+    different model than inference: eval CE can exceed ln(vocab) on trivially
+    predictable targets, and adapters train against bias-less activations.
+  ship_blocking: true
+  counter_example_classes:
+  - lora_path_drops_projection_biases
+  - bias_applied_after_rope_wrong_order
+- id: FALSIFY-CPU-LORA-QKV-BIAS-002
+  rule: |
+    The bias application must not sever the autograd chain: with biases
+    present, LoRA training must still move the adapters and decrease loss.
+  prediction: |
+    Overfit-one-batch (16 steps, lr 1e-2) on a use_bias=true tiny model:
+    lora_b max |Δ| > 1e-6 and final loss < first loss - 1e-3. A chain-severing
+    bias add (forward()'s add_bias helper) freezes both.
+  test: cargo test -p aprender-train --lib falsify_cpu_lora_qkv_bias_002_grad_flow_with_biases
+  if_fails: |
+    The bias add was switched to a non-autograd op (add_bias / raw
+    Tensor::from_vec). LoRA A/B are orphaned from the graph: loss is frozen
+    and adapters never move (PMAT-805 class) — silently, on bias models only.
+  ship_blocking: true
+  counter_example_classes:
+  - bias_add_severs_autograd_chain
+
+qa_gate:
+  id: QA-CPU-LORA-FORWARD-BIAS-PARITY-001
+  name: CPU LoRA forward bias-parity gate
+  description: |
+    forward_with_lora computes the same model as forward() at zero adapter
+    delta (biases included) and keeps LoRA gradients flowing through the bias
+    add — so CPU LoRA training and evaluation on Qwen2-family models train and
+    measure the model that inference actually runs.
+  checks:
+  - lora_zero_delta_identity
+  pass_criteria: FALSIFY-CPU-LORA-QKV-BIAS-001 and -002 pass
+  falsification: Any failure fails the gate (ship-blocking)

--- a/contracts/finetune-eval-gpu-forward-v1.yaml
+++ b/contracts/finetune-eval-gpu-forward-v1.yaml
@@ -1,0 +1,115 @@
+metadata:
+  id: C-QLORA-EVAL-GPU-FORWARD
+  version: 1.0.0
+  created: '2026-07-03'
+  author: PAIML Engineering
+  kind: pattern
+  status: ACTIVE_ALGORITHM_LEVEL
+  description: |
+    Pins NF4 QLoRA validation to the GPU forward: when `cuda_blocks` exist,
+    `InstructPipeline::evaluate()` must compute val logits with the SAME GPU
+    forward `train_step` optimizes, falling back to the CPU path only when the
+    GPU forward declines.
+
+    BACKGROUND. evaluate() always ran the CPU forward
+    (`model.forward_with_lora`) even when the whole model was GPU-resident.
+    Two consequences:
+      (1) SPEED — on a 1.5B at seq ~50 the CPU forward costs ~9.9s per sample
+          vs 89ms on the GPU (111x): at seq 2048 with a 40-sample val split,
+          every epoch boundary stalls for tens of minutes with the GPU idle.
+          Observed: a 560s-budget `apr finetune -m qlora` run finished its
+          full 160-step GPU epoch, then timed out INSIDE the val pass having
+          produced zero val output.
+      (2) REPRESENTATIVENESS — training optimizes the NF4-quantized GPU
+          model; the CPU eval measures the F32 weights. val_loss should
+          measure the model being trained.
+
+    FIX. evaluate() calls `forward_logits_gpu(&full_ids)` when
+    `cuda_blocks.is_some()`; a `None` (e.g. seq exceeds scratch capacity)
+    falls back to the CPU path, whose adapters stay current via
+    `sync_lora_to_cpu()` (C-QLORA-EVAL-SYNC-001 — the sync is retained).
+
+    DISCRIMINATING TOLERANCE. The NF4-GPU and F32-CPU forwards are distinct
+    arithmetic and never byte-identical, while NF4 quantization costs well
+    under 0.5 nats on this model — so GPU-vs-forced-CPU loss must satisfy
+    0 < |Δ| <= 0.5: Δ == 0 proves the GPU path silently was not taken;
+    Δ > 0.5 proves the GPU eval computes a different model. Measured GREEN:
+    gpu 2.2411 (89ms) vs cpu 1.9298 (9908ms), |Δ| = 0.3113. Measured RED
+    (GPU branch disabled): 1.92980385 == 1.92980385, |Δ| = 0 exactly.
+
+    NOTE: this contract's CPU reference is only meaningful because
+    C-CPU-LORA-FORWARD-BIAS-PARITY fixed the CPU LoRA forward — pre-fix the
+    CPU eval read 14.53 (worse than uniform) and the 0.5-nat band could not
+    hold against a broken oracle. The falsifier CAUGHT that defect: its upper
+    bound failed with |Δ| = 12.29, which is how the bias drop was discovered.
+
+  references:
+    - 'crates/aprender-train/src/finetune/instruct_pipeline/training.rs:497 (evaluate GPU-first logits path)'
+    - 'crates/aprender-train/src/finetune/instruct_pipeline/cuda_forward.rs:286 (forward_logits_gpu)'
+    - 'crates/aprender-train/src/finetune/instruct_pipeline/eval_sync_probe.rs:1 (FALSIFY-CUDA-EVAL-GPU-FORWARD-001)'
+  depends_on:
+    - 'finetune-eval-adapter-sync-v1'
+    - 'cpu-lora-forward-bias-parity-v1'
+
+equations:
+  eval_uses_training_forward:
+    formula: |
+      cuda_blocks present ∧ forward_logits_gpu(x) = Some(l)
+        ⇒ val_logits(x) = l
+      otherwise val_logits(x) = cpu_forward_with_lora(x, synced_adapters)
+    domain: |
+      Validation must measure the model being optimized (NF4 GPU forward) at
+      GPU speed; the CPU path remains as the fallback for sequences the GPU
+      scratch cannot hold and for non-CUDA builds.
+    invariants:
+    - 'GPU-path val loss differs from the forced-CPU loss (never byte-identical)'
+    - 'GPU-path val loss within 0.5 nats of the F32 CPU reference (same model)'
+    - 'CPU fallback preserved: forward_logits_gpu None ⇒ CPU path with synced adapters'
+    preconditions:
+    - 'C-CPU-LORA-FORWARD-BIAS-PARITY holds (CPU reference is the true model)'
+
+proof_obligations:
+- type: invariant
+  property: evaluate takes the GPU forward when CUDA blocks exist
+  formal: 'cuda_blocks.is_some() ⇒ CE_gpu_eval != CE_forced_cpu_eval (distinct arithmetic)'
+  applies_to: eval_uses_training_forward
+- type: invariant
+  property: GPU eval measures the same model as the CPU reference
+  formal: '|CE_gpu_eval - CE_forced_cpu_eval| <= 0.5 (NF4 quantization band)'
+  applies_to: eval_uses_training_forward
+
+falsification_tests:
+- id: FALSIFY-CUDA-EVAL-GPU-FORWARD-001
+  rule: |
+    evaluate() with cuda_blocks present must produce a loss that differs from
+    the forced-CPU fallback (proving the GPU path ran) by at most the NF4
+    quantization tolerance (proving it is the same model).
+  prediction: |
+    Same sample evaluated with blocks present, then with blocks take()n:
+    0 < |Δ| <= 0.5. GREEN measured: 2.2411 vs 1.9298, |Δ|=0.3113, 89ms vs
+    9908ms (111x). RED (GPU branch removed): byte-identical, |Δ|=0. Skips
+    vacuously without CUDA/APR_PARITY_MODEL.
+  test: cargo test -p aprender-train --features cuda --lib falsify_cuda_eval_gpu_forward_001
+  if_fails: |
+    Lower bound: the GPU branch in evaluate() was removed/short-circuited —
+    every epoch boundary silently pays minutes-per-sample CPU forwards again.
+    Upper bound: the GPU eval forward diverged from the CPU model (wrong-model
+    class: check rope pairing, biases, causal mask per the #2252 playbook) OR
+    the CPU reference regressed (re-run FALSIFY-CPU-LORA-QKV-BIAS-001 first).
+  ship_blocking: true
+  counter_example_classes:
+  - eval_silently_falls_back_to_cpu
+  - gpu_eval_forward_wrong_model
+  - broken_cpu_reference_masks_comparison
+
+qa_gate:
+  id: QA-QLORA-EVAL-GPU-FORWARD-001
+  name: NF4 QLoRA GPU-eval forward gate
+  description: |
+    evaluate() measures the NF4 model being trained, on the GPU, at GPU speed
+    (111x per-sample vs the CPU stall), with the CPU fallback preserved — so
+    per-epoch validation is fast, representative, and honest.
+  checks:
+  - eval_uses_training_forward
+  pass_criteria: FALSIFY-CUDA-EVAL-GPU-FORWARD-001 passes
+  falsification: Any failure fails the gate (ship-blocking)

--- a/crates/aprender-train/src/finetune/instruct_pipeline/eval_sync_probe.rs
+++ b/crates/aprender-train/src/finetune/instruct_pipeline/eval_sync_probe.rs
@@ -128,3 +128,179 @@ fn falsify_cuda_eval_adapter_sync_001() {
          selection, and early stopping are all driven by a constant.",
     );
 }
+
+/// FALSIFY-CUDA-EVAL-GPU-FORWARD-001 — `evaluate()` must run the GPU forward
+/// when CUDA blocks exist, not the minutes-per-sample CPU forward.
+///
+/// Defect class. `evaluate()` computed val logits with the CPU
+/// `forward_with_lora` even when the whole model was GPU-resident: on a 1.5B
+/// at seq 2048 that is minutes PER SAMPLE while the GPU sits idle, so every
+/// epoch boundary stalls for tens of minutes (observed: a 560s-budget CLI run
+/// finished its 160-step GPU epoch, then timed out inside the val pass having
+/// produced zero val output). It also measures a DIFFERENT model than the one
+/// being optimized: training updates the NF4-quantized GPU model, while the
+/// CPU eval forward runs the F32 weights.
+///
+/// Falsifier. Evaluate the same sample twice: once with `cuda_blocks` present
+/// (must take the GPU forward) and once with `cuda_blocks` removed (CPU
+/// fallback). The NF4-GPU and F32-CPU forwards are distinct arithmetic and are
+/// never byte-identical, while NF4 quantization costs well under 0.5 nats on
+/// this model — so the two losses must satisfy 0 < |Δ| <= 0.5:
+///   RED  (buggy: evaluate always CPU): both runs execute the identical CPU
+///        forward → |Δ| == 0 exactly — the lower bound fails.
+///   GREEN (fixed): the GPU-path loss differs by quantization error but stays
+///        within the same-model tolerance.
+#[test]
+#[ignore = "requires CUDA GPU + APR_PARITY_MODEL pointing at a Qwen2-family .apr"]
+fn falsify_cuda_eval_gpu_forward_001() {
+    if !trueno_gpu::driver::cuda_available() {
+        eprintln!("[eval-gpu] SKIP: no CUDA device");
+        return;
+    }
+    let Ok(model_path) = std::env::var("APR_PARITY_MODEL") else {
+        eprintln!("[eval-gpu] SKIP: APR_PARITY_MODEL unset");
+        return;
+    };
+    let model_path = std::path::PathBuf::from(model_path);
+    if !model_path.exists() {
+        eprintln!("[eval-gpu] SKIP: {model_path:?} does not exist");
+        return;
+    }
+
+    // Inlined (not a helper fn) so cargo-mutants generates no mutant for a
+    // function only reachable from this `#[ignore]` GPU test.
+    let model_config = TransformerConfig::from_apr_metadata(
+        Some(1536),
+        Some(12),
+        Some(2),
+        Some(8960),
+        Some(28),
+        Some(151_936),
+        Some(32_768),
+        Some(1e-6),
+        Some(1_000_000.0),
+        Some("qwen2"),
+    )
+    .expect("qwen2 config from metadata");
+    let instruct_config = InstructConfig {
+        lora_rank: 8,
+        lora_alpha: 16.0,
+        learning_rate: 2e-5,
+        epochs: 1,
+        max_seq_len: 128,
+        gradient_clip_norm: None,
+        quantize_nf4: true,
+    };
+    let mut p = InstructPipeline::from_apr(&model_path, &model_config, instruct_config)
+        .expect("pipeline from_apr");
+    assert!(p.cuda_blocks.is_some(), "CUDA blocks must initialize (quantize_nf4=true)");
+
+    // > 32 tokens: stays clear of the separate seq<32 partial-warp UB class.
+    let prompt = p.tokenize(
+        "You are a careful assistant. Consider the following request very \
+         precisely and answer with a single short factual sentence. What is the \
+         result of adding two and two together in ordinary arithmetic?\n",
+    );
+    let response = p.tokenize("Two plus two is equal to four.");
+
+    // GPU-path eval (cuda_blocks present).
+    let t0 = std::time::Instant::now();
+    let gpu_loss =
+        p.evaluate(std::slice::from_ref(&prompt), std::slice::from_ref(&response)).avg_loss;
+    let gpu_ms = t0.elapsed().as_millis();
+
+    // Forced CPU fallback: remove the blocks, evaluate, restore.
+    let blocks = p.cuda_blocks.take();
+    let t1 = std::time::Instant::now();
+    let cpu_loss =
+        p.evaluate(std::slice::from_ref(&prompt), std::slice::from_ref(&response)).avg_loss;
+    let cpu_ms = t1.elapsed().as_millis();
+    p.cuda_blocks = blocks;
+
+    let delta = (gpu_loss - cpu_loss).abs();
+    eprintln!(
+        "[eval-gpu] gpu_loss={gpu_loss:.8} ({gpu_ms}ms)  cpu_loss={cpu_loss:.8} ({cpu_ms}ms)  |Δ|={delta:.8}"
+    );
+    assert!(gpu_loss.is_finite() && cpu_loss.is_finite(), "both losses must be finite");
+
+    // Lower bound: byte-identity means both runs executed the same (CPU)
+    // forward — the GPU path was not taken.
+    assert!(
+        delta > 0.0,
+        "FALSIFY-CUDA-EVAL-GPU-FORWARD-001: evaluate() with cuda_blocks present \
+         returned a loss byte-identical to the forced-CPU fallback \
+         ({gpu_loss:.8}) — the GPU forward path is not being taken, so every \
+         epoch-boundary validation pays the minutes-per-sample CPU forward."
+    );
+    // Upper bound: same model within NF4 quantization tolerance (< 0.5 nats).
+    assert!(
+        delta <= 0.5,
+        "FALSIFY-CUDA-EVAL-GPU-FORWARD-001: GPU-eval loss diverges from the CPU \
+         oracle by {delta:.4} nats (> 0.5) — the GPU eval forward is computing a \
+         DIFFERENT model, not the NF4 quantization of the same one."
+    );
+}
+
+/// Diagnostic bisect probe — separates CPU `forward` vs `forward_with_lora`
+/// vs GPU losses per sample. This is the probe that isolated the
+/// FALSIFY-CPU-LORA-QKV-BIAS-001 defect (forward_with_lora dropping Q/K/V
+/// biases: 1.93 vs 14.53 on a 44-token sample). Keep it: any future eval-loss
+/// anomaly starts here.
+#[test]
+#[ignore = "diagnostic"]
+fn diag_cpu_eval_loss_bisect() {
+    let Ok(model_path) = std::env::var("APR_PARITY_MODEL") else { return };
+    let model_path = std::path::PathBuf::from(model_path);
+    let model_config = TransformerConfig::from_apr_metadata(
+        Some(1536),
+        Some(12),
+        Some(2),
+        Some(8960),
+        Some(28),
+        Some(151_936),
+        Some(32_768),
+        Some(1e-6),
+        Some(1_000_000.0),
+        Some("qwen2"),
+    )
+    .expect("config");
+    let instruct_config = InstructConfig {
+        lora_rank: 8,
+        lora_alpha: 16.0,
+        learning_rate: 2e-5,
+        epochs: 1,
+        max_seq_len: 128,
+        gradient_clip_norm: None,
+        quantize_nf4: true,
+    };
+    let mut p =
+        InstructPipeline::from_apr(&model_path, &model_config, instruct_config).expect("pipeline");
+
+    let ce = |logits: &[f32], ids: &[u32], prompt_len: usize| -> f32 {
+        let seq = ids.len();
+        let (s, e) = (prompt_len.saturating_sub(1), seq - 1);
+        let (loss, _) = InstructPipeline::compute_causal_lm_loss(logits, ids, s, e, 151_936);
+        loss
+    };
+
+    // Sample A: the eval-probe sample (long prompt, ~10-token response).
+    let pa = p.tokenize("You are a careful assistant. Consider the following request very precisely and answer with a single short factual sentence. What is the result of adding two and two together in ordinary arithmetic?\n");
+    let ra = p.tokenize("Two plus two is equal to four.");
+    // Sample B: the parity-probe sample (short).
+    let pb = p.tokenize("What is 2+2? Answer with just the number.\n");
+    let rb = p.tokenize("4");
+
+    for (name, pr, rs) in [("A(long)", &pa, &ra), ("B(short)", &pb, &rb)] {
+        let ids: Vec<u32> = pr.iter().chain(rs.iter()).copied().collect();
+        let lf = {
+            let lg = p.model.forward(&ids);
+            ce(lg.data().as_slice().expect("c"), &ids, pr.len())
+        };
+        let ll = {
+            let lg = p.model.forward_with_lora(&ids, &p.lora_layers);
+            ce(lg.data().as_slice().expect("c"), &ids, pr.len())
+        };
+        let lg_gpu = p.forward_logits_gpu(&ids).map(|l| ce(&l, &ids, pr.len()));
+        eprintln!("[diag] {name} seq={} | CPU forward={lf:.4} | CPU forward_with_lora(B=0)={ll:.4} | GPU={lg_gpu:?}", ids.len());
+    }
+}

--- a/crates/aprender-train/src/finetune/instruct_pipeline/tests.rs
+++ b/crates/aprender-train/src/finetune/instruct_pipeline/tests.rs
@@ -558,3 +558,127 @@ fn test_batch_result_clone_and_debug() {
     let debug_str = format!("{result:?}");
     assert!(debug_str.contains("InstructBatchResult"));
 }
+
+/// FALSIFY-CPU-LORA-QKV-BIAS-001: `forward_with_lora` must apply the same
+/// Q/K/V projection biases `forward()` applies.
+///
+/// With zero-initialized LoRA B the adapter delta is mathematically zero, so
+/// the two forwards MUST agree. The defect (this falsifier's RED state)
+/// dropped the biases entirely on the LoRA path, so every CPU LoRA train and
+/// eval forward on a bias-model (Qwen2-family `use_bias=true`) computed a
+/// DIFFERENT model — measured on qwen2.5-coder-1.5b: CE 4.4892 on the LoRA
+/// path vs 2.1309 on forward(), matching the parity probe's biases-DROPPED
+/// oracle bit-exactly (the same defect class #2252 fixed on the GPU path).
+#[test]
+fn falsify_cpu_lora_qkv_bias_001_forward_parity() {
+    let mut model_config = TransformerConfig::tiny();
+    model_config.use_bias = true;
+    let instruct_config = InstructConfig {
+        lora_rank: 4,
+        max_seq_len: 64,
+        gradient_clip_norm: None,
+        ..InstructConfig::default()
+    };
+    let mut pipeline = InstructPipeline::new(&model_config, instruct_config);
+
+    // Biases init to ZERO — with zero bias, dropping it is invisible. Set
+    // nonzero deterministic biases so the drop is observable.
+    for layer in &mut pipeline.model.layers {
+        let attn = &mut layer.self_attn;
+        let set = |t: &Option<crate::Tensor>, amp: f32| -> Option<crate::Tensor> {
+            t.as_ref().map(|b| {
+                let n = b.len();
+                crate::Tensor::from_vec(
+                    (0..n).map(|i| amp * ((i % 7) as f32 - 3.0)).collect(),
+                    true,
+                )
+            })
+        };
+        attn.b_q = set(&attn.b_q, 0.05);
+        attn.b_k = set(&attn.b_k, 0.03);
+        attn.b_v = set(&attn.b_v, 0.04);
+    }
+
+    let ids: Vec<u32> = (0..24).map(|i| (i * 37 % 1000) as u32).collect();
+    let seq = ids.len();
+    let vocab = pipeline.model.config().vocab_size;
+
+    let ce = |logits: &crate::Tensor| -> f32 {
+        let ld = logits.data();
+        let l = ld.as_slice().expect("contiguous logits");
+        InstructPipeline::compute_causal_lm_loss(l, &ids, 0, seq - 1, vocab).0
+    };
+
+    let loss_forward = ce(&pipeline.model.forward(&ids));
+    // LoRA B is zero-initialized → adapter delta is exactly zero.
+    let loss_lora = ce(&pipeline.model.forward_with_lora(&ids, &pipeline.lora_layers));
+
+    let delta = (loss_forward - loss_lora).abs();
+    assert!(
+        delta < 1e-4,
+        "FALSIFY-CPU-LORA-QKV-BIAS-001: forward_with_lora with zero-B adapters \
+         diverges from forward() by {delta} (forward={loss_forward:.6}, \
+         with_lora={loss_lora:.6}) on a use_bias=true model — the LoRA forward \
+         is dropping the Q/K/V projection biases, so CPU LoRA training and \
+         evaluation run a DIFFERENT model than inference."
+    );
+}
+
+/// FALSIFY-CPU-LORA-QKV-BIAS-002: the bias fix must NOT sever LoRA gradient
+/// flow. `forward()`'s `add_bias` helper returns a Tensor with no backward op
+/// — using it on the LoRA path would orphan the A/B adapters from the
+/// autograd graph (PMAT-805 class: loss frozen, adapters never move). The fix
+/// uses the autograd-aware add_scaled; this falsifier proves training still
+/// learns WITH biases present.
+#[test]
+fn falsify_cpu_lora_qkv_bias_002_grad_flow_with_biases() {
+    let mut model_config = TransformerConfig::tiny();
+    model_config.use_bias = true;
+    let instruct_config = InstructConfig {
+        lora_rank: 8,
+        lora_alpha: 16.0,
+        learning_rate: 1e-2,
+        max_seq_len: 64,
+        gradient_clip_norm: None,
+        ..InstructConfig::default()
+    };
+    let mut pipeline = InstructPipeline::new(&model_config, instruct_config);
+    for layer in &mut pipeline.model.layers {
+        let attn = &mut layer.self_attn;
+        if let Some(b) = attn.b_q.as_ref() {
+            let n = b.len();
+            attn.b_q = Some(crate::Tensor::from_vec(
+                (0..n).map(|i| 0.05 * ((i % 5) as f32 - 2.0)).collect(),
+                true,
+            ));
+        }
+    }
+
+    let prompt_ids: Vec<u32> = vec![1, 2, 3, 4, 5];
+    let response_ids: Vec<u32> = vec![6, 7, 8, 9, 10];
+
+    let v_b_before: Vec<f32> = pipeline.lora_layers[1].lora_b().data().to_vec();
+    let first = pipeline.train_step(&prompt_ids, &response_ids);
+    assert!(first.loss.is_finite() && first.loss > 0.0, "initial loss finite & positive");
+    let mut last_loss = first.loss;
+    for _ in 0..15 {
+        last_loss = pipeline.train_step(&prompt_ids, &response_ids).loss;
+    }
+    let v_b_after: Vec<f32> = pipeline.lora_layers[1].lora_b().data().to_vec();
+    let max_delta =
+        v_b_before.iter().zip(&v_b_after).map(|(a, b)| (a - b).abs()).fold(0.0_f32, f32::max);
+
+    assert!(
+        max_delta > 1e-6,
+        "FALSIFY-CPU-LORA-QKV-BIAS-002: LoRA V/B params did not move after 16 \
+         steps on a use_bias=true model (max_delta={max_delta}) — the bias add \
+         severed the autograd chain (add_bias-without-backward-op class)."
+    );
+    assert!(
+        last_loss < first.loss - 1e-3,
+        "FALSIFY-CPU-LORA-QKV-BIAS-002: loss did not decrease ({} -> {}) with \
+         biases present — gradient flow broken by the bias add.",
+        first.loss,
+        last_loss
+    );
+}

--- a/crates/aprender-train/src/finetune/instruct_pipeline/training.rs
+++ b/crates/aprender-train/src/finetune/instruct_pipeline/training.rs
@@ -494,14 +494,37 @@ impl InstructPipeline {
             let vocab_size = self.model.config().vocab_size;
             let prompt_len = prompt_len.min(seq_len);
 
-            // PMAT-805: evaluate the LoRA-adapted model so val_loss reflects the
-            // trained adapters (matches train_step's forward_with_lora path).
-            let logits = if self.lora_layers.is_empty() {
-                self.model.forward(&full_ids)
+            // FALSIFY-CUDA-EVAL-GPU-FORWARD-001: when CUDA blocks exist, run
+            // validation through the SAME GPU forward train_step optimizes
+            // (NF4 frozen weights + GPU-resident adapters). This is both the
+            // representative measurement (val measures the model being
+            // trained) and the fast one — the CPU forward on a 1.5B at seq
+            // 2048 costs minutes per sample while the GPU sits idle, turning
+            // every epoch boundary into a multi-minute stall (observed: a
+            // 560s-budget run finished its 160-step epoch but timed out
+            // inside the val pass). Falls back to the CPU path below when the
+            // GPU forward declines (e.g. seq exceeds scratch capacity).
+            #[cfg(feature = "cuda")]
+            let gpu_logits =
+                if self.cuda_blocks.is_some() { self.forward_logits_gpu(&full_ids) } else { None };
+            #[cfg(not(feature = "cuda"))]
+            let gpu_logits: Option<Vec<f32>> = None;
+
+            let logits_data = if let Some(logits) = gpu_logits {
+                logits
             } else {
-                self.model.forward_with_lora(&full_ids, &self.lora_layers)
+                // PMAT-805: evaluate the LoRA-adapted model so val_loss
+                // reflects the trained adapters (matches train_step's
+                // forward_with_lora path). `lora_layers` are current: synced
+                // from the GPU above (C-QLORA-EVAL-SYNC-001) or trained in
+                // place on the CPU/WGPU paths.
+                let logits = if self.lora_layers.is_empty() {
+                    self.model.forward(&full_ids)
+                } else {
+                    self.model.forward_with_lora(&full_ids, &self.lora_layers)
+                };
+                logits.data().as_slice().expect("contiguous logits").to_vec()
             };
-            let logits_data = logits.data().as_slice().expect("contiguous logits").to_vec();
 
             let loss_start = prompt_len.saturating_sub(1);
             let loss_end = seq_len - 1;

--- a/crates/aprender-train/src/transformer/attention.rs
+++ b/crates/aprender-train/src/transformer/attention.rs
@@ -674,6 +674,44 @@ impl MultiHeadAttention {
             crate::autograd::matmul_nt(&v_mid, lora_b_v, seq_len, lora_rank, kv_hidden_size);
         let v = crate::autograd::add_scaled(&v_base, &v_lora, lora_scale);
 
+        // FALSIFY-CPU-LORA-QKV-BIAS-001: apply the SAME Q/K/V projection
+        // biases forward() applies (Qwen2-family use_bias=true). Dropping
+        // them makes every CPU LoRA train/eval forward compute a DIFFERENT
+        // model — measured on qwen2.5-coder-1.5b: CE 4.49 vs forward()'s
+        // 2.13 on a trivially-predictable target, matching the parity
+        // probe's biases-DROPPED oracle bit-exactly (the same defect class
+        // #2252 fixed on the GPU path). NOTE: forward()'s `add_bias` helper
+        // severs the autograd chain (Tensor::from_vec, no backward op) — a
+        // frozen-weight non-issue for forward(), but here it would orphan
+        // the LoRA A/B gradients (PMAT-805 class). We instead broadcast the
+        // bias to (seq × dim) as a non-trainable tensor and use the
+        // autograd-aware add_scaled, which propagates grad to its first
+        // argument unchanged.
+        let broadcast_bias = |bias: &Tensor| -> Tensor {
+            let bd = bias.data();
+            let b = bd.as_slice().expect("contiguous bias");
+            let mut out = Vec::with_capacity(seq_len * b.len());
+            for _ in 0..seq_len {
+                out.extend_from_slice(b);
+            }
+            Tensor::from_vec(out, false)
+        };
+        let q = if let Some(ref b_q) = self.b_q {
+            crate::autograd::add_scaled(&q, &broadcast_bias(b_q), 1.0)
+        } else {
+            q
+        };
+        let k = if let Some(ref b_k) = self.b_k {
+            crate::autograd::add_scaled(&k, &broadcast_bias(b_k), 1.0)
+        } else {
+            k
+        };
+        let v = if let Some(ref b_v) = self.b_v {
+            crate::autograd::add_scaled(&v, &broadcast_bias(b_v), 1.0)
+        } else {
+            v
+        };
+
         // Apply Q/K RMSNorm if present (Qwen3 QK-norm, ENT-269)
         let q = if let Some(ref qn) = self.q_norm {
             apply_qk_norm(&q, qn, seq_len, num_heads, head_dim)


### PR DESCRIPTION
Two chained eval-path defects — the second's falsifier caught the first.

## 1) `forward_with_lora` drops the Q/K/V biases

The path **every CPU LoRA `train_step` and `evaluate()` forward** runs through never applied the Q/K/V projection biases that `forward()` applies. On Qwen2-family models (`use_bias=true`), all CPU LoRA training and evaluation ran a **different (bias-less) model** than inference.

**Fingerprint** (qwen2.5-coder-1.5b): `forward_with_lora(B=0)` CE **4.4892** — a bit-exact match to the parity probe's *"(x) CPU forward, biases DROPPED"* oracle (`forward()` gives 2.1309). On a 44-token sample: **1.93 vs 14.53** — worse than uniform (ln V = 11.93), the #2252 "wrong model, not noise" signature, this time on the CPU path.

**Fix** mirrors `forward()`'s bias application (before qk-norm/RoPE) — but **not** via its `add_bias` helper, which returns a Tensor with **no backward op** and would orphan the LoRA A/B gradients (PMAT-805 class). Instead: bias broadcast to (seq×dim) as a non-trainable tensor, added with the autograd-aware `add_scaled`.

| falsifier (CI, no GPU) | RED | GREEN |
|---|---|---|
| `FALSIFY-CPU-LORA-QKV-BIAS-001` zero-adapter parity | Δ=1.3e-3 > 1e-4 | Δ < 1e-4 ✓ |
| `FALSIFY-CPU-LORA-QKV-BIAS-002` grad-flow with biases | (guards severed-chain) | B moves + loss ↓ ✓ |

## 2) `evaluate()` runs the GPU forward

`evaluate()` computed val logits on the **CPU** even when the model is GPU-resident: ~9.9 s/sample at seq ~50 (minutes at seq 2048) with the GPU idle — a real `apr finetune -m qlora` run finished its 160-step GPU epoch then **timed out inside the val pass**. It also measured the F32 weights while training optimizes the NF4 model.

**Fix:** `evaluate()` uses `forward_logits_gpu()` when `cuda_blocks` exist; `None` (seq exceeds scratch) falls back to the CPU path, whose adapters stay current via `sync_lora_to_cpu` (#2257's C-QLORA-EVAL-SYNC-001 retained).

| falsifier (GPU-gated) | RED (branch disabled) | GREEN |
|---|---|---|
| `FALSIFY-CUDA-EVAL-GPU-FORWARD-001` `0 < \|Δ\| ≤ 0.5` | byte-identical, Δ=0 | 2.2411 (**89 ms**) vs 1.9298 (**9,908 ms**), Δ=0.311 — **111×** ✓ |

The tolerance band is doubly discriminating: Δ=0 catches silent CPU fallback; Δ>0.5 catches wrong-model. Its upper bound firing with **Δ=12.29** is exactly how defect (1) was discovered.

## Verification

- Contracts: `cpu-lora-forward-bias-parity-v1.yaml`, `finetune-eval-gpu-forward-v1.yaml` — `pv validate` + `pv lint` clean; GPU-eval contract `depends_on` bias-parity + eval-sync
- Suites: instruct_pipeline 96 pass (incl. the 2 new CI falsifiers), transformer 329 pass, non-cuda build clean
- Diff mutants: 2 generated, both **unviable** (`Tensor` and `InstructBatchResult` have no `Default` impl) → 0 missed
- Diagnostic bisect probe (`diag_cpu_eval_loss_bisect`, env-gated + ignored) kept in-tree — it's the tool that isolated defect (1)

## Related

Completes the eval-correctness chain: #2257 (adapters synced) → #2258 (convergent auto-lr) → this (honest + fast validation). With all three, `apr finetune -m qlora` trains, validates, and early-stops on real signal at GPU speed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)