### PR TITLE
docs(roadmap): reflect v0.55–v0.57 QLoRA training wave + name the GPU-CI doctrine gap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,14 +4,17 @@ Next Generation Machine Learning in Pure Rust
 
 ## Current status
 
-> **v0.49.1** (2026-06-13) — published to crates.io: `cargo install aprender` → `apr`.
-> **Actively shipping** the four-pillar **BEAT campaign** (below). The earlier
-> "3-month hiatus" was closed out; development resumed at v0.42 and is ongoing.
+> **v0.57.0** (2026-07-03) — published to crates.io: `cargo install aprender` → `apr`.
+> **Actively shipping** the four-pillar **BEAT campaign** (below) plus a **QLoRA
+> training-correctness wave** (v0.55–v0.57). The earlier "3-month hiatus" was closed
+> out; development resumed at v0.42 and is ongoing.
 
-Aprender is now an **80-crate monorepo** spanning model **training**, **inference**
-(realizar), **SIMD/GPU compute** (trueno), and a **103-subcommand `apr` CLI** — well
+Aprender is now an **86-crate monorepo** spanning model **training**, **inference**
+(realizar), **SIMD/GPU compute** (trueno), and a **104-subcommand `apr` CLI** — well
 beyond the single-algorithm releases this file originally tracked. 25,300+ tests,
-1148+ provable contracts.
+1,400+ provable contracts. *(Live counts drift; the enforced source of truth is
+[`contracts/readme-claims-v1.yaml`](contracts/readme-claims-v1.yaml), which gates the
+README's counts against `find contracts/ -name '*.yaml'` at HEAD.)*
 
 **This file is a high-level version overview, not the working backlog.** The
 canonical, issue-linked roadmap is
@@ -28,8 +31,10 @@ canonical, issue-linked roadmap is
 | v0.31–v0.34 | ✅ Released | MoE serving, distillation pipeline, MODEL-1 code model, provable-contract expansion |
 | v0.35.x | ✅ Released | Hiatus close-out (eval/distill fixes, book completeness, DX) |
 | v0.36–v0.41 | ✅ Released | sklearn-parity breadth — model-selection stack, 13 metrics, preprocessing, `datasets` |
-| **v0.42–v0.49** | ✅ **Current** | **Four-pillar BEAT campaign** — CI-gated falsifiable wins vs sklearn / PyTorch / Unsloth / Ollama (below) |
-| _in flight_ | 🔧 Hardening | Correctness wave — sampling params, Blackwell-GPU coherence, Gemma CPU, APR-format safety, RoPE/LoRA/MCP (each contract-backed) |
+| v0.42–v0.49 | ✅ Released | **Four-pillar BEAT campaign** — CI-gated falsifiable wins vs sklearn / PyTorch / Unsloth / Ollama (below) |
+| v0.50–v0.54 | ✅ Released | Correctness wave — sampling params, Blackwell-GPU coherence, Gemma CPU, APR-format safety, RoPE/LoRA/MCP, `apr-format` leaf extraction (each contract-backed) |
+| **v0.55–v0.57** | ✅ **Current** | **GPU QLoRA training actually works** — a 6-defect cascade fixed (deadlock → loss-window → cross-stream NaN → wrong-model → stale-adapter eval → CPU-only eval), each with a mutation-verified falsifier + contract; runnable `--merge`; rank-aware auto-lr (default no longer diverges) |
+| _in flight_ | 🔧 Hardening | CUDA CI lane so the GPU correctness falsifiers are actually enforced (see doctrine gap below); apr-code tool-call flip envelope measurement |
 | _next_ | 📋 Planned | tracked in [`docs/roadmaps/roadmap.yaml`](docs/roadmaps/roadmap.yaml) |
 
 ### 🎯 The mission (north star)
@@ -43,19 +48,41 @@ wedge none of the four have: **provable, contract-gated correctness.**
 |--------|-----------|--------------------|----------------------------------|
 | **P1** | scikit-learn | Classical-ML breadth & ergonomics | LinearRegression **2.0× faster** (LAPACK-free O(nd)), iris-RF accuracy. *(LAPACK-bound Ridge/Lasso/KMeans/PCA honestly conceded.)* |
 | **P2** | PyTorch | Tensors + autograd + training | Autograd gradients **≡ PyTorch, max\|Δ\|=5e-7**. *(Training speed conceded — ~11× MKL gap; the win is provable gradient correctness.)* |
-| **P3** | Unsloth | Fast low-VRAM PEFT (LoRA/QLoRA) | NF4 quant **≡ bitsandbytes (4.9e-7)** + LoRA-merge forward-**equivalence (1.5e-8)**. *(GPU-Triton tok/s conceded.)* |
+| **P3** | Unsloth | Fast low-VRAM PEFT (LoRA/QLoRA) | NF4 quant **≡ bitsandbytes (4.9e-7)** + LoRA-merge forward-**equivalence (1.5e-8)**; **GPU QLoRA training runs correct end-to-end** (v0.55–v0.57: 6-defect cascade fixed, trains+validates at GPU speed on RTX 4090 & GB10 Blackwell). *(GPU-Triton tok/s conceded; training-correctness falsifiers are developer-run pending a CUDA CI lane.)* |
 | **P4** | Ollama / llama.cpp | Fast local quantized inference | **Fail-closed correctness** — `apr` rejects 10/10 semantically-broken models that Ollama/llama.cpp silently run; decode **1.2–1.37× on RTX 4090**. |
 
 All four beats are **adversarially mutation-verified** — a deliberately injected
 regression must make the gate FAIL, or the gate is theater. Cross-cutting through-line:
 the model is trained → fine-tuned → distilled → served as one CODE model
-(qwen2.5-coder), measured by the apr-code-parity matrix.
+(qwen2.5-coder), measured by the apr-code-parity matrix. As of v0.55–v0.57 the
+**fine-tune stage of that through-line trains and validates correctly** (GPU QLoRA), so
+the lifecycle is closer to demonstrable end-to-end.
 
 **Campaign mode (2026-06):** ≥10 days fully-autonomous, BEATS-as-CI-artifacts across all
 four pillars plus the `cuda-oxide` pure-Rust→PTX spike on Blackwell. Every correctness
 fix ships a named `proof_obligation` + a falsifier verified RED-on-bug / GREEN-on-fix +
 a `pv`-validated contract bump (a bug shipped green ⇔ its falsifier was missing or too
 weak).
+
+### ⚠️ Honest doctrine gap: GPU falsifiers are not yet CI-enforced
+
+The v0.55–v0.57 QLoRA training-correctness falsifiers (deadlock, cross-stream NaN,
+wrong-model rope/bias, stale-adapter eval, GPU-vs-CPU eval-forward) require a CUDA
+device and are `#[ignore]`-gated — the CI fleet has **no CUDA-labeled runner**, so
+today they only run developer-side on the pre-authorized RTX 4090. By the "gates or
+theater" rule this is a real hole: a correctness gate that never runs unattended is
+weaker than one that does. **The highest-EV hardening item is a nightly CUDA lane on
+the 4090** that executes these falsifiers as a scheduled (eventually blocking) check.
+Until it lands, these wins are stated as *developer-verified*, not *CI-enforced* — the
+same discipline §6 applies to conceded speed.
+
+**Case-file lesson (CF-5, 2026-07-03):** the GPU eval-forward falsifier's tolerance band
+*fired against its own CPU reference* (Δ=12.29 ≫ 0.5). Rather than loosen the band, the
+right move was to bisect — which exposed an **unrelated** defect: `forward_with_lora`
+had been silently dropping the Q/K/V projection biases, so every CPU LoRA train/eval ran
+a bias-less model. New doctrine rule: *a falsifier whose band fails against its reference
+may have caught a broken reference — bisect before loosening.* The escape became two
+permanent falsifiers (`FALSIFY-CPU-LORA-QKV-BIAS-001/002`, CI-enforced, no GPU needed).
 
 ---
 

--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -27,11 +27,59 @@
 #
 # RULE: never ship a parity feature when a falsifiable BEAT is on the table.
 # PILLAR1-* items below are sklearn-PARITY (v0.44-0.48 shipped) — LOW marginal EV now.
+#
+# CORRECTION 2026-07-03 (session insight): the 2026-06-12 claim above that "GPU is
+# AUTONOMOUS ... GPU beats join the AUTONOMOUS track" is HALF TRUE and was masking a
+# doctrine gap. GPU WORK is autonomous (the RTX 4090 is pre-authorized and runs
+# unattended), but GPU CI ENFORCEMENT is not: there is NO CUDA-labeled CI runner, so
+# every GPU correctness falsifier shipped in the v0.55-v0.57 QLoRA training wave
+# (FALSIFY-CUDA-{FUSED-RMSNORM-DEADLOCK,NF4-FORWARD-NAN,NF4-TRAIN-LOSS-PARITY,
+# EVAL-ADAPTER-SYNC,EVAL-GPU-FORWARD}-001) is #[ignore]-gated and runs developer-side
+# only. By "gates or theater" these wins are DEVELOPER-VERIFIED, not CI-ENFORCED.
+# The intel-iGPU->Vulkan->wgpu path referenced above does NOT cover the CUDA-only
+# training falsifiers. NEW HIGHEST-EV HARDENING ITEM:
+#   H1. CUDA nightly CI lane on the pre-authorized 4090 (self-hosted, cuda label):
+#       run the GPU falsifier suite as a scheduled check (nightly first, then a
+#       blocking gate on training-path PRs). Converts ~6 developer-verified wins into
+#       CI-enforced ones. EV: very high (closes the biggest "gates or theater" hole).
+#       Prereq only: register a cuda-labeled self-hosted runner on lambda-vector.
+#
+# ALSO DONE this session (remove from backlog if listed): PMAT-711-class QLoRA training
+# now WORKS end-to-end (6-defect cascade #2249/#2250/#2251/#2252/#2257/#2260);
+# default `apr finetune -m qlora` auto-lr no longer diverges (rank-aware lr, #2258).
 # ============================================================================
 roadmap_version: '1.0'
 github_enabled: true
 github_repo: paiml/aprender
 roadmap:
+- id: CUDA-CI-NIGHTLY-001
+  github_issue: null
+  item_type: task
+  title: 'CUDA nightly CI lane — enforce the GPU QLoRA training-correctness falsifiers'
+  status: pending
+  priority: high
+  assigned_to: null
+  created: 2026-07-03T00:00:00.000000000+00:00
+  updated: 2026-07-03T00:00:00.000000000+00:00
+  spec: null
+  acceptance_criteria:
+  - 'A cuda-labeled self-hosted runner is registered on lambda-vector (RTX 4090, sm_89, CUDA 12.8).'
+  - 'A scheduled workflow runs the #[ignore]-gated GPU falsifier suite with APR_PARITY_MODEL set: FALSIFY-CUDA-FUSED-RMSNORM-DEADLOCK-001, FALSIFY-CUDA-NF4-FORWARD-NAN-001, FALSIFY-CUDA-NF4-TRAIN-LOSS-PARITY-001, FALSIFY-CUDA-EVAL-ADAPTER-SYNC-001, FALSIFY-CUDA-EVAL-GPU-FORWARD-001, plus the loss-window suite.'
+  - 'The lane is GREEN on main and its result is surfaced (nightly first; promote to a blocking gate on training-path PRs once stable).'
+  - 'Each formerly developer-verified GPU win is re-annotated as CI-enforced in ROADMAP.md P3 + the relevant contract qa_gate.'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - cuda
+  - ci
+  - pillar-3
+  - doctrine-gap
+  notes: >-
+    Closes the biggest "gates or theater" hole surfaced 2026-07-03: the entire
+    v0.55-v0.57 QLoRA training-correctness wave is falsified only developer-side
+    because the CI fleet has no CUDA runner. Prereq is purely operational
+    (register the runner); the falsifiers already exist and pass on the 4090.
 - id: GH-9
   github_issue: 9
   item_type: task


### PR DESCRIPTION
Adjusts the canonical roadmap/pillars (`ROADMAP.md`, `docs/roadmaps/roadmap.yaml`) with this session's insights — every number grounded against HEAD, not the stale snapshot.

## Scoreboard re-pin (all were **understated** — conservative drift)

| | was | now (HEAD) |
|---|---|---|
| version | v0.49.1 | **v0.57.0** |
| crates | 80 | **86** |
| CLI commands | 103 | **104** |
| contracts | "1148+" literal | now points at the **enforced source** (`readme-claims-v1.yaml`, gated to `find contracts/ -name '*.yaml'`) instead of a drifting number |

## P3: equivalence → equivalence **+ working correct training**

The v0.55–v0.57 wave fixed a **6-defect cascade** so GPU QLoRA training runs correct end-to-end (deadlock → loss-window → cross-stream NaN → wrong-model → stale-adapter eval → CPU-only eval), each with a mutation-verified falsifier + contract; trains + validates at GPU speed on RTX 4090 & GB10 Blackwell. This is the *Unsloth-competitive* claim — stronger ground than bit-equivalence — and it closes the fine-tune stage of the P5 through-line.

## The honest doctrine gap this surfaces ("gates or theater")

The GPU training-correctness falsifiers are `#[ignore]`-gated and **the CI fleet has no CUDA runner** — so they run developer-side only. The 2026-06-12 roadmap header claimed "GPU is AUTONOMOUS," which was masking this: GPU *work* is autonomous; GPU *CI enforcement* is not. This PR:

- Adds structured roadmap item **`CUDA-CI-NIGHTLY-001`** (highest-EV hardening: register a cuda-labeled runner on lambda-vector, run the falsifier suite on a schedule) — top of `roadmap.yaml`.
- Corrects the stale "GPU is autonomous" header note in place.
- Records **case-file CF-5**: the GPU eval-forward falsifier's tolerance band fired against its own CPU reference (Δ=12.29 ≫ 0.5) → bisecting (not loosening) exposed an unrelated CPU bias-drop defect. New doctrine rule: *a falsifier whose band fails against its reference may have caught a broken reference — bisect before loosening.*

Docs-only; PMAT pre-commit gates pass; `roadmap.yaml` re-parses (589 items).

🤖 Generated with [Claude Code](https://claude.com/claude-code)