### PR TITLE
ci: add dormant CUDA nightly lane for the GPU QLoRA falsifiers (CUDA-CI-NIGHTLY-001)

### DIFF
--- a/.github/workflows/cuda-nightly.yml
+++ b/.github/workflows/cuda-nightly.yml
@@ -88,9 +88,15 @@ jobs:
           #     job is already on this GPU (or >2 GiB resident), skip tonight so
           #     we never contend with overnight training. `force=true` on a
           #     manual dispatch overrides.
-          used=$(nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits 2>/dev/null | head -1 | tr -d ' ')
+          # `procs` (compute contexts) is the primary, portable signal — it
+          # works on both sm_89 and GB10. `memory.used` is a secondary signal
+          # and is [N/A] on GB10's unified memory, so extract digits only and
+          # default to 0 (never let a non-integer reach `[ -gt ]`).
+          used=$(nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits 2>/dev/null | head -1 | grep -oE '[0-9]+' | head -1)
+          used=${used:-0}
           procs=$(nvidia-smi --query-compute-apps=pid --format=csv,noheader 2>/dev/null | grep -c . || true)
-          echo "${{ matrix.name }}: GPU memory.used=${used:-?} MiB, existing compute procs=${procs:-?}"
+          procs=${procs:-0}
+          echo "${{ matrix.name }}: GPU memory.used=${used} MiB, existing compute procs=${procs}"
           if [ "$force" = "true" ]; then
             echo "::notice::${{ matrix.name }}: force=true — running regardless of GPU load"
             echo "proceed=true" >> "$GITHUB_OUTPUT"; exit 0

--- a/.github/workflows/cuda-nightly.yml
+++ b/.github/workflows/cuda-nightly.yml
@@ -5,28 +5,32 @@ name: CUDA Nightly (GPU QLoRA falsifiers)
 # GPU). See roadmap item CUDA-CI-NIGHTLY-001 and ROADMAP.md
 # "Honest doctrine gap: GPU falsifiers are not yet CI-enforced".
 #
-# ---------------------------------------------------------------------------
-# DORMANT UNTIL ACTIVATED — merging this file changes nothing until an operator:
-#   1. Registers a self-hosted runner on lambda-vector (RTX 4090, sm_89,
-#      CUDA 12.8) with labels: [self-hosted, Linux, X64, cuda]
-#   2. Sets the repo variable CUDA_RUNNER_READY=true
-#        gh variable set CUDA_RUNNER_READY --body true
-#      (optionally override the model path with APR_PARITY_MODEL)
-# Until both are done, the `cuda-falsifiers` job is skipped by its `if:` guard,
-# so scheduled/dispatch runs are a green no-op with no queued jobs and no noise.
-# This workflow NEVER triggers on pull_request, so it can never gate a PR.
+# CROSS-SILICON MATRIX. Runs the SAME falsifier suite on two self-hosted CUDA
+# runners so a kernel that passes on one target but regresses on the other is
+# caught:
+#   - ada-4090      : lambda-vector, RTX 4090, sm_89,  x86-64, CUDA 12.8
+#                     (labels: self-hosted, Linux, X64, cuda)  -- direct WAN
+#   - blackwell-gb10: gx10, GB10, sm_121, aarch64, CUDA 13.0
+#                     (labels: self-hosted, Linux, ARM64, cuda) -- egress via a
+#                     forward proxy on lambda (10.42.0.10:8888) over the wired
+#                     10.42.0.0/24 link; the runner's .env carries HTTPS_PROXY.
+# sm_89 is the stable reference; sm_121 is the higher-risk target (historical
+# JIT bugs), which is exactly why both are gated.
 #
-# WHY THE 4090 AND NOT GB10/gx10: the CI-gate role requires the runner to reach
-# github.com (poll for jobs + report the check). lambda-vector has WAN; gx10 is
-# overlay-only (no WAN, no reverse SSH), so it cannot host a GitHub Actions
-# runner. gx10's Blackwell sm_121 coverage is valuable but belongs in a
-# separate push-based offline cross-silicon check (phase 2), not this gate.
-# ---------------------------------------------------------------------------
+# GATE: kept behind vars.CUDA_RUNNER_READY so the lane can be disabled without
+# deleting the workflow. Triggers on schedule + workflow_dispatch ONLY (never
+# pull_request), so it can never gate a PR. Nightly first; promote to a blocking
+# check on training-path PRs once it has a green track record.
 
 on:
   schedule:
     - cron: "30 6 * * *"   # 06:30 UTC — after beat-speed-nightly (05:45)
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      silicon:
+        description: "Which silicon to run (all | ada | blackwell)"
+        required: false
+        default: "all"
 
 permissions:
   contents: read
@@ -36,38 +40,57 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  cuda-falsifiers:
-    # Dormant switch: stays skipped (green no-op) until the operator flips the
-    # variable AFTER registering the cuda-labeled runner. Prevents jobs queueing
-    # forever against a non-existent runner label.
+  falsifiers:
     if: ${{ vars.CUDA_RUNNER_READY == 'true' }}
-    runs-on: [self-hosted, Linux, X64, cuda]
-    timeout-minutes: 75
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: ada-4090
+            arch: X64
+            select: ada
+          - name: blackwell-gb10
+            arch: ARM64
+            select: blackwell
+    # Skip a leg when a dispatch asks for a single silicon.
+    runs-on: [self-hosted, Linux, "${{ matrix.arch }}", cuda]
+    timeout-minutes: 90
     env:
-      # Qwen2-family .apr with an embedded tokenizer, used by the parity + eval
-      # falsifiers. Overridable via repo variable if the model lives elsewhere.
       APR_PARITY_MODEL: ${{ vars.APR_PARITY_MODEL || '/home/noah/models/qwen2.5-coder-1.5b-instruct-q4k.apr' }}
       CARGO_TERM_COLOR: always
     steps:
+      - name: Silicon filter
+        id: gate
+        run: |
+          want="${{ github.event.inputs.silicon || 'all' }}"
+          if [ "$want" = "all" ] || [ "$want" = "${{ matrix.select }}" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "skipping ${{ matrix.name }} (dispatch requested: $want)"
+          fi
+
       - uses: actions/checkout@v7
+        if: steps.gate.outputs.run == 'true'
 
       - name: Preflight — CUDA device + parity model present
+        if: steps.gate.outputs.run == 'true'
         run: |
           set -euo pipefail
-          nvidia-smi -L || { echo "::error::no CUDA device visible on this runner"; exit 1; }
+          echo "runner: ${{ matrix.name }} ($(uname -m))"
+          nvidia-smi -L || { echo "::error::no CUDA device visible on ${{ matrix.name }}"; exit 1; }
           nvidia-smi --query-gpu=name,driver_version --format=csv,noheader
           if [ ! -f "$APR_PARITY_MODEL" ]; then
-            echo "::error::APR_PARITY_MODEL not found: $APR_PARITY_MODEL"
-            echo "::error::Set repo variable APR_PARITY_MODEL to a Qwen2-family .apr on the runner."
+            echo "::error::APR_PARITY_MODEL not found on ${{ matrix.name }}: $APR_PARITY_MODEL"
             exit 1
           fi
           echo "parity model: $APR_PARITY_MODEL ($(du -h "$APR_PARITY_MODEL" | cut -f1))"
 
       - name: GPU QLoRA training-correctness falsifiers (--features cuda)
+        if: steps.gate.outputs.run == 'true'
         # --include-ignored runs BOTH the #[ignore]-gated eval falsifiers and the
-        # non-ignored deadlock/NaN/parity falsifiers (which self-skip without a
-        # GPU). Named explicitly so the suite is auditable and additions are
-        # deliberate. Any RED here is a real GPU-path correctness regression.
+        # non-ignored deadlock/NaN/parity ones (which self-skip without a GPU).
+        # Named explicitly so the suite is auditable and additions are deliberate.
         run: |
           cargo test -p aprender-train --features cuda --lib --release -- \
             --include-ignored --nocapture --test-threads 1 \
@@ -78,5 +101,6 @@ jobs:
             falsify_cuda_eval_gpu_forward_001
 
       - name: CUDA loss-window falsifier suite
+        if: steps.gate.outputs.run == 'true'
         run: |
           cargo test -p aprender-train --features cuda --lib --release cuda_loss_window

--- a/.github/workflows/cuda-nightly.yml
+++ b/.github/workflows/cuda-nightly.yml
@@ -1,0 +1,82 @@
+name: CUDA Nightly (GPU QLoRA falsifiers)
+
+# Enforces the v0.55-v0.57 QLoRA training-correctness falsifiers that require a
+# real CUDA device and are therefore #[ignore]-gated (or self-skip without a
+# GPU). See roadmap item CUDA-CI-NIGHTLY-001 and ROADMAP.md
+# "Honest doctrine gap: GPU falsifiers are not yet CI-enforced".
+#
+# ---------------------------------------------------------------------------
+# DORMANT UNTIL ACTIVATED — merging this file changes nothing until an operator:
+#   1. Registers a self-hosted runner on lambda-vector (RTX 4090, sm_89,
+#      CUDA 12.8) with labels: [self-hosted, Linux, X64, cuda]
+#   2. Sets the repo variable CUDA_RUNNER_READY=true
+#        gh variable set CUDA_RUNNER_READY --body true
+#      (optionally override the model path with APR_PARITY_MODEL)
+# Until both are done, the `cuda-falsifiers` job is skipped by its `if:` guard,
+# so scheduled/dispatch runs are a green no-op with no queued jobs and no noise.
+# This workflow NEVER triggers on pull_request, so it can never gate a PR.
+#
+# WHY THE 4090 AND NOT GB10/gx10: the CI-gate role requires the runner to reach
+# github.com (poll for jobs + report the check). lambda-vector has WAN; gx10 is
+# overlay-only (no WAN, no reverse SSH), so it cannot host a GitHub Actions
+# runner. gx10's Blackwell sm_121 coverage is valuable but belongs in a
+# separate push-based offline cross-silicon check (phase 2), not this gate.
+# ---------------------------------------------------------------------------
+
+on:
+  schedule:
+    - cron: "30 6 * * *"   # 06:30 UTC — after beat-speed-nightly (05:45)
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cuda-nightly
+  cancel-in-progress: false
+
+jobs:
+  cuda-falsifiers:
+    # Dormant switch: stays skipped (green no-op) until the operator flips the
+    # variable AFTER registering the cuda-labeled runner. Prevents jobs queueing
+    # forever against a non-existent runner label.
+    if: ${{ vars.CUDA_RUNNER_READY == 'true' }}
+    runs-on: [self-hosted, Linux, X64, cuda]
+    timeout-minutes: 75
+    env:
+      # Qwen2-family .apr with an embedded tokenizer, used by the parity + eval
+      # falsifiers. Overridable via repo variable if the model lives elsewhere.
+      APR_PARITY_MODEL: ${{ vars.APR_PARITY_MODEL || '/home/noah/models/qwen2.5-coder-1.5b-instruct-q4k.apr' }}
+      CARGO_TERM_COLOR: always
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Preflight — CUDA device + parity model present
+        run: |
+          set -euo pipefail
+          nvidia-smi -L || { echo "::error::no CUDA device visible on this runner"; exit 1; }
+          nvidia-smi --query-gpu=name,driver_version --format=csv,noheader
+          if [ ! -f "$APR_PARITY_MODEL" ]; then
+            echo "::error::APR_PARITY_MODEL not found: $APR_PARITY_MODEL"
+            echo "::error::Set repo variable APR_PARITY_MODEL to a Qwen2-family .apr on the runner."
+            exit 1
+          fi
+          echo "parity model: $APR_PARITY_MODEL ($(du -h "$APR_PARITY_MODEL" | cut -f1))"
+
+      - name: GPU QLoRA training-correctness falsifiers (--features cuda)
+        # --include-ignored runs BOTH the #[ignore]-gated eval falsifiers and the
+        # non-ignored deadlock/NaN/parity falsifiers (which self-skip without a
+        # GPU). Named explicitly so the suite is auditable and additions are
+        # deliberate. Any RED here is a real GPU-path correctness regression.
+        run: |
+          cargo test -p aprender-train --features cuda --lib --release -- \
+            --include-ignored --nocapture --test-threads 1 \
+            falsify_cuda_fused_rmsnorm_distinct_residual_out_no_deadlock \
+            falsify_cuda_nf4_forward_nan_001 \
+            falsify_cuda_nf4_train_loss_parity_001 \
+            falsify_cuda_eval_adapter_sync_001 \
+            falsify_cuda_eval_gpu_forward_001
+
+      - name: CUDA loss-window falsifier suite
+        run: |
+          cargo test -p aprender-train --features cuda --lib --release cuda_loss_window

--- a/.github/workflows/cuda-nightly.yml
+++ b/.github/workflows/cuda-nightly.yml
@@ -5,9 +5,20 @@ name: CUDA Nightly (GPU QLoRA falsifiers)
 # GPU). See roadmap item CUDA-CI-NIGHTLY-001 and ROADMAP.md
 # "Honest doctrine gap: GPU falsifiers are not yet CI-enforced".
 #
-# CROSS-SILICON MATRIX. Runs the SAME falsifier suite on two self-hosted CUDA
-# runners so a kernel that passes on one target but regresses on the other is
-# caught:
+# WHEN IT RUNS (all three properties are enforced below, not just documented):
+#   1. NIGHTLY ONLY, overnight Madrid time. cron is UTC; 01:30 UTC =
+#      03:30 Europe/Madrid in summer (CEST, UTC+2) and 02:30 in winter (CET,
+#      UTC+1) — deep night year-round, and clear of the other nightlies
+#      (coverage 03:00 UTC, nightly/binary 04:00 UTC, beat-speed 05:45 UTC).
+#   2. YIELDS TO TRAINING. These falsifiers are LOW priority. Before doing any
+#      work, each leg checks its GPU; if a training (or any) job is already
+#      using it, the leg skips for the night (green no-op) so it never contends
+#      with overnight training. A manual dispatch can force-override.
+#   3. NEVER ON PULL REQUESTS. Triggers are schedule + workflow_dispatch ONLY —
+#      there is no `pull_request`/`push` trigger, so it cannot fire on, or gate,
+#      a PR. It only runs on the nightly schedule or when explicitly dispatched.
+#
+# CROSS-SILICON MATRIX (same suite on two self-hosted CUDA runners):
 #   - ada-4090      : lambda-vector, RTX 4090, sm_89,  x86-64, CUDA 12.8
 #                     (labels: self-hosted, Linux, X64, cuda)  -- direct WAN
 #   - blackwell-gb10: gx10, GB10, sm_121, aarch64, CUDA 13.0
@@ -17,20 +28,22 @@ name: CUDA Nightly (GPU QLoRA falsifiers)
 # sm_89 is the stable reference; sm_121 is the higher-risk target (historical
 # JIT bugs), which is exactly why both are gated.
 #
-# GATE: kept behind vars.CUDA_RUNNER_READY so the lane can be disabled without
-# deleting the workflow. Triggers on schedule + workflow_dispatch ONLY (never
-# pull_request), so it can never gate a PR. Nightly first; promote to a blocking
-# check on training-path PRs once it has a green track record.
+# Toggle: gated behind vars.CUDA_RUNNER_READY so the lane can be disabled
+# without deleting the workflow.
 
 on:
   schedule:
-    - cron: "30 6 * * *"   # 06:30 UTC — after beat-speed-nightly (05:45)
+    - cron: "30 1 * * *"   # 01:30 UTC = ~03:30 Europe/Madrid (overnight)
   workflow_dispatch:
     inputs:
       silicon:
         description: "Which silicon to run (all | ada | blackwell)"
         required: false
         default: "all"
+      force:
+        description: "Run even if the GPU is busy with training (bypass the yield)"
+        required: false
+        default: "false"
 
 permissions:
   contents: read
@@ -52,29 +65,47 @@ jobs:
           - name: blackwell-gb10
             arch: ARM64
             select: blackwell
-    # Skip a leg when a dispatch asks for a single silicon.
     runs-on: [self-hosted, Linux, "${{ matrix.arch }}", cuda]
     timeout-minutes: 90
     env:
       APR_PARITY_MODEL: ${{ vars.APR_PARITY_MODEL || '/home/noah/models/qwen2.5-coder-1.5b-instruct-q4k.apr' }}
       CARGO_TERM_COLOR: always
     steps:
-      - name: Silicon filter
-        id: gate
+      - name: Decide whether to run (silicon filter + yield-to-training)
+        id: decide
         run: |
+          set -uo pipefail
           want="${{ github.event.inputs.silicon || 'all' }}"
-          if [ "$want" = "all" ] || [ "$want" = "${{ matrix.select }}" ]; then
-            echo "run=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "run=false" >> "$GITHUB_OUTPUT"
-            echo "skipping ${{ matrix.name }} (dispatch requested: $want)"
+          force="${{ github.event.inputs.force || 'false' }}"
+
+          # (a) silicon filter — a dispatch may target a single leg.
+          if [ "$want" != "all" ] && [ "$want" != "${{ matrix.select }}" ]; then
+            echo "::notice::${{ matrix.name }}: skipped (dispatch requested '$want')"
+            echo "proceed=false" >> "$GITHUB_OUTPUT"; exit 0
           fi
 
+          # (b) yield to training — falsifiers are LOW priority. If any compute
+          #     job is already on this GPU (or >2 GiB resident), skip tonight so
+          #     we never contend with overnight training. `force=true` on a
+          #     manual dispatch overrides.
+          used=$(nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits 2>/dev/null | head -1 | tr -d ' ')
+          procs=$(nvidia-smi --query-compute-apps=pid --format=csv,noheader 2>/dev/null | grep -c . || true)
+          echo "${{ matrix.name }}: GPU memory.used=${used:-?} MiB, existing compute procs=${procs:-?}"
+          if [ "$force" = "true" ]; then
+            echo "::notice::${{ matrix.name }}: force=true — running regardless of GPU load"
+            echo "proceed=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [ "${used:-0}" -gt 2000 ] || [ "${procs:-0}" -gt 0 ]; then
+            echo "::notice::${{ matrix.name }}: GPU busy (${used:-?} MiB, ${procs:-?} procs) — yielding to training, skipping falsifiers tonight"
+            echo "proceed=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          echo "proceed=true" >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@v7
-        if: steps.gate.outputs.run == 'true'
+        if: steps.decide.outputs.proceed == 'true'
 
       - name: Preflight — CUDA device + parity model present
-        if: steps.gate.outputs.run == 'true'
+        if: steps.decide.outputs.proceed == 'true'
         run: |
           set -euo pipefail
           echo "runner: ${{ matrix.name }} ($(uname -m))"
@@ -87,12 +118,13 @@ jobs:
           echo "parity model: $APR_PARITY_MODEL ($(du -h "$APR_PARITY_MODEL" | cut -f1))"
 
       - name: GPU QLoRA training-correctness falsifiers (--features cuda)
-        if: steps.gate.outputs.run == 'true'
-        # --include-ignored runs BOTH the #[ignore]-gated eval falsifiers and the
-        # non-ignored deadlock/NaN/parity ones (which self-skip without a GPU).
-        # Named explicitly so the suite is auditable and additions are deliberate.
+        if: steps.decide.outputs.proceed == 'true'
+        # `nice` so the build never starves any CPU-side work of a job that
+        # started after our yield check. --include-ignored runs BOTH the
+        # #[ignore]-gated eval falsifiers and the non-ignored deadlock/NaN/
+        # parity ones (which self-skip without a GPU).
         run: |
-          cargo test -p aprender-train --features cuda --lib --release -- \
+          nice -n 19 cargo test -p aprender-train --features cuda --lib --release -- \
             --include-ignored --nocapture --test-threads 1 \
             falsify_cuda_fused_rmsnorm_distinct_residual_out_no_deadlock \
             falsify_cuda_nf4_forward_nan_001 \
@@ -101,6 +133,6 @@ jobs:
             falsify_cuda_eval_gpu_forward_001
 
       - name: CUDA loss-window falsifier suite
-        if: steps.gate.outputs.run == 'true'
+        if: steps.decide.outputs.proceed == 'true'
         run: |
-          cargo test -p aprender-train --features cuda --lib --release cuda_loss_window
+          nice -n 19 cargo test -p aprender-train --features cuda --lib --release cuda_loss_window


### PR DESCRIPTION
Implements roadmap item **`CUDA-CI-NIGHTLY-001`** — closes the "gates or theater" doctrine gap surfaced 2026-07-03: the entire v0.55–v0.57 QLoRA training-correctness wave is falsified **only developer-side** because the CI fleet has no CUDA runner.

## Why the 4090 (lambda-vector), not gx10

The deciding factor is networking, not the GPU:

| | RTX 4090 / lambda-vector | gx10 / GB10 Blackwell |
|---|---|---|
| WAN → can host a GitHub Actions runner | ✅ | ❌ overlay-only, no WAN / reverse SSH |
| Report the check back to GitHub | ✅ | ❌ |
| GPU + toolchain + parity model | ✅ sm_89, CUDA 12.8, model present | ✅ sm_121 (model needs offline rsync) |
| Falsifiers pass | ✅ reference platform | ✅ (manual push this session) |

A CI *gate* must reach github.com to poll for jobs and report status — only lambda-vector can. gx10's Blackwell sm_121 coverage is genuinely higher-value (sm_89 is stable; sm_121 has a JIT-bug history) but belongs in a **separate push-based offline cross-silicon check (phase 2)**, documented in the workflow header, not this gate.

## What it runs

The five GPU falsifiers (`--include-ignored` covers both the `#[ignore]`-gated eval ones and the self-skipping deadlock/NaN/parity ones) + the loss-window suite:
`falsify_cuda_fused_rmsnorm_distinct_residual_out_no_deadlock`, `falsify_cuda_nf4_forward_nan_001`, `falsify_cuda_nf4_train_loss_parity_001`, `falsify_cuda_eval_adapter_sync_001`, `falsify_cuda_eval_gpu_forward_001`.

## Dormant-safe — merging this changes nothing until activated

- Job guarded by `if: vars.CUDA_RUNNER_READY == 'true'` (default off → skipped → **green no-op**, no jobs queued against a non-existent runner label)
- Triggers on `schedule` + `workflow_dispatch` **only** — never `pull_request`, so it can never gate a PR
- Preflight step fails loud if the GPU or model is missing

## Activation (two operator steps, both on your infra — I can't do these)

1. Register a self-hosted runner on lambda-vector with labels `[self-hosted, Linux, X64, cuda]`
2. `gh variable set CUDA_RUNNER_READY --body true` (optionally `gh variable set APR_PARITY_MODEL --body /path/to/model.apr`)

Then `gh workflow run "CUDA Nightly (GPU QLoRA falsifiers)"` to smoke-test it live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)