### PR TITLE
ci(cuda-nightly): fix Decide step failing on GB10 under bash -e (memory.used=[N/A])

### DIFF
--- a/.github/workflows/cuda-nightly.yml
+++ b/.github/workflows/cuda-nightly.yml
@@ -90,9 +90,11 @@ jobs:
           #     manual dispatch overrides.
           # `procs` (compute contexts) is the primary, portable signal — it
           # works on both sm_89 and GB10. `memory.used` is a secondary signal
-          # and is [N/A] on GB10's unified memory, so extract digits only and
-          # default to 0 (never let a non-integer reach `[ -gt ]`).
-          used=$(nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits 2>/dev/null | head -1 | grep -oE '[0-9]+' | head -1)
+          # and is [N/A] on GB10's unified memory. GitHub runs `run:` as
+          # `bash -e -o pipefail`, so use `tr -cd` (never non-zero) to strip to
+          # digits — a `grep -oE` that finds no digit exits 1 and, under -e,
+          # would kill this step on GB10 (which is exactly what happened first).
+          used=$(nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits 2>/dev/null | head -1 | tr -cd '0-9')
           used=${used:-0}
           procs=$(nvidia-smi --query-compute-apps=pid --format=csv,noheader 2>/dev/null | grep -c . || true)
           procs=${procs:-0}


### PR DESCRIPTION
The end-to-end smoke dispatch of the new lane caught this immediately: the **blackwell-gb10 leg failed in the Decide step, before checkout**, while ada-4090 passed.

**Root cause:** GitHub runs `run:` steps as `bash -e -o pipefail`. On GB10, `nvidia-smi --query-gpu=memory.used` returns `[N/A]` (unified LPDDR), so `... | grep -oE '[0-9]+'` finds no digit → exits 1 → `-e` kills the step. The 4090 (`used=451`, digits present) sailed through — which is why only Blackwell failed. (My earlier manual re-test passed because plain SSH bash has no `-e` — the smoke-test is what surfaced it.)

**Fix:** `tr -cd '0-9'` instead of `grep -oE` — it strips to digits and never exits non-zero. `procs` (compute-context count) remains the primary, portable yield signal on both silicons.

**Verified under the exact `bash -e -o pipefail` shell on both boxes:**
- gx10: `used=0 procs=0 → IDLE-run → DECIDE-EXIT-OK`
- lambda: `used=451 procs=0 → IDLE-run → DECIDE-EXIT-OK`

Once merged I'll re-dispatch to confirm both legs run the full checkout → cargo → falsifier path green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)