### PR TITLE
fix(ci): pin generic self-hosted jobs to clean-room runners

### DIFF
--- a/.github/workflows/beat-speed-nightly.yml
+++ b/.github/workflows/beat-speed-nightly.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   beat-speed:
-    runs-on: [self-hosted, X64, Linux]
+    runs-on: [self-hosted, X64, Linux, clean-room]
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
   # giving us up to ~13 minutes of retry headroom before declaring the
   # registry unreachable. Mirrored in the `mutants` job below.
   workspace-test:
-    runs-on: [self-hosted, X64, Linux]
+    runs-on: [self-hosted, X64, Linux, clean-room]
     timeout-minutes: 85  # bumped to match 75min step + 10min overhead
     env:
       IMAGE: localhost:5000/sovereign-ci:stable
@@ -357,7 +357,7 @@ jobs:
   # Top-level gate: satisfies org ruleset "Green Main" which requires check named "gate".
   # The reusable workflow produces "ci / gate" but rulesets need exact match on "gate".
   gate:
-    runs-on: [self-hosted, X64, Linux]
+    runs-on: [self-hosted, X64, Linux, clean-room]
     needs: [ci, workspace-test, mutants]
     if: always()
     steps:
@@ -404,7 +404,7 @@ jobs:
   # to scope against, so we skip rather than fall back to the old hours-long
   # full-tree run.
   mutants:
-    runs-on: [self-hosted, X64, Linux]
+    runs-on: [self-hosted, X64, Linux, clean-room]
     timeout-minutes: 60
     needs: [ci, workspace-test]
     if: github.event_name == 'pull_request'


### PR DESCRIPTION
## Five Whys

The `mutants` check failed on #2268 while other PRs passed the same hour — a scheduling lottery, not a code issue.

1. **Why fail?** `mutants` couldn't pull `localhost:5000/sovereign-ci` — *"registry unreachable AND image not in local cache"*.
2. **Why unreachable?** the job ran on runner **`lambda-4090`** (the RTX 4090 dev box, `noah-Lambda-Vector`), which has no sovereign-ci registry/image — those live on the **intel clean-room** hosts.
3. **Why did a CPU/clean-room job land on a GPU box?** the job's `runs-on` was the bare `[self-hosted, X64, Linux]`.
4. **Why does that match a GPU runner?** GitHub auto-assigns `self-hosted`/`Linux`/`X64` as **default labels that cannot be removed**, so `lambda-4090` (registered today for GPU CI) satisfies the generic selector and silently joined the CPU pool.
5. **Root cause:** the sovereign-ci hosts are distinguished by the **`clean-room`** label (all 16 `intel-clean-room-*` runners have it; `coverage-nightly.yml` and the reusable `sovereign-ci.yml` jobs already pin it) — but **four inline jobs omit it**.

## Fix — root cause, no workaround, no bypass

Pin all four generic jobs to `clean-room`:
- `ci.yml`: **workspace-test**, **gate**, **mutants**
- `beat-speed-nightly.yml`: **beat-speed** — this one was **silent-green**: no hard failure, but running the timing beats off the calibrated Intel-MKL host produces *invalid benchmark numbers*. Worse than red.

GPU selectors (`[self-hosted, gpu]`, `[..., cuda]`) are **untouched** — the GPU runner stays for `cuda-nightly`. Not removing/re-scoping any runner.

## Verification

4-lens adversarial review (root-cause / fix-correctness / blast-radius / no-workaround): **root cause unrefuted, fix minimal, unanimously not a workaround.** Blast radius is **aprender-only** — `lambda-4090` and `gx10-blackwell` are repo-scoped runners; `gx10-blackwell` is ARM64 so it can't match X64. Confirmed the reusable `sovereign-ci.yml` jobs already pin `clean-room`.

## Follow-ups (separate, not blocking)
- `qwen-story-daily.yml` uses `[self-hosted, gpu]` but neither GPU runner carries a `gpu` label (they have `cuda`/`rtx4090`/`blackwell`) → that job matches no runner and queues indefinitely.
- Poka-yoke: a repo lint/contract rejecting any inline self-hosted job whose `runs-on` lacks `clean-room` (or a GPU label), so this convention drift can't silently reland.

🤖 Generated with [Claude Code](https://claude.com/claude-code)