### PR TITLE
ci(nightly): add aarch64-unknown-linux-gnu target

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,4 +1,4 @@
-# Nightly binary builds — cross-compiled for 4 targets
+# Nightly binary builds — cross-compiled for 5 targets
 # APR-MONO: All deps are in-tree. No sibling repo checkouts needed.
 # Spec: docs/specifications/release-system.md
 #
@@ -42,7 +42,7 @@ jobs:
             echo "No commits in last 24h — skipping nightly build"
           fi
 
-  # ── Cross-compile binaries (4 targets) ───────────────────
+  # ── Cross-compile binaries (5 targets) ───────────────────
   build:
     needs: check-activity
     if: needs.check-activity.outputs.has_commits == 'true'
@@ -52,6 +52,8 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             runner: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            runner: ubuntu-24.04-arm    # native ARM64, GA + free for public repos
           - target: x86_64-apple-darwin
             runner: macos-latest
           - target: aarch64-apple-darwin


### PR DESCRIPTION
## What

Adds an `aarch64-unknown-linux-gnu` target to the nightly binary build matrix in `.github/workflows/nightly.yml`, mirroring the change just landed in `paiml/forjar`. Bumps the matrix from 4 to 5 targets.

```yaml
- target: x86_64-unknown-linux-gnu
  runner: ubuntu-latest
- target: aarch64-unknown-linux-gnu      # <-- added
  runner: ubuntu-24.04-arm               # native ARM64, GA + free for public repos
- target: x86_64-apple-darwin
  runner: macos-latest
...
```

## Why

The fleet's only aarch64-linux box — the **GX10 / DGX-Spark** — currently has no prebuilt `apr` nightly and has to compile the whole workspace from source. This attaches a native ARM64 Linux `apr` binary to the `nightly` prerelease so that machine can just download it.

## How

Built natively on GitHub's `ubuntu-24.04-arm` runner (generally available, and free for public repos), matching the per-target native-runner approach the rest of this matrix already uses — no `cross` toolchain needed. The existing native build/package/upload steps apply unchanged (aarch64-linux is unix, so it follows the existing unix path).

Validated with `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/nightly.yml'))"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)