### PR TITLE
fix(serve): top_k=0 emits token 0 forever — garbage output on all chat surfaces (FALSIFY-SAMPLE-TOPK-ZERO-001)

### DIFF
--- a/crates/aprender-serve/src/gguf/inference/generate_quantized.rs
+++ b/crates/aprender-serve/src/gguf/inference/generate_quantized.rs
@@ -154,7 +154,15 @@ impl OwnedQuantizedModel {
         // Get top-k indices
         let mut indexed: Vec<(usize, f32)> = scaled.iter().copied().enumerate().collect();
         indexed.sort_by(|(_, a), (_, b)| b.partial_cmp(a).unwrap_or(std::cmp::Ordering::Equal));
-        indexed.truncate(top_k);
+        // `top_k == 0` means "disabled" in llama.cpp and Ollama, and both the
+        // Ollama-compat and OpenAI-compat surfaces pass it straight through. An
+        // unguarded `truncate(0)` empties `indexed`, so `probs` is empty and the
+        // inverse-CDF loop below falls through to `probs.last().map_or(0, ..)` —
+        // returning token 0 on EVERY step (`!!!!!!`). Guard exactly as the live
+        // MoE sampler does (infer/qwen3_moe_generate.rs:104).
+        if top_k > 0 && top_k < indexed.len() {
+            indexed.truncate(top_k);
+        }
 
         // Softmax over top-k
         let max_val = indexed.first().map_or(0.0, |(_, v)| *v);

--- a/crates/aprender-serve/src/gguf/inference/generate_quantized_topk_tests.rs
+++ b/crates/aprender-serve/src/gguf/inference/generate_quantized_topk_tests.rs
@@ -1,0 +1,79 @@
+//! FALSIFY-SAMPLE-TOPK-ZERO-001 — `top_k = 0` must mean "disabled", not "no candidates".
+//!
+//! llama.cpp and Ollama both use `top_k = 0` to mean *disable top-k filtering*, and
+//! aprender's Ollama-compat (`/api/chat`, `/api/generate`) and OpenAI-compat
+//! (`/v1/chat/completions`) surfaces pass the value straight through to the dense
+//! sampler. Before the fix, `sample_topk_with_draw` ran an unguarded
+//! `indexed.truncate(top_k)`: with `top_k == 0` that empties the candidate vector,
+//! the softmax/inverse-CDF loop has nothing to iterate, and the fallthrough
+//! `probs.last().map_or(0, ..)` returns **token 0** — on every step, forever, so the
+//! user sees a stream of `!!!!!!`.
+//!
+//! RED-on-bug / GREEN-on-fix: with `truncate(top_k)` unguarded these assertions fail
+//! (every draw returns 0); with the `top_k > 0 && top_k < len` guard they pass.
+
+use crate::gguf::OwnedQuantizedModel;
+use rand::rngs::StdRng;
+use rand::SeedableRng;
+
+/// Logits whose unique argmax is index 5. Deliberately NOT index 0, so a sampler
+/// that collapses to the fallthrough is distinguishable from one that is merely greedy.
+const LOGITS: [f32; 8] = [-9.0, -8.0, -7.0, -6.0, -5.0, 10.0, -4.0, -3.0];
+const ARGMAX: u32 = 5;
+
+/// The exact defect: `top_k = 0` returned token 0 on every draw.
+#[test]
+fn topk_zero_is_disabled_not_empty() {
+    // 10.0 vs the next-highest -3.0 is a ~13-logit gap; after temperature 0.7 the
+    // softmax mass on index 5 is >0.999999, so ANY uniform draw must select it.
+    // A single unlucky draw therefore cannot explain a failure here.
+    for seed in 0..64u64 {
+        let mut rng = StdRng::seed_from_u64(seed);
+        let tok = OwnedQuantizedModel::sample_topk_seeded(&LOGITS, 0.7, 0, &mut rng);
+        assert_eq!(
+            tok, ARGMAX,
+            "FALSIFY-SAMPLE-TOPK-ZERO-001: top_k=0 (llama.cpp/Ollama 'disabled') \
+             returned token {tok}, expected {ARGMAX}. Returning 0 means truncate(0) \
+             emptied the candidate set and the inverse-CDF fell through to \
+             probs.last().map_or(0, ..) — the '!!!!!!' garbage-output defect."
+        );
+    }
+}
+
+/// `top_k = 0` must be equivalent to "keep every candidate", i.e. the same
+/// distribution as `top_k >= vocab`. Oracle comparison, not a point assertion:
+/// this stays honest even if the argmax or the RNG changes.
+#[test]
+fn topk_zero_matches_topk_full_vocab() {
+    for seed in 0..64u64 {
+        let mut rng_zero = StdRng::seed_from_u64(seed);
+        let mut rng_full = StdRng::seed_from_u64(seed);
+        let a = OwnedQuantizedModel::sample_topk_seeded(&LOGITS, 1.0, 0, &mut rng_zero);
+        let b = OwnedQuantizedModel::sample_topk_seeded(&LOGITS, 1.0, LOGITS.len(), &mut rng_full);
+        assert_eq!(
+            a, b,
+            "FALSIFY-SAMPLE-TOPK-ZERO-001: top_k=0 must behave as 'disabled' \
+             (identical to top_k=vocab_len); got {a} vs {b} at seed {seed}"
+        );
+    }
+}
+
+/// `top_k` larger than the vocabulary must not panic or change behaviour —
+/// the guard's `top_k < indexed.len()` arm has to be a no-op, not a truncation.
+#[test]
+fn topk_larger_than_vocab_is_safe() {
+    let mut rng = StdRng::seed_from_u64(7);
+    let tok = OwnedQuantizedModel::sample_topk_seeded(&LOGITS, 0.7, 9999, &mut rng);
+    assert_eq!(tok, ARGMAX, "top_k > vocab_len must clamp harmlessly");
+}
+
+/// Ordinary top-k still filters: with `top_k = 1` only the argmax is reachable.
+/// Guards against a "fix" that simply disables truncation altogether.
+#[test]
+fn topk_one_is_still_greedy() {
+    for seed in 0..16u64 {
+        let mut rng = StdRng::seed_from_u64(seed);
+        let tok = OwnedQuantizedModel::sample_topk_seeded(&LOGITS, 1.0, 1, &mut rng);
+        assert_eq!(tok, ARGMAX, "top_k=1 must always return the argmax");
+    }
+}

--- a/crates/aprender-serve/src/gguf/inference/mod.rs
+++ b/crates/aprender-serve/src/gguf/inference/mod.rs
@@ -23,6 +23,8 @@ mod attention_flash_tests;
 #[cfg(test)]
 mod attention_gqa_tests;
 #[cfg(test)]
+mod generate_quantized_topk_tests;
+#[cfg(test)]
 mod generation_tests;
 #[cfg(test)]
 mod matmul_tests;


### PR DESCRIPTION
First v0.62.0 fix. **P0** — this is user-visible garbage output on the value llama.cpp and Ollama both use for "disabled".

## The defect

`sample_topk_with_draw` ran an unguarded `indexed.truncate(top_k)`:

```
top_k == 0  ->  truncate(0) empties the candidate vector
            ->  `probs` is empty, the inverse-CDF loop body never runs
            ->  fallthrough `probs.last().map_or(0, ..)` returns token 0
            ->  token 0 on EVERY step: the user sees `!!!!!!`
```

`top_k = 0` means **disable top-k filtering** in llama.cpp and Ollama, and our Ollama-compat (`/api/chat`, `/api/generate`) and OpenAI-compat (`/v1/chat/completions`) surfaces pass it straight through. Any client following that convention got pure garbage from `apr run`, `apr serve`, and every HTTP chat surface.

## The fix

The guard the live MoE sampler **already uses** (`infer/qwen3_moe_generate.rs:104`):

```rust
if top_k > 0 && top_k < indexed.len() { indexed.truncate(top_k); }
```

The `top_k < len` arm additionally makes `top_k > vocab_len` a harmless no-op rather than a pointless truncation.

## Mutation verification (RED on bug / GREEN on fix)

With the guard reverted to `indexed.truncate(top_k)`:

```
topk_zero_is_disabled_not_empty   ... FAILED   (returned 0, expected 5)
topk_zero_matches_topk_full_vocab ... FAILED   (got 0 vs 5 at seed 0)
topk_larger_than_vocab_is_safe    ... ok
topk_one_is_still_greedy          ... ok
```

Both control tests stay **green** under the mutation — the falsifier targets this defect specifically rather than failing broadly. With the guard restored all 4 pass; `generation_tests` unchanged at **43 passed**.

## Falsifier design

Deliberately oracle-based rather than a point assertion, per the contracts-are-a-ratchet rule:

- `top_k=0` must be **indistinguishable from** `top_k=vocab_len` across 64 seeds — stays honest if the argmax, logits, or RNG change
- argmax is index **5**, not 0, so "collapsed to the fallthrough" is distinguishable from "merely greedy"
- the ~13-logit gap puts >0.999999 softmax mass on the argmax, so a single unlucky draw cannot explain a failure
- `topk_one_is_still_greedy` guards against a "fix" that just deletes the truncation

Refs FALSIFY-SAMPLE-TOPK-ZERO-001