### PR TITLE
fix(release): cascade-drain default 6 → 20 passes (a real cascade needs ~15)

### DIFF
--- a/scripts/cascade-drain.sh
+++ b/scripts/cascade-drain.sh
@@ -16,7 +16,7 @@
 # Usage:
 #   scripts/cascade-drain.sh                  # target = workspace version
 #   scripts/cascade-drain.sh --target 0.61.0
-#   scripts/cascade-drain.sh --passes 8
+#   scripts/cascade-drain.sh --passes 30    # default is 20
 #
 # Exit codes: 0 drained | 2 stuck (no progress) | 3 passes exhausted
 set -uo pipefail
@@ -25,11 +25,21 @@ REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 cd "$REPO_ROOT" || exit 2
 
 TARGET=""
-PASSES=6
+# 20, not 6. TIERS[] in cascade-publish.sh is NOT a topological order — there are
+# 44 dependency edges pointing into the same or a later tier (e.g. aprender-core
+# in T2 depends on aprender-data in T8; apr-cli T10 -> aprender-registry T13).
+# cascade-publish.sh does exactly ONE retry round and then exits 1, so each drain
+# pass only resolves roughly one dependency layer. Simulation against the real
+# dep graph converges in ~15 passes; the old default of 6 exhausted first and
+# exited 3, which reads as a FAILED release while the cascade was in fact still
+# making forward progress. Cheap to over-provision: a pass with nothing left to
+# publish is one crates.io census (~seconds), and the loop exits 0 the moment it
+# reaches N/N.
+PASSES=20
 while [ $# -gt 0 ]; do
     case "$1" in
         --target) TARGET="${2:-}"; shift 2 ;;
-        --passes) PASSES="${2:-6}"; shift 2 ;;
+        --passes) PASSES="${2:-20}"; shift 2 ;;
         -h|--help) sed -n '2,20p' "$0"; exit 0 ;;
         *) echo "unknown arg: $1" >&2; exit 2 ;;
     esac


### PR DESCRIPTION
P1 from the v0.61.0 show-stopper hunt. Makes the safe value the default so the next release does not depend on an operator remembering.

## Why 6 was wrong

`TIERS[]` in `cascade-publish.sh` is **not** a topological order — 44 dependency edges point into the same or a later tier:

- `aprender-core` (T2) depends on `aprender-data` (T8)
- `apr-cli` (T10) depends on `aprender-registry` (T13)
- intra-tier: T8 lists `aprender-serve` before `aprender-data`

`cascade-publish.sh` does exactly **one** retry round then `exit 1`, so each drain pass resolves roughly one dependency layer. Simulation against the real dep graph converges in **~15 passes**.

The old default of 6 exhausted first and `exit 3` — which reads as a **failed release** while the cascade was still making forward progress.

## Why that failure mode is the dangerous one

On an append-only registry, the operator’s instinct on a "failed" publish is to bump the version and retry. That strands **every crate already published** at a version its siblings no longer request. A pass ceiling that fires early doesn’t just misreport — it actively invites the one recovery action that makes things worse.

## Why over-provisioning is safe

A pass with nothing left to publish costs one crates.io census (seconds), and the loop exits 0 the moment it reaches N/N. Genuine failure is still caught immediately and distinctly by the existing `STUCK: no progress` check, which fires on the **first** pass that publishes nothing new. That guard — not the pass ceiling — is what detects a real error.

## Evidence

The v0.61.0 cascade running right now was invoked manually with `--passes 20` for exactly this reason.

```
bash -n                 OK
bashrs lint             0 errors
--help                  Usage block still renders (lines 16-19, inside the sed 2,20p window)
--passes N              still overrides
```

Also corrects the `--help` example, which showed `--passes 8` — below the new default, reading as if 8 were reasonable.