### PR TITLE
fix(cli): --features full does not compile — point trueno-explain in-tree (FEATURES-FULL-COMPILE-001)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,6 +263,7 @@ dependencies = [
  "aprender-contracts",
  "aprender-core",
  "aprender-data",
+ "aprender-explain",
  "aprender-mcp",
  "aprender-orchestrate",
  "aprender-present-core",
@@ -314,7 +315,6 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tower 0.5.3",
- "trueno-explain",
  "unicode-normalization",
  "ureq 2.12.1",
  "which 7.0.3",
@@ -14734,23 +14734,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "trueno-explain"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d342a4c0eb322f9b339255de442e1b09f5391b2c5e1ba7f4e49e2353aee2702d"
-dependencies = [
- "clap",
- "colored 2.2.0",
- "crossterm 0.28.1",
- "ratatui",
- "regex",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "trueno-gpu",
-]
-
-[[package]]
 name = "trueno-gemm-codegen"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14759,16 +14742,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
-]
-
-[[package]]
-name = "trueno-gpu"
-version = "0.4.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7a4f3a053376a54fa47fc4c745c177407a9b04afecbd14aa4aa3e8e5b70469"
-dependencies = [
- "batuta-common",
- "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/crates/apr-cli/Cargo.toml
+++ b/crates/apr-cli/Cargo.toml
@@ -96,7 +96,7 @@ training = ["dep:entrenar", "dep:entrenar-lora", "dep:aprender-train-distill", "
 training-gpu = ["training"]
 whisper = ["whisper-apr"]
 dhat-heap = ["dep:dhat"]
-full = ["inference", "cuda", "cuda-batch", "visualization", "zram", "training", "training-gpu", "code", "xet"]
+full = ["inference", "cuda", "cuda-batch", "visualization", "zram", "training", "training-gpu", "code", "xet", "trueno-explain"]
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
@@ -208,8 +208,14 @@ trueno-zram-core = { workspace = true, optional = true }
 # Model registry and caching (Ollama-like model management)
 pacha = { workspace = true }
 
-# PTX analysis and bug detection (trueno-explain: PtxAnalyzer + PtxBugAnalyzer)
-trueno-explain = { version = "0.2.2", optional = true }
+# PTX analysis and bug detection (PtxAnalyzer + PtxBugAnalyzer).
+# Points at the IN-TREE crate, which ships `[lib] name = "trueno_explain"` — the
+# same aliasing pattern as aprender-compute -> trueno. This was previously
+# `{ version = "0.2.2" }` from crates.io, which both (a) reintroduced the
+# published-crate dependency cycle the APR-MONO consolidation removed, and
+# (b) was never actually linked, so every `trueno_explain::` path in
+# commands/ptx_explain.rs failed to resolve.
+trueno-explain = { path = "../aprender-explain", version = "0.61.0", package = "aprender-explain", optional = true }
 
 # ML tuning: LoRA/QLoRA configuration and memory planning (GH-176, PMAT-184)
 entrenar-lora = { workspace = true, optional = true }


### PR DESCRIPTION
P1 from the v0.61.0 show-stopper hunt. `README.md:25` advertises an install command that fails.

```
cargo install aprender --features full    # everything (training, visualization, zram)
```
```
error[E0433]: failed to resolve: use of unresolved module or unlinked crate `trueno_explain`
   ... x14
```

## Two independent defects, both in `crates/apr-cli/Cargo.toml`

**1. The dep resolved from crates.io, not in-tree.** `trueno-explain = { version = "0.2.2", optional = true }` violates the APR-MONO self-containment rule — every sibling must be a path alias, never a registry dep — and reintroduces exactly the published-crate dependency cycle the consolidation removed. `crates/aprender-explain` already ships `[lib] name = "trueno_explain"`, the same aliasing pattern as `aprender-compute` → `trueno`.

**2. `full` never activated it.** The feature list omitted `trueno-explain`, so the optional dep stayed off under the one feature set whose entire job is "everything". Every `trueno_explain::` path in `commands/ptx_explain.rs` was unresolvable under precisely the configuration the README tells users to install.

## Verification

```
before:  cargo check -p aprender --features full  ->  14x E0433
after:   cargo check -p aprender --features full  ->  Finished, 0 errors
```

## What is deliberately NOT in this PR

**A CI guard.** `grep -n features .github/workflows/ci.yml` returns **nothing** — CI builds with zero feature flags, which is why this rotted undetected for ~8 releases. The obvious follow-up is a job running `cargo check --features full`.

I did not add it here: `full` pulls in `cuda` + `training-gpu`, my local build passes because **this host has CUDA**, and I have no evidence the sovereign-ci clean-room image does. A blocking gate that fails for environmental reasons would wedge the merge queue and be worse than the gap it closes. Tracked as a follow-up once the container's CUDA capability is confirmed — at which point the guard is what stops this regressing again.

Refs FEATURES-FULL-COMPILE-001