### PR TITLE
fix(serve): top_p was a silent no-op on the dense CPU decode path (FALSIFY-SAMPLE-TOPP-NOOP-001)

### DIFF
--- a/crates/aprender-serve/src/gguf/inference/generate_quantized.rs
+++ b/crates/aprender-serve/src/gguf/inference/generate_quantized.rs
@@ -74,7 +74,7 @@ impl OwnedQuantizedModel {
                 Self::argmax(&logits)
             } else {
                 // Temperature + top-k sampling (seeded for reproducibility)
-                Self::sample_topk_seeded(&logits, config.temperature, config.top_k, &mut rng)
+                Self::sample_topk_seeded(&logits, config.temperature, config.top_k, config.top_p, &mut rng)
             };
 
             // Check stop condition
@@ -147,7 +147,13 @@ impl OwnedQuantizedModel {
     /// Pure: the only source of randomness is the caller-supplied `r`. This lets both the
     /// entropy-seeded [`Self::sample_topk`] and the seeded [`Self::sample_topk_seeded`]
     /// share one inverse-CDF implementation, so a seeded RNG fully determines the token.
-    fn sample_topk_with_draw(logits: &[f32], temperature: f32, top_k: usize, r: f32) -> u32 {
+    fn sample_topk_with_draw(
+        logits: &[f32],
+        temperature: f32,
+        top_k: usize,
+        top_p: f32,
+        r: f32,
+    ) -> u32 {
         // Apply temperature
         let scaled: Vec<f32> = logits.iter().map(|&x| x / temperature).collect();
 
@@ -164,7 +170,38 @@ impl OwnedQuantizedModel {
             indexed.truncate(top_k);
         }
 
-        // Softmax over top-k
+        // Top-p (nucleus): keep the smallest prefix whose cumulative softmax mass
+        // reaches `top_p`. Ported from the live MoE sampler
+        // (infer/qwen3_moe_generate.rs:109), which is where the only working
+        // implementation lived — the dense path accepted `top_p` in
+        // QuantizedGenerateConfig and then silently discarded it, so
+        // `--top-p 0.001` was byte-identical to `--top-p 1.0` on every
+        // /v1/chat/completions, /api/chat, /api/generate and `apr run` request.
+        //
+        // The `top_p > 0.0 && top_p < 1.0` guard is what keeps this a BIT-EXACT
+        // no-op at the default 1.0: the branch is not entered at all, so the
+        // candidate set and the inverse-CDF draw below are unchanged. That
+        // matters because the default config sets top_p = 1.0 (runtime.rs:51) —
+        // every existing caller must keep its current output token-for-token.
+        if top_p > 0.0 && top_p < 1.0 {
+            let max_val = indexed.first().map_or(0.0, |(_, v)| *v);
+            let exp_vals: Vec<f32> = indexed.iter().map(|(_, v)| (v - max_val).exp()).collect();
+            let total: f32 = exp_vals.iter().sum();
+            if total > 0.0 {
+                let mut cumulative = 0.0;
+                let mut cutoff = indexed.len();
+                for (i, &ev) in exp_vals.iter().enumerate() {
+                    cumulative += ev / total;
+                    if cumulative >= top_p {
+                        cutoff = i + 1;
+                        break;
+                    }
+                }
+                indexed.truncate(cutoff);
+            }
+        }
+
+        // Softmax over the filtered set
         let max_val = indexed.first().map_or(0.0, |(_, v)| *v);
         let exp_sum: f32 = indexed.iter().map(|(_, v)| (v - max_val).exp()).sum();
         let probs: Vec<(usize, f32)> = indexed
@@ -191,7 +228,9 @@ impl OwnedQuantizedModel {
     /// [`Self::sample_topk_seeded`].
     pub fn sample_topk(logits: &[f32], temperature: f32, top_k: usize) -> u32 {
         let r: f32 = rand::rng().random();
-        Self::sample_topk_with_draw(logits, temperature, top_k, r)
+        // top_p = 1.0 => the nucleus branch is skipped entirely: bit-exact no-op,
+        // so this public signature stays source-compatible for existing callers.
+        Self::sample_topk_with_draw(logits, temperature, top_k, 1.0, r)
     }
 
     /// Top-k sampling with temperature, drawing from a caller-owned seeded RNG.
@@ -207,10 +246,11 @@ impl OwnedQuantizedModel {
         logits: &[f32],
         temperature: f32,
         top_k: usize,
+        top_p: f32,
         rng: &mut StdRng,
     ) -> u32 {
         let r: f32 = rng.random();
-        Self::sample_topk_with_draw(logits, temperature, top_k, r)
+        Self::sample_topk_with_draw(logits, temperature, top_k, top_p, r)
     }
 
     /// Generate tokens using KV cache for efficient autoregressive decoding (IMP-101)
@@ -347,6 +387,7 @@ impl OwnedQuantizedModel {
                     &logits,
                     config.temperature,
                     config.top_k,
+                    config.top_p,
                     &mut rng,
                 )
             };
@@ -535,6 +576,7 @@ impl OwnedQuantizedModel {
                     &logits,
                     config.temperature,
                     config.top_k,
+                    config.top_p,
                     &mut rng,
                 )
             };

--- a/crates/aprender-serve/src/gguf/inference/generate_quantized_topk_tests.rs
+++ b/crates/aprender-serve/src/gguf/inference/generate_quantized_topk_tests.rs
@@ -29,7 +29,7 @@ fn topk_zero_is_disabled_not_empty() {
     // A single unlucky draw therefore cannot explain a failure here.
     for seed in 0..64u64 {
         let mut rng = StdRng::seed_from_u64(seed);
-        let tok = OwnedQuantizedModel::sample_topk_seeded(&LOGITS, 0.7, 0, &mut rng);
+        let tok = OwnedQuantizedModel::sample_topk_seeded(&LOGITS, 0.7, 0, 1.0, &mut rng);
         assert_eq!(
             tok, ARGMAX,
             "FALSIFY-SAMPLE-TOPK-ZERO-001: top_k=0 (llama.cpp/Ollama 'disabled') \
@@ -48,8 +48,9 @@ fn topk_zero_matches_topk_full_vocab() {
     for seed in 0..64u64 {
         let mut rng_zero = StdRng::seed_from_u64(seed);
         let mut rng_full = StdRng::seed_from_u64(seed);
-        let a = OwnedQuantizedModel::sample_topk_seeded(&LOGITS, 1.0, 0, &mut rng_zero);
-        let b = OwnedQuantizedModel::sample_topk_seeded(&LOGITS, 1.0, LOGITS.len(), &mut rng_full);
+        let a = OwnedQuantizedModel::sample_topk_seeded(&LOGITS, 1.0, 0, 1.0, &mut rng_zero);
+        let b =
+            OwnedQuantizedModel::sample_topk_seeded(&LOGITS, 1.0, LOGITS.len(), 1.0, &mut rng_full);
         assert_eq!(
             a, b,
             "FALSIFY-SAMPLE-TOPK-ZERO-001: top_k=0 must behave as 'disabled' \
@@ -63,7 +64,7 @@ fn topk_zero_matches_topk_full_vocab() {
 #[test]
 fn topk_larger_than_vocab_is_safe() {
     let mut rng = StdRng::seed_from_u64(7);
-    let tok = OwnedQuantizedModel::sample_topk_seeded(&LOGITS, 0.7, 9999, &mut rng);
+    let tok = OwnedQuantizedModel::sample_topk_seeded(&LOGITS, 0.7, 9999, 1.0, &mut rng);
     assert_eq!(tok, ARGMAX, "top_k > vocab_len must clamp harmlessly");
 }
 
@@ -73,7 +74,7 @@ fn topk_larger_than_vocab_is_safe() {
 fn topk_one_is_still_greedy() {
     for seed in 0..16u64 {
         let mut rng = StdRng::seed_from_u64(seed);
-        let tok = OwnedQuantizedModel::sample_topk_seeded(&LOGITS, 1.0, 1, &mut rng);
+        let tok = OwnedQuantizedModel::sample_topk_seeded(&LOGITS, 1.0, 1, 1.0, &mut rng);
         assert_eq!(tok, ARGMAX, "top_k=1 must always return the argmax");
     }
 }

--- a/crates/aprender-serve/src/gguf/inference/generate_quantized_topp_tests.rs
+++ b/crates/aprender-serve/src/gguf/inference/generate_quantized_topp_tests.rs
@@ -1,0 +1,111 @@
+//! FALSIFY-SAMPLE-TOPP-NOOP-001 — `top_p` must actually filter on the dense path.
+//!
+//! `QuantizedGenerateConfig` has carried a `top_p` field since the dense decode path
+//! existed (runtime.rs:30, default 1.0), and `/v1/chat/completions`, `/api/chat`,
+//! `/api/generate` and `apr run` all populate it from the request. But
+//! `sample_topk_with_draw` never took the parameter, so the value was read and then
+//! silently discarded: `--top-p 0.001` produced byte-identical output to
+//! `--top-p 1.0`. The only working nucleus implementation lived in `fails.rs`,
+//! which is not compiled into the crate.
+//!
+//! Why the prior contract missed it: `apr-run-sampling-plumbing-v1` only proved the
+//! value was *plumbed* from CLI/HTTP into the config struct — which was true. Nothing
+//! asserted the sampler's *behaviour* changed as a result. These are behavioural,
+//! oracle-based assertions rather than plumbing checks.
+
+use crate::gguf::OwnedQuantizedModel;
+use rand::rngs::StdRng;
+use rand::SeedableRng;
+
+/// A deliberately flat-ish tail with one clear head. Index 3 holds most of the mass;
+/// indices 0..=2 and 4..=7 are plausible-but-unlikely tail tokens that a correct
+/// nucleus filter must exclude at small `top_p`.
+const LOGITS: [f32; 8] = [1.0, 1.2, 1.4, 6.0, 1.3, 1.1, 0.9, 1.5];
+const HEAD: u32 = 3;
+
+/// RED-on-bug: a tiny `top_p` must collapse the candidate set to the head token.
+/// With `top_p` discarded, the full 8-token distribution is sampled and some seed
+/// inevitably draws a tail token.
+#[test]
+fn topp_small_collapses_to_head() {
+    for seed in 0..128u64 {
+        let mut rng = StdRng::seed_from_u64(seed);
+        let tok = OwnedQuantizedModel::sample_topk_seeded(&LOGITS, 1.0, 0, 0.02, &mut rng);
+        assert_eq!(
+            tok, HEAD,
+            "FALSIFY-SAMPLE-TOPP-NOOP-001: top_p=0.02 must keep only the nucleus \
+             (token {HEAD}); got {tok} at seed {seed}. A tail token here means top_p \
+             was ignored and the full distribution was sampled."
+        );
+    }
+}
+
+/// The other half of the oracle: `top_p` must NOT be equivalent to disabled.
+/// Guards against a "fix" that accepts the parameter and still ignores it —
+/// exactly the failure mode that made this defect survive 9 releases.
+#[test]
+fn topp_small_differs_from_topp_disabled() {
+    let mut differs = false;
+    for seed in 0..128u64 {
+        let mut a_rng = StdRng::seed_from_u64(seed);
+        let mut b_rng = StdRng::seed_from_u64(seed);
+        let filtered = OwnedQuantizedModel::sample_topk_seeded(&LOGITS, 1.0, 0, 0.02, &mut a_rng);
+        let unfiltered = OwnedQuantizedModel::sample_topk_seeded(&LOGITS, 1.0, 0, 1.0, &mut b_rng);
+        if filtered != unfiltered {
+            differs = true;
+            break;
+        }
+    }
+    assert!(
+        differs,
+        "FALSIFY-SAMPLE-TOPP-NOOP-001: top_p=0.02 produced the SAME token as \
+         top_p=1.0 for all 128 seeds — top_p is a no-op."
+    );
+}
+
+/// NO-REGRESSION: `top_p == 1.0` (the default in runtime.rs:51) must be bit-exact
+/// with the pre-fix behaviour. The guard skips the nucleus branch entirely, so the
+/// candidate set and inverse-CDF draw are untouched. Oracle: identical to `top_p`
+/// values at/above 1.0, which cannot filter anything.
+#[test]
+fn topp_one_is_bit_exact_noop() {
+    for seed in 0..128u64 {
+        let mut a_rng = StdRng::seed_from_u64(seed);
+        let mut b_rng = StdRng::seed_from_u64(seed);
+        let one = OwnedQuantizedModel::sample_topk_seeded(&LOGITS, 0.8, 0, 1.0, &mut a_rng);
+        let above = OwnedQuantizedModel::sample_topk_seeded(&LOGITS, 0.8, 0, 2.0, &mut b_rng);
+        assert_eq!(
+            one, above,
+            "top_p=1.0 must be a no-op identical to any value >= 1.0 (seed {seed})"
+        );
+    }
+}
+
+/// `top_p == 0.0` means "disabled" (llama.cpp/Ollama), not "keep nothing" — the same
+/// class of bug as top_k=0. The `top_p > 0.0` half of the guard covers this; without
+/// it a zero cutoff could truncate to an empty set and fall through to token 0.
+#[test]
+fn topp_zero_is_disabled_not_empty() {
+    for seed in 0..64u64 {
+        let mut rng = StdRng::seed_from_u64(seed);
+        let tok = OwnedQuantizedModel::sample_topk_seeded(&LOGITS, 1.0, 0, 0.0, &mut rng);
+        assert!(
+            (tok as usize) < LOGITS.len(),
+            "top_p=0.0 must mean disabled, not an empty candidate set (seed {seed})"
+        );
+    }
+}
+
+/// top_k and top_p compose: top_k runs first, then nucleus over the survivors.
+/// Mirrors the live MoE ordering (infer/qwen3_moe_generate.rs:101 then :109).
+#[test]
+fn topk_then_topp_compose() {
+    for seed in 0..64u64 {
+        let mut rng = StdRng::seed_from_u64(seed);
+        let tok = OwnedQuantizedModel::sample_topk_seeded(&LOGITS, 1.0, 4, 0.02, &mut rng);
+        assert_eq!(
+            tok, HEAD,
+            "top_k=4 then top_p=0.02 must still collapse to the head (seed {seed})"
+        );
+    }
+}

--- a/crates/aprender-serve/src/gguf/inference/generation_tests.rs
+++ b/crates/aprender-serve/src/gguf/inference/generation_tests.rs
@@ -478,8 +478,8 @@ fn test_sample_topk_seeded_same_seed_is_deterministic() {
 
     let mut rng_a = StdRng::seed_from_u64(12345);
     let mut rng_b = StdRng::seed_from_u64(12345);
-    let a = OwnedQuantizedModel::sample_topk_seeded(&logits, 1.5, 50, &mut rng_a);
-    let b = OwnedQuantizedModel::sample_topk_seeded(&logits, 1.5, 50, &mut rng_b);
+    let a = OwnedQuantizedModel::sample_topk_seeded(&logits, 1.5, 50, 1.0, &mut rng_a);
+    let b = OwnedQuantizedModel::sample_topk_seeded(&logits, 1.5, 50, 1.0, &mut rng_b);
     assert_eq!(
         a, b,
         "same seed must produce the same token (OpenAI seed contract)"
@@ -487,10 +487,10 @@ fn test_sample_topk_seeded_same_seed_is_deterministic() {
 
     // And the whole stream is reproducible, not just the first draw.
     let seq_a: Vec<u32> = (0..16)
-        .map(|_| OwnedQuantizedModel::sample_topk_seeded(&logits, 1.5, 50, &mut rng_a))
+        .map(|_| OwnedQuantizedModel::sample_topk_seeded(&logits, 1.5, 50, 1.0, &mut rng_a))
         .collect();
     let seq_b: Vec<u32> = (0..16)
-        .map(|_| OwnedQuantizedModel::sample_topk_seeded(&logits, 1.5, 50, &mut rng_b))
+        .map(|_| OwnedQuantizedModel::sample_topk_seeded(&logits, 1.5, 50, 1.0, &mut rng_b))
         .collect();
     assert_eq!(seq_a, seq_b, "the full seeded stream must be reproducible");
 }
@@ -508,7 +508,7 @@ fn test_sample_topk_seeded_different_seeds_can_diverge() {
     let stream = |seed: u64| -> Vec<u32> {
         let mut rng = StdRng::seed_from_u64(seed);
         (0..16)
-            .map(|_| OwnedQuantizedModel::sample_topk_seeded(&logits, 1.5, 50, &mut rng))
+            .map(|_| OwnedQuantizedModel::sample_topk_seeded(&logits, 1.5, 50, 1.0, &mut rng))
             .collect()
     };
     assert_ne!(

--- a/crates/aprender-serve/src/gguf/inference/mod.rs
+++ b/crates/aprender-serve/src/gguf/inference/mod.rs
@@ -25,6 +25,8 @@ mod attention_gqa_tests;
 #[cfg(test)]
 mod generate_quantized_topk_tests;
 #[cfg(test)]
+mod generate_quantized_topp_tests;
+#[cfg(test)]
 mod generation_tests;
 #[cfg(test)]
 mod matmul_tests;


### PR DESCRIPTION
P1 from the v0.61.0 show-stopper hunt. Nine releases old.

## The defect

`QuantizedGenerateConfig` has carried `top_p` since the dense decode path existed (`runtime.rs:30`, default 1.0), and `/v1/chat/completions`, `/api/chat`, `/api/generate` and `apr run` all populate it from the request. But `sample_topk_with_draw` **never took the parameter** — the value was read, stored in the config, and discarded.

`--top-p 0.001` was byte-identical to `--top-p 1.0`. The only working nucleus implementation lived in `fails.rs`, which is not compiled into the crate.

## The fix

Thread `top_p` through `sample_topk_with_draw` / `sample_topk_seeded` and port the guarded nucleus stage from the live MoE sampler (`infer/qwen3_moe_generate.rs:109`), preserving its ordering — top-k first, then nucleus over the survivors. All three dense call sites now pass `config.top_p`.

`sample_topk`’s public signature is unchanged; it delegates with `top_p = 1.0`, which skips the nucleus branch entirely and is a bit-exact no-op.

## Mutation verification (RED on bug / GREEN on fix)

Deleting the nucleus stage:

```
topp_small_collapses_to_head          ... FAILED  (got token 7, expected 3)
topp_small_differs_from_topp_disabled ... FAILED
    "top_p=0.02 produced the SAME token as top_p=1.0 for all 128 seeds"
topk_then_topp_compose                ... FAILED
topp_one_is_bit_exact_noop            ... ok
topp_zero_is_disabled_not_empty       ... ok
```

The three **behavioural** assertions go red; the two **no-regression** assertions stay green. That split is the point — the falsifier proves `top_p` filters, and cannot be satisfied by a change that merely accepts the argument.

## Why the previous contract missed it

`apr-run-sampling-plumbing-v1` proved `top_p` was **plumbed** from CLI/HTTP into the config struct. That was true, and stayed true for nine releases. Nothing asserted the sampler’s **behaviour** changed as a result — a contract that proves only what its falsifier exercises.

These assertions are behavioural and oracle-based:

- `top_p=0.02` must collapse to the nucleus head
- `top_p=0.02` must **differ** from `top_p=1.0` — kills "accepts but ignores"
- `top_p=1.0` must equal any value ≥ 1.0 — bit-exact default, no-regression
- `top_p=0.0` means disabled, not "keep nothing" — same class as the `top_k=0` bug in #2314
- top_k then top_p compose in the MoE order

## No regression

`generation_tests` unchanged at **43 passed**. The 5 seed-determinism call sites updated with `top_p = 1.0`, preserving their exact semantics.

Refs FALSIFY-SAMPLE-TOPP-NOOP-001