### PR TITLE
fix(cli): --backend cuda must refuse, not silently serve wgpu/CPU (fixes #2320)

### DIFF
--- a/crates/apr-cli/src/dispatch.rs
+++ b/crates/apr-cli/src/dispatch.rs
@@ -89,6 +89,45 @@ fn dispatch_runtime_commands(cli: &Cli) -> Option<Result<(), CliError>> {
                     eprintln!("Backend override: {b}");
                 }
             }
+            // FALSIFY-BACKEND-CUDA-HONESTY-001: refuse `--backend cuda` on a build
+            // that has no CUDA compiled in, instead of silently serving wgpu/CPU.
+            //
+            // The CUDA generate path is behind `#[cfg(feature = "cuda")]`
+            // (aprender-serve/src/infer/gguf_gpu_generate.rs:356). On a build without
+            // that feature the whole block VANISHES, control falls through to the
+            // GH-559 wgpu fallback, and the run prints:
+            //     Backend override: cuda
+            //     Backend: wgpu (Vulkan)
+            // wgpu then fails its own cpu-parity gate (cosine 0.884 < 0.99) and
+            // degrades again — ~20 tok/s where CUDA gives ~400. Measured 2026-07-27
+            // on an RTX 4090 with nvcc 12.8 present, so this is NOT a
+            // missing-hardware case; it is a build that cannot honour the flag
+            // reporting success anyway.
+            //
+            // This silently invalidates any measurement taken through it. The
+            // Pillar-4 decode beat run against such a binary reports
+            // `ratio_median=0.070x` and a BEAT-REGRESSION panic — a fabricated 14x
+            // regression with nothing wrong in apr's decode path.
+            //
+            // A 20x silent downgrade is never what the caller asked for. Fail.
+            //
+            // NOTE: this checks build capability only. When CUDA *is* compiled in
+            // but fails at runtime (e.g. the Blackwell sm_121 JIT), the GH-559
+            // wgpu fallback is deliberate and stays.
+            if backend.as_deref() == Some("cuda") && !cfg!(feature = "cuda") {
+                return Some(Err(CliError::ValidationFailed(
+                    "--backend cuda requested, but this `apr` was built WITHOUT the \
+`cuda` feature, so the CUDA backend does not exist in this binary. \
+Refusing to silently fall back to wgpu/CPU: that path is ~20x slower \
+(~20 tok/s vs ~400) and makes any throughput measurement taken through it \
+meaningless. Rebuild the ROOT facade with CUDA: `cargo build --release \
+--features cuda` (build the root, not `-p apr-cli`: BOTH packages define a \
+binary named `apr`, and only the root's cuda = [\"cli\", \"apr-cli/cuda\"] \
+chain enables this path). To run on this build anyway, pass `--backend cpu` \
+or drop `--backend`."
+                        .to_string(),
+                )));
+            }
             // GH-326: --gpu overrides --no-gpu when both specified
             let effective_no_gpu = if *gpu {
                 false

--- a/crates/apr-cli/tests/cli_commands.rs
+++ b/crates/apr-cli/tests/cli_commands.rs
@@ -391,3 +391,68 @@ fn tokenize_import_hf_subcommand_registered() {
         );
     }
 }
+
+/// FALSIFY-BACKEND-CUDA-HONESTY-001: `--backend cuda` must not silently serve wgpu/CPU.
+///
+/// The CUDA generate path lives behind `#[cfg(feature = "cuda")]`
+/// (aprender-serve/src/infer/gguf_gpu_generate.rs). On a build without that feature the
+/// block vanishes, control falls through to the GH-559 wgpu fallback, and the run prints
+/// `Backend override: cuda` followed by `Backend: wgpu (Vulkan)` — accepting the flag and
+/// then ignoring it. wgpu fails its own cpu-parity gate and degrades again, so the user
+/// gets ~20 tok/s where CUDA gives ~400.
+///
+/// Measured 2026-07-27 on an RTX 4090 with nvcc 12.8 installed, so this is not a
+/// missing-hardware case: it is a binary that cannot honour the flag reporting success.
+/// Any throughput measured through it is meaningless — the Pillar-4 decode beat run
+/// against such a build reports `ratio_median=0.070x` and a BEAT-REGRESSION panic, a
+/// fabricated 14x regression with nothing actually wrong in apr's decode path.
+///
+/// This test runs on the default (non-cuda) test build, so it exercises exactly that
+/// case. RED-on-bug: without the guard in dispatch.rs the process proceeds and does not
+/// report the refusal.
+#[test]
+fn backend_cuda_on_non_cuda_build_refuses_instead_of_falling_back() {
+    if cfg!(feature = "cuda") {
+        // A CUDA-capable build is allowed to proceed; the guard is build-capability only.
+        return;
+    }
+
+    let output = apr_binary()
+        .args([
+            "run",
+            "/nonexistent-model-path-for-backend-guard.gguf",
+            "--prompt",
+            "hi",
+            "--max-tokens",
+            "1",
+            "--backend",
+            "cuda",
+        ])
+        .output()
+        .expect("failed to run apr");
+
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert!(
+        !output.status.success(),
+        "FALSIFY-BACKEND-CUDA-HONESTY-001: `--backend cuda` exited 0 on a build with no \
+         CUDA compiled in. It must refuse rather than silently serve wgpu/CPU (~20x slower).\n\
+         Output:\n{combined}"
+    );
+    assert!(
+        combined.contains("built WITHOUT the `cuda` feature"),
+        "FALSIFY-BACKEND-CUDA-HONESTY-001: expected an explicit refusal naming the missing \
+         `cuda` feature, so the user is not left to infer it from a throughput number.\n\
+         Output:\n{combined}"
+    );
+    assert!(
+        !combined.contains("Backend: wgpu"),
+        "FALSIFY-BACKEND-CUDA-HONESTY-001: `--backend cuda` fell through to the wgpu \
+         backend — this is the exact silent-downgrade this gate exists to prevent.\n\
+         Output:\n{combined}"
+    );
+}


### PR DESCRIPTION
Fixes #2320 — filed and fixed in the same session. Stop the line, fix the defect.

## The defect

`--backend cuda` was parsed, echoed, and discarded. `dispatch.rs` only ever inspected the value for `"cpu"`. On a build without the `cuda` feature the CUDA generate path (behind `#[cfg(feature = "cuda")]`) does not exist, so control fell through to the GH-559 wgpu fallback:

```
$ apr run model.gguf --backend cuda
Backend override: cuda
Backend: wgpu (Vulkan)
```

wgpu then fails its own cpu-parity gate (`cosine 0.884 < 0.99`) and degrades again to CPU. Net: **~20 tok/s where CUDA gives ~400** — a 20× silent downgrade from a flag that reported success.

Measured on an RTX 4090 with **nvcc 12.8 present**, so this is not a missing-hardware case. It is a binary that cannot honour the flag saying nothing.

## Why fail rather than warn

It silently invalidates every measurement taken through it. The Pillar-4 decode beat run against such a binary reports:

```
apr_median7=20.9  ollama_median=297.8  ratio_median=0.070x
BEAT-REGRESSION beat-ollama-decode-throughput: ... no longer beats ... by 1.10x
```

A **fabricated 14× regression** with nothing wrong in apr’s decode path. Wiring that beat into cuda-nightly without this guard would publish that number nightly until someone believed it and went hunting.

Same defect family as `top_k`/`top_p` in #2314/#2317: a parameter accepted, then dropped.

## Scope

**Build capability only.** When CUDA *is* compiled in but fails at runtime (e.g. the Blackwell sm_121 JIT), the GH-559 wgpu fallback is deliberate and is left untouched.

The error message names the fix — including the trap that **both** the root facade and `apr-cli` define a binary called `apr`, and only the root’s `cuda = ["cli", "apr-cli/cuda"]` chain enables the path, so `cargo build -p apr-cli` silently produces the wrong binary.

## Mutation verification (RED on bug / GREEN on fix)

With the guard disabled:
```
backend_cuda_on_non_cuda_build_refuses_instead_of_falling_back ... FAILED
  "expected an explicit refusal naming the missing `cuda` feature"
```
Restored: **9 passed**.

The falsifier lives in `apr-cli/tests/cli_commands.rs`, already chained into the **ci.yml:317** gate — enforced per-PR, not merely present. It asserts three things: non-zero exit, an explicit message naming the missing feature, and the **absence** of `Backend: wgpu`. A "fix" that merely prints a warning and continues cannot satisfy it.

## Unblocks

`BEAT-OLLAMA-DECODE-CI-001`. The cuda-nightly wiring is written and held on `agent/cuda-nightly-ollama-beat`; it ships once a CUDA-capable `apr` can be produced, which this makes verifiable instead of silent.

Refs FALSIFY-BACKEND-CUDA-HONESTY-001