### PR TITLE
fix(docs): "82 workspace crates" is false — it is 78, and the gate proved the wrong proposition

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ publishing — all backed by YAML provable contracts that fail CI on drift.
 
 | Metric | Count | Source of truth |
 |-------:|------:|---|
-| Workspace crates | **82** workspace crates | `ls crates/` |
+| Workspace crates | **78** workspace crates | `cargo metadata --no-deps` (NOT `ls crates/` — 4 are `exclude`d, 1 has no Cargo.toml) |
 | Provable contracts | **1766** provable contracts | `find contracts/ -name '*.yaml'` |
 | CLI commands | **103** CLI commands | `apr --help` |
 | Book CLI chapters | **103** chapters | `ls book/src/cli/*.md` (parity with CLI) |

--- a/crates/aprender-core/tests/readme_contract.rs
+++ b/crates/aprender-core/tests/readme_contract.rs
@@ -67,29 +67,65 @@ fn test_readme_no_stale_install_refs() {
     }
 }
 
-/// FALSIFY-README-005: Crate count in README matches `ls crates/`.
+/// FALSIFY-README-005: the README's workspace-crate count matches CARGO.
 ///
-/// Superseded by `contracts/readme-claims-v1.yaml` + `scripts/check_readme_claims.sh`
-/// (FALSIFY-README-001). Kept as a belt-and-braces integration assertion:
-/// if the new shell-script gate and the Rust test ever disagree, both
-/// signal drift. Counts directory entries under `crates/` to match the
-/// canonical script contract — not `cargo metadata`, which returns more
-/// packages than directories (some crates define multiple [package]s).
+/// PREVIOUSLY THIS GATE PROVED THE WRONG PROPOSITION. It counted directory
+/// entries under `crates/` (82) and asserted the README contained `**82**`.
+/// The README duly said "82 workspace crates" and the gate went green — while
+/// `cargo metadata --no-deps` reports **78** packages. Four `crates/` entries
+/// are `exclude`d in the root Cargo.toml (old workspace-root shells
+/// aprender-viz-ttop / aprender-present / aprender-test, plus the dev-only
+/// aprender-train-canary), and a fifth (aprender-contracts-staging) has no
+/// Cargo.toml at all. A directory is not a workspace crate.
+///
+/// The old comment justified the choice as "not `cargo metadata`, which returns
+/// MORE packages than directories" — the opposite of the truth.
+///
+/// Hand-rolled counting cannot be made to agree with cargo. Four methods, four
+/// answers, measured 2026-07-27:
+///     ls crates/                    -> 82   (directories, incl. a non-crate)
+///     members + root                -> 84
+///     members - exclude + root      -> 81
+///     cargo metadata --no-deps      -> 78   <- the only authoritative one
+/// So this asks cargo, via the $CARGO the harness already sets for us.
+///
+/// It also now asserts the SPECIFIC claims-table row rather than a bare
+/// `**78**` occurring anywhere in the file: the old form would have been
+/// satisfied by any unrelated bold number.
 #[test]
 fn test_readme_crate_count_matches_workspace() {
     let readme = read_readme();
-    let crates_dir = workspace_root().join("crates");
 
-    let crate_count = std::fs::read_dir(&crates_dir)
-        .expect("read crates/")
-        .filter_map(Result::ok)
-        .filter(|e| e.path().is_dir())
-        .count();
-
-    let count_str = format!("**{crate_count}**");
+    let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
+    let out = std::process::Command::new(cargo)
+        .args(["metadata", "--no-deps", "--format-version", "1"])
+        .current_dir(workspace_root())
+        .output()
+        .expect("run cargo metadata");
     assert!(
-        readme.contains(&count_str),
-        "FALSIFY-README-005: README lacks `**{crate_count}**` matching `ls crates/`"
+        out.status.success(),
+        "FALSIFY-README-005: `cargo metadata` failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let json = String::from_utf8_lossy(&out.stdout);
+
+    // Count `"name":` keys inside the top-level "packages" array. --no-deps
+    // means packages == workspace members exactly.
+    let packages_start = json.find("\"packages\":").expect("metadata has packages");
+    let crate_count = json[packages_start..].matches("\"manifest_path\":").count();
+    assert!(
+        crate_count > 1,
+        "FALSIFY-README-005: parsed {crate_count} packages from cargo metadata — parser is wrong"
+    );
+
+    let expected_row = format!("| Workspace crates | **{crate_count}** workspace crates |");
+    assert!(
+        readme.contains(&expected_row),
+        "FALSIFY-README-005: README claims-table row does not match cargo.\n\
+         expected: {expected_row}\n\
+         `cargo metadata --no-deps` reports {crate_count} workspace packages. Note that\n\
+         `ls crates/` is NOT the same number — some crates/ entries are `exclude`d in the\n\
+         root Cargo.toml and one has no Cargo.toml at all. A directory is not a crate."
     );
 }
 


### PR DESCRIPTION
Toyota-way fix of a defect surfaced by the remaining-work audit.

## The defect

`README.md:43` claimed **"82 workspace crates"** with source of truth `ls crates/`, and `FALSIFY-README-005` counted `read_dir("crates/")` == 82 and passed.

Both were wrong in the same direction, so the gate **could never catch it**: it asserted a true statement about *directories* while the README made a false statement about *workspace crates*.

`cargo metadata --no-deps` reports **78**. The five `crates/` entries that are not members:

| Entry | Why not a member |
|---|---|
| `aprender-viz-ttop`, `aprender-present`, `aprender-test` | old workspace-root shells, `exclude`d in root Cargo.toml |
| `aprender-train-canary` | dev-only; its Cargo.toml pins an absolute `[patch.crates-io]` path, so including it breaks every clean checkout |
| `aprender-contracts-staging` | **no Cargo.toml at all** — a docs directory |

A directory is not a workspace crate.

## The old comment argued for the bug

> *"not `cargo metadata`, which returns MORE packages than directories"*

The exact opposite of the truth (78 < 82).

## Hand-rolled counting cannot agree with cargo

Four methods, four answers, measured today:

```
ls crates/                 -> 82   (directories, one of which is not a crate)
members + root             -> 84
members - exclude + root   -> 81
cargo metadata --no-deps   -> 78   <- authoritative
```

The gate now asks cargo, via the `$CARGO` the test harness already provides.

## Second defect in the same test

The assertion was `readme.contains("**82**")` — a bare bold number **anywhere** in the file satisfied it. It now asserts the specific claims-table row, so an unrelated bold `78` cannot keep it green.

## Mutation verification

```
README row back to **82**  -> FAILED  "claims-table row does not match cargo"
restored to **78**         -> 11 passed
```

Refs FALSIFY-README-005