### PR TITLE
fix(ci): the entire nightly speed lane was dark - one broken leg hid all 10 beats

### DIFF
--- a/.github/workflows/beat-speed-nightly.yml
+++ b/.github/workflows/beat-speed-nightly.yml
@@ -8,6 +8,26 @@
 #
 # Additive: a brand-new workflow that does NOT touch per-PR `ci.yml` / the merge
 # gate. A red run here flags a real speed regression; it never blocks PRs.
+#
+# OBSERVABILITY INVARIANT (added after the 2026-07-27/28 blackout). Steps here
+# are siblings, not a pipeline: each beat times a DIFFERENT estimator against a
+# DIFFERENT incumbent, so a failure in one says nothing about the next. With
+# default fail-fast semantics, though, the first red step aborted the job and
+# the remaining nine never ran — and a step that never ran reports no
+# measurement, which reads exactly like a step that ran and passed. That is how
+# a broken scikit-learn baseline in the LinReg leg (a poisoned `uv` env cache —
+# see scripts/check_beat_baseline_env.sh) silently took the ENTIRE Pillar-1
+# speed lane off the air while the GaussianNB beat was actively breaching its
+# ceiling (2026-07-03 ratio 0.563 and 07-04 ratio 0.520, both over the 0.50
+# gate) with nobody watching.
+#
+# So this workflow now enforces two rules:
+#   1. Every beat runs, even if an earlier beat failed (`!cancelled()`), so one
+#      broken leg can never hide the other nine.
+#   2. A MISSING measurement is a FAILURE, not a pass. The final step asserts
+#      that every expected `BEAT-*` marker line actually appeared in the log.
+#      Silence is treated as red, because silence is what the blackout looked
+#      like.
 name: BEAT Speed (nightly)
 
 on:
@@ -23,6 +43,9 @@ jobs:
   beat-speed:
     runs-on: [self-hosted, X64, Linux, clean-room]
     timeout-minutes: 45
+    env:
+      # Every beat step tees here; the final step audits it for completeness.
+      BEAT_LOG: ${{ runner.temp }}/beat-speed-measurements.log
     steps:
       - uses: actions/checkout@v7
 
@@ -36,15 +59,26 @@ jobs:
             echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           fi
 
+      # A speed beat is a RATIO against the incumbent. If the incumbent will not
+      # import, the beat measures nothing — so prove it imports before timing
+      # anything, and self-heal the known poisoned-uv-cache fault in place.
+      - name: Preflight — scikit-learn/numpy baseline must be importable
+        id: preflight
+        run: bash scripts/check_beat_baseline_env.sh
+
       - name: Pillar-1 — apr vs scikit-learn LinearRegression speed beat
+        if: ${{ !cancelled() && steps.preflight.outcome == 'success' }}
         run: |
+          set -o pipefail
           cargo test -p aprender-core --release \
-            --test beat_sklearn_linreg_speed -- --ignored --nocapture
+            --test beat_sklearn_linreg_speed -- --ignored --nocapture 2>&1 | tee -a "$BEAT_LOG"
 
       - name: Pillar-1 — apr vs scikit-learn GaussianNB speed beat
+        if: ${{ !cancelled() && steps.preflight.outcome == 'success' }}
         run: |
+          set -o pipefail
           cargo test -p aprender-core --release \
-            --test beat_sklearn_gaussiannb_speed -- --ignored --nocapture
+            --test beat_sklearn_gaussiannb_speed -- --ignored --nocapture 2>&1 | tee -a "$BEAT_LOG"
 
       # NOTE: StandardScaler / MinMaxScaler speed beats REMOVED (PMAT-733). Elementwise scalers have
       # no algorithmic edge over numpy — they "won" only on a fast dev box; on the canonical Intel CI
@@ -53,41 +87,63 @@ jobs:
       # across hosts. See memory: verify beats on the CI host, not just the dev box.
 
       - name: Pillar-1 — apr vs scikit-learn ComplementNB speed beat
+        if: ${{ !cancelled() && steps.preflight.outcome == 'success' }}
         run: |
+          set -o pipefail
           cargo test -p aprender-core --release \
-            --test beat_sklearn_complementnb_speed -- --ignored --nocapture
+            --test beat_sklearn_complementnb_speed -- --ignored --nocapture 2>&1 | tee -a "$BEAT_LOG"
 
       - name: Pillar-1 — apr vs scikit-learn BernoulliNB speed beat
+        if: ${{ !cancelled() && steps.preflight.outcome == 'success' }}
         run: |
+          set -o pipefail
           cargo test -p aprender-core --release \
-            --test beat_sklearn_bernoullinb_speed -- --ignored --nocapture
+            --test beat_sklearn_bernoullinb_speed -- --ignored --nocapture 2>&1 | tee -a "$BEAT_LOG"
 
       - name: Pillar-1 — apr vs scikit-learn MultinomialNB speed beat
+        if: ${{ !cancelled() && steps.preflight.outcome == 'success' }}
         run: |
+          set -o pipefail
           cargo test -p aprender-core --release \
-            --test beat_sklearn_multinomialnb_speed -- --ignored --nocapture
+            --test beat_sklearn_multinomialnb_speed -- --ignored --nocapture 2>&1 | tee -a "$BEAT_LOG"
 
       - name: Pillar-1 — apr vs scikit-learn GaussianMixture (GMM) speed beat
+        if: ${{ !cancelled() && steps.preflight.outcome == 'success' }}
         run: |
+          set -o pipefail
           cargo test -p aprender-core --release \
-            --test beat_sklearn_gmm_speed -- --ignored --nocapture
+            --test beat_sklearn_gmm_speed -- --ignored --nocapture 2>&1 | tee -a "$BEAT_LOG"
 
       - name: Pillar-2 — apr vs PyTorch one-shot cold-start training speed beat
+        if: ${{ !cancelled() && steps.preflight.outcome == 'success' }}
         run: |
+          set -o pipefail
           cargo test -p aprender-core --release \
-            --test beat_pytorch_coldstart_speed -- --ignored --nocapture
+            --test beat_pytorch_coldstart_speed -- --ignored --nocapture 2>&1 | tee -a "$BEAT_LOG"
 
       - name: Pillar-3 — apr vs Unsloth one-shot cold-start LoRA-adapter speed beat
+        if: ${{ !cancelled() && steps.preflight.outcome == 'success' }}
         run: |
+          set -o pipefail
           cargo test -p aprender-train --release \
-            --test beat_unsloth_coldstart_speed -- --ignored --nocapture
+            --test beat_unsloth_coldstart_speed -- --ignored --nocapture 2>&1 | tee -a "$BEAT_LOG"
 
       - name: Pillar-1 — apr vs scikit-learn one-shot cold-start speed beat
+        if: ${{ !cancelled() && steps.preflight.outcome == 'success' }}
         run: |
+          set -o pipefail
           cargo test -p aprender-core --release \
-            --test beat_sklearn_coldstart_speed -- --ignored --nocapture
+            --test beat_sklearn_coldstart_speed -- --ignored --nocapture 2>&1 | tee -a "$BEAT_LOG"
 
       - name: Pillar-4 — apr vs HuggingFace transformers one-shot inference cold-start speed beat
+        if: ${{ !cancelled() && steps.preflight.outcome == 'success' }}
         run: |
+          set -o pipefail
           cargo test -p aprender-core --release \
-            --test beat_hf_inference_coldstart_speed -- --ignored --nocapture
+            --test beat_hf_inference_coldstart_speed -- --ignored --nocapture 2>&1 | tee -a "$BEAT_LOG"
+
+      # Fail-closed observability: a beat that produced no measurement line did
+      # not "pass quietly", it went dark. Assert all ten reported.
+      - name: Every beat must have reported a measurement
+        if: ${{ !cancelled() }}
+        run: bash scripts/check_beat_measurements.sh "$BEAT_LOG"

--- a/scripts/check_beat_baseline_env.sh
+++ b/scripts/check_beat_baseline_env.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Preflight: the incumbent baseline (scikit-learn + numpy under `uv`) must
+# actually import before we time anything against it.
+#
+# WHY THIS EXISTS. Every Pillar-1/2/3 speed beat is a RELATIVE ratio: we time
+# apr and we time the incumbent on the same host in the same run. If the
+# incumbent cannot even be imported, the beat does not measure a regression -
+# it measures nothing, and it does so while printing a red X that looks exactly
+# like a lost beat. On 2026-07-27/28 the whole nightly lane died this way:
+#
+#   sklearn timing failed: ModuleNotFoundError: No module named 'numpy'
+#
+# ROOT CAUSE (diagnosed on intel-clean-room-10 / mac-server, uv 0.11.23). uv
+# caches the resolved `--with` environment as a venv under
+# `~/.cache/uv/archive-v0/<hash>/`. One of those archives had lost its
+# `pyvenv.cfg` (its `bin/` was Jul 26, its `lib/` Jul 2 - a torn write or a
+# disk-pressure sweep; this host has a history of both). uv still counted the
+# requirements as satisfied - so it printed no "Installed N packages" and did
+# no install - but with no `pyvenv.cfg` it could not use the archive as the
+# base for the ephemeral env, and silently fell back to `/usr/bin/python3`.
+# The archive's site-packages therefore never joined `sys.path`:
+#
+#   healthy:  .../builds-v0/<tmp>/lib/python3.10/site-packages
+#             .../archive-v0/<hash>/lib/python3.10/site-packages   <-- the --with env
+#             /usr/lib/python3/dist-packages
+#   poisoned: .../builds-v0/<tmp>/lib/python3.10/site-packages
+#             /usr/lib/python3/dist-packages                       <-- overlay GONE
+#
+# So python ran, found no numpy, and exited in under a second. Neither
+# `uv cache clean <pkg>` nor `uv run --refresh` repairs it: both operate on
+# wheel/package caches, and the corruption is in the cached *environment*.
+# `rm -rf`-ing that one archive fixed it immediately (verified: "Installed 5
+# packages in 33ms" -> numpy 2.2.6 / sklearn 1.7.2).
+#
+# WHAT THIS DOES. Behaviour first, layout second - we do not want a gate that
+# encodes a guess about uv's cache internals:
+#   1. Try the import. Pass -> done, no mutation.
+#   2. Fail -> remove only archives with the exact poison signature (venv-shaped
+#      - has bin/python3 - but missing pyvenv.cfg). Healthy archives always
+#      carry pyvenv.cfg + CACHEDIR.TAG, so this is precise, not a blanket wipe.
+#   3. Retry. Still failing -> full `uv cache clean` (last resort, self-healing
+#      at the cost of one re-download).
+#   4. Retry. Still failing -> exit 1 with the diagnosis, because at that point
+#      it is not a poisoned cache and a human needs the sys.path dump.
+#
+# Same shape as the EACCES self-heal added to guard-runner-labels in #2311:
+# detect a known-recurring runner-state fault, repair it, prove the repair.
+set -euo pipefail
+
+PROBE='import numpy, sklearn; print("BASELINE_OK numpy=%s sklearn=%s" % (numpy.__version__, sklearn.__version__))'
+
+if ! command -v uv >/dev/null 2>&1; then
+    echo "✗ check_beat_baseline_env: uv not on PATH - the speed beats cannot time the incumbent" >&2
+    exit 1
+fi
+
+echo "check_beat_baseline_env: $(uv --version)"
+
+try_probe() {
+    uv run --with scikit-learn --with numpy python3 -c "$PROBE" 2>&1
+}
+
+# Step 1 - ALWAYS sweep poisoned env archives, before probing.
+#
+# This is deliberately proactive rather than reactive. Measured on mac-server
+# 2026-07-28: 16 of 19 cached environments were missing pyvenv.cfg. The beats
+# use several different incumbents (scikit-learn, torch, transformers, unsloth),
+# each with its OWN cached environment, so a probe that only exercises the
+# scikit-learn env would pass while the torch env stayed broken - and we would
+# rediscover this one incumbent at a time. A poisoned archive is definitively
+# unusable (uv cannot use it as a venv base), so removing it is never a loss:
+# the worst case is one re-download.
+CACHE_DIR="${UV_CACHE_DIR:-$HOME/.cache/uv}"
+ARCHIVES="$CACHE_DIR/archive-v0"
+removed=0
+if [ -d "$ARCHIVES" ]; then
+    # find, not `ls` - archive names are content hashes, so iterate directories
+    # directly. A cached *environment* is venv-shaped (bin/python3 exists); a
+    # cached *package* is just an unpacked wheel and is skipped by that test.
+    while IFS= read -r archive; do
+        [ -n "$archive" ] || continue
+        # A cached *environment* is venv-shaped and healthy ones always carry
+        # pyvenv.cfg (plus CACHEDIR.TAG); a cached *package* is just an unpacked
+        # wheel with no bin/python3 and is skipped. So "has bin/python3 but no
+        # pyvenv.cfg" is the precise poison signature, verified against both a
+        # healthy and the poisoned archive on mac-server.
+        if [ -e "$archive/bin/python3" ] && [ ! -f "$archive/pyvenv.cfg" ]; then
+            # Belt and braces before an rm -rf: the path must be non-empty, must
+            # not be the filesystem root, and must still live strictly UNDER the
+            # cache root. An empty or unanchored $archive here is catastrophic,
+            # so validate immediately before the destructive call, not earlier.
+            unsafe=0
+            [ -z "$archive" ] && unsafe=1
+            [ "$archive" = "/" ] && unsafe=1
+            case "$archive" in
+                "$ARCHIVES"/?*) : ;;
+                *) unsafe=1 ;;
+            esac
+            if [ "$unsafe" -ne 0 ] || [ -z "$archive" ]; then
+                echo "  refusing to remove unsafe/unanchored path: '$archive'" >&2
+            elif [ -n "$archive" ] && [ "$archive" != "/" ]; then
+                echo "  removing poisoned env archive (venv-shaped, no pyvenv.cfg): $archive" >&2
+                rm -rf "${archive:?refusing to rm an empty path}"
+                removed=$((removed + 1))
+            fi
+        fi
+    done < <(find "$ARCHIVES" -mindepth 1 -maxdepth 1 -type d 2>/dev/null)
+fi
+echo "swept $removed poisoned env archive(s) from $ARCHIVES"
+
+# Step 2 - prove the incumbent actually imports.
+if out=$(try_probe) && [[ "$out" == *BASELINE_OK* ]]; then
+    echo "  $out"
+    echo "✓ check_beat_baseline_env: baseline importable (swept $removed poisoned archive(s))"
+    exit 0
+fi
+
+echo "⚠ baseline import FAILED even after sweeping $removed poisoned archive(s)" >&2
+echo "  probe output: ${out}" >&2
+
+# Step 3 - last resort: nuke the whole uv cache. Costs one re-download.
+echo "⚠ falling back to full 'uv cache clean'" >&2
+uv cache clean >&2 || true
+
+if out=$(try_probe) && [[ "$out" == *BASELINE_OK* ]]; then
+    echo "✓ check_beat_baseline_env: baseline restored by full cache clean"
+    exit 0
+fi
+
+# Not a cache fault. Give the operator everything needed to diagnose.
+echo "::error::check_beat_baseline_env: scikit-learn/numpy baseline is NOT importable after cache repair" >&2
+echo "  Every speed beat is a ratio against this baseline; without it the lane measures nothing." >&2
+echo "  final probe output: ${out}" >&2
+echo "  --- diagnostics ---" >&2
+uv run --with scikit-learn --with numpy python3 \
+    -c 'import sys; print("executable:", sys.executable); [print("  path:", p) for p in sys.path]' >&2 2>&1 || true
+exit 1

--- a/scripts/check_beat_measurements.sh
+++ b/scripts/check_beat_measurements.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Fail-closed observability for the nightly speed lane.
+#
+# A speed beat reports by printing a single measurement line, e.g.
+#   BEAT-SKLEARN-GAUSSIANNB-SPEED: apr=54.794ms sklearn=116.132ms ratio=0.472 ...
+#
+# A beat that printed NO such line did not quietly pass - it never ran, or it
+# died before it could measure. Both look identical to "green" if you only
+# check step exit codes, and that is precisely how the 2026-07-27/28 blackout
+# hid a genuinely breaching GaussianNB beat behind a broken LinReg baseline.
+#
+# So: silence is red. This asserts every expected marker actually appeared.
+#
+# The expected list is derived from the tests themselves rather than hardcoded
+# twice, so adding a beat to the workflow without wiring its marker (or renaming
+# a marker) cannot drift out of sync unnoticed.
+set -euo pipefail
+
+BEAT_LOG="${1:?usage: check_beat_measurements.sh <beat-log-path>}"
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$REPO_ROOT" || exit 2
+
+# Every speed beat the nightly workflow invokes, as `--test <name>` references.
+# Same extraction idiom as scripts/check_beats_gated.sh.
+INVOKED=$(grep -ohE '\-\-test[[:space:]]+beat_[A-Za-z0-9_]+' \
+              .github/workflows/beat-speed-nightly.yml 2>/dev/null \
+          | sed -E 's/--test[[:space:]]+//' | sort -u)
+
+n_invoked=$(printf '%s\n' "$INVOKED" | grep -c '[^[:space:]]' || true)
+
+if [ "$n_invoked" -eq 0 ]; then
+    echo "✗ check_beat_measurements: found no '--test beat_*' references in the workflow" >&2
+    echo "  Either the workflow was restructured or this check has drifted - both need a human." >&2
+    exit 2
+fi
+
+if [ ! -f "$BEAT_LOG" ]; then
+    echo "::error::check_beat_measurements: no measurement log at '$BEAT_LOG'" >&2
+    echo "  $n_invoked speed beats were configured and NOT ONE produced output." >&2
+    echo "  This is the blackout signature: the lane is dark, not green." >&2
+    exit 1
+fi
+
+missing=0
+found=0
+while IFS= read -r test_name; do
+    [ -n "$test_name" ] || continue
+    # tests/beat_sklearn_gaussiannb_speed.rs -> its BEAT-* marker.
+    src=$(find crates -path "*/tests/${test_name}.rs" -type f 2>/dev/null | head -1)
+    if [ -z "$src" ]; then
+        echo "✗ ${test_name}: workflow invokes it but no crates/*/tests/${test_name}.rs exists" >&2
+        missing=$((missing + 1))
+        continue
+    fi
+    marker=$(grep -ohE 'BEAT-[A-Z0-9-]+' "$src" | head -1)
+    if [ -z "$marker" ]; then
+        echo "✗ ${test_name}: no BEAT-* marker string in ${src} - it cannot report a measurement" >&2
+        missing=$((missing + 1))
+        continue
+    fi
+    if grep -q "${marker}:" "$BEAT_LOG"; then
+        echo "  ✓ ${marker}: $(grep -m1 "${marker}:" "$BEAT_LOG" | sed "s/.*${marker}: //")"
+        found=$((found + 1))
+    else
+        echo "✗ ${marker}: NO MEASUREMENT REPORTED (test ${test_name} went dark)" >&2
+        missing=$((missing + 1))
+    fi
+done < <(printf '%s\n' "$INVOKED")
+
+if [ "$missing" -gt 0 ]; then
+    echo "::error::check_beat_measurements: ${missing}/${n_invoked} speed beats reported no measurement" >&2
+    echo "  A beat that reports nothing is not a passing beat. Treating the lane as RED." >&2
+    exit 1
+fi
+
+echo "✓ check_beat_measurements: all ${found} speed beats reported a measurement"


### PR DESCRIPTION
## The defect

The nightly speed lane has not been measuring anything. It failed at **step 1** on 2026-07-27/28 with `ModuleNotFoundError: No module named 'numpy'`, and because the ten beat steps are a default fail-fast sequence, the other **nine never ran**. A step that never runs reports no measurement — and no measurement is indistinguishable from a pass if you only read exit codes.

**What that hid:** the GaussianNB beat is genuinely breaching. Re-running the lane after repairing the host:

| beat | ratio | verdict |
|---|---|---|
| `BEAT-SKLEARN-LINREG-SPEED` | 0.243 (apr 4.12× faster) | PASS |
| `BEAT-SKLEARN-GAUSSIANNB-SPEED` | **0.601** (apr 1.66× faster) | **FAIL** (ceiling 0.50) |

It had already gone red on 07-03 (0.563) and 07-04 (0.520) with nobody watching. That is `PMAT-GNB-SPEED-DEFENSE-001` with a live signal rather than a projection — filed separately, not fixed here.

## Root cause of the blackout

Diagnosed on `mac-server` / `intel-clean-room-10` (uv 0.11.23); **not** reproducible on lambda-vector (uv 0.5.5). uv caches a resolved `--with` environment as a venv under `~/.cache/uv/archive-v0/<hash>/`. Those archives had lost their `pyvenv.cfg`. uv still counted the requirements satisfied — no `Installed N packages`, no install — but with no `pyvenv.cfg` it could not use the archive as the ephemeral env's base and silently fell back to `/usr/bin/python3`, whose `sys.path` never includes the archive:

```
healthy:  .../builds-v0/<tmp>/lib/python3.10/site-packages
          .../archive-v0/<hash>/lib/python3.10/site-packages   <-- the --with env
          /usr/lib/python3/dist-packages
poisoned: .../builds-v0/<tmp>/lib/python3.10/site-packages
          /usr/lib/python3/dist-packages                       <-- overlay GONE
```

python ran without numpy and exited in 0.83s. Neither `uv cache clean <pkg>` nor `uv run --refresh` repairs it — both operate on wheel caches; the corruption is in the cached *environment*. **Systemic, not a one-off: 16 of that host's 19 cached environments were poisoned.**

## The fix (two parts, both fail-closed)

1. **`scripts/check_beat_baseline_env.sh`** — preflight. A speed beat is a *ratio* against an incumbent, so prove the incumbent imports before timing anything. Sweeps archives matching the exact poison signature (venv-shaped — has `bin/python3` — but no `pyvenv.cfg`), probes, falls back to full `uv cache clean`, then fails with a `sys.path` dump. The sweep is **proactive** because each incumbent (sklearn, torch, transformers, unsloth) has its own cached env — a sklearn-only probe would pass while the torch env stayed broken.

2. **`scripts/check_beat_measurements.sh`** — silence is red. Every beat must emit its `BEAT-*` marker; a missing marker fails the job. The expected list is derived from the workflow's own `--test` references and each test's marker string, so it cannot drift out of sync with the steps.

Plus `!cancelled() && steps.preflight.outcome == 'success'` on each beat step so one broken leg can never again mask the other nine.

## Verification

**Self-heal, on the real runner:** swept 16 poisoned archives → `BASELINE_OK numpy=2.2.6 sklearn=1.7.2`, exit 0. 151 package archives untouched (healthy archives always carry `pyvenv.cfg` + `CACHEDIR.TAG`).

**RED-turning mutations** (all exit 1):
- drop the GaussianNB line → `1/10 speed beats reported no measurement` *(the case that actually happened)*
- replay the real 07-28 log (LinReg traceback, no markers) → 10/10 dark
- no log at all → `the lane is dark, not green`

**GREEN:** all 10 markers present → exit 0. Both scripts bashrs-clean (0 errors), matching `check_beats_gated.sh`.

Nightly-only workflow — does not touch `ci.yml` or the merge gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)