### PR TITLE
fix(beat): the GaussianNB "4.9x" was a dev-box number - re-pin to the host that actually runs it

### DIFF
--- a/crates/aprender-core/tests/beat_sklearn_gaussiannb_speed.rs
+++ b/crates/aprender-core/tests/beat_sklearn_gaussiannb_speed.rs
@@ -28,9 +28,29 @@ const N_INFORMATIVE: usize = 20;
 const N_CLASSES: usize = 8;
 const SEED: u64 = 42;
 const RUNS: usize = 5;
-/// apr must be at least this fast (ratio = apr/sklearn). Measured ~0.20 (apr ~4.9x faster on a
-/// 16-core box after hoisting the per-class `ln` constant out of the predict hot loop); gate at
-/// 0.50 (apr >= 2x faster) for large margin against nightly-host variance.
+/// apr must be at least this fast (ratio = apr/sklearn).
+///
+/// MEASURED, PER HOST (2026-07-28 - the earlier "~0.20 / apr ~4.9x faster on a 16-core box"
+/// pinned here was a DEV-BOX number that has never been observed on the CI host, and it made
+/// the gate look like it had 2.5x of headroom when it has ~20%):
+///
+///   lambda-vector (modern 48-thread box, moderate load):
+///       apr ~12.0ms  sklearn ~56ms   ratio 0.188 / 0.237 / 0.220   (apr 4.2-5.3x)
+///   mac-server = the canonical nightly host (Xeon W-3245, 32 threads, IDLE):
+///       apr 27.961ms sklearn 70.308ms ratio 0.398                  (apr 2.51x)
+///   mac-server under real nightly load (historical, from run logs):
+///       ratio 0.278 .. 0.601 - i.e. it STRADDLES this gate.
+///
+/// Why the host matters so much: apr's GaussianNB is a scalar Rust loop, while sklearn's is
+/// vectorised numpy. The Xeon W-3245 has AVX-512 (avx512f/bw/cd/dq/vl), so numpy closes much
+/// of the gap there: going from lambda to mac-server costs apr 2.3x but sklearn only 1.25x.
+/// That is why the "4.9x" never reproduced - it is not decay, it is a different machine.
+///
+/// The gate stays at 0.50 (apr >= 2x). It is NOT weakened to accommodate the breaches: the
+/// idle-host reading (0.398) clears it, so a run over 0.50 is real signal - either genuine
+/// contention on a 17-runner box or a genuine regression, and the fit/predict split below
+/// exists to tell those two apart. See PMAT-GNB-SPEED-DEFENSE-001. The durable fix that would
+/// restore real margin is SIMD for the predict hot loop (trueno), not a looser threshold.
 const RATIO_CEILING: f64 = 0.50;
 
 fn median(xs: &[f64]) -> f64 {
@@ -44,21 +64,33 @@ fn median(xs: &[f64]) -> f64 {
     }
 }
 
-fn time_apr(x: &aprender::Matrix<f32>, y: &[usize]) -> f64 {
+/// Returns `(total_ms, fit_ms, predict_ms)`, each a median over `RUNS`.
+///
+/// The phase split is diagnostic, not decorative. When this beat goes red the question is
+/// always "contention or regression?", and the two look different: host contention inflates
+/// fit and predict roughly together, while an algorithmic regression lands in one phase. With
+/// only a fused total (the previous shape) five red nights told you nothing you could act on.
+fn time_apr(x: &aprender::Matrix<f32>, y: &[usize]) -> (f64, f64, f64) {
     {
         let mut m = GaussianNB::new();
         m.fit(x, y).expect("apr warmup fit");
         let _ = m.predict(x).expect("apr warmup predict");
     }
-    let mut times = Vec::with_capacity(RUNS);
+    let mut totals = Vec::with_capacity(RUNS);
+    let mut fits = Vec::with_capacity(RUNS);
+    let mut predicts = Vec::with_capacity(RUNS);
     for _ in 0..RUNS {
         let t = Instant::now();
         let mut m = GaussianNB::new();
         m.fit(x, y).expect("apr fit");
+        let fit_done = t.elapsed().as_secs_f64() * 1000.0;
         let _p = m.predict(x).expect("apr predict");
-        times.push(t.elapsed().as_secs_f64() * 1000.0);
+        let total = t.elapsed().as_secs_f64() * 1000.0;
+        totals.push(total);
+        fits.push(fit_done);
+        predicts.push(total - fit_done);
     }
-    median(&times)
+    (median(&totals), median(&fits), median(&predicts))
 }
 
 /// Writes features + label-as-last-column to CSV for the sklearn subprocess.
@@ -80,7 +112,9 @@ fn write_csv(x: &aprender::Matrix<f32>, y: &[usize]) -> tempfile::NamedTempFile 
     f
 }
 
-fn time_sklearn(csv: &std::path::Path) -> f64 {
+/// Returns `(total_ms, fit_ms, predict_ms)`, each a median over `RUNS`. See `time_apr` for why
+/// the phase split exists.
+fn time_sklearn(csv: &std::path::Path) -> (f64, f64, f64) {
     let py = format!(
         r#"
 import time, numpy as np
@@ -88,13 +122,24 @@ from sklearn.naive_bayes import GaussianNB
 D = np.loadtxt(r"{csv}", delimiter=",")
 X, y = D[:, :-1], D[:, -1].astype(np.int64)
 ts = []
+fs = []
+ps = []
 m = GaussianNB(); m.fit(X, y); _ = m.predict(X)  # warmup
 for _ in range({runs}):
     t = time.perf_counter()
-    m = GaussianNB(); m.fit(X, y); _ = m.predict(X)
-    ts.append((time.perf_counter() - t) * 1000.0)
-ts.sort()
-print("SKLEARN_MS=%f" % ts[len(ts)//2])
+    m = GaussianNB(); m.fit(X, y)
+    f = time.perf_counter()
+    _ = m.predict(X)
+    e = time.perf_counter()
+    fs.append((f - t) * 1000.0)
+    ps.append((e - f) * 1000.0)
+    ts.append((e - t) * 1000.0)
+def med(v):
+    v = sorted(v)
+    return v[len(v)//2]
+print("SKLEARN_MS=%f" % med(ts))
+print("SKLEARN_FIT_MS=%f" % med(fs))
+print("SKLEARN_PREDICT_MS=%f" % med(ps))
 "#,
         csv = csv.display(),
         runs = RUNS
@@ -118,11 +163,20 @@ print("SKLEARN_MS=%f" % ts[len(ts)//2])
         String::from_utf8_lossy(&out.stderr)
     );
     let stdout = String::from_utf8_lossy(&out.stdout);
-    let line = stdout
-        .lines()
-        .find_map(|l| l.strip_prefix("SKLEARN_MS="))
-        .unwrap_or_else(|| panic!("no SKLEARN_MS in: {stdout}"));
-    line.trim().parse::<f64>().expect("parse sklearn ms")
+    let field = |key: &str| -> f64 {
+        stdout
+            .lines()
+            .find_map(|l| l.strip_prefix(key))
+            .unwrap_or_else(|| panic!("no {key} in: {stdout}"))
+            .trim()
+            .parse::<f64>()
+            .unwrap_or_else(|e| panic!("parse {key}: {e}"))
+    };
+    (
+        field("SKLEARN_MS="),
+        field("SKLEARN_FIT_MS="),
+        field("SKLEARN_PREDICT_MS="),
+    )
 }
 
 #[test]
@@ -130,21 +184,34 @@ print("SKLEARN_MS=%f" % ts[len(ts)//2])
 fn beat_sklearn_gaussiannb_speed() {
     let (x, y) = make_classification(N_SAMPLES, N_FEATURES, N_INFORMATIVE, N_CLASSES, SEED);
 
-    let apr_ms = time_apr(&x, &y);
+    let (apr_ms, apr_fit_ms, apr_pred_ms) = time_apr(&x, &y);
     let csv = write_csv(&x, &y);
-    let sklearn_ms = time_sklearn(csv.path());
+    let (sklearn_ms, skl_fit_ms, skl_pred_ms) = time_sklearn(csv.path());
 
     let ratio = apr_ms / sklearn_ms;
     let speedup = sklearn_ms / apr_ms;
+    let fit_ratio = apr_fit_ms / skl_fit_ms;
+    let pred_ratio = apr_pred_ms / skl_pred_ms;
     eprintln!(
         "BEAT-SKLEARN-GAUSSIANNB-SPEED: apr={apr_ms:.3}ms sklearn={sklearn_ms:.3}ms \
          ratio={ratio:.3} (apr {speedup:.2}x faster) on {N_SAMPLES}x{N_FEATURES} \
          classes={N_CLASSES}, median of {RUNS}"
     );
+    // Phase split: which half moved? Contention drags fit and predict together; an
+    // algorithmic regression shows up in one of them. Printed on every run, pass or
+    // fail, so a sequence of nightlies is directly comparable.
+    eprintln!(
+        "BEAT-SKLEARN-GAUSSIANNB-SPEED-PHASES: fit apr={apr_fit_ms:.3}ms skl={skl_fit_ms:.3}ms \
+         ratio={fit_ratio:.3} | predict apr={apr_pred_ms:.3}ms skl={skl_pred_ms:.3}ms \
+         ratio={pred_ratio:.3}"
+    );
 
     assert!(
         ratio <= RATIO_CEILING,
         "FALSIFY-BEAT-SKLEARN-GAUSSIANNB-SPEED: apr/sklearn ratio {ratio:.3} > {RATIO_CEILING:.2} \
-         — apr GaussianNB is not faster than scikit-learn (apr={apr_ms:.3}ms, sklearn={sklearn_ms:.3}ms)"
+         — apr GaussianNB is not faster than scikit-learn (apr={apr_ms:.3}ms, sklearn={sklearn_ms:.3}ms). \
+         Phase split: fit {fit_ratio:.3}, predict {pred_ratio:.3}. Both phases up together on the \
+         nightly host usually means contention (mac-server runs 17 runners on 32 threads; idle \
+         reference is ratio 0.398 / apr 27.961ms); one phase up alone means a real regression."
     );
 }


### PR DESCRIPTION
`PMAT-GNB-SPEED-DEFENSE-001`. The beat pinned *"Measured ~0.20 (apr ~4.9× faster on a 16-core box)"* against a 0.50 ceiling — which reads as 2.5× of headroom. The real headroom on the machine that runs this beat is about **20%**, and the gate has been tripping: 07-03 `0.563`, 07-04 `0.520`, 07-28 `0.601`.

## Measured this session

| host | apr | sklearn | ratio |
|---|---|---|---|
| lambda-vector (modern, 48 threads) | ~12.0 ms | ~56 ms | 0.188 / 0.237 / 0.220 (4.2–5.3×) |
| **mac-server — canonical nightly host, IDLE** | 28.0 ms | 70.3 ms | **0.398** (2.51×) |
| mac-server under nightly load (run logs) | — | — | 0.278 … 0.601 (straddles 0.50) |

**This is not decay.** `git log --since=2026-07-01 -S"GaussianNB" -- crates/aprender-core/src/` is empty; the last impl change was #2181 (2026-06-22) and the ratio has bounced across that entire window. It's a different machine, plus contention.

## Why the host moves it so much

apr's GaussianNB is a scalar Rust loop; sklearn's is vectorised numpy. mac-server is a **Xeon W-3245 with AVX-512** (`avx512f/bw/cd/dq/vl`), so numpy closes much of the gap there: lambda → mac-server costs apr **2.3×** (12.0 → 28.0 ms) but sklearn only **1.25×** (56 → 70.3 ms). On top of that the box runs **17 registered runners on 32 threads**, which pushes a busy night the rest of the way over 0.50.

## What this does — and does not do

**It does NOT weaken the gate.** `RATIO_CEILING` stays `0.50`. The idle-host reading (0.398) clears it, so a run over 0.50 remains real signal rather than expected noise. Moving the threshold to make red go away would concede a win we still hold.

**It fixes the false baseline**, recording each measurement *with the host it came from*, so nobody re-tightens the gate on a number that machine cannot produce.

**It adds a fit/predict phase split**, printed every run and included in the failure message — the missing diagnostic. Contention drags both phases up together; an algorithmic regression lands in one. With only a fused total, five red nights told you nothing actionable.

```
BEAT-SKLEARN-GAUSSIANNB-SPEED: apr=11.675ms sklearn=51.795ms ratio=0.225 (apr 4.44x faster)
BEAT-SKLEARN-GAUSSIANNB-SPEED-PHASES: fit apr=4.666ms skl=15.508ms ratio=0.301
                                    | predict apr=7.078ms skl=37.199ms ratio=0.190
```

`predict` is where apr's edge is largest (5.3×) and `fit` is the weaker half (3.3×) — which also says where the durable fix belongs: **SIMD the predict hot loop via trueno** to restore real margin on AVX-512 hosts. That remains open under `PMAT-GNB-SPEED-DEFENSE-001`, deliberately not attempted here because it needs its own before/after on mac-server rather than a dev box.

> Note: this beat has been **unobservable since 2026-07-26** — the nightly lane died at step 1 on a poisoned uv env cache and fail-fast skipped every later beat (#2326). The 0.601 reading came from re-running the lane after repairing the host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)