### PR TITLE
fix(ci): runner.temp is not a valid context in a job-level env block

### DIFF
--- a/.github/workflows/beat-speed-nightly.yml
+++ b/.github/workflows/beat-speed-nightly.yml
@@ -45,7 +45,14 @@ jobs:
     timeout-minutes: 45
     env:
       # Every beat step tees here; the final step audits it for completeness.
-      BEAT_LOG: ${{ runner.temp }}/beat-speed-measurements.log
+      #
+      # NOT `runner.temp`: the `runner` context does not exist in a JOB-level env
+      # block (it is only available to steps), and using it there does not warn -
+      # it makes the whole workflow unparseable, so `workflow_dispatch` fails with
+      # "Unrecognized named-value: 'runner'" and the lane cannot run at all. That
+      # is exactly the blackout this file exists to prevent, reintroduced by the
+      # fix for it (#2326). `github` IS a valid context at job level.
+      BEAT_LOG: ${{ github.workspace }}/beat-speed-measurements.log
     steps:
       - uses: actions/checkout@v7
 


### PR DESCRIPTION
## Regression from my own #2326

#2326 set `BEAT_LOG: ${{ runner.temp }}/...` in the beat-speed-nightly **job** `env`. The `runner` context only exists for *steps*; referencing it at job level does not warn — it makes the entire workflow **unparseable**:

```
HTTP 422: failed to parse workflow: (Line: 48, Col: 17):
Unrecognized named-value: 'runner'
```

So `workflow_dispatch` is rejected and the lane cannot run at all. #2326 existed to stop this lane going dark, and then took it dark a different way.

**Why CI didn't catch it:** nothing evaluates a nightly workflow's expressions until it is dispatched. `yaml.safe_load` parses the file fine — the GitHub *expression* layer is what rejects it, and no per-PR job exercises that layer for a scheduled workflow.

## Fix

`github` **is** a valid context in a job-level `env` block, and `github.workspace` is where every step already runs, so `BEAT_LOG` moves there.

## Verification

Dispatched this workflow **from this branch** before requesting merge — the GitHub parser is the only real oracle here:

```
$ gh workflow run beat-speed-nightly.yml --ref fix/beat-log-runner-context
$ gh run list --workflow=beat-speed-nightly.yml
30376448935  queued  fix/beat-log-runner-context
```

A run is created instead of a 422, which is the proof. That same run also exercises the full lane end-to-end (preflight self-heal → 10 independent beat steps → measurement audit).

Follow-up worth doing separately: add `actionlint` to CI so workflow-expression errors fail a PR instead of surfacing on first dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)