### PR TITLE
fix(ci): probe EVERY incumbent, not just sklearn - a second uv poison class was hiding

### DIFF
--- a/scripts/check_beat_baseline_env.sh
+++ b/scripts/check_beat_baseline_env.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Preflight: the incumbent baseline (scikit-learn + numpy under `uv`) must
-# actually import before we time anything against it.
+# Preflight: every incumbent the speed beats time against (scikit-learn+numpy,
+# torch, transformers, peft - each in its own `uv` environment) must actually
+# import before we time anything against it.
 #
 # WHY THIS EXISTS. Every Pillar-1/2/3 speed beat is a RELATIVE ratio: we time
 # apr and we time the incumbent on the same host in the same run. If the
@@ -34,20 +35,41 @@
 #
 # WHAT THIS DOES. Behaviour first, layout second - we do not want a gate that
 # encodes a guess about uv's cache internals:
-#   1. Try the import. Pass -> done, no mutation.
-#   2. Fail -> remove only archives with the exact poison signature (venv-shaped
-#      - has bin/python3 - but missing pyvenv.cfg). Healthy archives always
-#      carry pyvenv.cfg + CACHEDIR.TAG, so this is precise, not a blanket wipe.
-#   3. Retry. Still failing -> full `uv cache clean` (last resort, self-healing
-#      at the cost of one re-download).
-#   4. Retry. Still failing -> exit 1 with the diagnosis, because at that point
-#      it is not a poisoned cache and a human needs the sys.path dump.
+#   1. Sweep archives matching the exact poison signature (venv-shaped - has
+#      bin/python3 - but missing pyvenv.cfg). Healthy archives always carry
+#      pyvenv.cfg + CACHEDIR.TAG, so this is precise, not a blanket wipe.
+#   2. Import-probe EVERY incumbent (see PROBES). All pass -> done.
+#   3. Any failure -> full `uv cache clean`, which is what repairs the second
+#      poison class below (present-but-INCOMPLETE archives, invisible to step 1).
+#   4. Re-probe. Still failing -> exit 1 with the diagnosis, because at that
+#      point it is not a cache fault and a human needs the sys.path dump.
 #
 # Same shape as the EACCES self-heal added to guard-runner-labels in #2311:
 # detect a known-recurring runner-state fault, repair it, prove the repair.
 set -euo pipefail
 
-PROBE='import numpy, sklearn; print("BASELINE_OK numpy=%s sklearn=%s" % (numpy.__version__, sklearn.__version__))'
+# EVERY incumbent the lane times against, one probe per uv environment.
+#
+# One probe is not enough. Each `--with` set gets its OWN cached environment, so a
+# green scikit-learn probe says nothing about the torch env. Proven on 2026-07-28:
+# after this preflight passed and the lane ran end-to-end for the first time in
+# days, the PyTorch beat still died on `ModuleNotFoundError: No module named
+# 'typing_extensions'` - its archive held torch but not torch's own transitive dep.
+#
+# That is a SECOND poison class, and it defeats the pyvenv.cfg sweep below: the
+# archive was venv-shaped AND had pyvenv.cfg, it was merely INCOMPLETE (48 packages,
+# typing_extensions missing). uv checks satisfaction against the REQUESTED
+# requirement only - `torch` was present, so it declared the env satisfied and
+# skipped the install that would have pulled the missing dep. Nothing short of
+# actually importing detects that, which is why these probes are behavioural.
+#
+# Format: "<label>|<--with args, comma separated>|<python import statement>"
+PROBES=(
+    "sklearn|scikit-learn,numpy|import numpy, sklearn; print('numpy=%s sklearn=%s' % (numpy.__version__, sklearn.__version__))"
+    "torch|torch|import torch, typing_extensions; print('torch=%s' % torch.__version__)"
+    "transformers|transformers,torch|import torch, transformers; print('transformers=%s' % transformers.__version__)"
+    "peft|torch,transformers,peft|import torch, transformers, peft; print('peft=%s' % peft.__version__)"
+)
 
 if ! command -v uv >/dev/null 2>&1; then
     echo "✗ check_beat_baseline_env: uv not on PATH - the speed beats cannot time the incumbent" >&2
@@ -56,8 +78,35 @@ fi
 
 echo "check_beat_baseline_env: $(uv --version)"
 
-try_probe() {
-    uv run --with scikit-learn --with numpy python3 -c "$PROBE" 2>&1
+# Run one probe spec. Echoes "<label>: <output>" and returns the probe's status.
+run_probe() {
+    spec_rest=${1#*|}
+    spec_with=${spec_rest%%|*}
+    spec_code=${spec_rest#*|}
+    with_args=""
+    old_ifs=$IFS
+    IFS=,
+    for pkg in $spec_with; do
+        with_args="$with_args --with $pkg"
+    done
+    IFS=$old_ifs
+    # shellcheck disable=SC2086 # deliberate word-splitting of the built flag list
+    uv run $with_args python3 -c "$spec_code" 2>&1
+}
+
+# Probe every incumbent; echo failures. Returns 0 only if ALL pass.
+try_all_probes() {
+    all_ok=0
+    for spec in "${PROBES[@]}"; do
+        label=${spec%%|*}
+        if out=$(run_probe "$spec"); then
+            echo "  ✓ ${label}: ${out##*$'\n'}"
+        else
+            echo "  ✗ ${label}: ${out##*$'\n'}" >&2
+            all_ok=1
+        fi
+    done
+    return "$all_ok"
 }
 
 # Step 1 - ALWAYS sweep poisoned env archives, before probing.
@@ -70,7 +119,12 @@ try_probe() {
 # rediscover this one incumbent at a time. A poisoned archive is definitively
 # unusable (uv cannot use it as a venv base), so removing it is never a loss:
 # the worst case is one re-download.
-CACHE_DIR="${UV_CACHE_DIR:-$HOME/.cache/uv}"
+# Ask uv where its cache is rather than assuming ~/.cache/uv: it can be moved by
+# UV_CACHE_DIR, by uv.toml, or by a symlink (on lambda-vector ~/.cache/uv points
+# at /mnt/nvme-raid0/cache/uv). Sweeping the wrong directory would silently find
+# nothing and report "swept 0", which reads exactly like a healthy cache.
+CACHE_DIR=$(uv cache dir 2>/dev/null || true)
+CACHE_DIR=${CACHE_DIR:-${UV_CACHE_DIR:-$HOME/.cache/uv}}
 ARCHIVES="$CACHE_DIR/archive-v0"
 removed=0
 if [ -d "$ARCHIVES" ]; then
@@ -108,29 +162,64 @@ if [ -d "$ARCHIVES" ]; then
 fi
 echo "swept $removed poisoned env archive(s) from $ARCHIVES"
 
-# Step 2 - prove the incumbent actually imports.
-if out=$(try_probe) && [[ "$out" == *BASELINE_OK* ]]; then
-    echo "  $out"
-    echo "✓ check_beat_baseline_env: baseline importable (swept $removed poisoned archive(s))"
+# Step 2 - prove EVERY incumbent actually imports.
+echo "probing ${#PROBES[@]} incumbent environment(s):"
+if try_all_probes; then
+    echo "✓ check_beat_baseline_env: all ${#PROBES[@]} incumbents importable (swept $removed poisoned archive(s))"
     exit 0
 fi
 
-echo "⚠ baseline import FAILED even after sweeping $removed poisoned archive(s)" >&2
-echo "  probe output: ${out}" >&2
+echo "⚠ at least one incumbent failed to import after sweeping $removed poisoned archive(s)" >&2
 
-# Step 3 - last resort: nuke the whole uv cache. Costs one re-download.
-echo "⚠ falling back to full 'uv cache clean'" >&2
+# Step 2b - targeted repair of the INCOMPLETE archives the signature sweep cannot
+# see. `uv run -v` names the cached environment it resolved to, so drop exactly
+# that one and let uv rebuild it. This is the manual fix that repaired the torch
+# env on mac-server on 2026-07-28, mechanised - and it is far cheaper than the
+# full clean below, which re-downloads multiple GB of torch/transformers wheels.
+for spec in "${PROBES[@]}"; do
+    label=${spec%%|*}
+    if run_probe "$spec" >/dev/null 2>&1; then
+        continue
+    fi
+    rest=${spec#*|}
+    with=${rest%%|*}
+    with_args=""
+    old_ifs=$IFS
+    IFS=,
+    for pkg in $with; do
+        with_args="$with_args --with $pkg"
+    done
+    IFS=$old_ifs
+    # shellcheck disable=SC2086 # deliberate word-splitting of the built flag list
+    bad=$(uv run -v $with_args python3 -c pass 2>&1 |
+          grep -oE 'archive-v0/[A-Za-z0-9_-]+' | head -1 || true)
+    if [ -n "$bad" ] && [ -d "$CACHE_DIR/$bad" ]; then
+        echo "  ${label}: dropping incomplete env archive $CACHE_DIR/$bad" >&2
+        rm -rf "${CACHE_DIR:?}/${bad:?}"
+    else
+        echo "  ${label}: could not identify a cached env to drop" >&2
+    fi
+done
+
+echo "re-probing after targeted repair:"
+if try_all_probes; then
+    echo "✓ check_beat_baseline_env: all ${#PROBES[@]} incumbents restored by targeted repair"
+    exit 0
+fi
+
+# Step 3 - last resort: nuke the whole uv cache.
+echo "⚠ targeted repair insufficient - falling back to full 'uv cache clean'" >&2
 uv cache clean >&2 || true
 
-if out=$(try_probe) && [[ "$out" == *BASELINE_OK* ]]; then
-    echo "✓ check_beat_baseline_env: baseline restored by full cache clean"
+echo "re-probing after full cache clean:"
+if try_all_probes; then
+    echo "✓ check_beat_baseline_env: all ${#PROBES[@]} incumbents restored by full cache clean"
     exit 0
 fi
 
 # Not a cache fault. Give the operator everything needed to diagnose.
-echo "::error::check_beat_baseline_env: scikit-learn/numpy baseline is NOT importable after cache repair" >&2
-echo "  Every speed beat is a ratio against this baseline; without it the lane measures nothing." >&2
-echo "  final probe output: ${out}" >&2
+echo "::error::check_beat_baseline_env: an incumbent is NOT importable after cache repair" >&2
+echo "  Every speed beat is a ratio against its incumbent; without it the beat measures nothing." >&2
 echo "  --- diagnostics ---" >&2
 uv run --with scikit-learn --with numpy python3 \
     -c 'import sys; print("executable:", sys.executable); [print("  path:", p) for p in sys.path]' >&2 2>&1 || true


### PR DESCRIPTION
The #2326 preflight probed **one** environment (scikit-learn+numpy) and its sweep looked for **one** signature (venv-shaped, no `pyvenv.cfg`). Both were too narrow — and the very first end-to-end run of the repaired lane proved it: preflight passed, nine beats reported, and the PyTorch beat still died on `ModuleNotFoundError: No module named 'typing_extensions'`.

## Second poison class

That torch archive was **not** missing `pyvenv.cfg` — it was present, venv-shaped, and simply **incomplete** (48 packages, no `typing_extensions`, which is torch's own transitive dep). uv checks satisfaction against the **requested** requirement only: `torch` was there, so it declared the env satisfied, skipped the install that would have pulled the missing dep, and ran python against a half-populated env. Nothing short of actually importing detects that — which is why these probes are behavioural rather than structural.

Each `--with` set gets its **own** cached environment, so a green scikit-learn probe says nothing about torch, transformers or peft. One probe per incumbent now:

| probe | `--with` | beats it backs |
|---|---|---|
| sklearn | scikit-learn + numpy | LinReg / NB family / GMM |
| torch | torch | Pillar-2 cold-start |
| transformers | transformers + torch | Pillar-4 HF cold-start |
| peft | torch + transformers + peft | Pillar-3 unsloth cold-start |

## Targeted repair instead of the big hammer

`uv run -v` names the cached environment it resolved to, so a failing probe drops **exactly that archive** and lets uv rebuild it — the manual fix that repaired mac-server, mechanised. Full `uv cache clean` stays as last resort; it would re-download multiple GB of torch/transformers wheels, which is not the right response to one bad archive.

Also: ask `uv cache dir` for the cache location instead of assuming `~/.cache/uv`. It can be moved by `UV_CACHE_DIR`, by `uv.toml`, or by a symlink (on lambda-vector `~/.cache/uv` → `/mnt/nvme-raid0/cache/uv`). Sweeping the wrong directory finds nothing and reports `swept 0` — which reads exactly like a healthy cache.

## RED-turning mutation, on the actual CI host

Faithful reproduction: removed `typing_extensions.py` from the live torch archive and confirmed `uv run --with torch python3 -c "import torch"` fails.

```
swept 0 poisoned env archive(s)            <- signature sweep correctly blind
probing 4 incumbent environment(s):
  ✓ sklearn: numpy=2.2.6 sklearn=1.7.2
  ✗ torch: ModuleNotFoundError: No module named 'typing_extensions'
  ✓ transformers: transformers=5.14.1
  ✓ peft: peft=0.20.0
  torch: dropping incomplete env archive .../archive-v0/zMEDAW6f9mEVEnab
re-probing after targeted repair:
  ✓ sklearn   ✓ torch: torch=2.13.0+cu130   ✓ transformers   ✓ peft
✓ all 4 incumbents restored by targeted repair
```

Only the torch archive was touched; sklearn/transformers/peft were left alone. GREEN case on a healthy host: all 4 pass, `swept 0`, no mutation. bashrs-clean (0 errors).

Stacks on #2329 (the `runner.temp` hotfix), which the lane needs in order to run at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)