### PR TITLE
fix(coverage): the coverage measurement reported 0% for everything - phase 2 measured a facade

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -274,10 +274,26 @@ else
 endif
 COV_CARGO_ENV := $(if $(COV_TARGET_DIR),CARGO_TARGET_DIR=$(COV_TARGET_DIR))
 
-# Coverage: Two-phase pattern (tests + deferred report)
-# Phase 1: Run tests with --no-report (keeps profraw, ~90s)
-# Phase 2: Single report pass for summary + threshold check (~90s)
-# HTML/LCOV generated separately via coverage-html (skipped for speed)
+# Coverage: SINGLE-phase (tests instrument AND write the report in one invocation).
+#
+# This was a two-phase pattern (`test --no-report`, then a separate `report`) and it
+# silently measured NOTHING: every run reported "TOTAL: 0/0 lines covered (0%)".
+#
+# Why: `cargo llvm-cov report` takes its package scope from the CURRENT package, and it
+# does NOT accept --workspace/--exclude ("--workspace is specific to [test,nextest,...]
+# and not supported for subcommand 'report'"). Phase 1 instrumented
+# `--workspace --exclude aprender-gpu`, phase 2 then reported on the ROOT package - which
+# is a facade with no code - so the LCOV came out empty and COV_PCT computed to 0. Same
+# facade trap .github/workflows/ci.yml:60-64 already documents for sovereign-ci.
+#
+# Verified on a multi-package run (aprender-common + aprender-bench-compute), in the
+# SHARED target dir this Makefile uses:
+#   two-phase, unscoped report  -> LH=0   LF=0    (empty)
+#   report --summary-only -p A -p B -> LH=686 LF=737  (93.08%)
+#   single-phase --lcov --output-path -> LH=686 LF=737  (93.08%)
+# Single-phase is chosen over an explicit -p list because the invocation that selects the
+# scope is the one that writes the report, so the two cannot drift apart again. profraw
+# survive it (31 present afterwards), so coverage-html still has data to work from.
 coverage: ## Coverage summary + threshold check (warm: ~3min)
 	@echo "📊 Running coverage ($(COV_THRESHOLD)%+ threshold)..."
 	@which cargo-llvm-cov > /dev/null 2>&1 || { cargo install cargo-llvm-cov --locked || exit 1; }
@@ -287,10 +303,11 @@ coverage: ## Coverage summary + threshold check (warm: ~3min)
 	if [ -n "$$COVDIR" ]; then find "$$COVDIR" -name '*.profraw' -delete 2>/dev/null || true; fi
 	@mkdir -p target/coverage
 	@printf '%s' '$(COVERAGE_EXCLUDE_REGEX)' > target/coverage/.exclude-re
-	@echo "🧪 Phase 1: Tests with instrumentation (CB-127-A: cargo llvm-cov test, not nextest)..."
+	@echo "🧪 Tests with instrumentation + report in ONE invocation (CB-127-A: cargo llvm-cov test, not nextest)..."
 	@PROPTEST_CASES=10 QUICKCHECK_TESTS=10 RUST_MIN_STACK=16777216 CARGO_BUILD_JOBS=4 \
-		$(COV_CARGO_ENV) cargo llvm-cov test --no-report \
+		$(COV_CARGO_ENV) cargo llvm-cov test \
 		--workspace --exclude aprender-gpu --lib \
+		--lcov --output-path target/coverage/lcov.info \
 		--ignore-filename-regex "$$(cat target/coverage/.exclude-re)" \
 		-- --skip prop_gbm_expected_value --skip slow --skip heavy --skip h12_ --skip j2_ \
 		   --skip falsification --skip chaos --skip disconnect --skip benchmark_parity \
@@ -298,8 +315,7 @@ coverage: ## Coverage summary + threshold check (warm: ~3min)
 		   --skip spec_checklist_w --skip spec_checklist_u --skip verify_audio --skip g9_roofline \
 		   --skip cuda --skip gpu_ \
 		|| { test -f ~/.cargo/config.toml.bak && mv ~/.cargo/config.toml.bak ~/.cargo/config.toml; exit 1; }
-	@echo "📊 Phase 2: Coverage report (LCOV → lightweight)..."
-	@$(COV_CARGO_ENV) cargo llvm-cov report --lcov --ignore-filename-regex "$$(cat target/coverage/.exclude-re)" > target/coverage/lcov.info
+	@echo "📊 Parsing LCOV for the threshold check..."
 	@# Parse LCOV for line coverage (LH=lines hit, LF=lines found)
 	@LH=$$(awk -F: '/^LH:/{s+=$$2} END{print s+0}' target/coverage/lcov.info); \
 	LF=$$(awk -F: '/^LF:/{s+=$$2} END{print s+0}' target/coverage/lcov.info); \
@@ -318,6 +334,11 @@ coverage: ## Coverage summary + threshold check (warm: ~3min)
 coverage-fast: coverage
 
 # HTML + LCOV reports (run after 'make coverage' to generate browseable report)
+# KNOWN DEFECT (same root cause as `coverage` above, NOT yet fixed): both `report` calls
+# below are unscoped, so they report the root facade and produce an EMPTY html/lcov. They
+# need either an explicit `-p <pkg>` list or to be folded into the instrumenting run, the
+# way `coverage` now is. Left as-is here because it is report-only cosmetics and does not
+# gate anything - unlike `coverage`, whose 0% fed the >=95% threshold check.
 coverage-html: ## Generate HTML + LCOV reports from last coverage run
 	@echo "📊 Generating HTML + LCOV reports..."
 	@test -f ~/.cargo/config.toml && mv ~/.cargo/config.toml ~/.cargo/config.toml.bak || true


### PR DESCRIPTION
`make coverage` has been printing this on **every** run:

```
TOTAL: 0/0 lines covered (0%)
❌ Coverage 0% is below threshold 95%
```

So the 95% floor quoted in CLAUDE.md and README isn't merely unenforced (coverage-nightly.yml swallows the exit with `|| true`) — **the number behind it does not exist.**

## Root cause

`cargo llvm-cov report` takes its package scope from the *current* package, and does **not** accept the flags phase 1 used:

```
--workspace is specific to [test,nextest,nextest-archive,show-env,clean,no subcommand]
and not supported for subcommand 'report'
```

Phase 1 instrumented `--workspace --exclude aprender-gpu --lib`. Phase 2 then ran a bare `report`, which scoped to the **root package — a facade with no code** — so the LCOV came out empty and `COV_PCT` computed to 0. It's the same facade trap `ci.yml:60-64` already documents for the sovereign-ci coverage job ("the ROOT crate is a facade … exercises 0 tests"), hit again from a different direction.

## Fix

Stop having two scopes that can disagree: instrument and report in **one** invocation, so the command that selects `--workspace --exclude aprender-gpu` is the command that writes the LCOV. An explicit `-p` list on `report` also works, but would have to enumerate ~78 crates and would drift the moment one is added.

## Verified

Multi-package run (aprender-common + aprender-bench-compute), in the **shared** target dir this Makefile actually uses:

| variant | result |
|---|---|
| two-phase, unscoped `report` | `LH=0 LF=0` — **the bug** |
| `report --summary-only -p A -p B` | `LH=686 LF=737` (93.08%) |
| **single-phase `--lcov --output-path`** | `LH=686 LF=737` (93.08%) |

And again with the **exact flag shape** this recipe now uses (`--lcov` + `--output-path` + `--ignore-filename-regex` + trailing `-- --skip …`): `LH=686 LF=737`, 93.1%.

## Deliberately not changed here

1. **The `|| true` in `coverage-nightly.yml:59` stays.** Arming the gate is a separate, sequenced step — the pipeline must first be *observed* producing a real percentage on the runner, with a `COV_BASELINE` committed, or main goes permanently red on the first run. That's the andon failure this fix exists to make impossible. **This change is the prerequisite, not the arming.**
2. An earlier reading blamed a second fault — that sharing the ordinary target dir suppresses profraw — because a shared-dir two-phase run produced 0 profraw. That was a two-phase artifact: single-phase in the *same* shared dir yields the numbers above. The target dir is not implicated.

Documented, not fixed: `coverage-html` has the identical unscoped-`report` bug (empty html/lcov). It gates nothing, so it gets a NOTE. Also latent: the stale-profraw pre-clean greps `show-env` for `CARGO_LLVM_COV_TARGET_DIR`, which that output doesn't contain, so `COVDIR` is empty and the cleanup is a silent no-op.

Refs `PMAT-COVERAGE-FLOOR-001`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)