### PR TITLE
feat(coverage): arm the ratchet - and the real number is 88.78%, not 96.35%

### DIFF
--- a/.github/workflows/coverage-nightly.yml
+++ b/.github/workflows/coverage-nightly.yml
@@ -9,8 +9,16 @@ name: Coverage Nightly
 # analysis CLAUDE.md mandates), and keeps a single tracking issue up to date so
 # the autonomous loop can fix the top gaps as small `test(...)` PRs.
 #
-# Report-mode by design: never fails the nightly on a coverage dip or a transient
-# tooling hiccup. Promote to a ratchet/hard gate later once it's proven stable.
+# RATCHET MODE (promoted 2026-07-29, as this header always intended). The step
+# below no longer ends in `|| true`. It enforces COV_FLOOR - the last MEASURED
+# value - so red means coverage REGRESSED, not that the 95% target is unmet.
+#
+# It could not be armed before now because the measurement was broken: every run
+# reported `TOTAL: 0/0 lines covered (0%)` (phase 2 scoped its report to the root
+# facade - fixed in #2333). Arming on top of that would have pinned the nightly
+# red forever. First real number, 2026-07-29 on 95145584f:
+# 786448/885829 = 88.78%, NOT the 96.35% that had been quoted since before the
+# measurement ever worked.
 
 on:
   schedule:
@@ -56,7 +64,11 @@ jobs:
           # Makefile's `which cargo-llvm-cov` short-circuits.
           export PATH="$HOME/.cargo/bin:$HOME/.local/bin:$PATH"
           command -v cargo-llvm-cov >/dev/null 2>&1 || cargo install cargo-llvm-cov --locked || true
-          make coverage COV_TARGET_DIR= 2>&1 | tee /tmp/cov.log || true
+          # ARMED (was `|| true`). `make coverage` now enforces a RATCHET floor
+          # (COV_FLOOR, the last measured value) rather than the aspirational 95%
+          # target, so a red here means coverage went DOWN - not that we have not
+          # reached 95% yet. set -o pipefail above makes the tee transparent.
+          make coverage COV_TARGET_DIR= 2>&1 | tee /tmp/cov.log
           pct="$(grep -oE 'TOTAL: [0-9]+/[0-9]+ lines covered \([0-9]+%\)' /tmp/cov.log | tail -1 | grep -oE '[0-9]+%' || true)"
           echo "pct=${pct:-unknown}" >> "$GITHUB_OUTPUT"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ make tier1                   # Fast feedback (<1s): fmt, clippy, check
 make tier2                   # Pre-commit (<5s): tests + strict clippy
 make tier3                   # Pre-push (1-5min): full validation + coverage
 make tier4                   # CI/CD: includes pmat analysis
-make coverage                # Coverage report (target ≥95%)
+make coverage                # Coverage report (enforced floor 88%, target ≥95%)
 ```
 
 ## Debugging: Use apr Tools First (MANDATORY)
@@ -269,14 +269,14 @@ Required: `set -euo pipefail`, no `ls` for iteration, quoted variables, explicit
 
 ## Testing
 
-Target: 60% unit, 30% property, 10% integration. Coverage: 96.35% line (target ≥95%).
+Target: 60% unit, 30% property, 10% integration. Coverage: **88.78% line** (786448/885829, measured 2026-07-29 by coverage-nightly on 95145584f; target ≥95%, enforced floor 88% via COV_FLOOR). The long-quoted "96.35%" predates the measurement ever working - the pipeline reported 0/0 until #2333.
 
 ```bash
 cargo test                    # All tests (12,974 lib + 4,599 integration)
 cargo test --lib              # Unit only
 cargo test --test integration # Integration
 cargo test --doc              # Doctests
-make coverage                 # Coverage report (disables mold linker, two-phase llvm-cov)
+make coverage                 # Coverage report (disables mold linker, single-phase llvm-cov)
 ```
 
 Mutation testing: `cargo mutants --no-times --timeout 300 --in-place -- --all-features` (or via CI).
@@ -330,7 +330,7 @@ apr qa model.gguf --assert-tps 100 --json
 
 ## PMAT Quality Analysis (v3.10.0)
 
-**Scores:** Project 124/134 (A+), TDG 95.2/100 (A+), Coverage 96.35%, Mutation 85.3%
+**Scores:** Project 124/134 (A+), TDG 95.2/100 (A+), Coverage 88.78% (measured 2026-07-29), Mutation 85.3%
 **Thresholds:** Coverage ≥95%, Complexity ≤10/fn, SATD 0, TDG ≥95, Mutation ≥85%, 0 unwrap()
 
 ```bash

--- a/Makefile
+++ b/Makefile
@@ -263,6 +263,19 @@ COVERAGE_EXCLUDE_REGEX := \.cargo/|trueno|realizar/|entrenar/|fuzz/|golden_trace
 # Coverage threshold (enforced: fail if below)
 COV_THRESHOLD := 95
 
+# Enforced RATCHET floor, distinct from the aspirational target above.
+#
+# Measured 2026-07-29 by the nightly on 95145584f (the commit that fixed the
+# measurement itself): TOTAL: 786448/885829 lines covered = 88.78%. The 95%
+# target is real but is NOT where the tree is, so gating on 95 today would paint
+# the nightly permanently red and train everyone to ignore it - the exact
+# "gate that cannot turn red usefully" failure this repo keeps finding.
+#
+# So the enforced condition is "do not regress below what we actually have".
+# Raise this number whenever a run comes in higher; never lower it to make red
+# go away. Integer truncation gives ~0.78pt of headroom before 88 becomes 87.
+COV_FLOOR := 88
+
 # NVMe target dir (mirrors cargo() shell function that sets CARGO_TARGET_DIR)
 # Without this, Make's subshell bypasses the function and uses ./target/ instead
 # of /mnt/nvme-raid0/targets/aprender, causing profraw/binary mismatch.
@@ -323,9 +336,16 @@ coverage: ## Coverage summary + threshold check (warm: ~3min)
 	echo "TOTAL: $$LH/$$LF lines covered ($${COV_PCT}%)"; \
 	echo "TOTAL $$LH $$LF $${COV_PCT}%" > target/coverage/summary.txt; \
 	test -f ~/.cargo/config.toml.bak && mv ~/.cargo/config.toml.bak ~/.cargo/config.toml || true; \
-	if [ "$$COV_PCT" -lt "$(COV_THRESHOLD)" ]; then \
-		echo "❌ Coverage $${COV_PCT}% is below threshold $(COV_THRESHOLD)%"; \
+	if [ "$$COV_PCT" -lt "$(COV_FLOOR)" ]; then \
+		echo "❌ REGRESSION: coverage $${COV_PCT}% fell below the enforced floor $(COV_FLOOR)%"; \
+		echo "   The floor is the last measured value, so this means coverage went DOWN."; \
+		echo "   Add tests for what you changed, or justify and lower COV_FLOOR deliberately."; \
 		exit 1; \
+	elif [ "$$COV_PCT" -lt "$(COV_THRESHOLD)" ]; then \
+		echo "✅ Coverage $${COV_PCT}% holds the floor $(COV_FLOOR)% (target is $(COV_THRESHOLD)%, not yet reached)"; \
+		if [ "$$COV_PCT" -gt "$(COV_FLOOR)" ]; then \
+			echo "   ⬆  Above the floor - raise COV_FLOOR to $${COV_PCT} to lock the gain in."; \
+		fi; \
 	else \
 		echo "✅ Coverage $${COV_PCT}% meets threshold $(COV_THRESHOLD)%"; \
 	fi


### PR DESCRIPTION
#2333 fixed the coverage measurement (it had been reporting `0/0` for everything). The nightly then produced this project's **first real coverage number**, on `95145584f` — the very commit that fixed it:

```
TOTAL: 786448/885829 lines covered (88%)     -> 88.78%
❌ Coverage 88% is below threshold 95%
... and the job still concluded SUCCESS
```

Two findings in one run. **The measurement works now.** And the **96.35% quoted in CLAUDE.md is off by 8.35 points** — a local point-in-time number from before the pipeline ever worked, carried forward for months while the thing meant to check it emitted `0/0` into a `|| true`.

## What changes

1. **CLAUDE.md states the measured number with provenance** (`786448/885829`, 2026-07-29, coverage-nightly on `95145584f`) instead of an unsourced 96.35%.

2. **`make coverage` gains `COV_FLOOR` (88)**, separate from `COV_THRESHOLD` (95). The *enforced* condition is "do not regress below what we actually have"; 95 stays the documented target. Gating on 95 today would paint the nightly permanently red and train everyone to ignore it — precisely the "gate that cannot usefully turn red" failure this repo keeps finding. Above the floor it prints `⬆ raise COV_FLOOR to N to lock the gain in`, so the ratchet advances deliberately rather than drifting.

3. **`coverage-nightly.yml` drops the `|| true`.** Its header has said *"Promote to a ratchet/hard gate later once it's proven stable"* since it was written; this is that promotion. It could not have happened before #2333 — arming a gate on a pipeline reporting 0% pins it red forever, so the sequencing was mandatory, not cautious.

## Verified — the ratchet discriminates

| coverage | verdict | exit |
|---|---|---|
| 95% | PASS (meets target) | 0 |
| 91% | PASS (above floor, raise it) | 0 |
| 88% | PASS (at floor) | 0 |
| **87%** | **FAIL (regression)** | **1** ← RED-turning mutation |

`set -o pipefail` is already on that step, so the `tee` doesn't mask the exit. Workflow YAML re-parsed.

## Scope note

88.78% is "of what", and the answer isn't "the workspace": `COVERAGE_EXCLUDE_REGEX` drops **743 of 3271** `.rs` files, and **`apr-cli/` alone accounts for 541** — the entire CLI crate and its 4,158 tests sit outside the denominator. Also, `entrenar/` in that regex now matches **0** files (pre-monorepo name), while `trueno` still matches 88 and `realizar/` 7. Reconciling that list is follow-up work; this change reports honestly on the denominator we have rather than quietly widening it in the same commit.

Refs `PMAT-COVERAGE-FLOOR-001`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)