### PR TITLE
fix(ci): PMAT-CI-PASSGREP-001 closed one instance of a class — two more were live

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -396,6 +396,12 @@ jobs:
       # for its own runner.
       - name: Every beat must be executed by some workflow
         run: bash scripts/check_beats_gated.sh
+      # Poka-yoke: PMAT-CI-PASSGREP-001 killed ONE `grep "0 failed"` that also
+      # matched "10 failed". Two more instances of the same class survived that
+      # fix, one of them a live contract falsifier. Probe every zero-count
+      # pass-grep against an all-failing line instead of trusting review.
+      - name: Every zero-count pass-grep must reject a failing line
+        run: bash scripts/check_pass_grep_anchored.sh
 
   # Top-level gate: satisfies org ruleset "Green Main" which requires check named "gate".
   # The reusable workflow produces "ci / gate" but rulesets need exact match on "gate".

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-Aprender is a next-generation ML framework in pure Rust — **monorepo with 82 workspace crates**. Install: `cargo install aprender` → `apr` binary (103 subcommands). 25,300+ tests, 1766 provable contracts. Core library in `crates/aprender-core/` ([lib] name = "aprender"). All 20 repos (trueno, realizar, entrenar, batuta, + 15 satellites) consolidated per APR-MONO spec. **v0.34.0 SHIPPED 2026-05-18: MODEL-2 §88 stack-existence-proof, paiml/albor-370m-v1 LIVE on HF Hub.**
+Aprender is a next-generation ML framework in pure Rust — **monorepo with 82 workspace crates**. Install: `cargo install aprender` → `apr` binary (103 subcommands). 25,300+ tests, 1767 provable contracts. Core library in `crates/aprender-core/` ([lib] name = "aprender"). All 20 repos (trueno, realizar, entrenar, batuta, + 15 satellites) consolidated per APR-MONO spec. **v0.34.0 SHIPPED 2026-05-18: MODEL-2 §88 stack-existence-proof, paiml/albor-370m-v1 LIVE on HF Hub.**
 
 ## Git Workflow (Branch Protection)
 
@@ -310,7 +310,7 @@ Key: `unsafe_code = "forbid"`, `clippy::all + pedantic = "warn"`, ML-specific al
 - `crates/aprender-core/src/text/chat_template.rs` - Chat template engine
 - `crates/apr-cli/` - CLI logic (82 commands)
 - `src/bin/apr.rs` - Root binary entry point (`cargo install aprender`)
-- `contracts/` - 1766 provable contracts (merged from all 20 repos)
+- `contracts/` - 1767 provable contracts (merged from all 20 repos)
 - `docs/specifications/aprender-monorepo-consolidation.md` - Monorepo spec
 
 ## APR CLI (`cargo install aprender`)

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ publishing — all backed by YAML provable contracts that fail CI on drift.
 | Metric | Count | Source of truth |
 |-------:|------:|---|
 | Workspace crates | **78** workspace crates | `cargo metadata --no-deps` (NOT `ls crates/` — 4 are `exclude`d, 1 has no Cargo.toml) |
-| Provable contracts | **1766** provable contracts | `find contracts/ -name '*.yaml'` |
+| Provable contracts | **1767** provable contracts | `find contracts/ -name '*.yaml'` |
 | CLI commands | **103** CLI commands | `apr --help` |
 | Book CLI chapters | **103** chapters | `ls book/src/cli/*.md` (parity with CLI) |
 | Book lib chapters | **69** chapters | `ls book/src/lib/*.md` (parity with `pub mod`) |
@@ -253,7 +253,7 @@ falsification_tests:
   prediction: apr validate bad-model.apr exits non-zero
 ```
 
-1766 contracts across inference, training, quantization, attention, FFN,
+1767 contracts across inference, training, quantization, attention, FFN,
 tokenization, model formats, CLI safety — and this README itself.
 
 ## Migration from old crates

--- a/contracts/ci-gate-integrity-v1.yaml
+++ b/contracts/ci-gate-integrity-v1.yaml
@@ -1,0 +1,97 @@
+metadata:
+  version: 1.0.0
+  created: '2026-07-29'
+  author: PAIML Engineering
+  description: "Gate integrity — the property that a CI check can actually turn RED. A gate that cannot fail on a real regression is worth negative EV: it consumes runner time, is counted as enforcement in every audit, and licenses the claim it was supposed to test. This contract owns the class of defects where a pass-detector matches a failing line."
+  kind: pattern
+  references:
+    - "scripts/check_pass_grep_anchored.sh — the ratchet"
+    - ".github/workflows/ci.yml — wired per-PR in guard-runner-labels (gate depends on it)"
+    - "PMAT-CI-PASSGREP-001 (#2298) — the first instance: `grep -q \"test result.*0 failed\"` matched \"10 failed\""
+    - "docs/specifications/roadmap-next-wave-2026-07-05.md — enforcement-integrity ranks above adding beats"
+
+five_whys:
+  symptom: "ci.yml's aprender-compute gate used `grep -q \"test result.*0 failed\"`. A summary reading 'test result: FAILED. 90 passed; 10 failed' CONTAINS the substring '0 failed', so runs with 10, 20, 30, ... failures merged GREEN. aprender-compute is excluded from the main nextest, so this grep was the sole gate for its lib failures."
+  why_1: "The pass-detector was written as a substring match against a decimal count, and no decimal count is a safe substring: every count ending in 0 contains '0'."
+  why_2: "The check was never run against a failing input. It was reviewed by reading, and reading a regex is exactly the activity a substring bug defeats."
+  why_3: "PMAT-CI-PASSGREP-001 fixed the one instance it found by inspection. Nothing scanned for siblings, so two more survived — including FALSIFY-QWEN-STORY-007, a contract falsifier, where the failure is invisible because the contract reports itself as passing."
+  why_4: "There is no mechanized notion of 'this gate demonstrably turns red'. Gates are added with a green run as evidence, and a green run is equally consistent with a correct gate and a vacuous one."
+  why_5: "Enforcement was audited by counting gates rather than by falsifying them."
+  root_cause: "Pass-detection was trusted on inspection instead of probed. The remedy is empirical: extract every zero-count pass-grep in the tree and run it against a line in which every count is non-zero. A pass-detector that matches an all-failing line fails open by definition — no reasoning about anchors, word boundaries or leading spaces is required."
+
+equations:
+  pass_grep_rejects_failure:
+    formula: "for every zero-count pass-grep P in the tree: match(P, all_failing_probe) == false"
+    domain: "grep patterns extracted from .github/workflows, contracts/, scripts/, Makefile that assert a zero count of error|fail|warn|issue|violation|problem"
+    codomain: "boolean per pattern; exit 1 if any pattern matches the probe"
+    invariants:
+      - "The probe carries a non-zero count for every keyword the extractor recognises"
+      - "A pattern that matches the probe cannot turn RED on that failure mode — it is reported with file:line"
+      - "Comment lines are out of scope: a commented-out grep is not a gate"
+      - "The checker excludes itself — its header quotes the historical bad patterns as documentation"
+
+  checker_is_not_vacuous:
+    formula: "checked_pattern_count >= MIN_EXPECTED"
+    domain: "the count of in-scope patterns the extractor located on this tree"
+    codomain: "exit code of scripts/check_pass_grep_anchored.sh"
+    invariants:
+      - "A checker that silently examines nothing prints the same OK as one that examined everything"
+      - "If the extraction regex rots or the search paths move, the check goes RED rather than reporting success on an empty set"
+      - "MIN_EXPECTED is overridable by environment only so the self-test can scan a one-file fixture"
+
+proof_obligations:
+  - type: invariant
+    property: "No pass-grep in the tree matches an all-failing line"
+    formal: "scripts/check_pass_grep_anchored.sh exits 0"
+    applies_to: pass_grep_rejects_failure
+  - type: invariant
+    property: "The checker can turn RED"
+    formal: "Given the pre-#2298 ci.yml pattern, the checker exits non-zero"
+    applies_to: pass_grep_rejects_failure
+  - type: invariant
+    property: "The checker is not vacuous"
+    formal: "The checker fails when it locates fewer than MIN_EXPECTED in-scope patterns"
+    applies_to: checker_is_not_vacuous
+  - type: invariant
+    property: "The checker is enforced per-PR, not merely present"
+    formal: "ci.yml invokes the checker in a job that `gate` depends on"
+    applies_to: pass_grep_rejects_failure
+
+falsification_tests:
+  - id: FALSIFY-CI-GATE-INTEGRITY-001
+    rule: "The ratchet exists and is executable"
+    prediction: "scripts/check_pass_grep_anchored.sh is a regular file with the execute bit set"
+    test: "test -x scripts/check_pass_grep_anchored.sh"
+    if_fails: "The ratchet was deleted or unmarked — the pass-grep class is unguarded again"
+
+  - id: FALSIFY-CI-GATE-INTEGRITY-002
+    rule: "No zero-count pass-grep in the tree matches an all-failing line"
+    prediction: "The ratchet exits 0 on the current tree"
+    test: "bash scripts/check_pass_grep_anchored.sh"
+    if_fails: "A pass-detector matches a line in which every count is non-zero — it cannot turn RED on that failure mode. The report names the file:line and the pattern."
+
+  - id: FALSIFY-CI-GATE-INTEGRITY-003
+    rule: "The ratchet demonstrably turns RED (mutation-verified, not merely green)"
+    prediction: "Fed the exact pattern that shipped in ci.yml before PMAT-CI-PASSGREP-001, the ratchet exits non-zero"
+    test: "bash scripts/check_pass_grep_anchored.sh --self-test"
+    if_fails: "The ratchet has itself become vacuous — it accepts the very pattern that merged 10 test failures GREEN"
+
+  - id: FALSIFY-CI-GATE-INTEGRITY-004
+    rule: "The ratchet is wired into the per-PR gate, not merely present in the tree"
+    prediction: "ci.yml invokes check_pass_grep_anchored.sh in guard-runner-labels, which `gate` lists in its needs"
+    test: "grep -q 'check_pass_grep_anchored.sh' .github/workflows/ci.yml"
+    if_fails: "A reference is not an execution — the ratchet would sit unexecuted while being counted as enforcement (the #2327 defect class)"
+
+  - id: FALSIFY-CI-GATE-INTEGRITY-005
+    rule: "The ratchet fails closed when it finds nothing to check"
+    prediction: "With MIN_EXPECTED set above the number of patterns present, the ratchet exits non-zero"
+    test: "! MIN_EXPECTED=9999 bash scripts/check_pass_grep_anchored.sh >/dev/null 2>&1"
+    if_fails: "The ratchet would report OK on an empty set — a blind checker is indistinguishable from a clean tree"
+
+qa_gate:
+  id: F-CI-GATE-INTEGRITY-001
+  name: "CI gate integrity — every pass-detector must be able to fail"
+  description: "Probes every zero-count pass-grep in the workflow, contract, script and Makefile surface against a line in which every count is non-zero. Empirical rather than syntactic: the probe settles whether a pattern can turn red, so no heuristic about regex anchoring is needed."
+  checks:
+    - "pass_grep_rejects_failure"
+    - "checker_is_not_vacuous"

--- a/contracts/qwen-story-v1.yaml
+++ b/contracts/qwen-story-v1.yaml
@@ -116,7 +116,7 @@ falsification_tests:
   - id: FALSIFY-QWEN-STORY-007
     rule: "Bashrs lints clean"
     prediction: "bashrs lint reports 0 errors on the story script"
-    test: "bashrs lint scripts/qwen-story.sh 2>&1 | grep -qE '0 error'"
+    test: "bashrs lint scripts/qwen-story.sh 2>&1 | grep -qE '(^|[^0-9])0 error'"
     if_fails: "Shell script quality regression — could shell-inject in CI"
 
   - id: FALSIFY-QWEN-STORY-008

--- a/scripts/check_pass_grep_anchored.sh
+++ b/scripts/check_pass_grep_anchored.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# check_pass_grep_anchored.sh - every "zero-count" pass-grep must actually turn RED.
+#
+# PMAT-CI-PASSGREP-001 closed ONE instance of this defect (ci.yml's
+# `grep -q "test result.*0 failed"`, which matched "10 failed" and merged a run
+# with 10 failures GREEN). The pattern is a CLASS, not an incident: two more
+# live instances survived that fix - `contracts/qwen-story-v1.yaml`'s
+# FALSIFY-QWEN-STORY-007 (`grep -qE '0 error'`, satisfied by "10 error(s)") and
+# `scripts/dogfood-book.sh` - so a point fix is not enough. This is the ratchet.
+#
+# METHOD: empirical, not syntactic. Regex-linting regexes is brittle; instead we
+# extract each pass-grep pattern from the tree and RUN it against a synthetic
+# line in which every count is non-zero. A pass-detector that matches an
+# all-failing line fails open, by definition. No heuristic about anchors,
+# word boundaries, or leading spaces is required - the probe settles it.
+#
+# Exit 0 = every pass-grep correctly rejects the failing probe.
+# Exit 1 = at least one pass-grep fails open (prints file:line and the pattern).
+
+set -euo pipefail
+
+SELF_PATH="$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
+
+cd "$(dirname "$0")/.." || exit 1
+
+# --self-test: prove this checker can turn RED, using the exact pattern that
+# shipped in ci.yml before PMAT-CI-PASSGREP-001. A gate nobody has ever seen
+# fail is indistinguishable from a gate that cannot fail.
+if [ "${1:-}" = "--self-test" ]; then
+    TMP=$(mktemp -d)
+    cleanup_selftest() {
+        if [ -n "$TMP" ] && [ "$TMP" != / ]; then
+            rm -rf "$TMP"
+        fi
+    }
+    trap cleanup_selftest EXIT
+    mkdir -p "$TMP/scripts" "$TMP/contracts" "$TMP/.github/workflows"
+    touch "$TMP/Makefile"
+    cp "$SELF_PATH" "$TMP/scripts/"
+    # The pre-PMAT-CI-PASSGREP-001 ci.yml line, verbatim.
+    HISTORICAL='grep -q "test result.*0 failed" out.log'
+    printf '%s\n' "$HISTORICAL" > "$TMP/scripts/historical_pattern.sh"
+    if (cd "$TMP" && MIN_EXPECTED=1 bash scripts/check_pass_grep_anchored.sh >/dev/null 2>&1); then
+        printf 'SELF-TEST FAILED: the checker accepted `grep -q "test result.*0 failed"`,\n' >&2
+        printf 'the exact pattern that merged 10 test failures GREEN (PMAT-CI-PASSGREP-001).\n' >&2
+        exit 1
+    fi
+    printf 'self-test OK: the checker turns RED on the PMAT-CI-PASSGREP-001 pattern.\n'
+    exit 0
+fi
+
+# A line in which EVERY count is non-zero. Any pattern claiming to detect
+# "zero errors / zero failures / zero warnings" must NOT match this.
+PROBE='Summary: 10 error(s), 20 warning(s), 30 info(s) :: test result: FAILED. 90 passed; 10 failed; 40 ignored'
+
+# Zero-count pass-detector keywords. A grep pattern mentioning one of these is
+# asserting "none of these happened" and is therefore in scope.
+KEYWORDS='0 error|0 fail|0 warn|0 issue|0 violation|0 problem'
+
+SEARCH_PATHS=(.github/workflows contracts scripts Makefile)
+
+# Known zero-count pass-greps in the tree at the time of writing. If the
+# extractor finds fewer than this, it has gone blind - see the tail of this
+# script.
+MIN_EXPECTED="${MIN_EXPECTED:-2}"
+
+VIOLATIONS=0
+CHECKED=0
+
+# Pull the quoted pattern out of a grep invocation. Handles the two forms used
+# in this tree: grep -q'X' with single quotes and with double quotes. Emits one
+# pattern per line.
+extract_patterns() {
+    # Two passes rather than one, so neither sed script needs escaped quotes:
+    # the single-quote form is written inside double quotes and vice versa.
+    sed -nE "s/.*grep[[:space:]]+(-[A-Za-z]+[[:space:]]+)*'([^']*)'.*/\2/p" "$1"
+    # shellcheck disable=SC2016
+    sed -nE 's/.*grep[[:space:]]+(-[A-Za-z]+[[:space:]]+)*"([^"]*)".*/\2/p' "$1"
+}
+
+SELF="scripts/check_pass_grep_anchored.sh"
+
+while IFS= read -r hit; do
+    file="${hit%%:*}"
+    rest="${hit#*:}"
+    lineno="${rest%%:*}"
+
+    # This checker's own header quotes the historical bad patterns verbatim as
+    # documentation; they are prose, not gates.
+    [ "$file" = "$SELF" ] && continue
+
+    # Re-read just this line and pull its grep pattern(s) out.
+    line_text=$(sed -n "${lineno}p" "$file")
+
+    trimmed=$(printf '%s' "$line_text" | sed 's/^[[:space:]]*//')
+
+    # A commented-out grep is not a gate.
+    case "$trimmed" in
+        '#'*) continue ;;
+        *) ;;
+    esac
+
+    # In a contract, only the `test:` field is executed by `pv`. Everything
+    # else - five_whys, references, if_fails - is prose, and prose routinely
+    # quotes the very bad patterns this checker exists to describe. Scanning it
+    # would make the gate fire on its own documentation.
+    case "$file" in
+        contracts/*)
+            case "$trimmed" in
+                test:*) ;;
+                *) continue ;;
+            esac
+            ;;
+        *) ;;
+    esac
+    patterns=$(printf '%s\n' "$line_text" | extract_patterns /dev/stdin || true)
+
+    [ -z "$patterns" ] && continue
+
+    while IFS= read -r pat; do
+        [ -z "$pat" ] && continue
+        # Only patterns that actually assert a zero count are in scope.
+        printf '%s\n' "$pat" | grep -qE "$KEYWORDS" || continue
+
+        CHECKED=$((CHECKED + 1))
+
+        # THE PROBE. If a "zero errors" detector matches an all-failing line,
+        # it can never turn red on that failure mode.
+        if printf '%s\n' "$PROBE" | grep -qE -- "$pat" 2>/dev/null; then
+            VIOLATIONS=$((VIOLATIONS + 1))
+            printf 'FAIL-OPEN %s:%s\n' "$file" "$lineno"
+            printf '          pattern: %s\n' "$pat"
+            printf '          matches: %s\n' "$PROBE"
+            printf '          fix: anchor the count, e.g. (^|[^0-9])0 error\n'
+        fi
+    done <<EOF
+$patterns
+EOF
+done <<EOF
+$(grep -rnE "grep.*($KEYWORDS)" "${SEARCH_PATHS[@]}" 2>/dev/null || true)
+EOF
+
+if [ "$VIOLATIONS" -gt 0 ]; then
+    printf '\n%s pass-grep(s) fail open (of %s checked).\n' "$VIOLATIONS" "$CHECKED" >&2
+    printf 'A gate that cannot turn RED on a real regression is worth negative EV.\n' >&2
+    exit 1
+fi
+
+# Fail-closed observability (the lesson of the dark beat lane): a checker that
+# silently examines NOTHING reports the same "OK" as one that examined
+# everything. If the extraction regex rots, or the search paths move, this
+# must go red rather than congratulate itself on an empty set.
+if [ "$CHECKED" -lt "$MIN_EXPECTED" ]; then
+    printf 'ERROR: only %s pass-grep(s) found (expected >= %s).\n' \
+        "$CHECKED" "$MIN_EXPECTED" >&2
+    printf 'The extractor probably stopped matching - this check is now vacuous.\n' >&2
+    exit 1
+fi
+
+printf 'OK: %s zero-count pass-grep(s) checked, all correctly reject a failing line.\n' "$CHECKED"

--- a/scripts/dogfood-book.sh
+++ b/scripts/dogfood-book.sh
@@ -90,7 +90,7 @@ fi
 # ---------------------------------------------------------------------------
 step "Phase 4: contract validity"
 if pv validate contracts/apr-book-completeness-v1.yaml > /tmp/dogfood-pv.log 2>&1; then
-  if grep -q "0 error(s), 0 warning(s)" /tmp/dogfood-pv.log; then
+  if grep -qE '(^|[^0-9])0 error\(s\), 0 warning\(s\)' /tmp/dogfood-pv.log; then
     pass "pv validate apr-book-completeness-v1.yaml: clean"
   else
     warn "pv validate has warnings (non-blocking)"


### PR DESCRIPTION
## The class, not the incident

#2298 killed `ci.yml`'s `grep -q "test result.*0 failed"` — a pattern satisfied by the substring inside `"10 failed"`, so runs with 10/20/30/… test failures merged **green**. It fixed that one line by inspection. Nothing scanned for siblings, and two were live:

| location | pattern |
|---|---|
| `contracts/qwen-story-v1.yaml:119` (FALSIFY-QWEN-STORY-007) | `bashrs lint … \| grep -qE '0 error'` |
| `scripts/dogfood-book.sh:93` | `grep -q "0 error(s), 0 warning(s)"` |

Demonstrated rather than argued — a copy of `qwen-story.sh` with ten real bashrs errors appended:

```
$ bashrs lint /tmp/m10.sh | tail -1
Summary: 10 error(s), 48 warning(s), 89 info(s)

$ bashrs lint /tmp/m10.sh | grep -qE '0 error'           ; echo $?
0     <- FALSIFY-QWEN-STORY-007 passes a script with 10 errors

$ bashrs lint /tmp/m10.sh | grep -qE '(^|[^0-9])0 error' ; echo $?
1     <- correctly red
```

The contract one is the worse of the two: the failure is invisible by construction, because the contract reports itself as passing.

## The ratchet

`scripts/check_pass_grep_anchored.sh` — **empirical, not syntactic**. Linting regexes for correct anchoring is brittle, and reading a regex is precisely the activity a substring bug defeats. So every zero-count pass-grep in `.github/workflows`, `contracts/`, `scripts/` and the `Makefile` is extracted and *run* against a probe line in which every count is non-zero. A pass-detector that matches an all-failing line fails open, by definition — no reasoning about anchors or word boundaries needed.

Verified in five directions:

| leg | result |
|---|---|
| normal | exit 0, `2 zero-count pass-grep(s) checked` |
| mutation | revert either fix → exit 1, naming file:line + pattern |
| historical | fed the pre-#2298 `ci.yml` pattern → exit 1 (`--self-test`) |
| fail-closed | `MIN_EXPECTED` unmet → exit 1, not OK-on-empty-set |
| no false-positive | a bad pattern quoted in contract *prose* is not flagged — in a contract only `test:` executes, so only `test:` is scanned |

The fail-closed leg matters as much as the probe: a checker that silently examines nothing prints the same `OK` as one that examined everything — the same defect in a new place. That is also why `--self-test` exists. **A gate nobody has ever seen fail is indistinguishable from a gate that cannot fail.**

## Enforcement

Wired per-PR in `ci.yml`'s `guard-runner-labels`, which `gate` lists in its `needs`, alongside `check_runner_labels.sh` and `check_beats_gated.sh`. Pure text check, no build — costs no extra runner.

New contract `contracts/ci-gate-integrity-v1.yaml` (`pv validate`: 0 errors, 0 warnings) owns the class: 2 equations, 4 proof obligations, 5 falsifiers — all five executed and passing. `FALSIFY-CI-GATE-INTEGRITY-003` *is* the mutation check, so "this gate can turn red" is a standing assertion rather than a claim in a PR description.

`bashrs lint` on the new script: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)