### PR TITLE
fix(ci): qwen-story-daily could not fail — it captured tee's exit code, not the story's

### DIFF
--- a/.github/workflows/qwen-story-daily.yml
+++ b/.github/workflows/qwen-story-daily.yml
@@ -64,10 +64,25 @@ jobs:
       - name: Run scripts/qwen-story.sh
         id: story
         continue-on-error: true
+        # `$?` after a pipeline is the LAST command's status - tee's - not the
+        # script's. GitHub's DEFAULT shell is `bash -e {0}`, WITHOUT pipefail
+        # (only an explicit `shell: bash` yields `-eo pipefail`), and `set +e`
+        # above disables even errexit. So this step reported exit_code=0 for
+        # every run since the cron was added: the "Fail the job" step at the
+        # bottom and the issue-filing step were both unreachable, and three
+        # consecutive green runs proved nothing.
+        #
+        # ${PIPESTATUS[0]} reads the FIRST pipeline element's status directly
+        # and does not depend on any shell default. `set -o pipefail` is kept
+        # as belt-and-braces so the step is correct under either reading.
+        # This is the same pipe-then-$? defect scripts/qwen-story.sh:17-18
+        # already warns about in its own header.
+        shell: bash
         run: |
           set +e
+          set -o pipefail
           bash scripts/qwen-story.sh 2>&1 | tee /tmp/story.log
-          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+          echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
 
       - name: Extract pmat bug-hunt manifest
         id: manifest

--- a/contracts/qwen-story-v1.yaml
+++ b/contracts/qwen-story-v1.yaml
@@ -119,6 +119,18 @@ falsification_tests:
     test: "bashrs lint scripts/qwen-story.sh 2>&1 | grep -qE '0 error'"
     if_fails: "Shell script quality regression — could shell-inject in CI"
 
+  - id: FALSIFY-QWEN-STORY-009
+    rule: "The daily cron reports the STORY's exit code, not the pipeline's last element"
+    prediction: "qwen-story-daily.yml captures ${PIPESTATUS[0]}, never a bare $? after the tee pipeline"
+    test: "grep -qF 'exit_code=${PIPESTATUS[0]}' .github/workflows/qwen-story-daily.yml"
+    if_fails: "The cron captures tee's status instead of the story's. exit_code is then permanently 0, the 'Fail the job' step and the issue-filing step are both unreachable, and every run is green regardless of how many beats FAILed - the story becomes a daily light that cannot turn red."
+
+  - id: FALSIFY-QWEN-STORY-010
+    rule: "The exit-code idiom is semantically correct under GitHub's DEFAULT shell"
+    prediction: "Under `bash -e` with `set +e` - what a run: step without an explicit `shell:` key gets - reading ${PIPESTATUS[0]} after `(exit 2) | tee` yields 2, whereas a bare $? yields 0"
+    test: "[ \"$(bash -e -c 'set +e; (exit 2) | tee /dev/null >/dev/null; echo ${PIPESTATUS[0]}')\" = '2' ] && [ \"$(bash -e -c 'set +e; (exit 2) | tee /dev/null >/dev/null; echo $?')\" = '0' ]"
+    if_fails: "The premise behind FALSIFY-QWEN-STORY-009 no longer holds on this bash - re-derive which idiom propagates the status before trusting the cron's verdict."
+
   - id: FALSIFY-QWEN-STORY-008
     rule: "Beat 7 doesn't run apr qa on 7B (known #1864 regression)"
     prediction: "Beat 7 calls profile/gpu/serve plan but NOT apr qa on the 7B model"

--- a/scripts/qwen-story.sh
+++ b/scripts/qwen-story.sh
@@ -49,6 +49,20 @@ run_cmd() {
   RC_TAIL=$(echo "$RC_OUT" | tail -1)
 }
 
+# Print the captured output of the last run_cmd, indented, so it survives into
+# the story log (and therefore into the `story-log` CI artifact).
+#
+# run_cmd deliberately captures into a variable rather than letting output
+# stream, which is what makes the OUT=$(cmd); EC=$? methodology work - but it
+# also means nothing a command printed was ever retained. The qa gate table in
+# particular has never reached an artifact: a downloaded story-log contains
+# "PASS  B2 apr qa" and not one word about which gates ran, skipped or failed.
+# A verdict with no evidence behind it cannot be audited after the fact.
+emit_evidence() {
+  printf '    -- captured output (%s) --\n' "$1"
+  printf '%s\n' "$RC_OUT" | sed 's/^/    /'
+}
+
 # Run pmat full audit on a list of command module patterns. Outputs a compact
 # manifest (top 3 high-risk untested functions, top 3 churn, top 3 faults).
 pmat_hunt() {
@@ -99,6 +113,12 @@ beat2_trust() {
   fi
   # Use 1.5B APR (apr qa Golden Output gate works on this; 7B has #1864).
   run_cmd 180 apr qa "$M_15B_APR"
+  # Retain the per-gate table regardless of verdict - it is the only record of
+  # which gates actually executed versus SKIPped, and `apr qa` prints
+  # "ALL GATES PASSED" even when gates skipped (GateResult::skipped sets
+  # passed:true). The grep below therefore cannot distinguish "everything ran
+  # and passed" from "half of it skipped".
+  emit_evidence "apr qa $M_15B_APR"
   if echo "$RC_OUT" | grep -q "ALL GATES PASSED"; then
     emit_pass "B2 apr qa"
   else


### PR DESCRIPTION
## A daily light that cannot turn red

`.github/workflows/qwen-story-daily.yml:69-70`:

```bash
set +e
bash scripts/qwen-story.sh 2>&1 | tee /tmp/story.log
echo "exit_code=$?" >> "$GITHUB_OUTPUT"
```

`$?` after a pipeline is the **last** element's status — `tee`'s — not the script's. GitHub's *default* shell is `bash -e {0}`, **without** pipefail; only an explicit `shell: bash` yields `-eo pipefail`. This step has no `shell:` key, the workflow has no `defaults:`, and line 68's `set +e` disables even errexit. So `exit_code` was permanently `0`.

Both consumers of that output are therefore unreachable:

| line | step | condition |
|---|---|---|
| `:147` | Fail the job if the story failed | `exit_code != '0'` |
| `:108` | File / update the tracking issue | `exit_code != '0' \|\| growth > 5` |

`qwen-story.sh:334` does `exit 2` when any beat FAILs. That signal has been discarded on every run since the cron was added. The last three scheduled runs are green and **prove nothing**.

## Verified by simulating both step bodies against a stub story that exits 2

```
OLD (bash -e, bare $?)              -> exit_code=0   job GREEN
NEW (shell: bash, ${PIPESTATUS[0]}) -> exit_code=2   job RED
```

`${PIPESTATUS[0]}` reads the first pipeline element directly and does not depend on any shell default; `set -o pipefail` and `shell: bash` are kept so the step is correct under either reading.

This is the same pipe-then-`$?` defect that `scripts/qwen-story.sh:17-18` already warns about in its own header — the script avoided it internally and the workflow reintroduced it at the boundary.

## Second defect: no gate-level evidence was retained

`run_cmd` captures output into `RC_OUT` (correctly — that is what makes the `OUT=$(cmd); EC=$?` methodology work) and nothing ever printed it. The downloaded `story-log` artifact for run 30429310693 contains `PASS  B2 apr qa` and not one word about which gates ran, skipped or failed.

Adds `emit_evidence()` and calls it for the qa beat so the per-gate table reaches the artifact regardless of verdict. That table matters here specifically: `apr qa` prints `ALL GATES PASSED` whenever `report.passed`, and `GateResult::skipped` sets `passed: true`, so the `:102` grep cannot distinguish *"everything ran and passed"* from *"half of it skipped"*. Retaining the table makes that distinction auditable after the fact; making it **fail** is separate work (`PMAT-QA-FMTPARITY-DECODE-001`).

## Falsifiers

| id | asserts |
|---|---|
| `FALSIFY-QWEN-STORY-009` | the cron captures `${PIPESTATUS[0]}`, never a bare `$?` |
| `FALSIFY-QWEN-STORY-010` | that idiom is semantically correct on this bash — and the bare-`$?` form demonstrably is not |

009 is a shape check; 010 is what makes it meaningful, by pinning the shell semantics 009 depends on. Existing 002/003/004/007 re-run and still pass. `pv validate`: 0 errors, 0 warnings. `bashrs lint`: 0 errors.

Scanned every workflow for the same pipe-then-`$?` pattern — this was the **only** instance, so generalizing it into a scanner alongside the pass-grep ratchet in #2335 is follow-up, not needed for a one-member class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)