### PR TITLE
feat(qa): format_parity compared ONE token — now it compares 64 decode steps

### DIFF
--- a/contracts/apr-cli-qa-v1.yaml
+++ b/contracts/apr-cli-qa-v1.yaml
@@ -54,6 +54,25 @@ equations:
     - "An EXPLICIT --safetensors-path that does not exist still FAILs (user requested a specific reference)"
     - "A reference that IS present but whose outputs diverge still FAILs — the SKIP never swallows a real bug"
 
+  format_parity_compares_decode_not_one_prefill:
+    formula: |
+      apr qa GGUF_MODEL with a usable SafeTensors reference:
+        steps_compared >= 64
+        AND every step is produced by the PRODUCTION cache entry point
+            (forward_single_with_cache / forward_with_cache)
+        AND both sides are teacher-forced with the SAME token each step
+        AND top-1 must agree at every step, except where
+            cosine(logits_gguf, logits_st) >= 0.98 (near-tie exemption)
+    domain: "apr qa format_parity gate, GGUF primary with a convertible SafeTensors reference"
+    codomain: "GateResult { value = steps agreed, threshold = steps compared }"
+    invariants:
+    - "At least 64 decode steps are compared - the gate this replaced ran ONE prefill forward and compared a single final-position argmax, so a divergence appearing at decode step 32 was structurally invisible to it"
+    - "--max-tokens cannot shrink the comparison below the 64-step floor; a smaller request is raised to the floor, a larger one is honored"
+    - "Both formats are driven through the SAME cache path production uses, so a KV-cache indexing or write defect is inside the system under test rather than bypassed by re-prefilling"
+    - "Teacher forcing keeps both sides on one shared sequence: without it the first disagreement would put the two formats on different sequences and every later step would compare unrelated distributions"
+    - "A top-1 disagreement whose logit vectors are cosine >= 0.98 is a floating-point near-tie, not a structural divergence, and is exempted - without this the gate flakes on tied logits while proving nothing about the cache"
+    - "A structural divergence FAILs the gate and names the step, so the failure is actionable"
+
   json_validity:
     formula: |
       forall cmd in JSON_COMMANDS:
@@ -199,6 +218,18 @@ falsification_tests:
   test: "cargo test -p apr-cli --lib resolve_safetensors_explicit_path_is_honored_not_skipped"
   if_fails: "the absent-reference SKIP swallowed a real format divergence"
 
+- id: FALSIFY-QA-013
+  rule: "format_parity compares at least 64 DECODE steps, not one prefill argmax (PMAT-QA-FMTPARITY-DECODE-001)"
+  prediction: "the decode floor is >= 64 and --max-tokens cannot lower it"
+  test: "cargo test -p apr-cli --lib -- format_parity_decode_floor_is_at_least_64_steps max_tokens_cannot_shrink_decode_below_the_floor"
+  if_fails: "the gate has reverted to the single-forward shape - a cached-decode divergence at step 32 becomes invisible again while the gate still reports itself as cross-format parity"
+
+- id: FALSIFY-QA-014
+  rule: "a divergence appearing only after many decode steps FAILs the gate (PMAT-QA-FMTPARITY-DECODE-001)"
+  prediction: "a report whose first divergence is at step 32 yields passed=false, skipped=false, and a message naming the step"
+  test: "cargo test -p apr-cli --lib -- decode_parity_late_divergence_fails_the_gate decode_parity_all_steps_agreed_passes decode_parity_near_ties_do_not_fail_the_gate"
+  if_fails: "late divergence is swallowed - exactly the class (PMAT-810 batched-prefill decode corruption, GH-1864) the gate exists to catch"
+
 proof_obligations:
 - type: invariant
   property: "all 58 commands exit 0 on --help"
@@ -208,6 +239,8 @@ proof_obligations:
   property: "JSON output is always valid"
 - type: invariant
   property: "format_parity SKIPs on a genuinely absent SafeTensors reference, FAILs on a present-but-diverging one (PMAT-815)"
+- type: invariant
+  property: "format_parity compares >= 64 greedy decode steps through the production cache path, teacher-forced, with a cosine >= 0.98 near-tie exemption (PMAT-QA-FMTPARITY-DECODE-001)"
 
 kani_harnesses:
 - id: KH-QA-001

--- a/crates/apr-cli/src/commands/forward_error.rs
+++ b/crates/apr-cli/src/commands/forward_error.rs
@@ -232,8 +232,197 @@ fn compute_argmax(logits: &[f32]) -> Option<u32> {
         .map(|(idx, _)| idx as u32)
 }
 
+/// Minimum decode steps the cross-format parity gate must compare.
+///
+/// PMAT-QA-FMTPARITY-DECODE-001. The gate previously ran ONE prefill forward per
+/// format and compared a single final-position argmax, so every cached-decode
+/// divergence — the class that actually ships (PMAT-810 'CertainlyCertainly',
+/// GH-1864) — was structurally invisible to it. 64 is the roadmap floor, chosen
+/// because cache-indexing bugs typically surface tens of tokens in, not at
+/// step 0.
+#[cfg(feature = "inference")]
+const FORMAT_PARITY_MIN_DECODE_STEPS: usize = 64;
+
+/// Cosine similarity of two logit vectors.
+///
+/// Used only to exempt NEAR-TIES: when the two formats' top-1 differ but the
+/// full distributions are essentially the same vector, the disagreement is
+/// floating-point noise between two legitimately-close candidates rather than a
+/// structural divergence. Without this the gate would flake on models with tied
+/// logits while telling us nothing about cache correctness.
+#[cfg(feature = "inference")]
+fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
+    if a.len() != b.len() || a.is_empty() {
+        return 0.0;
+    }
+    let mut dot = 0.0f64;
+    let mut na = 0.0f64;
+    let mut nb = 0.0f64;
+    for (&x, &y) in a.iter().zip(b.iter()) {
+        dot += f64::from(x) * f64::from(y);
+        na += f64::from(x) * f64::from(x);
+        nb += f64::from(y) * f64::from(y);
+    }
+    if na <= 0.0 || nb <= 0.0 {
+        return 0.0;
+    }
+    (dot / (na.sqrt() * nb.sqrt())) as f32
+}
+
+/// Cosine floor above which a top-1 disagreement counts as a near-tie.
+#[cfg(feature = "inference")]
+const FORMAT_PARITY_NEAR_TIE_COSINE: f32 = 0.98;
+
+/// Outcome of a lockstep cross-format decode comparison.
+#[cfg(feature = "inference")]
+struct DecodeParityReport {
+    /// Decode steps actually compared (excludes prefill).
+    steps: usize,
+    /// Steps whose top-1 agreed outright.
+    agreed: usize,
+    /// Steps whose top-1 differed but whose logit vectors were near-identical.
+    near_ties: usize,
+    /// First structural divergence: (step, gguf_argmax, st_argmax, cosine).
+    first_divergence: Option<(usize, u32, u32, f32)>,
+}
+
+/// Greedy-decode both formats in lockstep through their PRODUCTION cache paths
+/// and compare top-1 at every step.
+///
+/// Two design points that decide whether this proves anything:
+///
+/// 1. **Teacher forcing.** Both sides are fed the SAME next token (the GGUF
+///    argmax) rather than each following its own. If each free-ran, the first
+///    disagreement would put them on different sequences and every later step
+///    would compare unrelated distributions — the comparison would degrade into
+///    noise exactly when it matters most. Teacher forcing keeps all N steps on
+///    one shared sequence, so a divergence at step k is attributable to step k.
+///
+/// 2. **The cache path, not a re-prefill.** Both sides use the same
+///    single-token-plus-cache entry point production uses
+///    (`forward_single_with_cache` / `forward_with_cache`), so a KV-cache
+///    indexing or write bug is inside the system under test. Re-running a full
+///    prefill per step would be simpler and would test the wrong thing.
+#[cfg(feature = "inference")]
+fn lockstep_decode_parity(
+    gguf: &realizar::gguf::OwnedQuantizedModel,
+    st: &realizar::ValidatedAprTransformer,
+    prompt_tokens: &[u32],
+    steps: usize,
+) -> Result<DecodeParityReport> {
+    use realizar::apr_transformer::AprKVCache;
+    use realizar::gguf::OwnedQuantizedKVCache;
+
+    let max_seq = prompt_tokens.len() + steps + 1;
+
+    // from_config (not ::new) — it derives kv_dim as num_kv_heads * head_dim.
+    // Passing hidden_dim would over-allocate and mis-stride on any GQA model,
+    // and Qwen2.5-1.5B (12 query heads, 2 KV heads) is exactly that.
+    let mut gguf_cache = OwnedQuantizedKVCache::from_config(gguf.config(), max_seq);
+    let mut st_cache = AprKVCache::new(&st.config);
+
+    let mut gguf_logits = Vec::new();
+    let mut st_logits = Vec::new();
+
+    // Prefill: feed the prompt one token at a time so both caches are populated
+    // by the same code path that will serve the decode steps.
+    for (pos, &tok) in prompt_tokens.iter().enumerate() {
+        gguf_logits = gguf
+            .forward_single_with_cache(tok, &mut gguf_cache, pos)
+            .map_err(|e| {
+                CliError::ValidationFailed(format!("GGUF prefill failed at pos {pos}: {e}"))
+            })?;
+        st_logits = st
+            .forward_with_cache(tok, &mut st_cache, pos)
+            .map_err(|e| {
+                CliError::ValidationFailed(format!("SafeTensors prefill failed at pos {pos}: {e}"))
+            })?;
+    }
+
+    let mut report = DecodeParityReport {
+        steps: 0,
+        agreed: 0,
+        near_ties: 0,
+        first_divergence: None,
+    };
+
+    for step in 0..steps {
+        let Some(g_tok) = compute_argmax(&gguf_logits) else {
+            return Err(CliError::ValidationFailed(format!(
+                "GGUF produced no argmax at decode step {step}"
+            )));
+        };
+        let Some(s_tok) = compute_argmax(&st_logits) else {
+            return Err(CliError::ValidationFailed(format!(
+                "SafeTensors produced no argmax at decode step {step}"
+            )));
+        };
+
+        report.steps += 1;
+        if g_tok == s_tok {
+            report.agreed += 1;
+        } else {
+            let cos = cosine_similarity(&gguf_logits, &st_logits);
+            if cos >= FORMAT_PARITY_NEAR_TIE_COSINE {
+                report.near_ties += 1;
+            } else if report.first_divergence.is_none() {
+                report.first_divergence = Some((step, g_tok, s_tok, cos));
+            }
+        }
+
+        // Teacher-force both sides with the same token (see doc comment).
+        let pos = prompt_tokens.len() + step;
+        gguf_logits = gguf
+            .forward_single_with_cache(g_tok, &mut gguf_cache, pos)
+            .map_err(|e| {
+                CliError::ValidationFailed(format!("GGUF decode failed at step {step}: {e}"))
+            })?;
+        st_logits = st
+            .forward_with_cache(g_tok, &mut st_cache, pos)
+            .map_err(|e| {
+                CliError::ValidationFailed(format!("SafeTensors decode failed at step {step}: {e}"))
+            })?;
+    }
+
+    Ok(report)
+}
+
+/// Turn a lockstep decode comparison into the gate verdict.
+#[cfg(feature = "inference")]
+fn compare_decode_parity(report: &DecodeParityReport, duration: Duration) -> GateResult {
+    let matched = report.agreed + report.near_ties;
+    let total = report.steps as f64;
+
+    if let Some((step, g_tok, s_tok, cos)) = report.first_divergence {
+        return GateResult::failed(
+            "format_parity",
+            &format!(
+                "Cross-format decode DIVERGED at step {step}/{}: GGUF argmax={g_tok} != SafeTensors argmax={s_tok} (cosine={cos:.4} < {FORMAT_PARITY_NEAR_TIE_COSINE}). \
+                 {} of {} steps agreed ({} near-tie). A divergence this far into decode implicates the KV cache path, not the weights.",
+                report.steps, matched, report.steps, report.near_ties
+            ),
+            Some(matched as f64),
+            Some(total),
+            duration,
+        );
+    }
+
+    GateResult::passed(
+        "format_parity",
+        &format!(
+            "Cross-format parity VERIFIED over {} greedy decode steps through the cache path \
+             ({} exact top-1 matches, {} near-tie exemptions at cosine >= {FORMAT_PARITY_NEAR_TIE_COSINE})",
+            report.steps, report.agreed, report.near_ties
+        ),
+        Some(matched as f64),
+        Some(total),
+        duration,
+    )
+}
+
 /// Compare argmax values from GGUF and SafeTensors forward passes and produce
 /// the appropriate `GateResult`.
+#[allow(dead_code)]
 fn compare_argmax_results(
     gguf_argmax: Option<u32>,
     st_argmax: Option<u32>,
@@ -383,20 +572,13 @@ fn run_format_parity_gate(path: &Path, config: &QaConfig) -> Result<GateResult> 
         let bos = aprender::demo::SpecialTokens::qwen2().bos_id;
         let prompt_tokens: Vec<u32> = gguf.encode(prompt).unwrap_or_else(|| vec![bos, 9707]);
 
-        // Run GGUF forward pass to get logits
-        let gguf_logits = {
-            let mapped = MappedGGUFModel::from_path(path)
-                .map_err(|e| CliError::ValidationFailed(format!("GGUF map failed: {e}")))?;
-            let model = OwnedQuantizedModel::from_mapped(&mapped)
-                .map_err(|e| CliError::ValidationFailed(format!("GGUF model failed: {e}")))?;
-            model
-                .forward(&prompt_tokens)
-                .map_err(|e| CliError::ValidationFailed(format!("GGUF forward failed: {e}")))?
-        };
+        let mapped = MappedGGUFModel::from_path(path)
+            .map_err(|e| CliError::ValidationFailed(format!("GGUF map failed: {e}")))?;
+        let gguf_model = OwnedQuantizedModel::from_mapped(&mapped)
+            .map_err(|e| CliError::ValidationFailed(format!("GGUF model failed: {e}")))?;
 
-        // Run SafeTensors forward pass to get logits
-        let st_logits = match run_safetensors_forward(&safetensors_path, &prompt_tokens) {
-            Ok(logits) => logits,
+        let st_model = match load_safetensors_transformer(&safetensors_path) {
+            Ok(m) => m,
             Err(ForwardError::ConversionFailed(path)) => {
                 return Ok(GateResult::failed(
                     "format_parity",
@@ -409,12 +591,14 @@ fn run_format_parity_gate(path: &Path, config: &QaConfig) -> Result<GateResult> 
             Err(ForwardError::Cli(e)) => return Err(e),
         };
 
-        let duration = start.elapsed();
-        Ok(compare_argmax_results(
-            compute_argmax(&gguf_logits),
-            compute_argmax(&st_logits),
-            duration,
-        ))
+        // At least FORMAT_PARITY_MIN_DECODE_STEPS regardless of --max-tokens:
+        // the contract's claim is about decode-depth coverage, so a smaller
+        // --max-tokens must not be able to quietly shrink the gate back into the
+        // single-forward shape this replaced.
+        let steps = config.max_tokens.max(FORMAT_PARITY_MIN_DECODE_STEPS);
+        let report = lockstep_decode_parity(&gguf_model, &st_model, &prompt_tokens, steps)?;
+
+        Ok(compare_decode_parity(&report, start.elapsed()))
     }
 
     #[cfg(not(feature = "inference"))]
@@ -435,12 +619,15 @@ enum ForwardError {
     Cli(CliError),
 }
 
-/// Run SafeTensors forward pass, handling sharded and single-file models.
+/// Load the reference SafeTensors model, handling sharded and single-file layouts.
+///
+/// Split out of the old `run_safetensors_forward` so the caller can drive a
+/// multi-step cached decode against the SAME transformer instead of paying the
+/// (multi-second, multi-gigabyte) conversion once per forward pass.
 #[cfg(feature = "inference")]
-fn run_safetensors_forward(
+fn load_safetensors_transformer(
     safetensors_path: &Path,
-    prompt_tokens: &[u32],
-) -> std::result::Result<Vec<f32>, ForwardError> {
+) -> std::result::Result<realizar::ValidatedAprTransformer, ForwardError> {
     use realizar::safetensors_infer::SafetensorsToAprConverter;
     use realizar::{SafetensorsConfig, ShardedSafeTensorsModel};
 
@@ -457,8 +644,8 @@ fn run_safetensors_forward(
         SafetensorsToAprConverter::convert(safetensors_path)
     };
 
-    let model = match transformer {
-        Ok(t) => t,
+    match transformer {
+        Ok(t) => Ok(t),
         Err(e) => {
             // PMAT-743: ANY failure to load/convert the REFERENCE SafeTensors means
             // the parity comparison cannot run — that is a graceful GATE failure with
@@ -469,15 +656,12 @@ fn run_safetensors_forward(
             // whole `apr qa` run (exit 5). The diagnostic tool must survive a bad
             // reference and report it, not die. The error detail is preserved so the
             // user knows WHY (missing tensor, unsupported arch, corrupt weights, …).
-            return Err(ForwardError::ConversionFailed(format!(
+            Err(ForwardError::ConversionFailed(format!(
                 "{} ({e})",
                 safetensors_path.display()
-            )));
+            )))
         }
-    };
-
-    model.forward(prompt_tokens)
-        .map_err(|e| ForwardError::Cli(CliError::ValidationFailed(format!("SafeTensors forward failed: {e}"))))
+    }
 }
 
 fn check_ollama_available() -> bool {

--- a/crates/apr-cli/src/commands/forward_error_tests.rs
+++ b/crates/apr-cli/src/commands/forward_error_tests.rs
@@ -370,4 +370,125 @@ mod forward_error_tests {
             ),
         }
     }
+
+    // ========================================================================
+    // PMAT-QA-FMTPARITY-DECODE-001 — the gate must compare DECODE, not one
+    // prefill argmax.
+    // ========================================================================
+
+    /// The anti-theater assertion. The gate this replaced ran one forward per
+    /// format and compared a single final-position argmax; a cached-decode
+    /// divergence at step 32 was structurally invisible to it. If this floor is
+    /// ever lowered, the gate silently reverts to that shape while continuing
+    /// to report itself as cross-format parity.
+    #[test]
+    #[cfg(feature = "inference")]
+    fn format_parity_decode_floor_is_at_least_64_steps() {
+        assert!(
+            super::FORMAT_PARITY_MIN_DECODE_STEPS >= 64,
+            "the cross-format gate must compare at least 64 decode steps; \
+             found {}. Below this the gate cannot observe the cache-path \
+             divergence class it exists to catch.",
+            super::FORMAT_PARITY_MIN_DECODE_STEPS
+        );
+    }
+
+    /// `--max-tokens` must not be able to shrink the gate back below the floor.
+    #[test]
+    #[cfg(feature = "inference")]
+    fn max_tokens_cannot_shrink_decode_below_the_floor() {
+        for max_tokens in [0usize, 1, 8, 32, 63] {
+            let steps = max_tokens.max(super::FORMAT_PARITY_MIN_DECODE_STEPS);
+            assert!(
+                steps >= 64,
+                "--max-tokens {max_tokens} shrank the parity decode to {steps} steps"
+            );
+        }
+        // …but a LARGER request is still honored.
+        assert_eq!(128usize.max(super::FORMAT_PARITY_MIN_DECODE_STEPS), 128);
+    }
+
+    #[test]
+    #[cfg(feature = "inference")]
+    fn cosine_similarity_identical_vectors_is_one() {
+        let v = vec![0.5f32, -1.25, 3.0, 0.0];
+        let c = super::cosine_similarity(&v, &v);
+        assert!((c - 1.0).abs() < 1e-6, "expected 1.0, got {c}");
+    }
+
+    #[test]
+    #[cfg(feature = "inference")]
+    fn cosine_similarity_orthogonal_vectors_is_zero() {
+        let a = vec![1.0f32, 0.0];
+        let b = vec![0.0f32, 1.0];
+        assert!(super::cosine_similarity(&a, &b).abs() < 1e-6);
+    }
+
+    #[test]
+    #[cfg(feature = "inference")]
+    fn cosine_similarity_mismatched_lengths_is_zero_not_panic() {
+        assert_eq!(super::cosine_similarity(&[1.0, 2.0], &[1.0]), 0.0);
+        assert_eq!(super::cosine_similarity(&[], &[]), 0.0);
+    }
+
+    /// A clean run over the full step budget passes, and reports the budget as
+    /// the threshold so the summary table shows N/N rather than a token id.
+    #[test]
+    #[cfg(feature = "inference")]
+    fn decode_parity_all_steps_agreed_passes() {
+        let report = super::DecodeParityReport {
+            steps: 64,
+            agreed: 64,
+            near_ties: 0,
+            first_divergence: None,
+        };
+        let gate = super::compare_decode_parity(&report, Duration::from_millis(1));
+        assert!(gate.passed, "message was: {}", gate.message);
+        assert!(!gate.skipped);
+        assert_eq!(gate.value, Some(64.0));
+        assert_eq!(gate.threshold, Some(64.0));
+    }
+
+    /// A near-tie is an exemption, not a failure: the top-1 differed but the
+    /// distributions were the same vector to within FP noise.
+    #[test]
+    #[cfg(feature = "inference")]
+    fn decode_parity_near_ties_do_not_fail_the_gate() {
+        let report = super::DecodeParityReport {
+            steps: 64,
+            agreed: 61,
+            near_ties: 3,
+            first_divergence: None,
+        };
+        let gate = super::compare_decode_parity(&report, Duration::from_millis(1));
+        assert!(gate.passed, "message was: {}", gate.message);
+        assert_eq!(gate.value, Some(64.0));
+    }
+
+    /// The RED-turning case, and the whole point of the change: a divergence
+    /// that appears only after many decode steps must FAIL. The single-argmax
+    /// gate this replaced would have passed this scenario, because step 0
+    /// agreed.
+    #[test]
+    #[cfg(feature = "inference")]
+    fn decode_parity_late_divergence_fails_the_gate() {
+        let report = super::DecodeParityReport {
+            steps: 64,
+            agreed: 32,
+            near_ties: 0,
+            first_divergence: Some((32, 100, 200, 0.41)),
+        };
+        let gate = super::compare_decode_parity(&report, Duration::from_millis(1));
+        assert!(
+            !gate.passed,
+            "a divergence at decode step 32 MUST fail the gate; got PASS with: {}",
+            gate.message
+        );
+        assert!(!gate.skipped, "a divergence is a FAIL, never a SKIP");
+        assert!(
+            gate.message.contains("step 32"),
+            "the message must name the diverging step so the failure is actionable; got: {}",
+            gate.message
+        );
+    }
 }

--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -11937,7 +11937,7 @@ roadmap:
   github_issue: null
   item_type: task
   title: 'Give apr qa format_parity a real decode path (it is currently a #1864 clone)'
-  status: planned
+  status: completed
   priority: high
   assigned_to: null
   created: 2026-07-05 00:00:00+00:00

--- a/scripts/qwen-story.sh
+++ b/scripts/qwen-story.sh
@@ -27,6 +27,18 @@ trap '[ -n "$TMPDIR_STORY" ] && [ "$TMPDIR_STORY" != "/" ] && rm -rf "$TMPDIR_ST
 # -- Model registry ------------------------------------------------------------
 M_05B_ST="$MODELS_DIR/qwen2.5-coder-0.5b-instruct-safetensors/model.safetensors"
 M_15B_APR="$MODELS_DIR/qwen2.5-coder-1.5b-instruct-q4k.apr"
+# The format_parity gate peeks the primary's magic bytes and SKIPs anything that
+# isn't GGUF, so no .apr leg can ever exercise it. This is the only clean
+# GGUF + matching-SafeTensors pair on the runner (auto-discovery resolves the
+# reference out of the HF cache, so no --safetensors-path is needed).
+M_15B_GGUF="$MODELS_DIR/qwen2.5-coder-1.5b-instruct-q4_k_m.gguf"
+# Pinned explicitly rather than left to auto-discovery. On this runner
+# auto-discovery resolves to the HF cache snapshot, whose
+# layers.0.ffn_down_weight reads back 100% zeros and trips F-DATA-QUALITY-001
+# during conversion - so the gate would FAIL on a bad reference instead of
+# comparing anything. A gate must not depend on which of several copies a
+# search heuristic happens to find first.
+M_15B_ST="$MODELS_DIR/qwen2.5-coder-1.5b-instruct-safetensors/model.safetensors"
 M_7B_GGUF="$MODELS_DIR/qwen2.5-coder-7b-instruct-q4_k_m.gguf"
 M_30B_MOE="$MODELS_DIR/Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf"
 
@@ -90,6 +102,47 @@ beat1_discover() {
   pmat_hunt "registry list" crates/apr-cli/src/commands/list.rs crates/apr-cli/src/commands/pull.rs
 }
 
+# The GGUF leg of Beat 2. Deliberately NOT named beat<N>_* - the story has
+# exactly 8 beats (FALSIFY-QWEN-STORY-002) and this is a second assertion within
+# Beat 2, not a ninth beat.
+#
+# Why it exists: `run_format_parity_gate` peeks the primary's magic bytes and
+# returns SKIP for anything that isn't GGUF. Beat 2's other leg passes the .apr,
+# so format_parity has SKIPped on every scheduled run since the cron was added -
+# and a SKIP sets passed:true, so `apr qa` still printed ALL GATES PASSED. The
+# cross-format gate the doctrine says to reach for FIRST has never once executed
+# in CI.
+#
+# The assertion is on the JSON gate object, NOT on the ALL GATES PASSED banner,
+# precisely because that banner cannot distinguish "ran and passed" from
+# "skipped". It is also independent of `apr qa`'s exit code: unrelated gates
+# (ollama_parity, perf regression) legitimately fail on some hosts, and this
+# check is about format_parity specifically.
+check_format_parity_gguf() {
+  if [ ! -f "$M_15B_GGUF" ] || [ ! -f "$M_15B_ST" ]; then
+    emit_fail "B2 format_parity" "GGUF ($M_15B_GGUF) or SafeTensors reference ($M_15B_ST) absent - the cross-format gate cannot run. Provision the models rather than skipping: a silent skip is what hid this gate for months."
+    return
+  fi
+  run_cmd 900 apr qa "$M_15B_GGUF" --safetensors-path "$M_15B_ST" --json
+  FP=$(printf '%s\n' "$RC_OUT" \
+    | jq -r '.gates[]? | select(.name=="format_parity") | "\(.skipped) \(.passed) \(.value) \(.threshold)"' 2>/dev/null \
+    | tail -1)
+  case "$FP" in
+    "false true "*)
+      emit_pass "B2 format_parity (GGUF vs SafeTensors, executed: $FP)"
+      ;;
+    "true "*)
+      emit_fail "B2 format_parity" "gate SKIPped - it must EXECUTE on a GGUF primary"
+      ;;
+    "false false "*)
+      emit_fail "B2 format_parity" "cross-format decode DIVERGED: $(printf '%s\n' "$RC_OUT" | jq -r '.gates[]? | select(.name=="format_parity") | .message' 2>/dev/null | tail -1)"
+      ;;
+    *)
+      emit_fail "B2 format_parity" "no format_parity gate found in --json output (got: '$FP', apr qa exit=$RC_EC)"
+      ;;
+  esac
+}
+
 # -- Beat 2: Trust (0.5B safetensors) ------------------------------------------
 beat2_trust() {
   printf -- '-- Beat 2: Trust (QA gates) --\n'
@@ -105,6 +158,8 @@ beat2_trust() {
     emit_fail "B2 apr qa" "no 'ALL GATES PASSED' line"
     return
   fi
+  check_format_parity_gguf
+
   run_cmd 60 apr validate "$M_15B_APR" --quality
   if [ "$RC_EC" -eq 0 ]; then
     emit_pass "B2 apr validate --quality"


### PR DESCRIPTION
`PMAT-QA-FMTPARITY-DECODE-001` — Fable-review **EV rank 4**.

## What it was

`apr qa`'s `format_parity` gate — the tool the doctrine says to reach for *first* — ran one prefill forward per format and compared a single final-position argmax:

```rust
model.forward(&prompt_tokens)            // GGUF,        one call
run_safetensors_forward(&st, &prompt)    // SafeTensors, one call
compare_argmax_results(argmax(a), argmax(b))
```

Zero decode steps. The divergence class that actually ships — cached-decode corruption (PMAT-810 *"CertainlyCertainly"*, GH-1864) — was **structurally invisible** to it. It could only ever have caught a bug that was already wrong at token 0.

## What it is now

A ≥64-step lockstep greedy decode. Two design points decide whether it proves anything:

**Teacher forcing.** Both sides are fed the *same* next token (the GGUF argmax) rather than each following its own. If both free-ran, the first disagreement would put them on different sequences and every later step would compare unrelated distributions — the comparison would turn to noise exactly when it matters most. Teacher forcing keeps all 64 steps on one shared sequence, so a divergence at step *k* is attributable to step *k*.

**The cache path, not a re-prefill.** Both sides use the single-token-plus-cache entry point production uses (`forward_single_with_cache` / `forward_with_cache`), so a KV-cache indexing or write defect is *inside* the system under test. Re-prefilling each step would have been simpler and would have tested the wrong thing. The GGUF cache uses `OwnedQuantizedKVCache::from_config`, not `::new(.., hidden_dim, ..)` — Qwen2.5 is GQA (12 query heads, 2 KV heads), so `hidden_dim` would mis-stride the cache.

A top-1 disagreement whose logit vectors are cosine ≥ 0.98 is exempted as a floating-point near-tie. That exemption is load-bearing, not defensive — the real run below exercises it 4 times out of 64.

## Measured

On the RTX 4090 box that runs `qwen-story-daily`, 1.5B Q4_K_M GGUF vs the matching SafeTensors:

```
format_parity  PASS  value=64.0  threshold=64.0  19.8s
"Cross-format parity VERIFIED over 64 greedy decode steps through the cache path
 (60 exact top-1 matches, 4 near-tie exemptions at cosine >= 0.98)"
```

The old gate took 11.1s for its single forward — the full 64-step comparison costs ~8.7s more.

## RED-turning mutation (the roadmap's acceptance criterion, executed verbatim)

Dropped the SafeTensors-side KV write at decode step 32, rebuilt, re-ran:

```
apr qa exit code = 5
format_parity  FAIL  value=63.0  threshold=64.0
"Cross-format decode DIVERGED at step 33/64: GGUF argmax=151644 != SafeTensors
 argmax=198 (cosine=0.8185 < 0.98). 63 of 64 steps agreed (4 near-tie)."
```

It names **step 33** — the step after the dropped write — which is the physically correct answer. **The gate this replaces would have passed that mutation unchanged**, because step 0 still agreed.

## Making it actually run

The gate had a daily vehicle all along (`qwen-story-daily` → `qwen-story.sh`) but has **never once executed**: beat 2 passes the `.apr`, `run_format_parity_gate` peeks the magic bytes and SKIPs any non-GGUF primary — and `GateResult::skipped` sets `passed: true`, so `apr qa` still printed `ALL GATES PASSED`.

Adds a GGUF leg to beat 2 asserting on the **JSON gate object** (`.skipped == false && .passed == true`), not on that banner, which by construction cannot tell *"ran and passed"* from *"skipped"*. The leg is deliberately independent of `apr qa`'s exit code, since unrelated gates (ollama_parity, perf regression) legitimately fail on some hosts.

A missing GGUF/reference now **FAILs** the leg rather than SKIPping it. A silent skip on absent models is precisely what kept this gate dark.

### Unresolved finding, surfaced rather than worked around

The reference is pinned with `--safetensors-path` because on this runner **auto-discovery resolves to the HF cache snapshot, whose `layers.0.ffn_down_weight` reads back 100% zeros** and trips `F-DATA-QUALITY-001` during conversion — so the gate would FAIL on a bad reference instead of comparing anything. The copy under `~/models` converts fine. Whether that is a bad download or a converter defect (BF16 handling is the obvious suspect) is **not established here** and wants its own ticket. Either way a gate should not depend on which of several copies a search heuristic finds first.

## Verification

| check | result |
|---|---|
| new unit tests | 7, all executed |
| mutation-verify | ignoring `first_divergence` turns `decode_parity_late_divergence_fails_the_gate` RED and nothing else |
| full crate | 6613 passed, 0 failed |
| fmt / clippy | clean |
| `bashrs lint qwen-story.sh` | 0 errors |
| `pv validate apr-cli-qa-v1.yaml` | 0 errors, 0 warnings |

The floor test is the anti-theater one: it asserts ≥64 steps **and** that `--max-tokens` cannot shrink the comparison back to the single-forward shape.

Contract: new equation `format_parity_compares_decode_not_one_prefill` (6 invariants), a new proof obligation, and `FALSIFY-QA-013/014`. Both falsifier commands were executed verbatim — the first draft used two positional filters, which `cargo test` rejects, so they now use `--`. A falsifier that cannot run is the same defect one layer up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)