### PR TITLE
fix(claims): the readme-claims checker was wrong on 2 of 4 — the README was right

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-Aprender is a next-generation ML framework in pure Rust — **monorepo with 82 workspace crates**. Install: `cargo install aprender` → `apr` binary (103 subcommands). 25,300+ tests, 1767 provable contracts. Core library in `crates/aprender-core/` ([lib] name = "aprender"). All 20 repos (trueno, realizar, entrenar, batuta, + 15 satellites) consolidated per APR-MONO spec. **v0.34.0 SHIPPED 2026-05-18: MODEL-2 §88 stack-existence-proof, paiml/albor-370m-v1 LIVE on HF Hub.**
+Aprender is a next-generation ML framework in pure Rust — **monorepo with 78 workspace crates** (82 directories under `crates/`: 4 are `exclude`d from the workspace, 1 has no manifest). Install: `cargo install aprender` → `apr` binary (103 subcommands). 25,300+ tests, 1767 provable contracts. Core library in `crates/aprender-core/` ([lib] name = "aprender"). All 20 repos (trueno, realizar, entrenar, batuta, + 15 satellites) consolidated per APR-MONO spec. **v0.34.0 SHIPPED 2026-05-18: MODEL-2 §88 stack-existence-proof, paiml/albor-370m-v1 LIVE on HF Hub.**
 
 ## Git Workflow (Branch Protection)
 
@@ -58,11 +58,11 @@ When using `/loop`, treat fallback wakeups as cheap and merge events as primary.
 ## Build Commands
 
 ```bash
-cargo build --release              # Optimized build (all 82 crates)
+cargo build --release              # Optimized build (all 78 workspace crates)
 cargo test --workspace --lib       # Full workspace lib tests (25,300+)
 cargo test -p aprender-core --lib  # Core ML library only (12,975)
 cargo test -p apr-cli --lib        # CLI tests only (4,158)
-cargo check --workspace            # Type-check all 82 crates
+cargo check --workspace            # Type-check all 78 workspace crates
 cargo fmt --check                  # Check formatting
 cargo clippy -- -D warnings        # Strict linting
 
@@ -131,7 +131,7 @@ TraceSteps: `Tokenize`, `Embed`, `LayerNorm`, `Attention`, `FFN`, `TransformerBl
 2. **Backend Agnostic** - CPU (SIMD), GPU, WASM via Trueno
 3. **Three-Tier API**: High (`Estimator` trait), Mid (`Optimizer`/`Loss`/`Regularizer`), Low (Trueno primitives)
 
-**Monorepo layout** (82 crates, flat `crates/aprender-*` per Polars/Burn/Nushell pattern):
+**Monorepo layout** (78 workspace crates across 82 `crates/` dirs, flat `crates/aprender-*` per Polars/Burn/Nushell pattern):
 - `crates/aprender-core/` — ML library ([lib] name = "aprender")
 - `crates/aprender-compute/` — SIMD/GPU (was trueno, [lib] name = "trueno")
 - `crates/aprender-serve/` — inference server (was realizar, [lib] name = "realizar")
@@ -308,14 +308,14 @@ Key: `unsafe_code = "forbid"`, `clippy::all + pedantic = "warn"`, ML-specific al
 - `crates/aprender-core/src/primitives/` - Vector/Matrix with Cholesky solver
 - `crates/aprender-core/src/format/` - APR format, validation, lint, converter, export
 - `crates/aprender-core/src/text/chat_template.rs` - Chat template engine
-- `crates/apr-cli/` - CLI logic (82 commands)
+- `crates/apr-cli/` - CLI logic (103 commands)
 - `src/bin/apr.rs` - Root binary entry point (`cargo install aprender`)
 - `contracts/` - 1767 provable contracts (merged from all 20 repos)
 - `docs/specifications/aprender-monorepo-consolidation.md` - Monorepo spec
 
 ## APR CLI (`cargo install aprender`)
 
-82 commands across 10 categories. Contract: `contracts/apr-cli-commands-v1.yaml`.
+103 commands across 10 categories. Contract: `contracts/apr-cli-commands-v1.yaml`.
 Key commands: `run`, `chat`, `serve`, `pull`, `finetune`, `prune`, `distill`, `merge`, `quantize`, `inspect`, `debug`, `validate`, `diff`, `tensors`, `trace`, `lint`, `explain`, `export`, `import`, `convert`, `compile`, `train`, `tune`, `eval`, `bench`, `profile`, `qa`, `mcp`, `probar`, `cbtop`, `tui`, `hex`, `tree`, `flow`, `qualify`
 
 ```bash

--- a/scripts/check_readme_claims.sh
+++ b/scripts/check_readme_claims.sh
@@ -8,7 +8,7 @@
 #   bash scripts/check_readme_claims.sh --regen             # print new numbers for manual README edit
 #
 # Claims:
-#   crate_count        → `ls crates/ | wc -l` == README "N workspace crates"
+#   crate_count        → `cargo metadata --no-deps` members == README "N workspace crates"
 #   contract_count     → `find contracts/ -name '*.yaml' | wc -l` == README "M provable contracts"
 #   cli_command_count  → `apr --help` subcmd count == README "K CLI commands"
 #   cookbook_link      → README.md mentions `apr-cookbook`
@@ -26,7 +26,20 @@ fi
 # --- measurements (authoritative, from filesystem / live apr binary) ---
 
 measured_crate_count() {
-  find "$REPO_ROOT/crates" -maxdepth 1 -mindepth 1 -type d | wc -l | tr -d ' '
+  # `cargo metadata --no-deps` - the WORKSPACE members, which is what
+  # "workspace crates" means. NOT `find crates/ -type d`.
+  #
+  # Those two numbers genuinely differ, and the directory count is the wrong
+  # one: 82 directories, 81 with a Cargo.toml, 78 workspace members (4 are
+  # `exclude`d from the workspace, 1 has no manifest). README.md:43 documents
+  # the correct method AND warns against the directory count in the same
+  # sentence - this function was using exactly the method the README told it
+  # not to, so it reported the README as drifted while the README was right.
+  # Wiring it in that state would have forced README to claim 82 workspace
+  # crates, which is false. A gate that enforces the wrong answer is worse
+  # than no gate.
+  (cd "$REPO_ROOT" && cargo metadata --no-deps --format-version 1 2>/dev/null) \
+    | python3 -c 'import json,sys; print(len(json.load(sys.stdin)["packages"]))'
 }
 
 measured_contract_count() {
@@ -40,9 +53,17 @@ measured_cli_command_count() {
   #
   # Use `cargo run --quiet -p apr-cli --bin apr` so the number tracks
   # the committed source. Slow on cold build; fast after dev-profile warm.
+  #
+  # `help` is EXCLUDED. clap generates it automatically; it is not one of
+  # apr's commands, has no chapter, no contract and no implementation in
+  # crates/apr-cli/src/commands/. Counting it made this check report 104
+  # against a README claiming 103 - the README was right and this function
+  # was off by exactly clap's freebie.
   local subcmd_line_re='^  [a-z][-a-z0-9]* '
   (cd "$REPO_ROOT" && cargo run --quiet -p apr-cli --bin apr -- --help 2>&1) \
-    | grep -cE "$subcmd_line_re" | tr -d ' '
+    | grep -E "$subcmd_line_re" \
+    | grep -vE '^  help( |$)' \
+    | wc -l | tr -d ' '
 }
 
 measured_cookbook_link_present() {
@@ -88,7 +109,7 @@ check_crate_count() {
     return 1
   fi
   if [[ "$measured" != "$claimed" ]]; then
-    echo "FAIL FALSIFY-README-001 crate_count: README claims $claimed, filesystem has $measured" >&2
+    echo "FAIL FALSIFY-README-001 crate_count: README claims $claimed, cargo metadata --no-deps has $measured workspace members" >&2
     return 1
   fi
   echo "PASS FALSIFY-README-001 crate_count: $measured"
@@ -149,7 +170,7 @@ done
 
 case "$mode" in
   regen)
-    echo "crates/ count:         $(measured_crate_count)"
+    echo "workspace members:     $(measured_crate_count)"
     echo "contracts/ *.yaml:     $(measured_contract_count)"
     if cli=$(measured_cli_command_count 2>/dev/null); then
       echo "apr --help subcmds:    $cli"


### PR DESCRIPTION
`PMAT-DRIFT-GATES-001` (Fable-review **EV rank 7**) prerequisite.

The roadmap frames this item as *"README/CLAUDE.md counts corrected (… 82 crates)"* — it assumes the README drifted and should be updated to match the checker. I ran the checker, then **checked the checker**. It's the other way round.

```
$ bash scripts/check_readme_claims.sh; echo $?
FAIL FALSIFY-README-001 crate_count: README claims 78, filesystem has 82
PASS FALSIFY-README-002 contract_count: 1766
FAIL FALSIFY-README-003 cli_command_count: README claims 103, apr --help lists 104
PASS FALSIFY-README-004 cookbook_link: present
1
```

**Both FAILs are false positives.**

### FALSIFY-README-001 — wrong method

`measured_crate_count()` did `find crates -maxdepth 1 -type d | wc -l` = 82. But *"workspace crates"* means workspace **members**, and `cargo metadata --no-deps` reports **78**. The numbers genuinely differ:

| measure | value |
|---|---|
| directories under `crates/` | 82 |
| …with a `Cargo.toml` | 81 |
| workspace members | **78** |

78 + 4 excluded = 82; 82 − 1 without a manifest = 81. And `README.md:43` documents the correct method **and warns against the directory count in the same sentence**:

> `| Workspace crates | **78** workspace crates | cargo metadata --no-deps (NOT ls crates/ — 4 are excluded, 1 has no Cargo.toml) |`

The function was using precisely the method the README told it not to. **Wiring it in that state — which is what this roadmap item asks for — would have forced the README to claim 82 workspace crates, which is false.** A gate that enforces the wrong answer is worse than no gate.

### FALSIFY-README-003 — off by clap's freebie

`measured_cli_command_count()` counted clap's auto-generated `help` pseudo-command. It isn't one of apr's commands: no chapter, no contract, no module in `crates/apr-cli/src/commands/`. Excluding it gives **103** — exactly what the README claims.

Checked that the 104 wasn't a stale-binary artifact: a freshly built `apr` and the installed one produce identical 104-line lists, `help` present in both.

## Mutation-verified both ways

Making a checker green is not the same as making it right:

```
README claims 82 crates  -> FAIL FALSIFY-README-001, exit 1
README claims 104 CLI    -> FAIL FALSIFY-README-003, exit 1
restored                 -> exit 0
```

## Also corrects CLAUDE.md

It was wrong twice and self-contradictory once: it claimed *"82 workspace crates"* (the directory count) and, four sections apart, both *"103 subcommands"* and *"82 commands"* for the same CLI.

## Deliberately NOT wired per-PR here

The checker shells out to `cargo run -p apr-cli --bin apr -- --help`, so it needs a build — it can't join `check_runner_labels.sh` / `check_beats_gated.sh` / `check_pass_grep_anchored.sh` in `ci.yml`'s text-only `guard-runner-labels` job. Where it goes, and what that build costs per PR, is a real decision rather than a one-line addition.

It had to wait on this fix regardless: **wiring a checker that fails on correct documentation just paints main red.**

`bashrs lint`: 0 errors, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)