### PR TITLE
fix: two test targets have not compiled in months — found by running the suite CI never runs

### DIFF
--- a/crates/aprender-core/tests/includes/format_parity.rs
+++ b/crates/aprender-core/tests/includes/format_parity.rs
@@ -51,10 +51,28 @@ fn dd3_no_phone_home_urls() {
     }
 }
 
+/// Workspace root, resolved from this crate's manifest dir.
+///
+/// Integration tests run with CWD = the PACKAGE root
+/// (`crates/aprender-core/`), not the workspace root. Several assertions in
+/// this file were written when aprender-core WAS the repo root, so bare
+/// relative paths like `.github/workflows/ci.yml` silently stopped resolving
+/// when APR-MONO moved the crate under `crates/`. Nothing noticed, because this
+/// whole target has not compiled since that move.
+fn workspace_root() -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("workspace root must resolve from CARGO_MANIFEST_DIR")
+}
+
 /// DD5: License allows air-gap deployment
 #[test]
 fn dd5_license_allows_airgap() {
-    let license = include_str!("../../LICENSE");
+    // `../../` from tests/includes/ was the repo root before APR-MONO moved
+    // aprender-core under crates/. It now resolves to crates/aprender-core/,
+    // which has no LICENSE - so this target has not compiled since the move.
+    let license = include_str!("../../../../LICENSE");
 
     assert!(
         license.contains("MIT") || license.contains("Apache"),
@@ -178,9 +196,10 @@ fn cc4_version_documented() {
         "CC4 FALSIFIED: No version in Cargo.toml"
     );
 
-    let has_changelog = std::path::Path::new("CHANGELOG.md").exists()
-        || std::path::Path::new("CHANGES.md").exists()
-        || std::path::Path::new("docs/CHANGELOG.md").exists();
+    let root = workspace_root();
+    let has_changelog = root.join("CHANGELOG.md").exists()
+        || root.join("CHANGES.md").exists()
+        || root.join("docs/CHANGELOG.md").exists();
 
     if !has_changelog {
         eprintln!("CC4 WARNING: No CHANGELOG.md found - consider adding one");
@@ -240,7 +259,7 @@ fn cc3_block_size_gguf_compatible() {
 /// CC5: CI tests cross-repo compatibility
 #[test]
 fn cc5_cross_repo_testing_documented() {
-    let ci_path = std::path::Path::new(".github/workflows/ci.yml");
+    let ci_path = workspace_root().join(".github/workflows/ci.yml");
     assert!(
         ci_path.exists(),
         "CC5: No CI configuration found at .github/workflows/ci.yml"
@@ -322,7 +341,7 @@ fn dd4_audit_log_capability() {
 
     let has_error_handling = cargo_toml.contains("thiserror");
 
-    let has_cli_audit = std::path::Path::new("crates/apr-cli").exists();
+    let has_cli_audit = workspace_root().join("crates/apr-cli").exists();
 
     assert!(
         has_logging_crate || has_error_handling || has_cli_audit,
@@ -341,7 +360,10 @@ fn dd7_cryptographic_verification_capability() {
         || cargo_toml.contains("md5")
         || cargo_toml.contains("digest");
 
-    let v2_rs = include_str!("../../src/format/v2/mod.rs");
+    // src/format/v2/mod.rs no longer exists anywhere in the tree; the APR v2
+    // checksum implementation lives in src/format/core_io.rs. Pointing at a
+    // file that is gone made this assertion uncompilable rather than false.
+    let v2_rs = include_str!("../../src/format/core_io.rs");
     let has_checksum_impl = v2_rs.contains("checksum") || v2_rs.contains("crc");
 
     assert!(

--- a/crates/aprender-orchestrate/examples/agent_demo.rs
+++ b/crates/aprender-orchestrate/examples/agent_demo.rs
@@ -983,6 +983,10 @@ fn run_mcp_demos(rt: &tokio::runtime::Runtime) {
     #[cfg(feature = "agents-mcp")]
     {
         use batuta::agent::manifest::McpTransport;
+        // AgentManifest is imported in a SIBLING demo fn's scope (line 25), not
+        // this one - so this demo has not compiled under `--features agents-mcp`
+        // since the feature landed.
+        use batuta::agent::AgentManifest;
 
         println!("--- Demo 16: MCP Manifest Configuration ---");
         println!();

--- a/crates/aprender-orchestrate/src/cli/agent.rs
+++ b/crates/aprender-orchestrate/src/cli/agent.rs
@@ -30,6 +30,12 @@ use agent_helpers::{
     build_driver, build_guard, build_memory, build_tool_registry, detect_model_format,
     register_inference_tool, register_spawn_tool,
 };
+// register_mcp_tools is itself `#[cfg(feature = "agents-mcp")]`, so its
+// re-export must carry the same gate. It was simply omitted from the list
+// above, which is why agent_tests_extended.rs's
+// test_register_mcp_tools_no_servers has never compiled under that feature.
+#[cfg(all(test, feature = "agents-mcp"))]
+use agent_helpers::register_mcp_tools;
 #[cfg(test)]
 use agent_pool_cmds::{cmd_agent_pool, cmd_agent_status};
 #[cfg(test)]

--- a/crates/aprender-orchestrate/tests/agent_integration.rs
+++ b/crates/aprender-orchestrate/tests/agent_integration.rs
@@ -735,6 +735,8 @@ async fn test_runtime_mcp_privacy_sovereign_blocks_sse() {
         command: vec![],
         url: Some("https://api.example.com/mcp".into()),
         capabilities: vec!["*".into()],
+        // SSE transport does not spawn a subprocess, so env is inert here.
+        env: Default::default(),
     }];
 
     let driver = MockDriver::single_response("should not reach here");
@@ -766,6 +768,8 @@ async fn test_runtime_mcp_privacy_sovereign_allows_stdio() {
         command: vec!["node".into(), "server.js".into()],
         url: None,
         capabilities: vec!["*".into()],
+        // Empty map = inherit the parent env unchanged (PMAT-CODE-MCP-ENV-001).
+        env: Default::default(),
     }];
 
     let driver = MockDriver::single_response("stdio is fine");


### PR DESCRIPTION
Prerequisite work for `PMAT-THEATER-TRIAGE-001` (**EV rank 17**), and a finding in its own right.

## Context: the measurement that started this

| | count |
|---|---|
| top-level integration targets (`crates/*/tests/*.rs`) | **573** |
| named by any workflow | **26** (all on `ci.yml:317`) |
| **never execute** | **547** |

The mechanism is one flag: the only workspace-wide run is `cargo nextest run --profile ci --workspace --lib`, and `--lib` excludes every `tests/*.rs` target. So I ran the suite the repo never runs — and it didn't get as far as running anything.

## Finding 1 — three `agents-mcp` targets, broken since 2026-05-13

```
error[E0063]: missing field `env` in initializer of `McpServerConfig`
  --> crates/aprender-orchestrate/tests/agent_integration.rs:732:33  :763:33
```

`env` was added to `McpServerConfig` by #1574 on **2026-05-13** — 77 days. Fixing it exposed two more behind the same feature:

```
examples/agent_demo.rs:1006,1030      E0433 undeclared type `AgentManifest`
examples/agent_demo.rs:1033           E0282 type annotations needed
src/cli/agent_tests_extended.rs:244   E0425 cannot find `register_mcp_tools`
```

**Why it escaped.** All of it sits behind `#[cfg(feature = "agents-mcp")]`, which is *not* in the default set (`default = ["native", "rag", "agents", "inference"]`):

```
cargo clippy --all-targets -p aprender-orchestrate                -> CLEAN
cargo clippy --all-targets -p aprender-orchestrate -F agents-mcp  -> 6 errors
```

Per-crate builds with default features cfg the broken code out entirely. It only becomes visible under **workspace-wide feature unification**, where a sibling crate turns `agents-mcp` on — which is exactly what `--workspace --tests` does and what nothing in CI does.

Fixes: `env: Default::default()` on both initializers; the missing `AgentManifest` import (it was imported in a *sibling* demo fn's scope); and `register_mcp_tools` added to `agent.rs`'s `#[cfg(test)]` re-export list — which literally carries the comment *"Re-exports for agent_tests.rs"* and had simply omitted it. Gated `#[cfg(all(test, feature = "agents-mcp"))]`, since an ungated re-export would break the default build.

## Finding 2 — `format_parity_tests`, broken since APR-MONO

```
error: couldn't read `crates/aprender-core/tests/includes/../../LICENSE`
error: couldn't read `crates/aprender-core/tests/includes/../../src/format/v2/mod.rs`
```

Written when `aprender-core` *was* the repo root. After the move under `crates/`, `../../` resolves to `crates/aprender-core/`. `LICENSE` exists only at the workspace root; `src/format/v2/mod.rs` **no longer exists anywhere** — the v2 checksum implementation it reached for now lives in `src/format/core_io.rs`. Pointing at a deleted file made the assertion *uncompilable* rather than false, which is strictly worse: a false assertion at least reports something.

### And fixing compilation exposed a real failure — the point of the exercise

```
thread 'cc5_cross_repo_testing_documented' panicked at format_parity.rs:247:
CC5: No CI configuration found at .github/workflows/ci.yml
```

Integration tests run with CWD = the **package** root, so three more assertions had silently stopped resolving: `.github/workflows/ci.yml`, the `CHANGELOG.md` alternatives, and `crates/apr-cli`. Two of those are `.exists()` checks feeding `||` chains, so they had quietly degraded to *false* rather than failing — the CI-config one was the only `assert!` and thus the only one that spoke up.

Added a `workspace_root()` helper anchored on `env!("CARGO_MANIFEST_DIR")` (CWD-independent) and routed all four sites through it.

**Result: 29 passed, 0 failed**, on a target that previously did not build.

## Scope

This is the prerequisite, not the triage. The triage proper — which of the 547 pass, fail, or legitimately need models/GPU — could not start until the workspace's test targets compiled. It is running now; findings will be filed separately.

Verified: `cargo clippy --all-targets -p aprender-orchestrate --features agents-mcp` clean (was 6 errors across 3 targets); `cargo test -p aprender-core --test format_parity_tests` 29/29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)