### PR TITLE
fix(pv): the pv dispatch tests don't compile, and two point at a directory that moved

### DIFF
--- a/crates/aprender-contracts-cli/tests/includes/dispatch_tests.rs
+++ b/crates/aprender-contracts-cli/tests/includes/dispatch_tests.rs
@@ -85,6 +85,7 @@ fn dispatch_proof_status() {
         format: "text".to_string(),
         table: false,
         kind: None,
+        verify_bindings: None,
     });
     assert!(result.is_ok());
 }
@@ -97,6 +98,7 @@ fn dispatch_proof_status_json() {
         format: "json".to_string(),
         table: false,
         kind: None,
+        verify_bindings: None,
     });
     assert!(result.is_ok());
 }
@@ -109,6 +111,7 @@ fn dispatch_proof_status_directory() {
         format: "text".to_string(),
         table: false,
         kind: None,
+        verify_bindings: None,
     });
     assert!(result.is_ok());
 }
@@ -123,6 +126,7 @@ fn dispatch_proof_status_with_binding() {
         format: "json".to_string(),
         table: false,
         kind: None,
+        verify_bindings: None,
     });
     assert!(result.is_ok());
 }
@@ -375,6 +379,7 @@ fn dispatch_proof_status_markdown() {
         format: "markdown".to_string(),
         table: false,
         kind: None,
+        verify_bindings: None,
     });
     assert!(result.is_ok());
 }
@@ -418,7 +423,7 @@ fn dispatch_roofline_invalid_hw() {
 #[test]
 fn dispatch_pipeline_text() {
     let pipeline_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("../../contracts/pipelines/inference-forward-v1.yaml");
+        .join("../aprender-contracts-staging/contracts/pipelines/inference-forward-v1.yaml");
     let result = run_command(Commands::Pipeline {
         pipeline: pipeline_path,
         format: "text".to_string(),
@@ -429,7 +434,7 @@ fn dispatch_pipeline_text() {
 #[test]
 fn dispatch_pipeline_json() {
     let pipeline_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("../../contracts/pipelines/inference-forward-v1.yaml");
+        .join("../aprender-contracts-staging/contracts/pipelines/inference-forward-v1.yaml");
     let result = run_command(Commands::Pipeline {
         pipeline: pipeline_path,
         format: "json".to_string(),


### PR DESCRIPTION
Third target from the `PMAT-THEATER-TRIAGE-001` sweep (**rank 17**). Same shape as #2341: dark target, doesn't build, and fixing the build reveals real failures.

## Wouldn't compile

```
error[E0063]: missing field `verify_bindings` in initializer of `cli::Commands`
  --> tests/includes/dispatch_tests.rs:82 :94 :106 :120 :372
error: could not compile `aprender-contracts-cli` (bin "pv" test)
```

`verify_bindings: Option<PathBuf>` was added to the `ProofStatus` variant (`cli.rs:154`) and threaded through `main.rs:107/114`, but the five test initializers were never updated. All five are `Commands::ProofStatus` with `kind: None` last, so the edit is uniform.

## Then two real failures

```
dispatch_tests::dispatch_pipeline_text  assertion failed: result.is_ok()
dispatch_tests::dispatch_pipeline_json  assertion failed: result.is_ok()
```

Both load `../../contracts/pipelines/inference-forward-v1.yaml`. **There is no `contracts/pipelines/` directory in the repo** — the pipeline contracts now live inside the staging crate at `crates/aprender-contracts-staging/contracts/pipelines/`. Repointed both.

Worth distinguishing from #2341: these two were **not** the CWD-relative-path bug. They already used `env!("CARGO_MANIFEST_DIR")` correctly and were CWD-safe. The directory genuinely moved out from under them, and nothing noticed because the E0063 masked the stale path entirely — the target hasn't compiled since `verify_bindings` landed.

**Result: 60 passed, 0 failed**, on a target that previously did not build.

## Running tally for rank 17

| | |
|---|---|
| top-level integration targets | 573 |
| named by any workflow | 26 |
| never executed | **547** |
| …of those, don't compile | **11** |

This closes the third. The remaining 8 are all `aprender-serve` and all one mechanical class: **68 × E0063** for `GGUFConfig.query_pre_attn_scalar` (55) and `GGUFConfig.post_attn_norm_weight`/`post_ffw_norm_weight` (13).

Inventory them in one pass with `cargo build --tests --workspace --keep-going` — `cargo test` rejects `--keep-going`, and `--no-fail-fast` doesn't help with *compile* errors, so cargo otherwise surfaces exactly one broken target per run. I lost three sequential runs to that before working it out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)