### PR TITLE
feat(pull): apr pull --verify — check the hash pull already records but never compares

### DIFF
--- a/contracts/sharded-gguf-pull-v1.yaml
+++ b/contracts/sharded-gguf-pull-v1.yaml
@@ -91,6 +91,28 @@ falsification_tests:
     parse_gguf_shard_name mishandles prefixes containing digits/dashes. Check
     the rsplit_once('-') prefix split.
   evidence: cargo test -p apr-cli --lib sharded_gguf_tests::detects_three_part_with_quant_prefix
+- id: FT-SHGGUF-020
+  rule: a same-size content corruption is REJECTED by --verify
+  prediction: |
+    apr pull <dir> --verify exits 5 when a cached shard has the recorded byte
+    length but different content. This is the case size-only checking cannot
+    see: validate::validate_shard_manifest documents itself as "an
+    O(1)-per-file check (stat syscall only, no hashing)", so the BLAKE3 that
+    pull already records was never compared to anything.
+  if_fails: |
+    --verify has regressed to a size check and a corrupt-but-right-length model
+    passes. Measured motivating case: a 7.1 GB SafeTensors blob, fully
+    allocated, exact byte length, 27 of 339 tensors reading back as -0.0.
+  evidence: cargo test -p apr-cli --lib pull_verify_tests::same_size_different_content_is_caught
+- id: FT-SHGGUF-021
+  rule: --verify fails closed on an empty or absent manifest
+  prediction: |
+    A manifest naming zero files exits non-zero rather than printing success,
+    and an absent .apr-manifest.json is an error, not a pass.
+  if_fails: |
+    --verify would report "verified" having verified nothing - the same
+    vacuous-gate defect the command exists to expose.
+  evidence: cargo test -p apr-cli --lib -- pull_verify_tests::empty_manifest_fails_rather_than_reporting_success pull_verify_tests::absent_manifest_is_an_error_not_a_pass
 - id: FT-SHGGUF-003
   rule: single non-sharded GGUF is not treated as sharded
   prediction: detect_gguf_shards on one model.gguf returns None.

--- a/crates/apr-cli/src/commands/mod.rs
+++ b/crates/apr-cli/src/commands/mod.rs
@@ -125,6 +125,7 @@ pub(crate) mod ptx_map;
 pub(crate) mod publish;
 pub(crate) mod pull;
 pub(crate) mod pull_scheme;
+pub(crate) mod pull_verify;
 pub(crate) mod qa;
 pub(crate) mod qa_capability;
 pub(crate) mod qualify;

--- a/crates/apr-cli/src/commands/pull.rs
+++ b/crates/apr-cli/src/commands/pull.rs
@@ -426,6 +426,33 @@ fn run_sharded_gguf(
     Ok(())
 }
 
+/// Resolve the on-disk cache directory for a model reference, without any
+/// network I/O.
+///
+/// Used by `apr pull --verify`, which inspects an already-downloaded model.
+/// Accepts `hf://org/repo`, `org/repo`, or a bare path to a cache directory.
+pub(crate) fn resolve_cache_dir_for_ref(model_ref: &str) -> Result<std::path::PathBuf> {
+    // An explicit directory wins - lets the operator verify any cache layout.
+    let as_path = std::path::Path::new(model_ref);
+    if as_path.is_dir() {
+        return Ok(as_path.to_path_buf());
+    }
+    let trimmed = model_ref
+        .trim_start_matches("hf://")
+        .trim_start_matches("https://huggingface.co/")
+        .trim_matches('/');
+    let mut parts = trimmed.splitn(2, '/');
+    match (parts.next(), parts.next()) {
+        (Some(org), Some(repo)) if !org.is_empty() && !repo.is_empty() => {
+            resolve_shard_cache_dir(org, repo)
+        }
+        _ => Err(CliError::ValidationFailed(format!(
+            "Cannot resolve a cache directory from '{model_ref}'. \
+             Expected `org/repo`, `hf://org/repo`, or an existing directory."
+        ))),
+    }
+}
+
 /// Resolve the cache directory for a sharded model.
 fn resolve_shard_cache_dir(org: &str, repo: &str) -> Result<std::path::PathBuf> {
     Ok(dirs::home_dir()

--- a/crates/apr-cli/src/commands/pull_verify.rs
+++ b/crates/apr-cli/src/commands/pull_verify.rs
@@ -1,0 +1,208 @@
+//! `apr pull --verify`: re-hash cached model files against the checksums the
+//! download already recorded.
+//!
+//! GAP THIS CLOSES. `apr pull` computes a BLAKE3 hash of every shard and writes
+//! it to `.apr-manifest.json` (`ShardManifest` / `FileChecksum`, GH-213). That
+//! recorded hash is then never compared to anything. The only integrity check
+//! in the tree is `validate::validate_shard_manifest`, which documents itself
+//! as "an O(1)-per-file check (stat syscall only, no hashing)" and compares
+//! `size` alone.
+//!
+//! Size alone cannot see the failure mode that motivated this. A 7.1 GB
+//! SafeTensors blob in the HuggingFace cache was found with 27 of 339 tensors
+//! reading back as `-0.0` - fully allocated, byte-length exactly correct, not a
+//! sparse file, and its SHA-256 did not match the name HuggingFace had given it.
+//! A size check passes that file. A content hash rejects it.
+//!
+//! So `--verify` deliberately costs O(bytes): it re-reads and re-hashes. That is
+//! the point, and it is why it is opt-in rather than folded into every pull.
+
+use crate::error::{CliError, Result};
+use colored::Colorize;
+use std::io::Read;
+use std::path::Path;
+
+use super::pull::ShardManifest;
+
+/// Streamed BLAKE3 of a file. Chunked so a multi-gigabyte shard does not have
+/// to be resident to be verified.
+fn hash_file(path: &Path) -> Result<String> {
+    let file = std::fs::File::open(path)
+        .map_err(|e| CliError::ValidationFailed(format!("Cannot open {}: {e}", path.display())))?;
+    let mut reader = std::io::BufReader::with_capacity(1 << 20, file);
+    let mut hasher = blake3::Hasher::new();
+    let mut buf = vec![0u8; 1 << 20];
+    loop {
+        let n = reader.read(&mut buf).map_err(|e| {
+            CliError::ValidationFailed(format!("Read failed on {}: {e}", path.display()))
+        })?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    Ok(hasher.finalize().to_hex().to_string())
+}
+
+/// Outcome for a single file.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum FileVerdict {
+    Ok,
+    Missing,
+    /// Length differs - the classic truncation case the size check already caught.
+    SizeMismatch {
+        expected: u64,
+        actual: u64,
+    },
+    /// Length matches but content does not. This is the class the size-only
+    /// check is blind to, and the reason this command exists.
+    HashMismatch {
+        expected: String,
+        actual: String,
+    },
+}
+
+impl FileVerdict {
+    pub(crate) fn is_ok(&self) -> bool {
+        matches!(self, FileVerdict::Ok)
+    }
+}
+
+/// Verify one file against its recorded size and BLAKE3.
+///
+/// Size is checked first purely because it is free and yields a better message
+/// for a truncated file; a size match is NOT accepted as proof of integrity.
+pub(crate) fn verify_one(
+    path: &Path,
+    expected_size: u64,
+    expected_hash: &str,
+) -> Result<FileVerdict> {
+    if !path.exists() {
+        return Ok(FileVerdict::Missing);
+    }
+    let actual_size = std::fs::metadata(path)
+        .map_err(|e| CliError::ValidationFailed(format!("Cannot stat {}: {e}", path.display())))?
+        .len();
+    if actual_size != expected_size {
+        return Ok(FileVerdict::SizeMismatch {
+            expected: expected_size,
+            actual: actual_size,
+        });
+    }
+    let actual_hash = hash_file(path)?;
+    if actual_hash != expected_hash {
+        return Ok(FileVerdict::HashMismatch {
+            expected: expected_hash.to_string(),
+            actual: actual_hash,
+        });
+    }
+    Ok(FileVerdict::Ok)
+}
+
+/// Verify every file named by a `.apr-manifest.json`.
+///
+/// Returns the per-file verdicts in a stable (sorted) order so output and tests
+/// do not depend on `HashMap` iteration order.
+pub(crate) fn verify_manifest(
+    manifest_path: &Path,
+    cache_dir: &Path,
+) -> Result<Vec<(String, FileVerdict)>> {
+    let raw = std::fs::read_to_string(manifest_path).map_err(|e| {
+        CliError::ValidationFailed(format!(
+            "Cannot read manifest {}: {e}",
+            manifest_path.display()
+        ))
+    })?;
+    let manifest: ShardManifest = serde_json::from_str(&raw).map_err(|e| {
+        CliError::ValidationFailed(format!(
+            "Cannot parse manifest {}: {e}",
+            manifest_path.display()
+        ))
+    })?;
+
+    let mut names: Vec<&String> = manifest.files.keys().collect();
+    names.sort();
+
+    let mut out = Vec::with_capacity(names.len());
+    for name in names {
+        let checksum = &manifest.files[name];
+        let verdict = verify_one(&cache_dir.join(name), checksum.size, &checksum.blake3)?;
+        out.push((name.clone(), verdict));
+    }
+    Ok(out)
+}
+
+/// Print verdicts and return an error if any file failed.
+///
+/// Fail-closed on an EMPTY manifest: a manifest naming zero files would
+/// otherwise print "all files verified" having verified nothing, which is the
+/// same defect this command was written to expose.
+pub(crate) fn report(results: &[(String, FileVerdict)], cache_dir: &Path) -> Result<()> {
+    if results.is_empty() {
+        return Err(CliError::ValidationFailed(format!(
+            "Manifest in {} names ZERO files - nothing was verified. \
+             Treating as a failure rather than reporting success on an empty set.",
+            cache_dir.display()
+        )));
+    }
+
+    let mut bad = 0usize;
+    for (name, verdict) in results {
+        match verdict {
+            FileVerdict::Ok => println!("  {} {name}", "OK".green()),
+            FileVerdict::Missing => {
+                bad += 1;
+                println!("  {} {name} - file is missing", "MISSING".red());
+            }
+            FileVerdict::SizeMismatch { expected, actual } => {
+                bad += 1;
+                println!(
+                    "  {} {name} - expected {expected} bytes, found {actual} (truncated?)",
+                    "SIZE".red()
+                );
+            }
+            FileVerdict::HashMismatch { expected, actual } => {
+                bad += 1;
+                println!(
+                    "  {} {name} - size is correct but CONTENT differs\n      expected blake3 {expected}\n      actual   blake3 {actual}",
+                    "CORRUPT".red()
+                );
+            }
+        }
+    }
+
+    if bad > 0 {
+        return Err(CliError::ValidationFailed(format!(
+            "{bad} of {} file(s) failed verification in {}. Re-run `apr pull <model> --force` to re-download.",
+            results.len(),
+            cache_dir.display()
+        )));
+    }
+    println!();
+    println!(
+        "  {} {} file(s) verified by content hash, not just size",
+        "PASS".green().bold(),
+        results.len()
+    );
+    Ok(())
+}
+
+/// Entry point for `apr pull <model> --verify`.
+///
+/// Verifies an ALREADY-CACHED model; it performs no network I/O, so it is
+/// usable offline and on an air-gapped host.
+pub(crate) fn run_verify(cache_dir: &Path) -> Result<()> {
+    let manifest_path = cache_dir.join(".apr-manifest.json");
+    if !manifest_path.exists() {
+        return Err(CliError::ValidationFailed(format!(
+            "No .apr-manifest.json in {}. Nothing recorded to verify against - \
+             pull the model first (only sharded downloads record checksums).",
+            cache_dir.display()
+        )));
+    }
+    println!("{} {}", "Verifying".cyan().bold(), cache_dir.display());
+    let results = verify_manifest(&manifest_path, cache_dir)?;
+    report(&results, cache_dir)
+}
+
+include!("pull_verify_tests.rs");

--- a/crates/apr-cli/src/commands/pull_verify_tests.rs
+++ b/crates/apr-cli/src/commands/pull_verify_tests.rs
@@ -1,0 +1,174 @@
+// Tests for `apr pull --verify` (pull_verify.rs).
+
+#[cfg(test)]
+mod pull_verify_tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn write_manifest(dir: &Path, files: &[(&str, u64, &str)]) {
+        let mut map = HashMap::new();
+        for (name, size, hash) in files {
+            map.insert(
+                (*name).to_string(),
+                crate::commands::pull::FileChecksum {
+                    size: *size,
+                    blake3: (*hash).to_string(),
+                },
+            );
+        }
+        let manifest = crate::commands::pull::ShardManifest {
+            version: 1,
+            repo: "test/repo".to_string(),
+            files: map,
+        };
+        std::fs::write(
+            dir.join(".apr-manifest.json"),
+            serde_json::to_string(&manifest).expect("serialize manifest"),
+        )
+        .expect("write manifest");
+    }
+
+    fn blake3_of(bytes: &[u8]) -> String {
+        blake3::hash(bytes).to_hex().to_string()
+    }
+
+    #[test]
+    fn intact_file_verifies() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let body = b"model weights, entirely intact";
+        std::fs::write(dir.path().join("shard.bin"), body).expect("write");
+        write_manifest(
+            dir.path(),
+            &[("shard.bin", body.len() as u64, &blake3_of(body))],
+        );
+        let results = verify_manifest(&dir.path().join(".apr-manifest.json"), dir.path())
+            .expect("verify runs");
+        assert_eq!(results.len(), 1);
+        assert!(results[0].1.is_ok(), "got {:?}", results[0].1);
+        report(&results, dir.path()).expect("intact model must pass");
+    }
+
+    /// THE POINT OF THE COMMAND. Same length, different content - exactly the
+    /// shape of the corrupt HF blob that motivated this (right size, tensors
+    /// zeroed). The size-only check in validate.rs accepts this file.
+    #[test]
+    fn same_size_different_content_is_caught() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let good = b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+        let corrupt = b"AAAAAAAAAAAAAAAA\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0";
+        assert_eq!(good.len(), corrupt.len(), "the premise is equal length");
+
+        std::fs::write(dir.path().join("shard.bin"), corrupt).expect("write");
+        // Manifest records the GOOD hash and the (identical) size.
+        write_manifest(
+            dir.path(),
+            &[("shard.bin", good.len() as u64, &blake3_of(good))],
+        );
+
+        let results = verify_manifest(&dir.path().join(".apr-manifest.json"), dir.path())
+            .expect("verify runs");
+        match &results[0].1 {
+            FileVerdict::HashMismatch { .. } => {}
+            other => panic!("expected HashMismatch, got {other:?}"),
+        }
+        let err = report(&results, dir.path()).expect_err("corrupt content MUST fail");
+        assert!(
+            format!("{err}").contains("failed verification"),
+            "message should be actionable, got: {err}"
+        );
+    }
+
+    /// A size check alone would still catch truncation; keep that path working
+    /// and reported distinctly, because the remedy is the same but the
+    /// diagnosis differs.
+    #[test]
+    fn truncated_file_reports_size_not_hash() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let good = b"0123456789abcdef";
+        std::fs::write(dir.path().join("shard.bin"), b"0123").expect("write");
+        write_manifest(
+            dir.path(),
+            &[("shard.bin", good.len() as u64, &blake3_of(good))],
+        );
+        let results = verify_manifest(&dir.path().join(".apr-manifest.json"), dir.path())
+            .expect("verify runs");
+        match &results[0].1 {
+            FileVerdict::SizeMismatch { expected, actual } => {
+                assert_eq!(*expected, 16);
+                assert_eq!(*actual, 4);
+            }
+            other => panic!("expected SizeMismatch, got {other:?}"),
+        }
+        report(&results, dir.path()).expect_err("truncated file must fail");
+    }
+
+    #[test]
+    fn missing_file_is_reported_not_silently_skipped() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_manifest(dir.path(), &[("absent.bin", 10, &blake3_of(b"whatever"))]);
+        let results = verify_manifest(&dir.path().join(".apr-manifest.json"), dir.path())
+            .expect("verify runs");
+        assert_eq!(results[0].1, FileVerdict::Missing);
+        report(&results, dir.path()).expect_err("a missing shard must fail");
+    }
+
+    /// Fail-closed: a manifest naming zero files verified nothing, and must not
+    /// print success. Same defect class the command exists to expose.
+    #[test]
+    fn empty_manifest_fails_rather_than_reporting_success() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_manifest(dir.path(), &[]);
+        let results = verify_manifest(&dir.path().join(".apr-manifest.json"), dir.path())
+            .expect("verify runs");
+        assert!(results.is_empty());
+        let err = report(&results, dir.path()).expect_err("empty manifest must NOT pass");
+        assert!(
+            format!("{err}").contains("ZERO files"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn absent_manifest_is_an_error_not_a_pass() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let err = run_verify(dir.path()).expect_err("no manifest must not report success");
+        assert!(
+            format!("{err}").contains("No .apr-manifest.json"),
+            "got: {err}"
+        );
+    }
+
+    /// Verdicts are returned sorted, so output and assertions do not depend on
+    /// HashMap iteration order.
+    #[test]
+    fn results_are_deterministically_ordered() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        for name in ["c.bin", "a.bin", "b.bin"] {
+            std::fs::write(dir.path().join(name), name.as_bytes()).expect("write");
+        }
+        write_manifest(
+            dir.path(),
+            &[
+                ("c.bin", 5, &blake3_of(b"c.bin")),
+                ("a.bin", 5, &blake3_of(b"a.bin")),
+                ("b.bin", 5, &blake3_of(b"b.bin")),
+            ],
+        );
+        let results = verify_manifest(&dir.path().join(".apr-manifest.json"), dir.path())
+            .expect("verify runs");
+        let names: Vec<&str> = results.iter().map(|(n, _)| n.as_str()).collect();
+        assert_eq!(names, vec!["a.bin", "b.bin", "c.bin"]);
+        assert!(results.iter().all(|(_, v)| v.is_ok()));
+    }
+
+    /// Streamed hashing must agree with one-shot hashing across the 1 MiB
+    /// buffer boundary - otherwise large shards would false-positive.
+    #[test]
+    fn streamed_hash_matches_oneshot_across_buffer_boundary() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let body = vec![0xA5u8; (1 << 20) + 12345];
+        let p = dir.path().join("big.bin");
+        std::fs::write(&p, &body).expect("write");
+        assert_eq!(hash_file(&p).expect("hash"), blake3_of(&body));
+    }
+}

--- a/crates/apr-cli/src/commands_enum.rs
+++ b/crates/apr-cli/src/commands_enum.rs
@@ -452,6 +452,17 @@ pub enum Commands {
         /// Force re-download even if cached
         #[arg(long)]
         force: bool,
+        /// Verify an already-cached model by re-hashing every file against the
+        /// BLAKE3 checksums recorded in `.apr-manifest.json` at download time.
+        ///
+        /// `apr pull` has always RECORDED those hashes and never checked them:
+        /// the only integrity check in the tree compares file SIZE. Size cannot
+        /// see a same-length corruption (a 7.1 GB SafeTensors blob was found
+        /// with 27 of 339 tensors zeroed, byte-length exactly correct). This
+        /// costs O(bytes) by design, which is why it is opt-in. Performs no
+        /// network I/O.
+        #[arg(long)]
+        verify: bool,
         /// CRUX-A-01: resolve short name to canonical URL and exit without
         /// performing any network I/O.
         #[arg(long)]

--- a/crates/apr-cli/src/dispatch.rs
+++ b/crates/apr-cli/src/dispatch.rs
@@ -814,6 +814,7 @@ fn dispatch_model_commands(cli: &Cli) -> Option<Result<(), CliError>> {
             offline,
             include,
             output,
+            verify,
         } => {
             // SHIP-TWO-001 §26.8: when first positional is the literal
             // "dataset", treat the second positional as the HF dataset
@@ -836,6 +837,11 @@ fn dispatch_model_commands(cli: &Cli) -> Option<Result<(), CliError>> {
                         "apr pull dataset <REPO>: REPO argument required".to_string(),
                     )),
                 }
+            } else if *verify {
+                // Verify-only: no network I/O, no download. Resolves the cache
+                // directory for the reference and re-hashes what is on disk.
+                crate::commands::pull::resolve_cache_dir_for_ref(model_ref)
+                    .and_then(|dir| crate::commands::pull_verify::run_verify(&dir))
             } else {
                 pull::run(model_ref, *force, *dry_run, revision.as_deref(), *offline)
             }

--- a/crates/apr-cli/src/lib_dispatch_coverage.rs
+++ b/crates/apr-cli/src/lib_dispatch_coverage.rs
@@ -40,6 +40,7 @@
             offline: false,
             include: vec![],
             output: None,
+            verify: false,
         });
         let result = dispatch_model_commands(&cli);
         assert!(result.is_some(), "Pull should be handled by dispatch_model_commands");

--- a/crates/apr-cli/src/lib_extract_paths.rs
+++ b/crates/apr-cli/src/lib_extract_paths.rs
@@ -87,6 +87,7 @@
             offline: false,
             include: vec![],
             output: None,
+            verify: false,
         };
         let paths = extract_model_paths(&cmd);
         assert!(paths.is_empty(), "Pull is a diagnostic command (exempt)");

--- a/crates/apr-cli/src/lib_parse_export.rs
+++ b/crates/apr-cli/src/lib_parse_export.rs
@@ -308,6 +308,7 @@
                 offline: _,
                 include: _,
                 output: _,
+                verify: _,
             } => {
                 assert_eq!(model_ref, "hf://Qwen/Qwen2.5-Coder-1.5B");
                 assert!(force);
@@ -332,6 +333,7 @@
                 offline: _,
                 include: _,
                 output: _,
+                verify: _,
             } => {
                 assert_eq!(model_ref, "qwen2.5-coder");
                 assert!(!force);
@@ -356,6 +358,7 @@
                 offline: _,
                 include: _,
                 output: _,
+                verify: _,
             } => {
                 assert_eq!(model_ref, "llama3");
                 assert!(!force);


### PR DESCRIPTION
I surfaced this as *"worth a ticket"* and didn't build it. Building it.

## The gap

`apr pull` computes a BLAKE3 of every shard and writes it to `.apr-manifest.json` (`ShardManifest` / `FileChecksum`, GH-213). **That hash is then never compared to anything.** The only integrity check in the tree is `validate::validate_shard_manifest`, which describes itself in its own doc comment as:

> an O(1)-per-file check (stat syscall only, no hashing)

…and compares `size` alone. The repo has been recording the evidence and never reading it.

## Why size isn't enough

The motivating case was measured, not imagined: a 7.1 GB SafeTensors blob with **27 of 339 tensors reading back as `-0.0`**. Fully allocated (7,108,395,008 bytes on disk vs 7,108,390,387 apparent — not sparse), byte length exactly correct, and its SHA-256 didn't match the name HuggingFace gave it. A size check passes that file. A content hash rejects it.

## What it does

Re-reads every file named by the manifest and re-hashes with **streamed** BLAKE3 (1 MiB chunks, so a multi-gigabyte shard needn't be resident). **No network I/O** — it inspects an already-cached model, so it works offline and air-gapped. It costs O(bytes) by design, which is why it's opt-in rather than folded into every pull.

Verdicts are distinguished rather than lumped, because the diagnosis differs even when the remedy doesn't: `Ok` / `Missing` / `SizeMismatch` (truncated) / `HashMismatch` (right length, wrong bytes).

## End-to-end, with the real binary

```
intact                                         -> PASS, exit 0
flip ONE byte at offset 1,234,567 of a
2,000,000-byte shard (size 2000000 -> 2000000) -> CORRUPT, exit 5

  CORRUPT model-00001-of-00002.safetensors - size is correct but CONTENT differs
  OK      model-00002-of-00002.safetensors
  error: 1 of 2 file(s) failed verification ... Re-run `apr pull <model> --force`
```

The unaffected shard still reports `OK`, so the failure is localized rather than poisoning the whole report.

## Fail-closed

A manifest naming **zero** files is an error, not a pass — otherwise `--verify` would print "verified" having verified nothing, which is the same vacuous-gate defect it exists to expose. An absent manifest is likewise an error, not a silent success.

## Verification

8 unit tests, all executed: intact, same-size-different-content, truncation, missing file, empty manifest, absent manifest, deterministic ordering (verdicts sorted, so output doesn't depend on `HashMap` iteration order), and streamed-vs-one-shot hash agreement **across the 1 MiB buffer boundary** — without which large shards would false-positive.

Contract: `FT-SHGGUF-020/021` in `sharded-gguf-pull-v1.yaml`, both executed verbatim. `pv validate`: 0 errors, 0 warnings. `cargo fmt` clean; clippy clean.

## Not claimed

This verifies apr's **own** cache against apr's **own** recorded hashes. It does **not** verify the HuggingFace cache layout (`~/.cache/huggingface/hub/.../blobs/<sha256>`), where the blob filename *is* the expected hash — that's a separate and also-useful check, and the blob that motivated this lives there. Worth a follow-up; not silently folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)