### PR TITLE
docs(beat): record what the CI host actually measures for LinReg (0.788/0.805, ~11% headroom)

### DIFF
--- a/crates/aprender-core/tests/beat_sklearn_linreg_speed.rs
+++ b/crates/aprender-core/tests/beat_sklearn_linreg_speed.rs
@@ -40,6 +40,31 @@
 //! The large workload spans 0.49-0.64 across every locally inducible
 //! condition; the small one spanned 8x on CI.
 //!
+//! VALIDATED ON THE HOST THAT FAILED. Dispatched twice onto the clean-room
+//! pool at 200_000x50:
+//!
+//! ```text
+//!   apr=265.473ms sklearn=337.106ms ratio=0.788
+//!   apr=252.463ms sklearn=313.446ms ratio=0.805
+//! ```
+//!
+//! 2.2% spread, where the 10_000x20 configuration swung 0.234 -> 1.044 (346%)
+//! on that same pool. The stability goal is met.
+//!
+//! But read the LEVEL, not just the spread: on that host apr is ~1.25x faster,
+//! NOT the ~1.85x measured on lambda-vector, leaving only ~11% headroom under
+//! the 0.90 ceiling. apr is penalised more than sklearn by that host (2.3x vs
+//! 1.55x slower than lambda-vector). Do NOT "fix" a future failure here by
+//! enlarging the workload again - apr's advantage SHRINKS with size
+//! (0.26 at 10_000x20 -> 0.54 at 200_000x50 locally), so a bigger problem
+//! makes the ratio worse, not better.
+//!
+//! OPEN, not resolved here: the contract records baseline_floor 0.56, which
+//! describes neither this host (0.79-0.81) nor the old size (0.26). Whether
+//! that gap is slower CI hardware or a real apr regression cannot be settled
+//! without historical CI data at this size, and is deliberately not asserted
+//! either way.
+//!
 //! TWO HONEST CAVEATS. (1) The headline win SHRINKS with size: apr is ~3.6x
 //! faster at 10_000x20 but ~1.7x at 200_000x50. The smaller number is the one
 //! that can be measured reliably, and a gate that measures reliably is worth


### PR DESCRIPTION
Follow-up to #2345. This commit existed on that branch but was pushed **after** the merge queue had already snapshotted the PR, so the squash dropped it — the documented `squash-drops-late-commits` trap, caught by diffing main rather than assuming.

Main currently carries a claim I have since measured to be wrong for the host the gate runs on.

## What #2345's doc comment says vs. what CI measures

#2345 justified the new workload with numbers from lambda-vector (Threadripper 7960X): apr ~1.85× faster, 42% headroom. I then dispatched `beat-speed-nightly` **twice onto the clean-room pool** — the host that produced the original 1.044 excursion:

```
apr=265.473ms sklearn=337.106ms ratio=0.788
apr=252.463ms sklearn=313.446ms ratio=0.805
```

**The stability goal is met:** 2.2% spread, where the 10 000×20 configuration swung 0.234 → 1.044 (346%) on that same pool.

**But the level differs materially.** On that host apr is ~**1.25×** faster, not ~1.85×, leaving ~**11%** headroom under the 0.90 ceiling rather than 42%. It penalises apr more than sklearn — 2.3× vs 1.55× slower than lambda-vector.

## Two things recorded for whoever hits this next

**Do not enlarge the workload again** if this ever fails. apr's advantage *shrinks* with size (0.26 at 10 000×20 → 0.54 at 200 000×50, locally), so a bigger problem makes the ratio **worse**. That's the obvious next move and it's the wrong one.

**The contract's `baseline_floor: 0.56` describes neither host** — not this one (0.79–0.81) and not the old size (0.26). Whether that gap is slower CI hardware or a real apr regression cannot be settled without historical CI data at this size, so it is left explicitly open rather than asserted in either direction.

Docs only — no code, no threshold changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)