### PR TITLE
fix(ci): the nightly Qwen story died after six lines and every path meant to report it was broken

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -408,6 +408,15 @@ jobs:
       # green. Text-only check, no build.
       - name: Every CI-surface `apr` invocation must be pinned
         run: bash scripts/check_apr_bin_pinned.sh
+      # Poka-yoke: `set` in a SOURCED file mutates the caller's shell. apr_bin.sh
+      # opened with `set -euo pipefail`; qwen-story.sh sources it and had chosen
+      # `set -uo pipefail` deliberately (it must run every beat and tally the
+      # failures). The leak turned errexit on underneath it and the nightly
+      # story died after six lines inside an ADVISORY pmat hunt. Both files read
+      # correctly on their own - only the combination is wrong, which is why
+      # this is mechanical rather than a review note. Text-only, no build.
+      - name: Sourced libraries must not mutate the caller's shell options
+        run: bash scripts/check_sourced_libs_option_neutral.sh --self-test
 
   # Top-level gate: satisfies org ruleset "Green Main" which requires check named "gate".
   # The reusable workflow produces "ci / gate" but rulesets need exact match on "gate".

--- a/.github/workflows/qwen-story-daily.yml
+++ b/.github/workflows/qwen-story-daily.yml
@@ -115,10 +115,20 @@ jobs:
 
       - name: Extract pmat bug-hunt manifest
         id: manifest
+        shell: bash
         run: |
           # Pull the pmat hunt lines out of the log into a structured artifact.
+          #
+          # The pattern used to be '^(    gap|    churn|    fault)' - FOUR
+          # leading spaces - while qwen-story.sh emits these rows with EIGHT
+          # (see the pmat_rows filters). So it matched nothing, on every run:
+          # pmat-manifest.txt was 0 lines even on nights when the story log
+          # plainly contained `        churn ...` rows, which in turn pinned
+          # `growth` at 0 forever and made the "manifest grew by >5" alert
+          # branch below unreachable. Anchor on leading whitespace instead of a
+          # hardcoded indent so the two files cannot drift apart again.
           mkdir -p /tmp/qwen-story-artifacts
-          grep -E '^(    gap|    churn|    fault)' /tmp/story.log \
+          grep -E '^[[:space:]]+(gap|churn|fault)[[:space:]]' /tmp/story.log \
             > /tmp/qwen-story-artifacts/pmat-manifest.txt || true
           LINES=$(wc -l < /tmp/qwen-story-artifacts/pmat-manifest.txt)
           echo "manifest_lines=$LINES" >> "$GITHUB_OUTPUT"
@@ -148,14 +158,31 @@ jobs:
           path: /tmp/story.log
           retention-days: 30
 
+      # NOTE `continue-on-error`. This step NOTIFIES; it does not judge. When it
+      # was allowed to fail it took the real verdict down with it: on 2026-07-31
+      # it died with "could not add label: 'qwen-story-daily' not found", which
+      # (a) made the job's error message about labels instead of about the story
+      # and (b) skipped "Fail the job" below, because a step `if:` without a
+      # status function carries an implicit `success()`. Notification failures
+      # must never be able to mask or fake the story's own result.
       - name: File / update tracking issue on failure
+        continue-on-error: true
         if: |
           (steps.story.outputs.exit_code != '0' ||
            fromJson(steps.manifest.outputs.growth || '0') > 5) &&
           (github.event.inputs.file_issue != 'false')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
         run: |
+          set -uo pipefail
+          # Neither `qwen-story-daily` nor `regression` existed in this repo, so
+          # `gh issue create --label qwen-story-daily,regression` had never once
+          # succeeded - the alerting path was dead from the day it was written.
+          # Create them idempotently rather than assuming a human did.
+          for L in qwen-story-daily regression; do
+            gh label create "$L" --description "Filed by qwen-story-daily" --force >/dev/null 2>&1 || true
+          done
           TITLE="qwen-story-daily: story exit=${{ steps.story.outputs.exit_code }} manifest_growth=${{ steps.manifest.outputs.growth }}"
           # Look for an existing open issue with the qwen-story-daily label.
           EXISTING=$(gh issue list --label qwen-story-daily --state open --limit 1 \
@@ -187,8 +214,29 @@ jobs:
               --body-file /tmp/issue-body.md
           fi
 
+      # `always() &&` is load-bearing. Without a status function GitHub prepends
+      # an implicit `success()`, so ANY earlier step failing skips this one -
+      # including the purely cosmetic issue-filing step above. That is exactly
+      # what happened on 2026-07-31: the story really had failed, this step was
+      # skipped, and the job's only error was about a missing label. The
+      # authoritative verdict must not be conditional on the notifier's health.
       - name: Fail the job if the story failed
-        if: steps.story.outputs.exit_code != '0'
+        if: always() && steps.story.outputs.exit_code != '0'
         run: |
           echo "::error::Qwen story exited with code ${{ steps.story.outputs.exit_code }}. See artifact 'story-log' for details."
           exit 1
+
+      # Fail closed on a MISSING verdict. `exit_code` is written by the story
+      # step; if that step is itself skipped or dies before the redirect, the
+      # output is the empty string, `'' != '0'` is true, and the step above
+      # already fails. This one covers the opposite hole: a story step that
+      # somehow reports success without ever having produced a verdict.
+      - name: The story must have produced a verdict
+        if: always()
+        run: |
+          EC='${{ steps.story.outputs.exit_code }}'
+          if [ -z "$EC" ]; then
+            echo "::error::qwen-story.sh produced NO exit_code output - the run cannot be called green."
+            exit 1
+          fi
+          echo "story verdict: exit_code=$EC"

--- a/scripts/apr_bin.sh
+++ b/scripts/apr_bin.sh
@@ -18,8 +18,20 @@
 # already embeds the build-time git SHA (contract apr-version-traceability-v1,
 # F-VERSION-001..004): `apr --version` prints e.g. `apr 0.61.0 (e514cc5ed)`.
 # So "was this binary built from HEAD?" is a string comparison, not a guess.
-
-set -euo pipefail
+#
+# DELIBERATELY NO `set -euo pipefail` AT FILE SCOPE. This file is SOURCED, and
+# `set` in a sourced file mutates the CALLER's shell. The first version of this
+# script did `set -euo pipefail` here; qwen-story.sh sources it and had chosen
+# `set -uo pipefail` WITHOUT `-e` on purpose - the whole script is built around
+# running every beat and counting failures (emit_fail/FAILED_BEATS). Turning
+# errexit on under it meant the first non-zero command anywhere killed the run:
+# the nightly story died after SIX LINES, inside Beat 1's advisory pmat hunt,
+# and reported nothing about why. A sourceable library must be option-neutral.
+#
+# Fail-closed is preserved explicitly instead: the bottom of this file returns
+# non-zero when the binary is stale, so callers use
+#     . scripts/apr_bin.sh || exit 1
+# which fails the same way errexit would, without seizing the caller's shell.
 
 apr_bin_die() {
     printf '%s\n' "$*" >&2
@@ -86,8 +98,20 @@ apr_bin_assert_fresh() {
     return 1
 }
 
-APR=$(apr_bin_resolve) || apr_bin_die "apr_bin: no apr binary found (build one: cargo install --path crates/apr-cli --force)"
-apr_bin_assert_fresh "$APR"
+# Fail-closed without errexit. At the top level of a SOURCED file `return N`
+# ends the source with that status, so `. apr_bin.sh || exit 1` behaves exactly
+# as it did under `set -e`. When this file is EXECUTED instead, top-level
+# `return` is an error, and the `||` falls through to `exit`. One line covers
+# both entry points.
+if ! APR=$(apr_bin_resolve); then
+    apr_bin_die "apr_bin: no apr binary found (build one: cargo install --path crates/apr-cli --force)"
+    return 1 2>/dev/null || exit 1
+fi
+
+if ! apr_bin_assert_fresh "$APR"; then
+    return 1 2>/dev/null || exit 1
+fi
+
 export APR
 
 # When executed rather than sourced, print the resolved path.

--- a/scripts/check_sourced_libs_option_neutral.sh
+++ b/scripts/check_sourced_libs_option_neutral.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# check_sourced_libs_option_neutral.sh - a sourced script may not change the
+# caller's shell options.
+#
+# THE CLASS. `set` inside a sourced file mutates the SOURCING shell, not a
+# child. scripts/apr_bin.sh opened with `set -euo pipefail`; scripts/qwen-story.sh
+# sources it and had deliberately chosen `set -uo pipefail` WITHOUT `-e`,
+# because its whole design is to run every beat and tally failures. The source
+# silently turned errexit on underneath it, so the first non-zero command
+# anywhere aborted the run: the nightly story died after six lines, inside an
+# ADVISORY pmat hunt, and the log said nothing about why.
+#
+# The leak is invisible in review - both files are individually correct, and
+# `set -euo pipefail` is the thing you are normally praised for writing. Only
+# the COMBINATION is wrong, which is why this is a mechanical check rather than
+# a style note.
+#
+# A sourced library must be option-neutral and signal failure by RETURN STATUS:
+#     . scripts/apr_bin.sh || exit 1
+#
+# Exit 0 = every sourced library leaves the caller's options alone.
+# Exit 1 = at least one sets shell options at file scope.
+#
+# `--self-test` proves the check can still turn RED, by running it against a
+# reconstruction of the exact pre-fix apr_bin.sh header.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.." || exit 1
+
+SEARCH_DIR="scripts"
+
+# `set` with the errexit / nounset / pipefail family, at column 0 (file scope).
+# Indented `set` lines live inside functions or blocks, where the option change
+# is at least visible to the reader of that function.
+SETOPT_RE='^set[[:space:]]+[-+]'
+
+# Which files are actually SOURCED by another SCRIPT? Only those can leak: a
+# script that is merely executed (`bash scripts/foo.sh`) gets its own shell.
+#
+# Deliberately scoped to script-to-script sourcing, and deliberately anchored on
+# `.`/`source` as the FIRST token of a line. An earlier draft also scanned
+# .github/workflows/*.yml for `scripts/*.sh` near a `.` or `source`, and
+# promptly flagged check_format_sovereignty.sh - because ci.yml contains the
+# COMMENT "# catch dev-dep cycles. See scripts/check_format_sovereignty.sh",
+# where the sentence-ending period parsed as the source builtin. A workflow
+# `run:` block is its own throwaway shell anyway, so a `set` leak there cannot
+# outlive the block. Narrow and sound beats broad and wrong.
+sourced_basenames() {
+    grep -rhoE '^[[:space:]]*(\.|source)[[:space:]]+[^;&|#]+' "$SEARCH_DIR"/*.sh 2>/dev/null \
+        | grep -oE '[A-Za-z0-9_.-]+\.sh' | sort -u
+}
+
+scan_file() {
+    local f="$1"
+    grep -nE "$SETOPT_RE" "$f" 2>/dev/null || true
+}
+
+violations=0
+checked=0
+
+for base in $(sourced_basenames); do
+    f="$SEARCH_DIR/$base"
+    [ -f "$f" ] || continue
+    # A file that sources itself is not interesting; skip self-references.
+    checked=$((checked + 1))
+    hits=$(scan_file "$f")
+    if [ -n "$hits" ]; then
+        printf 'OPTION-LEAK %s is sourced by another script but sets shell options:\n' "$f" >&2
+        printf '%s\n' "$hits" | sed 's/^/           /' >&2
+        violations=$((violations + 1))
+    fi
+done
+
+# --self-test: reconstruct the pre-fix header and prove the matcher rejects it.
+# Without this, a matcher that silently stopped matching would report success.
+if [ "${1:-}" = "--self-test" ]; then
+    # Fed to grep on stdin rather than written to temp files: identical to
+    # scanning a file with this content, minus a mktemp, a trap and an
+    # `rm -rf "$tmp"` that bashrs rightly flags (SEC011) in a script whose only
+    # job is to read files.
+    bad_lib=$(printf '#!/usr/bin/env bash\n# a sourceable helper\n\nset -euo pipefail\n\nfoo() { :; }\n')
+    good_lib=$(printf '#!/usr/bin/env bash\n# a sourceable helper\n\nfoo() { :; }\n')
+
+    bad_hits=$(printf '%s\n' "$bad_lib" | grep -nE "$SETOPT_RE" || true)
+    good_hits=$(printf '%s\n' "$good_lib" | grep -nE "$SETOPT_RE" || true)
+
+    if [ -z "$bad_hits" ]; then
+        printf 'SELF-TEST FAILED: the matcher no longer flags `set -euo pipefail`.\n' >&2
+        exit 1
+    fi
+    if [ -n "$good_hits" ]; then
+        printf 'SELF-TEST FAILED: the matcher flags an option-neutral library.\n' >&2
+        exit 1
+    fi
+    printf 'self-test OK: rejects the pre-fix header, accepts an option-neutral one.\n'
+fi
+
+if [ "$violations" -gt 0 ]; then
+    printf '\n%s sourced librar(y/ies) mutate the caller shell (%s checked).\n' \
+        "$violations" "$checked" >&2
+    printf 'Remove the file-scope `set` and fail by return status instead:\n' >&2
+    printf '    # in the library, at file scope:\n' >&2
+    printf '    some_check || { return 1 2>/dev/null || exit 1; }\n' >&2
+    printf '    # at the call site:\n' >&2
+    printf '    . scripts/the_lib.sh || exit 1\n' >&2
+    exit 1
+fi
+
+# Fail closed: a discovery step that found nothing must not report success.
+MIN_EXPECTED="${MIN_EXPECTED:-1}"
+if [ "$checked" -lt "$MIN_EXPECTED" ]; then
+    printf 'ERROR: examined %s sourced librar(y/ies), expected >= %s - discovery has gone blind.\n' \
+        "$checked" "$MIN_EXPECTED" >&2
+    exit 1
+fi
+
+printf 'OK: %s sourced librar(y/ies) checked, none mutates the caller shell.\n' "$checked"

--- a/scripts/qwen-story.sh
+++ b/scripts/qwen-story.sh
@@ -16,6 +16,9 @@
 # Each beat uses OUT=$(cmd); EC=$? to avoid the pipe-then-$? methodology
 # defect documented in memory/feedback_test_methodology_can_fake_bugs.md.
 
+# NOTE the deliberate absence of `-e`. This script's contract is to run EVERY
+# beat and tally the results (emit_fail / FAILED_BEATS / exit 2), so a failing
+# beat must not abort the run. Anything sourced below must not turn errexit on.
 set -uo pipefail
 
 # Resolve `apr` and PROVE it was built from this commit. Sourcing this exports
@@ -23,8 +26,12 @@ set -uo pipefail
 # PATH, and on the cuda runner ~/.local/bin held a 24-day-old build that
 # shadowed the freshly installed one - so every beat below validated stale code
 # while reporting green. Set APR_BIN to override which binary is used.
+#
+# The explicit `|| exit 1` is what makes a stale binary fatal. apr_bin.sh used
+# to get that effect by doing `set -euo pipefail` at its own file scope, which
+# leaked errexit into THIS script and killed the nightly run six lines in.
 # shellcheck source=scripts/apr_bin.sh
-. "$(dirname "${BASH_SOURCE[0]}")/apr_bin.sh"
+. "$(dirname "${BASH_SOURCE[0]}")/apr_bin.sh" || exit 1
 
 MODELS_DIR="${MODELS_DIR:-$HOME/models}"
 PMAT_HUNT="${PMAT_HUNT:-1}"  # 1 = run pmat full audit per beat
@@ -86,6 +93,32 @@ emit_evidence() {
   printf '%s\n' "$RC_OUT" | sed 's/^/    /'
 }
 
+# Extract rows from one `pmat query`, tolerating BOTH shapes pmat can return.
+#
+# A function query returns a JSON ARRAY of function records, but when nothing
+# matches semantically pmat falls back to a document search and returns
+# `{"documents":[...]}` instead. The original filter ran `.[] | \(.function)`
+# unconditionally: on the fallback shape `.[]` yields the documents ARRAY, and
+# interpolating `.function` from an array raises "Cannot index array with
+# function" - jq exits 5. Under `pipefail` the whole assignment then returned
+# 5, which is what killed the nightly story once errexit leaked in from
+# apr_bin.sh. Guarding on `type == "array"` makes the no-match case yield an
+# empty string instead of an error.
+#
+# `|| true` is deliberate and load-bearing: this manifest is ADVISORY. It
+# annotates the story, and must never be able to fail it - not via pmat's exit
+# status, not via jq, not via SIGPIPE from `head`.
+#
+# Args: <jq-output-filter> <pmat query args...>
+pmat_rows() {
+  local filter="$1"; shift
+  pmat query "$@" --format json 2>/dev/null \
+    | jq -r "if type == \"array\" then .[] else empty end
+             | select(.function != null)
+             | $filter" 2>/dev/null \
+    | head -3 || true
+}
+
 # Run pmat full audit on a list of command module patterns. Outputs a compact
 # manifest (top 3 high-risk untested functions, top 3 churn, top 3 faults).
 pmat_hunt() {
@@ -96,17 +129,18 @@ pmat_hunt() {
   printf '    -- pmat bug-hunt manifest (%s) --\n' "$beat"
   for q in "$@"; do
     local gaps churn faults
-    gaps=$(pmat query --coverage-gaps --path "$q" --rank-by impact --limit 3 \
-      --format json 2>/dev/null | jq -r '.[] | "        gap   \(.function) (impact=\(.impact_score // "?"))"' 2>/dev/null | head -3)
-    churn=$(pmat query "$beat" --path "$q" --churn --max-complexity 30 --limit 3 \
-      --format json 2>/dev/null | jq -r '.[] | "        churn \(.function) (commits=\(.churn.commit_count // "?"))"' 2>/dev/null | head -3)
-    faults=$(pmat query "$beat" --path "$q" --faults --exclude-tests --limit 3 \
-      --format json 2>/dev/null | jq -r '.[] | "        fault \(.function) (\(.faults | join(\",\")))"' 2>/dev/null | head -3)
+    gaps=$(pmat_rows '"        gap   \(.function) (impact=\(.impact_score // "?"))"' \
+      --coverage-gaps --path "$q" --rank-by impact --limit 3)
+    churn=$(pmat_rows '"        churn \(.function) (commits=\(.churn.commit_count // "?"))"' \
+      "$beat" --path "$q" --churn --max-complexity 30 --limit 3)
+    faults=$(pmat_rows '"        fault \(.function) (\(.faults | join(",")))"' \
+      "$beat" --path "$q" --faults --exclude-tests --limit 3)
     [ -n "$gaps" ]   && printf '%s\n' "$gaps"
     [ -n "$churn" ]  && printf '%s\n' "$churn"
     [ -n "$faults" ] && printf '%s\n' "$faults"
   done
   printf '\n'
+  return 0
 }
 
 # -- Beat 1: Discover (0.5B SafeTensors) --------------------------------------─


### PR DESCRIPTION
The 2026-07-31 `qwen-story-daily` run went red with `could not add label: 'qwen-story-daily' not found`. That message is about the notifier. **The story itself had failed**, and four independent defects conspired to make that unsayable.

### 1. errexit leak — a regression from #2344 (mine)

`scripts/apr_bin.sh` opened with `set -euo pipefail`. It is **sourced**, and `set` in a sourced file mutates the *caller's* shell. `qwen-story.sh` had chosen `set -uo pipefail` **without** `-e` deliberately — its entire design is to run all eight beats and tally failures (`emit_fail` / `FAILED_BEATS` / `exit 2`). Under the leaked errexit, the first non-zero command aborted the run.

Reproduced at `12551dd19`: **exit 5, six lines**, dead inside Beat 1's *advisory* pmat hunt. With this fix, the same tree runs all eight beats — **153 lines, 13 PASS / 1 FAIL / 1 SKIP, 215s**.

`apr_bin.sh` now fails by return status; callers use `. scripts/apr_bin.sh || exit 1`, which is fail-closed in exactly the same way without seizing the caller's shell.

### 2. jq shape mismatch

`pmat query --format json` returns an **array** of function records — but on a semantic miss it falls back to a document search and returns `{"documents":[...]}`. The filter ran `.[] | \(.function)` unconditionally, so the fallback shape raised *"Cannot index array with function"* → jq **exit 5**, propagated by `pipefail`. That was the specific non-zero that defect 1 turned fatal.

Now shape-guarded, and `|| true` — an advisory manifest must never be able to fail the story it annotates.

### 3. The manifest grep never matched anything

The extractor looked for `^    gap` (**four** spaces); the script emits **eight**. `pmat-manifest.txt` was 0 lines on *every* run — including nights whose logs plainly contained `        churn ...` rows. That pinned `growth` at 0 forever and made the "manifest grew by >5" alert branch unreachable.

### 4. The verdict was gated behind the notifier

Neither `qwen-story-daily` nor `regression` existed as repo labels, so `gh issue create --label` had **never once succeeded**. Worse: a step `if:` without a status function carries an implicit `success()`, so that failure **skipped** `Fail the job if the story failed`. The job went red for the wrong reason, by accident.

Labels are now created idempotently, the notifier is `continue-on-error`, the verdict step is `always() && ...`, and a new step fails closed when no verdict was produced at all.

### Ratchet

`scripts/check_sourced_libs_option_neutral.sh`. Both files in defect 1 read correctly in isolation — only the *combination* is wrong, which is why this is mechanical rather than a review note.

**Mutation-verified against the real pre-fix header**: RED with it, GREEN without. Wired into ci.yml's text-only guard job with `--self-test`.

An earlier draft also scanned workflows and flagged `check_format_sovereignty.sh`, because ci.yml contains the comment `# catch dev-dep cycles. See scripts/check_format_sovereignty.sh` — the sentence-ending period parsed as the source builtin. Scope is now script-to-script only; a workflow `run:` block is its own throwaway shell.

### Blast radius

**One nightly.** #2344 landed after the 07-30 run (green at `e514cc5ed`); 07-31 was the first run to source `apr_bin.sh`.

### Not fixed here

The revived story surfaces a real finding: B2 `apr qa` **Golden Output** now fails on the 1.5B model where it passed on 07-30. No commit in that range touches inference, so it is filed separately rather than assumed to be a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)