### PR TITLE
fix(beat): withdraw the unreproducible ollama decode 1.371x claim — apr is at PARITY, not 1.37x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -408,6 +408,15 @@ jobs:
       # green. Text-only check, no build.
       - name: Every CI-surface `apr` invocation must be pinned
         run: bash scripts/check_apr_bin_pinned.sh
+      # Poka-yoke: `set` in a SOURCED file mutates the caller's shell. apr_bin.sh
+      # opened with `set -euo pipefail`; qwen-story.sh sources it and had chosen
+      # `set -uo pipefail` deliberately (it must run every beat and tally the
+      # failures). The leak turned errexit on underneath it and the nightly
+      # story died after six lines inside an ADVISORY pmat hunt. Both files read
+      # correctly on their own - only the combination is wrong, which is why
+      # this is mechanical rather than a review note. Text-only, no build.
+      - name: Sourced libraries must not mutate the caller's shell options
+        run: bash scripts/check_sourced_libs_option_neutral.sh --self-test
 
   # Top-level gate: satisfies org ruleset "Green Main" which requires check named "gate".
   # The reusable workflow produces "ci / gate" but rulesets need exact match on "gate".

--- a/.github/workflows/qwen-story-daily.yml
+++ b/.github/workflows/qwen-story-daily.yml
@@ -115,10 +115,20 @@ jobs:
 
       - name: Extract pmat bug-hunt manifest
         id: manifest
+        shell: bash
         run: |
           # Pull the pmat hunt lines out of the log into a structured artifact.
+          #
+          # The pattern used to be '^(    gap|    churn|    fault)' - FOUR
+          # leading spaces - while qwen-story.sh emits these rows with EIGHT
+          # (see the pmat_rows filters). So it matched nothing, on every run:
+          # pmat-manifest.txt was 0 lines even on nights when the story log
+          # plainly contained `        churn ...` rows, which in turn pinned
+          # `growth` at 0 forever and made the "manifest grew by >5" alert
+          # branch below unreachable. Anchor on leading whitespace instead of a
+          # hardcoded indent so the two files cannot drift apart again.
           mkdir -p /tmp/qwen-story-artifacts
-          grep -E '^(    gap|    churn|    fault)' /tmp/story.log \
+          grep -E '^[[:space:]]+(gap|churn|fault)[[:space:]]' /tmp/story.log \
             > /tmp/qwen-story-artifacts/pmat-manifest.txt || true
           LINES=$(wc -l < /tmp/qwen-story-artifacts/pmat-manifest.txt)
           echo "manifest_lines=$LINES" >> "$GITHUB_OUTPUT"
@@ -148,14 +158,31 @@ jobs:
           path: /tmp/story.log
           retention-days: 30
 
+      # NOTE `continue-on-error`. This step NOTIFIES; it does not judge. When it
+      # was allowed to fail it took the real verdict down with it: on 2026-07-31
+      # it died with "could not add label: 'qwen-story-daily' not found", which
+      # (a) made the job's error message about labels instead of about the story
+      # and (b) skipped "Fail the job" below, because a step `if:` without a
+      # status function carries an implicit `success()`. Notification failures
+      # must never be able to mask or fake the story's own result.
       - name: File / update tracking issue on failure
+        continue-on-error: true
         if: |
           (steps.story.outputs.exit_code != '0' ||
            fromJson(steps.manifest.outputs.growth || '0') > 5) &&
           (github.event.inputs.file_issue != 'false')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
         run: |
+          set -uo pipefail
+          # Neither `qwen-story-daily` nor `regression` existed in this repo, so
+          # `gh issue create --label qwen-story-daily,regression` had never once
+          # succeeded - the alerting path was dead from the day it was written.
+          # Create them idempotently rather than assuming a human did.
+          for L in qwen-story-daily regression; do
+            gh label create "$L" --description "Filed by qwen-story-daily" --force >/dev/null 2>&1 || true
+          done
           TITLE="qwen-story-daily: story exit=${{ steps.story.outputs.exit_code }} manifest_growth=${{ steps.manifest.outputs.growth }}"
           # Look for an existing open issue with the qwen-story-daily label.
           EXISTING=$(gh issue list --label qwen-story-daily --state open --limit 1 \
@@ -187,8 +214,29 @@ jobs:
               --body-file /tmp/issue-body.md
           fi
 
+      # `always() &&` is load-bearing. Without a status function GitHub prepends
+      # an implicit `success()`, so ANY earlier step failing skips this one -
+      # including the purely cosmetic issue-filing step above. That is exactly
+      # what happened on 2026-07-31: the story really had failed, this step was
+      # skipped, and the job's only error was about a missing label. The
+      # authoritative verdict must not be conditional on the notifier's health.
       - name: Fail the job if the story failed
-        if: steps.story.outputs.exit_code != '0'
+        if: always() && steps.story.outputs.exit_code != '0'
         run: |
           echo "::error::Qwen story exited with code ${{ steps.story.outputs.exit_code }}. See artifact 'story-log' for details."
           exit 1
+
+      # Fail closed on a MISSING verdict. `exit_code` is written by the story
+      # step; if that step is itself skipped or dies before the redirect, the
+      # output is the empty string, `'' != '0'` is true, and the step above
+      # already fails. This one covers the opposite hole: a story step that
+      # somehow reports success without ever having produced a verdict.
+      - name: The story must have produced a verdict
+        if: always()
+        run: |
+          EC='${{ steps.story.outputs.exit_code }}'
+          if [ -z "$EC" ]; then
+            echo "::error::qwen-story.sh produced NO exit_code output - the run cannot be called green."
+            exit 1
+          fi
+          echo "story verdict: exit_code=$EC"

--- a/contracts/beat-ollama-decode-throughput-speed-v1.yaml
+++ b/contracts/beat-ollama-decode-throughput-speed-v1.yaml
@@ -9,14 +9,31 @@ metadata:
     than ollama" observation (PMAT-742, 2026-06-13) from TRACKING into a
     falsifiable GATED beat.
 
-    VERDICT (2026-06-15, RE-MEASURED with the #2049 FP8 stall fix applied):
-    PROMOTED to status=enforced. The ~1.3x clean-decode advantage is REAL and is
-    now NON-FLAKY because the ~1-in-6 catastrophic decode stall (the old variance
-    blocker) is GONE once #2049's FP8-warmup OOB fix is on the decode path. The
-    enforced gate is apr median-of-7 decode tok/s >= ollama median x 1.10 — a wide
-    safety margin under the measured 1.37x median, with a bootstrapped ~0% false-
-    FAIL rate. It stays a MANUAL/GPU gate (#[ignore], NVIDIA host only) because
-    there is NO NVIDIA CI runner — same caveat as the cuda-oxide throughput gate.
+    VERDICT SUPERSEDED 2026-07-31 — THE 1.371x BEAT CLAIM IS WITHDRAWN.
+    This is now a NO-COLLAPSE PARITY FLOOR, not a beat. apr does not currently
+    win GPU decode against ollama on sm_89.
+
+    Four independent measurements on the same host (lambda RTX 4090 sm_89):
+      2026-06-15  apr 412.3  ollama 300.7  1.371x  promotion claim (#2067)
+      2026-07-29  apr 332.7  ollama 299.9  1.109x  cuda-nightly, PASSED
+      2026-07-31  apr 342.4  ollama 328.6  1.042x  cuda-nightly, FAILED
+      2026-07-31  apr 318.2  ollama 313.5  1.015x  idle box, this harness
+    The OLLAMA column reproduces across six weeks (300.7/299.9/328.6/313.5), so
+    the drift is not the measuring rig. The 2026-07-29 PASS at 1.109x was already
+    this regression clearing the gate by 0.8%; it went unexamined because green.
+
+    #2323 (2026-07-27) made auto_q4k return Mwv on every device; sm_89 previously
+    defaulted to HwDp4a, whose INT8 activation quant fails the F2 first-token
+    cosine floor (0.9186 < 0.95). The 412.3 figure predates that change. This is
+    NOT "#2323 cost 23%": re-running today with HW_DP4A_Q4K=1 measures 20.3 tok/s,
+    because HwDp4a is F2-rejected and the run ends on CPU SIMD. The claim is
+    withdrawn as unreproducible, not reattributed.
+
+    The floor is 0.90: 12% under the worst observed median so it does not flake,
+    while still catching the class that matters (CPU fallback ~= ratio 0.065).
+    Restoring a >= 1.10x win is tracked separately; until then Pillar-4 must not
+    claim a GPU decode win over ollama on sm_89. Still a MANUAL/GPU gate
+    (#[ignore], NVIDIA host only).
 
     SCOPE: STEADY-STATE GPU DECODE only — marginal token-generation rate with
     model load + FP8-weight-cache build + CUDA-graph capture + prefill amortized
@@ -62,8 +79,8 @@ version: 2
 status: enforced
 date: 2026-06-15
 
-# Beat-benchmark parameters. baseline_value records the RE-MEASURED CLEAN-decode
-# ratio (1.371x); beat_threshold (1.10) is the ENFORCED gate threshold the
+# Beat-benchmark parameters. baseline_value records the WORST reproducible
+# post-#2323 ratio (1.015x); beat_threshold (0.90) is the no-collapse floor the
 # median-of-7 harness asserts on an NVIDIA host.
 beat:
   pillar: 4
@@ -81,9 +98,12 @@ beat:
     ollama_median_eval_tps. NOT one-shot cold wall-clock (conceded).
   metric: decode_tps_ratio_apr_over_ollama
   direction: higher_is_better
-  baseline_value: 1.3710      # RE-MEASURED CLEAN-decode median ratio apr/ollama (412.3 / 300.7), #2049+#2060 applied
-  baseline_floor: 1.2300      # WORST single re-measured run (369.9 / 300.7); every single run clears the 1.10x gate
-  beat_threshold: 1.1000      # the ENFORCED gate threshold: apr median-of-7 decode tok/s >= ollama median x 1.10
+  baseline_value: 1.0150      # WITHDRAWN 2026-07-31: the 1.371x (412.3/300.7, 2026-06-15) is NOT reproducible.
+                              # Measured post-#2323 on the same host: 1.109 (07-29), 1.042 (07-31), 1.015 (idle).
+                              # Pinned to the WORST of the three, not the best.
+  baseline_floor: 0.9000      # NO-COLLAPSE floor, 12% under the worst observed median (1.015). Not a beat floor.
+  beat_threshold: 0.9000      # no-collapse gate: apr median-of-7 >= ollama median x 0.90. 1.10 asserted a win
+                              # apr does not currently have and failed ~every other night. Recovery tracked separately.
   baseline_sourced_date: "2026-06-15"
   approved_compute: GPU       # RTX 4090 (sm_89) steady-state decode; needs apr --features cuda + ollama
   ci_gate_name: "beat_ollama_decode_throughput_speed"

--- a/crates/aprender-serve/tests/beat_ollama_decode_throughput_speed.rs
+++ b/crates/aprender-serve/tests/beat_ollama_decode_throughput_speed.rs
@@ -7,24 +7,56 @@
 //! gate is MANUAL/operator-gated (lambda-vector RTX 4090 or gx10 GB10), exactly
 //! like the cuda-oxide throughput beat. The CPU unit tests below DO run in CI.
 //!
-//! ## VERDICT: PROMOTED to ENFORCED (re-measure-first honesty — task step 1)
-//! A real ~1.3x CLEAN-decode advantage EXISTS and is now NON-FLAKY. The blocker
-//! for the prior TRACKING verdict was apr's ~1-in-6 CATASTROPHIC DECODE STALL (a
-//! run takes ~36s and stops early — the known FUSION-003 "1-in-6 CUDA_ERROR"
-//! class), which made a median gate flake. That stall is FIXED by #2049 (the
-//! FP8-warmup OOB read that poisoned the CUDA context). Re-measured on RTX 4090
-//! with #2049 (+ #2060 layout/elementwise kernel-arg fix) applied:
-//!   apr 128/384 differential [458.0, 411.2, 430.4, 421.3, 369.9, 413.4, 384.3,
-//!   402.1] tok/s, median 412.3, worst 369.9; ollama median ~300.7 tok/s;
-//!   median ratio 1.371x; worst single run 1.230x; 0 stalls / 8 trials.
-//! Every single run cleared 1.10x, and a median-of-7 >= 1.10x gate bootstraps to a
-//! ~0% false-FAIL rate. So this harness now asserts the ENFORCED gate:
-//! apr MEDIAN-OF-7 decode tok/s >= ollama median x 1.10.
+//! ## VERDICT 2026-07-31: the 1.371x BEAT CLAIM IS WITHDRAWN. This is now a
+//! ## NO-COLLAPSE PARITY FLOOR, not a beat. apr does not currently win here.
 //!
-//! ## DEPENDENCY (task step 5): this gate's no-stall premise needs #2049 on main
-//! The ENFORCED 1.10x assertion is only non-flaky because the FP8-warmup OOB stall
-//! is fixed. If #2049 is reverted/absent, the ~1-in-6 stall returns and the median
-//! can flake — do NOT enforce without #2049.
+//! The old header asserted "median ratio 1.371x, worst single run 1.230x, every
+//! single run clears 1.10x, bootstrapped ~0% false-FAIL". That claim is not
+//! reproducible on this host and has been removed rather than re-explained.
+//!
+//! FOUR INDEPENDENT MEASUREMENTS, one host (lambda RTX 4090 sm_89):
+//!   date        apr median   ollama median   ratio    source
+//!   2026-06-15    412.3         300.7        1.371x   promotion claim (#2067)
+//!   2026-07-29    332.7         299.9        1.109x   cuda-nightly (PASSED)
+//!   2026-07-31    342.4         328.6        1.042x   cuda-nightly (FAILED)
+//!   2026-07-31    318.2         313.5        1.015x   idle box, this harness
+//!
+//! Read the OLLAMA column first: 300.7 / 299.9 / 328.6 / 313.5 over six weeks.
+//! The incumbent is reproducible, so the drift is not the measuring rig. apr's
+//! own column moved 412 -> ~303-342. The 2026-07-29 "PASS" at 1.109x was already
+//! this regression squeaking past a threshold with 0.8% headroom; nobody looked
+//! because it was green.
+//!
+//! WHAT CHANGED: #2323 (2026-07-27) made `auto_q4k` return Mwv on every device.
+//! The previous default on sm_89 was HwDp4a, whose INT8 Q8_1 activation quant is
+//! numerically degraded (F2 first-token cosine 0.9186 < the 0.95 floor). The
+//! 412.3 figure was measured under that old default.
+//!
+//! DO NOT read that as "#2323 cost us 23%" — that is NOT what was measured. Re-run
+//! today with the surviving opt-in, `HW_DP4A_Q4K=1`, and the differential is
+//! **20.3 tok/s**, not 412: HwDp4a is F2-REJECTED, wgpu then fails its own 0.99
+//! gate, and the run finishes on CPU SIMD. That is precisely the ~20 tok/s
+//! collapse #2323 was written to fix. So the honest statement is narrow: the
+//! 1.371x number was taken under a kernel default that no longer exists and can
+//! no longer be reproduced here. A correct 318 tok/s is worth far more than a
+//! degraded kernel the F2 gate refuses to let serve a token.
+//!
+//! WHY THE FLOOR IS 0.90 AND NOT 1.10. Keeping 1.10 asserts a win apr does not
+//! currently have; it would fail ~every other night and teach people to ignore
+//! this gate. Lowering it to ~1.00 would quietly redefine "beat" as "tie". So the
+//! assertion is renamed to what it can actually prove: apr must not COLLAPSE.
+//! 0.90 sits 12% under the worst observed median (1.015) so it does not flake,
+//! and still catches the failure class that matters — the CPU-fallback collapse
+//! is ratio ~0.065, a 14x violation.
+//!
+//! RECOVERING THE BEAT is tracked separately: either restore DP4A-class decode
+//! speed with activation quant that clears F2, or make Mwv faster. Until apr
+//! measures >= 1.10x on this host again, Pillar-4 must NOT claim a GPU decode
+//! win over ollama on sm_89.
+//!
+//! ## DEPENDENCY: the median premise still needs #2049 on main
+//! The ~1-in-6 catastrophic decode stall is fixed by #2049 (FP8-warmup OOB read).
+//! If #2049 is reverted/absent the stall returns and any median gate here flakes.
 //!
 //! ## What it measures (be honest about scope)
 //! STEADY-STATE GPU DECODE throughput only — the marginal token-generation rate
@@ -59,12 +91,16 @@
 use std::path::Path;
 use std::process::Command;
 
-/// ENFORCED gate threshold (mirrors the contract's `beat_threshold`): apr's
-/// MEDIAN-OF-7 clean decode must beat ollama's median by at least this factor. The
-/// re-measured median is 1.37x with worst single run 1.23x, so 1.10x is a wide
-/// safety margin (bootstrapped ~0% false-FAIL). This is asserted at runtime now
-/// that the #2049 FP8 stall fix makes the median non-flaky. See the contract VERDICT.
-const ENFORCED_THRESHOLD: f64 = 1.10;
+/// NO-COLLAPSE FLOOR (mirrors the contract's `beat_threshold`). apr's MEDIAN-OF-7
+/// decode must stay within this factor of ollama's median.
+///
+/// This is NOT a beat threshold. It was 1.10 while the harness believed apr ran
+/// at 1.371x; the three post-#2323 measurements are 1.109 / 1.042 / 1.015, so 1.10
+/// now fails about every other night for a reason the gate cannot fix. 0.90 sits
+/// 12% below the worst observed median — it will not flake — while still catching
+/// the collapse that actually costs users: an F2-rejected GPU path falling to CPU
+/// SIMD measures ratio ~0.065, violating this floor by 14x. See the header.
+const ENFORCED_THRESHOLD: f64 = 0.90;
 
 /// Forced token counts for the differential apr measurement (amortizes fixed cost).
 const N_LOW: u32 = 128;
@@ -257,17 +293,25 @@ fn beat_ollama_decode_throughput_speed() {
          beat-ollama-decode-throughput-speed-v1.yaml)."
     );
 
-    // ENFORCED assertion: apr's MEDIAN-OF-7 clean decode must beat ollama's median
-    // by >= 1.10x. The re-measured 1.37x median with worst single run 1.23x and 0
-    // stalls makes this a wide, non-flaky margin. A real regression (apr losing its
-    // decode advantage, or the #2049 stall fix being absent) fails the build.
+    // NO-COLLAPSE assertion. Deliberately NOT "apr beats ollama" - see the header:
+    // that claim was withdrawn on 2026-07-31 because it is not reproducible. What
+    // this still proves is that apr is serving decode on the GPU at all.
+    //
+    // The old message offered two diagnoses ("apr's advantage regressed, OR #2049
+    // is missing") and BOTH were wrong when it finally fired on 2026-07-31 - the
+    // cause was #2323 changing the default Q4K kernel. A failure message that
+    // confidently names the wrong cause is worse than one that names none, so this
+    // one reports the measurement and points at the checks that discriminate.
     assert!(
         ratio_med >= ENFORCED_THRESHOLD,
-        "BEAT-REGRESSION beat-ollama-decode-throughput: apr median-of-{APR_MEDIAN_N} decode \
-         {apr_med:.1} tok/s no longer beats ollama median {ollama_med:.1} tok/s by {ENFORCED_THRESHOLD:.2}x \
-         (ratio_median {ratio_med:.3} < {ENFORCED_THRESHOLD:.2}) — apr's clean-decode advantage \
-         regressed, OR the #2049 FP8 stall fix is missing from this binary so the median is \
-         stall-flaky (contract beat-ollama-decode-throughput-speed-v1.yaml DEPENDENCY)"
+        "DECODE-COLLAPSE beat-ollama-decode-throughput: apr median-of-{APR_MEDIAN_N} decode \
+         {apr_med:.1} tok/s is below {ENFORCED_THRESHOLD:.2}x ollama's median {ollama_med:.1} tok/s \
+         (ratio_median {ratio_med:.3}). This floor is NOT a beat threshold - at this depth apr is \
+         very likely not decoding on the GPU at all. Check, in order: (1) is the F2 first-token \
+         gate REJECTING the CUDA path (look for 'GPU diverges from CPU' / cosine < 0.95)? A \
+         rejected CUDA path falls to wgpu, then to CPU SIMD, and measures ~20 tok/s - ratio ~0.065. \
+         (2) is APR_BIN built --features cuda? (3) is HW_DP4A_Q4K set, re-selecting the degraded \
+         kernel #2323 removed as the default? (contract beat-ollama-decode-throughput-speed-v1.yaml)"
     );
 }
 

--- a/scripts/apr_bin.sh
+++ b/scripts/apr_bin.sh
@@ -18,8 +18,20 @@
 # already embeds the build-time git SHA (contract apr-version-traceability-v1,
 # F-VERSION-001..004): `apr --version` prints e.g. `apr 0.61.0 (e514cc5ed)`.
 # So "was this binary built from HEAD?" is a string comparison, not a guess.
-
-set -euo pipefail
+#
+# DELIBERATELY NO `set -euo pipefail` AT FILE SCOPE. This file is SOURCED, and
+# `set` in a sourced file mutates the CALLER's shell. The first version of this
+# script did `set -euo pipefail` here; qwen-story.sh sources it and had chosen
+# `set -uo pipefail` WITHOUT `-e` on purpose - the whole script is built around
+# running every beat and counting failures (emit_fail/FAILED_BEATS). Turning
+# errexit on under it meant the first non-zero command anywhere killed the run:
+# the nightly story died after SIX LINES, inside Beat 1's advisory pmat hunt,
+# and reported nothing about why. A sourceable library must be option-neutral.
+#
+# Fail-closed is preserved explicitly instead: the bottom of this file returns
+# non-zero when the binary is stale, so callers use
+#     . scripts/apr_bin.sh || exit 1
+# which fails the same way errexit would, without seizing the caller's shell.
 
 apr_bin_die() {
     printf '%s\n' "$*" >&2
@@ -86,8 +98,20 @@ apr_bin_assert_fresh() {
     return 1
 }
 
-APR=$(apr_bin_resolve) || apr_bin_die "apr_bin: no apr binary found (build one: cargo install --path crates/apr-cli --force)"
-apr_bin_assert_fresh "$APR"
+# Fail-closed without errexit. At the top level of a SOURCED file `return N`
+# ends the source with that status, so `. apr_bin.sh || exit 1` behaves exactly
+# as it did under `set -e`. When this file is EXECUTED instead, top-level
+# `return` is an error, and the `||` falls through to `exit`. One line covers
+# both entry points.
+if ! APR=$(apr_bin_resolve); then
+    apr_bin_die "apr_bin: no apr binary found (build one: cargo install --path crates/apr-cli --force)"
+    return 1 2>/dev/null || exit 1
+fi
+
+if ! apr_bin_assert_fresh "$APR"; then
+    return 1 2>/dev/null || exit 1
+fi
+
 export APR
 
 # When executed rather than sourced, print the resolved path.

--- a/scripts/check_sourced_libs_option_neutral.sh
+++ b/scripts/check_sourced_libs_option_neutral.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# check_sourced_libs_option_neutral.sh - a sourced script may not change the
+# caller's shell options.
+#
+# THE CLASS. `set` inside a sourced file mutates the SOURCING shell, not a
+# child. scripts/apr_bin.sh opened with `set -euo pipefail`; scripts/qwen-story.sh
+# sources it and had deliberately chosen `set -uo pipefail` WITHOUT `-e`,
+# because its whole design is to run every beat and tally failures. The source
+# silently turned errexit on underneath it, so the first non-zero command
+# anywhere aborted the run: the nightly story died after six lines, inside an
+# ADVISORY pmat hunt, and the log said nothing about why.
+#
+# The leak is invisible in review - both files are individually correct, and
+# `set -euo pipefail` is the thing you are normally praised for writing. Only
+# the COMBINATION is wrong, which is why this is a mechanical check rather than
+# a style note.
+#
+# A sourced library must be option-neutral and signal failure by RETURN STATUS:
+#     . scripts/apr_bin.sh || exit 1
+#
+# Exit 0 = every sourced library leaves the caller's options alone.
+# Exit 1 = at least one sets shell options at file scope.
+#
+# `--self-test` proves the check can still turn RED, by running it against a
+# reconstruction of the exact pre-fix apr_bin.sh header.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.." || exit 1
+
+SEARCH_DIR="scripts"
+
+# `set` with the errexit / nounset / pipefail family, at column 0 (file scope).
+# Indented `set` lines live inside functions or blocks, where the option change
+# is at least visible to the reader of that function.
+SETOPT_RE='^set[[:space:]]+[-+]'
+
+# Which files are actually SOURCED by another SCRIPT? Only those can leak: a
+# script that is merely executed (`bash scripts/foo.sh`) gets its own shell.
+#
+# Deliberately scoped to script-to-script sourcing, and deliberately anchored on
+# `.`/`source` as the FIRST token of a line. An earlier draft also scanned
+# .github/workflows/*.yml for `scripts/*.sh` near a `.` or `source`, and
+# promptly flagged check_format_sovereignty.sh - because ci.yml contains the
+# COMMENT "# catch dev-dep cycles. See scripts/check_format_sovereignty.sh",
+# where the sentence-ending period parsed as the source builtin. A workflow
+# `run:` block is its own throwaway shell anyway, so a `set` leak there cannot
+# outlive the block. Narrow and sound beats broad and wrong.
+sourced_basenames() {
+    grep -rhoE '^[[:space:]]*(\.|source)[[:space:]]+[^;&|#]+' "$SEARCH_DIR"/*.sh 2>/dev/null \
+        | grep -oE '[A-Za-z0-9_.-]+\.sh' | sort -u
+}
+
+scan_file() {
+    local f="$1"
+    grep -nE "$SETOPT_RE" "$f" 2>/dev/null || true
+}
+
+violations=0
+checked=0
+
+for base in $(sourced_basenames); do
+    f="$SEARCH_DIR/$base"
+    [ -f "$f" ] || continue
+    # A file that sources itself is not interesting; skip self-references.
+    checked=$((checked + 1))
+    hits=$(scan_file "$f")
+    if [ -n "$hits" ]; then
+        printf 'OPTION-LEAK %s is sourced by another script but sets shell options:\n' "$f" >&2
+        printf '%s\n' "$hits" | sed 's/^/           /' >&2
+        violations=$((violations + 1))
+    fi
+done
+
+# --self-test: reconstruct the pre-fix header and prove the matcher rejects it.
+# Without this, a matcher that silently stopped matching would report success.
+if [ "${1:-}" = "--self-test" ]; then
+    # Fed to grep on stdin rather than written to temp files: identical to
+    # scanning a file with this content, minus a mktemp, a trap and an
+    # `rm -rf "$tmp"` that bashrs rightly flags (SEC011) in a script whose only
+    # job is to read files.
+    bad_lib=$(printf '#!/usr/bin/env bash\n# a sourceable helper\n\nset -euo pipefail\n\nfoo() { :; }\n')
+    good_lib=$(printf '#!/usr/bin/env bash\n# a sourceable helper\n\nfoo() { :; }\n')
+
+    bad_hits=$(printf '%s\n' "$bad_lib" | grep -nE "$SETOPT_RE" || true)
+    good_hits=$(printf '%s\n' "$good_lib" | grep -nE "$SETOPT_RE" || true)
+
+    if [ -z "$bad_hits" ]; then
+        printf 'SELF-TEST FAILED: the matcher no longer flags `set -euo pipefail`.\n' >&2
+        exit 1
+    fi
+    if [ -n "$good_hits" ]; then
+        printf 'SELF-TEST FAILED: the matcher flags an option-neutral library.\n' >&2
+        exit 1
+    fi
+    printf 'self-test OK: rejects the pre-fix header, accepts an option-neutral one.\n'
+fi
+
+if [ "$violations" -gt 0 ]; then
+    printf '\n%s sourced librar(y/ies) mutate the caller shell (%s checked).\n' \
+        "$violations" "$checked" >&2
+    printf 'Remove the file-scope `set` and fail by return status instead:\n' >&2
+    printf '    # in the library, at file scope:\n' >&2
+    printf '    some_check || { return 1 2>/dev/null || exit 1; }\n' >&2
+    printf '    # at the call site:\n' >&2
+    printf '    . scripts/the_lib.sh || exit 1\n' >&2
+    exit 1
+fi
+
+# Fail closed: a discovery step that found nothing must not report success.
+MIN_EXPECTED="${MIN_EXPECTED:-1}"
+if [ "$checked" -lt "$MIN_EXPECTED" ]; then
+    printf 'ERROR: examined %s sourced librar(y/ies), expected >= %s - discovery has gone blind.\n' \
+        "$checked" "$MIN_EXPECTED" >&2
+    exit 1
+fi
+
+printf 'OK: %s sourced librar(y/ies) checked, none mutates the caller shell.\n' "$checked"

--- a/scripts/qwen-story.sh
+++ b/scripts/qwen-story.sh
@@ -16,6 +16,9 @@
 # Each beat uses OUT=$(cmd); EC=$? to avoid the pipe-then-$? methodology
 # defect documented in memory/feedback_test_methodology_can_fake_bugs.md.
 
+# NOTE the deliberate absence of `-e`. This script's contract is to run EVERY
+# beat and tally the results (emit_fail / FAILED_BEATS / exit 2), so a failing
+# beat must not abort the run. Anything sourced below must not turn errexit on.
 set -uo pipefail
 
 # Resolve `apr` and PROVE it was built from this commit. Sourcing this exports
@@ -23,8 +26,12 @@ set -uo pipefail
 # PATH, and on the cuda runner ~/.local/bin held a 24-day-old build that
 # shadowed the freshly installed one - so every beat below validated stale code
 # while reporting green. Set APR_BIN to override which binary is used.
+#
+# The explicit `|| exit 1` is what makes a stale binary fatal. apr_bin.sh used
+# to get that effect by doing `set -euo pipefail` at its own file scope, which
+# leaked errexit into THIS script and killed the nightly run six lines in.
 # shellcheck source=scripts/apr_bin.sh
-. "$(dirname "${BASH_SOURCE[0]}")/apr_bin.sh"
+. "$(dirname "${BASH_SOURCE[0]}")/apr_bin.sh" || exit 1
 
 MODELS_DIR="${MODELS_DIR:-$HOME/models}"
 PMAT_HUNT="${PMAT_HUNT:-1}"  # 1 = run pmat full audit per beat
@@ -86,6 +93,32 @@ emit_evidence() {
   printf '%s\n' "$RC_OUT" | sed 's/^/    /'
 }
 
+# Extract rows from one `pmat query`, tolerating BOTH shapes pmat can return.
+#
+# A function query returns a JSON ARRAY of function records, but when nothing
+# matches semantically pmat falls back to a document search and returns
+# `{"documents":[...]}` instead. The original filter ran `.[] | \(.function)`
+# unconditionally: on the fallback shape `.[]` yields the documents ARRAY, and
+# interpolating `.function` from an array raises "Cannot index array with
+# function" - jq exits 5. Under `pipefail` the whole assignment then returned
+# 5, which is what killed the nightly story once errexit leaked in from
+# apr_bin.sh. Guarding on `type == "array"` makes the no-match case yield an
+# empty string instead of an error.
+#
+# `|| true` is deliberate and load-bearing: this manifest is ADVISORY. It
+# annotates the story, and must never be able to fail it - not via pmat's exit
+# status, not via jq, not via SIGPIPE from `head`.
+#
+# Args: <jq-output-filter> <pmat query args...>
+pmat_rows() {
+  local filter="$1"; shift
+  pmat query "$@" --format json 2>/dev/null \
+    | jq -r "if type == \"array\" then .[] else empty end
+             | select(.function != null)
+             | $filter" 2>/dev/null \
+    | head -3 || true
+}
+
 # Run pmat full audit on a list of command module patterns. Outputs a compact
 # manifest (top 3 high-risk untested functions, top 3 churn, top 3 faults).
 pmat_hunt() {
@@ -96,17 +129,18 @@ pmat_hunt() {
   printf '    -- pmat bug-hunt manifest (%s) --\n' "$beat"
   for q in "$@"; do
     local gaps churn faults
-    gaps=$(pmat query --coverage-gaps --path "$q" --rank-by impact --limit 3 \
-      --format json 2>/dev/null | jq -r '.[] | "        gap   \(.function) (impact=\(.impact_score // "?"))"' 2>/dev/null | head -3)
-    churn=$(pmat query "$beat" --path "$q" --churn --max-complexity 30 --limit 3 \
-      --format json 2>/dev/null | jq -r '.[] | "        churn \(.function) (commits=\(.churn.commit_count // "?"))"' 2>/dev/null | head -3)
-    faults=$(pmat query "$beat" --path "$q" --faults --exclude-tests --limit 3 \
-      --format json 2>/dev/null | jq -r '.[] | "        fault \(.function) (\(.faults | join(\",\")))"' 2>/dev/null | head -3)
+    gaps=$(pmat_rows '"        gap   \(.function) (impact=\(.impact_score // "?"))"' \
+      --coverage-gaps --path "$q" --rank-by impact --limit 3)
+    churn=$(pmat_rows '"        churn \(.function) (commits=\(.churn.commit_count // "?"))"' \
+      "$beat" --path "$q" --churn --max-complexity 30 --limit 3)
+    faults=$(pmat_rows '"        fault \(.function) (\(.faults | join(",")))"' \
+      "$beat" --path "$q" --faults --exclude-tests --limit 3)
     [ -n "$gaps" ]   && printf '%s\n' "$gaps"
     [ -n "$churn" ]  && printf '%s\n' "$churn"
     [ -n "$faults" ] && printf '%s\n' "$faults"
   done
   printf '\n'
+  return 0
 }
 
 # -- Beat 1: Discover (0.5B SafeTensors) --------------------------------------─


### PR DESCRIPTION
The Pillar-4 apr-vs-ollama GPU decode beat failed in `cuda-nightly` on 2026-07-31. Its panic message offered two diagnoses — *"apr's clean-decode advantage regressed, OR the #2049 FP8 stall fix is missing"* — and **both were wrong**. This PR corrects the claim rather than the threshold's victim.

## Four independent measurements, one host (lambda RTX 4090 sm_89)

| date | apr median | ollama median | ratio | source |
|---|---|---|---|---|
| 2026-06-15 | 412.3 | 300.7 | **1.371×** | promotion claim (#2067) |
| 2026-07-29 | 332.7 | 299.9 | 1.109× | cuda-nightly, **PASSED** |
| 2026-07-31 | 342.4 | 328.6 | 1.042× | cuda-nightly, FAILED |
| 2026-07-31 | 318.2 | 313.5 | **1.015×** | idle box, this harness |

**Read the ollama column first**: 300.7 / 299.9 / 328.6 / 313.5 across six weeks. The incumbent reproduces, so this is not the measuring rig drifting. apr's own column moved 412 → ~303–342.

The 2026-07-29 **"PASS" at 1.109× was already this regression**, clearing a 1.10 gate by 0.8%. Nobody looked, because it was green.

## What changed

#2323 (2026-07-27) made `auto_q4k` return `Mwv` on every device. sm_89 previously defaulted to `HwDp4a`, whose INT8 Q8_1 activation quant fails the F2 first-token cosine floor (0.9186 < 0.95). The 412.3 figure predates that change.

**Do not read that as "#2323 cost us 23%" — that is not what was measured.** Re-running today with the surviving opt-in, `HW_DP4A_Q4K=1`, measures **20.3 tok/s**, not 412: HwDp4a is F2-rejected, wgpu then fails its own 0.99 gate, and the run ends on CPU SIMD. That is exactly the ~20 tok/s collapse #2323 was written to fix.

So the honest statement is narrow: the 1.371× number was taken under a kernel default that **no longer exists** and cannot be reproduced here. It is **withdrawn as unreproducible, not reattributed**. A correct 318 tok/s is worth far more than a fast kernel the F2 gate refuses to let serve a token.

## Why 0.90 and not 1.10

Keeping 1.10 asserts a win apr does not currently have; it fails about every other night for a reason the gate cannot fix — which is how gates get ignored. Lowering it to ~1.00 would quietly redefine "beat" as "tie".

Instead the assertion is **renamed to what it can still prove** — apr must not *collapse* — and pinned at 0.90: 12% under the worst observed median (1.015) so it does not flake, while still catching the class that actually costs users, since a CPU-fallback measures ratio ~0.065 and violates this floor by **14×**.

The panic message no longer names a cause it cannot know. It reports the measurement and lists the three checks that discriminate (F2 rejection, missing `--features cuda`, `HW_DP4A_Q4K` set).

## Not fixed here

Restoring a real ≥ 1.10× win. **Until apr measures that on this host again, Pillar-4 must not claim a GPU decode win over ollama on sm_89.** Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)