### PR TITLE
fix(security): RUSTSEC-2026-0222 (wasmtime) broke the security gate on release day — verified not shipped

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -34,6 +34,24 @@ ignore = [
     # cranelift cluster above. Availability bug, not RCE. Published
     # 2026-04-30; surfaced first on 2026-05-01 CI runs.
     "RUSTSEC-2026-0114",
+    # wasmtime 43.0.2 — "Stores can mix up type indices between engines",
+    # severity 3.8 LOW. Published 2026-07-31 and broke the security gate the
+    # same day, blocking the v0.62.0 release.
+    #
+    # NOT taken on faith from the cluster above — the "test-only, not
+    # production" claim was re-verified for this one:
+    #   cargo tree -p aprender                        -> 0 wasmtime paths
+    #   cargo tree -p aprender --no-default-features  -> 0 wasmtime paths
+    # wasmtime is optional and gated behind aprender-test-lib's `runtime`
+    # feature, which NOTHING in the workspace enables (its only consumer,
+    # aprender-qa-runner, takes `features = ["llm-types"]`). It appears here
+    # solely because Cargo.lock records optional dependencies, so cargo-audit
+    # sees it while no shipped artifact ever links it.
+    #
+    # The fix is a real upgrade, not this line: 43 -> >=46.0.2,<47 or >=47.0.3,
+    # a four-major jump on a test-only dep. Tracked separately; revisit before
+    # anything starts enabling `runtime`.
+    "RUSTSEC-2026-0222",
 
     # rustls-webpki 0.101.7 — transitive via aws-smithy-http-client (rustls 0.21).
     # Direct 0.103.x path already bumped to >=0.103.12. The 0.101.7 pin lives

--- a/deny.toml
+++ b/deny.toml
@@ -40,6 +40,7 @@ ignore = [
     { id = "RUSTSEC-2026-0094", reason = "wasmtime: test-only dep (aprender-test-lib)" },
     { id = "RUSTSEC-2026-0096", reason = "wasmtime: test-only dep (aprender-test-lib)" },
     { id = "RUSTSEC-2026-0114", reason = "wasmtime 43 table allocation panic: test-only dep, availability bug not RCE" },
+    { id = "RUSTSEC-2026-0222", reason = "wasmtime 43 cross-engine type-index confusion (3.8 low): verified 0 wasmtime paths in cargo tree -p aprender with and without default features; optional dep behind aprender-test-lib's `runtime` feature, which nothing enables. Upgrade to >=46.0.2 tracked separately" },
     # quick-xml 0.37.5 quadratic parse of duplicate-attribute start tags (DoS, not
     # RCE). Advisory: affected ONLY via `NsReader`; aprender-orchestrate's sole use
     # (oracle/arxiv.rs) is `quick_xml::Reader`, never `NsReader`, so we do not hit


### PR DESCRIPTION
**Release blocker.** RUSTSEC-2026-0222 was published **2026-07-31** and failed `ci / security` within hours, which evicted #2347 from the merge queue and blocks v0.62.0.

`wasmtime 43.0.2` — *"Stores can mix up type indices between engines"*, severity **3.8 (low)**.

## Why an ignore, and why it is not a rubber stamp

Seven wasmtime/cranelift advisories are already ignored here as *"test-only dep (aprender-test-lib), not production"*. That claim is the entire justification, and inheriting it unchecked is exactly how an ignore list rots. So it was **re-verified for this advisory**:

```
cargo tree -p aprender                        -> 0 wasmtime paths
cargo tree -p aprender --no-default-features  -> 0 wasmtime paths
```

wasmtime is optional, gated behind `aprender-test-lib`'s `runtime` feature — and **nothing in the workspace enables it**. Its only consumer, `aprender-qa-runner`, takes `features = ["llm-types"]`. It reaches cargo-audit solely because `Cargo.lock` records optional dependencies, so the scanner sees a crate no shipped artifact ever links.

## Both lists, deliberately

Added to `.cargo/audit.toml` (what the failing **Audit** step actually reads) *and* `deny.toml` (which audit.toml's header declares it mirrors).

`cargo-audit` does **not** read `deny.toml` — a deny.toml-only entry would have looked like a fix and changed nothing.

## Verification

```
cargo audit -n              -> exit 0  (4 pre-existing allowed warnings)
cargo deny check advisories -> exit 0, "advisories ok"
```

Read as real exit statuses. My first attempt printed `AUDIT EXIT=0` from a `| tail -4` — that was **tail's** status, not cargo's. Same pipe-then-`$?` defect #2336 fixed in qwen-story-daily; caught here only because the number looked right for the wrong reason.

## Not fixed here

The actual upgrade. `43` → `>=46.0.2,<47` or `>=47.0.3` is a **four-major** jump on a test-only dependency — not a release-day change. Tracked separately, and **must** be revisited before anything starts enabling the `runtime` feature, at which point this ignore stops being honest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)