### PR TITLE
chore(release): 0.62.0 — gate integrity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,89 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.62.0] - 2026-07-31
+
+The **gate-integrity** release. v0.61.0 fixed things that were silently broken or
+silently false; this one goes after the machinery that was supposed to catch them.
+Almost every entry below is a gate that could not fail, or a number that was not
+true. The pattern repeated often enough to be worth naming: *every one of these
+was green beforehand.* A substring pass-grep matched its own failure text, a
+pipeline reported `tee`'s exit code instead of the test's, a parity gate compared
+one token, a `skipped` result set `passed: true`, a coverage job measured a facade
+and reported 0%, 547 integration targets were never executed by any workflow, and
+the nightly regression story died six lines in while its own alerting path had
+never once worked.
+
+Three published speed claims were re-measured and did not survive: GaussianNB's
+"4.9x", LinearRegression's ratio, and the headline "apr beats ollama GPU decode
+1.371x". The last is **withdrawn** rather than re-explained — it was measured under
+a Q4K kernel default that no longer exists and cannot be reproduced. Under-claiming
+is also a reporting failure, so the replacement numbers are stated with the host,
+the spread, and the remaining headroom.
+
+### Fixed — gates that could not fail
+
+- The entire nightly speed lane was dark; one broken leg hid all 10 beats (#2326)
+- The anti-theater beat gate was satisfied by theater — a reference is not an
+  execution (#2327)
+- `PMAT-CI-PASSGREP-001` closed one instance of a class; two more were live, one of
+  them a contract falsifier failing open while reporting itself green (#2335)
+- `qwen-story-daily` could not fail: it captured `tee`'s exit code, not the story's.
+  GitHub's default `run:` shell is `bash -e {0}` — **without** pipefail (#2336)
+- `apr qa` format_parity compared ONE token; it now runs 64 teacher-forced decode
+  steps through the cache path (#2337)
+- A 3-turn serve gate that can actually fail, a falsifier that stopped being a
+  tautology, and 30 tests that were never run (#2340)
+- Two test targets had not compiled in months — found by running the suite CI never
+  runs (#2341)
+- The `pv` dispatch tests did not compile, and two pointed at a moved directory (#2342)
+- The nightly Qwen story died after six lines, and every path meant to report it was
+  broken: a sourced `set -euo pipefail` leaking errexit into the caller, a manifest
+  grep off by four spaces, labels that never existed, and a verdict step gated behind
+  a cosmetic notifier by an implicit `success()` (#2347)
+- Coverage measured a facade and reported 0% for everything (#2333)
+
+### Fixed — claims that were not true
+
+- "82 workspace crates" is false; it is 78, and the gate proved the wrong
+  proposition (#2325)
+- The GaussianNB "4.9x" was a dev-box number — re-pinned to the host that actually
+  runs it, with the phase split needed to tell contention from regression (#2328)
+- The readme-claims checker was wrong on 2 of 4; the README was right (#2339)
+- The LinReg speed beat was measuring the host, not the algorithms (#2345), and now
+  records what the CI host actually measures (#2346)
+- **Withdrawn:** the ollama GPU-decode "1.371x". Measured reality on sm_89 is
+  1.015–1.109x — parity, not a win. The gate is re-pinned to a no-collapse floor and
+  the beat claim is retracted until it is earned back (#2348)
+- MSRV reconciled 1.89 → 1.91 with a verification gate (#2303)
+
+### Fixed — correctness
+
+- `--backend cuda` must refuse, not silently serve wgpu/CPU (#2321)
+- Stop swallowing the CUDA forward failure that silently drops to CPU (#2322)
+- Default Q4K to fp32 MWV on all GPUs — HwDp4a is numerically degraded and was
+  making the product 20x slower on the most common discrete GPU (#2323)
+- `top_p` was a silent no-op on the dense CPU decode path (#2317)
+- `top_k=0` no longer emits token 0 forever (#2314)
+- `--features full` did not compile (#2316)
+
+### Added
+
+- `apr pull --verify` — re-hash cached model files against the BLAKE3 that `pull`
+  already records but never compared. Motivated by a 7.1 GB SafeTensors blob whose
+  byte length was exactly right and whose content was 27 tensors of `-0.0` (#2343)
+- Coverage ratchet armed — and the real number is 88.78%, not 96.35% (#2334)
+- Poka-yoke: every beat must be executed by some workflow (#2324)
+- Validation of the top 50 HuggingFace models (#2299)
+- `aarch64-unknown-linux-gnu` nightly target (#2300)
+
+### Security
+
+- RUSTSEC-2026-0222 (wasmtime 43, 3.8 low, published on release day). Verified not
+  present in any shipped path — `cargo tree -p aprender` resolves zero wasmtime
+  paths with and without default features — and ignored with that proof rather than
+  by inheriting the existing justification (#2351)
+
 ## [0.61.0] - 2026-07-26
 
 The **release-integrity** release. Every change here fixes something that was

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,7 +255,7 @@ dependencies = [
 
 [[package]]
 name = "apr-cli"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "anyhow",
  "aprender-common",
@@ -323,7 +323,7 @@ dependencies = [
 
 [[package]]
 name = "apr-format"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "bincode",
  "cargo_metadata",
@@ -393,7 +393,7 @@ dependencies = [
 
 [[package]]
 name = "aprender"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "apr-cli",
  "aprender-core",
@@ -401,7 +401,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-bench-compute"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "aprender-core",
  "criterion 0.7.0",
@@ -410,7 +410,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-bench-tokenizer"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "aprender-core",
  "criterion 0.7.0",
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cbtop"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "anyhow",
  "aprender-common",
@@ -444,7 +444,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cgp"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "anyhow",
  "aprender-gpu",
@@ -464,7 +464,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-common"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "lz4_flex 0.11.6",
  "zstd",
@@ -472,7 +472,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-compute"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "anyhow",
  "aprender-core",
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-compute-xtask"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "anyhow",
  "bashrs",
@@ -534,7 +534,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-contracts"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "aprender-contracts-macros",
  "criterion 0.5.1",
@@ -550,7 +550,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-contracts-cli"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "aprender-contracts",
  "clap",
@@ -561,7 +561,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-contracts-macros"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-core"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "aes-gcm",
  "alsa",
@@ -623,7 +623,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cuda-edge"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "aprender-gpu",
  "proptest",
@@ -634,7 +634,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cupti"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "bindgen 0.71.1",
  "bitflags 2.13.0",
@@ -644,7 +644,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-data"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -696,7 +696,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-db"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "anyhow",
  "aprender-common",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-distribute"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "aprender-compute",
  "aprender-db",
@@ -772,7 +772,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-explain"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "aprender-gpu",
  "aprender-present-core",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-fft"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-gemm-codegen"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -808,7 +808,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-gpu"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "aprender-common",
  "aprender-simulate",
@@ -827,7 +827,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-graph"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "anyhow",
  "aprender-compute",
@@ -849,7 +849,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-image"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-mcp"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -873,9 +873,9 @@ dependencies = [
 
 [[package]]
 name = "aprender-monte-carlo"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
- "aprender 0.61.0",
+ "aprender 0.62.0",
  "assert_cmd",
  "chrono",
  "clap",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-orchestrate"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "anyhow",
  "aprender-common",
@@ -966,7 +966,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-cli"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "aprender-present-yaml",
  "clap",
@@ -979,7 +979,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-core"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -991,7 +991,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-layout"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "aprender-present-core",
  "criterion 0.7.0",
@@ -1002,7 +1002,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-lib"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "aprender-present-core",
  "aprender-present-layout",
@@ -1031,7 +1031,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-terminal"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "aprender-present-core",
  "bitvec",
@@ -1052,7 +1052,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-test"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "aprender-present-core",
  "aprender-present-test-macros",
@@ -1063,7 +1063,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-test-macros"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1072,7 +1072,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-widgets"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "aprender-present-core",
  "aprender-present-yaml",
@@ -1084,7 +1084,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-yaml"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "aprender-present-core",
  "proptest",
@@ -1094,7 +1094,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-profile"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "addr2line 0.25.1",
  "anyhow",
@@ -1147,7 +1147,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-profile-core"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "hex",
  "serde",
@@ -1157,7 +1157,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-ptx-debug"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "proptest",
  "thiserror 2.0.18",
@@ -1165,7 +1165,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-certify"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "chrono",
  "proptest",
@@ -1175,7 +1175,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-cli"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "aprender-qa-certify",
  "aprender-qa-gen",
@@ -1194,7 +1194,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-gen"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1211,7 +1211,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-report"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "anyhow",
  "aprender-qa-gen",
@@ -1229,7 +1229,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-runner"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "anyhow",
  "aprender-qa-gen",
@@ -1254,14 +1254,14 @@ dependencies = [
 
 [[package]]
 name = "aprender-quant"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "half",
 ]
 
 [[package]]
 name = "aprender-rag"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "aprender-common",
  "aprender-compute",
@@ -1291,7 +1291,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-rag-cli"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "anyhow",
  "aprender-rag",
@@ -1309,7 +1309,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-rand"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1318,7 +1318,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-registry"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "anyhow",
  "aprender-core",
@@ -1348,7 +1348,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-serve"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "anyhow",
  "approx",
@@ -1415,7 +1415,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-shell"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "aprender-core",
  "assert_cmd",
@@ -1432,7 +1432,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-simulate"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "aprender-present-core",
  "aprender-present-terminal",
@@ -1471,7 +1471,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-solve"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "criterion 0.7.0",
  "half",
@@ -1481,7 +1481,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-sparse"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1490,7 +1490,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-tensor"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1499,7 +1499,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-cli"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "aprender-test-lib",
  "assert_cmd",
@@ -1527,7 +1527,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-derive"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1537,7 +1537,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-js-gen"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -1553,7 +1553,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-lib"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "aprender-compute",
  "aprender-present-core",
@@ -1597,7 +1597,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-showcase"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "aprender-present-terminal",
  "console_error_panic_hook",
@@ -1614,7 +1614,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "approx",
  "aprender-common",
@@ -1683,7 +1683,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-bench"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1700,7 +1700,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-common"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "aprender-viz",
  "clap",
@@ -1712,7 +1712,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-distill"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1733,7 +1733,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-inspect"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1749,7 +1749,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-lora"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1765,7 +1765,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-shell"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1781,7 +1781,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-wasm"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "proptest",
  "serde",
@@ -1792,9 +1792,9 @@ dependencies = [
 
 [[package]]
 name = "aprender-tsp"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
- "aprender 0.61.0",
+ "aprender 0.62.0",
  "assert_cmd",
  "clap",
  "crc32fast",
@@ -1807,7 +1807,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-verify"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "chrono",
  "criterion 0.5.1",
@@ -1819,7 +1819,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-verify-ml"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "aprender-compute",
  "aprender-core",
@@ -1849,7 +1849,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-viz"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "approx",
  "aprender-common",
@@ -1872,7 +1872,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "aprender-zram-adaptive",
  "aprender-zram-core",
@@ -1882,7 +1882,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-adaptive"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "aprender-zram-core",
  "proptest",
@@ -1891,7 +1891,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-cli"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "aprender-zram-adaptive",
  "aprender-zram-core",
@@ -1905,7 +1905,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-core"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "aprender-gpu",
  "criterion 0.7.0",
@@ -1917,7 +1917,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-generator"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "aprender-zram-core",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,7 +115,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.61.0"
+version = "0.62.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/paiml/aprender"
@@ -181,7 +181,7 @@ minijinja = { version = "2.14", features = ["loader", "serde"] }
 # Contracts
 provable-contracts = "0.3"
 provable-contracts-macros = "0.3"
-aprender-contracts-macros = { path = "crates/aprender-contracts-macros", version = "0.61.0" }
+aprender-contracts-macros = { path = "crates/aprender-contracts-macros", version = "0.62.0" }
 
 # YAML
 serde_yaml = "0.9"
@@ -193,43 +193,43 @@ hf-hub = { version = "0.4", default-features = false, features = ["ureq"] }
 hf-xet = "1.5.1"
 
 # Workspace-internal crates (paths within the monorepo)
-aprender-compute = { path = "crates/aprender-compute", version = "0.61.0" }
-aprender-gpu = { path = "crates/aprender-gpu", version = "0.61.0" }
-aprender-quant = { path = "crates/aprender-quant", version = "0.61.0" }
-aprender-serve = { path = "crates/aprender-serve", version = "0.61.0" }
-realizar = { path = "crates/aprender-serve", version = "0.61.0", package = "aprender-serve" }
-alimentar = { path = "crates/aprender-data", version = "0.61.0", package = "aprender-data" }
-pacha = { path = "crates/aprender-registry", version = "0.61.0", package = "aprender-registry" }
+aprender-compute = { path = "crates/aprender-compute", version = "0.62.0" }
+aprender-gpu = { path = "crates/aprender-gpu", version = "0.62.0" }
+aprender-quant = { path = "crates/aprender-quant", version = "0.62.0" }
+aprender-serve = { path = "crates/aprender-serve", version = "0.62.0" }
+realizar = { path = "crates/aprender-serve", version = "0.62.0", package = "aprender-serve" }
+alimentar = { path = "crates/aprender-data", version = "0.62.0", package = "aprender-data" }
+pacha = { path = "crates/aprender-registry", version = "0.62.0", package = "aprender-registry" }
 # APR-MONO self-containment: legacy sibling lib-name aliases -> in-monorepo crates (2026-06-12)
-trueno-quant = { path = "crates/aprender-quant", version = "0.61.0", package = "aprender-quant" }
-trueno-db = { path = "crates/aprender-db", version = "0.61.0", package = "aprender-db" }
-trueno-viz = { path = "crates/aprender-viz", version = "0.61.0", package = "aprender-viz" }
-trueno-rag = { path = "crates/aprender-rag", version = "0.61.0", package = "aprender-rag" }
-trueno-cuda-edge = { path = "crates/aprender-cuda-edge", version = "0.61.0", package = "aprender-cuda-edge" }
-renacer-core = { path = "crates/aprender-profile-core", version = "0.61.0", package = "aprender-profile-core" }
-repartir = { path = "crates/aprender-distribute", version = "0.61.0", package = "aprender-distribute" }
-simular = { path = "crates/aprender-simulate", version = "0.61.0", package = "aprender-simulate" }
-probar = { path = "crates/aprender-test-lib", version = "0.61.0", package = "aprender-test-lib" }
-aprender-train = { path = "crates/aprender-train", version = "0.61.0" }
-entrenar = { path = "crates/aprender-train", version = "0.61.0", package = "aprender-train" }
-aprender-train-common = { path = "crates/aprender-train-common", version = "0.61.0" }
-aprender-train-distill = { path = "crates/aprender-train-distill", version = "0.61.0" }
-aprender-orchestrate = { path = "crates/aprender-orchestrate", version = "0.61.0" }
-aprender-contracts = { path = "crates/aprender-contracts", version = "0.61.0" }
-aprender-profile = { path = "crates/aprender-profile", version = "0.61.0" }
-aprender-profile-core = { path = "crates/aprender-profile-core", version = "0.61.0" }
-aprender-zram-core = { path = "crates/aprender-zram-core", version = "0.61.0" }
-aprender-zram-adaptive = { path = "crates/aprender-zram-adaptive", version = "0.61.0" }
-aprender-present-core = { path = "crates/aprender-present-core", version = "0.61.0" }
-aprender-present-terminal = { path = "crates/aprender-present-terminal", version = "0.61.0" }
-aprender-present-widgets = { path = "crates/aprender-present-widgets", version = "0.61.0" }
-aprender-present-layout = { path = "crates/aprender-present-layout", version = "0.61.0" }
-aprender-present-yaml = { path = "crates/aprender-present-yaml", version = "0.61.0" }
-aprender-present-test = { path = "crates/aprender-present-test", version = "0.61.0" }
-aprender-db = { path = "crates/aprender-db", version = "0.61.0" }
-aprender-graph = { path = "crates/aprender-graph", version = "0.61.0" }
-aprender-rag = { path = "crates/aprender-rag", version = "0.61.0" }
-aprender-data = { path = "crates/aprender-data", version = "0.61.0" }
+trueno-quant = { path = "crates/aprender-quant", version = "0.62.0", package = "aprender-quant" }
+trueno-db = { path = "crates/aprender-db", version = "0.62.0", package = "aprender-db" }
+trueno-viz = { path = "crates/aprender-viz", version = "0.62.0", package = "aprender-viz" }
+trueno-rag = { path = "crates/aprender-rag", version = "0.62.0", package = "aprender-rag" }
+trueno-cuda-edge = { path = "crates/aprender-cuda-edge", version = "0.62.0", package = "aprender-cuda-edge" }
+renacer-core = { path = "crates/aprender-profile-core", version = "0.62.0", package = "aprender-profile-core" }
+repartir = { path = "crates/aprender-distribute", version = "0.62.0", package = "aprender-distribute" }
+simular = { path = "crates/aprender-simulate", version = "0.62.0", package = "aprender-simulate" }
+probar = { path = "crates/aprender-test-lib", version = "0.62.0", package = "aprender-test-lib" }
+aprender-train = { path = "crates/aprender-train", version = "0.62.0" }
+entrenar = { path = "crates/aprender-train", version = "0.62.0", package = "aprender-train" }
+aprender-train-common = { path = "crates/aprender-train-common", version = "0.62.0" }
+aprender-train-distill = { path = "crates/aprender-train-distill", version = "0.62.0" }
+aprender-orchestrate = { path = "crates/aprender-orchestrate", version = "0.62.0" }
+aprender-contracts = { path = "crates/aprender-contracts", version = "0.62.0" }
+aprender-profile = { path = "crates/aprender-profile", version = "0.62.0" }
+aprender-profile-core = { path = "crates/aprender-profile-core", version = "0.62.0" }
+aprender-zram-core = { path = "crates/aprender-zram-core", version = "0.62.0" }
+aprender-zram-adaptive = { path = "crates/aprender-zram-adaptive", version = "0.62.0" }
+aprender-present-core = { path = "crates/aprender-present-core", version = "0.62.0" }
+aprender-present-terminal = { path = "crates/aprender-present-terminal", version = "0.62.0" }
+aprender-present-widgets = { path = "crates/aprender-present-widgets", version = "0.62.0" }
+aprender-present-layout = { path = "crates/aprender-present-layout", version = "0.62.0" }
+aprender-present-yaml = { path = "crates/aprender-present-yaml", version = "0.62.0" }
+aprender-present-test = { path = "crates/aprender-present-test", version = "0.62.0" }
+aprender-db = { path = "crates/aprender-db", version = "0.62.0" }
+aprender-graph = { path = "crates/aprender-graph", version = "0.62.0" }
+aprender-rag = { path = "crates/aprender-rag", version = "0.62.0" }
+aprender-data = { path = "crates/aprender-data", version = "0.62.0" }
 
 # Additional external deps needed by sub-crates
 serde_yaml_ng = "0.10"
@@ -274,25 +274,25 @@ wasmtime = "43"
 bollard = "0.17"
 
 # Old crate name aliases (workspace = true refs in migrated sub-crates)
-trueno-zram-core = { path = "crates/aprender-zram-core", version = "0.61.0", package = "aprender-zram-core" }
-trueno-zram-adaptive = { path = "crates/aprender-zram-adaptive", version = "0.61.0", package = "aprender-zram-adaptive" }
-trueno = { path = "crates/aprender-compute", version = "0.61.0", package = "aprender-compute" }
-presentar-core = { path = "crates/aprender-present-core", version = "0.61.0", package = "aprender-present-core" }
-presentar-terminal = { path = "crates/aprender-present-terminal", version = "0.61.0", package = "aprender-present-terminal" }
-presentar-widgets = { path = "crates/aprender-present-widgets", version = "0.61.0", package = "aprender-present-widgets" }
-presentar-layout = { path = "crates/aprender-present-layout", version = "0.61.0", package = "aprender-present-layout" }
-presentar-yaml = { path = "crates/aprender-present-yaml", version = "0.61.0", package = "aprender-present-yaml" }
-presentar-test = { path = "crates/aprender-present-test", version = "0.61.0", package = "aprender-present-test" }
-presentar-test-macros = { path = "crates/aprender-present-test-macros", version = "0.61.0", package = "aprender-present-test-macros" }
-jugar-probar-derive = { path = "crates/aprender-test-derive", version = "0.61.0", package = "aprender-test-derive" }
-batuta-common = { path = "crates/aprender-common", version = "0.61.0", package = "aprender-common" }
+trueno-zram-core = { path = "crates/aprender-zram-core", version = "0.62.0", package = "aprender-zram-core" }
+trueno-zram-adaptive = { path = "crates/aprender-zram-adaptive", version = "0.62.0", package = "aprender-zram-adaptive" }
+trueno = { path = "crates/aprender-compute", version = "0.62.0", package = "aprender-compute" }
+presentar-core = { path = "crates/aprender-present-core", version = "0.62.0", package = "aprender-present-core" }
+presentar-terminal = { path = "crates/aprender-present-terminal", version = "0.62.0", package = "aprender-present-terminal" }
+presentar-widgets = { path = "crates/aprender-present-widgets", version = "0.62.0", package = "aprender-present-widgets" }
+presentar-layout = { path = "crates/aprender-present-layout", version = "0.62.0", package = "aprender-present-layout" }
+presentar-yaml = { path = "crates/aprender-present-yaml", version = "0.62.0", package = "aprender-present-yaml" }
+presentar-test = { path = "crates/aprender-present-test", version = "0.62.0", package = "aprender-present-test" }
+presentar-test-macros = { path = "crates/aprender-present-test-macros", version = "0.62.0", package = "aprender-present-test-macros" }
+jugar-probar-derive = { path = "crates/aprender-test-derive", version = "0.62.0", package = "aprender-test-derive" }
+batuta-common = { path = "crates/aprender-common", version = "0.62.0", package = "aprender-common" }
 # APR-MONO sibling aliases — MUST use workspace refs, NEVER crates.io versions.
 # Hard-pinning these to crates.io creates a diamond: sub-crates pull older
 # aprender versions → multiple `aprender` crates in Cargo.lock = MUDA.
-renacer = { path = "crates/aprender-profile", version = "0.61.0", package = "aprender-profile" }
-entrenar-lora = { path = "crates/aprender-train-lora", version = "0.61.0", package = "aprender-train-lora" }
-batuta = { path = "crates/aprender-orchestrate", version = "0.61.0", package = "aprender-orchestrate" }
-trueno-graph = { path = "crates/aprender-graph", version = "0.61.0", package = "aprender-graph" }
+renacer = { path = "crates/aprender-profile", version = "0.62.0", package = "aprender-profile" }
+entrenar-lora = { path = "crates/aprender-train-lora", version = "0.62.0", package = "aprender-train-lora" }
+batuta = { path = "crates/aprender-orchestrate", version = "0.62.0", package = "aprender-orchestrate" }
+trueno-graph = { path = "crates/aprender-graph", version = "0.62.0", package = "aprender-graph" }
 
 [workspace.lints.rust]
 # Safety
@@ -474,7 +474,7 @@ semicolon_if_nothing_returned = "allow"  # Style preference
 
 [package]
 name = "aprender"
-version = "0.61.0"
+version = "0.62.0"
 edition = "2021"
 rust-version = "1.91"
 authors = ["Noah Gift <noah@paiml.com>"]
@@ -504,9 +504,9 @@ required-features = ["cli"]
 # (e.g. apr-cookbook, downstream apps) don't pull apr-cli's heavy transitive
 # dep graph (renacer/profile/inference/zram/visualization). `cargo install
 # aprender` still works because `cli` is in default features. See GH-1599.
-apr-cli = { path = "crates/apr-cli", version = "0.61.0", default-features = true, optional = true }
+apr-cli = { path = "crates/apr-cli", version = "0.62.0", default-features = true, optional = true }
 # Core ML library (lib name = "aprender")
-aprender_ml = { path = "crates/aprender-core", version = "0.61.0", package = "aprender-core" }
+aprender_ml = { path = "crates/aprender-core", version = "0.62.0", package = "aprender-core" }
 
 [features]
 default = ["cli"]

--- a/crates/apr-cli/Cargo.toml
+++ b/crates/apr-cli/Cargo.toml
@@ -103,12 +103,12 @@ libc = "0.2"
 
 [dependencies]
 # Core aprender library
-aprender = { path = "../aprender-core", version = "0.61.0", package = "aprender-core", default-features = true, features = ["format-compression"] }
+aprender = { path = "../aprender-core", version = "0.62.0", package = "aprender-core", default-features = true, features = ["format-compression"] }
 # Provable-contracts engine — `apr beat-run` parses + evaluates BeatBenchmark contracts (PMAT-741)
 aprender-contracts = { workspace = true }
 
 # MCP (Model Context Protocol) server — `apr mcp` subcommand
-aprender-mcp = { path = "../aprender-mcp", version = "0.61.0" }
+aprender-mcp = { path = "../aprender-mcp", version = "0.62.0" }
 async-stream = "0.3"
 provable-contracts-macros = "0.3"
 
@@ -119,7 +119,7 @@ batuta-common = { workspace = true }
 # Non-optional since claude-code-parity-apr M150 (outcome-parity Phase 3
 # requires apr code in default builds). GH-344: path dep via
 # .cargo/config.toml.dev-overrides; CI uses checkout+symlink.
-batuta = { version = "0.61.0", path = "../aprender-orchestrate", package = "aprender-orchestrate", default-features = false, features = ["agents", "agents-inference", "agents-mcp", "rag"] }
+batuta = { version = "0.62.0", path = "../aprender-orchestrate", package = "aprender-orchestrate", default-features = false, features = ["agents", "agents-inference", "agents-mcp", "rag"] }
 
 # Inference engine (workspace path dep — enables cuda/gpu feature forwarding)
 # GH-573: shim (0.9.1) didn't forward cuda feature → 0.7 tok/s instead of 273 tok/s
@@ -215,7 +215,7 @@ pacha = { workspace = true }
 # published-crate dependency cycle the APR-MONO consolidation removed, and
 # (b) was never actually linked, so every `trueno_explain::` path in
 # commands/ptx_explain.rs failed to resolve.
-trueno-explain = { path = "../aprender-explain", version = "0.61.0", package = "aprender-explain", optional = true }
+trueno-explain = { path = "../aprender-explain", version = "0.62.0", package = "aprender-explain", optional = true }
 
 # ML tuning: LoRA/QLoRA configuration and memory planning (GH-176, PMAT-184)
 entrenar-lora = { workspace = true, optional = true }

--- a/crates/aprender-bench-compute/Cargo.toml
+++ b/crates/aprender-bench-compute/Cargo.toml
@@ -11,7 +11,7 @@ disallowed_methods = "allow"
 
 [dependencies]
 # The implementation under test
-aprender = { path = "../aprender-core", version = "0.61.0", package = "aprender-core", features = ["format-quantize"] }
+aprender = { path = "../aprender-core", version = "0.62.0", package = "aprender-core", features = ["format-quantize"] }
 
 # Reference implementation for A/B comparison
 # Pure Rust (no BLAS) to keep comparison fair — both are pure Rust SIMD

--- a/crates/aprender-bench-tokenizer/Cargo.toml
+++ b/crates/aprender-bench-tokenizer/Cargo.toml
@@ -11,7 +11,7 @@ disallowed_methods = "allow"
 
 [dependencies]
 # The implementation under test
-aprender = { path = "../aprender-core", version = "0.61.0", package = "aprender-core" }
+aprender = { path = "../aprender-core", version = "0.62.0", package = "aprender-core" }
 
 # HuggingFace reference for A/B comparison
 # Regular dep (not dev-dep) because [[bench]] harness=false binaries can't see dev-deps

--- a/crates/aprender-cbtop/Cargo.toml
+++ b/crates/aprender-cbtop/Cargo.toml
@@ -24,7 +24,7 @@ presentar-terminal = { workspace = true }
 
 # Compute backends
 trueno = { workspace = true }
-trueno-gpu = { version = "0.61.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true }
+trueno-gpu = { version = "0.62.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true }
 
 # Terminal handling
 crossterm = "0.28"

--- a/crates/aprender-cgp/Cargo.toml
+++ b/crates/aprender-cgp/Cargo.toml
@@ -36,7 +36,7 @@ num_cpus = "1.17"
 comfy-table = "7"
 colored = "3"
 # GPU profiling: direct cuBLAS measurement (OWN THE STACK)
-trueno-gpu = { path = "../aprender-gpu", version = "0.61.0", features = ["cuda"], optional = true, package = "aprender-gpu" }
+trueno-gpu = { path = "../aprender-gpu", version = "0.62.0", features = ["cuda"], optional = true, package = "aprender-gpu" }
 
 [features]
 default = []

--- a/crates/aprender-compute/Cargo.toml
+++ b/crates/aprender-compute/Cargo.toml
@@ -41,11 +41,11 @@ futures-intrusive = { version = "0.5", optional = true }
 wasm-bindgen-futures = { version = "0.4", optional = true }
 wasm-bindgen = { version = "0.2", optional = true }
 # Native CUDA monitoring via trueno-gpu (TRUENO-SPEC-010)
-trueno-gpu = { version = "0.61.0", path = "../aprender-gpu", optional = true, package = "aprender-gpu" }
+trueno-gpu = { version = "0.62.0", path = "../aprender-gpu", optional = true, package = "aprender-gpu" }
 # PMAT-336: Provable contracts compile-time enforcement
 provable-contracts-macros = "0.3"
 # P1a: Sovereign GEMM microkernel codegen (compile-time shape specialization)
-trueno-gemm-codegen = { version = "0.61.0", path = "../aprender-gemm-codegen", package = "aprender-gemm-codegen" }
+trueno-gemm-codegen = { version = "0.62.0", path = "../aprender-gemm-codegen", package = "aprender-gemm-codegen" }
 # Tracing/profiling support (renacer integration)
 tracing = { version = "0.1", optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"], optional = true }

--- a/crates/aprender-contracts-cli/Cargo.toml
+++ b/crates/aprender-contracts-cli/Cargo.toml
@@ -13,7 +13,7 @@ name = "pv"
 path = "src/main.rs"
 
 [dependencies]
-aprender-contracts = { path = "../aprender-contracts", version = "0.61.0" }
+aprender-contracts = { path = "../aprender-contracts", version = "0.62.0" }
 clap = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }

--- a/crates/aprender-contracts/Cargo.toml
+++ b/crates/aprender-contracts/Cargo.toml
@@ -19,7 +19,7 @@ kani = []
 name = "provable_contracts"
 
 [dependencies]
-provable-contracts-macros = { path = "../aprender-contracts-macros", version = "0.61.0", package = "aprender-contracts-macros" }
+provable-contracts-macros = { path = "../aprender-contracts-macros", version = "0.62.0", package = "aprender-contracts-macros" }
 regex = "1"
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/aprender-core/Cargo.toml
+++ b/crates/aprender-core/Cargo.toml
@@ -96,7 +96,7 @@ trueno-quant = { workspace = true }
 # APR-2231: sovereign `.apr` container leaf. aprender-core From-wraps its
 # AprFormatError into AprenderError and re-exports it (no API break). Leaf has
 # no dependency back on core, so this introduces no publish cycle.
-apr-format = { path = "../apr-format", version = "0.61" }
+apr-format = { path = "../apr-format", version = "0.62" }
 
 # NOTE: trueno-rag (=aprender-rag) removed (APR-MONO self-containment): aprender-rag
 # depends on aprender-core + aprender-serve, so core→rag closed a core→rag→serve→core

--- a/crates/aprender-cuda-edge/Cargo.toml
+++ b/crates/aprender-cuda-edge/Cargo.toml
@@ -15,7 +15,7 @@ name = "trueno_cuda_edge"
 [dependencies]
 thiserror = "2.0"
 serde = { version = "1.0", features = ["derive"] }
-trueno-gpu = { version = "0.61.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true }
+trueno-gpu = { version = "0.62.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true }
 
 [dev-dependencies]
 proptest = "1.6"

--- a/crates/aprender-explain/Cargo.toml
+++ b/crates/aprender-explain/Cargo.toml
@@ -25,7 +25,7 @@ presentar-terminal = { workspace = true }
 crossterm = "0.28"
 
 # Internal dependency for PTX generation
-trueno-gpu = { version = "0.61.0", path = "../aprender-gpu", package = "aprender-gpu", features = ["cuda"] }
+trueno-gpu = { version = "0.62.0", path = "../aprender-gpu", package = "aprender-gpu", features = ["cuda"] }
 
 [dev-dependencies]
 proptest = "1.4"

--- a/crates/aprender-graph/Cargo.toml
+++ b/crates/aprender-graph/Cargo.toml
@@ -28,7 +28,7 @@ anyhow = "1"
 thiserror = "2"
 
 # Phase 2+ dependencies
-aprender = { path = "../aprender-core", version = "0.61.0", package = "aprender-core" }                                        # Sparse matrix ops, PageRank
+aprender = { path = "../aprender-core", version = "0.62.0", package = "aprender-core" }                                        # Sparse matrix ops, PageRank
 trueno = { workspace = true }
 trueno-db = { workspace = true }
 

--- a/crates/aprender-monte-carlo/Cargo.toml
+++ b/crates/aprender-monte-carlo/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 name = "aprender-monte-carlo"
 
 [dependencies]
-aprender = { path = "../../", version = "0.61.0" }
+aprender = { path = "../../", version = "0.62.0" }
 clap = { version = "4", features = ["derive"] }
 rand = "0.9"
 rand_chacha = "0.9"

--- a/crates/aprender-orchestrate/Cargo.toml
+++ b/crates/aprender-orchestrate/Cargo.toml
@@ -120,7 +120,7 @@ pacha = { workspace = true, optional = true }
 realizar = { workspace = true, optional = true }
 
 # ML algorithms and training (native-only)
-aprender = { path = "../aprender-core", version = "0.61.0", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.62.0", package = "aprender-core", optional = true }
 entrenar = { workspace = true, optional = true }
 alimentar = { workspace = true, optional = true }
 

--- a/crates/aprender-profile/Cargo.toml
+++ b/crates/aprender-profile/Cargo.toml
@@ -74,7 +74,7 @@ trueno = { workspace = true }
 
 # Machine learning for anomaly detection (Sprint 23)
 # GH-581: Use path dep to avoid trueno version skew with local workspace
-aprender = { path = "../aprender-core", version = "0.61.0", package = "aprender-core" }
+aprender = { path = "../aprender-core", version = "0.62.0", package = "aprender-core" }
 
 # Lock-free data structures for ring buffer (Sprint 40)
 crossbeam = { version = "0.8", default-features = false, features = ["crossbeam-channel", "crossbeam-queue", "std"] }
@@ -112,7 +112,7 @@ crossterm = "0.28"
 
 # SIMD-accelerated visualization primitives (sister project)
 # NOTE: `monitor` feature removed upstream (#1979); this crate uses only viz primitives.
-trueno-viz = { version = "0.61.0", path = "../aprender-viz", package = "aprender-viz", default-features = false }
+trueno-viz = { version = "0.62.0", path = "../aprender-viz", package = "aprender-viz", default-features = false }
 
 # OpenTelemetry for distributed tracing (Sprint 30)
 opentelemetry = { version = "0.31.0", optional = true }

--- a/crates/aprender-qa-cli/Cargo.toml
+++ b/crates/aprender-qa-cli/Cargo.toml
@@ -23,10 +23,10 @@ serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 clap = { workspace = true }
 chrono = { workspace = true }
-aprender-qa-gen = { version = "0.61.0", path = "../aprender-qa-gen" }
-aprender-qa-runner = { version = "0.61.0", path = "../aprender-qa-runner" }
-aprender-qa-report = { version = "0.61.0", path = "../aprender-qa-report" }
-aprender-qa-certify = { version = "0.61.0", path = "../aprender-qa-certify" }
+aprender-qa-gen = { version = "0.62.0", path = "../aprender-qa-gen" }
+aprender-qa-runner = { version = "0.62.0", path = "../aprender-qa-runner" }
+aprender-qa-report = { version = "0.62.0", path = "../aprender-qa-report" }
+aprender-qa-certify = { version = "0.62.0", path = "../aprender-qa-certify" }
 ctrlc = "3.4"
 safetensors = { workspace = true }
 colored = "2.2"

--- a/crates/aprender-qa-report/Cargo.toml
+++ b/crates/aprender-qa-report/Cargo.toml
@@ -18,8 +18,8 @@ anyhow = { workspace = true }
 chrono = { workspace = true }
 colored = "2.2"
 csv = "1.3"
-aprender-qa-gen = { version = "0.61.0", path = "../aprender-qa-gen" }
-aprender-qa-runner = { version = "0.61.0", path = "../aprender-qa-runner" }
+aprender-qa-gen = { version = "0.62.0", path = "../aprender-qa-gen" }
+aprender-qa-runner = { version = "0.62.0", path = "../aprender-qa-runner" }
 
 [dev-dependencies]
 proptest = { workspace = true }

--- a/crates/aprender-qa-runner/Cargo.toml
+++ b/crates/aprender-qa-runner/Cargo.toml
@@ -22,14 +22,14 @@ anyhow = { workspace = true }
 tokio = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }
 tracing = { workspace = true }
-aprender-qa-gen = { version = "0.61.0", path = "../aprender-qa-gen" }
+aprender-qa-gen = { version = "0.62.0", path = "../aprender-qa-gen" }
 hostname = "0.4"
 rayon = "1.10"
 sha2 = "0.10"
 regex = { workspace = true }
 num_cpus = "1.16"
 safetensors = { workspace = true }
-jugar-probar = { version = "0.61.0", path = "../aprender-test-lib", package = "aprender-test-lib", features = ["llm-types"] }
+jugar-probar = { version = "0.62.0", path = "../aprender-test-lib", package = "aprender-test-lib", features = ["llm-types"] }
 # Test fixtures dependencies (optional)
 tempfile = { version = "3", optional = true }
 half = { version = "2.4", optional = true }

--- a/crates/aprender-rag-cli/Cargo.toml
+++ b/crates/aprender-rag-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aprender-rag-cli"
-version = "0.61.0"
+version = "0.62.0"
 edition = "2021"
 authors = ["Pragmatic AI Labs"]
 description = "CLI for Trueno-RAG pipeline"

--- a/crates/aprender-rag/Cargo.toml
+++ b/crates/aprender-rag/Cargo.toml
@@ -64,7 +64,7 @@ fastembed = { version = "5", optional = true }
 
 # NVIDIA Embed Nemotron 8B via realizar GGUF infrastructure (GH-3)
 # Large model (~4-32GB depending on quantization), requires GGUF file
-realizar = { version = "0.61.0", path = "../aprender-serve", package = "aprender-serve", default-features = false, optional = true }
+realizar = { version = "0.62.0", path = "../aprender-serve", package = "aprender-serve", default-features = false, optional = true }
 
 # Speech-to-text via whisper-apr (Whisper ASR, .apr model format)
 # Sovereign stack: whisper-apr + aprender + trueno for pure-Rust transcription

--- a/crates/aprender-registry/Cargo.toml
+++ b/crates/aprender-registry/Cargo.toml
@@ -42,7 +42,7 @@ zstd = { version = "0.13", optional = true }
 clap = { version = "4", features = ["derive"], optional = true }
 
 # Ecosystem integration
-aprender = { path = "../aprender-core", version = "0.61.0", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.62.0", package = "aprender-core", optional = true }
 alimentar = { workspace = true, optional = true }
 
 # HTTP client (optional)

--- a/crates/aprender-serve/Cargo.toml
+++ b/crates/aprender-serve/Cargo.toml
@@ -48,7 +48,7 @@ name = "realizar"
 trueno = { workspace = true, features = ["gpu"] }
 # CUDA PTX generation and runtime for NVIDIA GPUs (optional, pure Rust, no LLVM/nvcc)
 # v0.4.12: BatchedQ6K, MultiWarp, RopeNeox, FlashDecoding kernels
-trueno-gpu = { version = "0.61.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true, features = ["cuda"] }  # APR-MONO single-source-of-truth
+trueno-gpu = { version = "0.62.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true, features = ["cuda"] }  # APR-MONO single-source-of-truth
 # KV cache storage (for attention caching)
 trueno-db = { workspace = true, optional = true }
 # K-quantization formats (Q4_K, Q5_K, Q6_K) - Toyota Way: ONE source of truth
@@ -62,7 +62,7 @@ renacer-core = { workspace = true }
 
 # ML algorithms and .apr model format (optional for aprender model serving)
 # v0.24.1: chat templates, GGUF tokenizer preservation (local may be newer)
-aprender = { path = "../aprender-core", version = "0.61.0", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.62.0", package = "aprender-core", optional = true }
 
 # Data loading library (optional for data pipeline examples)
 alimentar = { workspace = true, optional = true }

--- a/crates/aprender-shell/Cargo.toml
+++ b/crates/aprender-shell/Cargo.toml
@@ -24,7 +24,7 @@ harness = false
 
 [dependencies]
 # Use path for local dev, crates.io for release
-aprender = { path = "../aprender-core", version = "0.61.0", package = "aprender-core", features = ["format-encryption", "format-compression", "format-homomorphic"] }
+aprender = { path = "../aprender-core", version = "0.62.0", package = "aprender-core", features = ["format-encryption", "format-compression", "format-homomorphic"] }
 clap = { version = "4", features = ["derive"] }
 dirs = "5"
 serde = { version = "1", features = ["derive"] }

--- a/crates/aprender-simulate/Cargo.toml
+++ b/crates/aprender-simulate/Cargo.toml
@@ -53,7 +53,7 @@ crossterm = { version = "0.28", optional = true }
 # ComputeBlocks from presentar-terminal (SIMD-optimized TUI widgets)
 # Path deps to avoid jugar-probar prod dep chain (CB-081)
 presentar-terminal = { workspace = true, optional = true }
-presentar-core = { version = "0.61.0", path = "../aprender-present-core", package = "aprender-present-core", default-features = false, optional = true }
+presentar-core = { version = "0.62.0", path = "../aprender-present-core", package = "aprender-present-core", default-features = false, optional = true }
 
 # WASM (optional)
 wasm-bindgen = { version = "0.2", optional = true }

--- a/crates/aprender-test-cli/Cargo.toml
+++ b/crates/aprender-test-cli/Cargo.toml
@@ -24,7 +24,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Core library (was: jugar-probar) — dep key preserves Rust identifier
-jugar-probar = { path = "../aprender-test-lib", version = "0.61.0", package = "aprender-test-lib" }
+jugar-probar = { path = "../aprender-test-lib", version = "0.62.0", package = "aprender-test-lib" }
 
 # CLI framework
 clap = { workspace = true }

--- a/crates/aprender-train-bench/Cargo.toml
+++ b/crates/aprender-train-bench/Cargo.toml
@@ -20,7 +20,7 @@ workspace = true
 
 [dependencies]
 entrenar = { workspace = true }
-entrenar-common = { version = "0.61.0", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar-common = { version = "0.62.0", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/aprender-train-distill/Cargo.toml
+++ b/crates/aprender-train-distill/Cargo.toml
@@ -33,7 +33,7 @@ shard-batch-source = []
 
 [dependencies]
 entrenar = { workspace = true }
-entrenar-common = { version = "0.61.0", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar-common = { version = "0.62.0", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/aprender-train-inspect/Cargo.toml
+++ b/crates/aprender-train-inspect/Cargo.toml
@@ -20,7 +20,7 @@ workspace = true
 
 [dependencies]
 entrenar = { workspace = true }
-entrenar-common = { version = "0.61.0", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar-common = { version = "0.62.0", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/aprender-train-lora/Cargo.toml
+++ b/crates/aprender-train-lora/Cargo.toml
@@ -20,7 +20,7 @@ workspace = true
 
 [dependencies]
 entrenar = { workspace = true }
-entrenar-common = { version = "0.61.0", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar-common = { version = "0.62.0", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/aprender-train-shell/Cargo.toml
+++ b/crates/aprender-train-shell/Cargo.toml
@@ -20,7 +20,7 @@ workspace = true
 
 [dependencies]
 entrenar = { workspace = true }
-entrenar-common = { version = "0.61.0", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar-common = { version = "0.62.0", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 rustyline = "14"
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/aprender-train/Cargo.toml
+++ b/crates/aprender-train/Cargo.toml
@@ -79,9 +79,9 @@ provable-contracts-macros = { version = "0.2" }
 # Core PAIML stack
 ndarray = "0.16"
 trueno = { workspace = true, features = ["parallel"] }
-trueno-gpu = { version = "0.61.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true }  # CUDA compute (APR-MONO single-source-of-truth)
+trueno-gpu = { version = "0.62.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true }  # CUDA compute (APR-MONO single-source-of-truth)
 realizar = { workspace = true, optional = true }
-aprender = { path = "../aprender-core", version = "0.61.0", package = "aprender-core" }  # ML interpret module + .apr format + tokenizers
+aprender = { path = "../aprender-core", version = "0.62.0", package = "aprender-core" }  # ML interpret module + .apr format + tokenizers
 trueno-viz = { workspace = true, features = ["terminal"] }
 batuta-common = { workspace = true, optional = true }  # WithDimensions trait for `viz` feature (APR-MONO §S #1978)
 presentar-terminal = { workspace = true, optional = true }

--- a/crates/aprender-tsp/Cargo.toml
+++ b/crates/aprender-tsp/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 name = "aprender-tsp"
 
 [dependencies]
-aprender = { path = "../../", version = "0.61.0" }
+aprender = { path = "../../", version = "0.62.0" }
 clap = { version = "4", features = ["derive"] }
 rand = "0.9"
 crc32fast = "1.4"

--- a/crates/aprender-verify-ml/Cargo.toml
+++ b/crates/aprender-verify-ml/Cargo.toml
@@ -50,7 +50,7 @@ uuid = { version = "1.11", features = ["v4", "serde"] }
 trueno = { workspace = true }
 
 # Machine learning for bug prediction (optional)
-aprender = { path = "../aprender-core", version = "0.61.0", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.62.0", package = "aprender-core", optional = true }
 
 # LLM fine-tuning integration (optional)
 entrenar = { workspace = true, optional = true }

--- a/crates/aprender-viz/Cargo.toml
+++ b/crates/aprender-viz/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["visualization", "graphics", "science", "wasm"]
 
 [dependencies]
 # Core SIMD/GPU acceleration
-trueno = { version = "0.61.0", path = "../aprender-compute", package = "aprender-compute", default-features = false }
+trueno = { version = "0.62.0", path = "../aprender-compute", package = "aprender-compute", default-features = false }
 
 # Shared Batuta stack utilities (display traits, formatting)
 batuta-common = { workspace = true }
@@ -29,10 +29,10 @@ base64 = "0.22"
 thiserror = "2.0"
 
 # Optional: ML integration
-aprender = { path = "../aprender-core", version = "0.61.0", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.62.0", package = "aprender-core", optional = true }
 
 # Optional: Graph integration
-trueno-graph = { version = "0.61.0", path = "../aprender-graph", package = "aprender-graph", default-features = false, optional = true }
+trueno-graph = { version = "0.62.0", path = "../aprender-graph", package = "aprender-graph", default-features = false, optional = true }
 
 # Optional: Database integration
 trueno-db = { workspace = true, optional = true }


### PR DESCRIPTION
v0.61.0 fixed things that were silently broken or silently false. **This release goes after the machinery that was supposed to catch them.**

Almost every entry is a gate that could not fail, or a number that was not true — and the pattern is worth naming: **every one of these was green beforehand.**

- A substring pass-grep matched its own failure text (`0 error` matches `10 error(s)`)
- A pipeline reported `tee`'s exit code instead of the test's
- A parity gate compared **one** token
- A `skipped` result set `passed: true`
- A coverage job measured a facade and reported 0%
- **547** integration targets were never executed by any workflow; 11 no longer compiled
- The nightly regression story died **six lines in**, while its own alerting path had never once worked

## Three speed claims re-measured; none survived

| claim | reality |
|---|---|
| GaussianNB "4.9×" | a dev-box number; re-pinned to the host that runs it (#2328) |
| LinearRegression ratio | was measuring the host, not the algorithms (#2345, #2346) |
| **ollama GPU decode "1.371×"** | **withdrawn** — measured reality on sm_89 is 1.015–1.109×, i.e. parity (#2348) |

The last is withdrawn rather than re-explained: it was measured under a Q4K kernel default that no longer exists and cannot be reproduced on the host. Under-claiming is also a reporting failure, so the replacements carry host, spread and remaining headroom instead of being rounded up.

## Verification before cutting

```
cargo set-version --workspace 0.62.0   exit 0, 35 manifests + Cargo.lock, no half-bump
all 78 crates                          at 0.62.0, none left behind
cargo fmt --all -- --check             exit 0
cargo test -p aprender-contracts       1420 passed / 0 failed
cargo audit -n                         exit 0
cargo deny check advisories            exit 0, "advisories ok"
cargo metadata --no-deps               exit 0
scripts/check_readme_claims.sh         4/4 PASS (78 crates, 1767 contracts, 103 commands)
```

The v0.61.0 `set-version` blocker at `Cargo.toml:509` stays fixed — no non-exact requirement, so no half-bumped tree.

## Known, not blocking

Two nightlies went red in a 15:20–15:40 window caused by restarting 16 previously-stopped CI runners, which spiked mac-server to load ~27:

- **GaussianNB beat** `0.535 > 0.50` — the harness's own discriminator says contention (fit **and** predict both up; apr 64.8 ms vs its 27.9 ms idle reference). #2328 deliberately declined to weaken this gate.
- **Coverage Nightly** reported an empty percentage — a shared-`CARGO_HOME` race on `cargo-llvm-cov`, filed as #2353 with the fix (the `security` job already uses a per-job `CARGO_HOME`).

Neither is a code defect. Both will be re-run to confirm green before the tag is pushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)