### PR TITLE
fix(tooling): a stale apr binary can no longer be resolved, hardcoded, or dogfooded

### DIFF
--- a/.claude/skills/dogfood/SKILL.md
+++ b/.claude/skills/dogfood/SKILL.md
@@ -41,11 +41,23 @@ Run ALL gates below. For each gate, run the check, report PASS/FAIL/SKIP with ev
 
 ```bash
 cargo install --path crates/apr-cli --force 2>&1 | tail -5
-apr --version
+# Resolve the binary through the guard, NEVER a bare `apr`. Sourcing exports
+# $APR and hard-fails when it was not built from HEAD.
+. scripts/apr_bin.sh || exit 1
+APR_BIN_STRICT=1 "$APR" --version
 git rev-parse --short HEAD
 ```
 
 PASS if version string contains the HEAD commit hash. FAIL if build errors or mismatch.
+
+> **Why `$APR` and not `apr`.** The previous version of this gate installed to
+> `$CARGO_HOME/bin` and then invoked a **bare `apr`**, which PATH resolves
+> independently. On the machine that runs this protocol `~/.local/bin/apr`
+> preceded `~/.cargo/bin/apr` and held a 26-day-old 0.60.0 build, so Gate 1
+> installed a fresh binary and then version-checked a stale one. That is the
+> exact defect #2344 fixed in `qwen-story-daily`, and it survived here — in the
+> protocol that certifies releases. A dogfood run is worthless if it exercised a
+> binary other than the one being shipped.
 
 ## Gate 2: Full Command Grid (FALSIFY-QA-001, FALSIFY-QA-009)
 
@@ -538,16 +550,29 @@ reporting a stale commit hash in git worktrees because `build.rs` watches a
 hardcoded `../../.git/HEAD` path that doesn't exist in a worktree layout.
 
 ```bash
-# After cargo install, apr --version SHA MUST match git rev-parse --short HEAD.
+# After cargo install, the SHA MUST match git rev-parse --short HEAD.
 # Run this from inside the source checkout (or worktree) you just built from.
-APR_SHA=$(apr --version 2>&1 | grep -oE '\([a-f0-9]{7,}\)' | tr -d '()')
+. scripts/apr_bin.sh || exit 1
+APR_SHA=$("$APR" --version 2>&1 | grep -oE '\([a-f0-9]{7,}\)' | tr -d '()')
 HEAD_SHA=$(git rev-parse --short HEAD)
 if [ -n "$APR_SHA" ] && [ "$APR_SHA" = "$HEAD_SHA" ]; then
-  echo "G13 PASS: apr --version SHA ($APR_SHA) matches HEAD"
+  echo "G13 PASS: $APR SHA ($APR_SHA) matches HEAD"
 elif [ -z "$APR_SHA" ]; then
-  echo "G13 SKIP: apr --version has no embedded SHA (likely crates.io install)"
+  # NOT a SKIP. A binary with no embedded SHA cannot be shown to be the code
+  # under test, and "cannot prove" must never read as "fine". This branch used
+  # to SKIP for "likely crates.io install" — and the binary that wins PATH
+  # resolution on this machine is `~/.local/bin/apr`, which reports exactly
+  # `apr 0.60.0 (v0.60.0+no-git)`. So the one stale artifact most likely to be
+  # executed was also the one that made the protocol's ONLY freshness gate
+  # excuse itself. If you are deliberately dogfooding a published crates.io
+  # build, say so explicitly with DOGFOOD_ALLOW_UNPINNED=1.
+  if [ "${DOGFOOD_ALLOW_UNPINNED:-0}" = "1" ]; then
+    echo "G13 SKIP (explicitly allowed): $APR has no embedded SHA"
+  else
+    echo "G13 FAIL: $APR has NO embedded SHA — cannot prove it is HEAD. Set DOGFOOD_ALLOW_UNPINNED=1 only for a deliberate crates.io dogfood."
+  fi
 else
-  echo "G13 FAIL: apr --version SHA=$APR_SHA but HEAD=$HEAD_SHA (#1862)"
+  echo "G13 FAIL: $APR SHA=$APR_SHA but HEAD=$HEAD_SHA (#1862)"
 fi
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,19 +84,33 @@ make coverage                # Coverage report (enforced floor 88%, target ≥95
 
 GH-202 lesson: we read code instead of running `apr qa` which would have instantly shown the failure.
 
+**Step 0 — pin the binary, ALWAYS.** Never invoke a bare `apr`, and never hardcode
+an absolute path to one. Four `apr` binaries were found coexisting on the dev box
+(0.60.0 ×2, 0.61.0, 0.62.0); a bare `apr` resolved to a **26-day-old** copy, and
+the path this file used to call "canonical" was two minor versions stale. There is
+no correct path to hardcode — `.cargo/config.toml` redirects cargo's target-dir and
+is gitignored, so the main checkout and a fresh worktree build to different places.
+
+```bash
+. scripts/apr_bin.sh || exit 1   # exports $APR, proves it was built from HEAD
+```
+
+Everything below uses `"$APR"`. A diagnostic run against the wrong binary is worse
+than no diagnostic: it produces a confident answer about code you are not running.
+
 ```bash
 # Step 1: ALWAYS start here (catches 80% of issues)
-apr qa model.apr
+"$APR" qa model.apr
 
 # Step 2: Check tensor shapes/stats
-apr tensors model.apr | head -20
+"$APR" tensors model.apr | head -20
 
 # Step 3: Diff against known-good model
-apr diff model.apr reference.gguf
+"$APR" diff model.apr reference.gguf
 
 # Step 4: Format/metadata integrity
-apr validate model.apr --quality
-apr lint model.apr
+"$APR" validate model.apr --quality
+"$APR" lint model.apr
 
 # Step 5: ONLY NOW read code
 ```

--- a/scripts/apr_bin.sh
+++ b/scripts/apr_bin.sh
@@ -38,18 +38,63 @@ apr_bin_die() {
     return 1
 }
 
-# Resolve the intended binary, most explicit first.
+# Resolve the binary THIS CHECKOUT builds. Ask cargo; never guess.
+#
+# This deliberately does NOT consult PATH, $CARGO_HOME/bin, or any absolute
+# path. Four `apr` binaries were found coexisting on one machine - 0.60.0,
+# 0.61.0, 0.62.0 and a second 0.60.0 with no embedded SHA at all - and every
+# resolution strategy that *searches* for a binary will eventually find the
+# wrong one. Detection was already in place and still lost 24 days to a stale
+# nightly, so the fix is to stop searching.
+#
+# `cargo metadata` reports the real target directory under every checkout shape,
+# which matters because `.cargo/config.toml` redirects it and is GITIGNORED
+# (.gitignore:55) while its siblings `.cargo/audit.toml` and `.cargo/mutants.toml`
+# are tracked. The directory looks version-controlled; the file that moves every
+# build output is not. Measured:
+#   main checkout  -> /mnt/nvme-raid0/coverage/aprender   (redirect applies)
+#   fresh worktree -> <worktree>/target                   (no config, cargo default)
+# A hardcoded absolute path is therefore right in exactly one of those and
+# silently wrong in the other - which is how a release smoke-test came to read a
+# five-hour-old binary and report a meaningless pass.
+apr_bin_target_dir() {
+    local here
+    here=$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+    (cd "$here" && cargo metadata --no-deps --format-version 1 2>/dev/null) \
+        | jq -r '.target_directory // empty' 2>/dev/null
+}
+
 apr_bin_resolve() {
+    # Explicit override is the ONLY escape hatch - needed for A/B work such as
+    # comparing a released binary against HEAD. It is still freshness-checked
+    # below, so it cannot be used to smuggle a stale binary past the gate.
     if [ -n "${APR_BIN:-}" ]; then
         printf '%s\n' "$APR_BIN"
         return 0
     fi
+    local td
+    td=$(apr_bin_target_dir)
+    [ -n "$td" ] || return 1
+    if [ -x "$td/release/apr" ]; then
+        printf '%s\n' "$td/release/apr"
+        return 0
+    fi
+    if [ -x "$td/debug/apr" ]; then
+        printf '%s\n' "$td/debug/apr"
+        return 0
+    fi
+    # Last resort: the `cargo install` destination. `cargo install` builds in a
+    # temp dir and copies only the finished binary here, so it leaves nothing in
+    # the target dir above - qwen-story-daily installs exactly this way. Kept
+    # LAST so a checkout that has built its own binary always tests that one,
+    # and it is still freshness-checked like every other candidate, so this is a
+    # fallback in resolution order only, never a way around the gate.
     local cargo_home="${CARGO_HOME:-$HOME/.cargo}"
     if [ -x "$cargo_home/bin/apr" ]; then
         printf '%s\n' "$cargo_home/bin/apr"
         return 0
     fi
-    command -v apr 2>/dev/null || return 1
+    return 1
 }
 
 # Assert the binary's embedded SHA matches HEAD. No-op outside a git checkout
@@ -59,6 +104,17 @@ apr_bin_assert_fresh() {
     local reported head shadows
 
     reported=$("$bin" --version 2>&1 || true)
+
+    # FAIL CLOSED outside a git checkout when strict. The old behaviour returned
+    # 0 here ("freshness not asserted"), which meant any binary passed the guard
+    # as long as you ran it from the wrong directory - a fail-OPEN hole in a
+    # script whose entire job is to refuse unproven binaries. Release and
+    # dogfood surfaces set APR_BIN_STRICT=1 so "cannot prove" means "refuse".
+    if [ "${APR_BIN_STRICT:-0}" = "1" ] && ! git rev-parse --short HEAD >/dev/null 2>&1; then
+        printf 'apr_bin: STRICT mode and this is not a git checkout - cannot prove %s\n' "$bin" >&2
+        printf '         was built from the code under test, so it is refused.\n' >&2
+        return 1
+    fi
 
     if ! git rev-parse --short HEAD >/dev/null 2>&1; then
         printf 'apr_bin: %s (%s) - not a git checkout, freshness not asserted\n' \

--- a/scripts/check_apr_bin_pinned.sh
+++ b/scripts/check_apr_bin_pinned.sh
@@ -56,6 +56,18 @@ scanned=0
 # by the case table below, not by reading.
 BARE_APR='(^|[;&|]|&&|\|\||run:)[[:space:]]*apr[[:space:]]+[a-z]'
 
+# An absolute path whose last component is `apr`. Anchored on a leading `/`,
+# `~/` or `$HOME/` so relative `target/release/apr` (correct inside a checkout)
+# is untouched, and requiring the path to END at `apr` so `apr-cli`,
+# `aprender-*` and `.../apr_bin.sh` do not match.
+# The leading anchor is load-bearing and was wrong in the first draft: without
+# it, `[A-Za-z0-9_.$/-]*` happily matched the `/apr` inside RELATIVE
+# `target/release/apr`, flagging correct code. Verified against a 12-case table
+# (4 absolute forms must match, 8 relative/`$APR`/`--bin apr`/prose forms must
+# not). This regex class has now been gotten wrong four times in this repo; if
+# you change it, re-run the table rather than reading it.
+ABS_APR='(^|[[:space:]"'"'"'=(])(/|~/|\$HOME/)[A-Za-z0-9_.$/-]*/apr([[:space:]"'"'"']|$)'
+
 check_file() {
     local f="$1" n=0
     scanned=$((scanned + 1))
@@ -91,6 +103,33 @@ check_file() {
         printf '         %s\n' "$trimmed"
         n=$((n + 1))
     done < <(grep -nE "$BARE_APR" "$f" 2>/dev/null || true)
+
+    # SECOND CLASS: an ABSOLUTE hardcoded apr path.
+    #
+    # This is the other half of the same defect, and the `case` above would wave
+    # it straight through: `/mnt/nvme-raid0/targets/aprender/release/apr` ends in
+    # `target/release/apr`, so it matched the "already pinned" list. It is not
+    # pinned to anything - it names one machine's build output, which on
+    # 2026-08-01 was 6 days and TWO MINOR VERSIONS stale while docs still called
+    # it canonical. A release smoke-test read it and reported a meaningless pass.
+    #
+    # There is no correct absolute path to hardcode: `.cargo/config.toml`
+    # redirects cargo's target-dir and is gitignored, so the main checkout builds
+    # to /mnt/nvme-raid0/coverage/aprender while a fresh worktree builds to
+    # <worktree>/target. Any absolute path is right in one and silently wrong in
+    # the other. Use `. scripts/apr_bin.sh || exit 1`, which asks cargo.
+    while IFS= read -r hit; do
+        local lineno text trimmed
+        lineno="${hit%%:*}"
+        text="${hit#*:}"
+        trimmed=$(printf '%s' "$text" | sed 's/^[[:space:]]*//')
+        case "$trimmed" in '#'*) continue ;; *) ;; esac
+        # apr_bin.sh itself documents these paths in its own comments.
+        case "$f" in */apr_bin.sh|*/check_apr_bin_pinned.sh) continue ;; *) ;; esac
+        printf 'ABS-APR  %s:%s\n' "$f" "$lineno"
+        printf '         %s\n' "$trimmed"
+        n=$((n + 1))
+    done < <(grep -nE "$ABS_APR" "$f" 2>/dev/null || true)
     violations=$((violations + n))
 }
 


### PR DESCRIPTION
**Four `apr` binaries were coexisting on the dev box:**

| path | version | age |
|---|---|---|
| `~/.local/bin/apr` | 0.60.0 (**no SHA**) | 26 days |
| `~/.cargo/bin/apr` | 0.62.0 (`341875412`) | fresh |
| `/mnt/nvme-raid0/coverage/…/apr` | 0.61.0 (`95145584f`) | 1 day |
| `/mnt/nvme-raid0/targets/…/apr` | 0.60.0 (`c55a3335c`) | 6 days |

This class has caused damage **three times**: `qwen-story-daily` validated 24-day-old code while reporting green (#2344); the v0.62.0 release smoke-test read a five-hour-old binary and reported a meaningless pass; and a real product regression (#2350) stayed hidden for 24 days because the nightly ran a pre-regression binary.

Detection already existed. It was not enough.

## 1. Resolution: ask cargo, never search

`apr_bin.sh` derived `$APR` from `$CARGO_HOME/bin` then PATH — both of which **search**, and a search finds the wrong binary eventually. It now asks `cargo metadata` for this checkout's `target_directory`.

That matters because `.cargo/config.toml` redirects target-dir and is **gitignored** (`.gitignore:55`) while its siblings `.cargo/audit.toml` and `.cargo/mutants.toml` are tracked — the directory *looks* version-controlled; the file that moves every build output is not. Measured:

```
main checkout   -> /mnt/nvme-raid0/coverage/aprender
fresh worktree  -> <worktree>/target
```

**No absolute path is correct in both.** `$CARGO_HOME/bin` is kept last (cargo install leaves nothing in `target/`), still freshness-checked.

## 2. Fail closed

`APR_BIN_STRICT=1` makes "not a git checkout" a refusal. It previously returned **0** with "freshness not asserted" — a fail-*open* hole in a script whose only job is refusing unproven binaries.

## 3. Hardcoded absolute paths are now a build failure

`check_apr_bin_pinned.sh` treated `/mnt/.../target/release/apr` as **pinned**, because it ends in `target/release/apr`. So the exact path that was 6 days and two minor versions stale sailed through the guard.

New `ABS-APR` class, **mutation-verified** by injecting that literal path into `qwen-story.sh`: RED exit 1, GREEN exit 0 after revert.

The regex is anchored at the path *start* — the first draft matched the `/apr` inside **relative** `target/release/apr` and flagged correct code. Verified against a 12-case table (4 must match, 8 must not). This regex class has now been gotten wrong four times in this repo, so the table ships with it.

## 4. The dogfood protocol was certifying releases with an unpinned binary

This is the part that matters most, and it was found by audit rather than by me:

- **Gate 1** ran `cargo install --path` (writes `$CARGO_HOME/bin`) and then a **bare `apr`** — PATH resolved to the 26-day-old `~/.local/bin` copy.
- **Gate 13**, the protocol's *only* freshness assertion, **SKIPPED** when the binary had no embedded SHA *"(likely crates.io install)"*. `~/.local/bin/apr` reports exactly `apr 0.60.0 (v0.60.0+no-git)`.

So the single artifact most likely to be executed was also the one that made the only freshness gate excuse itself. A dogfood run is worthless if it exercised a binary other than the one being shipped.

Both gates now go through `. scripts/apr_bin.sh || exit 1`; no-SHA is a **FAIL** unless `DOGFOOD_ALLOW_UNPINNED=1` is set deliberately.

## 5. CLAUDE.md

The "MANDATORY: use apr tools first" block — the most-followed instruction in the repo — told every agent to run bare `apr qa`. It now pins Step 0 and uses `"$APR"` throughout.

## Verification

`check_apr_bin_pinned`, `check_sourced_libs_option_neutral`, `check_pass_grep_anchored` all exit 0. bashrs errors across both changed scripts: **8 → 5**.

## Not fixed here

The stale binaries still **exist** on the box — deleting a developer's `~/.local/bin/apr` is an operator decision, not a repo change. Historical specs under `docs/specifications/` still quote the old absolute path as a record of past runs; those are records, not instructions. Both tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)