### PR TITLE
fix(release): the POST-PUBLISH verification could not fail, and the guard never scanned the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,9 +186,13 @@ tier2:
 	@echo "Running Tier 2: Pre-commit checks..."
 	@PROPTEST_CASES=5 QUICKCHECK_TESTS=5 cargo test --lib
 	@cargo clippy -- -D warnings
-	@if [ -d tests/golden ] && command -v apr >/dev/null 2>&1; then \
-		echo "Running probar golden regression..."; \
-		apr probar tests/golden/model.apr --golden tests/golden/ --assert --tolerance 0.98 2>/dev/null || true; \
+	@if [ -d tests/golden ]; then \
+		if . scripts/apr_bin.sh 2>/dev/null; then \
+			echo "Running probar golden regression... ($$APR)"; \
+			"$$APR" probar tests/golden/model.apr --golden tests/golden/ --assert --tolerance 0.98 2>/dev/null || true; \
+		else \
+			echo "Skipping probar golden regression: no apr built from HEAD (scripts/apr_bin.sh)"; \
+		fi; \
 	fi
 	@echo "Tier 2: PASSED"
 
@@ -206,9 +210,13 @@ tier3:
 	@bash scripts/check_build_rs_paths.sh
 	@echo "Checking self-hosted CI jobs pin a discriminating runner label..."
 	@bash scripts/check_runner_labels.sh
-	@if [ -d tests/golden ] && command -v apr >/dev/null 2>&1; then \
-		echo "Running probar golden regression with profiling..."; \
-		apr probar tests/golden/model.apr --golden tests/golden/ --assert --tolerance 0.98 2>/dev/null || true; \
+	@if [ -d tests/golden ]; then \
+		if . scripts/apr_bin.sh 2>/dev/null; then \
+			echo "Running probar golden regression with profiling... ($$APR)"; \
+			"$$APR" probar tests/golden/model.apr --golden tests/golden/ --assert --tolerance 0.98 2>/dev/null || true; \
+		else \
+			echo "Skipping probar golden regression: no apr built from HEAD (scripts/apr_bin.sh)"; \
+		fi; \
 	fi
 	@echo "Tier 3: PASSED"
 
@@ -908,7 +916,7 @@ publish: ## Publish crate(s) to crates.io — strips [patch], publishes, then ve
 	if [ "$$CRATE" = "apr-cli" ]; then \
 		echo "Verifying: cargo install apr-cli --force ..."; \
 		cargo install apr-cli --force 2>&1 | tee /tmp/publish-verify-$$CRATE.log; \
-		INSTALL_STATUS=$$?; \
+		INSTALL_STATUS=$${PIPESTATUS[0]}; \
 		if [ $$INSTALL_STATUS -ne 0 ]; then \
 			echo ""; \
 			echo "FATAL: cargo install apr-cli FAILED after publish!"; \
@@ -917,13 +925,20 @@ publish: ## Publish crate(s) to crates.io — strips [patch], publishes, then ve
 			exit 1; \
 		fi; \
 		echo "Verifying apr --version..."; \
-		VERSION=$$(apr --version 2>&1); \
-		echo "  $$VERSION"; \
-		echo "POST-PUBLISH VERIFICATION: PASSED"; \
+		WANT=$$(grep -m1 '^version' Cargo.toml | sed 's/.*"\(.*\)".*/\1/'); \
+		APR_BIN_PATH="$${CARGO_HOME:-$$HOME/.cargo}/bin/apr"; \
+		GOT=$$("$$APR_BIN_PATH" --version 2>&1); \
+		echo "  expected $$WANT, $$APR_BIN_PATH reports: $$GOT"; \
+		case "$$GOT" in \
+			*"$$WANT"*) echo "POST-PUBLISH VERIFICATION: PASSED" ;; \
+			*) echo "FATAL: published apr reports '$$GOT' but this tree is $$WANT."; \
+			   echo "The publish did not produce the binary we think it did."; \
+			   exit 1 ;; \
+		esac; \
 	else \
 		echo "Verifying: cargo install apr-cli --force (depends on $$CRATE)..."; \
 		cargo install apr-cli --force 2>&1 | tee /tmp/publish-verify-$$CRATE.log; \
-		INSTALL_STATUS=$$?; \
+		INSTALL_STATUS=$${PIPESTATUS[0]}; \
 		if [ $$INSTALL_STATUS -ne 0 ]; then \
 			echo ""; \
 			echo "FATAL: cargo install apr-cli FAILED after publishing $$CRATE!"; \

--- a/crates/aprender-serve/tests/beat_ollama_decode_throughput_speed.rs
+++ b/crates/aprender-serve/tests/beat_ollama_decode_throughput_speed.rs
@@ -231,7 +231,28 @@ fn ollama_eval_tps_once(model: &str) -> Option<f64> {
 #[ignore = "ENFORCED manual/GPU gate: needs NVIDIA GPU + apr --features cuda (incl. #2049 FP8 \
             stall fix) + ollama + Q4_K_M model (no NVIDIA CI runner; status=enforced, see contract)"]
 fn beat_ollama_decode_throughput_speed() {
-    let apr_bin = env_or("APR_BIN", "/mnt/nvme-raid0/targets/aprender/release/apr");
+    // APR_BIN is REQUIRED — there is deliberately no default path.
+    //
+    // This used to default to /mnt/nvme-raid0/targets/aprender/release/apr. That
+    // directory is ORPHANED: nothing in the repo writes it (`git grep target-dir`
+    // finds no producer), so it is hand-maintained convention that goes stale by
+    // construction. On 2026-08-01 it held 0.60.0 while HEAD was 0.62.0 — six days
+    // and two minor versions behind — and a beat measuring a stale binary reports
+    // a number about code nobody is shipping. cuda-nightly.yml already overrides
+    // APR_BIN for exactly this reason; the default only ever served whoever forgot.
+    //
+    // There is also no correct path to substitute: `.cargo/config.toml` redirects
+    // cargo's target-dir and is gitignored, so the main checkout and a worktree
+    // build to different places. Callers must resolve it — `scripts/apr_bin.sh`
+    // asks cargo and proves the binary's embedded SHA matches HEAD.
+    let apr_bin = std::env::var("APR_BIN").unwrap_or_else(|_| {
+        panic!(
+            "APR_BIN must be set to the apr binary under test. There is no default: \
+             any hardcoded path is stale in some checkout and right in another. \
+             Resolve it with `. scripts/apr_bin.sh` (exports $APR, asserts SHA == HEAD), \
+             then re-run with APR_BIN=\"$APR\"."
+        )
+    });
     let gguf = env_or(
         "APR_GGUF",
         &format!(

--- a/scripts/check_apr_bin_pinned.sh
+++ b/scripts/check_apr_bin_pinned.sh
@@ -54,7 +54,10 @@ scanned=0
 # Two earlier drafts got this wrong in opposite directions - one missed
 # `- run: apr qa` entirely, the next flagged ten step names. Both were caught
 # by the case table below, not by reading.
-BARE_APR='(^|[;&|]|&&|\|\||run:)[[:space:]]*apr[[:space:]]+[a-z]'
+# `@?` covers Makefile recipe lines, which start with a TAB and usually make's
+# silent-prefix `@`. Without it a recipe `\t@apr qa model.apr` slipped straight
+# through — caught by mutation-testing the Makefile scan, not by reading it.
+BARE_APR='(^|[;&|]|&&|\|\||run:)[[:space:]]*@?[[:space:]]*apr[[:space:]]+[a-z]'
 
 # An absolute path whose last component is `apr`. Anchored on a leading `/`,
 # `~/` or `$HOME/` so relative `target/release/apr` (correct inside a checkout)
@@ -142,6 +145,17 @@ while IFS= read -r s; do
     [ -n "$s" ] || continue
     check_file "$s"
 done < <(ci_scripts)
+
+# The Makefile is a CI surface: coverage-nightly.yml invokes `make coverage`, and
+# `make publish` runs the POST-PUBLISH RELEASE VERIFICATION. Leaving it unscanned
+# is how that verification came to run a bare `apr --version`, print it, and
+# declare "POST-PUBLISH VERIFICATION: PASSED" without comparing it to anything —
+# on a machine where a bare `apr` resolved to a 26-day-old build. A guard that
+# does not scan the surface where the release decision is made is theater,
+# however correct it is elsewhere.
+for f in Makefile; do
+    [ -f "$f" ] && check_file "$f"
+done
 
 if [ "$violations" -gt 0 ]; then
     printf '\n%s bare `apr` invocation(s) on CI surfaces (%s file(s) scanned).\n' \


### PR DESCRIPTION
Three defects on the **release-decision path**, all found by pointing `check_apr_bin_pinned.sh` at the Makefile for the first time.

## 1. `make publish`'s post-publish verification could not detect a broken crate

```make
cargo install apr-cli --force 2>&1 | tee /tmp/publish-verify-$CRATE.log
INSTALL_STATUS=$?
```

`$?` after a pipeline is **tee's** status. `INSTALL_STATUS` was always 0, so the `FATAL: cargo install apr-cli FAILED after publish!` branch below it was **unreachable**.

```
false | tee /dev/null ; echo $?               -> 0   (wrong)
false | tee /dev/null ; echo ${PIPESTATUS[0]} -> 1   (right)
```

The Makefile sets `SHELL := /bin/bash`, so `PIPESTATUS` is available. Fixed at both occurrences. Same class as #2336.

## 2. The version check asserted nothing

The same block captured `apr --version` into a variable, echoed it, and printed `POST-PUBLISH VERIFICATION: PASSED` — **without comparing it to anything**, on a bare `apr` that resolves to a 26-day-old 0.60.0 on this machine. It now reads the workspace version, invokes the cargo-install destination explicitly, and fails when they disagree.

## 3. The guard never scanned the Makefile — which is why 1 and 2 survived

`make coverage` is a CI surface (`coverage-nightly.yml:71`) and `make publish` is *the* release surface. Scanning it immediately found two more bare `apr probar` calls (tier2/tier3), now routed through `scripts/apr_bin.sh`. Their old precondition `command -v apr` asked whether *some* apr exists on PATH, not whether it was built from this commit; they skip loudly now.

### The mutation test failed first, and that mattered

Appending a recipe `\t@apr qa model.apr` did **not** turn the guard red. `BARE_APR` requires `apr` after a command separator, and make's silent-prefix `@` blocked it — the two `probar` lines had matched only because they sit after `; \` inside a multi-line block.

Added `@?`, re-verified against an 11-case table, re-ran the mutation: **RED (exit 1, naming the line), GREEN on revert.** Without mutation-testing the new scan I would have shipped a Makefile scanner blind to the most common Makefile form.

## 4. The ollama beat defaulted to an orphaned path

`beat_ollama_decode_throughput_speed` defaulted `APR_BIN` to `/mnt/nvme-raid0/targets/aprender/release/apr` — a directory **nothing in the repo writes** (`git grep target-dir` finds no producer), which on 2026-08-01 held 0.60.0 against a 0.62.0 HEAD. `cuda-nightly.yml` already overrides it for that reason; the default only ever served whoever forgot.

`APR_BIN` is now **required**, with a panic naming `scripts/apr_bin.sh`. Target compiles clean (`cargo check -p aprender-serve --test ...` exit 0).

## Verification

- guard: **28** CI-surface files scanned, all pinned (was 27)
- `make -n tier2` exit 0, unchanged from baseline
- beat target `cargo check` exit 0

Part of #2358.

🤖 Generated with [Claude Code](https://claude.com/claude-code)