### PR TITLE
fix(skills): the repo's dogfood skill was invisible — renamed to apr-dogfood so it can actually be invoked

### DIFF
--- a/.claude/skills/apr-dogfood/SKILL.md
+++ b/.claude/skills/apr-dogfood/SKILL.md
@@ -1,4 +1,12 @@
 ---
+# EXPLICIT name (#2332). Without this, the skill takes its name from the
+# directory, and `dogfood` collides with a personal user-scope skill at
+# ~/.claude/skills/dogfood/. On any machine where both exist the USER one
+# wins and this file NEVER APPEARS in the session's skill listing at all —
+# it cannot be invoked and nothing warns. That is worse than a missing
+# skill: edits here look effective and change nothing that runs, which is
+# exactly what happened when #2357 hardened Gates 1 and 13 below.
+name: apr-dogfood
 allowed-tools: Bash(cargo:*), Bash(apr:*), Bash(pmat:*), Bash(gh:*), Bash(git:*), Bash(find:*), Bash(head:*), Bash(tail:*), Bash(wc:*), Bash(grep:*), Bash(diff:*), Bash(timeout:*), Bash(jq:*), Bash(python3:*), Bash(echo:*), Bash(cat:*), Bash(rm:*), Bash(ssh:*), Read, Glob, Grep, Agent
 description: Dogfood apr-cli — rebuild, install, exercise all commands against real models, check quality, find next work
 ---

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ MoE GGUF. Every beat is a falsifier in
 [`contracts/qwen-story-v1.yaml`](contracts/qwen-story-v1.yaml); the runnable
 form is [`scripts/qwen-story.sh`](scripts/qwen-story.sh); nightly cron is
 [`.github/workflows/qwen-story-daily.yml`](.github/workflows/qwen-story-daily.yml);
-the dogfood gate is `/dogfood` Gate 18.
+the dogfood gate is `/apr-dogfood` Gate 18.
 
 ```bash
 # Reproduce locally (uses ~/models cache; ~3-5 min on RTX 4090):

--- a/docs/claude-code-skills/README.md
+++ b/docs/claude-code-skills/README.md
@@ -10,7 +10,7 @@ aprender ships with two [Claude Code skills](https://docs.anthropic.com/en/docs/
 
 ## Available Skills
 
-### `/dogfood` — Daily Development Loop
+### `/apr-dogfood` — Daily Development Loop
 
 **When to use:** After making changes, before picking up the next ticket.
 
@@ -33,7 +33,7 @@ Rebuilds `apr-cli` from source, exercises it against real model files, runs qual
 
 **Verdicts:** GO (all pass) / WARN (soft issues, binary works) / FAIL (blocking issues)
 
-**For debugging contributions:** Run `/dogfood` after your fix. Gate 2 exercises `apr` commands against real models — if your fix breaks model handling, this catches it. Gate 5 runs 3,800+ tests to catch regressions.
+**For debugging contributions:** Run `/apr-dogfood` after your fix. Gate 2 exercises `apr` commands against real models — if your fix breaks model handling, this catches it. Gate 5 runs 3,800+ tests to catch regressions.
 
 ---
 
@@ -72,7 +72,7 @@ If you're investigating a bug in aprender:
 
 1. **Reproduce** — Use `apr qa <model>` to get a falsifiable failure
 2. **Fix** — Make your code changes
-3. **Verify** — Run `/dogfood` to rebuild, exercise the binary, and run tests
+3. **Verify** — Run `/apr-dogfood` to rebuild, exercise the binary, and run tests
 4. **Pre-publish** — If touching packaging or deps, run `/pre-release`
 
 ### Example: Debugging a Model Import Issue

--- a/docs/dogfood-templates/albor-370m-v1-dogfood-template.md
+++ b/docs/dogfood-templates/albor-370m-v1-dogfood-template.md
@@ -4,7 +4,7 @@
 
 **Spec**: SPEC-SHIP-TWO-001 §88 (compute-bounded ship target) + §89 (distillation epic deferred).
 **Contract**: `contracts/apr-cli-qa-v1.yaml` + 5 companion contracts (silent-fallback, metamorphic, coverage, chaos, differential).
-**Skill**: `.claude/skills/dogfood/SKILL.md` (12 gates + P1-P12 protocols).
+**Skill**: `.claude/skills/apr-dogfood/SKILL.md` (12 gates + P1-P12 protocols).
 
 ---
 
@@ -128,7 +128,7 @@ Verify:
 
 ## 6. /dogfood skill (apr-cookbook 12-protocol sweep)
 
-Per `.claude/skills/dogfood/SKILL.md`:
+Per `.claude/skills/apr-dogfood/SKILL.md`:
 
 ```bash
 # Run from inside a Claude session with the model path argument

--- a/docs/specifications/apr-cli-qa-spec.md
+++ b/docs/specifications/apr-cli-qa-spec.md
@@ -10,7 +10,7 @@
 - `contracts/apr-qa-differential-v1.yaml` — ollama parity, tokenizer fidelity, concurrent serve (5 tests)
 - `contracts/apr-qa-chaos-v1.yaml` — memory budget, OOM, signals, disk, overwrite protection (5 tests)
 - `contracts/apr-qa-coverage-v1.yaml` — category coverage, SATD zero, complexity gate (5 tests)
-**Skill**: `.claude/skills/dogfood/SKILL.md`
+**Skill**: `.claude/skills/apr-dogfood/SKILL.md`
 **Source**: Extended from `apr-cookbook/.claude/skills/qa/SKILL.md`
 **arXiv**: 1807.10453, 2207.11976, 2505.03096, 2603.23611, 2103.13630, 2102.05351
 
@@ -280,7 +280,7 @@ Contract: `apr-qa-coverage-v1.yaml`
 
 ## Claude Code Skill
 
-`.claude/skills/dogfood/SKILL.md` — invoked via `/dogfood`:
+`.claude/skills/apr-dogfood/SKILL.md` — invoked via `/apr-dogfood`:
 - 12 gates (G1-G7 structural, G8-G12 v2.0)
 - 18 sub-checks (S1-S5, M2-M3, V1+V3, C2-C3, D1-D3)
 - GO/WARN/FAIL verdict


### PR DESCRIPTION
Closes #2332.

`.claude/skills/dogfood/SKILL.md` had no `name:` in its frontmatter, so it took its name from the directory. That collides with a personal user-scope skill at `~/.claude/skills/dogfood/`, and on any machine where both exist the **user** one wins — the repo's skill never appears in the session's skill listing at all. It cannot be invoked, and nothing warns.

**Confirmed live in this session.** The `dogfood` skill offered to the agent is described as *"Sovereign-stack PRE-RELEASE protocol … (copia, forjar, pmat, trueno, aprender)"* — the user-scope one. The repo's, *"Dogfood apr-cli — rebuild, install, exercise all commands against real models"*, is absent.

## Why this matters more than a naming nit

#2357 hardened this file's **Gate 1** and **Gate 13**, because the release-certifying protocol was validating an unpinned, possibly 26-day-old binary.

Those edits were made to a file that does not run.

A shadowed skill is worse than a missing one: edits to it *look* effective and change nothing. That is the same failure mode as every other defect in the current sweep — a surface that reports success while doing nothing.

## Fix

`git mv` to `.claude/skills/apr-dogfood/` **plus an explicit `name: apr-dogfood`**.

The explicit name is the durable half — a directory rename alone would silently re-collide the day someone adds `~/.claude/skills/apr-dogfood/`. The comment above it records why, so the next person doesn't tidy it away.

Updated the four docs pointing at the old path (README, `apr-cli-qa-spec`, `claude-code-skills/README`, the albor dogfood template) and the `/dogfood` invocation references. CHANGELOG entries are historical records and left alone.

## Not fixed here

The user-scope `~/.claude/skills/dogfood/` still exists and still owns the name `dogfood`. That's a file on a developer's machine, not a repo artifact — the repo's job is to stop colliding with it, which this does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)