### PR TITLE
fix(publish): a bare "tests/" exclude is not root-anchored — it dropped 443 files from the published aprender-serve

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -417,6 +417,15 @@ jobs:
       # this is mechanical rather than a review note. Text-only, no build.
       - name: Sourced libraries must not mutate the caller's shell options
         run: bash scripts/check_sourced_libs_option_neutral.sh --self-test
+      # Poka-yoke: a Cargo `exclude` entry is a gitignore pattern, so a bare
+      # `"tests/"` is NOT anchored to the package root - it matches at every
+      # depth. CB-510 was the same bug with `"models/"` hiding `src/models/`.
+      # In v0.63.0 it dropped 443 files from the published aprender-serve and
+      # left 11 (serve) + 18 (train) `mod tests;` declarations pointing at
+      # directories that are not in the tarball, so neither published crate can
+      # compile its own test suite. Text-only check, no build.
+      - name: No exclude pattern may swallow a src/ directory
+        run: bash scripts/check_exclude_anchored.sh
 
   # Top-level gate: satisfies org ruleset "Green Main" which requires check named "gate".
   # The reusable workflow produces "ci / gate" but rulesets need exact match on "gate".

--- a/Makefile
+++ b/Makefile
@@ -206,6 +206,8 @@ tier3:
 	@bash scripts/check_include_files.sh
 	@echo "Checking publish safety (symlinks, companion lookups)..."
 	@bash scripts/check_publish_safety.sh
+	@echo "Checking exclude patterns are root-anchored (CB-510 class)..."
+	@bash scripts/check_exclude_anchored.sh
 	@echo "Checking build.rs crate-root escapes (v0.31.1 yank class)..."
 	@bash scripts/check_build_rs_paths.sh
 	@echo "Checking self-hosted CI jobs pin a discriminating runner label..."

--- a/crates/aprender-contracts/Cargo.toml
+++ b/crates/aprender-contracts/Cargo.toml
@@ -9,7 +9,7 @@ license.workspace = true
 repository.workspace = true
 keywords = ["verification", "formal-methods", "kani", "contracts", "ml-kernels"]
 categories = ["development-tools::testing", "mathematics"]
-exclude = ["tests/", "benches/"]
+exclude = ["/tests/", "benches/"]
 
 [features]
 default = []

--- a/crates/aprender-data/Cargo.toml
+++ b/crates/aprender-data/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-exclude = ["tests/", "benches/", "docs/", ".github/", "book/", ".pmat/"]
+exclude = ["/tests/", "benches/", "docs/", ".github/", "book/", ".pmat/"]
 name = "aprender-data"
 version.workspace = true
 edition = "2021"

--- a/crates/aprender-db/Cargo.toml
+++ b/crates/aprender-db/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-exclude = ["tests/", "benches/", "docs/", ".github/", "book/", ".pmat/", "target/", ".profraw", ".profdata", ".vscode/", ".idea/", "proptest-regressions/"]
+exclude = ["/tests/", "benches/", "docs/", ".github/", "book/", ".pmat/", "target/", ".profraw", ".profdata", ".vscode/", ".idea/", "proptest-regressions/"]
 name = "aprender-db"
 version.workspace = true
 edition.workspace = true

--- a/crates/aprender-distribute/Cargo.toml
+++ b/crates/aprender-distribute/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-exclude = ["tests/", "benches/", "docs/", ".github/", "book/", ".pmat/"]
+exclude = ["/tests/", "benches/", "docs/", ".github/", "book/", ".pmat/"]
 name = "aprender-distribute"
 version.workspace = true
 edition = "2021"

--- a/crates/aprender-present-cli/Cargo.toml
+++ b/crates/aprender-present-cli/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-exclude = ["tests/", "benches/", "docs/", ".github/", ".pmat/", "target/", ".profraw", ".profdata", ".vscode/", ".idea/", "proptest-regressions/"]
+exclude = ["/tests/", "benches/", "docs/", ".github/", ".pmat/", "target/", ".profraw", ".profdata", ".vscode/", ".idea/", "proptest-regressions/"]
 name = "aprender-present-cli"
 description = "CLI for Presentar WASM apps - serve and bundle"
 version.workspace = true

--- a/crates/aprender-present-core/Cargo.toml
+++ b/crates/aprender-present-core/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-exclude = ["tests/", "benches/", "docs/", ".github/", ".pmat/", "target/", ".profraw", ".profdata", ".vscode/", ".idea/", "proptest-regressions/"]
+exclude = ["/tests/", "benches/", "docs/", ".github/", ".pmat/", "target/", ".profraw", ".profdata", ".vscode/", ".idea/", "proptest-regressions/"]
 name = "aprender-present-core"
 description = "Core types and traits for Presentar UI framework"
 version.workspace = true

--- a/crates/aprender-present-lib/Cargo.toml
+++ b/crates/aprender-present-lib/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-exclude = ["tests/", "benches/", "docs/", ".github/", ".pmat/", "target/", ".profraw", ".profdata", ".vscode/", ".idea/", "proptest-regressions/"]
+exclude = ["/tests/", "benches/", "docs/", ".github/", ".pmat/", "target/", ".profraw", ".profdata", ".vscode/", ".idea/", "proptest-regressions/"]
 name = "aprender-present-lib"
 description = "WASM-first visualization and rapid application framework"
 version.workspace = true

--- a/crates/aprender-present-terminal/Cargo.toml
+++ b/crates/aprender-present-terminal/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-exclude = ["tests/", "benches/", "docs/", ".github/", ".pmat/", "target/", ".profraw", ".profdata", ".vscode/", ".idea/", "proptest-regressions/"]
+exclude = ["/tests/", "benches/", "docs/", ".github/", ".pmat/", "target/", ".profraw", ".profdata", ".vscode/", ".idea/", "proptest-regressions/"]
 name = "aprender-present-terminal"
 description = "Terminal backend for Presentar UI framework with zero-allocation rendering"
 version.workspace = true

--- a/crates/aprender-profile/Cargo.toml
+++ b/crates/aprender-profile/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["strace", "tracing", "syscall", "debugging", "profiling"]
 exclude = [
     "book/",
     "docs/",
-    "tests/",
+    "/tests/",
     ".pmat/",
     ".pmat-metrics/",
     ".pmat-work/",

--- a/crates/aprender-rag/Cargo.toml
+++ b/crates/aprender-rag/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
     "book/",
     "docs/",
     "examples/",
-    "tests/",
+    "/tests/",
     ".pmat/",
     ".pmat-work/",
     ".pmat-tickets/",

--- a/crates/aprender-registry/Cargo.toml
+++ b/crates/aprender-registry/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-exclude = ["tests/", "benches/", "docs/", ".github/", "book/", ".pmat/", "target/", ".profraw", ".profdata", ".vscode/", ".idea/", "proptest-regressions/"]
+exclude = ["/tests/", "benches/", "docs/", ".github/", "book/", ".pmat/", "target/", ".profraw", ".profdata", ".vscode/", ".idea/", "proptest-regressions/"]
 name = "aprender-registry"
 version.workspace = true
 edition = "2021"

--- a/crates/aprender-serve/Cargo.toml
+++ b/crates/aprender-serve/Cargo.toml
@@ -16,7 +16,7 @@ readme = "README.md"
 keywords = ["machine-learning", "inference", "model-serving", "gguf", "transformer"]
 categories = ["science", "web-programming::http-server"]
 exclude = [
-    "artifacts/", "models/", "docs/", "tests/", "benches/", "book/",
+    "artifacts/", "models/", "docs/", "/tests/", "benches/", "book/",
     "target/", ".pmat/", ".pmat-work/", ".vscode/", ".idea/",
     "*.profraw", "*.profdata", "proptest-regressions/",
 ]

--- a/crates/aprender-simulate/Cargo.toml
+++ b/crates/aprender-simulate/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-exclude = ["tests/", "benches/", "docs/", ".github/", "book/", ".pmat/", "target/", ".profraw", ".profdata", ".vscode/", ".idea/", "proptest-regressions/"]
+exclude = ["/tests/", "benches/", "docs/", ".github/", "book/", ".pmat/", "target/", ".profraw", ".profdata", ".vscode/", ".idea/", "proptest-regressions/"]
 name = "aprender-simulate"
 version.workspace = true
 edition = "2021"

--- a/crates/aprender-train/Cargo.toml
+++ b/crates/aprender-train/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [
     "book/",
     "docs/",
     "examples/",
-    "tests/",
+    "/tests/",
     "scripts/",
     ".pmat/",
     ".pmat-work/",

--- a/crates/aprender-verify/Cargo.toml
+++ b/crates/aprender-verify/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-exclude = ["tests/", "benches/", "docs/", ".github/", "book/", ".pmat/"]
+exclude = ["/tests/", "benches/", "docs/", ".github/", "book/", ".pmat/"]
 name = "aprender-verify"
 version.workspace = true
 edition = "2021"

--- a/crates/aprender-zram/Cargo.toml
+++ b/crates/aprender-zram/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-exclude = ["tests/", "benches/", "docs/", ".github/", "book/", ".pmat/", "target/", ".profraw", ".profdata", ".vscode/", ".idea/", "proptest-regressions/"]
+exclude = ["/tests/", "benches/", "docs/", ".github/", "book/", ".pmat/", "target/", ".profraw", ".profdata", ".vscode/", ".idea/", "proptest-regressions/"]
 name = "aprender-zram"
 description = "SIMD-accelerated LZ4/ZSTD compression engine for Linux zram devices"
 version.workspace = true

--- a/scripts/check_exclude_anchored.sh
+++ b/scripts/check_exclude_anchored.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+#
+# check_exclude_anchored.sh — CB-510 class guard, generalised.
+#
+# A `exclude = [...]` entry in Cargo.toml is a gitignore-style pattern. A bare
+# directory name such as `"models/"` or `"tests/"` is NOT anchored to the package
+# root: it matches at EVERY depth, so it silently swallows `src/models/` and
+# `src/api/tests/` on the way to crates.io.
+#
+# This has now shipped twice:
+#   * CB-510  — `"models/"` hid `src/models/` from git and from the package.
+#   * v0.63.0 — `"tests/"` dropped 443 files from `aprender-serve` and 117 broken
+#               `mod tests;` declarations from `aprender-train`. Both published
+#               crates cannot compile their own test suites.
+#
+# The fix in both cases is a leading slash: `"/models/"`, `"/tests/"`.
+#
+# This guard fails when a non-anchored directory pattern in any `exclude` list
+# matches a directory that actually exists under that crate's `src/`.
+#
+# Usage: bash scripts/check_exclude_anchored.sh [repo_root]
+
+set -euo pipefail
+
+repo_root="${1:-$(git rev-parse --show-toplevel)}"
+cd "$repo_root"
+
+violations=0
+checked=0
+
+# Emit the quoted entries of the `exclude = [ ... ]` array of a Cargo.toml, one
+# per line, with the surrounding quotes stripped. Comment lines are skipped.
+extract_exclude_patterns() {
+    manifest="$1"
+    sed -n '/^exclude[[:space:]]*=[[:space:]]*\[/,/\]/p' "$manifest" \
+        | sed 's/#.*//' \
+        | grep -o '"[^"]*"' \
+        | tr -d '"'
+}
+
+while IFS= read -r manifest; do
+    crate_dir="$(dirname "$manifest")"
+    src_dir="$crate_dir/src"
+    [ -d "$src_dir" ] || continue
+
+    checked=$((checked + 1))
+
+    while IFS= read -r pattern; do
+        # Anchored (`/tests/`), glob (`*.rs`, `**/x`), and non-directory
+        # patterns are all fine — only a bare `name/` is ambiguous.
+        case "$pattern" in
+            /*) continue ;;
+            *\**) continue ;;
+            */) : ;;
+            *) continue ;;
+        esac
+
+        dir_name="${pattern%/}"
+        # A pattern containing a slash in the middle (`contracts/foo/`) is
+        # already specific enough to be unambiguous in practice.
+        case "$dir_name" in
+            */*) continue ;;
+        esac
+
+        matches="$(find "$src_dir" -type d -name "$dir_name" -print 2>/dev/null || true)"
+        if [ -n "$matches" ]; then
+            count="$(printf '%s\n' "$matches" | wc -l | tr -d ' ')"
+            printf 'FAIL %s\n' "$manifest"
+            printf '     exclude pattern "%s" is not root-anchored and matches %s director(y|ies) under %s:\n' \
+                "$pattern" "$count" "$src_dir"
+            printf '%s\n' "$matches" | sed 's/^/       /' | head -5
+            if [ "$count" -gt 5 ]; then
+                printf '       ... and %s more\n' "$((count - 5))"
+            fi
+            printf '     fix: write it as "/%s"\n\n' "$pattern"
+            violations=$((violations + 1))
+        fi
+    done < <(extract_exclude_patterns "$manifest")
+done < <(git ls-files '*Cargo.toml' | sort)
+
+if [ "$violations" -gt 0 ]; then
+    printf 'check_exclude_anchored: %s violation(s) across %s manifest(s) with a src/ tree\n' \
+        "$violations" "$checked" >&2
+    printf 'A non-anchored exclude pattern removes source from the published crate.\n' >&2
+    exit 1
+fi
+
+printf 'check_exclude_anchored: OK - %s manifest(s) checked, no non-anchored exclude swallows a src/ directory\n' "$checked"


### PR DESCRIPTION
Found by dogfooding `cargo install aprender` 0.63.0 from crates.io.

## The defect

`exclude` entries in `Cargo.toml` are gitignore-style patterns, so a bare `"tests/"` matches at **every** depth, not just the package root. Sixteen crates carried it. Two of them have `src/**/tests/` directories, so `cargo publish` silently dropped them from the tarball:

| crate | git `src/` | published `src/` | missing |
|---|---|---|---|
| aprender-serve 0.63.0 | 1527 | 1084 | **443** |
| aprender-train 0.63.0 | — | — | 18 directories |

The consequence: **neither published crate can compile its own test suite.** 11 (serve) and 18 (train) `#[cfg(test)] mod tests;` declarations point at directories that are not in the tarball. `cargo publish` never noticed, because its verify build is not a test build.

This is CB-510 exactly — that was `"models/"` swallowing `src/models/`, and the fix was the same leading slash. `aprender-core` still carries the comment from the last time: `# Model files (root-anchored: /models/ not models/ per CB-510)`.

## Verification

Repackaged both crates and re-inspected the tarballs:

| crate | packaged `src/` files | broken `mod tests;` decls |
|---|---|---|
| aprender-serve before | 1084 | 11 |
| aprender-serve after | **1527** (== git) | **0** |
| aprender-train before | — | 18 |
| aprender-train after | — | **0** |

## The guard

`scripts/check_exclude_anchored.sh` generalises the rule rather than patching this one pattern: it fails when **any** non-anchored directory pattern in **any** exclude list matches a directory that exists under that crate's `src/`. So `"models/"`, `"docs/"`, `"benches/"` are covered before they bite.

Mutation verified — reverting either crate's anchor turns it RED, restoring turns it GREEN:

```
$ bash scripts/check_exclude_anchored.sh
check_exclude_anchored: OK - 93 manifest(s) checked, no non-anchored exclude swallows a src/ directory     # rc=0

$ perl -0pi -e 's|"/tests/"|"tests/"|' crates/aprender-train/Cargo.toml
$ bash scripts/check_exclude_anchored.sh
FAIL crates/aprender-train/Cargo.toml
     exclude pattern "tests/" is not root-anchored and matches 18 director(y|ies) under crates/aprender-train/src:
       ...
     fix: write it as "/tests/"                                                                            # rc=1
```

Wired into `ci / gate` and `make tier3`. `bashrs lint` clean (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Fixes #2406

Audit epic: #2373
