### PR TITLE
fix(security): exempt RUSTSEC-2026-0235 (rkyv) — unreachable optional transitive blocking every PR

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -68,6 +68,31 @@ ignore = [
     "RUSTSEC-2026-0194",
     "RUSTSEC-2026-0195",  # quick-xml NsReader namespace-alloc DoS — same not-affected path as -0194
 
+    # rkyv 0.7.46 — published 2026-08-09 and broke the security gate the same
+    # day, blocking every open PR (main was green on the commit before it).
+    #
+    # Reachability re-verified rather than assumed, the same way the wasmtime
+    # 43.0.2 entry above was. (Deliberately no bare advisory id in this prose:
+    # CI builds its --ignore list by grepping every RUSTSEC-dddd-dddd token out
+    # of this file, comments included, so naming one here would silently exempt
+    # it.) Checks run on this branch:
+    #   cargo tree --workspace --all-features | grep -c rkyv   -> 0
+    #   cargo tree -p aprender                                 -> 0
+    #   cargo tree -p aprender --no-default-features           -> 0
+    #   cargo tree -p aprender --features full                 -> 0
+    #   cargo tree -p aprender-db --all-features               -> 0
+    # ZERO paths, even with --all-features. The chain is
+    # aprender-db -> duckdb -> rust_decimal -> rkyv, but duckdb is optional
+    # (gated behind aprender-db's `competitive-benchmarks`) AND rust_decimal's
+    # own `rkyv` dependency is optional and never enabled. It appears here only
+    # because Cargo.lock records optional dependencies, so cargo-audit sees it
+    # while nothing in the workspace can link it.
+    #
+    # The advisory's fix is rkyv >=0.8.17. We cannot take it: rust_decimal
+    # 1.42.1 is the newest published version and it still requires rkyv 0.7.
+    # Drop this line the moment rust_decimal ships a 0.8-based release.
+    "RUSTSEC-2026-0235",
+
     # SVG rendering stack — UNMAINTAINED only (no CVE, no patched release exists).
     # Both enter solely via resvg -> usvg -> {fontdb, rustybuzz} -> ttf-parser;
     # no direct usage in the workspace. Reviewed 2026-07-26. Re-review if a

--- a/deny.toml
+++ b/deny.toml
@@ -64,6 +64,11 @@ ignore = [
     # a maintained fork appears or resvg migrates off them.
     { id = "RUSTSEC-2026-0192", reason = "ttf-parser 0.25.1: unmaintained, transitive via resvg->usvg->{fontdb,rustybuzz}; no patched release exists" },
     { id = "RUSTSEC-2026-0206", reason = "rustybuzz 0.20.1: unmaintained, transitive via resvg->usvg; no patched release exists" },
+    # rkyv 0.7.46 — 0 paths in `cargo tree --workspace --all-features`. Enters via
+    # aprender-db -> duckdb -> rust_decimal, but duckdb is optional (competitive-benchmarks)
+    # and rust_decimal's own rkyv dep is optional and never enabled; Cargo.lock records it
+    # anyway. Fix is rkyv >=0.8.17, unavailable: rust_decimal 1.42.1 (newest) still needs 0.7.
+    { id = "RUSTSEC-2026-0235", reason = "rkyv 0.7.46: unreachable optional transitive (duckdb->rust_decimal, rkyv feature never enabled); rust_decimal 1.42.1 has no 0.8 release yet" },
 ]
 
 [licenses]


### PR DESCRIPTION
## Why now

RUSTSEC-2026-0235 (rkyv 0.7.46 — out-of-bounds read via shared-pointer validation) was published today and turned `ci / security` red on **every open PR**. `main` was green on the commit immediately before it, so this is the advisory arriving, not a code change. This PR unblocks the queue.

## Reachability — verified, not assumed

Same treatment as the wasmtime 43.0.2 entry above it:

```
cargo tree --workspace --all-features | grep -c rkyv   -> 0
cargo tree -p aprender                                 -> 0
cargo tree -p aprender --no-default-features           -> 0
cargo tree -p aprender --features full                 -> 0
cargo tree -p aprender-db --all-features               -> 0
```

**Zero paths, even with `--all-features`.** The chain is `aprender-db -> duckdb -> rust_decimal -> rkyv`, but `duckdb` is optional (gated behind aprender-db's `competitive-benchmarks`) *and* `rust_decimal`'s own `rkyv` dependency is optional and never enabled. It is in `Cargo.lock` only because Cargo.lock records optional dependencies — which is exactly what `cargo audit` scans.

## Why not just upgrade

The advisory's fix is `rkyv >= 0.8.17`. `rust_decimal 1.42.1` is the newest published release and still requires `rkyv 0.7`. Drop this exemption the moment rust_decimal ships a 0.8-based release.

## Verification

Run with **cargo-audit 0.22.2**, the version CI installs. (Worth noting: the dev box's 0.22.1 does not report this advisory at all, so a check against the locally-installed tool would have been a false green.)

| | result |
|---|---|
| without the exemption | `error: 1 vulnerability found!` → `rkyv` / `RUSTSEC-2026-0235`, rc=1 |
| with the exemption | rc=0 |
| `cargo deny check advisories` | `advisories ok`, rc=0 |

## A trap for whoever edits this file next

CI builds its `--ignore` list by grepping every `RUSTSEC-dddd-dddd` token out of `.cargo/audit.toml`, **comments included** — so merely naming an advisory in prose exempts it. The comment added here deliberately says "the wasmtime 43.0.2 entry above" rather than its id. (Also: 0.22.2 *does* read `.cargo/audit.toml` directly, contrary to the "cargo-audit 0.22 does NOT read config files" comment in the sovereign-ci step — that lives in `paiml/.github`, not here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)