### PR TITLE
fix(serve): SSE streaming deleted every space and newline — "Thequickbrownfox"

### DIFF
--- a/crates/aprender-serve/src/api/cuda_chat_backend.rs
+++ b/crates/aprender-serve/src/api/cuda_chat_backend.rs
@@ -160,7 +160,6 @@ async fn try_cuda_backend(
             request.model.clone(),
             state.metrics.clone(),
             start,
-            false,
         ));
     }
 
@@ -281,7 +280,6 @@ fn try_quantized_backend(
             request.model.clone(),
             state.metrics.clone(),
             start,
-            true,
         ));
     }
 
@@ -791,7 +789,6 @@ fn try_qwen3_moe_backend(
             request.model.clone(),
             state.metrics.clone(),
             start,
-            true,
         ));
     }
 

--- a/crates/aprender-serve/src/api/openai_handlers.rs
+++ b/crates/aprender-serve/src/api/openai_handlers.rs
@@ -475,14 +475,22 @@ fn sse_event(value: &impl serde::Serialize) -> Option<Result<Event, Infallible>>
         .map(|data| Ok(Event::default().data(data)))
 }
 
-/// Decode a token and optionally clean the output, returning the text if non-empty.
-fn decode_token(tokenizer: &BPETokenizer, token_id: u32, clean: bool) -> Option<String> {
+/// Decode a single streamed token, returning the text if non-empty.
+///
+/// The decode is deliberately RAW. `clean_chat_output()` must never be applied
+/// per token: it opens with `text.trim_start()` and closes with `.trim()`, so
+/// running it on one token at a time deletes the leading space or newline that
+/// BPE carries on the token itself (`"Ġquick"` -> `" quick"` -> `"quick"`).
+/// Concatenating the deltas then yields `"Thequickbrownfox"` while the
+/// non-streaming response for the same prompt reads `"The quick brown fox"`.
+/// Its other jobs cannot work per-token either: stop sequences and the
+/// `Human:`/`Assistant:` turn markers span several tokens, so a single-token
+/// `find()` never matches them. Whole-response cleaning belongs to the
+/// non-streaming path, which already does it.
+///
+/// This mirrors the same removal PMAT-759 made on `pregenerated_sse_response`.
+fn decode_token(tokenizer: &BPETokenizer, token_id: u32) -> Option<String> {
     let text = tokenizer.decode(&[token_id]).ok()?;
-    let text = if clean {
-        clean_chat_output(&text)
-    } else {
-        text
-    };
     if text.is_empty() {
         None
     } else {
@@ -526,6 +534,11 @@ fn pregenerated_sse_response(
 }
 
 /// Build a true-streaming SSE response with keep-alive (tokens arrive via channel).
+///
+/// Deltas are raw per-token decodes — see `decode_token`. The `clean` parameter
+/// this function used to take is gone on purpose: two of its three call sites
+/// passed `true`, and per-token cleaning silently deleted every space and
+/// newline from the stream.
 // serde_json::json!() uses infallible unwrap
 #[allow(clippy::disallowed_methods)]
 pub(crate) fn true_streaming_sse_response(
@@ -535,7 +548,6 @@ pub(crate) fn true_streaming_sse_response(
     model_name: String,
     metrics: Arc<crate::metrics::MetricsCollector>,
     start: Instant,
-    clean: bool,
 ) -> Response {
     use tokio_stream::wrappers::ReceiverStream;
     use tokio_stream::StreamExt;
@@ -553,7 +565,7 @@ pub(crate) fn true_streaming_sse_response(
             match result {
                 Ok(token_id) => {
                     completion_tokens += 1;
-                    if let Some(text) = decode_token(&tokenizer, token_id, clean) {
+                    if let Some(text) = decode_token(&tokenizer, token_id) {
                         let chunk = ChatCompletionChunk::content(&request_id, &model_name, &text);
                         if let Some(evt) = sse_event(&chunk) {
                             yield evt;

--- a/crates/aprender-serve/src/api/tests/mod.rs
+++ b/crates/aprender-serve/src/api/tests/mod.rs
@@ -50,3 +50,4 @@ mod tests_27; // T-COV-95 Generative Falsification: Proptest API Request Assault
 mod tests_28; // Coverage: realize_handlers pure functions, ContextWindow, clean_chat, build_trace_data, serde
 mod chat_template_contract; // PMAT-187: chat-template-v1.yaml contract enforcement (FALSIFY-CT-002)
 mod embeddings_pmat803; // PMAT-803: model-backed embeddings (semantic-similarity falsifier, dim==hidden_size)
+mod sse_stream_whitespace; // Dogfood 0.63.0: SSE deltas must reassemble with whitespace intact

--- a/crates/aprender-serve/src/api/tests/sse_stream_whitespace.rs
+++ b/crates/aprender-serve/src/api/tests/sse_stream_whitespace.rs
@@ -1,0 +1,114 @@
+//! Falsifier: SSE streaming deltas must reassemble into the same text the
+//! non-streaming response returns — whitespace included.
+//!
+//! Dogfooding `cargo install aprender` 0.63.0 from crates.io found that
+//! `POST /v1/chat/completions` with `"stream":true` produced
+//! `"Thequickbrownfoxjumpsoverthelazydog."` where the non-streaming call on the
+//! same server, same model and same prompt returned
+//! `"The quick brown fox jumps over the lazy dog."`.
+//!
+//! Cause: `true_streaming_sse_response` took a `clean: bool` and two of its
+//! three call sites passed `true`, which ran `clean_chat_output()` on EVERY
+//! SINGLE TOKEN. That function opens with `text.trim_start()` and closes with
+//! `.trim()`, so the leading space BPE carries on the token itself (`"Ġquick"`
+//! decodes to `" quick"`) was deleted from every delta. Newlines went the same
+//! way.
+//!
+//! This asserts the property that actually matters to a client: concatenating
+//! `choices[0].delta.content` across the stream reproduces the full decode
+//! byte-for-byte. Reinstating the per-token clean turns it RED.
+
+use crate::tokenizer::BPETokenizer;
+use std::sync::Arc;
+
+/// Build a tokenizer whose tokens carry leading whitespace, the way real BPE
+/// vocabularies do (`Ġ` in GPT-2/Qwen byte-level BPE decodes to a space).
+fn whitespace_bearing_tokenizer() -> (Arc<BPETokenizer>, Vec<u32>, String) {
+    let vocab: Vec<String> = vec![
+        "The".to_string(),
+        " quick".to_string(),
+        " brown".to_string(),
+        " fox".to_string(),
+        "\n".to_string(),
+        " jumps".to_string(),
+        ".".to_string(),
+    ];
+    let tokenizer = BPETokenizer::new(vocab.clone(), vec![], "The").expect("build tokenizer");
+    let ids: Vec<u32> = (0..vocab.len() as u32).collect();
+    let expected: String = vocab.concat();
+    (Arc::new(tokenizer), ids, expected)
+}
+
+/// Collect the `delta.content` fields out of an SSE body, in order.
+fn concat_sse_deltas(body: &str) -> String {
+    let mut out = String::new();
+    for line in body.lines() {
+        let Some(payload) = line.strip_prefix("data: ") else {
+            continue;
+        };
+        if payload.trim() == "[DONE]" {
+            continue;
+        }
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(payload) else {
+            continue;
+        };
+        if let Some(text) = value["choices"][0]["delta"]["content"].as_str() {
+            out.push_str(text);
+        }
+    }
+    out
+}
+
+#[tokio::test]
+async fn sse_deltas_reassemble_with_whitespace_intact() {
+    let (tokenizer, ids, expected) = whitespace_bearing_tokenizer();
+
+    // Sanity: the tokenizer really does round-trip the whitespace, so a failure
+    // below is the streaming path and not the fixture.
+    let full_decode = tokenizer.decode(&ids).expect("decode all");
+    assert_eq!(
+        full_decode, expected,
+        "fixture is wrong: tokenizer does not preserve whitespace on a bulk decode"
+    );
+
+    let (tx, rx) = tokio::sync::mpsc::channel::<Result<u32, String>>(16);
+    for id in &ids {
+        tx.send(Ok(*id)).await.expect("send token");
+    }
+    drop(tx);
+
+    let response = crate::api::openai_handlers::true_streaming_sse_response(
+        rx,
+        tokenizer,
+        "chatcmpl-test".to_string(),
+        "test-model".to_string(),
+        Arc::new(crate::metrics::MetricsCollector::new()),
+        std::time::Instant::now(),
+    );
+
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read SSE body");
+    let body = String::from_utf8(bytes.to_vec()).expect("SSE body is utf-8");
+
+    let streamed = concat_sse_deltas(&body);
+
+    assert_eq!(
+        streamed, expected,
+        "concatenated SSE deltas must equal the full decode.\n\
+         streamed: {streamed:?}\n\
+         expected: {expected:?}\n\
+         A mismatch here is the v0.63.0 defect: clean_chat_output() applied per \
+         token strips the leading space/newline off every delta."
+    );
+
+    // Spell the two specific losses out, so a regression names itself.
+    assert!(
+        streamed.contains(" quick"),
+        "leading spaces were stripped from the deltas: {streamed:?}"
+    );
+    assert!(
+        streamed.contains('\n'),
+        "newline tokens were stripped from the deltas: {streamed:?}"
+    );
+}


### PR DESCRIPTION
Found by dogfooding `cargo install aprender` 0.63.0 from crates.io. **P0 — every OpenAI-compatible streaming client got unusable output.**

## The defect

Same server, same model (`Qwen2.5-Coder-1.5B` Q4_K GGUF), same prompt, only `"stream"` differs:

| | result |
|---|---|
| non-streaming | `'The quick brown fox jumps over the lazy dog.'` |
| streaming, deltas concatenated | `'Thequickbrownfoxjumpsoverthelazydog.'` |

Newlines are destroyed too — a three-line reply streams as `line1line2line3`.

Every OpenAI SDK joins `choices[].delta.content` verbatim, so this is what the user sees.

Repro against 0.63.0:

```bash
apr serve run model.gguf --port 18401 &
curl -s -X POST :18401/v1/chat/completions -H 'Content-Type: application/json' \
  -d '{"model":"default","messages":[{"role":"user","content":"Write the sentence: the quick brown fox jumps over the lazy dog"}],"max_tokens":16,"temperature":0,"stream":true}' \
  | grep '^data: {' | sed 's/^data: //' \
  | python3 -c "import sys,json;print(repr(''.join(json.loads(l)['choices'][0].get('delta',{}).get('content','') for l in sys.stdin if l.strip())))"
```

## Cause

`true_streaming_sse_response` took a `clean: bool`, and **two of its three call sites passed `true`** (`cuda_chat_backend.rs:284` quantized path, `:793` qwen3-moe path). That ran `clean_chat_output()` on *every single token*. It opens with `text.trim_start()` and closes with `.trim()` — and byte-level BPE carries the leading space on the token itself (`"Ġquick"` → `" quick"`), so trimming per token deletes it from every delta.

Its other jobs cannot work per-token either: stop sequences and the `Human:`/`Assistant:` turn markers span several tokens, so a single-token `find()` never matches them. Per-token cleaning was doing nothing *except* destroying whitespace.

## Fix

The `clean` parameter is **removed**, not flipped to `false`, so a fourth caller cannot reintroduce it. This mirrors exactly what PMAT-759 did to the sibling `pregenerated_sse_response` in the same file, for the same reason ("All three callers passed `clean = false`, so the old `clean` param is dropped").

## Falsifier — mutation verified

`api::tests::sse_stream_whitespace` drives the real SSE response with a tokenizer whose tokens carry leading whitespace, and asserts the concatenated deltas equal the full decode.

```
fix in place:                     test result: ok. 1 passed
per-token clean reinstated:       FAILED
    streamed: "Thequickbrownfoxjumps."
    expected: "The quick brown fox\n jumps."
restored:                         test result: ok. 1 passed
```

1703 `aprender-serve` api tests pass; `cargo clippy -p aprender-serve --lib -- -D warnings` clean; `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Refs #2375 (partial — see the issue for the findings that remain)

Audit epic: #2373
