### PR TITLE
fix(serve): ollama clients silently dropped every apr response — created_at was a bare epoch, not RFC 3339

### DIFF
--- a/contracts/apr-serve-openai-compat-v1.yaml
+++ b/contracts/apr-serve-openai-compat-v1.yaml
@@ -225,6 +225,28 @@ proof_obligations:
       OLLAMA-API-ROUTED-ON-APR-SERVE non-streaming shape (no-regression). On a
       backend error the stream still terminates with a well-formed `done:true`
       object, never a bare error object lacking `done`.
+  - type: invariant
+    property: >
+      OLLAMA-CREATED-AT-IS-RFC3339: every Ollama-wire timestamp apr emits —
+      `created_at` on the coalesced `/api/chat` and `/api/generate` bodies, on
+      EVERY NDJSON stream chunk (intermediate and terminal), and `modified_at`
+      in the `/api/tags` model list — is a real RFC 3339 UTC instant with
+      nanosecond precision (`2026-08-09T16:55:33.983535246Z`), NOT a bare Unix
+      epoch with a `Z` appended (`1786293998.000000000Z`). This is a HARD
+      requirement, not cosmetic: ollama's own Go client declares these fields
+      as `time.Time` (api.ChatResponse.CreatedAt, api.GenerateResponse.CreatedAt,
+      api.ListModelResponse.ModifiedAt), so the value is decoded by
+      `time.Time.UnmarshalJSON`, which accepts RFC 3339 and nothing else. A
+      value it cannot parse makes `encoding/json` abandon the WHOLE object, so
+      the client observes an empty message, `done:false` and zeroed counts —
+      the response is dropped in its entirety, not merely mis-timestamped, and
+      a streaming client loop watching `done` never terminates. The timestamp
+      must also denote the current instant (UTC offset zero), so a decoding
+      client gets a usable time rather than the zero value. Holds for BOTH
+      implementations of the helper: the apr-cli adapter that `apr serve`
+      mounts (crates/apr-cli/src/commands/serve/ollama.rs::created_at_now) and
+      the realizar-side handlers any caller mounting create_router gets
+      (crates/aprender-serve/src/api/ollama_handlers.rs::created_at_now).
 
 falsification_tests:
   - id: FALSIFY-STOP-TRUNCATE-754
@@ -323,3 +345,15 @@ falsification_tests:
     test_harness: 'cargo test -p apr-cli --test ollama_ndjson_streaming api_chat_stream_false_is_single_coalesced_object'
     expected_output: "test result: ok"
     if_fails: 'POST /api/chat with explicit stream:false no longer returns a single coalesced object (it streams NDJSON), breaking the OLLAMA-API-ROUTED-ON-APR-SERVE non-streaming wire shape — the stream flag is not honored.'
+  - id: FALSIFY-OLLAMA-CREATED-AT-RFC3339-CLI
+    name: commands::serve::ollama::tests
+    prediction: 'On the apr-cli adapter apr serve mounts: created_at_now() parses with chrono::DateTime::parse_from_rfc3339, denotes the current instant (within 60s) at UTC offset 0; the serialized coalesced /api/chat and /api/generate bodies, EVERY line of the NDJSON stream (token chunks + terminal done:true), and /api/tags modified_at all parse as RFC 3339. The oracle is proven discriminating by a companion test asserting the old shape "1786293998.000000000Z" is REJECTED by the same parser. RED on the pre-fix format!("{secs}.000000000Z") — 4 tests fail with `input contains invalid characters`; GREEN on chrono::Utc::now().to_rfc3339_opts(Nanos, true).'
+    test_harness: 'cargo test -p apr-cli --lib commands::serve::ollama'
+    expected_output: "test result: ok"
+    if_fails: 'apr serve emits a non-RFC-3339 created_at/modified_at, so ollama Go clients decoding into time.Time drop the ENTIRE response (empty message, done:false, zero counts) on /api/chat, /api/generate, every NDJSON chunk, and /api/tags — the apr 0.63.0 behaviour.'
+  - id: FALSIFY-OLLAMA-CREATED-AT-RFC3339-REALIZAR
+    name: api::ollama_handlers::tests
+    prediction: 'On the realizar-side handlers mounted by create_router: created_at_now() parses with chrono::DateTime::parse_from_rfc3339, denotes the current instant (within 60s) at UTC offset 0, and the serialized OllamaChatResponse / OllamaGenerateResponse created_at fields parse as RFC 3339, with the same bare-epoch-rejection oracle test. RED on the pre-fix epoch string — 3 tests fail with `input contains invalid characters`.'
+    test_harness: 'cargo test -p aprender-serve --lib api::ollama_handlers'
+    expected_output: "test result: ok"
+    if_fails: 'A caller mounting realizar create_router serves a non-RFC-3339 created_at, so an ollama Go client discards the whole /api/chat or /api/generate response.'

--- a/crates/apr-cli/src/commands/serve/ollama.rs
+++ b/crates/apr-cli/src/commands/serve/ollama.rs
@@ -208,14 +208,19 @@ fn default_stream() -> bool {
 // Conversion helpers (pure — unit-tested)
 // ============================================================================
 
-/// RFC-3339-style timestamp for `created_at` (Ollama wire format).
+/// RFC 3339 timestamp for `created_at` / `modified_at` (Ollama wire format).
+///
+/// Ollama's own client declares these fields as a Go `time.Time`
+/// (`api.ChatResponse.CreatedAt`, `api.GenerateResponse.CreatedAt`,
+/// `api.ListModelResponse.ModifiedAt`), so the value goes through
+/// `time.Time.UnmarshalJSON`, which accepts RFC 3339 and nothing else. A bare
+/// epoch with a `Z` glued on (`"1786293998.000000000Z"`) fails that parse and
+/// `encoding/json` then discards the WHOLE object — message, `done`, counts —
+/// not merely the timestamp. For the NDJSON stream that means every chunk
+/// decodes empty with `done:false`, so a client loop never terminates. Emit
+/// UTC with nanosecond precision, the shape real ollama puts on the wire.
 fn created_at_now() -> String {
-    let secs = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
-    // Clients only require a string field, not strict parsing.
-    format!("{secs}.000000000Z")
+    chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Nanos, true)
 }
 
 /// Default model label when the request omits `model`.
@@ -900,5 +905,110 @@ mod tests {
         );
         let obj: serde_json::Value = serde_json::from_str(lines[0]).expect("json");
         assert_eq!(obj["done"], true);
+    }
+
+    // ------------------------------------------------------------------
+    // `created_at` / `modified_at` must be RFC 3339 (PMAT-923 follow-up).
+    //
+    // Ollama's Go client decodes these into a `time.Time`. A value it cannot
+    // parse makes `encoding/json` abandon the WHOLE object, so the client sees
+    // an empty message and `done:false` — not just a bad clock.
+    // ------------------------------------------------------------------
+
+    /// The oracle used below has to discriminate: the shape apr 0.63.0 emitted
+    /// (a bare epoch with a `Z` glued on) MUST fail it, otherwise the
+    /// assertions that follow would pass on the defect too.
+    #[test]
+    fn rfc3339_oracle_rejects_the_bare_epoch_shape() {
+        chrono::DateTime::parse_from_rfc3339("1786293998.000000000Z")
+            .expect_err("a bare epoch string is not RFC 3339 — oracle is not discriminating");
+    }
+
+    #[test]
+    fn created_at_now_is_rfc3339_utc_at_the_current_instant() {
+        let s = created_at_now();
+        let parsed = chrono::DateTime::parse_from_rfc3339(&s)
+            .unwrap_or_else(|e| panic!("created_at {s:?} must parse as RFC 3339: {e}"));
+
+        // Parseable is not enough: it must denote *now*, so a decoding client
+        // gets a usable instant rather than the zero time.
+        let now = chrono::Utc::now().timestamp();
+        let skew = (parsed.timestamp() - now).abs();
+        assert!(skew <= 60, "created_at {s:?} is {skew}s away from now");
+        assert_eq!(parsed.offset().local_minus_utc(), 0, "must be UTC: {s:?}");
+    }
+
+    /// The coalesced (`stream:false`) bodies of BOTH endpoints, as serialized.
+    #[test]
+    fn coalesced_chat_and_generate_created_at_are_client_decodable() {
+        let chat = serde_json::to_value(OllamaChatResponse {
+            model: "apr".to_string(),
+            created_at: created_at_now(),
+            message: OllamaMessage {
+                role: "assistant".to_string(),
+                content: "hello".to_string(),
+            },
+            done: true,
+            prompt_eval_count: 1,
+            eval_count: 2,
+        })
+        .expect("serialize");
+        let generate = serde_json::to_value(OllamaGenerateResponse {
+            model: "apr".to_string(),
+            created_at: created_at_now(),
+            response: "hi".to_string(),
+            done: true,
+            prompt_eval_count: 0,
+            eval_count: 1,
+        })
+        .expect("serialize");
+
+        for (endpoint, body) in [("/api/chat", &chat), ("/api/generate", &generate)] {
+            let s = body["created_at"].as_str().expect("created_at is a string");
+            chrono::DateTime::parse_from_rfc3339(s).unwrap_or_else(|e| {
+                panic!("{endpoint} created_at {s:?} must parse as RFC 3339: {e}")
+            });
+        }
+    }
+
+    /// `GET /api/tags` feeds `modified_at` from the same helper, and ollama's
+    /// `api.ListModelResponse.ModifiedAt` is a `time.Time` too — an
+    /// unparseable value empties the model list a client enumerates on startup.
+    #[test]
+    fn tags_modified_at_is_client_decodable() {
+        let body = ollama_tags_body("model.gguf");
+        let s = body["models"][0]["modified_at"]
+            .as_str()
+            .expect("modified_at is a string");
+        chrono::DateTime::parse_from_rfc3339(s)
+            .unwrap_or_else(|e| panic!("/api/tags modified_at {s:?} must parse as RFC 3339: {e}"));
+    }
+
+    /// Every NDJSON line carries its own `created_at` and the client parses
+    /// each one, so a bad timestamp empties every chunk — including the
+    /// terminal `done:true` object that ends the client's streaming loop.
+    #[tokio::test]
+    async fn ndjson_stream_created_at_is_client_decodable_on_every_line() {
+        use axum::body::to_bytes;
+
+        let (tx, rx) = tokio::sync::mpsc::channel::<std::result::Result<String, String>>(8);
+        for t in ["Hello", ", ", "world"] {
+            tx.send(Ok(t.to_string())).await.expect("send");
+        }
+        drop(tx);
+
+        let resp = ollama_ndjson_stream(OllamaStreamKind::Chat, "m".to_string(), 2, rx);
+        let bytes = to_bytes(resp.into_body(), 64 * 1024).await.expect("body");
+        let text = String::from_utf8(bytes.to_vec()).expect("utf8");
+        let lines: Vec<&str> = text.lines().filter(|l| !l.is_empty()).collect();
+        assert_eq!(lines.len(), 4, "3 token chunks + 1 terminal. body={text}");
+
+        for line in lines {
+            let obj: serde_json::Value = serde_json::from_str(line).expect("json");
+            let s = obj["created_at"].as_str().expect("created_at is a string");
+            chrono::DateTime::parse_from_rfc3339(s).unwrap_or_else(|e| {
+                panic!("NDJSON chunk created_at {s:?} must parse as RFC 3339: {e}")
+            });
+        }
     }
 }

--- a/crates/aprender-serve/src/api/ollama_handlers.rs
+++ b/crates/aprender-serve/src/api/ollama_handlers.rs
@@ -137,14 +137,16 @@ pub struct OllamaGenerateResponse {
 // Conversion helpers (pure — unit-tested)
 // ============================================================================
 
-/// RFC-3339-style timestamp for `created_at` (Ollama wire format).
+/// RFC 3339 timestamp for `created_at` (Ollama wire format).
+///
+/// Ollama's own client declares `CreatedAt` as a Go `time.Time`, so the value
+/// goes through `time.Time.UnmarshalJSON`, which accepts RFC 3339 and nothing
+/// else. A bare epoch with a `Z` glued on (`"1786293998.000000000Z"`) fails
+/// that parse and `encoding/json` then discards the WHOLE response — message,
+/// `done`, counts — not merely the timestamp. Emit UTC with nanosecond
+/// precision, the shape real ollama puts on the wire.
 fn created_at_now() -> String {
-    let secs = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
-    // Clients only require a string field, not strict parsing.
-    format!("{secs}.000000000Z")
+    chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Nanos, true)
 }
 
 /// Default model label when the request omits `model`.
@@ -397,5 +399,75 @@ mod tests {
         assert_eq!(json["response"], "hi");
         assert_eq!(json["done"], true);
         assert!(json.get("message").is_none(), "generate uses flat response");
+    }
+
+    // ------------------------------------------------------------------
+    // `created_at` must be RFC 3339 (PMAT-923 follow-up).
+    //
+    // Ollama's Go client decodes `created_at` into a `time.Time`. A value it
+    // cannot parse makes `encoding/json` abandon the WHOLE object, so the
+    // client sees an empty message and `done:false` — not just a bad clock.
+    // ------------------------------------------------------------------
+
+    /// The oracle used below has to discriminate: the shape apr 0.63.0 emitted
+    /// (a bare epoch with a `Z` glued on) MUST fail it, otherwise the
+    /// assertions that follow would pass on the defect too.
+    #[test]
+    fn rfc3339_oracle_rejects_the_bare_epoch_shape() {
+        chrono::DateTime::parse_from_rfc3339("1786293998.000000000Z")
+            .expect_err("a bare epoch string is not RFC 3339 — oracle is not discriminating");
+    }
+
+    #[test]
+    fn created_at_now_is_rfc3339_utc_at_the_current_instant() {
+        let s = created_at_now();
+        let parsed = chrono::DateTime::parse_from_rfc3339(&s)
+            .unwrap_or_else(|e| panic!("created_at {s:?} must parse as RFC 3339: {e}"));
+
+        // Parseable is not enough: it must denote *now*, so a decoding client
+        // gets a usable instant rather than the zero time.
+        let now = chrono::Utc::now().timestamp();
+        let skew = (parsed.timestamp() - now).abs();
+        assert!(skew <= 60, "created_at {s:?} is {skew}s away from now");
+        assert_eq!(parsed.offset().local_minus_utc(), 0, "must be UTC: {s:?}");
+    }
+
+    /// The value that actually reaches the wire for `/api/chat`.
+    #[test]
+    fn chat_response_created_at_is_client_decodable() {
+        let resp = OllamaChatResponse {
+            model: "apr".to_string(),
+            created_at: created_at_now(),
+            message: OllamaMessage {
+                role: "assistant".to_string(),
+                content: "hello".to_string(),
+            },
+            done: true,
+            prompt_eval_count: 1,
+            eval_count: 2,
+        };
+        let json = serde_json::to_value(&resp).expect("serialize");
+        let created_at = json["created_at"].as_str().expect("created_at is a string");
+        chrono::DateTime::parse_from_rfc3339(created_at).unwrap_or_else(|e| {
+            panic!("/api/chat created_at {created_at:?} must parse as RFC 3339: {e}")
+        });
+    }
+
+    /// The value that actually reaches the wire for `/api/generate`.
+    #[test]
+    fn generate_response_created_at_is_client_decodable() {
+        let resp = OllamaGenerateResponse {
+            model: "apr".to_string(),
+            created_at: created_at_now(),
+            response: "hi".to_string(),
+            done: true,
+            prompt_eval_count: 0,
+            eval_count: 1,
+        };
+        let json = serde_json::to_value(&resp).expect("serialize");
+        let created_at = json["created_at"].as_str().expect("created_at is a string");
+        chrono::DateTime::parse_from_rfc3339(created_at).unwrap_or_else(|e| {
+            panic!("/api/generate created_at {created_at:?} must parse as RFC 3339: {e}")
+        });
     }
 }


### PR DESCRIPTION
`apr serve` advertises itself as a drop-in Ollama HTTP replacement, but no real ollama Go client could read a single field of what it sent back. Found by dogfooding `cargo install aprender` 0.63.0 from crates.io.

## What a user saw

```
$ apr serve run <model> --port 18502
$ curl -s -X POST localhost:18502/api/chat -d '{"messages":[{"role":"user","content":"hi"}],"stream":false}'
{"model":"apr","created_at":"1786293998.000000000Z","message":{"role":"assistant",
 "content":" angle angletrade.cleanup"},"done":true,"prompt_eval_count":9,"eval_count":4}
```

Decoded with the actual upstream client type — `github.com/ollama/ollama/api`, built against `~/src/ollama`, not a look-alike struct — that body does not survive the trip:

```
err=parsing time "1786293998.000000000Z" as "2006-01-02T15:04:05Z07:00": cannot parse "293998.000000000Z" as "-"
parsed={Model:apr CreatedAt:0001-01-01 00:00:00 +0000 UTC Message:{Role: Content:} Done:false
        Metrics:{PromptEvalCount:0 EvalCount:0}}
```

`api.ChatResponse.CreatedAt` is a Go `time.Time` (`api/types.go:396`), so the value goes through `time.Time.UnmarshalJSON`, which accepts RFC 3339 and nothing else. When it fails, `encoding/json` abandons the whole object — the message text, `done`, and the token counts are all gone, not just the timestamp. The generated text was correct and arrived on the wire; the client threw it away. `Done:false` is the worst of it: a streaming client loops until it sees `done`, and every NDJSON chunk carries its own `created_at`, so the terminal chunk decodes empty too and the loop never ends.

Four surfaces, all confirmed against the crates.io binary: `/api/chat` (coalesced and every NDJSON line), `/api/generate`, and `/api/tags` — whose `modified_at` feeds the same helper and lands in `api.ListModelResponse.ModifiedAt`, also a `time.Time`, so the model list a client enumerates on startup came back empty as well.

## Root cause

`created_at_now()` built the string by hand from a Unix epoch and glued a `Z` on the end:

- `crates/aprender-serve/src/api/ollama_handlers.rs:141-148`
- `crates/apr-cli/src/commands/serve/ollama.rs:212-219` — this is the copy `apr serve` actually mounts; that module's own header notes `apr serve` builds bespoke routers rather than realizar's `create_router`, so fixing only the first would have left the user-visible defect intact.

Both carried the comment *"Clients only require a string field, not strict parsing"* — precisely the assumption that was false — while the doc comment directly above already called the value "RFC-3339-style". Both crates already depend on chrono, so both now emit `chrono::Utc::now().to_rfc3339_opts(Nanos, true)`.

## After the fix

Same request, same model, binary built from this branch:

```
raw={"model":"apr","created_at":"2026-08-09T16:55:33.983535246Z","message":{"role":"assistant",
     "content":" angle angletrade.cleanup"},"done":true,"prompt_eval_count":9,"eval_count":4}
err=<nil>
parsed={Model:apr CreatedAt:2026-08-09 16:55:33.983535246 +0000 UTC
        Message:{Role:assistant Content: angle angletrade.cleanup} Done:true
        Metrics:{PromptEvalCount:9 EvalCount:4}}
```

`/api/generate`, `/api/tags` and both lines of an NDJSON stream decode the same way, the terminal chunk as `Done:true DoneReason:stop`.

## Tests

The tests parse the emitted value with `chrono::DateTime::parse_from_rfc3339` and additionally require it to denote the current instant at UTC offset zero, so a merely-parseable constant would not pass. Because an oracle that accepts everything proves nothing, each crate also carries `rfc3339_oracle_rejects_the_bare_epoch_shape`, asserting the old string is REJECTED by the same parser.

Mutation check — restoring the epoch body under the new tests turns them RED:

```
---- created_at_now_is_rfc3339_utc_at_the_current_instant stdout ----
panicked at crates/apr-cli/src/commands/serve/ollama.rs:935:33:
created_at "1786294302.000000000Z" must parse as RFC 3339: input contains invalid characters
---- ndjson_stream_created_at_is_client_decodable_on_every_line stdout ----
panicked at crates/apr-cli/src/commands/serve/ollama.rs:1014:17:
NDJSON chunk created_at "1786294302.000000000Z" must parse as RFC 3339: input contains invalid characters
---- tags_modified_at_is_client_decodable stdout ----
panicked at crates/apr-cli/src/commands/serve/ollama.rs:988:33:
/api/tags modified_at "1786294302.000000000Z" must parse as RFC 3339: input contains invalid characters
test result: FAILED. 15 passed; 4 failed        (apr-cli)
test result: FAILED. 7 passed; 3 failed         (aprender-serve)
```

The oracle test stays green under the mutation, which is what makes the other seven meaningful. With the fix restored: 19 passed / 0 failed (apr-cli), 10 passed / 0 failed (aprender-serve); full lib suites 6627 and 15479 pass. `cargo fmt --all -- --check` and `cargo clippy --lib -- -D warnings` clean on both crates.

Contract `apr-serve-openai-compat-v1` gains the `OLLAMA-CREATED-AT-IS-RFC3339` invariant and a falsification test per crate; `pv lint contracts/` reports 0 errors with gate 4 at 21/21 refs found.

## Adjacent, not touched

`crates/aprender-serve/src/cli/tests_03.rs:173 test_home_dir_returns_some_when_set` mutates the process-wide `HOME` env var and races other tests reading it — it failed once in a full `-p aprender-serve --lib` run, passed in isolation and on rerun. Pre-existing (file untouched since #1545), unrelated to this change, left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
