### PR TITLE
fix(qa): --assert-tps was divided by ten, or discarded — the release gate could not fail

### DIFF
--- a/crates/apr-cli/src/commands/qa.rs
+++ b/crates/apr-cli/src/commands/qa.rs
@@ -139,8 +139,14 @@ mod brick_tracer_shim {
 /// QA configuration
 #[derive(Debug, Clone)]
 pub struct QaConfig {
-    /// Minimum throughput in tok/s (default: 100 for GPU, 10 for CPU)
-    pub min_tps: f64,
+    /// Throughput floor asserted by the user via `--assert-tps`, in tok/s.
+    ///
+    /// `None` means the user asserted nothing, and the throughput gate picks a
+    /// format-aware default instead (see `speedup.rs`). This has to stay an
+    /// `Option`: collapsing it to a plain `f64` with a default is what let the
+    /// gate confuse "the user demanded 100 tok/s" with "nobody said anything",
+    /// and then quietly substitute its own much lower number for both.
+    pub min_tps: Option<f64>,
     /// Minimum speedup vs Ollama (default: 2.0x)
     pub min_speedup: f64,
     /// Minimum GPU vs CPU speedup (default: 2.0x) - F-PERF-042
@@ -190,7 +196,7 @@ pub struct QaConfig {
 impl Default for QaConfig {
     fn default() -> Self {
         Self {
-            min_tps: 100.0,       // GPU target
+            min_tps: None,        // no assertion; the gate picks a format-aware default
             min_speedup: 0.2, // Ollama uses llama.cpp optimized kernels; 0.2x is realistic floor
             min_gpu_speedup: 2.0, // GPU must be 2x faster than CPU (F-PERF-042)
             skip_golden: false,
@@ -401,7 +407,7 @@ pub fn run(
 ) -> Result<()> {
     contract_pre_qa_gate_composition!();
     let config = QaConfig {
-        min_tps: min_tps.unwrap_or(100.0),
+        min_tps,
         min_speedup: min_speedup.unwrap_or(0.2), // Ollama uses llama.cpp optimized kernels
         min_gpu_speedup: min_gpu_speedup.unwrap_or(2.0), // GPU must be 2x faster (F-PERF-042)
         skip_golden,

--- a/crates/apr-cli/src/commands/qa_config.rs
+++ b/crates/apr-cli/src/commands/qa_config.rs
@@ -6,7 +6,7 @@
     #[test]
     fn test_qa_config_default() {
         let config = QaConfig::default();
-        assert!((config.min_tps - 100.0).abs() < f64::EPSILON);
+        assert_eq!(config.min_tps, None, "default asserts no throughput floor");
         assert!((config.min_speedup - 0.2).abs() < f64::EPSILON);
         assert!((config.min_gpu_speedup - 2.0).abs() < f64::EPSILON);
         assert!(!config.skip_golden);
@@ -35,12 +35,12 @@
     #[test]
     fn test_qa_config_clone() {
         let config = QaConfig {
-            min_tps: 50.0,
+            min_tps: Some(50.0),
             skip_golden: true,
             ..Default::default()
         };
         let cloned = config.clone();
-        assert!((cloned.min_tps - 50.0).abs() < f64::EPSILON);
+        assert_eq!(cloned.min_tps, Some(50.0));
         assert!(cloned.skip_golden);
     }
 

--- a/crates/apr-cli/src/commands/qa_config_print_gate.rs
+++ b/crates/apr-cli/src/commands/qa_config_print_gate.rs
@@ -6,12 +6,12 @@
         let min_speedup: Option<f64> = Some(1.5);
         let min_gpu_speedup: Option<f64> = Some(3.0);
         let config = QaConfig {
-            min_tps: min_tps.unwrap_or(100.0),
+            min_tps,
             min_speedup: min_speedup.unwrap_or(0.2),
             min_gpu_speedup: min_gpu_speedup.unwrap_or(2.0),
             ..Default::default()
         };
-        assert!((config.min_tps - 50.0).abs() < f64::EPSILON);
+        assert_eq!(config.min_tps, Some(50.0));
         assert!((config.min_speedup - 1.5).abs() < f64::EPSILON);
         assert!((config.min_gpu_speedup - 3.0).abs() < f64::EPSILON);
     }

--- a/crates/apr-cli/src/commands/qa_failed_gates_gate.rs
+++ b/crates/apr-cli/src/commands/qa_failed_gates_gate.rs
@@ -84,14 +84,14 @@
     fn qa_config_clone_with_safetensors_path() {
         let config = QaConfig {
             safetensors_path: Some(std::path::PathBuf::from("/deep/clone/test.safetensors")),
-            min_tps: 42.0,
+            min_tps: Some(42.0),
             json: true,
             verbose: true,
             ..Default::default()
         };
         let cloned = config.clone();
         assert_eq!(cloned.safetensors_path, config.safetensors_path);
-        assert!((cloned.min_tps - 42.0).abs() < f64::EPSILON);
+        assert_eq!(cloned.min_tps, Some(42.0));
         assert!(cloned.json);
         assert!(cloned.verbose);
     }
@@ -427,12 +427,12 @@
         let min_speedup: Option<f64> = None;
         let min_gpu_speedup: Option<f64> = None;
         let config = QaConfig {
-            min_tps: min_tps.unwrap_or(100.0),
+            min_tps,
             min_speedup: min_speedup.unwrap_or(0.2),
             min_gpu_speedup: min_gpu_speedup.unwrap_or(2.0),
             ..Default::default()
         };
-        assert!((config.min_tps - 100.0).abs() < f64::EPSILON);
+        assert_eq!(config.min_tps, None, "no --assert-tps means no user-set floor");
         assert!((config.min_speedup - 0.2).abs() < f64::EPSILON);
         assert!((config.min_gpu_speedup - 2.0).abs() < f64::EPSILON);
     }

--- a/crates/apr-cli/src/commands/qa_gguf.rs
+++ b/crates/apr-cli/src/commands/qa_gguf.rs
@@ -28,7 +28,18 @@ fn run_qa(path: &Path, config: &QaConfig) -> Result<QaReport> {
         output::header("APR Quality Assurance");
         let config_pairs = vec![
             ("Model", path.display().to_string()),
-            ("Min TPS", format!("{:.0} tok/s", config.min_tps)),
+            // Report the threshold the gate will actually apply. The banner
+            // used to print the raw `--assert-tps` value while the gate ran
+            // against a tenth of it, so the header contradicted the gate
+            // directly beneath it ("Min TPS 100 tok/s" over
+            // "FAIL Throughput 4.5 tok/s < 10 tok/s threshold").
+            (
+                "Min TPS",
+                match config.min_tps {
+                    Some(asserted) => format!("{asserted:.0} tok/s (--assert-tps)"),
+                    None => "10 tok/s (GGUF default)".to_string(),
+                },
+            ),
             ("Min Speedup", format!("{:.1}x Ollama", config.min_speedup)),
         ];
         println!("{}", output::kv_table(&config_pairs));

--- a/crates/apr-cli/src/commands/qa_report.rs
+++ b/crates/apr-cli/src/commands/qa_report.rs
@@ -122,7 +122,7 @@
         assert!(config.skip_format_parity);
         // Non-skip fields should be default
         assert_eq!(config.iterations, 10);
-        assert!((config.min_tps - 100.0).abs() < f64::EPSILON);
+        assert_eq!(config.min_tps, None, "default asserts no throughput floor");
     }
 
     /// QaConfig with json=true and verbose=true simultaneously.
@@ -142,7 +142,7 @@
     #[test]
     fn qa_config_extreme_thresholds() {
         let config = QaConfig {
-            min_tps: f64::MAX,
+            min_tps: Some(f64::MAX),
             min_speedup: 0.0,
             min_gpu_speedup: f64::MIN_POSITIVE,
             iterations: usize::MAX,
@@ -150,7 +150,7 @@
             max_tokens: 1,
             ..Default::default()
         };
-        assert_eq!(config.min_tps, f64::MAX);
+        assert_eq!(config.min_tps, Some(f64::MAX));
         assert!((config.min_speedup).abs() < f64::EPSILON);
         assert_eq!(config.iterations, usize::MAX);
         assert_eq!(config.warmup, 0);

--- a/crates/apr-cli/src/commands/qa_tests_report_pass_fail.rs
+++ b/crates/apr-cli/src/commands/qa_tests_report_pass_fail.rs
@@ -199,13 +199,13 @@
     #[test]
     fn qa_config_partial_override_preserves_defaults() {
         let config = QaConfig {
-            min_tps: 500.0,
+            min_tps: Some(500.0),
             skip_golden: true,
             iterations: 5,
             ..Default::default()
         };
         // Overridden fields
-        assert!((config.min_tps - 500.0).abs() < f64::EPSILON);
+        assert_eq!(config.min_tps, Some(500.0));
         assert!(config.skip_golden);
         assert_eq!(config.iterations, 5);
         // Default fields must be preserved

--- a/crates/apr-cli/src/commands/speedup.rs
+++ b/crates/apr-cli/src/commands/speedup.rs
@@ -1,4 +1,27 @@
 
+/// The throughput floor the gate applies, in tok/s.
+///
+/// An explicit `--assert-tps N` IS the threshold, verbatim. The format-aware
+/// numbers are a DEFAULT, and a default may only apply when the user asserted
+/// nothing.
+///
+/// This used to read `Gguf => 10.0.max(config.min_tps / 10.0)` with
+/// `Apr | SafeTensors => 1.0` — the user's assertion divided by ten for GGUF
+/// and discarded outright for the other two formats. `apr qa --assert-tps
+/// 100000` therefore passed at 4.1 tok/s and exited 0: the project's own
+/// release gate could not fail. It is a free function so the decision can be
+/// tested without a model on disk.
+#[cfg(feature = "inference")]
+fn throughput_threshold(asserted: Option<f64>, format: realizar::format::ModelFormat) -> f64 {
+    use realizar::format::ModelFormat;
+    asserted.unwrap_or(match format {
+        // Quantized GGUF on GPU is ~100x faster than F32 CPU, so an unasserted
+        // run holds each format to what that format can actually do.
+        ModelFormat::Gguf => 10.0,
+        ModelFormat::Apr | ModelFormat::SafeTensors => 1.0, // F32 CPU: 1 tok/s minimum
+    })
+}
+
 /// Gate 2: Throughput Falsification
 ///
 /// Runs a benchmark and asserts minimum tokens per second.
@@ -48,12 +71,7 @@ fn run_throughput_gate(path: &Path, config: &QaConfig) -> Result<GateResult> {
 
         let duration = start.elapsed();
 
-        // Format-aware thresholds: quantized GGUF on GPU is ~100x faster than F32 CPU.
-        // Comparing unquantized F32 models against a quantized GPU target is meaningless.
-        let threshold = match format {
-            ModelFormat::Gguf => 10.0_f64.max(config.min_tps / 10.0),
-            ModelFormat::Apr | ModelFormat::SafeTensors => 1.0, // F32 CPU: 1 tok/s minimum
-        };
+        let threshold = throughput_threshold(config.min_tps, format);
 
         if tps >= threshold {
             Ok(GateResult::passed(
@@ -444,5 +462,79 @@ fn run_gpu_speedup_gate(path: &Path, config: &QaConfig) -> Result<GateResult> {
             "gpu_speedup",
             "Requires 'inference' and 'cuda' features",
         ))
+    }
+}
+
+// ============================================================================
+// Throughput-threshold falsifiers (dogfood 0.63.0)
+// ============================================================================
+//
+// `apr qa --assert-tps 100000` measured 4.1 tok/s, reported
+// "4.1 tok/s >= 1 tok/s threshold", passed the gate and exited 0. On GGUF the
+// assertion was divided by ten (floored at 10); on APR and SafeTensors it was
+// discarded and replaced with 1.0. `apr qa` is the project's own release gate
+// and its throughput assertion could not fail.
+#[cfg(all(test, feature = "inference"))]
+mod assert_tps_tests {
+    use super::throughput_threshold;
+    use realizar::format::ModelFormat;
+
+    const ALL_FORMATS: [ModelFormat; 3] = [
+        ModelFormat::Gguf,
+        ModelFormat::Apr,
+        ModelFormat::SafeTensors,
+    ];
+
+    #[test]
+    fn an_asserted_threshold_is_used_verbatim_for_every_format() {
+        for format in ALL_FORMATS {
+            for asserted in [1.0_f64, 50.0, 100.0, 100_000.0] {
+                let got = throughput_threshold(Some(asserted), format);
+                assert!(
+                    (got - asserted).abs() < f64::EPSILON,
+                    "--assert-tps {asserted} on {format:?} became {got}; the user's \
+                     assertion must be the threshold, not a suggestion"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn the_shipped_0_63_0_repro_now_fails_the_gate() {
+        // The exact numbers from the dogfood run: 4.1 tok/s measured against
+        // --assert-tps 100000 on an APR model, which reported PASS at a
+        // substituted threshold of 1.0.
+        let measured = 4.050_120_237_944_564_f64;
+        let threshold = throughput_threshold(Some(100_000.0), ModelFormat::Apr);
+        assert!(
+            measured < threshold,
+            "4.1 tok/s must not satisfy --assert-tps 100000 (threshold was {threshold})"
+        );
+
+        // And the GGUF case: 15.9 tok/s measured against --assert-tps 50,
+        // which passed at a substituted threshold of 10.
+        let measured_gguf = 15.881_003_639_727_522_f64;
+        let threshold_gguf = throughput_threshold(Some(50.0), ModelFormat::Gguf);
+        assert!(
+            measured_gguf < threshold_gguf,
+            "15.9 tok/s must not satisfy --assert-tps 50 (threshold was {threshold_gguf})"
+        );
+    }
+
+    #[test]
+    fn no_assertion_keeps_the_format_aware_defaults() {
+        // Unasserted behaviour is unchanged, so this fix introduces no new
+        // failures for runs that never asked for a floor.
+        assert!((throughput_threshold(None, ModelFormat::Gguf) - 10.0).abs() < f64::EPSILON);
+        assert!((throughput_threshold(None, ModelFormat::Apr) - 1.0).abs() < f64::EPSILON);
+        assert!((throughput_threshold(None, ModelFormat::SafeTensors) - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn an_assertion_below_the_default_still_binds() {
+        // The old code floored GGUF at 10, so a deliberately lax
+        // `--assert-tps 2` was silently tightened to 10. An assertion is an
+        // assertion in both directions.
+        assert!((throughput_threshold(Some(2.0), ModelFormat::Gguf) - 2.0).abs() < f64::EPSILON);
     }
 }


### PR DESCRIPTION
Found by dogfooding `cargo install aprender` 0.63.0 from crates.io.

```
$ apr qa model.apr --assert-tps 100000 --json
{"name":"throughput","passed":true,"message":"4.1 tok/s >= 1 tok/s threshold", ...}
rc=0
```

4.1 tok/s satisfied an asserted floor of 100000. `apr qa` is the tool `CLAUDE.md` tells you to reach for first and the one the release gate runs — and its throughput assertion could not fail at any value.

## What it was doing with the number

```rust
// speedup.rs, before
ModelFormat::Gguf => 10.0_f64.max(config.min_tps / 10.0),
ModelFormat::Apr | ModelFormat::SafeTensors => 1.0,
```

| asserted | format | threshold actually applied | measured | verdict |
|---|---|---|---|---|
| 100000 | APR | **1.0** | 4.1 tok/s | PASS, rc=0 |
| 50 | GGUF | **10** | 15.9 tok/s | PASS, rc=0 |
| 100 | GGUF | 10 | 4.5 tok/s | FAIL — against a banner reading `Min TPS 100 tok/s` |

## The fix

The format-aware numbers are a reasonable *default*. The bug was applying them when the user had asserted something. `QaConfig::min_tps` was an `f64` built with `min_tps.unwrap_or(100.0)`, which erased the difference between "the user demanded 100 tok/s" and "nobody said anything" before the gate ever saw it. It is now `Option<f64>`:

```rust
let threshold = config.min_tps.unwrap_or(match format { … });
```

An explicit assertion is the threshold verbatim, in both directions — `--assert-tps 2` on GGUF is no longer silently *tightened* to 10 either. Runs with no assertion behave exactly as before, so no new failures are introduced.

The banner contradicted the gate directly beneath it because it printed the raw value while the gate used a tenth of it; it now prints the threshold that will actually be applied, and where it came from.

## The tests were part of the problem

Two existing tests reimplemented the buggy `min_tps.unwrap_or(100.0)` collapse *inside the test body* and asserted the result — encoding the defect rather than checking behaviour. Fixed.

## Verification

`commands::qa::assert_tps_tests` — four tests over the extracted decision function, including the exact shipped numbers. **Mutation verified**, restoring the divide-by-ten turns three of four RED:

```
an_asserted_threshold_is_used_verbatim_for_every_format ... FAILED
the_shipped_0_63_0_repro_now_fails_the_gate ... FAILED
    4.1 tok/s must not satisfy --assert-tps 100000 (threshold was 1)
an_assertion_below_the_default_still_binds ... FAILED
```

260 qa unit tests pass; `cargo clippy -p apr-cli --lib -- -D warnings` and `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Refs #2380 (partial — see the issue for the findings that remain)

Audit epic: #2373
