### PR TITLE
fix(rm): apr rm could not remove anything apr list printed

### DIFF
--- a/crates/apr-cli/src/commands/pull_list.rs
+++ b/crates/apr-cli/src/commands/pull_list.rs
@@ -1,23 +1,21 @@
 
-/// Scan the pacha cache directory for model files that are on disk but may not be
-/// tracked in the manifest (e.g., downloaded before pacha GH-162 added manifest
-/// persistence, or via direct writes outside the fetcher).
+/// Enumerate every model file sitting in the pacha cache directory.
 ///
-/// Contract: apr-list-disk-reconciliation-v1 F-LIST-DISK-001 (paiml/aprender#602).
-fn scan_cache_dir_for_orphans(
-    cache_dir: &Path,
-    known_paths: &HashSet<std::path::PathBuf>,
-) -> Vec<DiskModelEntry> {
+/// This is the single source of truth for "what is in the cache": `apr list`
+/// prints it and `apr rm` resolves against it (RM-NS-001). The pacha
+/// manifest is only an annotation on top of it — it can never be complete,
+/// because files land in this directory from the streaming pull path, from
+/// `apr convert`, and from plain file copies, none of which go through the
+/// fetcher. The directory always is complete, so it is the namespace both
+/// commands share.
+fn scan_cache_dir(cache_dir: &Path) -> Vec<DiskModelEntry> {
     let Ok(read_dir) = std::fs::read_dir(cache_dir) else {
         return Vec::new();
     };
-    let mut orphans = Vec::new();
+    let mut found = Vec::new();
     for entry in read_dir.flatten() {
         let path = entry.path();
         if !path.is_file() {
-            continue;
-        }
-        if known_paths.contains(&path) {
             continue;
         }
         let Some(ext) = path.extension().and_then(|s| s.to_str()) else {
@@ -35,14 +33,29 @@ fn scan_cache_dir_for_orphans(
             .and_then(|s| s.to_str())
             .unwrap_or("unknown")
             .to_string();
-        orphans.push(DiskModelEntry {
+        found.push(DiskModelEntry {
             name,
             size_bytes,
             format,
             path: path.clone(),
         });
     }
-    orphans
+    found
+}
+
+/// Scan the pacha cache directory for model files that are on disk but may not be
+/// tracked in the manifest (e.g., downloaded before pacha GH-162 added manifest
+/// persistence, or via direct writes outside the fetcher).
+///
+/// Contract: apr-list-disk-reconciliation-v1 F-LIST-DISK-001 (paiml/aprender#602).
+fn scan_cache_dir_for_orphans(
+    cache_dir: &Path,
+    known_paths: &HashSet<std::path::PathBuf>,
+) -> Vec<DiskModelEntry> {
+    scan_cache_dir(cache_dir)
+        .into_iter()
+        .filter(|e| !known_paths.contains(&e.path))
+        .collect()
 }
 
 struct DiskModelEntry {

--- a/crates/apr-cli/src/commands/pull_remove_resolve_model.rs
+++ b/crates/apr-cli/src/commands/pull_remove_resolve_model.rs
@@ -15,11 +15,101 @@ pub fn remove(model_ref: &str) -> Result<()> {
 
     if removed {
         println!("{} Model removed from cache", "✓".green());
-        Ok(())
-    } else {
-        // GH-601: rm of nonexistent model must exit non-zero (like unix rm).
-        println!("{} Model not found in cache", "⚠".yellow());
-        Err(CliError::FileNotFound(std::path::PathBuf::from(model_ref)))
+        return Ok(());
+    }
+
+    // RM-NS-001: the pacha manifest is not the cache. `apr pull`'s streaming path,
+    // `apr convert` and plain file copies all write straight into the cache
+    // directory, so a manifest lookup misses almost everything `apr list`
+    // prints — every name it showed was rejected here. Resolve against the same
+    // enumeration `apr list` uses instead.
+    if let Some(path) = remove_from_cache_dir(fetcher.cache_dir(), model_ref)? {
+        println!("{} Model removed from cache", "✓".green());
+        println!("  Path: {}", path.display());
+        return Ok(());
+    }
+
+    // GH-601: rm of nonexistent model must exit non-zero (like unix rm).
+    println!("{} Model not found in cache", "⚠".yellow());
+    Err(CliError::FileNotFound(std::path::PathBuf::from(model_ref)))
+}
+
+/// RM-NS-001: `blake3(uri)[..16]` — the stem `apr pull` gives a cached file
+/// (`build_single_cache_path`), so `apr rm hf://org/repo/model.gguf` can find
+/// what `apr pull hf://org/repo/model.gguf` wrote.
+fn cache_stem_for_ref(model_ref: &str) -> String {
+    let hash = blake3::hash(model_ref.as_bytes()).to_hex().to_string();
+    hash[..16].to_string()
+}
+
+/// RM-NS-001: does `model_ref` name this cached model file?
+///
+/// Accepts every form the user can plausibly have in hand: the identifier
+/// `apr list` prints (the file stem), the file name, a path to the file, and
+/// the `hf://` reference that was pulled.
+fn cache_entry_matches_ref(entry: &DiskModelEntry, model_ref: &str) -> bool {
+    if model_ref.is_empty() {
+        return false;
+    }
+    if entry.name == model_ref {
+        return true;
+    }
+    if entry.path.file_name().and_then(|s| s.to_str()) == Some(model_ref) {
+        return true;
+    }
+    let as_path = std::path::Path::new(model_ref);
+    if as_path == entry.path {
+        return true;
+    }
+    if let (Ok(given), Ok(cached)) = (as_path.canonicalize(), entry.path.canonicalize()) {
+        if given == cached {
+            return true;
+        }
+    }
+    entry.name == cache_stem_for_ref(model_ref)
+        || entry.name == cache_stem_for_ref(&normalize_hf_uri(model_ref))
+}
+
+/// RM-NS-001: resolve `model_ref` against the cache directory `apr list` enumerates.
+///
+/// Returns every matching model file so the caller can refuse an ambiguous
+/// reference rather than delete an arbitrary one.
+fn resolve_cached_model_files(cache_dir: &Path, model_ref: &str) -> Vec<std::path::PathBuf> {
+    scan_cache_dir(cache_dir)
+        .into_iter()
+        .filter(|entry| cache_entry_matches_ref(entry, model_ref))
+        .map(|entry| entry.path)
+        .collect()
+}
+
+/// RM-NS-001: delete the cached model file named by `model_ref`.
+///
+/// `Ok(None)` means nothing in the cache directory answers to that name — the
+/// caller turns that into GH-601's non-zero "not found". An ambiguous reference
+/// (same stem, several formats) is an error and deletes nothing.
+fn remove_from_cache_dir(cache_dir: &Path, model_ref: &str) -> Result<Option<std::path::PathBuf>> {
+    let mut matches = resolve_cached_model_files(cache_dir, model_ref);
+    match matches.len() {
+        0 => Ok(None),
+        1 => {
+            let path = matches.remove(0);
+            std::fs::remove_file(&path).map_err(|e| {
+                CliError::ValidationFailed(format!("Failed to remove {}: {e}", path.display()))
+            })?;
+            Ok(Some(path))
+        }
+        _ => {
+            matches.sort();
+            let candidates = matches
+                .iter()
+                .map(|p| format!("  {}", p.display()))
+                .collect::<Vec<_>>()
+                .join("\n");
+            Err(CliError::ValidationFailed(format!(
+                "'{model_ref}' matches {} cached models — pass the file name to pick one:\n{candidates}",
+                matches.len()
+            )))
+        }
     }
 }
 
@@ -515,6 +605,149 @@ fn find_brace_content(text: &str) -> Option<&str> {
         }
     }
     None
+}
+
+/// RM-NS-001: `apr rm` must be able to remove what `apr list` prints.
+///
+/// Every test here drives `remove_from_cache_dir` against a throwaway cache
+/// directory and asserts on the FILE — present or gone — not on a return shape.
+#[cfg(test)]
+mod rm_list_namespace_tests {
+    use super::{cache_stem_for_ref, remove_from_cache_dir, resolve_cached_model_files};
+    use std::path::{Path, PathBuf};
+
+    fn temp_cache(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "apr-rm-ns-{}-{}-{:?}",
+            tag,
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::remove_dir_all(&dir).ok();
+        std::fs::create_dir_all(&dir).expect("mkdir temp cache");
+        dir
+    }
+
+    fn touch(dir: &Path, name: &str) -> PathBuf {
+        let path = dir.join(name);
+        std::fs::write(&path, b"not-a-real-model").expect("write fixture");
+        path
+    }
+
+    /// FT-RMNS-001: the identifier `apr list` prints (the file stem) removes the
+    /// file. This is the exact repro: `apr list` showed `064a3693fa1ea02c` and
+    /// `apr rm 064a3693fa1ea02c` left it on disk.
+    #[test]
+    fn removes_by_the_name_list_prints() {
+        let dir = temp_cache("stem");
+        let model = touch(&dir, "064a3693fa1ea02c.safetensors");
+
+        let removed = remove_from_cache_dir(&dir, "064a3693fa1ea02c").expect("no error");
+
+        assert_eq!(removed.as_deref(), Some(model.as_path()));
+        assert!(
+            !model.exists(),
+            "FT-RMNS-001: the model file must be gone after rm, found it still at {}",
+            model.display()
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// FT-RMNS-002: the file name and an absolute path also remove the file.
+    #[test]
+    fn removes_by_filename_and_by_absolute_path() {
+        let dir = temp_cache("forms");
+        let by_name = touch(&dir, "aaaaaaaaaaaaaaaa.gguf");
+        remove_from_cache_dir(&dir, "aaaaaaaaaaaaaaaa.gguf").expect("no error");
+        assert!(!by_name.exists(), "FT-RMNS-002: file name form must delete");
+
+        let by_path = touch(&dir, "bbbbbbbbbbbbbbbb.apr");
+        let arg = by_path.display().to_string();
+        remove_from_cache_dir(&dir, &arg).expect("no error");
+        assert!(!by_path.exists(), "FT-RMNS-002: path form must delete");
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// FT-RMNS-003: the `hf://` reference that was pulled removes the file
+    /// `apr pull` wrote for it (pull names it `blake3(uri)[..16]`).
+    #[test]
+    fn removes_by_the_hf_reference_that_was_pulled() {
+        let dir = temp_cache("hfref");
+        let uri = "hf://Qwen/Qwen2.5-Coder-1.5B-Instruct-GGUF/qwen2.5-coder-1.5b-instruct-q4_k_m.gguf";
+        let model = touch(&dir, &format!("{}.gguf", cache_stem_for_ref(uri)));
+
+        remove_from_cache_dir(&dir, uri).expect("no error");
+
+        assert!(
+            !model.exists(),
+            "FT-RMNS-003: rm of the pulled hf:// ref must delete {}",
+            model.display()
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// FT-RMNS-004 (GH-601 preserved): a genuine miss removes nothing and
+    /// reports nothing removed, so the caller still exits non-zero.
+    #[test]
+    fn unknown_reference_removes_nothing() {
+        let dir = temp_cache("miss");
+        let other = touch(&dir, "cccccccccccccccc.gguf");
+
+        let removed = remove_from_cache_dir(&dir, "definitely-not-a-model").expect("no error");
+
+        assert!(
+            removed.is_none(),
+            "FT-RMNS-004: an unknown ref must not report a removal"
+        );
+        assert!(
+            other.exists(),
+            "FT-RMNS-004: an unknown ref must not delete an unrelated model"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// FT-RMNS-005: an ambiguous stem (same model cached in two formats) is
+    /// refused and deletes NEITHER file — rm must never guess.
+    #[test]
+    fn ambiguous_stem_deletes_nothing() {
+        let dir = temp_cache("ambig");
+        let st = touch(&dir, "dddddddddddddddd.safetensors");
+        let apr = touch(&dir, "dddddddddddddddd.apr");
+
+        let err = remove_from_cache_dir(&dir, "dddddddddddddddd")
+            .expect_err("FT-RMNS-005: ambiguous ref must be an error");
+        assert!(
+            format!("{err}").contains("matches 2 cached models"),
+            "FT-RMNS-005: error must name the ambiguity, got: {err}"
+        );
+        assert!(st.exists() && apr.exists(), "FT-RMNS-005: nothing deleted");
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// FT-RMNS-006: non-model files in the cache dir (manifest, companion
+    /// sidecars) are not removable through `apr rm` — it only ever deletes what
+    /// `apr list` enumerates.
+    #[test]
+    fn non_model_files_are_not_removable() {
+        let dir = temp_cache("sidecar");
+        let manifest = touch(&dir, "manifest.json");
+        let companion = touch(&dir, "eeeeeeeeeeeeeeee.config.json");
+
+        assert!(resolve_cached_model_files(&dir, "manifest.json").is_empty());
+        assert!(remove_from_cache_dir(&dir, "manifest.json")
+            .expect("no error")
+            .is_none());
+        assert!(remove_from_cache_dir(&dir, "eeeeeeeeeeeeeeee.config.json")
+            .expect("no error")
+            .is_none());
+        assert!(
+            manifest.exists() && companion.exists(),
+            "FT-RMNS-006: rm must not touch non-model files"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Every name `apr list` printed was rejected by `apr rm`, including a model `apr pull` had just downloaded. The `hf://` ref and the absolute path failed identically, so a user's only way to reclaim cache space was `rm -rf` on `~/.cache/pacha/models`.

Found by dogfooding `cargo install aprender` 0.63.0 from crates.io.

## Before (apr 0.63.0 from crates.io, throwaway `XDG_CACHE_HOME`)

```
$ apr pull hf://hf-internal-testing/tiny-random-gpt2/model.safetensors
✓ Downloaded successfully
  Path: .../pacha/models/f36eaf6d2b971606.safetensors

$ apr list
f36eaf6d2b971606   443.2 KB  SafeTensors  .../f36eaf6d2b971606.safetensors (orphan)

$ apr rm hf://hf-internal-testing/tiny-random-gpt2/model.safetensors
⚠ Model not found in cache
error: File not found: hf://hf-internal-testing/tiny-random-gpt2/model.safetensors
rc=3
```

Varied the reference form — `apr rm f36eaf6d2b971606`, the file name, and the absolute path all failed the same way, and a second fixture (`064a3693fa1ea02c.safetensors`) reproduced identically. The file was still on disk after every attempt.

## Root cause

`apr list` and `apr rm` did not share a namespace.

`remove()` (`crates/apr-cli/src/commands/pull_remove_resolve_model.rs:12`) delegated solely to `ModelFetcher::remove()`, which looks up a URI-derived key in the in-memory `CacheManager` loaded from `<cache>/manifest.json` (`crates/aprender-registry/src/fetcher.rs:398`).

Nothing on the pull path writes that manifest. `run_single_file_streaming` (`crates/apr-cli/src/commands/pull.rs:122`) streams the file straight into the cache directory as `blake3(uri)[..16].<ext>` and never touches the fetcher. `apr list` already had to reconcile against the directory to see those files at all — which is exactly why it labelled every one of them `(orphan)`.

## Why the directory, not the manifest

The brief offered two shapes: teach `pull` to record what it downloaded, or make `rm` resolve against what `list` enumerates. This takes the second.

The manifest can never be complete. Files also land in the cache directory from `apr convert` and from plain copies, neither of which goes through the fetcher. Teaching `pull` to write the manifest fixes one writer and leaves `rm` still unable to remove anything the other two produced — the same class of bug, just narrower. The directory is complete by construction.

So `apr list`'s enumeration is now `scan_cache_dir()`, and `apr rm` resolves against that same function. The two commands read from one source and cannot drift apart again. `list`'s behaviour is unchanged: `scan_cache_dir_for_orphans` is now a filter over `scan_cache_dir`, so contract `apr-list-disk-reconciliation-v1` F-LIST-DISK-001 still holds.

`rm` accepts every form a user can plausibly have in hand: the identifier `list` prints, the file name, a path to the file, and the `hf://` ref that was pulled. An ambiguous stem (one model cached in two formats) is refused and deletes neither file — `rm` never guesses. GH-601's non-zero exit on a genuine miss is unchanged and still covered by a test.

## After (release binary built from this branch)

```
$ apr rm hf://hf-internal-testing/tiny-random-gpt2/model.safetensors
✓ Model removed from cache
  Path: .../pacha/models/f36eaf6d2b971606.safetensors
rc=0

$ apr list
No cached models found.

$ apr rm definitely-not-a-model
⚠ Model not found in cache
rc=3
```

Full `pull → list → rm → list` round trip verified end to end against a temporary `XDG_CACHE_HOME`, never the real cache. The stem form and the absolute-path form were verified the same way.

## Mutation check

Six falsification tests (FT-RMNS-001..006) drive `remove_from_cache_dir` against a throwaway cache directory and assert on the file being present or gone, not on a return shape.

Reverting only the fix — making `resolve_cached_model_files` return an empty `Vec`, i.e. restoring the manifest-only namespace — while keeping the tests turns four of the six RED, and leaves green exactly the two that encode preserved behaviour:

```
test removes_by_filename_and_by_absolute_path ... FAILED
test ambiguous_stem_deletes_nothing ... FAILED
test removes_by_the_hf_reference_that_was_pulled ... FAILED
test removes_by_the_name_list_prints ... FAILED
test non_model_files_are_not_removable ... ok
test unknown_reference_removes_nothing ... ok

FT-RMNS-002: file name form must delete
FT-RMNS-005: ambiguous ref must be an error: None
FT-RMNS-003: rm of the pulled hf:// ref must delete
  /tmp/apr-rm-ns-hfref-540543-ThreadId(5)/d47927c5638f80ab.gguf
assertion `left == right` failed
  left: None
 right: Some("/tmp/apr-rm-ns-stem-540543-ThreadId(6)/064a3693fa1ea02c.safetensors")

test result: FAILED. 2 passed; 4 failed
```

With the fix restored, 6 passed.

## Gates

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p apr-cli --lib -- -D warnings` — clean
- `cargo test -p apr-cli --lib` — 6633 passed, 0 failed, 12 ignored

## Adjacent, not fixed here

`apr rm` deletes the model file but leaves its companion sidecars (`<stem>.config.json`, `<stem>.tokenizer.json`, `<stem>.tokenizer_config.json`) in the cache directory. They are small and `apr list` does not show them, so this is cosmetic rather than the reported defect, and cleaning them up is a separate change with its own blast radius.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Refs #2408 (partial — see the issue for the findings that remain)

Audit epic: #2373
