### PR TITLE
fix(apr-cli): --normalize false and --with-pooler false were documented but unparseable, so both flags were permanently ON

### DIFF
--- a/crates/apr-cli/src/commands/embed.rs
+++ b/crates/apr-cli/src/commands/embed.rs
@@ -449,4 +449,141 @@ mod tests {
             _ => panic!("expected ValidationFailed"),
         }
     }
+
+    // ── `apr embed --normalize` CLI surface ──────────────────────────
+    //
+    // `--help` documents "Pass `--normalize false` to keep raw
+    // magnitudes". With a bare `bool` field clap derives a SetTrue
+    // switch, so `default_value_t = true` pins the value ON and the
+    // documented `false` is rejected by the parser (exit 2). These
+    // tests assert the PARSED VALUE for each documented spelling, not
+    // merely that parsing succeeds.
+
+    /// Parse an exact `apr embed …` argv and return the `normalize`
+    /// field. `Err` carries clap's rendered error (what the user sees).
+    ///
+    /// Parsed on a 16 MiB thread: the flattened `Commands` enum is large
+    /// enough to overflow the default test stack (same reason as the
+    /// `apr pretrain` CLI tests).
+    fn parse_embed_normalize_argv(argv: &[&str]) -> std::result::Result<bool, String> {
+        let argv: Vec<String> = argv.iter().map(|s| (*s).to_string()).collect();
+        std::thread::Builder::new()
+            .stack_size(16 * 1024 * 1024)
+            .spawn(move || {
+                use clap::Parser;
+                match crate::Cli::try_parse_from(&argv) {
+                    Ok(cli) => match *cli.command {
+                        crate::Commands::Extended(crate::ExtendedCommands::Embed {
+                            normalize,
+                            ..
+                        }) => Ok(normalize),
+                        other => panic!("expected ExtendedCommands::Embed, got {other:?}"),
+                    },
+                    Err(e) => Err(e.to_string()),
+                }
+            })
+            .expect("spawn parse thread")
+            .join()
+            .expect("parse thread must not panic")
+    }
+
+    /// `apr embed <MODEL> --vocab … --text … <extra>` — the documented
+    /// argument order, with `extra` appended.
+    fn parse_embed_normalize(extra: &[&str]) -> std::result::Result<bool, String> {
+        let mut argv: Vec<&str> = vec![
+            "apr",
+            "embed",
+            "/tmp/_embed_norm/model.apr",
+            "--vocab",
+            "/tmp/_embed_norm/vocab.txt",
+            "--text",
+            "hello",
+        ];
+        argv.extend_from_slice(extra);
+        parse_embed_normalize_argv(&argv)
+    }
+
+    #[test]
+    fn embed_normalize_defaults_to_on_when_omitted() {
+        assert_eq!(
+            parse_embed_normalize(&[]),
+            Ok(true),
+            "omitting --normalize must keep the sentence-transformers default (L2-normalise)"
+        );
+    }
+
+    #[test]
+    fn embed_normalize_bare_flag_is_on() {
+        assert_eq!(
+            parse_embed_normalize(&["--normalize"]),
+            Ok(true),
+            "a bare --normalize must still mean ON"
+        );
+    }
+
+    #[test]
+    fn embed_normalize_space_separated_false_turns_it_off() {
+        // `--help` literally says: "Pass `--normalize false` to keep raw
+        // magnitudes". Before the fix clap rejected this with
+        // "unexpected argument 'false' found" (exit 2).
+        assert_eq!(
+            parse_embed_normalize(&["--normalize", "false"]),
+            Ok(false),
+            "`--normalize false` is documented in --help and MUST reach the handler as false"
+        );
+    }
+
+    #[test]
+    fn embed_normalize_equals_false_turns_it_off() {
+        // Before the fix: "unexpected value 'false' for '--normalize'
+        // found; no more were expected" (exit 2).
+        assert_eq!(
+            parse_embed_normalize(&["--normalize=false"]),
+            Ok(false),
+            "`--normalize=false` MUST reach the handler as false"
+        );
+    }
+
+    #[test]
+    fn embed_normalize_equals_true_is_on() {
+        assert_eq!(parse_embed_normalize(&["--normalize=true"]), Ok(true));
+    }
+
+    #[test]
+    fn embed_normalize_rejects_non_boolean_value() {
+        // The optional value must still be type-checked — `--normalize
+        // maybe` is a user error, not a silent default.
+        let err = parse_embed_normalize(&["--normalize", "maybe"])
+            .expect_err("non-boolean value must be rejected");
+        assert!(err.contains("maybe"), "{err}");
+    }
+
+    /// The one cost of an optional-valued flag: `--normalize` directly
+    /// followed by the MODEL positional is ambiguous, and clap resolves
+    /// it by treating the path as the flag's value. That is inherent to
+    /// `num_args(0..=1)` — the alternative (`require_equals`) would break
+    /// the `--normalize false` spelling that `--help` documents.
+    ///
+    /// It is a legible error listing the accepted values, not a silent
+    /// misparse, and `apr embed <MODEL> --normalize` (the documented
+    /// order) is unaffected. Asserted here so the trade-off is a
+    /// deliberate, reviewed behaviour rather than a latent surprise.
+    #[test]
+    fn embed_normalize_before_positional_errors_legibly() {
+        let err = parse_embed_normalize_argv(&[
+            "apr",
+            "embed",
+            "--normalize",
+            "/tmp/_embed_norm/model.apr",
+            "--vocab",
+            "/tmp/_embed_norm/vocab.txt",
+            "--text",
+            "hello",
+        ])
+        .expect_err("`--normalize <MODEL>` consumes the path as the flag value");
+        assert!(
+            err.contains("model.apr") && err.contains("true") && err.contains("false"),
+            "the error must name the offending token and list the accepted values, got: {err}"
+        );
+    }
 }

--- a/crates/apr-cli/src/commands/rerank.rs
+++ b/crates/apr-cli/src/commands/rerank.rs
@@ -540,4 +540,83 @@ mod tests {
             _ => panic!("expected ValidationFailed"),
         }
     }
+
+    // ── `apr rerank --with-pooler` CLI surface ───────────────────────
+    //
+    // `--help` documents "Cross-encoders that skip the pooler should
+    // pass `--with-pooler false`". A bare `bool` field derives a SetTrue
+    // switch, so `default_value_t = true` pinned the pooler ON and the
+    // documented `false` was rejected by the parser (exit 2), making
+    // pooler-less cross-encoders unloadable.
+
+    /// Parse a full `apr rerank …` argv and return the `with_pooler`
+    /// field. `Err` carries clap's rendered error (what the user sees).
+    fn parse_rerank_with_pooler(extra: &[&str]) -> std::result::Result<bool, String> {
+        let extra: Vec<String> = extra.iter().map(|s| (*s).to_string()).collect();
+        std::thread::Builder::new()
+            .stack_size(16 * 1024 * 1024)
+            .spawn(move || {
+                use clap::Parser;
+                let mut argv: Vec<String> = vec![
+                    "apr".to_string(),
+                    "rerank".to_string(),
+                    "/tmp/_rerank_pooler/model.apr".to_string(),
+                    "--vocab".to_string(),
+                    "/tmp/_rerank_pooler/vocab.txt".to_string(),
+                    "--query".to_string(),
+                    "q".to_string(),
+                    "--passages".to_string(),
+                    "p".to_string(),
+                ];
+                argv.extend(extra);
+                match crate::Cli::try_parse_from(&argv) {
+                    Ok(cli) => match *cli.command {
+                        crate::Commands::Extended(crate::ExtendedCommands::Rerank {
+                            with_pooler,
+                            ..
+                        }) => Ok(with_pooler),
+                        other => panic!("expected ExtendedCommands::Rerank, got {other:?}"),
+                    },
+                    Err(e) => Err(e.to_string()),
+                }
+            })
+            .expect("spawn parse thread")
+            .join()
+            .expect("parse thread must not panic")
+    }
+
+    #[test]
+    fn rerank_with_pooler_defaults_to_on_when_omitted() {
+        assert_eq!(parse_rerank_with_pooler(&[]), Ok(true));
+    }
+
+    #[test]
+    fn rerank_with_pooler_bare_flag_is_on() {
+        assert_eq!(parse_rerank_with_pooler(&["--with-pooler"]), Ok(true));
+    }
+
+    #[test]
+    fn rerank_with_pooler_space_separated_false_turns_it_off() {
+        // Before the fix: "unexpected argument 'false' found" (exit 2).
+        assert_eq!(
+            parse_rerank_with_pooler(&["--with-pooler", "false"]),
+            Ok(false),
+            "`--with-pooler false` is documented in --help and MUST reach the handler as false"
+        );
+    }
+
+    #[test]
+    fn rerank_with_pooler_equals_false_turns_it_off() {
+        assert_eq!(
+            parse_rerank_with_pooler(&["--with-pooler=false"]),
+            Ok(false)
+        );
+    }
+
+    #[test]
+    fn rerank_with_pooler_rejects_non_boolean_value() {
+        let err = parse_rerank_with_pooler(&["--with-pooler", "sometimes"])
+            .expect_err("non-boolean value must be rejected");
+        assert!(err.contains("sometimes"), "{err}");
+    }
 }

--- a/crates/apr-cli/src/extended_commands.rs
+++ b/crates/apr-cli/src/extended_commands.rs
@@ -1190,7 +1190,18 @@ pub enum ExtendedCommands {
         num_labels: usize,
         /// Load the optional BERT pooler dense layer (default: true).
         /// Cross-encoders that skip the pooler should pass `--with-pooler false`.
-        #[arg(long, default_value_t = true)]
+        ///
+        /// Takes an optional value: `--with-pooler` (bare) and an omitted flag
+        /// both mean true; `--with-pooler false` / `--with-pooler=false` turn
+        /// the pooler off. A bare `bool` here would compile to a SetTrue switch
+        /// and make the documented `false` unreachable.
+        #[arg(
+            long,
+            num_args = 0..=1,
+            default_value_t = true,
+            default_missing_value = "true",
+            action = clap::ArgAction::Set,
+        )]
         with_pooler: bool,
         /// Emit the raw logit instead of the sigmoid-mapped relevance score.
         #[arg(long)]
@@ -1235,7 +1246,22 @@ pub enum ExtendedCommands {
         /// L2-normalise the output embedding. Default: true (matches
         /// sentence-transformers convention). Pass `--normalize false`
         /// to keep raw magnitudes.
-        #[arg(long, default_value_t = true)]
+        ///
+        /// Takes an optional value: `--normalize` (bare) and an omitted flag
+        /// both mean true; `--normalize false` / `--normalize=false` keep the
+        /// raw magnitudes. A bare `bool` here would compile to a SetTrue switch
+        /// and make the documented `false` unreachable.
+        ///
+        /// Because the value is optional, do not place a bare `--normalize`
+        /// immediately before the MODEL positional — write
+        /// `apr embed MODEL --normalize` or `--normalize=true MODEL`.
+        #[arg(
+            long,
+            num_args = 0..=1,
+            default_value_t = true,
+            default_missing_value = "true",
+            action = clap::ArgAction::Set,
+        )]
         normalize: bool,
         /// Override hidden_dim (default: 384 / MiniLM).
         #[arg(long, default_value_t = 384)]


### PR DESCRIPTION
Found by dogfooding `cargo install aprender` 0.63.0.

`apr embed --help` tells the user "Pass `--normalize false` to keep raw magnitudes", and `apr rerank --help` tells them "Cross-encoders that skip the pooler should pass `--with-pooler false`". Neither spelling parses. Against the 0.63.0 binary installed from crates.io:

```
$ apr embed model.apr --vocab tok.json --text hi --normalize false
error: unexpected argument 'false' found
rc=2

$ apr embed model.apr --vocab tok.json --text hi --normalize=false
error: unexpected value 'false' for '--normalize' found; no more were expected
rc=2

$ apr rerank model.apr --vocab tok.json --query q --passages p --with-pooler false
error: unexpected argument 'false' found
rc=2
```

The field is a bare `bool`, so clap derives a `SetTrue` switch and `default_value_t = true` pins it on: true when omitted, true when passed bare, rejected when given a value. The "off" state had no reachable spelling at all — un-normalised embeddings could not be produced, and a cross-encoder without a pooler dense layer could not be loaded.

**Root cause:** `crates/apr-cli/src/extended_commands.rs:1238` (`normalize`) and `:1193` (`with_pooler`) — `#[arg(long, default_value_t = true)]` on a bare `bool`. Both handlers already consume the value correctly (`embed.rs:283` gates `l2_normalize`, `rerank.rs:254` passes it to `CrossEncoder::new`); only the parser was wrong.

**Fix:** `num_args(0..=1)` + `default_missing_value = "true"` + `ArgAction::Set`, so the syntax `--help` already documents parses. Omitted and bare both still mean true, so no existing invocation changes meaning. There is no negatable-flag convention already in this CLI to follow — I grepped for `no-` longs, `default_missing_value` and `ArgAction::Set` and found no prior instances — and this spelling is the one the help text promises.

## Measured effect

Real `cross-encoder/ms-marco-MiniLM` (90 MB safetensors imported to APR v2, 105 tensors), text `"hello world"`, mean pooling:

| binary | invocation | `normalize` | ‖v‖ |
|---|---|---|---|
| crates.io 0.63.0 | flag omitted | true | 1.000000 |
| crates.io 0.63.0 | bare `--normalize` | true | 1.000000 |
| this build | `--normalize false` | false | **9.499828** |
| this build | `--normalize=false` | false | **9.499828** |
| this build | flag omitted / bare | true | 1.000000 |

Not a single-input result: with normalisation off, `"the quick brown fox"` gives 9.492353 and `"a completely different sentence about databases"` gives 8.943374; both are 1.000000 with it on. On the rerank side the same passage scores logit 8.796466 with the pooler and 0.108038 without, so the flag reaches the model.

## Mutation check

Twelve falsifiers assert the parsed value for each documented spelling, in the existing `pretrain.rs` CLI-parse style (16 MiB worker thread — the flattened command enum overflows the default test stack). Reverting only the two `#[arg(...)]` attributes and keeping the tests turns 6 of the 12 RED, quoting the exact strings a user sees:

```
---- commands::embed::tests::embed_normalize_space_separated_false_turns_it_off stdout ----
assertion `left == right` failed: `--normalize false` is documented in --help and MUST reach the handler as false
  left: Err("error: unexpected argument 'false' found\n\nUsage: apr embed [OPTIONS] --vocab <FILE> <MODEL>\n\n...")
 right: Ok(false)

---- commands::rerank::tests::rerank_with_pooler_space_separated_false_turns_it_off stdout ----
assertion `left == right` failed: `--with-pooler false` is documented in --help and MUST reach the handler as false
  left: Err("error: unexpected argument 'false' found\n\nUsage: apr rerank [OPTIONS] <MODEL>\n\n...")
 right: Ok(false)

test result: FAILED. 6 passed; 6 failed
```

Restoring the attributes returns 12/12 green. Full `cargo test -p apr-cli --lib`: 6634 passed, 0 failed. `cargo fmt --all -- --check` and `cargo clippy -p apr-cli --lib -- -D warnings` both exit 0 (status captured without a pipe).

## Trade-off, asserted rather than latent

A bare `--normalize` placed immediately before the MODEL positional now swallows the path as its value. That is covered by a test asserting the error is legible and names the offending token; the documented order `apr embed MODEL --normalize` is unaffected. `require_equals` would have avoided it but would break the `--normalize false` spelling `--help` documents.

## Adjacent, not fixed here

Three more bare `bool` fields carry `default_value_t = true` and have the same unreachable-off shape:

- `crates/apr-cli/src/commands/mono.rs:23` — `apr mono publish --dry-run`, so that command can never actually publish
- `crates/aprender-train/src/config/cli/extended.rs:125` — `--model-card`
- `crates/aprender-train/examples/finetune_test_gen.rs:352` — `--publish`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Refs #2383 (partial — see the issue for the findings that remain)

Audit epic: #2373
