### PR TITLE
fix(rerank): apr rerank aborted with a library panic on ordinary flag values

### DIFF
--- a/crates/apr-cli/src/commands/rerank.rs
+++ b/crates/apr-cli/src/commands/rerank.rs
@@ -228,17 +228,6 @@ pub(crate) fn run(
     raw_logit: bool,
     json: bool,
 ) -> Result<()> {
-    // Load model once — reused across all passages in batch mode.
-    let model_bytes = std::fs::read(model).map_err(|e| {
-        CliError::ValidationFailed(format!("Failed to read {}: {e}", model.display()))
-    })?;
-    let reader = AprV2Reader::from_bytes(&model_bytes).map_err(|e| {
-        CliError::ValidationFailed(format!(
-            "Failed to parse APR v2 at {}: {e:?}",
-            model.display()
-        ))
-    })?;
-
     let config = BertConfig {
         hidden_dim,
         num_layers,
@@ -251,15 +240,81 @@ pub(crate) fn run(
         pad_token_id: 0,
     };
 
+    // `CrossEncoder::new` builds `MultiHeadAttention`, which *asserts*
+    // `hidden_dim % num_heads == 0`. `--hidden-dim` / `--num-heads` are
+    // user-facing override flags, so reject bad combinations here instead of
+    // aborting the process with a library panic. Checked before the model is
+    // read so a bad flag costs no I/O.
+    config
+        .validate()
+        .map_err(|e| CliError::ValidationFailed(format!("invalid BERT config: {e}")))?;
+
+    // Single-pair mode: resolve and check the (input_ids, token_type_ids)
+    // pair BEFORE the model is read, so a bad id also costs no I/O.
+    let single_pair = if passages.is_empty() {
+        let (input_ids, token_type_ids) =
+            match (input_ids_str, token_type_ids_str, query, passage, vocab) {
+                (Some(id_str), Some(tt_str), None, None, None) => {
+                    let input_ids = parse_id_list(id_str, "input-ids")?;
+                    let token_type_ids = parse_id_list(tt_str, "token-type-ids")?;
+                    (input_ids, token_type_ids)
+                }
+                (None, None, Some(q), Some(p), Some(vp)) => tokenize_query_passage(q, p, vp)?,
+                _ => {
+                    return Err(CliError::ValidationFailed(
+                        "apr rerank requires EITHER \
+                     (--input-ids AND --token-type-ids) \
+                     OR (--query AND --passage AND --vocab) \
+                     OR (--query AND --passages... AND --vocab)"
+                            .to_string(),
+                    ));
+                }
+            };
+
+        if input_ids.is_empty() {
+            return Err(CliError::ValidationFailed(
+                "--input-ids must be non-empty".to_string(),
+            ));
+        }
+        if input_ids.len() != token_type_ids.len() {
+            return Err(CliError::ValidationFailed(format!(
+                "--input-ids ({}) and --token-type-ids ({}) must have the same length",
+                input_ids.len(),
+                token_type_ids.len()
+            )));
+        }
+        // `BertEmbeddings::forward` slices the embedding tables unchecked, so
+        // an id past the end of a table aborts the process. Reject it here.
+        config
+            .validate_ids(&input_ids, &token_type_ids)
+            .map_err(|e| CliError::ValidationFailed(format!("invalid tokens: {e}")))?;
+        Some((input_ids, token_type_ids))
+    } else {
+        None
+    };
+
+    // Load model once — reused across all passages in batch mode.
+    let model_bytes = std::fs::read(model).map_err(|e| {
+        CliError::ValidationFailed(format!("Failed to read {}: {e}", model.display()))
+    })?;
+    let reader = AprV2Reader::from_bytes(&model_bytes).map_err(|e| {
+        CliError::ValidationFailed(format!(
+            "Failed to parse APR v2 at {}: {e:?}",
+            model.display()
+        ))
+    })?;
+
     let mut cross_encoder = CrossEncoder::new(&config, num_labels, with_pooler);
     cross_encoder
         .load_from_reader(&reader, &config)
         .map_err(|e| CliError::ValidationFailed(format!("BERT weight loading failed: {e}")))?;
 
-    // Phase 5 batch mode: `--query` + repeated `--passages` + `--vocab`.
-    if !passages.is_empty() {
+    // No single pair resolved ⟹ Phase 5 batch mode: `--query` + repeated
+    // `--passages` + `--vocab`, each passage tokenised and checked in turn.
+    let Some((input_ids, token_type_ids)) = single_pair else {
         return run_batch(
             &cross_encoder,
+            &config,
             model,
             query,
             passages,
@@ -269,40 +324,7 @@ pub(crate) fn run(
             raw_logit,
             json,
         );
-    }
-
-    // Single-pair mode: resolve the (input_ids, token_type_ids) pair.
-    let (input_ids, token_type_ids) =
-        match (input_ids_str, token_type_ids_str, query, passage, vocab) {
-            (Some(id_str), Some(tt_str), None, None, None) => {
-                let input_ids = parse_id_list(id_str, "input-ids")?;
-                let token_type_ids = parse_id_list(tt_str, "token-type-ids")?;
-                (input_ids, token_type_ids)
-            }
-            (None, None, Some(q), Some(p), Some(vp)) => tokenize_query_passage(q, p, vp)?,
-            _ => {
-                return Err(CliError::ValidationFailed(
-                    "apr rerank requires EITHER \
-                 (--input-ids AND --token-type-ids) \
-                 OR (--query AND --passage AND --vocab) \
-                 OR (--query AND --passages... AND --vocab)"
-                        .to_string(),
-                ));
-            }
-        };
-
-    if input_ids.is_empty() {
-        return Err(CliError::ValidationFailed(
-            "--input-ids must be non-empty".to_string(),
-        ));
-    }
-    if input_ids.len() != token_type_ids.len() {
-        return Err(CliError::ValidationFailed(format!(
-            "--input-ids ({}) and --token-type-ids ({}) must have the same length",
-            input_ids.len(),
-            token_type_ids.len()
-        )));
-    }
+    };
 
     let logit_tensor = cross_encoder.forward(&input_ids, &token_type_ids);
     let logits: &[f32] = logit_tensor.data();
@@ -355,6 +377,7 @@ pub(crate) fn run(
 #[allow(clippy::too_many_arguments)]
 fn run_batch(
     cross_encoder: &CrossEncoder,
+    config: &BertConfig,
     model: &Path,
     query: Option<&str>,
     passages: &[String],
@@ -376,6 +399,11 @@ fn run_batch(
     let mut scored: Vec<(usize, f32, f32)> = Vec::with_capacity(passages.len());
     for (i, p) in passages.iter().enumerate() {
         let (input_ids, token_type_ids) = tokenize_query_passage(query, p, vocab)?;
+        config
+            .validate_ids(&input_ids, &token_type_ids)
+            .map_err(|e| {
+                CliError::ValidationFailed(format!("invalid tokens for passage {i}: {e}"))
+            })?;
         let logit_tensor = cross_encoder.forward(&input_ids, &token_type_ids);
         let logit = logit_tensor.data()[0];
         let score = 1.0 / (1.0 + (-logit).exp());
@@ -439,6 +467,109 @@ fn run_batch(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Invoke `run` in `--input-ids` mode with MiniLM-L-6 defaults, allowing
+    /// individual overrides. The model path is deliberately bogus: every
+    /// argument-validation failure must be reported *before* the model is
+    /// read, so a returned "Failed to read" means the guard did not fire.
+    fn run_ids_mode(
+        ids: &str,
+        token_type_ids: &str,
+        hidden_dim: usize,
+        num_heads: usize,
+    ) -> Result<()> {
+        run(
+            Path::new("/nonexistent/rerank-guard.apr"),
+            Some(ids),
+            Some(token_type_ids),
+            None,
+            None,
+            &[],
+            false,
+            0,
+            None,
+            hidden_dim,
+            6,
+            num_heads,
+            1536,
+            30522,
+            512,
+            2,
+            1,
+            true,
+            false,
+            false,
+        )
+    }
+
+    fn validation_message(res: Result<()>) -> String {
+        match res.expect_err("must be rejected") {
+            CliError::ValidationFailed(msg) => msg,
+            other => panic!("expected ValidationFailed, got {other:?}"),
+        }
+    }
+
+    /// Regression (dogfood 0.63.0): `apr rerank … --hidden-dim 999` aborted
+    /// with `thread 'main' panicked at nn/transformer/mod.rs:124: embed_dim
+    /// (999) must be divisible by num_heads (12)` and exit 101. It must now
+    /// return a validation error naming both flag values.
+    #[test]
+    fn rerank_rejects_hidden_dim_not_divisible_by_num_heads() {
+        let msg = validation_message(run_ids_mode("101,2024,102", "0,0,0", 999, 12));
+        assert!(msg.contains("999") && msg.contains("12"), "{msg}");
+        assert!(msg.contains("divisible"), "{msg}");
+        assert!(
+            !msg.contains("Failed to read"),
+            "flags must be checked before the model is read: {msg}"
+        );
+    }
+
+    /// Same defect reached through `--num-heads`: 384 % 7 != 0.
+    #[test]
+    fn rerank_rejects_num_heads_not_dividing_hidden_dim() {
+        let msg = validation_message(run_ids_mode("101,2024,102", "0,0,0", 384, 7));
+        assert!(msg.contains("384") && msg.contains("7"), "{msg}");
+    }
+
+    /// Regression (dogfood 0.63.0): `--input-ids 101,999999,102` aborted with
+    /// `range start index 383999616 out of range for slice of length 11720448`
+    /// from the unchecked embedding-table slice, exit 101.
+    #[test]
+    fn rerank_rejects_input_id_beyond_vocab_size() {
+        let msg = validation_message(run_ids_mode("101,999999,102", "0,0,0", 384, 12));
+        assert!(msg.contains("999999") && msg.contains("30522"), "{msg}");
+        assert!(msg.contains("input_ids[1]"), "{msg}");
+    }
+
+    /// Same panic class via `--token-type-ids` (table has 2 rows).
+    #[test]
+    fn rerank_rejects_token_type_id_beyond_type_vocab_size() {
+        let msg = validation_message(run_ids_mode("101,2024,102", "0,7,0", 384, 12));
+        assert!(msg.contains("token_type_ids[1]"), "{msg}");
+        assert!(msg.contains('7'), "{msg}");
+    }
+
+    /// Regression: a 600-token pair aborted with `sequence length 600 exceeds
+    /// max_position_embeddings 512`.
+    #[test]
+    fn rerank_rejects_sequence_longer_than_position_table() {
+        let ids = vec!["101"; 600].join(",");
+        let tt = vec!["0"; 600].join(",");
+        let msg = validation_message(run_ids_mode(&ids, &tt, 384, 12));
+        assert!(msg.contains("600") && msg.contains("512"), "{msg}");
+    }
+
+    /// The guard must not reject legitimate input: with in-range ids and a
+    /// valid config, `run` gets past argument validation and fails on the
+    /// (deliberately missing) model file instead.
+    #[test]
+    fn rerank_accepts_in_range_ids_and_proceeds_to_model_load() {
+        let msg = validation_message(run_ids_mode("101,2024,102,3456,102", "0,0,0,1,1", 384, 12));
+        assert!(
+            msg.contains("Failed to read"),
+            "valid arguments must reach the model load, got: {msg}"
+        );
+    }
 
     #[test]
     fn parse_id_list_accepts_commas_and_spaces() {

--- a/crates/aprender-core/src/models/bert/config.rs
+++ b/crates/aprender-core/src/models/bert/config.rs
@@ -67,7 +67,132 @@ impl BertConfig {
             pad_token_id: 0,
         }
     }
+
+    /// Check the structural invariants that model construction **asserts**.
+    ///
+    /// `MultiHeadAttention::new` (reached via `BertEncoder::new` /
+    /// `CrossEncoder::new`) asserts that `hidden_dim` is a multiple of
+    /// `num_heads`, and `head_dim()` divides by `num_heads`. Callers that
+    /// build a config from untrusted input (CLI overrides, config files) must
+    /// call this first and surface the error, instead of letting the assert
+    /// abort the process.
+    ///
+    /// # Errors
+    ///
+    /// Returns `BertConfigError` naming the offending field when
+    /// `hidden_dim` or `num_heads` is zero, or when `hidden_dim` is not
+    /// divisible by `num_heads`.
+    pub fn validate(&self) -> Result<(), BertConfigError> {
+        if self.hidden_dim == 0 {
+            return Err(BertConfigError {
+                field: "hidden_dim".to_string(),
+                reason: "must be greater than 0".to_string(),
+            });
+        }
+        if self.num_heads == 0 {
+            return Err(BertConfigError {
+                field: "num_heads".to_string(),
+                reason: "must be greater than 0".to_string(),
+            });
+        }
+        if !self.hidden_dim.is_multiple_of(self.num_heads) {
+            return Err(BertConfigError {
+                field: "num_heads".to_string(),
+                reason: format!(
+                    "hidden_dim ({}) is not divisible by num_heads ({})",
+                    self.hidden_dim, self.num_heads
+                ),
+            });
+        }
+        Ok(())
+    }
+
+    /// Check a token-id batch against this config before a forward pass.
+    ///
+    /// `BertEmbeddings::forward` indexes the word/position/token-type tables
+    /// with the raw ids and slices them unchecked, so an id at or above the
+    /// corresponding table size aborts the process with a slice-range panic.
+    /// This is the fallible pre-check for any caller feeding user-supplied
+    /// ids.
+    ///
+    /// # Errors
+    ///
+    /// Returns `BertConfigError` for a length mismatch, a sequence longer
+    /// than `max_position_embeddings`, an input id `>= vocab_size`, or a
+    /// token-type id `>= type_vocab_size`.
+    pub fn validate_ids(
+        &self,
+        input_ids: &[u32],
+        token_type_ids: &[u32],
+    ) -> Result<(), BertConfigError> {
+        if input_ids.len() != token_type_ids.len() {
+            return Err(BertConfigError {
+                field: "token_type_ids".to_string(),
+                reason: format!(
+                    "length {} does not match input_ids length {}",
+                    token_type_ids.len(),
+                    input_ids.len()
+                ),
+            });
+        }
+        if input_ids.len() > self.max_position_embeddings {
+            return Err(BertConfigError {
+                field: "input_ids".to_string(),
+                reason: format!(
+                    "sequence length {} exceeds max_position_embeddings {}",
+                    input_ids.len(),
+                    self.max_position_embeddings
+                ),
+            });
+        }
+        if let Some((i, &id)) = input_ids
+            .iter()
+            .enumerate()
+            .find(|(_, &id)| id as usize >= self.vocab_size)
+        {
+            return Err(BertConfigError {
+                field: format!("input_ids[{i}]"),
+                reason: format!(
+                    "token id {id} is out of range for vocab_size {}",
+                    self.vocab_size
+                ),
+            });
+        }
+        if let Some((i, &id)) = token_type_ids
+            .iter()
+            .enumerate()
+            .find(|(_, &id)| id as usize >= self.type_vocab_size)
+        {
+            return Err(BertConfigError {
+                field: format!("token_type_ids[{i}]"),
+                reason: format!(
+                    "token-type id {id} is out of range for type_vocab_size {}",
+                    self.type_vocab_size
+                ),
+            });
+        }
+        Ok(())
+    }
 }
+
+/// Error returned when a `BertConfig` — or a token-id batch measured against
+/// one — violates an invariant that the forward path would otherwise hit as a
+/// panic.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BertConfigError {
+    /// Config field or input position at fault (e.g. `num_heads`, `input_ids[3]`).
+    pub field: String,
+    /// One-line description of what went wrong.
+    pub reason: String,
+}
+
+impl std::fmt::Display for BertConfigError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}", self.field, self.reason)
+    }
+}
+
+impl std::error::Error for BertConfigError {}
 
 #[cfg(test)]
 mod tests {
@@ -95,5 +220,168 @@ mod tests {
     fn head_dim_divides_evenly() {
         let c = BertConfig::default();
         assert_eq!(c.head_dim() * c.num_heads, c.hidden_dim);
+    }
+
+    /// `validate` accepts the shipped presets — the guard must not reject
+    /// working configs.
+    #[test]
+    fn validate_accepts_presets() {
+        BertConfig::default()
+            .validate()
+            .expect("bert-base is valid");
+        BertConfig::minilm_l6()
+            .validate()
+            .expect("MiniLM-L-6 is valid");
+    }
+
+    /// Regression: `apr rerank --hidden-dim 999` aborted with
+    /// `embed_dim (999) must be divisible by num_heads (12)` raised by
+    /// `MultiHeadAttention::new`. `validate` must reject the config first
+    /// and name the offending flag.
+    #[test]
+    fn validate_rejects_indivisible_hidden_dim() {
+        let c = BertConfig {
+            hidden_dim: 999,
+            ..BertConfig::minilm_l6()
+        };
+        let err = c.validate().expect_err("999 % 12 != 0 must be rejected");
+        assert_eq!(err.field, "num_heads");
+        assert!(
+            err.reason.contains("999") && err.reason.contains("12"),
+            "{err}"
+        );
+    }
+
+    /// Same defect through the other flag: `--num-heads 7` against the
+    /// model's own hidden_dim 384.
+    #[test]
+    fn validate_rejects_indivisible_num_heads() {
+        let c = BertConfig {
+            num_heads: 7,
+            ..BertConfig::minilm_l6()
+        };
+        let err = c.validate().expect_err("384 % 7 != 0 must be rejected");
+        assert_eq!(err.field, "num_heads");
+    }
+
+    #[test]
+    fn validate_rejects_zero_dims() {
+        let zero_heads = BertConfig {
+            num_heads: 0,
+            ..BertConfig::minilm_l6()
+        };
+        assert_eq!(
+            zero_heads
+                .validate()
+                .expect_err("num_heads 0 must be rejected")
+                .field,
+            "num_heads"
+        );
+        let zero_hidden = BertConfig {
+            hidden_dim: 0,
+            ..BertConfig::minilm_l6()
+        };
+        assert_eq!(
+            zero_hidden
+                .validate()
+                .expect_err("hidden_dim 0 must be rejected")
+                .field,
+            "hidden_dim"
+        );
+    }
+
+    /// `validate_ids` accepts a well-formed `[CLS] q [SEP] p [SEP]` pair.
+    #[test]
+    fn validate_ids_accepts_well_formed_pair() {
+        let c = BertConfig::minilm_l6();
+        c.validate_ids(&[101, 2024, 102, 3456, 102], &[0, 0, 0, 1, 1])
+            .expect("in-range ids are valid");
+    }
+
+    /// Regression: `apr rerank --input-ids 101,999999,102` aborted with
+    /// `range start index 383999616 out of range for slice of length …`
+    /// from the unchecked slice in `BertEmbeddings::forward`.
+    #[test]
+    fn validate_ids_rejects_token_id_at_or_above_vocab_size() {
+        let c = BertConfig::minilm_l6();
+        let err = c
+            .validate_ids(&[101, 999_999, 102], &[0, 0, 0])
+            .expect_err("999999 >= 30522 must be rejected");
+        assert_eq!(err.field, "input_ids[1]");
+        assert!(
+            err.reason.contains("999999") && err.reason.contains("30522"),
+            "{err}"
+        );
+        // Boundary: exactly vocab_size is out of range, vocab_size-1 is in.
+        assert!(c.validate_ids(&[30522], &[0]).is_err());
+        c.validate_ids(&[30521], &[0]).expect("last id is in range");
+    }
+
+    /// Same panic class through `token_type_ids` (table has only
+    /// `type_vocab_size` rows).
+    #[test]
+    fn validate_ids_rejects_token_type_id_out_of_range() {
+        let c = BertConfig::minilm_l6();
+        let err = c
+            .validate_ids(&[101, 2024, 102], &[0, 7, 0])
+            .expect_err("token-type 7 >= 2 must be rejected");
+        assert_eq!(err.field, "token_type_ids[1]");
+        c.validate_ids(&[101], &[1]).expect("type id 1 is in range");
+    }
+
+    /// Regression: a 600-token pair aborted with `sequence length 600
+    /// exceeds max_position_embeddings 512`.
+    #[test]
+    fn validate_ids_rejects_sequence_longer_than_position_table() {
+        let c = BertConfig::minilm_l6();
+        let ids = vec![101u32; 600];
+        let tt = vec![0u32; 600];
+        let err = c
+            .validate_ids(&ids, &tt)
+            .expect_err("600 > 512 must be rejected");
+        assert_eq!(err.field, "input_ids");
+        assert!(
+            err.reason.contains("600") && err.reason.contains("512"),
+            "{err}"
+        );
+        // Boundary: exactly max_position_embeddings is accepted.
+        c.validate_ids(&vec![101u32; 512], &vec![0u32; 512])
+            .expect("512 fits the position table");
+    }
+
+    #[test]
+    fn validate_ids_rejects_length_mismatch() {
+        let c = BertConfig::minilm_l6();
+        let err = c
+            .validate_ids(&[101, 2024, 102], &[0, 0])
+            .expect_err("length mismatch must be rejected");
+        assert_eq!(err.field, "token_type_ids");
+    }
+
+    /// The whole point of the guard: everything `validate` + `validate_ids`
+    /// accept must survive a real `CrossEncoder` construction and forward
+    /// pass without panicking. Proves the guard is not merely a string check
+    /// that happens to be stricter/looser than the assert it replaces.
+    #[test]
+    fn accepted_config_and_ids_survive_a_real_forward_pass() {
+        use crate::models::bert::CrossEncoder;
+        let c = BertConfig {
+            hidden_dim: 32,
+            num_layers: 1,
+            num_heads: 4,
+            intermediate_dim: 64,
+            vocab_size: 64,
+            max_position_embeddings: 16,
+            type_vocab_size: 2,
+            ..BertConfig::minilm_l6()
+        };
+        c.validate().expect("config is valid");
+        let input_ids = [1u32, 63, 2];
+        let token_type_ids = [0u32, 1, 1];
+        c.validate_ids(&input_ids, &token_type_ids)
+            .expect("ids are valid");
+        let ce = CrossEncoder::new(&c, 1, true);
+        let out = ce.forward(&input_ids, &token_type_ids);
+        assert_eq!(out.data().len(), 1);
     }
 }

--- a/crates/aprender-core/src/models/bert/embeddings.rs
+++ b/crates/aprender-core/src/models/bert/embeddings.rs
@@ -65,8 +65,12 @@ impl BertEmbeddings {
     ///
     /// # Panics
     ///
-    /// Panics if `input_ids.len() != token_type_ids.len()` or
-    /// `input_ids.len() > max_position_embeddings`.
+    /// Panics if `input_ids.len() != token_type_ids.len()`, if
+    /// `input_ids.len() > max_position_embeddings`, or if any id is at or
+    /// above its table size (the embedding rows are sliced unchecked).
+    /// Callers handling untrusted ids must pre-check with
+    /// [`BertConfig::validate_ids`](crate::models::bert::BertConfig::validate_ids)
+    /// and surface the error rather than aborting the process.
     #[must_use]
     pub fn forward(&self, input_ids: &[u32], token_type_ids: &[u32]) -> Tensor {
         assert_eq!(
@@ -138,5 +142,29 @@ mod tests {
         let token_type_ids = vec![0u32, 0, 0, 1, 1];
         let out = emb.forward(&input_ids, &token_type_ids);
         assert_eq!(out.shape(), &[1, 5, 384]);
+    }
+
+    /// The hazard `BertConfig::validate_ids` exists to guard: the embedding
+    /// rows are sliced with the raw id, so an id past the end of the table
+    /// aborts the process. Pinning it here keeps the guard load-bearing — if
+    /// this ever stops panicking, the pre-check is no longer the only thing
+    /// standing between user input and a slice-range abort.
+    #[test]
+    #[should_panic(expected = "out of range for slice")]
+    fn embeddings_out_of_range_id_panics_without_a_pre_check() {
+        let config = BertConfig::minilm_l6();
+        let emb = BertEmbeddings::new(&config);
+        let _ = emb.forward(&[101u32, 999_999, 102], &[0u32, 0, 0]);
+    }
+
+    /// The same ids, run through the pre-check first, are rejected with a
+    /// recoverable error instead of aborting.
+    #[test]
+    fn validate_ids_rejects_what_forward_would_abort_on() {
+        let config = BertConfig::minilm_l6();
+        let err = config
+            .validate_ids(&[101, 999_999, 102], &[0, 0, 0])
+            .expect_err("id past the word-embedding table must be rejected");
+        assert_eq!(err.field, "input_ids[1]");
     }
 }

--- a/crates/aprender-core/src/models/bert/mod.rs
+++ b/crates/aprender-core/src/models/bert/mod.rs
@@ -35,7 +35,7 @@ pub mod encoder;
 pub mod layer;
 pub mod load;
 
-pub use config::BertConfig;
+pub use config::{BertConfig, BertConfigError};
 pub use cross_encoder::CrossEncoder;
 pub use embeddings::BertEmbeddings;
 pub use encoder::BertEncoder;


### PR DESCRIPTION
Dogfooding `cargo install aprender` 0.63.0, six different `apr rerank` invocations killed the process with `thread 'main' panicked` and exit 101 instead of reporting a user error. Every one is reachable through advertised, documented flags.

```
APR=~/.cargo/bin/apr   # apr 0.63.0 (v0.63.0+no-git)

$ "$APR" rerank ce.apr --input-ids 101,999999,102 --token-type-ids 0,0,0
rc=101
thread 'main' panicked at aprender-core-0.63.0/src/models/bert/embeddings.rs:94:33:
range start index 383999616 out of range for slice of length 11720448

$ "$APR" rerank ce.apr --query a --passage b --vocab tokenizer.json --hidden-dim 999
rc=101
thread 'main' panicked at aprender-core-0.63.0/src/nn/transformer/mod.rs:124:9:
embed_dim (999) must be divisible by num_heads (12)
```

The other four: `--num-heads 7` against a 384-dim model, `--token-type-ids 0,7,0` (the token-type table has 2 rows), a 600-token pair against a 512-position table, and batch mode `--passages` with a 700-word passage, which panicked at `sequence length 704 exceeds max_position_embeddings 512`.

## Root cause

`rerank` hands raw user input to two infallible library APIs that assert on it.

`crates/apr-cli/src/commands/rerank.rs:231` builds a `BertConfig` straight from the `--hidden-dim` / `--num-heads` flags and passes it to `CrossEncoder::new`, which reaches `MultiHeadAttention::new` and its `assert!(embed_dim.is_multiple_of(num_heads))` at `crates/aprender-core/src/nn/transformer/mod.rs:124`.

Separately the parsed `--input-ids` go to `BertEmbeddings::forward`, which at `crates/aprender-core/src/models/bert/embeddings.rs:94` slices the embedding table with the raw id — `&we_data[wid * h..(wid + 1) * h]` — with no bounds check. Neither entry point can return an error, so the CLI had nothing to catch.

## Fix

`BertConfig` had no fallible checker to call, so this adds one: `BertConfig::validate` for the structural invariant that model construction asserts, and `BertConfig::validate_ids` for a token batch. `rerank` calls both before it reads the model, so a bad flag costs no I/O, and `run_batch` checks each passage after tokenisation.

The six aborts become exit 5:

```
error: Validation failed: invalid tokens: input_ids[1]: token id 999999 is out of range for vocab_size 30522
error: Validation failed: invalid BERT config: num_heads: hidden_dim (999) is not divisible by num_heads (12)
error: Validation failed: invalid tokens for passage 0: input_ids: sequence length 704 exceeds max_position_embeddings 512
```

Validating ids against the config rather than the loaded tensors is exact, not an approximation: `load.rs::read_tensor` rejects any embedding table whose element count is not `vocab_size * hidden_dim` (likewise the position and token-type tables), so a successful load guarantees the tables are exactly config-sized.

Verified end-to-end against a release binary built from this branch (`apr 0.63.0 (d37f2fefc)`, distinct from the crates.io `v0.63.0+no-git`), not from unit tests alone. Two scoring runs pin that working input is untouched — a valid single pair still returns `score[0] = 0.000211` and a two-passage batch still returns `0.999758` / `0.000012`, byte-identical to 0.63.0.

## Mutation check

Removing the two call sites in `rerank.rs` while keeping the tests turns 5 CLI tests RED, each falling through to the model read the guard is supposed to precede:

```
test commands::rerank::tests::rerank_rejects_hidden_dim_not_divisible_by_num_heads ... FAILED
---- commands::rerank::tests::rerank_rejects_input_id_beyond_vocab_size stdout ----
panicked at crates/apr-cli/src/commands/rerank.rs:536:9:
Failed to read /nonexistent/rerank-guard.apr: No such file or directory (os error 2)
test result: FAILED. 8 passed; 5 failed
```

Neutering the two guard bodies to `Ok(())` instead turns 8 core tests RED:

```
---- models::bert::config::tests::validate_ids_rejects_token_id_at_or_above_vocab_size stdout ----
panicked at crates/aprender-core/src/models/bert/config.rs:314:14:
999999 >= 30522 must be rejected: ()
test result: FAILED. 26 passed; 8 failed
```

Restored, both are green: 13984 passed in aprender-core, 6628 in apr-cli. `cargo fmt --all -- --check` and `cargo clippy --lib -- -D warnings` clean on both crates.

The library-level tests pin the hazard rather than the wording — one asserts `BertEmbeddings::forward` still aborts on an out-of-range id (so the guard stays load-bearing), and one builds a real `CrossEncoder` and runs a forward pass on ids that `validate`/`validate_ids` accept, proving the checks are neither stricter nor looser than the asserts they front.

## Adjacent, deliberately not fixed here

`apr embed` panics identically on `--num-heads 7` (same assert, exit 101). Its clean exit 5 on `--hidden-dim 999` is incidental — the weight loader happens to catch the shape mismatch before the encoder is built, so there was no shared validation path to reuse. Left alone to keep this diff scoped; `BertConfig::validate` is the one call it needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Refs #2383 (partial — see the issue for the findings that remain)

Audit epic: #2373
