### PR TITLE
fix(mcp): apr.serve never started a server and called it success

### DIFF
--- a/contracts/apr-mcp-tool-schemas-v1.yaml
+++ b/contracts/apr-mcp-tool-schemas-v1.yaml
@@ -222,8 +222,8 @@ tools:
   - name: apr.serve
     shipped_in: 'PR #872 (M2 slice 7)'
     source: crates/aprender-mcp/src/tools/serve.rs
-    description: "Start an `apr serve` inference daemon in the background. Returns {pid, url}; kill the pid via OS to stop. Cancel-token lifecycle (SIGTERM) is a post-M3 follow-up; apr.run already honours notifications/cancelled."
-    cli_mapping: "apr serve <model_path> --port <port>"
+    description: "Start an `apr serve run` inference daemon in the background. Waits for the daemon to bind its port, then returns {pid, url, ready}; kill the pid via OS to stop. Returns isError if the daemon exits during startup (bad model path, port in use). Cancel-token lifecycle (SIGTERM) is a post-M3 follow-up; apr.run already honours notifications/cancelled."
+    cli_mapping: "apr serve run <model_path> --port <port>"
     args:
       - name: model_path
         type: string

--- a/crates/aprender-mcp/contracts/apr-mcp-tool-schemas-v1.yaml
+++ b/crates/aprender-mcp/contracts/apr-mcp-tool-schemas-v1.yaml
@@ -222,8 +222,8 @@ tools:
   - name: apr.serve
     shipped_in: 'PR #872 (M2 slice 7)'
     source: crates/aprender-mcp/src/tools/serve.rs
-    description: "Start an `apr serve` inference daemon in the background. Returns {pid, url}; kill the pid via OS to stop. Cancel-token lifecycle (SIGTERM) is a post-M3 follow-up; apr.run already honours notifications/cancelled."
-    cli_mapping: "apr serve <model_path> --port <port>"
+    description: "Start an `apr serve run` inference daemon in the background. Waits for the daemon to bind its port, then returns {pid, url, ready}; kill the pid via OS to stop. Returns isError if the daemon exits during startup (bad model path, port in use). Cancel-token lifecycle (SIGTERM) is a post-M3 follow-up; apr.run already honours notifications/cancelled."
+    cli_mapping: "apr serve run <model_path> --port <port>"
     args:
       - name: model_path
         type: string

--- a/crates/aprender-mcp/src/tools/serve.rs
+++ b/crates/aprender-mcp/src/tools/serve.rs
@@ -1,9 +1,29 @@
-//! `apr.serve` — fire-and-forget subprocess wrapper over `apr serve`.
+//! `apr.serve` — background subprocess wrapper over `apr serve run`.
 //!
 //! Unlike every other Phase-1 tool, this one does NOT wait for the subprocess
-//! to exit: `apr serve` is a long-running HTTP daemon. We spawn it, capture
-//! the OS pid, and return `{pid, url}` so the MCP client can reach the daemon.
-//! The caller is responsible for killing the pid out-of-band.
+//! to exit: `apr serve run` is a long-running HTTP daemon. We spawn it, wait
+//! for it to actually bind its port, then return `{pid, url, ready}` so the
+//! MCP client can reach the daemon. The caller is responsible for killing the
+//! pid out-of-band.
+//!
+//! DOGFOOD-0.63.0 (#2388) — two defects were fixed here at once:
+//!
+//! 1. The spawned argv was `apr serve <model> --port <n>`, which is not a
+//!    valid CLI form: `apr serve` takes a `plan`/`run` subcommand, so every
+//!    invocation died instantly with `error: unrecognized subcommand` (rc=2).
+//!    The correct form is `apr serve run <model> --port <n>`; it is built by
+//!    [`serve_argv`] and asserted by a unit test so it cannot silently drift.
+//! 2. The `Child` handle was dropped without ever checking liveness, so
+//!    `is_error` was left `None` and the tool reported `{pid, url}` — a
+//!    success — for a process that was already a zombie, including for a
+//!    model path that does not exist. Silent success on failure.
+//!
+//! [`spawn_and_confirm`] now polls until one of three terminal states:
+//! the child exits (→ `isError` with the exit status and the tail of its
+//! stderr), the port accepts a TCP connection (→ success, `ready: true`), or
+//! the readiness window elapses with the child still alive (→ non-error, but
+//! explicitly `ready: false` — a big model may still be loading; we report
+//! what is true rather than claiming a listening server).
 //!
 //! M3 shipped `notifications/cancelled` → SIGTERM → SIGKILL for `apr.run`
 //! only (see `server.rs::CancelHandle` docs: "Only `apr.run` currently
@@ -11,19 +31,57 @@
 //! cancel token → SIGTERM the captured pid with 30s grace → SIGKILL — is a
 //! post-M3 follow-up targeted at M5 alongside the pmcp dispatcher port (see
 //! `docs/specifications/apr-mcp-server-spec.md` § Milestones → M5).
-//! Until then, dropping the `Child` leaves a zombie on Unix until the OS
-//! parent reaps it.
+//! Until then, a daemon that is still alive when we return leaves a zombie on
+//! Unix until the OS parent reaps it. A daemon that died inside the readiness
+//! window IS reaped, by the `try_wait` that detects the death.
 
 #![allow(clippy::disallowed_methods)] // serde_json::json! macro expands to .unwrap() internally
 
 use crate::types::{ContentBlock, InputSchema, ToolCallResult, ToolDefinition};
+use std::io::Read;
+use std::net::{Ipv4Addr, SocketAddr, TcpStream};
 use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
 
 /// Tool name registered with MCP clients.
 pub const NAME: &str = "apr.serve";
 
 /// Default HTTP port when the caller omits `port`.
 const DEFAULT_PORT: u16 = 8080;
+
+/// How long to wait for the spawned daemon to bind its port before returning
+/// a non-error `ready: false`. Generous enough for a multi-GB model load on
+/// CPU; an argv/clap failure is detected in the first poll (~50ms).
+const READY_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Poll interval for the readiness loop.
+const READY_POLL: Duration = Duration::from_millis(50);
+
+/// Per-probe TCP connect timeout.
+const CONNECT_TIMEOUT: Duration = Duration::from_millis(200);
+
+/// Readiness window when `port == 0` (OS-assigned): there is no port to probe,
+/// so we can only prove the child did not die immediately.
+const EPHEMERAL_PORT_WINDOW: Duration = Duration::from_secs(2);
+
+/// Bytes of the child's stderr echoed back in a failure message.
+const STDERR_TAIL_BYTES: usize = 2048;
+
+/// The exact CLI form `apr.serve` shells out to.
+///
+/// `apr serve` is a command *group* — `plan` and `run` are its subcommands.
+/// Omitting `run` makes the model path parse as a subcommand name and clap
+/// exits 2 before the server is ever constructed (#2388).
+#[must_use]
+pub fn serve_argv(model_path: &str, port: u16) -> Vec<String> {
+    vec![
+        "serve".to_string(),
+        "run".to_string(),
+        model_path.to_string(),
+        "--port".to_string(),
+        port.to_string(),
+    ]
+}
 
 /// Return the MCP tool definition for `apr.serve`.
 ///
@@ -46,12 +104,12 @@ pub fn serve_tool_definition() -> ToolDefinition {
     }
 }
 
-/// Execute `apr.serve` by spawning `apr serve <model_path> --port <port>`.
+/// Execute `apr.serve` by spawning `apr serve run <model_path> --port <port>`
+/// and confirming the daemon is alive before reporting success.
 ///
-/// Fire-and-forget: the `Child` handle is dropped and the subprocess continues
-/// running. On Unix this leaves a zombie until the OS parent reaps it. A
-/// lifecycle-tracked registry is a post-M3 follow-up (M5 alongside the pmcp
-/// dispatcher port); see this module's header for context.
+/// Returns `isError: true` when the child exits inside the readiness window —
+/// which is what a bad argv, a missing model file, or an already-bound port
+/// all look like. See this module's header for the terminal states.
 #[must_use]
 pub fn call(args: &serde_json::Value) -> ToolCallResult {
     let Some(model_path) = args.get("model_path").and_then(|v| v.as_str()) else {
@@ -70,38 +128,158 @@ pub fn call(args: &serde_json::Value) -> ToolCallResult {
         },
     };
 
-    let spawn_result = Command::new("apr")
-        .arg("serve")
-        .arg(model_path)
-        .arg("--port")
-        .arg(port.to_string())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn();
+    spawn_and_confirm("apr", &serve_argv(model_path, port), port, READY_TIMEOUT)
+}
 
-    let child = match spawn_result {
+/// Spawn `program <args...>` as a background HTTP daemon on `port` and wait
+/// up to `ready_timeout` for it to prove it is running.
+///
+/// Generic over the program name so the readiness/liveness contract can be
+/// exercised in unit tests without a built `apr` on `PATH` — the same shape
+/// `subprocess::spawn_cancellable` uses.
+#[must_use]
+pub fn spawn_and_confirm(
+    program: &str,
+    args: &[String],
+    port: u16,
+    ready_timeout: Duration,
+) -> ToolCallResult {
+    let cmd_display = format!("{program} {}", args.join(" "));
+
+    // The daemon outlives this call, so its stderr must not go to a pipe
+    // nobody drains (a full pipe buffer would wedge the server). Route it to
+    // a file we can read back if the child dies, and hand the path to the
+    // caller when it lives.
+    let log_path = stderr_log_path(port);
+    let stderr = match std::fs::File::create(&log_path) {
+        Ok(f) => Stdio::from(f),
+        Err(_) => Stdio::null(),
+    };
+
+    let mut child = match Command::new(program)
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(stderr)
+        .spawn()
+    {
         Ok(c) => c,
         Err(e) => {
-            return ToolCallResult::error(format!("failed to spawn apr serve: {e}"));
+            let _ = std::fs::remove_file(&log_path);
+            return ToolCallResult::error(format!("failed to spawn `{cmd_display}`: {e}"));
         }
     };
 
     let pid: u32 = child.id();
-    // Fire-and-forget: drop the Child handle. See module doc-comment for M3
-    // follow-up on proper lifecycle tracking.
-    drop(child);
+    let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, port));
+    // Port 0 means "OS assigns" — there is nothing to probe, so the window
+    // only proves the child survived startup.
+    let window = if port == 0 {
+        ready_timeout.min(EPHEMERAL_PORT_WINDOW)
+    } else {
+        ready_timeout
+    };
+    let deadline = Instant::now() + window;
 
+    loop {
+        // Liveness first: a dead child can never be ready, and checking it
+        // before the connect probe stops an unrelated process that happens to
+        // hold `port` from masquerading as our daemon.
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                let detail = read_stderr_tail(&log_path);
+                let _ = std::fs::remove_file(&log_path);
+                let code = status
+                    .code()
+                    .map_or_else(|| "signal".to_string(), |c| c.to_string());
+                return ToolCallResult::error(format!(
+                    "`{cmd_display}` exited immediately (status {code}) — no server is \
+                     listening on port {port}{detail}"
+                ));
+            }
+            Ok(None) => {}
+            Err(e) => {
+                let _ = std::fs::remove_file(&log_path);
+                return ToolCallResult::error(format!("failed to poll `{cmd_display}`: {e}"));
+            }
+        }
+
+        if port != 0 && TcpStream::connect_timeout(&addr, CONNECT_TIMEOUT).is_ok() {
+            // Re-check liveness: the connect could have raced a dying child.
+            if let Ok(Some(status)) = child.try_wait() {
+                let detail = read_stderr_tail(&log_path);
+                let _ = std::fs::remove_file(&log_path);
+                let code = status
+                    .code()
+                    .map_or_else(|| "signal".to_string(), |c| c.to_string());
+                return ToolCallResult::error(format!(
+                    "`{cmd_display}` exited immediately (status {code}) — no server is \
+                     listening on port {port}{detail}"
+                ));
+            }
+            return running_result(pid, port, true, &log_path);
+        }
+
+        if Instant::now() >= deadline {
+            return running_result(pid, port, false, &log_path);
+        }
+        std::thread::sleep(READY_POLL);
+    }
+}
+
+/// Build the non-error payload for a child that is still running.
+///
+/// `ready` distinguishes "the port accepted a connection" from "still alive
+/// but not listening yet" — the caller is told which, never told a listening
+/// server exists when none does.
+fn running_result(pid: u32, port: u16, ready: bool, log_path: &std::path::Path) -> ToolCallResult {
+    let note = if ready {
+        "server is accepting connections; kill pid via OS to stop"
+    } else {
+        "process is alive but has not bound the port yet (still loading?); kill pid via OS to stop"
+    };
     let payload = serde_json::json!({
         "pid": pid,
         "url": format!("http://localhost:{port}"),
-        "note": "fire-and-forget: kill pid via OS to stop",
+        "ready": ready,
+        "stderr_log": log_path.display().to_string(),
+        "note": note,
     });
     let text = serde_json::to_string(&payload)
         .unwrap_or_else(|_| format!("{{\"pid\":{pid},\"url\":\"http://localhost:{port}\"}}"));
-
     ToolCallResult {
         content: vec![ContentBlock::text(text)],
         is_error: None,
+    }
+}
+
+/// Unique-per-call path for the daemon's stderr.
+fn stderr_log_path(port: u16) -> std::path::PathBuf {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |d| d.as_nanos());
+    std::env::temp_dir().join(format!(
+        "apr-mcp-serve-{pid}-{port}-{nanos}.log",
+        pid = std::process::id()
+    ))
+}
+
+/// Last [`STDERR_TAIL_BYTES`] of the child's stderr, formatted for appending
+/// to an error message. Empty string when there is nothing to report.
+fn read_stderr_tail(log_path: &std::path::Path) -> String {
+    let Ok(mut f) = std::fs::File::open(log_path) else {
+        return String::new();
+    };
+    let mut buf = Vec::new();
+    if f.read_to_end(&mut buf).is_err() {
+        return String::new();
+    }
+    let start = buf.len().saturating_sub(STDERR_TAIL_BYTES);
+    let tail = String::from_utf8_lossy(&buf[start..]).trim().to_string();
+    if tail.is_empty() {
+        String::new()
+    } else {
+        format!(": {tail}")
     }
 }
 
@@ -168,5 +346,161 @@ mod tests {
         }));
         assert_eq!(result.is_error, Some(true));
         assert!(result.content[0].text.contains("port"));
+    }
+
+    // ---- DOGFOOD-0.63.0 (#2388) falsifiers -------------------------------
+
+    /// The argv defect: 0.63.0 built `apr serve <model> --port N`, so clap
+    /// parsed the model path as a subcommand name and exited 2. `serve` is a
+    /// command group; `run` is mandatory and must sit between them.
+    #[test]
+    fn serve_argv_places_run_between_serve_and_model_path() {
+        let argv = serve_argv("/models/qwen.gguf", 18590);
+        assert_eq!(
+            argv,
+            vec!["serve", "run", "/models/qwen.gguf", "--port", "18590"],
+            "apr.serve must shell out to `apr serve run <model> --port <n>`"
+        );
+        // Position matters, not mere presence: the model path must never be
+        // in the subcommand slot.
+        assert_eq!(argv[1], "run");
+        assert_ne!(argv[1], "/models/qwen.gguf");
+    }
+
+    /// Pick a port nothing is listening on. Binding and immediately dropping
+    /// leaves the port free with high probability, which is enough for a test
+    /// whose assertion is about the child, not the port.
+    #[cfg(unix)]
+    fn free_port() -> u16 {
+        let l = std::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0))
+            .expect("bind ephemeral port");
+        l.local_addr().expect("local_addr").port()
+    }
+
+    #[cfg(unix)]
+    fn payload_of(result: &ToolCallResult) -> serde_json::Value {
+        serde_json::from_str(&result.content[0].text)
+            .unwrap_or_else(|e| panic!("payload must be JSON: {e}; got {}", result.content[0].text))
+    }
+
+    /// The silent-success defect: 0.63.0 dropped the `Child` without checking
+    /// liveness, so a subprocess that had already exited non-zero was still
+    /// reported as `{pid, url}` with no `isError`.
+    #[cfg(unix)]
+    #[test]
+    fn child_that_exits_immediately_is_reported_as_error() {
+        let port = free_port();
+        let result = spawn_and_confirm("false", &[], port, Duration::from_secs(5));
+        assert_eq!(
+            result.is_error,
+            Some(true),
+            "a child that exited must NOT be reported as a running server; got: {}",
+            result.content[0].text
+        );
+        let msg = &result.content[0].text;
+        assert!(
+            msg.contains("exited immediately"),
+            "error must say the child exited, got: {msg}"
+        );
+        assert!(
+            msg.contains(&port.to_string()),
+            "error must name the port that has no server, got: {msg}"
+        );
+    }
+
+    /// A failing child's own diagnostics must survive into the MCP error —
+    /// this is what turns "it didn't work" into "unrecognized subcommand".
+    #[cfg(unix)]
+    #[test]
+    fn dead_child_error_carries_its_stderr_and_exit_status() {
+        let port = free_port();
+        let args = vec![
+            "-c".to_string(),
+            "echo 'unrecognized subcommand' >&2; exit 2".to_string(),
+        ];
+        let result = spawn_and_confirm("sh", &args, port, Duration::from_secs(5));
+        assert_eq!(result.is_error, Some(true));
+        let msg = &result.content[0].text;
+        assert!(
+            msg.contains("unrecognized subcommand"),
+            "child stderr must be echoed back, got: {msg}"
+        );
+        assert!(
+            msg.contains("status 2"),
+            "exit status must be reported, got: {msg}"
+        );
+    }
+
+    /// Success path: a live child plus a port that accepts connections is the
+    /// only combination that may report `ready: true`.
+    #[cfg(unix)]
+    #[test]
+    fn live_child_with_bound_port_reports_ready_true() {
+        let listener = std::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0))
+            .expect("bind ephemeral port");
+        let port = listener.local_addr().expect("local_addr").port();
+        let args = vec!["5".to_string()];
+        let result = spawn_and_confirm("sleep", &args, port, Duration::from_secs(5));
+        assert_eq!(result.is_error, None, "got: {}", result.content[0].text);
+        let payload = payload_of(&result);
+        assert_eq!(payload["ready"], serde_json::json!(true));
+        assert_eq!(
+            payload["url"],
+            serde_json::json!(format!("http://localhost:{port}"))
+        );
+        assert!(payload["pid"].as_u64().is_some_and(|p| p > 0));
+        // The log path handed to the client must actually exist.
+        let log = payload["stderr_log"]
+            .as_str()
+            .expect("stderr_log is a path");
+        assert!(
+            std::path::Path::new(log).exists(),
+            "stderr_log {log} must exist for a running daemon"
+        );
+        let _ = std::fs::remove_file(log);
+        drop(listener);
+    }
+
+    /// A live child that never binds is neither a failure nor a running
+    /// server: report it truthfully as `ready: false` rather than implying a
+    /// reachable URL.
+    #[cfg(unix)]
+    #[test]
+    fn live_child_that_never_binds_reports_ready_false() {
+        let port = free_port();
+        let args = vec!["5".to_string()];
+        let result = spawn_and_confirm("sleep", &args, port, Duration::from_millis(300));
+        assert_eq!(result.is_error, None);
+        let payload = payload_of(&result);
+        assert_eq!(
+            payload["ready"],
+            serde_json::json!(false),
+            "must not claim readiness for a port nothing is listening on"
+        );
+        assert!(
+            payload["note"]
+                .as_str()
+                .is_some_and(|n| n.contains("has not bound")),
+            "note must explain the port is unbound, got: {}",
+            payload["note"]
+        );
+        if let Some(log) = payload["stderr_log"].as_str() {
+            let _ = std::fs::remove_file(log);
+        }
+    }
+
+    /// Spawning a program that does not exist is an error, not a `{pid,url}`.
+    #[cfg(unix)]
+    #[test]
+    fn unspawnable_program_reports_error() {
+        let port = free_port();
+        let result = spawn_and_confirm(
+            "apr-does-not-exist-9c1f",
+            &[],
+            port,
+            Duration::from_millis(200),
+        );
+        assert_eq!(result.is_error, Some(true));
+        assert!(result.content[0].text.contains("failed to spawn"));
     }
 }


### PR DESCRIPTION
The MCP tool `apr.serve` returned `{pid, url}` with no `isError`, and nothing was ever listening on that url. The child was a zombie by the time the result was written, so an MCP client received a URL it could not connect to and no signal that anything had failed — including for a model path that does not exist.

Reproduced against the binary a user gets from `cargo install aprender` 0.63.0:

```
tools/call apr.serve {"model_path":".../d47927c5638f80ab.gguf","port":18590}
 -> {"pid":826572,"url":"http://localhost:18590","note":"fire-and-forget: kill pid via OS to stop"}
    (no isError field)
listeners on 18590: 0
curl http://localhost:18590/health: 000
```

Varied inputs before naming a cause: two GGUF models, one APR model, a nonexistent path, ports 18590/18591, and a FIFO-held stdin so the MCP parent stayed alive for the whole poll — every one returned a non-error `{pid, url}` and a dead port.

## Root cause

Two independent defects in `crates/aprender-mcp/src/tools/serve.rs`.

**The argv was invalid.** `serve.rs:73-80` built `apr serve <model> --port <n>`. `apr serve` is a command *group* — `plan` and `run` are its subcommands — so the model path was parsed as a subcommand name and clap exited 2 before a server was ever constructed:

```
$ apr serve /home/noah/.cache/pacha/models/d47927c5638f80ab.gguf --port 18590
error: unrecognized subcommand '/home/noah/.cache/pacha/models/d47927c5638f80ab.gguf'
Usage: apr serve [OPTIONS] <COMMAND>
rc=2
```

The correct form is `apr serve run <model> --port <n>`, now built by `serve_argv()`. The contract carried the same error: `cli_mapping` in `contracts/apr-mcp-tool-schemas-v1.yaml:226` read `apr serve <model_path> --port <port>` — the implementation was faithful to a wrong spec. Both copies of the YAML are corrected.

**The success was unconditional.** The `Child` was dropped at `serve.rs:92` without ever being polled, so `is_error` stayed `None` at `serve.rs:104` regardless of what the child did.

`spawn_and_confirm()` now polls to one of three terminal states:

- the child exits → `isError: true` with the exit status and the tail of its stderr;
- the port accepts a TCP connection → success with `ready: true`;
- the readiness window (30s) elapses with the child alive → non-error but explicitly `ready: false`, because a multi-GB model may still be loading and reporting that is honest where claiming a listening server is not.

Liveness is checked *before* the connect probe, so an unrelated process holding the port cannot masquerade as our daemon, and re-checked after a successful connect to close the race. The daemon outlives the call, so its stderr goes to a file rather than a pipe nobody drains; the path is returned in the payload and removed on the failure path once its tail has been read.

## After, same repro

Verified with a release binary built from this branch — `apr 0.63.0 (5643db51d)`, the git SHA proving it is not the crates.io build:

```
tools/call -> {"pid":2534155,"url":"http://localhost:18592","ready":true,
               "stderr_log":"/tmp/apr-mcp-serve-2534153-18592-....log",
               "note":"server is accepting connections; kill pid via OS to stop"}
listeners on 18592: 1
curl /health: 200
{"status":"ok","version":"0.63.0","compute_mode":"cpu","model_loaded":true,"uptime_sec":4.008}
```

The failure cases now say so instead of handing back a URL:

```
/nonexistent/nope.gguf -> isError: true
  `apr serve run /nonexistent/nope.gguf --port 18593` exited immediately (status 3)
  — no server is listening on port 18593: error: File not found: /nonexistent/nope.gguf

Qwen3.5-0.8B-Q4_K_M.gguf -> isError: true
  ... exited immediately (status 6) ... error: Model load failed: Architecture 'qwen35'
  uses SSM/Gated Delta Net layers which are not yet supported for inference.
```

That second one is a real load failure 0.63.0 reported as a running server.

## Mutation check

Reverting the argv fix alone, keeping the tests, turns one red:

```
---- tools::serve::tests::serve_argv_places_run_between_serve_and_model_path stdout ----
assertion `left == right` failed: apr.serve must shell out to `apr serve run <model> --port <n>`
  left: ["serve", "/models/qwen.gguf", "--port", "18590"]
 right: ["serve", "run", "/models/qwen.gguf", "--port", "18590"]
test result: FAILED. 19 passed; 1 failed
```

Restoring the fire-and-forget `drop(child)` turns three more red, and the payload in the failure output is byte-for-byte the shipped defect:

```
---- tools::serve::tests::child_that_exits_immediately_is_reported_as_error stdout ----
assertion `left == right` failed: a child that exited must NOT be reported as a running server;
got: {"note":"server is accepting connections; kill pid via OS to stop","pid":1951695,
      "ready":true,"stderr_log":"/tmp/apr-mcp-serve-1951679-35509-....log",
      "url":"http://localhost:35509"}
  left: None
 right: Some(true)

---- tools::serve::tests::dead_child_error_carries_its_stderr_and_exit_status stdout ----
  left: None
 right: Some(true)

---- tools::serve::tests::live_child_that_never_binds_reports_ready_false stdout ----
assertion `left == right` failed: must not claim readiness for a port nothing is listening on
  left: Bool(true)
 right: Bool(false)

test result: FAILED. 17 passed; 3 failed
```

Restored: 60 passed, 0 failed.

## Gates

`cargo fmt --all -- --check` clean, `cargo clippy -p aprender-mcp --lib -- -D warnings` clean, `cargo test -p aprender-mcp --lib` 60/60, `cargo test -p aprender-mcp --test falsify_mcp_008` 9/9 (the contract-drift gate, which covers the description change), `pv validate contracts/apr-mcp-tool-schemas-v1.yaml` → 0 errors.

Not changed, and worth its own ticket: `Command::new("apr")` here and in `tools/subprocess.rs` still resolves a bare `apr` off `PATH`, which the repo's own binary-pinning discipline forbids; and a daemon still alive when the call returns leaves a zombie until the OS parent reaps it (the M5 lifecycle-registry follow-up). Neither is part of this cluster.

Audit epic: #2373

Fixes #2388

🤖 Generated with [Claude Code](https://claude.com/claude-code)
