### PR TITLE
fix(cli): --offline downloaded anyway on pull, chat and showcase

### DIFF
--- a/contracts/crux-A-20-v1.yaml
+++ b/contracts/crux-A-20-v1.yaml
@@ -152,9 +152,26 @@ falsification_tests:
     grep -qiE 'cache|not.?found|missing' "$LOG" || { echo "FAIL: no cache-miss keyword" >&2; exit 1; }
     grep -qi 'gpt2\|config.json' "$LOG" || { echo "FAIL: error does not name missing repo/file" >&2; exit 1; }
   if_fails: "offline cache miss lacked non-zero exit or actionable message"
-  # No algorithm-level sub-claim: this gate requires a real cache layer +
-  # populated/empty cache states + actual pull path execution. Discharge
-  # deferred to the follow-up network-gated harness.
+  discharge_status: PARTIAL_ALGORITHM_LEVEL
+  evidence_discharged_by:
+    harness: crates/apr-cli/src/commands/offline.rs
+    tests:
+    - pull_run_refuses_uncached_model_when_offline
+    - pull_dataset_refuses_listing_when_offline
+    - resolve_model_refuses_uncached_model_when_caller_forgot_the_flag
+    - import_step_refuses_download_when_offline
+    classifier: crates/apr-cli/src/commands/offline.rs
+    scope: >
+      Command-level discharge of the "hard error, no silent network
+      fallback" invariant on the REAL pull path (not the dry-run path):
+      `pull::run(offline=true)`, `pull::run_dataset`, `run::resolve_model`
+      and the showcase import step each return a non-zero `NetworkError`
+      naming `--offline mode` on an uncached repo, before any request is
+      constructed. Prior to this the `--offline` parameter was read only
+      inside `pull`'s `--dry-run` branch, so `apr pull --offline
+      hf://org/repo` downloaded 3.9 MB and exited 0.
+      NOT YET DISCHARGED: strace-verified zero non-loopback TCP connects,
+      and the byte-for-byte cache-hit parity of FALSIFY-CRUX-A-20-005.
 
 - id: FALSIFY-CRUX-A-20-004
   rule: --offline flag is equivalent to APR_OFFLINE=1
@@ -220,7 +237,7 @@ proof_obligations:
 verification_summary:
   total_obligations: 5
   proven: 0
-  tested: 3  # FALSIFY-001/002/004 at PARTIAL_ALGORITHM_LEVEL
+  tested: 4  # FALSIFY-001/002/003/004 at PARTIAL_ALGORITHM_LEVEL
   status: partial
   evidence:
     rust_tests: crates/apr-cli/tests/falsification_crux_a_20.rs
@@ -237,6 +254,10 @@ verification_summary:
     - falsify-004: falsify_crux_a_20_algo_001_dry_run_offline_flag_accepted
     - falsify-004: falsify_crux_a_20_algo_001_dry_run_offline_is_deterministic
     - algo-005: falsify_crux_a_20_algo_005_default_offline_is_false
+    - falsify-003: pull_run_refuses_uncached_model_when_offline
+    - falsify-003: pull_dataset_refuses_listing_when_offline
+    - falsify-003: resolve_model_refuses_uncached_model_when_caller_forgot_the_flag
+    - falsify-003: import_step_refuses_download_when_offline
   scope_honesty: >
     FALSIFY-CRUX-A-20-001/002/004 are discharged at PARTIAL_ALGORITHM_LEVEL
     — the Rust harness proves the offline sub-claims (CLI flag / env var
@@ -245,8 +266,11 @@ verification_summary:
     sub-claims (strace-verified zero non-loopback TCP connect() syscalls,
     DNS suppression) remain TODO and require a separate strace-gated
     harness with a primed cache. FALSIFY-CRUX-A-20-003 (cache-miss hard
-    error) and FALSIFY-CRUX-A-20-005 (huggingface_hub byte parity) are
-    NOT yet discharged — both need cache-layer + real pull-path wiring.
+    error) is now discharged at command level on the real pull path — the
+    refusal is asserted for `pull`, `pull dataset`, `resolve_model`
+    (the `chat`/`run` entry) and the showcase import step — but its
+    strace half is still open. FALSIFY-CRUX-A-20-005 (huggingface_hub
+    byte parity) is NOT yet discharged; it needs cache-layer wiring.
     Contract stays `status: partial`.
 
 pmat_work_tracking:

--- a/crates/apr-cli/src/commands/chat.rs
+++ b/crates/apr-cli/src/commands/chat.rs
@@ -123,7 +123,11 @@ pub(crate) fn run(
         _ => hf_uri,
     };
     let model_source = crate::commands::run::ModelSource::parse(&fully_resolved_source)?;
-    let actual_path = crate::commands::run::resolve_model(&model_source, false, false)?;
+    // CRUX-A-20: this argument was a hardcoded `false`, which is why
+    // `apr --offline chat hf://org/repo` downloaded the model instead of
+    // refusing. Read the offline decision from the process-wide latch.
+    let offline = crate::commands::offline::network_forbidden();
+    let actual_path = crate::commands::run::resolve_model(&model_source, false, offline)?;
     let path = actual_path.as_path();
 
     // Validate file exists

--- a/crates/apr-cli/src/commands/offline.rs
+++ b/crates/apr-cli/src/commands/offline.rs
@@ -1,11 +1,19 @@
-//! Offline mode detection for `apr pull --offline` (CRUX-A-20).
+//! Offline mode detection and enforcement for `apr --offline` (CRUX-A-20).
 //!
 //! Contract: `contracts/crux-A-20-v1.yaml`.
 //!
-//! Pure classifier — takes the parsed `--offline` flag and a slice of
-//! environment variables, returns a `bool`. No I/O. Unit-testable offline.
-//! The actual network-gating behavior (zero TCP connects, cache-miss
-//! error messages) is discharged by a separate strace-gated harness.
+//! Two layers live here:
+//!
+//! 1. [`is_offline`] — a pure classifier over the parsed `--offline` flag and
+//!    an environment snapshot. No I/O, deterministic, unit-testable.
+//! 2. The **enforcement point** — [`latch`], [`scope`], [`network_forbidden`]
+//!    and [`guard`]. `--offline` used to be a per-command `bool` that each
+//!    command had to remember to forward to each download helper; three of
+//!    them (`pull`, `chat`, `showcase`) forgot, so the flag was inert and
+//!    `apr pull --offline hf://...` happily downloaded. A per-process latch
+//!    removes the forwarding step entirely: the flag is recorded once in
+//!    `execute_command`, and every outbound-network helper asks [`guard`].
+//!    Forgetting to plumb a parameter can no longer disarm the control.
 
 /// Environment variables that trigger offline mode. APR-native and
 /// HF-compatible. Both MUST be observationally equivalent to the
@@ -54,6 +62,76 @@ pub fn read_offline_env() -> Vec<(String, String)> {
         .iter()
         .filter_map(|k| std::env::var(k).ok().map(|v| ((*k).to_string(), v)))
         .collect()
+}
+
+/// Process-wide latch, set once from the parsed CLI in `execute_command`.
+/// Monotonic: it can only ever be turned ON, so no later code path can
+/// silently re-enable the network for a run the user asked to be offline.
+static PROCESS_OFFLINE: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+thread_local! {
+    /// Thread-scoped override used by [`scope`] so a command that receives
+    /// `offline` as a parameter (e.g. `pull::run`) feeds the very same
+    /// enforcement point without mutating global state — which also keeps
+    /// parallel unit tests isolated, since each test runs on its own thread.
+    static THREAD_OFFLINE: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+/// Record the process-wide offline decision. Only ever sets the latch.
+pub fn latch(cli_flag: bool) {
+    if cli_flag {
+        PROCESS_OFFLINE.store(true, std::sync::atomic::Ordering::SeqCst);
+    }
+}
+
+/// RAII guard returned by [`scope`]; restores the previous thread value.
+pub struct OfflineScope(bool);
+
+impl Drop for OfflineScope {
+    fn drop(&mut self) {
+        THREAD_OFFLINE.with(|c| c.set(self.0));
+    }
+}
+
+/// Force offline for the current thread until the returned guard drops.
+/// `scope(false)` is a no-op that still restores on drop.
+#[must_use]
+pub fn scope(on: bool) -> OfflineScope {
+    let previous = THREAD_OFFLINE.with(|c| {
+        let previous = c.get();
+        c.set(previous || on);
+        previous
+    });
+    OfflineScope(previous)
+}
+
+/// True iff outbound network I/O is forbidden for this call.
+///
+/// Reads the process latch, the thread scope, and the environment — so a
+/// command that never received the `--offline` parameter still cannot make
+/// a request. This is the property that makes the control structural.
+pub fn network_forbidden() -> bool {
+    if PROCESS_OFFLINE.load(std::sync::atomic::Ordering::SeqCst)
+        || THREAD_OFFLINE.with(std::cell::Cell::get)
+    {
+        return true;
+    }
+    let env = read_offline_env();
+    is_offline(false, env.iter().map(|(k, v)| (k.as_str(), v.as_str())))
+}
+
+/// The single enforcement point. Every helper that is about to perform
+/// outbound network I/O calls this first. `activity` completes the sentence
+/// "Cannot {activity} in --offline mode".
+pub fn guard(activity: &str) -> crate::error::Result<()> {
+    if network_forbidden() {
+        return Err(crate::error::CliError::NetworkError(format!(
+            "Cannot {activity} in --offline mode. \
+             Network access is disabled by --offline (or APR_OFFLINE=1 / \
+             HF_HUB_OFFLINE=1). Use an already-cached model or a local path."
+        )));
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -125,5 +203,315 @@ mod tests {
         let a = is_offline(false, [("HF_HUB_OFFLINE", "1")]);
         let b = is_offline(false, [("HF_HUB_OFFLINE", "1")]);
         assert_eq!(a, b);
+    }
+
+    // ---------------------------------------------------------------
+    // CRUX-A-20 enforcement. These assert the REFUSAL, not the shape:
+    // each one drives a real command entry point and requires it to come
+    // back with an error naming --offline mode. With the enforcement
+    // removed, each command instead reaches the network and returns some
+    // HTTP/DNS error (or, for `pull`, succeeds and writes to the cache),
+    // and every assertion below fails.
+    // ---------------------------------------------------------------
+
+    /// The scope must be an override, not a toggle: it can turn offline ON
+    /// and must restore the previous value when it drops.
+    #[test]
+    fn scope_forces_offline_then_restores() {
+        let baseline = network_forbidden();
+        {
+            let _s = scope(true);
+            assert!(network_forbidden(), "scope(true) must forbid the network");
+            assert!(guard("fetch x").is_err(), "guard must refuse inside scope");
+        }
+        assert_eq!(
+            network_forbidden(),
+            baseline,
+            "scope must restore the previous decision on drop"
+        );
+    }
+
+    /// `scope(false)` must not weaken an enclosing offline scope.
+    #[test]
+    fn inner_online_scope_cannot_re_enable_network() {
+        let _outer = scope(true);
+        let _inner = scope(false);
+        assert!(
+            network_forbidden(),
+            "an inner scope(false) must NOT re-enable the network"
+        );
+    }
+
+    /// The refusal must be a `NetworkError` naming `--offline mode`, so it
+    /// reads like `apr run --offline` and exits with the network exit code
+    /// rather than looking like a download failure.
+    #[test]
+    fn guard_error_names_offline_mode() {
+        let _s = scope(true);
+        let err = guard("download hf://org/repo").expect_err("must refuse");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("--offline mode"),
+            "refusal must name --offline mode, got: {msg}"
+        );
+        assert!(
+            matches!(err, crate::error::CliError::NetworkError(_)),
+            "refusal must be a NetworkError"
+        );
+    }
+
+    /// `apr pull --offline hf://org/repo` downloaded 3.9 MB and exited 0 in
+    /// v0.63.0: `pull::run` read its `offline` parameter only inside the
+    /// `--dry-run` branch. Drive `pull::run` with `offline = true` and
+    /// require a refusal. The repo name is deliberately nonexistent so the
+    /// pre-fix path fails on the HTTP status instead of downloading — that
+    /// error does not mention `--offline mode`, so this test is RED before
+    /// the fix and needs no network to be GREEN after it.
+    #[test]
+    fn pull_run_refuses_uncached_model_when_offline() {
+        let err = crate::commands::pull::run(
+            "hf://hf-internal-testing/apr-offline-falsifier-does-not-exist",
+            false,
+            false,
+            None,
+            true,
+        )
+        .expect_err("pull --offline must refuse an uncached model");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("--offline mode"),
+            "pull --offline must refuse before any network I/O, got: {msg}"
+        );
+    }
+
+    /// `apr pull dataset <repo> --offline` reached HuggingFace and returned
+    /// `HTTP 404 Not Found` in v0.63.0 — proof that the listing request went
+    /// out. The dataset lister goes through the same `hf_get` choke point.
+    #[test]
+    fn pull_dataset_refuses_listing_when_offline() {
+        let _s = scope(true);
+        let err = crate::commands::pull::run_dataset(
+            "hf-internal-testing/apr-offline-falsifier-does-not-exist",
+            &[],
+            None,
+            Some(std::path::Path::new("/nonexistent/apr-offline-falsifier")),
+            false,
+        )
+        .expect_err("pull dataset --offline must refuse");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("--offline mode"),
+            "dataset listing must be refused offline, got: {msg}"
+        );
+    }
+
+    /// `apr chat` passed a hardcoded `offline = false` into `resolve_model`
+    /// (chat.rs:126), so `apr --offline chat hf://org/repo` downloaded the
+    /// model. `resolve_model` now consults the enforcement point itself, so
+    /// the refusal no longer depends on any caller remembering to forward
+    /// the flag — which is what this asserts: `offline` is passed as
+    /// `false`, exactly as chat used to, and the model must STILL be refused.
+    #[test]
+    fn resolve_model_refuses_uncached_model_when_caller_forgot_the_flag() {
+        let _s = scope(true);
+        let source = crate::commands::run::ModelSource::parse(
+            "hf://hf-internal-testing/apr-offline-falsifier-does-not-exist",
+        )
+        .expect("parse hf uri");
+        let err = crate::commands::run::resolve_model(&source, false, false)
+            .expect_err("uncached model must be refused while offline");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("OFFLINE MODE"),
+            "resolve_model must refuse regardless of the caller's flag, got: {msg}"
+        );
+    }
+
+    /// The refusal must not claim something it cannot know.
+    ///
+    /// Enforcing `--offline` on the Hub API costs `apr run --offline
+    /// hf://org/repo` the ability to learn WHICH file a bare repo means — in
+    /// 0.63.0 that lookup went out over the network under `--offline`, and
+    /// the answer is what made the pacha cache probe possible. Offline,
+    /// `file` is therefore `None` and the cache — keyed on the full
+    /// `hf://org/repo/<file>` — cannot be probed, so "not cached" would be
+    /// an unsupported claim about a file that may well be sitting in it.
+    ///
+    /// Same repo, two URIs, two different truths: the bare form must say it
+    /// cannot resolve, and only the named-file form may say "not cached".
+    #[test]
+    fn bare_repo_refusal_does_not_claim_the_model_is_uncached() {
+        let _s = scope(true);
+
+        let bare = crate::commands::run::ModelSource::parse(
+            "hf://hf-internal-testing/apr-offline-falsifier-does-not-exist",
+        )
+        .expect("parse bare hf uri");
+        let bare_msg = crate::commands::run::resolve_model(&bare, false, true)
+            .expect_err("bare repo must be refused while offline")
+            .to_string();
+        assert!(
+            !bare_msg.contains("not cached"),
+            "a bare repo cannot be known to be uncached offline, got: {bare_msg}"
+        );
+        assert!(
+            bare_msg.contains("cannot resolve"),
+            "the bare-repo refusal must say resolution is what failed, got: {bare_msg}"
+        );
+
+        let named = crate::commands::run::ModelSource::parse(
+            "hf://hf-internal-testing/apr-offline-falsifier-does-not-exist/model.safetensors",
+        )
+        .expect("parse named hf uri");
+        let named_msg = crate::commands::run::resolve_model(&named, false, true)
+            .expect_err("named file must be refused while offline")
+            .to_string();
+        assert!(
+            named_msg.contains("not cached"),
+            "a named file IS probed in the cache, so this one may say so, got: {named_msg}"
+        );
+    }
+
+    /// The whole CLI path, parsed exactly as a user types it.
+    ///
+    /// `apr pull dataset R --offline` reached the Hub and returned
+    /// `HTTP 404 Not Found` in v0.63.0 — proof an outbound request went out
+    /// under a flag that forbids them. It is the branch furthest from the
+    /// flag: the dataset puller never enters `pull::run`, so no amount of
+    /// parameter-threading inside `pull` would have covered it.
+    ///
+    /// `--offline` is declared twice — once as a clap global on `Cli` and
+    /// once on the `Pull` variant — and clap populates BOTH, which this
+    /// asserts so a future refactor that drops either one is caught here
+    /// rather than by a silent download.
+    ///
+    /// The repo does not exist, so without enforcement this reaches the Hub
+    /// and comes back with an HTTP status error — which does not name
+    /// `--offline mode`, making this RED before the fix and needing no
+    /// network to be GREEN after it.
+    #[test]
+    fn pull_dataset_subcommand_flag_is_enforced_end_to_end() {
+        // The dispatcher matches over the whole `Commands` enum in one frame,
+        // which does not fit a 2 MiB test thread. `main` gets 8 MiB, so give
+        // this the same room rather than testing a smaller stack than
+        // production uses.
+        std::thread::Builder::new()
+            .stack_size(16 * 1024 * 1024)
+            .spawn(pull_dataset_offline_body)
+            .expect("spawn")
+            .join()
+            .expect("dataset offline falsifier panicked");
+    }
+
+    fn pull_dataset_offline_body() {
+        use clap::Parser;
+
+        let cli = crate::Cli::parse_from([
+            "apr",
+            "pull",
+            "dataset",
+            "hf-internal-testing/apr-offline-falsifier-does-not-exist",
+            "--offline",
+        ]);
+
+        // Both carriers of the flag must be populated — the enforcement reads
+        // the global (via the latch in `execute_command`) and the variant (via
+        // the scope armed in `dispatch_model_commands`), so losing either one
+        // would silently narrow the control.
+        assert!(cli.offline, "the clap global --offline must be set");
+        assert!(
+            matches!(*cli.command, crate::Commands::Pull { offline: true, .. }),
+            "the flag must also land on the Pull variant"
+        );
+
+        // Enter through the real dispatcher rather than `execute_command`:
+        // the latch is a process-wide static and this test shares its process
+        // with ~6 600 others, several of which do reach the network.
+        // `dispatch_model_commands` is the frame that arms the scope for all
+        // three `pull` branches, so it is the narrowest entry that still
+        // proves the flag travels from `clap` to the refusal. The
+        // `execute_command` half — the latch itself — is covered by
+        // `latch_survives_into_a_command_that_never_receives_the_flag`.
+        let err = crate::dispatch_model_commands(&cli)
+            .expect("pull must be handled by the model dispatcher")
+            .expect_err("apr pull dataset --offline must refuse");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("--offline mode"),
+            "apr pull dataset --offline must refuse before any network I/O, got: {msg}"
+        );
+    }
+
+    /// `apr --offline chat hf://org/repo` downloaded 478 440 bytes into an
+    /// empty cache in v0.63.0: `chat` has no `--offline` of its own, so the
+    /// only carrier is the clap global, and `chat.rs` passed a hardcoded
+    /// `false` into `resolve_model`. This is the half of the plumbing the
+    /// dispatcher-level test above cannot see — that `execute_command`
+    /// latches `cli.offline` for a command that never receives it as a
+    /// parameter.
+    ///
+    /// The latch is a process-wide static and cannot be un-set, so setting it
+    /// in-process would force every other test in this binary offline (five
+    /// `pull` companion tests do real HTTP and go red). It therefore runs in
+    /// a child process: this same test binary, re-invoked with a filter and
+    /// `APR_OFFLINE_LATCH_CHILD=1`, which takes the branch below.
+    ///
+    /// The repo does not exist, so without the fix the child reaches the Hub
+    /// and prints a download/HTTP failure that says nothing about offline
+    /// mode — RED before the fix, and GREEN after it without a network.
+    #[test]
+    fn latch_survives_into_a_command_that_never_receives_the_flag() {
+        const CHILD_ENV: &str = "APR_OFFLINE_LATCH_CHILD";
+        const TEST_PATH: &str =
+            "commands::offline::tests::latch_survives_into_a_command_that_never_receives_the_flag";
+
+        if std::env::var(CHILD_ENV).is_ok() {
+            child_runs_offline_chat();
+            return;
+        }
+
+        let exe = std::env::current_exe().expect("current test binary");
+        let out = std::process::Command::new(exe)
+            .args(["--exact", TEST_PATH, "--nocapture", "--test-threads=1"])
+            .env(CHILD_ENV, "1")
+            .output()
+            .expect("re-run this test binary as a child");
+        let combined = format!(
+            "{}{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+        assert!(
+            combined.contains("OFFLINE-REFUSAL:"),
+            "child did not reach the refusal at all; output was:\n{combined}"
+        );
+        assert!(
+            combined.to_ascii_lowercase().contains("offline mode"),
+            "apr --offline chat must be refused without any download, got:\n{combined}"
+        );
+    }
+
+    fn child_runs_offline_chat() {
+        std::thread::Builder::new()
+            .stack_size(16 * 1024 * 1024)
+            .spawn(|| {
+                use clap::Parser;
+
+                let cli = crate::Cli::parse_from([
+                    "apr",
+                    "--offline",
+                    "chat",
+                    "hf://hf-internal-testing/apr-offline-falsifier-does-not-exist",
+                ]);
+                assert!(cli.offline, "the clap global --offline must be set");
+
+                // `dispatch_run.rs` is include!()d into the crate root.
+                let err = crate::execute_command(&cli)
+                    .expect_err("apr --offline chat must refuse an uncached model");
+                println!("OFFLINE-REFUSAL: {err}");
+            })
+            .expect("spawn")
+            .join()
+            .expect("offline chat falsifier panicked");
     }
 }

--- a/crates/apr-cli/src/commands/pull.rs
+++ b/crates/apr-cli/src/commands/pull.rs
@@ -69,6 +69,19 @@ pub fn run(
         return run_dry_run(model_ref, revision, offline);
     }
 
+    // CRUX-A-20: the `offline` parameter used to be read ONLY inside the
+    // `dry_run` branch above, so `apr pull --offline hf://org/repo` performed
+    // a full download and exited 0 — a compliance control that controlled
+    // nothing. Feed it into the same enforcement point every download helper
+    // consults; `hf_get` then refuses every outbound request.
+    //
+    // A cache hit still succeeds offline when the URI names the file
+    // (`hf://org/repo/model.safetensors` → `run_single_file_streaming` returns
+    // from the cache before any request). A bare `hf://org/repo` cannot: the
+    // filename is only knowable from the Hub API, so offline it is refused
+    // rather than guessed.
+    let _offline_scope = super::offline::scope(offline);
+
     // GH-213: Resolve HuggingFace URI — detect single vs sharded models
     let resolved = resolve_hf_model(model_ref)?;
 
@@ -237,6 +250,10 @@ fn download_single_model(
     fetcher: &mut ModelFetcher,
     model_ref: &str,
 ) -> Result<pacha::fetcher::FetchResult> {
+    // CRUX-A-20: the pacha fetcher opens its own sockets, so it does not pass
+    // through `hf_get`. The cache-hit path above already returned, so reaching
+    // here means a real download is about to start.
+    super::offline::guard(&format!("download {model_ref}"))?;
     println!();
     println!("{}", "Downloading...".yellow());
 

--- a/crates/apr-cli/src/commands/pull_dataset.rs
+++ b/crates/apr-cli/src/commands/pull_dataset.rs
@@ -133,7 +133,7 @@ fn list_dataset_repo_files(repo: &str, revision: &str) -> Result<Vec<String>> {
     let mut paths = Vec::new();
     let mut next_url: Option<String> = Some(initial_url.clone());
     while let Some(url) = next_url.take() {
-        let response = hf_get(&url).call().map_err(|e| match &e {
+        let response = hf_get(&url)?.call().map_err(|e| match &e {
             ureq::Error::Status(404, _) => CliError::HttpNotFound(format!(
                 "Dataset {repo} not found at revision {revision}"
             )),

--- a/crates/apr-cli/src/commands/pull_extract_shard.rs
+++ b/crates/apr-cli/src/commands/pull_extract_shard.rs
@@ -70,13 +70,21 @@ fn resolve_hf_token() -> Option<String> {
 }
 
 /// Build an authenticated ureq request if HF token is available.
-fn hf_get(url: &str) -> ureq::Request {
+///
+/// CRUX-A-20: this is the single place every HuggingFace request in the
+/// `pull` family (model API lookup, single-file streaming, shard index,
+/// dataset listing, dataset file download) is constructed, so it is where
+/// `--offline` is enforced. Returning `Result` rather than a bare `Request`
+/// is deliberate: a future call site cannot reach the network without first
+/// acknowledging that the request may be refused.
+fn hf_get(url: &str) -> Result<ureq::Request> {
+    crate::commands::offline::guard(&format!("fetch {url}"))?;
     let req = ureq::get(url);
-    if let Some(token) = resolve_hf_token() {
+    Ok(if let Some(token) = resolve_hf_token() {
         req.set("Authorization", &format!("Bearer {token}"))
     } else {
         req
-    }
+    })
 }
 
 /// GH-355: Format a user-friendly error for HTTP 401 from HuggingFace gated models.
@@ -102,7 +110,7 @@ fn format_gated_model_error_inner(url: &str, has_token: bool) -> String {
 }
 
 fn download_file(url: &str, path: &Path) -> Result<()> {
-    let response = hf_get(url).call().map_err(|e| match &e {
+    let response = hf_get(url)?.call().map_err(|e| match &e {
         ureq::Error::Status(404, _) => {
             CliError::HttpNotFound(format!("HTTP 404: {url}"))
         }
@@ -124,7 +132,7 @@ fn download_file(url: &str, path: &Path) -> Result<()> {
 /// Returns a `FileChecksum` with the downloaded size and BLAKE3 hash.
 /// Verifies that downloaded bytes match Content-Length when available.
 fn download_file_with_progress(url: &str, path: &Path) -> Result<FileChecksum> {
-    let response = hf_get(url).call().map_err(|e| match &e {
+    let response = hf_get(url)?.call().map_err(|e| match &e {
         ureq::Error::Status(401, _) => {
             CliError::NetworkError(format_gated_model_error(url))
         }

--- a/crates/apr-cli/src/commands/pull_gh355_356_357.rs
+++ b/crates/apr-cli/src/commands/pull_gh355_356_357.rs
@@ -81,8 +81,11 @@
         std::env::set_var("HF_TOKEN", "hf_test_auth");
 
         // hf_get returns a ureq::Request — we can't inspect headers directly,
-        // but we can verify it doesn't panic with a token set
-        let _req = hf_get("https://example.com/test");
+        // but we can verify it doesn't panic with a token set.
+        // CRUX-A-20: hf_get now returns Result (it refuses while offline);
+        // discard it rather than unwrap, so this stays a panic check and does
+        // not start failing under APR_OFFLINE=1.
+        let _ = hf_get("https://example.com/test");
 
         match saved {
             Some(t) => std::env::set_var("HF_TOKEN", t),
@@ -96,7 +99,7 @@
         let saved = std::env::var("HF_TOKEN").ok();
         std::env::remove_var("HF_TOKEN");
 
-        let _req = hf_get("https://example.com/test");
+        let _ = hf_get("https://example.com/test");
 
         if let Some(t) = saved {
             std::env::set_var("HF_TOKEN", t);

--- a/crates/apr-cli/src/commands/pull_remove_resolve_model.rs
+++ b/crates/apr-cli/src/commands/pull_remove_resolve_model.rs
@@ -125,7 +125,7 @@ fn fetch_safetensors_companions(model_path: &Path, resolved_uri: &str) -> Result
         );
 
         // GH-355: Use hf_get() for auth — ureq::get() bypassed gated model tokens
-        match hf_get(&url).call() {
+        match hf_get(&url)?.call() {
             Ok(response) => {
                 let mut body = Vec::new();
                 response.into_reader().read_to_end(&mut body).map_err(|e| {
@@ -298,7 +298,7 @@ fn select_best_gguf(gguf_files: &[&str], org: &str, repo: &str) -> ResolvedModel
 fn resolve_sharded_safetensors(org: &str, repo: &str) -> Result<ResolvedModel> {
     let index_url =
         format!("https://huggingface.co/{org}/{repo}/resolve/main/model.safetensors.index.json");
-    let index_response = hf_get(&index_url)
+    let index_response = hf_get(&index_url)?
         .call()
         .map_err(|e| CliError::NetworkError(format!("Failed to download model index: {e}")))?;
 
@@ -375,7 +375,7 @@ pub(crate) fn resolve_hf_model(uri: &str) -> Result<ResolvedModel> {
     let repo = parts[1];
 
     let api_url = format!("https://huggingface.co/api/models/{org}/{repo}");
-    let response = hf_get(&api_url).call().map_err(|e| match &e {
+    let response = hf_get(&api_url)?.call().map_err(|e| match &e {
         ureq::Error::Status(401, _) => {
             CliError::NetworkError(format_gated_model_error(&api_url))
         }

--- a/crates/apr-cli/src/commands/run.rs
+++ b/crates/apr-cli/src/commands/run.rs
@@ -291,6 +291,11 @@ pub(crate) fn run_model(source: &str, options: &RunOptions) -> Result<RunResult>
 ///
 /// Per Section 9.2 (Sovereign AI): "apr run --offline is mandatory for production"
 pub(crate) fn resolve_model(source: &ModelSource, force: bool, offline: bool) -> Result<PathBuf> {
+    // CRUX-A-20: `chat` called this with a hardcoded `offline = false`, so
+    // `apr --offline chat hf://org/repo` downloaded the model. Consult the
+    // process-wide offline latch as well as the parameter, so a caller that
+    // forgets to forward the flag cannot re-enable the network.
+    let offline = offline || crate::commands::offline::network_forbidden();
     match source {
         ModelSource::Local(path) => Ok(path.clone()),
         ModelSource::HuggingFace { org, repo, file } => {
@@ -303,7 +308,24 @@ pub(crate) fn resolve_model(source: &ModelSource, force: bool, offline: bool) ->
             }
 
             if offline {
-                // OFFLINE MODE: Reject any network access attempt
+                // OFFLINE MODE: Reject any network access attempt.
+                //
+                // CRUX-A-20: a BARE `hf://org/repo` gets a different message,
+                // because "not cached" would be a claim we cannot support. The
+                // caller reached here having asked the Hub API which file the
+                // repo means (`run_model` → `resolve_hf_model`) and been
+                // refused, so `file` is None and the pacha cache — keyed on the
+                // full `hf://org/repo/<file>` — cannot be probed at all. The
+                // file may well be cached under a name we cannot name.
+                if file.is_none() {
+                    return Err(CliError::ValidationFailed(format!(
+                        "OFFLINE MODE: cannot resolve hf://{org}/{repo} to a file. \
+                         Which file a bare repo means is only knowable from the \
+                         HuggingFace API, and network access is disabled. Name the \
+                         file (e.g. hf://{org}/{repo}/model.safetensors), pass a \
+                         local path, or cache it first with: apr import hf://{org}/{repo}"
+                    )));
+                }
                 return Err(CliError::ValidationFailed(format!(
                     "OFFLINE MODE: Model hf://{org}/{repo} not cached. \
                      Network access is disabled. Cache the model first with: \

--- a/crates/apr-cli/src/commands/showcase/pipeline.rs
+++ b/crates/apr-cli/src/commands/showcase/pipeline.rs
@@ -26,6 +26,17 @@ pub(super) fn run_import(config: &ShowcaseConfig) -> Result<bool> {
         return Ok(true);
     }
 
+    // CRUX-A-20: `apr showcase --step import --offline` downloaded 491 MB —
+    // the dispatcher never forwarded `--offline` and this step never asked.
+    // The download is a `huggingface-cli` subprocess, so it bypasses every
+    // in-process HTTP helper; ask the enforcement point directly. Placed
+    // after the `gguf_path.exists()` check so an already-imported model is
+    // still usable offline.
+    crate::commands::offline::guard(&format!(
+        "download {} from HuggingFace",
+        config.tier.model_path()
+    ))?;
+
     // Ensure model directory exists
     std::fs::create_dir_all(&config.model_dir)
         .map_err(|e| CliError::ValidationFailed(format!("Failed to create model dir: {e}")))?;
@@ -487,4 +498,41 @@ pub(super) fn run_apr_inference(config: &ShowcaseConfig) -> Result<bool> {
     }
 
     Ok(true)
+}
+
+#[cfg(test)]
+mod offline_enforcement_tests {
+    use super::*;
+    use crate::commands::offline;
+
+    /// `apr showcase --step import --offline` downloaded 491 MB in v0.63.0:
+    /// `dispatch_analysis.rs` never bound or forwarded `offline`, and the
+    /// import step shells out to `huggingface-cli`, so it bypassed every
+    /// in-process HTTP helper. `run_import` now asks the enforcement point
+    /// directly, so the missing dispatcher plumbing can no longer disarm it.
+    ///
+    /// Asserts the refusal, not the shape: without the guard this call
+    /// spawns `huggingface-cli` and returns `Ok`, so the assertion fails.
+    #[test]
+    fn import_step_refuses_download_when_offline() {
+        let dir = std::env::temp_dir().join("apr-showcase-offline-falsifier");
+        std::fs::remove_dir_all(&dir).ok();
+        let config = ShowcaseConfig {
+            tier: ModelTier::Tiny,
+            model_dir: dir.clone(),
+            ..Default::default()
+        };
+
+        let _s = offline::scope(true);
+        let err = run_import(&config).expect_err("showcase import must refuse while offline");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("--offline mode"),
+            "showcase import must be refused offline, got: {msg}"
+        );
+        assert!(
+            !dir.exists(),
+            "showcase import must not create the model dir while offline"
+        );
+    }
 }

--- a/crates/apr-cli/src/dispatch.rs
+++ b/crates/apr-cli/src/dispatch.rs
@@ -816,6 +816,12 @@ fn dispatch_model_commands(cli: &Cli) -> Option<Result<(), CliError>> {
             output,
             verify,
         } => {
+            // CRUX-A-20: `pull` declares its OWN `--offline` in addition to the
+            // clap global, and the dataset / `--verify` branches below never
+            // enter `pull::run`. Arm the enforcement scope here, around all
+            // three branches, from the variant's own flag — so the refusal does
+            // not depend on clap continuing to populate the global as well.
+            let _offline_scope = crate::commands::offline::scope(*offline);
             // SHIP-TWO-001 §26.8: when first positional is the literal
             // "dataset", treat the second positional as the HF dataset
             // repo and dispatch to the dataset puller. Otherwise fall

--- a/crates/apr-cli/src/dispatch_run.rs
+++ b/crates/apr-cli/src/dispatch_run.rs
@@ -332,6 +332,12 @@ fn dispatch_rosetta(action: &RosettaCommands, global_json: bool) -> Result<(), C
 /// Execute the CLI command and return the result.
 pub fn execute_command(cli: &Cli) -> Result<(), CliError> {
     contract_pre_contract_gate_enforcement!();
+    // CRUX-A-20: record `--offline` once, here, for the whole process. Every
+    // outbound-network helper consults `commands::offline::guard`, so no
+    // command can disarm the control by forgetting to forward a parameter.
+    // `--offline` is a clap global, so it is seen in either position
+    // (`apr --offline pull ...` and `apr pull --offline ...`).
+    crate::commands::offline::latch(cli.offline);
     // PMAT-237: Contract gate — refuse to operate on corrupt models
     if !cli.skip_contract {
         let paths = extract_model_paths(&cli.command);


### PR DESCRIPTION
`apr pull --offline hf://...` downloaded the model and exited 0. So did
`apr --offline pull ...`, `APR_OFFLINE=1 apr pull ...` and
`apr --offline chat hf://...`. The Sovereign-AI network-isolation control
did not isolate anything on those paths.

Measured against `cargo install aprender` 0.63.0, each run given a fresh
empty HOME so the byte count is the download:

  $ APR=<0.63.0 from crates.io>; export HOME=<fresh empty dir>
  $ "$APR" pull hf://hf-internal-testing/tiny-random-gpt2 --offline
  Downloading (streaming)...
   11% 20% 31% 40% 50% 61% 70% 81% 90% 100%
  ✓ Downloaded successfully
    Size: 443.2 KB
  exit=0                       # 488745 bytes now in the "offline" cache

  $ "$APR" --offline chat hf://hf-internal-testing/tiny-random-gpt2
  Loading model...
  Loaded SafeTensors format in 0.00s (0.5 MB)
  exit=4                       # 478440 bytes downloaded first

  $ "$APR" pull dataset hf-internal-testing/dataset_dict --offline
  error: HTTP 404 Not Found: Dataset ... not found at revision main
  exit=11                      # a 404 is proof the request went out

Same six commands on a binary built from this commit, same fresh HOMEs,
all now 4096 bytes (the empty directory) and non-zero exits:

  $ apr pull hf://hf-internal-testing/tiny-random-gpt2 --offline
  error: Network error: Cannot fetch
  https://huggingface.co/api/models/hf-internal-testing/tiny-random-gpt2
  in --offline mode. ...
  exit=10

Root cause is not one missing check, it is that `--offline` was a `bool`
each command had to carry by hand to each download helper, and three
commands dropped it:

- crates/apr-cli/src/commands/pull.rs:69 — `offline` was read only inside
  the `if dry_run` branch; the real pull path never looked at it again.
- crates/apr-cli/src/commands/chat.rs:126 — `resolve_model(&src, false,
  false)`, a hardcoded `false` in the offline position.
- crates/apr-cli/src/dispatch_analysis.rs:1498 — the `Showcase` destructure
  binds ten fields and not `offline`, and never consults `cli.offline`
  either, so `apr showcase --step import --offline` shelled out to
  `huggingface-cli` and pulled 491 MB.

Adding three more checks would leave the same hole open for the fourth
caller, so the flag stops being a parameter. `execute_command` latches it
once into `commands::offline`, `dispatch_model_commands` also arms it from
`pull`'s own subcommand-local `--offline`, and every outbound-network
helper asks `offline::guard()` before it opens a socket:

- `hf_get` (pull_extract_shard.rs) now returns `Result<ureq::Request>` and
  guards. It is the single constructor for every HuggingFace request in the
  `pull` family — API lookup, file streaming, shard index, dataset listing,
  dataset download — so all five inherit the refusal. Returning `Result`
  makes a future call site acknowledge the refusal at compile time.
- `download_single_model` guards the pacha fetcher, which opens its own
  sockets and so does not pass through `hf_get`.
- `showcase::pipeline::run_import` guards its `huggingface-cli` subprocess.
- `run::resolve_model` ORs the latch into its `offline` parameter, so
  `chat`'s hardcoded `false` can no longer re-enable the network.

An already-cached model still resolves offline when the URI names the file:

  $ apr pull hf://hf-internal-testing/tiny-random-gpt2/model.safetensors --offline
  ✓ Model already cached
  exit=0

A bare `hf://org/repo` cannot, and that costs something worth stating
plainly. `apr run --offline hf://org/repo` used to reach a warm cache — by
asking the Hub API which file the repo means, which is itself the request
`--offline` forbids. That lookup is now refused, so `file` is `None`, and
the pacha cache is keyed on the full `hf://org/repo/<file>` and cannot be
probed. The old "Model ... not cached" would then be a claim about a file
we cannot name, so the bare form gets its own message pointing at the
remedy, which was verified to work on the warm cache with zero bytes over
the network:

  error: OFFLINE MODE: cannot resolve hf://org/repo to a file. Which file a
  bare repo means is only knowable from the HuggingFace API, and network
  access is disabled. Name the file (e.g. hf://org/repo/model.safetensors),
  pass a local path, or cache it first with: apr import hf://org/repo

Falsifiers in crates/apr-cli/src/commands/offline.rs and
showcase/pipeline.rs drive the real entry points and require the refusal —
`pull::run`, `pull::run_dataset`, `resolve_model` called the way `chat`
called it, `run_import`, `dispatch_model_commands` for `apr pull dataset
--offline`, and `execute_command` for `apr --offline chat`. The last one
runs in a child process: the latch is a process-wide static that cannot be
un-set, so setting it in-process forces every other test in the binary
offline and five `pull` companion tests that do real HTTP go red. Each
falsifier names a repo that does not exist, so without the fix it reaches
the Hub and returns an HTTP error that says nothing about offline mode —
red before, green after, and no network needed to pass.

Mutation check — reverting the eight enforcement sites and keeping the
tests:

  test commands::offline::tests::pull_dataset_refuses_listing_when_offline ... FAILED
  test commands::offline::tests::pull_dataset_subcommand_flag_is_enforced_end_to_end ... FAILED
  test commands::offline::tests::pull_run_refuses_uncached_model_when_offline ... FAILED
  test commands::offline::tests::resolve_model_refuses_uncached_model_when_caller_forgot_the_flag ... FAILED
  test commands::offline::tests::latch_survives_into_a_command_that_never_receives_the_flag ... FAILED
  test commands::showcase::pipeline::offline_enforcement_tests::import_step_refuses_download_when_offline ... FAILED

  pull --offline must refuse before any network I/O, got: Network error:
  Failed to query HuggingFace API:
  https://huggingface.co/api/models/hf-internal-testing/apr-offline-falsifier-does-not-exist:
  status code 404

  dataset listing must be refused offline, got: HTTP 404 Not Found: Dataset
  hf-internal-testing/apr-offline-falsifier-does-not-exist not found at
  revision main

The showcase falsifier reproduced the original defect while mutated: it
spawned `huggingface-cli` and left 469 MB in /tmp before the assertion
tripped. And reverting the bare-repo message alone:

  test commands::offline::tests::bare_repo_refusal_does_not_claim_the_model_is_uncached ... FAILED
  a bare repo cannot be known to be uncached offline, got: Validation
  failed: OFFLINE MODE: Model hf://... not cached.

Restored: 6637 passed, 0 failed.

contracts/crux-A-20-v1.yaml FALSIFY-CRUX-A-20-003 moves from "not
discharged" to PARTIAL_ALGORITHM_LEVEL — the cache-miss hard error is now
proven on the real pull path. Its strace half (zero non-loopback connects)
and FALSIFY-005 byte parity stay open; the contract stays `status: partial`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Fixes #2379

Audit epic: #2373
