### PR TITLE
fix(rosetta): every verdict apr rosetta printed was unfalsifiable — compare-inference, fingerprint and verify all exited 0 no matter what

### DIFF
--- a/crates/apr-cli/src/commands/fingerprints.rs
+++ b/crates/apr-cli/src/commands/fingerprints.rs
@@ -201,14 +201,34 @@ fn print_diff_row(
     );
 }
 
+/// Anomaly `field` marker for a tensor of model A that has no counterpart in B.
+const FIELD_MISSING_IN_B: &str = "missing_in_b";
+/// Anomaly `field` marker for a tensor of model B that has no counterpart in A.
+const FIELD_MISSING_IN_A: &str = "missing_in_a";
+
+/// Count anomalies of a given `field` kind.
+fn count_field(anomalies: &[StatisticalAnomaly], field: &str) -> usize {
+    anomalies.iter().filter(|a| a.field == field).count()
+}
+
 /// Print the diff summary (JSON or text).
+// serde_json::json!() macro uses infallible unwrap internally
+#[allow(clippy::disallowed_methods)]
 fn print_diff_summary(total: usize, anomalies: &[StatisticalAnomaly], json: bool) {
+    let missing_in_b = count_field(anomalies, FIELD_MISSING_IN_B);
+    let missing_in_a = count_field(anomalies, FIELD_MISSING_IN_A);
+
     if json {
-        println!("{{");
-        println!("  \"total_tensors\": {},", total);
-        println!("  \"anomalies\": {},", anomalies.len());
-        println!("  \"passed\": {}", anomalies.is_empty());
-        println!("}}");
+        println!(
+            "{:#}",
+            serde_json::json!({
+                "total_tensors": total,
+                "anomalies": anomalies.len(),
+                "missing_in_b": missing_in_b,
+                "missing_in_a": missing_in_a,
+                "passed": anomalies.is_empty(),
+            })
+        );
     } else if anomalies.is_empty() {
         println!(
             "║ {} ║",
@@ -217,10 +237,26 @@ fn print_diff_summary(total: usize, anomalies: &[StatisticalAnomaly], json: bool
     } else {
         println!(
             "║ {} ║",
-            format!("✗ {} ANOMALIES DETECTED", anomalies.len())
-                .red()
-                .bold()
+            format!(
+                "✗ {} ANOMALIES DETECTED ({} missing in B, {} missing in A)",
+                anomalies.len(),
+                missing_in_b,
+                missing_in_a
+            )
+            .red()
+            .bold()
         );
+    }
+}
+
+/// Build an anomaly for a tensor present in one model and absent from the other.
+fn missing_tensor_anomaly(name: &str, field: &'static str) -> StatisticalAnomaly {
+    StatisticalAnomaly {
+        tensor: name.to_string(),
+        field: field.to_string(),
+        expected: 0.0,
+        actual: 0.0,
+        deviation_sigma: f32::INFINITY,
     }
 }
 
@@ -251,9 +287,15 @@ fn print_fingerprint_diff(
         );
     }
 
+    let mut matched_in_b: std::collections::HashSet<String> = std::collections::HashSet::new();
+
     for fp_a in fps_a {
         let norm_name_a = normalize_tensor_name(&fp_a.name);
         let Some(fp_b) = map_b.get(&norm_name_a) else {
+            // A tensor that model B does not have at all is the maximum possible
+            // anomaly. It used to be printed and then dropped on the floor, so a
+            // diff where every tensor was missing still reported "No statistical
+            // anomalies detected" / "passed": true and exited 0.
             if !json {
                 println!(
                     "║ {} {:<72} ║",
@@ -262,8 +304,10 @@ fn print_fingerprint_diff(
                 );
                 println!("║   Missing in Model B ║");
             }
+            anomalies.push(missing_tensor_anomaly(&fp_a.name, FIELD_MISSING_IN_B));
             continue;
         };
+        matched_in_b.insert(norm_name_a);
 
         let (mean_diff, has_anomaly) = fingerprint_anomaly(fp_a, fp_b);
 
@@ -283,8 +327,35 @@ fn print_fingerprint_diff(
         }
     }
 
+    // Tensors that exist only in model B are just as much a difference as tensors
+    // that exist only in model A; the walker above can never see them.
+    for fp_b in fps_b {
+        let norm_name_b = normalize_tensor_name(&fp_b.name);
+        if !matched_in_b.contains(&norm_name_b) {
+            if !json {
+                println!(
+                    "║ {} {:<72} ║",
+                    "+".red(),
+                    truncate_path(fp_b.name.clone(), 72)
+                );
+                println!("║   Missing in Model A ║");
+            }
+            anomalies.push(missing_tensor_anomaly(&fp_b.name, FIELD_MISSING_IN_A));
+        }
+    }
+
     print_diff_summary(fps_a.len(), &anomalies, json);
-    Ok(())
+
+    if anomalies.is_empty() {
+        return Ok(());
+    }
+    Err(CliError::ValidationFailed(format!(
+        "{} statistical anomalies detected between the two models \
+         ({} tensors missing in B, {} missing in A)",
+        anomalies.len(),
+        count_field(&anomalies, FIELD_MISSING_IN_B),
+        count_field(&anomalies, FIELD_MISSING_IN_A),
+    )))
 }
 
 /// Convert fingerprints to JSON

--- a/crates/apr-cli/src/commands/inference.rs
+++ b/crates/apr-cli/src/commands/inference.rs
@@ -38,6 +38,8 @@ pub fn run_verify(source: &Path, intermediate: &str, tolerance: f32, json: bool)
         .verify_roundtrip(source, intermediate_format)
         .map_err(|e| CliError::ValidationFailed(format!("Verification failed: {e}")))?;
 
+    let passed = report.passes_with_tolerance(tolerance);
+
     if json {
         print_verification_json(&report);
     } else {
@@ -56,14 +58,34 @@ pub fn run_verify(source: &Path, intermediate: &str, tolerance: f32, json: bool)
         }
 
         println!();
-        if report.passes_with_tolerance(tolerance) {
+        if passed {
             println!("{}", "Round-trip verification PASSED".green().bold());
         } else {
             println!("{}", "Round-trip verification FAILED".red().bold());
         }
     }
 
-    Ok(())
+    verify_outcome(&report, tolerance)
+}
+
+/// Turn a round-trip verification report into the command's exit status.
+///
+/// A verification command that prints "Round-trip verification FAILED" must not
+/// exit 0: a `set -e` pipeline would otherwise treat a broken round-trip as a pass,
+/// and the exit status of `rosetta verify` would carry no information at all.
+fn verify_outcome(report: &VerificationReport, tolerance: f32) -> Result<()> {
+    if report.passes_with_tolerance(tolerance) {
+        return Ok(());
+    }
+    let detail = if report.failed_tensors.is_empty() {
+        String::new()
+    } else {
+        format!(" Failed tensors: {}.", report.failed_tensors.join(", "))
+    };
+    Err(CliError::ValidationFailed(format!(
+        "Round-trip verification FAILED: is_equivalent={}, max_diff={:.2e} exceeds tolerance {:.2e}.{}",
+        report.is_equivalent, report.max_diff, tolerance, detail
+    )))
 }
 
 /// Print the header box for inference comparison report
@@ -99,6 +121,20 @@ fn print_compare_header(model_a: &Path, model_b: &Path, prompt: &str) {
     );
 }
 
+/// Did the inference comparison pass?
+///
+/// A run that compared zero token pairs never passes: `passed` must not be derived
+/// from `mismatches == 0` when there was nothing to mismatch. That is how
+/// `compare-inference` used to report `"passed": true` / "MATCH (100%)" for two
+/// models that produced completely different text.
+fn compare_passed(total_tokens: usize, mismatches: usize, tolerance: f32) -> bool {
+    if total_tokens == 0 {
+        return false;
+    }
+    let match_rate = 1.0 - (mismatches as f32 / total_tokens as f32);
+    mismatches == 0 || (1.0 - match_rate) <= tolerance
+}
+
 /// Print JSON output for inference comparison
 #[allow(clippy::too_many_arguments)]
 fn print_compare_json(
@@ -117,6 +153,8 @@ fn print_compare_json(
         0.0
     };
 
+    let passed = compare_passed(total_tokens, mismatches, tolerance);
+
     println!("{{");
     println!("  \"model_a\": \"{}\",", model_a.display());
     println!("  \"model_b\": \"{}\",", model_b.display());
@@ -126,14 +164,17 @@ fn print_compare_json(
     println!("  \"match_rate\": {:.4},", match_rate);
     println!("  \"text_a\": {:?},", text_a);
     println!("  \"text_b\": {:?},", text_b);
-    println!(
-        "  \"passed\": {}",
-        mismatches == 0 || (1.0 - match_rate as f32) <= tolerance
-    );
+    println!("  \"passed\": {}", passed);
     println!("}}");
 }
 
 /// Validate that tokens were captured from both models (GH-188)
+///
+/// Called only when zero token pairs were captured. Every path here is a failure:
+/// a comparison that compared nothing is vacuous, not successful. Previously the
+/// function returned `Ok(())` whenever both models happened to emit *some* text,
+/// which let `compare-inference` report "INFERENCE MATCH (100%)" and exit 0 while
+/// the two models had produced completely different output.
 fn validate_captured_tokens(text_a: &str, text_b: &str) -> Result<()> {
     let a_empty = text_a.is_empty() || text_a.contains("tok/s");
     let b_empty = text_b.is_empty() || text_b.contains("tok/s");
@@ -154,7 +195,13 @@ fn validate_captured_tokens(text_a: &str, text_b: &str) -> Result<()> {
             text_a
         )));
     }
-    Ok(())
+    Err(CliError::ValidationFailed(format!(
+        "VACUOUS COMPARISON: 0 token pairs were captured, so no tokens were compared. \
+         The verification is vacuous, not successful. \
+         Both models emitted text (A: {:?}, B: {:?}) but APR_TRACE_LOGITS produced no \
+         per-token logits to compare.",
+        text_a, text_b
+    )))
 }
 
 /// Run the rosetta compare-inference subcommand (PMAT-114)

--- a/crates/apr-cli/src/commands/inference_result.rs
+++ b/crates/apr-cli/src/commands/inference_result.rs
@@ -389,11 +389,31 @@ fn print_conversion_summary(report: &ConversionReport) {
     }
 }
 
+/// RFC 8259 has no `inf`/`nan` literal, so a hand-rolled `{}` of an f32 produces a
+/// document that strict parsers (python `json`, `serde_json`) reject outright while
+/// lenient ones (jq) silently rewrite to `f64::MAX`. Non-finite values become `null`.
+pub(crate) fn json_number(value: f32) -> serde_json::Value {
+    if value.is_finite() {
+        serde_json::Number::from_f64(f64::from(value)).map_or(serde_json::Value::Null, |n| {
+            serde_json::Value::Number(n)
+        })
+    } else {
+        serde_json::Value::Null
+    }
+}
+
+/// Build the `rosetta verify --json` document.
+// serde_json::json!() macro uses infallible unwrap internally
+#[allow(clippy::disallowed_methods)]
+pub(crate) fn verification_json(report: &VerificationReport) -> serde_json::Value {
+    serde_json::json!({
+        "is_equivalent": report.is_equivalent,
+        "max_diff": json_number(report.max_diff),
+        "mean_diff": json_number(report.mean_diff),
+        "failed_tensors": report.failed_tensors.len(),
+    })
+}
+
 fn print_verification_json(report: &VerificationReport) {
-    println!("{{");
-    println!("  \"is_equivalent\": {},", report.is_equivalent);
-    println!("  \"max_diff\": {},", report.max_diff);
-    println!("  \"mean_diff\": {},", report.mean_diff);
-    println!("  \"failed_tensors\": {}", report.failed_tensors.len());
-    println!("}}");
+    println!("{:#}", verification_json(report));
 }

--- a/crates/apr-cli/src/commands/rosetta_08.rs
+++ b/crates/apr-cli/src/commands/rosetta_08.rs
@@ -20,4 +20,5 @@ include!("rosetta_print_fingerprint.rs");
 include!("rosetta_verification_report.rs");
 include!("rosetta_print_inference_tests.rs");
 include!("rosetta_inference_result_tests.rs");
+include!("rosetta_fail_closed_tests.rs");
 }

--- a/crates/apr-cli/src/commands/rosetta_compute_tensor_get.rs
+++ b/crates/apr-cli/src/commands/rosetta_compute_tensor_get.rs
@@ -407,7 +407,7 @@
         let fps_a = vec![make_fingerprint("tensor_a", 0.5, 1.0, 0, 0)];
         let fps_b = vec![make_fingerprint("tensor_a", 10.0, 1.0, 0, 0)];
         let result = print_fingerprint_diff(&fps_a, &fps_b, false, true);
-        assert!(result.is_ok());
+        assert!(result.is_err(), "--json must not mask an anomalous diff");
     }
 
     #[test]
@@ -423,7 +423,7 @@
         let fps_a = vec![make_fingerprint("tensor_a", 0.5, 1.0, 0, 0)];
         let fps_b = vec![make_fingerprint("tensor_a", 20.0, 1.0, 5, 0)];
         let result = print_fingerprint_diff(&fps_a, &fps_b, true, false);
-        assert!(result.is_ok());
+        assert!(result.is_err(), "--verbose must not mask an anomalous diff");
     }
 
     #[test]
@@ -431,7 +431,7 @@
         let fps_a = vec![make_fingerprint("only_in_a", 0.5, 1.0, 0, 0)];
         let fps_b: Vec<TensorFingerprint> = vec![];
         let result = print_fingerprint_diff(&fps_a, &fps_b, false, true);
-        assert!(result.is_ok());
+        assert!(result.is_err(), "--json must not mask a missing tensor");
     }
 
     #[test]

--- a/crates/apr-cli/src/commands/rosetta_diff_tensor.rs
+++ b/crates/apr-cli/src/commands/rosetta_diff_tensor.rs
@@ -294,7 +294,9 @@ pub fn run_fingerprint(
     }
 
     let fingerprints_a = compute_fingerprints(model, filter)?;
-    run_fingerprint_body(&fingerprints_a, model_b, filter, verbose, json)?;
+    // Deliberately not `?`: a failing diff must still write --output and close the
+    // report box, but it must still be the exit status of the command.
+    let diff_result = run_fingerprint_body(&fingerprints_a, model_b, filter, verbose, json);
 
     if let Some(output_path) = output {
         let json_content = fingerprints_to_json(&fingerprints_a);
@@ -314,7 +316,7 @@ pub fn run_fingerprint(
         );
     }
 
-    Ok(())
+    diff_result
 }
 
 /// Run the rosetta validate-stats subcommand (PMAT-202)
@@ -354,6 +356,42 @@ fn resolve_reference_fingerprints(
 }
 
 /// Print validation anomalies as JSON.
+///
+/// Built with serde rather than hand-rolled `println!`: `deviation` is `f32::INFINITY`
+/// for nan/inf-count anomalies, and a bare `inf` literal is not valid JSON.
+// serde_json::json!() macro uses infallible unwrap internally
+#[allow(clippy::disallowed_methods)]
+fn validate_stats_json(
+    model: &Path,
+    threshold: f32,
+    strict: bool,
+    total_tensors: usize,
+    anomalies: &[StatisticalAnomaly],
+) -> serde_json::Value {
+    let details: Vec<serde_json::Value> = anomalies
+        .iter()
+        .map(|a| {
+            serde_json::json!({
+                "tensor": a.tensor,
+                "field": a.field,
+                "expected": json_number(a.expected),
+                "actual": json_number(a.actual),
+                "deviation": json_number(a.deviation_sigma),
+            })
+        })
+        .collect();
+
+    serde_json::json!({
+        "model": model.display().to_string(),
+        "threshold": json_number(threshold),
+        "strict": strict,
+        "total_tensors": total_tensors,
+        "anomalies": anomalies.len(),
+        "anomaly_details": details,
+        "passed": anomalies.is_empty(),
+    })
+}
+
 fn print_validate_stats_json(
     model: &Path,
     threshold: f32,
@@ -361,25 +399,10 @@ fn print_validate_stats_json(
     total_tensors: usize,
     anomalies: &[StatisticalAnomaly],
 ) {
-    println!("{{");
-    println!("  \"model\": \"{}\",", model.display());
-    println!("  \"threshold\": {},", threshold);
-    println!("  \"strict\": {},", strict);
-    println!("  \"total_tensors\": {},", total_tensors);
-    println!("  \"anomalies\": {},", anomalies.len());
-    if !anomalies.is_empty() {
-        println!("  \"anomaly_details\": [");
-        for (i, anomaly) in anomalies.iter().enumerate() {
-            let comma = if i < anomalies.len() - 1 { "," } else { "" };
-            println!(
-                "    {{\"tensor\": \"{}\", \"field\": \"{}\", \"expected\": {:.6}, \"actual\": {:.6}, \"deviation\": {:.2}}}{}",
-                anomaly.tensor, anomaly.field, anomaly.expected, anomaly.actual, anomaly.deviation_sigma, comma
-            );
-        }
-        println!("  ],");
-    }
-    println!("  \"passed\": {}", anomalies.is_empty());
-    println!("}}");
+    println!(
+        "{:#}",
+        validate_stats_json(model, threshold, strict, total_tensors, anomalies)
+    );
 }
 
 /// Print validation anomalies as formatted text.

--- a/crates/apr-cli/src/commands/rosetta_fail_closed_tests.rs
+++ b/crates/apr-cli/src/commands/rosetta_fail_closed_tests.rs
@@ -1,0 +1,221 @@
+
+// ============================================================================
+// Falsifiers for the `apr rosetta` gates that could not fail (issue #2382).
+//
+// Every test here asserts BEHAVIOUR of a verdict — the exit status, the verdict
+// line, or the machine-readable document — for an input the command must reject.
+// Each one turns RED against the 0.63.0 code it replaces.
+// ============================================================================
+
+// ── rosetta fingerprint: a diff that finds differences must fail ────────────
+
+#[test]
+fn falsifier_fingerprint_diff_all_tensors_missing_in_b_is_a_failure() {
+    // The shipped repro: model A has 27 tensors, model B is a different model and
+    // has none of them. 0.63.0 printed 27x "Missing in Model B" and then
+    // "No statistical anomalies detected" / "passed": true, exit 0.
+    let fps_a: Vec<TensorFingerprint> = (0..27)
+        .map(|i| make_fingerprint(&format!("model.layers.{i}.weight"), 0.5, 1.0, 0, 0))
+        .collect();
+    let fps_b: Vec<TensorFingerprint> = vec![];
+
+    let err = print_fingerprint_diff(&fps_a, &fps_b, false, false)
+        .expect_err("27 of 27 tensors absent from B must not report success");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("27"),
+        "failure must name how many tensors are missing, got: {msg}"
+    );
+    assert!(
+        matches!(err, CliError::ValidationFailed(_)),
+        "must be a validation failure so the process exits 5, got: {err:?}"
+    );
+}
+
+#[test]
+fn falsifier_fingerprint_diff_tensor_only_in_b_is_a_failure() {
+    // The walker only iterates model A, so a tensor that exists solely in model B
+    // was invisible: the extra 175 tensors of the shipped repro were never counted.
+    let fps_a: Vec<TensorFingerprint> = vec![];
+    let fps_b = vec![make_fingerprint("only_in_b.weight", 0.5, 1.0, 0, 0)];
+
+    assert!(
+        print_fingerprint_diff(&fps_a, &fps_b, false, false).is_err(),
+        "a tensor present only in model B is a difference and must fail the diff"
+    );
+}
+
+#[test]
+fn falsifier_fingerprint_diff_identical_models_still_pass() {
+    // Control: the fail-closed change must not turn every diff red.
+    let fps_a = vec![
+        make_fingerprint("model.embed_tokens.weight", 0.01, 0.02, 0, 0),
+        make_fingerprint("model.norm.weight", 1.0, 0.1, 0, 0),
+    ];
+    assert!(
+        print_fingerprint_diff(&fps_a, &fps_a, false, false).is_ok(),
+        "a model compared against itself must still pass"
+    );
+}
+
+#[test]
+fn falsifier_missing_tensor_anomalies_are_counted_by_direction() {
+    let anomalies = vec![
+        missing_tensor_anomaly("a1", FIELD_MISSING_IN_B),
+        missing_tensor_anomaly("a2", FIELD_MISSING_IN_B),
+        missing_tensor_anomaly("b1", FIELD_MISSING_IN_A),
+    ];
+    assert_eq!(count_field(&anomalies, FIELD_MISSING_IN_B), 2);
+    assert_eq!(count_field(&anomalies, FIELD_MISSING_IN_A), 1);
+}
+
+// ── rosetta verify: FAILED must not exit 0 ─────────────────────────────────
+
+/// The report `verify_roundtrip` produces for the shipped repro: tensor count
+/// mismatch, `max_diff` / `mean_diff` non-finite.
+fn tensor_count_mismatch_report() -> VerificationReport {
+    let mut report = VerificationReport::passing();
+    report.is_equivalent = false;
+    report.max_diff = f32::INFINITY;
+    report.mean_diff = f32::INFINITY;
+    report.failed_tensors = vec!["Tensor count mismatch".to_string()];
+    report
+}
+
+#[test]
+fn falsifier_verify_outcome_is_an_error_when_the_report_failed() {
+    // 0.63.0 printed "Round-trip verification FAILED" and returned Ok(()), so a
+    // `set -e` pipeline saw a broken round-trip as a pass.
+    let report = tensor_count_mismatch_report();
+    let err = verify_outcome(&report, 1e-5).expect_err("a FAILED report must not exit 0");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("FAILED"),
+        "the error must say what failed, got: {msg}"
+    );
+}
+
+#[test]
+fn falsifier_verify_outcome_is_ok_when_the_report_passed() {
+    // Control: an equivalent round-trip still exits 0.
+    assert!(verify_outcome(&VerificationReport::passing(), 1e-5).is_ok());
+}
+
+// ── rosetta verify --json: non-finite values must not be bare `inf` ────────
+
+#[test]
+fn falsifier_verification_json_is_parseable_when_diffs_are_infinite() {
+    // 0.63.0 emitted `"max_diff": inf`, which RFC 8259 has no literal for:
+    // python's json rejects the document and jq silently rewrites it to f64::MAX.
+    let report = tensor_count_mismatch_report();
+    let text = serde_json::to_string(&verification_json(&report)).expect("serialize");
+    assert!(
+        !text.contains("inf"),
+        "the document must not contain a bare inf literal: {text}"
+    );
+
+    let parsed: serde_json::Value = serde_json::from_str(&text)
+        .unwrap_or_else(|e| panic!("verify --json must be valid JSON, got {text:?}: {e}"));
+    assert!(parsed["max_diff"].is_null(), "non-finite becomes null");
+    assert!(parsed["mean_diff"].is_null(), "non-finite becomes null");
+    assert_eq!(parsed["is_equivalent"], serde_json::json!(false));
+}
+
+#[test]
+fn falsifier_verification_json_keeps_finite_numbers() {
+    // Control: the passing path is unchanged and still numeric.
+    let mut report = VerificationReport::passing();
+    report.max_diff = 0.25;
+    report.mean_diff = 0.125;
+    let parsed = verification_json(&report);
+    assert_eq!(parsed["max_diff"], serde_json::json!(0.25));
+    assert_eq!(parsed["mean_diff"], serde_json::json!(0.125));
+}
+
+#[test]
+fn falsifier_json_number_maps_non_finite_to_null() {
+    assert!(json_number(f32::INFINITY).is_null());
+    assert!(json_number(f32::NEG_INFINITY).is_null());
+    assert!(json_number(f32::NAN).is_null());
+    assert_eq!(json_number(1.5), serde_json::json!(1.5));
+}
+
+#[test]
+fn falsifier_validate_stats_json_is_parseable_with_infinite_deviation() {
+    // nan_count/inf_count anomalies carry deviation_sigma = INFINITY, which the
+    // hand-rolled `{:.2}` printed as a bare `inf`.
+    let anomalies = vec![StatisticalAnomaly {
+        tensor: "model.layers.0.weight".to_string(),
+        field: "nan_count".to_string(),
+        expected: 0.0,
+        actual: 12.0,
+        deviation_sigma: f32::INFINITY,
+    }];
+    let doc = validate_stats_json(Path::new("/tmp/m.apr"), 3.0, false, 1, &anomalies);
+    let text = serde_json::to_string(&doc).expect("serialize");
+    assert!(!text.contains("inf"), "no bare inf literal: {text}");
+    let parsed: serde_json::Value = serde_json::from_str(&text)
+        .unwrap_or_else(|e| panic!("validate-stats --json must be valid JSON: {e}"));
+    assert!(parsed["anomaly_details"][0]["deviation"].is_null());
+    assert_eq!(parsed["passed"], serde_json::json!(false));
+}
+
+// ── rosetta compare-inference: zero token pairs is not a 100% match ────────
+
+#[test]
+fn falsifier_compare_inference_zero_tokens_is_not_a_match() {
+    // The shipped repro compared a 1.5B GGUF against a 0.5B APR, captured zero
+    // token pairs, and reported "RESULT: INFERENCE MATCH (100%)".
+    let line = inference_result_line(0, 0, 0.1);
+    assert!(
+        !line.contains("MATCH (100%)"),
+        "0 token pairs must not read as a 100% match, got: {line}"
+    );
+    assert!(
+        line.contains("VACUOUS"),
+        "0 token pairs must be reported as vacuous, got: {line}"
+    );
+}
+
+#[test]
+fn falsifier_compare_inference_real_match_still_reads_as_a_match() {
+    // Control: a genuine 5-of-5 match is unchanged.
+    assert!(inference_result_line(5, 0, 0.1).contains("MATCH (100%)"));
+}
+
+#[test]
+fn falsifier_compare_passed_is_false_with_zero_tokens() {
+    // The `--json` surface: `"passed": true` for a comparison of nothing made this
+    // command unusable as a CI gate.
+    assert!(
+        !compare_passed(0, 0, 0.1),
+        "a comparison of zero token pairs never passes"
+    );
+    assert!(compare_passed(5, 0, 0.1), "a real 5/5 match still passes");
+    assert!(
+        !compare_passed(5, 5, 0.1),
+        "a real 0/5 match still does not pass"
+    );
+}
+
+#[test]
+fn falsifier_validate_captured_tokens_rejects_vacuous_comparison() {
+    // Both models emitted text, but no token pairs were captured. 0.63.0 returned
+    // Ok(()) here, which is the whole reason the command exited 0.
+    let err = validate_captured_tokens("4 2", "<unk><unk><unk>")
+        .expect_err("zero token pairs compared must never be a success");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("VACUOUS"),
+        "the error must name the vacuous comparison, got: {msg}"
+    );
+}
+
+#[test]
+fn falsifier_validate_captured_tokens_still_reports_a_silent_model() {
+    // Controls: the pre-existing GH-188 diagnoses must survive.
+    assert!(validate_captured_tokens("", "").is_err());
+    assert!(validate_captured_tokens("", "some text").is_err());
+    assert!(validate_captured_tokens("some text", "").is_err());
+    assert!(validate_captured_tokens("120 tok/s", "real output").is_err());
+}

--- a/crates/apr-cli/src/commands/rosetta_print_fingerprint.rs
+++ b/crates/apr-cli/src/commands/rosetta_print_fingerprint.rs
@@ -12,7 +12,7 @@
         let fps_a = vec![make_fingerprint("tensor_a", 0.5, 1.0, 0, 0)];
         let fps_b = vec![make_fingerprint("tensor_a", 0.5, 1.0, 0, 5)];
         let result = print_fingerprint_diff(&fps_a, &fps_b, false, false);
-        assert!(result.is_ok());
+        assert!(result.is_err(), "infinities only in B must fail the diff");
     }
 
     #[test]
@@ -27,7 +27,10 @@
             make_fingerprint("t2", 50.0, 1.0, 3, 0), // anomaly
         ];
         let result = print_fingerprint_diff(&fps_a, &fps_b, true, false);
-        assert!(result.is_ok());
+        assert!(
+            result.is_err(),
+            "one anomalous tensor and one missing tensor must fail the diff"
+        );
     }
 
     // ====================================================================

--- a/crates/apr-cli/src/commands/rosetta_print_inference.rs
+++ b/crates/apr-cli/src/commands/rosetta_print_inference.rs
@@ -1,4 +1,44 @@
 
+/// Build the one-line verdict at the bottom of the inference comparison report.
+///
+/// `total_tokens == 0` is its own verdict. It used to fall through to the
+/// `mismatches == 0` arm and print "RESULT: INFERENCE MATCH (100%)" — in the same
+/// report that had already printed "NO TOKENS CAPTURED" and, below the box, two
+/// completely different model outputs.
+fn inference_result_line(total_tokens: usize, mismatches: usize, tolerance: f32) -> String {
+    if total_tokens == 0 {
+        return "RESULT: VACUOUS - 0 TOKEN PAIRS COMPARED, NOTHING WAS VERIFIED"
+            .red()
+            .bold()
+            .to_string();
+    }
+
+    let match_rate = 1.0 - (mismatches as f32 / total_tokens as f32);
+
+    if mismatches == 0 {
+        "RESULT: INFERENCE MATCH (100%)".green().bold().to_string()
+    } else if match_rate >= (1.0 - tolerance) {
+        format!(
+            "RESULT: PARTIAL MATCH ({:.0}% within tolerance {:.0}%)",
+            match_rate * 100.0,
+            tolerance * 100.0
+        )
+        .yellow()
+        .bold()
+        .to_string()
+    } else {
+        format!(
+            "RESULT: INFERENCE MISMATCH ({}/{} tokens = {:.0}%)",
+            mismatches,
+            total_tokens,
+            match_rate * 100.0
+        )
+        .red()
+        .bold()
+        .to_string()
+    }
+}
+
 /// Print diagnosis section for inference comparison (extracted for complexity reduction).
 fn print_inference_diagnosis(
     total_tokens: usize,
@@ -70,36 +110,10 @@ fn print_inference_diagnosis(
         "╠══════════════════════════════════════════════════════════════════════════════╣".cyan()
     );
 
-    // Result
-    let match_rate = if total_tokens > 0 {
-        1.0 - (mismatches as f32 / total_tokens as f32)
-    } else {
-        0.0
-    };
-
-    let result_text = if mismatches == 0 {
-        "RESULT: INFERENCE MATCH (100%)".green().bold().to_string()
-    } else if match_rate >= (1.0 - tolerance) {
-        format!(
-            "RESULT: PARTIAL MATCH ({:.0}% within tolerance {:.0}%)",
-            match_rate * 100.0,
-            tolerance * 100.0
-        )
-        .yellow()
-        .bold()
-        .to_string()
-    } else {
-        format!(
-            "RESULT: INFERENCE MISMATCH ({}/{} tokens = {:.0}%)",
-            mismatches,
-            total_tokens,
-            match_rate * 100.0
-        )
-        .red()
-        .bold()
-        .to_string()
-    };
-    println!("║ {:<76} ║", result_text);
+    println!(
+        "║ {:<76} ║",
+        inference_result_line(total_tokens, mismatches, tolerance)
+    );
     println!(
         "{}",
         "╚══════════════════════════════════════════════════════════════════════════════╝".cyan()

--- a/crates/apr-cli/src/commands/rosetta_tensor_fingerprint_statistical.rs
+++ b/crates/apr-cli/src/commands/rosetta_tensor_fingerprint_statistical.rs
@@ -83,10 +83,12 @@
 
     #[test]
     fn test_print_fingerprint_diff_with_anomaly() {
+        // Was `assert!(result.is_ok())`, which is exactly what let a diff report
+        // anomalies and still exit 0.
         let fps_a = vec![make_fingerprint("tensor_a", 0.5, 1.0, 0, 0)];
         let fps_b = vec![make_fingerprint("tensor_a", 10.0, 1.0, 0, 0)];
         let result = print_fingerprint_diff(&fps_a, &fps_b, false, false);
-        assert!(result.is_ok());
+        assert!(result.is_err(), "a 9.5-sigma mean shift must fail the diff");
     }
 
     #[test]
@@ -94,7 +96,10 @@
         let fps_a = vec![make_fingerprint("only_in_a", 0.5, 1.0, 0, 0)];
         let fps_b: Vec<TensorFingerprint> = vec![];
         let result = print_fingerprint_diff(&fps_a, &fps_b, false, false);
-        assert!(result.is_ok());
+        assert!(
+            result.is_err(),
+            "a tensor absent from model B must fail the diff, not be dropped"
+        );
     }
 
     #[test]
@@ -118,7 +123,7 @@
         let fps_a = vec![make_fingerprint("tensor_a", 0.5, 1.0, 0, 0)];
         let fps_b = vec![make_fingerprint("tensor_a", 0.5, 1.0, 5, 0)];
         let result = print_fingerprint_diff(&fps_a, &fps_b, false, false);
-        assert!(result.is_ok());
+        assert!(result.is_err(), "NaNs appearing only in B must fail the diff");
     }
 
     #[test]

--- a/crates/aprender-core/src/format/rosetta/check.rs
+++ b/crates/aprender-core/src/format/rosetta/check.rs
@@ -235,6 +235,58 @@ impl Default for ConversionOptions {
     }
 }
 
+impl ConversionOptions {
+    /// Copy of these options with quantization removed.
+    ///
+    /// Used for the intermediate hop of a multi-step conversion: quantizing at the
+    /// intermediate step *and* at the final export would quantize the weights twice.
+    #[must_use]
+    pub fn without_quantization(&self) -> Self {
+        Self {
+            quantization: None,
+            tokenizer_path: self.tokenizer_path.clone(),
+            ..*self
+        }
+    }
+}
+
+/// The `--quantize` values `apr rosetta convert` accepts, in the order shown to users.
+pub const SUPPORTED_QUANTIZATIONS: &[&str] = &[
+    "int4", "int8", "fp16", "f16", "q4_k", "q4_k_m", "q6_k", "q8_0",
+];
+
+/// Parse a `ConversionOptions::quantization` string into a concrete quantization type.
+///
+/// An unrecognised value is rejected. Previously the mapping was an `and_then` that
+/// returned `None` for anything it did not know, so `--quantize BOGUS_XYZ` was
+/// indistinguishable from no flag at all: exit 0, no diagnostic, unquantized output.
+///
+/// # Errors
+///
+/// Returns [`AprenderError::FormatError`] if `quantization` is not one of
+/// [`SUPPORTED_QUANTIZATIONS`].
+pub fn parse_quantization(
+    quantization: Option<&str>,
+) -> Result<Option<crate::format::converter::QuantizationType>> {
+    use crate::format::converter::QuantizationType;
+
+    let Some(raw) = quantization else {
+        return Ok(None);
+    };
+    // Note: Q6_K maps to Q4K since that's what realizar's inference supports.
+    match raw.to_lowercase().as_str() {
+        "q4_k" | "q4_k_m" | "int4" | "q6_k" => Ok(Some(QuantizationType::Q4K)),
+        "int8" | "q8_0" => Ok(Some(QuantizationType::Int8)),
+        "fp16" | "f16" => Ok(Some(QuantizationType::Fp16)),
+        other => Err(AprenderError::FormatError {
+            message: format!(
+                "Unknown quantization {other:?}. Supported values: {}",
+                SUPPORTED_QUANTIZATIONS.join(", ")
+            ),
+        }),
+    }
+}
+
 // ============================================================================
 // Rosetta Stone Converter
 // ============================================================================

--- a/crates/aprender-core/src/format/rosetta/sharded.rs
+++ b/crates/aprender-core/src/format/rosetta/sharded.rs
@@ -170,9 +170,19 @@ impl RosettaStone {
                 None
             }
         });
+        // Sharded SafeTensors are unquantized, so --quantize applies to the APR write.
+        // Rejects an unrecognised value here too, before any work is done.
+        let parsed_quantize = parse_quantization(opts.quantization.as_deref())?;
+        // Multi-hop conversions quantize at the final export, not at the temp APR.
+        let import_quantize = if target_format == FormatType::Apr {
+            parsed_quantize
+        } else {
+            None
+        };
         let import_opts = ImportOptions {
             tokenizer_path: effective_tokenizer,
             allow_no_config: true, // Sharded models may have config.json; let import warn
+            quantize: import_quantize,
             ..ImportOptions::default()
         };
 
@@ -215,21 +225,23 @@ impl RosettaStone {
         // GH-205 FIX: Map ConversionOptions.quantization to ExportOptions.quantize
         // Previously opts was ignored, causing F32 GGUF export even when quantization requested.
         // Note: Q6_K maps to Q4K since that's what realizar's inference supports.
-        let export_quantize =
-            opts.quantization
-                .as_ref()
-                .and_then(|q| match q.to_lowercase().as_str() {
-                    "q4_k" | "q4_k_m" | "int4" | "q6_k" => Some(QuantizationType::Q4K),
-                    "int8" | "q8_0" => Some(QuantizationType::Int8),
-                    "fp16" | "f16" => Some(QuantizationType::Fp16),
-                    _ => None,
-                });
+        // An unrecognised value is an error, not a silent no-op: `--quantize BOGUS_XYZ`
+        // used to be accepted with exit 0 and produce an unquantized file.
+        let export_quantize = parse_quantization(opts.quantization.as_deref())?;
 
         match (source_format, target_format) {
             // GGUF/SafeTensors → APR (same conversion path via apr_import)
             // GH-196: Default ImportOptions are permissive (strict=false),
             // so format conversion proceeds with warnings for unverified architectures.
             (FormatType::Gguf | FormatType::SafeTensors, FormatType::Apr) => {
+                if source_format == FormatType::Gguf && export_quantize.is_some() {
+                    return Err(AprenderError::FormatError {
+                        message: "Cannot re-quantize a GGUF source: its tensors are already \
+                                  quantized, and requantizing them would compound the error. \
+                                  Drop --quantize, or start from an unquantized SafeTensors model."
+                            .to_string(),
+                    });
+                }
                 let source_str = source.to_string_lossy();
                 let effective_tokenizer = opts.tokenizer_path.clone().or_else(|| {
                     let sibling = source.with_file_name("tokenizer.json");
@@ -242,6 +254,9 @@ impl RosettaStone {
                 let import_opts = ImportOptions {
                     tokenizer_path: effective_tokenizer,
                     allow_no_config: true,
+                    // Previously left at ImportOptions::default() (None), so every
+                    // `--quantize` value was a no-op for APR targets.
+                    quantize: export_quantize,
                     ..ImportOptions::default()
                 };
                 apr_import(&source_str, target, import_opts)?;
@@ -268,6 +283,14 @@ impl RosettaStone {
 
             // APR → SafeTensors
             (FormatType::Apr, FormatType::SafeTensors) => {
+                if export_quantize.is_some() {
+                    return Err(AprenderError::FormatError {
+                        message: "SafeTensors export does not support --quantize; \
+                                  SafeTensors carries no k-quant block layout. \
+                                  Convert to .gguf or .apr instead."
+                            .to_string(),
+                    });
+                }
                 apr_export(
                     source,
                     target,
@@ -282,7 +305,16 @@ impl RosettaStone {
             // GGUF → SafeTensors (via APR)
             (FormatType::Gguf, FormatType::SafeTensors) => {
                 let temp_apr = std::env::temp_dir().join("rosetta_temp.apr");
-                self.convert_internal(source, &temp_apr, FormatType::Gguf, FormatType::Apr, opts)?;
+                // Quantization belongs to the final hop only; quantizing the temp APR
+                // as well would quantize the same weights twice.
+                let hop_opts = opts.without_quantization();
+                self.convert_internal(
+                    source,
+                    &temp_apr,
+                    FormatType::Gguf,
+                    FormatType::Apr,
+                    &hop_opts,
+                )?;
                 self.convert_internal(
                     &temp_apr,
                     target,
@@ -297,12 +329,13 @@ impl RosettaStone {
             // SafeTensors → GGUF (via APR)
             (FormatType::SafeTensors, FormatType::Gguf) => {
                 let temp_apr = std::env::temp_dir().join("rosetta_temp.apr");
+                let hop_opts = opts.without_quantization();
                 self.convert_internal(
                     source,
                     &temp_apr,
                     FormatType::SafeTensors,
                     FormatType::Apr,
-                    opts,
+                    &hop_opts,
                 )?;
                 self.convert_internal(&temp_apr, target, FormatType::Apr, FormatType::Gguf, opts)?;
                 let _ = std::fs::remove_file(temp_apr);

--- a/crates/aprender-core/src/format/rosetta/tests_pygmy_validation.rs
+++ b/crates/aprender-core/src/format/rosetta/tests_pygmy_validation.rs
@@ -102,16 +102,23 @@ fn p083b_conversion_options_quantization_variants() {
     }
 }
 
-/// P084b: ConversionOptions with unknown quantization (maps to None in convert_internal)
+/// P084b: ConversionOptions with unknown quantization is rejected, not silently dropped.
+///
+/// This test used to assert only that the struct stores the string, and its comment
+/// recorded the defect as intended behaviour ("would map to None"). Mapping an
+/// unrecognised value to None is precisely what made `--quantize BOGUS_XYZ` exit 0
+/// and produce an unquantized file.
 #[test]
 fn p084b_conversion_options_unknown_quantization() {
     let opts = ConversionOptions {
         quantization: Some("unknown_quant".to_string()),
         ..Default::default()
     };
-    // The ConversionOptions struct itself just stores the string
-    // The mapping happens in convert_internal - "unknown_quant" would map to None
     assert_eq!(opts.quantization, Some("unknown_quant".to_string()));
+    assert!(
+        parse_quantization(opts.quantization.as_deref()).is_err(),
+        "an unrecognised quantization must be an error, not a silent no-op"
+    );
 }
 
 // ========================================================================
@@ -366,3 +373,6 @@ fn test_bug_212_convert_sharded_nonexistent() {
 
 #[path = "tests_gh346.rs"]
 mod tests_gh346;
+
+#[path = "tests_quantize_flag.rs"]
+mod tests_quantize_flag;

--- a/crates/aprender-core/src/format/rosetta/tests_quantize_flag.rs
+++ b/crates/aprender-core/src/format/rosetta/tests_quantize_flag.rs
@@ -1,0 +1,84 @@
+// ============================================================================
+// Falsifiers for `apr rosetta convert --quantize` (issue #2382, finding 4).
+//
+// In 0.63.0 the flag was a no-op for every value and accepted garbage silently:
+// int8, int4, fp16, bogus and BOGUS_XYZ all produced byte-identical output to a
+// convert with no flag at all, each exiting 0 with no diagnostic.
+// ============================================================================
+
+use super::*;
+use crate::format::converter::QuantizationType;
+
+#[test]
+fn falsifier_unknown_quantization_is_rejected() {
+    // `--quantize BOGUS_XYZ` used to be indistinguishable from no flag at all.
+    for bogus in ["bogus", "BOGUS_XYZ", "q3_k", "", "int2"] {
+        let err = parse_quantization(Some(bogus))
+            .err()
+            .unwrap_or_else(|| panic!("--quantize {bogus:?} must be rejected, not ignored"));
+        let msg = err.to_string();
+        assert!(
+            msg.contains("Unknown quantization"),
+            "the error must name the bad value, got: {msg}"
+        );
+        assert!(
+            msg.contains("int8"),
+            "the error must list what IS supported, got: {msg}"
+        );
+    }
+}
+
+#[test]
+fn falsifier_documented_quantization_values_all_map() {
+    // Every value in the `--quantize` help text must map to a real type.
+    for value in SUPPORTED_QUANTIZATIONS {
+        let parsed = parse_quantization(Some(value))
+            .unwrap_or_else(|e| panic!("documented value {value:?} must parse: {e}"));
+        assert!(
+            parsed.is_some(),
+            "documented value {value:?} must map to a quantization type, not None"
+        );
+    }
+}
+
+#[test]
+fn falsifier_quantization_values_map_to_distinct_types() {
+    assert_eq!(
+        parse_quantization(Some("int8")).expect("int8"),
+        Some(QuantizationType::Int8)
+    );
+    assert_eq!(
+        parse_quantization(Some("int4")).expect("int4"),
+        Some(QuantizationType::Q4K)
+    );
+    assert_eq!(
+        parse_quantization(Some("fp16")).expect("fp16"),
+        Some(QuantizationType::Fp16)
+    );
+    // Case-insensitive, as the CLI lowercases nothing itself.
+    assert_eq!(
+        parse_quantization(Some("INT8")).expect("INT8"),
+        Some(QuantizationType::Int8)
+    );
+}
+
+#[test]
+fn falsifier_no_quantize_flag_stays_none() {
+    assert_eq!(parse_quantization(None).expect("no flag"), None);
+}
+
+#[test]
+fn falsifier_intermediate_hop_drops_quantization() {
+    // A multi-step conversion (SafeTensors → APR → GGUF) must quantize once, at
+    // the final export. Quantizing the temp APR too would quantize twice.
+    let opts = ConversionOptions {
+        quantization: Some("int8".to_string()),
+        verify: false,
+        tolerance: 0.25,
+        ..Default::default()
+    };
+    let hop = opts.without_quantization();
+    assert_eq!(hop.quantization, None, "the intermediate hop must not quantize");
+    assert!(!hop.verify, "other options must survive unchanged");
+    assert_eq!(hop.tolerance, 0.25, "other options must survive unchanged");
+}


### PR DESCRIPTION
Dogfooding `cargo install aprender` 0.63.0 found that the three `apr rosetta` subcommands whose entire purpose is comparison could not report a failure. All five findings in the cluster are fixed here.

## What a user saw

`rosetta compare-inference` on a 1.5B GGUF vs a 0.5B APR:

```
║ ⚠️  NO TOKENS CAPTURED - INFERENCE MAY HAVE FAILED!                          ║
╠══════════════════════════════════════════════════════════════════════════════╣
║ RESULT: INFERENCE MATCH (100%)                                               ║
╚══════════════════════════════════════════════════════════════════════════════╝

=== Generated Text ===
Model A: "4 2"
Model B: "<unk><unk><unk>"

⚠️  TEXT CONTENT DIFFERS:
```

rc=0. `rosetta fingerprint A B` listed 27 of 27 tensors as "Missing in Model B" and concluded `"passed": true`, rc=0. `rosetta verify --intermediate apr` printed "Round-trip verification FAILED" with `Max Diff: inf`, rc=0, and its `--json` contained a bare `inf` literal that python's `json` rejects while `jq` silently rewrites it to `f64::MAX`. Any CI job gating on these commands was permanently green.

## Root cause

Every one is the same shape: a verdict derived from a variable that stays empty when nothing was measured.

- `crates/apr-cli/src/commands/inference.rs` — `validate_captured_tokens` returned `Ok(())` as soon as both models had emitted *some* text, so zero token pairs fell through to `validate_match_tolerance(0, 0, tol)`, which cannot fail. Zero token pairs is now a hard failure, matching how `apr compare-hf` already fails closed ("The verification is vacuous, not successful"). `inference_result_line` and `compare_passed` no longer let `mismatches == 0` mean "match" when there was nothing to mismatch.
- `crates/apr-cli/src/commands/fingerprints.rs` — the diff walker printed the "Missing in Model B" rows and never pushed them into `anomalies`; `print_diff_summary` derived both the text verdict and `"passed"` solely from that vector. Missing tensors are now anomalies in both directions (the walker iterates only model A, so tensors present solely in B were invisible), and a non-empty anomaly set is the command's exit status.
- `crates/apr-cli/src/commands/inference.rs` — `run_verify` printed FAILED and returned `Ok(())`. The decision now lives in `verify_outcome`, which errors when the report does not pass.
- `crates/apr-cli/src/commands/inference_result.rs` and `rosetta_diff_tensor.rs` — the verify and validate-stats JSON documents were hand-rolled `println!`, so `f32::INFINITY` reached the wire as `inf`. Both are built with serde now; non-finite values serialise as `null`.
- `crates/aprender-core/src/format/rosetta/sharded.rs` — `--quantize` was mapped with an `and_then` that returned `None` for anything unrecognised, and the →APR arm left `ImportOptions::quantize` at its default, so every value was a no-op. `parse_quantization` (new, in `check.rs`) rejects unknown values; the import path receives the requested quantization; the two paths that cannot honour it (re-quantizing an already-quantized GGUF source, SafeTensors export) say so rather than ignoring it; multi-hop conversions quantize at the final export only.

## Before / after, same fixtures

Binary before: `cargo install aprender` 0.63.0 (`apr 0.63.0 (v0.63.0+no-git)`). After: `cargo build --bin apr --release` from this branch (`apr 0.63.0 (5643db51d)`). Exit codes captured as `cmd > file 2>&1; rc=$?`, never through a pipe.

| command | before | after |
|---|---|---|
| `rosetta fingerprint A B` | rc=0, "No statistical anomalies detected", `{"anomalies": 0, "passed": true}` | rc=5, "229 ANOMALIES DETECTED (27 missing in B, 202 missing in A)", `{"anomalies": 229, "missing_in_b": 27, "missing_in_a": 202, "passed": false}` |
| `rosetta fingerprint A A` (control) | rc=0, no anomalies | rc=0, no anomalies |
| `rosetta verify A --intermediate apr` | rc=0, "FAILED" | rc=5, "FAILED" + `error: Validation failed: Round-trip verification FAILED` |
| `rosetta verify A --intermediate safetensors` (control) | rc=0, PASSED, Max Diff 0.00e0 | rc=0, PASSED, Max Diff 0.00e0 |
| `rosetta verify A --intermediate apr --json` | `"max_diff": inf` → `json.load`: `Expecting value: line 3 column 15` | `"max_diff": null` → `JSON OK, max_diff = None` |
| `rosetta compare-inference gguf apr --max-tokens 3` | rc=0, "RESULT: INFERENCE MATCH (100%)" | rc=5, "RESULT: VACUOUS - 0 TOKEN PAIRS COMPARED, NOTHING WAS VERIFIED" |

`rosetta convert` on `57e6e922118ea840.safetensors` (105 tensors, 86.6 MB of tensor data), varying the model away from the 4.6 MB toy fixture in the issue:

```
before  int8 90,868,740   int4 90,868,740   fp16 90,868,740   none 90,868,740   BOGUS_XYZ rc=0
after   int8 22,827,204   int4 16,490,820   fp16 45,441,540   none 90,868,740   BOGUS_XYZ rc=5
```

with tensor count preserved 105 → 105, and

```
error: Validation failed: Conversion failed: Invalid model format: Unknown quantization "bogus_xyz". Supported values: int4, int8, fp16, f16, q4_k, q4_k_m, q6_k, q8_0
```

One honest caveat on the issue's own 4.6 MB fixture: `--quantize int4` there grows the file (8.6 MB → 47 MB) because that model's hidden dim is 8 and Q4_K's 256-element super-blocks pad heavily. That is a property of k-quants on a toy shape, not a regression — before this change the flag simply did nothing at all.

## Tests

16 new falsifiers (`crates/apr-cli/src/commands/rosetta_fail_closed_tests.rs`, `crates/aprender-core/src/format/rosetta/tests_quantize_flag.rs`), each asserting a verdict rather than a shape, plus controls so the fail-closed change cannot just turn everything red.

8 existing tests were asserting `is_ok()` on inputs the tool must reject and were holding the defect in place — `test_print_fingerprint_diff_missing_in_b` asserted success on a tensor absent from model B, and `p084b_conversion_options_unknown_quantization` documented the no-op as intended behaviour in its comment ("would map to None"). They now assert the failure.

## Mutation check

Reverting the six production changes while keeping the tests turns 9 of 16 apr-cli falsifiers and 2 core tests RED, and leaves every control green:

```
test commands::rosetta::tests::falsifier_compare_passed_is_false_with_zero_tokens ... FAILED
test commands::rosetta::tests::falsifier_compare_inference_zero_tokens_is_not_a_match ... FAILED
test commands::rosetta::tests::falsifier_json_number_maps_non_finite_to_null ... FAILED
test commands::rosetta::tests::falsifier_fingerprint_diff_tensor_only_in_b_is_a_failure ... FAILED
test commands::rosetta::tests::falsifier_validate_captured_tokens_rejects_vacuous_comparison ... FAILED
test commands::rosetta::tests::falsifier_fingerprint_diff_all_tensors_missing_in_b_is_a_failure ... FAILED
test commands::rosetta::tests::falsifier_verify_outcome_is_an_error_when_the_report_failed ... FAILED
test commands::rosetta::tests::falsifier_verification_json_is_parseable_when_diffs_are_infinite ... FAILED
test commands::rosetta::tests::falsifier_validate_stats_json_is_parseable_with_infinite_deviation ... FAILED
test result: FAILED. 10 passed; 9 failed; 0 ignored; 0 measured; 6635 filtered out

test ...tests_quantize_flag::falsifier_unknown_quantization_is_rejected ... FAILED
test ...tests_pygmy_validation::p084b_conversion_options_unknown_quantization ... FAILED
test result: FAILED. 4 passed; 1 failed
```

Restored: `cargo test -p apr-cli --lib rosetta` 454 passed / 0 failed, `cargo test -p aprender-core --lib rosetta` 268 passed / 0 failed, `cargo fmt --all -- --check` clean, `cargo clippy -p apr-cli --lib -- -D warnings` and `cargo clippy -p aprender-core --lib -- -D warnings` clean.

Audit epic: #2373

Fixes #2382

🤖 Generated with [Claude Code](https://claude.com/claude-code)
