### PR TITLE
fix(cli): a NaN tolerance turned every CRUX lint gate into a permanent pass that printed Ok

### DIFF
--- a/contracts/apr-cli-commands-v1.yaml
+++ b/contracts/apr-cli-commands-v1.yaml
@@ -1,5 +1,5 @@
 metadata:
-  version: 1.0.0
+  version: 1.1.0
   created: '2026-04-06'
   author: PAIML Engineering
   registry: true
@@ -20,7 +20,7 @@ metadata:
 
 kind: CLICommandContract
 name: apr-cli-commands
-version: "1.0.0"
+version: "1.1.0"
 scope: "all apr CLI subcommands (77 commands — original 57 + `mcp` added 2026-04-17 via PR #864 + `registry` added 2026-04-20 via CRUX-A-01 + `ollama-chat-lint` added 2026-04-21 via CRUX-C-04 SHIP-001 retrofit + `dry-sampling-lint` added 2026-04-21 via CRUX-C-23 SHIP-001 retrofit + `awq-lint` added 2026-04-21 via CRUX-B-08 SHIP-001 retrofit + `oom-lint` added 2026-04-21 via CRUX-F-13 SHIP-001 + `tool-use-lint` added 2026-04-21 via CRUX-C-11 SHIP-001 retrofit + `gbnf-lint` added 2026-04-21 via CRUX-C-10 SHIP-001 retrofit + `typical-p-lint` added 2026-04-21 via CRUX-C-22 SHIP-001 retrofit + `grad-norm` added 2026-04-21 via CRUX-F-09 + `registry-quota-lint` added 2026-04-21 via CRUX-A-22 SHIP-001 retrofit + `fp8-lint` added 2026-04-22 via CRUX-B-11 SHIP-001 retrofit + `imatrix-lint` added 2026-04-22 via CRUX-B-07 SHIP-001 retrofit + `nf4-lint` added 2026-04-22 via CRUX-B-10 SHIP-001 retrofit + `gptq-lint` added 2026-04-22 via CRUX-B-09 SHIP-001 retrofit + `embeddings-lint` added 2026-04-23 via CRUX-C-13 SHIP-001 retrofit + `unified-search-lint` added 2026-04-23 via CRUX-A-23 SHIP-001 retrofit + `rm-gc-lint` added 2026-04-23 via CRUX-A-25 SHIP-001 retrofit + `shared-cache-lint` added 2026-04-23 via CRUX-A-21 SHIP-001 retrofit + `ppl` added 2026-04-23 via CRUX-E-02 SHIP-001 retrofit)"
 binary: "apr"
 install: "cargo install aprender"
@@ -709,3 +709,20 @@ falsification:
     description: "Command count drifts from contract"
     check: "The number of commands in `apr --help` must equal the count in this YAML"
     enforcement: "cargo test --test apr_cli_commands test_command_count_matches"
+
+  - name: FALSIFY-CLI-THRESHOLD-NAN-001
+    description: >
+      A tolerance/threshold flag accepts a value that makes its gate
+      unfalsifiable. Every CRUX lint gate compares an observation against a
+      threshold (`mad > tol_abs`, `efficiency < floor`, `used_pct < threshold`);
+      IEEE-754 makes every comparison against NaN false, so a NaN threshold
+      makes the failing branch unreachable — the command exits 0 and the report
+      prints `Ok` next to the violating number. A negative value does the same
+      to the floor-style gates. Shipped in 0.63.0 on 8 flags across 5 commands
+      (see #2391).
+    check: >
+      Every f64 tolerance/threshold flag must reject NaN, ±inf and
+      out-of-domain values at parse time (exit 2), and each lint `run()` must
+      re-check its thresholds so a non-clap caller also fails closed. The
+      shared validator is crates/apr-cli/src/commands/threshold_arg.rs.
+    enforcement: "cargo test -p apr-cli --test cli_commands nan_threshold_never_reports_a_failing_lint_gate_as_ok"

--- a/crates/apr-cli/src/commands/attn_parity_lint.rs
+++ b/crates/apr-cli/src/commands/attn_parity_lint.rs
@@ -16,6 +16,7 @@ use super::attn_parity_classifier::{
     AttnHeadDimErrorOutcome, AttnParityNumericsOutcome, AttnProvenanceOutcome,
     L02_DEFAULT_MAX_ABS_DIFF, L02_DEFAULT_MIN_COSINE_SIM,
 };
+use super::threshold_arg;
 use crate::error::{CliError, Result};
 
 pub(crate) fn run(
@@ -26,6 +27,10 @@ pub(crate) fn run(
     tol_cos: f64,
     json: bool,
 ) -> Result<()> {
+    // Fail closed before any gate runs: `mad > tol_abs` / `cos < tol_cos` are
+    // both false against a NaN threshold, so the gate could never fire.
+    threshold_arg::guard("--tol-abs", tol_abs, threshold_arg::TOLERANCE)?;
+    threshold_arg::guard("--tol-cos", tol_cos, threshold_arg::COSINE)?;
     if parity_file.is_none() && provenance_file.is_none() && head_dim_error_file.is_none() {
         return Err(CliError::ValidationFailed(
             "apr attn-parity-lint: at least one of --parity-file, --provenance-file, or --head-dim-error-file is required"
@@ -171,6 +176,50 @@ mod cov_tests {
         .unwrap_err();
         assert!(matches!(err, CliError::FileNotFound(_)));
     }
+    /// A parity body that fails at the shipped defaults must keep failing: in
+    /// 0.63.0 `--tol-abs nan --tol-cos nan` printed
+    /// `parity_numerics : Ok { max_abs_diff: 999.0, cosine_sim: -0.5 }` and
+    /// exited 0, because `mad > NaN` and `cos < NaN` are both false.
+    #[test]
+    fn nan_tolerance_cannot_disarm_the_parity_gate() {
+        use std::io::Write;
+        let mut f = tempfile::NamedTempFile::new().expect("tempfile");
+        f.write_all(br#"{"max_abs_diff":999.0,"cosine_sim":-0.5}"#)
+            .expect("write");
+        f.flush().expect("flush");
+
+        // Control: the defaults reject this body on the numerics gate.
+        let err = run(
+            Some(f.path()),
+            None,
+            None,
+            ATTN_PARITY_DEFAULT_MAX_ABS_DIFF,
+            ATTN_PARITY_DEFAULT_MIN_COSINE_SIM,
+            false,
+        )
+        .unwrap_err();
+        match err {
+            CliError::ValidationFailed(msg) => {
+                assert!(msg.contains("parity-numerics"), "got: {msg}");
+            }
+            other => panic!("expected the numerics gate to fire, got {other:?}"),
+        }
+
+        for (abs, cos, flag) in [
+            (f64::NAN, ATTN_PARITY_DEFAULT_MIN_COSINE_SIM, "--tol-abs"),
+            (ATTN_PARITY_DEFAULT_MAX_ABS_DIFF, f64::NAN, "--tol-cos"),
+            (-1.0, ATTN_PARITY_DEFAULT_MIN_COSINE_SIM, "--tol-abs"),
+        ] {
+            let err = run(Some(f.path()), None, None, abs, cos, false).unwrap_err();
+            match err {
+                CliError::ValidationFailed(msg) => {
+                    assert!(msg.contains(flag), "expected {flag} named; got: {msg}");
+                }
+                other => panic!("({abs}, {cos}) must fail closed, got {other:?}"),
+            }
+        }
+    }
+
     #[test]
     fn missing_provenance_file_is_file_not_found() {
         let err = run(

--- a/crates/apr-cli/src/commands/attn_viz_lint.rs
+++ b/crates/apr-cli/src/commands/attn_viz_lint.rs
@@ -15,6 +15,7 @@ use super::attn_viz_classifier::{
     classify_causal_mask, classify_html_heatmap_count, classify_row_softmax_normalization,
     AttnCausalMaskOutcome, AttnHtmlOutcome, AttnRowsOutcome,
 };
+use super::threshold_arg;
 use crate::error::{CliError, Result};
 
 pub(crate) fn run(
@@ -25,6 +26,10 @@ pub(crate) fn run(
     epsilon: f64,
     json: bool,
 ) -> Result<()> {
+    // Fail closed before any gate runs: with a NaN tolerance/epsilon the
+    // row-softmax and causal-mask comparisons are false for every element.
+    threshold_arg::guard("--tolerance", tolerance, threshold_arg::TOLERANCE)?;
+    threshold_arg::guard("--epsilon", epsilon, threshold_arg::TOLERANCE)?;
     if attn_file.is_none() && html_file.is_none() {
         return Err(CliError::ValidationFailed(
             "apr attn-viz-lint: at least one of --attn-file or --html-file is required".to_string(),
@@ -153,6 +158,40 @@ mod cov_tests {
         .unwrap_err();
         assert!(matches!(err, CliError::FileNotFound(_)));
     }
+    /// 0.63.0 printed `row_softmax : Ok { shape: (1, 1, 2, 2) }` and
+    /// `causal_mask : Ok` for a dump whose first row sums to 5.0 and whose
+    /// upper-triangular entry is 2.0, whenever the tolerance/epsilon was NaN.
+    #[test]
+    fn nan_tolerance_or_epsilon_cannot_disarm_the_attn_gates() {
+        use std::io::Write;
+        let mut f = tempfile::NamedTempFile::new().expect("tempfile");
+        f.write_all(b"[[[[3.0,2.0],[0.5,0.5]]]]").expect("write");
+        f.flush().expect("flush");
+
+        // Control: the shipped defaults reject this dump.
+        let err = run(Some(f.path()), None, 0, 1e-5, 1e-9, false).unwrap_err();
+        match err {
+            CliError::ValidationFailed(msg) => {
+                assert!(msg.contains("row-softmax"), "got: {msg}");
+            }
+            other => panic!("expected the row-softmax gate to fire, got {other:?}"),
+        }
+
+        for (tol, eps, flag) in [
+            (f64::NAN, 1e-9, "--tolerance"),
+            (1e-5, f64::NAN, "--epsilon"),
+            (-1.0, 1e-9, "--tolerance"),
+        ] {
+            let err = run(Some(f.path()), None, 0, tol, eps, false).unwrap_err();
+            match err {
+                CliError::ValidationFailed(msg) => {
+                    assert!(msg.contains(flag), "expected {flag} named; got: {msg}");
+                }
+                other => panic!("({tol}, {eps}) must fail closed, got {other:?}"),
+            }
+        }
+    }
+
     #[test]
     fn missing_html_file_is_file_not_found() {
         let err = run(

--- a/crates/apr-cli/src/commands/ddp_metrics_lint.rs
+++ b/crates/apr-cli/src/commands/ddp_metrics_lint.rs
@@ -15,6 +15,7 @@ use super::ddp_metrics_classifier::{
     DdpAllreduceOutcome, DdpLossParityOutcome, DdpScalingOutcome, D11_DEFAULT_LOSS_TOLERANCE,
     D11_DEFAULT_SCALING_FLOOR,
 };
+use super::threshold_arg;
 use crate::error::{CliError, Result};
 
 pub(crate) fn run(
@@ -25,6 +26,11 @@ pub(crate) fn run(
     loss_tolerance: f64,
     json: bool,
 ) -> Result<()> {
+    // Fail closed before any gate runs: with a NaN floor/tolerance the
+    // scaling-efficiency and loss-parity comparisons are false, so the report
+    // would assert `Ok { efficiency: 0.0025 }` for a run that fails outright.
+    threshold_arg::guard("--scaling-floor", scaling_floor, threshold_arg::FRACTION)?;
+    threshold_arg::guard("--loss-tolerance", loss_tolerance, threshold_arg::TOLERANCE)?;
     let body_1 = load_json(metrics_1gpu_file)?;
     let body_n = load_json(metrics_ngpu_file)?;
 
@@ -144,6 +150,56 @@ mod cov_tests {
         .unwrap_err();
         assert!(matches!(err, CliError::FileNotFound(_)));
     }
+    /// 0.63.0 printed `scaling_efficiency : Ok { efficiency: 0.0025 }` — a
+    /// positive assertion that 0.25% DDP scaling is acceptable — whenever the
+    /// floor was NaN or negative, because `efficiency < floor` is false there.
+    #[test]
+    fn nan_or_negative_floor_cannot_disarm_the_ddp_gates() {
+        let a = w(r#"{"tokens_per_sec":1000.0,"final_loss":2.0}"#);
+        let b = w(r#"{"tokens_per_sec":10.0,"final_loss":9.9,
+                "ddp_metrics":{"allreduce_bandwidth_gbps":[12.5]}}"#);
+
+        // Control: the shipped defaults reject this pair on scaling efficiency.
+        let err = run(
+            a.path(),
+            b.path(),
+            4,
+            DDP_METRICS_DEFAULT_SCALING_FLOOR,
+            DDP_METRICS_DEFAULT_LOSS_TOLERANCE,
+            false,
+        )
+        .unwrap_err();
+        match err {
+            CliError::ValidationFailed(msg) => {
+                assert!(msg.contains("scaling-efficiency"), "got: {msg}");
+            }
+            other => panic!("expected the scaling gate to fire, got {other:?}"),
+        }
+
+        for (floor, tol, flag) in [
+            (
+                f64::NAN,
+                DDP_METRICS_DEFAULT_LOSS_TOLERANCE,
+                "--scaling-floor",
+            ),
+            (-1.0, DDP_METRICS_DEFAULT_LOSS_TOLERANCE, "--scaling-floor"),
+            (
+                DDP_METRICS_DEFAULT_SCALING_FLOOR,
+                f64::NAN,
+                "--loss-tolerance",
+            ),
+            (DDP_METRICS_DEFAULT_SCALING_FLOOR, -1.0, "--loss-tolerance"),
+        ] {
+            let err = run(a.path(), b.path(), 4, floor, tol, false).unwrap_err();
+            match err {
+                CliError::ValidationFailed(msg) => {
+                    assert!(msg.contains(flag), "expected {flag} named; got: {msg}");
+                }
+                other => panic!("({floor}, {tol}) must fail closed, got {other:?}"),
+            }
+        }
+    }
+
     #[test]
     fn invalid_json_is_invalid_format() {
         let a = w("xx");

--- a/crates/apr-cli/src/commands/explain_token_lint.rs
+++ b/crates/apr-cli/src/commands/explain_token_lint.rs
@@ -13,6 +13,7 @@ use super::explain_token_classifier::{
     classify_schema, ExplainGreedyOutcome, ExplainProbsOutcome, ExplainSampledOutcome,
     ExplainSchemaOutcome,
 };
+use super::threshold_arg;
 use crate::error::{CliError, Result};
 
 pub(crate) fn run(
@@ -21,6 +22,9 @@ pub(crate) fn run(
     require_greedy: bool,
     json: bool,
 ) -> Result<()> {
+    // Fail closed before any gate runs: `(sum - 1.0).abs() > tolerance` is
+    // false against NaN, so the probs-normalize gate could never fire.
+    threshold_arg::guard("--tolerance", tolerance, threshold_arg::TOLERANCE)?;
     if !jsonl_file.exists() {
         return Err(CliError::FileNotFound(PathBuf::from(jsonl_file)));
     }
@@ -117,6 +121,37 @@ mod cov_tests {
         let f = w("");
         let _ = run(f.path(), 1e-5, false, true);
     }
+    /// 0.63.0 printed `probs_normalize : Ok` and exited 0 for a record whose
+    /// post_probs sum to 0.6, whenever `--tolerance nan` was passed.
+    #[test]
+    fn nan_tolerance_cannot_disarm_the_probs_normalize_gate() {
+        let f = w(concat!(
+            r#"{"step":0,"sampled_id":7,"candidates":["#,
+            r#"{"token_id":7,"pre_prob":0.9,"post_prob":0.5,"rank":0},"#,
+            r#"{"token_id":3,"pre_prob":0.1,"post_prob":0.1,"rank":1}]}"#,
+            "\n"
+        ));
+
+        // Control: the shipped default rejects this body.
+        let err = run(f.path(), 1e-5, false, false).unwrap_err();
+        match err {
+            CliError::ValidationFailed(msg) => {
+                assert!(msg.contains("probs-normalize"), "got: {msg}");
+            }
+            other => panic!("expected the probs gate to fire, got {other:?}"),
+        }
+
+        for bad in [f64::NAN, -1.0, f64::INFINITY] {
+            let err = run(f.path(), bad, false, false).unwrap_err();
+            match err {
+                CliError::ValidationFailed(msg) => {
+                    assert!(msg.contains("--tolerance"), "got: {msg}");
+                }
+                other => panic!("tolerance {bad} must fail closed, got {other:?}"),
+            }
+        }
+    }
+
     #[test]
     fn garbage_jsonl_errors() {
         let f = w("garbage line\nanother\n");

--- a/crates/apr-cli/src/commands/kv_timeline_lint.rs
+++ b/crates/apr-cli/src/commands/kv_timeline_lint.rs
@@ -15,9 +15,18 @@ use super::kv_timeline_classifier::{
     classify_schema, classify_used_pct_arithmetic, KvBlockConservationOutcome, KvPeakOutcome,
     KvPreemptionOutcome, KvSchemaOutcome, KvUsedPctOutcome, F06_DEFAULT_PREEMPT_THRESHOLD,
 };
+use super::threshold_arg;
 use crate::error::{CliError, Result};
 
 pub(crate) fn run(timeline_file: &Path, preempt_threshold: f64, json: bool) -> Result<()> {
+    // Fail closed before any gate runs: a NaN threshold makes `used_pct <
+    // threshold` false for every step, so the preemption gate could never fire
+    // and the report would print a positive `preemption_trigger : Ok`.
+    threshold_arg::guard(
+        "--preempt-threshold",
+        preempt_threshold,
+        threshold_arg::FRACTION,
+    )?;
     if !timeline_file.exists() {
         return Err(CliError::FileNotFound(PathBuf::from(timeline_file)));
     }
@@ -166,6 +175,34 @@ mod tests {
         let f = write_obs(r#"{"timeline": []}"#);
         let err = run(f.path(), KV_TIMELINE_DEFAULT_THRESHOLD, false).unwrap_err();
         assert!(matches!(err, CliError::ValidationFailed(_)));
+    }
+
+    /// A body that FAILS the preemption gate at the default 0.95 must not turn
+    /// into a pass just because the threshold is NaN or negative: `used_pct <
+    /// NaN` is false, so the gate could never fire and the report printed
+    /// `preemption_trigger : Ok` while exiting 0 (0.63.0).
+    #[test]
+    fn nan_or_negative_threshold_cannot_disarm_the_preemption_gate() {
+        let failing = r#"{"block_size_tokens":16,"total_blocks":100,"peak_used_pct":0.1,
+            "preemption_count":3,
+            "timeline":[{"step":0,"t_ms":1.0,"used_blocks":10,"free_blocks":90,
+                         "used_pct":0.10,"active_seqs":1,"preempted_seqs":3}]}"#;
+        let f = write_obs(failing);
+
+        // Control: the shipped default still rejects this body.
+        let err = run(f.path(), KV_TIMELINE_DEFAULT_THRESHOLD, false).unwrap_err();
+        assert!(matches!(err, CliError::ValidationFailed(_)));
+
+        for bad in [f64::NAN, -1.0, f64::INFINITY, 99.0] {
+            let err = run(f.path(), bad, false).unwrap_err();
+            match err {
+                CliError::ValidationFailed(msg) => assert!(
+                    msg.contains("--preempt-threshold"),
+                    "threshold {bad} must be rejected by name; got: {msg}"
+                ),
+                other => panic!("threshold {bad} must fail closed, got {other:?}"),
+            }
+        }
     }
 
     #[test]

--- a/crates/apr-cli/src/commands/mod.rs
+++ b/crates/apr-cli/src/commands/mod.rs
@@ -6,6 +6,8 @@
 //! - Visualization: Make problems visible
 
 pub(crate) mod aliases;
+pub(crate) mod threshold_arg;
+
 pub(crate) mod attn_parity_classifier;
 pub(crate) mod attn_parity_lint;
 pub(crate) mod attn_viz_classifier;

--- a/crates/apr-cli/src/commands/threshold_arg.rs
+++ b/crates/apr-cli/src/commands/threshold_arg.rs
@@ -1,0 +1,392 @@
+//! Shared domain validation for numeric tolerance/threshold CLI flags.
+//!
+//! Every CRUX lint gate is of the form `if observed > tolerance { fail }` or
+//! `if observed < floor { fail }`. IEEE-754 says *every* comparison involving
+//! NaN is false, so a NaN tolerance makes the failing branch unreachable: the
+//! gate can never fire, the report prints a positive `Ok` for an observation it
+//! never actually checked, and the command exits 0. A negative tolerance does
+//! the same for the floor-style gates. Neither is a legitimate tolerance.
+//!
+//! The classifiers already refuse to judge a non-finite *observation*
+//! (`AttnParityNumericsOutcome::NonFiniteMaxAbsDiff`); this module is the
+//! symmetric guard on the *threshold* side. It is used twice:
+//!
+//! 1. as a clap `value_parser`, so a bad value is rejected at parse time
+//!    (exit 2) before any gate runs, and
+//! 2. as a `guard()` call at the top of each lint `run()`, so a caller that
+//!    bypasses clap still fails closed instead of printing `Ok`.
+
+use crate::error::{CliError, Result};
+
+/// The closed interval a threshold flag must lie in, plus a human name used in
+/// the error message.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct ThresholdDomain {
+    /// Inclusive lower bound.
+    pub lo: f64,
+    /// Inclusive upper bound.
+    pub hi: f64,
+    /// How the domain is described to the user, e.g. "a non-negative finite tolerance".
+    pub what: &'static str,
+}
+
+/// A tolerance / epsilon: finite and non-negative, no upper bound.
+pub(crate) const TOLERANCE: ThresholdDomain = ThresholdDomain {
+    lo: 0.0,
+    hi: f64::MAX,
+    what: "a finite tolerance >= 0",
+};
+
+/// A fraction of one, e.g. a utilization threshold or a scaling-efficiency floor.
+pub(crate) const FRACTION: ThresholdDomain = ThresholdDomain {
+    lo: 0.0,
+    hi: 1.0,
+    what: "a finite fraction in [0.0, 1.0]",
+};
+
+/// A cosine-similarity floor, which legitimately spans the whole cosine range.
+pub(crate) const COSINE: ThresholdDomain = ThresholdDomain {
+    lo: -1.0,
+    hi: 1.0,
+    what: "a finite cosine similarity in [-1.0, 1.0]",
+};
+
+/// Reason a threshold value was rejected. Kept separate from the rendered
+/// message so both the clap parser and `guard()` phrase it consistently.
+fn reject_reason(value: f64, domain: ThresholdDomain) -> Option<String> {
+    if value.is_nan() {
+        return Some(format!(
+            "NaN is not a threshold: every comparison against NaN is false, so the gate could never fail. Expected {}",
+            domain.what
+        ));
+    }
+    if value.is_infinite() {
+        return Some(format!(
+            "{value} disarms the gate rather than setting it. Expected {}",
+            domain.what
+        ));
+    }
+    if value < domain.lo || value > domain.hi {
+        return Some(format!(
+            "{value} is outside the valid domain. Expected {}",
+            domain.what
+        ));
+    }
+    None
+}
+
+/// Validate an already-parsed threshold. Returns the value unchanged when it is
+/// usable, or a rendered rejection message.
+pub(crate) fn check(value: f64, domain: ThresholdDomain) -> std::result::Result<f64, String> {
+    match reject_reason(value, domain) {
+        Some(msg) => Err(msg),
+        None => Ok(value),
+    }
+}
+
+/// clap `value_parser` for a tolerance/epsilon flag.
+pub(crate) fn parse_tolerance(s: &str) -> std::result::Result<f64, String> {
+    parse_in(s, TOLERANCE)
+}
+
+/// clap `value_parser` for a `[0.0, 1.0]` fraction flag.
+pub(crate) fn parse_fraction(s: &str) -> std::result::Result<f64, String> {
+    parse_in(s, FRACTION)
+}
+
+/// clap `value_parser` for a cosine-similarity floor flag.
+pub(crate) fn parse_cosine(s: &str) -> std::result::Result<f64, String> {
+    parse_in(s, COSINE)
+}
+
+fn parse_in(s: &str, domain: ThresholdDomain) -> std::result::Result<f64, String> {
+    let value: f64 = s.parse().map_err(|_| "invalid float literal".to_string())?;
+    check(value, domain)
+}
+
+/// Fail-closed guard for the `run()` entry points, so a non-clap caller cannot
+/// disarm a gate either. Errors as `ValidationFailed` (exit 5), matching the
+/// exit code the gate itself would have produced.
+pub(crate) fn guard(flag: &str, value: f64, domain: ThresholdDomain) -> Result<()> {
+    match reject_reason(value, domain) {
+        Some(msg) => Err(CliError::ValidationFailed(format!(
+            "invalid value for {flag}: {msg}"
+        ))),
+        None => Ok(()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn nan_is_rejected_in_every_domain() {
+        for d in [TOLERANCE, FRACTION, COSINE] {
+            let err = check(f64::NAN, d).unwrap_err();
+            assert!(
+                err.contains("NaN is not a threshold"),
+                "NaN must be rejected for {d:?}; got: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn infinities_are_rejected_in_every_domain() {
+        for d in [TOLERANCE, FRACTION, COSINE] {
+            assert!(check(f64::INFINITY, d).is_err(), "+inf must be rejected");
+            assert!(
+                check(f64::NEG_INFINITY, d).is_err(),
+                "-inf must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn negative_tolerance_is_rejected() {
+        let err = check(-1.0, TOLERANCE).unwrap_err();
+        assert!(err.contains("outside the valid domain"), "got: {err}");
+        assert!(check(-1.0, FRACTION).is_err());
+        // A cosine floor legitimately reaches -1.0.
+        assert_eq!(check(-1.0, COSINE), Ok(-1.0));
+    }
+
+    #[test]
+    fn legitimate_values_pass_through_unchanged() {
+        assert_eq!(check(0.0, TOLERANCE), Ok(0.0));
+        assert_eq!(check(5e-3, TOLERANCE), Ok(5e-3));
+        assert_eq!(check(1e9, TOLERANCE), Ok(1e9));
+        assert_eq!(check(0.95, FRACTION), Ok(0.95));
+        assert_eq!(check(1.0, FRACTION), Ok(1.0));
+        assert_eq!(check(0.9999, COSINE), Ok(0.9999));
+    }
+
+    #[test]
+    fn fraction_rejects_out_of_range_upper_bound() {
+        let err = check(99.0, FRACTION).unwrap_err();
+        assert!(err.contains("outside the valid domain"), "got: {err}");
+    }
+
+    #[test]
+    fn parsers_reject_nan_and_keep_rejecting_garbage() {
+        assert!(parse_tolerance("nan").is_err());
+        assert!(parse_tolerance("NaN").is_err());
+        assert!(parse_fraction("nan").is_err());
+        assert!(parse_cosine("nan").is_err());
+        assert_eq!(
+            parse_tolerance("banana").unwrap_err(),
+            "invalid float literal"
+        );
+        assert_eq!(parse_tolerance("1e-5"), Ok(1e-5));
+        assert_eq!(parse_fraction("0.85"), Ok(0.85));
+    }
+
+    /// `Commands` is a very large enum; building the clap command tree needs
+    /// more stack than the 2 MiB a test thread gets by default.
+    fn on_big_stack(f: impl FnOnce() + Send + 'static) {
+        std::thread::Builder::new()
+            .stack_size(32 * 1024 * 1024)
+            .spawn(f)
+            .expect("spawn")
+            .join()
+            .expect("join");
+    }
+
+    /// The user-visible half of the fix: clap itself must refuse the value, so
+    /// no gate ever runs and no `Ok` is ever printed. One case per flag in the
+    /// family, each with the literal that shipped the disarm in 0.63.0.
+    #[test]
+    fn cli_rejects_nan_on_every_threshold_flag_in_the_lint_family() {
+        on_big_stack(cli_rejects_nan_body);
+    }
+
+    fn cli_rejects_nan_body() {
+        use clap::Parser;
+
+        let disarming: &[&[&str]] = &[
+            &[
+                "apr",
+                "kv-timeline-lint",
+                "--timeline-file",
+                "kv.json",
+                "--preempt-threshold",
+                "nan",
+            ],
+            &[
+                "apr",
+                "kv-timeline-lint",
+                "--timeline-file",
+                "kv.json",
+                "--preempt-threshold=-1",
+            ],
+            &[
+                "apr",
+                "attn-parity-lint",
+                "--parity-file",
+                "p.json",
+                "--tol-abs",
+                "nan",
+            ],
+            &[
+                "apr",
+                "attn-parity-lint",
+                "--parity-file",
+                "p.json",
+                "--tol-cos",
+                "NaN",
+            ],
+            &[
+                "apr",
+                "attn-viz-lint",
+                "--attn-file",
+                "a.json",
+                "--tolerance",
+                "nan",
+            ],
+            &[
+                "apr",
+                "attn-viz-lint",
+                "--attn-file",
+                "a.json",
+                "--epsilon",
+                "nan",
+            ],
+            &[
+                "apr",
+                "explain-token-lint",
+                "--jsonl-file",
+                "e.jsonl",
+                "--tolerance",
+                "nan",
+            ],
+            &[
+                "apr",
+                "ddp-metrics-lint",
+                "--metrics-1gpu-file",
+                "a.json",
+                "--metrics-ngpu-file",
+                "b.json",
+                "--world-size",
+                "4",
+                "--scaling-floor",
+                "nan",
+            ],
+            &[
+                "apr",
+                "ddp-metrics-lint",
+                "--metrics-1gpu-file",
+                "a.json",
+                "--metrics-ngpu-file",
+                "b.json",
+                "--world-size",
+                "4",
+                "--loss-tolerance",
+                "nan",
+            ],
+            &[
+                "apr",
+                "ddp-metrics-lint",
+                "--metrics-1gpu-file",
+                "a.json",
+                "--metrics-ngpu-file",
+                "b.json",
+                "--world-size",
+                "4",
+                "--scaling-floor=-1",
+            ],
+        ];
+
+        for argv in disarming {
+            let parsed = crate::Cli::try_parse_from(argv.iter().copied());
+            assert!(
+                parsed.is_err(),
+                "clap accepted a gate-disarming threshold: {argv:?}"
+            );
+        }
+    }
+
+    /// The fix must not narrow the legitimate domain: every value the shipped
+    /// falsification suites pass on the command line still parses.
+    #[test]
+    fn cli_still_accepts_the_documented_threshold_values() {
+        on_big_stack(cli_accepts_documented_body);
+    }
+
+    fn cli_accepts_documented_body() {
+        use clap::Parser;
+
+        let legitimate: &[&[&str]] = &[
+            &[
+                "apr",
+                "kv-timeline-lint",
+                "--timeline-file",
+                "kv.json",
+                "--preempt-threshold",
+                "0.80",
+            ],
+            &[
+                "apr",
+                "attn-parity-lint",
+                "--parity-file",
+                "p.json",
+                "--tol-abs",
+                "0.01",
+                "--tol-cos",
+                "0.9999",
+            ],
+            &[
+                "apr",
+                "attn-viz-lint",
+                "--attn-file",
+                "a.json",
+                "--tolerance",
+                "0.05",
+                "--epsilon",
+                "1e-9",
+            ],
+            &[
+                "apr",
+                "explain-token-lint",
+                "--jsonl-file",
+                "e.jsonl",
+                "--tolerance",
+                "0.05",
+            ],
+            &[
+                "apr",
+                "ddp-metrics-lint",
+                "--metrics-1gpu-file",
+                "a.json",
+                "--metrics-ngpu-file",
+                "b.json",
+                "--world-size",
+                "4",
+                "--scaling-floor",
+                "0.5",
+                "--loss-tolerance",
+                "0.01",
+            ],
+        ];
+
+        for argv in legitimate {
+            let parsed = crate::Cli::try_parse_from(argv.iter().copied());
+            assert!(
+                parsed.is_ok(),
+                "clap rejected a legitimate threshold: {argv:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn guard_reports_the_flag_name_and_is_validation_failed() {
+        let err = guard("--tol-abs", f64::NAN, TOLERANCE).unwrap_err();
+        match err {
+            CliError::ValidationFailed(msg) => {
+                assert!(msg.contains("--tol-abs"), "got: {msg}");
+                assert!(msg.contains("NaN"), "got: {msg}");
+            }
+            other => panic!("expected ValidationFailed, got {other:?}"),
+        }
+        assert!(guard("--tol-abs", 5e-3, TOLERANCE).is_ok());
+    }
+}

--- a/crates/apr-cli/src/extended_commands.rs
+++ b/crates/apr-cli/src/extended_commands.rs
@@ -867,10 +867,12 @@ pub enum ExtendedCommands {
         #[arg(long, value_name = "N")]
         world_size: i64,
         /// Scaling-efficiency floor (default 0.85, PyTorch DDP convention)
-        #[arg(long, value_name = "F", default_value_t = 0.85)]
+        #[arg(long, value_name = "F", default_value_t = 0.85,
+              value_parser = commands::threshold_arg::parse_fraction)]
         scaling_floor: f64,
         /// Loss-parity relative tolerance (default 0.01)
-        #[arg(long, value_name = "F", default_value_t = 0.01)]
+        #[arg(long, value_name = "F", default_value_t = 0.01,
+              value_parser = commands::threshold_arg::parse_tolerance)]
         loss_tolerance: f64,
     },
     /// Lint a captured `apr dataset audio-inspect --format json` body (CRUX-H-13)
@@ -897,10 +899,12 @@ pub enum ExtendedCommands {
         #[arg(long, value_name = "FILE")]
         head_dim_error_file: Option<PathBuf>,
         /// Max absolute diff tolerance (default 5e-3, FlashAttention-2 bound)
-        #[arg(long, value_name = "F", default_value_t = 5e-3)]
+        #[arg(long, value_name = "F", default_value_t = 5e-3,
+              value_parser = commands::threshold_arg::parse_tolerance)]
         tol_abs: f64,
         /// Min cosine similarity floor (default 0.9999)
-        #[arg(long, value_name = "F", default_value_t = 0.9999)]
+        #[arg(long, value_name = "F", default_value_t = 0.9999,
+              value_parser = commands::threshold_arg::parse_cosine)]
         tol_cos: f64,
     },
     /// Lint a captured `apr attn-viz` attention dump (CRUX-F-17)
@@ -915,10 +919,12 @@ pub enum ExtendedCommands {
         #[arg(long, value_name = "N", default_value_t = 1)]
         expected_heatmaps: usize,
         /// Row-softmax normalization tolerance (default 1e-5)
-        #[arg(long, value_name = "F64", default_value_t = 1e-5)]
+        #[arg(long, value_name = "F64", default_value_t = 1e-5,
+              value_parser = commands::threshold_arg::parse_tolerance)]
         tolerance: f64,
         /// Causal-mask zero epsilon (default 1e-9)
-        #[arg(long, value_name = "F64", default_value_t = 1e-9)]
+        #[arg(long, value_name = "F64", default_value_t = 1e-9,
+              value_parser = commands::threshold_arg::parse_tolerance)]
         epsilon: f64,
     },
     /// Lint a captured `apr trace --check-finite` error JSON and/or `--list` coverage JSON (CRUX-F-11)
@@ -951,7 +957,8 @@ pub enum ExtendedCommands {
         #[arg(long, value_name = "FILE")]
         jsonl_file: PathBuf,
         /// Tolerance for `Σ post_prob ≈ 1.0` (default 1e-5)
-        #[arg(long, value_name = "F64", default_value_t = 1e-5)]
+        #[arg(long, value_name = "F64", default_value_t = 1e-5,
+              value_parser = commands::threshold_arg::parse_tolerance)]
         tolerance: f64,
         /// Assert greedy decoding: sampled_id must equal argmax(pre_prob)
         #[arg(long)]
@@ -969,7 +976,8 @@ pub enum ExtendedCommands {
         #[arg(long, value_name = "FILE")]
         timeline_file: PathBuf,
         /// Preemption threshold (default 0.95, vLLM canonical)
-        #[arg(long, value_name = "FRACTION", default_value_t = 0.95)]
+        #[arg(long, value_name = "FRACTION", default_value_t = 0.95,
+              value_parser = commands::threshold_arg::parse_fraction)]
         preempt_threshold: f64,
     },
     /// Lint a captured OTLP/JSON ExportTraceServiceRequest body (CRUX-K-08)

--- a/crates/apr-cli/tests/cli_commands.rs
+++ b/crates/apr-cli/tests/cli_commands.rs
@@ -456,3 +456,141 @@ fn backend_cuda_on_non_cuda_build_refuses_instead_of_falling_back() {
          Output:\n{combined}"
     );
 }
+
+/// True when the report printed `<gate> : Ok` — i.e. a positive assertion that
+/// the named gate examined the observation and was satisfied by it.
+fn report_says_gate_is_ok(stdout: &str, gate: &str) -> bool {
+    stdout.lines().any(|line| {
+        let line = line.trim();
+        match line.split_once(':') {
+            Some((label, verdict)) => label.trim() == gate && verdict.trim().starts_with("Ok"),
+            None => false,
+        }
+    })
+}
+
+/// FALSIFY-CLI-THRESHOLD-NAN-001: a NaN (or negative) tolerance must never turn
+/// a failing CRUX lint gate into a reported pass.
+///
+/// Every one of these gates compares an observation against a threshold —
+/// `mad > tol_abs`, `efficiency < floor`, `used_pct < threshold`. IEEE-754
+/// makes every comparison against NaN false, so in apr 0.63.0 `--tol-abs nan`,
+/// `--scaling-floor nan`, `--preempt-threshold nan`, `--tolerance nan` and
+/// `--epsilon nan` each made the failing branch unreachable: the command exited
+/// 0 AND the report printed a positive `Ok` next to the violating number, e.g.
+/// `scaling_efficiency : Ok { efficiency: 0.0025 }` for a 0.25%-efficient DDP
+/// run. A CI log scraper reading that gets the wrong answer.
+///
+/// Each case runs twice against the SAME observation file: once with the
+/// shipped defaults (must fail — proving the body is genuinely bad and the gate
+/// works) and once with the disarming value (must also fail).
+#[test]
+fn nan_threshold_never_reports_a_failing_lint_gate_as_ok() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let p = |name: &str, body: &str| -> String {
+        let path = dir.path().join(name);
+        std::fs::write(&path, body).expect("write fixture");
+        path.display().to_string()
+    };
+
+    let kv = p(
+        "kv.json",
+        r#"{"block_size_tokens":16,"total_blocks":100,"peak_used_pct":0.1,"preemption_count":3,
+            "timeline":[{"step":0,"t_ms":1.0,"used_blocks":10,"free_blocks":90,
+                         "used_pct":0.10,"active_seqs":1,"preempted_seqs":3}]}"#,
+    );
+    let parity = p("parity.json", r#"{"max_abs_diff":999.0,"cosine_sim":-0.5}"#);
+    let attn = p("attn.json", "[[[[3.0,2.0],[0.5,0.5]]]]");
+    let explain = p(
+        "explain.jsonl",
+        "{\"step\":0,\"sampled_id\":7,\"candidates\":[\
+         {\"token_id\":7,\"pre_prob\":0.9,\"post_prob\":0.5,\"rank\":0},\
+         {\"token_id\":3,\"pre_prob\":0.1,\"post_prob\":0.1,\"rank\":1}]}\n",
+    );
+    let ddp1 = p("ddp1.json", r#"{"tokens_per_sec":1000.0,"final_loss":2.0}"#);
+    let ddpn = p(
+        "ddpn.json",
+        r#"{"tokens_per_sec":10.0,"final_loss":9.9,
+            "ddp_metrics":{"allreduce_bandwidth_gbps":[12.5]}}"#,
+    );
+
+    // (args that fail at the defaults, the disarming values, the gate label
+    //  that must never be reported as Ok)
+    let cases: Vec<(Vec<String>, Vec<String>, &str)> = vec![
+        (
+            vec!["kv-timeline-lint".into(), "--timeline-file".into(), kv],
+            vec!["--preempt-threshold".into(), "nan".into()],
+            "preemption_trigger",
+        ),
+        (
+            vec!["attn-parity-lint".into(), "--parity-file".into(), parity],
+            vec![
+                "--tol-abs".into(),
+                "nan".into(),
+                "--tol-cos".into(),
+                "nan".into(),
+            ],
+            "parity_numerics",
+        ),
+        (
+            vec!["attn-viz-lint".into(), "--attn-file".into(), attn],
+            vec![
+                "--tolerance".into(),
+                "nan".into(),
+                "--epsilon".into(),
+                "nan".into(),
+            ],
+            "row_softmax",
+        ),
+        (
+            vec!["explain-token-lint".into(), "--jsonl-file".into(), explain],
+            vec!["--tolerance".into(), "nan".into()],
+            "probs_normalize",
+        ),
+        (
+            vec![
+                "ddp-metrics-lint".into(),
+                "--metrics-1gpu-file".into(),
+                ddp1,
+                "--metrics-ngpu-file".into(),
+                ddpn,
+                "--world-size".into(),
+                "4".into(),
+            ],
+            vec![
+                "--scaling-floor".into(),
+                "nan".into(),
+                "--loss-tolerance".into(),
+                "nan".into(),
+            ],
+            "scaling_efficiency",
+        ),
+    ];
+
+    for (base, disarm, gate) in cases {
+        let control = apr_binary().args(&base).output().expect("run apr");
+        assert!(
+            !control.status.success(),
+            "FALSIFY-CLI-THRESHOLD-NAN-001 control: `apr {}` must FAIL at the shipped \
+             defaults, otherwise the disarm case below proves nothing.\nstdout:\n{}",
+            base.join(" "),
+            String::from_utf8_lossy(&control.stdout)
+        );
+
+        let mut args = base.clone();
+        args.extend(disarm.iter().cloned());
+        let out = apr_binary().args(&args).output().expect("run apr");
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        assert!(
+            !out.status.success(),
+            "FALSIFY-CLI-THRESHOLD-NAN-001: `apr {}` exited 0 — a NaN threshold disarmed \
+             the {gate} gate on a body that fails at the defaults.\nstdout:\n{stdout}",
+            args.join(" ")
+        );
+        assert!(
+            !report_says_gate_is_ok(&stdout, gate),
+            "FALSIFY-CLI-THRESHOLD-NAN-001: the report asserted `{gate} : Ok` for an \
+             observation it never actually checked.\nstdout:\n{stdout}"
+        );
+    }
+}


### PR DESCRIPTION
Eight tolerance/threshold flags across five lint commands accept `nan` and silently disarm the gate they configure. On apr 0.63.0 installed from crates.io, the same DDP metrics pair that fails at the shipped defaults:

```
$ apr ddp-metrics-lint --metrics-1gpu-file ddp1.json --metrics-ngpu-file ddp4.json --world-size 4
  scaling_efficiency  : BelowThreshold { world_size: 4, t1: 1000.0, tn: 10.0, efficiency: 0.0025, threshold: 0.85 }
  loss_parity         : Divergence { l1: 2.0, ln: 9.9, rel_diff: 3.95, tolerance: 0.01 }
rc=5

$ apr ddp-metrics-lint ... --scaling-floor nan --loss-tolerance nan
  scaling_efficiency  : Ok { efficiency: 0.0025 }
  loss_parity         : Ok { rel_diff: 3.95 }
rc=0
```

The exit code is the smaller half of the damage. The report prints a positive `Ok` next to the violating number — a statement that 0.25% DDP scaling efficiency and a 3860% loss divergence were examined and found acceptable. A CI log scraper reading that line gets the wrong answer with no indication anything was skipped, and neither the text nor the `--json` report echoes the threshold used, so the disarm is unauditable after the fact.

Reproduced on all five commands with four different observation shapes (JSON object, two-file JSON pair, 4-D array, JSONL), and isolated to NaN/negative by holding the body constant and sweeping only the threshold: `0.95` FAIL, `99` FAIL, `inf` FAIL, `NaN` PASS, `-1` PASS. `abc` was already rejected by clap, so the parser validated syntax but never domain.

## Root cause

One mechanism repeated eight times, not eight bugs. Every gate is `if observed > tolerance { fail }` or `if observed < floor { fail }`:

- `crates/apr-cli/src/commands/kv_timeline_classifier.rs:256` — `if up < threshold`
- `crates/apr-cli/src/commands/attn_parity_classifier.rs:91,97`
- `crates/apr-cli/src/commands/ddp_metrics_classifier.rs:114,146`
- the equivalents in `attn_viz_classifier.rs` and `explain_token_classifier.rs`

IEEE-754 makes every comparison against NaN false, so the failing branch is unreachable. Nothing validated the incoming threshold — notable because those same classifiers already refuse to judge a non-finite *observation* (`AttnParityNumericsOutcome::NonFiniteMaxAbsDiff`). This PR adds the symmetric guard on the threshold side.

## Fix

`crates/apr-cli/src/commands/threshold_arg.rs` is the single validator, used at both layers:

1. as a clap `value_parser` on all eight flags, so a bad value is rejected at parse time (exit 2) before any gate runs;
2. as a `guard()` at the top of each lint `run()`, so a caller that bypasses clap also fails closed instead of printing `Ok`.

Three domains: `TOLERANCE` (finite, `>= 0`), `FRACTION` (`[0,1]`), `COSINE` (`[-1,1]`).

```
$ apr kv-timeline-lint --timeline-file kv.json --preempt-threshold=nan
error: invalid value 'nan' for '--preempt-threshold <FRACTION>': NaN is not a threshold:
every comparison against NaN is false, so the gate could never fail.
Expected a finite fraction in [0.0, 1.0]
rc=2
```

Two deliberate behaviour changes beyond NaN: `inf` and out-of-domain values are now rejected too. Both previously "worked" in the sense of failing loudly (`--preempt-threshold 99` reported `threshold: 99.0`), but neither can express a bound, and an infinite tolerance disarms a max-style gate exactly as NaN does. Explicit relaxation still works through legitimate values — `--scaling-floor 0.0 --loss-tolerance 1e9` still exits 0, and every threshold value used by the shipped CRUX falsification suites still parses.

## Mutation check

With `reject_reason()` stubbed to `return None` and all tests kept, the falsifiers go RED:

```
FALSIFY-CLI-THRESHOLD-NAN-001: `apr kv-timeline-lint --timeline-file /tmp/.tmpZng1k4/kv.json
--preempt-threshold nan` exited 0 — a NaN threshold disarmed the preemption_trigger gate on
a body that fails at the defaults.
stdout:
kv-timeline-lint report for /tmp/.tmpZng1k4/kv.json
  schema             : Ok
  block_conservation : Ok
  used_pct_arithmetic: Ok
  peak_consistency   : Ok
  preemption_trigger : Ok

expected --scaling-floor named; got: ddp-metrics-lint loss-parity gate rejected:
Divergence { l1: 2.0, ln: 9.9, rel_diff: 3.95, tolerance: 0.01 }

clap accepted a gate-disarming threshold:
["apr", "kv-timeline-lint", "--timeline-file", "kv.json", "--preempt-threshold", "nan"]

test result: FAILED. 0 passed; 5 failed   (lib run() guards, one per command)
test result: FAILED. 2 passed; 7 failed   (threshold_arg unit + clap parse, one case per flag)
test result: FAILED. 0 passed; 1 failed   (cli_commands e2e against the real binary)
```

Restored: `cargo test -p apr-cli --lib` 6641 passed / 0 failed; `cli_commands` 10/10; the five CRUX falsification suites (F-06, L-02, F-17, F-19, D-11) 52/52. `cargo fmt --all -- --check` and `cargo clippy -p apr-cli --lib -- -D warnings` clean. `pv validate contracts/apr-cli-commands-v1.yaml` valid.

The e2e falsifier lives in `tests/cli_commands.rs` on purpose — it is one of the few integration targets `ci.yml` actually runs — and it asserts the control case (the same body must still fail at the defaults) before asserting the disarm case, so it cannot pass vacuously.

## Verified end-to-end

Against `target/release/apr` built from this branch, every original repro from #2391 now exits 2 with a domain error instead of 0 with `Ok`: `--preempt-threshold` {nan, NaN, -1, inf, 99}, `--tol-abs`, `--tol-cos`, `--tolerance`, `--epsilon`, `--scaling-floor`, `--loss-tolerance`.

Refs #2391 (partial) — this PR fixes findings 1, 2, 3 and 5 (the NaN/negative threshold family). Remaining in that issue, untouched here: finding 4 (imatrix-lint duplicate `falsify_id`), finding 6 (typical-p-lint silently skips a mistyped section), finding 7 (`stamp --license` accepts non-SPDX), finding 8 (`beat-run` leaks `Some(..)` and misattributes a non-finite `--measured`).

Audit epic: #2373

🤖 Generated with [Claude Code](https://claude.com/claude-code)
