### PR TITLE
fix(mcp,code): apr 0.63.0 ran apr 0.60.0 — both subprocess backends resolved a bare apr through PATH

### DIFF
--- a/crates/aprender-mcp/src/apr_bin.rs
+++ b/crates/aprender-mcp/src/apr_bin.rs
@@ -1,0 +1,198 @@
+//! Resolution of the `apr` binary this server delegates to.
+//!
+//! Every subprocess-backed MCP tool shells out to `apr <subcommand> --json`.
+//! Until this module existed, that spawn was a literal `Command::new("apr")`,
+//! which asks the operating system to search `$PATH`. That is the exact
+//! anti-pattern `CLAUDE.md` opens with ("NEVER hardcode or PATH-resolve an
+//! `apr` binary"), and it produced a wrong-answer channel in the field:
+//!
+//! * `apr mcp` launched from the freshly installed 0.63.0 artifact executed
+//!   `/home/noah/.local/bin/apr`, which is 0.60.0, for all eight subprocess
+//!   tools — while `apr.version` kept answering `0.63.0` from in-process
+//!   state. The one tool a client uses to establish provenance reported a
+//!   version that none of the other tools actually ran.
+//! * A user who runs the binary by path without putting its install directory
+//!   on `$PATH` gets `Failed to spawn ...: No such file or directory` from
+//!   eight of nine tools.
+//!
+//! [`apr_binary`] fixes both: when the running executable *is* `apr`, the
+//! server delegates to **itself**, so `apr mcp` from 0.63.0 runs 0.63.0.
+//!
+//! # Resolution order
+//!
+//! 1. `$APR_BIN`, if set and non-empty. Escape hatch for embedders and for
+//!    tests that need to point the server at a mock.
+//! 2. [`std::env::current_exe`], **if its file stem is exactly `apr`**. The
+//!    stem check is what keeps the library usable outside the `apr` binary:
+//!    under `cargo test` the current executable is
+//!    `target/debug/deps/aprender_mcp-<hash>`, which must not be spawned with
+//!    `validate model.gguf --json`.
+//! 3. The bare name `apr`, resolved by the OS through `$PATH`. Reached only
+//!    when the host process is not `apr` itself.
+
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+
+/// Environment variable that overrides binary resolution entirely.
+pub const APR_BIN_ENV: &str = "APR_BIN";
+
+/// The program the subprocess-backed tools should execute.
+///
+/// See the [module docs](self) for the resolution order.
+#[must_use]
+pub fn apr_binary() -> PathBuf {
+    resolve(std::env::var_os(APR_BIN_ENV), std::env::current_exe().ok())
+}
+
+/// Pure core of [`apr_binary`], parameterised over the two pieces of process
+/// state it reads so the resolution policy is testable without mutating the
+/// environment of the running test process.
+#[must_use]
+pub fn resolve(override_var: Option<OsString>, current_exe: Option<PathBuf>) -> PathBuf {
+    if let Some(explicit) = override_var {
+        if !explicit.is_empty() {
+            return PathBuf::from(explicit);
+        }
+    }
+    if let Some(exe) = current_exe {
+        if is_apr_binary(&exe) {
+            return exe;
+        }
+    }
+    PathBuf::from("apr")
+}
+
+/// True when `path` names the `apr` CLI itself (`apr`, or `apr.exe` on
+/// Windows). Deliberately an exact stem match: `aprender_mcp-1a2b3c` and
+/// `apr-cli` are *not* `apr`, and spawning them with `apr` subcommands would
+/// be worse than falling back to `$PATH`.
+fn is_apr_binary(path: &Path) -> bool {
+    path.file_stem().is_some_and(|stem| stem == "apr")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    /// Write an executable shell script at `path` that prints `marker`.
+    fn write_marker_bin(path: &Path, marker: &str) {
+        let mut f = std::fs::File::create(path).expect("create marker bin");
+        writeln!(f, "#!/bin/sh").expect("shebang");
+        writeln!(f, "echo {marker}").expect("body");
+        f.sync_all().expect("sync");
+        drop(f);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(path).expect("stat").permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(path, perms).expect("chmod");
+        }
+    }
+
+    /// Per-process, per-call scratch dir. A fixed path would let two
+    /// concurrent runs of this test binary delete each other's shim.
+    fn scratch_dir(name: &str) -> PathBuf {
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let dir = std::env::temp_dir().join(format!(
+            "aprender-mcp-apr-bin-{name}-{}-{nonce}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).expect("mkdir scratch");
+        dir
+    }
+
+    /// FALSIFIER (#2384): when the running executable *is* `apr`, resolution
+    /// must yield that exact executable — not the bare name `apr`, which the
+    /// OS would resolve through `$PATH` to whatever stale `apr` happens to be
+    /// installed first.
+    ///
+    /// Behavioural, not shape-based: we execute the resolved program and
+    /// assert it is the one we designated as "self". Before the fix, resolve
+    /// returned `PathBuf::from("apr")`, which is not executable as written
+    /// (no such relative file) and is not the self binary.
+    #[test]
+    #[cfg(unix)]
+    fn resolution_executes_the_current_executable_not_a_path_lookup() {
+        let dir = scratch_dir("self");
+        let self_apr = dir.join("apr");
+        write_marker_bin(&self_apr, "SELF-BINARY-UNDER-TEST");
+
+        let resolved = resolve(None, Some(self_apr.clone()));
+        assert_eq!(
+            resolved,
+            self_apr,
+            "resolution must return the running executable, got {}",
+            resolved.display()
+        );
+
+        let out = std::process::Command::new(&resolved)
+            .output()
+            .unwrap_or_else(|e| panic!("spawn resolved program {}: {e}", resolved.display()));
+        assert_eq!(
+            String::from_utf8_lossy(&out.stdout).trim(),
+            "SELF-BINARY-UNDER-TEST",
+            "the resolved program must be the current executable"
+        );
+    }
+
+    /// The two `apr` binaries in the field bug differ only by directory, so a
+    /// basename comparison would have passed while the defect was live. Assert
+    /// on the full path: resolving from `/a/apr` must never yield `/b/apr`.
+    #[test]
+    fn resolution_keeps_the_directory_of_the_current_executable() {
+        let a = PathBuf::from("/opt/release-0.63.0/bin/apr");
+        let b = PathBuf::from("/home/user/.local/bin/apr");
+        assert_eq!(resolve(None, Some(a.clone())), a);
+        assert_eq!(resolve(None, Some(b.clone())), b);
+        assert_ne!(resolve(None, Some(a)), b);
+    }
+
+    /// Library-embedded use (and every `cargo test` run) must still fall back
+    /// to `$PATH`: the current executable is a test harness, and spawning it
+    /// with `validate model.gguf --json` would be nonsense.
+    #[test]
+    fn non_apr_host_process_falls_back_to_the_path_name() {
+        let harness = PathBuf::from("/w/target/debug/deps/aprender_mcp-1a2b3c4d");
+        assert_eq!(resolve(None, Some(harness)), PathBuf::from("apr"));
+        assert_eq!(resolve(None, None), PathBuf::from("apr"));
+    }
+
+    /// `apr-cli`, `aprender`, `apr_serve` are not `apr`. Exact stem only.
+    #[test]
+    fn similar_names_are_not_treated_as_apr() {
+        for name in ["apr-cli", "aprender", "apr_serve", "aprx"] {
+            let exe = PathBuf::from("/usr/bin").join(name);
+            assert_eq!(
+                resolve(None, Some(exe)),
+                PathBuf::from("apr"),
+                "{name} must not be mistaken for the apr binary"
+            );
+        }
+    }
+
+    /// An `.exe` suffix is stripped by `file_stem`, so `apr.exe` is `apr`.
+    /// (Written with `/` separators so the assertion means the same thing on
+    /// every host — `\` is not a separator on Unix.)
+    #[test]
+    fn exe_suffix_is_recognised() {
+        let exe = PathBuf::from("/Program Files/apr/apr.exe");
+        assert_eq!(resolve(None, Some(exe.clone())), exe);
+    }
+
+    /// `$APR_BIN` wins over self-resolution, and an empty value is ignored
+    /// (an exported-but-empty variable must not spawn `""`).
+    #[test]
+    fn explicit_override_wins_and_empty_is_ignored() {
+        let exe = PathBuf::from("/opt/bin/apr");
+        assert_eq!(
+            resolve(Some(OsString::from("/mock/apr")), Some(exe.clone())),
+            PathBuf::from("/mock/apr")
+        );
+        assert_eq!(resolve(Some(OsString::new()), Some(exe.clone())), exe);
+    }
+}

--- a/crates/aprender-mcp/src/lib.rs
+++ b/crates/aprender-mcp/src/lib.rs
@@ -37,6 +37,7 @@
 //! real-model end-to-end; M5 ports the dispatcher to `pmcp = "2.3"` and
 //! extends cancellation to `apr.serve`.
 
+pub mod apr_bin;
 pub mod server;
 pub mod tools;
 pub mod types;

--- a/crates/aprender-mcp/src/tools/finetune.rs
+++ b/crates/aprender-mcp/src/tools/finetune.rs
@@ -125,7 +125,10 @@ pub fn call_with_sink(
     let argv: Vec<&str> = owned.iter().map(String::as_str).collect();
 
     match (sink, progress_token) {
-        (Some(sink), Some(token)) => stream_with_sink("apr", &argv, sink, &token),
+        (Some(sink), Some(token)) => {
+            // #2384: self-resolved binary, never a `$PATH` lookup.
+            stream_with_sink(crate::apr_bin::apr_binary(), &argv, sink, &token)
+        }
         _ => run_apr(&argv),
     }
 }
@@ -136,8 +139,8 @@ pub fn call_with_sink(
 /// forwarded as a plain string. The returned `ToolCallResult` is the
 /// aggregated stdout (same shape as `run_apr`'s success body).
 #[must_use]
-pub fn stream_with_sink(
-    program: &str,
+pub fn stream_with_sink<P: AsRef<std::ffi::OsStr>>(
+    program: P,
     args: &[&str],
     sink: &NotificationSink,
     progress_token: &serde_json::Value,

--- a/crates/aprender-mcp/src/tools/run.rs
+++ b/crates/aprender-mcp/src/tools/run.rs
@@ -120,7 +120,11 @@ pub fn call_with_sink(
     let argv: Vec<&str> = owned.iter().map(String::as_str).collect();
 
     match (streaming, sink, progress_token) {
-        (true, Some(sink), Some(token)) => stream_with_sink("apr", &argv, sink, &token),
+        (true, Some(sink), Some(token)) => {
+            // #2384: the streaming path must target the same self-resolved
+            // binary as the non-streaming path, not a `$PATH` lookup.
+            stream_with_sink(crate::apr_bin::apr_binary(), &argv, sink, &token)
+        }
         _ => run_apr_cancellable(&argv, cancel_rx, CANCEL_GRACE_MS),
     }
 }
@@ -134,8 +138,8 @@ pub fn call_with_sink(
 /// is the aggregated stdout (same shape as `run_apr_cancellable`'s success
 /// body) so non-streaming consumers get the full payload too.
 #[must_use]
-pub fn stream_with_sink(
-    program: &str,
+pub fn stream_with_sink<P: AsRef<std::ffi::OsStr>>(
+    program: P,
     args: &[&str],
     sink: &NotificationSink,
     progress_token: &serde_json::Value,

--- a/crates/aprender-mcp/src/tools/serve.rs
+++ b/crates/aprender-mcp/src/tools/serve.rs
@@ -70,7 +70,10 @@ pub fn call(args: &serde_json::Value) -> ToolCallResult {
         },
     };
 
-    let spawn_result = Command::new("apr")
+    // #2384: spawn the running `apr` executable, never a `$PATH` lookup —
+    // otherwise `apr mcp` from 0.63.0 starts whatever older `apr` is first on
+    // `$PATH`, and fails outright when the install dir is not on `$PATH`.
+    let spawn_result = Command::new(crate::apr_bin::apr_binary())
         .arg("serve")
         .arg(model_path)
         .arg("--port")

--- a/crates/aprender-mcp/src/tools/subprocess.rs
+++ b/crates/aprender-mcp/src/tools/subprocess.rs
@@ -11,7 +11,9 @@
 //! cancellation is signalled. The non-cancellable [`run_apr`] is kept as a
 //! thin wrapper for tools that don't support cancellation yet.
 
+use crate::apr_bin::apr_binary;
 use crate::types::ToolCallResult;
+use std::ffi::OsStr;
 use std::io::{BufRead, BufReader, Read};
 use std::process::{Command, Stdio};
 use std::sync::mpsc::{Receiver, TryRecvError};
@@ -36,11 +38,20 @@ const POLL_INTERVAL: Duration = Duration::from_millis(10);
 /// - Spawn failure → `error("Failed to spawn apr ...: <io-err>")`
 #[must_use]
 pub fn run_apr(args: &[&str]) -> ToolCallResult {
-    let output = match Command::new("apr").args(args).output() {
+    run_program(apr_binary(), args)
+}
+
+/// Generic-over-program variant of [`run_apr`]. [`run_apr`] binds `program`
+/// to [`crate::apr_bin::apr_binary`] — the running `apr` executable — so the
+/// version the user launched is the version that answers.
+#[must_use]
+pub fn run_program<P: AsRef<OsStr>>(program: P, args: &[&str]) -> ToolCallResult {
+    let program = program.as_ref();
+    let cmd_display = display_cmd(program, args);
+    let output = match Command::new(program).args(args).output() {
         Ok(o) => o,
         Err(e) => {
-            let cmd = format!("apr {}", args.join(" "));
-            return ToolCallResult::error(format!("Failed to spawn `{cmd}`: {e}"));
+            return ToolCallResult::error(format!("Failed to spawn `{cmd_display}`: {e}"));
         }
     };
 
@@ -49,8 +60,7 @@ pub fn run_apr(args: &[&str]) -> ToolCallResult {
 
     if output.status.success() {
         if stdout.trim().is_empty() {
-            let cmd = format!("apr {}", args.join(" "));
-            ToolCallResult::error(format!("`{cmd}` produced no output"))
+            ToolCallResult::error(format!("`{cmd_display}` produced no output"))
         } else {
             ToolCallResult::success(stdout)
         }
@@ -61,9 +71,13 @@ pub fn run_apr(args: &[&str]) -> ToolCallResult {
         } else {
             stderr
         };
-        let cmd = format!("apr {}", args.join(" "));
-        ToolCallResult::error(format!("`{cmd}` failed (exit {code}): {detail}"))
+        ToolCallResult::error(format!("`{cmd_display}` failed (exit {code}): {detail}"))
     }
+}
+
+/// Render `program args...` for user-facing error messages.
+fn display_cmd(program: &OsStr, args: &[&str]) -> String {
+    format!("{} {}", program.to_string_lossy(), args.join(" "))
 }
 
 /// Spawn `apr <args...>` cancellable via `cancel_rx`.
@@ -82,19 +96,21 @@ pub fn run_apr_cancellable(
     cancel_rx: &Receiver<()>,
     grace_ms: u64,
 ) -> ToolCallResult {
-    spawn_cancellable("apr", args, cancel_rx, grace_ms)
+    spawn_cancellable(apr_binary(), args, cancel_rx, grace_ms)
 }
 
-/// Test-visible generic over the binary name. `run_apr_cancellable` is the
-/// `"apr"`-bound wrapper clients should use in production code.
+/// Generic over the binary. `run_apr_cancellable` binds `program` to
+/// [`crate::apr_bin::apr_binary`] — the running `apr` executable — which is
+/// what production code should use.
 #[must_use]
-pub fn spawn_cancellable(
-    program: &str,
+pub fn spawn_cancellable<P: AsRef<OsStr>>(
+    program: P,
     args: &[&str],
     cancel_rx: &Receiver<()>,
     grace_ms: u64,
 ) -> ToolCallResult {
-    let cmd_display = format!("{program} {}", args.join(" "));
+    let program = program.as_ref();
+    let cmd_display = display_cmd(program, args);
 
     let mut child = match Command::new(program)
         .args(args)
@@ -252,17 +268,22 @@ pub fn run_apr_streaming<F>(args: &[&str], on_line: F) -> ToolCallResult
 where
     F: FnMut(&str),
 {
-    spawn_streaming("apr", args, on_line)
+    spawn_streaming(apr_binary(), args, on_line)
 }
 
-/// Generic-over-program variant of [`run_apr_streaming`] used by tests that
-/// need to inject a mock subprocess.
+/// Generic-over-program variant of [`run_apr_streaming`]. Production callers
+/// pass [`crate::apr_bin::apr_binary`]; tests use it to inject a mock.
 #[must_use]
-pub fn spawn_streaming<F>(program: &str, args: &[&str], mut on_line: F) -> ToolCallResult
+pub fn spawn_streaming<P: AsRef<OsStr>, F>(
+    program: P,
+    args: &[&str],
+    mut on_line: F,
+) -> ToolCallResult
 where
     F: FnMut(&str),
 {
-    let cmd_display = format!("{program} {}", args.join(" "));
+    let program = program.as_ref();
+    let cmd_display = display_cmd(program, args);
 
     let mut child = match Command::new(program)
         .args(args)
@@ -347,6 +368,65 @@ mod tests {
     fn spawn_failure_maps_to_tool_error() {
         let result = run_apr(&["this-subcommand-does-not-exist"]);
         assert_eq!(result.is_error, Some(true));
+    }
+
+    /// FALSIFIER (#2384): `run_apr` must execute the *resolved* `apr` binary,
+    /// not a hard-coded `Command::new("apr")` that the OS looks up on `$PATH`.
+    ///
+    /// The field defect: `apr mcp` shipped in 0.63.0 returned results produced
+    /// by a 0.60.0 binary that happened to be first on `$PATH`, while
+    /// `apr.version` kept answering 0.63.0.
+    ///
+    /// Here we designate a specific binary via `$APR_BIN` and assert its
+    /// marker output comes back as the tool payload. Before the fix, `run_apr`
+    /// ignored resolution entirely and this returned whatever `apr` `$PATH`
+    /// produced — never the marker.
+    ///
+    /// The shim mirrors the real CLI's exit semantics (unknown subcommand →
+    /// exit 2) so it is compatible with `spawn_failure_maps_to_tool_error`
+    /// should the two overlap while `$APR_BIN` is set.
+    #[test]
+    #[cfg(unix)]
+    fn falsify_2384_run_apr_executes_the_resolved_binary() {
+        use std::io::Write;
+        use std::os::unix::fs::PermissionsExt;
+
+        // Unique per process: a fixed path lets two concurrent runs of this
+        // test binary delete each other's shim mid-flight.
+        let dir =
+            std::env::temp_dir().join(format!("aprender-mcp-2384-run-apr-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("mkdir scratch");
+        let shim = dir.join("apr");
+        {
+            let mut f = std::fs::File::create(&shim).expect("create shim");
+            writeln!(f, "#!/bin/sh").expect("shebang");
+            writeln!(f, "if [ \"$1\" = \"validate\" ]; then").expect("if");
+            writeln!(f, "  echo '{{\"marker\":\"APR-BIN-RESOLVED-SHIM\"}}'").expect("body");
+            writeln!(f, "  exit 0").expect("ok");
+            writeln!(f, "fi").expect("fi");
+            writeln!(f, "exit 2").expect("unknown subcommand");
+            f.sync_all().expect("sync");
+        }
+        let mut perms = std::fs::metadata(&shim).expect("stat").permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&shim, perms).expect("chmod");
+
+        // Edition 2021 — `set_var` is safe here.
+        std::env::set_var(crate::apr_bin::APR_BIN_ENV, &shim);
+        let result = run_apr(&["validate", "/dev/null", "--json"]);
+        std::env::remove_var(crate::apr_bin::APR_BIN_ENV);
+
+        assert!(
+            result.is_error.is_none(),
+            "resolved shim should succeed, got: {}",
+            result.content[0].text
+        );
+        assert!(
+            result.content[0].text.contains("APR-BIN-RESOLVED-SHIM"),
+            "run_apr must execute the resolved binary; got: {}",
+            result.content[0].text
+        );
     }
 
     /// Cancellable path: a never-firing receiver lets the subprocess run to

--- a/crates/aprender-orchestrate/src/agent/driver/apr_serve.rs
+++ b/crates/aprender-orchestrate/src/agent/driver/apr_serve.rs
@@ -518,13 +518,57 @@ fn configure_parent_death_signal(_cmd: &mut Command) {
     // on graceful exit). The point of this stub is to keep the crate building on those targets.
 }
 
-/// Find the `apr` binary on PATH.
+/// Environment variable that overrides `apr` binary resolution.
+pub(crate) const APR_BIN_ENV: &str = "APR_BIN";
+
+/// Resolve the `apr` binary that `apr code` launches as its inference backend.
+///
+/// #2384: this used to be a bare `which::which("apr")`. That made `apr code`
+/// serve its answers from whatever `apr` happened to be first on `$PATH` —
+/// a freshly installed 0.63.0 silently started a 0.60.0 backend — and it fails
+/// outright for anyone who runs the binary by path without installing it on
+/// `$PATH`. When the running executable *is* `apr`, launch **itself**.
+///
+/// `$PATH` is still the last resort, so a host process that is not `apr`
+/// (tests, embedders of the `batuta` library) keeps working.
 fn find_apr_binary() -> Result<PathBuf, AgentError> {
-    which::which("apr").map_err(|_| {
+    resolve_apr_binary(std::env::var_os(APR_BIN_ENV), std::env::current_exe().ok(), || {
+        which::which("apr").ok()
+    })
+    .ok_or_else(|| {
         AgentError::Driver(DriverError::InferenceFailed(
-            "apr binary not found on PATH. Install: cargo install apr-cli".into(),
+            "apr binary not found: this process is not `apr`, and no `apr` is on PATH. \
+             Install: cargo install aprender"
+                .into(),
         ))
     })
+}
+
+/// Pure core of [`find_apr_binary`], parameterised over the process state it
+/// reads so the resolution policy is testable without mutating `$PATH` or the
+/// environment of the running test process.
+fn resolve_apr_binary<F>(
+    override_var: Option<std::ffi::OsString>,
+    current_exe: Option<PathBuf>,
+    path_lookup: F,
+) -> Option<PathBuf>
+where
+    F: FnOnce() -> Option<PathBuf>,
+{
+    if let Some(explicit) = override_var {
+        if !explicit.is_empty() {
+            return Some(PathBuf::from(explicit));
+        }
+    }
+    if let Some(exe) = current_exe {
+        // Exact stem match only: `apr-cli` and `batuta-<hash>` test harnesses
+        // are not the `apr` CLI, and launching them with `serve run …` would
+        // be worse than falling back to `$PATH`.
+        if exe.file_stem().is_some_and(|stem| stem == "apr") {
+            return Some(exe);
+        }
+    }
+    path_lookup()
 }
 
 #[cfg(test)]

--- a/crates/aprender-orchestrate/src/agent/driver/apr_serve_tests.rs
+++ b/crates/aprender-orchestrate/src/agent/driver/apr_serve_tests.rs
@@ -9,6 +9,127 @@ fn test_find_apr_binary() {
     assert!(result.is_ok(), "apr binary should be on PATH: {result:?}");
 }
 
+// ═══ #2384: `apr code` must launch ITSELF, not a $PATH-resolved `apr` ═══
+//
+// Field defect: `apr code` from a freshly installed 0.63.0 spawned
+// `/home/noah/.local/bin/apr` (0.60.0) as its inference backend, because
+// `find_apr_binary` was a bare `which::which("apr")`.
+
+/// Write an executable `/bin/sh` script at `path` that prints `marker`.
+#[cfg(unix)]
+fn write_marker_bin(path: &std::path::Path, marker: &str) {
+    use std::io::Write;
+    let mut f = std::fs::File::create(path).expect("create marker bin");
+    writeln!(f, "#!/bin/sh").expect("shebang");
+    writeln!(f, "echo {marker}").expect("body");
+    f.sync_all().expect("sync");
+    drop(f);
+    use std::os::unix::fs::PermissionsExt;
+    let mut perms = std::fs::metadata(path).expect("stat").permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(path, perms).expect("chmod");
+}
+
+/// FALSIFIER (#2384): with a *different* `apr` reachable through the PATH
+/// lookup, resolution must still pick the running executable — and executing
+/// the resolved path must produce the self binary's output, not the PATH
+/// one's. Before the fix, `find_apr_binary` never consulted `current_exe`
+/// and always returned the PATH candidate.
+#[test]
+#[cfg(unix)]
+fn falsify_2384_self_wins_over_path_lookup() {
+    // Unique per process: a fixed path lets two concurrent runs of this test
+    // binary delete each other's shim mid-flight.
+    let dir =
+        std::env::temp_dir().join(format!("aprender-orchestrate-2384-self-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(dir.join("self")).expect("mkdir self");
+    std::fs::create_dir_all(dir.join("path")).expect("mkdir path");
+
+    let self_apr = dir.join("self").join("apr");
+    let path_apr = dir.join("path").join("apr");
+    write_marker_bin(&self_apr, "SELF-0.63.0");
+    write_marker_bin(&path_apr, "PATH-0.60.0");
+
+    let resolved = resolve_apr_binary(None, Some(self_apr.clone()), || Some(path_apr.clone()))
+        .expect("resolution must succeed");
+    assert_eq!(
+        resolved,
+        self_apr,
+        "must launch the running executable, got {}",
+        resolved.display()
+    );
+
+    let out = std::process::Command::new(&resolved).output().expect("spawn resolved backend");
+    assert_eq!(
+        String::from_utf8_lossy(&out.stdout).trim(),
+        "SELF-0.63.0",
+        "the backend that runs must be the binary the user invoked"
+    );
+}
+
+/// The field bug's two binaries share a basename and differ only by
+/// directory, so a basename comparison would have passed while the defect was
+/// live. Resolution must preserve the full path.
+#[test]
+fn falsify_2384_resolution_preserves_the_directory() {
+    let installed = std::path::PathBuf::from("/opt/release-0.63.0/bin/apr");
+    let stale = std::path::PathBuf::from("/home/user/.local/bin/apr");
+    let resolved = resolve_apr_binary(None, Some(installed.clone()), || Some(stale.clone()))
+        .expect("resolution must succeed");
+    assert_eq!(resolved, installed);
+    assert_ne!(resolved, stale);
+}
+
+/// A host process that is not `apr` (the `batuta` library embedded elsewhere,
+/// or this very test harness) must still fall back to `$PATH`.
+#[test]
+fn falsify_2384_non_apr_host_falls_back_to_path() {
+    let harness = std::path::PathBuf::from("/w/target/debug/deps/batuta-1a2b3c4d");
+    let on_path = std::path::PathBuf::from("/usr/bin/apr");
+    assert_eq!(
+        resolve_apr_binary(None, Some(harness), || Some(on_path.clone())),
+        Some(on_path.clone())
+    );
+    assert_eq!(resolve_apr_binary(None, None, || Some(on_path.clone())), Some(on_path));
+    // Nothing anywhere → None, which `find_apr_binary` maps to an error.
+    assert_eq!(resolve_apr_binary(None, None, || None), None);
+}
+
+/// Near-miss names are not the `apr` CLI.
+#[test]
+fn falsify_2384_similar_names_are_not_apr() {
+    let on_path = std::path::PathBuf::from("/usr/bin/apr");
+    for name in ["apr-cli", "aprender", "batuta", "aprx"] {
+        let exe = std::path::PathBuf::from("/usr/bin").join(name);
+        assert_eq!(
+            resolve_apr_binary(None, Some(exe), || Some(on_path.clone())),
+            Some(on_path.clone()),
+            "{name} must not be mistaken for the apr binary"
+        );
+    }
+}
+
+/// `$APR_BIN` overrides everything; an exported-but-empty value is ignored.
+#[test]
+fn falsify_2384_explicit_override_wins() {
+    let exe = std::path::PathBuf::from("/opt/bin/apr");
+    let on_path = std::path::PathBuf::from("/usr/bin/apr");
+    assert_eq!(
+        resolve_apr_binary(
+            Some(std::ffi::OsString::from("/mock/apr")),
+            Some(exe.clone()),
+            || Some(on_path.clone())
+        ),
+        Some(std::path::PathBuf::from("/mock/apr"))
+    );
+    assert_eq!(
+        resolve_apr_binary(Some(std::ffi::OsString::new()), Some(exe.clone()), || Some(on_path)),
+        Some(exe)
+    );
+    assert_eq!(APR_BIN_ENV, "APR_BIN");
+}
+
 #[test]
 fn test_privacy_tier_is_sovereign() {
     assert_eq!(PrivacyTier::Sovereign, PrivacyTier::Sovereign);


### PR DESCRIPTION
Dogfooding `cargo install aprender` 0.63.0 turned up the one anti-pattern this repo's CLAUDE.md opens with, in shipped code: `apr` asked the operating system to find `apr`. Both defects in this cluster are that single mistake at two call sites, and both are reproduced below against the installed crates.io artifact.

## What the user saw

**`apr mcp` (finding 2).** All eight subprocess-backed tools spawned `Command::new("apr")`. On a box where the first `apr` on `$PATH` is `/home/noah/.local/bin/apr` (0.60.0), the MCP server shipped *inside* 0.63.0 answered every tool call from a 0.60.0 binary — while `apr.version` kept reporting 0.63.0 from in-process state. The one tool a client uses to establish provenance named a version that none of the other eight actually executed.

With a logging shim first on `$PATH`, the shim's payload came back verbatim as the tool result:

```
$ PATH="$S/shim:$PATH" apr mcp < fifo   # apr = crates.io 0.63.0
{"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"{\"shim\":\"I am NOT the binary under test\"}\n"}]}}
$ cat $S/argv.log
SHIM-ARGV: validate /home/noah/.cache/pacha/models/d47927c5638f80ab.gguf --json
```

With no `apr` on `$PATH` at all, eight of nine tools failed outright:

```
--- command -v apr under that PATH ---
(no apr on PATH)
id 95 isError= True  'Failed to spawn `apr validate /home/noah/models/Qwen3.5-0.8B-Q4_K_M.gguf --json`: No such file or directory (os error 2)'
id 96 isError= None  '{"server":"aprender-mcp","version":"0.63.0","protocol_version":"2024-11-05"}'
```

**`apr code` (finding 1).** `find_apr_binary` was a bare `which::which("apr")`, so the inference backend was likewise whatever `apr` `$PATH` produced. Same shim:

```
$ cat $S/argv.log
SHIM-ARGV: serve run /home/noah/models/qwen2.5-coder-0.5b-instruct.apr --port 19789 --host 127.0.0.1 --gpu

stderr:
Launched apr serve on port 19789 (pid 863428)
⚠ apr serve unavailable (driver error: inference failed: apr serve exited with exit status: 3 during startup
```

For reference, what a bare `apr` resolves to on this box:

```
/home/noah/.local/bin/apr => apr 0.60.0 (v0.60.0+no-git)
/home/noah/.cargo/bin/apr => apr 0.63.0 (5643db51d)
```

## Root cause

Six literal `apr` program names, all resolved by the OS through `$PATH`:

| file:line | site |
|---|---|
| `crates/aprender-mcp/src/tools/subprocess.rs:39` | `Command::new("apr").args(args).output()` |
| `crates/aprender-mcp/src/tools/subprocess.rs:82` | `spawn_cancellable("apr", …)` |
| `crates/aprender-mcp/src/tools/subprocess.rs:~250` | `spawn_streaming("apr", …)` |
| `crates/aprender-mcp/src/tools/serve.rs:73` | `Command::new("apr")` |
| `crates/aprender-mcp/src/tools/run.rs:122` | `stream_with_sink("apr", …)` |
| `crates/aprender-orchestrate/src/agent/driver/apr_serve.rs:523` | `which::which("apr")` |
| `crates/aprender-mcp/src/tools/finetune.rs:128` | `stream_with_sink("apr", …)` |

The issue named the first, second-to-last and one middle site; the other three are the same defect on the streaming and cancellable paths and would have left the hole half-open.

## Fix

New `crates/aprender-mcp/src/apr_bin.rs` and a matching `resolve_apr_binary` in the orchestrate driver. Resolution order:

1. `$APR_BIN`, if set and non-empty — escape hatch for embedders and mocks.
2. `std::env::current_exe()`, **if its file stem is exactly `apr`** — so the version the user launched is the version that serves.
3. The bare name `apr` through `$PATH` — reached only when the host process is not `apr`.

The stem match is deliberately exact. Under `cargo test` the current executable is `target/debug/deps/aprender_mcp-<hash>`, which must never be spawned with `validate model.gguf --json`; that is also what keeps the crate usable as a library, and what keeps the existing PATH-shim integration tests (`falsify_mcp_003`, `_006`, `_progress_001` — 11 tests, all still green) exercising a real branch rather than a mock.

Also corrected the not-found hint, which read `cargo install apr-cli` — a crate that does not exist. The published crate is `aprender`.

## Falsifiers

All in lib unit tests, so they run under the `--lib` workspace gate rather than joining the dark integration targets.

- `aprender-mcp` `apr_bin::tests` — 6 cases. The lead one writes an executable marker script, designates it as the current executable, and **executes the resolved path**, asserting the marker comes back. Others pin that the directory is preserved (the two field binaries share a basename, so a basename comparison would have passed while the defect was live), that near-miss names (`apr-cli`, `aprender`, `apr_serve`) are not `apr`, and that non-`apr` hosts still fall back.
- `aprender-mcp` `tools::subprocess::tests::falsify_2384_run_apr_executes_the_resolved_binary` — drives the real `run_apr` entry point at a marker shim and asserts the shim's payload is what the tool returns. This is the test that catches a regression at the *call site* rather than in the resolver.
- `aprender-orchestrate` `agent::driver::apr_serve::tests::falsify_2384_*` — 5 cases, the lead one making a *different* `apr` reachable through the PATH lookup and asserting the executed backend is still the designated self binary.

## Mutation check

Reverting the fix while keeping the tests turns **5 red in `aprender-mcp`** and **3 red in `aprender-orchestrate`**:

```
---- apr_bin::tests::resolution_executes_the_current_executable_not_a_path_lookup stdout ----
assertion `left == right` failed: resolution must return the running executable, got apr
  left: "apr"
 right: "/tmp/aprender-mcp-apr-bin-self-3027748-1786348633152226785/apr"

---- apr_bin::tests::resolution_keeps_the_directory_of_the_current_executable stdout ----
assertion `left == right` failed
  left: "apr"
 right: "/opt/release-0.63.0/bin/apr"

---- tools::subprocess::tests::falsify_2384_run_apr_executes_the_resolved_binary stdout ----
resolved shim should succeed, got: `apr validate /dev/null --json` failed (exit 3): error: Not a file: /dev/null

test result: FAILED. 56 passed; 5 failed; 0 ignored; 0 measured; 0 filtered out
```

```
---- agent::driver::apr_serve::tests::falsify_2384_self_wins_over_path_lookup stdout ----
assertion `left == right` failed: must launch the running executable, got /tmp/aprender-orchestrate-2384-self-3077322/path/apr
  left: "/tmp/aprender-orchestrate-2384-self-3077322/path/apr"
 right: "/tmp/aprender-orchestrate-2384-self-3077322/self/apr"

test result: FAILED. 2 passed; 3 failed; 0 ignored; 0 measured; 6519 filtered out
```

The `run_apr` failure is the production defect in miniature: with the fix reverted, `run_apr` reached past the binary it was handed and executed the ambient `$PATH` `apr`, which answered `Not a file: /dev/null`. Restoring the fix returns 61/61 and 5/5 green.

Two of the eleven falsifiers stay green under the mutation by design — they assert the `$PATH` fallback, which the mutation does not remove.

## End-to-end on a release build of this branch

`cargo build --bin apr --release` → `/mnt/nvme-raid0/targets/aprender/release/apr` (`apr 0.63.0 (5643db51d)`), same repro scripts:

```
--- shim argv.log (empty == fix works) ---
SHIM NEVER INVOKED (no argv.log) — fix confirmed
shim marker present: False
model: /home/noah/.cache/pacha/models/d47927c5638f80ab.gguf
format: gguf
total_tensors: 339
```

```
$ apr code --model qwen2.5-coder-0.5b-instruct.apr -p "hi"   # shim first on PATH
--- shim argv.log (empty == fix works) ---
(no shim invocation)
Launched apr serve on port 19588 (pid 3410247)
apr serve ready (1.0s)
```

The shim exits 3; `apr serve ready (1.0s)` is only reachable if the launched child was a real `apr`, and the shim directory was first on `$PATH`, so a PATH lookup could not have missed it.

Third variation — no `apr` on `$PATH` at all, the case that broke eight of nine tools:

```
--- command -v apr under that PATH ---
(no apr on PATH)
id 95 isError= None '{\n  "model": "/home/noah/models/Qwen3.5-0.8B-Q4_K_M.gguf",\n  "format": "gguf",\n  "total_tensors": 320, ...'
id 96 isError= None '{"server":"aprender-mcp","version":"0.63.0",...}'
```

`apr code` still ends in `Invalid shape: matmul weight has EMPTY data buffer … see aprender#1789` on that particular `.apr` fixture. That is a pre-existing, unrelated model-loading defect — the crates.io binary hits the identical error through its embedded fallback — and it is downstream of the resolution this PR fixes.

## Gates

`cargo fmt --all -- --check` clean · `cargo clippy -p aprender-mcp --lib -- -D warnings` clean · `cargo clippy -p aprender-orchestrate --lib -- -D warnings` clean · `aprender-mcp --lib` 61/61 · `aprender-orchestrate --lib` 6520/6520 · `aprender-mcp` shim-based integration tests 11/11.

## Left for other tickets

- `apr.serve` still builds `apr serve <model>` where the valid form is `apr serve run <model>` — **#2388**, deliberately untouched here so the two changes stay reviewable apart.
- `apr code` still passes `--gpu` unconditionally even on a build with no cuda feature.

Fixes #2384
Audit epic: #2373

🤖 Generated with [Claude Code](https://claude.com/claude-code)
