### PR TITLE
fix(ci): three wall-clock assertions made the required workspace-test check non-deterministic

### DIFF
--- a/crates/aprender-test-lib/src/tui_load.rs
+++ b/crates/aprender-test-lib/src/tui_load.rs
@@ -1023,6 +1023,16 @@ mod tests {
 
         let _warmup = run_once();
 
+        // The invariant this test is named for is that 5000 items are handled
+        // without hanging. That is asserted on every iteration below and is a
+        // property of the code.
+        //
+        // The p95 frame time is REPORTED, not asserted. It used to be gated at
+        // `best_p95 < 100.0` and it failed at 174ms on a CI runner shared with
+        // 15 other jobs — min-of-3, so all three runs overshot. An absolute
+        // wall-clock bound inside the REQUIRED `workspace-test` check measures
+        // machine contention, and when it trips it aborts the run with ~10k
+        // tests unexecuted, hiding anything real behind it. See #2421.
         let mut best_p95 = f64::INFINITY;
         for _ in 0..3 {
             let result = run_once();
@@ -1033,9 +1043,10 @@ mod tests {
             }
         }
 
+        println!("tui_load 5000 items: p95 (min of 3) = {best_p95:.2}ms (informational)");
         assert!(
-            best_p95 < 100.0,
-            "p95 (min of 3) = {best_p95:.2}ms, should be < 100ms"
+            best_p95.is_finite(),
+            "p95 was not measured on any of the 3 runs"
         );
     }
 

--- a/crates/aprender-zram-core/src/benchmark.rs
+++ b/crates/aprender-zram-core/src/benchmark.rs
@@ -397,11 +397,19 @@ mod tests {
 
     #[test]
     fn test_f058_entropy_overhead_minimal() {
-        // F058: Entropy calculation overhead should be minimal
-        // Note: Debug builds are ~10x slower than release builds; on a busy
-        // self-hosted CI runner the debug budget needs extra headroom to avoid
-        // flakes. 500us still catches real regressions (release target is <1us,
-        // so this is a 500x safety margin).
+        // F058: same-fill detection must not be dramatically worse than the
+        // naive scan it replaces.
+        //
+        // This used to assert an ABSOLUTE `per_page_ns < 500_000`. That budget
+        // had already been widened once "to avoid flakes on a busy self-hosted
+        // CI runner" and it flaked again anyway, at 557us, when 16 CI jobs
+        // shared the box. Widening an absolute wall-clock bound is a treadmill:
+        // the number it measures is how loaded the machine is.
+        //
+        // The ratio below is load-immune because both measurements are taken in
+        // the same process, microseconds apart, under whatever load exists. It
+        // still catches the regression that matters — an implementation that
+        // has become pathologically worse than a byte-by-byte scan.
         use crate::samefill::detect_same_fill;
 
         let page = [0xCDu8; PAGE_SIZE];
@@ -413,10 +421,26 @@ mod tests {
         }
         let elapsed = start.elapsed();
 
+        let baseline_start = std::time::Instant::now();
+        let mut sink = 0usize;
+        for _ in 0..iterations {
+            sink += usize::from(page.iter().all(|&b| b == page[0]));
+        }
+        let baseline = baseline_start.elapsed();
+        assert_eq!(sink, iterations, "baseline scan disagreed with the fixture");
+
         let per_page_ns = elapsed.as_nanos() as f64 / iterations as f64;
+        let baseline_ns = baseline.as_nanos() as f64 / iterations as f64;
+        let ratio = per_page_ns / baseline_ns.max(1.0);
+        println!(
+            "F058: same-fill {per_page_ns:.1}ns/page vs naive scan {baseline_ns:.1}ns/page \
+             (ratio {ratio:.2}x)"
+        );
         assert!(
-            per_page_ns < 500_000.0,
-            "Same-fill detection {per_page_ns:.1}ns exceeds 500us debug/CI target"
+            ratio < 20.0,
+            "Same-fill detection is {ratio:.2}x the naive scan \
+             ({per_page_ns:.1}ns vs {baseline_ns:.1}ns per page) - expected it to be at \
+             worst comparable, so this is an algorithmic regression, not CI noise"
         );
     }
 
@@ -523,25 +547,37 @@ mod tests {
             compressed.push(lz4::compress(page).unwrap());
         }
 
-        // Decompress using SIMD dispatch (should use AVX-512)
+        // Decompress using SIMD dispatch (should use AVX-512) and check every
+        // page round-trips. THAT is what this test's own first line claims to
+        // verify ("AVX-512 SIMD path is correctly selected when available") and
+        // it is a property of the code, not of how busy the machine is.
         let start = std::time::Instant::now();
-        for comp in &compressed {
+        for (i, comp) in compressed.iter().enumerate() {
             let mut output = [0u8; PAGE_SIZE];
-            let _ = lz4::decompress_simd(comp, &mut output).unwrap();
+            let n = lz4::decompress_simd(comp, &mut output).unwrap();
+            assert_eq!(
+                n, PAGE_SIZE,
+                "F053: page {i} decompressed to {n} bytes, expected {PAGE_SIZE}"
+            );
+            assert_eq!(
+                output.as_slice(),
+                pages[i].as_slice(),
+                "F053: page {i} did not round-trip through the SIMD decompressor"
+            );
         }
         let elapsed = start.elapsed();
 
         let bytes = pages.len() * PAGE_SIZE;
         let throughput_gbps = (bytes as f64) / elapsed.as_secs_f64() / 1_000_000_000.0;
 
-        println!("F053: AVX-512 decompression throughput: {throughput_gbps:.2} GB/s");
-
-        // Debug builds are ~50-100x slower due to no optimizations
-        // In release mode, this should achieve >5 GB/s
-        // In debug mode with coverage instrumentation, we allow >10 MB/s
-        assert!(
-            throughput_gbps > 0.01,
-            "AVX-512 decompression throughput {throughput_gbps:.2} GB/s below 10 MB/s debug baseline"
+        // Reported, deliberately NOT asserted. The previous gate was
+        // `throughput_gbps > 0.01` and it failed on a saturated CI runner at
+        // exactly 0.01 GB/s, taking ~10k unrelated tests down with it. An
+        // absolute wall-clock bound inside a REQUIRED check measures runner
+        // contention, not this crate. Throughput belongs in a benchmark that
+        // records a trend on a quiet box. See #2421.
+        println!(
+            "F053: AVX-512 decompression throughput: {throughput_gbps:.2} GB/s (informational)"
         );
     }
 }


### PR DESCRIPTION
`workspace-test` is a **required** check. It contained three absolute wall-clock assertions, and all three failed within one hour on unrelated PRs while 16 CI jobs shared the runner:

| test | failure | on PR | that PR's diff |
|---|---|---|---|
| `tui_load::test_tui_load_test_large_dataset` | `p95 (min of 3) = 174.48ms, should be < 100ms` | #2365 | `Cargo.toml` exclude fields |
| `zram-core test_f053_avx512_simd_path_used` | `throughput 0.01 GB/s below 10 MB/s debug baseline` | #2368 | an exit code |
| `zram-core test_f058_entropy_overhead_minimal` | `557140.1ns exceeds 500us debug/CI target` | #2372 | a threshold comparison |

None of those PRs touches timing-sensitive code. What the assertions measured was how busy the machine was.

Each failure aborts the run with ~10,000 tests unexecuted — `10658/80031 tests were not run due to test failure` — so a genuine regression sitting behind one of these is invisible.

## Why not just widen the bounds

This repo has already been on that treadmill. The F058 comment reads:

> Note: Debug builds are ~10x slower than release builds; on a busy self-hosted CI runner the debug budget needs extra headroom to avoid flakes. **500us still catches real regressions**

It was widened to 500 µs. It flaked at 557 µs.

## What each test now asserts

**F053** — its own first line says it verifies "AVX-512 SIMD path is correctly selected when available", but it asserted *throughput*, a proxy that a corrupt-but-fast implementation passes. It now asserts all 1000 pages **round-trip** through `decompress_simd`, and reports throughput without gating on it. Strictly stronger than what it replaced — mutation-verified by corrupting one byte per page, which the old throughput assert would have sailed through:

```
assertion `left == right` failed: F053: page 0 did not round-trip through the SIMD decompressor
```

**F058** — now compares same-fill detection against a naive byte scan measured **in the same process, microseconds later**, so both observations carry whatever load exists and the ratio does not. Currently 1.39× against a 20× bound. Mutation-verified with a 60× slowdown:

```
Same-fill detection is 82.51x the naive scan (854109.0ns vs 10351.3ns per page)
  - expected it to be at worst comparable, so this is an algorithmic regression, not CI noise
```

**tui_load** — its invariant is already in its own assert, `"Should handle 5000 items without hang"`, running on every iteration. The p95 is now reported, not gated.

`#[ignore]` was deliberately not used: the andon rule bans it for flakes, and these are not flaky correctness tests — they are benchmarks that were wired into a blocking gate.

406 `aprender-zram-core` and 6304 `aprender-test-lib` unit tests pass; `clippy -D warnings` and `fmt --check` clean.

Refs #2421

🤖 Generated with [Claude Code](https://claude.com/claude-code)
