### PR TITLE
fix(cli): six qa/bench/probar/qualify defects — a gate that could not fail, a manifest of files that did not exist, and three flags with no effect

### DIFF
--- a/crates/apr-cli/src/commands/bench.rs
+++ b/crates/apr-cli/src/commands/bench.rs
@@ -155,6 +155,24 @@ struct BenchResult {
     "apr-cli-operations-v1",
     equation = "side_effect_classification"
 )]
+/// Parse one `--percentiles` point, enforcing the documented (0, 100] range.
+///
+/// Out-of-range points used to sail through to `print_bench_json`, where the
+/// non-`Ok` `PercentileOutcome` was serialised as `null` under a plausible key
+/// (`latency_p101_ms`) — a consumer of the report saw a metric, not an error.
+pub(crate) fn parse_percentile(s: &str) -> std::result::Result<f64, String> {
+    let value: f64 = s
+        .trim()
+        .parse()
+        .map_err(|e| format!("invalid percentile '{s}': {e}"))?;
+    if !value.is_finite() || value <= 0.0 || value > 100.0 {
+        return Err(format!(
+            "percentile '{s}' out of range: values must be in (0, 100]"
+        ));
+    }
+    Ok(value)
+}
+
 pub(crate) fn run(
     path: &Path,
     warmup: usize,
@@ -166,6 +184,16 @@ pub(crate) fn run(
     json: bool,
     percentiles: &[f64],
 ) -> Result<()> {
+    // Defence in depth: the clap value_parser rejects out-of-range points, but
+    // `run` is also reachable from non-clap callers.
+    for &p in percentiles {
+        if !p.is_finite() || p <= 0.0 || p > 100.0 {
+            return Err(CliError::ValidationFailed(format!(
+                "percentile {p} out of range: values must be in (0, 100]"
+            )));
+        }
+    }
+
     // GH-512: Warn on deprecated --fast flag instead of silently ignoring
     if fast && !json {
         eprintln!("Warning: --fast is deprecated (always uses fast path now). Flag has no effect.");

--- a/crates/apr-cli/src/commands/bench_brick_name.rs
+++ b/crates/apr-cli/src/commands/bench_brick_name.rs
@@ -394,6 +394,62 @@
         assert_eq!(result.median_time, Duration::from_millis(300));
     }
 
+    // ====================================================================
+    // --percentiles range enforcement
+    // ====================================================================
+
+    /// The help text says "Values must be in (0, 100]" but 0 and 101 were
+    /// accepted, each emitting a plausible-looking `latency_p0_ms` /
+    /// `latency_p101_ms` key with a `null` value into the JSON report.
+    #[test]
+    fn parse_percentile_rejects_out_of_range_points() {
+        for bad in ["0", "101", "-5", "100.5", "nan", "inf"] {
+            let err =
+                parse_percentile(bad).expect_err("point outside (0, 100] must be rejected");
+            assert!(
+                err.contains(bad) || err.contains("out of range"),
+                "error must explain the rejection, got: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_percentile_accepts_the_documented_range() {
+        assert!((parse_percentile("50").expect("50") - 50.0).abs() < f64::EPSILON);
+        assert!((parse_percentile("100").expect("100") - 100.0).abs() < f64::EPSILON);
+        assert!(parse_percentile("0.1").is_ok(), "just above zero is valid");
+        assert!(parse_percentile("99.9").is_ok());
+    }
+
+    #[test]
+    fn parse_percentile_rejects_non_numeric() {
+        assert!(parse_percentile("abc").is_err());
+        assert!(parse_percentile("").is_err());
+    }
+
+    /// `run` is also reachable from non-clap callers, so it range-checks too —
+    /// and does so before touching the model, which is why a nonexistent path
+    /// still surfaces the percentile error.
+    #[test]
+    fn bench_run_rejects_out_of_range_percentiles() {
+        let err = run(
+            Path::new("/tmp/nonexistent_bench_percentile_model.gguf"),
+            0,
+            1,
+            2,
+            None,
+            false,
+            None,
+            true,
+            &[101.0],
+        )
+        .expect_err("101 must be rejected");
+        assert!(
+            err.to_string().contains("out of range"),
+            "got: {err}"
+        );
+    }
+
     #[cfg(feature = "inference")]
     #[test]
     fn test_calculate_stats_high_token_count() {

--- a/crates/apr-cli/src/commands/eval/eval_mod_tests.rs
+++ b/crates/apr-cli/src/commands/eval/eval_mod_tests.rs
@@ -440,6 +440,37 @@ fn load_eval_prompts_missing_file_errors() {
     assert!(load_eval_prompts(Path::new("/no/prompts.jsonl")).is_err());
 }
 
+// ── --device in perplexity mode ────────────────────────────────────────────
+//
+// `--device cuda` and `--device bogus` used to produce byte-identical output to
+// `--device cpu`, with no mention of a device anywhere — the flag was accepted,
+// never consulted, and never reported.
+
+#[test]
+fn perplexity_device_is_always_cpu() {
+    assert_eq!(perplexity_device("cpu"), "cpu");
+    assert_eq!(
+        perplexity_device("cuda"),
+        "cpu",
+        "perplexity has no GPU path; the report must say cpu"
+    );
+}
+
+#[test]
+fn perplexity_device_notice_fires_only_when_the_request_is_not_honoured() {
+    assert!(
+        perplexity_device_notice("cpu").is_none(),
+        "no notice when the request is honoured"
+    );
+
+    let notice = perplexity_device_notice("cuda").expect("cuda must be called out");
+    assert!(notice.contains("cuda"), "notice must quote the request");
+    assert!(
+        notice.contains("CPU-only") && notice.contains("cpu"),
+        "notice must state what actually ran, got: {notice}"
+    );
+}
+
 #[test]
 fn default_prompts_are_nonempty_python() {
     let prompts = default_code_eval_prompts();

--- a/crates/apr-cli/src/commands/eval/mod.rs
+++ b/crates/apr-cli/src/commands/eval/mod.rs
@@ -88,6 +88,31 @@ struct EvalResult {
     pub threshold: f32,
 }
 
+/// The device perplexity evaluation actually runs on.
+///
+/// There is no GPU path here — the only readers of `device` are the
+/// humaneval/mbpp code-eval paths — so this is always `"cpu"`. It exists so the
+/// answer is stated rather than assumed.
+pub(crate) fn perplexity_device(_requested: &str) -> &'static str {
+    "cpu"
+}
+
+/// Notice to emit when `--device` cannot be honoured in perplexity mode.
+///
+/// `--device cuda` used to run byte-identically to `--device cpu` with no
+/// mention of a device anywhere in the output, so an operator who typo'd
+/// `--device cude` (or asked for a GPU this build has no kernels for) believed
+/// the run was GPU-accelerated.
+pub(crate) fn perplexity_device_notice(requested: &str) -> Option<String> {
+    if perplexity_device(requested) == requested {
+        return None;
+    }
+    Some(format!(
+        "⚠ --device {requested} requested, but perplexity evaluation is CPU-only — running on cpu \
+         (--device applies to --task humaneval/mbpp)"
+    ))
+}
+
 /// Run the eval command
 #[provable_contracts_macros::contract(
     "apr-cli-operations-v1",
@@ -99,8 +124,13 @@ pub(crate) fn run(
     text: Option<&str>,
     max_tokens: Option<usize>,
     threshold: Option<f32>,
+    device: &str,
     json: bool,
 ) -> Result<()> {
+    if let Some(notice) = perplexity_device_notice(device) {
+        eprintln!("{notice}");
+    }
+
     let dataset_enum: Dataset = dataset
         .parse()
         .map_err(|e: String| CliError::ValidationFailed(e))?;
@@ -114,6 +144,8 @@ pub(crate) fn run(
 
     if !json {
         print_header(path, &config);
+        output::kv("Device", perplexity_device(device));
+        println!();
     }
 
     // Run evaluation
@@ -121,7 +153,7 @@ pub(crate) fn run(
 
     // GH-248: JSON output mode
     if json {
-        return print_json_results(path, &config, &result);
+        return print_json_results(path, &config, &result, device);
     }
 
     // Print results
@@ -141,10 +173,16 @@ pub(crate) fn run(
 /// GH-248: JSON output mode for eval results
 // serde_json::json!() macro uses infallible unwrap internally
 #[allow(clippy::disallowed_methods)]
-fn print_json_results(path: &Path, config: &EvalConfig, result: &EvalResult) -> Result<()> {
+fn print_json_results(
+    path: &Path,
+    config: &EvalConfig,
+    result: &EvalResult,
+    device: &str,
+) -> Result<()> {
     let output = serde_json::json!({
         "model": path.display().to_string(),
         "dataset": format!("{:?}", config.dataset),
+        "device": perplexity_device(device),
         "perplexity": result.perplexity,
         "cross_entropy": result.cross_entropy,
         "tokens_evaluated": result.tokens_evaluated,

--- a/crates/apr-cli/src/commands/eval_tests.rs
+++ b/crates/apr-cli/src/commands/eval_tests.rs
@@ -297,6 +297,7 @@ fn test_run_unknown_dataset() {
         None,
         None,
         None,
+        "cpu",
         false,
     );
 
@@ -317,6 +318,7 @@ fn test_run_file_not_found() {
         None,
         None,
         None,
+        "cpu",
         false,
     );
 
@@ -332,6 +334,7 @@ fn test_run_custom_without_text() {
         None, // Missing text for custom dataset
         None,
         None,
+        "cpu",
         false,
     );
 

--- a/crates/apr-cli/src/commands/eval_tests_get.rs
+++ b/crates/apr-cli/src/commands/eval_tests_get.rs
@@ -221,6 +221,7 @@ fn test_run_with_max_tokens() {
         None,
         Some(128),
         None,
+        "cpu",
         false,
     );
     assert!(result.is_err());
@@ -234,6 +235,7 @@ fn test_run_with_threshold() {
         None,
         None,
         Some(5.0),
+        "cpu",
         false,
     );
     assert!(result.is_err());
@@ -248,6 +250,7 @@ fn test_run_custom_with_text() {
         Some("test input text"),
         None,
         None,
+        "cpu",
         false,
     );
     assert!(result.is_err());

--- a/crates/apr-cli/src/commands/fields.rs
+++ b/crates/apr-cli/src/commands/fields.rs
@@ -361,3 +361,103 @@
         let result = discover_sibling_subdir(tmp.path(), "nonexistent");
         assert!(result.is_none());
     }
+
+    // ====================================================================
+    // PTX Parity gate: zero comparisons is not a pass
+    // ====================================================================
+
+    /// Without the `cuda` feature `validate_all_kernel_pairs` returns an empty
+    /// report. `all_passed()` is `failed == 0`, vacuously true when nothing was
+    /// compared, so the gate reported "0/0 kernel pairs passed PTX parity" as
+    /// PASS — a gate that could not fail by construction.
+    #[cfg(feature = "inference")]
+    #[test]
+    fn ptx_gate_skips_when_no_kernel_pairs_were_compared() {
+        let empty = realizar::ptx_parity::PtxParityReport {
+            results: Vec::new(),
+            total: 0,
+            passed: 0,
+            failed: 0,
+        };
+        assert!(
+            empty.all_passed(),
+            "precondition: an empty report still claims all_passed()"
+        );
+
+        let gate = ptx_gate_result(&empty, std::time::Duration::from_millis(1));
+        assert!(gate.skipped, "0/0 comparisons must be reported as SKIP");
+        assert!(
+            !gate.message.contains("0/0 kernel pairs passed"),
+            "must not claim a pass it did not earn, got: {}",
+            gate.message
+        );
+    }
+
+    #[cfg(feature = "inference")]
+    #[test]
+    fn ptx_gate_still_judges_real_comparisons() {
+        let ok = realizar::ptx_parity::PtxParityReport {
+            results: Vec::new(),
+            total: 6,
+            passed: 6,
+            failed: 0,
+        };
+        let gate = ptx_gate_result(&ok, std::time::Duration::from_millis(1));
+        assert!(!gate.skipped, "real comparisons must produce a verdict");
+        assert!(gate.passed, "6/6 must PASS");
+
+        let bad = realizar::ptx_parity::PtxParityReport {
+            results: Vec::new(),
+            total: 6,
+            passed: 5,
+            failed: 1,
+        };
+        let gate = ptx_gate_result(&bad, std::time::Duration::from_millis(1));
+        assert!(!gate.skipped);
+        assert!(!gate.passed, "1 failing kernel pair must FAIL");
+    }
+
+    // ====================================================================
+    // Capability Match gate: no GPU claims from a build with no GPU backend
+    // ====================================================================
+
+    /// On a build without `cuda`, the gate asserted "all N required ops
+    /// supported by GPU" — a claim about kernels the binary cannot reach.
+    #[cfg(all(feature = "inference", not(feature = "cuda")))]
+    #[test]
+    fn capability_gate_makes_no_gpu_claim_without_cuda() {
+        // A GGUF carrying general.architecture — without it the gate short
+        // circuits on "missing architecture metadata" and never reaches the
+        // GPU claim, so the test would prove nothing.
+        let mut tmp = NamedTempFile::new().expect("tempfile");
+        tmp.write_all(b"GGUF").expect("magic");
+        tmp.write_all(&3u32.to_le_bytes()).expect("version");
+        tmp.write_all(&0u64.to_le_bytes()).expect("tensor count");
+        tmp.write_all(&1u64.to_le_bytes()).expect("kv count");
+        let key = b"general.architecture";
+        tmp.write_all(&(key.len() as u64).to_le_bytes())
+            .expect("key len");
+        tmp.write_all(key).expect("key");
+        tmp.write_all(&8u32.to_le_bytes()).expect("STRING type tag");
+        let value = b"qwen2";
+        tmp.write_all(&(value.len() as u64).to_le_bytes())
+            .expect("value len");
+        tmp.write_all(value).expect("value");
+        tmp.flush().expect("flush");
+
+        let config = QaConfig::default();
+        let gate = crate::commands::qa_capability::run_capability_gate(tmp.path(), &config)
+            .expect("gate runs");
+        assert!(
+            !gate.message.contains("supported by GPU"),
+            "a CPU-only build must not assert GPU support, got: {}",
+            gate.message
+        );
+        // Proves the fixture got past architecture extraction — otherwise the
+        // gate short circuits earlier and the assertion above is vacuous.
+        assert!(
+            gate.skipped && gate.message.contains("Requires 'inference' and 'cuda'"),
+            "expected the cuda-feature SKIP, got: {}",
+            gate.message
+        );
+    }

--- a/crates/apr-cli/src/commands/gpu_isolation_result.rs
+++ b/crates/apr-cli/src/commands/gpu_isolation_result.rs
@@ -106,6 +106,16 @@ fn ptx_gate_result(
     report: &realizar::ptx_parity::PtxParityReport,
     duration: Duration,
 ) -> GateResult {
+    // Zero comparisons is not a pass. Without the `cuda` feature
+    // `validate_all_kernel_pairs` returns an empty report, whose `all_passed()`
+    // is vacuously true — the gate then reported "0/0 kernel pairs passed PTX
+    // parity" as a green verdict and could not fail by construction.
+    if report.total == 0 {
+        return GateResult::skipped(
+            "ptx_parity",
+            "no PTX kernel pairs compiled in (requires 'cuda' feature)",
+        );
+    }
     if report.all_passed() {
         GateResult::passed(
             "ptx_parity",

--- a/crates/apr-cli/src/commands/mod.rs
+++ b/crates/apr-cli/src/commands/mod.rs
@@ -109,6 +109,7 @@ pub(crate) mod otlp_classifier;
 pub(crate) mod otlp_lint;
 pub(crate) mod parity;
 pub(crate) mod pipeline;
+pub(crate) mod png_encode;
 pub(crate) mod ppl;
 #[cfg(feature = "training")]
 pub(crate) mod pretrain;

--- a/crates/apr-cli/src/commands/png_encode.rs
+++ b/crates/apr-cli/src/commands/png_encode.rs
@@ -1,0 +1,121 @@
+//! Minimal, dependency-free 8-bit grayscale PNG encoder.
+//!
+//! `apr probar tensor --format png` used to advertise `.png` files while writing
+//! Netpbm `.pgm` bytes, so every path it printed was a file that did not exist.
+//! This module produces a real PNG so the printed manifest is true.
+//!
+//! The encoder emits the smallest spec-conformant stream: a grayscale IHDR, an
+//! IDAT holding a zlib wrapper around *stored* (uncompressed) DEFLATE blocks,
+//! and IEND. Stored blocks keep the implementation auditable — no compression
+//! state machine to get wrong — at the cost of the file being ~raster-sized.
+//! Histogram strips are 256x100, so that is ~26 KB.
+
+/// PNG file signature (RFC 2083 §3.1).
+const SIGNATURE: [u8; 8] = [0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A];
+
+/// Largest payload a single DEFLATE stored block can carry.
+const MAX_STORED_BLOCK: usize = 65_535;
+
+/// Encode an 8-bit grayscale raster as a PNG byte stream.
+///
+/// `pixels` is row-major, `width * height` bytes. Returns `None` when the
+/// dimensions are zero or do not match the buffer length — callers must not
+/// write a truncated image.
+pub(crate) fn encode_grayscale(width: usize, height: usize, pixels: &[u8]) -> Option<Vec<u8>> {
+    if width == 0 || height == 0 || pixels.len() != width.checked_mul(height)? {
+        return None;
+    }
+    let w32 = u32::try_from(width).ok()?;
+    let h32 = u32::try_from(height).ok()?;
+
+    // Each scanline is prefixed with its filter-type byte (0 = None).
+    let mut raw = Vec::with_capacity(height * (width + 1));
+    for row in pixels.chunks_exact(width) {
+        raw.push(0u8);
+        raw.extend_from_slice(row);
+    }
+
+    let mut out = Vec::new();
+    out.extend_from_slice(&SIGNATURE);
+
+    let mut ihdr = Vec::with_capacity(13);
+    ihdr.extend_from_slice(&w32.to_be_bytes());
+    ihdr.extend_from_slice(&h32.to_be_bytes());
+    ihdr.push(8); // bit depth
+    ihdr.push(0); // color type: grayscale
+    ihdr.push(0); // compression method: deflate
+    ihdr.push(0); // filter method: adaptive
+    ihdr.push(0); // interlace: none
+    write_chunk(&mut out, b"IHDR", &ihdr);
+
+    write_chunk(&mut out, b"IDAT", &zlib_stored(&raw));
+    write_chunk(&mut out, b"IEND", &[]);
+    Some(out)
+}
+
+/// Append a length-prefixed, CRC-suffixed PNG chunk.
+fn write_chunk(out: &mut Vec<u8>, kind: &[u8; 4], data: &[u8]) {
+    let len = u32::try_from(data.len()).unwrap_or(u32::MAX);
+    out.extend_from_slice(&len.to_be_bytes());
+    out.extend_from_slice(kind);
+    out.extend_from_slice(data);
+    let mut crc_input = Vec::with_capacity(4 + data.len());
+    crc_input.extend_from_slice(kind);
+    crc_input.extend_from_slice(data);
+    out.extend_from_slice(&crc32(&crc_input).to_be_bytes());
+}
+
+/// Wrap `data` in a zlib stream built from DEFLATE stored blocks.
+fn zlib_stored(data: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(data.len() + 64);
+    // CMF: deflate, 32K window. FLG chosen so (CMF << 8 | FLG) % 31 == 0.
+    out.push(0x78);
+    out.push(0x01);
+
+    if data.is_empty() {
+        out.push(0x01); // BFINAL=1, BTYPE=00
+        out.extend_from_slice(&0u16.to_le_bytes());
+        out.extend_from_slice(&(!0u16).to_le_bytes());
+    } else {
+        let mut chunks = data.chunks(MAX_STORED_BLOCK).peekable();
+        while let Some(chunk) = chunks.next() {
+            let final_block = u8::from(chunks.peek().is_none());
+            out.push(final_block); // BFINAL bit, BTYPE=00 (stored)
+            let len = u16::try_from(chunk.len()).unwrap_or(u16::MAX);
+            out.extend_from_slice(&len.to_le_bytes());
+            out.extend_from_slice(&(!len).to_le_bytes());
+            out.extend_from_slice(chunk);
+        }
+    }
+
+    out.extend_from_slice(&adler32(data).to_be_bytes());
+    out
+}
+
+/// CRC-32 (IEEE 802.3), as required for every PNG chunk.
+fn crc32(data: &[u8]) -> u32 {
+    let mut crc = 0xFFFF_FFFFu32;
+    for &byte in data {
+        crc ^= u32::from(byte);
+        for _ in 0..8 {
+            let mask = 0u32.wrapping_sub(crc & 1);
+            crc = (crc >> 1) ^ (0xEDB8_8320 & mask);
+        }
+    }
+    !crc
+}
+
+/// Adler-32 checksum trailing the zlib stream.
+fn adler32(data: &[u8]) -> u32 {
+    let mut a = 1u32;
+    let mut b = 0u32;
+    for &byte in data {
+        a = (a + u32::from(byte)) % 65_521;
+        b = (b + a) % 65_521;
+    }
+    (b << 16) | a
+}
+
+#[cfg(test)]
+#[path = "png_encode_tests.rs"]
+mod tests;

--- a/crates/apr-cli/src/commands/png_encode_tests.rs
+++ b/crates/apr-cli/src/commands/png_encode_tests.rs
@@ -1,0 +1,136 @@
+use super::*;
+
+/// Walk the chunk list, verifying every CRC, and return (kind, payload) pairs.
+fn parse_chunks(png: &[u8]) -> Vec<(String, Vec<u8>)> {
+    assert_eq!(&png[0..8], &SIGNATURE, "PNG signature");
+    let mut chunks = Vec::new();
+    let mut i = 8;
+    while i + 8 <= png.len() {
+        let len = u32::from_be_bytes([png[i], png[i + 1], png[i + 2], png[i + 3]]) as usize;
+        let kind = String::from_utf8_lossy(&png[i + 4..i + 8]).into_owned();
+        let data = png[i + 8..i + 8 + len].to_vec();
+        let crc_at = i + 8 + len;
+        let stated = u32::from_be_bytes([
+            png[crc_at],
+            png[crc_at + 1],
+            png[crc_at + 2],
+            png[crc_at + 3],
+        ]);
+        let mut crc_input = png[i + 4..i + 8].to_vec();
+        crc_input.extend_from_slice(&data);
+        assert_eq!(crc32(&crc_input), stated, "CRC of {kind} chunk");
+        chunks.push((kind, data));
+        i = crc_at + 4;
+    }
+    assert_eq!(i, png.len(), "chunk stream consumed exactly");
+    chunks
+}
+
+/// Inflate a zlib stream made only of stored blocks, checking the Adler-32.
+fn inflate_stored(z: &[u8]) -> Vec<u8> {
+    assert_eq!(z[0], 0x78, "zlib CMF");
+    assert_eq!(
+        (u32::from(z[0]) * 256 + u32::from(z[1])) % 31,
+        0,
+        "zlib header check bits"
+    );
+    let mut out = Vec::new();
+    let mut i = 2;
+    loop {
+        let header = z[i];
+        assert_eq!(header & 0b110, 0, "BTYPE must be 00 (stored)");
+        let len = u16::from_le_bytes([z[i + 1], z[i + 2]]) as usize;
+        let nlen = u16::from_le_bytes([z[i + 3], z[i + 4]]);
+        assert_eq!(!(len as u16), nlen, "NLEN is the ones-complement of LEN");
+        out.extend_from_slice(&z[i + 5..i + 5 + len]);
+        i += 5 + len;
+        if header & 1 == 1 {
+            break;
+        }
+    }
+    let stated = u32::from_be_bytes([z[i], z[i + 1], z[i + 2], z[i + 3]]);
+    assert_eq!(adler32(&out), stated, "zlib Adler-32");
+    assert_eq!(i + 4, z.len(), "zlib stream consumed exactly");
+    out
+}
+
+/// Decode a grayscale PNG produced by `encode_grayscale` back to (w, h, pixels).
+fn decode_grayscale(png: &[u8]) -> (usize, usize, Vec<u8>) {
+    let chunks = parse_chunks(png);
+    let kinds: Vec<&str> = chunks.iter().map(|(k, _)| k.as_str()).collect();
+    assert_eq!(kinds, vec!["IHDR", "IDAT", "IEND"], "chunk order");
+
+    let ihdr = &chunks[0].1;
+    assert_eq!(ihdr.len(), 13, "IHDR length");
+    let w = u32::from_be_bytes([ihdr[0], ihdr[1], ihdr[2], ihdr[3]]) as usize;
+    let h = u32::from_be_bytes([ihdr[4], ihdr[5], ihdr[6], ihdr[7]]) as usize;
+    assert_eq!(ihdr[8], 8, "bit depth");
+    assert_eq!(ihdr[9], 0, "color type grayscale");
+    assert_eq!(ihdr[10], 0, "compression method");
+    assert_eq!(ihdr[11], 0, "filter method");
+    assert_eq!(ihdr[12], 0, "interlace");
+
+    let raw = inflate_stored(&chunks[1].1);
+    assert_eq!(raw.len(), h * (w + 1), "scanline count");
+    let mut pixels = Vec::with_capacity(w * h);
+    for row in raw.chunks_exact(w + 1) {
+        assert_eq!(row[0], 0, "filter type None");
+        pixels.extend_from_slice(&row[1..]);
+    }
+    (w, h, pixels)
+}
+
+#[test]
+fn encode_grayscale_round_trips_pixels() {
+    let pixels: Vec<u8> = (0..(7 * 5u16)).map(|v| (v * 7 % 256) as u8).collect();
+    let png = encode_grayscale(7, 5, &pixels).expect("encode");
+    let (w, h, decoded) = decode_grayscale(&png);
+    assert_eq!((w, h), (7, 5));
+    assert_eq!(decoded, pixels, "pixel data survives the round trip");
+}
+
+#[test]
+fn encode_grayscale_emits_png_magic_not_netpbm() {
+    let png = encode_grayscale(2, 2, &[0, 255, 255, 0]).expect("encode");
+    assert_eq!(
+        &png[0..8],
+        b"\x89PNG\r\n\x1a\n",
+        "must start with the PNG signature, not Netpbm 'P5'"
+    );
+    assert_ne!(&png[0..2], b"P5", "Netpbm magic must not appear");
+}
+
+#[test]
+fn encode_grayscale_spans_multiple_stored_blocks() {
+    // 300x300 grayscale = 300 * 301 = 90_300 raw bytes > one 65_535 stored block.
+    let w = 300;
+    let h = 300;
+    let pixels: Vec<u8> = (0..w * h).map(|i| (i % 251) as u8).collect();
+    let png = encode_grayscale(w, h, &pixels).expect("encode");
+    let (dw, dh, decoded) = decode_grayscale(&png);
+    assert_eq!((dw, dh), (w, h));
+    assert_eq!(decoded, pixels, "multi-block stream round trips");
+}
+
+#[test]
+fn encode_grayscale_rejects_mismatched_buffer() {
+    assert!(
+        encode_grayscale(4, 4, &[0u8; 15]).is_none(),
+        "short buffer must not produce a truncated image"
+    );
+    assert!(encode_grayscale(0, 4, &[]).is_none(), "zero width");
+    assert!(encode_grayscale(4, 0, &[]).is_none(), "zero height");
+}
+
+#[test]
+fn crc32_matches_known_vector() {
+    // The IEND chunk's CRC is a fixed, published value: 0xAE426082.
+    assert_eq!(crc32(b"IEND"), 0xAE42_6082);
+    assert_eq!(crc32(b"123456789"), 0xCBF4_3926);
+}
+
+#[test]
+fn adler32_matches_known_vector() {
+    assert_eq!(adler32(b"Wikipedia"), 0x11E6_0398);
+    assert_eq!(adler32(b""), 1);
+}

--- a/crates/apr-cli/src/commands/probar.rs
+++ b/crates/apr-cli/src/commands/probar.rs
@@ -235,23 +235,40 @@ fn print_summary(
     }
 }
 
-fn print_generated_files(format: ExportFormat, output_dir: &Path, layers: &[LayerSnapshot]) {
-    println!();
-    println!("{}", "Generated files:".white().bold());
+/// The artifacts `export_by_format` writes for `format`.
+///
+/// This is the single source of truth for both the export and the printed
+/// manifest: the two used to disagree (`.png` printed, `.pgm` written), so a
+/// CI step copying the listed paths failed with ENOENT.
+fn generated_file_paths(
+    format: ExportFormat,
+    output_dir: &Path,
+    layers: &[LayerSnapshot],
+) -> Vec<std::path::PathBuf> {
+    let mut paths = Vec::new();
 
     if matches!(format, ExportFormat::Json | ExportFormat::Both) {
-        println!("  - {}/manifest.json", output_dir.display());
+        paths.push(output_dir.join("manifest.json"));
     }
 
     if matches!(format, ExportFormat::Png | ExportFormat::Both) {
         for layer in layers {
-            println!(
-                "  - {}/layer_{:03}_{}.png",
-                output_dir.display(),
-                layer.index,
-                layer.name
+            paths.push(output_dir.join(format!("layer_{:03}_{}.png", layer.index, layer.name)));
+            paths.push(
+                output_dir.join(format!("layer_{:03}_{}.meta.json", layer.index, layer.name)),
             );
         }
+    }
+
+    paths
+}
+
+fn print_generated_files(format: ExportFormat, output_dir: &Path, layers: &[LayerSnapshot]) {
+    println!();
+    println!("{}", "Generated files:".white().bold());
+
+    for path in generated_file_paths(format, output_dir, layers) {
+        println!("  - {}", path.display());
     }
 }
 
@@ -412,14 +429,18 @@ fn export_png(layers: &[LayerSnapshot], output_dir: &Path) -> Result<(), CliErro
             }
         }
 
-        // Write as simple PGM (portable graymap) - easy to convert to PNG
-        // For now, write as .pgm which can be viewed in most image viewers
-        let pgm_path = output_dir.join(format!("layer_{:03}_{}.pgm", layer.index, layer.name));
-        let mut file = File::create(&pgm_path)?;
-        writeln!(file, "P5")?;
-        writeln!(file, "{width} {height}")?;
-        writeln!(file, "255")?;
-        file.write_all(&pixels)?;
+        // Write a real PNG. `print_generated_files` advertises `.png`, so this
+        // must actually be one: writing Netpbm here made every listed path a
+        // file that did not exist.
+        let png_bytes =
+            super::png_encode::encode_grayscale(width, height, &pixels).ok_or_else(|| {
+                CliError::InvalidFormat(format!(
+                    "failed to encode {width}x{height} histogram for layer '{}' as PNG",
+                    layer.name
+                ))
+            })?;
+        let mut file = File::create(&png_path)?;
+        file.write_all(&png_bytes)?;
 
         // Create a metadata sidecar JSON
         let meta_path =
@@ -439,10 +460,6 @@ fn export_png(layers: &[LayerSnapshot], output_dir: &Path) -> Result<(), CliErro
 
         let mut meta_file = File::create(&meta_path)?;
         meta_file.write_all(meta_json.as_bytes())?;
-
-        // Note: In production, use image crate or similar to generate actual PNG
-        // For now, PGM format works for development/testing
-        let _ = png_path; // Suppress unused warning
     }
 
     Ok(())

--- a/crates/apr-cli/src/commands/probar_tests_export_png.rs
+++ b/crates/apr-cli/src/commands/probar_tests_export_png.rs
@@ -1,4 +1,48 @@
 
+/// Decode an 8-bit grayscale PNG whose IDAT uses stored DEFLATE blocks.
+/// Deliberately independent of the encoder's own test helpers so this asserts
+/// the file's bytes, not the encoder's view of them.
+fn decode_grayscale_png(png: &[u8]) -> Vec<u8> {
+    let mut idat = Vec::new();
+    let (mut width, mut height) = (0usize, 0usize);
+    let mut i = 8; // skip signature
+    while i + 8 <= png.len() {
+        let len = u32::from_be_bytes([png[i], png[i + 1], png[i + 2], png[i + 3]]) as usize;
+        let kind = &png[i + 4..i + 8];
+        let data = &png[i + 8..i + 8 + len];
+        if kind == b"IHDR" {
+            width = u32::from_be_bytes([data[0], data[1], data[2], data[3]]) as usize;
+            height = u32::from_be_bytes([data[4], data[5], data[6], data[7]]) as usize;
+            assert_eq!(data[8], 8, "bit depth");
+            assert_eq!(data[9], 0, "grayscale color type");
+        } else if kind == b"IDAT" {
+            idat.extend_from_slice(data);
+        }
+        i += 8 + len + 4;
+    }
+
+    // Inflate stored blocks (zlib header is 2 bytes, Adler-32 trailer is 4).
+    let mut raw = Vec::new();
+    let mut j = 2;
+    loop {
+        let header = idat[j];
+        let blen = u16::from_le_bytes([idat[j + 1], idat[j + 2]]) as usize;
+        raw.extend_from_slice(&idat[j + 5..j + 5 + blen]);
+        j += 5 + blen;
+        if header & 1 == 1 {
+            break;
+        }
+    }
+
+    assert_eq!(raw.len(), height * (width + 1), "scanline count");
+    let mut pixels = Vec::with_capacity(width * height);
+    for row in raw.chunks_exact(width + 1) {
+        assert_eq!(row[0], 0, "filter type None");
+        pixels.extend_from_slice(&row[1..]);
+    }
+    pixels
+}
+
 #[test]
 fn test_export_png_histogram_normalization() {
     let output_dir = tempdir().expect("create output dir");
@@ -21,18 +65,15 @@ fn test_export_png_histogram_normalization() {
 
     export_png(&layers, output_dir.path()).expect("export png");
 
-    // Read the PGM and verify pixel data
-    let content = fs::read(output_dir.path().join("layer_000_spike.pgm")).expect("read pgm");
-    // Find start of pixel data (after 3rd newline)
-    let header_end = content
-        .windows(1)
-        .enumerate()
-        .filter(|(_, w)| w[0] == b'\n')
-        .nth(2)
-        .map(|(i, _)| i + 1)
-        .expect("find header end");
-
-    let pixels = &content[header_end..];
+    // Read the PNG back and verify pixel data. This used to read a `.pgm`,
+    // which is exactly the file the command claimed it had NOT written.
+    let content = fs::read(output_dir.path().join("layer_000_spike.png")).expect("read png");
+    assert_eq!(
+        &content[0..8],
+        b"\x89PNG\r\n\x1a\n",
+        "export_png must write a real PNG"
+    );
+    let pixels = decode_grayscale_png(&content);
     // Column 128 should have a black bar (value 0), other columns should be white (255)
     // Check bottom pixel of column 0 (should be white - no bar)
     let bottom_row = 99; // height - 1
@@ -84,12 +125,12 @@ fn test_export_by_format_json_creates_manifest_only() {
     .expect("export");
 
     assert!(output_dir.path().join("manifest.json").exists());
-    // PNG/PGM should NOT exist
-    assert!(!output_dir.path().join("layer_000_l.pgm").exists());
+    // PNG should NOT exist
+    assert!(!output_dir.path().join("layer_000_l.png").exists());
 }
 
 #[test]
-fn test_export_by_format_png_creates_pgm_only() {
+fn test_export_by_format_png_creates_png_only() {
     let output_dir = tempdir().expect("create output dir");
     let layers = vec![LayerSnapshot {
         name: "x".to_string(),
@@ -114,7 +155,17 @@ fn test_export_by_format_png_creates_pgm_only() {
     export_by_format(ExportFormat::Png, &manifest, &layers, output_dir.path()).expect("export");
 
     assert!(!output_dir.path().join("manifest.json").exists());
-    assert!(output_dir.path().join("layer_000_x.pgm").exists());
+    let png = output_dir.path().join("layer_000_x.png");
+    assert!(png.exists(), "the path printed to the user must exist");
+    assert_eq!(
+        &fs::read(&png).expect("read png")[0..8],
+        b"\x89PNG\r\n\x1a\n",
+        "and it must actually be a PNG"
+    );
+    assert!(
+        !output_dir.path().join("layer_000_x.pgm").exists(),
+        "no stray Netpbm file"
+    );
 }
 
 #[test]
@@ -143,7 +194,47 @@ fn test_export_by_format_both_creates_all() {
     export_by_format(ExportFormat::Both, &manifest, &layers, output_dir.path()).expect("export");
 
     assert!(output_dir.path().join("manifest.json").exists());
-    assert!(output_dir.path().join("layer_000_y.pgm").exists());
+    assert!(output_dir.path().join("layer_000_y.png").exists());
+}
+
+#[test]
+fn test_every_listed_generated_file_actually_exists() {
+    // The defect: `Generated files:` printed `.png` paths while `export_png`
+    // wrote `.pgm`, so a consumer copying the listed paths hit ENOENT.
+    for format in [ExportFormat::Json, ExportFormat::Png, ExportFormat::Both] {
+        let output_dir = tempdir().expect("create output dir");
+        let layers = vec![LayerSnapshot {
+            name: "block_0".to_string(),
+            index: 0,
+            histogram: vec![7; 256],
+            mean: 0.0,
+            std: 1.0,
+            min: -1.0,
+            max: 1.0,
+            heatmap: None,
+            heatmap_width: None,
+            heatmap_height: None,
+        }];
+        let manifest = ProbarManifest {
+            source_model: "m.apr".to_string(),
+            timestamp: "t".to_string(),
+            format: "APR".to_string(),
+            layers: layers.clone(),
+            golden_reference: None,
+        };
+
+        export_by_format(format, &manifest, &layers, output_dir.path()).expect("export");
+
+        let listed = generated_file_paths(format, output_dir.path(), &layers);
+        assert!(!listed.is_empty(), "{format:?} must list something");
+        for path in listed {
+            assert!(
+                path.exists(),
+                "{format:?}: listed {} but it was never written",
+                path.display()
+            );
+        }
+    }
 }
 
 // ========================================================================

--- a/crates/apr-cli/src/commands/qa.rs
+++ b/crates/apr-cli/src/commands/qa.rs
@@ -275,7 +275,7 @@ impl GateResult {
         }
     }
 
-    fn skipped(name: &str, reason: &str) -> Self {
+    pub(crate) fn skipped(name: &str, reason: &str) -> Self {
         Self {
             name: name.to_string(),
             passed: true, // Skipped gates don't fail

--- a/crates/apr-cli/src/commands/qa_capability.rs
+++ b/crates/apr-cli/src/commands/qa_capability.rs
@@ -91,8 +91,21 @@ pub fn run_capability_gate(path: &Path, config: &QaConfig) -> Result<GateResult>
         ));
     };
 
+    // A build without the `cuda` feature has no GPU backend compiled in, so
+    // "all N required ops supported by GPU" would be a claim about kernels
+    // this binary cannot reach. SKIP, matching the gpu_speedup and
+    // gpu_state_isolation gates in the same report.
+    #[cfg(all(feature = "inference", not(feature = "cuda")))]
+    {
+        let _ = arch;
+        return Ok(GateResult::skipped(
+            "capability_match",
+            "Requires 'inference' and 'cuda' features",
+        ));
+    }
+
     // Derive constraints and check capability
-    #[cfg(feature = "inference")]
+    #[cfg(all(feature = "inference", feature = "cuda"))]
     {
         use realizar::capability::{check_capability, gpu_supported_ops, required_ops};
         use realizar::gguf::ArchConstraints;

--- a/crates/apr-cli/src/commands/qualify.rs
+++ b/crates/apr-cli/src/commands/qualify.rs
@@ -121,6 +121,53 @@ where
     }
 }
 
+/// Repo-relative location of the tensor-layout contract audited by the
+/// `standard` and `full` tiers.
+const TENSOR_LAYOUT_CONTRACT: &str = "contracts/aprender/tensor-layout-v1.yaml";
+
+/// Resolve a repo-relative contract path without assuming the caller's working
+/// directory *is* the aprender checkout.
+///
+/// Search order:
+/// 1. `override_dir` (from `APR_CONTRACTS_DIR`), joined with the path after the
+///    leading `contracts/` component, so the env var points at a contracts dir.
+/// 2. `start` and each of its ancestors — finds the checkout root from any
+///    subdirectory of it.
+///
+/// Returns `None` when the contract is nowhere to be found; the caller must
+/// then SKIP the gate rather than report the missing file as an audit failure.
+fn locate_contract_from(
+    start: &Path,
+    override_dir: Option<&Path>,
+    rel: &str,
+) -> Option<std::path::PathBuf> {
+    if let Some(dir) = override_dir {
+        let tail = rel.strip_prefix("contracts/").unwrap_or(rel);
+        let candidate = dir.join(tail);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+
+    let mut cursor = Some(start);
+    while let Some(dir) = cursor {
+        let candidate = dir.join(rel);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        cursor = dir.parent();
+    }
+
+    None
+}
+
+/// `locate_contract_from` wired to the process environment.
+fn locate_contract(rel: &str) -> Option<std::path::PathBuf> {
+    let override_dir = std::env::var_os("APR_CONTRACTS_DIR").map(std::path::PathBuf::from);
+    let cwd = std::env::current_dir().ok()?;
+    locate_contract_from(&cwd, override_dir.as_deref(), rel)
+}
+
 /// Run an external tool gate (shell out). Skips gracefully if binary not on PATH.
 fn run_external_gate(
     name: &str,
@@ -439,13 +486,27 @@ pub fn run(
     // ── Phase 2: Contract Audit (standard or full tier) ────────────────
 
     if (tier == "standard" || tier == "full") && !skip_set.contains("contract_audit") {
-        let gate = run_external_gate(
-            "contract_audit",
-            "Contract Audit (pv)",
-            "pv",
-            &["audit", "contracts/aprender/tensor-layout-v1.yaml"],
-            timeout,
-        );
+        let gate = match locate_contract(TENSOR_LAYOUT_CONTRACT) {
+            Some(contract) => run_external_gate(
+                "contract_audit",
+                "Contract Audit (pv)",
+                "pv",
+                &["audit", &contract.display().to_string()],
+                timeout,
+            ),
+            // The contract ships with the aprender source tree, not with the
+            // installed binary. Not finding it is a missing input, not a
+            // failed audit — report it as such instead of a false FAIL.
+            None => GateResult {
+                name: "contract_audit".to_string(),
+                display_name: "Contract Audit (pv)".to_string(),
+                status: GateStatus::Skip,
+                message: format!(
+                    "{TENSOR_LAYOUT_CONTRACT} not found — set APR_CONTRACTS_DIR or run from an aprender checkout"
+                ),
+                duration_ms: 0,
+            },
+        };
         print_gate_result(&gate, json);
         gates.push(gate);
     }
@@ -640,6 +701,61 @@ mod tests {
         let gate = run_gate("ok_test", "OK Test", 5, false, || Ok(()));
         assert_eq!(gate.status, GateStatus::Pass);
         assert_eq!(gate.message, "OK");
+    }
+
+    // ── Contract location (the Contract Audit gate's input) ──────────────
+    //
+    // The gate used to pass the literal relative path
+    // "contracts/aprender/tensor-layout-v1.yaml" to `pv`, so it resolved
+    // against the CALLER's cwd: PASS inside the aprender checkout, FAIL with
+    // "Failed to read contract file" everywhere else.
+
+    #[test]
+    fn test_locate_contract_finds_it_from_a_subdirectory() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let contract = root.path().join(TENSOR_LAYOUT_CONTRACT);
+        std::fs::create_dir_all(contract.parent().expect("parent")).expect("mkdir");
+        std::fs::write(&contract, "kind: KernelContract\n").expect("write");
+
+        let deep = root.path().join("crates/apr-cli/src");
+        std::fs::create_dir_all(&deep).expect("mkdir deep");
+
+        let found = locate_contract_from(&deep, None, TENSOR_LAYOUT_CONTRACT)
+            .expect("must walk up to the checkout root");
+        assert_eq!(
+            std::fs::canonicalize(found).expect("canon"),
+            std::fs::canonicalize(&contract).expect("canon"),
+        );
+    }
+
+    #[test]
+    fn test_locate_contract_honours_explicit_contracts_dir() {
+        let elsewhere = tempfile::tempdir().expect("tempdir");
+        let contracts = elsewhere.path().join("contracts");
+        std::fs::create_dir_all(contracts.join("aprender")).expect("mkdir");
+        let contract = contracts.join("aprender/tensor-layout-v1.yaml");
+        std::fs::write(&contract, "kind: KernelContract\n").expect("write");
+
+        // Start from a directory that has no contracts/ anywhere above it.
+        let bare = tempfile::tempdir().expect("tempdir");
+        let found = locate_contract_from(bare.path(), Some(&contracts), TENSOR_LAYOUT_CONTRACT)
+            .expect("override dir must be searched");
+        assert_eq!(
+            std::fs::canonicalize(found).expect("canon"),
+            std::fs::canonicalize(&contract).expect("canon"),
+        );
+    }
+
+    #[test]
+    fn test_locate_contract_returns_none_off_tree() {
+        // A user who installed `apr` from crates.io and ran it from their home
+        // directory has no contracts/ anywhere: the gate must SKIP, and that
+        // decision is driven by this returning None.
+        let bare = tempfile::tempdir().expect("tempdir");
+        assert!(
+            locate_contract_from(bare.path(), None, TENSOR_LAYOUT_CONTRACT).is_none(),
+            "must not invent a path that does not exist"
+        );
     }
 
     #[test]

--- a/crates/apr-cli/src/dispatch_analysis.rs
+++ b/crates/apr-cli/src/dispatch_analysis.rs
@@ -78,17 +78,28 @@ fn dispatch_analysis_commands(cli: &Cli) -> Option<Result<(), CliError>> {
                 layer,
                 assert,
                 tolerance,
-            } => crate::error::resolve_model_path(file).and_then(|r| {
-                probar::run(
-                    &r,
-                    output,
-                    format.parse().unwrap_or(probar::ExportFormat::Both),
-                    golden.as_deref(),
-                    layer.as_deref(),
-                    *assert,
-                    *tolerance,
-                )
-            }),
+            } => {
+                // An unparseable --format used to be swallowed by
+                // `.unwrap_or(Both)`, so `--format bogus` silently exported
+                // something the user never asked for. FromStr already produces
+                // the right message; surface it.
+                format
+                    .parse::<probar::ExportFormat>()
+                    .map_err(crate::error::CliError::ValidationFailed)
+                    .and_then(|export_format| {
+                        crate::error::resolve_model_path(file).and_then(|r| {
+                            probar::run(
+                                &r,
+                                output,
+                                export_format,
+                                golden.as_deref(),
+                                layer.as_deref(),
+                                *assert,
+                                *tolerance,
+                            )
+                        })
+                    })
+            }
         },
 
         ExtendedCommands::CompareHf {
@@ -1267,6 +1278,7 @@ fn dispatch_profiling_commands(cli: &Cli) -> Option<Result<(), CliError>> {
                 text.as_deref(),
                 Some(*max_tokens),
                 Some(*threshold),
+                device,
                 cli.json,
             ),
         }),

--- a/crates/apr-cli/src/extended_commands.rs
+++ b/crates/apr-cli/src/extended_commands.rs
@@ -77,7 +77,12 @@ pub enum ExtendedCommands {
         brick: Option<String>,
         /// Comma-separated latency percentile points for JSON output
         /// (CRUX-E-07). Default: `50,95,99`. Values must be in (0, 100].
-        #[arg(long, value_delimiter = ',', default_value = "50,95,99")]
+        #[arg(
+            long,
+            value_delimiter = ',',
+            default_value = "50,95,99",
+            value_parser = crate::commands::bench::parse_percentile
+        )]
         percentiles: Vec<f64>,
     },
     /// Evaluate model perplexity (spec H13: PPL <= 20) or classification metrics
@@ -112,8 +117,9 @@ pub enum ExtendedCommands {
         /// Generate HuggingFace model card (README.md) in checkpoint dir
         #[arg(long)]
         generate_card: bool,
-        /// Device for inference: "cpu" (default) or "cuda" (GPU-accelerated, ALB-089)
-        #[arg(long, default_value = "cpu")]
+        /// Device for inference: "cpu" (default) or "cuda" (GPU-accelerated, ALB-089).
+        /// Applies to --task humaneval/mbpp; perplexity evaluation is CPU-only.
+        #[arg(long, default_value = "cpu", value_parser = ["cpu", "cuda"])]
         device: String,
         /// Number of samples per problem for pass@k (ALB-088, default: 1)
         #[arg(long, default_value = "1")]

--- a/crates/apr-cli/src/lib_dispatch_coverage.rs
+++ b/crates/apr-cli/src/lib_dispatch_coverage.rs
@@ -269,6 +269,115 @@
         assert!(result.is_some(), "Diagnose should be handled by analysis dispatcher");
     }
 
+    // ── apr showcase --step ─────────────────────────────────────────────
+
+    /// `--step bogus` used to map to `None`, indistinguishable from "no --step
+    /// given", so the CLI answered "No step specified" to a command line that
+    /// plainly specified one.
+    #[test]
+    fn test_showcase_unknown_step_names_the_offending_value() {
+        let err = parse_showcase_step("bogus").expect_err("unknown step must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("bogus"),
+            "error must quote what the user typed, got: {msg}"
+        );
+        assert!(
+            !msg.contains("No step specified"),
+            "must not claim no step was specified, got: {msg}"
+        );
+        for expected in ["import", "gguf", "convert", "apr", "all"] {
+            assert!(
+                msg.contains(expected),
+                "error should list '{expected}', got: {msg}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_showcase_every_documented_step_parses() {
+        // The list printed by `print_available_steps`, plus `chat`.
+        for name in [
+            "import",
+            "gguf",
+            "convert",
+            "apr",
+            "brick",
+            "bench",
+            "chat",
+            "visualize",
+            "zram",
+            "cuda",
+            "all",
+        ] {
+            assert!(
+                parse_showcase_step(name).is_ok(),
+                "'{name}' is advertised and must parse"
+            );
+        }
+    }
+
+    #[test]
+    fn test_showcase_step_typo_is_rejected_not_silently_ignored() {
+        // A near-miss is the realistic case: `--step ggug` for `gguf`.
+        assert!(parse_showcase_step("ggug").is_err());
+        assert!(parse_showcase_step("GGUF").is_err(), "matching is exact");
+        assert!(parse_showcase_step("").is_err());
+    }
+
+    /// `apr probar tensor --format bogus` used to be silently rewritten to
+    /// `both` by `.unwrap_or(ExportFormat::Both)`, so a typo produced a
+    /// different export than requested and exited 0.
+    #[test]
+    fn test_dispatch_analysis_probar_rejects_unknown_format() {
+        let cli = make_cli(Commands::Extended(ExtendedCommands::Probar {
+            command: ProbarSubcommand::Tensor {
+                file: PathBuf::from("/tmp/nonexistent_probar_model.apr"),
+                output: PathBuf::from("/tmp/nonexistent_probar_out"),
+                format: "bogus".to_string(),
+                golden: None,
+                layer: None,
+                assert: false,
+                tolerance: 0.98,
+            },
+        }));
+        let result = dispatch_analysis_commands(&cli);
+        let err = result
+            .expect("Probar should be handled by analysis dispatcher")
+            .expect_err("unknown --format must be rejected, not silently defaulted");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("Unknown format") && msg.contains("bogus"),
+            "error must name the rejected value, got: {msg}"
+        );
+    }
+
+    /// The valid values must still reach probar (which then fails on the
+    /// missing model, not on the format).
+    #[test]
+    fn test_dispatch_analysis_probar_accepts_known_formats() {
+        for format in ["json", "png", "both", "all"] {
+            let cli = make_cli(Commands::Extended(ExtendedCommands::Probar {
+                command: ProbarSubcommand::Tensor {
+                    file: PathBuf::from("/tmp/nonexistent_probar_model.apr"),
+                    output: PathBuf::from("/tmp/nonexistent_probar_out"),
+                    format: format.to_string(),
+                    golden: None,
+                    layer: None,
+                    assert: false,
+                    tolerance: 0.98,
+                },
+            }));
+            let err = dispatch_analysis_commands(&cli)
+                .expect("handled")
+                .expect_err("missing model file still errors");
+            assert!(
+                !err.to_string().contains("Unknown format"),
+                "'{format}' must be accepted, got: {err}"
+            );
+        }
+    }
+
     #[test]
     fn test_dispatch_analysis_compare_hf_offline_rejected() {
         let mut cli = make_cli(Commands::Extended(ExtendedCommands::CompareHf {

--- a/crates/apr-cli/src/validate.rs
+++ b/crates/apr-cli/src/validate.rs
@@ -310,6 +310,40 @@ fn dispatch_cbtop(
     })
 }
 
+/// The `--step` values `apr showcase` accepts, in the order `--help` lists them.
+const SHOWCASE_STEPS: &[(&str, showcase::ShowcaseStep)] = &[
+    ("import", showcase::ShowcaseStep::Import),
+    ("gguf", showcase::ShowcaseStep::GgufInference),
+    ("convert", showcase::ShowcaseStep::Convert),
+    ("apr", showcase::ShowcaseStep::AprInference),
+    ("brick", showcase::ShowcaseStep::BrickDemo),
+    ("bench", showcase::ShowcaseStep::Benchmark),
+    ("chat", showcase::ShowcaseStep::Chat),
+    ("visualize", showcase::ShowcaseStep::Visualize),
+    ("zram", showcase::ShowcaseStep::ZramDemo),
+    ("cuda", showcase::ShowcaseStep::CudaDemo),
+    ("all", showcase::ShowcaseStep::All),
+];
+
+/// Resolve a `--step` value, naming the offending input when it is unknown.
+///
+/// An unrecognised step used to map to `None`, which is the same state as
+/// "no `--step` given" — so `--step bogus` reported "No step specified", a
+/// message that contradicts the command line the user typed.
+fn parse_showcase_step(s: &str) -> Result<showcase::ShowcaseStep, CliError> {
+    SHOWCASE_STEPS
+        .iter()
+        .find(|(name, _)| *name == s)
+        .map(|(_, step)| *step)
+        .ok_or_else(|| {
+            let names: Vec<&str> = SHOWCASE_STEPS.iter().map(|(name, _)| *name).collect();
+            CliError::ValidationFailed(format!(
+                "unknown step '{s}'; available: {}",
+                names.join(", ")
+            ))
+        })
+}
+
 /// Dispatch `apr showcase` — extracted to reduce cognitive complexity of `execute_command`
 #[allow(clippy::too_many_arguments)]
 fn dispatch_showcase(
@@ -325,20 +359,7 @@ fn dispatch_showcase(
     verbose: bool,
     quiet: bool,
 ) -> Result<(), CliError> {
-    let step = step.and_then(|s| match s {
-        "import" => Some(showcase::ShowcaseStep::Import),
-        "gguf" => Some(showcase::ShowcaseStep::GgufInference),
-        "convert" => Some(showcase::ShowcaseStep::Convert),
-        "apr" => Some(showcase::ShowcaseStep::AprInference),
-        "bench" => Some(showcase::ShowcaseStep::Benchmark),
-        "chat" => Some(showcase::ShowcaseStep::Chat),
-        "visualize" => Some(showcase::ShowcaseStep::Visualize),
-        "zram" => Some(showcase::ShowcaseStep::ZramDemo),
-        "cuda" => Some(showcase::ShowcaseStep::CudaDemo),
-        "brick" => Some(showcase::ShowcaseStep::BrickDemo),
-        "all" => Some(showcase::ShowcaseStep::All),
-        _ => None,
-    });
+    let step = step.map(parse_showcase_step).transpose()?;
 
     let tier = match tier {
         "tiny" => showcase::ModelTier::Tiny,


### PR DESCRIPTION
Found by dogfooding `apr` 0.63.0 installed from crates.io. Six of the seven findings in #2380 — the seventh (`--assert-tps` divided by ten) is PR #2372 and is not touched here.

Every repro below was run first against the crates.io 0.63.0 binary, then against a release build of this branch.

## `apr qualify --tier standard` failed for everyone outside the source checkout

The Contract Audit gate shelled out to `pv audit contracts/aprender/tensor-layout-v1.yaml` — a path resolved against the **caller's** working directory (`qualify.rs:441-446`). The gate's verdict was therefore a function of where you stood.

```
# 0.63.0 from /tmp
rc=5
│ Contract Audit (pv) │ ✗ FAIL │ error: Failed to read contract file: No such file or directory (os error 2) │

# 0.63.0 from /home/noah/src/aprender — same model, same tier
│ Contract Audit (pv) │ ✓ PASS │ OK │
```

The contract ships with the source tree, not with the binary, so a missing file is a missing *input*, not a failed audit. `locate_contract` now resolves it from `APR_CONTRACTS_DIR` or by walking up from cwd, and the gate SKIPs with an actionable message when it is nowhere to be found.

```
# this branch, from /tmp
│ Contract Audit (pv) │ ○ SKIP │ contracts/aprender/tensor-layout-v1.yaml not found — set APR_CONTRACTS_DIR or run from an aprender checkout │

# this branch, from /tmp, with APR_CONTRACTS_DIR=/home/noah/src/aprender/contracts
│ Contract Audit (pv) │ ✓ PASS │ OK │

# this branch, from the repo root — unchanged
│ Contract Audit (pv) │ ✓ PASS │ OK │
```

## `apr probar tensor` listed files it had not written

It printed a `Generated files:` manifest of `.png` paths (`probar.rs:249`) and then wrote Netpbm `.pgm` bytes (`probar.rs:417`, with `let _ = png_path;` at :445 silencing the unused variable). A CI step copying the listed paths into probar fixtures fails with ENOENT.

```
# 0.63.0
Generated files:
  - .../layer_000_block_0.png
  - .../layer_001_block_1.png
$ ls
layer_000_block_0.meta.json  layer_000_block_0.pgm  layer_001_block_1.meta.json  layer_001_block_1.pgm
```

Rather than downgrade the promise, this adds a dependency-free 8-bit grayscale PNG encoder (`png_encode.rs`: IHDR + zlib-stored IDAT + IEND, CRC-32 and Adler-32, ~110 lines) and the export writes real PNGs. The printed manifest and the export are now derived from one function, so they cannot drift apart again.

```
# this branch
Generated files:
  - .../layer_000_block_0.png
  - .../layer_000_block_0.meta.json
  - .../layer_001_block_1.png
  - .../layer_001_block_1.meta.json
$ file layer_000_block_0.png
... PNG image data, 256 x 100, 8-bit grayscale, non-interlaced
$ python3 -c "from PIL import Image; print(Image.open('layer_000_block_0.png').format)"
PNG
```

Separately, `--format bogus` was swallowed by `.unwrap_or(ExportFormat::Both)` (`dispatch_analysis.rs:85`) and silently exported something the user never asked for, at exit 0. The `FromStr` error it already produced is now surfaced:

```
# 0.63.0: bogus rc=0, wrote .pgm + manifest.json
# this branch:
rc=5
error: Validation failed: Unknown format: bogus. Use json, png, or both
```

## `apr qa` passed two GPU gates vacuously on a CPU-only build

```
# 0.63.0 (default features, no cuda)
  ✓ PASS Capability Match Architecture 'qwen2': all 5 required ops supported by GPU
  ○ SKIP GPU Speedup Skipped: Requires 'inference' and 'cuda' features
  ✓ PASS PTX Parity 0/0 kernel pairs passed PTX parity
  ○ SKIP GPU State Isolation Skipped: Requires inference+cuda features
```

Capability Match asserted GPU kernel support from a build with no GPU backend compiled in. PTX Parity reported a pass over zero comparisons: without the `cuda` feature `validate_all_kernel_pairs` returns an empty report, and `all_passed()` is `failed == 0`, which is vacuously true. Zero comparisons is not a pass — that gate could not fail by construction. Both now SKIP, matching their two neighbours:

```
# this branch, same model
  ○ SKIP Capability Match Skipped: Requires 'inference' and 'cuda' features
  ○ SKIP GPU Speedup Skipped: Requires 'inference' and 'cuda' features
  ○ SKIP PTX Parity Skipped: no PTX kernel pairs compiled in (requires 'cuda' feature)
  ○ SKIP GPU State Isolation Skipped: Requires inference+cuda features
```

## `apr bench --percentiles` emitted a null metric instead of an argument error

The help text says "Values must be in (0, 100]"; 0 and 101 were accepted and reached `bench.rs:264-267`, where the non-`Ok` `PercentileOutcome` serialised as `null` under a plausible key.

```
# 0.63.0 --percentiles 101
  "latency_p101_ms": null

# this branch
error: invalid value '101' for '--percentiles <PERCENTILES>': percentile '101' out of range: values must be in (0, 100]
rc=2
# and the in-range case is untouched: --percentiles 50 -> "latency_p50_ms": 430.41200000000003
```

Non-numeric input was already rejected by the value parser, so the range check belongs there; `bench::run` also checks, for non-clap callers.

## `apr eval --device` accepted anything and did nothing

`--device cpu`, `cuda` and `bogus` produced byte-identical perplexity with no mention of a device anywhere in the output — a typo like `--device cude` ran on CPU while the operator believed otherwise. The only readers of `device` are the humaneval/mbpp paths (`inference.rs:121`, `:1531`); the perplexity path never consults it.

```
# this branch
$ apr eval model.gguf ... --device cuda
⚠ --device cuda requested, but perplexity evaluation is CPU-only — running on cpu (--device applies to --task humaneval/mbpp)
  Device: cpu
$ apr eval model.gguf ... --device bogus
error: invalid value 'bogus' for '--device <DEVICE>'
  [possible values: cpu, cuda]
rc=2
$ apr eval ... --device cuda --json
  "device": "cpu",
```

## `apr showcase --step <unknown>` contradicted the command line

The unknown-value branch fell through to the not-specified branch because both mapped to `None`.

```
# 0.63.0
error: Validation failed: No step specified. Use --auto-verify or --step <step>

# this branch
error: Validation failed: unknown step 'bogus'; available: import, gguf, convert, apr, brick, bench, chat, visualize, zram, cuda, all
```

## Mutation check

Reverting all six fixes while keeping the tests turns 14 tests RED:

```
test result: FAILED. 6638 passed; 13 failed; 12 ignored

    commands::bench::tests::bench_run_rejects_out_of_range_percentiles
    commands::bench::tests::parse_percentile_rejects_out_of_range_points
    commands::eval::eval_mod_tests::perplexity_device_notice_fires_only_when_the_request_is_not_honoured
    commands::probar::tests::test_every_listed_generated_file_actually_exists
    commands::probar::tests::test_export_by_format_both_creates_all
    commands::probar::tests::test_export_by_format_png_creates_png_only
    commands::probar::tests::test_export_png_histogram_normalization
    commands::qa::tests::ptx_gate_skips_when_no_kernel_pairs_were_compared
    commands::qualify::tests::test_locate_contract_finds_it_from_a_subdirectory
    commands::qualify::tests::test_locate_contract_honours_explicit_contracts_dir
    commands::qualify::tests::test_locate_contract_returns_none_off_tree
    tests::test_dispatch_analysis_probar_rejects_unknown_format
    tests::test_showcase_unknown_step_names_the_offending_value
```

with, verbatim:

```
---- commands::qualify::tests::test_locate_contract_returns_none_off_tree stdout ----
panicked at crates/apr-cli/src/commands/qualify.rs:739:9:
must not invent a path that does not exist

---- commands::probar::tests::test_every_listed_generated_file_actually_exists stdout ----
panicked at crates/apr-cli/src/commands/probar_tests_export_png.rs:231:13:
Png: listed /tmp/.tmpxBAi54/layer_000_block_0.png but it was never written

---- commands::qa::tests::ptx_gate_skips_when_no_kernel_pairs_were_compared stdout ----
panicked at crates/apr-cli/src/commands/fields.rs:388:9:
0/0 comparisons must be reported as SKIP

---- commands::bench::tests::parse_percentile_rejects_out_of_range_points stdout ----
panicked at crates/apr-cli/src/commands/bench_brick_name.rs:408:39:
point outside (0, 100] must be rejected: 0.0

---- commands::eval::eval_mod_tests::perplexity_device_notice_fires_only_when_the_request_is_not_honoured stdout ----
panicked at crates/apr-cli/src/commands/eval/eval_mod_tests.rs:466:51:
cuda must be called out

---- tests::test_dispatch_analysis_probar_rejects_unknown_format stdout ----
panicked at crates/apr-cli/src/lib_dispatch_coverage.rs:349:9:
error must name the rejected value, got: File not found: /tmp/nonexistent_probar_model.apr

---- tests::test_showcase_unknown_step_names_the_offending_value stdout ----
panicked at crates/apr-cli/src/lib_dispatch_coverage.rs:281:9:
error must quote what the user typed, got: Validation failed: No step specified. Use --auto-verify or --step <step>
```

The 14th, `capability_gate_makes_no_gpu_claim_without_cuda`, was **itself vacuous on the first pass** — its GGUF fixture carried no metadata, so the gate short circuited on "missing architecture metadata" and never reached the GPU claim. It now writes a `general.architecture` KV and additionally asserts the SKIP message, which is what proves the fixture engaged. Re-mutated afterwards:

```
---- commands::qa::tests::capability_gate_makes_no_gpu_claim_without_cuda stdout ----
panicked at crates/apr-cli/src/commands/fields.rs:451:9:
a CPU-only build must not assert GPU support, got: Architecture 'qwen2': all 5 required ops supported by GPU
```

One pre-existing test encoded a defect and was rewritten: `test_export_by_format_png_creates_pgm_only` asserted that a `.pgm` existed — exactly the file the command claimed it had not written. It is now `test_export_by_format_png_creates_png_only` and asserts the `.png` the command advertises, plus that no stray Netpbm file is left behind.

## Gates

`cargo fmt --all -- --check` clean, `cargo clippy -p apr-cli --lib -- -D warnings` clean, 6651 apr-cli lib tests pass. End-to-end verification ran against `/mnt/nvme-raid0/targets/aprender/release/apr` (`apr 0.63.0 (5643db51d)`) built from this branch — never a bare `apr`.

Audit epic: #2373

Refs #2380 (partial) — fixes findings 2, 3, 4, 5, 6 and 7. Finding 1 (`apr qa --assert-tps` divided by ten for GGUF and discarded for APR/SafeTensors) is **not** touched here; it is PR #2372 and remains the only open item in the cluster once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
