### PR TITLE
fix(run): --stream sent nothing, --trace-output recorded nothing, and a typo'd --backend ran the default backend

### DIFF
--- a/crates/apr-cli/src/commands/chat.rs
+++ b/crates/apr-cli/src/commands/chat.rs
@@ -296,16 +296,40 @@ fn find_qwen_tokenizer(model_path: &Path) -> Result<Option<Qwen2BpeTokenizer>, C
         }
     }
 
-    Err(CliError::InvalidFormat(
-        "No Qwen tokenizer found. Searched:\n\
-         1. Pacha cache ({stem}.tokenizer.json alongside model)\n\
-         2. Model directory (tokenizer.json)\n\
-         3. HuggingFace cache (~/.cache/huggingface/hub/models--Qwen--*/snapshots/*/tokenizer.json)\n\
-         4. APR cache (~/.apr/tokenizers/qwen2/tokenizer.json)\n\n\
+    Err(CliError::InvalidFormat(no_qwen_tokenizer_message(
+        model_path,
+    )))
+}
+
+/// The "no tokenizer" message for `model_path`, with every search location
+/// spelled out as a concrete path.
+///
+/// This message used to print the literal text `{stem}.tokenizer.json` — the
+/// format placeholder was written inside a plain string, so it was never
+/// substituted and the user was shown a template instead of the filename `apr`
+/// actually looked for. Naming the real paths is the difference between "go
+/// find out what apr means by stem" and "create this file".
+fn no_qwen_tokenizer_message(model_path: &Path) -> String {
+    let dir = model_path
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .map_or_else(|| ".".to_string(), |p| p.display().to_string());
+    let stem = model_path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("<model>");
+    let home = dirs::home_dir().map_or_else(|| "~".to_string(), |h| h.display().to_string());
+
+    format!(
+        "No Qwen tokenizer found for {model}. Searched:\n\
+         1. Pacha cache:       {dir}/{stem}.tokenizer.json\n\
+         2. Model directory:   {dir}/tokenizer.json\n\
+         3. HuggingFace cache: {home}/.cache/huggingface/hub/models--Qwen--*/snapshots/*/tokenizer.json\n\
+         4. APR cache:         {home}/.apr/tokenizers/qwen2/tokenizer.json\n\n\
          To fix: Download a Qwen model with tokenizer:\n\
-           apr pull hf://Qwen/Qwen2.5-0.5B-Instruct-GGUF"
-            .to_string(),
-    ))
+           apr pull hf://Qwen/Qwen2.5-0.5B-Instruct-GGUF",
+        model = model_path.display(),
+    )
 }
 
 /// Normalize repeated punctuation (max 3 repeats of `!`, `?`, `.`).

--- a/crates/apr-cli/src/commands/chat_command_find_qwen.rs
+++ b/crates/apr-cli/src/commands/chat_command_find_qwen.rs
@@ -59,27 +59,45 @@
         assert!(result.is_ok() || result.is_err());
     }
 
+    /// The message must name the file the user has to produce.
+    ///
+    /// This test used to build its OWN copy of the error string and assert on
+    /// that, so it passed while the shipped message printed the literal
+    /// `{stem}.tokenizer.json` — an unsubstituted format placeholder — to every
+    /// user who ran `apr chat` on a model with no tokenizer. It now calls the
+    /// real message builder.
     #[test]
     fn test_find_qwen_tokenizer_error_message_content_when_no_cache() {
-        // When find_qwen_tokenizer fails, it should return an InvalidFormat error
-        // with a helpful message listing the search locations.
-        // We test the error construction directly since the function may succeed
-        // on machines with cached tokenizers.
-        let err = CliError::InvalidFormat(
-            "No Qwen tokenizer found. Searched:\n\
-             1. Model directory (tokenizer.json)\n\
-             2. HuggingFace cache (~/.cache/huggingface/hub/models--Qwen--*/snapshots/*/tokenizer.json)\n\
-             3. APR cache (~/.apr/tokenizers/qwen2/tokenizer.json)\n\n\
-             To fix: Download a Qwen model with tokenizer:\n\
-               apr pull hf://Qwen/Qwen2.5-0.5B-Instruct-GGUF"
-                .to_string(),
+        let msg = no_qwen_tokenizer_message(Path::new("/models/sub/m.apr"));
+
+        assert!(
+            !msg.contains("{stem}"),
+            "the message must not show an unsubstituted format placeholder: {msg}"
         );
-        let msg = err.to_string();
+        assert!(
+            msg.contains("/models/sub/m.tokenizer.json"),
+            "the pacha-cache candidate must be a concrete path: {msg}"
+        );
+        assert!(
+            msg.contains("/models/sub/tokenizer.json"),
+            "the model-directory candidate must be a concrete path: {msg}"
+        );
         assert!(msg.contains("No Qwen tokenizer found"));
-        assert!(msg.contains("tokenizer.json"));
         assert!(msg.contains("HuggingFace cache"));
         assert!(msg.contains("APR cache"));
         assert!(msg.contains("apr pull"));
+    }
+
+    /// A bare filename has no parent directory; the message must still resolve
+    /// to something a user can act on rather than an empty path fragment.
+    #[test]
+    fn no_qwen_tokenizer_message_handles_bare_filename() {
+        let msg = no_qwen_tokenizer_message(Path::new("m.apr"));
+        assert!(!msg.contains("{stem}"), "{msg}");
+        assert!(
+            msg.contains("./m.tokenizer.json"),
+            "bare filename must resolve against the CWD: {msg}"
+        );
     }
 
     #[test]

--- a/crates/apr-cli/src/commands/gguf_generate_result.rs
+++ b/crates/apr-cli/src/commands/gguf_generate_result.rs
@@ -334,6 +334,49 @@ fn format_prediction_output(
 /// NaN/Inf counts), those are printed per layer. Otherwise falls back to
 /// aggregate timing from RunResult.
 fn print_layer_trace(result: &RunResult, max_tokens: usize) {
+    eprint!("{}", render_layer_trace(result, max_tokens));
+}
+
+/// Fixed share of per-token wall time attributed to each step of the 8-step
+/// state machine. These are ASSUMPTIONS, not measurements — see
+/// [`render_layer_trace`].
+fn layer_trace_share(step: &str) -> f64 {
+    match step {
+        "TRANSFORMER" => 0.85,
+        "LM_HEAD" => 0.08,
+        "SAMPLE" => 0.02,
+        _ => 0.017,
+    }
+}
+
+/// Render the layer-trace table.
+///
+/// # These numbers are ESTIMATES and the table says so
+///
+/// The per-step figures are `wall_ms / tokens * <fixed share>` — a constant
+/// split of one measured total, identical for every model and every prompt.
+/// The table used to head that column `Time` and print the values bare, so it
+/// read as a measurement: it always "proved" TRANSFORMER was 85% of the run,
+/// while the real `[BRICK-PROFILE]` block a few lines above the same output
+/// reported FFN 42% / Qkv 21% / LmHead 4.5% for that identical run. TOKENIZE,
+/// EMBED and DECODE came out equal to the hundredth of a millisecond in every
+/// run, which is the tell.
+///
+/// Two things follow, and both are in the rendered output now:
+///
+/// 1. The column is `Est. Time`, each value is prefixed `~`, and the share used
+///    to derive it is printed next to it. A reader cannot mistake a derived
+///    number for a measured one.
+/// 2. `TOTAL` is labelled wall-clock **including model load**, and its rate is
+///    labelled end-to-end. Reporting `1.0 tok/s` next to the profiler's
+///    `19.2 tok/s` for the same run, with neither labelled, is a 19x
+///    contradiction inside one screen of output.
+///
+/// Returned as a `String` so the rendering is directly assertable; the caller
+/// prints it to stderr.
+fn render_layer_trace(result: &RunResult, max_tokens: usize) -> String {
+    use std::fmt::Write as _;
+
     let tokens_generated = result.tokens_generated.unwrap_or(max_tokens);
     let total_ms = result.duration_secs * 1000.0;
     let tok_per_sec = if result.duration_secs > 0.0 {
@@ -341,10 +384,6 @@ fn print_layer_trace(result: &RunResult, max_tokens: usize) {
     } else {
         0.0
     };
-
-    eprintln!();
-    eprintln!("{}", "=== Layer Trace (APR-TRACE-001) ===".cyan().bold());
-    eprintln!();
 
     // 8-step inference state machine trace
     let steps = [
@@ -362,34 +401,68 @@ fn print_layer_trace(result: &RunResult, max_tokens: usize) {
         total_ms
     };
 
-    eprintln!(
-        "  {:<16} {:<10} {}",
+    let mut out = String::new();
+    let _ = writeln!(out);
+    let _ = writeln!(out, "{}", "=== Layer Trace (APR-TRACE-001) ===".cyan().bold());
+    let _ = writeln!(out);
+    let _ = writeln!(
+        out,
+        "  {}",
+        "ESTIMATED — per-step values are a fixed share of measured wall time,".yellow()
+    );
+    let _ = writeln!(
+        out,
+        "  {}",
+        "NOT per-step measurements. Same ratios for every model and prompt.".yellow()
+    );
+    let _ = writeln!(out);
+    let _ = writeln!(
+        out,
+        "  {:<16} {:<12} {:<8} {}",
         "Step".bold(),
-        "Time".bold(),
+        "Est. Time".bold(),
+        "Share".bold(),
         "Description".bold()
     );
-    eprintln!("  {}", "─".repeat(56));
+    let _ = writeln!(out, "  {}", "─".repeat(66));
 
     for (name, desc) in &steps {
-        // Approximate per-step timing from total (real brick timing
-        // requires BrickProfiler integration via `apr profile --granular`)
-        let step_ms = match *name {
-            "TRANSFORMER" => per_token_ms * 0.85,
-            "LM_HEAD" => per_token_ms * 0.08,
-            "SAMPLE" => per_token_ms * 0.02,
-            _ => per_token_ms * 0.017,
-        };
-        eprintln!("  {:<16} {:>7.2}ms  {}", name, step_ms, desc.dimmed());
+        let share = layer_trace_share(name);
+        let _ = writeln!(
+            out,
+            "  {:<16} ~{:>8.2}ms  {:>6.1}%  {}",
+            name,
+            per_token_ms * share,
+            share * 100.0,
+            desc.dimmed()
+        );
     }
 
-    eprintln!("  {}", "─".repeat(56));
-    eprintln!("  {:<16} {:>7.2}ms  {:.1} tok/s", "TOTAL", total_ms, tok_per_sec);
-    eprintln!();
-    eprintln!(
-        "  {}",
-        "Tip: Use `apr profile <model> --granular` for real per-brick µs timing.".dimmed()
+    let _ = writeln!(out, "  {}", "─".repeat(66));
+    let _ = writeln!(
+        out,
+        "  {:<16} {:>9.2}ms  measured wall clock, incl. model load",
+        "TOTAL", total_ms
     );
-    eprintln!();
+    let _ = writeln!(
+        out,
+        "  {:<16} {:>9.1} tok/s  end-to-end ({} tokens / total wall clock);",
+        "RATE", tok_per_sec, tokens_generated
+    );
+    let _ = writeln!(
+        out,
+        "  {:<16} {}",
+        "",
+        "decode-only throughput is the [BRICK-PROFILE] figure, which excludes load".dimmed()
+    );
+    let _ = writeln!(out);
+    let _ = writeln!(
+        out,
+        "  {}",
+        "For measured per-brick µs timing: `apr profile <model> --granular`.".dimmed()
+    );
+    let _ = writeln!(out);
+    out
 }
 
 /// Print payload trace with activation statistics (TensorStats per layer).

--- a/crates/apr-cli/src/commands/inference_output.rs
+++ b/crates/apr-cli/src/commands/inference_output.rs
@@ -179,6 +179,11 @@ struct InferenceOutput {
     used_gpu: Option<bool>,
     /// GH-250: Generated token IDs for parity checking
     generated_tokens: Option<Vec<u32>>,
+    /// Decoded text for each entry of `generated_tokens`, in the same order.
+    ///
+    /// Populated only when `--stream` asked for it (see
+    /// [`decode_token_pieces`]) — every other mode renders the whole `text`.
+    token_texts: Option<Vec<String>>,
 }
 
 /// Execute inference on model
@@ -235,8 +240,48 @@ fn execute_inference(
             tok_per_sec: None,
             used_gpu: None,
             generated_tokens: None,
+            token_texts: None,
         })
     }
+}
+
+/// Decode each generated token id to its own text piece, using the model's own
+/// tokenizer.
+///
+/// # Why
+///
+/// `apr run --stream` emitted one NDJSON event per token whose `text` field was
+/// **always** the empty string — the token ids were right (the terminal `final`
+/// event decoded them into the full reply) but the per-token decode was simply
+/// never done. A consumer rendering `text` as events arrive saw nothing at all
+/// until the run finished, which is the entire point of the flag.
+///
+/// Single-token decode is the same thing the HTTP streaming path does
+/// (`decode_token(&tokenizer, token_id, clean)` in the SSE handler), so a
+/// `--stream` consumer and an SSE consumer see the same pieces. A multi-byte
+/// character split across two tokens decodes to a replacement char in the piece
+/// that carries only part of it; the `final` event always carries the
+/// authoritative full text.
+///
+/// Returns `None` when no tokenizer can be resolved for the model — the caller
+/// then leaves `text` empty rather than inventing pieces.
+#[cfg(feature = "inference")]
+fn decode_token_pieces(model_path: &Path, ids: &[u32]) -> Option<Vec<String>> {
+    if ids.is_empty() {
+        return Some(Vec::new());
+    }
+
+    // GGUF carries its vocabulary inside the file.
+    if let Ok(mapped) = realizar::gguf::MappedGGUFModel::from_path(model_path) {
+        return Some(ids.iter().map(|&id| mapped.model.decode(&[id])).collect());
+    }
+
+    // APR / SafeTensors: sibling tokenizer.json (hash-prefixed or plain).
+    if let Some(tok) = realizar::apr::AprV2Model::load_tokenizer(model_path) {
+        return Some(ids.iter().map(|&id| tok.decode(&[id])).collect());
+    }
+
+    None
 }
 
 /// Execute inference using realizar engine
@@ -317,6 +362,15 @@ fn execute_with_realizar(
     } else {
         Some(Vec::new())
     };
+    // Only `--stream` renders per-token text, and resolving the tokenizer costs
+    // a second open of the model file — so do not pay it on every run.
+    let token_texts = if options.stream {
+        generated_tokens
+            .as_deref()
+            .and_then(|ids| decode_token_pieces(model_path, ids))
+    } else {
+        None
+    };
     Ok(InferenceOutput {
         text: result.text,
         tokens_generated: Some(result.generated_token_count),
@@ -324,6 +378,7 @@ fn execute_with_realizar(
         tok_per_sec: Some(result.tok_per_sec),
         used_gpu: Some(result.used_gpu),
         generated_tokens,
+        token_texts,
     })
 }
 
@@ -375,5 +430,6 @@ fn execute_with_whisper(
         tok_per_sec: Some(word_count as f64 / duration.as_secs_f64()),
         used_gpu: Some(false),
         generated_tokens: None,
+        token_texts: None,
     })
 }

--- a/crates/apr-cli/src/commands/run.rs
+++ b/crates/apr-cli/src/commands/run.rs
@@ -169,6 +169,12 @@ pub(crate) struct RunOptions {
     pub repeat_last_n: usize,
     /// Process prompt tokens one-by-one (debug prefill)
     pub split_prompt: bool,
+    /// `--stream`: emit one NDJSON event per generated token.
+    ///
+    /// Known here (not only at the print site) because streaming is the one
+    /// mode that needs per-token decoded text, and resolving the tokenizer for
+    /// it costs a second open of the model file.
+    pub stream: bool,
 }
 
 impl Default for RunOptions {
@@ -196,6 +202,7 @@ impl Default for RunOptions {
             repeat_penalty: 1.0,
             repeat_last_n: 64,
             split_prompt: false,
+            stream: false,
         }
     }
 }
@@ -217,6 +224,12 @@ pub(crate) struct RunResult {
     pub used_gpu: Option<bool>,
     /// GH-250: Generated token IDs for parity checking
     pub generated_tokens: Option<Vec<u32>>,
+    /// Per-token decoded text, positionally aligned with `generated_tokens`.
+    ///
+    /// `Some` only in `--stream` mode and only when a tokenizer for the model
+    /// could be resolved. `--stream` used to emit `"text":""` for every token
+    /// because nothing ever decoded the ids one at a time.
+    pub token_texts: Option<Vec<String>>,
 }
 
 /// Run the model on input
@@ -279,6 +292,7 @@ pub(crate) fn run_model(source: &str, options: &RunOptions) -> Result<RunResult>
         tok_per_sec: output.tok_per_sec,
         used_gpu: output.used_gpu,
         generated_tokens: output.generated_tokens,
+        token_texts: output.token_texts,
     })
 }
 

--- a/crates/apr-cli/src/commands/run_07.rs
+++ b/crates/apr-cli/src/commands/run_07.rs
@@ -8,5 +8,6 @@ include!("run_tests_format_prediction.rs");
 include!("run_tests_parse_token_ids.rs");
 include!("run_tests_inference_output.rs");
 include!("run_tests_chrome_trace.rs");
+include!("run_tests_layer_trace.rs");
 include!("run_tests_stream_output.rs");
 }

--- a/crates/apr-cli/src/commands/run_entry.rs
+++ b/crates/apr-cli/src/commands/run_entry.rs
@@ -70,6 +70,11 @@ pub(crate) fn run(
         );
     }
 
+    // Kept for the chrome-trace writer below: `RunOptions` takes ownership of
+    // `trace_output`, and `--trace-level chrome` must honour the path the user
+    // asked for instead of inventing `trace-<epoch>.json` in the CWD.
+    let requested_trace_output = trace_output.clone();
+
     let options = RunOptions {
         input: input.map(Path::to_path_buf),
         prompt: prompt.map(String::from),
@@ -93,6 +98,7 @@ pub(crate) fn run(
         repeat_penalty,
         repeat_last_n,
         split_prompt,
+        stream,
     };
 
     let result = run_model(source, &options)?;
@@ -109,7 +115,13 @@ pub(crate) fn run(
     // Integrates layer trace + brick profile into chrome://tracing format.
     // Usage: apr run model.gguf "prompt" --trace --trace-level chrome --profile
     if trace && trace_level == "chrome" {
-        print_chrome_trace(&result, source, max_tokens, profile);
+        print_chrome_trace(
+            &result,
+            source,
+            max_tokens,
+            profile,
+            requested_trace_output.as_deref(),
+        );
     }
 
     if profile && trace_level != "chrome" {
@@ -130,21 +142,65 @@ pub(crate) fn run(
 
 /// F-CLIPARITY-01 / PMAT-386: Chrome trace JSON output.
 /// Integrates layer trace + brick profile into chrome://tracing format.
-/// Output file: trace-{timestamp}.json (matches Candle's --tracing output).
+///
+/// Destination: `--trace-output FILE` when the caller gave one, otherwise
+/// `trace-{timestamp}.json` in the CWD (matches Candle's `--tracing` output).
+///
+/// The path argument exists because `--trace-level chrome` used to ignore
+/// `--trace-output` unconditionally: the chrome JSON landed in an auto-named
+/// file in the working directory while the path the user asked for was left
+/// holding the summary stub, so a scripted consumer silently read the wrong
+/// file.
 fn print_chrome_trace(
     result: &super::run::RunResult,
     source: &str,
     max_tokens: usize,
     include_profile: bool,
+    trace_output: Option<&Path>,
 ) {
     use std::time::{SystemTime, UNIX_EPOCH};
 
-    let timestamp = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
-    let filename = format!("trace-{timestamp}.json");
+    let filename = match trace_output {
+        Some(p) => p.to_path_buf(),
+        None => {
+            let timestamp = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+            PathBuf::from(format!("trace-{timestamp}.json"))
+        }
+    };
 
+    let trace = build_chrome_trace(result, source, max_tokens, include_profile);
+
+    match std::fs::write(
+        &filename,
+        serde_json::to_string_pretty(&trace).unwrap_or_default(),
+    ) {
+        Ok(()) => eprintln!(
+            "Chrome trace written to: {} (load in chrome://tracing)",
+            filename.display()
+        ),
+        Err(e) => eprintln!("Failed to write chrome trace: {e}"),
+    }
+}
+
+/// Build the chrome://tracing document for a completed run.
+///
+/// Split out of [`print_chrome_trace`] so the document can be asserted on
+/// directly. The tests used to assert against a *copy* of this logic kept in
+/// the test file, which proved only that the copy agreed with itself.
+///
+/// `metadata.timing_model` is `"derived"`: apart from the run's total wall
+/// clock, the per-event durations here are a fixed split of that total, not
+/// measured spans. Real per-operation timing comes from the brick profiler
+/// (`apr profile --granular`).
+pub(crate) fn build_chrome_trace(
+    result: &super::run::RunResult,
+    source: &str,
+    max_tokens: usize,
+    include_profile: bool,
+) -> serde_json::Value {
     let mut events = Vec::new();
     let mut ts_us: u64 = 0;
 
@@ -234,8 +290,7 @@ fn print_chrome_trace(
         }
     }
 
-    // Write chrome trace JSON
-    let trace = serde_json::json!({
+    serde_json::json!({
         "traceEvents": events,
         "displayTimeUnit": "ms",
         "metadata": {
@@ -243,17 +298,12 @@ fn print_chrome_trace(
             "tool": "apr run --trace --trace-level chrome",
             "max_tokens": max_tokens,
             "tok_per_sec": result.tok_per_sec,
-            "include_profile": include_profile
+            "include_profile": include_profile,
+            // Honesty marker: only the run total is measured; the per-event
+            // durations below are a fixed split of it.
+            "timing_model": "derived"
         }
-    });
-
-    match std::fs::write(
-        &filename,
-        serde_json::to_string_pretty(&trace).unwrap_or_default(),
-    ) {
-        Ok(()) => eprintln!("Chrome trace written to: {filename} (load in chrome://tracing)"),
-        Err(e) => eprintln!("Failed to write chrome trace: {e}"),
-    }
+    })
 }
 
 /// Print trace configuration when tracing is enabled.
@@ -381,9 +431,11 @@ fn build_final_json(result: &RunResult, source: &str, max_tokens: usize) -> serd
 /// {"event":"final","model":"...","text":"...","tokens":[...],"tok_per_sec":42.0,...}
 /// ```
 ///
-/// Per-token `text` is best-effort: when no per-token decoded text is
-/// available (today, always — see `print_run_output` doc) the field is an
-/// empty string. The token id is always present and exact.
+/// Per-token `text` carries that token's own decoded text, so a consumer can
+/// render the reply as the events arrive. It falls back to an empty string
+/// only when no tokenizer could be resolved for the model; the token id is
+/// always present and exact, and the terminal `final` event always carries the
+/// authoritative full text.
 fn print_stream_output(result: &RunResult, source: &str, max_tokens: usize) -> Result<()> {
     use std::io::Write;
     let stdout = std::io::stdout();
@@ -402,14 +454,13 @@ pub(crate) fn write_stream_output<W: std::io::Write>(
     max_tokens: usize,
 ) -> std::io::Result<()> {
     if let Some(tokens) = result.generated_tokens.as_deref() {
+        let texts = result.token_texts.as_deref().unwrap_or(&[]);
         for (index, token_id) in tokens.iter().copied().enumerate() {
             let evt = serde_json::json!({
                 "event": "token",
                 "index": index as u32,
                 "token_id": token_id,
-                // Per-token decoded text isn't available from realizar yet;
-                // stream consumers should fall back to the final `text` field.
-                "text": "",
+                "text": texts.get(index).map_or("", String::as_str),
             });
             writeln!(out, "{}", serde_json::to_string(&evt).unwrap_or_default())?;
         }

--- a/crates/apr-cli/src/commands/run_tests_chrome_trace.rs
+++ b/crates/apr-cli/src/commands/run_tests_chrome_trace.rs
@@ -8,76 +8,10 @@
     // the function does not panic with various inputs.
     // ═══════════════════════════════════════════════════════════════════════════
 
-    /// Helper to build a trace JSON structure in-memory (mirrors print_chrome_trace logic)
-    /// for content verification without touching the filesystem.
-    fn build_chrome_trace_events(
-        result: &RunResult,
-        source: &str,
-        max_tokens: usize,
-        include_profile: bool,
-    ) -> serde_json::Value {
-        let mut events = Vec::new();
-        let mut ts_us: u64 = 0;
-
-        let load_dur = (result.duration_secs * 1_000_000.0) as u64;
-        events.push(serde_json::json!({
-            "name": "model_load", "cat": "lifecycle", "ph": "X",
-            "ts": 0, "dur": load_dur / 10, "pid": 1, "tid": 1,
-            "args": {"source": source, "max_tokens": max_tokens}
-        }));
-        ts_us = load_dur / 10;
-
-        let tokenize_dur = load_dur / 100;
-        events.push(serde_json::json!({
-            "name": "tokenize", "cat": "tokenize", "ph": "X",
-            "ts": ts_us, "dur": tokenize_dur, "pid": 1, "tid": 1,
-            "args": {"source": source}
-        }));
-        ts_us += tokenize_dur;
-
-        let embed_dur = load_dur / 100;
-        events.push(serde_json::json!({
-            "name": "embed", "cat": "embed", "ph": "X",
-            "ts": ts_us, "dur": embed_dur, "pid": 1, "tid": 1
-        }));
-        ts_us += embed_dur;
-
-        if let Some(count) = result.tokens_generated {
-            let gen_dur = load_dur - ts_us;
-            let per_token = if count > 0 { gen_dur / count as u64 } else { gen_dur };
-            for i in 0..count {
-                let token_start = ts_us + (i as u64 * per_token);
-                let layer_dur = per_token * 9 / 10;
-                events.push(serde_json::json!({
-                    "name": format!("layer_{}", i % 28), "cat": "layer", "ph": "X",
-                    "ts": token_start, "dur": layer_dur, "pid": 1, "tid": 1,
-                    "args": {"token_idx": i, "layer": i % 28}
-                }));
-                events.push(serde_json::json!({
-                    "name": "sample", "cat": "sample", "ph": "X",
-                    "ts": token_start + layer_dur, "dur": per_token - layer_dur,
-                    "pid": 1, "tid": 1, "args": {"token_idx": i}
-                }));
-                events.push(serde_json::json!({
-                    "name": format!("token_{}", i), "cat": "decode", "ph": "X",
-                    "ts": token_start, "dur": per_token, "pid": 1, "tid": 1,
-                    "args": {"token_idx": i}
-                }));
-            }
-        }
-
-        serde_json::json!({
-            "traceEvents": events,
-            "displayTimeUnit": "ms",
-            "metadata": {
-                "source": source,
-                "tool": "apr run --trace --trace-level chrome",
-                "max_tokens": max_tokens,
-                "tok_per_sec": result.tok_per_sec,
-                "include_profile": include_profile
-            }
-        })
-    }
+    /// These tests used to assert against a hand-maintained COPY of
+    /// `print_chrome_trace`'s body kept here in the test file, which could only
+    /// ever prove the copy agreed with itself. They now call the real builder.
+    use super::build_chrome_trace as build_chrome_trace_events;
 
     #[test]
     fn test_chrome_trace_event_categories() {
@@ -89,6 +23,7 @@
             tok_per_sec: Some(1.5),
             used_gpu: Some(false),
             generated_tokens: None,
+            token_texts: None,
         };
 
         let json = build_chrome_trace_events(&result, "model.gguf", 16, true);
@@ -118,6 +53,7 @@
             tok_per_sec: None,
             used_gpu: None,
             generated_tokens: None,
+            token_texts: None,
         };
 
         let json = build_chrome_trace_events(&result, "empty.gguf", 0, false);
@@ -136,6 +72,7 @@
             tok_per_sec: None,
             used_gpu: None,
             generated_tokens: None,
+            token_texts: None,
         };
 
         let json = build_chrome_trace_events(&result, "model.gguf", 10, false);
@@ -154,6 +91,7 @@
             tok_per_sec: Some(10.0),
             used_gpu: Some(true),
             generated_tokens: None,
+            token_texts: None,
         };
 
         let json = build_chrome_trace_events(&result, "my-model.gguf", 64, true);
@@ -172,6 +110,7 @@
             tok_per_sec: Some(2.0),
             used_gpu: Some(false),
             generated_tokens: None,
+            token_texts: None,
         };
 
         let json = build_chrome_trace_events(&result, "model.gguf", 10, false);
@@ -200,6 +139,7 @@
             tok_per_sec: Some(2.0),
             used_gpu: Some(false),
             generated_tokens: None,
+            token_texts: None,
         };
 
         let json = build_chrome_trace_events(&result, "model.gguf", 10, false);
@@ -218,6 +158,7 @@
             tok_per_sec: Some(1.0),
             used_gpu: None,
             generated_tokens: None,
+            token_texts: None,
         };
         let json = build_chrome_trace_events(&result, "m.gguf", 1, false);
         assert_eq!(json["displayTimeUnit"], "ms");
@@ -236,9 +177,51 @@
             tok_per_sec: Some(5.0),
             used_gpu: Some(false),
             generated_tokens: None,
+            token_texts: None,
         };
         // Just ensure no panic; file creation is best-effort
-        print_chrome_trace(&result, "test-model.gguf", 32, false);
+        print_chrome_trace(&result, "test-model.gguf", 32, false, None);
+    }
+
+    /// `--trace-level chrome --trace-output FILE` must put the chrome trace in
+    /// FILE.
+    ///
+    /// Before the fix the chrome writer ignored `--trace-output` entirely: it
+    /// wrote `trace-<epoch>.json` into the process CWD, and the path the user
+    /// named was left holding the summary stub written by the inference layer.
+    /// A scripted consumer read the file it asked for and found no
+    /// `traceEvents` at all.
+    #[test]
+    fn chrome_trace_honours_requested_output_path() {
+        let dir = std::env::temp_dir().join(format!(
+            "apr-chrome-trace-{}-{}",
+            std::process::id(),
+            line!()
+        ));
+        std::fs::create_dir_all(&dir).expect("tempdir");
+        let target = dir.join("requested.json");
+
+        let result = RunResult {
+            text: "Hello world".to_string(),
+            duration_secs: 1.0,
+            cached: false,
+            tokens_generated: Some(3),
+            tok_per_sec: Some(3.0),
+            used_gpu: Some(false),
+            generated_tokens: None,
+            token_texts: None,
+        };
+        print_chrome_trace(&result, "test-model.gguf", 32, false, Some(&target));
+
+        let body = std::fs::read_to_string(&target)
+            .unwrap_or_else(|e| panic!("chrome trace must be written to {}: {e}", target.display()));
+        let v: serde_json::Value = serde_json::from_str(&body).expect("valid JSON");
+        let events = v["traceEvents"].as_array().expect("traceEvents array");
+        assert!(
+            !events.is_empty(),
+            "chrome trace at the requested path must carry events, got: {body}"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -255,6 +238,7 @@
             tok_per_sec: Some(50.0),
             used_gpu: Some(false),
             generated_tokens: None,
+            token_texts: None,
         };
         print_benchmark_results(&result, "model.gguf", "text", 100);
     }
@@ -269,6 +253,7 @@
             tok_per_sec: Some(50.0),
             used_gpu: Some(false),
             generated_tokens: None,
+            token_texts: None,
         };
         print_benchmark_results(&result, "model.gguf", "json", 50);
     }
@@ -283,6 +268,7 @@
             tok_per_sec: None,
             used_gpu: None,
             generated_tokens: None,
+            token_texts: None,
         };
         print_benchmark_results(&result, "model.gguf", "text", 10);
     }

--- a/crates/apr-cli/src/commands/run_tests_inference_output.rs
+++ b/crates/apr-cli/src/commands/run_tests_inference_output.rs
@@ -14,6 +14,7 @@
             tok_per_sec: Some(500.0),
             used_gpu: Some(false),
             generated_tokens: Some(vec![1, 2, 3, 4, 5]),
+            token_texts: None,
         };
         assert_eq!(output.text, "hello");
         assert_eq!(output.tokens_generated, Some(5));
@@ -30,6 +31,7 @@
             tok_per_sec: None,
             used_gpu: None,
             generated_tokens: None,
+            token_texts: None,
         };
         assert!(output.tokens_generated.is_none());
         assert!(output.inference_ms.is_none());

--- a/crates/apr-cli/src/commands/run_tests_layer_trace.rs
+++ b/crates/apr-cli/src/commands/run_tests_layer_trace.rs
@@ -1,0 +1,99 @@
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Layer trace honesty (gguf_generate_result.rs::render_layer_trace)
+    //
+    // `apr run --trace --trace-level layer` printed a table headed `Time` whose
+    // per-step values were `wall_ms / tokens * <fixed share>` — the same
+    // 85/8/2/1.7 split for every model and every prompt. TOKENIZE, EMBED and
+    // DECODE came out identical to the hundredth of a millisecond in every run,
+    // and the table "proved" TRANSFORMER was 85% while the real [BRICK-PROFILE]
+    // block in the same output said FFN 42% / Qkv 21% / LmHead 4.5%.
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    fn layer_trace_result(duration_secs: f64, tokens: usize) -> RunResult {
+        RunResult {
+            text: "hi".to_string(),
+            duration_secs,
+            cached: true,
+            tokens_generated: Some(tokens),
+            tok_per_sec: Some(tokens as f64 / duration_secs),
+            used_gpu: Some(false),
+            generated_tokens: None,
+            token_texts: None,
+        }
+    }
+
+    /// A derived number must never be printed as if it were measured.
+    #[test]
+    fn layer_trace_marks_derived_timings_as_estimates() {
+        let out = render_layer_trace(&layer_trace_result(2.0, 4), 4);
+
+        assert!(
+            out.contains("ESTIMATED"),
+            "the table must say the per-step values are estimated; got:\n{out}"
+        );
+        assert!(
+            out.contains("Est. Time"),
+            "the column heading must not be a bare `Time`; got:\n{out}"
+        );
+        assert!(
+            out.contains("~"),
+            "each derived value must be marked approximate; got:\n{out}"
+        );
+        assert!(
+            out.contains("Share"),
+            "the fixed share used to derive each value must be shown, so the \
+             three equal rows are explicable; got:\n{out}"
+        );
+        assert!(
+            out.contains("85.0%"),
+            "TRANSFORMER's assumed 85% share must be visible; got:\n{out}"
+        );
+    }
+
+    /// The run total and the decode rate must be labelled, or the table
+    /// contradicts the profiler block printed a few lines above it (1.0 tok/s
+    /// vs 19.2 tok/s for the identical run, neither labelled).
+    #[test]
+    fn layer_trace_labels_wall_clock_and_end_to_end_rate() {
+        let out = render_layer_trace(&layer_trace_result(2.0, 4), 4);
+
+        assert!(
+            out.contains("incl. model load"),
+            "TOTAL must state that it includes model load; got:\n{out}"
+        );
+        assert!(
+            out.contains("end-to-end"),
+            "the rate must be labelled end-to-end, not left to be read as decode \
+             throughput; got:\n{out}"
+        );
+        assert!(
+            out.contains("BRICK-PROFILE"),
+            "the table must point at the measured decode-rate figure; got:\n{out}"
+        );
+    }
+
+    /// The estimate itself must still be arithmetically what it claims: the
+    /// stated share of per-token wall time.
+    #[test]
+    fn layer_trace_estimates_match_their_stated_share() {
+        // 2.0s wall / 4 tokens = 500ms per token; TRANSFORMER's share is 85%.
+        let out = render_layer_trace(&layer_trace_result(2.0, 4), 4);
+        assert!(
+            out.contains("425.00ms"),
+            "TRANSFORMER must be 0.85 * 500ms = 425.00ms; got:\n{out}"
+        );
+        // 1.7% of 500ms = 8.50ms, shared by TOKENIZE/EMBED/DECODE.
+        assert!(
+            out.contains("8.50ms"),
+            "the 1.7%-share steps must be 8.50ms; got:\n{out}"
+        );
+    }
+
+    /// Zero tokens must not divide by zero or print NaN.
+    #[test]
+    fn layer_trace_zero_tokens_is_finite() {
+        let out = render_layer_trace(&layer_trace_result(1.0, 0), 0);
+        assert!(!out.contains("NaN"), "got:\n{out}");
+        assert!(!out.contains("inf"), "got:\n{out}");
+    }

--- a/crates/apr-cli/src/commands/run_tests_model_source.rs
+++ b/crates/apr-cli/src/commands/run_tests_model_source.rs
@@ -38,6 +38,7 @@
             tok_per_sec: None,
             used_gpu: None,
             generated_tokens: None,
+            token_texts: None,
         };
         let _debug = format!("{:?}", result);
         assert_eq!(result.tokens_generated, Some(5));
@@ -189,6 +190,7 @@
             tok_per_sec: None,
             used_gpu: None,
             generated_tokens: None,
+            token_texts: None,
         };
         let cloned = result.clone();
         assert_eq!(result.text, cloned.text);

--- a/crates/apr-cli/src/commands/run_tests_parse_token_ids.rs
+++ b/crates/apr-cli/src/commands/run_tests_parse_token_ids.rs
@@ -231,6 +231,7 @@
             tok_per_sec: None,
             used_gpu: None,
             generated_tokens: None,
+            token_texts: None,
         };
         let result_zero = RunResult {
             text: String::new(),
@@ -240,6 +241,7 @@
             tok_per_sec: None,
             used_gpu: None,
             generated_tokens: None,
+            token_texts: None,
         };
         assert_ne!(
             result_none.tokens_generated, result_zero.tokens_generated,
@@ -259,6 +261,7 @@
             tok_per_sec: Some(100.0),
             used_gpu: Some(true),
             generated_tokens: Some(vec![10, 20, 30]),
+            token_texts: None,
         };
         assert_eq!(result.text, "output");
         assert!((result.duration_secs - 1.234).abs() < f64::EPSILON);

--- a/crates/apr-cli/src/commands/run_tests_stream_output.rs
+++ b/crates/apr-cli/src/commands/run_tests_stream_output.rs
@@ -11,6 +11,11 @@ fn stream_output_emits_n_plus_one_json_lines() {
         tok_per_sec: Some(12.0),
         used_gpu: Some(false),
         generated_tokens: Some(vec![100, 200, 300]),
+        token_texts: Some(vec![
+            "Hello".to_string(),
+            " world".to_string(),
+            "!".to_string(),
+        ]),
     };
 
     let mut buf: Vec<u8> = Vec::new();
@@ -24,13 +29,16 @@ fn stream_output_emits_n_plus_one_json_lines() {
     );
 
     // Each token line has expected shape and ascending index.
+    //
+    // NOTE: this loop used to assert `v["text"].is_string()`, which is true of
+    // the empty string and therefore passed for the entire life of the defect —
+    // every shipped event had `"text":""`. Assert the CONTENT.
     for (i, line) in lines[..3].iter().enumerate() {
         let v: serde_json::Value = serde_json::from_str(line)
             .unwrap_or_else(|e| panic!("token line {i} must be valid JSON: {e} | {line}"));
         assert_eq!(v["event"], "token", "line {i}: event must be 'token'");
         assert_eq!(v["index"], i as i64, "line {i}: index field");
         assert!(v["token_id"].is_u64(), "line {i}: token_id is u64");
-        assert!(v["text"].is_string(), "line {i}: text field present");
     }
     let token_ids: Vec<u64> = lines[..3]
         .iter()
@@ -54,6 +62,81 @@ fn stream_output_emits_n_plus_one_json_lines() {
     assert_eq!(final_v["cached"], false);
 }
 
+/// FALSIFIER: every token event must carry that token's own text, and the
+/// pieces must reconstruct the reply.
+///
+/// Shipped 0.63.0 emitted `{"event":"token","index":0,"token_id":40,"text":""}`
+/// for every token — correct ids, empty text — so a consumer rendering `text`
+/// as events arrived saw nothing until the terminal `final` event. That is the
+/// whole purpose of `--stream`.
+#[test]
+fn stream_token_events_carry_their_own_decoded_text() {
+    let result = RunResult {
+        text: "I'm here to help".to_string(),
+        duration_secs: 1.0,
+        cached: true,
+        tokens_generated: Some(4),
+        tok_per_sec: Some(4.0),
+        used_gpu: Some(false),
+        generated_tokens: Some(vec![40, 2776, 1588, 311]),
+        token_texts: Some(vec![
+            "I".to_string(),
+            "'m".to_string(),
+            " here".to_string(),
+            " to help".to_string(),
+        ]),
+    };
+
+    let mut buf: Vec<u8> = Vec::new();
+    write_stream_output(&mut buf, &result, "model.gguf", 8).expect("write must succeed");
+    let s = String::from_utf8(buf).expect("utf-8");
+    let lines: Vec<&str> = s.lines().collect();
+
+    let mut streamed = String::new();
+    for (i, line) in lines[..4].iter().enumerate() {
+        let v: serde_json::Value = serde_json::from_str(line).expect("token json");
+        let text = v["text"].as_str().unwrap_or_default();
+        assert!(
+            !text.is_empty(),
+            "token event {i} must carry decoded text, got: {line}"
+        );
+        streamed.push_str(text);
+    }
+
+    let final_v: serde_json::Value = serde_json::from_str(lines[4]).expect("final json");
+    assert_eq!(
+        streamed,
+        final_v["text"].as_str().unwrap_or_default(),
+        "concatenating the streamed pieces must reproduce the final text"
+    );
+}
+
+/// When no tokenizer can be resolved the pieces are absent, and the events must
+/// still be well-formed (empty `text`, exact ids) rather than missing or
+/// invented.
+#[test]
+fn stream_token_events_degrade_to_empty_text_without_a_tokenizer() {
+    let result = RunResult {
+        text: "abc".to_string(),
+        duration_secs: 1.0,
+        cached: true,
+        tokens_generated: Some(2),
+        tok_per_sec: Some(2.0),
+        used_gpu: Some(false),
+        generated_tokens: Some(vec![7, 9]),
+        token_texts: None,
+    };
+
+    let mut buf: Vec<u8> = Vec::new();
+    write_stream_output(&mut buf, &result, "model.apr", 8).expect("write");
+    let s = String::from_utf8(buf).expect("utf-8");
+    let lines: Vec<&str> = s.lines().collect();
+    assert_eq!(lines.len(), 3, "2 tokens + final, got: {s}");
+    let first: serde_json::Value = serde_json::from_str(lines[0]).expect("json");
+    assert_eq!(first["token_id"], 7);
+    assert_eq!(first["text"], "");
+}
+
 /// Empty token list still emits exactly one `final` blob (no tokens, no
 /// orphan lines).
 #[test]
@@ -66,6 +149,7 @@ fn stream_output_no_tokens_emits_only_final() {
         tok_per_sec: Some(0.0),
         used_gpu: Some(false),
         generated_tokens: Some(Vec::new()),
+        token_texts: None,
     };
 
     let mut buf: Vec<u8> = Vec::new();
@@ -90,6 +174,7 @@ fn stream_output_none_tokens_emits_only_final() {
         tok_per_sec: None,
         used_gpu: None,
         generated_tokens: None,
+        token_texts: None,
     };
 
     let mut buf: Vec<u8> = Vec::new();
@@ -113,6 +198,7 @@ fn build_final_json_matches_legacy_json_shape() {
         tok_per_sec: Some(99.99),
         used_gpu: Some(true),
         generated_tokens: Some(vec![1, 2, 3]),
+        token_texts: None,
     };
     let v = build_final_json(&result, "src.apr", 100);
     assert_eq!(v["model"], "src.apr");

--- a/crates/apr-cli/src/commands_enum.rs
+++ b/crates/apr-cli/src/commands_enum.rs
@@ -1,4 +1,24 @@
 
+/// Compute backends `--backend` accepts on `apr run` / `apr chat`.
+///
+/// The flag used to be a free-form `String`: `--backend banana` printed
+/// `Backend override: banana` and then quietly ran the default backend. That is
+/// the exact failure the `--backend cuda` guard in `dispatch.rs` exists to
+/// prevent — a run whose throughput number was taken through a backend the
+/// caller did not ask for — so a typo must be rejected by the parser, not
+/// echoed back.
+pub const BACKEND_VALUES: [&str; 3] = ["cuda", "cpu", "wgpu"];
+
+/// Trace detail levels `--trace-level` accepts.
+///
+/// Each value is dispatched on by string equality in `run_entry.rs`; an
+/// unrecognised value silently selected "no extra trace output at all" while
+/// printing `Trace level: <typo>` as though it had taken effect.
+pub const TRACE_LEVEL_VALUES: [&str; 5] = ["none", "basic", "layer", "payload", "chrome"];
+
+/// Output formats `apr run -f/--format` accepts.
+pub const RUN_FORMAT_VALUES: [&str; 4] = ["text", "json", "srt", "vtt"];
+
 /// Output format for `apr code` non-interactive mode (PMAT-CODE-OUTPUT-FORMAT-001).
 /// Mirrors Claude Code's `claude -p --output-format <fmt>` parity row.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum, Default)]
@@ -51,7 +71,7 @@ pub enum Commands {
         #[arg(short, long)]
         task: Option<String>,
         /// Output format (text, json, srt, vtt)
-        #[arg(short = 'f', long, default_value = "text")]
+        #[arg(short = 'f', long, default_value = "text", value_parser = RUN_FORMAT_VALUES)]
         format: String,
         /// Disable GPU acceleration (force CPU-only inference)
         #[arg(long, alias = "cpu", conflicts_with = "gpu")]
@@ -80,7 +100,7 @@ pub enum Commands {
         /// Trace detail level (none, basic, layer, payload, chrome)
         /// "chrome" outputs chrome://tracing JSON integrating layer trace + brick profile.
         /// F-CLIPARITY-01 / PMAT-386 / paiml/aprender#574
-        #[arg(long, value_name = "LEVEL", default_value = "basic")]
+        #[arg(long, value_name = "LEVEL", default_value = "basic", value_parser = TRACE_LEVEL_VALUES)]
         trace_level: String,
         /// Shorthand for --trace --trace-level payload (tensor value inspection)
         #[arg(long)]
@@ -131,7 +151,7 @@ pub enum Commands {
         #[arg(short, long)]
         verbose: bool,
         /// PMAT-488: Compute backend override (cuda, cpu, wgpu)
-        #[arg(long, value_name = "BACKEND")]
+        #[arg(long, value_name = "BACKEND", value_parser = BACKEND_VALUES)]
         backend: Option<String>,
     },
     /// Inference server (plan/run)

--- a/crates/apr-cli/src/extended_commands.rs
+++ b/crates/apr-cli/src/extended_commands.rs
@@ -43,13 +43,13 @@ pub enum ExtendedCommands {
         #[arg(long, value_name = "FILE")]
         trace_output: Option<PathBuf>,
         /// Trace detail level (none, basic, layer, payload)
-        #[arg(long, value_name = "LEVEL", default_value = "basic")]
+        #[arg(long, value_name = "LEVEL", default_value = "basic", value_parser = TRACE_LEVEL_VALUES)]
         trace_level: String,
         /// Enable inline Roofline profiling (PMAT-SHOWCASE-METHODOLOGY-001)
         #[arg(long)]
         profile: bool,
         /// PMAT-488: Compute backend override (cuda, cpu, wgpu)
-        #[arg(long, value_name = "BACKEND")]
+        #[arg(long, value_name = "BACKEND", value_parser = BACKEND_VALUES)]
         backend: Option<String>,
     },
     /// Benchmark throughput (spec H12: >= 10 tok/s)

--- a/crates/aprender-serve/src/brick/profiler_contracts.rs
+++ b/crates/aprender-serve/src/brick/profiler_contracts.rs
@@ -62,17 +62,42 @@ impl ProfileReport {
             }
         }
 
-        // CONTRACT 3: decoded_tokens == LmHead.count
+        // CONTRACT 3: LmHead fires once per FORWARD PASS
         // "LmHead is invoked exactly once per decoded token"
         // Catches: token accounting errors, profiler miscounting
+        //
+        // The comparison used to be `lm.count != tokens_processed`, which fired on
+        // 100% of healthy runs — always short by exactly one. That is not a defect
+        // in the profiler, it is the shape of the generation loop:
+        // `generate_with_cache` (gguf/inference/generate_quantized.rs) runs one
+        // forward pass per prompt token, then per generated token it SAMPLES from
+        // the logits it already has and only afterwards forwards the new token to
+        // produce the next logits. The final sampled token is never fed back — the
+        // loop breaks at `tokens.len() >= max_seq_len` before that forward — so its
+        // logits are never computed and LmHead never fires for it, while
+        // `tokens_processed` (prefill + generated) counts it.
+        //
+        // So the honest invariant is "one LmHead per forward pass", i.e.
+        // `tokens_processed - 1` (the last token was not fed back) or
+        // `tokens_processed` (every processed token was). Anything outside that
+        // band is real miscounting — a missing instrumentation path, or LmHead
+        // firing more than once per token — and still fires the warning.
+        //
+        // A falsifier that fires on every healthy run carries no information, and
+        // trains readers to ignore the one run where it means something.
         if let Some(lm) = lm_head {
-            if self.tokens_processed > 0 && lm.count != self.tokens_processed {
+            let expected_low = self.tokens_processed.saturating_sub(1);
+            if self.tokens_processed > 0
+                && (lm.count < expected_low || lm.count > self.tokens_processed)
+            {
                 violations.push((
                     ContractSeverity::Warning,
                     format!(
-                        "gpu-decode-profiling-v1 TOKEN_ACCOUNTING: LmHead.count={} != tokens_processed={}. \
-                         LmHead should fire exactly once per decoded token.",
-                        lm.count, self.tokens_processed
+                        "gpu-decode-profiling-v1 TOKEN_ACCOUNTING: LmHead.count={} outside \
+                         [{}, {}] for tokens_processed={}. LmHead fires once per forward pass \
+                         (every processed token except, optionally, the final sampled token, \
+                         which is never fed back).",
+                        lm.count, expected_low, self.tokens_processed, self.tokens_processed
                     ),
                 ));
             }

--- a/crates/aprender-serve/src/brick/profiler_tests.rs
+++ b/crates/aprender-serve/src/brick/profiler_tests.rs
@@ -465,4 +465,94 @@ mod tests {
         assert!(stats.contains_key("op1"));
         assert!(stats.contains_key("op2"));
     }
+
+    // =========================================================================
+    // gpu-decode-profiling-v1 TOKEN_ACCOUNTING falsifiers
+    //
+    // Every `apr run --trace` printed
+    //   [CONTRACT WARN] ... LmHead.count=10 != tokens_processed=11
+    // and the gap was always exactly 1 (10/11, 11/12, 12/13, 16/17, 37/38).
+    // That is the generation loop, not a defect: the final sampled token is
+    // never fed back through a forward pass, so LmHead never fires for it.
+    // =========================================================================
+
+    /// Build a report whose LmHead/RmsNorm satisfy the other invariants, so
+    /// only TOKEN_ACCOUNTING is under test.
+    fn token_accounting_report(lm_head_count: usize, tokens_processed: usize) -> ProfileReport {
+        let mut ops = std::collections::HashMap::new();
+
+        let mut lm = OpStats::default();
+        lm.count = lm_head_count;
+        lm.total_us = 900.0;
+        lm.avg_us = 300.0;
+        ops.insert("LmHead".to_string(), lm);
+
+        let mut rms = OpStats::default();
+        rms.count = tokens_processed;
+        rms.total_us = 100.0;
+        rms.avg_us = 1.0;
+        ops.insert("RmsNorm".to_string(), rms);
+
+        ProfileReport {
+            operations: ops,
+            total_inference_us: 1000.0,
+            tokens_processed,
+            num_layers: 28,
+            throughput_tok_s: 100.0,
+            is_real_data: true,
+        }
+    }
+
+    fn token_accounting_violation(report: &ProfileReport) -> Option<String> {
+        report
+            .validate_contracts()
+            .into_iter()
+            .map(|(_, msg)| msg)
+            .find(|msg| msg.contains("TOKEN_ACCOUNTING"))
+    }
+
+    /// The exact shape observed on every healthy CPU run: 9 prefill + 2 decode
+    /// = 11 tokens processed, 10 LmHead calls. Must NOT warn.
+    #[test]
+    fn token_accounting_silent_when_last_token_is_never_fed_back() {
+        let report = token_accounting_report(10, 11);
+        assert_eq!(
+            token_accounting_violation(&report),
+            None,
+            "LmHead.count == tokens_processed - 1 is the normal generation loop \
+             (the final sampled token is never forwarded) and must not warn"
+        );
+    }
+
+    /// The GPU/graph path where every processed token was forwarded must also
+    /// stay silent.
+    #[test]
+    fn token_accounting_silent_when_every_token_was_forwarded() {
+        let report = token_accounting_report(11, 11);
+        assert_eq!(token_accounting_violation(&report), None);
+    }
+
+    /// Real miscounting — instrumentation missing from a code path — must
+    /// still be reported. This is what the contract exists to catch.
+    #[test]
+    fn token_accounting_warns_when_lm_head_is_undercounted() {
+        let report = token_accounting_report(1, 11);
+        let msg = token_accounting_violation(&report)
+            .expect("LmHead.count=1 for 11 tokens is real miscounting and must warn");
+        assert!(msg.contains("LmHead.count=1"), "must quote the count: {msg}");
+        assert!(
+            msg.contains("tokens_processed=11"),
+            "must quote the expectation: {msg}"
+        );
+    }
+
+    /// LmHead firing MORE than once per token is also a defect.
+    #[test]
+    fn token_accounting_warns_when_lm_head_is_overcounted() {
+        let report = token_accounting_report(22, 11);
+        assert!(
+            token_accounting_violation(&report).is_some(),
+            "two LmHead calls per token must warn"
+        );
+    }
 }

--- a/crates/aprender-serve/src/gguf/inference/matmul_fused.rs
+++ b/crates/aprender-serve/src/gguf/inference/matmul_fused.rs
@@ -497,8 +497,14 @@ fn validate_matmul_weight_shape(weight: &OwnedQuantizedTensor) -> Result<()> {
     if weight.data.is_empty() {
         return Err(RealizarError::InvalidShape {
             reason: format!(
-                "matmul weight has EMPTY data buffer (in_dim={}, out_dim={}, qtype={}); \
-                 likely a MoE per-expert tensor was registered with len-0 data — see aprender#1789",
+                "matmul weight has EMPTY data buffer (in_dim={}, out_dim={}, qtype={}): \
+                 the tensor is declared with a shape but carries 0 bytes. Known causes: \
+                 (1) a tied-embedding model (e.g. dense Qwen2/Qwen2.5) whose lm_head.weight \
+                 is declared but empty because it was never aliased to the populated token \
+                 embedding matrix; (2) a MoE parent FFN tensor whose real weights live in \
+                 per-expert slices the loader has not wired in. Run `apr tensors <model>` — \
+                 the tensor showing a shape with 0 B of data is the one at fault. \
+                 See aprender#1789",
                 weight.in_dim, weight.out_dim, weight.qtype
             ),
         });
@@ -559,6 +565,33 @@ mod tests {
         assert!(
             msg.contains("in_dim=4096"),
             "must include declared dims for diagnostics; got: {msg}"
+        );
+    }
+
+    /// The message must not diagnose ONE cause it cannot have established.
+    ///
+    /// On `qwen2.5-coder-0.5b-instruct.apr` — a dense, tied-embedding model
+    /// with no experts at all — this guard fired and told the user "likely a
+    /// MoE per-expert tensor was registered with len-0 data". The actual state
+    /// was `lm_head.weight [151936, 896] 0 B` beside a fully populated
+    /// `model.embed_tokens.weight`: tied embeddings that were never resolved.
+    /// A confident wrong diagnosis costs more than no diagnosis.
+    #[test]
+    fn validate_empty_data_does_not_blame_moe_alone() {
+        let t = mk_tensor(vec![], 896, 151_936, GGUF_TYPE_F32);
+        let msg = format!("{}", validate_matmul_weight_shape(&t).unwrap_err());
+        assert!(
+            msg.contains("tied-embedding") || msg.contains("lm_head"),
+            "a dense tied-embedding model is the other known cause and must be \
+             named; got: {msg}"
+        );
+        assert!(
+            !msg.contains("likely a MoE"),
+            "must not present MoE as the single likely cause; got: {msg}"
+        );
+        assert!(
+            msg.contains("apr tensors"),
+            "must tell the user how to find the offending tensor; got: {msg}"
         );
     }
 

--- a/crates/aprender-serve/src/infer/inference_result.rs
+++ b/crates/aprender-serve/src/infer/inference_result.rs
@@ -299,6 +299,119 @@ fn print_gguf_verbose_info(
     eprintln!("Model loaded in {:.1}ms", load_ms);
 }
 
+/// The measured facts a `--trace-output` document is built from.
+///
+/// Grouped into one struct so [`build_gguf_trace_json`] is a pure function of
+/// plain values and can be asserted on directly in a unit test without
+/// constructing a full `GGUFConfig`.
+#[derive(Debug, Clone, Copy)]
+struct GgufTraceFacts<'a> {
+    model_path: &'a str,
+    num_layers: usize,
+    hidden_dim: usize,
+    vocab_size: usize,
+    num_heads: usize,
+    input_token_count: usize,
+    generated_token_count: usize,
+    load_ms: f64,
+    inference_ms: f64,
+    tps: f64,
+    used_gpu: bool,
+}
+
+/// Build the `--trace-output` JSON document for a GGUF run.
+///
+/// # Why this exists
+///
+/// The document used to be assembled with `format!` and ended in a hardcoded
+/// `"events": []`, so **every** `--trace-output FILE` — at every
+/// `--trace-level` — wrote a file whose event list was empty. A consumer that
+/// scripted `--trace-output` got a well-formed file that said nothing had
+/// happened. Two defects came out of that one string:
+///
+/// 1. `events` was a literal empty array, never populated from the run.
+/// 2. The model path was interpolated raw into a JSON string literal, so a path
+///    containing `"` or `\` emitted a file that is not parseable JSON.
+///
+/// Both are fixed by building a `serde_json::Value` and filling `events` from
+/// the timings the run actually measured.
+///
+/// # What goes in `events`
+///
+/// Only measured spans. `model_load` and `generate` are wall-clock timings
+/// taken around the real work (`load_ms` / `inference_ms`), expressed as
+/// chrome-tracing-compatible complete events (`ph: "X"`, µs timestamps) so the
+/// file can be read by the same tooling as `--trace-level chrome`. Per-brick
+/// and per-layer spans are deliberately NOT synthesised here: the brick
+/// profiler owns those and inventing a split from the total would be the same
+/// class of defect this function is fixing.
+fn build_gguf_trace_json(facts: &GgufTraceFacts<'_>) -> serde_json::Value {
+    let GgufTraceFacts {
+        model_path,
+        num_layers,
+        hidden_dim,
+        vocab_size,
+        num_heads,
+        input_token_count,
+        generated_token_count,
+        load_ms,
+        inference_ms,
+        tps,
+        used_gpu,
+    } = *facts;
+    let load_us = (load_ms * 1000.0).round() as u64;
+    let infer_us = (inference_ms * 1000.0).round() as u64;
+    let events = serde_json::json!([
+        {
+            "name": "model_load",
+            "cat": "lifecycle",
+            "ph": "X",
+            "ts": 0,
+            "dur": load_us,
+            "pid": 1,
+            "tid": 1,
+            "args": { "path": model_path, "format": "GGUF" }
+        },
+        {
+            "name": "generate",
+            "cat": "inference",
+            "ph": "X",
+            "ts": load_us,
+            "dur": infer_us,
+            "pid": 1,
+            "tid": 1,
+            "args": {
+                "input_tokens": input_token_count,
+                "generated_tokens": generated_token_count,
+                "tok_per_sec": tps,
+                "used_gpu": used_gpu
+            }
+        }
+    ]);
+
+    serde_json::json!({
+        "version": "1.0",
+        "timestamp": chrono::Utc::now().to_rfc3339(),
+        "model": {
+            "path": model_path,
+            "format": "GGUF",
+            "num_layers": num_layers,
+            "hidden_dim": hidden_dim,
+            "vocab_size": vocab_size,
+            "num_heads": num_heads,
+        },
+        "inference": {
+            "input_tokens": input_token_count,
+            "generated_tokens": generated_token_count,
+            "load_ms": load_ms,
+            "inference_ms": inference_ms,
+            "tok_per_sec": tps,
+            "used_gpu": used_gpu,
+        },
+        "events": events,
+    })
+}
+
 /// Write GGUF trace output if requested (PMAT-SHOWCASE-METHODOLOGY-001)
 fn write_gguf_trace(
     config: &InferenceConfig,
@@ -314,42 +427,21 @@ fn write_gguf_trace(
         Some(ref p) => p,
         None => return,
     };
-    let trace_json = format!(
-        r#"{{
-  "version": "1.0",
-  "timestamp": "{}",
-  "model": {{
-    "path": "{}",
-    "format": "GGUF",
-    "num_layers": {},
-    "hidden_dim": {},
-    "vocab_size": {},
-    "num_heads": {}
-  }},
-  "inference": {{
-    "input_tokens": {},
-    "generated_tokens": {},
-    "load_ms": {:.2},
-    "inference_ms": {:.2},
-    "tok_per_sec": {:.2},
-    "used_gpu": {}
-  }},
-  "events": []
-}}
-"#,
-        chrono::Utc::now().to_rfc3339(),
-        config.model_path.display(),
-        model_config.num_layers,
-        model_config.hidden_dim,
-        model_config.vocab_size,
-        model_config.num_heads,
+    let model_path = config.model_path.display().to_string();
+    let trace_json = serde_json::to_string_pretty(&build_gguf_trace_json(&GgufTraceFacts {
+        model_path: &model_path,
+        num_layers: model_config.num_layers,
+        hidden_dim: model_config.hidden_dim,
+        vocab_size: model_config.vocab_size,
+        num_heads: model_config.num_heads,
         input_token_count,
         generated_token_count,
         load_ms,
         inference_ms,
         tps,
-        used_gpu
-    );
+        used_gpu,
+    }))
+    .unwrap_or_default();
     if let Err(e) = std::fs::write(trace_path, trace_json) {
         eprintln!(
             "Warning: Failed to write trace output to {}: {}",
@@ -1127,5 +1219,76 @@ mod cuda_silent_fallback_tests {
             "must inoculate against the fabricated-regression reading: any throughput \
              measured after this point reflects the fallback backend. Got: {msg}"
         );
+    }
+}
+
+#[cfg(test)]
+mod trace_output_events_tests {
+    use super::{build_gguf_trace_json, GgufTraceFacts};
+
+    fn facts(path: &str) -> GgufTraceFacts<'_> {
+        GgufTraceFacts {
+            model_path: path,
+            num_layers: 28,
+            hidden_dim: 1536,
+            vocab_size: 151_936,
+            num_heads: 12,
+            input_token_count: 9,
+            generated_token_count: 3,
+            load_ms: 120.5,
+            inference_ms: 640.25,
+            tps: 4.7,
+            used_gpu: false,
+        }
+    }
+
+    /// FALSIFIER: `--trace-output FILE` must not write an empty event list.
+    ///
+    /// The document was assembled by `format!` and ended in a hardcoded
+    /// `"events": []`, so every `--trace-output` at every `--trace-level`
+    /// produced a file that said nothing had happened. Shape alone is not
+    /// enough here — asserting that `events` is an array passes on the bug — so
+    /// this asserts the events exist AND carry the run's measured durations.
+    #[test]
+    fn trace_output_events_are_populated_from_measured_timings() {
+        let v = build_gguf_trace_json(&facts("/models/qwen.gguf"));
+        let events = v["events"].as_array().expect("events must be an array");
+        assert!(
+            !events.is_empty(),
+            "trace-output must carry events, got an empty list: {v}"
+        );
+
+        let load = events
+            .iter()
+            .find(|e| e["name"] == "model_load")
+            .unwrap_or_else(|| panic!("no model_load event in {v}"));
+        assert_eq!(
+            load["dur"].as_u64(),
+            Some(120_500),
+            "model_load duration must be the MEASURED load_ms in microseconds"
+        );
+
+        let generate = events
+            .iter()
+            .find(|e| e["name"] == "generate")
+            .unwrap_or_else(|| panic!("no generate event in {v}"));
+        assert_eq!(
+            generate["dur"].as_u64(),
+            Some(640_250),
+            "generate duration must be the MEASURED inference_ms in microseconds"
+        );
+        assert_eq!(generate["args"]["generated_tokens"], 3);
+        assert_eq!(generate["args"]["input_tokens"], 9);
+    }
+
+    /// A model path containing a quote used to be interpolated raw into a JSON
+    /// string literal, so the "trace" file was not parseable JSON at all.
+    #[test]
+    fn trace_output_is_valid_json_for_a_path_with_a_quote() {
+        let v = build_gguf_trace_json(&facts(r#"/models/we"ird\path.gguf"#));
+        let text = serde_json::to_string(&v).expect("serialise");
+        let round: serde_json::Value = serde_json::from_str(&text)
+            .unwrap_or_else(|e| panic!("trace output must be parseable JSON: {e}\n{text}"));
+        assert_eq!(round["model"]["path"], r#"/models/we"ird\path.gguf"#);
     }
 }


### PR DESCRIPTION
Six of the ten `apr run` findings in #2378, each reproduced against the installed
0.63.0 binary first and verified against a binary built from this branch.

## What a user saw

`apr run model.gguf "hi" -n 8 --no-gpu --stream` on 0.63.0:

```
{"event":"token","index":0,"token_id":40,"text":""}
{"event":"token","index":1,"token_id":2776,"text":""}
...
{"...,"text":"I'm here to help! How can","tokens":[40,2776,...],"event":"final"}
```

Eight events, every one of them empty. The ids were right — the final event
decodes them into the whole reply — so a consumer rendering `text` as events
arrive saw nothing until the run had already finished. Same branch, same command:

```
{"event":"token","index":0,"token_id":40,"text":"I"}
{"event":"token","index":1,"token_id":2776,"text":"'m"}
{"event":"token","index":2,"token_id":1588,"text":" here"}
{"event":"token","index":3,"token_id":311,"text":" to"}
{"event":"token","index":4,"token_id":1492,"text":" help"}
{"event":"token","index":5,"token_id":0,"text":"!"}
{"event":"token","index":6,"token_id":2585,"text":" How"}
{"event":"token","index":7,"token_id":646,"text":" can"}
```

`--trace-output FILE` wrote `"events": []` at every documented `--trace-level`,
and `--trace-level chrome` wrote its chrome JSON to `trace-<epoch>.json` in the
CWD while leaving the requested path holding the empty stub. Before / after,
same five levels:

```
before                        after
none:    events_len= 0        none:    events = 2 ['model_load', 'generate']
basic:   events_len= 0        basic:   events = 2 ['model_load', 'generate']
layer:   events_len= 0        layer:   events = 2 ['model_load', 'generate']
payload: events_len= 0        payload: events = 2 ['model_load', 'generate']
chrome:  events_len= 0        chrome:  chrome traceEvents = 12
trace-1786290823.json         stray trace-*.json in CWD: (none)
```

`--backend banana` printed `Backend override: banana` and ran the default
backend at exit 0 — the precise outcome the `--backend cuda` guard exists to
prevent, because it makes any throughput measured through that run meaningless.
Now:

```
run --backend banana   -> rc=2  error: invalid value 'banana' for '--backend <BACKEND>'
                                  [possible values: cuda, cpu, wgpu]
run -f banana          -> rc=2  error: invalid value 'banana' for '--format <FORMAT>'
                                  [possible values: text, json, srt, vtt]
run --trace-level banana -> rc=2 error: invalid value 'banana' for '--trace-level <LEVEL>'
                                  [possible values: none, basic, layer, payload, chrome]
chat --backend banana  -> rc=2  (same)
run --backend cpu      -> rc=0  (unchanged)
run --backend cuda     -> rc=5  (the build-capability guard still fires, unchanged)
```

## Root causes

| Finding | Cause |
|---|---|
| 1 `--stream` empty `text` | `run_entry.rs` wrote a literal `"text": ""` per event; nothing ever decoded the ids one at a time. Now filled from the model's own tokenizer (single-token decode, the same call the SSE streaming handler makes), resolved once per streamed run and only under `--stream`. |
| 2 `"events": []` + chrome path | `inference_result.rs:337` ended a `format!` string with that literal. Rebuilt with `serde_json` and filled from measured timings (`model_load` = `load_ms`, `generate` = `inference_ms`). The same `format!` also interpolated the model path raw into a JSON string, so a path containing `"` produced non-JSON — fixed by construction. `print_chrome_trace` now takes the requested path. |
| 3 fabricated layer timings | `gguf_generate_result.rs:373-380` computed `per_token_ms * {0.85, 0.08, 0.02, 0.017}` and printed it under a column headed `Time`. The values stay (they are the only estimate available without the brick profiler) but the table now says `ESTIMATED`, marks each value `~`, prints the share it assumed, and labels `TOTAL` as wall clock incl. model load and `RATE` as end-to-end — the 19x contradiction with the `[BRICK-PROFILE]` block six lines above was two unlabelled numbers. |
| 5 unvalidated flag values | `--backend`, `--trace-level`, `-f` were free-form `String`s. clap `value_parser`s on `run` and `chat`. |
| 6 false `TOKEN_ACCOUNTING` warning | `profiler_contracts.rs:69` compared `LmHead.count != tokens_processed`. `generate_with_cache` samples the final token and breaks at `tokens.len() >= max_seq_len` *before* feeding it back, so LmHead never fires for it while `tokens_processed` counts it — the gap was deterministically 1 on every healthy run (10/11, 11/12, 12/13, 16/17, 37/38). Invariant is now "one LmHead per forward pass": `tokens_processed` or `tokens_processed - 1`; real miscounting still warns. |
| 7 two misleading strings | `matmul_fused.rs:501` blamed "a MoE per-expert tensor" for an empty `lm_head.weight` on a dense tied-embedding Qwen2.5 with no experts at all; it now names both known causes and says to run `apr tensors` to find the 0-byte tensor. `chat.rs:301` printed the literal `{stem}.tokenizer.json` — an unsubstituted format placeholder inside a plain string — instead of the filename it looked for. |

## Two existing tests were holding defects in place

- `run_tests_stream_output.rs` asserted `v["text"].is_string()`. That is true of
  `""`, so the test passed for the entire life of the empty-text bug. It now
  asserts the content, and that concatenating the streamed pieces reproduces the
  final text.
- `run_tests_chrome_trace.rs` asserted against a hand-maintained **copy** of
  `print_chrome_trace`'s body kept in the test file — it could only prove the
  copy agreed with itself. The builder is now extracted (`build_chrome_trace`)
  and the tests call it.

## Mutation check

Each fix reverted with the tests kept, RED verbatim:

```
trace_output_events_are_populated_from_measured_timings
  trace-output must carry events, got an empty list: {"events":[], ...}

token_accounting_silent_when_last_token_is_never_fed_back
  left: Some("... TOKEN_ACCOUNTING: LmHead.count=10 outside [10, 11] for tokens_processed=11 ...")
  right: None

validate_empty_data_does_not_blame_moe_alone
  a dense tied-embedding model is the other known cause and must be named; got:
  ... likely a MoE per-expert tensor was registered with len-0 data — see aprender#1789

stream_token_events_carry_their_own_decoded_text
  token event 0 must carry decoded text, got: {"event":"token","index":0,"token_id":40,"text":""}

chrome_trace_honours_requested_output_path
  chrome trace must be written to /tmp/apr-chrome-trace-.../requested.json: No such file or directory

layer_trace_marks_derived_timings_as_estimates
  the table must say the per-step values are estimated; got: ... Step  Time  Share ...

test_find_qwen_tokenizer_error_message_content_when_no_cache
no_qwen_tokenizer_message_handles_bare_filename
  1. Pacha cache ({stem}.tokenizer.json alongside model)
```

Restored: all 8 GREEN. `cargo test -p apr-cli --lib` 6635 passed,
`cargo test -p aprender-serve --lib` 15486 passed, `cargo fmt --all -- --check`
clean, `cargo clippy -p apr-cli --lib` and `-p aprender-serve --lib` clean with
`-D warnings`.

## Not fixed here

- **4** `apr run` accepts a GGUF whose `output_norm.weight` is half the declared
  `embedding_length`. Needs shape validation at model load against the tensor
  contract, not a CLI change.
- **8, 9** the default wgpu path dequantizes the whole model to F32 (13.9 GB RSS
  for a 1.0 GB Q4_K) before a parity gate that then rejects it at cosine 0.884 on
  this GPU. Backend-ordering and wgpu-kernel work.
- **10** the `--features cuda` build's unconditional debug spew (238 `eprintln!`
  under `crates/aprender-serve/src/cuda/`) — needs a CUDA build to verify.

Also left alone deliberately: `apr serve --backend` / `--trace-level` still take
free-form strings. Same fix applies, different cluster's file.

Refs #2378 (partial) — findings 1, 2, 3, 5, 6, 7 fixed; 4, 8, 9, 10 remain.
Audit epic: #2373

🤖 Generated with [Claude Code](https://claude.com/claude-code)
