### PR TITLE
fix(validate): a tensor that could not be read was dropped, and the count only saw survivors

### DIFF
--- a/crates/aprender-core/src/format/rosetta/arch_inference.rs
+++ b/crates/aprender-core/src/format/rosetta/arch_inference.rs
@@ -536,15 +536,22 @@ impl RosettaStone {
 
         for name in &tensor_names {
             // Use GgufReader's dequantization (handles Q4K, Q6K, etc.)
-            if let Ok((f32_data, _shape)) = reader.get_tensor_f32(name) {
-                let tv = self.compute_tensor_validation(name, &f32_data);
+            match reader.get_tensor_f32(name) {
+                Ok((f32_data, _shape)) => {
+                    let tv = self.compute_tensor_validation(name, &f32_data);
 
-                total_nan += tv.nan_count;
-                total_inf += tv.inf_count;
-                if tv.is_all_zeros() {
-                    all_zero_tensors.push(name.clone());
+                    total_nan += tv.nan_count;
+                    total_inf += tv.inf_count;
+                    if tv.is_all_zeros() {
+                        all_zero_tensors.push(name.clone());
+                    }
+                    tensors.push(tv);
                 }
-                tensors.push(tv);
+                // A tensor the reader cannot decode is a validation FAILURE, not a
+                // tensor to omit from the count. The two guards above catch a
+                // truncated FILE; this catches a single tensor whose declared extent
+                // overruns it. See `unreadable_tensor_validation`.
+                Err(e) => tensors.push(Self::unreadable_tensor_validation(name, &e.to_string())),
             }
         }
 
@@ -579,15 +586,20 @@ impl RosettaStone {
 
         for name in mapped.tensor_names() {
             // get_tensor returns Result<Vec<f32>, String>
-            if let Ok(f32_data) = mapped.get_tensor(name) {
-                let tv = self.compute_tensor_validation(name, &f32_data);
+            match mapped.get_tensor(name) {
+                Ok(f32_data) => {
+                    let tv = self.compute_tensor_validation(name, &f32_data);
 
-                total_nan += tv.nan_count;
-                total_inf += tv.inf_count;
-                if tv.is_all_zeros() {
-                    all_zero_tensors.push(name.to_string());
+                    total_nan += tv.nan_count;
+                    total_inf += tv.inf_count;
+                    if tv.is_all_zeros() {
+                        all_zero_tensors.push(name.to_string());
+                    }
+                    tensors.push(tv);
                 }
-                tensors.push(tv);
+                // Same rule as the GGUF and APR paths: unreadable is a failure,
+                // not an omission. See `unreadable_tensor_validation`.
+                Err(e) => tensors.push(Self::unreadable_tensor_validation(name, &e.to_string())),
             }
         }
 

--- a/crates/aprender-core/src/format/rosetta/tests_tokenizer_stress.rs
+++ b/crates/aprender-core/src/format/rosetta/tests_tokenizer_stress.rs
@@ -253,3 +253,6 @@ fn gh175_validation_report_display() {
 
 #[path = "tests_pygmy.rs"]
 mod tests_pygmy;
+
+#[path = "tests_unreadable_tensor.rs"]
+mod tests_unreadable_tensor;

--- a/crates/aprender-core/src/format/rosetta/tests_unreadable_tensor.rs
+++ b/crates/aprender-core/src/format/rosetta/tests_unreadable_tensor.rs
@@ -1,0 +1,125 @@
+//! Falsifier: a tensor the reader cannot decode must FAIL validation, not vanish.
+//!
+//! Dogfooding `cargo install aprender` 0.63.0 found that `apr validate` reported a
+//! corrupt GGUF as `VALID: 338 tensors checked, 0 contract violations` with exit 0,
+//! while `apr tensors` counted **339** on the same file and `inspect`, `debug`,
+//! `tree` and `diff` all rejected it with
+//! `Tensor 'output_norm.weight' data exceeds file size`.
+//!
+//! All three `validate_*` paths wrote `if let Ok(data) = reader.get_tensor(..)` and
+//! silently dropped the tensor on the else branch, then reported
+//! `tensor_count: tensors.len()` — the count of what SURVIVED. The gate was
+//! arithmetically incapable of failing on that corruption class, because the
+//! evidence was removed from the denominator before the comparison.
+//!
+//! This drives the real `RosettaStone::validate` over a real file on disk. The
+//! SafeTensors format is used because it can be hand-written here without a
+//! writer dependency; the defect and the fix are identical across GGUF, APR and
+//! SafeTensors, which share `unreadable_tensor_validation`.
+
+use super::super::*;
+
+/// Write a SafeTensors file whose header declares two tensors: one readable and
+/// entirely healthy, one whose declared extent runs a megabyte past EOF.
+///
+/// `good` carries real non-zero values on purpose. If it were zeros the file
+/// would fail the all-zeros data-quality gate and the test would pass for the
+/// wrong reason — the whole point is that the ONLY thing wrong with this file is
+/// the tensor that cannot be read.
+fn write_file_with_unreadable_tensor() -> std::path::PathBuf {
+    use std::io::Write;
+
+    let path = unique_temp_path("unreadable_tensor", "safetensors");
+    let header = concat!(
+        r#"{"good":{"dtype":"F32","shape":[4],"data_offsets":[0,16]},"#,
+        r#""overrun":{"dtype":"F32","shape":[4],"data_offsets":[16,1048576]}}"#
+    );
+    let mut header = header.as_bytes().to_vec();
+    while header.len() % 8 != 0 {
+        header.push(b' ');
+    }
+
+    let mut f = std::fs::File::create(&path).expect("create fixture");
+    f.write_all(&(header.len() as u64).to_le_bytes())
+        .expect("write header len");
+    f.write_all(&header).expect("write header");
+    for v in [1.5f32, -2.25, 3.0, 0.75] {
+        f.write_all(&v.to_le_bytes()).expect("write good tensor");
+    }
+    // Only 16 bytes of padding — nowhere near the 1 MiB `overrun` declares.
+    f.write_all(&[0u8; 16]).expect("write padding");
+    path
+}
+
+#[test]
+fn a_tensor_that_cannot_be_read_fails_validation() {
+    let path = write_file_with_unreadable_tensor();
+    let report = RosettaStone::new().validate(&path).expect("validate ran");
+    let _ = std::fs::remove_file(&path);
+
+    assert!(
+        !report.passed(),
+        "a file with an undecodable tensor must not validate.\n\
+         got: {}\n\
+         0.63.0 reported `VALID: 1 tensors checked, 0 contract violations` here, \
+         with exit 0, by dropping the unreadable tensor before counting.",
+        report.summary()
+    );
+}
+
+#[test]
+fn the_reported_tensor_count_includes_the_unreadable_tensor() {
+    let path = write_file_with_unreadable_tensor();
+    let report = RosettaStone::new().validate(&path).expect("validate ran");
+    let _ = std::fs::remove_file(&path);
+
+    // This is the assertion that makes the defect unrepresentable rather than
+    // merely fixed: the count must be what the FILE declares, not what happened
+    // to decode. A dropped tensor cannot be invisible if the count still sees it.
+    assert_eq!(
+        report.tensor_count, 2,
+        "header declares 2 tensors, so validate must report 2, not the number \
+         that decoded. summary: {}",
+        report.summary()
+    );
+    assert_eq!(
+        report.failed_tensor_count, 1,
+        "exactly one tensor is undecodable. summary: {}",
+        report.summary()
+    );
+}
+
+#[test]
+fn the_failure_names_the_tensor_and_says_why() {
+    let path = write_file_with_unreadable_tensor();
+    let report = RosettaStone::new().validate(&path).expect("validate ran");
+    let _ = std::fs::remove_file(&path);
+
+    let failed: Vec<&TensorValidation> = report.tensors.iter().filter(|t| !t.is_valid).collect();
+    assert_eq!(failed.len(), 1, "expected exactly one failing tensor");
+    assert_eq!(
+        failed[0].name, "overrun",
+        "the failing tensor must be the unreadable one, not a bystander"
+    );
+    assert!(
+        failed[0]
+            .failures
+            .iter()
+            .any(|f| f.contains("could not be read")),
+        "the failure should say the data could not be read, got {:?}",
+        failed[0].failures
+    );
+
+    // And the healthy tensor must still be reported as healthy — the fix must not
+    // turn one bad tensor into a blanket condemnation of the file.
+    let good = report
+        .tensors
+        .iter()
+        .find(|t| t.name == "good")
+        .expect("good tensor present in the report");
+    assert!(
+        good.is_valid,
+        "the readable, healthy tensor must still pass: {:?}",
+        good.failures
+    );
+}

--- a/crates/aprender-core/src/format/rosetta/validate_inspect.rs
+++ b/crates/aprender-core/src/format/rosetta/validate_inspect.rs
@@ -69,6 +69,13 @@ impl RosettaStone {
                     all_zero_tensors.push(name.to_string());
                 }
                 tensors.push(tv);
+            } else {
+                // A tensor the reader cannot decode is a validation FAILURE, not a
+                // tensor to omit from the count. See `unreadable_tensor_validation`.
+                tensors.push(Self::unreadable_tensor_validation(
+                    name,
+                    "APR reader returned no data (shape/offset may exceed the file)",
+                ));
             }
         }
 
@@ -87,6 +94,38 @@ impl RosettaStone {
             tensors,
             duration_ms: 0,
         })
+    }
+
+    /// Build a FAILING `TensorValidation` for a tensor the reader could not decode.
+    ///
+    /// A tensor that cannot be read is the strongest possible signal that a file is
+    /// corrupt, and it used to be the one signal `validate` threw away: all three
+    /// `validate_*` paths wrote `if let Ok(data) = reader.get_tensor(..)` and silently
+    /// dropped the tensor on the else branch, then reported
+    /// `tensor_count: tensors.len()` — the number that survived. On a GGUF whose
+    /// `output_norm.weight` extent overruns EOF that produced
+    /// `VALID: 338 tensors checked, 0 contract violations` with exit 0, while
+    /// `apr tensors` counted 339 on the same file and `inspect`, `debug`, `tree` and
+    /// `diff` all rejected it outright. The gate was arithmetically incapable of
+    /// failing on that corruption class, because the evidence was removed from the
+    /// denominator before the comparison.
+    ///
+    /// Recording the failure as a tensor keeps `tensor_count` equal to the number the
+    /// file declares, so a dropped tensor can no longer be invisible.
+    pub(crate) fn unreadable_tensor_validation(name: &str, reason: &str) -> TensorValidation {
+        TensorValidation {
+            name: name.to_string(),
+            is_valid: false,
+            nan_count: 0,
+            inf_count: 0,
+            zero_count: 0,
+            element_count: 0,
+            min: 0.0,
+            max: 0.0,
+            mean: 0.0,
+            std: 0.0,
+            failures: vec![format!("tensor data could not be read: {reason}")],
+        }
     }
 
     /// Build an empty (valid) `TensorValidation` for tensors with no elements.


### PR DESCRIPTION
```
$ apr validate qwen_shape_corrupt.gguf
VALID: 338 tensors checked, 0 contract violations (PMAT-235)      exit 0

$ apr tensors qwen_shape_corrupt.gguf
Tensors: 339

$ apr inspect qwen_shape_corrupt.gguf
error: Tensor 'output_norm.weight' data exceeds file size          exit 4
   (debug, tree and diff reject it identically)
```

339 in the file, 338 checked, `VALID`. `apr validate` is the dedicated integrity command — `CLAUDE.md` step 4 — and it was the only one of five commands that accepted the file. `--strict` and `--quality --min-score 90` also exited 0.

## Cause

All three `validate_*` paths were written as

```rust
if let Ok(data) = reader.get_tensor(name) { /* ...check it... */ }
```

with **nothing on the else branch**, and then reported `tensor_count: tensors.len()` — the number that *survived*. A tensor whose declared extent overruns EOF cannot be decoded, so it was removed from the check set and the summary counted only what remained. The gate was arithmetically incapable of failing on that corruption class: the evidence was taken out of the denominator before the comparison.

Two guards already exist in `validate_gguf`, and **both still pass on this file** — GH-707 compares declared vs parsed tensor *count*, and S1-FIX checks the file is long enough to reach the data section. Neither checks a single tensor's extent.

## Fix

An unreadable tensor is now recorded as a failing `TensorValidation` naming the tensor and the reason, so `is_valid` becomes false, the exit code is non-zero, `tensor_count` equals what the file *declares* rather than what decoded, and healthy tensors in the same file are still reported healthy. Fixed in all three formats through one shared helper, because all three had the identical shape.

## Measured

Hand-built SafeTensors file, header declares two tensors: one healthy with real non-zero values, one declaring an extent 1 MiB past EOF.

| | result |
|---|---|
| 0.63.0 from crates.io | `VALID: 1 tensors checked, 0 contract violations` — exit 0 |
| this branch | `INVALID: 2 tensors, 1 contract violations` — exit 5 |

## Falsifier — mutation verified

`format::rosetta::tests_unreadable_tensor`, three tests over the real `RosettaStone::validate` on a real file on disk. One asserts the file fails; one asserts `tensor_count == 2`, which is what makes the defect **unrepresentable** rather than merely fixed; one asserts the failure names `overrun` and that the healthy tensor is still healthy.

Restoring the silent skip turns all three RED with the shipped symptom:

```
assertion `left == right` failed: header declares 2 tensors, so validate must report 2,
not the number that decoded.
summary: VALID: 1 tensors checked, 0 contract violations (PMAT-235)
```

The `good` tensor deliberately carries non-zero values — zeros would trip the all-zeros data-quality gate and the test would pass for the wrong reason.

13975 `aprender-core` unit tests pass; `clippy -D warnings` and `fmt --check` clean.

Refs #2394

Audit epic: #2373

🤖 Generated with [Claude Code](https://claude.com/claude-code)
