### PR TITLE
fix(serve): six native routes were dead on every apr serve run model.gguf, and one request could kill the server

### DIFF
--- a/crates/aprender-serve/src/api/batch.rs
+++ b/crates/aprender-serve/src/api/batch.rs
@@ -1,10 +1,125 @@
 
+/// Sampling knobs the quantized engine actually reads, resolved from the
+/// documented request fields.
+pub(super) struct QuantizedSampling {
+    pub(super) top_k: usize,
+    pub(super) top_p: f32,
+}
+
+/// Resolve `strategy` / `top_k` / `top_p` / `temperature` onto the engine's knobs.
+///
+/// aprender#2376(2) and (4): `strategy`, `top_p` and `seed` are documented public
+/// fields of [`GenerateRequest`] with documented defaults, and the quantized path
+/// built its config from `max_tokens`/`temperature`/`top_k` only. The observable
+/// consequences were that `strategy:"greedy"` still sampled, `top_p:0.01` was
+/// byte-identical to no `top_p` at all, and negative temperatures were accepted
+/// with HTTP 200 while inverting the softmax into multilingual garbage.
+///
+/// `top_p` is validated only on the branch that consumes it, so a request that
+/// merely carries a `top_p` alongside `strategy:"greedy"` is still accepted.
+///
+/// # Errors
+///
+/// 400 for a negative or NaN `temperature`, an unknown `strategy`, or a `top_p`
+/// outside `(0, 1]` when nucleus sampling was requested.
+pub(super) fn resolve_quantized_sampling(
+    strategy: &str,
+    top_k: usize,
+    top_p: f32,
+    temperature: f32,
+) -> Result<QuantizedSampling, ApiErr> {
+    // NaN is rejected alongside negatives. A negative temperature divides the logits
+    // by a negative number, which inverts the distribution: the model then emits its
+    // LEAST likely tokens and the client cannot tell that from a bad model.
+    if temperature.is_nan() || temperature < 0.0 {
+        return Err(api_err(
+            StatusCode::BAD_REQUEST,
+            format!("temperature must be >= 0, got {temperature}"),
+        ));
+    }
+
+    // temperature == 0 means greedy on every surface; honour it before strategy.
+    if temperature == 0.0 {
+        return Ok(QuantizedSampling {
+            top_k: 1,
+            top_p: 1.0,
+        });
+    }
+
+    match strategy {
+        // top_k == 1 IS argmax in this engine (generate_quantized.rs), and
+        // top_p == 1.0 skips the nucleus branch entirely.
+        "greedy" => Ok(QuantizedSampling {
+            top_k: 1,
+            top_p: 1.0,
+        }),
+        "top_k" => Ok(QuantizedSampling {
+            top_k,
+            top_p: 1.0,
+        }),
+        "top_p" => {
+            if top_p.is_nan() || top_p <= 0.0 || top_p > 1.0 {
+                return Err(api_err(
+                    StatusCode::BAD_REQUEST,
+                    format!("top_p must be in (0, 1], got {top_p}"),
+                ));
+            }
+            // top_k == 0 disables the top-k cut so the nucleus is the only filter.
+            Ok(QuantizedSampling { top_k: 0, top_p })
+        },
+        other => Err(api_err(
+            StatusCode::BAD_REQUEST,
+            format!("Invalid strategy: {other}"),
+        )),
+    }
+}
+
+/// Map a generation failure onto an HTTP status.
+///
+/// A prompt or `max_tokens` that does not fit the context window is a client
+/// error: it is fully determined by the request, so 500 ("the server failed")
+/// misattributes it (aprender#2376 findings 9 and 11).
+fn generation_err(e: &crate::error::RealizarError) -> ApiErr {
+    let status = super::generation_error_status(e);
+    if status == StatusCode::BAD_REQUEST {
+        api_err(status, e)
+    } else {
+        api_err(status, format!("CPU generation failed: {e}"))
+    }
+}
+
+/// Build the quantized engine config shared by `/generate` and `/batch/generate`.
+fn quantized_config(
+    state: &AppState,
+    tokenizer: &BPETokenizer,
+    max_tokens: usize,
+    temperature: f32,
+    sampling: &QuantizedSampling,
+    seed: Option<u64>,
+) -> crate::gguf::QuantizedGenerateConfig {
+    use crate::gguf::QuantizedGenerateConfig;
+
+    let mut config = QuantizedGenerateConfig {
+        max_tokens,
+        temperature,
+        top_k: sampling.top_k,
+        top_p: sampling.top_p,
+        stop_tokens: vec![eos_id(tokenizer, state.model_eos_token_id())],
+        trace: state.is_trace_enabled(),
+        ..Default::default()
+    };
+    // Leave the default seed alone when the client did not ask for one, so an
+    // unseeded request keeps its current output.
+    if let Some(seed) = seed {
+        config.seed = seed;
+    }
+    config
+}
+
 fn try_quantized_generate(
     state: &AppState,
     request: &GenerateRequest,
 ) -> Result<Option<GenerateResponse>, ApiErr> {
-    use crate::gguf::QuantizedGenerateConfig;
-
     let quantized_model = match state.quantized_model() {
         Some(m) => m,
         None => return Ok(None),
@@ -13,18 +128,20 @@ fn try_quantized_generate(
     let prompt_ids = tokenize_prompt(&tokenizer, &request.prompt)?;
     let prompt_tokens = prompt_ids.len();
 
-    let q_config = QuantizedGenerateConfig {
-        max_tokens: request.max_tokens,
-        temperature: request.temperature,
-        top_k: if request.temperature == 0.0 {
-            1
-        } else {
-            request.top_k
-        },
-        stop_tokens: vec![eos_id(&tokenizer, state.model_eos_token_id())],
-        trace: state.is_trace_enabled(),
-        ..Default::default()
-    };
+    let sampling = resolve_quantized_sampling(
+        &request.strategy,
+        request.top_k,
+        request.top_p,
+        request.temperature,
+    )?;
+    let q_config = quantized_config(
+        state,
+        &tokenizer,
+        request.max_tokens,
+        request.temperature,
+        &sampling,
+        request.seed,
+    );
 
     // GH-95: Use generate_with_cache for O(n) autoregressive generation.
     // The previous .generate() call was O(n²) — it reprocessed the entire
@@ -32,12 +149,7 @@ fn try_quantized_generate(
     // processed each step. Contract: gguf-cpu-cache-v1.yaml
     let generated = quantized_model
         .generate_with_cache(&prompt_ids, &q_config)
-        .map_err(|e| {
-            api_err(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("CPU generation failed: {e}"),
-            )
-        })?;
+        .map_err(|e| generation_err(&e))?;
     let text = tokenizer
         .decode(&generated)
         .map_err(|e| api_err(StatusCode::INTERNAL_SERVER_ERROR, e))?;
@@ -159,7 +271,7 @@ fn registry_generate(
 ) -> Result<GenerateResponse, ApiErr> {
     let (model, tokenizer) = state
         .get_model(request.model_id.as_deref())
-        .map_err(|e| api_err(StatusCode::NOT_FOUND, e))?;
+        .map_err(|e| api_err(super::model_resolution_status(&e), e))?;
 
     let prompt_ids = tokenize_prompt(&tokenizer, &request.prompt)?;
     let prompt: Vec<usize> = prompt_ids.iter().map(|&id| id as usize).collect();
@@ -276,10 +388,10 @@ pub async fn batch_tokenize_handler(
         ));
     }
 
-    // Get tokenizer (use default model)
-    let (_model, tokenizer) = state.get_model(None).map_err(|e| {
+    // aprender#2376(1): tokenizer-only resolution — see tokenize_handler.
+    let tokenizer = state.get_tokenizer(None).map_err(|e| {
         (
-            StatusCode::INTERNAL_SERVER_ERROR,
+            super::model_resolution_status(&e),
             Json(ErrorResponse {
                 error: e.to_string(),
             }),
@@ -370,6 +482,59 @@ fn try_cuda_batch_generate(
     Ok(Some(results))
 }
 
+/// Quantized (GGUF / APR Q4_K) backend for `POST /batch/generate` and `/realize/batch`.
+///
+/// aprender#2376(1, 10): `batch_generate_handler` dispatched to CUDA, then to the
+/// APR f32 transformer, then fell through to `registry_generate`, which resolves
+/// the dense `Model` — always `None` for a GGUF server. So a route printed in the
+/// server's own startup banner answered `"No model available"` on every
+/// `apr serve run model.gguf`, while `/generate` on the same process worked,
+/// because only `/generate` had this backend.
+fn try_quantized_batch_generate(
+    state: &AppState,
+    request: &BatchGenerateRequest,
+) -> Result<Option<Vec<GenerateResponse>>, ApiErr> {
+    let quantized_model = match state.quantized_model() {
+        Some(m) => m,
+        None => return Ok(None),
+    };
+    let tokenizer = require_tok(state)?;
+
+    let sampling = resolve_quantized_sampling(
+        &request.strategy,
+        request.top_k,
+        request.top_p,
+        request.temperature,
+    )?;
+    let q_config = quantized_config(
+        state,
+        &tokenizer,
+        request.max_tokens,
+        request.temperature,
+        &sampling,
+        request.seed,
+    );
+
+    let mut results = Vec::with_capacity(request.prompts.len());
+    for prompt_text in &request.prompts {
+        let prompt_ids = tokenize_prompt(&tokenizer, prompt_text)?;
+        let prompt_tokens = prompt_ids.len();
+        let generated = quantized_model
+            .generate_with_cache(&prompt_ids, &q_config)
+            .map_err(|e| generation_err(&e))?;
+        let text = tokenizer
+            .decode(&generated)
+            .map_err(|e| api_err(StatusCode::INTERNAL_SERVER_ERROR, e))?;
+        results.push(GenerateResponse {
+            num_generated: generated.len().saturating_sub(prompt_tokens),
+            token_ids: generated,
+            text,
+        });
+    }
+
+    Ok(Some(results))
+}
+
 fn try_apr_batch_generate(
     state: &AppState,
     request: &BatchGenerateRequest,
@@ -426,7 +591,7 @@ fn registry_batch_generate(
 ) -> Result<Vec<GenerateResponse>, ApiErr> {
     let (model, tokenizer) = state
         .get_model(None)
-        .map_err(|e| api_err(StatusCode::INTERNAL_SERVER_ERROR, e))?;
+        .map_err(|e| api_err(super::model_resolution_status(&e), e))?;
 
     let strategy = match request.strategy.as_str() {
         "greedy" => SamplingStrategy::Greedy,
@@ -499,6 +664,10 @@ pub async fn batch_generate_handler(
 
     #[cfg(feature = "cuda")]
     if let Some(results) = try_cuda_batch_generate(&state, &request)? {
+        return Ok(Json(BatchGenerateResponse { results }));
+    }
+
+    if let Some(results) = try_quantized_batch_generate(&state, &request)? {
         return Ok(Json(BatchGenerateResponse { results }));
     }
 

--- a/crates/aprender-serve/src/api/batch_processing.rs
+++ b/crates/aprender-serve/src/api/batch_processing.rs
@@ -365,8 +365,11 @@ pub async fn models_handler(
                 id: "default".to_string(),
                 name: "Default Model".to_string(),
                 description: "Single model deployment".to_string(),
-                format: "unknown".to_string(),
-                loaded: true,
+                // aprender#2376(6): was the literal "unknown" while /realize/model
+                // hardcoded "gguf" — two endpoints on one server contradicting each
+                // other about one model. Both now read the resident backend.
+                format: state.model_format().to_string(),
+                loaded: state.model_loaded(),
             }],
         }))
     }
@@ -377,9 +380,12 @@ pub async fn tokenize_handler(
     State(state): State<AppState>,
     Json(request): Json<TokenizeRequest>,
 ) -> Result<Json<TokenizeResponse>, (StatusCode, Json<ErrorResponse>)> {
-    let (_model, tokenizer) = state.get_model(request.model_id.as_deref()).map_err(|e| {
+    // aprender#2376(1): tokenizing needs a tokenizer, not the dense f32 Model.
+    // Asking get_model() for one made this route unreachable on every
+    // `apr serve run model.gguf`, where the weights are in `quantized_model`.
+    let tokenizer = state.get_tokenizer(request.model_id.as_deref()).map_err(|e| {
         (
-            StatusCode::NOT_FOUND,
+            super::model_resolution_status(&e),
             Json(ErrorResponse {
                 error: e.to_string(),
             }),

--- a/crates/aprender-serve/src/api/mod.rs
+++ b/crates/aprender-serve/src/api/mod.rs
@@ -206,6 +206,41 @@ impl crate::audit::AuditSink for InMemorySinkWrapper {
     }
 }
 
+/// HTTP status for a model/tokenizer resolution failure.
+///
+/// One server-side condition must map to one status code. Before this existed the
+/// identical `"Model registry error: No model available"` came back as 404 from
+/// `/tokenize`, `/stream/generate` and `/realize/embed` but as 500 from
+/// `/batch/tokenize` and `/batch/generate`, so a client retry policy keyed on
+/// status treated the same failure as permanent on one route and as a server bug
+/// on the next (aprender#2376 finding 5).
+///
+/// * [`RealizarError::ModelNotFound`] — the client named a model this server does
+///   not have: 404, the route and request are fine.
+/// * [`RealizarError::RegistryError`] — the server has no usable model at all.
+///   That is a server-side condition, so 503 (the shape `/metrics/dispatch`
+///   already uses), never 404: the resource exists, the server cannot serve it.
+pub(crate) fn model_resolution_status(err: &RealizarError) -> StatusCode {
+    match err {
+        RealizarError::ModelNotFound(_) => StatusCode::NOT_FOUND,
+        RealizarError::RegistryError(_) => StatusCode::SERVICE_UNAVAILABLE,
+        _ => StatusCode::INTERNAL_SERVER_ERROR,
+    }
+}
+
+/// HTTP status for a generation failure.
+///
+/// A prompt or `max_tokens` that does not fit the model's context window is fully
+/// determined by the request, so it is a client error. Reporting it as 500 tells
+/// the caller the server broke and invites a retry of the identical request
+/// (aprender#2376 findings 9 and 11).
+pub(crate) fn generation_error_status(err: &RealizarError) -> StatusCode {
+    match err {
+        RealizarError::ContextLimitExceeded { .. } => StatusCode::BAD_REQUEST,
+        _ => StatusCode::INTERNAL_SERVER_ERROR,
+    }
+}
+
 include!("mod_app_state_gpu.rs");
 include!("mod_create_demo.rs");
 include!("router.rs");

--- a/crates/aprender-serve/src/api/mod_app_state_new.rs
+++ b/crates/aprender-serve/src/api/mod_app_state_new.rs
@@ -133,6 +133,66 @@ impl AppState {
         Ok((model, tokenizer))
     }
 
+    /// Resolve just the tokenizer, without requiring a dense `Model`.
+    ///
+    /// [`Self::get_model`] can only answer with the dense f32 [`Model`], which is
+    /// `None` for every `apr serve run model.gguf` — the weights live in
+    /// `quantized_model` instead. Handlers that need nothing but the tokenizer
+    /// (`/tokenize`, `/batch/tokenize`) used to call `get_model()` and were
+    /// therefore dead on the standard serve path, answering
+    /// `"Model registry error: No model available"` on a server whose `/generate`
+    /// was working and whose `/health` reported `model_loaded:true`
+    /// (aprender#2376 findings 1 and 10).
+    ///
+    /// Registry mode still resolves through the registry so a `model_id` selects
+    /// that model's tokenizer.
+    ///
+    /// # Errors
+    ///
+    /// [`RealizarError::ModelNotFound`] if a registry `model_id` is unknown, or
+    /// [`RealizarError::RegistryError`] if no tokenizer is resident at all.
+    pub(crate) fn get_tokenizer(
+        &self,
+        model_id: Option<&str>,
+    ) -> Result<Arc<BPETokenizer>, RealizarError> {
+        if let Some(registry) = &self.registry {
+            let id = model_id
+                .or(self.default_model_id.as_deref())
+                .ok_or_else(|| RealizarError::RegistryError("No model ID specified".to_string()))?;
+            return registry.get(id).map(|(_, tokenizer)| tokenizer);
+        }
+
+        self.tokenizer
+            .clone()
+            .ok_or_else(|| RealizarError::RegistryError("No tokenizer available".to_string()))
+    }
+
+    /// The on-disk format of the resident model, as proven by which backend loaded it.
+    ///
+    /// Single source of truth for `GET /models` and `GET /realize/model`, which
+    /// used to hardcode two different literals — `"unknown"` and `"gguf"` — and so
+    /// contradicted each other about the same model (aprender#2376 finding 6).
+    ///
+    /// Returns `"unknown"` for the dense f32 transformer: it is built from either
+    /// a `.apr` or a `.safetensors` file and does not retain which, and a
+    /// confident wrong answer is worse than an honest unknown.
+    #[must_use]
+    pub fn model_format(&self) -> &'static str {
+        // Every GGUF-derived backend: quantized K-quant weights or a live mmap.
+        if self.quantized_model.is_some() || self.mapped_gguf_model.is_some() {
+            return "gguf";
+        }
+        #[cfg(feature = "gpu")]
+        if self.gpu_model.is_some() || self.cached_model.is_some() {
+            return "gguf";
+        }
+        #[cfg(feature = "cuda")]
+        if self.cuda_model.is_some() {
+            return "gguf";
+        }
+        "unknown"
+    }
+
     /// Create application state with model caching enabled
     ///
     /// # Arguments

--- a/crates/aprender-serve/src/api/openai_handlers.rs
+++ b/crates/aprender-serve/src/api/openai_handlers.rs
@@ -724,7 +724,8 @@ fn try_cached_backend(
         .generate_with_cache(&prompt_ids, &q_config)
     {
         Ok(g) => g,
-        Err(e) => return Some(fail_response(state, StatusCode::INTERNAL_SERVER_ERROR, e)),
+        // aprender#2376(9): context-budget rejections are 400, not 500.
+        Err(e) => return Some(fail_response(state, super::generation_error_status(&e), e)),
     };
 
     let token_ids: Vec<u32> = generated.iter().skip(prompt_tokens).copied().collect();

--- a/crates/aprender-serve/src/api/realize_handlers_embed_completion.rs
+++ b/crates/aprender-serve/src/api/realize_handlers_embed_completion.rs
@@ -64,13 +64,20 @@ pub async fn realize_embed_handler(
     Json(request): Json<EmbeddingRequest>,
 ) -> Result<Json<EmbeddingResponse>, (StatusCode, Json<ErrorResponse>)> {
     let model_id = request.model.as_deref();
+    // aprender#2376(5): the dense f32 Model is genuinely required here —
+    // `forward_hidden` (the residual stream `lm_head` consumes) exists only on it,
+    // and the quantized backend does not expose hidden states. But "this server
+    // has no dense model" is a server-side condition, so 503 with a message that
+    // says which backend is missing — not 404 "No model available" on a server
+    // whose /health says model_loaded:true.
     let (model, tokenizer) = state.get_model(model_id).map_err(|e| {
-        (
-            StatusCode::NOT_FOUND,
-            Json(ErrorResponse {
-                error: e.to_string(),
-            }),
-        )
+        let status = super::model_resolution_status(&e);
+        let error = if status == StatusCode::SERVICE_UNAVAILABLE {
+            format!("{e}: /realize/embed needs a dense (.apr / .safetensors) model; this server has a quantized model loaded")
+        } else {
+            e.to_string()
+        };
+        (status, Json(ErrorResponse { error }))
     })?;
 
     // PMAT-802 × PMAT-803 (stacked): OpenAI `/v1/embeddings` accepts `input` as a single
@@ -152,8 +159,11 @@ pub async fn realize_model_handler(
             id: "default".to_string(),
             name: "Default Model".to_string(),
             description: "Single model deployment".to_string(),
-            format: "gguf".to_string(),
-            loaded: true,
+            // aprender#2376(6): was the literal "gguf" while GET /models hardcoded
+            // "unknown". Both endpoints now read the resident backend, so they
+            // cannot contradict each other about the same model.
+            format: state.model_format().to_string(),
+            loaded: state.model_loaded(),
         })
     };
 
@@ -434,11 +444,11 @@ async fn try_cached_completions(
     let generated = if let Some(metrics) = state.dispatch_metrics() {
         cached_model
             .generate_with_cache_adaptive(&prompt_ids, &q_config, metrics)
-            .map_err(|e| rerr(state, StatusCode::INTERNAL_SERVER_ERROR, e))?
+            .map_err(|e| rerr(state, super::generation_error_status(&e), e))?
     } else {
         cached_model
             .generate_with_cache(&prompt_ids, &q_config)
-            .map_err(|e| rerr(state, StatusCode::INTERNAL_SERVER_ERROR, e))?
+            .map_err(|e| rerr(state, super::generation_error_status(&e), e))?
     };
 
     let token_ids: Vec<u32> = generated.iter().skip(prompt_tokens).copied().collect();
@@ -502,9 +512,11 @@ fn try_quantized_completions(
             ..Default::default()
     };
 
+    // aprender#2376(9): a context-budget rejection is a client error (400), not a
+    // server failure — same classification as /generate.
     let generated = quantized_model
         .generate_with_cache(&prompt_ids, &q_config)
-        .map_err(|e| rerr(state, StatusCode::INTERNAL_SERVER_ERROR, e))?;
+        .map_err(|e| rerr(state, super::generation_error_status(&e), e))?;
     let token_ids: Vec<u32> = generated.iter().skip(prompt_tokens).copied().collect();
     let completion_tokens = token_ids.len();
     let text = tokenizer

--- a/crates/aprender-serve/src/api/router.rs
+++ b/crates/aprender-serve/src/api/router.rs
@@ -39,6 +39,67 @@ impl Default for RouterConfig {
     }
 }
 
+/// Routes mounted unconditionally by [`create_router_with_config`], as (method, path).
+///
+/// aprender#2376(12): the 404 body told clients "See /health for available
+/// endpoints", and `/health` returns five status fields and no route list — so
+/// following the instruction in the error message yielded nothing. The 404 now
+/// serves this list itself, and `test_advertised_routes_are_all_mounted` probes
+/// every entry so the list cannot drift into a second false advertisement.
+const NATIVE_ROUTES: &[(&str, &str)] = &[
+    ("GET", "/health"),
+    ("GET", "/health/live"),
+    ("GET", "/health/ready"),
+    ("GET", "/metrics"),
+    ("GET", "/metrics/dispatch"),
+    ("POST", "/metrics/dispatch/reset"),
+    ("GET", "/models"),
+    ("POST", "/tokenize"),
+    ("POST", "/generate"),
+    ("POST", "/batch/tokenize"),
+    ("POST", "/batch/generate"),
+    ("POST", "/stream/generate"),
+    ("POST", "/realize/generate"),
+    ("POST", "/realize/batch"),
+    ("POST", "/realize/embed"),
+    ("GET", "/realize/model"),
+    ("POST", "/realize/reload"),
+];
+
+/// Routes mounted only when `RouterConfig::openai_api` is set (the default).
+const OPENAI_ROUTES: &[(&str, &str)] = &[
+    ("GET", "/v1/models"),
+    ("POST", "/v1/completions"),
+    ("POST", "/v1/chat/completions"),
+    ("POST", "/v1/chat/completions/stream"),
+    ("POST", "/v1/embeddings"),
+    ("POST", "/v1/predict"),
+    ("POST", "/v1/explain"),
+    ("GET", "/v1/audit/:request_id"),
+    ("POST", "/v1/gpu/warmup"),
+    ("GET", "/v1/gpu/status"),
+    ("POST", "/v1/batch/completions"),
+    ("GET", "/v1/metrics"),
+    ("POST", "/api/chat"),
+    ("POST", "/api/generate"),
+];
+
+/// Routes mounted only in CUDA builds (realizr#191).
+#[cfg(feature = "cuda")]
+const CUDA_ROUTES: &[(&str, &str)] = &[("POST", "/v1/logprobs"), ("POST", "/v1/perplexity")];
+
+/// The routes this router mounts, as `"METHOD /path"` strings for the 404 body.
+fn route_index(openai_api: bool) -> Vec<String> {
+    let fmt = |(method, path): &(&str, &str)| format!("{method} {path}");
+    let mut routes: Vec<String> = NATIVE_ROUTES.iter().map(fmt).collect();
+    if openai_api {
+        routes.extend(OPENAI_ROUTES.iter().map(fmt));
+    }
+    #[cfg(feature = "cuda")]
+    routes.extend(CUDA_ROUTES.iter().map(fmt));
+    routes
+}
+
 /// Create the API router with default options (OpenAI API enabled)
 ///
 /// # Arguments
@@ -118,14 +179,21 @@ pub fn create_router_with_config(state: AppState, config: RouterConfig) -> Route
     }
 
     // GH-672: Return JSON error body for unmatched routes (not empty 404)
-    router = router.fallback(|| async {
-        (
-            axum::http::StatusCode::NOT_FOUND,
-            Json(serde_json::json!({
-                "error": "not_found",
-                "message": "Route not found. See /health for available endpoints."
-            })),
-        )
+    // aprender#2376(12): serve the route list here instead of pointing clients at
+    // /health, which does not have one.
+    let routes = route_index(config.openai_api);
+    router = router.fallback(move || {
+        let routes = routes.clone();
+        async move {
+            (
+                axum::http::StatusCode::NOT_FOUND,
+                Json(serde_json::json!({
+                    "error": "not_found",
+                    "message": "Route not found. Available routes are listed in `routes`.",
+                    "routes": routes,
+                })),
+            )
+        }
     });
 
     // GH-649: Sanitize axum deserialization errors to avoid leaking internals to clients.

--- a/crates/aprender-serve/src/api/stream_generate.rs
+++ b/crates/aprender-serve/src/api/stream_generate.rs
@@ -1,5 +1,109 @@
 
-/// Stream generate handler - generates tokens one by one via Server-Sent Events
+/// Dense f32 `Model` backend for `POST /stream/generate` (registry / safetensors).
+///
+/// Unchanged behaviour, lifted out of the handler so the quantized backend can be
+/// tried first. Only the status for an unresolvable model moved: a server with no
+/// usable model is 503, not 404 (see `model_resolution_status`).
+fn dense_stream_tokens(
+    state: &AppState,
+    request: &GenerateRequest,
+) -> Result<(Vec<u32>, usize, std::sync::Arc<BPETokenizer>), ApiErr> {
+    let (model, tokenizer) = state
+        .get_model(request.model_id.as_deref())
+        .map_err(|e| api_err(super::model_resolution_status(&e), e))?;
+
+    let prompt_ids = tokenize_prompt(&tokenizer, &request.prompt)?;
+    let prompt: Vec<usize> = prompt_ids.iter().map(|&id| id as usize).collect();
+    let prompt_len = prompt.len();
+
+    let strategy = match request.strategy.as_str() {
+        "greedy" => SamplingStrategy::Greedy,
+        "top_k" => SamplingStrategy::TopK { k: request.top_k },
+        "top_p" => SamplingStrategy::TopP { p: request.top_p },
+        other => {
+            return Err(api_err(
+                StatusCode::BAD_REQUEST,
+                format!("Invalid strategy: {other}"),
+            ))
+        },
+    };
+
+    let mut config = GenerationConfig::default()
+        .with_max_tokens(request.max_tokens)
+        .with_temperature(request.temperature);
+    config.strategy = strategy;
+    if let Some(seed) = request.seed {
+        config = config.with_seed(seed);
+    }
+
+    let generated = model
+        .generate(&prompt, &config)
+        .map_err(|e| api_err(StatusCode::INTERNAL_SERVER_ERROR, e))?;
+
+    let token_ids: Vec<u32> = generated
+        .iter()
+        .map(|&id| {
+            u32::try_from(id).map_err(|_| {
+                api_err(
+                    StatusCode::BAD_REQUEST,
+                    format!("Token ID {id} exceeds u32 range"),
+                )
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok((token_ids, prompt_len, tokenizer))
+}
+
+/// Quantized (GGUF / APR Q4_K) backend for `POST /stream/generate` and
+/// `/realize/generate`.
+///
+/// aprender#2376(1, 10): this handler resolved the dense f32 `Model` via
+/// `get_model()`, which is `None` on every `apr serve run model.gguf`, so a route
+/// the startup banner advertises as "SSE streaming" answered 404
+/// `"No model available"` while `/health` reported `model_loaded:true` and
+/// `/generate` on the same process returned tokens.
+///
+/// Returns `Ok(None)` when no quantized model is resident, so the dense path below
+/// is unchanged.
+fn try_quantized_stream_tokens(
+    state: &AppState,
+    request: &GenerateRequest,
+) -> Result<Option<(Vec<u32>, usize, std::sync::Arc<BPETokenizer>)>, ApiErr> {
+    let quantized_model = match state.quantized_model() {
+        Some(m) => m,
+        None => return Ok(None),
+    };
+    let tokenizer = require_tok(state)?;
+    let prompt_ids = tokenize_prompt(&tokenizer, &request.prompt)?;
+    let prompt_len = prompt_ids.len();
+
+    let sampling = resolve_quantized_sampling(
+        &request.strategy,
+        request.top_k,
+        request.top_p,
+        request.temperature,
+    )?;
+    let q_config = quantized_config(
+        state,
+        &tokenizer,
+        request.max_tokens,
+        request.temperature,
+        &sampling,
+        request.seed,
+    );
+
+    let generated = quantized_model
+        .generate_with_cache(&prompt_ids, &q_config)
+        .map_err(|e| generation_err(&e))?;
+
+    Ok(Some((generated, prompt_len, tokenizer)))
+}
+
+/// Stream generate handler — generates tokens one by one via Server-Sent Events.
+///
+/// Tries the quantized backend first (the `apr serve run model.gguf` path), then
+/// the dense f32 `Model`.
 pub async fn stream_generate_handler(
     State(state): State<AppState>,
     Json(request): Json<GenerateRequest>,
@@ -7,88 +111,20 @@ pub async fn stream_generate_handler(
     // NOTE: Streaming via CUDA model uses /v1/chat/completions endpoint with stream=true
     // This handler uses the CPU model path; for GPU streaming use OpenAI-compatible endpoint
 
-    // Get model and tokenizer
-    let (model, tokenizer) = state.get_model(request.model_id.as_deref()).map_err(|e| {
-        (
-            StatusCode::NOT_FOUND,
-            Json(ErrorResponse {
-                error: e.to_string(),
-            }),
-        )
-    })?;
-
-    // Tokenize prompt
-    let prompt_ids = tokenizer.encode(&request.prompt);
-    if prompt_ids.is_empty() {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            Json(ErrorResponse {
-                error: "Prompt cannot be empty".to_string(),
-            }),
-        ));
-    }
-
-    // Convert to usize for model
-    let prompt: Vec<usize> = prompt_ids.iter().map(|&id| id as usize).collect();
-    let prompt_len = prompt.len();
-
-    // Build generation config
-    let strategy = match request.strategy.as_str() {
-        "greedy" => SamplingStrategy::Greedy,
-        "top_k" => SamplingStrategy::TopK { k: request.top_k },
-        "top_p" => SamplingStrategy::TopP { p: request.top_p },
-        _ => {
-            return Err((
-                StatusCode::BAD_REQUEST,
-                Json(ErrorResponse {
-                    error: format!("Invalid strategy: {}", request.strategy),
-                }),
-            ));
-        },
-    };
-
-    let mut config = GenerationConfig::default()
-        .with_max_tokens(request.max_tokens)
-        .with_temperature(request.temperature);
-
-    config.strategy = strategy;
-    if let Some(seed) = request.seed {
-        config = config.with_seed(seed);
-    }
-
-    // Generate all tokens (in future, this will be truly streaming token-by-token)
-    let generated = match model.generate(&prompt, &config) {
-        Ok(tokens) => tokens,
-        Err(e) => {
-            return Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse {
-                    error: e.to_string(),
-                }),
-            ));
-        },
-    };
-
-    // Convert to u32 with proper overflow handling
-    let token_ids: Vec<u32> = generated
-        .iter()
-        .map(|&id| {
-            u32::try_from(id).map_err(|_| {
-                (
-                    StatusCode::BAD_REQUEST,
-                    Json(ErrorResponse {
-                        error: format!("Token ID {id} exceeds u32 range"),
-                    }),
-                )
-            })
-        })
-        .collect::<Result<Vec<_>, _>>()?;
+    let (token_ids, prompt_len, tokenizer_clone) =
+        if let Some(resolved) = try_quantized_stream_tokens(&state, &request)? {
+            resolved
+        } else {
+            dense_stream_tokens(&state, &request)?
+        };
 
     // Create stream that emits tokens one by one
-    let tokenizer_clone = tokenizer;
     let stream = async_stream::stream! {
-        // Skip prompt tokens, only stream generated tokens
-        for &token_id in &token_ids[prompt_len..] {
+        // Skip prompt tokens, only stream generated tokens. A backend that stops
+        // on the first sampled token returns the prompt alone, so clamp rather
+        // than slice past the end.
+        let generated_start = prompt_len.min(token_ids.len());
+        for &token_id in &token_ids[generated_start..] {
             // Decode single token
             let text = match tokenizer_clone.decode(&[token_id]) {
                 Ok(t) => t,
@@ -105,7 +141,7 @@ pub async fn stream_generate_handler(
 
         // Send done event
         let done_event = StreamDoneEvent {
-            num_generated: token_ids.len() - prompt_len,
+            num_generated: token_ids.len().saturating_sub(prompt_len),
         };
         // Serialization of simple struct should not fail, but handle gracefully
         let data = serde_json::to_string(&done_event)

--- a/crates/aprender-serve/src/api/tests/batch_generate_03.rs
+++ b/crates/aprender-serve/src/api/tests/batch_generate_03.rs
@@ -21,10 +21,14 @@ async fn test_batch_generate_handler_via_http() {
         )
         .await
         .expect("test value should be present");
-    assert!(
-        response.status() == StatusCode::OK
-            || response.status() == StatusCode::NOT_FOUND
-            || response.status() == StatusCode::INTERNAL_SERVER_ERROR
+    // aprender#2376(5): the shared test state has NO model, so this condition is
+    // deterministic — a server with no usable model answers 503 on every route.
+    // The old assertion accepted a SET of statuses that included the defect, so it
+    // could not fail and held the 404-here/500-there split in place.
+    assert_eq!(
+        response.status(),
+        StatusCode::SERVICE_UNAVAILABLE,
+        "no model is resident: expected 503"
     );
 }
 
@@ -371,10 +375,14 @@ async fn test_stream_generate_handler_via_http() {
         )
         .await
         .expect("test value should be present");
-    assert!(
-        response.status() == StatusCode::OK
-            || response.status() == StatusCode::NOT_FOUND
-            || response.status() == StatusCode::INTERNAL_SERVER_ERROR
+    // aprender#2376(5): the shared test state has NO model, so this condition is
+    // deterministic — a server with no usable model answers 503 on every route.
+    // The old assertion accepted a SET of statuses that included the defect, so it
+    // could not fail and held the 404-here/500-there split in place.
+    assert_eq!(
+        response.status(),
+        StatusCode::SERVICE_UNAVAILABLE,
+        "no model is resident: expected 503"
     );
 }
 

--- a/crates/aprender-serve/src/api/tests/clean_chat_format.rs
+++ b/crates/aprender-serve/src/api/tests/clean_chat_format.rs
@@ -129,10 +129,14 @@ async fn test_realize_embed_endpoint() {
 
     // May return 404 if model not found in demo mode, but exercises the handler
     let status = response.status();
-    assert!(
-        status == StatusCode::OK || status == StatusCode::NOT_FOUND,
-        "Unexpected status: {}",
-        status
+    // aprender#2376(5): the shared test state has NO model, so this condition is
+    // deterministic — a server with no usable model answers 503 on every route.
+    // The old assertion accepted a SET of statuses that included the defect, so it
+    // could not fail and held the 404-here/500-there split in place.
+    assert_eq!(
+        status,
+        StatusCode::SERVICE_UNAVAILABLE,
+        "no model is resident: expected 503"
     );
 }
 
@@ -245,10 +249,14 @@ async fn test_openai_embeddings_endpoint() {
         .expect("test value should be present");
 
     let status = response.status();
-    assert!(
-        status == StatusCode::OK || status == StatusCode::NOT_FOUND,
-        "Unexpected status: {}",
-        status
+    // aprender#2376(5): the shared test state has NO model, so this condition is
+    // deterministic — a server with no usable model answers 503 on every route.
+    // The old assertion accepted a SET of statuses that included the defect, so it
+    // could not fail and held the 404-here/500-there split in place.
+    assert_eq!(
+        status,
+        StatusCode::SERVICE_UNAVAILABLE,
+        "no model is resident: expected 503"
     );
 }
 

--- a/crates/aprender-serve/src/api/tests/completion_request_02.rs
+++ b/crates/aprender-serve/src/api/tests/completion_request_02.rs
@@ -250,9 +250,14 @@ async fn test_realize_embed_long_input() {
 
     // Should handle long input gracefully
     let status = response.status();
-    assert!(
-        status == StatusCode::OK || status == StatusCode::NOT_FOUND,
-        "Unexpected status: {status}"
+    // aprender#2376(5): the shared test state has NO model, so this condition is
+    // deterministic — a server with no usable model answers 503 on every route.
+    // The old assertion accepted a SET of statuses that included the defect, so it
+    // could not fail and held the 404-here/500-there split in place.
+    assert_eq!(
+        status,
+        StatusCode::SERVICE_UNAVAILABLE,
+        "no model is resident: expected 503"
     );
 }
 
@@ -278,9 +283,14 @@ async fn test_realize_embed_unicode_input() {
         .expect("test value should be present");
 
     let status = response.status();
-    assert!(
-        status == StatusCode::OK || status == StatusCode::NOT_FOUND,
-        "Unexpected status: {status}"
+    // aprender#2376(5): the shared test state has NO model, so this condition is
+    // deterministic — a server with no usable model answers 503 on every route.
+    // The old assertion accepted a SET of statuses that included the defect, so it
+    // could not fail and held the 404-here/500-there split in place.
+    assert_eq!(
+        status,
+        StatusCode::SERVICE_UNAVAILABLE,
+        "no model is resident: expected 503"
     );
 }
 

--- a/crates/aprender-serve/src/api/tests/completions_invalid.rs
+++ b/crates/aprender-serve/src/api/tests/completions_invalid.rs
@@ -352,7 +352,15 @@ async fn test_realize_embed() {
         .expect("send");
 
     let status = response.status();
-    assert!(status == StatusCode::OK || status == StatusCode::NOT_FOUND);
+    // aprender#2376(5): the shared test state has NO model, so this condition is
+    // deterministic — a server with no usable model answers 503 on every route.
+    // The old assertion accepted a SET of statuses that included the defect, so it
+    // could not fail and held the 404-here/500-there split in place.
+    assert_eq!(
+        status,
+        StatusCode::SERVICE_UNAVAILABLE,
+        "no model is resident: expected 503"
+    );
 }
 
 #[tokio::test]

--- a/crates/aprender-serve/src/api/tests/deep_apicov_02.rs
+++ b/crates/aprender-serve/src/api/tests/deep_apicov_02.rs
@@ -18,7 +18,15 @@ async fn test_deep_apicov_generate_with_model_id() {
 
     // Will fail because custom model doesn't exist, but exercises the path
     let status = response.status();
-    assert!(status == StatusCode::OK || status == StatusCode::NOT_FOUND);
+    // aprender#2376(5): the shared test state has NO model, so this condition is
+    // deterministic — a server with no usable model answers 503 on every route.
+    // The old assertion accepted a SET of statuses that included the defect, so it
+    // could not fail and held the 404-here/500-there split in place.
+    assert_eq!(
+        status,
+        StatusCode::SERVICE_UNAVAILABLE,
+        "no model is resident: expected 503"
+    );
 }
 
 #[tokio::test]

--- a/crates/aprender-serve/src/api/tests/format_chat_02.rs
+++ b/crates/aprender-serve/src/api/tests/format_chat_02.rs
@@ -240,10 +240,14 @@ async fn test_openai_embeddings_endpoint() {
         .expect("test value should be present");
 
     let response = app.oneshot(request).await.expect("test value should be present");
-    assert!(
-        response.status() == StatusCode::OK
-            || response.status() == StatusCode::NOT_FOUND
-            || response.status() == StatusCode::INTERNAL_SERVER_ERROR,
+    // aprender#2376(5): the shared test state has NO model, so this condition is
+    // deterministic — a server with no usable model answers 503 on every route.
+    // The old assertion accepted a SET of statuses that included the defect, so it
+    // could not fail and held the 404-here/500-there split in place.
+    assert_eq!(
+        response.status(),
+        StatusCode::SERVICE_UNAVAILABLE,
+        "no model is resident: expected 503"
     );
 }
 

--- a/crates/aprender-serve/src/api/tests/mod.rs
+++ b/crates/aprender-serve/src/api/tests/mod.rs
@@ -50,3 +50,4 @@ mod tests_27; // T-COV-95 Generative Falsification: Proptest API Request Assault
 mod tests_28; // Coverage: realize_handlers pure functions, ContextWindow, clean_chat, build_trace_data, serde
 mod chat_template_contract; // PMAT-187: chat-template-v1.yaml contract enforcement (FALSIFY-CT-002)
 mod embeddings_pmat803; // PMAT-803: model-backed embeddings (semantic-similarity falsifier, dim==hidden_size)
+mod native_routes_2376; // aprender#2376: native routes on a quantized server, KV-cache budget, sampling fields

--- a/crates/aprender-serve/src/api/tests/native_routes_2376.rs
+++ b/crates/aprender-serve/src/api/tests/native_routes_2376.rs
@@ -1,0 +1,569 @@
+//! Falsifiers for aprender#2376 — native serve routes on a quantized server.
+//!
+//! Every test here fails against the shipped 0.63.0 behaviour. They assert what a
+//! client observes (status code, body content, whether two responses differ), not
+//! that a function was called.
+
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+};
+use tower::util::ServiceExt;
+
+use crate::api::{create_router, AppState};
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/// A quantized-only server: exactly what `apr serve run model.gguf` builds — a
+/// tokenizer plus `quantized_model`, and NO dense f32 `Model`.
+#[cfg(feature = "gpu")]
+fn quantized_state() -> AppState {
+    use crate::api::test_helpers::create_test_quantized_model;
+    use crate::gguf::{ArchConstraints, GGUFConfig};
+
+    let config = GGUFConfig {
+        architecture: "llama".to_string(),
+        constraints: ArchConstraints::from_architecture("llama"),
+        hidden_dim: 64,
+        intermediate_dim: 128,
+        num_layers: 2,
+        num_heads: 4,
+        num_kv_heads: 4,
+        vocab_size: 256,
+        context_length: 128,
+        rope_theta: 10000.0,
+        eps: 1e-5,
+        rope_type: 0,
+        explicit_head_dim: None,
+        query_pre_attn_scalar: None,
+        bos_token_id: None,
+        eos_token_id: None,
+    };
+    AppState::with_quantized_model(create_test_quantized_model(&config))
+        .expect("build quantized AppState")
+}
+
+async fn body_string(response: axum::response::Response) -> String {
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read body");
+    String::from_utf8_lossy(&bytes).into_owned()
+}
+
+async fn post(state: AppState, uri: &str, json: &str) -> (StatusCode, String) {
+    let response = create_router(state)
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(uri)
+                .header("content-type", "application/json")
+                .body(Body::from(json.to_string()))
+                .expect("build request"),
+        )
+        .await
+        .expect("dispatch");
+    let status = response.status();
+    (status, body_string(response).await)
+}
+
+async fn get(state: AppState, uri: &str) -> (StatusCode, String) {
+    let response = create_router(state)
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(uri)
+                .body(Body::empty())
+                .expect("build request"),
+        )
+        .await
+        .expect("dispatch");
+    let status = response.status();
+    (status, body_string(response).await)
+}
+
+// ---------------------------------------------------------------------------
+// Finding 9 (P0): one request must not be able to kill the process
+// ---------------------------------------------------------------------------
+
+/// A `max_tokens` larger than the context window must be CLAMPED, not allocated.
+///
+/// 0.63.0 sized the KV cache as `prompt + max_tokens` with no ceiling, so this
+/// request asked the allocator for ~1 TB and Rust's allocation-error handler
+/// aborted the process — which is why the server died with no HTTP reply at all.
+/// The clamp makes the cache size a property of the model, not of the request.
+#[test]
+#[cfg(feature = "gpu")]
+fn test_generate_with_cache_clamps_max_tokens_to_context() {
+    use crate::api::test_helpers::create_test_quantized_model;
+    use crate::error::RealizarError;
+    use crate::gguf::{ArchConstraints, GGUFConfig, QuantizedGenerateConfig};
+
+    let config = GGUFConfig {
+        architecture: "llama".to_string(),
+        constraints: ArchConstraints::from_architecture("llama"),
+        hidden_dim: 64,
+        intermediate_dim: 128,
+        num_layers: 2,
+        num_heads: 4,
+        num_kv_heads: 4,
+        vocab_size: 256,
+        context_length: 128,
+        rope_theta: 10000.0,
+        eps: 1e-5,
+        rope_type: 0,
+        explicit_head_dim: None,
+        query_pre_attn_scalar: None,
+        bos_token_id: None,
+        eos_token_id: None,
+    };
+    let model = create_test_quantized_model(&config);
+    // 1000 > context_length 128. Kept small deliberately: with the clamp removed
+    // this assertion fails in a second (1003 tokens) instead of running for the
+    // hours that `max_tokens: 999_999_999` would take — same defect, fast signal.
+    let gen_config = QuantizedGenerateConfig {
+        max_tokens: 1000,
+        // No stop token, so nothing but the context bound can end this loop —
+        // exactly the shape that ran unbounded before the clamp.
+        stop_tokens: Vec::new(),
+        ..Default::default()
+    };
+
+    let tokens = model
+        .generate_with_cache(&[1, 2, 3], &gen_config)
+        .expect("a clamped request still generates");
+    assert_eq!(
+        tokens.len(),
+        128,
+        "prompt + generated must stop at context_length, never at max_tokens"
+    );
+
+    // A prompt that alone exceeds the context is still unsatisfiable (GH-167).
+    let long_prompt: Vec<u32> = (0..200).map(|i| (i % 256) as u32).collect();
+    match model
+        .generate_with_cache(&long_prompt, &gen_config)
+        .expect_err("a prompt longer than the context cannot be served")
+    {
+        RealizarError::ContextLimitExceeded { provided, maximum } => {
+            assert_eq!(provided, 200);
+            assert_eq!(maximum, 128);
+        },
+        other => panic!("expected ContextLimitExceeded, got {other:?}"),
+    }
+}
+
+/// The same request over HTTP must be answered, by a server that is still alive.
+/// 0.63.0 returned nothing at all: the process was gone (curl exit 52, port dead).
+#[tokio::test]
+#[cfg(feature = "gpu")]
+async fn test_generate_survives_oversized_max_tokens() {
+    let (status, body) = post(
+        quantized_state(),
+        "/generate",
+        r#"{"prompt":"token5","max_tokens":999999999}"#,
+    )
+    .await;
+
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "the request must be answered, not fatal, body: {body}"
+    );
+    let parsed: serde_json::Value = serde_json::from_str(&body).expect("json body");
+    let generated = parsed["token_ids"].as_array().expect("token_ids").len();
+    assert!(
+        generated <= 128,
+        "generation must be bounded by the model context (128), got {generated}"
+    );
+
+    // The server survived: a normal request on a fresh router still works.
+    let (status, _) = post(quantized_state(), "/generate", r#"{"prompt":"token5"}"#).await;
+    assert_eq!(status, StatusCode::OK, "server must still serve");
+}
+
+/// An over-long PROMPT is still a client error, and it must be reported as one:
+/// 0.63.0 answered 500, which tells the caller the server broke.
+#[tokio::test]
+#[cfg(feature = "gpu")]
+async fn test_oversized_prompt_is_400_not_500() {
+    // 300 whitespace-separated tokens against a 128-token context window.
+    let prompt = "token5 ".repeat(300);
+    let json = serde_json::json!({"prompt": prompt, "max_tokens": 4}).to_string();
+    let (status, body) = post(quantized_state(), "/generate", &json).await;
+
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "a prompt over the context window is a client error, body: {body}"
+    );
+    assert!(
+        body.to_lowercase().contains("context"),
+        "the error must name the context limit, got: {body}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Findings 1 + 10 (P0/P1): the native routes must work on a quantized server
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[cfg(feature = "gpu")]
+async fn test_tokenize_works_on_quantized_server() {
+    let (status, body) = post(quantized_state(), "/tokenize", r#"{"text":"token5"}"#).await;
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    assert!(
+        !body.contains("No model available"),
+        "tokenizing needs only the tokenizer, got: {body}"
+    );
+    assert!(body.contains("token_ids"), "body: {body}");
+}
+
+#[tokio::test]
+#[cfg(feature = "gpu")]
+async fn test_batch_tokenize_works_on_quantized_server() {
+    let (status, body) = post(
+        quantized_state(),
+        "/batch/tokenize",
+        r#"{"texts":["token5","token6"]}"#,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    assert!(!body.contains("No model available"), "body: {body}");
+}
+
+#[tokio::test]
+#[cfg(feature = "gpu")]
+async fn test_batch_generate_works_on_quantized_server() {
+    let (status, body) = post(
+        quantized_state(),
+        "/batch/generate",
+        r#"{"prompts":["token5"],"max_tokens":2}"#,
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "a banner-advertised route must work when a model is loaded, body: {body}"
+    );
+    assert!(!body.contains("No model available"), "body: {body}");
+    assert!(body.contains("results"), "body: {body}");
+}
+
+/// `/realize/batch` is the same handler under the spec §5.2 path.
+#[tokio::test]
+#[cfg(feature = "gpu")]
+async fn test_realize_batch_works_on_quantized_server() {
+    let (status, body) = post(
+        quantized_state(),
+        "/realize/batch",
+        r#"{"prompts":["token5"],"max_tokens":2}"#,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    assert!(!body.contains("No model available"), "body: {body}");
+}
+
+#[tokio::test]
+#[cfg(feature = "gpu")]
+async fn test_stream_generate_works_on_quantized_server() {
+    let response = create_router(quantized_state())
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/stream/generate")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"prompt":"token5","max_tokens":2}"#))
+                .expect("build request"),
+        )
+        .await
+        .expect("dispatch");
+
+    let status = response.status();
+    let content_type = response
+        .headers()
+        .get("content-type")
+        .map(|v| v.to_str().unwrap_or_default().to_string())
+        .unwrap_or_default();
+    let body = body_string(response).await;
+
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    assert!(
+        content_type.starts_with("text/event-stream"),
+        "SSE route must answer with an event stream, got content-type {content_type:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Finding 5 (P2): one condition, one status code
+// ---------------------------------------------------------------------------
+
+/// "This server has no usable model" is 503 on EVERY route that can report it.
+/// 0.63.0 answered 404 on `/tokenize` and `/stream/generate` but 500 on
+/// `/batch/tokenize` and `/batch/generate` for the identical condition.
+#[tokio::test]
+async fn test_no_model_available_is_503_everywhere() {
+    let cases: [(&str, &str); 4] = [
+        ("/tokenize", r#"{"text":"hi"}"#),
+        ("/batch/tokenize", r#"{"texts":["hi"]}"#),
+        ("/batch/generate", r#"{"prompts":["hi"],"max_tokens":2}"#),
+        ("/stream/generate", r#"{"prompt":"hi","max_tokens":2}"#),
+    ];
+
+    for (uri, json) in cases {
+        let state = AppState::demo_mock().expect("mock state");
+        let (status, body) = post(state, uri, json).await;
+        assert_eq!(
+            status,
+            StatusCode::SERVICE_UNAVAILABLE,
+            "{uri} must report a missing model as 503, got {status} / {body}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Findings 2 + 4 (P1/P2): documented sampling fields must be honoured or rejected
+// ---------------------------------------------------------------------------
+
+/// `resolve_quantized_sampling` errors carry a non-Debug `Json` body; pull the status.
+fn rejected_status(
+    result: Result<
+        crate::api::gpu_handlers::QuantizedSampling,
+        (StatusCode, axum::Json<crate::api::ErrorResponse>),
+    >,
+) -> StatusCode {
+    match result {
+        Ok(_) => panic!("expected the request to be rejected"),
+        Err((status, _)) => status,
+    }
+}
+
+/// Unwrap a resolved sampling config (the error side is not Debug).
+fn accepted(
+    result: Result<
+        crate::api::gpu_handlers::QuantizedSampling,
+        (StatusCode, axum::Json<crate::api::ErrorResponse>),
+    >,
+) -> crate::api::gpu_handlers::QuantizedSampling {
+    match result {
+        Ok(sampling) => sampling,
+        Err((status, _)) => panic!("expected the request to be accepted, got {status}"),
+    }
+}
+
+#[test]
+fn test_negative_temperature_is_rejected() {
+    use crate::api::gpu_handlers::resolve_quantized_sampling;
+
+    for temperature in [-1.0_f32, -5.0, -100.0, f32::NAN] {
+        assert_eq!(
+            rejected_status(resolve_quantized_sampling("greedy", 50, 0.9, temperature)),
+            StatusCode::BAD_REQUEST,
+            "temperature {temperature} inverts the softmax and must be rejected"
+        );
+    }
+    // Positive controls: the neighbouring values still work.
+    for temperature in [0.0_f32, 0.7, 2.0] {
+        let _ = accepted(resolve_quantized_sampling("greedy", 50, 0.9, temperature));
+    }
+}
+
+#[test]
+fn test_strategy_selects_the_sampler() {
+    use crate::api::gpu_handlers::resolve_quantized_sampling;
+
+    // greedy => argmax, regardless of a wide top_k / hot temperature.
+    let greedy = accepted(resolve_quantized_sampling("greedy", 500, 0.9, 2.0));
+    assert_eq!(greedy.top_k, 1, "greedy must be argmax");
+    assert_eq!(greedy.top_p, 1.0, "greedy must not narrow by nucleus");
+
+    // top_k is passed through.
+    let top_k = accepted(resolve_quantized_sampling("top_k", 500, 0.9, 2.0));
+    assert_eq!(top_k.top_k, 500);
+
+    // top_p reaches the engine instead of being discarded.
+    let top_p = accepted(resolve_quantized_sampling("top_p", 500, 0.01, 2.0));
+    assert_eq!(top_p.top_p, 0.01, "top_p must reach the sampler");
+    assert_eq!(top_p.top_k, 0, "nucleus-only sampling disables the top-k cut");
+
+    // temperature 0 is greedy on every surface.
+    let zero = accepted(resolve_quantized_sampling("top_k", 500, 0.9, 0.0));
+    assert_eq!(zero.top_k, 1);
+
+    // An unknown strategy is a client error, not silence.
+    assert_eq!(
+        rejected_status(resolve_quantized_sampling("bogus", 50, 0.9, 1.0)),
+        StatusCode::BAD_REQUEST
+    );
+
+    // An out-of-range top_p is a client error on the branch that uses it.
+    assert_eq!(
+        rejected_status(resolve_quantized_sampling("top_p", 50, 9.9, 1.0)),
+        StatusCode::BAD_REQUEST
+    );
+}
+
+/// End to end: `strategy:"greedy"` must decode like `temperature:0`, and must NOT
+/// match a sampled decode of the same request. 0.63.0 sampled in all three cases.
+#[tokio::test]
+#[cfg(feature = "gpu")]
+async fn test_greedy_strategy_is_argmax_over_http() {
+    let (_, reference) = post(
+        quantized_state(),
+        "/generate",
+        r#"{"prompt":"token5","max_tokens":4,"temperature":0.0}"#,
+    )
+    .await;
+    let (_, greedy) = post(
+        quantized_state(),
+        "/generate",
+        r#"{"prompt":"token5","max_tokens":4,"temperature":2.0,"top_k":500,"strategy":"greedy"}"#,
+    )
+    .await;
+    let (_, sampled) = post(
+        quantized_state(),
+        "/generate",
+        r#"{"prompt":"token5","max_tokens":4,"temperature":2.0,"top_k":500,"strategy":"top_k","seed":7}"#,
+    )
+    .await;
+
+    assert_eq!(
+        greedy, reference,
+        "strategy=greedy must decode identically to temperature=0"
+    );
+    assert_ne!(
+        sampled, greedy,
+        "a sampled decode must differ from greedy, else `strategy` is being ignored"
+    );
+}
+
+/// The request-level rejections are visible over HTTP, on a server that has a model.
+#[tokio::test]
+#[cfg(feature = "gpu")]
+async fn test_generate_rejects_bad_sampling_params_with_400() {
+    let cases = [
+        r#"{"prompt":"token5","max_tokens":4,"temperature":-1.0}"#,
+        r#"{"prompt":"token5","max_tokens":4,"strategy":"invalid_strategy"}"#,
+        r#"{"prompt":"token5","max_tokens":4,"strategy":"top_p","top_p":9.9}"#,
+    ];
+    for json in cases {
+        let (status, body) = post(quantized_state(), "/generate", json).await;
+        assert_eq!(
+            status,
+            StatusCode::BAD_REQUEST,
+            "{json} must be rejected, got {status} / {body}"
+        );
+    }
+    // Positive control on the same server: a well-formed request still succeeds.
+    let (status, _) = post(
+        quantized_state(),
+        "/generate",
+        r#"{"prompt":"token5","max_tokens":4,"temperature":0.7,"strategy":"top_p","top_p":0.9}"#,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+}
+
+/// Two different `seed` values must produce two different samples.
+#[tokio::test]
+#[cfg(feature = "gpu")]
+async fn test_seed_changes_the_sample_over_http() {
+    let body = |seed: u32| {
+        format!(
+            r#"{{"prompt":"token5","max_tokens":4,"temperature":2.0,"top_k":500,"strategy":"top_k","seed":{seed}}}"#
+        )
+    };
+    let (_, one) = post(quantized_state(), "/generate", &body(1)).await;
+    let (_, two) = post(quantized_state(), "/generate", &body(2)).await;
+    let (_, one_again) = post(quantized_state(), "/generate", &body(1)).await;
+
+    assert_eq!(one, one_again, "the same seed must be reproducible");
+    assert_ne!(one, two, "seed=1 and seed=2 must not be byte-identical");
+}
+
+// ---------------------------------------------------------------------------
+// Finding 6 (P2): two model-info endpoints must not contradict each other
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[cfg(feature = "gpu")]
+async fn test_models_and_realize_model_agree_on_format() {
+    let (_, models) = get(quantized_state(), "/models").await;
+    let (_, realize) = get(quantized_state(), "/realize/model").await;
+
+    let models: serde_json::Value = serde_json::from_str(&models).expect("models json");
+    let realize: serde_json::Value = serde_json::from_str(&realize).expect("realize json");
+
+    let listed = models["models"][0]["format"]
+        .as_str()
+        .expect("format field")
+        .to_string();
+    let detailed = realize["format"].as_str().expect("format field").to_string();
+
+    assert_eq!(
+        listed, detailed,
+        "/models and /realize/model must report one format for one model"
+    );
+    assert_eq!(listed, "gguf", "a quantized GGUF model is 'gguf', not 'unknown'");
+}
+
+// ---------------------------------------------------------------------------
+// Finding 12 (P2): the 404 must point at something that exists
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_404_body_lists_routes() {
+    let state = AppState::demo_mock().expect("mock state");
+    let (status, body) = get(state, "/nope/nope").await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+
+    let parsed: serde_json::Value = serde_json::from_str(&body).expect("json 404 body");
+    let routes = parsed["routes"].as_array().expect("routes array in 404 body");
+    assert!(!routes.is_empty(), "404 must list the routes it promises");
+    assert!(
+        routes.iter().any(|r| r == "POST /generate"),
+        "route list must contain the routes this server mounts: {routes:?}"
+    );
+    assert!(
+        !body.contains("See /health for available endpoints"),
+        "/health returns no endpoint list, so the 404 must not send clients there"
+    );
+}
+
+/// Every route the 404 advertises must actually be mounted. This is what stops the
+/// list from becoming a second false advertisement as routes move.
+#[tokio::test]
+async fn test_advertised_routes_are_all_mounted() {
+    let state = AppState::demo_mock().expect("mock state");
+    let (_, body) = get(state, "/nope/nope").await;
+    let parsed: serde_json::Value = serde_json::from_str(&body).expect("json 404 body");
+    let routes: Vec<String> = parsed["routes"]
+        .as_array()
+        .expect("routes array")
+        .iter()
+        .map(|r| r.as_str().unwrap_or_default().to_string())
+        .collect();
+
+    for route in routes {
+        let (method, path) = route.split_once(' ').expect("METHOD /path");
+        // Axum path params are placeholders; substitute something concrete.
+        let path = path.replace(":request_id", "not-a-uuid");
+        let state = AppState::demo_mock().expect("mock state");
+        let response = create_router(state)
+            .oneshot(
+                Request::builder()
+                    .method(method)
+                    .uri(&path)
+                    .header("content-type", "application/json")
+                    .body(Body::from("{}"))
+                    .expect("build request"),
+            )
+            .await
+            .expect("dispatch");
+        assert_ne!(
+            response.status(),
+            StatusCode::NOT_FOUND,
+            "{method} {path} is advertised in the 404 body but is not mounted"
+        );
+    }
+}

--- a/crates/aprender-serve/src/api/tests/openai_chat.rs
+++ b/crates/aprender-serve/src/api/tests/openai_chat.rs
@@ -260,7 +260,15 @@ async fn test_tokenize_with_model_id_more_cov() {
         .expect("test");
 
     let status = response.status();
-    assert!(status == StatusCode::OK || status == StatusCode::NOT_FOUND);
+    // aprender#2376(5): the shared test state has NO model, so this condition is
+    // deterministic — a server with no usable model answers 503 on every route.
+    // The old assertion accepted a SET of statuses that included the defect, so it
+    // could not fail and held the 404-here/500-there split in place.
+    assert_eq!(
+        status,
+        StatusCode::SERVICE_UNAVAILABLE,
+        "no model is resident: expected 503"
+    );
 }
 
 #[tokio::test]
@@ -307,7 +315,15 @@ async fn test_realize_embed_with_model_more_cov() {
         .expect("test");
 
     let status = response.status();
-    assert!(status == StatusCode::OK || status == StatusCode::NOT_FOUND);
+    // aprender#2376(5): the shared test state has NO model, so this condition is
+    // deterministic — a server with no usable model answers 503 on every route.
+    // The old assertion accepted a SET of statuses that included the defect, so it
+    // could not fail and held the 404-here/500-there split in place.
+    assert_eq!(
+        status,
+        StatusCode::SERVICE_UNAVAILABLE,
+        "no model is resident: expected 503"
+    );
 }
 
 #[test]

--- a/crates/aprender-serve/src/api/tests/openai_completions.rs
+++ b/crates/aprender-serve/src/api/tests/openai_completions.rs
@@ -163,9 +163,14 @@ async fn test_openai_embeddings_endpoint_basic() {
         .expect("test value should be present");
 
     let status = response.status();
-    assert!(
-        status == StatusCode::OK || status == StatusCode::NOT_FOUND,
-        "Unexpected status: {status}"
+    // aprender#2376(5): the shared test state has NO model, so this condition is
+    // deterministic — a server with no usable model answers 503 on every route.
+    // The old assertion accepted a SET of statuses that included the defect, so it
+    // could not fail and held the 404-here/500-there split in place.
+    assert_eq!(
+        status,
+        StatusCode::SERVICE_UNAVAILABLE,
+        "no model is resident: expected 503"
     );
 }
 
@@ -190,9 +195,14 @@ async fn test_openai_embeddings_without_model() {
         .expect("test value should be present");
 
     let status = response.status();
-    assert!(
-        status == StatusCode::OK || status == StatusCode::NOT_FOUND,
-        "Unexpected status: {status}"
+    // aprender#2376(5): the shared test state has NO model, so this condition is
+    // deterministic — a server with no usable model answers 503 on every route.
+    // The old assertion accepted a SET of statuses that included the defect, so it
+    // could not fail and held the 404-here/500-there split in place.
+    assert_eq!(
+        status,
+        StatusCode::SERVICE_UNAVAILABLE,
+        "no model is resident: expected 503"
     );
 }
 
@@ -218,9 +228,14 @@ async fn test_openai_embeddings_long_text() {
         .expect("test value should be present");
 
     let status = response.status();
-    assert!(
-        status == StatusCode::OK || status == StatusCode::NOT_FOUND,
-        "Unexpected status: {status}"
+    // aprender#2376(5): the shared test state has NO model, so this condition is
+    // deterministic — a server with no usable model answers 503 on every route.
+    // The old assertion accepted a SET of statuses that included the defect, so it
+    // could not fail and held the 404-here/500-there split in place.
+    assert_eq!(
+        status,
+        StatusCode::SERVICE_UNAVAILABLE,
+        "no model is resident: expected 503"
     );
 }
 

--- a/crates/aprender-serve/src/api/tests/openai_model_02.rs
+++ b/crates/aprender-serve/src/api/tests/openai_model_02.rs
@@ -305,10 +305,14 @@ async fn test_invalid_strategy_generate() {
         .await
         .expect("test value should be present");
     // Should return BAD_REQUEST for invalid strategy
-    assert!(
-        response.status() == StatusCode::BAD_REQUEST
-            || response.status() == StatusCode::NOT_FOUND
-            || response.status() == StatusCode::INTERNAL_SERVER_ERROR
+    // aprender#2376(5): the shared test state has NO model, so this condition is
+    // deterministic — a server with no usable model answers 503 on every route.
+    // The old assertion accepted a SET of statuses that included the defect, so it
+    // could not fail and held the 404-here/500-there split in place.
+    assert_eq!(
+        response.status(),
+        StatusCode::SERVICE_UNAVAILABLE,
+        "no model is resident: expected 503"
     );
 }
 

--- a/crates/aprender-serve/src/api/tests/reload_request_response.rs
+++ b/crates/aprender-serve/src/api/tests/reload_request_response.rs
@@ -182,10 +182,14 @@ async fn test_realize_embed_handler_via_http() {
         .await
         .expect("test value should be present");
     // May return OK or error depending on mock state
-    assert!(
-        response.status() == StatusCode::OK
-            || response.status() == StatusCode::NOT_FOUND
-            || response.status() == StatusCode::INTERNAL_SERVER_ERROR
+    // aprender#2376(5): the shared test state has NO model, so this condition is
+    // deterministic — a server with no usable model answers 503 on every route.
+    // The old assertion accepted a SET of statuses that included the defect, so it
+    // could not fail and held the 404-here/500-there split in place.
+    assert_eq!(
+        response.status(),
+        StatusCode::SERVICE_UNAVAILABLE,
+        "no model is resident: expected 503"
     );
 }
 
@@ -364,10 +368,14 @@ async fn test_tokenize_handler_via_http() {
         )
         .await
         .expect("test value should be present");
-    assert!(
-        response.status() == StatusCode::OK
-            || response.status() == StatusCode::NOT_FOUND
-            || response.status() == StatusCode::INTERNAL_SERVER_ERROR
+    // aprender#2376(5): the shared test state has NO model, so this condition is
+    // deterministic — a server with no usable model answers 503 on every route.
+    // The old assertion accepted a SET of statuses that included the defect, so it
+    // could not fail and held the 404-here/500-there split in place.
+    assert_eq!(
+        response.status(),
+        StatusCode::SERVICE_UNAVAILABLE,
+        "no model is resident: expected 503"
     );
 }
 
@@ -388,10 +396,14 @@ async fn test_batch_tokenize_handler_via_http() {
         )
         .await
         .expect("test value should be present");
-    assert!(
-        response.status() == StatusCode::OK
-            || response.status() == StatusCode::NOT_FOUND
-            || response.status() == StatusCode::INTERNAL_SERVER_ERROR
+    // aprender#2376(5): the shared test state has NO model, so this condition is
+    // deterministic — a server with no usable model answers 503 on every route.
+    // The old assertion accepted a SET of statuses that included the defect, so it
+    // could not fail and held the 404-here/500-there split in place.
+    assert_eq!(
+        response.status(),
+        StatusCode::SERVICE_UNAVAILABLE,
+        "no model is resident: expected 503"
     );
 }
 
@@ -417,9 +429,13 @@ async fn test_generate_handler_via_http() {
         )
         .await
         .expect("test value should be present");
-    assert!(
-        response.status() == StatusCode::OK
-            || response.status() == StatusCode::NOT_FOUND
-            || response.status() == StatusCode::INTERNAL_SERVER_ERROR
+    // aprender#2376(5): the shared test state has NO model, so this condition is
+    // deterministic — a server with no usable model answers 503 on every route.
+    // The old assertion accepted a SET of statuses that included the defect, so it
+    // could not fail and held the 404-here/500-there split in place.
+    assert_eq!(
+        response.status(),
+        StatusCode::SERVICE_UNAVAILABLE,
+        "no model is resident: expected 503"
     );
 }

--- a/crates/aprender-serve/src/api/tests/stream_generate.rs
+++ b/crates/aprender-serve/src/api/tests/stream_generate.rs
@@ -12,11 +12,14 @@ async fn test_stream_generate_endpoint() {
         .expect("test value should be present");
 
     let response = app.oneshot(request).await.expect("test value should be present");
-    assert!(
-        response.status() == StatusCode::OK
-            || response.status() == StatusCode::NOT_FOUND
-            || response.status() == StatusCode::INTERNAL_SERVER_ERROR
-            || response.status() == StatusCode::UNPROCESSABLE_ENTITY,
+    // aprender#2376(5): the shared test state has NO model, so this condition is
+    // deterministic — a server with no usable model answers 503 on every route.
+    // The old assertion accepted a SET of statuses that included the defect, so it
+    // could not fail and held the 404-here/500-there split in place.
+    assert_eq!(
+        response.status(),
+        StatusCode::SERVICE_UNAVAILABLE,
+        "no model is resident: expected 503"
     );
 }
 

--- a/crates/aprender-serve/src/api/tests/tests_19.rs
+++ b/crates/aprender-serve/src/api/tests/tests_19.rs
@@ -416,11 +416,14 @@ async fn test_realize_generate_endpoint() {
         .expect("test value should be present");
 
     let response = app.oneshot(request).await.expect("test value should be present");
-    assert!(
-        response.status() == StatusCode::OK
-            || response.status() == StatusCode::NOT_FOUND
-            || response.status() == StatusCode::INTERNAL_SERVER_ERROR
-            || response.status() == StatusCode::UNPROCESSABLE_ENTITY,
+    // aprender#2376(5): the shared test state has NO model, so this condition is
+    // deterministic — a server with no usable model answers 503 on every route.
+    // The old assertion accepted a SET of statuses that included the defect, so it
+    // could not fail and held the 404-here/500-there split in place.
+    assert_eq!(
+        response.status(),
+        StatusCode::SERVICE_UNAVAILABLE,
+        "no model is resident: expected 503"
     );
 }
 
@@ -437,11 +440,14 @@ async fn test_realize_batch_endpoint() {
         .expect("test value should be present");
 
     let response = app.oneshot(request).await.expect("test value should be present");
-    assert!(
-        response.status() == StatusCode::OK
-            || response.status() == StatusCode::NOT_FOUND
-            || response.status() == StatusCode::INTERNAL_SERVER_ERROR
-            || response.status() == StatusCode::UNPROCESSABLE_ENTITY,
+    // aprender#2376(5): the shared test state has NO model, so this condition is
+    // deterministic — a server with no usable model answers 503 on every route.
+    // The old assertion accepted a SET of statuses that included the defect, so it
+    // could not fail and held the 404-here/500-there split in place.
+    assert_eq!(
+        response.status(),
+        StatusCode::SERVICE_UNAVAILABLE,
+        "no model is resident: expected 503"
     );
 }
 

--- a/crates/aprender-serve/src/gguf/inference/generate_quantized.rs
+++ b/crates/aprender-serve/src/gguf/inference/generate_quantized.rs
@@ -1,4 +1,34 @@
 impl OwnedQuantizedModel {
+    /// How many tokens this request may actually generate, bounded by the context.
+    ///
+    /// Every generate entry point sizes the KV cache as `prompt.len() + max_tokens`
+    /// (`OwnedQuantizedKVCache::from_config`). `max_tokens` arrives straight from an
+    /// unauthenticated HTTP body, so without a bound the allocation is
+    /// caller-controlled and unbounded: `{"max_tokens":999999999}` asked the
+    /// allocator for 1,024,000,000,000 bytes and Rust's allocation-error handler
+    /// **aborted the whole server process** — one request, no reply, port dead
+    /// (aprender#2376 finding 9).
+    ///
+    /// A model cannot emit tokens past its own context window, so an over-large
+    /// `max_tokens` is clamped to what remains rather than rejected: every request
+    /// that worked before still works, and the KV cache can never exceed
+    /// `context_length` entries no matter what a client sends.
+    ///
+    /// # Errors
+    ///
+    /// [`RealizarError::ContextLimitExceeded`] when the PROMPT alone exceeds the
+    /// context window (GH-167) — that one is unsatisfiable, and callers map it to
+    /// HTTP 400 because it is determined entirely by the request.
+    fn effective_max_tokens(&self, prompt_len: usize, requested: usize) -> Result<usize> {
+        if prompt_len > self.config.context_length {
+            return Err(RealizarError::ContextLimitExceeded {
+                provided: prompt_len,
+                maximum: self.config.context_length,
+            });
+        }
+        Ok(requested.min(self.config.context_length - prompt_len))
+    }
+
     /// Get most likely next token
     ///
     /// # Errors
@@ -39,23 +69,19 @@ impl OwnedQuantizedModel {
             });
         }
 
-        // GH-167: Check context length before GPU dispatch to avoid cryptic CUDA errors
-        if prompt.len() > self.config.context_length {
-            return Err(RealizarError::ContextLimitExceeded {
-                provided: prompt.len(),
-                maximum: self.config.context_length,
-            });
-        }
+        // GH-167 + aprender#2376(9): the KV cache is sized prompt + max_tokens, so
+        // the budget is bounded by the context window before anything is allocated.
+        let max_tokens = self.effective_max_tokens(prompt.len(), config.max_tokens)?;
 
         let mut tokens = prompt.to_vec();
-        let max_len = prompt.len() + config.max_tokens;
+        let max_len = prompt.len() + max_tokens;
         // PMAT-819: seed the sampler RNG from config.seed so the OpenAI `seed`
         // API contract holds (same prompt+seed+params => same tokens). Greedy
         // (temperature==0 || top_k==1) never touches the RNG, so the default
         // config is byte-for-byte unchanged.
         let mut rng = StdRng::seed_from_u64(config.seed);
 
-        for _ in 0..config.max_tokens {
+        for _ in 0..max_tokens {
             // Forward pass with fused Q4_K ops (1.37x faster)
             let mut logits = self.forward(&tokens)?;
 
@@ -277,15 +303,11 @@ impl OwnedQuantizedModel {
             });
         }
 
-        // GH-167: Check context length before processing to avoid cryptic CUDA errors
-        if prompt.len() > self.config.context_length {
-            return Err(RealizarError::ContextLimitExceeded {
-                provided: prompt.len(),
-                maximum: self.config.context_length,
-            });
-        }
+        // GH-167 + aprender#2376(9): the KV cache is sized prompt + max_tokens, so
+        // the budget is bounded by the context window before anything is allocated.
+        let max_tokens = self.effective_max_tokens(prompt.len(), config.max_tokens)?;
 
-        let max_seq_len = prompt.len() + config.max_tokens;
+        let max_seq_len = prompt.len() + max_tokens;
         let mut cache = OwnedQuantizedKVCache::from_config(&self.config, max_seq_len);
         let mut tokens = prompt.to_vec();
         // PMAT-819: seeded sampler RNG (OpenAI `seed` determinism). This is the
@@ -311,7 +333,7 @@ impl OwnedQuantizedModel {
             eprintln!(
                 "[TRACE-CACHE] Prefill: {} tokens, max_gen={}",
                 prompt.len(),
-                config.max_tokens
+                max_tokens
             );
         }
 
@@ -341,7 +363,7 @@ impl OwnedQuantizedModel {
 
         // Generate new tokens
         // First iteration uses logits from prefill, subsequent use logits from forward pass
-        for gen_idx in 0..config.max_tokens {
+        for gen_idx in 0..max_tokens {
             let token_start = std::time::Instant::now();
             // DEBUG: Print logits info for first generated token
             if gen_idx == 0 && std::env::var("REALIZAR_DEBUG_LOGITS").is_ok() {
@@ -497,15 +519,11 @@ impl OwnedQuantizedModel {
             });
         }
 
-        // GH-167: Check context length before processing to avoid cryptic CUDA errors
-        if prompt.len() > self.config.context_length {
-            return Err(RealizarError::ContextLimitExceeded {
-                provided: prompt.len(),
-                maximum: self.config.context_length,
-            });
-        }
+        // GH-167 + aprender#2376(9): the KV cache is sized prompt + max_tokens, so
+        // the budget is bounded by the context window before anything is allocated.
+        let max_tokens = self.effective_max_tokens(prompt.len(), config.max_tokens)?;
 
-        let max_seq_len = prompt.len() + config.max_tokens;
+        let max_seq_len = prompt.len() + max_tokens;
         let mut cache = OwnedQuantizedKVCache::from_config(&self.config, max_seq_len);
         let mut tokens = prompt.to_vec();
         // PMAT-819: seeded sampler RNG (OpenAI `seed` determinism, streaming dense path).
@@ -530,7 +548,7 @@ impl OwnedQuantizedModel {
             eprintln!(
                 "[TRACE-CACHE] Prefill: {} tokens, max_gen={}",
                 prompt.len(),
-                config.max_tokens
+                max_tokens
             );
         }
 
@@ -558,7 +576,7 @@ impl OwnedQuantizedModel {
         }
 
         // Generate new tokens with streaming
-        for gen_idx in 0..config.max_tokens {
+        for gen_idx in 0..max_tokens {
             let token_start = std::time::Instant::now();
             // PMAT-814: apply repetition penalty in place over the recent context
             // BEFORE both greedy argmax and sampling (no-op when repeat_penalty == 1.0).


### PR DESCRIPTION
## What a user saw

Start the server the documented way against a GGUF model — the only way `apr serve run` is shown in the README and in the startup banner:

```
APR=<cargo install aprender 0.63.0>/bin/apr
M=/home/noah/.cache/pacha/models/d47927c5638f80ab.gguf
"$APR" serve run "$M" --port 18410 --host 127.0.0.1
```

`/health` reports the model is loaded and `/generate` returns tokens. Six other native routes on that same live process do not:

```
{"status":"ok","version":"0.63.0","compute_mode":"cpu","model_loaded":true,"uptime_sec":17.9}

POST /generate        -> {"token_ids":[...],"text":"What is 2+2? To solve the problem 2+2","num_generated":8} 200
POST /tokenize        -> {"error":"Model registry error: No model available"} 404
POST /batch/tokenize  -> {"error":"Model registry error: No model available"} 500
POST /batch/generate  -> {"error":"Model registry error: No model available"} 500
POST /stream/generate -> {"error":"Model registry error: No model available"} 404
POST /realize/generate-> {"error":"Model registry error: No model available"} 404
POST /realize/batch   -> {"error":"Model registry error: No model available"} 500
```

`/stream/generate` and `/batch/generate` are printed by the server's own startup banner as "SSE streaming" and "Batch inference".

And one unauthenticated request ended the process:

```
curl -X POST .../generate -d '{"prompt":"hi","max_tokens":999999999}'
-> curl: (52) Empty reply from server        curl_rc=52
serve.log: memory allocation of 1024000000000 bytes failed
health_after=000   curl_rc=7
ss -ltn | grep 18411  ->  PORT DEAD
```

## Root cause

`AppState::get_model()` (`crates/aprender-serve/src/api/mod_app_state_new.rs:111-134`) resolves only `self.model`, the dense f32 `Model`. That field is `None` for every `apr serve run model.gguf` — the weights live in `quantized_model`. `tokenize_handler`, `batch_tokenize_handler`, `stream_generate_handler` and `batch_generate_handler` all called it directly; only `generate_handler` had a quantized backend (`try_quantized_generate`, `api/batch.rs`). So the whole native surface was dead on the standard path while `/generate` worked, which is why `/health` and the banner both looked fine.

The process abort is `crates/aprender-serve/src/gguf/inference/generate_quantized.rs:288` — `let max_seq_len = prompt.len() + config.max_tokens;` feeding `OwnedQuantizedKVCache::from_config`. The guard above it only checked the prompt. `max_tokens` arrives verbatim from an unauthenticated request body, so the allocation size was caller-controlled: `(999999999 + 2) * 1024 = 1.024 TB`, and Rust's allocation-error handler aborts — no panic line, no 5xx, just a reset connection.

## After (same repro, binary built from this branch)

`apr 0.63.0 (7b4df4b5d)` — built from this branch's commit, `<target-dir>/release/apr`:

```
POST /tokenize        -> {"token_ids":[9707,1879],"num_tokens":2} 200
POST /batch/tokenize  -> {"results":[{"token_ids":[9707],"num_tokens":1},{"token_ids":[14615],"num_tokens":1}]} 200
POST /batch/generate  -> {"results":[{"token_ids":[...],"text":"What is 2+2? To determine the value","num_generated":4}]} 200
POST /stream/generate -> event: token
                         data: {"token_id":2014,"text":" To"}
                         ... event: done  data: {"num_generated":4}                                              200
POST /realize/batch   -> 200
POST /realize/embed   -> 503 {"error":"... /realize/embed needs a dense (.apr / .safetensors) model; this
                              server has a quantized model loaded"}
```

The killer request:

```
health_before=200
POST /generate {"prompt":"hi","max_tokens":999999999}
health_after=200
still generating -> {"token_ids":[...],"text":"What is 2+2? To determine the value of \\(2 +","num_generated":8} [200]
PORT ALIVE
```

Sampling fields, same server:

```
temp=-1.0   -> {"error":"temperature must be >= 0, got -1"} 400        (was 200 + multilingual garbage)
strategy=invalid_strategy -> {"error":"Invalid strategy: invalid_strategy"} 400
top_p=9.9   -> {"error":"top_p must be in (0, 1], got 9.9"} 400

reference temperature=0.0        -> "The capital of France is Paris. Paris is the largest"
strategy=greedy temp=2 top_k=500 -> "The capital of France is Paris. Paris is the largest"   (was "__\nA.\nRio and")
strategy=top_k seed=1            -> "The capital of France is\r\nReply Select, the answers"
strategy=top_k seed=2            -> "The capital of France is Paris.\nCompare the similarity or"
strategy=top_k seed=1 (again)    -> "The capital of France is\r\nReply Select, the answers"
strategy=top_p top_p=0.01        -> "The capital of France is Paris. Paris is the largest"
strategy=top_p top_p=1.0         -> "The capital of France is_LAYOUT Rahmen/utility.full_configuration GHC"

GET /models        -> ...,"format":"gguf",...      (was "unknown")
GET /realize/model -> ...,"format":"gguf",...      (agrees)

GET /nope/nope -> {"error":"not_found","message":"Route not found. Available routes are listed in `routes`.",
                   "routes":["GET /health","GET /health/live",...,"POST /api/generate"]} 404
```

## The clamp, not a rejection

`effective_max_tokens()` clamps `max_tokens` to what remains of the model's context window rather than 400-ing on it. A model cannot emit tokens past its own context, so clamping keeps every request that worked before working, while making the KV cache a property of the model instead of the request. I tried the reject-with-400 variant first and it turned two existing tests red for a legitimate reason — a default chat request (`max_tokens` 256) against a small-context model — which is exactly the compatibility break clamping avoids. A prompt that alone exceeds the context is still an error, and is now 400 rather than 500.

## Mutation check

Round A — revert the clamp, keep the tests:

```
---- test_generate_with_cache_clamps_max_tokens_to_context stdout ----
assertion `left == right` failed: prompt + generated must stop at context_length, never at max_tokens
  left: 1003
 right: 128
```

Round B — revert the routing / status / sampling / 404 changes, keep the tests. 11 of 17 go red with the exact 0.63.0 observations:

```
---- test_tokenize_works_on_quantized_server ----
  body: {"error":"Model registry error: No model available"}   left: 404  right: 200
---- test_batch_tokenize_works_on_quantized_server ----
  body: {"error":"Model registry error: No model available"}   left: 500  right: 200
---- test_stream_generate_works_on_quantized_server ----
  body: {"error":"Model registry error: No model available"}   left: 404  right: 200
---- test_batch_generate_works_on_quantized_server ----
  a banner-advertised route must work when a model is loaded   left: 503  right: 200
---- test_no_model_available_is_503_everywhere ----
  /tokenize must report a missing model as 503, got 404 Not Found
---- test_models_and_realize_model_agree_on_format ----
  left: "unknown"  right: "gguf"
---- test_greedy_strategy_is_argmax_over_http ----
  strategy=greedy must decode identically to temperature=0
  left:  "...\"text\":\"token5token34token134token63token138\"..."
  right: "...\"text\":\"token5\"..."
---- test_seed_changes_the_sample_over_http ----
  seed=1 and seed=2 must not be byte-identical
---- test_404_body_lists_routes / test_advertised_routes_are_all_mounted ----
  routes array in 404 body   (absent)
```

Round C — revert only the `ContextLimitExceeded -> 400` classification: `test_oversized_prompt_is_400_not_500` goes `left: 500, right: 400`.

Restored, and the restored tree is byte-identical to the pre-mutation diff. `cargo test -p aprender-serve --lib`: **15496 passed, 0 failed**.

## Tests that were holding the bug in place

22 existing assertions had to change. Every one asserted a *set* of statuses that included the defect — `assert!(status == OK || status == NOT_FOUND || status == INTERNAL_SERVER_ERROR || status == UNPROCESSABLE_ENTITY)` — against `AppState::demo_mock()`, a state with no model at all. They could not fail, and they were what let the 404-here/500-there split live. They now assert the single status that state can produce.

## Gates

- `cargo fmt --all -- --check` clean
- `cargo clippy -p aprender-serve --lib -- -D warnings` clean (`--all-targets` fails on pre-existing broken integration targets, untouched here)
- `cargo test -p aprender-serve --lib` — 15496 passed / 0 failed
- `cargo check -p apr-cli --lib` clean

## What this PR does NOT fix

- **Finding 3** (no cancellation on client disconnect) is untouched, and this PR sharpens it: a clamped `max_tokens=999999999` is no longer fatal but still generates up to the full 32768-token context, which occupies a core for well over 15 minutes after the client has gone. `--context-length 512` does not bound it — the flag does not reach `OwnedQuantizedModel.config.context_length`.
- **Finding 7** (400/415 error bodies are `text/plain` and leak serde internals; the GH-649 sanitizer only intercepts 422) — router-layer, separate change.
- **Finding 8** (three routers ship and only one is mounted per format, so `/`, `/ready`, `/predict`, `/transcribe` 404 on the GGUF path and the banner advertises `/v1/predict` unconditionally).
- **Finding 11** is half-fixed: the oversized-prompt rejection is now 400 instead of 500, but it still costs ~172 s of prefill before returning, and the message still says "Use --truncate", a CLI flag an HTTP client cannot act on.
- **Finding 1, `/realize/embed`** is not made to work: it needs `Model::forward_hidden`, which the quantized backend does not expose. It now returns 503 with a message naming the missing backend instead of 404 "No model available".

Refs #2376 (partial) — fixed: 1 (6 of its 7 routes), 2, 4, 5, 6, 9, 10, 12. Partial: 11 (status only). Not fixed: 3, 7, 8, and `/realize/embed` under finding 1.

Audit epic: #2373

🤖 Generated with [Claude Code](https://claude.com/claude-code)
