### PR TITLE
fix(lint): ten apr *-lint gates exited 0 on observations that asserted nothing

### DIFF
--- a/crates/apr-cli/src/commands/dry_sampling_lint.rs
+++ b/crates/apr-cli/src/commands/dry_sampling_lint.rs
@@ -27,7 +27,11 @@ use std::path::{Path, PathBuf};
 use serde_json::Value;
 
 use crate::commands::dry_sampling_classifier as clf;
+use crate::commands::lint_vacuity::{assert_not_vacuous, skipped_label, SectionRun};
 use crate::error::{CliError, Result};
+
+/// Each classifier reads exactly one top-level section of the same name.
+static SECTION_NAMES: [&str; 5] = ["params", "identity", "match_len", "penalty", "monotone"];
 
 pub(crate) fn run(observation_file: &Path, json: bool) -> Result<()> {
     if !observation_file.exists() {
@@ -48,7 +52,7 @@ pub(crate) fn run(observation_file: &Path, json: bool) -> Result<()> {
     let penalty = classify_penalty(&obs);
     let monotone = classify_monotone(&obs);
 
-    let fail_reasons: Vec<String> = [
+    let mut fail_reasons: Vec<String> = [
         params.as_ref().and_then(params_fail_reason),
         identity.as_ref().and_then(identity_fail_reason),
         match_len.as_ref().and_then(match_len_fail_reason),
@@ -61,6 +65,7 @@ pub(crate) fn run(observation_file: &Path, json: bool) -> Result<()> {
 
     print_report(
         observation_file,
+        &obs,
         params.as_ref(),
         identity.as_ref(),
         match_len.as_ref(),
@@ -68,6 +73,29 @@ pub(crate) fn run(observation_file: &Path, json: bool) -> Result<()> {
         monotone.as_ref(),
         json,
     );
+
+    // An all-skipped run asserts nothing about DRY sampling. Note this also
+    // catches the case where `params.base = 0.5` (a real violation) was hidden
+    // because an unrelated sibling field carried the wrong JSON type.
+    let ran = [
+        params.is_some(),
+        identity.is_some(),
+        match_len.is_some(),
+        penalty.is_some(),
+        monotone.is_some(),
+    ];
+    let sections: Vec<SectionRun> = SECTION_NAMES
+        .iter()
+        .zip(ran)
+        .map(|(name, ran)| SectionRun {
+            name,
+            keys: std::slice::from_ref(name),
+            ran,
+        })
+        .collect();
+    if let Err(reason) = assert_not_vacuous("FALSIFY-CRUX-C-23", &obs, &sections) {
+        fail_reasons.push(reason);
+    }
 
     if fail_reasons.is_empty() {
         Ok(())
@@ -243,6 +271,7 @@ fn monotone_fail_reason(o: &clf::MonotonicityOutcome) -> Option<String> {
 #[allow(clippy::too_many_arguments)]
 fn print_report(
     path: &Path,
+    obs: &Value,
     params: Option<&clf::DryParamOutcome>,
     identity: Option<&clf::IdentityOutcome>,
     match_len: Option<&MatchLenOutcome>,
@@ -265,18 +294,43 @@ fn print_report(
         );
     } else {
         println!("dry-sampling-lint report for {}", path.display());
-        print_line("  params:    ", params.map(|o| format!("{o:?}")));
-        print_line("  identity:  ", identity.map(|o| format!("{o:?}")));
-        print_line("  match_len: ", match_len.map(|o| format!("{o:?}")));
-        print_line("  penalty:   ", penalty.map(|o| format!("{o:?}")));
-        print_line("  monotone:  ", monotone.map(|o| format!("{o:?}")));
+        print_line(
+            "  params:    ",
+            params.map(|o| format!("{o:?}")),
+            obs,
+            "params",
+        );
+        print_line(
+            "  identity:  ",
+            identity.map(|o| format!("{o:?}")),
+            obs,
+            "identity",
+        );
+        print_line(
+            "  match_len: ",
+            match_len.map(|o| format!("{o:?}")),
+            obs,
+            "match_len",
+        );
+        print_line(
+            "  penalty:   ",
+            penalty.map(|o| format!("{o:?}")),
+            obs,
+            "penalty",
+        );
+        print_line(
+            "  monotone:  ",
+            monotone.map(|o| format!("{o:?}")),
+            obs,
+            "monotone",
+        );
     }
 }
 
-fn print_line(prefix: &str, v: Option<String>) {
+fn print_line(prefix: &str, v: Option<String>, obs: &Value, key: &str) {
     match v {
         Some(s) => println!("{prefix}{s}"),
-        None => println!("{prefix}(missing fields — classifier skipped)"),
+        None => println!("{prefix}{}", skipped_label(obs, &[key])),
     }
 }
 
@@ -306,11 +360,59 @@ mod tests {
         assert!(matches!(err, CliError::InvalidFormat(_)));
     }
 
+    // This test asserted `is_ok()` on `{}` and its comment ("no fail reasons →
+    // Ok") documented the defect as intended behaviour. A run in which no
+    // classifier reached a verdict has checked nothing.
     #[test]
-    fn empty_object_passes_with_no_gates() {
-        // No recognized sections → no fail reasons → Ok.
+    fn falsifier_empty_object_is_rejected() {
         let f = write_obs("{}");
-        assert!(run(f.path(), false).is_ok());
+        let err = run(f.path(), false).unwrap_err();
+        match err {
+            CliError::ValidationFailed(msg) => assert!(
+                msg.contains("has none of params/identity/match_len/penalty/monotone"),
+                "{msg}"
+            ),
+            other => panic!("expected ValidationFailed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn falsifier_unrelated_body_is_rejected() {
+        let f = write_obs(r#"{"unrelated": 123, "nonsense": "hello"}"#);
+        assert!(matches!(
+            run(f.path(), false).unwrap_err(),
+            CliError::ValidationFailed(_)
+        ));
+    }
+
+    // `base: 0.5` violates the DRY contract in all three bodies below. Only
+    // the well-typed one used to be caught; a wrong-typed *sibling* field
+    // suppressed the whole gate.
+    #[test]
+    fn falsifier_wrong_typed_sibling_does_not_suppress_a_real_violation() {
+        let ok_types =
+            write_obs(r#"{"params": {"multiplier": 0.8, "base": 0.5, "allowed_length": 2}}"#);
+        match run(ok_types.path(), false).unwrap_err() {
+            CliError::ValidationFailed(msg) => {
+                assert!(msg.contains("base=0.5 < 1.0"), "control: {msg}");
+            }
+            other => panic!("control: expected ValidationFailed, got {other:?}"),
+        }
+
+        for body in [
+            r#"{"params": {"multiplier": 0.8, "base": 0.5, "allowed_length": "2"}}"#,
+            r#"{"params": {"multiplier": 0.8, "base": 0.5, "allowed_length": -2}}"#,
+            r#"{"params": {"multiplier": "oops", "base": 0.5, "allowed_length": 2}}"#,
+        ] {
+            let f = write_obs(body);
+            match run(f.path(), false).unwrap_err() {
+                CliError::ValidationFailed(msg) => {
+                    assert!(msg.contains("present but unusable"), "{body}: {msg}");
+                    assert!(msg.contains("params"), "{body}: {msg}");
+                }
+                other => panic!("{body}: expected ValidationFailed, got {other:?}"),
+            }
+        }
     }
 
     #[test]

--- a/crates/apr-cli/src/commands/gbnf_lint.rs
+++ b/crates/apr-cli/src/commands/gbnf_lint.rs
@@ -27,7 +27,13 @@ use std::path::{Path, PathBuf};
 use serde_json::Value;
 
 use crate::commands::gbnf_classifier as clf;
+use crate::commands::lint_vacuity::{assert_not_vacuous, skipped_label, SectionRun};
 use crate::error::{CliError, Result};
+
+/// Top-level observation keys each classifier reads, in report order.
+const JSON_KEYS: &[&str] = &["output", "finish_reason"];
+const DIAGNOSTIC_KEYS: &[&str] = &["grammar_error"];
+const MASKING_KEYS: &[&str] = &["masking"];
 
 pub(crate) fn run(observation_file: &Path, json: bool) -> Result<()> {
     if !observation_file.exists() {
@@ -46,7 +52,7 @@ pub(crate) fn run(observation_file: &Path, json: bool) -> Result<()> {
     let err_diag = classify_error_diagnostic(&obs);
     let masking = classify_masking(&obs);
 
-    let fail_reasons: Vec<String> = [
+    let mut fail_reasons: Vec<String> = [
         json_out.as_ref().and_then(json_fail_reason),
         err_diag.as_ref().and_then(error_fail_reason),
         masking.as_ref().and_then(masking_fail_reason),
@@ -57,11 +63,38 @@ pub(crate) fn run(observation_file: &Path, json: bool) -> Result<()> {
 
     print_report(
         observation_file,
+        &obs,
         json_out.as_ref(),
         err_diag.as_ref(),
         masking.as_ref(),
         json,
     );
+
+    // A run in which no gate reached a verdict has proved nothing about the
+    // grammar-constrained decode; it must not exit 0.
+    if let Err(reason) = assert_not_vacuous(
+        "FALSIFY-CRUX-C-10",
+        &obs,
+        &[
+            SectionRun {
+                name: "json",
+                keys: JSON_KEYS,
+                ran: json_out.is_some(),
+            },
+            SectionRun {
+                name: "diagnostic",
+                keys: DIAGNOSTIC_KEYS,
+                ran: err_diag.is_some(),
+            },
+            SectionRun {
+                name: "masking",
+                keys: MASKING_KEYS,
+                ran: masking.is_some(),
+            },
+        ],
+    ) {
+        fail_reasons.push(reason);
+    }
 
     if fail_reasons.is_empty() {
         Ok(())
@@ -157,6 +190,7 @@ fn masking_fail_reason(o: &clf::IllegalTokenMaskingOutcome) -> Option<String> {
 
 fn print_report(
     path: &Path,
+    obs: &Value,
     json_out: Option<&clf::JsonGrammarOutputOutcome>,
     err_diag: Option<&clf::GrammarErrorDiagnosticOutcome>,
     masking: Option<&clf::IllegalTokenMaskingOutcome>,
@@ -175,16 +209,31 @@ fn print_report(
         );
     } else {
         println!("gbnf-lint report for {}", path.display());
-        print_line("  json:        ", json_out.map(|o| format!("{o:?}")));
-        print_line("  diagnostic:  ", err_diag.map(|o| format!("{o:?}")));
-        print_line("  masking:     ", masking.map(|o| format!("{o:?}")));
+        print_line(
+            "  json:        ",
+            json_out.map(|o| format!("{o:?}")),
+            obs,
+            JSON_KEYS,
+        );
+        print_line(
+            "  diagnostic:  ",
+            err_diag.map(|o| format!("{o:?}")),
+            obs,
+            DIAGNOSTIC_KEYS,
+        );
+        print_line(
+            "  masking:     ",
+            masking.map(|o| format!("{o:?}")),
+            obs,
+            MASKING_KEYS,
+        );
     }
 }
 
-fn print_line(prefix: &str, v: Option<String>) {
+fn print_line(prefix: &str, v: Option<String>, obs: &Value, keys: &[&str]) {
     match v {
         Some(s) => println!("{prefix}{s}"),
-        None => println!("{prefix}(missing fields — classifier skipped)"),
+        None => println!("{prefix}{}", skipped_label(obs, keys)),
     }
 }
 
@@ -214,10 +263,70 @@ mod tests {
         assert!(matches!(err, CliError::InvalidFormat(_)));
     }
 
+    // This test used to assert `is_ok()` on `{}` and so held the defect in
+    // place: an observation that engages no classifier proves nothing about
+    // the decode and must not exit 0.
     #[test]
-    fn empty_object_passes_no_gates() {
+    fn falsifier_empty_object_is_rejected() {
         let f = write_obs("{}");
-        assert!(run(f.path(), false).is_ok());
+        let err = run(f.path(), false).unwrap_err();
+        match err {
+            CliError::ValidationFailed(msg) => {
+                assert!(msg.contains("has none of json/diagnostic/masking"), "{msg}");
+            }
+            other => panic!("expected ValidationFailed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn falsifier_unrelated_body_is_rejected() {
+        let f = write_obs(r#"{"hello": "world", "nested": {"a": 1}}"#);
+        let err = run(f.path(), false).unwrap_err();
+        assert!(matches!(err, CliError::ValidationFailed(_)));
+    }
+
+    #[test]
+    fn falsifier_null_observation_is_rejected() {
+        let f = write_obs("null");
+        let err = run(f.path(), true).unwrap_err();
+        match err {
+            CliError::ValidationFailed(msg) => assert!(msg.contains("not a JSON object"), "{msg}"),
+            other => panic!("expected ValidationFailed, got {other:?}"),
+        }
+    }
+
+    // 0/1 and true/false express the same legal-token mask. The int form used
+    // to suppress the masking gate entirely, hiding a real violation.
+    #[test]
+    fn falsifier_int_legal_mask_does_not_suppress_the_masking_gate() {
+        let bools = write_obs(
+            r#"{"masking": {"logits": [1.0, 5.0, 2.0], "legal_mask": [true,false,true]}}"#,
+        );
+        let ints = write_obs(r#"{"masking": {"logits": [1.0, 5.0, 2.0], "legal_mask": [1,0,1]}}"#);
+        assert!(
+            run(bools.path(), false).is_err(),
+            "control: bool mask must fail"
+        );
+        let err = run(ints.path(), false).unwrap_err();
+        match err {
+            CliError::ValidationFailed(msg) => {
+                assert!(msg.contains("present but unusable"), "{msg}")
+            }
+            other => panic!("expected ValidationFailed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn falsifier_wrong_typed_finish_reason_is_rejected() {
+        let f = write_obs(r#"{"output": "{}", "finish_reason": 7}"#);
+        let err = run(f.path(), false).unwrap_err();
+        match err {
+            CliError::ValidationFailed(msg) => {
+                assert!(msg.contains("present but unusable"), "{msg}");
+                assert!(msg.contains("json"), "{msg}");
+            }
+            other => panic!("expected ValidationFailed, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/apr-cli/src/commands/hang_trace_lint.rs
+++ b/crates/apr-cli/src/commands/hang_trace_lint.rs
@@ -31,6 +31,17 @@ pub(crate) fn run(
     if !trace_dir.exists() {
         return Err(CliError::FileNotFound(PathBuf::from(trace_dir)));
     }
+    // `classify_timeout_dump` short-circuits to `Ok { ranks_seen: 0 }` at
+    // world_size 0, so an unset `${WORLD_SIZE}` expanding to 0 turned the whole
+    // timeout-dump gate into an unconditional pass whatever the directory held.
+    // ddp-metrics-lint already rejects world_size 0; this matches it.
+    if mode == HangMode::Timeout && world_size == 0 {
+        return Err(CliError::ValidationFailed(
+            "hang-trace-lint: --world-size 0 is not a world size — the timeout-dump gate would \
+             accept any directory contents. Pass the rank count the run was launched with."
+                .to_string(),
+        ));
+    }
     let entries = std::fs::read_dir(trace_dir)?
         .filter_map(|e| e.ok())
         .filter(|e| e.file_type().map(|t| t.is_file()).unwrap_or(false))
@@ -149,5 +160,50 @@ mod cov_tests {
         )
         .unwrap_err();
         assert!(matches!(err, CliError::FileNotFound(_)));
+    }
+
+    /// At `--world-size 0` the timeout-dump gate reported
+    /// `Ok { ranks_seen: 0 }` for three different directory states, each of
+    /// which it correctly rejects at world_size 2.
+    #[test]
+    fn falsifier_world_size_zero_is_rejected_not_silently_passed() {
+        let dir = tempfile::tempdir().unwrap();
+        let good = dir.path().join("rank0.py.txt");
+        std::fs::write(&good, "stack rank0").unwrap();
+        std::fs::write(dir.path().join("rank1.py.txt"), "stack rank1").unwrap();
+
+        // Control: the gate is live at a real world size.
+        assert!(run(dir.path(), HangMode::Timeout, 2, None, None, false).is_ok());
+
+        for state in ["populated", "truncated", "unrecognised-file"] {
+            match state {
+                "truncated" => std::fs::write(&good, "").unwrap(),
+                "unrecognised-file" => {
+                    std::fs::write(dir.path().join("random.txt"), "x").unwrap();
+                }
+                _ => {}
+            }
+            let err = run(dir.path(), HangMode::Timeout, 0, None, None, false).unwrap_err();
+            match err {
+                CliError::ValidationFailed(msg) => {
+                    assert!(msg.contains("--world-size 0 is not a world size"), "{msg}");
+                }
+                other => panic!("{state}: expected ValidationFailed, got {other:?}"),
+            }
+            // …and at a real world size the same directory does fail.
+            if state != "populated" {
+                assert!(
+                    run(dir.path(), HangMode::Timeout, 2, None, None, false).is_err(),
+                    "{state}: control must fail at world_size 2"
+                );
+            }
+        }
+    }
+
+    /// Success mode does not consult world_size, so it must stay reachable.
+    #[test]
+    fn success_mode_ignores_world_size_zero() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(run(dir.path(), HangMode::Success, 0, None, None, false).is_ok());
     }
 }

--- a/crates/apr-cli/src/commands/lint_vacuity.rs
+++ b/crates/apr-cli/src/commands/lint_vacuity.rs
@@ -1,0 +1,248 @@
+//! Shared vacuity guard for the observation-file lint family.
+//!
+//! Every `apr *-lint` command reads a captured JSON observation and dispatches
+//! a set of pure classifiers over it. Each classifier is optional: a section
+//! that is not present in the observation is skipped. That is the right
+//! behaviour for an *absent* section and the wrong behaviour for every other
+//! reason a classifier can fail to run.
+//!
+//! Two failure modes fell through the gap and made these commands
+//! unfalsifiable when wired into CI:
+//!
+//! 1. **Nothing was recognised.** `{}`, `{"typo": {...}}` or a JSON scalar
+//!    engages no classifier at all, so no failure reason is produced and the
+//!    command exits 0 having checked nothing.
+//! 2. **A section is present but unusable.** `{"range": {"p": "1.7"}}` has the
+//!    field the classifier wants; it is merely the wrong JSON type, so the
+//!    `?`-chain that reads it yields `None` and the gate is silently dropped —
+//!    including gates whose input carries a *real, detectable* violation.
+//!
+//! A lint that asserts nothing must not report success. [`assert_not_vacuous`]
+//! turns both cases into a hard error, and [`skipped_label`] stops the report
+//! from describing a wrong-typed field as "missing".
+
+use serde_json::Value;
+
+/// What a gate actually established about the observation.
+///
+/// `Vacuous` is deliberately distinct from `Pass`. The `[PASS]`/`[FAIL]`
+/// binary is what let 0.63.0 print `[PASS] offline … expected_count_ok=false`
+/// and `"passed": true` for a gate that compared nothing. All three verdicts
+/// are reported; only `Pass` exits 0.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Verdict {
+    Pass,
+    Fail,
+    Vacuous,
+}
+
+impl Verdict {
+    /// Report tag. `VACUOUS` is spelled out so an operator scanning CI logs
+    /// cannot mistake it for a pass.
+    pub(crate) fn tag(self) -> &'static str {
+        match self {
+            Verdict::Pass => "PASS",
+            Verdict::Fail => "FAIL",
+            Verdict::Vacuous => "VACUOUS",
+        }
+    }
+
+    /// Classify a gate result. A reason opening with `VACUOUS` means the gate
+    /// had nothing to check, as opposed to checking something and rejecting it.
+    pub(crate) fn of(result: &Result<String, String>) -> Verdict {
+        match result {
+            Ok(_) => Verdict::Pass,
+            Err(msg) if msg.starts_with("VACUOUS") => Verdict::Vacuous,
+            Err(_) => Verdict::Fail,
+        }
+    }
+}
+
+/// Report tag for a gate whose outcome string is already rendered.
+///
+/// Lets a command that stores only `passed: bool` still distinguish the third
+/// verdict, by recognising the `VACUOUS` prefix its own gate wrote.
+pub(crate) fn verdict_tag(passed: bool, outcome: &str) -> &'static str {
+    if passed {
+        Verdict::Pass.tag()
+    } else if outcome.starts_with("VACUOUS") {
+        Verdict::Vacuous.tag()
+    } else {
+        Verdict::Fail.tag()
+    }
+}
+
+/// JSON type name, for schema-error messages.
+pub(crate) fn json_type(v: &Value) -> &'static str {
+    match v {
+        Value::Null => "null",
+        Value::Bool(_) => "boolean",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
+/// One classifier's participation in a run.
+pub(crate) struct SectionRun {
+    /// Gate name as printed in the report (e.g. `"masking"`).
+    pub name: &'static str,
+    /// Top-level observation keys the classifier reads. The section counts as
+    /// *engaged* when the observation carries any of them.
+    pub keys: &'static [&'static str],
+    /// Whether the classifier actually produced an outcome.
+    pub ran: bool,
+}
+
+/// True when the observation carries at least one of `keys` (non-null).
+pub(crate) fn any_key_present(obs: &Value, keys: &[&str]) -> bool {
+    keys.iter()
+        .any(|k| !matches!(obs.get(k), None | Some(Value::Null)))
+}
+
+/// Report label for a classifier that produced no outcome.
+///
+/// Distinguishes "you did not supply this section" from "you supplied it and
+/// it is unusable" — the shipped binary printed the former for both, so a
+/// wrong-typed field read as an intentional omission.
+pub(crate) fn skipped_label(obs: &Value, keys: &[&str]) -> &'static str {
+    if any_key_present(obs, keys) {
+        "(PRESENT BUT UNUSABLE — missing or wrong-typed fields; NOT checked)"
+    } else {
+        "(section absent — not checked)"
+    }
+}
+
+/// Fail a run in which no gate could reach a verdict.
+///
+/// `Ok(())` only when at least one section ran and every *engaged* section ran.
+/// The returned string is the operator-facing reason.
+pub(crate) fn assert_not_vacuous(
+    falsify_prefix: &str,
+    obs: &Value,
+    sections: &[SectionRun],
+) -> Result<(), String> {
+    let all_names = sections
+        .iter()
+        .map(|s| s.name)
+        .collect::<Vec<_>>()
+        .join("/");
+
+    if !obs.is_object() {
+        return Err(format!(
+            "{falsify_prefix}: observation is not a JSON object, so none of {all_names} could be \
+             read — nothing was checked"
+        ));
+    }
+
+    let unusable: Vec<&str> = sections
+        .iter()
+        .filter(|s| !s.ran && any_key_present(obs, s.keys))
+        .map(|s| s.name)
+        .collect();
+    if !unusable.is_empty() {
+        return Err(format!(
+            "{falsify_prefix}: section(s) {} are present but unusable (a required field is \
+             missing or has the wrong JSON type), so those gates did not run — a present-but-\
+             malformed section is a schema error, not a skip",
+            unusable.join(", ")
+        ));
+    }
+
+    if !sections.iter().any(|s| s.ran) {
+        return Err(format!(
+            "{falsify_prefix}: observation has none of {all_names} — no gate ran, so nothing was \
+             checked (a lint that asserts nothing must not pass)"
+        ));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    const SECTIONS: &[&str] = &["alpha", "beta"];
+
+    fn sections(alpha_ran: bool, beta_ran: bool) -> Vec<SectionRun> {
+        vec![
+            SectionRun {
+                name: "alpha",
+                keys: &["alpha"],
+                ran: alpha_ran,
+            },
+            SectionRun {
+                name: "beta",
+                keys: &["beta"],
+                ran: beta_ran,
+            },
+        ]
+    }
+
+    #[test]
+    fn falsifier_empty_observation_is_vacuous() {
+        let err = assert_not_vacuous("X", &json!({}), &sections(false, false)).unwrap_err();
+        assert!(err.contains("has none of alpha/beta"), "{err}");
+        assert!(err.contains("nothing was checked"), "{err}");
+    }
+
+    #[test]
+    fn falsifier_unrecognised_keys_are_vacuous() {
+        let err =
+            assert_not_vacuous("X", &json!({"typo": 1}), &sections(false, false)).unwrap_err();
+        assert!(err.contains("has none of alpha/beta"), "{err}");
+    }
+
+    #[test]
+    fn falsifier_scalar_observation_is_vacuous() {
+        let err = assert_not_vacuous("X", &json!(42), &sections(false, false)).unwrap_err();
+        assert!(err.contains("not a JSON object"), "{err}");
+    }
+
+    #[test]
+    fn falsifier_present_but_unrunnable_section_is_an_error() {
+        // `alpha` is supplied; its classifier could not run. That is a schema
+        // error, not an omission.
+        let err = assert_not_vacuous(
+            "X",
+            &json!({"alpha": {"p": "1.7"}}),
+            &sections(false, false),
+        )
+        .unwrap_err();
+        assert!(err.contains("present but unusable"), "{err}");
+        assert!(err.contains("alpha"), "{err}");
+    }
+
+    #[test]
+    fn falsifier_unrunnable_section_fails_even_when_a_sibling_ran() {
+        let err = assert_not_vacuous(
+            "X",
+            &json!({"alpha": {"p": "1.7"}, "beta": {}}),
+            &sections(false, true),
+        )
+        .unwrap_err();
+        assert!(err.contains("present but unusable"), "{err}");
+    }
+
+    #[test]
+    fn control_one_section_that_ran_is_not_vacuous() {
+        assert!(assert_not_vacuous("X", &json!({"beta": {}}), &sections(false, true)).is_ok());
+    }
+
+    #[test]
+    fn skipped_label_distinguishes_absent_from_unusable() {
+        assert!(skipped_label(&json!({}), &["alpha"]).contains("absent"));
+        assert!(skipped_label(&json!({"alpha": "x"}), &["alpha"]).contains("UNUSABLE"));
+        // A null value reads as "not supplied", not as a malformed section.
+        assert!(skipped_label(&json!({"alpha": null}), &["alpha"]).contains("absent"));
+    }
+
+    #[test]
+    fn any_key_present_is_true_when_any_alias_is_supplied() {
+        assert!(any_key_present(&json!({"beta": 1}), SECTIONS));
+        assert!(!any_key_present(&json!({"gamma": 1}), SECTIONS));
+    }
+}

--- a/crates/apr-cli/src/commands/mod.rs
+++ b/crates/apr-cli/src/commands/mod.rs
@@ -83,6 +83,7 @@ pub(crate) mod kernel_explain;
 pub(crate) mod kv_timeline_classifier;
 pub(crate) mod kv_timeline_lint;
 pub(crate) mod lint;
+pub(crate) mod lint_vacuity;
 pub(crate) mod manifest;
 pub(crate) mod mcp;
 pub(crate) mod merge;

--- a/crates/apr-cli/src/commands/nf4_lint.rs
+++ b/crates/apr-cli/src/commands/nf4_lint.rs
@@ -6,7 +6,7 @@
 //! ```jsonc
 //! {
 //!   "codebook": {
-//!     "expected": [ -1.0, -0.6961..., ..., 1.0 ]   // 16 entries, bnb canonical
+//!     "expected": [ -1.0, -0.6961..., ..., 1.0 ]   // REQUIRED: 16 entries, bnb canonical
 //!   },
 //!   "roundtrip": {
 //!     "weights":    [f32, ...],
@@ -29,6 +29,7 @@
 //! Any missing top-level key is skipped. Non-zero exit + FALSIFY-CRUX-B-10
 //! stderr stamp on any failing gate.
 
+use crate::commands::lint_vacuity::{json_type, verdict_tag, Verdict};
 use crate::commands::nf4_classifier::{
     expected_nf4_storage_bytes, nearest_codebook_index, nf4_dequantize_block, nf4_quantize_block,
     rel_l2_error, NF4_CODEBOOK, NF4_DEFAULT_BLOCK_SIZE, NF4_MAX_REL_L2_ERROR_SYNTHETIC,
@@ -113,7 +114,7 @@ pub fn run(args: Nf4LintArgs) -> Result<(), String> {
         println!("{}", serde_json::to_string_pretty(&payload).unwrap());
     } else {
         for r in &reports {
-            let tag = if r.passed { "PASS" } else { "FAIL" };
+            let tag = verdict_tag(r.passed, &r.outcome);
             println!("[{tag}] {} ({}): {}", r.gate, r.falsify_id, r.outcome);
         }
     }
@@ -134,28 +135,85 @@ fn read_f32_array(v: &Value) -> Vec<f32> {
         .unwrap_or_default()
 }
 
-fn run_codebook_gate(v: &Value) -> (GateReport, Option<String>) {
-    let expected = v.get("expected").map(read_f32_array).unwrap_or_default();
-    let passed = if expected.is_empty() {
-        NF4_CODEBOOK.len() == 16
-    } else if expected.len() != NF4_CODEBOOK.len() {
-        false
-    } else {
-        expected
-            .iter()
-            .zip(NF4_CODEBOOK.iter())
-            .all(|(e, c)| (*e - *c).abs() < 1e-6)
-    };
-    let desc = if passed {
-        format!("codebook matches ({} entries)", NF4_CODEBOOK.len())
-    } else {
+/// Read the observation's `expected` codebook.
+///
+/// 0.63.0 funnelled "absent", "empty", "wrong type" and "misspelled key" into
+/// one empty `Vec`, whose branch then asserted `NF4_CODEBOOK.len() == 16` — a
+/// tautology over a compile-time constant. The gate printed "codebook matches
+/// (16 entries)" having compared nothing.
+fn parse_expected_codebook(v: &Value) -> Result<Vec<f32>, String> {
+    let obj = v.as_object().ok_or_else(|| {
         format!(
+            "codebook section must be a JSON object, got {}",
+            json_type(v)
+        )
+    })?;
+    let Some(expected) = obj.get("expected").filter(|e| !e.is_null()) else {
+        let keys: Vec<&str> = obj.keys().map(String::as_str).collect();
+        return Err(format!(
+            "VACUOUS: codebook section supplies no \"expected\" array (keys present: {keys:?}), \
+             so the NF4 codebook was compared against nothing"
+        ));
+    };
+    let arr = expected.as_array().ok_or_else(|| {
+        format!(
+            "codebook.expected must be an array of {} numbers, got {}",
+            NF4_CODEBOOK.len(),
+            json_type(expected)
+        )
+    })?;
+    if arr.is_empty() {
+        return Err(
+            "VACUOUS: codebook.expected is an empty array, so no entry was compared".to_string(),
+        );
+    }
+    arr.iter()
+        .enumerate()
+        .map(|(i, n)| {
+            n.as_f64().map(|f| f as f32).ok_or_else(|| {
+                format!(
+                    "codebook.expected[{i}] must be a number, got {}",
+                    json_type(n)
+                )
+            })
+        })
+        .collect()
+}
+
+fn compare_codebook(v: &Value) -> Result<String, String> {
+    let expected = parse_expected_codebook(v)?;
+    if expected.len() != NF4_CODEBOOK.len() {
+        return Err(format!(
             "codebook divergence (expected_len={}, got_len={})",
             expected.len(),
             NF4_CODEBOOK.len()
-        )
+        ));
+    }
+    if let Some((i, (e, c))) = expected
+        .iter()
+        .zip(NF4_CODEBOOK.iter())
+        .enumerate()
+        .find(|(_, (e, c))| (**e - **c).abs() >= 1e-6)
+        .map(|(i, pair)| (i, pair))
+    {
+        return Err(format!(
+            "codebook divergence at index {i}: expected {e}, got {c}"
+        ));
+    }
+    Ok(format!(
+        "supplied codebook compared entry-by-entry against the built-in NF4 table and matched \
+         ({} entries)",
+        NF4_CODEBOOK.len()
+    ))
+}
+
+fn run_codebook_gate(v: &Value) -> (GateReport, Option<String>) {
+    let result = compare_codebook(v);
+    let verdict = Verdict::of(&result);
+    let desc = match result {
+        Ok(msg) | Err(msg) => msg,
     };
-    let err = if passed {
+    let err = if verdict == Verdict::Pass {
         None
     } else {
         Some(format!(
@@ -167,7 +225,7 @@ fn run_codebook_gate(v: &Value) -> (GateReport, Option<String>) {
             gate: "codebook",
             falsify_id: "FALSIFY-CRUX-B-10-001",
             outcome: desc,
-            passed,
+            passed: verdict == Verdict::Pass,
         },
         err,
     )
@@ -351,11 +409,60 @@ mod tests {
         assert!(err.contains("none of codebook/roundtrip/storage/parity"));
     }
 
+    /// Was `codebook_default_passes_when_empty_expected`, asserting `is_ok()`
+    /// on `{"codebook": {}}` with the comment "gate checks
+    /// NF4_CODEBOOK.len()==16, which passes" — the test encoded the tautology
+    /// as intended behaviour and so held the defect in place.
     #[test]
-    fn codebook_default_passes_when_empty_expected() {
-        // Empty `expected` → gate checks NF4_CODEBOOK.len()==16, which passes.
-        let f = write_obs(r#"{"codebook": {}}"#);
-        assert!(run(args_for(&f)).is_ok());
+    fn falsifier_codebook_with_nothing_supplied_is_vacuous() {
+        for body in [
+            r#"{"codebook": {}}"#,                     // section present, empty
+            r#"{"codebook": {"expected": []}}"#,       // empty array
+            r#"{"codebook": {"expcted": [0.0,1.0]}}"#, // key misspelled
+        ] {
+            let f = write_obs(body);
+            let err = run(args_for(&f)).unwrap_err();
+            assert!(err.contains("VACUOUS"), "{body}: {err}");
+            assert!(err.contains("FALSIFY-CRUX-B-10-001"), "{body}: {err}");
+            assert!(
+                !err.contains("codebook matches"),
+                "{body}: must not claim a comparison happened: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn falsifier_wrong_typed_codebook_is_a_schema_error() {
+        for (body, want) in [
+            (
+                r#"{"codebook": {"expected": "oops"}}"#,
+                "codebook.expected must be an array",
+            ),
+            (
+                r#"{"codebook": {"expected": [0.0, "x"]}}"#,
+                "codebook.expected[1] must be a number",
+            ),
+            (
+                r#"{"codebook": "oops"}"#,
+                "codebook section must be a JSON object",
+            ),
+        ] {
+            let f = write_obs(body);
+            let err = run(args_for(&f)).unwrap_err();
+            assert!(err.contains(want), "{body}: expected {want:?}, got {err}");
+        }
+    }
+
+    /// A 16-entry codebook that differs in one entry must be caught — the
+    /// length check alone would wave it through.
+    #[test]
+    fn falsifier_codebook_with_one_wrong_entry_fails() {
+        let mut expected: Vec<f32> = NF4_CODEBOOK.to_vec();
+        expected[7] += 0.25;
+        let obs = serde_json::json!({ "codebook": { "expected": expected } });
+        let f = write_obs(&obs.to_string());
+        let err = run(args_for(&f)).unwrap_err();
+        assert!(err.contains("codebook divergence at index 7"), "{err}");
     }
 
     #[test]
@@ -427,7 +534,7 @@ mod tests {
     #[test]
     fn json_mode_renders_all_gates_ok() {
         let obs = serde_json::json!({
-            "codebook": {},
+            "codebook": { "expected": NF4_CODEBOOK.to_vec() },
             "parity": { "target": 1.0, "expected_index": 15 }
         });
         let f = write_obs(&obs.to_string());

--- a/crates/apr-cli/src/commands/ollama_tools_lint.rs
+++ b/crates/apr-cli/src/commands/ollama_tools_lint.rs
@@ -31,16 +31,27 @@ pub(crate) fn run(
         return Err(CliError::FileNotFound(PathBuf::from(response_file)));
     }
     let body = std::fs::read_to_string(response_file)?;
-    let declared: Vec<String> = match request_file {
-        Some(p) => load_declared_tool_names(p)?,
-        None => Vec::new(),
-    };
 
     if stream {
-        run_stream(&body, response_file, json)
-    } else {
-        run_non_streaming(&body, response_file, &declared, json)
+        // The streaming gate never consults the allowlist.
+        return run_stream(&body, response_file, json);
     }
+
+    // The allowlist gate runs unconditionally in non-streaming mode, so
+    // without a request file it compares every call against an empty declared
+    // set: a response WITH tool calls got `NoDeclaredTools` and one WITHOUT
+    // got `MissingToolCalls`. No response could pass, and the help text called
+    // the flag "Optional". It is required here.
+    let Some(request_file) = request_file else {
+        return Err(CliError::ValidationFailed(
+            "apr ollama-tools-lint: --request-file is required in non-streaming mode — the \
+             tool-name allowlist gate has nothing to check a response against without the \
+             request that declared the tools."
+                .to_string(),
+        ));
+    };
+    let declared = load_declared_tool_names(request_file)?;
+    run_non_streaming(&body, response_file, &declared, json)
 }
 
 fn run_non_streaming(body: &str, path: &Path, declared: &[String], json: bool) -> Result<()> {
@@ -207,10 +218,75 @@ mod cov_tests {
         );
         assert!(err.is_err());
     }
+    /// Was `run(f.path(), None, false, false)`, which passed for the wrong
+    /// reason once the missing-request-file check landed ahead of the parse.
     #[test]
     fn malformed_response_errors() {
         let f = w("not a json response");
-        let err = run(f.path(), None, false, false);
-        assert!(err.is_err());
+        let req = w(r#"{"tools":[]}"#);
+        let err = run(f.path(), Some(req.path()), false, false).unwrap_err();
+        assert!(matches!(err, CliError::InvalidFormat(_)));
+    }
+
+    const RESP_ONE_CALL: &str = r#"{"model":"q","created_at":"t","done":true,"message":
+        {"role":"assistant","content":"","tool_calls":
+        [{"function":{"name":"get_weather","arguments":{"city":"Paris"}}}]}}"#;
+
+    /// No response at all could pass `apr ollama-tools-lint --response-file X`:
+    /// with tool calls it was `NoDeclaredTools`, without them
+    /// `MissingToolCalls`. The command now says which flag is missing.
+    #[test]
+    fn falsifier_non_streaming_without_request_file_names_the_missing_flag() {
+        let two_calls = r#"{"model":"q","created_at":"t","done":true,"message":
+            {"role":"assistant","content":"","tool_calls":
+            [{"function":{"name":"a","arguments":{}}},{"function":{"name":"b","arguments":{}}}]}}"#;
+        let no_calls = r#"{"model":"q","created_at":"t","done":true,"message":
+            {"role":"assistant","content":"hello"}}"#;
+
+        for body in [RESP_ONE_CALL, two_calls, no_calls] {
+            let resp = w(body);
+            let err = run(resp.path(), None, false, false).unwrap_err();
+            match err {
+                CliError::ValidationFailed(msg) => {
+                    assert!(msg.contains("--request-file is required"), "{msg}");
+                    assert!(!msg.contains("NoDeclaredTools"), "{msg}");
+                }
+                other => panic!("expected ValidationFailed, got {other:?}"),
+            }
+        }
+    }
+
+    /// With the flag the gate is still a real gate in both directions.
+    #[test]
+    fn allowlist_gate_still_passes_and_still_catches_a_hallucinated_name() {
+        let resp = w(RESP_ONE_CALL);
+        let matching = w(r#"{"model":"q","tools":[{"type":"function",
+            "function":{"name":"get_weather","parameters":{}}}]}"#);
+        assert!(run(resp.path(), Some(matching.path()), false, false).is_ok());
+
+        let other = w(r#"{"model":"q","tools":[{"type":"function",
+            "function":{"name":"get_stock","parameters":{}}}]}"#);
+        let err = run(resp.path(), Some(other.path()), false, false).unwrap_err();
+        match err {
+            CliError::ValidationFailed(msg) => assert!(msg.contains("Hallucinated"), "{msg}"),
+            other => panic!("expected ValidationFailed, got {other:?}"),
+        }
+    }
+
+    /// Streaming mode does not use the allowlist, so it must stay usable
+    /// without the flag.
+    #[test]
+    fn stream_mode_does_not_require_request_file() {
+        let ndjson = w(concat!(
+            r#"{"model":"q","message":{"role":"assistant","content":"","tool_calls":"#,
+            r#"[{"function":{"name":"get_weather","arguments":{}}}]},"done":false}"#,
+            "\n",
+            r#"{"model":"q","message":{"role":"assistant","content":""},"done":true}"#,
+        ));
+        let res = run(ndjson.path(), None, true, false);
+        assert!(
+            !matches!(&res, Err(CliError::ValidationFailed(m)) if m.contains("--request-file")),
+            "stream mode must not demand --request-file: {res:?}"
+        );
     }
 }

--- a/crates/apr-cli/src/commands/otlp_lint.rs
+++ b/crates/apr-cli/src/commands/otlp_lint.rs
@@ -4,6 +4,10 @@
 //! dispatches the pure classifiers in `otlp_classifier`. Exits non-zero on
 //! any failure.
 //!
+//! Every check is opt-in, so at least one of `--require-apr-span`,
+//! `--require-genai-attrs` or `--expect-trace-id` must be given. A run that
+//! selects no gate is rejected rather than reported as clean.
+//!
 //! Spec: `contracts/crux-K-08-v1.yaml`. CRUX-SHIP-001 g2/g3 surface.
 
 use std::path::{Path, PathBuf};
@@ -34,6 +38,18 @@ pub(crate) fn run(
             otlp_file.display()
         ))
     })?;
+
+    // All three checks are opt-in, so the documented bare invocation
+    // `apr otlp-lint --otlp-file body.json` ran zero of them and exited 0 for
+    // any parseable JSON — including the scalar `42`. A CI step wired to it
+    // was permanently green.
+    if !require_apr_span && !require_genai_attrs && expect_trace_id.is_none() {
+        return Err(CliError::ValidationFailed(format!(
+            "otlp-lint: VACUOUS RUN — no gate was selected, so nothing in {} was checked. Pass at \
+             least one of --require-apr-span, --require-genai-attrs or --expect-trace-id <ID>.",
+            otlp_file.display()
+        )));
+    }
 
     let span = if require_apr_span {
         Some(classify_span_present(&body, K08_ROOT_SPAN_NAME))
@@ -130,9 +146,46 @@ mod cov_tests {
         let err = run(f.path(), false, false, None, false);
         assert!(err.is_err());
     }
+    /// Was `empty_json_object_runs`, which discarded the result entirely and
+    /// so asserted nothing about the very command whose job is to assert.
     #[test]
-    fn empty_json_object_runs() {
-        let f = w("{}");
-        let _ = run(f.path(), false, false, None, true);
+    fn falsifier_no_gate_flags_is_a_vacuous_run() {
+        // Six bodies the 0.63.0 binary all accepted with rc=0 and a report
+        // header that reads as a clean PASS.
+        for body in [
+            "{}",
+            r#"{"totally":"unrelated"}"#,
+            "[]",
+            r#""str""#,
+            "42",
+            "false",
+        ] {
+            let f = w(body);
+            for json in [false, true] {
+                let err = run(f.path(), false, false, None, json).unwrap_err();
+                match err {
+                    CliError::ValidationFailed(msg) => {
+                        assert!(msg.contains("VACUOUS RUN"), "{body}: {msg}");
+                        assert!(msg.contains("--require-apr-span"), "{body}: {msg}");
+                    }
+                    other => panic!("{body}: expected ValidationFailed, got {other:?}"),
+                }
+            }
+        }
+    }
+
+    /// The gates themselves still work, and an armed run on a good body still
+    /// passes — the fix is to the default, not to the checks.
+    #[test]
+    fn armed_gate_still_distinguishes_good_from_bad() {
+        let bad = w("[]");
+        assert!(run(bad.path(), true, false, None, false).is_err());
+
+        let good = w(r#"{"resourceSpans":[{"scopeSpans":[{"spans":[
+            {"name":"apr.inference","traceId":"0123456789abcdef0123456789abcdef"}]}]}]}"#);
+        assert!(
+            run(good.path(), true, false, None, false).is_ok(),
+            "an armed span-present gate must still pass a well-formed body"
+        );
     }
 }

--- a/crates/apr-cli/src/commands/tool_use_lint.rs
+++ b/crates/apr-cli/src/commands/tool_use_lint.rs
@@ -32,8 +32,12 @@ use std::path::{Path, PathBuf};
 
 use serde_json::Value;
 
+use crate::commands::lint_vacuity::{assert_not_vacuous, skipped_label, SectionRun};
 use crate::commands::tool_use_classifier as clf;
 use crate::error::{CliError, Result};
+
+/// Each classifier reads exactly one top-level section of the same name.
+static SECTION_NAMES: [&str; 3] = ["shape", "schema", "passthrough"];
 
 pub(crate) fn run(observation_file: &Path, json: bool) -> Result<()> {
     if !observation_file.exists() {
@@ -52,7 +56,7 @@ pub(crate) fn run(observation_file: &Path, json: bool) -> Result<()> {
     let schema = classify_schema(&obs);
     let passthrough = classify_passthrough(&obs);
 
-    let fail_reasons: Vec<String> = [
+    let mut fail_reasons: Vec<String> = [
         shape.as_ref().and_then(shape_fail_reason),
         schema.as_ref().and_then(schema_fail_reason),
         passthrough.as_ref().and_then(passthrough_fail_reason),
@@ -63,11 +67,28 @@ pub(crate) fn run(observation_file: &Path, json: bool) -> Result<()> {
 
     print_report(
         observation_file,
+        &obs,
         shape.as_ref(),
         schema.as_ref(),
         passthrough.as_ref(),
         json,
     );
+
+    // CRUX-C-11 is a falsifier surface: a green run is read as a discharged
+    // proof obligation, so a run that discharged nothing must be red.
+    let ran = [shape.is_some(), schema.is_some(), passthrough.is_some()];
+    let sections: Vec<SectionRun> = SECTION_NAMES
+        .iter()
+        .zip(ran)
+        .map(|(name, ran)| SectionRun {
+            name,
+            keys: std::slice::from_ref(name),
+            ran,
+        })
+        .collect();
+    if let Err(reason) = assert_not_vacuous("FALSIFY-CRUX-C-11", &obs, &sections) {
+        fail_reasons.push(reason);
+    }
 
     if fail_reasons.is_empty() {
         Ok(())
@@ -202,6 +223,7 @@ fn passthrough_fail_reason(o: &clf::NoToolsPassthroughOutcome) -> Option<String>
 
 fn print_report(
     path: &Path,
+    obs: &Value,
     shape: Option<&clf::ToolCallsShapeOutcome>,
     schema: Option<&clf::SchemaValidationOutcome>,
     passthrough: Option<&clf::NoToolsPassthroughOutcome>,
@@ -220,16 +242,31 @@ fn print_report(
         );
     } else {
         println!("tool-use-lint report for {}", path.display());
-        print_line("  shape:       ", shape.map(|o| format!("{o:?}")));
-        print_line("  schema:      ", schema.map(|o| format!("{o:?}")));
-        print_line("  passthrough: ", passthrough.map(|o| format!("{o:?}")));
+        print_line(
+            "  shape:       ",
+            shape.map(|o| format!("{o:?}")),
+            obs,
+            "shape",
+        );
+        print_line(
+            "  schema:      ",
+            schema.map(|o| format!("{o:?}")),
+            obs,
+            "schema",
+        );
+        print_line(
+            "  passthrough: ",
+            passthrough.map(|o| format!("{o:?}")),
+            obs,
+            "passthrough",
+        );
     }
 }
 
-fn print_line(prefix: &str, v: Option<String>) {
+fn print_line(prefix: &str, v: Option<String>, obs: &Value, key: &str) {
     match v {
         Some(s) => println!("{prefix}{s}"),
-        None => println!("{prefix}(missing fields — classifier skipped)"),
+        None => println!("{prefix}{}", skipped_label(obs, &[key])),
     }
 }
 
@@ -259,15 +296,69 @@ mod tests {
         assert!(matches!(err, CliError::InvalidFormat(_)));
     }
 
+    /// Both of these asserted `is_ok()` on `{}`. CRUX-C-11 is a falsifier
+    /// surface, so a green run is read as a discharged proof obligation —
+    /// these two tests certified that an observation asserting nothing
+    /// discharged it.
     #[test]
-    fn empty_object_passes_no_gates() {
-        let f = write_obs("{}");
-        assert!(run(f.path(), false).is_ok());
+    fn falsifier_empty_object_is_rejected_in_both_output_modes() {
+        for json in [false, true] {
+            let f = write_obs("{}");
+            match run(f.path(), json).unwrap_err() {
+                CliError::ValidationFailed(msg) => assert!(
+                    msg.contains("has none of shape/schema/passthrough"),
+                    "json={json}: {msg}"
+                ),
+                other => panic!("json={json}: expected ValidationFailed, got {other:?}"),
+            }
+        }
     }
 
     #[test]
-    fn empty_object_json_mode_passes() {
-        let f = write_obs("{}");
-        assert!(run(f.path(), true).is_ok());
+    fn falsifier_section_name_typo_is_rejected() {
+        let f = write_obs(
+            r#"{"shpae":{"declared_tools":[],"tool_calls":[],"finish_reason":"tool_calls"}}"#,
+        );
+        match run(f.path(), false).unwrap_err() {
+            CliError::ValidationFailed(msg) => {
+                assert!(msg.contains("no gate ran"), "{msg}");
+            }
+            other => panic!("expected ValidationFailed, got {other:?}"),
+        }
+    }
+
+    /// A present-but-wrong-typed section is a schema error, not a skip.
+    #[test]
+    fn falsifier_wrong_typed_section_is_rejected() {
+        for body in [
+            r#"{"shape":{"declared_tools":[],"tool_calls":"notarray","finish_reason":"tool_calls"}}"#,
+            r#"{"schema":{"parameters":{"type":"object"},"arguments":123}}"#,
+        ] {
+            let f = write_obs(body);
+            match run(f.path(), false).unwrap_err() {
+                CliError::ValidationFailed(msg) => {
+                    assert!(msg.contains("present but unusable"), "{body}: {msg}");
+                }
+                other => panic!("{body}: expected ValidationFailed, got {other:?}"),
+            }
+        }
+    }
+
+    /// Control: a well-formed violating observation still fails through the
+    /// classifier, not through the vacuity guard.
+    #[test]
+    fn well_formed_violation_still_reports_the_real_reason() {
+        let f = write_obs(
+            r#"{"shape":{"declared_tools":[{"name":"get_weather","parameters":{"type":"object"}}],
+                "tool_calls":[{"id":"c1","type":"function","name":"NOT_DECLARED","arguments":"{}"}],
+                "finish_reason":"tool_calls"}}"#,
+        );
+        match run(f.path(), false).unwrap_err() {
+            CliError::ValidationFailed(msg) => {
+                assert!(msg.contains("NOT_DECLARED"), "{msg}");
+                assert!(!msg.contains("present but unusable"), "{msg}");
+            }
+            other => panic!("expected ValidationFailed, got {other:?}"),
+        }
     }
 }

--- a/crates/apr-cli/src/commands/typical_p_lint.rs
+++ b/crates/apr-cli/src/commands/typical_p_lint.rs
@@ -22,8 +22,12 @@ use std::path::{Path, PathBuf};
 
 use serde_json::Value;
 
+use crate::commands::lint_vacuity::{assert_not_vacuous, skipped_label, SectionRun};
 use crate::commands::typical_p_classifier as clf;
 use crate::error::{CliError, Result};
+
+/// Each classifier reads exactly one top-level section of the same name.
+static SECTION_NAMES: [&str; 5] = ["range", "identity", "mass", "sort", "renorm"];
 
 pub(crate) fn run(observation_file: &Path, json: bool) -> Result<()> {
     if !observation_file.exists() {
@@ -44,7 +48,7 @@ pub(crate) fn run(observation_file: &Path, json: bool) -> Result<()> {
     let sort = classify_sort(&obs);
     let renorm = classify_renorm(&obs);
 
-    let fail_reasons: Vec<String> = [
+    let mut fail_reasons: Vec<String> = [
         range.as_ref().and_then(range_fail_reason),
         identity.as_ref().and_then(identity_fail_reason),
         mass.as_ref().and_then(mass_fail_reason),
@@ -57,6 +61,7 @@ pub(crate) fn run(observation_file: &Path, json: bool) -> Result<()> {
 
     print_report(
         observation_file,
+        &obs,
         range.as_ref(),
         identity.as_ref(),
         mass.as_ref(),
@@ -64,6 +69,28 @@ pub(crate) fn run(observation_file: &Path, json: bool) -> Result<()> {
         renorm.as_ref(),
         json,
     );
+
+    // `{"range": {"p": "1.7"}}` carries the same violation as `{"range":
+    // {"p": 1.7}}`; only the type differs. Neither may exit 0.
+    let ran = [
+        range.is_some(),
+        identity.is_some(),
+        mass.is_some(),
+        sort.is_some(),
+        renorm.is_some(),
+    ];
+    let sections: Vec<SectionRun> = SECTION_NAMES
+        .iter()
+        .zip(ran)
+        .map(|(name, ran)| SectionRun {
+            name,
+            keys: std::slice::from_ref(name),
+            ran,
+        })
+        .collect();
+    if let Err(reason) = assert_not_vacuous("FALSIFY-CRUX-C-22", &obs, &sections) {
+        fail_reasons.push(reason);
+    }
 
     if fail_reasons.is_empty() {
         Ok(())
@@ -216,6 +243,7 @@ fn renorm_fail_reason(o: &clf::RenormOutcome) -> Option<String> {
 #[allow(clippy::too_many_arguments)]
 fn print_report(
     path: &Path,
+    obs: &Value,
     range: Option<&clf::TypicalPRangeOutcome>,
     identity: Option<&clf::IdentityOutcome>,
     mass: Option<&clf::MassCoverageOutcome>,
@@ -238,18 +266,33 @@ fn print_report(
         );
     } else {
         println!("typical-p-lint report for {}", path.display());
-        print_line("  range:    ", range.map(|o| format!("{o:?}")));
-        print_line("  identity: ", identity.map(|o| format!("{o:?}")));
-        print_line("  mass:     ", mass.map(|o| format!("{o:?}")));
-        print_line("  sort:     ", sort.map(|o| format!("{o:?}")));
-        print_line("  renorm:   ", renorm.map(|o| format!("{o:?}")));
+        print_line(
+            "  range:    ",
+            range.map(|o| format!("{o:?}")),
+            obs,
+            "range",
+        );
+        print_line(
+            "  identity: ",
+            identity.map(|o| format!("{o:?}")),
+            obs,
+            "identity",
+        );
+        print_line("  mass:     ", mass.map(|o| format!("{o:?}")), obs, "mass");
+        print_line("  sort:     ", sort.map(|o| format!("{o:?}")), obs, "sort");
+        print_line(
+            "  renorm:   ",
+            renorm.map(|o| format!("{o:?}")),
+            obs,
+            "renorm",
+        );
     }
 }
 
-fn print_line(prefix: &str, v: Option<String>) {
+fn print_line(prefix: &str, v: Option<String>, obs: &Value, key: &str) {
     match v {
         Some(s) => println!("{prefix}{s}"),
-        None => println!("{prefix}(missing fields — classifier skipped)"),
+        None => println!("{prefix}{}", skipped_label(obs, &[key])),
     }
 }
 
@@ -279,10 +322,56 @@ mod tests {
         assert!(matches!(err, CliError::InvalidFormat(_)));
     }
 
+    // Was `assert!(run(...).is_ok())` on `{}` — an observation with no
+    // recognised section runs zero classifiers and proves nothing.
     #[test]
-    fn empty_object_passes_no_gates() {
+    fn falsifier_empty_object_is_rejected() {
         let f = write_obs("{}");
-        assert!(run(f.path(), false).is_ok());
+        match run(f.path(), false).unwrap_err() {
+            CliError::ValidationFailed(msg) => assert!(
+                msg.contains("has none of range/identity/mass/sort/renorm"),
+                "{msg}"
+            ),
+            other => panic!("expected ValidationFailed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn falsifier_typo_in_section_name_is_rejected() {
+        let f = write_obs(r#"{"rnage": {"p": 1.7}}"#);
+        assert!(matches!(
+            run(f.path(), false).unwrap_err(),
+            CliError::ValidationFailed(_)
+        ));
+    }
+
+    // p=1.7 is out of range however it is spelled. The quoted form used to
+    // exit 0 while the numeric form exited 5.
+    #[test]
+    fn falsifier_quoted_p_carries_the_same_violation_as_numeric_p() {
+        let numeric = write_obs(r#"{"range": {"p": 1.7}}"#);
+        match run(numeric.path(), false).unwrap_err() {
+            CliError::ValidationFailed(msg) => {
+                assert!(msg.contains("p=1.7 > 1.0"), "control: {msg}");
+            }
+            other => panic!("control: expected ValidationFailed, got {other:?}"),
+        }
+
+        for body in [
+            r#"{"range": {"p": "1.7"}}"#,
+            r#"{"range": {"p": null}}"#,
+            r#"{"range": {"p": [1.7]}}"#,
+            r#"{"range": "nope"}"#,
+        ] {
+            let f = write_obs(body);
+            match run(f.path(), false).unwrap_err() {
+                CliError::ValidationFailed(msg) => {
+                    assert!(msg.contains("present but unusable"), "{body}: {msg}");
+                    assert!(msg.contains("range"), "{body}: {msg}");
+                }
+                other => panic!("{body}: expected ValidationFailed, got {other:?}"),
+            }
+        }
     }
 
     #[test]

--- a/crates/apr-cli/src/commands/unified_search_lint.rs
+++ b/crates/apr-cli/src/commands/unified_search_lint.rs
@@ -21,7 +21,14 @@
 //!
 //! Any missing top-level key is skipped. Non-zero exit + FALSIFY-CRUX-A-23
 //! stderr stamp on any failing gate.
+//!
+//! A gate reaches one of three verdicts, not two. `PASS` means every supplied
+//! expectation held; `FAIL` means one did not; `VACUOUS` means the section
+//! supplied no expectation to check (or supplied one the parser could not
+//! read), so the gate proved nothing. `VACUOUS` exits non-zero: a falsifier
+//! that asserted nothing must not be recorded as a discharged obligation.
 
+use crate::commands::lint_vacuity::{json_type, Verdict};
 use crate::commands::search_merge::{merge_search_results, MergedRow, SearchHit, Source};
 use serde_json::Value;
 use std::collections::BTreeMap;
@@ -39,6 +46,7 @@ struct GateReport {
     gate: &'static str,
     falsify_id: &'static str,
     outcome: String,
+    verdict: &'static str,
     passed: bool,
 }
 
@@ -61,18 +69,16 @@ pub fn run(args: UnifiedSearchLintArgs) -> Result<(), String> {
     let mut reports: Vec<GateReport> = Vec::new();
     let mut failures: Vec<String> = Vec::new();
 
-    if let Some(v) = obs.get("offline") {
-        let (r, err) = run_offline_gate(v);
-        reports.push(r);
-        if let Some(e) = err {
-            failures.push(e);
-        }
-    }
-    if let Some(v) = obs.get("dedup") {
-        let (r, err) = run_dedup_gate(v);
-        reports.push(r);
-        if let Some(e) = err {
-            failures.push(e);
+    for (key, gate, falsify_id) in [
+        ("offline", "offline", "FALSIFY-CRUX-A-23-001"),
+        ("dedup", "dedup", "FALSIFY-CRUX-A-23-002"),
+    ] {
+        if let Some(v) = obs.get(key) {
+            let (r, err) = run_gate(gate, falsify_id, v);
+            reports.push(r);
+            if let Some(e) = err {
+                failures.push(e);
+            }
         }
     }
 
@@ -88,8 +94,10 @@ pub fn run(args: UnifiedSearchLintArgs) -> Result<(), String> {
         println!("{}", serde_json::to_string_pretty(&payload).unwrap());
     } else {
         for r in &reports {
-            let tag = if r.passed { "PASS" } else { "FAIL" };
-            println!("[{tag}] {} ({}): {}", r.gate, r.falsify_id, r.outcome);
+            println!(
+                "[{}] {} ({}): {}",
+                r.verdict, r.gate, r.falsify_id, r.outcome
+            );
         }
     }
 
@@ -99,35 +107,90 @@ pub fn run(args: UnifiedSearchLintArgs) -> Result<(), String> {
     Ok(())
 }
 
-fn parse_hits(v: Option<&Value>) -> Vec<SearchHit> {
-    v.and_then(|x| x.as_array())
-        .map(|a| {
-            a.iter()
-                .filter_map(|h| {
-                    let repo = h.get("repo")?.as_str()?.to_string();
-                    let downloads = h.get("downloads").and_then(|x| x.as_u64()).unwrap_or(0);
-                    let likes = h.get("likes").and_then(|x| x.as_u64()).unwrap_or(0);
-                    let cached = h.get("cached").and_then(|x| x.as_bool()).unwrap_or(false);
-                    Some(SearchHit {
-                        repo,
-                        downloads,
-                        likes,
-                        cached,
-                    })
-                })
-                .collect()
+/// Parse a `hub`/`local` hit array.
+///
+/// Every wrong JSON type is an error. The 0.63.0 binary used `filter_map` here,
+/// so a hit whose `repo` was not a string vanished from the merged rows and
+/// silently changed the very count the gate compares against.
+fn parse_hits(field: &str, v: Option<&Value>) -> Result<Vec<SearchHit>, String> {
+    let Some(v) = v else {
+        return Ok(Vec::new());
+    };
+    if v.is_null() {
+        return Ok(Vec::new());
+    }
+    let arr = v
+        .as_array()
+        .ok_or_else(|| format!("{field} must be an array of hits, got {}", json_type(v)))?;
+    arr.iter()
+        .enumerate()
+        .map(|(i, h)| {
+            let repo = h
+                .get("repo")
+                .and_then(Value::as_str)
+                .ok_or_else(|| format!("{field}[{i}] has no string \"repo\" field"))?
+                .to_string();
+            let downloads = parse_u64_field(h, &format!("{field}[{i}].downloads"))?.unwrap_or(0);
+            let likes = parse_u64_field(h, &format!("{field}[{i}].likes"))?.unwrap_or(0);
+            let cached = match h.get("cached") {
+                None | Some(Value::Null) => false,
+                Some(c) => c.as_bool().ok_or_else(|| {
+                    format!(
+                        "{field}[{i}].cached must be a boolean, got {}",
+                        json_type(c)
+                    )
+                })?,
+            };
+            Ok(SearchHit {
+                repo,
+                downloads,
+                likes,
+                cached,
+            })
         })
-        .unwrap_or_default()
+        .collect()
 }
 
-fn parse_expected_sources(v: Option<&Value>) -> BTreeMap<String, String> {
-    v.and_then(|x| x.as_object())
-        .map(|o| {
-            o.iter()
-                .filter_map(|(k, val)| val.as_str().map(|s| (k.clone(), s.to_string())))
-                .collect()
+/// Read `<obj>.<last path segment>` as a `u64`, erroring on a wrong type.
+fn parse_u64_field(obj: &Value, path: &str) -> Result<Option<u64>, String> {
+    let key = path.rsplit('.').next().unwrap_or(path);
+    match obj.get(key) {
+        None | Some(Value::Null) => Ok(None),
+        Some(n) => n.as_u64().map(Some).ok_or_else(|| {
+            format!(
+                "{path} must be a non-negative integer, got {} ({n})",
+                json_type(n)
+            )
+        }),
+    }
+}
+
+/// Parse `expected_sources`. A wrong-typed map (or entry) is an error, never
+/// an empty map — an empty map silently disarms the whole source comparison.
+fn parse_expected_sources(v: Option<&Value>) -> Result<BTreeMap<String, String>, String> {
+    let Some(v) = v else {
+        return Ok(BTreeMap::new());
+    };
+    if v.is_null() {
+        return Ok(BTreeMap::new());
+    }
+    let obj = v.as_object().ok_or_else(|| {
+        format!(
+            "expected_sources must be an object of repo -> source, got {}",
+            json_type(v)
+        )
+    })?;
+    obj.iter()
+        .map(|(k, val)| {
+            let s = val.as_str().ok_or_else(|| {
+                format!(
+                    "expected_sources[{k:?}] must be a string, got {}",
+                    json_type(val)
+                )
+            })?;
+            Ok((k.clone(), s.to_string()))
         })
-        .unwrap_or_default()
+        .collect()
 }
 
 fn source_tag(s: Source) -> &'static str {
@@ -143,6 +206,15 @@ fn compare_merge(
     expected_count: Option<u64>,
     expected_sources: &BTreeMap<String, String>,
 ) -> Result<String, String> {
+    // A section that supplies no expectation merges rows and compares nothing.
+    // 0.63.0 rendered that as `[PASS] … expected_count_ok=false sources_ok=0`.
+    if expected_count.is_none() && expected_sources.is_empty() {
+        return Err(format!(
+            "VACUOUS: section supplies neither expected_count nor expected_sources, so the {} \
+             merged row(s) were compared against nothing — a gate that asserts nothing cannot pass",
+            rows.len()
+        ));
+    }
     if let Some(want) = expected_count {
         if rows.len() as u64 != want {
             return Err(format!(
@@ -168,65 +240,57 @@ fn compare_merge(
         }
     }
     Ok(format!(
-        "rows={} expected_count_ok={} sources_ok={}",
+        "rows={} expected_count={} expected_sources={} — every supplied expectation held",
         rows.len(),
-        expected_count.is_some(),
+        expected_count.map_or_else(|| "(not supplied)".to_string(), |c| c.to_string()),
         expected_sources.len()
     ))
 }
 
-fn run_offline_gate(v: &Value) -> (GateReport, Option<String>) {
-    let hub = parse_hits(v.get("hub")); // absent → empty (offline)
-    let local = parse_hits(v.get("local"));
-    let expected_count = v.get("expected_count").and_then(|x| x.as_u64());
-    let expected_sources = parse_expected_sources(v.get("expected_sources"));
-
-    let rows = merge_search_results(&hub, &local);
-    let (passed, desc) = match compare_merge(&rows, expected_count, &expected_sources) {
-        Ok(msg) => (true, msg),
-        Err(msg) => (false, msg),
+/// Evaluate one gate section. Schema errors, vacuity and genuine violations
+/// are all non-zero; only a section that supplied an expectation and met it
+/// reaches `Verdict::Pass`.
+fn run_gate(
+    gate: &'static str,
+    falsify_id: &'static str,
+    v: &Value,
+) -> (GateReport, Option<String>) {
+    let result = evaluate_section(v);
+    let verdict = Verdict::of(&result);
+    let desc = match result {
+        Ok(msg) | Err(msg) => msg,
     };
-    let err = if passed {
+    let err = if verdict == Verdict::Pass {
         None
     } else {
-        Some(format!("FALSIFY-CRUX-A-23-001 offline gate failed: {desc}"))
+        Some(format!("{falsify_id} {gate} gate failed: {desc}"))
     };
     (
         GateReport {
-            gate: "offline",
-            falsify_id: "FALSIFY-CRUX-A-23-001",
+            gate,
+            falsify_id,
             outcome: desc,
-            passed,
+            verdict: verdict.tag(),
+            passed: verdict == Verdict::Pass,
         },
         err,
     )
 }
 
-fn run_dedup_gate(v: &Value) -> (GateReport, Option<String>) {
-    let hub = parse_hits(v.get("hub"));
-    let local = parse_hits(v.get("local"));
-    let expected_count = v.get("expected_count").and_then(|x| x.as_u64());
-    let expected_sources = parse_expected_sources(v.get("expected_sources"));
+fn evaluate_section(v: &Value) -> Result<String, String> {
+    if !v.is_object() {
+        return Err(format!(
+            "section must be a JSON object, got {} — nothing could be read from it",
+            json_type(v)
+        ));
+    }
+    let hub = parse_hits("hub", v.get("hub"))?; // absent → empty (offline)
+    let local = parse_hits("local", v.get("local"))?;
+    let expected_count = parse_u64_field(v, "expected_count")?;
+    let expected_sources = parse_expected_sources(v.get("expected_sources"))?;
 
     let rows = merge_search_results(&hub, &local);
-    let (passed, desc) = match compare_merge(&rows, expected_count, &expected_sources) {
-        Ok(msg) => (true, msg),
-        Err(msg) => (false, msg),
-    };
-    let err = if passed {
-        None
-    } else {
-        Some(format!("FALSIFY-CRUX-A-23-002 dedup gate failed: {desc}"))
-    };
-    (
-        GateReport {
-            gate: "dedup",
-            falsify_id: "FALSIFY-CRUX-A-23-002",
-            outcome: desc,
-            passed,
-        },
-        err,
-    )
+    compare_merge(&rows, expected_count, &expected_sources)
 }
 
 #[cfg(test)]
@@ -321,6 +385,105 @@ mod tests {
         );
         let err = run(args_for(&f)).unwrap_err();
         assert!(err.contains("FALSIFY-CRUX-A-23-002"));
+    }
+
+    /// `{"offline": {}}` merged zero rows and compared them to nothing, and
+    /// 0.63.0 called that `[PASS] … expected_count_ok=false sources_ok=0`.
+    #[test]
+    fn falsifier_section_with_no_expectations_is_vacuous_not_pass() {
+        for body in [
+            r#"{"offline": {}}"#,
+            r#"{"dedup": {}}"#,
+            r#"{"offline": {"local": [{"repo": "gpt2", "cached": true}]}}"#,
+            r#"{"offline": {"local": [{"repo": "gpt2", "cached": true}], "expected_sources": {}}}"#,
+        ] {
+            let f = write_obs(body);
+            let err = run(args_for(&f)).unwrap_err();
+            assert!(err.contains("VACUOUS"), "{body}: {err}");
+            assert!(err.contains("asserts nothing"), "{body}: {err}");
+        }
+    }
+
+    /// The same expectation quoted instead of numeric used to skip the whole
+    /// count comparison and exit 0.
+    #[test]
+    fn falsifier_wrong_typed_expectation_is_a_schema_error() {
+        let numeric = write_obs(
+            r#"{"offline": {"local": [{"repo": "gpt2", "cached": true}], "expected_count": 99}}"#,
+        );
+        assert!(
+            run(args_for(&numeric))
+                .unwrap_err()
+                .contains("expected_count=99, got 1"),
+            "control: a numeric expectation must still be compared"
+        );
+
+        for (body, want) in [
+            (
+                r#"{"offline": {"local": [{"repo": "gpt2", "cached": true}], "expected_count": "99"}}"#,
+                "expected_count must be a non-negative integer",
+            ),
+            (
+                r#"{"offline": {"local": [{"repo": "gpt2", "cached": true}], "expected_sources": "gpt2=HUB"}}"#,
+                "expected_sources must be an object",
+            ),
+            (
+                r#"{"offline": {"local": [{"repo": "gpt2", "cached": true}], "expected_sources": {"gpt2": 7}}}"#,
+                "expected_sources[\"gpt2\"] must be a string",
+            ),
+            (r#"{"offline": "nope"}"#, "section must be a JSON object"),
+            (
+                r#"{"offline": {"local": "gpt2", "expected_count": 1}}"#,
+                "local must be an array of hits",
+            ),
+            (
+                r#"{"offline": {"local": [{"repo": 7}], "expected_count": 1}}"#,
+                "local[0] has no string \"repo\" field",
+            ),
+        ] {
+            let f = write_obs(body);
+            let err = run(args_for(&f)).unwrap_err();
+            assert!(err.contains(want), "{body}: expected {want:?}, got {err}");
+            assert!(!err.contains("VACUOUS"), "{body}: {err}");
+        }
+    }
+
+    /// The report line and the exit code must agree. 0.63.0's `--json` said
+    /// `"passed": true` next to `expected_count_ok=false`.
+    #[test]
+    fn falsifier_json_report_never_marks_a_vacuous_gate_passed() {
+        let f = write_obs(r#"{"offline": {}}"#);
+        let args = UnifiedSearchLintArgs {
+            observation_file: f.path().to_string_lossy().into_owned(),
+            json: true,
+        };
+        assert!(run(args).is_err());
+
+        let (report, err) = run_gate("offline", "FALSIFY-CRUX-A-23-001", &serde_json::json!({}));
+        assert_eq!(report.verdict, "VACUOUS");
+        assert!(!report.passed);
+        assert!(err.is_some());
+    }
+
+    #[test]
+    fn passing_outcome_string_names_what_was_checked() {
+        let (report, err) = run_gate(
+            "offline",
+            "FALSIFY-CRUX-A-23-001",
+            &serde_json::json!({
+                "local": [{"repo": "gpt2", "cached": true}],
+                "expected_count": 1,
+                "expected_sources": {"gpt2": "LOCAL"},
+            }),
+        );
+        assert!(err.is_none());
+        assert_eq!(report.verdict, "PASS");
+        assert_eq!(
+            report.outcome,
+            "rows=1 expected_count=1 expected_sources=1 — every supplied expectation held"
+        );
+        // The self-contradictory 0.63.0 rendering must not come back.
+        assert!(!report.outcome.contains("_ok="));
     }
 
     #[test]

--- a/crates/apr-cli/src/extended_commands.rs
+++ b/crates/apr-cli/src/extended_commands.rs
@@ -766,8 +766,9 @@ pub enum ExtendedCommands {
         /// Path to captured /api/chat response (JSON object, or NDJSON if --stream)
         #[arg(long, value_name = "FILE")]
         response_file: PathBuf,
-        /// Optional captured request JSON — enables tool-name allowlist gate
-        /// (every called tool name must appear in request.tools[*].function.name)
+        /// Captured request JSON, required unless --stream — supplies the
+        /// tool-name allowlist (every called tool name must appear in
+        /// request.tools[*].function.name)
         #[arg(long, value_name = "FILE")]
         request_file: Option<PathBuf>,
         /// Treat input as NDJSON stream (one frame per line)
@@ -972,7 +973,10 @@ pub enum ExtendedCommands {
         #[arg(long, value_name = "FRACTION", default_value_t = 0.95)]
         preempt_threshold: f64,
     },
-    /// Lint a captured OTLP/JSON ExportTraceServiceRequest body (CRUX-K-08)
+    /// Lint a captured OTLP/JSON ExportTraceServiceRequest body (CRUX-K-08).
+    ///
+    /// At least one gate flag is required: every check is opt-in, so a bare
+    /// invocation would check nothing and exit 0 for any parseable JSON.
     OtlpLint {
         /// Path to captured OTLP/JSON export body
         #[arg(long, value_name = "FILE")]


### PR DESCRIPTION
Most of the observation-file lint family could not fail. `apr unified-search-lint --observation-file` printed

```
[PASS] offline (FALSIFY-CRUX-A-23-001): rows=0 expected_count_ok=false sources_ok=0
```

and exited 0. The `_ok` fields were `expected_count.is_some()` — "an expectation was supplied", not "the expectation held" — and `expected_sources.len()`, a count wearing a boolean's name. A section that supplied no expectation merged rows, compared nothing, and was recorded as a discharged falsifier, with `--json` doubling down on `"passed": true` next to that same outcome string.

`apr otlp-lint --otlp-file body.json`, the documented invocation, ran zero of its three opt-in checks and exited 0 for any parseable JSON — including the scalar `42` — under a header that reads as a clean report. `apr nf4-lint` printed `codebook matches (16 entries)` for four different ways of supplying no codebook. `apr typical-p-lint` exited 5 on `{"range":{"p":1.7}}` and 0 on `{"range":{"p":"1.7"}}`, the identical violation quoted, reporting the present field as `(missing fields — classifier skipped)`. `apr hang-trace-lint --world-size 0` reported `Ok { ranks_seen: 0 }` whatever the directory held. And `apr ollama-tools-lint --response-file X` could not exit 0 for **any** response, because the allowlist gate its help text called "Optional" ran unconditionally against an empty declared-tool set.

## Root cause

One shape throughout: a verdict derived from a variable that stays empty when nothing was measured.

| file:line | defect |
|---|---|
| `unified_search_lint.rs:170` | renders `expected_count.is_some()` as `expected_count_ok`; `:146` skips the count assertion whenever `as_u64()` yields None |
| `otlp_lint.rs:38-48` | all three checks conditional; returns `Ok(())` at `:79` when none was selected |
| `nf4_lint.rs:139` | `if expected.is_empty() { NF4_CODEBOOK.len() == 16 }` — a tautology over a compile-time constant |
| `typical_p_lint.rs`, `tool_use_lint.rs`, `gbnf_lint.rs`, `dry_sampling_lint.rs` | `?`-chains where every `as_f64()?` / `as_array()?` failure means "skip the gate"; an all-skipped run is treated as success |
| `hang_trace_classifier.rs:75` | short-circuits at `world_size == 0` by design; nothing stopped a user reaching it |
| `ollama_tools_lint.rs` | runs `classify_tool_name_allowlist` against `Vec::new()` when `--request-file` is absent |

## Fix

Follows the shape #2420 used for `rosetta`: **VACUOUS is a verdict distinct from PASS and FAIL**, and "no gate reached a verdict" routes to it with a non-zero exit. A new shared `crates/apr-cli/src/commands/lint_vacuity.rs` carries the `Verdict` enum, an `assert_not_vacuous` guard and a `skipped_label` that distinguishes `(section absent — not checked)` from `(PRESENT BUT UNUSABLE — …)`. A present-but-wrong-typed section is now a schema error, not a skip. No outcome string contains an `_ok=` field that means something other than what it says.

## Before / after, measured against a build of this branch

```
before  [PASS] offline …: rows=0 expected_count_ok=false sources_ok=0            rc=0
after   [VACUOUS] offline …: VACUOUS: section supplies neither expected_count
        nor expected_sources, so the 0 merged row(s) were compared against
        nothing — a gate that asserts nothing cannot pass                        rc=1

before  apr otlp-lint --otlp-file <{} | [] | 42 | false | "str">                 rc=0
after   otlp-lint: VACUOUS RUN — no gate was selected …                          rc=5

before  apr nf4-lint {"codebook":{}} → "codebook matches (16 entries)"           rc=0
after   [VACUOUS] codebook …: supplies no "expected" array (keys present: [])    rc=1

before  apr typical-p-lint {"range":{"p":"1.7"}} → "classifier skipped"          rc=0
after   section(s) range are present but unusable …                              rc=5

before  apr hang-trace-lint --trace-dir td --world-size 0 → Ok{ranks_seen:0}     rc=0
after   --world-size 0 is not a world size …                                     rc=5

before  apr ollama-tools-lint --response-file ot_one.json → NoDeclaredTools      rc=5
after   --request-file is required in non-streaming mode                         rc=5
        …and WITH the flag, rc=0 — the first input that can pass at all
```

Positive controls still pass: a fully-specified unified-search observation is `[PASS] … rows=1 expected_count=1 expected_sources=1` rc=0; an armed otlp span gate on a good body is rc=0; a matching 16-entry NF4 codebook is rc=0; the ollama allowlist still catches a hallucinated tool name; `hang-trace-lint --world-size 2` on a valid dump is rc=0.

## Tests that encoded the bug

Several shipped tests asserted `is_ok()` on inputs that should fail and thereby held the defects in place. Each is rewritten, with the old name recorded in a doc comment:

- `nf4_lint::codebook_default_passes_when_empty_expected` — its comment ("gate checks `NF4_CODEBOOK.len()==16`, which passes") documented the tautology as intended behaviour
- `tool_use_lint::empty_object_passes_no_gates` / `empty_object_json_mode_passes`
- `otlp_lint::empty_json_object_runs` — discarded the result entirely
- `gbnf_lint::empty_object_passes_no_gates`, `dry_sampling_lint::empty_object_passes_with_no_gates`, `typical_p_lint::empty_object_passes_no_gates`
- `ollama_tools_lint::malformed_response_errors` was passing for the wrong reason once the missing-flag check landed ahead of the parse; it now pins `InvalidFormat`

## Mutation check

Each decision was reverted with every test kept: `assert_not_vacuous` forced to `Ok(())`, `unified_search_lint::run_gate` forced to treat every `Err` as a pass, the otlp and hang-trace guards disabled with `if false &&`, the nf4 tautology branch restored, the ollama empty-allowlist path restored.

```
test result: FAILED. 223 passed; 29 failed
failures:
    commands::dry_sampling_lint::tests::falsifier_empty_object_is_rejected
    commands::dry_sampling_lint::tests::falsifier_unrelated_body_is_rejected
    commands::dry_sampling_lint::tests::falsifier_wrong_typed_sibling_does_not_suppress_a_real_violation
    commands::gbnf_lint::tests::falsifier_empty_object_is_rejected
    commands::gbnf_lint::tests::falsifier_int_legal_mask_does_not_suppress_the_masking_gate
    commands::gbnf_lint::tests::falsifier_null_observation_is_rejected
    commands::gbnf_lint::tests::falsifier_unrelated_body_is_rejected
    commands::gbnf_lint::tests::falsifier_wrong_typed_finish_reason_is_rejected
    commands::hang_trace_lint::cov_tests::falsifier_world_size_zero_is_rejected_not_silently_passed
    commands::lint_vacuity::tests::falsifier_empty_observation_is_vacuous
    commands::lint_vacuity::tests::falsifier_present_but_unrunnable_section_is_an_error
    commands::lint_vacuity::tests::falsifier_scalar_observation_is_vacuous
    commands::lint_vacuity::tests::falsifier_unrecognised_keys_are_vacuous
    commands::lint_vacuity::tests::falsifier_unrunnable_section_fails_even_when_a_sibling_ran
    commands::nf4_lint::tests::falsifier_codebook_with_nothing_supplied_is_vacuous
    commands::nf4_lint::tests::falsifier_wrong_typed_codebook_is_a_schema_error
    commands::ollama_tools_lint::cov_tests::falsifier_non_streaming_without_request_file_names_the_missing_flag
    commands::otlp_lint::cov_tests::falsifier_no_gate_flags_is_a_vacuous_run
    commands::tool_use_lint::tests::falsifier_empty_object_is_rejected_in_both_output_modes
    commands::tool_use_lint::tests::falsifier_section_name_typo_is_rejected
    commands::tool_use_lint::tests::falsifier_wrong_typed_section_is_rejected
    commands::typical_p_lint::tests::falsifier_empty_object_is_rejected
    commands::typical_p_lint::tests::falsifier_quoted_p_carries_the_same_violation_as_numeric_p
    commands::typical_p_lint::tests::falsifier_typo_in_section_name_is_rejected
    commands::unified_search_lint::tests::dedup_gate_wrong_source_fails
    commands::unified_search_lint::tests::falsifier_json_report_never_marks_a_vacuous_gate_passed
    commands::unified_search_lint::tests::falsifier_section_with_no_expectations_is_vacuous_not_pass
    commands::unified_search_lint::tests::falsifier_wrong_typed_expectation_is_a_schema_error
    commands::unified_search_lint::tests::offline_gate_wrong_count_fails
```

Restored: `6685 passed; 0 failed`. `cargo fmt --all -- --check` and `cargo clippy -p apr-cli --lib -- -D warnings` clean.

## Not fixed here

- **Finding 5** — `awq-lint` / `gptq-lint` / `imatrix-lint` / `fp8-lint` read the pass threshold from the observation they are linting, with no CLI override. Fixing it means adding threshold flags to four commands and deciding whether a file-supplied threshold may ever loosen the compiled default; that is a distinct design decision and belongs in its own PR.
- **Finding 12** — `apr lint <model>` exits 5 with "0 error(s)" on every model tested. That is the inverse defect (a gate that can never be green rather than never red) and changing the default exit semantics plus adding `--strict` touches a different surface.

Refs #2389 (partial — findings 5 and 12 remain)
Audit epic: #2373
