### PR TITLE
fix(cbtop): the --ci gate could not fail, and --iterations 0 forged a green report

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -587,7 +587,13 @@ showcase-headless: ## Run cbtop in headless mode with JSON output (simulated dat
 	@cargo run --release -p apr-cli -- cbtop --headless --simulated --json --output target/showcase-results.json --iterations 100
 	@echo "✅ Results saved to target/showcase-results.json"
 
-showcase-ci: ## Run showcase benchmark in CI mode with threshold check
+# NOTE (#2397): `cbtop --ci` now honours the report's own FAIL/red verdict, not
+# just the explicit --throughput number. The --simulated pipeline jitters each
+# brick +/-20% around its budget, so roughly half land over budget and this
+# target exits non-zero. That is the true state of the simulated data; it used
+# to print "CI validation passed" over a report that read "Status: FAIL | CI:
+# red" only because the exit path never consulted the verdict.
+showcase-ci: ## Run showcase benchmark in CI mode with threshold check (RED on simulated data — see #2397)
 	@echo "🔍 Running showcase CI validation (throughput >= 100 tok/s)..."
 	@cargo run --release -p apr-cli -- cbtop --headless --simulated --ci --throughput 100 --iterations 100
 	@echo "✅ CI validation passed"

--- a/contracts/apr-cli-operations-v1.yaml
+++ b/contracts/apr-cli-operations-v1.yaml
@@ -243,6 +243,21 @@ falsification_tests:
   prediction: No input produces more than 4x tokens (BPE worst case)
   test: Encode adversarial strings (single-byte tokens), verify count <= 4 * len
   if_fails: Token explosion — unbounded memory usage
+- id: FALSIFY-OPS-008
+  rule: A --ci gate exits non-zero whenever the report it printed says FAIL
+  prediction: apr cbtop --headless --simulated --ci exits non-zero when the report reads "Status FAIL | CI red", with no explicit --throughput or --brick-score threshold set
+  test: commands::cbtop::tests::test_ci_gate_fails_on_red_report_without_explicit_thresholds
+  if_fails: The CI gate ignores its own verdict and cannot fail the build it exists to fail
+- id: FALSIFY-OPS-009
+  rule: A benchmark refuses to report measurements it never took
+  prediction: apr cbtop --iterations 0 is rejected at parse time rather than producing a report scoring every brick a perfect 100/A from zero samples
+  test: tests::test_parse_cbtop_rejects_zero_iterations
+  if_fails: Appending --iterations 0 turns any cbtop --ci gate unconditionally green
+- id: FALSIFY-OPS-010
+  rule: Report timestamps carry the real UTC date
+  prediction: The timestamp in a cbtop report matches the UTC date at the moment it was generated, on both headless paths
+  test: commands::cbtop::tests::test_chrono_timestamp_is_current_utc_date
+  if_fails: Persisted CI provenance is stamped with a stale hardcoded date
 kani_harnesses:
 - id: KANI-OPS-001
   obligation: ReadOnly commands have no side effects
@@ -297,7 +312,7 @@ qa_gate:
   - progress_reporting
   - concurrent_model_access
   - tokenizer_consistency
-  pass_criteria: All 7 falsification tests pass
+  pass_criteria: All 10 falsification tests pass
   falsification: >
     Run read-only command with filesystem watcher to detect mutations.
     Force inference error and measure GPU memory leak.

--- a/crates/apr-cli/src/commands/cbtop.rs
+++ b/crates/apr-cli/src/commands/cbtop.rs
@@ -393,6 +393,18 @@ impl App {
 /// Run the cbtop command
 #[provable_contracts_macros::contract("apr-cli-operations-v1", equation = "long_running_graceful")]
 pub fn run(config: CbtopConfig) -> Result<()> {
+    // A zero-iteration run collects no samples at all: every brick's measured
+    // time stays 0.0µs, every gap factor is 0.00x, every score rounds to 100/A
+    // and the falsification summary reads all-passed. That is a green report
+    // for measurements that never happened, so refuse to produce one.
+    if config.iterations == 0 {
+        return Err(CliError::ValidationFailed(
+            "cbtop requires at least 1 measurement iteration (--iterations 0 measures nothing: \
+             every brick would report 0.0µs and score a perfect 100/A)"
+                .to_string(),
+        ));
+    }
+
     if config.headless {
         run_headless(config)
     } else {

--- a/crates/apr-cli/src/commands/cbtop_chrono_timestamp_get.rs
+++ b/crates/apr-cli/src/commands/cbtop_chrono_timestamp_get.rs
@@ -1,15 +1,48 @@
 
     // === chrono_timestamp Tests ===
 
+    /// The timestamp must be the real UTC date, not a hardcoded literal.
+    ///
+    /// This test used to assert `ts.starts_with("2026-01-12T")`, which locked
+    /// the defect in place: the implementation spliced a live time-of-day into
+    /// a string-literal date, so every report was stamped seven months stale
+    /// and the test happily agreed.
+    ///
+    /// Bracketing the call with a before/after date makes the assertion immune
+    /// to a UTC midnight rollover landing between the two `now()` reads.
+    fn utc_dates_bracketing<T>(f: impl FnOnce() -> T) -> (String, T, String) {
+        let before = chrono::Utc::now().format("%Y-%m-%d").to_string();
+        let value = f();
+        let after = chrono::Utc::now().format("%Y-%m-%d").to_string();
+        (before, value, after)
+    }
+
     #[test]
-    fn test_chrono_timestamp_format() {
-        let ts = chrono_timestamp();
-        // Should be in ISO 8601-like format: 2026-01-12THH:MM:SSZ
-        assert!(ts.starts_with("2026-01-12T") || ts == "unknown");
-        if ts != "unknown" {
-            assert!(ts.ends_with('Z'));
-            assert_eq!(ts.len(), 20); // "2026-01-12THH:MM:SSZ"
-        }
+    fn test_chrono_timestamp_is_current_utc_date() {
+        let (before, ts, after) = utc_dates_bracketing(chrono_timestamp);
+        assert!(
+            ts.starts_with(&before) || ts.starts_with(&after),
+            "timestamp {ts} carries neither {before} nor {after} — the real UTC date"
+        );
+        assert!(ts.ends_with('Z'));
+        assert_eq!(ts.len(), 20); // "YYYY-MM-DDTHH:MM:SSZ"
+    }
+
+    /// The simulated headless report must carry the same real UTC date, and it
+    /// must be the same helper — two hardcoded date literals on the two
+    /// headless paths meant one run could stamp two different days.
+    #[test]
+    fn test_simulated_report_timestamp_is_current_utc_date() {
+        let mut pipeline = PipelineState::new();
+        pipeline.update_demo();
+        let (before, report, after) = utc_dates_bracketing(|| {
+            generate_headless_report_simulated("ts", &pipeline, &CbtopConfig::default())
+        });
+        assert!(
+            report.timestamp.starts_with(&before) || report.timestamp.starts_with(&after),
+            "report timestamp {} carries neither {before} nor {after}",
+            report.timestamp
+        );
     }
 
     // === get_cpu_info Tests ===

--- a/crates/apr-cli/src/commands/cbtop_falsification_summary_hardware.rs
+++ b/crates/apr-cli/src/commands/cbtop_falsification_summary_hardware.rs
@@ -407,9 +407,132 @@
         assert!(json.starts_with('{'));
         assert!(json.ends_with('}'));
 
-        // CI thresholds with no thresholds set
-        assert!(check_ci_thresholds(&report, &config));
+        // With no explicit thresholds the gate must still follow the report's
+        // own verdict. This assertion used to be a bare `assert!(...)`, which
+        // encoded the defect: it demanded a PASS from a report that may well
+        // say `Status: FAIL | CI: red`.
+        assert_eq!(
+            check_ci_thresholds(&report, &config),
+            report.ci_result == "green",
+            "CI gate disagreed with the report it was handed ({} / {})",
+            report.status,
+            report.ci_result
+        );
 
         // Text output should not panic
         print_report_text(&report);
+    }
+
+    // ========================================================================
+    // Dogfood 0.63.0 (#2397) falsifiers
+    // ========================================================================
+
+    /// Build a report whose bricks are all inside budget (`green`).
+    fn green_report() -> HeadlessReport {
+        HeadlessReport {
+            model: "gate".to_string(),
+            timestamp: "2026-01-12T00:00:00Z".to_string(),
+            hardware: HardwareInfo {
+                gpu: "test".to_string(),
+                cpu: "test".to_string(),
+                memory_gb: 32,
+            },
+            throughput: ThroughputMetrics {
+                tokens_per_sec: 900.0,
+                ttft_ms: 1.0,
+                cv_percent: 1.0,
+                p50_us: 1.0,
+                p99_us: 2.0,
+            },
+            brick_scores: vec![BrickScore {
+                name: "RmsNorm".to_string(),
+                score: 100,
+                grade: "A".to_string(),
+                budget_us: 1.5,
+                actual_us: 1.2,
+                gap_factor: 0.8,
+            }],
+            pmat_scores: PmatScores {
+                rust_project_score: 0.0,
+                tdg_score: 0.0,
+                cuda_tdg_score: 0.0,
+                brick_score: 100,
+                grade: "A".to_string(),
+            },
+            falsification: FalsificationSummary {
+                total_points: 7,
+                passed: 7,
+                failed: 0,
+                blocked: 0,
+            },
+            status: "PASS".to_string(),
+            ci_result: "green".to_string(),
+        }
+    }
+
+    /// #2397 finding 2: `--ci` must fail on a report that says `CI: red`, even
+    /// when the caller passed no explicit --throughput / --brick-score number.
+    #[test]
+    fn test_ci_gate_fails_on_red_report_without_explicit_thresholds() {
+        let mut report = green_report();
+        report.status = "FAIL".to_string();
+        report.ci_result = "red".to_string();
+        report.falsification = FalsificationSummary {
+            total_points: 7,
+            passed: 4,
+            failed: 3,
+            blocked: 0,
+        };
+
+        let config = CbtopConfig {
+            ci: true,
+            ..Default::default()
+        };
+
+        assert!(
+            !check_ci_thresholds(&report, &config),
+            "cbtop --ci returned pass for a report it had already judged FAIL/red"
+        );
+    }
+
+    /// The converse: a green report with no thresholds must still pass, so the
+    /// fix above is a gate and not a blanket failure.
+    #[test]
+    fn test_ci_gate_passes_on_green_report_without_explicit_thresholds() {
+        let config = CbtopConfig {
+            ci: true,
+            ..Default::default()
+        };
+        assert!(check_ci_thresholds(&green_report(), &config));
+    }
+
+    /// #2397 finding 1: zero measurement iterations must be refused, not
+    /// turned into a perfect 100/A report from zero samples.
+    #[test]
+    fn test_run_rejects_zero_iterations() {
+        let config = CbtopConfig {
+            headless: true,
+            simulated: true,
+            iterations: 0,
+            ..Default::default()
+        };
+        let err = run(config).expect_err("cbtop accepted --iterations 0");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("iteration"),
+            "unexpected rejection message: {msg}"
+        );
+    }
+
+    /// The guard must discriminate on the value, not reject every run: one
+    /// iteration is the smallest honest measurement and must still be served.
+    #[test]
+    fn test_run_accepts_one_iteration() {
+        let config = CbtopConfig {
+            headless: true,
+            simulated: true,
+            iterations: 1,
+            ..Default::default()
+        };
+        run(config).expect("cbtop rejected the smallest honest run, --iterations 1");
     }

--- a/crates/apr-cli/src/commands/cbtop_get_cpu_memory.rs
+++ b/crates/apr-cli/src/commands/cbtop_get_cpu_memory.rs
@@ -85,20 +85,10 @@ fn generate_headless_report_simulated(
     pipeline: &PipelineState,
     _config: &CbtopConfig,
 ) -> HeadlessReport {
-    use std::time::{SystemTime, UNIX_EPOCH};
-
-    let timestamp = SystemTime::now().duration_since(UNIX_EPOCH).map_or_else(
-        |_| "unknown".to_string(),
-        |d| {
-            let secs = d.as_secs();
-            format!(
-                "2026-01-11T{:02}:{:02}:{:02}Z",
-                (secs / 3600) % 24,
-                (secs / 60) % 60,
-                secs % 60
-            )
-        },
-    );
+    // The date must be the real UTC date. A string-literal date with a
+    // computed time-of-day stamped every report ever written — including
+    // files persisted with --output for CI provenance — with the wrong day.
+    let timestamp = chrono_timestamp();
 
     let brick_scores: Vec<BrickScore> = pipeline.bricks.iter().map(score_brick).collect();
 

--- a/crates/apr-cli/src/commands/cbtop_headless_report.rs
+++ b/crates/apr-cli/src/commands/cbtop_headless_report.rs
@@ -258,8 +258,13 @@
                 failed: 0,
                 blocked: 0,
             },
-            status: "FAIL".to_string(),
-            ci_result: "red".to_string(),
+            // #2397 finding 2: this fixture used to say FAIL/red while the test
+            // asserted the gate PASSED — it encoded the defect that `--ci`
+            // ignored the report's own verdict. The verdict is now green so the
+            // test isolates what it is actually about: with only a throughput
+            // threshold set, the failing brick score must not be consulted.
+            status: "PASS".to_string(),
+            ci_result: "green".to_string(),
         };
 
         let config = CbtopConfig {
@@ -270,6 +275,13 @@
 
         // Throughput passes, brick not checked
         assert!(check_ci_thresholds(&report, &config));
+
+        // The same report with a red verdict must fail even though the only
+        // configured threshold still passes.
+        let mut red = report;
+        red.status = "FAIL".to_string();
+        red.ci_result = "red".to_string();
+        assert!(!check_ci_thresholds(&red, &config));
     }
 
     #[test]

--- a/crates/apr-cli/src/commands/cbtop_measure_batch.rs
+++ b/crates/apr-cli/src/commands/cbtop_measure_batch.rs
@@ -446,19 +446,12 @@ fn score_to_grade(score: u32) -> String {
     .to_string()
 }
 
-/// Get ISO 8601 timestamp
+/// Get ISO 8601 UTC timestamp for a report.
+///
+/// Both headless paths call this so a single run cannot stamp two different
+/// dates. It formats the real current UTC date — the previous implementation
+/// spliced the correct time-of-day into a hardcoded date literal, so every
+/// report claimed to have been produced in January 2026.
 fn chrono_timestamp() -> String {
-    use std::time::{SystemTime, UNIX_EPOCH};
-    SystemTime::now().duration_since(UNIX_EPOCH).map_or_else(
-        |_| "unknown".to_string(),
-        |d| {
-            let secs = d.as_secs();
-            format!(
-                "2026-01-12T{:02}:{:02}:{:02}Z",
-                (secs / 3600) % 24,
-                (secs / 60) % 60,
-                secs % 60
-            )
-        },
-    )
+    chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string()
 }

--- a/crates/apr-cli/src/commands/cbtop_report_tui.rs
+++ b/crates/apr-cli/src/commands/cbtop_report_tui.rs
@@ -1,7 +1,25 @@
 
-/// Check CI thresholds
+/// Check CI thresholds.
+///
+/// The report's own verdict is the primary gate: when cbtop has already
+/// concluded `Status: FAIL | CI: red` (one or more bricks over budget), `--ci`
+/// must fail even if the caller passed no explicit `--throughput` /
+/// `--brick-score` number. Previously only the explicit numeric thresholds
+/// could set `passed = false`, so `apr cbtop --ci` printed a red report and
+/// exited 0 — a gate that could not fail.
 fn check_ci_thresholds(report: &HeadlessReport, config: &CbtopConfig) -> bool {
     let mut passed = true;
+
+    if report.ci_result != "green" {
+        eprintln!(
+            "cbtop: FAIL - report status {} (CI: {}), falsification {}/{} passed",
+            report.status,
+            report.ci_result,
+            report.falsification.passed,
+            report.falsification.total_points
+        );
+        passed = false;
+    }
 
     if let Some(threshold) = config.throughput_threshold {
         if report.throughput.tokens_per_sec < threshold {

--- a/crates/apr-cli/src/extended_commands.rs
+++ b/crates/apr-cli/src/extended_commands.rs
@@ -434,12 +434,12 @@ pub enum ExtendedCommands {
         #[arg(long)]
         headless: bool,
         /// Output JSON format (requires --headless)
-        #[arg(long)]
+        #[arg(long, requires = "headless")]
         json: bool,
         /// Output file path (requires --headless)
-        #[arg(long, value_name = "FILE")]
+        #[arg(long, value_name = "FILE", requires = "headless")]
         output: Option<PathBuf>,
-        /// CI mode: exit with code 1 if thresholds not met
+        /// CI mode: exit non-zero if thresholds are not met or the report status is FAIL
         #[arg(long)]
         ci: bool,
         /// Minimum throughput threshold in tok/s (for --ci)
@@ -451,8 +451,8 @@ pub enum ExtendedCommands {
         /// Number of warmup iterations before measurement
         #[arg(long, default_value = "10")]
         warmup: usize,
-        /// Number of measurement iterations
-        #[arg(long, default_value = "100")]
+        /// Number of measurement iterations (must be >= 1)
+        #[arg(long, default_value = "100", value_parser = parse_cbtop_iterations)]
         iterations: usize,
         /// PAR-100: Enable speculative decoding benchmark
         #[arg(long)]
@@ -1392,4 +1392,24 @@ pub enum ProbarSubcommand {
         #[arg(long, default_value = "0.98")]
         tolerance: f32,
     },
+}
+
+/// Parse `apr cbtop --iterations`, rejecting 0.
+///
+/// With zero measurement iterations every brick keeps zero samples, so its
+/// measured time is 0.0µs, its gap factor is 0.00x and it scores a perfect
+/// 100/A — a green report attesting to measurements that never ran. Reject the
+/// value where the user typed it rather than emitting the fabricated report.
+fn parse_cbtop_iterations(s: &str) -> std::result::Result<usize, String> {
+    let n: usize = s
+        .parse()
+        .map_err(|_| format!("`{s}` is not a valid iteration count"))?;
+    if n == 0 {
+        return Err(
+            "must be at least 1 — a zero-iteration run measures nothing and would report every \
+             brick as a perfect 100/A from zero samples"
+                .to_string(),
+        );
+    }
+    Ok(n)
 }

--- a/crates/apr-cli/src/parsing.rs
+++ b/crates/apr-cli/src/parsing.rs
@@ -253,6 +253,61 @@
         }
     }
 
+    /// #2397 finding 1: `--iterations 0` must be rejected where it is typed.
+    /// Appending it to any `cbtop --ci` invocation used to turn the gate green
+    /// because a brick with zero samples scores a perfect 100/A.
+    #[test]
+    fn test_parse_cbtop_rejects_zero_iterations() {
+        let args = vec![
+            "apr",
+            "cbtop",
+            "--headless",
+            "--simulated",
+            "--ci",
+            "--iterations",
+            "0",
+        ];
+        assert!(
+            parse_cli(args).is_err(),
+            "cbtop accepted --iterations 0 at parse time"
+        );
+
+        // One iteration is the smallest honest run and must still parse.
+        let ok = vec!["apr", "cbtop", "--headless", "--iterations", "1"];
+        let cli = parse_cli(ok).expect("--iterations 1 should parse");
+        match *cli.command {
+            Commands::Extended(ExtendedCommands::Cbtop { iterations, .. }) => {
+                assert_eq!(iterations, 1);
+            }
+            _ => panic!("Expected Cbtop command"),
+        }
+    }
+
+    /// #2397 finding 4: `--json` and `--output` document "requires --headless",
+    /// so the parser must enforce it. Without the constraint the flag was
+    /// silently dropped and cbtop entered the interactive TUI instead.
+    #[test]
+    fn test_parse_cbtop_json_requires_headless() {
+        assert!(
+            parse_cli(vec!["apr", "cbtop", "--json"]).is_err(),
+            "cbtop --json was accepted without --headless"
+        );
+        assert!(
+            parse_cli(vec!["apr", "cbtop", "--output", "r.json"]).is_err(),
+            "cbtop --output was accepted without --headless"
+        );
+
+        let cli = parse_cli(vec!["apr", "cbtop", "--headless", "--json"])
+            .expect("--json --headless should parse");
+        match *cli.command {
+            Commands::Extended(ExtendedCommands::Cbtop { headless, json, .. }) => {
+                assert!(headless);
+                assert!(json);
+            }
+            _ => panic!("Expected Cbtop command"),
+        }
+    }
+
     /// Test parsing 'apr qa' command
     #[test]
     fn test_parse_qa_command() {


### PR DESCRIPTION
`apr cbtop --headless --simulated --ci` printed `Status: FAIL | CI: red` and exited 0. A pipeline step whose entire reason to exist is failing a build could not fail one — unless the caller also remembered to pass an explicit `--throughput` or `--brick-score` number. The report's own verdict was never consulted.

Worse, `--iterations 0` was accepted. With zero measurement iterations every brick keeps zero samples, so its measured time is 0.0µs, its gap factor 0.00x, and its score rounds to a perfect 100/A. The shipped 0.63.0 binary answered the same threshold pair two ways, with the measurement count as the only variable:

```
--iterations 100 -> rc=5  cbtop: FAIL - Brick score 96 < threshold 100
--iterations 0   -> rc=0  cbtop: PASS - Brick score 100 >= threshold 100
                          Falsification: 7/7 passed
                          Status: PASS | CI: green
```

Appending `--iterations 0` to any cbtop gate made it unconditionally green, and the fabricated numbers were valid JSON, so a machine consumer could not tell either. The report even claimed 986 tok/s alongside `p50_us: 0.00` and `p99_us: 0.00`.

## Root cause

| file:line | defect |
|---|---|
| `crates/apr-cli/src/commands/cbtop_report_tui.rs:10` | `check_ci_thresholds()` only ever set `passed = false` from `config.throughput_threshold` / `config.brick_score_threshold`. It never read `report.status` or `report.ci_result`. Both headless paths (`gguf.rs:40`, `cbtop_measure_batch.rs:395`) route through this one function, so both were blind. |
| `crates/apr-cli/src/extended_commands.rs:455` | `iterations` had no value parser, so `0` reached the measurement loop. `--warmup abc` was already rejected — the parser validated the field's *type* but not its *domain*. |
| `crates/apr-cli/src/commands/cbtop_get_cpu_memory.rs:95` and `cbtop_measure_batch.rs:457` | Both spliced a live time-of-day into a string-literal date (`"2026-01-11T…"` and `"2026-01-12T…"`). Every report ever written — including files persisted with `--output` for CI provenance — was stamped seven months stale, and one run could stamp two different days. |
| `crates/apr-cli/src/extended_commands.rs:437,440` | `--json` and `--output` both document "requires --headless" but carried no clap constraint. The flag was silently dropped and cbtop entered the interactive TUI: an interactive user who asked for JSON got a full-screen UI, and CI got a raw-mode errno that said nothing about the actual mistake. |

## After

Measured against a release binary built from this tree, `apr 0.63.0 (8cc3aafeb)`:

```
$ apr cbtop --headless --simulated --ci --iterations 0 --brick-score 100 --throughput 900
rc=2
error: invalid value '0' for '--iterations <ITERATIONS>': must be at least 1 —
       a zero-iteration run measures nothing and would report every brick as a
       perfect 100/A from zero samples
(stdout: 0 bytes — no report is produced at all)

$ apr cbtop --headless --simulated --ci --iterations 50
rc=5
  Status: FAIL | CI: red
cbtop: FAIL - report status FAIL (CI: red), falsification 2/7 passed

$ apr cbtop --headless --simulated --json --iterations 20
report: 2026-08-10T17:43:33Z
now:    2026-08-10T17:43:33Z

$ apr cbtop --json
rc=2  error: the following required arguments were not provided: --headless
$ apr cbtop --output r.json
rc=2  error: the following required arguments were not provided: --headless

$ apr cbtop --headless --simulated --iterations 1     # smallest honest run
rc=0
$ apr cbtop --headless --simulated --json --iterations 5
rc=0  parsed ok, status= FAIL
```

The exit status now tracks the printed verdict rather than ignoring it: across 10 consecutive `--ci` runs the report read `Status: FAIL | CI: red` and the exit code was 5 every time. The green direction is covered by unit test, since the simulated pipeline essentially never produces an all-under-budget report.

## Two pre-existing tests had encoded the defects

Both went red and were fixed, as the brief anticipates:

- `test_ci_threshold_only_throughput_set` built a report with `status: "FAIL"` / `ci_result: "red"` and asserted `check_ci_thresholds` returned **true**. Its fixture is now green so the test isolates what it is actually about — with only a throughput threshold set, the failing brick score is not consulted — plus a companion assertion that the same report with a red verdict fails.
- `test_chrono_timestamp_format` asserted `ts.starts_with("2026-01-12T")`, locking the hardcoded date in place. It now brackets the call with a before/after UTC date, so a midnight rollover cannot flake it.

I also dropped a candidate test that asserted the *fabricated* report was perfect (`assert_eq!(report.status, "PASS")` for a zero-sample pipeline) — that is the same defect-locking pattern, just written by me. It is replaced by `test_run_accepts_one_iteration`, which proves the guard discriminates on the value instead of rejecting every run.

## Mutation check

Each fix reverted in turn, tests left in place.

**iterations guard removed** — and the failure output prints the forged report the guard prevents:

```
    ✅ RmsNorm      100 (A) - 0.0µs / 1.5µs (0.00x)
    ✅ QkvBrick     100 (A) - 0.0µs / 6.0µs (0.00x)
    ... (all seven bricks 0.0µs, score 100)
  Falsification: 7/7 passed
  Status: PASS | CI: green

panicked at cbtop_falsification_summary_hardware.rs:519: cbtop accepted --iterations 0: ()
panicked at parsing.rs:270: cbtop accepted --iterations 0 at parse time
test result: FAILED. 17 passed; 2 failed
```

**ci_result check removed:**

```
panicked at cbtop_falsification_summary_hardware.rs:492:
  cbtop --ci returned pass for a report it had already judged FAIL/red
panicked at cbtop_headless_report.rs:284:
  assertion failed: !check_ci_thresholds(&red, &config)
test result: FAILED. 49 passed; 2 failed
```

**hardcoded date restored** — note the second failure, which proves both headless paths now share the one helper rather than carrying two literals:

```
panicked at cbtop_chrono_timestamp_get.rs:23:
  timestamp 2026-01-12T17:39:12Z carries neither 2026-08-10 nor 2026-08-10 — the real UTC date
panicked at cbtop_chrono_timestamp_get.rs:41:
  report timestamp 2026-01-12T17:39:12Z carries neither 2026-08-10 nor 2026-08-10
test result: FAILED. 0 passed; 2 failed
```

**`requires = "headless"` removed:**

```
panicked at parsing.rs:291: cbtop --json was accepted without --headless
test result: FAILED. 0 passed; 1 failed
```

Restored, the working tree diff is byte-identical to the pre-mutation snapshot and all 6662 apr-cli lib tests pass.

## One consequence worth stating plainly

`make showcase-ci` now exits 5. The `--simulated` pipeline jitters each brick ±20% around its budget, so roughly half land over budget and the report is genuinely red. That target has printed `✅ CI validation passed` for as long as it has existed only because the exit path ignored the verdict — it is the same defect, one layer up. It is not referenced by any workflow, so `main` is unaffected; the Makefile now carries a note explaining why it is red.

## Gates

`cargo fmt --all -- --check` rc=0 · `cargo clippy -p apr-cli --lib -- -D warnings` rc=0 · `cargo test -p apr-cli --lib` 6662 passed, 0 failed · `cargo test -p aprender-contracts --lib` 1420 passed, 0 failed · `pv validate contracts/apr-cli-operations-v1.yaml` rc=0.

Contract `apr-cli-operations-v1` gains FALSIFY-OPS-008/009/010, each naming the test that falsifies it.

A build note for whoever picks this up: the workspace `CARGO_TARGET_DIR` is shared across worktrees, and a concurrent agent's build made `apr-cli` fail with a spurious `can't find crate for provable_contracts`. Everything above was built and measured with a private `CARGO_TARGET_DIR`; nothing in the tree was wrong.

Fixes #2397
Audit epic: #2373
