### PR TITLE
fix(mcp): a wrong-typed argument was silently dropped, and a failing apr.qa threw its own gate report away

### DIFF
--- a/crates/apr-cli/src/commands/finetune.rs
+++ b/crates/apr-cli/src/commands/finetune.rs
@@ -347,6 +347,26 @@ fn build_instruct_config(
 ///   4. Fix: Use InstructPipeline::from_apr() + InstructTrainer::train()
 ///
 /// Contract: qlora-training-loop-v1 (frozen_base, lora_forward, response_only_loss)
+/// #2417: reject a base model the training pipeline cannot open, naming the
+/// actual limitation and the command that fixes it.
+///
+/// `apr.finetune`'s `inputSchema` advertises `.apr`, `.gguf` and
+/// `.safetensors`; only `.apr` can currently be trained from. Saying so is the
+/// difference between a usable diagnostic and "Invalid magic: e00a0000".
+#[cfg(feature = "training")]
+fn ensure_apr_base_model(model_path: &Path) -> Result<()> {
+    if super::model_config::is_apr_file(model_path) {
+        return Ok(());
+    }
+    Err(CliError::ValidationFailed(format!(
+        "Fine-tuning requires an APR base model; '{}' is not one. \
+         The LoRA/QLoRA training pipeline reads .apr only. \
+         Convert first: `apr convert {} -o base.apr`, then fine-tune base.apr.",
+        model_path.display(),
+        model_path.display(),
+    )))
+}
+
 #[cfg(feature = "training")]
 fn execute_training(
     model_path: &Path,
@@ -363,6 +383,13 @@ fn execute_training(
     use entrenar::finetune::instruct_corpus::InstructSample;
     use entrenar::finetune::instruct_pipeline::InstructPipeline;
     use entrenar::finetune::instruct_trainer::{InstructTrainer, InstructTrainingConfig};
+
+    // 0. #2417: every training path below ends in `InstructPipeline::from_apr`,
+    // which reads APR only. A .safetensors or .gguf base used to reach that
+    // call and fail as "Failed to open APR file '<model>.safetensors': Invalid
+    // magic" — a message naming a format the caller never mentioned, after a
+    // full plan had already been printed. Reject it here, actionably.
+    ensure_apr_base_model(model_path)?;
 
     // 1. Resolve model config from APR metadata (GH-376: pass model_size for GGUF files)
     let model_config =
@@ -2239,3 +2266,64 @@ mod contract_tests;
 #[cfg(test)]
 #[path = "finetune_display_tests.rs"]
 mod display_tests;
+
+#[cfg(all(test, feature = "training"))]
+mod tests_2417 {
+    use super::ensure_apr_base_model;
+
+    fn scratch(tag: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!("apr-2417-ft-{tag}-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("create scratch dir");
+        dir
+    }
+
+    /// #2417 — a .safetensors base reached `InstructPipeline::from_apr` and
+    /// died as "Failed to open APR file '<model>.safetensors': Invalid magic:
+    /// e00a0000", after printing a full training plan. The rejection must name
+    /// the real limitation and the command that fixes it.
+    #[test]
+    fn safetensors_base_is_rejected_with_an_actionable_message() {
+        let dir = scratch("st");
+        let model = dir.join("base.safetensors");
+        // Real safetensors: 8-byte little-endian header length, then JSON.
+        let header = br#"{"__metadata__":{"format":"pt"}}"#;
+        let mut bytes = (header.len() as u64).to_le_bytes().to_vec();
+        bytes.extend_from_slice(header);
+        std::fs::write(&model, &bytes).expect("write model");
+
+        let err = ensure_apr_base_model(&model).expect_err("safetensors cannot be trained from");
+        let msg = err.to_string();
+        assert!(
+            !msg.contains("Invalid magic"),
+            "message leaks the loader's internals: {msg}"
+        );
+        assert!(msg.contains("base.safetensors"), "{msg}");
+        assert!(
+            msg.contains("apr convert"),
+            "message must say how to proceed: {msg}"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// The positive control: an APR v2 header passes the preflight untouched,
+    /// so the check cannot break the one format that does work.
+    #[test]
+    fn apr_base_passes_the_preflight() {
+        let dir = scratch("apr");
+        let model = dir.join("base.apr");
+        let mut bytes = b"APR\0".to_vec();
+        bytes.resize(128, 0);
+        std::fs::write(&model, &bytes).expect("write model");
+
+        ensure_apr_base_model(&model).expect("an APR base must be accepted");
+
+        // v1 "APRN" is accepted too — the preflight must not narrow support.
+        let v1 = dir.join("legacy.apr");
+        let mut bytes = b"APRN".to_vec();
+        bytes.resize(128, 0);
+        std::fs::write(&v1, &bytes).expect("write v1 model");
+        ensure_apr_base_model(&v1).expect("an APR v1 base must be accepted");
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/crates/apr-cli/src/commands/inference_output.rs
+++ b/crates/apr-cli/src/commands/inference_output.rs
@@ -239,6 +239,19 @@ fn execute_inference(
     }
 }
 
+/// Map a realizar inference failure onto `CliError::InferenceFailed`.
+///
+/// #2403: the variant already renders as `"Inference failed: {0}"`
+/// (`error.rs:45`), so wrapping the payload in another `"Inference failed: "`
+/// printed the context twice — `apr run` on an unsupported architecture
+/// emitted `error: Inference failed: Inference failed: Format error: ...`,
+/// which is what MCP clients relayed verbatim. The payload must carry the
+/// underlying diagnosis only.
+#[cfg(feature = "inference")]
+fn inference_error<E: std::fmt::Display>(e: E) -> CliError {
+    CliError::InferenceFailed(e.to_string())
+}
+
 /// Execute inference using realizar engine
 ///
 /// Per spec APR-CLI-DELEGATE-001: All inference delegates to realizar's
@@ -295,8 +308,7 @@ fn execute_with_realizar(
     }
 
     // Run inference via realizar
-    let result = run_inference(&config)
-        .map_err(|e| CliError::InferenceFailed(format!("Inference failed: {e}")))?;
+    let result = run_inference(&config).map_err(inference_error)?;
 
     // Report performance if benchmarking
     if options.benchmark {
@@ -376,4 +388,31 @@ fn execute_with_whisper(
         used_gpu: Some(false),
         generated_tokens: None,
     })
+}
+
+#[cfg(all(test, feature = "inference"))]
+mod tests_2403 {
+    use super::inference_error;
+
+    /// #2403 — `apr run` on a qwen3.5 GGUF emitted
+    /// `error: Inference failed: Inference failed: Format error: ...`, and MCP
+    /// relayed that doubled prefix verbatim. The context belongs to the error
+    /// variant's Display, not to the payload.
+    #[test]
+    fn inference_context_appears_exactly_once() {
+        let rendered = inference_error(
+            "Format error: Architecture 'qwen35' uses SSM/Gated Delta Net layers",
+        )
+        .to_string();
+
+        assert_eq!(
+            rendered.matches("Inference failed:").count(),
+            1,
+            "context applied more than once: {rendered}"
+        );
+        assert_eq!(
+            rendered,
+            "Inference failed: Format error: Architecture 'qwen35' uses SSM/Gated Delta Net layers"
+        );
+    }
 }

--- a/crates/apr-cli/src/commands/model_config.rs
+++ b/crates/apr-cli/src/commands/model_config.rs
@@ -48,13 +48,38 @@ pub(crate) fn read_apr_architecture(
     )
 }
 
+/// Whether `path` starts with an APR magic (`APR\0` v2 or `APRN` v1).
+///
+/// #2417: the LoRA training pipeline is `InstructPipeline::from_apr` — APR
+/// only. A `.safetensors` base used to travel the whole way to that call and
+/// surface as `Failed to open APR file '<model>.safetensors': Invalid magic`,
+/// naming a format the caller never mentioned. Callers use this to reject an
+/// unsupported base up front, with an actionable message.
+pub(crate) fn is_apr_file(path: &Path) -> bool {
+    use aprender::format::v2::MAGIC_V2;
+    use std::io::Read;
+
+    const MAGIC_V1: [u8; 4] = *b"APRN";
+
+    let Ok(mut file) = std::fs::File::open(path) else {
+        return false;
+    };
+    let mut magic = [0u8; 4];
+    if file.read_exact(&mut magic).is_err() {
+        return false;
+    }
+    magic == MAGIC_V2 || magic == MAGIC_V1
+}
+
 /// Resolve TransformerConfig from .apr metadata, HF config.json, or --model-size fallback.
 ///
 /// Precedence:
 ///   1. `.apr` file metadata (provable, validated at import)
-///   2. HuggingFace `config.json` in model directory
-///   3. `--model-size` string match (legacy fallback, no .apr file)
-///   4. Error (refuse to silently degrade to tiny)
+///   2. HuggingFace `config.json` beside the model file (#2417)
+///   3. HuggingFace `config.json` in model directory
+///   4. `--model-size` string match (legacy fallback, no .apr file)
+///   5. Error naming the path that was actually supplied (refuse to silently
+///      degrade to tiny, and refuse to claim no path was given when one was)
 pub(crate) fn resolve_transformer_config(
     model_path: Option<&Path>,
     model_size: Option<&str>,
@@ -64,21 +89,88 @@ pub(crate) fn resolve_transformer_config(
         if let Some(config) = read_apr_architecture(path) {
             return Ok(config);
         }
+        // Attempt 2: a .safetensors / .gguf checkout ships its architecture in
+        // a sibling config.json. Before #2417 this was only consulted when the
+        // model path was a DIRECTORY, so `apr finetune model.safetensors`
+        // could never resolve an architecture even with the config.json
+        // sitting right next to the weights.
+        if let Some(config) = read_sibling_hf_config(path) {
+            return Ok(config);
+        }
         eprintln!(
-            "[GH-376] WARNING: could not read architecture from .apr metadata, \
-             falling back to --model-size"
+            "[GH-376] WARNING: could not read architecture from '{}' \
+             (not APR v2 metadata, and no sibling config.json), \
+             falling back to --model-size",
+            path.display()
         );
     }
 
-    // Attempt 2: Read architecture from HuggingFace config.json in model directory
+    // Attempt 3: Read architecture from HuggingFace config.json in model directory
     if let Some(path) = model_path.filter(|p| p.is_dir()) {
         if let Some(config) = read_hf_config_json(path) {
             return Ok(config);
         }
     }
 
-    // Attempt 3: Legacy --model-size string matching
+    // Attempt 4: Legacy --model-size string matching.
+    //
+    // #2417: when no --model-size was given the legacy message was
+    // "No model path or --model-size provided" even though a path WAS the
+    // first positional argument and the CLI had just read tensors out of it.
+    // Report what actually happened instead.
+    if model_size.is_none() {
+        if let Some(path) = model_path {
+            return Err(CliError::ValidationFailed(
+                unresolvable_architecture_message(path),
+            ));
+        }
+    }
     resolve_transformer_config_by_size(model_size)
+}
+
+/// The accurate diagnostic for "a model path was supplied but no architecture
+/// could be derived from it".
+fn unresolvable_architecture_message(path: &Path) -> String {
+    let kind = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .map_or_else(|| "file".to_string(), |e| format!(".{e} file"));
+    format!(
+        "Cannot determine architecture from '{}': the {kind} carries no APR v2 \
+         architecture metadata and no HuggingFace config.json was found beside it \
+         (looked for {}). Convert it with `apr convert`, place the model's \
+         config.json alongside the weights, or pass --model-size.",
+        path.display(),
+        sibling_config_candidates(path)
+            .iter()
+            .map(|p| format!("'{}'", p.display()))
+            .collect::<Vec<_>>()
+            .join(" and "),
+    )
+}
+
+/// Where a `config.json` for `file` may live: the pacha cache writes
+/// `<hash>.config.json` next to `<hash>.safetensors`, while a HuggingFace
+/// checkout puts a plain `config.json` in the same directory.
+fn sibling_config_candidates(file: &Path) -> Vec<std::path::PathBuf> {
+    let Some(dir) = file.parent() else {
+        return Vec::new();
+    };
+    let mut candidates = Vec::new();
+    if let Some(stem) = file.file_stem() {
+        let mut name = stem.to_os_string();
+        name.push(".config.json");
+        candidates.push(dir.join(name));
+    }
+    candidates.push(dir.join("config.json"));
+    candidates
+}
+
+/// Read TransformerConfig from a `config.json` sitting beside a model file.
+fn read_sibling_hf_config(file: &Path) -> Option<entrenar::transformer::TransformerConfig> {
+    sibling_config_candidates(file)
+        .iter()
+        .find_map(|c| read_hf_config_file(c))
 }
 
 /// Read TransformerConfig from a HuggingFace `config.json` in a model directory.
@@ -86,8 +178,12 @@ pub(crate) fn resolve_transformer_config(
 /// Parses the standard HF model config format used by Qwen, LLaMA, Mistral, etc.
 /// Returns None if config.json doesn't exist or required fields are missing.
 fn read_hf_config_json(dir: &Path) -> Option<entrenar::transformer::TransformerConfig> {
-    let config_path = dir.join("config.json");
-    let data = std::fs::read_to_string(&config_path).ok()?;
+    read_hf_config_file(&dir.join("config.json"))
+}
+
+/// Parse one HuggingFace `config.json` file into a `TransformerConfig`.
+fn read_hf_config_file(config_path: &Path) -> Option<entrenar::transformer::TransformerConfig> {
+    let data = std::fs::read_to_string(config_path).ok()?;
     let json: serde_json::Value = serde_json::from_str(&data).ok()?;
 
     let hidden_size = json.get("hidden_size")?.as_u64()? as usize;
@@ -248,4 +344,94 @@ fn transformer_config_from_apr_metadata(
         hf_model_type: None,
         tie_word_embeddings: false,
     })
+}
+
+#[cfg(test)]
+mod tests_2417 {
+    use super::*;
+
+    const QWEN_CONFIG: &str = r#"{
+        "hidden_size": 896,
+        "num_attention_heads": 14,
+        "num_key_value_heads": 2,
+        "intermediate_size": 4864,
+        "num_hidden_layers": 24,
+        "vocab_size": 151936
+    }"#;
+
+    fn tmpdir(tag: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!("apr-2417-{tag}-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        dir
+    }
+
+    /// #2417 — `apr finetune model.safetensors` reported "No model path or
+    /// --model-size provided" while a model path WAS the first positional
+    /// argument. The message named a condition that was false.
+    #[test]
+    fn safetensors_without_config_reports_the_path_it_was_given() {
+        let dir = tmpdir("nocfg");
+        let model = dir.join("weights.safetensors");
+        std::fs::write(&model, b"not-an-apr-file").expect("write model");
+
+        let err = resolve_transformer_config(Some(&model), None)
+            .expect_err("architecture is genuinely underivable here");
+        let msg = err.to_string();
+
+        assert!(
+            !msg.contains("No model path"),
+            "message still claims no path was provided: {msg}"
+        );
+        assert!(
+            msg.contains("weights.safetensors"),
+            "message must name the path it was given: {msg}"
+        );
+        assert!(
+            !msg.contains(".apr metadata"),
+            "message must not cite .apr metadata for a .safetensors input: {msg}"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// With no path AND no --model-size, the original message is still the
+    /// accurate one.
+    #[test]
+    fn no_path_and_no_size_keeps_the_original_message() {
+        let err = resolve_transformer_config(None, None).expect_err("nothing to go on");
+        assert!(err.to_string().contains("No model path or --model-size"));
+    }
+
+    /// #2417 — a HuggingFace checkout keeps `config.json` beside the weights.
+    /// Resolution used to consult it only when the model path was a DIRECTORY,
+    /// so pointing at the .safetensors file itself could never work.
+    #[test]
+    fn safetensors_resolves_from_sibling_config_json() {
+        let dir = tmpdir("hf");
+        let model = dir.join("model.safetensors");
+        std::fs::write(&model, b"not-an-apr-file").expect("write model");
+        std::fs::write(dir.join("config.json"), QWEN_CONFIG).expect("write config");
+
+        let config = resolve_transformer_config(Some(&model), None)
+            .expect("architecture comes from the sibling config.json");
+        assert_eq!(config.hidden_size, 896);
+        assert_eq!(config.num_hidden_layers, 24);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// The pacha cache stores `<hash>.safetensors` and `<hash>.config.json`
+    /// side by side — the exact fixture layout the audit used.
+    #[test]
+    fn safetensors_resolves_from_hash_prefixed_sibling_config() {
+        let dir = tmpdir("pacha");
+        let model = dir.join("064a3693fa1ea02c.safetensors");
+        std::fs::write(&model, b"not-an-apr-file").expect("write model");
+        std::fs::write(dir.join("064a3693fa1ea02c.config.json"), QWEN_CONFIG)
+            .expect("write config");
+
+        let config = resolve_transformer_config(Some(&model), None)
+            .expect("architecture comes from <stem>.config.json");
+        assert_eq!(config.num_attention_heads, 14);
+        assert_eq!(config.num_kv_heads, 2);
+        std::fs::remove_dir_all(&dir).ok();
+    }
 }

--- a/crates/aprender-mcp/src/tools/args.rs
+++ b/crates/aprender-mcp/src/tools/args.rs
@@ -1,0 +1,245 @@
+//! Typed extraction of `tools/call` arguments.
+//!
+//! Every tool used to read its optional arguments with a bare
+//! `args.get("max_tokens").and_then(Value::as_u64)`, so the `None` branch —
+//! "the caller sent something, but not of the declared type" — was
+//! indistinguishable from "the caller sent nothing" and the flag was simply
+//! omitted from the spawned argv. That is a wrong-answer channel: the client
+//! believes it asserted something the server never applied, and the result
+//! JSON echoes the CLI's *default* so the drop is undetectable downstream.
+//! `apr.qa`'s `assert_tps` is the sharpest case — passed as a JSON string it
+//! disarmed the throughput gate entirely (#2403).
+//!
+//! The rules here are deliberately narrow:
+//!
+//! - absent or JSON `null` → `Ok(None)` (the argument is optional)
+//! - the declared JSON type → `Ok(Some(v))`
+//! - a **string that parses exactly** into the declared type → `Ok(Some(v))`.
+//!   LLM clients routinely emit numbers as JSON strings, so `"8"` for an
+//!   integer is the common path, not an exotic one — coercing it is what the
+//!   caller meant and it is lossless.
+//! - anything else → `Err(message)`, which the tool turns into an
+//!   `isError: true` result. This matches the one field that already
+//!   validated before this module existed, `apr.serve`'s `port`.
+//!
+//! Nothing is ever silently dropped.
+
+use serde_json::Value;
+
+/// `Ok(None)` = absent, `Ok(Some(v))` = present and usable, `Err` = present
+/// but not convertible to the declared type.
+pub type ArgResult<T> = Result<Option<T>, String>;
+
+/// Early-return an `isError` [`crate::types::ToolCallResult`] when an
+/// argument is present with an unusable type.
+macro_rules! try_arg {
+    ($expr:expr) => {
+        match $expr {
+            Ok(v) => v,
+            Err(msg) => return crate::types::ToolCallResult::error(msg),
+        }
+    };
+}
+pub(crate) use try_arg;
+
+fn type_error(name: &str, expected: &str, value: &Value) -> String {
+    format!("Invalid {name}: expected {expected}, got {value}")
+}
+
+/// Look the argument up, treating JSON `null` as absent.
+fn lookup<'a>(args: &'a Value, name: &str) -> Option<&'a Value> {
+    args.get(name).filter(|v| !v.is_null())
+}
+
+/// Extract a non-negative integer argument (`"type": "integer"`).
+///
+/// Accepts a JSON integer, a JSON float with no fractional part (`8.0`), or a
+/// decimal string (`"8"`). Rejects negatives, fractions and anything else.
+///
+/// # Errors
+/// Returns the client-facing message when the value is present but not an
+/// integer.
+pub fn opt_u64(args: &Value, name: &str) -> ArgResult<u64> {
+    let Some(value) = lookup(args, name) else {
+        return Ok(None);
+    };
+    if let Some(n) = value.as_u64() {
+        return Ok(Some(n));
+    }
+    if let Some(f) = value.as_f64() {
+        if f.is_finite() && f >= 0.0 && f.fract() == 0.0 {
+            #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+            return Ok(Some(f as u64));
+        }
+    }
+    if let Some(s) = value.as_str() {
+        if let Ok(n) = s.trim().parse::<u64>() {
+            return Ok(Some(n));
+        }
+    }
+    Err(type_error(name, "integer", value))
+}
+
+/// Extract a floating-point argument (`"type": "number"`).
+///
+/// Accepts a JSON number or a numeric string (`"100000"`, `"0.7"`). Rejects
+/// non-finite results and anything unparseable.
+///
+/// # Errors
+/// Returns the client-facing message when the value is present but not a
+/// number.
+pub fn opt_f64(args: &Value, name: &str) -> ArgResult<f64> {
+    let Some(value) = lookup(args, name) else {
+        return Ok(None);
+    };
+    if let Some(f) = value.as_f64() {
+        return Ok(Some(f));
+    }
+    if let Some(s) = value.as_str() {
+        if let Ok(f) = s.trim().parse::<f64>() {
+            if f.is_finite() {
+                return Ok(Some(f));
+            }
+        }
+    }
+    Err(type_error(name, "number", value))
+}
+
+/// Extract a boolean argument (`"type": "boolean"`).
+///
+/// Accepts a JSON boolean or the strings `"true"` / `"false"` in any case.
+/// Rejects `0` / `1` and every other spelling.
+///
+/// # Errors
+/// Returns the client-facing message when the value is present but not a
+/// boolean.
+pub fn opt_bool(args: &Value, name: &str) -> ArgResult<bool> {
+    let Some(value) = lookup(args, name) else {
+        return Ok(None);
+    };
+    if let Some(b) = value.as_bool() {
+        return Ok(Some(b));
+    }
+    if let Some(s) = value.as_str() {
+        let t = s.trim();
+        if t.eq_ignore_ascii_case("true") {
+            return Ok(Some(true));
+        }
+        if t.eq_ignore_ascii_case("false") {
+            return Ok(Some(false));
+        }
+    }
+    Err(type_error(name, "boolean", value))
+}
+
+/// Extract a string argument (`"type": "string"`).
+///
+/// Strict: a number is not a path or a name pattern, so `{"reference": 42}`
+/// is an error rather than a silently stringified `"42"`.
+///
+/// # Errors
+/// Returns the client-facing message when the value is present but not a
+/// string.
+pub fn opt_str<'a>(args: &'a Value, name: &str) -> ArgResult<&'a str> {
+    let Some(value) = lookup(args, name) else {
+        return Ok(None);
+    };
+    match value.as_str() {
+        Some(s) => Ok(Some(s)),
+        None => Err(type_error(name, "string", value)),
+    }
+}
+
+/// Extract a required string argument, reporting absence and wrong type
+/// distinctly.
+///
+/// # Errors
+/// Returns the client-facing message when the value is missing or not a
+/// string.
+pub fn required_str<'a>(args: &'a Value, name: &str) -> Result<&'a str, String> {
+    match lookup(args, name) {
+        None => Err(format!("Missing required argument: {name}")),
+        Some(v) => match v.as_str() {
+            Some(s) => Ok(s),
+            None => Err(type_error(name, "string", v)),
+        },
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::disallowed_methods)] // serde_json::json! expands to code that hits unwrap()
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn absent_and_null_are_none_not_errors() {
+        let args = json!({ "max_tokens": null });
+        assert_eq!(opt_u64(&args, "max_tokens"), Ok(None));
+        assert_eq!(opt_u64(&args, "iterations"), Ok(None));
+        assert_eq!(opt_f64(&args, "assert_tps"), Ok(None));
+        assert_eq!(opt_bool(&args, "stats"), Ok(None));
+        assert_eq!(opt_str(&args, "prompt"), Ok(None));
+    }
+
+    #[test]
+    fn correctly_typed_values_pass_through() {
+        let args = json!({
+            "max_tokens": 8,
+            "assert_tps": 100_000.0,
+            "stats": true,
+            "filter": "attn_qkv",
+        });
+        assert_eq!(opt_u64(&args, "max_tokens"), Ok(Some(8)));
+        assert_eq!(opt_f64(&args, "assert_tps"), Ok(Some(100_000.0)));
+        assert_eq!(opt_bool(&args, "stats"), Ok(Some(true)));
+        assert_eq!(opt_str(&args, "filter"), Ok(Some("attn_qkv")));
+    }
+
+    /// The #2403 repro: an LLM client emitting numbers as JSON strings must
+    /// still reach the CLI, never be dropped.
+    #[test]
+    fn numeric_strings_are_coerced_not_dropped() {
+        let args = json!({ "max_tokens": "8", "assert_tps": "100000", "stats": "true" });
+        assert_eq!(opt_u64(&args, "max_tokens"), Ok(Some(8)));
+        assert_eq!(opt_f64(&args, "assert_tps"), Ok(Some(100_000.0)));
+        assert_eq!(opt_bool(&args, "stats"), Ok(Some(true)));
+    }
+
+    #[test]
+    fn integral_float_is_accepted_for_integer() {
+        assert_eq!(opt_u64(&json!({ "n": 8.0 }), "n"), Ok(Some(8)));
+    }
+
+    #[test]
+    fn unusable_values_are_errors_not_silent_drops() {
+        assert!(opt_u64(&json!({ "n": "eight" }), "n").is_err());
+        assert!(opt_u64(&json!({ "n": -1 }), "n").is_err());
+        assert!(opt_u64(&json!({ "n": 1.5 }), "n").is_err());
+        assert!(opt_u64(&json!({ "n": true }), "n").is_err());
+        assert!(opt_f64(&json!({ "n": "fast" }), "n").is_err());
+        assert!(opt_bool(&json!({ "n": 1 }), "n").is_err());
+        assert!(opt_bool(&json!({ "n": "yes" }), "n").is_err());
+        assert!(opt_str(&json!({ "n": 42 }), "n").is_err());
+    }
+
+    #[test]
+    fn error_message_names_the_field_the_type_and_the_value() {
+        let err = opt_u64(&json!({ "max_tokens": "eight" }), "max_tokens")
+            .expect_err("string 'eight' is not an integer");
+        assert!(err.contains("max_tokens"), "{err}");
+        assert!(err.contains("integer"), "{err}");
+        assert!(err.contains("eight"), "{err}");
+    }
+
+    #[test]
+    fn required_str_distinguishes_missing_from_wrong_type() {
+        let missing = required_str(&json!({}), "model_path").expect_err("absent");
+        assert!(missing.contains("Missing required argument"));
+        assert!(missing.contains("model_path"));
+
+        let wrong = required_str(&json!({ "model_path": 7 }), "model_path").expect_err("not a str");
+        assert!(wrong.contains("model_path"));
+        assert!(wrong.contains("string"));
+    }
+}

--- a/crates/aprender-mcp/src/tools/bench.rs
+++ b/crates/aprender-mcp/src/tools/bench.rs
@@ -4,6 +4,7 @@
 
 #![allow(clippy::disallowed_methods)] // serde_json::json! macro expands to .unwrap() internally
 
+use crate::tools::args::{self, try_arg};
 use crate::tools::subprocess::run_apr;
 use crate::types::{InputSchema, ToolCallResult, ToolDefinition};
 
@@ -31,12 +32,13 @@ pub fn bench_tool_definition() -> ToolDefinition {
     }
 }
 
-/// Execute `apr.bench` by spawning `apr bench <model> --json [...flags]`.
-#[must_use]
-pub fn call(args: &serde_json::Value) -> ToolCallResult {
-    let Some(model_path) = args.get("model_path").and_then(|v| v.as_str()) else {
-        return ToolCallResult::error("Missing required argument: model_path");
-    };
+/// Build the `apr bench ...` argv from `tools/call` arguments.
+///
+/// # Errors
+/// Returns the client-facing message when an argument is present but not
+/// usable at its declared type.
+pub fn build_argv(args: &serde_json::Value) -> Result<Vec<String>, String> {
+    let model_path = args::required_str(args, "model_path")?;
 
     let mut owned: Vec<String> = vec![
         "bench".to_string(),
@@ -44,20 +46,26 @@ pub fn call(args: &serde_json::Value) -> ToolCallResult {
         "--json".to_string(),
     ];
 
-    if let Some(n) = args.get("iterations").and_then(serde_json::Value::as_u64) {
+    if let Some(n) = args::opt_u64(args, "iterations")? {
         owned.push("--iterations".to_string());
         owned.push(n.to_string());
     }
-    if let Some(n) = args.get("max_tokens").and_then(serde_json::Value::as_u64) {
+    if let Some(n) = args::opt_u64(args, "max_tokens")? {
         owned.push("--max-tokens".to_string());
         owned.push(n.to_string());
     }
-    let prompt = args.get("prompt").and_then(|v| v.as_str()).unwrap_or("");
+    let prompt = args::opt_str(args, "prompt")?.unwrap_or("");
     if !prompt.is_empty() {
         owned.push("--prompt".to_string());
         owned.push(prompt.to_string());
     }
+    Ok(owned)
+}
 
+/// Execute `apr.bench` by spawning `apr bench <model> --json [...flags]`.
+#[must_use]
+pub fn call(args: &serde_json::Value) -> ToolCallResult {
+    let owned = try_arg!(build_argv(args));
     let argv: Vec<&str> = owned.iter().map(String::as_str).collect();
     run_apr(&argv)
 }
@@ -102,5 +110,37 @@ mod tests {
         let result = call(&serde_json::json!({}));
         assert_eq!(result.is_error, Some(true));
         assert!(result.content[0].text.contains("model_path"));
+    }
+
+    /// #2403 — the audit asked for 1 iteration of 8 tokens as JSON strings and
+    /// got 5 iterations of 32 tokens (the CLI defaults), reported back as if
+    /// that is what it had asked for.
+    #[test]
+    fn string_iterations_and_max_tokens_reach_the_cli() {
+        let argv = build_argv(&serde_json::json!({
+            "model_path": "m.gguf",
+            "iterations": "1",
+            "max_tokens": "8"
+        }))
+        .expect("numeric strings are usable");
+        assert_eq!(
+            argv,
+            vec![
+                "bench",
+                "m.gguf",
+                "--json",
+                "--iterations",
+                "1",
+                "--max-tokens",
+                "8"
+            ]
+        );
+    }
+
+    #[test]
+    fn unusable_iterations_is_an_error_not_a_dropped_flag() {
+        let result = call(&serde_json::json!({ "model_path": "m.gguf", "iterations": "lots" }));
+        assert_eq!(result.is_error, Some(true));
+        assert!(result.content[0].text.contains("iterations"));
     }
 }

--- a/crates/aprender-mcp/src/tools/finetune.rs
+++ b/crates/aprender-mcp/src/tools/finetune.rs
@@ -29,6 +29,7 @@
 #![allow(clippy::disallowed_methods)] // serde_json::json! macro expands to .unwrap() internally
 
 use crate::server::NotificationSink;
+use crate::tools::args::{self, try_arg};
 use crate::tools::subprocess::{run_apr, spawn_streaming};
 use crate::types::{InputSchema, JsonRpcNotification, ToolCallResult, ToolDefinition};
 
@@ -79,15 +80,33 @@ pub fn call(args: &serde_json::Value) -> ToolCallResult {
 /// progressToken, per MCP spec "servers MUST NOT send progress notifications
 /// if the client did not request them"), we fall back to the non-streaming
 /// [`run_apr`] path.
+///
+/// Every optional argument the `inputSchema` declares — `dataset`,
+/// `lora_rank`, `epochs`, `method`, `output` — is forwarded by
+/// [`build_argv`], and a wrong-typed one is now an `isError` result rather
+/// than a silent omission (#2417 / #2403).
 #[must_use]
 pub fn call_with_sink(
     args: &serde_json::Value,
     sink: Option<&NotificationSink>,
     progress_token: Option<serde_json::Value>,
 ) -> ToolCallResult {
-    let Some(base_model) = args.get("base_model").and_then(|v| v.as_str()) else {
-        return ToolCallResult::error("Missing required argument: base_model");
-    };
+    let owned = try_arg!(build_argv(args));
+    let argv: Vec<&str> = owned.iter().map(String::as_str).collect();
+
+    match (sink, progress_token) {
+        (Some(sink), Some(token)) => stream_with_sink("apr", &argv, sink, &token),
+        _ => run_apr(&argv),
+    }
+}
+
+/// Build the `apr finetune ...` argv from `tools/call` arguments.
+///
+/// # Errors
+/// Returns the client-facing message when an argument is present but not
+/// usable at its declared type.
+pub fn build_argv(args: &serde_json::Value) -> Result<Vec<String>, String> {
+    let base_model = args::required_str(args, "base_model")?;
 
     let mut owned: Vec<String> = vec![
         "finetune".to_string(),
@@ -95,39 +114,33 @@ pub fn call_with_sink(
         "--json".to_string(),
     ];
 
-    if let Some(dataset) = args.get("dataset").and_then(|v| v.as_str()) {
+    if let Some(dataset) = args::opt_str(args, "dataset")? {
         if !dataset.is_empty() {
             owned.push("--data".to_string());
             owned.push(dataset.to_string());
         }
     }
-    if let Some(rank) = args.get("lora_rank").and_then(serde_json::Value::as_u64) {
+    if let Some(rank) = args::opt_u64(args, "lora_rank")? {
         owned.push("--rank".to_string());
         owned.push(rank.to_string());
     }
-    if let Some(epochs) = args.get("epochs").and_then(serde_json::Value::as_u64) {
+    if let Some(epochs) = args::opt_u64(args, "epochs")? {
         owned.push("--epochs".to_string());
         owned.push(epochs.to_string());
     }
-    if let Some(method) = args.get("method").and_then(|v| v.as_str()) {
+    if let Some(method) = args::opt_str(args, "method")? {
         if !method.is_empty() {
             owned.push("--method".to_string());
             owned.push(method.to_string());
         }
     }
-    if let Some(output) = args.get("output").and_then(|v| v.as_str()) {
+    if let Some(output) = args::opt_str(args, "output")? {
         if !output.is_empty() {
             owned.push("--output".to_string());
             owned.push(output.to_string());
         }
     }
-
-    let argv: Vec<&str> = owned.iter().map(String::as_str).collect();
-
-    match (sink, progress_token) {
-        (Some(sink), Some(token)) => stream_with_sink("apr", &argv, sink, &token),
-        _ => run_apr(&argv),
-    }
+    Ok(owned)
 }
 
 /// Test-visible: stream `program args...` and forward each stdout line as a
@@ -216,6 +229,61 @@ mod tests {
         let result = call(&serde_json::json!({ "base_model": 42 }));
         assert_eq!(result.is_error, Some(true));
         assert!(result.content[0].text.contains("base_model"));
+    }
+
+    /// #2417 — every optional argument the inputSchema declares must appear in
+    /// the spawned argv. A declared argument that is dropped is a wrong-answer
+    /// channel: the caller believes it configured the run.
+    #[test]
+    fn every_declared_optional_argument_is_forwarded() {
+        let argv = build_argv(&serde_json::json!({
+            "base_model": "base.safetensors",
+            "dataset": "/tmp/d.jsonl",
+            "lora_rank": 4,
+            "epochs": 1,
+            "method": "lora",
+            "output": "/tmp/out"
+        }))
+        .expect("all arguments usable");
+        assert_eq!(
+            argv,
+            vec![
+                "finetune",
+                "base.safetensors",
+                "--json",
+                "--data",
+                "/tmp/d.jsonl",
+                "--rank",
+                "4",
+                "--epochs",
+                "1",
+                "--method",
+                "lora",
+                "--output",
+                "/tmp/out"
+            ]
+        );
+    }
+
+    /// The same call with the two integers sent as JSON strings — the shape an
+    /// LLM client routinely emits — must be identical, not silently rank-less.
+    #[test]
+    fn string_typed_rank_and_epochs_are_forwarded() {
+        let argv = build_argv(&serde_json::json!({
+            "base_model": "base.safetensors",
+            "lora_rank": "4",
+            "epochs": "1"
+        }))
+        .expect("numeric strings usable");
+        assert!(argv.contains(&"--rank".to_string()), "{argv:?}");
+        assert!(argv.contains(&"--epochs".to_string()), "{argv:?}");
+    }
+
+    #[test]
+    fn unusable_lora_rank_is_an_error_not_a_dropped_flag() {
+        let result = call(&serde_json::json!({ "base_model": "b.apr", "lora_rank": "high" }));
+        assert_eq!(result.is_error, Some(true));
+        assert!(result.content[0].text.contains("lora_rank"));
     }
 
     /// FALSIFY-MCP-PROGRESS-001 (unit): `stream_with_sink` fires one

--- a/crates/aprender-mcp/src/tools/mod.rs
+++ b/crates/aprender-mcp/src/tools/mod.rs
@@ -9,6 +9,7 @@
 //!   see FALSIFY-MCP-PROGRESS-001) + `notifications/cancelled` →
 //!   SIGTERM→SIGKILL for `apr.run` (FALSIFY-MCP-006).
 
+pub mod args;
 pub mod bench;
 pub mod finetune;
 pub mod qa;

--- a/crates/aprender-mcp/src/tools/qa.rs
+++ b/crates/aprender-mcp/src/tools/qa.rs
@@ -4,6 +4,7 @@
 
 #![allow(clippy::disallowed_methods)] // serde_json::json! macro expands to .unwrap() internally
 
+use crate::tools::args::{self, try_arg};
 use crate::tools::subprocess::run_apr;
 use crate::types::{InputSchema, ToolCallResult, ToolDefinition};
 
@@ -31,12 +32,16 @@ pub fn qa_tool_definition() -> ToolDefinition {
     }
 }
 
-/// Execute `apr.qa` by spawning `apr qa <model> --json [...flags]`.
-#[must_use]
-pub fn call(args: &serde_json::Value) -> ToolCallResult {
-    let Some(model_path) = args.get("model_path").and_then(|v| v.as_str()) else {
-        return ToolCallResult::error("Missing required argument: model_path");
-    };
+/// Build the `apr qa ...` argv from `tools/call` arguments.
+///
+/// Separated from [`call`] so falsifiers can assert what actually reaches the
+/// CLI rather than merely that the call returned something.
+///
+/// # Errors
+/// Returns the client-facing message when an argument is present but not
+/// usable at its declared type.
+pub fn build_argv(args: &serde_json::Value) -> Result<Vec<String>, String> {
+    let model_path = args::required_str(args, "model_path")?;
 
     let mut owned: Vec<String> = vec![
         "qa".to_string(),
@@ -44,19 +49,27 @@ pub fn call(args: &serde_json::Value) -> ToolCallResult {
         "--json".to_string(),
     ];
 
-    if let Some(tps) = args.get("assert_tps").and_then(serde_json::Value::as_f64) {
+    // A wrong-typed assert_tps used to vanish here, disarming the throughput
+    // gate without any diagnostic (#2403).
+    if let Some(tps) = args::opt_f64(args, "assert_tps")? {
         owned.push("--assert-tps".to_string());
         owned.push(tps.to_string());
     }
-    if let Some(n) = args.get("max_tokens").and_then(serde_json::Value::as_u64) {
+    if let Some(n) = args::opt_u64(args, "max_tokens")? {
         owned.push("--max-tokens".to_string());
         owned.push(n.to_string());
     }
-    if let Some(n) = args.get("iterations").and_then(serde_json::Value::as_u64) {
+    if let Some(n) = args::opt_u64(args, "iterations")? {
         owned.push("--iterations".to_string());
         owned.push(n.to_string());
     }
+    Ok(owned)
+}
 
+/// Execute `apr.qa` by spawning `apr qa <model> --json [...flags]`.
+#[must_use]
+pub fn call(args: &serde_json::Value) -> ToolCallResult {
+    let owned = try_arg!(build_argv(args));
     let argv: Vec<&str> = owned.iter().map(String::as_str).collect();
     run_apr(&argv)
 }
@@ -101,5 +114,52 @@ mod tests {
         let result = call(&serde_json::json!({}));
         assert_eq!(result.is_error, Some(true));
         assert!(result.content[0].text.contains("model_path"));
+    }
+
+    /// #2403/#2418 — the sharpest case in the audit. `assert_tps` is a
+    /// pass/fail threshold; sent as a JSON string it used to vanish from argv,
+    /// turning a gate that should fail into one that cannot fail, silently.
+    #[test]
+    fn assert_tps_as_a_json_string_still_reaches_the_gate() {
+        let argv = build_argv(&serde_json::json!({
+            "model_path": "m.gguf",
+            "assert_tps": "100000",
+            "iterations": 1
+        }))
+        .expect("string 100000 is a usable number");
+        assert!(
+            argv.contains(&"--assert-tps".to_string()),
+            "throughput gate disarmed: {argv:?}"
+        );
+        let idx = argv
+            .iter()
+            .position(|a| a == "--assert-tps")
+            .expect("flag present");
+        assert_eq!(argv[idx + 1], "100000");
+    }
+
+    /// A number still works exactly as before — the positive control the
+    /// audit ran alongside the string case.
+    #[test]
+    fn assert_tps_as_a_number_reaches_the_gate() {
+        let argv =
+            build_argv(&serde_json::json!({ "model_path": "m.gguf", "assert_tps": 100_000 }))
+                .expect("number is usable");
+        assert!(argv.contains(&"--assert-tps".to_string()), "{argv:?}");
+    }
+
+    /// An assert_tps that cannot mean a threshold is an error the client can
+    /// see, never a silently disarmed gate.
+    #[test]
+    fn unusable_assert_tps_is_an_error_not_a_dropped_flag() {
+        let result = call(&serde_json::json!({ "model_path": "m.gguf", "assert_tps": "fast" }));
+        assert_eq!(result.is_error, Some(true));
+        assert!(result.content[0].text.contains("assert_tps"));
+    }
+
+    #[test]
+    fn omitted_assert_tps_stays_omitted() {
+        let argv = build_argv(&serde_json::json!({ "model_path": "m.gguf" })).expect("valid");
+        assert_eq!(argv, vec!["qa", "m.gguf", "--json"]);
     }
 }

--- a/crates/aprender-mcp/src/tools/run.rs
+++ b/crates/aprender-mcp/src/tools/run.rs
@@ -17,6 +17,7 @@
 #![allow(clippy::disallowed_methods)] // serde_json::json! macro expands to .unwrap() internally
 
 use crate::server::NotificationSink;
+use crate::tools::args::{self, try_arg};
 use crate::tools::subprocess::{run_apr_cancellable, spawn_streaming, CANCEL_GRACE_MS};
 use crate::types::{InputSchema, JsonRpcNotification, ToolCallResult, ToolDefinition};
 use std::sync::mpsc::Receiver;
@@ -59,6 +60,47 @@ pub fn call(args: &serde_json::Value, cancel_rx: &Receiver<()>) -> ToolCallResul
     call_with_sink(args, cancel_rx, None, None)
 }
 
+/// Build the `apr run ...` argv from `tools/call` arguments.
+///
+/// `streaming` selects `--stream` (NDJSON) over `--json` (one blob).
+///
+/// # Errors
+/// Returns the client-facing message when an argument is present but not
+/// usable at its declared type.
+pub fn build_argv(args: &serde_json::Value, streaming: bool) -> Result<Vec<String>, String> {
+    let model_path = args::required_str(args, "model_path")?;
+
+    let mut owned: Vec<String> = vec!["run".to_string(), model_path.to_string()];
+    // --stream emits NDJSON (one event per line); the legacy --json path
+    // emits a single pretty-printed blob. Pick whichever matches the
+    // intended consumer.
+    if streaming {
+        owned.push("--stream".to_string());
+    } else {
+        owned.push("--json".to_string());
+    }
+
+    if let Some(prompt) = args::opt_str(args, "prompt")? {
+        if !prompt.is_empty() {
+            owned.push("--prompt".to_string());
+            owned.push(prompt.to_string());
+        }
+    }
+    if let Some(n) = args::opt_u64(args, "max_tokens")? {
+        owned.push("--max-tokens".to_string());
+        owned.push(n.to_string());
+    }
+    if let Some(t) = args::opt_f64(args, "temperature")? {
+        owned.push("--temperature".to_string());
+        owned.push(t.to_string());
+    }
+    if let Some(p) = args::opt_f64(args, "top_p")? {
+        owned.push("--top-p".to_string());
+        owned.push(p.to_string());
+    }
+    Ok(owned)
+}
+
 /// Execute `apr.run` with optional `notifications/progress` streaming.
 ///
 /// FALSIFY-MCP-PROGRESS-002: when both `sink` and `progress_token` are
@@ -82,41 +124,8 @@ pub fn call_with_sink(
     sink: Option<&NotificationSink>,
     progress_token: Option<serde_json::Value>,
 ) -> ToolCallResult {
-    let Some(model_path) = args.get("model_path").and_then(|v| v.as_str()) else {
-        return ToolCallResult::error("Missing required argument: model_path");
-    };
-
     let streaming = sink.is_some() && progress_token.is_some();
-
-    let mut owned: Vec<String> = vec!["run".to_string(), model_path.to_string()];
-    // --stream emits NDJSON (one event per line); the legacy --json path
-    // emits a single pretty-printed blob. Pick whichever matches the
-    // intended consumer.
-    if streaming {
-        owned.push("--stream".to_string());
-    } else {
-        owned.push("--json".to_string());
-    }
-
-    if let Some(prompt) = args.get("prompt").and_then(|v| v.as_str()) {
-        if !prompt.is_empty() {
-            owned.push("--prompt".to_string());
-            owned.push(prompt.to_string());
-        }
-    }
-    if let Some(n) = args.get("max_tokens").and_then(serde_json::Value::as_u64) {
-        owned.push("--max-tokens".to_string());
-        owned.push(n.to_string());
-    }
-    if let Some(t) = args.get("temperature").and_then(serde_json::Value::as_f64) {
-        owned.push("--temperature".to_string());
-        owned.push(t.to_string());
-    }
-    if let Some(p) = args.get("top_p").and_then(serde_json::Value::as_f64) {
-        owned.push("--top-p".to_string());
-        owned.push(p.to_string());
-    }
-
+    let owned = try_arg!(build_argv(args, streaming));
     let argv: Vec<&str> = owned.iter().map(String::as_str).collect();
 
     match (streaming, sink, progress_token) {
@@ -194,5 +203,47 @@ mod tests {
         let result = call(&serde_json::json!({}), &rx);
         assert_eq!(result.is_error, Some(true));
         assert!(result.content[0].text.contains("model_path"));
+    }
+
+    /// #2403 — `max_tokens: "8"` produced a 32-token generation whose result
+    /// JSON echoed `"max_tokens": 32`, so the client could not even detect
+    /// that its request had been ignored.
+    #[test]
+    fn string_max_tokens_reaches_the_cli() {
+        let argv = build_argv(
+            &serde_json::json!({ "model_path": "m.gguf", "prompt": "hi", "max_tokens": "8" }),
+            false,
+        )
+        .expect("numeric string is usable");
+        let idx = argv
+            .iter()
+            .position(|a| a == "--max-tokens")
+            .unwrap_or_else(|| panic!("max_tokens dropped: {argv:?}"));
+        assert_eq!(argv[idx + 1], "8");
+    }
+
+    #[test]
+    fn unusable_temperature_is_an_error_not_a_dropped_flag() {
+        let (_tx, rx) = std::sync::mpsc::channel::<()>();
+        let result = call(
+            &serde_json::json!({ "model_path": "m.gguf", "temperature": "warm" }),
+            &rx,
+        );
+        assert_eq!(result.is_error, Some(true));
+        assert!(result.content[0].text.contains("temperature"));
+    }
+
+    /// Streaming selects `--stream`; the argument handling is otherwise
+    /// identical, so a wrong-typed value must not sneak through that path.
+    #[test]
+    fn streaming_argv_uses_stream_flag_and_same_coercion() {
+        let argv = build_argv(
+            &serde_json::json!({ "model_path": "m.gguf", "top_p": "0.9" }),
+            true,
+        )
+        .expect("numeric string is usable");
+        assert!(argv.contains(&"--stream".to_string()), "{argv:?}");
+        assert!(!argv.contains(&"--json".to_string()), "{argv:?}");
+        assert!(argv.contains(&"--top-p".to_string()), "{argv:?}");
     }
 }

--- a/crates/aprender-mcp/src/tools/serve.rs
+++ b/crates/aprender-mcp/src/tools/serve.rs
@@ -37,6 +37,7 @@
 
 #![allow(clippy::disallowed_methods)] // serde_json::json! macro expands to .unwrap() internally
 
+use crate::tools::args::{self, try_arg};
 use crate::types::{ContentBlock, InputSchema, ToolCallResult, ToolDefinition};
 use std::io::Read;
 use std::net::{Ipv4Addr, SocketAddr, TcpStream};
@@ -112,17 +113,15 @@ pub fn serve_tool_definition() -> ToolDefinition {
 /// all look like. See this module's header for the terminal states.
 #[must_use]
 pub fn call(args: &serde_json::Value) -> ToolCallResult {
-    let Some(model_path) = args.get("model_path").and_then(|v| v.as_str()) else {
-        return ToolCallResult::error("Missing required argument: model_path");
-    };
+    let model_path = try_arg!(args::required_str(args, "model_path"));
 
-    let port: u16 = match args.get("port") {
+    let port: u16 = match try_arg!(args::opt_u64(args, "port")) {
         None => DEFAULT_PORT,
-        Some(v) => match v.as_u64().and_then(|n| u16::try_from(n).ok()) {
-            Some(n) => n,
-            None => {
+        Some(n) => match u16::try_from(n) {
+            Ok(p) => p,
+            Err(_) => {
                 return ToolCallResult::error(format!(
-                    "Invalid port: expected integer 0..=65535, got {v}"
+                    "Invalid port: expected integer 0..=65535, got {n}"
                 ));
             }
         },

--- a/crates/aprender-mcp/src/tools/subprocess.rs
+++ b/crates/aprender-mcp/src/tools/subprocess.rs
@@ -10,8 +10,16 @@
 //! SIGTERM → (grace window) → SIGKILL on the spawned subprocess when a
 //! cancellation is signalled. The non-cancellable [`run_apr`] is kept as a
 //! thin wrapper for tools that don't support cancellation yet.
+//!
+//! #2418: the failure path used to pick *either* stderr *or* stdout — stdout
+//! only when stderr was empty. `apr qa` writes its JSON gate report to stdout
+//! and a one-line summary to stderr, so every failing QA run (the tool's
+//! primary use case) reached the client as a single line with the >3 KB
+//! report thrown away. [`failure_result`] now keeps the summary as the first
+//! content block and attaches the report as a second one, so a failing gate
+//! is as inspectable as a passing one.
 
-use crate::types::ToolCallResult;
+use crate::types::{ContentBlock, ToolCallResult};
 use std::io::{BufRead, BufReader, Read};
 use std::process::{Command, Stdio};
 use std::sync::mpsc::{Receiver, TryRecvError};
@@ -27,6 +35,56 @@ pub const CANCEL_GRACE_MS: u64 = 30_000;
 /// Poll interval when waiting for subprocess exit / cancel signal.
 const POLL_INTERVAL: Duration = Duration::from_millis(10);
 
+/// Render one argv element so the echoed command can actually be re-run.
+///
+/// `format!("apr {}", args.join(" "))` produced `--prompt What is 2+2?`, which
+/// is a different command from the one that ran (#2403). Anything outside the
+/// POSIX-safe set is single-quoted, with embedded quotes escaped the shell way.
+fn quote_arg(arg: &str) -> String {
+    let safe = !arg.is_empty()
+        && arg
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b"@%+=:,./-_".contains(&b));
+    if safe {
+        arg.to_string()
+    } else {
+        format!("'{}'", arg.replace('\'', r"'\''"))
+    }
+}
+
+/// Render `program args...` as a copy-pasteable shell command.
+pub(crate) fn display_command(program: &str, args: &[&str]) -> String {
+    let mut out = quote_arg(program);
+    for a in args {
+        out.push(' ');
+        out.push_str(&quote_arg(a));
+    }
+    out
+}
+
+/// Build the `isError` result for a subprocess that exited non-zero.
+///
+/// The first content block is the one-line summary the client already relied
+/// on. When the command wrote to BOTH streams the stdout payload is attached
+/// as a second block instead of being discarded (#2418).
+fn failure_result(cmd_display: &str, code: i32, stdout: &str, stderr: &str) -> ToolCallResult {
+    let summary = if stderr.trim().is_empty() {
+        stdout.to_string()
+    } else {
+        stderr.to_string()
+    };
+    let mut content = vec![ContentBlock::text(format!(
+        "`{cmd_display}` failed (exit {code}): {summary}"
+    ))];
+    if !stderr.trim().is_empty() && !stdout.trim().is_empty() {
+        content.push(ContentBlock::text(stdout.to_string()));
+    }
+    ToolCallResult {
+        content,
+        is_error: Some(true),
+    }
+}
+
 /// Spawn `apr <args...>` and wait synchronously. Shorthand for the
 /// non-cancellable path used by every tool except `apr.run`.
 ///
@@ -36,10 +94,10 @@ const POLL_INTERVAL: Duration = Duration::from_millis(10);
 /// - Spawn failure → `error("Failed to spawn apr ...: <io-err>")`
 #[must_use]
 pub fn run_apr(args: &[&str]) -> ToolCallResult {
+    let cmd = display_command("apr", args);
     let output = match Command::new("apr").args(args).output() {
         Ok(o) => o,
         Err(e) => {
-            let cmd = format!("apr {}", args.join(" "));
             return ToolCallResult::error(format!("Failed to spawn `{cmd}`: {e}"));
         }
     };
@@ -49,20 +107,13 @@ pub fn run_apr(args: &[&str]) -> ToolCallResult {
 
     if output.status.success() {
         if stdout.trim().is_empty() {
-            let cmd = format!("apr {}", args.join(" "));
             ToolCallResult::error(format!("`{cmd}` produced no output"))
         } else {
             ToolCallResult::success(stdout)
         }
     } else {
         let code = output.status.code().unwrap_or(-1);
-        let detail = if stderr.trim().is_empty() {
-            stdout
-        } else {
-            stderr
-        };
-        let cmd = format!("apr {}", args.join(" "));
-        ToolCallResult::error(format!("`{cmd}` failed (exit {code}): {detail}"))
+        failure_result(&cmd, code, &stdout, &stderr)
     }
 }
 
@@ -94,7 +145,7 @@ pub fn spawn_cancellable(
     cancel_rx: &Receiver<()>,
     grace_ms: u64,
 ) -> ToolCallResult {
-    let cmd_display = format!("{program} {}", args.join(" "));
+    let cmd_display = display_command(program, args);
 
     let mut child = match Command::new(program)
         .args(args)
@@ -147,12 +198,7 @@ pub fn spawn_cancellable(
                 }
             } else {
                 let code = status.code().unwrap_or(-1);
-                let detail = if stderr.trim().is_empty() {
-                    stdout
-                } else {
-                    stderr
-                };
-                ToolCallResult::error(format!("`{cmd_display}` failed (exit {code}): {detail}"))
+                failure_result(&cmd_display, code, &stdout, &stderr)
             }
         }
         Err(CancelReason::Signalled) => {
@@ -262,7 +308,7 @@ pub fn spawn_streaming<F>(program: &str, args: &[&str], mut on_line: F) -> ToolC
 where
     F: FnMut(&str),
 {
-    let cmd_display = format!("{program} {}", args.join(" "));
+    let cmd_display = display_command(program, args);
 
     let mut child = match Command::new(program)
         .args(args)
@@ -340,6 +386,106 @@ mod tests {
     use super::*;
     use std::sync::mpsc;
     use std::thread;
+
+    /// #2418 — a failing `apr qa` writes its JSON gate report to stdout and a
+    /// one-line summary to stderr. The report is the whole point of the tool;
+    /// it must survive the failure path, not be replaced by the summary.
+    #[test]
+    fn failure_keeps_the_stdout_report_when_stderr_also_spoke() {
+        let report = r#"{"passed":false,"gates":[{"name":"ollama_parity","passed":false}]}"#;
+        let result = failure_result(
+            "apr qa m.gguf --json",
+            5,
+            report,
+            "error: Validation failed",
+        );
+
+        assert_eq!(result.is_error, Some(true));
+        let whole: String = result
+            .content
+            .iter()
+            .map(|b| b.text.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            whole.contains("ollama_parity"),
+            "gate report must reach the client, got: {whole}"
+        );
+        assert!(
+            whole.contains("failed (exit 5)"),
+            "summary line must survive too, got: {whole}"
+        );
+    }
+
+    /// End-to-end through a real subprocess that writes to BOTH streams and
+    /// exits non-zero — the exact shape of a failing `apr qa`.
+    ///
+    /// The report is asserted on the SECOND content block specifically. The
+    /// first block echoes the command, and the command here IS the script
+    /// text, so an `any()` over all blocks passed even with the report
+    /// discarded — that is how the first draft of this test survived its own
+    /// mutation check.
+    #[test]
+    fn cancellable_failure_carries_both_streams() {
+        let (_tx, rx) = mpsc::channel::<()>();
+        let result = spawn_cancellable(
+            "sh",
+            &[
+                "-c",
+                "printf '{\"gates\":\"REP\"}\\nORT\\n'; echo SUMMARY >&2; exit 5",
+            ],
+            &rx,
+            CANCEL_GRACE_MS,
+        );
+        assert_eq!(result.is_error, Some(true));
+        assert!(
+            result.content[0].text.contains("SUMMARY"),
+            "stderr dropped: {}",
+            result.content[0].text
+        );
+        assert_eq!(
+            result.content.len(),
+            2,
+            "stdout report dropped, only got: {:?}",
+            result.content
+        );
+        assert!(
+            result.content[1].text.contains("{\"gates\":\"REP\"}\nORT"),
+            "stdout report mangled: {}",
+            result.content[1].text
+        );
+    }
+
+    /// A failure with nothing on stderr still reports stdout in the summary,
+    /// and does not emit a redundant duplicate block.
+    #[test]
+    fn failure_with_empty_stderr_reports_stdout_once() {
+        let result = failure_result("apr qa m.gguf", 1, "only-stdout", "   \n");
+        assert_eq!(result.content.len(), 1);
+        assert!(result.content[0].text.contains("only-stdout"));
+    }
+
+    /// #2403 (secondary) — the echoed reproduction command must be
+    /// copy-pasteable. `--prompt What is 2+2?` is a different command from the
+    /// one that ran.
+    #[test]
+    fn echoed_command_is_shell_quoted() {
+        let cmd = display_command("apr", &["run", "m.gguf", "--prompt", "What is 2+2?"]);
+        assert_eq!(cmd, "apr run m.gguf --prompt 'What is 2+2?'");
+    }
+
+    /// Quoting must be idempotent for safe argv elements (no needless noise)
+    /// and must survive an embedded single quote.
+    #[test]
+    fn quoting_leaves_safe_args_alone_and_escapes_quotes() {
+        assert_eq!(quote_arg("--max-tokens"), "--max-tokens");
+        assert_eq!(
+            quote_arg("/home/noah/models/a.gguf"),
+            "/home/noah/models/a.gguf"
+        );
+        assert_eq!(quote_arg(""), "''");
+        assert_eq!(quote_arg("it's"), r"'it'\''s'");
+    }
 
     /// Spawning `apr` with an unrecognised subcommand yields a tool error
     /// (non-zero exit), not a panic.

--- a/crates/aprender-mcp/src/tools/tensors.rs
+++ b/crates/aprender-mcp/src/tools/tensors.rs
@@ -4,6 +4,7 @@
 
 #![allow(clippy::disallowed_methods)] // serde_json::json! macro expands to .unwrap() internally
 
+use crate::tools::args::{self, try_arg};
 use crate::tools::subprocess::run_apr;
 use crate::types::{InputSchema, ToolCallResult, ToolDefinition};
 
@@ -32,26 +33,35 @@ pub fn tensors_tool_definition() -> ToolDefinition {
     }
 }
 
+/// Build the `apr tensors ...` argv from `tools/call` arguments.
+///
+/// # Errors
+/// Returns the client-facing message when an argument is present but not
+/// usable at its declared type.
+pub fn build_argv(args: &serde_json::Value) -> Result<Vec<String>, String> {
+    let model_path = args::required_str(args, "model_path")?;
+
+    let mut argv: Vec<String> = vec![
+        "tensors".to_string(),
+        model_path.to_string(),
+        "--json".to_string(),
+    ];
+    if args::opt_bool(args, "stats")?.unwrap_or(false) {
+        argv.push("--stats".to_string());
+    }
+    let filter = args::opt_str(args, "filter")?.unwrap_or("");
+    if !filter.is_empty() {
+        argv.push("--filter".to_string());
+        argv.push(filter.to_string());
+    }
+    Ok(argv)
+}
+
 /// Execute `apr.tensors` by spawning `apr tensors <model> --json [...flags]`.
 #[must_use]
 pub fn call(args: &serde_json::Value) -> ToolCallResult {
-    let Some(model_path) = args.get("model_path").and_then(|v| v.as_str()) else {
-        return ToolCallResult::error("Missing required argument: model_path");
-    };
-
-    let mut argv: Vec<&str> = vec!["tensors", model_path, "--json"];
-    if args
-        .get("stats")
-        .and_then(serde_json::Value::as_bool)
-        .unwrap_or(false)
-    {
-        argv.push("--stats");
-    }
-    let filter = args.get("filter").and_then(|v| v.as_str()).unwrap_or("");
-    if !filter.is_empty() {
-        argv.push("--filter");
-        argv.push(filter);
-    }
+    let owned = try_arg!(build_argv(args));
+    let argv: Vec<&str> = owned.iter().map(String::as_str).collect();
 
     run_apr(&argv)
 }
@@ -93,5 +103,21 @@ mod tests {
         let result = call(&serde_json::json!({}));
         assert_eq!(result.is_error, Some(true));
         assert!(result.content[0].text.contains("model_path"));
+    }
+
+    /// #2403 — `stats: "true"` used to drop `--stats`, so the caller got a
+    /// bare listing back and no indication its request was ignored.
+    #[test]
+    fn string_stats_still_asks_for_stats() {
+        let argv = build_argv(&serde_json::json!({ "model_path": "m.gguf", "stats": "true" }))
+            .expect("\"true\" is a usable boolean");
+        assert!(argv.contains(&"--stats".to_string()), "{argv:?}");
+    }
+
+    #[test]
+    fn unusable_stats_is_an_error_not_a_dropped_flag() {
+        let result = call(&serde_json::json!({ "model_path": "m.gguf", "stats": 1 }));
+        assert_eq!(result.is_error, Some(true));
+        assert!(result.content[0].text.contains("stats"));
     }
 }

--- a/crates/aprender-mcp/src/tools/trace.rs
+++ b/crates/aprender-mcp/src/tools/trace.rs
@@ -4,6 +4,7 @@
 
 #![allow(clippy::disallowed_methods)] // serde_json::json! macro expands to .unwrap() internally
 
+use crate::tools::args::{self, try_arg};
 use crate::tools::subprocess::run_apr;
 use crate::types::{InputSchema, ToolCallResult, ToolDefinition};
 
@@ -31,12 +32,13 @@ pub fn trace_tool_definition() -> ToolDefinition {
     }
 }
 
-/// Execute `apr.trace` by spawning `apr trace <model> --json [...flags]`.
-#[must_use]
-pub fn call(args: &serde_json::Value) -> ToolCallResult {
-    let Some(model_path) = args.get("model_path").and_then(|v| v.as_str()) else {
-        return ToolCallResult::error("Missing required argument: model_path");
-    };
+/// Build the `apr trace ...` argv from `tools/call` arguments.
+///
+/// # Errors
+/// Returns the client-facing message when an argument is present but not
+/// usable at its declared type.
+pub fn build_argv(args: &serde_json::Value) -> Result<Vec<String>, String> {
+    let model_path = args::required_str(args, "model_path")?;
 
     let mut owned: Vec<String> = vec![
         "trace".to_string(),
@@ -44,18 +46,25 @@ pub fn call(args: &serde_json::Value) -> ToolCallResult {
         "--json".to_string(),
     ];
 
-    if let Some(pat) = args.get("layer").and_then(|v| v.as_str()) {
+    if let Some(pat) = args::opt_str(args, "layer")? {
         if !pat.is_empty() {
             owned.push("--layer".to_string());
             owned.push(pat.to_string());
         }
     }
-    if let Some(ref_path) = args.get("reference").and_then(|v| v.as_str()) {
+    if let Some(ref_path) = args::opt_str(args, "reference")? {
         if !ref_path.is_empty() {
             owned.push("--reference".to_string());
             owned.push(ref_path.to_string());
         }
     }
+    Ok(owned)
+}
+
+/// Execute `apr.trace` by spawning `apr trace <model> --json [...flags]`.
+#[must_use]
+pub fn call(args: &serde_json::Value) -> ToolCallResult {
+    let owned = try_arg!(build_argv(args));
 
     let argv: Vec<&str> = owned.iter().map(String::as_str).collect();
     run_apr(&argv)
@@ -101,5 +110,40 @@ mod tests {
         let result = call(&serde_json::json!({}));
         assert_eq!(result.is_error, Some(true));
         assert!(result.content[0].text.contains("model_path"));
+    }
+
+    /// #2403 — `{"layer": 7, "reference": 42}` dropped BOTH flags and traced
+    /// the whole model against nothing, reported as a success.
+    #[test]
+    fn integer_layer_and_reference_are_errors_not_dropped_flags() {
+        let result = call(&serde_json::json!({ "model_path": "m.gguf", "layer": 7 }));
+        assert_eq!(result.is_error, Some(true));
+        assert!(result.content[0].text.contains("layer"));
+
+        let result = call(&serde_json::json!({ "model_path": "m.gguf", "reference": 42 }));
+        assert_eq!(result.is_error, Some(true));
+        assert!(result.content[0].text.contains("reference"));
+    }
+
+    #[test]
+    fn string_layer_and_reference_reach_the_cli() {
+        let argv = build_argv(&serde_json::json!({
+            "model_path": "m.gguf",
+            "layer": "blk.7",
+            "reference": "ref.gguf"
+        }))
+        .expect("strings are usable");
+        assert_eq!(
+            argv,
+            vec![
+                "trace",
+                "m.gguf",
+                "--json",
+                "--layer",
+                "blk.7",
+                "--reference",
+                "ref.gguf"
+            ]
+        );
     }
 }

--- a/crates/aprender-mcp/src/tools/validate.rs
+++ b/crates/aprender-mcp/src/tools/validate.rs
@@ -10,6 +10,7 @@
 
 #![allow(clippy::disallowed_methods)] // serde_json::json! macro expands to .unwrap() internally
 
+use crate::tools::args::{self, try_arg};
 use crate::tools::subprocess::run_apr;
 use crate::types::{InputSchema, ToolCallResult, ToolDefinition};
 
@@ -41,9 +42,7 @@ pub fn validate_tool_definition() -> ToolDefinition {
 /// Execute `apr.validate` by spawning `apr validate <model_path> --json`.
 #[must_use]
 pub fn call(args: &serde_json::Value) -> ToolCallResult {
-    let Some(model_path) = args.get("model_path").and_then(|v| v.as_str()) else {
-        return ToolCallResult::error("Missing required argument: model_path");
-    };
+    let model_path = try_arg!(args::required_str(args, "model_path"));
     run_apr(&["validate", model_path, "--json"])
 }
 


### PR DESCRIPTION
Ask the MCP server for `apr.qa` with `assert_tps: "100000"` — a JSON string, the shape an LLM client routinely emits — and 0.63.0 spawns

```
apr qa <model> --json --iterations 1
```

The threshold is gone. No warning, no `isError`, and the result reads like a pass. `assert_tps` is a pass/fail gate, so passing it as a string turned a gate that should fail into one that could not fail. The same silent drop hit `max_tokens`, `iterations`, `stats`, `filter`, `layer`, `reference` and `lora_rank` across apr.run / apr.bench / apr.qa / apr.tensors / apr.trace / apr.finetune: every optional argument was read with a bare `as_u64()` / `as_bool()`, whose `None` branch cannot distinguish "the caller sent nothing" from "the caller sent the wrong type", so the flag was simply omitted. The result JSON then echoed the CLI's *default* — `apr.run` with `max_tokens: "8"` came back saying `"max_tokens": 32` — so the client could not even detect the drop. `apr.serve`'s `port` was the one field that validated.

The second defect lives in the same layer. `apr qa` writes its JSON gate report to stdout and a one-line summary to stderr. `subprocess.rs` used stdout **only** when stderr was empty, so on any non-zero exit the report was replaced by the summary: a failing gate — the tool's entire reason to exist — reached the client as 182 bytes with the 3.2 KB report discarded. The only outcome that carried the report was the one where every gate passed.

## Root causes

| file:line | defect |
|---|---|
| `crates/aprender-mcp/src/tools/{qa,run,bench,tensors,trace,finetune}.rs` | bare `as_u64()`/`as_bool()`/`as_str()`; `None` → flag omitted |
| `crates/aprender-mcp/src/tools/subprocess.rs:57-64` (pre-fix) | `let detail = if stderr.is_empty() { stdout } else { stderr }` |
| `crates/aprender-mcp/src/tools/subprocess.rs` (pre-fix) | `format!("apr {}", args.join(" "))` — unquoted echoed command |
| `crates/apr-cli/src/commands/inference_output.rs:299` (pre-fix) | `InferenceFailed(format!("Inference failed: {e}"))` over `#[error("Inference failed: {0}")]` |
| `crates/apr-cli/src/commands/model_config.rs:58-81` (pre-fix) | `config.json` consulted only for a *directory*; error claims no path was given |
| `crates/apr-cli/src/commands/finetune.rs` | non-APR base travels to `InstructPipeline::from_apr` and dies as "Invalid magic" |

## Fix

New `crates/aprender-mcp/src/tools/args.rs` gives each declared type one narrow rule: absent or `null` is `Ok(None)`; the declared type passes; a string that parses exactly into it is coerced (`"8"` is what the caller meant, and lossless); anything else is an `Err` the tool turns into `isError`, matching what `apr.serve`'s port already did. Nothing is ever dropped. Each tool's argv construction moved into a `build_argv` so falsifiers assert what actually reaches the CLI rather than merely that the call returned something.

`failure_result` keeps the summary as the first content block and attaches the stdout report as a second one. `quote_arg` makes the echoed command re-runnable.

On the CLI side: the doubled context string is gone; architecture resolution now looks for `<stem>.config.json` and `<dir>/config.json` beside a model *file* (pacha cache and HF checkout layouts respectively), and when nothing can be derived the error names the path it was given instead of claiming none was provided. That exposed the real limitation underneath — the LoRA pipeline is `InstructPipeline::from_apr`, APR only — so a preflight rejects a non-APR base up front and points at `apr convert`.

## Before / after

Recorded evidence from the audit (crates.io 0.63.0) on the left; this build (`apr 0.63.0 (8cc3aafeb)`, same repros) on the right.

```
BEFORE  SHIM-ARGV: qa <model> --json --assert-tps 100000 --iterations 1   <- 100000
BEFORE  SHIM-ARGV: qa <model> --json --iterations 1                       <- "100000"
AFTER   SHIM-ARGV: qa <model> --json --assert-tps 100000 --iterations 1   <- 100000
AFTER   SHIM-ARGV: qa <model> --json --assert-tps 100000 --iterations 1   <- "100000"
AFTER   id=82 isError=True 'Invalid assert_tps: expected number, got "fast"'
AFTER   id=87 isError=True 'Invalid layer: expected string, got 7'

BEFORE  apr.qa failing gate -> isError=true, 1 block, 182 bytes, report gone
AFTER   apr.qa failing gate -> isError=true, 2 blocks, block 1 = 3211-byte report

BEFORE  ... failed (exit 8): error: Inference failed: Inference failed: Format error: ...
AFTER   ... failed (exit 8): error: Inference failed: Format error: ...

BEFORE  `apr run <m> --json --prompt What is 2+2? --max-tokens 8`
AFTER   `apr run <m> --json --prompt 'What is 2+2?' --max-tokens 8`

BEFORE  finetune <m>.safetensors -> error: No model path or --model-size provided
AFTER   finetune <m>.safetensors -> Fine-tuning requires an APR base model; ...
                                    Convert first: `apr convert <m> -o base.apr`
```

## Mutation check

Reverting `args.rs` to the shipped bare-accessor behaviour turns **14** tests RED, including the audit's own evidence line:

```
thread 'tools::qa::tests::assert_tps_as_a_json_string_still_reaches_the_gate'
panicked at crates/aprender-mcp/src/tools/qa.rs:130:
throughput gate disarmed: ["qa", "m.gguf", "--json", "--iterations", "1"]
```

Reverting only the `Err` branches (silent drop, correct types still honoured) turns 8 RED. Reverting `failure_result` and `quote_arg`:

```
panicked at subprocess.rs:403: gate report must reach the client, got:
  `apr qa m.gguf --json` failed (exit 5): error: Validation failed
panicked at subprocess.rs:439: stdout report dropped, only got: [ContentBlock
  { text: "`sh -c ...` failed (exit 5): SUMMARY\n" }]  left: 1  right: 2
panicked at subprocess.rs:467: left: "apr run m.gguf --prompt What is 2+2?"
```

**The first draft of `cancellable_failure_carries_both_streams` survived that mutation** — it searched every content block for the report string, and the first block echoes the command, which for an `sh -c` test *is* the script text. It now asserts on `content[1]` specifically. Flagging it because it is exactly the "test that locks the defect in" pattern the audit found four of.

Reverting the CLI fixes:

```
panicked: context applied more than once: Inference failed: Inference failed:
  Format error: Architecture 'qwen35' uses SSM/Gated Delta Net layers
panicked: message still claims no path was provided: Validation failed: No model
  path or --model-size provided. Cannot determine architecture.
panicked: message leaks the loader's internals: ... Invalid magic: e00a0000
```

All restored GREEN.

## Verification

- `cargo fmt --all -- --check` clean; `cargo clippy -p aprender-mcp --lib -- -D warnings` and `-p apr-cli --lib` clean.
- aprender-mcp: 88/88 lib + all 13 integration targets green. apr-cli: 6662/6662 lib green.
- End-to-end against a release binary built from this tree, pinned on PATH — not a unit test alone. MCP repros ran through `apr mcp` over a fifo; finetune repros ran on the real fixtures.
- Inputs varied per finding: number / string / unparseable for every field; both safetensors fixtures plus a GGUF; an APR base as positive control (passes the preflight and reaches the pipeline, failing later on an unrelated tied-embedding shape mismatch — a separate pre-existing defect, not touched here).

Fixes #2403
Fixes #2418
Fixes #2417
Audit epic: #2373
