### PR TITLE
fix(mcp): apr mcp dropped every tool result on stdin EOF, and one bad byte killed the server

### DIFF
--- a/contracts/apr-mcp-server-v1.yaml
+++ b/contracts/apr-mcp-server-v1.yaml
@@ -150,11 +150,16 @@ falsification_conditions:
 
   - id: FALSIFY-MCP-007
     description: >
-      An `initialize` whose `params.protocolVersion` does not match the
-      server's supported version is rejected with JSON-RPC error code
-      -32602 (Invalid Params); the negotiation must not advance.
+      An `initialize` whose `params.protocolVersion` differs from the
+      server's is answered with a SUCCESS result carrying the version the
+      server does support, never a JSON-RPC error. The MCP lifecycle makes
+      version negotiation a proposal the client may accept or abandon by
+      disconnecting; answering -32602 aborts the handshake, which barred
+      every client proposing a newer dated version (Claude Code / Cursor
+      propose 2025-03-26 / 2025-06-18) from connecting at all. Revised
+      2026-08-10 from the inverted gate found by the 0.63.0 dogfood (#2393).
     test_file: crates/aprender-mcp/tests/falsify_m1.rs
-    test_name: falsify_mcp_007_protocol_version_mismatch_is_minus_32602
+    test_name: falsify_mcp_007_protocol_version_mismatch_negotiates_down
     status: ENFORCED
 
   - id: FALSIFY-MCP-008
@@ -183,14 +188,81 @@ falsification_conditions:
     test_name: falsify_mcp_009_no_reply_to_notification
     status: ENFORCED
 
+  - id: FALSIFY-MCP-010
+    description: >
+      Every request carrying an `id` is answered BEFORE the read loop
+      returns, including a `tools/call` still in flight when stdin reaches
+      EOF. `tools/call` runs on a worker thread that writes its own
+      response; the 0.63.0 loop returned the instant stdin closed without
+      joining those workers, so the canonical `printf ... | apr mcp`
+      invocation silently dropped every tool result while exiting 0 —
+      indistinguishable, to the client, from a tool that produced no output.
+      Added 2026-08-10 from the 0.63.0 dogfood (#2393, P0).
+    test_file: crates/aprender-mcp/src/server.rs
+    test_name: serve_stream_answers_tools_call_before_returning_on_eof
+    status: ENFORCED
+
+  - id: FALSIFY-MCP-011
+    description: >
+      A line that is not valid UTF-8 is a malformed MESSAGE: it is answered
+      with -32700 and the session keeps serving, exactly as an already-
+      correct malformed-JSON line is. The 0.63.0 loop read lines via
+      `BufRead::lines()`, which surfaced a bad byte as an io::Error that
+      propagated out and killed the process (exit 1), losing every request
+      after it — while well-formed-UTF-8 malformed JSON was handled
+      correctly, so the server disagreed with itself.
+      Added 2026-08-10 from the 0.63.0 dogfood (#2393).
+    test_file: crates/aprender-mcp/src/server.rs
+    test_name: serve_stream_survives_invalid_utf8_line
+    status: ENFORCED
+
+  - id: FALSIFY-MCP-012
+    description: >
+      Valid JSON that is not a valid Request object is -32600 Invalid
+      Request with the client's `id` echoed, NOT -32700 Parse error with
+      `id: null`; genuinely malformed JSON stays -32700; and a JSON-RPC
+      batch ARRAY is declined with a message that names batching rather
+      than leaking serde's "invalid type: map, expected a string". The
+      server already classified a WRONG `jsonrpc` VALUE correctly, so the
+      missing-field path disagreed with its own neighbour and lost the id
+      the client needs to correlate the failure.
+      Added 2026-08-10 from the 0.63.0 dogfood (#2393).
+    test_file: crates/aprender-mcp/src/server.rs
+    test_name: missing_required_field_is_invalid_request_with_id_echoed
+    status: ENFORCED
+
+  - id: FALSIFY-MCP-013
+    description: >
+      `ping` is MCP base protocol, not an advertised capability: it is
+      answered with an empty result at any point in the session. 0.63.0
+      returned -32601 Method not found, which a keepalive client reads as a
+      dead server and acts on by restarting it.
+      Added 2026-08-10 from the 0.63.0 dogfood (#2393).
+    test_file: crates/aprender-mcp/src/server.rs
+    test_name: ping_returns_empty_result
+    status: ENFORCED
+
+  - id: FALSIFY-MCP-014
+    description: >
+      A required `tools/call` argument supplied with the WRONG JSON TYPE is
+      reported as a type error naming the received type, never as
+      "Missing required argument". 0.63.0 emitted the byte-identical
+      "missing" message for absent, empty and wrong-type arguments, so a
+      client (or an LLM) told the argument was missing retries by adding a
+      key it already sent, and loops.
+      Added 2026-08-10 from the 0.63.0 dogfood (#2393).
+    test_file: crates/aprender-mcp/src/tools/args.rs
+    test_name: wrong_type_names_the_type_and_never_says_missing
+    status: ENFORCED
+
 # ── Acceptance gate ──
-# Promoting this contract out of ACTIVE requires all 9 conditions above to
+# Promoting this contract out of ACTIVE requires all 14 conditions above to
 # hold simultaneously on a clean checkout with `cargo test -p aprender-mcp`.
 
 qa_gate:
   id: F-MCP-SERVER-GATE
   name: "apr mcp end-to-end contract"
-  pass_criteria: "All 9 FALSIFY-MCP-* tests listed in falsification_conditions pass"
+  pass_criteria: "All 14 FALSIFY-MCP-* tests listed in falsification_conditions pass"
   run: "cargo test -p aprender-mcp --no-fail-fast"
   falsification: >
     Rename or delete any referenced test_file / test_name and the

--- a/crates/aprender-contracts/tests/apr_mcp_server_contract.rs
+++ b/crates/aprender-contracts/tests/apr_mcp_server_contract.rs
@@ -5,8 +5,10 @@
 //!
 //! 1. The YAML file exists and parses as valid YAML.
 //! 2. Top-level `status: ACTIVE`.
-//! 3. Exactly 9 entries in `falsification_conditions`, with ids
-//!    FALSIFY-MCP-001 through FALSIFY-MCP-009 (no gaps, no duplicates).
+//! 3. Exactly 14 entries in `falsification_conditions`, with ids
+//!    FALSIFY-MCP-001 through FALSIFY-MCP-014 (no gaps, no duplicates).
+//!    010-014 were added 2026-08-10 for the transport and protocol defects
+//!    found by the 0.63.0 crates.io dogfood (#2393).
 //! 4. Every entry has a non-empty `test_file` that exists on disk relative
 //!    to the workspace root, plus a non-empty `test_name` and
 //!    `status: ENFORCED`.
@@ -75,29 +77,39 @@ fn apr_mcp_server_contract_is_active() {
     );
 }
 
+/// Number of FALSIFY-MCP gates the spec defines. Raised from 9 to 14 on
+/// 2026-08-10 when the 0.63.0 crates.io dogfood (#2393) surfaced five gaps
+/// this contract had no gate for: responses dropped on stdin EOF (-010), a
+/// bad UTF-8 byte killing the session (-011), Invalid-Request vs Parse-error
+/// classification (-012), `ping` (-013), and wrong-type argument diagnostics
+/// (-014).
+const EXPECTED_GATES: usize = 14;
+
 #[test]
-fn apr_mcp_server_contract_has_exactly_nine_conditions() {
+fn apr_mcp_server_contract_has_exactly_expected_conditions() {
     let contract = load_contract();
     assert_eq!(
         contract.falsification_conditions.len(),
-        9,
-        "spec defines 9 FALSIFY-MCP gates; contract has {}",
+        EXPECTED_GATES,
+        "spec defines {EXPECTED_GATES} FALSIFY-MCP gates; contract has {}",
         contract.falsification_conditions.len()
     );
 }
 
 #[test]
-fn apr_mcp_server_contract_ids_are_falsify_mcp_001_through_009() {
+fn apr_mcp_server_contract_ids_are_contiguous_from_001() {
     let contract = load_contract();
     let actual: Vec<String> = contract
         .falsification_conditions
         .iter()
         .map(|c| c.id.clone())
         .collect();
-    let expected: Vec<String> = (1..=9).map(|n| format!("FALSIFY-MCP-{n:03}")).collect();
+    let expected: Vec<String> = (1..=EXPECTED_GATES)
+        .map(|n| format!("FALSIFY-MCP-{n:03}"))
+        .collect();
     assert_eq!(
         actual, expected,
-        "ids must be exactly FALSIFY-MCP-001..009 in order (no gaps, no duplicates)"
+        "ids must be exactly FALSIFY-MCP-001..{EXPECTED_GATES:03} in order (no gaps, no duplicates)"
     );
 }
 

--- a/crates/aprender-mcp/src/server.rs
+++ b/crates/aprender-mcp/src/server.rs
@@ -61,6 +61,13 @@ type InFlight = Arc<Mutex<HashMap<serde_json::Value, CancelHandle>>>;
 #[derive(Debug, Default)]
 pub struct AprMcpServer {
     in_flight: InFlight,
+    /// Join handles for `tools/call` workers spawned by
+    /// [`Self::spawn_tools_call_worker`]. The read loop MUST join these
+    /// before returning on EOF, otherwise the process exits while a worker
+    /// still owes the client a response and the answer is lost — see
+    /// [`Self::serve_stream`].
+    #[cfg(feature = "native")]
+    workers: Vec<std::thread::JoinHandle<()>>,
 }
 
 impl AprMcpServer {
@@ -81,11 +88,10 @@ impl AprMcpServer {
     /// [`Self::handle_request_with_sink`] to drive FALSIFY-MCP-PROGRESS-001
     /// in tests.
     ///
-    /// The dispatcher enforces two protocol-level invariants before routing:
+    /// The dispatcher enforces one protocol-level invariant before routing:
     /// FALSIFY-MCP-005 (`jsonrpc` must be exactly `"2.0"` or the response is
-    /// `-32600 Invalid Request`) and FALSIFY-MCP-007 (an `initialize` whose
-    /// `params.protocolVersion` mismatches ours returns `-32602 Invalid Params`
-    /// instead of advancing to tools/list).
+    /// `-32600 Invalid Request`). Version negotiation is NOT a gate — see
+    /// [`Self::handle_initialize`] (FALSIFY-MCP-007).
     #[must_use]
     pub fn handle_request(&mut self, request: &JsonRpcRequest) -> JsonRpcResponse {
         if request.jsonrpc != "2.0" {
@@ -103,6 +109,12 @@ impl AprMcpServer {
             "initialize" => self.handle_initialize(request),
             "tools/list" => self.handle_tools_list(request),
             "tools/call" => self.handle_tools_call_sync(request),
+            // MCP base protocol utility: `ping` is not a capability and is
+            // never advertised, so a client may send it at any time to check
+            // liveness. The receiver "MUST respond promptly with an empty
+            // response". Answering -32601 makes keepalive clients conclude
+            // the server is dead and restart it.
+            "ping" => JsonRpcResponse::success(request.id.clone(), serde_json::json!({})),
             other => JsonRpcResponse::error(
                 request.id.clone(),
                 -32601,
@@ -111,28 +123,20 @@ impl AprMcpServer {
         }
     }
 
+    /// Handle `initialize`.
+    ///
+    /// FALSIFY-MCP-007: version negotiation is a *proposal*, not a gate. The
+    /// MCP lifecycle says that if the server supports the requested version it
+    /// responds with that version, and OTHERWISE responds with a version it
+    /// does support, leaving the client to decide whether to proceed or
+    /// disconnect. Returning `-32602` on a mismatch aborts the handshake, so a
+    /// client negotiating anything newer than ours (Claude Code and Cursor
+    /// both propose 2025-03-26 / 2025-06-18) can never connect at all — even
+    /// though the wire protocol it would then speak is one we handle.
+    ///
+    /// We support exactly one version, so the reply always carries
+    /// [`crate::PROTOCOL_VERSION`] regardless of what was proposed.
     fn handle_initialize(&self, request: &JsonRpcRequest) -> JsonRpcResponse {
-        // FALSIFY-MCP-007: if the client advertises a protocolVersion, it must
-        // match ours. Missing field is permitted (some clients omit it on the
-        // very first handshake); only a *mismatch* is rejected.
-        if let Some(client_version) = request
-            .params
-            .get("protocolVersion")
-            .and_then(|v| v.as_str())
-        {
-            if client_version != crate::PROTOCOL_VERSION {
-                return JsonRpcResponse::error(
-                    request.id.clone(),
-                    -32602,
-                    format!(
-                        "Unsupported protocolVersion: client requested \"{}\", server speaks \"{}\"",
-                        client_version,
-                        crate::PROTOCOL_VERSION
-                    ),
-                );
-            }
-        }
-
         JsonRpcResponse::success(
             request.id.clone(),
             serde_json::json!({
@@ -271,49 +275,128 @@ impl AprMcpServer {
 
     /// Run the server over stdio (blocking).
     ///
-    /// Reads one JSON-RPC message per line from stdin. `initialize`,
-    /// `tools/list`, and unknown methods dispatch inline. `tools/call`
-    /// spawns a worker thread so a subsequent `notifications/cancelled`
-    /// message can flow through the main loop and signal the worker's
-    /// cancel channel. Workers write their responses directly to stdout
-    /// (guarded by a mutex) so the main loop never has to wait on them.
+    /// Thin wrapper: binds [`Self::serve_stream`] to the real stdin/stdout.
+    /// All loop behaviour — and every falsifier for it — lives in
+    /// `serve_stream`, which is generic over its streams precisely so the
+    /// read loop can be exercised in-process. `run_stdio` itself is the one
+    /// piece that cannot be unit-tested, so it is kept to two lines with no
+    /// logic of its own.
     ///
     /// # Errors
     /// Returns an error if stdin/stdout I/O fails.
     #[cfg(feature = "native")]
     pub fn run_stdio(&mut self) -> anyhow::Result<()> {
-        use std::io::{self, BufRead};
+        let stdin = std::io::stdin();
+        let reader = stdin.lock();
+        self.serve_stream(reader, Arc::new(Mutex::new(std::io::stdout())))
+    }
 
-        let stdin = io::stdin();
-        let stdout = Arc::new(Mutex::new(io::stdout()));
+    /// Serve one JSON-RPC-over-newline-delimited-JSON session to completion.
+    ///
+    /// Reads one message per line from `reader`. `initialize`, `tools/list`,
+    /// `ping`, and unknown methods dispatch inline. `tools/call` spawns a
+    /// worker thread so a subsequent `notifications/cancelled` message can
+    /// flow through the main loop and signal the worker's cancel channel.
+    /// Workers write their responses directly to `out` (guarded by a mutex)
+    /// so the main loop never has to wait on them mid-stream.
+    ///
+    /// Two transport invariants live here, both found by the 0.63.0 dogfood
+    /// and both invisible to a dispatcher-level test:
+    ///
+    /// * **FALSIFY-MCP-010** — on EOF the loop MUST join every worker it
+    ///   spawned before returning. Without that join the process exits the
+    ///   instant stdin closes, so the canonical `printf ... | apr mcp`
+    ///   invocation loses every `tools/call` result while still exiting 0 —
+    ///   indistinguishable, to the client, from a tool that produced no
+    ///   output.
+    /// * **FALSIFY-MCP-011** — lines are read as BYTES and decoded per line.
+    ///   A line that is not valid UTF-8 is a malformed *message*, answered
+    ///   with `-32700`, not a transport failure that takes the session down
+    ///   with it.
+    ///
+    /// `W` must be `Send + 'static` because the same handle is shared with
+    /// every worker thread.
+    ///
+    /// # Errors
+    /// Returns an error if reading or writing the streams fails.
+    #[cfg(feature = "native")]
+    pub fn serve_stream<R, W>(&mut self, mut reader: R, out: Arc<Mutex<W>>) -> anyhow::Result<()>
+    where
+        R: std::io::BufRead,
+        W: std::io::Write + Send + 'static,
+    {
+        let mut buf: Vec<u8> = Vec::new();
 
-        for line in stdin.lock().lines() {
-            let line = line?;
+        loop {
+            buf.clear();
+            if reader.read_until(b'\n', &mut buf)? == 0 {
+                break; // EOF
+            }
+            while matches!(buf.last(), Some(b'\n' | b'\r')) {
+                buf.pop();
+            }
+
+            // FALSIFY-MCP-011: one bad byte must cost one message, not the
+            // session. `BufRead::lines()` surfaced this as an io::Error that
+            // propagated out of the loop and killed the process (exit 1), so
+            // every request after the bad byte went unanswered.
+            let Ok(line) = std::str::from_utf8(&buf) else {
+                let resp =
+                    JsonRpcResponse::error(None, -32700, "Parse error: message is not valid UTF-8");
+                write_response(&out, &resp)?;
+                continue;
+            };
+
             if line.trim().is_empty() {
                 continue;
             }
 
-            let parsed: Result<JsonRpcRequest, _> = serde_json::from_str(&line);
-            match parsed {
-                Ok(req) => self.route_stdio_message(req, &stdout)?,
-                Err(e) => {
-                    let resp = JsonRpcResponse::error(None, -32700, format!("Parse error: {e}"));
-                    write_response(&stdout, &resp)?;
-                }
+            match parse_incoming(line) {
+                Ok(req) => self.route_stdio_message(req, &out)?,
+                Err(resp) => write_response(&out, &resp)?,
             }
+
+            self.reap_finished_workers();
         }
 
+        // FALSIFY-MCP-010: drain before returning. EOF means the client sent
+        // everything it intends to, NOT that it stopped wanting answers.
+        self.join_workers();
         Ok(())
     }
 
-    /// Dispatch one parsed request within the stdio loop. Separated from
-    /// [`Self::run_stdio`] for testability.
+    /// Drop join handles for workers that have already finished, so a
+    /// long-lived session does not accumulate one handle per tool call.
+    /// Never blocks — `is_finished` is a non-blocking check.
     #[cfg(feature = "native")]
-    fn route_stdio_message(
+    fn reap_finished_workers(&mut self) {
+        self.workers.retain(|h| !h.is_finished());
+    }
+
+    /// Block until every in-flight `tools/call` worker has written its
+    /// response. Called once, on EOF, by [`Self::serve_stream`].
+    ///
+    /// A panicking worker is ignored rather than propagated: the client is
+    /// owed whatever the surviving workers produced, and the panic message
+    /// has already reached stderr.
+    #[cfg(feature = "native")]
+    fn join_workers(&mut self) {
+        for handle in std::mem::take(&mut self.workers) {
+            let _ = handle.join();
+        }
+    }
+
+    /// Dispatch one parsed request within the read loop. Separated from
+    /// [`Self::serve_stream`] for testability.
+    #[cfg(feature = "native")]
+    fn route_stdio_message<W>(
         &mut self,
         req: JsonRpcRequest,
-        stdout: &Arc<Mutex<std::io::Stdout>>,
-    ) -> anyhow::Result<()> {
+        stdout: &Arc<Mutex<W>>,
+    ) -> anyhow::Result<()>
+    where
+        W: std::io::Write + Send + 'static,
+    {
         // FALSIFY-MCP-005: jsonrpc field gate runs before method dispatch.
         if req.jsonrpc != "2.0" {
             let resp = JsonRpcResponse::error(
@@ -361,11 +444,14 @@ impl AprMcpServer {
     }
 
     #[cfg(feature = "native")]
-    fn spawn_tools_call_worker(
+    fn spawn_tools_call_worker<W>(
         &mut self,
         req: JsonRpcRequest,
-        stdout: &Arc<Mutex<std::io::Stdout>>,
-    ) -> anyhow::Result<()> {
+        stdout: &Arc<Mutex<W>>,
+    ) -> anyhow::Result<()>
+    where
+        W: std::io::Write + Send + 'static,
+    {
         // Notifications would arrive with id = None; tools/call must have
         // an id per JSON-RPC. Defensive: if it's missing, respond inline
         // with an error so the client sees the failure immediately.
@@ -410,7 +496,12 @@ impl AprMcpServer {
         });
 
         match spawn_result {
-            Ok(_handle) => Ok(()),
+            Ok(handle) => {
+                // FALSIFY-MCP-010: keep the handle so EOF can wait for this
+                // worker's response instead of exiting out from under it.
+                self.workers.push(handle);
+                Ok(())
+            }
             Err(e) => {
                 // Failed to spawn — clean up the registry entry we just
                 // inserted and report the failure inline.
@@ -502,12 +593,123 @@ fn extract_progress_token(params: &serde_json::Value) -> Option<serde_json::Valu
 }
 
 #[cfg(feature = "native")]
-fn write_response(
-    stdout: &Arc<Mutex<std::io::Stdout>>,
+/// JSON type name, in JSON Schema vocabulary, for diagnostics.
+fn json_type_name(value: &serde_json::Value) -> &'static str {
+    crate::tools::args::json_type_name(value)
+}
+
+/// Parse one incoming line into a [`JsonRpcRequest`], or into the JSON-RPC
+/// error response that must be sent instead.
+///
+/// FALSIFY-MCP-012: JSON-RPC 2.0 draws a line the old
+/// `serde_json::from_str::<JsonRpcRequest>` path could not see. `-32700 Parse
+/// error` means "the payload was not valid JSON". A payload that IS valid JSON
+/// but is not a valid Request object is `-32600 Invalid Request`, and its
+/// response must echo the request's `id` so the client can correlate the
+/// failure. Deserializing straight into the struct reported a missing
+/// `jsonrpc` or `method` field as a *parse* error with `id: null` — while a
+/// jsonrpc field with the WRONG VALUE was already correctly reported as
+/// -32600 with the id echoed, so the server disagreed with itself.
+///
+/// A batch ARRAY gets its own message. Batching is optional for a 2024-11-05
+/// server and we decline it, but the old behaviour surfaced serde's attempt to
+/// read the first array element as the `jsonrpc` string — "invalid type: map,
+/// expected a string at line 1 column 1" — which names neither batching nor
+/// arrays and points at a '[' that is perfectly valid JSON.
+/// The error side is boxed because `JsonRpcResponse` is large enough that
+/// clippy's `result_large_err` fires on the bare form, and the error path is
+/// the rare one.
+fn parse_incoming(line: &str) -> Result<JsonRpcRequest, Box<JsonRpcResponse>> {
+    let value: serde_json::Value = serde_json::from_str(line).map_err(|e| {
+        Box::new(JsonRpcResponse::error(
+            None,
+            -32700,
+            format!("Parse error: {e}"),
+        ))
+    })?;
+
+    if value.is_array() {
+        return Err(Box::new(JsonRpcResponse::error(
+            None,
+            -32600,
+            "Invalid Request: JSON-RPC batch arrays are not supported; \
+             send one request per line",
+        )));
+    }
+
+    let Some(obj) = value.as_object() else {
+        return Err(Box::new(JsonRpcResponse::error(
+            None,
+            -32600,
+            format!(
+                "Invalid Request: a request must be a JSON object, got {}",
+                json_type_name(&value)
+            ),
+        )));
+    };
+
+    // A null id is the same as an absent one (serde maps JSON null to None for
+    // `Option<Value>`), which is what keeps FALSIFY-MCP-009's notification
+    // rule intact.
+    let id = obj.get("id").filter(|v| !v.is_null()).cloned();
+
+    let jsonrpc = match obj.get("jsonrpc") {
+        Some(serde_json::Value::String(s)) => s.clone(),
+        Some(other) => {
+            return Err(Box::new(JsonRpcResponse::error(
+                id,
+                -32600,
+                format!(
+                    "Invalid Request: \"jsonrpc\" must be the string \"2.0\", got {}",
+                    json_type_name(other)
+                ),
+            )));
+        }
+        None => {
+            return Err(Box::new(JsonRpcResponse::error(
+                id,
+                -32600,
+                "Invalid Request: missing required field \"jsonrpc\"",
+            )));
+        }
+    };
+
+    let method = match obj.get("method") {
+        Some(serde_json::Value::String(s)) => s.clone(),
+        Some(other) => {
+            return Err(Box::new(JsonRpcResponse::error(
+                id,
+                -32600,
+                format!(
+                    "Invalid Request: \"method\" must be a string, got {}",
+                    json_type_name(other)
+                ),
+            )));
+        }
+        None => {
+            return Err(Box::new(JsonRpcResponse::error(
+                id,
+                -32600,
+                "Invalid Request: missing required field \"method\"",
+            )));
+        }
+    };
+
+    Ok(JsonRpcRequest {
+        jsonrpc,
+        id,
+        method,
+        params: obj
+            .get("params")
+            .cloned()
+            .unwrap_or(serde_json::Value::Null),
+    })
+}
+
+fn write_response<W: std::io::Write>(
+    stdout: &Arc<Mutex<W>>,
     resp: &JsonRpcResponse,
 ) -> anyhow::Result<()> {
-    use std::io::Write;
-
     let json = serde_json::to_string(resp)?;
     let mut guard = stdout
         .lock()
@@ -522,12 +724,10 @@ fn write_response(
 /// worker-local `NotificationSink` built in
 /// [`AprMcpServer::spawn_tools_call_worker`].
 #[cfg(feature = "native")]
-fn write_notification(
-    stdout: &Arc<Mutex<std::io::Stdout>>,
+fn write_notification<W: std::io::Write>(
+    stdout: &Arc<Mutex<W>>,
     notif: &JsonRpcNotification,
 ) -> anyhow::Result<()> {
-    use std::io::Write;
-
     let json = notif.to_json_line()?;
     let mut guard = stdout
         .lock()
@@ -549,6 +749,259 @@ mod tests {
             method: method.to_string(),
             params,
         }
+    }
+
+    /// Drive a whole session through [`AprMcpServer::serve_stream`] with
+    /// in-memory streams and return the response lines it wrote.
+    ///
+    /// This is the point of `serve_stream` being generic: FALSIFY-MCP-010 and
+    /// -011 live in the read loop, not in request handling, so a
+    /// `handle_request` test cannot see either. Driving the real loop over a
+    /// byte slice reproduces both defects exactly — including invalid UTF-8,
+    /// which cannot even be expressed as a `&str` input.
+    #[cfg(feature = "native")]
+    fn drive(input: &[u8]) -> Vec<serde_json::Value> {
+        let out = Arc::new(Mutex::new(Vec::<u8>::new()));
+        let mut server = AprMcpServer::new();
+        server
+            .serve_stream(std::io::Cursor::new(input.to_vec()), Arc::clone(&out))
+            .expect("serve_stream must not propagate an error out of the session");
+
+        let guard = out.lock().expect("output mutex not poisoned");
+        String::from_utf8_lossy(&guard)
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .map(|l| {
+                serde_json::from_str::<serde_json::Value>(l)
+                    .unwrap_or_else(|e| panic!("non-JSON output line {l:?}: {e}"))
+            })
+            .collect()
+    }
+
+    #[cfg(feature = "native")]
+    fn find_id(responses: &[serde_json::Value], id: i64) -> Option<&serde_json::Value> {
+        responses.iter().find(|r| r["id"] == serde_json::json!(id))
+    }
+
+    #[cfg(feature = "native")]
+    const INIT_LINE: &str = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05"}}"#;
+    #[cfg(feature = "native")]
+    const CALL_LINE: &str = r#"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"apr.version","arguments":{}}}"#;
+
+    /// FALSIFY-MCP-010: every request carrying an `id` must be answered before
+    /// the loop returns, INCLUDING a `tools/call` still in flight when the
+    /// input reaches EOF.
+    ///
+    /// The shipped 0.63.0 loop returned the instant stdin closed, without
+    /// joining the worker that owed the client its answer, so
+    /// `printf '<initialize>\n<tools/call>\n' | apr mcp` answered initialize,
+    /// exited 0, and silently dropped the tool result — indistinguishable
+    /// from a tool that produced no output.
+    #[cfg(feature = "native")]
+    #[test]
+    fn serve_stream_answers_tools_call_before_returning_on_eof() {
+        let responses = drive(format!("{INIT_LINE}\n{CALL_LINE}\n").as_bytes());
+
+        let call = find_id(&responses, 2).unwrap_or_else(|| {
+            panic!(
+                "tools/call response (id=2) was DROPPED at EOF; got {} response(s): {responses:?}",
+                responses.len()
+            )
+        });
+        assert!(
+            call.get("error").is_none(),
+            "tools/call must succeed, got {call:?}"
+        );
+        let text = call["result"]["content"][0]["text"]
+            .as_str()
+            .unwrap_or_else(|| panic!("missing content text in {call:?}"));
+        let payload: serde_json::Value =
+            serde_json::from_str(text).expect("apr.version payload is JSON");
+        assert_eq!(
+            payload["server"], "aprender-mcp",
+            "must be the real apr.version result, not an empty envelope"
+        );
+        assert!(
+            find_id(&responses, 1).is_some(),
+            "initialize still answered"
+        );
+    }
+
+    /// FALSIFY-MCP-010 (concurrency): several pipelined `tools/call` requests
+    /// must ALL be answered, not just the ones that happened to finish before
+    /// EOF.
+    #[cfg(feature = "native")]
+    #[test]
+    fn serve_stream_answers_every_pipelined_tools_call() {
+        let mut input = format!("{INIT_LINE}\n");
+        for id in 2..=6 {
+            input.push_str(&format!(
+                r#"{{"jsonrpc":"2.0","id":{id},"method":"tools/call","params":{{"name":"apr.version","arguments":{{}}}}}}"#
+            ));
+            input.push('\n');
+        }
+
+        let responses = drive(input.as_bytes());
+        for id in 1..=6 {
+            assert!(
+                find_id(&responses, id).is_some(),
+                "id={id} unanswered; got {} of 6: {responses:?}",
+                responses.len()
+            );
+        }
+    }
+
+    /// FALSIFY-MCP-011: an invalid UTF-8 byte is a malformed MESSAGE. It must
+    /// cost exactly that one message — a -32700 — and the session must keep
+    /// serving, matching how the loop already treats malformed JSON.
+    ///
+    /// The shipped loop propagated an `io::Error` out of `BufRead::lines()`
+    /// and killed the process (exit 1), losing every later request. Here the
+    /// same failure would surface as `serve_stream` returning `Err`, which
+    /// `drive` turns into a panic.
+    #[cfg(feature = "native")]
+    #[test]
+    fn serve_stream_survives_invalid_utf8_line() {
+        let mut input: Vec<u8> = Vec::new();
+        input.extend_from_slice(br#"{"jsonrpc":"2.0","id":1,"method":"ping"}"#);
+        input.push(b'\n');
+        input.push(0xFF); // never valid UTF-8
+        input.push(b'\n');
+        input.extend_from_slice(br#"{"jsonrpc":"2.0","id":2,"method":"ping"}"#);
+        input.push(b'\n');
+
+        let responses = drive(&input);
+
+        assert!(
+            find_id(&responses, 1).is_some(),
+            "request before the bad byte must be answered: {responses:?}"
+        );
+        let after = find_id(&responses, 2)
+            .unwrap_or_else(|| panic!("request AFTER the bad byte was lost: {responses:?}"));
+        assert!(
+            after.get("error").is_none(),
+            "request after the bad byte must be served normally, got {after:?}"
+        );
+        let parse_err = responses
+            .iter()
+            .find(|r| r["error"]["code"] == serde_json::json!(-32700))
+            .unwrap_or_else(|| panic!("the bad line itself must be reported: {responses:?}"));
+        assert!(
+            parse_err["error"]["message"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("UTF-8"),
+            "the -32700 must name the cause, got {parse_err:?}"
+        );
+    }
+
+    /// FALSIFY-MCP-011 (leading byte): a bad byte arriving before any valid
+    /// request must not stop the session from ever starting.
+    #[cfg(feature = "native")]
+    #[test]
+    fn serve_stream_survives_leading_invalid_utf8() {
+        let mut input: Vec<u8> = vec![0x80, b'\n'];
+        input.extend_from_slice(br#"{"jsonrpc":"2.0","id":1,"method":"ping"}"#);
+        input.push(b'\n');
+
+        let responses = drive(&input);
+        assert!(
+            find_id(&responses, 1).is_some(),
+            "the request after a leading bad byte must be answered: {responses:?}"
+        );
+    }
+
+    /// The whole request-handling surface, over the real loop: negotiation,
+    /// ping, Invalid-Request classification, batch diagnostics, and the
+    /// -32700 case that must NOT regress.
+    #[cfg(feature = "native")]
+    #[test]
+    fn serve_stream_protocol_surface_matches_jsonrpc_and_mcp() {
+        let input = concat!(
+            r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18"}}"#,
+            "\n",
+            r#"{"jsonrpc":"2.0","id":2,"method":"ping"}"#,
+            "\n",
+            r#"{"id":3,"method":"tools/list"}"#,
+            "\n",
+            r#"{"jsonrpc":"2.0","id":4}"#,
+            "\n",
+            r#"[{"jsonrpc":"2.0","id":5,"method":"tools/list"}]"#,
+            "\n",
+            r#"{not json"#,
+            "\n",
+            r#"{"jsonrpc":"2.0","id":7,"method":"tools/list"}"#,
+            "\n",
+        );
+
+        let responses = drive(input.as_bytes());
+
+        let init = find_id(&responses, 1).expect("initialize answered");
+        assert!(
+            init.get("error").is_none(),
+            "a newer protocolVersion must not abort the handshake: {init:?}"
+        );
+        assert_eq!(init["result"]["protocolVersion"], crate::PROTOCOL_VERSION);
+
+        let pong = find_id(&responses, 2).expect("ping answered");
+        assert_eq!(pong["result"], serde_json::json!({}), "ping must pong");
+
+        for id in [3, 4] {
+            let resp = find_id(&responses, id).unwrap_or_else(|| {
+                panic!("id={id} must be echoed on an Invalid Request: {responses:?}")
+            });
+            assert_eq!(
+                resp["error"]["code"],
+                serde_json::json!(-32600),
+                "id={id} must be Invalid Request, not Parse error: {resp:?}"
+            );
+        }
+
+        let batch = responses
+            .iter()
+            .find(|r| {
+                r["error"]["message"]
+                    .as_str()
+                    .is_some_and(|m| m.contains("batch"))
+            })
+            .unwrap_or_else(|| panic!("batch array must be diagnosed as such: {responses:?}"));
+        assert_eq!(batch["error"]["code"], serde_json::json!(-32600));
+
+        assert!(
+            responses
+                .iter()
+                .any(|r| r["error"]["code"] == serde_json::json!(-32700)),
+            "`{{not json` must remain a Parse error: {responses:?}"
+        );
+        assert!(
+            find_id(&responses, 7).is_some(),
+            "the loop must keep serving after every malformed line: {responses:?}"
+        );
+    }
+
+    /// FALSIFY-MCP-009 over the real loop: a request with no id is a
+    /// notification and MUST NOT be answered.
+    #[cfg(feature = "native")]
+    #[test]
+    fn serve_stream_never_answers_a_notification() {
+        let responses = drive(
+            concat!(
+                r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#,
+                "\n",
+                r#"{"jsonrpc":"2.0","method":"tools/list"}"#,
+                "\n",
+                r#"{"jsonrpc":"2.0","id":9,"method":"ping"}"#,
+                "\n",
+            )
+            .as_bytes(),
+        );
+
+        assert_eq!(
+            responses.len(),
+            1,
+            "only the id-bearing request may be answered: {responses:?}"
+        );
+        assert!(find_id(&responses, 9).is_some());
     }
 
     /// FALSIFY-MCP-001: initialize returns protocolVersion "2024-11-05".
@@ -700,6 +1153,164 @@ mod tests {
             !signalled_again,
             "cancelling an already-removed id is a no-op"
         );
+    }
+
+    /// FALSIFY-MCP-007: a client proposing a version we do not speak must get
+    /// the version we DO speak, not a handshake-aborting error. Claude Code
+    /// and Cursor propose 2025-03-26 / 2025-06-18; under the old -32602 gate
+    /// neither could ever connect.
+    #[test]
+    fn initialize_negotiates_down_instead_of_erroring() {
+        for proposed in ["2025-06-18", "2025-03-26", "2024-10-07", "latest", ""] {
+            let mut server = AprMcpServer::new();
+            let req = make_request(
+                "initialize",
+                serde_json::json!({ "protocolVersion": proposed }),
+            );
+            let resp = server.handle_request(&req);
+
+            assert!(
+                resp.error.is_none(),
+                "proposing {proposed:?} must not abort the handshake, got {:?}",
+                resp.error
+            );
+            let result = resp.result.expect("result present");
+            assert_eq!(
+                result["protocolVersion"],
+                crate::PROTOCOL_VERSION,
+                "server must answer with the version it actually speaks"
+            );
+        }
+    }
+
+    /// A non-string `protocolVersion` must not be treated as a proposal we
+    /// somehow honoured — the reply still carries our version.
+    #[test]
+    fn initialize_ignores_non_string_protocol_version() {
+        let mut server = AprMcpServer::new();
+        let req = make_request("initialize", serde_json::json!({ "protocolVersion": 2025 }));
+        let resp = server.handle_request(&req);
+        assert!(resp.error.is_none());
+        let result = resp.result.expect("result present");
+        assert_eq!(result["protocolVersion"], crate::PROTOCOL_VERSION);
+    }
+
+    /// `ping` is MCP base protocol: an empty result, not -32601. A keepalive
+    /// client reads an error (or silence) as a dead server and restarts it.
+    #[test]
+    fn ping_returns_empty_result() {
+        let mut server = AprMcpServer::new();
+        let req = make_request("ping", serde_json::json!({}));
+        let resp = server.handle_request(&req);
+
+        assert!(
+            resp.error.is_none(),
+            "ping must not error: {:?}",
+            resp.error
+        );
+        assert_eq!(resp.result, Some(serde_json::json!({})));
+        assert_eq!(resp.id, Some(serde_json::json!(1)), "id echoed");
+    }
+
+    /// FALSIFY-MCP-012: valid JSON that is not a valid Request object is
+    /// -32600 Invalid Request with the id echoed — NOT -32700 with id null.
+    /// The server already got this right for a WRONG jsonrpc value, so the
+    /// missing-field path disagreed with its own neighbour.
+    #[test]
+    fn missing_required_field_is_invalid_request_with_id_echoed() {
+        for line in [
+            r#"{"id":1,"method":"tools/list"}"#,
+            r#"{"jsonrpc":"2.0","id":1}"#,
+            r#"{"jsonrpc":2.0,"id":1,"method":"tools/list"}"#,
+            r#"{"jsonrpc":"2.0","id":1,"method":42}"#,
+        ] {
+            let resp = parse_incoming(line).expect_err("must be rejected");
+            let err = resp.error.as_ref().expect("error present");
+            assert_eq!(
+                err.code, -32600,
+                "{line} must be Invalid Request, got {err:?}"
+            );
+            assert_eq!(
+                resp.id,
+                Some(serde_json::json!(1)),
+                "{line} must echo the client's id so it can correlate"
+            );
+        }
+    }
+
+    /// Genuinely malformed JSON must STAY -32700 — the fix above must not
+    /// swallow the case the code already handled correctly.
+    #[test]
+    fn malformed_json_is_still_parse_error() {
+        for line in [
+            r#"{not json"#,
+            r#"{"jsonrpc":"2.0","id":1,"method":"tools/li"#,
+        ] {
+            let resp = parse_incoming(line).expect_err("must be rejected");
+            let err = resp.error.as_ref().expect("error present");
+            assert_eq!(err.code, -32700, "{line} must remain a Parse error");
+        }
+    }
+
+    /// A batch array must be diagnosed as a batch array. The old message was
+    /// serde's "invalid type: map, expected a string at line 1 column 1",
+    /// which names neither batching nor arrays.
+    #[test]
+    fn batch_array_is_diagnosed_as_unsupported_batching() {
+        let line = r#"[{"jsonrpc":"2.0","id":1,"method":"tools/list"},{"jsonrpc":"2.0","id":2,"method":"tools/list"}]"#;
+        let resp = parse_incoming(line).expect_err("batch must be rejected");
+        let err = resp.error.as_ref().expect("error present");
+        assert_eq!(err.code, -32600);
+        assert!(
+            err.message.contains("batch"),
+            "message must name batching, got: {}",
+            err.message
+        );
+        assert!(
+            !err.message.contains("expected a string"),
+            "must not leak serde's field-level error, got: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn non_object_request_is_invalid_request() {
+        for line in ["42", r#""hello""#, "null", "true"] {
+            let resp = parse_incoming(line).expect_err("must be rejected");
+            let err = resp.error.as_ref().expect("error present");
+            assert_eq!(err.code, -32600, "{line} must be Invalid Request");
+        }
+    }
+
+    /// Happy path: a well-formed request survives the new shape validation
+    /// with every field intact, including an absent `params`.
+    #[test]
+    fn well_formed_request_parses_unchanged() {
+        let req = parse_incoming(r#"{"jsonrpc":"2.0","id":"abc","method":"tools/list"}"#)
+            .expect("well-formed request must parse");
+        assert_eq!(req.jsonrpc, "2.0");
+        assert_eq!(req.method, "tools/list");
+        assert_eq!(req.id, Some(serde_json::json!("abc")));
+        assert_eq!(req.params, serde_json::Value::Null);
+
+        let with_params = parse_incoming(
+            r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"apr.version"}}"#,
+        )
+        .expect("params must round-trip");
+        assert_eq!(with_params.params["name"], "apr.version");
+    }
+
+    /// FALSIFY-MCP-009 must survive the rewrite: a null or absent id still
+    /// means "notification", which `route_stdio_message` relies on to stay
+    /// silent.
+    #[test]
+    fn null_and_absent_id_both_parse_as_notification() {
+        let absent = parse_incoming(r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#)
+            .expect("parse");
+        assert!(absent.id.is_none());
+        let null_id =
+            parse_incoming(r#"{"jsonrpc":"2.0","id":null,"method":"tools/list"}"#).expect("parse");
+        assert!(null_id.id.is_none(), "a null id is not an id");
     }
 
     /// FALSIFY-MCP-006 (unit): cancelling an unknown id is a safe no-op.

--- a/crates/aprender-mcp/src/tools/args.rs
+++ b/crates/aprender-mcp/src/tools/args.rs
@@ -1,0 +1,114 @@
+//! Shared `tools/call` argument extraction.
+//!
+//! Every subprocess wrapper needs the same thing: pull a required string out
+//! of the `arguments` object or fail. Doing that with
+//! `args.get(name).and_then(|v| v.as_str())` collapses two distinct client
+//! mistakes into one message — an argument that was never sent and an
+//! argument sent with the wrong JSON type both read as
+//! "Missing required argument: model_path". A client (or an LLM) told the
+//! argument is missing retries by adding a key it already sent, and loops.
+//!
+//! [`require_str`] keeps the two apart: absent says missing, present-but-not-a-
+//! string names the type it actually received and the type the declared
+//! `inputSchema` asked for.
+
+use crate::types::ToolCallResult;
+
+/// JSON type name as it appears in a JSON Schema `type` keyword.
+///
+/// Used in argument-validation messages so the text a client sees lines up
+/// with the vocabulary of the `inputSchema` it was given by `tools/list`.
+#[must_use]
+pub fn json_type_name(value: &serde_json::Value) -> &'static str {
+    match value {
+        serde_json::Value::Null => "null",
+        serde_json::Value::Bool(_) => "boolean",
+        serde_json::Value::Number(_) => "number",
+        serde_json::Value::String(_) => "string",
+        serde_json::Value::Array(_) => "array",
+        serde_json::Value::Object(_) => "object",
+    }
+}
+
+/// Extract a required string argument from a `tools/call` `arguments` object.
+///
+/// # Errors
+/// Returns a ready-to-send `isError: true` [`ToolCallResult`] when the
+/// argument is absent (`Missing required argument: <name>`) or present with a
+/// non-string JSON type (`Argument <name> must be a string, got <type>`). The
+/// two messages are deliberately distinguishable — see the module header.
+pub fn require_str<'a>(args: &'a serde_json::Value, name: &str) -> Result<&'a str, ToolCallResult> {
+    match args.get(name) {
+        Some(serde_json::Value::String(s)) => Ok(s.as_str()),
+        Some(other) => Err(ToolCallResult::error(format!(
+            "Argument {name} must be a string, got {}",
+            json_type_name(other)
+        ))),
+        None => Err(ToolCallResult::error(format!(
+            "Missing required argument: {name}"
+        ))),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::disallowed_methods)] // serde_json::json! expands to code that hits unwrap()
+mod tests {
+    use super::*;
+
+    #[test]
+    fn present_string_is_returned() {
+        let args = serde_json::json!({ "model_path": "/tmp/m.gguf" });
+        assert_eq!(require_str(&args, "model_path").ok(), Some("/tmp/m.gguf"));
+    }
+
+    #[test]
+    fn absent_argument_says_missing() {
+        let args = serde_json::json!({});
+        let err = require_str(&args, "model_path").expect_err("absent must fail");
+        assert_eq!(err.is_error, Some(true));
+        assert_eq!(err.content[0].text, "Missing required argument: model_path");
+    }
+
+    /// The defect this module exists for: a wrong-TYPE argument must not be
+    /// reported as missing, because the client can see it sent the key.
+    #[test]
+    fn wrong_type_names_the_type_and_never_says_missing() {
+        for (value, expected_type) in [
+            (serde_json::json!(123), "number"),
+            (serde_json::json!(true), "boolean"),
+            (serde_json::json!(["/tmp/m.gguf"]), "array"),
+            (serde_json::json!({ "path": "/tmp/m.gguf" }), "object"),
+            (serde_json::json!(null), "null"),
+        ] {
+            let args = serde_json::json!({ "model_path": value });
+            let err = require_str(&args, "model_path").expect_err("wrong type must fail");
+            let text = &err.content[0].text;
+            assert_eq!(
+                text,
+                &format!("Argument model_path must be a string, got {expected_type}"),
+                "wrong-type message for {value}"
+            );
+            assert!(
+                !text.contains("Missing"),
+                "a supplied argument must never be reported as missing, got: {text}"
+            );
+        }
+    }
+
+    #[test]
+    fn non_object_arguments_read_as_missing() {
+        let args = serde_json::json!("notanobject");
+        let err = require_str(&args, "model_path").expect_err("non-object must fail");
+        assert_eq!(err.content[0].text, "Missing required argument: model_path");
+    }
+
+    #[test]
+    fn json_type_name_covers_every_variant() {
+        assert_eq!(json_type_name(&serde_json::json!(null)), "null");
+        assert_eq!(json_type_name(&serde_json::json!(false)), "boolean");
+        assert_eq!(json_type_name(&serde_json::json!(1.5)), "number");
+        assert_eq!(json_type_name(&serde_json::json!("s")), "string");
+        assert_eq!(json_type_name(&serde_json::json!([])), "array");
+        assert_eq!(json_type_name(&serde_json::json!({})), "object");
+    }
+}

--- a/crates/aprender-mcp/src/tools/bench.rs
+++ b/crates/aprender-mcp/src/tools/bench.rs
@@ -34,8 +34,9 @@ pub fn bench_tool_definition() -> ToolDefinition {
 /// Execute `apr.bench` by spawning `apr bench <model> --json [...flags]`.
 #[must_use]
 pub fn call(args: &serde_json::Value) -> ToolCallResult {
-    let Some(model_path) = args.get("model_path").and_then(|v| v.as_str()) else {
-        return ToolCallResult::error("Missing required argument: model_path");
+    let model_path = match crate::tools::args::require_str(args, "model_path") {
+        Ok(p) => p,
+        Err(e) => return e,
     };
 
     let mut owned: Vec<String> = vec![

--- a/crates/aprender-mcp/src/tools/finetune.rs
+++ b/crates/aprender-mcp/src/tools/finetune.rs
@@ -85,8 +85,9 @@ pub fn call_with_sink(
     sink: Option<&NotificationSink>,
     progress_token: Option<serde_json::Value>,
 ) -> ToolCallResult {
-    let Some(base_model) = args.get("base_model").and_then(|v| v.as_str()) else {
-        return ToolCallResult::error("Missing required argument: base_model");
+    let base_model = match crate::tools::args::require_str(args, "base_model") {
+        Ok(p) => p,
+        Err(e) => return e,
     };
 
     let mut owned: Vec<String> = vec![
@@ -216,6 +217,12 @@ mod tests {
         let result = call(&serde_json::json!({ "base_model": 42 }));
         assert_eq!(result.is_error, Some(true));
         assert!(result.content[0].text.contains("base_model"));
+        // Shape ("is_error, mentions the field") passed while the message said
+        // the argument was MISSING — see tools::args. Assert the behaviour.
+        assert_eq!(
+            result.content[0].text,
+            "Argument base_model must be a string, got number"
+        );
     }
 
     /// FALSIFY-MCP-PROGRESS-001 (unit): `stream_with_sink` fires one

--- a/crates/aprender-mcp/src/tools/mod.rs
+++ b/crates/aprender-mcp/src/tools/mod.rs
@@ -9,6 +9,7 @@
 //!   see FALSIFY-MCP-PROGRESS-001) + `notifications/cancelled` →
 //!   SIGTERM→SIGKILL for `apr.run` (FALSIFY-MCP-006).
 
+pub mod args;
 pub mod bench;
 pub mod finetune;
 pub mod qa;

--- a/crates/aprender-mcp/src/tools/qa.rs
+++ b/crates/aprender-mcp/src/tools/qa.rs
@@ -34,8 +34,9 @@ pub fn qa_tool_definition() -> ToolDefinition {
 /// Execute `apr.qa` by spawning `apr qa <model> --json [...flags]`.
 #[must_use]
 pub fn call(args: &serde_json::Value) -> ToolCallResult {
-    let Some(model_path) = args.get("model_path").and_then(|v| v.as_str()) else {
-        return ToolCallResult::error("Missing required argument: model_path");
+    let model_path = match crate::tools::args::require_str(args, "model_path") {
+        Ok(p) => p,
+        Err(e) => return e,
     };
 
     let mut owned: Vec<String> = vec![

--- a/crates/aprender-mcp/src/tools/run.rs
+++ b/crates/aprender-mcp/src/tools/run.rs
@@ -82,8 +82,9 @@ pub fn call_with_sink(
     sink: Option<&NotificationSink>,
     progress_token: Option<serde_json::Value>,
 ) -> ToolCallResult {
-    let Some(model_path) = args.get("model_path").and_then(|v| v.as_str()) else {
-        return ToolCallResult::error("Missing required argument: model_path");
+    let model_path = match crate::tools::args::require_str(args, "model_path") {
+        Ok(p) => p,
+        Err(e) => return e,
     };
 
     let streaming = sink.is_some() && progress_token.is_some();

--- a/crates/aprender-mcp/src/tools/serve.rs
+++ b/crates/aprender-mcp/src/tools/serve.rs
@@ -112,8 +112,9 @@ pub fn serve_tool_definition() -> ToolDefinition {
 /// all look like. See this module's header for the terminal states.
 #[must_use]
 pub fn call(args: &serde_json::Value) -> ToolCallResult {
-    let Some(model_path) = args.get("model_path").and_then(|v| v.as_str()) else {
-        return ToolCallResult::error("Missing required argument: model_path");
+    let model_path = match crate::tools::args::require_str(args, "model_path") {
+        Ok(p) => p,
+        Err(e) => return e,
     };
 
     let port: u16 = match args.get("port") {

--- a/crates/aprender-mcp/src/tools/tensors.rs
+++ b/crates/aprender-mcp/src/tools/tensors.rs
@@ -35,8 +35,9 @@ pub fn tensors_tool_definition() -> ToolDefinition {
 /// Execute `apr.tensors` by spawning `apr tensors <model> --json [...flags]`.
 #[must_use]
 pub fn call(args: &serde_json::Value) -> ToolCallResult {
-    let Some(model_path) = args.get("model_path").and_then(|v| v.as_str()) else {
-        return ToolCallResult::error("Missing required argument: model_path");
+    let model_path = match crate::tools::args::require_str(args, "model_path") {
+        Ok(p) => p,
+        Err(e) => return e,
     };
 
     let mut argv: Vec<&str> = vec!["tensors", model_path, "--json"];

--- a/crates/aprender-mcp/src/tools/trace.rs
+++ b/crates/aprender-mcp/src/tools/trace.rs
@@ -34,8 +34,9 @@ pub fn trace_tool_definition() -> ToolDefinition {
 /// Execute `apr.trace` by spawning `apr trace <model> --json [...flags]`.
 #[must_use]
 pub fn call(args: &serde_json::Value) -> ToolCallResult {
-    let Some(model_path) = args.get("model_path").and_then(|v| v.as_str()) else {
-        return ToolCallResult::error("Missing required argument: model_path");
+    let model_path = match crate::tools::args::require_str(args, "model_path") {
+        Ok(p) => p,
+        Err(e) => return e,
     };
 
     let mut owned: Vec<String> = vec![

--- a/crates/aprender-mcp/src/tools/validate.rs
+++ b/crates/aprender-mcp/src/tools/validate.rs
@@ -41,8 +41,9 @@ pub fn validate_tool_definition() -> ToolDefinition {
 /// Execute `apr.validate` by spawning `apr validate <model_path> --json`.
 #[must_use]
 pub fn call(args: &serde_json::Value) -> ToolCallResult {
-    let Some(model_path) = args.get("model_path").and_then(|v| v.as_str()) else {
-        return ToolCallResult::error("Missing required argument: model_path");
+    let model_path = match crate::tools::args::require_str(args, "model_path") {
+        Ok(p) => p,
+        Err(e) => return e,
     };
     run_apr(&["validate", model_path, "--json"])
 }
@@ -84,9 +85,22 @@ mod tests {
         assert!(result.content[0].text.contains("model_path"));
     }
 
+    /// This test used to assert only `is_error == Some(true)`, which is shape,
+    /// not behaviour — it passed while the server told the client an argument
+    /// it had plainly sent was "Missing required argument: model_path". A
+    /// wrong-TYPE argument must name the type, so a client (or an LLM) does
+    /// not retry by re-adding a key it already supplied.
     #[test]
     fn nonstring_model_path_returns_error() {
         let result = call(&serde_json::json!({ "model_path": 42 }));
         assert_eq!(result.is_error, Some(true));
+        assert_eq!(
+            result.content[0].text,
+            "Argument model_path must be a string, got number"
+        );
+        assert!(
+            !result.content[0].text.contains("Missing"),
+            "an argument the client sent must never be reported as missing"
+        );
     }
 }

--- a/crates/aprender-mcp/tests/falsify_m1.rs
+++ b/crates/aprender-mcp/tests/falsify_m1.rs
@@ -135,28 +135,40 @@ fn falsify_mcp_005_invalid_jsonrpc_version_is_minus_32600() {
     assert_eq!(resp.id, Some(serde_json::json!(40)), "id echoed back");
 }
 
-/// FALSIFY-MCP-007: an `initialize` whose `params.protocolVersion` does not
-/// match the server's supported version must be rejected with `-32602 Invalid
-/// Params`. The server must not advance the connection — subsequent
-/// `tools/list` from the same client would also need to fail until a compatible
-/// version is negotiated, but here we only assert the negotiation-phase error.
+/// FALSIFY-MCP-007: an `initialize` whose `params.protocolVersion` differs
+/// from ours must be answered with the version the server DOES support, so the
+/// client can decide whether to proceed or disconnect.
+///
+/// This gate previously asserted the opposite — `-32602 Invalid Params` on any
+/// mismatch — and so locked in the defect found by the 0.63.0 dogfood: every
+/// MCP client that negotiates a newer dated version (Claude Code and Cursor
+/// propose 2025-03-26 / 2025-06-18) had its handshake aborted and could never
+/// connect, even though the wire protocol it would then speak is one this
+/// server handles. The MCP lifecycle is explicit that a version mismatch is
+/// answered with a supported version, not an error. Rewritten with the
+/// contract entry in `contracts/apr-mcp-server-v1.yaml`.
 #[test]
-fn falsify_mcp_007_protocol_version_mismatch_is_minus_32602() {
-    let mut server = AprMcpServer::new();
-    let resp = server.handle_request(&request(
-        50,
-        "initialize",
-        serde_json::json!({ "protocolVersion": "1999-01-01" }),
-    ));
+fn falsify_mcp_007_protocol_version_mismatch_negotiates_down() {
+    for proposed in ["1999-01-01", "2025-06-18", "2025-03-26", "2024-10-07"] {
+        let mut server = AprMcpServer::new();
+        let resp = server.handle_request(&request(
+            50,
+            "initialize",
+            serde_json::json!({ "protocolVersion": proposed }),
+        ));
 
-    assert!(resp.result.is_none(), "must not return success");
-    let err = resp.error.expect("error present");
-    assert_eq!(err.code, -32602, "must be Invalid Params");
-    assert!(
-        err.message.contains("protocolVersion"),
-        "message should mention protocolVersion, got: {}",
-        err.message
-    );
+        assert!(
+            resp.error.is_none(),
+            "proposing {proposed} must not abort the handshake, got: {:?}",
+            resp.error
+        );
+        let result = resp.result.expect("result present");
+        assert_eq!(
+            result["protocolVersion"], PROTOCOL_VERSION,
+            "server must answer with the version it speaks"
+        );
+        assert_eq!(result["serverInfo"]["name"], "aprender-mcp");
+    }
 }
 
 /// FALSIFY-MCP-007 (negative): an `initialize` whose `params.protocolVersion`

--- a/crates/aprender-mcp/tests/falsify_mcp_stdio_protocol.rs
+++ b/crates/aprender-mcp/tests/falsify_mcp_stdio_protocol.rs
@@ -1,0 +1,355 @@
+//! FALSIFY-MCP-010/-011 — stdio TRANSPORT conformance for `apr mcp`.
+//!
+//! These two defects are invisible to an in-process dispatcher test, because
+//! both live in the read loop rather than in request handling:
+//!
+//! * **FALSIFY-MCP-010** — `tools/call` runs on a worker thread that writes
+//!   its own response. The read loop returned on EOF without joining workers,
+//!   so `printf '<initialize>\n<tools/call>\n' | apr mcp` answered initialize,
+//!   exited 0, and silently dropped the tool result. 3/3 deterministic on the
+//!   shipped 0.63.0 binary.
+//! * **FALSIFY-MCP-011** — one invalid UTF-8 byte on stdin propagated an
+//!   `io::Error` out of `BufRead::lines()` and killed the process (exit 1),
+//!   losing every request after it. Well-formed-UTF-8 malformed JSON was
+//!   already handled correctly (-32700, keep serving), so the two disagreed.
+//!
+//! Both are asserted here by driving the real `apr mcp` binary, because a
+//! unit test cannot observe "the process exited before the answer was
+//! written".
+
+#![allow(clippy::disallowed_methods)] // serde_json::json! expands to code that hits unwrap()
+
+use std::io::{Read, Write};
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::sync::mpsc;
+use std::time::Duration;
+
+/// Hard cap on a whole stdio session. Anything slower is a hang, not a slow
+/// machine — `apr.version` is answered in-process with no subprocess spawn.
+const SESSION_TIMEOUT: Duration = Duration::from_secs(30);
+
+const INITIALIZE: &str = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"falsifier","version":"1"}}}"#;
+const TOOLS_CALL_VERSION: &str = r#"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"apr.version","arguments":{}}}"#;
+
+/// Locate the workspace-built `apr`, building it on demand when the test
+/// crate is exercised in isolation. Same approach as
+/// `falsify_mcp_dogfood_001.rs`.
+fn apr_binary() -> PathBuf {
+    let candidate = assert_cmd::cargo::cargo_bin("apr");
+    if candidate.is_file() {
+        return candidate;
+    }
+    let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
+    let pkg_spec = format!("aprender@{}", env!("CARGO_PKG_VERSION"));
+    let status = Command::new(&cargo)
+        .args(["build", "--bin", "apr", "-p", &pkg_spec, "--quiet"])
+        .status()
+        .expect("invoke `cargo build --bin apr`");
+    assert!(
+        status.success(),
+        "cargo build --bin apr -p {pkg_spec} failed"
+    );
+    let path = assert_cmd::cargo::cargo_bin("apr");
+    assert!(path.is_file(), "apr binary missing after cargo build");
+    path
+}
+
+/// One complete stdio session: write `input`, CLOSE stdin (the whole point —
+/// this is the EOF the server used to exit through), then read stdout to EOF.
+///
+/// Returns `(exit_code, parsed_response_lines, stderr)`.
+fn drive_stdio(input: &[u8]) -> (Option<i32>, Vec<serde_json::Value>, String) {
+    let mut child = Command::new(apr_binary())
+        .arg("mcp")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn `apr mcp`");
+
+    let mut stdin = child.stdin.take().expect("piped stdin");
+    stdin.write_all(input).expect("write stdin");
+    stdin.flush().expect("flush stdin");
+    drop(stdin); // EOF
+
+    let mut stdout = child.stdout.take().expect("piped stdout");
+    let (tx, rx) = mpsc::channel::<String>();
+    let reader = std::thread::spawn(move || {
+        let mut buf = String::new();
+        let _ = stdout.read_to_string(&mut buf);
+        let _ = tx.send(buf);
+    });
+
+    let out = match rx.recv_timeout(SESSION_TIMEOUT) {
+        Ok(s) => s,
+        Err(e) => {
+            let _ = child.kill();
+            panic!("`apr mcp` did not close stdout within {SESSION_TIMEOUT:?}: {e}");
+        }
+    };
+    let _ = reader.join();
+
+    let status = child.wait().expect("wait for `apr mcp`");
+    let mut stderr = String::new();
+    if let Some(mut e) = child.stderr.take() {
+        let _ = e.read_to_string(&mut stderr);
+    }
+
+    let responses = out
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| {
+            serde_json::from_str::<serde_json::Value>(l)
+                .unwrap_or_else(|e| panic!("`apr mcp` emitted a non-JSON stdout line {l:?}: {e}"))
+        })
+        .collect();
+
+    (status.code(), responses, stderr)
+}
+
+fn find_id(responses: &[serde_json::Value], id: i64) -> Option<&serde_json::Value> {
+    responses.iter().find(|r| r["id"] == serde_json::json!(id))
+}
+
+/// FALSIFY-MCP-010: every request carrying an `id` must be answered before
+/// the server exits, INCLUDING a `tools/call` still in flight when stdin
+/// closes. Run three times because the shipped defect was deterministic and
+/// a single green run could otherwise be a scheduling accident.
+#[test]
+fn falsify_mcp_010_tools_call_is_answered_before_eof_exit() {
+    let input = format!("{INITIALIZE}\n{TOOLS_CALL_VERSION}\n");
+
+    for attempt in 1..=3 {
+        let (code, responses, stderr) = drive_stdio(input.as_bytes());
+
+        assert_eq!(
+            code,
+            Some(0),
+            "attempt {attempt}: clean exit; stderr: {stderr}"
+        );
+        let call = find_id(&responses, 2).unwrap_or_else(|| {
+            panic!(
+                "attempt {attempt}: tools/call response (id=2) was DROPPED on stdin EOF. \
+                 Got {} response(s): {:?}",
+                responses.len(),
+                responses
+            )
+        });
+        assert!(
+            call.get("error").is_none(),
+            "attempt {attempt}: tools/call must succeed, got {call:?}"
+        );
+        let text = call["result"]["content"][0]["text"]
+            .as_str()
+            .unwrap_or_else(|| panic!("attempt {attempt}: missing content text in {call:?}"));
+        let payload: serde_json::Value =
+            serde_json::from_str(text).expect("apr.version payload is JSON");
+        assert_eq!(
+            payload["server"], "aprender-mcp",
+            "attempt {attempt}: tool payload must be the real apr.version result"
+        );
+        assert!(
+            find_id(&responses, 1).is_some(),
+            "attempt {attempt}: initialize must still be answered"
+        );
+    }
+}
+
+// REMOVED: an "ordering variant" that sent an inline `tools/list` AFTER the
+// tools/call. It was mutation-tested against the unfixed binary and PASSED —
+// serializing the large tools/list response gives the worker enough time to
+// finish writing before EOF, so the test could never observe the drop it
+// claimed to guard. A test that stays green on the defect is theater; the two
+// FALSIFY-MCP-010 cases that remain both turn RED (verbatim: "tools/call
+// response (id=2) was DROPPED on stdin EOF").
+
+/// FALSIFY-MCP-010 (concurrency): several `tools/call` requests in one
+/// pipeline must ALL be answered, not just the ones that happened to finish
+/// before EOF.
+#[test]
+fn falsify_mcp_010_every_pipelined_tools_call_is_answered() {
+    let mut input = String::from(INITIALIZE);
+    input.push('\n');
+    for id in 2..=6 {
+        input.push_str(&format!(
+            r#"{{"jsonrpc":"2.0","id":{id},"method":"tools/call","params":{{"name":"apr.version","arguments":{{}}}}}}"#
+        ));
+        input.push('\n');
+    }
+
+    let (code, responses, stderr) = drive_stdio(input.as_bytes());
+    assert_eq!(code, Some(0), "clean exit; stderr: {stderr}");
+    for id in 1..=6 {
+        assert!(
+            find_id(&responses, id).is_some(),
+            "id={id} unanswered; got {} of 6: {responses:?}",
+            responses.len()
+        );
+    }
+}
+
+/// FALSIFY-MCP-011: an invalid UTF-8 byte is a malformed MESSAGE. It must
+/// cost exactly that one message — a -32700 — and the session must keep
+/// serving, matching how the server already treats malformed JSON.
+#[test]
+fn falsify_mcp_011_invalid_utf8_line_does_not_kill_the_session() {
+    let mut input: Vec<u8> = Vec::new();
+    input.extend_from_slice(br#"{"jsonrpc":"2.0","id":1,"method":"tools/list"}"#);
+    input.push(b'\n');
+    input.push(0xFF); // lone continuation byte — never valid UTF-8
+    input.push(b'\n');
+    input.extend_from_slice(br#"{"jsonrpc":"2.0","id":2,"method":"ping"}"#);
+    input.push(b'\n');
+
+    let (code, responses, stderr) = drive_stdio(&input);
+
+    assert_eq!(
+        code,
+        Some(0),
+        "one bad byte must not kill the server; stderr: {stderr}"
+    );
+    assert!(
+        find_id(&responses, 1).is_some(),
+        "request before the bad byte must be answered: {responses:?}"
+    );
+    let after = find_id(&responses, 2)
+        .unwrap_or_else(|| panic!("request AFTER the bad byte was lost; got {responses:?}"));
+    assert!(
+        after.get("error").is_none(),
+        "request after the bad byte must be served normally, got {after:?}"
+    );
+    let parse_err = responses
+        .iter()
+        .find(|r| r["error"]["code"] == serde_json::json!(-32700))
+        .unwrap_or_else(|| panic!("the bad line itself must be reported: {responses:?}"));
+    assert!(
+        parse_err["error"]["message"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("UTF-8"),
+        "the -32700 must name the cause, got {parse_err:?}"
+    );
+}
+
+/// FALSIFY-MCP-011 (leading byte): the bad byte arriving before any valid
+/// request must not prevent the session from ever starting.
+#[test]
+fn falsify_mcp_011_leading_invalid_utf8_still_serves_the_first_request() {
+    let mut input: Vec<u8> = vec![0x80, b'\n'];
+    input.extend_from_slice(br#"{"jsonrpc":"2.0","id":1,"method":"tools/list"}"#);
+    input.push(b'\n');
+
+    let (code, responses, stderr) = drive_stdio(&input);
+    assert_eq!(code, Some(0), "clean exit; stderr: {stderr}");
+    assert!(
+        find_id(&responses, 1).is_some(),
+        "the request after a leading bad byte must be answered: {responses:?}"
+    );
+}
+
+/// FALSIFY-MCP-011 (embedded): an invalid 2-byte sequence inside an otherwise
+/// well-formed request is rejected with -32700 and never silently repaired
+/// into a different string value.
+#[test]
+fn falsify_mcp_011_invalid_utf8_inside_a_request_is_rejected_not_repaired() {
+    let mut input: Vec<u8> = Vec::new();
+    input.extend_from_slice(
+        br#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"apr.validate","arguments":{"model_path":"/tmp/"#,
+    );
+    input.extend_from_slice(&[0xC3, 0x28]); // invalid 2-byte sequence
+    input.extend_from_slice(br#".gguf"}}}"#);
+    input.push(b'\n');
+    input.extend_from_slice(br#"{"jsonrpc":"2.0","id":2,"method":"ping"}"#);
+    input.push(b'\n');
+
+    let (code, responses, stderr) = drive_stdio(&input);
+    assert_eq!(code, Some(0), "clean exit; stderr: {stderr}");
+    assert!(
+        responses
+            .iter()
+            .any(|r| r["error"]["code"] == serde_json::json!(-32700)),
+        "the malformed line must be reported as a parse error: {responses:?}"
+    );
+    assert!(
+        find_id(&responses, 2).is_some(),
+        "the following request must still be served: {responses:?}"
+    );
+}
+
+/// End-to-end confirmation of the four request-handling fixes over the real
+/// transport: version negotiation, `ping`, Invalid-Request classification and
+/// batch-array diagnostics.
+#[test]
+fn falsify_mcp_stdio_protocol_surface_matches_jsonrpc_and_mcp() {
+    let input = concat!(
+        r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18"}}"#,
+        "\n",
+        r#"{"jsonrpc":"2.0","id":2,"method":"ping"}"#,
+        "\n",
+        r#"{"id":3,"method":"tools/list"}"#,
+        "\n",
+        r#"{"jsonrpc":"2.0","id":4}"#,
+        "\n",
+        r#"[{"jsonrpc":"2.0","id":5,"method":"tools/list"}]"#,
+        "\n",
+        r#"{not json"#,
+        "\n",
+        r#"{"jsonrpc":"2.0","id":7,"method":"tools/list"}"#,
+        "\n",
+    );
+
+    let (code, responses, stderr) = drive_stdio(input.as_bytes());
+    assert_eq!(code, Some(0), "clean exit; stderr: {stderr}");
+
+    // A newer proposed version negotiates DOWN to ours, it does not abort.
+    let init = find_id(&responses, 1).expect("initialize answered");
+    assert!(
+        init.get("error").is_none(),
+        "a newer protocolVersion must not abort the handshake: {init:?}"
+    );
+    assert_eq!(init["result"]["protocolVersion"], "2024-11-05");
+
+    // ping is base protocol — empty result, never -32601.
+    let pong = find_id(&responses, 2).expect("ping answered");
+    assert_eq!(
+        pong["result"],
+        serde_json::json!({}),
+        "ping must pong: {pong:?}"
+    );
+
+    // Valid JSON that isn't a valid Request is -32600, with the id echoed.
+    for id in [3, 4] {
+        let resp = find_id(&responses, id).unwrap_or_else(|| {
+            panic!("id={id} must be echoed on an Invalid Request: {responses:?}")
+        });
+        assert_eq!(
+            resp["error"]["code"],
+            serde_json::json!(-32600),
+            "id={id} must be Invalid Request, not Parse error: {resp:?}"
+        );
+    }
+
+    // A batch array names batching.
+    let batch = responses
+        .iter()
+        .find(|r| {
+            r["error"]["message"]
+                .as_str()
+                .is_some_and(|m| m.contains("batch"))
+        })
+        .unwrap_or_else(|| panic!("batch array must be diagnosed as such: {responses:?}"));
+    assert_eq!(batch["error"]["code"], serde_json::json!(-32600));
+
+    // Genuinely malformed JSON is still -32700, and the session survives it.
+    assert!(
+        responses
+            .iter()
+            .any(|r| r["error"]["code"] == serde_json::json!(-32700)),
+        "`{{not json` must remain a Parse error: {responses:?}"
+    );
+    assert!(
+        find_id(&responses, 7).is_some(),
+        "the server must keep serving after every malformed line: {responses:?}"
+    );
+}


### PR DESCRIPTION
Driving the shipped 0.63.0 `apr mcp` over stdio, the canonical scripted invocation loses its answer:

```
printf '<initialize>\n<tools/call apr.version>\n' | apr mcp
-> exit 0, ONE response line (id=1), the id=2 tool result never written
```

3/3 deterministic, stderr empty. `tools/call` runs on a worker thread that writes its own response, while `initialize`/`tools/list` answer inline on the read loop. The loop returned the instant stdin closed without joining those workers, so the process exited while a worker still owed the client a reply. Exit 0 with no output is indistinguishable, to a client, from a tool that produced nothing — the failure is silent. Holding stdin open was the only working client pattern and was documented nowhere.

Same loop, second defect: one invalid UTF-8 byte terminated the whole server.

```
rc=1, "error: Aprender error: mcp server: stream did not contain valid UTF-8"
```

Every request after the bad byte was lost. `BufRead::lines()` surfaces a bad byte as an `io::Error` and `let line = line?` propagated it out. The server already handled well-formed-UTF-8 malformed JSON correctly (-32700, keep serving), so it disagreed with itself about what a malformed message costs.

Both now: lines are read as BYTES and decoded per line, so a bad line is a malformed *message* answered with -32700; and EOF joins every in-flight worker before returning.

## The other five

| Finding | Before | After |
|---|---|---|
| `initialize` negotiation | -32602 on anything but the literal `2024-11-05` (including *older* versions — string inequality, not a floor check) | success carrying `2024-11-05`, per the MCP lifecycle |
| `ping` | -32601 Method not found | `{"result":{}}` |
| Missing `jsonrpc`/`method` | -32700 with `id:null` (while a *wrong* `jsonrpc` value was already correctly -32600 with id echoed) | -32600 with id echoed; malformed JSON stays -32700 |
| Batch array | serde's `invalid type: map, expected a string at line 1 column 1` | -32600 naming batching |
| Wrong-type argument | `Missing required argument: model_path` for an argument that WAS sent | `Argument model_path must be a string, got number` |

The negotiation defect barred every client this server advertises itself to: Claude Code and Cursor propose 2025-03-26 / 2025-06-18, and `README.md:25` names them.

## Root causes

All in `crates/aprender-mcp/src/server.rs` at 0.63.0: the read loop (`for line in stdin.lock().lines()` / `let line = line?`, no worker join on EOF), `handle_initialize`'s -32602 early return, the absent `ping` arm, and `serde_json::from_str::<JsonRpcRequest>` mapping a missing field to a parse error.

## Why the loop was made generic

`run_stdio` is now a two-line binding over a new `serve_stream<R, W>`. Not cosmetic: FALSIFY-MCP-010 and -011 live in the read loop, not in request handling, so no `handle_request` test can see either — and invalid UTF-8 cannot even be expressed as a `&str` input. CI's `workspace-test` runs `--lib` plus an explicit allowlist that does not include this crate's `tests/` directory, so an integration-only guard for a P0 would never run. Making the loop generic puts six falsifiers for it in the `--lib` target CI actually executes.

## Mutation check

Reverted each fix, kept the tests, rebuilt the binary so the harness could not reuse a fixed one:

```
serve_stream_answers_tools_call_before_returning_on_eof
  tools/call response (id=2) was DROPPED at EOF; got 1 response(s): [...]
serve_stream_answers_every_pipelined_tools_call
  id=2 unanswered; got 1 of 6
serve_stream_survives_invalid_utf8_line
  serve_stream must not propagate an error out of the session:
  stream did not contain valid UTF-8: invalid utf-8 sequence of 1 bytes
falsify_mcp_007_protocol_version_mismatch_negotiates_down
  proposing 1999-01-01 must not abort the handshake, got:
  Some(JsonRpcError { code: -32602, ... })
wrong_type_names_the_type_and_never_says_missing
  left:  "Missing required argument: model_path"
  right: "Argument model_path must be a string, got number"
```

At the binary level the reverted build reproduced the issue verbatim, including `tools/call response (id=2) was DROPPED on stdin EOF` and rc=1 `stream did not contain valid UTF-8`.

## Two tests did not survive that check

- `falsify_m1`'s FALSIFY-MCP-007 **asserted the defect** — it required -32602 on any mismatch, so the gate was actively holding the handshake broken. Rewritten together with its contract entry.
- A `tools/call` "ordering variant" in the new integration file **PASSED against the unfixed binary**: serializing the large `tools/list` response gives the worker time to finish before EOF, so it could never observe the drop it claimed to guard. Removed — a test that stays green on the defect is theater.

`validate.rs` / `finetune.rs` wrong-type tests asserted only `is_error == Some(true)`, which is shape; they passed while the message contradicted the request. Strengthened to assert the text.

## Contract

`contracts/apr-mcp-server-v1.yaml` gains FALSIFY-MCP-010 through -014; the loader test's hardcoded nine-gate count becomes a named constant. `pv validate` clean.

## End-to-end verification

Against a binary built from this tree, using the issue's own repros: all four proposed protocolVersions negotiate to 2024-11-05, ping pongs, both missing-field cases are -32600 with id echoed, the batch array is named, the wrong-type argument names the type, the tools/call result arrives 3/3 on EOF, and the bad-byte stream answers ids 1 and 2 plus a -32700 with rc=0.

Note: the crates.io 0.63.0 reference binary was never present at the path the task specified, so the "before" side is the issue's recorded evidence plus a locally rebuilt reverted binary, which reproduced every finding.

Fixes #2393
Audit epic: #2373
