### PR TITLE
fix(serve): /realize/model invented its own provenance and the GGUF serve path was not Ollama-compatible at all

### DIFF
--- a/contracts/apr-serve-openai-compat-v1.yaml
+++ b/contracts/apr-serve-openai-compat-v1.yaml
@@ -1,7 +1,7 @@
 contract: apr-serve-openai-compat
 metadata:
   kind: pattern
-  version: "1.15.0"
+  version: "1.16.0"
   description: >
     OpenAI-compatible serve layer (/v1/chat/completions, /v1/completions,
     /v1/embeddings) fidelity invariants. Established by an adversarial audit
@@ -248,6 +248,59 @@ proof_obligations:
       the realizar-side handlers any caller mounting create_router gets
       (crates/aprender-serve/src/api/ollama_handlers.rs::created_at_now).
 
+  - type: invariant
+    property: >
+      OLLAMA-COMPAT-ON-THE-REALIZAR-ROUTER (dogfood 0.63.0, #2396): the Ollama
+      surface obligations above are stated for the apr-cli APR-CPU router.
+      `apr serve run <GGUF>` mounts a DIFFERENT router — realizar
+      create_router, via apr-cli run_cpu_server — and 0.63.0 shipped that one
+      unfixed: `stream:true` was parsed and discarded (one buffered
+      application/json object with content-length 181), and /api/tags,
+      /api/show and /api/version answered 404 while the startup banner
+      advertised "Ollama-Parity Endpoints". On the realizar router,
+      `stream:true` now responds application/x-ndjson with NO content-length:
+      a sequence of `{...,done:false}` objects whose content/response
+      fragments CONCATENATE to the full generation, terminated by exactly one
+      `{...,done:true,done_reason:"stop",prompt_eval_count,eval_count}`.
+      Non-terminal objects omit the counts rather than sending zeros.
+      `stream:false` is unchanged (one application/json object). NOTE ON
+      SCOPE: this router's chat backend has no token callback, so the
+      fragments are produced from the finished generation — the WIRE PROTOCOL
+      is correct and clients no longer freeze, but time-to-first-object is
+      unchanged. /api/tags, /api/show and /api/version are routed.
+  - type: invariant
+    property: >
+      MODEL-METADATA-MEASURED-OR-ABSENT (dogfood 0.63.0, #2402): every field
+      the metadata endpoints (/realize/model, /api/tags, /api/show) report is
+      either MEASURED or ABSENT from the JSON. There is no defaulted value.
+      0.63.0 returned `size_bytes: 0`, `quantization: "Q4_K_M"`,
+      `context_length: 4096`, `format: "gguf"` and
+      `content_hash: "blake3:0".repeat(16)` as constants for every model — on a
+      1.04 GiB Q4_K GGUF served with `--context-length 128` against a
+      32768-context model, all five were wrong. The content_hash is the worst
+      of them: a 128-character string shaped exactly like a BLAKE3 digest,
+      which a consumer cannot distinguish from a real one and will store and
+      compare as provenance. `lineage` is therefore emitted ONLY when a hash
+      was actually computed over the model bytes. Measured values come from
+      api/model_source.rs::ModelSourceInfo: size and container format from the
+      FILE (magic bytes, not the extension), quantization from the qtype of
+      the loaded projection tensors (not GGUF's advisory general.file_type),
+      architecture from the loader. The context the server was CONFIGURED with
+      (`--context-length`) and the model's own advertised maximum are reported
+      as two SEPARATE fields; conflating them is what produced the 4096.
+  - type: invariant
+    property: >
+      ERROR-MESSAGES-NAME-A-REAL-REMEDY (dogfood 0.63.0, #2402): an error body
+      that tells the caller how to fix the problem must name a remedy that
+      exists. POST /realize/reload without registry mode answers 501; 0.63.0's
+      body said "Start server with --registry flag", and `apr serve run
+      --registry <FILE>` is rejected by clap with exit 2 (no such flag on
+      `apr serve run` or on `apr serve`), so the endpoint was unreachable by
+      any documented invocation. The message now states that the CLI does not
+      expose registry mode, names the embedder API that does
+      (AppState::with_registry), and gives the working alternative (restart
+      with `apr serve run <MODEL>`).
+
 falsification_tests:
   - id: FALSIFY-STOP-TRUNCATE-754
     name: pmat754_stop_truncation_tests
@@ -357,3 +410,27 @@ falsification_tests:
     test_harness: 'cargo test -p aprender-serve --lib api::ollama_handlers'
     expected_output: "test result: ok"
     if_fails: 'A caller mounting realizar create_router serves a non-RFC-3339 created_at, so an ollama Go client discards the whole /api/chat or /api/generate response.'
+  - id: FALSIFY-OLLAMA-REALIZAR-ROUTER-NDJSON-2396
+    name: api_chat_with_stream_true_returns_ndjson_terminated_by_done
+    prediction: 'On the router `apr serve run <GGUF>` actually mounts (realizar create_router, reached via apr-cli run_cpu_server — NOT the apr-cli APR-CPU router PMAT-928 fixed), POST /api/chat and POST /api/generate with stream:true answer Content-Type application/x-ndjson with NO content-length header, and a body of newline-delimited JSON objects in which only the LAST carries done:true (plus done_reason, prompt_eval_count, eval_count); the non-terminal objects omit the counts entirely. stream:false still returns exactly one application/json object (no-regression). RED on 0.63.0, where the realizar handlers hardcoded stream:false and answered application/json with content-length 181 for a stream:true request.'
+    test_harness: 'cargo test -p aprender-serve --lib api::tests::ollama_compat_http'
+    expected_output: "test result: ok"
+    if_fails: 'A stream:true /api/chat or /api/generate request against the GGUF serve path returns one buffered application/json object, so every Ollama-compatible UI (ollama CLI, Open WebUI, continue.dev) shows a frozen cursor for the whole generation — the shipped 0.63.0 behaviour on the realizar router.'
+  - id: FALSIFY-OLLAMA-REALIZAR-ROUTER-DISCOVERY-2396
+    name: api_tags_is_routed_and_lists_a_model_the_client_can_ask_for
+    prediction: 'GET /api/tags, POST /api/show and GET /api/version are ROUTED on realizar create_router — each answers 200 with its own body, never the axum not_found fallback (`{"error":"not_found"}`). /api/tags lists exactly one model whose `name` is an addressable `model:tag` echoed in `model`; /api/show carries `details` and a `capabilities` list containing "completion"; /api/version returns a semver-shaped string. RED on 0.63.0, where all three returned HTTP 404 while the startup banner advertised "Ollama-Parity Endpoints".'
+    test_harness: 'cargo test -p aprender-serve --lib api::tests::ollama_compat_http'
+    expected_output: "test result: ok"
+    if_fails: 'The Ollama discovery routes are unwired on the router apr serve mounts for GGUF, so `ollama list`, Open WebUI, LangChain ChatOllama and LlamaIndex cannot enumerate the model and never issue a chat request at all.'
+  - id: FALSIFY-MODEL-METADATA-MEASURED-OR-ABSENT-2402
+    name: realize_model_never_emits_a_synthetic_content_hash
+    prediction: 'GET /realize/model, GET /api/tags and POST /api/show emit a field ONLY when the loader measured it. With no ModelSourceInfo attached, size_bytes / context_length / quantization / format and the whole `lineage` block are ABSENT from the JSON, and the body contains no "blake3:0blake3:0" substring. With a ModelSourceInfo built from a real file, size_bytes equals the file size, format comes from the magic bytes (an APR file reports "apr", not "gguf"), and `context_length` (what --context-length set) and `model_max_context_length` (the model''s own advertised maximum) are reported as SEPARATE values. RED on 0.63.0, which hardcoded size_bytes:0, quantization:"Q4_K_M", context_length:4096, format:"gguf" and content_hash:"blake3:0".repeat(16).'
+    test_harness: 'cargo test -p aprender-serve --lib api::tests::ollama_compat_http'
+    expected_output: "test result: ok"
+    if_fails: 'A metadata endpoint substitutes a plausible-looking constant for an unmeasured field. The content_hash case is the worst: a 128-character string shaped exactly like a BLAKE3 digest is indistinguishable to a consumer from a real one, so fabricated provenance gets stored and compared as if it were measured.'
+  - id: FALSIFY-RELOAD-501-NAMES-A-REAL-REMEDY-2402
+    name: realize_reload_501_does_not_advertise_a_nonexistent_flag
+    prediction: 'POST /realize/reload without registry mode answers 501 with an error body that does NOT contain "Start server with --registry flag", DOES state that the CLI does not expose registry mode, and DOES name the working alternative (`apr serve run`). RED on 0.63.0, whose 501 body pointed at a --registry flag that clap rejects with exit 2 on both `apr serve run` and `apr serve`.'
+    test_harness: 'cargo test -p aprender-serve --lib realize_reload_501_does_not_advertise_a_nonexistent_flag'
+    expected_output: "test result: ok"
+    if_fails: 'The 501 tells the caller to pass a flag that does not exist, so the endpoint is unreachable by any documented invocation and the error message sends users down a dead end.'

--- a/crates/apr-cli/src/commands/serve/mod.rs
+++ b/crates/apr-cli/src/commands/serve/mod.rs
@@ -30,6 +30,13 @@ use crate::error::{CliError, Result};
 /// Serve command entry point (blocking)
 #[provable_contracts_macros::contract("apr-cli-operations-v1", equation = "long_running_graceful")]
 pub(crate) fn run(model_path: &Path, config: &ServerConfig) -> Result<()> {
+    // Record which file we are serving so the metadata endpoints can MEASURE
+    // it instead of reporting constants. Everything downstream takes
+    // `&ServerConfig`, so stamping it once here reaches every serve path.
+    let config = &ServerConfig {
+        model_path: Some(model_path.to_path_buf()),
+        ..config.clone()
+    };
     contract_pre_graceful_shutdown!();
     contract_pre_resource_cleanup!();
     contract_pre_concurrent_isolation!();

--- a/crates/apr-cli/src/commands/serve/server.rs
+++ b/crates/apr-cli/src/commands/serve/server.rs
@@ -1,4 +1,60 @@
 
+/// The quantization actually present in the loaded weights.
+///
+/// Derived from the qtype of the projection tensors themselves — the ground
+/// truth — not from GGUF's advisory `general.file_type`, which goes stale when
+/// a file is requantized. Returns the modal qtype across every layer's
+/// attention-output and FFN projections, or `None` when no layer carries a
+/// qtype this build knows a name for. Never guesses "Q4_K_M".
+#[cfg(feature = "inference")]
+fn dominant_quantization(model: &realizar::gguf::OwnedQuantizedModel) -> Option<&'static str> {
+    use std::collections::HashMap;
+
+    let mut counts: HashMap<u32, usize> = HashMap::new();
+    for layer in model.layers() {
+        let mut tally = |qtype: u32| *counts.entry(qtype).or_insert(0) += 1;
+        tally(layer.attn_output_weight.qtype);
+        tally(layer.ffn_up_weight.qtype);
+        tally(layer.ffn_down_weight.qtype);
+        if let Some(gate) = layer.ffn_gate_weight.as_ref() {
+            tally(gate.qtype);
+        }
+    }
+    counts
+        .into_iter()
+        .filter_map(|(qtype, n)| realizar::api::gguf_qtype_name(qtype).map(|name| (name, n)))
+        .max_by_key(|&(_, n)| n)
+        .map(|(name, _)| name)
+}
+
+/// Everything this process actually knows about the model it just loaded.
+///
+/// Facts come from three places, all measured: the file (size, container
+/// format from magic bytes), the loaded weights (architecture, quantization,
+/// the model's own advertised context length) and the operator's flags
+/// (`--context-length`). No field is defaulted — an unmeasured field is
+/// reported as absent by the metadata handlers.
+#[cfg(feature = "inference")]
+fn measured_model_source(
+    model: &realizar::gguf::OwnedQuantizedModel,
+    config: &ServerConfig,
+) -> realizar::api::ModelSourceInfo {
+    let base = config
+        .model_path
+        .as_deref()
+        .map(realizar::api::ModelSourceInfo::from_path)
+        .unwrap_or_default();
+
+    let mut source = base
+        .with_architecture(model.config().architecture.as_str())
+        .with_model_max_context_length(model.config().context_length)
+        .with_context_length(config.context_length);
+    if let Some(quantization) = dominant_quantization(model) {
+        source = source.with_quantization(quantization);
+    }
+    source
+}
+
 /// Run the CPU inference server
 ///
 /// `mapped_model` is `None` for non-GGUF formats (APR / SafeTensors). For
@@ -16,8 +72,14 @@ fn run_cpu_server(
 ) -> Result<()> {
     use realizar::api::{create_router, AppState};
 
+    // Measure the model BEFORE it is moved into AppState. Anything not
+    // measurable here stays absent — `/realize/model` no longer substitutes
+    // `size_bytes: 0` / `context_length: 4096` / `quantization: "Q4_K_M"`.
+    let model_source = measured_model_source(&quantized_model, config);
+
     let mut state = AppState::with_quantized_model_and_vocab(quantized_model, vocab)
-        .map_err(|e| CliError::InferenceFailed(format!("Failed to create app state: {e}")))?;
+        .map_err(|e| CliError::InferenceFailed(format!("Failed to create app state: {e}")))?
+        .with_model_source(model_source);
     if let Some(mapped) = mapped_model {
         state = state.with_mapped_gguf_model(mapped);
     }
@@ -53,6 +115,11 @@ fn run_cpu_server(
         println!("  POST /batch/generate      - Batch inference");
         println!("  POST /v1/completions      - OpenAI-compatible");
         println!("  POST /v1/chat/completions - Chat completions");
+        println!("  GET  /api/tags            - Ollama model list");
+        println!("  POST /api/show            - Ollama model metadata");
+        println!("  GET  /api/version         - Server version");
+        println!("  POST /api/chat            - Ollama chat (stream:true -> NDJSON)");
+        println!("  POST /api/generate        - Ollama generate (stream:true -> NDJSON)");
         println!();
         println!(
             "{}",

--- a/crates/apr-cli/src/commands/serve/types.rs
+++ b/crates/apr-cli/src/commands/serve/types.rs
@@ -62,6 +62,12 @@ pub struct ServerConfig {
     pub no_fp8_cache: bool,
     /// Ollama compatibility mode
     pub ollama_compat: bool,
+    /// Path of the model being served, recorded by `serve::run`.
+    ///
+    /// The metadata endpoints (`/realize/model`, `/api/tags`, `/api/show`)
+    /// measure size/format from this file. Before it existed they reported
+    /// constants — `size_bytes: 0`, `format: "gguf"` — for every model.
+    pub model_path: Option<std::path::PathBuf>,
 }
 
 impl Default for ServerConfig {
@@ -85,6 +91,7 @@ impl Default for ServerConfig {
             context_length: 4096,
             no_fp8_cache: false,
             ollama_compat: false,
+            model_path: None,
         }
     }
 }

--- a/crates/aprender-serve/src/api/mod.rs
+++ b/crates/aprender-serve/src/api/mod.rs
@@ -63,7 +63,14 @@ pub(crate) use openai_handlers::{
 // PMAT-923: Ollama HTTP compat (/api/chat, /api/generate) — delegates to the
 // OpenAI chat path so `apr serve` is a drop-in Ollama HTTP replacement.
 mod ollama_handlers;
-pub(crate) use ollama_handlers::{ollama_chat_handler, ollama_generate_handler};
+pub(crate) use ollama_handlers::{
+    ollama_chat_handler, ollama_generate_handler, ollama_show_handler, ollama_tags_handler,
+    ollama_version_handler,
+};
+// What this server actually measured about the model it loaded. Metadata
+// handlers read it instead of substituting plausible-looking constants.
+mod model_source;
+pub use model_source::{detect_format_from_magic, gguf_qtype_name, ModelSourceInfo};
 mod gpu_handlers;
 pub(crate) use gpu_handlers::{
     batch_generate_handler, batch_tokenize_handler, generate_handler,
@@ -183,6 +190,30 @@ pub struct AppState {
     verbose: bool,
     /// GH-103: Enable inference tracing (propagates into QuantizedGenerateConfig.trace)
     trace: bool,
+    /// What the loader measured about the served model (path, size, format,
+    /// quantization, context length). `None` means this server was built
+    /// without that knowledge — the metadata handlers then report the fields
+    /// as ABSENT rather than inventing values.
+    model_source: Option<Arc<ModelSourceInfo>>,
+}
+
+impl AppState {
+    /// Attach measured model provenance/metadata.
+    ///
+    /// Call this from whatever loaded the model; it is what makes
+    /// `/realize/model`, `/api/tags` and `/api/show` report the truth instead
+    /// of constants.
+    #[must_use]
+    pub fn with_model_source(mut self, source: ModelSourceInfo) -> Self {
+        self.model_source = Some(Arc::new(source));
+        self
+    }
+
+    /// Measured model provenance/metadata, if the loader supplied any.
+    #[must_use]
+    pub fn model_source(&self) -> Option<&ModelSourceInfo> {
+        self.model_source.as_deref()
+    }
 }
 
 /// Helper to create default audit infrastructure

--- a/crates/aprender-serve/src/api/mod_app_state_gpu.rs
+++ b/crates/aprender-serve/src/api/mod_app_state_gpu.rs
@@ -63,6 +63,7 @@ impl AppState {
             cached_eos_token_id: None,
             verbose: false,
             trace: false,
+            model_source: None,
         })
     }
 
@@ -117,6 +118,7 @@ impl AppState {
             cached_eos_token_id: None,
             verbose: false,
             trace: false,
+            model_source: None,
         })
     }
 
@@ -179,6 +181,7 @@ impl AppState {
             cached_eos_token_id: None,
             verbose: false,
             trace: false,
+            model_source: None,
         })
     }
 
@@ -244,6 +247,7 @@ impl AppState {
             cached_eos_token_id: eos,
             verbose: false,
             trace: false,
+            model_source: None,
         })
     }
 
@@ -298,6 +302,7 @@ impl AppState {
             cached_eos_token_id: eos,
             verbose: false,
             trace: false,
+            model_source: None,
         })
     }
 
@@ -357,6 +362,7 @@ impl AppState {
             cached_eos_token_id: None,
             verbose: false,
             trace: false,
+            model_source: None,
         })
     }
 
@@ -578,6 +584,7 @@ impl AppState {
             cached_eos_token_id: eos_id,
             verbose: false,
             trace: false,
+            model_source: None,
         })
     }
 
@@ -624,6 +631,7 @@ impl AppState {
             cached_eos_token_id: None,
             verbose: false,
             trace: false,
+            model_source: None,
         })
     }
 

--- a/crates/aprender-serve/src/api/mod_app_state_new.rs
+++ b/crates/aprender-serve/src/api/mod_app_state_new.rs
@@ -44,6 +44,7 @@ impl AppState {
             cached_eos_token_id: None,
             verbose: false,
             trace: false,
+            model_source: None,
         }
     }
 
@@ -103,6 +104,7 @@ impl AppState {
             cached_eos_token_id: None,
             verbose: false,
             trace: false,
+            model_source: None,
         })
     }
 
@@ -203,6 +205,7 @@ impl AppState {
             cached_eos_token_id: None,
             verbose: false,
             trace: false,
+            model_source: None,
         }
     }
 
@@ -275,6 +278,7 @@ impl AppState {
             cached_eos_token_id: None,
             verbose: false,
             trace: false,
+            model_source: None,
         })
     }
 
@@ -329,6 +333,7 @@ impl AppState {
             cached_eos_token_id: None,
             verbose: false,
             trace: false,
+            model_source: None,
         })
     }
 
@@ -388,6 +393,7 @@ impl AppState {
             cached_eos_token_id: None,
             verbose: false,
             trace: false,
+            model_source: None,
         })
     }
 
@@ -442,6 +448,7 @@ impl AppState {
             cached_eos_token_id: None,
             verbose: false,
             trace: false,
+            model_source: None,
         })
     }
 
@@ -509,6 +516,7 @@ impl AppState {
             cached_eos_token_id: None,
             verbose: false,
             trace: false,
+            model_source: None,
         })
     }
 }

--- a/crates/aprender-serve/src/api/model_source.rs
+++ b/crates/aprender-serve/src/api/model_source.rs
@@ -1,0 +1,316 @@
+//! What the server actually knows about the model it loaded.
+//!
+//! `/realize/model` and the Ollama discovery endpoints (`/api/tags`,
+//! `/api/show`) report model metadata. Before this type existed they reported
+//! *constants*: `size_bytes: 0`, `context_length: 4096`,
+//! `quantization: "Q4_K_M"`, `format: "gguf"` and a `content_hash` of
+//! `"blake3:0".repeat(16)` — a 128-character string shaped exactly like a real
+//! BLAKE3 digest, which a consumer will happily store and compare as
+//! provenance. Every one of those was wrong for at least one shipped model,
+//! and the hash was wrong for all of them.
+//!
+//! The rule this type enforces: **every field is either measured or absent.**
+//! Each accessor returns `Option`, `None` means "this server does not know",
+//! and the handlers omit unknown fields from the JSON rather than substituting
+//! a plausible-looking default. An absent field is a fact a client can act on;
+//! a fabricated one is not.
+
+use std::path::Path;
+
+/// Measured provenance/metadata for the model this server is serving.
+///
+/// Built by the process that loaded the model (`apr serve run`), attached to
+/// [`super::AppState`] via `with_model_source`, and read by the metadata
+/// handlers. Construct with [`ModelSourceInfo::from_path`] so `size_bytes` and
+/// `format` come from the file itself; layer on what the loader learned with
+/// the `with_*` builders.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ModelSourceInfo {
+    path: Option<String>,
+    size_bytes: Option<u64>,
+    format: Option<String>,
+    quantization: Option<String>,
+    architecture: Option<String>,
+    /// Context length this server was CONFIGURED with (`--context-length`),
+    /// NOT the model's advertised maximum — a server started with
+    /// `--context-length 128` must not report 4096, and must not report the
+    /// model's 32768 either. These are three different facts.
+    context_length: Option<usize>,
+    /// Model's own advertised maximum context, when the loader read one.
+    model_max_context_length: Option<usize>,
+    content_hash: Option<String>,
+    parameter_count: Option<u64>,
+}
+
+/// Identify a model container from its leading bytes.
+///
+/// Returns `None` rather than guessing: an unrecognised container is reported
+/// as unknown, never as "gguf".
+#[must_use]
+pub fn detect_format_from_magic(magic: &[u8]) -> Option<&'static str> {
+    if magic.starts_with(b"GGUF") {
+        return Some("gguf");
+    }
+    // APR v2 is "APR\0", v1 is "APRN"; both share the 3-byte "APR" prefix.
+    if magic.starts_with(&crate::apr::MAGIC_PREFIX) {
+        return Some("apr");
+    }
+    // SafeTensors: 8-byte little-endian header length, then a JSON object.
+    if magic.len() > 8 && magic[8] == b'{' {
+        return Some("safetensors");
+    }
+    None
+}
+
+impl ModelSourceInfo {
+    /// Measure what the file itself tells us: absolute path, byte size, and
+    /// container format (from magic bytes, not the extension).
+    ///
+    /// Unreadable metadata leaves the corresponding field `None`; this never
+    /// fails, because a missing metadata field must not stop the server from
+    /// serving.
+    #[must_use]
+    pub fn from_path(path: &Path) -> Self {
+        let size_bytes = std::fs::metadata(path).ok().map(|m| m.len());
+        let format = read_magic(path)
+            .as_deref()
+            .and_then(detect_format_from_magic)
+            .map(str::to_string);
+        let path_str = std::fs::canonicalize(path)
+            .unwrap_or_else(|_| path.to_path_buf())
+            .to_string_lossy()
+            .into_owned();
+        Self {
+            path: Some(path_str),
+            size_bytes,
+            format,
+            ..Self::default()
+        }
+    }
+
+    /// Record the quantization actually present in the loaded weights.
+    #[must_use]
+    pub fn with_quantization(mut self, quantization: impl Into<String>) -> Self {
+        self.quantization = Some(quantization.into());
+        self
+    }
+
+    /// Record the model architecture the loader identified (e.g. `qwen2`).
+    #[must_use]
+    pub fn with_architecture(mut self, architecture: impl Into<String>) -> Self {
+        self.architecture = Some(architecture.into());
+        self
+    }
+
+    /// Record the context length this server was configured with.
+    #[must_use]
+    pub fn with_context_length(mut self, context_length: usize) -> Self {
+        self.context_length = Some(context_length);
+        self
+    }
+
+    /// Record the model's own advertised maximum context length.
+    #[must_use]
+    pub fn with_model_max_context_length(mut self, context_length: usize) -> Self {
+        self.model_max_context_length = Some(context_length);
+        self
+    }
+
+    /// Record a **computed** content hash, e.g. `blake3:<hex>`.
+    ///
+    /// Only call this with a digest that was actually computed over the model
+    /// bytes. There is deliberately no default.
+    #[must_use]
+    pub fn with_content_hash(mut self, content_hash: impl Into<String>) -> Self {
+        self.content_hash = Some(content_hash.into());
+        self
+    }
+
+    /// Record the parameter count the loader derived from the weights.
+    #[must_use]
+    pub fn with_parameter_count(mut self, parameter_count: u64) -> Self {
+        self.parameter_count = Some(parameter_count);
+        self
+    }
+
+    /// Absolute path of the served model file, if it came from a file.
+    #[must_use]
+    pub fn path(&self) -> Option<&str> {
+        self.path.as_deref()
+    }
+
+    /// Size of the model file in bytes.
+    #[must_use]
+    pub fn size_bytes(&self) -> Option<u64> {
+        self.size_bytes
+    }
+
+    /// Container format (`gguf`, `apr`, `safetensors`).
+    #[must_use]
+    pub fn format(&self) -> Option<&str> {
+        self.format.as_deref()
+    }
+
+    /// Quantization of the loaded weights.
+    #[must_use]
+    pub fn quantization(&self) -> Option<&str> {
+        self.quantization.as_deref()
+    }
+
+    /// Model architecture.
+    #[must_use]
+    pub fn architecture(&self) -> Option<&str> {
+        self.architecture.as_deref()
+    }
+
+    /// Context length this server was configured with.
+    #[must_use]
+    pub fn context_length(&self) -> Option<usize> {
+        self.context_length
+    }
+
+    /// Model's advertised maximum context length.
+    #[must_use]
+    pub fn model_max_context_length(&self) -> Option<usize> {
+        self.model_max_context_length
+    }
+
+    /// Computed content hash of the model bytes.
+    #[must_use]
+    pub fn content_hash(&self) -> Option<&str> {
+        self.content_hash.as_deref()
+    }
+
+    /// Parameter count.
+    #[must_use]
+    pub fn parameter_count(&self) -> Option<u64> {
+        self.parameter_count
+    }
+}
+
+/// Read the first 16 bytes of a file for format detection.
+fn read_magic(path: &Path) -> Option<Vec<u8>> {
+    use std::io::Read;
+    let mut file = std::fs::File::open(path).ok()?;
+    let mut buf = [0u8; 16];
+    let n = file.read(&mut buf).ok()?;
+    Some(buf[..n].to_vec())
+}
+
+/// Human-readable name for a GGUF quantization type id.
+///
+/// Derived from the qtype actually stored in the loaded tensors, which is the
+/// ground truth — `general.file_type` in GGUF metadata is advisory and is
+/// known to go stale when a file is requantized.
+#[must_use]
+pub fn gguf_qtype_name(qtype: u32) -> Option<&'static str> {
+    Some(match qtype {
+        0 => "F32",
+        1 => "F16",
+        2 => "Q4_0",
+        3 => "Q4_1",
+        6 => "Q5_0",
+        7 => "Q5_1",
+        8 => "Q8_0",
+        9 => "Q8_1",
+        10 => "Q2_K",
+        11 => "Q3_K",
+        12 => "Q4_K",
+        13 => "Q5_K",
+        14 => "Q6_K",
+        15 => "Q8_K",
+        30 => "BF16",
+        _ => return None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_source_knows_nothing_and_admits_it() {
+        // The point of the type: an empty source reports absence, not defaults.
+        let src = ModelSourceInfo::default();
+        assert_eq!(src.size_bytes(), None);
+        assert_eq!(src.format(), None);
+        assert_eq!(src.quantization(), None);
+        assert_eq!(src.context_length(), None);
+        assert_eq!(src.content_hash(), None, "never invent a content hash");
+    }
+
+    #[test]
+    fn detect_format_recognises_the_three_containers() {
+        assert_eq!(detect_format_from_magic(b"GGUF\0\0\0\0"), Some("gguf"));
+        assert_eq!(detect_format_from_magic(b"APR\0____"), Some("apr"));
+        assert_eq!(detect_format_from_magic(b"APRN____"), Some("apr"));
+        // SafeTensors: u64 header length then '{'.
+        let st = [8u8, 0, 0, 0, 0, 0, 0, 0, b'{', b'"'];
+        assert_eq!(detect_format_from_magic(&st), Some("safetensors"));
+    }
+
+    #[test]
+    fn unrecognised_magic_is_unknown_not_gguf() {
+        // The shipped defect reported "gguf" for every model regardless.
+        assert_eq!(detect_format_from_magic(b"\x7fELF\0\0\0\0"), None);
+        assert_eq!(detect_format_from_magic(b""), None);
+    }
+
+    #[test]
+    fn from_path_measures_size_and_format_of_a_real_file() {
+        let dir = std::env::temp_dir().join(format!(
+            "apr-model-source-{}-{}",
+            std::process::id(),
+            line!()
+        ));
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        let path = dir.join("tiny.gguf");
+        // 4-byte magic + 12 bytes of payload = 16 bytes on disk.
+        std::fs::write(&path, b"GGUF\x03\0\0\0\0\0\0\0\0\0\0\0").expect("write");
+
+        let src = ModelSourceInfo::from_path(&path);
+        assert_eq!(
+            src.size_bytes(),
+            Some(16),
+            "size must be the real file size"
+        );
+        assert_eq!(src.format(), Some("gguf"));
+        assert!(src.path().is_some_and(|p| p.ends_with("tiny.gguf")));
+        assert_eq!(src.content_hash(), None);
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn from_path_on_a_missing_file_reports_absence_not_zero() {
+        let src = ModelSourceInfo::from_path(Path::new("/nonexistent/model.gguf"));
+        assert_eq!(src.size_bytes(), None, "a missing file is unknown, not 0");
+        assert_eq!(src.format(), None);
+    }
+
+    #[test]
+    fn builders_record_measured_values() {
+        let src = ModelSourceInfo::default()
+            .with_quantization("Q4_K")
+            .with_architecture("qwen2")
+            .with_context_length(128)
+            .with_model_max_context_length(32768)
+            .with_content_hash("blake3:deadbeef")
+            .with_parameter_count(1_500_000_000);
+        assert_eq!(src.quantization(), Some("Q4_K"));
+        assert_eq!(src.architecture(), Some("qwen2"));
+        assert_eq!(src.context_length(), Some(128));
+        assert_eq!(src.model_max_context_length(), Some(32768));
+        assert_eq!(src.content_hash(), Some("blake3:deadbeef"));
+        assert_eq!(src.parameter_count(), Some(1_500_000_000));
+    }
+
+    #[test]
+    fn qtype_names_cover_the_shipped_quantizations() {
+        assert_eq!(gguf_qtype_name(12), Some("Q4_K"));
+        assert_eq!(gguf_qtype_name(14), Some("Q6_K"));
+        assert_eq!(gguf_qtype_name(0), Some("F32"));
+        // Unknown ids must not be reported as some plausible quantization.
+        assert_eq!(gguf_qtype_name(9999), None);
+    }
+}

--- a/crates/aprender-serve/src/api/ollama_handlers.rs
+++ b/crates/aprender-serve/src/api/ollama_handlers.rs
@@ -28,7 +28,7 @@ use serde::{Deserialize, Serialize};
 
 use super::{
     openai_chat_completions_handler, AppState, ChatCompletionRequest, ChatCompletionResponse,
-    ChatMessage,
+    ChatMessage, ModelSourceInfo,
 };
 
 // ============================================================================
@@ -133,6 +133,139 @@ pub struct OllamaGenerateResponse {
     pub eval_count: usize,
 }
 
+/// One newline-delimited object of an Ollama `/api/chat` stream.
+///
+/// Non-terminal chunks carry a content fragment and `done:false`; the terminal
+/// chunk carries empty content, `done:true`, `done_reason` and the token
+/// counts. This is exactly the framing `ollama serve` puts on the wire, and
+/// the framing every Ollama client's read loop expects.
+#[derive(Debug, Clone, Serialize)]
+pub struct OllamaChatChunk {
+    /// Model tag echoed back.
+    pub model: String,
+    /// RFC 3339 creation timestamp.
+    pub created_at: String,
+    /// Fragment of the assistant turn (empty on the terminal chunk).
+    pub message: OllamaMessage,
+    /// Terminal flag — false on every chunk but the last.
+    pub done: bool,
+    /// Why generation ended (terminal chunk only).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub done_reason: Option<String>,
+    /// Prompt token count (terminal chunk only).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt_eval_count: Option<usize>,
+    /// Generated token count (terminal chunk only).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub eval_count: Option<usize>,
+}
+
+/// One newline-delimited object of an Ollama `/api/generate` stream.
+#[derive(Debug, Clone, Serialize)]
+pub struct OllamaGenerateChunk {
+    /// Model tag echoed back.
+    pub model: String,
+    /// RFC 3339 creation timestamp.
+    pub created_at: String,
+    /// Fragment of the completion (empty on the terminal chunk).
+    pub response: String,
+    /// Terminal flag — false on every chunk but the last.
+    pub done: bool,
+    /// Why generation ended (terminal chunk only).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub done_reason: Option<String>,
+    /// Prompt token count (terminal chunk only).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt_eval_count: Option<usize>,
+    /// Generated token count (terminal chunk only).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub eval_count: Option<usize>,
+}
+
+// ============================================================================
+// Ollama discovery wire types (`/api/tags`, `/api/show`, `/api/version`)
+// ============================================================================
+
+/// `details` block shared by `/api/tags` and `/api/show`.
+///
+/// Every field is `Option` and skipped when absent: a server that did not
+/// measure a model's family or quantization must say nothing about it rather
+/// than emit a plausible constant.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct OllamaModelDetails {
+    /// Container format (`gguf`, `apr`, `safetensors`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub format: Option<String>,
+    /// Model family (architecture, e.g. `qwen2`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub family: Option<String>,
+    /// Families list — Ollama clients read this as well as `family`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub families: Option<Vec<String>>,
+    /// Human-readable parameter count (e.g. `1.5B`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parameter_size: Option<String>,
+    /// Quantization of the loaded weights (e.g. `Q4_K`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub quantization_level: Option<String>,
+}
+
+/// One entry of `GET /api/tags`.
+#[derive(Debug, Clone, Serialize)]
+pub struct OllamaTag {
+    /// `name:tag` the client should send back as `model`.
+    pub name: String,
+    /// Same value as `name` (Ollama emits both; clients read either).
+    pub model: String,
+    /// File mtime, RFC 3339. Omitted when unknown.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub modified_at: Option<String>,
+    /// File size in bytes. Omitted when unknown — never 0 as a stand-in.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub size: Option<u64>,
+    /// Content digest. Omitted unless one was actually computed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub digest: Option<String>,
+    /// Measured detail block.
+    pub details: OllamaModelDetails,
+}
+
+/// `GET /api/tags` response.
+#[derive(Debug, Clone, Serialize)]
+pub struct OllamaTagsResponse {
+    /// Models this server can serve.
+    pub models: Vec<OllamaTag>,
+}
+
+/// `POST /api/show` request.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct OllamaShowRequest {
+    /// Model tag (Ollama's newer field).
+    #[serde(default)]
+    pub model: Option<String>,
+    /// Model tag (Ollama's older field). Accepted for compatibility.
+    #[serde(default)]
+    pub name: Option<String>,
+}
+
+/// `POST /api/show` response.
+#[derive(Debug, Clone, Serialize)]
+pub struct OllamaShowResponse {
+    /// Measured detail block.
+    pub details: OllamaModelDetails,
+    /// Measured key/value metadata. Only keys this server actually measured.
+    pub model_info: serde_json::Map<String, serde_json::Value>,
+    /// What this model can do.
+    pub capabilities: Vec<String>,
+}
+
+/// `GET /api/version` response.
+#[derive(Debug, Clone, Serialize)]
+pub struct OllamaVersionResponse {
+    /// Server version.
+    pub version: String,
+}
+
 // ============================================================================
 // Conversion helpers (pure — unit-tested)
 // ============================================================================
@@ -183,11 +316,201 @@ fn to_chat_request(
         top_k: opts.top_k,
         seed: opts.seed,
         n: 1,
-        // We always coalesce into one final Ollama message, so drive the
-        // underlying chat path non-streaming regardless of the client flag.
+        // The internal chat path has no token callback, so it is always driven
+        // non-streaming. `stream:true` on the Ollama request is honoured at the
+        // WIRE level instead — see `ndjson_response` — never discarded.
         stream: false,
         ..Default::default()
     }
+}
+
+/// Split generated text into the fragments an Ollama stream carries.
+///
+/// Invariant (asserted by the falsifiers): `content_fragments(s).concat() == s`
+/// for every `s`. A client that concatenates the `content` of every chunk must
+/// reconstruct the response byte-for-byte — that is the whole contract of the
+/// streaming protocol, and dropping or duplicating a character breaks it.
+///
+/// Empty input yields no fragments: the response is then just the terminal
+/// `done:true` object, which is what ollama does for an empty generation.
+fn content_fragments(content: &str) -> Vec<String> {
+    if content.is_empty() {
+        return Vec::new();
+    }
+    content
+        .split_inclusive(char::is_whitespace)
+        .map(str::to_string)
+        .collect()
+}
+
+/// Serialize objects to newline-delimited JSON and send them as a streamed
+/// body (`application/x-ndjson`, chunked — no `content-length`).
+///
+/// The shipped 0.63.0 returned ONE buffered JSON object with a `content-length`
+/// no matter what `stream` said; every Ollama-compatible UI showed a frozen
+/// cursor because its read loop waits for objects terminated by `done:true`.
+fn ndjson_response<T: Serialize>(objects: &[T]) -> Response {
+    let mut lines: Vec<axum::body::Bytes> = Vec::with_capacity(objects.len());
+    for obj in objects {
+        match serde_json::to_string(obj) {
+            Ok(mut s) => {
+                s.push('\n');
+                lines.push(axum::body::Bytes::from(s));
+            },
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({ "error": e.to_string() })),
+                )
+                    .into_response()
+            },
+        }
+    }
+
+    let stream = tokio_stream::iter(
+        lines
+            .into_iter()
+            .map(Ok::<axum::body::Bytes, std::convert::Infallible>),
+    );
+
+    match Response::builder()
+        .status(StatusCode::OK)
+        .header(
+            axum::http::header::CONTENT_TYPE,
+            "application/x-ndjson; charset=utf-8",
+        )
+        .body(axum::body::Body::from_stream(stream))
+    {
+        Ok(resp) => resp,
+        // Unreachable: the only header is a constant. Fall back rather than panic.
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({ "error": e.to_string() })),
+        )
+            .into_response(),
+    }
+}
+
+/// Build the full `/api/chat` NDJSON stream for a completed generation.
+fn chat_stream_objects(
+    model: &str,
+    content: &str,
+    prompt_eval_count: usize,
+    eval_count: usize,
+) -> Vec<OllamaChatChunk> {
+    let created_at = created_at_now();
+    let mut out: Vec<OllamaChatChunk> = content_fragments(content)
+        .into_iter()
+        .map(|fragment| OllamaChatChunk {
+            model: model.to_string(),
+            created_at: created_at.clone(),
+            message: OllamaMessage {
+                role: "assistant".to_string(),
+                content: fragment,
+            },
+            done: false,
+            done_reason: None,
+            prompt_eval_count: None,
+            eval_count: None,
+        })
+        .collect();
+    out.push(OllamaChatChunk {
+        model: model.to_string(),
+        created_at,
+        message: OllamaMessage {
+            role: "assistant".to_string(),
+            content: String::new(),
+        },
+        done: true,
+        done_reason: Some("stop".to_string()),
+        prompt_eval_count: Some(prompt_eval_count),
+        eval_count: Some(eval_count),
+    });
+    out
+}
+
+/// Build the full `/api/generate` NDJSON stream for a completed generation.
+fn generate_stream_objects(
+    model: &str,
+    content: &str,
+    prompt_eval_count: usize,
+    eval_count: usize,
+) -> Vec<OllamaGenerateChunk> {
+    let created_at = created_at_now();
+    let mut out: Vec<OllamaGenerateChunk> = content_fragments(content)
+        .into_iter()
+        .map(|fragment| OllamaGenerateChunk {
+            model: model.to_string(),
+            created_at: created_at.clone(),
+            response: fragment,
+            done: false,
+            done_reason: None,
+            prompt_eval_count: None,
+            eval_count: None,
+        })
+        .collect();
+    out.push(OllamaGenerateChunk {
+        model: model.to_string(),
+        created_at,
+        response: String::new(),
+        done: true,
+        done_reason: Some("stop".to_string()),
+        prompt_eval_count: Some(prompt_eval_count),
+        eval_count: Some(eval_count),
+    });
+    out
+}
+
+/// Render a parameter count the way Ollama does (`1.5B`, `370M`).
+fn parameter_size_label(count: u64) -> String {
+    if count >= 1_000_000_000 {
+        format!("{:.1}B", count as f64 / 1e9)
+    } else if count >= 1_000_000 {
+        format!("{:.0}M", count as f64 / 1e6)
+    } else {
+        format!("{count}")
+    }
+}
+
+/// The `name:tag` this server answers to, derived from the model file name.
+///
+/// Falls back to `apr` when no path was recorded. This is an addressable
+/// identifier the client sends back as `model`, not a provenance claim.
+fn tag_name(source: Option<&ModelSourceInfo>) -> String {
+    let stem = source
+        .and_then(ModelSourceInfo::path)
+        .and_then(|p| {
+            std::path::Path::new(p)
+                .file_stem()
+                .map(|s| s.to_string_lossy().into_owned())
+        })
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "apr".to_string());
+    format!("{stem}:latest")
+}
+
+/// Build the `details` block from measured facts only.
+fn details_from_source(source: Option<&ModelSourceInfo>) -> OllamaModelDetails {
+    let Some(src) = source else {
+        return OllamaModelDetails::default();
+    };
+    OllamaModelDetails {
+        format: src.format().map(str::to_string),
+        family: src.architecture().map(str::to_string),
+        families: src.architecture().map(|a| vec![a.to_string()]),
+        parameter_size: src.parameter_count().map(parameter_size_label),
+        quantization_level: src.quantization().map(str::to_string),
+    }
+}
+
+/// File mtime as RFC 3339, when the file is readable.
+fn modified_at(source: Option<&ModelSourceInfo>) -> Option<String> {
+    let path = source.and_then(ModelSourceInfo::path)?;
+    let modified = std::fs::metadata(path).ok()?.modified().ok()?;
+    Some(
+        chrono::DateTime::<chrono::Utc>::from(modified)
+            .to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+    )
 }
 
 /// Extract `(content, prompt_tokens, completion_tokens)` from the OpenAI chat
@@ -243,11 +566,21 @@ pub async fn ollama_chat_handler(
     Json(request): Json<OllamaChatRequest>,
 ) -> Response {
     let model = model_label(&request.model);
+    let stream = request.stream;
     let chat_req = to_chat_request(&model, request.messages, &request.options);
 
     let inner = openai_chat_completions_handler(State(state), headers, Json(chat_req)).await;
     let (status, body) = split_response(inner).await;
     let (content, prompt_tokens, eval_count) = chat_response_to_parts(status, &body);
+
+    if stream {
+        return ndjson_response(&chat_stream_objects(
+            &model,
+            &content,
+            prompt_tokens,
+            eval_count,
+        ));
+    }
 
     Json(OllamaChatResponse {
         model,
@@ -273,6 +606,7 @@ pub async fn ollama_generate_handler(
     Json(request): Json<OllamaGenerateRequest>,
 ) -> Response {
     let model = model_label(&request.model);
+    let stream = request.stream;
 
     let mut messages = Vec::new();
     if let Some(system) = request.system.filter(|s| !s.is_empty()) {
@@ -291,6 +625,15 @@ pub async fn ollama_generate_handler(
     let (status, body) = split_response(inner).await;
     let (content, prompt_tokens, eval_count) = chat_response_to_parts(status, &body);
 
+    if stream {
+        return ndjson_response(&generate_stream_objects(
+            &model,
+            &content,
+            prompt_tokens,
+            eval_count,
+        ));
+    }
+
     Json(OllamaGenerateResponse {
         model,
         created_at: created_at_now(),
@@ -300,6 +643,86 @@ pub async fn ollama_generate_handler(
         eval_count,
     })
     .into_response()
+}
+
+/// `GET /api/tags` — Ollama model enumeration.
+///
+/// Every Ollama-compatible client (the `ollama` CLI, Open WebUI, LangChain
+/// `ChatOllama`, LlamaIndex) calls this BEFORE it will issue a single chat
+/// request. 0.63.0 returned 404 while the startup banner advertised
+/// "Ollama-Parity Endpoints", so none of those clients could reach the server
+/// at all.
+pub async fn ollama_tags_handler(State(state): State<AppState>) -> Json<OllamaTagsResponse> {
+    let source = state.model_source();
+    let name = tag_name(source);
+    Json(OllamaTagsResponse {
+        models: vec![OllamaTag {
+            model: name.clone(),
+            name,
+            modified_at: modified_at(source),
+            size: source.and_then(ModelSourceInfo::size_bytes),
+            // Never invent a digest — omitted until one is computed.
+            digest: None,
+            details: details_from_source(source),
+        }],
+    })
+}
+
+/// `POST /api/show` — Ollama capability/metadata probe.
+///
+/// Reports only what the loader measured. Unknown keys are absent from
+/// `model_info` rather than present with a plausible constant.
+pub async fn ollama_show_handler(
+    State(state): State<AppState>,
+    Json(_request): Json<OllamaShowRequest>,
+) -> Json<OllamaShowResponse> {
+    let source = state.model_source();
+    let mut model_info = serde_json::Map::new();
+    if let Some(src) = source {
+        if let Some(arch) = src.architecture() {
+            model_info.insert(
+                "general.architecture".to_string(),
+                serde_json::Value::String(arch.to_string()),
+            );
+        }
+        if let Some(q) = src.quantization() {
+            model_info.insert(
+                "general.quantization".to_string(),
+                serde_json::Value::String(q.to_string()),
+            );
+        }
+        if let Some(size) = src.size_bytes() {
+            model_info.insert("general.size_bytes".to_string(), serde_json::json!(size));
+        }
+        // The context this server will actually serve (the KV-cache bound) is a
+        // different fact from the model's advertised maximum. Report both, and
+        // label them so neither can be mistaken for the other.
+        if let Some(ctx) = src.context_length() {
+            model_info.insert(
+                "apr.configured_context_length".to_string(),
+                serde_json::json!(ctx),
+            );
+        }
+        if let Some(ctx) = src.model_max_context_length() {
+            model_info.insert("general.context_length".to_string(), serde_json::json!(ctx));
+        }
+    }
+
+    Json(OllamaShowResponse {
+        details: details_from_source(source),
+        model_info,
+        capabilities: vec!["completion".to_string()],
+    })
+}
+
+/// `GET /api/version` — server version.
+///
+/// Reports THIS server's version. It is not pretending to be some ollama
+/// release; a client that version-gates gets a real, comparable semver.
+pub async fn ollama_version_handler() -> Json<OllamaVersionResponse> {
+    Json(OllamaVersionResponse {
+        version: env!("CARGO_PKG_VERSION").to_string(),
+    })
 }
 
 #[cfg(test)]
@@ -339,7 +762,12 @@ mod tests {
         assert_eq!(req.messages[1].content, "hi");
         assert_eq!(req.max_tokens, Some(32));
         assert_eq!(req.top_k, Some(10));
-        assert!(!req.stream, "Ollama path always drives chat non-streaming");
+        // The INTERNAL chat path has no token callback, so it is always driven
+        // non-streaming. This says nothing about the wire: `stream:true` is
+        // honoured by re-framing the finished generation as NDJSON (see the
+        // `stream_*` falsifiers below). Asserting the internal flag is NOT a
+        // licence to discard the client's flag.
+        assert!(!req.stream, "internal chat path is driven non-streaming");
     }
 
     #[test]
@@ -469,5 +897,191 @@ mod tests {
         chrono::DateTime::parse_from_rfc3339(created_at).unwrap_or_else(|e| {
             panic!("/api/generate created_at {created_at:?} must parse as RFC 3339: {e}")
         });
+    }
+}
+
+// ============================================================================
+// Streaming + discovery falsifiers (dogfood 0.63.0, #2396)
+// ============================================================================
+//
+// 0.63.0 parsed `stream` on both Ollama endpoints and then threw it away: the
+// wire always carried ONE buffered JSON object with a `content-length`, so
+// every ollama-compatible UI (ollama CLI, Open WebUI, continue.dev) sat on a
+// frozen cursor for the whole generation. And `/api/tags`, `/api/show` and
+// `/api/version` 404'd while the startup banner advertised "Ollama-Parity
+// Endpoints" — clients call /api/tags BEFORE they will issue any chat request,
+// so the server was unreachable to them.
+#[cfg(test)]
+mod stream_and_discovery_tests {
+    use super::*;
+
+    /// Concatenating the fragments must reproduce the input exactly. A client
+    /// assembles the reply by joining every chunk's `content`; a dropped space
+    /// or a duplicated word is a silently corrupted answer.
+    #[test]
+    fn fragments_reassemble_to_the_original_text() {
+        for text in [
+            "The capital of France is Paris.",
+            "one",
+            "  leading and trailing  ",
+            "multi\nline\ttext with  double  spaces",
+            "unicode: héllo wörld 日本語 🎉",
+        ] {
+            let joined: String = content_fragments(text).concat();
+            assert_eq!(joined, text, "fragments must reassemble {text:?} exactly");
+        }
+    }
+
+    /// Empty generation carries no content chunks — only the terminal object.
+    #[test]
+    fn empty_content_yields_no_fragments() {
+        assert!(content_fragments("").is_empty());
+    }
+
+    /// A stream is a SEQUENCE terminated by `done:true`, and only the last
+    /// object may be terminal. One object with `done:true` is what 0.63.0 sent
+    /// and is indistinguishable from a non-streaming reply.
+    #[test]
+    fn chat_stream_is_a_sequence_terminated_by_done_true() {
+        let objs = chat_stream_objects("apr", "The capital of France is Paris.", 21, 7);
+        assert!(
+            objs.len() > 2,
+            "a 6-word answer must arrive as several chunks, got {}",
+            objs.len()
+        );
+        let (last, rest) = objs.split_last().expect("non-empty");
+        assert!(last.done, "final object must be done:true");
+        assert_eq!(last.done_reason.as_deref(), Some("stop"));
+        assert_eq!(last.prompt_eval_count, Some(21));
+        assert_eq!(last.eval_count, Some(7));
+        assert!(
+            last.message.content.is_empty(),
+            "ollama's terminal chat object carries no content"
+        );
+        for chunk in rest {
+            assert!(!chunk.done, "only the last object may be done:true");
+            assert!(chunk.done_reason.is_none());
+            assert!(chunk.prompt_eval_count.is_none());
+            assert!(chunk.eval_count.is_none());
+            assert_eq!(chunk.message.role, "assistant");
+        }
+        let assembled: String = rest.iter().map(|c| c.message.content.as_str()).collect();
+        assert_eq!(assembled, "The capital of France is Paris.");
+    }
+
+    /// Same contract on `/api/generate`, whose chunks carry a flat `response`.
+    #[test]
+    fn generate_stream_is_a_sequence_terminated_by_done_true() {
+        let objs = generate_stream_objects("apr", "1 2 3 4 5 6 7 8", 16, 16);
+        let (last, rest) = objs.split_last().expect("non-empty");
+        assert!(last.done);
+        assert_eq!(last.done_reason.as_deref(), Some("stop"));
+        assert_eq!(last.eval_count, Some(16));
+        assert!(last.response.is_empty());
+        assert!(!rest.is_empty(), "must emit incremental chunks");
+        assert!(rest.iter().all(|c| !c.done));
+        let assembled: String = rest.iter().map(|c| c.response.as_str()).collect();
+        assert_eq!(assembled, "1 2 3 4 5 6 7 8");
+    }
+
+    /// Even an empty generation must terminate the stream, or a client's read
+    /// loop hangs waiting for `done:true`.
+    #[test]
+    fn empty_generation_still_terminates_the_stream() {
+        let objs = chat_stream_objects("apr", "", 3, 0);
+        assert_eq!(objs.len(), 1);
+        assert!(objs[0].done);
+    }
+
+    /// Each object must be ONE line of valid JSON: NDJSON framing is the
+    /// protocol, and an embedded newline splits one object into two garbage
+    /// halves in the client's line reader.
+    #[test]
+    fn each_object_serializes_to_exactly_one_json_line() {
+        for chunk in chat_stream_objects("apr", "a b\nc", 1, 3) {
+            let line = serde_json::to_string(&chunk).expect("serialize");
+            assert!(
+                !line.contains('\n'),
+                "raw newline would break NDJSON framing: {line}"
+            );
+            serde_json::from_str::<serde_json::Value>(&line).expect("each line is valid JSON");
+        }
+    }
+
+    /// Non-terminal chunks must OMIT the counts rather than send zeros: a
+    /// client that reads the first present `eval_count` would otherwise be
+    /// told the model generated nothing.
+    #[test]
+    fn non_terminal_chunks_omit_counts_and_done_reason() {
+        let objs = chat_stream_objects("apr", "two words", 5, 2);
+        let first = serde_json::to_value(&objs[0]).expect("serialize");
+        assert!(first.get("eval_count").is_none());
+        assert!(first.get("prompt_eval_count").is_none());
+        assert!(first.get("done_reason").is_none());
+        assert_eq!(first["done"], false);
+    }
+
+    /// `created_at` must be RFC 3339 on streamed chunks too — the Go client
+    /// decodes every chunk into the same `api.ChatResponse`.
+    #[test]
+    fn stream_chunk_created_at_is_rfc3339() {
+        for chunk in chat_stream_objects("apr", "hi there", 1, 2) {
+            let json = serde_json::to_value(&chunk).expect("serialize");
+            let created_at = json["created_at"].as_str().expect("string");
+            chrono::DateTime::parse_from_rfc3339(created_at)
+                .unwrap_or_else(|e| panic!("chunk created_at {created_at:?} not RFC 3339: {e}"));
+        }
+    }
+
+    /// A model without a recorded source must not acquire a family, a
+    /// quantization or a size out of thin air.
+    #[test]
+    fn details_without_a_source_claim_nothing() {
+        let details = details_from_source(None);
+        let json = serde_json::to_value(details).expect("serialize");
+        assert_eq!(
+            json.as_object().map(serde_json::Map::len),
+            Some(0),
+            "unmeasured details must be absent, got {json}"
+        );
+    }
+
+    /// With a measured source, `details` reports what was measured — and still
+    /// omits what was not (no `parameter_size` here).
+    #[test]
+    fn details_report_measured_values_only() {
+        let src = ModelSourceInfo::default()
+            .with_quantization("Q4_K")
+            .with_architecture("qwen2");
+        let json = serde_json::to_value(details_from_source(Some(&src))).expect("serialize");
+        assert_eq!(json["family"], "qwen2");
+        assert_eq!(json["families"][0], "qwen2");
+        assert_eq!(json["quantization_level"], "Q4_K");
+        assert!(json.get("parameter_size").is_none());
+        assert!(json.get("format").is_none());
+    }
+
+    /// The tag must be derived from the served file, so `ollama list` shows
+    /// the model the operator actually launched.
+    #[test]
+    fn tag_name_comes_from_the_served_file() {
+        let src = ModelSourceInfo::default();
+        assert_eq!(tag_name(Some(&src)), "apr:latest");
+        assert_eq!(tag_name(None), "apr:latest");
+
+        let dir = std::env::temp_dir().join(format!("apr-tag-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        let path = dir.join("qwen2.5-coder-1.5b.gguf");
+        std::fs::write(&path, b"GGUF\0\0\0\0").expect("write");
+        let src = ModelSourceInfo::from_path(&path);
+        assert_eq!(tag_name(Some(&src)), "qwen2.5-coder-1.5b:latest");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn parameter_size_labels_match_ollama_style() {
+        assert_eq!(parameter_size_label(1_500_000_000), "1.5B");
+        assert_eq!(parameter_size_label(370_000_000), "370M");
+        assert_eq!(parameter_size_label(512), "512");
     }
 }

--- a/crates/aprender-serve/src/api/realize_handlers.rs
+++ b/crates/aprender-serve/src/api/realize_handlers.rs
@@ -383,16 +383,32 @@ pub struct ModelMetadataResponse {
     pub id: String,
     /// Model name
     pub name: String,
-    /// Model format (GGUF, APR, SafeTensors)
-    pub format: String,
-    /// Model size in bytes
-    pub size_bytes: u64,
+    /// Container format (`gguf`, `apr`, `safetensors`), detected from the
+    /// file's magic bytes. Absent when this server did not measure it — never
+    /// defaulted to `"gguf"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub format: Option<String>,
+    /// Model size in bytes, measured from the file. Absent when unknown;
+    /// `0` is not used as a stand-in for "we did not look".
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub size_bytes: Option<u64>,
     /// Quantization type
     #[serde(skip_serializing_if = "Option::is_none")]
     pub quantization: Option<String>,
-    /// Context window size
-    pub context_length: usize,
-    /// Model lineage from Pacha
+    /// Context window this server will actually serve (the KV-cache bound,
+    /// i.e. what `--context-length` set). Absent when unknown.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context_length: Option<usize>,
+    /// The model's own advertised maximum context, when the loader read one.
+    /// A separate fact from `context_length`; conflating them is how the
+    /// shipped handler reported 4096 for a 32768-context model served at 128.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model_max_context_length: Option<usize>,
+    /// Model architecture the loader identified (e.g. `qwen2`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub architecture: Option<String>,
+    /// Model lineage. Present ONLY when a real content hash was computed —
+    /// provenance is either measured or absent, never synthesised.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub lineage: Option<ModelLineage>,
     /// Whether model is loaded

--- a/crates/aprender-serve/src/api/realize_handlers_completion_request.rs
+++ b/crates/aprender-serve/src/api/realize_handlers_completion_request.rs
@@ -467,10 +467,12 @@
         let response = ModelMetadataResponse {
             id: "debug".to_string(),
             name: "Debug Model".to_string(),
-            format: "APR".to_string(),
-            size_bytes: 0,
+            format: Some("APR".to_string()),
+            size_bytes: Some(0),
             quantization: None,
-            context_length: 2048,
+            context_length: Some(2048),
+            model_max_context_length: None,
+            architecture: None,
             lineage: None,
             loaded: false,
         };
@@ -483,10 +485,12 @@
         let response = ModelMetadataResponse {
             id: "c".to_string(),
             name: "Clone".to_string(),
-            format: "GGUF".to_string(),
-            size_bytes: 42,
+            format: Some("GGUF".to_string()),
+            size_bytes: Some(42),
             quantization: Some("Q4_K_M".to_string()),
-            context_length: 4096,
+            context_length: Some(4096),
+            model_max_context_length: None,
+            architecture: None,
             lineage: None,
             loaded: true,
         };

--- a/crates/aprender-serve/src/api/realize_handlers_context_window.rs
+++ b/crates/aprender-serve/src/api/realize_handlers_context_window.rs
@@ -389,10 +389,12 @@
         let response = ModelMetadataResponse {
             id: "model-123".to_string(),
             name: "TinyLlama".to_string(),
-            format: "GGUF".to_string(),
-            size_bytes: 1_000_000_000,
+            format: Some("GGUF".to_string()),
+            size_bytes: Some(1_000_000_000),
             quantization: Some("Q4_K_M".to_string()),
-            context_length: 4096,
+            context_length: Some(4096),
+            model_max_context_length: None,
+            architecture: None,
             lineage: None,
             loaded: true,
         };
@@ -405,10 +407,12 @@
         let response = ModelMetadataResponse {
             id: "model-456".to_string(),
             name: "CustomModel".to_string(),
-            format: "APR".to_string(),
-            size_bytes: 500_000_000,
+            format: Some("APR".to_string()),
+            size_bytes: Some(500_000_000),
             quantization: None,
-            context_length: 2048,
+            context_length: Some(2048),
+            model_max_context_length: None,
+            architecture: None,
             lineage: Some(ModelLineage {
                 uri: "pacha://models/custom".to_string(),
                 version: "1.0.0".to_string(),
@@ -428,10 +432,12 @@
         let response = ModelMetadataResponse {
             id: "test".to_string(),
             name: "Test".to_string(),
-            format: "GGUF".to_string(),
-            size_bytes: 100,
+            format: Some("GGUF".to_string()),
+            size_bytes: Some(100),
             quantization: None,
-            context_length: 1024,
+            context_length: Some(1024),
+            model_max_context_length: None,
+            architecture: None,
             lineage: None,
             loaded: true,
         };

--- a/crates/aprender-serve/src/api/realize_handlers_embed_completion.rs
+++ b/crates/aprender-serve/src/api/realize_handlers_embed_completion.rs
@@ -140,9 +140,21 @@ pub async fn realize_embed_handler(
 }
 
 /// Native Realizar model metadata handler (/realize/model)
+///
+/// **Every field is measured or absent.** 0.63.0 shipped this handler with
+/// `size_bytes: 0`, `context_length: 4096`, `quantization: "Q4_K_M"`,
+/// `format: "gguf"` and `content_hash: "blake3:0".repeat(16)` — a 128-character
+/// string shaped exactly like a BLAKE3 digest that a consumer would store and
+/// compare as provenance. Those were constants, not observations: the same
+/// server reported 4096 while running with `--context-length 128` against a
+/// 32768-context 1.04 GiB GGUF. Values now come from
+/// [`super::ModelSourceInfo`], and anything the loader did not measure is
+/// omitted from the JSON entirely.
 pub async fn realize_model_handler(
     State(state): State<AppState>,
 ) -> Result<Json<ModelMetadataResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let source = state.model_source();
+
     // Get default model info
     let model_info = if let Some(registry) = &state.registry {
         let models = registry.list();
@@ -152,7 +164,12 @@ pub async fn realize_model_handler(
             id: "default".to_string(),
             name: "Default Model".to_string(),
             description: "Single model deployment".to_string(),
-            format: "gguf".to_string(),
+            // Detected from the file's magic bytes when a path was recorded.
+            // Empty means "unknown" and is reported as an ABSENT field below.
+            format: source
+                .and_then(crate::api::ModelSourceInfo::format)
+                .unwrap_or_default()
+                .to_string(),
             loaded: true,
         })
     };
@@ -166,28 +183,61 @@ pub async fn realize_model_handler(
         )
     })?;
 
+    // Lineage is emitted ONLY when a content hash was actually computed over
+    // the model bytes. There is deliberately no synthetic fallback: a client
+    // cannot distinguish a fabricated digest from a real one, so a fabricated
+    // one is worse than none.
+    let lineage = source
+        .and_then(crate::api::ModelSourceInfo::content_hash)
+        .map(|hash| ModelLineage {
+            uri: format!("file://{}", source.and_then(crate::api::ModelSourceInfo::path).unwrap_or_default()),
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            recipe: None,
+            parent: None,
+            content_hash: hash.to_string(),
+        });
+
     Ok(Json(ModelMetadataResponse {
         id: info.id.clone(),
         name: info.name,
-        format: info.format,
-        size_bytes: 0, // Would be populated from actual model
-        quantization: Some("Q4_K_M".to_string()),
-        context_length: 4096,
-        lineage: Some(ModelLineage {
-            uri: format!("pacha://{}:latest", info.id),
-            version: "1.0.0".to_string(),
-            recipe: None,
-            parent: None,
-            content_hash: "blake3:0".repeat(16),
-        }),
+        format: Some(info.format).filter(|f| !f.is_empty()),
+        size_bytes: source.and_then(crate::api::ModelSourceInfo::size_bytes),
+        quantization: source
+            .and_then(crate::api::ModelSourceInfo::quantization)
+            .map(str::to_string),
+        context_length: source.and_then(crate::api::ModelSourceInfo::context_length),
+        model_max_context_length: source
+            .and_then(crate::api::ModelSourceInfo::model_max_context_length),
+        architecture: source
+            .and_then(crate::api::ModelSourceInfo::architecture)
+            .map(str::to_string),
+        lineage,
         loaded: info.loaded,
     }))
 }
+
+/// Body returned by `/realize/reload` when the server is not in registry mode.
+///
+/// Must not name a CLI flag: `apr serve run` has none that enables registry
+/// mode. Stating the actual situation is more useful than inventing a remedy.
+pub(crate) const REGISTRY_MODE_UNAVAILABLE: &str =
+    "Hot-reload requires multi-model registry mode, which this server is not running. \
+     The apr CLI does not expose registry mode (there is no --registry flag on `apr serve run`); \
+     it is available only to embedders that build AppState via AppState::with_registry. \
+     To serve a different model, restart: apr serve run <MODEL>.";
 
 /// Native Realizar hot-reload handler (/realize/reload)
 ///
 /// Performs atomic model hot-reload via the ModelRegistry.
 /// Requires registry mode (multi-model serving) to be enabled.
+///
+/// **Error-message contract.** When registry mode is off this returns 501, and
+/// the body must NOT name a remedy that does not exist. 0.63.0 answered
+/// "Start server with --registry flag" — `apr serve run` has no `--registry`
+/// flag (clap rejects it with exit 2), and neither does `apr serve`, so the
+/// advice sent every caller down a dead end. Registry mode is reached by
+/// embedding this crate and calling `AppState::with_registry`; the CLI does
+/// not expose it, and the message now says exactly that.
 pub async fn realize_reload_handler(
     State(state): State<AppState>,
     Json(request): Json<ReloadRequest>,
@@ -201,8 +251,7 @@ pub async fn realize_reload_handler(
         (
             StatusCode::NOT_IMPLEMENTED,
             Json(ErrorResponse {
-                error: "Hot-reload requires registry mode. Start server with --registry flag."
-                    .to_string(),
+                error: REGISTRY_MODE_UNAVAILABLE.to_string(),
             }),
         )
     })?;

--- a/crates/aprender-serve/src/api/router.rs
+++ b/crates/aprender-serve/src/api/router.rs
@@ -106,7 +106,13 @@ pub fn create_router_with_config(state: AppState, config: RouterConfig) -> Route
             // a drop-in Ollama HTTP replacement. Both delegate to the OpenAI chat
             // generation path. Discharges OBLIG-OLLAMA-API-CHAT-GENERATE-ROUTED.
             .route("/api/chat", post(ollama_chat_handler))
-            .route("/api/generate", post(ollama_generate_handler));
+            .route("/api/generate", post(ollama_generate_handler))
+            // Model discovery. Ollama clients call /api/tags BEFORE issuing any
+            // chat request and /api/show to probe capabilities; without them the
+            // "drop-in Ollama replacement" claim above is unreachable in practice.
+            .route("/api/tags", get(ollama_tags_handler))
+            .route("/api/show", post(ollama_show_handler))
+            .route("/api/version", get(ollama_version_handler));
     }
 
     // realizr#191: Logprobs + perplexity endpoints (CUDA only, F-QUALITY-01)

--- a/crates/aprender-serve/src/api/tests/completion_request.rs
+++ b/crates/aprender-serve/src/api/tests/completion_request.rs
@@ -200,10 +200,12 @@ fn test_model_metadata_with_lineage() {
     let response = ModelMetadataResponse {
         id: "model-with-lineage".to_string(),
         name: "Test Model".to_string(),
-        format: "GGUF".to_string(),
-        size_bytes: 1_000_000,
+        format: Some("GGUF".to_string()),
+        size_bytes: Some(1_000_000),
         quantization: Some("Q4_K_M".to_string()),
-        context_length: 4096,
+        context_length: Some(4096),
+        model_max_context_length: None,
+        architecture: None,
         lineage: Some(ModelLineage {
             uri: "pacha://test:v1".to_string(),
             version: "1.0".to_string(),
@@ -222,10 +224,12 @@ fn test_model_metadata_traits() {
     let response = ModelMetadataResponse {
         id: "debug-id".to_string(),
         name: "Debug".to_string(),
-        format: "APR".to_string(),
-        size_bytes: 500,
+        format: Some("APR".to_string()),
+        size_bytes: Some(500),
         quantization: None,
-        context_length: 2048,
+        context_length: Some(2048),
+        model_max_context_length: None,
+        architecture: None,
         lineage: None,
         loaded: false,
     };

--- a/crates/aprender-serve/src/api/tests/completion_request_02.rs
+++ b/crates/aprender-serve/src/api/tests/completion_request_02.rs
@@ -52,10 +52,12 @@ fn test_model_metadata_response_with_lineage() {
     let response = ModelMetadataResponse {
         id: "test-model".to_string(),
         name: "Test Model".to_string(),
-        format: "GGUF".to_string(),
-        size_bytes: 4_000_000_000,
+        format: Some("GGUF".to_string()),
+        size_bytes: Some(4_000_000_000),
         quantization: Some("Q4_K_M".to_string()),
-        context_length: 8192,
+        context_length: Some(8192),
+        model_max_context_length: None,
+        architecture: None,
         lineage: Some(lineage),
         loaded: true,
     };
@@ -74,18 +76,20 @@ fn test_model_metadata_response_large_size() {
     let response = ModelMetadataResponse {
         id: "large-model".to_string(),
         name: "Large Model".to_string(),
-        format: "SafeTensors".to_string(),
-        size_bytes: 70_000_000_000, // 70GB
+        format: Some("SafeTensors".to_string()),
+        size_bytes: Some(70_000_000_000), // 70GB
         quantization: None,
-        context_length: 32768,
+        context_length: Some(32768),
+        model_max_context_length: None,
+        architecture: None,
         lineage: None,
         loaded: false,
     };
 
     let json = serde_json::to_string(&response).expect("serialize");
     let parsed: ModelMetadataResponse = serde_json::from_str(&json).expect("deserialize");
-    assert_eq!(parsed.size_bytes, 70_000_000_000);
-    assert_eq!(parsed.context_length, 32768);
+    assert_eq!(parsed.size_bytes, Some(70_000_000_000));
+    assert_eq!(parsed.context_length, Some(32768));
 }
 
 #[test]
@@ -93,10 +97,12 @@ fn test_model_metadata_response_clone() {
     let response = ModelMetadataResponse {
         id: "test".to_string(),
         name: "Test".to_string(),
-        format: "GGUF".to_string(),
-        size_bytes: 1000,
+        format: Some("GGUF".to_string()),
+        size_bytes: Some(1000),
         quantization: Some("Q4_0".to_string()),
-        context_length: 2048,
+        context_length: Some(2048),
+        model_max_context_length: None,
+        architecture: None,
         lineage: None,
         loaded: true,
     };
@@ -111,10 +117,12 @@ fn test_model_metadata_response_debug() {
     let response = ModelMetadataResponse {
         id: "debug".to_string(),
         name: "Debug".to_string(),
-        format: "APR".to_string(),
-        size_bytes: 0,
+        format: Some("APR".to_string()),
+        size_bytes: Some(0),
         quantization: None,
-        context_length: 512,
+        context_length: Some(512),
+        model_max_context_length: None,
+        architecture: None,
         lineage: None,
         loaded: false,
     };

--- a/crates/aprender-serve/src/api/tests/context_window_serde.rs
+++ b/crates/aprender-serve/src/api/tests/context_window_serde.rs
@@ -439,10 +439,12 @@ fn test_model_metadata_response_serde() {
     let resp = ModelMetadataResponse {
         id: "m1".to_string(),
         name: "Test Model".to_string(),
-        format: "GGUF".to_string(),
-        size_bytes: 1024,
+        format: Some("GGUF".to_string()),
+        size_bytes: Some(1024),
         quantization: Some("Q4_K_M".to_string()),
-        context_length: 2048,
+        context_length: Some(2048),
+        model_max_context_length: None,
+        architecture: None,
         lineage: None,
         loaded: true,
     };

--- a/crates/aprender-serve/src/api/tests/mod.rs
+++ b/crates/aprender-serve/src/api/tests/mod.rs
@@ -51,3 +51,4 @@ mod tests_28; // Coverage: realize_handlers pure functions, ContextWindow, clean
 mod chat_template_contract; // PMAT-187: chat-template-v1.yaml contract enforcement (FALSIFY-CT-002)
 mod embeddings_pmat803; // PMAT-803: model-backed embeddings (semantic-similarity falsifier, dim==hidden_size)
 mod sse_stream_whitespace; // Dogfood 0.63.0: SSE deltas must reassemble with whitespace intact
+mod ollama_compat_http; // Dogfood 0.63.0 (#2396/#2402): /api/tags|show|version routed, stream:true is NDJSON, /realize/* stops fabricating

--- a/crates/aprender-serve/src/api/tests/model_metadata.rs
+++ b/crates/aprender-serve/src/api/tests/model_metadata.rs
@@ -8,10 +8,12 @@ fn test_model_metadata_response_full_cov() {
     let metadata = ModelMetadataResponse {
         id: "my-model-v1".to_string(),
         name: "My Model V1".to_string(),
-        format: "GGUF".to_string(),
-        size_bytes: 4_000_000_000,
+        format: Some("GGUF".to_string()),
+        size_bytes: Some(4_000_000_000),
         quantization: Some("Q4_K_M".to_string()),
-        context_length: 4096,
+        context_length: Some(4096),
+        model_max_context_length: None,
+        architecture: None,
         lineage: Some(ModelLineage {
             uri: "pacha://org/model".to_string(),
             version: "1.0.0".to_string(),
@@ -33,10 +35,12 @@ fn test_model_metadata_response_minimal_cov() {
     let metadata = ModelMetadataResponse {
         id: "basic".to_string(),
         name: "Basic Model".to_string(),
-        format: "APR".to_string(),
-        size_bytes: 100_000_000,
+        format: Some("APR".to_string()),
+        size_bytes: Some(100_000_000),
         quantization: None,
-        context_length: 1024,
+        context_length: Some(1024),
+        model_max_context_length: None,
+        architecture: None,
         lineage: None,
         loaded: false,
     };

--- a/crates/aprender-serve/src/api/tests/ollama_compat_http.rs
+++ b/crates/aprender-serve/src/api/tests/ollama_compat_http.rs
@@ -1,0 +1,498 @@
+//! Falsifiers for the Ollama-compat and `/realize/*` metadata surfaces, at the
+//! HTTP layer where the defects were observed.
+//!
+//! Dogfooding `cargo install aprender` 0.63.0 from crates.io found four things
+//! that a unit test on a handler function could not have caught, because each
+//! is a property of the ROUTER or of the response envelope:
+//!
+//! - `GET /api/tags`, `POST /api/show`, `GET /api/version` answered 404 while
+//!   the startup banner advertised "Ollama-Parity Endpoints" (#2396). Every
+//!   Ollama client calls `/api/tags` before it will issue a chat request, so
+//!   the server was unreachable to all of them.
+//! - `POST /api/chat` and `/api/generate` accepted `"stream":true` and returned
+//!   one buffered JSON object with a `content-length` (#2396).
+//! - `GET /realize/model` returned `size_bytes: 0`, `context_length: 4096`,
+//!   `format: "gguf"`, `quantization: "Q4_K_M"` and a `content_hash` of
+//!   `"blake3:0".repeat(16)` for every model (#2402).
+//! - `POST /realize/reload`'s 501 told the caller to "Start server with
+//!   --registry flag" — a flag `apr serve run` does not have (#2402).
+
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+};
+use tower::util::ServiceExt;
+
+use crate::api::test_helpers::create_test_app_shared;
+use crate::api::{create_router, AppState, ModelSourceInfo};
+
+async fn body_json(response: axum::response::Response) -> serde_json::Value {
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read body");
+    serde_json::from_slice(&bytes).expect("body is JSON")
+}
+
+// ---------------------------------------------------------------------------
+// #2396 finding 2: the discovery routes must EXIST.
+// ---------------------------------------------------------------------------
+
+/// The 404 body 0.63.0 returned for these paths. If a route is missing, the
+/// axum fallback produces this — so the tests below check for its ABSENCE,
+/// which is what distinguishes "route wired" from "route missing".
+fn is_route_not_found(json: &serde_json::Value) -> bool {
+    json.get("error").and_then(serde_json::Value::as_str) == Some("not_found")
+}
+
+#[tokio::test]
+async fn api_tags_is_routed_and_lists_a_model_the_client_can_ask_for() {
+    let app = create_test_app_shared();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/tags")
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "/api/tags 404'd in 0.63.0; every Ollama client calls it first"
+    );
+    let json = body_json(response).await;
+    assert!(!is_route_not_found(&json), "got the fallback body: {json}");
+
+    let models = json["models"].as_array().expect("models is an array");
+    assert_eq!(models.len(), 1, "single-model server advertises one tag");
+    let name = models[0]["name"].as_str().expect("name is a string");
+    assert!(
+        !name.is_empty() && name.contains(':'),
+        "name must be an addressable `model:tag`, got {name:?}"
+    );
+    assert_eq!(models[0]["model"], models[0]["name"]);
+}
+
+#[tokio::test]
+async fn api_version_is_routed_and_returns_a_parseable_version() {
+    let app = create_test_app_shared();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/version")
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+    let version = json["version"].as_str().expect("version is a string");
+    // Clients version-gate on this; it must be a real dotted version, not a
+    // placeholder like "unknown".
+    assert!(
+        version.split('.').count() >= 2 && version.starts_with(|c: char| c.is_ascii_digit()),
+        "version {version:?} must be a semver-shaped string"
+    );
+}
+
+#[tokio::test]
+async fn api_show_is_routed_and_answers_a_post() {
+    let app = create_test_app_shared();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/show")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"model":"apr"}"#))
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+    assert!(!is_route_not_found(&json), "got the fallback body: {json}");
+    assert!(json.get("details").is_some(), "show must carry details");
+    assert!(
+        json["capabilities"]
+            .as_array()
+            .is_some_and(|c| c.iter().any(|v| v == "completion")),
+        "a server that serves /api/chat has the completion capability"
+    );
+}
+
+/// `/api/show` with no recorded model source must not invent metadata. This is
+/// the same "measured or absent" rule `/realize/model` violated.
+#[tokio::test]
+async fn api_show_without_a_measured_source_claims_nothing() {
+    let app = create_test_app_shared();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/show")
+                .header("content-type", "application/json")
+                .body(Body::from("{}"))
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+
+    let json = body_json(response).await;
+    let details = json["details"].as_object().expect("details is an object");
+    assert!(
+        details.is_empty(),
+        "unmeasured details must be absent, got {details:?}"
+    );
+    let info = json["model_info"].as_object().expect("model_info object");
+    assert!(
+        info.is_empty(),
+        "unmeasured model_info must be absent, got {info:?}"
+    );
+}
+
+/// With a measured source attached, the SAME endpoints report the measured
+/// values. This is the other half of the falsifier: absence must be caused by
+/// not knowing, not by the fields being unreachable.
+#[tokio::test]
+async fn api_show_reports_the_measured_source() {
+    let source = ModelSourceInfo::default()
+        .with_architecture("qwen2")
+        .with_quantization("Q4_K")
+        .with_context_length(128)
+        .with_model_max_context_length(32768);
+    let state = AppState::demo().expect("demo state").with_model_source(source);
+    let app = create_router(state);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/show")
+                .header("content-type", "application/json")
+                .body(Body::from("{}"))
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+
+    let json = body_json(response).await;
+    assert_eq!(json["details"]["family"], "qwen2");
+    assert_eq!(json["details"]["quantization_level"], "Q4_K");
+    // The served bound and the model's own maximum are DIFFERENT facts. 0.63.0
+    // collapsed them into a constant 4096 and reported that for both.
+    assert_eq!(json["model_info"]["apr.configured_context_length"], 128);
+    assert_eq!(json["model_info"]["general.context_length"], 32768);
+}
+
+// ---------------------------------------------------------------------------
+// #2396 finding 3: stream:true must produce NDJSON, not one buffered object.
+// ---------------------------------------------------------------------------
+
+/// Read the body as text and parse it as newline-delimited JSON.
+async fn ndjson_objects(response: axum::response::Response) -> Vec<serde_json::Value> {
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read body");
+    let text = String::from_utf8(bytes.to_vec()).expect("utf-8 body");
+    text.lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| serde_json::from_str(l).expect("each line is a JSON object"))
+        .collect()
+}
+
+#[tokio::test]
+async fn api_chat_with_stream_true_returns_ndjson_terminated_by_done() {
+    let app = create_test_app_shared();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/chat")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    r#"{"model":"apr","messages":[{"role":"user","content":"hi"}],"stream":true,"options":{"num_predict":8}}"#,
+                ))
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let content_type = response
+        .headers()
+        .get(axum::http::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default()
+        .to_string();
+    assert!(
+        content_type.starts_with("application/x-ndjson"),
+        "stream:true must be framed as NDJSON, got content-type {content_type:?}"
+    );
+    // 0.63.0's proof of buffering: a content-length on a streamed response.
+    assert!(
+        response
+            .headers()
+            .get(axum::http::header::CONTENT_LENGTH)
+            .is_none(),
+        "a streamed body must not be length-prefixed"
+    );
+
+    let objects = ndjson_objects(response).await;
+    assert!(!objects.is_empty(), "stream must carry at least one object");
+    let last = objects.last().expect("non-empty");
+    assert_eq!(last["done"], true, "stream must terminate with done:true");
+    for obj in &objects[..objects.len() - 1] {
+        assert_eq!(obj["done"], false, "only the last object may be done:true");
+    }
+}
+
+#[tokio::test]
+async fn api_generate_with_stream_true_returns_ndjson_terminated_by_done() {
+    let app = create_test_app_shared();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/generate")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    r#"{"model":"apr","prompt":"count","stream":true,"options":{"num_predict":8}}"#,
+                ))
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    // Same two wire facts as /api/chat. Without them this test passes on the
+    // 0.63.0 behaviour: one buffered object IS one parseable NDJSON line with
+    // done:true, so only the FRAMING distinguishes fixed from broken.
+    let content_type = response
+        .headers()
+        .get(axum::http::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default()
+        .to_string();
+    assert!(
+        content_type.starts_with("application/x-ndjson"),
+        "stream:true must be framed as NDJSON, got content-type {content_type:?}"
+    );
+    assert!(
+        response
+            .headers()
+            .get(axum::http::header::CONTENT_LENGTH)
+            .is_none(),
+        "a streamed body must not be length-prefixed"
+    );
+
+    let objects = ndjson_objects(response).await;
+    let last = objects.last().expect("non-empty");
+    assert_eq!(last["done"], true);
+    assert!(
+        last.get("message").is_none(),
+        "/api/generate uses a flat `response`, never a nested message"
+    );
+    // The terminal object carries the counts; content chunks do not.
+    assert!(last.get("done_reason").is_some());
+}
+
+/// `stream:false` (and an absent `stream`) must keep the single-object shape —
+/// the fix must not break the clients that were working.
+#[tokio::test]
+async fn api_chat_without_stream_stays_a_single_json_object() {
+    let app = create_test_app_shared();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/chat")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    r#"{"model":"apr","messages":[{"role":"user","content":"hi"}],"stream":false,"options":{"num_predict":4}}"#,
+                ))
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+
+    let content_type = response
+        .headers()
+        .get(axum::http::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default()
+        .to_string();
+    assert!(
+        content_type.starts_with("application/json"),
+        "non-streaming must stay application/json, got {content_type:?}"
+    );
+    let json = body_json(response).await;
+    assert_eq!(json["done"], true);
+    assert!(json["message"]["role"] == "assistant");
+}
+
+// ---------------------------------------------------------------------------
+// #2402 finding 1: /realize/model must never fabricate provenance.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn realize_model_never_emits_a_synthetic_content_hash() {
+    let app = create_test_app_shared();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/realize/model")
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+
+    // The exact 128-character string 0.63.0 shipped, and the shape of it.
+    let serialized = json.to_string();
+    assert!(
+        !serialized.contains("blake3:0blake3:0"),
+        "synthetic content hash still on the wire: {serialized}"
+    );
+    assert!(
+        json.get("lineage").is_none(),
+        "lineage must be absent until a real content hash is computed, got {json}"
+    );
+    // Unmeasured metadata is ABSENT, not defaulted. `size_bytes: 0` reads as a
+    // zero-byte model; `format: "gguf"` misreports every other container.
+    for field in ["size_bytes", "context_length", "quantization", "format"] {
+        assert!(
+            json.get(field).is_none(),
+            "{field} must be absent when unmeasured, got {}",
+            json[field]
+        );
+    }
+    assert_eq!(json["loaded"], true);
+}
+
+#[tokio::test]
+async fn realize_model_reports_measured_values_when_the_loader_supplied_them() {
+    let dir = std::env::temp_dir().join(format!(
+        "apr-realize-model-{}-{}",
+        std::process::id(),
+        line!()
+    ));
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    let path = dir.join("fixture.gguf");
+    // 4-byte magic + 60 bytes of payload = 64 bytes on disk.
+    std::fs::write(&path, [b"GGUF".to_vec(), vec![0u8; 60]].concat()).expect("write");
+
+    let source = ModelSourceInfo::from_path(&path)
+        .with_architecture("qwen2")
+        .with_quantization("Q4_K")
+        .with_context_length(128)
+        .with_model_max_context_length(32768);
+    let state = AppState::demo().expect("demo state").with_model_source(source);
+    let app = create_router(state);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/realize/model")
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+    let json = body_json(response).await;
+
+    assert_eq!(json["size_bytes"], 64, "size must be the real file size");
+    assert_eq!(json["format"], "gguf", "format comes from the magic bytes");
+    assert_eq!(json["quantization"], "Q4_K");
+    assert_eq!(json["architecture"], "qwen2");
+    // The two context facts stay distinct. 0.63.0 answered 4096 for a server
+    // started with --context-length 128 against a 32768-context model.
+    assert_eq!(json["context_length"], 128);
+    assert_eq!(json["model_max_context_length"], 32768);
+    assert!(
+        json.get("lineage").is_none(),
+        "no hash was computed, so no lineage"
+    );
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// A non-GGUF file must not be reported as `gguf`. 0.63.0 hardcoded the string.
+#[tokio::test]
+async fn realize_model_does_not_call_an_apr_file_gguf() {
+    let dir = std::env::temp_dir().join(format!(
+        "apr-realize-model-{}-{}",
+        std::process::id(),
+        line!()
+    ));
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    let path = dir.join("fixture.apr");
+    std::fs::write(&path, [b"APR\0".to_vec(), vec![0u8; 28]].concat()).expect("write");
+
+    let state = AppState::demo()
+        .expect("demo state")
+        .with_model_source(ModelSourceInfo::from_path(&path));
+    let app = create_router(state);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/realize/model")
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+    let json = body_json(response).await;
+    assert_eq!(json["format"], "apr");
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+// ---------------------------------------------------------------------------
+// #2402 finding 2: the 501 must not name a flag that does not exist.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn realize_reload_501_does_not_advertise_a_nonexistent_flag() {
+    let app = create_test_app_shared();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/realize/reload")
+                .header("content-type", "application/json")
+                .body(Body::from("{}"))
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+
+    assert_eq!(response.status(), StatusCode::NOT_IMPLEMENTED);
+    let json = body_json(response).await;
+    let error = json["error"].as_str().expect("error is a string");
+
+    // `apr serve run --registry <FILE>` is rejected by clap with exit 2: the
+    // flag does not exist on `apr serve run` or on `apr serve`. An error that
+    // tells the user how to fix the problem must name a real remedy.
+    assert!(
+        !error.contains("Start server with --registry flag"),
+        "the 0.63.0 dead-end advice is still on the wire: {error}"
+    );
+    assert!(
+        error.contains("does not expose registry mode"),
+        "the message must state that the CLI cannot enable this: {error}"
+    );
+    // And it must still say what the caller CAN do.
+    assert!(
+        error.contains("apr serve run"),
+        "message must offer the working alternative: {error}"
+    );
+}

--- a/crates/aprender-serve/src/api/tests/openai_completions.rs
+++ b/crates/aprender-serve/src/api/tests/openai_completions.rs
@@ -310,17 +310,19 @@ fn test_model_metadata_response_zero_size() {
     let response = ModelMetadataResponse {
         id: "streaming-model".to_string(),
         name: "Streaming Model".to_string(),
-        format: "GGUF".to_string(),
-        size_bytes: 0,
+        format: Some("GGUF".to_string()),
+        size_bytes: Some(0),
         quantization: None,
-        context_length: 4096,
+        context_length: Some(4096),
+        model_max_context_length: None,
+        architecture: None,
         lineage: None,
         loaded: false,
     };
 
     let json = serde_json::to_string(&response).expect("serialize");
     let parsed: ModelMetadataResponse = serde_json::from_str(&json).expect("deserialize");
-    assert_eq!(parsed.size_bytes, 0);
+    assert_eq!(parsed.size_bytes, Some(0));
 }
 
 #[test]
@@ -330,10 +332,12 @@ fn test_model_metadata_response_all_quantizations() {
         let response = ModelMetadataResponse {
             id: format!("model-{quant}"),
             name: format!("Model {quant}"),
-            format: "GGUF".to_string(),
-            size_bytes: 1000,
+            format: Some("GGUF".to_string()),
+            size_bytes: Some(1000),
             quantization: Some(quant.to_string()),
-            context_length: 2048,
+            context_length: Some(2048),
+            model_max_context_length: None,
+            architecture: None,
             lineage: None,
             loaded: true,
         };

--- a/crates/aprender-serve/src/api/tests/realize_generate.rs
+++ b/crates/aprender-serve/src/api/tests/realize_generate.rs
@@ -77,10 +77,12 @@ fn test_model_metadata_response_clone_debug_more_cov() {
     let metadata = ModelMetadataResponse {
         id: "test".to_string(),
         name: "Test".to_string(),
-        format: "GGUF".to_string(),
-        size_bytes: 1000,
+        format: Some("GGUF".to_string()),
+        size_bytes: Some(1000),
         quantization: None,
-        context_length: 4096,
+        context_length: Some(4096),
+        model_max_context_length: None,
+        architecture: None,
         lineage: None,
         loaded: true,
     };

--- a/crates/aprender-serve/src/api/tests/tests_07.rs
+++ b/crates/aprender-serve/src/api/tests/tests_07.rs
@@ -400,10 +400,12 @@ fn test_model_metadata_response_serialization() {
     let response = ModelMetadataResponse {
         id: "model-001".to_string(),
         name: "Test Model".to_string(),
-        format: "GGUF".to_string(),
-        size_bytes: 1024 * 1024 * 100,
+        format: Some("GGUF".to_string()),
+        size_bytes: Some(1024 * 1024 * 100),
         quantization: Some("Q4_K_M".to_string()),
-        context_length: 4096,
+        context_length: Some(4096),
+        model_max_context_length: None,
+        architecture: None,
         lineage: None,
         loaded: true,
     };
@@ -423,10 +425,12 @@ fn test_model_metadata_response_without_optional_fields() {
     let response = ModelMetadataResponse {
         id: "model-002".to_string(),
         name: "Minimal Model".to_string(),
-        format: "APR".to_string(),
-        size_bytes: 1000,
+        format: Some("APR".to_string()),
+        size_bytes: Some(1000),
         quantization: None,
-        context_length: 2048,
+        context_length: Some(2048),
+        model_max_context_length: None,
+        architecture: None,
         lineage: None,
         loaded: false,
     };

--- a/crates/aprender-serve/src/api/tests/tests_28.rs
+++ b/crates/aprender-serve/src/api/tests/tests_28.rs
@@ -371,10 +371,12 @@ fn test_model_metadata_response_serde() {
     let resp = ModelMetadataResponse {
         id: "model-1".to_string(),
         name: "Test Model".to_string(),
-        format: "gguf".to_string(),
-        size_bytes: 1_000_000,
+        format: Some("gguf".to_string()),
+        size_bytes: Some(1_000_000),
         quantization: Some("Q4_K_M".to_string()),
-        context_length: 4096,
+        context_length: Some(4096),
+        model_max_context_length: None,
+        architecture: None,
         lineage: Some(ModelLineage {
             uri: "pacha://model:latest".to_string(),
             version: "1.0.0".to_string(),
@@ -396,10 +398,12 @@ fn test_model_metadata_response_no_lineage() {
     let resp = ModelMetadataResponse {
         id: "model-2".to_string(),
         name: "Simple Model".to_string(),
-        format: "apr".to_string(),
-        size_bytes: 500_000,
+        format: Some("apr".to_string()),
+        size_bytes: Some(500_000),
         quantization: None,
-        context_length: 2048,
+        context_length: Some(2048),
+        model_max_context_length: None,
+        architecture: None,
         lineage: None,
         loaded: false,
     };


### PR DESCRIPTION
Serving a real 1.04 GiB Q4_K GGUF with `apr serve run ... --context-length 128`,
0.63.0 answered GET /realize/model with five values it had never looked at:

  {"format":"gguf","size_bytes":0,"quantization":"Q4_K_M","context_length":4096,
   "lineage":{"uri":"pacha://default:latest","version":"1.0.0",
   "content_hash":"blake3:0blake3:0blake3:0blake3:0blake3:0blake3:0blake3:0blake3:0blake3:0blake3:0blake3:0blake3:0blake3:0blake3:0blake3:0blake3:0"}}

Every one was a constant. `apr inspect` on the same file says 1.04 GiB and
context_length 32768, the server had been started with --context-length 128, and
the content_hash is `"blake3:0".repeat(16)` — a 128-character string shaped
exactly like a BLAKE3 digest, which a consumer cannot tell from a real one and
will store and compare as provenance. That in the release whose theme is
provenance.

The rule now is: every field is measured or absent. api/model_source.rs holds a
ModelSourceInfo whose accessors all return Option; the handlers omit what they do
not know instead of substituting something plausible. Size and container format
come from the file (magic bytes, not the extension — an .apr file no longer
reports "gguf"), quantization from the qtype of the loaded projection tensors
(GGUF's general.file_type is advisory and goes stale on requantize),
architecture from the loader, and the context the server was CONFIGURED with is
reported separately from the model's own advertised maximum — collapsing those
two is what produced the 4096. `lineage` appears only when a hash was actually
computed over the model bytes, which today means never, so it is absent.

  after: {"format":"gguf","size_bytes":1117320768,"quantization":"Q4_K",
          "context_length":128,"model_max_context_length":32768,
          "architecture":"qwen2","loaded":true}

POST /realize/reload answered 501 with "Start server with --registry flag".
There is no --registry flag: `apr serve run --registry <FILE>` exits 2 with
"unexpected argument '--registry' found", and `apr serve --help` has none
either, so the endpoint was unreachable by any documented invocation and the
message sent the caller down a dead end. It now says the CLI does not expose
registry mode, names the embedder API that does, and gives the working
alternative.

The same server was also not an Ollama server. PMAT-928 wired NDJSON streaming
and /api/tags onto the apr-cli APR-CPU router; `apr serve run <GGUF>` mounts a
different one — realizar's create_router, via run_cpu_server — and that one was
never fixed. /api/tags, /api/show and /api/version returned 404 while the
startup banner advertised "Ollama-Parity Endpoints", and every Ollama client
calls /api/tags before it will issue a single chat request. `stream:true` was
parsed off the request and thrown away: the reply was one buffered
application/json object with content-length 190, so Open WebUI, continue.dev and
the ollama CLI showed a frozen cursor for the whole generation.

Both are fixed on that router. stream:true now answers application/x-ndjson with
no content-length: one `{...,done:false}` object per fragment, concatenating to
the full text, terminated by exactly one `{...,done:true,done_reason:"stop",
prompt_eval_count,eval_count}`. A Go client built on ollama's own ChatResponse
type (CreatedAt time.Time) decodes it end to end:

  content-type: application/x-ndjson; charset=utf-8
  content-length header present: false
  objects=7 done_reason="stop" eval_count=7
  assembled="The capital of France is Paris."

This router's chat backend has no token callback, so the fragments are cut from
the finished generation — the wire protocol is now correct and clients no longer
hang, but time-to-first-object is unchanged. stream:false is byte-identical to
before, asserted by a no-regression test.

Root causes: crates/aprender-serve/src/api/realize_handlers_embed_completion.rs:173-183
(the five constants and the synthetic hash) and :204 (the --registry advice);
crates/aprender-serve/src/api/ollama_handlers.rs:185-186 (stream hardcoded false)
and crates/aprender-serve/src/api/router.rs:108-109 (only /api/chat and
/api/generate registered).

One test encoded the defect rather than the requirement and was rewritten:
to_chat_request_maps_messages_and_options asserted `!req.stream` under the
message "Ollama path always drives chat non-streaming". The internal chat path
is still driven non-streaming — that part is true and still asserted — but the
old wording read as a licence to discard the client's flag, which is the bug.
The assertion now says it is about the internal path only, and points at the
stream falsifiers for the wire behaviour.

Mutation check. Reverting all four fixes and keeping the tests turns 10 of the 12
HTTP falsifiers RED:

  api_tags_is_routed_and_lists_a_model_the_client_can_ask_for ... FAILED
    /api/tags 404'd in 0.63.0; every Ollama client calls it first
  api_chat_with_stream_true_returns_ndjson_terminated_by_done ... FAILED
    stream:true must be framed as NDJSON, got content-type "application/json"
  realize_model_never_emits_a_synthetic_content_hash ... FAILED
    synthetic content hash still on the wire: {"context_length":4096,"format":"gguf",
    ...,"content_hash":"blake3:0blake3:0...","size_bytes":0}
  realize_reload_501_does_not_advertise_a_nonexistent_flag ... FAILED
    the 0.63.0 dead-end advice is still on the wire: Hot-reload requires registry
    mode. Start server with --registry flag.
  test result: FAILED. 2 passed; 10 failed

Of the two survivors one was the intended control (stream:false must stay a
single JSON object). The other,
api_generate_stream_true_is_ndjson_multi_chunk, was a hole: one buffered object
IS one parseable NDJSON line with done:true, so only the framing distinguishes
fixed from broken. It now asserts content-type and the absence of
content-length, and goes RED under the stream mutation alongside its /api/chat
twin. Separately, replacing split_inclusive with split in content_fragments
turns the reassembly falsifiers RED, so they are not merely counting chunks.

Fixes #2402
Refs #2396 (partial) — findings 2 and 3 fixed on the realizar router; /api/embeddings
and /api/embed left out, because that path needs real embeddings on the quantized
backend (realize_embed_handler requires state.model, which is None for GGUF) and
routing them would only produce a well-formed error.
Audit epic: #2373

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
