### PR TITLE
fix(convert): apr convert threw away the tokenizer it had just parsed and exited 0 (#2392)

### DIFF
--- a/crates/apr-cli/src/commands/convert.rs
+++ b/crates/apr-cli/src/commands/convert.rs
@@ -94,13 +94,7 @@ fn validate_convert_inputs(file: &Path, output: &Path, force: bool) -> Result<()
     if !file.exists() {
         return Err(CliError::FileNotFound(file.to_path_buf()));
     }
-    if output.exists() && !force {
-        return Err(CliError::ValidationFailed(format!(
-            "Output file '{}' already exists. Use --force to overwrite.",
-            output.display()
-        )));
-    }
-    Ok(())
+    crate::error::refuse_overwrite(output, force)
 }
 
 fn print_convert_banner(

--- a/crates/apr-cli/src/commands/export.rs
+++ b/crates/apr-cli/src/commands/export.rs
@@ -252,6 +252,7 @@ pub(crate) fn run(
     batch: Option<&str>,
     json_output: bool,
     plan: bool,
+    force: bool,
 ) -> Result<()> {
     contract_pre_format_conversion_roundtrip!();
     contract_pre_atomic_write_safety!();
@@ -293,6 +294,10 @@ pub(crate) fn run(
     if pipe_to_stdout {
         return run_export_to_stdout(file, export_format, quant_type);
     }
+
+    // #2392 finding 4: export used to write straight over an existing file and
+    // exit 0. `-o -` is exempt above (stdout is not a file we can clobber).
+    crate::error::refuse_overwrite(output, force)?;
 
     if !json_output {
         output::header("APR Export");

--- a/crates/apr-cli/src/commands/export_file.rs
+++ b/crates/apr-cli/src/commands/export_file.rs
@@ -38,6 +38,7 @@ mod tests {
             None,
             false,
             false,
+            true, // #2392: force — these tests predate the overwrite guard
         );
         assert!(result.is_err());
         match result {
@@ -48,7 +49,7 @@ mod tests {
 
     #[test]
     fn test_run_no_file() {
-        let result = run(None, "safetensors", None, None, false, None, false, false);
+        let result = run(None, "safetensors", None, None, false, None, false, false, true);
         assert!(result.is_err());
         match result {
             Err(CliError::ValidationFailed(msg)) => {
@@ -70,6 +71,7 @@ mod tests {
             None,
             false,
             false,
+            true, // #2392: force — these tests predate the overwrite guard
         );
         assert!(result.is_err());
         match result {
@@ -92,6 +94,7 @@ mod tests {
             None,
             false,
             false,
+            true, // #2392: force — these tests predate the overwrite guard
         );
         assert!(result.is_err());
         match result {
@@ -114,6 +117,7 @@ mod tests {
             None,
             false,
             false,
+            true, // #2392: force — these tests predate the overwrite guard
         );
         assert!(result.is_err());
         match result {
@@ -136,6 +140,7 @@ mod tests {
             None,
             false,
             false,
+            true, // #2392: force — these tests predate the overwrite guard
         );
         assert!(result.is_err());
         match result {
@@ -158,6 +163,7 @@ mod tests {
             None,
             false,
             false,
+            true, // #2392: force — these tests predate the overwrite guard
         );
         assert!(result.is_err());
         match result {
@@ -180,6 +186,7 @@ mod tests {
             None,
             false,
             false,
+            true, // #2392: force — these tests predate the overwrite guard
         );
         assert!(result.is_err());
         match result {
@@ -232,6 +239,7 @@ mod tests {
             None,
             false,
             false,
+            true, // #2392: force — these tests predate the overwrite guard
         );
         assert!(result.is_err());
     }
@@ -242,13 +250,13 @@ mod tests {
 
     #[test]
     fn test_list_formats() {
-        let result = run(None, "safetensors", None, None, true, None, false, false);
+        let result = run(None, "safetensors", None, None, true, None, false, false, true);
         assert!(result.is_ok());
     }
 
     #[test]
     fn test_list_formats_json() {
-        let result = run(None, "safetensors", None, None, true, None, true, false);
+        let result = run(None, "safetensors", None, None, true, None, true, false, true);
         assert!(result.is_ok());
     }
 
@@ -268,6 +276,7 @@ mod tests {
             Some("gguf,unknown"),
             false,
             false,
+            true, // #2392: force — these tests predate the overwrite guard
         );
         assert!(result.is_err());
     }
@@ -284,6 +293,7 @@ mod tests {
             Some("gguf,onnx"),
             false,
             false,
+            true, // #2392: force — these tests predate the overwrite guard
         );
         assert!(result.is_err());
         match result {
@@ -382,6 +392,7 @@ mod tests {
             None,
             false,
             false,
+            true, // #2392: force — these tests predate the overwrite guard
         );
         assert!(result.is_err());
     }
@@ -459,6 +470,7 @@ mod tests {
             None,
             false,
             false,
+            true, // #2392: force — these tests predate the overwrite guard
         );
         // Fails with FileNotFound (not output validation) because stdout is detected
         assert!(result.is_err());
@@ -476,6 +488,7 @@ mod tests {
             None,
             false,
             false,
+            true, // #2392: force — these tests predate the overwrite guard
         );
         assert!(result.is_err());
         assert!(matches!(result, Err(CliError::FileNotFound(_))));

--- a/crates/apr-cli/src/commands/merge.rs
+++ b/crates/apr-cli/src/commands/merge.rs
@@ -235,6 +235,7 @@ pub(crate) fn run(
     seed: u64,
     json_output: bool,
     plan: bool,
+    force: bool,
 ) -> Result<()> {
     contract_pre_merge_tensor_shape!();
     contract_pre_merge_weight_conservation!(files);
@@ -255,6 +256,10 @@ pub(crate) fn run(
     let output = output.ok_or_else(|| {
         CliError::ValidationFailed("--output is required for merge execution".into())
     })?;
+
+    // #2392 finding 4: merge used to write straight over an existing file and
+    // exit 0, with no --force flag to opt into the guard convert already had.
+    crate::error::refuse_overwrite(output, force)?;
 
     validate_merge_inputs(files)?;
 

--- a/crates/apr-cli/src/commands/merge_tests.rs
+++ b/crates/apr-cli/src/commands/merge_tests.rs
@@ -29,6 +29,7 @@ fn test_run_insufficient_files() {
         42,
         false,
         false,
+        true, // #2392: force — these tests predate the overwrite guard
     );
     // Debug: unreachable (panicked above). Release: must be a rejection, not a successful merge.
     #[cfg(not(debug_assertions))]
@@ -54,6 +55,7 @@ fn test_run_empty_files() {
         42,
         false,
         false,
+        true, // #2392: force — these tests predate the overwrite guard
     );
     // Debug: unreachable (panicked above). Release: must be a rejection, not a successful merge.
     #[cfg(not(debug_assertions))]
@@ -80,6 +82,7 @@ fn test_run_file_not_found() {
         42,
         false,
         false,
+        true, // #2392: force — these tests predate the overwrite guard
     );
     assert!(result.is_err());
     match result {
@@ -106,6 +109,7 @@ fn test_run_second_file_not_found() {
         42,
         false,
         false,
+        true, // #2392: force — these tests predate the overwrite guard
     );
     assert!(result.is_err());
     match result {
@@ -130,6 +134,7 @@ fn test_run_unknown_strategy() {
         42,
         false,
         false,
+        true, // #2392: force — these tests predate the overwrite guard
     );
     assert!(result.is_err());
     match result {
@@ -156,6 +161,7 @@ fn test_run_ties_without_base_model() {
         42,
         false,
         false,
+        true, // #2392: force — these tests predate the overwrite guard
     );
     assert!(result.is_err());
     match result {
@@ -184,6 +190,7 @@ fn test_run_dare_without_base_model() {
         42,
         false,
         false,
+        true, // #2392: force — these tests predate the overwrite guard
     );
     assert!(result.is_err());
     match result {
@@ -217,6 +224,7 @@ fn test_run_slerp_with_three_models() {
         42,
         false,
         false,
+        true, // #2392: force — these tests predate the overwrite guard
     );
     assert!(result.is_err());
 }
@@ -286,6 +294,7 @@ fn test_run_invalid_apr_files() {
         42,
         false,
         false,
+        true, // #2392: force — these tests predate the overwrite guard
     );
     // Should fail because files are not valid APR
     assert!(result.is_err());
@@ -310,6 +319,7 @@ fn test_run_with_weights() {
         42,
         false,
         false,
+        true, // #2392: force — these tests predate the overwrite guard
     );
     // Will fail at actual merge, but tests weight parsing path
     assert!(result.is_err());

--- a/crates/apr-cli/src/commands/quantize.rs
+++ b/crates/apr-cli/src/commands/quantize.rs
@@ -16,7 +16,8 @@
 use crate::error::{CliError, Result};
 use crate::output;
 use aprender::format::{
-    apr_convert, streaming_quantize_peak_estimate, ConvertOptions, QuantizationType,
+    apr_convert, q4k_output_size_estimate, streaming_quantize_peak_estimate, ConvertOptions,
+    QuantizationType,
 };
 use humansize::{format_size, BINARY};
 use std::path::Path;
@@ -68,12 +69,40 @@ fn estimate_memory(file_size: u64, scheme: QuantScheme) -> (u64, u64, f64) {
     let input_size = file_size;
     // Assume input is F32 (32 bits/weight)
     let output_size = (file_size as f64 * bits_per_weight / 32.0) as u64;
-    let reduction = if output_size > 0 {
+    let reduction = ratio(input_size, output_size);
+    (input_size, output_size, reduction)
+}
+
+/// Reduction ratio input/output, guarding division by zero.
+fn ratio(input_size: u64, output_size: u64) -> f64 {
+    if output_size > 0 {
         input_size as f64 / output_size as f64
     } else {
         1.0
-    };
-    (input_size, output_size, reduction)
+    }
+}
+
+/// #2392 (dogfood 0.63.0, finding 3): size estimate for `--plan`.
+///
+/// For Q4K the flat bits-per-weight model is not merely imprecise, it is
+/// structurally wrong — it produced the same 7.111x ratio for a 4.8 MB model, an
+/// 87 MB model and a 992 MB model, and was 4.34x optimistic on the middle one.
+/// Q4K skips whole classes of tensor (embeddings, norms, biases, scales, and
+/// anything under one super-block) and pads each row up to a multiple of 256, so
+/// the answer depends on the tensor inventory. Ask the shape-aware estimator
+/// first and only fall back to the flat model when the input's tensor index
+/// cannot be read.
+///
+/// The other three schemes are left on the flat model: measured against real
+/// conversions they are accurate (int8 4.0x plan vs 3.98x actual, fp16 2.0x vs
+/// 2.0x, int4 8.0x vs 7.05x), so there is nothing to fix there.
+fn estimate_sizes(file: &Path, file_size: u64, scheme: QuantScheme) -> (u64, u64, f64) {
+    if matches!(scheme, QuantScheme::Q4K) {
+        if let Some(payload) = q4k_output_size_estimate(file) {
+            return (file_size, payload, ratio(file_size, payload));
+        }
+    }
+    estimate_memory(file_size, scheme)
 }
 
 /// Run the quantize command
@@ -135,13 +164,7 @@ pub(crate) fn run(
 
 /// F-CONV-064: Overwrite protection check.
 fn check_overwrite_protection(output_path: &Path, force: bool) -> Result<()> {
-    if output_path.exists() && !force {
-        return Err(CliError::ValidationFailed(format!(
-            "Output file '{}' already exists. Use --force to overwrite.",
-            output_path.display()
-        )));
-    }
-    Ok(())
+    crate::error::refuse_overwrite(output_path, force)
 }
 
 /// Print header for quantize command (no-op in JSON mode).
@@ -263,7 +286,7 @@ fn run_plan(
         .map_err(|e| CliError::ValidationFailed(format!("Cannot read model file: {e}")))?
         .len();
 
-    let (input_size, output_size, reduction) = estimate_memory(file_size, scheme);
+    let (input_size, output_size, reduction) = estimate_sizes(file, file_size, scheme);
     let output_format = format.unwrap_or("apr");
 
     // GH-434 / ALB-093: Large APR+Q4K uses the streaming path — peak is bounded
@@ -352,7 +375,7 @@ fn run_batch_plan(
             .iter()
             .zip(parsed.iter())
             .map(|(name, scheme)| {
-                let (input_size, output_size, reduction) = estimate_memory(file_size, *scheme);
+                let (input_size, output_size, reduction) = estimate_sizes(file, file_size, *scheme);
                 serde_json::json!({
                     "scheme": name,
                     "input_size": input_size,
@@ -381,7 +404,7 @@ fn run_batch_plan(
         println!();
 
         for (name, scheme) in scheme_list.iter().zip(parsed.iter()) {
-            let (_input_size, output_size, reduction) = estimate_memory(file_size, *scheme);
+            let (_input_size, output_size, reduction) = estimate_sizes(file, file_size, *scheme);
             println!(
                 "  {name:<8} → {}  ({reduction:.2}x reduction, peak memory: {})",
                 format_size(output_size, BINARY),

--- a/crates/apr-cli/src/commands/quantize_quant_scheme.rs
+++ b/crates/apr-cli/src/commands/quantize_quant_scheme.rs
@@ -204,4 +204,80 @@ mod tests {
         );
         assert!(result.is_err());
     }
+
+    // ── #2392 finding 3: `--plan -s q4k` returned a hardcoded 7.111x ratio ──
+
+    /// Write a SafeTensors file whose tensors are deliberately a mix of
+    /// Q4K-eligible and Q4K-ineligible: a big embedding table (skipped by name,
+    /// stays F32) plus a projection whose row width is a clean multiple of 256.
+    fn mixed_safetensors(path: &Path) {
+        use aprender::serialization::safetensors::save_safetensors;
+        use std::collections::BTreeMap;
+        let mut t: BTreeMap<String, (Vec<f32>, Vec<usize>)> = BTreeMap::new();
+        t.insert(
+            "model.embed_tokens.weight".to_string(),
+            (vec![0.5; 128 * 512], vec![128, 512]),
+        );
+        t.insert(
+            "model.layers.0.mlp.down_proj.weight".to_string(),
+            (vec![0.25; 128 * 512], vec![128, 512]),
+        );
+        save_safetensors(path, &t).expect("write safetensors fixture");
+    }
+
+    /// The CLI must actually ASK the shape-aware estimator. The flat model
+    /// returns `file_size * 4.5 / 32` for Q4K no matter what is in the file —
+    /// on a model that is half ineligible embedding, that is wildly optimistic.
+    #[test]
+    fn q4k_plan_uses_the_shape_aware_estimate_not_the_flat_ratio() {
+        let dir = std::env::temp_dir().join(format!("apr-2392-f3cli-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        let src = dir.join("mixed.safetensors");
+        mixed_safetensors(&src);
+        let file_size = std::fs::metadata(&src).expect("stat").len();
+
+        let (_, planned, planned_ratio) = estimate_sizes(&src, file_size, QuantScheme::Q4K);
+        let (_, flat, flat_ratio) = estimate_memory(file_size, QuantScheme::Q4K);
+        let direct = aprender::format::q4k_output_size_estimate(&src);
+        let _ = std::fs::remove_dir_all(&dir);
+
+        assert_ne!(
+            planned, flat,
+            "#2392 finding 3: `--plan -s q4k` still returned the flat bits-per-weight \
+             estimate ({flat} bytes, {flat_ratio:.3}x). That number is a constant function of \
+             the file size — it was identical (7.111x) for a 4.8 MB, an 87 MB and a 992 MB \
+             model, and 4.34x optimistic on a real one."
+        );
+        assert!(
+            planned_ratio < flat_ratio,
+            "#2392 finding 3: half of this model is a Q4K-ineligible embedding table that \
+             stays F32, so the honest ratio ({planned_ratio:.3}x) must be below the flat \
+             assumption ({flat_ratio:.3}x)"
+        );
+        assert_eq!(
+            Some(planned),
+            direct,
+            "the CLI must report exactly what the estimator computed"
+        );
+    }
+
+    /// The other three schemes were measured accurate against real conversions,
+    /// so they must keep the flat model — this fix is Q4K-only by design.
+    #[test]
+    fn non_q4k_schemes_keep_the_flat_estimate() {
+        let dir = std::env::temp_dir().join(format!("apr-2392-f3cli2-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        let src = dir.join("mixed.safetensors");
+        mixed_safetensors(&src);
+        let file_size = std::fs::metadata(&src).expect("stat").len();
+
+        for scheme in [QuantScheme::Int8, QuantScheme::Int4, QuantScheme::Fp16] {
+            assert_eq!(
+                estimate_sizes(&src, file_size, scheme),
+                estimate_memory(file_size, scheme),
+                "{scheme:?} must be unaffected by the Q4K estimator change"
+            );
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 }

--- a/crates/apr-cli/src/commands/shard/mod.rs
+++ b/crates/apr-cli/src/commands/shard/mod.rs
@@ -54,9 +54,20 @@ pub fn parse_size(s: &str) -> Result<u64, String> {
     let num_part = num_part.trim();
     let unit_part = unit_part.trim();
 
+    // #2392 (dogfood 0.63.0, finding 7): the unit-suffix split leaves `num_part`
+    // empty for an all-alphabetic value like `abc` (unit = "abc"), and reporting
+    // on that residue produced "invalid number '': cannot parse float from empty
+    // string" — quoting an empty string the user never typed and blaming an
+    // emptiness that is an artifact of our own parser. Echo what they passed.
+    if num_part.is_empty() {
+        return Err(format!(
+            "'{s}' has no numeric part (expected a number with an optional unit, e.g. '500MB')"
+        ));
+    }
+
     let num: f64 = num_part
         .parse()
-        .map_err(|e| format!("invalid number '{num_part}': {e}"))?;
+        .map_err(|e| format!("invalid number '{num_part}' in '{s}': {e}"))?;
     if num < 0.0 || !num.is_finite() {
         return Err(format!("size must be a finite non-negative number: {num}"));
     }
@@ -131,5 +142,53 @@ mod size_tests {
     #[test]
     fn rejects_empty() {
         assert!(parse_size("").is_err());
+    }
+
+    /// #2392 finding 7: `apr shard … --max-shard-size abc` was rejected (right)
+    /// with "invalid number '': cannot parse float from empty string" (wrong).
+    /// The user typed `abc`; the message quoted an empty string they never typed
+    /// and blamed an emptiness that is an artifact of our own unit-suffix split
+    /// (`abc` → unit `abc`, number ``). An error must name the input it is about.
+    #[test]
+    fn alphabetic_value_is_quoted_back_to_the_user() {
+        let err = parse_size("abc").expect_err("'abc' is not a size");
+        assert!(
+            err.contains("abc"),
+            "#2392 finding 7: the message must echo the value the user passed. Got: {err}"
+        );
+        assert!(
+            !err.contains("''"),
+            "#2392 finding 7: the message must not quote an empty string. Got: {err}"
+        );
+    }
+
+    /// Same rule for a value that has a unit but no digits at all.
+    #[test]
+    fn unit_without_a_number_is_quoted_back_to_the_user() {
+        let err = parse_size("GB").expect_err("'GB' has no magnitude");
+        assert!(
+            err.contains("GB") && !err.contains("''"),
+            "#2392 finding 7: got: {err}"
+        );
+    }
+
+    /// A malformed but non-empty number must still name the whole input, not
+    /// just the fragment our splitter produced.
+    #[test]
+    fn malformed_number_names_the_whole_input() {
+        let err = parse_size("1.2.3MB").expect_err("'1.2.3' is not a number");
+        assert!(err.contains("1.2.3MB"), "#2392 finding 7: got: {err}");
+    }
+
+    /// The already-good messages must stay good — these were correct in 0.63.0
+    /// and the fix must not have flattened them into the generic branch.
+    #[test]
+    fn specific_messages_are_preserved() {
+        let unknown = parse_size("5XB").expect_err("XB is not a unit");
+        assert!(
+            unknown.contains("unknown size unit") && unknown.contains("XB"),
+            "got: {unknown}"
+        );
+        assert_eq!(parse_size("0").expect("zero parses"), 0);
     }
 }

--- a/crates/apr-cli/src/commands_enum.rs
+++ b/crates/apr-cli/src/commands_enum.rs
@@ -401,6 +401,9 @@ pub enum Commands {
         /// Plan mode (validate inputs, show export plan, no execution)
         #[arg(long)]
         plan: bool,
+        /// #2392: Overwrite an existing output file (refused without it)
+        #[arg(short, long)]
+        force: bool,
     },
     /// Import from external formats (hf://org/repo, local files, URLs)
     Import {
@@ -634,6 +637,9 @@ pub enum Commands {
         /// Plan mode (validate inputs, show merge plan, no execution)
         #[arg(long)]
         plan: bool,
+        /// #2392: Overwrite an existing output file (refused without it)
+        #[arg(short, long)]
+        force: bool,
     },
     /// Quantize model weights (GH-243)
     Quantize {

--- a/crates/apr-cli/src/dispatch.rs
+++ b/crates/apr-cli/src/dispatch.rs
@@ -491,6 +491,7 @@ fn dispatch_format_commands(cli: &Cli) -> Option<Result<(), CliError>> {
             batch,
             json,
             plan,
+            force,
         } => {
             match file
                 .as_ref()
@@ -506,6 +507,7 @@ fn dispatch_format_commands(cli: &Cli) -> Option<Result<(), CliError>> {
                     batch.as_deref(),
                     *json || cli.json,
                     *plan,
+                    *force,
                 ),
                 Err(e) => Err(e),
             }
@@ -659,6 +661,7 @@ fn dispatch_model_commands(cli: &Cli) -> Option<Result<(), CliError>> {
             density,
             seed,
             plan,
+            force,
         } => {
             let resolved: std::result::Result<Vec<std::path::PathBuf>, _> = files
                 .iter()
@@ -676,6 +679,7 @@ fn dispatch_model_commands(cli: &Cli) -> Option<Result<(), CliError>> {
                     *seed,
                     cli.json,
                     *plan,
+                    *force,
                 ),
                 Err(e) => Err(e),
             }

--- a/crates/apr-cli/src/dispatch_analysis.rs
+++ b/crates/apr-cli/src/dispatch_analysis.rs
@@ -580,9 +580,14 @@ fn dispatch_analysis_commands(cli: &Cli) -> Option<Result<(), CliError>> {
             file,
             max_shard_size,
             output,
-        } => dispatch_shard(file, max_shard_size, output, cli.json),
+            force,
+        } => dispatch_shard(file, max_shard_size, output, *force, cli.json),
 
-        ExtendedCommands::Unshard { input, output } => dispatch_unshard(input, output, cli.json),
+        ExtendedCommands::Unshard {
+            input,
+            output,
+            force,
+        } => dispatch_unshard(input, output, *force, cli.json),
 
         ExtendedCommands::Diagnose {
             checkpoint_dir,
@@ -607,8 +612,13 @@ fn dispatch_shard(
     file: &std::path::Path,
     max_shard_size: &str,
     output: &std::path::Path,
+    force: bool,
     json: bool,
 ) -> Result<(), CliError> {
+    // #2392 finding 4: a shard set is identified by its weight-map index. Writing
+    // a second set into the same directory silently replaces the index (and the
+    // shards it names) — refuse unless the user asked for it.
+    crate::error::refuse_overwrite(&output.join("model.safetensors.index.json"), force)?;
     match commands::shard::run_shard(file, max_shard_size, output) {
         Ok(report) => {
             if json {
@@ -653,8 +663,10 @@ fn dispatch_shard(
 fn dispatch_unshard(
     input: &std::path::Path,
     output: &std::path::Path,
+    force: bool,
     json: bool,
 ) -> Result<(), CliError> {
+    crate::error::refuse_overwrite(output, force)?;
     match commands::shard::run_unshard(input, output) {
         Ok(report) => {
             if json {

--- a/crates/apr-cli/src/error.rs
+++ b/crates/apr-cli/src/error.rs
@@ -87,6 +87,31 @@ impl From<aprender::error::AprenderError> for CliError {
     }
 }
 
+/// Refuse to clobber an existing output artifact unless `--force` was given.
+///
+/// #2392 (dogfood 0.63.0, finding 4): `apr convert` and `apr quantize` already
+/// refused with exit 5 and "Use --force to overwrite", but `apr export`,
+/// `apr merge`, `apr shard` and `apr unshard` wrote straight over whatever was
+/// at the output path and exited 0 — and none of them even *had* a `--force`
+/// flag, so the guarded behaviour was unreachable. A 9-byte file handed to
+/// `apr export -o precious.safetensors` came back as 9717255 bytes of model with
+/// no warning. Every write-a-file command now routes its overwrite decision
+/// through this one function so the policy cannot drift again.
+///
+/// # Errors
+///
+/// Returns [`CliError::ValidationFailed`] (exit 5) when `path` exists and
+/// `force` is false.
+pub fn refuse_overwrite(path: &std::path::Path, force: bool) -> std::result::Result<(), CliError> {
+    if path.exists() && !force {
+        return Err(CliError::ValidationFailed(format!(
+            "Output file '{}' already exists. Use --force to overwrite.",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
 /// Resolve a model path: if given a directory, look for common model files inside.
 ///
 /// HuggingFace models are stored as directories containing `model.safetensors`,

--- a/crates/apr-cli/src/extended_commands.rs
+++ b/crates/apr-cli/src/extended_commands.rs
@@ -1093,6 +1093,9 @@ pub enum ExtendedCommands {
         /// Output directory for shards + model.safetensors.index.json
         #[arg(short, long, value_name = "DIR")]
         output: PathBuf,
+        /// #2392: Overwrite an existing shard set in the output directory
+        #[arg(short, long)]
+        force: bool,
     },
     /// Reconstruct a single safetensors file from a sharded directory (CRUX-B-05)
     Unshard {
@@ -1102,6 +1105,9 @@ pub enum ExtendedCommands {
         /// Output single-file safetensors path
         #[arg(short, long, value_name = "FILE")]
         output: PathBuf,
+        /// #2392: Overwrite an existing output file (refused without it)
+        #[arg(short, long)]
+        force: bool,
     },
     /// Publishing, conversion, and analysis tools
     #[command(flatten)]

--- a/crates/apr-cli/src/lib_07.rs
+++ b/crates/apr-cli/src/lib_07.rs
@@ -18,4 +18,5 @@ include!("lib_execute_export_convert.rs");
 include!("lib_verbose_inheritance_parse.rs");
 include!("lib_parse_serve.rs");
 include!("lib_dispatch_coverage.rs");
+include!("lib_dogfood_2392.rs");
 }

--- a/crates/apr-cli/src/lib_dispatch_coverage.rs
+++ b/crates/apr-cli/src/lib_dispatch_coverage.rs
@@ -87,7 +87,8 @@
             density: 0.2,
             seed: 42,
             plan: false,
-        });
+                force: true,
+            });
         let result = dispatch_model_commands(&cli);
         assert!(result.is_some(), "Merge should be handled by dispatch_model_commands");
         // merge with nonexistent files should error
@@ -109,7 +110,8 @@
             density: 0.2,
             seed: 42,
             plan: true,
-        });
+                force: true,
+            });
         let result = dispatch_model_commands(&cli);
         assert!(result.is_some(), "Merge plan should be handled by dispatch_model_commands");
     }
@@ -541,7 +543,8 @@
             batch: None,
             json: false,
             plan: false,
-        });
+                force: true,
+            });
         let result = dispatch_inspection_commands(&cli);
         assert!(result.is_none(), "Export should NOT be handled by inspection dispatcher");
     }
@@ -660,7 +663,8 @@
             batch: None,
             json: false,
             plan: false,
-        });
+                force: true,
+            });
         let result = dispatch_format_commands(&cli);
         assert!(result.is_some(), "Export should be handled by format dispatcher");
     }

--- a/crates/apr-cli/src/lib_dogfood_2392.rs
+++ b/crates/apr-cli/src/lib_dogfood_2392.rs
@@ -1,0 +1,217 @@
+
+    // ════════════════════════════════════════════════════════════════════
+    // #2392 finding 4 — export / merge / shard / unshard silently destroyed
+    // pre-existing output artifacts and had no --force flag at all, while
+    // convert and quantize in the same CLI refused the identical situation
+    // with exit 5 and "Use --force to overwrite".
+    // ════════════════════════════════════════════════════════════════════
+
+    /// Is this the overwrite refusal (as opposed to some later failure)?
+    fn is_overwrite_refusal(e: &CliError) -> bool {
+        matches!(e, CliError::ValidationFailed(m) if m.contains("already exists")
+            && m.contains("--force"))
+    }
+
+    fn scratch(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("apr-2392-f4-{tag}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("mkdir scratch");
+        dir
+    }
+
+    /// `apr export -o precious.safetensors` overwrote a 9-byte file with
+    /// 9717255 bytes of model and exited 0, with no way to opt out.
+    #[test]
+    fn export_refuses_to_clobber_an_existing_output() {
+        let dir = scratch("export");
+        let input = dir.join("in.apr");
+        std::fs::write(&input, b"APR\0not-a-real-model").expect("write input");
+        let out = dir.join("precious.safetensors");
+        std::fs::write(&out, b"PRECIOUS\n").expect("write precious");
+
+        let err = commands::export::run(
+            Some(&input),
+            "safetensors",
+            Some(&out),
+            None,
+            false,
+            None,
+            true,
+            false,
+            false, // force
+        )
+        .expect_err("#2392 finding 4: export must refuse to clobber");
+        assert!(
+            is_overwrite_refusal(&err),
+            "#2392 finding 4: expected the overwrite refusal, got: {err}"
+        );
+        assert_eq!(
+            std::fs::read(&out).expect("precious still readable"),
+            b"PRECIOUS\n",
+            "#2392 finding 4: the pre-existing file must be untouched"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// …and `--force` must still let the user through. (A guard with no escape
+    /// hatch is a different defect.) The export then fails for its own reasons
+    /// — the input is deliberately not a real model — but it must not be the
+    /// overwrite refusal.
+    #[test]
+    fn export_force_bypasses_the_overwrite_guard() {
+        let dir = scratch("export-force");
+        let input = dir.join("in.apr");
+        std::fs::write(&input, b"APR\0not-a-real-model").expect("write input");
+        let out = dir.join("existing.safetensors");
+        std::fs::write(&out, b"OLD\n").expect("write existing");
+
+        let result = commands::export::run(
+            Some(&input),
+            "safetensors",
+            Some(&out),
+            None,
+            false,
+            None,
+            true,
+            false,
+            true, // force
+        );
+        if let Err(ref e) = result {
+            assert!(
+                !is_overwrite_refusal(e),
+                "#2392 finding 4: --force must not hit the overwrite guard, got: {e}"
+            );
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// `apr merge a b -o precious2.apr` did the same thing: a 10-byte file came
+    /// back as 9717255 bytes of merged model, rc=0.
+    #[test]
+    fn merge_refuses_to_clobber_an_existing_output() {
+        let dir = scratch("merge");
+        let a = dir.join("a.apr");
+        let b = dir.join("b.apr");
+        std::fs::write(&a, b"APR\0a").expect("write a");
+        std::fs::write(&b, b"APR\0b").expect("write b");
+        let out = dir.join("precious2.apr");
+        std::fs::write(&out, b"PRECIOUS2\n").expect("write precious");
+
+        let err = commands::merge::run(
+            &[a, b],
+            "average",
+            Some(&out),
+            None,
+            None,
+            0.9,
+            0.2,
+            42,
+            true,
+            false,
+            false, // force
+        )
+        .expect_err("#2392 finding 4: merge must refuse to clobber");
+        assert!(
+            is_overwrite_refusal(&err),
+            "#2392 finding 4: expected the overwrite refusal, got: {err}"
+        );
+        assert_eq!(
+            std::fs::read(&out).expect("precious still readable"),
+            b"PRECIOUS2\n",
+            "#2392 finding 4: the pre-existing file must be untouched"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// `apr shard -o dir/` wrote a second shard set into a directory that
+    /// already held one, replacing the weight-map index that names the shards.
+    /// The index is what identifies a shard set, so that is what we guard.
+    #[test]
+    fn shard_refuses_to_replace_an_existing_shard_set() {
+        let dir = scratch("shard");
+        let input = dir.join("model.safetensors");
+        std::fs::write(&input, b"not-a-real-safetensors").expect("write input");
+        let out_dir = dir.join("shards");
+        std::fs::create_dir_all(&out_dir).expect("mkdir out");
+        let index = out_dir.join("model.safetensors.index.json");
+        std::fs::write(&index, b"{\"existing\":true}").expect("write index");
+
+        let err = dispatch_shard(&input, "1MB", &out_dir, false, false)
+            .expect_err("#2392 finding 4: shard must refuse to replace a shard set");
+        assert!(
+            is_overwrite_refusal(&err),
+            "#2392 finding 4: expected the overwrite refusal, got: {err}"
+        );
+        assert_eq!(
+            std::fs::read(&index).expect("index still readable"),
+            b"{\"existing\":true}",
+            "#2392 finding 4: the pre-existing index must be untouched"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Sharding into a fresh directory must NOT be blocked — the guard is about
+    /// destroying an existing shard set, not about the directory existing.
+    #[test]
+    fn shard_into_a_directory_without_an_index_is_not_blocked() {
+        let dir = scratch("shard-clean");
+        let input = dir.join("model.safetensors");
+        std::fs::write(&input, b"not-a-real-safetensors").expect("write input");
+        let out_dir = dir.join("shards");
+        std::fs::create_dir_all(&out_dir).expect("mkdir out");
+        std::fs::write(out_dir.join("unrelated.txt"), b"keep me").expect("write unrelated");
+
+        let result = dispatch_shard(&input, "1MB", &out_dir, false, false);
+        if let Err(ref e) = result {
+            assert!(
+                !is_overwrite_refusal(e),
+                "#2392 finding 4: a directory with no shard index must not trip the guard, \
+                 got: {e}"
+            );
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// `apr unshard -o merged.safetensors` writes a single file and clobbered it
+    /// the same way. Leaving one command in the family unguarded would make the
+    /// "consistent overwrite policy" claim false.
+    #[test]
+    fn unshard_refuses_to_clobber_an_existing_output() {
+        let dir = scratch("unshard");
+        let in_dir = dir.join("shards");
+        std::fs::create_dir_all(&in_dir).expect("mkdir in");
+        let out = dir.join("merged.safetensors");
+        std::fs::write(&out, b"PRECIOUS3\n").expect("write precious");
+
+        let err = dispatch_unshard(&in_dir, &out, false, false)
+            .expect_err("#2392 finding 4: unshard must refuse to clobber");
+        assert!(
+            is_overwrite_refusal(&err),
+            "#2392 finding 4: expected the overwrite refusal, got: {err}"
+        );
+        assert_eq!(
+            std::fs::read(&out).expect("precious still readable"),
+            b"PRECIOUS3\n",
+            "#2392 finding 4: the pre-existing file must be untouched"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The shared helper itself: absent output is always allowed, present
+    /// output is refused unless forced. This is the single decision point every
+    /// write-a-file command now routes through.
+    #[test]
+    fn refuse_overwrite_decision_table() {
+        let dir = scratch("helper");
+        let missing = dir.join("missing.apr");
+        let present = dir.join("present.apr");
+        std::fs::write(&present, b"x").expect("write present");
+
+        assert!(crate::error::refuse_overwrite(&missing, false).is_ok());
+        assert!(crate::error::refuse_overwrite(&missing, true).is_ok());
+        assert!(crate::error::refuse_overwrite(&present, true).is_ok());
+        let err = crate::error::refuse_overwrite(&present, false)
+            .expect_err("existing output without --force must be refused");
+        assert!(is_overwrite_refusal(&err), "got: {err}");
+        let _ = std::fs::remove_dir_all(&dir);
+    }

--- a/crates/apr-cli/src/lib_execute_export_convert.rs
+++ b/crates/apr-cli/src/lib_execute_export_convert.rs
@@ -11,7 +11,8 @@
             batch: None,
             json: false,
             plan: false,
-        });
+                force: true,
+            });
         let result = execute_command(&cli);
         assert!(result.is_err(), "Export should fail with non-existent file");
     }

--- a/crates/apr-cli/src/lib_parse_rosetta.rs
+++ b/crates/apr-cli/src/lib_parse_rosetta.rs
@@ -344,7 +344,8 @@
             density: 0.2,
             seed: 42,
             plan: false,
-        };
+                force: true,
+            };
         let paths = extract_model_paths(&cmd);
         assert_eq!(paths.len(), 3);
     }

--- a/crates/apr-cli/src/lib_parse_rosetta_02.rs
+++ b/crates/apr-cli/src/lib_parse_rosetta_02.rs
@@ -149,7 +149,8 @@
             batch: None,
             json: false,
             plan: false,
-        };
+                force: true,
+            };
         let paths = extract_model_paths(&cmd);
         assert_eq!(paths, vec![PathBuf::from("model.apr")]);
     }

--- a/crates/apr-cli/src/output.rs
+++ b/crates/apr-cli/src/output.rs
@@ -273,6 +273,23 @@ pub(crate) fn table(headers: &[&str], rows: &[Vec<String>]) -> String {
 }
 
 /// Render a key-value table (two columns: Key, Value)
+///
+/// #2392 (dogfood 0.63.0, finding 5): a key-value table has **no header row** —
+/// every record is a data pair. `tabled`'s `Style::rounded()` draws a horizontal
+/// rule after record 0 (its header separator) and a bottom border only once at
+/// least one record follows it. With a single pair — `apr convert … --quantize
+/// int8` prints exactly one config pair — the table rendered as
+///
+/// ```text
+/// ╭──────────────┬──────╮
+/// │ Quantization │ Int8 │
+/// ├──────────────┼──────┤        <- header separator, then nothing
+/// ```
+///
+/// an unterminated box, on every single-pair call site in the CLI. Multi-pair
+/// tables only looked right by accident: the first pair was being drawn as a
+/// header it never was. `remove_horizontals()` drops the header rule, so the box
+/// closes for one pair and reads as a uniform key/value list for many.
 pub(crate) fn kv_table(pairs: &[(&str, String)]) -> String {
     if pairs.is_empty() {
         return String::new();
@@ -282,7 +299,7 @@ pub(crate) fn kv_table(pairs: &[(&str, String)]) -> String {
         builder.push_record([*key, value.as_str()]);
     }
     let mut tbl = builder.build();
-    tbl.with(Style::rounded())
+    tbl.with(Style::rounded().remove_horizontals())
         .with(Modify::new(Columns::first()).with(Alignment::right()));
     tbl.to_string()
 }

--- a/crates/apr-cli/src/output_tests.rs
+++ b/crates/apr-cli/src/output_tests.rs
@@ -418,3 +418,86 @@ fn test_pipeline_stage_all_statuses() {
     pipeline_stage("Export", StageStatus::Failed);
     pipeline_stage("Optional", StageStatus::Skipped);
 }
+
+// ==================== #2392 finding 5: unterminated single-row kv_table ======
+
+/// Does the rendered table close with a bottom border?
+fn closes_the_box(rendered: &str) -> bool {
+    rendered
+        .lines()
+        .last()
+        .is_some_and(|last| last.starts_with('╰') && last.ends_with('╯'))
+}
+
+/// #2392 finding 5: `apr convert model.safetensors --quantize int8` prints a
+/// single-pair config table, and it rendered as
+///
+/// ```text
+/// ╭──────────────┬──────╮
+/// │ Quantization │ Int8 │
+/// ├──────────────┼──────┤
+/// ```
+///
+/// — top border, one row, a header separator, then nothing. The box never
+/// closed. It reproduced for all four quantization schemes and at every
+/// single-pair `kv_table` call site in the CLI; adding `--compress` gave a
+/// second row and the box closed, which is what identified row count (not
+/// content) as the discriminator.
+#[test]
+fn kv_table_single_pair_closes_its_box() {
+    let rendered = kv_table(&[("Quantization", "Int8".to_string())]);
+    assert!(
+        closes_the_box(&rendered),
+        "#2392 finding 5: a one-pair kv_table must terminate with ╰───┴───╯.\nGot:\n{rendered}"
+    );
+}
+
+/// The same must hold at every row count — the shipped behaviour was correct
+/// for 2+ pairs only by accident of the first pair being drawn as a header.
+#[test]
+fn kv_table_closes_its_box_at_every_row_count() {
+    let all: Vec<(&str, String)> = vec![
+        ("Input", "model.safetensors".to_string()),
+        ("Output", "model.apr".to_string()),
+        ("Quantization", "Int8".to_string()),
+        ("Compression", "ZstdDefault".to_string()),
+    ];
+    for n in 1..=all.len() {
+        let rendered = kv_table(&all[..n]);
+        assert!(
+            closes_the_box(&rendered),
+            "#2392 finding 5: kv_table with {n} pair(s) left the box open.\nGot:\n{rendered}"
+        );
+    }
+}
+
+/// A key-value table has no header, so it must not draw a header separator that
+/// implies the first pair is one. This is the specific rule the fix installs;
+/// without it the single-pair case cannot close.
+#[test]
+fn kv_table_draws_no_header_separator() {
+    let rendered = kv_table(&[
+        ("Quantization", "None (copy)".to_string()),
+        ("Compression", "ZstdDefault".to_string()),
+    ]);
+    assert!(
+        !rendered.contains('├'),
+        "#2392 finding 5: kv_table pairs are all data — none is a header.\nGot:\n{rendered}"
+    );
+}
+
+/// Guard the honest negative: `table()` DOES have a real header row and must
+/// keep its separator. A blanket `remove_horizontals()` would break it.
+#[test]
+fn table_with_real_headers_keeps_its_header_separator() {
+    let rows = vec![vec!["a".to_string(), "b".to_string()]];
+    let rendered = table(&["Col1", "Col2"], &rows);
+    assert!(
+        rendered.contains('├'),
+        "a headed table must still separate its header from the body.\nGot:\n{rendered}"
+    );
+    assert!(
+        closes_the_box(&rendered),
+        "and must still close.\nGot:\n{rendered}"
+    );
+}

--- a/crates/aprender-core/src/format/converter/apr_export_fn.rs
+++ b/crates/aprender-core/src/format/converter/apr_export_fn.rs
@@ -44,7 +44,24 @@ pub fn apr_export<P: AsRef<Path>>(
     }
 
     let provenance = load_model_tensors_provenance(input_path)?;
-    let original_size = calculate_tensor_size(provenance.as_map());
+    // #2392 (dogfood 0.63.0, finding 2): `original_size` is printed directly
+    // beside `exported_size`, which is an on-disk file size, so it must be one
+    // too. It used to be `calculate_tensor_size()` — the sum of DEQUANTIZED F32
+    // tensor bytes — which is a property of the model's parameter count, not of
+    // the input file: it reported an identical 9714528 for five different input
+    // APRs spanning 1.37 MB to 30.5 MB on disk. A true 30.5 MB -> 9.7 MB shrink
+    // was reported as slight growth, and a real 55 MB -> 90 MB growth was hidden.
+    // The same command's `--plan` mode already reports the file size correctly as
+    // `input_size`, and the raw APR->GGUF passthrough path
+    // (`export_apr_to_gguf_raw`) already uses the file size, so this also makes
+    // the two export paths agree.
+    let original_size = if input_path.is_dir() {
+        dir_total_size(input_path)
+    } else {
+        fs::metadata(input_path)
+            .map(|m| m.len() as usize)
+            .unwrap_or_else(|_| calculate_tensor_size(provenance.as_map()))
+    };
     let tensors = provenance.into_map();
 
     // PMAT-260: Capture original dtypes from SafeTensors source for round-trip preservation.

--- a/crates/aprender-core/src/format/converter/f16_convert.rs
+++ b/crates/aprender-core/src/format/converter/f16_convert.rs
@@ -200,16 +200,22 @@ fn add_tensor_with_quantization(
 /// Save model tensors with optional compression
 ///
 /// Note: For .apr output, use save_model_tensors_with_config() instead to embed metadata.
+///
+/// `tokenizer` carries the tokenizer that the convert pipeline already located and
+/// parsed for the source model. It MUST be forwarded to the APR writer — an APR
+/// file with no embedded tokenizer is unusable for inference (see
+/// `save_model_tensors_with_config`).
 fn save_model_tensors(
     tensors: &BTreeMap<String, (Vec<f32>, Vec<usize>)>,
     output: &Path,
     compression: Option<Compression>,
     quantize: Option<QuantizationType>,
+    tokenizer: Option<&GgufTokenizer>,
 ) -> Result<()> {
     // GH-165 FIX: If output is .apr, use APR format with embedded config
     let extension = output.extension().and_then(|e| e.to_str()).unwrap_or("");
     if extension == "apr" {
-        return save_model_tensors_with_config(tensors, output, compression, quantize);
+        return save_model_tensors_with_config(tensors, output, compression, quantize, tokenizer);
     }
 
     // PMAT-274 FIX: Apply quantization for SafeTensors output too
@@ -350,11 +356,23 @@ fn f32_slice_to_f16_le_bytes(data: &[f32]) -> Vec<u8> {
 /// Infers model configuration from tensor shapes and embeds it in APR metadata.
 /// This ensures AprTransformer can load with correct dimensions.
 /// If config cannot be inferred (generic tensors), saves with minimal metadata.
+///
+/// #2392 (dogfood 0.63.0, finding 1): this is the fallback save path taken by
+/// `apr convert` / `apr quantize` whenever no sibling `config.json` was found,
+/// i.e. for every scheme except Q4K (which returns early into
+/// `save_model_tensors_q4k`). It used to drop `tokenizer` on the floor: convert
+/// located the tokenizer, parsed all 151665 tokens, printed that it had done so,
+/// then wrote an APR with no `tokenizer.vocabulary` and exited 0 reporting
+/// "Conversion successful". The resulting artifact violated the format contract
+/// the same binary enforces at load time and failed `apr run` with rc=8
+/// ("APR format requires self-contained tokenizer"). The tokenizer is now
+/// embedded here with the identical helper the Q4K and import paths use.
 fn save_model_tensors_with_config(
     tensors: &BTreeMap<String, (Vec<f32>, Vec<usize>)>,
     output: &Path,
     _compression: Option<Compression>,
     quantize: Option<QuantizationType>,
+    tokenizer: Option<&GgufTokenizer>,
 ) -> Result<()> {
     // Try to infer model configuration from tensor shapes
     let config = infer_model_config_from_tensors(tensors);
@@ -371,6 +389,35 @@ fn save_model_tensors_with_config(
         metadata.num_heads = cfg.num_heads;
         metadata.num_kv_heads = cfg.num_kv_heads;
         metadata.intermediate_size = cfg.intermediate_size;
+    }
+
+    // #2392 (finding 1, second half): embedding the tokenizer alone still left
+    // the artifact unrunnable — `apr run` then died with "C-01: APR model
+    // missing 'architecture' metadata — cannot infer model type". This path
+    // never stamped `architecture` at all. The tensor names carry it, and the
+    // import path already reads them with this exact helper, so use it here too.
+    // ("unknown" is what the helper returns for GGUF-style `blk.N` names it
+    // cannot disambiguate — stamping that would be worse than leaving it unset.)
+    if metadata.architecture.is_none() {
+        if let Some(arch) = import::infer_architecture_from_names(tensors) {
+            if arch != "unknown" {
+                metadata.model_type.clone_from(&arch);
+                metadata.architecture = Some(arch);
+            }
+        }
+    }
+
+    // #2392: embed the tokenizer the caller already resolved. Same helper the
+    // Q4K path (`save_model_tensors_q4k`) and the SafeTensors import path use,
+    // so every quantization scheme now produces a self-contained APR.
+    if let Some(tok) = tokenizer {
+        write::insert_f32_tokenizer_metadata(tok, &mut metadata.custom);
+        eprintln!(
+            "[#2392] Embedded tokenizer ({} vocab, {} merges) into APR, architecture={}",
+            tok.vocabulary.len(),
+            tok.merges.len(),
+            metadata.architecture.as_deref().unwrap_or("unset")
+        );
     }
 
     // GH-237: Create writer and add tensors with correct dtype dispatch

--- a/crates/aprender-core/src/format/converter/mod.rs
+++ b/crates/aprender-core/src/format/converter/mod.rs
@@ -296,7 +296,7 @@ fn save_output(
             quantize,
         )
     } else {
-        save_model_tensors(tensors, output_path, compression, quantize)
+        save_model_tensors(tensors, output_path, compression, quantize, gguf_tokenizer)
     }
 }
 

--- a/crates/aprender-core/src/format/converter/source_load_result.rs
+++ b/crates/aprender-core/src/format/converter/source_load_result.rs
@@ -243,16 +243,44 @@ const CONFIG_ALIASES_MAX_POS: &[&str] = &["max_position_embeddings", "n_position
 /// GH-278: LLaMA/Qwen use "rms_norm_eps", GPT-2/BERT use "layer_norm_epsilon".
 const CONFIG_ALIASES_NORM_EPS: &[&str] = &["rms_norm_eps", "layer_norm_epsilon", "layer_norm_eps"];
 
+/// Locate the `config.json` belonging to `model_path`.
+///
+/// #2392 (dogfood 0.63.0, finding 6, second half): this used to accept only a
+/// bare sibling `config.json`. The Pacha cache stores everything for one model
+/// under a shared hash stem — `<hash>.safetensors`, `<hash>.tokenizer.json`,
+/// `<hash>.config.json` — and `tokenizer_loader.rs` in this same binary
+/// explicitly understands that layout ("[BUG-TOK-002] Found tokenizer at Pacha
+/// cache path"). The config loader did not, so `apr convert` on a Pacha model
+/// silently fell back to shape inference and produced an APR with no
+/// `num_heads`/`num_kv_heads`/`rope_theta` — which `apr run` then rejected with
+/// "C-03: APR model missing 'num_heads' metadata" even though every one of those
+/// values was sitting in a file next to the weights.
+fn find_config_json(model_path: &Path) -> Option<PathBuf> {
+    let standard = model_path.with_file_name("config.json");
+    if standard.exists() {
+        return Some(standard);
+    }
+    // Pacha cache layout: `<stem>.config.json`, same stem rule the tokenizer
+    // loader uses (strip trailing extensions like `.converted` from the stem).
+    let stem = model_path.file_stem()?.to_str()?;
+    let base_stem = stem.split('.').next().unwrap_or(stem);
+    let pacha = model_path.with_file_name(format!("{base_stem}.config.json"));
+    if pacha.exists() {
+        eprintln!(
+            "[#2392] Found model config at Pacha cache path: {}",
+            pacha.display()
+        );
+        return Some(pacha);
+    }
+    None
+}
+
 /// Load model config from config.json alongside the model file (PMAT-098)
 ///
 /// This is the preferred way to get model config for SafeTensors models.
 /// Falls back to shape inference if config.json is not found.
 pub(crate) fn load_model_config_from_json(model_path: &Path) -> Option<GgufModelConfig> {
-    // Look for config.json alongside the model file
-    let config_path = model_path.with_file_name("config.json");
-    if !config_path.exists() {
-        return None;
-    }
+    let config_path = find_config_json(model_path)?;
 
     let content = fs::read_to_string(&config_path).ok()?;
     let sanitized = sanitize_hf_json(&content);

--- a/crates/aprender-core/src/format/converter/streaming_quantize.rs
+++ b/crates/aprender-core/src/format/converter/streaming_quantize.rs
@@ -227,3 +227,91 @@ pub fn streaming_quantize_peak_estimate(path: &Path) -> Option<u64> {
         })
         .max()
 }
+
+/// Bytes a single tensor contributes to a Q4K APR, given only its name+shape.
+///
+/// Mirrors the two Q4K write paths exactly — `save_model_tensors_q4k` and
+/// `streaming_quantize_apr_to_q4k` both gate on [`should_quantize_tensor`] and
+/// then emit either `quantize_q4_k_matrix` blocks or a plain F32 tensor.
+///
+/// A Q4K super-block covers 256 elements in 144 bytes, and
+/// `quantize_q4_k_matrix` blocks **per row**, zero-padding each row up to a
+/// whole number of super-blocks. So a `[N, 384]` weight costs
+/// `N * 2 * 144` bytes, not `N * 384 * 4.5 / 8`.
+fn q4k_tensor_bytes(name: &str, shape: &[usize]) -> u64 {
+    const SUPER_BLOCK_SIZE: usize = 256;
+    const SUPER_BLOCK_BYTES: u64 = 144;
+
+    let elements: usize = shape.iter().product();
+    if !should_quantize_tensor(name, shape, elements) {
+        // Not eligible → written verbatim as F32.
+        return (elements as u64).saturating_mul(4);
+    }
+    if shape.len() == 2 {
+        let rows = shape[0] as u64;
+        let super_blocks_per_row = shape[1].div_ceil(SUPER_BLOCK_SIZE) as u64;
+        return rows
+            .saturating_mul(super_blocks_per_row)
+            .saturating_mul(SUPER_BLOCK_BYTES);
+    }
+    // >2D falls through to flat `quantize_q4_k`, which blocks the whole buffer.
+    (elements.div_ceil(SUPER_BLOCK_SIZE) as u64).saturating_mul(SUPER_BLOCK_BYTES)
+}
+
+/// Estimate the Q4K tensor payload `apr quantize -s q4k` would write, by
+/// scanning only the input's tensor index (no tensor data is loaded).
+///
+/// #2392 (dogfood 0.63.0, finding 3): `apr quantize --plan -s q4k` used to apply
+/// a flat "4.5 bits per weight against an assumed-F32 input", producing a
+/// **constant** 7.111x reduction ratio for every model ever passed to it. That
+/// ignores the two things that actually decide a Q4K model's size: which tensors
+/// are eligible at all (embeddings, norms, biases, scales and anything under 256
+/// elements stay F32 — 84.4% of one real model's bytes), and the per-row padding
+/// Q4K applies to rows whose width is not a multiple of 256. On a real 87 MB
+/// model the plan promised 12778677 bytes and quantization produced 55507012 —
+/// 4.34x optimistic. On a small model whose weights Q4K actually *inflates*, the
+/// plan still promised a 7x shrink.
+///
+/// Returns the summed tensor payload, or `None` when the input's tensor index
+/// cannot be read (unknown format) so the caller can fall back to the flat
+/// estimate. This counts tensor bytes only: the container's metadata — notably
+/// an embedded tokenizer vocabulary, which can be megabytes for a 151k-token BPE
+/// model — is not included, so the estimate is a lower bound on the file size.
+pub fn q4k_output_size_estimate(path: &Path) -> Option<u64> {
+    q4k_estimate_from_apr(path).or_else(|| q4k_estimate_from_safetensors(path))
+}
+
+/// Q4K payload estimate for an APR v2 source (both `apr quantize` APR paths).
+fn q4k_estimate_from_apr(path: &Path) -> Option<u64> {
+    use crate::bundle::MappedFile;
+
+    let mapped = MappedFile::open(path).ok()?;
+    let reader = AprV2ReaderRef::from_bytes(mapped.as_slice()).ok()?;
+    let names = reader.tensor_names();
+    if names.is_empty() {
+        return None;
+    }
+    Some(
+        names
+            .iter()
+            .filter_map(|n| reader.get_tensor(n).map(|e| (n, e)))
+            .map(|(n, e)| q4k_tensor_bytes(n, &e.shape))
+            .fold(0u64, u64::saturating_add),
+    )
+}
+
+/// Q4K payload estimate for a SafeTensors source.
+fn q4k_estimate_from_safetensors(path: &Path) -> Option<u64> {
+    let mapped = crate::serialization::safetensors::MappedSafeTensors::open(path).ok()?;
+    let names = mapped.tensor_names();
+    if names.is_empty() {
+        return None;
+    }
+    Some(
+        names
+            .iter()
+            .filter_map(|n| mapped.get_metadata(n).map(|m| (n, m)))
+            .map(|(n, m)| q4k_tensor_bytes(n, &m.shape))
+            .fold(0u64, u64::saturating_add),
+    )
+}

--- a/crates/aprender-core/src/format/converter/tests/dogfood_2392.rs
+++ b/crates/aprender-core/src/format/converter/tests/dogfood_2392.rs
@@ -1,0 +1,539 @@
+//! Falsifiers for #2392 — convert / quantize / export defects found by
+//! dogfooding the crates.io 0.63.0 `apr` binary.
+//!
+//! Every test here asserts BEHAVIOUR that was observably wrong in 0.63.0, not
+//! the shape of a struct. Each one turns RED when its fix is reverted.
+
+#[allow(unused_imports)]
+use super::super::*;
+
+// =============================================================================
+// Finding 1 — convert/quantize discarded the tokenizer for every scheme but Q4K
+// =============================================================================
+#[cfg(test)]
+mod finding_1_tokenizer_survives_every_scheme {
+    use super::*;
+    use crate::format::gguf::GgufTokenizer;
+    use std::collections::BTreeMap;
+
+    fn tiny_tokenizer() -> GgufTokenizer {
+        GgufTokenizer {
+            vocabulary: vec![
+                "<|endoftext|>".to_string(),
+                "hello".to_string(),
+                "world".to_string(),
+            ],
+            merges: vec!["h e".to_string(), "l l".to_string()],
+            model_type: Some("gpt2".to_string()),
+            bos_token_id: Some(0),
+            eos_token_id: Some(0),
+            architecture: Some("qwen2".to_string()),
+            model_name: Some("dogfood-2392".to_string()),
+            ..Default::default()
+        }
+    }
+
+    fn tiny_tensors() -> BTreeMap<String, (Vec<f32>, Vec<usize>)> {
+        let mut tensors: BTreeMap<String, (Vec<f32>, Vec<usize>)> = BTreeMap::new();
+        tensors.insert(
+            "model.embed_tokens.weight".to_string(),
+            (vec![0.25; 8 * 256], vec![8, 256]),
+        );
+        tensors.insert(
+            "model.layers.0.self_attn.q_proj.weight".to_string(),
+            (vec![0.125; 256 * 256], vec![256, 256]),
+        );
+        tensors
+    }
+
+    /// Read back the APR container and report whether it carries a usable
+    /// embedded tokenizer (a non-empty `tokenizer.vocabulary` array).
+    fn embedded_vocab_len(path: &std::path::Path) -> usize {
+        let data = std::fs::read(path).expect("read APR back");
+        let reader = crate::format::v2::AprV2Reader::from_bytes(&data).expect("parse APR v2");
+        reader
+            .metadata()
+            .custom
+            .get("tokenizer.vocabulary")
+            .and_then(|v| v.as_array())
+            .map_or(0, Vec::len)
+    }
+
+    /// #2392 finding 1: the convert/quantize fallback save path located the
+    /// tokenizer, parsed it, printed how many tokens it had read — and then
+    /// wrote an APR with no tokenizer at all, exiting 0 with "Conversion
+    /// successful". `apr run` on the result died with rc=8 and
+    /// "APR format requires self-contained tokenizer", so the command produced
+    /// an artifact violating the format contract the same binary enforces.
+    ///
+    /// The behaviour was systematic in the scheme: Q4K embedded the tokenizer in
+    /// 4/4 outputs, int8/int4/fp16/none in 0/7. So this asserts across schemes.
+    #[test]
+    fn every_quantization_scheme_embeds_the_tokenizer_it_was_given() {
+        let tensors = tiny_tensors();
+        let tok = tiny_tokenizer();
+        let dir = std::env::temp_dir().join(format!("apr-2392-f1-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("mkdir");
+
+        // The four schemes reachable from `apr convert --quantize` / `apr
+        // quantize -s`, plus "no quantization at all" (`--compress zstd`).
+        let schemes: [(&str, Option<QuantizationType>); 5] = [
+            ("none", None),
+            ("int8", Some(QuantizationType::Int8)),
+            ("int4", Some(QuantizationType::Int4)),
+            ("fp16", Some(QuantizationType::Fp16)),
+            ("q4k", Some(QuantizationType::Q4K)),
+        ];
+
+        for (name, quant) in schemes {
+            let path = dir.join(format!("{name}.apr"));
+            save_model_tensors_with_config(&tensors, &path, None, quant, Some(&tok))
+                .unwrap_or_else(|e| panic!("save failed for {name}: {e:?}"));
+
+            let vocab_len = embedded_vocab_len(&path);
+            assert_eq!(
+                vocab_len,
+                tok.vocabulary.len(),
+                "#2392 finding 1: scheme '{name}' produced an APR with {vocab_len} embedded \
+                 vocabulary entries, expected {}. An APR without a tokenizer cannot run \
+                 inference — the loader rejects it with 'APR format requires self-contained \
+                 tokenizer' — so writing one and reporting success is silent data loss.",
+                tok.vocabulary.len()
+            );
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A tokenizer with BPE merges must keep them too: an APR that has the
+    /// vocabulary but not the merge rules still cannot encode a prompt.
+    #[test]
+    fn int8_apr_keeps_bpe_merges_not_just_the_vocabulary() {
+        let tensors = tiny_tensors();
+        let tok = tiny_tokenizer();
+        let dir = std::env::temp_dir().join(format!("apr-2392-f1m-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        let path = dir.join("int8.apr");
+
+        save_model_tensors_with_config(
+            &tensors,
+            &path,
+            None,
+            Some(QuantizationType::Int8),
+            Some(&tok),
+        )
+        .expect("save int8 APR");
+
+        let data = std::fs::read(&path).expect("read APR back");
+        let reader = crate::format::v2::AprV2Reader::from_bytes(&data).expect("parse APR v2");
+        let merges = reader
+            .metadata()
+            .custom
+            .get("tokenizer.merges")
+            .and_then(|v| v.as_array())
+            .map_or(0, Vec::len);
+
+        let _ = std::fs::remove_dir_all(&dir);
+        assert_eq!(
+            merges,
+            tok.merges.len(),
+            "#2392 finding 1: int8 APR embedded {merges} BPE merge rules, expected {}",
+            tok.merges.len()
+        );
+    }
+
+    /// #2392 finding 1, second half: a tokenizer is necessary but not
+    /// sufficient. With the tokenizer embedded, `apr run` got one step further
+    /// and then died with "C-01: APR model missing 'architecture' metadata —
+    /// cannot infer model type", because this save path never stamped it. The
+    /// artifact still could not run, so the command still reported a success
+    /// that was not one.
+    #[test]
+    fn the_saved_apr_declares_its_architecture() {
+        let tensors = tiny_tensors();
+        let tok = tiny_tokenizer();
+        let dir = std::env::temp_dir().join(format!("apr-2392-f1a-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        let path = dir.join("int8.apr");
+
+        save_model_tensors_with_config(
+            &tensors,
+            &path,
+            None,
+            Some(QuantizationType::Int8),
+            Some(&tok),
+        )
+        .expect("save int8 APR");
+
+        let data = std::fs::read(&path).expect("read APR back");
+        let reader = crate::format::v2::AprV2Reader::from_bytes(&data).expect("parse APR v2");
+        let arch = reader.metadata().architecture.clone();
+        let _ = std::fs::remove_dir_all(&dir);
+
+        let arch = arch.expect(
+            "#2392 finding 1: the APR must declare an architecture — without it the loader \
+             refuses with 'C-01: APR model missing architecture metadata'",
+        );
+        assert_ne!(arch, "unknown", "an 'unknown' architecture is not a declaration");
+        // These tensors are `model.layers.N.self_attn.*` with no attention bias
+        // and no QK norm — the inference helper calls that llama.
+        assert_eq!(arch, "llama", "architecture must be inferred from the tensor names");
+    }
+
+    /// Guard the honest negative: when there genuinely is no tokenizer to
+    /// embed, the save must still succeed and simply not invent one. (A fix
+    /// that unconditionally wrote a key would pass the tests above.)
+    #[test]
+    fn no_tokenizer_available_means_no_tokenizer_key() {
+        let tensors = tiny_tensors();
+        let dir = std::env::temp_dir().join(format!("apr-2392-f1n-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        let path = dir.join("no-tok.apr");
+
+        save_model_tensors_with_config(&tensors, &path, None, Some(QuantizationType::Int8), None)
+            .expect("save APR without tokenizer");
+
+        let vocab_len = embedded_vocab_len(&path);
+        let _ = std::fs::remove_dir_all(&dir);
+        assert_eq!(
+            vocab_len, 0,
+            "no tokenizer was supplied, so none may appear in the output"
+        );
+    }
+}
+
+// =============================================================================
+// Finding 3 — `quantize --plan -s q4k` returned a hardcoded 7.111x ratio
+// =============================================================================
+#[cfg(test)]
+mod finding_3_q4k_plan_is_shape_aware {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    /// Build an APR whose tensors are deliberately a mix of Q4K-eligible and
+    /// Q4K-ineligible shapes, mirroring a real model: a big embedding table
+    /// (skipped by name), a norm (skipped by name), a row width that is a clean
+    /// multiple of 256, and a row width that is not (384 — the case that made
+    /// the shipped estimator 4.34x optimistic on a real 87 MB model).
+    fn mixed_model() -> BTreeMap<String, (Vec<f32>, Vec<usize>)> {
+        let mut t: BTreeMap<String, (Vec<f32>, Vec<usize>)> = BTreeMap::new();
+        t.insert(
+            "model.embed_tokens.weight".to_string(),
+            (vec![0.5; 64 * 384], vec![64, 384]),
+        );
+        t.insert(
+            "model.layers.0.input_layernorm.weight".to_string(),
+            (vec![1.0; 384], vec![384]),
+        );
+        t.insert(
+            "model.layers.0.self_attn.q_proj.weight".to_string(),
+            (vec![0.25; 384 * 384], vec![384, 384]),
+        );
+        t.insert(
+            "model.layers.0.mlp.down_proj.weight".to_string(),
+            (vec![0.25; 256 * 512], vec![256, 512]),
+        );
+        t
+    }
+
+    fn write_apr(tensors: &BTreeMap<String, (Vec<f32>, Vec<usize>)>, path: &std::path::Path) {
+        save_model_tensors_with_config(tensors, path, None, None, None).expect("write f32 APR");
+    }
+
+    /// #2392 finding 3: the estimate must track the real Q4K writer, which
+    /// blocks per ROW with 256-element super-blocks (144 bytes each) and leaves
+    /// embeddings/norms/biases/scales as F32. The shipped estimator applied a
+    /// flat 4.5 bits/weight, so it returned the identical 7.111x reduction ratio
+    /// for a 4.8 MB model, an 87 MB model and a 992 MB model alike.
+    #[test]
+    fn q4k_estimate_matches_the_bytes_quantization_actually_writes() {
+        let tensors = mixed_model();
+        let dir = std::env::temp_dir().join(format!("apr-2392-f3-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        let src = dir.join("src.apr");
+        let dst = dir.join("dst-q4k.apr");
+        write_apr(&tensors, &src);
+
+        let estimate = crate::format::q4k_output_size_estimate(&src)
+            .expect("estimator must read an APR tensor index");
+
+        // Now actually quantize and measure the tensor payload that resulted.
+        save_model_tensors_q4k(&tensors, &dst, None).expect("q4k quantize");
+        let actual_payload: u64 = {
+            let data = std::fs::read(&dst).expect("read q4k APR");
+            let reader = crate::format::v2::AprV2Reader::from_bytes(&data).expect("parse q4k APR");
+            reader
+                .tensor_names()
+                .iter()
+                .filter_map(|n| reader.get_tensor(n))
+                .map(|e| e.size as u64)
+                .sum()
+        };
+        let _ = std::fs::remove_dir_all(&dir);
+
+        assert_eq!(
+            estimate, actual_payload,
+            "#2392 finding 3: `--plan -s q4k` estimated {estimate} tensor bytes but Q4K \
+             quantization wrote {actual_payload}. --plan exists to size disk and RAM before a \
+             long run; an estimate that ignores which tensors are eligible and how rows are \
+             padded is worse than none."
+        );
+    }
+
+    /// The old estimator's signature failure was that its answer did not depend
+    /// on the model at all. Two models with the same on-disk size but different
+    /// tensor shapes must get different Q4K estimates.
+    #[test]
+    fn q4k_estimate_is_not_a_constant_ratio() {
+        let dir = std::env::temp_dir().join(format!("apr-2392-f3c-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("mkdir");
+
+        // Same element count (and therefore near-identical F32 file size), but
+        // one is all-embedding (Q4K-ineligible) and one is all-projection.
+        let mut skipped: BTreeMap<String, (Vec<f32>, Vec<usize>)> = BTreeMap::new();
+        skipped.insert(
+            "model.embed_tokens.weight".to_string(),
+            (vec![0.5; 256 * 512], vec![256, 512]),
+        );
+        let mut quantized: BTreeMap<String, (Vec<f32>, Vec<usize>)> = BTreeMap::new();
+        quantized.insert(
+            "model.layers.0.mlp.down_proj.weight".to_string(),
+            (vec![0.5; 256 * 512], vec![256, 512]),
+        );
+
+        let a = dir.join("skipped.apr");
+        let b = dir.join("quantized.apr");
+        write_apr(&skipped, &a);
+        write_apr(&quantized, &b);
+
+        let est_a = crate::format::q4k_output_size_estimate(&a).expect("estimate a");
+        let est_b = crate::format::q4k_output_size_estimate(&b).expect("estimate b");
+        let size_a = std::fs::metadata(&a).expect("stat a").len();
+        let size_b = std::fs::metadata(&b).expect("stat b").len();
+        let _ = std::fs::remove_dir_all(&dir);
+
+        assert!(
+            est_a > est_b,
+            "#2392 finding 3: an all-embedding model stays F32 under Q4K and an all-projection \
+             model shrinks, so their estimates must differ (got {est_a} vs {est_b} for inputs of \
+             {size_a} and {size_b} bytes). The shipped estimator returned the same 7.111x ratio \
+             for every model ever passed to it."
+        );
+        assert_eq!(
+            est_a,
+            256 * 512 * 4,
+            "an ineligible tensor is written verbatim as F32"
+        );
+        assert_eq!(
+            est_b,
+            256 * 2 * 144,
+            "a [256, 512] projection is 2 super-blocks per row at 144 bytes"
+        );
+    }
+
+    /// A path with no readable tensor index must yield `None` so the caller can
+    /// fall back, rather than a confidently wrong zero.
+    #[test]
+    fn unreadable_input_yields_none_not_zero() {
+        let dir = std::env::temp_dir().join(format!("apr-2392-f3n-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        let junk = dir.join("junk.apr");
+        std::fs::write(&junk, b"not a model at all").expect("write junk");
+        let got = crate::format::q4k_output_size_estimate(&junk);
+        let _ = std::fs::remove_dir_all(&dir);
+        assert!(got.is_none(), "unreadable input must not produce a number");
+    }
+}
+
+// =============================================================================
+// Finding 6 — a missing LOCAL path was answered with a Hugging Face Hub hint
+// =============================================================================
+#[cfg(test)]
+mod finding_6_local_path_gets_a_local_remedy {
+    use super::*;
+
+    /// #2392 finding 6: `apr import /nonexistent.safetensors` failed correctly
+    /// (rc=5) but told the user to "verify the model name exists on
+    /// huggingface.co/models" — a remedy that cannot apply to an absolute local
+    /// path. `resolve_local_source` already encodes the distinction by setting
+    /// `status: 0` ("local file, not HTTP"); the message just never read it.
+    #[test]
+    fn local_not_found_does_not_advise_a_hub_lookup() {
+        let err = ImportError::NotFound {
+            resource: "/nonexistent.safetensors".to_string(),
+            status: 0,
+        };
+        let msg = err.to_string();
+        assert!(
+            !msg.contains("huggingface.co"),
+            "#2392 finding 6: a local filesystem path must not be answered with a Hub \
+             lookup hint. Got: {msg}"
+        );
+        assert!(
+            msg.contains("/nonexistent.safetensors"),
+            "the message must name the path that was not found. Got: {msg}"
+        );
+        assert!(
+            msg.contains("File not found"),
+            "the message must say what actually went wrong. Got: {msg}"
+        );
+    }
+
+    /// #2392 finding 6, second half: the Pacha cache stores one model's files
+    /// under a shared hash stem (`<hash>.safetensors`, `<hash>.tokenizer.json`,
+    /// `<hash>.config.json`). The tokenizer loader understands that layout and
+    /// says so on stderr; the CONFIG loader did not, so `apr convert` on a Pacha
+    /// model silently fell back to shape inference and emitted an APR with no
+    /// `num_heads` — which `apr run` rejects with "C-03: APR model missing
+    /// 'num_heads' metadata", with the real value sitting in a file beside the
+    /// weights the whole time.
+    #[test]
+    fn pacha_cache_config_json_is_found() {
+        let dir = std::env::temp_dir().join(format!("apr-2392-f6p-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        let model = dir.join("064a3693fa1ea02c.safetensors");
+        std::fs::write(&model, b"placeholder").expect("write model");
+        std::fs::write(
+            dir.join("064a3693fa1ea02c.config.json"),
+            br#"{"model_type":"qwen2","hidden_size":8,"num_hidden_layers":2,
+                 "num_attention_heads":4,"num_key_value_heads":2,
+                 "intermediate_size":32,"vocab_size":151665,"rope_theta":10000.0}"#,
+        )
+        .expect("write pacha config");
+
+        let cfg = crate::format::converter::import::load_model_config_from_json(&model);
+        let _ = std::fs::remove_dir_all(&dir);
+
+        let cfg = cfg.expect(
+            "#2392 finding 6: the Pacha `<hash>.config.json` layout must be recognised — the \
+             tokenizer loader in the same binary already does",
+        );
+        assert_eq!(cfg.num_heads, Some(4), "num_heads must come from config.json");
+        assert_eq!(cfg.num_kv_heads, Some(2), "num_kv_heads must come from config.json");
+        assert_eq!(cfg.hidden_size, Some(8));
+        assert_eq!(cfg.architecture.as_deref(), Some("qwen2"));
+    }
+
+    /// A bare sibling `config.json` must keep working, and a model with neither
+    /// layout must still yield `None` rather than a fabricated config.
+    #[test]
+    fn standard_layout_still_works_and_absence_is_still_none() {
+        let dir = std::env::temp_dir().join(format!("apr-2392-f6s-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        let model = dir.join("model.safetensors");
+        std::fs::write(&model, b"placeholder").expect("write model");
+
+        assert!(
+            crate::format::converter::import::load_model_config_from_json(&model).is_none(),
+            "no config.json anywhere means no config"
+        );
+
+        std::fs::write(
+            dir.join("config.json"),
+            br#"{"model_type":"llama","hidden_size":16,"num_attention_heads":8}"#,
+        )
+        .expect("write standard config");
+        let cfg = crate::format::converter::import::load_model_config_from_json(&model);
+        let _ = std::fs::remove_dir_all(&dir);
+        assert_eq!(
+            cfg.and_then(|c| c.num_heads),
+            Some(8),
+            "the standard HuggingFace layout must keep working"
+        );
+    }
+
+    /// The Hub hint is still right for a real Hub 404 — the fix must not have
+    /// deleted it, only stopped applying it to local paths.
+    #[test]
+    fn hub_404_still_advises_a_hub_lookup() {
+        let err = ImportError::NotFound {
+            resource: "openai/no-such-model".to_string(),
+            status: 404,
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("huggingface.co/models"),
+            "a genuine Hub 404 must keep its Hub remedy. Got: {msg}"
+        );
+        assert!(msg.contains("404"), "the status belongs in the message: {msg}");
+    }
+}
+
+// =============================================================================
+// Finding 2 — `apr export` reported the dequantized tensor total as
+//             `original_size`, a number independent of the input file
+// =============================================================================
+#[cfg(test)]
+mod finding_2_export_original_size_is_a_file_size {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    /// #2392 finding 2: `original_size` is printed directly beside
+    /// `exported_size`, which is a real on-disk size, so the two must be
+    /// comparable. As shipped, `original_size` was the sum of dequantized F32
+    /// tensor bytes: it read an identical 9714528 for five different input APRs
+    /// spanning 1.37 MB to 30.5 MB on disk, turning a true 3x shrink into a
+    /// reported slight growth.
+    #[test]
+    fn export_reports_the_input_files_on_disk_size() {
+        let dir = std::env::temp_dir().join(format!("apr-2392-f2-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("mkdir");
+
+        let mut tensors: BTreeMap<String, (Vec<f32>, Vec<usize>)> = BTreeMap::new();
+        tensors.insert(
+            "model.layers.0.mlp.down_proj.weight".to_string(),
+            (vec![0.5; 256 * 512], vec![256, 512]),
+        );
+
+        // Two inputs holding the SAME tensors, so the F32 tensor total is
+        // identical, but stored at different precisions so the FILES differ.
+        let f32_src = dir.join("f32.apr");
+        let fp16_src = dir.join("fp16.apr");
+        save_model_tensors_with_config(&tensors, &f32_src, None, None, None).expect("write f32");
+        save_model_tensors_with_config(
+            &tensors,
+            &fp16_src,
+            None,
+            Some(QuantizationType::Fp16),
+            None,
+        )
+        .expect("write fp16");
+
+        let f32_bytes = std::fs::metadata(&f32_src).expect("stat f32").len() as usize;
+        let fp16_bytes = std::fs::metadata(&fp16_src).expect("stat fp16").len() as usize;
+        assert!(
+            f32_bytes > fp16_bytes,
+            "precondition: the fp16 APR must actually be the smaller file \
+             ({f32_bytes} vs {fp16_bytes})"
+        );
+
+        let opts = || ExportOptions {
+            format: ExportFormat::SafeTensors,
+            skip_completeness_check: true,
+            ..Default::default()
+        };
+        let r_f32 = apr_export(f32_src.as_path(), dir.join("a.safetensors").as_path(), opts())
+            .expect("export f32 source");
+        let r_fp16 = apr_export(
+            fp16_src.as_path(),
+            dir.join("b.safetensors").as_path(),
+            opts(),
+        )
+        .expect("export fp16 source");
+        let _ = std::fs::remove_dir_all(&dir);
+
+        assert_eq!(
+            r_f32.original_size, f32_bytes,
+            "#2392 finding 2: original_size must be the input file's on-disk size"
+        );
+        assert_eq!(
+            r_fp16.original_size, fp16_bytes,
+            "#2392 finding 2: original_size must be the input file's on-disk size"
+        );
+        assert_ne!(
+            r_f32.original_size, r_fp16.original_size,
+            "#2392 finding 2: two inputs of different on-disk size reported the SAME \
+             original_size — that is the defect: it was the dequantized tensor total, a \
+             property of the parameter count, not of the file."
+        );
+    }
+}

--- a/crates/aprender-core/src/format/converter/tests/mod.rs
+++ b/crates/aprender-core/src/format/converter/tests/mod.rs
@@ -26,3 +26,6 @@ mod pure_functions;
 mod sharded_import;
 mod tokenizer_parse;
 mod coverage_gap_quantized_save;
+/// #2392 — falsifiers for the convert/quantize/export defects found by
+/// dogfooding the crates.io 0.63.0 binary.
+mod dogfood_2392;

--- a/crates/aprender-core/src/format/converter/tests/pmat.rs
+++ b/crates/aprender-core/src/format/converter/tests/pmat.rs
@@ -269,7 +269,7 @@ mod tests_gh165_apr_config_metadata {
         let apr_path = temp_dir.join("test_gh165.apr");
 
         // Use the save function that should embed config
-        let result = save_model_tensors_with_config(&tensors, &apr_path, None, None);
+        let result = save_model_tensors_with_config(&tensors, &apr_path, None, None, None);
         assert!(result.is_ok(), "Failed to save APR: {:?}", result);
 
         // Verify file exists

--- a/crates/aprender-core/src/format/converter/tokenizer_loader.rs
+++ b/crates/aprender-core/src/format/converter/tokenizer_loader.rs
@@ -399,7 +399,7 @@ fn infer_intermediate_size_from_tensors(
 /// LLaMA, Mistral, Phi all use `model.layers`. Now uses Qwen2-specific signals:
 /// - Qwen2 has attention bias (`self_attn.q_proj.bias`) — LLaMA/Mistral do not.
 /// - Qwen2 sometimes has fused `qkv_proj.weight`.
-fn infer_architecture_from_names(
+pub(super) fn infer_architecture_from_names(
     tensors: &BTreeMap<String, (Vec<f32>, Vec<usize>)>,
 ) -> Option<String> {
     let has_model_layers = tensors.keys().any(|k| k.contains("model.layers"));

--- a/crates/aprender-core/src/format/converter_types_expectations.rs
+++ b/crates/aprender-core/src/format/converter_types_expectations.rs
@@ -349,6 +349,22 @@ impl std::fmt::Display for ImportError {
                 write!(f, "Missing required tensor: {name}")
             }
             // GH-129: Actionable error messages
+            //
+            // #2392 (dogfood 0.63.0, finding 6): `status` is the HTTP status of a
+            // Hub lookup, and `resolve_local_source` sets it to 0 to mean "this
+            // was a filesystem path, no request was made". That distinction was
+            // never read, so `apr import /nonexistent.safetensors` advised the
+            // user to "verify the model name exists on huggingface.co/models" —
+            // a remedy that cannot apply to an absolute local path. The sibling
+            // commands (`apr convert`, `apr export`) already say "File not found"
+            // for the same input.
+            Self::NotFound { resource, status } if *status == 0 => {
+                write!(
+                    f,
+                    "File not found: {resource}. \
+                     Fix: check the path, or use hf://org/repo to import from the Hub"
+                )
+            }
             Self::NotFound { resource, status } => {
                 write!(
                     f,

--- a/crates/aprender-core/src/format/mod.rs
+++ b/crates/aprender-core/src/format/mod.rs
@@ -258,10 +258,11 @@ pub use validation::{fail_no_validation_rules, Gate, PokaYoke, PokaYokeResult};
 
 // Re-export converter types (spec §13 - Import/Convert Pipeline)
 pub use converter::{
-    apr_convert, apr_export, apr_import, apr_merge, streaming_quantize_peak_estimate, AprConverter,
-    Architecture, ConvertOptions, ConvertReport, EvolutionaryMergeConfig, EvolutionaryMergeResult,
-    ExportFormat, ExportOptions, ExportReport, ImportError, ImportOptions, MergeOptions,
-    MergeReport, MergeStrategy, QuantizationType, Source, TensorExpectation, ValidationConfig,
+    apr_convert, apr_export, apr_import, apr_merge, q4k_output_size_estimate,
+    streaming_quantize_peak_estimate, AprConverter, Architecture, ConvertOptions, ConvertReport,
+    EvolutionaryMergeConfig, EvolutionaryMergeResult, ExportFormat, ExportOptions, ExportReport,
+    ImportError, ImportOptions, MergeOptions, MergeReport, MergeStrategy, QuantizationType, Source,
+    TensorExpectation, ValidationConfig,
 };
 
 // Re-export lint types (spec §4.11 - Best Practices & Conventions)


### PR DESCRIPTION
`apr convert model.safetensors -o out.apr --quantize int8` located the sibling tokenizer, parsed all 151665 tokens, printed that it had done so, then wrote an APR with no tokenizer in it and reported "Conversion successful" with exit 0. `apr run out.apr` then died with rc=8 and "APR format requires self-contained tokenizer" — the command produced an artifact that violates the format contract the same binary enforces at load time. It was systematic in the quantization scheme, not the model: q4k embedded the tokenizer in 4/4 outputs, int8/int4/fp16/no-quant in 0/7, on the same input file.

Root cause is `save_model_tensors_with_config` in `crates/aprender-core/src/format/converter/f16_convert.rs:370` — the fallback save path taken whenever no sibling `config.json` is found, i.e. every scheme except q4k, which returns early into `save_model_tensors_q4k`. It took no `tokenizer` argument at all, so `save_output` had nowhere to pass the one it had resolved.

Embedding the tokenizer got `apr run` one step further and it then failed on `C-01: APR model missing 'architecture' metadata`, and after that on `C-03: APR model missing 'num_heads' metadata`. Both are on the same path and both are the same class of defect, so both are fixed here. The save path now stamps the architecture it can already infer from the tensor names (the import path uses that exact helper), and `load_model_config_from_json` now understands the Pacha cache's `<hash>.config.json` layout — the layout `tokenizer_loader.rs` in the same binary has understood all along, announcing it on stderr as `[BUG-TOK-002] Found tokenizer at Pacha cache path`. Every value `apr run` demanded (`num_attention_heads: 4`, `num_key_value_heads: 2`, `rope_theta`, `rms_norm_eps`) was sitting in a file next to the weights the whole time. That inconsistency is recorded in the issue as the second half of finding 6.

Measured on `/home/noah/.cache/pacha/models/064a3693fa1ea02c.safetensors` with a release binary built from this tree:

```
before  apr convert … --quantize int8   exit 0, "Conversion successful"
        apr run out.apr --prompt Hi     rc=8
        [PMAT-172] ERROR: APR file missing embedded tokenizer.

after   apr convert … --quantize int8   exit 0
        [#2392] Found model config at Pacha cache path: …064a…config.json
        [PMAT-113] Embedding 151665 vocabulary tokens into APR metadata
        [PMAT-171] Embedding 151387 BPE merge rules into APR metadata
        apr run out.apr --prompt Hi     rc=0, generation completes
```

`apr import` on the same Pacha model now also succeeds without `--allow-no-config` (rc=0), which it previously required.

## The other six

**`apr export` reported `original_size` as a tensor total, not a file size.** It sat directly beside `exported_size`, a real on-disk size, but was the sum of dequantized F32 tensor bytes — an identical 9714528 for five input APRs spanning 1.37 MB to 30.5 MB. A true 3x shrink read as slight growth. Now the input file's size, which the same command's `--plan` mode already reported correctly as `input_size` and which the raw APR→GGUF passthrough path already used.

```
before  stat m.apr → 6241028   export --plan input_size 6241028   export original_size 9714528
after   stat m.apr → 6241028   export --plan input_size 6241028   export original_size 6241028
```

**`apr quantize --plan -s q4k` returned a constant 7.111x ratio for every model ever passed to it.** A flat 4.5 bits/weight against an assumed-F32 input. Q4K skips embeddings, norms, biases, scales and sub-super-block tensors, and pads each row up to a multiple of 256, so the answer depends on the tensor inventory. New `q4k_output_size_estimate` walks the input's tensor index — no tensor data loaded — applying the same `should_quantize_tensor` predicate and the same per-row 144-byte super-block arithmetic both q4k write paths use.

| model | plan before | plan after | actual |
|---|---|---|---|
| 87 MB (`57e6e922…`) | 12778677 (7.109x) | 55207716 (1.646x) | 55507012 (1.637x) |
| 4.8 MB (`064a3693…`) | 683445 (7.111x) | 26715600 (0.182x) | 30522180 (0.159x) |

The residual on the small model is the embedded tokenizer metadata — 151665 vocabulary strings plus 151387 merge rules — which is container metadata, not tensor payload. The doc comment states the estimate is a lower bound on file size for that reason. int8/int4/fp16 keep the flat model: measured against real conversions they are accurate (4.0 vs 3.98, 8.0 vs 7.05, 2.0 vs 2.0), so this change is q4k-only and there is a test asserting the other three are untouched.

**`export`, `merge`, `shard` and `unshard` silently destroyed pre-existing output and had no `--force` flag at all**, while `convert` and `quantize` in the same CLI refused the identical situation with exit 5. A 9-byte file handed to `apr export -o precious.safetensors` came back as 9717255 bytes of model, rc=0. All four now take `--force` and route their decision through one `refuse_overwrite` helper that convert and quantize also use, so the policy cannot drift again. `shard` guards on the weight-map index — the artifact that identifies a shard set — not on the directory existing, so sharding into a fresh or unrelated directory is unaffected.

```
before  apr export m.apr -o precious.safetensors     rc=0, 9 bytes → 9717255
after   apr export m.apr -o precious.safetensors     rc=5, file still 9 bytes
        apr export m.apr -o precious.safetensors -f  rc=0, 9717255
        apr shard … -o shards/  (second time)        rc=5 on model.safetensors.index.json
        apr shard … -o shards/ --force               rc=0
```

**A single-pair `kv_table` never closed its box.** `apr convert … --quantize int8` prints exactly one config pair:

```
before                          after
╭──────────────┬──────╮         ╭──────────────┬──────╮
│ Quantization │ Int8 │         │ Quantization │ Int8 │
├──────────────┼──────┤         ╰──────────────┴──────╯
```

tabled promotes record 0 to a header and only draws the bottom border once a body row follows. A key-value table has no header, so multi-pair tables were only correct by accident — the first pair was being drawn as a header it never was. Dropping the header rule fixes every single-pair call site in the CLI. `table()`, which does have real headers, keeps its separator and has a test saying so.

**`apr import /nonexistent.safetensors` advised a Hugging Face Hub lookup.** It failed correctly (rc=5) and then said "verify the model name exists on huggingface.co/models" — a remedy that cannot apply to an absolute local path, and one the sibling commands do not give. `resolve_local_source` already encodes the distinction as `status: 0` ("local file, not HTTP"); the message never read it.

```
before  error: … Resource not found (0): /nonexistent.safetensors. Fix: verify the model name exists on huggingface.co/models
after   error: … File not found: /nonexistent.safetensors. Fix: check the path, or use hf://org/repo to import from the Hub
```

**`apr shard --max-shard-size abc` quoted an empty string.** The user typed `abc`; the message blamed an emptiness that is an artifact of our own unit-suffix split (`abc` → unit `abc`, number ``).

```
before  invalid --max-shard-size: invalid number '': cannot parse float from empty string
after   invalid --max-shard-size: 'abc' has no numeric part (expected a number with an optional unit, e.g. '500MB')
```

The already-correct messages (`'5XB'` → "unknown size unit 'XB'", `'0'` → "must be positive") are preserved, with a test.

## Falsifiers and mutation check

29 tests across five files. Several guard the honest negative: no tokenizer supplied still means no tokenizer key; a real Hub 404 keeps its Hub remedy; a headed `table()` keeps its header separator; `--force` still gets through; sharding into a directory with no index is not blocked; the bare `config.json` layout still works and a model with neither layout still yields `None`.

Each fix was reverted in place with its tests kept. Every falsifier went RED:

```
finding 1  assertion `left == right` failed: scheme 'none' produced an APR with 0
           embedded vocabulary entries, expected 3
           left: 0  right: 3

finding 1  #2392 finding 1: the APR must declare an architecture — without it the
           loader refuses with 'C-01: APR model missing architecture metadata'
           [#2392] Embedded tokenizer (3 vocab, 2 merges) into APR, architecture=unset

finding 2  assertion `left == right` failed: original_size must be the input
           file's on-disk size
           left: 524288  right: 524676

finding 3  assertion `left != right` failed: `--plan -s q4k` still returned the
           flat bits-per-weight estimate (73756 bytes, 7.111x)
           left: 73756  right: 73756

finding 4  expected the overwrite refusal, got: Validation failed: Invalid model
           format: Failed to parse APR file: InvalidHeader("file too small")
           (export, merge, shard, unshard)
           existing output without --force must be refused: ()

finding 5  a one-pair kv_table must terminate with ╰───┴───╯.
           Got:
           ╭──────────────┬──────╮
           │ Quantization │ Int8 │
           ├──────────────┼──────┤

finding 6  a local filesystem path must not be answered with a Hub lookup hint.
           Got: Resource not found (0): /nonexistent.safetensors. Fix: verify the
           model name exists on huggingface.co/models

finding 6  the Pacha `<hash>.config.json` layout must be recognised — the
           tokenizer loader in the same binary already does

finding 7  the message must echo the value the user passed. Got: invalid number
           '': cannot parse float from empty string
```

Restored, all green: `aprender-core` 14070 passed / 0 failed, `apr-cli` 6672 passed / 0 failed, `cargo clippy -p aprender-core -p apr-cli --lib -- -D warnings` exit 0, `cargo fmt --all -- --check` clean. Every finding was also re-verified against a release binary built from this tree, not on a unit test alone.

One note on method, since it nearly produced a false result: the shared `CARGO_TARGET_DIR` on this box is written by several worktrees at once, and my first build reused a stale `aprender-core` rlib — the binary did not contain the fix while the source did, and `strings` on the binary is what caught it. All measurements above come from a build into a private target dir.

Fixes #2392
Audit epic: #2373
