### PR TITLE
fix(lint): four *-lint gates passed on evidence they never read, and one printed a number the input did not contain

### DIFF
--- a/crates/apr-cli/src/commands/audio_inspect_classifier.rs
+++ b/crates/apr-cli/src/commands/audio_inspect_classifier.rs
@@ -42,22 +42,50 @@ pub enum AudioBoundsOutcome {
 /// Outcome of `classify_sample_rate`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AudioSampleRateOutcome {
-    Ok { rate: u32 },
+    Ok {
+        rate: u32,
+    },
     MissingSampleRate,
-    SampleRateNotPositive { got: i64 },
-    ExpectedRateMismatch { got: u32, expected: u32 },
-    NonCanonicalRate { got: u32 },
+    SampleRateNotPositive {
+        got: i64,
+    },
+    /// Value does not fit in `u32`. Reported with the ORIGINAL `i64` so the
+    /// report never prints a number the observation did not contain.
+    SampleRateOutOfRange {
+        got: i64,
+    },
+    ExpectedRateMismatch {
+        got: u32,
+        expected: u32,
+    },
+    NonCanonicalRate {
+        got: u32,
+    },
 }
 
 /// Outcome of `classify_channel_shape`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AudioChannelShapeOutcome {
-    Ok { channels: u32, samples: u64 },
+    Ok {
+        channels: u32,
+        samples: u64,
+    },
     MissingChannels,
     MissingSamples,
-    ChannelsNotPositive { got: i64 },
-    SamplesNotPositive { got: i64 },
-    ExpectedChannelsMismatch { got: u32, expected: u32 },
+    ChannelsNotPositive {
+        got: i64,
+    },
+    /// Channel count does not fit in `u32` (reported with the original `i64`).
+    ChannelsOutOfRange {
+        got: i64,
+    },
+    SamplesNotPositive {
+        got: i64,
+    },
+    ExpectedChannelsMismatch {
+        got: u32,
+        expected: u32,
+    },
 }
 
 /// FALSIFY-CRUX-H-13-001: amplitude bounds + finite.
@@ -103,7 +131,12 @@ pub fn classify_sample_rate(body: &Value, expected: Option<u32>) -> AudioSampleR
     if raw <= 0 {
         return AudioSampleRateOutcome::SampleRateNotPositive { got: raw };
     }
-    let rate = raw as u32;
+    // A `raw as u32` here WRAPS: 4_294_983_296 (2^32 + 16000) would alias to
+    // 16000 and PASS the canonical-set check while the report printed a rate
+    // the observation never contained.
+    let Ok(rate) = u32::try_from(raw) else {
+        return AudioSampleRateOutcome::SampleRateOutOfRange { got: raw };
+    };
     if let Some(exp) = expected {
         if rate != exp {
             return AudioSampleRateOutcome::ExpectedRateMismatch {
@@ -136,7 +169,11 @@ pub fn classify_channel_shape(
     if raw_s <= 0 {
         return AudioChannelShapeOutcome::SamplesNotPositive { got: raw_s };
     }
-    let channels = raw_c as u32;
+    // `raw_c as u32` WRAPS: 4_294_967_297 (2^32 + 1) would alias to 1 and the
+    // report would print `channels: 1` for an input that said 4294967297.
+    let Ok(channels) = u32::try_from(raw_c) else {
+        return AudioChannelShapeOutcome::ChannelsOutOfRange { got: raw_c };
+    };
     let samples = raw_s as u64;
     if let Some(exp) = expected_channels {
         if channels != exp {
@@ -306,6 +343,93 @@ mod tests {
             classify_channel_shape(&body, None),
             AudioChannelShapeOutcome::SamplesNotPositive { got: 0 }
         ));
+    }
+
+    // ── wrapping-cast falsifiers (dogfood 0.63.0 #2377 finding 5) ────────
+    //
+    // `raw as u32` silently aliases anything >= 2^32 into the canonical set.
+    // These assert BEHAVIOUR: an out-of-range value must be rejected, and the
+    // reported value must be the one the observation actually contained.
+
+    #[test]
+    fn sample_rate_rejects_value_above_u32_that_aliases_to_16k() {
+        // 2^32 + 16000: `as u32` yields exactly 16000, a canonical rate.
+        let mut body = good_body();
+        body["sample_rate"] = json!(4_294_983_296i64);
+        assert_eq!(
+            classify_sample_rate(&body, None),
+            AudioSampleRateOutcome::SampleRateOutOfRange { got: 4_294_983_296 }
+        );
+    }
+
+    #[test]
+    fn sample_rate_out_of_range_is_not_rescued_by_expected_rate() {
+        // The explicit --expected-sample-rate path must not be fooled either:
+        // wrapped, 4294983296 == 16000 == expected.
+        let mut body = good_body();
+        body["sample_rate"] = json!(4_294_983_296i64);
+        assert_eq!(
+            classify_sample_rate(&body, Some(16_000)),
+            AudioSampleRateOutcome::SampleRateOutOfRange { got: 4_294_983_296 }
+        );
+    }
+
+    #[test]
+    fn sample_rate_at_exactly_2_pow_32_reports_the_input_not_zero() {
+        // `as u32` yields 0 here, so the pre-fix code reported
+        // `NonCanonicalRate { got: 0 }` — a value never present in the input.
+        let mut body = good_body();
+        body["sample_rate"] = json!(4_294_967_296i64);
+        assert_eq!(
+            classify_sample_rate(&body, None),
+            AudioSampleRateOutcome::SampleRateOutOfRange { got: 4_294_967_296 }
+        );
+    }
+
+    #[test]
+    fn sample_rate_at_u32_max_is_in_range_and_merely_non_canonical() {
+        // Boundary: u32::MAX still fits, so it must reach the canonical-set
+        // check rather than the range check.
+        let mut body = good_body();
+        body["sample_rate"] = json!(4_294_967_295i64);
+        assert_eq!(
+            classify_sample_rate(&body, None),
+            AudioSampleRateOutcome::NonCanonicalRate { got: 4_294_967_295 }
+        );
+    }
+
+    #[test]
+    fn channel_shape_rejects_channels_above_u32_that_aliases_to_1() {
+        // 2^32 + 1: `as u32` yields 1, a perfectly valid mono count.
+        let mut body = good_body();
+        body["channels"] = json!(4_294_967_297i64);
+        assert_eq!(
+            classify_channel_shape(&body, None),
+            AudioChannelShapeOutcome::ChannelsOutOfRange { got: 4_294_967_297 }
+        );
+    }
+
+    #[test]
+    fn channel_shape_out_of_range_is_not_rescued_by_expected_channels() {
+        let mut body = good_body();
+        body["channels"] = json!(4_294_967_297i64);
+        assert_eq!(
+            classify_channel_shape(&body, Some(1)),
+            AudioChannelShapeOutcome::ChannelsOutOfRange { got: 4_294_967_297 }
+        );
+    }
+
+    #[test]
+    fn channel_shape_at_u32_max_is_in_range() {
+        let mut body = good_body();
+        body["channels"] = json!(4_294_967_295i64);
+        assert_eq!(
+            classify_channel_shape(&body, None),
+            AudioChannelShapeOutcome::Ok {
+                channels: 4_294_967_295,
+                samples: 48_000
+            }
+        );
     }
 
     #[test]

--- a/crates/apr-cli/src/commands/audio_inspect_lint.rs
+++ b/crates/apr-cli/src/commands/audio_inspect_lint.rs
@@ -107,4 +107,39 @@ mod cov_tests {
         let f = w("{}");
         let _ = run(f.path(), None, None, true);
     }
+
+    /// Dogfood 0.63.0 #2377 finding 5 at the command surface: the body says
+    /// 4294983296, the pre-fix report said `Ok { rate: 16000 }` and exited 0.
+    #[test]
+    fn out_of_range_sample_rate_fails_the_command() {
+        let f = w(r#"{"min":-0.5,"max":0.5,"sample_rate":4294983296,"channels":1,"samples":100}"#);
+        let err = run(f.path(), None, None, false).unwrap_err();
+        assert!(matches!(err, CliError::ValidationFailed(_)), "{err:?}");
+        let msg = err.to_string();
+        assert!(msg.contains("4294983296"), "must echo the input: {msg}");
+        assert!(!msg.contains("16000"), "must not invent a rate: {msg}");
+    }
+
+    /// The explicit assertion path was fooled identically: wrapped, the value
+    /// equalled the `--expected-sample-rate` the user asked for.
+    #[test]
+    fn out_of_range_sample_rate_fails_even_with_expected_rate() {
+        let f = w(r#"{"min":-0.5,"max":0.5,"sample_rate":4294983296,"channels":1,"samples":100}"#);
+        let err = run(f.path(), Some(16_000), None, false).unwrap_err();
+        assert!(err.to_string().contains("4294983296"), "{err}");
+    }
+
+    #[test]
+    fn out_of_range_channel_count_fails_the_command() {
+        let f =
+            w(r#"{"min":-0.5,"max":0.5,"sample_rate":16000,"channels":4294967297,"samples":100}"#);
+        let err = run(f.path(), None, None, false).unwrap_err();
+        assert!(err.to_string().contains("4294967297"), "{err}");
+    }
+
+    #[test]
+    fn a_well_formed_body_still_passes() {
+        let f = w(r#"{"min":-0.5,"max":0.5,"sample_rate":16000,"channels":1,"samples":100}"#);
+        assert!(run(f.path(), Some(16_000), Some(1), false).is_ok());
+    }
 }

--- a/crates/apr-cli/src/commands/embeddings_lint.rs
+++ b/crates/apr-cli/src/commands/embeddings_lint.rs
@@ -114,7 +114,47 @@ pub fn run(args: EmbeddingsLintArgs) -> Result<(), String> {
     Ok(())
 }
 
+/// The three fields the shape gate reasons over must all be present and of
+/// the right JSON type. Anything else is unknown evidence, not a pass.
+fn require_shape_fields(v: &Value) -> Result<(), String> {
+    if !v.is_object() {
+        return Err(format!("`shape` is not an object: {v}"));
+    }
+    for field in ["input_len", "hidden_size"] {
+        match v.get(field) {
+            None => return Err(format!("missing `{field}`")),
+            Some(x) if x.as_u64().is_none() => {
+                return Err(format!("`{field}` is not a non-negative integer: {x}"))
+            }
+            Some(_) => {}
+        }
+    }
+    match v.get("data") {
+        None => Err("missing `data`".to_string()),
+        Some(x) if !x.is_array() => Err(format!("`data` is not an array: {x}")),
+        Some(_) => Ok(()),
+    }
+}
+
 fn run_shape_gate(v: &Value) -> (GateReport, Option<String>) {
+    // `{"shape": {}}` used to default input_len/hidden_size to 0 and `data`
+    // to the empty vector, so 0 == 0 and the gate reported
+    // `Ok { n_rows: 0 }` — a verdict about evidence that was never present.
+    if let Err(why) = require_shape_fields(v) {
+        let desc = format!("shape evidence unreadable: {why}");
+        let err = Some(format!(
+            "FALSIFY-CRUX-C-13-001 shape gate could not be evaluated: {desc}"
+        ));
+        return (
+            GateReport {
+                gate: "shape",
+                falsify_id: "FALSIFY-CRUX-C-13-001",
+                outcome: desc,
+                passed: false,
+            },
+            err,
+        );
+    }
     let input_len = v.get("input_len").and_then(|x| x.as_u64()).unwrap_or(0) as usize;
     let hidden_size = v.get("hidden_size").and_then(|x| x.as_u64()).unwrap_or(0) as usize;
 
@@ -370,6 +410,50 @@ mod tests {
     #[test]
     fn flag_gate_disabled_default_passes() {
         let f = write_obs(r#"{"flag": {"argv": ["apr", "serve"], "expected": "disabled"}}"#);
+        assert!(run(args_for(&f)).is_ok());
+    }
+
+    // ── shape gate: an empty section is unknown, not Ok ───────────────────
+    //
+    // Dogfood 0.63.0 #2377 finding 4: `{"shape": {}}` defaulted input_len,
+    // hidden_size and data to 0/0/[] and reported `Ok { n_rows: 0 }`.
+
+    #[test]
+    fn shape_gate_empty_section_is_unreadable_not_ok() {
+        let f = write_obs(r#"{"shape": {}}"#);
+        let err = run(args_for(&f)).unwrap_err();
+        assert!(
+            err.contains("could not be evaluated"),
+            "an empty shape section must fail the gate, got: {err}"
+        );
+    }
+
+    #[test]
+    fn shape_gate_missing_data_is_unreadable() {
+        let f = write_obs(r#"{"shape": {"input_len": 0, "hidden_size": 4}}"#);
+        let err = run(args_for(&f)).unwrap_err();
+        assert!(err.contains("missing `data`"), "got: {err}");
+    }
+
+    #[test]
+    fn shape_gate_scalar_section_is_unreadable() {
+        let f = write_obs(r#"{"shape": "nonsense"}"#);
+        let err = run(args_for(&f)).unwrap_err();
+        assert!(err.contains("not an object"), "got: {err}");
+    }
+
+    #[test]
+    fn shape_gate_wrong_typed_input_len_is_unreadable() {
+        let f = write_obs(r#"{"shape": {"input_len": "2", "hidden_size": 3, "data": []}}"#);
+        let err = run(args_for(&f)).unwrap_err();
+        assert!(err.contains("input_len"), "got: {err}");
+    }
+
+    #[test]
+    fn shape_gate_explicit_zero_rows_still_passes() {
+        // A genuine empty-input response is still a pass — the fix rejects
+        // absent evidence, not a legitimately empty one.
+        let f = write_obs(r#"{"shape": {"input_len": 0, "hidden_size": 4, "data": []}}"#);
         assert!(run(args_for(&f)).is_ok());
     }
 

--- a/crates/apr-cli/src/commands/hang_trace_classifier.rs
+++ b/crates/apr-cli/src/commands/hang_trace_classifier.rs
@@ -22,11 +22,21 @@ pub const F14_TIMEOUT_EXIT_CODE: i32 = 124;
 /// Outcome of `classify_timeout_dump`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum HangTimeoutOutcome {
-    Ok { ranks_seen: usize },
+    Ok {
+        ranks_seen: usize,
+    },
+    /// `world_size == 0`: the gate has nothing to assert, so it cannot pass.
+    WorldSizeZero,
     DirEmpty,
-    MissingRank { rank: usize },
-    EmptyFile { rank: usize },
-    UnexpectedFilename { name: String },
+    MissingRank {
+        rank: usize,
+    },
+    EmptyFile {
+        rank: usize,
+    },
+    UnexpectedFilename {
+        name: String,
+    },
 }
 
 /// Outcome of `classify_empty_on_success`.
@@ -71,9 +81,11 @@ pub fn classify_timeout_dump(
     world_size: usize,
 ) -> HangTimeoutOutcome {
     if world_size == 0 {
-        // Degenerate: zero ranks expected => any contents is fine,
-        // but a missing dir would be a different problem; treat as Ok.
-        return HangTimeoutOutcome::Ok { ranks_seen: 0 };
+        // A timeout dump with zero expected ranks asserts nothing. Treating
+        // it as Ok made an EMPTY trace dir pass, so a CI job whose
+        // `--world-size` came from an env var that resolved to empty got a
+        // green gate on no evidence at all. Unknown is not a pass.
+        return HangTimeoutOutcome::WorldSizeZero;
     }
     if listing.names.is_empty() {
         return HangTimeoutOutcome::DirEmpty;
@@ -209,6 +221,30 @@ mod tests {
             HangTimeoutOutcome::UnexpectedFilename { name } => assert_eq!(name, "scratchpad.txt"),
             other => panic!("expected UnexpectedFilename, got {other:?}"),
         }
+    }
+
+    // Dogfood 0.63.0 #2377 finding 4: `--world-size 0` short-circuited to
+    // `Ok { ranks_seen: 0 }`, so an EMPTY trace dir passed the timeout gate.
+    // A CI job whose world_size came from an env var that resolved to empty
+    // got a green gate on no evidence at all.
+    #[test]
+    fn timeout_dump_world_size_zero_does_not_pass_on_empty_dir() {
+        let pairs: Vec<(String, u64)> = vec![];
+        let listing = listing_view(&pairs);
+        assert_eq!(
+            classify_timeout_dump(&listing, 0),
+            HangTimeoutOutcome::WorldSizeZero
+        );
+    }
+
+    #[test]
+    fn timeout_dump_world_size_zero_does_not_pass_on_populated_dir() {
+        let pairs = vec![("rank0.py.txt".to_string(), 256u64)];
+        let listing = listing_view(&pairs);
+        assert_eq!(
+            classify_timeout_dump(&listing, 0),
+            HangTimeoutOutcome::WorldSizeZero
+        );
     }
 
     #[test]

--- a/crates/apr-cli/src/commands/imatrix_lint.rs
+++ b/crates/apr-cli/src/commands/imatrix_lint.rs
@@ -163,25 +163,57 @@ fn run_improvement_gate(v: &Value) -> (GateReport, Option<String>) {
     )
 }
 
+/// Canonicalise one `*_hashes` element into the string used for set
+/// membership. A hash may legitimately be serialised as a JSON string or as
+/// a JSON number; both are accepted and compared on the same footing so that
+/// `[1, 2]` vs `[1, 2]` is detected as leakage rather than silently dropped.
+/// Composite values (array/object/null) are not hashes and are rejected.
+fn canonical_hash(el: &Value) -> Result<String, String> {
+    match el {
+        Value::String(s) => Ok(s.clone()),
+        Value::Number(n) => Ok(n.to_string()),
+        Value::Bool(b) => Ok(b.to_string()),
+        other => Err(format!("element is not a scalar hash: {other}")),
+    }
+}
+
+/// Extract one hash set, refusing to invent an empty set out of missing or
+/// wrongly-typed evidence. Returning `Err` makes the gate FAIL: an
+/// unreadable observation is unknown, not disjoint.
+fn extract_hash_set(v: &Value, field: &str) -> Result<BTreeSet<String>, String> {
+    let Some(raw) = v.get(field) else {
+        return Err(format!("missing `{field}`"));
+    };
+    let Some(arr) = raw.as_array() else {
+        return Err(format!("`{field}` is not an array"));
+    };
+    let mut out = BTreeSet::new();
+    for (i, el) in arr.iter().enumerate() {
+        match canonical_hash(el) {
+            Ok(h) => {
+                out.insert(h);
+            }
+            Err(why) => return Err(format!("`{field}`[{i}]: {why}")),
+        }
+    }
+    Ok(out)
+}
+
 fn run_leakage_gate(v: &Value) -> (GateReport, Option<String>) {
-    let calib: BTreeSet<String> = v
-        .get("calib_hashes")
-        .and_then(|x| x.as_array())
-        .map(|a| {
-            a.iter()
-                .filter_map(|s| s.as_str().map(|s| s.to_string()))
-                .collect()
-        })
-        .unwrap_or_default();
-    let eval: BTreeSet<String> = v
-        .get("eval_hashes")
-        .and_then(|x| x.as_array())
-        .map(|a| {
-            a.iter()
-                .filter_map(|s| s.as_str().map(|s| s.to_string()))
-                .collect()
-        })
-        .unwrap_or_default();
+    // A non-object `leakage`, a missing array, or non-scalar elements used to
+    // collapse to two empty sets and be reported as `disjoint (|calib|=0,
+    // |eval|=0)` — a statement about data that was never read.
+    if !v.is_object() {
+        return leakage_unreadable(format!("`leakage` is not an object: {v}"));
+    }
+    let calib = match extract_hash_set(v, "calib_hashes") {
+        Ok(s) => s,
+        Err(why) => return leakage_unreadable(why),
+    };
+    let eval = match extract_hash_set(v, "eval_hashes") {
+        Ok(s) => s,
+        Err(why) => return leakage_unreadable(why),
+    };
     let disjoint = calibration_eval_disjoint(&calib, &eval);
     let overlap: Vec<&String> = calib.intersection(&eval).collect();
     let desc = if disjoint {
@@ -206,6 +238,23 @@ fn run_leakage_gate(v: &Value) -> (GateReport, Option<String>) {
             falsify_id: "FALSIFY-CRUX-B-07-001",
             outcome: desc,
             passed: disjoint,
+        },
+        err,
+    )
+}
+
+/// Build the FAIL report used when the `leakage` section cannot be read.
+fn leakage_unreadable(why: String) -> (GateReport, Option<String>) {
+    let desc = format!("leakage evidence unreadable: {why}");
+    let err = Some(format!(
+        "FALSIFY-CRUX-B-07-001 leakage gate could not be evaluated: {desc}"
+    ));
+    (
+        GateReport {
+            gate: "leakage",
+            falsify_id: "FALSIFY-CRUX-B-07-001",
+            outcome: desc,
+            passed: false,
         },
         err,
     )
@@ -421,6 +470,71 @@ mod tests {
         let f = write_obs(r#"{"provenance": {}}"#);
         let err = run(args_for(&f)).unwrap_err();
         assert!(err.contains("FALSIFY-CRUX-B-07-003"));
+    }
+
+    // ── leakage gate: degenerate evidence must not read as "disjoint" ─────
+    //
+    // Dogfood 0.63.0 #2377 finding 4. The gate reported
+    // `[PASS] leakage ...: disjoint (|calib|=0, |eval|=0)` for bodies it had
+    // never actually read, because `filter_map(as_str)` on a non-object or on
+    // integer-typed hashes yields two empty sets.
+
+    #[test]
+    fn leakage_overlapping_integer_hashes_are_detected() {
+        // Same overlap as the string case below, only serialized as numbers.
+        // Pre-fix this PASSED with "disjoint (|calib|=0, |eval|=0)".
+        let f = write_obs(r#"{"leakage": {"calib_hashes": [1, 2], "eval_hashes": [1, 2]}}"#);
+        let err = run(args_for(&f)).unwrap_err();
+        assert!(
+            err.contains("leakage invariant violated"),
+            "integer-typed overlapping hashes must be leakage, got: {err}"
+        );
+        assert!(err.contains('1'), "overlap must be named: {err}");
+    }
+
+    #[test]
+    fn leakage_overlapping_string_hashes_are_detected() {
+        // Control: the type the gate always handled correctly.
+        let f = write_obs(r#"{"leakage": {"calib_hashes": ["a"], "eval_hashes": ["a"]}}"#);
+        let err = run(args_for(&f)).unwrap_err();
+        assert!(err.contains("leakage invariant violated"), "got: {err}");
+    }
+
+    #[test]
+    fn leakage_scalar_section_is_unreadable_not_disjoint() {
+        let f = write_obs(r#"{"leakage": "nonsense"}"#);
+        let err = run(args_for(&f)).unwrap_err();
+        assert!(
+            err.contains("could not be evaluated"),
+            "a non-object leakage section must fail the gate, got: {err}"
+        );
+    }
+
+    #[test]
+    fn leakage_missing_eval_hashes_is_unreadable() {
+        let f = write_obs(r#"{"leakage": {"calib_hashes": ["a"]}}"#);
+        let err = run(args_for(&f)).unwrap_err();
+        assert!(err.contains("eval_hashes"), "got: {err}");
+    }
+
+    #[test]
+    fn leakage_non_scalar_element_is_unreadable() {
+        let f = write_obs(r#"{"leakage": {"calib_hashes": [["a"]], "eval_hashes": ["b"]}}"#);
+        let err = run(args_for(&f)).unwrap_err();
+        assert!(err.contains("not a scalar hash"), "got: {err}");
+    }
+
+    #[test]
+    fn leakage_genuinely_disjoint_still_passes() {
+        // The fix must not turn a real pass into a failure.
+        let f = write_obs(r#"{"leakage": {"calib_hashes": ["a"], "eval_hashes": ["b"]}}"#);
+        assert!(run(args_for(&f)).is_ok());
+    }
+
+    #[test]
+    fn leakage_empty_but_explicit_sets_are_disjoint() {
+        let f = write_obs(r#"{"leakage": {"calib_hashes": [], "eval_hashes": []}}"#);
+        assert!(run(args_for(&f)).is_ok());
     }
 
     #[test]

--- a/crates/apr-cli/src/commands/quant_preservation.rs
+++ b/crates/apr-cli/src/commands/quant_preservation.rs
@@ -28,11 +28,30 @@ use crate::error::{CliError, Result};
 /// the qtype enum on disk.
 const QUANT_VOLATILE_KEYS: &[&str] = &["general.quantization_version", "general.file_type"];
 
+/// Longest verbatim rendering of a single metadata value kept in a divergence
+/// entry. Beyond this the value is summarised.
+///
+/// GGUF tokenizer metadata is not small: `tokenizer.ggml.merges` on a Qwen
+/// vocab renders to 4.8 MB and `tokenizer.ggml.tokens` to 4.4 MB via `Debug`.
+/// Emitting those verbatim produced a 13 MB, 19-line report (14.9 MB under
+/// `--json`) that wedged terminals and blew CI log budgets, burying the
+/// actionable one-line scalar divergences on either side of it.
+pub const DIFF_VALUE_MAX_CHARS: usize = 200;
+
+/// Characters of the verbatim rendering retained as a head sample when a
+/// value is summarised.
+const DIFF_VALUE_HEAD_CHARS: usize = 96;
+
 #[derive(Debug, Clone, Serialize)]
 pub struct DiffEntry {
     pub key: String,
     pub reference: String,
     pub requant: String,
+    /// Where the two values first differ, when that is computable (same array
+    /// variant on both sides). `None` for scalars and cross-type divergences,
+    /// where the rendered values already show the difference.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub first_difference: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -99,8 +118,9 @@ pub fn classify_preservation(
                 if !values_equal(ref_val, req_val) {
                     let entry = DiffEntry {
                         key: key.clone(),
-                        reference: format!("{ref_val:?}"),
-                        requant: format!("{req_val:?}"),
+                        reference: render_value_bounded(ref_val),
+                        requant: render_value_bounded(req_val),
+                        first_difference: describe_first_difference(ref_val, req_val),
                     };
                     if prefix_general {
                         general_diverged.push(entry);
@@ -168,6 +188,127 @@ fn values_equal(a: &GgufValue, b: &GgufValue) -> bool {
     format!("{a:?}") == format!("{b:?}")
 }
 
+/// Variant name of a `GgufValue`, used as the label of a summarised value.
+fn value_kind(v: &GgufValue) -> &'static str {
+    match v {
+        GgufValue::Uint8(_) => "Uint8",
+        GgufValue::Int8(_) => "Int8",
+        GgufValue::Uint16(_) => "Uint16",
+        GgufValue::Int16(_) => "Int16",
+        GgufValue::Uint32(_) => "Uint32",
+        GgufValue::Int32(_) => "Int32",
+        GgufValue::Float32(_) => "Float32",
+        GgufValue::Bool(_) => "Bool",
+        GgufValue::String(_) => "String",
+        GgufValue::Uint64(_) => "Uint64",
+        GgufValue::Int64(_) => "Int64",
+        GgufValue::Float64(_) => "Float64",
+        GgufValue::ArrayUint32(_) => "ArrayUint32",
+        GgufValue::ArrayInt32(_) => "ArrayInt32",
+        GgufValue::ArrayFloat32(_) => "ArrayFloat32",
+        GgufValue::ArrayString(_) => "ArrayString",
+    }
+}
+
+/// Element count for array-valued metadata; `None` for scalars.
+fn array_len(v: &GgufValue) -> Option<usize> {
+    match v {
+        GgufValue::ArrayUint32(a) => Some(a.len()),
+        GgufValue::ArrayInt32(a) => Some(a.len()),
+        GgufValue::ArrayFloat32(a) => Some(a.len()),
+        GgufValue::ArrayString(a) => Some(a.len()),
+        _ => None,
+    }
+}
+
+/// Hex sha256 of the canonical rendering, truncated to 16 chars — enough to
+/// tell two vocabularies apart in a log line without reproducing either.
+fn digest16(bytes: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    let full = Sha256::digest(bytes);
+    full.iter().take(8).map(|b| format!("{b:02x}")).collect()
+}
+
+/// Render a metadata value for a divergence report, bounded in size.
+///
+/// Short values (every scalar, and small arrays) are rendered verbatim — the
+/// `general.architecture :: String("qwen35") → String("qwen2")` form is
+/// exactly what a reader needs. Anything longer than
+/// [`DIFF_VALUE_MAX_CHARS`] is replaced by a summary carrying the element
+/// count (or character count), a content digest, and a head sample.
+pub fn render_value_bounded(v: &GgufValue) -> String {
+    let full = format!("{v:?}");
+    if full.chars().count() <= DIFF_VALUE_MAX_CHARS {
+        return full;
+    }
+    let digest = digest16(full.as_bytes());
+    let head: String = full.chars().take(DIFF_VALUE_HEAD_CHARS).collect();
+    match array_len(v) {
+        Some(n) => format!("{}(len={n}, sha256={digest}, head={head}…)", value_kind(v)),
+        None => format!(
+            "{}(chars={}, sha256={digest}, head={head}…)",
+            value_kind(v),
+            full.chars().count()
+        ),
+    }
+}
+
+/// For two arrays of the same variant, the index of the first element that
+/// differs (or the point at which one ran out). `None` when the values are
+/// not a same-variant array pair.
+pub fn describe_first_difference(a: &GgufValue, b: &GgufValue) -> Option<String> {
+    fn locate<T: PartialEq>(x: &[T], y: &[T]) -> String {
+        match x.iter().zip(y.iter()).position(|(p, q)| p != q) {
+            Some(i) => format!(
+                "first differing element: index {i} (len {} vs {})",
+                x.len(),
+                y.len()
+            ),
+            None => format!(
+                "common prefix identical; lengths differ: {} vs {}",
+                x.len(),
+                y.len()
+            ),
+        }
+    }
+    match (a, b) {
+        (GgufValue::ArrayUint32(x), GgufValue::ArrayUint32(y)) => Some(locate(x, y)),
+        (GgufValue::ArrayInt32(x), GgufValue::ArrayInt32(y)) => Some(locate(x, y)),
+        (GgufValue::ArrayString(x), GgufValue::ArrayString(y)) => Some(locate(x, y)),
+        (GgufValue::ArrayFloat32(x), GgufValue::ArrayFloat32(y)) => {
+            let pos = x
+                .iter()
+                .zip(y.iter())
+                .position(|(p, q)| p.to_bits() != q.to_bits());
+            Some(match pos {
+                Some(i) => format!(
+                    "first differing element: index {i} (len {} vs {})",
+                    x.len(),
+                    y.len()
+                ),
+                None => format!(
+                    "common prefix identical; lengths differ: {} vs {}",
+                    x.len(),
+                    y.len()
+                ),
+            })
+        }
+        _ => None,
+    }
+}
+
+/// One divergence line, plus an indented locator line when we could compute
+/// where two arrays first differ.
+fn push_diff_entry(out: &mut String, e: &DiffEntry) {
+    out.push_str(&format!(
+        "    {} :: {} → {}\n",
+        e.key, e.reference, e.requant
+    ));
+    if let Some(loc) = &e.first_difference {
+        out.push_str(&format!("      {loc}\n"));
+    }
+}
+
 /// Render the report as a human-readable summary.
 pub fn render_text(report: &PreservationReport) -> String {
     let mut out = String::new();
@@ -191,19 +332,13 @@ pub fn render_text(report: &PreservationReport) -> String {
     if !report.general_keys_diverged.is_empty() {
         out.push_str("  diverged general.*:\n");
         for e in &report.general_keys_diverged {
-            out.push_str(&format!(
-                "    {} :: {} → {}\n",
-                e.key, e.reference, e.requant
-            ));
+            push_diff_entry(&mut out, e);
         }
     }
     if !report.tokenizer_keys_diverged.is_empty() {
         out.push_str("  diverged tokenizer.*:\n");
         for e in &report.tokenizer_keys_diverged {
-            out.push_str(&format!(
-                "    {} :: {} → {}\n",
-                e.key, e.reference, e.requant
-            ));
+            push_diff_entry(&mut out, e);
         }
     }
     out.push_str(&format!(
@@ -418,5 +553,111 @@ mod tests {
             report.tokenizer_keys_added_in_requant,
             vec!["tokenizer.ggml.merges"]
         );
+    }
+
+    // ── bounded divergence reporting (dogfood 0.63.0 #2377 findings 1+7) ──
+    //
+    // Two diverging tokenizer vocabularies produced a 13 MB, 19-line text
+    // report (14.9 MB under --json) with a single 4.8 MB line, because every
+    // diverged value was stored as the untruncated `Debug` of the whole GGUF
+    // array. These assert the SIZE of the emitted report, not its shape.
+
+    /// A vocab-sized array is the realistic worst case: 151936 tokens.
+    fn big_vocab(seed: &str, n: usize) -> GgufValue {
+        GgufValue::ArrayString((0..n).map(|i| format!("{seed}-token-{i}")).collect())
+    }
+
+    #[test]
+    fn diverging_vocabularies_do_not_produce_a_multi_megabyte_report() {
+        let reference = meta_kv(&[("tokenizer.ggml.tokens", big_vocab("ref", 151_936))]);
+        let requant = meta_kv(&[("tokenizer.ggml.tokens", big_vocab("req", 151_936))]);
+        let report = classify_preservation(&reference, &requant, "r.gguf".into(), "q.gguf".into());
+        assert!(!report.passed, "divergent vocabularies must be VIOLATED");
+
+        let text = render_text(&report);
+        assert!(
+            text.len() < 4096,
+            "divergence report must stay bounded; got {} bytes:\n{}",
+            text.len(),
+            &text[..text.len().min(400)]
+        );
+        // Every line must be readable in a terminal and a CI log.
+        let longest = text.lines().map(str::len).max().unwrap_or(0);
+        assert!(longest < 512, "longest line is {longest} chars");
+
+        let json = serde_json::to_string(&report).expect("serialize");
+        assert!(json.len() < 4096, "--json payload is {} bytes", json.len());
+    }
+
+    #[test]
+    fn summarised_value_names_the_length_and_a_digest_not_the_contents() {
+        let big = big_vocab("ref", 151_936);
+        let rendered = render_value_bounded(&big);
+        assert!(rendered.contains("len=151936"), "got: {rendered}");
+        assert!(rendered.contains("sha256="), "got: {rendered}");
+        assert!(
+            rendered.chars().count() < 400,
+            "summary is {} chars",
+            rendered.chars().count()
+        );
+    }
+
+    #[test]
+    fn two_different_vocabularies_summarise_to_different_digests() {
+        // A digest that collided would make the summary useless.
+        let a = render_value_bounded(&big_vocab("ref", 8_000));
+        let b = render_value_bounded(&big_vocab("req", 8_000));
+        assert_ne!(a, b, "distinct vocabularies must not summarise identically");
+    }
+
+    #[test]
+    fn short_scalar_divergences_are_still_rendered_verbatim() {
+        // The actionable one-line signals must not be summarised away.
+        let reference = meta_kv(&[
+            (
+                "general.architecture",
+                GgufValue::String("qwen35".to_string()),
+            ),
+            ("tokenizer.ggml.eos_token_id", GgufValue::Uint32(248_046)),
+        ]);
+        let requant = meta_kv(&[
+            (
+                "general.architecture",
+                GgufValue::String("qwen2".to_string()),
+            ),
+            ("tokenizer.ggml.eos_token_id", GgufValue::Uint32(151_645)),
+        ]);
+        let text = render_text(&classify_preservation(
+            &reference,
+            &requant,
+            "r.gguf".into(),
+            "q.gguf".into(),
+        ));
+        assert!(
+            text.contains(r#"general.architecture :: String("qwen35") → String("qwen2")"#),
+            "got:\n{text}"
+        );
+        assert!(
+            text.contains("tokenizer.ggml.eos_token_id :: Uint32(248046) → Uint32(151645)"),
+            "got:\n{text}"
+        );
+    }
+
+    #[test]
+    fn array_divergence_reports_the_first_differing_index() {
+        let reference = meta_kv(&[(
+            "tokenizer.ggml.token_type",
+            GgufValue::ArrayInt32(vec![1; 4096]),
+        )]);
+        let mut changed = vec![1i32; 4096];
+        changed[2047] = 4;
+        let requant = meta_kv(&[("tokenizer.ggml.token_type", GgufValue::ArrayInt32(changed))]);
+        let report = classify_preservation(&reference, &requant, "r.gguf".into(), "q.gguf".into());
+        let entry = &report.tokenizer_keys_diverged[0];
+        assert_eq!(
+            entry.first_difference.as_deref(),
+            Some("first differing element: index 2047 (len 4096 vs 4096)")
+        );
+        assert!(render_text(&report).contains("index 2047"));
     }
 }

--- a/crates/apr-cli/src/extended_commands.rs
+++ b/crates/apr-cli/src/extended_commands.rs
@@ -1013,6 +1013,8 @@ pub enum ExtendedCommands {
     },
     /// Lint a typical-p sampling observation (CRUX-C-22)
     TypicalPLint {
+        /// Path to captured typical-p observation JSON, with any of the
+        /// sections range/identity/mass/sort/renorm
         #[arg(long, value_name = "FILE")]
         observation_file: PathBuf,
     },
@@ -1045,6 +1047,8 @@ pub enum ExtendedCommands {
     },
     /// Lint a captured /v1/embeddings observation (CRUX-C-13)
     EmbeddingsLint {
+        /// Path to captured /v1/embeddings observation JSON, with any of the
+        /// sections shape/determinism/usage/flag
         #[arg(long, value_name = "FILE")]
         observation_file: PathBuf,
     },

--- a/crates/apr-cli/src/parsing.rs
+++ b/crates/apr-cli/src/parsing.rs
@@ -464,3 +464,46 @@
             _ => panic!("Expected Profile command"),
         }
     }
+
+    /// Dogfood 0.63.0 #2377 finding 10: `apr typical-p-lint --help` printed
+    /// its only required flag with an empty description, so the (non-obvious,
+    /// otherwise undocumented) observation schema had no route to the user.
+    /// Every other command in the 16-command lint family documents its flag.
+    ///
+    /// A family-wide ratchet, not a one-line fix: a new `*-lint` command that
+    /// forgets its flag doc turns this red.
+    #[test]
+    fn every_lint_command_documents_its_flags() {
+        use clap::CommandFactory;
+        let offenders = std::thread::Builder::new()
+            .stack_size(16 * 1024 * 1024)
+            .spawn(|| {
+                let mut root = Cli::command();
+                root.build();
+                let mut bad: Vec<String> = Vec::new();
+                for sub in root.get_subcommands() {
+                    if !sub.get_name().ends_with("-lint") {
+                        continue;
+                    }
+                    for arg in sub.get_arguments() {
+                        if arg.get_id() == "help" || arg.get_id() == "version" {
+                            continue;
+                        }
+                        let documented = arg
+                            .get_help()
+                            .is_some_and(|h| !h.to_string().trim().is_empty());
+                        if !documented {
+                            bad.push(format!("{} --{}", sub.get_name(), arg.get_id()));
+                        }
+                    }
+                }
+                bad
+            })
+            .expect("spawn")
+            .join()
+            .expect("join");
+        assert!(
+            offenders.is_empty(),
+            "lint commands with an undocumented flag: {offenders:?}"
+        );
+    }


### PR DESCRIPTION
`apr audio-inspect-lint` accepted a body declaring `sample_rate: 4294983296`, printed `sample_rate : Ok { rate: 16000 }` and exited 0. That number is 2^32 + 16000, and `raw as u32` wraps, so the value aliased onto a canonical rate and passed while the report showed a rate the file never contained. `--expected-sample-rate 16000` did not catch it either — after the wrap the two were equal. `channels: 4294967297` aliased to 1 the same way, and `sample_rate: 4294967296` failed but reported `NonCanonicalRate { got: 0 }`, another value absent from the input.

Three more gates in the same family reported PASS for sections that were absent, empty, or of the wrong JSON type. `apr imatrix-lint` on `{"leakage":{"calib_hashes":[1,2],"eval_hashes":[1,2]}}` — two identical sets — printed `[PASS] leakage: disjoint (|calib|=0, |eval|=0)`, because `filter_map(Value::as_str)` dropped every integer-typed hash and the gate then made a cardinality claim about data it had not read. `{"leakage":"nonsense"}` produced the same green line. `apr embeddings-lint` did it with `{"shape":{}}`: input_len, hidden_size and data all defaulted to 0/0/[], 0 == 0, `Ok { n_rows: 0 }`. `apr hang-trace-lint --world-size 0` short-circuited to `Ok { ranks_seen: 0 }` on an **empty** trace dir, so a CI job whose world size came from an env var that resolved to empty got a green gate on no evidence at all.

`apr quant-preservation-lint` across two models with different tokenizers emitted 13,282,156 bytes over 19 lines, one line 4,814,215 characters long (14,896,285 bytes under `--json`). It stored the untruncated `Debug` of every diverged GGUF value including the whole 248k-entry `tokenizer.ggml.merges` and `tokenizer.ggml.tokens`. The actionable signals in that same run were buried between three multi-megabyte dumps.

## Before / after

Both binaries carry an embedded git SHA proving which tree they came from, and both were built into a private target dir — the workspace target dir is shared with three other worktrees, and the first "after" binary picked up from it turned out to be another worktree's build, byte-identical to the "before" one and showing zero change.

| | before — `apr 0.63.0 (8cc3aafeb)` | after — `apr 0.63.0 (dd617995c)` |
|---|---|---|
| `sample_rate: 4294983296` | `Ok { rate: 16000 }` rc=0 | `SampleRateOutOfRange { got: 4294983296 }` rc=5 |
| same, `--expected-sample-rate 16000` | `Ok { rate: 16000 }` rc=0 | `SampleRateOutOfRange { got: 4294983296 }` rc=5 |
| `channels: 4294967297` | `Ok { channels: 1 }` rc=0 | `ChannelsOutOfRange { got: 4294967297 }` rc=5 |
| `sample_rate: 4294967296` | `NonCanonicalRate { got: 0 }` rc=5 | `SampleRateOutOfRange { got: 4294967296 }` rc=5 |
| imatrix, integer hashes `[1,2]` vs `[1,2]` | `[PASS] disjoint (\|calib\|=0, \|eval\|=0)` rc=0 | `[FAIL] leakage detected: 2 overlapping item(s): ["1", "2"]` rc=1 |
| imatrix, `{"leakage":"nonsense"}` | `[PASS] disjoint (\|calib\|=0, \|eval\|=0)` rc=0 | `[FAIL] leakage evidence unreadable: \`leakage\` is not an object` rc=1 |
| embeddings, `{"shape":{}}` | `[PASS] Ok { n_rows: 0 }` rc=0 | `[FAIL] shape evidence unreadable: missing \`input_len\`` rc=1 |
| hang-trace, empty dir `--world-size 0` | `Ok { ranks_seen: 0 }` rc=0 | `WorldSizeZero` rc=5 |
| quant-preservation, diverging vocabs | 13,282,156 B / 19 lines / longest 4,814,215 | 2,446 B / 22 lines / longest 338 |
| same, `--json` | 14,896,285 B | 3,761 B |

Controls held throughout: genuinely disjoint hash sets still pass, a well-formed `{"shape":{...}}` still passes, an explicitly empty `{"input_len":0,"hidden_size":4,"data":[]}` response still passes, `--world-size 2` on a populated dir still passes, and identical GGUFs still report `PRESERVED` in 319 bytes. The fix rejects absent evidence, not legitimately empty evidence.

The summarised divergence line now carries what a reader can act on:

```
tokenizer.ggml.tokens :: ArrayString(len=248320, sha256=3751959a6d53cc72, head=ArrayString(["!", "\"", "#", …)
                       → ArrayString(len=151936, sha256=77485efcba6e358f, head=ArrayString(["!", "\"", "#", …)
  first differing element: index 280 (len 248320 vs 151936)
general.architecture :: String("qwen35") → String("qwen2")
tokenizer.ggml.eos_token_id :: Uint32(248046) → Uint32(151645)
```

Scalars are untouched — only values over 200 characters are summarised.

## Root cause

- `crates/apr-cli/src/commands/audio_inspect_classifier.rs:106,139` — `as u32` applied after only a `raw <= 0` check
- `crates/apr-cli/src/commands/imatrix_lint.rs:166` — `and_then(as_array).map(filter_map(as_str)).unwrap_or_default()` over a possibly-absent, possibly-non-string section
- `crates/apr-cli/src/commands/embeddings_lint.rs:117` — three defaults standing in for missing fields
- `crates/apr-cli/src/commands/hang_trace_classifier.rs:69` — `world_size == 0` returned `Ok`, with a comment calling it "Degenerate"
- `crates/apr-cli/src/commands/quant_preservation.rs:100` — `format!("{ref_val:?}")` stored whole, rendered whole at `:201-208` and serialized whole under `--json`

## The help-text finding found a second instance

`apr typical-p-lint --help` printed its only required flag with an empty description, so its non-obvious observation schema had no route to a user. Instead of fixing the one string, the falsifier walks every `*-lint` subcommand through clap's `CommandFactory` and asserts each flag carries help text. It immediately went red on an instance the audit had not found:

```
lint commands with an undocumented flag: ["embeddings-lint --observation_file"]
```

Confirmed against the shipped binary — `embeddings-lint --help | cat -A` shows `--observation-file <FILE>  $`. Both are documented now, and a new `*-lint` command that forgets its flag doc turns the test red.

## Mutation check

Each fix reverted in turn, tests kept:

```
audio       8 failed   left: Ok { rate: 16000 }          right: SampleRateOutOfRange { got: 4294983296 }
                       left: Ok { channels: 1, .. }      right: ChannelsOutOfRange { got: 4294967297 }
                       left: NonCanonicalRate { got: 0 } right: SampleRateOutOfRange { got: 4294967296 }
imatrix     4 failed   [PASS] leakage (FALSIFY-CRUX-B-07-001): disjoint (|calib|=0, |eval|=0)
embeddings  4 failed   [PASS] shape (FALSIFY-CRUX-C-13-001): Ok { n_rows: 0 }
hang-trace  2 failed   left: Ok { ranks_seen: 0 }        right: WorldSizeZero
quant       2 failed   divergence report must stay bounded; got 5855530 bytes
                       left: None  right: Some("first differing element: index 2047 (len 4096 vs 4096)")
help        1 failed   lint commands with an undocumented flag: ["typical-p-lint --observation_file"]
```

Restored: `test result: ok. 6686 passed; 0 failed`. `cargo fmt --all -- --check` rc=0, `cargo clippy -p apr-cli --lib -- -D warnings` rc=0.

## Left for other PRs

- finding 2 — the "CLI flag accepted" gates stamp PASS for argv the real `apr quantize` / `apr serve run` parser rejects with exit 2. Fixing it means coupling those gates to the real clap definition, which will make four shipped commands start failing (correctly) on inputs users have today.
- finding 3 — 8 linters document a producer command (`apr attn-viz`, `apr dataset audio-inspect`, `apr trace --check-finite`, …) that the binary does not have.
- finding 6 — the family ships two mutually incompatible `--json` envelopes; unifying them is a family-wide change.
- findings 8 and 9 — the exit-code split (3/4/5 vs 1) and the `Invalid APR format` prefix on JSON observation files. Issue #2404 already owns exactly this, so touching `CliError` here would collide.

Refs #2377 (partial) — remaining: 2, 3, 6, 8, 9
Audit epic: #2373
