### PR TITLE
fix(cli): --quiet and --verbose were advertised on all 104 subcommands and read by two

### DIFF
--- a/contracts/apr-global-verbosity-wiring-v1.yaml
+++ b/contracts/apr-global-verbosity-wiring-v1.yaml
@@ -1,0 +1,117 @@
+metadata:
+  version: 1.0.0
+  created: '2026-08-10'
+  author: PAIML Engineering
+  description: "apr --quiet / --verbose global wiring contract — the two clap globals advertised in all 104 subcommands' --help MUST materially affect output, via one process-wide latch rather than a per-command parameter. Generalizes apr-list-quiet-wiring-v1 from `list` to every subcommand."
+  references:
+    - "paiml/aprender#2401 (dogfood-0.63.0: --quiet/--verbose byte-for-byte no-ops on 14 of 16 sampled commands)"
+    - "paiml/aprender#2373 (dogfood-0.63.0 audit epic)"
+    - "contracts/apr-list-quiet-wiring-v1.yaml (the single-command ancestor; its why_5 predicted this)"
+  registry: true
+  kind: kernel
+  tags:
+    - cli
+    - quiet
+    - verbose
+    - silent-flag
+    - five-whys
+
+five_whys:
+  symptom: "cmp -s <(apr inspect m.apr) <(apr inspect m.apr --quiet) reports IDENTICAL on 14 of 16 sampled commands; apr hex m.apr --quiet still writes 303972 bytes and apr gbnf-lint -q still prints the full PASS report"
+  why_1: "execute_command never read cli.quiet or cli.verbose at all — the parsed values were dropped on the floor"
+  why_2: "Reading them meant threading a `quiet: bool` parameter into every command's signature; only `list` and `lint` ever received one, so only those two honoured the flag"
+  why_3: "apr-list-quiet-wiring-v1 fixed the ONE command it was written for, leaving the same forwarding hazard on the other 103"
+  why_4: "A per-command parameter makes correctness opt-in: a new command is born ignoring --quiet, and nothing goes red"
+  why_5: "The control had no single decision point, so there was nothing a contract could bind to — exactly the gap apr-list-quiet-wiring-v1's own why_5 named and did not close"
+  root_cause: "Global output level was modelled as a per-command parameter instead of a process-wide latch consulted by the crate's print macros; a command could disarm it by forgetting to plumb an argument."
+
+equations:
+  quiet_materiality:
+    formula: "∀ cmd ∈ apr subcommands: stdout(cmd --quiet) = ∅ ∨ cmd ∈ OptOut"
+    domain: "any apr subcommand that produces user-facing stdout"
+    codomain: "stdout bytes"
+    invariants:
+      - "--quiet suppresses ordinary stdout for every command, without the command being aware of the flag"
+      - "--quiet leaves stderr and the process exit code untouched, so `Quiet mode (errors only)` is literally true"
+      - "--quiet does not suppress --json: the JSON document is the payload a script asked for"
+      - "OptOut = {list, lint} — commands with richer quiet semantics of their own, which emit via emitln!/emit!"
+  verbose_materiality:
+    formula: "∀ cmd ∈ apr subcommands: stdout(cmd --verbose) ≠ stdout(cmd)"
+    domain: "any apr subcommand dispatched through execute_command"
+    codomain: "stdout bytes"
+    invariants:
+      - "--verbose reports the dispatcher's own resolution: the model paths extracted and the contract-gate decision"
+      - "The three contract-gate outcomes (enforced, skipped via --skip-contract, not applicable) are distinguishable"
+      - "--verbose is additive: commands that already had verbose detail (check, oracle, trace) keep it"
+  precedence:
+    formula: "level(quiet, verbose) = Quiet if quiet else Verbose if verbose else Normal"
+    domain: "the two boolean clap globals"
+    codomain: "{Quiet, Normal, Verbose}"
+    invariants:
+      - "`-q -v` together was previously accepted with no error and no effect; --quiet now wins"
+      - "The latch never resets to Normal, so an in-process second command cannot un-quiet a quiet run"
+
+proof_obligations:
+  - type: invariant
+    property: "quiet empties stdout on a command that never receives the flag"
+    formal: "stdout(apr gbnf-lint --observation-file f --quiet) = ∅"
+    applies_to: quiet_materiality
+  - type: invariant
+    property: "quiet preserves errors and exit codes on stderr"
+    formal: "stderr(cmd --quiet) = stderr(cmd) ∧ exit(cmd --quiet) = exit(cmd)"
+    applies_to: quiet_materiality
+  - type: invariant
+    property: "json survives quiet"
+    formal: "stdout_suppressed(Quiet, json=true) = false"
+    applies_to: quiet_materiality
+  - type: invariant
+    property: "verbose is not a byte-for-byte no-op"
+    formal: "stdout(cmd --verbose) ≠ stdout(cmd)"
+    applies_to: verbose_materiality
+  - type: invariant
+    property: "quiet dominates verbose"
+    formal: "resolve(true, true) = Quiet"
+    applies_to: precedence
+
+falsification_tests:
+  - id: FALSIFY-VERBOSITY-001
+    rule: "--quiet empties stdout on a command that never receives the flag as a parameter"
+    prediction: "apr gbnf-lint --observation-file f --quiet prints zero bytes to stdout while the unflagged run prints its report"
+    test: "crates/apr-cli/src/verbosity.rs::tests::quiet_and_verbose_reach_a_command_that_never_receives_them"
+    if_fails: "The latch is not set in execute_command, or the crate-wide println! shadow is not in scope — --quiet is inert again"
+  - id: FALSIFY-VERBOSITY-002
+    rule: "--verbose changes stdout on the same command"
+    prediction: "stdout(gbnf-lint --verbose) != stdout(gbnf-lint), compared byte-for-byte over the same observation file"
+    test: "crates/apr-cli/src/verbosity.rs::tests::quiet_and_verbose_reach_a_command_that_never_receives_them"
+    if_fails: "--verbose is a no-op again, as it was on 13 of 16 commands in v0.63.0"
+  - id: FALSIFY-VERBOSITY-003
+    rule: "the three contract-gate outcomes are distinguishable under --verbose"
+    prediction: "preamble_lines reports enforced / skipped / not-applicable as three different texts"
+    test: "crates/apr-cli/src/verbosity.rs::tests::preamble_reports_the_gate_decision_not_a_fixed_string"
+    if_fails: "--verbose prints a fixed banner that carries no information, which is theater not detail"
+  - id: FALSIFY-VERBOSITY-004
+    rule: "--json --quiet still emits the JSON document"
+    prediction: "stdout_suppressed() is false whenever --json is in effect"
+    test: "crates/apr-cli/src/verbosity.rs::tests::json_survives_quiet"
+    if_fails: "Scripts asking for machine-readable output get nothing"
+  - id: FALSIFY-VERBOSITY-005
+    rule: "--quiet wins over --verbose"
+    prediction: "resolve(true, true) = Quiet"
+    test: "crates/apr-cli/src/verbosity.rs::tests::quiet_wins_over_verbose"
+    if_fails: "The contradictory pair is accepted with an undefined outcome, as in v0.63.0"
+
+kani_harnesses:
+  - id: KANI-VERBOSITY-001
+    obligation: "quiet dominates verbose"
+    bound: 4
+    strategy: bounded_int
+
+qa_gate:
+  id: F-VERBOSITY-001
+  name: "apr global --quiet/--verbose wiring contract"
+  description: "The two clap globals advertised on all 104 subcommands must materially affect output through a single process-wide latch, not a per-command parameter that a command can forget to forward"
+  checks:
+    - "quiet_materiality"
+    - "verbose_materiality"
+    - "precedence"
+  pass_criteria: "FALSIFY-VERBOSITY-{001,002,003,004,005} all PASS"

--- a/crates/apr-cli/src/commands/lint.rs
+++ b/crates/apr-cli/src/commands/lint.rs
@@ -19,6 +19,18 @@ use std::path::Path;
     equation = "side_effect_classification"
 )]
 pub(crate) fn run(file: &Path, json: bool, quiet: bool) -> Result<()> {
+    // #2401: `apr lint` already had richer quiet semantics than "print
+    // nothing" — GH-685 filters the issue table down to errors. Opt this
+    // command out of the crate-wide stdout gate so that behaviour survives;
+    // the `quiet` parameter below stays the thing that shapes the report.
+    let _verbosity = crate::verbosity::scope(
+        if crate::verbosity::is_verbose() {
+            crate::verbosity::Level::Verbose
+        } else {
+            crate::verbosity::Level::Normal
+        },
+        json,
+    );
     contract_pre_apr_model_validity!();
     contract_pre_lint_model_conventions!();
     // Validate input exists

--- a/crates/apr-cli/src/commands/pull_list.rs
+++ b/crates/apr-cli/src/commands/pull_list.rs
@@ -76,12 +76,15 @@ pub fn list(json: bool, quiet: bool) -> Result<()> {
 
     // Contract: apr-list-quiet-wiring-v1 F-LIST-QUIET-001 (paiml/aprender#623).
     // Quiet mode: one identifier per line, no decoration, no help text.
+    // #2401: `emitln!` bypasses the crate-wide `--quiet` stdout gate. This IS
+    // the quiet output F-LIST-QUIET-001 requires, so it must survive the gate
+    // that silences ordinary reporting.
     if quiet {
         for m in &models {
-            println!("{}", m.name);
+            emitln!("{}", m.name);
         }
         for o in &orphans {
-            println!("{}", o.name);
+            emitln!("{}", o.name);
         }
         return Ok(());
     }

--- a/crates/apr-cli/src/dispatch_run.rs
+++ b/crates/apr-cli/src/dispatch_run.rs
@@ -338,10 +338,30 @@ pub fn execute_command(cli: &Cli) -> Result<(), CliError> {
     // `--offline` is a clap global, so it is seen in either position
     // (`apr --offline pull ...` and `apr pull --offline ...`).
     crate::commands::offline::latch(cli.offline);
+    // #2401: same shape, same reason. `--quiet` / `--verbose` are clap
+    // globals advertised on all 104 subcommands and were read by exactly two
+    // of them, because reading them meant threading a parameter through every
+    // command. Record the level once, here, and let the crate-wide `println!`
+    // shadow in `crate::verbosity` consult it.
+    crate::verbosity::latch(cli.quiet, cli.verbose, cli.json);
     // PMAT-237: Contract gate — refuse to operate on corrupt models
+    let gated_paths = extract_model_paths(&cli.command);
+    // #2401: and the other half — `--verbose` was byte-inert on 13 of 16
+    // sampled commands. Report the dispatcher's own resolution instead of
+    // inventing per-command chatter for all 104: which model paths were
+    // extracted, and what the contract gate did with them.
+    if crate::verbosity::is_verbose() {
+        for line in crate::verbosity::preamble_lines(
+            env!("CARGO_PKG_VERSION"),
+            cli.offline,
+            cli.skip_contract,
+            &gated_paths,
+        ) {
+            vprintln!("{line}");
+        }
+    }
     if !cli.skip_contract {
-        let paths = extract_model_paths(&cli.command);
-        validate_model_contract(&paths)?;
+        validate_model_contract(&gated_paths)?;
     }
 
     dispatch_core_command(cli).unwrap_or_else(|| dispatch_extended_command(cli))

--- a/crates/apr-cli/src/lib.rs
+++ b/crates/apr-cli/src/lib.rs
@@ -23,6 +23,14 @@ use std::path::{Path, PathBuf};
 #[allow(unused_macros, clippy::duplicated_attributes)]
 mod generated_contracts;
 
+// #2401: `--quiet` / `--verbose` control. MUST come before `mod commands;` —
+// it shadows `println!`/`print!` for every module declared after it, which is
+// how the two global flags reach ~9 000 call sites without any command having
+// to remember to forward a parameter.
+#[macro_use]
+#[allow(unused_macros)]
+pub mod verbosity;
+
 mod commands;
 pub mod error;
 mod output;
@@ -95,11 +103,11 @@ pub struct Cli {
     #[arg(long, global = true)]
     pub json: bool,
 
-    /// Verbose output
+    /// Verbose output: dispatch resolution, plus per-command detail where there is more to show
     #[arg(short, long, global = true)]
     pub verbose: bool,
 
-    /// Quiet mode (errors only)
+    /// Quiet mode: suppress stdout (errors still go to stderr; --json still prints)
     #[arg(short, long, global = true)]
     pub quiet: bool,
 

--- a/crates/apr-cli/src/verbosity.rs
+++ b/crates/apr-cli/src/verbosity.rs
@@ -1,0 +1,478 @@
+//! Process-wide output level for `--quiet` / `--verbose` (dogfood-0.63.0, #2401).
+//!
+//! `-q, --quiet` and `-v, --verbose` are declared as clap **globals** on
+//! [`crate::Cli`], so clap prints them in the Options block of all 104
+//! subcommands' `--help`. Until this module existed nothing read them: in
+//! v0.63.0 `apr inspect m.apr` and `apr inspect m.apr --quiet` produced
+//! byte-identical stdout on 14 of 16 sampled commands, `apr hex m.apr
+//! --quiet` still wrote 303 972 bytes, and `apr gbnf-lint ... -q` still
+//! printed the full PASS report. Only `list` and `lint` — the two commands
+//! that happened to receive `quiet` as a parameter — honoured it.
+//!
+//! Threading a `quiet` parameter into every command is the design that
+//! already failed: it is the same forwarding bug `--offline` had (see
+//! [`crate::commands::offline`]), where three commands forgot to pass the
+//! flag along and the control was silently inert. So this is a **latch**,
+//! set once in [`crate::execute_command`], plus a crate-wide shadow of
+//! `println!`/`print!` that consults it. A command cannot disarm `--quiet`
+//! by forgetting to plumb a parameter, because it never receives one.
+//!
+//! Semantics:
+//!
+//! * `--quiet` suppresses ordinary stdout. stderr is untouched, so the
+//!   `error: ...` line printed by [`crate::cli_main`] and the process exit
+//!   code both survive — "errors only", as the help text promises.
+//! * `--quiet` does **not** suppress `--json`: the JSON document is the
+//!   machine-readable payload a script asked for, and swallowing it would
+//!   make `--json --quiet` useless. [`stdout_suppressed`] returns false
+//!   whenever `--json` is in effect.
+//! * A command that implements its own richer quiet semantics opts out of
+//!   the blanket gate with [`emitln!`]/[`emit!`]. Two do: `apr list --quiet`
+//!   must still print one model identifier per line (contract
+//!   `apr-list-quiet-wiring-v1` F-LIST-QUIET-001), and `apr lint --quiet`
+//!   filters its table down to errors rather than going silent.
+//! * `--verbose` raises the level so commands can print detail they
+//!   otherwise elide; see [`is_verbose`] and [`vprintln!`].
+//! * `--quiet` wins over `--verbose` when both are given.
+
+use std::cell::Cell;
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+
+/// How much ordinary stdout a run should produce.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Level {
+    /// `--quiet`: ordinary stdout suppressed.
+    Quiet,
+    /// Neither flag given.
+    Normal,
+    /// `--verbose`: commands may print elided detail.
+    Verbose,
+}
+
+impl Level {
+    const fn as_u8(self) -> u8 {
+        match self {
+            Level::Quiet => 0,
+            Level::Normal => 1,
+            Level::Verbose => 2,
+        }
+    }
+
+    const fn from_u8(v: u8) -> Level {
+        match v {
+            0 => Level::Quiet,
+            2 => Level::Verbose,
+            _ => Level::Normal,
+        }
+    }
+}
+
+/// Resolve the two flags into one level.
+///
+/// `--quiet` wins over `--verbose`: the pair used to be accepted with no
+/// error and no effect at all, so *some* rule is needed, and silencing is
+/// the safer of the two for anything reading the stream.
+#[must_use]
+pub fn resolve(quiet: bool, verbose: bool) -> Level {
+    if quiet {
+        Level::Quiet
+    } else if verbose {
+        Level::Verbose
+    } else {
+        Level::Normal
+    }
+}
+
+static PROCESS_LEVEL: AtomicU8 = AtomicU8::new(Level::Normal.as_u8());
+static PROCESS_JSON: AtomicBool = AtomicBool::new(false);
+
+thread_local! {
+    /// Thread-scoped override used by [`scope`] so tests can drive the gate
+    /// without mutating process-global state shared with ~6 600 siblings.
+    static THREAD_LEVEL: Cell<Option<Level>> = const { Cell::new(None) };
+    static THREAD_JSON: Cell<Option<bool>> = const { Cell::new(None) };
+}
+
+/// Record the run's output level. Called once from `execute_command`.
+///
+/// Never resets to [`Level::Normal`]: an in-process test that runs a second
+/// command must not be able to un-quiet a run the user asked to be quiet.
+pub fn latch(quiet: bool, verbose: bool, json: bool) {
+    match resolve(quiet, verbose) {
+        Level::Normal => {}
+        level => PROCESS_LEVEL.store(level.as_u8(), Ordering::SeqCst),
+    }
+    if json {
+        PROCESS_JSON.store(true, Ordering::SeqCst);
+    }
+}
+
+/// RAII guard returned by [`scope`]; restores the previous thread values.
+pub struct VerbosityScope(Option<Level>, Option<bool>);
+
+impl Drop for VerbosityScope {
+    fn drop(&mut self) {
+        THREAD_LEVEL.with(|c| c.set(self.0));
+        THREAD_JSON.with(|c| c.set(self.1));
+    }
+}
+
+/// Override the level for the current thread until the guard drops.
+#[must_use]
+pub fn scope(level: Level, json: bool) -> VerbosityScope {
+    let prev_level = THREAD_LEVEL.with(|c| c.replace(Some(level)));
+    let prev_json = THREAD_JSON.with(|c| c.replace(Some(json)));
+    VerbosityScope(prev_level, prev_json)
+}
+
+/// The level in effect for this call.
+#[must_use]
+pub fn level() -> Level {
+    if let Some(l) = THREAD_LEVEL.with(Cell::get) {
+        return l;
+    }
+    Level::from_u8(PROCESS_LEVEL.load(Ordering::SeqCst))
+}
+
+/// True iff `--json` is in effect for this call.
+#[must_use]
+pub fn json_enabled() -> bool {
+    if let Some(j) = THREAD_JSON.with(Cell::get) {
+        return j;
+    }
+    PROCESS_JSON.load(Ordering::SeqCst)
+}
+
+/// True iff `--quiet` was given.
+#[must_use]
+pub fn is_quiet() -> bool {
+    level() == Level::Quiet
+}
+
+/// True iff `--verbose` was given (and `--quiet` was not).
+#[must_use]
+pub fn is_verbose() -> bool {
+    level() == Level::Verbose
+}
+
+/// The single decision the shadowed `println!`/`print!` consult.
+///
+/// Quiet suppresses ordinary stdout, except when `--json` is in effect —
+/// the JSON document is the payload, not chatter.
+#[must_use]
+pub fn stdout_suppressed() -> bool {
+    !json_enabled() && is_quiet()
+}
+
+/// The `--verbose` preamble `execute_command` prints before dispatching.
+///
+/// `--verbose` was the other half of #2401: byte-inert on 13 of 16 sampled
+/// commands, because only `check`, `oracle` and `trace` ever received it as
+/// a parameter. Rather than invent per-command chatter for 104 commands,
+/// this reports what the *dispatcher* actually resolved and decided — facts
+/// the run already computed and then threw away:
+///
+/// * which model paths `extract_model_paths` pulled out of the parsed
+///   command, and their sizes on disk;
+/// * whether the PMAT-237 contract gate ran over them, was disabled with
+///   `--skip-contract`, or did not apply because the command is one of the
+///   diagnostic ones the gate deliberately exempts. That last line also
+///   explains the audit's separate observation that `--skip-contract` has
+///   "zero effect" on `inspect`/`validate`/`tensors`: there is nothing for
+///   it to skip there, and now the CLI says so instead of staying mute.
+/// * whether `--offline` is latched.
+///
+/// Pure so it can be asserted directly; the caller prints the lines.
+#[must_use]
+pub fn preamble_lines(
+    version: &str,
+    offline: bool,
+    skip_contract: bool,
+    paths: &[std::path::PathBuf],
+) -> Vec<String> {
+    let mut out = vec![format!("verbose: apr {version}")];
+    out.push(format!(
+        "verbose: offline = {}",
+        if offline { "on" } else { "off" }
+    ));
+    if skip_contract {
+        out.push("verbose: contract gate = skipped (--skip-contract)".to_string());
+    } else if paths.is_empty() {
+        out.push(
+            "verbose: contract gate = not applicable (no gated model path for this command)"
+                .to_string(),
+        );
+    } else {
+        out.push(format!(
+            "verbose: contract gate = enforced over {} path(s)",
+            paths.len()
+        ));
+    }
+    for p in paths {
+        let size = std::fs::metadata(p).map_or_else(
+            |_| "unreadable".to_string(),
+            |m| format!("{} bytes", m.len()),
+        );
+        out.push(format!("verbose: model = {} ({size})", p.display()));
+    }
+    out
+}
+
+/// Crate-wide shadow of `std::println!` that honours `--quiet`.
+///
+/// Declared with `#[macro_use] mod verbosity;` before `mod commands;` in
+/// `lib.rs`, so every `println!` in the ~9 000 call sites below that point
+/// resolves here instead of to the standard-library prelude. That is the
+/// whole point: `--quiet` cannot be forgotten by a command author, because
+/// there is nothing for a command author to remember.
+macro_rules! println {
+    () => {
+        if !$crate::verbosity::stdout_suppressed() { ::std::println!() }
+    };
+    ($($arg:tt)*) => {
+        if !$crate::verbosity::stdout_suppressed() { ::std::println!($($arg)*) }
+    };
+}
+
+/// Crate-wide shadow of `std::print!` that honours `--quiet`.
+macro_rules! print {
+    ($($arg:tt)*) => {
+        if !$crate::verbosity::stdout_suppressed() { ::std::print!($($arg)*) }
+    };
+}
+
+/// Print only under `--verbose`.
+macro_rules! vprintln {
+    ($($arg:tt)*) => {
+        if $crate::verbosity::is_verbose() { ::std::println!($($arg)*) }
+    };
+}
+
+/// Print regardless of `--quiet` — the opt-out for commands that implement
+/// their own quiet semantics (`apr list --quiet`, `apr lint --quiet`).
+macro_rules! emitln {
+    () => { ::std::println!() };
+    ($($arg:tt)*) => { ::std::println!($($arg)*) };
+}
+
+/// `print!` counterpart of [`emitln!`].
+macro_rules! emit {
+    ($($arg:tt)*) => { ::std::print!($($arg)*) };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn quiet_wins_over_verbose() {
+        assert_eq!(resolve(true, true), Level::Quiet);
+        assert_eq!(resolve(true, false), Level::Quiet);
+        assert_eq!(resolve(false, true), Level::Verbose);
+        assert_eq!(resolve(false, false), Level::Normal);
+    }
+
+    #[test]
+    fn default_level_prints() {
+        let _s = scope(Level::Normal, false);
+        assert!(!stdout_suppressed());
+        assert!(!is_quiet());
+        assert!(!is_verbose());
+    }
+
+    #[test]
+    fn quiet_suppresses_stdout() {
+        let _s = scope(Level::Quiet, false);
+        assert!(stdout_suppressed(), "--quiet must suppress ordinary stdout");
+    }
+
+    #[test]
+    fn json_survives_quiet() {
+        let _s = scope(Level::Quiet, true);
+        assert!(
+            !stdout_suppressed(),
+            "--json --quiet must still emit the JSON document"
+        );
+    }
+
+    #[test]
+    fn verbose_does_not_suppress() {
+        let _s = scope(Level::Verbose, false);
+        assert!(!stdout_suppressed());
+        assert!(is_verbose());
+    }
+
+    #[test]
+    fn scope_restores_previous_level() {
+        let baseline = level();
+        {
+            let _s = scope(Level::Quiet, false);
+            assert_eq!(level(), Level::Quiet);
+        }
+        assert_eq!(level(), baseline, "scope must restore on drop");
+    }
+
+    #[test]
+    fn preamble_reports_the_gate_decision_not_a_fixed_string() {
+        let none: Vec<std::path::PathBuf> = vec![];
+        let skipped = preamble_lines("9.9.9", false, true, &none);
+        let inapplicable = preamble_lines("9.9.9", false, false, &none);
+        let enforced = preamble_lines("9.9.9", true, false, &[std::path::PathBuf::from("/x.apr")]);
+
+        assert!(
+            skipped.iter().any(|l| l.contains("--skip-contract")),
+            "--skip-contract must be visible under --verbose, got {skipped:?}"
+        );
+        assert!(
+            inapplicable.iter().any(|l| l.contains("not applicable")),
+            "a command the gate exempts must say so rather than stay mute, got {inapplicable:?}"
+        );
+        assert!(
+            enforced.iter().any(|l| l.contains("enforced over 1 path")),
+            "an enforced gate must report its paths, got {enforced:?}"
+        );
+        assert!(
+            enforced.iter().any(|l| l.contains("/x.apr")),
+            "the resolved model path must be reported, got {enforced:?}"
+        );
+        assert!(
+            enforced.iter().any(|l| l.contains("offline = on")),
+            "--offline must be visible under --verbose, got {enforced:?}"
+        );
+        assert_ne!(
+            skipped, inapplicable,
+            "the three gate outcomes must be distinguishable"
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // Behavioural falsifiers for #2401.
+    //
+    // The unit tests above only prove the *decision function*. They cannot
+    // see the thing that was actually broken in v0.63.0: `execute_command`
+    // never recorded the flags, so the ~9 000 `println!` call sites below
+    // `mod commands;` printed regardless. Proving that needs a real command
+    // run end to end with real stdout.
+    //
+    // The level is a process-wide latch that deliberately cannot be un-set
+    // (an in-process test must not be able to un-quiet a run the user asked
+    // to be quiet), so each mode runs in its own child process — the same
+    // pattern `commands::offline` uses for the same reason.
+    //
+    // `gbnf-lint` is the audit's own repro from finding 1 and needs nothing
+    // but a small JSON file, so the falsifier is hermetic.
+    // ---------------------------------------------------------------
+
+    const CHILD_ENV: &str = "APR_VERBOSITY_LATCH_CHILD";
+    const BEGIN: &str = "<<<APR-2401-BEGIN>>>";
+    const END: &str = "<<<APR-2401-END>>>";
+    const TEST_PATH: &str =
+        "verbosity::tests::quiet_and_verbose_reach_a_command_that_never_receives_them";
+
+    /// The parent creates this once and hands the SAME path to all three
+    /// children. An earlier draft stamped the child's pid into the name, so
+    /// `normal` and `verbose` differed by the path alone and the
+    /// "--verbose is not a no-op" assertion passed while --verbose was
+    /// disabled — a test that would have locked the defect in. One path for
+    /// every mode makes the comparison a byte comparison, which is the
+    /// methodology the audit used.
+    const OBS_ENV: &str = "APR_VERBOSITY_OBS_FILE";
+
+    fn parent_observation_file() -> std::path::PathBuf {
+        let p = std::env::temp_dir().join(format!("apr-2401-obs-{}.json", std::process::id()));
+        std::fs::write(&p, r#"{"output":"{\"a\":1}","finish_reason":"stop"}"#)
+            .expect("write observation file");
+        p
+    }
+
+    /// Run `apr gbnf-lint` in this child with whichever flag the parent asked
+    /// for, going through the real `execute_command` so the latch is exercised.
+    fn child_runs_gbnf_lint(mode: &str) {
+        // `Commands` is a very large enum; parsing it on libtest's default
+        // stack overflows, exactly as `commands::offline`'s child does.
+        let mode = mode.to_string();
+        std::thread::Builder::new()
+            .stack_size(16 * 1024 * 1024)
+            .spawn(move || {
+                use clap::Parser;
+
+                let obs = std::env::var(OBS_ENV).expect("parent must hand down the same obs file");
+                let mut argv = vec!["apr", "gbnf-lint", "--observation-file", obs.as_str()];
+                match mode.as_str() {
+                    "quiet" => argv.push("--quiet"),
+                    "verbose" => argv.push("--verbose"),
+                    _ => {}
+                }
+                let cli = crate::Cli::parse_from(argv);
+                // Markers use `::std::println!` so they survive `--quiet` and
+                // give the parent an exact slice of the command's own stdout;
+                // libtest with --nocapture interleaves its own text otherwise.
+                ::std::println!("{BEGIN}");
+                crate::execute_command(&cli)
+                    .expect("gbnf-lint on a well-formed observation must succeed");
+                ::std::println!("{END}");
+            })
+            .expect("spawn")
+            .join()
+            .expect("gbnf-lint verbosity falsifier panicked");
+    }
+
+    fn run_child(mode: &str, obs: &std::path::Path) -> String {
+        let exe = std::env::current_exe().expect("current test binary");
+        let out = std::process::Command::new(exe)
+            .args(["--exact", TEST_PATH, "--nocapture", "--test-threads=1"])
+            .env(CHILD_ENV, mode)
+            .env(OBS_ENV, obs)
+            .output()
+            .expect("re-run this test binary as a child");
+        assert!(
+            out.status.success(),
+            "child ({mode}) failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        // libtest's own progress lines share this stdout, so slice out the
+        // marked region rather than trying to recognise them.
+        let all = String::from_utf8_lossy(&out.stdout).into_owned();
+        let start = all
+            .find(BEGIN)
+            .map(|i| i + BEGIN.len())
+            .unwrap_or_else(|| panic!("child ({mode}) never reached the command; got:\n{all}"));
+        let end = all[start..]
+            .find(END)
+            .unwrap_or_else(|| panic!("child ({mode}) never finished the command; got:\n{all}"));
+        all[start..start + end].trim().to_string()
+    }
+
+    #[test]
+    fn quiet_and_verbose_reach_a_command_that_never_receives_them() {
+        if let Ok(mode) = std::env::var(CHILD_ENV) {
+            child_runs_gbnf_lint(&mode);
+            return;
+        }
+
+        let obs = parent_observation_file();
+        let normal = run_child("normal", &obs);
+        let quiet = run_child("quiet", &obs);
+        let verbose = run_child("verbose", &obs);
+        let _ = std::fs::remove_file(&obs);
+
+        assert!(
+            normal.contains("gbnf-lint report"),
+            "control run must print the report, got:\n{normal}"
+        );
+        assert!(
+            quiet.is_empty(),
+            "--quiet must suppress the PASS report as its own help text promises \
+             (`Quiet mode (errors only)`); `apr gbnf-lint -q` still printed:\n{quiet}"
+        );
+        assert_ne!(
+            normal, verbose,
+            "--verbose must not be a byte-for-byte no-op; it was on 13 of 16 \
+             sampled commands in v0.63.0"
+        );
+        assert!(
+            verbose.contains("verbose: contract gate ="),
+            "--verbose must report the dispatcher's gate decision, got:\n{verbose}"
+        );
+    }
+}


### PR DESCRIPTION
Every apr subcommand's `--help` lists `-q, --quiet  Quiet mode (errors only)` and `-v, --verbose  Verbose output`. In 0.63.0 neither flag did anything on almost any of them. A user scripting `apr validate model.apr --quiet` to get a pass/fail got 22 KB of tables; `apr hex model.apr --quiet` still wrote 303 972 bytes; `apr gbnf-lint --observation-file f -q` still printed its full PASS report. Measured with `cmp -s` on captured stdout, 14 of 16 sampled commands were byte-identical with and without `--quiet`, and 13 of 16 with and without `--verbose`.

## Root cause

`crates/apr-cli/src/dispatch_run.rs:333` — `execute_command()` read `cli.offline` and `cli.json` and dropped `cli.quiet` and `cli.verbose` on the floor. Both are clap globals, so clap advertises them on all 104 subcommands, but consuming one meant threading a `quiet: bool` parameter into each command's signature. Exactly two commands were ever given one — `list` and `lint` — and those two are precisely the two the audit found working.

`contracts/apr-list-quiet-wiring-v1.yaml` fixed that one command back in April, and its own `why_5` named this gap verbatim: *"No contract formalizes 'every global flag must materially affect every subcommand'"*.

## Fix

Threading a parameter into 104 commands is the design that already failed — it is the same forwarding bug `--offline` had, where three commands forgot to pass the flag along. So `--quiet` is a **latch**, set once in `execute_command`, plus a crate-wide shadow of `println!`/`print!` declared before `mod commands;` so all ~9 000 call sites consult it. A command cannot disarm `--quiet` by forgetting to plumb a parameter, because it never receives one.

- stderr and the exit code are untouched, so "errors only" is now literally true
- `--json --quiet` still prints the JSON document
- the two commands with richer quiet semantics of their own opt out via `emitln!`: `apr list --quiet` keeps printing one identifier per line (F-LIST-QUIET-001) and `apr lint --quiet` keeps filtering its table to errors

`--verbose` gets the same latch and reports what the dispatcher itself resolved rather than inventing chatter for 104 commands: the model paths `extract_model_paths` pulled out, their size on disk, and which of the three contract-gate outcomes applied. That last line also answers the audit's separate observation that `--skip-contract` has "zero effect" on `inspect`/`validate`/`tensors` — there is nothing for it to skip on a command the PMAT-237 gate exempts, and the CLI now says so instead of staying mute:

```
$ apr check model.apr --verbose
verbose: apr 0.63.0
verbose: offline = off
verbose: contract gate = enforced over 1 path(s)
verbose: model = /home/noah/models/qwen2.5-coder-0.5b-instruct.apr (991907012 bytes)

$ apr check model.apr --verbose --skip-contract
verbose: contract gate = skipped (--skip-contract)

$ apr inspect model.apr --verbose
verbose: contract gate = not applicable (no gated model path for this command)
```

## Evidence

Same binary invocation, stdout bytes, before -> after:

| command | 0.5B APR base | `--quiet` | `--verbose` | 0.8B GGUF base | `--quiet` | `--verbose` |
|---|---|---|---|---|---|---|
| inspect | 1529 | 1529 -> **0** | 1529 -> **1651** | 6282 | 6282 -> **0** | 6282 -> **6404** |
| tensors | 29878 | 29878 -> **0** | 29878 -> **30000** | 28393 | 28393 -> **0** | 28393 -> **28515** |
| validate | 2855 | 2855 -> **0** | 2855 -> **2977** | 22858 | 22858 -> **0** | 22858 -> **22980** |
| tree | 25794 | 25794 -> **0** | 25794 -> **25916** | 24270 | 24270 -> **0** | 24270 -> **24392** |
| hex | 303972 | 303972 -> **0** | 303972 -> **304094** | 690273 | 690273 -> **0** | 690273 -> **690395** |
| debug | 771 | 771 -> **0** | 771 -> **893** | 923 | 923 -> **0** | 923 -> **1045** |

`explain`, `flow`, `oracle` and `gpu` likewise go to 0 under `--quiet` and gain the preamble under `--verbose`; `oracle`'s own +34 verbose bytes survive alongside it. `list --quiet` still shrinks 4807 -> 575 and `lint --quiet` 1930 -> 507. Errors are unaffected: `apr inspect /nope/missing.apr --quiet` still prints `error: File not found` and exits 3, and `--quiet` on the corrupt GGUF still exits 5. `-q -v` together, previously accepted with no error and no effect, now resolves to quiet.

## Mutation check

Removing the latch from `execute_command` and keeping the tests:

```
---- verbosity::tests::quiet_and_verbose_reach_a_command_that_never_receives_them
--quiet must suppress the PASS report as its own help text promises
(`Quiet mode (errors only)`); `apr gbnf-lint -q` still printed:
gbnf-lint report for /tmp/apr-2401-414795.json
  json:        Ok
  diagnostic:  (missing fields — classifier skipped)
  masking:     (missing fields — classifier skipped)
```

Disabling only the verbose preamble instead:

```
assertion `left != right` failed: --verbose must not be a byte-for-byte no-op
  left: "gbnf-lint report for /tmp/apr-2401-obs-1001521.json\n  json:        Ok..."
 right: "gbnf-lint report for /tmp/apr-2401-obs-1001521.json\n  json:        Ok..."
```

That second RED only appeared **after fixing the test**. The first draft gave each child process a pid-stamped observation file, so `normal` and `verbose` differed by the temp path alone and the `assert_ne!` passed while `--verbose` was disabled — a test that would have locked the defect in. All three children now share one path, so the comparison is a byte comparison, which is the methodology the audit used.

The falsifier runs the real `execute_command` end to end in child processes, because the level is a process-wide latch that deliberately cannot be un-set — the same pattern `commands::offline` uses for the same reason. `gbnf-lint` is the audit's own repro from finding 1 and needs only a small JSON file, so it stays hermetic.

## Gates

- `cargo fmt --all -- --check` clean
- `cargo clippy -p apr-cli --lib -- -D warnings` clean
- `cargo test -p apr-cli --lib` 6663 passed, 0 failed
- `cargo test -p aprender-contracts --lib` 1420 passed, 0 failed
- `pv validate contracts/apr-global-verbosity-wiring-v1.yaml` 0 errors, 0 warnings; `pv score` Falsify 1.00

All CLI evidence above was produced with the release binary built from this branch (`apr 0.63.0 (8cc3aafeb)` + these commits), not from a unit test.

Note for reviewers: the shared cargo target dir on this box held a zero-byte `libprovable_contracts-*.rmeta` from an interrupted build, which made `apr-cli` fail to compile with a spurious `E0463: can't find crate for provable_contracts`. That is environmental, reproduces on unmodified `main`, and is cleared by forcing a rebuild of `aprender-contracts`.

Fixes #2401
Audit epic: #2373
