### PR TITLE
fix(profile): apr profile ignored --warmup/--measure/--json and matched --focus against names it never emits

### DIFF
--- a/crates/apr-cli/src/commands/diff_benchmark_report.rs
+++ b/crates/apr-cli/src/commands/diff_benchmark_report.rs
@@ -26,12 +26,13 @@ pub(crate) fn run(
     callgraph: bool,
     fail_on_naive: bool,
     output_path: Option<&Path>,
+    warmup_passes: usize,
+    measure_passes: usize,
     tokens: usize,
     ollama: bool,
     no_gpu: bool,
 ) -> Result<(), CliError> {
     // GH-517: Warn on unimplemented profiler flags (suppress unused warnings)
-    let _ = naive_threshold;
     if compare_hf.is_some() {
         eprintln!("Warning: --compare-hf is not yet implemented. Flag ignored.");
     }
@@ -41,9 +42,10 @@ pub(crate) fn run(
     if callgraph {
         eprintln!("Warning: --callgraph is not yet implemented. Flag ignored.");
     }
-    if fail_on_naive {
-        eprintln!("Warning: --fail-on-naive is not yet implemented. Flag ignored.");
-    }
+    // GH-2395: --fail-on-naive used to print "not yet implemented. Flag ignored."
+    // and return 0 unconditionally, so a CI job gating on it could never fail.
+    // It now runs the detection (implying --detect-naive) and exits non-zero.
+    let detect_naive = detect_naive || fail_on_naive;
 
     // Validate file exists
     if !path.exists() {
@@ -87,7 +89,7 @@ pub(crate) fn run(
             let gpu_result = std::thread::Builder::new()
                 .name("gpu-profile".into())
                 .stack_size(16 * 1024 * 1024)
-                .spawn(move || profile_gpu_generation(&path_owned, tokens, 3, 10))
+                .spawn(move || profile_gpu_generation(&path_owned, tokens, warmup_passes, measure_passes))
                 .map_err(|e| CliError::ValidationFailed(format!("Failed to spawn profiling thread: {e}")))?
                 .join()
                 .map_err(|_| CliError::ValidationFailed("GPU profiling thread panicked".into()))?;
@@ -110,12 +112,13 @@ pub(crate) fn run(
         if let Some(r) = gpu_fallback_result {
             r
         } else {
-            profile_real_inference_cpu(path, 3, 10)?
+            profile_real_inference_cpu(path, warmup_passes, measure_passes)?
         }
     };
 
     #[cfg(not(feature = "inference"))]
     let mut results = {
+        let _ = (warmup_passes, measure_passes);
         output::warn("Inference feature not enabled. Cannot run real profiling.");
         output::warn("Build with: cargo build --features inference");
         return Err(CliError::ValidationFailed(
@@ -124,6 +127,19 @@ pub(crate) fn run(
     };
 
     let profile_time = start.elapsed();
+
+    // GH-2395: --tokens drives multi-token generation on the GPU path and the
+    // ollama comparison only. The CPU per-operation path measures one forward
+    // pass per measurement pass, so say so instead of discarding the value in
+    // silence and reporting numbers the user did not ask for.
+    #[cfg(feature = "inference")]
+    if tokens != 1 && results.backend == "cpu" {
+        eprintln!(
+            "Warning: --tokens {tokens} has no effect on the CPU per-operation profiler, \
+             which measures one forward pass per measurement pass. Use --measure to change \
+             the number of samples."
+        );
+    }
 
     // Compute roofline analysis
     #[cfg(feature = "inference")]
@@ -134,8 +150,10 @@ pub(crate) fn run(
     // GH-173: Apply focus filtering to results (PMAT-182)
     let filtered_results = filter_results_by_focus(&results, focus);
 
-    // Show focus filter if applied
-    if !matches!(focus, ProfileFocus::All) {
+    // Show focus filter if applied. GH-2395: only in Human mode — this used to
+    // print unconditionally, so `--format json --focus mlp` put "  Focus filter: Mlp"
+    // on stdout ahead of the JSON body.
+    if !matches!(focus, ProfileFocus::All) && matches!(format, OutputFormat::Human) {
         output::kv("Focus filter", format!("{:?}", focus));
         println!();
     }
@@ -153,10 +171,30 @@ pub(crate) fn run(
         granular,
         perf_grade,
         detect_naive,
+        naive_threshold,
         ollama_baseline.as_ref(),
         output_path,
         profile_time,
-    )
+    )?;
+
+    // GH-2395: the exit-code contract `--fail-on-naive` advertises. Evaluated on
+    // the UNFILTERED results — `--focus` narrows the report, not the verdict.
+    if fail_on_naive {
+        let suspicions = detect_naive_implementations(&results, naive_threshold);
+        if !suspicions.is_empty() {
+            return Err(CliError::ValidationFailed(format!(
+                "naive implementation detected ({} signal(s)): {}",
+                suspicions.len(),
+                suspicions
+                    .iter()
+                    .map(|s| s.reason.as_str())
+                    .collect::<Vec<_>>()
+                    .join("; ")
+            )));
+        }
+    }
+
+    Ok(())
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -166,13 +204,14 @@ fn print_profile_output(
     granular: bool,
     perf_grade: bool,
     detect_naive: bool,
+    naive_threshold: f64,
     ollama_baseline: Option<&OllamaBaseline>,
     output_path: Option<&Path>,
     profile_time: std::time::Duration,
 ) -> Result<(), CliError> {
     match format {
         OutputFormat::Human => {
-            print_human_results(results, granular, perf_grade, detect_naive)?;
+            print_human_results(results, granular, perf_grade, detect_naive, naive_threshold)?;
             if let Some(baseline) = ollama_baseline {
                 print_ollama_comparison(results, baseline);
             }

--- a/crates/apr-cli/src/commands/profile.rs
+++ b/crates/apr-cli/src/commands/profile.rs
@@ -151,6 +151,23 @@ impl CiProfileReport {
         // Convert us to ms for latency
         let latency_ms = results.total_inference_us / 1000.0;
 
+        // GH-2395: the measurement passes DO produce a latency distribution
+        // (`latency_p50_ms` / `latency_p99_ms` are real percentiles over the
+        // per-pass forward times). CI mode used the mean for both, so p99 always
+        // equalled p50 and `--assert-p99` asserted on the mean, not the tail —
+        // a tail-only regression could never fail the gate. Fall back to the mean
+        // only when no percentiles were recorded (e.g. static-analysis backend).
+        let p50_ms = if results.latency_p50_ms > 0.0 {
+            results.latency_p50_ms
+        } else {
+            latency_ms
+        };
+        let p99_ms = if results.latency_p99_ms > 0.0 {
+            results.latency_p99_ms
+        } else {
+            latency_ms
+        };
+
         // Check throughput assertion
         if let Some(min_tps) = assertions.min_throughput {
             let passed = results.throughput_tok_s >= min_tps;
@@ -165,30 +182,30 @@ impl CiProfileReport {
             });
         }
 
-        // Check p99 assertion (using avg as proxy since we don't have percentiles yet)
+        // Check p99 assertion against the real tail
         if let Some(max_p99) = assertions.max_p99_ms {
-            let passed = latency_ms <= max_p99;
+            let passed = p99_ms <= max_p99;
             if !passed {
                 all_passed = false;
             }
             assertion_results.push(AssertionResult {
                 name: "latency_p99".to_string(),
                 expected: format!("<= {:.1} ms", max_p99),
-                actual: format!("{:.2} ms", latency_ms),
+                actual: format!("{:.2} ms", p99_ms),
                 passed,
             });
         }
 
         // Check p50 assertion
         if let Some(max_p50) = assertions.max_p50_ms {
-            let passed = latency_ms <= max_p50;
+            let passed = p50_ms <= max_p50;
             if !passed {
                 all_passed = false;
             }
             assertion_results.push(AssertionResult {
                 name: "latency_p50".to_string(),
                 expected: format!("<= {:.1} ms", max_p50),
-                actual: format!("{:.2} ms", latency_ms),
+                actual: format!("{:.2} ms", p50_ms),
                 passed,
             });
         }
@@ -197,8 +214,8 @@ impl CiProfileReport {
             model_path: results.model_path.clone(),
             passed: all_passed,
             throughput_tok_s: results.throughput_tok_s,
-            latency_p50_ms: latency_ms,
-            latency_p99_ms: latency_ms, // Using same value for now
+            latency_p50_ms: p50_ms,
+            latency_p99_ms: p99_ms,
             assertions: assertion_results,
         }
     }
@@ -447,6 +464,7 @@ fn percentile(sorted: &[f64], p: f64) -> f64 {
     }
 }
 
+include!("profile_options.rs");
 include!("diff_benchmark_report.rs");
 include!("profile_pct_change_classify.rs");
 include!("kernel.rs");

--- a/crates/apr-cli/src/commands/profile_09.rs
+++ b/crates/apr-cli/src/commands/profile_09.rs
@@ -12,4 +12,5 @@ include!("profile_profile.rs");
 include!("profile_print_flamegraph.rs");
 include!("profile_filter_mlp.rs");
 include!("profile_pct_change_classify_tests.rs");
+include!("profile_gh2395_tests.rs");
 }

--- a/crates/apr-cli/src/commands/profile_file.rs
+++ b/crates/apr-cli/src/commands/profile_file.rs
@@ -20,6 +20,8 @@
             false, // callgraph
             false, // fail_on_naive
             None,  // output_path
+            3,     // warmup passes
+            10,    // measure passes
             32,    // tokens
             false, // ollama
             true,  // no_gpu
@@ -45,6 +47,8 @@
             false,
             false,
             None,
+            3,
+            10,
             32,
             false,
             true,
@@ -71,6 +75,8 @@
             false,
             false,
             None,
+            3,
+            10,
             32,
             false,
             true,
@@ -97,6 +103,8 @@
             false,
             false,
             None,
+            3,
+            10,
             32,
             false,
             true,
@@ -123,6 +131,8 @@
             false,
             false,
             None,
+            3,
+            10,
             32,
             false,
             true,
@@ -149,6 +159,8 @@
             false,
             false,
             None,
+            3,
+            10,
             32,
             false,
             true,

--- a/crates/apr-cli/src/commands/profile_gh2395_tests.rs
+++ b/crates/apr-cli/src/commands/profile_gh2395_tests.rs
@@ -1,0 +1,445 @@
+    // ========================================================================
+    // GH-2395: `apr profile` defects found by dogfooding crates.io 0.63.0.
+    //
+    // These assert BEHAVIOUR against the operation names the profiler actually
+    // emits. The pre-existing focus tests fed synthetic hotspots literally named
+    // "up_proj" / "down_proj" / "mm_q4k", which the snake_case keyword table
+    // matched — so they passed for two releases while `--focus mlp` on a real
+    // model kept 1 of 4 FFN operations.
+    // ========================================================================
+
+    /// The CamelCase operation names `BrickProfiler` emits for a qwen2 decode,
+    /// taken verbatim from `apr profile <gguf>` on the 1.5B fixture.
+    fn real_decode_hotspot_names() -> Vec<(&'static str, f64)> {
+        vec![
+            ("GateProjection", 23.2),
+            ("UpProjection", 23.0),
+            ("DownProjection", 20.6),
+            ("QkvProjection", 15.2),
+            ("OutputProjection", 13.2),
+            ("LmHead", 2.4),
+            ("Activation", 1.4),
+            ("RopeEmbedding", 0.5),
+            ("Embedding", 0.1),
+            ("RmsNorm", 0.4),
+            ("AttentionScore", 0.3),
+        ]
+    }
+
+    fn results_with_real_names() -> RealProfileResults {
+        let hotspots = real_decode_hotspot_names()
+            .into_iter()
+            .map(|(name, percent)| Hotspot {
+                name: name.to_string(),
+                time_us: percent * 1000.0,
+                percent,
+                count: 280,
+                avg_us: percent * 10.0,
+                min_us: 0.0,
+                max_us: 0.0,
+                bottleneck: None,
+                efficiency_pct: None,
+                category: None,
+                bandwidth_gbs: None,
+                data_bytes_per_call: None,
+            })
+            .collect();
+        RealProfileResults {
+            model_path: "qwen2-1.5b.gguf".to_string(),
+            architecture: "qwen2".to_string(),
+            num_layers: 28,
+            vocab_size: 151_936,
+            hidden_dim: 1536,
+            warmup_passes: 3,
+            measure_passes: 10,
+            total_inference_us: 100_000.0,
+            throughput_tok_s: 18.9,
+            tokens_per_pass: 1,
+            hotspots,
+            per_layer_us: vec![],
+            is_real_data: true,
+            roofline: None,
+            category_summary: None,
+            backend: "cpu".to_string(),
+            ..Default::default()
+        }
+    }
+
+    fn filtered_names(focus: ProfileFocus) -> Vec<String> {
+        filter_results_by_focus(&results_with_real_names(), focus)
+            .hotspots
+            .iter()
+            .map(|h| h.name.clone())
+            .collect()
+    }
+
+    #[test]
+    fn test_gh2395_focus_mlp_keeps_all_four_real_ffn_ops() {
+        // 0.63.0 kept ONLY GateProjection: "upprojection" does not contain
+        // "up_proj" and "downprojection" does not contain "down_proj".
+        let names = filtered_names(ProfileFocus::Mlp);
+        for expected in ["GateProjection", "UpProjection", "DownProjection", "Activation"] {
+            assert!(
+                names.iter().any(|n| n == expected),
+                "--focus mlp dropped {expected}; kept {names:?}"
+            );
+        }
+        assert!(
+            !names.iter().any(|n| n == "QkvProjection"),
+            "--focus mlp must not keep attention ops; kept {names:?}"
+        );
+    }
+
+    #[test]
+    fn test_gh2395_focus_matmul_is_not_empty() {
+        // 0.63.0 returned an EMPTY table with exit 0: no emitted name contains
+        // "matmul", "gemm" or "linear".
+        let names = filtered_names(ProfileFocus::Matmul);
+        assert!(
+            !names.is_empty(),
+            "--focus matmul returned an empty hotspot table"
+        );
+        for expected in ["QkvProjection", "UpProjection", "DownProjection", "LmHead"] {
+            assert!(
+                names.iter().any(|n| n == expected),
+                "--focus matmul dropped the weight-matrix op {expected}; kept {names:?}"
+            );
+        }
+        assert!(
+            !names.iter().any(|n| n == "Activation" || n == "RmsNorm"),
+            "--focus matmul must not keep elementwise ops; kept {names:?}"
+        );
+    }
+
+    #[test]
+    fn test_gh2395_focus_attention_keeps_output_projection() {
+        // 0.63.0 kept only QkvProjection + AttentionScore; OutputProjection (13.2%
+        // of decode) was silently dropped from the attention view.
+        let names = filtered_names(ProfileFocus::Attention);
+        for expected in ["QkvProjection", "AttentionScore", "OutputProjection"] {
+            assert!(
+                names.iter().any(|n| n == expected),
+                "--focus attention dropped {expected}; kept {names:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_gh2395_focus_embedding_keeps_lm_head_and_drops_rope() {
+        // 0.63.0 inverted this: it captured RopeEmbedding (positional encoding)
+        // and missed LmHead (the vocabulary projection, 27402µs — the largest
+        // genuinely embedding-adjacent op).
+        let names = filtered_names(ProfileFocus::Embedding);
+        assert!(
+            names.iter().any(|n| n == "LmHead"),
+            "--focus embedding dropped LmHead; kept {names:?}"
+        );
+        assert!(
+            names.iter().any(|n| n == "Embedding"),
+            "--focus embedding dropped Embedding; kept {names:?}"
+        );
+        assert!(
+            !names.iter().any(|n| n == "RopeEmbedding"),
+            "RopeEmbedding is positional encoding, not an embedding-table op; kept {names:?}"
+        );
+    }
+
+    #[test]
+    fn test_gh2395_focused_table_prints_share_of_total_not_of_survivors() {
+        // This is the number the hotspot TABLE prints. 0.63.0 divided each row's
+        // time by the sum over the rows it was about to print, so after --focus
+        // dropped every row but one, the survivor printed as "100.0%" of a model
+        // whose Category Summary put FFN at 70.5%.
+        let filtered = filter_results_by_focus(&results_with_real_names(), ProfileFocus::Mlp);
+        let percents = hotspot_display_percents(&filtered.hotspots);
+        let sum: f64 = percents.iter().sum();
+        assert!(
+            (sum - 68.2).abs() < 0.5,
+            "the focused table must still sum to the FFN share of total (~68.2%), got {sum:.1}%"
+        );
+        assert!(
+            percents.iter().all(|p| *p < 99.0),
+            "no single focused row may print as ~100%: {percents:?}"
+        );
+
+        // Degenerate case: --focus down to exactly one row.
+        let one = RealProfileResults {
+            hotspots: vec![filtered.hotspots[0].clone()],
+            ..results_with_real_names()
+        };
+        let p = hotspot_display_percents(&one.hotspots);
+        assert!(
+            (p[0] - 23.2).abs() < 1e-6,
+            "a lone surviving row must keep its 23.2% share of total, printed {:.1}%",
+            p[0]
+        );
+    }
+
+    #[test]
+    fn test_gh2395_table_falls_back_to_local_share_when_no_percent_recorded() {
+        // Results built without recorded percentages (older snapshots, synthetic
+        // instrumentation) must still produce a usable table.
+        let hotspots: Vec<Hotspot> = [("A", 750.0), ("B", 250.0)]
+            .iter()
+            .map(|(name, t)| Hotspot {
+                name: (*name).to_string(),
+                time_us: *t,
+                percent: 0.0,
+                count: 1,
+                avg_us: *t,
+                min_us: *t,
+                max_us: *t,
+                bottleneck: None,
+                efficiency_pct: None,
+                category: None,
+                bandwidth_gbs: None,
+                data_bytes_per_call: None,
+            })
+            .collect();
+        let p = hotspot_display_percents(&hotspots);
+        assert!((p[0] - 75.0).abs() < 1e-6, "{p:?}");
+        assert!((p[1] - 25.0).abs() < 1e-6, "{p:?}");
+        assert!(hotspot_display_percents(&[]).is_empty());
+    }
+
+    #[test]
+    fn test_gh2395_unknown_focus_is_rejected_not_ignored() {
+        // 0.63.0 fell back to the full unfiltered report with exit 0.
+        assert!(resolve_focus(Some("bogus")).is_err());
+        assert!(resolve_focus(Some("mlpp")).is_err());
+        assert!(resolve_focus(Some("")).is_err());
+        // Documented values still resolve.
+        for ok in ["all", "attention", "attn", "mlp", "ffn", "matmul", "gemm", "embedding"] {
+            assert!(resolve_focus(Some(ok)).is_ok(), "--focus {ok} must be accepted");
+        }
+        assert!(matches!(resolve_focus(None), Ok(ProfileFocus::All)));
+    }
+
+    #[test]
+    fn test_gh2395_global_json_flag_selects_json_output() {
+        // 0.63.0 parsed the global --json (it is `global = true` on `Cli`) and
+        // printed the human table anyway, while `apr bench --json` honoured it.
+        assert!(matches!(
+            resolve_output_format("human", true),
+            Ok(OutputFormat::Json)
+        ));
+        assert!(matches!(
+            resolve_output_format("human", false),
+            Ok(OutputFormat::Human)
+        ));
+        assert!(matches!(
+            resolve_output_format("flamegraph", false),
+            Ok(OutputFormat::Flamegraph)
+        ));
+    }
+
+    #[test]
+    fn test_gh2395_unknown_format_is_rejected_not_silently_human() {
+        assert!(resolve_output_format("jsonn", false).is_err());
+        assert!(resolve_output_format("", false).is_err());
+    }
+
+    // ------------------------------------------------------------------
+    // CI mode percentiles
+    // ------------------------------------------------------------------
+
+    fn ci_results_with_spread() -> RealProfileResults {
+        // Numbers from the issue's non-CI run on the same model/binary:
+        // p50=120.2 p95=132.6 p99=136.3 min=99.2 max=137.2, mean 105.96ms.
+        RealProfileResults {
+            total_inference_us: 105_960.0,
+            throughput_tok_s: 18.9,
+            latency_p50_ms: 120.2,
+            latency_p95_ms: 132.6,
+            latency_p99_ms: 136.3,
+            latency_min_ms: 99.2,
+            latency_max_ms: 137.2,
+            measure_passes: 10,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_gh2395_ci_p99_is_the_tail_not_the_mean() {
+        // 0.63.0 assigned the mean to BOTH percentiles, so `--assert-p99` was
+        // asserting on a single averaged sample and p50 always equalled p99.
+        let report = CiProfileReport::from_results(
+            &ci_results_with_spread(),
+            &CiAssertions {
+                min_throughput: None,
+                max_p99_ms: None,
+                max_p50_ms: None,
+                max_memory_mb: None,
+            },
+        );
+        assert!(
+            (report.latency_p99_ms - 136.3).abs() < 1e-6,
+            "CI p99 must be the measured tail, got {}",
+            report.latency_p99_ms
+        );
+        assert!(
+            (report.latency_p50_ms - 120.2).abs() < 1e-6,
+            "CI p50 must be the measured median, got {}",
+            report.latency_p50_ms
+        );
+        assert!(
+            report.latency_p99_ms > report.latency_p50_ms,
+            "p99 ({}) collapsed onto p50 ({})",
+            report.latency_p99_ms,
+            report.latency_p50_ms
+        );
+    }
+
+    #[test]
+    fn test_gh2395_assert_p99_fails_on_a_tail_only_regression() {
+        // The behavioural consequence: a budget of 130ms sits ABOVE the mean
+        // (105.96) and BELOW the real tail (136.3). 0.63.0 compared against the
+        // mean and passed, so a tail-only regression could never fail the gate.
+        let report = CiProfileReport::from_results(
+            &ci_results_with_spread(),
+            &CiAssertions {
+                min_throughput: None,
+                max_p99_ms: Some(130.0),
+                max_p50_ms: None,
+                max_memory_mb: None,
+            },
+        );
+        assert!(
+            !report.passed,
+            "--assert-p99 130 must FAIL when the measured p99 is 136.3ms"
+        );
+        let a = report
+            .assertions
+            .iter()
+            .find(|a| a.name == "latency_p99")
+            .expect("p99 assertion recorded");
+        assert!(
+            a.actual.starts_with("136.3"),
+            "p99 assertion reported {} instead of the tail",
+            a.actual
+        );
+    }
+
+    #[test]
+    fn test_gh2395_ci_falls_back_to_mean_when_no_percentiles_recorded() {
+        // The static-analysis backend records no per-pass times; the mean is then
+        // the only honest number available.
+        let results = RealProfileResults {
+            total_inference_us: 50_000.0,
+            ..Default::default()
+        };
+        let report = CiProfileReport::from_results(
+            &results,
+            &CiAssertions {
+                min_throughput: None,
+                max_p99_ms: None,
+                max_p50_ms: None,
+                max_memory_mb: None,
+            },
+        );
+        assert!((report.latency_p99_ms - 50.0).abs() < 1e-6);
+        assert!((report.latency_p50_ms - 50.0).abs() < 1e-6);
+    }
+
+    // ------------------------------------------------------------------
+    // --detect-naive / --fail-on-naive
+    // ------------------------------------------------------------------
+
+    fn results_with_achieved_gflops(gflops: f64) -> RealProfileResults {
+        let mut r = results_with_real_names();
+        r.roofline = Some(RooflineAnalysis {
+            peak_compute: 2304.0,
+            peak_bandwidth_gbps: 80.0,
+            achieved_gflops: gflops,
+            achieved_bandwidth_gbps: 60.0,
+            arithmetic_intensity: 0.3,
+            ai_threshold: 28.8,
+            bottleneck: "MEMORY BOUND".to_string(),
+            hardware_model: "AMD Ryzen (24 cores, 512-bit SIMD)".to_string(),
+            ..Default::default()
+        });
+        r
+    }
+
+    #[test]
+    fn test_gh2395_threshold_drives_the_naive_verdict() {
+        // 0.63.0 did `let _ = naive_threshold;` — `--threshold 100000` against a
+        // run achieving 22.1 GFLOPS still reported "No obvious naive
+        // implementations detected".
+        let r = results_with_achieved_gflops(22.1);
+        assert!(
+            detect_naive_implementations(&r, 10.0).is_empty(),
+            "22.1 GFLOPS clears the default 10.0 floor"
+        );
+        let flagged = detect_naive_implementations(&r, 100_000.0);
+        assert!(
+            !flagged.is_empty(),
+            "--threshold 100000 must flag a 22.1 GFLOPS run"
+        );
+        assert!(
+            flagged[0].reason.contains("22.1")&& flagged[0].reason.contains("100000"),
+            "the reason must name both numbers, got {:?}",
+            flagged[0].reason
+        );
+    }
+
+    #[test]
+    fn test_gh2395_dominant_op_still_flagged_without_a_roofline() {
+        let mut r = results_with_real_names();
+        r.roofline = None;
+        r.hotspots[0].avg_us = r.total_inference_us * 0.9;
+        assert!(!detect_naive_implementations(&r, 0.0).is_empty());
+    }
+
+    // ------------------------------------------------------------------
+    // Hardware identity in the roofline block
+    // ------------------------------------------------------------------
+
+    #[test]
+    #[cfg(feature = "inference")]
+    fn test_gh2395_cpuinfo_vendor_and_model_are_resolved() {
+        // 0.63.0 printed `Hardware: Unknown Unknown (24 cores, 512)` beside the
+        // peak GFLOPS/bandwidth figures that justify the MEMORY BOUND verdict.
+        let amd = "processor\t: 0\nvendor_id\t: AuthenticAMD\ncpu family\t: 25\n\
+                   model name\t: AMD Ryzen 9 7900X 12-Core Processor\n";
+        assert_eq!(
+            trueno::hardware::parse_cpuinfo(amd),
+            (
+                Some("AMD".to_string()),
+                Some("AMD Ryzen 9 7900X 12-Core Processor".to_string())
+            )
+        );
+
+        let intel = "vendor_id\t: GenuineIntel\nmodel name\t: Intel(R) Core(TM) i9-13900K\n";
+        assert_eq!(
+            trueno::hardware::parse_cpuinfo(intel).0,
+            Some("Intel".to_string())
+        );
+
+        // aarch64 kernels expose no vendor_id / model name.
+        let arm = "processor\t: 0\nCPU implementer\t: 0x41\nCPU part\t: 0xd4c\n";
+        assert_eq!(trueno::hardware::parse_cpuinfo(arm).0, Some("ARM".to_string()));
+
+        // Nothing parseable stays honest rather than inventing a vendor.
+        assert_eq!(trueno::hardware::parse_cpuinfo(""), (None, None));
+    }
+
+    #[test]
+    fn test_gh2395_hardware_label_names_the_cpu_and_units_the_simd_width() {
+        // 0.63.0: "Unknown Unknown (24 cores, 512)".
+        assert_eq!(
+            cpu_hardware_label("AMD", "AMD Ryzen Threadripper 7960X 24-Cores", 24, 512),
+            "AMD Ryzen Threadripper 7960X 24-Cores (24 cores, 512-bit SIMD)"
+        );
+        // Vendor is prepended only when the model does not already carry it.
+        assert_eq!(
+            cpu_hardware_label("Intel", "Core i9-13900K", 24, 256),
+            "Intel Core i9-13900K (24 cores, 256-bit SIMD)"
+        );
+        // Unresolvable model must not print "Unknown Unknown".
+        assert_eq!(
+            cpu_hardware_label("ARM", "Unknown", 8, 128),
+            "ARM (8 cores, 128-bit SIMD)"
+        );
+        assert!(!cpu_hardware_label("Unknown", "Unknown", 24, 512).contains("Unknown Unknown"));
+    }

--- a/crates/apr-cli/src/commands/profile_ollama.rs
+++ b/crates/apr-cli/src/commands/profile_ollama.rs
@@ -318,12 +318,14 @@ fn roofline_hardware_specs(is_gpu: bool) -> (f64, f64, f64, String) {
             hw.cpu.peak_gflops,
             hw.cpu.memory_bw_gbps,
             hw.roofline.cpu_arithmetic_intensity,
-            format!(
-                "{} {} ({} cores, {})",
-                hw.cpu.vendor,
-                hw.cpu.model,
+            // GH-2395: this read `Unknown Unknown (24 cores, 512)` — vendor and
+            // model unresolved, and the SIMD width printed as a bare "512" with no
+            // unit, in the same parenthesis as a core count.
+            cpu_hardware_label(
+                &hw.cpu.vendor,
+                &hw.cpu.model,
                 hw.cpu.cores,
-                hw.cpu.simd.bits()
+                hw.cpu.simd.bits(),
             ),
         )
     }

--- a/crates/apr-cli/src/commands/profile_options.rs
+++ b/crates/apr-cli/src/commands/profile_options.rs
@@ -1,0 +1,57 @@
+// GH-2395: option resolution for `apr profile`, kept pure so it can be falsified
+// without loading a model.
+//
+// Every defect these functions guard shipped in 0.63.0:
+//   * `--json` is a global flag; `apr bench --json` honours it and `apr profile
+//     --json` printed the human table.
+//   * an unparseable `--format` silently degraded to Human, so `--format jsonn`
+//     produced a human table that a `| jq` pipeline choked on.
+//   * an unrecognised `--focus` silently degraded to the full unfiltered report
+//     with exit 0, so a typo answered a different question than the one asked.
+
+/// Resolve the effective output format from `--format` plus the global `--json`.
+///
+/// `--json` wins, because it is the flag the rest of the CLI uses for
+/// machine-readable output.
+pub(crate) fn resolve_output_format(format: &str, json: bool) -> Result<OutputFormat, CliError> {
+    if json {
+        return Ok(OutputFormat::Json);
+    }
+    format.parse().map_err(|_| {
+        CliError::ValidationFailed(format!(
+            "Unknown --format value '{format}'. Valid values: human (text), json, flamegraph (svg)"
+        ))
+    })
+}
+
+/// Build the `Hardware:` label for the roofline block.
+///
+/// The model string usually already carries the vendor ("AMD Ryzen Threadripper
+/// 7960X"), so repeating it would print "AMD AMD Ryzen …".
+pub(crate) fn cpu_hardware_label(
+    vendor: &str,
+    model: &str,
+    cores: usize,
+    simd_bits: usize,
+) -> String {
+    let name = if model.is_empty() || model == "Unknown" {
+        vendor.to_string()
+    } else if model.to_lowercase().starts_with(&vendor.to_lowercase()) {
+        model.to_string()
+    } else {
+        format!("{vendor} {model}")
+    };
+    format!("{name} ({cores} cores, {simd_bits}-bit SIMD)")
+}
+
+/// Resolve `--focus`, rejecting values that name no focus area.
+pub(crate) fn resolve_focus(focus: Option<&str>) -> Result<ProfileFocus, CliError> {
+    match focus {
+        None => Ok(ProfileFocus::All),
+        Some(f) => f.parse().map_err(|_| {
+            CliError::ValidationFailed(format!(
+                "Unknown --focus value '{f}'. Valid values: all, attention, mlp (ffn), matmul (gemm), embedding"
+            ))
+        }),
+    }
+}

--- a/crates/apr-cli/src/commands/profile_pct_change_classify.rs
+++ b/crates/apr-cli/src/commands/profile_pct_change_classify.rs
@@ -154,15 +154,118 @@ pub(crate) fn run_diff_benchmark(
     }
 }
 
+/// Every operation name the profilers actually emit.
+///
+/// GH-2395: `--focus` used to be a snake_case keyword match (`up_proj`, `down_proj`,
+/// `matmul`, `lm_head`) applied to the CamelCase names `BrickProfiler` emits.
+/// Lowercased, "upprojection" does not contain "up_proj" and nothing at all
+/// contains "matmul", so `--focus mlp` kept 1 of 4 FFN ops and `--focus matmul`
+/// returned an empty table with exit 0. When a hotspot carries one of these known
+/// names, membership decides the filter; keyword matching is only the fallback for
+/// unrecognised names (custom/synthetic instrumentation).
+const KNOWN_OP_NAMES: &[&str] = &[
+    // Attention (GPU brick names + CPU brick names)
+    "QKV",
+    "QkvProjection",
+    "AttentionScore",
+    "AttentionSoftmax",
+    "AttentionOutput",
+    "Attention",
+    "OProj",
+    "OutputProjection",
+    "RoPE",
+    "RopeEmbedding",
+    // FFN
+    "FFNGateUp",
+    "FFNDown",
+    "SwiGLU",
+    "GateProjection",
+    "UpProjection",
+    "DownProjection",
+    "Activation",
+    // Embedding / vocabulary projection
+    "Embedding",
+    "LmHead",
+    // Norm / residual / tokenization (belong to no focus area)
+    "RmsNorm",
+    "RmsNorm1",
+    "RmsNorm2",
+    "OutputNorm",
+    "LayerNorm",
+    "Residual1",
+    "Residual2",
+    "Tokenize",
+    "TokenizeEncode",
+    "TokenizeDecode",
+];
+
+/// Exact operation names belonging to a focus area.
+fn focus_op_names(focus: ProfileFocus) -> &'static [&'static str] {
+    match focus {
+        ProfileFocus::All => &[],
+        ProfileFocus::Attention => &[
+            "QKV",
+            "QkvProjection",
+            "AttentionScore",
+            "AttentionSoftmax",
+            "AttentionOutput",
+            "Attention",
+            "OProj",
+            "OutputProjection",
+            "RoPE",
+            "RopeEmbedding",
+        ],
+        ProfileFocus::Mlp => &[
+            "FFNGateUp",
+            "FFNDown",
+            "SwiGLU",
+            "GateProjection",
+            "UpProjection",
+            "DownProjection",
+            "Activation",
+        ],
+        // Every weight-matrix projection, including the vocabulary GEMV.
+        ProfileFocus::Matmul => &[
+            "QKV",
+            "QkvProjection",
+            "OProj",
+            "OutputProjection",
+            "FFNGateUp",
+            "FFNDown",
+            "GateProjection",
+            "UpProjection",
+            "DownProjection",
+            "LmHead",
+        ],
+        // RopeEmbedding is positional encoding, not an embedding-table op — it
+        // belongs to Attention. LmHead is the output-side embedding projection.
+        ProfileFocus::Embedding => &["Embedding", "LmHead"],
+    }
+}
+
 /// Return focus-area keywords, or `None` for `All` (no filtering).
+///
+/// Fallback only, for operation names outside [`KNOWN_OP_NAMES`].
 fn focus_keywords(focus: ProfileFocus) -> Option<&'static [&'static str]> {
     match focus {
         ProfileFocus::All => None,
-        ProfileFocus::Attention => Some(&["attention", "attn", "qkv", "softmax"]),
-        ProfileFocus::Mlp => Some(&["mlp", "ffn", "gate", "up_proj", "down_proj"]),
-        ProfileFocus::Matmul => Some(&["matmul", "gemm", "mm", "linear"]),
+        ProfileFocus::Attention => Some(&["attention", "attn", "qkv", "softmax", "rope"]),
+        ProfileFocus::Mlp => Some(&["mlp", "ffn", "gate", "up_proj", "down_proj", "swiglu"]),
+        ProfileFocus::Matmul => Some(&["matmul", "gemm", "mm", "linear", "_proj", "projection"]),
         ProfileFocus::Embedding => Some(&["embed", "lm_head", "vocab"]),
     }
+}
+
+/// Does this operation belong to the requested focus area?
+fn matches_focus(focus: ProfileFocus, name: &str) -> bool {
+    if matches!(focus, ProfileFocus::All) {
+        return true;
+    }
+    if KNOWN_OP_NAMES.contains(&name) {
+        return focus_op_names(focus).contains(&name);
+    }
+    let lower = name.to_lowercase();
+    focus_keywords(focus).is_some_and(|keywords| keywords.iter().any(|k| lower.contains(k)))
 }
 
 /// GH-173: Filter profile results by focus area (PMAT-182)
@@ -170,18 +273,12 @@ fn filter_results_by_focus(
     results: &RealProfileResults,
     focus: ProfileFocus,
 ) -> RealProfileResults {
-    let filtered_hotspots = match focus_keywords(focus) {
-        None => results.hotspots.clone(),
-        Some(keywords) => results
-            .hotspots
-            .iter()
-            .filter(|h| {
-                let lower = h.name.to_lowercase();
-                keywords.iter().any(|k| lower.contains(k))
-            })
-            .cloned()
-            .collect(),
-    };
+    let filtered_hotspots: Vec<Hotspot> = results
+        .hotspots
+        .iter()
+        .filter(|h| matches_focus(focus, &h.name))
+        .cloned()
+        .collect();
 
     RealProfileResults {
         model_path: results.model_path.clone(),

--- a/crates/apr-cli/src/commands/profile_print_hotspot.rs
+++ b/crates/apr-cli/src/commands/profile_print_hotspot.rs
@@ -1,16 +1,39 @@
 
+/// Share of total inference time to print for each hotspot row.
+///
+/// GH-2395: this used to be `time_us / sum(time_us of the rows being printed)`.
+/// After `--focus mlp` dropped every row but one, that denominator was the single
+/// survivor, so the table reported "100.0%" for an operation the same tool's own
+/// Category Summary put at 23.2% — a fabricated number of exactly the kind that
+/// gets pasted into an optimisation ticket. `Hotspot::percent` is recorded against
+/// TOTAL inference time when the hotspot is built, so use it; the local sum is
+/// only a fallback for results that carry no recorded percentages at all.
+fn hotspot_display_percents(hotspots: &[Hotspot]) -> Vec<f64> {
+    let recorded_total: f64 = hotspots.iter().map(|h| h.percent).sum();
+    if recorded_total > 0.0 {
+        return hotspots.iter().map(|h| h.percent).collect();
+    }
+    let total_time: f64 = hotspots.iter().map(|h| h.time_us).sum();
+    hotspots
+        .iter()
+        .map(|h| {
+            if total_time > 0.0 {
+                (h.time_us / total_time) * 100.0
+            } else {
+                0.0
+            }
+        })
+        .collect()
+}
+
 fn print_hotspot_table(results: &RealProfileResults, granular: bool) {
     output::subheader("Per-Operation Hotspots (ungraphed — SKIP_CUDA_GRAPH=1)");
     println!();
 
-    let total_time = results.hotspots.iter().map(|h| h.time_us).sum::<f64>();
+    let percents = hotspot_display_percents(&results.hotspots);
     let mut rows: Vec<Vec<String>> = Vec::new();
     for (i, hotspot) in results.hotspots.iter().enumerate() {
-        let percent = if total_time > 0.0 {
-            (hotspot.time_us / total_time) * 100.0
-        } else {
-            0.0
-        };
+        let percent = percents[i];
         let bar = output::progress_bar(percent as usize, 100, 20);
         let bottleneck_str = hotspot.bottleneck.as_deref().unwrap_or("-");
         let mut row = vec![
@@ -251,30 +274,74 @@ fn print_perf_grade_section(results: &RealProfileResults, show: bool) {
     println!();
 }
 
-fn print_naive_detection(results: &RealProfileResults, detect: bool) {
+/// One reason the model looks naively implemented.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct NaiveSuspicion {
+    /// Human-readable reason, printed under `--detect-naive`.
+    pub(crate) reason: String,
+}
+
+/// Decide whether a profile looks naively implemented, at a GFLOPS `threshold`.
+///
+/// GH-2395: `--threshold <GFLOPS>` is documented as "GFLOPS threshold for naive
+/// detection" but nothing read it — `run()` did `let _ = naive_threshold;` and the
+/// only heuristic was "one op takes over half of total time". `--threshold 100000`
+/// on a run achieving 22.1 GFLOPS therefore still reported "No obvious naive
+/// implementations detected". Both signals now feed the verdict, and the verdict is
+/// what `--fail-on-naive` exits on.
+///
+/// Returns an empty vector when nothing is suspicious.
+fn detect_naive_implementations(
+    results: &RealProfileResults,
+    threshold_gflops: f64,
+) -> Vec<NaiveSuspicion> {
+    let mut suspicions = Vec::new();
+
+    // Signal 1: achieved compute throughput below the floor the user asked for.
+    if let Some(ref r) = results.roofline {
+        if threshold_gflops > 0.0 && r.achieved_gflops < threshold_gflops {
+            suspicions.push(NaiveSuspicion {
+                reason: format!(
+                    "achieved {:.1} GFLOPS < --threshold {:.1} GFLOPS",
+                    r.achieved_gflops, threshold_gflops
+                ),
+            });
+        }
+    }
+
+    // Signal 2: a single operation dominating the forward pass, which is the
+    // classic shape of a scalar fallback inside one kernel.
+    for h in &results.hotspots {
+        if h.count > 0 && h.avg_us > results.total_inference_us * 0.5 {
+            suspicions.push(NaiveSuspicion {
+                reason: format!(
+                    "{} takes {:.1}% of total time ({:.0}µs avg) — check for scalar fallback",
+                    h.name, h.percent, h.avg_us
+                ),
+            });
+        }
+    }
+
+    suspicions
+}
+
+fn print_naive_detection(results: &RealProfileResults, detect: bool, threshold_gflops: f64) {
     if !detect {
         return;
     }
     output::subheader("Naive Implementation Detection");
     println!();
-    let mut found = false;
-    for h in &results.hotspots {
-        if h.count > 0 && h.avg_us > results.total_inference_us * 0.5 {
-            println!(
-                "  {} {} takes {:.1}% of total time ({:.0}µs avg) — check for scalar fallback",
-                output::badge_warn("NAIVE?"),
-                h.name,
-                h.percent,
-                h.avg_us
-            );
-            found = true;
-        }
-    }
-    if !found {
+    let suspicions = detect_naive_implementations(results, threshold_gflops);
+    if suspicions.is_empty() {
         println!(
-            "  {} No obvious naive implementations detected",
-            output::badge_pass("OK")
+            "  {} No obvious naive implementations detected (threshold {:.1} GFLOPS)",
+            output::badge_pass("OK"),
+            threshold_gflops
         );
+    } else {
+        for s in &suspicions {
+            println!("  {} {}", output::badge_warn("NAIVE?"), s.reason);
+        }
     }
     println!();
 }

--- a/crates/apr-cli/src/commands/profile_profile.rs
+++ b/crates/apr-cli/src/commands/profile_profile.rs
@@ -147,7 +147,7 @@
             backend: "cpu".to_string(),
             ..Default::default()
         };
-        let result = print_human_results(&results, false, false, false);
+        let result = print_human_results(&results, false, false, false, 10.0);
         assert!(result.is_ok());
     }
 
@@ -185,7 +185,7 @@
             backend: "cpu".to_string(),
             ..Default::default()
         };
-        let result = print_human_results(&results, true, false, false);
+        let result = print_human_results(&results, true, false, false, 10.0);
         assert!(result.is_ok());
     }
 
@@ -210,7 +210,7 @@
             backend: "cpu".to_string(),
             ..Default::default()
         };
-        let result = print_human_results(&results, false, false, false);
+        let result = print_human_results(&results, false, false, false, 10.0);
         assert!(result.is_ok());
     }
 
@@ -248,7 +248,7 @@
             backend: "cpu".to_string(),
             ..Default::default()
         };
-        let result = print_human_results(&results, false, false, false);
+        let result = print_human_results(&results, false, false, false, 10.0);
         assert!(result.is_ok());
     }
 
@@ -289,7 +289,7 @@
             backend: "cpu".to_string(),
             ..Default::default()
         };
-        let result = print_human_results(&results, true, false, false);
+        let result = print_human_results(&results, true, false, false, 10.0);
         assert!(result.is_ok());
     }
 
@@ -314,7 +314,7 @@
             backend: "cpu".to_string(),
             ..Default::default()
         };
-        let result = print_human_results(&results, true, false, false);
+        let result = print_human_results(&results, true, false, false, 10.0);
         assert!(result.is_ok());
     }
 

--- a/crates/apr-cli/src/commands/profile_safetensors.rs
+++ b/crates/apr-cli/src/commands/profile_safetensors.rs
@@ -9,7 +9,7 @@ fn profile_safetensors_real(
     // Check sibling GGUF/APR for real inference profiling
     let gguf_path = path.with_extension("gguf");
     if gguf_path.exists() {
-        output::info(&format!(
+        output::info_stderr(&format!(
             "Found sibling GGUF: {}. Profiling that instead.",
             gguf_path.display()
         ));
@@ -17,7 +17,7 @@ fn profile_safetensors_real(
     }
     let apr_path = path.with_extension("apr");
     if apr_path.exists() {
-        output::info(&format!(
+        output::info_stderr(&format!(
             "Found sibling APR: {}. Profiling that instead.",
             apr_path.display()
         ));
@@ -25,7 +25,7 @@ fn profile_safetensors_real(
     }
 
     // Static analysis fallback via Rosetta Stone
-    output::info("SafeTensors: running static analysis profile (no inference engine needed)");
+    output::info_stderr("SafeTensors: running static analysis profile (no inference engine needed)");
     let rosetta = aprender::format::rosetta::RosettaStone::new();
     let report = rosetta
         .inspect(path)
@@ -85,7 +85,10 @@ fn profile_gguf_real(
     measure_passes: usize,
 ) -> Result<RealProfileResults, CliError> {
     // Load the model
-    println!("{}", "Loading model...".dimmed());
+    // GH-2395: progress is status, not data. It used to go to stdout, so
+    // `apr profile M --format json` emitted three human progress lines ahead of
+    // the JSON body and nothing downstream could parse the stream.
+    eprintln!("{}", "Loading model...".dimmed());
     let mapped = MappedGGUFModel::from_path(path)
         .map_err(|e| CliError::ValidationFailed(format!("Failed to load GGUF: {e}")))?;
 
@@ -124,7 +127,7 @@ fn profile_gguf_real(
     };
 
     // Warmup passes (discard timing)
-    println!(
+    eprintln!(
         "{}",
         format!("Running {} warmup passes...", warmup_passes).dimmed()
     );
@@ -133,7 +136,7 @@ fn profile_gguf_real(
     }
 
     // Measurement passes with per-operation profiler
-    println!(
+    eprintln!(
         "{}",
         format!(
             "Running {} measurement passes (per-op instrumented)...",
@@ -144,7 +147,12 @@ fn profile_gguf_real(
 
     let mut profiler = BrickProfiler::new();
     profiler.set_num_layers(num_layers);
-    profiler.set_tokens(tokens_per_pass * measure_passes);
+    // GH-2395: `tokens_processed` means DECODED tokens — the gpu-decode-profiling-v1
+    // TOKEN_ACCOUNTING contract asserts LmHead fires exactly once per decoded token.
+    // Each measurement pass runs one profiled forward and so decodes exactly one
+    // token; feeding it prompt_len * passes made every single profile run emit
+    // "LmHead.count=10 != tokens_processed=20", training users to ignore the warning.
+    profiler.set_tokens(measure_passes);
 
     let mut forward_times: Vec<f64> = Vec::new();
 
@@ -172,10 +180,9 @@ fn profile_gguf_real(
             let has_inf = logits.iter().any(|x| x.is_infinite());
 
             if has_nan || has_inf {
-                output::warn(&format!(
-                    "Forward pass produced invalid logits: NaN={}, Inf={}",
-                    has_nan, has_inf
-                ));
+                eprintln!(
+                    "Warning: forward pass produced invalid logits: NaN={has_nan}, Inf={has_inf}"
+                );
             }
         }
     }
@@ -271,7 +278,8 @@ fn profile_gguf_real(
         latency_max_ms: sorted_times.last().copied().unwrap_or(0.0),
         prefill_tok_s: 0.0, // CPU path doesn't separate prefill/decode
         decode_tok_s: tps,
-        total_tokens_generated: tokens_per_pass * measure_passes,
+        // One profiled forward pass per measurement pass => one decoded token each.
+        total_tokens_generated: measure_passes,
         kernel_launch_overhead_pct: 0.0, // CPU path: no kernel launches
         kernel_launch_overhead_us: 0.0,
     })
@@ -287,7 +295,8 @@ fn profile_apr_real(
     use realizar::apr_transformer::AprTransformer;
 
     // Load the model using AprTransformer
-    println!("{}", "Loading APR model...".dimmed());
+    // GH-2395: progress to stderr — see `profile_gguf_real`.
+    eprintln!("{}", "Loading APR model...".dimmed());
     let model = AprTransformer::from_apr_file(path)
         .map_err(|e| CliError::ValidationFailed(format!("Failed to load APR: {e}")))?;
 
@@ -312,7 +321,7 @@ fn profile_apr_real(
     let tokens_per_pass = test_tokens.len();
 
     // Warmup
-    println!(
+    eprintln!(
         "{}",
         format!("Running {} warmup passes...", warmup_passes).dimmed()
     );
@@ -321,14 +330,19 @@ fn profile_apr_real(
     }
 
     // Measurement
-    println!(
+    eprintln!(
         "{}",
         format!("Running {} measurement passes...", measure_passes).dimmed()
     );
 
     let mut profiler = BrickProfiler::new();
     profiler.set_num_layers(num_layers);
-    profiler.set_tokens(tokens_per_pass * measure_passes);
+    // GH-2395: `tokens_processed` means DECODED tokens — the gpu-decode-profiling-v1
+    // TOKEN_ACCOUNTING contract asserts LmHead fires exactly once per decoded token.
+    // Each measurement pass runs one profiled forward and so decodes exactly one
+    // token; feeding it prompt_len * passes made every single profile run emit
+    // "LmHead.count=10 != tokens_processed=20", training users to ignore the warning.
+    profiler.set_tokens(measure_passes);
 
     let mut forward_times: Vec<f64> = Vec::new();
 
@@ -356,10 +370,9 @@ fn profile_apr_real(
             let has_inf = logits.iter().any(|x| x.is_infinite());
 
             if has_nan || has_inf {
-                output::warn(&format!(
-                    "Forward pass produced invalid logits: NaN={}, Inf={}",
-                    has_nan, has_inf
-                ));
+                eprintln!(
+                    "Warning: forward pass produced invalid logits: NaN={has_nan}, Inf={has_inf}"
+                );
             }
         }
     }
@@ -420,7 +433,8 @@ fn profile_apr_real(
         latency_max_ms: sorted_times.last().copied().unwrap_or(0.0),
         prefill_tok_s: 0.0,
         decode_tok_s: tps,
-        total_tokens_generated: tokens_per_pass * measure_passes,
+        // One profiled forward pass per measurement pass => one decoded token each.
+        total_tokens_generated: measure_passes,
         kernel_launch_overhead_pct: 0.0, // APR CPU: no kernel launches
         kernel_launch_overhead_us: 0.0,
     })
@@ -440,7 +454,8 @@ fn load_tokenizer_for_profile(model_path: &Path) -> Option<aprender::text::bpe::
     let sibling = model_path.with_file_name(format!("{stem}.tokenizer.json"));
     if sibling.exists() {
         if let Ok(tok) = BpeTokenizer::from_huggingface(&sibling) {
-            println!(
+            // GH-2395: progress to stderr — see `profile_gguf_real`.
+            eprintln!(
                 "{}",
                 format!("Loaded tokenizer from {}", sibling.display()).dimmed()
             );
@@ -453,7 +468,7 @@ fn load_tokenizer_for_profile(model_path: &Path) -> Option<aprender::text::bpe::
         let tokenizer_json = parent.join("tokenizer.json");
         if tokenizer_json.exists() {
             if let Ok(tok) = BpeTokenizer::from_huggingface(&tokenizer_json) {
-                println!(
+                eprintln!(
                     "{}",
                     format!("Loaded tokenizer from {}", tokenizer_json.display()).dimmed()
                 );
@@ -471,6 +486,7 @@ fn print_human_results(
     granular: bool,
     show_perf_grade: bool,
     detect_naive: bool,
+    naive_threshold_gflops: f64,
 ) -> Result<(), CliError> {
     print_profile_model_header(results);
     print_hotspot_table(results, granular);
@@ -479,7 +495,7 @@ fn print_human_results(
     print_per_layer_timing(results, granular);
     print_roofline_section(results);
     print_perf_grade_section(results, show_perf_grade);
-    print_naive_detection(results, detect_naive);
+    print_naive_detection(results, detect_naive, naive_threshold_gflops);
     print_generation_performance(results);
     print_latency_percentiles(results);
     print_profile_summary(results);

--- a/crates/apr-cli/src/dispatch_analysis.rs
+++ b/crates/apr-cli/src/dispatch_analysis.rs
@@ -1175,6 +1175,7 @@ fn dispatch_profiling_commands(cli: &Cli) -> Option<Result<(), CliError>> {
                 *ollama,
                 *no_gpu,
                 compare.as_deref(),
+                cli.json,
             )
         }),
 

--- a/crates/apr-cli/src/extended_commands.rs
+++ b/crates/apr-cli/src/extended_commands.rs
@@ -139,22 +139,22 @@ pub enum ExtendedCommands {
         /// Detect naive implementations
         #[arg(long)]
         detect_naive: bool,
-        /// GFLOPS threshold for naive detection
+        /// Achieved-GFLOPS floor below which the run is reported as naive
         #[arg(long, default_value = "10.0")]
         threshold: f64,
-        /// Compare against HuggingFace baseline
+        /// [NOT IMPLEMENTED — accepted and ignored] Compare against HuggingFace baseline
         #[arg(long)]
         compare_hf: Option<String>,
-        /// Measure energy consumption (requires RAPL)
+        /// [NOT IMPLEMENTED — accepted and ignored] Measure energy consumption (requires RAPL)
         #[arg(long)]
         energy: bool,
         /// Compute performance grade (vs Ollama baseline)
         #[arg(long)]
         perf_grade: bool,
-        /// Show call graph
+        /// [NOT IMPLEMENTED — accepted and ignored] Show call graph
         #[arg(long)]
         callgraph: bool,
-        /// Exit non-zero if naive implementation detected
+        /// Exit non-zero if naive implementation detected (implies --detect-naive)
         #[arg(long)]
         fail_on_naive: bool,
         /// Output file path for flamegraph SVG (GH-174, PMAT-182)
@@ -180,7 +180,8 @@ pub enum ExtendedCommands {
         /// Measurement passes (default: 10)
         #[arg(long, default_value = "10")]
         measure: usize,
-        /// Number of tokens to generate per measurement pass (default: 32)
+        /// Tokens generated per measurement pass — GPU and --ollama paths only;
+        /// the CPU per-operation profiler measures one forward pass per pass
         #[arg(long, default_value = "32")]
         tokens: usize,
         /// Compare against Ollama baseline (runs ollama for comparison)

--- a/crates/apr-cli/src/output.rs
+++ b/crates/apr-cli/src/output.rs
@@ -88,6 +88,17 @@ pub(crate) fn info(msg: &str) {
     println!("{} {}", "[INFO]".blue(), msg);
 }
 
+/// Print an info message on stderr.
+///
+/// GH-2395: progress and provenance notes are status, not data. Emitting them on
+/// stdout put human text ahead of the JSON body of `apr profile --format json`,
+/// so the stream could not be parsed at all. Any command with a machine-readable
+/// output mode must route its chatter here.
+#[allow(dead_code)]
+pub(crate) fn info_stderr(msg: &str) {
+    eprintln!("{} {}", "[INFO]".blue(), msg);
+}
+
 /// Print an error message
 #[allow(dead_code)]
 pub(crate) fn error(msg: &str) {

--- a/crates/apr-cli/src/validate.rs
+++ b/crates/apr-cli/src/validate.rs
@@ -408,8 +408,12 @@ fn dispatch_profile(
     ollama: bool,
     no_gpu: bool,
     compare: Option<&Path>,
+    json: bool,
 ) -> Result<(), CliError> {
-    let output_format = format.parse().unwrap_or(profile::OutputFormat::Human);
+    // GH-2395: `--json` is a global flag that `apr profile` parsed and ignored, and
+    // an unparseable `--format` silently degraded to the human table. See
+    // `commands/profile_options.rs`.
+    let output_format = profile::resolve_output_format(format, json)?;
 
     // PMAT-192: CI mode takes precedence
     if ci || assert_throughput.is_some() || assert_p99.is_some() || assert_p50.is_some() {
@@ -440,9 +444,10 @@ fn dispatch_profile(
             ))
         }
     } else {
-        let profile_focus = focus
-            .and_then(|f| f.parse().ok())
-            .unwrap_or(profile::ProfileFocus::All);
+        // An unrecognised --focus used to silently degrade to the full unfiltered
+        // report with exit 0, so a typo produced a report that answered a different
+        // question than the one asked.
+        let profile_focus = profile::resolve_focus(focus)?;
         profile::run(
             file,
             granular,
@@ -456,6 +461,8 @@ fn dispatch_profile(
             callgraph,
             fail_on_naive,
             output,
+            warmup,
+            measure,
             tokens,
             ollama,
             no_gpu,

--- a/crates/aprender-compute/src/hardware/mod.rs
+++ b/crates/aprender-compute/src/hardware/mod.rs
@@ -253,11 +253,77 @@ pub enum Bottleneck {
     Compute,
 }
 
+/// Map a raw x86 `vendor_id` to a human-readable vendor name.
+fn normalize_cpu_vendor(raw: &str) -> String {
+    match raw.trim() {
+        "GenuineIntel" => "Intel".to_string(),
+        "AuthenticAMD" => "AMD".to_string(),
+        "" => "Unknown".to_string(),
+        other => other.to_string(),
+    }
+}
+
+/// Parse `(vendor, model)` out of `/proc/cpuinfo` contents.
+///
+/// GH-2395: `detect_cpu` hardcoded `vendor: "Unknown", model: "Unknown"`, so the
+/// roofline block of `apr profile` reported `Hardware: Unknown Unknown (24 cores, …)`
+/// while the peak GFLOPS and bandwidth printed beside it — the basis for the
+/// MEMORY BOUND verdict — claimed to describe that machine.
+///
+/// Split out from the filesystem read so it is testable without `/proc`. Handles
+/// the x86 layout (`vendor_id` / `model name`) and the aarch64 layout
+/// (`CPU implementer` / `Model`, with no `model name` on many kernels).
+pub fn parse_cpuinfo(contents: &str) -> (Option<String>, Option<String>) {
+    let mut vendor = None;
+    let mut model = None;
+    for line in contents.lines() {
+        let Some((key, value)) = line.split_once(':') else {
+            continue;
+        };
+        let key = key.trim();
+        let value = value.trim();
+        if value.is_empty() {
+            continue;
+        }
+        match key {
+            "vendor_id" if vendor.is_none() => vendor = Some(normalize_cpu_vendor(value)),
+            "model name" | "Model" if model.is_none() => model = Some(value.to_string()),
+            // aarch64 has no vendor_id; implementer 0x41 is ARM Ltd.
+            "CPU implementer" if vendor.is_none() => {
+                vendor = Some(match value {
+                    "0x41" => "ARM".to_string(),
+                    "0x51" => "Qualcomm".to_string(),
+                    "0x4e" => "NVIDIA".to_string(),
+                    other => other.to_string(),
+                });
+            }
+            _ => {}
+        }
+    }
+    (vendor, model)
+}
+
+/// Read CPU vendor/model from the OS, falling back to `"Unknown"`.
+fn detect_cpu_identity() -> (String, String) {
+    #[cfg(target_os = "linux")]
+    {
+        if let Ok(contents) = fs::read_to_string("/proc/cpuinfo") {
+            let (vendor, model) = parse_cpuinfo(&contents);
+            return (
+                vendor.unwrap_or_else(|| "Unknown".to_string()),
+                model.unwrap_or_else(|| "Unknown".to_string()),
+            );
+        }
+    }
+    ("Unknown".to_string(), "Unknown".to_string())
+}
+
 /// Detect CPU capabilities
 fn detect_cpu() -> CpuCapability {
     let simd = detect_simd();
     let cores = num_cpus::get_physical();
     let threads = num_cpus::get();
+    let (vendor, model) = detect_cpu_identity();
 
     // Estimate frequency (fallback to 3.0 GHz if unknown)
     let base_freq_ghz = 3.0;
@@ -269,8 +335,8 @@ fn detect_cpu() -> CpuCapability {
     let memory_bw_gbps = 80.0; // Conservative estimate
 
     CpuCapability {
-        vendor: "Unknown".to_string(),
-        model: "Unknown".to_string(),
+        vendor,
+        model,
         cores,
         threads,
         simd,


### PR DESCRIPTION
`apr profile` accepted its own documented flags and then discarded them, so every number it printed described a run nobody asked for.

## `--warmup` / `--measure` parsed and dropped

`dispatch_profile` called `profile::run` with fifteen positional arguments and simply omitted these two, so every non-CI profile ran the hardcoded 3 warmup / 10 measurement passes. The JSON body then reported `"warmup_passes": 3` / `"measure_passes": 10`, actively misinforming a consumer that had overridden them.

| | before (0.63.0) | after |
|---|---|---|
| `--warmup 7 --measure 9` | `Warmup 3 / Measure 10` | `Warmup 7 / Measure 9` |
| `--format json --warmup 1 --measure 2` | `"warmup_passes": 3, "measure_passes": 10` | `"warmup_passes": 1, "measure_passes": 2` |
| wall time `--measure 1` | 3.10s | **2.26s** |
| wall time `--measure 100` | 3.14s | **20.67s** |

The 100× measure difference costing 0.04s was the issue's falsifying proof that the flags were not merely mis-reported but genuinely unused. It now costs 18s.

`--tokens` is forwarded but only drives the GPU and `--ollama` paths; the CPU per-operation profiler measures one forward pass per measurement pass. It now says so on stderr instead of silently measuring something else, and `--help` carries the same caveat.

## `--focus` matched snake_case against CamelCase

`focus_keywords` was a snake_case table (`up_proj`, `down_proj`, `matmul`, `lm_head`) matched with `lower.contains(k)` against the CamelCase names `BrickProfiler` emits. Lowercased, `"upprojection"` does not contain `"up_proj"` and nothing at all contains `"matmul"`. Only `"gate"` happened to hit.

```
$ apr profile <qwen2-1.5b.gguf> --focus mlp
before:  GateProjection 100.0%                                   1 of 4 FFN ops
after:   GateProjection 21.7%  DownProjection 20.9%
         UpProjection   20.4%  Activation      1.6%              4 rows, 64.6% of total

$ apr profile <qwen2-1.5b.gguf> --focus matmul
before:  (no hotspot rows), exit 0
after:   QkvProjection, GateProjection, DownProjection,
         UpProjection, OutputProjection, LmHead                  6 rows
```

`--focus attention` also dropped `OutputProjection` (11.6% of decode) and `--focus embedding` captured `RopeEmbedding` (positional encoding) while missing `LmHead` (the vocabulary projection). Both fixed.

Filtering is now an exact-name membership test over the names the profilers actually emit; keyword matching survives only as the fallback for unrecognised names from custom instrumentation.

The surviving row was additionally renormalised over the filtered subset and printed as **"100.0%"** of a model whose own Category Summary put FFN at 70.5% — a fabricated figure of exactly the kind that gets pasted into an optimisation ticket. The table now prints the share of total inference time that `Hotspot::percent` already records.

`--focus bogus` silently fell back to the full unfiltered report with exit 0; it now errors. Same for an unparseable `--format`.

## `--ci` reported p50 == p99

CI mode assigned the mean to both percentiles, so `--assert-p99` was asserting on a single averaged sample and a tail-only regression could never fail the gate. The distribution was already being computed — the non-CI path on the same model prints p50=120.2 / p95=132.6 / p99=136.3 — CI mode just did not read it.

```
$ apr profile <qwen2-1.5b.gguf> --ci --assert-p99 90
before:  p50 105.96 ms / p99 105.96 ms                exit 0
after:   p50  83.36 ms / p99  92.86 ms
         FAIL latency_p99: 92.86 ms (expected <= 90.0 ms)   exit 5
```

The 90 ms budget sits between the median and the tail, which is precisely the regression 0.63.0 could not see.

## `--json` ignored, and `--format json` unparseable

`--json` is `global = true` on `Cli` and `apr bench` honours it; `apr profile` parsed it and printed the human table. Separately, `--format json` wrote human progress to **stdout** ahead of the JSON body, so the stream did not parse at all. Progress is status, not data, and now goes to stderr.

```
$ apr profile <model> --format json | python3 -c 'import json,sys; json.load(sys.stdin)'
before:  JSONDecodeError: Expecting value: line 1 column 1 (char 0)
after:   parses — keys model, architecture, num_layers, vocab_size, hidden_dim,
         is_real_data, timing, hotspots
```

Verified clean on all three loadable fixtures (1.5B GGUF, SafeTensors, 1.5B q4k APR). The APR path had a fourth polluter, `Loaded tokenizer from …`, found only because the fixture sweep checked more than one format.

## `--fail-on-naive` could not fail, `--threshold` did nothing

`--fail-on-naive` printed `"not yet implemented. Flag ignored."` and returned 0 unconditionally — an exit-code contract a CI job may already depend on. `--threshold`, documented as the GFLOPS floor for naive detection, was consumed by `let _ = naive_threshold;`, so `--threshold 100000` against a run achieving 22 GFLOPS still reported "No obvious naive implementations detected".

```
$ apr profile <model> --detect-naive --fail-on-naive --threshold 100000
before:  Warning: --fail-on-naive is not yet implemented. Flag ignored.
         OK No obvious naive implementations detected              exit 0
after:   NAIVE? achieved 28.0 GFLOPS < --threshold 100000.0 GFLOPS
         error: naive implementation detected (1 signal(s))        exit 5

$ apr profile <model> --detect-naive --fail-on-naive          # default threshold 10.0
after:   OK No obvious naive implementations detected (threshold 10.0 GFLOPS)  exit 0
```

Both signals — the achieved-GFLOPS floor and the dominant-operation heuristic — feed one verdict, evaluated on the **unfiltered** results so `--focus` narrows the report and not the gate. `--energy` and `--callgraph` remain stubs but now say so in `--help` rather than only at runtime.

## Roofline provenance

```
Hardware: Unknown Unknown (24 cores, 512)  (peak 2304.0 GFLOPS, 80.0 GB/s)
      ->  AMD Ryzen Threadripper 7960X 24-Cores (24 cores, 512-bit SIMD) (peak 2304.0 GFLOPS, 80.0 GB/s)
```

`detect_cpu` hardcoded both strings and the SIMD width printed as a bare `512` with no unit — in the block whose peak figures justify the `MEMORY BOUND` verdict. `parse_cpuinfo` is split out from the filesystem read so it is testable without `/proc`, and handles the aarch64 layout too.

And every single run emitted `[CONTRACT WARN] gpu-decode-profiling-v1 TOKEN_ACCOUNTING: LmHead.count=10 != tokens_processed=20`, because the CPU profiler set `tokens_processed` to `prompt_len * passes` while each measurement pass decodes exactly one token. The tool was violating its own instrumentation contract on the happy path, training users to ignore a real warning. Gone.

## Root causes

| file:line | defect |
|---|---|
| `crates/apr-cli/src/validate.rs:443` | `warmup` / `measure` never forwarded to `profile::run` |
| `crates/apr-cli/src/commands/profile_pct_change_classify.rs:158` | snake_case keyword table vs CamelCase op names |
| `crates/apr-cli/src/commands/profile_print_hotspot.rs:5` | share renormalised over the filtered subset |
| `crates/apr-cli/src/commands/profile.rs:168` | mean assigned to both p50 and p99 |
| `crates/apr-cli/src/commands/diff_benchmark_report.rs:36` | `let _ = naive_threshold;`, `--fail-on-naive` a no-op |
| `crates/apr-cli/src/commands/profile_safetensors.rs:147` | `set_tokens(prompt_len * passes)` |
| `crates/aprender-compute/src/hardware/mod.rs:272` | `vendor`/`model` hardcoded to `"Unknown"` |

## Mutation check

Each fix reverted in turn with the tests kept. Verbatim RED:

```
focus table -> keyword-only
  --focus mlp dropped UpProjection; kept ["GateProjection"]
  --focus attention dropped OutputProjection; kept ["QkvProjection", "AttentionScore"]
  --focus matmul returned an empty hotspot table
  --focus embedding dropped LmHead; kept ["RopeEmbedding", "Embedding"]
  the focused table must still sum to the FFN share of total (~68.2%), got 23.2%

percent -> renormalise over printed rows
  the focused table must still sum to the FFN share of total (~68.2%), got 100.0%

CI percentiles -> mean
  CI p99 must be the measured tail, got 105.96
  --assert-p99 130 must FAIL when the measured p99 is 136.3ms

option resolution -> unwrap_or(default)
  assertion failed: matches!(resolve_output_format("human", true), Ok(OutputFormat::Json))
  assertion failed: resolve_output_format("jsonn", false).is_err()
  assertion failed: resolve_focus(Some("bogus")).is_err()

threshold -> let _ =, cpuinfo vendor -> never resolved
  --threshold 100000 must flag a 22.1 GFLOPS run
   left: (None, Some("AMD Ryzen 9 7900X 12-Core Processor"))
  right: (Some("AMD"), Some("AMD Ryzen 9 7900X 12-Core Processor"))

hardware label -> vendor+model unconditional, bare bit width
   left: "AMD AMD Ryzen Threadripper 7960X 24-Cores (24 cores, 512)"
  right: "AMD Ryzen Threadripper 7960X 24-Cores (24 cores, 512-bit SIMD)"
```

Restored: 6671 `apr-cli` lib tests green, 30 `aprender-compute` hardware tests green, `cargo fmt --all --check` and `clippy --lib -D warnings` clean on both crates.

## Two things worth flagging to a reviewer

**A pre-existing test encoded the old behaviour and was corrected, not accommodated.** The 16 focus tests that guarded this fed synthetic hotspots literally named `"up_proj"` / `"down_proj"` / `"mm_q4k"`, which the keyword table *did* match — so they passed for two releases while no name the profiler actually emits ever did. The new falsifiers use the real names. One legitimate test, `test_filter_matmul_mm_keyword`, went red against an earlier draft that had removed the `"mm"` keyword; `"mm"` is restored, and since the keyword list is now the fallback consulted only for names outside the exact-name table, it can no longer produce false positives on real ops.

**The first end-to-end verification run measured the wrong binary.** `cargo metadata` resolves `target_directory` to the shared `/mnt/nvme-raid0/targets/aprender`, which sibling worktrees write concurrently — the build log even referenced worktree `…-8`. That binary reported the correct git SHA and still rejected nothing for `--focus bogus`. All evidence above comes from a release build into a private `CARGO_TARGET_DIR`, pinned by first proving the fix is present (`--focus bogus` errors) before trusting any other output from it.

Fixes #2395
Audit epic: #2373
