### PR TITLE
fix(train): CpuInfo compared a machine-wide core count against a process-restricted one

### DIFF
--- a/crates/aprender-train/src/efficiency/device/cpu.rs
+++ b/crates/aprender-train/src/efficiency/device/cpu.rs
@@ -31,14 +31,31 @@ impl CpuInfo {
         self
     }
 
+    /// Reconcile a machine-wide physical core count against the parallelism this
+    /// process is actually allowed to use.
+    ///
+    /// `available_parallelism` is cgroup- and affinity-aware: it reports what THIS
+    /// process may run on. `/proc/cpuinfo` is not — it describes the whole machine
+    /// regardless of any restriction. Comparing the two directly mixes denominators,
+    /// and under any CPU restriction the machine-wide figure is both larger than the
+    /// usable one and useless for sizing work.
+    ///
+    /// Clamping keeps `cores <= threads` true by construction and makes `cores` mean
+    /// "physical cores this process can actually use", which is what every consumer
+    /// of the field (thread-pool sizing, efficiency estimates) needs.
+    pub(super) fn usable_cores(detected_physical: Option<u32>, threads: u32) -> u32 {
+        let threads = threads.max(1);
+        detected_physical.map_or(threads, |physical| physical.clamp(1, threads))
+    }
+
     /// Detect current CPU information
     pub fn detect() -> Self {
-        // Get logical CPU count using standard library
+        // Get logical CPU count using standard library. This is cgroup/affinity aware.
         let threads = std::thread::available_parallelism().map(|n| n.get() as u32).unwrap_or(1);
 
-        // Estimate physical cores (assumes hyperthreading with 2 threads per core)
-        // This is a heuristic - for accurate counts would need platform-specific APIs
-        let cores = Self::detect_physical_cores().unwrap_or_else(|| threads.max(1));
+        // Physical cores come from /proc/cpuinfo, which is NOT restriction-aware, so
+        // the result is reconciled against `threads` — see `usable_cores`.
+        let cores = Self::usable_cores(Self::detect_physical_cores(), threads);
         let simd = SimdCapability::detect();
 
         // Try to get CPU model name

--- a/crates/aprender-train/src/efficiency/device/tests.rs
+++ b/crates/aprender-train/src/efficiency/device/tests.rs
@@ -51,6 +51,67 @@ fn test_cpu_info_detect() {
     assert!(!cpu.model.is_empty());
 }
 
+/// The regression that turned Coverage Nightly red on 2026-08-11.
+///
+/// `threads` is `available_parallelism()` — cgroup- and affinity-aware, so it reports
+/// what this process may use. `cores` was read from `/proc/cpuinfo`, which describes
+/// the whole machine and ignores every restriction. On a CI host running 16 concurrent
+/// jobs the two disagree badly; measured on the box that failed:
+///
+/// ```text
+/// $ awk -F: '/^physical id/{p=$2} /^core id/{print p"-"$2}' /proc/cpuinfo | sort -u | wc -l
+/// 24                       # machine-wide physical cores
+/// $ taskset -c 0,1 nproc
+/// 2                        # what a restricted process may use
+/// ```
+///
+/// so `test_cpu_info_detect`'s `threads >= cores` became `2 >= 24` and panicked,
+/// failing the whole run after 7451 passing tests.
+///
+/// These cases drive the reconciliation directly, so the invariant is falsifiable
+/// without needing to actually restrict the test process's CPUs.
+#[test]
+fn usable_cores_never_exceeds_available_parallelism() {
+    // The exact failing shape: a 24-core machine seen by a 2-CPU-restricted process.
+    assert_eq!(
+        CpuInfo::usable_cores(Some(24), 2),
+        2,
+        "a process allowed 2 CPUs must not report 24 usable physical cores"
+    );
+
+    // Unrestricted hyperthreaded host: physical count stands, nothing is clamped.
+    assert_eq!(CpuInfo::usable_cores(Some(24), 48), 24);
+
+    // Exactly-equal case (hyperthreading off) is not a restriction.
+    assert_eq!(CpuInfo::usable_cores(Some(16), 16), 16);
+
+    // /proc/cpuinfo unreadable (non-Linux, container without procfs): fall back to
+    // the one figure we do trust.
+    assert_eq!(CpuInfo::usable_cores(None, 8), 8);
+
+    // Degenerate inputs must still produce a usable core count, never 0.
+    assert_eq!(CpuInfo::usable_cores(Some(0), 4), 1);
+    assert_eq!(CpuInfo::usable_cores(None, 0), 1);
+}
+
+/// The invariant `test_cpu_info_detect` asserts, stated over the whole input space
+/// rather than over whatever the current host happens to look like.
+#[test]
+fn usable_cores_upholds_the_cores_le_threads_invariant() {
+    for physical in [None, Some(1), Some(2), Some(8), Some(24), Some(128)] {
+        for threads in [0u32, 1, 2, 4, 24, 48, 256] {
+            let cores = CpuInfo::usable_cores(physical, threads);
+            assert!(cores >= 1, "cores must be >= 1, got {cores} for {physical:?}/{threads}");
+            assert!(
+                cores <= threads.max(1),
+                "cores ({cores}) must never exceed usable threads ({}) — \
+                 physical={physical:?}",
+                threads.max(1)
+            );
+        }
+    }
+}
+
 #[test]
 fn test_gpu_info_new() {
     let gpu = GpuInfo::new("NVIDIA RTX 4090", 24 * 1024 * 1024 * 1024);


### PR DESCRIPTION
Coverage Nightly is red on `main` after 7451 passing tests:

```
thread 'efficiency::device::tests::test_cpu_info_detect' panicked at
  crates/aprender-train/src/efficiency/device/tests.rs:50:5:
assertion failed: cpu.threads >= cpu.cores
test result: FAILED. 7451 passed; 1 failed
make: *** [Makefile:339: coverage] Error 1
```

`threads` comes from `available_parallelism()` — cgroup- and affinity-aware, so it reports what **this process** may use. `cores` came from `/proc/cpuinfo`, which describes the **whole machine** and honours no restriction. Different denominators; under CPU restriction the machine-wide number is the larger one and the invariant inverts.

Measured on the 24-physical-core runner that failed:

```
$ awk -F: '/^physical id/{p=$2} /^core id/{print p"-"$2}' /proc/cpuinfo | sort -u | wc -l
24
$ nproc                 # unrestricted
48
$ taskset -c 0,1 nproc  # what a restricted process sees
2
```

so the assertion became `2 >= 24`. Not a flake — with 16 concurrent CI jobs on one box that is the expected reading, and it aborts the run with the rest of the suite unexecuted, so a real regression behind it would be invisible.

`usable_cores` now clamps the machine-wide physical count to the parallelism actually available, so `cores` means "physical cores this process can use" — which is what consumers need (`estimated_memory_bandwidth_gbps` sizes from it).

**Mutation check** — old expression restored, new tests kept:

```
detected_physical.unwrap_or_else(|| threads.max(1))  // MUTATION

test usable_cores_never_exceeds_available_parallelism ... FAILED
test usable_cores_upholds_the_cores_le_threads_invariant ... FAILED
assertion `left == right` failed: a process allowed 2 CPUs must not report
  24 usable physical cores
```

`test_cpu_info_detect` stayed **green** under that mutation, because this host is unrestricted — which is exactly why the defect only ever appeared on a loaded CI runner. The new tests drive the reconciliation over its input space instead of over whatever the current machine happens to be.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
