### PR TITLE
fix(story): the nightly failed a gate that had run and PASSED

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -426,6 +426,16 @@ jobs:
       # compile its own test suite. Text-only check, no build.
       - name: No exclude pattern may swallow a src/ directory
         run: bash scripts/check_exclude_anchored.sh
+      # Poka-yoke: capturing `cmd 2>&1` into one variable and then parsing it as
+      # JSON puts the command's diagnostics in front of its data. On 2026-08-11
+      # the nightly story reported `no format_parity gate found in --json output
+      # (got: '')` for a gate that had run and PASSED, because `apr qa --json`
+      # writes JSON to stdout while the CUDA path emits `[trueno#243]` lines to
+      # stderr. A false FAIL reddens main for a non-reason. The converse matters
+      # too: a Rust panic arrives on stderr, so the panic checks must keep
+      # reading the merged view. Behavioural, text-only, no build.
+      - name: Story JSON parsing must read stdout, not the merged stream
+        run: bash scripts/check_story_json_streams.sh
 
   # Top-level gate: satisfies org ruleset "Green Main" which requires check named "gate".
   # The reusable workflow produces "ci / gate" but rulesets need exact match on "gate".

--- a/contracts/qwen-story-v1.yaml
+++ b/contracts/qwen-story-v1.yaml
@@ -149,6 +149,12 @@ falsification_tests:
     test: "grep -q 'rev-parse --short HEAD' scripts/apr_bin.sh && grep -q 'STALE apr BINARY' scripts/apr_bin.sh"
     if_fails: "Freshness is asserted by version string alone or not at all; a rebuilt-but-not-reinstalled binary would pass."
 
+  - id: FALSIFY-QWEN-STORY-014
+    rule: "A check that parses JSON reads STDOUT alone; only pattern checks see the merged stream"
+    prediction: "scripts/check_story_json_streams.sh exits 0: run_cmd sets RC_OUT from stdout only, RC_ERR from stderr only, RC_ALL from both, and no jq call site in qwen-story.sh is fed from the merged stream"
+    test: "bash scripts/check_story_json_streams.sh"
+    if_fails: "run_cmd captured `cmd 2>&1` into one variable, so a command's stderr was prepended to its JSON. On 2026-08-11 that reported `no format_parity gate found in --json output (got: '', apr qa exit=0)` for a gate that had run and PASSED - apr qa writes JSON to stdout and the CUDA path emits unconditional `[trueno#243]` lines to stderr. A false FAIL is as corrosive as a gate that cannot fail: main goes red for a non-reason. Note the converse is equally a defect - a Rust panic arrives on stderr, so the panic checks must keep reading RC_ALL."
+
   - id: FALSIFY-QWEN-STORY-008
     rule: "Beat 7 doesn't run apr qa on 7B (known #1864 regression)"
     prediction: "Beat 7 calls profile/gpu/serve plan but NOT apr qa on the 7B model"

--- a/scripts/check_story_json_streams.sh
+++ b/scripts/check_story_json_streams.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# check_story_json_streams.sh - prove run_cmd keeps stdout and stderr apart.
+#
+# The nightly story failed on 2026-08-11 with
+#
+#     ✗ FAIL  B2 format_parity  -  no format_parity gate found in --json
+#             output (got: '', apr qa exit=0)
+#
+# while the gate had actually run and PASSED. run_cmd captured `cmd 2>&1`, so
+# `apr qa --json`'s stderr diagnostics (the CUDA path emits unconditional
+# `[trueno#243] ...` lines) were prepended to its JSON. `jq` could not parse
+# that, the extraction came back empty, and the harness reported a defect that
+# did not exist.
+#
+# These are BEHAVIOURAL assertions - they run the real run_cmd from the real
+# library over commands with known stream behaviour. A grep-for-the-idiom guard
+# would have passed the whole time the bug was live, because `2>&1` is correct
+# in most of the places it appears.
+
+set -uo pipefail
+
+LIB="$(dirname "$0")/lib_story_run.sh"
+[ -f "$LIB" ] || { echo "check_story_json_streams: missing $LIB"; exit 1; }
+# shellcheck source=scripts/lib_story_run.sh
+. "$LIB" || { echo "check_story_json_streams: could not source $LIB"; exit 1; }
+
+fails=0
+ok()   { printf '  ok    %s\n' "$1"; }
+bad()  { fails=$((fails+1)); printf '  FAIL  %s\n     expected: %s\n     actual:   %s\n' "$1" "$2" "$3"; }
+want() { # name expected actual
+  if [ "$2" = "$3" ]; then ok "$1"; else bad "$1" "$2" "$3"; fi
+}
+
+echo "check_story_json_streams: run_cmd stream separation"
+
+# -- 1. The exact failing shape --------------------------------------------
+# A command that writes JSON to stdout and diagnostics to stderr. Parsing
+# RC_OUT must yield the field; this is what the format_parity check does.
+run_cmd 10 bash -c 'echo "[trueno#243] Manual graph construction: pos=0" >&2; echo "{\"gates\":[{\"name\":\"format_parity\",\"skipped\":false,\"passed\":true}]}"'
+got=$(printf '%s\n' "$RC_OUT" | jq -r '.gates[] | select(.name=="format_parity") | "\(.skipped) \(.passed)"' 2>/dev/null)
+want "JSON on stdout survives diagnostics on stderr" "false true" "$got"
+
+# -- 2. Each stream lands in its own variable -------------------------------
+run_cmd 10 bash -c 'echo OUTLINE; echo ERRLINE >&2'
+want "RC_OUT is stdout only" "OUTLINE" "$RC_OUT"
+want "RC_ERR is stderr only" "ERRLINE" "$RC_ERR"
+
+# -- 3. RC_ALL keeps the merged view the panic checks depend on -------------
+# A Rust panic is written to STDERR. If RC_ALL dropped it, the story would stop
+# detecting panics - a strictly worse failure than the one being fixed here.
+run_cmd 10 bash -c "echo normal; echo \"thread 'main' panicked at src/x.rs:1:1\" >&2"
+if printf '%s\n' "$RC_ALL" | grep -qE 'thread.*panicked'; then
+  ok "RC_ALL still sees a panic written to stderr"
+else
+  bad "RC_ALL still sees a panic written to stderr" "match" "$RC_ALL"
+fi
+
+# -- 4. Exit status belongs to the COMMAND, not to the capture plumbing -----
+run_cmd 10 bash -c 'echo x >&2; exit 7'
+want "RC_EC is the command exit status" "7" "$RC_EC"
+run_cmd 1 sleep 5
+want "RC_EC is 124 on timeout" "124" "$RC_EC"
+
+# -- 5. Empty stderr must not inject a blank line into RC_ALL ---------------
+# RC_ALL is greped and tailed; a stray trailing newline changes RC_TAIL.
+run_cmd 10 bash -c 'echo only-stdout'
+want "RC_ALL has no phantom blank line when stderr is empty" "only-stdout" "$RC_ALL"
+want "RC_TAIL is the last real line" "only-stdout" "$RC_TAIL"
+
+# -- 6. No JSON-parsing call site may read the merged stream ----------------
+# Behavioural checks above cover run_cmd itself; this covers the CALLERS, which
+# is where the defect actually surfaced. Any `jq` fed from RC_ALL/RC_ERR is the
+# same bug in a new place.
+STORY="$(dirname "$0")/qwen-story.sh"
+if [ -f "$STORY" ]; then
+  offenders=$(grep -nE '\$RC_(ALL|ERR)"?[^|]*\|[[:space:]]*jq' "$STORY" || true)
+  if [ -z "$offenders" ]; then
+    ok "no jq call site parses the merged stream"
+  else
+    bad "no jq call site parses the merged stream" "none" "$offenders"
+  fi
+fi
+
+echo
+if [ "$fails" -eq 0 ]; then
+  echo "check_story_json_streams: OK - stdout and stderr stay separate"
+  exit 0
+fi
+echo "check_story_json_streams: $fails assertion(s) FAILED"
+exit 1

--- a/scripts/lib_story_run.sh
+++ b/scripts/lib_story_run.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# lib_story_run.sh - command capture for the qwen story, with the two output
+# streams kept APART.
+#
+# Why this exists
+# ---------------
+# run_cmd used to capture `"$@" 2>&1` into a single RC_OUT, and nine call sites
+# then read RC_OUT: some pipe it to `jq`, some grep it for a panic. Those two
+# groups want opposite things, and merging served neither.
+#
+# On 2026-08-11 the nightly failed with
+#
+#     ✗ FAIL  B2 format_parity  -  no format_parity gate found in --json
+#             output (got: '', apr qa exit=0)
+#
+# The gate had in fact run and PASSED. `apr qa --json` writes its JSON to
+# stdout and its diagnostics to stderr (the CUDA path emits unconditional
+# `[trueno#243] Manual graph construction: ...` lines via eprintln!). Merging
+# put those lines in front of the JSON, `jq` could not parse the result, the
+# extraction came back empty, and the story reported a defect that did not
+# exist. A false FAIL is exactly as corrosive as a gate that cannot fail: main
+# goes red for a non-reason and the andon stops meaning anything.
+#
+# Conversely a panic message arrives on STDERR, so the checks that grep for
+# `thread ... panicked` genuinely need the merged view. Hence three variables
+# rather than one, and each call site states which view it needs.
+#
+# OPTION NEUTRALITY (load-bearing)
+# --------------------------------
+# This file is SOURCED. It must not run `set`: doing so mutates the CALLER's
+# shell. apr_bin.sh once opened with `set -euo pipefail`, qwen-story.sh sourced
+# it, and the leaked errexit killed the nightly six lines in - the story's whole
+# contract is to run every beat and tally failures, which errexit forbids.
+# Sourceable libraries here fail by RETURN STATUS, never by shell option.
+# Enforced by scripts/check_sourced_libs_option_neutral.sh.
+
+# Run one command under a timeout, capturing its streams separately.
+#
+# Args: timeout_seconds command...
+# Sets: RC_EC   exit status of the command (124 on timeout)
+#       RC_OUT  STDOUT only  - parse this when you want JSON
+#       RC_ERR  STDERR only  - diagnostics, warnings, progress
+#       RC_ALL  both, stdout first - grep this for panics and banners
+#       RC_TAIL last line of RC_ALL
+#
+# If the first argument is the literal `apr`, it is rewritten to "$APR" so every
+# call site is pinned to the freshness-asserted binary without touching them all.
+run_cmd() {
+  local t="$1"; shift
+  if [ "${1:-}" = "apr" ]; then shift; set -- "${APR:-apr}" "$@"; fi
+
+  local errfile
+  errfile=$(mktemp "${TMPDIR:-/tmp}/story-stderr.XXXXXX") || return 1
+
+  # Only stderr is redirected, so RC_OUT is exactly what the command wrote to
+  # stdout - byte for byte, with nothing interleaved.
+  RC_OUT=$(timeout "$t" "$@" 2>"$errfile"); RC_EC=$?
+  RC_ERR=$(cat "$errfile")
+  rm -f "$errfile"
+
+  # printf rather than a double-quoted string containing a literal newline:
+  # bashrs flags the latter as SC1078 (an unclosed double-quoted string).
+  if [ -n "$RC_ERR" ]; then
+    RC_ALL=$(printf '%s\n%s' "$RC_OUT" "$RC_ERR")
+  else
+    RC_ALL="$RC_OUT"
+  fi
+  RC_TAIL=$(printf '%s\n' "$RC_ALL" | tail -1)
+}

--- a/scripts/qwen-story.sh
+++ b/scripts/qwen-story.sh
@@ -67,17 +67,18 @@ emit_pass(){ PASS=$((PASS+1)); printf '✓ PASS  %s\n' "$1"; }
 emit_fail(){ FAIL=$((FAIL+1)); FAILED_BEATS+=("$1"); printf '✗ FAIL  %s  -  %s\n' "$1" "$2"; }
 emit_skip(){ SKIP=$((SKIP+1)); printf '○ SKIP  %s  -  %s\n' "$1" "$2"; }
 
-# Run a single apr command with a timeout, capture exit + last-line output.
-# Args: timeout_seconds command...
-# Sets globals: RC_EC, RC_OUT, RC_TAIL
-run_cmd() {
-  local t="$1"; shift
-  # Route a bare `apr` through the resolved, freshness-asserted binary so every
-  # call site is pinned without having to touch all 16 of them.
-  if [ "${1:-}" = "apr" ]; then shift; set -- "$APR" "$@"; fi
-  RC_OUT=$(timeout "$t" "$@" 2>&1); RC_EC=$?
-  RC_TAIL=$(echo "$RC_OUT" | tail -1)
-}
+# run_cmd lives in a sourceable library so its stream handling can be tested
+# directly - see scripts/check_story_json_streams.sh. It sets RC_OUT (stdout
+# only), RC_ERR (stderr only), RC_ALL (both) and RC_EC.
+#
+# Parse RC_OUT when you want JSON; grep RC_ALL when the thing you are looking
+# for could arrive on either stream (panics go to stderr). Merging the two
+# unconditionally is what made a PASSING format_parity gate report as missing.
+#
+# The explicit `|| exit 1` is what makes a missing library fatal; the library
+# itself must not run `set`, which would leak options into this script.
+# shellcheck source=scripts/lib_story_run.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib_story_run.sh" || exit 1
 
 # Print the captured output of the last run_cmd, indented, so it survives into
 # the story log (and therefore into the `story-log` CI artifact).
@@ -90,7 +91,7 @@ run_cmd() {
 # A verdict with no evidence behind it cannot be audited after the fact.
 emit_evidence() {
   printf '    -- captured output (%s) --\n' "$1"
-  printf '%s\n' "$RC_OUT" | sed 's/^/    /'
+  printf '%s\n' "$RC_ALL" | sed 's/^/    /'
 }
 
 # Extract rows from one `pmat query`, tolerating BOTH shapes pmat can return.
@@ -112,10 +113,18 @@ emit_evidence() {
 # Args: <jq-output-filter> <pmat query args...>
 pmat_rows() {
   local filter="$1"; shift
+  # The jq program is assembled with printf rather than written as a
+  # double-quoted string spanning several lines: bashrs reads the latter as an
+  # unterminated string (SC1078) and reported 2 errors here, which kept
+  # FALSIFY-QWEN-STORY-007 ("bashrs lints clean") red. Behaviour is unchanged -
+  # only the quoting is.
+  local prog
+  prog=$(printf '%s\n%s\n%s' \
+    'if type == "array" then .[] else empty end' \
+    '| select(.function != null)' \
+    "| $filter")
   pmat query "$@" --format json 2>/dev/null \
-    | jq -r "if type == \"array\" then .[] else empty end
-             | select(.function != null)
-             | $filter" 2>/dev/null \
+    | jq -r "$prog" 2>/dev/null \
     | head -3 || true
 }
 
@@ -217,7 +226,9 @@ beat2_trust() {
   # passed:true). The grep below therefore cannot distinguish "everything ran
   # and passed" from "half of it skipped".
   emit_evidence "apr qa $M_15B_APR"
-  if echo "$RC_OUT" | grep -q "ALL GATES PASSED"; then
+  # RC_ALL: the banner is a human-facing line and apr is free to put it on
+  # either stream; this check is about presence, not about parsing.
+  if echo "$RC_ALL" | grep -q "ALL GATES PASSED"; then
     emit_pass "B2 apr qa"
   else
     emit_fail "B2 apr qa" "no 'ALL GATES PASSED' line"
@@ -296,7 +307,9 @@ beat4_adapt() {
   elif [ "$RC_EC" -eq 5 ]; then
     # Clean validation error is acceptable post-#1865 (e.g. missing num_heads).
     emit_pass "B4 apr export (clean exit=5, no panic)"
-  elif [ "$RC_EC" -eq 101 ] || echo "$RC_OUT" | grep -qE 'thread.*panicked'; then
+  # RC_ALL, NOT RC_OUT: a Rust panic message is written to STDERR. Grepping
+  # stdout alone would silently stop detecting panics.
+  elif [ "$RC_EC" -eq 101 ] || echo "$RC_ALL" | grep -qE 'thread.*panicked'; then
     emit_fail "B4 apr export" "PANIC (exit=$RC_EC)  -  #1865 regression"
   else
     emit_fail "B4 apr export" "unexpected exit=$RC_EC"


### PR DESCRIPTION
`qwen-story-daily` is red on `main` with:

```
✗ FAIL  B2 format_parity  -  no format_parity gate found in --json
        output (got: '', apr qa exit=0)
16 PASS  /  1 FAIL  /  1 SKIP
```

**The gate ran. It passed.** Same command, same fixtures, same host, by hand:

```
format_parity: skipped=False passed=True
```

`run_cmd` captured `timeout "$t" "$@" 2>&1` into one `RC_OUT`, and nine call sites read it — some pipe it to `jq`, some grep it for a panic. Those want opposite things. `apr qa --json` writes JSON to stdout and diagnostics to stderr; the CUDA path emits unconditional `[trueno#243] Manual graph construction: ...` lines via `eprintln!` (7 sites under `crates/aprender-serve/src/cuda/`). Merging put those in front of the JSON → `jq` failed → empty extraction → a reported defect that does not exist.

A false FAIL is as corrosive as a gate that cannot fail: main goes red for a non-reason, and an andon that cries wolf stops being read.

`run_cmd` moves to `scripts/lib_story_run.sh` (sourceable and **option-neutral** — it must never run `set`, which is how `apr_bin.sh` once leaked errexit and killed this same nightly six lines in) and sets three views:

| | |
|---|---|
| `RC_OUT` | stdout only — parse this for JSON |
| `RC_ERR` | stderr only |
| `RC_ALL` | both — grep this for panics and banners |

The two sites that genuinely need stderr are switched to `RC_ALL` and say why. Not cosmetic: **a Rust panic is written to stderr**, so splitting the streams without moving `grep -qE 'thread.*panicked'` would have silently stopped the story detecting panics — a worse defect than the one being fixed.

**Falsifier**: `scripts/check_story_json_streams.sh` drives the real `run_cmd` over commands with known stream behaviour, including the exact failing shape. Wired into `ci.yml` beside the other text-only poka-yoke guards, and registered as `FALSIFY-QWEN-STORY-014`.

**Mutation check** — merged capture restored, guard kept:

```
RC_OUT=$(timeout "$t" "$@" 2>&1); RC_EC=$?   # MUTATION

FAIL  JSON on stdout survives diagnostics on stderr
   expected: false true
   actual:
FAIL  RC_OUT is stdout only
FAIL  RC_ERR is stderr only
check_story_json_streams: 3 assertion(s) FAILED
```

`actual:` empty is the production symptom exactly — the `got: ''` the nightly printed. The panic assertion stays green under that mutation, correctly: the pre-fix code did see panics.

**Also**: `FALSIFY-QWEN-STORY-007` ("bashrs lints clean") was *already failing on main* — 2 × `SC1078` from the `jq` program in `pmat_rows` being a double-quoted string spanning three lines. Assembled with `printf` instead; identical program, verified on both shapes pmat returns including the documents-object fallback. That falsifier is green again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
