### PR TITLE
fix(dogfood): batch 4 — nine gates that could not fail, found in the tooling that judges us

### DIFF
--- a/.claude/skills/apr-dogfood/SKILL.md
+++ b/.claude/skills/apr-dogfood/SKILL.md
@@ -27,7 +27,7 @@ description: Dogfood apr-cli — rebuild, install, exercise all commands against
 
 - apr-cli local version: !`grep '^version' crates/apr-cli/Cargo.toml | head -1`
 - Current git commit: !`git rev-parse --short HEAD`
-- Installed apr version: !`apr --version 2>/dev/null || echo "not installed"`
+- apr built from HEAD: !`APR=$(bash scripts/apr_bin.sh 2>/dev/null) && "$APR" --version || echo "none built from HEAD yet (Gate 1 builds it)"`
 - Available models: !`find ~/models -maxdepth 2 \( -name "*.apr" -o -name "*.gguf" -o -name "*.safetensors" \) -type f 2>/dev/null | wc -l` files
 - Test count: !`cargo test -p apr-cli --lib 2>&1 | grep 'test result' | tail -1`
 
@@ -78,56 +78,64 @@ Pick one per format. For EACH format, exercise ALL command categories:
 
 ### 2a. Inspection (11 commands)
 ```bash
+. scripts/apr_bin.sh || exit 1
 for cmd in inspect debug validate lint tensors trace diff hex tree flow explain; do
-  echo -n "$cmd: " && timeout 30 apr $cmd $MODEL 2>&1 | head -1 && echo "OK" || echo "FAIL"
+  echo -n "$cmd: " && timeout 30 "$APR" $cmd $MODEL 2>&1 | head -1 && echo "OK" || echo "FAIL"
 done
 ```
 
 ### 2b. QA & Evaluation (8 commands)
 ```bash
+. scripts/apr_bin.sh || exit 1
 for cmd in check qa qualify bench eval canary compare-hf parity; do
-  echo -n "$cmd: " && timeout 60 apr $cmd $MODEL 2>&1 | head -1 && echo "OK" || echo "SKIP/FAIL"
+  echo -n "$cmd: " && timeout 60 "$APR" $cmd $MODEL 2>&1 | head -1 && echo "OK" || echo "SKIP/FAIL"
 done
 ```
 
 ### 2c. Transform (9 commands)
 ```bash
+. scripts/apr_bin.sh || exit 1
 for cmd in convert export import quantize merge prune compile encrypt decrypt; do
-  echo -n "$cmd: " && timeout 30 apr $cmd --help 2>&1 | head -1 && echo "OK" || echo "FAIL"
+  echo -n "$cmd: " && timeout 30 "$APR" $cmd --help 2>&1 | head -1 && echo "OK" || echo "FAIL"
 done
 ```
 
 ### 2d. Inference (4 commands) — timeout 60
 ```bash
-apr run $MODEL "What is 2+2?" --max-tokens 16 2>&1 | tail -3
-apr serve plan $MODEL 2>&1 | head -5
+. scripts/apr_bin.sh || exit 1
+"$APR" run $MODEL "What is 2+2?" --max-tokens 16 2>&1 | tail -3
+"$APR" serve plan $MODEL 2>&1 | head -5
 ```
 
 ### 2e. Registry (4 commands)
 ```bash
-apr list 2>&1 | head -5
-apr list --json 2>&1 | jq length
-apr gpu 2>&1 | head -5
+. scripts/apr_bin.sh || exit 1
+"$APR" list 2>&1 | head -5
+"$APR" list --json 2>&1 | jq length
+"$APR" gpu 2>&1 | head -5
 ```
 
 ### 2f. Training & Data (6 commands)
 ```bash
+. scripts/apr_bin.sh || exit 1
 for cmd in finetune distill train tokenize tune data; do
-  echo -n "$cmd: " && timeout 10 apr $cmd --help 2>&1 | head -1 && echo "OK" || echo "FAIL"
+  echo -n "$cmd: " && timeout 10 "$APR" $cmd --help 2>&1 | head -1 && echo "OK" || echo "FAIL"
 done
 ```
 
 ### 2g. UI & Pipeline (7 commands)
 ```bash
+. scripts/apr_bin.sh || exit 1
 for cmd in tui monitor runs experiment pipeline diagnose showcase; do
-  echo -n "$cmd: " && apr $cmd --help 2>&1 | head -1 && echo "OK" || echo "FAIL"
+  echo -n "$cmd: " && "$APR" $cmd --help 2>&1 | head -1 && echo "OK" || echo "FAIL"
 done
 ```
 
 ### 2h. Remaining (8 commands)
 ```bash
+. scripts/apr_bin.sh || exit 1
 for cmd in rosetta publish oracle probar ptx ptx-map code cbtop; do
-  echo -n "$cmd: " && apr $cmd --help 2>&1 | head -1 && echo "OK" || echo "FAIL"
+  echo -n "$cmd: " && "$APR" $cmd --help 2>&1 | head -1 && echo "OK" || echo "FAIL"
 done
 ```
 
@@ -137,9 +145,10 @@ SKIP (not FAIL) if no models found. FAIL if any command panics or crashes.
 
 ### P1. Silent-Flag Protocol (FALSIFY-QA-007)
 ```bash
-diff <(apr inspect $M 2>&1) <(apr inspect --json $M 2>&1)
-diff <(apr inspect $M 2>&1) <(apr inspect --vocab $M 2>&1)
-diff <(apr list 2>&1) <(apr list --json 2>&1)
+. scripts/apr_bin.sh || exit 1
+diff <("$APR" inspect $M 2>&1) <("$APR" inspect --json $M 2>&1)
+diff <("$APR" inspect $M 2>&1) <("$APR" inspect --vocab $M 2>&1)
+diff <("$APR" list 2>&1) <("$APR" list --json 2>&1)
 ```
 FAIL if any flag produces identical output (no-op flag).
 
@@ -153,26 +162,30 @@ done
 
 ### P3. Flag-Echo Protocol
 ```bash
-out=$(apr run $M "test" --max-tokens 8 --temperature 0.5 2>&1)
+. scripts/apr_bin.sh || exit 1
+out=$("$APR" run $M "test" --max-tokens 8 --temperature 0.5 2>&1)
 # Verify temperature is actually 0.5, not default
 ```
 
 ### P4. Cross-Subcommand Consistency (FALSIFY-QA-010)
 ```bash
-F_INSPECT=$(apr inspect --json $M 2>/dev/null | jq -r '.architecture // empty')
-F_CHECK=$(apr check $M 2>&1 | grep -i arch | head -1)
+. scripts/apr_bin.sh || exit 1
+F_INSPECT=$("$APR" inspect --json $M 2>/dev/null | jq -r '.architecture // empty')
+F_CHECK=$("$APR" check $M 2>&1 | grep -i arch | head -1)
 echo "inspect=$F_INSPECT check=$F_CHECK"
 ```
 
 ### P5. Cache Integrity
 ```bash
-BEFORE=$(apr list 2>&1 | wc -l)
+. scripts/apr_bin.sh || exit 1
+BEFORE=$("$APR" list 2>&1 | wc -l)
 # pull, list, rm cycle should be consistent
 ```
 
 ### P6. GPU/CPU Parity (if GPU available)
 ```bash
-apr gpu 2>&1 | head -3
+. scripts/apr_bin.sh || exit 1
+"$APR" gpu 2>&1 | head -3
 # If GPU present: compare apr run --device cpu vs --device gpu
 ```
 
@@ -185,13 +198,15 @@ done
 
 ### P8. Version Sanity (FALSIFY-QA-005)
 ```bash
-apr --version | grep -qE '\(unknown\)|0000000' && echo "P3 VERSION SENTINEL"
+. scripts/apr_bin.sh || exit 1
+"$APR" --version | grep -qE '\(unknown\)|0000000' && echo "P3 VERSION SENTINEL"
 ```
 
 ### P9. Phantom Subcommand (FALSIFY-QA-008)
 ```bash
-apr --help | awk '/^  [a-z]/{print $1}' | while read cmd; do
-  apr "$cmd" --help 2>&1 | grep -qi "not.*implemented" && echo "PHANTOM: $cmd"
+. scripts/apr_bin.sh || exit 1
+"$APR" --help | awk '/^  [a-z]/{print $1}' | while read cmd; do
+  "$APR" "$cmd" --help 2>&1 | grep -qi "not.*implemented" && echo "PHANTOM: $cmd"
 done
 ```
 
@@ -204,13 +219,15 @@ done
 
 ### P11. Default-Defamation Protocol
 ```bash
-apr eval $M 2>&1 | grep -qi 'garbage\|broken\|corrupt' && echo "P3 DEFAMATION"
+. scripts/apr_bin.sh || exit 1
+"$APR" eval $M 2>&1 | grep -qi 'garbage\|broken\|corrupt' && echo "P3 DEFAMATION"
 ```
 
 ### P12. Hardware Cascade Protocol
 ```bash
+. scripts/apr_bin.sh || exit 1
 # If GPU fails, does CPU fallback work?
-apr gpu 2>&1 | head -3
+"$APR" gpu 2>&1 | head -3
 ```
 
 ## Gate 4: Contract Validation
@@ -261,12 +278,13 @@ Bad inputs MUST fail LOUD (non-zero exit + stderr message), never silently degra
 
 ### S1. Truncated file detection (GH-707)
 ```bash
+. scripts/apr_bin.sh || exit 1
 M_GGUF=$(find ~/models -maxdepth 2 -name "*.gguf" -type f | head -1)
 if [ -n "$M_GGUF" ]; then
   SIZE=$(stat -c%s "$M_GGUF")
   head -c $((SIZE / 2)) "$M_GGUF" > /tmp/apr-qa-truncated.gguf
   # IMPORTANT: capture exit code without piping (pipe loses $?)
-  OUTPUT=$(apr validate /tmp/apr-qa-truncated.gguf 2>&1); EC=$?
+  OUTPUT=$("$APR" validate /tmp/apr-qa-truncated.gguf 2>&1); EC=$?
   echo "$OUTPUT" | tail -3
   [ "$EC" -ne 0 ] && echo "S1 PASS: truncated file rejected (exit $EC)" || echo "S1 FAIL: truncated file accepted (GH-707)"
 fi
@@ -274,17 +292,19 @@ fi
 
 ### S2. Bad file rejection
 ```bash
-OUTPUT=$(apr bench /dev/null --iterations 1 2>&1); EC=$?
+. scripts/apr_bin.sh || exit 1
+OUTPUT=$("$APR" bench /dev/null --iterations 1 2>&1); EC=$?
 echo "$OUTPUT" | tail -1
 [ "$EC" -ne 0 ] && echo "S2 PASS: /dev/null rejected (exit $EC)" || echo "S2 FAIL: /dev/null accepted"
 ```
 
 ### S3. Unknown architecture handling (GH-704 pattern)
 ```bash
+. scripts/apr_bin.sh || exit 1
 # Check that Qwen3.5 SSM model gets a clear error, not silent llama fallback
 M_SSM=$(find ~/models -maxdepth 2 -name "*Qwen3.5*" -o -name "*qwen35*" 2>/dev/null | head -1)
 if [ -n "$M_SSM" ]; then
-  OUTPUT=$(apr run "$M_SSM" "test" --max-tokens 1 2>&1); EC=$?
+  OUTPUT=$("$APR" run "$M_SSM" "test" --max-tokens 1 2>&1); EC=$?
   echo "$OUTPUT" | grep -qi "not.*supported\|unsupported\|SSM" && \
     echo "S3 PASS: unsupported arch gives clear error" || echo "S3 FAIL: no clear error for unsupported arch"
 else
@@ -294,10 +314,11 @@ fi
 
 ### S4. Corrupted metadata detection
 ```bash
+. scripts/apr_bin.sh || exit 1
 if [ -n "$M_GGUF" ]; then
   cp "$M_GGUF" /tmp/apr-qa-corrupt.gguf
   dd if=/dev/zero of=/tmp/apr-qa-corrupt.gguf bs=1 count=64 seek=8 conv=notrunc 2>/dev/null
-  OUTPUT=$(apr validate /tmp/apr-qa-corrupt.gguf 2>&1); EC=$?
+  OUTPUT=$("$APR" validate /tmp/apr-qa-corrupt.gguf 2>&1); EC=$?
   echo "$OUTPUT" | tail -1
   [ "$EC" -ne 0 ] && echo "S4 PASS: corrupt metadata rejected (exit $EC)" || echo "S4 FAIL: corrupt metadata accepted"
 fi
@@ -305,7 +326,8 @@ fi
 
 ### S5. Missing model graceful (FALSIFY-QA-002)
 ```bash
-OUTPUT=$(apr inspect /nonexistent/model.gguf 2>&1); EC=$?
+. scripts/apr_bin.sh || exit 1
+OUTPUT=$("$APR" inspect /nonexistent/model.gguf 2>&1); EC=$?
 echo "$OUTPUT" | tail -1
 [ "$EC" -ne 0 ] && echo "S5 PASS: missing model exits non-zero (exit $EC)" || echo "S5 FAIL: exit 0 for missing model"
 ```
@@ -318,12 +340,13 @@ Contract: `contracts/apr-qa-metamorphic-v1.yaml`
 
 ### M1. Format roundtrip (GGUF→APR→GGUF tensor fidelity)
 ```bash
+. scripts/apr_bin.sh || exit 1
 if [ -n "$M_GGUF" ]; then
-  apr convert "$M_GGUF" --quantize q4k -o /tmp/apr-qa-rt.apr 2>&1 | tail -1  # --quantize is REQUIRED
+  "$APR" convert "$M_GGUF" --quantize q4k -o /tmp/apr-qa-rt.apr 2>&1 | tail -1  # --quantize is REQUIRED
   # If convert succeeds, check tensor count matches
   if [ -f /tmp/apr-qa-rt.apr ]; then
-    ORIG_TENSORS=$(apr tensors "$M_GGUF" --json 2>/dev/null | jq length 2>/dev/null || echo 0)
-    RT_TENSORS=$(apr tensors /tmp/apr-qa-rt.apr --json 2>/dev/null | jq length 2>/dev/null || echo 0)
+    ORIG_TENSORS=$("$APR" tensors "$M_GGUF" --json 2>/dev/null | jq length 2>/dev/null || echo 0)
+    RT_TENSORS=$("$APR" tensors /tmp/apr-qa-rt.apr --json 2>/dev/null | jq length 2>/dev/null || echo 0)
     echo "M1 orig=$ORIG_TENSORS rt=$RT_TENSORS"
     [ "$ORIG_TENSORS" -gt 0 ] && [ "$RT_TENSORS" -gt 0 ] && echo "M1 PASS" || echo "M1 WARN: tensor count mismatch"
   else
@@ -336,10 +359,11 @@ fi
 
 ### M2. Multi-architecture smoke
 ```bash
+. scripts/apr_bin.sh || exit 1
 # Check that inspect works across all available model architectures
 ARCH_COUNT=0
 for m in $(find ~/models -maxdepth 2 \( -name "*.gguf" -o -name "*.apr" -o -name "*.safetensors" \) -type f 2>/dev/null); do
-  ARCH=$(timeout 10 apr inspect --json "$m" 2>/dev/null | jq -r '.architecture // empty' 2>/dev/null)
+  ARCH=$(timeout 10 "$APR" inspect --json "$m" 2>/dev/null | jq -r '.architecture // empty' 2>/dev/null)
   [ -n "$ARCH" ] && ARCH_COUNT=$((ARCH_COUNT + 1)) && echo "  M2 arch=$ARCH ($m)"
 done
 [ "$ARCH_COUNT" -ge 2 ] && echo "M2 PASS: $ARCH_COUNT architectures inspected" || echo "M2 WARN: only $ARCH_COUNT architectures available"
@@ -347,10 +371,11 @@ done
 
 ### M3. Temperature determinism (temp=0 → identical output across 3 runs)
 ```bash
+. scripts/apr_bin.sh || exit 1
 M_APR=$(find ~/models -maxdepth 2 -name "*.apr" -type f | head -1)
 if [ -n "$M_APR" ]; then
-  OUT1=$(timeout 60 apr run "$M_APR" "Say hello" --max-tokens 4 --temperature 0.0 2>&1 | grep "^Output:" | head -1)
-  OUT2=$(timeout 60 apr run "$M_APR" "Say hello" --max-tokens 4 --temperature 0.0 2>&1 | grep "^Output:" | head -1)
+  OUT1=$(timeout 60 "$APR" run "$M_APR" "Say hello" --max-tokens 4 --temperature 0.0 2>&1 | grep "^Output:" | head -1)
+  OUT2=$(timeout 60 "$APR" run "$M_APR" "Say hello" --max-tokens 4 --temperature 0.0 2>&1 | grep "^Output:" | head -1)
   if [ "$OUT1" = "$OUT2" ] && [ -n "$OUT1" ]; then
     echo "M3 PASS: temp=0 deterministic"
   else
@@ -389,16 +414,17 @@ echo "V2: $SATD_HIGH High-severity SATD items"
 
 ### V3. Critical modules exercised (no panic on real model)
 ```bash
+. scripts/apr_bin.sh || exit 1
 M=$(find ~/models -maxdepth 2 \( -name "*.gguf" -o -name "*.apr" \) -type f | head -1)
 if [ -n "$M" ]; then
   V3_PASS=0; V3_TOTAL=0
   for cmd in "hex" "profile --iterations 1"; do
     V3_TOTAL=$((V3_TOTAL+1))
-    timeout 30 apr $cmd "$M" 2>&1 | head -3 >/dev/null && V3_PASS=$((V3_PASS+1)) && echo "  V3 $cmd: OK" || echo "  V3 $cmd: FAIL/SKIP"
+    timeout 30 "$APR" $cmd "$M" 2>&1 | head -3 >/dev/null && V3_PASS=$((V3_PASS+1)) && echo "  V3 $cmd: OK" || echo "  V3 $cmd: FAIL/SKIP"
   done
   for cmd in "serve plan" "train plan"; do
     V3_TOTAL=$((V3_TOTAL+1))
-    timeout 10 apr $cmd "$M" 2>&1 | head -3 >/dev/null && V3_PASS=$((V3_PASS+1)) && echo "  V3 $cmd: OK" || echo "  V3 $cmd: FAIL/SKIP"
+    timeout 10 "$APR" $cmd "$M" 2>&1 | head -3 >/dev/null && V3_PASS=$((V3_PASS+1)) && echo "  V3 $cmd: OK" || echo "  V3 $cmd: FAIL/SKIP"
   done
   echo "V3: $V3_PASS/$V3_TOTAL modules exercised"
   [ "$V3_PASS" -ge 2 ] && echo "V3 PASS" || echo "V3 WARN"
@@ -475,17 +501,19 @@ fi
 
 ### C2. Overwrite protection
 ```bash
+. scripts/apr_bin.sh || exit 1
 touch /tmp/apr-qa-existing.apr
-apr convert /dev/null -o /tmp/apr-qa-existing.apr 2>&1; EC=$?
+"$APR" convert /dev/null -o /tmp/apr-qa-existing.apr 2>&1; EC=$?
 # Should either fail (non-zero) or prompt — never silently overwrite
 [ "$EC" -ne 0 ] && echo "C2 PASS: existing file not silently overwritten" || echo "C2 WARN: may have overwritten"
 ```
 
 ### C3. SIGINT handling
 ```bash
+. scripts/apr_bin.sh || exit 1
 M_APR=$(find ~/models -maxdepth 2 -name "*.apr" -type f | head -1)
 if [ -n "$M_APR" ]; then
-  timeout 5 apr run "$M_APR" "Tell me a very long story about everything" --max-tokens 500 &
+  timeout 5 "$APR" run "$M_APR" "Tell me a very long story about everything" --max-tokens 500 &
   PID=$!
   sleep 2
   kill -INT $PID 2>/dev/null
@@ -505,11 +533,12 @@ Contract: `contracts/apr-qa-differential-v1.yaml`
 
 ### D1. Cross-format tensor agreement
 ```bash
+. scripts/apr_bin.sh || exit 1
 M_GGUF=$(find ~/models -maxdepth 2 -name "*.gguf" -type f | head -1)
 M_APR=$(find ~/models -maxdepth 2 -name "*.apr" -type f | head -1)
 if [ -n "$M_GGUF" ] && [ -n "$M_APR" ]; then
-  GGUF_COUNT=$(apr tensors "$M_GGUF" --json 2>/dev/null | jq length 2>/dev/null || echo 0)
-  APR_COUNT=$(apr tensors "$M_APR" --json 2>/dev/null | jq length 2>/dev/null || echo 0)
+  GGUF_COUNT=$("$APR" tensors "$M_GGUF" --json 2>/dev/null | jq length 2>/dev/null || echo 0)
+  APR_COUNT=$("$APR" tensors "$M_APR" --json 2>/dev/null | jq length 2>/dev/null || echo 0)
   echo "D1: GGUF tensors=$GGUF_COUNT APR tensors=$APR_COUNT"
   [ "$GGUF_COUNT" -gt 0 ] && [ "$APR_COUNT" -gt 0 ] && echo "D1 PASS: both formats report tensors" || echo "D1 WARN"
 else
@@ -534,11 +563,12 @@ fi
 
 ### D3. JSON schema consistency across commands
 ```bash
+. scripts/apr_bin.sh || exit 1
 M=$(find ~/models -maxdepth 2 \( -name "*.gguf" -o -name "*.apr" \) -type f | head -1)
 if [ -n "$M" ]; then
   D3_PASS=0
   for cmd in "inspect --json" "check --json" "list --json" "gpu --json"; do
-    timeout 15 apr $cmd $M 2>/dev/null | jq . >/dev/null 2>&1 && D3_PASS=$((D3_PASS+1))
+    timeout 15 "$APR" $cmd $M 2>/dev/null | jq . >/dev/null 2>&1 && D3_PASS=$((D3_PASS+1))
   done
   echo "D3: $D3_PASS/4 JSON outputs valid"
   [ "$D3_PASS" -ge 3 ] && echo "D3 PASS" || echo "D3 WARN"
@@ -608,11 +638,12 @@ Catches [#1865](https://github.com/paiml/aprender/issues/1865) — `apr export
 panic; exit 5 (clean ValidationFailed) is acceptable, exit 101 is a FAIL.
 
 ```bash
+. scripts/apr_bin.sh || exit 1
 G14_PASS=0
 G14_TOTAL=0
 for apr in $(find ~/models -maxdepth 2 -name "*.apr" -type f 2>/dev/null); do
   G14_TOTAL=$((G14_TOTAL+1))
-  OUT=$(timeout 60 apr export "$apr" --format gguf -o /tmp/g14-rt.gguf 2>&1); EC=$?
+  OUT=$(timeout 60 "$APR" export "$apr" --format gguf -o /tmp/g14-rt.gguf 2>&1); EC=$?
   # IMPORTANT: capture exit code via OUT=$(...); EC=$? — never via pipe (see Pre-Gate note).
   if [ "$EC" -eq 101 ] || echo "$OUT" | grep -qE "thread .* panicked"; then
     echo "G14 FAIL ($apr): panic exit=$EC"
@@ -642,15 +673,16 @@ checks are stubbed `Skip(Not implemented)` and the threshold gate compared
 against the full 100-point ceiling.
 
 ```bash
+. scripts/apr_bin.sh || exit 1
 # Find a known-good model — one that apr qa says is fine.
 M=$(find ~/models -maxdepth 2 \( -name "*.apr" -o -name "*.gguf" \) -type f | head -1)
 if [ -z "$M" ]; then
   echo "G15 SKIP: no model available"
 else
-  OUT=$(timeout 90 apr validate "$M" --quality 2>&1); EC=$?
+  OUT=$(timeout 90 "$APR" validate "$M" --quality 2>&1); EC=$?
   # apr qa is the canonical pass/fail (CLAUDE.md). If qa passes, validate --quality
   # MUST NOT exit non-zero solely because checks are unimplemented.
-  QA_OUT=$(timeout 120 apr qa "$M" 2>&1 | grep -E "ALL GATES PASSED|FAIL"); QA_PASSES=$?
+  QA_OUT=$(timeout 120 "$APR" qa "$M" 2>&1 | grep -E "ALL GATES PASSED|FAIL"); QA_PASSES=$?
   if echo "$QA_OUT" | grep -q "ALL GATES PASSED" && [ "$EC" -ne 0 ]; then
     echo "G15 FAIL: apr qa says ✓ ALL GATES PASSED but apr validate --quality exit=$EC (#1866)"
     echo "         likely score threshold counting Skip(Not implemented) against runnable denom"
@@ -671,11 +703,12 @@ Catches the secondary defect from [#1864](https://github.com/paiml/aprender/issu
 — `apr run` exiting 0 even when GPU dispatch produced obvious gibberish.
 
 ```bash
+. scripts/apr_bin.sh || exit 1
 M=$(find ~/models -maxdepth 2 -name "*.apr" -type f | head -1)
 if [ -z "$M" ]; then
   echo "G16 SKIP: no APR model"
 else
-  OUT=$(timeout 90 apr run "$M" "What is 2+2?" --max-tokens 16 2>&1); EC=$?
+  OUT=$(timeout 90 "$APR" run "$M" "What is 2+2?" --max-tokens 16 2>&1); EC=$?
   # Heuristic gibberish detectors. Real models answering 2+2 should produce
   # digits or short English. If the output contains chat-template control tokens
   # (e.g. <|im_start|>, <|endoftext|>) repeated, OR is dominated by a single
@@ -711,12 +744,13 @@ configuration; if 7B GPU inference produces gibberish, the canonical demo
 is broken.
 
 ```bash
+. scripts/apr_bin.sh || exit 1
 M_7B=$(find ~/models -maxdepth 2 -name "*7b*q4*" -type f 2>/dev/null | head -1)
 if [ -z "$M_7B" ]; then
   echo "G17 SKIP: no 7B Q4_K model in registry"
 else
   # apr qa Golden Output gate already encodes correctness; reuse it.
-  OUT=$(timeout 300 apr qa "$M_7B" 2>&1 | grep -E "Golden Output")
+  OUT=$(timeout 300 "$APR" qa "$M_7B" 2>&1 | grep -E "Golden Output")
   if echo "$OUT" | grep -q "FAIL"; then
     echo "G17 FAIL: 7B Golden Output gate FAILS — $OUT (#1864)"
   elif echo "$OUT" | grep -q "PASS"; then
@@ -744,12 +778,13 @@ be gated on a FRESH convert against the GGUF, on BOTH CPU and GPU. This is the g
 post-publish QA was missing (it tested `.apr` inspect/validate but never `.apr` *run*).
 
 ```bash
+. scripts/apr_bin.sh || exit 1
 M_GGUF=$(find ~/models -maxdepth 2 -name "*.gguf" -type f -size -3G | head -1)
 if [ -z "$M_GGUF" ]; then echo "G18 SKIP: no GGUF model"; else
   # NB: `apr convert` REQUIRES --quantize (or --compress). Omitting it fails with
   # "At least one of --quantize or --compress must be specified" and writes NO .apr —
   # which a naive test misreads as empty inference output. ALWAYS pass --quantize.
-  apr convert "$M_GGUF" --quantize q4k -o /tmp/g18-fresh.apr 2>&1 | tail -1
+  "$APR" convert "$M_GGUF" --quantize q4k -o /tmp/g18-fresh.apr 2>&1 | tail -1
   [ -f /tmp/g18-fresh.apr ] || echo "G18 FAIL: apr convert produced no .apr (forgot --quantize?)"
   norm(){ sed -n '/^Output:/,$p' | tail -n +2 | tr -d '[:space:]'; }
   # The P0 (PMAT-888) was GARBAGE, not a verbosity diff. GGUF runs may be response-CACHED
@@ -757,8 +792,8 @@ if [ -z "$M_GGUF" ]; then echo "G18 SKIP: no GGUF model"; else
   # COHERENCE (the real P0 signal), NOT byte-equality with GGUF.
   coherent(){ [ -n "$1" ] && echo "$1" | grep -qE '[0-9A-Za-z]' \
               && ! echo "$1" | grep -qE 'ä|ã|�|<\|im_start|<\|endoftext'; }
-  GGUF_OUT=$(timeout 120 apr run "$M_GGUF"        --no-gpu --prompt "What is 2+2?" --max-tokens 12 2>&1 | norm)
-  APR_OUT=$( timeout 120 apr run /tmp/g18-fresh.apr --no-gpu --prompt "What is 2+2?" --max-tokens 12 2>&1 | norm)
+  GGUF_OUT=$(timeout 120 "$APR" run "$M_GGUF"        --no-gpu --prompt "What is 2+2?" --max-tokens 12 2>&1 | norm)
+  APR_OUT=$( timeout 120 "$APR" run /tmp/g18-fresh.apr --no-gpu --prompt "What is 2+2?" --max-tokens 12 2>&1 | norm)
   echo "G18 gguf=[$GGUF_OUT] apr=[$APR_OUT]"
   if coherent "$APR_OUT"; then
     [ "$GGUF_OUT" = "$APR_OUT" ] && echo "G18 PASS: fresh .apr CPU inference coherent AND == GGUF" \
@@ -770,7 +805,7 @@ if [ -z "$M_GGUF" ]; then echo "G18 SKIP: no GGUF model"; else
   fi
   # GPU leg (if a GPU is present): the .apr GPU path must also be coherent
   if apr gpu 2>&1 | grep -qiE 'cuda|gpu.*(yes|available|RTX|GB10)'; then
-    APR_GPU=$(timeout 120 apr run /tmp/g18-fresh.apr --prompt "What is 2+2?" --max-tokens 12 2>&1 | norm)
+    APR_GPU=$(timeout 120 "$APR" run /tmp/g18-fresh.apr --prompt "What is 2+2?" --max-tokens 12 2>&1 | norm)
     coherent "$APR_GPU" && echo "G18-GPU PASS: fresh .apr GPU coherent" \
       || echo "G18-GPU FAIL: fresh .apr GPU=[$APR_GPU] not coherent"
   fi
@@ -789,11 +824,12 @@ not the original command's. Two real bugs were filed in a 2026-05-22 dogfood
 session and immediately retracted as false positives because of this:
 
 ```bash
+. scripts/apr_bin.sh || exit 1
 # WRONG — $? is head's exit, not apr's
-apr publish /nonexistent paiml/test 2>&1 | head -8; echo "exit=$?"   # always 0
+"$APR" publish /nonexistent paiml/test 2>&1 | head -8; echo "exit=$?"   # always 0
 
 # RIGHT — captures the command's real exit code
-OUT=$(apr publish /nonexistent paiml/test 2>&1); EC=$?
+OUT=$("$APR" publish /nonexistent paiml/test 2>&1); EC=$?
 echo "$OUT" | tail -1; echo "exit=$EC"
 ```
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -436,6 +436,17 @@ jobs:
       # reading the merged view. Behavioural, text-only, no build.
       - name: Story JSON parsing must read stdout, not the merged stream
         run: bash scripts/check_story_json_streams.sh
+      # Poka-yoke: mac-server runs 16 runners under ONE $HOME, so
+      # $HOME/.cargo/bin is shared mutable state. `cargo install` replaces a
+      # binary there while another job is mid-run and about to exec it — on
+      # 2026-07-31 Coverage Nightly died on
+      # `could not execute process .../cargo-llvm-cov ... No such file or
+      # directory (os error 2)` and posted an EMPTY coverage figure, i.e. a
+      # missing measurement (#2353). Text-only check, no build.
+      - name: Self-hosted jobs must install cargo tools into a private root
+        run: |
+          bash scripts/check_cargo_install_private_root.sh --self-test
+          bash scripts/check_cargo_install_private_root.sh
       # Poka-yoke: the 0.63.0 dogfood audit found 201 defects in code that was
       # shipped, tested and covered. The 5 Whys (docs/audits/dogfood-0.63.0-hansei.md)
       # landed on: nothing mechanical requires an assertion to EXCLUDE an outcome.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -455,6 +455,20 @@ jobs:
         run: |
           bash scripts/check_cargo_install_private_root.sh --self-test
           bash scripts/check_cargo_install_private_root.sh
+      # Poka-yoke: the nightly's pmat bug-hunt printed eight manifest headers and
+      # ZERO rows every night since the cron was added (#2356), so the workflow's
+      # "manifest grew by >5" alert branch never had a non-zero input. Three
+      # causes, each silent: the jq filters named `.function`/`.churn.commit_count`
+      # /`.faults` where pmat emits `function_name`/`commit_count`/
+      # `fault_annotations`; the churn and fault hunts passed the beat label as a
+      # free-text query, which is a relevance filter applied BEFORE `--path` and
+      # collapses a module-scoped hunt to nothing; and three hunted paths had been
+      # deleted or moved. All three present as "the manifest is empty tonight",
+      # which used to be indistinguishable from "the code is clean tonight" -
+      # pmat_hunt returned 0 unconditionally. It now fails the beat. Behavioural
+      # against a stubbed pmat, text-only, no build.
+      - name: The pmat bug-hunt manifest must be able to produce rows
+        run: bash scripts/check_story_pmat_hunt.sh
       # Poka-yoke: the 0.63.0 dogfood audit found 201 defects in code that was
       # shipped, tested and covered. The 5 Whys (docs/audits/dogfood-0.63.0-hansei.md)
       # landed on: nothing mechanical requires an assertion to EXCLUDE an outcome.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -406,8 +406,16 @@ jobs:
       # installed 0.61.0 to ~/.cargo/bin and then executed a 24-day-old 0.60.0
       # from ~/.local/bin, so every beat validated stale code while reporting
       # green. Text-only check, no build.
-      - name: Every CI-surface `apr` invocation must be pinned
+      - name: Every execution-surface `apr` reference must be pinned
         run: bash scripts/check_apr_bin_pinned.sh
+      # The guard's own must-match/must-not-match table plus one mutation per
+      # SCANNED SURFACE, in that surface's own syntax. #2358: extending the
+      # scope to scripts/** and .claude/skills/** did NOT carry the old proof
+      # over - the Makefile lesson repeated itself twice (a skill bash fence and
+      # a `!`...`` inline command were both invisible to a pattern that was
+      # correct everywhere else). Run the table; do not re-read the regex.
+      - name: "`apr`-pinning guard must still turn RED (case table + surfaces)"
+        run: bash scripts/check_apr_bin_pinned.sh --self-test
       # Poka-yoke: `set` in a SOURCED file mutates the caller's shell. apr_bin.sh
       # opened with `set -euo pipefail`; qwen-story.sh sources it and had chosen
       # `set -uo pipefail` deliberately (it must run every beat and tally the

--- a/.github/workflows/coverage-nightly.yml
+++ b/.github/workflows/coverage-nightly.yml
@@ -39,6 +39,29 @@ jobs:
     # full-workspace llvm-cov run. The `clean-room` label pins to that pool.
     runs-on: [self-hosted, Linux, X64, clean-room]
     timeout-minutes: 75
+    env:
+      IMAGE: localhost:5000/sovereign-ci:stable
+      # PER-RUN PRIVATE TOOL ROOT (#2353). mac-server runs 16 runners under ONE
+      # $HOME, so $HOME/.cargo/bin is shared mutable state across every
+      # concurrent job. `cargo install` replaces a binary there; a job that is
+      # mid-run and execs that same path gets whatever exists at that instant.
+      # On 2026-07-31 this job died with
+      #   could not execute process `/home/noah/.cargo/bin/cargo-llvm-cov`
+      #   (never executed) No such file or directory (os error 2)
+      # and reported an EMPTY coverage figure into the tracking issue — a
+      # MISSING measurement, the class project_coverage_floor_measurement_broken
+      # is about. ENOENT on an absolute path means the path did not exist when
+      # exec'd, which nothing but a concurrent writer to that path can produce.
+      #
+      # The fix removes the shared path rather than retrying around it: every
+      # `cargo install` in this job lands in a directory named after THIS run,
+      # which no other job can address. Note this deliberately redirects only
+      # the INSTALL ROOT, not CARGO_HOME (which is what the `security` job
+      # isolates): the registry/git caches under ~/.cargo are guarded by cargo's
+      # own package-cache lock and are safe to share, while a private CARGO_HOME
+      # would re-download the whole dependency graph every night for no gain.
+      COV_TOOLS: /tmp/apr-cov-tools-${{ github.run_id }}-${{ github.run_attempt }}
+      CARGO_INSTALL_ROOT: /tmp/apr-cov-tools-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       # clean: false — a coverage run builds from source and doesn't need a
       # pristine tree, and the default git-clean choked on root-owned leftovers
@@ -47,6 +70,60 @@ jobs:
       - uses: actions/checkout@v7
         with:
           clean: false
+
+      # Provision cargo-llvm-cov WITHOUT touching ~/.cargo/bin (#2353).
+      #
+      # Preferred source is the copy already baked into sovereign-ci at
+      # /usr/local/cargo/bin/cargo-llvm-cov — verified 2026-08-13 on mac-server
+      # to be the SAME version the runtime install was producing (0.8.7) and to
+      # execute on the host once copied out (host glibc 2.35). Using it costs a
+      # 4.5MB file copy instead of a ~5.5min compile, and the binary is pinned
+      # to whatever the image ships rather than to whatever crates.io has today.
+      #
+      # Fallback (image not cached / registry down / binary won't run here):
+      # compile it, but with an explicit --root so it STILL never lands in
+      # ~/.cargo/bin. Both paths write only to $COV_TOOLS.
+      #
+      # Fail closed. A coverage run without a working cargo-llvm-cov must be RED
+      # here, not a green job that reports an empty percentage.
+      - name: Provision cargo-llvm-cov into the per-run private root
+        run: |
+          set -euo pipefail
+          mkdir -p "$COV_TOOLS/bin"
+          src="none"
+          if docker image inspect "$IMAGE" > /dev/null 2>&1; then
+            # --user: without it the copy lands root-owned and the cleanup step
+            # (running as the runner user) cannot remove it.
+            if docker run --rm --user "$(id -u):$(id -g)" \
+                 -v "$COV_TOOLS/bin:/out" --entrypoint sh "$IMAGE" \
+                 -c 'cp /usr/local/cargo/bin/cargo-llvm-cov /out/'; then
+              src="image"
+            else
+              echo "::warning::could not copy cargo-llvm-cov out of $IMAGE — will build it"
+            fi
+          else
+            echo "sovereign-ci image not cached on this runner — will build the tool"
+          fi
+          if [ "$src" = "image" ]; then
+            if ! "$COV_TOOLS/bin/cargo-llvm-cov" llvm-cov --version; then
+              echo "::warning::baked cargo-llvm-cov does not run on this host — falling back to cargo install"
+              rm -f "$COV_TOOLS/bin/cargo-llvm-cov"
+              src="none"
+            fi
+          fi
+          if [ "$src" = "none" ]; then
+            export PATH="$COV_TOOLS/bin:$HOME/.cargo/bin:$HOME/.local/bin:$PATH"
+            cargo install cargo-llvm-cov --locked --root "$COV_TOOLS"
+            src="cargo-install"
+          fi
+          # Prove the mechanism engaged: name the file that will actually run.
+          # Under `set -e` this last check is the fail-closed gate — no working
+          # tool here means a RED job, never a green one reporting no number.
+          echo "provisioned from: $src"
+          ls -l "$COV_TOOLS/bin/cargo-llvm-cov"
+          "$COV_TOOLS/bin/cargo-llvm-cov" llvm-cov --version
+          # Ahead of ~/.cargo/bin for every later step in this job.
+          echo "$COV_TOOLS/bin" >> "$GITHUB_PATH"
 
       # Data + summary via the maintained Makefile machinery (handles the
       # mold-linker/config.toml dance + slow-test skips correctly). Non-blocking.
@@ -57,13 +134,24 @@ jobs:
         id: cov
         run: |
           set -o pipefail
-          # The 15 intel runners aren't uniformly provisioned: cargo / cargo-llvm-cov
-          # may be off PATH (some runners lack it), which makes the Makefile's
-          # `cargo install cargo-llvm-cov || exit 1` abort immediately. Put cargo on
-          # PATH for the make subshell + pre-install the tool (non-blocking) so the
-          # Makefile's `which cargo-llvm-cov` short-circuits.
-          export PATH="$HOME/.cargo/bin:$HOME/.local/bin:$PATH"
-          command -v cargo-llvm-cov >/dev/null 2>&1 || cargo install cargo-llvm-cov --locked || true
+          # The 15 intel runners aren't uniformly provisioned: cargo may be off
+          # PATH for a raw `run:` step, so put it there for the make subshell.
+          # $COV_TOOLS/bin goes FIRST so the Makefile's `which cargo-llvm-cov`
+          # short-circuits on the private copy — if ~/.cargo/bin led here, the
+          # private root would be decorative and #2353 would still be live.
+          export PATH="$COV_TOOLS/bin:$HOME/.cargo/bin:$HOME/.local/bin:$PATH"
+          # Assert it, don't assume it: a measurement run must prove which
+          # binary it is about to use, not describe its intent.
+          resolved="$(command -v cargo-llvm-cov || true)"
+          echo "cargo-llvm-cov resolves to: ${resolved:-<none>}"
+          case "$resolved" in
+            "$COV_TOOLS/bin/"*) ;;
+            *)
+              echo "::error::cargo-llvm-cov resolved to '${resolved:-<none>}', not the per-run private root $COV_TOOLS/bin"
+              echo "::error::a concurrent job could replace that path mid-run (aprender#2353)"
+              exit 1
+              ;;
+          esac
           # ARMED (was `|| true`). `make coverage` now enforces a RATCHET floor
           # (COV_FLOOR, the last measured value) rather than the aspirational 95%
           # target, so a red here means coverage went DOWN - not that we have not
@@ -76,10 +164,13 @@ jobs:
       # on PATH for raw run: steps on these runners, so source the cargo env; and
       # `|| true` keeps a pmat failure from aborting the job (the coverage % below
       # is the core deliverable; gap ranking is a bonus).
+      # CARGO_INSTALL_ROOT (job env) sends this install to the per-run root too,
+      # so this step cannot clobber another job's pmat either — the exposure is
+      # symmetric and #2353 only happened to be observed from the victim side.
       - name: Ensure pmat installed
         run: |
-          export PATH="$HOME/.cargo/bin:$HOME/.local/bin:$PATH"
-          command -v pmat >/dev/null 2>&1 || cargo install pmat --locked || true
+          export PATH="$COV_TOOLS/bin:$HOME/.cargo/bin:$HOME/.local/bin:$PATH"
+          command -v pmat >/dev/null 2>&1 || cargo install pmat --locked --root "$COV_TOOLS" || true
 
       # Dogfooded gap analysis — pmat query, NOT raw llvm-cov output (CLAUDE.md).
       # Same default ./target as the make step so pmat finds the coverage profiles.
@@ -87,7 +178,7 @@ jobs:
         id: gaps
         if: always()
         run: |
-          export PATH="$HOME/.cargo/bin:$HOME/.local/bin:$PATH"
+          export PATH="$COV_TOOLS/bin:$HOME/.cargo/bin:$HOME/.local/bin:$PATH"
           if command -v pmat >/dev/null 2>&1; then
             pmat query --coverage-gaps --exclude-tests --limit 30 > /tmp/gaps.txt 2>/dev/null \
               || echo "(pmat --coverage-gaps returned no data — coverage profile missing?)" > /tmp/gaps.txt
@@ -133,3 +224,14 @@ jobs:
           else
             gh issue create --title "$title" --body "$body" && echo "created tracking issue"
           fi
+
+      # A per-run directory that is never removed is just a slower leak. Drop
+      # this run's, then sweep any orphan left by a hard-killed run (which skips
+      # even `if: always()` steps — the same failure mode the workspace-test
+      # ownership-restore step exists for).
+      - name: Remove the per-run tool root
+        if: always()
+        run: |
+          rm -rf "$COV_TOOLS"
+          find /tmp -maxdepth 1 -name 'apr-cov-tools-*' -uid "$(id -u)" -mtime +1 \
+            -exec rm -rf {} + 2>/dev/null || true

--- a/.github/workflows/qwen-story-daily.yml
+++ b/.github/workflows/qwen-story-daily.yml
@@ -78,17 +78,23 @@ jobs:
           # Fail closed on staleness. A path fix alone would silently rot again
           # the next time PATH changes; this asserts that the apr the story is
           # about to run IS the one just built from this checkout.
-          WANT=$(grep -m1 '^version' Cargo.toml | sed 's/.*"\(.*\)".*/\1/')
-          GOT=$(apr --version)
-          echo "workspace version: $WANT"
-          echo "apr --version:     $GOT  ($(command -v apr))"
-          case "$GOT" in
-            *"$WANT"*) echo "apr binary is fresh" ;;
-            *)
-              echo "::error::STALE apr: workspace is $WANT but PATH resolves to '$GOT' at $(command -v apr). The story would validate code that is not this commit."
-              exit 1
-              ;;
-          esac
+          #
+          # This was hand-rolled as `GOT=$(apr --version)` compared against
+          # Cargo.toml's version, which is weaker than it looks in two ways
+          # (#2358): it read the version off a BARE `apr` - the exact defect the
+          # step exists to catch, six lines under a comment explaining it - and
+          # it compared only the VERSION, so any two builds of 0.63.0 matched,
+          # including a month-old one. scripts/apr_bin.sh asks cargo for the
+          # binary and compares the git SHA that build.rs embeds, so "fresh"
+          # means built from THIS commit rather than tagged with this number.
+          # APR_BIN_STRICT=1 makes "cannot prove" mean "refuse".
+          export APR_BIN_STRICT=1
+          . scripts/apr_bin.sh || {
+            echo "::error::STALE or missing apr - the story would validate code that is not this commit."
+            exit 1
+          }
+          echo "apr pinned to: $APR"
+          "$APR" --version
 
       - name: Run scripts/qwen-story.sh
         id: story

--- a/.github/workflows/toolchain-ceiling.yml
+++ b/.github/workflows/toolchain-ceiling.yml
@@ -1,0 +1,56 @@
+name: Toolchain Ceiling
+
+# The CEILING gate (aprender#2370). `scripts/check_msrv.sh` guards the FLOOR;
+# nothing guarded the ceiling.
+#
+# Every gate this repo owns — `make tier1/2/3`, the sovereign-ci `lint` job —
+# runs clippy through `rust-toolchain.toml`, which pins one exact release
+# (1.93.0). Clippy findings introduced by NEWER clippy releases therefore
+# accumulate with nothing to report them. #2370 is what that looks like from
+# outside: a fresh checkout on a machine whose rustc is not rustup-managed (a
+# homebrew rust, so the pin is silently inert) ran `make`, got clippy 1.96, and
+# `tier2` died with 28 errors that no gate here had ever seen. By the time it
+# was reported the tree had 107 findings across 12 lints.
+#
+# This job lints the tree on whatever stable is CURRENT, daily, and FAILS.
+#
+# Why scheduled and not per-PR: a new Rust release can introduce a lint on a
+# Tuesday morning. Blocking the merge queue on an event outside the repo is
+# the wrong trade — but letting it accumulate unseen is what produced #2370.
+# Scheduled + fail-closed is the middle: red the next morning, nobody blocked.
+#
+# The script refuses to pass vacuously (stale `stable` older than the pin, no
+# clippy component, broken version comparator) — see its header.
+
+on:
+  schedule:
+    - cron: '0 5 * * *' # 05:00 UTC — after the 04:00 binary nightly
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: toolchain-ceiling
+  cancel-in-progress: true
+
+jobs:
+  clippy-current-stable:
+    # clean-room pool, same as coverage-nightly: this is a full-workspace clippy
+    # run on a toolchain that is NOT the pinned one, so it cold-builds.
+    runs-on: [self-hosted, Linux, X64, clean-room]
+    timeout-minutes: 90
+    steps:
+      # clean: false — matches coverage-nightly; the default git-clean chokes on
+      # root-owned leftovers from prior jobs (contracts/.pv/cache → EACCES).
+      - uses: actions/checkout@v7
+        with:
+          clean: false
+
+      - name: Clippy on current stable (ceiling gate)
+        run: |
+          # Explicit `shell: run` default here is `bash -e`, NOT `bash -eo pipefail`
+          # (see memory: feedback_gh_default_shell_no_pipefail). No pipes below, and
+          # the script's own exit status is the verdict — do not tee it.
+          export PATH="$HOME/.cargo/bin:$HOME/.local/bin:$PATH"
+          bash scripts/check_clippy_current_stable.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -355,6 +355,26 @@ Mutation testing: `cargo mutants --no-times --timeout 300 --in-place -- --all-fe
 Workspace-level lints in `Cargo.toml` (`[workspace.lints.rust]` / `[workspace.lints.clippy]`).
 Key: `unsafe_code = "forbid"`, `clippy::all + pedantic = "warn"`, ML-specific allows for casts/float_cmp.
 
+**Both ends of the toolchain range are gated (#2370).** `rust-toolchain.toml` pins one
+exact release, so every gate we own — `make tier1/2/3`, sovereign-ci `lint` — lints
+under that one clippy and nothing else.
+
+| End | Guard | Runs |
+|-----|-------|------|
+| FLOOR — declared `rust-version` still builds | `scripts/check_msrv.sh` | on demand |
+| CEILING — current stable clippy is clean | `scripts/check_clippy_current_stable.sh` / `make lint-current` | `toolchain-ceiling.yml`, daily 05:00 UTC |
+
+Without the ceiling gate, findings from newer clippy releases accumulate invisibly:
+#2370 was a fresh mbp whose homebrew rustc is not rustup-managed (so the pin is
+silently inert) running plain `make` and getting 28 errors out of `tier2` — the tree
+had 107 findings across 12 lints by then, none of which any gate had ever run.
+The ceiling gate refuses to pass vacuously (stale `stable`, missing clippy component,
+broken version comparator) and ships a comparator case table that `tier3` re-runs.
+
+Clippy's lint set is **not monotonic**: the #2370 tree is clean on 1.93/1.96/1.97 and
+1.95 *alone* reports 8 `collapsible_match` findings. A green ceiling gate means
+"clean on the pin and on current stable", never "clean on every release between".
+
 ## CI/CD (`.github/workflows/`)
 
 - **ci.yml**: check, fmt, clippy, test, coverage (Codecov), mutation testing, security audit, docs, bashrs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,33 @@
 
 ## Project Overview
 
-Aprender is a next-generation ML framework in pure Rust — **monorepo with 78 workspace crates** (82 directories under `crates/`: 4 are `exclude`d from the workspace, 1 has no manifest). Install: `cargo install aprender` → `apr` binary (103 subcommands). 25,300+ tests, 1767 provable contracts. Core library in `crates/aprender-core/` ([lib] name = "aprender"). All 20 repos (trueno, realizar, entrenar, batuta, + 15 satellites) consolidated per APR-MONO spec. **v0.34.0 SHIPPED 2026-05-18: MODEL-2 §88 stack-existence-proof, paiml/albor-370m-v1 LIVE on HF Hub.**
+Aprender is a next-generation ML framework in pure Rust — a monorepo where the
+workspace, not this file, is the source of truth. Install: `cargo install aprender` →
+`apr` binary. Core library in `crates/aprender-core/` ([lib] name = "aprender").
+20 repos (5 core + 15 satellites, per `docs/specifications/aprender-monorepo-consolidation.md`)
+were merged in and archived 20/20.
+
+### Derive the numbers; do not quote them (#2331)
+
+Every count in this file drifted. The published figures were wrong by 3.2× on the
+test count and 29 minor versions on the release line before they were checked. So
+**the table gives the command, and the value is only a dated sample.** If a number
+here disagrees with its command, the command wins.
+
+| Fact | Derive with | Sample (2026-08-13) |
+|------|-------------|---------------------|
+| Workspace crates | `cargo metadata --no-deps --format-version 1 \| python3 -c "import json,sys;print(len(json.load(sys.stdin)['packages']))"` | 78 — 77 under `crates/` plus the root facade |
+| Dirs under `crates/` | `ls -1d crates/*/ \| wc -l` | 82. **This is not the crate count**: 4 are `exclude`d in the root `Cargo.toml`, and `aprender-contracts-staging` has no manifest. A directory is not a crate |
+| `apr` subcommands | `apr --help`; registry is `contracts/apr-cli-commands-v1.yaml` §`commands`, mirrored by `crates/apr-cli/tests/cli_commands.rs::registered_commands` | 103, in 10 categories |
+| Provable contracts | `find contracts -name '*.yaml' \| wc -l` | 1768 |
+| Workspace lib tests | the `Summary` line of CI's `workspace-test` job (see Build Commands for the exact nextest invocation) | **80,604 passed**, 130 skipped, across 69 binaries — CI run `31631488466`, `main` @ `d40756541`, 2026-08-12 |
+| Released version | `git tag --sort=-creatordate \| head -1` · `gh release list` | **v0.63.0**, 2026-08-01 ("provenance") |
+
+`crates/aprender-core/tests/readme_contract.rs` is the drift gate for all three published
+docs: README.md's crate/contract counts, `docs/BEATS.md` vs the beat contracts, and every
+repo-relative file path cited in **this file**. A path here that does not exist fails the
+build (FALSIFY-DOCS-CLAUDE-001) — that is what caught the six pre-monorepo `realizar/…`
+and `src/format/…` paths this file still advertised. Counts it cannot check, you re-derive.
 
 ## Git Workflow (Branch Protection)
 
@@ -58,13 +84,20 @@ When using `/loop`, treat fallback wakeups as cheap and merge events as primary.
 ## Build Commands
 
 ```bash
-cargo build --release              # Optimized build (all 78 workspace crates)
-cargo test --workspace --lib       # Full workspace lib tests (25,300+)
-cargo test -p aprender-core --lib  # Core ML library only (12,975)
-cargo test -p apr-cli --lib        # CLI tests only (4,158)
-cargo check --workspace            # Type-check all 78 workspace crates
-cargo fmt --check                  # Check formatting
-cargo clippy -- -D warnings        # Strict linting
+cargo build --release              # Optimized build (every workspace member; no default-members)
+cargo test -p aprender-core --lib  # Core ML library only
+cargo test -p apr-cli --lib        # CLI tests only
+cargo check --workspace            # Type-check the whole workspace
+cargo fmt --all -- --check         # Check formatting (--all, not just the root package)
+cargo clippy -p <crate> --lib -- -D warnings   # Strict lint. Bare `cargo clippy` only
+                                   # lints the ROOT FACADE package, which is nearly empty
+
+# What CI's `workspace-test` job actually runs (.github/workflows/ci.yml). Reproduce
+# THIS, not `cargo test --workspace --lib` — the three excluded crates need a GPU
+# toolchain and are gated separately:
+cargo nextest run --profile ci --workspace --lib \
+    --exclude aprender-gpu --exclude aprender-cuda-edge --exclude aprender-compute
+cargo test -p aprender-compute --lib   # the SIMD crate, run as its own CI step
 
 # Install
 cargo install aprender             # Install `apr` binary (like cargo install ollama)
@@ -88,8 +121,8 @@ GH-202 lesson: we read code instead of running `apr qa` which would have instant
 an absolute path to one. Four `apr` binaries were found coexisting on the dev box
 (0.60.0 ×2, 0.61.0, 0.62.0); a bare `apr` resolved to a **26-day-old** copy, and
 the path this file used to call "canonical" was two minor versions stale. There is
-no correct path to hardcode — `.cargo/config.toml` redirects cargo's target-dir and
-is gitignored, so the main checkout and a fresh worktree build to different places.
+no correct path to hardcode — `.cargo/config.toml` [gitignored] redirects cargo's
+target-dir, so the main checkout and a fresh worktree build to different places.
 
 ```bash
 . scripts/apr_bin.sh || exit 1   # exports $APR, proves it was built from HEAD
@@ -131,13 +164,25 @@ All tools support GGUF, APR, and SafeTensors formats. If a tool says "format not
 
 ### Realizar Inference Tracing
 
-Located in `realizar/src/inference_trace.rs`:
+**There is no `realizar` binary.** `realizar` is the *library* name of the
+`aprender-serve` package (`[lib] name = "realizar"`, `crates/aprender-serve/Cargo.toml`);
+that package ships no `[[bin]]`. Tracing is driven through `apr run`:
+
 ```bash
-realizar run model.safetensors --prompt "2+2?" --trace
-realizar run model.gguf --prompt "Hi" --trace=tokenize,sample,decode
+"$APR" run model.safetensors --prompt "2+2?" --trace
+"$APR" run model.gguf --prompt "Hi" --trace --trace-steps tokenize,sample,decode
+"$APR" run model.gguf --prompt "Hi" --trace --trace-level payload   # or --trace-payload
 ```
 
-TraceSteps: `Tokenize`, `Embed`, `LayerNorm`, `Attention`, `FFN`, `TransformerBlock`, `LmHead`, `Sample`, `Decode`
+The flag is `--trace-steps <a,b,c>` (comma-delimited), not `--trace=<...>`.
+`--trace-level` accepts `none|basic|layer|payload|chrome` and defaults to `basic`.
+
+Implementation: `crates/aprender-serve/src/inference_trace/` (a DIRECTORY — `mod.rs`
+plus `save_tensor*.rs`, `gpu_stage_dump.rs`, `tracer_contracts.rs`, …).
+
+TraceSteps (`TraceStep` in `crates/aprender-serve/src/inference_trace/mod.rs`): `Tokenize`, `Embed`, `LayerNorm`,
+`Attention`, `FFN`, `TransformerBlock`, `LmHead`, `Sample`, `Decode`, `KernelLaunch`
+(PTX-level, GH-219), `BrickProfile` (trueno `BrickProfiler`).
 
 ## Architecture
 
@@ -145,7 +190,8 @@ TraceSteps: `Tokenize`, `Embed`, `LayerNorm`, `Attention`, `FFN`, `TransformerBl
 2. **Backend Agnostic** - CPU (SIMD), GPU, WASM via Trueno
 3. **Three-Tier API**: High (`Estimator` trait), Mid (`Optimizer`/`Loss`/`Regularizer`), Low (Trueno primitives)
 
-**Monorepo layout** (78 workspace crates across 82 `crates/` dirs, flat `crates/aprender-*` per Polars/Burn/Nushell pattern):
+**Monorepo layout** (flat `crates/aprender-*` per the Polars/Burn/Nushell pattern; for
+the crate count run the command in the Project Overview table, don't trust a number here):
 - `crates/aprender-core/` — ML library ([lib] name = "aprender")
 - `crates/aprender-compute/` — SIMD/GPU (was trueno, [lib] name = "trueno")
 - `crates/aprender-serve/` — inference server (was realizar, [lib] name = "realizar")
@@ -185,7 +231,11 @@ cargo run --bin apr --features inference -- run model.safetensors \
     --prompt "What is 2+2?" --max-tokens 32
 ```
 
-Feature flag: `inference = ["realizar", "tokio", "axum"]` (default-enabled in apr-cli).
+Feature flag (`crates/apr-cli/Cargo.toml`): `inference = ["realizar", "trueno", "tokio",
+"axum", "futures-util"]`, and `default = ["hf-hub", "safetensors-compare", "inference",
+"training", "visualization", "zram"]` — so `inference` is on unless you pass
+`--no-default-features`. GPU work needs `--features cuda`, which pulls in `inference`,
+`realizar/cuda` and `entrenar/cuda`.
 Always profile with `apr profile`/`apr trace`/`apr bench` before optimizing.
 
 ### Performance Targets (Ollama Parity)
@@ -196,19 +246,25 @@ Always profile with `apr profile`/`apr trace`/`apr bench` before optimizing.
 | 7B Q4_K | 30+ | 150+ | 4GB |
 | 13B Q4_K | 15+ | 80+ | 8GB |
 
+These are **targets**, not measurements. For what is actually measured against Ollama,
+see `docs/BEATS.md`: GPU decode on RTX 4090 sm_89 is at **parity** (1.015–1.109×), and
+`contracts/beat-ollama-decode-throughput-speed-v1.yaml` enforces `beat_threshold: 0.9000`
+— a no-collapse floor. The old "apr beats Ollama 1.371×" headline is **withdrawn**.
+
 Architecture: Trueno SIMD backend, realizar fused dequant+matmul kernels, PagedAttention KV cache, optional wgpu/CUDA.
 
 ### FFN Gate+Up Kernel Fusion (PMAT-FFN-FUSION)
 
 The SwiGLU FFN block fuses gate and up projections into a single rayon dispatch via
-`generic_fused_gate_up_matvec_into<F>` (realizar `quantize/fused_gate_up.rs`). This halves
+`generic_fused_gate_up_matvec_into<F>` (`crates/aprender-serve/src/quantize/fused_gate_up.rs:63`). This halves
 rayon spawn overhead (56→28 dispatches/token on 28-layer models) and improves L1/L2 cache
 reuse by loading the activation vector once per midi-tile instead of twice.
 
 - **Fused path**: Q4K, Q5K, Q6K when both gate+up weights share the same qtype and dims
 - **Fallback**: `rayon::join` with two separate `fused_matmul_into` for mixed types
 - **Q8K path**: Existing `fused_q4k_q8k_ffn_up_gate_into` still used when Q8K activations available
-- **Key files**: `realizar/src/quantize/fused_gate_up.rs`, `fused_matmul_into.rs` (`fused_gate_up_matmul_into`)
+- **Key files**: `crates/aprender-serve/src/quantize/fused_gate_up.rs`,
+  `crates/aprender-serve/src/gguf/inference/fused_matmul_into.rs` (`fused_gate_up_matmul_into`)
 
 ## LAYOUT-001/002: Tensor Layout Safety
 
@@ -235,11 +291,12 @@ use crate::quantize::fused_q4k_parallel_matvec;
 use crate::quantize::fused_q6k_parallel_matvec;
 ```
 
-**Key Files:**
+**Key Files** (all under `crates/aprender-core/` — the pre-monorepo top-level `src/`
+paths this file used to give have not existed since APR-MONO):
 - `contracts/tensor-layout-v1.yaml` - **SOURCE OF TRUTH**
-- `src/format/layout_contract.rs` - Rust validation API
-- `src/format/converter/write.rs` - GGUF→APR import with transpose
-- `src/format/converter/mod.rs` - `transpose_q4k_for_matmul()`, `transpose_q6k_for_matmul()`
+- `crates/aprender-core/src/format/layout_contract.rs` - Rust validation API
+- `crates/aprender-core/src/format/converter/write.rs` - GGUF→APR import with transpose
+- `crates/aprender-core/src/format/converter/mod.rs` - `transpose_q4k_for_matmul()`, `transpose_q6k_for_matmul()`
 
 ```rust
 use aprender::format::layout_contract::{CONTRACT, LayoutContract};
@@ -259,14 +316,23 @@ CONTRACT.validate_apr_shape("lm_head.weight", &[vocab, hidden], vocab, hidden)?;
 The `models/` pattern silently matches `src/models/` — hiding source code from git and crates.io. Always use `/models/` (root-anchored).
 
 ```bash
-# Pre-publish checks (also in make tier3)
-bash scripts/check_include_files.sh     # All 562 include!() files tracked by git
-bash scripts/check_package_includes.sh  # All 319 src/ include!() files in cargo package
+# Pre-publish checks (also in make tier3). Both print the count they checked —
+# read it off the output, don't quote a number from this file.
+bash scripts/check_include_files.sh     # scans src/ AND crates/; printed 1771 on 2026-08-13
+bash scripts/check_package_includes.sh  # scans src/ ONLY, against `cargo package -p aprender --list`
 
 # After creating new include!() files, verify they're not gitignored:
-git ls-files --others --exclude-standard src/
-git check-ignore -v src/path/to/new_file.rs  # Should return exit 1 (not ignored)
+git ls-files --others --exclude-standard crates/
+git check-ignore -v crates/<crate>/src/path/to/new_file.rs  # exit 1 == not ignored (good)
 ```
+
+**`check_package_includes.sh` is currently vacuous — know this before trusting it.**
+It greps `include!(` in the root `src/` only, and the root `src/` is a two-file facade
+(`lib.rs`, `bin/`) with **zero** `include!()` directives. So it reports
+`OK: All 0 include!() files are included in cargo package` and can never fail. The
+real coverage against CB-510 today comes from `check_include_files.sh` (1771 files,
+`src/` + `crates/`). Extending the package check to the 70+ publishable member crates
+is open work — do not treat its green as evidence.
 
 **After any `.gitignore` or `Cargo.toml` exclude change:** re-run both scripts.
 
@@ -341,12 +407,22 @@ ran (#2361). When a fix seems to have no effect, ask what else claims that name
 Target: 60% unit, 30% property, 10% integration. Coverage: **88.78% line** (786448/885829, measured 2026-07-29 by coverage-nightly on 95145584f; target ≥95%, enforced floor 88% via COV_FLOOR). The long-quoted "96.35%" predates the measurement ever working - the pipeline reported 0/0 until #2333.
 
 ```bash
-cargo test                    # All tests (12,974 lib + 4,599 integration)
-cargo test --lib              # Unit only
-cargo test --test integration # Integration
-cargo test --doc              # Doctests
-make coverage                 # Coverage report (disables mold linker, single-phase llvm-cov)
+cargo test -p <crate> --lib             # Unit tests for one crate (what you run while working)
+cargo test -p <crate> --test <target>   # ONE integration target. There is NO root
+                                        # `tests/` dir, so `cargo test --test integration`
+                                        # fails at the workspace root — the `integration.rs`
+                                        # targets live per-crate (aprender-core, aprender-data,
+                                        # aprender-registry, …)
+cargo test --doc                        # Doctests
+make coverage                           # Coverage report (disables mold linker, single-phase llvm-cov)
 ```
+
+For the workspace-wide number, reproduce CI's `workspace-test` nextest command (see
+Build Commands) and read its `Summary` line — 80,604 tests on 2026-08-12. Only a
+subset of integration targets is wired into CI: `.github/workflows/ci.yml` runs `--lib`
+across the workspace, plus ONE explicit line listing the individual `--test` targets
+(beats, `cli_commands`, `monorepo_invariants`, `readme_contract`, …). A new
+`tests/*.rs` file is dark until it is added to that line.
 
 Mutation testing: `cargo mutants --no-times --timeout 300 --in-place -- --all-features` (or via CI).
 
@@ -397,14 +473,20 @@ Clippy's lint set is **not monotonic**: the #2370 tree is clean on 1.93/1.96/1.9
 - `crates/aprender-core/src/primitives/` - Vector/Matrix with Cholesky solver
 - `crates/aprender-core/src/format/` - APR format, validation, lint, converter, export
 - `crates/aprender-core/src/text/chat_template/` - Chat template engine (a DIRECTORY: mod.rs + template.rs/raw_template.rs/ship_008.rs via include!)
-- `crates/apr-cli/` - CLI logic (103 commands)
+- `crates/apr-cli/` - CLI logic (command registry: `contracts/apr-cli-commands-v1.yaml`)
 - `src/bin/apr.rs` - Root binary entry point (`cargo install aprender`)
-- `contracts/` - 1767 provable contracts (merged from all 20 repos)
+- `contracts/` - provable contracts, merged from all 20 repos (`find contracts -name '*.yaml' | wc -l`)
 - `docs/specifications/aprender-monorepo-consolidation.md` - Monorepo spec
+- `docs/BEATS.md` - the public beat scoreboard. Gated against `contracts/` by
+  `crates/aprender-core/tests/readme_contract.rs`
 
 ## APR CLI (`cargo install aprender`)
 
-103 commands across 10 categories. Contract: `contracts/apr-cli-commands-v1.yaml`.
+103 commands across 10 categories as of 2026-08-13; the registry is
+`contracts/apr-cli-commands-v1.yaml` (§`commands`), mirrored by
+`crates/apr-cli/tests/cli_commands.rs::registered_commands` and enforced by
+FALSIFY-CLI-001/002. Note the contract's own `scope:` string still says "77 commands" —
+that prose is stale; the list is authoritative.
 Key commands: `run`, `chat`, `serve`, `pull`, `finetune`, `prune`, `distill`, `merge`, `quantize`, `inspect`, `debug`, `validate`, `diff`, `tensors`, `trace`, `lint`, `explain`, `export`, `import`, `convert`, `compile`, `train`, `tune`, `eval`, `bench`, `profile`, `qa`, `mcp`, `probar`, `cbtop`, `tui`, `hex`, `tree`, `flow`, `qualify`
 
 ```bash
@@ -417,10 +499,32 @@ apr import hf://openai/whisper-tiny -o whisper.apr --arch whisper
 apr qa model.gguf --assert-tps 100 --json
 ```
 
-## PMAT Quality Analysis (v3.10.0)
+## PMAT Quality Analysis
 
-**Scores:** Project 124/134 (A+), TDG 95.2/100 (A+), Coverage 88.78% (measured 2026-07-29), Mutation 85.3%
-**Thresholds:** Coverage ≥95%, Complexity ≤10/fn, SATD 0, TDG ≥95, Mutation ≥85%, 0 unwrap()
+Version: run `pmat --version` (3.30.0 on this box, 2026-08-13). `.pmat-gates.toml`
+still carries a header comment claiming it was "Updated for PMAT v2.215.0".
+
+**Scores.** Only one of these has a citable measurement, so only one is stated:
+
+| Score | Value | Provenance |
+|-------|-------|------------|
+| Line coverage | **88.78%** (786448/885829) | coverage-nightly, 2026-07-29, commit `95145584f`. The long-quoted "96.35%"/"96.94%" predates the pipeline ever working — it reported 0/0 until #2333 |
+| Project score / TDG / mutation % | **re-derive** — `pmat rust-project-score`, `pmat tdg . --include-components`, `cargo mutants` | The previously published "124/134", "TDG 95.2/100" and "Mutation 85.3%" carried no date or commit and could not be reproduced from the tree |
+
+**Thresholds — read from the config, which does not say what this file used to say:**
+
+| Gate | Configured as | Where |
+|------|---------------|-------|
+| Coverage (aspirational) | `min_coverage = 95.0` | `.pmat-gates.toml` |
+| Coverage (**enforced**) | `COV_FLOOR := 88` — the last *measured* value, and the one that actually fails a build | `Makefile:287`, `.github/workflows/coverage-nightly.yml` |
+| Cyclomatic complexity | `max_complexity = 10` per fn | `.pmat-gates.toml` |
+| TDG | `min_grade = "B"` — **not** "≥95" | `.pmat-gates.toml` `[tdg]` |
+| Mutation | `MUTANTS_MAX_MISSED` (default **0**) surviving mutants **on the PR diff** — not a global 85% score | `.github/workflows/ci.yml:517` |
+| Verification ladder | `min_level = "L3"` | `.pmat-gates.toml` |
+| `unwrap()` | banned outright | `.clippy.toml` disallowed-methods |
+
+SATD is checked by `pmat analyze satd`, but no SATD threshold is configured in
+`.pmat-gates.toml`; the pre-commit hook there is `pmat comply check --failures-only`.
 
 ```bash
 pmat quality-gates              # Run all gates (config: .pmat-gates.toml)
@@ -452,7 +556,12 @@ pv diff contracts/apr-mcp-server-v1.yaml HEAD~3  # semver bump suggestion
 pv coverage                                      # cross-contract obligation coverage
 ```
 
-40+ `pv` subcommands: `validate, scaffold, codegen, kani, probar, status, audit, diff, coverage, generate, graph, equations, lean, proof-status, lint, score, query, invariants, coq, fuzz, mirai, flux, tla, book, infer, roofline, pipeline, kaizen, certify, verify-structure, verify-pipeline, ...`.
+`pv --help` lists the full set (42 subcommands + `help` in pv 0.49.0): `explain,
+validate, check-parity, scaffold, extract-pytorch, codegen, kani, probar, status,
+audit, diff, coverage, generate, graph, equations, lean, lean-status, proof-status,
+lint, score, query, invariants, coq, fuzz, mirai, flux, tla, book, infer, unlock,
+roofline, pipeline, kaizen, certify, verify-structure, verify-pipeline,
+verify-bindings, migrate`.
 
 **If `pv validate` rejects a contract** (wrong kind, missing required fields), the fix is one of:
 1. Restructure the contract to fit the existing schema (usually `KernelContract` shape with `equations`, `proof_obligations`, `falsification_tests`).
@@ -561,12 +670,16 @@ See monorepo spec Rule 7: Coverage + Contracts Co-Evolution.
 
 ```bash
 batuta oracle --rag "your question here"    # Search entire Sovereign AI Stack
-batuta oracle --rag-index                   # Reindex (335 docs)
+batuta oracle --rag-index                   # Reindex (the command prints the doc count)
 ```
 
 Use proactively for trueno SIMD patterns, cross-language equivalents, and stack best practices.
 
-## SSC Training Infrastructure Status (2026-03-22)
+## SSC Training Infrastructure Status (snapshot 2026-03-22 — STALE, re-verify before acting)
+
+This block has not been re-measured in ~5 months and one of its premises no longer
+holds: it points at "trueno 0.4.36" as an external crate, but since APR-MONO trueno is
+in-tree as `crates/aprender-compute` and has no independent version to wait on.
 
 - **SSC canary eval**: 90% accuracy, SHIP gate PASS — classifier ready to ship
 - **entrenar cuBLAS integration**: GEMM parity verified between CPU and GPU paths

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ SHELL := /bin/bash
 # Multi-line recipes execute in same shell
 .ONESHELL:
 
-.PHONY: all build test test-smoke test-fast test-quick test-full test-heavy lint fmt clean doc book book-build book-serve book-test tier1 tier2 tier3 tier4 coverage coverage-fast profile hooks-install hooks-verify lint-scripts bashrs-score bashrs-lint-makefile chaos-test chaos-test-full chaos-test-lite fuzz bench dev pre-push ci check run-ci run-bench audit deps-validate deny pmat-score pmat-gates quality-report semantic-search examples mutants mutants-fast property-test install-alsa test-alsa test-audio-full contract-validate contract-test contract-audit contract-regen contract-check dev-setup check-siblings
+.PHONY: all build test test-smoke test-fast test-quick test-full test-heavy lint lint-current fmt clean doc book book-build book-serve book-test tier1 tier2 tier3 tier4 coverage coverage-fast profile hooks-install hooks-verify lint-scripts bashrs-score bashrs-lint-makefile chaos-test chaos-test-full chaos-test-lite fuzz bench dev pre-push ci check run-ci run-bench audit deps-validate deny pmat-score pmat-gates quality-report semantic-search examples mutants mutants-fast property-test install-alsa test-alsa test-audio-full contract-validate contract-test contract-audit contract-regen contract-check dev-setup check-siblings
 
 # Default target
 all: tier2
@@ -126,6 +126,14 @@ test-spec: ## Run ALL spec falsification tests (structural only, no models)
 lint:
 	cargo clippy -- -D warnings
 
+# Toolchain CEILING gate (aprender#2370). `lint` above runs through the
+# rust-toolchain.toml pin, so clippy findings from NEWER releases accumulate
+# unseen until someone's toolchain outruns the pin. This lints on current
+# stable instead, and refuses to pass vacuously. Mirror of `check_msrv.sh`,
+# which guards the floor.
+lint-current:
+	@bash scripts/check_clippy_current_stable.sh
+
 # Format check
 fmt:
 	cargo fmt
@@ -212,6 +220,8 @@ tier3:
 	@bash scripts/check_build_rs_paths.sh
 	@echo "Checking self-hosted CI jobs pin a discriminating runner label..."
 	@bash scripts/check_runner_labels.sh
+	@echo "Checking the toolchain-ceiling guard's comparator (aprender#2370)..."
+	@bash scripts/check_clippy_current_stable.sh --self-test
 	@if [ -d tests/golden ]; then \
 		if . scripts/apr_bin.sh 2>/dev/null; then \
 			echo "Running probar golden regression with profiling... ($$APR)"; \

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ publishing — all backed by YAML provable contracts that fail CI on drift.
 | Metric | Count | Source of truth |
 |-------:|------:|---|
 | Workspace crates | **78** workspace crates | `cargo metadata --no-deps` (NOT `ls crates/` — 4 are `exclude`d, 1 has no Cargo.toml) |
-| Provable contracts | **1768** provable contracts | `find contracts/ -name '*.yaml'` |
+| Provable contracts | **1770** provable contracts | `find contracts/ -name '*.yaml'` |
 | CLI commands | **103** CLI commands | `apr --help` |
 | Book CLI chapters | **103** chapters | `ls book/src/cli/*.md` (parity with CLI) |
 | Book lib chapters | **69** chapters | `ls book/src/lib/*.md` (parity with `pub mod`) |

--- a/contracts/apr-docs-v1.yaml
+++ b/contracts/apr-docs-v1.yaml
@@ -52,6 +52,38 @@ equations:
     - "All markdown files parse correctly"
     - "All internal links resolve"
 
+  beats_scoreboard_matches_contracts:
+    formula: |
+      let T = contracts/beat-ollama-decode-throughput-speed-v1.yaml : beat.beat_threshold
+      docs/BEATS.md MUST state T verbatim as the gate of record
+      T < 1.0  =>  no Ollama-decode row in docs/BEATS.md is marked **WON**
+      forall m in measurements recorded by the contract:
+        docs/BEATS.md contains m
+    domain: docs/BEATS.md text, contracts/beat-*.yaml
+    codomain: bool (scoreboard agrees with contract)
+    invariants:
+    - "The contract is the gate of record; the scoreboard may not invent a threshold"
+    - "beat_threshold < 1.0 is a NO-COLLAPSE FLOOR and may never be reported as a win"
+    - "A withdrawn claim is retracted with its replacing numbers, never deleted —
+       under-claiming is a reporting failure too"
+    preconditions:
+    - "docs/BEATS.md exists and the referenced beat contract parses"
+    postconditions:
+    - "A reader of docs/BEATS.md sees the same threshold CI enforces"
+
+  claude_md_paths_resolve:
+    formula: |
+      forall p in backticked repo-relative source paths cited in {CLAUDE.md, docs/BEATS.md}:
+        exists(workspace_root / p)  or  the citing line is marked `[gitignored]`
+    domain: CLAUDE.md and docs/BEATS.md text, filesystem
+    codomain: bool
+    invariants:
+    - "Onboarding docs cite paths that exist — APR-MONO moved every crate under crates/"
+    - "Scope is narrow (backticked, no glob metacharacters, source extension) so the
+       gate cannot cry wolf"
+    preconditions:
+    - "Both documents exist at the workspace root"
+
 falsification_tests:
 - id: FALSIFY-README-001
   rule: cargo install aprender in README
@@ -83,9 +115,39 @@ falsification_tests:
   test: mdbook build book/
   if_fails: Documentation is broken
 
+- id: FALSIFY-DOCS-BEATS-001
+  rule: BEATS.md publishes the gate the contract carries, and never the withdrawn 1.10x one
+  prediction: >-
+    docs/BEATS.md contains the literal "beat_threshold: <value>" read from
+    contracts/beat-ollama-decode-throughput-speed-v1.yaml
+  test: cargo test -p aprender-core --test readme_contract test_beats_md_ollama_gate_matches_contract
+  if_fails: The public scoreboard advertises a CI gate that does not exist
+
+- id: FALSIFY-DOCS-BEATS-002
+  rule: a no-collapse floor is never reported as a win
+  prediction: while beat_threshold < 1.0, no Ollama-decode row in docs/BEATS.md contains "**WON**"
+  test: cargo test -p aprender-core --test readme_contract test_beats_md_ollama_decode_is_not_marked_won_under_a_floor
+  if_fails: A withdrawn beat is republished as WON — the exact #2349 defect
+
+- id: FALSIFY-DOCS-BEATS-003
+  rule: a withdrawal cites the numbers that replaced the claim
+  prediction: every apr/ollama tok/s and ratio in the contract's measurement table appears in docs/BEATS.md
+  test: cargo test -p aprender-core --test readme_contract test_beats_md_publishes_every_contract_measurement
+  if_fails: The retraction hides the measurements — under-claiming instead of over-claiming
+
+- id: FALSIFY-DOCS-CLAUDE-001
+  rule: documented paths exist
+  prediction: every backticked repo-relative source path in CLAUDE.md and docs/BEATS.md resolves
+  test: cargo test -p aprender-core --test readme_contract test_documented_paths_exist
+  if_fails: Onboarding docs send readers to files deleted by APR-MONO
+
 proof_obligations:
 - type: invariant
   property: "README install command matches actual binary"
+- type: invariant
+  property: "docs/BEATS.md states the same beat_threshold the contract enforces"
+- type: invariant
+  property: "documented file paths resolve in the tree"
 
 kani_harnesses:
 - id: KH-DOCS-001
@@ -94,7 +156,7 @@ kani_harnesses:
   bound: 4
 
 verification_summary:
-  total_obligations: 5
+  total_obligations: 9
   proven: 0
-  tested: 5
+  tested: 9
   status: tested

--- a/contracts/apr-lint-flag-parity-v1.yaml
+++ b/contracts/apr-lint-flag-parity-v1.yaml
@@ -1,0 +1,225 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# apr-lint-flag-parity-v1
+#
+# A gate may not own a parser.
+#
+# `apr gptq-lint` and `apr awq-lint` each ran a "CLI flag accepted" gate that
+# decided whether an argv recorded in an observation would be accepted by the
+# shipped binary. Both decided it with a hand-rolled `while i < argv.len()`
+# matcher living in the same crate as the assertion
+# (`parse_gptq_flags`/`parse_awq_flags` + `validate_*_flags`). Those matchers
+# understood `--method`, `--bits`, `--group-size`.
+#
+# The shipped `apr quantize` (`Commands::Quantize`, crates/apr-cli/src/commands_enum.rs)
+# takes `<FILE> --scheme/-s --output/-o --format --batch --plan --force`. NOT ONE
+# FLAG WAS SHARED, and neither `gptq` nor `awq` is an accepted `--scheme` value.
+# The gate was green throughout while validating a second implementation that
+# stood beside the assertion instead of the command that ships.
+#
+# This contract binds the gate's verdict to the SHIPPED clap parser, so the two
+# cannot drift: renaming a `quantize` flag changes the gate's answer in the same
+# commit that changes the CLI.
+#
+# aprender#2377 finding 2.
+# ─────────────────────────────────────────────────────────────────────────────
+
+contract: apr-lint-flag-parity
+metadata:
+  kind: pattern
+  version: 1.0.0
+  created: '2026-08-13'
+  last_modified: '2026-08-13'
+  author: PAIML Engineering
+  description: >
+    The `flags` gate of every `apr *-lint` command decides "would the shipped
+    `apr quantize` accept this argv?" by running the shipped clap parser
+    (`Cli::command().try_get_matches_from`), never a second parser of its own.
+    Implemented by crates/apr-cli/src/commands/quantize_flag_parity.rs and
+    consumed by gptq_lint.rs and awq_lint.rs.
+  references:
+  - 'aprender#2377 finding 2 — the lint flag gate validated a CLI that does not exist'
+  - 'crates/apr-cli/src/commands/quantize_flag_parity.rs — the predicate'
+  - 'crates/apr-cli/src/commands/lint_error.rs — the exit-code convention (3/4/5/7)'
+  - 'crates/apr-cli/src/commands_enum.rs — Commands::Quantize, the shipped surface'
+
+equations:
+  gate_verdict_is_the_shipped_parser_verdict:
+    formula: >
+      verdict(argv) = accepted  <=>  Cli::command().try_get_matches_from(["apr", "quantize"] ++ argv).is_ok()
+    domain: argv is Vec<String>, the argv recorded after `apr quantize` in an observation
+    codomain: verdict in {accepted, rejected}
+    invariants:
+    - 'no argv is classified by any parser other than the one the binary parses with'
+    - 'argv containing --method, --bits or --group-size is rejected (apr quantize has no such flag)'
+    - 'argv = [<FILE>, --scheme, <s>, -o, <path>] is accepted'
+    - 'verdict is deterministic: verdict(argv) = verdict(argv) for all argv'
+    postconditions:
+    - 'verdict is Rejected implies reason is the clap error first line, non-empty'
+    preconditions:
+    - 'every element of argv is a UTF-8 string'
+
+  gate_passes_iff_observation_matches_the_parser:
+    formula: >
+      gate.passed = (verdict(argv) == expected_outcome), expected_outcome in {accepted, ok, rejected}
+    domain: >
+      argv is Vec<String>, expected_outcome is String read from observation.flags.expected_outcome
+    codomain: gate.passed is bool
+    invariants:
+    - 'expected_outcome = accepted (or its alias ok) and verdict = rejected implies gate.passed = false'
+    - 'expected_outcome = rejected and verdict = accepted implies gate.passed = false'
+    - 'gate.passed = false implies the failure text names the flags apr quantize does accept'
+    postconditions:
+    - 'gate.failure is Some if and only if gate.passed = false'
+    preconditions:
+    - 'observation.flags.argv is present and is an array of strings'
+    - 'observation.flags.expected_outcome is present'
+
+  unusable_observation_is_exit_4_not_exit_5:
+    formula: >
+      exit_code = if expected_outcome not in {accepted, ok, rejected} then 4 else (if gate.passed then 0 else 5)
+    domain: observation.flags is a JSON object
+    codomain: exit_code in {0, 4, 5}
+    invariants:
+    - 'a per-flag label (missing_method, wrong_method, unknown_method, invalid_bits, missing_bits, invalid_group_size) is exit 4, never folded into rejected'
+    - 'a missing expected_outcome is exit 4, never defaulted to accepted'
+    - 'a missing argv is exit 4, never treated as the empty argv'
+    postconditions:
+    - 'exit_code 5 implies the observation was usable and the shipped parser disagreed with it'
+    preconditions:
+    - 'the observation file exists, is non-empty and parses as JSON (otherwise 3/4/7 per lint_error.rs)'
+
+  accepted_flag_list_is_read_off_the_shipped_command:
+    formula: >
+      accepts_summary = join(render(a) for a in Cli::command().find_subcommand("quantize").get_arguments() if a.id not in {help, version})
+    domain: the shipped clap Command tree
+    codomain: a String naming every argument apr quantize accepts
+    invariants:
+    - 'accepts_summary contains <FILE>, --scheme, --output, --format, --batch, --plan and --force'
+    - 'accepts_summary never contains --method, --bits or --group-size'
+    postconditions:
+    - 'accepts_summary is non-empty'
+    preconditions:
+    - 'the shipped CLI exposes a `quantize` subcommand'
+
+falsification_tests:
+- id: FALSIFY-LINTFLAG-001
+  rule: the acceptance oracle is the shipped parser, not a copy of it
+  name: shipped_parser_rejects_the_flags_the_hand_rolled_parser_accepted
+  prediction: >
+    shipped_quantize_verdict(["--method","gptq","--bits","4","--group-size","128"])
+    returns Rejected, and the reason names --method. The deleted
+    validate_gptq_flags called this exact argv Ok { bits: 4, group_size: 128 }.
+  test_harness: 'cargo test -p apr-cli --lib shipped_parser_rejects_the_flags_the_hand_rolled_parser_accepted'
+  expected_output: "test result: ok"
+  if_fails: >
+    Pre-fix behaviour: the gate ran its own matcher, so an argv the shipped
+    `apr quantize` refuses outright was reported as a valid CLI surface.
+
+- id: FALSIFY-LINTFLAG-002
+  rule: a real apr quantize invocation is reported accepted
+  name: shipped_parser_accepts_a_real_quantize_invocation
+  prediction: >
+    shipped_quantize_verdict(["model.safetensors","--scheme","int4","-o","out.apr"])
+    returns Accepted — the flags the binary really takes.
+  test_harness: 'cargo test -p apr-cli --lib shipped_parser_accepts_a_real_quantize_invocation'
+  expected_output: "test result: ok"
+  if_fails: >
+    Pre-fix behaviour: parse_gptq_flags/parse_awq_flags saw no --method in this
+    argv and returned MissingMethod, so the one argv `apr quantize` actually
+    accepts was the one the gate called invalid.
+
+- id: FALSIFY-LINTFLAG-003
+  rule: the gate verdict equals the shipped parser verdict
+  name: gate_fails_when_observation_expects_the_nonexistent_flags_to_be_accepted
+  prediction: >
+    evaluate_flags_observation({argv: [--method, gptq, --bits, 4, --group-size, 128],
+    expected_outcome: ok}) returns passed = false with a failure naming --scheme.
+  test_harness: 'cargo test -p apr-cli --lib gate_fails_when_observation_expects_the_nonexistent_flags_to_be_accepted'
+  expected_output: "test result: ok"
+  if_fails: >
+    Pre-fix behaviour: this observation PASSED. got == expected == "ok" because
+    both sides were produced by the same hand-rolled matcher.
+
+- id: FALSIFY-LINTFLAG-004
+  rule: both lint commands report the rejection end to end
+  name: flags_gate_rejects_the_method_bits_argv_the_shipped_cli_never_took
+  prediction: >
+    `apr gptq-lint` and `apr awq-lint` both fail on an observation recording
+    --method/--bits/--group-size with expected_outcome ok; the stderr carries
+    the FALSIFY stamp, the word REJECTED, and the --scheme flag the binary does
+    take. Two tests share this name, one per lint.
+  test_harness: 'cargo test -p apr-cli --lib flags_gate_rejects_the_method_bits_argv_the_shipped_cli_never_took'
+  expected_output: "test result: ok"
+  if_fails: >
+    Pre-fix behaviour: both commands exited 0 on that observation, so a CI
+    harness wired to them could never notice the flags did not exist.
+
+- id: FALSIFY-LINTFLAG-005
+  rule: the accepted-flag list an operator is shown comes from clap
+  name: accepts_summary_never_advertises_the_flags_that_do_not_exist
+  prediction: >
+    shipped_quantize_accepts_summary() names <FILE>, --scheme, --output,
+    --format, --batch, --plan and --force, and contains none of --method,
+    --bits, --group-size.
+  test_harness: 'cargo test -p apr-cli --lib accepts_summary'
+  expected_output: "test result: ok"
+  if_fails: >
+    A hardcoded flag list in the failure message drifts from the CLI exactly the
+    way the hand-rolled parser did, and tells the operator to try flags that do
+    not exist.
+
+- id: FALSIFY-LINTFLAG-006
+  rule: a stale observation is unusable input (exit 4), not a gate rejection (exit 5)
+  name: flags_gate_stale_vocabulary_is_unusable_input
+  prediction: >
+    An observation whose expected_outcome is a per-flag label the real parser
+    cannot emit (missing_bits, missing_method, …) exits 4 per
+    crates/apr-cli/src/commands/lint_error.rs, so a CI wrapper reads "your
+    capture is stale" and not "the system under test broke a contract".
+  test_harness: 'cargo test -p apr-cli --lib flags_gate_stale_vocabulary_is_unusable_input'
+  expected_output: "test result: ok"
+  if_fails: >
+    Folding the stale labels into "rejected" would let an old observation pass
+    for a brand-new reason — the exact class of test that locks a defect in.
+
+- id: FALSIFY-LINTFLAG-007
+  rule: an observation may assert the refusal the parser really produces
+  name: gate_passes_when_observation_expects_the_nonexistent_flags_to_be_rejected
+  prediction: >
+    evaluate_flags_observation({argv: [--method, awq, --bits, 4],
+    expected_outcome: rejected}) returns passed = true — negative captures stay
+    expressible under the new vocabulary.
+  test_harness: 'cargo test -p apr-cli --lib gate_passes_when_observation_expects_the_nonexistent_flags_to_be_rejected'
+  expected_output: "test result: ok"
+  if_fails: >
+    A gate that can only report acceptance cannot record a deliberate negative
+    case, so operators would drop the negative captures entirely.
+
+proof_obligations:
+- type: invariant
+  property: "gate verdict = shipped clap parser verdict for every argv"
+- type: invariant
+  property: "no lint gate contains an argv parser of its own"
+- type: invariant
+  property: "an expected_outcome outside {accepted, ok, rejected} exits 4, never 5"
+- type: invariant
+  property: "the accepted-flag list shown on failure is read from Cli::command()"
+
+qa_gate:
+  id: F-LINT-FLAG-PARITY-GATE
+  name: Lint Flag Parity Gate
+  description: >
+    The `flags` gate of the apr *-lint family must decide acceptance with the
+    shipped clap parser. Any reintroduction of a hand-rolled argv matcher turns
+    FALSIFY-LINTFLAG-001/003/004 red.
+  checks:
+  - validation
+  - falsification
+  pass_criteria: All 7 falsification tests + 4 proof obligations pass
+
+verification_summary:
+  total_obligations: 4
+  l2_property_tested: 4
+  l3_kani_proved: 0
+  l4_lean_proved: 0
+  l4_sorry_count: 0

--- a/contracts/apr-serve-cancellation-v1.yaml
+++ b/contracts/apr-serve-cancellation-v1.yaml
@@ -1,0 +1,201 @@
+metadata:
+  version: 1.0.0
+  created: '2026-08-13'
+  author: PAIML Engineering
+  description: apr serve must stop generating when the HTTP client disconnects
+  references:
+  - aprender#2376 finding 3
+  lessons_learned:
+  - 'aprender#2376(3): one abandoned request pinned a core at ~250% CPU for the remaining
+    life of the process, with zero open connections'
+  - 'Dropping a future only cancels work suspended at an await point; a synchronous
+    decode loop has no await inside it, so axum dropping the response future could
+    not reach it'
+  - 'Asserting that a cancellation flag was set proves nothing — the shipped defect
+    is compatible with the flag being set and nobody reading it. Assert observed work
+    (tokens produced) instead.'
+
+equations:
+  tokens_generated_bound:
+    formula: len(generate(prompt, cfg)) - len(prompt) == min(cfg.max_tokens, effective_context_budget,
+      polls_until_cancel)
+    domain: prompt in u32^n with 1 <= n <= context_length; cfg.max_tokens in N; cfg.cancel
+      a CancelToken
+    codomain: N (count of newly generated tokens)
+    invariants:
+    - tokens_generated <= cfg.max_tokens
+    - tokens_generated <= polls_until_cancel
+    - cfg.cancel is never cancelled => tokens_generated == min(cfg.max_tokens, effective_context_budget)
+    - cfg.cancel cancelled before entry => tokens_generated == 0
+    - the cancelled output is a prefix of the uncancelled output for the same prompt,
+      seed and sampling parameters
+    preconditions:
+    - prompt is non-empty
+    - the decode loop calls cfg.cancel.is_cancelled() exactly once per decode step,
+      before performing that step's forward pass
+    postconditions:
+    - result.len() >= prompt.len()
+    - result.len() - prompt.len() <= cfg.max_tokens
+    - result.len() - prompt.len() <= cfg.cancel.polls()
+    - result[..prompt.len()] == prompt
+  poll_rate:
+    formula: cancel.polls() == tokens_generated + 1 when cancellation trips, else tokens_generated
+    domain: a live CancelToken observed by exactly one decode loop
+    codomain: N (poll count)
+    invariants:
+    - 'polls is bounded: the loop polls at most once per token, so cancellation is
+      observed within one token of being requested'
+    - CancelToken::never() allocates nothing and always answers false, so an unwired
+      caller pays a null check and no atomic
+    preconditions:
+    - the token is not shared between concurrent decode loops
+    postconditions:
+    - cancel.polls() <= tokens_generated + 1
+    - cancel.polls() == 0 for CancelToken::never()
+  disconnect_signal:
+    formula: drop(response_future) => cancel.peek_cancelled() == true
+    domain: an axum request routed through the cancel_on_disconnect layer
+    codomain: bool (cancellation state observable by the decode loop)
+    invariants:
+    - the layer mints one token per request and publishes it in the request extensions
+    - the CancelOnDrop guard lives in the layer's future, so axum dropping that future
+      on client disconnect sets the flag
+    - the inner handler runs in a separate task, so its decode loop is still alive
+      to observe the flag after the drop
+    - a request that COMPLETES returns a response byte-identical to the same handler
+      invoked directly with CancelToken::never()
+    preconditions:
+    - the router carries the cancel_on_disconnect layer
+    - the handler installs the extension token on its generation config
+    postconditions:
+    - cancel.peek_cancelled() == true after the layer's future is dropped
+    - the decode loop terminates with tokens_generated < cfg.max_tokens
+    - a completed request's response body is unchanged by the layer
+
+falsification_tests:
+- id: FALSIFY-SERVE-CANCEL-001
+  name: dense_generation_stops_at_the_cancel_point_not_max_tokens
+  prediction: 'Model::generate with max_tokens=64 and CancelToken::with_budget(8) returns
+    prompt.len() + 8 tokens and polls the token 9 times; the same call with no cancellation
+    returns prompt.len() + 64, and the cancelled output is a prefix of it.'
+  test_harness: cargo test -p aprender-serve --lib dense_generation_stops_at_the_cancel_point_not_max_tokens
+  expected_output: 'test result: ok'
+  if_fails: 'PRE-FIX: GenerationConfig had no cancel field and layers/model_model.rs::generate
+    had no poll, so the loop produced 64 tokens whether or not the client was still
+    there — a cancelled request was indistinguishable from an uncancelled one.'
+- id: FALSIFY-SERVE-CANCEL-002
+  name: dense_generation_cancelled_before_start_produces_no_tokens
+  prediction: 'Model::generate with an already-cancelled CancelToken and max_tokens=64
+    returns exactly prompt.len() tokens — zero decode work.'
+  test_harness: cargo test -p aprender-serve --lib dense_generation_cancelled_before_start_produces_no_tokens
+  expected_output: 'test result: ok'
+  if_fails: 'PRE-FIX: the loop ran all 64 forward passes. Also fails if the poll is
+    placed at the END of the loop body instead of the top, which costs one wasted
+    forward pass per cancelled request.'
+- id: FALSIFY-SERVE-CANCEL-003
+  name: quantized_generation_stops_at_the_cancel_point_not_max_tokens
+  prediction: 'OwnedQuantizedModel::generate_with_cache with max_tokens=48 and CancelToken::with_budget(6)
+    returns prompt.len() + 6 tokens and polls 7 times; uncancelled it returns prompt.len()
+    + 48.'
+  test_harness: cargo test -p aprender-serve --lib quantized_generation_stops_at_the_cancel_point_not_max_tokens
+  expected_output: 'test result: ok'
+  if_fails: 'PRE-FIX: this is the loop behind apr serve run model.gguf on /generate,
+    /stream/generate, /v1/completions and /v1/chat/completions. It ran the full 48-token
+    budget for a client that had already hung up.'
+- id: FALSIFY-SERVE-CANCEL-004
+  name: dropping_the_request_future_stops_a_running_generation
+  prediction: 'A synchronous decode loop with a ceiling of 500000 steps, running under
+    the cancel_on_disconnect layer, terminates after strictly fewer than 500000 steps
+    once the request future is dropped mid-decode.'
+  test_harness: cargo test -p aprender-serve --lib dropping_the_request_future_stops_a_running_generation
+  expected_output: 'test result: ok'
+  if_fails: 'PRE-FIX: there was no cancellation machinery in crates/aprender-serve/src/api/
+    at all — no CancelToken, no is_closed() check, no tokio::select — so the loop ran
+    to its ceiling with zero open connections. Also fails if the CancelOnDrop guard
+    is removed from the layer, or if the handler is awaited inline instead of in its
+    own task (the loop then has no await point to be dropped at).'
+- id: FALSIFY-SERVE-CANCEL-005
+  name: the_real_router_hands_every_request_a_live_cancel_token
+  prediction: 'A handler mounted under the cancel_on_disconnect layer reads a token
+    from the request extensions whose peek_cancelled() is true after the response future
+    is dropped — which CancelToken::never() can never report.'
+  test_harness: cargo test -p aprender-serve --lib the_real_router_hands_every_request_a_live_cancel_token
+  expected_output: 'test result: ok'
+  if_fails: 'PRE-FIX: no layer existed, so request_cancel_token fell back to CancelToken::never()
+    and every decode loop polled a token that answers false forever. Also fails if
+    the layer is dropped from create_router.'
+- id: FALSIFY-SERVE-CANCEL-006
+  name: a_completed_generate_request_is_unchanged_by_the_cancellation_layer
+  prediction: 'POST /generate {"prompt":"token5","max_tokens":4} through create_router
+    produces a JSON body equal to the one generate_handler produces when invoked directly
+    with CancelToken::never().'
+  test_harness: cargo test -p aprender-serve --lib a_completed_generate_request_is_unchanged_by_the_cancellation_layer
+  expected_output: 'test result: ok'
+  if_fails: 'The CancelOnDrop guard fires on NORMAL completion too, and the layer now
+    runs every handler in a spawned task. Either could truncate or reshape a completed
+    response. A failure here means the fix changed what a working request returns.'
+
+proof_obligations:
+- type: invariant
+  property: An uncancelled decode loop produces exactly its budget
+  formal: for all cfg with cfg.cancel = never, tokens_generated(cfg) = min(cfg.max_tokens,
+    context_length - len(prompt))
+  applies_to: Model::generate, OwnedQuantizedModel::generate_with_cache
+  discharged_by: FALSIFY-SERVE-CANCEL-001, FALSIFY-SERVE-CANCEL-003
+  notes: >-
+    The converse half. Without it a falsifier could pass because generation is
+    broken and emits nothing, which is indistinguishable from "cancellation
+    worked" if only the cancelled case is asserted.
+- type: invariant
+  property: Cancellation is observed within one decode step of being requested
+  formal: for all cfg, tokens_generated(cfg) <= polls_until_cancel(cfg.cancel) and
+    cancel.polls() <= tokens_generated + 1
+  applies_to: every decode loop that takes a GenerationConfig, QuantizedGenerateConfig,
+    GpuGenerateConfig or apr_transformer GenerateConfig
+  discharged_by: FALSIFY-SERVE-CANCEL-001, FALSIFY-SERVE-CANCEL-002, FALSIFY-SERVE-CANCEL-003
+  notes: >-
+    Bounds the wasted work at one token. The poll must be at the TOP of the loop
+    body: at the bottom it costs one extra forward pass per cancelled request,
+    which FALSIFY-SERVE-CANCEL-002 detects.
+- type: invariant
+  property: A dropped response future stops the decode loop
+  formal: drop(response_future) => eventually the decode loop exits with
+    tokens_generated < cfg.max_tokens
+  applies_to: every route mounted on create_router
+  discharged_by: FALSIFY-SERVE-CANCEL-004, FALSIFY-SERVE-CANCEL-005
+  notes: >-
+    Requires all three of: the token in the request extensions, the CancelOnDrop
+    guard in the layer's future, and the handler running in its own task.
+    Removing any one restores the defect; each removal is separately mutation-verified.
+- type: invariant
+  property: Cancellation does not change a completed response
+  formal: for all requests r that complete, response(router_with_layer, r) ==
+    response(handler_with_never_token, r)
+  applies_to: POST /generate and every other route on create_router
+  discharged_by: FALSIFY-SERVE-CANCEL-006
+  notes: >-
+    The guard fires on normal completion too, and the layer interposes a task.
+    Neither may alter a successful response.
+
+kani_harnesses:
+- id: KANI-SERVE-CANCEL-001
+  obligation: Cancellation is observed within one decode step of being requested
+  property: for any budget b and ceiling m, a loop polling once per step runs exactly
+    min(b, m) steps
+  bound: 32
+  strategy: exhaustive
+  harness: verify_cancel_budget_bounds_steps
+  status: planned
+
+qa_gate:
+  id: F-SERVE-CANCEL-001
+  name: apr serve cancellation contract
+  checks:
+  - Every decode loop taking a generation config polls config.cancel at the top of
+    its loop body
+  - create_router carries the cancel_on_disconnect layer
+  - Every generate handler extracts Extension<CancelToken> and installs it on its
+    generation config
+  - A completed request returns the same body with and without the layer
+  pass_criteria: All six FALSIFY-SERVE-CANCEL falsifiers pass, and each has been
+    mutation-verified by removing the mechanism it covers and observing RED

--- a/contracts/apr-validate-quality-threshold-v1.yaml
+++ b/contracts/apr-validate-quality-threshold-v1.yaml
@@ -1,8 +1,8 @@
 metadata:
-  version: 1.0.0
+  version: 2.0.0
   created: '2026-05-22'
   author: PAIML Engineering
-  description: "`apr validate --quality` must gate pass/fail on the *implemented* check denominator, not the aspirational 100-point denominator. Stubbed `Skip(Not implemented)` checks cannot count against working models — otherwise every valid APR file scores Grade F until every placeholder is filled in."
+  description: "`apr validate --quality` must score, grade and gate against the *implemented* check denominator, not the aspirational 100-point denominator. Stubbed `Skip(Not implemented)` checks cannot count against working models — otherwise every valid APR file scores Grade F until every placeholder is filled in. v2.0.0 extends the rule from the exit code to every OUTPUT: the grade, the JSON `passed`/`verdict`, the `--min-score` threshold and `ValidationReport::passed()` are now one decision, so they cannot contradict each other."
   kind: pattern
   references:
     - "paiml/aprender#1866 (apr validate --quality: 22/25 checks 'Pending — Not implemented' → working models score 3/100, exit 5)"
@@ -23,6 +23,15 @@ five_whys:
   why_4: "The QA checklist was designed as an aspirational 100-point ceiling (APR-SPEC-v2-draft.md Section 11) but the implementation grew incrementally — gate code assumed all checks would be implemented; they never were"
   why_5: "No provable contract bound the threshold to the implementation surface — 'score thresholds are relative to runnable checks' was an unstated invariant"
   root_cause: "Threshold gate uses the aspirational 100-point denominator instead of the runnable denominator (count of non-Skip checks). The fix moves the gate to `implemented_score_pct() < 50` and treats a fully-stubbed suite as informational (None) rather than a hard fail."
+
+five_whys_v2:
+  symptom: "v1.0.0 fixed the EXIT CODE and nothing else. Re-measured 2026-08-13 on `/home/noah/models/qwen2.5-coder-0.5b-instruct.apr` at 6adeb6351: `apr validate --quality` exits 0 and prints `✓ VALID 3/4 checks that ran` — and, four lines later, `TOTAL: 3/100  Grade: F`. The `--json` document says `\"grade\": \"F\"`, `\"failed\": 0`, `\"passed\": true` simultaneously. `--min-score 50` on the same healthy model exits 5 with `Score 3/100 below minimum 50`."
+  why_1: "`ValidationReport::grade()` still banded `total_score` — the raw count of awarded points — against a fixed 100-point match arm"
+  why_2: "the `--quality` category table, `--min-score`, `ValidationReport::passed()`, `apr import`'s Score/Grade panel and the TUI QA panel all read `total_score` directly, so each one re-derived the same wrong denominator independently"
+  why_3: "v1.0.0 added `implemented_max` / `implemented_score_pct` but wired them into exactly ONE caller (the exit-code gate); the helpers existed and the other six call sites were never migrated"
+  why_4: "no test read two of the outputs at once — `grade`, `passed` and the human verdict each had passing tests in isolation, and their mutual contradiction was invisible to all of them"
+  why_5: "'a fix is done when the reported symptom stops' — the issue reported exit 5, so the exit code was fixed and the issue closed COMPLETED; the wrong number stayed on screen for 81 more days"
+  root_cause: "The measured denominator was introduced as a local fix at one call site instead of as the definition of the report's score. v2.0.0 makes `grade()`, `passed()`, `is_valid()` and every renderer derive from `implemented_score()`, and asserts the three user-visible outputs agree by construction."
 
 equations:
   implemented_denominator:
@@ -52,6 +61,34 @@ equations:
       - "Fully-stubbed reports (implemented_max == 0) PASS as informational"
       - "apr qa is the canonical pass/fail gate per CLAUDE.md; `apr validate --quality` complements with structural integrity audit"
 
+  grade_on_measured:
+    formula: "grade(report) = if ran == 0 then 'N/A' else if any_failed then 'F' else band(pct)"
+    domain: "validation reports"
+    codomain: "letter grade in {N/A, F, D, C, C+, B, B+, A, A+}"
+    invariants:
+      - "band(pct) is floored at 'D': with no failures every check that ran passed or warned, so 'F' is unreachable without a failure"
+      - "grade(report) == 'F' if and only if ran > 0 AND at least one check failed"
+      - "a report with 4 checks that ran (3 Pass, 1 Warn) and 22 Skip stubs grades 'C+', not 'F'"
+      - "'N/A' is not a score of zero — it means nothing was measured"
+
+  verdict_agreement:
+    formula: "is_valid(report) = (failed_checks(report) == 0); verdict = if is_valid then VALID else INVALID"
+    domain: "any apr validate invocation on a .apr file"
+    codomain: "the triple (grade, passed, human verdict)"
+    invariants:
+      - "the human VALID/INVALID badge, the JSON `verdict` field and the JSON `passed` flag are all is_valid(report) — one predicate, not three"
+      - "passed == true implies grade != 'F' (the #1866 contradiction is unrepresentable)"
+      - "grade == 'F' implies verdict == INVALID implies passed == false"
+
+  min_score_on_measured:
+    formula: "min_score_ok(report, n) = pct(report) is Some(p) AND p >= n"
+    domain: "apr validate --min-score N, and ValidationReport::passed(N)"
+    codomain: "boolean"
+    invariants:
+      - "the threshold is a percentage of the checks that RAN, never a count of awarded points"
+      - "pct == None (nothing ran) REFUSES the flag rather than satisfying it — a threshold against an uncomputed number is a gate that cannot fail"
+      - "a report of 3 Pass + 1 Warn + 22 Skip clears --min-score 75 and is refused by --min-score 80"
+
 proof_obligations:
   - type: invariant
     property: "Working models pass the threshold"
@@ -65,6 +102,22 @@ proof_obligations:
     property: "Half-implemented half-failing models do fail"
     formal: "implemented_max = 4 AND fail_count = 3 ⟹ fail_gate(report)"
     applies_to: threshold_gate_on_implemented
+  - type: invariant
+    property: "A healthy model is never graded F"
+    formal: "ran > 0 AND fail_count == 0 ⟹ grade(report) != 'F'"
+    applies_to: grade_on_measured
+  - type: invariant
+    property: "Grade F is earned only by a failing check"
+    formal: "grade(report) == 'F' ⟺ (ran > 0 AND fail_count > 0)"
+    applies_to: grade_on_measured
+  - type: invariant
+    property: "Grade, passed flag and human verdict never contradict"
+    formal: "passed(report) ⟹ grade(report) != 'F' AND verdict(report) == VALID"
+    applies_to: verdict_agreement
+  - type: invariant
+    property: "min_score cannot be cleared against an unmeasured score"
+    formal: "pct(report) == None ⟹ NOT min_score_ok(report, n) for every n"
+    applies_to: min_score_on_measured
 
 falsification_tests:
   - id: FALSIFY-VALIDATE-QUALITY-001
@@ -80,17 +133,50 @@ falsification_tests:
     if_fails: "Working models still mis-scored against unimplemented denominator"
 
   - id: FALSIFY-VALIDATE-QUALITY-003
-    rule: "validate.rs gates on implemented_score_pct, not total_score"
-    prediction: "validate.rs source contains implemented_score_pct call and no `total_score < 50` bare comparison in the gate"
-    test: "grep -q 'implemented_score_pct' crates/apr-cli/src/commands/validate.rs && ! grep -nE 'report\\.total_score *< *50' crates/apr-cli/src/commands/validate.rs"
-    if_fails: "Threshold gate still uses the aspirational 100-point denominator"
+    rule: "validate.rs reads the measured score, never the raw point total"
+    prediction: "validate.rs calls implemented_score() and contains no `report.total_score` READ at all (v2.0.0 strengthened this from 'no `total_score < 50` comparison' — the original grep passed while five other call sites still read the raw total for the grade, the table, --min-score and the JSON)"
+    test: "grep -q 'implemented_score()' crates/apr-cli/src/commands/validate.rs && ! grep -nE '^[^/]*report\\.total_score' crates/apr-cli/src/commands/validate.rs"
+    if_fails: "Threshold gate or a renderer is back on the aspirational 100-point denominator"
+
+  - id: FALSIFY-VALIDATE-QUALITY-004
+    rule: "A healthy model is not graded F"
+    prediction: "The report apr validate builds for qwen2.5-coder-0.5b-instruct.apr (3 Pass, 1 Warn, 22 Skip) grades C+"
+    test: "cargo test -p aprender-core --lib healthy_model_is_not_graded_f"
+    if_fails: "Working models are still graded F against a denominator nothing was measured against"
+
+  - id: FALSIFY-VALIDATE-QUALITY-005
+    rule: "grade == F exactly when a check that ran failed"
+    prediction: "Exhaustive over all 256 arrangements of Pass/Fail/Warn/Skip across four checks, (grade == 'F') == !is_valid() whenever anything ran"
+    test: "cargo test -p aprender-core --lib grade_is_f_exactly_when_a_check_failed"
+    if_fails: "The grade and the VALID/INVALID verdict can disagree again"
+
+  - id: FALSIFY-VALIDATE-QUALITY-006
+    rule: "The --json document cannot report grade F, verdict VALID and passed true at once"
+    prediction: "apr_validation_json on the healthy report yields grade C+, verdict VALID, passed true, total_score 75, checks_ran 4, checks_not_implemented 22; adding one Fail flips grade/verdict/passed together"
+    test: "cargo test -p apr-cli --lib json_grade_passed_and_verdict_agree"
+    if_fails: "Machine consumers see a self-contradictory document again"
+
+  - id: FALSIFY-VALIDATE-QUALITY-007
+    rule: "The --quality table scores only what ran"
+    prediction: "quality_assessment_body contains neither '/100  Grade' nor '0/25', names the unimplemented categories, and reads Grade: C+"
+    test: "cargo test -p apr-cli --lib quality_table_scores_only_what_ran"
+    if_fails: "The table again draws a zero for categories that declare no checks"
+
+  - id: FALSIFY-VALIDATE-QUALITY-008
+    rule: "--min-score thresholds the checks that ran, and is refused when none did"
+    prediction: "The healthy report clears --min-score 75, is refused by --min-score 80 quoting '75/100', and an all-Skip report refuses even --min-score 0"
+    test: "cargo test -p apr-cli --lib min_score"
+    if_fails: "--min-score again rejects healthy models, or silently passes when no score exists"
 
 qa_gate:
   id: F-VALIDATE-QUALITY-001
-  name: "apr validate --quality threshold gates on implemented checks"
-  description: "Pass/fail threshold must use percentage of implemented (non-Skip) checks. A fully-stubbed suite must be treated as informational, not a hard fail."
+  name: "apr validate --quality scores, grades and gates on implemented checks"
+  description: "Score, grade, --min-score threshold and pass/fail must all use the checks that ran (non-Skip). A fully-stubbed suite must be treated as informational for the gate and REFUSED for an explicit threshold, never as a score of zero. The grade, the JSON passed/verdict flags and the human VALID/INVALID badge must be derived from one predicate so they cannot contradict each other."
   checks:
     - "implemented_denominator"
     - "implemented_score_pct"
     - "threshold_gate_on_implemented"
-  pass_criteria: "FALSIFY-VALIDATE-QUALITY-{001,002,003} all PASS"
+    - "grade_on_measured"
+    - "verdict_agreement"
+    - "min_score_on_measured"
+  pass_criteria: "FALSIFY-VALIDATE-QUALITY-{001..008} all PASS"

--- a/contracts/beat-ollama-decode-throughput-speed-v1.yaml
+++ b/contracts/beat-ollama-decode-throughput-speed-v1.yaml
@@ -72,10 +72,12 @@ metadata:
   - "memory/project_fusion_003_1_5b_falsified.md (the 1-in-6 CUDA_ERROR variance class — fixed by #2049)"
   - "contracts/apr-fail-closed-garbage-beat-v1.yaml (the correctness-headline Pillar-4 beat)"
 version: 2
-# ENFORCED (manual/GPU gate): a real, non-flaky clean-decode beat. The ~1-in-6
-# decode-stall variance that blocked promotion is fixed by #2049; a median-of-7
-# >= 1.10x gate clears the measured 1.37x median with a ~0% bootstrapped flake
-# rate. Held for #2049 landing on main (see description DEPENDENCY). See VERDICT.
+# ENFORCED (manual/GPU gate) as a NO-COLLAPSE FLOOR, not a beat. The 1.371x win
+# claim is WITHDRAWN (see VERDICT SUPERSEDED in the description); the enforced
+# assertion is median-of-7 >= ollama median x 0.90 (`beat_threshold` below), which
+# catches CPU fallback (~0.065) without asserting a win apr does not have. The
+# ~1-in-6 decode-stall variance is fixed by #2049, which the median premise still
+# DEPENDS on (see description DEPENDENCY).
 status: enforced
 date: 2026-06-15
 
@@ -116,27 +118,34 @@ beat:
 ci_gating:
   mode: manual          # ENFORCED gate, run manually on a GPU host (no NVIDIA CI runner)
   reason: >
-    ENFORCED median-of-7 >= 1.10x gate. (1) Non-flaky: the ~1-in-6 catastrophic
-    decode stall (FUSION-003 1-in-6 CUDA_ERROR class) that previously made a median
-    gate flake is FIXED by #2049 (FP8-warmup OOB poison) — re-measured 0 stalls / 8
-    trials, median 1.37x, worst single run 1.23x; a median-of-7 >= 1.10x gate
-    bootstraps to ~0% false-FAIL. This gate's non-stall premise DEPENDS on #2049
-    being on main; do NOT enforce without it. (2) Manual/GPU: requires an RTX-class
-    GPU, apr `--features cuda`, ollama + the Q4_K_M model, and the matching GGUF on
-    disk — none on the CPU-only self-hosted CI runners. Like the cuda-oxide
-    throughput beat, it runs manually on an NVIDIA host (lambda-vector RTX 4090 /
-    gx10 GB10), not in per-PR CI.
+    ENFORCED median-of-7 >= 0.90x NO-COLLAPSE FLOOR (NOT a beat threshold; the
+    1.371x win claim is withdrawn — see VERDICT SUPERSEDED). (1) Non-flaky: the
+    ~1-in-6 catastrophic decode stall (FUSION-003 1-in-6 CUDA_ERROR class) that
+    previously made a median gate flake is FIXED by #2049 (FP8-warmup OOB poison) —
+    re-measured 0 stalls / 8 trials. 0.90 also sits 12% under the worst observed
+    post-#2323 median (1.015), so it does not flake for distributional reasons
+    either. This gate's non-stall premise DEPENDS on #2049 being on main; do NOT
+    enforce without it. (2) Manual/GPU: requires an RTX-class GPU, apr
+    `--features cuda`, ollama + the Q4_K_M model, and the matching GGUF on disk —
+    none on the CPU-only self-hosted CI runners. Like the cuda-oxide throughput
+    beat, it runs manually on an NVIDIA host (lambda-vector RTX 4090 / gx10 GB10),
+    not in per-PR CI. A green run proves apr did not COLLAPSE; it does not license
+    any claim that apr is faster than ollama.
   run_recipe: |
     # On an NVIDIA host with apr (--features cuda), ollama, and the model:
-    #   1. Build/locate the cuda apr binary (must include #2049 FP8 stall fix):
-    #        cargo build --release --features cuda  # -> target/release/apr
-    #      (canonical: /mnt/nvme-raid0/targets/aprender/release/apr)
+    #   1. Resolve the cuda apr binary. NEVER hardcode a path and never call a bare
+    #      `apr` — scripts/apr_bin.sh exports $APR and PROVES it was built from HEAD
+    #      (four apr binaries once coexisted here; a bare `apr` won at 26 days old).
+    #        cargo build --release --features cuda
+    #        . scripts/apr_bin.sh || exit 1    # -> $APR
+    #      The build must include #2049 (FP8 stall fix); without it the median premise
+    #      above does not hold.
     #   2. Ensure the GGUF + ollama model match:
     #        ls ~/models/qwen2.5-coder-1.5b-instruct-q4_k_m.gguf
     #        ollama pull qwen2.5-coder:1.5b-instruct-q4_K_M && ollama ps
     #   3. Run the ignored ENFORCED gate (asserts apr median-of-7 >= ollama
-    #      median x 1.10; FAILS the build on a real regression):
-    #        APR_BIN=/mnt/nvme-raid0/targets/aprender/release/apr \
+    #      median x 0.90 — the no-collapse floor; FAILS the build on a collapse):
+    #        APR_BIN="$APR" \
     #        APR_GGUF=$HOME/models/qwen2.5-coder-1.5b-instruct-q4_k_m.gguf \
     #        OLLAMA_MODEL=qwen2.5-coder:1.5b-instruct-q4_K_M \
     #        cargo test -p aprender-serve --test beat_ollama_decode_throughput_speed \

--- a/contracts/crux-B-08-v1.yaml
+++ b/contracts/crux-B-08-v1.yaml
@@ -92,48 +92,44 @@ falsification_tests:
 
 - id: FALSIFY-CRUX-B-08-002
   rule: CLI surface matches vllm
-  prediction: "apr quantize --method awq --bits --group-size all accepted"
+  prediction: "the SHIPPED `apr quantize` clap parser decides whether a recorded argv is accepted; it has no --method/--bits/--group-size, so the vllm/awq surface is NOT exposed"
   test: |
-    apr quantize --help 2>&1 | grep -qE -- '--method[[:space:]<]'
-    apr quantize --help 2>&1 | grep -qE -- '--bits[[:space:]<]'
-    apr quantize --help 2>&1 | grep -qE -- '--group-size[[:space:]<]'
+    cargo test -p apr-cli --lib flags_gate_rejects_the_method_bits_argv_the_shipped_cli_never_took
   if_fails: "apr quantize missing AWQ-equivalent flags; competitor parity broken"
   evidence_discharged_by:
-    classifier_path: crates/apr-cli/src/commands/awq_classifier.rs
+    classifier_path: crates/apr-cli/src/commands/quantize_flag_parity.rs
     cli_path: crates/apr-cli/src/commands/awq_lint.rs
     e2e_path: crates/apr-cli/tests/falsification_crux_b_08.rs
     e2e_tests:
-    - falsify_crux_b_08_002_flags_ok_canonical
-    - falsify_crux_b_08_002_flags_ok_equals_form
-    - falsify_crux_b_08_002_flags_rejects_wrong_method
-    - falsify_crux_b_08_002_flags_rejects_invalid_bits
-    - falsify_crux_b_08_002_flags_rejects_missing_bits
-    - falsify_crux_b_08_002_flags_rejects_invalid_group_size
-    - falsify_crux_b_08_002_flags_observer_can_assert_expected_failure
+    - falsify_crux_b_08_002_flags_ok_on_a_real_quantize_argv
+    - falsify_crux_b_08_002_flags_reject_method_bits_group_size
+    - falsify_crux_b_08_002_flags_reject_quantize_without_the_required_file
+    - falsify_crux_b_08_002_flags_observer_can_assert_expected_rejection
+    - falsify_crux_b_08_002_stale_per_flag_label_is_unusable_input
     sub_claim: |
-      Algorithm-level necessary condition: `parse_awq_flags` extracts
-      all three flags (`--method`, `--bits`, `--group-size`) in both
-      space and `=` forms; `validate_awq_flags` enforces the full
-      contract envelope — bits ∈ {3,4,8}, group_size ∈ {64,128},
-      default group_size = `AWQ_DEFAULT_GROUP_SIZE` (128, matching
-      vllm/awq reference). Missing method, unknown method, and invalid
-      bits/group_size each map to a distinct error variant.
+      HONEST STATE (aprender#2377 finding 2): this gate used to be discharged
+      by `parse_awq_flags` + `validate_awq_flags`, a hand-rolled argv matcher
+      that lived beside the assertion and understood `--method`, `--bits` and
+      `--group-size`. The shipped `apr quantize` takes none of those three, so
+      the gate had never once validated the command it named — it validated a
+      second parser. Both functions are DELETED.
+      The verdict now comes from the shipped clap parser
+      (`quantize_flag_parity::shipped_quantize_verdict`, contract
+      apr-lint-flag-parity-v1), which REJECTS `--method awq --bits 4
+      --group-size 128`. That rejection is the truthful state of this rule:
+      the vllm/awq CLI surface is not implemented, and the gate now says so
+      instead of asserting the opposite.
     tests:
-    - parse_all_three_space_form
-    - parse_all_three_equals_form
-    - parse_absent_bits_yields_none
-    - validate_ok_with_default_group_size
-    - validate_ok_with_explicit_group_size
-    - validate_rejects_missing_method
-    - validate_rejects_unknown_method
-    - validate_rejects_invalid_bits
-    - validate_rejects_missing_bits
-    - validate_rejects_invalid_group_size
-    - allowed_sets_include_reference_values
-    - validate_is_deterministic
-    scope: argv → AwqFlags → AwqFlagValidation (pure)
-    discharge_status: PARTIAL_ALGORITHM_LEVEL
-    full_discharge_blocked_on: "clap `apr quantize --help` subcommand surface"
+    - shipped_parser_rejects_the_awq_argv_the_hand_rolled_parser_accepted
+    - shipped_parser_accepts_a_real_quantize_invocation
+    - gate_fails_when_observation_expects_the_nonexistent_flags_to_be_accepted
+    - gate_passes_when_observation_expects_the_nonexistent_flags_to_be_rejected
+    - flags_gate_rejects_the_method_bits_argv_the_shipped_cli_never_took
+    - flags_gate_accepts_a_real_quantize_invocation
+    - flags_gate_stale_vocabulary_is_unusable_input
+    scope: argv → shipped clap Command → {accepted, rejected}
+    discharge_status: REFUTED_SURFACE_NOT_IMPLEMENTED
+    full_discharge_blocked_on: "`apr quantize` gaining a --method/--bits/--group-size surface (or this rule being retired); see contracts/apr-lint-flag-parity-v1.yaml"
 
 - id: FALSIFY-CRUX-B-08-003
   rule: AWQ artifact size <= 0.3x fp16
@@ -186,8 +182,8 @@ verification_summary:
     discharge_status: PARTIAL_ALGORITHM_LEVEL
     blocked_on: real AWQ quantizer + HumanEval/0..9 scoring harness
   - falsify_id: FALSIFY-CRUX-B-08-002
-    discharge_status: PARTIAL_ALGORITHM_LEVEL
-    blocked_on: "clap `apr quantize --help` subcommand surface"
+    discharge_status: REFUTED_SURFACE_NOT_IMPLEMENTED
+    blocked_on: "`apr quantize` has no --method/--bits/--group-size; the gate now runs the shipped clap parser and says so (aprender#2377 finding 2)"
   - falsify_id: FALSIFY-CRUX-B-08-003
     discharge_status: PARTIAL_ALGORITHM_LEVEL
     blocked_on: real AWQ 4-bit packer + fp16 source pair on disk

--- a/contracts/crux-B-09-v1.yaml
+++ b/contracts/crux-B-09-v1.yaml
@@ -134,44 +134,44 @@ falsification_tests:
 
 - id: FALSIFY-CRUX-B-09-003
   rule: GPTQ CLI surface parity with vllm/auto-gptq
-  prediction: "--method gptq --bits --group-size all accepted"
+  prediction: "the SHIPPED `apr quantize` clap parser decides whether a recorded argv is accepted; it has no --method/--bits/--group-size, so the vllm/auto-gptq surface is NOT exposed"
   test: |
-    apr quantize --help 2>&1 | grep -qE -- '--method[[:space:]<]'
-    apr quantize --help 2>&1 | grep -qE 'gptq'
+    cargo test -p apr-cli --lib flags_gate_rejects_the_method_bits_argv_the_shipped_cli_never_took
   if_fails: "apr quantize lacks --method gptq; vllm/auto-gptq path not exposed"
   evidence_discharged_by:
-    classifier_path: crates/apr-cli/src/commands/gptq_classifier.rs
+    classifier_path: crates/apr-cli/src/commands/quantize_flag_parity.rs
     cli_path: crates/apr-cli/src/commands/gptq_lint.rs
     e2e_path: crates/apr-cli/tests/falsification_crux_b_09.rs
     e2e_tests:
-    - falsify_crux_b_09_003_flags_ok_on_canonical_argv
-    - falsify_crux_b_09_003_flags_ok_on_equals_form
-    - falsify_crux_b_09_003_flags_rejects_wrong_method
-    - falsify_crux_b_09_003_flags_rejects_invalid_bits
-    - falsify_crux_b_09_003_flags_rejects_missing_bits
-    - falsify_crux_b_09_003_flags_observer_can_assert_expected_failure
+    - falsify_crux_b_09_003_flags_ok_on_a_real_quantize_argv
+    - falsify_crux_b_09_003_flags_reject_method_bits_group_size
+    - falsify_crux_b_09_003_flags_reject_an_unknown_flag
+    - falsify_crux_b_09_003_flags_observer_can_assert_expected_rejection
+    - falsify_crux_b_09_003_stale_per_flag_label_is_unusable_input
     sub_claim: |
-      Algorithm-level necessary condition: `parse_gptq_flags` handles
-      both `--method gptq` and `--method=gptq`; accepts the auto-gptq
-      convention `--group-size=-1` (per-tensor). `validate_gptq_flags`
-      enforces bits ∈ {2,3,4,8}, group_size ∈ {-1,32,64,128}, default
-      = `GPTQ_DEFAULT_GROUP_SIZE` (128). Missing method, wrong method,
-      missing/invalid bits, and invalid group_size each map to a
-      distinct error variant.
+      HONEST STATE (aprender#2377 finding 2): this gate used to be discharged
+      by `parse_gptq_flags` + `validate_gptq_flags`, a hand-rolled argv matcher
+      that lived beside the assertion and understood `--method`, `--bits` and
+      `--group-size`. The shipped `apr quantize` takes none of those three, so
+      the gate had never once validated the command it named — it validated a
+      second parser. Both functions are DELETED.
+      The verdict now comes from the shipped clap parser
+      (`quantize_flag_parity::shipped_quantize_verdict`, contract
+      apr-lint-flag-parity-v1), which REJECTS `--method gptq --bits 4
+      --group-size 128`. That rejection is the truthful state of this rule:
+      the vllm/auto-gptq CLI surface is not implemented, and the gate now says
+      so instead of asserting the opposite.
     tests:
-    - parse_all_three_space_form
-    - parse_group_size_neg_one_is_per_tensor
-    - validate_ok_with_default_group_size
-    - validate_ok_with_per_tensor_group_size
-    - validate_rejects_wrong_method
-    - validate_rejects_missing_bits
-    - validate_rejects_invalid_bits
-    - validate_rejects_invalid_group_size
-    - validate_is_deterministic
-    - reference_constants_match_spec
-    scope: argv → GptqFlags → GptqFlagValidation (pure)
-    discharge_status: PARTIAL_ALGORITHM_LEVEL
-    full_discharge_blocked_on: "clap `apr quantize --help` subcommand surface + gptq method enum"
+    - shipped_parser_rejects_the_flags_the_hand_rolled_parser_accepted
+    - shipped_parser_accepts_a_real_quantize_invocation
+    - gate_fails_when_observation_expects_the_nonexistent_flags_to_be_accepted
+    - gate_passes_when_observation_expects_the_nonexistent_flags_to_be_rejected
+    - flags_gate_rejects_the_method_bits_argv_the_shipped_cli_never_took
+    - flags_gate_accepts_a_real_quantize_invocation
+    - flags_gate_stale_vocabulary_is_unusable_input
+    scope: argv → shipped clap Command → {accepted, rejected}
+    discharge_status: REFUTED_SURFACE_NOT_IMPLEMENTED
+    full_discharge_blocked_on: "`apr quantize` gaining a --method/--bits/--group-size surface (or this rule being retired); see contracts/apr-lint-flag-parity-v1.yaml"
 
 proof_obligations:
 - type: invariant
@@ -196,8 +196,8 @@ verification_summary:
     discharge_status: PARTIAL_ALGORITHM_LEVEL
     blocked_on: "evidence/crux/vllm/gptq/prompts-64.jsonl + `apr diff --metric logit-cosine` harness"
   - falsify_id: FALSIFY-CRUX-B-09-003
-    discharge_status: PARTIAL_ALGORITHM_LEVEL
-    blocked_on: "clap `apr quantize --help` subcommand surface + gptq method enum"
+    discharge_status: REFUTED_SURFACE_NOT_IMPLEMENTED
+    blocked_on: "`apr quantize` has no --method/--bits/--group-size; the gate now runs the shipped clap parser and says so (aprender#2377 finding 2)"
 
 ship_discipline:
   ship_rule: CRUX-SHIP-001

--- a/contracts/qwen-story-v1.yaml
+++ b/contracts/qwen-story-v1.yaml
@@ -42,10 +42,13 @@ equations:
   pmat_audit_per_beat:
     formula: "PMAT_HUNT=1 emits a manifest of {coverage_gap, churn, fault} for each beat's command-handler module"
     domain: "any beat that PASSed (manifest only meaningful if the command actually ran)"
-    codomain: "structured stderr manifest (gap=, churn=, fault= prefixed lines)"
+    codomain: "structured stdout manifest (gap, churn, fault prefixed lines)"
     invariants:
-      - "Each beat with PMAT_HUNT=1 emits at most 9 lines (3 gaps + 3 churn + 3 faults)"
-      - "Manifest is informational — it does not change exit code"
+      - "Each beat with PMAT_HUNT=1 emits at most 9 lines per hunted path (3 gaps + 3 churn + 3 faults)"
+      - "A beat with PMAT_HUNT=1 emits AT LEAST ONE row: a header with nothing under it fails the beat"
+      - "Row formatters read pmat's own JSON keys — function_name, impact_score, commit_count, fault_annotations"
+      - "Hunts are scoped by --path alone; a free-text query is a relevance filter applied BEFORE --path and collapses a module-scoped hunt to nothing"
+      - "Every path a beat hunts exists in the tree"
       - "Manifest is consumed by the daily cron to detect drift over time"
 
   beat_to_command_surface:
@@ -91,8 +94,12 @@ falsification_tests:
 
   - id: FALSIFY-QWEN-STORY-003
     rule: "Every beat uses OUT=$(cmd); EC=$? pattern via run_cmd helper"
-    prediction: "Script defines run_cmd helper that captures both stdout and exit code"
-    test: "grep -qE 'RC_OUT=.*timeout.*RC_EC=' scripts/qwen-story.sh"
+    prediction: "run_cmd captures both stdout and the exit code without a pipeline"
+    # Was `grep ... scripts/qwen-story.sh`, which stopped matching the moment
+    # run_cmd moved into scripts/lib_story_run.sh - a falsifier that can no
+    # longer see the code it is about is not testing anything. Same class as the
+    # inert pmat manifest this contract now also covers (FALSIFY-QWEN-STORY-015).
+    test: "grep -qE 'RC_OUT=.*timeout.*RC_EC=' scripts/lib_story_run.sh"
     if_fails: "Methodology regression — pipe-then-$? could re-introduce false-positive bugs"
 
   - id: FALSIFY-QWEN-STORY-004
@@ -154,6 +161,12 @@ falsification_tests:
     prediction: "scripts/check_story_json_streams.sh exits 0: run_cmd sets RC_OUT from stdout only, RC_ERR from stderr only, RC_ALL from both, and no jq call site in qwen-story.sh is fed from the merged stream"
     test: "bash scripts/check_story_json_streams.sh"
     if_fails: "run_cmd captured `cmd 2>&1` into one variable, so a command's stderr was prepended to its JSON. On 2026-08-11 that reported `no format_parity gate found in --json output (got: '', apr qa exit=0)` for a gate that had run and PASSED - apr qa writes JSON to stdout and the CUDA path emits unconditional `[trueno#243]` lines to stderr. A false FAIL is as corrosive as a gate that cannot fail: main goes red for a non-reason. Note the converse is equally a defect - a Rust panic arrives on stderr, so the panic checks must keep reading RC_ALL."
+
+  - id: FALSIFY-QWEN-STORY-015
+    rule: "The pmat bug-hunt manifest can produce rows, and an empty manifest fails the beat"
+    prediction: "scripts/check_story_pmat_hunt.sh exits 0: pmat_rows formats from function_name/impact_score/commit_count/fault_annotations, a free-text query before --path yields nothing, pmat_hunt returns 1 and calls emit_fail when its header carries no rows, and every path the story hunts exists"
+    test: "bash scripts/check_story_pmat_hunt.sh"
+    if_fails: "The hunt printed eight manifest headers and ZERO rows a night from the day the cron was added, so the workflow's 'manifest grew by >5' alert branch never had a non-zero input and half the nightly's alerting was decorative. Three independent causes, each sufficient: (1) the jq filters named .function / .churn.commit_count / .faults while pmat emits function_name / commit_count / fault_annotations - the row guard select(.function != null) discarded 100% of records; (2) the churn and fault hunts passed the beat label as a free-text query, and --path is a POST-filter over the semantic top-K, so a module-scoped hunt collapsed to nothing (measured on pmat 3.30.0: query + --path <module> = 0 rows, no query + --path <same module> = 3 rows); (3) commands/list.rs, commands/code.rs and commands/serve.rs had been deleted or moved. All three present as an empty manifest, which pmat_hunt's unconditional `return 0` made indistinguishable from clean code."
 
   - id: FALSIFY-QWEN-STORY-008
     rule: "Beat 7 doesn't run apr qa on 7B (known #1864 regression)"

--- a/crates/apr-cli/src/commands/awq_classifier.rs
+++ b/crates/apr-cli/src/commands/awq_classifier.rs
@@ -1,29 +1,28 @@
 //! CRUX-B-08 AWQ quantization — algorithm-level classifiers.
 //!
-//! Partial discharge for the `apr quantize --method awq` contract
-//! (`contracts/crux-B-08-v1.yaml`). Three pure classifiers cover:
+//! Partial discharge for the AWQ quantization contract
+//! (`contracts/crux-B-08-v1.yaml`). Two pure classifiers cover:
 //!
 //! 1. Quality retention (pass@1 AWQ ≥ 0.80 × pass@1 fp16) — FALSIFY-001.
-//! 2. CLI flag parser + validation (`--method`, `--bits`, `--group-size`) — FALSIFY-002.
-//! 3. Compression ratio (AWQ bytes ≤ 0.30 × fp16 bytes) — FALSIFY-003.
+//! 2. Compression ratio (AWQ bytes ≤ 0.30 × fp16 bytes) — FALSIFY-003.
 //!
 //! Full discharge still requires a real AWQ quantizer and real
 //! HumanEval scoring — neither lives in the CLI crate.
-
-/// Default AWQ group size, matching vllm/awq reference implementation.
-pub const AWQ_DEFAULT_GROUP_SIZE: u32 = 128;
+//!
+//! The CLI-surface gate (FALSIFY-002) used to live here as `parse_awq_flags` +
+//! `validate_awq_flags`: a hand-rolled `--method`/`--bits`/`--group-size`
+//! matcher that decided whether the shipped `apr quantize` would accept an
+//! argv. `apr quantize` takes none of those three flags, so the gate had never
+//! once validated the command it claimed to. It is deleted; the verdict now
+//! comes from the shipped clap parser via
+//! `commands::quantize_flag_parity::shipped_quantize_verdict`
+//! (aprender#2377 finding 2, `contracts/apr-lint-flag-parity-v1.yaml`).
 
 /// Minimum quality-retention ratio the contract demands.
 pub const AWQ_MIN_QUALITY_RETENTION: f64 = 0.80;
 
 /// Maximum compressed-to-source byte ratio for 4-bit AWQ.
 pub const AWQ_MAX_COMPRESSION_RATIO: f64 = 0.30;
-
-/// Allowed AWQ bit widths.
-pub const AWQ_ALLOWED_BITS: &[u32] = &[3, 4, 8];
-
-/// Allowed AWQ group sizes.
-pub const AWQ_ALLOWED_GROUP_SIZES: &[u32] = &[64, 128];
 
 /// Outcome of comparing fp16 vs AWQ pass@1.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -79,102 +78,6 @@ pub fn classify_compression_ratio(
     } else {
         CompressionOutcome::Insufficient { ratio, max_ratio }
     }
-}
-
-/// Parsed AWQ CLI surface.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct AwqFlags {
-    pub method: Option<String>,
-    pub bits: Option<u32>,
-    pub group_size: Option<u32>,
-}
-
-/// Parse `--method`, `--bits`, `--group-size` from argv.
-/// Accepts both space and `=` separated forms.
-#[must_use]
-pub fn parse_awq_flags(argv: &[&str]) -> AwqFlags {
-    let mut out = AwqFlags {
-        method: None,
-        bits: None,
-        group_size: None,
-    };
-    let mut i = 0;
-    while i < argv.len() {
-        let a = argv[i];
-        match a {
-            "--method" => {
-                out.method = argv.get(i + 1).map(|s| (*s).to_string());
-            }
-            "--bits" => {
-                out.bits = argv.get(i + 1).and_then(|s| s.parse::<u32>().ok());
-            }
-            "--group-size" => {
-                out.group_size = argv.get(i + 1).and_then(|s| s.parse::<u32>().ok());
-            }
-            _ => {
-                if let Some(rest) = a.strip_prefix("--method=") {
-                    out.method = Some(rest.to_string());
-                } else if let Some(rest) = a.strip_prefix("--bits=") {
-                    if let Ok(v) = rest.parse::<u32>() {
-                        out.bits = Some(v);
-                    }
-                } else if let Some(rest) = a.strip_prefix("--group-size=") {
-                    if let Ok(v) = rest.parse::<u32>() {
-                        out.group_size = Some(v);
-                    }
-                }
-            }
-        }
-        i += 1;
-    }
-    out
-}
-
-/// Validation outcome for a parsed AWQ flag set.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum AwqFlagValidation {
-    Ok { bits: u32, group_size: u32 },
-    MissingMethod,
-    UnknownMethod { got: String },
-    InvalidBits { got: u32, allowed: &'static [u32] },
-    InvalidGroupSize { got: u32, allowed: &'static [u32] },
-}
-
-/// Validate parsed AWQ flags. Applies `AWQ_DEFAULT_GROUP_SIZE` when
-/// `--group-size` is omitted. `--bits` has no default (must be given).
-#[must_use]
-pub fn validate_awq_flags(flags: &AwqFlags) -> AwqFlagValidation {
-    let Some(method) = flags.method.as_deref() else {
-        return AwqFlagValidation::MissingMethod;
-    };
-    if method != "awq" {
-        return AwqFlagValidation::UnknownMethod {
-            got: method.to_string(),
-        };
-    }
-    let bits = match flags.bits {
-        Some(b) if AWQ_ALLOWED_BITS.contains(&b) => b,
-        Some(b) => {
-            return AwqFlagValidation::InvalidBits {
-                got: b,
-                allowed: AWQ_ALLOWED_BITS,
-            }
-        }
-        None => {
-            return AwqFlagValidation::InvalidBits {
-                got: 0,
-                allowed: AWQ_ALLOWED_BITS,
-            }
-        }
-    };
-    let group_size = flags.group_size.unwrap_or(AWQ_DEFAULT_GROUP_SIZE);
-    if !AWQ_ALLOWED_GROUP_SIZES.contains(&group_size) {
-        return AwqFlagValidation::InvalidGroupSize {
-            got: group_size,
-            allowed: AWQ_ALLOWED_GROUP_SIZES,
-        };
-    }
-    AwqFlagValidation::Ok { bits, group_size }
 }
 
 #[cfg(test)]
@@ -244,154 +147,5 @@ mod tests {
     fn compression_zero_source_is_insufficient() {
         let r = classify_compression_ratio(0, 100, AWQ_MAX_COMPRESSION_RATIO);
         assert!(matches!(r, CompressionOutcome::Insufficient { .. }));
-    }
-
-    // ---- FALSIFY-002 (CLI parsing + validation) ----
-
-    #[test]
-    fn parse_all_three_space_form() {
-        let argv = &[
-            "quantize",
-            "model.apr",
-            "--method",
-            "awq",
-            "--bits",
-            "4",
-            "--group-size",
-            "128",
-        ];
-        let f = parse_awq_flags(argv);
-        assert_eq!(f.method.as_deref(), Some("awq"));
-        assert_eq!(f.bits, Some(4));
-        assert_eq!(f.group_size, Some(128));
-    }
-
-    #[test]
-    fn parse_all_three_equals_form() {
-        let argv = &["quantize", "--method=awq", "--bits=4", "--group-size=128"];
-        let f = parse_awq_flags(argv);
-        assert_eq!(f.method.as_deref(), Some("awq"));
-        assert_eq!(f.bits, Some(4));
-        assert_eq!(f.group_size, Some(128));
-    }
-
-    #[test]
-    fn parse_absent_bits_yields_none() {
-        let argv = &["quantize", "--method", "awq"];
-        let f = parse_awq_flags(argv);
-        assert_eq!(f.bits, None);
-    }
-
-    #[test]
-    fn validate_ok_with_default_group_size() {
-        let f = AwqFlags {
-            method: Some("awq".into()),
-            bits: Some(4),
-            group_size: None,
-        };
-        assert_eq!(
-            validate_awq_flags(&f),
-            AwqFlagValidation::Ok {
-                bits: 4,
-                group_size: AWQ_DEFAULT_GROUP_SIZE
-            }
-        );
-    }
-
-    #[test]
-    fn validate_ok_with_explicit_group_size() {
-        let f = AwqFlags {
-            method: Some("awq".into()),
-            bits: Some(4),
-            group_size: Some(64),
-        };
-        assert_eq!(
-            validate_awq_flags(&f),
-            AwqFlagValidation::Ok {
-                bits: 4,
-                group_size: 64
-            }
-        );
-    }
-
-    #[test]
-    fn validate_rejects_missing_method() {
-        let f = AwqFlags {
-            method: None,
-            bits: Some(4),
-            group_size: Some(128),
-        };
-        assert_eq!(validate_awq_flags(&f), AwqFlagValidation::MissingMethod);
-    }
-
-    #[test]
-    fn validate_rejects_unknown_method() {
-        let f = AwqFlags {
-            method: Some("gptq".into()),
-            bits: Some(4),
-            group_size: Some(128),
-        };
-        assert!(matches!(
-            validate_awq_flags(&f),
-            AwqFlagValidation::UnknownMethod { .. }
-        ));
-    }
-
-    #[test]
-    fn validate_rejects_invalid_bits() {
-        let f = AwqFlags {
-            method: Some("awq".into()),
-            bits: Some(5),
-            group_size: Some(128),
-        };
-        assert!(matches!(
-            validate_awq_flags(&f),
-            AwqFlagValidation::InvalidBits { got: 5, .. }
-        ));
-    }
-
-    #[test]
-    fn validate_rejects_missing_bits() {
-        let f = AwqFlags {
-            method: Some("awq".into()),
-            bits: None,
-            group_size: Some(128),
-        };
-        assert!(matches!(
-            validate_awq_flags(&f),
-            AwqFlagValidation::InvalidBits { got: 0, .. }
-        ));
-    }
-
-    #[test]
-    fn validate_rejects_invalid_group_size() {
-        let f = AwqFlags {
-            method: Some("awq".into()),
-            bits: Some(4),
-            group_size: Some(96),
-        };
-        assert!(matches!(
-            validate_awq_flags(&f),
-            AwqFlagValidation::InvalidGroupSize { got: 96, .. }
-        ));
-    }
-
-    #[test]
-    fn allowed_sets_include_reference_values() {
-        assert!(AWQ_ALLOWED_BITS.contains(&4));
-        assert!(AWQ_ALLOWED_GROUP_SIZES.contains(&128));
-        assert_eq!(AWQ_DEFAULT_GROUP_SIZE, 128);
-    }
-
-    #[test]
-    fn validate_is_deterministic() {
-        let f = AwqFlags {
-            method: Some("awq".into()),
-            bits: Some(4),
-            group_size: None,
-        };
-        let a = validate_awq_flags(&f);
-        let b = validate_awq_flags(&f);
-        assert_eq!(a, b);
     }
 }

--- a/crates/apr-cli/src/commands/awq_lint.rs
+++ b/crates/apr-cli/src/commands/awq_lint.rs
@@ -16,21 +16,26 @@
 //!     "max_ratio":           0.30
 //!   },
 //!   "flags": {
-//!     "argv":             ["--method", "awq", "--bits", "4", "--group-size", "128"],
-//!     "expected_outcome": "ok"    // ok | missing_method | unknown_method | invalid_bits | invalid_group_size
+//!     "argv":             ["model.safetensors", "--scheme", "int4", "-o", "out.apr"],
+//!     "expected_outcome": "accepted"   // accepted (alias: ok) | rejected
 //!   }
 //! }
 //! ```
 //!
 //! Any missing top-level key is skipped. Non-zero exit + FALSIFY-CRUX-B-08
 //! stderr stamp on any failing gate.
+//!
+//! The `flags` gate asks the SHIPPED clap parser (`commands::quantize_flag_parity`)
+//! whether `apr quantize <argv>` is accepted — it used to ask a hand-rolled
+//! matcher that understood `--method`/`--bits`/`--group-size`, none of which
+//! `apr quantize` has ever taken (aprender#2377 finding 2).
 
 use super::lint_error::{load_json_observation, LintError};
 use crate::commands::awq_classifier::{
-    classify_compression_ratio, classify_quality_retention, parse_awq_flags, validate_awq_flags,
-    AwqFlagValidation, CompressionOutcome, QualityRetention, AWQ_MAX_COMPRESSION_RATIO,
-    AWQ_MIN_QUALITY_RETENTION,
+    classify_compression_ratio, classify_quality_retention, CompressionOutcome, QualityRetention,
+    AWQ_MAX_COMPRESSION_RATIO, AWQ_MIN_QUALITY_RETENTION,
 };
+use crate::commands::quantize_flag_parity::evaluate_flags_observation;
 use serde_json::Value;
 use std::fs;
 use std::path::Path;
@@ -70,7 +75,7 @@ pub fn run(args: AwqLintArgs) -> Result<(), LintError> {
         }
     }
     if let Some(f) = obs.get("flags") {
-        let (report, err) = run_flags_gate(f);
+        let (report, err) = run_flags_gate(f)?;
         reports.push(report);
         if let Some(e) = err {
             failures.push(e);
@@ -176,47 +181,28 @@ fn run_compression_gate(v: &Value) -> (GateReport, Option<String>) {
     )
 }
 
-fn run_flags_gate(v: &Value) -> (GateReport, Option<String>) {
-    let argv_owned: Vec<String> = v
-        .get("argv")
-        .and_then(|x| x.as_array())
-        .map(|a| {
-            a.iter()
-                .filter_map(|s| s.as_str().map(|s| s.to_string()))
-                .collect()
-        })
-        .unwrap_or_default();
-    let argv: Vec<&str> = argv_owned.iter().map(|s| s.as_str()).collect();
-    let flags = parse_awq_flags(&argv);
-    let validation = validate_awq_flags(&flags);
-
-    let expected = v
-        .get("expected_outcome")
-        .and_then(|x| x.as_str())
-        .unwrap_or("ok");
-    let got = match &validation {
-        AwqFlagValidation::Ok { .. } => "ok",
-        AwqFlagValidation::MissingMethod => "missing_method",
-        AwqFlagValidation::UnknownMethod { .. } => "unknown_method",
-        AwqFlagValidation::InvalidBits { .. } => "invalid_bits",
-        AwqFlagValidation::InvalidGroupSize { .. } => "invalid_group_size",
-    };
-    let passed = got == expected;
-    let desc = format!("expected={expected} got={got} ({validation:?})");
-    let err = if passed {
-        None
-    } else {
-        Some(format!("FALSIFY-CRUX-B-08-002 flags gate failed: {desc}"))
-    };
-    (
+/// The CLI-surface gate: does the SHIPPED `apr quantize` agree with what the
+/// observation claims about this argv?
+///
+/// `Err` (exit 4) means the observation cannot be used — a missing argv, a
+/// missing expectation, or an `expected_outcome` written in the vocabulary of
+/// the hand-rolled parser this gate no longer owns. `Ok` with a failure string
+/// (exit 5) means the observation was usable and the real parser disagreed.
+fn run_flags_gate(v: &Value) -> Result<(GateReport, Option<String>), LintError> {
+    const FALSIFY_ID: &str = "FALSIFY-CRUX-B-08-002";
+    let gate = evaluate_flags_observation(v, FALSIFY_ID).map_err(LintError::unusable)?;
+    let err = gate
+        .failure
+        .map(|m| format!("{FALSIFY_ID} flags gate failed: {m}"));
+    Ok((
         GateReport {
             gate: "flags",
-            falsify_id: "FALSIFY-CRUX-B-08-002",
-            outcome: desc,
-            passed,
+            falsify_id: FALSIFY_ID,
+            outcome: gate.outcome,
+            passed: gate.passed,
         },
         err,
-    )
+    ))
 }
 
 #[cfg(test)]
@@ -302,26 +288,51 @@ mod tests {
     }
 
     #[test]
-    fn flags_gate_valid_awq_passes() {
+    fn flags_gate_accepts_a_real_quantize_invocation() {
+        let f = write_obs(
+            r#"{"flags": {"argv": ["model.safetensors", "--scheme", "int4", "-o", "out.apr"], "expected_outcome": "accepted"}}"#,
+        );
+        run(args_for(&f)).expect("the shipped `apr quantize` accepts this argv");
+    }
+
+    /// FALSIFY-LINTFLAG-004 (awq half). Before aprender#2377 finding 2 this
+    /// observation PASSED: `parse_awq_flags` + `validate_awq_flags` reported
+    /// `Ok { bits: 4, group_size: 128 }` for an argv the shipped `apr quantize`
+    /// has never accepted. The gate now runs the real clap parser and refuses.
+    #[test]
+    fn flags_gate_rejects_the_method_bits_argv_the_shipped_cli_never_took() {
         let f = write_obs(
             r#"{"flags": {"argv": ["--method", "awq", "--bits", "4", "--group-size", "128"], "expected_outcome": "ok"}}"#,
         );
-        assert!(run(args_for(&f)).is_ok());
+        let err = run(args_for(&f))
+            .expect_err("shipped `apr quantize` has no --method/--bits/--group-size")
+            .to_string();
+        assert!(err.contains("FALSIFY-CRUX-B-08-002"), "got: {err}");
+        assert!(err.contains("REJECTED"), "got: {err}");
+        assert!(
+            err.contains("--scheme"),
+            "the operator must be told which flags `apr quantize` does accept; got: {err}"
+        );
     }
 
+    /// An observation may legitimately record that the CLI refuses something.
     #[test]
-    fn flags_gate_missing_method_classified() {
+    fn flags_gate_passes_when_the_observation_expects_a_rejection() {
+        let f = write_obs(
+            r#"{"flags": {"argv": ["--method", "awq", "--bits", "4"], "expected_outcome": "rejected"}}"#,
+        );
+        run(args_for(&f)).expect("observer asserted the refusal that actually happens");
+    }
+
+    /// Exit 4, not exit 5: a label the real parser cannot emit is a broken
+    /// capture, not a contract violation by the system under test.
+    #[test]
+    fn flags_gate_stale_vocabulary_is_unusable_input() {
         let f = write_obs(
             r#"{"flags": {"argv": ["--bits", "4"], "expected_outcome": "missing_method"}}"#,
         );
-        assert!(run(args_for(&f)).is_ok());
-    }
-
-    #[test]
-    fn flags_gate_mismatch_fails() {
-        let f = write_obs(r#"{"flags": {"argv": ["--bits", "4"], "expected_outcome": "ok"}}"#);
-        let err = run(args_for(&f)).unwrap_err().to_string();
-        assert!(err.contains("FALSIFY-CRUX-B-08-002"));
+        let err = run(args_for(&f)).expect_err("`missing_method` is not a clap verdict");
+        assert_eq!(err.exit_code_value(), 4, "got: {err}");
     }
 
     #[test]

--- a/crates/apr-cli/src/commands/awq_lint.rs
+++ b/crates/apr-cli/src/commands/awq_lint.rs
@@ -88,7 +88,11 @@ pub fn run(args: AwqLintArgs) -> Result<(), LintError> {
             "contract": "CRUX-B-08",
             "gates": reports,
         });
-        println!("{}", serde_json::to_string_pretty(&payload).unwrap());
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&payload)
+                .expect("the --json report is a locally-built serde_json::Value")
+        );
     } else {
         for r in &reports {
             let tag = if r.passed { "PASS" } else { "FAIL" };

--- a/crates/apr-cli/src/commands/benchmark.rs
+++ b/crates/apr-cli/src/commands/benchmark.rs
@@ -349,6 +349,7 @@ fn run_apr_benchmark(
         repetition_penalty: 1.0,
         trace: false,
         stop_tokens: vec![],
+        cancel: realizar::generate::CancelToken::never(),
     };
 
     // Warmup (untraced)

--- a/crates/apr-cli/src/commands/chat_generate_safetensors.rs
+++ b/crates/apr-cli/src/commands/chat_generate_safetensors.rs
@@ -44,6 +44,7 @@ impl ChatSession {
                 repetition_penalty: 1.0,
                 trace: config.trace,
             stop_tokens: vec![],
+            cancel: realizar::generate::CancelToken::never(),
             };
 
             transformer

--- a/crates/apr-cli/src/commands/compare_hf.rs
+++ b/crates/apr-cli/src/commands/compare_hf.rs
@@ -27,6 +27,15 @@ pub(crate) fn run(
     threshold: f64,
     json_output: bool,
 ) -> Result<(), CliError> {
+    // GH-2391: `max_abs_diff < threshold` is false for a NaN threshold, so every
+    // tensor is reported as failing-but-not-gated and the summary printed a
+    // count it never computed. Refuse the threshold instead.
+    crate::commands::threshold_arg::guard(
+        "--threshold",
+        threshold,
+        crate::commands::threshold_arg::TOLERANCE,
+    )?;
+
     #[cfg(not(feature = "safetensors-compare"))]
     {
         let _ = (apr_path, hf_repo, tensor_filter, threshold, json_output);

--- a/crates/apr-cli/src/commands/embeddings_lint.rs
+++ b/crates/apr-cli/src/commands/embeddings_lint.rs
@@ -88,7 +88,11 @@ pub fn run(args: EmbeddingsLintArgs) -> Result<(), LintError> {
             "contract": "CRUX-C-13",
             "gates": reports,
         });
-        println!("{}", serde_json::to_string_pretty(&payload).unwrap());
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&payload)
+                .expect("the --json report is a locally-built serde_json::Value")
+        );
     } else {
         for r in &reports {
             let tag = if r.passed { "PASS" } else { "FAIL" };

--- a/crates/apr-cli/src/commands/fp8_lint.rs
+++ b/crates/apr-cli/src/commands/fp8_lint.rs
@@ -72,7 +72,11 @@ pub fn run(args: Fp8LintArgs) -> Result<(), LintError> {
             "contract": "CRUX-B-11",
             "gates": reports,
         });
-        println!("{}", serde_json::to_string_pretty(&payload).unwrap());
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&payload)
+                .expect("the --json report is a locally-built serde_json::Value")
+        );
     } else {
         for r in &reports {
             let tag = if r.passed { "PASS" } else { "FAIL" };

--- a/crates/apr-cli/src/commands/gptq_classifier.rs
+++ b/crates/apr-cli/src/commands/gptq_classifier.rs
@@ -1,26 +1,25 @@
 //! CRUX-B-09 GPTQ quantization — algorithm-level classifiers.
 //!
-//! Partial discharge for the `apr quantize --method gptq` contract
-//! (`contracts/crux-B-09-v1.yaml`). Three pure classifiers cover:
+//! Partial discharge for the GPTQ quantization contract
+//! (`contracts/crux-B-09-v1.yaml`). Two pure classifiers cover:
 //!
 //! 1. Compression ratio (GPTQ bytes ≤ 0.30 × fp16 bytes) — FALSIFY-001.
 //! 2. Logit-fidelity cosine (mean cos ≥ 0.98 across N held-out prompts) — FALSIFY-002.
-//! 3. CLI surface — `--method gptq --bits --group-size` — FALSIFY-003.
+//!
+//! The CLI-surface gate (FALSIFY-003) used to live here as `parse_gptq_flags` +
+//! `validate_gptq_flags`: a hand-rolled `--method`/`--bits`/`--group-size`
+//! matcher that decided whether the shipped `apr quantize` would accept an
+//! argv. `apr quantize` takes none of those three flags, so the gate had never
+//! once validated the command it claimed to. It is deleted; the verdict now
+//! comes from the shipped clap parser via
+//! `commands::quantize_flag_parity::shipped_quantize_verdict`
+//! (aprender#2377 finding 2, `contracts/apr-lint-flag-parity-v1.yaml`).
 
 /// Maximum GPTQ-to-fp16 byte ratio.
 pub const GPTQ_MAX_COMPRESSION_RATIO: f64 = 0.30;
 
 /// Minimum mean logit-cosine the contract demands.
 pub const GPTQ_MIN_MEAN_COSINE: f64 = 0.98;
-
-/// Allowed GPTQ bit widths (matches auto-gptq reference).
-pub const GPTQ_ALLOWED_BITS: &[u32] = &[2, 3, 4, 8];
-
-/// Allowed GPTQ group sizes.
-pub const GPTQ_ALLOWED_GROUP_SIZES: &[i32] = &[-1, 32, 64, 128];
-
-/// Default group size (auto-gptq / GPTQ-for-LLaMa default).
-pub const GPTQ_DEFAULT_GROUP_SIZE: i32 = 128;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum CompressionOutcome {
@@ -102,87 +101,6 @@ pub fn classify_mean_cosine(pairs: &[(&[f64], &[f64])], threshold: f64) -> Cosin
     } else {
         CosineFidelity::Degraded { mean, threshold, n }
     }
-}
-
-// ---- CLI surface ----
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct GptqFlags {
-    pub method: Option<String>,
-    pub bits: Option<u32>,
-    pub group_size: Option<i32>,
-}
-
-#[must_use]
-pub fn parse_gptq_flags(argv: &[&str]) -> GptqFlags {
-    let mut f = GptqFlags {
-        method: None,
-        bits: None,
-        group_size: None,
-    };
-    let mut i = 0;
-    while i < argv.len() {
-        let a = argv[i];
-        match a {
-            "--method" => f.method = argv.get(i + 1).map(|s| (*s).to_string()),
-            "--bits" => f.bits = argv.get(i + 1).and_then(|s| s.parse::<u32>().ok()),
-            "--group-size" => f.group_size = argv.get(i + 1).and_then(|s| s.parse::<i32>().ok()),
-            _ => {
-                if let Some(rest) = a.strip_prefix("--method=") {
-                    f.method = Some(rest.to_string());
-                } else if let Some(rest) = a.strip_prefix("--bits=") {
-                    if let Ok(v) = rest.parse::<u32>() {
-                        f.bits = Some(v);
-                    }
-                } else if let Some(rest) = a.strip_prefix("--group-size=") {
-                    if let Ok(v) = rest.parse::<i32>() {
-                        f.group_size = Some(v);
-                    }
-                }
-            }
-        }
-        i += 1;
-    }
-    f
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum GptqFlagValidation {
-    Ok { bits: u32, group_size: i32 },
-    MissingMethod,
-    WrongMethod { got: String },
-    InvalidBits { got: u32, allowed: &'static [u32] },
-    MissingBits,
-    InvalidGroupSize { got: i32, allowed: &'static [i32] },
-}
-
-#[must_use]
-pub fn validate_gptq_flags(flags: &GptqFlags) -> GptqFlagValidation {
-    let Some(method) = flags.method.as_deref() else {
-        return GptqFlagValidation::MissingMethod;
-    };
-    if method != "gptq" {
-        return GptqFlagValidation::WrongMethod {
-            got: method.to_string(),
-        };
-    }
-    let Some(bits) = flags.bits else {
-        return GptqFlagValidation::MissingBits;
-    };
-    if !GPTQ_ALLOWED_BITS.contains(&bits) {
-        return GptqFlagValidation::InvalidBits {
-            got: bits,
-            allowed: GPTQ_ALLOWED_BITS,
-        };
-    }
-    let group_size = flags.group_size.unwrap_or(GPTQ_DEFAULT_GROUP_SIZE);
-    if !GPTQ_ALLOWED_GROUP_SIZES.contains(&group_size) {
-        return GptqFlagValidation::InvalidGroupSize {
-            got: group_size,
-            allowed: GPTQ_ALLOWED_GROUP_SIZES,
-        };
-    }
-    GptqFlagValidation::Ok { bits, group_size }
 }
 
 #[cfg(test)]
@@ -314,131 +232,5 @@ mod tests {
             CosineFidelity::Ok { n, .. } => assert_eq!(n, 1),
             o => panic!("expected Ok with n=1, got {:?}", o),
         }
-    }
-
-    // ---- FALSIFY-003 (CLI) ----
-
-    #[test]
-    fn parse_all_three_space_form() {
-        let argv = &[
-            "quantize",
-            "--method",
-            "gptq",
-            "--bits",
-            "4",
-            "--group-size",
-            "128",
-        ];
-        let f = parse_gptq_flags(argv);
-        assert_eq!(f.method.as_deref(), Some("gptq"));
-        assert_eq!(f.bits, Some(4));
-        assert_eq!(f.group_size, Some(128));
-    }
-
-    #[test]
-    fn parse_group_size_neg_one_is_per_tensor() {
-        // auto-gptq convention: group_size=-1 means per-tensor.
-        let argv = &["--method=gptq", "--bits=4", "--group-size=-1"];
-        let f = parse_gptq_flags(argv);
-        assert_eq!(f.group_size, Some(-1));
-    }
-
-    #[test]
-    fn validate_ok_with_default_group_size() {
-        let f = GptqFlags {
-            method: Some("gptq".into()),
-            bits: Some(4),
-            group_size: None,
-        };
-        assert_eq!(
-            validate_gptq_flags(&f),
-            GptqFlagValidation::Ok {
-                bits: 4,
-                group_size: GPTQ_DEFAULT_GROUP_SIZE
-            }
-        );
-    }
-
-    #[test]
-    fn validate_ok_with_per_tensor_group_size() {
-        let f = GptqFlags {
-            method: Some("gptq".into()),
-            bits: Some(4),
-            group_size: Some(-1),
-        };
-        assert_eq!(
-            validate_gptq_flags(&f),
-            GptqFlagValidation::Ok {
-                bits: 4,
-                group_size: -1
-            }
-        );
-    }
-
-    #[test]
-    fn validate_rejects_wrong_method() {
-        let f = GptqFlags {
-            method: Some("awq".into()),
-            bits: Some(4),
-            group_size: Some(128),
-        };
-        assert!(matches!(
-            validate_gptq_flags(&f),
-            GptqFlagValidation::WrongMethod { .. }
-        ));
-    }
-
-    #[test]
-    fn validate_rejects_missing_bits() {
-        let f = GptqFlags {
-            method: Some("gptq".into()),
-            bits: None,
-            group_size: Some(128),
-        };
-        assert_eq!(validate_gptq_flags(&f), GptqFlagValidation::MissingBits);
-    }
-
-    #[test]
-    fn validate_rejects_invalid_bits() {
-        let f = GptqFlags {
-            method: Some("gptq".into()),
-            bits: Some(5),
-            group_size: Some(128),
-        };
-        assert!(matches!(
-            validate_gptq_flags(&f),
-            GptqFlagValidation::InvalidBits { got: 5, .. }
-        ));
-    }
-
-    #[test]
-    fn validate_rejects_invalid_group_size() {
-        let f = GptqFlags {
-            method: Some("gptq".into()),
-            bits: Some(4),
-            group_size: Some(96),
-        };
-        assert!(matches!(
-            validate_gptq_flags(&f),
-            GptqFlagValidation::InvalidGroupSize { got: 96, .. }
-        ));
-    }
-
-    #[test]
-    fn validate_is_deterministic() {
-        let f = GptqFlags {
-            method: Some("gptq".into()),
-            bits: Some(4),
-            group_size: None,
-        };
-        assert_eq!(validate_gptq_flags(&f), validate_gptq_flags(&f));
-    }
-
-    #[test]
-    fn reference_constants_match_spec() {
-        assert!(GPTQ_ALLOWED_BITS.contains(&4));
-        assert!(GPTQ_ALLOWED_GROUP_SIZES.contains(&128));
-        assert!(GPTQ_ALLOWED_GROUP_SIZES.contains(&-1));
-        assert_eq!(GPTQ_DEFAULT_GROUP_SIZE, 128);
     }
 }

--- a/crates/apr-cli/src/commands/gptq_lint.rs
+++ b/crates/apr-cli/src/commands/gptq_lint.rs
@@ -18,21 +18,26 @@
 //!     "threshold": 0.98
 //!   },
 //!   "flags": {
-//!     "argv":             ["--method", "gptq", "--bits", "4", "--group-size", "128"],
-//!     "expected_outcome": "ok"    // ok | missing_method | wrong_method | invalid_bits | missing_bits | invalid_group_size
+//!     "argv":             ["model.safetensors", "--scheme", "int4", "-o", "out.apr"],
+//!     "expected_outcome": "accepted"   // accepted (alias: ok) | rejected
 //!   }
 //! }
 //! ```
 //!
 //! Any missing top-level key is skipped. Non-zero exit + FALSIFY-CRUX-B-09
 //! stderr stamp on any failing gate.
+//!
+//! The `flags` gate asks the SHIPPED clap parser (`commands::quantize_flag_parity`)
+//! whether `apr quantize <argv>` is accepted — it used to ask a hand-rolled
+//! matcher that understood `--method`/`--bits`/`--group-size`, none of which
+//! `apr quantize` has ever taken (aprender#2377 finding 2).
 
 use super::lint_error::{load_json_observation, LintError};
 use crate::commands::gptq_classifier::{
-    classify_compression_ratio, classify_mean_cosine, parse_gptq_flags, validate_gptq_flags,
-    CompressionOutcome, CosineFidelity, GptqFlagValidation, GPTQ_MAX_COMPRESSION_RATIO,
-    GPTQ_MIN_MEAN_COSINE,
+    classify_compression_ratio, classify_mean_cosine, CompressionOutcome, CosineFidelity,
+    GPTQ_MAX_COMPRESSION_RATIO, GPTQ_MIN_MEAN_COSINE,
 };
+use crate::commands::quantize_flag_parity::evaluate_flags_observation;
 use serde_json::Value;
 use std::fs;
 use std::path::Path;
@@ -72,7 +77,7 @@ pub fn run(args: GptqLintArgs) -> Result<(), LintError> {
         }
     }
     if let Some(fl) = obs.get("flags") {
-        let (report, err) = run_flags_gate(fl);
+        let (report, err) = run_flags_gate(fl)?;
         reports.push(report);
         if let Some(e) = err {
             failures.push(e);
@@ -208,49 +213,28 @@ fn run_cosine_gate(v: &Value) -> (GateReport, Option<String>) {
     )
 }
 
-fn run_flags_gate(v: &Value) -> (GateReport, Option<String>) {
-    let argv_owned: Vec<String> = v
-        .get("argv")
-        .and_then(|x| x.as_array())
-        .map(|a| {
-            a.iter()
-                .filter_map(|s| s.as_str().map(|s| s.to_string()))
-                .collect()
-        })
-        .unwrap_or_default();
-    let argv: Vec<&str> = argv_owned.iter().map(|s| s.as_str()).collect();
-    let flags = parse_gptq_flags(&argv);
-    let validation = validate_gptq_flags(&flags);
-
-    let expected = v
-        .get("expected_outcome")
-        .and_then(|x| x.as_str())
-        .unwrap_or("ok");
-
-    let got = match &validation {
-        GptqFlagValidation::Ok { .. } => "ok",
-        GptqFlagValidation::MissingMethod => "missing_method",
-        GptqFlagValidation::WrongMethod { .. } => "wrong_method",
-        GptqFlagValidation::InvalidBits { .. } => "invalid_bits",
-        GptqFlagValidation::MissingBits => "missing_bits",
-        GptqFlagValidation::InvalidGroupSize { .. } => "invalid_group_size",
-    };
-    let passed = got == expected;
-    let desc = format!("expected={expected} got={got} ({validation:?})");
-    let err = if passed {
-        None
-    } else {
-        Some(format!("FALSIFY-CRUX-B-09-003 flags gate failed: {desc}"))
-    };
-    (
+/// The CLI-surface gate: does the SHIPPED `apr quantize` agree with what the
+/// observation claims about this argv?
+///
+/// `Err` (exit 4) means the observation cannot be used — a missing argv, a
+/// missing expectation, or an `expected_outcome` written in the vocabulary of
+/// the hand-rolled parser this gate no longer owns. `Ok` with a failure string
+/// (exit 5) means the observation was usable and the real parser disagreed.
+fn run_flags_gate(v: &Value) -> Result<(GateReport, Option<String>), LintError> {
+    const FALSIFY_ID: &str = "FALSIFY-CRUX-B-09-003";
+    let gate = evaluate_flags_observation(v, FALSIFY_ID).map_err(LintError::unusable)?;
+    let err = gate
+        .failure
+        .map(|m| format!("{FALSIFY_ID} flags gate failed: {m}"));
+    Ok((
         GateReport {
             gate: "flags",
-            falsify_id: "FALSIFY-CRUX-B-09-003",
-            outcome: desc,
-            passed,
+            falsify_id: FALSIFY_ID,
+            outcome: gate.outcome,
+            passed: gate.passed,
         },
         err,
-    )
+    ))
 }
 
 #[cfg(test)]
@@ -336,26 +320,51 @@ mod tests {
     }
 
     #[test]
-    fn flags_gate_valid_gptq_passes() {
+    fn flags_gate_accepts_a_real_quantize_invocation() {
+        let f = write_obs(
+            r#"{"flags": {"argv": ["model.safetensors", "--scheme", "int4", "-o", "out.apr"], "expected_outcome": "accepted"}}"#,
+        );
+        run(args_for(&f)).expect("the shipped `apr quantize` accepts this argv");
+    }
+
+    /// FALSIFY-LINTFLAG-004 (gptq half). Before aprender#2377 finding 2 this
+    /// observation PASSED: `parse_gptq_flags` + `validate_gptq_flags` reported
+    /// `Ok { bits: 4, group_size: 128 }` for an argv the shipped `apr quantize`
+    /// has never accepted. The gate now runs the real clap parser and refuses.
+    #[test]
+    fn flags_gate_rejects_the_method_bits_argv_the_shipped_cli_never_took() {
         let f = write_obs(
             r#"{"flags": {"argv": ["--method", "gptq", "--bits", "4", "--group-size", "128"], "expected_outcome": "ok"}}"#,
         );
-        assert!(run(args_for(&f)).is_ok());
+        let err = run(args_for(&f))
+            .expect_err("shipped `apr quantize` has no --method/--bits/--group-size")
+            .to_string();
+        assert!(err.contains("FALSIFY-CRUX-B-09-003"), "got: {err}");
+        assert!(err.contains("REJECTED"), "got: {err}");
+        assert!(
+            err.contains("--scheme"),
+            "the operator must be told which flags `apr quantize` does accept; got: {err}"
+        );
     }
 
+    /// An observation may legitimately record that the CLI refuses something.
     #[test]
-    fn flags_gate_missing_bits_classified() {
+    fn flags_gate_passes_when_the_observation_expects_a_rejection() {
+        let f = write_obs(
+            r#"{"flags": {"argv": ["--method", "gptq", "--bits", "4"], "expected_outcome": "rejected"}}"#,
+        );
+        run(args_for(&f)).expect("observer asserted the refusal that actually happens");
+    }
+
+    /// Exit 4, not exit 5: a label the real parser cannot emit is a broken
+    /// capture, not a contract violation by the system under test.
+    #[test]
+    fn flags_gate_stale_vocabulary_is_unusable_input() {
         let f = write_obs(
             r#"{"flags": {"argv": ["--method", "gptq"], "expected_outcome": "missing_bits"}}"#,
         );
-        assert!(run(args_for(&f)).is_ok());
-    }
-
-    #[test]
-    fn flags_gate_mismatch_fails() {
-        let f = write_obs(r#"{"flags": {"argv": ["--method", "gptq"], "expected_outcome": "ok"}}"#);
-        let err = run(args_for(&f)).unwrap_err().to_string();
-        assert!(err.contains("FALSIFY-CRUX-B-09-003"));
+        let err = run(args_for(&f)).expect_err("`missing_bits` is not a clap verdict");
+        assert_eq!(err.exit_code_value(), 4, "got: {err}");
     }
 
     #[test]

--- a/crates/apr-cli/src/commands/gptq_lint.rs
+++ b/crates/apr-cli/src/commands/gptq_lint.rs
@@ -90,7 +90,11 @@ pub fn run(args: GptqLintArgs) -> Result<(), LintError> {
             "contract": "CRUX-B-09",
             "gates": reports,
         });
-        println!("{}", serde_json::to_string_pretty(&payload).unwrap());
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&payload)
+                .expect("the --json report is a locally-built serde_json::Value")
+        );
     } else {
         for r in &reports {
             let tag = if r.passed { "PASS" } else { "FAIL" };

--- a/crates/apr-cli/src/commands/grad_norm.rs
+++ b/crates/apr-cli/src/commands/grad_norm.rs
@@ -43,6 +43,16 @@ pub(crate) fn run(
     spike_multiplier: f64,
     json: bool,
 ) -> Result<()> {
+    // GH-2391: a NaN cap makes `norm > cap` false for every step, so the
+    // cap-violation check reports zero violations for telemetry it never read.
+    use crate::commands::threshold_arg;
+    threshold_arg::guard_opt("--max-grad-norm", max_grad_norm, threshold_arg::TOLERANCE)?;
+    threshold_arg::guard(
+        "--spike-multiplier",
+        spike_multiplier,
+        threshold_arg::TOLERANCE,
+    )?;
+
     if !history_file.exists() {
         return Err(CliError::FileNotFound(PathBuf::from(history_file)));
     }

--- a/crates/apr-cli/src/commands/imatrix_lint.rs
+++ b/crates/apr-cli/src/commands/imatrix_lint.rs
@@ -82,7 +82,11 @@ pub fn run(args: ImatrixLintArgs) -> Result<(), LintError> {
             "contract": "CRUX-B-07",
             "gates": reports,
         });
-        println!("{}", serde_json::to_string_pretty(&payload).unwrap());
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&payload)
+                .expect("the --json report is a locally-built serde_json::Value")
+        );
     } else {
         for r in &reports {
             let tag = if r.passed { "PASS" } else { "FAIL" };

--- a/crates/apr-cli/src/commands/import.rs
+++ b/crates/apr-cli/src/commands/import.rs
@@ -217,9 +217,13 @@ pub(crate) struct ImportDescription {
 /// exact string a consumer parses.
 // serde_json::json!() uses infallible unwrap internally
 #[allow(clippy::disallowed_methods)]
+///
+/// `score` is `None` when no QA check ran — `null`, never `0`. A zero score
+/// and an unmeasured score are different facts, and printing the first for the
+/// second is the #1866 defect in miniature.
 pub(crate) fn import_json_stdout(
     describe: &ImportDescription,
-    score: u8,
+    score: Option<u8>,
     grade: &str,
     passed: bool,
 ) -> String {
@@ -245,14 +249,19 @@ fn print_import_result(
     match result {
         Ok(report) => {
             let grade = report.grade();
+            // #1866: `passed`/`score` are measured against the checks that RAN.
+            // They used to be measured against a fixed 100-point denominator
+            // that the checklist can never reach — 22 of its 26 checks are
+            // `Skip("Not implemented")` stubs — so `passed(95)` was
+            // unreachable and EVERY successful import printed
+            // "Import completed with warnings" next to Grade F.
+            let score = report.implemented_score();
             let passed = report.passed(95);
 
             if json {
                 // Exactly one JSON document on stdout, nothing else.
-                println!(
-                    "{}",
-                    import_json_stdout(describe, report.total_score, grade, passed)
-                );
+                let pct = score.pct().map(|p| p.round() as u8);
+                println!("{}", import_json_stdout(describe, pct, grade, passed));
                 return Ok(());
             }
 
@@ -261,7 +270,7 @@ fn print_import_result(
             println!(
                 "{}",
                 output::kv_table(&[
-                    ("Score", format!("{}/100", report.total_score)),
+                    ("Score", format!("{score}")),
                     ("Grade", output::grade_color(grade).to_string()),
                 ])
             );

--- a/crates/apr-cli/src/commands/import_tests.rs
+++ b/crates/apr-cli/src/commands/import_tests.rs
@@ -514,7 +514,7 @@ fn import_description_fixture() -> ImportDescription {
 
 #[test]
 fn test_import_json_stdout_parses_as_json() {
-    let stdout = import_json_stdout(&import_description_fixture(), 97, "A", true);
+    let stdout = import_json_stdout(&import_description_fixture(), Some(97), "A", true);
 
     let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|e| {
         panic!(
@@ -532,7 +532,7 @@ fn test_import_json_stdout_parses_as_json() {
 
 #[test]
 fn test_import_json_stdout_carries_no_human_decoration() {
-    let stdout = import_json_stdout(&import_description_fixture(), 60, "D", false);
+    let stdout = import_json_stdout(&import_description_fixture(), Some(60), "D", false);
 
     // These are the strings apr 0.63.0 put on stdout ahead of any document.
     for leak in [
@@ -555,7 +555,7 @@ fn test_import_json_stdout_carries_no_human_decoration() {
 fn test_import_json_stdout_reports_quantization_when_requested() {
     let mut describe = import_description_fixture();
     describe.quantize = Some("Int8".to_string());
-    let stdout = import_json_stdout(&describe, 91, "A", true);
+    let stdout = import_json_stdout(&describe, Some(91), "A", true);
 
     let parsed: serde_json::Value =
         serde_json::from_str(&stdout).expect("quantized import must still be one JSON document");

--- a/crates/apr-cli/src/commands/lint_family_guard.rs
+++ b/crates/apr-cli/src/commands/lint_family_guard.rs
@@ -124,6 +124,62 @@ mod tests {
         );
     }
 
+    /// The non-test half of a `*_lint.rs`, i.e. everything above `#[cfg(test)]`.
+    ///
+    /// The ban below is about *shipped* code. Test bodies in this family use
+    /// `.unwrap()` on `NamedTempFile` freely and that is fine — a panicking test
+    /// is a failing test. Scanning the whole file would flag those and the guard
+    /// would be deleted within a week.
+    /// Yields `(1-based line number in the real file, line)`. The line number is
+    /// carried rather than recomputed after filtering: `code_only` drops comment
+    /// lines, so enumerating its output reports a number that does not exist in
+    /// the file the reader then has to open.
+    fn shipped_code(src: &str) -> Vec<(usize, &str)> {
+        let end = src.find("#[cfg(test)]").unwrap_or(src.len());
+        src[..end]
+            .lines()
+            .enumerate()
+            .map(|(i, l)| (i + 1, l))
+            .filter(|(_, l)| !l.trim_start().starts_with("//"))
+            .collect()
+    }
+
+    /// `.unwrap()` is banned by `.clippy.toml` (`disallowed_methods`), but
+    /// `apr-cli/src/lib.rs` opens with
+    /// `#![allow(clippy::all, clippy::pedantic, clippy::disallowed_methods)]`,
+    /// so for this crate — the one with all 103 subcommands in it — the ban is
+    /// switched off crate-wide and clippy is green with unwraps present.
+    ///
+    /// That is why ten of them accumulated on one identical line, in ten files,
+    /// with nothing complaining:
+    ///
+    /// ```ignore
+    /// println!("{}", serde_json::to_string_pretty(&payload).unwrap());
+    /// ```
+    ///
+    /// Lifting the crate-wide allow is a large, separate change (the crate has
+    /// many other pedantic violations behind it). Until then this test restores
+    /// the ban for the family that demonstrably propagates by copy-paste, so a
+    /// new `*_lint.rs` cannot reintroduce the eleventh.
+    #[test]
+    fn no_lint_command_unwraps_in_shipped_code() {
+        let mut offenders = Vec::new();
+        for (name, src) in lint_family() {
+            for (lineno, line) in shipped_code(&src) {
+                if line.contains(".unwrap()") {
+                    offenders.push(format!("{name}:{lineno} {}", line.trim()));
+                }
+            }
+        }
+        assert!(
+            offenders.is_empty(),
+            "`.unwrap()` is banned (.clippy.toml disallowed_methods) but apr-cli \
+             allows it crate-wide, so only this scan catches it. Use .expect(\"why\") \
+             or propagate with ?:\n{}",
+            offenders.join("\n")
+        );
+    }
+
     #[test]
     fn no_lint_command_blames_the_apr_model_format_for_an_observation() {
         // #2377-9. `CliError::InvalidFormat` Displays as "Invalid APR format".

--- a/crates/apr-cli/src/commands/mod.rs
+++ b/crates/apr-cli/src/commands/mod.rs
@@ -7,6 +7,10 @@
 
 pub(crate) mod aliases;
 pub(crate) mod threshold_arg;
+// GH-2391 falsifiers for the whole threshold/tolerance flag family, not just
+// the *-lint commands the module originally covered.
+#[cfg(test)]
+mod threshold_arg_gh2391;
 
 pub(crate) mod attn_parity_classifier;
 pub(crate) mod attn_parity_lint;

--- a/crates/apr-cli/src/commands/mod.rs
+++ b/crates/apr-cli/src/commands/mod.rs
@@ -148,6 +148,7 @@ pub(crate) mod qa_capability;
 pub(crate) mod qualify;
 pub(crate) mod quant_preservation;
 pub(crate) mod quantize;
+pub(crate) mod quantize_flag_parity;
 pub(crate) mod react_trace_classifier;
 pub(crate) mod react_trace_lint;
 pub(crate) mod recipe;

--- a/crates/apr-cli/src/commands/nf4_lint.rs
+++ b/crates/apr-cli/src/commands/nf4_lint.rs
@@ -99,7 +99,11 @@ pub fn run(args: Nf4LintArgs) -> Result<(), LintError> {
             "contract": "CRUX-B-10",
             "gates": reports,
         });
-        println!("{}", serde_json::to_string_pretty(&payload).unwrap());
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&payload)
+                .expect("the --json report is a locally-built serde_json::Value")
+        );
     } else {
         for r in &reports {
             let tag = verdict_tag(r.passed, &r.outcome);

--- a/crates/apr-cli/src/commands/qa.rs
+++ b/crates/apr-cli/src/commands/qa.rs
@@ -406,6 +406,23 @@ pub fn run(
     assert_classifier_head: bool,
 ) -> Result<()> {
     contract_pre_qa_gate_composition!();
+    // GH-2391: every QA gate is `observed >= asserted`. A NaN or negative
+    // assertion makes that comparison unable to distinguish pass from fail, so
+    // the release gate reports a verdict it never reached. Refuse the value.
+    use crate::commands::threshold_arg;
+    threshold_arg::guard_opt("--assert-tps", min_tps, threshold_arg::TOLERANCE)?;
+    threshold_arg::guard_opt("--assert-speedup", min_speedup, threshold_arg::TOLERANCE)?;
+    threshold_arg::guard_opt(
+        "--assert-gpu-speedup",
+        min_gpu_speedup,
+        threshold_arg::TOLERANCE,
+    )?;
+    threshold_arg::guard_opt(
+        "--regression-threshold",
+        regression_threshold,
+        threshold_arg::FRACTION,
+    )?;
+
     let config = QaConfig {
         min_tps,
         min_speedup: min_speedup.unwrap_or(0.2), // Ollama uses llama.cpp optimized kernels

--- a/crates/apr-cli/src/commands/quantize_flag_parity.rs
+++ b/crates/apr-cli/src/commands/quantize_flag_parity.rs
@@ -1,0 +1,523 @@
+//! "Would the SHIPPED `apr quantize` accept this argv?" — asked of the real
+//! clap parser, never of a second implementation.
+//!
+//! # Why this module exists (aprender#2377 finding 2)
+//!
+//! `gptq_lint` and `awq_lint` each ran a "CLI flag accepted" gate whose verdict
+//! came from a hand-rolled `while i < argv.len()` matcher living next to the
+//! assertion (`parse_gptq_flags` / `parse_awq_flags` + `validate_*_flags`).
+//! Those matchers understood `--method`, `--bits` and `--group-size`. The
+//! shipped `apr quantize` (`Commands::Quantize` in `commands_enum.rs`) takes
+//! `--scheme`/`-s`, `--output`/`-o`, `--format`, `--batch`, `--plan`, `--force`
+//! over a required `<FILE>` positional. **Not one flag was shared**, and neither
+//! `gptq` nor `awq` is an accepted `--scheme` value. The gate was green for
+//! years while validating a CLI that does not exist.
+//!
+//! A gate may not own a parser. This module answers the question by handing the
+//! argv to `Cli::command()` — the very `clap::Command` the binary parses with —
+//! via `try_get_matches_from`, so the gate cannot drift from what ships: adding,
+//! renaming or removing a `quantize` flag changes this verdict in the same
+//! commit that changes the CLI.
+//!
+//! # Observation vocabulary
+//!
+//! `flags.expected_outcome` is now `accepted` | `rejected` (`ok` is kept as a
+//! spelling of `accepted`, which is what the rest of the `*-lint` family uses).
+//! The pre-fix labels (`missing_method`, `wrong_method`, `unknown_method`,
+//! `invalid_bits`, `missing_bits`, `invalid_group_size`) name classifications
+//! the real parser cannot produce, so they are refused as an unusable
+//! observation (exit 4, "your capture step is broken") rather than quietly
+//! folded into "rejected" — an old capture that passed for a brand-new reason
+//! is the failure this whole change exists to remove.
+
+use std::sync::OnceLock;
+
+use clap::CommandFactory;
+use serde_json::Value;
+
+use crate::Cli;
+
+/// `flags.expected_outcome` spelling for "the shipped parser takes this argv".
+pub const EXPECTED_ACCEPTED: &str = "accepted";
+/// Legacy spelling of [`EXPECTED_ACCEPTED`], used across the `*-lint` family.
+pub const EXPECTED_ACCEPTED_ALIAS: &str = "ok";
+/// `flags.expected_outcome` spelling for "the shipped parser refuses this argv".
+pub const EXPECTED_REJECTED: &str = "rejected";
+
+/// What the shipped `apr quantize` parser did with a recorded argv.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum QuantizeArgvVerdict {
+    /// `apr quantize <argv>` parses.
+    Accepted,
+    /// `apr quantize <argv>` is refused; `reason` is the parser's own first
+    /// diagnostic line (e.g. `unexpected argument '--method' found`).
+    Rejected { reason: String },
+}
+
+impl QuantizeArgvVerdict {
+    /// The word this verdict is reported and compared as.
+    #[must_use]
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::Accepted => EXPECTED_ACCEPTED,
+            Self::Rejected { .. } => EXPECTED_REJECTED,
+        }
+    }
+
+    #[must_use]
+    pub fn is_accepted(&self) -> bool {
+        matches!(self, Self::Accepted)
+    }
+}
+
+/// Clap's parser for `apr`'s ~103 subcommands needs more stack than a default
+/// thread has in debug builds — `parsing.rs::parse_cli` spawns a 16 MB thread
+/// for exactly this reason. Every entry into the shipped parser goes through
+/// here so a lint gate is safe to call from a test thread too.
+fn on_big_stack<T: Send + 'static>(f: impl FnOnce() -> T + Send + 'static) -> T {
+    std::thread::Builder::new()
+        .stack_size(16 * 1024 * 1024)
+        .spawn(f)
+        .expect("spawn shipped-CLI parser thread")
+        .join()
+        .expect("shipped-CLI parser thread must not panic")
+}
+
+/// Prefix the recorded argv with the binary and subcommand the parser expects.
+///
+/// Observations record the argv *after* `apr quantize`; a capture that also
+/// recorded the literal `quantize` is tolerated rather than double-prefixed.
+fn normalized_argv(argv: &[&str]) -> Vec<String> {
+    let mut full = Vec::with_capacity(argv.len() + 2);
+    full.push("apr".to_string());
+    if argv.first().copied() != Some("quantize") {
+        full.push("quantize".to_string());
+    }
+    full.extend(argv.iter().map(|s| (*s).to_string()));
+    full
+}
+
+/// The shipped parser's first diagnostic line, without clap's `error:` stamp.
+fn clap_reason(e: &clap::Error) -> String {
+    use clap::error::ErrorKind;
+    match e.kind() {
+        ErrorKind::DisplayHelp | ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand => {
+            "argv is a help request, not an `apr quantize` invocation".to_string()
+        }
+        ErrorKind::DisplayVersion => {
+            "argv is a version request, not an `apr quantize` invocation".to_string()
+        }
+        _ => first_diagnostic_line(&e.to_string()),
+    }
+}
+
+fn first_diagnostic_line(rendered: &str) -> String {
+    rendered
+        .lines()
+        .map(str::trim)
+        .find(|l| !l.is_empty())
+        .map(|l| l.trim_start_matches("error:").trim().to_string())
+        .filter(|l| !l.is_empty())
+        .unwrap_or_else(|| "refused by the shipped parser".to_string())
+}
+
+/// Ask the shipped `apr` clap parser whether `apr quantize <argv>` is accepted.
+///
+/// This is the only acceptance oracle the lint gates may use.
+#[must_use]
+pub fn shipped_quantize_verdict(argv: &[&str]) -> QuantizeArgvVerdict {
+    let owned = normalized_argv(argv);
+    on_big_stack(move || match Cli::command().try_get_matches_from(&owned) {
+        Ok(_) => QuantizeArgvVerdict::Accepted,
+        Err(e) => QuantizeArgvVerdict::Rejected {
+            reason: clap_reason(&e),
+        },
+    })
+}
+
+fn arg_value_name(a: &clap::Arg) -> String {
+    a.get_value_names()
+        .and_then(<[clap::builder::Str]>::first)
+        .map_or_else(|| a.get_id().as_str().to_uppercase(), ToString::to_string)
+}
+
+fn arg_takes_value(a: &clap::Arg) -> bool {
+    use clap::ArgAction;
+    !matches!(
+        a.get_action(),
+        ArgAction::SetTrue | ArgAction::SetFalse | ArgAction::Count | ArgAction::Help
+    )
+}
+
+fn render_arg(a: &clap::Arg) -> String {
+    if a.is_positional() {
+        return format!("<{}>", arg_value_name(a));
+    }
+    let mut s = String::new();
+    if let Some(l) = a.get_long() {
+        s.push_str("--");
+        s.push_str(l);
+    }
+    if let Some(c) = a.get_short() {
+        s.push('/');
+        s.push('-');
+        s.push(c);
+    }
+    if arg_takes_value(a) {
+        s.push_str(&format!(" <{}>", arg_value_name(a)));
+    }
+    s
+}
+
+fn build_quantize_summary() -> String {
+    let root = Cli::command();
+    let Some(q) = root.find_subcommand("quantize") else {
+        return "(the shipped CLI has no `quantize` subcommand)".to_string();
+    };
+    let parts: Vec<String> = q
+        .get_arguments()
+        .filter(|a| !matches!(a.get_id().as_str(), "help" | "version"))
+        .map(render_arg)
+        .collect();
+    if parts.is_empty() {
+        return "(no arguments)".to_string();
+    }
+    parts.join(" ")
+}
+
+/// Every argument the shipped `apr quantize` actually accepts, read off the
+/// same `clap::Command` the binary parses with — so an operator reading a
+/// failure is told the truth and not a copy of it.
+#[must_use]
+pub fn shipped_quantize_accepts_summary() -> &'static str {
+    static SUMMARY: OnceLock<String> = OnceLock::new();
+    SUMMARY.get_or_init(|| on_big_stack(build_quantize_summary))
+}
+
+/// One flags-gate verdict, ready for a lint's `GateReport`.
+#[derive(Debug, Clone)]
+pub struct FlagParityGate {
+    pub passed: bool,
+    /// One-line summary for the gate report.
+    pub outcome: String,
+    /// Operator-facing explanation, present exactly when `!passed`.
+    pub failure: Option<String>,
+}
+
+fn read_argv(v: &Value, falsify_id: &str) -> Result<Vec<String>, String> {
+    let Some(items) = v.get("argv").and_then(Value::as_array) else {
+        return Err(format!(
+            "{falsify_id}: flags.argv is missing or is not an array — the gate has no argv to hand the shipped `apr quantize` parser"
+        ));
+    };
+    items
+        .iter()
+        .map(|s| {
+            s.as_str().map(ToString::to_string).ok_or_else(|| {
+                format!("{falsify_id}: flags.argv contains a non-string element ({s})")
+            })
+        })
+        .collect()
+}
+
+/// `true` = the observation claims the shipped parser accepts this argv.
+fn read_expectation(v: &Value, falsify_id: &str) -> Result<bool, String> {
+    let Some(raw) = v.get("expected_outcome").and_then(Value::as_str) else {
+        return Err(format!(
+            "{falsify_id}: flags.expected_outcome is missing — state `{EXPECTED_ACCEPTED}` or `{EXPECTED_REJECTED}`; a gate with an implied expectation asserts nothing"
+        ));
+    };
+    match raw {
+        EXPECTED_ACCEPTED | EXPECTED_ACCEPTED_ALIAS => Ok(true),
+        EXPECTED_REJECTED => Ok(false),
+        other => Err(format!(
+            "{falsify_id}: flags.expected_outcome `{other}` is not a verdict of the shipped `apr quantize` parser. This gate now runs the real clap parser, whose only outcomes are `{EXPECTED_ACCEPTED}` (alias `{EXPECTED_ACCEPTED_ALIAS}`) and `{EXPECTED_REJECTED}`; the per-flag labels this observation was captured with described a parser that never shipped. Re-capture it."
+        )),
+    }
+}
+
+fn describe_argv(argv: &[String]) -> String {
+    if argv.is_empty() {
+        "(empty)".to_string()
+    } else {
+        argv.join(" ")
+    }
+}
+
+fn failure_text(expected_accepted: bool, argv: &[String], verdict: &QuantizeArgvVerdict) -> String {
+    let shown = describe_argv(argv);
+    let accepts = shipped_quantize_accepts_summary();
+    match verdict {
+        QuantizeArgvVerdict::Rejected { reason } => format!(
+            "the shipped `apr quantize` REJECTED this argv, but the observation expected it to be accepted.\n  \
+             argv:                   {shown}\n  \
+             shipped parser said:    {reason}\n  \
+             `apr quantize` accepts: {accepts}"
+        ),
+        QuantizeArgvVerdict::Accepted => {
+            debug_assert!(!expected_accepted, "accepted+expected-accepted is a pass");
+            format!(
+                "the shipped `apr quantize` ACCEPTED this argv, but the observation expected it to be rejected.\n  \
+                 argv:                   {shown}\n  \
+                 `apr quantize` accepts: {accepts}"
+            )
+        }
+    }
+}
+
+/// Run the flags gate over an observation's `flags` object.
+///
+/// `Err` means the observation itself is unusable (the caller maps it to exit
+/// 4); `Ok(gate)` with `passed == false` means the observation was usable and
+/// the shipped parser disagreed with it (exit 5).
+pub fn evaluate_flags_observation(v: &Value, falsify_id: &str) -> Result<FlagParityGate, String> {
+    let argv = read_argv(v, falsify_id)?;
+    let expected_accepted = read_expectation(v, falsify_id)?;
+
+    let borrowed: Vec<&str> = argv.iter().map(String::as_str).collect();
+    let verdict = shipped_quantize_verdict(&borrowed);
+    let passed = verdict.is_accepted() == expected_accepted;
+
+    let expected_label = if expected_accepted {
+        EXPECTED_ACCEPTED
+    } else {
+        EXPECTED_REJECTED
+    };
+    let got = verdict.label();
+    let outcome = match &verdict {
+        QuantizeArgvVerdict::Accepted => {
+            format!("expected={expected_label} got={got} (shipped `apr quantize` parser)")
+        }
+        QuantizeArgvVerdict::Rejected { reason } => {
+            format!("expected={expected_label} got={got} (shipped `apr quantize` parser: {reason})")
+        }
+    };
+    let failure = if passed {
+        None
+    } else {
+        Some(failure_text(expected_accepted, &argv, &verdict))
+    };
+    Ok(FlagParityGate {
+        passed,
+        outcome,
+        failure,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // ---- FALSIFY-LINTFLAG-001: the oracle is the shipped parser ----
+
+    #[test]
+    fn shipped_parser_rejects_the_flags_the_hand_rolled_parser_accepted() {
+        // The load-bearing case. `parse_gptq_flags` + `validate_gptq_flags`
+        // called this argv `Ok { bits: 4, group_size: 128 }`. `apr quantize`
+        // has no `--method`, no `--bits` and no `--group-size`.
+        let v =
+            shipped_quantize_verdict(&["--method", "gptq", "--bits", "4", "--group-size", "128"]);
+        let QuantizeArgvVerdict::Rejected { reason } = v else {
+            panic!("shipped `apr quantize` must REFUSE --method/--bits/--group-size, got: {v:?}");
+        };
+        assert!(
+            reason.contains("--method"),
+            "the refusal must name the flag that does not exist; got: {reason}"
+        );
+    }
+
+    #[test]
+    fn shipped_parser_rejects_the_awq_argv_the_hand_rolled_parser_accepted() {
+        let v = shipped_quantize_verdict(&["--method=awq", "--bits=4"]);
+        assert!(
+            !v.is_accepted(),
+            "shipped `apr quantize` must REFUSE --method=awq --bits=4, got: {v:?}"
+        );
+    }
+
+    #[test]
+    fn shipped_parser_accepts_a_real_quantize_invocation() {
+        let v =
+            shipped_quantize_verdict(&["model.safetensors", "--scheme", "int4", "-o", "out.apr"]);
+        assert_eq!(
+            v,
+            QuantizeArgvVerdict::Accepted,
+            "a real `apr quantize <FILE> --scheme int4 -o out.apr` must be accepted"
+        );
+    }
+
+    #[test]
+    fn shipped_parser_accepts_the_long_form_and_the_plan_flag() {
+        assert_eq!(
+            shipped_quantize_verdict(&["m.apr", "--scheme", "q4k", "--plan"]),
+            QuantizeArgvVerdict::Accepted
+        );
+        assert_eq!(
+            shipped_quantize_verdict(&[
+                "m.apr", "--output", "o.apr", "--format", "gguf", "--force"
+            ]),
+            QuantizeArgvVerdict::Accepted
+        );
+    }
+
+    #[test]
+    fn a_leading_literal_quantize_is_not_double_prefixed() {
+        assert_eq!(
+            shipped_quantize_verdict(&["quantize", "m.apr", "--scheme", "int8"]),
+            QuantizeArgvVerdict::Accepted
+        );
+    }
+
+    #[test]
+    fn shipped_parser_refuses_quantize_without_the_required_file() {
+        let v = shipped_quantize_verdict(&["--scheme", "int4"]);
+        assert!(
+            !v.is_accepted(),
+            "`apr quantize --scheme int4` omits the required <FILE>; got: {v:?}"
+        );
+    }
+
+    #[test]
+    fn shipped_parser_refuses_an_unknown_flag() {
+        let v = shipped_quantize_verdict(&["m.apr", "--totally-made-up"]);
+        assert!(!v.is_accepted(), "unknown flag must be refused; got: {v:?}");
+    }
+
+    #[test]
+    fn verdict_labels_are_the_observation_vocabulary() {
+        assert_eq!(QuantizeArgvVerdict::Accepted.label(), "accepted");
+        assert_eq!(
+            QuantizeArgvVerdict::Rejected { reason: "x".into() }.label(),
+            "rejected"
+        );
+    }
+
+    // ---- FALSIFY-LINTFLAG-002: the accepted-flag list is read off clap ----
+
+    #[test]
+    fn accepts_summary_names_the_real_quantize_surface() {
+        let s = shipped_quantize_accepts_summary();
+        for expected in [
+            "<FILE>", "--scheme", "--output", "--format", "--batch", "--plan", "--force",
+        ] {
+            assert!(
+                s.contains(expected),
+                "summary must name {expected}; got: {s}"
+            );
+        }
+    }
+
+    #[test]
+    fn accepts_summary_never_advertises_the_flags_that_do_not_exist() {
+        let s = shipped_quantize_accepts_summary();
+        for absent in ["--method", "--bits", "--group-size"] {
+            assert!(
+                !s.contains(absent),
+                "summary must not advertise {absent}, which `apr quantize` does not take; got: {s}"
+            );
+        }
+    }
+
+    // ---- FALSIFY-LINTFLAG-003: gate verdict = shipped parser verdict ----
+
+    #[test]
+    fn gate_fails_when_observation_expects_the_nonexistent_flags_to_be_accepted() {
+        let obs = json!({
+            "argv": ["--method", "gptq", "--bits", "4", "--group-size", "128"],
+            "expected_outcome": "ok"
+        });
+        let gate = evaluate_flags_observation(&obs, "FALSIFY-TEST").expect("observation is usable");
+        assert!(
+            !gate.passed,
+            "gate must fail: the shipped parser refuses this argv; outcome={}",
+            gate.outcome
+        );
+        let msg = gate.failure.expect("a failed gate must explain itself");
+        assert!(msg.contains("REJECTED"), "got: {msg}");
+        assert!(
+            msg.contains("--scheme"),
+            "the failure must name the flags `apr quantize` does accept; got: {msg}"
+        );
+    }
+
+    #[test]
+    fn gate_passes_when_observation_expects_a_real_invocation_to_be_accepted() {
+        let obs = json!({
+            "argv": ["model.safetensors", "--scheme", "int4", "-o", "out.apr"],
+            "expected_outcome": "accepted"
+        });
+        let gate = evaluate_flags_observation(&obs, "FALSIFY-TEST").expect("observation is usable");
+        assert!(gate.passed, "outcome={}", gate.outcome);
+        assert!(gate.failure.is_none());
+    }
+
+    #[test]
+    fn gate_passes_when_observation_expects_the_nonexistent_flags_to_be_rejected() {
+        let obs = json!({
+            "argv": ["--method", "awq", "--bits", "4"],
+            "expected_outcome": "rejected"
+        });
+        let gate = evaluate_flags_observation(&obs, "FALSIFY-TEST").expect("observation is usable");
+        assert!(gate.passed, "outcome={}", gate.outcome);
+    }
+
+    #[test]
+    fn gate_fails_when_observation_expects_a_real_invocation_to_be_rejected() {
+        let obs = json!({
+            "argv": ["m.apr", "--scheme", "int4", "-o", "o.apr"],
+            "expected_outcome": "rejected"
+        });
+        let gate = evaluate_flags_observation(&obs, "FALSIFY-TEST").expect("observation is usable");
+        assert!(!gate.passed, "outcome={}", gate.outcome);
+        let msg = gate.failure.expect("a failed gate must explain itself");
+        assert!(msg.contains("ACCEPTED"), "got: {msg}");
+    }
+
+    // ---- unusable observations (exit 4), not gate failures (exit 5) ----
+
+    #[test]
+    fn a_stale_per_flag_label_is_refused_as_unusable_not_folded_into_rejected() {
+        let obs = json!({ "argv": ["--method", "gptq"], "expected_outcome": "missing_bits" });
+        let err = evaluate_flags_observation(&obs, "FALSIFY-TEST")
+            .expect_err("a label the real parser cannot produce must be refused");
+        assert!(err.contains("missing_bits"), "got: {err}");
+        assert!(err.contains("Re-capture it"), "got: {err}");
+    }
+
+    #[test]
+    fn a_missing_expectation_is_refused_rather_than_defaulted() {
+        let obs = json!({ "argv": ["m.apr", "--scheme", "int4", "-o", "o.apr"] });
+        let err = evaluate_flags_observation(&obs, "FALSIFY-TEST")
+            .expect_err("an implied expectation asserts nothing");
+        assert!(err.contains("expected_outcome is missing"), "got: {err}");
+    }
+
+    #[test]
+    fn a_missing_argv_is_refused_rather_than_treated_as_empty() {
+        let obs = json!({ "expected_outcome": "accepted" });
+        let err = evaluate_flags_observation(&obs, "FALSIFY-TEST")
+            .expect_err("no argv means nothing was captured");
+        assert!(err.contains("flags.argv is missing"), "got: {err}");
+    }
+
+    #[test]
+    fn a_non_string_argv_element_is_refused() {
+        let obs = json!({ "argv": ["m.apr", 4], "expected_outcome": "accepted" });
+        let err =
+            evaluate_flags_observation(&obs, "FALSIFY-TEST").expect_err("argv must be strings");
+        assert!(err.contains("non-string element"), "got: {err}");
+    }
+
+    #[test]
+    fn the_gate_is_deterministic() {
+        let obs = json!({
+            "argv": ["--method", "gptq", "--bits", "4"],
+            "expected_outcome": "ok"
+        });
+        let a = evaluate_flags_observation(&obs, "FALSIFY-TEST").expect("usable");
+        let b = evaluate_flags_observation(&obs, "FALSIFY-TEST").expect("usable");
+        assert_eq!(a.passed, b.passed);
+        assert_eq!(a.outcome, b.outcome);
+    }
+}

--- a/crates/apr-cli/src/commands/registry_quota_lint.rs
+++ b/crates/apr-cli/src/commands/registry_quota_lint.rs
@@ -79,7 +79,11 @@ pub fn run(args: RegistryQuotaLintArgs) -> Result<(), LintError> {
             "contract": "CRUX-A-22",
             "gates": reports,
         });
-        println!("{}", serde_json::to_string_pretty(&payload).unwrap());
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&payload)
+                .expect("the --json report is a locally-built serde_json::Value")
+        );
     } else {
         for r in &reports {
             let tag = if r.passed { "PASS" } else { "FAIL" };

--- a/crates/apr-cli/src/commands/rm_gc_lint.rs
+++ b/crates/apr-cli/src/commands/rm_gc_lint.rs
@@ -93,7 +93,11 @@ pub fn run(args: RmGcLintArgs) -> Result<(), LintError> {
             "contract": "CRUX-A-25",
             "gates": reports,
         });
-        println!("{}", serde_json::to_string_pretty(&payload).unwrap());
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&payload)
+                .expect("the --json report is a locally-built serde_json::Value")
+        );
     } else {
         for r in &reports {
             let tag = if r.passed { "PASS" } else { "FAIL" };

--- a/crates/apr-cli/src/commands/rosetta.rs
+++ b/crates/apr-cli/src/commands/rosetta.rs
@@ -93,7 +93,8 @@ pub enum RosettaCommands {
         intermediate: String,
 
         /// Tolerance for numerical differences (default: 1e-5)
-        #[arg(long, default_value = "1e-5")]
+        #[arg(long, default_value = "1e-5",
+              value_parser = crate::commands::threshold_arg::parse_tolerance_f32)]
         tolerance: f32,
 
         /// Output as JSON
@@ -124,7 +125,8 @@ pub enum RosettaCommands {
         temperature: f32,
 
         /// Logit difference tolerance
-        #[arg(long, default_value = "0.1")]
+        #[arg(long, default_value = "0.1",
+              value_parser = crate::commands::threshold_arg::parse_fraction_f32)]
         tolerance: f32,
 
         /// Output as JSON
@@ -212,7 +214,8 @@ pub enum RosettaCommands {
         fingerprints: Option<PathBuf>,
 
         /// Deviation threshold in standard deviations (default: 3.0)
-        #[arg(long, default_value = "3.0")]
+        #[arg(long, default_value = "3.0",
+              value_parser = crate::commands::threshold_arg::parse_tolerance_f32)]
         threshold: f32,
 
         /// Use role-specific thresholds (stricter for LayerNorm, looser for embeddings)

--- a/crates/apr-cli/src/commands/rosetta_validate.rs
+++ b/crates/apr-cli/src/commands/rosetta_validate.rs
@@ -8,6 +8,15 @@ pub fn run_validate_stats(
     strict: bool,
     json: bool,
 ) -> Result<()> {
+    // GH-2391: an anomaly is `deviation > threshold`. NaN makes that false for
+    // every tensor, so the command reports "no anomalies" over a model it never
+    // judged.
+    crate::commands::threshold_arg::guard_f32(
+        "--threshold",
+        threshold,
+        crate::commands::threshold_arg::TOLERANCE,
+    )?;
+
     validate_stats_inputs(model, reference, fingerprints_file)?;
 
     if !json {

--- a/crates/apr-cli/src/commands/serve/chat.rs
+++ b/crates/apr-cli/src/commands/serve/chat.rs
@@ -269,6 +269,7 @@ pub(crate) async fn safetensors_chat_completions_handler(
         repetition_penalty: 1.0,
         trace: false,
         stop_tokens: vec![],
+        cancel: realizar::generate::CancelToken::never(),
     };
     let output_ids = {
         // PMAT-189: Handle transformer lock poisoning gracefully

--- a/crates/apr-cli/src/commands/serve/handler_apr_cpu_completion.rs
+++ b/crates/apr-cli/src/commands/serve/handler_apr_cpu_completion.rs
@@ -137,6 +137,7 @@ fn spawn_cpu_streaming_task(
             repetition_penalty: 1.0,
             trace: false,
             stop_tokens: vec![],
+            cancel: realizar::generate::CancelToken::never(),
         };
 
         let Ok(t) = transformer.lock() else {
@@ -210,6 +211,7 @@ fn spawn_cpu_token_text_stream(
             repetition_penalty: 1.0,
             trace: false,
             stop_tokens: vec![],
+            cancel: realizar::generate::CancelToken::never(),
         };
 
         let Ok(t) = transformer.lock() else {

--- a/crates/apr-cli/src/commands/serve/handlers.rs
+++ b/crates/apr-cli/src/commands/serve/handlers.rs
@@ -873,6 +873,7 @@ fn run_apr_cpu_inference(
         repetition_penalty: 1.0,
         trace: false,
         stop_tokens: vec![],
+        cancel: realizar::generate::CancelToken::never(),
     };
 
     let gen_start = Instant::now();

--- a/crates/apr-cli/src/commands/serve/simple.rs
+++ b/crates/apr-cli/src/commands/serve/simple.rs
@@ -48,6 +48,7 @@ pub(crate) async fn safetensors_generate_handler(
         repetition_penalty: 1.0,
         trace: false,
         stop_tokens: vec![],
+        cancel: realizar::generate::CancelToken::never(),
     };
     let output_ids = {
         // PMAT-189: Handle transformer lock poisoning gracefully

--- a/crates/apr-cli/src/commands/shared_cache_lint.rs
+++ b/crates/apr-cli/src/commands/shared_cache_lint.rs
@@ -80,7 +80,11 @@ pub fn run(args: SharedCacheLintArgs) -> Result<(), LintError> {
             "contract": "CRUX-A-21",
             "gates": reports,
         });
-        println!("{}", serde_json::to_string_pretty(&payload).unwrap());
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&payload)
+                .expect("the --json report is a locally-built serde_json::Value")
+        );
     } else {
         for r in &reports {
             let tag = if r.passed { "PASS" } else { "FAIL" };

--- a/crates/apr-cli/src/commands/threshold_arg.rs
+++ b/crates/apr-cli/src/commands/threshold_arg.rs
@@ -104,6 +104,48 @@ fn parse_in(s: &str, domain: ThresholdDomain) -> std::result::Result<f64, String
     check(value, domain)
 }
 
+/// clap `value_parser` for an `f32` tolerance/floor flag.
+///
+/// The `f32` family exists because roughly half the gate thresholds in the CLI
+/// are declared `f32` (cosine floors on `apr diff`, sigma thresholds on
+/// `apr rosetta validate-stats`, the perplexity ceiling on `apr eval`). Parsing
+/// as `f32` first and widening for the domain check keeps the round-trip exact:
+/// parsing as `f64` and narrowing would accept `1e-300` and then hand the gate a
+/// silent `0.0`.
+pub(crate) fn parse_tolerance_f32(s: &str) -> std::result::Result<f32, String> {
+    parse_in_f32(s, TOLERANCE)
+}
+
+/// clap `value_parser` for an `f32` `[0.0, 1.0]` fraction flag.
+pub(crate) fn parse_fraction_f32(s: &str) -> std::result::Result<f32, String> {
+    parse_in_f32(s, FRACTION)
+}
+
+/// clap `value_parser` for an `f32` cosine-similarity floor flag.
+pub(crate) fn parse_cosine_f32(s: &str) -> std::result::Result<f32, String> {
+    parse_in_f32(s, COSINE)
+}
+
+fn parse_in_f32(s: &str, domain: ThresholdDomain) -> std::result::Result<f32, String> {
+    let value: f32 = s.parse().map_err(|_| "invalid float literal".to_string())?;
+    check(f64::from(value), domain)?;
+    Ok(value)
+}
+
+/// `guard()` for an `f32` threshold. Same fail-closed contract as [`guard`].
+pub(crate) fn guard_f32(flag: &str, value: f32, domain: ThresholdDomain) -> Result<()> {
+    guard(flag, f64::from(value), domain)
+}
+
+/// `guard()` for an optional threshold: `None` means "no assertion", which is
+/// not a disarmed gate, so it passes. `Some(NaN)` is a disarmed gate.
+pub(crate) fn guard_opt(flag: &str, value: Option<f64>, domain: ThresholdDomain) -> Result<()> {
+    match value {
+        Some(v) => guard(flag, v, domain),
+        None => Ok(()),
+    }
+}
+
 /// Fail-closed guard for the `run()` entry points, so a non-clap caller cannot
 /// disarm a gate either. Errors as `ValidationFailed` (exit 5), matching the
 /// exit code the gate itself would have produced.

--- a/crates/apr-cli/src/commands/threshold_arg_gh2391.rs
+++ b/crates/apr-cli/src/commands/threshold_arg_gh2391.rs
@@ -1,0 +1,397 @@
+//! GH-2391 falsifiers — a NaN or out-of-domain threshold must never reach a gate.
+//!
+//! `threshold_arg` shipped in the *-lint family and five callers used it. The
+//! issue is broader: *any* CLI flag whose value ends up on one side of a
+//! pass/fail comparison disarms that gate when it is NaN, because IEEE-754 makes
+//! every comparison involving NaN false. An enumeration of `apr-cli`'s clap
+//! definitions found 52 `f32`/`f64` flags, 23 of which feed a gate comparison;
+//! 8 were guarded, 15 were not.
+//!
+//! These tests are the *user-visible* proof: the exact command line an operator
+//! would type must be refused, and the refusal must name the flag.
+//!
+//! `apr grad-norm` is the mutation witness. It already had a
+//! `spike_multiplier <= 0.0` check — which is itself NaN-blind, since
+//! `NaN <= 0.0` is false — and its cap check is
+//! `grad_norm_clipped > cap + 1e-6`. Against a NaN cap that is false for every
+//! step, so the command printed a report and exited 0 over telemetry that
+//! blew straight through the cap.
+
+use super::threshold_arg::{guard, guard_f32, guard_opt, COSINE, FRACTION, TOLERANCE};
+use crate::error::CliError;
+
+/// `Commands` is a very large enum; building the clap command tree needs more
+/// stack than the 2 MiB a test thread gets by default.
+fn on_big_stack(f: impl FnOnce() + Send + 'static) {
+    std::thread::Builder::new()
+        .stack_size(32 * 1024 * 1024)
+        .spawn(f)
+        .expect("spawn")
+        .join()
+        .expect("join");
+}
+
+/// Every gate-feeding flag the enumeration found unguarded, as
+/// `(base command line, flag, legitimate value, disarming values)`.
+///
+/// Each row is checked BOTH ways on purpose. `try_parse_from(...).is_err()` on
+/// its own proves nothing: it is equally satisfied by a missing positional
+/// argument, so a typo in the test's own command line would fake a pass. The
+/// legitimate value pins the base command line as parseable, and only then does
+/// the rejection of the disarming value mean what it claims.
+type ThresholdCase = (
+    &'static [&'static str],
+    &'static str,
+    &'static str,
+    &'static [&'static str],
+);
+
+const GATE_FLAGS: &[ThresholdCase] = &[
+    // apr diff --quant-roundtrip: "any tensor cosine < threshold" (CRUX-B-20).
+    (
+        &["apr", "diff", "a.apr", "b.apr"],
+        "--threshold",
+        "0.95",
+        &["nan", "1.5", "-2"],
+    ),
+    // apr eval: perplexity pass/fail threshold.
+    (
+        &["apr", "eval", "m.apr"],
+        "--threshold",
+        "20.0",
+        &["nan", "-1"],
+    ),
+    // apr profile: achieved-GFLOPS floor, then the three CI assertions.
+    (
+        &["apr", "profile", "m.apr"],
+        "--threshold",
+        "10.0",
+        &["nan", "-1"],
+    ),
+    (
+        &["apr", "profile", "m.apr"],
+        "--assert-throughput",
+        "100",
+        &["nan", "-1", "inf"],
+    ),
+    (
+        &["apr", "profile", "m.apr"],
+        "--assert-p99",
+        "50",
+        &["nan", "-1"],
+    ),
+    (
+        &["apr", "profile", "m.apr"],
+        "--assert-p50",
+        "25",
+        &["nan", "-1"],
+    ),
+    // apr qa: the project's own release gate.
+    (
+        &["apr", "qa", "m.gguf"],
+        "--assert-tps",
+        "100",
+        &["nan", "-1", "inf"],
+    ),
+    (
+        &["apr", "qa", "m.gguf"],
+        "--assert-speedup",
+        "1.0",
+        &["nan", "-1"],
+    ),
+    (
+        &["apr", "qa", "m.gguf"],
+        "--assert-gpu-speedup",
+        "2.0",
+        &["nan", "-1"],
+    ),
+    (
+        &["apr", "qa", "m.gguf"],
+        "--regression-threshold",
+        "0.10",
+        &["nan", "-1", "42"],
+    ),
+    // apr compare-hf: "max_abs_diff < threshold".
+    (
+        &["apr", "compare-hf", "m.apr", "--hf", "org/repo"],
+        "--threshold",
+        "1e-5",
+        &["nan", "-1"],
+    ),
+    // apr grad-norm: cap-violation check and spike detection.
+    (
+        &["apr", "grad-norm", "--history-file", "h.json"],
+        "--max-grad-norm",
+        "1.0",
+        &["nan", "-1"],
+    ),
+    (
+        &["apr", "grad-norm", "--history-file", "h.json"],
+        "--spike-multiplier",
+        "10.0",
+        &["nan", "-1"],
+    ),
+    // apr cbtop --ci: minimum throughput.
+    (&["apr", "cbtop"], "--throughput", "225.0", &["nan", "-1"]),
+    // apr probar tensor --assert: cosine floor for the golden comparison.
+    (
+        &["apr", "probar", "tensor", "m.apr"],
+        "--tolerance",
+        "0.98",
+        &["nan", "2.0", "-2"],
+    ),
+    // apr rosetta: verify tolerance, inference mismatch rate, sigma threshold.
+    (
+        &["apr", "rosetta", "verify", "m.apr"],
+        "--tolerance",
+        "1e-5",
+        &["nan", "-1"],
+    ),
+    (
+        &["apr", "rosetta", "compare-inference", "a.gguf", "b.apr"],
+        "--tolerance",
+        "0.1",
+        &["nan", "-1", "42"],
+    ),
+    (
+        &["apr", "rosetta", "validate-stats", "m.apr"],
+        "--threshold",
+        "3.0",
+        &["nan", "-1"],
+    ),
+];
+
+/// `apr pretrain` only exists under the `training` feature, so its row is kept
+/// out of the always-on table rather than making the whole table's "must parse"
+/// premise feature-dependent.
+#[cfg(feature = "training")]
+const TRAINING_GATE_FLAGS: &[ThresholdCase] = &[(
+    &[
+        "apr",
+        "pretrain",
+        "--dataset",
+        "d.bin",
+        "--tokenizer",
+        "tok/",
+        "--run-dir",
+        "run/",
+    ],
+    "--target-val-loss",
+    "2.2",
+    &["nan", "-1"],
+)];
+
+#[test]
+fn cli_refuses_a_disarming_threshold_on_every_newly_guarded_gate_flag() {
+    on_big_stack(cli_gate_flag_table_body);
+}
+
+fn cli_gate_flag_table_body() {
+    use clap::Parser;
+
+    let mut cases: Vec<&ThresholdCase> = GATE_FLAGS.iter().collect();
+    #[cfg(feature = "training")]
+    cases.extend(TRAINING_GATE_FLAGS.iter());
+
+    for (base, flag, good, bad_values) in cases {
+        let mut ok_argv: Vec<&str> = base.to_vec();
+        ok_argv.push(flag);
+        ok_argv.push(good);
+        assert!(
+            crate::Cli::try_parse_from(ok_argv.iter().copied()).is_ok(),
+            "the test's own command line must parse, or the rejections below \
+             prove nothing: {ok_argv:?}"
+        );
+
+        for bad in *bad_values {
+            let mut argv: Vec<&str> = base.to_vec();
+            argv.push(flag);
+            argv.push(bad);
+            assert!(
+                crate::Cli::try_parse_from(argv.iter().copied()).is_err(),
+                "clap accepted a gate-disarming threshold: {argv:?}"
+            );
+        }
+    }
+}
+
+/// The whole family the fix touches must still accept its own documented
+/// defaults. Guarding a flag is only correct if it did not narrow the domain,
+/// and every `good` value in the table above is either the flag's shipped
+/// default or a value the falsification suites pass on the command line.
+#[test]
+fn cli_still_accepts_the_documented_values_for_those_same_flags() {
+    on_big_stack(cli_defaults_body);
+}
+
+fn cli_defaults_body() {
+    use clap::Parser;
+
+    // Combining every flag of a command in one invocation catches a guard that
+    // only works when the flag is passed alone.
+    let combined: &[&[&str]] = &[
+        &[
+            "apr",
+            "profile",
+            "m.apr",
+            "--threshold",
+            "10.0",
+            "--assert-throughput",
+            "100",
+            "--assert-p99",
+            "50",
+            "--assert-p50",
+            "25",
+        ],
+        &[
+            "apr",
+            "qa",
+            "m.gguf",
+            "--assert-tps",
+            "100",
+            "--assert-speedup",
+            "1.0",
+            "--assert-gpu-speedup",
+            "2.0",
+            "--regression-threshold",
+            "0.10",
+        ],
+        &[
+            "apr",
+            "grad-norm",
+            "--history-file",
+            "h.json",
+            "--max-grad-norm",
+            "1.0",
+            "--spike-multiplier",
+            "10.0",
+        ],
+    ];
+
+    for argv in combined {
+        assert!(
+            crate::Cli::try_parse_from(argv.iter().copied()).is_ok(),
+            "clap rejected a legitimate combination: {argv:?}"
+        );
+    }
+}
+
+/// MUTATION WITNESS for the `guard()` half of the fix (the half a non-clap
+/// caller reaches). `apr grad-norm` is handed telemetry whose clipped norm is
+/// 99.0 against a NaN `--max-grad-norm`. `max_exceeds_cap` is
+/// `clipped > cap + 1e-6`, false against NaN, so without the guard the command
+/// prints its report and returns `Ok(())`: a cap violation reported as a clean
+/// run. With the guard it refuses, before it even opens the file.
+#[test]
+fn grad_norm_refuses_a_nan_cap_instead_of_reporting_a_clean_run() {
+    let dir = std::env::temp_dir().join(format!(
+        "apr-gh2391-gradnorm-{}-{:?}",
+        std::process::id(),
+        std::thread::current().id()
+    ));
+    std::fs::create_dir_all(&dir).expect("create temp dir");
+    let history = dir.join("history.json");
+    // grad_norm_clipped = 99.0 blows through any sane cap; with a finite cap
+    // this file makes the command exit non-zero.
+    std::fs::write(
+        &history,
+        r#"[{"step":0,"grad_norm":100.0,"grad_norm_clipped":99.0,"loss":2.0}]"#,
+    )
+    .expect("write history");
+
+    let err = super::grad_norm::run(&history, Some(f64::NAN), 16, 10.0, false)
+        .expect_err("a NaN --max-grad-norm must not produce a clean run");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("--max-grad-norm"),
+        "the refusal must name the flag the operator typed, got: {msg}"
+    );
+    assert!(
+        msg.contains("NaN"),
+        "the refusal must say why NaN is not a threshold, got: {msg}"
+    );
+
+    // Control: the same file against a finite cap still reaches the gate and
+    // still fails it, so the guard did not replace the gate.
+    let gate_err = super::grad_norm::run(&history, Some(1.0), 16, 10.0, false)
+        .expect_err("clipped 99.0 exceeds a cap of 1.0");
+    assert!(
+        gate_err.to_string().contains("exceeds --max-grad-norm cap"),
+        "expected the cap gate to fire, got: {gate_err}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// The NaN-blind range check `spike_multiplier <= 0.0` that shipped in
+/// `grad_norm` is the whole bug class in one line: it looks like validation and
+/// admits NaN. The guard must catch what it misses.
+#[test]
+fn grad_norm_refuses_a_nan_spike_multiplier_that_its_own_range_check_admits() {
+    let nan_multiplier = "nan".parse::<f64>().expect("NaN literal");
+    assert!(
+        !(nan_multiplier <= 0.0),
+        "premise: the shipped `spike_multiplier <= 0.0` check is false for NaN"
+    );
+    let err = guard("--spike-multiplier", f64::NAN, TOLERANCE)
+        .expect_err("NaN must be refused by the guard the range check missed");
+    assert!(err.to_string().contains("--spike-multiplier"), "{err}");
+}
+
+/// `guard_opt` distinguishes "no assertion" from "an assertion that cannot
+/// fail". `None` is a legitimate absence of a gate; `Some(NaN)` is a gate that
+/// was armed and then disarmed.
+#[test]
+fn guard_opt_admits_none_and_refuses_some_nan() {
+    guard_opt("--assert-tps", None, TOLERANCE).expect("no assertion is not a disarmed gate");
+    guard_opt("--assert-tps", Some(100.0), TOLERANCE).expect("100 tok/s is a real floor");
+
+    let err = guard_opt("--assert-tps", Some(f64::NAN), TOLERANCE)
+        .expect_err("Some(NaN) must be refused");
+    match err {
+        CliError::ValidationFailed(msg) => {
+            assert!(msg.contains("--assert-tps"), "got: {msg}");
+        }
+        other => panic!("expected ValidationFailed, got {other:?}"),
+    }
+
+    // A negative throughput floor is satisfied by every measurement, including
+    // a broken one, so it is a disarm even though it is finite.
+    guard_opt("--assert-tps", Some(-1.0), TOLERANCE)
+        .expect_err("a negative floor disarms the gate");
+}
+
+/// The `f32` half of the family. Half of apr-cli's gate thresholds are `f32`;
+/// widening for the domain check must not change the verdict.
+#[test]
+fn guard_f32_refuses_the_same_values_as_the_f64_guard() {
+    guard_f32("--threshold", f32::NAN, COSINE).expect_err("NaN cosine floor");
+    guard_f32("--threshold", f32::INFINITY, TOLERANCE).expect_err("infinite floor");
+    guard_f32("--tolerance", 2.0, COSINE).expect_err("cosine cannot exceed 1.0");
+    guard_f32("--tolerance", -0.5, FRACTION).expect_err("a fraction cannot be negative");
+
+    guard_f32("--threshold", 0.95, COSINE).expect("0.95 is a real cosine floor");
+    guard_f32("--threshold", 3.0, TOLERANCE).expect("3 sigma is a real threshold");
+    guard_f32("--tolerance", 0.1, FRACTION).expect("10% mismatch is a real tolerance");
+}
+
+/// Parsing an `f32` flag through the `f64` domain check must not silently
+/// widen what the flag accepts: `1e-300` is representable as `f64` and rounds
+/// to `0.0` as `f32`, which would hand a "tolerance" gate a zero it never asked
+/// for. Parsing as `f32` first keeps the value the user typed and the value the
+/// gate sees identical.
+#[test]
+fn f32_parsers_do_not_launder_a_value_through_f64() {
+    use super::threshold_arg::parse_tolerance_f32;
+
+    let parsed = parse_tolerance_f32("1e-300").expect("finite and non-negative");
+    assert_eq!(
+        parsed, 0.0f32,
+        "an f32 flag must report the f32 value the gate will actually use"
+    );
+
+    assert_eq!(parse_tolerance_f32("0.95"), Ok(0.95f32));
+    assert_eq!(parse_tolerance_f32("nan"), parse_tolerance_f32("NaN"));
+    parse_tolerance_f32("inf").expect_err("an infinite tolerance disarms the gate");
+    parse_tolerance_f32("banana").expect_err("not a float literal");
+}

--- a/crates/apr-cli/src/commands/tui.rs
+++ b/crates/apr-cli/src/commands/tui.rs
@@ -188,7 +188,15 @@ impl App {
             Ok(data) => {
                 let mut validator = AprValidator::new();
                 let report = validator.validate_bytes(&data);
-                self.validation_score = Some(report.total_score);
+                // #1866: percentage of the checks that RAN, not raw awarded
+                // points banded against a 100 the checklist cannot reach.
+                // The panel used to paint a healthy model "QA Score: 3/100" in
+                // red. `None` (nothing ran) hides the panel rather than
+                // painting a zero.
+                self.validation_score = report
+                    .implemented_score()
+                    .pct()
+                    .map(|pct| pct.round() as u8);
                 match AprReader::from_bytes(data) {
                     Ok(reader) => {
                         self.load_tensors(&reader);

--- a/crates/apr-cli/src/commands/unified_search_lint.rs
+++ b/crates/apr-cli/src/commands/unified_search_lint.rs
@@ -81,7 +81,11 @@ pub fn run(args: UnifiedSearchLintArgs) -> Result<(), LintError> {
             "contract": "CRUX-A-23",
             "gates": reports,
         });
-        println!("{}", serde_json::to_string_pretty(&payload).unwrap());
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&payload)
+                .expect("the --json report is a locally-built serde_json::Value")
+        );
     } else {
         for r in &reports {
             println!(

--- a/crates/apr-cli/src/commands/validate.rs
+++ b/crates/apr-cli/src/commands/validate.rs
@@ -135,14 +135,7 @@ fn run_apr_validation(
         print_quality_assessment(report);
     }
 
-    if let Some(min) = min_score {
-        if report.total_score < min {
-            return Err(CliError::ValidationFailed(format!(
-                "Score {}/100 below minimum {min}",
-                report.total_score
-            )));
-        }
-    }
+    check_min_score(report, min_score)?;
 
     // GH-647: Exit non-zero when validation shows contract violations
     // GH-642: --skip-contract bypasses the contract score threshold gate
@@ -152,12 +145,11 @@ fn run_apr_validation(
     //        Grade F on every valid APR file until every stub was filled in.
     //        See apr-validate-quality-threshold-v1.yaml.
     if !skip_contract {
-        if let Some(pct) = report.implemented_score_pct() {
+        let score = report.implemented_score();
+        if let Some(pct) = score.pct() {
             if pct < 50.0 {
-                let max = report.implemented_max();
                 return Err(CliError::ValidationFailed(format!(
-                    "Score {}/{max} implemented checks passed ({:.0}%) — below 50% threshold",
-                    report.total_score, pct
+                    "{score} ({pct:.0}%) — below 50% threshold"
                 )));
             }
         }
@@ -169,6 +161,40 @@ fn run_apr_validation(
     // PMAT-926: fail-closed content gate (F-DATA-QUALITY-001..007) +
     // --strict wiring, applied identically to the Rosetta GGUF/ST path.
     gate_apr_content(&content, strict, skip_contract)
+}
+
+/// `--min-score N` against the checks that RAN, never against the aspirational
+/// 100 (#1866).
+///
+/// This used to read `report.total_score < min`, where `total_score` is a raw
+/// count of awarded points and the `.apr` checklist can award at most 4 of
+/// them (22 of 26 checks are `Skip("Not implemented")` stubs). `--min-score 50`
+/// therefore failed a model that the very same run printed `✓ VALID` for and
+/// exited 0 on without the flag. Measured on
+/// `qwen2.5-coder-0.5b-instruct.apr`: `error: Validation failed: Score 3/100
+/// below minimum 50`, exit 5.
+///
+/// When nothing ran there is no score to threshold, so the flag is REFUSED
+/// rather than silently satisfied — same rule as `produces_qa_score` above:
+/// a threshold against a number that is never computed is a gate that cannot
+/// fail.
+fn check_min_score(report: &ValidationReport, min_score: Option<u8>) -> Result<(), CliError> {
+    let Some(min) = min_score else {
+        return Ok(());
+    };
+    let score = report.implemented_score();
+    let Some(pct) = score.pct() else {
+        return Err(CliError::ValidationFailed(format!(
+            "--min-score {min} cannot be evaluated: none of the {} declared QA checks ran, so there is no score to threshold.",
+            score.declared
+        )));
+    };
+    if pct < f64::from(min) {
+        return Err(CliError::ValidationFailed(format!(
+            "Score {pct:.0}/100 below minimum {min} ({score})"
+        )));
+    }
+    Ok(())
 }
 
 /// PMAT-926: gate the `.apr` exit code on the Rosetta content gates.
@@ -386,23 +412,26 @@ fn print_contract_violations(failures: &[(&str, &str)]) {
     }
 }
 
-/// Print APR validation report as JSON (GH-240/GH-251: machine-parseable output).
+/// The exact `apr validate --json` document for a `.apr` file, and whether it
+/// passed.
+///
+/// Kept separate from printing so a unit test can assert on the document a
+/// machine consumer actually parses, rather than on a side effect of stdout.
+/// #1866 shipped for 81 days because nothing ever looked at all three fields
+/// at once: the same document said `"grade": "F"`, `"failed": 0` and
+/// `"passed": true`.
 // serde_json::json!() macro uses infallible unwrap internally
 #[allow(clippy::disallowed_methods)]
-fn print_apr_validation_json(
+fn apr_validation_json(
     path: &Path,
     report: &ValidationReport,
     content: &Result<RosettaValidationReport, AprenderError>,
-    strict: bool,
     min_score: Option<u8>,
-    skip_contract: bool,
-) -> Result<(), CliError> {
-    // PMAT-926: --strict is now honored on the APR JSON path. The structural
-    // 100-point report still drives `passed`, but the fail-closed content
-    // gate (F-DATA-QUALITY) is applied AFTER the JSON is printed so machine
-    // consumers always get a report, and the exit code fails closed.
-    let passed =
-        report.failed_checks().is_empty() && min_score.is_none_or(|min| report.total_score >= min);
+) -> (serde_json::Value, bool) {
+    // #1866: `passed` is now the same predicate as the human VALID badge and
+    // the grade band — `report.is_valid()` — and `--min-score` thresholds the
+    // measured percentage, not the raw awarded points.
+    let structurally_passed = report.is_valid() && check_min_score(report, min_score).is_ok();
     // GH-251: Only include executed checks (PASS/FAIL) — SKIP/WARN are not actionable
     // and cause parity checker false positives
     let checks_json: Vec<serde_json::Value> = report
@@ -438,30 +467,65 @@ fn print_apr_validation_json(
         ),
         Err(_) => (false, 0, 0, 0, 0),
     };
+    let passed = structurally_passed && content_passed;
+    let score = report.implemented_score();
     let output = serde_json::json!({
         "model": path.display().to_string(),
         "format": "apr",
-        "total_score": report.total_score,
+        // #1866: `total_score` now means what its name says — a score out of
+        // 100 — computed against the checks that RAN. It used to be the raw
+        // count of awarded points printed as "3/100" for a healthy model.
+        // `points_earned` / `checks_ran` keep the raw numbers available.
+        "total_score": score.pct().map(|p| p.round() as u8),
         "grade": report.grade(),
+        "verdict": if report.is_valid() { "VALID" } else { "INVALID" },
+        "points_earned": score.passed,
+        "checks_ran": score.ran,
+        "checks_not_implemented": score.not_implemented(),
         "checks": checks_json,
         "total_checks": report.checks.len(),
         "failed": report.failed_checks().len(),
-        "passed": passed && content_passed,
+        "passed": passed,
         "content_passed": content_passed,
         "content_total_nan": content_nan,
         "content_total_inf": content_inf,
         "content_all_zero_tensors": content_zero,
         "content_failed_tensors": content_failed,
     });
+    (output, passed)
+}
+
+/// Print APR validation report as JSON (GH-240/GH-251: machine-parseable output).
+// serde_json::json!() macro uses infallible unwrap internally
+#[allow(clippy::disallowed_methods)]
+fn print_apr_validation_json(
+    path: &Path,
+    report: &ValidationReport,
+    content: &Result<RosettaValidationReport, AprenderError>,
+    strict: bool,
+    min_score: Option<u8>,
+    skip_contract: bool,
+) -> Result<(), CliError> {
+    // PMAT-926: --strict is now honored on the APR JSON path. The structural
+    // report still drives `passed`, but the fail-closed content gate
+    // (F-DATA-QUALITY) is applied AFTER the JSON is printed so machine
+    // consumers always get a report, and the exit code fails closed.
+    let (output, passed) = apr_validation_json(path, report, content, min_score);
     println!(
         "{}",
         serde_json::to_string_pretty(&output).unwrap_or_default()
     );
     if !passed {
-        return Err(CliError::ValidationFailed(format!(
-            "Score {}/100",
-            report.total_score
-        )));
+        // Report the reason the caller can act on: the threshold it missed, a
+        // failed structural check, or — falling through — the content gate.
+        check_min_score(report, min_score)?;
+        let failed = report.failed_checks().len();
+        if failed > 0 {
+            return Err(CliError::ValidationFailed(format!(
+                "{failed} validation checks failed ({})",
+                report.implemented_score()
+            )));
+        }
     }
     // PMAT-926: fail-closed content gate + --strict, after the JSON is printed.
     gate_apr_content(content, strict, skip_contract)
@@ -615,10 +679,21 @@ fn print_summary(report: &ValidationReport) -> Result<(), CliError> {
     }
 }
 
-fn print_quality_assessment(report: &ValidationReport) {
-    output::header("100-Point Quality Assessment");
-
-    // Category score rows as table
+/// The `--quality` category table and TOTAL line, as a string.
+///
+/// Returned rather than printed so the falsifier can read the exact text a
+/// user sees. #1866: this block printed
+///
+/// ```text
+/// │ B. Tensor Physics & Statistics   │  0/25 │ ░░░░░░░░░░░░░░░░░░░░ │
+///   TOTAL: 3/100  Grade: F
+/// ```
+///
+/// on a model `apr qa` passes and `apr run` answers correctly from. Both
+/// numbers were fiction: category B declares no checks at all on the `.apr`
+/// path (so `0/25` is a zero for something never measured, not a zero score),
+/// and `3/100` banded 3 awarded points against a ceiling of 4.
+fn quality_assessment_body(report: &ValidationReport) -> String {
     let categories = [
         (Category::Structure, "A. Format & Structural Integrity"),
         (Category::Physics, "B. Tensor Physics & Statistics"),
@@ -628,23 +703,37 @@ fn print_quality_assessment(report: &ValidationReport) {
 
     let mut rows: Vec<Vec<String>> = Vec::new();
     for (cat, name) in &categories {
-        let score = report.category_scores.get(cat).copied().unwrap_or(0);
-        let max = 25;
-        let bar = output::progress_bar(score as usize, max as usize, 20);
-        rows.push(vec![(*name).to_string(), format!("{score}/{max}"), bar]);
+        let score = report.category_score(*cat);
+        let (cell, bar) = match score.pct() {
+            Some(_) => (
+                format!("{}/{}", score.passed, score.ran),
+                output::progress_bar(score.passed as usize, score.ran as usize, 20),
+            ),
+            // Nothing in this category ran. Say so; do not draw a zero.
+            None => ("not implemented".to_string(), String::new()),
+        };
+        rows.push(vec![(*name).to_string(), cell, bar]);
     }
-    println!(
-        "{}",
-        output::table(&["Category", "Score", "Progress"], &rows)
-    );
 
-    // Total score with grade
-    let grade = report.grade();
-    println!(
-        "\n  TOTAL: {}/100  Grade: {}",
-        format!("{}", report.total_score).white().bold(),
-        output::grade_color(grade),
-    );
+    let mut out = output::table(&["Category", "Checks passed", "Progress"], &rows);
+    let score = report.implemented_score();
+    let grade = output::grade_color(report.grade());
+    match score.pct() {
+        Some(pct) => out.push_str(&format!(
+            "\n  TOTAL: {}\n  SCORE: {pct:.0}% of the checks that ran   Grade: {grade}\n",
+            format!("{score}").white().bold(),
+        )),
+        None => out.push_str(&format!(
+            "\n  TOTAL: none of the {} declared checks ran — nothing was measured\n  SCORE: unavailable   Grade: {grade}\n",
+            score.declared,
+        )),
+    }
+    out
+}
+
+fn print_quality_assessment(report: &ValidationReport) {
+    output::header("Quality Assessment");
+    println!("{}", quality_assessment_body(report));
 
     // Print failed checks summary
     let failed = report.failed_checks();

--- a/crates/apr-cli/src/commands/validate_tests.rs
+++ b/crates/apr-cli/src/commands/validate_tests.rs
@@ -635,3 +635,217 @@ fn valid_verdict_omits_the_stub_clause_when_nothing_was_skipped() {
     assert!(line.contains("1/1"), "{line}");
     assert!(!line.contains("not implemented"), "{line}");
 }
+
+// ============================================================================
+// #1866 FALSIFIER: `apr validate --quality` graded a healthy model F at exit 0
+// while the same run said passed:true, failed:0 and printed "✓ VALID".
+//
+// Reproduced on /home/noah/models/qwen2.5-coder-0.5b-instruct.apr at
+// 6adeb6351 before the fix:
+//
+//     TOTAL: 3/100  Grade: F                                    (exit 0)
+//     { "total_score": 3, "grade": "F", "failed": 0, "passed": true }
+//     --min-score 50 -> error: Validation failed: Score 3/100 below minimum 50
+//
+// Contract: apr-validate-quality-threshold-v1
+// ============================================================================
+
+/// The report `apr validate` actually builds for that model: checks 1/2/3
+/// PASS, check 11 WARNs on an unknown flag bit, 22 checks are
+/// `Skip("Not implemented")` stubs.
+fn healthy_apr_report() -> ValidationReport {
+    use aprender::format::validation::ValidationCheck;
+
+    fn push(report: &mut ValidationReport, id: u8, status: CheckStatus) {
+        let points = u8::from(status.is_pass());
+        report.add_check(ValidationCheck {
+            id,
+            name: "check",
+            category: Category::Structure,
+            status,
+            points,
+        });
+    }
+
+    let mut report = ValidationReport::new();
+    push(&mut report, 1, CheckStatus::Pass);
+    push(&mut report, 2, CheckStatus::Pass);
+    push(&mut report, 3, CheckStatus::Pass);
+    push(
+        &mut report,
+        11,
+        CheckStatus::Warn("Unknown flag bits: 0x00000100".to_string()),
+    );
+    push(
+        &mut report,
+        4,
+        CheckStatus::Skip("Footer not implemented".to_string()),
+    );
+    for id in 5..=25 {
+        push(
+            &mut report,
+            id,
+            CheckStatus::Skip("Not implemented".to_string()),
+        );
+    }
+    report
+}
+
+/// A clean content-gate result, as `RosettaStone::validate` returns for that
+/// model.
+fn clean_content() -> Result<RosettaValidationReport, AprenderError> {
+    Ok(RosettaValidationReport {
+        format: FormatType::Apr,
+        file_path: "model.apr".to_string(),
+        is_valid: true,
+        tensor_count: 339,
+        failed_tensor_count: 0,
+        total_nan_count: 0,
+        total_inf_count: 0,
+        all_zero_tensors: Vec::new(),
+        tensors: Vec::new(),
+        duration_ms: 1,
+    })
+}
+
+/// FALSIFY-VALIDATE-QUALITY-006: the `--json` document cannot say
+/// `grade: F`, `verdict: VALID` and `passed: true` at the same time.
+#[test]
+fn json_grade_passed_and_verdict_agree_on_a_healthy_model() {
+    let report = healthy_apr_report();
+    let (doc, passed) = apr_validation_json(
+        Path::new("/models/qwen2.5-coder-0.5b-instruct.apr"),
+        &report,
+        &clean_content(),
+        None,
+    );
+
+    assert!(passed, "no check failed and the content gate is clean");
+    assert_eq!(doc["passed"], serde_json::json!(true));
+    assert_eq!(doc["failed"], serde_json::json!(0));
+    assert_eq!(doc["verdict"], serde_json::json!("VALID"));
+    assert_ne!(
+        doc["grade"],
+        serde_json::json!("F"),
+        "a document reporting passed:true and failed:0 must not grade F: {doc}"
+    );
+    assert_eq!(doc["grade"], serde_json::json!("C+"));
+    // The score is measured against the 4 checks that ran, not the 26 declared.
+    assert_eq!(doc["total_score"], serde_json::json!(75));
+    assert_eq!(doc["checks_ran"], serde_json::json!(4));
+    assert_eq!(doc["checks_not_implemented"], serde_json::json!(22));
+}
+
+/// The same document must flip every field together when a check really does
+/// fail — otherwise the agreement above is just a constant.
+#[test]
+fn json_grade_passed_and_verdict_agree_on_a_broken_model() {
+    use aprender::format::validation::ValidationCheck;
+
+    let mut report = healthy_apr_report();
+    report.add_check(ValidationCheck {
+        id: 26,
+        name: "Magic bytes valid",
+        category: Category::Structure,
+        status: CheckStatus::Fail("Invalid magic".to_string()),
+        points: 0,
+    });
+    let (doc, passed) = apr_validation_json(
+        Path::new("/models/broken.apr"),
+        &report,
+        &clean_content(),
+        None,
+    );
+
+    assert!(!passed);
+    assert_eq!(doc["passed"], serde_json::json!(false));
+    assert_eq!(doc["verdict"], serde_json::json!("INVALID"));
+    assert_eq!(doc["grade"], serde_json::json!("F"));
+    assert_eq!(doc["failed"], serde_json::json!(1));
+}
+
+/// FALSIFY-VALIDATE-QUALITY-007: the `--quality` table must not print a
+/// score against a denominator nothing was measured against, and must not
+/// draw `0/25` for categories in which no check is even declared.
+/// Colour is a terminal concern; the assertions below are about text.
+fn strip_ansi(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars();
+    while let Some(c) = chars.next() {
+        if c == '\u{1b}' {
+            for c in chars.by_ref() {
+                if c.is_ascii_alphabetic() {
+                    break;
+                }
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
+#[test]
+fn quality_table_scores_only_what_ran() {
+    let body = strip_ansi(&quality_assessment_body(&healthy_apr_report()));
+
+    assert!(
+        !body.contains("/100"),
+        "the TOTAL line still bands against a 100 nothing was measured against: {body}"
+    );
+    assert!(
+        !body.contains("0/25"),
+        "categories that declare no checks must not be drawn as scoring zero: {body}"
+    );
+    assert!(
+        body.contains("not implemented"),
+        "the empty categories must be named as unimplemented: {body}"
+    );
+    assert!(body.contains("Grade: C+"), "{body}");
+    assert!(body.contains("3/4 checks that ran"), "{body}");
+}
+
+/// FALSIFY-VALIDATE-QUALITY-008: `--min-score` thresholds the checks that ran.
+///
+/// `--min-score 50` used to reject this model with
+/// `Score 3/100 below minimum 50` — while the identical run without the flag
+/// printed `✓ VALID` and exited 0.
+#[test]
+fn min_score_thresholds_the_checks_that_ran() {
+    let report = healthy_apr_report();
+
+    check_min_score(&report, Some(50)).expect("3 of 4 checks that ran passed — that is 75%");
+    check_min_score(&report, Some(75)).expect("75% must clear a 75 threshold");
+
+    let err = check_min_score(&report, Some(80))
+        .expect_err("75% must NOT clear an 80 threshold — the gate must still bite");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("75/100"),
+        "the refusal must quote the measured score: {msg}"
+    );
+}
+
+/// A threshold against a score nothing produced is a gate that cannot fail;
+/// refuse it rather than satisfy it silently.
+#[test]
+fn min_score_is_refused_when_no_check_ran() {
+    use aprender::format::validation::ValidationCheck;
+
+    let mut report = ValidationReport::new();
+    for id in 1..=25u8 {
+        report.add_check(ValidationCheck {
+            id,
+            name: "stub",
+            category: Category::Structure,
+            status: CheckStatus::Skip("Not implemented".to_string()),
+            points: 0,
+        });
+    }
+    let err = check_min_score(&report, Some(0))
+        .expect_err("no check ran, so not even --min-score 0 was demonstrated");
+    assert!(
+        format!("{err}").contains("none of the 25 declared QA checks ran"),
+        "{err}"
+    );
+}

--- a/crates/apr-cli/src/commands_enum.rs
+++ b/crates/apr-cli/src/commands_enum.rs
@@ -272,7 +272,8 @@ pub enum Commands {
         quant_roundtrip: bool,
         /// CRUX-B-20: cosine threshold for the quant-roundtrip exit-code gate.
         /// Any tensor with cosine < threshold makes the command exit non-zero.
-        #[arg(long, default_value = "0.95")]
+        #[arg(long, default_value = "0.95",
+              value_parser = crate::commands::threshold_arg::parse_cosine_f32)]
         threshold: f32,
         /// CRUX-B-20: suppress the threshold exit-code gate (still emits the report).
         #[arg(long)]

--- a/crates/apr-cli/src/dispatch.rs
+++ b/crates/apr-cli/src/dispatch.rs
@@ -458,6 +458,11 @@ fn dispatch_quant_roundtrip(
 ) -> Result<(), CliError> {
     use commands::diff_quant_roundtrip::{build_report, render_tsv};
 
+    // GH-2391: `any_below_threshold` is an OR of `cosine < threshold`. Against a
+    // NaN threshold every term is false, so the CRUX-B-20 exit-code gate reports
+    // a clean roundtrip for a quantization it never checked.
+    commands::threshold_arg::guard_f32("--threshold", threshold, commands::threshold_arg::COSINE)?;
+
     let report = build_report(reference, quantized, threshold)?;
 
     if json {

--- a/crates/apr-cli/src/extended_commands.rs
+++ b/crates/apr-cli/src/extended_commands.rs
@@ -100,7 +100,8 @@ pub enum ExtendedCommands {
         #[arg(long, default_value = "512")]
         max_tokens: usize,
         /// Perplexity threshold for pass/fail
-        #[arg(long, default_value = "20.0")]
+        #[arg(long, default_value = "20.0",
+              value_parser = commands::threshold_arg::parse_tolerance_f32)]
         threshold: f32,
         /// Task type: omit for perplexity, "classify" for classification eval
         #[arg(long)]
@@ -146,7 +147,8 @@ pub enum ExtendedCommands {
         #[arg(long)]
         detect_naive: bool,
         /// Achieved-GFLOPS floor below which the run is reported as naive
-        #[arg(long, default_value = "10.0")]
+        #[arg(long, default_value = "10.0",
+              value_parser = commands::threshold_arg::parse_tolerance)]
         threshold: f64,
         /// [NOT IMPLEMENTED — accepted and ignored] Compare against HuggingFace baseline
         #[arg(long)]
@@ -172,13 +174,13 @@ pub enum ExtendedCommands {
         #[arg(long)]
         ci: bool,
         /// Minimum throughput in tok/s (CI assertion, exits 1 if below)
-        #[arg(long)]
+        #[arg(long, value_parser = commands::threshold_arg::parse_tolerance)]
         assert_throughput: Option<f64>,
         /// Maximum p99 latency in ms (CI assertion, exits 1 if above)
-        #[arg(long)]
+        #[arg(long, value_parser = commands::threshold_arg::parse_tolerance)]
         assert_p99: Option<f64>,
         /// Maximum p50 latency in ms (CI assertion, exits 1 if above)
-        #[arg(long)]
+        #[arg(long, value_parser = commands::threshold_arg::parse_tolerance)]
         assert_p50: Option<f64>,
         /// Warmup passes before measurement (default: 3)
         #[arg(long, default_value = "3")]
@@ -206,13 +208,16 @@ pub enum ExtendedCommands {
         #[arg(value_name = "FILE")]
         file: PathBuf,
         /// Minimum throughput threshold in tok/s
-        #[arg(long, value_name = "TPS")]
+        #[arg(long, value_name = "TPS",
+              value_parser = commands::threshold_arg::parse_tolerance)]
         assert_tps: Option<f64>,
         /// Minimum speedup vs Ollama
-        #[arg(long, value_name = "SPEEDUP")]
+        #[arg(long, value_name = "SPEEDUP",
+              value_parser = commands::threshold_arg::parse_tolerance)]
         assert_speedup: Option<f64>,
         /// Minimum GPU vs CPU speedup (F-PERF-042)
-        #[arg(long, value_name = "SPEEDUP")]
+        #[arg(long, value_name = "SPEEDUP",
+              value_parser = commands::threshold_arg::parse_tolerance)]
         assert_gpu_speedup: Option<f64>,
         /// Skip golden output test
         #[arg(long)]
@@ -260,7 +265,8 @@ pub enum ExtendedCommands {
         #[arg(long, value_name = "FILE")]
         previous_report: Option<PathBuf>,
         /// Maximum allowed performance regression ratio (default: 0.10 = 10%)
-        #[arg(long, value_name = "RATIO")]
+        #[arg(long, value_name = "RATIO",
+              value_parser = commands::threshold_arg::parse_fraction)]
         regression_threshold: Option<f64>,
         /// Skip GPU state isolation test
         #[arg(long)]
@@ -460,7 +466,8 @@ pub enum ExtendedCommands {
         #[arg(long)]
         ci: bool,
         /// Minimum throughput threshold in tok/s (for --ci)
-        #[arg(long, value_name = "TOK_S")]
+        #[arg(long, value_name = "TOK_S",
+              value_parser = commands::threshold_arg::parse_tolerance)]
         throughput: Option<f64>,
         /// Minimum brick score threshold 0-100 (for --ci)
         #[arg(long, value_name = "SCORE")]
@@ -511,7 +518,8 @@ pub enum ExtendedCommands {
         #[arg(long)]
         tensor: Option<String>,
         /// Comparison threshold (default: 1e-5)
-        #[arg(long, default_value = "1e-5")]
+        #[arg(long, default_value = "1e-5",
+              value_parser = commands::threshold_arg::parse_tolerance)]
         threshold: f64,
         /// Output as JSON
         #[arg(long)]
@@ -689,7 +697,7 @@ pub enum ExtendedCommands {
         seed: u64,
         /// Target val_loss. Omit to inherit mode default
         /// (finetune: 2.2, from-scratch: 3.0).
-        #[arg(long)]
+        #[arg(long, value_parser = commands::threshold_arg::parse_tolerance_f32)]
         target_val_loss: Option<f32>,
         /// Vocabulary size (required for `--mode from-scratch` INV-TRAIN-005
         /// regime-dependent cap: 2·ln(vocab_size)). MODEL-2 uses 50257.
@@ -1060,13 +1068,15 @@ pub enum ExtendedCommands {
         #[arg(long, value_name = "FILE")]
         history_file: PathBuf,
         /// Maximum allowed clipped grad-norm (for cap-violation check)
-        #[arg(long, value_name = "M")]
+        #[arg(long, value_name = "M",
+              value_parser = commands::threshold_arg::parse_tolerance)]
         max_grad_norm: Option<f64>,
         /// Rolling-median window size for spike detection (in steps)
         #[arg(long, default_value = "16")]
         spike_window: usize,
         /// Multiplier threshold for spike detection
-        #[arg(long, default_value = "10.0")]
+        #[arg(long, default_value = "10.0",
+              value_parser = commands::threshold_arg::parse_tolerance)]
         spike_multiplier: f64,
     },
     /// Lint a captured registry byte-quota observation (CRUX-A-22)
@@ -1461,7 +1471,8 @@ pub enum ProbarSubcommand {
         #[arg(long)]
         assert: bool,
         /// Cosine similarity threshold for golden comparison (default: 0.98)
-        #[arg(long, default_value = "0.98")]
+        #[arg(long, default_value = "0.98",
+              value_parser = commands::threshold_arg::parse_cosine_f32)]
         tolerance: f32,
     },
 }

--- a/crates/apr-cli/src/lib.rs
+++ b/crates/apr-cli/src/lib.rs
@@ -3,6 +3,21 @@
 //! This library is the foundation for the apr CLI binary.
 //! Exports CLI structures for testing and reuse.
 
+// PMAT-540 declared `#![cfg_attr(coverage_nightly, coverage(off))]` in twenty
+// files of this crate but never declared the feature that makes `coverage(off)`
+// legal, and nothing in the workspace did. On the pinned stable toolchain
+// (rust-toolchain.toml = 1.93.0) the `cfg_attr` is inert, so nobody noticed; the
+// moment a coverage run sets `--cfg coverage_nightly` — which is exactly what
+// `pmat quality-gates` does via `cargo +nightly llvm-cov` — the crate stops
+// compiling:
+//
+//     crates/apr-cli/src/generated_contracts.rs:9:31: error[E0658]:
+//     the `#[coverage]` attribute is an experimental feature
+//
+// and the coverage gate reports "failed to run" rather than a number. A gate
+// that cannot run is not a gate that passed. This declaration is likewise
+// gated, so stable builds are byte-identical.
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 // APR-MONO: Clippy pedantic allows for monorepo transition.
 // unwrap() eliminated (524 → expect()). Style lints from 20 merged crates
 // are suppressed at crate level. Will be incrementally addressed.

--- a/crates/apr-cli/src/output.rs
+++ b/crates/apr-cli/src/output.rs
@@ -254,6 +254,9 @@ pub(crate) fn grade_color(grade: &str) -> ColoredString {
         "B+" | "B" => grade.green(),
         "C+" | "C" => grade.yellow(),
         "D" => grade.yellow().bold(),
+        // #1866: "N/A" means nothing was measured. That is not a failing
+        // grade and must not be painted like one.
+        "N/A" => grade.dimmed(),
         _ => grade.red().bold(),
     }
 }

--- a/crates/apr-cli/src/validate.rs
+++ b/crates/apr-cli/src/validate.rs
@@ -431,6 +431,20 @@ fn dispatch_profile(
     compare: Option<&Path>,
     json: bool,
 ) -> Result<(), CliError> {
+    // GH-2391: the CI assertions are `throughput >= min` / `p99 <= max`. A NaN
+    // bound makes both false, which for the latency bounds looks like a clean
+    // FAIL and for the throughput bound like a clean PASS — neither verdict was
+    // computed from the measurement. A negative floor disarms outright.
+    use crate::commands::threshold_arg;
+    threshold_arg::guard("--threshold", threshold, threshold_arg::TOLERANCE)?;
+    threshold_arg::guard_opt(
+        "--assert-throughput",
+        assert_throughput,
+        threshold_arg::TOLERANCE,
+    )?;
+    threshold_arg::guard_opt("--assert-p99", assert_p99, threshold_arg::TOLERANCE)?;
+    threshold_arg::guard_opt("--assert-p50", assert_p50, threshold_arg::TOLERANCE)?;
+
     // GH-2395: `--json` is a global flag that `apr profile` parsed and ignored, and
     // an unparseable `--format` silently degraded to the human table. See
     // `commands/profile_options.rs`.

--- a/crates/apr-cli/tests/falsification_crux_b_08.rs
+++ b/crates/apr-cli/tests/falsification_crux_b_08.rs
@@ -8,7 +8,7 @@
 //! ```jsonc
 //! {
 //!   "quality":     { "p_fp16", "p_awq", "threshold" },         // FALSIFY-CRUX-B-08-001
-//!   "flags":       { "argv": [..], "expected_outcome": "ok" }, // FALSIFY-CRUX-B-08-002
+//!   "flags":       { "argv": [..], "expected_outcome": "accepted" }, // FALSIFY-CRUX-B-08-002
 //!   "compression": { "fp16_bytes", "awq_bytes", "max_ratio" }  // FALSIFY-CRUX-B-08-003
 //! }
 //! ```
@@ -175,12 +175,40 @@ fn falsify_crux_b_08_003_compression_rejects_zero_source() {
 }
 
 // ---- flags gate (FALSIFY-CRUX-B-08-002) -----------------------------------
+//
+// The verdict comes from the SHIPPED clap parser (`commands::quantize_flag_parity`),
+// not from a hand-rolled matcher living beside the assertion. `expected_outcome`
+// is `accepted` (alias `ok`) or `rejected`; the pre-fix per-flag labels are
+// refused as an unusable observation. See aprender#2377 finding 2 and
+// `contracts/apr-lint-flag-parity-v1.yaml`.
 
 #[test]
-fn falsify_crux_b_08_002_flags_ok_canonical() {
-    // --method awq --bits 4 --group-size 128 → Ok
+fn falsify_crux_b_08_002_flags_ok_on_a_real_quantize_argv() {
     let tmp = write_tmp_json(
         "awq-flags-ok",
+        r#"{ "flags": { "argv": ["model.safetensors", "--scheme", "int4", "-o", "out.apr"],
+                        "expected_outcome": "accepted" } }"#,
+    );
+    let out = apr_binary()
+        .args(["awq-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr awq-lint");
+    assert!(
+        out.status.success(),
+        "a real `apr quantize <FILE> --scheme int4 -o out.apr` must pass; stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// The load-bearing falsifier. Before aprender#2377 finding 2 this exact
+/// observation exited 0: the gate asked `parse_awq_flags`/`validate_awq_flags`,
+/// which reported `Ok { bits: 4, group_size: 128 }`. `apr quantize` has no
+/// `--method`, no `--bits` and no `--group-size`.
+#[test]
+fn falsify_crux_b_08_002_flags_reject_method_bits_group_size() {
+    let tmp = write_tmp_json(
+        "awq-flags-legacy",
         r#"{ "flags": { "argv": ["--method", "awq", "--bits", "4", "--group-size", "128"],
                         "expected_outcome": "ok" } }"#,
     );
@@ -189,113 +217,44 @@ fn falsify_crux_b_08_002_flags_ok_canonical() {
         .arg(tmp.path())
         .output()
         .expect("run apr awq-lint");
-    assert!(
-        out.status.success(),
-        "canonical flags must pass; stderr={}",
+    assert_eq!(
+        out.status.code(),
+        Some(5),
+        "a gate rejection is exit 5; stderr={}",
         String::from_utf8_lossy(&out.stderr)
     );
-}
-
-#[test]
-fn falsify_crux_b_08_002_flags_ok_equals_form() {
-    // --method=awq --bits=4 → Ok (group_size defaults to 128)
-    let tmp = write_tmp_json(
-        "awq-flags-eq",
-        r#"{ "flags": { "argv": ["--method=awq", "--bits=4"],
-                        "expected_outcome": "ok" } }"#,
-    );
-    let out = apr_binary()
-        .args(["awq-lint", "--observation-file"])
-        .arg(tmp.path())
-        .output()
-        .expect("run apr awq-lint");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-B-08-002"), "got: {stderr}");
+    assert!(stderr.contains("REJECTED"), "got: {stderr}");
     assert!(
-        out.status.success(),
-        "equals-form flags must pass; stderr={}",
-        String::from_utf8_lossy(&out.stderr)
+        stderr.contains("--scheme"),
+        "the failure must name the flags `apr quantize` does accept; got: {stderr}"
     );
 }
 
 #[test]
-fn falsify_crux_b_08_002_flags_rejects_wrong_method() {
-    // Observer expected ok, but method=gptq → UnknownMethod → mismatch fails
+fn falsify_crux_b_08_002_flags_reject_quantize_without_the_required_file() {
     let tmp = write_tmp_json(
-        "awq-flags-wrongmethod",
-        r#"{ "flags": { "argv": ["--method", "gptq", "--bits", "4"],
-                        "expected_outcome": "ok" } }"#,
+        "awq-flags-nofile",
+        r#"{ "flags": { "argv": ["--scheme", "int4"],
+                        "expected_outcome": "accepted" } }"#,
     );
     let out = apr_binary()
         .args(["awq-lint", "--observation-file"])
         .arg(tmp.path())
         .output()
         .expect("run apr awq-lint");
-    assert!(!out.status.success(), "wrong method must fail");
-    let stderr = String::from_utf8_lossy(&out.stderr);
-    assert!(stderr.contains("FALSIFY-CRUX-B-08-002"));
+    assert_eq!(out.status.code(), Some(5));
 }
 
 #[test]
-fn falsify_crux_b_08_002_flags_rejects_invalid_bits() {
-    // --bits 5 is not in AWQ_ALLOWED_BITS → InvalidBits
-    let tmp = write_tmp_json(
-        "awq-flags-bits",
-        r#"{ "flags": { "argv": ["--method", "awq", "--bits", "5"],
-                        "expected_outcome": "ok" } }"#,
-    );
-    let out = apr_binary()
-        .args(["awq-lint", "--observation-file"])
-        .arg(tmp.path())
-        .output()
-        .expect("run apr awq-lint");
-    assert!(!out.status.success(), "invalid bits must fail");
-    let stderr = String::from_utf8_lossy(&out.stderr);
-    assert!(stderr.contains("FALSIFY-CRUX-B-08-002"));
-}
-
-#[test]
-fn falsify_crux_b_08_002_flags_rejects_missing_bits() {
-    // Missing --bits → InvalidBits { got: 0 }
-    let tmp = write_tmp_json(
-        "awq-flags-nobits",
-        r#"{ "flags": { "argv": ["--method", "awq"],
-                        "expected_outcome": "ok" } }"#,
-    );
-    let out = apr_binary()
-        .args(["awq-lint", "--observation-file"])
-        .arg(tmp.path())
-        .output()
-        .expect("run apr awq-lint");
-    assert!(!out.status.success(), "missing bits must fail");
-    let stderr = String::from_utf8_lossy(&out.stderr);
-    assert!(stderr.contains("FALSIFY-CRUX-B-08-002"));
-}
-
-#[test]
-fn falsify_crux_b_08_002_flags_rejects_invalid_group_size() {
-    // --group-size 96 is not in AWQ_ALLOWED_GROUP_SIZES → InvalidGroupSize
-    let tmp = write_tmp_json(
-        "awq-flags-gs",
-        r#"{ "flags": { "argv": ["--method", "awq", "--bits", "4", "--group-size", "96"],
-                        "expected_outcome": "ok" } }"#,
-    );
-    let out = apr_binary()
-        .args(["awq-lint", "--observation-file"])
-        .arg(tmp.path())
-        .output()
-        .expect("run apr awq-lint");
-    assert!(!out.status.success(), "invalid group size must fail");
-    let stderr = String::from_utf8_lossy(&out.stderr);
-    assert!(stderr.contains("FALSIFY-CRUX-B-08-002"));
-}
-
-#[test]
-fn falsify_crux_b_08_002_flags_observer_can_assert_expected_failure() {
-    // Observer deliberately captured a wrong-method case and expects that
-    // classification → PASS (the captured outcome matches expectation).
+fn falsify_crux_b_08_002_flags_observer_can_assert_expected_rejection() {
+    // Observer captured a deliberate negative case and asserts the refusal
+    // that the shipped parser actually produces.
     let tmp = write_tmp_json(
         "awq-flags-negobs",
         r#"{ "flags": { "argv": ["--method", "gptq", "--bits", "4"],
-                        "expected_outcome": "unknown_method" } }"#,
+                        "expected_outcome": "rejected" } }"#,
     );
     let out = apr_binary()
         .args(["awq-lint", "--observation-file"])
@@ -304,7 +263,29 @@ fn falsify_crux_b_08_002_flags_observer_can_assert_expected_failure() {
         .expect("run apr awq-lint");
     assert!(
         out.status.success(),
-        "observer-asserts-expected-failure must pass; stderr={}",
+        "observer-asserts-the-real-refusal must pass; stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// Exit 4, not 5: an `expected_outcome` the real parser cannot emit means the
+/// capture step is stale, not that the system under test broke a contract.
+#[test]
+fn falsify_crux_b_08_002_stale_per_flag_label_is_unusable_input() {
+    let tmp = write_tmp_json(
+        "awq-flags-stale",
+        r#"{ "flags": { "argv": ["--bits", "4"],
+                        "expected_outcome": "missing_method" } }"#,
+    );
+    let out = apr_binary()
+        .args(["awq-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr awq-lint");
+    assert_eq!(
+        out.status.code(),
+        Some(4),
+        "stale vocabulary is unusable input (exit 4); stderr={}",
         String::from_utf8_lossy(&out.stderr)
     );
 }
@@ -362,7 +343,7 @@ fn falsify_crux_b_08_json_output_shape() {
         r#"{
           "quality":     { "p_fp16": 0.50, "p_awq": 0.45, "threshold": 0.80 },
           "compression": { "fp16_bytes": 1000000000, "awq_bytes": 250000000, "max_ratio": 0.30 },
-          "flags":       { "argv": ["--method", "awq", "--bits", "4", "--group-size", "128"],
+          "flags":       { "argv": ["m.apr", "--scheme", "int4", "-o", "o.apr"],
                            "expected_outcome": "ok" }
         }"#,
     );

--- a/crates/apr-cli/tests/falsification_crux_b_09.rs
+++ b/crates/apr-cli/tests/falsification_crux_b_09.rs
@@ -182,11 +182,42 @@ fn falsify_crux_b_09_002_cosine_rejects_missing_pairs_key() {
 }
 
 // ---- flags gate (FALSIFY-CRUX-B-09-003) -----------------------------------
+//
+// The verdict comes from the SHIPPED clap parser (`commands::quantize_flag_parity`),
+// not from a hand-rolled matcher living beside the assertion. `expected_outcome`
+// is `accepted` (alias `ok`) or `rejected`; the pre-fix per-flag labels are
+// refused as an unusable observation. See aprender#2377 finding 2 and
+// `contracts/apr-lint-flag-parity-v1.yaml`.
 
 #[test]
-fn falsify_crux_b_09_003_flags_ok_on_canonical_argv() {
+fn falsify_crux_b_09_003_flags_ok_on_a_real_quantize_argv() {
     let tmp = write_tmp_json(
         "gptq-flg-ok",
+        r#"{ "flags": {
+               "argv": ["model.safetensors", "--scheme", "int4", "-o", "out.apr"],
+               "expected_outcome": "accepted"
+             } }"#,
+    );
+    let out = apr_binary()
+        .args(["gptq-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr gptq-lint");
+    assert!(
+        out.status.success(),
+        "a real `apr quantize <FILE> --scheme int4 -o out.apr` must pass; stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// The load-bearing falsifier. Before aprender#2377 finding 2 this exact
+/// observation exited 0: the gate asked `parse_gptq_flags`/`validate_gptq_flags`,
+/// which reported `Ok { bits: 4, group_size: 128 }`. `apr quantize` has no
+/// `--method`, no `--bits` and no `--group-size`.
+#[test]
+fn falsify_crux_b_09_003_flags_reject_method_bits_group_size() {
+    let tmp = write_tmp_json(
+        "gptq-flg-legacy",
         r#"{ "flags": {
                "argv": ["--method", "gptq", "--bits", "4", "--group-size", "128"],
                "expected_outcome": "ok"
@@ -197,41 +228,28 @@ fn falsify_crux_b_09_003_flags_ok_on_canonical_argv() {
         .arg(tmp.path())
         .output()
         .expect("run apr gptq-lint");
-    assert!(
-        out.status.success(),
-        "canonical flags must pass; stderr={}",
+    assert_eq!(
+        out.status.code(),
+        Some(5),
+        "a gate rejection is exit 5; stderr={}",
         String::from_utf8_lossy(&out.stderr)
     );
-}
-
-#[test]
-fn falsify_crux_b_09_003_flags_ok_on_equals_form() {
-    let tmp = write_tmp_json(
-        "gptq-flg-eq",
-        r#"{ "flags": {
-               "argv": ["--method=gptq", "--bits=4", "--group-size=-1"],
-               "expected_outcome": "ok"
-             } }"#,
-    );
-    let out = apr_binary()
-        .args(["gptq-lint", "--observation-file"])
-        .arg(tmp.path())
-        .output()
-        .expect("run apr gptq-lint");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FALSIFY-CRUX-B-09-003"), "got: {stderr}");
+    assert!(stderr.contains("REJECTED"), "got: {stderr}");
     assert!(
-        out.status.success(),
-        "--method=gptq per-tensor group_size must pass; stderr={}",
-        String::from_utf8_lossy(&out.stderr)
+        stderr.contains("--scheme"),
+        "the failure must name the flags `apr quantize` does accept; got: {stderr}"
     );
 }
 
 #[test]
-fn falsify_crux_b_09_003_flags_rejects_wrong_method() {
+fn falsify_crux_b_09_003_flags_reject_an_unknown_flag() {
     let tmp = write_tmp_json(
-        "gptq-flg-wm",
+        "gptq-flg-unknown",
         r#"{ "flags": {
-               "argv": ["--method", "awq", "--bits", "4"],
-               "expected_outcome": "ok"
+               "argv": ["m.apr", "--totally-made-up"],
+               "expected_outcome": "accepted"
              } }"#,
     );
     let out = apr_binary()
@@ -239,58 +257,18 @@ fn falsify_crux_b_09_003_flags_rejects_wrong_method() {
         .arg(tmp.path())
         .output()
         .expect("run apr gptq-lint");
-    assert!(!out.status.success());
-    let stderr = String::from_utf8_lossy(&out.stderr);
-    assert!(stderr.contains("FALSIFY-CRUX-B-09-003"));
+    assert_eq!(out.status.code(), Some(5));
 }
 
 #[test]
-fn falsify_crux_b_09_003_flags_rejects_invalid_bits() {
-    let tmp = write_tmp_json(
-        "gptq-flg-bits",
-        r#"{ "flags": {
-               "argv": ["--method", "gptq", "--bits", "5"],
-               "expected_outcome": "ok"
-             } }"#,
-    );
-    let out = apr_binary()
-        .args(["gptq-lint", "--observation-file"])
-        .arg(tmp.path())
-        .output()
-        .expect("run apr gptq-lint");
-    assert!(!out.status.success());
-    let stderr = String::from_utf8_lossy(&out.stderr);
-    assert!(stderr.contains("FALSIFY-CRUX-B-09-003"));
-}
-
-#[test]
-fn falsify_crux_b_09_003_flags_rejects_missing_bits() {
-    let tmp = write_tmp_json(
-        "gptq-flg-mb",
-        r#"{ "flags": {
-               "argv": ["--method", "gptq"],
-               "expected_outcome": "ok"
-             } }"#,
-    );
-    let out = apr_binary()
-        .args(["gptq-lint", "--observation-file"])
-        .arg(tmp.path())
-        .output()
-        .expect("run apr gptq-lint");
-    assert!(!out.status.success());
-    let stderr = String::from_utf8_lossy(&out.stderr);
-    assert!(stderr.contains("FALSIFY-CRUX-B-09-003"));
-}
-
-#[test]
-fn falsify_crux_b_09_003_flags_observer_can_assert_expected_failure() {
-    // Observer captured a deliberate negative case: argv has wrong method,
-    // and the observation asserts that the gate SHOULD produce wrong_method.
+fn falsify_crux_b_09_003_flags_observer_can_assert_expected_rejection() {
+    // Observer captured a deliberate negative case and asserts the refusal
+    // that the shipped parser actually produces.
     let tmp = write_tmp_json(
         "gptq-flg-neg",
         r#"{ "flags": {
                "argv": ["--method", "awq", "--bits", "4"],
-               "expected_outcome": "wrong_method"
+               "expected_outcome": "rejected"
              } }"#,
     );
     let out = apr_binary()
@@ -300,7 +278,31 @@ fn falsify_crux_b_09_003_flags_observer_can_assert_expected_failure() {
         .expect("run apr gptq-lint");
     assert!(
         out.status.success(),
-        "expected_outcome=wrong_method must match observed wrong_method; stderr={}",
+        "expected_outcome=rejected must match the shipped parser's refusal; stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// Exit 4, not 5: an `expected_outcome` the real parser cannot emit means the
+/// capture step is stale, not that the system under test broke a contract.
+#[test]
+fn falsify_crux_b_09_003_stale_per_flag_label_is_unusable_input() {
+    let tmp = write_tmp_json(
+        "gptq-flg-stale",
+        r#"{ "flags": {
+               "argv": ["--method", "gptq"],
+               "expected_outcome": "missing_bits"
+             } }"#,
+    );
+    let out = apr_binary()
+        .args(["gptq-lint", "--observation-file"])
+        .arg(tmp.path())
+        .output()
+        .expect("run apr gptq-lint");
+    assert_eq!(
+        out.status.code(),
+        Some(4),
+        "stale vocabulary is unusable input (exit 4); stderr={}",
         String::from_utf8_lossy(&out.stderr)
     );
 }
@@ -352,7 +354,7 @@ fn falsify_crux_b_09_json_output_shape() {
         "gptq-json",
         r#"{
           "compression": { "fp16_bytes": 1000000, "gptq_bytes": 250000, "max_ratio": 0.30 },
-          "flags":       { "argv": ["--method","gptq","--bits","4"], "expected_outcome": "ok" }
+          "flags":       { "argv": ["m.apr","--scheme","int4","-o","o.apr"], "expected_outcome": "accepted" }
         }"#,
     );
     let out = apr_binary()

--- a/crates/aprender-common/src/sys.rs
+++ b/crates/aprender-common/src/sys.rs
@@ -61,9 +61,7 @@ pub fn get_cpu_info() -> String {
 /// Uses `std::thread::available_parallelism()`, falling back to 1.
 #[must_use]
 pub fn cpu_count() -> usize {
-    std::thread::available_parallelism()
-        .map(std::num::NonZero::get)
-        .unwrap_or(1)
+    std::thread::available_parallelism().map_or(1, std::num::NonZero::get)
 }
 
 #[cfg(test)]

--- a/crates/aprender-compute/src/brick/profiler/reporting.rs
+++ b/crates/aprender-compute/src/brick/profiler/reporting.rs
@@ -61,7 +61,7 @@ impl BrickProfiler {
         }
 
         // Sort by total time descending
-        all_stats.sort_by(|a, b| b.1.total_ns.cmp(&a.1.total_ns));
+        all_stats.sort_by_key(|b| std::cmp::Reverse(b.1.total_ns));
 
         for (name, stats) in &all_stats {
             let pct = if self.total_ns > 0 {
@@ -139,7 +139,7 @@ impl BrickProfiler {
         }
 
         // Sort by total time descending
-        all_stats.sort_by(|a, b| b.1.total_ns.cmp(&a.1.total_ns));
+        all_stats.sort_by_key(|b| std::cmp::Reverse(b.1.total_ns));
 
         for (name, stats) in all_stats {
             let pct = if self.total_ns > 0 {

--- a/crates/aprender-compute/src/inference/generate.rs
+++ b/crates/aprender-compute/src/inference/generate.rs
@@ -127,8 +127,7 @@ pub fn generate(
     }
 
     // Decode: generate tokens one at a time
-    let mut pos = prompt_tokens.len();
-    for _ in 0..max_tokens {
+    for pos in (prompt_tokens.len()..).take(max_tokens) {
         let token = sample_token(&last_logits, params, &mut rng);
 
         if token == eos_token {
@@ -140,7 +139,6 @@ pub fn generate(
 
         generated.push(token);
         last_logits = model.forward(token, pos, &mut kv_cache, &mut arena)?;
-        pos += 1;
     }
 
     Ok(generated)

--- a/crates/aprender-compute/src/tuner/brick_tuner/persistence.rs
+++ b/crates/aprender-compute/src/tuner/brick_tuner/persistence.rs
@@ -9,7 +9,7 @@ use super::BrickTuner;
 
 impl BrickTuner {
     /// APR format magic bytes (APR1 = uncompressed)
-    const APR_MAGIC: [u8; 4] = [b'A', b'P', b'R', b'1'];
+    const APR_MAGIC: [u8; 4] = *b"APR1";
 
     /// Serialize to JSON
     pub fn to_json(&self) -> Result<String, TunerError> {

--- a/crates/aprender-contracts/src/lean_gen/mod.rs
+++ b/crates/aprender-contracts/src/lean_gen/mod.rs
@@ -159,8 +159,7 @@ pub fn format_status_report(reports: &[LeanStatusReport]) -> String {
         "Total", total_ob, total_proved, total_sorry, total_wip, total_na
     ));
 
-    if total_ob > 0 {
-        let pct = total_proved * 100 / total_ob;
+    if let Some(pct) = (total_proved * 100).checked_div(total_ob) {
         out.push_str(&format!(
             "L4 Coverage: {pct}% ({total_proved}/{total_ob})   Sorry Debt: {total_sorry}\n"
         ));

--- a/crates/aprender-contracts/src/lint/config.rs
+++ b/crates/aprender-contracts/src/lint/config.rs
@@ -243,10 +243,8 @@ fn apply_kv(config: &mut PvConfig, section: &str, key: &str, val: &str) {
             "files" => config.lint.suppress.files = parse_toml_array(val),
             _ => {}
         },
-        "lint.diff" => {
-            if key == "base_ref" {
-                config.lint.diff.base_ref = Some(val.to_string());
-            }
+        "lint.diff" if key == "base_ref" => {
+            config.lint.diff.base_ref = Some(val.to_string());
         }
         "lint.trend" => match key {
             "enabled" => config.lint.trend.enabled = val == "true",

--- a/crates/aprender-contracts/src/lint/mod.rs
+++ b/crates/aprender-contracts/src/lint/mod.rs
@@ -291,7 +291,7 @@ pub fn run_lint(config: &LintConfig) -> LintReport {
             contract_timings.push((format!("{stem}.yaml"), ct_ms));
         }
         // Sort by duration descending
-        contract_timings.sort_by(|a, b| b.1.cmp(&a.1));
+        contract_timings.sort_by_key(|b| std::cmp::Reverse(b.1));
     }
 
     // Stale suppression detection (PV-SUP-001, Section 17 Gap 2)

--- a/crates/aprender-contracts/src/lint/strict_test_binding.rs
+++ b/crates/aprender-contracts/src/lint/strict_test_binding.rs
@@ -403,10 +403,8 @@ fn parse_fn_name(line: &str) -> Option<String> {
         r
     } else if let Some(r) = t.strip_prefix("async fn ") {
         r
-    } else if let Some(r) = t.strip_prefix("fn ") {
-        r
     } else {
-        return None;
+        t.strip_prefix("fn ")?
     };
     let name: String = rest
         .chars()

--- a/crates/aprender-contracts/src/readme_gen.rs
+++ b/crates/aprender-contracts/src/readme_gen.rs
@@ -39,11 +39,7 @@ fn write_coverage_summary(out: &mut String, report: &CoverageReport) {
         .iter()
         .filter(|c| c.falsification_covered > 0)
         .count();
-    let pct = if total > 0 {
-        with_tests * 100 / total
-    } else {
-        0
-    };
+    let pct = (with_tests * 100).checked_div(total).unwrap_or(0);
 
     let _ = writeln!(
         out,

--- a/crates/aprender-core/build_parsing.rs
+++ b/crates/aprender-core/build_parsing.rs
@@ -451,13 +451,8 @@ fn parse_size_block(name: &str, block: &str, path: &Path) -> SizeData {
     let intermediate_dim = get_usize_with_alt(block, "intermediate_dim", &["encoder_ffn_dim"], path, name, false);
     let vocab_size = get_usize(block, "vocab_size").unwrap_or(0);
     let max_pos = get_usize(block, "max_position_embeddings").unwrap_or(0);
-    let head_dim = get_usize(block, "head_dim").unwrap_or_else(|| {
-        if num_heads > 0 {
-            hidden_dim / num_heads
-        } else {
-            0
-        }
-    });
+    let head_dim = get_usize(block, "head_dim")
+        .unwrap_or_else(|| hidden_dim.checked_div(num_heads).unwrap_or(0));
     let rope_theta = get_f64(block, "rope_theta").unwrap_or(0.0);
     let norm_eps = get_f64(block, "rms_norm_eps")
         .or_else(|| get_f64(block, "norm_eps"))

--- a/crates/aprender-core/src/autograd/grad_fn.rs
+++ b/crates/aprender-core/src/autograd/grad_fn.rs
@@ -1153,7 +1153,7 @@ impl GradFn for SoftmaxLastDimBackward {
         let ndim = shape.len();
         let features = if ndim == 0 { 1 } else { shape[ndim - 1] };
         let total = self.output.numel();
-        let rows = if features == 0 { 0 } else { total / features };
+        let rows = total.checked_div(features).unwrap_or(0);
 
         let out_data = self.output.data();
         let grad_data = grad_output.data();

--- a/crates/aprender-core/src/bench/mod.rs
+++ b/crates/aprender-core/src/bench/mod.rs
@@ -46,7 +46,7 @@ pub trait EvalTask: Send + Sync {
 
     /// Timeout per turn
     fn turn_timeout(&self) -> Duration {
-        Duration::from_secs(60)
+        Duration::from_mins(1)
     }
 }
 

--- a/crates/aprender-core/src/cache/mod.rs
+++ b/crates/aprender-core/src/cache/mod.rs
@@ -419,7 +419,7 @@ impl CacheTier {
     pub const fn typical_latency(&self) -> Duration {
         match self {
             Self::L1Hot => Duration::from_nanos(100),
-            Self::L2Warm => Duration::from_micros(1000),
+            Self::L2Warm => Duration::from_millis(1),
             Self::L3Cold => Duration::from_millis(10),
         }
     }

--- a/crates/aprender-core/src/chaos.rs
+++ b/crates/aprender-core/src/chaos.rs
@@ -50,7 +50,7 @@ impl Default for ChaosConfig {
         Self {
             memory_limit: 0,
             cpu_limit: 0.0,
-            timeout: Duration::from_secs(60),
+            timeout: Duration::from_mins(1),
             signal_injection: false,
         }
     }
@@ -188,7 +188,7 @@ impl ChaosConfig {
         Self::new()
             .with_memory_limit(512 * 1024 * 1024)
             .with_cpu_limit(0.8)
-            .with_timeout(Duration::from_secs(120))
+            .with_timeout(Duration::from_mins(2))
     }
 
     /// Aggressive chaos preset: strict limits, short timeout, signal injection.

--- a/crates/aprender-core/src/citl/compiler/cargo_project.rs
+++ b/crates/aprender-core/src/citl/compiler/cargo_project.rs
@@ -8,7 +8,7 @@ impl RustCompiler {
             cargo_path: which_cargo(),
             edition: RustEdition::default(),
             target: None,
-            timeout: Duration::from_secs(60),
+            timeout: Duration::from_mins(1),
             mode: CompilationMode::default(),
             extra_flags: Vec::new(),
         }

--- a/crates/aprender-core/src/citl/encoder/gnn_encoder_features.rs
+++ b/crates/aprender-core/src/citl/encoder/gnn_encoder_features.rs
@@ -78,11 +78,7 @@ impl GNNErrorEncoder {
     /// Mean pool over nodes.
     fn mean_pool(&self, tensor: &Tensor, num_nodes: usize) -> Vec<f32> {
         let data = tensor.data();
-        let feature_dim = if num_nodes > 0 {
-            data.len() / num_nodes
-        } else {
-            self.output_dim
-        };
+        let feature_dim = data.len().checked_div(num_nodes).unwrap_or(self.output_dim);
 
         let mut pooled = vec![0.0f32; feature_dim];
         if num_nodes == 0 {

--- a/crates/aprender-core/src/citl/metrics.rs
+++ b/crates/aprender-core/src/citl/metrics.rs
@@ -249,7 +249,7 @@ impl PatternUsageMetrics {
     #[must_use]
     pub fn most_used(&self, n: usize) -> Vec<(usize, u64)> {
         let mut counts: Vec<_> = self.usage_counts.iter().map(|(&k, &v)| (k, v)).collect();
-        counts.sort_by(|a, b| b.1.cmp(&a.1));
+        counts.sort_by_key(|b| std::cmp::Reverse(b.1));
         counts.truncate(n);
         counts
     }
@@ -392,7 +392,7 @@ impl ErrorFrequencyMetrics {
             .iter()
             .map(|(k, &v)| (k.clone(), v))
             .collect();
-        counts.sort_by(|a, b| b.1.cmp(&a.1));
+        counts.sort_by_key(|b| std::cmp::Reverse(b.1));
         counts.truncate(n);
         counts
     }

--- a/crates/aprender-core/src/format/converter/gguf_export_config.rs
+++ b/crates/aprender-core/src/format/converter/gguf_export_config.rs
@@ -208,11 +208,7 @@ fn resolve_gguf_config(
             }),
         rms_norm_eps: apr_metadata.and_then(|m| m.rms_norm_eps).unwrap_or(1e-6),
         // N-02 (Meyer DbC): 0 when dimensions unknown, not hardcoded 128.
-        head_dim: if num_heads > 0 {
-            hidden_size / num_heads
-        } else {
-            0
-        },
+        head_dim: hidden_size.checked_div(num_heads).unwrap_or(0),
         model_name: apr_metadata
             .and_then(|m| m.name.clone())
             .unwrap_or_else(|| "model".to_string()),

--- a/crates/aprender-core/src/format/converter/metadata.rs
+++ b/crates/aprender-core/src/format/converter/metadata.rs
@@ -228,11 +228,7 @@ fn build_gguf_arch_metadata(
     let rope_theta = apr_metadata.rope_theta.unwrap_or_else(||
         super::export::default_rope_theta_for_architecture(arch));
     let rms_norm_eps = apr_metadata.rms_norm_eps.unwrap_or(1e-6);
-    let head_dim = if num_heads > 0 {
-        hidden_size / num_heads
-    } else {
-        0
-    };
+    let head_dim = hidden_size.checked_div(num_heads).unwrap_or(0);
     let model_name = apr_metadata
         .name
         .clone()

--- a/crates/aprender-core/src/format/converter/tensor.rs
+++ b/crates/aprender-core/src/format/converter/tensor.rs
@@ -133,11 +133,8 @@ fn infer_model_config(tensors: &BTreeMap<String, (Vec<f32>, Vec<usize>)>) -> Str
         .unwrap_or(hidden_size * 4); // Default to 4x hidden_size (common in transformers)
 
     // GH-193: Infer head_dim (guard against division by zero)
-    let head_dim = if num_attention_heads > 0 {
-        hidden_size / num_attention_heads
-    } else {
-        64 // Default head dimension
-    };
+    // 64 is the default head dimension when the head count is unknown (0).
+    let head_dim = hidden_size.checked_div(num_attention_heads).unwrap_or(64);
 
     // GH-193: Infer num_key_value_heads (GQA support)
     // Look for k_proj shape to detect if using GQA (grouped query attention)
@@ -153,11 +150,7 @@ fn infer_model_config(tensors: &BTreeMap<String, (Vec<f32>, Vec<usize>)>) -> Str
             // If shape[0] < hidden_size, it's GQA
             let kv_dim = shape.first().copied().unwrap_or(hidden_size);
             // Guard against division by zero
-            if head_dim > 0 {
-                (kv_dim / head_dim).max(1)
-            } else {
-                1
-            }
+            kv_dim.checked_div(head_dim).unwrap_or(1).max(1)
         })
         .unwrap_or(num_attention_heads); // Default: same as num_attention_heads (MHA)
 

--- a/crates/aprender-core/src/format/parsing.rs
+++ b/crates/aprender-core/src/format/parsing.rs
@@ -48,11 +48,7 @@ fn parse_size_config(yaml: &YamlValue, family: &str, size: &str) -> Result<Model
                 .get_usize("num_heads")
                 .or_else(|| yaml.get_usize("encoder_attention_heads"))
                 .unwrap_or(0);
-            if heads > 0 {
-                hidden / heads
-            } else {
-                0
-            }
+            hidden.checked_div(heads).unwrap_or(0)
         }),
         rope_theta: yaml.get_f64("rope_theta").unwrap_or(0.0),
         norm_eps: yaml

--- a/crates/aprender-core/src/format/rosetta_ml/error_pattern.rs
+++ b/crates/aprender-core/src/format/rosetta_ml/error_pattern.rs
@@ -418,7 +418,7 @@ fn compute_pareto(
         .map(|(cat, (attempts, successes))| (*cat, attempts - successes))
         .collect();
 
-    failures.sort_by(|a, b| b.1.cmp(&a.1));
+    failures.sort_by_key(|b| std::cmp::Reverse(b.1));
 
     let threshold = (total_failures as f32 * 0.80) as usize;
     let mut cumulative = 0;

--- a/crates/aprender-core/src/format/validation.rs
+++ b/crates/aprender-core/src/format/validation.rs
@@ -117,6 +117,20 @@ impl ImplementedScore {
     pub fn not_implemented(&self) -> usize {
         self.declared.saturating_sub(self.ran as usize)
     }
+
+    /// Percentage of the checks that RAN which passed, or `None` when nothing
+    /// ran.
+    ///
+    /// `None` is not zero. Zero means "we measured and you failed everything";
+    /// `None` means "nothing was measured", which is not a score and must not
+    /// be rendered as one (#1866).
+    #[must_use]
+    pub fn pct(&self) -> Option<f64> {
+        if self.ran == 0 {
+            return None;
+        }
+        Some((f64::from(self.passed) / f64::from(self.ran)) * 100.0)
+    }
 }
 
 impl std::fmt::Display for ImplementedScore {
@@ -166,25 +180,87 @@ impl ValidationReport {
         self.total_score += points;
     }
 
-    /// Get grade based on score
+    /// Letter grade for what the checklist ACTUALLY measured (#1866).
+    ///
+    /// This used to band `total_score`, a raw count of awarded points, against
+    /// a fixed 100-point denominator. 22 of the 26 checks the `.apr` path
+    /// declares are `Skip("Not implemented")` stubs that never run, so the
+    /// ceiling was 4 and every healthy model was graded `F` — while the same
+    /// report said `passed: true`, `failed: 0` and printed `✓ VALID`. A grade
+    /// nobody can earn is not a grade, it is a lie with a letter on it.
+    ///
+    /// The grade is now a function of the checks that ran, and it is wired to
+    /// the verdict rather than merely correlated with it:
+    ///
+    /// * nothing ran            → `"N/A"` — not a grade; nothing was measured
+    /// * any check FAILED       → `"F"`
+    /// * otherwise              → band of [`Self::implemented_score_pct`],
+    ///   floored at `"D"` because a report with no failures is at worst
+    ///   all-advisory.
+    ///
+    /// Invariant, proved by construction and asserted in
+    /// `grade_is_f_exactly_when_a_check_failed`:
+    ///
+    /// ```text
+    /// grade() == "F"  <=>  a check ran AND at least one check failed
+    ///                 <=>  !is_valid()  (given something ran)
+    /// ```
+    ///
+    /// so `is_valid()` (the human `VALID` badge), the JSON `passed` flag and
+    /// the grade cannot disagree.
     #[must_use]
     pub fn grade(&self) -> &'static str {
-        match self.total_score {
-            95..=100 => "A+",
-            90..=94 => "A",
-            85..=89 => "B+",
-            80..=84 => "B",
-            75..=79 => "C+",
-            70..=74 => "C",
-            60..=69 => "D",
-            _ => "F",
+        let Some(pct) = self.implemented_score_pct() else {
+            return "N/A";
+        };
+        if !self.is_valid() {
+            return "F";
+        }
+        // No failures ⇒ every check that ran either passed or warned ⇒ the
+        // worst reachable band here is "D". "F" is unreachable without a
+        // failure, which is exactly the invariant above.
+        if pct >= 95.0 {
+            "A+"
+        } else if pct >= 90.0 {
+            "A"
+        } else if pct >= 85.0 {
+            "B+"
+        } else if pct >= 80.0 {
+            "B"
+        } else if pct >= 75.0 {
+            "C+"
+        } else if pct >= 70.0 {
+            "C"
+        } else {
+            "D"
         }
     }
 
-    /// Check if validation passed (score >= threshold)
+    /// True when no check that ran reported a failure.
+    ///
+    /// This is the single predicate behind the human `VALID` / `INVALID`
+    /// badge, the JSON `verdict`, and the `"F"` grade band — so the three
+    /// cannot contradict each other (#1866).
+    #[must_use]
+    pub fn is_valid(&self) -> bool {
+        self.failed_checks().is_empty()
+    }
+
+    /// Check if validation cleared a `min_score` threshold, expressed as a
+    /// percentage of the checks that RAN (#1866).
+    ///
+    /// It used to compare `total_score` — raw awarded points — against the
+    /// threshold, so `report.passed(95)` was unreachable for any `.apr` file
+    /// (ceiling 4) and `apr import` reported "completed with warnings" on
+    /// every successful import.
+    ///
+    /// Fails closed when nothing ran: you cannot clear a threshold against a
+    /// number that was never measured. That is the same rule `apr validate`
+    /// applies when refusing `--min-score` on a format that computes no score.
     #[must_use]
     pub fn passed(&self, min_score: u8) -> bool {
-        self.total_score >= min_score
+        self.implemented_score_pct()
+            .is_some_and(|pct| pct >= f64::from(min_score))
     }
 
     /// Get failed checks
@@ -234,17 +310,29 @@ impl ValidationReport {
     /// a hard fail (#1866).
     #[must_use]
     pub fn implemented_score_pct(&self) -> Option<f64> {
-        let max = self.implemented_max();
-        if max == 0 {
-            return None;
+        self.implemented_score().pct()
+    }
+
+    /// The same measured score, restricted to one category (#1866).
+    ///
+    /// The `--quality` table printed `B. Tensor Physics & Statistics 0/25` for
+    /// categories in which not a single check is even declared on the `.apr`
+    /// path — an empty progress bar that reads as "measured, scored nothing"
+    /// when the truth is "never ran". `ran == 0` here lets the renderer say
+    /// so instead of drawing a zero.
+    #[must_use]
+    pub fn category_score(&self, category: Category) -> ImplementedScore {
+        let in_category = || self.checks.iter().filter(|c| c.category == category);
+        let clamp = |n: usize| n.min(u8::MAX as usize) as u8;
+        ImplementedScore {
+            passed: clamp(in_category().filter(|c| c.status.is_pass()).count()),
+            ran: clamp(
+                in_category()
+                    .filter(|c| !matches!(c.status, CheckStatus::Skip(_)))
+                    .count(),
+            ),
+            declared: in_category().count(),
         }
-        let passed: u8 = self
-            .checks
-            .iter()
-            .filter(|c| c.status.is_pass())
-            .count()
-            .min(u8::MAX as usize) as u8;
-        Some((f64::from(passed) / f64::from(max)) * 100.0)
     }
 }
 

--- a/crates/aprender-core/src/format/validation_impl.rs
+++ b/crates/aprender-core/src/format/validation_impl.rs
@@ -392,11 +392,7 @@ impl PokaYokeResult {
             .fold(0u8, u8::saturating_add);
         let total_points: u16 = gates.iter().map(|g| u16::from(g.points)).sum();
         let max_points: u16 = gates.iter().map(|g| u16::from(g.max_points)).sum();
-        let score = if max_points > 0 {
-            ((total_points * 100) / max_points).min(100) as u8
-        } else {
-            0
-        };
+        let score = (total_points * 100).checked_div(max_points).unwrap_or(0).min(100) as u8;
         Self {
             gates,
             score,
@@ -415,11 +411,7 @@ impl PokaYokeResult {
     fn recalculate_score(&mut self) {
         let total_points: u16 = self.gates.iter().map(|g| u16::from(g.points)).sum();
         let max_points: u16 = self.gates.iter().map(|g| u16::from(g.max_points)).sum();
-        self.score = if max_points > 0 {
-            ((total_points * 100) / max_points).min(100) as u8
-        } else {
-            0
-        };
+        self.score = (total_points * 100).checked_div(max_points).unwrap_or(0).min(100) as u8;
     }
 
     /// Get letter grade

--- a/crates/aprender-core/src/format/validation_tests_report.rs
+++ b/crates/aprender-core/src/format/validation_tests_report.rs
@@ -24,6 +24,13 @@ mod tests_report {
         assert_eq!(report.total_score, 95);
     }
 
+    /// #1866: `F` is earned by FAILING checks, never by a short checklist.
+    ///
+    /// This test used to assert that 50 checks — every one of them PASSING —
+    /// graded `F`, because the grade banded 50 awarded points against a fixed
+    /// 100-point denominator. That assertion was the defect written down as a
+    /// test: it is the same arithmetic that graded a healthy `.apr` file `F`
+    /// at 3/100.
     #[test]
     fn test_report_grade_f() {
         let mut report = ValidationReport::new();
@@ -36,10 +43,29 @@ mod tests_report {
                 points: 1,
             });
         }
-        assert_eq!(report.grade(), "F");
+        assert_eq!(
+            report.grade(),
+            "A+",
+            "50 of 50 checks passed; a short checklist is not a failing model"
+        );
         assert_eq!(report.total_score, 50);
+
+        // One genuine failure, and only then, is F.
+        report.add_check(ValidationCheck {
+            id: 51,
+            name: "broken",
+            category: Category::Structure,
+            status: CheckStatus::Fail("magic bytes".to_string()),
+            points: 0,
+        });
+        assert_eq!(report.grade(), "F");
     }
 
+    /// #1866: the threshold is a percentage of the checks that RAN.
+    ///
+    /// It used to compare raw awarded points, so `passed(95)` was unreachable
+    /// for any real `.apr` file (ceiling 4 points) and `apr import` reported
+    /// "completed with warnings" on every successful import.
     #[test]
     fn test_report_passed_threshold() {
         let mut report = ValidationReport::new();
@@ -53,7 +79,33 @@ mod tests_report {
             });
         }
         assert!(report.passed(90));
-        assert!(!report.passed(95));
+        assert!(report.passed(95), "90/90 checks passed — that is 100%");
+
+        // A tenth of the suite failing puts it under the bar.
+        for i in 91..=100 {
+            report.add_check(ValidationCheck {
+                id: i,
+                name: "test",
+                category: Category::Structure,
+                status: CheckStatus::Fail("bad".to_string()),
+                points: 0,
+            });
+        }
+        assert!(!report.passed(95), "90/100 = 90% must not clear 95");
+    }
+
+    /// A threshold cannot be cleared against a score that was never measured.
+    #[test]
+    fn passed_fails_closed_when_no_check_ran() {
+        let mut report = ValidationReport::new();
+        for i in 1..=25 {
+            push_check(&mut report, i, CheckStatus::Skip("Not implemented".into()));
+        }
+        assert!(
+            !report.passed(0),
+            "nothing ran, so no threshold — not even 0 — was demonstrated"
+        );
+        assert_eq!(report.grade(), "N/A");
     }
 
     #[test]
@@ -629,5 +681,124 @@ mod tests_report {
         assert_eq!(score.ran, 2, "a FAILED check ran and must count against us");
         assert_eq!(score.not_implemented(), 0);
         assert_eq!(score.to_string(), "1/2 checks that ran");
+    }
+
+    // ========================================================================
+    // #1866 FALSIFIER: a healthy model must not be graded F, and the grade,
+    // the pass flag and the human verdict must not contradict each other.
+    //
+    // Contract: apr-validate-quality-threshold-v1
+    // ========================================================================
+
+    /// The exact report `apr validate` builds for
+    /// `/home/noah/models/qwen2.5-coder-0.5b-instruct.apr` — a model
+    /// `apr qa` passes and `apr run` answers correctly from. Checks 1/2/3
+    /// PASS, check 11 WARNs on an unknown flag bit, and 22 checks are
+    /// `Skip("Not implemented")` stubs.
+    fn healthy_apr_report() -> ValidationReport {
+        let mut report = ValidationReport::new();
+        push_check(&mut report, 1, CheckStatus::Pass);
+        push_check(&mut report, 2, CheckStatus::Pass);
+        push_check(&mut report, 3, CheckStatus::Pass);
+        push_check(
+            &mut report,
+            11,
+            CheckStatus::Warn("Unknown flag bits: 0x00000100".into()),
+        );
+        push_check(
+            &mut report,
+            4,
+            CheckStatus::Skip("Footer not implemented".into()),
+        );
+        for id in 5..=25 {
+            push_check(&mut report, id, CheckStatus::Skip("Not implemented".into()));
+        }
+        report
+    }
+
+    /// FALSIFY-VALIDATE-QUALITY-004 (#1866): a healthy model must score above
+    /// the F band.
+    ///
+    /// Before the fix this asserted `"F"` on a working model, at exit 0, while
+    /// the same report advertised `passed: true` and printed `✓ VALID`.
+    #[test]
+    fn healthy_model_is_not_graded_f() {
+        let report = healthy_apr_report();
+
+        assert_eq!(report.implemented_score().ran, 4);
+        assert_eq!(report.implemented_score().not_implemented(), 22);
+        assert_ne!(
+            report.grade(),
+            "F",
+            "a model with zero failed checks was graded F: {:?}",
+            report.implemented_score()
+        );
+        assert_eq!(report.grade(), "C+", "3 of the 4 checks that ran passed");
+    }
+
+    /// FALSIFY-VALIDATE-QUALITY-005 (#1866): grade, pass flag and human
+    /// verdict are one decision, not three.
+    ///
+    /// `grade() == "F"` must hold EXACTLY when a check that ran reported a
+    /// failure — which is also `!is_valid()`, the predicate behind the
+    /// `VALID` / `INVALID` badge. Exhaustive over every arrangement of
+    /// Pass/Fail/Warn/Skip across four checks (256 reports).
+    #[test]
+    fn grade_is_f_exactly_when_a_check_failed() {
+        let statuses = [
+            CheckStatus::Pass,
+            CheckStatus::Fail("bad".into()),
+            CheckStatus::Warn("advisory".into()),
+            CheckStatus::Skip("Not implemented".into()),
+        ];
+        // Every arrangement of four checks, enumerated as the base-4 digits
+        // of 0..256 — one loop instead of four nested ones.
+        for shape in 0..statuses.len().pow(4) {
+            let picks = [shape % 4, (shape / 4) % 4, (shape / 16) % 4, (shape / 64) % 4];
+            let mut report = ValidationReport::new();
+            for (i, idx) in picks.into_iter().enumerate() {
+                push_check(&mut report, i as u8 + 1, statuses[idx].clone());
+            }
+            let grade = report.grade();
+            let any_failed = !report.is_valid();
+
+            if report.implemented_score().ran == 0 {
+                assert_eq!(grade, "N/A", "nothing ran but was graded {grade}");
+                continue;
+            }
+            assert_eq!(
+                grade == "F",
+                any_failed,
+                "grade {grade} disagrees with the VALID/INVALID verdict for {picks:?}"
+            );
+            // The JSON `passed` flag is `is_valid()` too, so a passing report
+            // can never carry an F.
+            assert!(
+                any_failed || grade != "F",
+                "passing report graded F for {picks:?}"
+            );
+        }
+    }
+
+    /// A category in which nothing is declared must report `ran == 0`, so the
+    /// renderer can say "not implemented" instead of drawing `0/25` — a zero
+    /// for something that was never measured (#1866).
+    #[test]
+    fn category_score_distinguishes_never_ran_from_scored_zero() {
+        let report = healthy_apr_report(); // Structure only.
+
+        let structure = report.category_score(Category::Structure);
+        assert_eq!(structure.ran, 4);
+        assert_eq!(structure.passed, 3);
+
+        for empty in [Category::Physics, Category::Tooling, Category::Conversion] {
+            let score = report.category_score(empty);
+            assert_eq!(score.declared, 0, "{empty:?} declares no checks here");
+            assert_eq!(
+                score.pct(),
+                None,
+                "{empty:?} ran nothing, so it has no score — not a score of zero"
+            );
+        }
     }
 }

--- a/crates/aprender-core/src/hf_hub/client_impl.rs
+++ b/crates/aprender-core/src/hf_hub/client_impl.rs
@@ -391,7 +391,7 @@ impl HfHubClient {
         let response = ureq::post(&url)
             .set("Authorization", &format!("Bearer {token}"))
             .set("Content-Type", "application/x-ndjson")
-            .timeout(std::time::Duration::from_secs(120))
+            .timeout(std::time::Duration::from_mins(2))
             .send_string(&ndjson_body);
 
         match response {

--- a/crates/aprender-core/src/hf_hub/upload.rs
+++ b/crates/aprender-core/src/hf_hub/upload.rs
@@ -122,7 +122,7 @@ impl HfHubClient {
             let t = Instant::now();
             let resp = ureq::put(chunk_url)
                 .set("Content-Type", "application/octet-stream")
-                .timeout(std::time::Duration::from_secs(7200))
+                .timeout(std::time::Duration::from_hours(2))
                 .send_bytes(chunk_data)
                 .map_err(|e| {
                     eprintln!("[LFS] ERROR: Chunk {} upload failed: {}", i + 1, e);
@@ -169,7 +169,7 @@ impl HfHubClient {
 
         let mut request = ureq::put(url)
             .set("Content-Type", "application/octet-stream")
-            .timeout(std::time::Duration::from_secs(7200));
+            .timeout(std::time::Duration::from_hours(2));
 
         if let Some(hdrs) = headers {
             for (key, value) in hdrs {
@@ -317,7 +317,7 @@ impl HfHubClient {
 
         let mut request = ureq::put(upload_url)
             .set("Content-Type", "application/octet-stream")
-            .timeout(std::time::Duration::from_secs(7200));
+            .timeout(std::time::Duration::from_hours(2));
 
         if let Some(header_obj) = upload_action
             .and_then(|a| a.get("header"))

--- a/crates/aprender-core/src/native/mod.rs
+++ b/crates/aprender-core/src/native/mod.rs
@@ -263,11 +263,9 @@ impl<T: Copy + Default> AlignedVec<T> {
     #[must_use]
     pub fn with_capacity(capacity: usize) -> Self {
         let size_of_t = size_of::<T>();
-        let aligned_cap = if size_of_t > 0 {
-            (capacity * size_of_t).div_ceil(64) * 64 / size_of_t
-        } else {
-            capacity
-        };
+        let aligned_cap = ((capacity * size_of_t).div_ceil(64) * 64)
+            .checked_div(size_of_t)
+            .unwrap_or(capacity);
         let aligned_cap = aligned_cap.max(capacity);
         let data = vec![T::default(); aligned_cap];
         Self {

--- a/crates/aprender-core/src/online/corpus_merger.rs
+++ b/crates/aprender-core/src/online/corpus_merger.rs
@@ -85,7 +85,7 @@ impl CorpusMerger {
         }
 
         // Sort by priority (higher first) so dedup keeps the highest-priority copy.
-        all_samples.sort_by(|a, b| b.1.cmp(&a.1));
+        all_samples.sort_by_key(|b| std::cmp::Reverse(b.1));
 
         let (mut buffer, duplicates) = self.build_buffer(&all_samples);
         provenance.duplicates_removed = duplicates;

--- a/crates/aprender-core/src/pruning/width.rs
+++ b/crates/aprender-core/src/pruning/width.rs
@@ -391,11 +391,9 @@ impl WidthPruner {
     /// Compute head dimension after pruning.
     #[must_use]
     pub fn head_dim_after_pruning(&self) -> usize {
-        if self.num_attention_heads == 0 {
-            0
-        } else {
-            self.target_hidden_dim / self.num_attention_heads
-        }
+        self.target_hidden_dim
+            .checked_div(self.num_attention_heads)
+            .unwrap_or(0)
     }
 }
 

--- a/crates/aprender-core/src/qa/mod.rs
+++ b/crates/aprender-core/src/qa/mod.rs
@@ -180,11 +180,7 @@ impl QaReport {
             .map(|s| u16::from(s.points_possible))
             .sum();
 
-        self.total_score = if possible > 0 {
-            ((earned * 100) / possible).min(100) as u8
-        } else {
-            0
-        };
+        self.total_score = (earned * 100).checked_div(possible).unwrap_or(0).min(100) as u8;
 
         // Pass if score >= 80 and no blockers
         self.passed = self.total_score >= 80 && self.blockers.is_empty();

--- a/crates/aprender-core/src/text/tokenize/bpe_training.rs
+++ b/crates/aprender-core/src/text/tokenize/bpe_training.rs
@@ -355,11 +355,10 @@ impl BpeTokenizer {
                         current_value.push(c);
                     }
                 }
-                _ if !in_string && !c.is_whitespace() => {
-                    if !parsing_key {
+                _ if !in_string && !c.is_whitespace()
+                    && !parsing_key => {
                         current_value.push(c);
                     }
-                }
                 _ => {}
             }
         }

--- a/crates/aprender-core/src/text/tokenize/unigram_training.rs
+++ b/crates/aprender-core/src/text/tokenize/unigram_training.rs
@@ -57,7 +57,7 @@ impl UnigramTokenizer {
         let mut vocab_items: Vec<(String, usize)> = token_counts.into_iter().collect();
 
         // Sort by frequency (descending), keep top tokens
-        vocab_items.sort_by(|a, b| b.1.cmp(&a.1));
+        vocab_items.sort_by_key(|b| std::cmp::Reverse(b.1));
 
         // Prune to target size (keep special tokens + most frequent)
         if vocab_items.len() > vocab_size {

--- a/crates/aprender-core/src/zoo/index.rs
+++ b/crates/aprender-core/src/zoo/index.rs
@@ -109,7 +109,7 @@ impl ModelZooIndex {
     #[must_use]
     pub fn most_popular(&self, limit: usize) -> Vec<&ModelZooEntry> {
         let mut models: Vec<_> = self.models.iter().collect();
-        models.sort_by(|a, b| b.downloads.cmp(&a.downloads));
+        models.sort_by_key(|b| std::cmp::Reverse(b.downloads));
         models.into_iter().take(limit).collect()
     }
 

--- a/crates/aprender-core/tests/readme_contract.rs
+++ b/crates/aprender-core/tests/readme_contract.rs
@@ -1,18 +1,27 @@
-//! README.md Contract Enforcement
+//! Published-docs Contract Enforcement — README.md, docs/BEATS.md, CLAUDE.md
 //!
 //! Enforces: contracts/apr-docs-v1.yaml
-//! FALSIFY-README-001 through FALSIFY-README-005 + FALSIFY-SVG-002/003
+//! FALSIFY-README-001..007 + FALSIFY-SVG-002/003
+//! FALSIFY-DOCS-BEATS-001..003, FALSIFY-DOCS-CLAUDE-001
 //!
-//! These tests prevent README drift from the actual workspace state.
+//! These tests prevent our *published* claims from drifting away from the tree
+//! and from `contracts/`. A doc claim nobody re-measures is a claim nobody can
+//! trust — see the withdrawn 1.371x Ollama beat in docs/BEATS.md.
+//!
+//! WHY ALL THREE DOCS SHARE ONE TEST TARGET. `.github/workflows/ci.yml` runs
+//! `--lib` across the workspace, and gates integration targets by *explicit name*
+//! on one physical line. A brand-new `tests/*.rs` file would therefore never run
+//! (547 of 573 integration targets in this repo are dark for exactly this
+//! reason), and only one PR at a time may edit that line without a merge-queue
+//! conflict. `readme_contract` is already on it, so the doc gates live here.
 
 use std::path::Path;
-use std::process::Command;
 
 fn workspace_root() -> std::path::PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("../..")
         .canonicalize()
-        .unwrap()
+        .expect("workspace root (crates/aprender-core/../..) must resolve")
 }
 
 fn read_readme() -> String {
@@ -273,5 +282,236 @@ fn test_every_readme_links_monorepo() {
         no_link.is_empty(),
         "FALSIFY-README-CRATE-002: READMEs without monorepo link: {:?}",
         no_link
+    );
+}
+
+// ---------------------------------------------------------------------------
+// docs/BEATS.md — the public scoreboard must match contracts/
+// ---------------------------------------------------------------------------
+//
+// #2349 carve-out. docs/BEATS.md published "apr 1.371x faster than Ollama" as a
+// WON headline beat with "gate >=1.10x" long after the claim was withdrawn. The
+// contract had already been corrected to `beat_threshold: 0.9000` (a NO-COLLAPSE
+// FLOOR) and the harness to `ENFORCED_THRESHOLD: f64 = 0.90`; only the
+// scoreboard still said "win". Nothing failed, because nothing compared the two.
+
+const OLLAMA_BEAT_CONTRACT: &str = "contracts/beat-ollama-decode-throughput-speed-v1.yaml";
+
+fn read_doc(rel: &str) -> String {
+    let path = workspace_root().join(rel);
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("{rel} must be readable: {e}"))
+}
+
+/// Parse `beat_threshold:` out of a beat contract.
+///
+/// Deliberately reads the CONTRACT rather than a constant duplicated here — a
+/// gate that hardcodes the number it is checking proves only that someone typed
+/// the same digits twice.
+fn contract_beat_threshold(yaml: &str) -> f64 {
+    for line in yaml.lines() {
+        if let Some(rest) = line.trim_start().strip_prefix("beat_threshold:") {
+            let value = rest.split('#').next().unwrap_or("").trim();
+            return value
+                .parse::<f64>()
+                .unwrap_or_else(|e| panic!("beat_threshold {value:?} is not a number: {e}"));
+        }
+    }
+    panic!("{OLLAMA_BEAT_CONTRACT} has no `beat_threshold:` key");
+}
+
+/// Every `<date> apr <tps> ollama <tps> <ratio>x` row recorded in the contract
+/// description, as the literal strings a reader would look for.
+fn contract_measurement_figures(yaml: &str) -> Vec<String> {
+    let mut figures = Vec::new();
+    for line in yaml.lines() {
+        let t = line.trim();
+        if !t.starts_with("20") || !t.contains(" apr ") || !t.contains(" ollama ") {
+            continue;
+        }
+        // 2026-06-15  apr 412.3  ollama 300.7  1.371x  <note...>
+        let fields: Vec<&str> = t.split_whitespace().collect();
+        if fields.len() < 6 {
+            continue;
+        }
+        figures.push(fields[2].to_string()); // apr tok/s
+        figures.push(fields[4].to_string()); // ollama tok/s
+        figures.push(fields[5].trim_end_matches('x').to_string()); // ratio
+    }
+    figures
+}
+
+/// FALSIFY-DOCS-BEATS-001: docs/BEATS.md states the Ollama gate exactly as the
+/// contract carries it, and never restates the withdrawn 1.10x gate as live.
+#[test]
+fn test_beats_md_ollama_gate_matches_contract() {
+    let beats = read_doc("docs/BEATS.md");
+    let threshold = contract_beat_threshold(&read_doc(OLLAMA_BEAT_CONTRACT));
+
+    let rendered = format!("beat_threshold: {threshold:.4}");
+    assert!(
+        beats.contains(&rendered),
+        "FALSIFY-DOCS-BEATS-001: docs/BEATS.md must publish the Ollama gate as the \
+         contract carries it (`{rendered}`, from {OLLAMA_BEAT_CONTRACT}). The scoreboard \
+         is public; a gate figure it invents is a false claim about what CI enforces."
+    );
+
+    // The withdrawn gate, in the exact forms BEATS.md used to publish it.
+    const WITHDRAWN_GATE_PHRASES: [&str; 3] = [
+        "gate \u{2265}1.10\u{d7}",     // "gate ≥1.10×"
+        "\u{2265} ollama \u{d7} 1.10", // "≥ ollama × 1.10"
+        "ollama median x 1.10",
+    ];
+    let restated: Vec<&str> = WITHDRAWN_GATE_PHRASES
+        .into_iter()
+        .filter(|p| beats.contains(p))
+        .collect();
+    assert!(
+        restated.is_empty(),
+        "FALSIFY-DOCS-BEATS-001: docs/BEATS.md restates the WITHDRAWN 1.10x Ollama gate as \
+         live: {restated:?}. The contract enforces {threshold:.4}."
+    );
+}
+
+/// FALSIFY-DOCS-BEATS-002: while the contract's threshold is a floor
+/// (`beat_threshold < 1.0`), no Ollama-decode row in docs/BEATS.md may be marked
+/// WON. A floor proves apr did not collapse; it cannot prove a win.
+#[test]
+fn test_beats_md_ollama_decode_is_not_marked_won_under_a_floor() {
+    let beats = read_doc("docs/BEATS.md");
+    let threshold = contract_beat_threshold(&read_doc(OLLAMA_BEAT_CONTRACT));
+
+    assert!(
+        threshold < 1.0,
+        "FALSIFY-DOCS-BEATS-002: {OLLAMA_BEAT_CONTRACT} now carries \
+         beat_threshold={threshold:.4} >= 1.0, i.e. it asserts a WIN again. That is a \
+         scoreboard promotion, not a doc edit: re-measure, then update docs/BEATS.md and \
+         this test together."
+    );
+
+    let mut won_rows: Vec<String> = Vec::new();
+    for line in beats.lines() {
+        let lower = line.to_lowercase();
+        if lower.contains("ollama") && lower.contains("decode") && line.contains("**WON**") {
+            won_rows.push(line.trim().chars().take(120).collect());
+        }
+    }
+    assert!(
+        won_rows.is_empty(),
+        "FALSIFY-DOCS-BEATS-002: docs/BEATS.md marks an Ollama-decode row **WON** while the \
+         contract gate is a no-collapse floor (beat_threshold={threshold:.4}). \
+         Offending line(s): {won_rows:?}"
+    );
+}
+
+/// FALSIFY-DOCS-BEATS-003: docs/BEATS.md publishes EVERY measurement the contract
+/// records — including the ones that killed the claim.
+///
+/// This is the under-claiming guard. Deleting the retracted numbers would let the
+/// scoreboard pass FALSIFY-DOCS-BEATS-001/002 while telling the reader less than
+/// we know. A withdrawal has to cite what replaced the claim.
+#[test]
+fn test_beats_md_publishes_every_contract_measurement() {
+    let beats = read_doc("docs/BEATS.md");
+    let figures = contract_measurement_figures(&read_doc(OLLAMA_BEAT_CONTRACT));
+
+    assert!(
+        figures.len() >= 12,
+        "FALSIFY-DOCS-BEATS-003: parsed only {} figures from {OLLAMA_BEAT_CONTRACT} — the \
+         parser is wrong, or the contract's measurement table changed shape. Fix the parser \
+         before trusting this gate.",
+        figures.len()
+    );
+
+    let missing: Vec<&String> = figures.iter().filter(|f| !beats.contains(*f)).collect();
+    assert!(
+        missing.is_empty(),
+        "FALSIFY-DOCS-BEATS-003: docs/BEATS.md omits measurement(s) the contract records: \
+         {missing:?}. Under-claiming is a reporting failure too — publish the numbers that \
+         replaced the withdrawn claim, do not just delete the claim."
+    );
+}
+
+// ---------------------------------------------------------------------------
+// CLAUDE.md / docs/BEATS.md — every path they cite must exist
+// ---------------------------------------------------------------------------
+
+/// FALSIFY-DOCS-CLAUDE-001: every repo-relative source path cited in CLAUDE.md
+/// (and docs/BEATS.md) resolves on disk.
+///
+/// CLAUDE.md advertised six pre-monorepo paths for months —
+/// `realizar/src/inference_trace.rs`, `realizar/src/quantize/fused_gate_up.rs`,
+/// `quantize/fused_gate_up.rs`, `src/format/layout_contract.rs`,
+/// `src/format/converter/write.rs`, `src/format/converter/mod.rs` — none of which
+/// have existed since APR-MONO moved everything under `crates/`. Nothing checked
+/// them, so nothing complained.
+///
+/// Scope is deliberately narrow so the gate cannot cry wolf: a token counts only
+/// if it sits inside backticks, contains `/`, carries no shell/glob
+/// metacharacters, and ends in a source extension. A path that legitimately is
+/// not in the tree (e.g. the gitignored `.cargo/config.toml`) is marked
+/// `[gitignored]` on the same line — information the reader wants anyway.
+const DOCS_WITH_PATHS: [&str; 2] = ["CLAUDE.md", "docs/BEATS.md"];
+
+/// Does this backticked token look like a repo-relative source path we can check?
+fn looks_like_repo_path(token: &str) -> bool {
+    const EXTENSIONS: [&str; 6] = [".rs", ".yaml", ".yml", ".toml", ".sh", ".md"];
+    const SKIP_PREFIXES: [&str; 5] = ["http", "hf://", "~", "/", "target/"];
+    const METACHARACTERS: [char; 12] = [' ', '*', '<', '>', '|', '(', ')', '[', ']', '{', '}', '?'];
+
+    token.contains('/')
+        && !token.contains("..")
+        && !token.contains(METACHARACTERS)
+        && !SKIP_PREFIXES.iter().any(|p| token.starts_with(p))
+        && EXTENSIONS.iter().any(|e| token.ends_with(e))
+}
+
+/// Every `(1-based line, path)` a document cites, skipping lines that mark the
+/// reference as historical (`DELETED`) or deliberately absent (`[gitignored]`).
+fn cited_paths(doc: &str) -> Vec<(usize, String)> {
+    read_doc(doc)
+        .lines()
+        .enumerate()
+        .filter(|(_, line)| !line.contains("DELETED") && !line.contains("[gitignored]"))
+        // Odd-indexed `split('`')` fragments are the backticked spans.
+        .flat_map(|(i, line)| {
+            line.split('`')
+                .skip(1)
+                .step_by(2)
+                .filter(|t| looks_like_repo_path(t))
+                .map(move |t| (i + 1, t.to_string()))
+                .collect::<Vec<_>>()
+        })
+        .collect()
+}
+
+#[test]
+fn test_documented_paths_exist() {
+    let ws_root = workspace_root();
+    let cited: Vec<(&str, usize, String)> = DOCS_WITH_PATHS
+        .iter()
+        .flat_map(|doc| {
+            cited_paths(doc)
+                .into_iter()
+                .map(move |(line, path)| (*doc, line, path))
+        })
+        .collect();
+
+    assert!(
+        cited.len() >= 20,
+        "FALSIFY-DOCS-CLAUDE-001: only {} paths extracted from {DOCS_WITH_PATHS:?} — the \
+         extractor stopped matching. A gate that checks nothing is worse than no gate.",
+        cited.len()
+    );
+
+    let missing: Vec<String> = cited
+        .iter()
+        .filter(|(_, _, path)| !ws_root.join(path).exists())
+        .map(|(doc, line, path)| format!("{doc}:{line}: {path}"))
+        .collect();
+    assert!(
+        missing.is_empty(),
+        "FALSIFY-DOCS-CLAUDE-001: documented path(s) do not exist: {missing:#?}\n\
+         Fix the doc (APR-MONO moved everything under crates/), or mark a deliberately \
+         absent path `[gitignored]` on the same line."
     );
 }

--- a/crates/aprender-data/src/serve/plugin.rs
+++ b/crates/aprender-data/src/serve/plugin.rs
@@ -402,6 +402,11 @@ pub struct CoursePlugin;
 
 impl CoursePlugin {
     /// Create a new course plugin
+    // `mod plugin` is private, so nothing outside this file can call it yet; the
+    // struct above carries the same allow for the same reason. rustc >= 1.95
+    // reports unreachable associated fns, which the struct-level allow does not
+    // cover.
+    #[allow(dead_code)]
     pub fn new() -> Self {
         Self
     }
@@ -684,6 +689,9 @@ pub struct BookPlugin;
 
 impl BookPlugin {
     /// Create a new book plugin
+    // See `CoursePlugin::new` — private module, so this is unreachable until
+    // `mod plugin` is exported.
+    #[allow(dead_code)]
     pub fn new() -> Self {
         Self
     }

--- a/crates/aprender-data/src/streaming.rs
+++ b/crates/aprender-data/src/streaming.rs
@@ -346,9 +346,9 @@ impl DataSource for ChainedSource {
     fn size_hint(&self) -> Option<usize> {
         let mut total = 0;
         for source in &self.sources {
-            match source.size_hint() {
-                Some(hint) => total += hint,
-                None => return None,
+            {
+                let hint = source.size_hint()?;
+                total += hint;
             }
         }
         Some(total)

--- a/crates/aprender-orchestrate/src/agent/contracts.rs
+++ b/crates/aprender-orchestrate/src/agent/contracts.rs
@@ -118,7 +118,7 @@ impl VerificationResult {
 
         for status in self.invariant_status.values() {
             let mark = if status.test_found { "✓" } else { "✗" };
-            let _ = writeln!(out, "  [{mark}] {} — {}", status.id, status.name,);
+            let _ = writeln!(out, "  [{mark}] {} — {}", status.id, status.name);
         }
 
         if !self.missing_bindings.is_empty() {
@@ -152,7 +152,7 @@ pub fn verify_bindings(contract: &ContractFile, known_tests: &[String]) -> Verif
         if found {
             verified += 1;
         } else {
-            missing.push(format!("{}: {} (expected: {})", inv.id, inv.name, inv.test_binding,));
+            missing.push(format!("{}: {} (expected: {})", inv.id, inv.name, inv.test_binding));
         }
 
         status.insert(

--- a/crates/aprender-orchestrate/src/agent/manifest.rs
+++ b/crates/aprender-orchestrate/src/agent/manifest.rs
@@ -136,7 +136,7 @@ impl ModelConfig {
                 .unwrap_or_else(|| PathBuf::from("/tmp"))
                 .join("pacha")
                 .join("models");
-            let filename = format!("{}-{}.gguf", repo.replace('/', "--"), quant,);
+            let filename = format!("{}-{}.gguf", repo.replace('/', "--"), quant);
             return Some(cache_dir.join(filename));
         }
         None

--- a/crates/aprender-orchestrate/src/agent/session.rs
+++ b/crates/aprender-orchestrate/src/agent/session.rs
@@ -82,7 +82,7 @@ impl SessionStore {
     /// Only returns sessions modified within `max_age` (default 24h).
     /// PMAT-165: age filter prevents offering stale sessions.
     pub fn find_recent_for_cwd() -> Option<SessionManifest> {
-        Self::find_recent_for_cwd_within(std::time::Duration::from_secs(24 * 3600))
+        Self::find_recent_for_cwd_within(std::time::Duration::from_hours(24))
     }
 
     /// Find the most recent session for cwd within the given age limit.

--- a/crates/aprender-orchestrate/src/agent/skill.rs
+++ b/crates/aprender-orchestrate/src/agent/skill.rs
@@ -182,10 +182,8 @@ pub fn parse_skill_md(source: &str) -> Result<Skill, SkillError> {
         match key {
             "name" => name = value.to_string(),
             "description" => description = value.to_string(),
-            "when_to_use" | "when-to-use" => {
-                if !value.is_empty() {
-                    when_to_use = Some(value.to_string());
-                }
+            "when_to_use" | "when-to-use" if !value.is_empty() => {
+                when_to_use = Some(value.to_string());
             }
             "allowed-tools" | "allowed_tools" => {
                 allowed_tools = value

--- a/crates/aprender-orchestrate/src/agent/tool/compute.rs
+++ b/crates/aprender-orchestrate/src/agent/tool/compute.rs
@@ -41,7 +41,7 @@ pub struct ComputeTool {
 impl ComputeTool {
     /// Create a new compute tool.
     pub fn new(working_dir: String) -> Self {
-        Self { max_concurrent: 4, task_timeout: Duration::from_secs(300), working_dir }
+        Self { max_concurrent: 4, task_timeout: Duration::from_mins(5), working_dir }
     }
 
     /// Set maximum concurrent tasks.

--- a/crates/aprender-orchestrate/src/agent/tool/inference.rs
+++ b/crates/aprender-orchestrate/src/agent/tool/inference.rs
@@ -90,7 +90,7 @@ impl Tool for InferenceTool {
     }
 
     fn timeout(&self) -> std::time::Duration {
-        std::time::Duration::from_secs(300)
+        std::time::Duration::from_mins(5)
     }
 }
 

--- a/crates/aprender-orchestrate/src/agent/tool/mcp_client.rs
+++ b/crates/aprender-orchestrate/src/agent/tool/mcp_client.rs
@@ -69,7 +69,7 @@ impl McpClientTool {
             description: description.into(),
             input_schema,
             transport,
-            timeout: Duration::from_secs(60),
+            timeout: Duration::from_mins(1),
         }
     }
 

--- a/crates/aprender-orchestrate/src/agent/tool/mcp_server.rs
+++ b/crates/aprender-orchestrate/src/agent/tool/mcp_server.rs
@@ -177,7 +177,7 @@ impl McpHandler for MemoryHandler {
                         for f in &fragments {
                             use std::fmt::Write;
                             let _ =
-                                writeln!(out, "- {} (score: {:.2})", f.content, f.relevance_score,);
+                                writeln!(out, "- {} (score: {:.2})", f.content, f.relevance_score);
                         }
                         ToolResult::success(out)
                     }
@@ -257,7 +257,7 @@ impl McpHandler for RagHandler {
         for (i, r) in truncated.iter().enumerate() {
             use std::fmt::Write;
             let _ =
-                writeln!(out, "{}. [{}] {} (score: {:.3})", i + 1, r.component, r.source, r.score,);
+                writeln!(out, "{}. [{}] {} (score: {:.3})", i + 1, r.component, r.source, r.score);
             let _ = writeln!(out, "   {}", r.content);
         }
         ToolResult::success(out)
@@ -365,7 +365,7 @@ async fn execute_command(command: &str, working_dir: &str, max_bytes: usize) -> 
             if out.status.success() {
                 ToolResult::success(text)
             } else {
-                ToolResult::error(format!("exit {}: {}", out.status.code().unwrap_or(-1), text,))
+                ToolResult::error(format!("exit {}: {}", out.status.code().unwrap_or(-1), text))
             }
         }
         Err(e) => ToolResult::error(format!("exec failed: {e}")),

--- a/crates/aprender-orchestrate/src/agent/tool/mod.rs
+++ b/crates/aprender-orchestrate/src/agent/tool/mod.rs
@@ -111,7 +111,7 @@ pub trait Tool: Send + Sync {
 
     /// Execution timeout (Jidoka: stop on timeout).
     fn timeout(&self) -> Duration {
-        Duration::from_secs(120)
+        Duration::from_mins(2)
     }
 }
 

--- a/crates/aprender-orchestrate/src/agent/tool/rag.rs
+++ b/crates/aprender-orchestrate/src/agent/tool/rag.rs
@@ -70,7 +70,7 @@ impl Tool for RagTool {
     }
 
     fn timeout(&self) -> std::time::Duration {
-        std::time::Duration::from_secs(120)
+        std::time::Duration::from_mins(2)
     }
 }
 

--- a/crates/aprender-orchestrate/src/agent/tool/search.rs
+++ b/crates/aprender-orchestrate/src/agent/tool/search.rs
@@ -120,7 +120,7 @@ impl Tool for GlobTool {
         }
 
         // Sort by modification time (most recent first)
-        results.sort_by(|a, b| b.1.cmp(&a.1));
+        results.sort_by_key(|b| std::cmp::Reverse(b.1));
         results.truncate(MAX_GLOB_RESULTS);
 
         if results.is_empty() {

--- a/crates/aprender-orchestrate/src/analyzer.rs
+++ b/crates/aprender-orchestrate/src/analyzer.rs
@@ -112,7 +112,7 @@ fn detect_languages(path: &Path) -> Result<Vec<LanguageStats>> {
         })
         .collect();
 
-    stats.sort_by(|a, b| b.line_count.cmp(&a.line_count));
+    stats.sort_by_key(|b| std::cmp::Reverse(b.line_count));
 
     Ok(stats)
 }

--- a/crates/aprender-orchestrate/src/bug_hunter/ticket.rs
+++ b/crates/aprender-orchestrate/src/bug_hunter/ticket.rs
@@ -164,26 +164,22 @@ fn parse_section_line<'a>(
     }
 
     match section.to_lowercase().as_str() {
-        "description" | "summary" => {
-            if !trimmed.is_empty() {
-                description_lines.push(trimmed);
-            }
+        "description" | "summary" if !trimmed.is_empty() => {
+            description_lines.push(trimmed);
         }
-        "affected files" | "files" | "paths" | "scope" => {
-            if trimmed.starts_with("- ") || trimmed.starts_with("* ") {
-                let path_str = strip_list_marker(trimmed).trim().trim_matches('`');
-                ticket.affected_paths.push(PathBuf::from(path_str));
-            }
+        "affected files" | "files" | "paths" | "scope"
+            if (trimmed.starts_with("- ") || trimmed.starts_with("* ")) =>
+        {
+            let path_str = strip_list_marker(trimmed).trim().trim_matches('`');
+            ticket.affected_paths.push(PathBuf::from(path_str));
         }
-        "expected behavior" | "expected" => {
-            if !trimmed.is_empty() {
-                ticket.expected_behavior = Some(trimmed.to_string());
-            }
+        "expected behavior" | "expected" if !trimmed.is_empty() => {
+            ticket.expected_behavior = Some(trimmed.to_string());
         }
-        "acceptance criteria" | "criteria" => {
-            if trimmed.starts_with("- ") || trimmed.starts_with("* ") {
-                ticket.acceptance_criteria.push(strip_list_marker(trimmed).to_string());
-            }
+        "acceptance criteria" | "criteria"
+            if (trimmed.starts_with("- ") || trimmed.starts_with("* ")) =>
+        {
+            ticket.acceptance_criteria.push(strip_list_marker(trimmed).to_string());
         }
         "priority" => {
             ticket.priority = parse_priority(trimmed);

--- a/crates/aprender-orchestrate/src/content/emitter.rs
+++ b/crates/aprender-orchestrate/src/content/emitter.rs
@@ -330,7 +330,9 @@ course:
 
                 // Generate module entries
                 for m in 1..=modules {
-                    let week = if weeks > 0 { ((m - 1) / (modules / weeks).max(1)) + 1 } else { 1 };
+                    let week = modules
+                        .checked_div(weeks)
+                        .map_or(1, |per_week| ((m - 1) / per_week.max(1)) + 1);
                     output.push_str(&format!(
                         r"  - id: module_{}
     week: {}

--- a/crates/aprender-orchestrate/src/hf/client.rs
+++ b/crates/aprender-orchestrate/src/hf/client.rs
@@ -31,7 +31,7 @@ impl Default for RateLimitConfig {
     fn default() -> Self {
         Self {
             initial_backoff: Duration::from_secs(1),
-            max_backoff: Duration::from_secs(60),
+            max_backoff: Duration::from_mins(1),
             max_retries: 5,
             multiplier: 2.0,
         }

--- a/crates/aprender-orchestrate/src/hf/hub_client.rs
+++ b/crates/aprender-orchestrate/src/hf/hub_client.rs
@@ -243,7 +243,7 @@ impl ResponseCache {
 
     /// Default cache with 15 minute TTL
     pub fn default_ttl() -> Self {
-        Self::new(Duration::from_secs(15 * 60))
+        Self::new(Duration::from_mins(15))
     }
 
     /// Cache a search result

--- a/crates/aprender-orchestrate/src/oracle/coursera/reflection.rs
+++ b/crates/aprender-orchestrate/src/oracle/coursera/reflection.rs
@@ -111,12 +111,12 @@ fn extract_themes(text: &str) -> Vec<String> {
 
     let top_unigrams: Vec<(String, usize)> = {
         let mut v: Vec<_> = freq.into_iter().filter(|(_, c)| *c >= 3).collect();
-        v.sort_by(|a, b| b.1.cmp(&a.1));
+        v.sort_by_key(|b| std::cmp::Reverse(b.1));
         v.into_iter().take(10).collect()
     };
 
     themes.extend(top_unigrams);
-    themes.sort_by(|a, b| b.1.cmp(&a.1));
+    themes.sort_by_key(|b| std::cmp::Reverse(b.1));
     themes.dedup_by(|a, b| a.0 == b.0);
 
     themes.into_iter().take(5).map(|(t, _)| capitalize_theme(&t)).collect()

--- a/crates/aprender-orchestrate/src/oracle/coursera/vocabulary.rs
+++ b/crates/aprender-orchestrate/src/oracle/coursera/vocabulary.rs
@@ -155,7 +155,7 @@ pub fn extract_vocabulary(transcripts: &[TranscriptInput]) -> Vec<VocabularyEntr
         })
         .collect();
 
-    entries.sort_by(|a, b| b.frequency.cmp(&a.frequency));
+    entries.sort_by_key(|b| std::cmp::Reverse(b.frequency));
     entries
 }
 

--- a/crates/aprender-orchestrate/src/oracle/rag/profiling.rs
+++ b/crates/aprender-orchestrate/src/oracle/rag/profiling.rs
@@ -346,7 +346,7 @@ impl std::fmt::Display for MetricsSummary {
             writeln!(f)?;
             writeln!(f, "Spans:")?;
             for (name, stats) in &self.spans {
-                let avg_us = if stats.count > 0 { stats.total_us / stats.count } else { 0 };
+                let avg_us = stats.total_us.checked_div(stats.count).unwrap_or(0);
                 writeln!(
                     f,
                     "  {}: count={}, avg={:.2}ms, min={:.2}ms, max={:.2}ms",

--- a/crates/aprender-orchestrate/src/oracle/rag/quantization/retriever.rs
+++ b/crates/aprender-orchestrate/src/oracle/rag/quantization/retriever.rs
@@ -111,7 +111,7 @@ impl RescoreRetriever {
             .collect();
 
         // Sort descending by score
-        scores.sort_by(|a, b| b.1.cmp(&a.1));
+        scores.sort_by_key(|b| std::cmp::Reverse(b.1));
         scores.truncate(num_candidates);
 
         scores

--- a/crates/aprender-orchestrate/src/oracle/rag/query_cache.rs
+++ b/crates/aprender-orchestrate/src/oracle/rag/query_cache.rs
@@ -46,7 +46,7 @@ impl QueryPlanCache {
             capacity: cap,
             hits: 0,
             misses: 0,
-            ttl: Duration::from_secs(300), // 5 minutes default
+            ttl: Duration::from_mins(5), // 5 minutes default
         }
     }
 

--- a/crates/aprender-orchestrate/src/oracle/rag/tui.rs
+++ b/crates/aprender-orchestrate/src/oracle/rag/tui.rs
@@ -460,7 +460,7 @@ fn format_bar_segments(filled: usize, width: usize) -> String {
 
 /// Render a horizontal bar
 fn render_bar(value: usize, max: usize, width: usize) -> String {
-    let filled = if max > 0 { (value * width / max).min(width) } else { 0 };
+    let filled = (value * width).checked_div(max).unwrap_or(0).min(width);
     format_bar_segments(filled, width)
 }
 

--- a/crates/aprender-orchestrate/src/recipes/sovereign_deployment.rs
+++ b/crates/aprender-orchestrate/src/recipes/sovereign_deployment.rs
@@ -102,7 +102,7 @@ impl SovereignDeploymentRecipe {
     pub fn sign_artifact(&mut self, artifact_name: impl Into<String>, key_id: impl Into<String>) {
         let name = artifact_name.into();
         // In production, this would actually compute the signature
-        let signature = format!("sig_placeholder_{}", &name);
+        let signature = format!("sig_placeholder_{}", name);
         self.distribution.signatures.push(crate::experiment::ArtifactSignature {
             artifact_name: name,
             algorithm: crate::experiment::SignatureAlgorithm::Ed25519,

--- a/crates/aprender-orchestrate/src/serve/lambda.rs
+++ b/crates/aprender-orchestrate/src/serve/lambda.rs
@@ -546,7 +546,7 @@ impl LambdaClient {
         Self {
             function_arn: function_arn.into(),
             region: region.into(),
-            timeout: Duration::from_secs(60),
+            timeout: Duration::from_mins(1),
         }
     }
 

--- a/crates/aprender-orchestrate/src/serve/router.rs
+++ b/crates/aprender-orchestrate/src/serve/router.rs
@@ -208,7 +208,7 @@ impl SpilloverRouter {
             config,
             metrics,
             last_window: std::sync::RwLock::new(Instant::now()),
-            window_duration: Duration::from_secs(60),
+            window_duration: Duration::from_mins(1),
         }
     }
 

--- a/crates/aprender-orchestrate/src/stack/crates_io/client.rs
+++ b/crates/aprender-orchestrate/src/stack/crates_io/client.rs
@@ -41,7 +41,7 @@ impl CratesIoClient {
             client,
             cache: HashMap::new(),
             persistent_cache: None,
-            cache_ttl: Duration::from_secs(15 * 60), // 15 minutes
+            cache_ttl: Duration::from_mins(15), // 15 minutes
             offline: false,
         }
     }

--- a/crates/aprender-present-core/src/gesture.rs
+++ b/crates/aprender-present-core/src/gesture.rs
@@ -223,10 +223,9 @@ impl GestureRecognizer {
     }
 
     fn on_touch_move(&mut self, id: TouchId, position: Point, pressure: f32) -> Option<Event> {
-        if let Some(touch) = self.touches.get_mut(&id) {
+        {
+            let touch = self.touches.get_mut(&id)?;
             touch.update(position, pressure);
-        } else {
-            return None;
         }
 
         match self.touches.len() {

--- a/crates/aprender-present-core/src/shortcut.rs
+++ b/crates/aprender-present-core/src/shortcut.rs
@@ -401,7 +401,7 @@ impl ShortcutManager {
             .collect();
 
         // Sort by priority (highest first)
-        matches.sort_by(|a, b| b.1.cmp(&a.1));
+        matches.sort_by_key(|b| std::cmp::Reverse(b.1));
 
         // Try handlers in priority order
         for (id, _) in matches {

--- a/crates/aprender-present-terminal/src/compute_block.rs
+++ b/crates/aprender-present-terminal/src/compute_block.rs
@@ -1231,7 +1231,7 @@ impl GpuVramBlock {
     #[must_use]
     pub fn top_consumers(&self, n: usize) -> Vec<&(u32, u64, String)> {
         let mut sorted: Vec<_> = self.per_process.iter().collect();
-        sorted.sort_by(|a, b| b.1.cmp(&a.1));
+        sorted.sort_by_key(|b| std::cmp::Reverse(b.1));
         sorted.into_iter().take(n).collect()
     }
 }

--- a/crates/aprender-present-terminal/src/perf_trace/core.rs
+++ b/crates/aprender-present-terminal/src/perf_trace/core.rs
@@ -620,7 +620,7 @@ impl PerfTracer {
         ];
 
         let mut sorted: Vec<_> = self.stats.iter().collect();
-        sorted.sort_by(|a, b| b.1.total_duration.cmp(&a.1.total_duration));
+        sorted.sort_by_key(|b| std::cmp::Reverse(b.1.total_duration));
 
         for (name, stats) in sorted {
             let avg_us = stats.avg_duration().as_micros();

--- a/crates/aprender-present-terminal/src/widgets/files_panel.rs
+++ b/crates/aprender-present-terminal/src/widgets/files_panel.rs
@@ -182,7 +182,7 @@ impl FilesPanel {
     /// Get sorted entries (by size descending).
     fn sorted_entries(&self) -> Vec<&FileEntry> {
         let mut sorted: Vec<_> = self.entries.iter().collect();
-        sorted.sort_by(|a, b| b.size.cmp(&a.size));
+        sorted.sort_by_key(|b| std::cmp::Reverse(b.size));
         sorted
     }
 

--- a/crates/aprender-present-terminal/src/widgets/gpu_panel.rs
+++ b/crates/aprender-present-terminal/src/widgets/gpu_panel.rs
@@ -364,7 +364,7 @@ impl GpuPanel {
 
         // Sort by VRAM usage
         let mut sorted: Vec<_> = self.processes.iter().collect();
-        sorted.sort_by(|a, b| b.vram_used.cmp(&a.vram_used));
+        sorted.sort_by_key(|b| std::cmp::Reverse(b.vram_used));
 
         for proc in sorted.iter().take(self.max_processes) {
             // Truncate name to fit

--- a/crates/aprender-present-terminal/src/widgets/histogram.rs
+++ b/crates/aprender-present-terminal/src/widgets/histogram.rs
@@ -475,9 +475,7 @@ impl Histogram {
             }
 
             // Draw bar
-            let bar_chars: String = (0..(bar_width.ceil() as usize).max(0))
-                .map(|_| '█')
-                .collect();
+            let bar_chars: String = (0..(bar_width.ceil() as usize)).map(|_| '█').collect();
             if !bar_chars.is_empty() {
                 canvas.draw_text(&bar_chars, Point::new(x, y), &style);
             }

--- a/crates/aprender-present-terminal/src/widgets/info_dense.rs
+++ b/crates/aprender-present-terminal/src/widgets/info_dense.rs
@@ -481,11 +481,7 @@ impl Widget for CoreUtilizationHistogram {
                 if count == 0 {
                     return;
                 }
-                let bar_w = if total > 0 {
-                    (count * bar_max) / total
-                } else {
-                    0
-                };
+                let bar_w = (count * bar_max).checked_div(total).unwrap_or(0);
                 let bar: String = "█".repeat(bar_w);
                 let pad: String = "░".repeat(bar_max - bar_w);
 

--- a/crates/aprender-present-terminal/src/widgets/treemap.rs
+++ b/crates/aprender-present-terminal/src/widgets/treemap.rs
@@ -494,7 +494,7 @@ impl Widget for Treemap {
 
         // Draw rectangles from deepest to shallowest (painter's algorithm)
         let mut sorted_rects: Vec<_> = self.computed_rects.iter().collect();
-        sorted_rects.sort_by(|a, b| b.depth.cmp(&a.depth));
+        sorted_rects.sort_by_key(|b| std::cmp::Reverse(b.depth));
 
         for computed in sorted_rects {
             if computed.rect.width < 1.0 || computed.rect.height < 1.0 {

--- a/crates/aprender-profile/src/decision_export.rs
+++ b/crates/aprender-profile/src/decision_export.rs
@@ -297,7 +297,7 @@ pub fn print_stats(path: &std::path::Path) -> Result<(), String> {
 
     println!("By category:");
     let mut categories: Vec<_> = by_category.into_iter().collect();
-    categories.sort_by(|a, b| b.1.cmp(&a.1));
+    categories.sort_by_key(|b| std::cmp::Reverse(b.1));
     for (category, count) in categories {
         println!("  {category}: {count}");
     }

--- a/crates/aprender-profile/src/function_profiler.rs
+++ b/crates/aprender-profile/src/function_profiler.rs
@@ -140,7 +140,7 @@ impl FunctionProfiler {
 
         // Sort by total time (descending)
         let mut sorted: Vec<_> = self.stats.iter().collect();
-        sorted.sort_by(|a, b| b.1.total_time_us.cmp(&a.1.total_time_us));
+        sorted.sort_by_key(|b| std::cmp::Reverse(b.1.total_time_us));
 
         eprintln!("\n╔════════════════════════════════════════════════════════════════════════════════════════════════════╗");
         eprintln!("║  Function Timing Summary (sorted by total time)                                                   ║");
@@ -154,8 +154,7 @@ impl FunctionProfiler {
 
         for (function, stats) in &sorted {
             let total_seconds = stats.total_time_us as f64 / 1_000_000.0;
-            let avg_us =
-                if stats.syscall_count > 0 { stats.total_time_us / stats.syscall_count } else { 0 };
+            let avg_us = stats.total_time_us.checked_div(stats.syscall_count).unwrap_or(0);
             let avg_seconds = avg_us as f64 / 1_000_000.0;
 
             // Highlight functions with high-latency I/O

--- a/crates/aprender-profile/src/html_output.rs
+++ b/crates/aprender-profile/src/html_output.rs
@@ -228,7 +228,7 @@ impl HtmlOutput {
 
         // Sort by total time (descending)
         let mut sorted_stats: Vec<_> = stats.iter().collect();
-        sorted_stats.sort_by(|a, b| b.1.total_time_us.cmp(&a.1.total_time_us));
+        sorted_stats.sort_by_key(|b| std::cmp::Reverse(b.1.total_time_us));
 
         for (name, stat) in sorted_stats {
             let pct = if total_time > 0 {
@@ -237,7 +237,7 @@ impl HtmlOutput {
                 0.0
             };
 
-            let usecs_per_call = if stat.count > 0 { stat.total_time_us / stat.count } else { 0 };
+            let usecs_per_call = stat.total_time_us.checked_div(stat.count).unwrap_or(0);
 
             let seconds = stat.total_time_us as f64 / 1_000_000.0;
 

--- a/crates/aprender-profile/src/process_tracer.rs
+++ b/crates/aprender-profile/src/process_tracer.rs
@@ -328,7 +328,7 @@ impl SyscallBreakdown {
             ("other", self.other_us),
             ("compute", self.compute_us),
         ];
-        categories.sort_by(|a, b| b.1.cmp(&a.1));
+        categories.sort_by_key(|b| std::cmp::Reverse(b.1));
         categories
     }
 }

--- a/crates/aprender-profile/src/sequence/anomaly.rs
+++ b/crates/aprender-profile/src/sequence/anomaly.rs
@@ -154,7 +154,7 @@ pub fn detect_sequence_anomalies(
     }
 
     // Sort by severity (Critical → High → Medium → Low)
-    anomalies.sort_by(|a, b| b.severity.cmp(&a.severity));
+    anomalies.sort_by_key(|b| std::cmp::Reverse(b.severity));
 
     anomalies
 }

--- a/crates/aprender-profile/src/sequence/ngram.rs
+++ b/crates/aprender-profile/src/sequence/ngram.rs
@@ -66,7 +66,7 @@ pub fn top_ngrams(ngrams: &NGramMap, k: usize) -> Vec<(NGram, usize)> {
         ngrams.iter().map(|(ngram, count)| (ngram.clone(), *count)).collect();
 
     // Sort by frequency (descending)
-    ngram_vec.sort_by(|a, b| b.1.cmp(&a.1));
+    ngram_vec.sort_by_key(|b| std::cmp::Reverse(b.1));
 
     ngram_vec.into_iter().take(k).collect()
 }

--- a/crates/aprender-profile/src/stats.rs
+++ b/crates/aprender-profile/src/stats.rs
@@ -271,7 +271,7 @@ impl StatsTracker {
 
         // Sort by call count
         let mut sorted: Vec<_> = self.stats.iter().collect();
-        sorted.sort_by(|a, b| b.1.count.cmp(&a.1.count));
+        sorted.sort_by_key(|b| std::cmp::Reverse(b.1.count));
 
         for (name, stats) in sorted {
             #[cfg(feature = "otlp")]
@@ -318,7 +318,7 @@ impl StatsTracker {
 
         // Sort by call count (descending)
         let mut sorted: Vec<_> = self.stats.iter().collect();
-        sorted.sort_by(|a, b| b.1.count.cmp(&a.1.count));
+        sorted.sort_by_key(|b| std::cmp::Reverse(b.1.count));
 
         // Print header
         eprintln!("% time     seconds  usecs/call     calls    errors syscall");
@@ -332,8 +332,7 @@ impl StatsTracker {
                 0.0
             };
             let seconds = stats.total_time_us as f64 / 1_000_000.0;
-            let usecs_per_call =
-                if stats.count > 0 { stats.total_time_us / stats.count } else { 0 };
+            let usecs_per_call = stats.total_time_us.checked_div(stats.count).unwrap_or(0);
 
             eprintln!(
                 "{:6.2} {:>11.6} {:>11} {:>9} {:>9} {}",
@@ -349,7 +348,7 @@ impl StatsTracker {
         // Print summary line
         eprintln!("------ ----------- ----------- --------- --------- ----------------");
         let total_seconds = total_time_us as f64 / 1_000_000.0;
-        let avg_usecs = if total_calls > 0 { total_time_us / total_calls } else { 0 };
+        let avg_usecs = total_time_us.checked_div(total_calls).unwrap_or(0);
         eprintln!(
             "100.00 {:>11.6} {:>11} {:>9} {:>9} total",
             total_seconds,

--- a/crates/aprender-profile/src/time_attribution/attribution.rs
+++ b/crates/aprender-profile/src/time_attribution/attribution.rs
@@ -125,7 +125,7 @@ pub fn calculate_time_attribution(
         .collect();
 
     // Sort by time (descending)
-    attributions.sort_by(|a, b| b.total_time.cmp(&a.total_time));
+    attributions.sort_by_key(|b| std::cmp::Reverse(b.total_time));
 
     attributions
 }

--- a/crates/aprender-rag/src/fusion.rs
+++ b/crates/aprender-rag/src/fusion.rs
@@ -167,7 +167,7 @@ impl FusionStrategy {
         }
 
         let mut results: Vec<_> = scores.into_iter().collect();
-        results.sort_by(|a, b| a.1 .1.cmp(&b.1 .1)); // Sort by rank
+        results.sort_by_key(|a| a.1 .1); // Sort by rank
         results.into_iter().map(|(id, (score, _))| (id, score)).collect()
     }
 

--- a/crates/aprender-registry/src/cache.rs
+++ b/crates/aprender-registry/src/cache.rs
@@ -389,11 +389,11 @@ impl EvictionPolicy {
     /// Sort entries by eviction priority (lowest priority first)
     pub fn sort_for_eviction<'a>(&self, entries: &mut [&'a CacheEntry]) {
         match self {
-            Self::LRU => entries.sort_by(|a, b| a.last_accessed.cmp(&b.last_accessed)),
-            Self::LFU => entries.sort_by(|a, b| a.access_count.cmp(&b.access_count)),
-            Self::FIFO => entries.sort_by(|a, b| a.created_at.cmp(&b.created_at)),
-            Self::LargestFirst => entries.sort_by(|a, b| b.size_bytes.cmp(&a.size_bytes)),
-            Self::OldestFirst => entries.sort_by(|a, b| a.created_at.cmp(&b.created_at)),
+            Self::LRU => entries.sort_by_key(|a| a.last_accessed),
+            Self::LFU => entries.sort_by_key(|a| a.access_count),
+            Self::FIFO => entries.sort_by_key(|a| a.created_at),
+            Self::LargestFirst => entries.sort_by_key(|b| std::cmp::Reverse(b.size_bytes)),
+            Self::OldestFirst => entries.sort_by_key(|a| a.created_at),
         }
     }
 }
@@ -621,7 +621,7 @@ impl CacheManager {
     #[must_use]
     pub fn list(&self) -> Vec<&CacheEntry> {
         let mut entries: Vec<_> = self.entries.values().collect();
-        entries.sort_by(|a, b| b.last_accessed.cmp(&a.last_accessed));
+        entries.sort_by_key(|b| std::cmp::Reverse(b.last_accessed));
         entries
     }
 

--- a/crates/aprender-registry/src/catalog.rs
+++ b/crates/aprender-registry/src/catalog.rs
@@ -594,9 +594,9 @@ impl ModelCatalog {
         // Sort
         match query.sort {
             SortOrder::Name => matches.sort_by(|a, b| a.name.cmp(&b.name)),
-            SortOrder::Downloads => matches.sort_by(|a, b| b.downloads.cmp(&a.downloads)),
-            SortOrder::SizeAsc => matches.sort_by(|a, b| a.size_bytes.cmp(&b.size_bytes)),
-            SortOrder::SizeDesc => matches.sort_by(|a, b| b.size_bytes.cmp(&a.size_bytes)),
+            SortOrder::Downloads => matches.sort_by_key(|b| std::cmp::Reverse(b.downloads)),
+            SortOrder::SizeAsc => matches.sort_by_key(|a| a.size_bytes),
+            SortOrder::SizeDesc => matches.sort_by_key(|b| std::cmp::Reverse(b.size_bytes)),
             SortOrder::DateDesc => {
                 matches.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
             }
@@ -604,10 +604,10 @@ impl ModelCatalog {
                 matches.sort_by(|a, b| a.updated_at.cmp(&b.updated_at));
             }
             SortOrder::ParametersAsc => {
-                matches.sort_by(|a, b| a.parameters.cmp(&b.parameters));
+                matches.sort_by_key(|a| a.parameters);
             }
             SortOrder::ParametersDesc => {
-                matches.sort_by(|a, b| b.parameters.cmp(&a.parameters));
+                matches.sort_by_key(|b| std::cmp::Reverse(b.parameters));
             }
         }
 

--- a/crates/aprender-serve/src/api/batch.rs
+++ b/crates/aprender-serve/src/api/batch.rs
@@ -332,7 +332,7 @@ pub async fn generate_handler(
     if state.is_verbose() {
         eprintln!(
             "[VERBOSE] POST /generate prompt={:?} max_tokens={}",
-            &request.prompt.chars().take(50).collect::<String>(),
+            request.prompt.chars().take(50).collect::<String>(),
             request.max_tokens
         );
     }

--- a/crates/aprender-serve/src/api/batch.rs
+++ b/crates/aprender-serve/src/api/batch.rs
@@ -89,6 +89,10 @@ fn generation_err(e: &crate::error::RealizarError) -> ApiErr {
 }
 
 /// Build the quantized engine config shared by `/generate` and `/batch/generate`.
+///
+/// `cancel` is the request's [`CancelToken`] (aprender#2376(3)). It is a required
+/// parameter rather than an `Option` so that a new call site cannot silently
+/// produce a config whose decode loop runs on after the client hangs up.
 fn quantized_config(
     state: &AppState,
     tokenizer: &BPETokenizer,
@@ -96,6 +100,7 @@ fn quantized_config(
     temperature: f32,
     sampling: &QuantizedSampling,
     seed: Option<u64>,
+    cancel: &CancelToken,
 ) -> crate::gguf::QuantizedGenerateConfig {
     use crate::gguf::QuantizedGenerateConfig;
 
@@ -106,6 +111,7 @@ fn quantized_config(
         top_p: sampling.top_p,
         stop_tokens: vec![eos_id(tokenizer, state.model_eos_token_id())],
         trace: state.is_trace_enabled(),
+        cancel: cancel.clone(),
         ..Default::default()
     };
     // Leave the default seed alone when the client did not ask for one, so an
@@ -119,6 +125,7 @@ fn quantized_config(
 fn try_quantized_generate(
     state: &AppState,
     request: &GenerateRequest,
+    cancel: &CancelToken,
 ) -> Result<Option<GenerateResponse>, ApiErr> {
     let quantized_model = match state.quantized_model() {
         Some(m) => m,
@@ -141,6 +148,7 @@ fn try_quantized_generate(
         request.temperature,
         &sampling,
         request.seed,
+        cancel,
     );
 
     // GH-95: Use generate_with_cache for O(n) autoregressive generation.
@@ -229,6 +237,7 @@ async fn try_apr_q4k_generate(
 fn try_apr_generate(
     state: &AppState,
     request: &GenerateRequest,
+    cancel: &CancelToken,
 ) -> Result<Option<GenerateResponse>, ApiErr> {
     use crate::apr_transformer::GenerateConfig;
 
@@ -243,6 +252,7 @@ fn try_apr_generate(
     let gen_config = GenerateConfig {
         max_tokens: request.max_tokens,
         temperature: request.temperature,
+        cancel: cancel.clone(),
         ..Default::default()
     };
 
@@ -268,6 +278,7 @@ fn try_apr_generate(
 fn registry_generate(
     state: &AppState,
     request: &GenerateRequest,
+    cancel: &CancelToken,
 ) -> Result<GenerateResponse, ApiErr> {
     let (model, tokenizer) = state
         .get_model(request.model_id.as_deref())
@@ -290,7 +301,8 @@ fn registry_generate(
 
     let mut config = GenerationConfig::default()
         .with_max_tokens(request.max_tokens)
-        .with_temperature(request.temperature);
+        .with_temperature(request.temperature)
+        .with_cancel(cancel.clone());
     config.strategy = strategy;
     if let Some(seed) = request.seed {
         config = config.with_seed(seed);
@@ -322,8 +334,15 @@ fn registry_generate(
     })
 }
 
+/// `POST /generate`.
+///
+/// `cancel` (aprender#2376(3)) is minted per request by `cancel_on_disconnect` and
+/// reaches every backend's decode loop. When the client goes away, axum drops that
+/// middleware's future, the guard fires, and the loop breaks at its next token
+/// instead of running to `max_tokens` for nobody.
 pub async fn generate_handler(
     State(state): State<AppState>,
+    Extension(cancel): Extension<CancelToken>,
     Json(request): Json<GenerateRequest>,
 ) -> Result<Json<GenerateResponse>, ApiErr> {
     use std::time::Instant;
@@ -338,14 +357,14 @@ pub async fn generate_handler(
     }
 
     #[cfg(feature = "cuda")]
-    if let Some(resp) = try_cuda_generate(&state, &request)? {
+    if let Some(resp) = try_cuda_generate(&state, &request, &cancel)? {
         state
             .metrics
             .record_success(resp.num_generated, start.elapsed());
         return Ok(Json(resp));
     }
 
-    if let Some(resp) = try_quantized_generate(&state, &request)? {
+    if let Some(resp) = try_quantized_generate(&state, &request, &cancel)? {
         state
             .metrics
             .record_success(resp.num_generated, start.elapsed());
@@ -360,14 +379,14 @@ pub async fn generate_handler(
         return Ok(Json(resp));
     }
 
-    if let Some(resp) = try_apr_generate(&state, &request)? {
+    if let Some(resp) = try_apr_generate(&state, &request, &cancel)? {
         state
             .metrics
             .record_success(resp.num_generated, start.elapsed());
         return Ok(Json(resp));
     }
 
-    let resp = registry_generate(&state, &request)?;
+    let resp = registry_generate(&state, &request, &cancel)?;
     state
         .metrics
         .record_success(resp.num_generated, start.elapsed());
@@ -422,6 +441,7 @@ pub async fn batch_tokenize_handler(
 fn try_cuda_batch_generate(
     state: &AppState,
     request: &BatchGenerateRequest,
+    cancel: &CancelToken,
 ) -> Result<Option<Vec<GenerateResponse>>, ApiErr> {
     use crate::gguf::QuantizedGenerateConfig;
 
@@ -441,6 +461,7 @@ fn try_cuda_batch_generate(
         },
         stop_tokens: vec![eos_id(&tokenizer, state.model_eos_token_id())],
         trace: state.is_trace_enabled(),
+        cancel: cancel.clone(),
         ..Default::default()
     };
 
@@ -493,6 +514,7 @@ fn try_cuda_batch_generate(
 fn try_quantized_batch_generate(
     state: &AppState,
     request: &BatchGenerateRequest,
+    cancel: &CancelToken,
 ) -> Result<Option<Vec<GenerateResponse>>, ApiErr> {
     let quantized_model = match state.quantized_model() {
         Some(m) => m,
@@ -513,6 +535,7 @@ fn try_quantized_batch_generate(
         request.temperature,
         &sampling,
         request.seed,
+        cancel,
     );
 
     let mut results = Vec::with_capacity(request.prompts.len());
@@ -538,6 +561,7 @@ fn try_quantized_batch_generate(
 fn try_apr_batch_generate(
     state: &AppState,
     request: &BatchGenerateRequest,
+    cancel: &CancelToken,
 ) -> Result<Option<Vec<GenerateResponse>>, ApiErr> {
     use crate::apr_transformer::GenerateConfig;
 
@@ -550,6 +574,7 @@ fn try_apr_batch_generate(
     let gen_config = GenerateConfig {
         max_tokens: request.max_tokens,
         temperature: request.temperature,
+        cancel: cancel.clone(),
         ..Default::default()
     };
 
@@ -588,6 +613,7 @@ fn try_apr_batch_generate(
 fn registry_batch_generate(
     state: &AppState,
     request: &BatchGenerateRequest,
+    cancel: &CancelToken,
 ) -> Result<Vec<GenerateResponse>, ApiErr> {
     let (model, tokenizer) = state
         .get_model(None)
@@ -607,7 +633,8 @@ fn registry_batch_generate(
 
     let mut config = GenerationConfig::default()
         .with_max_tokens(request.max_tokens)
-        .with_temperature(request.temperature);
+        .with_temperature(request.temperature)
+        .with_cancel(cancel.clone());
     config.strategy = strategy;
     if let Some(seed) = request.seed {
         config = config.with_seed(seed);
@@ -651,8 +678,11 @@ fn registry_batch_generate(
     Ok(results)
 }
 
+/// `POST /batch/generate` and `/realize/batch`. See [`generate_handler`] for how
+/// `cancel` reaches the decode loops (aprender#2376(3)).
 pub async fn batch_generate_handler(
     State(state): State<AppState>,
+    Extension(cancel): Extension<CancelToken>,
     Json(request): Json<BatchGenerateRequest>,
 ) -> Result<Json<BatchGenerateResponse>, ApiErr> {
     if request.prompts.is_empty() {
@@ -663,18 +693,18 @@ pub async fn batch_generate_handler(
     }
 
     #[cfg(feature = "cuda")]
-    if let Some(results) = try_cuda_batch_generate(&state, &request)? {
+    if let Some(results) = try_cuda_batch_generate(&state, &request, &cancel)? {
         return Ok(Json(BatchGenerateResponse { results }));
     }
 
-    if let Some(results) = try_quantized_batch_generate(&state, &request)? {
+    if let Some(results) = try_quantized_batch_generate(&state, &request, &cancel)? {
         return Ok(Json(BatchGenerateResponse { results }));
     }
 
-    if let Some(results) = try_apr_batch_generate(&state, &request)? {
+    if let Some(results) = try_apr_batch_generate(&state, &request, &cancel)? {
         return Ok(Json(BatchGenerateResponse { results }));
     }
 
-    let results = registry_batch_generate(&state, &request)?;
+    let results = registry_batch_generate(&state, &request, &cancel)?;
     Ok(Json(BatchGenerateResponse { results }))
 }

--- a/crates/aprender-serve/src/api/batch_processing.rs
+++ b/crates/aprender-serve/src/api/batch_processing.rs
@@ -48,7 +48,7 @@ async fn process_batch(
         // Send responses
         match results {
             Ok(all_token_ids) => {
-                for (request, token_ids) in batch.drain(..).zip(all_token_ids.into_iter()) {
+                for (request, token_ids) in batch.drain(..).zip(all_token_ids) {
                     let response = ContinuousBatchResponse {
                         token_ids,
                         prompt_len: request.prompt_tokens.len(),

--- a/crates/aprender-serve/src/api/batch_processing.rs
+++ b/crates/aprender-serve/src/api/batch_processing.rs
@@ -408,6 +408,7 @@ pub async fn tokenize_handler(
 fn try_cuda_generate(
     state: &AppState,
     request: &GenerateRequest,
+    cancel: &CancelToken,
 ) -> Result<Option<GenerateResponse>, ApiErr> {
     use crate::gguf::QuantizedGenerateConfig;
 
@@ -429,7 +430,8 @@ fn try_cuda_generate(
         },
         stop_tokens: vec![eos_id(&tokenizer, state.model_eos_token_id())],
         trace: false,
-                ..Default::default()
+        cancel: cancel.clone(),
+        ..Default::default()
     };
 
     let mut cuda_model = cuda_model_lock.write().map_err(|_| {

--- a/crates/aprender-serve/src/api/cancel_scope.rs
+++ b/crates/aprender-serve/src/api/cancel_scope.rs
@@ -1,0 +1,116 @@
+//! The handler half of aprender#2376(3): turn an axum client-disconnect into a
+//! cancellation signal the decode loops can actually observe.
+//!
+//! # Why "axum drops the future" was not already enough
+//!
+//! Every generate handler in this crate calls its backend *synchronously* from
+//! inside its `async fn`:
+//!
+//! ```ignore
+//! pub async fn generate_handler(...) -> ... {
+//!     let generated = model.generate_with_cache(&prompt_ids, &q_config)?; // no .await
+//!     ...
+//! }
+//! ```
+//!
+//! Axum cancels an abandoned request by **dropping the response future**, and a
+//! future can only be dropped while it is suspended at an `.await`. There is no
+//! `.await` anywhere inside a synchronous decode loop, so the task never yielded,
+//! the drop never landed, and generation ran all the way to `max_tokens` for a
+//! client that had already hung up. That is the ~250%-CPU-with-zero-open-
+//! connections symptom in aprender#2376(3).
+//!
+//! # The shape that works
+//!
+//! [`cancel_on_disconnect`] is a `tower` layer over the whole router. Per request
+//! it:
+//!
+//! 1. mints a [`CancelToken`] and puts a clone in the request extensions, so any
+//!    handler can pull it out with `Extension<CancelToken>` and install it on its
+//!    generation config;
+//! 2. holds a [`CancelOnDrop`](crate::generate::CancelOnDrop) guard for the whole
+//!    middleware future — this is the piece axum drops on disconnect; and
+//! 3. runs the inner handler in a **separate task** ([`tokio::spawn`]) and awaits
+//!    its `JoinHandle`.
+//!
+//! Step 3 is not decoration. Awaiting is what gives this future a suspension point
+//! to be dropped at, and running the handler in its own task is what lets the
+//! decode loop still be alive — and therefore still able to observe the flag —
+//! *after* the drop. Dropping a `JoinHandle` detaches its task rather than killing
+//! it, and nothing can preempt a synchronous loop anyway, which is exactly why the
+//! loop has to cooperate by polling.
+//!
+//! Take any one of the three away and the defect returns:
+//!
+//! | Missing | Result |
+//! |---------|--------|
+//! | 1 | The loop polls a token nobody shares — always false. |
+//! | 2 | Nothing ever sets the flag. |
+//! | 3 | No await point; the drop never happens mid-generation. |
+//!
+//! # Panics are preserved
+//!
+//! A panicking handler is re-raised with [`std::panic::resume_unwind`] so hyper
+//! still sees a panic rather than this layer converting it into a 500. Interposing
+//! a task must not change what a completed — or a failing — request returns.
+//!
+//! # Contract
+//!
+//! `contracts/apr-serve-cancellation-v1.yaml`.
+
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+    middleware::Next,
+    response::{IntoResponse, Response},
+    Json,
+};
+
+use crate::generate::CancelToken;
+
+use super::ErrorResponse;
+
+/// Per-request cancellation layer. See the module docs for why all three steps
+/// are load-bearing.
+pub(crate) async fn cancel_on_disconnect(mut request: Request<Body>, next: Next) -> Response {
+    let token = CancelToken::new();
+    request.extensions_mut().insert(token.clone());
+
+    // (2) Lives in THIS future. Dropped when the response is finished *or* when
+    // axum abandons the request because the client went away.
+    let _disconnect_guard = token.cancel_on_drop();
+
+    // (3) The handler outlives this future's drop, so its decode loop is still
+    // running to see the flag the guard just set.
+    let handle = tokio::spawn(async move { next.run(request).await });
+
+    match handle.await {
+        Ok(response) => response,
+        Err(join_err) if join_err.is_panic() => std::panic::resume_unwind(join_err.into_panic()),
+        Err(join_err) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse {
+                error: format!("Request task did not complete: {join_err}"),
+            }),
+        )
+            .into_response(),
+    }
+}
+
+/// The token a handler should install on its generation config.
+///
+/// Handlers take `Extension<CancelToken>`; this exists for the paths that hold a
+/// `Request` rather than running as an extractor-based handler, and for tests that
+/// invoke a handler without going through [`cancel_on_disconnect`].
+#[must_use]
+pub fn request_cancel_token(request: &Request<Body>) -> CancelToken {
+    request
+        .extensions()
+        .get::<CancelToken>()
+        .cloned()
+        .unwrap_or_else(CancelToken::never)
+}
+
+#[cfg(test)]
+#[path = "tests/cancel_scope_2376.rs"]
+mod cancel_scope_2376;

--- a/crates/aprender-serve/src/api/cuda_chat_backend.rs
+++ b/crates/aprender-serve/src/api/cuda_chat_backend.rs
@@ -6,6 +6,7 @@ fn try_safetensors_cuda_backend(
     request: &ChatCompletionRequest,
     request_id: &str,
     start: Instant,
+    cancel: &CancelToken,
 ) -> Option<Response> {
     let model_lock = state.safetensors_cuda_model()?;
     let tokenizer = match require_tokenizer(state) {
@@ -83,6 +84,7 @@ async fn try_cuda_backend(
     request_id: &str,
     trace_level: Option<&str>,
     start: Instant,
+    cancel: &CancelToken,
 ) -> Option<Response> {
     // PMAT-821: config now built by chat_quantized_config (in openai_handlers.rs).
     let ttft_trace = std::env::var("TTFT_TRACE").is_ok();
@@ -112,6 +114,7 @@ async fn try_cuda_backend(
         &tokenizer,
         state.model_eos_token_id(),
         state.should_trace(trace_level),
+        cancel,
     );
     let max_tokens = q_config.max_tokens;
 
@@ -231,6 +234,7 @@ fn try_quantized_backend(
     request_id: &str,
     trace_level: Option<&str>,
     start: Instant,
+    cancel: &CancelToken,
 ) -> Option<Response> {
     // PMAT-821: config now built by chat_quantized_config (in openai_handlers.rs).
     let quantized_model = state.quantized_model()?;
@@ -254,6 +258,7 @@ fn try_quantized_backend(
         &tokenizer,
         state.model_eos_token_id(),
         state.should_trace(trace_level),
+        cancel,
     );
     let max_tokens = q_config.max_tokens;
 
@@ -341,6 +346,7 @@ fn registry_fallback(
     request: &ChatCompletionRequest,
     request_id: &str,
     start: Instant,
+    cancel: &CancelToken,
 ) -> Response {
     let model_id = if request.model == "default" || request.model.is_empty() {
         None
@@ -361,7 +367,7 @@ fn registry_fallback(
 
     let prompt_tokens = prompt_ids.len();
     let prompt: Vec<usize> = prompt_ids.iter().map(|&id| id as usize).collect();
-    let config = build_gen_config(request);
+    let config = build_gen_config(request).with_cancel(cancel.clone());
 
     let generated = match model.generate(&prompt, &config) {
         Ok(g) => g,
@@ -482,6 +488,8 @@ async fn try_apr_q4k_chat_backend(
     trace_level: Option<&str>,
     start: Instant,
 ) -> Option<Response> {
+    // aprender#2376(3): this backend hands the work to the Q4K scheduler thread
+    // rather than decoding here, so there is no in-handler loop to poll.
     use crate::api::apr_q4k_scheduler::AprQ4kRequest;
 
     let q4k_tx = state.apr_q4k_tx()?;
@@ -576,6 +584,7 @@ async fn try_apr_q4k_chat_backend(
 pub async fn openai_chat_completions_handler(
     State(state): State<AppState>,
     headers: HeaderMap,
+    Extension(cancel): Extension<CancelToken>,
     Json(request): Json<ChatCompletionRequest>,
 ) -> Response {
     let start = Instant::now();
@@ -606,24 +615,37 @@ pub async fn openai_chat_completions_handler(
             .as_millis()
     );
 
-    if let Some(r) = try_qwen3_moe_backend(&state, &request, &request_id, start) {
+    if let Some(r) = try_qwen3_moe_backend(&state, &request, &request_id, start, &cancel) {
         return r;
     }
 
     #[cfg(feature = "gpu")]
-    if let Some(r) = try_gpu_backend(&state, &request, &request_id, trace_level.as_deref(), start) {
+    if let Some(r) = try_gpu_backend(
+        &state,
+        &request,
+        &request_id,
+        trace_level.as_deref(),
+        start,
+        &cancel,
+    ) {
         return r;
     }
 
     #[cfg(feature = "gpu")]
-    if let Some(r) =
-        try_cached_backend(&state, &request, &request_id, trace_level.as_deref(), start)
-    {
+    if let Some(r) = try_cached_backend(
+        &state,
+        &request,
+        &request_id,
+        trace_level.as_deref(),
+        start,
+        &cancel,
+    ) {
         return r;
     }
 
     #[cfg(feature = "cuda")]
-    if let Some(r) = try_cuda_backend(&state, &request, &request_id, trace_level.as_deref(), start).await
+    if let Some(r) =
+        try_cuda_backend(&state, &request, &request_id, trace_level.as_deref(), start, &cancel).await
     {
         return r;
     }
@@ -636,17 +658,22 @@ pub async fn openai_chat_completions_handler(
 
     // #169: SafeTensors CUDA backend (format parity)
     #[cfg(feature = "cuda")]
-    if let Some(r) = try_safetensors_cuda_backend(&state, &request, &request_id, start) {
+    if let Some(r) = try_safetensors_cuda_backend(&state, &request, &request_id, start, &cancel) {
         return r;
     }
 
-    if let Some(r) =
-        try_quantized_backend(&state, &request, &request_id, trace_level.as_deref(), start)
-    {
+    if let Some(r) = try_quantized_backend(
+        &state,
+        &request,
+        &request_id,
+        trace_level.as_deref(),
+        start,
+        &cancel,
+    ) {
         return r;
     }
 
-    registry_fallback(&state, &request, &request_id, start)
+    registry_fallback(&state, &request, &request_id, start, &cancel)
 }
 
 /// aprender#1789 Option B: qwen3_moe MoE-aware dispatch for /v1/chat/completions.
@@ -671,6 +698,7 @@ fn try_qwen3_moe_backend(
     request: &ChatCompletionRequest,
     request_id: &str,
     start: Instant,
+    cancel: &CancelToken,
 ) -> Option<Response> {
     use crate::gguf::QuantizedGenerateConfig;
 
@@ -759,6 +787,7 @@ fn try_qwen3_moe_backend(
         repeat_last_n: request.repeat_last_n.unwrap_or(defaults.repeat_last_n),
         seed: request.seed.unwrap_or(defaults.seed),
         stop_tokens,
+        cancel: cancel.clone(),
         ..defaults
     };
 

--- a/crates/aprender-serve/src/api/gpu_completions_handler.rs
+++ b/crates/aprender-serve/src/api/gpu_completions_handler.rs
@@ -23,6 +23,7 @@ fn try_gpu_completions(
     max_tokens: usize,
     temperature: f32,
     start: std::time::Instant,
+    cancel: &CancelToken,
 ) -> Result<Option<CompletionResponse>, RErr> {
     use crate::gpu::GpuGenerateConfig;
 
@@ -54,6 +55,7 @@ fn try_gpu_completions(
         top_k: 1,
         stop_tokens: Vec::new(),
         trace: state.is_trace_enabled(),
+        cancel: cancel.clone(),
     };
 
     let mut gpu_model = gpu_model_lock.write().map_err(|e| {
@@ -117,6 +119,7 @@ fn registry_completions(
     max_tokens: usize,
     temperature: f32,
     start: std::time::Instant,
+    cancel: &CancelToken,
 ) -> Result<CompletionResponse, RErr> {
     let model_id = if request.model == "default" || request.model.is_empty() {
         None
@@ -140,7 +143,8 @@ fn registry_completions(
 
     let mut config = GenerationConfig::default()
         .with_max_tokens(max_tokens)
-        .with_temperature(temperature);
+        .with_temperature(temperature)
+        .with_cancel(cancel.clone());
     if let Some(top_p) = request.top_p {
         config.strategy = SamplingStrategy::TopP { p: top_p as f32 };
     }
@@ -384,12 +388,13 @@ pub(crate) fn completion_sse_response(response: &CompletionResponse) -> axum::re
 /// forget the streaming decision (all of them return a `CompletionResponse`).
 pub async fn openai_completions_handler(
     State(state): State<AppState>,
+    Extension(cancel): Extension<CancelToken>,
     Json(request): Json<CompletionRequest>,
 ) -> Result<axum::response::Response, RErr> {
     use axum::response::IntoResponse;
 
     let stream = request.stream;
-    let completion = completions_inner(state, request).await?;
+    let completion = completions_inner(state, request, cancel).await?;
     Ok(if stream {
         completion_sse_response(&completion)
     } else {
@@ -400,6 +405,7 @@ pub async fn openai_completions_handler(
 async fn completions_inner(
     state: AppState,
     request: CompletionRequest,
+    cancel: CancelToken,
 ) -> Result<CompletionResponse, RErr> {
     let start = std::time::Instant::now();
     let max_tokens = request.max_tokens.unwrap_or(256);
@@ -407,17 +413,21 @@ async fn completions_inner(
 
     #[cfg(feature = "gpu")]
     if let Some(r) =
-        try_cached_completions(&state, &request, max_tokens, temperature, start).await?
+        try_cached_completions(&state, &request, max_tokens, temperature, start, &cancel).await?
     {
         return Ok(r);
     }
 
-    if let Some(r) = try_quantized_completions(&state, &request, max_tokens, temperature, start)? {
+    if let Some(r) =
+        try_quantized_completions(&state, &request, max_tokens, temperature, start, &cancel)?
+    {
         return Ok(r);
     }
 
     #[cfg(feature = "gpu")]
-    if let Some(r) = try_gpu_completions(&state, &request, max_tokens, temperature, start)? {
+    if let Some(r) =
+        try_gpu_completions(&state, &request, max_tokens, temperature, start, &cancel)?
+    {
         return Ok(r);
     }
 
@@ -489,7 +499,7 @@ async fn completions_inner(
         });
     }
 
-    registry_completions(&state, &request, max_tokens, temperature, start)
+    registry_completions(&state, &request, max_tokens, temperature, start, &cancel)
 }
 
 /// realizr#191: Logprobs endpoint for perplexity measurement (F-QUALITY-01).

--- a/crates/aprender-serve/src/api/gpu_handlers.rs
+++ b/crates/aprender-serve/src/api/gpu_handlers.rs
@@ -10,7 +10,7 @@ use axum::{
     extract::State,
     http::StatusCode,
     response::sse::{Event, Sse},
-    Json,
+    Extension, Json,
 };
 use futures::stream::Stream;
 use serde::{Deserialize, Serialize};
@@ -20,7 +20,7 @@ use super::{
     BatchTokenizeRequest, BatchTokenizeResponse, ErrorResponse, GenerateRequest, GenerateResponse,
     ModelsResponse, StreamDoneEvent, StreamTokenEvent, TokenizeRequest, TokenizeResponse,
 };
-use crate::generate::{GenerationConfig, SamplingStrategy};
+use crate::generate::{CancelToken, GenerationConfig, SamplingStrategy};
 use crate::registry::ModelInfo;
 use crate::tokenizer::BPETokenizer;
 

--- a/crates/aprender-serve/src/api/mod.rs
+++ b/crates/aprender-serve/src/api/mod.rs
@@ -49,6 +49,11 @@ use crate::{
     tokenizer::BPETokenizer,
 };
 
+// aprender#2376(3): request-scoped cancellation for the generate handlers.
+mod cancel_scope;
+pub(crate) use cancel_scope::cancel_on_disconnect;
+pub use cancel_scope::request_cancel_token;
+
 // PMAT-802: Extracted handlers
 #[cfg(feature = "cuda")]
 pub mod apr_q4k_scheduler;

--- a/crates/aprender-serve/src/api/ollama_handlers.rs
+++ b/crates/aprender-serve/src/api/ollama_handlers.rs
@@ -22,7 +22,7 @@ use axum::{
     extract::State,
     http::{HeaderMap, StatusCode},
     response::{IntoResponse, Response},
-    Json,
+    Extension, Json,
 };
 use serde::{Deserialize, Serialize};
 
@@ -587,13 +587,16 @@ async fn split_response(resp: Response) -> (StatusCode, axum::body::Bytes) {
 pub async fn ollama_chat_handler(
     State(state): State<AppState>,
     headers: HeaderMap,
+    Extension(cancel): Extension<crate::generate::CancelToken>,
     Json(request): Json<OllamaChatRequest>,
 ) -> Response {
     let model = model_label(&request.model);
     let stream = request.stream;
     let chat_req = to_chat_request(&model, request.messages, &request.options);
 
-    let inner = openai_chat_completions_handler(State(state), headers, Json(chat_req)).await;
+    let inner =
+        openai_chat_completions_handler(State(state), headers, Extension(cancel), Json(chat_req))
+            .await;
     let (status, body) = split_response(inner).await;
     let (content, prompt_tokens, eval_count) = chat_response_to_parts(status, &body);
 
@@ -627,6 +630,7 @@ pub async fn ollama_chat_handler(
 pub async fn ollama_generate_handler(
     State(state): State<AppState>,
     headers: HeaderMap,
+    Extension(cancel): Extension<crate::generate::CancelToken>,
     Json(request): Json<OllamaGenerateRequest>,
 ) -> Response {
     let model = model_label(&request.model);
@@ -645,7 +649,9 @@ pub async fn ollama_generate_handler(
     });
 
     let chat_req = to_chat_request(&model, messages, &request.options);
-    let inner = openai_chat_completions_handler(State(state), headers, Json(chat_req)).await;
+    let inner =
+        openai_chat_completions_handler(State(state), headers, Extension(cancel), Json(chat_req))
+            .await;
     let (status, body) = split_response(inner).await;
     let (content, prompt_tokens, eval_count) = chat_response_to_parts(status, &body);
 

--- a/crates/aprender-serve/src/api/openai_handlers.rs
+++ b/crates/aprender-serve/src/api/openai_handlers.rs
@@ -15,7 +15,7 @@ use axum::{
         sse::{Event, Sse},
         IntoResponse, Response,
     },
-    Json,
+    Extension, Json,
 };
 use futures::stream::Stream;
 
@@ -24,7 +24,7 @@ use super::{
     ChatCompletionChunk, ChatCompletionRequest, ChatCompletionResponse, ChatMessage, ErrorResponse,
     FinishReason, OpenAIModel, OpenAIModelsResponse, Usage,
 };
-use crate::generate::{GenerationConfig, SamplingStrategy};
+use crate::generate::{CancelToken, GenerationConfig, SamplingStrategy};
 use crate::tokenizer::BPETokenizer;
 
 // ============================================================================
@@ -170,11 +170,16 @@ mod pmat760_top_k_tests {
 /// (`chat_gen_params` / `resolve_chat_top_k`).
 ///
 /// Discharges F-CHAT-HANDLER-THREADS-PARAMS-001 in `contracts/openai-compat-v1.yaml`.
+///
+/// `cancel` is the request's cancellation signal (aprender#2376(3)). It is a
+/// required parameter rather than an `Option` so a new chat backend cannot
+/// silently produce a config whose decode loop outlives its client.
 fn chat_quantized_config(
     request: &ChatCompletionRequest,
     tokenizer: &BPETokenizer,
     model_eos: Option<u32>,
     trace: bool,
+    cancel: &crate::generate::CancelToken,
 ) -> crate::gguf::QuantizedGenerateConfig {
     let defaults = crate::gguf::QuantizedGenerateConfig::default();
     let (max_tokens, temperature, eos_token_id) = chat_gen_params(request, tokenizer, model_eos);
@@ -188,6 +193,7 @@ fn chat_quantized_config(
         seed: request.seed.unwrap_or(defaults.seed),
         stop_tokens: vec![eos_token_id],
         trace,
+        cancel: cancel.clone(),
         ..defaults
     }
 }
@@ -243,7 +249,13 @@ mod pmat821_chat_handler_threading_tests {
         // which is orthogonal to top_p but keeps the request realistic.
         request.temperature = Some(0.7);
         let tokenizer = test_tokenizer();
-        let config = chat_quantized_config(&request, &tokenizer, None, false);
+        let config = chat_quantized_config(
+            &request,
+            &tokenizer,
+            None,
+            false,
+            &crate::generate::CancelToken::never(),
+        );
         assert!(
             (config.top_p - 0.5).abs() < f32::EPSILON,
             "handler dropped top_p: expected 0.5, got {}",
@@ -258,7 +270,13 @@ mod pmat821_chat_handler_threading_tests {
         request.repeat_penalty = Some(1.3);
         request.temperature = Some(0.7);
         let tokenizer = test_tokenizer();
-        let config = chat_quantized_config(&request, &tokenizer, None, false);
+        let config = chat_quantized_config(
+            &request,
+            &tokenizer,
+            None,
+            false,
+            &crate::generate::CancelToken::never(),
+        );
         assert!(
             (config.repeat_penalty - 1.3).abs() < f32::EPSILON,
             "handler dropped repeat_penalty: expected 1.3, got {}",
@@ -273,7 +291,13 @@ mod pmat821_chat_handler_threading_tests {
         request.seed = Some(7);
         request.temperature = Some(0.7);
         let tokenizer = test_tokenizer();
-        let config = chat_quantized_config(&request, &tokenizer, None, false);
+        let config = chat_quantized_config(
+            &request,
+            &tokenizer,
+            None,
+            false,
+            &crate::generate::CancelToken::never(),
+        );
         assert_eq!(config.repeat_last_n, 128, "handler dropped repeat_last_n");
         assert_eq!(config.seed, 7, "handler dropped seed");
     }
@@ -286,7 +310,13 @@ mod pmat821_chat_handler_threading_tests {
         let request = base_request();
         let tokenizer = test_tokenizer();
         let defaults = QuantizedGenerateConfig::default();
-        let config = chat_quantized_config(&request, &tokenizer, None, false);
+        let config = chat_quantized_config(
+            &request,
+            &tokenizer,
+            None,
+            false,
+            &crate::generate::CancelToken::never(),
+        );
         assert!(
             (config.top_p - defaults.top_p).abs() < f32::EPSILON,
             "no-param top_p must equal default"
@@ -620,6 +650,7 @@ fn try_gpu_backend(
     request_id: &str,
     trace_level: Option<&str>,
     start: Instant,
+    cancel: &crate::generate::CancelToken,
 ) -> Option<Response> {
     use crate::gpu::GpuGenerateConfig;
 
@@ -646,6 +677,7 @@ fn try_gpu_backend(
         top_k: resolve_chat_top_k(temperature, request.top_k),
         stop_tokens: vec![eos_token_id as usize],
         trace: state.should_trace(trace_level),
+        cancel: cancel.clone(),
     };
 
     let mut model = match gpu_model_lock.write() {
@@ -714,6 +746,7 @@ fn try_cached_backend(
     request_id: &str,
     trace_level: Option<&str>,
     start: Instant,
+    cancel: &crate::generate::CancelToken,
 ) -> Option<Response> {
     use crate::gguf::QuantizedGenerateConfig;
 
@@ -739,6 +772,7 @@ fn try_cached_backend(
         top_k: resolve_chat_top_k(temperature, request.top_k),
         stop_tokens: vec![eos_token_id],
         trace: state.should_trace(trace_level),
+        cancel: cancel.clone(),
         ..Default::default()
     };
 

--- a/crates/aprender-serve/src/api/realize_handlers.rs
+++ b/crates/aprender-serve/src/api/realize_handlers.rs
@@ -4,13 +4,13 @@
 //! Contains context window management and native Realize API endpoints.
 #![allow(unreachable_pub)] // Items re-exported as pub from api/mod.rs
 
-use axum::{extract::State, http::StatusCode, Json};
+use axum::{extract::State, http::StatusCode, Extension, Json};
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "gpu")]
 use super::ContinuousBatchRequest;
 use super::{AppState, ChatMessage, ChoiceCount, ErrorResponse, FinishReason, Usage};
-use crate::generate::{GenerationConfig, SamplingStrategy};
+use crate::generate::{CancelToken, GenerationConfig, SamplingStrategy};
 use crate::registry::ModelInfo;
 
 // ============================================================================

--- a/crates/aprender-serve/src/api/realize_handlers_embed_completion.rs
+++ b/crates/aprender-serve/src/api/realize_handlers_embed_completion.rs
@@ -17,11 +17,10 @@ fn mean_pool_hidden_states(
 ) -> Vec<f32> {
     // Never index past the rows we were actually given: `data` is
     // `[seq_len, hidden_dim]` and the caller's `token_ids` must align with it.
-    let seq_len = if hidden_dim == 0 {
-        0
-    } else {
-        token_ids.len().min(data.len() / hidden_dim)
-    };
+    let seq_len = data
+        .len()
+        .checked_div(hidden_dim)
+        .map_or(0, |rows| token_ids.len().min(rows));
 
     let mut sum = vec![0.0f32; hidden_dim];
     let mut counted = 0usize;

--- a/crates/aprender-serve/src/api/realize_handlers_embed_completion.rs
+++ b/crates/aprender-serve/src/api/realize_handlers_embed_completion.rs
@@ -542,6 +542,7 @@ async fn try_cached_completions(
     max_tokens: usize,
     temperature: f32,
     start: std::time::Instant,
+    cancel: &CancelToken,
 ) -> Result<Option<CompletionResponse>, RErr> {
     use crate::gguf::QuantizedGenerateConfig;
 
@@ -588,7 +589,8 @@ async fn try_cached_completions(
         top_k: if temperature == 0.0 { 1 } else { 40 },
         stop_tokens: Vec::new(),
         trace: state.is_trace_enabled(),
-            ..Default::default()
+        cancel: cancel.clone(),
+        ..Default::default()
     };
 
     // IMP-126: adaptive generation when dispatch_metrics available
@@ -630,6 +632,7 @@ fn try_quantized_completions(
     max_tokens: usize,
     temperature: f32,
     start: std::time::Instant,
+    cancel: &CancelToken,
 ) -> Result<Option<CompletionResponse>, RErr> {
     use crate::gguf::QuantizedGenerateConfig;
 
@@ -660,7 +663,8 @@ fn try_quantized_completions(
         top_k: if temperature == 0.0 { 1 } else { 40 },
         stop_tokens: Vec::new(),
         trace: state.is_trace_enabled(),
-            ..Default::default()
+        cancel: cancel.clone(),
+        ..Default::default()
     };
 
     // aprender#2376(9): a context-budget rejection is a client error (400), not a

--- a/crates/aprender-serve/src/api/router.rs
+++ b/crates/aprender-serve/src/api/router.rs
@@ -283,6 +283,12 @@ pub fn create_router_with_config(state: AppState, config: RouterConfig) -> Route
         }
     });
 
+    // aprender#2376(3): mint a per-request CancelToken, publish it to the handlers
+    // via request extensions, and cancel it when axum drops this request because
+    // the client went away. Applied to the WHOLE router, not just the generate
+    // routes, so a route added later cannot silently opt out of cancellation.
+    router = router.layer(axum::middleware::from_fn(cancel_on_disconnect));
+
     // GH-649: Sanitize axum deserialization errors to avoid leaking internals to clients.
     // Axum returns 422 with raw serde error details by default; replace with a generic message.
     router = router.layer(axum::middleware::from_fn(sanitize_json_rejection));

--- a/crates/aprender-serve/src/api/stream_generate.rs
+++ b/crates/aprender-serve/src/api/stream_generate.rs
@@ -7,6 +7,7 @@
 fn dense_stream_tokens(
     state: &AppState,
     request: &GenerateRequest,
+    cancel: &CancelToken,
 ) -> Result<(Vec<u32>, usize, std::sync::Arc<BPETokenizer>), ApiErr> {
     let (model, tokenizer) = state
         .get_model(request.model_id.as_deref())
@@ -30,7 +31,8 @@ fn dense_stream_tokens(
 
     let mut config = GenerationConfig::default()
         .with_max_tokens(request.max_tokens)
-        .with_temperature(request.temperature);
+        .with_temperature(request.temperature)
+        .with_cancel(cancel.clone());
     config.strategy = strategy;
     if let Some(seed) = request.seed {
         config = config.with_seed(seed);
@@ -69,6 +71,7 @@ fn dense_stream_tokens(
 fn try_quantized_stream_tokens(
     state: &AppState,
     request: &GenerateRequest,
+    cancel: &CancelToken,
 ) -> Result<Option<(Vec<u32>, usize, std::sync::Arc<BPETokenizer>)>, ApiErr> {
     let quantized_model = match state.quantized_model() {
         Some(m) => m,
@@ -91,6 +94,7 @@ fn try_quantized_stream_tokens(
         request.temperature,
         &sampling,
         request.seed,
+        cancel,
     );
 
     let generated = quantized_model
@@ -104,18 +108,25 @@ fn try_quantized_stream_tokens(
 ///
 /// Tries the quantized backend first (the `apr serve run model.gguf` path), then
 /// the dense f32 `Model`.
+///
+/// aprender#2376(3): the whole sequence is generated *before* the SSE stream is
+/// built, so this handler's synchronous decode is exactly the work an abandoned
+/// request used to keep doing. `cancel` (minted per request by
+/// `cancel_on_disconnect`) is installed on the config so the loop stops at its
+/// next token boundary once the client goes away.
 pub async fn stream_generate_handler(
     State(state): State<AppState>,
+    Extension(cancel): Extension<CancelToken>,
     Json(request): Json<GenerateRequest>,
 ) -> Result<Sse<impl Stream<Item = Result<Event, Infallible>>>, (StatusCode, Json<ErrorResponse>)> {
     // NOTE: Streaming via CUDA model uses /v1/chat/completions endpoint with stream=true
     // This handler uses the CPU model path; for GPU streaming use OpenAI-compatible endpoint
 
     let (token_ids, prompt_len, tokenizer_clone) =
-        if let Some(resolved) = try_quantized_stream_tokens(&state, &request)? {
+        if let Some(resolved) = try_quantized_stream_tokens(&state, &request, &cancel)? {
             resolved
         } else {
-            dense_stream_tokens(&state, &request)?
+            dense_stream_tokens(&state, &request, &cancel)?
         };
 
     // Create stream that emits tokens one by one

--- a/crates/aprender-serve/src/api/tests/cancel_scope_2376.rs
+++ b/crates/aprender-serve/src/api/tests/cancel_scope_2376.rs
@@ -1,0 +1,457 @@
+//! Falsifiers for aprender#2376(3) — generation must stop when the client goes.
+//!
+//! Contract: `contracts/apr-serve-cancellation-v1.yaml`.
+//!
+//! # What these assert, and what they refuse to assert
+//!
+//! Every test here asserts on **observed work** — how many tokens a decode loop
+//! actually produced. None of them asserts that a flag was set. "the token was set
+//! to true" is compatible with the loop never reading it, which is exactly the
+//! shipped defect, so a test shaped that way would have passed against 0.63.0.
+//!
+//! Each falsifier also asserts the **converse**: with no cancellation the same call
+//! produces the full `max_tokens` output. Without that, a test could pass because
+//! generation is broken and returns nothing at all.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use tower::util::ServiceExt;
+
+use crate::api::{create_router, request_cancel_token, AppState};
+use crate::generate::CancelToken;
+use crate::layers::{Model, ModelConfig};
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/// A tiny dense model. `Model::generate` here is the real production loop that
+/// `/generate`'s registry backend and `/v1/completions`' CPU fallback run.
+fn tiny_dense_model() -> Model {
+    Model::new(ModelConfig {
+        vocab_size: 16,
+        hidden_dim: 8,
+        num_heads: 2,
+        num_layers: 1,
+        intermediate_dim: 16,
+        eps: 1e-5,
+    })
+    .expect("build tiny dense model")
+}
+
+/// A quantized-only server: what `apr serve run model.gguf` builds.
+#[cfg(feature = "gpu")]
+fn quantized_state() -> AppState {
+    use crate::api::test_helpers::create_test_quantized_model;
+    use crate::gguf::{ArchConstraints, GGUFConfig};
+
+    let config = GGUFConfig {
+        architecture: "llama".to_string(),
+        constraints: ArchConstraints::from_architecture("llama"),
+        hidden_dim: 64,
+        intermediate_dim: 128,
+        num_layers: 2,
+        num_heads: 4,
+        num_kv_heads: 4,
+        vocab_size: 256,
+        context_length: 512,
+        rope_theta: 10000.0,
+        eps: 1e-5,
+        rope_type: 0,
+        explicit_head_dim: None,
+        query_pre_attn_scalar: None,
+        bos_token_id: None,
+        eos_token_id: None,
+    };
+    AppState::with_quantized_model(create_test_quantized_model(&config))
+        .expect("build quantized AppState")
+}
+
+// ---------------------------------------------------------------------------
+// FALSIFY-SERVE-CANCEL-001 — the dense decode loop stops at the cancel point
+// ---------------------------------------------------------------------------
+
+/// The dense `Model::generate` loop must stop within one token of the moment
+/// cancellation is observed, not run on to `max_tokens`.
+///
+/// Pre-fix behaviour: `GenerationConfig` had no `cancel` field and
+/// `layers/model_model.rs::generate` had no poll, so `tokens.len()` was
+/// `prompt + max_tokens` for every input — a cancelled request was
+/// indistinguishable from an uncancelled one.
+#[test]
+fn dense_generation_stops_at_the_cancel_point_not_max_tokens() {
+    use crate::generate::GenerationConfig;
+
+    let model = tiny_dense_model();
+    let prompt = [1_usize, 2];
+    const MAX_TOKENS: usize = 64;
+    const BUDGET: usize = 8;
+
+    // Uncancelled control FIRST: if this does not produce the full budget then the
+    // cancelled assertion below proves nothing (generation could just be broken).
+    let uncancelled = model
+        .generate(
+            &prompt,
+            &GenerationConfig::greedy().with_max_tokens(MAX_TOKENS),
+        )
+        .expect("uncancelled generation");
+    assert_eq!(
+        uncancelled.len(),
+        prompt.len() + MAX_TOKENS,
+        "control: with no cancellation the loop must run the full {MAX_TOKENS}-token budget, \
+         otherwise the cancelled case below is not measuring cancellation"
+    );
+
+    // Cancelled: the token trips after BUDGET polls, and the loop polls once per token.
+    let token = CancelToken::with_budget(BUDGET);
+    let cancelled = model
+        .generate(
+            &prompt,
+            &GenerationConfig::greedy()
+                .with_max_tokens(MAX_TOKENS)
+                .with_cancel(token.clone()),
+        )
+        .expect("cancelled generation still returns what it produced");
+
+    let produced = cancelled.len() - prompt.len();
+    assert_eq!(
+        produced, BUDGET,
+        "generation must stop at the cancel point ({BUDGET} tokens), not run to \
+         max_tokens ({MAX_TOKENS}); it produced {produced}"
+    );
+    assert_eq!(
+        token.polls(),
+        BUDGET + 1,
+        "the loop must poll exactly once per decode step (BUDGET polls that returned \
+         false, plus the one that returned true and broke the loop)"
+    );
+
+    // The cancelled prefix must be the uncancelled prefix: cancelling stops work, it
+    // does not change the tokens that were already produced.
+    assert_eq!(
+        cancelled,
+        uncancelled[..cancelled.len()].to_vec(),
+        "a cancelled run must be a strict prefix of the uncancelled run"
+    );
+}
+
+/// A token cancelled before the first poll must produce **zero** tokens: the loop
+/// polls before doing any work, not after.
+#[test]
+fn dense_generation_cancelled_before_start_produces_no_tokens() {
+    use crate::generate::GenerationConfig;
+
+    let model = tiny_dense_model();
+    let prompt = [1_usize, 2];
+    let token = CancelToken::new();
+    token.cancel();
+
+    let out = model
+        .generate(
+            &prompt,
+            &GenerationConfig::greedy()
+                .with_max_tokens(64)
+                .with_cancel(token),
+        )
+        .expect("an already-cancelled request is not an error");
+
+    assert_eq!(
+        out.len(),
+        prompt.len(),
+        "an already-cancelled request must do no decode work at all; it returned \
+         {} tokens beyond the prompt",
+        out.len() - prompt.len()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// FALSIFY-SERVE-CANCEL-002 — the quantized (GGUF) decode loop stops too
+// ---------------------------------------------------------------------------
+
+/// `OwnedQuantizedModel::generate_with_cache` is the loop behind
+/// `apr serve run model.gguf` on `/generate`, `/stream/generate`,
+/// `/v1/completions` and `/v1/chat/completions`. It must observe cancellation.
+#[test]
+#[cfg(feature = "gpu")]
+fn quantized_generation_stops_at_the_cancel_point_not_max_tokens() {
+    use crate::api::test_helpers::create_test_quantized_model;
+    use crate::gguf::{ArchConstraints, GGUFConfig, QuantizedGenerateConfig};
+
+    let gguf_config = GGUFConfig {
+        architecture: "llama".to_string(),
+        constraints: ArchConstraints::from_architecture("llama"),
+        hidden_dim: 64,
+        intermediate_dim: 128,
+        num_layers: 2,
+        num_heads: 4,
+        num_kv_heads: 4,
+        vocab_size: 256,
+        context_length: 512,
+        rope_theta: 10000.0,
+        eps: 1e-5,
+        rope_type: 0,
+        explicit_head_dim: None,
+        query_pre_attn_scalar: None,
+        bos_token_id: None,
+        eos_token_id: None,
+    };
+    let model = create_test_quantized_model(&gguf_config);
+    let prompt = [3_u32, 4, 5];
+    const MAX_TOKENS: usize = 48;
+    const BUDGET: usize = 6;
+
+    let base = QuantizedGenerateConfig::deterministic(MAX_TOKENS);
+
+    let uncancelled = model
+        .generate_with_cache(&prompt, &base)
+        .expect("uncancelled quantized generation");
+    assert_eq!(
+        uncancelled.len(),
+        prompt.len() + MAX_TOKENS,
+        "control: the quantized loop must run its full {MAX_TOKENS}-token budget when \
+         nothing cancels it"
+    );
+
+    let token = CancelToken::with_budget(BUDGET);
+    let cancelled = model
+        .generate_with_cache(&prompt, &base.clone().with_cancel(token.clone()))
+        .expect("cancelled quantized generation");
+
+    let produced = cancelled.len() - prompt.len();
+    assert_eq!(
+        produced, BUDGET,
+        "the quantized loop must stop at the cancel point ({BUDGET}), not run to \
+         max_tokens ({MAX_TOKENS}); it produced {produced}"
+    );
+    assert_eq!(
+        token.polls(),
+        BUDGET + 1,
+        "the quantized loop must poll exactly once per decode step"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// FALSIFY-SERVE-CANCEL-003 — dropping the response future stops the work
+// ---------------------------------------------------------------------------
+
+/// The mechanism proof. A synchronous loop running under the
+/// `cancel_on_disconnect` layer must **stop early when the layer's future is
+/// dropped** — which is what axum does when a client disconnects.
+///
+/// The assertion is on iterations actually executed by the loop, not on the flag.
+/// Pre-fix, no layer existed, the loop had no token to poll, and the counter here
+/// would reach `BUDGET_CEILING`.
+#[tokio::test]
+async fn dropping_the_request_future_stops_a_running_generation() {
+    use axum::routing::post;
+    use axum::Router;
+
+    /// Ceiling that stands in for `max_tokens`. Reaching it means the loop never
+    /// observed cancellation — the defect.
+    const BUDGET_CEILING: usize = 500_000;
+
+    // How many decode steps the fake loop actually performed.
+    let steps = Arc::new(AtomicUsize::new(0));
+    // Set once the loop has done enough work that we know it is running; the test
+    // drops the request future only after this, so the drop lands mid-decode.
+    let (started_tx, started_rx) = std::sync::mpsc::channel::<()>();
+    let (finished_tx, finished_rx) = std::sync::mpsc::channel::<usize>();
+
+    let steps_for_handler = Arc::clone(&steps);
+    let started = Arc::new(std::sync::Mutex::new(Some(started_tx)));
+    let finished = Arc::new(std::sync::Mutex::new(Some(finished_tx)));
+
+    // A handler shaped exactly like the real ones: it pulls the request's token out
+    // of the extensions and runs a synchronous loop that polls it once per "token".
+    let handler = move |request: Request<Body>| {
+        let steps = Arc::clone(&steps_for_handler);
+        let started = Arc::clone(&started);
+        let finished = Arc::clone(&finished);
+        async move {
+            let cancel = request_cancel_token(&request);
+            tokio::task::spawn_blocking(move || {
+                for i in 0..BUDGET_CEILING {
+                    if cancel.is_cancelled() {
+                        break;
+                    }
+                    steps.store(i + 1, Ordering::SeqCst);
+                    if i == 64 {
+                        if let Some(tx) = started.lock().ok().and_then(|mut g| g.take()) {
+                            let _ = tx.send(());
+                        }
+                    }
+                    // Keep each step cheap but not free, so the drop lands well
+                    // before the ceiling on any machine.
+                    std::hint::spin_loop();
+                    std::thread::yield_now();
+                }
+                if let Some(tx) = finished.lock().ok().and_then(|mut g| g.take()) {
+                    let _ = tx.send(steps.load(Ordering::SeqCst));
+                }
+            });
+            // Never completes: the only way out of this handler is the client
+            // going away, which is the case under test.
+            std::future::pending::<StatusCode>().await
+        }
+    };
+
+    let app = Router::new()
+        .route("/decode", post(handler))
+        .layer(axum::middleware::from_fn(crate::api::cancel_on_disconnect));
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/decode")
+        .body(Body::empty())
+        .expect("build request");
+
+    // Drive the request, then DROP the future — exactly what axum does to an
+    // abandoned request.
+    let mut response_future = Box::pin(app.oneshot(request));
+    let started_rx = tokio::task::spawn_blocking(move || {
+        started_rx
+            .recv_timeout(std::time::Duration::from_secs(10))
+            .map(|()| ())
+    });
+    tokio::select! {
+        _ = &mut response_future => panic!("the handler must not complete on its own"),
+        r = started_rx => r.expect("join").expect("the decode loop must start"),
+    }
+    drop(response_future);
+
+    let observed = tokio::task::spawn_blocking(move || {
+        finished_rx.recv_timeout(std::time::Duration::from_secs(10))
+    })
+    .await
+    .expect("join")
+    .expect("the decode loop must terminate after the request future is dropped");
+
+    assert!(
+        observed < BUDGET_CEILING,
+        "dropping the request future must stop the decode loop; it ran {observed} of \
+         {BUDGET_CEILING} steps, i.e. it never observed cancellation"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// FALSIFY-SERVE-CANCEL-004 — the layer is mounted, and completed requests are
+// byte-for-byte unchanged
+// ---------------------------------------------------------------------------
+
+/// Every route on the real router must receive a live token. A handler that pulls
+/// `CancelToken::never` out of the extensions has no way to stop, so this is the
+/// wiring the other falsifiers depend on.
+#[tokio::test]
+#[cfg(feature = "gpu")]
+async fn the_real_router_hands_every_request_a_live_cancel_token() {
+    // A live token reports its polls; `CancelToken::never` reports 0 forever and
+    // cannot be cancelled. Distinguish them by behaviour, not by name.
+    let observed = Arc::new(std::sync::Mutex::new(None::<CancelToken>));
+    let sink = Arc::clone(&observed);
+
+    let app = axum::Router::new()
+        .route(
+            "/probe",
+            axum::routing::get(move |request: Request<Body>| {
+                let sink = Arc::clone(&sink);
+                async move {
+                    let token = request_cancel_token(&request);
+                    if let Ok(mut g) = sink.lock() {
+                        *g = Some(token);
+                    }
+                    StatusCode::OK
+                }
+            }),
+        )
+        .layer(axum::middleware::from_fn(crate::api::cancel_on_disconnect));
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/probe")
+                .body(Body::empty())
+                .expect("build request"),
+        )
+        .await
+        .expect("probe request");
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let token = observed
+        .lock()
+        .ok()
+        .and_then(|g| g.clone())
+        .expect("handler must have seen a token");
+    assert!(
+        token.peek_cancelled(),
+        "the layer must cancel the token when the response future is dropped; a \
+         `never` token cannot report cancelled, which is how this distinguishes a \
+         live token from a missing one"
+    );
+}
+
+/// Interposing a task and a cancellation layer must not change what a COMPLETED
+/// request returns.
+///
+/// The guard fires on *normal* completion too, and the middleware now runs every
+/// handler in a spawned task. Either could have truncated or reshaped a response.
+/// The baseline is the same handler invoked directly with
+/// [`CancelToken::never`] — i.e. the pre-fix code path — and the two bodies must
+/// be byte-identical.
+#[tokio::test]
+#[cfg(feature = "gpu")]
+async fn a_completed_generate_request_is_unchanged_by_the_cancellation_layer() {
+    use axum::extract::State;
+    use axum::{Extension, Json};
+
+    const BODY: &str = r#"{"prompt":"token5","max_tokens":4}"#;
+
+    // Through the real router, which carries the cancellation layer.
+    let response = create_router(quantized_state())
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/generate")
+                .header("content-type", "application/json")
+                .body(Body::from(BODY))
+                .expect("build request"),
+        )
+        .await
+        .expect("generate request");
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "a normal request must still succeed"
+    );
+    let via_router = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read body");
+    let via_router: serde_json::Value = serde_json::from_slice(&via_router).expect("json body");
+
+    // Baseline: the handler called directly with a token that never cancels —
+    // behaviourally the pre-fix path.
+    let request = serde_json::from_str(BODY).expect("parse request");
+    let baseline = crate::api::generate_handler(
+        State(quantized_state()),
+        Extension(CancelToken::never()),
+        Json(request),
+    )
+    .await;
+    let baseline = match baseline {
+        Ok(Json(resp)) => serde_json::to_value(resp).expect("serialize baseline"),
+        Err((status, Json(err))) => {
+            panic!(
+                "baseline generation must succeed, got {status}: {}",
+                err.error
+            )
+        },
+    };
+
+    assert_eq!(
+        via_router, baseline,
+        "the cancellation layer must not change a completed response; routing it \
+         through the layer produced {via_router} but the direct call produced {baseline}"
+    );
+}

--- a/crates/aprender-serve/src/apr/tokenizer.rs
+++ b/crates/aprender-serve/src/apr/tokenizer.rs
@@ -185,7 +185,7 @@ fn split_by_special_tokens(text: &str, special_tokens: &HashMap<String, u32>) ->
     }
 
     let mut sorted_tokens: Vec<(&String, &u32)> = special_tokens.iter().collect();
-    sorted_tokens.sort_by(|a, b| b.0.len().cmp(&a.0.len()));
+    sorted_tokens.sort_by_key(|b| std::cmp::Reverse(b.0.len()));
 
     let mut segments = Vec::new();
     let mut remaining = text;

--- a/crates/aprender-serve/src/apr_transformer/config.rs
+++ b/crates/aprender-serve/src/apr_transformer/config.rs
@@ -54,13 +54,9 @@ impl AprKVCache {
     pub fn new(config: &AprTransformerConfig) -> Self {
         let num_layers = config.num_layers;
         let num_kv_heads = config.num_kv_heads;
-        let head_dim = config.explicit_head_dim.unwrap_or_else(|| {
-            if config.num_heads > 0 {
-                config.hidden_dim / config.num_heads
-            } else {
-                0
-            }
-        });
+        let head_dim = config
+            .explicit_head_dim
+            .unwrap_or_else(|| config.hidden_dim.checked_div(config.num_heads).unwrap_or(0));
         // N-03 (Meyer DbC): context_length may be 0 if metadata is missing.
         // Apply a safe minimum for KV cache allocation.
         let capacity = if config.context_length > 0 {

--- a/crates/aprender-serve/src/apr_transformer/config.rs
+++ b/crates/aprender-serve/src/apr_transformer/config.rs
@@ -214,6 +214,12 @@ pub struct GenerateConfig {
     /// **Design by Contract**: These come from the model config, not hardcoded.
     /// Empty means no EOS checking (generate until max_tokens).
     pub stop_tokens: Vec<u32>,
+    /// Cooperative cancellation signal, polled once per decode step.
+    ///
+    /// aprender#2376(3). Defaults to
+    /// [`CancelToken::never`](crate::generate::CancelToken::never) — zero-cost,
+    /// never cancels — so every existing caller is unaffected.
+    pub cancel: crate::generate::CancelToken,
 }
 
 impl Default for GenerateConfig {
@@ -226,6 +232,7 @@ impl Default for GenerateConfig {
             repetition_penalty: 1.0,
             trace: false,
             stop_tokens: Vec::new(),
+            cancel: crate::generate::CancelToken::never(),
         }
     }
 }

--- a/crates/aprender-serve/src/apr_transformer/config_apr.rs
+++ b/crates/aprender-serve/src/apr_transformer/config_apr.rs
@@ -145,6 +145,7 @@ mod tests {
             repetition_penalty: 1.1,
             trace: true,
             stop_tokens: vec![],
+            cancel: crate::generate::CancelToken::never(),
         };
         let cloned = config.clone();
         assert_eq!(cloned.max_tokens, 100);

--- a/crates/aprender-serve/src/apr_transformer/generation.rs
+++ b/crates/aprender-serve/src/apr_transformer/generation.rs
@@ -134,6 +134,11 @@ fn generate_next_tokens(
 ) -> Result<()> {
     let mut logits = initial_logits;
     for i in 0..config.max_tokens {
+        // aprender#2376(3): CANCELLATION POLL. The HTTP client may be gone;
+        // stop here instead of burning a core to max_tokens for nobody.
+        if config.cancel.is_cancelled() {
+            break;
+        }
         let next_token = sample_from_logits(&logits, config);
         output.push(next_token);
 
@@ -277,6 +282,11 @@ where
     // Generate tokens with streaming callback
     let mut logits = logits;
     for i in 0..config.max_tokens {
+        // aprender#2376(3): CANCELLATION POLL. The HTTP client may be gone;
+        // stop here instead of burning a core to max_tokens for nobody.
+        if config.cancel.is_cancelled() {
+            break;
+        }
         let next_token = sample_from_logits(&logits, config);
         output.push(next_token);
 
@@ -324,6 +334,7 @@ mod top_p_top_k_tests {
             repetition_penalty: 1.0,
             trace: false,
             stop_tokens: vec![],
+            cancel: crate::generate::CancelToken::never(),
         }
     }
 

--- a/crates/aprender-serve/src/apr_transformer/tests/apr.rs
+++ b/crates/aprender-serve/src/apr_transformer/tests/apr.rs
@@ -261,6 +261,7 @@ fn test_generate_config_greedy() {
         repetition_penalty: 1.0,
         trace: false,
         stop_tokens: vec![],
+        cancel: crate::generate::CancelToken::never(),
     };
     assert_eq!(config.temperature, 0.0);
     assert_eq!(config.top_k, 1);
@@ -276,6 +277,7 @@ fn test_generate_config_with_nucleus_sampling() {
         repetition_penalty: 1.1,
         trace: false,
         stop_tokens: vec![],
+        cancel: crate::generate::CancelToken::never(),
     };
     assert_eq!(config.top_p, 0.9);
 }
@@ -290,6 +292,7 @@ fn test_generate_config_with_trace() {
         repetition_penalty: 1.0,
         trace: true,
         stop_tokens: vec![],
+        cancel: crate::generate::CancelToken::never(),
     };
     assert!(config.trace);
 }

--- a/crates/aprender-serve/src/apr_transformer/tests/benchmark_runner.rs
+++ b/crates/aprender-serve/src/apr_transformer/tests/benchmark_runner.rs
@@ -435,6 +435,7 @@ fn test_generate_with_cache_top_k_sampling() {
         repetition_penalty: 1.0,
         trace: false,
         stop_tokens: vec![],
+        cancel: crate::generate::CancelToken::never(),
     };
 
     let result = transformer.generate_with_cache(&[0, 1], &gen_config);
@@ -454,6 +455,7 @@ fn test_generate_with_cache_top_p_sampling() {
         repetition_penalty: 1.0,
         trace: false,
         stop_tokens: vec![],
+        cancel: crate::generate::CancelToken::never(),
     };
 
     let result = transformer.generate_with_cache(&[0], &gen_config);

--- a/crates/aprender-serve/src/apr_transformer/tests/coverage_generate_config.rs
+++ b/crates/aprender-serve/src/apr_transformer/tests/coverage_generate_config.rs
@@ -9,6 +9,7 @@ fn test_generate_config_custom() {
         repetition_penalty: 1.1,
         trace: false,
         stop_tokens: vec![],
+        cancel: crate::generate::CancelToken::never(),
     };
 
     assert_eq!(config.max_tokens, 100);
@@ -28,6 +29,7 @@ fn test_generate_config_clone() {
         repetition_penalty: 1.2,
         trace: false,
         stop_tokens: vec![],
+        cancel: crate::generate::CancelToken::never(),
     };
 
     let cloned = original.clone();

--- a/crates/aprender-serve/src/apr_transformer/tests/create.rs
+++ b/crates/aprender-serve/src/apr_transformer/tests/create.rs
@@ -364,6 +364,7 @@ fn test_generate_config_custom_values() {
         repetition_penalty: 1.1,
         trace: true,
         stop_tokens: vec![],
+        cancel: crate::generate::CancelToken::never(),
     };
     assert_eq!(config.max_tokens, 64);
     assert!((config.temperature - 1.0).abs() < f32::EPSILON);

--- a/crates/aprender-serve/src/apr_transformer/tests/generate.rs
+++ b/crates/aprender-serve/src/apr_transformer/tests/generate.rs
@@ -12,6 +12,7 @@ fn test_generate_with_cache_repetition_penalty() {
         repetition_penalty: 1.5, // Strong repetition penalty
         trace: false,
         stop_tokens: vec![],
+        cancel: crate::generate::CancelToken::never(),
     };
 
     let result = transformer.generate_with_cache(&[0, 1, 2], &gen_config);

--- a/crates/aprender-serve/src/bench/statistics.rs
+++ b/crates/aprender-serve/src/bench/statistics.rs
@@ -40,7 +40,7 @@ impl Default for MeasurementProtocol {
         Self {
             latency_samples: 100,
             latency_percentiles: vec![50.0, 90.0, 95.0, 99.0, 99.9],
-            throughput_duration: Duration::from_secs(60),
+            throughput_duration: Duration::from_mins(1),
             throughput_ramp_up: Duration::from_secs(10),
             memory_samples: 10,
             memory_interval: Duration::from_secs(1),

--- a/crates/aprender-serve/src/generate/cancel.rs
+++ b/crates/aprender-serve/src/generate/cancel.rs
@@ -1,0 +1,273 @@
+//! Cooperative cancellation for autoregressive generation loops.
+//!
+//! aprender#2376(3): `apr serve` had **no cancellation machinery at all**. Every
+//! decode loop in this crate ran `for _ in 0..max_tokens` with no exit other than
+//! EOS, and every HTTP handler called that loop *synchronously* from inside its
+//! `async fn`. A synchronous call has no `.await` inside it, so the task never
+//! yields while generating — which means axum dropping the response future when the
+//! client goes away cannot interrupt it. One abandoned request therefore kept a core
+//! pinned at ~250% CPU for the remaining life of the process, with zero open
+//! connections.
+//!
+//! Dropping a future only cancels work that is *suspended at an await point*. The
+//! fix is therefore two-sided and both sides are required:
+//!
+//! 1. the decode loop must **poll** a cancellation signal once per token
+//!    ([`CancelToken::is_cancelled`]), and
+//! 2. the handler must run that loop off-task (`spawn_blocking`) while holding a
+//!    [`CancelOnDrop`] guard, so the drop that axum performs on disconnect actually
+//!    reaches the loop.
+//!
+//! Doing only (1) leaves nothing to set the flag. Doing only (2) leaves the flag
+//! set with nobody reading it. See `crates/aprender-serve/src/api/cancel_scope.rs`
+//! for the handler half.
+//!
+//! # Cost when nobody cancels
+//!
+//! [`CancelToken::default`] (== [`CancelToken::never`]) holds `None`, so
+//! `is_cancelled()` is a null check with no atomic and no allocation. Every existing
+//! caller that constructs a config with `..Default::default()` keeps that.
+//!
+//! # Contract
+//!
+//! `contracts/apr-serve-cancellation-v1.yaml`.
+
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::Arc;
+
+/// Shared state behind a live token.
+#[derive(Debug)]
+struct Inner {
+    /// Set by [`CancelToken::cancel`] — e.g. from [`CancelOnDrop`] when axum drops
+    /// the response future.
+    cancelled: AtomicBool,
+    /// How many times [`CancelToken::is_cancelled`] has been called. This is the
+    /// loop's *observed* poll count, which is what lets a falsifier assert the loop
+    /// polls once per token rather than merely trusting that it polls at all.
+    polls: AtomicUsize,
+    /// Poll index at which the token starts reporting cancelled regardless of
+    /// `cancelled` — i.e. a deterministic work budget of `budget` further polls.
+    /// [`usize::MAX`] means "no budget", which is the normal production token.
+    budget: usize,
+}
+
+/// A cooperative cancellation signal read by generation loops.
+///
+/// Cloning is cheap (`Arc` bump) and all clones observe the same state.
+#[derive(Clone, Debug, Default)]
+pub struct CancelToken {
+    inner: Option<Arc<Inner>>,
+}
+
+impl CancelToken {
+    /// A token that can be cancelled.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::with_budget(usize::MAX)
+    }
+
+    /// A token that is never cancelled, allocates nothing, and costs a null check
+    /// per poll. This is the default so that adding a `cancel` field to a config
+    /// struct changes no existing behaviour.
+    #[must_use]
+    pub fn never() -> Self {
+        Self { inner: None }
+    }
+
+    /// A token that reports cancelled once it has been polled `budget` times —
+    /// a deterministic work budget of `budget` decode steps.
+    ///
+    /// This is how the falsifiers cancel *at a known token index* without a sleep,
+    /// a second thread, or any other source of flake: the loop polls once per token,
+    /// so a budget of `n` stops generation after exactly `n` tokens.
+    #[must_use]
+    pub fn with_budget(budget: usize) -> Self {
+        Self {
+            inner: Some(Arc::new(Inner {
+                cancelled: AtomicBool::new(false),
+                polls: AtomicUsize::new(0),
+                budget,
+            })),
+        }
+    }
+
+    /// Request cancellation. Idempotent, and callable from any thread.
+    pub fn cancel(&self) {
+        if let Some(inner) = &self.inner {
+            inner.cancelled.store(true, Ordering::Release);
+        }
+    }
+
+    /// Poll the signal. **Counts as one poll** — see [`CancelToken::polls`].
+    ///
+    /// Generation loops call this once per decode step and `break` when it is true.
+    #[must_use]
+    pub fn is_cancelled(&self) -> bool {
+        match &self.inner {
+            None => false,
+            Some(inner) => {
+                let seen = inner.polls.fetch_add(1, Ordering::Relaxed);
+                inner.cancelled.load(Ordering::Acquire) || seen >= inner.budget
+            },
+        }
+    }
+
+    /// Read the cancelled flag **without** counting a poll or spending budget.
+    ///
+    /// For assertions and for reporting; loops must use [`CancelToken::is_cancelled`].
+    #[must_use]
+    pub fn peek_cancelled(&self) -> bool {
+        match &self.inner {
+            None => false,
+            Some(inner) => inner.cancelled.load(Ordering::Acquire),
+        }
+    }
+
+    /// Number of times [`CancelToken::is_cancelled`] has been called.
+    ///
+    /// A [`CancelToken::never`] token reports 0 because it has no state; that is the
+    /// point — it is the zero-cost variant.
+    #[must_use]
+    pub fn polls(&self) -> usize {
+        match &self.inner {
+            None => 0,
+            Some(inner) => inner.polls.load(Ordering::Relaxed),
+        }
+    }
+
+    /// Arm a guard that cancels this token when it is dropped.
+    ///
+    /// Hold the guard inside the async response future. Axum drops that future when
+    /// the client disconnects, which drops the guard, which sets the flag, which the
+    /// decode loop observes at its next token boundary.
+    #[must_use]
+    pub fn cancel_on_drop(&self) -> CancelOnDrop {
+        CancelOnDrop {
+            token: self.clone(),
+        }
+    }
+}
+
+/// Cancels its [`CancelToken`] on drop.
+///
+/// Firing after generation already finished is harmless — the loop is gone and the
+/// flag is read by nobody — so the guard is deliberately not disarmable. That keeps
+/// the disconnect path from depending on a "did we remember to disarm" branch.
+#[derive(Debug)]
+pub struct CancelOnDrop {
+    token: CancelToken,
+}
+
+impl CancelOnDrop {
+    /// The token this guard will cancel.
+    #[must_use]
+    pub fn token(&self) -> &CancelToken {
+        &self.token
+    }
+}
+
+impl Drop for CancelOnDrop {
+    fn drop(&mut self) {
+        self.token.cancel();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn never_token_is_free_and_never_cancels() {
+        let t = CancelToken::never();
+        t.cancel();
+        assert!(!t.is_cancelled(), "never() must not be cancellable");
+        assert!(!t.peek_cancelled());
+        assert_eq!(t.polls(), 0, "never() must hold no state");
+    }
+
+    #[test]
+    fn default_is_never() {
+        let t = CancelToken::default();
+        t.cancel();
+        assert!(
+            !t.is_cancelled(),
+            "Default must be the zero-cost never() token so adding a cancel field \
+             changes no existing caller's behaviour"
+        );
+    }
+
+    #[test]
+    fn cancel_is_observed_by_clones() {
+        let t = CancelToken::new();
+        let clone = t.clone();
+        assert!(!clone.peek_cancelled());
+        t.cancel();
+        assert!(
+            clone.peek_cancelled(),
+            "clones must share state or a spawn_blocking worker cannot see the guard fire"
+        );
+    }
+
+    #[test]
+    fn polls_counts_only_is_cancelled() {
+        let t = CancelToken::new();
+        assert_eq!(t.polls(), 0);
+        let _ = t.is_cancelled();
+        let _ = t.is_cancelled();
+        assert_eq!(t.polls(), 2);
+        let _ = t.peek_cancelled();
+        assert_eq!(t.polls(), 2, "peek must not consume budget");
+    }
+
+    #[test]
+    fn budget_trips_after_exactly_n_polls() {
+        let t = CancelToken::with_budget(3);
+        assert!(!t.is_cancelled(), "poll 0 within budget");
+        assert!(!t.is_cancelled(), "poll 1 within budget");
+        assert!(!t.is_cancelled(), "poll 2 within budget");
+        assert!(t.is_cancelled(), "poll 3 exhausts a budget of 3");
+        assert!(t.is_cancelled(), "and stays cancelled");
+    }
+
+    #[test]
+    fn zero_budget_trips_immediately() {
+        let t = CancelToken::with_budget(0);
+        assert!(t.is_cancelled(), "a budget of 0 permits no work at all");
+    }
+
+    #[test]
+    fn new_token_has_no_budget() {
+        let t = CancelToken::new();
+        for i in 0..10_000 {
+            assert!(
+                !t.is_cancelled(),
+                "poll {i} must not trip an unbudgeted token"
+            );
+        }
+    }
+
+    #[test]
+    fn guard_cancels_token_on_drop() {
+        let t = CancelToken::new();
+        {
+            let _guard = t.cancel_on_drop();
+            assert!(
+                !t.peek_cancelled(),
+                "the guard must not cancel while it is still alive"
+            );
+        }
+        assert!(
+            t.peek_cancelled(),
+            "dropping the guard is what turns an axum client-disconnect into a stop signal"
+        );
+    }
+
+    #[test]
+    fn guard_exposes_the_token_it_will_cancel() {
+        let t = CancelToken::new();
+        let guard = t.cancel_on_drop();
+        assert!(!guard.token().peek_cancelled());
+        drop(guard);
+        assert!(t.peek_cancelled());
+    }
+}

--- a/crates/aprender-serve/src/generate/mod.rs
+++ b/crates/aprender-serve/src/generate/mod.rs
@@ -18,7 +18,11 @@ use crate::{
 
 // Submodules
 mod algorithms;
+pub mod cancel;
 mod sampler;
+
+// aprender#2376(3): cooperative cancellation for the decode loops.
+pub use cancel::{CancelOnDrop, CancelToken};
 
 // Re-exports from algorithms (unique sampling algorithms)
 pub use algorithms::{
@@ -137,6 +141,11 @@ pub struct GenerationConfig {
     pub eos_token_id: Option<usize>,
     /// Random seed for reproducibility
     pub seed: Option<u64>,
+    /// Cooperative cancellation signal, polled once per decode step.
+    ///
+    /// aprender#2376(3). Defaults to [`CancelToken::never`] — zero-cost, never
+    /// cancels — so every existing caller is unaffected.
+    pub cancel: CancelToken,
 }
 
 impl Default for GenerationConfig {
@@ -147,6 +156,7 @@ impl Default for GenerationConfig {
             temperature: 1.0,
             eos_token_id: None,
             seed: None,
+            cancel: CancelToken::never(),
         }
     }
 }
@@ -204,6 +214,13 @@ impl GenerationConfig {
     #[must_use]
     pub fn with_seed(mut self, seed: u64) -> Self {
         self.seed = Some(seed);
+        self
+    }
+
+    /// Attach a cooperative cancellation signal (aprender#2376(3)).
+    #[must_use]
+    pub fn with_cancel(mut self, cancel: CancelToken) -> Self {
+        self.cancel = cancel;
         self
     }
 }

--- a/crates/aprender-serve/src/gguf/config.rs
+++ b/crates/aprender-serve/src/gguf/config.rs
@@ -574,11 +574,11 @@ impl GGUFConfig {
     #[inline]
     #[must_use]
     pub fn head_dim(&self) -> usize {
-        self.explicit_head_dim.unwrap_or(if self.num_heads > 0 {
-            self.hidden_dim / self.num_heads
-        } else {
-            self.hidden_dim
-        })
+        let derived = self
+            .hidden_dim
+            .checked_div(self.num_heads)
+            .unwrap_or(self.hidden_dim);
+        self.explicit_head_dim.unwrap_or(derived)
     }
 
     /// PMAT-810: Pre-softmax attention scale `1/sqrt(d)`.
@@ -634,11 +634,7 @@ impl GGUFConfig {
         hidden_dim: usize,
         num_heads: usize,
     ) -> Option<usize> {
-        let default_head_dim = if num_heads > 0 {
-            hidden_dim / num_heads
-        } else {
-            hidden_dim
-        };
+        let default_head_dim = hidden_dim.checked_div(num_heads).unwrap_or(hidden_dim);
         model
             .key_length()
             .or_else(|| {

--- a/crates/aprender-serve/src/gguf/cuda/generate_2.rs
+++ b/crates/aprender-serve/src/gguf/cuda/generate_2.rs
@@ -23,6 +23,11 @@ impl OwnedQuantizedModelCuda {
         let mut tokens = prompt.to_vec();
 
         for _ in 0..config.max_tokens {
+            // aprender#2376(3): CANCELLATION POLL. The HTTP client may be gone;
+            // stop here instead of burning a core to max_tokens for nobody.
+            if config.cancel.is_cancelled() {
+                break;
+            }
             let logits = self.forward_cuda(&tokens)?;
 
             // Greedy sampling (temperature=0)
@@ -107,6 +112,11 @@ impl OwnedQuantizedModelCuda {
         let mut last_token = prompt[prompt.len() - 1];
 
         for _ in 0..config.max_tokens {
+            // aprender#2376(3): CANCELLATION POLL. The HTTP client may be gone;
+            // stop here instead of burning a core to max_tokens for nobody.
+            if config.cancel.is_cancelled() {
+                break;
+            }
             let logits = self.forward_single_cuda_with_cache(last_token, &mut cache, position)?;
 
             // Greedy sampling (temperature=0)
@@ -190,6 +200,11 @@ impl OwnedQuantizedModelCuda {
         let mut last_token = prompt[prompt.len() - 1];
 
         for _ in 0..config.max_tokens {
+            // aprender#2376(3): CANCELLATION POLL. The HTTP client may be gone;
+            // stop here instead of burning a core to max_tokens for nobody.
+            if config.cancel.is_cancelled() {
+                break;
+            }
             let logits =
                 self.forward_single_full_cuda_with_cache(last_token, &mut cache, position)?;
 

--- a/crates/aprender-serve/src/gguf/inference/attention_gqa.rs
+++ b/crates/aprender-serve/src/gguf/inference/attention_gqa.rs
@@ -161,11 +161,7 @@ impl OwnedQuantizedModel {
         let q_per_kv = num_heads / num_kv_heads;
 
         // Total sequence length = cached + 1 (current)
-        let cache_len = if kv_dim > 0 {
-            k_cache.len() / kv_dim
-        } else {
-            0
-        };
+        let cache_len = k_cache.len().checked_div(kv_dim).unwrap_or(0);
         let total_len = cache_len + 1;
 
         let mut output = vec![0.0f32; q_dim];
@@ -270,11 +266,7 @@ impl OwnedQuantizedModel {
 
         let q_per_kv = num_heads / num_kv_heads;
 
-        let cache_len = if kv_dim > 0 {
-            k_cache.len() / kv_dim
-        } else {
-            0
-        };
+        let cache_len = k_cache.len().checked_div(kv_dim).unwrap_or(0);
         let total_len = cache_len + 1;
 
         // Zero output buffer
@@ -399,11 +391,7 @@ impl OwnedQuantizedModel {
         let hidden_dim = self.config.hidden_dim;
 
         // Calculate cache length
-        let cache_len = if hidden_dim > 0 {
-            k_cache.len() / hidden_dim
-        } else {
-            0
-        };
+        let cache_len = k_cache.len().checked_div(hidden_dim).unwrap_or(0);
 
         // Threshold for GPU dispatch (matches IMP-119)
         const GPU_CACHE_LEN_THRESHOLD: usize = 64;

--- a/crates/aprender-serve/src/gguf/inference/cached/sync_owned_quantized_02.rs
+++ b/crates/aprender-serve/src/gguf/inference/cached/sync_owned_quantized_02.rs
@@ -86,6 +86,11 @@ impl OwnedQuantizedModelCachedSync {
 
         // Generation loop with batched FFN (PARITY-021: GPU optimization)
         for gen_idx in 0..config.max_tokens {
+            // aprender#2376(3): CANCELLATION POLL. The HTTP client may be gone;
+            // stop here instead of burning a core to max_tokens for nobody.
+            if config.cancel.is_cancelled() {
+                break;
+            }
             // Collect active prompts for this generation step
             let active_indices: Vec<usize> = (0..num_prompts).filter(|&i| !done[i]).collect();
 

--- a/crates/aprender-serve/src/gguf/inference/fails.rs
+++ b/crates/aprender-serve/src/gguf/inference/fails.rs
@@ -51,6 +51,11 @@ impl OwnedQuantizedModel {
         let max_len = prompt.len() + config.max_tokens;
 
         for _ in 0..config.max_tokens {
+            // aprender#2376(3): CANCELLATION POLL. The HTTP client may be gone;
+            // stop here instead of burning a core to max_tokens for nobody.
+            if config.cancel.is_cancelled() {
+                break;
+            }
             // Forward pass with fused Q4_K ops (1.37x faster)
             let logits = self.forward(&tokens)?;
 
@@ -239,6 +244,11 @@ impl OwnedQuantizedModel {
         // Generate new tokens
         // First iteration uses logits from prefill, subsequent use logits from forward pass
         for gen_idx in 0..config.max_tokens {
+            // aprender#2376(3): CANCELLATION POLL. The HTTP client may be gone;
+            // stop here instead of burning a core to max_tokens for nobody.
+            if config.cancel.is_cancelled() {
+                break;
+            }
             let token_start = std::time::Instant::now();
             // DEBUG: Print logits info for first generated token
             if gen_idx == 0 && std::env::var("REALIZAR_DEBUG_LOGITS").is_ok() {
@@ -389,6 +399,11 @@ impl OwnedQuantizedModel {
 
         // Generate new tokens with streaming
         for gen_idx in 0..config.max_tokens {
+            // aprender#2376(3): CANCELLATION POLL. The HTTP client may be gone;
+            // stop here instead of burning a core to max_tokens for nobody.
+            if config.cancel.is_cancelled() {
+                break;
+            }
             let token_start = std::time::Instant::now();
             // Sample next token
             let next_token = if config.temperature == 0.0 || config.top_k == 1 {

--- a/crates/aprender-serve/src/gguf/inference/forward/batch_size.rs
+++ b/crates/aprender-serve/src/gguf/inference/forward/batch_size.rs
@@ -66,6 +66,11 @@ impl OwnedQuantizedModel {
 
         // Generation phase: process all active requests together
         for gen_idx in 0..config.max_tokens {
+            // aprender#2376(3): CANCELLATION POLL. The HTTP client may be gone;
+            // stop here instead of burning a core to max_tokens for nobody.
+            if config.cancel.is_cancelled() {
+                break;
+            }
             // Count active requests
             let active_count = active.iter().filter(|&&a| a).count();
             if active_count == 0 {

--- a/crates/aprender-serve/src/gguf/inference/forward/batched.rs
+++ b/crates/aprender-serve/src/gguf/inference/forward/batched.rs
@@ -332,6 +332,11 @@ impl OwnedQuantizedModel {
 
         // Generate new tokens one at a time (autoregressive)
         for gen_idx in 0..config.max_tokens {
+            // aprender#2376(3): CANCELLATION POLL. The HTTP client may be gone;
+            // stop here instead of burning a core to max_tokens for nobody.
+            if config.cancel.is_cancelled() {
+                break;
+            }
             // PMAT-814: apply repetition penalty in place over the recent context
             // BEFORE both greedy argmax and sampling (no-op when repeat_penalty == 1.0).
             crate::gguf::OwnedQuantizedModel::apply_repeat_penalty(
@@ -410,6 +415,11 @@ impl OwnedQuantizedModel {
 
         // Generate new tokens
         for gen_idx in 0..config.max_tokens {
+            // aprender#2376(3): CANCELLATION POLL. The HTTP client may be gone;
+            // stop here instead of burning a core to max_tokens for nobody.
+            if config.cancel.is_cancelled() {
+                break;
+            }
             let position = prompt.len() + gen_idx;
             let last_token = *tokens.last().ok_or_else(|| RealizarError::InvalidShape {
                 reason: "Token buffer empty during generation".to_string(),

--- a/crates/aprender-serve/src/gguf/inference/forward/encoder_decoder.rs
+++ b/crates/aprender-serve/src/gguf/inference/forward/encoder_decoder.rs
@@ -126,11 +126,7 @@ impl OwnedQuantizedModel {
             // added at embedding time).
 
             // Multi-head bidirectional attention
-            let group_size = if num_kv_heads > 0 {
-                num_heads / num_kv_heads
-            } else {
-                1
-            };
+            let group_size = num_heads.checked_div(num_kv_heads).unwrap_or(1);
 
             for h in 0..num_heads {
                 let kv_h = h / group_size;

--- a/crates/aprender-serve/src/gguf/inference/forward/encoder_decoder_decode.rs
+++ b/crates/aprender-serve/src/gguf/inference/forward/encoder_decoder_decode.rs
@@ -46,7 +46,7 @@ pub fn decode(
 
     let q_dim = num_heads * head_dim;
     let kv_dim_per = num_kv_heads * head_dim;
-    let group_size = if num_kv_heads > 0 { num_heads / num_kv_heads } else { 1 };
+    let group_size = num_heads.checked_div(num_kv_heads).unwrap_or(1);
 
     for layer in self.layers.iter() {
         // === Causal self-attention ===

--- a/crates/aprender-serve/src/gguf/inference/generate_quantized.rs
+++ b/crates/aprender-serve/src/gguf/inference/generate_quantized.rs
@@ -82,6 +82,11 @@ impl OwnedQuantizedModel {
         let mut rng = StdRng::seed_from_u64(config.seed);
 
         for _ in 0..max_tokens {
+            // aprender#2376(3): CANCELLATION POLL. The HTTP client may be gone;
+            // stop here instead of burning a core to max_tokens for nobody.
+            if config.cancel.is_cancelled() {
+                break;
+            }
             // Forward pass with fused Q4_K ops (1.37x faster)
             let mut logits = self.forward(&tokens)?;
 
@@ -364,6 +369,11 @@ impl OwnedQuantizedModel {
         // Generate new tokens
         // First iteration uses logits from prefill, subsequent use logits from forward pass
         for gen_idx in 0..max_tokens {
+            // aprender#2376(3): CANCELLATION POLL. The HTTP client may be gone;
+            // stop here instead of burning a core to max_tokens for nobody.
+            if config.cancel.is_cancelled() {
+                break;
+            }
             let token_start = std::time::Instant::now();
             // DEBUG: Print logits info for first generated token
             if gen_idx == 0 && std::env::var("REALIZAR_DEBUG_LOGITS").is_ok() {
@@ -577,6 +587,11 @@ impl OwnedQuantizedModel {
 
         // Generate new tokens with streaming
         for gen_idx in 0..max_tokens {
+            // aprender#2376(3): CANCELLATION POLL. The HTTP client may be gone;
+            // stop here instead of burning a core to max_tokens for nobody.
+            if config.cancel.is_cancelled() {
+                break;
+            }
             let token_start = std::time::Instant::now();
             // PMAT-814: apply repetition penalty in place over the recent context
             // BEFORE both greedy argmax and sampling (no-op when repeat_penalty == 1.0).

--- a/crates/aprender-serve/src/gguf/inference/generate_scratch.rs
+++ b/crates/aprender-serve/src/gguf/inference/generate_scratch.rs
@@ -76,6 +76,11 @@ impl OwnedQuantizedModel {
         // 1. Sample from current logits (prefill on first iter, previous forward otherwise)
         // 2. Then run forward on the new token to get logits for next iteration
         for gen_idx in 0..config.max_tokens {
+            // aprender#2376(3): CANCELLATION POLL. The HTTP client may be gone;
+            // stop here instead of burning a core to max_tokens for nobody.
+            if config.cancel.is_cancelled() {
+                break;
+            }
             let token_start = std::time::Instant::now();
             // PMAT-814: apply repetition penalty in place over the recent context
             // BEFORE both greedy argmax and sampling (no-op when repeat_penalty == 1.0).
@@ -189,6 +194,11 @@ impl OwnedQuantizedModel {
 
         // Generate new tokens with adaptive attention
         for gen_idx in 0..config.max_tokens {
+            // aprender#2376(3): CANCELLATION POLL. The HTTP client may be gone;
+            // stop here instead of burning a core to max_tokens for nobody.
+            if config.cancel.is_cancelled() {
+                break;
+            }
             let token_start = std::time::Instant::now();
             // PMAT-814: apply repetition penalty in place over the recent context
             // BEFORE both greedy argmax and sampling (no-op when repeat_penalty == 1.0).

--- a/crates/aprender-serve/src/gguf/inference/generate_with.rs
+++ b/crates/aprender-serve/src/gguf/inference/generate_with.rs
@@ -76,6 +76,11 @@ impl OwnedQuantizedModel {
         // 1. Sample from current logits (prefill on first iter, previous forward otherwise)
         // 2. Then run forward on the new token to get logits for next iteration
         for gen_idx in 0..config.max_tokens {
+            // aprender#2376(3): CANCELLATION POLL. The HTTP client may be gone;
+            // stop here instead of burning a core to max_tokens for nobody.
+            if config.cancel.is_cancelled() {
+                break;
+            }
             let token_start = std::time::Instant::now();
             // Sample next token from current logits (prefill logits on first iter)
             let next_token = if config.temperature == 0.0 || config.top_k == 1 {
@@ -181,6 +186,11 @@ impl OwnedQuantizedModel {
 
         // Generate new tokens with adaptive attention
         for gen_idx in 0..config.max_tokens {
+            // aprender#2376(3): CANCELLATION POLL. The HTTP client may be gone;
+            // stop here instead of burning a core to max_tokens for nobody.
+            if config.cancel.is_cancelled() {
+                break;
+            }
             let token_start = std::time::Instant::now();
             // Sample next token from current logits
             let next_token = if config.temperature == 0.0 || config.top_k == 1 {

--- a/crates/aprender-serve/src/gguf/loader_apr_quantized.rs
+++ b/crates/aprender-serve/src/gguf/loader_apr_quantized.rs
@@ -396,8 +396,8 @@ impl OwnedQuantizedModel {
         if let Some(q_tensor) = apr.find_tensor(q_tensor_name).or_else(|| apr.find_tensor(gguf_q_name)) {
             if q_tensor.shape.len() == 2 {
                 let q_out_dim = q_tensor.shape[0];
-                let inferred_head_dim = if config.num_heads > 0 { q_out_dim / config.num_heads } else { 0 };
-                let default_head_dim = if config.num_heads > 0 { hidden_dim / config.num_heads } else { 0 };
+                let inferred_head_dim = q_out_dim.checked_div(config.num_heads).unwrap_or(0);
+                let default_head_dim = hidden_dim.checked_div(config.num_heads).unwrap_or(0);
                 if inferred_head_dim > 0 && inferred_head_dim != default_head_dim {
                     config.explicit_head_dim = Some(inferred_head_dim);
                 }

--- a/crates/aprender-serve/src/gguf/runtime.rs
+++ b/crates/aprender-serve/src/gguf/runtime.rs
@@ -9,6 +9,7 @@
 //! on other complex types, making them easy to extract.
 
 use super::config::GGUFConfig;
+use crate::generate::CancelToken;
 
 // ============================================================================
 // QuantizedGenerateConfig - Generation parameters
@@ -40,6 +41,13 @@ pub struct QuantizedGenerateConfig {
     pub trace: bool,
     /// Return per-token log probabilities (realizr#191, F-QUALITY-01)
     pub logprobs: bool,
+    /// Cooperative cancellation signal, polled once per decode step.
+    ///
+    /// aprender#2376(3): without this, an abandoned HTTP request kept decoding to
+    /// `max_tokens` with the client long gone. Defaults to
+    /// [`CancelToken::never`] — zero-cost, never cancels — so every existing caller
+    /// is unaffected.
+    pub cancel: CancelToken,
 }
 
 impl Default for QuantizedGenerateConfig {
@@ -55,6 +63,7 @@ impl Default for QuantizedGenerateConfig {
             stop_tokens: Vec::new(),
             trace: false,
             logprobs: false,
+            cancel: CancelToken::never(),
         }
     }
 }
@@ -77,6 +86,13 @@ impl QuantizedGenerateConfig {
     #[must_use]
     pub fn with_trace(mut self, trace: bool) -> Self {
         self.trace = trace;
+        self
+    }
+
+    /// Attach a cooperative cancellation signal (aprender#2376(3)).
+    #[must_use]
+    pub fn with_cancel(mut self, cancel: CancelToken) -> Self {
+        self.cancel = cancel;
         self
     }
 

--- a/crates/aprender-serve/src/gpu/mod_max_error_recovery.rs
+++ b/crates/aprender-serve/src/gpu/mod_max_error_recovery.rs
@@ -419,7 +419,7 @@ impl ConnectionConfig {
         Self {
             max_connections: 10,
             min_connections: 1,
-            idle_timeout: Duration::from_secs(300),
+            idle_timeout: Duration::from_mins(5),
         }
     }
 

--- a/crates/aprender-serve/src/gpu/scheduler/forward_block.rs
+++ b/crates/aprender-serve/src/gpu/scheduler/forward_block.rs
@@ -421,6 +421,11 @@ impl GpuModel {
 
         // Generate new tokens
         for _ in 0..config.max_tokens {
+            // aprender#2376(3): CANCELLATION POLL. The HTTP client may be gone;
+            // stop here instead of burning a core to max_tokens for nobody.
+            if config.cancel.is_cancelled() {
+                break;
+            }
             // Sample next token (greedy when temperature=0, otherwise top-k)
             let next_token = if config.temperature == 0.0 || config.top_k == 1 {
                 // Greedy decoding

--- a/crates/aprender-serve/src/gpu/scheduler/from_gguf_config.rs
+++ b/crates/aprender-serve/src/gpu/scheduler/from_gguf_config.rs
@@ -375,6 +375,11 @@ impl GpuModel {
 
         // Generate remaining tokens using optimized incremental forward
         for _ in 1..config.max_tokens {
+            // aprender#2376(3): CANCELLATION POLL. The HTTP client may be gone;
+            // stop here instead of burning a core to max_tokens for nobody.
+            if config.cancel.is_cancelled() {
+                break;
+            }
             let logits = self.forward_gpu_incremental_optimized(next_token, &mut kv_cache)?;
 
             next_token = if config.temperature == 0.0 || config.top_k == 1 {

--- a/crates/aprender-serve/src/gpu/scheduler/kv_forward_block.rs
+++ b/crates/aprender-serve/src/gpu/scheduler/kv_forward_block.rs
@@ -340,6 +340,11 @@ pub fn generate_with_cache(
     tokens.push(next_token);
 
     for _ in 1..config.max_tokens {
+        // aprender#2376(3): CANCELLATION POLL. The HTTP client may be gone;
+        // stop here instead of burning a core to max_tokens for nobody.
+        if config.cancel.is_cancelled() {
+            break;
+        }
         let logits = forward_gpu_incremental(model, next_token, &mut kv_cache)?;
         next_token = sample_token(&logits, config.temperature, config.top_k);
 

--- a/crates/aprender-serve/src/gpu/scheduler/types.rs
+++ b/crates/aprender-serve/src/gpu/scheduler/types.rs
@@ -338,6 +338,12 @@ pub struct GpuGenerateConfig {
     pub stop_tokens: Vec<usize>,
     /// Enable debug tracing (F-COV-95: Added for cli/inference.rs compatibility)
     pub trace: bool,
+    /// Cooperative cancellation signal, polled once per decode step.
+    ///
+    /// aprender#2376(3). Defaults to
+    /// [`CancelToken::never`](crate::generate::CancelToken::never) — zero-cost,
+    /// never cancels — so every existing caller is unaffected.
+    pub cancel: crate::generate::CancelToken,
 }
 
 impl Default for GpuGenerateConfig {
@@ -348,6 +354,7 @@ impl Default for GpuGenerateConfig {
             top_k: 1,
             stop_tokens: Vec::new(),
             trace: false,
+            cancel: crate::generate::CancelToken::never(),
         }
     }
 }
@@ -362,6 +369,7 @@ impl GpuGenerateConfig {
             top_k: 1,
             stop_tokens: Vec::new(),
             trace: false,
+            cancel: crate::generate::CancelToken::never(),
         }
     }
 
@@ -374,6 +382,7 @@ impl GpuGenerateConfig {
             top_k,
             stop_tokens: Vec::new(),
             trace: false,
+            cancel: crate::generate::CancelToken::never(),
         }
     }
 

--- a/crates/aprender-serve/src/inference/kv_cache.rs
+++ b/crates/aprender-serve/src/inference/kv_cache.rs
@@ -177,11 +177,7 @@ pub fn attention_with_cache(
 ) -> Vec<f32> {
     let hidden_dim = q.len();
     let head_dim = hidden_dim / num_heads;
-    let cache_len = if hidden_dim > 0 {
-        k_cache.len() / hidden_dim
-    } else {
-        0
-    };
+    let cache_len = k_cache.len().checked_div(hidden_dim).unwrap_or(0);
     let total_len = cache_len + 1;
     let scale = 1.0 / (head_dim as f32).sqrt();
 
@@ -345,11 +341,7 @@ pub fn attention_with_transposed_v(
 ) -> Vec<f32> {
     let hidden_dim = q.len();
     let head_dim = hidden_dim / num_heads;
-    let cache_len = if hidden_dim > 0 {
-        k_cache.len() / hidden_dim
-    } else {
-        0
-    };
+    let cache_len = k_cache.len().checked_div(hidden_dim).unwrap_or(0);
     let total_len = cache_len + 1;
     let scale = 1.0 / (head_dim as f32).sqrt();
 

--- a/crates/aprender-serve/src/layers/model_model.rs
+++ b/crates/aprender-serve/src/layers/model_model.rs
@@ -160,6 +160,11 @@ impl Model {
         let mut rng_state = config.seed.unwrap_or(42);
 
         for _ in 0..config.max_tokens {
+            // aprender#2376(3): CANCELLATION POLL. The HTTP client may be gone;
+            // stop here instead of burning a core to max_tokens for nobody.
+            if config.cancel.is_cancelled() {
+                break;
+            }
             // Forward pass
             let logits = self.forward(&tokens)?;
 

--- a/crates/aprender-serve/src/quantize/gemv_pool.rs
+++ b/crates/aprender-serve/src/quantize/gemv_pool.rs
@@ -45,8 +45,11 @@ impl GemvPool {
                                     Some((f, od)) => {
                                         // Can't clone Box<dyn Fn>, but we can get a ref
                                         // The Mutex is only locked briefly to read the ptr
-                                        let f_ptr = f.as_ref()
-                                            as *const (dyn Fn(usize, usize) + Send + Sync);
+                                        let f_ptr = std::ptr::from_ref::<
+                                            dyn Fn(usize, usize) + Send + Sync,
+                                        >(
+                                            f.as_ref()
+                                        );
                                         (f_ptr, *od)
                                     },
                                     None => {

--- a/crates/aprender-serve/src/safetensors/inner.rs
+++ b/crates/aprender-serve/src/safetensors/inner.rs
@@ -20,16 +20,12 @@ impl ValidatedAprTransformer {
         let intermediate_dim = config.intermediate_dim;
         // GH-313: Infer head_dim from actual QKV tensor shape when available.
         // Some models (Qwen3-0.6B) have head_dim != hidden_dim/num_heads.
-        let default_head_dim = if config.num_heads > 0 {
-            hidden_dim / config.num_heads
-        } else {
-            hidden_dim
-        };
+        let default_head_dim = hidden_dim.checked_div(config.num_heads).unwrap_or(hidden_dim);
         let head_dim = if !transformer.layers.is_empty() {
             let qkv_len = transformer.layers[0].qkv_weight.len();
             // qkv_weight has (q_dim + 2*kv_dim) * hidden_dim elements
             // Try to infer: qkv_out_dim = qkv_len / hidden_dim
-            let qkv_out_dim_inferred = if hidden_dim > 0 { qkv_len / hidden_dim } else { 0 };
+            let qkv_out_dim_inferred = qkv_len.checked_div(hidden_dim).unwrap_or(0);
             // q_dim = qkv_out_dim - 2*kv_dim. With GQA: kv_dim = num_kv_heads * head_dim
             // qkv_out_dim = num_heads*hd + 2*num_kv_heads*hd = hd*(num_heads + 2*num_kv_heads)
             let total_heads = config.num_heads + 2 * config.num_kv_heads;

--- a/crates/aprender-serve/src/safetensors/safetensors_parser.rs
+++ b/crates/aprender-serve/src/safetensors/safetensors_parser.rs
@@ -517,7 +517,7 @@ impl SafetensorsConfig {
         self.head_dim.or_else(|| {
             let hidden = self.hidden_size?;
             let heads = self.num_attention_heads?;
-            if heads > 0 { Some(hidden / heads) } else { None }
+            hidden.checked_div(heads)
         })
     }
 

--- a/crates/aprender-serve/src/warmup.rs
+++ b/crates/aprender-serve/src/warmup.rs
@@ -65,7 +65,7 @@ impl Default for WarmupConfig {
     fn default() -> Self {
         Self {
             warmup_iterations: 3,
-            timeout: Duration::from_secs(60),
+            timeout: Duration::from_mins(1),
             sample_prompt: "Hello, world!".to_string(),
             sample_max_tokens: 10,
             validate_output: true,

--- a/crates/aprender-serve/tests/apr_coverage.rs
+++ b/crates/aprender-serve/tests/apr_coverage.rs
@@ -1462,6 +1462,7 @@ fn test_generate_config_custom() {
         repetition_penalty: 1.2,
         trace: false,
         stop_tokens: vec![],
+        cancel: realizar::generate::CancelToken::never(),
     };
     assert_eq!(config.max_tokens, 100);
     assert!((config.temperature - 0.7).abs() < 0.001);

--- a/crates/aprender-serve/tests/apr_transformer_coverage.rs
+++ b/crates/aprender-serve/tests/apr_transformer_coverage.rs
@@ -506,6 +506,7 @@ fn test_generate_config_custom_values() {
         repetition_penalty: 1.2,
         trace: false,
         stop_tokens: vec![],
+        cancel: realizar::generate::CancelToken::never(),
     };
     assert_eq!(config.max_tokens, 100);
     assert!((config.temperature - 0.5).abs() < f32::EPSILON);

--- a/crates/aprender-serve/tests/apr_transformer_deep_coverage.rs
+++ b/crates/aprender-serve/tests/apr_transformer_deep_coverage.rs
@@ -512,6 +512,7 @@ fn test_generate_config_clone() {
         repetition_penalty: 1.2,
         trace: false,
         stop_tokens: vec![],
+        cancel: realizar::generate::CancelToken::never(),
     };
     let cloned = config.clone();
     assert_eq!(config.max_tokens, cloned.max_tokens);

--- a/crates/aprender-serve/tests/pipeline_fuzz.rs
+++ b/crates/aprender-serve/tests/pipeline_fuzz.rs
@@ -82,6 +82,7 @@ proptest! {
             temperature: 1.0,
             eos_token_id: None,
             seed: Some(42),
+            cancel: realizar::generate::CancelToken::never(),
         };
 
         let result = model.generate(&prompt, &gen_config);
@@ -326,6 +327,7 @@ fn test_greedy_sampling_deterministic() {
         temperature: 1.0,
         eos_token_id: None,
         seed: None,
+        cancel: realizar::generate::CancelToken::never(),
     };
 
     let result1 = model.generate(&prompt, &gen_config).expect("gen1");
@@ -355,6 +357,7 @@ fn test_different_sampling_strategies() {
             temperature: 1.0,
             eos_token_id: None,
             seed: Some(42),
+            cancel: realizar::generate::CancelToken::never(),
         };
 
         let result = model.generate(&prompt, &gen_config);

--- a/crates/aprender-train-distill/src/lib.rs
+++ b/crates/aprender-train-distill/src/lib.rs
@@ -90,11 +90,10 @@ impl MemoryEstimate {
         let target_memory = (available_vram as f64 * 0.8) as u64;
         let per_sample = (seq_len * hidden_dim * 32 * 2) as u64;
         let available_for_activations = target_memory.saturating_sub(model_bytes + optimizer_bytes);
-        let recommended_batch_size = if per_sample > 0 {
-            (available_for_activations / per_sample).max(1) as usize
-        } else {
-            1
-        };
+        let recommended_batch_size = available_for_activations
+            .checked_div(per_sample)
+            .unwrap_or(1)
+            .max(1) as usize;
 
         Self {
             model_bytes,

--- a/crates/aprender-train/src/finetune/classify_eval_report.rs
+++ b/crates/aprender-train/src/finetune/classify_eval_report.rs
@@ -450,7 +450,7 @@ impl ClassifyEvalReport {
                 }
             }
         }
-        pairs.sort_by(|a, b| b.2.cmp(&a.2));
+        pairs.sort_by_key(|b| std::cmp::Reverse(b.2));
         pairs.truncate(top_n);
         pairs
     }
@@ -959,7 +959,7 @@ impl ClassifyEvalReport {
             if count > 0 {
                 let lo = i as f64 * 0.1;
                 let hi = lo + 0.1;
-                out.push_str(&format!("[{lo:.1}-{hi:.1})   {conf:.3}   {acc:.3}   {count:>5}\n",));
+                out.push_str(&format!("[{lo:.1}-{hi:.1})   {conf:.3}   {acc:.3}   {count:>5}\n"));
             }
         }
         out.push_str("```\n\n");

--- a/crates/aprender-train/src/monitor/report/analyzer.rs
+++ b/crates/aprender-train/src/monitor/report/analyzer.rs
@@ -71,7 +71,7 @@ impl HanseiAnalyzer {
         self.check_missing_metrics(&summary, &mut issues);
 
         // Sort issues by severity (critical first)
-        issues.sort_by(|a, b| b.severity.cmp(&a.severity));
+        issues.sort_by_key(|b| std::cmp::Reverse(b.severity));
 
         PostTrainingReport {
             training_id: training_id.to_string(),

--- a/crates/aprender-train/src/prune/schedule/gradual/mod.rs
+++ b/crates/aprender-train/src/prune/schedule/gradual/mod.rs
@@ -48,10 +48,14 @@ impl PruningSchedule {
         end_step: usize,
         frequency: usize,
     ) -> usize {
-        if frequency == 0 {
-            1
-        } else {
-            (end_step - start_step) / frequency + 1
+        // NonZeroUsize rather than `checked_div`: it keeps `end_step - start_step`
+        // inside the divisor-is-nonzero branch, exactly as the original
+        // `if frequency == 0 { 1 } else { ... }` did. `checked_div` would hoist
+        // the subtraction out and underflow on end_step < start_step, which
+        // `gradual_validate` rejects but this fn does not re-check.
+        match std::num::NonZeroUsize::new(frequency) {
+            None => 1,
+            Some(f) => (end_step - start_step) / f + 1,
         }
     }
 

--- a/crates/aprender-train/src/quality/failure/analysis.rs
+++ b/crates/aprender-train/src/quality/failure/analysis.rs
@@ -24,7 +24,7 @@ impl ParetoAnalysis {
         }
 
         let mut categories: Vec<(FailureCategory, u32)> = counts.into_iter().collect();
-        categories.sort_by(|a, b| b.1.cmp(&a.1)); // Sort descending by count
+        categories.sort_by_key(|b| std::cmp::Reverse(b.1)); // Sort descending by count
 
         Self { categories, total_failures: failures.len() as u32 }
     }

--- a/crates/aprender-train/src/tokenizer/char.rs
+++ b/crates/aprender-train/src/tokenizer/char.rs
@@ -40,7 +40,7 @@ impl Tokenizer for CharTokenizer {
 
         // Sort by frequency and take top vocab_size
         let mut chars: Vec<_> = char_counts.into_iter().collect();
-        chars.sort_by(|a, b| b.1.cmp(&a.1));
+        chars.sort_by_key(|b| std::cmp::Reverse(b.1));
 
         for (c, count) in chars.into_iter().take(self.config.vocab_size) {
             if count >= self.config.min_frequency {

--- a/crates/aprender-train/src/train/tui/refresh.rs
+++ b/crates/aprender-train/src/train/tui/refresh.rs
@@ -23,7 +23,7 @@ impl Default for RefreshPolicy {
     fn default() -> Self {
         Self {
             min_interval: Duration::from_millis(50),
-            max_interval: Duration::from_millis(1000),
+            max_interval: Duration::from_secs(1),
             step_interval: 10,
             last_refresh: Instant::now(),
             last_step: 0,

--- a/crates/aprender-train/src/transformer/attention.rs
+++ b/crates/aprender-train/src/transformer/attention.rs
@@ -924,29 +924,17 @@ impl MultiHeadAttention {
                 self.w_o = value;
                 true
             }
-            "self_attn.q_proj.bias" => {
-                if self.b_q.is_some() {
-                    self.b_q = Some(value);
-                    true
-                } else {
-                    false
-                }
+            "self_attn.q_proj.bias" if self.b_q.is_some() => {
+                self.b_q = Some(value);
+                true
             }
-            "self_attn.k_proj.bias" => {
-                if self.b_k.is_some() {
-                    self.b_k = Some(value);
-                    true
-                } else {
-                    false
-                }
+            "self_attn.k_proj.bias" if self.b_k.is_some() => {
+                self.b_k = Some(value);
+                true
             }
-            "self_attn.v_proj.bias" => {
-                if self.b_v.is_some() {
-                    self.b_v = Some(value);
-                    true
-                } else {
-                    false
-                }
+            "self_attn.v_proj.bias" if self.b_v.is_some() => {
+                self.b_v = Some(value);
+                true
             }
             _ => false,
         }

--- a/docs/BEATS.md
+++ b/docs/BEATS.md
@@ -23,6 +23,12 @@ showing apr ≥ the incumbent on the incumbent's own canonical task (PMAT-741).
 > theater). Verified 2026-06-14: NF4 / LoRA-merge / fail-closed each fail under a
 > targeted mutation; autograd fails by construction (pinned-reference tolerance). See
 > `evidence/beats-adversarial-verification-2026-06-14/findings.md`.
+>
+> **Withdrawal rule:** a beat whose re-measurement no longer supports the claim is
+> **withdrawn from the scoreboard and recorded**, never quietly downgraded or
+> deleted. Under-claiming is as much a reporting failure as over-claiming, so a
+> withdrawal cites the numbers that replaced the claim. See
+> [Withdrawn beats](#withdrawn-beats).
 
 ## Speed scoreboard (evidence-backed, sourced)
 
@@ -31,7 +37,6 @@ contract (status: `enforced`) or in-repo evidence:
 
 | Speed win | Result | Source (contract / evidence) |
 |-----------|--------|------------------------------|
-| **GPU decode vs Ollama** (headline) | apr **1.371× faster** median (412.3 vs 300.7 tok/s; worst single run 1.230×), qwen2.5-coder-1.5b Q4_K_M, RTX 4090, same GGUF/host | `beat-ollama-decode-throughput-speed-v1.yaml` (ENFORCED, gate ≥1.10×) · `crates/aprender-serve/tests/beat_ollama_decode_throughput_speed.rs` |
 | **Cold-start vs sklearn** (static binary, no Python import) | apr **~528× faster** end-to-end (ratio 0.0019) | `beat-sklearn-coldstart-speed-v1.yaml` · `crates/aprender-core/tests/beat_sklearn_coldstart_speed.rs` |
 | **Cold-start vs PyTorch** | apr **~1500× faster** (ratio 0.0007) | `beat-pytorch-coldstart-speed-v1.yaml` · `crates/aprender-core/tests/beat_pytorch_coldstart_speed.rs` |
 | **Cold-start vs HF transformers** (inference import) | apr **~1388× faster** (ratio 0.0007) | `beat-hf-inference-coldstart-speed-v1.yaml` · `crates/aprender-core/tests/beat_hf_inference_coldstart_speed.rs` |
@@ -47,11 +52,17 @@ contract (status: `enforced`) or in-repo evidence:
 | **trueno SIMD dot product** | AVX-512 **6–17× faster** / AVX2 **10–12× faster** than scalar | `crates/aprender-compute/AVX512_COMPUTE_BOUND_VALIDATION.md` |
 | **Deploy footprint vs PyTorch** | apr **53.9 MiB** static binary, **15.8–17.1× smaller** than torch ~853–921 MiB | `beat-pytorch-deploy-footprint-v1.yaml` |
 
+apr is at measured **parity** — not a win, not a loss — in this case:
+
+| Parity (no win claimed) | Result | Source (contract / evidence) |
+|-------------------------|--------|------------------------------|
+| **GPU decode vs Ollama** | apr **1.015–1.109×** ollama on RTX 4090 sm_89 (three post-#2323 medians: 1.109 / 1.042 / 1.015). Inside measurement noise — apr does **not** currently win GPU decode vs ollama. The earlier **1.371× headline is WITHDRAWN** (see [Withdrawn beats](#withdrawn-beats)) | `beat-ollama-decode-throughput-speed-v1.yaml` (`beat_threshold: 0.9000` — a **no-collapse floor**, not a beat) · `crates/aprender-serve/tests/beat_ollama_decode_throughput_speed.rs` (`ENFORCED_THRESHOLD: f64 = 0.90`) |
+
 apr **loses** speed in these **specific, narrow** cases (not a blanket concession):
 
 | Speed loss (narrow case) | Result | Note |
 |--------------------------|--------|------|
-| **llama.cpp** single-request c=1 decode | llama.cpp ~1.55× faster (431 vs 277 tok/s, RTX 4090) | This is *llama.cpp*, not Ollama; apr **wins** the same-host steady-state decode vs Ollama 1.371× |
+| **llama.cpp** single-request c=1 decode | llama.cpp ~1.55× faster (431 vs 277 tok/s, RTX 4090) | This is *llama.cpp*, not Ollama; against Ollama on the same host apr is at **parity** (1.015–1.109×), not ahead — the 1.371× win previously cited here is withdrawn |
 | **7B-Q4K on GB10 Blackwell** | ~12 tok/s (bandwidth-bound; DP4A path degraded) | Memory-wall + degraded DP4A on Blackwell, not a kernel-design loss |
 | **Short-prompt one-shot wall-clock vs Ollama** | apr CLI ~2.7–3.9 s fixed startup vs Ollama's resident daemon | Decode-rate beat is steady-state; one-shot startup is a separate, scoped comparison (see Pillar 4) |
 | **PCA fit_transform vs sklearn** | apr ~18.6× *slower* | sklearn delegates to LAPACK-SVD; apr's decomposition is unoptimized |
@@ -66,6 +77,8 @@ apr **loses** speed in these **specific, narrow** cases (not a blanket concessio
 | 📊 **TRACKING** | measured, pinned baseline; gate not yet wired (or stretch target) |
 | 🚧 **PLANNED** | identified; not yet built |
 | ⚖️ **NARROW LOSS** | measured; apr loses in this *specific* case (named root cause) — an optimization target, not a blanket concession |
+| 🟰 **PARITY (no-collapse floor)** | measured within noise of the incumbent. The contract still gates, but it gates against *collapse* (`beat_threshold < 1.0`), so **no win may be claimed** from a green run |
+| ⛔ **WITHDRAWN** | was published as WON; re-measurement did not reproduce it. Kept on the scoreboard with the retraction and the replacing numbers — never deleted |
 
 ## Pillar 1 — scikit-learn
 
@@ -115,31 +128,35 @@ named** set of losses — not a blanket speed concession. See
 
 | Beat | Metric | Result | Gate |
 |------|--------|--------|------|
-| **GPU decode throughput vs Ollama** (headline speed) | tok/s ratio (RTX-4090) | ✅ **WON** (PMAT-755) — apr **1.371× faster** median (apr median-of-7 **412.3** vs ollama **300.7** tok/s; worst single run 1.230×, best 1.523×), same qwen2.5-coder-1.5b Q4_K_M GGUF, same host. Gate = apr median-of-7 ≥ ollama × 1.10 (wide margin under 1.371×; ~0% bootstrapped flake rate) | manual/GPU gate (no NVIDIA CI runner) · `beat_ollama_decode_throughput_speed` · `beat-ollama-decode-throughput-speed-v1` |
+| **GPU decode throughput vs Ollama** | tok/s ratio (RTX-4090 sm_89) | 🟰 **PARITY (no-collapse floor)** — apr **1.015–1.109×** ollama, same qwen2.5-coder-1.5b Q4_K_M GGUF, same host. Gate = apr median-of-7 ≥ ollama median **× 0.90** (`beat_threshold: 0.9000`). That is a floor against collapse, **not** a win — a green run proves apr did not fall off a cliff, nothing more. ⛔ The prior **1.371× WON claim is WITHDRAWN** (see below) | manual/GPU gate (no NVIDIA CI runner) · `beat_ollama_decode_throughput_speed` · `beat-ollama-decode-throughput-speed-v1` |
 | **Fail-closed correctness** (headline correctness) | broken-artifact classes rejected | ✅ **WON** — apr rejects **10/10** semantically-broken tensor classes (zero/NaN/Inf/L2~0/constant/shape) fail-closed; **llama.cpp accepts** the same (measured: zeroed-ffn GGUF → `apr validate` ✗ FAIL, `llama-cli` 0 errors + ran it) | CI `beat_fail_closed_garbage` · `apr-fail-closed-garbage-beat-v1` |
-| **llama.cpp** single-request c=1 decode | tok/s ratio (RTX-4090) | ⚖️ **NARROW LOSS** — llama.cpp ~1.55× *faster* (431 vs 277 tok/s) at concurrency=1; this is *llama.cpp*, not Ollama, which apr beats 1.371× same-host | — |
+| **llama.cpp** single-request c=1 decode | tok/s ratio (RTX-4090) | ⚖️ **NARROW LOSS** — llama.cpp ~1.55× *faster* (431 vs 277 tok/s) at concurrency=1; this is *llama.cpp*, not Ollama, against which apr measures at parity (1.015–1.109×) | — |
 | 7B-Q4K decode on GB10 Blackwell | tok/s | ⚖️ **NARROW LOSS** — ~12 tok/s (bandwidth-bound; DP4A path degraded on Blackwell) | — |
 | Short-prompt one-shot wall-clock vs Ollama | end-to-end seconds | ⚖️ **NARROW LOSS** — apr CLI ~2.7–3.9 s fixed startup vs Ollama's resident daemon (separate from the steady-state decode beat above) | — |
 
-**Headline speed beat — apr beats Ollama 1.371× on GPU decode (PMAT-755):** for the
-*same* qwen2.5-coder-1.5b Q4_K_M GGUF on the *same* RTX 4090, apr's steady-state GPU
-decode is **412.3 tok/s** (median of 7) vs Ollama's **300.7 tok/s** (median, tight
-294–306 band) = **1.371× median**; every single apr run clears the **1.10×** enforced
-gate (worst 369.9 = 1.230×, best 1.523×). This was promoted from TRACKING to an
-**ENFORCED** beat once the ~1-in-6 decode-stall variance was fixed (#2049) and a
-median-of-7 estimator brought the false-FAIL rate to ~0% — the contract is now the
-source of truth (`contracts/beat-ollama-decode-throughput-speed-v1.yaml`, status
-`enforced`). It stays a **manual/GPU gate** (`#[ignore]`, NVIDIA host only) because
-there is no NVIDIA CI runner — same caveat as the cuda-oxide throughput gate. The
-narrow losses above (llama.cpp at c=1, 7B-on-Blackwell, one-shot startup) are
-**specific, named** cases, not a blanket "speed conceded" stance.
+**GPU decode vs Ollama — PARITY, and the gate is a floor (PMAT-755, withdrawn
+2026-07-31):** for the *same* qwen2.5-coder-1.5b Q4_K_M GGUF on the *same* RTX 4090
+(sm_89), the three reproducible post-#2323 medians are **1.109×** (2026-07-29, apr
+332.7 vs ollama 299.9), **1.042×** (2026-07-31, 342.4 vs 328.6) and **1.015×**
+(2026-07-31 idle box, 318.2 vs 313.5). The contract pins `baseline_value: 1.0150` —
+the **worst** of the three, not the best — and sets `beat_threshold: 0.9000`, matched
+by `ENFORCED_THRESHOLD: f64 = 0.90` in the harness. **0.90 is a no-collapse floor: it
+cannot express a win.** It exists to catch the class that actually hurts (silent CPU
+fallback lands near ratio 0.065), and it sits 12% under the worst observed median so
+it does not flake. Pillar 4 therefore claims **no GPU decode win over Ollama on
+sm_89**; restoring a ≥1.10× win is tracked separately. Still a **manual/GPU gate**
+(`#[ignore]`, NVIDIA host only) — there is no NVIDIA CI runner, same caveat as the
+cuda-oxide throughput gate. The narrow losses above (llama.cpp at c=1,
+7B-on-Blackwell, one-shot startup) remain **specific, named** cases, not a blanket
+"speed conceded" stance — see the Speed scoreboard for the cases apr does win.
 
 **Headline correctness beat — "we provably never ship garbage; they provably do":** a
 model that *parses* but is *semantically* dead (all-zero / NaN / Inf weights) loads and
 runs in llama.cpp/Ollama with exit 0 and no warning; apr's Poka-Yoke validation
 (F-DATA-QUALITY-001..004) rejects it. Measured head-to-head 2026-06-13 in
 `evidence/pillar4-fail-closed-2026-06-13/`. Correctness is a wedge none of the four
-incumbents have — *and* apr now also wins the GPU decode-rate beat above.
+incumbents have. It is Pillar 4's **only** WON beat: the GPU decode-rate row above is
+parity, not a second win.
 
 **PMAT-742 (unblocked Pillar 4):** the default `apr run --gpu` was silently 8 tok/s — its
 CUDA first-token parity gate false-rejected the correct fast path (a single BOS-only probe
@@ -215,6 +232,51 @@ kernel throughput, measured A/B against the incumbent hand-written path:
 kernels (attention, RMSNorm, RoPE, SwiGLU). The DP4A-bound Q4K GEMV/FFN path (PMAT-881)
 stays hand-PTX — a **named NO-GO**, not a blanket loss.
 
+## Withdrawn beats
+
+A beat is withdrawn when re-measurement stops supporting the published claim. The
+row is **not deleted** — deleting it would hide that the scoreboard was wrong, and a
+reader who saw the old claim deserves the retraction next to it.
+
+### ⛔ GPU decode throughput vs Ollama — "apr 1.371× faster" (WITHDRAWN 2026-07-31)
+
+| | |
+|---|---|
+| **Claimed** | ✅ WON, apr **1.371×** ollama median (apr median-of-7 **412.3** vs ollama **300.7** tok/s; worst run 1.230×, best 1.523×), gate ≥ **1.10×** |
+| **Claimed on** | 2026-06-15 (measurement), published 2026-06-25 via #2067 (PMAT-755), promoted TRACKING → ENFORCED |
+| **Replaced by** | 🟰 PARITY, **1.015–1.109×**, gate `beat_threshold: 0.9000` (no-collapse floor) |
+| **Contract** | `contracts/beat-ollama-decode-throughput-speed-v1.yaml` v2.0.0 — `baseline_value: 1.0150`, `baseline_floor: 0.9000`, `beat_threshold: 0.9000` |
+| **Harness** | `crates/aprender-serve/tests/beat_ollama_decode_throughput_speed.rs` — `ENFORCED_THRESHOLD: f64 = 0.90` |
+
+Four measurements on one host (lambda RTX 4090, sm_89), same GGUF on both sides:
+
+| Date | apr median | ollama median | ratio | Source |
+|------|-----------:|--------------:|------:|--------|
+| 2026-06-15 | 412.3 | 300.7 | **1.371×** | promotion claim (#2067) — **not reproducible** |
+| 2026-07-29 | 332.7 | 299.9 | 1.109× | cuda-nightly, PASSED |
+| 2026-07-31 | 342.4 | 328.6 | 1.042× | cuda-nightly, FAILED |
+| 2026-07-31 | 318.2 | 313.5 | 1.015× | idle box, this harness |
+
+**Why it is apr's number that moved, not the rig:** the *ollama* column reproduces
+across six weeks — 300.7 / 299.9 / 328.6 / 313.5. A measurement fault would drift
+both columns. apr's moved 412 → ~318–342.
+
+**Why the gate did not catch it:** the 2026-07-29 run **PASSED at 1.109×** against a
+1.10× gate — 0.8% of headroom. It went unexamined because it was green. *A gate
+passing with <1% headroom is a finding, not a pass.*
+
+**Attribution, stated honestly:** #2323 (2026-07-27) made `auto_q4k` return `Mwv` on
+every device; sm_89 previously defaulted to `HwDp4a`. The 412.3 figure predates that
+change. This is **not** "#2323 cost 23%" — re-running today with `HW_DP4A_Q4K=1`
+measures **20.3 tok/s**, because `HwDp4a` fails the F2 first-token cosine floor
+(0.9186 < 0.95) and the run finishes on CPU SIMD. The claim is withdrawn as
+**unreproducible**, not reattributed to a cause we have not proven.
+
+**Consequence for the scoreboard:** Pillar 4 has **one** WON beat (fail-closed
+correctness), not two. Restoring a ≥1.10× GPU decode win is tracked separately; until
+a re-measurement supports it, no GPU decode win over Ollama on sm_89 may be published
+here.
+
 ## Beat infrastructure (PMAT-741)
 
 The machinery every beat plugs into:
@@ -236,15 +298,31 @@ The machinery every beat plugs into:
 3. **Measure before claiming.** apr **wins** speed in many CI-gated cases (Speed
    scoreboard above); where it loses, name the **specific case** and root cause — never
    a blanket "speed conceded" stance.
+4. **The contract is the gate of record.** This file must state the same threshold the
+   contract carries; a `beat_threshold < 1.0` is a floor and may never be reported as a
+   win. `crates/aprender-core/tests/readme_contract.rs` fails the build on drift
+   (FALSIFY-DOCS-BEATS-001/002/003).
+5. **A gate passing with <1% headroom is a finding.** Green is not the same as proven —
+   the 2026-07-29 Ollama run passed at 1.109× against a 1.10× gate and was the
+   regression.
 
-_Last updated: 2026-06-25 — promoted the mission from FOUR-pillar to FIVE-pillar:
-added Pillar 5 (Claude Code / `apr code`) with the honest split — function-scale
-outcome parity WON (1.0000, corpus 30/30 + HumanEval + test-survival), project-scale
-Arena TRACKED GAP (0.20, 1/5), per the CCPA harness (claude-code-parity-apr-v1.yaml
-v1.32.0, 20 gates) + the new aprender-side tracking pointer
-beat-claude-code-parity-v1.yaml; V1_004 model-family finding noted as the leading
-hypothesis for the gap. Earlier 2026-06-25 edit promoted the Ollama GPU-decode beat
-from TRACKING to ENFORCED (1.371× median, 412.3 vs 300.7 tok/s); asserted the
-evidence-backed cold-start (~528–5000×), LAPACK-free ML (1.6–4.9×), cuda-oxide/SIMD
-(1.4–17×), and footprint (15.8–17.1×) speed wins; replaced blanket-concession wording
-with specific, sourced narrow-loss cases._
+_Last updated: 2026-08-13 — **withdrew the Ollama GPU-decode "1.371× WON" headline**
+(#2349 carve-out). Measured reality on RTX 4090 sm_89 is **1.015–1.109×** — parity —
+and the contract enforces `beat_threshold: 0.9000`, a no-collapse floor, not a beat.
+The row moved out of the Speed-wins table into a new PARITY table; Pillar 4's table,
+the llama.cpp comparison note and the headline paragraph were corrected to match; the
+full claim history is preserved under [Withdrawn beats](#withdrawn-beats); ⛔/🟰
+statuses and a withdrawal rule were added to the legend, and Discipline gained rules 4
+and 5. `beats_doc_contract.rs` now gates this file against the contract._
+
+_2026-06-25 — promoted the mission from FOUR-pillar to FIVE-pillar: added Pillar 5
+(Claude Code / `apr code`) with the honest split — function-scale outcome parity WON
+(1.0000, corpus 30/30 + HumanEval + test-survival), project-scale Arena TRACKED GAP
+(0.20, 1/5), per the CCPA harness (claude-code-parity-apr-v1.yaml v1.32.0, 20 gates) +
+the new aprender-side tracking pointer beat-claude-code-parity-v1.yaml; V1_004
+model-family finding noted as the leading hypothesis for the gap. Earlier 2026-06-25
+edit promoted the Ollama GPU-decode beat from TRACKING to ENFORCED (1.371× median,
+412.3 vs 300.7 tok/s — **since withdrawn, see above**); asserted the evidence-backed
+cold-start (~528–5000×), LAPACK-free ML (1.6–4.9×), cuda-oxide/SIMD (1.4–17×), and
+footprint (15.8–17.1×) speed wins; replaced blanket-concession wording with specific,
+sourced narrow-loss cases._

--- a/scripts/check_apr_bin_pinned.sh
+++ b/scripts/check_apr_bin_pinned.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# check_apr_bin_pinned.sh - no CI surface may invoke a bare `apr`.
+# check_apr_bin_pinned.sh - no execution surface may resolve `apr` through PATH
+# or through a hardcoded absolute path.
 #
 # THE CLASS. `cargo install --path crates/apr-cli --force` writes to
 # ~/.cargo/bin. If anything earlier on PATH holds an older `apr`, a bare `apr`
@@ -9,159 +10,513 @@
 #
 # scripts/apr_bin.sh makes that DETECTABLE at runtime (it compares the binary's
 # embedded git SHA against HEAD). This script makes it UNREINTRODUCIBLE: any new
-# bare `apr` invocation on a CI surface fails the PR that adds it.
+# unpinned `apr` invocation on an execution surface fails the PR that adds it.
 #
 # An invocation is PINNED when it goes through one of:
 #   "$APR" / ${APR} / $APR_BIN     - resolved by scripts/apr_bin.sh
-#   an explicit path               - ./target/release/apr, ~/.cargo/bin/apr, /abs/apr
+#   a checkout-relative path       - ./target/release/apr, ${ROOT}/target/...
 #   cargo run ... --bin apr        - built from the current source by definition
 #
-# Exit 0 = every CI-surface invocation is pinned. Exit 1 = at least one is bare.
+# Exit 0 = every invocation on every scanned surface is pinned.
+# Exit 1 = at least one is not.
+#
+# ---------------------------------------------------------------------------
+# SCOPE (#2358). The previous revision scanned workflows, the scripts a workflow
+# NAMES, and the Makefile. Three whole surfaces sat outside it, and all three
+# held live violations:
+#
+#   1. scripts/ reachable only INDIRECTLY. Discovery was one level deep - grep
+#      the workflows for `scripts/*.sh`. scripts/dogfood-book.sh runs
+#      scripts/check_book_examples_executable.sh, which resolved its binary with
+#      `command -v apr` and fell back to a hardcoded /mnt path. Never scanned,
+#      because no workflow names it by name. The fix is to stop deriving: EVERY
+#      scripts/**/*.sh is in scope. "Reachable from CI" is not a property you can
+#      compute with one grep, and guessing it wrong fails silently.
+#   2. .claude/skills/**. The dogfood skill is the surface where the RELEASE
+#      decision is made, and its bash fences invoked a bare `apr` 43 times.
+#      #2361 already taught this once (a user-scope skill shadowed the repo's
+#      release-certifying skill); the skills were still unscanned.
+#   3. The PATH-resolution class itself, which the old regexes could not see at
+#      all - see CLASS 3 below. check_book_cli_parity.sh IS in the old scope and
+#      still shipped `APR="$(which apr)"`, because laundering PATH into $APR
+#      made every later use look pinned.
+#
+# Extending a guard's SCOPE requires re-mutating in the NEW scope; the old proof
+# does not transfer. `--self-test` injects a violation into each surface in that
+# surface's own syntax and asserts this script turns RED. Run it, don't read it.
+# ---------------------------------------------------------------------------
 
 set -euo pipefail
 
+SELF_PATH="$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
 cd "$(dirname "$0")/.." || exit 1
 
-# CI surfaces only. Developer convenience scripts that CI never runs are out of
-# scope on purpose - the invariant being protected is "what CI executes was
-# built from the commit under test", not "nobody may ever type apr".
-WORKFLOW_GLOB=".github/workflows"
+# ---------------------------------------------------------------------------
+# CLASS 1: `apr` in COMMAND POSITION - the only place it can launch a binary.
+#
+# Command position means: start of line, after a shell separator (; & | && ||),
+# inside a substitution or subshell ( `(` covers both `(` and `$(` ), after a
+# backtick, or after a YAML `run:`. Anchoring on command position rather than
+# scanning line content is what keeps prose out:
+#   - name: Pillar-1 - apr vs scikit-learn ...   (a label)
+#   emit_pass "B2 apr qa"                        (a message)
+# Two early drafts got this wrong in opposite directions - one missed
+# `- run: apr qa`, the next flagged ten step names. Both were caught by the case
+# table, not by reading.
+#
+# `@?` covers Makefile recipe lines, which start with a TAB and usually make's
+# silent-prefix `@`. Without it a recipe `\t@apr qa model.apr` slipped straight
+# through.
+#
+# WRAP covers command prefixes that do NOT change the fact that `apr` is the
+# command being launched: `timeout 30 apr qa`, `nohup apr distill`,
+# `APR_LOG=1 apr run`. The dogfood skill hid 19 invocations behind `timeout N`
+# alone, every one of them invisible to the un-wrapped pattern.
+WRAP='([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+|timeout[[:space:]]+[0-9]+[a-z]?[[:space:]]+|nohup[[:space:]]+|time[[:space:]]+|sudo[[:space:]]+|nice[[:space:]]+|env[[:space:]]+|exec[[:space:]]+|stdbuf[[:space:]]+-[^[:space:]]+[[:space:]]+)'
+#
+# A BACKTICK is deliberately NOT an opener, and this is a measured call rather
+# than an oversight. Once markdown is in scope the backtick is overwhelmingly a
+# code-span delimiter, not command substitution: every ``apr`` occurrence
+# after a backtick in this tree - all 10 of them - is prose (script header
+# comments, `printf '**Tool:** \`apr qualify\`'`, and a book-example string
+# reading `'apr rm <id>   # from \`apr list\` output'`). Zero are the legacy
+# `cmd` substitution form. Treating it as an opener produced one false positive
+# and caught nothing. RESIDUAL GAP, stated rather than hidden: a genuine
+# OUT=`apr qa model` would slip past. `$( )` - the form this tree actually uses,
+# and the one shellcheck requires - is covered, via `(` below.
+# `!` + backtick IS an opener: that pair is unambiguously "run this" in a skill,
+# never a markdown code span (a span opens on a bare backtick). So the inline
+# command form is covered without the false positives a bare backtick brings.
+OPEN='(^|[;&|(]|&&|\|\||run:|!`)'
+# The trailing class exists to require an ARGUMENT, so that bare `apr` and the
+# crate name `apr-cli` do not match. It was `[a-z]` - a subcommand and nothing
+# else - and each character missing from it was a silent hole:
+#   `-`        `apr --version`   the single most load-bearing bare invocation
+#                                there is, since reading a version off the
+#                                wrong binary IS the defect. Four live ones,
+#                                one of them inside qwen-story-daily's own
+#                                anti-staleness step.
+#   `"` `'` `$` `apr "$cmd" --help`, `apr $cmd $MODEL`  - the dogfood skill
+#                                drives whole subcommand grids this way.
+#   `/` `~` `.` `apr ./model.apr`, `apr ~/models/x.gguf`
+# Widening it is not a loosening: the OPENER is what keeps prose out, and it is
+# unchanged. This class has been wrong five times; re-run --self-test.
+BARE_APR="${OPEN}[[:space:]]*@?[[:space:]]*${WRAP}*apr[[:space:]]+[a-z\"'\$/~.-]"
 
-# Scripts reachable from a workflow. Derived, not hand-listed, so a newly wired
-# script is covered the moment the workflow names it.
-ci_scripts() {
-    grep -rhoE 'scripts/[A-Za-z0-9_.-]+\.sh' "$WORKFLOW_GLOB"/*.yml 2>/dev/null \
-        | sort -u \
-        | while IFS= read -r s; do
-            [ -f "$s" ] && printf '%s\n' "$s"
-          done
-}
+# ---------------------------------------------------------------------------
+# CLASS 2: an ABSOLUTE hardcoded `apr` path.
+#
+# The other half of the same defect, and the class-1 "already pinned" allowlist
+# waves it straight through: `/mnt/nvme-raid0/targets/aprender/release/apr` ends
+# in `target/release/apr`. It is not pinned to anything - it names one machine's
+# build output, which on 2026-08-01 was 6 days and TWO MINOR VERSIONS stale
+# while docs still called it canonical. A release smoke-test read it and
+# reported a meaningless pass.
+#
+# There is no correct absolute path to hardcode: `.cargo/config.toml` redirects
+# cargo's target-dir and is gitignored, so the main checkout builds to
+# /mnt/nvme-raid0/coverage/aprender while a fresh worktree builds to
+# <worktree>/target. Any absolute path is right in one and silently wrong in the
+# other. Use `. scripts/apr_bin.sh || exit 1`, which asks cargo.
+#
+# The leading anchor is load-bearing: without it `[A-Za-z0-9_.$/-]*` matches the
+# `/apr` inside RELATIVE `target/release/apr`, flagging correct code. `:-` and
+# `:=` are openers because `${APR:-/home/noah/.cargo/bin/apr}` is a hardcoded
+# absolute path wearing a parameter-expansion costume - that exact line was live
+# in check_book_cli_parity.sh, INSIDE the old scope, invisible for two
+# independent reasons (the `-` before `/home` was not an opener, and the `}`
+# after `apr` was not a terminator). `}` and `)` are therefore terminators.
+#
+# This regex class has now been gotten wrong five times in this repo. If you
+# change it, re-run `--self-test` rather than reading it.
+ABS_APR='(^|[[:space:]"'"'"'=(`]|:-|:=)(/|~/|\$HOME/)[A-Za-z0-9_.$/-]*/apr([[:space:]"'"'"'})]|$)'
 
-MIN_EXPECTED="${MIN_EXPECTED:-1}"
+# ---------------------------------------------------------------------------
+# CLASS 3: resolving `apr` through PATH into a variable.
+#
+# `APR="$(which apr)"` is the ORIGINAL defect with the guard's own approved
+# costume on. The binary is still whatever PATH holds - but every subsequent
+# `"$APR" qa` matches the "already pinned" allowlist, so the old checker read
+# the file, found nothing, and passed. Three CI-adjacent scripts shipped this:
+# check_book_cli_parity.sh (a gate), check_book_examples_executable.sh (a gate),
+# qualify-matrix.sh.
+#
+# `command -v apr` inside an `echo` is a DIAGNOSTIC, not a resolution -
+# qwen-story-daily prints it precisely to name the shadowing binary. The
+# echo/printf exemption below covers that.
+PATHRES='(command[[:space:]]+-v[[:space:]]+apr|which[[:space:]]+apr|type[[:space:]]+(-[A-Za-z]+[[:space:]]+)?apr)([[:space:]]|[;)&|]|$)'
+
+MIN_EXPECTED="${MIN_EXPECTED:-80}"
 
 violations=0
 scanned=0
 
-# A line invokes apr "bare" when `apr` appears as a command word - i.e. at the
-# start of a command - and is not preceded by $, /, or - (which would make it
-# $APR, a path, or part of apr-cli / apr-corpus-ingest).
-# `apr` in COMMAND POSITION - the only place it can actually launch a binary.
-# That means: at the start of a line, right after a shell separator
-# (; & | && ||), or after a YAML `run:`. Anchoring on command position rather
-# than scanning line content is what keeps prose out:
-#   - name: Pillar-1 - apr vs scikit-learn ...   (a label)
-#   emit_pass "B2 apr qa"                        (a message)
-# Two earlier drafts got this wrong in opposite directions - one missed
-# `- run: apr qa` entirely, the next flagged ten step names. Both were caught
-# by the case table below, not by reading.
-# `@?` covers Makefile recipe lines, which start with a TAB and usually make's
-# silent-prefix `@`. Without it a recipe `\t@apr qa model.apr` slipped straight
-# through — caught by mutation-testing the Makefile scan, not by reading it.
-BARE_APR='(^|[;&|]|&&|\|\||run:)[[:space:]]*@?[[:space:]]*apr[[:space:]]+[a-z]'
-
-# An absolute path whose last component is `apr`. Anchored on a leading `/`,
-# `~/` or `$HOME/` so relative `target/release/apr` (correct inside a checkout)
-# is untouched, and requiring the path to END at `apr` so `apr-cli`,
-# `aprender-*` and `.../apr_bin.sh` do not match.
-# The leading anchor is load-bearing and was wrong in the first draft: without
-# it, `[A-Za-z0-9_.$/-]*` happily matched the `/apr` inside RELATIVE
-# `target/release/apr`, flagging correct code. Verified against a 12-case table
-# (4 absolute forms must match, 8 relative/`$APR`/`--bin apr`/prose forms must
-# not). This regex class has now been gotten wrong four times in this repo; if
-# you change it, re-run the table rather than reading it.
-ABS_APR='(^|[[:space:]"'"'"'=(])(/|~/|\$HOME/)[A-Za-z0-9_.$/-]*/apr([[:space:]"'"'"']|$)'
-
-check_file() {
-    local f="$1" n=0
-    scanned=$((scanned + 1))
-    while IFS= read -r hit; do
-        local lineno text trimmed
-        lineno="${hit%%:*}"
-        text="${hit#*:}"
-        trimmed=$(printf '%s' "$text" | sed 's/^[[:space:]]*//')
-
-        # Comments are documentation, not invocations.
-        case "$trimmed" in
-            '#'*) continue ;;
-            *) ;;
-        esac
-        # YAML metadata is prose, not shell. beat-speed-nightly.yml has ten
-        # step names reading "Pillar-1 - apr vs scikit-learn ..."; flagging
-        # those would make the check fire on its own labels.
-        if printf '%s' "$trimmed" \
-            | grep -qE '^-?[[:space:]]*(name|description|title|summary|if|id|uses|shell|working-directory):'; then
-            continue
-        fi
-        # Already pinned?
-        case "$text" in
-            *'$APR'*|*'${APR'*|*'target/release/apr'*|*'target/debug/apr'*|*'.cargo/bin/apr'*|*'--bin apr'*)
-                continue ;;
-            # qwen-story.sh's run_cmd substitutes a leading bare `apr` with
-            # "$APR", so its call sites are pinned by the wrapper.
-            *'run_cmd '*)
-                continue ;;
-            *) ;;
-        esac
-        printf 'BARE-APR %s:%s\n' "$f" "$lineno"
-        printf '         %s\n' "$trimmed"
-        n=$((n + 1))
-    done < <(grep -nE "$BARE_APR" "$f" 2>/dev/null || true)
-
-    # SECOND CLASS: an ABSOLUTE hardcoded apr path.
-    #
-    # This is the other half of the same defect, and the `case` above would wave
-    # it straight through: `/mnt/nvme-raid0/targets/aprender/release/apr` ends in
-    # `target/release/apr`, so it matched the "already pinned" list. It is not
-    # pinned to anything - it names one machine's build output, which on
-    # 2026-08-01 was 6 days and TWO MINOR VERSIONS stale while docs still called
-    # it canonical. A release smoke-test read it and reported a meaningless pass.
-    #
-    # There is no correct absolute path to hardcode: `.cargo/config.toml`
-    # redirects cargo's target-dir and is gitignored, so the main checkout builds
-    # to /mnt/nvme-raid0/coverage/aprender while a fresh worktree builds to
-    # <worktree>/target. Any absolute path is right in one and silently wrong in
-    # the other. Use `. scripts/apr_bin.sh || exit 1`, which asks cargo.
-    while IFS= read -r hit; do
-        local lineno text trimmed
-        lineno="${hit%%:*}"
-        text="${hit#*:}"
-        trimmed=$(printf '%s' "$text" | sed 's/^[[:space:]]*//')
-        case "$trimmed" in '#'*) continue ;; *) ;; esac
-        # apr_bin.sh itself documents these paths in its own comments.
-        case "$f" in */apr_bin.sh|*/check_apr_bin_pinned.sh) continue ;; *) ;; esac
-        printf 'ABS-APR  %s:%s\n' "$f" "$lineno"
-        printf '         %s\n' "$trimmed"
-        n=$((n + 1))
-    done < <(grep -nE "$ABS_APR" "$f" 2>/dev/null || true)
-    violations=$((violations + n))
+# ---------------------------------------------------------------------------
+# Surfaces. Everything that can EXECUTE apr, with no reachability guessing.
+#
+# docs/ and book/ are deliberately NOT here. `apr run model.apr` in a model card
+# is instruction to a human who installed the binary; there is one `apr` on
+# their machine and pinning prose to a worktree path would be nonsense. The
+# invariant is about surfaces that run apr and then REPORT A VERDICT.
+surface_files() {
+    local f
+    for f in .github/workflows/*.yml .github/workflows/*.yaml; do
+        [ -f "$f" ] && printf '%s\n' "$f"
+    done
+    [ -f Makefile ] && printf '%s\n' Makefile
+    find scripts -name '*.sh' -type f 2>/dev/null | sort
+    find .claude/skills -name '*.md' -type f 2>/dev/null | sort
 }
 
-for f in "$WORKFLOW_GLOB"/*.yml; do
-    [ -f "$f" ] || continue
+# Lines a surface can EXECUTE, as `lineno:text`.
+#
+# For markdown (skills) that is the content of bash fences only. A skill's prose
+# says things like "run apr qa first" at the start of a line, which is command
+# position by syntax and documentation by intent. Scanning the fences keeps the
+# check on the text an agent actually pastes into a shell.
+# The `/apr/` pre-filter is sound, not a shortcut: all three classes require the
+# literal substring `apr` somewhere on the line, so a line without it cannot be a
+# violation. It takes the scan from ~30k bash-regex evaluations to a few hundred
+# (12.6s -> under a second), which matters because this runs on every PR.
+emit_lines() {
+    local f="$1"
+    case "$f" in
+        *.md)
+            # Two executable forms in a skill, and only the first is obvious:
+            #   1. ```bash fences  - what an agent pastes into a shell.
+            #   2. !`...` lines    - the skill front-matter's inline command
+            #                        substitution, which Claude Code RUNS when
+            #                        the skill loads. apr-dogfood used one to
+            #                        report "Installed apr version" from a bare
+            #                        `apr --version`, i.e. the PATH binary, in
+            #                        the header of the protocol that certifies
+            #                        releases.
+            awk '
+                /^[[:space:]]*```/ {
+                    if (infence) { infence = 0 }
+                    else if ($0 ~ /```(bash|sh|shell|console)[[:space:]]*$/) { infence = 1 }
+                    next
+                }
+                infence && /apr/ { printf "%d:%s\n", NR, $0; next }
+                /!`/ && /apr/ { printf "%d:%s\n", NR, $0 }
+            ' "$f"
+            ;;
+        *)
+            awk '/apr/ { printf "%d:%s\n", NR, $0 }' "$f"
+            ;;
+    esac
+}
+
+# Strip leading whitespace, into $LTRIM. A bash-regex capture rather than the
+# nested `${t#"${t%%[![:space:]]*}"}` idiom: same result, one expansion, and it
+# does not fork a process per line (this scans ~30k lines).
+ltrim() {
+    [[ $1 =~ ^[[:space:]]*(.*)$ ]]
+    LTRIM="${BASH_REMATCH[1]}"
+}
+
+# Quoted text handed to echo/printf is a MESSAGE, not a command. Stripping the
+# quoted segments (and only for echo/printf lines) keeps
+#   echo 'MODEL_DIR is a FILE; apr publish needs a directory'
+# out while keeping
+#   echo '{"jsonrpc":"2.0"}' | apr mcp
+# in - the pipe and the invocation are OUTSIDE the quotes.
+demessage() {
+    local t="$1"
+    case "$t" in
+        echo\ *|printf\ *|echo|printf)
+            printf '%s' "$t" | sed "s/'[^']*'//g; s/\"[^\"]*\"//g"
+            ;;
+        *) printf '%s' "$t" ;;
+    esac
+}
+
+report() {
+    printf '%s %s:%s\n' "$1" "$2" "$3"
+    printf '         %s\n' "$4"
+    violations=$((violations + 1))
+}
+
+check_file() {
+    local f="$1" hit lineno text trimmed probe self=0
+    scanned=$((scanned + 1))
+    # This file quotes deliberate violations verbatim in its case table, and
+    # apr_bin.sh names the stale absolute paths it exists to detect. Both are
+    # data, not invocations. (check_pass_grep_anchored.sh exempts itself for the
+    # same reason.) The case table is what proves these two are still honest.
+    case "$f" in */apr_bin.sh|*/check_apr_bin_pinned.sh) self=1 ;; esac
+    [ "$self" -eq 1 ] && return 0
+    while IFS= read -r hit; do
+        lineno="${hit%%:*}"
+        text="${hit#*:}"
+        ltrim "$text"; trimmed="$LTRIM"
+
+        # Comments are documentation, not invocations.
+        case "$trimmed" in '#'*) continue ;; esac
+
+        # YAML metadata is prose, not shell. beat-speed-nightly.yml has ten step
+        # names reading "Pillar-1 - apr vs scikit-learn ..."; flagging those
+        # would make the check fire on its own labels.
+        case "$trimmed" in
+            name:*|-\ name:*|description:*|title:*|summary:*|if:*|-\ if:*|id:*|uses:*|shell:*|working-directory:*)
+                continue ;;
+        esac
+
+        probe="$(demessage "$trimmed")"
+
+        # CLASS 1 --------------------------------------------------------
+        if [[ $probe =~ $BARE_APR ]]; then
+            case "$text" in
+                *'$APR'*|*'${APR'*|*'target/release/apr'*|*'target/debug/apr'*|*'.cargo/bin/apr'*|*'--bin apr'*)
+                    : ;;
+                # qwen-story.sh's run_cmd substitutes a leading bare `apr` with
+                # "$APR", so its call sites are pinned by the wrapper.
+                *'run_cmd '*) : ;;
+                *) report 'BARE-APR' "$f" "$lineno" "$trimmed" ;;
+            esac
+        fi
+
+        # CLASS 2 --------------------------------------------------------
+        if [[ $trimmed =~ $ABS_APR ]]; then
+            report 'ABS-APR ' "$f" "$lineno" "$trimmed"
+        fi
+
+        # CLASS 3 --------------------------------------------------------
+        # apr_bin.sh probes `type -aP apr` on purpose, to NAME the shadows;
+        # it is exempted wholesale above.
+        if [[ $probe =~ $PATHRES ]]; then
+            report 'PATH-APR' "$f" "$lineno" "$trimmed"
+        fi
+    done < <(emit_lines "$f")
+}
+
+# ---------------------------------------------------------------------------
+# --self-test: the must-match / must-not-match case table, plus one mutation
+# per SURFACE in that surface's own syntax.
+#
+# The surface half is not decoration. When this guard grew from "workflows" to
+# "workflows + Makefile", the Makefile recipe form `\t@apr qa` was still
+# invisible - the scope moved, the proof did not, and only re-mutating inside
+# the Makefile found it. Every surface added since gets its own probe here.
+if [ "${1:-}" = "--self-test" ]; then
+    fails=0
+
+    # -- regex case table ---------------------------------------------------
+    must_match_bare=(
+        'apr qa model.apr'
+        '  apr run model.gguf --prompt hi'
+        '- run: apr qa model.apr'
+        '	@apr qa model.apr'
+        '	apr validate model.apr'
+        'cd /tmp && apr qa model.apr'
+        'foo; apr lint model.apr'
+        'echo hi | apr mcp'
+        'OUT=$(apr inspect model.apr)'
+        'OUT=$(timeout 10 apr inspect model.apr)'
+        '  echo -n x && timeout 30 apr run $M'
+        'nohup apr distill teacher.apr &'
+        'APR_LOG=1 apr run model.apr'
+        'env APR_LOG=1 apr run model.apr'
+        'echo {} | apr mcp'
+        '- Installed apr version: !`apr --version 2>/dev/null`'
+        'apr --version | grep -qE unknown'
+        'apr "$cmd" --help 2>&1 | grep -qi not-implemented'
+        'apr $cmd $MODEL 2>&1 | head -1'
+        'apr ./model.apr qa'
+        'apr ~/models/x.gguf qa'
+    )
+    must_not_match_bare=(
+        '"$APR" qa model.apr'
+        '${APR} qa model.apr'
+        '"$APR_BIN" qa model.apr'
+        './target/release/apr qa model.apr'
+        '"${REPO_ROOT}/target/release/apr" qa model.apr'
+        'cargo run --bin apr -- qa model.apr'
+        '- name: Pillar-1 - apr vs scikit-learn parity'
+        '# apr qa model.apr'
+        'emit_pass "B2 apr qa"'
+        'run_cmd apr qa model.apr'
+        'cargo install apr-cli --force'
+        'echo "  apr pull ${REPO} && apr qa <path>"'
+        "echo 'MODEL_DIR is a FILE; apr publish needs a directory'"
+        'aprender-core builds apr eventually'
+        'ls scripts/apr_bin.sh'
+        # Markdown/prose code spans. A backtick is not an opener - see OPEN.
+        "EXAMPLE[rm]='apr rm <id>   # from \`apr list\` output'"
+        "printf '**Tool:** \`apr qualify\` (11-gate smoke test)\\n'"
+    )
+    must_match_abs=(
+        '/mnt/nvme-raid0/targets/aprender/release/apr publish x'
+        'APR="${APR:-/home/noah/.cargo/bin/apr}"'
+        'APR_BINARY="${APR_BINARY:-/mnt/nvme-raid0/targets/aprender/release/apr}"'
+        'elif [ -x /mnt/nvme-raid0/targets/aprender/release/apr ]; then'
+        'APR_BIN=/mnt/nvme-raid0/targets/aprender/release/apr'
+        '~/.cargo/bin/apr --version'
+        '$HOME/.cargo/bin/apr --version'
+    )
+    must_not_match_abs=(
+        './target/release/apr --version'
+        'APR_BIN="${APR_BIN:-${REPO_DIR}/target/release/apr}"'
+        'readonly APR_BIN="${PROJECT_ROOT}/target/release/apr"'
+        'cp "target/${{ matrix.target }}/release/apr" "$ARCHIVE/"'
+        'APR_BIN_PATH="${CARGO_HOME:-$HOME/.cargo}/bin/apr"'
+        'bash scripts/apr_bin.sh'
+        'cargo run --bin apr'
+        'ls /mnt/nvme-raid0/targets/aprender/release/apr-cli'
+    )
+    must_match_pathres=(
+        'APR="$(which apr)"'
+        'APR_BIN="$(command -v apr)"'
+        'if command -v apr >/dev/null 2>&1; then'
+        'if ! command -v apr; then'
+    )
+    must_not_match_pathres=(
+        'echo "apr --version: $GOT ($(command -v apr))"'
+        'echo "::error::PATH resolves to $(command -v apr)."'
+        'command -v cargo >/dev/null'
+        'which apr-cli'
+        'command -v aprender'
+    )
+
+    probe_case() {
+        local re="$1" line="$2" want="$3" label="$4" p t
+        # Mirror check_file's own pre-filters exactly, or the table would be
+        # testing a different pipeline than the one that ships.
+        ltrim "$line"; t="$LTRIM"
+        p="$(demessage "$t")"
+        case "$t" in '#'*) p='' ;; esac
+        case "$t" in name:*|-\ name:*) p='' ;; esac
+        if [ "$want" = match ]; then
+            if ! [[ $p =~ $re ]]; then
+                printf 'CASE-TABLE FAIL [%s] expected MATCH, got none: %s\n' "$label" "$line" >&2
+                fails=$((fails + 1))
+            fi
+        else
+            if [[ $p =~ $re ]]; then
+                printf 'CASE-TABLE FAIL [%s] expected NO match, got one: %s\n' "$label" "$line" >&2
+                fails=$((fails + 1))
+            fi
+        fi
+    }
+
+    for c in "${must_match_bare[@]}"; do probe_case "$BARE_APR" "$c" match bare; done
+    for c in "${must_not_match_bare[@]}"; do
+        # The allowlist is part of the class-1 decision, so apply it here too.
+        case "$c" in
+            *'$APR'*|*'${APR'*|*'target/release/apr'*|*'target/debug/apr'*|*'.cargo/bin/apr'*|*'--bin apr'*|*'run_cmd '*)
+                continue ;;
+        esac
+        probe_case "$BARE_APR" "$c" nomatch bare
+    done
+    for c in "${must_match_abs[@]}"; do probe_case "$ABS_APR" "$c" match abs; done
+    for c in "${must_not_match_abs[@]}"; do probe_case "$ABS_APR" "$c" nomatch abs; done
+    for c in "${must_match_pathres[@]}"; do probe_case "$PATHRES" "$c" match pathres; done
+    for c in "${must_not_match_pathres[@]}"; do probe_case "$PATHRES" "$c" nomatch pathres; done
+
+    # -- per-surface mutation ----------------------------------------------
+    TMPROOT=$(mktemp -d)
+    cleanup_selftest() {
+        if [ -n "${TMPROOT:-}" ] && [ "$TMPROOT" != / ] && [ -d "$TMPROOT" ]; then
+            rm -rf "$TMPROOT"
+        fi
+    }
+    trap cleanup_selftest EXIT
+
+    # A FRESH tree per probe. The first draft reused one directory and cleaned it
+    # with `rm -rf "$TMP"/*`, which does not match dotfiles - so `.github/` and
+    # `.claude/` survived, every later probe inherited the FIRST probe's
+    # violation, and all of them "turned RED" without their own mutation ever
+    # being read. Probes that pass for a reason other than the thing they probe
+    # are the exact failure mode this script exists to prevent; the guard's own
+    # test is not exempt. Only the prose probe (which must stay GREEN) noticed.
+    mk_tree() {
+        local d
+        d=$(mktemp -d "$TMPROOT/probe.XXXXXX")
+        mkdir -p "$d/scripts"
+        cp "$SELF_PATH" "$d/scripts/check_apr_bin_pinned.sh"
+        : > "$d/Makefile"
+        printf '%s' "$d"
+    }
+
+    surface_probe() {
+        local label="$1" path="$2" content="$3" d
+        d=$(mk_tree)
+        mkdir -p "$d/$(dirname "$path")"
+        printf '%s\n' "$content" > "$d/$path"
+        if (cd "$d" && MIN_EXPECTED=1 bash scripts/check_apr_bin_pinned.sh >/dev/null 2>&1); then
+            printf 'SURFACE-PROBE FAIL [%s]: guard stayed GREEN with a violation in %s\n' \
+                "$label" "$path" >&2
+            fails=$((fails + 1))
+        fi
+    }
+
+    # Each violation is written in the SURFACE'S OWN syntax. The Makefile case is
+    # the reason this section exists: a tab-and-@ recipe line is not a shell line
+    # and the pattern that covered every workflow was blind to it.
+    surface_probe 'workflow'  '.github/workflows/w.yml' \
+        '      - name: x
+        run: apr qa model.apr'
+    surface_probe 'makefile'  'Makefile' \
+        'qa:
+	@apr qa model.apr'
+    surface_probe 'script-indirect' 'scripts/never-named-by-a-workflow.sh' \
+        '#!/usr/bin/env bash
+apr qa model.apr'
+    surface_probe 'script-nested' 'scripts/pub/deep.sh' \
+        '#!/usr/bin/env bash
+/mnt/nvme-raid0/targets/aprender/release/apr publish x'
+    surface_probe 'skill-fence' '.claude/skills/x/SKILL.md' \
+        'Run the gate:
+
+```bash
+apr qa model.apr
+```'
+    surface_probe 'skill-wrapped' '.claude/skills/x/SKILL.md' \
+        '```bash
+timeout 30 apr run $MODEL --max-tokens 4
+```'
+    surface_probe 'skill-inline-bang' '.claude/skills/x/SKILL.md' \
+        '- Installed apr version: !`apr --version 2>/dev/null || echo none`'
+    surface_probe 'pathres-launder' 'scripts/launder.sh' \
+        '#!/usr/bin/env bash
+APR="$(which apr)"
+"$APR" qa model.apr'
+    surface_probe 'abs-default' 'scripts/absdefault.sh' \
+        '#!/usr/bin/env bash
+APR="${APR:-/home/noah/.cargo/bin/apr}"'
+
+    # A skill's PROSE is not an execution surface; only its bash fences are.
+    # This asserts the fence filter, so the guard cannot start policing English.
+    prose_dir=$(mk_tree)
+    mkdir -p "$prose_dir/.claude/skills/x"
+    printf 'apr qa model.apr is the first tool to reach for.\n' \
+        > "$prose_dir/.claude/skills/x/SKILL.md"
+    if ! (cd "$prose_dir" && MIN_EXPECTED=1 bash scripts/check_apr_bin_pinned.sh >/dev/null 2>&1); then
+        printf 'SURFACE-PROBE FAIL [skill-prose]: guard flagged markdown prose outside a bash fence\n' >&2
+        fails=$((fails + 1))
+    fi
+
+    if [ "$fails" -gt 0 ]; then
+        printf '\nself-test FAILED with %s case(s).\n' "$fails" >&2
+        exit 1
+    fi
+    printf 'self-test OK: %s regex cases and 9 surface probes.\n' \
+        "$(( ${#must_match_bare[@]} + ${#must_not_match_bare[@]} + ${#must_match_abs[@]} \
+             + ${#must_not_match_abs[@]} + ${#must_match_pathres[@]} + ${#must_not_match_pathres[@]} ))"
+    exit 0
+fi
+
+while IFS= read -r f; do
+    [ -n "$f" ] || continue
     check_file "$f"
-done
-
-while IFS= read -r s; do
-    [ -n "$s" ] || continue
-    check_file "$s"
-done < <(ci_scripts)
-
-# The Makefile is a CI surface: coverage-nightly.yml invokes `make coverage`, and
-# `make publish` runs the POST-PUBLISH RELEASE VERIFICATION. Leaving it unscanned
-# is how that verification came to run a bare `apr --version`, print it, and
-# declare "POST-PUBLISH VERIFICATION: PASSED" without comparing it to anything —
-# on a machine where a bare `apr` resolved to a 26-day-old build. A guard that
-# does not scan the surface where the release decision is made is theater,
-# however correct it is elsewhere.
-for f in Makefile; do
-    [ -f "$f" ] && check_file "$f"
-done
+done < <(surface_files)
 
 if [ "$violations" -gt 0 ]; then
-    printf '\n%s bare `apr` invocation(s) on CI surfaces (%s file(s) scanned).\n' \
+    printf '\n%s unpinned `apr` reference(s) on execution surfaces (%s file(s) scanned).\n' \
         "$violations" "$scanned" >&2
     printf 'A bare `apr` runs whatever PATH resolves - which is how a 24-day-old\n' >&2
-    printf 'binary validated a gate merged the day before. Pin it:\n' >&2
+    printf 'binary validated a gate merged the day before. An absolute path names\n' >&2
+    printf 'one machine. `$(which apr)` is PATH wearing a pinned costume. Pin it:\n' >&2
     printf '  . scripts/apr_bin.sh    # exports $APR, asserts it was built from HEAD\n' >&2
     printf '  "$APR" qa model.gguf\n' >&2
     exit 1
@@ -174,4 +529,4 @@ if [ "$scanned" -lt "$MIN_EXPECTED" ]; then
     exit 1
 fi
 
-printf 'OK: %s CI-surface file(s) scanned, every `apr` invocation is pinned.\n' "$scanned"
+printf 'OK: %s execution-surface file(s) scanned, every `apr` reference is pinned.\n' "$scanned"

--- a/scripts/check_book_cli_parity.sh
+++ b/scripts/check_book_cli_parity.sh
@@ -3,13 +3,17 @@
 # Per BOOK-CLOSEOUT-001 § Phase 4.
 set -euo pipefail
 
-APR="${APR:-/home/noah/.cargo/bin/apr}"
-if ! [ -x "$APR" ]; then
-  APR="$(which apr)"
-fi
-
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
+
+# This gate reads `apr --help` and asserts a chapter exists for every subcommand.
+# It used to resolve the binary as `${APR:-/home/noah/.cargo/bin/apr}`, falling
+# back to `$(which apr)` — one developer's home directory, then PATH. Both are
+# the #2357 defect: the command list it compared the book against came from
+# whatever binary happened to be installed, not from this commit. A chapter
+# added for a NEW subcommand would have been reported missing, and a chapter for
+# a DELETED one reported present, with no way to tell from the output.
+. scripts/apr_bin.sh || exit 1
 
 cmds=$("$APR" --help 2>&1 | awk '/^Commands:/{f=1; next} f && /^  [a-z]/{print $1}')
 

--- a/scripts/check_book_examples_executable.sh
+++ b/scripts/check_book_examples_executable.sh
@@ -25,19 +25,26 @@ skip=0
 fail=0
 total=0
 
-# Build the apr binary path. If `apr` is on PATH we use it; otherwise we look
-# for the canonical lambda-vector build path before giving up gracefully.
+# Resolve the binary THIS CHECKOUT builds (#2358).
+#
+# This used to be `command -v apr`, falling back to a hardcoded
+# /mnt/nvme-raid0/targets/aprender/release/apr. Both are the #2357 defect, and
+# this gate is a bad place for it: it executes the book's own examples and
+# reports whether they work. Against a stale binary it certifies that examples
+# run correctly on code nobody is shipping — an example using a flag added this
+# week FAILS, and an example using a flag deleted this week PASSES. The /mnt
+# fallback is worse than stale: nothing writes that path any more.
+#
+# `. scripts/apr_bin.sh` asks cargo for the target dir and asserts the binary's
+# embedded git SHA matches HEAD. It returns non-zero when there is no
+# freshly-built binary, which for this gate is a SKIP, not a failure — the
+# examples are still scanned and rust blocks still reported.
 APR_BIN=""
-if command -v apr >/dev/null 2>&1; then
-    APR_BIN="$(command -v apr)"
-elif [ -x /mnt/nvme-raid0/targets/aprender/release/apr ]; then
-    APR_BIN=/mnt/nvme-raid0/targets/aprender/release/apr
-fi
-
-# If we have no apr binary at all, all CLI examples skip — but the
-# script still scans rust blocks (none of which it runs) and reports.
-if [ -z "$APR_BIN" ]; then
-    echo "[INFO] apr binary not on PATH; all CLI examples will SKIP"
+if . scripts/apr_bin.sh 2>/dev/null; then
+    APR_BIN="$APR"
+else
+    echo "[INFO] no apr binary built from HEAD; all CLI examples will SKIP"
+    echo "[INFO]   build one with: cargo build --release -p apr-cli --bin apr"
 fi
 
 # Helper: rewrite a destructive command into a safe variant (or fail).

--- a/scripts/check_cargo_install_private_root.sh
+++ b/scripts/check_cargo_install_private_root.sh
@@ -1,0 +1,321 @@
+#!/usr/bin/env bash
+# check_cargo_install_private_root.sh - no self-hosted job may install a cargo
+# tool into the SHARED ~/.cargo/bin.
+#
+# THE CLASS (aprender#2353). mac-server hosts 16 runners under ONE user, so
+# every self-hosted job shares a single $HOME/.cargo/bin. `cargo install`
+# replaces a binary at that path; a concurrent job that is mid-run and execs the
+# same path gets whatever the filesystem has at that instant. On 2026-07-31 the
+# Coverage Nightly died with
+#
+#   could not execute process `/home/noah/.cargo/bin/cargo-llvm-cov` (never executed)
+#   No such file or directory (os error 2)
+#
+# ENOENT on an absolute path means the path did not exist at exec time - which
+# nothing but a concurrent writer to that path can produce. It reported an EMPTY
+# coverage figure into the tracking issue: a missing measurement, the same class
+# as project_coverage_floor_measurement_broken.
+#
+# THE RULE. A job that runs on a self-hosted runner and installs a cargo tool
+# must route the install to a per-run private root, either
+#   * `cargo install ... --root <dir>`, or
+#   * a job/step `CARGO_INSTALL_ROOT:` (or `CARGO_HOME:`) that is NOT under
+#     ~/.cargo.
+# and, once it has opted into a private root, must not then put $HOME/.cargo/bin
+# back at the FRONT of PATH - which would resolve the shared copy anyway and
+# make the private root decorative.
+#
+# Out of scope on purpose:
+#   * GitHub-hosted runners (`ubuntu-latest`): ephemeral home per job, no
+#     sharing, nothing to race.
+#   * `cargo install` inside `docker run`: the container has its own CARGO_HOME
+#     (/usr/local/cargo in sovereign-ci), not the host's.
+#
+# Exit 0 = every self-hosted install is private (or explicitly exempt below).
+# Exit 1 = at least one writes the shared path.
+#
+# `--self-test` runs the must-match/must-not-match case table for the line
+# classifiers. Per the house rule, a guard regex ships a case table: re-run the
+# table rather than re-reading the pattern.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.." || exit 1
+
+WORKFLOW_DIR=".github/workflows"
+MIN_EXPECTED_JOBS="${MIN_EXPECTED_JOBS:-8}"
+
+# ---------------------------------------------------------------------------
+# EXEMPTIONS - closed list, keyed "<workflow file>:<job id>", each with a reason.
+# A new self-hosted `cargo install` fails by default; adding it here is a
+# deliberate, reviewable act.
+#
+# qwen-story-daily.yml:story - installs `apr` itself into ~/.cargo/bin ON
+#   PURPOSE: scripts/apr_bin.sh and the story's PATH pinning both expect the
+#   freshly built binary at that path, and the very next lines assert the
+#   running binary's embedded SHA equals HEAD (so a clobbered install fails
+#   closed and loudly rather than silently measuring the wrong build). It
+#   carries the same race exposure as everything else on that box; moving it
+#   needs apr_bin.sh to move with it and is tracked separately, NOT fixed here.
+# ---------------------------------------------------------------------------
+is_exempt() {
+    case "$1" in
+        "qwen-story-daily.yml:story") return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# ---------------------------------------------------------------------------
+# Line classifiers. Each is probed by --self-test.
+# ---------------------------------------------------------------------------
+
+# `cargo install` in COMMAND POSITION - start of a line, after a shell
+# separator, or straight after a YAML `run:`. Anchoring on command position is
+# what keeps prose and comments ("# cargo install writes to ~/.cargo/bin") out.
+RE_INSTALL='(^|[;&|]|&&|\|\||run:)[[:space:]]*(sudo[[:space:]]+)?cargo[[:space:]]+install([[:space:]]|$)'
+
+is_install() {
+    printf '%s\n' "$1" | grep -qE "$RE_INSTALL"
+}
+
+# An explicit `--root <dir>` / `--root=<dir>` on the install itself.
+has_explicit_root() {
+    printf '%s\n' "$1" | grep -qE -- '--root([[:space:]]|=)'
+}
+
+# A CARGO_INSTALL_ROOT / CARGO_HOME declaration (YAML `KEY: value`, `export
+# KEY=value`, or a bare `KEY=value` prefix) whose value is NOT the shared
+# ~/.cargo. `CARGO_HOME: /tmp/cargo-home-security-...` (what the security job
+# already does) and `CARGO_INSTALL_ROOT: /tmp/apr-cov-tools-...` both qualify;
+# `CARGO_INSTALL_ROOT="$HOME/.cargo"` does not.
+declares_private_root() {
+    printf '%s\n' "$1" | grep -qE '(CARGO_INSTALL_ROOT|CARGO_HOME)[[:space:]]*[:=]' || return 1
+    if printf '%s\n' "$1" | grep -qE '(\$HOME|\$\{HOME\}|~)/\.cargo'; then
+        return 1
+    fi
+    return 0
+}
+
+# `docker run` opens a chain: the `cargo install` may be several backslash
+# continuations further down (ci.yml's mutants job is exactly that shape). The
+# caller clears the chain on the first line that does not end in a backslash.
+opens_docker_chain() {
+    printf '%s\n' "$1" | grep -qE '(^|[[:space:]])docker[[:space:]]+run([[:space:]]|$)'
+}
+
+continues_line() {
+    printf '%s\n' "$1" | grep -qE '\\[[:space:]]*$'
+}
+
+# First component of an `export PATH=...` assignment, or empty if the line is
+# not such an assignment.
+path_first_entry() {
+    printf '%s\n' "$1" \
+        | sed -n 's/.*export[[:space:]][[:space:]]*PATH=["'"'"']\{0,1\}\([^:"'"'"']*\).*/\1/p'
+}
+
+# A PATH assignment is FRONT-SHARED when its first component is a $HOME dir or
+# the inherited $PATH (which on these runners contains ~/.cargo/bin). Such a
+# line cancels a private install root.
+path_front_is_shared() {
+    local first
+    first="$(path_first_entry "$1")"
+    [ -n "$first" ] || return 1
+    case "$first" in
+        '$HOME'/*|'${HOME}'/*|'~'/*|'$PATH'|'${PATH}') return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# ---------------------------------------------------------------------------
+# Self-test: must-match / must-not-match table.
+# ---------------------------------------------------------------------------
+self_test() {
+    local fails=0
+
+    probe() { # probe <fn> <expect 0|1> <line>
+        local fn="$1" want="$2" line="$3" got=0
+        "$fn" "$line" || got=1
+        if [ "$got" != "$want" ]; then
+            printf 'CASE-FAIL %s expected=%s got=%s on: %s\n' "$fn" "$want" "$got" "$line" >&2
+            fails=$((fails + 1))
+        fi
+    }
+
+    # is_install MUST match
+    probe is_install 0 '          cargo install cargo-llvm-cov --locked'
+    probe is_install 0 '        run: cargo install pmat --locked'
+    probe is_install 0 '  command -v pmat >/dev/null 2>&1 || cargo install pmat --locked || true'
+    probe is_install 0 '            cargo install cargo-mutants --locked'
+    probe is_install 0 '          cargo install --path crates/apr-cli --force'
+    # is_install MUST NOT match
+    probe is_install 1 '          # cargo install writes to ~/.cargo/bin'
+    probe is_install 1 '        name: Install cargo-mutants'
+    probe is_install 1 '          echo "cargo installed already"'
+    probe is_install 1 '          cargo build --release'
+    probe is_install 1 '          cargo-install-helper --run'
+
+    # has_explicit_root
+    probe has_explicit_root 0 'cargo install cargo-llvm-cov --locked --root "$COV_TOOLS"'
+    probe has_explicit_root 0 'cargo install pmat --root=/tmp/x'
+    probe has_explicit_root 1 'cargo install pmat --locked'
+    probe has_explicit_root 1 'cargo install pmat --rooted'
+
+    # declares_private_root
+    probe declares_private_root 0 '      CARGO_HOME: /tmp/cargo-home-security-intel-clean-room-14'
+    probe declares_private_root 0 '      CARGO_INSTALL_ROOT: /tmp/apr-cov-tools-123-1'
+    probe declares_private_root 0 '          export CARGO_INSTALL_ROOT=/tmp/tools'
+    probe declares_private_root 1 '          export CARGO_INSTALL_ROOT="$HOME/.cargo"'
+    probe declares_private_root 1 '      CARGO_HOME: ~/.cargo'
+    probe declares_private_root 1 '          # CARGO_INSTALL_ROOT would help here'
+    probe declares_private_root 1 '          export PATH="$HOME/.cargo/bin:$PATH"'
+
+    # opens_docker_chain
+    probe opens_docker_chain 0 '          docker run --rm \'
+    probe opens_docker_chain 1 '          if docker image inspect "$IMAGE" > /dev/null 2>&1'
+    probe opens_docker_chain 1 '          echo "docker running"'
+
+    # path_front_is_shared
+    probe path_front_is_shared 0 '          export PATH="$HOME/.cargo/bin:$HOME/.local/bin:$PATH"'
+    probe path_front_is_shared 0 '          export PATH="$PATH:$COV_TOOLS/bin"'
+    probe path_front_is_shared 0 "          export PATH=~/.cargo/bin:\$PATH"
+    probe path_front_is_shared 1 '          export PATH="$COV_TOOLS/bin:$HOME/.cargo/bin:$PATH"'
+    probe path_front_is_shared 1 '          export PATH="/tmp/tools/bin:$PATH"'
+    probe path_front_is_shared 1 '          echo "PATH is $PATH"'
+
+    if [ "$fails" -gt 0 ]; then
+        printf '\nSELF-TEST FAILED: %s failing probe(s).\n' "$fails" >&2
+        return 1
+    fi
+    printf 'OK: classifier case table passes.\n'
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# Scan
+# ---------------------------------------------------------------------------
+
+# Emit "<start>\t<end>\t<job id>" for every job in a workflow file.
+job_ranges() {
+    awk '
+        /^jobs:[[:space:]]*$/ { injobs=1; next }
+        /^[A-Za-z]/ && injobs && job { print start "\t" NR-1 "\t" job; job=""; injobs=0; next }
+        /^[A-Za-z]/ { injobs=0; next }
+        injobs && /^  [A-Za-z0-9_.-]+:[[:space:]]*$/ {
+            if (job) print start "\t" NR-1 "\t" job
+            job=$0
+            sub(/^  /,"",job)
+            sub(/:.*$/,"",job)
+            start=NR
+        }
+        END { if (job) print start "\t" NR "\t" job }
+    ' "$1"
+}
+
+violations=0
+jobs_scanned=0
+installs_seen=0
+
+check_job() {
+    local file="$1" job="$2" start="$3" end="$4"
+    local key="${file##*/}:$job"
+    local selfhosted=0 privroot=0
+    local line trimmed docker_chain=0 lineno
+
+    # Pass 1: job-wide facts (runs-on, private-root declarations anywhere in the
+    # job - job env, step env, or an inline export).
+    while IFS= read -r line; do
+        if printf '%s\n' "$line" | grep -q 'runs-on:' && printf '%s\n' "$line" | grep -q 'self-hosted'; then
+            selfhosted=1
+        fi
+        trimmed="$(printf '%s' "$line" | sed 's/^[[:space:]]*//')"
+        case "$trimmed" in '#'*) continue ;; *) ;; esac
+        if declares_private_root "$line"; then
+            privroot=1
+        fi
+    done < <(sed -n "${start},${end}p" "$file")
+
+    jobs_scanned=$((jobs_scanned + 1))
+    [ "$selfhosted" = 1 ] || return 0
+
+    # Pass 2: the installs themselves, plus the PATH-order rule.
+    lineno=$((start - 1))
+    while IFS= read -r line; do
+        lineno=$((lineno + 1))
+        trimmed="$(printf '%s' "$line" | sed 's/^[[:space:]]*//')"
+        case "$trimmed" in
+            '#'*)
+                continues_line "$line" || docker_chain=0
+                continue
+                ;;
+            *) ;;
+        esac
+
+        if opens_docker_chain "$line"; then
+            docker_chain=1
+        fi
+
+        if is_install "$line"; then
+            installs_seen=$((installs_seen + 1))
+            if [ "$docker_chain" = 1 ]; then
+                : # containerized: the container owns its own CARGO_HOME
+            elif has_explicit_root "$line" || [ "$privroot" = 1 ]; then
+                : # private root
+            elif is_exempt "$key"; then
+                printf 'EXEMPT   %s:%s (%s) shared-root install, allowlisted\n' \
+                    "$file" "$lineno" "$key"
+            else
+                printf 'SHARED-INSTALL %s:%s (job %s)\n' "$file" "$lineno" "$job"
+                printf '               %s\n' "$trimmed"
+                violations=$((violations + 1))
+            fi
+        fi
+
+        # A private root that PATH then front-runs with $HOME/.cargo/bin is
+        # decorative: the shared copy still wins resolution.
+        if [ "$privroot" = 1 ] && path_front_is_shared "$line"; then
+            printf 'SHARED-PATH-FIRST %s:%s (job %s)\n' "$file" "$lineno" "$job"
+            printf '                  %s\n' "$trimmed"
+            violations=$((violations + 1))
+        fi
+
+        continues_line "$line" || docker_chain=0
+    done < <(sed -n "${start},${end}p" "$file")
+}
+
+main() {
+    local f start end job
+    for f in "$WORKFLOW_DIR"/*.yml; do
+        [ -f "$f" ] || continue
+        while IFS="$(printf '\t')" read -r start end job; do
+            [ -n "$job" ] || continue
+            check_job "$f" "$job" "$start" "$end"
+        done < <(job_ranges "$f")
+    done
+
+    if [ "$violations" -gt 0 ]; then
+        printf '\n%s shared-~/.cargo/bin exposure(s) on self-hosted jobs.\n' "$violations" >&2
+        printf 'mac-server runs 16 runners under one $HOME, so `cargo install` there\n' >&2
+        printf 'replaces a binary that another running job is about to exec (aprender#2353:\n' >&2
+        printf 'cargo-llvm-cov, ENOENT, empty coverage figure). Give the job a per-run root:\n' >&2
+        printf '  env:\n' >&2
+        printf '    CARGO_INSTALL_ROOT: /tmp/<tool>-${{ github.run_id }}-${{ github.run_attempt }}\n' >&2
+        printf '  ... and put "$CARGO_INSTALL_ROOT/bin" FIRST on PATH.\n' >&2
+        exit 1
+    fi
+
+    # Fail closed: a scanner that examined nothing must not report success.
+    if [ "$jobs_scanned" -lt "$MIN_EXPECTED_JOBS" ]; then
+        printf 'ERROR: scanned %s job(s), expected >= %s - job discovery has gone blind.\n' \
+            "$jobs_scanned" "$MIN_EXPECTED_JOBS" >&2
+        exit 1
+    fi
+
+    printf 'OK: %s workflow job(s) scanned, %s cargo install(s); no self-hosted job writes the shared ~/.cargo/bin.\n' \
+        "$jobs_scanned" "$installs_seen"
+}
+
+case "${1:-}" in
+    --self-test) self_test ;;
+    *) main ;;
+esac

--- a/scripts/check_clippy_current_stable.sh
+++ b/scripts/check_clippy_current_stable.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# check_clippy_current_stable.sh - the CEILING gate (aprender#2370).
+#
+# `scripts/check_msrv.sh` proves the workspace still builds on its declared FLOOR.
+# Nothing proved the ceiling: every gate we own - `make tier1/2/3`, the sovereign-ci
+# `lint` job - runs through `rust-toolchain.toml`, which pins one exact release. So
+# clippy findings introduced by NEWER clippy releases accumulate with nothing to
+# report them, and the first person to see them is whoever's toolchain the pin does
+# not reach. That is aprender#2370: a fresh mbp ran `make`, got clippy 1.96 (a
+# homebrew rustc is not rustup-managed, so the pin is silently inert), and 28 errors
+# came out of `cargo clippy -- -D warnings` in `tier2` - none of which any gate here
+# had ever seen. The pin is not the bug; the pin being the ONLY thing we ever lint
+# under is the bug.
+#
+# This script closes that by linting on whatever stable is CURRENT, and failing.
+#
+# It refuses to pass vacuously. Three ways this gate could report a meaningless
+# green, all of them checked before any linting happens:
+#   1. `stable` resolves to something OLDER than the pin (a stale local rustup that
+#      never self-updated) - then "clean on current stable" is a lie about a
+#      toolchain we already lint under. FAIL.
+#   2. clippy is not installed for that toolchain - `cargo clippy` would error, but
+#      we say so in one line instead of a cargo backtrace. FAIL.
+#   3. the version comparator is wrong. Shell string comparison says 1.9 > 1.10 and
+#      1.99 > 1.100, which would make check (1) pass on exactly the drift it exists
+#      to catch. The comparator therefore ships a case table and runs it on EVERY
+#      invocation (`--self-test` runs only the table and exits).
+#
+# What it does NOT prove: clippy's lint set is not monotonic, so "clean on current
+# stable" does not imply "clean on every release between the pin and it". Measured
+# while fixing #2370: the tree is clean on 1.93 (the pin), 1.96 and 1.97 (then
+# current), and 1.95 alone reported 8 `collapsible_match` findings that neither
+# neighbour emits. So a green here still leaves an intermediate release able to go
+# red; that is a smaller hole than the one this closes, and it shrinks on its own as
+# people upgrade. Do not read a pass as "every toolchain is clean".
+#
+# RED-turning mutation (verified): revert any fix from aprender#2370 - e.g. put
+# `.map(std::num::NonZero::get).unwrap_or(1)` back in crates/aprender-common/src/sys.rs
+# - and this exits 1 with `error: called map(<f>).unwrap_or(<a>) on a Result value`.
+# Mutating the comparator (`ver_ge` returning 0 unconditionally) turns the self-test
+# RED without needing a toolchain at all.
+#
+# Usage:
+#   bash scripts/check_clippy_current_stable.sh              # self-test, then lint
+#   bash scripts/check_clippy_current_stable.sh --self-test  # comparator table only
+set -euo pipefail
+cd "$(dirname "$0")/.." || exit 2
+
+# ── version comparator ──────────────────────────────────────────────
+# ver_ge A B  → success when version A >= version B, numerically, per component.
+# Missing components read as 0, so "1.93" == "1.93.0".
+ver_ge() {
+    local a="$1" b="$2" i a_i b_i
+    local -a av bv
+    IFS='.' read -r -a av <<<"$a"
+    IFS='.' read -r -a bv <<<"$b"
+    for i in 0 1 2; do
+        a_i="${av[i]:-0}"
+        b_i="${bv[i]:-0}"
+        # strip any pre-release/suffix noise, keep leading digits only
+        a_i="${a_i%%[!0-9]*}"
+        b_i="${b_i%%[!0-9]*}"
+        a_i="${a_i:-0}"
+        b_i="${b_i:-0}"
+        if [ "$a_i" -gt "$b_i" ]; then return 0; fi
+        if [ "$a_i" -lt "$b_i" ]; then return 1; fi
+    done
+    return 0
+}
+
+# ── the case table ──────────────────────────────────────────────────
+# Every row is "A B expected", expected ∈ {ge, lt}. The 1.9/1.10 and 1.99/1.100
+# rows are the lexicographic traps: a string comparator gets exactly those wrong,
+# and getting them wrong is what makes the vacuity check pass when it must fail.
+self_test() {
+    local -a cases=(
+        "1.97.1 1.93.0 ge"   # newer stable than the pin - the normal case
+        "1.93.0 1.97.1 lt"   # stale rustup - MUST be caught
+        "1.93.0 1.93.0 ge"   # pin already IS current stable - still a real run
+        "1.93 1.93.0 ge"     # missing patch component reads as 0
+        "1.93.0 1.93 ge"
+        "1.94.0 1.93.9 ge"   # minor outranks patch
+        "1.10.0 1.9.0 ge"    # LEXICOGRAPHIC TRAP: "1.10" < "1.9" as strings
+        "1.9.0 1.10.0 lt"
+        "1.100.0 1.99.0 ge"  # LEXICOGRAPHIC TRAP: three-digit minor
+        "1.99.0 1.100.0 lt"
+        "2.0.0 1.999.999 ge" # major outranks everything
+        "1.999.999 2.0.0 lt"
+    )
+    local row a b want got fails=0
+    for row in "${cases[@]}"; do
+        read -r a b want <<<"$row"
+        if ver_ge "$a" "$b"; then got=ge; else got=lt; fi
+        if [ "$got" != "$want" ]; then
+            echo "  ✗ ver_ge $a $b → $got (expected $want)" >&2
+            fails=$((fails + 1))
+        fi
+    done
+    if [ "$fails" -ne 0 ]; then
+        echo "check_clippy_current_stable: comparator self-test FAILED ($fails/${#cases[@]} rows)" >&2
+        echo "  The vacuity check below relies on this comparator; refusing to lint." >&2
+        return 1
+    fi
+    echo "✓ comparator self-test: ${#cases[@]}/${#cases[@]} rows"
+    return 0
+}
+
+self_test || exit 1
+if [ "${1:-}" = "--self-test" ]; then
+    exit 0
+fi
+
+# ── resolve the pin and the current stable ──────────────────────────
+PINNED="$(grep -m1 '^channel' rust-toolchain.toml | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' || true)"
+if [ -z "$PINNED" ]; then
+    echo "check_clippy_current_stable: rust-toolchain.toml pins a non-numeric channel;" >&2
+    echo "  nothing to compare against - treating that as an unpinned tree is not safe." >&2
+    exit 2
+fi
+
+echo "Pinned channel (rust-toolchain.toml): $PINNED"
+echo "→ rustup toolchain install stable (clippy component)"
+rustup toolchain install stable --profile minimal --component clippy --no-self-update
+
+STABLE_RUSTC="$(rustup run stable rustc --version)"
+STABLE_VER="$(printf '%s' "$STABLE_RUSTC" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
+[ -n "$STABLE_VER" ] || {
+    echo "check_clippy_current_stable: could not parse a version out of: $STABLE_RUSTC" >&2
+    exit 2
+}
+
+# Prove clippy is really there - a missing component must not read as "no findings".
+STABLE_CLIPPY="$(rustup run stable cargo clippy --version)" || {
+    echo "check_clippy_current_stable: clippy is not installed for the stable toolchain." >&2
+    echo "  Fix: rustup component add clippy --toolchain stable" >&2
+    exit 2
+}
+
+echo "Current stable: $STABLE_RUSTC / $STABLE_CLIPPY"
+
+if ! ver_ge "$STABLE_VER" "$PINNED"; then
+    echo "✗ VACUOUS RUN REFUSED: 'stable' resolved to $STABLE_VER, which is OLDER than" >&2
+    echo "  the pinned $PINNED. Linting under it would prove nothing this repo does not" >&2
+    echo "  already prove on every PR. Fix: rustup self update && rustup update stable" >&2
+    exit 2
+fi
+
+# ── the actual gate ─────────────────────────────────────────────────
+# The sovereign-ci `lint` job's command, on current stable instead of the pin. Its
+# scope is a superset of the `cargo clippy -- -D warnings` that `make tier2` runs -
+# same packages, plus the root package's test/bench/example targets. Do NOT read the
+# status through a pipe (see CLAUDE.md "Verification Discipline" #1).
+echo "→ cargo +stable clippy --all-targets -- -D warnings   (pin $PINNED → stable $STABLE_VER)"
+if rustup run stable cargo clippy --all-targets -- -D warnings; then
+    echo "✓ clean under current stable clippy ($STABLE_VER); the pin is $PINNED"
+else
+    rc=$?
+    echo "✗ TOOLCHAIN CEILING DRIFT: the tree does NOT pass clippy on current stable" >&2
+    echo "  ($STABLE_VER). It still passes on the pinned $PINNED, which is why no PR" >&2
+    echo "  gate caught this - see aprender#2370." >&2
+    echo "  Fix the findings above. Do not relax the lint; if one is genuinely wrong" >&2
+    echo "  for this codebase, #[allow(...)] it with a comment giving the reason." >&2
+    exit "$rc"
+fi

--- a/scripts/check_story_pmat_hunt.sh
+++ b/scripts/check_story_pmat_hunt.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+# check_story_pmat_hunt.sh - prove the qwen story's pmat bug-hunt manifest can
+# actually produce rows, and that it goes RED when it cannot.
+#
+# The nightly emitted eight manifest headers and zero rows every night since the
+# cron was added (#2356), so the workflow's "manifest grew by >5" alert branch
+# never had a non-zero input. Three causes, all silent:
+#
+#   1. the jq filters named `.function` / `.churn.commit_count` / `.faults`;
+#      pmat emits `function_name` / `commit_count` / `fault_annotations`.
+#      `select(.function != null)` discarded every record before formatting.
+#   2. the churn and fault hunts passed the beat label as a free-text query.
+#      That is a relevance filter applied BEFORE `--path`, so a module-scoped
+#      hunt collapsed to nothing.
+#   3. three of the hunted paths had been deleted or moved.
+#
+# These are BEHAVIOURAL assertions: they run the REAL pmat_rows / pmat_hunt from
+# scripts/lib_story_pmat.sh against a stub `pmat` whose JSON shape and whose
+# query-narrows-before-path behaviour are both taken from measurements on pmat
+# 3.30.0. A grep-for-the-field-name guard would not have caught cause 2 at all,
+# and would have to be rewritten every time the formatter changes.
+#
+# Exit 0 = the manifest formats rows from pmat's real field names, and an empty
+#          manifest fails the beat instead of passing silently.
+# Exit 1 = at least one assertion failed.
+
+set -uo pipefail
+
+cd "$(dirname "$0")/.." || exit 1
+
+LIB="scripts/lib_story_pmat.sh"
+STORY="scripts/qwen-story.sh"
+[ -f "$LIB" ] || { echo "check_story_pmat_hunt: missing $LIB"; exit 1; }
+
+fails=0
+ok()  { printf '  ok    %s\n' "$1"; }
+bad() { fails=$((fails+1)); printf '  FAIL  %s\n     expected: %s\n     actual:   %s\n' "$1" "$2" "$3"; }
+want() { # name expected actual
+  # Body on its own line: with the `[ ... ]` on the same line as `want()`,
+  # bashrs reads the function-definition parentheses as unescaped parens inside
+  # a test and errors (SC1028).
+  if [ "$2" = "$3" ]; then ok "$1"; else bad "$1" "$2" "$3"; fi
+}
+
+TMP=$(mktemp -d "${TMPDIR:-/tmp}/story-pmat-check.XXXXXX") || exit 1
+trap 'rm -rf "$TMP"' EXIT
+
+# -- the stub ---------------------------------------------------------------
+# Mirrors pmat 3.30.0 as measured on this tree:
+#   * records are keyed function_name / impact_score / commit_count /
+#     churn_score / fault_annotations, and fault_annotations is null for a
+#     function with no annotations;
+#   * a free-text query is a relevance filter applied BEFORE --path, so
+#     `query "some words" --path <module>` returns [] while the same call
+#     without the words returns rows. That asymmetry is cause 2, and encoding
+#     it here is what makes re-adding the beat label turn this check red.
+mkdir -p "$TMP/bin"
+# The stub's shebang is printf'd rather than written into the heredoc: a literal
+# `#!` at the start of a line makes bashrs report SC1128 ("the shebang must be
+# on the first line") against THIS file, at the heredoc's line number.
+printf '#!/usr/bin/env bash\n' > "$TMP/bin/pmat"
+cat >> "$TMP/bin/pmat" <<'STUB'
+# Stub pmat for check_story_pmat_hunt.sh.
+case "${STUB_MODE:-rows}" in
+  empty) printf '[]\n'; exit 0 ;;
+  docs)  printf '{"documents":[{"path":"a.rs"},{"path":"b.rs"}]}\n'; exit 0 ;;
+esac
+shift  # drop the `query` subcommand
+# A leading non-flag argument is a free-text semantic query.
+if [ "$#" -gt 0 ] && [ "${1#-}" = "$1" ]; then
+  printf '[]\n'
+  exit 0
+fi
+cat <<'JSON'
+[
+  {"function_name":"cache_path","file_path":"x.rs","impact_score":42,
+   "commit_count":7,"churn_score":0.5,"fault_annotations":["CLONE","UNWRAP"]},
+  {"function_name":"parse","file_path":"x.rs","impact_score":9,
+   "commit_count":3,"churn_score":0.1,"fault_annotations":null},
+  {"function_name":"ModelSource","file_path":"x.rs","impact_score":0,
+   "commit_count":3,"churn_score":0.1,"fault_annotations":["PANIC"]}
+]
+JSON
+STUB
+chmod +x "$TMP/bin/pmat"
+PATH="$TMP/bin:$PATH"
+export PATH
+
+echo "check_story_pmat_hunt: manifest row formatting and the zero-row andon"
+
+# -- 0. The library refuses to load without the caller's tally function -----
+# pmat_hunt calls emit_fail. Discovering that is missing halfway through a
+# nightly is how an advisory helper takes the whole run down.
+( unset -f emit_fail 2>/dev/null; . "$LIB" ) >/dev/null 2>&1
+want "library refuses to source when emit_fail is undefined" "1" "$?"
+
+FAILLOG="$TMP/emit_fail.log"
+emit_fail() { printf '%s :: %s\n' "$1" "$2" >> "$FAILLOG"; }
+# shellcheck source=scripts/lib_story_pmat.sh
+. "$LIB" || { echo "check_story_pmat_hunt: could not source $LIB"; exit 1; }
+
+# -- 1. Each filter reads a field pmat ACTUALLY emits ------------------------
+# Under the pre-fix filters every one of these is empty: the row guard was
+# `select(.function != null)` and `.function` is null on every pmat record.
+got=$(pmat_rows "$PMAT_FILTER_GAP" --coverage-gaps --path x.rs --rank-by impact --limit 3)
+want "gap rows carry function_name and impact_score" \
+  "        gap   cache_path (impact=42)" "$(printf '%s\n' "$got" | head -1)"
+want "gap block has 3 rows" "3" "$(printf '%s\n' "$got" | grep -c .)"
+
+got=$(pmat_rows "$PMAT_FILTER_CHURN" --path x.rs --churn --limit 3)
+want "churn rows read commit_count, not .churn.commit_count" \
+  "        churn cache_path (commits=7)" "$(printf '%s\n' "$got" | head -1)"
+
+got=$(pmat_rows "$PMAT_FILTER_FAULT" --path x.rs --faults --exclude-tests --limit 3)
+want "fault rows read fault_annotations, not .faults" \
+  "        fault cache_path (CLONE,UNWRAP)" "$(printf '%s\n' "$got" | head -1)"
+# A function with no annotations must not produce `fault parse ()`: that row is
+# noise, and being non-empty it would also defeat the zero-row andon below.
+want "fault block skips records whose fault_annotations is null" "2" \
+  "$(printf '%s\n' "$got" | grep -c .)"
+
+# -- 2. The document-fallback shape yields nothing, not a jq error -----------
+got=$(STUB_MODE=docs pmat_rows "$PMAT_FILTER_GAP" --coverage-gaps --path x.rs)
+want "the {\"documents\":[...]} fallback shape yields no rows" "" "$got"
+
+# -- 3. A free-text query before --path collapses a module-scoped hunt -------
+# This is cause 2 stated as behaviour rather than as a comment. If a future
+# edit re-adds the beat label as a query argument, this row goes empty and the
+# hunt in assertion 4 turns red.
+got=$(pmat_rows "$PMAT_FILTER_CHURN" "qa validate lint" --path x.rs --churn --limit 3)
+want "a leading free-text query returns nothing for a module-scoped path" "" "$got"
+
+# -- 4. A hunt that finds rows passes and does not tally a failure ----------
+: > "$FAILLOG"
+out=$(PMAT_HUNT=1 pmat_hunt "check" "$LIB"); rc=$?
+want "a hunt with rows returns 0" "0" "$rc"
+want "a hunt with rows tallies no failure" "" "$(cat "$FAILLOG")"
+
+# EACH of the three query kinds must contribute, checked SEPARATELY.
+#
+# This started as one grep for `(gap|churn|fault)`, and re-adding the beat label
+# to the churn call - the exact pre-fix shape, cause 2 - left it GREEN: the gap
+# call carries no free-text query, so it still produced rows, PMAT_HUNT_ROWS was
+# non-zero and the hunt passed. An aggregate row count cannot see one of three
+# queries go silent, which is the same blindness that let the whole manifest go
+# inert. Per-kind assertions are what turn that mutation red.
+for kind in gap churn fault; do
+  n=$(printf '%s\n' "$out" | grep -cE "^        $kind ")
+  if [ "$n" -gt 0 ]; then
+    ok "the hunt emitted $kind rows ($n)"
+  else
+    bad "the hunt emitted $kind rows" ">= 1" "0 (whole manifest: $out)"
+  fi
+done
+
+# -- 5. A hunt that finds NOTHING must go RED -------------------------------
+# The whole point of #2356: pmat_hunt used to `return 0` unconditionally, so
+# eight empty manifests a night were indistinguishable from clean code.
+: > "$FAILLOG"
+out=$(STUB_MODE=empty PMAT_HUNT=1 pmat_hunt "check" "$LIB"); rc=$?
+want "a hunt with zero rows returns 1" "1" "$rc"
+if grep -q 'pmat-hunt check' "$FAILLOG"; then
+  ok "a hunt with zero rows calls emit_fail"
+else
+  bad "a hunt with zero rows calls emit_fail" "a pmat-hunt failure" "$(cat "$FAILLOG")"
+fi
+if printf '%s\n' "$out" | grep -q -- '-- pmat bug-hunt manifest'; then
+  ok "the empty hunt did print a header (this is the inert shape being caught)"
+else
+  bad "the empty hunt did print a header" "a header" "$out"
+fi
+
+# -- 6. A deleted path is named, not merely counted -------------------------
+: > "$FAILLOG"
+STUB_MODE=empty PMAT_HUNT=1 pmat_hunt "check" "scripts/does_not_exist.rs" >/dev/null 2>&1
+if grep -q 'do not exist:.*does_not_exist.rs' "$FAILLOG"; then
+  ok "a hunted path that no longer exists is named in the failure"
+else
+  bad "a hunted path that no longer exists is named in the failure" \
+    "message naming does_not_exist.rs" "$(cat "$FAILLOG")"
+fi
+
+# -- 7. PMAT_HUNT=0 stays silent and stays green ----------------------------
+# The opt-out must not print a header, or the workflow's manifest extractor
+# would count an opt-out as growth.
+: > "$FAILLOG"
+out=$(PMAT_HUNT=0 pmat_hunt "check" "$LIB"); rc=$?
+want "PMAT_HUNT=0 returns 0" "0" "$rc"
+want "PMAT_HUNT=0 prints nothing" "" "$out"
+want "PMAT_HUNT=0 tallies no failure" "" "$(cat "$FAILLOG")"
+
+# -- 8. Every path the story hunts still exists -----------------------------
+# Cause 3. Static, because a path can rot without anyone running the nightly.
+if [ -f "$STORY" ]; then
+  missing=""
+  checked=0
+  while read -r p; do
+    checked=$((checked + 1))
+    [ -e "$p" ] || missing="$missing $p"
+  done < <(grep -oE '(crates|src)/[A-Za-z0-9_./-]+' "$STORY" \
+             | grep -E '\.rs$|/serve$' | sort -u)
+  want "every source path hunted by qwen-story.sh exists" "" "$missing"
+  # Fail closed: a discovery step that found nothing must not report success.
+  if [ "$checked" -ge 15 ]; then
+    ok "path discovery found $checked hunted paths"
+  else
+    bad "path discovery found enough hunted paths" ">= 15" "$checked"
+  fi
+fi
+
+echo
+if [ "$fails" -eq 0 ]; then
+  echo "check_story_pmat_hunt: OK - the manifest produces rows, and an empty one fails the beat"
+  exit 0
+fi
+echo "check_story_pmat_hunt: $fails assertion(s) FAILED"
+exit 1

--- a/scripts/dispatch-phase6-publish.sh
+++ b/scripts/dispatch-phase6-publish.sh
@@ -124,7 +124,14 @@ if [ "${PUBLISH_HOST}" = "gx10" ]; then
     "
 else
     echo "=== dispatching apr publish locally ==="
-    /mnt/nvme-raid0/targets/aprender/release/apr publish "${APR_PUBLISH_ARGS[@]}"
+    # The local branch hardcoded /mnt/nvme-raid0/targets/aprender/release/apr
+    # while the gx10 branch three lines up correctly used a checkout-relative
+    # ./target/release/apr - the same publish, one path per host, only one of
+    # them pinned. That /mnt path is orphaned (nothing writes it), so a local
+    # publish shipped a model to Hugging Face using a binary of unknown age
+    # (#2358). Ask cargo instead.
+    . "$(dirname "$0")/apr_bin.sh" || exit 1
+    "$APR" publish "${APR_PUBLISH_ARGS[@]}"
 fi
 
 echo

--- a/scripts/gen-cli-chapter-stubs.sh
+++ b/scripts/gen-cli-chapter-stubs.sh
@@ -15,11 +15,10 @@ cd "$ROOT"
 CLI_DIR="book/src/cli"
 mkdir -p "$CLI_DIR"
 
-APR="${APR:-/home/noah/.cargo/bin/apr}"
-if ! [ -x "$APR" ]; then
-  echo "error: apr binary not found at $APR — set APR=path/to/apr" >&2
-  exit 2
-fi
+# This generator writes book chapters from `apr --help`. Hardcoding one
+# developer's ~/.cargo/bin meant the generated chapters documented whatever was
+# installed there, on any machine that happened to have it (#2358).
+. scripts/apr_bin.sh || exit 2
 
 # Categories drive the example. Default is `apr <cmd> --help`.
 declare -A EXAMPLE

--- a/scripts/lib_story_pmat.sh
+++ b/scripts/lib_story_pmat.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# lib_story_pmat.sh - the qwen story's pmat bug-hunt manifest.
+#
+# Why this exists
+# ---------------
+# The nightly ran the hunt on every one of its 8 beats and produced ZERO rows,
+# every night, since the cron was added (#2356). Eight headers, no content. The
+# workflow's "manifest grew by >5" alert branch therefore never had a non-zero
+# input and could not fire, so half the nightly's alerting was decorative.
+#
+# Three independent causes, each sufficient on its own:
+#
+#   1. THE JQ FILTERS NAMED FIELDS PMAT DOES NOT EMIT. `pmat query --format json`
+#      returns records keyed `function_name` / `commit_count` / `churn_score` /
+#      `fault_annotations` / `impact_score`. The filters read `.function`,
+#      `.churn.commit_count` and `.faults`. The row guard was
+#      `select(.function != null)`, which is null for EVERY record pmat has ever
+#      returned - so the guard discarded 100% of input before any interpolation
+#      ran. Measured on pmat 3.30.0:
+#
+#          $ pmat query --path crates/apr-cli/src/commands/qa.rs --churn \
+#              --limit 3 --format json | jq '.[0]|keys'
+#          [... "churn_score", "commit_count", ... "function_name", ...]
+#
+#   2. `--path` IS A POST-FILTER OVER THE SEMANTIC TOP-K, NOT A SEARCH SCOPE.
+#      The churn and fault hunts passed the beat label ("qa validate lint") as a
+#      free-text query. That query returns THREE records for the entire
+#      repository - pmat applies a relevance floor - and `--path` then filters
+#      those three. Measured, same tree, same pmat:
+#
+#          query + --path crates/apr-cli/src/commands/qa.rs  -> 0 rows
+#          query + --path crates/apr-cli/src/commands        -> 0 rows
+#          query + --path crates/apr-cli                     -> 2 rows
+#          query, no --path, --limit 100                     -> 3 rows
+#          NO query + --path crates/apr-cli/src/commands/qa.rs -> 3 rows
+#
+#      So the fix is not "widen the path" (a hunt scoped at crates/apr-cli is
+#      not a hunt of the module the beat exercised); it is to drop the free-text
+#      query and let --path do the scoping. A file-scoped --path returns rows
+#      perfectly well once nothing has already thrown away the candidates.
+#
+#   3. THREE OF THE PATHS NO LONGER EXIST. commands/list.rs (list now lives in
+#      pull.rs - `Commands::List => pull::list(...)`), commands/code.rs (moved to
+#      aprender-orchestrate/src/cli/code.rs) and commands/serve.rs (became the
+#      commands/serve/ directory). A hunt aimed at a deleted file is silent, and
+#      nothing said so.
+#
+# THE MANIFEST IS NO LONGER ADVISORY.
+# -----------------------------------
+# It used to be, and `pmat_hunt` returned 0 unconditionally while `pmat_rows`
+# ended in `|| true`. That is precisely why causes 1-3 survived: every one of
+# them presents as "the manifest is empty tonight", which was indistinguishable
+# from "the code is clean tonight". A hunt that prints a header and then no rows
+# now calls emit_fail and returns 1, so the story exits 2 and the cron files an
+# issue. Silence is a finding, not a pass.
+#
+# OPTION NEUTRALITY (load-bearing)
+# --------------------------------
+# This file is SOURCED. It must not run `set`: that mutates the CALLER's shell.
+# apr_bin.sh once opened with `set -euo pipefail`, qwen-story.sh sourced it, and
+# the leaked errexit killed the nightly six lines in - inside this very hunt.
+# Sourceable libraries here fail by RETURN STATUS. Enforced by
+# scripts/check_sourced_libs_option_neutral.sh.
+
+# emit_fail is the caller's tally function (it feeds FAILED_BEATS and the exit-2
+# verdict). Fail at SOURCE time rather than discovering it is missing halfway
+# through a nightly - and fail by return status, never by `set -e`.
+if ! declare -F emit_fail >/dev/null 2>&1; then
+  printf 'lib_story_pmat.sh: caller must define emit_fail() before sourcing this library\n' >&2
+  return 1 2>/dev/null || exit 1
+fi
+
+# The three row formatters, kept next to the field-name evidence above so a
+# rename in pmat's JSON has exactly one place to land.
+#
+# The fault filter drops records whose fault_annotations is null: pmat returns
+# every function in the path, annotated or not, and a bare "fault foo ()" row is
+# noise that would also defeat the zero-row check below by being technically
+# non-empty.
+PMAT_FILTER_GAP='"        gap   \(.function_name) (impact=\(.impact_score // "?"))"'
+PMAT_FILTER_CHURN='"        churn \(.function_name) (commits=\(.commit_count // "?"))"'
+PMAT_FILTER_FAULT='select((.fault_annotations // []) | length > 0)
+  | "        fault \(.function_name) (\(.fault_annotations | join(",")))"'
+
+# Extract rows from one `pmat query`, tolerating BOTH shapes pmat can return.
+#
+# A function query returns a JSON ARRAY of records, but when nothing matches
+# semantically pmat falls back to a document search and returns
+# `{"documents":[...]}`. Running `.[]` unconditionally on that yields the
+# documents ARRAY, and interpolating a field from an array raises "Cannot index
+# array with string" - jq exits 5. Guarding on `type == "array"` makes the
+# no-match case yield nothing instead of an error.
+#
+# pmat is invoked into a variable rather than piped, so PMAT_ROWS_EC is pmat's
+# OWN status and not jq's or head's. Reading `$?` after a pipeline is the defect
+# this repo has shipped four times.
+#
+# Args:   <jq-output-filter> <pmat query args...>
+# Sets:   PMAT_ROWS_EC  exit status of the `pmat query` invocation
+# Prints: at most 3 formatted rows (empty output when there are none)
+pmat_rows() {
+  local filter="$1"; shift
+  local raw prog rows
+  raw=$("${PMAT_BIN:-pmat}" query "$@" --format json 2>/dev/null)
+  PMAT_ROWS_EC=$?
+  [ "$PMAT_ROWS_EC" -eq 0 ] || return 0
+  # printf rather than a multi-line double-quoted string: bashrs reads the
+  # latter as an unterminated string (SC1078).
+  prog=$(printf '%s\n%s\n%s' \
+    'if type == "array" then .[] else empty end' \
+    '| select(.function_name != null)' \
+    "| $filter")
+  rows=$(printf '%s\n' "$raw" | jq -r "$prog" 2>/dev/null)
+  [ -n "$rows" ] || return 0
+  printf '%s\n' "$rows" | head -3
+}
+
+# Print one block of rows and add its line count to PMAT_HUNT_ROWS.
+_pmat_hunt_emit() {
+  [ -n "$1" ] || return 0
+  printf '%s\n' "$1"
+  local n
+  n=$(printf '%s\n' "$1" | grep -c .)
+  PMAT_HUNT_ROWS=$((PMAT_HUNT_ROWS + n))
+}
+
+# Run the pmat audit over a list of source paths the beat just exercised.
+# Outputs a compact manifest: top 3 coverage gaps, top 3 churn, top 3 faults per
+# path.
+#
+# Returns 0 when the manifest carried at least one row, 1 (and emit_fail) when
+# the header was printed with nothing under it. See "THE MANIFEST IS NO LONGER
+# ADVISORY" above.
+#
+# Args: <beat-label> <source-path...>
+pmat_hunt() {
+  local beat="$1"; shift
+  if [ "${PMAT_HUNT:-1}" != "1" ] || ! command -v "${PMAT_BIN:-pmat}" >/dev/null 2>&1; then
+    return 0
+  fi
+  printf '    -- pmat bug-hunt manifest (%s) --\n' "$beat"
+  PMAT_HUNT_ROWS=0
+  local paths=$# missing="" q gaps churn faults
+  # Each pmat_rows call is ONE physical line. Splitting a command substitution
+  # across a backslash continuation makes bashrs read the nested quotes as an
+  # unterminated string (SC1078, 6 errors), and FALSIFY-QWEN-STORY-007 requires
+  # these scripts to lint clean.
+  for q in "$@"; do
+    # A path that no longer exists is reported by name. Cause 3 above cost three
+    # beats worth of hunting, and "the manifest is empty" never once said so.
+    [ -e "$q" ] || missing="$missing $q"
+    # No free-text query in any of the three: it is a relevance filter applied
+    # BEFORE --path, and it collapses a module-scoped hunt to nothing. Cause 2.
+    gaps=$(pmat_rows "$PMAT_FILTER_GAP" --coverage-gaps --path "$q" --rank-by impact --limit 3)
+    churn=$(pmat_rows "$PMAT_FILTER_CHURN" --path "$q" --churn --max-complexity 30 --limit 3)
+    faults=$(pmat_rows "$PMAT_FILTER_FAULT" --path "$q" --faults --exclude-tests --limit 3)
+    _pmat_hunt_emit "$gaps"
+    _pmat_hunt_emit "$churn"
+    _pmat_hunt_emit "$faults"
+  done
+  printf '\n'
+  if [ "$PMAT_HUNT_ROWS" -eq 0 ]; then
+    if [ -n "$missing" ]; then
+      emit_fail "pmat-hunt $beat" "manifest header printed with 0 rows over $paths path(s); these do not exist:$missing"
+    else
+      emit_fail "pmat-hunt $beat" "manifest header printed with 0 rows over $paths existing path(s) - the hunt is inert (#2356). Check the JSON field names pmat emits, and that --path is not being narrowed by a free-text query."
+    fi
+    return 1
+  fi
+  return 0
+}

--- a/scripts/publish/albor-370m-publish-readiness.sh
+++ b/scripts/publish/albor-370m-publish-readiness.sh
@@ -30,9 +30,11 @@ Example (using the §85 P2-E ep49 checkpoint):
         /mnt/nvme-raid0/runs/model-2-p2e-tuned-hp-20260517/ckpt/epoch-049.apr
 
 The checkpoint MUST be the stamped variant (post-§86 salvage if it's
-a pre-P0-K artifact). To stamp:
+a pre-P0-K artifact). To stamp (pin the binary first — stamping metadata with
+an unknown-age apr is how a model ships with provenance it does not have):
 
-    apr stamp <pre-p0k.apr> \
+    . scripts/apr_bin.sh || exit 1
+    "$APR" stamp <pre-p0k.apr> \
         --architecture qwen2 \
         --hf-architecture Qwen2ForCausalLM \
         --hf-model-type qwen2 \

--- a/scripts/qualify-matrix.sh
+++ b/scripts/qualify-matrix.sh
@@ -18,13 +18,17 @@ MATRIX_FILE="${REPO_ROOT}/docs/qualify-matrix.md"
 TIMEOUT=180
 CACHED_ONLY=false
 
-# Find apr binary on PATH
-if ! command -v apr >/dev/null 2>&1; then
-    echo "ERROR: apr not found on PATH. Run:"
-    echo "  cargo install --path crates/apr-cli"
+# Resolve the binary THIS CHECKOUT builds, not whatever PATH holds (#2358).
+# This script writes docs/qualify-matrix.md — a published claim about which
+# models qualify. Sourced from PATH, that table described whichever apr was
+# installed first, which is how a 24-day-old binary came to certify a gate
+# merged the day before.
+if ! . "$(dirname "$0")/apr_bin.sh"; then
+    echo "ERROR: no apr binary built from HEAD. Run:" >&2
+    echo "  cargo build --release -p apr-cli --bin apr" >&2
     exit 1
 fi
-APR_BIN="$(command -v apr)"
+APR_BIN="$APR"
 
 # Local models (ordered smallest-first)
 LOCAL_MODELS=(

--- a/scripts/qwen-story.sh
+++ b/scripts/qwen-story.sh
@@ -94,63 +94,21 @@ emit_evidence() {
   printf '%s\n' "$RC_ALL" | sed 's/^/    /'
 }
 
-# Extract rows from one `pmat query`, tolerating BOTH shapes pmat can return.
+# pmat_rows / pmat_hunt live in a sourceable library so the manifest can be
+# driven directly against a stubbed pmat - see scripts/check_story_pmat_hunt.sh.
+# They ran here for months emitting eight headers and zero rows a night (#2356);
+# the library header records all three causes and the measurements behind them.
 #
-# A function query returns a JSON ARRAY of function records, but when nothing
-# matches semantically pmat falls back to a document search and returns
-# `{"documents":[...]}` instead. The original filter ran `.[] | \(.function)`
-# unconditionally: on the fallback shape `.[]` yields the documents ARRAY, and
-# interpolating `.function` from an array raises "Cannot index array with
-# function" - jq exits 5. Under `pipefail` the whole assignment then returned
-# 5, which is what killed the nightly story once errexit leaked in from
-# apr_bin.sh. Guarding on `type == "array"` makes the no-match case yield an
-# empty string instead of an error.
+# The hunt is NO LONGER ADVISORY: a header with no rows under it calls emit_fail
+# and fails the beat, because every one of those three causes presented as an
+# empty manifest and nothing could tell that apart from clean code. emit_fail
+# must therefore be defined before this point - the library checks and refuses
+# to load otherwise.
 #
-# `|| true` is deliberate and load-bearing: this manifest is ADVISORY. It
-# annotates the story, and must never be able to fail it - not via pmat's exit
-# status, not via jq, not via SIGPIPE from `head`.
-#
-# Args: <jq-output-filter> <pmat query args...>
-pmat_rows() {
-  local filter="$1"; shift
-  # The jq program is assembled with printf rather than written as a
-  # double-quoted string spanning several lines: bashrs reads the latter as an
-  # unterminated string (SC1078) and reported 2 errors here, which kept
-  # FALSIFY-QWEN-STORY-007 ("bashrs lints clean") red. Behaviour is unchanged -
-  # only the quoting is.
-  local prog
-  prog=$(printf '%s\n%s\n%s' \
-    'if type == "array" then .[] else empty end' \
-    '| select(.function != null)' \
-    "| $filter")
-  pmat query "$@" --format json 2>/dev/null \
-    | jq -r "$prog" 2>/dev/null \
-    | head -3 || true
-}
-
-# Run pmat full audit on a list of command module patterns. Outputs a compact
-# manifest (top 3 high-risk untested functions, top 3 churn, top 3 faults).
-pmat_hunt() {
-  local beat="$1"; shift
-  if [ "$PMAT_HUNT" != "1" ] || ! command -v pmat >/dev/null 2>&1; then
-    return 0
-  fi
-  printf '    -- pmat bug-hunt manifest (%s) --\n' "$beat"
-  for q in "$@"; do
-    local gaps churn faults
-    gaps=$(pmat_rows '"        gap   \(.function) (impact=\(.impact_score // "?"))"' \
-      --coverage-gaps --path "$q" --rank-by impact --limit 3)
-    churn=$(pmat_rows '"        churn \(.function) (commits=\(.churn.commit_count // "?"))"' \
-      "$beat" --path "$q" --churn --max-complexity 30 --limit 3)
-    faults=$(pmat_rows '"        fault \(.function) (\(.faults | join(",")))"' \
-      "$beat" --path "$q" --faults --exclude-tests --limit 3)
-    [ -n "$gaps" ]   && printf '%s\n' "$gaps"
-    [ -n "$churn" ]  && printf '%s\n' "$churn"
-    [ -n "$faults" ] && printf '%s\n' "$faults"
-  done
-  printf '\n'
-  return 0
-}
+# The explicit `|| exit 1` is what makes a missing library fatal; the library
+# itself must not run `set`, which would leak options into this script.
+# shellcheck source=scripts/lib_story_pmat.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib_story_pmat.sh" || exit 1
 
 # -- Beat 1: Discover (0.5B SafeTensors) --------------------------------------─
 beat1_discover() {
@@ -167,7 +125,9 @@ beat1_discover() {
     emit_fail "B1 list" "exit=$RC_EC"
     return
   fi
-  pmat_hunt "registry list" crates/apr-cli/src/commands/list.rs crates/apr-cli/src/commands/pull.rs
+  # No commands/list.rs: `Commands::List => pull::list(...)` - list and pull are
+  # the same module. The dead path was hunted nightly and returned nothing.
+  pmat_hunt "registry list" crates/apr-cli/src/commands/pull.rs
 }
 
 # The GGUF leg of Beat 2. Deliberately NOT named beat<N>_* - the story has
@@ -352,10 +312,12 @@ beat5_use() {
   else
     emit_skip "B5 apr code -p" "non-zero exit=$RC_EC (may need --model)"
   fi
+  # `apr code` moved out of apr-cli into aprender-orchestrate; commands/code.rs
+  # has not existed for some time and was hunted nightly regardless.
   pmat_hunt "run chat code" \
     crates/apr-cli/src/commands/run.rs \
     crates/apr-cli/src/commands/chat.rs \
-    crates/apr-cli/src/commands/code.rs
+    crates/aprender-orchestrate/src/cli/code.rs
 }
 
 # -- Beat 6: Serve (1.5B over HTTP) --------------------------------------------
@@ -395,8 +357,10 @@ beat6_serve() {
     emit_fail "B6 /v1/chat/completions" "no message.content in response"
   fi
   kill "$pid" 2>/dev/null; wait "$pid" 2>/dev/null
+  # commands/serve.rs became the commands/serve/ DIRECTORY (handlers, routes,
+  # server, ollama, auth). The file path had been dead for months.
   pmat_hunt "serve http chat-completions" \
-    crates/apr-cli/src/commands/serve.rs \
+    crates/apr-cli/src/commands/serve \
     crates/aprender-serve/src/api/cuda_chat_backend.rs
 }
 

--- a/scripts/ship-discharges/ship-002-discharge.sh
+++ b/scripts/ship-discharges/ship-002-discharge.sh
@@ -22,7 +22,16 @@
 set -euo pipefail
 
 # --- Defaults -----------------------------------------------------------
-APR_BINARY="${APR_BINARY:-/mnt/nvme-raid0/targets/aprender/release/apr}"
+# Default: the binary THIS CHECKOUT builds (#2358). The previous default was a
+# hardcoded /mnt/nvme-raid0/targets/aprender/release/apr - a path nothing writes
+# any more, and one that on 2026-08-01 was two minor versions stale while docs
+# still called it canonical. A discharge script signs off a SHIP; signing it off
+# with a binary of unknown provenance certifies nothing. `--apr-binary` and the
+# APR_BINARY env var both still override.
+APR_BINARY="${APR_BINARY:-}"
+if [ -z "$APR_BINARY" ] && . "$(dirname "$0")/../apr_bin.sh" 2>/dev/null; then
+    APR_BINARY="$APR"
+fi
 MODEL="${MODEL:-paiml/qwen2.5-coder-7b-apache-q4k-v1.safetensors}"
 PROMPT="def fib(n):"
 EVIDENCE_DIR="evidence/ship-002-full-discharge"

--- a/scripts/ship-discharges/ship-005-discharge.sh
+++ b/scripts/ship-discharges/ship-005-discharge.sh
@@ -24,7 +24,16 @@
 set -euo pipefail
 
 # --- Defaults -----------------------------------------------------------
-APR_BINARY="${APR_BINARY:-/mnt/nvme-raid0/targets/aprender/release/apr}"
+# Default: the binary THIS CHECKOUT builds (#2358). The previous default was a
+# hardcoded /mnt/nvme-raid0/targets/aprender/release/apr - a path nothing writes
+# any more, and one that on 2026-08-01 was two minor versions stale while docs
+# still called it canonical. A discharge script signs off a SHIP; signing it off
+# with a binary of unknown provenance certifies nothing. `--apr-binary` and the
+# APR_BINARY env var both still override.
+APR_BINARY="${APR_BINARY:-}"
+if [ -z "$APR_BINARY" ] && . "$(dirname "$0")/../apr_bin.sh" 2>/dev/null; then
+    APR_BINARY="$APR"
+fi
 MODEL="${MODEL:-paiml/qwen2.5-coder-7b-apache-q4k-v1}"
 NOMINAL_THRESHOLD="86.00"
 EFFECTIVE_THRESHOLD="84.80"  # nominal - 1.2 pp noise allowance

--- a/scripts/ship-discharges/ship-006-discharge.sh
+++ b/scripts/ship-discharges/ship-006-discharge.sh
@@ -23,7 +23,16 @@
 set -euo pipefail
 
 # --- Defaults -----------------------------------------------------------
-APR_BINARY="${APR_BINARY:-/mnt/nvme-raid0/targets/aprender/release/apr}"
+# Default: the binary THIS CHECKOUT builds (#2358). The previous default was a
+# hardcoded /mnt/nvme-raid0/targets/aprender/release/apr - a path nothing writes
+# any more, and one that on 2026-08-01 was two minor versions stale while docs
+# still called it canonical. A discharge script signs off a SHIP; signing it off
+# with a binary of unknown provenance certifies nothing. `--apr-binary` and the
+# APR_BINARY env var both still override.
+APR_BINARY="${APR_BINARY:-}"
+if [ -z "$APR_BINARY" ] && . "$(dirname "$0")/../apr_bin.sh" 2>/dev/null; then
+    APR_BINARY="$APR"
+fi
 MODEL="${MODEL:-paiml/qwen2.5-coder-7b-apache-q4k-v1}"
 REQUIRED_GATE_COUNT=8
 EVIDENCE_DIR="evidence/ship-006-full-discharge"

--- a/scripts/ship-discharges/ship-007-discharge.sh
+++ b/scripts/ship-discharges/ship-007-discharge.sh
@@ -23,7 +23,16 @@
 set -euo pipefail
 
 # --- Defaults -----------------------------------------------------------
-APR_BINARY="${APR_BINARY:-/mnt/nvme-raid0/targets/aprender/release/apr}"
+# Default: the binary THIS CHECKOUT builds (#2358). The previous default was a
+# hardcoded /mnt/nvme-raid0/targets/aprender/release/apr - a path nothing writes
+# any more, and one that on 2026-08-01 was two minor versions stale while docs
+# still called it canonical. A discharge script signs off a SHIP; signing it off
+# with a binary of unknown provenance certifies nothing. `--apr-binary` and the
+# APR_BINARY env var both still override.
+APR_BINARY="${APR_BINARY:-}"
+if [ -z "$APR_BINARY" ] && . "$(dirname "$0")/../apr_bin.sh" 2>/dev/null; then
+    APR_BINARY="$APR"
+fi
 MODEL="${MODEL:-paiml/qwen2.5-coder-7b-apache-q4k-v1}"
 ITERATIONS=5
 MAX_TOKENS=128

--- a/scripts/ship-discharges/ship-008-discharge.sh
+++ b/scripts/ship-discharges/ship-008-discharge.sh
@@ -29,7 +29,16 @@
 set -euo pipefail
 
 # --- Defaults -----------------------------------------------------------
-APR_BINARY="${APR_BINARY:-/mnt/nvme-raid0/targets/aprender/release/apr}"
+# Default: the binary THIS CHECKOUT builds (#2358). The previous default was a
+# hardcoded /mnt/nvme-raid0/targets/aprender/release/apr - a path nothing writes
+# any more, and one that on 2026-08-01 was two minor versions stale while docs
+# still called it canonical. A discharge script signs off a SHIP; signing it off
+# with a binary of unknown provenance certifies nothing. `--apr-binary` and the
+# APR_BINARY env var both still override.
+APR_BINARY="${APR_BINARY:-}"
+if [ -z "$APR_BINARY" ] && . "$(dirname "$0")/../apr_bin.sh" 2>/dev/null; then
+    APR_BINARY="$APR"
+fi
 MODEL="${MODEL:-paiml/qwen2.5-coder-7b-apache-q4k-v1}"
 SYSTEM_MSG="You are a helpful coding assistant."
 USER_MSG="Write a Python function to compute the nth Fibonacci number."

--- a/scripts/ship-two-001/eval-shard.sh
+++ b/scripts/ship-two-001/eval-shard.sh
@@ -33,6 +33,13 @@
 
 set -euo pipefail
 
+# The LOCAL shard runs `apr run --batch-jsonl` directly; remote shards go
+# through eval-pass-at-k.sh on the far host. The local invocation was bare, so
+# a benchmark number attributed to this commit could come from any apr on the
+# orchestrator's PATH - and FALSIFY-SHARD-003 compares shards for parity, which
+# a version skew between local and remote would quietly break (#2358).
+. "$(dirname "$0")/../apr_bin.sh" || exit 1
+
 BENCHMARK="${1:?Usage: eval-shard.sh BENCHMARK (humaneval|mbpp|bigcodebench)}"
 
 : "${HOSTS:?HOSTS env var required (space-separated ssh aliases)}"
@@ -191,7 +198,7 @@ dispatch_one() {
         # stdout from `apr run --batch-jsonl` (one JSON per completion).
         local raw_out="${REMOTE_WORKDIR}/completions_shard_${i}.jsonl"
         if (( is_local )); then
-            apr run "$remote_model" \
+            "$APR" run "$remote_model" \
                 --batch-jsonl "$remote_shard" \
                 --max-tokens "$MAX_TOKENS" \
                 --temperature "$TEMPERATURE" \

--- a/scripts/ship-two-001/ex-04-upload-hf.sh
+++ b/scripts/ship-two-001/ex-04-upload-hf.sh
@@ -32,7 +32,14 @@ set -euo pipefail
 
 : "${HF_TOKEN:?HF_TOKEN env var required (write access to paiml)}"
 
-APR_BIN="${APR_BIN:-/mnt/nvme-raid0/targets/aprender/release/apr}"
+# Default: the binary THIS CHECKOUT builds (#2358). The old default named one
+# machine's build output; this script UPLOADS A MODEL TO HUGGING FACE, so the
+# binary that produced the artifacts must be the one under test. APR_BIN still
+# overrides.
+APR_BIN="${APR_BIN:-}"
+if [ -z "$APR_BIN" ] && . "$(dirname "$0")/../apr_bin.sh" 2>/dev/null; then
+    APR_BIN="$APR"
+fi
 STAGING_DIR="${STAGING_DIR:-/mnt/nvme-raid0/models/ship-two-001}"
 MODEL_ID="paiml/qwen2.5-coder-7b-apache-q4k-v1"
 MANIFEST_DIR="contracts/publish-manifests"

--- a/scripts/ship-two-001/ex-06-pull-and-rerun.sh
+++ b/scripts/ship-two-001/ex-06-pull-and-rerun.sh
@@ -14,6 +14,12 @@
 
 set -euo pipefail
 
+# This script discharges AC-EX-005/006 by pulling the PUBLISHED model and
+# re-running it. Both acceptance criteria are claims about this commit's `apr`,
+# so the binary must be this commit's (#2358) - a bare `apr` here would have
+# discharged the criteria against whatever was installed.
+. "$(dirname "$0")/../apr_bin.sh" || exit 1
+
 MODEL_ID="${MODEL_ID:-paiml/qwen2.5-coder-7b-apache-q4k-v1}"
 MANIFEST_DIR="${MANIFEST_DIR:-contracts/publish-manifests}"
 MANIFEST_PREFIX="${MANIFEST_PREFIX:-paiml-qwen2.5-coder-7b-apache-q4k-v1}"
@@ -27,7 +33,7 @@ echo "[EX-06] apr pull $MODEL_ID"
 # `apr pull` has no -o flag; it caches into ~/.cache/pacha/models/ and prints
 # the path on a `Path: <path>` line. NO_COLOR=1 strips ANSI so awk is clean.
 PULL_LOG="$TMPDIR/pull.log"
-NO_COLOR=1 apr pull "$MODEL_ID" 2>&1 | tee "$PULL_LOG"
+NO_COLOR=1 "$APR" pull "$MODEL_ID" 2>&1 | tee "$PULL_LOG"
 PULLED_PATH=$(awk '/^  *Path:/ {print $2; exit}' "$PULL_LOG")
 if [[ -z "$PULLED_PATH" || ! -f "$PULLED_PATH" ]]; then
     echo "ABORT: could not parse pulled path from apr pull output" >&2
@@ -65,7 +71,7 @@ fi
 
 echo "[EX-06] apr run --prompt 'def fib(n):'"
 OUTPUT_FILE="$TMPDIR/apr_run.out"
-apr run "$PULLED_PATH" --prompt 'def fib(n):' --max-tokens 64 --temperature 0.0 --top-k 1 > "$OUTPUT_FILE" 2>&1 || true
+"$APR" run "$PULLED_PATH" --prompt 'def fib(n):' --max-tokens 64 --temperature 0.0 --top-k 1 > "$OUTPUT_FILE" 2>&1 || true
 
 # AC-EX-006 (spec §12.3 literal): "emits syntactically valid Python"
 # We extract the generated body between the "Output:\n" banner and the


### PR DESCRIPTION
fix(dogfood): batch 4 — nine gates that could not fail, found in the tooling that judges us

Batches 1-3 (#2449, #2451, #2453) fixed the audit's findings and then its root
cause. This batch turns that lens on the quality machinery itself and on the
issue backlog, and the results are worse than the original audit: the tools we
have been using to certify everything else were themselves reporting verdicts
they had not measured.

## The coverage gate never ran. It could not compile.

`pmat quality-gates` reported

    x coverage (123.45s)
      x Coverage check failed to run: ... could not compile `apr-cli` (lib)

"Failed to run" is not a coverage number and is not a pass, and nothing treated
it as a failure. Root cause: `crates/apr-cli/src/generated_contracts.rs:9` uses
the experimental `#[coverage]` attribute, so every instrumented build died.
Alongside it, apr-cli had the repo-wide `unwrap()` ban switched OFF — the crate
with the most surface was exempt from the policy.

## Coverage Nightly measured nothing, twice over

#2353. The nightly ran its whole build through a rustc wrapper on the SHARED
`~/.cargo/bin`, where 16 runners under one $HOME replace each other's binaries
mid-run. On 2026-07-31 it died and posted an EMPTY coverage figure into the
tracking issue — a missing measurement presented as a measurement. Now installs
into a private root, with a guard.

## Every gate ran the pinned clippy, so 115 findings were never seen

#2370. `make` on a fresh mbp died in tier2 with 28 clippy errors, and the
machine was fine: the tree genuinely did not pass clippy on any release newer
than the pinned 1.93.0, and no gate we own had ever looked. This is not the
reported symptom — it is why the reported symptom was possible.

## The nightly bug-hunt manifest was inert from day one

#2356. Eight headers, zero rows, every night since the cron was added, so the
workflow's "manifest grew by >5" alert branch never had a non-zero input. Triage
called it a three-way product decision; it is three mechanical defects, each
sufficient alone, all presenting identically as "the manifest is empty tonight"
— which was indistinguishable from "the code is clean tonight" because
`pmat_hunt` returned 0 unconditionally. It now fails the beat.

## The apr-pinning guard scanned 31 files; 62 violations lived outside them

#2358. #2357 landed the guard over workflows, the scripts a workflow NAMES, and
the Makefile. Script discovery was one level deep, so anything reached
indirectly was invisible — including the release-certifying skill. The issue's
"39" was stale; 62 is what the tree held today.

## 19 more gate thresholds accepted NaN

#2391. `mad > tol` and `cos < tol` are both FALSE against NaN, so a NaN
threshold disarms the gate and it reports PASS over an unread measurement. The
deliverable was the enumeration, not the patch: 52 float CLI flags, 30 feeding a
gate comparison, 11 already guarded, 19 fixed here. The other 22 are
hyperparameters (temperature, learning rate, split ratios) where NaN yields
visible garbage rather than a false PASS — deliberately scoped out and named
rather than silently widened.

`grad_norm::run` already had `if spike_multiplier <= 0.0 { return Err(..) }` —
itself NaN-blind, since `NaN <= 0.0` is false. A validation that looks like
validation and admits NaN is the bug class in one line.

## apr validate --quality graded healthy models F at exit 0

#1866. Reproduced first: exit 0, `TOTAL: 3/100 Grade: F`, JSON reporting grade F
AND passed true AND failed 0, human output printing VALID. #1870 (closed
2026-05-22) fixed the EXIT CODE only — it wired the implemented-only denominator
into ONE caller, while `grade()`, the category table, `--min-score`,
`ValidationReport::passed()`, `apr import`'s panel and the TUI panel each kept
re-deriving the aspirational 100-point denominator. No test read two outputs at
once, so the contradiction was invisible for 81 days behind a COMPLETED label.

Design call: score what was MEASURED and name what was not. `grade()` returns
N/A when nothing ran and F only when a check actually failed.

## The flag gate asked its own parser, not the one that ships

#2377-2. The AWQ/GPTQ gates decided "would `apr quantize` accept this argv?"
using a hand-rolled matcher living beside the assertion. It parsed
`--method`/`--bits`/`--group-size`; the shipped command takes
`--scheme`/`--output`/`--format`/`--batch`/`--plan`/`--force`. Not one flag was
shared. The predicate now builds the real `clap::Command` via `CommandFactory`
and runs `try_get_matches_from`, and the accepted-flag list in the error message
is read off that same Command so it cannot drift either. The hand-rolled parsers
are deleted.

## An abandoned request kept a core at 250% CPU

#2376-3. There was no cancellation machinery anywhere in
`crates/aprender-serve/src/api/` — no CancelToken, no `is_closed()`, no
`tokio::select` in any generate path. One client hitting Ctrl-C left a decode
loop running to max_tokens for the remaining life of the process, with zero open
connections. Every falsifier here asserts OBSERVED WORK — how many tokens the
loop actually produced — and each asserts the converse, so it cannot pass by
generation simply being broken.

## A withdrawn beat was still on the public scoreboard

#2331, #2349. `docs/BEATS.md` sold "apr 1.371x faster than Ollama" as a WON
headline beat with "gate >=1.10x" in four places. That claim was WITHDRAWN:
measured reality across three nightlies is 1.03-1.09x, and the contract enforces
0.90 — a no-collapse floor, not a beat. CLAUDE.md also sent readers to six
deleted paths. Under-claiming and over-claiming are both reporting failures;
these now say what was measured.

Closes #2353
Closes #2356
Closes #2358
Closes #2370
Closes #2391
Closes #1866
Closes #2331

(One `Closes` per line: GitHub applies a single keyword to only the FIRST number
in a comma list, which is why four of #2451's six issues stayed open.)

Refs #2377, #2376, #2349, #2373

## Verification

cargo test --workspace --lib: 87,047 passed, 0 failed, exit 0
CI's 18-command integration chain + all 9 guard scripts: green after one fix —
`readme_contract` (FALSIFY-README-007) caught that this batch adds two contracts,
so the README's count row said 1768 where `find contracts/ -name '*.yaml'` is
1770. Third batch running this falsifier has caught a stale count; it is the
reason that published number can be trusted.
check_assertions_exclude.sh: 319 sites, delta 0 — ten agent commits, zero new
assertions that admit more than one outcome class.

## Not in this batch, stated plainly

A session limit killed four agents mid-flight; none had pushed, so this is
re-runnable work, not lost work: #2377-3 (the three missing producer commands),
#2375 findings 4 and 7, #2310 (wasm32), and the pmat COMPLEXITY refactor — so
validate.rs, dispatch_analysis.rs, prometheus_classifier.rs and
react_trace_classifier.rs still force `--no-verify` on any commit touching them.

The adversarial verify of the cancellation work also died with the limit. I
reviewed it directly instead: its falsifiers assert observed token counts and
each asserts the converse, so it cannot pass by generation being broken. That is
my review, not an independent one — worth a second pass before release.
