### PR TITLE
fix: drop the unused aprender-db dependency that breaks docs.rs downstream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -832,7 +832,6 @@ dependencies = [
  "anyhow",
  "aprender-compute",
  "aprender-core",
- "aprender-db",
  "arrow 57.3.1",
  "bytemuck",
  "criterion 0.6.0",
@@ -1265,7 +1264,6 @@ version = "0.63.0"
 dependencies = [
  "aprender-common",
  "aprender-compute",
- "aprender-db",
  "aprender-serve",
  "async-trait",
  "bincode",

--- a/crates/aprender-graph/Cargo.toml
+++ b/crates/aprender-graph/Cargo.toml
@@ -30,7 +30,6 @@ thiserror = "2"
 # Phase 2+ dependencies
 aprender = { path = "../aprender-core", version = "0.63.0", package = "aprender-core" }                                        # Sparse matrix ops, PageRank
 trueno = { workspace = true }
-trueno-db = { workspace = true }
 
 # Phase 3: GPU acceleration (optional - requires wgpu-capable hardware)
 wgpu = { version = "22", optional = true, features = ["wgsl"] }

--- a/crates/aprender-rag/Cargo.toml
+++ b/crates/aprender-rag/Cargo.toml
@@ -33,7 +33,6 @@ name = "aprender_rag"
 [dependencies]
 # Core compute
 trueno = { workspace = true }
-trueno-db = { workspace = true }
 
 # Async runtime
 tokio = { version = "1.49", features = ["full"] }


### PR DESCRIPTION
`aprender-graph` and `aprender-rag` each declare `trueno-db` (package `aprender-db`) as a
**non-optional** dependency, and **neither references it anywhere** — not `src/`, not
`tests/`, `benches/` or `examples/`.

That unused edge drags the whole Arrow tree into every downstream crate:

```
lexical-util ← lexical-core ← arrow-cast ← arrow ← aprender-db ← aprender-graph / aprender-rag
```

`lexical-util 1.0.7` opens with `#![cfg_attr(docsrs, feature(doc_auto_cfg))]`. `doc_auto_cfg`
was **removed in Rust 1.92** and merged into `doc_cfg`, so on docs.rs — nightly, with `docsrs`
defined — it fails to compile:

```
error[E0557]: feature has been removed
  --> lexical-util-1.0.7/src/lib.rs:83:29
   = note: removed in 1.92.0; merged into `doc_cfg`
```

1.0.7 is that crate's latest release. There is no version to bump to; the only fix is to leave
its dependency graph.

**This has already broken a downstream crate.** `pmat` takes `aprender-graph` non-optionally,
so no feature selection avoided the chain — docs.rs has never built it (3.29.0 and 3.30.0 both
failed), and it is published on crates.io with no API documentation. Two of the three paths
into `arrow` were these unused edges.

Both crates already gate their *real* storage support behind a feature (`aprender-graph`'s
`storage = ["dep:arrow", "dep:parquet"]`), and both `pmat` and `aprender-viz` consume
`aprender-graph` with `default-features = false` — so the mandatory edge bought nothing the
feature did not already buy, while making Arrow impossible to opt out of.

## Verification

| check | result |
|---|---|
| `cargo check -p aprender-graph` | ok |
| `cargo check -p aprender-rag` | ok |
| `cargo test -p aprender-graph -p aprender-rag --lib` | **539 passed, 0 failed** |
| `cargo tree -p aprender-rag -i lexical-util` | no match |
| `cargo tree -p aprender-graph --no-default-features -i lexical-util` | no match |
| `cargo tree -p aprender-graph --no-default-features -i arrow` | no match |

`--no-default-features` is exactly how both downstream consumers take it.

The other eight crates that name `aprender-db` genuinely use it and are untouched.

Downstream issue: paiml/paiml-mcp-agent-toolkit#988

🤖 Generated with [Claude Code](https://claude.com/claude-code)