### PR TITLE
fix(deps): the monorepo pulled its own siblings from crates.io, and the gate that should have caught it could not fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -503,6 +503,24 @@ jobs:
         run: bash scripts/check_assertions_exclude.sh
       - name: Assertion-exclusion guard case table
         run: bash scripts/check_assertions_exclude.sh --self-test
+      # Poka-yoke: APR-MONO made every sibling a path alias under crates/, but
+      # `trueno = "0.16"` still BUILDS - cargo resolves the crates.io copy
+      # alongside the in-tree one, so the tree compiles two mutually
+      # type-incompatible `trueno`s and the published-crate dependency cycle the
+      # consolidation removed comes back. Nothing goes red; you only see it in
+      # `cargo tree --duplicates`. At 88791ff55 the lockfile held four registry
+      # copies of trueno beside the path one. CLAUDE.md has forbidden this in
+      # prose since the consolidation - prose is not a gate.
+      # The name set is package names UNION lib names, because they diverge here
+      # (package aprender-compute has lib trueno): a guard built from package
+      # names alone would sail straight past the one declaration it exists to
+      # stop. Vacuity-guarded three ways, including a positive control that must
+      # be flagged before any clean verdict is printed. Text-only, no build.
+      # Self-test first: if the guard is blind, that matters more than its verdict.
+      - name: Sibling-crate pathing guard case table
+        run: bash scripts/check_workspace_siblings_pathed.sh --self-test
+      - name: In-tree siblings must be pathed, never pulled from crates.io
+        run: bash scripts/check_workspace_siblings_pathed.sh
 
   # Top-level gate: satisfies org ruleset "Green Main" which requires check named "gate".
   # The reusable workflow produces "ci / gate" but rulesets need exact match on "gate".

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,14 +8,7 @@ version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
 dependencies = [
- "cpp_demangle",
- "fallible-iterator",
  "gimli 0.32.3",
- "memmap2",
- "object 0.37.3",
- "rustc-demangle",
- "smallvec",
- "typed-arena",
 ]
 
 [[package]]
@@ -261,6 +254,7 @@ dependencies = [
  "aprender-common",
  "aprender-compute",
  "aprender-contracts",
+ "aprender-contracts-macros",
  "aprender-core",
  "aprender-data",
  "aprender-explain",
@@ -271,6 +265,7 @@ dependencies = [
  "aprender-profile",
  "aprender-registry",
  "aprender-serve",
+ "aprender-test-lib",
  "aprender-train",
  "aprender-train-common",
  "aprender-train-distill",
@@ -295,12 +290,10 @@ dependencies = [
  "glob",
  "half",
  "humansize",
- "jugar-probar 0.4.2",
  "libc",
- "parquet 57.3.1",
+ "parquet",
  "predicates",
  "proptest",
- "provable-contracts-macros 0.3.1",
  "rayon",
  "regex",
  "rmp-serde",
@@ -341,26 +334,6 @@ dependencies = [
 
 [[package]]
 name = "aprender"
-version = "0.25.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7053416de79df742f9da17a53dea7087830b83761a80f69bc2a91b708aab781c"
-dependencies = [
- "bincode",
- "getrandom 0.2.17",
- "memmap2",
- "minijinja",
- "rand 0.8.6",
- "rand_chacha 0.3.1",
- "rayon",
- "rmp-serde",
- "serde",
- "serde_json",
- "trueno 0.14.6",
- "trueno-quant",
-]
-
-[[package]]
-name = "aprender"
 version = "0.27.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df954f1095e9717ef2e19bdcc3f6ffa1975eba2a93d0f6a5a6ae0a2231e414b"
@@ -376,7 +349,6 @@ dependencies = [
  "provable-contracts-macros 0.2.2",
  "rand 0.9.4",
  "rand_chacha 0.9.0",
- "rayon",
  "rmp-serde",
  "rustfft",
  "safetensors 0.4.5",
@@ -386,7 +358,7 @@ dependencies = [
  "sha2 0.10.9",
  "tempfile",
  "thiserror 2.0.18",
- "trueno 0.17.5",
+ "trueno",
  "trueno-quant",
  "ureq 2.12.1",
 ]
@@ -427,11 +399,11 @@ dependencies = [
  "aprender-gpu",
  "aprender-present-core",
  "aprender-present-terminal",
+ "aprender-test-lib",
  "chrono",
  "clap",
  "crossterm 0.28.1",
  "dirs 5.0.1",
- "jugar-probar 1.0.4",
  "libc",
  "pollster",
  "proptest",
@@ -475,6 +447,7 @@ name = "aprender-compute"
 version = "0.63.0"
 dependencies = [
  "anyhow",
+ "aprender-contracts-macros",
  "aprender-core",
  "aprender-cuda-edge",
  "aprender-gemm-codegen",
@@ -501,7 +474,6 @@ dependencies = [
  "num_cpus",
  "pollster",
  "proptest",
- "provable-contracts-macros 0.3.1",
  "rayon",
  "regex",
  "serde",
@@ -578,9 +550,12 @@ dependencies = [
  "apr-format",
  "aprender-common",
  "aprender-compute",
+ "aprender-contracts",
+ "aprender-contracts-macros",
  "aprender-data",
  "aprender-profile",
  "aprender-quant",
+ "aprender-test-lib",
  "aprender-train",
  "aprender-zram-core",
  "argon2",
@@ -595,13 +570,10 @@ dependencies = [
  "hf-xet",
  "hkdf",
  "js-sys",
- "jugar-probar 0.5.1",
  "lz4_flex 0.11.6",
  "memmap2",
  "minijinja",
  "proptest",
- "provable-contracts 0.3.1",
- "provable-contracts-macros 0.3.1",
  "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rayon",
@@ -636,7 +608,7 @@ dependencies = [
 name = "aprender-cupti"
 version = "0.63.0"
 dependencies = [
- "bindgen 0.71.1",
+ "bindgen",
  "bitflags 2.13.0",
  "libc",
  "thiserror 2.0.18",
@@ -647,6 +619,7 @@ name = "aprender-data"
 version = "0.63.0"
 dependencies = [
  "aes-gcm",
+ "aprender-test-lib",
  "argon2",
  "arrow 57.3.1",
  "arrow-csv",
@@ -666,11 +639,10 @@ dependencies = [
  "hex",
  "hkdf",
  "js-sys",
- "jugar-probar 1.0.4",
  "lz4_flex 0.11.6",
  "memmap2",
  "nu-ansi-term",
- "parquet 57.3.1",
+ "parquet",
  "predicates",
  "proptest",
  "rand 0.9.4",
@@ -714,7 +686,7 @@ dependencies = [
  "futures-intrusive",
  "js-sys",
  "lz4_flex 0.11.6",
- "parquet 57.3.1",
+ "parquet",
  "proptest",
  "prost 0.13.5",
  "quickcheck",
@@ -745,14 +717,14 @@ version = "0.63.0"
 dependencies = [
  "aprender-compute",
  "aprender-db",
+ "aprender-test-lib",
  "arrow 57.3.1",
  "bincode",
  "criterion 0.5.1",
  "crossterm 0.28.1",
  "futures",
- "jugar-probar 0.4.2",
  "num_cpus",
- "parquet 57.3.1",
+ "parquet",
  "pepita",
  "pollster",
  "proptest",
@@ -812,10 +784,10 @@ version = "0.63.0"
 dependencies = [
  "aprender-common",
  "aprender-simulate",
+ "aprender-test-lib",
  "bytemuck",
  "criterion 0.7.0",
  "crossterm 0.28.1",
- "jugar-probar 0.4.2",
  "libloading",
  "manzana",
  "pollster",
@@ -837,7 +809,7 @@ dependencies = [
  "bytemuck",
  "criterion 0.6.0",
  "futures-intrusive",
- "parquet 57.3.1",
+ "parquet",
  "proptest",
  "serial_test",
  "tempfile",
@@ -897,6 +869,8 @@ dependencies = [
  "anyhow",
  "aprender-common",
  "aprender-compute",
+ "aprender-contracts",
+ "aprender-contracts-macros",
  "aprender-core",
  "aprender-cuda-edge",
  "aprender-data",
@@ -930,15 +904,11 @@ dependencies = [
  "futures-util",
  "glob",
  "indexmap 2.14.0",
- "jugar-probar 1.0.4",
  "libc",
  "pepita",
  "pmcp",
  "predicates",
- "presentar",
  "proptest",
- "provable-contracts 0.2.2",
- "provable-contracts-macros 0.2.2",
  "quick-xml 0.41.0",
  "reqwest 0.12.28",
  "resvg",
@@ -956,7 +926,6 @@ dependencies = [
  "tower 0.5.3",
  "tracing",
  "tracing-subscriber",
- "trueno-ublk",
  "walkdir",
  "wasm-bindgen",
  "web-sys",
@@ -981,9 +950,9 @@ dependencies = [
 name = "aprender-present-core"
 version = "0.63.0"
 dependencies = [
+ "aprender-contracts-macros",
  "criterion 0.7.0",
  "proptest",
- "provable-contracts-macros 0.3.1",
  "serde",
  "serde_json",
  "serde_yaml_ng",
@@ -1004,6 +973,7 @@ dependencies = [
 name = "aprender-present-lib"
 version = "0.63.0"
 dependencies = [
+ "aprender-contracts",
  "aprender-present-core",
  "aprender-present-layout",
  "aprender-present-test",
@@ -1016,7 +986,6 @@ dependencies = [
  "hex",
  "js-sys",
  "proptest",
- "provable-contracts 0.3.1",
  "regex",
  "serde",
  "serde_json",
@@ -1045,7 +1014,6 @@ dependencies = [
  "serde_yaml_ng",
  "sysinfo 0.32.1",
  "thiserror 2.0.18",
- "ttop",
  "unicode-segmentation",
  "unicode-width 0.2.0",
 ]
@@ -1353,6 +1321,8 @@ dependencies = [
  "anyhow",
  "approx",
  "aprender-compute",
+ "aprender-contracts",
+ "aprender-contracts-macros",
  "aprender-core",
  "aprender-cuda-edge",
  "aprender-data",
@@ -1362,6 +1332,7 @@ dependencies = [
  "aprender-profile-core",
  "aprender-quant",
  "aprender-registry",
+ "aprender-test-lib",
  "aprender-viz",
  "arc-swap",
  "arrow 57.3.1",
@@ -1381,7 +1352,6 @@ dependencies = [
  "http-body-util",
  "hyper 1.10.1",
  "indicatif 0.17.11",
- "jugar-probar 0.4.2",
  "libc",
  "lz4_flex 0.11.6",
  "memmap2",
@@ -1391,8 +1361,6 @@ dependencies = [
  "once_cell",
  "predicates",
  "proptest",
- "provable-contracts 0.2.2",
- "provable-contracts-macros 0.2.2",
  "rand 0.9.4",
  "rayon",
  "reqwest 0.11.27",
@@ -1434,6 +1402,8 @@ dependencies = [
 name = "aprender-simulate"
 version = "0.63.0"
 dependencies = [
+ "aprender-contracts",
+ "aprender-contracts-macros",
  "aprender-present-core",
  "aprender-present-terminal",
  "aprender-present-test",
@@ -1450,8 +1420,6 @@ dependencies = [
  "memmap2",
  "num-traits",
  "proptest",
- "provable-contracts 0.2.2",
- "provable-contracts-macros 0.2.2",
  "rand 0.9.4",
  "rand_pcg",
  "serde",
@@ -1558,6 +1526,7 @@ dependencies = [
  "aprender-compute",
  "aprender-present-core",
  "aprender-present-terminal",
+ "aprender-test-derive",
  "async-trait",
  "base64 0.22.1",
  "bincode",
@@ -1570,7 +1539,6 @@ dependencies = [
  "gif 0.13.3",
  "image",
  "js-sys",
- "jugar-probar-derive",
  "mp4",
  "notify",
  "png 0.17.16",
@@ -1600,9 +1568,9 @@ name = "aprender-test-showcase"
 version = "0.63.0"
 dependencies = [
  "aprender-present-terminal",
+ "aprender-test-lib",
  "console_error_panic_hook",
  "crossterm 0.28.1",
- "jugar-probar 1.0.4",
  "proptest",
  "serde",
  "serde_json",
@@ -1619,6 +1587,8 @@ dependencies = [
  "approx",
  "aprender-common",
  "aprender-compute",
+ "aprender-contracts",
+ "aprender-contracts-macros",
  "aprender-core",
  "aprender-data",
  "aprender-db",
@@ -1628,6 +1598,7 @@ dependencies = [
  "aprender-profile",
  "aprender-rag",
  "aprender-serve",
+ "aprender-test-lib",
  "aprender-viz",
  "arrow 57.3.1",
  "axum 0.8.9",
@@ -1649,13 +1620,10 @@ dependencies = [
  "insta",
  "js-sys",
  "jsonschema",
- "jugar-probar 1.0.4",
  "ndarray 0.16.1",
  "nvml-wrapper",
- "parquet 57.3.1",
+ "parquet",
  "proptest",
- "provable-contracts 0.2.2",
- "provable-contracts-macros 0.2.2",
  "rand 0.9.4",
  "rayon",
  "regex",
@@ -1829,7 +1797,7 @@ dependencies = [
  "clap",
  "criterion 0.7.0",
  "indicatif 0.18.4",
- "parquet 57.3.1",
+ "parquet",
  "pest",
  "pest_derive",
  "proptest",
@@ -1980,24 +1948,6 @@ checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
 
 [[package]]
 name = "arrow"
-version = "54.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5ec52ba94edeed950e4a41f75d35376df196e8cb04437f7280a5aa49f20f796"
-dependencies = [
- "arrow-arith 54.3.1",
- "arrow-array 54.3.1",
- "arrow-buffer 54.3.1",
- "arrow-cast 54.3.1",
- "arrow-data 54.3.1",
- "arrow-ord 54.3.1",
- "arrow-row 54.3.1",
- "arrow-schema 54.3.1",
- "arrow-select 54.3.1",
- "arrow-string 54.3.1",
-]
-
-[[package]]
-name = "arrow"
 version = "57.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bd47f2a6ddc39244bd722a27ee5da66c03369d087b9e024eafdb03e98b98ea7"
@@ -2008,7 +1958,7 @@ dependencies = [
  "arrow-cast 57.3.1",
  "arrow-csv",
  "arrow-data 57.3.1",
- "arrow-ipc 57.3.1",
+ "arrow-ipc",
  "arrow-json",
  "arrow-ord 57.3.1",
  "arrow-row 57.3.1",
@@ -2037,20 +1987,6 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "54.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc766fdacaf804cb10c7c70580254fcdb5d55cdfda2bc57b02baf5223a3af9e"
-dependencies = [
- "arrow-array 54.3.1",
- "arrow-buffer 54.3.1",
- "arrow-data 54.3.1",
- "arrow-schema 54.3.1",
- "chrono",
- "num",
-]
-
-[[package]]
-name = "arrow-arith"
 version = "57.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c7bbd679c5418b8639b92be01f361d60013c4906574b578b77b63c78356594c"
@@ -2075,22 +2011,6 @@ dependencies = [
  "arrow-schema 58.3.0",
  "chrono",
  "num-traits",
-]
-
-[[package]]
-name = "arrow-array"
-version = "54.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12fcdb3f1d03f69d3ec26ac67645a8fe3f878d77b5ebb0b15d64a116c212985"
-dependencies = [
- "ahash 0.8.12",
- "arrow-buffer 54.3.1",
- "arrow-data 54.3.1",
- "arrow-schema 54.3.1",
- "chrono",
- "half",
- "hashbrown 0.15.5",
- "num",
 ]
 
 [[package]]
@@ -2131,17 +2051,6 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "54.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "263f4801ff1839ef53ebd06f99a56cecd1dbaf314ec893d93168e2e860e0291c"
-dependencies = [
- "bytes",
- "half",
- "num",
-]
-
-[[package]]
-name = "arrow-buffer"
 version = "57.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d18b89b4c4f4811d0858175e79541fe98e33e18db3b011708bc287b1240593f"
@@ -2162,26 +2071,6 @@ dependencies = [
  "half",
  "num-bigint",
  "num-traits",
-]
-
-[[package]]
-name = "arrow-cast"
-version = "54.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede6175fbc039dfc946a61c1b6d42fd682fcecf5ab5d148fbe7667705798cac9"
-dependencies = [
- "arrow-array 54.3.1",
- "arrow-buffer 54.3.1",
- "arrow-data 54.3.1",
- "arrow-schema 54.3.1",
- "arrow-select 54.3.1",
- "atoi",
- "base64 0.22.1",
- "chrono",
- "half",
- "lexical-core",
- "num",
- "ryu",
 ]
 
 [[package]]
@@ -2245,18 +2134,6 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "54.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61cfdd7d99b4ff618f167e548b2411e5dd2c98c0ddebedd7df433d34c20a4429"
-dependencies = [
- "arrow-buffer 54.3.1",
- "arrow-schema 54.3.1",
- "half",
- "num",
-]
-
-[[package]]
-name = "arrow-data"
 version = "57.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1683705c63dcf0d18972759eda48489028cbbff67af7d6bef2c6b7b74ab778a"
@@ -2283,19 +2160,6 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "54.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62ff528658b521e33905334723b795ee56b393dbe9cf76c8b1f64b648c65a60c"
-dependencies = [
- "arrow-array 54.3.1",
- "arrow-buffer 54.3.1",
- "arrow-data 54.3.1",
- "arrow-schema 54.3.1",
- "flatbuffers 24.12.23",
-]
-
-[[package]]
-name = "arrow-ipc"
 version = "57.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cf72d04c07229fbf4dbebe7145cac37d7cf7ec582fe705c6b92cb314af096ab"
@@ -2305,7 +2169,7 @@ dependencies = [
  "arrow-data 57.3.1",
  "arrow-schema 57.3.1",
  "arrow-select 57.3.1",
- "flatbuffers 25.12.19",
+ "flatbuffers",
 ]
 
 [[package]]
@@ -2330,19 +2194,6 @@ dependencies = [
  "serde_core",
  "serde_json",
  "simdutf8",
-]
-
-[[package]]
-name = "arrow-ord"
-version = "54.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a3334a743bd2a1479dbc635540617a3923b4b2f6870f37357339e6b5363c21"
-dependencies = [
- "arrow-array 54.3.1",
- "arrow-buffer 54.3.1",
- "arrow-data 54.3.1",
- "arrow-schema 54.3.1",
- "arrow-select 54.3.1",
 ]
 
 [[package]]
@@ -2373,19 +2224,6 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "54.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d1d7a7291d2c5107e92140f75257a99343956871f3d3ab33a7b41532f79cb68"
-dependencies = [
- "arrow-array 54.3.1",
- "arrow-buffer 54.3.1",
- "arrow-data 54.3.1",
- "arrow-schema 54.3.1",
- "half",
-]
-
-[[package]]
-name = "arrow-row"
 version = "57.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a931b520a2a5e22033e01a6f2486b4cdc26f9106b759abeebc320f125e94d7"
@@ -2412,12 +2250,6 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "54.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39cfaf5e440be44db5413b75b72c2a87c1f8f0627117d110264048f2969b99e9"
-
-[[package]]
-name = "arrow-schema"
 version = "57.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4cf0d4a6609679e03002167a61074a21d7b1ad9ea65e462b2c0a97f8a3b2bc6"
@@ -2429,20 +2261,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f633dbfdf39c039ada1bf9e34c694816eb71fbb7dc78f613993b7245e078a1ed"
 dependencies = [
  "bitflags 2.13.0",
-]
-
-[[package]]
-name = "arrow-select"
-version = "54.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69efcd706420e52cd44f5c4358d279801993846d1c2a8e52111853d61d55a619"
-dependencies = [
- "ahash 0.8.12",
- "arrow-array 54.3.1",
- "arrow-buffer 54.3.1",
- "arrow-data 54.3.1",
- "arrow-schema 54.3.1",
- "num",
 ]
 
 [[package]]
@@ -2471,23 +2289,6 @@ dependencies = [
  "arrow-data 58.3.0",
  "arrow-schema 58.3.0",
  "num-traits",
-]
-
-[[package]]
-name = "arrow-string"
-version = "54.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21546b337ab304a32cfc0770f671db7411787586b45b78b4593ae78e64e2b03"
-dependencies = [
- "arrow-array 54.3.1",
- "arrow-buffer 54.3.1",
- "arrow-data 54.3.1",
- "arrow-schema 54.3.1",
- "arrow-select 54.3.1",
- "memchr",
- "num",
- "regex",
- "regex-syntax",
 ]
 
 [[package]]
@@ -2574,18 +2375,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-channel"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
-dependencies = [
- "concurrent-queue",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
 name = "async-compression"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2595,107 +2384,6 @@ dependencies = [
  "compression-core",
  "pin-project-lite",
  "tokio",
-]
-
-[[package]]
-name = "async-executor"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
-dependencies = [
- "async-task",
- "concurrent-queue",
- "fastrand",
- "futures-lite",
- "pin-project-lite",
- "slab",
-]
-
-[[package]]
-name = "async-fs"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
-dependencies = [
- "async-lock",
- "blocking",
- "futures-lite",
-]
-
-[[package]]
-name = "async-io"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
-dependencies = [
- "autocfg",
- "cfg-if 1.0.4",
- "concurrent-queue",
- "futures-io",
- "futures-lite",
- "parking",
- "polling",
- "rustix 1.1.4",
- "slab",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "async-lock"
-version = "3.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
-dependencies = [
- "event-listener",
- "event-listener-strategy",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-net"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
-dependencies = [
- "async-io",
- "blocking",
- "futures-lite",
-]
-
-[[package]]
-name = "async-process"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
-dependencies = [
- "async-channel",
- "async-io",
- "async-lock",
- "async-signal",
- "async-task",
- "blocking",
- "cfg-if 1.0.4",
- "event-listener",
- "futures-lite",
- "rustix 1.1.4",
-]
-
-[[package]]
-name = "async-signal"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
-dependencies = [
- "async-io",
- "async-lock",
- "atomic-waker",
- "cfg-if 1.0.4",
- "futures-core",
- "futures-io",
- "rustix 1.1.4",
- "signal-hook-registry",
- "slab",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2719,12 +2407,6 @@ dependencies = [
  "quote",
  "syn 2.0.118",
 ]
-
-[[package]]
-name = "async-task"
-version = "4.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -2966,7 +2648,7 @@ dependencies = [
  "http 0.2.12",
  "http 1.4.2",
  "http-body 1.0.1",
- "lru 0.16.4",
+ "lru",
  "percent-encoding",
  "regex-lite",
  "sha2 0.11.0",
@@ -3580,29 +3262,6 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.69.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
-dependencies = [
- "bitflags 2.13.0",
- "cexpr",
- "clang-sys",
- "itertools 0.12.1",
- "lazy_static",
- "lazycell",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 1.1.0",
- "shlex 1.3.0",
- "syn 2.0.118",
- "which 4.4.2",
-]
-
-[[package]]
-name = "bindgen"
 version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
@@ -3682,12 +3341,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitmaps"
-version = "3.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d084b0137aaa901caf9f1e8b21daa6aa24d41cd806e111335541eff9683bd6"
-
-[[package]]
 name = "bitstream-io"
 version = "4.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3762,19 +3415,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
-]
-
-[[package]]
-name = "blocking"
-version = "1.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
-dependencies = [
- "async-channel",
- "async-task",
- "futures-io",
- "futures-lite",
- "piper",
 ]
 
 [[package]]
@@ -3853,34 +3493,13 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc97b8f16f944bba54f0433f07e30be199b6dc2bd25937444bbad560bcea29bd"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
- "brotli-decompressor 4.0.3",
-]
-
-[[package]]
-name = "brotli"
 version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
- "brotli-decompressor 5.0.3",
-]
-
-[[package]]
-name = "brotli-decompressor"
-version = "4.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a334ef7c9e23abf0ce748e8cd309037da93e606ad52eb372e4ce327a0dcfbdfd"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
+ "brotli-decompressor",
 ]
 
 [[package]]
@@ -4098,12 +3717,6 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
 ]
-
-[[package]]
-name = "cassowary"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
 name = "cast"
@@ -4579,15 +4192,6 @@ name = "compression-core"
 version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
-
-[[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
-]
 
 [[package]]
 name = "console"
@@ -5380,28 +4984,8 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
-]
-
-[[package]]
-name = "darling"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
-dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
-]
-
-[[package]]
-name = "darling"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
-dependencies = [
- "darling_core 0.23.0",
- "darling_macro 0.23.0",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -5419,61 +5003,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "darling_core"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
-dependencies = [
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.118",
-]
-
-[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core 0.20.11",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
-dependencies = [
- "darling_core 0.21.3",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
-dependencies = [
- "darling_core 0.23.0",
+ "darling_core",
  "quote",
  "syn 2.0.118",
 ]
@@ -5590,7 +5125,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
 dependencies = [
- "darling 0.20.11",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -5603,18 +5138,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "derive_setters"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e6f6fa1f03c14ae082120b84b3c7fbd7b8588d924cf2d7c3daf9afd49df8b9"
-dependencies = [
- "darling 0.21.3",
- "proc-macro2",
- "quote",
  "syn 2.0.118",
 ]
 
@@ -5696,16 +5219,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
  "dirs-sys 0.5.0",
-]
-
-[[package]]
-name = "dirs-next"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
-dependencies = [
- "cfg-if 1.0.4",
- "dirs-sys-next",
 ]
 
 [[package]]
@@ -5817,79 +5330,6 @@ dependencies = [
  "os_pipe",
  "shared_child",
  "shared_thread",
-]
-
-[[package]]
-name = "duende-core"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d727bf9ff95f2950ee82116f61fc76f997e8387ada8a69e0054fe9846387af78"
-dependencies = [
- "async-trait",
- "dirs-next",
- "humantime",
- "nix 0.29.0",
- "pacha",
- "repartir",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "tokio",
- "toml 0.8.23",
- "tracing",
- "uuid",
-]
-
-[[package]]
-name = "duende-mlock"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a79abd55ed5f318a0ebddd9ab6027b393caee1e28f1840fe7bd29e1b5aa0af9"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "duende-platform"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e60d7f4f3fb9fe3b36818a547d1b2375f3aef1ec3ef00a7f90495e289ed54f0"
-dependencies = [
- "async-trait",
- "duende-core",
- "libc",
- "nix 0.29.0",
- "repartir",
- "serde",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "duende-policy"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4edbbff1cb2ebb1c5a1300d352c40cb1c47482e72165c0070b18cff162dd306"
-dependencies = [
- "async-trait",
- "duende-core",
- "repartir",
- "serde",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "duende-ublk"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb4bd3b34b81c94694c753578827e74d1fd432764646ef96c5421ceb412638b"
-dependencies = [
- "io-uring",
- "libc",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6158,27 +5598,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "event-listener"
-version = "5.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
-dependencies = [
- "concurrent-queue",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener-strategy"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
-dependencies = [
- "event-listener",
- "pin-project-lite",
-]
-
-[[package]]
 name = "exr"
 version = "1.74.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6373,16 +5792,6 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
-
-[[package]]
-name = "flatbuffers"
-version = "24.12.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f1baf0dbf96932ec9a3038d57900329c015b0bfb7b63d904f3bc27e2b02a096"
-dependencies = [
- "bitflags 1.3.2",
- "rustc_version",
-]
 
 [[package]]
 name = "flatbuffers"
@@ -6631,19 +6040,6 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
-
-[[package]]
-name = "futures-lite"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
-dependencies = [
- "fastrand",
- "futures-core",
- "futures-io",
- "parking",
- "pin-project-lite",
-]
 
 [[package]]
 name = "futures-locks"
@@ -6963,7 +6359,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 dependencies = [
  "fallible-iterator",
- "indexmap 2.14.0",
  "stable_deref_trait",
 ]
 
@@ -7334,8 +6729,6 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
- "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -7973,7 +7366,7 @@ version = "15.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1955a75fa080c677d3972822ec4bad316169ab1cfc6c257a942c2265dbe5fe"
 dependencies = [
- "bitmaps 2.1.0",
+ "bitmaps",
  "rand_core 0.6.4",
  "rand_xoshiro",
  "sized-chunks",
@@ -8077,15 +7470,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "inotify"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8125,19 +7509,6 @@ dependencies = [
  "serde",
  "similar",
  "tempfile",
-]
-
-[[package]]
-name = "instability"
-version = "0.3.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
-dependencies = [
- "darling 0.23.0",
- "indoc",
- "proc-macro2",
- "quote",
- "syn 2.0.118",
 ]
 
 [[package]]
@@ -8184,18 +7555,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
 dependencies = [
  "rustversion",
-]
-
-[[package]]
-name = "io-uring"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d09b98f7eace8982db770e4408e7470b028ce513ac28fecdc6bf4c30fe92b62"
-dependencies = [
- "bindgen 0.69.5",
- "bitflags 2.13.0",
- "cfg-if 1.0.4",
- "libc",
 ]
 
 [[package]]
@@ -8388,115 +7747,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jugar-probar"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d08aff8480ddf05a63e8178afcfbc393ca8af1e74011c2b4fe587e72fcd44c45"
-dependencies = [
- "base64 0.22.1",
- "chrono",
- "crossterm 0.28.1",
- "gif 0.13.3",
- "image",
- "js-sys",
- "mp4",
- "notify",
- "png 0.17.16",
- "ratatui",
- "regex",
- "serde",
- "serde_json",
- "serde_yaml",
- "sha2 0.10.9",
- "thiserror 2.0.18",
- "tracing",
- "tracing-subscriber",
- "trueno 0.11.0",
- "uuid",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "jugar-probar"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da5603ded7edb5ba47f3151dfbeeff0c244b9d07211b3df6b0a1786ccef83f7c"
-dependencies = [
- "base64 0.22.1",
- "bincode",
- "chrono",
- "crossterm 0.28.1",
- "gif 0.13.3",
- "image",
- "js-sys",
- "mp4",
- "notify",
- "png 0.17.16",
- "proc-macro2",
- "ratatui",
- "regex",
- "serde",
- "serde_json",
- "serde_yaml",
- "sha2 0.10.9",
- "syn 2.0.118",
- "thiserror 2.0.18",
- "tracing",
- "tracing-subscriber",
- "uuid",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "jugar-probar"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5a299150747f498a5970f057f1da1f56fbc99a80dca81ef797a9cb014eecce9"
-dependencies = [
- "async-trait",
- "base64 0.22.1",
- "bincode",
- "chromiumoxide",
- "chrono",
- "crossterm 0.28.1",
- "futures",
- "gif 0.14.2",
- "image",
- "js-sys",
- "mp4",
- "notify",
- "png 0.18.1",
- "proc-macro2",
- "regex",
- "serde",
- "serde_json",
- "serde_yaml_ng",
- "sha2 0.10.9",
- "syn 2.0.118",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "tracing-subscriber",
- "uuid",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "jugar-probar-derive"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a05ebb156a58509410b63603cff6195b28f2c2f6050abd99595ded7dec3de5f3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
 name = "khronos-egl"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8567,12 +7817,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lcov2cobertura"
@@ -8731,41 +7975,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libublk"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0cc4f0d9771dc50a2807a495e80287911d1bf4871fad45663753692db7c432"
-dependencies = [
- "async-lock",
- "bitflags 2.13.0",
- "bitmaps 3.2.1",
- "derive_setters",
- "futures-timer",
- "io-uring",
- "libc",
- "libublk-rs-sys",
- "log",
- "serde",
- "serde_json",
- "slab",
- "smol",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "libublk-rs-sys"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ab204ac509937ddb9ca815e642e204f8944bb98c8f0dd613a7c2567c774e593"
-dependencies = [
- "anyhow",
- "bindgen 0.69.5",
- "libc",
- "regex",
- "serde",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8828,15 +8037,6 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
-dependencies = [
- "hashbrown 0.15.5",
-]
-
-[[package]]
-name = "lru"
 version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
@@ -8856,7 +8056,7 @@ version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
 dependencies = [
- "twox-hash 2.1.2",
+ "twox-hash",
 ]
 
 [[package]]
@@ -8865,7 +8065,7 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90071f8077f8e40adfc4b7fe9cd495ce316263f19e75c2211eeff3fdf475a3d9"
 dependencies = [
- "twox-hash 2.1.2",
+ "twox-hash",
 ]
 
 [[package]]
@@ -8874,7 +8074,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
 dependencies = [
- "twox-hash 2.1.2",
+ "twox-hash",
 ]
 
 [[package]]
@@ -9879,9 +9079,7 @@ version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
- "flate2",
  "memchr",
- "ruzstd",
 ]
 
 [[package]]
@@ -9891,11 +9089,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271638cd5fa9cca89c4c304675ca658efc4e64a66c716b7cfe1afb4b9611dbbc"
 dependencies = [
  "crc32fast",
- "flate2",
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
  "memchr",
- "ruzstd",
 ]
 
 [[package]]
@@ -10185,28 +9381,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pacha"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "873be034730a0b6ae567897812926b649f13f12d59d0f1805a7eb5f3622702a8"
-dependencies = [
- "anyhow",
- "blake3",
- "chrono",
- "clap",
- "ed25519-dalek",
- "rand 0.8.6",
- "rmp-serde",
- "rusqlite",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "toml 0.8.23",
- "uuid",
- "zstd",
-]
-
-[[package]]
 name = "page_size"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10226,12 +9400,6 @@ dependencies = [
  "fnv",
  "unicode-width 0.1.11",
 ]
-
-[[package]]
-name = "parking"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -10258,39 +9426,6 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "54.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb15796ac6f56b429fd99e33ba133783ad75b27c36b4b5ce06f1f82cc97754e"
-dependencies = [
- "ahash 0.8.12",
- "arrow-array 54.3.1",
- "arrow-buffer 54.3.1",
- "arrow-cast 54.3.1",
- "arrow-data 54.3.1",
- "arrow-ipc 54.3.1",
- "arrow-schema 54.3.1",
- "arrow-select 54.3.1",
- "base64 0.22.1",
- "brotli 7.0.0",
- "bytes",
- "chrono",
- "flate2",
- "half",
- "hashbrown 0.15.5",
- "lz4_flex 0.11.6",
- "num",
- "num-bigint",
- "paste",
- "seq-macro",
- "simdutf8",
- "snap",
- "thrift",
- "twox-hash 1.6.3",
- "zstd",
-]
-
-[[package]]
-name = "parquet"
 version = "57.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e832c6aa20310fc6de7ea5a3f4e20d34fd83e3b43229d32b81ffe5c14d74692"
@@ -10300,11 +9435,11 @@ dependencies = [
  "arrow-buffer 57.3.1",
  "arrow-cast 57.3.1",
  "arrow-data 57.3.1",
- "arrow-ipc 57.3.1",
+ "arrow-ipc",
  "arrow-schema 57.3.1",
  "arrow-select 57.3.1",
  "base64 0.22.1",
- "brotli 8.0.4",
+ "brotli",
  "bytes",
  "chrono",
  "flate2",
@@ -10319,7 +9454,7 @@ dependencies = [
  "simdutf8",
  "snap",
  "thrift",
- "twox-hash 2.1.2",
+ "twox-hash",
  "zstd",
 ]
 
@@ -10521,17 +9656,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "piper"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
-dependencies = [
- "atomic-waker",
- "fastrand",
- "futures-io",
-]
-
-[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10647,20 +9771,6 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
-]
-
-[[package]]
-name = "polling"
-version = "3.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
-dependencies = [
- "cfg-if 1.0.4",
- "concurrent-queue",
- "hermit-abi 0.5.2",
- "pin-project-lite",
- "rustix 1.1.4",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10780,88 +9890,6 @@ checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
 dependencies = [
  "predicates-core",
  "termtree",
-]
-
-[[package]]
-name = "presentar"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fb6890554d1df121309cf690a5d30ddd278310676918dacf6fc650d1f78feac"
-dependencies = [
- "bincode",
- "console_error_panic_hook",
- "getrandom 0.2.17",
- "js-sys",
- "presentar-core",
- "presentar-layout",
- "presentar-widgets",
- "presentar-yaml",
- "serde",
- "serde_json",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "presentar-core"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cec076597046cb63e9c064b708e010ab98a1f48db4c0004e8192724e383a6c8d"
-dependencies = [
- "serde",
- "serde_json",
- "trueno 0.14.6",
-]
-
-[[package]]
-name = "presentar-layout"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "344e0a61e39945da7af93e7330ab74afa3797cd899cf7022486562b7e74cc01a"
-dependencies = [
- "presentar-core",
- "serde",
-]
-
-[[package]]
-name = "presentar-terminal"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "280dc9e13136a2d3490fde1d76d0450cca37268a280e95d814964a41efa31bcc"
-dependencies = [
- "bitvec",
- "clap",
- "compact_str 0.8.2",
- "crossterm 0.28.1",
- "presentar-core",
- "serde_json",
- "sysinfo 0.33.1",
- "thiserror 2.0.18",
- "unicode-segmentation",
- "unicode-width 0.2.0",
-]
-
-[[package]]
-name = "presentar-widgets"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5401130deb743b51fe812a4d35d08706125bc1fef768c8244ed77c943533a42e"
-dependencies = [
- "presentar-core",
- "presentar-yaml",
- "serde",
-]
-
-[[package]]
-name = "presentar-yaml"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562b2337f4821ad079e76778fe9cc692827ed1f2c0450986e0c686843a26a9c1"
-dependencies = [
- "presentar-core",
- "serde",
- "serde_yaml_ng",
 ]
 
 [[package]]
@@ -10989,31 +10017,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "procfs"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc5b72d8145275d844d4b5f6d4e1eef00c8cd889edb6035c21675d1bb1f45c9f"
-dependencies = [
- "bitflags 2.13.0",
- "chrono",
- "flate2",
- "hex",
- "procfs-core",
- "rustix 0.38.44",
-]
-
-[[package]]
-name = "procfs-core"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239df02d8349b06fc07398a3a1697b06418223b1c7725085e801e7c0fc6a12ec"
-dependencies = [
- "bitflags 2.13.0",
- "chrono",
- "hex",
-]
-
-[[package]]
 name = "profiling"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11098,34 +10101,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "provable-contracts"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec46f6a8b0575811e6ab321e86f68e086e9acd7d79111106ce5bc676d9407716"
-dependencies = [
- "provable-contracts-macros 0.2.2",
- "regex",
- "serde",
- "serde_json",
- "serde_yaml",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "provable-contracts"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49c4074b55824441df3872f57aecaeb69902a568dabffb59da9b15533a91cca4"
-dependencies = [
- "provable-contracts-macros 0.3.1",
- "regex",
- "serde",
- "serde_json",
- "serde_yaml",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "provable-contracts-macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11141,17 +10116,6 @@ name = "provable-contracts-macros"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0772baeb8ded27f9590b49756f98d88c40376659d74816ba752d39495e63137d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "provable-contracts-macros"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6bb7beb246ab375bc516720bcab5c5c2b93adb63115e785454a5424ba89fc0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11530,27 +10494,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca45419789ae5a7899559e9512e58ca889e41f04f1f2445e9f4b290ceccd1d08"
 
 [[package]]
-name = "ratatui"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
-dependencies = [
- "bitflags 2.13.0",
- "cassowary",
- "compact_str 0.8.2",
- "crossterm 0.28.1",
- "indoc",
- "instability",
- "itertools 0.13.0",
- "lru 0.12.5",
- "paste",
- "strum 0.26.3",
- "unicode-segmentation",
- "unicode-truncate",
- "unicode-width 0.2.0",
-]
-
-[[package]]
 name = "rav1e"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11675,7 +10618,7 @@ dependencies = [
  "serde_yaml_ng",
  "smallvec",
  "thiserror 1.0.69",
- "trueno 0.17.5",
+ "trueno",
  "trueno-quant",
  "uuid",
 ]
@@ -11829,45 +10772,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
-name = "renacer"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9445ea7144e1feb5a108f5428349efff2221077175dc18c4afa825703774784e"
-dependencies = [
- "addr2line 0.25.1",
- "anyhow",
- "aprender 0.25.9",
- "backtrace",
- "clap",
- "crossbeam",
- "crossterm 0.28.1",
- "dashmap",
- "fnv",
- "gimli 0.32.3",
- "hex",
- "libc",
- "memmap2",
- "nix 0.30.1",
- "object 0.38.1",
- "rand 0.8.6",
- "ratatui",
- "regex",
- "rmp-serde",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "static_assertions",
- "thiserror 2.0.18",
- "toml 0.8.23",
- "tracing",
- "tracing-subscriber",
- "trueno 0.14.6",
- "trueno-db",
- "trueno-graph",
- "trueno-viz",
-]
-
-[[package]]
 name = "renacer-core"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11893,22 +10797,6 @@ name = "renderdoc-sys"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
-
-[[package]]
-name = "repartir"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efe68c3c52133131141c7b04a828af59f1352f85019a6a758c488be21e9f6089"
-dependencies = [
- "futures",
- "num_cpus",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
- "uuid",
-]
 
 [[package]]
 name = "reqwest"
@@ -12512,9 +11400,6 @@ name = "ruzstd"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7c1c839d570d835527c9a5e4db7cb2198683a988cb9d7293fc8674e6bd58fc8"
-dependencies = [
- "twox-hash 2.1.2",
-]
 
 [[package]]
 name = "ryu"
@@ -13127,7 +12012,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
 dependencies = [
- "bitmaps 2.1.0",
+ "bitmaps",
  "typenum",
 ]
 
@@ -13153,23 +12038,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "smol"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33bd3e260892199c3ccfc487c88b2da2265080acb316cd920da72fdfd7c599f"
-dependencies = [
- "async-channel",
- "async-executor",
- "async-fs",
- "async-io",
- "async-lock",
- "async-net",
- "async-process",
- "blocking",
- "futures-lite",
 ]
 
 [[package]]
@@ -13691,20 +12559,6 @@ name = "sysinfo"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c33cd241af0f2e9e3b5c32163b873b29956890b5342e6745b917ce9d490f4af"
-dependencies = [
- "core-foundation-sys",
- "libc",
- "memchr",
- "ntapi",
- "rayon",
- "windows 0.57.0",
-]
-
-[[package]]
-name = "sysinfo"
-version = "0.33.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc858248ea01b66f19d8e8a6d55f41deaf91e9d495246fd01368d99935c6c01"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -14629,54 +13483,6 @@ dependencies = [
 
 [[package]]
 name = "trueno"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a0756605a19a0b79f5dca9b61fba7e428c497abe9ebeac2ef91b39d90b6da91"
-dependencies = [
- "anyhow",
- "bytemuck",
- "futures-intrusive",
- "num_cpus",
- "pollster",
- "thiserror 2.0.18",
- "wgpu 27.0.1",
-]
-
-[[package]]
-name = "trueno"
-version = "0.14.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90b0f08c743a6d63e691f80624e67e306e83f9bc532ebc618b2352cd02126e7e"
-dependencies = [
- "anyhow",
- "chrono",
- "hostname",
- "num_cpus",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "toml 0.8.23",
-]
-
-[[package]]
-name = "trueno"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e19fa22753d395f043b205999122520efd45a33e0867d137f20b777ad794ef"
-dependencies = [
- "anyhow",
- "chrono",
- "hostname",
- "num_cpus",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "toml 0.8.23",
- "trueno-quant",
-]
-
-[[package]]
-name = "trueno"
 version = "0.17.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b290ee9696b82ac3aa61e45a10b31043888075e2bc89250f1ea14319c507ec8"
@@ -14701,39 +13507,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "trueno-db"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef9435a39b53dd71c59545ed2a2336d037481e3c2dd61eb8f3cdd6df4ac37cb"
-dependencies = [
- "anyhow",
- "arrow 54.3.1",
- "axum 0.7.9",
- "batuta-common",
- "chrono",
- "clap",
- "console_error_panic_hook",
- "dashmap",
- "js-sys",
- "parquet 54.3.1",
- "rayon",
- "rustc-hash 2.1.2",
- "serde",
- "serde-wasm-bindgen",
- "serde_json",
- "serde_yaml_ng",
- "sqlparser",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "tracing-subscriber",
- "trueno 0.17.5",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
 name = "trueno-gemm-codegen"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14745,90 +13518,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "trueno-graph"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fb66018c97b3a2296df80bdaedcc8d47879e61cd43b466609e9d1a24ce4a0d3"
-dependencies = [
- "anyhow",
- "aprender 0.27.8",
- "arrow 54.3.1",
- "parquet 54.3.1",
- "thiserror 2.0.18",
- "tokio",
- "trueno 0.17.5",
- "trueno-db",
-]
-
-[[package]]
 name = "trueno-quant"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5da5ac788b596e45d1d3fa0991c04b0e1bac63ffe4ae2faf6ae7c0d9fdfc00eb"
 dependencies = [
  "half",
-]
-
-[[package]]
-name = "trueno-ublk"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f73a7de38afcb76f90ed573edb5c8a1a8a0fc7052db1c8de8187513039e1c6c"
-dependencies = [
- "anyhow",
- "async-trait",
- "clap",
- "crossterm 0.28.1",
- "ctrlc",
- "duende-core",
- "duende-mlock",
- "duende-platform",
- "duende-policy",
- "duende-ublk",
- "io-uring",
- "libublk",
- "nix 0.29.0",
- "parking_lot",
- "procfs",
- "ratatui",
- "rayon",
- "renacer",
- "rustc-hash 2.1.2",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "tracing-subscriber",
- "trueno-zram-core",
-]
-
-[[package]]
-name = "trueno-viz"
-version = "0.1.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882ffd53613bef43526c08f0a87d6058a10c276a599c7055caa985103475faf9"
-dependencies = [
- "base64 0.22.1",
- "batuta-common",
- "crossterm 0.28.1",
- "dirs 5.0.1",
- "libc",
- "png 0.17.16",
- "ratatui",
- "serde",
- "serde_yaml_ng",
- "thiserror 2.0.18",
- "trueno 0.15.0",
-]
-
-[[package]]
-name = "trueno-zram-core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e75a0f63770d4b926254d02d2fc9a0abd286f333d9e2d19f18cf8b801daf235e"
-dependencies = [
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -14859,23 +13554,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 dependencies = [
  "core_maths",
-]
-
-[[package]]
-name = "ttop"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f7c5527eb2047094b6dd1d63ff325bfef64b82f64e6107a78f58c9307b1bb61"
-dependencies = [
- "anyhow",
- "batuta-common",
- "clap",
- "crossterm 0.28.1",
- "presentar-core",
- "presentar-terminal",
- "serde",
- "serde_yaml_ng",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -14948,25 +13626,9 @@ dependencies = [
 
 [[package]]
 name = "twox-hash"
-version = "1.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
-dependencies = [
- "cfg-if 1.0.4",
- "static_assertions",
-]
-
-[[package]]
-name = "twox-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
-
-[[package]]
-name = "typed-arena"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "typenum"
@@ -15057,17 +13719,6 @@ name = "unicode-segmentation"
 version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
-
-[[package]]
-name = "unicode-truncate"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
-dependencies = [
- "itertools 0.13.0",
- "unicode-segmentation",
- "unicode-width 0.1.11",
-]
 
 [[package]]
 name = "unicode-vo"
@@ -15323,7 +13974,7 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7df16e474ef958526d1205f6dda359fdfab79d9aa6d54bafcb92dcd07673dca"
 dependencies = [
- "darling 0.20.11",
+ "darling",
  "once_cell",
  "proc-macro-error2",
  "proc-macro2",
@@ -16439,18 +15090,6 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix 0.38.44",
-]
-
-[[package]]
-name = "which"
 version = "6.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f"
@@ -16498,7 +15137,7 @@ dependencies = [
  "realizar",
  "symphonia",
  "thiserror 2.0.18",
- "trueno 0.17.5",
+ "trueno",
 ]
 
 [[package]]
@@ -17225,7 +15864,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a76ff259533532054cfbaefb115c613203c73707017459206380f03b3b3f266e"
 dependencies = [
- "darling 0.20.11",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.118",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,8 +179,12 @@ sha2 = "0.10"
 minijinja = { version = "2.14", features = ["loader", "serde"] }
 
 # Contracts
-provable-contracts = "0.3"
-provable-contracts-macros = "0.3"
+# APR-MONO self-containment: `provable-contracts` was merged in-tree as
+# `crates/aprender-contracts` (lib name `provable_contracts`). Declaring it from
+# crates.io compiled a SECOND copy of the contract engine alongside the in-tree
+# one — exactly the duplicate-crate + publish-cycle the consolidation removed.
+provable-contracts = { path = "crates/aprender-contracts", version = "0.63.0", package = "aprender-contracts" }
+provable-contracts-macros = { path = "crates/aprender-contracts-macros", version = "0.63.0", package = "aprender-contracts-macros" }
 aprender-contracts-macros = { path = "crates/aprender-contracts-macros", version = "0.63.0" }
 
 # YAML
@@ -210,6 +214,14 @@ renacer-core = { path = "crates/aprender-profile-core", version = "0.63.0", pack
 repartir = { path = "crates/aprender-distribute", version = "0.63.0", package = "aprender-distribute" }
 simular = { path = "crates/aprender-simulate", version = "0.63.0", package = "aprender-simulate" }
 probar = { path = "crates/aprender-test-lib", version = "0.63.0", package = "aprender-test-lib" }
+# `jugar-probar` is the crates.io/lib name of the same in-tree crate as `probar`
+# above. Both aliases resolve to ONE package; consumers that spelled it
+# `jugar-probar = "0.4"|"0.5"|"1.0"` were building three extra copies.
+jugar-probar = { path = "crates/aprender-test-lib", version = "0.63.0", package = "aprender-test-lib" }
+# NOTE: the matching `jugar-probar-derive` alias already exists further down this
+# same table (it points at crates/aprender-test-derive). crates/aprender-test-lib
+# was pinning `jugar-probar-derive = "=1.0.3"` from crates.io regardless — the
+# alias was sitting there unused.
 aprender-train = { path = "crates/aprender-train", version = "0.63.0" }
 entrenar = { path = "crates/aprender-train", version = "0.63.0", package = "aprender-train" }
 aprender-train-common = { path = "crates/aprender-train-common", version = "0.63.0" }

--- a/Makefile
+++ b/Makefile
@@ -498,8 +498,19 @@ audit:
 # Validate dependencies (duplicates + security)
 deps-validate:
 	@echo "🔍 Validating dependencies..."
-	@cargo tree --duplicate | grep -v "^$$" || echo "✅ No duplicate dependencies"
-	@cargo audit || echo "⚠️  Security issues found"
+	@# `cmd | grep ... || echo` reads GREP's status, not cargo's, so this target
+	@# exited 0 while printing 1,828 lines of duplicates. Nothing invoked it either.
+	@# Same class as #2336/#2360. Redirect, then read the real status.
+	@cargo tree --duplicates > /tmp/apr-dup.txt 2>&1; \
+	if [ -s /tmp/apr-dup.txt ]; then \
+		echo "FAIL: duplicate dependencies present:"; cat /tmp/apr-dup.txt; exit 1; \
+	fi; \
+	echo "OK: no duplicate dependencies"
+	@cargo audit > /tmp/apr-audit.txt 2>&1; rc=$$?; \
+	if [ $$rc -ne 0 ]; then \
+		echo "FAIL: cargo audit reported issues:"; cat /tmp/apr-audit.txt; exit 1; \
+	fi; \
+	echo "OK: cargo audit clean"
 
 # Run cargo-deny checks (licenses, bans, advisories, sources)
 deny:

--- a/crates/apr-cli/Cargo.toml
+++ b/crates/apr-cli/Cargo.toml
@@ -110,7 +110,7 @@ aprender-contracts = { workspace = true }
 # MCP (Model Context Protocol) server — `apr mcp` subcommand
 aprender-mcp = { path = "../aprender-mcp", version = "0.63.0" }
 async-stream = "0.3"
-provable-contracts-macros = "0.3"
+provable-contracts-macros = { workspace = true }
 
 # Shared formatting and system utilities (Batuta stack)
 batuta-common = { workspace = true }
@@ -262,7 +262,7 @@ assert_cmd = "2.0"
 predicates = "3.1"
 tempfile = "3.14"
 proptest = "1.6"
-jugar-probar = { version = "0.4", features = ["tui"] }
+jugar-probar = { workspace = true, features = ["tui"] }
 regex = "1.10"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
 axum-test = "16"

--- a/crates/aprender-cbtop/Cargo.toml
+++ b/crates/aprender-cbtop/Cargo.toml
@@ -59,7 +59,7 @@ libc = "0.2"
 proptest = "1"
 tempfile = "3"
 # TUI pixel-level testing framework
-jugar-probar = "1.0"
+jugar-probar = { workspace = true }
 
 [features]
 default = []

--- a/crates/aprender-compute/Cargo.toml
+++ b/crates/aprender-compute/Cargo.toml
@@ -43,7 +43,7 @@ wasm-bindgen = { version = "0.2", optional = true }
 # Native CUDA monitoring via trueno-gpu (TRUENO-SPEC-010)
 trueno-gpu = { version = "0.63.0", path = "../aprender-gpu", optional = true, package = "aprender-gpu" }
 # PMAT-336: Provable contracts compile-time enforcement
-provable-contracts-macros = "0.3"
+provable-contracts-macros = { workspace = true }
 # P1a: Sovereign GEMM microkernel codegen (compile-time shape specialization)
 trueno-gemm-codegen = { version = "0.63.0", path = "../aprender-gemm-codegen", package = "aprender-gemm-codegen" }
 # Tracing/profiling support (renacer integration)

--- a/crates/aprender-core/Cargo.toml
+++ b/crates/aprender-core/Cargo.toml
@@ -150,7 +150,7 @@ js-sys = { version = "0.3", optional = true }
 minijinja = { version = "2.14.0", features = ["loader", "serde"] }
 
 # UCBD: compile-time contract enforcement via #[contract] proc macro
-provable-contracts-macros = "0.3"
+provable-contracts-macros = { workspace = true }
 
 # Toyota Way: ONE source of truth for quantization (Step E)
 # NOTE: Currently blocked by cyclic dependency (realizar optionally depends on aprender).
@@ -173,9 +173,9 @@ criterion = { workspace = true }
 # until aprender-core does).
 renacer = { path = "../aprender-profile", package = "aprender-profile" }
 tempfile = "3.14"  # For format module tests
-jugar-probar = "0.5"  # TUI/GUI testing framework with coverage tracking (spec §8)
+jugar-probar = { workspace = true }  # TUI/GUI testing framework with coverage tracking (spec §8)
 ctrlc = "3.4"  # Signal handling for SIGINT/SIGTERM (PMAT-098-PF: zombie process mitigation)
-provable-contracts = "0.3"  # Contract enforcement (dev-only)
+provable-contracts = { workspace = true }  # Contract enforcement (dev-only)
 # Integration tests for InferenceMonitor (GH-305: was runtime dep, now dev-only).
 # Same publish-time cycle break as renacer above.
 entrenar = { path = "../aprender-train", package = "aprender-train" }

--- a/crates/aprender-data/Cargo.toml
+++ b/crates/aprender-data/Cargo.toml
@@ -109,7 +109,7 @@ criterion = { version = "0.5", features = ["html_reports"] }
 proptest = "1.6"
 assert_cmd = "2"
 predicates = "3"
-jugar-probar = "1.0.1"
+jugar-probar = { workspace = true }
 
 [[bin]]
 name = "alimentar"

--- a/crates/aprender-db/wasm-pkg/Cargo.toml
+++ b/crates/aprender-db/wasm-pkg/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 # Parent crate (simd only, no tokio for WASM)
 trueno-db = { path = "..", default-features = false, features = ["simd", "wasm"] }
-trueno = "0.7.1"  # Direct dependency for SIMD backend
+trueno = { path = "../../aprender-compute", package = "aprender-compute" }  # in-tree SIMD backend (APR-MONO)
 
 # WASM bindings
 wasm-bindgen = "0.2"

--- a/crates/aprender-distribute/Cargo.toml
+++ b/crates/aprender-distribute/Cargo.toml
@@ -94,7 +94,7 @@ tracing-subscriber = "0.3"
 futures = "0.3"
 
 # TUI testing via probador
-jugar-probar = { version = "0.4", default-features = false, features = ["tui"] }
+jugar-probar = { workspace = true, features = ["tui"] }
 
 [lints]
 workspace = true

--- a/crates/aprender-gpu/Cargo.toml
+++ b/crates/aprender-gpu/Cargo.toml
@@ -56,9 +56,14 @@ bytemuck = { version = "1.21", features = ["derive"] }
 # ^0.51.0 version pin closed a crates.io publish cycle
 # (aprender-compute → aprender-gpu → aprender-profile → aprender-core → aprender-compute).
 
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-# GPU pixel testing with TUI visualization (Sovereign Stack)
-jugar-probar = { version = "0.4.0", optional = true }
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+# GPU pixel testing with TUI visualization (Sovereign Stack).
+# DEV-dependency, not a normal one: every use is in tests/ (gpu_pixels.rs,
+# pixel_fkr, lz4_fkr) and none in src/. As a *normal* dep the in-tree edge
+# aprender-gpu -> aprender-test-lib -> aprender-compute -> aprender-gpu is a
+# cargo-rejected cycle; through a dev edge it is legal, which is why this was
+# still pinned to a crates.io copy.
+jugar-probar = { workspace = true }
 
 [features]
 default = []
@@ -71,8 +76,9 @@ wasm = ["dep:wasm-bindgen"]
 stress-test = ["dep:simular"]
 # TUI monitoring mode for stress tests
 tui-monitor = ["stress-test", "dep:crossterm"]
-# GPU pixel testing with probar TUI visualization
-gpu-pixels = ["dep:jugar-probar", "dep:crossterm"]
+# GPU pixel testing with probar TUI visualization.
+# `jugar-probar` is a dev-dependency (see above) so it cannot be a `dep:` entry.
+gpu-pixels = ["dep:crossterm"]
 # WGPU backend for cross-platform GPU compute (WebGPU via wgpu crate)
 wgpu = ["dep:wgpu"]
 # Apple Metal backend via manzana (macOS only)

--- a/crates/aprender-orchestrate/Cargo.toml
+++ b/crates/aprender-orchestrate/Cargo.toml
@@ -69,8 +69,14 @@ trueno = { workspace = true, optional = true, features = ["gpu"] }
 # SIMD/GPU memory compression (LZ4/ZSTD, native-only)
 trueno-zram-core = { workspace = true, optional = true }
 
-# GPU-accelerated block device via ublk (native-only)
-trueno-ublk = { version = "0.3", optional = true }
+# NOTE: `trueno-ublk = { version = "0.3", optional = true }` was REMOVED, not
+# re-pointed at the in-tree crate. It was a crates.io copy of an in-tree package
+# (`crates/aprender-zram/bins/trueno-ublk`) that this crate never imports —
+# `trueno_ublk` appears here only as a string literal in the Oracle knowledge
+# graph and as println! text in examples/trueno_ublk_demo.rs. The in-tree
+# package is also unbuildable today (its `trueno-zram-core` path dep points at
+# `crates/aprender-zram/crates/trueno-zram-core`, which does not exist), so
+# wiring it in would newly break the build for zero call sites.
 
 # Distributed compute (CPU/GPU/Remote executors, native-only)
 repartir = { workspace = true, optional = true, features = ["cpu", "remote"] }
@@ -127,7 +133,11 @@ alimentar = { workspace = true, optional = true }
 # RAG and visualization (native-only)
 trueno-rag = { workspace = true, optional = true, features = ["sqlite"] }
 trueno-viz = { workspace = true, optional = true }
-presentar = { version = "0.3", optional = true }
+# NOTE: `presentar = { version = "0.3", optional = true }` REMOVED. `presentar`
+# is the published name of the in-tree `crates/aprender-present-cli`, but that
+# package is binary-only ([[bin]] name = "presentar", no [lib]) so there is no
+# library to point at — and nothing here imported `presentar::` anyway (the
+# `presentar_terminal::`/`presentar_core::` uses come from the path deps above).
 
 # Speech recognition (native-only)
 whisper-apr = { version = "0.2", optional = true }
@@ -142,8 +152,15 @@ simular = { workspace = true, optional = true }
 # depyler = { version = "3.20", optional = true }  # blocked: serde version conflict (1.0.200-1.0.219)
 bashrs = { version = "6.65", optional = true }
 
-# Testing and quality (native-only)
-probar = { workspace = true, optional = true }
+# Testing and quality (native-only).
+# NOTE: the `probar = { workspace = true, optional = true }` alias that used to
+# sit here was removed. `probar` and `jugar-probar` are two workspace aliases for
+# the SAME package (crates/aprender-test-lib); once `jugar-probar` stopped
+# resolving to a crates.io copy they became one package under two names, which
+# cargo rejects ("depends on crate ... multiple times with different names").
+# Nothing here imported `probar::` — the only hits are inside raw-string cookbook
+# recipes — whereas `jugar_probar::{Browser, BrowserConfig, Page}` is a real
+# import in src/agent/tool/browser.rs. So `jugar-probar` below is the survivor.
 
 # HTTP server for Banco workbench API
 axum = { version = "0.7", features = ["json", "multipart", "ws"], optional = true }
@@ -152,7 +169,7 @@ async-stream = { version = "0.3", optional = true }
 tokio-stream = { version = "0.1", optional = true }
 
 # Headless browser automation (agent BrowserTool)
-jugar-probar = { version = "1.0", features = ["browser"], optional = true }
+jugar-probar = { workspace = true, features = ["browser"], optional = true }
 base64 = { version = "0.22", optional = true }
 
 # MCP protocol: client (consume external tools) + server (expose agent tools).
@@ -163,8 +180,8 @@ base64 = { version = "0.22", optional = true }
 pmcp = { version = "2.3", optional = true }
 
 # Provable design-by-contract (compile-time contract binding)
-provable-contracts = { version = "0.2", optional = true }
-provable-contracts-macros = { version = "0.2", optional = true }
+provable-contracts = { workspace = true, optional = true }
+provable-contracts-macros = { workspace = true, optional = true }
 
 # PNG rasterization for Coursera banner assets (native-only)
 resvg = { version = "0.47", optional = true }
@@ -232,7 +249,7 @@ ml = ["aprender", "entrenar", "alimentar", "native"]
 rag = ["trueno-rag", "oracle-mode"]
 
 # Visualization (terminal and WASM)
-viz = ["trueno-viz", "presentar", "native"]
+viz = ["trueno-viz", "native"]
 
 # Speech recognition (Whisper ASR)
 speech = ["whisper-apr", "native"]
@@ -243,8 +260,10 @@ kernel = ["pepita", "native"]
 # SIMD/GPU compression (LZ4/ZSTD with AVX2/AVX-512/NEON)
 compression = ["trueno-zram-core", "native"]
 
-# GPU-accelerated block device (ublk)
-block-device = ["trueno-ublk", "compression"]
+# GPU-accelerated block device (ublk). The `trueno-ublk` dep this used to pull
+# from crates.io is gone (see the dependency section); the feature keeps its
+# compression enablement so downstream `--features block-device` still resolves.
+block-device = ["compression"]
 
 # Simulation engine
 simulation = ["simular", "native"]
@@ -253,8 +272,9 @@ simulation = ["simular", "native"]
 # depyler blocked until serde versions aligned
 transpilers = ["bashrs", "native"]
 
-# Testing and quality
-testing = ["probar", "native"]
+# Testing and quality (see the dependency note: `probar` -> `jugar-probar`,
+# the same in-tree package under its other alias)
+testing = ["jugar-probar", "native"]
 
 # Banco: local-first AI workbench HTTP API (batteries included)
 # Includes: realizar (inference), aprender (BPE), alimentar (Arrow), entrenar (training/merge)
@@ -276,7 +296,7 @@ agents-mcp = ["agents", "pmcp"]
 # Provable design-by-contract (compile-time contract binding)
 agents-contracts = ["agents", "provable-contracts", "provable-contracts-macros"]
 # WASM visualization for agent dashboards in wos
-agents-viz = ["agents", "presentar"]
+agents-viz = ["agents"]
 # Full sovereign agent (all agent features)
 agents-full = ["agents-inference", "agents-rag"]
 
@@ -303,7 +323,7 @@ proptest = "1.5"
 blake3 = "1.8"
 filetime = "0.2"
 trueno-cuda-edge = { path = "../aprender-cuda-edge", package = "aprender-cuda-edge" }
-jugar-probar = { version = "1.0", features = ["browser"] }
+jugar-probar = { workspace = true, features = ["browser"] }
 tokio-tungstenite = "0.24"
 
 [[bench]]

--- a/crates/aprender-present-core/Cargo.toml
+++ b/crates/aprender-present-core/Cargo.toml
@@ -20,7 +20,7 @@ serde_json = { workspace = true }
 # closed compute→gpu→present-core→compute (and …→simulate→present-core→…) cycles. The
 # never-enabled `simd` feature's trueno-backed helpers are dropped; the always-on
 # auto-vectorized f64 ComputeBlocks (batch_sum_f64, …) remain.
-provable-contracts-macros = "0.3"
+provable-contracts-macros = { workspace = true }
 
 [build-dependencies]
 serde = { workspace = true }

--- a/crates/aprender-present-lib/Cargo.toml
+++ b/crates/aprender-present-lib/Cargo.toml
@@ -36,7 +36,7 @@ console_error_panic_hook = { workspace = true }
 getrandom = { workspace = true }
 
 [dev-dependencies]
-provable-contracts = "0.3"
+provable-contracts = { workspace = true }
 presentar-test = { path = "../aprender-present-test", package = "aprender-present-test" }
 sha2 = "0.10"
 hex = "0.4"

--- a/crates/aprender-present-terminal/Cargo.toml
+++ b/crates/aprender-present-terminal/Cargo.toml
@@ -32,9 +32,13 @@ thiserror = "2.0"
 proptest = { workspace = true }
 criterion = { workspace = true }
 
-# ttop for parity testing against the reference implementation
-# See SPEC-024 Section 11 - Visual Comparison Findings
-ttop = "2.0"
+# NOTE: `ttop = "2.0"` REMOVED (same reason as the trueno-viz note below).
+# `ttop` is the published name of the in-tree `crates/aprender-viz-ttop`, which
+# is binary-only (no [lib]) — so the crates.io copy could not be swapped for it.
+# Nothing here imported `ttop::`; the dep only dragged in a parallel crates.io
+# stack (ttop 2.0 -> presentar-terminal 0.3.5 -> presentar-core 0.3.4 ->
+# trueno 0.14.6), i.e. a second copy of THIS crate and of the SIMD foundation.
+# SPEC-024 Section 11 visual-parity comparison was never wired up in code.
 # NOTE: trueno-viz dev-dep removed — it was unused (0 references) and its ^0.51.0
 # requirement created a crates.io publish cycle
 # (aprender-compute → aprender-present-terminal → aprender-viz → aprender-compute).

--- a/crates/aprender-serve/Cargo.toml
+++ b/crates/aprender-serve/Cargo.toml
@@ -55,7 +55,7 @@ trueno-db = { workspace = true, optional = true }
 trueno-quant = { workspace = true }
 
 # Contract macros for pre/post-condition enforcement (zero cost in release)
-provable-contracts-macros = { version = "0.2" }
+provable-contracts-macros = { workspace = true }
 
 # PMAT-284: Core tracing primitives (zero-dep, breaks renacer circular dep)
 renacer-core = { workspace = true }
@@ -166,10 +166,10 @@ serde_yaml_ng = "0.10"
 
 [dev-dependencies]
 # Contract trait enforcement (Section 23)
-provable-contracts = { version = "0.2" }
+provable-contracts = { workspace = true }
 
 # Visual regression testing framework (playbooks, TUI testing, GPU pixel verification)
-jugar-probar = { version = "0.4", features = ["tui", "gpu"] }
+jugar-probar = { workspace = true, features = ["tui", "gpu"] }
 
 # GPU edge-case test framework (null fuzzing, boundary probing, lifecycle chaos)
 trueno-cuda-edge = { path = "../aprender-cuda-edge", package = "aprender-cuda-edge" }

--- a/crates/aprender-simulate/Cargo.toml
+++ b/crates/aprender-simulate/Cargo.toml
@@ -81,7 +81,7 @@ bitflags = "2.6"
 
 # Work stealing for Heijunka
 crossbeam-deque = "0.8"
-provable-contracts-macros = { version = "0.2" }
+provable-contracts-macros = { workspace = true }
 
 # Z3 removed from Cargo.toml to reduce Cargo.lock bloat (CB-081)
 # Re-add with: z3 = { version = "0.12", optional = true }
@@ -93,7 +93,7 @@ serde_yaml = "0.9"
 
 [dev-dependencies]
 # Contract trait enforcement (Section 23)
-provable-contracts = { version = "0.2" }
+provable-contracts = { workspace = true }
 # Property-based testing (Popperian falsification)
 proptest = "1.5"
 criterion = { version = "0.5", default-features = false }

--- a/crates/aprender-test-lib/Cargo.toml
+++ b/crates/aprender-test-lib/Cargo.toml
@@ -66,7 +66,7 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 
 # Optional derive macros for type-safe selectors (Phase 4)
-jugar-probar-derive = { version = "=1.0.3", optional = true }
+jugar-probar-derive = { workspace = true, optional = true }
 
 # Optional GPU compute via trueno
 trueno = { workspace = true, optional = true }

--- a/crates/aprender-test-showcase/Cargo.toml
+++ b/crates/aprender-test-showcase/Cargo.toml
@@ -32,7 +32,7 @@ web-sys = { version = "0.3", optional = true, features = [
 
 [dev-dependencies]
 # Use local probar for dogfooding PIXEL-001 v2.1
-jugar-probar = "1.0"
+jugar-probar = { workspace = true }
 proptest.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 

--- a/crates/aprender-test/Cargo.toml
+++ b/crates/aprender-test/Cargo.toml
@@ -79,15 +79,16 @@ syn = { version = "2.0", features = ["full", "visit", "parsing", "extra-traits"]
 bincode = "1.3"
 
 # GPU compute (trueno - SIMD-accelerated tensor operations)
-trueno = { version = "0.16.5", features = ["gpu"] }
+# APR-MONO: in-tree sibling, not crates.io (package aprender-compute, [lib] name = "trueno")
+trueno = { path = "../aprender-compute", package = "aprender-compute", features = ["gpu"] }
 
 # TUI Testing (EDD compliance)
 # Uses custom TextGrid/MockTty - no external TUI deps
 crossterm = "0.28"
 
 # ComputeBlock testing (presentar-terminal integration)
-presentar-terminal = "0.3"
-presentar-core = "0.3"
+presentar-terminal = { path = "../aprender-present-terminal", package = "aprender-present-terminal" }
+presentar-core = { path = "../aprender-present-core", package = "aprender-present-core" }
 
 # Deterministic replay
 serde_yaml_ng = "0.10"

--- a/crates/aprender-train-canary/Cargo.toml
+++ b/crates/aprender-train-canary/Cargo.toml
@@ -6,7 +6,8 @@ publish = false
 
 [dependencies]
 burn = { version = "0.21.0-pre.2", features = ["wgpu"] }
-trueno = { version = "0.16", features = ["parallel", "gpu"] }
-
-[patch.crates-io]
-trueno = { path = "/home/noah/src/trueno" }
+# APR-MONO: in-tree sibling. This replaces BOTH the crates.io pin and the
+# `[patch.crates-io] trueno = { path = "/home/noah/src/trueno" }` that used to
+# follow — an absolute path to a now-archived sibling checkout that exists only
+# on one dev box.
+trueno = { path = "../aprender-compute", package = "aprender-compute", features = ["parallel", "gpu"] }

--- a/crates/aprender-train/Cargo.toml
+++ b/crates/aprender-train/Cargo.toml
@@ -75,7 +75,7 @@ viz = ["dep:batuta-common"]
 
 [dependencies]
 # Contract macros for pre/post-condition enforcement (zero cost in release)
-provable-contracts-macros = { version = "0.2" }
+provable-contracts-macros = { workspace = true }
 # Core PAIML stack
 ndarray = "0.16"
 trueno = { workspace = true, features = ["parallel"] }
@@ -146,8 +146,8 @@ arrow = { version = "57", default-features = false }  # For MNIST example array 
 parquet = { version = "57", default-features = false }  # For ALB-007 Parquet writing in tests
 insta = { version = "1.42", features = ["json", "yaml"] }  # Snapshot testing for PMAT QA
 dirs = "5.0"  # Cache directory detection for examples
-jugar-probar = "1.0"  # TUI snapshot testing (ENT-140)
-provable-contracts = { version = "0.2" }  # Contract trait enforcement (Section 23)
+jugar-probar = { workspace = true }  # TUI snapshot testing (ENT-140)
+provable-contracts = { workspace = true }  # Contract trait enforcement (Section 23)
 
 [[bench]]
 name = "monitor_bench"

--- a/crates/aprender-viz-ttop/Cargo.toml
+++ b/crates/aprender-viz-ttop/Cargo.toml
@@ -43,7 +43,7 @@ serde_yaml_ng = "0.10"
 
 [dev-dependencies]
 # Probar testing (Brick Architecture, version + path for clean-room)
-jugar-probar = { version = "1.0.4", default-features = false, features = ["tui", "media"] }
+jugar-probar = { path = "../aprender-test-lib", package = "aprender-test-lib", default-features = false, features = ["tui", "media"] }
 proptest = "1.4"
 tempfile = "3.10"
 

--- a/crates/aprender-zram/bins/trueno-ublk/Cargo.toml
+++ b/crates/aprender-zram/bins/trueno-ublk/Cargo.toml
@@ -97,7 +97,7 @@ renacer = { workspace = true, default-features = false }
 [dev-dependencies]
 proptest = { workspace = true }
 tempfile = "3.14"
-jugar-probar = { version = "0.4", default-features = false, features = ["tui"] }
+jugar-probar = { path = "../../../aprender-test-lib", package = "aprender-test-lib", default-features = false, features = ["tui"] }
 criterion = { version = "0.5", features = ["html_reports"] }
 
 [[bench]]

--- a/scripts/check_workspace_siblings_pathed.sh
+++ b/scripts/check_workspace_siblings_pathed.sh
@@ -1,0 +1,417 @@
+#!/usr/bin/env bash
+#
+# check_workspace_siblings_pathed.sh — an in-tree sibling may never be declared
+# as a crates.io dependency.
+#
+# THE CLASS
+# ---------
+# APR-MONO consolidated 20 repos into this one. Every sibling — trueno, realizar,
+# entrenar, pacha, simular, alimentar, renacer, … — now lives under `crates/` and
+# is consumed through a `[workspace.dependencies]` path alias:
+#
+#     # root Cargo.toml
+#     trueno = { path = "crates/aprender-compute", version = "0.63.0", package = "aprender-compute" }
+#     # member Cargo.toml
+#     trueno = { workspace = true }
+#
+# Writing `trueno = "0.16"` instead does NOT fail to build. Cargo happily resolves
+# the crates.io copy ALONGSIDE the in-tree one, so the tree compiles two different
+# `trueno`s whose types are mutually incompatible, and the published-crate
+# dependency cycle the consolidation removed comes back. Nothing goes red. It is
+# invisible until someone reads `cargo tree --duplicates`.
+#
+# It is not hypothetical. At 88791ff55 (2026-08-14) the lockfile carried FOUR
+# registry copies of `trueno` (0.11.0, 0.14.6, 0.15.0, 0.17.5) beside the path
+# one, plus registry copies of provable-contracts, provable-contracts-macros,
+# jugar-probar, jugar-probar-derive, presentar-core, presentar-terminal and
+# trueno-ublk — every one of them seeded by a declaration this guard names.
+#
+# CLAUDE.md has forbidden this in prose since the consolidation. Prose is not a
+# gate; that is the whole finding.
+#
+# THE RULE
+# --------
+# For every dependency declaration in every tracked manifest, if the crate named
+# is served in-tree, the declaration must resolve to the local source:
+#
+#   legal    trueno = { workspace = true }
+#   legal    trueno = { path = "../aprender-compute" }
+#   legal    trueno = { path = "…", version = "0.63.0" }   # path + version is what
+#                                                          # `cargo publish` needs
+#   FAIL     trueno = "0.16"                               # registry
+#   FAIL     trueno = { version = "0.16.5", features = ["gpu"] }
+#   FAIL     trueno = { git = "…" }                        # also not the in-tree copy
+#
+# A `version` beside a `path` is fine — cargo builds from the path and reads the
+# version only when publishing. The defect is a version with NO local source.
+#
+# THE NAME SET — WHY `[lib] name` IS LOAD-BEARING
+# -----------------------------------------------
+# Package name and lib name DIVERGE throughout this tree, and the divergence is
+# exactly where the motivating bug lives:
+#
+#     crates/aprender-compute   [package] aprender-compute   [lib] trueno
+#     crates/aprender-db        [package] aprender-db        [lib] trueno_db
+#     crates/aprender-serve     [package] aprender-serve     [lib] realizar
+#
+# A guard built from `[package] name` alone would hold "aprender-compute" and
+# would sail straight past `trueno = "0.16"` — the one declaration it exists to
+# stop. So the set is package names UNION lib names, each in both `-` and `_`
+# spelling (a lib is `trueno_db`; the crate it shadows publishes as `trueno-db`),
+# UNION every root `[workspace.dependencies]` key carrying a `path =`.
+#
+# SCOPE
+# -----
+# NAMES come from the root manifest and every manifest under `crates/`.
+# SCANNING is wider — every tracked `Cargo.toml`. A violation can be written
+# anywhere, and one of the live ones was in `crates/aprender-db/wasm-pkg/`, a
+# nested demo manifest no crate-list glob would reach.
+#
+# VACUITY GUARD
+# -------------
+# A guard that matches nothing must not report clean — "found no violations" and
+# "looked in the wrong place" print identically. Three defences:
+#   1. it refuses to pass with fewer than MIN_CRATES in-tree names,
+#   2. it refuses to pass having scanned fewer than MIN_MANIFESTS manifests,
+#   3. before printing PASS it runs a POSITIVE CONTROL — a synthetic
+#      `trueno = "0.16"` through the real scanner with the real name set — and
+#      aborts if that is not flagged. The absence is only reported once the
+#      search is proved able to succeed.
+#
+# SELF-TEST
+# ---------
+#   bash scripts/check_workspace_siblings_pathed.sh --self-test
+# runs the must-fail / must-pass case table, twelve whole-fragment cases, and an
+# end-to-end mutation probe on a throwaway tree (Verification Discipline #7:
+# re-run the table, never re-read the pattern).
+
+set -euo pipefail
+
+SELF_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LIB_DIR="${REPO_ROOT}/scripts/lib"
+NAME_AWK="${LIB_DIR}/workspace_sibling_names.awk"
+SCAN_AWK="${LIB_DIR}/workspace_siblings_pathed.awk"
+CASES="${LIB_DIR}/workspace_siblings_cases.txt"
+
+MIN_CRATES="${MIN_CRATES:-70}"
+MIN_MANIFESTS="${MIN_MANIFESTS:-60}"
+
+for prog in "$NAME_AWK" "$SCAN_AWK"; do
+    if [ ! -f "$prog" ]; then
+        printf 'ERROR: %s is missing - the scanner cannot run.\n' "$prog" >&2
+        exit 2
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# File discovery.
+# ---------------------------------------------------------------------------
+list_manifests() {
+    local root="$1"
+    if git -C "$root" rev-parse --git-dir >/dev/null 2>&1; then
+        git -C "$root" ls-files -z '*Cargo.toml' | tr '\0' '\n' | sed "s|^|${root}/|"
+    else
+        find "$root" -name Cargo.toml -type f -not -path '*/target/*' | sort
+    fi
+}
+
+# The manifests that DEFINE in-tree crate names: the root facade plus everything
+# under crates/, at any depth.
+list_name_sources() {
+    local root="$1" f
+    [ -f "$root/Cargo.toml" ] && printf '%s\n' "$root/Cargo.toml"
+    while IFS= read -r f; do
+        case "$f" in "$root"/crates/*) printf '%s\n' "$f" ;; esac
+    done < <(list_manifests "$root")
+}
+
+intree_names() {
+    local root="$1" f
+    while IFS= read -r f; do
+        [ -n "$f" ] || continue
+        if [ "$f" = "$root/Cargo.toml" ]; then
+            awk -v ROOT=1 -f "$NAME_AWK" "$f"
+        else
+            awk -v ROOT=0 -f "$NAME_AWK" "$f"
+        fi
+    done < <(list_name_sources "$root") | sort -u
+}
+
+# scan_manifest <file-on-disk> <name-for-report> <namefile>
+scan_manifest() {
+    awk -v FILE="$2" -v NAMEFILE="$3" -f "$SCAN_AWK" "$1"
+}
+
+# ---------------------------------------------------------------------------
+# --self-test
+# ---------------------------------------------------------------------------
+if [ "${1:-}" = "--self-test" ]; then
+    TD="$(mktemp -d)"
+    if [ -z "${TD:-}" ] || [ ! -d "$TD" ]; then
+        printf 'FAIL: could not create a temp dir for the case table.\n' >&2
+        exit 1
+    fi
+    trap 'rm -rf "${TD:?}"' EXIT
+
+    # The name set the table runs against: the real divergent trio, in both
+    # spellings, so the table exercises package name, lib name, and alias.
+    printf '%s\n' trueno trueno-db trueno_db realizar aprender-compute aprender-db \
+        > "$TD/names.txt"
+
+    fails=0
+    ncases=0
+
+    if [ ! -f "$CASES" ]; then
+        printf 'FAIL: the case table %s is missing.\n' "$CASES" >&2
+        exit 1
+    fi
+
+    # ---- the case table, driven from scripts/lib/workspace_siblings_cases.txt
+    #
+    # `LINE <fail|pass> <decl>` is wrapped in a [dependencies] header and run
+    # through the REAL scanner. `FRAG <flag|clean> <label>` … `END` is a whole
+    # manifest fragment, verbatim.
+    probe_line() {
+        printf '[dependencies]\n%s\n' "$1" > "$TD/probe.toml"
+        scan_manifest "$TD/probe.toml" 'probe.toml' "$TD/names.txt"
+    }
+    eval_line() {
+        local want="$1" text="$2" got
+        ncases=$((ncases + 1))
+        got="$(probe_line "$text")"
+        if [ "$want" = fail ] && [ -z "$got" ]; then
+            printf 'CASE-TABLE FAIL [must-fail] not flagged: %s\n' "$text" >&2
+            fails=$((fails + 1))
+        elif [ "$want" = pass ] && [ -n "$got" ]; then
+            printf 'CASE-TABLE FAIL [must-pass] false positive: %s\n         -> %s\n' "$text" "$got" >&2
+            fails=$((fails + 1))
+        fi
+    }
+    eval_frag() {
+        local want="$1" label="$2" got
+        ncases=$((ncases + 1))
+        got="$(scan_manifest "$TD/frag.toml" 'frag.toml' "$TD/names.txt")"
+        if [ "$want" = flag ] && [ -z "$got" ]; then
+            printf 'FRAGMENT FAIL [%s] expected a finding, got none\n' "$label" >&2
+            fails=$((fails + 1))
+        elif [ "$want" = clean ] && [ -n "$got" ]; then
+            printf 'FRAGMENT FAIL [%s] false positive: %s\n' "$label" "$got" >&2
+            fails=$((fails + 1))
+        fi
+    }
+
+    # Strip leading whitespace into $LTRIM. A bash-regex capture rather than the
+    # nested `${t#"${t%%[![:space:]]*}"}` idiom: same result, and no nested
+    # parameter expansion for bashrs to trip over (SC2296).
+    ltrim() {
+        [[ $1 =~ ^[[:space:]]*(.*)$ ]]
+        LTRIM="${BASH_REMATCH[1]}"
+    }
+
+    mode=out
+    want=""
+    label=""
+    while IFS= read -r raw || [ -n "$raw" ]; do
+        if [ "$mode" = frag ]; then
+            if [ "$raw" = "END" ]; then
+                mode=out
+                eval_frag "$want" "$label"
+            else
+                printf '%s\n' "$raw" >> "$TD/frag.toml"
+            fi
+            continue
+        fi
+        case "$raw" in ''|'#'*) continue ;; esac
+        kw="${raw%%[[:space:]]*}"
+        ltrim "${raw#"$kw"}"; rest="$LTRIM"
+        want="${rest%%[[:space:]]*}"
+        ltrim "${rest#"$want"}"; arg="$LTRIM"
+        case "$kw" in
+            LINE) eval_line "$want" "$arg" ;;
+            FRAG) label="$arg"; : > "$TD/frag.toml"; mode=frag ;;
+            *)
+                printf 'CASE-TABLE FAIL: unknown keyword %s in %s\n' "$kw" "$CASES" >&2
+                fails=$((fails + 1))
+                ;;
+        esac
+    done < "$CASES"
+
+    if [ "$mode" = frag ]; then
+        printf 'CASE-TABLE FAIL: unterminated FRAG %s (missing END)\n' "$label" >&2
+        fails=$((fails + 1))
+    fi
+    # Vacuity, applied to the table itself: a table that ran no cases proves
+    # nothing, and would print the same "OK" as one that ran them all.
+    if [ "$ncases" -lt 20 ]; then
+        printf 'CASE-TABLE FAIL: only %s cases parsed from %s - the table did not load.\n' \
+            "$ncases" "$CASES" >&2
+        fails=$((fails + 1))
+    fi
+
+    # ---- end-to-end mutation probe on a throwaway tree --------------------
+    # A passing regex table does not prove the driver wires up: extending a
+    # guard's scope requires re-mutating IN that scope. Build a miniature repo,
+    # inject the violation, assert RED; remove it, assert GREEN.
+    mk_tree() {
+        local d
+        d="$(mktemp -d "$TD/tree.XXXXXX")"
+        mkdir -p "$d/scripts/lib" "$d/crates/aprender-compute" "$d/crates/aprender-db"
+        cp "$SELF_PATH" "$d/scripts/check_workspace_siblings_pathed.sh"
+        cp "$NAME_AWK" "$SCAN_AWK" "$d/scripts/lib/"
+        printf '[workspace]\nmembers = ["crates/aprender-compute"]\n\n[package]\nname = "aprender"\nversion = "0.1.0"\n\n[lib]\nname = "aprender"\n\n[workspace.dependencies]\ntrueno = { path = "crates/aprender-compute", version = "0.1.0", package = "aprender-compute" }\n' \
+            > "$d/Cargo.toml"
+        printf '[package]\nname = "aprender-compute"\nversion = "0.1.0"\n\n[lib]\nname = "trueno"\n' \
+            > "$d/crates/aprender-compute/Cargo.toml"
+        printf '%s' "$d"
+    }
+    # Rewrite crates/aprender-db's [dependencies] block. The block arrives on ONE
+    # line with `\n` escapes, expanded by `printf %b`: a multi-line literal
+    # (heredoc or quoted) would be identical to bash but unparseable to bashrs,
+    # which reads TOML's `name = "value"` as a malformed shell assignment and
+    # then desyncs over the rest of the file.
+    write_db() {
+        {
+            printf '[package]\nname = "aprender-db"\nversion = "0.1.0"\n\n'
+            printf '[lib]\nname = "trueno_db"\n\n'
+            printf '[dependencies]\n'
+            printf '%b' "$2"
+        } > "$1/crates/aprender-db/Cargo.toml"
+    }
+    run_tree() {
+        (cd "$1" && MIN_CRATES=4 MIN_MANIFESTS=3 \
+            bash scripts/check_workspace_siblings_pathed.sh >/dev/null 2>&1)
+    }
+
+    t="$(mk_tree)"
+    write_db "$t" 'trueno = { workspace = true }\nserde = "1"\n'
+    if ! run_tree "$t"; then
+        printf 'MUTATION FAIL: the clean baseline tree is already RED\n' >&2
+        fails=$((fails + 1))
+    fi
+
+    write_db "$t" 'trueno = "0.16"\nserde = "1"\n'
+    if run_tree "$t"; then
+        printf 'MUTATION FAIL: stayed GREEN with `trueno = "0.16"` in a member manifest\n' >&2
+        fails=$((fails + 1))
+    fi
+
+    # The `[lib] name` half specifically: a package-name-only guard passes here.
+    write_db "$t" 'trueno-db = "0.3"\n'
+    if run_tree "$t"; then
+        printf 'MUTATION FAIL: stayed GREEN with `trueno-db = "0.3"` (lib-name shadow)\n' >&2
+        fails=$((fails + 1))
+    fi
+
+    # A violation in a NESTED manifest, which the name globs never reach but the
+    # scan scope must.
+    write_db "$t" 'trueno = { workspace = true }\n'
+    mkdir -p "$t/crates/aprender-db/wasm-pkg"
+    printf '[package]\nname = "trueno-db-wasm"\nversion = "0.1.0"\n\n[dependencies]\ntrueno = "0.7.1"\n' \
+        > "$t/crates/aprender-db/wasm-pkg/Cargo.toml"
+    if run_tree "$t"; then
+        printf 'MUTATION FAIL: stayed GREEN with a violation in a NESTED manifest\n' >&2
+        fails=$((fails + 1))
+    fi
+    rm -rf "${t:?}/crates/aprender-db/wasm-pkg"
+    if ! run_tree "$t"; then
+        printf 'MUTATION FAIL: did not return GREEN after the mutation was removed\n' >&2
+        fails=$((fails + 1))
+    fi
+
+    # Vacuity: a tree with no in-tree crates must FAIL, not pass empty-handed.
+    v="$(mktemp -d "$TD/vac.XXXXXX")"
+    mkdir -p "$v/scripts/lib"
+    cp "$SELF_PATH" "$v/scripts/check_workspace_siblings_pathed.sh"
+    cp "$NAME_AWK" "$SCAN_AWK" "$v/scripts/lib/"
+    printf '[package]\nname = "x"\nversion = "0.1.0"\n' > "$v/Cargo.toml"
+    if (cd "$v" && bash scripts/check_workspace_siblings_pathed.sh >/dev/null 2>&1); then
+        printf 'VACUITY FAIL: reported clean on a tree with no workspace-local crates\n' >&2
+        fails=$((fails + 1))
+    fi
+
+    if [ "$fails" -ne 0 ]; then
+        printf '\nSELF-TEST FAILED (%s cases wrong)\n' "$fails" >&2
+        exit 1
+    fi
+    printf 'self-test OK: %s cases from %s, plus 6 end-to-end tree probes.\n' \
+        "$ncases" "${CASES#"$REPO_ROOT"/}"
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Normal mode.
+# ---------------------------------------------------------------------------
+printf '=== workspace-local siblings must be pathed, never crates.io (check_workspace_siblings_pathed.sh) ===\n'
+
+NAMEFILE="$(mktemp)"
+FINDINGS="$(mktemp)"
+PROBE_DIR="$(mktemp -d)"
+cleanup() {
+    rm -f "$NAMEFILE" "$FINDINGS"
+    if [ -n "${PROBE_DIR:-}" ] && [ "$PROBE_DIR" != / ] && [ -d "$PROBE_DIR" ]; then
+        rm -rf "${PROBE_DIR:?}"
+    fi
+}
+trap cleanup EXIT
+
+intree_names "$REPO_ROOT" > "$NAMEFILE"
+ncrates="$(grep -c . "$NAMEFILE" || true)"
+
+nmanifests=0
+while IFS= read -r m; do
+    [ -n "$m" ] || continue
+    [ -f "$m" ] || continue
+    nmanifests=$((nmanifests + 1))
+    scan_manifest "$m" "${m#"$REPO_ROOT"/}" "$NAMEFILE" >> "$FINDINGS"
+done < <(list_manifests "$REPO_ROOT")
+
+nfind="$(grep -c . "$FINDINGS" || true)"
+
+# --- vacuity 1 + 2: did the search have any chance at all? -----------------
+if [ "$ncrates" -lt "$MIN_CRATES" ]; then
+    printf 'FAIL (vacuity): enumerated %s workspace-local crate name(s), expected >= %s.\n' \
+        "$ncrates" "$MIN_CRATES" >&2
+    printf '  The name extraction has gone blind. Fix the extraction, not this floor.\n' >&2
+    exit 1
+fi
+if [ "$nmanifests" -lt "$MIN_MANIFESTS" ]; then
+    printf 'FAIL (vacuity): scanned %s manifest(s), expected >= %s.\n' \
+        "$nmanifests" "$MIN_MANIFESTS" >&2
+    printf '  The file discovery has gone blind. Fix the discovery, not this floor.\n' >&2
+    exit 1
+fi
+
+# --- vacuity 3: positive control ------------------------------------------
+# Prove the scanner can still find the thing, before believing it found nothing.
+printf '[dependencies]\ntrueno = "0.16"\n' > "$PROBE_DIR/Cargo.toml"
+probe_out="$(scan_manifest "$PROBE_DIR/Cargo.toml" 'POSITIVE-CONTROL' "$NAMEFILE")"
+if [ -z "$probe_out" ]; then
+    printf 'FAIL (vacuity): the positive control was NOT flagged.\n' >&2
+    printf '  A synthetic `trueno = "0.16"` went unseen, so a clean verdict from this\n' >&2
+    printf '  run would mean nothing. The scanner or the name set is broken.\n' >&2
+    exit 1
+fi
+
+if [ "$nfind" -gt 0 ]; then
+    printf '\n%s workspace-local sibling(s) declared as crates.io dependencies:\n\n' "$nfind" >&2
+    while IFS=$'\t' read -r file lineno name cls text; do
+        [ -n "$file" ] || continue
+        printf '  %s %s:%s\n' "$cls" "$file" "$lineno" >&2
+        printf '           %s\n' "$text" >&2
+        printf '           `%s` is served from this workspace; this pulls a second copy from the registry.\n' "$name" >&2
+    done < "$FINDINGS"
+    printf '\nEach of these compiles a SECOND, type-incompatible copy of a crate the\n' >&2
+    printf 'workspace already builds from source, and reintroduces the published-crate\n' >&2
+    printf 'dependency cycle APR-MONO removed. Consume the path alias instead:\n' >&2
+    printf '  trueno = { workspace = true }     # in a member manifest\n' >&2
+    printf '  trueno = { path = "crates/aprender-compute", version = "...", package = "aprender-compute" }\n' >&2
+    printf 'Confirm with: cargo tree --workspace --duplicates\n' >&2
+    exit 1
+fi
+
+printf 'PASS: %s manifest(s) scanned against %s workspace-local crate name(s); every\n' \
+    "$nmanifests" "$ncrates"
+printf '      declaration of a workspace-local crate resolves to a path or the workspace alias.\n'
+printf '      (positive control flagged, so this absence is a measurement, not a blind spot)\n'
+exit 0

--- a/scripts/lib/workspace_sibling_names.awk
+++ b/scripts/lib/workspace_sibling_names.awk
@@ -1,0 +1,56 @@
+# workspace_sibling_names.awk — emit the names a manifest serves IN-TREE.
+#
+# Driven by scripts/check_workspace_siblings_pathed.sh. Run with -v ROOT=1 for
+# the workspace root manifest, -v ROOT=0 for a member.
+#
+# Three sources, and the second is the load-bearing one:
+#
+#   [package] name   aprender-compute   — what cargo calls the package
+#   [lib] name       trueno             — what `use` sees, and what a crates.io
+#                                         crate would COLLIDE with
+#   root [workspace.dependencies] keys that carry a `path =` — in-tree by
+#                                         construction, whatever they are named
+#
+# Package and lib names diverge throughout this tree (aprender-compute/trueno,
+# aprender-db/trueno_db, aprender-serve/realizar), so a name set built from
+# `[package] name` alone would not contain "trueno" and would sail straight past
+# `trueno = "0.16"` — the exact declaration the guard exists to stop.
+#
+# Every name is emitted in BOTH spellings: Rust lib names use `_`, the crates.io
+# package they shadow publishes with `-` (lib `trueno_db` vs crate `trueno-db`).
+
+function unquote(line,   v) {
+    v = line
+    sub(/^[^=]*=[[:space:]]*/, "", v)
+    sub(/[[:space:]]*#.*$/, "", v)
+    gsub(/^["']|["'][[:space:]]*$/, "", v)
+    return v
+}
+
+function emit(n,   a, b) {
+    if (n == "") return
+    a = n; gsub(/_/, "-", a)
+    b = n; gsub(/-/, "_", b)
+    print a
+    print b
+}
+
+/^[[:space:]]*#/  { next }
+
+/^[[:space:]]*\[/ {
+    sec = $0
+    sub(/[[:space:]]*#.*$/, "", sec)
+    gsub(/[[:space:]]/, "", sec)
+    next
+}
+
+sec == "[package]" && /^[[:space:]]*name[[:space:]]*=/ { emit(unquote($0)); next }
+sec == "[lib]"     && /^[[:space:]]*name[[:space:]]*=/ { emit(unquote($0)); next }
+
+sec == "[workspace.dependencies]" && ROOT == 1 \
+    && /^[[:space:]]*[A-Za-z0-9_-]+[[:space:]]*=/ && /path[[:space:]]*=/ {
+    k = $0
+    sub(/^[[:space:]]*/, "", k)
+    sub(/[[:space:]]*=.*$/, "", k)
+    emit(k)
+}

--- a/scripts/lib/workspace_siblings_cases.txt
+++ b/scripts/lib/workspace_siblings_cases.txt
@@ -1,0 +1,139 @@
+# workspace_siblings_cases.txt — the must-fail / must-pass case table for
+# scripts/check_workspace_siblings_pathed.sh --self-test.
+#
+# Verification Discipline #7: a guard's pattern ships a case table, and the table
+# is RE-RUN rather than re-read. The `apr`-invocation patterns next door were
+# wrong five separate times; every one was caught here, none by review.
+#
+# The table lives in a data file rather than inline heredocs because bashrs parses
+# heredoc bodies as shell, and TOML's `name = "value"` reads to it as a malformed
+# assignment (SC1007). Keeping it out here buys a 0-error lint AND a table you can
+# grep.
+#
+# FORMAT
+#   LINE <fail|pass> <one dependency declaration>     — wrapped in [dependencies]
+#   FRAG <flag|clean> <label>                         — a whole manifest fragment,
+#   …verbatim lines…                                    verbatim, terminated by
+#   END                                                 a lone END
+#   # …                                               — comment (outside a FRAG)
+#
+# The name set the table runs against is: trueno, trueno-db, trueno_db, realizar,
+# aprender-compute, aprender-db — the real divergent package/lib pairs, so the
+# table exercises package name, lib name, and both spellings.
+
+# ---------------------------------------------------------------------------
+# must FAIL — an in-tree sibling pulled from the registry
+# ---------------------------------------------------------------------------
+LINE fail trueno = "0.16"
+LINE fail trueno = { version = "0.16.5", features = ["gpu"] }
+LINE fail trueno = {version="0.16"}
+# lib name `trueno_db` shadows the crates.io package `trueno-db`; a guard built
+# from [package] name alone holds only "aprender-db" and misses this one.
+LINE fail trueno-db = "0.3.2"
+# a trailing comment must not launder the declaration
+LINE fail trueno = "0.7.1"  # Direct dependency for SIMD backend
+LINE fail realizar = { version = "0.63", optional = true }
+# renamed key: the key is innocent, the `package` value is not
+LINE fail compute = { package = "trueno", version = "0.16" }
+# git is not the in-tree copy either
+LINE fail trueno = { git = "https://github.com/paiml/trueno" }
+# dotted-key form
+LINE fail trueno.version = "0.16"
+
+# ---------------------------------------------------------------------------
+# must PASS — a local source, or a genuine third-party crate
+# ---------------------------------------------------------------------------
+LINE pass trueno = { workspace = true }
+LINE pass trueno = { path = "../aprender-compute" }
+# path + version is what `cargo publish` requires; cargo builds from the path
+LINE pass trueno = { path = "crates/aprender-compute", version = "0.63.0", package = "aprender-compute" }
+LINE pass trueno = { path = "..", default-features = false, features = ["simd"] }
+LINE pass trueno.workspace = true
+LINE pass serde = "1"
+LINE pass serde = { version = "1.0", features = ["derive"] }
+LINE pass nalgebra = { version = "0.33", optional = true }
+LINE pass tokio = { workspace = true }
+
+# ---------------------------------------------------------------------------
+# structural cases — whole manifest fragments
+# ---------------------------------------------------------------------------
+
+# A [features] entry is NOT a dependency, however much it looks like one. This
+# exact line is live in crates/aprender-orchestrate/Cargo.toml.
+FRAG clean features-array
+[features]
+trueno-integration = ["trueno", "native"]
+default = ["trueno"]
+END
+
+# …and a real dep in the same file is still caught.
+FRAG flag features-plus-dep
+[features]
+trueno-integration = ["trueno", "native"]
+
+[dependencies]
+trueno = "0.16"
+END
+
+FRAG flag dev-dependencies
+[dev-dependencies]
+realizar = "0.63"
+END
+
+FRAG flag build-dependencies
+[build-dependencies]
+trueno = "0.16"
+END
+
+FRAG flag target-cfg-dep
+[target.'cfg(target_arch = "x86_64")'.dependencies]
+trueno = "0.16"
+END
+
+# The root alias itself can be the defect — provable-contracts was.
+FRAG flag workspace-dependencies
+[workspace.dependencies]
+trueno = "0.16"
+END
+
+FRAG flag subtable-registry
+[dependencies.trueno]
+version = "0.16"
+features = ["gpu"]
+END
+
+FRAG clean subtable-path
+[dependencies.trueno]
+path = ".."
+END
+
+# A sub-table must be decided at the section boundary, not leak into the next
+# section and read [package] version as its own.
+FRAG clean subtable-then-package
+[dependencies.trueno]
+path = ".."
+
+[package]
+name = "x"
+version = "0.16"
+END
+
+# [patch.crates-io] IS the redirection, not a dependency.
+FRAG clean patch-section
+[patch.crates-io]
+trueno = { path = "crates/aprender-compute" }
+END
+
+# `version` under [package] is this crate's own version.
+FRAG clean package-version
+[package]
+name = "trueno"
+version = "0.63.0"
+END
+
+# The comment-stripping direction that matters is the false NEGATIVE: an
+# unstripped comment would make this read as a legal path dep.
+FRAG flag comment-hides-path
+[dependencies]
+trueno = "0.16"  # was path = "../aprender-compute"
+END

--- a/scripts/lib/workspace_siblings_pathed.awk
+++ b/scripts/lib/workspace_siblings_pathed.awk
@@ -1,0 +1,142 @@
+# workspace_siblings_pathed.awk — find in-tree crates declared from crates.io.
+#
+# Driven by scripts/check_workspace_siblings_pathed.sh, which supplies:
+#   -v FILE=<repo-relative path>   for the report
+#   -v NAMEFILE=<file>             one in-tree crate name per line
+#
+# Emits one violation per line: FILE \t line \t crate \t class \t text
+#
+# SECTION-SCOPED ON PURPOSE. `[features]` carries lines indistinguishable from
+# dependency declarations by shape alone —
+#     trueno-integration = ["trueno", "native"]
+# — so a line-oriented grep would have to guess. Tracking the current section
+# means the parser never sees them. `[patch.crates-io]` is out of scope for the
+# same kind of reason: a patch entry IS the redirection.
+
+function strip_comment(s,   out, i, c, inq) {
+    out = ""; inq = 0
+    for (i = 1; i <= length(s); i++) {
+        c = substr(s, i, 1)
+        if (c == "\"") inq = 1 - inq
+        if (c == "#" && inq == 0) break
+        out = out c
+    }
+    return out
+}
+
+function is_dep_sec(s) {
+    if (s ~ /^\[(workspace\.)?(dependencies|dev-dependencies|build-dependencies)\]$/) return 1
+    if (s ~ /^\[target\.[^]]*\.(dependencies|dev-dependencies|build-dependencies)\]$/) return 1
+    return 0
+}
+
+# `[dependencies.foo]` / `[target.<cfg>.dev-dependencies.foo]`.
+# Split at the LAST dot: a crate name never contains one, while a target cfg
+# string can.
+function dep_subtable(s,   i, last, head, tail) {
+    last = 0
+    for (i = length(s); i >= 1; i--) {
+        if (substr(s, i, 1) == ".") { last = i; break }
+    }
+    if (last == 0) return ""
+    head = substr(s, 1, last - 1) "]"
+    tail = substr(s, last + 1)
+    sub(/\]$/, "", tail)
+    if (tail !~ /^[A-Za-z0-9_-]+$/) return ""
+    if (!is_dep_sec(head)) return ""
+    return tail
+}
+
+# Classify a declaration's right-hand side (or a sub-table's accumulated fields).
+# "" == legal.
+#
+# A `version` NEXT TO a `path` is legal and common: cargo builds from the path
+# and uses the version only when publishing. The defect is a version with no
+# local source at all.
+function verdict(val) {
+    if (val ~ /workspace[[:space:]]*=[[:space:]]*true/) return ""
+    if (val ~ /(^|[^A-Za-z0-9_])path[[:space:]]*=/)     return ""
+    if (val ~ /(^|[^A-Za-z0-9_])git[[:space:]]*=/)      return "GIT"
+    if (val ~ /^[[:space:]]*["']/)                      return "REGISTRY"
+    if (val ~ /(^|[^A-Za-z0-9_])version[[:space:]]*=/)  return "REGISTRY"
+    return ""
+}
+
+# `compute = { package = "trueno", version = "0.16" }` renames the key, so the
+# key alone would not match the name set. The `package` value is the real crate.
+function renamed_pkg(val,   v) {
+    if (val !~ /(^|[^A-Za-z0-9_])package[[:space:]]*=/) return ""
+    v = val
+    sub(/^.*[^A-Za-z0-9_]package[[:space:]]*=[[:space:]]*/, "", v)
+    sub(/^[[:space:]]*package[[:space:]]*=[[:space:]]*/, "", v)
+    gsub(/^["']/, "", v)
+    sub(/["'].*$/, "", v)
+    return v
+}
+
+function report(name, lineno, cls, text) {
+    printf "%s\t%s\t%s\t%s\t%s\n", FILE, lineno, name, cls, text
+}
+
+# A `[dependencies.x]` sub-table is only decidable once every field has been
+# read, i.e. at the next section header or at EOF.
+function flush_sub(   cls, pkg) {
+    if (sub_name == "") return
+    cls = verdict(sub_body)
+    pkg = renamed_pkg(sub_body)
+    if (cls != "" && (sub_name in intree || (pkg != "" && pkg in intree)))
+        report(sub_name, sub_line, cls, "[dependencies." sub_name "]" sub_body)
+    sub_name = ""; sub_body = ""; sub_line = 0
+}
+
+BEGIN {
+    while ((getline n < NAMEFILE) > 0) if (n != "") intree[n] = 1
+    close(NAMEFILE)
+    sec = ""; sub_name = ""; sub_body = ""; sub_line = 0; depsec = 0
+}
+
+{ line = strip_comment($0) }
+
+line ~ /^[[:space:]]*$/ { next }
+
+line ~ /^[[:space:]]*\[/ {
+    flush_sub()
+    hdr = line
+    gsub(/[[:space:]]/, "", hdr)
+    sec = hdr
+    depsec = is_dep_sec(hdr)
+    if (!depsec) {
+        s = dep_subtable(hdr)
+        if (s != "") { sub_name = s; sub_body = ""; sub_line = FNR }
+    }
+    next
+}
+
+sub_name != "" { sub_body = sub_body " " line; next }
+
+depsec == 1 {
+    t = line
+    sub(/^[[:space:]]*/, "", t)
+    if (t !~ /^[A-Za-z0-9_.-]+[[:space:]]*=/) next
+
+    key = t
+    sub(/[[:space:]]*=.*$/, "", key)
+    rhs = t
+    sub(/^[A-Za-z0-9_.-]+[[:space:]]*=[[:space:]]*/, "", rhs)
+
+    # Dotted-key form: `serde.workspace = true`, `serde.version = "1"`.
+    if (key ~ /\./) {
+        field = key
+        sub(/^[^.]*\./, "", field)
+        sub(/\..*$/, "", key)
+        rhs = field " = " rhs
+    }
+
+    cls = verdict(rhs)
+    if (cls == "") next
+    pkg = renamed_pkg(rhs)
+    if (key in intree || (pkg != "" && pkg in intree))
+        report(key, FNR, cls, t)
+}
+
+END { flush_sub() }


### PR DESCRIPTION
fix(deps): the monorepo pulled its own siblings from crates.io, and the gate that should have caught it could not fail

CLAUDE.md states the rule: the workspace is a self-contained DAG and every sibling
must be a path alias consumed as `{ workspace = true }`, because "pulling a
crates.io copy reintroduces a duplicate crate + the published-crate dependency
cycle the consolidation removed".

36 declarations violated it. `trueno` — the SIMD/GPU foundation — resolved at
0.16, 0.16.5 AND the in-tree 0.63.0 simultaneously. `jugar-probar` spanned seven
declared versions. All now resolve to the in-tree path.

## The gate that should have caught this exited 0 by construction

`Makefile:485` was:

    @cargo tree --duplicate | grep -v "^$$" || echo "✅ No duplicate dependencies"
    @cargo audit || echo "⚠️  Security issues found"

`||` reads GREP's status, not cargo's. Measured on the unfixed tree: **1,828 lines
of duplicates printed, exit code 0**. The second line swallows `cargo audit`
failures the same way. And nothing in .github/workflows/ or any tier target
invokes `deps-validate` at all, so even a working version was never run.

Third instance of this exact class here (#2336 qwen-story-daily, #2360 make
publish's POST-PUBLISH VERIFICATION). Both lines now redirect to a file and read
the real status; `make deps-validate` returns non-zero on the current tree, where
it returned 0 before.

## The guard, and why it ships in the same commit

`scripts/check_workspace_siblings_pathed.sh` fails any manifest declaring a
workspace-local crate with a registry `version =`. It matches on BOTH `[package]
name` and `[lib] name`, which is not optional here: package `aprender-compute` has
`[lib] name = "trueno"`, so a checker comparing only package names is blind to the
single most important violation.

    PASS: 100 manifest(s) scanned against 272 workspace-local crate name(s)
          (positive control flagged, so this absence is a measurement, not a blind spot)

self-test: 30 cases from a table file, plus 6 end-to-end tree probes.

**Landing order was a real hazard.** The guard is wired into `guard-runner-labels`,
which `gate` hard-requires with an explicit `exit 1`. Merged before the 36 manifest
fixes it would turn main RED and block every PR. Verified they pass together: with
both applied, the guard exits 0.

## Numbers, and why the headline one understates it

`cargo tree --workspace --duplicates`: 57 -> 56 distinct duplicated names.

That is a poor measure of this change and should not be quoted as its value.
`cargo tree --duplicates` is **structurally blind** to the class being fixed: the
in-tree packages were RENAMED during consolidation (aprender-compute, aprender-serve),
so a registry `trueno` and a path `aprender-compute` are different names and no
collision exists for the duplicate detector to see. The verifier proved this —
`cargo tree -p aprender-rag --features transcription` lists crates.io
`aprender v0.27.8` and `trueno v0.17.5`, a stale published copy of this monorepo,
while `--duplicates` on the same invocation reports nothing.

Cargo.lock is the honest measure: 1493 -> 1402 packages, 91 removed, 0 added.

## Not in this commit

- The third-party version unification (57 -> 41) conflicts with this change on
  eight manifests. Hand-merging two sets of manifest edits is how a silent defect
  ships, so it rebases and lands separately.
- `whisper-apr` still transitively re-imports crates.io `aprender 0.27.8`,
  `realizar 0.8.6`, `trueno 0.17.5` via apr-cli's `whisper` feature. Real, and
  invisible to `--duplicates` for the renaming reason above. Its own ticket.
- `crates/aprender-test/Cargo.toml:102` declares `probar = { path = "crates/probar" }`
  pointing at a directory that does not exist. That crate is workspace-EXCLUDED
  and unbuildable already (#2470).

`cargo check --workspace`: clean, 0 errors.

Refs #2463, #2470

