### PR TITLE
fix(gguf): a GGUF without a context-length key refused every prompt

### DIFF
--- a/crates/aprender-serve/src/gguf/config.rs
+++ b/crates/aprender-serve/src/gguf/config.rs
@@ -727,7 +727,14 @@ impl GGUFConfig {
 
         let intermediate_dim = Self::infer_intermediate_dim(model, hidden_dim);
 
-        let context_length = model.context_length().unwrap_or(0);
+        // A GGUF that omits the context-length key used to yield 0 here, and
+        // nothing downstream treats 0 as "unset": every use site is a bound
+        // check of the form `if prompt.len() > config.context_length`, so a 0
+        // refuses EVERY non-empty prompt. Validation could not catch it either
+        // -- validate_metadata_bounds only checked the upper bound. 2048 is the
+        // default the rest of this crate already uses (config_gguf.rs:74/126/151,
+        // runtime.rs:414/442).
+        let context_length = model.context_length().unwrap_or(DEFAULT_CONTEXT_LENGTH);
 
         // C-02 (Meyer DbC): rope_theta from GGUF metadata, or architecture-specific default.
         let rope_theta = model
@@ -829,36 +836,8 @@ impl ValidatedModelConfig {
     ///
     /// Returns `RealizarError::InvalidShape` if any structural invariant is violated.
     pub fn validate(config: GGUFConfig) -> Result<Self> {
-        if config.hidden_dim == 0 {
-            return Err(RealizarError::InvalidShape {
-                reason: "hidden_dim must be > 0".to_string(),
-            });
-        }
-        if config.num_layers == 0 {
-            return Err(RealizarError::InvalidShape {
-                reason: "num_layers must be > 0".to_string(),
-            });
-        }
-        if config.vocab_size == 0 {
-            return Err(RealizarError::InvalidShape {
-                reason: "vocab_size must be > 0".to_string(),
-            });
-        }
-        if config.num_heads == 0 {
-            return Err(RealizarError::InvalidShape {
-                reason: "num_heads must be > 0".to_string(),
-            });
-        }
-        if config.num_kv_heads == 0 {
-            return Err(RealizarError::InvalidShape {
-                reason: "num_kv_heads must be > 0".to_string(),
-            });
-        }
-        if config.intermediate_dim == 0 {
-            return Err(RealizarError::InvalidShape {
-                reason: "intermediate_dim must be > 0".to_string(),
-            });
-        }
+        check_dims_nonzero(&config)?;
+
         // GH-305: When head_dim is explicitly set (from GGUF metadata), hidden_dim may not
         // equal num_heads * head_dim (e.g., Qwen3-0.6B: hidden=1024, heads=16, head_dim=128).
         // Only enforce divisibility when head_dim is NOT explicitly overridden.
@@ -1127,6 +1106,10 @@ impl std::ops::Deref for ValidatedModelConfig {
 ///
 /// Extracted from `ValidatedModelConfig::validate()` for complexity compliance.
 /// Catches corrupted/impossible configs before they cause OOM or panics.
+/// Context length assumed when a GGUF omits the key. Matches the default the
+/// rest of this crate already uses (config_gguf.rs, runtime.rs).
+const DEFAULT_CONTEXT_LENGTH: usize = 2048;
+
 fn validate_metadata_bounds(config: &GGUFConfig) -> Result<()> {
     check_usize_max(config.hidden_dim, 65_536, "hidden_dim")?;
     check_usize_max(config.num_layers, 256, "num_layers")?;
@@ -1135,6 +1118,8 @@ fn validate_metadata_bounds(config: &GGUFConfig) -> Result<()> {
     check_usize_max(config.vocab_size, 1_000_000, "vocab_size")?;
     check_usize_max(config.intermediate_dim, 262_144, "intermediate_dim")?;
     check_usize_max(config.context_length, 2_097_152, "context_length")?;
+
+    check_context_length_usable(config.context_length)?;
 
     // rope_theta: must be >= 1.0 when set (0.0 means "not configured")
     if config.rope_theta > 0.0 && config.rope_theta < 1.0 {
@@ -1178,6 +1163,47 @@ fn check_usize_max(value: usize, max: usize, field: &str) -> Result<()> {
     if value > max {
         return Err(RealizarError::InvalidShape {
             reason: format!("{field} {value} exceeds max {max} (model-metadata-bounds-v1)"),
+        });
+    }
+    Ok(())
+}
+
+/// The six "must be > 0" dimension checks, table-driven.
+///
+/// They were six identical `if x == 0 { return Err(..) }` blocks inline in
+/// `validate`, which is what put that function at cognitive 28 against a
+/// threshold of 25 -- blocking any commit that touched this file, including ones
+/// that changed none of them. Messages are byte-identical to the originals.
+fn check_dims_nonzero(config: &GGUFConfig) -> Result<()> {
+    for (value, name) in [
+        (config.hidden_dim, "hidden_dim"),
+        (config.num_layers, "num_layers"),
+        (config.vocab_size, "vocab_size"),
+        (config.num_heads, "num_heads"),
+        (config.num_kv_heads, "num_kv_heads"),
+        (config.intermediate_dim, "intermediate_dim"),
+    ] {
+        if value == 0 {
+            return Err(RealizarError::InvalidShape {
+                reason: format!("{name} must be > 0"),
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Lower bound on `context_length`, the mirror of the `check_usize_max` above.
+///
+/// Every consumer compares `prompt.len() > config.context_length`, so a zero does
+/// not mean "unbounded" or "unset" -- it refuses every non-empty prompt, at
+/// generate time, with nothing pointing back at the model metadata. Bounding only
+/// the upper side is how a GGUF missing the context-length key reached users.
+fn check_context_length_usable(value: usize) -> Result<()> {
+    if value == 0 {
+        return Err(RealizarError::InvalidShape {
+            reason: "context_length is 0: the model declares no usable context, so \
+                     every prompt would be rejected (model-metadata-bounds-v1)"
+                .to_string(),
         });
     }
     Ok(())

--- a/crates/aprender-serve/src/gguf/config_validated.rs
+++ b/crates/aprender-serve/src/gguf/config_validated.rs
@@ -189,6 +189,22 @@ mod tests {
         assert!(err.to_string().contains("2097152"), "{err}");
     }
 
+    /// The mirror of the too-large case above. `context_length` was bounded on
+    /// one side only, and every consumer compares `prompt.len() > context_length`,
+    /// so a zero refused every non-empty prompt instead of failing at load. A
+    /// GGUF that omits the key produced exactly that.
+    #[test]
+    fn test_validated_config_rejects_context_length_zero() {
+        let mut cfg = valid_llama_config();
+        cfg.context_length = 0;
+        let err = ValidatedModelConfig::validate(cfg).unwrap_err();
+        assert!(err.to_string().contains("context_length"), "{err}");
+        assert!(
+            err.to_string().contains("every prompt would be rejected"),
+            "the error must say what a 0 actually does to the user: {err}"
+        );
+    }
+
     #[test]
     fn test_validated_config_rejects_rope_theta_too_small() {
         let mut cfg = valid_llama_config();

--- a/crates/aprender-serve/tests/api_coverage.rs
+++ b/crates/aprender-serve/tests/api_coverage.rs
@@ -880,12 +880,14 @@ fn test_completion_choice_with_logprobs() {
 #[test]
 fn test_model_metadata_response_full() {
     let response = ModelMetadataResponse {
+        architecture: None,
+        model_max_context_length: None,
         id: "phi-2".to_string(),
         name: "Phi-2".to_string(),
-        format: "gguf".to_string(),
-        size_bytes: 2_700_000_000,
+        format: Some("gguf".to_string()),
+        size_bytes: Some(2_700_000_000),
         quantization: Some("Q4_K_M".to_string()),
-        context_length: 2048,
+        context_length: Some(2048),
         lineage: Some(ModelLineage {
             uri: "pacha://phi-2:latest".to_string(),
             version: "1.0.0".to_string(),
@@ -900,7 +902,7 @@ fn test_model_metadata_response_full() {
     let deserialized: ModelMetadataResponse =
         serde_json::from_str(&json).expect("should deserialize");
 
-    assert_eq!(deserialized.format, "gguf");
+    assert_eq!(deserialized.format.as_deref(), Some("gguf"));
     assert!(deserialized.lineage.is_some());
     let lineage = deserialized.lineage.unwrap();
     assert_eq!(lineage.parent, Some("phi-1.5".to_string()));
@@ -909,12 +911,14 @@ fn test_model_metadata_response_full() {
 #[test]
 fn test_model_metadata_response_minimal() {
     let response = ModelMetadataResponse {
+        architecture: None,
+        model_max_context_length: None,
         id: "simple".to_string(),
         name: "Simple Model".to_string(),
-        format: "apr".to_string(),
-        size_bytes: 100_000,
+        format: Some("apr".to_string()),
+        size_bytes: Some(100_000),
         quantization: None,
-        context_length: 512,
+        context_length: Some(512),
         lineage: None,
         loaded: false,
     };
@@ -2645,12 +2649,14 @@ fn test_reload_request_only_path() {
 #[test]
 fn test_model_metadata_response_no_quantization() {
     let response = ModelMetadataResponse {
+        architecture: None,
+        model_max_context_length: None,
         id: "fp16-model".to_string(),
         name: "Full Precision Model".to_string(),
-        format: "safetensors".to_string(),
-        size_bytes: 10_000_000_000,
+        format: Some("safetensors".to_string()),
+        size_bytes: Some(10_000_000_000),
         quantization: None,
-        context_length: 8192,
+        context_length: Some(8192),
         lineage: None,
         loaded: true,
     };
@@ -3533,12 +3539,14 @@ fn test_prediction_with_score_one() {
 #[test]
 fn test_model_metadata_full_with_all_fields() {
     let response = ModelMetadataResponse {
+        architecture: None,
+        model_max_context_length: None,
         id: "model-v2".to_string(),
         name: "Test Model V2".to_string(),
-        format: "apr".to_string(),
-        size_bytes: 5_000_000_000,
+        format: Some("apr".to_string()),
+        size_bytes: Some(5_000_000_000),
         quantization: Some("Q4_K_M".to_string()),
-        context_length: 32768,
+        context_length: Some(32768),
         lineage: Some(ModelLineage {
             uri: "pacha://test:v2".to_string(),
             version: "2.0.0".to_string(),
@@ -3553,7 +3561,7 @@ fn test_model_metadata_full_with_all_fields() {
     let deserialized: ModelMetadataResponse =
         serde_json::from_str(&json).expect("should deserialize");
 
-    assert_eq!(deserialized.context_length, 32768);
+    assert_eq!(deserialized.context_length, Some(32768));
     assert!(deserialized.lineage.is_some());
     let lineage = deserialized.lineage.unwrap();
     assert_eq!(lineage.recipe, Some("finetune-chat".to_string()));
@@ -4590,12 +4598,14 @@ fn test_completion_response_with_logprobs() {
 fn test_model_metadata_response_variations() {
     // GGUF model with quantization
     let gguf = ModelMetadataResponse {
+        architecture: None,
+        model_max_context_length: None,
         id: "llama-7b-q4".to_string(),
         name: "LLaMA 7B Q4_K_M".to_string(),
-        format: "gguf".to_string(),
-        size_bytes: 4_000_000_000,
+        format: Some("gguf".to_string()),
+        size_bytes: Some(4_000_000_000),
         quantization: Some("Q4_K_M".to_string()),
-        context_length: 4096,
+        context_length: Some(4096),
         lineage: Some(ModelLineage {
             uri: "pacha://llama:7b".to_string(),
             version: "1.0.0".to_string(),
@@ -4611,12 +4621,14 @@ fn test_model_metadata_response_variations() {
 
     // SafeTensors model without quantization
     let safetensors = ModelMetadataResponse {
+        architecture: None,
+        model_max_context_length: None,
         id: "bert-base".to_string(),
         name: "BERT Base".to_string(),
-        format: "safetensors".to_string(),
-        size_bytes: 440_000_000,
+        format: Some("safetensors".to_string()),
+        size_bytes: Some(440_000_000),
         quantization: None,
-        context_length: 512,
+        context_length: Some(512),
         lineage: None,
         loaded: false,
     };

--- a/crates/aprender-serve/tests/api_deep_coverage.rs
+++ b/crates/aprender-serve/tests/api_deep_coverage.rs
@@ -639,12 +639,14 @@ fn test_completion_choice_with_logprobs() {
 #[test]
 fn test_model_metadata_response_without_quantization() {
     let response = ModelMetadataResponse {
+        architecture: None,
+        model_max_context_length: None,
         id: "model-1".to_string(),
         name: "Full precision".to_string(),
-        format: "safetensors".to_string(),
-        size_bytes: 10_000_000_000,
+        format: Some("safetensors".to_string()),
+        size_bytes: Some(10_000_000_000),
         quantization: None,
-        context_length: 8192,
+        context_length: Some(8192),
         lineage: None,
         loaded: true,
     };
@@ -1812,12 +1814,14 @@ fn test_completion_choice_empty_text() {
 #[test]
 fn test_model_metadata_response_large_size() {
     let response = ModelMetadataResponse {
+        architecture: None,
+        model_max_context_length: None,
         id: "llama-70b".to_string(),
         name: "LLaMA 70B".to_string(),
-        format: "gguf".to_string(),
-        size_bytes: 140_000_000_000, // 140 GB
+        format: Some("gguf".to_string()),
+        size_bytes: Some(140_000_000_000), // 140 GB
         quantization: Some("Q4_K_M".to_string()),
-        context_length: 128000,
+        context_length: Some(128000),
         lineage: None,
         loaded: false,
     };

--- a/crates/aprender-serve/tests/convert_coverage.rs
+++ b/crates/aprender-serve/tests/convert_coverage.rs
@@ -25,6 +25,7 @@ fn create_minimal_gguf_transformer(
     intermediate_dim: usize,
 ) -> GGUFTransformer {
     let config = GGUFConfig {
+        query_pre_attn_scalar: None,
         architecture: "test_arch".to_string(),
         constraints: ArchConstraints::from_architecture("llama"),
         hidden_dim,
@@ -858,6 +859,7 @@ fn test_conversion_with_bias_weights() {
 fn test_gguf_transformer_with_gate_weights() {
     // Create GGUF transformer with FFN gate weights (SwiGLU style)
     let config = GGUFConfig {
+        query_pre_attn_scalar: None,
         architecture: "swiglu_test".to_string(),
         constraints: ArchConstraints::from_architecture("llama"),
         hidden_dim: 8,
@@ -1495,6 +1497,7 @@ fn test_to_apr_bytes_many_layers() {
 #[test]
 fn test_from_gguf_transformer_with_all_biases() {
     let config = GGUFConfig {
+        query_pre_attn_scalar: None,
         architecture: "biased".to_string(),
         constraints: ArchConstraints::from_architecture("llama"),
         hidden_dim: 8,
@@ -1559,6 +1562,7 @@ fn test_from_gguf_transformer_with_all_biases() {
 #[test]
 fn test_from_gguf_transformer_with_ffn_norm() {
     let config = GGUFConfig {
+        query_pre_attn_scalar: None,
         architecture: "normed_ffn".to_string(),
         constraints: ArchConstraints::from_architecture("llama"),
         hidden_dim: 8,
@@ -1621,6 +1625,7 @@ fn test_from_gguf_transformer_preserves_intermediate_dim() {
 #[test]
 fn test_from_gguf_transformer_different_kv_heads() {
     let config = GGUFConfig {
+        query_pre_attn_scalar: None,
         architecture: "gqa".to_string(),
         constraints: ArchConstraints::from_architecture("llama"),
         hidden_dim: 32,
@@ -2191,6 +2196,7 @@ fn test_apr_bytes_reserved_bytes() {
 #[test]
 fn test_gguf_transformer_with_output_norm_bias() {
     let config = GGUFConfig {
+        query_pre_attn_scalar: None,
         architecture: "with_bias".to_string(),
         constraints: ArchConstraints::from_architecture("llama"),
         hidden_dim: 8,
@@ -2246,6 +2252,7 @@ fn test_gguf_transformer_with_output_norm_bias() {
 #[test]
 fn test_gguf_transformer_with_lm_head_bias() {
     let config = GGUFConfig {
+        query_pre_attn_scalar: None,
         architecture: "lm_bias".to_string(),
         constraints: ArchConstraints::from_architecture("llama"),
         hidden_dim: 8,
@@ -2305,6 +2312,7 @@ fn test_gguf_transformer_with_lm_head_bias() {
 #[test]
 fn test_layer_attn_norm_bias_preservation() {
     let config = GGUFConfig {
+        query_pre_attn_scalar: None,
         architecture: "attn_norm_bias".to_string(),
         constraints: ArchConstraints::from_architecture("llama"),
         hidden_dim: 8,
@@ -2359,6 +2367,7 @@ fn test_layer_attn_norm_bias_preservation() {
 #[test]
 fn test_layer_qkv_bias_preservation() {
     let config = GGUFConfig {
+        query_pre_attn_scalar: None,
         architecture: "qkv_bias".to_string(),
         constraints: ArchConstraints::from_architecture("llama"),
         hidden_dim: 8,
@@ -2413,6 +2422,7 @@ fn test_layer_qkv_bias_preservation() {
 #[test]
 fn test_layer_attn_output_bias_preservation() {
     let config = GGUFConfig {
+        query_pre_attn_scalar: None,
         architecture: "attn_out_bias".to_string(),
         constraints: ArchConstraints::from_architecture("llama"),
         hidden_dim: 8,
@@ -2467,6 +2477,7 @@ fn test_layer_attn_output_bias_preservation() {
 #[test]
 fn test_layer_ffn_up_bias_preservation() {
     let config = GGUFConfig {
+        query_pre_attn_scalar: None,
         architecture: "ffn_up_bias".to_string(),
         constraints: ArchConstraints::from_architecture("llama"),
         hidden_dim: 8,
@@ -2521,6 +2532,7 @@ fn test_layer_ffn_up_bias_preservation() {
 #[test]
 fn test_layer_ffn_down_bias_preservation() {
     let config = GGUFConfig {
+        query_pre_attn_scalar: None,
         architecture: "ffn_down_bias".to_string(),
         constraints: ArchConstraints::from_architecture("llama"),
         hidden_dim: 8,

--- a/crates/aprender-serve/tests/driver_cpu.rs
+++ b/crates/aprender-serve/tests/driver_cpu.rs
@@ -73,6 +73,8 @@ fn create_llama_style_test_model(config: &GGUFConfig) -> OwnedQuantizedModel {
     let mut layers = Vec::with_capacity(config.num_layers);
     for _ in 0..config.num_layers {
         layers.push(OwnedQuantizedLayer {
+            post_attn_norm_weight: None,
+            post_ffw_norm_weight: None,
             attn_norm_weight: attn_norm_weight.clone(),
             attn_norm_bias: None, // RMSNorm has no bias
             qkv_weight: OwnedQKVWeights::Fused(qkv_weight.clone()),
@@ -130,6 +132,8 @@ fn create_phi2_style_test_model(config: &GGUFConfig) -> OwnedQuantizedModel {
     let mut layers = Vec::with_capacity(config.num_layers);
     for _ in 0..config.num_layers {
         layers.push(OwnedQuantizedLayer {
+            post_attn_norm_weight: None,
+            post_ffw_norm_weight: None,
             attn_norm_weight: attn_norm_weight.clone(),
             attn_norm_bias: Some(attn_norm_bias.clone()), // LayerNorm has bias
             qkv_weight: OwnedQKVWeights::Fused(qkv_weight.clone()),
@@ -173,6 +177,7 @@ fn create_phi2_style_test_model(config: &GGUFConfig) -> OwnedQuantizedModel {
 fn test_driver_cpu_forward_llama_single_token() {
     // Illuminates: forward/core.rs:forward(), RMSNorm path, SwiGLU path
     let config = GGUFConfig {
+        query_pre_attn_scalar: None,
         architecture: "llama".to_string(),
         hidden_dim: 64,
         intermediate_dim: 128,
@@ -212,6 +217,7 @@ fn test_driver_cpu_forward_llama_single_token() {
 fn test_driver_cpu_forward_llama_multi_token() {
     // Illuminates: forward/core.rs multi-position attention loop
     let config = GGUFConfig {
+        query_pre_attn_scalar: None,
         architecture: "llama".to_string(),
         hidden_dim: 64,
         intermediate_dim: 128,
@@ -245,6 +251,7 @@ fn test_driver_cpu_forward_llama_multi_token() {
 fn test_driver_cpu_forward_phi2_single_token() {
     // Illuminates: forward/core.rs LayerNorm path, GELU path
     let config = GGUFConfig {
+        query_pre_attn_scalar: None,
         architecture: "phi".to_string(),
         hidden_dim: 64,
         intermediate_dim: 128,
@@ -280,6 +287,7 @@ fn test_driver_cpu_forward_gqa_attention() {
     // num_kv_heads < num_heads triggers GQA
     // Note: GQA has known bugs with small dimensions - using catch_unwind for coverage
     let config = GGUFConfig {
+        query_pre_attn_scalar: None,
         architecture: "llama".to_string(),
         hidden_dim: 64,
         intermediate_dim: 128,
@@ -317,6 +325,7 @@ fn test_driver_cpu_forward_gqa_attention() {
 fn test_driver_cpu_forward_cached_single() {
     // Illuminates: forward_cached() - KV cache code path
     let config = GGUFConfig {
+        query_pre_attn_scalar: None,
         architecture: "llama".to_string(),
         hidden_dim: 64,
         intermediate_dim: 128,
@@ -348,6 +357,7 @@ fn test_driver_cpu_forward_cached_single() {
 fn test_driver_cpu_forward_cached_sequence() {
     // Illuminates: forward_cached() with accumulated KV cache
     let config = GGUFConfig {
+        query_pre_attn_scalar: None,
         architecture: "llama".to_string(),
         hidden_dim: 64,
         intermediate_dim: 128,
@@ -393,6 +403,7 @@ fn test_driver_cpu_forward_cached_gqa() {
     // Illuminates: attention_with_cache_gqa code path
     // Note: GQA has known bugs with small dimensions - using catch_unwind for coverage
     let config = GGUFConfig {
+        query_pre_attn_scalar: None,
         architecture: "llama".to_string(),
         hidden_dim: 64,
         intermediate_dim: 128,
@@ -510,6 +521,7 @@ fn test_driver_loader_metadata_u32() {
 fn test_driver_cpu_forward_max_context() {
     // Test near context length boundary
     let config = GGUFConfig {
+        query_pre_attn_scalar: None,
         architecture: "llama".to_string(),
         hidden_dim: 32, // Small for speed
         intermediate_dim: 64,
@@ -542,6 +554,7 @@ fn test_driver_cpu_forward_max_context() {
 fn test_driver_cpu_forward_cached_long_generation() {
     // Simulate longer generation to exercise cache
     let config = GGUFConfig {
+        query_pre_attn_scalar: None,
         architecture: "llama".to_string(),
         hidden_dim: 32,
         intermediate_dim: 64,
@@ -573,6 +586,7 @@ fn test_driver_cpu_forward_cached_long_generation() {
 fn test_driver_cpu_neox_rope() {
     // Test NEOX-style RoPE (type 2)
     let config = GGUFConfig {
+        query_pre_attn_scalar: None,
         architecture: "llama".to_string(),
         hidden_dim: 64,
         intermediate_dim: 128,

--- a/crates/aprender-serve/tests/ffn_coverage.rs
+++ b/crates/aprender-serve/tests/ffn_coverage.rs
@@ -56,6 +56,7 @@ fn create_test_tensor(in_dim: usize, out_dim: usize) -> OwnedQuantizedTensor {
 /// Create test config
 fn test_config() -> GGUFConfig {
     GGUFConfig {
+        query_pre_attn_scalar: None,
         architecture: "test".to_string(),
         constraints: ArchConstraints::from_architecture("llama"),
         hidden_dim: 64,
@@ -82,6 +83,8 @@ fn create_gelu_layer(config: &GGUFConfig) -> OwnedQuantizedLayer {
     let qkv_out_dim = hidden_dim + 2 * kv_dim;
 
     OwnedQuantizedLayer {
+        post_attn_norm_weight: None,
+        post_ffw_norm_weight: None,
         attn_norm_weight: vec![1.0f32; hidden_dim],
         attn_norm_bias: None,
         qkv_weight: OwnedQKVWeights::Fused(create_test_tensor(hidden_dim, qkv_out_dim)),
@@ -109,6 +112,8 @@ fn create_fused_swiglu_layer(config: &GGUFConfig) -> OwnedQuantizedLayer {
     let qkv_out_dim = hidden_dim + 2 * kv_dim;
 
     OwnedQuantizedLayer {
+        post_attn_norm_weight: None,
+        post_ffw_norm_weight: None,
         attn_norm_weight: vec![1.0f32; hidden_dim], // RMSNorm: no bias
         attn_norm_bias: None,
         qkv_weight: OwnedQKVWeights::Fused(create_test_tensor(hidden_dim, qkv_out_dim)),
@@ -136,6 +141,8 @@ fn create_nonfused_swiglu_layer(config: &GGUFConfig) -> OwnedQuantizedLayer {
     let qkv_out_dim = hidden_dim + 2 * kv_dim;
 
     OwnedQuantizedLayer {
+        post_attn_norm_weight: None,
+        post_ffw_norm_weight: None,
         attn_norm_weight: vec![1.0f32; hidden_dim],
         attn_norm_bias: None,
         qkv_weight: OwnedQKVWeights::Fused(create_test_tensor(hidden_dim, qkv_out_dim)),
@@ -163,6 +170,8 @@ fn create_layernorm_swiglu_layer(config: &GGUFConfig) -> OwnedQuantizedLayer {
     let qkv_out_dim = hidden_dim + 2 * kv_dim;
 
     OwnedQuantizedLayer {
+        post_attn_norm_weight: None,
+        post_ffw_norm_weight: None,
         attn_norm_weight: vec![1.0f32; hidden_dim],
         attn_norm_bias: Some(vec![0.0f32; hidden_dim]), // Bias = LayerNorm
         qkv_weight: OwnedQKVWeights::Fused(create_test_tensor(hidden_dim, qkv_out_dim)),

--- a/crates/aprender-serve/tests/gguf_config_coverage.rs
+++ b/crates/aprender-serve/tests/gguf_config_coverage.rs
@@ -276,6 +276,7 @@ fn test_cov_gguf_config_missing_embedding_length() {
 #[test]
 fn test_cov_scratch_buffer_from_config() {
     let config = GGUFConfig {
+        query_pre_attn_scalar: None,
         architecture: "llama".to_string(),
         constraints: ArchConstraints::from_architecture("llama"),
         hidden_dim: 2048,
@@ -312,6 +313,7 @@ fn test_cov_scratch_buffer_from_config() {
 #[test]
 fn test_cov_scratch_buffer_q8k_buffers() {
     let config = GGUFConfig {
+        query_pre_attn_scalar: None,
         architecture: "llama".to_string(),
         constraints: ArchConstraints::from_architecture("llama"),
         hidden_dim: 2048,
@@ -344,6 +346,7 @@ fn test_cov_scratch_buffer_q8k_buffers() {
 #[test]
 fn test_cov_scratch_buffer_reset() {
     let config = GGUFConfig {
+        query_pre_attn_scalar: None,
         architecture: "test".to_string(),
         constraints: ArchConstraints::from_architecture("llama"),
         hidden_dim: 128,
@@ -381,6 +384,7 @@ fn test_cov_scratch_buffer_reset() {
 #[test]
 fn test_cov_scratch_buffer_small_model() {
     let config = GGUFConfig {
+        query_pre_attn_scalar: None,
         architecture: "tiny".to_string(),
         constraints: ArchConstraints::from_architecture("llama"),
         hidden_dim: 64,
@@ -410,6 +414,7 @@ fn test_cov_scratch_buffer_small_model() {
 #[test]
 fn test_cov_owned_scratch_buffer_from_config() {
     let config = GGUFConfig {
+        query_pre_attn_scalar: None,
         architecture: "llama".to_string(),
         constraints: ArchConstraints::from_architecture("llama"),
         hidden_dim: 2048,
@@ -440,6 +445,7 @@ fn test_cov_owned_scratch_buffer_from_config() {
 #[test]
 fn test_cov_owned_scratch_buffer_qkv_size() {
     let config = GGUFConfig {
+        query_pre_attn_scalar: None,
         architecture: "llama".to_string(),
         constraints: ArchConstraints::from_architecture("llama"),
         hidden_dim: 2048,
@@ -468,6 +474,7 @@ fn test_cov_owned_scratch_buffer_qkv_size() {
 #[test]
 fn test_cov_owned_scratch_buffer_reset() {
     let config = GGUFConfig {
+        query_pre_attn_scalar: None,
         architecture: "test".to_string(),
         constraints: ArchConstraints::from_architecture("llama"),
         hidden_dim: 128,
@@ -502,6 +509,7 @@ fn test_cov_owned_scratch_buffer_reset() {
 #[test]
 fn test_cov_owned_scratch_buffer_q8k_buffers() {
     let config = GGUFConfig {
+        query_pre_attn_scalar: None,
         architecture: "llama".to_string(),
         constraints: ArchConstraints::from_architecture("llama"),
         hidden_dim: 2048,

--- a/crates/aprender-serve/tests/gguf_coverage.rs
+++ b/crates/aprender-serve/tests/gguf_coverage.rs
@@ -208,6 +208,7 @@ fn create_test_config() -> GGUFConfig {
         bos_token_id: None,
         eos_token_id: None,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
     }
 }
 
@@ -243,6 +244,8 @@ fn create_test_layer(config: &GGUFConfig) -> OwnedQuantizedLayer {
         ffn_norm_bias: None,
         attn_q_norm_weight: None,
         attn_k_norm_weight: None,
+        post_attn_norm_weight: None,
+        post_ffw_norm_weight: None,
     }
 }
 
@@ -268,7 +271,11 @@ fn test_cov_header_invalid_magic() {
 fn test_cov_header_unsupported_version() {
     let mut data = Vec::new();
     data.extend_from_slice(&GGUF_MAGIC.to_le_bytes());
-    data.extend_from_slice(&2u32.to_le_bytes()); // Version 2 not supported
+    // Was `2`, asserted to be unsupported. GGUF v2 and v3 are both real and both
+    // load, so this test asserted the opposite of the truth from the day the
+    // support landed -- and never once ran to say so. Use a version that genuinely
+    // does not exist, which is what the test name means.
+    data.extend_from_slice(&99u32.to_le_bytes());
     data.extend_from_slice(&0u64.to_le_bytes());
     data.extend_from_slice(&0u64.to_le_bytes());
 
@@ -1051,6 +1058,8 @@ fn test_cov_owned_layer_with_biases() {
         ffn_norm_bias: None,
         attn_q_norm_weight: None,
         attn_k_norm_weight: None,
+        post_attn_norm_weight: None,
+        post_ffw_norm_weight: None,
     };
 
     assert!(layer.attn_norm_bias.is_some());
@@ -1516,6 +1525,7 @@ fn create_inference_test_model() -> OwnedQuantizedModel {
         bos_token_id: None,
         eos_token_id: None,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
     };
 
     // Q4_0 block size: 18 bytes for 32 elements
@@ -1562,6 +1572,8 @@ fn create_inference_test_model() -> OwnedQuantizedModel {
             ffn_norm_bias: None,
             attn_q_norm_weight: None,
             attn_k_norm_weight: None,
+            post_attn_norm_weight: None,
+            post_ffw_norm_weight: None,
         });
     }
 
@@ -1611,11 +1623,15 @@ fn test_cov_model_forward_multiple_tokens() {
 }
 
 #[test]
-#[should_panic(expected = "subtract with overflow")]
+#[should_panic(expected = "precondition violated")]
 fn test_cov_model_forward_empty_tokens() {
     let model = create_inference_test_model();
 
-    // Forward pass with empty token list panics due to seq_len - 1 underflow
+    // This used to expect the panic message "subtract with overflow" -- a
+    // `seq_len - 1` underflow. The operation is now guarded by an explicit
+    // rmsnorm precondition, so the message changed and this test failed the
+    // first time it was ever compiled. The guarantee worth pinning is that an
+    // empty token list is REFUSED, not which arithmetic accident refuses it.
     let token_ids: [u32; 0] = [];
     let _ = model.forward(&token_ids);
 }
@@ -1792,6 +1808,8 @@ fn test_cov_ffn_without_gate() {
         ffn_norm_bias: None,
         attn_q_norm_weight: None,
         attn_k_norm_weight: None,
+        post_attn_norm_weight: None,
+        post_ffw_norm_weight: None,
     };
 
     assert!(layer.ffn_gate_weight.is_none());
@@ -1984,6 +2002,7 @@ fn test_cov_config_with_gqa() {
         bos_token_id: None,
         eos_token_id: None,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
     };
 
     assert_eq!(config.num_heads / config.num_kv_heads, 4);
@@ -2008,6 +2027,7 @@ fn test_cov_config_with_mqa() {
         bos_token_id: None,
         eos_token_id: None,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
     };
 
     assert_eq!(config.num_kv_heads, 1);
@@ -2039,6 +2059,7 @@ fn test_cov_config_large_context() {
         bos_token_id: None,
         eos_token_id: None,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
     };
 
     assert_eq!(config.context_length, 131072);
@@ -2163,6 +2184,8 @@ fn test_cov_layer_with_all_biases() {
         ffn_norm_bias: Some(vec![0.0; hidden]),
         attn_q_norm_weight: None,
         attn_k_norm_weight: None,
+        post_attn_norm_weight: None,
+        post_ffw_norm_weight: None,
     };
 
     assert!(layer.attn_norm_bias.is_some());
@@ -2197,6 +2220,8 @@ fn test_cov_layer_minimal_no_biases() {
         ffn_norm_bias: None,
         attn_q_norm_weight: None,
         attn_k_norm_weight: None,
+        post_attn_norm_weight: None,
+        post_ffw_norm_weight: None,
     };
 
     assert!(layer.attn_norm_bias.is_none());
@@ -2252,6 +2277,8 @@ fn test_cov_layer_separate_qkv() {
         ffn_norm_bias: None,
         attn_q_norm_weight: None,
         attn_k_norm_weight: None,
+        post_attn_norm_weight: None,
+        post_ffw_norm_weight: None,
     };
 
     match layer.qkv_weight {
@@ -2388,6 +2415,7 @@ fn test_cov_config_head_dim_calculation() {
         bos_token_id: None,
         eos_token_id: None,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
     };
 
     let head_dim = config.hidden_dim / config.num_heads;
@@ -2416,6 +2444,7 @@ fn test_cov_config_intermediate_ratio() {
         bos_token_id: None,
         eos_token_id: None,
         explicit_head_dim: None,
+        query_pre_attn_scalar: None,
     };
 
     let ratio = config.intermediate_dim as f32 / config.hidden_dim as f32;

--- a/crates/aprender-serve/tests/gguf_extended_coverage.rs
+++ b/crates/aprender-serve/tests/gguf_extended_coverage.rs
@@ -439,6 +439,7 @@ fn test_tensor_info_empty_dims() {
 #[test]
 fn test_gguf_config_llama() {
     let config = GGUFConfig {
+        query_pre_attn_scalar: None,
         architecture: "llama".to_string(),
         constraints: ArchConstraints::from_architecture("llama"),
         hidden_dim: 4096,
@@ -463,6 +464,7 @@ fn test_gguf_config_llama() {
 #[test]
 fn test_gguf_config_llama2() {
     let config = GGUFConfig {
+        query_pre_attn_scalar: None,
         architecture: "llama".to_string(),
         constraints: ArchConstraints::from_architecture("llama"),
         hidden_dim: 4096,
@@ -485,6 +487,7 @@ fn test_gguf_config_llama2() {
 #[test]
 fn test_gguf_config_phi() {
     let config = GGUFConfig {
+        query_pre_attn_scalar: None,
         architecture: "phi".to_string(),
         constraints: ArchConstraints::from_architecture("llama"),
         hidden_dim: 2560,
@@ -507,6 +510,7 @@ fn test_gguf_config_phi() {
 #[test]
 fn test_gguf_config_mistral() {
     let config = GGUFConfig {
+        query_pre_attn_scalar: None,
         architecture: "mistral".to_string(),
         constraints: ArchConstraints::from_architecture("llama"),
         hidden_dim: 4096,
@@ -530,6 +534,7 @@ fn test_gguf_config_mistral() {
 #[test]
 fn test_gguf_config_head_dim_calculation() {
     let config = GGUFConfig {
+        query_pre_attn_scalar: None,
         architecture: "test".to_string(),
         constraints: ArchConstraints::from_architecture("llama"),
         hidden_dim: 512,
@@ -552,6 +557,7 @@ fn test_gguf_config_head_dim_calculation() {
 #[test]
 fn test_gguf_config_gqa_ratio() {
     let config = GGUFConfig {
+        query_pre_attn_scalar: None,
         architecture: "test".to_string(),
         constraints: ArchConstraints::from_architecture("llama"),
         hidden_dim: 1024,
@@ -575,6 +581,7 @@ fn test_gguf_config_gqa_ratio() {
 #[test]
 fn test_gguf_config_clone() {
     let config = GGUFConfig {
+        query_pre_attn_scalar: None,
         architecture: "cloneable".to_string(),
         constraints: ArchConstraints::from_architecture("llama"),
         hidden_dim: 256,
@@ -599,6 +606,7 @@ fn test_gguf_config_clone() {
 #[test]
 fn test_gguf_config_debug() {
     let config = GGUFConfig {
+        query_pre_attn_scalar: None,
         architecture: "debug".to_string(),
         constraints: ArchConstraints::from_architecture("llama"),
         hidden_dim: 128,
@@ -622,6 +630,7 @@ fn test_gguf_config_debug() {
 #[test]
 fn test_gguf_config_rope_theta_values() {
     let config_10k = GGUFConfig {
+        query_pre_attn_scalar: None,
         architecture: "test".to_string(),
         constraints: ArchConstraints::from_architecture("llama"),
         hidden_dim: 256,
@@ -641,6 +650,7 @@ fn test_gguf_config_rope_theta_values() {
     assert_eq!(config_10k.rope_theta, 10000.0);
 
     let config_1m = GGUFConfig {
+        query_pre_attn_scalar: None,
         architecture: "test".to_string(),
         constraints: ArchConstraints::from_architecture("llama"),
         hidden_dim: 256,
@@ -666,6 +676,7 @@ fn test_gguf_config_rope_theta_values() {
 
 fn make_test_config(hidden_dim: usize, num_heads: usize) -> GGUFConfig {
     GGUFConfig {
+        query_pre_attn_scalar: None,
         architecture: "test".to_string(),
         constraints: ArchConstraints::from_architecture("llama"),
         hidden_dim,
@@ -832,6 +843,7 @@ fn test_tensor_info_long_name() {
 #[test]
 fn test_gguf_config_very_small_model() {
     let config = GGUFConfig {
+        query_pre_attn_scalar: None,
         architecture: "tiny".to_string(),
         constraints: ArchConstraints::from_architecture("llama"),
         hidden_dim: 16,
@@ -854,6 +866,7 @@ fn test_gguf_config_very_small_model() {
 #[test]
 fn test_gguf_config_very_large_model() {
     let config = GGUFConfig {
+        query_pre_attn_scalar: None,
         architecture: "huge".to_string(),
         constraints: ArchConstraints::from_architecture("llama"),
         hidden_dim: 16384,
@@ -913,6 +926,7 @@ fn test_gguf_config_different_eps_values() {
     let eps_values = [1e-3, 1e-4, 1e-5, 1e-6, 1e-7];
     for eps in eps_values {
         let config = GGUFConfig {
+            query_pre_attn_scalar: None,
             architecture: "test".to_string(),
             constraints: ArchConstraints::from_architecture("llama"),
             hidden_dim: 256,

--- a/crates/aprender-serve/tests/gguf_kv_cache_coverage.rs
+++ b/crates/aprender-serve/tests/gguf_kv_cache_coverage.rs
@@ -16,6 +16,7 @@ use realizar::gguf::{ArchConstraints, ContiguousKVCache, GGUFConfig, OwnedQuanti
 /// Helper function to create a test GGUFConfig with specified layers and hidden_dim
 fn make_test_config(num_layers: usize, hidden_dim: usize) -> GGUFConfig {
     GGUFConfig {
+        query_pre_attn_scalar: None,
         architecture: "test".to_string(),
         constraints: ArchConstraints::from_architecture("llama"),
         hidden_dim,

--- a/crates/aprender-serve/tests/validated_config_contract_falsify.rs
+++ b/crates/aprender-serve/tests/validated_config_contract_falsify.rs
@@ -12,6 +12,7 @@ use realizar::gguf::{ArchConstraints, GGUFConfig, ValidatedModelConfig};
 /// Construct a known-valid base config (LLaMA-7B-like).
 fn valid_base_config() -> GGUFConfig {
     GGUFConfig {
+        query_pre_attn_scalar: None,
         architecture: "llama".to_string(),
         constraints: ArchConstraints::from_architecture("llama"),
         hidden_dim: 4096,
@@ -178,6 +179,7 @@ proptest! {
         prop_assume!(intermediate_dim <= 262_144);
 
         let cfg = GGUFConfig {
+    query_pre_attn_scalar: None,
             architecture: "llama".to_string(),
             constraints: ArchConstraints::from_architecture("llama"),
             hidden_dim,


### PR DESCRIPTION
`gguf_coverage.rs` -- 144 tests -- has not compiled since Gemma-era fields were
added to `GGUFConfig` and `OwnedQuantizedLayer`. Nobody noticed because
workspace-test runs `--lib`, so the target is never compiled either. 14 struct
initializers were missing `query_pre_attn_scalar`, `post_attn_norm_weight` and
`post_ffw_norm_weight`; all three are Option and `None` is what the rest of the
crate already passes.

Making it compile and run surfaced a real defect on the first execution.

    let context_length = model.context_length().unwrap_or(0);

Nothing downstream treats 0 as "unset". Every consumer is a bound check of the
form `if prompt.len() > self.config.context_length` (generate_scratch.rs:36,
hidden_states.rs:39, cuda/generate_1.rs:51), so a model whose GGUF omits the
context-length key refuses EVERY non-empty prompt, at generate time, with nothing
pointing back at the metadata.

`validate_metadata_bounds` could not catch it: it bounded `context_length` from
ABOVE only. Bounding one side of a range is the same shape as an assertion that
excludes no outcome.

Fixes:
  * default to 2048 when the key is absent, matching what the rest of this crate
    already uses (config_gguf.rs:74/126/151, runtime.rs:414/442)
  * `check_context_length_usable`, the mirror of `check_usize_max`, with a message
    that says what a zero does to the user rather than restating the number

The other two failures were stale, and both asserted the opposite of the truth
from the day the behaviour changed -- never once running to say so:
  * test_cov_header_unsupported_version asserted GGUF v2 is REJECTED. v2 and v3
    are both real and both load. Now uses version 99, which is what the test name
    means.
  * test_cov_model_forward_empty_tokens pinned the panic "subtract with overflow",
    a `seq_len - 1` underflow that is now a guarded rmsnorm precondition. Pins the
    guarantee (empty input is refused) rather than the arithmetic accident.

Also unblocks this file. `validate` sat at cognitive 28 against a threshold of 25,
so the pre-commit gate rejected ANY commit touching config.rs -- verified
identical with and without this change. Its first six checks were the same
`if x == 0 { return Err(..) }` block six times; they are now table-driven in
`check_dims_nonzero` with byte-identical messages. validate: 28 -> 10 cognitive,
file 81 -> 69.

Mutation-verified, each RED then restored GREEN:
  * default back to 0        -> test_cov_config_defaults
  * lower bound disarmed     -> test_validated_config_rejects_context_length_zero
  * check_dims_nonzero disarmed -> 3 config tests

Two mutation attempts proved nothing and were re-run: deleting the validation
block broke the build so no test ran, and `cargo build --tests --workspace
--keep-going` exits 0 on this tree while `cargo test --workspace --no-run` does
not -- the inventory command in our own notes is blind to this class.

gguf_coverage: 144 passed (from "does not compile").
aprender-serve --lib: 15655 passed, 0 failed.

Refs #2474

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>