### PR TITLE
fix(readme): three different contract counts, and the guard that watches them ran nowhere

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -503,6 +503,17 @@ jobs:
         run: bash scripts/check_assertions_exclude.sh
       - name: Assertion-exclusion guard case table
         run: bash scripts/check_assertions_exclude.sh --self-test
+
+      # FALSIFY-README-00*: README metric claims must match measurement. The
+      # guard existed and ran nowhere -- its only caller was scripts/dogfood-book.sh,
+      # which is itself in no workflow and no Makefile target, so it was
+      # unreachable. It was also pattern-narrow: it matched `**M** provable
+      # contracts` and took `head -1`, while the README carried THREE different
+      # contract counts (1771 in the table, 1158 at line 225, 1767 at line 256).
+      # It now checks every contract-count claim, so the README cannot contradict
+      # itself either. Text-only, no build.
+      - name: README claims must match measurement
+        run: bash scripts/check_readme_claims.sh
       # Poka-yoke: APR-MONO made every sibling a path alias under crates/, but
       # `trueno = "0.16"` still BUILDS - cargo resolves the crates.io copy
       # alongside the in-tree one, so the tree compiles two mutually

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ paiml/aprender/
 │   ├── aprender-profile/           # Profiling
 │   ├── aprender-db/ aprender-graph/ aprender-rag/
 │   └── ... (82 crates total)
-├── contracts/                      # 1158 provable YAML contracts
+├── contracts/                      # 1771 provable YAML contracts
 └── book/                           # mdBook documentation
 ```
 
@@ -253,7 +253,7 @@ falsification_tests:
   prediction: apr validate bad-model.apr exits non-zero
 ```
 
-1767 contracts across inference, training, quantization, attention, FFN,
+1771 contracts across inference, training, quantization, attention, FFN,
 tokenization, model formats, CLI safety — and this README itself.
 
 ## Migration from old crates

--- a/scripts/check_readme_claims.sh
+++ b/scripts/check_readme_claims.sh
@@ -84,11 +84,21 @@ claimed_crate_count() {
   grep -oE "$crate_re" "$README" | grep -oE "$num_re" | head -1
 }
 
-claimed_contract_count() {
-  # Look for pattern "**M** provable contracts"
-  local contract_re='\*\*[0-9]+\*\* provable contracts'
-  local num_re='[0-9]+'
-  grep -oE "$contract_re" "$README" | grep -oE "$num_re" | head -1
+# EVERY contract count the README claims, one per line, deduplicated.
+#
+# This used to match only `**M** provable contracts` -- the bold table form --
+# and then `head -1`. The README carried THREE different counts and the guard
+# saw one of them: 1771 in the table (correct), 1158 at line 225 ("# 1158
+# provable YAML contracts", wrong by 613) and 1767 at line 256 ("1767 contracts
+# across inference, training..."). A drift detector that reads one of three
+# claims reports claim discipline it is not providing.
+#
+# Now: any number immediately preceding "contract(s)", optionally through one
+# qualifier word ("provable YAML contracts"), with markdown bold stripped.
+claimed_contract_counts() {
+  grep -oiE '[0-9]+\*{0,2}( +[a-z]+){0,2} +contracts?\b' "$README" \
+    | grep -oE '^[0-9]+' \
+    | sort -un
 }
 
 claimed_cli_command_count() {
@@ -116,18 +126,27 @@ check_crate_count() {
 }
 
 check_contract_count() {
-  local measured claimed
+  local measured claimed rc=0 n=0
   measured=$(measured_contract_count)
-  claimed=$(claimed_contract_count)
+  claimed=$(claimed_contract_counts)
   if [[ -z "$claimed" ]]; then
-    echo "FAIL FALSIFY-README-002 contract_count: README lacks '**M** provable contracts' claim" >&2
+    echo "FAIL FALSIFY-README-002 contract_count: README makes no contract-count claim" >&2
     return 1
   fi
-  if [[ "$measured" != "$claimed" ]]; then
-    echo "FAIL FALSIFY-README-002 contract_count: README claims $claimed, filesystem has $measured" >&2
-    return 1
-  fi
-  echo "PASS FALSIFY-README-002 contract_count: $measured"
+  # EVERY claim must agree with the filesystem, not just the first one found.
+  # The README is also not allowed to contradict itself: three different counts
+  # in one file is a drift the reader cannot resolve.
+  while IFS= read -r c; do
+    [[ -n "$c" ]] || continue
+    n=$((n + 1))
+    if [[ "$measured" != "$c" ]]; then
+      echo "FAIL FALSIFY-README-002 contract_count: README claims $c, filesystem has $measured" >&2
+      grep -niE "\\b$c\\*{0,2}( +[a-z]+){0,2} +contracts?\\b" "$README" | sed 's|^|       |' >&2
+      rc=1
+    fi
+  done <<< "$claimed"
+  [[ "$rc" -eq 0 ]] || return 1
+  echo "PASS FALSIFY-README-002 contract_count: $measured ($n claim(s) checked)"
 }
 
 check_cli_command_count() {


### PR DESCRIPTION
README claimed 1771 provable contracts in its metrics table (correct), 1158 at
line 225, and 1767 at line 256. Filesystem: 1771 `.yaml`, 0 `.yml`.

`scripts/check_readme_claims.sh` implements FALSIFY-README-00* precisely to stop
this, and it could not:

  1. It ran NOWHERE. Not in any workflow, not in the Makefile. Its only caller in
     the entire tree is `scripts/dogfood-book.sh:112`, and dogfood-book.sh is
     itself in no workflow and no Makefile target -- unreachable from anything.
  2. It matched only `**M** provable contracts`, the bold table form, then took
     `head -1`. The prose forms at lines 225 and 256 were invisible to it, and
     even a second bold claim would have been dropped by the head.

So the one claim it checked was the one that happened to be right. A drift
detector that is both unwired and pattern-narrow supplies the APPEARANCE of claim
discipline, which is worse than no detector -- a reader of the README has no way
to know which of three numbers to believe, and nothing in CI made any of them
true.

Fixes:
  * README lines 225 and 256 corrected to 1771.
  * `claimed_contract_counts` returns EVERY contract-count claim (a number
    optionally followed by up to two qualifier words, then "contract(s)"), and
    all of them must equal the measurement. The README is no longer permitted to
    contradict itself, which is a stronger property than matching the filesystem
    once. On failure it prints the offending lines with line numbers.
  * Wired into the merge-blocking guard block.

Mutation-verified, each RED then restored GREEN:
  * drift ONLY the line-256 prose claim -- the form the old guard was blind to
  * drift the line-44 table claim -- the form it did see

Refs #2481

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>